### PR TITLE
tooling: fix approval prompts, OAuth write-back, and skill improvements

### DIFF
--- a/.claude/agents/pr-reviewer.md
+++ b/.claude/agents/pr-reviewer.md
@@ -14,10 +14,10 @@ You are reviewing PR #$ARGUMENTS for the CFGMS project. Execute all 6 phases seq
 
 ## Phase 1: PR Overview Assessment
 
-Fetch PR details and validate workflow:
+Fetch PR details and validate workflow (uses helper to avoid approval prompts):
 
 ```bash
-gh pr view $ARGUMENTS --json title,body,baseRefName,headRefName,state,author,files
+./scripts/pr-review-helper.sh pr-overview $ARGUMENTS
 ```
 
 **Validate git workflow FIRST (BLOCKING)**:
@@ -72,7 +72,7 @@ Check all changed `.go` files for violations:
 - Table-driven patterns where appropriate
 
 ```bash
-gh pr diff $ARGUMENTS -- '*.go' | grep -n "t\.Skip\|mock\|fake\|stub"
+./scripts/pr-review-helper.sh diff-scan $ARGUMENTS
 ```
 
 ## Phase 4: Documentation & Integration Review
@@ -86,7 +86,7 @@ gh pr diff $ARGUMENTS -- '*.go' | grep -n "t\.Skip\|mock\|fake\|stub"
 ## Phase 5: GitHub Actions CI Verification (MANDATORY — BLOCKING)
 
 ```bash
-gh pr checks $ARGUMENTS --required
+./scripts/pr-review-helper.sh pr-checks $ARGUMENTS
 ```
 
 **Required checks** (ALL must pass):

--- a/.claude/agents/security-engineer.md
+++ b/.claude/agents/security-engineer.md
@@ -73,11 +73,11 @@ Get changed files with `git diff --name-only develop...HEAD`, then review for:
 
 ### WARNING Issues (Should Fix, Not Blocking)
 
-8. **OWASP Top 10 Patterns**: Command injection, SSRF, broken access control.
+9. **OWASP Top 10 Patterns**: Command injection, SSRF, broken access control.
 
-9. **Cryptographic Concerns**: Weak algorithms, insufficient key lengths, predictable randomness.
+10. **Cryptographic Concerns**: Weak algorithms, insufficient key lengths, predictable randomness.
 
-10. **Logging Sensitive Data**: Secrets, tokens, or PII in log statements.
+11. **Logging Sensitive Data**: Secrets, tokens, or PII in log statements.
 
 ## Output Format
 

