### PR TITLE
fix: evict disconnected stewards from cache on re-registration (E2E)

### DIFF
--- a/test/e2e/framework.go
+++ b/test/e2e/framework.go
@@ -516,11 +516,21 @@ func (f *E2ETestFramework) RegisterStewardWithController(stewardName, tenantID s
 	// Check if already registered (with read lock)
 	f.mu.RLock()
 	if existing, exists := f.registeredStewards[stewardName]; exists {
+		if existing.MQTTClient != nil && existing.MQTTClient.IsConnected() {
+			f.mu.RUnlock()
+			f.logger.Info("Reusing existing registered steward", "steward_name", stewardName)
+			return existing, nil
+		}
+		// Stale entry — client was disconnected (e.g., by a failover test).
+		// Remove it and re-register below.
 		f.mu.RUnlock()
-		f.logger.Info("Reusing existing registered steward", "steward_name", stewardName)
-		return existing, nil
+		f.mu.Lock()
+		delete(f.registeredStewards, stewardName)
+		f.mu.Unlock()
+		f.logger.Info("Evicting disconnected steward, will re-register", "steward_name", stewardName)
+	} else {
+		f.mu.RUnlock()
 	}
-	f.mu.RUnlock()
 
 	// Step 1: Create registration token (no lock needed)
 	token, err := f.CreateRegistrationToken(tenantID)


### PR DESCRIPTION
## Summary

Fixes flaky `TestFailoverDetection` E2E test by evicting disconnected stewards
from the registration cache before reuse.

## Problem Context

`TestE2EScenarios/TestFailoverDetection` intentionally disconnects an MQTT client
to simulate steward failure (line 876: `registered.MQTTClient.Disconnect(0)`).
When the test framework's retry logic re-runs the test, `RegisterStewardWithController`
returned the cached steward — with its dead MQTT client. Since `AutoReconnect=false`,
the client stayed disconnected, causing:

```
Error: steward MQTT client not connected
Test:  TestE2EScenarios/TestFailoverDetection
```

## Changes

- `test/e2e/framework.go`: `RegisterStewardWithController` now checks `IsConnected()`
  before reusing a cached steward. Disconnected entries are evicted and a fresh
  steward is registered.

## Testing

- `go build ./test/e2e/...` compiles cleanly
- CI will validate the E2E suite passes with the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)