### PR TITLE
Docs: Clarify git workflow rules in CLAUDE.md to prevent main branch PRs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,6 +42,11 @@ See `.claude/slash-commands/` for complete documentation.
 - **No Failing Tests**: Cannot start new work or commit with ANY test failures
 - **Security Gates**: All security scans must pass before commits
 - **Feature Branches**: Always use `feature/story-[NUMBER]-[description]` branches
+- **Git Workflow (CRITICAL)**: Feature branches ALWAYS target `develop`, NEVER `main`
+  - ✅ CORRECT: `gh pr create --base develop`
+  - ❌ WRONG: `gh pr create --base main` (breaks GitFlow workflow)
+  - Only `develop → main` PRs allowed (for releases)
+  - See [docs/development/git-workflow.md](docs/development/git-workflow.md) for details
 - **Real Component Testing**: Never mock CFGMS functionality in tests - use real components
 
 #### EPIC 6 Complete: Storage Architecture (CRITICAL)
@@ -60,7 +65,7 @@ See `.claude/slash-commands/` for complete documentation.
 2. **Branch**: Create `feature/story-[NUMBER]-[description]` from develop
 3. **Develop**: Write tests first, implement with TDD approach
 4. **Commit**: Run `make test-commit` - blocks on any failures
-5. **Complete**: Create PR and update project status
+5. **Complete**: Create PR **targeting develop** (`gh pr create --base develop`) and update project status
 
 See [docs/development/story-checklist.md](docs/development/story-checklist.md) for complete manual checklist.
 


### PR DESCRIPTION
## Problem

During Story #294 development, **multiple PRs were incorrectly created targeting `main`** instead of `develop`, violating CFGMS GitFlow workflow:
- Phase 1 (PR #302): Manually created → targeted `main` ❌
- Phase 3 (initial attempt): Manually created → targeted `main` ❌

**Root Cause:** CLAUDE.md did not explicitly state that feature branch PRs MUST target `develop`. The critical rule was only documented in `docs/development/git-workflow.md`, which wasn't consulted during manual PR creation.

## Solution

Make git workflow rules **immediately visible** in CLAUDE.md core instructions to prevent future mistakes.

## Changes

### 1. Zero Tolerance Policies Section (Lines 40-50)

**Added explicit Git Workflow (CRITICAL) rule:**
```markdown
- **Git Workflow (CRITICAL)**: Feature branches ALWAYS target `develop`, NEVER `main`
  - ✅ CORRECT: `gh pr create --base develop`
  - ❌ WRONG: `gh pr create --base main` (breaks GitFlow workflow)
  - Only `develop → main` PRs allowed (for releases)
  - See docs/development/git-workflow.md for details
```

**Why This Location:**
- Part of "Critical Development Rules (MANDATORY)" section
- Listed alongside other zero-tolerance policies
- Visible in core context that's always loaded

### 2. Manual Workflow Section (Line 68)

**Updated step 5 to be explicit:**

**Before:**
```markdown
5. **Complete**: Create PR and update project status
```

**After:**
```markdown
5. **Complete**: Create PR **targeting develop** (`gh pr create --base develop`) and update project status
```

**Why This Change:**
- Provides exact command to use
- Emphasizes "targeting develop" in bold
- Prevents ambiguity when following manual workflow

## Impact

### Prevention
- ✅ Git workflow rule now in core CLAUDE.md instructions
- ✅ Explicit "develop" target in manual workflow steps
- ✅ Clear visual markers (✅/❌) show correct/incorrect usage
- ✅ Links to full documentation for details

### Consistency
- ✅ Aligns with `docs/development/git-workflow.md` (line 64-65)
- ✅ Matches automated `/story-complete` behavior
- ✅ Maintains GitFlow branching strategy

### No Breaking Changes
- Documentation only - no code changes
- No impact on existing workflows
- Backward compatible with all automation

## Why This Happened

**Analysis:**
1. **CLAUDE.md lacked explicit rule** - Only mentioned creating branch "from develop" (line 60)
2. **Documentation buried** - Critical rule in git-workflow.md, not in core instructions
3. **Automation bypassed** - Manual `gh pr create` had no safeguard

**This PR fixes #1 and #2** by making the rule prominent in CLAUDE.md.

## Testing

- ✅ Markdown syntax verified
- ✅ Links tested (`docs/development/git-workflow.md` exists)
- ✅ Formatting renders correctly
- ✅ No code changes to test

## Review Checklist

- [x] Documentation update only
- [x] Addresses root cause of workflow violations
- [x] Consistent with existing git-workflow.md
- [x] Clear examples of correct/incorrect usage
- [x] Properly formatted markdown
- [x] No breaking changes

---

**Related Issues:** Story #294 (where the git workflow violations occurred)

🤖 Generated with [Claude Code](https://claude.com/claude-code)