### PR TITLE
transport: evolve BroadcastCommand to FanOutCommand (Issue #483)

### DIFF
--- a/pkg/controlplane/interfaces/provider.go
+++ b/pkg/controlplane/interfaces/provider.go
@@ -58,11 +58,16 @@ type ControlPlaneProvider interface {
 	// for command execution - use SubscribeEvents to receive completion events.
 	SendCommand(ctx context.Context, cmd *types.Command) error
 
-	// BroadcastCommand sends a command to all stewards in a tenant
+	// FanOutCommand sends a command to a specific list of stewards.
 	//
-	// The command's TenantID field is used to target stewards. Stewards
-	// filter broadcasts based on their tenant membership.
-	BroadcastCommand(ctx context.Context, cmd *types.Command) error
+	// The caller is responsible for resolving target steward IDs (by tenant,
+	// search results, online status, etc.). The transport layer delivers to
+	// each steward without knowledge of organizational hierarchy.
+	//
+	// Returns FanOutResult with per-steward delivery status. The error return
+	// is for systemic failures (provider not started, etc.), not per-steward
+	// delivery failures which are reported in FanOutResult.Failed.
+	FanOutCommand(ctx context.Context, cmd *types.Command, stewardIDs []string) (*types.FanOutResult, error)
 
 	// SubscribeCommands subscribes to commands (steward-side)
 	//

--- a/pkg/controlplane/interfaces/provider_test.go
+++ b/pkg/controlplane/interfaces/provider_test.go
@@ -54,8 +54,8 @@ func (m *mockProvider) SendCommand(ctx context.Context, cmd *types.Command) erro
 	return nil
 }
 
-func (m *mockProvider) BroadcastCommand(ctx context.Context, cmd *types.Command) error {
-	return nil
+func (m *mockProvider) FanOutCommand(ctx context.Context, cmd *types.Command, stewardIDs []string) (*types.FanOutResult, error) {
+	return &types.FanOutResult{Succeeded: stewardIDs, Failed: make(map[string]error)}, nil
 }
 
 func (m *mockProvider) SubscribeCommands(ctx context.Context, stewardID string, handler CommandHandler) error {

--- a/pkg/controlplane/providers/mqtt/commands.go
+++ b/pkg/controlplane/providers/mqtt/commands.go
@@ -39,37 +39,43 @@ func (p *Provider) SendCommand(ctx context.Context, cmd *types.Command) error {
 	return nil
 }
 
-// BroadcastCommand sends a command to all stewards in a tenant (controller-side).
-func (p *Provider) BroadcastCommand(ctx context.Context, cmd *types.Command) error {
+// FanOutCommand sends a command to a specific list of stewards (controller-side).
+func (p *Provider) FanOutCommand(ctx context.Context, cmd *types.Command, stewardIDs []string) (*types.FanOutResult, error) {
 	if p.mode != ModeServer {
-		return fmt.Errorf("BroadcastCommand only available in server mode")
+		return nil, fmt.Errorf("FanOutCommand only available in server mode")
 	}
 
-	if cmd.TenantID == "" {
-		return fmt.Errorf("TenantID required for broadcast commands")
+	if len(stewardIDs) == 0 {
+		return nil, fmt.Errorf("stewardIDs must not be empty")
 	}
 
-	p.mu.Lock()
-	p.stats.CommandsSent++
-	p.mu.Unlock()
-
-	// Serialize command to JSON
+	// Serialize command once; reuse payload for all stewards
 	payload, err := marshalMessage(cmd)
 	if err != nil {
-		return fmt.Errorf("failed to marshal command: %w", err)
+		return nil, fmt.Errorf("failed to marshal command: %w", err)
 	}
 
-	// Publish to tenant broadcast topic
-	topic := fmt.Sprintf(topicCommandTenantBcast, cmd.TenantID)
-	err = p.broker.Publish(ctx, topic, payload, 1, false)
-	if err != nil {
-		p.mu.Lock()
-		p.stats.DeliveryFailures++
-		p.mu.Unlock()
-		return fmt.Errorf("failed to broadcast command: %w", err)
+	result := &types.FanOutResult{
+		Succeeded: make([]string, 0, len(stewardIDs)),
+		Failed:    make(map[string]error),
 	}
 
-	return nil
+	for _, stewardID := range stewardIDs {
+		topic := fmt.Sprintf(topicCommandUnicast, stewardID)
+		if pubErr := p.broker.Publish(ctx, topic, payload, 1, false); pubErr != nil {
+			p.mu.Lock()
+			p.stats.DeliveryFailures++
+			p.mu.Unlock()
+			result.Failed[stewardID] = pubErr
+		} else {
+			p.mu.Lock()
+			p.stats.CommandsSent++
+			p.mu.Unlock()
+			result.Succeeded = append(result.Succeeded, stewardID)
+		}
+	}
+
+	return result, nil
 }
 
 // SubscribeCommands subscribes to commands for a steward (steward-side).

--- a/pkg/controlplane/providers/mqtt/integration_test.go
+++ b/pkg/controlplane/providers/mqtt/integration_test.go
@@ -154,8 +154,8 @@ func TestIntegration_EventFlow(t *testing.T) {
 	mu.Unlock()
 }
 
-// TestIntegration_BroadcastToMultipleStewards tests broadcast functionality
-func TestIntegration_BroadcastToMultipleStewards(t *testing.T) {
+// TestIntegration_FanOutToMultipleStewards tests fan-out delivery to explicit steward list
+func TestIntegration_FanOutToMultipleStewards(t *testing.T) {
 	broker := newMockBroker()
 
 	// Controller
@@ -165,28 +165,31 @@ func TestIntegration_BroadcastToMultipleStewards(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	// Broadcast command to tenant
+	// Fan out command to specific stewards
 	cmd := &types.Command{
-		ID:        "broadcast-cmd",
+		ID:        "fanout-cmd",
 		Type:      types.CommandExecuteTask,
-		TenantID:  "tenant-1",
 		Timestamp: time.Now(),
 	}
 
-	err = controller.BroadcastCommand(context.Background(), cmd)
+	stewardIDs := []string{"steward-1", "steward-2"}
+	result, err := controller.FanOutCommand(context.Background(), cmd, stewardIDs)
 	require.NoError(t, err)
+	assert.Len(t, result.Succeeded, 2)
+	assert.Empty(t, result.Failed)
 
-	// Verify broadcast was published to correct topic
-	lastMsg := broker.getLastPublished()
-	require.NotNil(t, lastMsg)
-	assert.Equal(t, "cfgms/commands/tenant-1/broadcast", lastMsg.topic)
+	// Verify messages published to correct unicast topics
+	broker.mu.RLock()
+	require.Len(t, broker.published, 2)
+	assert.Equal(t, "cfgms/commands/steward-1", broker.published[0].topic)
+	assert.Equal(t, "cfgms/commands/steward-2", broker.published[1].topic)
+	broker.mu.RUnlock()
 
-	// Verify command can be deserialized
+	// Verify command can be deserialized from either message
 	var decoded types.Command
-	err = unmarshalMessage(lastMsg.payload, &decoded)
+	err = unmarshalMessage(broker.published[0].payload, &decoded)
 	require.NoError(t, err)
-	assert.Equal(t, "broadcast-cmd", decoded.ID)
-	assert.Equal(t, "tenant-1", decoded.TenantID)
+	assert.Equal(t, "fanout-cmd", decoded.ID)
 }
 
 // TestIntegration_ResponseWaitFlow tests request-response pattern

--- a/pkg/controlplane/providers/mqtt/provider_test.go
+++ b/pkg/controlplane/providers/mqtt/provider_test.go
@@ -4,6 +4,7 @@ package mqtt
 
 import (
 	"context"
+	"fmt"
 	"sync"
 	"testing"
 	"time"
@@ -19,6 +20,7 @@ type mockBroker struct {
 	mu          sync.RWMutex
 	published   []mockMessage
 	subscribers map[string]mqttInterfaces.MessageHandler
+	failTopics  map[string]error // topics that should return an error on Publish
 }
 
 type mockMessage struct {
@@ -32,6 +34,7 @@ func newMockBroker() *mockBroker {
 	return &mockBroker{
 		published:   []mockMessage{},
 		subscribers: make(map[string]mqttInterfaces.MessageHandler),
+		failTopics:  make(map[string]error),
 	}
 }
 
@@ -52,6 +55,13 @@ func (m *mockBroker) Stop(ctx context.Context) error {
 
 func (m *mockBroker) Publish(ctx context.Context, topic string, payload []byte, qos byte, retain bool) error {
 	m.mu.Lock()
+
+	// Check if this topic should fail
+	if err, shouldFail := m.failTopics[topic]; shouldFail {
+		m.mu.Unlock()
+		return err
+	}
+
 	m.published = append(m.published, mockMessage{
 		topic:   topic,
 		payload: payload,
@@ -320,7 +330,7 @@ func TestProvider_SendCommand(t *testing.T) {
 	assert.Equal(t, int64(1), stats.CommandsSent)
 }
 
-func TestProvider_BroadcastCommand(t *testing.T) {
+func TestProvider_FanOutCommand(t *testing.T) {
 	provider := New(ModeServer)
 	broker := newMockBroker()
 
@@ -332,24 +342,36 @@ func TestProvider_BroadcastCommand(t *testing.T) {
 	err := provider.Initialize(ctx, config)
 	require.NoError(t, err)
 
-	// Broadcast command
 	cmd := &types.Command{
-		ID:        "cmd-456",
+		ID:        "cmd-fanout",
 		Type:      types.CommandExecuteTask,
-		TenantID:  "tenant-1",
 		Timestamp: time.Now(),
 	}
 
-	err = provider.BroadcastCommand(ctx, cmd)
+	stewardIDs := []string{"steward-1", "steward-2", "steward-3"}
+	result, err := provider.FanOutCommand(ctx, cmd, stewardIDs)
 	require.NoError(t, err)
+	require.NotNil(t, result)
 
-	// Verify broadcast was published
-	msg := broker.getLastPublished()
-	require.NotNil(t, msg)
-	assert.Equal(t, "cfgms/commands/tenant-1/broadcast", msg.topic)
+	// All 3 should succeed
+	assert.Len(t, result.Succeeded, 3)
+	assert.Empty(t, result.Failed)
+
+	// Verify 3 messages published to correct unicast topics
+	broker.mu.RLock()
+	assert.Len(t, broker.published, 3)
+	topics := make([]string, len(broker.published))
+	for i, msg := range broker.published {
+		topics[i] = msg.topic
+	}
+	broker.mu.RUnlock()
+
+	assert.Contains(t, topics, "cfgms/commands/steward-1")
+	assert.Contains(t, topics, "cfgms/commands/steward-2")
+	assert.Contains(t, topics, "cfgms/commands/steward-3")
 }
 
-func TestProvider_BroadcastCommand_RequiresTenantID(t *testing.T) {
+func TestProvider_FanOutCommand_PartialFailure(t *testing.T) {
 	provider := New(ModeServer)
 	broker := newMockBroker()
 
@@ -361,15 +383,91 @@ func TestProvider_BroadcastCommand_RequiresTenantID(t *testing.T) {
 	err := provider.Initialize(ctx, config)
 	require.NoError(t, err)
 
-	// Broadcast without tenant ID should fail
+	// Make steward-2's topic fail
+	broker.failTopics["cfgms/commands/steward-2"] = fmt.Errorf("connection refused")
+
 	cmd := &types.Command{
-		ID:   "cmd-456",
+		ID:        "cmd-partial",
+		Type:      types.CommandExecuteTask,
+		Timestamp: time.Now(),
+	}
+
+	stewardIDs := []string{"steward-1", "steward-2", "steward-3"}
+	result, err := provider.FanOutCommand(ctx, cmd, stewardIDs)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	assert.Len(t, result.Succeeded, 2)
+	assert.Len(t, result.Failed, 1)
+	assert.Contains(t, result.Failed, "steward-2")
+	assert.Contains(t, result.Failed["steward-2"].Error(), "connection refused")
+}
+
+func TestProvider_FanOutCommand_EmptyList(t *testing.T) {
+	provider := New(ModeServer)
+	broker := newMockBroker()
+
+	config := map[string]interface{}{
+		"broker": broker,
+	}
+
+	ctx := context.Background()
+	err := provider.Initialize(ctx, config)
+	require.NoError(t, err)
+
+	cmd := &types.Command{
+		ID:   "cmd-empty",
 		Type: types.CommandExecuteTask,
 	}
 
-	err = provider.BroadcastCommand(ctx, cmd)
+	result, err := provider.FanOutCommand(ctx, cmd, []string{})
 	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "TenantID")
+	assert.Nil(t, result)
+	assert.Contains(t, err.Error(), "stewardIDs must not be empty")
+}
+
+func TestProvider_FanOutCommand_ServerModeOnly(t *testing.T) {
+	provider := New(ModeClient)
+
+	ctx := context.Background()
+	cmd := &types.Command{ID: "cmd-1", Type: types.CommandSyncConfig}
+
+	result, err := provider.FanOutCommand(ctx, cmd, []string{"steward-1"})
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	assert.Contains(t, err.Error(), "server mode")
+}
+
+func TestProvider_FanOutCommand_Stats(t *testing.T) {
+	provider := New(ModeServer)
+	broker := newMockBroker()
+
+	config := map[string]interface{}{
+		"broker": broker,
+	}
+
+	ctx := context.Background()
+	err := provider.Initialize(ctx, config)
+	require.NoError(t, err)
+
+	// Make one topic fail
+	broker.failTopics["cfgms/commands/steward-3"] = fmt.Errorf("timeout")
+
+	cmd := &types.Command{
+		ID:        "cmd-stats",
+		Type:      types.CommandExecuteTask,
+		Timestamp: time.Now(),
+	}
+
+	_, err = provider.FanOutCommand(ctx, cmd, []string{"steward-1", "steward-2", "steward-3"})
+	require.NoError(t, err)
+
+	stats, err := provider.GetStats(ctx)
+	require.NoError(t, err)
+
+	// 2 succeeded, 1 failed
+	assert.Equal(t, int64(2), stats.CommandsSent)
+	assert.Equal(t, int64(1), stats.DeliveryFailures)
 }
 
 func TestProvider_SendCommand_ClientMode_Error(t *testing.T) {

--- a/pkg/controlplane/types/messages.go
+++ b/pkg/controlplane/types/messages.go
@@ -235,6 +235,15 @@ type ConfigStatusReport struct {
 	ExecutionTimeMs int64 `json:"execution_time_ms,omitempty"`
 }
 
+// FanOutResult reports per-steward delivery status from a FanOutCommand.
+type FanOutResult struct {
+	// Succeeded contains steward IDs that received the command
+	Succeeded []string
+
+	// Failed maps steward IDs to their delivery errors
+	Failed map[string]error
+}
+
 // EventFilter defines criteria for filtering events during subscription.
 type EventFilter struct {
 	// StewardIDs filters events to specific stewards (empty = all)


### PR DESCRIPTION
## Summary

Replaces `BroadcastCommand` with `FanOutCommand` across the ControlPlaneProvider
interface, MQTT provider, and all tests. This decouples the interface from MQTT
transport semantics (tenant-based topic wildcards) by requiring explicit steward
ID lists — the caller resolves targets, the transport just delivers. Phase 1 of
the gRPC over QUIC epic (#482).

## Problem Context

The `ControlPlaneProvider.BroadcastCommand` method routed by `cmd.TenantID` to
an MQTT topic wildcard (`cfgms/commands/{tenant_id}/broadcast`). This is an
MQTT-ism that would not translate to gRPC, where fan-out must use explicit
steward lists. Since `BroadcastCommand` is never called from feature code (only
defined, implemented, and tested), this is a non-breaking interface change.

## Changes

- Replace `BroadcastCommand(ctx, cmd)` with `FanOutCommand(ctx, cmd, stewardIDs)` in interface
- Add `FanOutResult` type with per-steward `Succeeded`/`Failed` tracking
- MQTT provider serializes payload once, publishes to each steward's unicast topic
- Collect partial failures in `FanOutResult.Failed` (systemic errors returned separately)
- Update mockProvider and mockBroker (added `failTopics` for failure injection)

## Measured Impact

All 52 controlplane tests pass. Verification:
- `grep -r "BroadcastCommand" --include="*.go" pkg/` returns 0 matches
- No files outside `pkg/controlplane/` modified

## Testing

6 test cases covering the new method:
- `TestProvider_FanOutCommand` — 3 stewards, all succeed, correct unicast topics
- `TestProvider_FanOutCommand_PartialFailure` — 1 of 3 fails, correct Succeeded/Failed split
- `TestProvider_FanOutCommand_EmptyList` — empty stewardIDs returns error
- `TestProvider_FanOutCommand_ServerModeOnly` — client mode returns error
- `TestProvider_FanOutCommand_Stats` — CommandsSent and DeliveryFailures counters verified
- `TestIntegration_FanOutToMultipleStewards` — end-to-end publish and deserialize

## Review Results

- QA Test Runner: PASS — all quality validation gates green (unit, lint, production-critical, cross-platform, Docker)
- QA Code Reviewer: PASS — 0 blocking issues, 3 warnings (pre-existing time.Sleep sync pattern, pre-existing error swallow in handler dispatch)
- Security Engineer: PASS — 0 blocking issues, 3 warnings (stewardID topic validation recommended, lock churn in hot loop, DeviceName echo in compliance handler)

Fixes #483
Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>