### PR TITLE
fix: resolve remaining 8 CodeQL code scanning alerts

### DIFF
--- a/features/rbac/authdefense/ip_rate_limiter.go
+++ b/features/rbac/authdefense/ip_rate_limiter.go
@@ -65,6 +65,7 @@ func NewIPRateLimiter(cfg AuthDefenseConfig, clock Clock) *IPRateLimiter {
 		DefaultTTL:      cfg.IPRateWindow * 2, // keep entries alive a bit beyond window
 		CleanupInterval: cfg.IPRateWindow,
 		EvictionPolicy:  cache.EvictionLRU,
+		Clock:           clock, // share clock with cache for deterministic LRU ordering
 	})
 
 	return &IPRateLimiter{

--- a/features/rbac/authdefense/ip_rate_limiter_test.go
+++ b/features/rbac/authdefense/ip_rate_limiter_test.go
@@ -114,17 +114,22 @@ func TestIPRateLimiter_LRUEviction(t *testing.T) {
 	limiter := NewIPRateLimiter(cfg, clock)
 	defer limiter.Close()
 
-	// Fill cache beyond max tracked
+	// Fill cache beyond max tracked, advancing clock between each to ensure
+	// distinct timestamps for deterministic LRU ordering (Windows has ~15ms
+	// time.Now() resolution which caused flaky eviction order).
 	for i := 0; i < 20; i++ {
 		ip := fmt.Sprintf("10.0.0.%d", i)
 		limiter.RecordFailure(ip)
+		clock.Advance(1 * time.Millisecond)
 	}
 
-	// Most recent IPs should still be tracked
+	// Most recent IPs should still be tracked (they have the newest timestamps)
 	assert.True(t, limiter.IsRateLimited("10.0.0.19"))
+	assert.True(t, limiter.IsRateLimited("10.0.0.15"))
 
-	// Earliest IPs may have been evicted (LRU) — exact behavior depends on cache eviction
-	// We just verify no panic and that recent entries work
+	// Earliest IPs should have been evicted (LRU)
+	assert.False(t, limiter.IsRateLimited("10.0.0.0"))
+	assert.False(t, limiter.IsRateLimited("10.0.0.5"))
 }
 
 func TestIPRateLimiter_ConcurrentAccess(t *testing.T) {

--- a/features/reports/api/handlers.go
+++ b/features/reports/api/handlers.go
@@ -68,7 +68,7 @@ func (h *Handler) generateReport(w http.ResponseWriter, r *http.Request) {
 	// Generate the report
 	report, err := h.engine.GenerateReport(r.Context(), req)
 	if err != nil {
-		h.logger.Error("failed to generate report", "error", err, "format", logging.SanitizeLogValue(string(req.Format)))
+		h.logger.Error("failed to generate report", "error", logging.SanitizeLogValue(err.Error()), "format", logging.SanitizeLogValue(string(req.Format)))
 		h.writeError(w, http.StatusInternalServerError, "Failed to generate report", err)
 		return
 	}
@@ -76,12 +76,13 @@ func (h *Handler) generateReport(w http.ResponseWriter, r *http.Request) {
 	// Export in requested format
 	exportData, err := h.exporter.Export(r.Context(), report, req.Format)
 	if err != nil {
-		h.logger.Error("failed to export report", "error", err, "format", logging.SanitizeLogValue(string(req.Format)))
+		h.logger.Error("failed to export report", "error", logging.SanitizeLogValue(err.Error()), "format", logging.SanitizeLogValue(string(req.Format)))
 		h.writeError(w, http.StatusInternalServerError, "Failed to export report", err)
 		return
 	}
 
-	// Set appropriate content type and headers
+	// Set appropriate content type and headers (nosniff prevents MIME-type sniffing XSS)
+	w.Header().Set("X-Content-Type-Options", "nosniff")
 	h.setExportHeaders(w, req.Format, report.ID)
 	if _, err := w.Write(exportData); err != nil {
 		h.logger.Error("failed to write export data", "error", err)
@@ -89,8 +90,8 @@ func (h *Handler) generateReport(w http.ResponseWriter, r *http.Request) {
 	}
 
 	h.logger.Info("report generated successfully",
-		"report_id", report.ID,
-		"type", report.Type,
+		"report_id", logging.SanitizeLogValue(report.ID),
+		"type", logging.SanitizeLogValue(string(report.Type)),
 		"format", logging.SanitizeLogValue(string(req.Format)),
 		"generation_ms", report.Metadata.GenerationMS)
 }

--- a/features/reports/exporters/exporter.go
+++ b/features/reports/exporters/exporter.go
@@ -56,7 +56,7 @@ func (e *MultiFormatExporter) WithConfig(config Config) *MultiFormatExporter {
 
 // Export exports a report in the specified format
 func (e *MultiFormatExporter) Export(ctx context.Context, report *interfaces.Report, format interfaces.ExportFormat) ([]byte, error) {
-	e.logger.Debug("exporting report", "format", logging.SanitizeLogValue(string(format)), "report_id", report.ID)
+	e.logger.Debug("exporting report", "format", logging.SanitizeLogValue(string(format)), "report_id", logging.SanitizeLogValue(report.ID))
 
 	switch format {
 	case interfaces.FormatJSON:

--- a/features/reports/provider/provider.go
+++ b/features/reports/provider/provider.go
@@ -70,7 +70,7 @@ func (p *DataProvider) GetDNAData(ctx context.Context, query interfaces.DataQuer
 
 	p.logger.Debug("retrieved DNA records",
 		"count", len(allRecords),
-		"time_range", fmt.Sprintf("%v to %v", query.TimeRange.Start, query.TimeRange.End),
+		"time_range", logging.SanitizeLogValue(fmt.Sprintf("%v to %v", query.TimeRange.Start, query.TimeRange.End)),
 		"devices", len(query.DeviceIDs))
 
 	return allRecords, nil
@@ -83,7 +83,7 @@ func (p *DataProvider) GetDriftEvents(ctx context.Context, query interfaces.Data
 	// This is a limitation that would need to be addressed in the drift detection system.
 
 	p.logger.Debug("drift event querying not fully implemented - returning empty results",
-		"time_range", fmt.Sprintf("%v to %v", query.TimeRange.Start, query.TimeRange.End))
+		"time_range", logging.SanitizeLogValue(fmt.Sprintf("%v to %v", query.TimeRange.Start, query.TimeRange.End)))
 
 	// Return empty slice for now
 	return []drift.DriftEvent{}, nil

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -19,6 +19,20 @@ type Cache struct {
 	stopCleanup chan struct{}
 	cleanupDone *sync.WaitGroup
 	closeOnce   sync.Once
+	accessSeq   uint64 // monotonic counter for deterministic LRU ordering
+}
+
+// now returns the current time using the configured clock, or time.Now() if no clock is set.
+func (c *Cache) now() time.Time {
+	if c.config.Clock != nil {
+		return c.config.Clock.Now()
+	}
+	return time.Now()
+}
+
+// isExpired checks if the cache entry has expired using the cache's clock.
+func (c *Cache) isExpired(e *CacheEntry) bool {
+	return c.now().After(e.ExpiresAt)
 }
 
 // NewCache creates a new general-purpose cache with the specified configuration
@@ -53,13 +67,15 @@ func (c *Cache) Get(key string) (interface{}, bool) {
 	}
 
 	// Check expiration
-	if entry.IsExpired() {
+	if c.isExpired(entry) {
 		c.stats.Misses++
 		return nil, false
 	}
 
 	// Update access tracking for LRU/LFU eviction
-	entry.LastAccessed = time.Now()
+	entry.LastAccessed = c.now()
+	c.accessSeq++
+	entry.LastAccessSeq = c.accessSeq
 	entry.AccessCount++
 
 	c.stats.Hits++
@@ -76,13 +92,15 @@ func (c *Cache) Set(key string, value interface{}, ttl time.Duration) error {
 		ttl = c.config.DefaultTTL
 	}
 
-	now := time.Now()
+	now := c.now()
+	c.accessSeq++
 	c.items[key] = &CacheEntry{
-		Value:        value,
-		ExpiresAt:    now.Add(ttl),
-		CreatedAt:    now,
-		LastAccessed: now,
-		AccessCount:  0,
+		Value:         value,
+		ExpiresAt:     now.Add(ttl),
+		CreatedAt:     now,
+		LastAccessed:  now,
+		LastAccessSeq: c.accessSeq,
+		AccessCount:   0,
 	}
 
 	// Enforce size limits
@@ -163,11 +181,13 @@ func (c *Cache) GetMany(keys []string) map[string]interface{} {
 	defer c.mutex.Unlock()
 
 	result := make(map[string]interface{})
-	now := time.Now()
+	now := c.now()
 	for _, key := range keys {
-		if entry, exists := c.items[key]; exists && !entry.IsExpired() {
+		if entry, exists := c.items[key]; exists && !c.isExpired(entry) {
 			// Update access tracking for LRU/LFU eviction
 			entry.LastAccessed = now
+			c.accessSeq++
+			entry.LastAccessSeq = c.accessSeq
 			entry.AccessCount++
 
 			result[key] = entry.Value
@@ -190,15 +210,17 @@ func (c *Cache) SetMany(items map[string]interface{}, ttl time.Duration) error {
 		ttl = c.config.DefaultTTL
 	}
 
-	now := time.Now()
+	now := c.now()
 	expiresAt := now.Add(ttl)
 	for key, value := range items {
+		c.accessSeq++
 		c.items[key] = &CacheEntry{
-			Value:        value,
-			ExpiresAt:    expiresAt,
-			CreatedAt:    now,
-			LastAccessed: now,
-			AccessCount:  0,
+			Value:         value,
+			ExpiresAt:     expiresAt,
+			CreatedAt:     now,
+			LastAccessed:  now,
+			LastAccessSeq: c.accessSeq,
+			AccessCount:   0,
 		}
 	}
 
@@ -251,11 +273,11 @@ func (c *Cache) cleanupExpiredItems() {
 	c.mutex.Lock()
 	defer c.mutex.Unlock()
 
-	now := time.Now()
+	now := c.now()
 	expired := int64(0)
 
 	for key, entry := range c.items {
-		if entry.IsExpired() {
+		if c.isExpired(entry) {
 			delete(c.items, key)
 			expired++
 		}
@@ -326,23 +348,24 @@ func (c *Cache) evictFIFO(count int) {
 	c.stats.Evictions += int64(count)
 }
 
-// evictLRU removes the least recently accessed items
+// evictLRU removes the least recently accessed items using monotonic sequence
+// numbers for deterministic ordering regardless of clock resolution.
 func (c *Cache) evictLRU(count int) {
 	type entry struct {
-		key          string
-		lastAccessed time.Time
+		key       string
+		accessSeq uint64
 	}
 
-	// Collect all entries with last access times
+	// Collect all entries with access sequence numbers
 	entries := make([]entry, 0, len(c.items))
 	for key, item := range c.items {
-		entries = append(entries, entry{key: key, lastAccessed: item.LastAccessed})
+		entries = append(entries, entry{key: key, accessSeq: item.LastAccessSeq})
 	}
 
-	// Sort by last access time (least recently accessed first)
+	// Sort by access sequence (lowest sequence = least recently accessed)
 	for i := 0; i < len(entries)-1; i++ {
 		for j := i + 1; j < len(entries); j++ {
-			if entries[i].lastAccessed.After(entries[j].lastAccessed) {
+			if entries[i].accessSeq > entries[j].accessSeq {
 				entries[i], entries[j] = entries[j], entries[i]
 			}
 		}

--- a/pkg/cache/runtime.go
+++ b/pkg/cache/runtime.go
@@ -13,6 +13,12 @@ import (
 	"github.com/cfgis/cfgms/pkg/storage/interfaces"
 )
 
+// Clock abstracts time operations for deterministic testing of cache behavior.
+// When nil in CacheConfig, the cache defaults to using time.Now().
+type Clock interface {
+	Now() time.Time
+}
+
 // CacheConfig defines configuration for the runtime cache
 type CacheConfig struct {
 	// Name identifies the cache instance (for logging/debugging)
@@ -28,6 +34,9 @@ type CacheConfig struct {
 
 	// Eviction strategy when cache is full
 	EvictionPolicy EvictionPolicy // FIFO, LRU, or LFU eviction policy
+
+	// Clock provides time for expiration and LRU tracking. If nil, uses time.Now().
+	Clock Clock
 }
 
 // DefaultCacheConfig returns a sensible default configuration
@@ -56,14 +65,16 @@ const (
 
 // CacheEntry represents a cached item with expiration and access tracking
 type CacheEntry struct {
-	Value        interface{}
-	ExpiresAt    time.Time
-	CreatedAt    time.Time // When the entry was created
-	LastAccessed time.Time // When the entry was last accessed (for LRU)
-	AccessCount  int64     // Number of times accessed (for LFU)
+	Value         interface{}
+	ExpiresAt     time.Time
+	CreatedAt     time.Time // When the entry was created
+	LastAccessed  time.Time // When the entry was last accessed (for LRU)
+	LastAccessSeq uint64    // Monotonic sequence number for deterministic LRU ordering
+	AccessCount   int64     // Number of times accessed (for LFU)
 }
 
-// IsExpired checks if the cache entry has expired
+// IsExpired checks if the cache entry has expired using the system clock.
+// For clock-aware expiration checking, use Cache.isExpired() instead.
 func (e *CacheEntry) IsExpired() bool {
 	return time.Now().After(e.ExpiresAt)
 }

--- a/pkg/transport/quic/tls_test.go
+++ b/pkg/transport/quic/tls_test.go
@@ -363,7 +363,7 @@ func TestGRPCOverQUIC_mTLS_NoCert(t *testing.T) {
 		// Dial itself failed — server rejected immediately.
 		return
 	}
-	defer conn.Close()
+	defer func() { _ = conn.Close() }()
 
 	// Write data to trigger the server to process our (absent) certificate.
 	_, _ = conn.Write([]byte{0x00})
@@ -424,7 +424,7 @@ func TestGRPCOverQUIC_mTLS_WrongCA(t *testing.T) {
 	if dialErr != nil {
 		return
 	}
-	defer conn.Close()
+	defer func() { _ = conn.Close() }()
 
 	_, _ = conn.Write([]byte{0x00})
 	time.Sleep(100 * time.Millisecond)


### PR DESCRIPTION
## Summary

Resolves the 8 remaining CodeQL code scanning alerts (7 log-injection, 1 reflected-XSS)
in the reports feature that were missed by PR #501. Also fixes deterministic LRU cache
eviction that was failing on Windows CI due to 15ms timer resolution.

## Problem Context

After PR #501 merged, 8 CodeQL alerts remained open on `develop`:
- **7 high-severity log-injection** in `features/reports/api/handlers.go`,
  `features/reports/exporters/exporter.go`, `features/reports/provider/provider.go`
- **1 medium-severity reflected-XSS** in `features/reports/api/handlers.go`

These were caused by user-influenced values (`report.ID`, `report.Type`, error messages,
time range parameters) being logged or written to HTTP responses without sanitization.

Additionally, the `TestIPRateLimiter_LRUEviction` test failed on Windows CI because
`pkg/cache` used `time.Now()` for LRU ordering. Windows has ~15ms timer resolution,
so entries inserted within the same tick received identical timestamps, causing
non-deterministic eviction order.

## Changes

- Sanitize `err.Error()` in report generation/export error log calls (handlers.go)
- Sanitize `report.ID` and `report.Type` in success log calls (handlers.go, exporter.go)
- Sanitize time range strings in provider debug log calls (provider.go)
- Add `X-Content-Type-Options: nosniff` header to prevent MIME-sniffing XSS (handlers.go)
- Fix errcheck lint violations in `defer conn.Close()` calls (tls_test.go)
- Add monotonic `accessSeq` counter to `pkg/cache` for deterministic LRU eviction
- Add `Clock` interface to `CacheConfig` for testable time operations
- Pass test clock from `IPRateLimiter` to cache for deterministic ordering

## CodeQL Alerts Addressed

| Alert | Severity | Rule | File | Fix |
|-------|----------|------|------|-----|
| #470 | High | log-injection | handlers.go:71 | Sanitize err.Error() |
| #471 | High | log-injection | handlers.go:79 | Sanitize err.Error() |
| #473 | High | log-injection | handlers.go:92 | Sanitize report.ID |
| #474 | High | log-injection | handlers.go:93 | Sanitize report.Type |
| #472 | High | log-injection | exporter.go:59 | Sanitize report.ID |
| #463 | High | log-injection | provider.go:73 | Sanitize time range |
| #464 | High | log-injection | provider.go:86 | Sanitize time range |
| #448 | Medium | reflected-xss | handlers.go:86 | Add nosniff header |

## Testing

### Review Team Results
- **QA Test Runner**: PASS - 102 packages, all passing (unit tests, lint, production-critical, cross-platform builds, Docker integration)
- **QA Code Reviewer**: PASS - 0 blocking issues, 1 warning (missing assertion in concurrency test, non-blocking)
- **Security Engineer**: PASS - all automated scans passed (security-precommit, check-architecture, security-scan), manual review confirmed all tainted values sanitized

### Key Test Results
- Privilege escalation: 523/523 attacks blocked (100%)
- Certificate registration: 16/16 subtests passed
- Cross-platform compilation: linux/amd64, linux/arm64, darwin/amd64, darwin/arm64, windows/amd64

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>