### PR TITLE
fix: force download for HTML report exports to prevent reflected XSS

### DIFF
--- a/features/reports/api/handlers.go
+++ b/features/reports/api/handlers.go
@@ -488,6 +488,7 @@ func (h *Handler) setExportHeaders(w http.ResponseWriter, format interfaces.Expo
 		w.Header().Set("Content-Disposition", fmt.Sprintf("attachment; filename=\"report_%s.csv\"", reportID))
 	case interfaces.FormatHTML:
 		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		w.Header().Set("Content-Disposition", fmt.Sprintf("attachment; filename=\"report_%s.html\"", reportID))
 	case interfaces.FormatPDF:
 		w.Header().Set("Content-Type", "application/pdf")
 		w.Header().Set("Content-Disposition", fmt.Sprintf("attachment; filename=\"report_%s.pdf\"", reportID))


### PR DESCRIPTION
## Summary

Resolves the last remaining CodeQL code scanning alert (#448) — reflected XSS in
HTML report exports. Forces browser to download HTML exports instead of rendering
inline, eliminating the XSS vector.

## Problem Context

PR #502 added `X-Content-Type-Options: nosniff` to prevent MIME-sniffing XSS, but
CodeQL still flagged `w.Write(exportData)` because the `Content-Type` is explicitly
set to `text/html; charset=utf-8` for HTML format. The `nosniff` header prevents
*sniffing* but does not prevent rendering when the content type already declares HTML.

CSV, PDF, and Excel formats already use `Content-Disposition: attachment` to force
download. HTML was the only format missing this header.

## Changes

- Add `Content-Disposition: attachment` header for HTML export format in `setExportHeaders`

## Testing

- `go test ./features/reports/...` — all passing
- One-line change consistent with existing pattern for CSV/PDF/Excel formats

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>