### PR TITLE
tooling: add claude.ai to container DNS allowlist

### DIFF
--- a/.devcontainer/dnsmasq-allowlist.conf
+++ b/.devcontainer/dnsmasq-allowlist.conf
@@ -7,8 +7,10 @@
 # No default server= and no-resolv means unlisted domains get REFUSED instantly.
 # Do NOT use address=/#/ — it returns 0.0.0.0 which causes connection hangs.
 
-# --- Anthropic (Claude API + telemetry) ---
+# --- Anthropic (Claude API + OAuth + remote-control) ---
 server=/anthropic.com/9.9.9.9
+server=/claude.ai/9.9.9.9
+server=/claude.com/9.9.9.9
 server=/sentry.io/9.9.9.9
 
 # --- GitHub (API, git push, asset downloads) ---


### PR DESCRIPTION
## Summary

Adds `claude.ai` to the agent container DNS allowlist, fixing OAuth login
and remote-control failures in interactive sessions.

## Problem Context

The agent container firewall blocks all DNS except allowlisted domains.
`platform.claude.com` (subdomain of `claude.ai`) is required for OAuth
login and remote-control, but was missing from the allowlist. Error:

```
Failed to connect to platform.claude.com: EAI_AGAIN
```

Headless agents were unaffected because they only use `anthropic.com` (the API).

## Changes

- `.devcontainer/dnsmasq-allowlist.conf`: add `server=/claude.ai/9.9.9.9`

## Testing

Rebuild image and retry `/agent-setup creds` — OAuth and remote-control should connect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)