### PR TITLE
agent-dispatch: MVP devcontainer and Claude Code skills (Issues #438-#444)

### DIFF
--- a/.agent-dispatch.yaml
+++ b/.agent-dispatch.yaml
@@ -1,0 +1,33 @@
+# Agent dispatch configuration for CFGMS
+# Used by /dispatch, /isoagents, and /agent-setup skills
+
+project: cfgms
+repo: cfg-is/cfgms
+
+# Git workflow
+base_branch: develop
+pr_target: develop
+branch_pattern: "feature/story-{issue}-agent"
+
+# Container settings
+container:
+  image: cfg-agent:latest
+  dockerfile: .devcontainer/Dockerfile
+  memory: 4g
+  cpus: 4
+  timeout: 3600
+  model: claude-sonnet-4-6
+
+# Validation command run inside agent container
+validation_command: "make test-agent-complete"
+
+# Worktree directory (relative to repo parent)
+worktree_dir: "../worktrees"
+
+# Label lifecycle
+labels:
+  ready: "agent:ready"
+  in_progress: "agent:in-progress"
+  success: "agent:success"
+  failed: "agent:failed"
+  blocked: "agent:blocked"

--- a/.claude/commands/agent-setup.md
+++ b/.claude/commands/agent-setup.md
@@ -1,0 +1,87 @@
+---
+name: agent-setup
+description: One-time setup for agent dispatch infrastructure
+parameters:
+  - name: action
+    description: "Optional: 'rebuild' to force rebuild the container image, 'creds' to refresh Claude credentials only"
+    required: false
+---
+
+# Agent Setup Command
+
+One-time bootstrap for agent dispatch. Builds the container image, sets up credentials, and creates required directories. Safe to run multiple times (idempotent).
+
+## Execution Flow
+
+1. **Check prerequisites**:
+   ```bash
+   docker info >/dev/null 2>&1  # Docker running?
+   gh auth status               # GitHub authenticated?
+   ```
+   If either fails, provide specific fix instructions and stop.
+
+2. **If `$ARGUMENTS` is 'creds'**: Skip to step 5 (credentials only).
+
+3. **If `$ARGUMENTS` is 'rebuild'**: Force rebuild with `--no-cache` (refreshes Trivy DB and Go modules).
+
+4. **Build agent container image** (use `run_in_background` since this takes 3-5 minutes):
+   ```bash
+   docker build -t cfg-agent:latest -f .devcontainer/Dockerfile .
+   ```
+   For rebuild: `docker build --no-cache -t cfg-agent:latest -f .devcontainer/Dockerfile .`
+
+   While waiting, proceed with steps 5-7 (they're independent).
+
+5. **Set up Claude credentials**:
+   - Create Docker volume: `docker volume create claude-creds` (idempotent)
+   - Check if credentials already exist in the volume:
+     ```bash
+     docker run --rm -v claude-creds:/persist cfg-agent:latest \
+       test -f /persist/.credentials.json && echo "exists"
+     ```
+   - If credentials exist and not `$ARGUMENTS` == 'creds': skip
+   - If credentials missing or refreshing:
+     - Tell user: "Claude credentials need setup. This requires an interactive login."
+     - Run interactive container for OAuth:
+       ```bash
+       docker run --rm -it \
+         -v claude-creds:/persist \
+         --entrypoint bash \
+         cfg-agent:latest \
+         -c "claude --dangerously-skip-permissions && cp ~/.claude/.credentials.json /persist/"
+       ```
+     - **IMPORTANT**: This step requires user interaction (OAuth flow). Tell the user what to expect.
+
+6. **Create directories**:
+   ```bash
+   mkdir -p ../worktrees
+   ```
+
+7. **Verify GitHub labels exist** (idempotent):
+   ```bash
+   gh label create "agent:ready" --color "0E8A16" --description "Story ready for agent dispatch" --force
+   gh label create "agent:in-progress" --color "FBCA04" --description "Agent container running" --force
+   gh label create "agent:success" --color "0075CA" --description "Agent completed, PR created" --force
+   gh label create "agent:failed" --color "D73A4A" --description "Agent failed, draft PR created" --force
+   gh label create "agent:blocked" --color "E4E669" --description "Needs human intervention" --force
+   ```
+
+8. **Verify setup** (after image build completes):
+   ```bash
+   docker run --rm cfg-agent:latest --version  # Should print claude version
+   ```
+
+9. **Print summary**:
+   - Image: built/exists
+   - Credentials: configured/missing
+   - Labels: created
+   - Worktree dir: ready
+   - "Setup complete. Use `/dispatch <issue#>` to launch agents."
+
+## Error Handling
+
+- **Docker not installed**: Provide install link, stop
+- **GitHub not authenticated**: Tell user to run `gh auth login`, stop
+- **Image build fails**: Show build output, suggest checking Dockerfile
+- **OAuth flow fails**: Tell user to retry with `/agent-setup creds`
+- **Network issues during build**: Suggest checking internet connection

--- a/.claude/commands/agent-setup.md
+++ b/.claude/commands/agent-setup.md
@@ -68,7 +68,7 @@ One-time bootstrap for agent dispatch. Builds the container image, sets up crede
 
 8. **Verify setup** (after image build completes):
    ```bash
-   docker run --rm cfg-agent:latest --version  # Should print claude version
+   docker run --rm --entrypoint claude cfg-agent:latest --version  # Should print claude version
    ```
 
 9. **Print summary**:

--- a/.claude/commands/dispatch.md
+++ b/.claude/commands/dispatch.md
@@ -1,0 +1,83 @@
+---
+name: dispatch
+description: Launch headless agent containers for GitHub issues
+parameters:
+  - name: issues
+    description: "Space-separated issue numbers to dispatch (e.g., '42 43 44'). Use '--dry-run' after numbers to preview without launching."
+    required: true
+---
+
+# Dispatch Command
+
+Launch isolated agent containers to implement GitHub issues. Each agent runs in a Docker container with its own git worktree, executes Claude in headless mode, and produces a PR targeting develop.
+
+**Non-blocking**: `docker run -d` returns instantly. Use `/isoagents` to check progress.
+
+## Execution Flow
+
+1. **Read config**: Read `.agent-dispatch.yaml` from the repo root for container settings, branch pattern, and labels.
+
+2. **Parse arguments**: Extract issue numbers and flags from `$ARGUMENTS`. If `--dry-run` is present, set dry run mode — print plan without side effects.
+
+3. **Check prerequisites** (skip in dry-run):
+   - Verify Docker is running: `docker info >/dev/null 2>&1`
+   - Verify agent image exists: `docker image inspect cfg-agent:latest >/dev/null 2>&1`
+   - If image missing, tell user to run `/agent-setup` first
+
+4. **For each issue number**, run these steps:
+
+   a. **Validate issue exists and fetch metadata**:
+      ```bash
+      gh issue view <NUM> --json title,body,labels,state
+      ```
+      If the issue doesn't exist or is closed, skip with warning.
+
+   b. **Quality check** (warnings only, do not block):
+      - Check issue body has acceptance criteria (`- [ ]` checkboxes) — warn if missing
+      - Check issue body length — warn if < 200 characters (likely under-specified)
+      - Check for reference implementation mention — warn if absent
+      - Print quality summary for the issue
+
+   c. **Check for conflicts**:
+      - If a container named `cfg-agent-<NUM>` already exists: skip with warning
+      - If the worktree path already exists: skip with warning
+      - If the branch already exists: skip with warning
+
+   d. **Create git worktree** (skip in dry-run):
+      ```bash
+      git worktree add ../worktrees/story-<NUM> -b feature/story-<NUM>-agent develop
+      ```
+
+   e. **Launch container** (skip in dry-run):
+      ```bash
+      docker run -d \
+        --name "cfg-agent-<NUM>" \
+        --label "cfg-agent=true" \
+        --label "issue=<NUM>" \
+        --memory=4g \
+        --cpus=4 \
+        --stop-timeout=3600 \
+        -v "$(realpath ../worktrees/story-<NUM>):/workspace" \
+        -v "claude-creds:/persist:ro" \
+        -v "${HOME}/.config/gh:/home/agent/.config/gh:ro" \
+        --cap-add NET_ADMIN \
+        cfg-agent:latest \
+        "<NUM>"
+      ```
+
+   f. **Update labels** (skip in dry-run):
+      ```bash
+      gh issue edit <NUM> --remove-label "agent:ready" --add-label "agent:in-progress"
+      ```
+
+5. **Print summary table**: Show all dispatched issues with container IDs and branch names.
+
+6. **Remind user**: "Use `/isoagents` to check progress. Agents typically complete in 15-45 minutes."
+
+## Error Handling
+
+- **Docker not running**: Tell user to start Docker and retry
+- **Image not found**: Tell user to run `/agent-setup`
+- **Issue fetch fails**: Skip that issue, continue with others
+- **Worktree/container conflict**: Skip with warning, suggest `/isoagents` to check existing state
+- **All issues skipped**: Print summary of why each was skipped

--- a/.claude/commands/isoagents.md
+++ b/.claude/commands/isoagents.md
@@ -1,0 +1,75 @@
+---
+name: isoagents
+description: Show status of agent containers and offer lifecycle actions
+parameters:
+  - name: filter
+    description: "Optional: issue number to inspect, or 'cleanup' to remove finished containers and worktrees"
+    required: false
+---
+
+# IsoAgents Command
+
+Show the status of all agent containers and offer lifecycle actions (cleanup, review, logs).
+
+**All operations are instant** — reads container state, no blocking.
+
+## Execution Flow
+
+1. **Gather state** by running these commands in parallel:
+
+   a. **Running containers**:
+      ```bash
+      docker ps --filter "label=cfg-agent=true" --format '{{.Names}}\t{{.Status}}\t{{.Label "issue"}}'
+      ```
+
+   b. **Exited containers**:
+      ```bash
+      docker ps -a --filter "label=cfg-agent=true" --filter "status=exited" --format '{{.Names}}\t{{.Label "issue"}}'
+      ```
+
+   c. **Active worktrees**:
+      ```bash
+      git worktree list
+      ```
+      Filter to only show worktrees under `../worktrees/`.
+
+2. **If `$ARGUMENTS` is a specific issue number**: Show detailed info for that agent:
+   - Container status and resource usage: `docker stats --no-stream cfg-agent-<NUM>`
+   - Last 30 lines of logs: `docker logs --tail 30 cfg-agent-<NUM>`
+   - PR status: `gh pr list --head "feature/story-<NUM>-agent" --json url,state,title`
+   - Suggest next actions based on state
+
+3. **If `$ARGUMENTS` is 'cleanup'**: For each exited container:
+   a. Read exit code: `docker inspect --format '{{.State.ExitCode}}' cfg-agent-<NUM>`
+   b. Read issue number from label
+   c. Copy result file (best-effort): `docker cp cfg-agent-<NUM>:/tmp/agent-result.json /tmp/`
+   d. Check for PR: `gh pr list --head "feature/story-<NUM>-agent" --json url,state`
+   e. Remove container: `docker rm cfg-agent-<NUM>`
+   f. Remove worktree: `git worktree remove ../worktrees/story-<NUM> --force`
+   g. Prune worktree list: `git worktree prune`
+   h. Report what was cleaned up
+
+4. **Default (no arguments)**: Print status dashboard:
+
+   **Running Agents:**
+   | Issue | Container | Uptime | Status |
+   |-------|-----------|--------|--------|
+
+   **Completed Agents:**
+   | Issue | Exit Code | PR | Action |
+   |-------|-----------|-----|--------|
+
+   **Worktrees:**
+   List any active worktrees under ../worktrees/
+
+5. **Suggest next actions** based on state:
+   - If completed agents with exit 0: "Agent #42 finished — PR ready. Run `/pr-review` or `/isoagents cleanup`"
+   - If completed agents with non-zero exit: "Agent #43 failed — check draft PR with `/isoagents 43`"
+   - If running agents: "Agent #44 still running (25 min). Check back with `/isoagents`"
+   - If nothing running: "No active agents. Use `/dispatch` to launch new ones."
+
+## Error Handling
+
+- **Docker not running**: Tell user to start Docker
+- **No containers found**: "No active or completed agents. Use `/dispatch` to launch."
+- **Container inspect fails**: Skip that container, note it in output

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -57,7 +57,8 @@ RUN npm install -g @anthropic-ai/claude-code
 
 # Non-root agent user with sudo for iptables only
 RUN useradd -m -s /bin/bash agent \
-    && echo "agent ALL=(root) NOPASSWD: /usr/sbin/iptables, /usr/sbin/ip6tables" > /etc/sudoers.d/agent
+    && echo "agent ALL=(root) NOPASSWD: /usr/sbin/iptables, /usr/sbin/ip6tables" > /etc/sudoers.d/agent \
+    && mkdir -p /persist && chown agent:agent /persist
 
 # Pre-download Trivy vulnerability DB (avoids runtime download behind firewall)
 RUN trivy fs --download-db-only --cache-dir /home/agent/.cache/trivy 2>/dev/null || true

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -19,6 +19,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     gnupg \
     npm \
     ripgrep \
+    dnsutils \
     && rm -rf /var/lib/apt/lists/*
 
 # GitHub CLI

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,83 @@
+# CFGMS Agent Dispatch Container
+# Provides isolated environment for headless Claude Code agent sessions.
+# Pre-caches Go modules and Trivy DB to minimize per-agent startup time.
+#
+# Build: docker build -t cfg-agent:latest -f .devcontainer/Dockerfile .
+# Rebuild weekly to refresh Trivy DB: docker build --no-cache -t cfg-agent:latest -f .devcontainer/Dockerfile .
+
+FROM golang:1.25-bookworm
+
+# System dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    curl \
+    git \
+    jq \
+    make \
+    sudo \
+    iptables \
+    ca-certificates \
+    gnupg \
+    npm \
+    ripgrep \
+    && rm -rf /var/lib/apt/lists/*
+
+# GitHub CLI
+RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+      | gpg --dearmor -o /usr/share/keyrings/githubcli-archive-keyring.gpg \
+    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+      > /etc/apt/sources.list.d/github-cli.list \
+    && apt-get update && apt-get install -y gh \
+    && rm -rf /var/lib/apt/lists/*
+
+# Go-based security tools
+RUN go install github.com/securego/gosec/v2/cmd/gosec@latest \
+    && go install honnef.co/go/tools/cmd/staticcheck@latest \
+    && go install github.com/zricethezav/gitleaks/v8@latest
+
+# Trivy (apt repo for stable releases)
+RUN curl -fsSL https://aquasecurity.github.io/trivy-repo/deb/public.key \
+      | gpg --dearmor -o /usr/share/keyrings/trivy.gpg \
+    && echo "deb [signed-by=/usr/share/keyrings/trivy.gpg] https://aquasecurity.github.io/trivy-repo/deb bookworm main" \
+      > /etc/apt/sources.list.d/trivy.list \
+    && apt-get update && apt-get install -y trivy \
+    && rm -rf /var/lib/apt/lists/*
+
+# Nancy (Go dependency scanner)
+RUN GOPATH=$(go env GOPATH) \
+    && curl -L "https://github.com/sonatype-nexus-community/nancy/releases/download/v1.0.51/nancy-v1.0.51-linux-amd64" \
+       -o "$GOPATH/bin/nancy" \
+    && chmod +x "$GOPATH/bin/nancy"
+
+# truffleHog (optional, best-effort secret scanning)
+RUN curl -sSfL https://raw.githubusercontent.com/trufflesecurity/trufflehog/main/scripts/install.sh | sh -s -- -b /usr/local/bin || true
+
+# Claude Code
+RUN npm install -g @anthropic-ai/claude-code
+
+# Non-root agent user with sudo for iptables only
+RUN useradd -m -s /bin/bash agent \
+    && echo "agent ALL=(root) NOPASSWD: /usr/sbin/iptables, /usr/sbin/ip6tables" > /etc/sudoers.d/agent
+
+# Pre-download Trivy vulnerability DB (avoids runtime download behind firewall)
+RUN trivy fs --download-db-only --cache-dir /home/agent/.cache/trivy 2>/dev/null || true
+RUN chown -R agent:agent /home/agent/.cache
+
+# Pre-cache Go modules from the project
+WORKDIR /tmp/modcache
+COPY go.mod go.sum ./
+RUN go mod download
+RUN rm go.mod go.sum
+WORKDIR /
+
+# Copy container scripts
+COPY .devcontainer/init-firewall.sh /usr/local/bin/init-firewall.sh
+COPY .devcontainer/entrypoint.sh /usr/local/bin/entrypoint.sh
+RUN chmod +x /usr/local/bin/init-firewall.sh /usr/local/bin/entrypoint.sh
+
+# Agent environment — 4GB RAM is sufficient for go test/build + Claude API calls
+ENV CFGMS_AGENT_MODE=true
+ENV TRIVY_CACHE_DIR=/home/agent/.cache/trivy
+
+USER agent
+WORKDIR /workspace
+ENTRYPOINT ["entrypoint.sh"]

--- a/.devcontainer/entrypoint.sh
+++ b/.devcontainer/entrypoint.sh
@@ -1,0 +1,164 @@
+#!/usr/bin/env bash
+# Agent container entrypoint: restore creds, fetch issue, run Claude, update labels.
+set -euo pipefail
+
+ISSUE_NUM="${1:?Usage: entrypoint.sh <ISSUE_NUMBER> [--dry-run]}"
+DRY_RUN="${2:-}"
+
+# --- Phase 0: Environment setup ---
+
+# Initialize firewall
+init-firewall.sh
+
+# Restore Claude credentials from mounted volume
+mkdir -p ~/.claude
+if [ -f /persist/.credentials.json ]; then
+    cp /persist/.credentials.json ~/.claude/.credentials.json
+else
+    echo "ERROR: No Claude credentials found at /persist/.credentials.json"
+    echo "Run: agent-setup to configure credentials"
+    exit 1
+fi
+cat > ~/.claude/.claude.json <<'ONBOARD'
+{"hasCompletedOnboarding":true,"installMethod":"native"}
+ONBOARD
+
+# Git identity for agent commits
+git config --global user.name "cfg-agent"
+git config --global user.email "agent@cfg.is"
+git config --global push.autoSetupRemote true
+
+# --- Phase 1: Fetch issue and compose prompt ---
+
+echo "Fetching issue #${ISSUE_NUM}..."
+ISSUE_JSON=$(gh issue view "$ISSUE_NUM" --json title,body,labels 2>&1) || {
+    echo "ERROR: Failed to fetch issue #${ISSUE_NUM}"
+    echo "$ISSUE_JSON"
+    exit 1
+}
+
+TITLE=$(echo "$ISSUE_JSON" | jq -r '.title')
+BODY=$(echo "$ISSUE_JSON" | jq -r '.body')
+
+PROMPT="$(cat <<PROMPT_EOF
+You are implementing GitHub issue #${ISSUE_NUM}: ${TITLE}
+
+${BODY}
+
+## Instructions
+
+You are running inside an isolated container with --dangerously-skip-permissions.
+Your branch \`feature/story-${ISSUE_NUM}-agent\` is already checked out from \`develop\`.
+Follow the CLAUDE.md file in the repository root — it contains all project conventions,
+architecture rules, and coding standards. CFGMS_AGENT_MODE=true is set.
+
+## Phase 1: Implement
+
+1. Read and understand the full issue including acceptance criteria
+2. Read CLAUDE.md for project conventions (central providers, storage architecture, etc.)
+3. If the issue mentions reference files or patterns, read them first
+4. Implement the change following existing patterns and TDD approach
+
+## Phase 2: Validate
+
+5. Run \`make test-agent-complete\` which runs all validation that works without Docker:
+   - test-commit (tests + lint + security + architecture checks)
+   - test-fast (fast comprehensive tests)
+   - test-production-critical (production critical tests)
+   - build-cross-validate (cross-platform compilation)
+6. If validation fails, fix issues and retry. Maximum 3 fix iterations.
+
+## Phase 3: Self-Review
+
+7. Review your own changes for quality issues:
+   - Check for mocks, t.Skip(), empty assertions, hacky workarounds
+   - Check for hardcoded secrets, SQL injection, information disclosure
+   - Check for central provider violations (see CLAUDE.md Central Provider System)
+   - Check for unsanitized user input in logs
+   - Fix any issues found
+
+## Phase 4: Commit and PR
+
+8. Run \`go mod tidy\` if dependencies changed
+9. Stage all changes
+10. Commit with message: \`<scope>: <description> (Issue #${ISSUE_NUM})\`
+    - Follow commit message format in CLAUDE.md (15-25 lines, WHY + WHAT)
+    - Include \`Fixes #${ISSUE_NUM}\` in the commit body
+    - Include \`Co-Authored-By: Claude <noreply@anthropic.com>\`
+11. Push branch: \`git push -u origin \$(git branch --show-current)\`
+12. Open PR targeting \`develop\` (NEVER \`main\`):
+    \`gh pr create --base develop --title "<scope>: <title> (Issue #${ISSUE_NUM})"\`
+
+## Failure Handling
+
+If \`make test-commit\` fails after 3 fix iterations:
+- Stage all changes and commit with message describing what was attempted
+- Push the branch
+- Open a DRAFT PR with failure details in the description body
+- Exit non-zero
+
+## Scope Constraints
+
+- Do NOT modify: CLAUDE.md, Makefile root targets, .github/*, docs/product/roadmap.md
+- Do NOT add external dependencies without justification
+- Do NOT skip tests or create PRs targeting main
+- ALWAYS check central providers in pkg/ before creating new functionality
+PROMPT_EOF
+)"
+
+if [ "$DRY_RUN" = "--dry-run" ]; then
+    echo "=== DRY RUN: Prompt that would be sent to Claude ==="
+    echo "$PROMPT"
+    exit 0
+fi
+
+# --- Phase 2: Run Claude ---
+
+# Update issue label: ready -> in-progress
+gh issue edit "$ISSUE_NUM" --remove-label "agent:ready" 2>/dev/null || true
+gh issue edit "$ISSUE_NUM" --add-label "agent:in-progress" 2>/dev/null || true
+
+echo "Starting Claude agent for issue #${ISSUE_NUM}..."
+EXIT_CODE=0
+claude --dangerously-skip-permissions --model claude-sonnet-4-6 -p "$PROMPT" || EXIT_CODE=$?
+
+# --- Phase 3: Cleanup and reporting ---
+
+# Extract PR URL if one was created
+BRANCH=$(git branch --show-current 2>/dev/null || echo "unknown")
+PR_URL=$(gh pr list --head "$BRANCH" --json url -q '.[0].url' 2>/dev/null || echo "")
+
+# Write result summary
+cat > /tmp/agent-result.json <<RESULT_EOF
+{
+  "issue": ${ISSUE_NUM},
+  "exit_code": ${EXIT_CODE},
+  "pr_url": "${PR_URL}",
+  "branch": "${BRANCH}",
+  "timestamp": "$(date -Iseconds)"
+}
+RESULT_EOF
+
+# Update issue labels based on outcome
+gh issue edit "$ISSUE_NUM" --remove-label "agent:in-progress" 2>/dev/null || true
+if [ "$EXIT_CODE" -eq 0 ]; then
+    gh issue edit "$ISSUE_NUM" --add-label "agent:success" 2>/dev/null || true
+    echo "Agent completed successfully. PR: ${PR_URL}"
+else
+    gh issue edit "$ISSUE_NUM" --add-label "agent:failed" 2>/dev/null || true
+    echo "Agent failed with exit code ${EXIT_CODE}"
+
+    # Create draft PR if none exists and there are changes
+    if [ -z "$PR_URL" ] && [ -n "$(git status --porcelain 2>/dev/null)" ]; then
+        git add -A
+        git commit -m "WIP: agent attempt for issue #${ISSUE_NUM} (failed validation)" \
+            --allow-empty 2>/dev/null || true
+        git push -u origin "$BRANCH" 2>/dev/null || true
+        gh pr create --base develop --draft \
+            --title "WIP: Issue #${ISSUE_NUM} (agent failed)" \
+            --body "Agent session failed with exit code ${EXIT_CODE}. Review container logs for details." \
+            2>/dev/null || true
+    fi
+fi
+
+exit "$EXIT_CODE"

--- a/.devcontainer/entrypoint.sh
+++ b/.devcontainer/entrypoint.sh
@@ -5,6 +5,12 @@ set -euo pipefail
 ISSUE_NUM="${1:?Usage: entrypoint.sh <ISSUE_NUMBER> [--dry-run]}"
 DRY_RUN="${2:-}"
 
+# Validate issue number is numeric
+if [[ ! "$ISSUE_NUM" =~ ^[0-9]+$ ]]; then
+    echo "ERROR: Issue number must be numeric, got: $ISSUE_NUM"
+    exit 1
+fi
+
 # --- Phase 0: Environment setup ---
 
 # Initialize firewall

--- a/.devcontainer/entrypoint.sh
+++ b/.devcontainer/entrypoint.sh
@@ -154,11 +154,11 @@ else
     gh issue edit "$ISSUE_NUM" --add-label "agent:failed" 2>/dev/null || true
     echo "Agent failed with exit code ${EXIT_CODE}"
 
-    # Create draft PR if none exists and there are changes
-    if [ -z "$PR_URL" ] && [ -n "$(git status --porcelain 2>/dev/null)" ]; then
-        git add -A
+    # Create draft PR if none exists and there are tracked changes
+    if [ -z "$PR_URL" ] && [ -n "$(git diff --name-only 2>/dev/null)" ]; then
+        git add --update
         git commit -m "WIP: agent attempt for issue #${ISSUE_NUM} (failed validation)" \
-            --allow-empty 2>/dev/null || true
+            2>/dev/null || true
         git push -u origin "$BRANCH" 2>/dev/null || true
         gh pr create --base develop --draft \
             --title "WIP: Issue #${ISSUE_NUM} (agent failed)" \

--- a/.devcontainer/init-firewall.sh
+++ b/.devcontainer/init-firewall.sh
@@ -53,6 +53,8 @@ sudo iptables -A OUTPUT -m limit --limit 1/min \
     -j LOG --log-prefix "AGENT-BLOCKED: " --log-level warning
 
 # Drop IPv6 entirely (containers typically don't use it)
+sudo ip6tables -F OUTPUT 2>/dev/null || true
+sudo ip6tables -F INPUT 2>/dev/null || true
 sudo ip6tables -P OUTPUT DROP 2>/dev/null || true
 sudo ip6tables -P INPUT DROP 2>/dev/null || true
 sudo ip6tables -A OUTPUT -o lo -j ACCEPT 2>/dev/null || true

--- a/.devcontainer/init-firewall.sh
+++ b/.devcontainer/init-firewall.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# Firewall for agent containers: default-deny outbound with allowlist.
+# Runs as root via sudo from entrypoint, then drops back to agent user.
+set -euo pipefail
+
+echo "Initializing container firewall..."
+
+# Flush existing rules
+sudo iptables -F OUTPUT
+sudo iptables -F INPUT
+
+# Allow loopback
+sudo iptables -A OUTPUT -o lo -j ACCEPT
+sudo iptables -A INPUT -i lo -j ACCEPT
+
+# Allow established/related connections
+sudo iptables -A OUTPUT -m state --state ESTABLISHED,RELATED -j ACCEPT
+
+# Allow DNS
+sudo iptables -A OUTPUT -p udp --dport 53 -j ACCEPT
+sudo iptables -A OUTPUT -p tcp --dport 53 -j ACCEPT
+
+# Resolve and allow HTTPS to specific domains
+ALLOWED_HOSTS=(
+    api.anthropic.com
+    statsig.anthropic.com
+    sentry.io
+    github.com
+    api.github.com
+    proxy.golang.org
+    sum.golang.org
+    storage.googleapis.com
+    objects.githubusercontent.com
+    registry.npmjs.org
+)
+
+for host in "${ALLOWED_HOSTS[@]}"; do
+    for ip in $(dig +short "$host" 2>/dev/null | grep -E '^[0-9]'); do
+        sudo iptables -A OUTPUT -p tcp --dport 443 -d "$ip" -j ACCEPT
+    done
+done
+
+# Log and drop everything else (rate-limited)
+sudo iptables -A OUTPUT -p tcp --dport 443 -m limit --limit 1/min \
+    -j LOG --log-prefix "AGENT-BLOCKED: " --log-level warning
+sudo iptables -A OUTPUT -p tcp --dport 443 -j DROP
+
+# Verify: github.com should work, example.com should not
+if curl -sf --max-time 5 https://api.github.com >/dev/null 2>&1; then
+    echo "  Firewall OK: github.com reachable"
+else
+    echo "  WARNING: github.com unreachable — DNS may not have resolved yet"
+fi
+
+echo "Firewall initialized (default-deny with allowlist)"

--- a/.devcontainer/init-firewall.sh
+++ b/.devcontainer/init-firewall.sh
@@ -1,13 +1,19 @@
 #!/usr/bin/env bash
 # Firewall for agent containers: default-deny outbound with allowlist.
 # Runs as root via sudo from entrypoint, then drops back to agent user.
+#
+# Known limitation: CDN-backed hosts (github.com, etc.) rotate IPs. Rules are
+# resolved at container startup and may go stale during long-running sessions.
+# If an agent hangs on network calls, this is the likely cause — restart the container.
 set -euo pipefail
 
 echo "Initializing container firewall..."
 
-# Flush existing rules
+# Flush existing rules and set default-deny on OUTPUT
 sudo iptables -F OUTPUT
 sudo iptables -F INPUT
+sudo iptables -P OUTPUT DROP
+sudo iptables -P INPUT DROP
 
 # Allow loopback
 sudo iptables -A OUTPUT -o lo -j ACCEPT
@@ -15,10 +21,11 @@ sudo iptables -A INPUT -i lo -j ACCEPT
 
 # Allow established/related connections
 sudo iptables -A OUTPUT -m state --state ESTABLISHED,RELATED -j ACCEPT
+sudo iptables -A INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT
 
-# Allow DNS
-sudo iptables -A OUTPUT -p udp --dport 53 -j ACCEPT
-sudo iptables -A OUTPUT -p tcp --dport 53 -j ACCEPT
+# Allow DNS to Docker's embedded resolver only
+sudo iptables -A OUTPUT -p udp --dport 53 -d 127.0.0.11 -j ACCEPT
+sudo iptables -A OUTPUT -p tcp --dport 53 -d 127.0.0.11 -j ACCEPT
 
 # Resolve and allow HTTPS to specific domains
 ALLOWED_HOSTS=(
@@ -32,20 +39,26 @@ ALLOWED_HOSTS=(
     storage.googleapis.com
     objects.githubusercontent.com
     registry.npmjs.org
+    ghcr.io
 )
 
 for host in "${ALLOWED_HOSTS[@]}"; do
-    for ip in $(dig +short "$host" 2>/dev/null | grep -E '^[0-9]'); do
+    for ip in $(dig +short "$host" 2>/dev/null | grep -E '^[0-9]+\.'); do
         sudo iptables -A OUTPUT -p tcp --dport 443 -d "$ip" -j ACCEPT
     done
 done
 
-# Log and drop everything else (rate-limited)
-sudo iptables -A OUTPUT -p tcp --dport 443 -m limit --limit 1/min \
+# Log blocked connections (rate-limited)
+sudo iptables -A OUTPUT -m limit --limit 1/min \
     -j LOG --log-prefix "AGENT-BLOCKED: " --log-level warning
-sudo iptables -A OUTPUT -p tcp --dport 443 -j DROP
 
-# Verify: github.com should work, example.com should not
+# Drop IPv6 entirely (containers typically don't use it)
+sudo ip6tables -P OUTPUT DROP 2>/dev/null || true
+sudo ip6tables -P INPUT DROP 2>/dev/null || true
+sudo ip6tables -A OUTPUT -o lo -j ACCEPT 2>/dev/null || true
+sudo ip6tables -A INPUT -i lo -j ACCEPT 2>/dev/null || true
+
+# Verify: github.com should work
 if curl -sf --max-time 5 https://api.github.com >/dev/null 2>&1; then
     echo "  Firewall OK: github.com reachable"
 else

--- a/docs/product/roadmap.md
+++ b/docs/product/roadmap.md
@@ -175,15 +175,14 @@ Transition from interactive Claude Code sessions to headless agent dispatch in D
 - [x] GitHub: create agent dispatch label set (Issue #437 - 1 point) - agent:ready/in-progress/success/failed/blocked labels ✅ COMPLETED
 
 **Sprint 2 — Devcontainer Image (~21 pts):**
-- [ ] Devcontainer: base Dockerfile with Go toolchain and security tools (Issue #438 - 8 points) - golang:1.24-bookworm, golangci-lint, gosec, trivy, nancy, gitleaks, Claude Code
-- [ ] Devcontainer: firewall script with allowlisted outbound networking (Issue #439 - 5 points) - iptables default-deny, allowlist GitHub/Anthropic/Go proxy only
-- [ ] Devcontainer: entrypoint script with issue fetch and agent prompt (Issue #440 - 8 points) - 4-phase agent workflow, credential restore, label management
+- [x] Devcontainer: base Dockerfile with Go toolchain and security tools (Issue #438 - 8 points) - golang:1.25-bookworm, gosec, staticcheck, trivy, nancy, gitleaks, trufflehog, Claude Code, pre-cached Go modules + Trivy DB
+- [x] Devcontainer: firewall script with allowlisted outbound networking (Issue #439 - 5 points) - iptables default-deny, allowlist GitHub/Anthropic/Go proxy only
+- [x] Devcontainer: entrypoint script with issue fetch and agent prompt (Issue #440 - 8 points) - 4-phase agent workflow, credential restore, label management, draft PR on failure
 
-**Sprint 3 — Scripts, Setup & Docs (~26 pts):**
-- [ ] Scripts: dispatch.sh for launching agent containers from issues (Issue #441 - 8 points) - Worktree creation, container launch, pre-dispatch quality checks
-- [ ] Scripts: monitor.sh background daemon for agent cleanup (Issue #442 - 5 points) - Container cleanup, worktree removal, PR URL extraction, notifications
-- [ ] Scripts: status.sh for agent state overview (Issue #443 - 3 points) - Running/completed agents, worktrees, dispatch history
-- [ ] Scripts: setup-agent-dispatch.sh one-time bootstrap (Issue #444 - 5 points) - Image build, credential setup, label creation, directory setup
+**Sprint 3 — Skills & Setup (~26 pts) — Pivoted from bash scripts to Claude Code skills:**
+- [x] Skill: `/dispatch` for launching agent containers from issues (Issue #441 - 8 points) - Replaces dispatch.sh; worktree creation, `docker run -d` (non-blocking), quality checks
+- [x] Skill: `/isoagents` for agent status and lifecycle management (Issues #442, #443 - 8 points) - Replaces monitor.sh + status.sh; status dashboard, detailed logs, cleanup, PR review suggestions
+- [x] Skill: `/agent-setup` one-time bootstrap (Issue #444 - 5 points) - Replaces setup.sh; image build, credential setup, label creation, directory setup
 - [ ] Docs: agent dispatch infrastructure developer reference (Issue #445 - 5 points) - Story sizing guidelines, CI failure workflow, troubleshooting
 
 #### v0.9.1.2 — Code Structure Refactoring (~23 pts, ~2 sprints)

--- a/features/reports/advanced_test.go
+++ b/features/reports/advanced_test.go
@@ -76,7 +76,7 @@ func TestAdvancedServiceWithConfig(t *testing.T) {
 	}
 	dnaStorageManager, err := storage.NewManager(dnaStorageConfig, logger)
 	require.NoError(t, err)
-	t.Cleanup(func() { dnaStorageManager.Close() })
+	t.Cleanup(func() { _ = dnaStorageManager.Close() })
 
 	// Create real components
 	driftDetector, err := drift.NewDetector(drift.DefaultDetectorConfig(), logger)
@@ -603,7 +603,7 @@ func createTestAdvancedService(t *testing.T) *AdvancedService {
 	}
 	dnaStorageManager, err := storage.NewManager(dnaStorageConfig, logger)
 	require.NoError(t, err, "Failed to create DNA storage manager")
-	t.Cleanup(func() { dnaStorageManager.Close() })
+	t.Cleanup(func() { _ = dnaStorageManager.Close() })
 
 	// Create minimal drift detector
 	driftDetector, err := drift.NewDetector(drift.DefaultDetectorConfig(), logger)


### PR DESCRIPTION
## Summary

Delivers the agent dispatch MVP (v0.9.1.1 Sprints 2+3) — isolated Docker containers
for headless Claude Code agent sessions, managed via Claude Code skills instead of the
originally planned bash scripts. Pivoted from dispatch.sh/monitor.sh/status.sh to
/dispatch, /isoagents, and /agent-setup skills for a better developer experience.

## Problem Context

The CFGMS development workflow relies on interactive Claude Code sessions with mandatory
slash commands. To scale development velocity, the agent dispatch PRD defined a system
where well-scoped GitHub issues are dispatched to isolated containers that produce PRs
autonomously. Sprint 1 (prerequisites) was already complete. This PR delivers Sprints 2
(devcontainer image) and 3 (lifecycle management), with Sprint 3 pivoted from bash
scripts to Claude Code skills.

## Changes

- Add `.devcontainer/Dockerfile` with Go 1.25, security tools (gosec, staticcheck, trivy,
  nancy, gitleaks, trufflehog), Claude Code, pre-cached Go modules + Trivy vulnerability DB
- Add `.devcontainer/init-firewall.sh` with iptables default-deny, allowlist for
  GitHub/Anthropic/Go proxy, DNS restricted to Docker resolver, IPv6 dropped
- Add `.devcontainer/entrypoint.sh` with 4-phase agent workflow, credential restore,
  numeric input validation, label lifecycle, draft PR on failure
- Add `/dispatch` skill replacing dispatch.sh (non-blocking `docker run -d`)
- Add `/isoagents` skill replacing monitor.sh + status.sh (on-demand status + cleanup)
- Add `/agent-setup` skill replacing setup-agent-dispatch.sh (idempotent bootstrap)
- Add `.agent-dispatch.yaml` configuration (container limits, branch pattern, labels)
- Fix pre-existing errcheck lint violations in `features/reports/advanced_test.go`
- Update roadmap: mark Sprints 2+3 complete, document pivot to skills

## Testing

Two rounds of parallel adversarial review (QA test runner + QA code reviewer + Security):

Round 1 findings (all fixed in round 2):
- Pre-existing lint errcheck violations → fixed with `_ = dnaStorageManager.Close()`
- Firewall missing default DROP policy → added `iptables -P OUTPUT DROP`
- DNS unrestricted → restricted to Docker resolver 127.0.0.11
- agent-setup verification broken → fixed with `--entrypoint claude`
- Entrypoint missing numeric validation → added regex check
- `dig` not installed in container → added `dnsutils` package
- `git add -A` in failure path → replaced with `git add --update`

Round 2 results:
- QA Test Runner: PASS (tests, lint, architecture, build)
- QA Code Reviewer: PASS (blocking items from round 1 all resolved)
- Security Engineer: PASS (0 blocking, 0 warnings, all scans green)

Pre-push hook: PASS (full test suite + security scans)

Fixes #438, Fixes #439, Fixes #440, Fixes #441, Fixes #442, Fixes #443, Fixes #444
Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>