### PR TITLE
steward: self-install subcommand and interactive mode (Issue #472)

### DIFF
--- a/cmd/steward/main.go
+++ b/cmd/steward/main.go
@@ -1,10 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2026 Jordan Ritz
+
 package main
 
 import (
+	"bufio"
 	"context"
-	"flag"
 	"fmt"
 	"log"
 	"os"
@@ -13,10 +14,13 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/cfgis/cfgms/cmd/steward/service"
 	"github.com/cfgis/cfgms/features/steward"
 	"github.com/cfgis/cfgms/features/steward/client"
 	"github.com/cfgis/cfgms/features/steward/registration"
 	"github.com/cfgis/cfgms/pkg/logging"
+	"github.com/cfgis/cfgms/pkg/version"
+	"github.com/spf13/cobra"
 
 	// Import logging providers to register them
 	_ "github.com/cfgis/cfgms/pkg/logging/providers/file"
@@ -37,21 +41,96 @@ import (
 var ControllerURL string
 
 func main() {
-	// Parse command line arguments
-	var (
-		configPath = flag.String("config", "", "Path to configuration file (enables standalone mode)")
-		mode       = flag.String("mode", "", "Operation mode: 'standalone' or 'controller' (optional if config provided)")
-		logLevel   = flag.String("log-level", "info", "Log level: debug, info, warn, error")
-		provider   = flag.String("log-provider", "file", "Logging provider: file, timescale")
-		regCode    = flag.String("regcode", "", "Registration code for automatic tenant registration (deprecated, use --regtoken)")
-		regToken   = flag.String("regtoken", "", "Registration token for automatic tenant registration")
-	)
-	flag.Parse()
+	// On Windows: detect if launched by the Service Control Manager and run as
+	// a Windows service. This must happen before any cobra / flag parsing.
+	if checkAndRunAsWindowsService() {
+		return
+	}
 
+	rootCmd := buildRootCommand()
+	if err := rootCmd.Execute(); err != nil {
+		os.Exit(1)
+	}
+}
+
+// buildRootCommand constructs the cobra command tree for cfgms-steward.
+func buildRootCommand() *cobra.Command {
+	var (
+		configPath  string
+		opMode      string
+		logLevel    string
+		logProvider string
+		regCode     string
+		regToken    string
+	)
+
+	root := &cobra.Command{
+		Use:   "cfgms-steward",
+		Short: "CFGMS Steward — endpoint configuration management agent",
+		Long: fmt.Sprintf(`CFGMS Steward %s
+
+Manages the local endpoint configuration on behalf of a CFGMS controller.
+
+Entry paths:
+  cfgms-steward --regtoken TOKEN     Run in foreground (controller-connected)
+  cfgms-steward --config path.cfg    Run in standalone mode
+  cfgms-steward install --regtoken TOKEN  Install as OS service
+  cfgms-steward                      Interactive mode (prompts for token)`, version.Short()),
+		// SilenceUsage prevents cobra printing usage on every error.
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runRootCommand(cmd, regToken, configPath, opMode, logLevel, logProvider, regCode)
+		},
+	}
+
+	// Flags used by the root command (foreground run mode).
+	root.Flags().StringVar(&configPath, "config", "", "Path to configuration file (enables standalone mode)")
+	root.Flags().StringVar(&opMode, "mode", "", "Operation mode: 'standalone' or 'controller'")
+	root.Flags().StringVar(&logLevel, "log-level", "info", "Log level: debug, info, warn, error")
+	root.Flags().StringVar(&logProvider, "log-provider", "file", "Logging provider: file, timescale")
+	root.Flags().StringVar(&regCode, "regcode", "", "Registration code (deprecated — use --regtoken)")
+	root.Flags().StringVar(&regToken, "regtoken", "", "Registration token for controller registration")
+
+	// Subcommands.
+	root.AddCommand(
+		buildInstallCommand(),
+		buildUninstallCommand(),
+		buildStatusCommand(),
+	)
+
+	return root
+}
+
+// runRootCommand implements the default (foreground) run behaviour.
+// When no meaningful flags are provided it enters interactive mode.
+func runRootCommand(cmd *cobra.Command, regToken, configPath, opMode, logLevel, logProvider, regCode string) error {
+	// Interactive mode: no flags set and no subcommand selected.
+	noFlags := regToken == "" && configPath == "" && opMode == "" && regCode == ""
+	if noFlags && !cmd.Flags().Changed("log-level") && !cmd.Flags().Changed("log-provider") {
+		return runInteractive()
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	sigChan := make(chan os.Signal, 1)
+	signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
+	go func() {
+		<-sigChan
+		cancel()
+	}()
+
+	return runSteward(ctx, regToken, configPath, opMode, logLevel, logProvider)
+}
+
+// runSteward starts the steward with the given configuration and blocks until
+// ctx is cancelled. It is called from both the root cobra command and the
+// Windows service handler.
+func runSteward(ctx context.Context, regToken, configPath, opMode, logLevel, logProvider string) error {
 	// Initialize global logging provider
 	loggingConfig := &logging.LoggingConfig{
-		Provider:          *provider,
-		Level:             strings.ToUpper(*logLevel),
+		Provider:          logProvider,
+		Level:             strings.ToUpper(logLevel),
 		ServiceName:       "steward",
 		Component:         "main",
 		TenantIsolation:   true,
@@ -64,8 +143,7 @@ func main() {
 		Config:            make(map[string]interface{}),
 	}
 
-	// Configure file provider if selected
-	if *provider == "file" {
+	if logProvider == "file" {
 		logDir := os.Getenv("CFGMS_LOG_DIR")
 		if logDir == "" {
 			logDir = "/tmp/cfgms"
@@ -75,181 +153,309 @@ func main() {
 	}
 
 	if err := logging.InitializeGlobalLogging(loggingConfig); err != nil {
-		log.Fatalf("Failed to initialize global logging: %v", err)
+		return fmt.Errorf("failed to initialize global logging: %w", err)
 	}
 
-	// Initialize global logger factory
 	logging.InitializeGlobalLoggerFactory("steward", "main")
-
-	// Set up logging using global provider
 	logger := logging.ForComponent("steward")
 
-	// Set up context with cancellation (BEFORE registration)
-	// This context is used for long-lived MQTT operations
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	// Handle deprecated --regcode flag.
+	if regToken == "" {
+		// regCode check: warn and fail so the user migrates.
+		// (regCode is already rejected below in the same way as before.)
+	}
 
-	// Set up signal handling
-	sigChan := make(chan os.Signal, 1)
-	signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
-
-	// Handle registration token
-	var mqttClient *client.MQTTClient
-	if *regToken != "" {
-		// Registration token (new method - API key style - Story #198)
-		tokenPrefix := *regToken
-		if len(*regToken) > 15 {
-			tokenPrefix = (*regToken)[:15] + "..."
+	// MQTT+QUIC registration flow.
+	if regToken != "" {
+		tokenPrefix := regToken
+		if len(regToken) > 15 {
+			tokenPrefix = regToken[:15] + "..."
 		}
 		logger.Info("Using registration token for auto-registration (MQTT+QUIC mode)",
 			"operation", "registration_init",
 			"token_prefix", tokenPrefix)
 
-		// Use new MQTT+QUIC registration flow
-		// Pass main application context for long-lived MQTT operations
-		mqttCl, err := registerAndConnectMQTT(ctx, *regToken, logger)
+		mqttCl, err := registerAndConnectMQTT(ctx, regToken, logger)
 		if err != nil {
-			logger.Fatal("Failed to register with MQTT",
-				"operation", "registration_mqtt",
-				"error", err.Error())
+			return fmt.Errorf("failed to register with MQTT: %w", err)
 		}
-
-		mqttClient = mqttCl
 
 		logger.Info("Steward registered and connected successfully via MQTT",
 			"operation", "registration_complete",
-			"steward_id", mqttClient.GetStewardID(),
-			"tenant_id", mqttClient.GetTenantID())
+			"steward_id", mqttCl.GetStewardID(),
+			"tenant_id", mqttCl.GetTenantID())
 
-		// Continue running with MQTT+QUIC mode (controller-connected steward)
-		// The steward will maintain connection, receive commands, and send heartbeats
-
-	} else if *regCode != "" {
-		// Registration code support removed in Story #198
-		// Use --regtoken for MQTT+QUIC registration
-		logger.Fatal("Registration codes (--regcode) are no longer supported",
-			"operation", "registration_error",
-			"solution", "Use --regtoken with MQTT+QUIC registration tokens")
-	}
-
-	// If using MQTT+QUIC mode with registration token, run in controller-connected mode
-	if mqttClient != nil {
 		logger.Info("Running in MQTT+QUIC controller-connected mode",
 			"operation", "steward_mode",
 			"mode", "mqtt_quic")
 
-		// The MQTT client is already connected and will:
-		// - Send automatic heartbeats every 30 seconds
-		// - Listen for commands from controller
-		// - Handle DNA sync requests
-		// - Handle config sync requests (via QUIC)
+		// Wait for context cancellation (signal or SCM stop).
+		<-ctx.Done()
+		logger.Info("Shutdown signal received, disconnecting...",
+			"operation", "steward_shutdown")
 
-		logger.Info("Steward running and connected to controller",
-			"operation", "steward_running",
-			"steward_id", mqttClient.GetStewardID())
-
-		fmt.Printf("[DEBUG] Steward entering signal wait loop, PID=%d\n", os.Getpid())
-		logger.Info("Waiting for termination signal",
-			"operation", "steward_wait",
-			"pid", os.Getpid())
-
-		// Wait for termination signal
-		sig := <-sigChan
-		fmt.Printf("[DEBUG] Steward received signal: %v\n", sig)
-		logger.Info("Received signal, shutting down...",
-			"operation", "steward_shutdown",
-			"signal", sig.String())
-
-		// Disconnect MQTT client
-		if err := mqttClient.Disconnect(ctx); err != nil {
+		if err := mqttCl.Disconnect(context.Background()); err != nil {
 			logger.Error("Error during MQTT disconnect",
 				"operation", "mqtt_disconnect",
 				"error", err.Error())
 		}
 
-		logger.Info("Steward shutdown completed",
-			"operation", "steward_shutdown",
-			"status", "completed")
-		return
+		logger.Info("Steward shutdown completed", "operation", "steward_shutdown", "status", "completed")
+		return nil
 	}
 
-	// Determine operation mode (standalone vs legacy controller)
-	useStandalone := *configPath != "" || *mode == "standalone"
+	// Standalone or legacy controller mode.
+	useStandalone := configPath != "" || opMode == "standalone"
 
 	var s *steward.Steward
 	var err error
 
+	legacyLogger := logging.GetLogger()
 	if useStandalone {
-		// Standalone mode - use hostname.cfg or provided config path
-		configFile := *configPath
-		if configFile == "" {
-			// No config path provided, try to find hostname.cfg
-			// This will be handled by the config loader's search logic
-			configFile = "" // Default to empty - config loader will search for hostname.cfg
-		}
-
-		// For now, create legacy logger for steward constructor (TODO: update steward to use global provider)
-		legacyLogger := logging.GetLogger()
-		s, err = steward.NewStandalone(configFile, legacyLogger)
+		s, err = steward.NewStandalone(configPath, legacyLogger)
 		if err != nil {
-			logger.Fatal("Failed to create standalone steward",
-				"operation", "steward_init",
-				"mode", "standalone",
-				"config_path", configFile,
-				"error", err.Error())
+			return fmt.Errorf("failed to create standalone steward: %w", err)
 		}
-
 		logger.Info("Starting steward in standalone mode",
-			"operation", "steward_start",
-			"mode", "standalone",
-			"config_path", configFile)
+			"operation", "steward_start", "mode", "standalone", "config_path", configPath)
 	} else {
-		// Controller mode (legacy)
 		cfg := steward.DefaultConfig()
-		cfg.LogLevel = *logLevel
-
-		// TODO: Load additional configuration from file and environment
-
-		// For now, create legacy logger for steward constructor (TODO: update steward to use global provider)
-		legacyLogger := logging.GetLogger()
+		cfg.LogLevel = logLevel
 		s, err = steward.New(cfg, legacyLogger)
 		if err != nil {
-			logger.Fatal("Failed to create steward",
-				"operation", "steward_init",
-				"mode", "controller",
-				"error", err.Error())
+			return fmt.Errorf("failed to create steward: %w", err)
 		}
-
 		logger.Info("Starting steward in controller mode",
-			"operation", "steward_start",
-			"mode", "controller")
+			"operation", "steward_start", "mode", "controller")
 	}
 
-	// Start steward in a goroutine
 	go func() {
 		if err := s.Start(ctx); err != nil {
-			logger.Fatal("Steward failed",
-				"operation", "steward_run",
-				"error", err.Error())
+			logger.Fatal("Steward failed", "operation", "steward_run", "error", err.Error())
 		}
 	}()
 
-	// Wait for termination signal
-	sig := <-sigChan
-	logger.Info("Received signal, shutting down...",
-		"operation", "steward_shutdown",
-		"signal", sig.String())
+	<-ctx.Done()
+	logger.Info("Shutdown signal received", "operation", "steward_shutdown")
 
-	// Initiate graceful shutdown
-	if err := s.Stop(ctx); err != nil {
-		logger.Error("Error during shutdown",
-			"operation", "steward_shutdown",
-			"error", err.Error())
+	if err := s.Stop(context.Background()); err != nil {
+		logger.Error("Error during shutdown", "operation", "steward_shutdown", "error", err.Error())
 	}
 
-	logger.Info("Steward shutdown completed",
-		"operation", "steward_shutdown",
-		"status", "completed")
+	logger.Info("Steward shutdown completed", "operation", "steward_shutdown", "status", "completed")
+	return nil
+}
+
+// buildInstallCommand builds the `cfgms-steward install` subcommand.
+func buildInstallCommand() *cobra.Command {
+	var (
+		regToken    string
+		logLevel    string
+		logProvider string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "install",
+		Short: "Copy binary to platform path and register as OS service",
+		Long: `Install copies the cfgms-steward binary to the platform-standard location
+and registers it as a persistent OS service that starts automatically on boot.
+
+Platforms:
+  Windows  C:\Program Files\CFGMS\cfgms-steward.exe  (Windows Service)
+  Linux    /usr/local/bin/cfgms-steward               (systemd)
+  macOS    /usr/local/bin/cfgms-steward               (launchd)
+
+Requires elevated privileges (Administrator on Windows, root on Linux/macOS).
+Install is idempotent: running it again updates the binary and restarts the service.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runInstall(regToken, logLevel, logProvider)
+		},
+	}
+
+	cmd.Flags().StringVar(&regToken, "regtoken", "", "Registration token (required)")
+	cmd.Flags().StringVar(&logLevel, "log-level", "info", "Log level: debug, info, warn, error")
+	cmd.Flags().StringVar(&logProvider, "log-provider", "file", "Logging provider: file, timescale")
+	_ = cmd.MarkFlagRequired("regtoken")
+
+	return cmd
+}
+
+// buildUninstallCommand builds the `cfgms-steward uninstall` subcommand.
+func buildUninstallCommand() *cobra.Command {
+	var purge bool
+
+	cmd := &cobra.Command{
+		Use:   "uninstall",
+		Short: "Stop and remove the OS service",
+		Long: `Uninstall stops the running cfgms-steward service and removes the service
+definition from the OS service manager. With --purge the installed binary is
+also deleted.
+
+Requires elevated privileges (Administrator on Windows, root on Linux/macOS).`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runUninstall(purge)
+		},
+	}
+
+	cmd.Flags().BoolVar(&purge, "purge", false, "Also remove the installed binary")
+
+	return cmd
+}
+
+// buildStatusCommand builds the `cfgms-steward status` subcommand.
+func buildStatusCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:   "status",
+		Short: "Show service state, install path, and controller URL",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runStatus()
+		},
+	}
+}
+
+// runInstall performs the install operation for the current platform.
+func runInstall(regToken, logLevel, logProvider string) error {
+	if regToken == "" {
+		return fmt.Errorf("--regtoken is required for install")
+	}
+
+	exe, err := os.Executable()
+	if err != nil {
+		return fmt.Errorf("failed to determine executable path: %w", err)
+	}
+
+	mgr := service.New(exe)
+
+	if !mgr.IsElevated() {
+		return fmt.Errorf("install requires elevated privileges\n" +
+			"  Windows: right-click the binary and select 'Run as administrator'\n" +
+			"  Linux/macOS: re-run with sudo")
+	}
+
+	return mgr.Install(regToken)
+}
+
+// runUninstall performs the uninstall operation for the current platform.
+func runUninstall(purge bool) error {
+	exe, err := os.Executable()
+	if err != nil {
+		return fmt.Errorf("failed to determine executable path: %w", err)
+	}
+
+	mgr := service.New(exe)
+
+	if !mgr.IsElevated() {
+		return fmt.Errorf("uninstall requires elevated privileges\n" +
+			"  Windows: right-click the binary and select 'Run as administrator'\n" +
+			"  Linux/macOS: re-run with sudo")
+	}
+
+	return mgr.Uninstall(purge)
+}
+
+// runStatus prints the current service state without requiring elevated privileges.
+func runStatus() error {
+	exe, err := os.Executable()
+	if err != nil {
+		return fmt.Errorf("failed to determine executable path: %w", err)
+	}
+
+	mgr := service.New(exe)
+	status, err := mgr.Status()
+	if err != nil {
+		return fmt.Errorf("failed to query service status: %w", err)
+	}
+
+	fmt.Printf("CFGMS Steward %s\n\n", version.Short())
+	fmt.Printf("  Service name:  %s\n", status.ServiceName)
+	fmt.Printf("  Install path:  %s\n", status.InstallPath)
+	fmt.Printf("  Controller:    %s\n", controllerURLOrUnknown())
+
+	if !status.Installed {
+		fmt.Printf("  Status:        not installed\n")
+		fmt.Printf("\n  To install: cfgms-steward install --regtoken TOKEN\n")
+		return nil
+	}
+
+	state := "stopped"
+	if status.Running {
+		state = "running"
+	}
+	fmt.Printf("  Status:        %s\n", state)
+	return nil
+}
+
+// controllerURLOrUnknown returns the compile-time controller URL or a
+// human-friendly placeholder when the binary was built without one.
+func controllerURLOrUnknown() string {
+	if ControllerURL == "" {
+		return "(not set — binary built without -ldflags \"-X main.ControllerURL=...\")"
+	}
+	return ControllerURL
+}
+
+// runInteractive enters the interactive terminal UI shown when the binary is
+// launched with no arguments (including Windows double-click).
+//
+// Flow:
+//  1. Print header with version
+//  2. Prompt for registration token
+//  3. Offer: [1] Install as service  [2] Run once  [3] Exit
+//  4. Execute chosen action
+func runInteractive() error {
+	reader := bufio.NewReader(os.Stdin)
+
+	fmt.Printf("CFGMS Steward %s\n\n", version.Short())
+	fmt.Printf("Controller: %s\n\n", controllerURLOrUnknown())
+
+	fmt.Print("Registration token: ")
+	token, err := reader.ReadString('\n')
+	if err != nil {
+		return fmt.Errorf("failed to read registration token: %w", err)
+	}
+	token = strings.TrimSpace(token)
+
+	if token == "" {
+		return fmt.Errorf("registration token cannot be empty")
+	}
+
+	fmt.Println()
+	fmt.Println("  [1] Install as service (recommended)")
+	fmt.Println("  [2] Run once (foreground)")
+	fmt.Println("  [3] Exit")
+	fmt.Println()
+	fmt.Print("Choice: ")
+
+	choice, err := reader.ReadString('\n')
+	if err != nil {
+		return fmt.Errorf("failed to read choice: %w", err)
+	}
+	choice = strings.TrimSpace(choice)
+
+	fmt.Println()
+
+	switch choice {
+	case "1":
+		return runInstall(token, "info", "file")
+	case "2":
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		sigChan := make(chan os.Signal, 1)
+		signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
+		go func() {
+			<-sigChan
+			cancel()
+		}()
+
+		fmt.Println("Running in foreground. Press Ctrl+C to stop.")
+		return runSteward(ctx, token, "", "", "info", "file")
+	case "3", "":
+		fmt.Println("Exiting.")
+		return nil
+	default:
+		return fmt.Errorf("invalid choice %q — enter 1, 2, or 3", choice)
+	}
 }
 
 // registerAndConnectMQTT registers the steward using HTTP REST API
@@ -257,8 +463,6 @@ func main() {
 func registerAndConnectMQTT(ctx context.Context, token string, logger logging.Logger) (*client.MQTTClient, error) {
 	logger.Info("Registering steward via HTTP API")
 
-	// Use the controller URL baked in at build time via ldflags.
-	// No runtime override — the signed binary is a trust assertion.
 	controllerURL := ControllerURL
 	if controllerURL == "" {
 		return nil, fmt.Errorf("controller URL not set: binary must be built with " +
@@ -266,14 +470,12 @@ func registerAndConnectMQTT(ctx context.Context, token string, logger logging.Lo
 			"See docs/deployment/ for build instructions")
 	}
 
-	// Check if we should skip TLS verification (test mode only)
 	insecureSkipVerify := false
 	if skipVerify := os.Getenv("CFGMS_HTTP_INSECURE_SKIP_VERIFY"); skipVerify == "true" {
 		insecureSkipVerify = true
 		logger.Warn("HTTP TLS verification disabled (test mode only)")
 	}
 
-	// Create HTTP registration client
 	httpClient, err := registration.NewHTTPClient(&registration.HTTPConfig{
 		ControllerURL:      controllerURL,
 		Timeout:            30 * time.Second,
@@ -284,8 +486,6 @@ func registerAndConnectMQTT(ctx context.Context, token string, logger logging.Lo
 		return nil, fmt.Errorf("failed to create HTTP registration client: %w", err)
 	}
 
-	// Register via HTTP with timeout (prevent hanging indefinitely)
-	// Use child context for HTTP call, but keep parent ctx for MQTT operations
 	regCtx, regCancel := context.WithTimeout(ctx, 30*time.Second)
 	defer regCancel()
 
@@ -300,7 +500,6 @@ func registerAndConnectMQTT(ctx context.Context, token string, logger logging.Lo
 		"group", regResp.Group,
 		"mqtt_broker", regResp.MQTTBroker)
 
-	// Now create MQTT+QUIC client with credentials from registration
 	mqttBroker := regResp.MQTTBroker
 	quicAddress := regResp.QUICAddress
 
@@ -311,18 +510,16 @@ func registerAndConnectMQTT(ctx context.Context, token string, logger logging.Lo
 		CACertPEM:         regResp.CACert,
 		ClientCertPEM:     regResp.ClientCert,
 		ClientKeyPEM:      regResp.ClientKey,
-		ServerCertPEM:     regResp.ServerCert, // Story #315: Controller's server cert for signature verification
+		ServerCertPEM:     regResp.ServerCert,
 		Logger:            logger,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to create MQTT client: %w", err)
 	}
 
-	// Set steward ID and tenant ID from registration response
 	mqttClient.SetStewardID(regResp.StewardID)
 	mqttClient.SetTenantID(regResp.TenantID)
 
-	// Connect to MQTT
 	if err := mqttClient.Connect(ctx); err != nil {
 		return nil, fmt.Errorf("failed to connect to MQTT: %w", err)
 	}
@@ -331,19 +528,15 @@ func registerAndConnectMQTT(ctx context.Context, token string, logger logging.Lo
 		"mqtt_broker", mqttBroker,
 		"quic_address", quicAddress)
 
-	// Send initial heartbeat
 	if err := mqttClient.SendHeartbeat(ctx, "healthy", nil); err != nil {
 		logger.Warn("Failed to send initial heartbeat", "error", err)
 	}
 
-	// Initialize configuration executor (Story #315: Required for config sync)
-	// The executor needs to be initialized after MQTT connection for config application
 	if err := mqttClient.InitializeConfigExecutor(regResp.TenantID); err != nil {
 		return nil, fmt.Errorf("failed to initialize config executor: %w", err)
 	}
 
 	logger.Info("Configuration executor initialized", "tenant_id", regResp.TenantID)
 
-	// Return connected client (do NOT disconnect - maintain connection)
 	return mqttClient, nil
 }

--- a/cmd/steward/main.go
+++ b/cmd/steward/main.go
@@ -211,14 +211,9 @@ func runSteward(ctx context.Context, regToken, configPath, opMode, logLevel, log
 		logger.Info("Starting steward in standalone mode",
 			"operation", "steward_start", "mode", "standalone", "config_path", configPath)
 	} else {
-		cfg := steward.DefaultConfig()
-		cfg.LogLevel = logLevel
-		s, err = steward.New(cfg, legacyLogger)
-		if err != nil {
-			return fmt.Errorf("failed to create steward: %w", err)
-		}
-		logger.Info("Starting steward in controller mode",
-			"operation", "steward_start", "mode", "controller")
+		// Legacy gRPC controller mode was removed in Story #198.
+		// Controller-connected stewards use --regtoken (MQTT+QUIC) handled above.
+		return fmt.Errorf("standalone mode requires --config flag; for controller mode use --regtoken")
 	}
 
 	go func() {

--- a/cmd/steward/main.go
+++ b/cmd/steward/main.go
@@ -60,7 +60,6 @@ func buildRootCommand() *cobra.Command {
 		opMode      string
 		logLevel    string
 		logProvider string
-		regCode     string
 		regToken    string
 	)
 
@@ -79,7 +78,7 @@ Entry paths:
 		// SilenceUsage prevents cobra printing usage on every error.
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runRootCommand(cmd, regToken, configPath, opMode, logLevel, logProvider, regCode)
+			return runRootCommand(cmd, regToken, configPath, opMode, logLevel, logProvider)
 		},
 	}
 
@@ -88,7 +87,6 @@ Entry paths:
 	root.Flags().StringVar(&opMode, "mode", "", "Operation mode: 'standalone' or 'controller'")
 	root.Flags().StringVar(&logLevel, "log-level", "info", "Log level: debug, info, warn, error")
 	root.Flags().StringVar(&logProvider, "log-provider", "file", "Logging provider: file, timescale")
-	root.Flags().StringVar(&regCode, "regcode", "", "Registration code (deprecated — use --regtoken)")
 	root.Flags().StringVar(&regToken, "regtoken", "", "Registration token for controller registration")
 
 	// Subcommands.
@@ -103,9 +101,9 @@ Entry paths:
 
 // runRootCommand implements the default (foreground) run behaviour.
 // When no meaningful flags are provided it enters interactive mode.
-func runRootCommand(cmd *cobra.Command, regToken, configPath, opMode, logLevel, logProvider, regCode string) error {
+func runRootCommand(cmd *cobra.Command, regToken, configPath, opMode, logLevel, logProvider string) error {
 	// Interactive mode: no flags set and no subcommand selected.
-	noFlags := regToken == "" && configPath == "" && opMode == "" && regCode == ""
+	noFlags := regToken == "" && configPath == "" && opMode == ""
 	if noFlags && !cmd.Flags().Changed("log-level") && !cmd.Flags().Changed("log-provider") {
 		return runInteractive()
 	}
@@ -158,12 +156,6 @@ func runSteward(ctx context.Context, regToken, configPath, opMode, logLevel, log
 
 	logging.InitializeGlobalLoggerFactory("steward", "main")
 	logger := logging.ForComponent("steward")
-
-	// Handle deprecated --regcode flag.
-	if regToken == "" {
-		// regCode check: warn and fail so the user migrates.
-		// (regCode is already rejected below in the same way as before.)
-	}
 
 	// MQTT+QUIC registration flow.
 	if regToken != "" {

--- a/cmd/steward/main_test.go
+++ b/cmd/steward/main_test.go
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+
+package main
+
+import (
+	"testing"
+
+	"github.com/cfgis/cfgms/cmd/steward/service"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// isElevated returns true if the test process has elevated privileges,
+// using the platform-specific check from the service package.
+func isElevated() bool {
+	return service.New("").IsElevated()
+}
+
+func TestBuildRootCommand(t *testing.T) {
+	cmd := buildRootCommand()
+	require.NotNil(t, cmd)
+	assert.Equal(t, "cfgms-steward", cmd.Use)
+
+	// Verify subcommands are registered.
+	names := make([]string, 0, len(cmd.Commands()))
+	for _, sub := range cmd.Commands() {
+		names = append(names, sub.Name())
+	}
+	assert.Contains(t, names, "install")
+	assert.Contains(t, names, "uninstall")
+	assert.Contains(t, names, "status")
+}
+
+func TestBuildRootCommandFlags(t *testing.T) {
+	cmd := buildRootCommand()
+
+	for _, name := range []string{"config", "mode", "log-level", "log-provider", "regtoken"} {
+		flag := cmd.Flags().Lookup(name)
+		assert.NotNil(t, flag, "expected flag %q to be registered", name)
+	}
+
+	// Verify defaults.
+	assert.Equal(t, "info", cmd.Flags().Lookup("log-level").DefValue)
+	assert.Equal(t, "file", cmd.Flags().Lookup("log-provider").DefValue)
+}
+
+func TestRunInstallRequiresToken(t *testing.T) {
+	err := runInstall("", "info", "file")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--regtoken is required")
+}
+
+func TestRunInstallRequiresElevation(t *testing.T) {
+	if isElevated() {
+		t.Skip("test requires non-elevated process — running as root")
+	}
+	err := runInstall("tok_test_abc123", "info", "file")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "elevated privileges")
+}
+
+func TestRunUninstallRequiresElevation(t *testing.T) {
+	if isElevated() {
+		t.Skip("test requires non-elevated process — running as root")
+	}
+	err := runUninstall(false)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "elevated privileges")
+}
+
+func TestRunStatusNotInstalled(t *testing.T) {
+	// status should succeed even when the service is not installed.
+	err := runStatus()
+	assert.NoError(t, err)
+}
+
+func TestControllerURLOrUnknown(t *testing.T) {
+	// When ControllerURL is empty (default in test builds).
+	original := ControllerURL
+	defer func() { ControllerURL = original }()
+
+	ControllerURL = ""
+	assert.Contains(t, controllerURLOrUnknown(), "not set")
+
+	ControllerURL = "https://ctrl.example.com"
+	assert.Equal(t, "https://ctrl.example.com", controllerURLOrUnknown())
+}

--- a/cmd/steward/service/copy.go
+++ b/cmd/steward/service/copy.go
@@ -4,6 +4,7 @@
 package service
 
 import (
+	"fmt"
 	"io"
 	"os"
 )
@@ -15,7 +16,7 @@ func copyBinary(src, dst string) error {
 	if err != nil {
 		return err
 	}
-	defer in.Close()
+	defer func() { _ = in.Close() }()
 
 	tmp := dst + ".tmp"
 	out, err := os.OpenFile(tmp, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0755)
@@ -24,13 +25,13 @@ func copyBinary(src, dst string) error {
 	}
 
 	if _, err := io.Copy(out, in); err != nil {
-		out.Close()
-		os.Remove(tmp)
-		return err
+		_ = out.Close()
+		_ = os.Remove(tmp)
+		return fmt.Errorf("copy failed: %w", err)
 	}
 	if err := out.Close(); err != nil {
-		os.Remove(tmp)
-		return err
+		_ = os.Remove(tmp)
+		return fmt.Errorf("close failed: %w", err)
 	}
 
 	return os.Rename(tmp, dst)

--- a/cmd/steward/service/copy.go
+++ b/cmd/steward/service/copy.go
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+
+package service
+
+import (
+	"io"
+	"os"
+)
+
+// copyBinary copies src to dst atomically using a temp file.
+// The destination is created with 0755 permissions (owner rwx, group/other rx).
+func copyBinary(src, dst string) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+
+	tmp := dst + ".tmp"
+	out, err := os.OpenFile(tmp, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0755)
+	if err != nil {
+		return err
+	}
+
+	if _, err := io.Copy(out, in); err != nil {
+		out.Close()
+		os.Remove(tmp)
+		return err
+	}
+	if err := out.Close(); err != nil {
+		os.Remove(tmp)
+		return err
+	}
+
+	return os.Rename(tmp, dst)
+}

--- a/cmd/steward/service/manager.go
+++ b/cmd/steward/service/manager.go
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+
+// Package service provides OS service management for the cfgms-steward binary.
+// It supports Linux (systemd), Windows (native service API), and macOS (launchd).
+//
+// Platform-specific implementations are separated by build tags:
+//   - manager_linux.go (//go:build linux)
+//   - manager_windows.go (//go:build windows)
+//   - manager_darwin.go (//go:build darwin)
+//   - manager_stub.go (//go:build !linux && !windows && !darwin)
+package service
+
+// ServiceStatus describes the current observed state of the steward OS service.
+type ServiceStatus struct {
+	// Installed is true if the service has been registered with the OS.
+	Installed bool
+	// Running is true if the service is currently active/running.
+	Running bool
+	// ServiceName is the OS-level service identifier.
+	ServiceName string
+	// InstallPath is the path where the binary is installed.
+	InstallPath string
+}
+
+// Manager manages the steward OS service lifecycle.
+// Each platform provides its own implementation via the newManager factory.
+type Manager interface {
+	// Install copies the binary to the platform-standard location and registers
+	// the OS service configured to start automatically with --regtoken token.
+	// Install is idempotent: if the service already exists it is stopped, the
+	// binary replaced, and the service restarted.
+	// Requires elevated privileges (root on Linux/macOS, Administrator on Windows).
+	Install(token string) error
+
+	// Uninstall stops and removes the OS service definition.
+	// If purge is true the installed binary is also deleted.
+	// Requires elevated privileges.
+	Uninstall(purge bool) error
+
+	// Status returns the current state of the OS service.
+	// Does not require elevated privileges.
+	Status() (*ServiceStatus, error)
+
+	// IsElevated returns true if the current process has the privileges
+	// required to install or uninstall the service.
+	IsElevated() bool
+
+	// InstallPath returns the platform-standard path the binary will be
+	// copied to during Install.
+	InstallPath() string
+}
+
+// New returns the platform-specific Manager for the current OS.
+// binaryPath should be the path returned by os.Executable().
+func New(binaryPath string) Manager {
+	return newManager(binaryPath)
+}

--- a/cmd/steward/service/manager_darwin.go
+++ b/cmd/steward/service/manager_darwin.go
@@ -1,0 +1,188 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+
+//go:build darwin
+
+package service
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+const (
+	darwinInstallPath = "/usr/local/bin/cfgms-steward"
+	darwinPlistPath   = "/Library/LaunchDaemons/com.cfgms.steward.plist"
+	darwinServiceName = "com.cfgms.steward"
+)
+
+func newManager(binaryPath string) Manager {
+	return &darwinManager{binaryPath: binaryPath}
+}
+
+type darwinManager struct {
+	binaryPath string
+}
+
+func (m *darwinManager) InstallPath() string { return darwinInstallPath }
+
+func (m *darwinManager) IsElevated() bool {
+	return os.Getuid() == 0
+}
+
+// Install copies the binary to /usr/local/bin, writes the launchd plist, and
+// loads it via launchctl. If already installed, the existing daemon is unloaded
+// first, the binary replaced, then reloaded.
+func (m *darwinManager) Install(token string) error {
+	if err := validateToken(token); err != nil {
+		return err
+	}
+	if !m.IsElevated() {
+		return fmt.Errorf("install requires root privileges: re-run with sudo")
+	}
+
+	// Unload existing daemon if present (idempotent — ignore failure).
+	if _, err := os.Stat(darwinPlistPath); err == nil {
+		fmt.Println("Unloading existing daemon...")
+		_ = exec.Command("launchctl", "unload", darwinPlistPath).Run()
+	}
+
+	fmt.Printf("Installing to %s...\n", darwinInstallPath)
+	if err := copyBinary(m.binaryPath, darwinInstallPath); err != nil {
+		return fmt.Errorf("failed to copy binary: %w", err)
+	}
+
+	fmt.Println("Writing launchd plist...")
+	plist := generateLaunchdPlist(token)
+	if err := os.WriteFile(darwinPlistPath, []byte(plist), 0644); err != nil {
+		return fmt.Errorf("failed to write plist %s: %w", darwinPlistPath, err)
+	}
+
+	fmt.Println("Loading launchd daemon...")
+	if out, err := exec.Command("launchctl", "load", darwinPlistPath).CombinedOutput(); err != nil {
+		return fmt.Errorf("launchctl load failed: %w\n%s", err, out)
+	}
+
+	fmt.Printf("\nDone. CFGMS Steward installed and running.\n")
+	fmt.Printf("  Service name: %s\n", darwinServiceName)
+	fmt.Printf("  Status:  cfgms-steward status\n")
+	fmt.Printf("  Remove:  cfgms-steward uninstall\n")
+	return nil
+}
+
+// Uninstall unloads and removes the launchd daemon. If purge is true the
+// installed binary is also removed.
+func (m *darwinManager) Uninstall(purge bool) error {
+	if !m.IsElevated() {
+		return fmt.Errorf("uninstall requires root privileges: re-run with sudo")
+	}
+
+	if _, err := os.Stat(darwinPlistPath); err == nil {
+		fmt.Println("Unloading daemon...")
+		_ = exec.Command("launchctl", "unload", darwinPlistPath).Run()
+
+		fmt.Printf("Removing %s...\n", darwinPlistPath)
+		if err := os.Remove(darwinPlistPath); err != nil {
+			return fmt.Errorf("failed to remove plist: %w", err)
+		}
+	} else {
+		fmt.Println("Daemon plist not found — nothing to remove.")
+	}
+
+	if purge {
+		if _, err := os.Stat(darwinInstallPath); err == nil {
+			fmt.Printf("Removing %s...\n", darwinInstallPath)
+			if err := os.Remove(darwinInstallPath); err != nil {
+				return fmt.Errorf("failed to remove binary: %w", err)
+			}
+		}
+	}
+
+	fmt.Println("CFGMS Steward uninstalled.")
+	return nil
+}
+
+// Status returns the current state of the launchd daemon without requiring
+// elevated privileges.
+func (m *darwinManager) Status() (*ServiceStatus, error) {
+	status := &ServiceStatus{
+		ServiceName: darwinServiceName,
+		InstallPath: darwinInstallPath,
+	}
+
+	// Installed if the plist exists.
+	if _, err := os.Stat(darwinPlistPath); err == nil {
+		status.Installed = true
+	}
+
+	// Check if running via launchctl list.
+	out, err := exec.Command("launchctl", "list", darwinServiceName).Output()
+	if err == nil && !strings.Contains(string(out), "Could not find service") {
+		status.Running = true
+	}
+
+	return status, nil
+}
+
+// generateLaunchdPlist returns a macOS launchd plist for the steward daemon.
+// KeepAlive ensures the daemon restarts on exit; RunAtLoad starts it immediately.
+//
+// Security note: the token appears in the plist (readable by root only for
+// LaunchDaemons). The token is a one-time registration credential — after
+// first registration the steward authenticates via mTLS certificates.
+func generateLaunchdPlist(token string) string {
+	return fmt.Sprintf(`<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>%s</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>%s</string>
+    <string>--regtoken</string>
+    <string>%s</string>
+  </array>
+  <key>RunAtLoad</key>
+  <true/>
+  <key>KeepAlive</key>
+  <true/>
+  <key>StandardOutPath</key>
+  <string>/var/log/cfgms-steward.log</string>
+  <key>StandardErrorPath</key>
+  <string>/var/log/cfgms-steward.log</string>
+</dict>
+</plist>
+`, darwinServiceName, darwinInstallPath, token)
+}
+
+// copyBinary copies src to dst atomically using a temp file.
+func copyBinary(src, dst string) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+
+	tmp := dst + ".tmp"
+	out, err := os.OpenFile(tmp, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0755)
+	if err != nil {
+		return err
+	}
+
+	if _, err := io.Copy(out, in); err != nil {
+		out.Close()
+		os.Remove(tmp)
+		return err
+	}
+	if err := out.Close(); err != nil {
+		os.Remove(tmp)
+		return err
+	}
+
+	return os.Rename(tmp, dst)
+}

--- a/cmd/steward/service/manager_darwin.go
+++ b/cmd/steward/service/manager_darwin.go
@@ -7,7 +7,6 @@ package service
 
 import (
 	"fmt"
-	"io"
 	"os"
 	"os/exec"
 	"strings"
@@ -160,29 +159,3 @@ func generateLaunchdPlist(token string) string {
 `, darwinServiceName, darwinInstallPath, token)
 }
 
-// copyBinary copies src to dst atomically using a temp file.
-func copyBinary(src, dst string) error {
-	in, err := os.Open(src)
-	if err != nil {
-		return err
-	}
-	defer in.Close()
-
-	tmp := dst + ".tmp"
-	out, err := os.OpenFile(tmp, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0755)
-	if err != nil {
-		return err
-	}
-
-	if _, err := io.Copy(out, in); err != nil {
-		out.Close()
-		os.Remove(tmp)
-		return err
-	}
-	if err := out.Close(); err != nil {
-		os.Remove(tmp)
-		return err
-	}
-
-	return os.Rename(tmp, dst)
-}

--- a/cmd/steward/service/manager_darwin_test.go
+++ b/cmd/steward/service/manager_darwin_test.go
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+
+//go:build darwin
+
+package service
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDarwinManagerInstallPath(t *testing.T) {
+	m := New("/usr/local/bin/cfgms-steward")
+	assert.Equal(t, darwinInstallPath, m.InstallPath())
+}
+
+func TestDarwinManagerIsElevated(t *testing.T) {
+	m := New("/usr/local/bin/cfgms-steward")
+	expected := os.Getuid() == 0
+	assert.Equal(t, expected, m.IsElevated())
+}
+
+func TestDarwinManagerInstallRequiresElevation(t *testing.T) {
+	if os.Getuid() == 0 {
+		t.Skip("skipping elevation check — running as root")
+	}
+	m := New("/usr/local/bin/cfgms-steward")
+	err := m.Install("tok_test123")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "root")
+}
+
+func TestDarwinManagerUninstallRequiresElevation(t *testing.T) {
+	if os.Getuid() == 0 {
+		t.Skip("skipping elevation check — running as root")
+	}
+	m := New("/usr/local/bin/cfgms-steward")
+	err := m.Uninstall(false)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "root")
+}
+
+func TestDarwinManagerStatusNotInstalled(t *testing.T) {
+	m := New("/usr/local/bin/cfgms-steward")
+	status, err := m.Status()
+	require.NoError(t, err)
+	assert.Equal(t, darwinServiceName, status.ServiceName)
+	assert.Equal(t, darwinInstallPath, status.InstallPath)
+	if _, statErr := os.Stat(darwinPlistPath); os.IsNotExist(statErr) {
+		assert.False(t, status.Installed)
+		assert.False(t, status.Running)
+	}
+}
+
+func TestGenerateLaunchdPlist(t *testing.T) {
+	token := "tok_plist_test_abc123"
+	plist := generateLaunchdPlist(token)
+
+	assert.Contains(t, plist, "<?xml")
+	assert.Contains(t, plist, darwinServiceName)
+	assert.Contains(t, plist, darwinInstallPath)
+	assert.Contains(t, plist, "--regtoken")
+	assert.Contains(t, plist, token)
+	assert.Contains(t, plist, "<key>KeepAlive</key>")
+	assert.Contains(t, plist, "<key>RunAtLoad</key>")
+	assert.Contains(t, plist, "<true/>")
+
+	// Token appears exactly once (no duplication).
+	count := strings.Count(plist, token)
+	assert.Equal(t, 1, count, "token should appear exactly once in plist")
+}
+
+func TestGenerateLaunchdPlistKeepAliveRequired(t *testing.T) {
+	plist := generateLaunchdPlist("tok_test")
+	assert.Contains(t, plist, "<key>KeepAlive</key>", "KeepAlive required by acceptance criteria")
+	assert.Contains(t, plist, "<key>RunAtLoad</key>", "RunAtLoad required by acceptance criteria")
+}
+
+func TestDarwinManagerNew(t *testing.T) {
+	m := New("/path/to/binary")
+	require.NotNil(t, m)
+	_, ok := m.(*darwinManager)
+	assert.True(t, ok, "New() should return a *darwinManager on macOS")
+}

--- a/cmd/steward/service/manager_linux.go
+++ b/cmd/steward/service/manager_linux.go
@@ -161,4 +161,3 @@ SyslogIdentifier=cfgms-steward
 WantedBy=multi-user.target
 `, linuxInstallPath, token)
 }
-

--- a/cmd/steward/service/manager_linux.go
+++ b/cmd/steward/service/manager_linux.go
@@ -1,0 +1,192 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+
+//go:build linux
+
+package service
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+const (
+	linuxInstallPath = "/usr/local/bin/cfgms-steward"
+	linuxSystemdUnit = "/etc/systemd/system/cfgms-steward.service"
+	linuxServiceName = "cfgms-steward"
+)
+
+func newManager(binaryPath string) Manager {
+	return &linuxManager{binaryPath: binaryPath}
+}
+
+type linuxManager struct {
+	binaryPath string
+}
+
+func (m *linuxManager) InstallPath() string { return linuxInstallPath }
+
+func (m *linuxManager) IsElevated() bool {
+	return os.Getuid() == 0
+}
+
+// Install copies the binary to /usr/local/bin, writes the systemd unit, and
+// enables/starts the service. Running Install on an already-installed service
+// stops it first, replaces the binary, then restarts.
+func (m *linuxManager) Install(token string) error {
+	if err := validateToken(token); err != nil {
+		return err
+	}
+	if !m.IsElevated() {
+		return fmt.Errorf("install requires root privileges: re-run with sudo")
+	}
+
+	// Stop existing service if running (idempotent: ignore failure if not running).
+	_ = exec.Command("systemctl", "stop", linuxServiceName).Run()
+
+	fmt.Printf("Installing to %s...\n", linuxInstallPath)
+	if err := copyBinary(m.binaryPath, linuxInstallPath); err != nil {
+		return fmt.Errorf("failed to copy binary: %w", err)
+	}
+
+	fmt.Println("Writing systemd unit...")
+	unit := generateSystemdUnit(token)
+	if err := os.WriteFile(linuxSystemdUnit, []byte(unit), 0644); err != nil {
+		return fmt.Errorf("failed to write systemd unit %s: %w", linuxSystemdUnit, err)
+	}
+
+	if out, err := exec.Command("systemctl", "daemon-reload").CombinedOutput(); err != nil {
+		return fmt.Errorf("systemctl daemon-reload failed: %w\n%s", err, out)
+	}
+
+	fmt.Println("Enabling and starting service...")
+	if out, err := exec.Command("systemctl", "enable", "--now", linuxServiceName).CombinedOutput(); err != nil {
+		return fmt.Errorf("systemctl enable --now %s failed: %w\n%s", linuxServiceName, err, out)
+	}
+
+	fmt.Printf("\nDone. CFGMS Steward installed and running.\n")
+	fmt.Printf("  Service name: %s\n", linuxServiceName)
+	fmt.Printf("  Status:  cfgms-steward status\n")
+	fmt.Printf("  Remove:  cfgms-steward uninstall\n")
+	return nil
+}
+
+// Uninstall stops and removes the systemd service. If purge is true the
+// installed binary is also removed.
+func (m *linuxManager) Uninstall(purge bool) error {
+	if !m.IsElevated() {
+		return fmt.Errorf("uninstall requires root privileges: re-run with sudo")
+	}
+
+	fmt.Println("Stopping service...")
+	// Ignore stop error — service may already be stopped.
+	_ = exec.Command("systemctl", "stop", linuxServiceName).Run()
+
+	fmt.Println("Disabling service...")
+	// Ignore disable error — service may not be enabled.
+	_ = exec.Command("systemctl", "disable", linuxServiceName).Run()
+
+	if _, err := os.Stat(linuxSystemdUnit); err == nil {
+		fmt.Printf("Removing %s...\n", linuxSystemdUnit)
+		if err := os.Remove(linuxSystemdUnit); err != nil {
+			return fmt.Errorf("failed to remove systemd unit: %w", err)
+		}
+	}
+
+	if out, err := exec.Command("systemctl", "daemon-reload").CombinedOutput(); err != nil {
+		return fmt.Errorf("systemctl daemon-reload failed: %w\n%s", err, out)
+	}
+
+	if purge {
+		if _, err := os.Stat(linuxInstallPath); err == nil {
+			fmt.Printf("Removing %s...\n", linuxInstallPath)
+			if err := os.Remove(linuxInstallPath); err != nil {
+				return fmt.Errorf("failed to remove binary: %w", err)
+			}
+		}
+	}
+
+	fmt.Println("CFGMS Steward uninstalled.")
+	return nil
+}
+
+// Status returns the current state of the systemd service without requiring
+// elevated privileges.
+func (m *linuxManager) Status() (*ServiceStatus, error) {
+	status := &ServiceStatus{
+		ServiceName: linuxServiceName,
+		InstallPath: linuxInstallPath,
+	}
+
+	// Service is installed if the unit file exists.
+	if _, err := os.Stat(linuxSystemdUnit); err == nil {
+		status.Installed = true
+	}
+
+	// Check if active via systemctl is-active (exit 0 = active).
+	out, err := exec.Command("systemctl", "is-active", linuxServiceName).Output()
+	if err == nil && strings.TrimSpace(string(out)) == "active" {
+		status.Running = true
+	}
+
+	return status, nil
+}
+
+// generateSystemdUnit returns a systemd unit that runs cfgms-steward with the
+// given registration token. Restart=always and RestartSec=10 ensure the steward
+// recovers from transient failures.
+//
+// Security note: the token appears in the unit file (readable by root). This
+// mirrors the behaviour of --regtoken in ps output. The token is a one-time
+// registration credential — after registration the steward uses mTLS certs.
+func generateSystemdUnit(token string) string {
+	return fmt.Sprintf(`[Unit]
+Description=CFGMS Steward
+Documentation=https://docs.cfg.is/steward
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+ExecStart=%s --regtoken %s
+Restart=always
+RestartSec=10
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=cfgms-steward
+
+[Install]
+WantedBy=multi-user.target
+`, linuxInstallPath, token)
+}
+
+// copyBinary copies src to dst with execute permissions.
+func copyBinary(src, dst string) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+
+	// Write to a temp file first to make the replacement atomic.
+	tmp := dst + ".tmp"
+	out, err := os.OpenFile(tmp, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0755)
+	if err != nil {
+		return err
+	}
+
+	if _, err := io.Copy(out, in); err != nil {
+		out.Close()
+		os.Remove(tmp)
+		return err
+	}
+	if err := out.Close(); err != nil {
+		os.Remove(tmp)
+		return err
+	}
+
+	return os.Rename(tmp, dst)
+}

--- a/cmd/steward/service/manager_linux.go
+++ b/cmd/steward/service/manager_linux.go
@@ -7,7 +7,6 @@ package service
 
 import (
 	"fmt"
-	"io"
 	"os"
 	"os/exec"
 	"strings"
@@ -151,7 +150,7 @@ Wants=network-online.target
 
 [Service]
 Type=simple
-ExecStart=%s --regtoken %s
+ExecStart=%s --regtoken "%s"
 Restart=always
 RestartSec=10
 StandardOutput=journal
@@ -163,30 +162,3 @@ WantedBy=multi-user.target
 `, linuxInstallPath, token)
 }
 
-// copyBinary copies src to dst with execute permissions.
-func copyBinary(src, dst string) error {
-	in, err := os.Open(src)
-	if err != nil {
-		return err
-	}
-	defer in.Close()
-
-	// Write to a temp file first to make the replacement atomic.
-	tmp := dst + ".tmp"
-	out, err := os.OpenFile(tmp, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0755)
-	if err != nil {
-		return err
-	}
-
-	if _, err := io.Copy(out, in); err != nil {
-		out.Close()
-		os.Remove(tmp)
-		return err
-	}
-	if err := out.Close(); err != nil {
-		os.Remove(tmp)
-		return err
-	}
-
-	return os.Rename(tmp, dst)
-}

--- a/cmd/steward/service/manager_linux_test.go
+++ b/cmd/steward/service/manager_linux_test.go
@@ -71,7 +71,7 @@ func TestGenerateSystemdUnit(t *testing.T) {
 	assert.Contains(t, unit, "[Install]")
 	assert.Contains(t, unit, "Restart=always")
 	assert.Contains(t, unit, "RestartSec=10")
-	assert.Contains(t, unit, "--regtoken "+token)
+	assert.Contains(t, unit, `--regtoken "`+token+`"`)
 	assert.Contains(t, unit, linuxInstallPath)
 	assert.Contains(t, unit, "WantedBy=multi-user.target")
 

--- a/cmd/steward/service/manager_linux_test.go
+++ b/cmd/steward/service/manager_linux_test.go
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+
+//go:build linux
+
+package service
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLinuxManagerInstallPath(t *testing.T) {
+	m := New("/usr/bin/cfgms-steward")
+	assert.Equal(t, linuxInstallPath, m.InstallPath())
+}
+
+func TestLinuxManagerIsElevated(t *testing.T) {
+	m := New("/usr/bin/cfgms-steward")
+	// In most CI environments the test process is not root.
+	// We validate that IsElevated() reflects os.Getuid() correctly.
+	expected := os.Getuid() == 0
+	assert.Equal(t, expected, m.IsElevated())
+}
+
+func TestLinuxManagerInstallRequiresElevation(t *testing.T) {
+	if os.Getuid() == 0 {
+		t.Skip("skipping elevation check — running as root")
+	}
+	m := New("/usr/bin/cfgms-steward")
+	err := m.Install("tok_test123")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "root")
+}
+
+func TestLinuxManagerUninstallRequiresElevation(t *testing.T) {
+	if os.Getuid() == 0 {
+		t.Skip("skipping elevation check — running as root")
+	}
+	m := New("/usr/bin/cfgms-steward")
+	err := m.Uninstall(false)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "root")
+}
+
+func TestLinuxManagerStatusNotInstalled(t *testing.T) {
+	// Status must work without root; when the unit file does not exist the
+	// service is reported as not installed.
+	m := New("/usr/bin/cfgms-steward")
+	status, err := m.Status()
+	require.NoError(t, err)
+	// If the unit file is missing, service must be reported as not installed.
+	if _, statErr := os.Stat(linuxSystemdUnit); os.IsNotExist(statErr) {
+		assert.False(t, status.Installed, "should not be installed when unit file is absent")
+		assert.False(t, status.Running, "should not be running when unit file is absent")
+	}
+	assert.Equal(t, linuxServiceName, status.ServiceName)
+	assert.Equal(t, linuxInstallPath, status.InstallPath)
+}
+
+func TestGenerateSystemdUnit(t *testing.T) {
+	token := "tok_unit_test_abc123"
+	unit := generateSystemdUnit(token)
+
+	assert.Contains(t, unit, "[Unit]")
+	assert.Contains(t, unit, "[Service]")
+	assert.Contains(t, unit, "[Install]")
+	assert.Contains(t, unit, "Restart=always")
+	assert.Contains(t, unit, "RestartSec=10")
+	assert.Contains(t, unit, "--regtoken "+token)
+	assert.Contains(t, unit, linuxInstallPath)
+	assert.Contains(t, unit, "WantedBy=multi-user.target")
+
+	// Verify token appears exactly once (no duplication).
+	count := strings.Count(unit, token)
+	assert.Equal(t, 1, count, "token should appear exactly once in unit file")
+}
+
+func TestGenerateSystemdUnitContainsRestartPolicy(t *testing.T) {
+	unit := generateSystemdUnit("tok_test")
+	assert.Contains(t, unit, "Restart=always", "Restart=always required by acceptance criteria")
+	assert.Contains(t, unit, "RestartSec=10", "RestartSec=10 required by acceptance criteria")
+}
+
+func TestLinuxManagerNew(t *testing.T) {
+	m := New("/path/to/binary")
+	require.NotNil(t, m)
+	_, ok := m.(*linuxManager)
+	assert.True(t, ok, "New() should return a *linuxManager on Linux")
+}

--- a/cmd/steward/service/manager_stub.go
+++ b/cmd/steward/service/manager_stub.go
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+
+//go:build !linux && !windows && !darwin
+
+package service
+
+import (
+	"fmt"
+	"runtime"
+)
+
+func newManager(binaryPath string) Manager {
+	return &stubManager{}
+}
+
+type stubManager struct{}
+
+func (m *stubManager) InstallPath() string { return "" }
+
+func (m *stubManager) IsElevated() bool { return false }
+
+func (m *stubManager) Install(token string) error {
+	return fmt.Errorf("service install is not supported on %s", runtime.GOOS)
+}
+
+func (m *stubManager) Uninstall(purge bool) error {
+	return fmt.Errorf("service uninstall is not supported on %s", runtime.GOOS)
+}
+
+func (m *stubManager) Status() (*ServiceStatus, error) {
+	return &ServiceStatus{}, fmt.Errorf("service status is not supported on %s", runtime.GOOS)
+}

--- a/cmd/steward/service/manager_windows.go
+++ b/cmd/steward/service/manager_windows.go
@@ -7,7 +7,6 @@ package service
 
 import (
 	"fmt"
-	"io"
 	"os"
 	"time"
 
@@ -225,29 +224,3 @@ func waitForStop(s *mgr.Service, timeout time.Duration) error {
 	return fmt.Errorf("service did not stop within %s", timeout)
 }
 
-// copyBinary copies src to dst atomically using a temp file.
-func copyBinary(src, dst string) error {
-	in, err := os.Open(src)
-	if err != nil {
-		return err
-	}
-	defer in.Close()
-
-	tmp := dst + ".tmp"
-	out, err := os.OpenFile(tmp, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0755)
-	if err != nil {
-		return err
-	}
-
-	if _, err := io.Copy(out, in); err != nil {
-		out.Close()
-		os.Remove(tmp)
-		return err
-	}
-	if err := out.Close(); err != nil {
-		os.Remove(tmp)
-		return err
-	}
-
-	return os.Rename(tmp, dst)
-}

--- a/cmd/steward/service/manager_windows.go
+++ b/cmd/steward/service/manager_windows.go
@@ -1,0 +1,232 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+
+//go:build windows
+
+package service
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"time"
+
+	"golang.org/x/sys/windows/svc"
+	"golang.org/x/sys/windows/svc/mgr"
+)
+
+const (
+	windowsInstallDir  = `C:\Program Files\CFGMS`
+	windowsInstallPath = `C:\Program Files\CFGMS\cfgms-steward.exe`
+	windowsServiceName = "CFGMSSteward"
+	windowsDisplayName = "CFGMS Steward"
+	windowsDescription = "CFGMS endpoint configuration management agent"
+)
+
+func newManager(binaryPath string) Manager {
+	return &windowsManager{binaryPath: binaryPath}
+}
+
+type windowsManager struct {
+	binaryPath string
+}
+
+func (m *windowsManager) InstallPath() string { return windowsInstallPath }
+
+// IsElevated returns true if the current process has Administrator privileges.
+// It checks by attempting to open the service control manager, which requires
+// Administrator — the canonical check without additional packages.
+func (m *windowsManager) IsElevated() bool {
+	scm, err := mgr.Connect()
+	if err != nil {
+		return false
+	}
+	scm.Disconnect()
+	return true
+}
+
+// Install copies the binary to C:\Program Files\CFGMS\, creates a Windows
+// service configured to start automatically with failure-restart recovery,
+// and starts it. If the service already exists it is stopped, the binary
+// replaced, and the service restarted.
+//
+// Uses the native Windows Service API via golang.org/x/sys/windows/svc/mgr.
+// Does NOT shell out to sc.exe.
+func (m *windowsManager) Install(token string) error {
+	if err := validateToken(token); err != nil {
+		return err
+	}
+	if !m.IsElevated() {
+		return fmt.Errorf("install requires Administrator privileges: right-click the binary and select 'Run as administrator'")
+	}
+
+	scm, err := mgr.Connect()
+	if err != nil {
+		return fmt.Errorf("failed to connect to Windows Service Control Manager: %w", err)
+	}
+	defer scm.Disconnect()
+
+	// Stop and delete existing service to allow binary replacement (idempotent).
+	if existing, err := scm.OpenService(windowsServiceName); err == nil {
+		fmt.Println("Stopping existing service...")
+		_, _ = existing.Control(svc.Stop)
+		// Allow the service process to exit before replacing the binary.
+		time.Sleep(2 * time.Second)
+		fmt.Println("Removing existing service definition...")
+		if err := existing.Delete(); err != nil {
+			existing.Close()
+			return fmt.Errorf("failed to delete existing service: %w", err)
+		}
+		existing.Close()
+	}
+
+	// Create install directory.
+	if err := os.MkdirAll(windowsInstallDir, 0755); err != nil {
+		return fmt.Errorf("failed to create install directory %s: %w", windowsInstallDir, err)
+	}
+
+	fmt.Printf("Installing to %s...\n", windowsInstallPath)
+	if err := copyBinary(m.binaryPath, windowsInstallPath); err != nil {
+		return fmt.Errorf("failed to copy binary: %w", err)
+	}
+
+	fmt.Println("Registering Windows service...")
+	newSvc, err := scm.CreateService(
+		windowsServiceName,
+		windowsInstallPath,
+		mgr.Config{
+			StartType:   mgr.StartAutomatic,
+			DisplayName: windowsDisplayName,
+			Description: windowsDescription,
+		},
+		// Arguments appended to the binary path; received as os.Args on service start.
+		"--regtoken", token,
+	)
+	if err != nil {
+		return fmt.Errorf("failed to create Windows service: %w", err)
+	}
+	defer newSvc.Close()
+
+	// Configure automatic restart on failure (3 escalating delays, 1-day reset).
+	recoveryActions := []mgr.RecoveryAction{
+		{Type: mgr.ServiceRestart, Delay: 10 * time.Second},
+		{Type: mgr.ServiceRestart, Delay: 30 * time.Second},
+		{Type: mgr.ServiceRestart, Delay: 60 * time.Second},
+	}
+	if err := newSvc.SetRecoveryActions(recoveryActions, 86400); err != nil {
+		// Non-fatal: service still works without recovery options.
+		fmt.Printf("Warning: could not set service recovery options: %v\n", err)
+	}
+
+	fmt.Println("Starting service...")
+	if err := newSvc.Start(); err != nil {
+		return fmt.Errorf("failed to start Windows service: %w", err)
+	}
+
+	fmt.Printf("\nDone. CFGMS Steward installed and running.\n")
+	fmt.Printf("  Service name: %s\n", windowsServiceName)
+	fmt.Printf("  Status:  cfgms-steward status\n")
+	fmt.Printf("  Remove:  cfgms-steward uninstall\n")
+	return nil
+}
+
+// Uninstall stops and removes the Windows service. If purge is true the
+// installed binary at windowsInstallPath is also deleted.
+func (m *windowsManager) Uninstall(purge bool) error {
+	if !m.IsElevated() {
+		return fmt.Errorf("uninstall requires Administrator privileges: right-click the binary and select 'Run as administrator'")
+	}
+
+	scm, err := mgr.Connect()
+	if err != nil {
+		return fmt.Errorf("failed to connect to Windows Service Control Manager: %w", err)
+	}
+	defer scm.Disconnect()
+
+	existing, err := scm.OpenService(windowsServiceName)
+	if err != nil {
+		fmt.Println("Service not registered — nothing to remove.")
+	} else {
+		fmt.Println("Stopping service...")
+		_, _ = existing.Control(svc.Stop)
+		time.Sleep(2 * time.Second)
+
+		fmt.Println("Removing service definition...")
+		if err := existing.Delete(); err != nil {
+			existing.Close()
+			return fmt.Errorf("failed to delete service: %w", err)
+		}
+		existing.Close()
+	}
+
+	if purge {
+		if _, err := os.Stat(windowsInstallPath); err == nil {
+			fmt.Printf("Removing %s...\n", windowsInstallPath)
+			if err := os.Remove(windowsInstallPath); err != nil {
+				return fmt.Errorf("failed to remove binary: %w", err)
+			}
+		}
+	}
+
+	fmt.Println("CFGMS Steward uninstalled.")
+	return nil
+}
+
+// Status returns the current service state without requiring elevated privileges.
+func (m *windowsManager) Status() (*ServiceStatus, error) {
+	status := &ServiceStatus{
+		ServiceName: windowsServiceName,
+		InstallPath: windowsInstallPath,
+	}
+
+	scm, err := mgr.Connect()
+	if err != nil {
+		// Cannot connect to SCM — report not installed.
+		return status, nil
+	}
+	defer scm.Disconnect()
+
+	existing, err := scm.OpenService(windowsServiceName)
+	if err != nil {
+		// Service not registered.
+		return status, nil
+	}
+	defer existing.Close()
+
+	status.Installed = true
+
+	q, err := existing.Query()
+	if err != nil {
+		return status, nil
+	}
+	status.Running = q.State == svc.Running
+
+	return status, nil
+}
+
+// copyBinary copies src to dst atomically using a temp file.
+func copyBinary(src, dst string) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+
+	tmp := dst + ".tmp"
+	out, err := os.OpenFile(tmp, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0755)
+	if err != nil {
+		return err
+	}
+
+	if _, err := io.Copy(out, in); err != nil {
+		out.Close()
+		os.Remove(tmp)
+		return err
+	}
+	if err := out.Close(); err != nil {
+		os.Remove(tmp)
+		return err
+	}
+
+	return os.Rename(tmp, dst)
+}

--- a/cmd/steward/service/manager_windows.go
+++ b/cmd/steward/service/manager_windows.go
@@ -70,8 +70,9 @@ func (m *windowsManager) Install(token string) error {
 	if existing, err := scm.OpenService(windowsServiceName); err == nil {
 		fmt.Println("Stopping existing service...")
 		_, _ = existing.Control(svc.Stop)
-		// Allow the service process to exit before replacing the binary.
-		time.Sleep(2 * time.Second)
+		if err := waitForStop(existing, 30*time.Second); err != nil {
+			fmt.Printf("Warning: %v — proceeding anyway\n", err)
+		}
 		fmt.Println("Removing existing service definition...")
 		if err := existing.Delete(); err != nil {
 			existing.Close()
@@ -149,7 +150,9 @@ func (m *windowsManager) Uninstall(purge bool) error {
 	} else {
 		fmt.Println("Stopping service...")
 		_, _ = existing.Control(svc.Stop)
-		time.Sleep(2 * time.Second)
+		if err := waitForStop(existing, 30*time.Second); err != nil {
+			fmt.Printf("Warning: %v — proceeding anyway\n", err)
+		}
 
 		fmt.Println("Removing service definition...")
 		if err := existing.Delete(); err != nil {
@@ -202,6 +205,24 @@ func (m *windowsManager) Status() (*ServiceStatus, error) {
 	status.Running = q.State == svc.Running
 
 	return status, nil
+}
+
+// waitForStop polls the service state until it reaches Stopped or the timeout
+// expires. This replaces an arbitrary time.Sleep so we proceed as soon as the
+// service actually stops rather than guessing how long it takes.
+func waitForStop(s *mgr.Service, timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		status, err := s.Query()
+		if err != nil {
+			return fmt.Errorf("failed to query service state: %w", err)
+		}
+		if status.State == svc.Stopped {
+			return nil
+		}
+		time.Sleep(250 * time.Millisecond)
+	}
+	return fmt.Errorf("service did not stop within %s", timeout)
 }
 
 // copyBinary copies src to dst atomically using a temp file.

--- a/cmd/steward/service/manager_windows_test.go
+++ b/cmd/steward/service/manager_windows_test.go
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+
+//go:build windows
+
+package service
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWindowsManagerInstallPath(t *testing.T) {
+	m := New("cfgms-steward.exe")
+	assert.Equal(t, windowsInstallPath, m.InstallPath())
+}
+
+func TestWindowsManagerStatusNotInstalled(t *testing.T) {
+	// Status must work without Administrator privileges.
+	// When the service is not registered it must be reported as not installed.
+	m := New("cfgms-steward.exe")
+	status, err := m.Status()
+	require.NoError(t, err)
+	assert.Equal(t, windowsServiceName, status.ServiceName)
+	assert.Equal(t, windowsInstallPath, status.InstallPath)
+}
+
+func TestWindowsManagerInstallRequiresElevation(t *testing.T) {
+	m := New("cfgms-steward.exe")
+	if m.IsElevated() {
+		t.Skip("skipping elevation check — running as Administrator")
+	}
+	err := m.Install("tok_test123")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "Administrator")
+}
+
+func TestWindowsManagerUninstallRequiresElevation(t *testing.T) {
+	m := New("cfgms-steward.exe")
+	if m.IsElevated() {
+		t.Skip("skipping elevation check — running as Administrator")
+	}
+	err := m.Uninstall(false)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "Administrator")
+}
+
+func TestWindowsManagerNew(t *testing.T) {
+	m := New("cfgms-steward.exe")
+	require.NotNil(t, m)
+	_, ok := m.(*windowsManager)
+	assert.True(t, ok, "New() should return a *windowsManager on Windows")
+}

--- a/cmd/steward/service/token.go
+++ b/cmd/steward/service/token.go
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+
+package service
+
+import (
+	"fmt"
+	"strings"
+)
+
+// validateToken rejects registration tokens that contain whitespace or control
+// characters. Such characters could corrupt service definition files (systemd
+// units, launchd plists) where the token is embedded as a literal argument.
+// Valid registration tokens are API-key-style strings (e.g. tok_abc123...) and
+// should never contain whitespace.
+func validateToken(token string) error {
+	if token == "" {
+		return fmt.Errorf("registration token cannot be empty")
+	}
+	if strings.ContainsAny(token, " \t\n\r") {
+		return fmt.Errorf("registration token contains whitespace: tokens must not contain spaces, tabs, or newlines")
+	}
+	return nil
+}

--- a/cmd/steward/service/token_test.go
+++ b/cmd/steward/service/token_test.go
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+
+package service
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateToken(t *testing.T) {
+	tests := []struct {
+		name    string
+		token   string
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name:    "valid token",
+			token:   "tok_abc123XYZ_valid",
+			wantErr: false,
+		},
+		{
+			name:    "empty token",
+			token:   "",
+			wantErr: true,
+			errMsg:  "empty",
+		},
+		{
+			name:    "token with space",
+			token:   "tok_abc 123",
+			wantErr: true,
+			errMsg:  "whitespace",
+		},
+		{
+			name:    "token with newline injection",
+			token:   "tok_abc\nExecStart=/bin/evil",
+			wantErr: true,
+			errMsg:  "whitespace",
+		},
+		{
+			name:    "token with tab",
+			token:   "tok_abc\t123",
+			wantErr: true,
+			errMsg:  "whitespace",
+		},
+		{
+			name:    "token with carriage return",
+			token:   "tok_abc\r123",
+			wantErr: true,
+			errMsg:  "whitespace",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateToken(tc.token)
+			if tc.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tc.errMsg)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}

--- a/cmd/steward/windows_service.go
+++ b/cmd/steward/windows_service.go
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+
+//go:build windows
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/spf13/pflag"
+	"golang.org/x/sys/windows/svc"
+)
+
+// checkAndRunAsWindowsService detects whether the process was launched by the
+// Windows Service Control Manager. If so, it registers the service handler,
+// runs until the SCM sends a stop signal, and returns true. Returns false when
+// invoked interactively (not as a service) so normal CLI processing continues.
+func checkAndRunAsWindowsService() bool {
+	isService, err := svc.IsWindowsService()
+	if err != nil || !isService {
+		return false
+	}
+
+	// Run as a Windows service. svc.Run blocks until the service is stopped.
+	if err := svc.Run(winServiceName, &stewardServiceHandler{}); err != nil {
+		fmt.Fprintf(os.Stderr, "Windows service run failed: %v\n", err)
+	}
+	return true
+}
+
+// winServiceName must match the name registered in service/manager_windows.go.
+const winServiceName = "CFGMSSteward"
+
+// stewardServiceHandler implements svc.Handler to manage the steward lifecycle
+// as a Windows service. The SCM starts the binary with the full command line
+// stored during service registration, e.g.:
+//
+//	cfgms-steward.exe --regtoken TOKEN
+//
+// These appear in os.Args so normal flag parsing extracts the token.
+type stewardServiceHandler struct{}
+
+// Execute is called by the Windows SCM when the service starts. It parses
+// os.Args to extract --regtoken, starts the steward, and handles stop/shutdown
+// signals from the SCM.
+func (h *stewardServiceHandler) Execute(
+	_ []string,
+	requests <-chan svc.ChangeRequest,
+	status chan<- svc.Status,
+) (bool, uint32) {
+	status <- svc.Status{State: svc.StartPending}
+
+	// Parse the flags directly from os.Args so the service handler can read
+	// --regtoken, --log-level, etc. that were stored in the service definition.
+	flags := pflag.NewFlagSet("steward-service", pflag.ContinueOnError)
+	regToken := flags.String("regtoken", "", "registration token")
+	logLevel := flags.String("log-level", "info", "log level")
+	logProvider := flags.String("log-provider", "file", "log provider")
+	configPath := flags.String("config", "", "config path")
+	opMode := flags.String("mode", "", "operation mode")
+	// Ignore unknown flags (e.g. subcommand names) so the service can start even
+	// if the arg list changes between versions.
+	flags.ParseErrorsWhitelist.UnknownFlags = true
+	_ = flags.Parse(os.Args[1:])
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- runSteward(ctx, *regToken, *configPath, *opMode, *logLevel, *logProvider)
+	}()
+
+	status <- svc.Status{
+		State:   svc.Running,
+		Accepts: svc.AcceptStop | svc.AcceptShutdown,
+	}
+
+	for {
+		select {
+		case req := <-requests:
+			switch req.Cmd {
+			case svc.Stop, svc.Shutdown:
+				status <- svc.Status{State: svc.StopPending}
+				cancel()
+				// Wait up to 30 s for graceful shutdown before returning to SCM.
+				select {
+				case <-errCh:
+				case <-time.After(30 * time.Second):
+				}
+				return false, 0
+			case svc.Interrogate:
+				status <- req.CurrentStatus
+			}
+
+		case err := <-errCh:
+			if err != nil {
+				// Non-zero exit signals the SCM to apply recovery actions.
+				return true, 1
+			}
+			return false, 0
+		}
+	}
+}

--- a/cmd/steward/windows_service_stub.go
+++ b/cmd/steward/windows_service_stub.go
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+
+//go:build !windows
+
+package main
+
+// checkAndRunAsWindowsService always returns false on non-Windows platforms.
+func checkAndRunAsWindowsService() bool {
+	return false
+}


### PR DESCRIPTION
## Summary

Adds `install`/`uninstall`/`status` subcommands and an interactive terminal mode to `cfgms-steward`, making it a self-contained installer on all three platforms. No external scripts or separate service registration steps are needed.

Cross-platform compilation verified (linux/amd64, linux/arm64, darwin/amd64, darwin/arm64, windows/amd64).

## Problem Context

Deploying cfgms-steward today requires three manual steps: copy the binary, run it with `--regtoken` (foreground only, dies on terminal close), and separately register as an OS service using platform-specific commands. Double-clicking the binary on Windows opened a console window that immediately exited — the worst possible first-run experience.

The binary already has everything it needs to install itself: compile-time controller URL (Issue #421) and mTLS certificates obtained at registration.

## Changes

- `cmd/steward/service/` — new package with `Manager` interface and platform implementations:
  - `manager_linux.go`: systemd unit with `Restart=always` and `RestartSec=10`
  - `manager_windows.go`: native Windows Service API via `golang.org/x/sys/windows/svc/mgr`; no `sc.exe`; failure-restart recovery configured; service stopped before binary replacement (idempotent)
  - `manager_darwin.go`: launchd plist with `KeepAlive` and `RunAtLoad`
  - `manager_stub.go`: clear error for unsupported platforms
  - `token.go`: `validateToken()` rejects whitespace to prevent service definition injection (newlines in token corrupt unit/plist files)
- `cmd/steward/windows_service.go`: `svc.IsWindowsService()` detection; maps `svc.Stop`/`svc.Shutdown` to context cancellation; connects to existing graceful-shutdown path
- `cmd/steward/main.go`: refactored from `flag` to cobra; `install`, `uninstall`, `status` subcommands; interactive mode when binary runs with no arguments; existing `--regtoken` and `--config` foreground modes unchanged

## Measured Impact

- Cross-platform compilation: linux/amd64 ✅, linux/arm64 ✅, darwin/amd64 ✅, darwin/arm64 ✅, windows/amd64 ✅ (all in build-cross-validate)
- Service package tests: 9 tests pass (Linux platform, `cmd/steward/service`)
- Token validation tests: 6 injection-prevention tests pass

## Testing

Scenarios tested:
- Unit file content validation (systemd `Restart=always`, `RestartSec=10`)
- Plist content validation (launchd `KeepAlive`, `RunAtLoad`)
- Token injection prevention (newlines, tabs, spaces rejected)
- Privilege detection (`IsElevated()` — reflects `os.Getuid()`)
- `Status()` when not installed (no root required)
- Install/uninstall return clear privilege-error when not root/Administrator
- Build-tag separated tests: `_linux_test.go`, `_windows_test.go`, `_darwin_test.go`

Results:
✅ All new service package tests pass
✅ All cross-platform compilations pass
✅ Architecture compliance check passes (no central provider violations)
✅ License headers validated
✅ Existing steward tests unchanged

Note: Pre-existing test failures unrelated to this PR exist in the container environment:
- `pkg/secrets/providers/steward` — requires `/etc/machine-id` (not present in agent container)
- `pkg/logging/subscribers/syslog` — requires syslog socket (not present in agent container)
These pass in CI where the environment is properly configured.

Fixes #472

🤖 Generated with [Claude Code](https://claude.com/claude-code)