### PR TITLE
Story #312: Fix TestModuleExecution suite container and TLS issues

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1635,9 +1635,9 @@ test-e2e-mqtt-quic:
 	@echo "🧪 Running MQTT+QUIC integration tests..."
 	@if [ -f .env.test ]; then \
 		set -a && . ./.env.test && set +a && \
-		CFGMS_TEST_HTTP_ADDR=https://127.0.0.1:8080 \
-		CFGMS_TEST_MQTT_ADDR=ssl://127.0.0.1:1886 \
-		CFGMS_TEST_QUIC_ADDR=127.0.0.1:4436 \
+		CFGMS_TEST_HTTP_ADDR=https://localhost:8080 \
+		CFGMS_TEST_MQTT_ADDR=ssl://localhost:1886 \
+		CFGMS_TEST_QUIC_ADDR=localhost:4436 \
 		CFGMS_TEST_CERTS_PATH=$(PWD)/test/integration/mqtt_quic/certs \
 		go test -v -race -timeout=15m ./test/integration/mqtt_quic/... || exit 1; \
 	else \

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -571,7 +571,8 @@ services:
     tmpfs:
       # Story #315: Use tmpfs for module execution test workspace (writable, fast, ephemeral)
       # Simulates real-world endpoint with writable directory, no permission issues
-      - /test-workspace:uid=1001,gid=1001,mode=0755
+      # exec flag required for script execution tests
+      - /test-workspace:uid=1001,gid=1001,mode=0755,exec
     depends_on:
       controller-standalone:
         condition: service_healthy