--- a/.claude/commands/agent-setup.md
+++ b/.claude/commands/agent-setup.md
@@ -45,6 +45,8 @@ One-time bootstrap for agent dispatch. Builds the container image, sets up crede
    While waiting, proceed with steps 6-8 (they're independent).
 
 6. **Set up Claude credentials**:
+   **IMPORTANT**: The OAuth flow below requires a real TTY for interactive browser login. The Bash tool CANNOT provide this. Do NOT attempt to run the `docker run --rm -it` command via the Bash tool — it will fail with "the input device is not a TTY". Instead, print the command and tell the user to run it manually in their terminal.
+
    - Create Docker volume: `docker volume create claude-creds` (idempotent)
    - Check if credentials already exist in the volume:
      ```bash
@@ -54,15 +56,17 @@ One-time bootstrap for agent dispatch. Builds the container image, sets up crede
    - If credentials exist and `$ARGUMENTS` is not 'creds': skip
    - If credentials missing or refreshing:
      - Tell user: "Claude credentials need setup. This requires an interactive login."
-     - Run interactive container for OAuth:
+     - Run interactive container for OAuth (runs as root to allow npm update, then switches to agent user for OAuth):
        ```bash
        docker run --rm -it \
          -v claude-creds:/persist \
+         --user root \
          --entrypoint bash \
          cfg-agent:latest \
-         -c "claude --dangerously-skip-permissions && cp ~/.claude/.credentials.json /persist/"
+         -c "npm update -g @anthropic-ai/claude-code && su agent -c 'claude --dangerously-skip-permissions && cp ~/.claude/.credentials.json /persist/'"
        ```
      - **IMPORTANT**: This step requires user interaction (OAuth flow). Tell the user what to expect.
+     - The `npm update` ensures the container's Claude Code matches the latest version before authenticating.
 
 7. **Create directories**:
    ```bash

--- a/.claude/commands/dispatch.md
+++ b/.claude/commands/dispatch.md
@@ -64,9 +64,38 @@ Launch isolated agent containers to implement GitHub issues. Each agent runs in 
       gh issue edit <NUM> --remove-label "agent:ready" --add-label "agent:in-progress"
       ```
 
-5. **Print summary table**: Show all dispatched issues with container IDs and branch names.
+5. **Post-launch auth check** (skip in dry-run): After ALL containers are launched, verify they survive past the OAuth authentication phase. Auth failures cause containers to exit within ~10 seconds.
 
-6. **Remind user**: "Use `/isoagents` to check progress. Agents typically complete in 15-45 minutes."
+   ```bash
+   ./scripts/agent-dispatch.sh wait-for-auth <NUM1> [NUM2...]
+   ```
+   Pass all dispatched issue numbers. The helper polls every 5s for up to 30s.
+
+   Parse output lines:
+   - `AUTH_OK:<NUM>:...` — Container survived auth, agent is working
+   - `AUTH_FAILED:<NUM>:...` — Container died early (likely expired OAuth token). Print the exit code and last log lines. Suggest: "Run `/agent-setup creds` to refresh OAuth credentials, then re-dispatch."
+   - `AUTH_UNKNOWN:<NUM>:...` — Unexpected state, report as warning
+
+   If ANY container fails auth, prominently warn the user that credentials likely need refresh before dispatching more agents.
+
+6. **Print full agent dashboard** (skip in dry-run): After auth check, gather state for ALL agents (not just the ones dispatched this run) to give the user a complete picture:
+
+   ```bash
+   ./scripts/agent-dispatch.sh list-running
+   ./scripts/agent-dispatch.sh list-exited
+   ```
+
+   Print a single summary table showing ALL agents:
+
+   **Agent Dashboard:**
+   | Issue | Status | Auth | Branch | Notes |
+   |-------|--------|------|--------|-------|
+
+   Status values: Running, Exited (exit code), Not found
+   Auth column: OK / FAILED / n/a (for agents from prior dispatches)
+   Notes: uptime for running, PR URL for exited with code 0, failure hint for exited with non-zero
+
+7. **Remind user**: If all auth checks passed: "Agents are running. Use `/isoagents` to check progress (typically 15-45 minutes)." If any failed: "Some agents failed auth — run `/agent-setup creds` to refresh, then `/dispatch` the failed issues again."
 
 ## Error Handling
 

--- a/.claude/commands/isoagents.md
+++ b/.claude/commands/isoagents.md
@@ -37,16 +37,18 @@ Show the status of all agent containers and offer lifecycle actions (cleanup, re
    - PR status: `gh pr list --head "feature/story-<NUM>-agent" --json url,state,title`
    - Suggest next actions based on state
 
-3. **If `$ARGUMENTS` is 'cleanup'**: For each exited container:
+3. **If `$ARGUMENTS` is 'cleanup'** (no number): For each exited container:
    a. Read exit code: `./scripts/agent-dispatch.sh inspect-exit <NUM>`
    b. Read issue number from label
-   c. Copy result file (best-effort): `docker cp cfg-agent-<NUM>:/tmp/agent-result.json /tmp/`
-   d. Check for PR: `gh pr list --head "feature/story-<NUM>-agent" --json url,state`
-   e. Remove container: `docker rm cfg-agent-<NUM>`
-   f. Remove clone directory: `rm -rf ../worktrees/story-<NUM>`
-   g. Report what was cleaned up
+   c. Check for PR: `gh pr list --head "feature/story-<NUM>-agent" --json url,state`
+   d. Clean up: `./scripts/agent-dispatch.sh cleanup-issue <NUM>`
+   e. Report what was cleaned up
 
-4. **Default (no arguments)**: Print status dashboard:
+4. **If `$ARGUMENTS` is 'cleanup <NUM>'** (specific issue): Clean up a single agent:
+   a. `./scripts/agent-dispatch.sh cleanup-issue <NUM>`
+   b. Report what was cleaned up
+
+5. **Default (no arguments)**: Print status dashboard:
 
    **Running Agents:**
    | Issue | Container | Uptime | Status |
@@ -59,7 +61,7 @@ Show the status of all agent containers and offer lifecycle actions (cleanup, re
    **Clones:**
    List any active clone directories under ../worktrees/
 
-5. **Suggest next actions** based on state:
+6. **Suggest next actions** based on state:
    - If completed agents with exit 0: "Agent #42 finished — PR ready. Run `/pr-review` or `/isoagents cleanup`"
    - If completed agents with non-zero exit: "Agent #43 failed — check draft PR with `/isoagents 43`"
    - If running agents: "Agent #44 still running (25 min). Check back with `/isoagents`"

--- a/.claude/commands/pr-review.md
+++ b/.claude/commands/pr-review.md
@@ -1,6 +1,6 @@
 ---
 name: pr-review
-description: Structured PR review using the pr-reviewer agent for fresh-context 6-phase methodology
+description: Structured PR review using the pr-reviewer agent for fresh-context 6-phase methodology. Use when reviewing PRs, checking PR quality, or the user says "review PR", "check the PR", "is this ready to merge", "review #X", or wants to approve/reject a pull request.
 parameters:
   - name: pr_number
     description: Pull request number to review (optional - auto-selects if 1 PR, shows menu if multiple)
@@ -27,15 +27,15 @@ gh pr list --state=open --json number,title,author,headRefName,isDraft --limit 2
 
 ### 2. Pre-Review Git Sync
 
-Ensure the local repo reflects the latest state:
+Ensure the local repo reflects the latest state (uses helper to avoid approval prompts):
 
 ```bash
-git fetch origin
+./scripts/pr-review-helper.sh pre-review <NUM>
 ```
 
-Check for uncommitted changes — warn if working directory is dirty.
-
-Check for unpushed commits on feature branches — push them before review so the PR reflects all code.
+Parse output:
+- `DIRTY:true` — warn user about uncommitted changes
+- `UNPUSHED:true` — warn user about unpushed commits, suggest pushing before review
 
 ### 3. Launch PR Reviewer Agent
 
@@ -59,6 +59,19 @@ When the agent completes, relay its findings to the user:
 - Phase-by-phase summary
 - Final recommendation (APPROVED / CHANGES REQUIRED / BLOCKED)
 - Any blocking issues that need resolution
+
+### 5. Agent Cleanup on Approval
+
+If the review result is **APPROVED FOR MERGE** or **APPROVED WITH COMMENTS**, check whether the PR branch came from an agent dispatch (branch pattern `feature/story-*-agent`). If so:
+
+1. Extract the story number from the branch name
+2. Clean up the agent's container and clone:
+   ```bash
+   ./scripts/agent-dispatch.sh cleanup-issue <story_number>
+   ```
+3. Report what was cleaned up
+
+This keeps agent infrastructure tidy — once a PR is approved, the container and worktree are no longer needed.
 
 ## Error Handling
 

--- a/.claude/commands/story-commit.md
+++ b/.claude/commands/story-commit.md
@@ -1,6 +1,6 @@
 ---
 name: story-commit
-description: Commit changes with mandatory validation checks and story progress tracking
+description: Commit changes with mandatory validation checks and story progress tracking. MUST use for ALL commits during story development — never use raw git commit. Use when the user says "commit", "save changes", "checkpoint", or wants to commit their work.
 parameters:
   - name: message
     description: The commit message (optional - auto-generates from diff if omitted)

--- a/.claude/commands/story-complete.md
+++ b/.claude/commands/story-complete.md
@@ -92,7 +92,7 @@ Commit roadmap changes to the story branch so they're included in the single PR.
 ### 9. Push to Remote
 
 ```bash
-git push -u origin $(git branch --show-current)
+git push -u origin HEAD
 ```
 
 Verify push succeeds before creating PR.
@@ -101,9 +101,12 @@ Verify push succeeds before creating PR.
 
 **Git workflow rules**: Feature/tooling branches ALWAYS target `develop`. Never `main`.
 
-Check for existing PR on this branch:
+Check for existing PR on this branch. First get the branch name with `git branch --show-current`, then use it:
 ```bash
-gh pr list --head $(git branch --show-current) --state=open
+git branch --show-current
+```
+```bash
+gh pr list --head <branch-name-from-above> --state=open
 ```
 
 - **If existing PR found**: Update it with `gh pr edit [number] --body "[template]" --base develop`

--- a/.claude/commands/story-start.md
+++ b/.claude/commands/story-start.md
@@ -1,6 +1,6 @@
 ---
 name: story-start
-description: Start a new story with mandatory pre-flight validation and roadmap auto-detection
+description: Start a new story with mandatory pre-flight validation and roadmap auto-detection. MUST use when beginning any new development work, picking up an issue, or the user says "start story", "new story", "work on issue", "begin work on #X", or similar.
 parameters:
   - name: story_number
     description: The story/issue number (optional - auto-detects from roadmap if omitted)

--- a/.claude/skills/ci-verify/SKILL.md
+++ b/.claude/skills/ci-verify/SKILL.md
@@ -16,9 +16,9 @@ allowed-tools: Bash
 
 ## Verification Steps
 
-1. **Check PR required checks**:
+1. **Check PR required checks** (uses helper to avoid approval prompts):
    ```bash
-   gh pr checks $ARGUMENTS --required
+   ./scripts/pr-review-helper.sh pr-checks $ARGUMENTS
    ```
 
 2. **Evaluate results**:
@@ -27,10 +27,9 @@ allowed-tools: Bash
    - ANY PENDING → Report "CI IN PROGRESS — wait for completion" with pending check names
    - NO RUNS → Report "CI NOT RUN — branch may not be pushed"
 
-3. **For failures, get details**:
+3. **For failures, get details** (uses helper to avoid approval prompts):
    ```bash
-   head_branch=$(gh pr view $ARGUMENTS --json headRefName -q .headRefName)
-   gh run list --branch "$head_branch" --limit 5 --json conclusion,name,status,headBranch
+   ./scripts/pr-review-helper.sh ci-details $ARGUMENTS
    ```
 
 ## Blocking Policy

--- a/.claude/skills/doc-review/SKILL.md
+++ b/.claude/skills/doc-review/SKILL.md
@@ -13,20 +13,17 @@ Detect internal tracking documents in the diff that should NOT be in PRs. These 
 
 ## Scan Steps
 
-1. **Find potentially problematic files in the diff**:
-   ```bash
-   git diff --name-only develop...HEAD -- docs/ | grep -iE '(status|summary|validation|report|review|sprint|milestone|story-[0-9]+)'
-   ```
+Run the doc scan helper (wraps pipe+regex commands to avoid approval prompts):
 
-2. **Check for version-specific internal reports**:
-   ```bash
-   git ls-files docs/ | grep -E 'v[0-9]+\.[0-9]+\.[0-9]+'
-   ```
+```bash
+./scripts/pr-review-helper.sh doc-scan
+```
 
-3. **Look for "Story #" references in new docs** (may indicate internal tracking):
-   ```bash
-   git diff --name-only develop...HEAD -- docs/ | xargs grep -l "Story #[0-9]" 2>/dev/null
-   ```
+Parse the output sections:
+- **Changed docs in PR** — Files matching internal tracking patterns (status, summary, report, etc.)
+- **Version-specific internal reports** — Files with version numbers in their name
+- **New docs with Story references** — Changed docs containing "Story #NNN" references
+- `(none)` means that section found nothing
 
 ## Classification Rules
 

--- a/.claude/skills/git-workflow/SKILL.md
+++ b/.claude/skills/git-workflow/SKILL.md
@@ -25,17 +25,15 @@ user-invocable: false
 
 ## Push Procedures
 - Verify all changes committed before push: `git status --porcelain`
-- Push with upstream tracking: `git push -u origin $(git branch --show-current)`
+- Push with upstream tracking: `git push -u origin HEAD`
 - After push, verify remote is up to date
 
 ## Branch Validation
-```bash
-current_branch=$(git branch --show-current)
-if [[ $current_branch == feature/* ]] || [[ $current_branch == tooling/* ]]; then
-  target_branch="develop"
-elif [[ $current_branch == hotfix/* ]]; then
-  target_branch="main"
-else
-  echo "ERROR: Unexpected branch pattern"
-fi
-```
+
+Determine the correct PR base branch from the current branch name:
+- `feature/*` or `tooling/*` → base is `develop`
+- `hotfix/*` → base is `main`
+- Anything else → ERROR: unexpected branch pattern
+
+Use `git branch --show-current` to get the current branch, then match the prefix.
+Do NOT compose multi-line bash scripts or use `$()` command substitution for this — use the Bash tool with simple single commands and apply the logic in your reasoning.

--- a/.claude/skills/story-context/SKILL.md
+++ b/.claude/skills/story-context/SKILL.md
@@ -12,14 +12,14 @@ allowed-tools: Bash
 
 1. **Detect story number from branch**:
    ```bash
-   branch=$(git branch --show-current)
-   story_number=$(echo "$branch" | grep -oP 'story-\K[0-9]+')
+   git branch --show-current
    ```
+   Extract the story number from the branch name by finding the numeric part after `story-`.
    If no story number found in branch name, check if a story number was passed as argument: `$ARGUMENTS`
 
-2. **Fetch issue details from GitHub**:
+2. **Fetch issue details from GitHub** (use the extracted story number):
    ```bash
-   gh issue view $story_number --json body,title,state,assignees
+   gh issue view <story_number> --json body,title,state,assignees
    ```
 
 3. **Parse acceptance criteria** from issue body:

--- a/.devcontainer/entrypoint.sh
+++ b/.devcontainer/entrypoint.sh
@@ -128,6 +128,13 @@ echo "Starting Claude agent for issue #${ISSUE_NUM}..."
 EXIT_CODE=0
 claude --dangerously-skip-permissions --model claude-sonnet-4-6 -p "$PROMPT" || EXIT_CODE=$?
 
+# Write back potentially refreshed OAuth credentials to the shared volume.
+# Claude Code may refresh the OAuth token during its session — persisting it
+# ensures the next container launch gets a valid token instead of a stale one.
+if [ -f ~/.claude/.credentials.json ]; then
+    cp ~/.claude/.credentials.json /persist/.credentials.json 2>/dev/null || true
+fi
+
 # --- Phase 3: Cleanup and reporting ---
 
 # Extract PR URL if one was created

--- a/scripts/agent-dispatch.sh
+++ b/scripts/agent-dispatch.sh
@@ -15,6 +15,8 @@ Commands:
   check-conflicts <NUM> [NUM...]   Check for existing containers/clones
   create-clone    <NUM>            Clone repo and create feature branch
   launch          <NUM>            Launch agent container
+  wait-for-auth   <NUM> [NUM...]   Poll containers until past auth phase (~30s)
+  cleanup-issue   <NUM>            Remove container and clone for a specific issue
   list-running                     List running agent containers
   list-exited                      List exited agent containers
   inspect-exit    <NUM>            Print exit code of container
@@ -64,7 +66,7 @@ case "$cmd" in
     clone_path="${WORKTREE_BASE}/story-${num}"
     real_path=$(realpath "$clone_path")
     gh_token=$(gh auth token)
-    container_id=$(docker run -d \
+    if container_id=$(docker run -d \
       --name "cfg-agent-${num}" \
       --label "cfg-agent=true" \
       --label "issue=${num}" \
@@ -72,12 +74,83 @@ case "$cmd" in
       --cpus=4 \
       --stop-timeout=3600 \
       -v "${real_path}:/workspace" \
-      -v "claude-creds:/persist:ro" \
+      -v "claude-creds:/persist" \
       -e "GH_TOKEN=${gh_token}" \
       --cap-add NET_ADMIN \
       cfg-agent:latest \
-      "${num}")
-    echo "LAUNCHED:${num}:${container_id}"
+      "${num}" 2>&1); then
+      echo "LAUNCHED:${num}:${container_id}"
+    else
+      # Launch failed — clean up orphaned clone to prevent blocking future dispatches
+      echo "LAUNCH_FAILED:${num}:${container_id}"
+      rm -rf "$clone_path"
+      echo "CLEANED:clone:${clone_path}"
+      exit 1
+    fi
+    ;;
+
+  wait-for-auth)
+    [[ $# -ge 1 ]] || { echo "wait-for-auth requires at least one issue number"; exit 1; }
+    # Poll containers every 5s for up to 30s to confirm they survive past auth.
+    # Auth failures cause exit within ~10s. If still running at 30s, auth succeeded.
+    max_wait=30
+    interval=5
+    elapsed=0
+    nums=("$@")
+    while [[ $elapsed -lt $max_wait ]]; do
+      sleep "$interval"
+      elapsed=$((elapsed + interval))
+      all_resolved=true
+      for num in "${nums[@]}"; do
+        status=$(docker inspect --format "{{.State.Status}}" "cfg-agent-${num}" 2>/dev/null || echo "not_found")
+        if [[ "$status" == "exited" ]]; then
+          exit_code=$(docker inspect --format "{{.State.ExitCode}}" "cfg-agent-${num}" 2>/dev/null || echo "?")
+          last_log=$(docker logs --tail 5 "cfg-agent-${num}" 2>/dev/null || echo "(no logs)")
+          echo "AUTH_FAILED:${num}:exit_code=${exit_code}:${last_log}"
+        elif [[ "$status" == "running" ]]; then
+          if [[ $elapsed -ge $max_wait ]]; then
+            echo "AUTH_OK:${num}:running after ${elapsed}s"
+          else
+            all_resolved=false
+          fi
+        else
+          echo "AUTH_UNKNOWN:${num}:status=${status}"
+        fi
+      done
+      if $all_resolved; then
+        break
+      fi
+    done
+    # Final check for any still running (in case loop ended by time)
+    for num in "${nums[@]}"; do
+      status=$(docker inspect --format "{{.State.Status}}" "cfg-agent-${num}" 2>/dev/null || echo "not_found")
+      if [[ "$status" == "running" ]]; then
+        echo "AUTH_OK:${num}:running after ${elapsed}s"
+      fi
+    done
+    echo "WAIT_DONE"
+    ;;
+
+  cleanup-issue)
+    [[ $# -eq 1 ]] || { echo "cleanup-issue requires exactly one issue number"; exit 1; }
+    num="$1"
+    # Copy result file (best-effort)
+    docker cp "cfg-agent-${num}:/tmp/agent-result.json" "/tmp/agent-result-${num}.json" 2>/dev/null || true
+    # Remove container (works for both running and exited)
+    if docker rm -f "cfg-agent-${num}" >/dev/null 2>&1; then
+      echo "CLEANED:container:cfg-agent-${num}"
+    else
+      echo "SKIP:container:cfg-agent-${num} not found"
+    fi
+    # Remove clone directory
+    clone_dir="${WORKTREE_BASE}/story-${num}"
+    if [[ -d "$clone_dir" ]]; then
+      rm -rf "$clone_dir"
+      echo "CLEANED:clone:${clone_dir}"
+    else
+      echo "SKIP:clone:${clone_dir} not found"
+    fi
+    echo "CLEANUP_DONE:${num}"
     ;;
 
   list-running)

--- a/scripts/pr-review-helper.sh
+++ b/scripts/pr-review-helper.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+# Helper for /pr-review, pr-reviewer agent, and ci-verify skill.
+# Wraps commands that contain $(), Go-template quotes, or pipe+regex
+# patterns so Claude Code can invoke them without triggering approval prompts.
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: pr-review-helper.sh <command> [args...]
+
+Commands:
+  doc-scan                Scan for internal tracking documents in PR diff
+  pre-review     <NUM>   Fetch origin, check dirty state, check unpushed commits
+  diff-scan      <NUM>   Scan PR diff for test quality issues (mocks, skips, etc.)
+  ci-details     <NUM>   Get CI failure details (head branch + recent runs)
+  pr-overview    <NUM>   Fetch PR metadata (title, body, base, head, files)
+  pr-checks      <NUM>   Run gh pr checks --required
+  pr-diff        <NUM>   Get full PR diff
+EOF
+  exit 1
+}
+
+[[ $# -ge 1 ]] || usage
+
+cmd="$1"; shift
+
+case "$cmd" in
+
+  doc-scan)
+    echo "=== Changed docs in PR ==="
+    git diff --name-only develop...HEAD -- docs/ 2>/dev/null | grep -iE '(status|summary|validation|report|review|sprint|milestone|story-[0-9]+)' || echo "(none)"
+
+    echo "=== Version-specific internal reports ==="
+    git ls-files docs/ 2>/dev/null | grep -E 'v[0-9]+\.[0-9]+\.[0-9]+' || echo "(none)"
+
+    echo "=== New docs with Story references ==="
+    changed_docs=$(git diff --name-only develop...HEAD -- docs/ 2>/dev/null || true)
+    if [[ -n "$changed_docs" ]]; then
+      echo "$changed_docs" | xargs grep -l "Story #[0-9]" 2>/dev/null || echo "(none)"
+    else
+      echo "(no changed docs)"
+    fi
+
+    echo "DOC_SCAN_DONE"
+    ;;
+
+  pre-review)
+    [[ $# -eq 1 ]] || { echo "pre-review requires a PR number"; exit 1; }
+    num="$1"
+
+    # Fetch latest from origin
+    echo "FETCH:start"
+    git fetch origin 2>&1 || echo "FETCH:failed"
+    echo "FETCH:done"
+
+    # Check dirty state
+    dirty=$(git status --porcelain 2>/dev/null)
+    if [[ -n "$dirty" ]]; then
+      echo "DIRTY:true"
+      echo "$dirty"
+    else
+      echo "DIRTY:false"
+    fi
+
+    # Check for unpushed commits on current branch
+    current_branch=$(git branch --show-current 2>/dev/null || echo "")
+    if [[ -n "$current_branch" ]]; then
+      upstream="origin/${current_branch}"
+      unpushed=$(git log "${upstream}..HEAD" --oneline 2>/dev/null || echo "")
+      if [[ -n "$unpushed" ]]; then
+        echo "UNPUSHED:true"
+        echo "$unpushed"
+      else
+        echo "UNPUSHED:false"
+      fi
+    fi
+
+    echo "PRE_REVIEW_DONE"
+    ;;
+
+  diff-scan)
+    [[ $# -eq 1 ]] || { echo "diff-scan requires a PR number"; exit 1; }
+    num="$1"
+
+    echo "=== Test Quality Scan ==="
+    # Scan for mocks, skips, stubs, fakes in Go files
+    gh pr diff "$num" -- '*.go' 2>/dev/null | grep -n -E 't\.Skip|mock|Mock|fake|Fake|stub|Stub|TODO|HACK|FIXME' || echo "(no test quality issues found)"
+
+    echo "=== Security Scan ==="
+    # Scan for potential security issues
+    gh pr diff "$num" -- '*.go' 2>/dev/null | grep -n -E 'hardcoded|password|secret|token.*=.*"|sql\.Query.*\+|fmt\.Sprintf.*SELECT|Sprintf.*INSERT' || echo "(no security patterns found)"
+
+    echo "DIFF_SCAN_DONE"
+    ;;
+
+  ci-details)
+    [[ $# -eq 1 ]] || { echo "ci-details requires a PR number"; exit 1; }
+    num="$1"
+
+    head_branch=$(gh pr view "$num" --json headRefName -q .headRefName 2>/dev/null || echo "unknown")
+    echo "HEAD_BRANCH:${head_branch}"
+
+    if [[ "$head_branch" != "unknown" ]]; then
+      echo "=== Recent Runs ==="
+      gh run list --branch "$head_branch" --limit 5 --json conclusion,name,status,headBranch 2>/dev/null || echo "(no runs found)"
+    fi
+
+    echo "CI_DETAILS_DONE"
+    ;;
+
+  pr-overview)
+    [[ $# -eq 1 ]] || { echo "pr-overview requires a PR number"; exit 1; }
+    gh pr view "$1" --json title,body,baseRefName,headRefName,state,author,files 2>/dev/null || echo "ERROR:failed to fetch PR"
+    ;;
+
+  pr-checks)
+    [[ $# -eq 1 ]] || { echo "pr-checks requires a PR number"; exit 1; }
+    gh pr checks "$1" --required 2>/dev/null || echo "CHECKS:no required checks or PR not found"
+    ;;
+
+  pr-diff)
+    [[ $# -eq 1 ]] || { echo "pr-diff requires a PR number"; exit 1; }
+    gh pr diff "$1" 2>/dev/null || echo "ERROR:failed to fetch diff"
+    ;;
+
+  *)
+    echo "Unknown command: $cmd"
+    usage
+    ;;
+esac


### PR DESCRIPTION
## Summary

Fixes Claude Code approval prompt interruptions across all skills/agents, resolves agent OAuth token expiration causing silent failures, and improves skill triggering accuracy. 16 files changed across the skill/agent/helper infrastructure.

## Problem Context

Three separate issues were degrading the agent dispatch and interactive workflow experience:

1. **Approval prompts**: Bash commands containing `$()` subshells, pipe+regex, and `cd`+`git` compounds require manual approval in non-yolo mode. Skills like `/pr-review`, `/story-complete`, and `ci-verify` triggered these repeatedly, breaking flow.

2. **OAuth token expiration**: Agent containers mounted the `claude-creds` volume read-only. When Claude Code refreshed the OAuth token during a session, the refreshed token died with the container. Next launch used the stale original — failing silently until `/isoagents` was checked manually.

3. **No early failure detection**: `/dispatch` returned immediately after `docker run -d`, reporting success. Auth failures (expired tokens) caused containers to exit within ~10 seconds, but the user wouldn't discover this until checking `/isoagents` 15-45 minutes later.

## Changes

- Add `scripts/pr-review-helper.sh` — wraps all PR review/CI bash commands that trigger approval prompts (7 commands: doc-scan, pre-review, diff-scan, ci-details, pr-overview, pr-checks, pr-diff)
- Add `wait-for-auth` and `cleanup-issue` commands to `scripts/agent-dispatch.sh`
- Fix `launch` to clean up orphaned clones when `docker run` fails
- Write back OAuth credentials to shared volume after each agent session
- Remove `:ro` from `claude-creds` volume mount to enable write-back
- Eliminate all `$()` subshell patterns from 7 skill/agent markdown files
- Add TTY warning to `agent-setup` creds flow (prevents repeated failed attempts)
- Run `npm update` during creds refresh to sync Claude Code version
- Improve skill descriptions for `story-start`, `story-commit`, `pr-review` (better trigger accuracy)
- Add targeted cleanup: `/isoagents cleanup <NUM>` for single-issue cleanup
- Auto-cleanup agent container/clone on PR approval in `/pr-review`
- Fix duplicate numbering (8→9,10,11) in `security-engineer` agent

## Testing

- Dispatched agent #472 twice to verify auth polling catches expired tokens within 10 seconds
- Verified `wait-for-auth` output format (AUTH_OK/AUTH_FAILED/WAIT_DONE)
- Confirmed `cleanup-issue` removes both container and clone
- Grep sweep confirms zero remaining `$()` patterns in `.claude/` markdown files
- Both helper scripts verified executable

🤖 Generated with [Claude Code](https://claude.com/claude-code)