### PR TITLE
CLAUDE.md: add agent execution mode and headless workflow (Issue #434)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,11 +21,61 @@ CFGMS (Config Management System) is a modern, Go-based configuration management 
 
 **Cross-Platform Development:** All components compile and run on developer workstations across Windows, macOS, and Linux for seamless development experience.
 
-## Development Workflow
+## Execution Mode
+
+CFGMS supports two execution modes, detected automatically. Both enforce identical validation gates.
+
+- **Agent Mode**: `CFGMS_AGENT_MODE=true` env var is set. Follow [Agent Implementation Workflow](#agent-implementation-workflow) below.
+- **Interactive Mode** (default): Use mandatory [slash commands](#slash-commands-mandatory) for all development work.
+
+### Agent Implementation Workflow
+
+When `CFGMS_AGENT_MODE=true`, follow these four phases:
+
+**Phase 1: Implement**
+
+1. Read the GitHub issue (`gh issue view <NUMBER>`)
+2. Check [central providers](#central-provider-system-critical) and [operating model docs](#operating-model-important) for overlap
+3. Write tests first (TDD), implement with real components (no mocks)
+4. Branch from `develop`: `feature/story-<NUMBER>-<description>`
+
+**Phase 2: Validate**
+Run the agent validation target (matches all CI required checks):
+```bash
+make test-agent-complete  # test-commit + test-fast + test-production-critical + build-cross-validate
+```
+
+**Phase 3: Self-Review**
+Before committing, verify your own changes against QA and security checks:
+- No mocks of CFGMS components (use real implementations)
+- No skipped tests (`t.Skip()` without justification)
+- No hacky workarounds (TODO/HACK/FIXME without issue reference)
+- All new code has test coverage
+- No hardcoded secrets, credentials, or unsanitized user input in logs
+- No SQL/command injection (parameterized queries only)
+- No central provider violations (`make check-architecture`)
+- Storage imports use `pkg/storage/interfaces` only
+
+**Phase 4: Commit and PR**
+1. Commit with proper format: `<scope>: <what changed> (Issue #XXX)` with `Fixes #XXX` in body
+2. Create PR targeting `develop`: `gh pr create --base develop`
+3. PR description follows [PR Standards](#pull-request-descriptions)
+
+### Agent Failure Handling
+
+If validation fails after 3 fix iterations, create a **draft** PR (`gh pr create --base develop --draft`) with error output under `## Validation Failures`. Do NOT force-merge or skip validation gates.
+
+### Agent Scope Constraints
+- **Protected files**: Do not modify `CLAUDE.md`, `Makefile` root targets, `.github/workflows/`, or `scripts/install-git-hooks.sh` unless the story explicitly requires it
+- **Dependencies**: Do not add new Go module dependencies without story justification
+- **Architecture**: Do not create new central providers — extend existing ones or flag for human review
+- **Destructive git**: Never force-push, reset --hard, or delete branches
+
+## Development Workflow (Interactive Mode)
 
 ### Slash Commands (MANDATORY)
 
-**CRITICAL**: You MUST use these slash commands for ALL development work. Manual workflows are deprecated and prone to missing critical validation steps.
+**CRITICAL**: In interactive mode, you MUST use these slash commands for ALL development work. Manual workflows are deprecated and prone to missing critical validation steps. (In agent mode, follow the [Agent Implementation Workflow](#agent-implementation-workflow) instead.)
 
 **Required Commands:**
 - **`/story-start`** - MUST use to begin new story with pre-flight checks and roadmap auto-detection

--- a/docs/product/roadmap.md
+++ b/docs/product/roadmap.md
@@ -169,7 +169,7 @@ Transition from interactive Claude Code sessions to headless agent dispatch in D
 
 **Sprint 1 — Prerequisites & Configuration (~13 pts):**
 - [x] CI: add integration-tests-controller as required check on develop (Issue #433 - 2 points) - Close CI coverage gap before agents skip Docker tests
-- [ ] CLAUDE.md: add agent execution mode and headless workflow (Issue #434 - 5 points) - Dual-mode CLAUDE.md with CFGMS_AGENT_MODE detection
+- [x] CLAUDE.md: add agent execution mode and headless workflow (Issue #434 - 5 points) - Dual-mode CLAUDE.md with CFGMS_AGENT_MODE detection
 - [ ] Makefile: add test-agent-complete target for container validation (Issue #435 - 2 points) - test-complete minus Docker targets (~95% coverage)
 - [ ] GitHub: create agent-story issue template for dispatch workflow (Issue #436 - 3 points) - Structured YAML template with reference impl, acceptance criteria
 - [ ] GitHub: create agent dispatch label set (Issue #437 - 1 point) - agent:ready/in-progress/success/failed/blocked labels


### PR DESCRIPTION
## Summary

Adds dual-mode execution support to CLAUDE.md via `CFGMS_AGENT_MODE=true` environment variable detection. Agent mode provides a structured 4-phase workflow for headless CI agents and autonomous dispatch systems. Interactive mode continues to mandate slash commands. Both modes enforce identical validation gates.

## Problem Context

The upcoming agent dispatch infrastructure (PRD #446) requires headless agents to follow CFGMS development standards without interactive slash commands. CLAUDE.md needed a clearly defined agent workflow that enforces the same quality gates (tests, security, architecture compliance) while being executable without human interaction.

## Changes

- Add "Execution Mode" section near top of CLAUDE.md with automatic mode detection
- Add "Agent Implementation Workflow" with 4 phases: Implement, Validate, Self-Review, Commit/PR
- Add failure handling (draft PR after 3 fix iterations, no force-merge)
- Add agent scope constraints (protected files, dependency rules, no destructive git)
- Update "Development Workflow" section header and intro to acknowledge both modes

## Testing

This is a docs-only change (CLAUDE.md + roadmap). No functional code modified.

Review results:
- QA Code Review: PASS — no test quality issues (docs-only)
- Security Review: PASS — all scans pass, no vulnerabilities
- Test Runner: PASS — all code tests pass (94 packages)
- File stays at exactly 650 lines (budget limit)
- All existing CLAUDE.md content preserved (only 2 lines modified for cross-referencing)

Fixes #434

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>