### PR TITLE
fix: align tenant context key between auth middleware and config handlers (Issue #430)

### DIFF
--- a/features/controller/api/handlers_stewards.go
+++ b/features/controller/api/handlers_stewards.go
@@ -14,6 +14,7 @@ import (
 	"gopkg.in/yaml.v3"
 
 	controller "github.com/cfgis/cfgms/api/proto/controller"
+	"github.com/cfgis/cfgms/features/controller/ctxkeys"
 	stewardconfig "github.com/cfgis/cfgms/features/steward/config"
 	"github.com/cfgis/cfgms/pkg/logging"
 )
@@ -267,7 +268,7 @@ func (s *Server) handleUpdateStewardConfig(w http.ResponseWriter, r *http.Reques
 
 	// Extract tenant from context or use default
 	tenantID := "default"
-	if tid, ok := r.Context().Value("tenant-id").(string); ok && tid != "" {
+	if tid, ok := r.Context().Value(ctxkeys.TenantID).(string); ok && tid != "" {
 		tenantID = tid
 	}
 
@@ -395,7 +396,7 @@ func (s *Server) handleGetEffectiveConfig(w http.ResponseWriter, r *http.Request
 
 	// Extract tenant from context or use default
 	tenantID := "default"
-	if tid, ok := r.Context().Value("tenant-id").(string); ok && tid != "" {
+	if tid, ok := r.Context().Value(ctxkeys.TenantID).(string); ok && tid != "" {
 		tenantID = tid
 	}
 

--- a/features/controller/api/middleware.go
+++ b/features/controller/api/middleware.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/gorilla/mux"
 
+	"github.com/cfgis/cfgms/features/controller/ctxkeys"
 	"github.com/cfgis/cfgms/pkg/logging"
 )
 
@@ -23,7 +24,6 @@ const (
 	// Context keys
 	apiKeyContextKey       contextKey = "api_key"
 	userIDContextKey       contextKey = "user_id"
-	tenantIDContextKey     contextKey = "tenant_id"
 	authDecisionContextKey contextKey = "auth_decision"
 )
 
@@ -175,7 +175,7 @@ func (s *Server) authenticationMiddleware(next http.Handler) http.Handler {
 		// Add key info to request context
 		ctx := context.WithValue(r.Context(), apiKeyContextKey, keyInfo)
 		ctx = context.WithValue(ctx, userIDContextKey, keyInfo.ID)
-		ctx = context.WithValue(ctx, tenantIDContextKey, keyInfo.TenantID)
+		ctx = context.WithValue(ctx, ctxkeys.TenantID, keyInfo.TenantID)
 
 		next.ServeHTTP(w, r.WithContext(ctx))
 	})
@@ -293,7 +293,7 @@ func (s *Server) requirePermission(resourceType, action string) func(http.Handle
 			}
 
 			userID, _ := r.Context().Value(userIDContextKey).(string)
-			tenantID, _ := r.Context().Value(tenantIDContextKey).(string)
+			tenantID, _ := r.Context().Value(ctxkeys.TenantID).(string)
 
 			// Build resource identifier from URL path variables
 			resource := s.buildResourceIdentifier(r, resourceType)

--- a/features/controller/api/server.go
+++ b/features/controller/api/server.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/cfgis/cfgms/commercial/ha"
 	"github.com/cfgis/cfgms/features/controller/config"
+	"github.com/cfgis/cfgms/features/controller/ctxkeys"
 	"github.com/cfgis/cfgms/features/controller/service"
 	"github.com/cfgis/cfgms/features/monitoring"
 	"github.com/cfgis/cfgms/features/rbac"
@@ -152,7 +153,7 @@ func New(
 		authdefense.DefaultConfig(),
 		logger,
 		authdefense.WithTenantExtractor(func(r *http.Request) string {
-			if tid, ok := r.Context().Value(tenantIDContextKey).(string); ok {
+			if tid, ok := r.Context().Value(ctxkeys.TenantID).(string); ok {
 				return tid
 			}
 			return ""

--- a/features/controller/api/server_test.go
+++ b/features/controller/api/server_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/cfgis/cfgms/features/controller/config"
+	"github.com/cfgis/cfgms/features/controller/ctxkeys"
 	"github.com/cfgis/cfgms/features/controller/service"
 	"github.com/cfgis/cfgms/features/rbac"
 	"github.com/cfgis/cfgms/features/tenant"
@@ -992,4 +993,71 @@ func TestTestEndpointAuthGate(t *testing.T) {
 		assert.Equal(t, http.StatusUnauthorized, rec.Code, "Env var value 'yes' should not bypass auth")
 		assert.False(t, handlerCalled, "Handler should not be called with non-exact env var value")
 	})
+}
+
+// TestTenantContextPropagation verifies that tenant ID set by the auth middleware flows
+// through to the config handler and is used for config storage (not silently falling back
+// to "default"). This is a regression test for the context key type mismatch fixed in
+// Issue #430: auth middleware used typed contextKey("tenant_id") while handlers used
+// plain string "tenant-id" — so context.Value() always returned nil before the fix.
+func TestTenantContextPropagation(t *testing.T) {
+	server := setupTestServer(t)
+
+	// Create an API key for a specific tenant (not the default "test-tenant").
+	// NewEphemeralTestKey stores the key with this tenantID in the server's in-memory
+	// key map, so when the auth middleware validates the key it will read TenantID = "acme-corp"
+	// and store it under ctxkeys.TenantID in the request context.
+	configWriteKey := NewEphemeralTestKey(t, server, []string{"steward:write-config"}, "acme-corp", 5*time.Minute)
+
+	// Build a minimal valid StewardConfig that passes ValidateConfiguration.
+	configBody := []byte(`{
+		"steward": {
+			"id": "test-steward-1",
+			"mode": "standalone",
+			"logging": {"level": "info"}
+		},
+		"resources": []
+	}`)
+
+	req := httptest.NewRequest("PUT", "/api/v1/stewards/test-steward-1/config", bytes.NewReader(configBody))
+	req.Header.Set("X-API-Key", configWriteKey)
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+
+	server.router.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code, "Config write should succeed; body: %s", rec.Body.String())
+
+	var response APIResponse
+	err := json.Unmarshal(rec.Body.Bytes(), &response)
+	require.NoError(t, err)
+
+	data, ok := response.Data.(map[string]interface{})
+	require.True(t, ok, "Response data should be a map")
+
+	// The tenant_id in the response must match the key's tenant, not "default".
+	// Before the fix the handler extracted via plain string "tenant-id" which never
+	// matched the typed contextKey set by the middleware, so tenantID was always "default".
+	assert.Equal(t, "acme-corp", data["tenant_id"],
+		"tenant_id in response should reflect the authenticated API key's tenant, not 'default'")
+	assert.Equal(t, "test-steward-1", data["steward_id"])
+}
+
+// TestTenantContextKeyType verifies that ctxkeys.TenantID can be retrieved from a context
+// that was populated using the same key — confirming the type identity that was broken before.
+func TestTenantContextKeyType(t *testing.T) {
+	ctx := context.WithValue(context.Background(), ctxkeys.TenantID, "acme-corp")
+
+	val, ok := ctx.Value(ctxkeys.TenantID).(string)
+	assert.True(t, ok, "ctxkeys.TenantID should be retrievable with the same typed key")
+	assert.Equal(t, "acme-corp", val)
+
+	// Plain string "tenant_id" must NOT match the typed key — this confirms the
+	// type-safe key prevents silent collisions with untyped string keys.
+	plainVal := ctx.Value("tenant_id")
+	assert.Nil(t, plainVal, "plain string 'tenant_id' must not match the typed ctxkeys.TenantID")
+
+	// Old hyphenated string "tenant-id" must also not match.
+	oldVal := ctx.Value("tenant-id")
+	assert.Nil(t, oldVal, "old plain string 'tenant-id' must not match the typed ctxkeys.TenantID")
 }

--- a/features/controller/api/validation_middleware.go
+++ b/features/controller/api/validation_middleware.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/gorilla/mux"
 
+	"github.com/cfgis/cfgms/features/controller/ctxkeys"
 	"github.com/cfgis/cfgms/pkg/security"
 )
 
@@ -68,7 +69,7 @@ func (s *Server) buildSecurityContext(r *http.Request) *security.SecurityContext
 	if userID, ok := r.Context().Value(userIDContextKey).(string); ok {
 		ctx.UserID = userID
 	}
-	if tenantID, ok := r.Context().Value(tenantIDContextKey).(string); ok {
+	if tenantID, ok := r.Context().Value(ctxkeys.TenantID).(string); ok {
 		ctx.TenantID = tenantID
 	}
 

--- a/features/controller/ctxkeys/ctxkeys.go
+++ b/features/controller/ctxkeys/ctxkeys.go
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+// Package ctxkeys defines shared context key types for the controller feature.
+// Using a typed key prevents collisions with plain string keys and enables
+// safe sharing across the api and service packages without circular imports.
+package ctxkeys
+
+// ContextKey is the type for controller context keys. Using a named type
+// prevents accidental collisions with keys from other packages.
+type ContextKey string
+
+const (
+	// TenantID is the context key for the authenticated tenant ID.
+	// Set by the auth middleware after validating an API key and read by
+	// config handlers and service methods to enforce tenant isolation.
+	TenantID ContextKey = "tenant_id"
+)

--- a/features/controller/service/config_service_v2.go
+++ b/features/controller/service/config_service_v2.go
@@ -11,6 +11,7 @@ import (
 
 	common "github.com/cfgis/cfgms/api/proto/common"
 	controller "github.com/cfgis/cfgms/api/proto/controller"
+	"github.com/cfgis/cfgms/features/controller/ctxkeys"
 	stewardconfig "github.com/cfgis/cfgms/features/steward/config"
 	"github.com/cfgis/cfgms/features/validation"
 	"github.com/cfgis/cfgms/pkg/config"
@@ -375,12 +376,12 @@ func (s *ConfigurationServiceV2) convertValidationLevel(level string) controller
 
 // extractTenantID extracts tenant ID from context
 func (s *ConfigurationServiceV2) extractTenantID(ctx context.Context) string {
-	// Extract tenant ID from context value (set by MQTT/HTTP handlers)
-	if tenantID, ok := ctx.Value("tenant-id").(string); ok && tenantID != "" {
+	// Extract tenant ID from context value (set by auth middleware)
+	if tenantID, ok := ctx.Value(ctxkeys.TenantID).(string); ok && tenantID != "" {
 		return tenantID
 	}
 
-	s.logger.Debug("No tenant-id in context, using default tenant")
+	s.logger.Debug("No tenant ID in context, using default tenant")
 	return "default"
 }
 

--- a/features/controller/service/controller_service.go
+++ b/features/controller/service/controller_service.go
@@ -12,6 +12,7 @@ import (
 
 	common "github.com/cfgis/cfgms/api/proto/common"
 	controller "github.com/cfgis/cfgms/api/proto/controller"
+	"github.com/cfgis/cfgms/features/controller/ctxkeys"
 	"github.com/cfgis/cfgms/pkg/logging"
 )
 
@@ -341,11 +342,11 @@ func (s *ControllerService) verifySyncStatus(existingSteward *StewardInfo, req *
 
 // extractTenantID extracts tenant ID from context
 func (s *ControllerService) extractTenantID(ctx context.Context) string {
-	// Extract tenant ID from context value (set by MQTT/HTTP handlers)
-	if tenantID, ok := ctx.Value("tenant-id").(string); ok && tenantID != "" {
+	// Extract tenant ID from context value (set by auth middleware)
+	if tenantID, ok := ctx.Value(ctxkeys.TenantID).(string); ok && tenantID != "" {
 		return tenantID
 	}
 
-	s.logger.Debug("No tenant-id in context, using default tenant")
+	s.logger.Debug("No tenant ID in context, using default tenant")
 	return "default"
 }


### PR DESCRIPTION
## Summary

Auth middleware stored tenant ID using typed `contextKey("tenant_id")` while config
handlers and service `extractTenantID` methods read it with plain string `"tenant-id"`.
Go's `context.Value()` requires exact type and value match, so the lookup always returned
nil — all config operations (Set, Get, GetEffective) silently fell back to tenant
`"default"` regardless of the authenticated principal.

## Problem Context

The mismatch was between three independent definitions of "the tenant ID key":
- `middleware.go`: `type contextKey string; tenantIDContextKey contextKey = "tenant_id"` (typed, underscore)
- `handlers_stewards.go:270,398`: `r.Context().Value("tenant-id")` (plain string, hyphen)
- `config_service_v2.go:379`, `controller_service.go:345`: `ctx.Value("tenant-id")` (plain string, hyphen)

With no shared canonical definition, each site chose its own type and spelling.
The result: tenant isolation in the config service was effectively bypassed for HTTP paths.

## Changes

- New `features/controller/ctxkeys` package: exported `ContextKey` type and `TenantID` constant — no CFGMS imports, importable by both `api` and `service` without circular deps
- `middleware.go`: store tenant with `ctxkeys.TenantID`; remove now-unused local `tenantIDContextKey`
- `handlers_stewards.go`: extract tenant with `ctxkeys.TenantID` (was `"tenant-id"`)
- `server.go`, `validation_middleware.go`: update tenant extractor to use `ctxkeys.TenantID`
- `config_service_v2.go`, `controller_service.go`: `extractTenantID` uses `ctxkeys.TenantID`
- `server_test.go`: two regression tests added

## Measured Impact

`TestTenantContextPropagation`: PUT config request authenticated as tenant "acme-corp" now returns `tenant_id: "acme-corp"` in the response (previously would have returned `"default"`).

`TestTenantContextKeyType`: asserts typed key isolation — `"tenant_id"` and `"tenant-id"` plain strings do NOT match `ctxkeys.TenantID` in context lookup.

## Testing

- `features/controller/api` — ✅ all tests pass (including new regression tests)
- `features/controller/service` — ✅ all tests pass
- `features/controller` — ✅ all tests pass
- `test/unit/controller` — ✅ all tests pass
- Pre-existing failures in `features/saas`, `pkg/logging/subscribers/syslog`, `pkg/secrets/providers/steward` are container environment issues (no network, no syslog, no `/etc/machine-id`); confirmed pre-existing before this change

Fixes #430