--- a/test/integration/mqtt_quic/module_execution_test.go
+++ b/test/integration/mqtt_quic/module_execution_test.go
@@ -62,8 +62,8 @@ func (s *ModuleExecutionTestSuite) SetupSuite() {
 	// Wait for steward to initialize
 	time.Sleep(5 * time.Second)
 
-	// Setup test helper for TLS config
-	s.testHelper = NewTestHelper(GetTestHTTPAddr("https://127.0.0.1:8080"))
+	// Setup test helper for TLS config (use localhost to match TLS ServerName)
+	s.testHelper = NewTestHelper(GetTestHTTPAddr("https://localhost:8080"))
 	s.tlsConfig, s.stewardID = s.testHelper.GetTLSConfigFromRegistration(s.T(), "default", "integration-test")
 
 	s.helper = NewModuleTestHelper(
@@ -646,10 +646,12 @@ func (s *ModuleExecutionTestSuite) TestFilePermissionVariations() {
 			// Verify permissions
 			fileInfo, err := s.helper.CheckFileInContainer(t, containerName, filePath)
 			s.NoError(err)
-			s.True(fileInfo.Exists)
+			if fileInfo != nil {
+				s.True(fileInfo.Exists)
 
-			expectedPermsStr := fmt.Sprintf("%o", tc.perms)
-			s.Equal(expectedPermsStr, fileInfo.Permissions, "Permissions should match for %s", tc.name)
+				expectedPermsStr := fmt.Sprintf("%o", tc.perms)
+				s.Equal(expectedPermsStr, fileInfo.Permissions, "Permissions should match for %s", tc.name)
+			}
 
 			// Cleanup after test
 			s.helper.CleanupTestFiles(t, containerName, filePath)

--- a/test/integration/mqtt_quic/module_helpers.go
+++ b/test/integration/mqtt_quic/module_helpers.go
@@ -51,9 +51,14 @@ func NewModuleTestHelper(baseURL, mqttAddr string, tlsConfig *tls.Config) *Modul
 	}
 
 	// Configure TLS if provided
+	// For HTTP client, use InsecureSkipVerify in test environment with auto-generated certs
+	// The tlsConfig is still used for MQTT connections with proper verification
 	if tlsConfig != nil {
+		// Create a copy of the TLS config for HTTP client with InsecureSkipVerify
+		httpTLSConfig := tlsConfig.Clone()
+		httpTLSConfig.InsecureSkipVerify = true
 		httpClient.Transport = &http.Transport{
-			TLSClientConfig: tlsConfig,
+			TLSClientConfig: httpTLSConfig,
 		}
 	}
 
@@ -180,14 +185,16 @@ func (h *ModuleTestHelper) CheckFileInContainer(t *testing.T, containerName, fil
 
 	info.Exists = true
 
-	// Get file content
+	// Get file content (may fail for write-only files - non-fatal)
 	cmd = exec.CommandContext(ctx, "docker", "exec", containerName, "cat", filePath)
 	var stdout bytes.Buffer
 	cmd.Stdout = &stdout
 	if err := cmd.Run(); err != nil {
-		return nil, fmt.Errorf("failed to read file content: %w", err)
+		// Content read failed (e.g., write-only file) - leave content empty but continue
+		info.Content = ""
+	} else {
+		info.Content = stdout.String()
 	}
-	info.Content = stdout.String()
 
 	// Get file permissions and ownership
 	cmd = exec.CommandContext(ctx, "docker", "exec", containerName, "stat", "-c", "%a %U %G", filePath)
@@ -502,8 +509,8 @@ func (h *ModuleTestHelper) CreateFileInContainerUsingModule(t *testing.T, contai
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	// Write content using printf (safer than echo)
-	cmd := exec.CommandContext(ctx, "docker", "exec", containerName, "tee", filePath)
+	// Write content using tee with interactive mode (-i flag required for stdin)
+	cmd := exec.CommandContext(ctx, "docker", "exec", "-i", containerName, "tee", filePath)
 	cmd.Stdin = strings.NewReader(content)
 	if err := cmd.Run(); err != nil {
 		return fmt.Errorf("failed to write file content: %w", err)


### PR DESCRIPTION
## Summary

Fixed all pre-existing test failures in the TestModuleExecution suite by addressing container configuration, helper function bugs, and TLS certificate validation issues. All 12 subtests now pass with 100% success rate.

## Changes

### Container Configuration Fixes
- **docker-compose.test.yml**: Added `exec` flag to tmpfs mount for `/test-workspace`
  - tmpfs defaults to `noexec` for security, preventing script execution
  - Fixes: TestScriptModuleExecution and TestScriptModuleFailureHandling

### Helper Function Fixes
- **module_helpers.go**: Added `-i` flag to `docker exec` in `CreateFileInContainerUsingModule()`
  - Required for proper stdin piping to `tee` command
  - Fixes: TestFileModuleExecution (files were created empty without this)

- **module_helpers.go**: Made file content reading non-fatal in `CheckFileInContainer()`
  - Write-only files (0222 permissions) cannot be read with `cat`
  - Fixes: TestFilePermissionVariations/write-only

- **module_helpers.go**: Added `InsecureSkipVerify` for HTTP client in `NewModuleTestHelper()`
  - Controller auto-generates CA certificates in test environment
  - MQTT client still uses proper certificate verification
  - Fixes: TestConfigStatusReporting TLS certificate validation

### Test Configuration Fixes
- **module_execution_test.go**: Added nil check before accessing `fileInfo.Exists`
  - Prevents panic when fileInfo is nil for write-only files
  - Fixes: TestFilePermissionVariations/write-only nil pointer panic

- **module_execution_test.go** + **Makefile**: Changed test addresses from `127.0.0.1` to `localhost`
  - Ensures consistency with TLS ServerName configuration
  - Part of TestConfigStatusReporting fix

## Test Results

### Before Fixes
```
❌ FAILING (5 test failures):
- TestFileModuleExecution - empty file content
- TestFilePermissionVariations/write-only - nil pointer panic  
- TestScriptModuleExecution - permission denied (noexec)
- TestScriptModuleFailureHandling - permission denied (noexec)
- TestConfigStatusReporting - TLS certificate verification failure
```

### After Fixes
```
✅ PASSING (12/12 subtests - 100%):
- TestConfigStatusReporting ✅
- TestContainerFileSystemAccess ✅
- TestDirectoryModuleExecution ✅
- TestDirectoryPermissionVariations ✅ (4/4)
- TestFileModuleExecution ✅
- TestFilePermissionVariations ✅ (6/6)
- TestIdempotency ✅
- TestModuleFailureReporting ✅
- TestMultipleModulesExecution ✅
- TestNestedDirectoryCreation ✅
- TestScriptModuleExecution ✅
- TestScriptModuleFailureHandling ✅
```

### Validation
```
✅ make test-complete passed with no regressions
✅ All pre-commit checks passed (tests, lint, security, architecture)
✅ Cross-platform compilation validated
✅ Docker integration tests passed
✅ E2E tests passed (MQTT+QUIC + Controller)
```

## Acceptance Criteria

- ✅ steward-standalone container has `/test-workspace` directory available
- ✅ TestFileModuleExecution passes (creates files with correct content/permissions)
- ✅ TestDirectoryModuleExecution passes (creates directories with correct permissions)
- ✅ TestScriptModuleExecution passes (executes scripts and captures output)
- ✅ All module execution tests pass without skips (12/12 - 100%)
- ✅ make test-complete passes with no regressions
- ⏳ GitHub CI "Production Risk Gates" workflow passes (this PR)

## Impact

- **Test Coverage**: All 12 TestModuleExecution subtests now pass (100%)
- **CI Compatibility**: Fixes work in both local and CI environments
- **No Regressions**: Full test-complete validation passed
- **Development Velocity**: Developers can now run module execution tests reliably

## Files Modified

- `test/integration/mqtt_quic/module_helpers.go` (3 changes)
- `docker-compose.test.yml` (1 change)
- `test/integration/mqtt_quic/module_execution_test.go` (2 changes)
- `Makefile` (1 change)

**Total**: 4 files, 25 insertions(+), 15 deletions(-)

🤖 Generated with [Claude Code](https://claude.com/claude-code)