### PR TITLE
fix: resolve 24 CodeQL code scanning alerts

### DIFF
--- a/api/proto/transport/transport_test.go
+++ b/api/proto/transport/transport_test.go
@@ -25,8 +25,8 @@ func TestCommand_Construction(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			cmd := &Command{
-				Id:    "cmd-001",
-				Type:  tt.cmdType,
+				Id:     "cmd-001",
+				Type:   tt.cmdType,
 				Params: map[string]string{"key": "value"},
 			}
 			assert.Equal(t, tt.cmdType, cmd.GetType())

--- a/features/config/git/storage/local.go
+++ b/features/config/git/storage/local.go
@@ -20,6 +20,7 @@ import (
 	"github.com/go-git/go-git/v5/plumbing/transport/http"
 
 	cfgit "github.com/cfgis/cfgms/features/config/git"
+	"github.com/cfgis/cfgms/pkg/security"
 )
 
 // LocalRepositoryStore implements RepositoryStore using go-git
@@ -109,7 +110,10 @@ func (s *LocalRepositoryStore) Push(ctx context.Context, localPath string) error
 
 // ReadFile reads a file from the repository
 func (s *LocalRepositoryStore) ReadFile(ctx context.Context, localPath, filePath string) ([]byte, error) {
-	fullPath := filepath.Join(localPath, filePath)
+	fullPath, err := security.ValidateAndCleanPath(localPath, filePath)
+	if err != nil {
+		return nil, fmt.Errorf("invalid file path: %w", err)
+	}
 
 	data, err := os.ReadFile(fullPath)
 	if err != nil {
@@ -124,7 +128,10 @@ func (s *LocalRepositoryStore) ReadFile(ctx context.Context, localPath, filePath
 
 // WriteFile writes a file to the repository
 func (s *LocalRepositoryStore) WriteFile(ctx context.Context, localPath, filePath string, content []byte) error {
-	fullPath := filepath.Join(localPath, filePath)
+	fullPath, err := security.ValidateAndCleanPath(localPath, filePath)
+	if err != nil {
+		return fmt.Errorf("invalid file path: %w", err)
+	}
 
 	// Create directory if needed
 	dir := filepath.Dir(fullPath)
@@ -158,7 +165,10 @@ func (s *LocalRepositoryStore) WriteFile(ctx context.Context, localPath, filePat
 
 // DeleteFile deletes a file from the repository
 func (s *LocalRepositoryStore) DeleteFile(ctx context.Context, localPath, filePath string) error {
-	fullPath := filepath.Join(localPath, filePath)
+	fullPath, err := security.ValidateAndCleanPath(localPath, filePath)
+	if err != nil {
+		return fmt.Errorf("invalid file path: %w", err)
+	}
 
 	// Check if file exists
 	if _, err := os.Stat(fullPath); os.IsNotExist(err) {

--- a/features/reports/api/handlers.go
+++ b/features/reports/api/handlers.go
@@ -5,6 +5,7 @@ package api
 import (
 	"encoding/json"
 	"fmt"
+	"html"
 	"net/http"
 	"strconv"
 	"time"
@@ -67,7 +68,7 @@ func (h *Handler) generateReport(w http.ResponseWriter, r *http.Request) {
 	// Generate the report
 	report, err := h.engine.GenerateReport(r.Context(), req)
 	if err != nil {
-		h.logger.Error("failed to generate report", "error", err, "request", req)
+		h.logger.Error("failed to generate report", "error", err, "format", logging.SanitizeLogValue(string(req.Format)))
 		h.writeError(w, http.StatusInternalServerError, "Failed to generate report", err)
 		return
 	}
@@ -75,7 +76,7 @@ func (h *Handler) generateReport(w http.ResponseWriter, r *http.Request) {
 	// Export in requested format
 	exportData, err := h.exporter.Export(r.Context(), report, req.Format)
 	if err != nil {
-		h.logger.Error("failed to export report", "error", err, "format", req.Format)
+		h.logger.Error("failed to export report", "error", err, "format", logging.SanitizeLogValue(string(req.Format)))
 		h.writeError(w, http.StatusInternalServerError, "Failed to export report", err)
 		return
 	}
@@ -90,7 +91,7 @@ func (h *Handler) generateReport(w http.ResponseWriter, r *http.Request) {
 	h.logger.Info("report generated successfully",
 		"report_id", report.ID,
 		"type", report.Type,
-		"format", req.Format,
+		"format", logging.SanitizeLogValue(string(req.Format)),
 		"generation_ms", report.Metadata.GenerationMS)
 }
 
@@ -423,7 +424,7 @@ func (h *Handler) parseTimeRange(r *http.Request) (interfaces.TimeRange, error) 
 		if parsedStart, err := time.Parse(time.RFC3339, startStr); err == nil {
 			start = parsedStart
 		} else {
-			return interfaces.TimeRange{}, fmt.Errorf("invalid start time format: %s", startStr)
+			return interfaces.TimeRange{}, fmt.Errorf("invalid start time format: %s", html.EscapeString(startStr))
 		}
 	}
 
@@ -431,7 +432,7 @@ func (h *Handler) parseTimeRange(r *http.Request) (interfaces.TimeRange, error) 
 		if parsedEnd, err := time.Parse(time.RFC3339, endStr); err == nil {
 			end = parsedEnd
 		} else {
-			return interfaces.TimeRange{}, fmt.Errorf("invalid end time format: %s", endStr)
+			return interfaces.TimeRange{}, fmt.Errorf("invalid end time format: %s", html.EscapeString(endStr))
 		}
 	}
 

--- a/features/reports/engine/engine.go
+++ b/features/reports/engine/engine.go
@@ -85,8 +85,8 @@ func (e *Engine) GenerateReport(ctx context.Context, req interfaces.ReportReques
 	if e.config.CacheEnabled {
 		if cached, err := e.cache.Get(ctx, cacheKey); err == nil && cached != nil {
 			e.logger.Info("report cache hit",
-				"request_type", req.Type,
-				"template", req.Template,
+				"request_type", logging.SanitizeLogValue(string(req.Type)),
+				"template", logging.SanitizeLogValue(req.Template),
 				"cache_key", cacheKey)
 
 			cached.Metadata.CacheHit = true
@@ -127,8 +127,8 @@ func (e *Engine) GenerateReport(ctx context.Context, req interfaces.ReportReques
 	}
 
 	e.logger.Info("report generated successfully",
-		"type", req.Type,
-		"template", req.Template,
+		"type", logging.SanitizeLogValue(string(req.Type)),
+		"template", logging.SanitizeLogValue(req.Template),
 		"devices", len(reportData.DNARecords),
 		"generation_ms", generationTime.Milliseconds())
 

--- a/features/reports/exporters/exporter.go
+++ b/features/reports/exporters/exporter.go
@@ -56,7 +56,7 @@ func (e *MultiFormatExporter) WithConfig(config Config) *MultiFormatExporter {
 
 // Export exports a report in the specified format
 func (e *MultiFormatExporter) Export(ctx context.Context, report *interfaces.Report, format interfaces.ExportFormat) ([]byte, error) {
-	e.logger.Debug("exporting report", "format", format, "report_id", report.ID)
+	e.logger.Debug("exporting report", "format", logging.SanitizeLogValue(string(format)), "report_id", report.ID)
 
 	switch format {
 	case interfaces.FormatJSON:

--- a/features/reports/provider/provider.go
+++ b/features/reports/provider/provider.go
@@ -54,7 +54,7 @@ func (p *DataProvider) GetDNAData(ctx context.Context, query interfaces.DataQuer
 
 			historyResult, err := p.storageManager.GetHistory(ctx, deviceID, options)
 			if err != nil {
-				p.logger.Warn("failed to get DNA history for device", "device_id", deviceID, "error", err)
+				p.logger.Warn("failed to get DNA history for device", "device_id", logging.SanitizeLogValue(deviceID), "error", err)
 				continue
 			}
 
@@ -120,7 +120,7 @@ func (p *DataProvider) GetDeviceStats(ctx context.Context, deviceIDs []string, t
 	for _, deviceID := range deviceIDs {
 		deviceStats, err := p.calculateDeviceStats(ctx, deviceID, timeRange)
 		if err != nil {
-			p.logger.Warn("failed to calculate stats for device", "device_id", deviceID, "error", err)
+			p.logger.Warn("failed to calculate stats for device", "device_id", logging.SanitizeLogValue(deviceID), "error", err)
 			continue
 		}
 		stats[deviceID] = deviceStats

--- a/features/reports/templates/processor.go
+++ b/features/reports/templates/processor.go
@@ -50,7 +50,7 @@ func (p *Processor) ProcessTemplate(ctx context.Context, templateName string, da
 	}
 
 	p.logger.Debug("processing template",
-		"template", templateName,
+		"template", logging.SanitizeLogValue(templateName),
 		"type", template.Type,
 		"dna_records", len(data.DNARecords),
 		"drift_events", len(data.DriftEvents))

--- a/features/steward/dna/storage/indexer.go
+++ b/features/steward/dna/storage/indexer.go
@@ -173,7 +173,7 @@ func (i *MemoryIndexer) QueryRecords(ctx context.Context, deviceID string, optio
 	result := filteredRecords[start_idx:end_idx]
 
 	i.logger.Debug("DNA records queried",
-		"device_id", deviceID,
+		"device_id", logging.SanitizeLogValue(deviceID),
 		"total_found", totalCount,
 		"returned", len(result),
 		"query_time", time.Since(start))

--- a/features/steward/dna/storage/storage.go
+++ b/features/steward/dna/storage/storage.go
@@ -353,7 +353,7 @@ func (m *Manager) GetHistory(ctx context.Context, deviceID string, options *Quer
 	}
 
 	m.logger.Debug("DNA history retrieved",
-		"device_id", deviceID,
+		"device_id", logging.SanitizeLogValue(deviceID),
 		"records_found", len(records),
 		"total_count", totalCount,
 		"execution_time", executionTime,

--- a/pkg/transport/quic/dialer_test.go
+++ b/pkg/transport/quic/dialer_test.go
@@ -5,7 +5,6 @@ package quic
 
 import (
 	"context"
-	"net"
 	"testing"
 	"time"
 
@@ -38,7 +37,6 @@ func TestDialer_ReturnsNetConn(t *testing.T) {
 	// doesn't leak waiting in AcceptStream.
 	_, _ = conn.Write([]byte{0x00})
 
-	var _ net.Conn = conn
 	assert.NotNil(t, conn.LocalAddr())
 	assert.NotNil(t, conn.RemoteAddr())
 
@@ -51,9 +49,6 @@ func TestDialer_NewDialer_ContextDialer(t *testing.T) {
 	tlsPair := newTestTLSPair(t)
 
 	dialFn := NewDialer(tlsPair.client, nil)
-
-	// Verify the function signature matches grpc.WithContextDialer expectation.
-	var _ func(ctx context.Context, addr string) (net.Conn, error) = dialFn
 
 	lis, err := Listen("127.0.0.1:0", tlsPair.server, nil)
 	require.NoError(t, err)

--- a/pkg/transport/quic/integration_test.go
+++ b/pkg/transport/quic/integration_test.go
@@ -225,9 +225,8 @@ func startEchoServer(t *testing.T, tlsPair *testTLSPair) (*grpc.Server, string) 
 	srv.RegisterService(&echoServiceDesc, &echoServer{})
 
 	go func() {
-		if serveErr := srv.Serve(lis); serveErr != nil {
-			// Serve returns an error when the listener is closed.
-		}
+		// Serve returns an error when the listener is closed; ignore it.
+		_ = srv.Serve(lis)
 	}()
 
 	t.Cleanup(func() {


### PR DESCRIPTION
## Summary

Resolves 24 CodeQL security alerts across 3 categories: 20 log-injection
(CWE-117, HIGH), 3 path-injection (CWE-22, HIGH), and 1 reflected XSS
(CWE-79, MEDIUM). All fixes wire up existing security utilities — no new
infrastructure needed.

## Problem Context

CodeQL code scanning reported 24 open alerts in `features/` business logic
code. User-provided values (format, template, deviceID, time ranges) were
logged without sanitization (log forging). File paths were joined without
traversal validation. Raw query params were reflected in error messages
without HTML escaping.

## Changes

- Sanitize 12 log statements across 7 files with `logging.SanitizeLogValue()`
- Validate file paths in 3 git storage methods with `security.ValidateAndCleanPath()`
- Escape user query params in 2 error messages with `html.EscapeString()`
- Fix pre-existing lint issues in transport test files (gofmt, staticcheck)

## Files Changed

| Category | Files |
|----------|-------|
| Log injection | `features/reports/api/handlers.go`, `engine/engine.go`, `exporters/exporter.go`, `provider/provider.go`, `templates/processor.go`, `features/steward/dna/storage/indexer.go`, `storage.go` |
| Path injection | `features/config/git/storage/local.go` |
| Reflected XSS | `features/reports/api/handlers.go` |
| Lint fixes | `api/proto/transport/transport_test.go`, `pkg/transport/quic/dialer_test.go`, `integration_test.go` |

## Testing

- All quality validation gates passed (make test-quality)
- Unit tests: ~75 packages, all passing with race detection
- Cross-platform builds: linux/amd64, linux/arm64, darwin/amd64, darwin/arm64, windows/amd64
- Docker integration tests: storage + controller passing
- Linting: 0 issues
- Security scans: all passed (Trivy, Nancy, gosec, staticcheck)
- Architecture compliance: no violations

## Review Summary

| Reviewer | Result |
|----------|--------|
| QA Test Runner | PASS — all quality gates passed |
| QA Code Reviewer | PASS — no issues in files changed by this PR |
| Security Engineer | PASS — 0 blocking issues, 3 low/medium warnings (pre-existing) |

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>