### PR TITLE
transport: QUIC net.Listener/net.Conn adapters for gRPC (Issue #485)

### DIFF
--- a/pkg/transport/quic/addr.go
+++ b/pkg/transport/quic/addr.go
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 CFGMS Contributors
+
+package quic
+
+// Addr implements net.Addr for QUIC endpoints.
+type Addr struct {
+	network string
+	address string
+}
+
+// Network returns the network name ("quic").
+func (a *Addr) Network() string { return a.network }
+
+// String returns the address string (host:port).
+func (a *Addr) String() string { return a.address }
+
+// newAddr creates a new Addr with network "quic" and the given address string.
+func newAddr(address string) *Addr {
+	return &Addr{network: "quic", address: address}
+}

--- a/pkg/transport/quic/conn.go
+++ b/pkg/transport/quic/conn.go
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 CFGMS Contributors
+
+package quic
+
+import (
+	"net"
+	"time"
+
+	quicgo "github.com/quic-go/quic-go"
+)
+
+// Conn wraps a QUIC stream to implement net.Conn.
+//
+// Read, Write, Close, and deadline operations delegate to the underlying
+// QUIC stream. Address methods return the addresses from the parent QUIC
+// connection.
+type Conn struct {
+	stream     *quicgo.Stream
+	localAddr  net.Addr
+	remoteAddr net.Addr
+}
+
+// Compile-time check that Conn implements net.Conn.
+var _ net.Conn = (*Conn)(nil)
+
+// newConn creates a Conn from a QUIC stream and connection addresses.
+func newConn(stream *quicgo.Stream, localAddr, remoteAddr net.Addr) *Conn {
+	return &Conn{
+		stream:     stream,
+		localAddr:  localAddr,
+		remoteAddr: remoteAddr,
+	}
+}
+
+// Read reads data from the QUIC stream.
+func (c *Conn) Read(b []byte) (int, error) {
+	return c.stream.Read(b)
+}
+
+// Write writes data to the QUIC stream.
+func (c *Conn) Write(b []byte) (int, error) {
+	return c.stream.Write(b)
+}
+
+// Close closes the QUIC stream.
+func (c *Conn) Close() error {
+	return c.stream.Close()
+}
+
+// LocalAddr returns the local QUIC connection address.
+func (c *Conn) LocalAddr() net.Addr {
+	return c.localAddr
+}
+
+// RemoteAddr returns the remote QUIC connection address.
+func (c *Conn) RemoteAddr() net.Addr {
+	return c.remoteAddr
+}
+
+// SetDeadline sets the read and write deadline on the QUIC stream.
+func (c *Conn) SetDeadline(t time.Time) error {
+	return c.stream.SetDeadline(t)
+}
+
+// SetReadDeadline sets the read deadline on the QUIC stream.
+func (c *Conn) SetReadDeadline(t time.Time) error {
+	return c.stream.SetReadDeadline(t)
+}
+
+// SetWriteDeadline sets the write deadline on the QUIC stream.
+func (c *Conn) SetWriteDeadline(t time.Time) error {
+	return c.stream.SetWriteDeadline(t)
+}

--- a/pkg/transport/quic/conn_test.go
+++ b/pkg/transport/quic/conn_test.go
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 CFGMS Contributors
+
+package quic
+
+import (
+	"net"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestConn_ImplementsNetConn verifies the compile-time interface contract.
+func TestConn_ImplementsNetConn(t *testing.T) {
+	var _ net.Conn = (*Conn)(nil)
+}
+
+// TestConn_ReadWrite verifies that bytes written through one end of a QUIC stream
+// are readable from the Conn wrapper on the other end.
+func TestConn_ReadWrite(t *testing.T) {
+	tlsPair := newTestTLSPair(t)
+	serverConn, clientConn := dialPair(t, tlsPair)
+
+	// Client writes, server reads.
+	_, err := clientConn.Write([]byte("hello"))
+	require.NoError(t, err)
+
+	buf := make([]byte, 16)
+	require.NoError(t, serverConn.SetReadDeadline(time.Now().Add(5*time.Second)))
+	n, err := serverConn.Read(buf)
+	require.NoError(t, err)
+	assert.Equal(t, "hello", string(buf[:n]))
+
+	// Server writes, client reads.
+	_, err = serverConn.Write([]byte("world"))
+	require.NoError(t, err)
+
+	require.NoError(t, clientConn.SetReadDeadline(time.Now().Add(5*time.Second)))
+	n, err = clientConn.Read(buf)
+	require.NoError(t, err)
+	assert.Equal(t, "world", string(buf[:n]))
+}
+
+// TestConn_Addresses verifies that LocalAddr and RemoteAddr return valid QUIC
+// addresses with network "quic".
+func TestConn_Addresses(t *testing.T) {
+	tlsPair := newTestTLSPair(t)
+	serverConn, clientConn := dialPair(t, tlsPair)
+
+	// Both sides should report addresses.
+	require.NotNil(t, serverConn.LocalAddr())
+	require.NotNil(t, serverConn.RemoteAddr())
+	require.NotNil(t, clientConn.LocalAddr())
+	require.NotNil(t, clientConn.RemoteAddr())
+
+	// The addresses must be non-empty strings.
+	assert.NotEmpty(t, serverConn.LocalAddr().String())
+	assert.NotEmpty(t, serverConn.RemoteAddr().String())
+	assert.NotEmpty(t, clientConn.LocalAddr().String())
+	assert.NotEmpty(t, clientConn.RemoteAddr().String())
+
+	// The network name must be "quic".
+	assert.Equal(t, "quic", serverConn.LocalAddr().Network())
+	assert.Equal(t, "quic", serverConn.RemoteAddr().Network())
+}
+
+// TestConn_Deadlines verifies that deadline methods propagate to the stream
+// without returning errors under normal conditions.
+func TestConn_Deadlines(t *testing.T) {
+	tlsPair := newTestTLSPair(t)
+	_, clientConn := dialPair(t, tlsPair)
+
+	deadline := time.Now().Add(5 * time.Second)
+
+	require.NoError(t, clientConn.SetDeadline(deadline))
+	require.NoError(t, clientConn.SetReadDeadline(deadline))
+	require.NoError(t, clientConn.SetWriteDeadline(deadline))
+
+	// Clear deadlines (zero time means no deadline).
+	require.NoError(t, clientConn.SetDeadline(time.Time{}))
+	require.NoError(t, clientConn.SetReadDeadline(time.Time{}))
+	require.NoError(t, clientConn.SetWriteDeadline(time.Time{}))
+}

--- a/pkg/transport/quic/dialer.go
+++ b/pkg/transport/quic/dialer.go
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 CFGMS Contributors
+
+package quic
+
+import (
+	"context"
+	"crypto/tls"
+	"net"
+
+	quicgo "github.com/quic-go/quic-go"
+)
+
+// Dial establishes a QUIC connection to addr and opens the first bidirectional
+// stream, returning it as a net.Conn.
+//
+// tlsConfig must have NextProtos set to a value matching the server's config.
+// If quicConfig is nil, sensible defaults are used.
+//
+// The returned net.Conn is suitable for use as a gRPC transport connection when
+// paired with grpc.WithTransportCredentials(insecure.NewCredentials()), since
+// TLS is handled at the QUIC layer.
+func Dial(ctx context.Context, addr string, tlsConfig *tls.Config, quicConfig *quicgo.Config) (net.Conn, error) {
+	quicConn, err := quicgo.DialAddr(ctx, addr, tlsConfig, mergeQuicConfig(quicConfig))
+	if err != nil {
+		return nil, err
+	}
+
+	stream, err := quicConn.OpenStreamSync(ctx)
+	if err != nil {
+		_ = quicConn.CloseWithError(1, "stream open failed")
+		return nil, err
+	}
+
+	localAddr := newAddr(quicConn.LocalAddr().String())
+	remoteAddr := newAddr(quicConn.RemoteAddr().String())
+	return newConn(stream, localAddr, remoteAddr), nil
+}
+
+// NewDialer returns a function compatible with grpc.WithContextDialer.
+//
+// Example:
+//
+//	conn, err := grpc.NewClient(addr,
+//	    grpc.WithContextDialer(quic.NewDialer(tlsConfig, nil)),
+//	    grpc.WithTransportCredentials(insecure.NewCredentials()),
+//	)
+func NewDialer(tlsConfig *tls.Config, quicConfig *quicgo.Config) func(ctx context.Context, addr string) (net.Conn, error) {
+	return func(ctx context.Context, addr string) (net.Conn, error) {
+		return Dial(ctx, addr, tlsConfig, quicConfig)
+	}
+}

--- a/pkg/transport/quic/dialer_test.go
+++ b/pkg/transport/quic/dialer_test.go
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 CFGMS Contributors
+
+package quic
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestDialer_ReturnsNetConn verifies that Dial returns a valid net.Conn.
+func TestDialer_ReturnsNetConn(t *testing.T) {
+	tlsPair := newTestTLSPair(t)
+
+	lis, err := Listen("127.0.0.1:0", tlsPair.server, nil)
+	require.NoError(t, err)
+	defer func() { _ = lis.Close() }()
+
+	// Accept in the background. Server goroutine will return once it
+	// receives the sync byte written below.
+	go func() {
+		conn, aerr := lis.Accept()
+		if aerr == nil {
+			_ = conn.Close()
+		}
+	}()
+
+	conn, err := Dial(t.Context(), lis.Addr().String(), tlsPair.client, nil)
+	require.NoError(t, err)
+	require.NotNil(t, conn)
+
+	// Write a byte to trigger stream notification so the server goroutine
+	// doesn't leak waiting in AcceptStream.
+	_, _ = conn.Write([]byte{0x00})
+
+	var _ net.Conn = conn
+	assert.NotNil(t, conn.LocalAddr())
+	assert.NotNil(t, conn.RemoteAddr())
+
+	require.NoError(t, conn.Close())
+}
+
+// TestDialer_NewDialer_ContextDialer verifies that NewDialer returns a function
+// with the correct signature for grpc.WithContextDialer.
+func TestDialer_NewDialer_ContextDialer(t *testing.T) {
+	tlsPair := newTestTLSPair(t)
+
+	dialFn := NewDialer(tlsPair.client, nil)
+
+	// Verify the function signature matches grpc.WithContextDialer expectation.
+	var _ func(ctx context.Context, addr string) (net.Conn, error) = dialFn
+
+	lis, err := Listen("127.0.0.1:0", tlsPair.server, nil)
+	require.NoError(t, err)
+	defer func() { _ = lis.Close() }()
+
+	go func() {
+		conn, aerr := lis.Accept()
+		if aerr == nil {
+			_ = conn.Close()
+		}
+	}()
+
+	conn, err := dialFn(t.Context(), lis.Addr().String())
+	require.NoError(t, err)
+	require.NotNil(t, conn)
+
+	_, _ = conn.Write([]byte{0x00})
+	require.NoError(t, conn.Close())
+}
+
+// TestDialer_InvalidAddr verifies that Dial returns an error when it cannot
+// reach the target address within the given context deadline.
+func TestDialer_InvalidAddr(t *testing.T) {
+	tlsPair := newTestTLSPair(t)
+
+	ctx, cancel := context.WithTimeout(t.Context(), 3*time.Second)
+	defer cancel()
+
+	// Port 1 is privileged and almost certainly not listening.
+	// QUIC/UDP will eventually give up or get ICMP unreachable.
+	_, err := Dial(ctx, "127.0.0.1:1", tlsPair.client, nil)
+	assert.Error(t, err, "Dial to unreachable address should fail")
+}

--- a/pkg/transport/quic/doc.go
+++ b/pkg/transport/quic/doc.go
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 CFGMS Contributors
+
+// Package quic provides net.Listener and net.Conn adapters that allow gRPC to
+// run over QUIC streams.
+//
+// gRPC requires a net.Listener (server) and net.Conn (both sides) to operate
+// its HTTP/2 transport. QUIC provides quic.Listener and quic.Stream. This
+// package bridges the two with thin adapters so gRPC can run over QUIC without
+// any gRPC-internal modifications.
+//
+// # Architecture
+//
+// One QUIC connection maps to one gRPC connection. gRPC handles its own HTTP/2
+// stream multiplexing within that single QUIC stream. This is the correct
+// mapping: each QUIC connection carries exactly one bidirectional stream, which
+// gRPC uses for its entire HTTP/2 connection lifetime.
+//
+// # Server usage
+//
+//	lis, err := quic.Listen(addr, tlsConfig, nil)
+//	if err != nil {
+//	    log.Fatal(err)
+//	}
+//	grpcServer := grpc.NewServer()
+//	grpcServer.Serve(lis)
+//
+// # Client usage
+//
+//	dialer := quic.NewDialer(tlsConfig, nil)
+//	conn, err := grpc.NewClient(addr,
+//	    grpc.WithContextDialer(dialer),
+//	    grpc.WithTransportCredentials(insecure.NewCredentials()),
+//	)
+//
+// # TLS
+//
+// TLS is handled entirely by the QUIC layer. Callers must provide a *tls.Config
+// with NextProtos set to a common value on both ends. gRPC should be configured
+// with insecure credentials since security is provided by the QUIC transport.
+//
+// This package contains no CFGMS business logic and may be used independently.
+package quic

--- a/pkg/transport/quic/integration_test.go
+++ b/pkg/transport/quic/integration_test.go
@@ -1,0 +1,459 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 CFGMS Contributors
+
+package quic
+
+import (
+	"context"
+	"crypto/tls"
+	"errors"
+	"io"
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/status"
+)
+
+// ---------------------------------------------------------------------------
+// Minimal in-test gRPC service definitions (no proto file required)
+// ---------------------------------------------------------------------------
+
+// echoServiceServer is the interface that the Echo service handler must implement.
+// gRPC's RegisterService requires HandlerType to be a pointer to an interface.
+type echoServiceServer interface{}
+
+// echoServer implements echoServiceServer.
+type echoServer struct{}
+
+// echoServiceDesc describes a minimal Echo service with unary, server-streaming,
+// and bidi-streaming RPCs. This avoids any proto-generated code dependency.
+var echoServiceDesc = grpc.ServiceDesc{
+	ServiceName: "test.Echo",
+	HandlerType: (*echoServiceServer)(nil),
+	Methods: []grpc.MethodDesc{
+		{
+			MethodName: "UnaryEcho",
+			Handler:    echoUnaryHandler,
+		},
+	},
+	Streams: []grpc.StreamDesc{
+		{
+			StreamName:    "ServerStream",
+			Handler:       echoServerStreamHandler,
+			ServerStreams: true,
+		},
+		{
+			StreamName:    "BidiStream",
+			Handler:       echoBidiStreamHandler,
+			ServerStreams: true,
+			ClientStreams: true,
+		},
+	},
+}
+
+// echoMessage is a trivial framed message: 4-byte length + payload.
+// We use raw bytes over the gRPC stream to avoid protobuf dependencies.
+
+// echoUnaryHandler echoes the request message back.
+func echoUnaryHandler(srv interface{}, ctx context.Context, dec func(interface{}) error, _ grpc.UnaryServerInterceptor) (interface{}, error) {
+	var msg echoMsg
+	if err := dec(&msg); err != nil {
+		return nil, err
+	}
+	return &msg, nil
+}
+
+// echoServerStreamHandler sends the request message back three times.
+func echoServerStreamHandler(srv interface{}, stream grpc.ServerStream) error {
+	var msg echoMsg
+	if err := stream.RecvMsg(&msg); err != nil {
+		return err
+	}
+	for i := 0; i < 3; i++ {
+		if err := stream.SendMsg(&msg); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// echoBidiStreamHandler echoes each message received until the client closes.
+func echoBidiStreamHandler(srv interface{}, stream grpc.ServerStream) error {
+	for {
+		var msg echoMsg
+		if err := stream.RecvMsg(&msg); err != nil {
+			if errors.Is(err, io.EOF) {
+				return nil
+			}
+			return err
+		}
+		if err := stream.SendMsg(&msg); err != nil {
+			return err
+		}
+	}
+}
+
+// echoMsg is a codec-compatible message wrapper around a byte slice.
+// grpc uses the registered codec to marshal/unmarshal; we use the default
+// protobuf codec which handles []byte via protobuf's bytes field when wrapped.
+// Instead, we implement the proto.Message interface stub to pass raw bytes.
+//
+// For simplicity in tests we use gRPC's raw encoding by registering our own
+// codec. However, an easier approach is to use gRPC's test helpers.
+//
+// Actually the simplest approach: use grpc.ForceCodecV2 with a passthrough
+// codec so the "message" is just raw bytes on the wire.
+
+// echoMsg wraps a payload for our test service.
+type echoMsg struct {
+	Payload []byte
+}
+
+// We implement proto.Message by supplying the minimum needed for gRPC's
+// codec to handle our messages. gRPC's default codec is protobuf; we need
+// our message to be encodable. The cleanest approach without a .proto file
+// is to make echoMsg implement encoding.BinaryMarshaler / BinaryUnmarshaler
+// and register a custom codec.
+//
+// For test simplicity we instead just use gRPC's built-in "proto" codec but
+// wrap our payload in a real proto message: we treat []byte as a proto bytes
+// field (field number 1, wire type 2 = length-delimited).
+
+// ProtoMessage implements proto.Message (duck typing for gRPC codec).
+func (e *echoMsg) ProtoMessage() {}
+
+// Reset implements proto.Message.
+func (e *echoMsg) Reset() {}
+
+// String implements proto.Message.
+func (e *echoMsg) String() string { return string(e.Payload) }
+
+// Marshal encodes echoMsg as a proto bytes field (field 1, wire type 2).
+func (e *echoMsg) Marshal() ([]byte, error) {
+	if len(e.Payload) == 0 {
+		return nil, nil
+	}
+	// Encode as proto field 1, wire type 2 (length-delimited).
+	// Tag = (field_number << 3) | wire_type = (1<<3)|2 = 0x0a
+	payload := e.Payload
+	size := len(payload)
+	// Varint encoding for size.
+	var sizeBytes []byte
+	for size >= 0x80 {
+		sizeBytes = append(sizeBytes, byte(size)|0x80)
+		size >>= 7
+	}
+	sizeBytes = append(sizeBytes, byte(size))
+	out := make([]byte, 0, 1+len(sizeBytes)+len(payload))
+	out = append(out, 0x0a)
+	out = append(out, sizeBytes...)
+	out = append(out, payload...)
+	return out, nil
+}
+
+// Unmarshal decodes echoMsg from proto bytes field 1.
+func (e *echoMsg) Unmarshal(data []byte) error {
+	if len(data) == 0 {
+		e.Payload = nil
+		return nil
+	}
+	// Parse proto field 1, wire type 2.
+	i := 0
+	for i < len(data) {
+		tag := data[i]
+		i++
+		wireType := tag & 0x07
+		fieldNum := tag >> 3
+		if wireType == 2 && fieldNum == 1 {
+			// Varint length.
+			var length int
+			shift := 0
+			for i < len(data) {
+				b := data[i]
+				i++
+				length |= int(b&0x7f) << shift
+				shift += 7
+				if b < 0x80 {
+					break
+				}
+			}
+			if i+length > len(data) {
+				return status.Error(codes.Internal, "truncated proto message")
+			}
+			e.Payload = make([]byte, length)
+			copy(e.Payload, data[i:i+length])
+			return nil
+		}
+	}
+	e.Payload = nil
+	return nil
+}
+
+// ProtoSize returns the encoded size (for proto.Sizer).
+func (e *echoMsg) ProtoSize() int {
+	if len(e.Payload) == 0 {
+		return 0
+	}
+	size := len(e.Payload)
+	varintSize := 1
+	for s := size; s >= 0x80; s >>= 7 {
+		varintSize++
+	}
+	return 1 + varintSize + size
+}
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+// startEchoServer creates a gRPC server on a QUIC listener and starts serving.
+// Returns the server, the listener address, and a cleanup function.
+func startEchoServer(t *testing.T, tlsPair *testTLSPair) (*grpc.Server, string) {
+	t.Helper()
+
+	lis, err := Listen("127.0.0.1:0", tlsPair.server, nil)
+	require.NoError(t, err)
+
+	srv := grpc.NewServer()
+	srv.RegisterService(&echoServiceDesc, &echoServer{})
+
+	go func() {
+		if serveErr := srv.Serve(lis); serveErr != nil {
+			// Serve returns an error when the listener is closed.
+		}
+	}()
+
+	t.Cleanup(func() {
+		srv.GracefulStop()
+	})
+
+	return srv, lis.Addr().String()
+}
+
+// newEchoClient dials the echo server over QUIC and returns a gRPC ClientConn.
+func newEchoClient(t *testing.T, addr string, tlsPair *testTLSPair) *grpc.ClientConn {
+	t.Helper()
+
+	conn, err := grpc.NewClient(
+		addr,
+		grpc.WithContextDialer(NewDialer(tlsPair.client, nil)),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = conn.Close() })
+	return conn
+}
+
+// invoke performs a unary echoMsg RPC on the given client connection.
+func invokeUnary(ctx context.Context, cc *grpc.ClientConn, payload []byte) ([]byte, error) {
+	req := &echoMsg{Payload: payload}
+	resp := &echoMsg{}
+	err := cc.Invoke(ctx, "/test.Echo/UnaryEcho", req, resp)
+	if err != nil {
+		return nil, err
+	}
+	return resp.Payload, nil
+}
+
+// ---------------------------------------------------------------------------
+// Integration tests
+// ---------------------------------------------------------------------------
+
+// TestGRPCOverQUIC_UnaryRPC tests a full gRPC unary call over the QUIC transport.
+func TestGRPCOverQUIC_UnaryRPC(t *testing.T) {
+	tlsPair := newTestTLSPair(t)
+	_, addr := startEchoServer(t, tlsPair)
+
+	cc := newEchoClient(t, addr, tlsPair)
+
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+	defer cancel()
+
+	got, err := invokeUnary(ctx, cc, []byte("ping"))
+	require.NoError(t, err)
+	assert.Equal(t, []byte("ping"), got)
+}
+
+// TestGRPCOverQUIC_ServerStreaming tests a server-streaming RPC over QUIC.
+func TestGRPCOverQUIC_ServerStreaming(t *testing.T) {
+	tlsPair := newTestTLSPair(t)
+	_, addr := startEchoServer(t, tlsPair)
+	cc := newEchoClient(t, addr, tlsPair)
+
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+	defer cancel()
+
+	stream, err := cc.NewStream(ctx, &grpc.StreamDesc{ServerStreams: true}, "/test.Echo/ServerStream")
+	require.NoError(t, err)
+
+	require.NoError(t, stream.SendMsg(&echoMsg{Payload: []byte("hello")}))
+	require.NoError(t, stream.CloseSend())
+
+	var received [][]byte
+	for {
+		var msg echoMsg
+		err := stream.RecvMsg(&msg)
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		require.NoError(t, err)
+		received = append(received, msg.Payload)
+	}
+
+	assert.Len(t, received, 3, "server should send 3 echoes")
+	for _, payload := range received {
+		assert.Equal(t, []byte("hello"), payload)
+	}
+}
+
+// TestGRPCOverQUIC_BidiStreaming tests a bidirectional streaming RPC over QUIC.
+func TestGRPCOverQUIC_BidiStreaming(t *testing.T) {
+	tlsPair := newTestTLSPair(t)
+	_, addr := startEchoServer(t, tlsPair)
+	cc := newEchoClient(t, addr, tlsPair)
+
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+	defer cancel()
+
+	stream, err := cc.NewStream(ctx, &grpc.StreamDesc{ServerStreams: true, ClientStreams: true}, "/test.Echo/BidiStream")
+	require.NoError(t, err)
+
+	messages := [][]byte{[]byte("a"), []byte("bb"), []byte("ccc")}
+
+	// Send all messages.
+	for _, msg := range messages {
+		require.NoError(t, stream.SendMsg(&echoMsg{Payload: msg}))
+	}
+	require.NoError(t, stream.CloseSend())
+
+	// Receive echoed messages.
+	var received [][]byte
+	for {
+		var msg echoMsg
+		err := stream.RecvMsg(&msg)
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		require.NoError(t, err)
+		received = append(received, msg.Payload)
+	}
+
+	require.Len(t, received, len(messages))
+	for i, payload := range received {
+		assert.Equal(t, messages[i], payload)
+	}
+}
+
+// TestGRPCOverQUIC_MultipleClients tests 5 clients connecting simultaneously.
+func TestGRPCOverQUIC_MultipleClients(t *testing.T) {
+	const numClients = 5
+	tlsPair := newTestTLSPair(t)
+	_, addr := startEchoServer(t, tlsPair)
+
+	var wg sync.WaitGroup
+	errs := make([]error, numClients)
+
+	for i := range numClients {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+
+			cc := newEchoClient(t, addr, tlsPair)
+			ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+			defer cancel()
+
+			_, errs[idx] = invokeUnary(ctx, cc, []byte("client"))
+		}(i)
+	}
+
+	wg.Wait()
+
+	for i, err := range errs {
+		assert.NoError(t, err, "client %d failed", i)
+	}
+}
+
+// TestGRPCOverQUIC_ClientDisconnect verifies that when a client disconnects
+// mid-stream, the server side receives an error.
+func TestGRPCOverQUIC_ClientDisconnect(t *testing.T) {
+	tlsPair := newTestTLSPair(t)
+	_, addr := startEchoServer(t, tlsPair)
+
+	// Create a context we will cancel to simulate client disconnect.
+	ctx, cancel := context.WithCancel(t.Context())
+
+	cc := newEchoClient(t, addr, tlsPair)
+	stream, err := cc.NewStream(ctx, &grpc.StreamDesc{ServerStreams: true, ClientStreams: true}, "/test.Echo/BidiStream")
+	require.NoError(t, err)
+
+	// Send one message, then cancel the context (simulates disconnect).
+	require.NoError(t, stream.SendMsg(&echoMsg{Payload: []byte("bye")}))
+
+	// Cancel before receiving the response.
+	cancel()
+
+	// The stream operations after cancel should return a context error.
+	var msg echoMsg
+	err = stream.RecvMsg(&msg)
+	if err != nil {
+		// Expected: context canceled or EOF.
+		t.Logf("RecvMsg after cancel returned (expected): %v", err)
+	}
+}
+
+// TestGRPCOverQUIC_TLSRequired verifies that a connection attempt with a
+// mismatched or missing TLS configuration fails.
+func TestGRPCOverQUIC_TLSRequired(t *testing.T) {
+	tlsPair := newTestTLSPair(t)
+	_, addr := startEchoServer(t, tlsPair)
+
+	// Build a "bad" client TLS config with a different CA (no valid cert).
+	badCA := newTestTLSPair(t)
+
+	// Use a client TLS config from a different CA that the server will reject.
+	// The server requires client cert verification against its own CA.
+	wrongCATLS := &tls.Config{
+		InsecureSkipVerify: false, //nolint:gosec // intentional bad cert for negative test
+		NextProtos:         []string{testALPN},
+		ServerName:         "localhost",
+		RootCAs:            badCA.client.RootCAs, // wrong CA pool
+	}
+
+	ctx, cancel := context.WithTimeout(t.Context(), 3*time.Second)
+	defer cancel()
+
+	_, dialErr := Dial(ctx, addr, wrongCATLS, nil)
+	assert.Error(t, dialErr, "dial with wrong CA should fail TLS verification")
+}
+
+// TestGRPCOverQUIC_AddrWrapper verifies that our Addr wrapper is used for
+// addresses returned from the Conn (network = "quic").
+func TestGRPCOverQUIC_AddrWrapper(t *testing.T) {
+	tlsPair := newTestTLSPair(t)
+	serverConn, clientConn := dialPair(t, tlsPair)
+
+	// Both server and client addresses should report network "quic".
+	assert.Equal(t, "quic", serverConn.LocalAddr().Network())
+	assert.Equal(t, "quic", serverConn.RemoteAddr().Network())
+	assert.Equal(t, "quic", clientConn.LocalAddr().Network())
+	assert.Equal(t, "quic", clientConn.RemoteAddr().Network())
+
+	// Both sides should have non-empty addresses.
+	assert.NotEmpty(t, serverConn.RemoteAddr().String())
+	assert.NotEmpty(t, clientConn.LocalAddr().String())
+}
+
+// TestAddr_NetworkAndString verifies the Addr type satisfies net.Addr.
+func TestAddr_NetworkAndString(t *testing.T) {
+	a := newAddr("127.0.0.1:4433")
+	var _ net.Addr = a
+	assert.Equal(t, "quic", a.Network())
+	assert.Equal(t, "127.0.0.1:4433", a.String())
+}

--- a/pkg/transport/quic/listener.go
+++ b/pkg/transport/quic/listener.go
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 CFGMS Contributors
+
+package quic
+
+import (
+	"context"
+	"crypto/tls"
+	"net"
+	"time"
+
+	quicgo "github.com/quic-go/quic-go"
+)
+
+// defaultQuicConfig returns the default QUIC configuration for the transport
+// adapter. Callers may override individual fields by passing their own config.
+func defaultQuicConfig() *quicgo.Config {
+	return &quicgo.Config{
+		MaxIdleTimeout:  30 * time.Second,
+		KeepAlivePeriod: 10 * time.Second,
+	}
+}
+
+// mergeQuicConfig returns cfg if non-nil, otherwise returns the default config.
+func mergeQuicConfig(cfg *quicgo.Config) *quicgo.Config {
+	if cfg != nil {
+		return cfg
+	}
+	return defaultQuicConfig()
+}
+
+// Listener wraps a QUIC listener to implement net.Listener.
+//
+// Each accepted QUIC connection opens its first bidirectional stream, which is
+// wrapped as a net.Conn for gRPC to use. gRPC handles its own HTTP/2
+// multiplexing within that stream.
+type Listener struct {
+	ql     *quicgo.Listener
+	ctx    context.Context
+	cancel context.CancelFunc
+}
+
+// Compile-time check that Listener implements net.Listener.
+var _ net.Listener = (*Listener)(nil)
+
+// Listen creates a new QUIC listener on the given address.
+//
+// tlsConfig must have NextProtos set to a value agreed with the client.
+// If quicConfig is nil, sensible defaults (MaxIdleTimeout: 30s,
+// KeepAlivePeriod: 10s) are used.
+func Listen(addr string, tlsConfig *tls.Config, quicConfig *quicgo.Config) (*Listener, error) {
+	ql, err := quicgo.ListenAddr(addr, tlsConfig, mergeQuicConfig(quicConfig))
+	if err != nil {
+		return nil, err
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	return &Listener{
+		ql:     ql,
+		ctx:    ctx,
+		cancel: cancel,
+	}, nil
+}
+
+// Accept waits for and returns the next connection.
+//
+// It accepts the next QUIC connection, waits for the first bidirectional
+// stream to be opened, and returns that stream as a net.Conn.
+func (l *Listener) Accept() (net.Conn, error) {
+	quicConn, err := l.ql.Accept(l.ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	stream, err := quicConn.AcceptStream(l.ctx)
+	if err != nil {
+		_ = quicConn.CloseWithError(1, "stream accept failed")
+		return nil, err
+	}
+
+	localAddr := newAddr(quicConn.LocalAddr().String())
+	remoteAddr := newAddr(quicConn.RemoteAddr().String())
+	return newConn(stream, localAddr, remoteAddr), nil
+}
+
+// Close stops the listener. Any blocked Accept call will return with an error.
+func (l *Listener) Close() error {
+	l.cancel()
+	return l.ql.Close()
+}
+
+// Addr returns the listener's network address.
+func (l *Listener) Addr() net.Addr {
+	return l.ql.Addr()
+}

--- a/pkg/transport/quic/listener_test.go
+++ b/pkg/transport/quic/listener_test.go
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 CFGMS Contributors
+
+package quic
+
+import (
+	"net"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestListener_ImplementsNetListener verifies the compile-time interface contract.
+func TestListener_ImplementsNetListener(t *testing.T) {
+	var _ net.Listener = (*Listener)(nil)
+}
+
+// TestListener_AcceptAndClose verifies that Accept returns a valid net.Conn
+// with correct address fields.
+func TestListener_AcceptAndClose(t *testing.T) {
+	tlsPair := newTestTLSPair(t)
+
+	lis, err := Listen("127.0.0.1:0", tlsPair.server, nil)
+	require.NoError(t, err)
+
+	// Addr should be a valid non-empty address.
+	require.NotNil(t, lis.Addr())
+	assert.NotEmpty(t, lis.Addr().String())
+
+	// Accept in a goroutine.
+	type acceptResult struct {
+		conn net.Conn
+		err  error
+	}
+	acceptCh := make(chan acceptResult, 1)
+	go func() {
+		conn, aerr := lis.Accept()
+		acceptCh <- acceptResult{conn: conn, err: aerr}
+	}()
+
+	// Dial and write a byte to trigger stream notification on the server side.
+	clientConn, err := Dial(t.Context(), lis.Addr().String(), tlsPair.client, nil)
+	require.NoError(t, err)
+	defer func() { _ = clientConn.Close() }()
+
+	_, err = clientConn.Write([]byte{0x00})
+	require.NoError(t, err)
+
+	// Wait for Accept with a bounded timeout.
+	select {
+	case result := <-acceptCh:
+		require.NoError(t, result.err)
+		require.NotNil(t, result.conn)
+		assert.NotNil(t, result.conn.LocalAddr())
+		assert.NotNil(t, result.conn.RemoteAddr())
+		_ = result.conn.Close()
+	case <-time.After(10 * time.Second):
+		t.Fatal("timed out waiting for Accept")
+	}
+
+	require.NoError(t, lis.Close())
+}
+
+// TestListener_CloseUnblocksAccept verifies that Close causes a blocked Accept
+// to return with an error rather than hanging indefinitely.
+func TestListener_CloseUnblocksAccept(t *testing.T) {
+	tlsPair := newTestTLSPair(t)
+
+	lis, err := Listen("127.0.0.1:0", tlsPair.server, nil)
+	require.NoError(t, err)
+
+	errCh := make(chan error, 1)
+	go func() {
+		_, aerr := lis.Accept()
+		errCh <- aerr
+	}()
+
+	// Close the listener, which should unblock Accept.
+	require.NoError(t, lis.Close())
+
+	select {
+	case err := <-errCh:
+		assert.Error(t, err, "Accept should return an error after Close")
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for Accept to unblock after Close")
+	}
+}

--- a/pkg/transport/quic/testhelper_test.go
+++ b/pkg/transport/quic/testhelper_test.go
@@ -1,0 +1,128 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 CFGMS Contributors
+
+package quic
+
+import (
+	"crypto/tls"
+	"testing"
+	"time"
+
+	cfgcert "github.com/cfgis/cfgms/pkg/cert"
+	"github.com/stretchr/testify/require"
+)
+
+// testALPN is the ALPN protocol used in tests to distinguish from production traffic.
+const testALPN = "cfgms-transport-test"
+
+// testTLSPair holds matched server and client TLS configurations.
+type testTLSPair struct {
+	server *tls.Config
+	client *tls.Config
+}
+
+// newTestTLSPair creates a CA, signs server and client certificates, and returns
+// matched TLS configs for both sides.
+func newTestTLSPair(t *testing.T) *testTLSPair {
+	t.Helper()
+
+	// Create and initialize a test CA.
+	ca, err := cfgcert.NewCA(&cfgcert.CAConfig{
+		Organization: "CFGMS Test",
+		Country:      "US",
+		ValidityDays: 1,
+		KeySize:      2048,
+	})
+	require.NoError(t, err)
+	require.NoError(t, ca.Initialize(nil))
+
+	caPEM, err := ca.GetCACertificate()
+	require.NoError(t, err)
+
+	// Server certificate signed by the CA.
+	serverCert, err := ca.GenerateServerCertificate(&cfgcert.ServerCertConfig{
+		CommonName:   "localhost",
+		DNSNames:     []string{"localhost"},
+		ValidityDays: 1,
+		KeySize:      2048,
+	})
+	require.NoError(t, err)
+
+	// Client certificate signed by the same CA.
+	clientCert, err := ca.GenerateClientCertificate(&cfgcert.ClientCertConfig{
+		CommonName:   "test-client",
+		ValidityDays: 1,
+		KeySize:      2048,
+	})
+	require.NoError(t, err)
+
+	// Build server TLS config (requires and verifies client cert).
+	serverTLS, err := cfgcert.CreateServerTLSConfig(
+		serverCert.CertificatePEM, serverCert.PrivateKeyPEM,
+		caPEM, tls.VersionTLS13,
+	)
+	require.NoError(t, err)
+	serverTLS.NextProtos = []string{testALPN}
+
+	// Build client TLS config (provides client cert, verifies server).
+	clientTLS, err := cfgcert.CreateClientTLSConfig(
+		clientCert.CertificatePEM, clientCert.PrivateKeyPEM,
+		caPEM, "localhost", tls.VersionTLS13,
+	)
+	require.NoError(t, err)
+	clientTLS.NextProtos = []string{testALPN}
+
+	return &testTLSPair{server: serverTLS, client: clientTLS}
+}
+
+// dialPair starts a QUIC listener, dials it, and returns matching server and
+// client Conn values ready for use. The listener is closed via t.Cleanup.
+//
+// QUIC only notifies the server of a new bidirectional stream when it receives
+// data on that stream. dialPair writes a 1-byte sync signal from client to
+// server and drains it before returning, so callers receive clean connections.
+func dialPair(t *testing.T, tlsPair *testTLSPair) (serverConn, clientConn *Conn) {
+	t.Helper()
+
+	lis, err := Listen("127.0.0.1:0", tlsPair.server, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = lis.Close() })
+
+	type serverResult struct {
+		conn *Conn
+		err  error
+	}
+	serverCh := make(chan serverResult, 1)
+	go func() {
+		nc, aerr := lis.Accept()
+		if aerr != nil {
+			serverCh <- serverResult{err: aerr}
+			return
+		}
+		serverCh <- serverResult{conn: nc.(*Conn)}
+	}()
+
+	addr := lis.Addr().String()
+	cc, err := Dial(t.Context(), addr, tlsPair.client, nil)
+	require.NoError(t, err)
+
+	// QUIC only delivers stream notifications when data is received on the
+	// stream. Write a single sync byte to wake up the server's AcceptStream.
+	_, err = cc.Write([]byte{0x00})
+	require.NoError(t, err)
+
+	sr := <-serverCh
+	require.NoError(t, sr.err)
+
+	// Drain the sync byte from the server side so tests start with clean buffers.
+	require.NoError(t, sr.conn.SetReadDeadline(time.Now().Add(10*time.Second)))
+	syncBuf := make([]byte, 1)
+	_, err = sr.conn.Read(syncBuf)
+	require.NoError(t, err)
+	require.NoError(t, sr.conn.SetReadDeadline(time.Time{}))
+
+	t.Cleanup(func() { _ = cc.Close() })
+	t.Cleanup(func() { _ = sr.conn.Close() })
+
+	return sr.conn, cc.(*Conn)
+}


### PR DESCRIPTION
## Summary

Creates `pkg/transport/quic/` — thin `net.Listener` and `net.Conn` adapters that let gRPC run over QUIC streams without any gRPC-internal modifications. Phase 3 of the gRPC over QUIC epic (#482), depends on Phase 2 (#484).

All 17 tests pass: 11 unit tests and 6 integration tests proving gRPC unary, server-streaming, and bidi-streaming RPCs work over QUIC.

## Problem Context

gRPC requires a `net.Listener` (server) and `net.Conn` (both sides) to operate its HTTP/2 transport. QUIC provides `quic.Listener` and `quic.Stream`. Without this adapter layer, there is no way to run gRPC over QUIC without modifying gRPC internals.

The key architectural mapping: one QUIC connection = one gRPC connection. gRPC handles HTTP/2 stream multiplexing within a single QUIC stream. TLS is handled entirely by QUIC (TLS 1.3); gRPC is configured with insecure credentials.

## Changes

- `pkg/transport/quic/listener.go` — Listener wraps quic.Listener; Accept() accepts the QUIC connection, waits for the first bidirectional stream, returns it as net.Conn; compile-time var _ net.Listener check
- `pkg/transport/quic/conn.go` — Conn wraps quic.Stream; delegates Read/Write/Close/deadlines to the stream; wraps QUIC connection addresses in our Addr type (network = "quic"); compile-time var _ net.Conn check
- `pkg/transport/quic/dialer.go` — Dial and NewDialer; NewDialer returns a function compatible with grpc.WithContextDialer
- `pkg/transport/quic/addr.go` — net.Addr implementation (network = "quic") wrapping QUIC UDP addresses
- `pkg/transport/quic/doc.go` — package documentation with usage examples

## Measured Impact

Test results from `go test ./pkg/transport/quic/... -v -count=1`:

All 17 tests PASS (total: 5.4s)
- 11 unit tests covering interface compliance, read/write, addresses, deadlines, listener accept/close, dialer
- 6 integration tests: unary RPC, server streaming, bidi streaming, 5 concurrent clients, client disconnect, TLS rejection

## Testing

- All 17 tests pass (`ok github.com/cfgis/cfgms/pkg/transport/quic 5.4s`)
- Architecture check passes (`make check-architecture`)
- License headers pass (`make check-license-headers`)
- No CFGMS business logic imported (pure transport library)
- No modifications to existing `pkg/quic/` files

Fixes #485