### PR TITLE
ci: update Trivy action versions (setup-trivy v0.2.6, trivy-action v0.35.0)

### DIFF
--- a/.github/workflows/docker-security.yml
+++ b/.github/workflows/docker-security.yml
@@ -50,7 +50,7 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Install Trivy (cached)
-      uses: aquasecurity/setup-trivy@v0.2.5
+      uses: aquasecurity/setup-trivy@v0.2.6
       with:
         version: ${{ env.TRIVY_VERSION }}
         cache: true
@@ -78,7 +78,7 @@ jobs:
         cache-to: type=gha,mode=max
 
     - name: Run Trivy vulnerability scanner
-      uses: aquasecurity/trivy-action@0.34.2
+      uses: aquasecurity/trivy-action@v0.35.0
       with:
         image-ref: ${{ env.IMAGE_PREFIX }}/controller:scan
         format: 'sarif'
@@ -101,7 +101,7 @@ jobs:
 
     - name: Generate human-readable report
       if: always()
-      uses: aquasecurity/trivy-action@0.34.2
+      uses: aquasecurity/trivy-action@v0.35.0
       with:
         image-ref: ${{ env.IMAGE_PREFIX }}/controller:scan
         format: 'table'
@@ -137,7 +137,7 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Install Trivy (cached)
-      uses: aquasecurity/setup-trivy@v0.2.5
+      uses: aquasecurity/setup-trivy@v0.2.6
       with:
         version: ${{ env.TRIVY_VERSION }}
         cache: true
@@ -165,7 +165,7 @@ jobs:
         cache-to: type=gha,mode=max
 
     - name: Run Trivy vulnerability scanner
-      uses: aquasecurity/trivy-action@0.34.2
+      uses: aquasecurity/trivy-action@v0.35.0
       with:
         image-ref: ${{ env.IMAGE_PREFIX }}/steward:scan
         format: 'sarif'
@@ -188,7 +188,7 @@ jobs:
 
     - name: Generate human-readable report
       if: always()
-      uses: aquasecurity/trivy-action@0.34.2
+      uses: aquasecurity/trivy-action@v0.35.0
       with:
         image-ref: ${{ env.IMAGE_PREFIX }}/steward:scan
         format: 'table'


### PR DESCRIPTION
## Summary

Fixes container image scan CI failures by updating pinned Trivy GitHub Action versions.

## Problem Context

The `Scan Controller Image` and `Scan Steward Image` jobs in `docker-security.yml` were
failing instantly with:

```
Unable to resolve action `aquasecurity/setup-trivy@v0.2.5`, unable to find version `v0.2.5`.
Unable to resolve action `aquasecurity/trivy-action@0.34.2`, unable to find version `0.34.2`
```

Upstream removed/re-tagged these versions.

## Changes

- `aquasecurity/setup-trivy`: `v0.2.5` → `v0.2.6`
- `aquasecurity/trivy-action`: `0.34.2` → `v0.35.0` (also fixed missing `v` prefix)

## Testing

CI will validate — the docker-security workflow should now resolve the actions successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)