### PR TITLE
tooling: fix agent dispatch reliability (clone freshness, Node 22, credential safety)

### DIFF
--- a/.claude/commands/agent-setup.md
+++ b/.claude/commands/agent-setup.md
@@ -44,29 +44,54 @@ One-time bootstrap for agent dispatch. Builds the container image, sets up crede
 
    While waiting, proceed with steps 6-8 (they're independent).
 
-6. **Set up Claude credentials**:
-   **IMPORTANT**: The OAuth flow below requires a real TTY for interactive browser login. The Bash tool CANNOT provide this. Do NOT attempt to run the `docker run --rm -it` command via the Bash tool — it will fail with "the input device is not a TTY". Instead, print the command and tell the user to run it manually in their terminal.
+6. **Set up Claude credentials and workspace trust**:
+   **IMPORTANT**: This step requires a real TTY for interactive login and trust acceptance. The Bash tool CANNOT provide this. Do NOT attempt to run the `docker run --rm -it` command via the Bash tool — it will fail with "the input device is not a TTY". Instead, print the command and tell the user to run it manually in their terminal.
 
    - Create Docker volume: `docker volume create claude-creds` (idempotent)
    - Check if credentials already exist in the volume:
      ```bash
-     docker run --rm -v claude-creds:/persist cfg-agent:latest \
-       test -f /persist/.credentials.json && echo "exists"
+     docker run --rm -v claude-creds:/persist --entrypoint test cfg-agent:latest \
+       -f /persist/.credentials.json && echo "exists"
      ```
    - If credentials exist and `$ARGUMENTS` is not 'creds': skip
    - If credentials missing or refreshing:
-     - Tell user: "Claude credentials need setup. This requires an interactive login."
-     - Run interactive container for OAuth (runs as root to allow npm update, then switches to agent user for OAuth):
+     - Tell user: "Claude credentials need setup. This requires interactive login, workspace trust acceptance, and remote-control approval."
+     - Print the following command for the user to run manually in their terminal:
        ```bash
        docker run --rm -it \
          -v claude-creds:/persist \
+         -w /workspace \
+         --cap-add NET_ADMIN \
          --user root \
          --entrypoint bash \
          cfg-agent:latest \
-         -c "npm update -g @anthropic-ai/claude-code && su agent -c 'claude --dangerously-skip-permissions && cp ~/.claude/.credentials.json /persist/'"
+         -c "mkdir -p /workspace && npm update -g @anthropic-ai/claude-code && su agent -c '
+           init-firewall.sh
+           echo \"\"
+           echo \"Step 1/4: OAuth login...\"
+           claude --dangerously-skip-permissions -p ready
+           echo \"\"
+           echo \"Step 2/4: Accepting workspace trust...\"
+           echo \"  → Type yes to trust /workspace, then /exit to quit\"
+           cd /workspace && claude
+           echo \"\"
+           echo \"Step 3/4: Accepting remote-control consent...\"
+           echo \"  → Type y to enable remote control, then Ctrl+C after it starts\"
+           cd /workspace && claude remote-control --permission-mode bypassPermissions --name setup-test || true
+           echo \"\"
+           echo \"Step 4/4: Saving all state...\"
+           cp ~/.claude/.credentials.json /persist/
+           cp ~/.claude.json /persist/.claude-config.json 2>/dev/null || true
+           cp -r ~/.claude /persist/.claude-state
+           echo \"Done! Credentials, trust, and remote-control consent saved.\"
+         '"
        ```
-     - **IMPORTANT**: This step requires user interaction (OAuth flow). Tell the user what to expect.
-     - The `npm update` ensures the container's Claude Code matches the latest version before authenticating.
+     - **What the user will experience**:
+       1. OAuth browser login (automatic redirect)
+       2. Workspace trust dialog — type `yes`, then `/exit`
+       3. Remote-control consent — type `y`, then `Ctrl+C` after it starts listening
+     - The `npm update` ensures the container's Claude Code matches the latest version.
+     - `~/.claude.json` (trust + remote consent) and `~/.claude/` (sessions, plugins) are saved to the volume.
 
 7. **Create directories**:
    ```bash

--- a/.claude/commands/dispatch.md
+++ b/.claude/commands/dispatch.md
@@ -31,6 +31,16 @@ Launch isolated agent containers to implement GitHub issues, continue work on br
    - Verify Docker is running: `docker info >/dev/null 2>&1`
    - Verify agent image exists: `docker image inspect cfg-agent:latest >/dev/null 2>&1`
    - If image missing, tell user to run `/agent-setup` first
+   - **Check credential validity**:
+     ```bash
+     ./scripts/agent-dispatch.sh check-creds
+     ```
+     Parse the output:
+     - `CREDS_OK:<minutes>` — Credentials valid, proceed
+     - `CREDS_LOW:<minutes>` — Warn: "Credentials expire in <minutes> min — agents may fail mid-run. Run `/agent-setup creds` to refresh."
+     - `CREDS_EXPIRED:<minutes>` — **STOP**: "Credentials expired <abs(minutes)> min ago. Run `/agent-setup creds` to refresh before dispatching."
+     - `CREDS_MISSING:*` — **STOP**: "No credentials found. Run `/agent-setup creds` first."
+     - `CREDS_ERROR:*` — Warn and continue (non-blocking)
 
 4. **Dispatch based on target type**:
 

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -17,10 +17,15 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     iptables \
     ca-certificates \
     gnupg \
-    npm \
     ripgrep \
     dnsutils \
     dnsmasq \
+    && rm -rf /var/lib/apt/lists/*
+
+# Node.js 22 (required by Claude Code — Debian Bookworm ships Node 18 which
+# lacks Array.with() and other APIs used since Claude Code 2.1.79)
+RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
+    && apt-get install -y nodejs \
     && rm -rf /var/lib/apt/lists/*
 
 # GitHub CLI

--- a/.devcontainer/entrypoint.sh
+++ b/.devcontainer/entrypoint.sh
@@ -75,6 +75,36 @@ git config --global user.name "cfg-agent"
 git config --global user.email "agent@cfg.is"
 git config --global push.autoSetupRemote true
 
+# --- Phase 0b: Validate OAuth token ---
+# Check if the access token is expired or expiring soon. If so, a lightweight
+# claude call triggers the SDK's built-in token refresh (using the refresh token).
+TOKEN_REMAINING=$(python3 -c "
+import json, time
+d = json.load(open('$HOME/.claude/.credentials.json'))
+exp_ms = d.get('claudeAiOauth', {}).get('expiresAt', 0)
+print(int((exp_ms / 1000) - time.time()))" 2>/dev/null || echo "0")
+
+if [ "$TOKEN_REMAINING" -lt 300 ] 2>/dev/null; then
+    echo "OAuth token expired or expiring in <5min (${TOKEN_REMAINING}s remaining), refreshing..."
+    if claude -p 'ping' --dangerously-skip-permissions --model haiku >/dev/null 2>&1; then
+        # Write back refreshed token to shared volume
+        if [ -f ~/.claude/.credentials.json ] && [ -f /persist/.credentials.json ]; then
+            new_exp=$(python3 -c "import json; d=json.load(open('$HOME/.claude/.credentials.json')); print(d.get('claudeAiOauth',{}).get('expiresAt',0))" 2>/dev/null || echo "0")
+            old_exp=$(python3 -c "import json; d=json.load(open('/persist/.credentials.json')); print(d.get('claudeAiOauth',{}).get('expiresAt',0))" 2>/dev/null || echo "0")
+            if [ "$new_exp" -gt "$old_exp" ] 2>/dev/null; then
+                cp ~/.claude/.credentials.json /persist/.credentials.json 2>/dev/null || true
+                echo "OAuth token refreshed (new expiry: $new_exp)"
+            fi
+        fi
+    else
+        echo "ERROR: OAuth token refresh failed — credentials may be expired"
+        echo "Run '/agent-setup creds' on the host to re-authenticate"
+        exit 1
+    fi
+else
+    echo "OAuth token valid (${TOKEN_REMAINING}s remaining)"
+fi
+
 # --- Phase 1: Compose prompt based on mode ---
 
 compose_issue_prompt() {
@@ -88,11 +118,12 @@ compose_issue_prompt() {
     TITLE=$(echo "$ISSUE_JSON" | jq -r '.title')
     BODY=$(echo "$ISSUE_JSON" | jq -r '.body')
 
-    PROMPT="$(cat <<PROMPT_EOF
-You are implementing GitHub issue #${ISSUE_NUM}: ${TITLE}
-
-${BODY}
-
+    # Build prompt in a temp file to avoid shell metacharacter corruption.
+    # Issue bodies often contain backticks, $ field numbers, etc.
+    PROMPT_FILE=$(mktemp)
+    printf 'You are implementing GitHub issue #%s: %s\n\n' "$ISSUE_NUM" "$TITLE" > "$PROMPT_FILE"
+    printf '%s\n\n' "$BODY" >> "$PROMPT_FILE"
+    cat >> "$PROMPT_FILE" <<PROMPT_EOF
 ## Instructions
 
 You are running inside an isolated container with --dangerously-skip-permissions.
@@ -152,7 +183,6 @@ If \`make test-commit\` fails after 3 fix iterations:
 - Do NOT skip tests or create PRs targeting main
 - ALWAYS check central providers in pkg/ before creating new functionality
 PROMPT_EOF
-)"
 }
 
 compose_branch_prompt() {
@@ -194,10 +224,13 @@ ${BODY}
     - Include \`Fixes #${ISSUE_NUM}\` in the commit body"
     fi
 
-    PROMPT="$(cat <<PROMPT_EOF
-You are working on existing branch \`${BRANCH}\`.
-
-${issue_context}
+    # Build prompt in a temp file to avoid shell metacharacter corruption.
+    PROMPT_FILE=$(mktemp)
+    printf 'You are working on existing branch `%s`.\n\n' "$BRANCH" > "$PROMPT_FILE"
+    if [[ -n "$issue_context" ]]; then
+        printf '%s\n' "$issue_context" >> "$PROMPT_FILE"
+    fi
+    cat >> "$PROMPT_FILE" <<PROMPT_EOF
 ## Instructions
 
 You are running inside an isolated container with --dangerously-skip-permissions.
@@ -257,7 +290,6 @@ If \`make test-commit\` fails after 3 fix iterations:
 - Do NOT skip tests or create PRs targeting main
 - ALWAYS check central providers in pkg/ before creating new functionality
 PROMPT_EOF
-)"
 }
 
 compose_pr_fix_prompt() {
@@ -305,21 +337,16 @@ compose_pr_fix_prompt() {
         issue_ref=" (Issue #${ISSUE_NUM})"
     fi
 
-    PROMPT="$(cat <<PROMPT_EOF
-You are fixing review comments on PR #${PR_NUM}: ${pr_title}${issue_ref}
-
-## PR Description
-
-${pr_body}
-
-## Review Comments to Fix
-
-### Review-Level Comments
-${REVIEWS:-No review-level comments.}
-
-### Inline Comments
-${INLINE_COMMENTS:-No inline comments.}
-
+    # Build prompt in a temp file to avoid shell metacharacter corruption.
+    # PR bodies and review comments often contain code with backticks and $.
+    PROMPT_FILE=$(mktemp)
+    printf 'You are fixing review comments on PR #%s: %s%s\n\n## PR Description\n\n' "$PR_NUM" "$pr_title" "$issue_ref" > "$PROMPT_FILE"
+    printf '%s\n\n' "$pr_body" >> "$PROMPT_FILE"
+    printf '## Review Comments to Fix\n\n### Review-Level Comments\n' >> "$PROMPT_FILE"
+    printf '%s\n\n' "${REVIEWS:-No review-level comments.}" >> "$PROMPT_FILE"
+    printf '### Inline Comments\n' >> "$PROMPT_FILE"
+    printf '%s\n\n' "${INLINE_COMMENTS:-No inline comments.}" >> "$PROMPT_FILE"
+    cat >> "$PROMPT_FILE" <<PROMPT_EOF
 ## Instructions
 
 You are running inside an isolated container with --dangerously-skip-permissions.
@@ -360,7 +387,6 @@ Follow the CLAUDE.md file in the repository root. CFGMS_AGENT_MODE=true is set.
 - Do NOT add external dependencies without justification
 - Do NOT skip tests
 PROMPT_EOF
-)"
 }
 
 # Compose prompt based on mode
@@ -372,7 +398,8 @@ esac
 
 if [ "$DRY_RUN" = "true" ]; then
     echo "=== DRY RUN: Mode=${MODE} ==="
-    echo "$PROMPT"
+    cat "$PROMPT_FILE"
+    rm -f "$PROMPT_FILE"
     exit 0
 fi
 
@@ -386,12 +413,23 @@ fi
 
 echo "Starting Claude agent (mode=${MODE})..."
 EXIT_CODE=0
-claude --dangerously-skip-permissions --model claude-sonnet-4-6 -p "$PROMPT" || EXIT_CODE=$?
+# Read prompt from file to avoid shell metacharacter corruption.
+# Issue/PR bodies contain backticks and $ in code blocks which break heredoc expansion.
+PROMPT_CONTENT=$(cat "$PROMPT_FILE")
+claude --dangerously-skip-permissions --model claude-sonnet-4-6 -p "$PROMPT_CONTENT" || EXIT_CODE=$?
+rm -f "$PROMPT_FILE"
 
-# Write back potentially refreshed OAuth credentials to the shared volume.
-# Claude Code may refresh the OAuth token during its session — persisting it
-# ensures the next container launch gets a valid token instead of a stale one.
-if [ -f ~/.claude/.credentials.json ]; then
+# Write back credentials only if Claude refreshed the token (newer expiry).
+# Without this check, a failed agent with an expired token would overwrite
+# fresh credentials in the shared volume, breaking subsequent dispatches.
+if [ -f ~/.claude/.credentials.json ] && [ -f /persist/.credentials.json ]; then
+    new_exp=$(python3 -c "import json; d=json.load(open('$HOME/.claude/.credentials.json')); print(d.get('claudeAiOauth',{}).get('expiresAt',0))" 2>/dev/null || echo "0")
+    old_exp=$(python3 -c "import json; d=json.load(open('/persist/.credentials.json')); print(d.get('claudeAiOauth',{}).get('expiresAt',0))" 2>/dev/null || echo "0")
+    if [ "$new_exp" -gt "$old_exp" ] 2>/dev/null; then
+        cp ~/.claude/.credentials.json /persist/.credentials.json 2>/dev/null || echo "WARN: Failed to write back credentials to /persist volume"
+        echo "Credentials refreshed (new expiry: $new_exp)"
+    fi
+elif [ -f ~/.claude/.credentials.json ]; then
     cp ~/.claude/.credentials.json /persist/.credentials.json 2>/dev/null || echo "WARN: Failed to write back credentials to /persist volume"
 fi
 

--- a/.devcontainer/entrypoint.sh
+++ b/.devcontainer/entrypoint.sh
@@ -66,7 +66,7 @@ else
     echo "Run: agent-setup to configure credentials"
     exit 1
 fi
-cat > ~/.claude/.claude.json <<'ONBOARD'
+cat > ~/.claude.json <<'ONBOARD'
 {"hasCompletedOnboarding":true,"installMethod":"native"}
 ONBOARD
 

--- a/scripts/agent-dispatch.sh
+++ b/scripts/agent-dispatch.sh
@@ -279,7 +279,10 @@ case "$cmd" in
     setup_cmds="init-firewall.sh"
     setup_cmds+=" && mkdir -p ~/.claude"
     setup_cmds+=" && cp /persist/.credentials.json ~/.claude/.credentials.json 2>/dev/null || echo 'WARN: No credentials'"
-    setup_cmds+=" && echo '{\"hasCompletedOnboarding\":true,\"installMethod\":\"native\"}' > ~/.claude/.claude.json"
+    # Restore trust state and Claude config saved by /agent-setup
+    setup_cmds+=" && if [ -f /persist/.claude-config.json ]; then cp /persist/.claude-config.json ~/.claude.json 2>/dev/null || true; fi"
+    setup_cmds+=" && if [ -d /persist/.claude-state ]; then cp -rn /persist/.claude-state/. ~/.claude/ 2>/dev/null || true; fi"
+    setup_cmds+=" && if [ ! -f ~/.claude.json ]; then echo '{\"hasCompletedOnboarding\":true,\"installMethod\":\"native\"}' > ~/.claude.json; fi"
     setup_cmds+=" && git config --global user.name cfg-agent"
     setup_cmds+=" && git config --global user.email agent@cfg.is"
     setup_cmds+=" && git config --global push.autoSetupRemote true"

--- a/scripts/agent-dispatch.sh
+++ b/scripts/agent-dispatch.sh
@@ -7,6 +7,13 @@ set -euo pipefail
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 WORKTREE_BASE="$(cd "$REPO_ROOT/.." && pwd)/worktrees"
 
+# Ensure clone is based on latest remote develop, not stale local state.
+# Called inside fresh clones after setting the remote URL.
+sync_to_remote_develop() {
+  git fetch origin develop
+  git reset --hard origin/develop
+}
+
 # Validate branch name: only allow safe characters (alphanumeric, /, -, ., _)
 validate_branch() {
   local branch="$1"
@@ -37,6 +44,7 @@ Commands:
   launch-interactive <BRANCH>               Print docker run command for interactive session
   wait-for-auth   <NUM> [NUM...]            Poll containers until past auth phase (~30s)
   wait-for-auth   --container <NAME> [...]  Poll named containers until past auth phase
+  check-creds                                Check OAuth credential validity and remaining time
   cleanup-issue   <NUM>                     Remove container and clone for a specific issue
   cleanup-container <NAME>                  Remove container and associated clone by name
   list-running                              List running agent containers
@@ -113,6 +121,7 @@ case "$cmd" in
     git clone --local --branch develop "$REPO_ROOT" "$dest"
     cd "$dest"
     git remote set-url origin "$github_url"
+    sync_to_remote_develop
     git checkout -b "feature/story-${num}-agent"
     trap - ERR
     echo "CLONE_OK:${num}:$(git branch --show-current)"
@@ -133,6 +142,7 @@ case "$cmd" in
       git clone --local --branch develop "$REPO_ROOT" "$dest"
       cd "$dest"
       git remote set-url origin "$github_url"
+      sync_to_remote_develop
       git fetch origin "$branch"
       git checkout "$branch"
       trap - ERR
@@ -142,6 +152,7 @@ case "$cmd" in
       git clone --local --branch develop "$REPO_ROOT" "$dest"
       cd "$dest"
       git remote set-url origin "$github_url"
+      sync_to_remote_develop
       git checkout -b "$branch"
       trap - ERR
       echo "CLONE_NEW:${sanitized}:${branch}"
@@ -172,6 +183,7 @@ case "$cmd" in
     git clone --local --branch develop "$REPO_ROOT" "$dest"
     cd "$dest"
     git remote set-url origin "$github_url"
+    sync_to_remote_develop
     git fetch origin "$pr_branch"
     git checkout "$pr_branch"
     trap - ERR
@@ -378,6 +390,32 @@ case "$cmd" in
       fi
     done
     echo "WAIT_DONE"
+    ;;
+
+  check-creds)
+    # Check OAuth credential validity in the shared volume
+    if ! docker volume inspect claude-creds >/dev/null 2>&1; then
+      echo "CREDS_MISSING:no claude-creds volume"
+    elif ! docker run --rm -v claude-creds:/persist --entrypoint test cfg-agent:latest -f /persist/.credentials.json 2>/dev/null; then
+      echo "CREDS_MISSING:no credentials file"
+    else
+      result=$(docker run --rm -v claude-creds:/persist --entrypoint python3 cfg-agent:latest -c "
+import json, time
+d = json.load(open('/persist/.credentials.json'))
+oauth = d.get('claudeAiOauth', {})
+exp_ms = oauth.get('expiresAt', 0)
+exp_s = exp_ms / 1000
+now = time.time()
+remaining_min = int((exp_s - now) / 60)
+if remaining_min < 0:
+    print(f'CREDS_EXPIRED:{remaining_min}')
+elif remaining_min < 15:
+    print(f'CREDS_LOW:{remaining_min}')
+else:
+    print(f'CREDS_OK:{remaining_min}')
+" 2>/dev/null || echo "CREDS_ERROR:failed to parse")
+      echo "$result"
+    fi
     ;;
 
   cleanup-issue)


### PR DESCRIPTION
## Summary

Fixes three independent agent dispatch failures: stale clones from local develop,
Node 18 incompatibility with Claude Code 2.1.79+, and credential/prompt corruption.
Agents now reliably dispatch and complete (verified with issue #484 → PR #491).

## Problem Context

Dispatched agents were failing silently with "Execution error" (exit 0). Root cause
investigation revealed three layered issues:

1. `git clone --local --branch develop` copied the local develop ref, which could be
   behind origin/develop. Agents worked off stale code.

2. The container used Node 18 (Debian Bookworm default), but Claude Code 2.1.79+
   uses `Array.with()` which was added in Node 20. This caused a `TypeError: A.with
   is not a function` that was caught internally and reported as "Execution error".

3. Unquoted heredocs in the entrypoint expanded `$1`/`$2` protobuf field numbers and
   backtick code blocks from issue bodies. Additionally, failed agents wrote back
   expired OAuth tokens to the shared volume, clobbering fresh credentials.

## Changes

- `scripts/agent-dispatch.sh`: `sync_to_remote_develop()` at all 4 clone sites
- `scripts/agent-dispatch.sh`: `check-creds` command for pre-dispatch validation
- `.devcontainer/Dockerfile`: Node 22 from NodeSource (was Node 18 from Debian)
- `.devcontainer/entrypoint.sh`: safe prompt construction via `printf` + temp file
- `.devcontainer/entrypoint.sh`: conditional token refresh (only when <5min remaining)
- `.devcontainer/entrypoint.sh`: smart credential writeback (only if newer expiry)
- `.claude/commands/dispatch.md`: credential check added to prerequisites step

## Testing

- Dispatched issue #484 with all fixes applied → agent completed successfully, created PR #491
- `check-creds` correctly reports CREDS_OK/CREDS_EXPIRED/CREDS_MISSING states
- `sync_to_remote_develop` verified: clone fetched origin/develop when local was behind
- Node 22 confirmed: `TypeError: A.with is not a function` no longer occurs

🤖 Generated with [Claude Code](https://claude.com/claude-code)