### PR TITLE
docs: mark story #437 complete and clean up labels (Issue #437)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,6 +74,7 @@ m365-test-creds/
 
 # Claude Code local settings
 .claude/settings.local.json
+.claude/worktrees/
 
 .obsidian/
 

--- a/docs/product/roadmap.md
+++ b/docs/product/roadmap.md
@@ -4,7 +4,7 @@
 
 This document outlines the development roadmap for the Configuration Management System (CFGMS). It provides a clear vision for the project's development, including milestones, features, and release planning, incorporating recent strategic adjustments to better align with MSP market voids and core product vision.
 
-**Last Updated**: 2026-02-19
+**Last Updated**: 2026-03-09
 
 ## Versioning Strategy
 
@@ -172,7 +172,7 @@ Transition from interactive Claude Code sessions to headless agent dispatch in D
 - [x] CLAUDE.md: add agent execution mode and headless workflow (Issue #434 - 5 points) - Dual-mode CLAUDE.md with CFGMS_AGENT_MODE detection
 - [x] Makefile: add test-agent-complete target for container validation (Issue #435 - 2 points) - test-complete minus Docker targets (~95% coverage)
 - [x] GitHub: create agent-story issue template for dispatch workflow (Issue #436 - 3 points) - Structured YAML template with reference impl, acceptance criteria
-- [ ] GitHub: create agent dispatch label set (Issue #437 - 1 point) - agent:ready/in-progress/success/failed/blocked labels
+- [x] GitHub: create agent dispatch label set (Issue #437 - 1 point) - agent:ready/in-progress/success/failed/blocked labels ✅ COMPLETED
 
 **Sprint 2 — Devcontainer Image (~21 pts):**
 - [ ] Devcontainer: base Dockerfile with Go toolchain and security tools (Issue #438 - 8 points) - golang:1.24-bookworm, golangci-lint, gosec, trivy, nancy, gitleaks, Claude Code
@@ -438,7 +438,7 @@ Multi-layered validation approach:
 ## Version Information
 
 - **Document Version**: 3.0
-- **Last Updated**: 2026-02-19
+- **Last Updated**: 2026-03-09
 
 ### Related Documentation
 


### PR DESCRIPTION
## Summary

Marks story #437 (GitHub agent dispatch labels) as complete in the roadmap. All 6 labels
(`agent:ready`, `agent:in-progress`, `agent:success`, `agent:failed`, `agent:blocked`, `story`)
were already created via GitHub API. Also cleaned up 18 unused/outdated labels (old phase system,
past version tags, unused GitHub defaults), reducing total from 60 to 42.

## Changes

- Mark Issue #437 as completed in `docs/product/roadmap.md` (Sprint 1 now 5/5 complete)
- Add `.claude/worktrees/` to `.gitignore` (used by agent worktrees, shouldn't be tracked)
- Update roadmap "Last Updated" date to 2026-03-09

## Label Cleanup (via GitHub API, not in diff)

Removed 18 labels: `invalid`, `wontfix`, `duplicate`, `question`, `triage`,
`implementation`, `integration`, `configuration`, `phase/1-modules`, `phase/2-steward`,
`phase/3-controller`, `phase:code-cleanup`, `phase:community-launch`, `phase:licensing-docs`,
`phase:security-review`, `v0.1.0`, `v0.3.0`, `v0.8.1`

## Review Results

- **QA Code Review**: PASS — docs-only change, no test quality issues
- **Security Review**: PASS — no security issues, all automated scans passed
- **Test Runner**: PASS — all unit tests, linting, cross-platform builds passing
  (Docker integration DB tests skipped due to missing PostgreSQL infrastructure — pre-existing, unrelated)

Fixes #437
Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)