### PR TITLE
fix: encapsulate StewardConnection.LastActivity behind mutex getter

### DIFF
--- a/pkg/transport/registry/connection.go
+++ b/pkg/transport/registry/connection.go
@@ -38,33 +38,44 @@ type StewardConnection struct {
 	// ConnectedAt records when this connection was registered.
 	ConnectedAt time.Time
 
-	// LastActivity records the most recent send or received activity.
-	LastActivity time.Time
+	// lastActivity records the most recent send or received activity.
+	// Access via GetLastActivity() for thread-safe reads.
+	lastActivity time.Time
 
 	// RemoteAddr is the network address of the connected steward.
 	RemoteAddr string
 
-	// mu serializes writes to Sender.
+	// mu serializes writes to Sender and lastActivity.
 	mu sync.Mutex
 }
 
 // Send writes a message to this steward's connection.
 //
 // Send is thread-safe — concurrent callers are serialized via an internal
-// mutex. LastActivity is updated on every successful or failed send attempt.
+// mutex. lastActivity is updated on every successful or failed send attempt.
 func (c *StewardConnection) Send(msg interface{}) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	c.LastActivity = time.Now()
+	c.lastActivity = time.Now()
 	return c.Sender.SendMsg(msg)
 }
 
 // UpdateActivity records the current time as the most recent activity.
 //
 // Call this when a message is received from the steward to keep the
-// LastActivity timestamp current for health monitoring purposes.
+// activity timestamp current for health monitoring purposes.
 func (c *StewardConnection) UpdateActivity() {
 	c.mu.Lock()
-	c.LastActivity = time.Now()
+	c.lastActivity = time.Now()
 	c.mu.Unlock()
+}
+
+// GetLastActivity returns the most recent activity timestamp.
+//
+// Thread-safe — acquires the internal mutex to read the timestamp
+// that is written by Send() and UpdateActivity().
+func (c *StewardConnection) GetLastActivity() time.Time {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.lastActivity
 }

--- a/pkg/transport/registry/registry_test.go
+++ b/pkg/transport/registry/registry_test.go
@@ -471,7 +471,7 @@ func TestRegistry_ConcurrentSend(t *testing.T) {
 // Connection tests
 // =============================================================================
 
-// TestStewardConnection_Send verifies that Send updates LastActivity.
+// TestStewardConnection_Send verifies that Send updates lastActivity.
 func TestStewardConnection_Send(t *testing.T) {
 	conn := &StewardConnection{
 		StewardID: "s1",
@@ -484,8 +484,9 @@ func TestStewardConnection_Send(t *testing.T) {
 	}
 	after := time.Now()
 
-	if conn.LastActivity.Before(before) || conn.LastActivity.After(after) {
-		t.Errorf("LastActivity = %v, want between %v and %v", conn.LastActivity, before, after)
+	activity := conn.GetLastActivity()
+	if activity.Before(before) || activity.After(after) {
+		t.Errorf("GetLastActivity() = %v, want between %v and %v", activity, before, after)
 	}
 }
 


### PR DESCRIPTION
## Summary

Makes `LastActivity` private and adds `GetLastActivity()` to prevent
unsynchronized reads of a mutex-protected field.

## Problem Context

`StewardConnection.LastActivity` was a public field written under `c.mu.Lock()`
by `Send()` and `UpdateActivity()`, but any caller could read it directly without
the mutex. This is a data race under `-race` and violates the no-foot-guns rule —
callers shouldn't need to know which fields require locking to read safely.

## Changes

- `pkg/transport/registry/connection.go`: `LastActivity` → `lastActivity` (private),
  add `GetLastActivity()` method that acquires the mutex
- `pkg/transport/registry/registry_test.go`: use `GetLastActivity()` instead of
  direct field access

## Testing

All 20 registry tests pass with `-race`:
```
ok  github.com/cfgis/cfgms/pkg/transport/registry  1.015s
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)