### PR TITLE
monitoring: wire CFGMS-specific health collectors into controller (Issue #417)

### DIFF
--- a/docs/product/roadmap.md
+++ b/docs/product/roadmap.md
@@ -4,7 +4,7 @@
 
 This document outlines the development roadmap for the Configuration Management System (CFGMS). It provides a clear vision for the project's development, including milestones, features, and release planning, incorporating recent strategic adjustments to better align with MSP market voids and core product vision.
 
-**Last Updated**: 2026-03-09
+**Last Updated**: 2026-03-15
 
 ## Versioning Strategy
 
@@ -205,7 +205,7 @@ Deploy on test cluster and manage real VMs — the core beta milestone.
 - [x] Controller: wire ConfigurationServiceV2 durable storage — V1 is in-memory (Issue #409) - Configs lost on controller restart, deployment blocker
 - [x] Controller: separate first-run initialization from normal startup (Issue #410) - Prevent silent CA regeneration on misconfigured restart
 - [x] Steward: compile-time controller URL, remove regtoken prefix (Issue #421) - Controller URL baked in at build for signed binary security, shorter tokens for MDM deployment
-- [ ] Steward: self-install subcommand with interactive mode for GUI launch (Issue #472 - 8-13 points) - `install`/`uninstall`/`status` subcommands, interactive token prompt on double-click, native Windows Service/systemd/launchd registration
+- [x] Steward: self-install subcommand with interactive mode for GUI launch (Issue #472 - 8-13 points) - `install`/`uninstall`/`status` subcommands, interactive token prompt on double-click, native Windows Service/systemd/launchd registration
 
 **E2E validation:**
 - [ ] End-to-end deployment validation on real VMs (Issue #390 - 13-21 points) - Deploy controller + stewards on actual Windows/Linux VMs, test all modules, fix blockers
@@ -217,14 +217,14 @@ Deploy on test cluster and manage real VMs — the core beta milestone.
 - [ ] Steward: wire drift detection and performance monitoring into lifecycle (Issue #413) - Built but never started
 - [ ] Steward: implement offline report queueing (Issue #419) - Reports discarded when controller unreachable
 - [ ] Steward/Controller: implement hash-based DNA sync (Issue #418) - Full DNA sent every time, QUIC handler is a stub
-- [ ] Controller: wire monitoring and health infrastructure into server (Issue #417) - Passed as nil, placeholder responses
+- [x] Controller: wire monitoring and health infrastructure into server (Issue #417) - Passed as nil, placeholder responses
 - [ ] Controller: wire reports engine and rollback system into API (Issue #416) - Built but routes never registered
 - [ ] Controller: implement multi-node orchestration (Issue #415) - No multi-steward coordination
 - [ ] Controller: implement workflow engine (Issue #414) - Documented as core capability, no code exists
 - [ ] Steward: registration approval via workflow engine hook (Issue #422) - Approval logic as workflow policy, default accept-all, depends on #414
 - [ ] Controller: per-tenant config source routing via mount points (Issue #428) - External git repos as read-only config source at any hierarchy level, one-way sync, versioned compiled configs
-- [ ] Controller: fix tenant context key mismatch between auth middleware and config handlers (Issue #430) - Tenant ID never flows from auth to config operations, all ops use "default"
-- [ ] Controller: replace MockConfigStore in config_service_storage_test.go with real storage (Issue #431) - Testing standards violation, uses mock instead of real git backend
+- [x] Controller: fix tenant context key mismatch between auth middleware and config handlers (Issue #430) - Tenant ID never flows from auth to config operations, all ops use "default"
+- [x] Controller: replace MockConfigStore in config_service_storage_test.go with real storage (Issue #431) - Testing standards violation, uses mock instead of real git backend
 
 #### v0.9.3 — Three-Certificate Architecture (~47-65 pts, ~3-5 weeks)
 
@@ -438,7 +438,7 @@ Multi-layered validation approach:
 ## Version Information
 
 - **Document Version**: 3.0
-- **Last Updated**: 2026-03-09
+- **Last Updated**: 2026-03-15
 
 ### Related Documentation
 

--- a/features/controller/api/handlers_monitoring.go
+++ b/features/controller/api/handlers_monitoring.go
@@ -88,27 +88,43 @@ func (s *Server) handleSystemHealth(w http.ResponseWriter, r *http.Request) {
 
 // handleBasicSystemHealth provides fallback health check when platform monitor is not available
 func (s *Server) handleBasicSystemHealth(w http.ResponseWriter, r *http.Request) {
-	// Calculate uptime (placeholder - would need actual start time)
-	uptime := "24h30m15s" // This should be calculated from actual start time
-
-	// Check component health
 	components := map[string]string{
-		"database":       "healthy",
 		"certificate_ca": "healthy",
 		"grpc_server":    "healthy",
 		"rbac_service":   "healthy",
 	}
-
-	// Check dependencies
 	dependencies := map[string]string{
 		"storage":    "available",
 		"networking": "available",
 	}
 
-	// Determine overall health status
+	// Use real health collector metrics if available (Story #417)
+	if s.healthCollector != nil {
+		if metrics, err := s.healthCollector.GetCurrentMetrics(); err == nil {
+			if metrics.MQTT != nil {
+				if metrics.MQTT.ActiveConnections > 0 {
+					components["mqtt_broker"] = "healthy"
+				} else {
+					components["mqtt_broker"] = "no_connections"
+				}
+			}
+			if metrics.Storage != nil && metrics.Storage.Provider != "" {
+				components["storage"] = "healthy"
+				dependencies["storage"] = metrics.Storage.Provider
+			}
+			if metrics.System != nil {
+				if metrics.System.CPUPercent > 90 || metrics.System.MemoryPercent > 90 {
+					components["system_resources"] = "degraded"
+				} else {
+					components["system_resources"] = "healthy"
+				}
+			}
+		}
+	}
+
 	status := "healthy"
-	for _, componentStatus := range components {
-		if componentStatus != "healthy" {
+	for _, cs := range components {
+		if cs == "degraded" || cs == "unhealthy" {
 			status = "degraded"
 			break
 		}
@@ -117,8 +133,8 @@ func (s *Server) handleBasicSystemHealth(w http.ResponseWriter, r *http.Request)
 	health := SystemHealth{
 		Status:       status,
 		Timestamp:    time.Now(),
-		Version:      "0.5.0", // Updated version
-		Uptime:       uptime,
+		Version:      "0.5.0",
+		Uptime:       "unknown",
 		Components:   components,
 		Dependencies: dependencies,
 	}
@@ -179,40 +195,37 @@ func (s *Server) handleSystemMetrics(w http.ResponseWriter, r *http.Request) {
 
 // handleBasicSystemMetrics provides fallback metrics when platform monitor is not available
 func (s *Server) handleBasicSystemMetrics(w http.ResponseWriter, r *http.Request) {
-	// In a real implementation, these would be collected from actual system monitoring
 	metrics := SystemMetrics{
-		Timestamp: time.Now(),
-		CPU: map[string]float64{
-			"usage_percent": 15.5,
-			"load_1m":       1.2,
-			"load_5m":       1.1,
-			"load_15m":      0.9,
-		},
-		Memory: map[string]int64{
-			"total_bytes":     8589934592, // 8GB
-			"used_bytes":      2147483648, // 2GB
-			"available_bytes": 6442450944, // 6GB
-			"cache_bytes":     1073741824, // 1GB
-		},
-		Disk: map[string]int64{
-			"total_bytes":     1099511627776, // 1TB
-			"used_bytes":      214748364800,  // 200GB
-			"available_bytes": 884763262976,  // 800GB
-		},
-		Network: map[string]int64{
-			"bytes_sent":       1048576000, // 1GB
-			"bytes_received":   2097152000, // 2GB
-			"packets_sent":     1000000,
-			"packets_received": 1500000,
-		},
-		ActiveStewards: 42,
-		TotalStewards:  50,
-		ConfigRequests: 10000,
-		Errors: map[string]int64{
-			"authentication": 5,
-			"configuration":  2,
-			"network":        1,
-		},
+		Timestamp:      time.Now(),
+		CPU:            map[string]float64{},
+		Memory:         map[string]int64{},
+		Disk:           map[string]int64{},
+		Network:        map[string]int64{},
+		ActiveStewards: 0,
+		TotalStewards:  0,
+		ConfigRequests: 0,
+		Errors:         map[string]int64{},
+	}
+
+	// Use real health collector metrics if available (Story #417)
+	if s.healthCollector != nil {
+		if cm, err := s.healthCollector.GetCurrentMetrics(); err == nil {
+			if cm.System != nil {
+				metrics.CPU["usage_percent"] = cm.System.CPUPercent
+				metrics.Memory["used_bytes"] = cm.System.MemoryUsedBytes
+				metrics.Memory["heap_bytes"] = cm.System.HeapBytes
+				metrics.Memory["rss_bytes"] = cm.System.RSSBytes
+			}
+			if cm.MQTT != nil {
+				metrics.ActiveStewards = int(cm.MQTT.ActiveConnections)
+				metrics.Network["mqtt_messages_sent"] = cm.MQTT.TotalMessagesSent
+				metrics.Network["mqtt_messages_received"] = cm.MQTT.TotalMessagesReceived
+				metrics.Errors["mqtt_connection_errors"] = cm.MQTT.ConnectionErrors
+			}
+			if cm.Storage != nil {
+				metrics.Errors["storage_query_errors"] = cm.Storage.QueryErrors
+			}
+		}
 	}
 
 	s.writeSuccessResponse(w, metrics)

--- a/features/controller/api/handlers_registration_tokens_test.go
+++ b/features/controller/api/handlers_registration_tokens_test.go
@@ -93,7 +93,8 @@ func setupTestServerWithTokenStore(t *testing.T) (*Server, registration.Store) {
 		nil, // No tracer for basic tests
 		nil, // No HA manager for basic tests
 		tokenStore,
-		"", // No signer cert serial for basic tests
+		"",  // No signer cert serial for basic tests
+		nil, // No health collector for basic tests
 	)
 	require.NoError(t, err)
 

--- a/features/controller/api/server.go
+++ b/features/controller/api/server.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cfgis/cfgms/commercial/ha"
 	"github.com/cfgis/cfgms/features/controller/config"
 	"github.com/cfgis/cfgms/features/controller/ctxkeys"
+	"github.com/cfgis/cfgms/features/controller/health"
 	"github.com/cfgis/cfgms/features/controller/service"
 	"github.com/cfgis/cfgms/features/monitoring"
 	"github.com/cfgis/cfgms/features/rbac"
@@ -51,6 +52,7 @@ type Server struct {
 	rbacManager             *rbac.Manager
 	systemMonitor           *monitoring.SystemMonitor
 	platformMonitor         pkgmonitoring.PlatformMonitor
+	healthCollector         *health.Collector
 	tracer                  *telemetry.Tracer
 	haManager               *ha.Manager
 	apiKeys                 map[string]*APIKey             // In-memory cache for fast lookup
@@ -116,6 +118,7 @@ func New(
 	haManager *ha.Manager,
 	registrationTokenStore registration.Store,
 	signerCertSerial string, // Story #378: Serial of cert used for config signing
+	healthCollector *health.Collector, // Story #417: CFGMS health monitoring
 ) (*Server, error) {
 	if cfg == nil {
 		return nil, fmt.Errorf("config cannot be nil")
@@ -139,6 +142,7 @@ func New(
 		rbacManager:             rbacManager,
 		systemMonitor:           systemMonitor,
 		platformMonitor:         platformMonitor,
+		healthCollector:         healthCollector,
 		tracer:                  tracer,
 		haManager:               haManager,
 		registrationTokenStore:  registrationTokenStore,

--- a/features/controller/api/server_test.go
+++ b/features/controller/api/server_test.go
@@ -78,6 +78,7 @@ func setupTestServer(t *testing.T) *Server {
 		nil, // No HA manager for basic tests
 		nil, // No registration token store for basic tests
 		"",  // No signer cert serial for basic tests
+		nil, // No health collector for basic tests
 	)
 	require.NoError(t, err)
 
@@ -817,7 +818,7 @@ func setupTestServerWithLogger(t *testing.T, logger logging.Logger) *Server {
 	server, err := New(
 		cfg, logger, controllerService, configService,
 		nil, rbacService, nil, tenantManager, rbacManager,
-		nil, nil, nil, nil, nil, "",
+		nil, nil, nil, nil, nil, "", nil,
 	)
 	require.NoError(t, err)
 

--- a/features/controller/controller.go
+++ b/features/controller/controller.go
@@ -101,6 +101,7 @@ func New(cfg *config.Config, logger logging.Logger) (*Controller, error) {
 		srv.GetHAManager(),              // HA manager
 		srv.GetRegistrationTokenStore(), // registrationTokenStore - now wired for MQTT+QUIC mode
 		srv.GetSignerCertSerial(),       // Story #378: signer cert serial for registration
+		nil,                             // healthCollector - wired in server.New() for MQTT+QUIC mode
 	)
 	if err != nil {
 		return nil, err

--- a/features/controller/health/collector.go
+++ b/features/controller/health/collector.go
@@ -210,23 +210,42 @@ func (c *Collector) collectMetrics() error {
 		}
 	}
 
-	// Start all collections
-	wg.Add(4)
-	go collectWithTimeout(c.mqttCollector, "MQTT")
-	go collectWithTimeout(c.storageCollector, "Storage")
-	go collectWithTimeout(c.applicationCollector, "Application")
-	go collectWithTimeout(c.systemCollector, "System")
+	// Start collections for non-nil collectors
+	if c.mqttCollector != nil {
+		wg.Add(1)
+		go collectWithTimeout(c.mqttCollector, "MQTT")
+	}
+	if c.storageCollector != nil {
+		wg.Add(1)
+		go collectWithTimeout(c.storageCollector, "Storage")
+	}
+	if c.applicationCollector != nil {
+		wg.Add(1)
+		go collectWithTimeout(c.applicationCollector, "Application")
+	}
+	if c.systemCollector != nil {
+		wg.Add(1)
+		go collectWithTimeout(c.systemCollector, "System")
+	}
 
 	// Wait for all collections to complete
 	wg.Wait()
 
-	// Aggregate metrics
+	// Aggregate metrics — nil collectors produce nil metric sections
 	metrics := &ControllerMetrics{
-		Timestamp:   timestamp,
-		MQTT:        c.mqttCollector.GetMetrics(),
-		Storage:     c.storageCollector.GetMetrics(),
-		Application: c.applicationCollector.GetMetrics(),
-		System:      c.systemCollector.GetMetrics(),
+		Timestamp: timestamp,
+	}
+	if c.mqttCollector != nil {
+		metrics.MQTT = c.mqttCollector.GetMetrics()
+	}
+	if c.storageCollector != nil {
+		metrics.Storage = c.storageCollector.GetMetrics()
+	}
+	if c.applicationCollector != nil {
+		metrics.Application = c.applicationCollector.GetMetrics()
+	}
+	if c.systemCollector != nil {
+		metrics.System = c.systemCollector.GetMetrics()
 	}
 
 	// Store metrics

--- a/features/controller/server/health_adapters.go
+++ b/features/controller/server/health_adapters.go
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+package server
+
+import (
+	"context"
+
+	mqttInterfaces "github.com/cfgis/cfgms/pkg/mqtt/interfaces"
+)
+
+// MochiBrokerStatsAdapter adapts the MQTT broker's GetStats() to the
+// health.MQTTBrokerStats interface used by the health collector.
+type MochiBrokerStatsAdapter struct {
+	broker mqttInterfaces.Broker
+}
+
+// NewMochiBrokerStatsAdapter creates an adapter wrapping an MQTT broker.
+func NewMochiBrokerStatsAdapter(broker mqttInterfaces.Broker) *MochiBrokerStatsAdapter {
+	return &MochiBrokerStatsAdapter{broker: broker}
+}
+
+// GetActiveConnections returns the number of connected MQTT clients.
+func (a *MochiBrokerStatsAdapter) GetActiveConnections() int64 {
+	stats, err := a.broker.GetStats(context.Background())
+	if err != nil {
+		return 0
+	}
+	return stats.ClientsConnected
+}
+
+// GetMessageQueueDepth returns messages dropped as a proxy for queue pressure.
+func (a *MochiBrokerStatsAdapter) GetMessageQueueDepth() int64 {
+	stats, err := a.broker.GetStats(context.Background())
+	if err != nil {
+		return 0
+	}
+	return stats.MessagesDropped
+}
+
+// GetTotalMessagesSent returns the total messages sent by the broker.
+func (a *MochiBrokerStatsAdapter) GetTotalMessagesSent() int64 {
+	stats, err := a.broker.GetStats(context.Background())
+	if err != nil {
+		return 0
+	}
+	return stats.MessagesSent
+}
+
+// GetTotalMessagesReceived returns the total messages received by the broker.
+func (a *MochiBrokerStatsAdapter) GetTotalMessagesReceived() int64 {
+	stats, err := a.broker.GetStats(context.Background())
+	if err != nil {
+		return 0
+	}
+	return stats.MessagesReceived
+}
+
+// GetConnectionErrors returns messages dropped as a proxy for connection errors.
+func (a *MochiBrokerStatsAdapter) GetConnectionErrors() int64 {
+	stats, err := a.broker.GetStats(context.Background())
+	if err != nil {
+		return 0
+	}
+	return stats.MessagesDropped
+}
+
+// BasicStorageStats implements health.StorageProviderStats with the provider
+// name and zero metrics. Real latency instrumentation is a follow-up.
+type BasicStorageStats struct {
+	providerName string
+}
+
+// NewBasicStorageStats creates a BasicStorageStats for the given provider.
+func NewBasicStorageStats(providerName string) *BasicStorageStats {
+	return &BasicStorageStats{providerName: providerName}
+}
+
+// GetProviderName returns the storage provider name.
+func (s *BasicStorageStats) GetProviderName() string {
+	return s.providerName
+}
+
+// GetPoolUtilization returns 0 (not instrumented yet).
+func (s *BasicStorageStats) GetPoolUtilization() float64 {
+	return 0
+}
+
+// GetQueryMetrics returns zeros (not instrumented yet).
+func (s *BasicStorageStats) GetQueryMetrics() (avgLatencyMs, p95LatencyMs float64, totalQueries, slowQueries, queryErrors int64) {
+	return 0, 0, 0, 0, 0
+}
+
+// NoOpApplicationQueueStats implements health.ApplicationQueueStats returning
+// zeros. The workflow engine doesn't exist yet.
+type NoOpApplicationQueueStats struct{}
+
+// GetWorkflowStats returns zeros.
+func (n *NoOpApplicationQueueStats) GetWorkflowStats() (queueDepth int64, maxWaitTime float64, activeWorkflows int64) {
+	return 0, 0, 0
+}
+
+// GetScriptStats returns zeros.
+func (n *NoOpApplicationQueueStats) GetScriptStats() (queueDepth int64, maxWaitTime float64, activeScripts int64) {
+	return 0, 0, 0
+}
+
+// GetConfigQueueDepth returns 0.
+func (n *NoOpApplicationQueueStats) GetConfigQueueDepth() int64 {
+	return 0
+}

--- a/features/controller/server/health_adapters_test.go
+++ b/features/controller/server/health_adapters_test.go
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+package server
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	mqttInterfaces "github.com/cfgis/cfgms/pkg/mqtt/interfaces"
+)
+
+// stubBroker implements mqttInterfaces.Broker for testing the adapter.
+// Only GetStats is used by the adapter; other methods are no-ops.
+type stubBroker struct {
+	mqttInterfaces.Broker // embed interface to satisfy unused methods
+	stats                 mqttInterfaces.BrokerStats
+	err                   error
+}
+
+func (b *stubBroker) GetStats(_ context.Context) (mqttInterfaces.BrokerStats, error) {
+	return b.stats, b.err
+}
+
+func TestMochiBrokerStatsAdapter_MapsStatsCorrectly(t *testing.T) {
+	broker := &stubBroker{
+		stats: mqttInterfaces.BrokerStats{
+			ClientsConnected: 5,
+			MessagesSent:     100,
+			MessagesReceived: 200,
+			MessagesDropped:  3,
+		},
+	}
+
+	adapter := NewMochiBrokerStatsAdapter(broker)
+
+	assert.Equal(t, int64(5), adapter.GetActiveConnections())
+	assert.Equal(t, int64(3), adapter.GetMessageQueueDepth())
+	assert.Equal(t, int64(100), adapter.GetTotalMessagesSent())
+	assert.Equal(t, int64(200), adapter.GetTotalMessagesReceived())
+	assert.Equal(t, int64(3), adapter.GetConnectionErrors())
+}
+
+func TestMochiBrokerStatsAdapter_ReturnsZerosOnError(t *testing.T) {
+	broker := &stubBroker{
+		err: assert.AnError,
+	}
+
+	adapter := NewMochiBrokerStatsAdapter(broker)
+
+	assert.Equal(t, int64(0), adapter.GetActiveConnections())
+	assert.Equal(t, int64(0), adapter.GetMessageQueueDepth())
+	assert.Equal(t, int64(0), adapter.GetTotalMessagesSent())
+	assert.Equal(t, int64(0), adapter.GetTotalMessagesReceived())
+	assert.Equal(t, int64(0), adapter.GetConnectionErrors())
+}
+
+func TestBasicStorageStats_ReturnsProviderName(t *testing.T) {
+	stats := NewBasicStorageStats("git")
+
+	require.Equal(t, "git", stats.GetProviderName())
+	assert.Equal(t, float64(0), stats.GetPoolUtilization())
+
+	avg, p95, total, slow, errors := stats.GetQueryMetrics()
+	assert.Equal(t, float64(0), avg)
+	assert.Equal(t, float64(0), p95)
+	assert.Equal(t, int64(0), total)
+	assert.Equal(t, int64(0), slow)
+	assert.Equal(t, int64(0), errors)
+}
+
+func TestNoOpApplicationQueueStats_ReturnsZeros(t *testing.T) {
+	stats := &NoOpApplicationQueueStats{}
+
+	depth, wait, active := stats.GetWorkflowStats()
+	assert.Equal(t, int64(0), depth)
+	assert.Equal(t, float64(0), wait)
+	assert.Equal(t, int64(0), active)
+
+	depth, wait, active = stats.GetScriptStats()
+	assert.Equal(t, int64(0), depth)
+	assert.Equal(t, float64(0), wait)
+	assert.Equal(t, int64(0), active)
+
+	assert.Equal(t, int64(0), stats.GetConfigQueueDepth())
+}

--- a/features/controller/server/server.go
+++ b/features/controller/server/server.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cfgis/cfgms/features/controller/api"
 	"github.com/cfgis/cfgms/features/controller/commands"
 	"github.com/cfgis/cfgms/features/controller/config"
+	"github.com/cfgis/cfgms/features/controller/health"
 	"github.com/cfgis/cfgms/features/controller/heartbeat"
 	"github.com/cfgis/cfgms/features/controller/initialization"
 	controllerQuic "github.com/cfgis/cfgms/features/controller/quic"
@@ -71,6 +72,8 @@ type Server struct {
 	dataPlaneProvider       dataplaneInterfaces.DataPlaneProvider
 	configHandler           *controllerQuic.ConfigHandler
 	signerCertSerial        string // Serial number of server cert used for config signing (Story #378)
+	healthCollector         *health.Collector
+	alertManager            *health.DefaultAlertManager
 }
 
 // New creates a new server instance
@@ -427,8 +430,39 @@ func New(cfg *config.Config, logger logging.Logger) (*Server, error) {
 		logger.Debug("Config handler initialized for data plane", "signing_enabled", signer != nil)
 	}
 
-	// Initialize HTTP API server with minimal monitoring for now
-	// TODO: Properly initialize monitoring components when needed
+	// Initialize health collectors (Story #417)
+	var healthCollector *health.Collector
+	var healthAlertManager *health.DefaultAlertManager
+	{
+		// MQTT stats adapter — uses real broker if available, otherwise nil-safe
+		var mqttStats health.MQTTBrokerStats
+		if mqttBroker != nil {
+			mqttStats = NewMochiBrokerStatsAdapter(mqttBroker)
+		} else {
+			mqttStats = &health.MockMQTTBrokerStats{} // zeros
+		}
+		mqttCollector := health.NewDefaultMQTTCollector(mqttStats)
+
+		// Storage stats — provider name only, latency instrumentation is follow-up
+		storageStats := NewBasicStorageStats(cfg.Storage.Provider)
+		storageCollector := health.NewDefaultStorageCollector(storageStats)
+
+		// Application stats — no-op until workflow engine exists
+		appCollector := health.NewDefaultApplicationCollector(&NoOpApplicationQueueStats{})
+
+		// System stats (CPU, memory, goroutines)
+		systemCollector, sysErr := health.NewDefaultSystemCollector()
+		if sysErr != nil {
+			logger.Warn("Failed to initialize system collector, using fallback", "error", sysErr)
+			systemCollector, _ = health.NewDefaultSystemCollector()
+		}
+
+		healthCollector = health.NewCollector(mqttCollector, storageCollector, appCollector, systemCollector)
+		healthAlertManager = health.NewAlertManager(health.DefaultThresholds(), health.SMTPConfig{})
+		logger.Info("Health collectors initialized (Story #417)")
+	}
+
+	// Initialize HTTP API server
 	httpServer, err := api.New(
 		cfg,
 		logger,
@@ -445,6 +479,7 @@ func New(cfg *config.Config, logger logging.Logger) (*Server, error) {
 		haManager,
 		regStore,         // registrationTokenStore
 		signerCertSerial, // Story #378: signer cert serial for registration
+		healthCollector,  // Story #417: CFGMS health monitoring
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize HTTP API server: %w", err)
@@ -474,6 +509,8 @@ func New(cfg *config.Config, logger logging.Logger) (*Server, error) {
 		configHandler:           configHandler,
 		httpServer:              httpServer,
 		signerCertSerial:        signerCertSerial, // Story #378: For registration handler
+		healthCollector:         healthCollector,
+		alertManager:            healthAlertManager,
 	}
 
 	// Wire up QUIC trigger function to API server (if data plane is enabled)
@@ -589,6 +626,22 @@ func (s *Server) Start() error {
 		// go s.acceptDataPlaneSessions(context.Background())
 	}
 
+	// Start health collector and alert manager (Story #417)
+	if s.healthCollector != nil {
+		if err := s.healthCollector.Start(context.Background(), 30*time.Second); err != nil {
+			s.logger.Warn("Failed to start health collector", "error", err)
+		} else {
+			s.logger.Info("Health collector started", "interval", "30s")
+		}
+	}
+	if s.alertManager != nil {
+		if err := s.alertManager.Start(context.Background()); err != nil {
+			s.logger.Warn("Failed to start alert manager", "error", err)
+		} else {
+			s.logger.Info("Alert manager started")
+		}
+	}
+
 	// Start HTTP API server
 	if s.httpServer != nil {
 		logger := s.logger // Capture logger for goroutine
@@ -622,6 +675,18 @@ func (s *Server) Stop() error {
 	defer s.mu.Unlock()
 
 	s.logger.Info("Shutting down controller server")
+
+	// Stop health collector and alert manager (Story #417)
+	if s.healthCollector != nil {
+		if err := s.healthCollector.Stop(); err != nil {
+			s.logger.Warn("Failed to stop health collector", "error", err)
+		}
+	}
+	if s.alertManager != nil {
+		if err := s.alertManager.Stop(); err != nil {
+			s.logger.Warn("Failed to stop alert manager", "error", err)
+		}
+	}
 
 	// Stop HA manager first
 	if s.haManager != nil {

--- a/features/controller/server/server.go
+++ b/features/controller/server/server.go
@@ -434,14 +434,11 @@ func New(cfg *config.Config, logger logging.Logger) (*Server, error) {
 	var healthCollector *health.Collector
 	var healthAlertManager *health.DefaultAlertManager
 	{
-		// MQTT stats adapter — uses real broker if available, otherwise nil-safe
-		var mqttStats health.MQTTBrokerStats
+		// MQTT collector — only created when broker is configured
+		var mqttCollector health.MQTTCollector
 		if mqttBroker != nil {
-			mqttStats = NewMochiBrokerStatsAdapter(mqttBroker)
-		} else {
-			mqttStats = &health.MockMQTTBrokerStats{} // zeros
+			mqttCollector = health.NewDefaultMQTTCollector(NewMochiBrokerStatsAdapter(mqttBroker))
 		}
-		mqttCollector := health.NewDefaultMQTTCollector(mqttStats)
 
 		// Storage stats — provider name only, latency instrumentation is follow-up
 		storageStats := NewBasicStorageStats(cfg.Storage.Provider)
@@ -453,8 +450,7 @@ func New(cfg *config.Config, logger logging.Logger) (*Server, error) {
 		// System stats (CPU, memory, goroutines)
 		systemCollector, sysErr := health.NewDefaultSystemCollector()
 		if sysErr != nil {
-			logger.Warn("Failed to initialize system collector, using fallback", "error", sysErr)
-			systemCollector, _ = health.NewDefaultSystemCollector()
+			logger.Warn("Failed to initialize system collector", "error", sysErr)
 		}
 
 		healthCollector = health.NewCollector(mqttCollector, storageCollector, appCollector, systemCollector)


### PR DESCRIPTION
## Summary

Wires the existing `features/controller/health/` collector framework into the controller server so monitoring API endpoints return real MQTT broker stats, storage provider info, and system metrics (CPU/memory/goroutines) instead of hardcoded placeholder values. This provides operational visibility for lab deployment (#390).

## Problem Context

The controller had ~9,500 lines of health monitoring code across 4 packages (`features/controller/health/`, `features/monitoring/`, `pkg/monitoring/`) but nothing was wired — `systemMonitor` and `platformMonitor` were passed as `nil` in `server.New()`, and API endpoints returned hardcoded fake data (e.g., `ActiveStewards: 42`, `CPU: 15.5%`). PR #477 (from agent) only wired generic OS-level metrics via `PlatformMonitor`, which doesn't answer CFGMS-specific questions like "are stewards connected?" or "is storage working?".

## Changes

- Create `MochiBrokerStatsAdapter` bridging MQTT broker `GetStats()` to `health.MQTTBrokerStats` interface (active connections, messages sent/received, messages dropped)
- Create `BasicStorageStats` (returns provider name, zeros for latency — instrumentation is follow-up) and `NoOpApplicationQueueStats` (workflow engine doesn't exist yet)
- Wire `health.Collector` and `AlertManager` into `Server` struct with 30s collection interval, full start/stop lifecycle management
- Pass `health.Collector` to API server, replace hardcoded placeholder responses in `handleBasicSystemHealth` and `handleBasicSystemMetrics` with real metrics from the collector
- Update all `api.New()` call sites (server.go, controller.go, 3 test files) for new `healthCollector` parameter

## Testing

All validation gates passed:
- Unit tests: all packages passing with race detection
- Linting: 0 issues
- Security scans: all passed (gosec, Trivy, Nancy, staticcheck, gitleaks, truffleHog)
- Architecture compliance: no central provider violations
- Cross-platform builds: 5 platforms verified
- New adapter tests: `TestMochiBrokerStatsAdapter_MapsStatsCorrectly`, `TestMochiBrokerStatsAdapter_ReturnsZerosOnError`, `TestBasicStorageStats_ReturnsProviderName`, `TestNoOpApplicationQueueStats_ReturnsZeros`

## Review Results

- QA Test Runner: PASS (Docker DB tests skipped — requires PostgreSQL, passes in CI)
- QA Code Review: PASS (1 pre-existing `time.Sleep` flagged in unrelated test, not introduced by this story)
- Security Review: PASS (0 blocking issues, 3 warnings all in pre-existing code)

Fixes #417
Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>