### PR TITLE
fix: DNA storage tests writing artifacts into repo directory

### DIFF
--- a/features/reports/advanced_test.go
+++ b/features/reports/advanced_test.go
@@ -56,6 +56,7 @@ func TestAdvancedServiceWithConfig(t *testing.T) {
 	// Create DNA storage manager
 	dnaStorageConfig := &storage.Config{
 		Backend:                storage.BackendSQLite,
+		DataDir:                t.TempDir(),
 		CompressionLevel:       6,
 		CompressionType:        "gzip",
 		TargetCompressionRatio: 0.7, // More relaxed target for testing
@@ -75,6 +76,7 @@ func TestAdvancedServiceWithConfig(t *testing.T) {
 	}
 	dnaStorageManager, err := storage.NewManager(dnaStorageConfig, logger)
 	require.NoError(t, err)
+	t.Cleanup(func() { dnaStorageManager.Close() })
 
 	// Create real components
 	driftDetector, err := drift.NewDetector(drift.DefaultDetectorConfig(), logger)
@@ -581,6 +583,7 @@ func createTestAdvancedService(t *testing.T) *AdvancedService {
 	// Create DNA storage manager (which is what the constructor expects)
 	dnaStorageConfig := &storage.Config{
 		Backend:                storage.BackendSQLite,
+		DataDir:                t.TempDir(),
 		CompressionLevel:       6,
 		CompressionType:        "gzip",
 		TargetCompressionRatio: 0.7, // More relaxed target for testing
@@ -600,6 +603,7 @@ func createTestAdvancedService(t *testing.T) *AdvancedService {
 	}
 	dnaStorageManager, err := storage.NewManager(dnaStorageConfig, logger)
 	require.NoError(t, err, "Failed to create DNA storage manager")
+	t.Cleanup(func() { dnaStorageManager.Close() })
 
 	// Create minimal drift detector
 	driftDetector, err := drift.NewDetector(drift.DefaultDetectorConfig(), logger)


### PR DESCRIPTION
## Summary

Reports advanced tests created `storage.Config` without setting `DataDir`, causing the SQLite backend to fall back to a relative `"data"` path. This created `features/reports/data/dna.db` (and WAL/SHM files) inside the repository on every test run, contaminating worktrees with gitignored but persistent artifacts.

## Problem Context

The `features/steward/dna/storage/sqlite_backend.go` defaults `DataDir` to `"data"` (relative) when not explicitly set. Two test functions in `features/reports/advanced_test.go` constructed `storage.Config{}` without overriding this, so every `make test` run created `features/reports/data/dna.db`, `dna.db-shm`, and `dna.db-wal` inside the repo.

While gitignored, these artifacts pollute worktrees and can cause confusion during development.

## Changes

- Add `DataDir: t.TempDir()` to `TestAdvancedServiceWithConfig` storage config
- Add `DataDir: t.TempDir()` to `createTestAdvancedService` storage config

## Testing

- `make test` — all tests pass, zero artifacts in repo after run
- `make test-commit` — all validation gates pass (lint, security, architecture)
- Verified with `git ls-files --others` that no untracked or ignored files are created

🤖 Generated with [Claude Code](https://claude.com/claude-code)