### PR TITLE
transport: gRPC ControlPlaneProvider — replace MQTT with gRPC-over-QUIC (Issue #504)

### DIFF
--- a/pkg/controlplane/providers/grpc/convert.go
+++ b/pkg/controlplane/providers/grpc/convert.go
@@ -1,0 +1,284 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+
+package grpc
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	transportpb "github.com/cfgis/cfgms/api/proto/transport"
+	"github.com/cfgis/cfgms/pkg/controlplane/types"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+// --- Command conversion ---
+
+// commandTypeToProto maps semantic CommandType to proto enum.
+var commandTypeToProto = map[types.CommandType]transportpb.CommandType{
+	types.CommandSyncConfig:       transportpb.CommandType_COMMAND_TYPE_SYNC_CONFIG,
+	types.CommandSyncDNA:          transportpb.CommandType_COMMAND_TYPE_SYNC_DNA,
+	types.CommandConnectDataPlane: transportpb.CommandType_COMMAND_TYPE_CONNECT_DATAPLANE,
+	types.CommandValidateConfig:   transportpb.CommandType_COMMAND_TYPE_VALIDATE_CONFIG,
+	types.CommandExecuteTask:      transportpb.CommandType_COMMAND_TYPE_EXECUTE_TASK,
+	types.CommandShutdown:         transportpb.CommandType_COMMAND_TYPE_SHUTDOWN,
+}
+
+// protoToCommandType maps proto enum to semantic CommandType.
+var protoToCommandType = map[transportpb.CommandType]types.CommandType{
+	transportpb.CommandType_COMMAND_TYPE_SYNC_CONFIG:       types.CommandSyncConfig,
+	transportpb.CommandType_COMMAND_TYPE_SYNC_DNA:          types.CommandSyncDNA,
+	transportpb.CommandType_COMMAND_TYPE_CONNECT_DATAPLANE: types.CommandConnectDataPlane,
+	transportpb.CommandType_COMMAND_TYPE_VALIDATE_CONFIG:   types.CommandValidateConfig,
+	transportpb.CommandType_COMMAND_TYPE_EXECUTE_TASK:      types.CommandExecuteTask,
+	transportpb.CommandType_COMMAND_TYPE_SHUTDOWN:          types.CommandShutdown,
+}
+
+func commandToProto(cmd *types.Command) *transportpb.Command {
+	if cmd == nil {
+		return nil
+	}
+	pb := &transportpb.Command{
+		Id:        cmd.ID,
+		Type:      commandTypeToProto[cmd.Type],
+		StewardId: cmd.StewardID,
+		TenantId:  cmd.TenantID,
+		Timestamp: timestamppb.New(cmd.Timestamp),
+		Priority:  int32(cmd.Priority),
+	}
+	if len(cmd.Params) > 0 {
+		pb.Params = interfaceMapToStringMap(cmd.Params)
+	}
+	return pb
+}
+
+func commandFromProto(pb *transportpb.Command) *types.Command {
+	if pb == nil {
+		return nil
+	}
+	cmd := &types.Command{
+		ID:        pb.GetId(),
+		Type:      protoToCommandType[pb.GetType()],
+		StewardID: pb.GetStewardId(),
+		TenantID:  pb.GetTenantId(),
+		Timestamp: protoTimestampToTime(pb.GetTimestamp()),
+		Priority:  int(pb.GetPriority()),
+	}
+	if len(pb.GetParams()) > 0 {
+		cmd.Params = stringMapToInterfaceMap(pb.GetParams())
+	}
+	return cmd
+}
+
+// --- Event conversion ---
+
+// eventTypeToProto maps semantic EventType to proto enum.
+var eventTypeToProto = map[types.EventType]transportpb.EventType{
+	types.EventConfigApplied: transportpb.EventType_EVENT_TYPE_CONFIG_APPLIED,
+	types.EventDNASynced:     transportpb.EventType_EVENT_TYPE_DNA_SYNCED,
+	types.EventTaskCompleted: transportpb.EventType_EVENT_TYPE_TASK_COMPLETED,
+	types.EventTaskFailed:    transportpb.EventType_EVENT_TYPE_TASK_FAILED,
+	types.EventError:         transportpb.EventType_EVENT_TYPE_ERROR,
+}
+
+// protoToEventType maps proto enum to semantic EventType.
+var protoToEventType = map[transportpb.EventType]types.EventType{
+	transportpb.EventType_EVENT_TYPE_CONFIG_APPLIED: types.EventConfigApplied,
+	transportpb.EventType_EVENT_TYPE_DNA_SYNCED:     types.EventDNASynced,
+	transportpb.EventType_EVENT_TYPE_TASK_COMPLETED: types.EventTaskCompleted,
+	transportpb.EventType_EVENT_TYPE_TASK_FAILED:    types.EventTaskFailed,
+	transportpb.EventType_EVENT_TYPE_ERROR:          types.EventError,
+}
+
+// severityToProto maps semantic severity string to proto enum.
+var severityToProto = map[string]transportpb.Severity{
+	"info":     transportpb.Severity_SEVERITY_INFO,
+	"warning":  transportpb.Severity_SEVERITY_WARNING,
+	"error":    transportpb.Severity_SEVERITY_ERROR,
+	"critical": transportpb.Severity_SEVERITY_CRITICAL,
+}
+
+// protoToSeverity maps proto enum to semantic severity string.
+var protoToSeverity = map[transportpb.Severity]string{
+	transportpb.Severity_SEVERITY_INFO:     "info",
+	transportpb.Severity_SEVERITY_WARNING:  "warning",
+	transportpb.Severity_SEVERITY_ERROR:    "error",
+	transportpb.Severity_SEVERITY_CRITICAL: "critical",
+}
+
+func eventToProto(event *types.Event) *transportpb.Event {
+	if event == nil {
+		return nil
+	}
+	pb := &transportpb.Event{
+		Id:        event.ID,
+		Type:      eventTypeToProto[event.Type],
+		StewardId: event.StewardID,
+		TenantId:  event.TenantID,
+		Timestamp: timestamppb.New(event.Timestamp),
+		CommandId: event.CommandID,
+		Severity:  severityToProto[event.Severity],
+	}
+	if len(event.Details) > 0 {
+		pb.Details = interfaceMapToStringMap(event.Details)
+	}
+	return pb
+}
+
+func eventFromProto(pb *transportpb.Event) *types.Event {
+	if pb == nil {
+		return nil
+	}
+	event := &types.Event{
+		ID:        pb.GetId(),
+		Type:      protoToEventType[pb.GetType()],
+		StewardID: pb.GetStewardId(),
+		TenantID:  pb.GetTenantId(),
+		Timestamp: protoTimestampToTime(pb.GetTimestamp()),
+		CommandID: pb.GetCommandId(),
+		Severity:  protoToSeverity[pb.GetSeverity()],
+	}
+	if len(pb.GetDetails()) > 0 {
+		event.Details = stringMapToInterfaceMap(pb.GetDetails())
+	}
+	return event
+}
+
+// --- Heartbeat conversion ---
+
+// heartbeatStatusToProto maps semantic HeartbeatStatus to proto enum.
+var heartbeatStatusToProto = map[types.HeartbeatStatus]transportpb.StewardStatus{
+	types.StatusHealthy:      transportpb.StewardStatus_STEWARD_STATUS_HEALTHY,
+	types.StatusDegraded:     transportpb.StewardStatus_STEWARD_STATUS_DEGRADED,
+	types.StatusError:        transportpb.StewardStatus_STEWARD_STATUS_ERROR,
+	types.StatusDisconnected: transportpb.StewardStatus_STEWARD_STATUS_DISCONNECTED,
+}
+
+// protoToHeartbeatStatus maps proto enum to semantic HeartbeatStatus.
+var protoToHeartbeatStatus = map[transportpb.StewardStatus]types.HeartbeatStatus{
+	transportpb.StewardStatus_STEWARD_STATUS_HEALTHY:      types.StatusHealthy,
+	transportpb.StewardStatus_STEWARD_STATUS_DEGRADED:     types.StatusDegraded,
+	transportpb.StewardStatus_STEWARD_STATUS_ERROR:        types.StatusError,
+	transportpb.StewardStatus_STEWARD_STATUS_DISCONNECTED: types.StatusDisconnected,
+}
+
+func heartbeatToProto(hb *types.Heartbeat) *transportpb.Heartbeat {
+	if hb == nil {
+		return nil
+	}
+	pb := &transportpb.Heartbeat{
+		StewardId: hb.StewardID,
+		TenantId:  hb.TenantID,
+		Status:    heartbeatStatusToProto[hb.Status],
+		Timestamp: timestamppb.New(hb.Timestamp),
+		Version:   hb.Version,
+	}
+	if len(hb.Metrics) > 0 {
+		pb.Metrics = interfaceMapToStringMap(hb.Metrics)
+	}
+	return pb
+}
+
+func heartbeatFromProto(pb *transportpb.Heartbeat) *types.Heartbeat {
+	if pb == nil {
+		return nil
+	}
+	hb := &types.Heartbeat{
+		StewardID: pb.GetStewardId(),
+		TenantID:  pb.GetTenantId(),
+		Status:    protoToHeartbeatStatus[pb.GetStatus()],
+		Timestamp: protoTimestampToTime(pb.GetTimestamp()),
+		Version:   pb.GetVersion(),
+	}
+	if len(pb.GetMetrics()) > 0 {
+		hb.Metrics = stringMapToInterfaceMap(pb.GetMetrics())
+	}
+	return hb
+}
+
+// --- Response conversion ---
+
+func responseToProto(resp *types.Response) *transportpb.Response {
+	if resp == nil {
+		return nil
+	}
+	pb := &transportpb.Response{
+		CommandId: resp.CommandID,
+		StewardId: resp.StewardID,
+		Success:   resp.Success,
+		Message:   resp.Message,
+		Timestamp: timestamppb.New(resp.Timestamp),
+	}
+	if len(resp.Details) > 0 {
+		pb.Details = interfaceMapToStringMap(resp.Details)
+	}
+	return pb
+}
+
+func responseFromProto(pb *transportpb.Response) *types.Response {
+	if pb == nil {
+		return nil
+	}
+	resp := &types.Response{
+		CommandID: pb.GetCommandId(),
+		StewardID: pb.GetStewardId(),
+		Success:   pb.GetSuccess(),
+		Message:   pb.GetMessage(),
+		Timestamp: protoTimestampToTime(pb.GetTimestamp()),
+	}
+	if len(pb.GetDetails()) > 0 {
+		resp.Details = stringMapToInterfaceMap(pb.GetDetails())
+	}
+	return resp
+}
+
+// --- Map conversion helpers ---
+
+// interfaceMapToStringMap converts map[string]interface{} to map[string]string.
+// String values are kept as-is; non-string values are JSON-serialized.
+func interfaceMapToStringMap(m map[string]interface{}) map[string]string {
+	result := make(map[string]string, len(m))
+	for k, v := range m {
+		switch val := v.(type) {
+		case string:
+			result[k] = val
+		default:
+			data, err := json.Marshal(val)
+			if err != nil {
+				result[k] = fmt.Sprintf("%v", val)
+			} else {
+				result[k] = string(data)
+			}
+		}
+	}
+	return result
+}
+
+// stringMapToInterfaceMap converts map[string]string to map[string]interface{}.
+// Values that are valid JSON are deserialized; plain strings are kept as-is.
+func stringMapToInterfaceMap(m map[string]string) map[string]interface{} {
+	result := make(map[string]interface{}, len(m))
+	for k, v := range m {
+		var parsed interface{}
+		if err := json.Unmarshal([]byte(v), &parsed); err == nil {
+			// Only use parsed value if it's not a plain string (avoids
+			// double-wrapping strings that happen to be valid JSON like "true").
+			if _, isString := parsed.(string); !isString {
+				result[k] = parsed
+				continue
+			}
+		}
+		result[k] = v
+	}
+	return result
+}
+
+// --- Timestamp helpers ---
+
+func protoTimestampToTime(ts *timestamppb.Timestamp) time.Time {
+	if ts == nil {
+		return time.Time{}
+	}
+	return ts.AsTime()
+}

--- a/pkg/controlplane/providers/grpc/convert_test.go
+++ b/pkg/controlplane/providers/grpc/convert_test.go
@@ -1,0 +1,428 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+
+package grpc
+
+import (
+	"testing"
+	"time"
+
+	"github.com/cfgis/cfgms/pkg/controlplane/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCommandRoundTrip(t *testing.T) {
+	now := time.Now().Truncate(time.Microsecond) // proto truncates to microseconds
+
+	tests := []struct {
+		name string
+		cmd  *types.Command
+	}{
+		{
+			name: "full command",
+			cmd: &types.Command{
+				ID:        "cmd-123",
+				Type:      types.CommandSyncConfig,
+				StewardID: "steward-1",
+				TenantID:  "tenant-1",
+				Timestamp: now,
+				Params: map[string]interface{}{
+					"version":  "1.2.3",
+					"priority": float64(10),
+					"nested":   map[string]interface{}{"key": "val"},
+				},
+				Priority: 5,
+			},
+		},
+		{
+			name: "minimal command",
+			cmd: &types.Command{
+				ID:        "cmd-456",
+				Type:      types.CommandShutdown,
+				Timestamp: now,
+			},
+		},
+		{
+			name: "nil params",
+			cmd: &types.Command{
+				ID:        "cmd-789",
+				Type:      types.CommandExecuteTask,
+				StewardID: "steward-2",
+				Timestamp: now,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pb := commandToProto(tt.cmd)
+			require.NotNil(t, pb)
+
+			result := commandFromProto(pb)
+			require.NotNil(t, result)
+
+			assert.Equal(t, tt.cmd.ID, result.ID)
+			assert.Equal(t, tt.cmd.Type, result.Type)
+			assert.Equal(t, tt.cmd.StewardID, result.StewardID)
+			assert.Equal(t, tt.cmd.TenantID, result.TenantID)
+			assert.Equal(t, tt.cmd.Timestamp.UTC(), result.Timestamp.UTC())
+			assert.Equal(t, tt.cmd.Priority, result.Priority)
+
+			if tt.cmd.Params != nil {
+				require.NotNil(t, result.Params)
+				// String values round-trip exactly
+				if v, ok := tt.cmd.Params["version"]; ok {
+					assert.Equal(t, v, result.Params["version"])
+				}
+			} else {
+				assert.Nil(t, result.Params)
+			}
+		})
+	}
+}
+
+func TestCommandNil(t *testing.T) {
+	assert.Nil(t, commandToProto(nil))
+	assert.Nil(t, commandFromProto(nil))
+}
+
+func TestCommandTypeRoundTrip(t *testing.T) {
+	allTypes := []types.CommandType{
+		types.CommandSyncConfig,
+		types.CommandSyncDNA,
+		types.CommandConnectDataPlane,
+		types.CommandValidateConfig,
+		types.CommandExecuteTask,
+		types.CommandShutdown,
+	}
+	for _, ct := range allTypes {
+		t.Run(string(ct), func(t *testing.T) {
+			pb := commandTypeToProto[ct]
+			result := protoToCommandType[pb]
+			assert.Equal(t, ct, result)
+		})
+	}
+}
+
+func TestEventRoundTrip(t *testing.T) {
+	now := time.Now().Truncate(time.Microsecond)
+
+	tests := []struct {
+		name  string
+		event *types.Event
+	}{
+		{
+			name: "full event",
+			event: &types.Event{
+				ID:        "evt-123",
+				Type:      types.EventConfigApplied,
+				StewardID: "steward-1",
+				TenantID:  "tenant-1",
+				Timestamp: now,
+				CommandID: "cmd-123",
+				Details:   map[string]interface{}{"modules": float64(5)},
+				Severity:  "warning",
+			},
+		},
+		{
+			name: "minimal event",
+			event: &types.Event{
+				ID:        "evt-456",
+				Type:      types.EventError,
+				StewardID: "steward-2",
+				Timestamp: now,
+				Severity:  "error",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pb := eventToProto(tt.event)
+			require.NotNil(t, pb)
+
+			result := eventFromProto(pb)
+			require.NotNil(t, result)
+
+			assert.Equal(t, tt.event.ID, result.ID)
+			assert.Equal(t, tt.event.Type, result.Type)
+			assert.Equal(t, tt.event.StewardID, result.StewardID)
+			assert.Equal(t, tt.event.TenantID, result.TenantID)
+			assert.Equal(t, tt.event.Timestamp.UTC(), result.Timestamp.UTC())
+			assert.Equal(t, tt.event.CommandID, result.CommandID)
+			assert.Equal(t, tt.event.Severity, result.Severity)
+		})
+	}
+}
+
+func TestEventNil(t *testing.T) {
+	assert.Nil(t, eventToProto(nil))
+	assert.Nil(t, eventFromProto(nil))
+}
+
+func TestEventTypeRoundTrip(t *testing.T) {
+	allTypes := []types.EventType{
+		types.EventConfigApplied,
+		types.EventDNASynced,
+		types.EventTaskCompleted,
+		types.EventTaskFailed,
+		types.EventError,
+	}
+	for _, et := range allTypes {
+		t.Run(string(et), func(t *testing.T) {
+			pb := eventTypeToProto[et]
+			result := protoToEventType[pb]
+			assert.Equal(t, et, result)
+		})
+	}
+}
+
+func TestSeverityRoundTrip(t *testing.T) {
+	allSeverities := []string{"info", "warning", "error", "critical"}
+	for _, s := range allSeverities {
+		t.Run(s, func(t *testing.T) {
+			pb := severityToProto[s]
+			result := protoToSeverity[pb]
+			assert.Equal(t, s, result)
+		})
+	}
+}
+
+func TestHeartbeatRoundTrip(t *testing.T) {
+	now := time.Now().Truncate(time.Microsecond)
+
+	tests := []struct {
+		name string
+		hb   *types.Heartbeat
+	}{
+		{
+			name: "full heartbeat",
+			hb: &types.Heartbeat{
+				StewardID: "steward-1",
+				TenantID:  "tenant-1",
+				Status:    types.StatusHealthy,
+				Timestamp: now,
+				Metrics: map[string]interface{}{
+					"cpu":    "45.2",
+					"memory": "1024",
+				},
+				Version: "2.1.0",
+			},
+		},
+		{
+			name: "degraded no metrics",
+			hb: &types.Heartbeat{
+				StewardID: "steward-2",
+				Status:    types.StatusDegraded,
+				Timestamp: now,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pb := heartbeatToProto(tt.hb)
+			require.NotNil(t, pb)
+
+			result := heartbeatFromProto(pb)
+			require.NotNil(t, result)
+
+			assert.Equal(t, tt.hb.StewardID, result.StewardID)
+			assert.Equal(t, tt.hb.TenantID, result.TenantID)
+			assert.Equal(t, tt.hb.Status, result.Status)
+			assert.Equal(t, tt.hb.Timestamp.UTC(), result.Timestamp.UTC())
+			assert.Equal(t, tt.hb.Version, result.Version)
+
+			if tt.hb.Metrics != nil {
+				require.NotNil(t, result.Metrics)
+			} else {
+				assert.Nil(t, result.Metrics)
+			}
+		})
+	}
+}
+
+func TestHeartbeatNil(t *testing.T) {
+	assert.Nil(t, heartbeatToProto(nil))
+	assert.Nil(t, heartbeatFromProto(nil))
+}
+
+func TestHeartbeatStatusRoundTrip(t *testing.T) {
+	allStatuses := []types.HeartbeatStatus{
+		types.StatusHealthy,
+		types.StatusDegraded,
+		types.StatusError,
+		types.StatusDisconnected,
+	}
+	for _, s := range allStatuses {
+		t.Run(string(s), func(t *testing.T) {
+			pb := heartbeatStatusToProto[s]
+			result := protoToHeartbeatStatus[pb]
+			assert.Equal(t, s, result)
+		})
+	}
+}
+
+func TestResponseRoundTrip(t *testing.T) {
+	now := time.Now().Truncate(time.Microsecond)
+
+	tests := []struct {
+		name string
+		resp *types.Response
+	}{
+		{
+			name: "success response",
+			resp: &types.Response{
+				CommandID: "cmd-123",
+				StewardID: "steward-1",
+				Success:   true,
+				Message:   "command accepted",
+				Timestamp: now,
+				Details:   map[string]interface{}{"eta": "5s"},
+			},
+		},
+		{
+			name: "failure response",
+			resp: &types.Response{
+				CommandID: "cmd-456",
+				StewardID: "steward-2",
+				Success:   false,
+				Message:   "insufficient permissions",
+				Timestamp: now,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pb := responseToProto(tt.resp)
+			require.NotNil(t, pb)
+
+			result := responseFromProto(pb)
+			require.NotNil(t, result)
+
+			assert.Equal(t, tt.resp.CommandID, result.CommandID)
+			assert.Equal(t, tt.resp.StewardID, result.StewardID)
+			assert.Equal(t, tt.resp.Success, result.Success)
+			assert.Equal(t, tt.resp.Message, result.Message)
+			assert.Equal(t, tt.resp.Timestamp.UTC(), result.Timestamp.UTC())
+
+			if tt.resp.Details != nil {
+				require.NotNil(t, result.Details)
+			} else {
+				assert.Nil(t, result.Details)
+			}
+		})
+	}
+}
+
+func TestResponseNil(t *testing.T) {
+	assert.Nil(t, responseToProto(nil))
+	assert.Nil(t, responseFromProto(nil))
+}
+
+func TestInterfaceMapToStringMap(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    map[string]interface{}
+		expected map[string]string
+	}{
+		{
+			name:     "nil map",
+			input:    nil,
+			expected: map[string]string{},
+		},
+		{
+			name:     "string values",
+			input:    map[string]interface{}{"a": "hello", "b": "world"},
+			expected: map[string]string{"a": "hello", "b": "world"},
+		},
+		{
+			name:     "numeric values",
+			input:    map[string]interface{}{"count": float64(42), "pi": 3.14},
+			expected: map[string]string{"count": "42", "pi": "3.14"},
+		},
+		{
+			name:     "boolean values",
+			input:    map[string]interface{}{"enabled": true, "debug": false},
+			expected: map[string]string{"enabled": "true", "debug": "false"},
+		},
+		{
+			name:  "nested object",
+			input: map[string]interface{}{"nested": map[string]interface{}{"key": "val"}},
+			expected: map[string]string{
+				"nested": `{"key":"val"}`,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := interfaceMapToStringMap(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestStringMapToInterfaceMap(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    map[string]string
+		expected map[string]interface{}
+	}{
+		{
+			name:     "nil map",
+			input:    nil,
+			expected: map[string]interface{}{},
+		},
+		{
+			name:     "plain strings",
+			input:    map[string]string{"a": "hello", "b": "world"},
+			expected: map[string]interface{}{"a": "hello", "b": "world"},
+		},
+		{
+			name:     "numeric JSON",
+			input:    map[string]string{"count": "42", "pi": "3.14"},
+			expected: map[string]interface{}{"count": float64(42), "pi": 3.14},
+		},
+		{
+			name:     "boolean JSON",
+			input:    map[string]string{"enabled": "true"},
+			expected: map[string]interface{}{"enabled": true},
+		},
+		{
+			name:  "nested JSON object",
+			input: map[string]string{"nested": `{"key":"val"}`},
+			expected: map[string]interface{}{
+				"nested": map[string]interface{}{"key": "val"},
+			},
+		},
+		{
+			name:     "non-JSON string kept as-is",
+			input:    map[string]string{"msg": "hello world"},
+			expected: map[string]interface{}{"msg": "hello world"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := stringMapToInterfaceMap(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestMapRoundTrip(t *testing.T) {
+	original := map[string]interface{}{
+		"string_val": "hello",
+		"int_val":    float64(42),
+		"bool_val":   true,
+		"nested":     map[string]interface{}{"inner": "value"},
+	}
+
+	stringMap := interfaceMapToStringMap(original)
+	result := stringMapToInterfaceMap(stringMap)
+
+	assert.Equal(t, original, result)
+}

--- a/pkg/controlplane/providers/grpc/integration_test.go
+++ b/pkg/controlplane/providers/grpc/integration_test.go
@@ -267,8 +267,14 @@ func TestWaitForResponse(t *testing.T) {
 		close(done)
 	}()
 
-	// Send the command
-	time.Sleep(50 * time.Millisecond) // let WaitForResponse register first
+	// Wait for the pending response channel to be registered before sending
+	require.Eventually(t, func() bool {
+		env.server.responseMu.Lock()
+		_, ok := env.server.pendingResponses["cmd-resp-001"]
+		env.server.responseMu.Unlock()
+		return ok
+	}, 5*time.Second, time.Millisecond)
+
 	err = env.server.SendCommand(context.Background(), &types.Command{
 		ID:        "cmd-resp-001",
 		Type:      types.CommandSyncConfig,
@@ -338,9 +344,10 @@ func TestEventFilter(t *testing.T) {
 		t.Fatal("timed out waiting for filtered event")
 	}
 
-	// Give a moment to ensure the non-matching event doesn't arrive
-	time.Sleep(200 * time.Millisecond)
-	assert.Empty(t, received, "non-matching event should not have been delivered")
+	// Verify the non-matching event does not arrive
+	require.Never(t, func() bool {
+		return len(received) > 0
+	}, 200*time.Millisecond, 20*time.Millisecond, "non-matching event should not have been delivered")
 }
 
 func TestFanOutCommand(t *testing.T) {
@@ -471,6 +478,16 @@ func TestDisconnectCleansUpRegistry(t *testing.T) {
 		_, ok := reg.Get("steward-disconnect")
 		return !ok
 	}, 5*time.Second, 10*time.Millisecond, "steward should be unregistered after disconnect")
+
+	// SendCommand to the disconnected steward should return an error
+	err = server.SendCommand(context.Background(), &types.Command{
+		ID:        "cmd-after-disconnect",
+		Type:      types.CommandSyncConfig,
+		StewardID: "steward-disconnect",
+		Timestamp: time.Now(),
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not connected")
 }
 
 func TestMultipleConcurrentStewards(t *testing.T) {
@@ -499,29 +516,31 @@ func TestMultipleConcurrentStewards(t *testing.T) {
 		clientConfigs[id] = tc.clientTLSConfig(t, id)
 	}
 
+	// Create and initialize all clients on the main goroutine (safe for t.Cleanup),
+	// then connect them concurrently.
+	clients := make([]*Provider, numStewards)
+	for i := 0; i < numStewards; i++ {
+		id := fmt.Sprintf("steward-%d", i)
+		client := New(ModeClient)
+		err := client.Initialize(context.Background(), map[string]interface{}{
+			"mode":       "client",
+			"addr":       listenAddr,
+			"tls_config": clientConfigs[id],
+			"steward_id": id,
+		})
+		require.NoError(t, err)
+		clients[i] = client
+		t.Cleanup(func() { _ = client.Stop(context.Background()) })
+	}
+
 	var wg sync.WaitGroup
 	for i := 0; i < numStewards; i++ {
 		wg.Add(1)
 		go func(idx int) {
 			defer wg.Done()
-			id := fmt.Sprintf("steward-%d", idx)
-
-			client := New(ModeClient)
-			err := client.Initialize(context.Background(), map[string]interface{}{
-				"mode":       "client",
-				"addr":       listenAddr,
-				"tls_config": clientConfigs[id],
-				"steward_id": id,
-			})
-			if err != nil {
-				t.Errorf("steward %s init failed: %v", id, err)
-				return
+			if err := clients[idx].Start(context.Background()); err != nil {
+				t.Errorf("steward-%d start failed: %v", idx, err)
 			}
-			if err := client.Start(context.Background()); err != nil {
-				t.Errorf("steward %s start failed: %v", id, err)
-				return
-			}
-			t.Cleanup(func() { _ = client.Stop(context.Background()) })
 		}(i)
 	}
 
@@ -560,8 +579,12 @@ func TestStatsTracking(t *testing.T) {
 		StewardID: "steward-stats-test", Status: types.StatusHealthy, Timestamp: now,
 	}))
 
-	// Give dispatchers time to process
-	time.Sleep(200 * time.Millisecond)
+	// Poll until all stats are populated (async dispatch via goroutines)
+	require.Eventually(t, func() bool {
+		return env.server.eventsReceived.Load() >= 1 &&
+			env.server.heartbeatsReceived.Load() >= 1 &&
+			env.client.commandsReceived.Load() >= 1
+	}, 5*time.Second, 10*time.Millisecond)
 
 	// Check server stats
 	serverStats, err := env.server.GetStats(context.Background())

--- a/pkg/controlplane/providers/grpc/integration_test.go
+++ b/pkg/controlplane/providers/grpc/integration_test.go
@@ -1,0 +1,642 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+
+package grpc
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	cfgcert "github.com/cfgis/cfgms/pkg/cert"
+	"github.com/cfgis/cfgms/pkg/controlplane/interfaces"
+	"github.com/cfgis/cfgms/pkg/controlplane/types"
+	quictransport "github.com/cfgis/cfgms/pkg/transport/quic"
+	"github.com/cfgis/cfgms/pkg/transport/registry"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// testEnv holds a matched server + client provider pair connected over real QUIC+mTLS.
+type testEnv struct {
+	server   *Provider
+	client   *Provider
+	registry registry.Registry
+}
+
+// newTestEnv creates a server and client provider connected over real QUIC+mTLS.
+// The client certificate CN is used as the steward ID.
+func newTestEnv(t *testing.T, stewardID string) *testEnv {
+	t.Helper()
+
+	serverTLS, clientTLS := newTestTLSConfigs(t, stewardID)
+	reg := registry.NewRegistry()
+
+	server := New(ModeServer)
+	err := server.Initialize(context.Background(), map[string]interface{}{
+		"mode":       "server",
+		"addr":       "127.0.0.1:0",
+		"tls_config": serverTLS,
+		"registry":   reg,
+	})
+	require.NoError(t, err)
+
+	// Start server on ephemeral port
+	err = server.Start(context.Background())
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = server.Stop(context.Background()) })
+
+	// Get the actual listen address
+	listenAddr := server.listener.Addr().String()
+
+	client := New(ModeClient)
+	err = client.Initialize(context.Background(), map[string]interface{}{
+		"mode":       "client",
+		"addr":       listenAddr,
+		"tls_config": clientTLS,
+		"steward_id": stewardID,
+	})
+	require.NoError(t, err)
+
+	err = client.Start(context.Background())
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = client.Stop(context.Background()) })
+
+	// Wait for the steward to appear in the registry
+	require.Eventually(t, func() bool {
+		_, ok := reg.Get(stewardID)
+		return ok
+	}, 5*time.Second, 10*time.Millisecond, "steward should be registered")
+
+	return &testEnv{server: server, client: client, registry: reg}
+}
+
+// testCA holds a test CA and its PEM-encoded certificate for reuse across
+// multiple steward client configs in multi-steward tests.
+type testCA struct {
+	ca    *cfgcert.CA
+	caPEM []byte
+}
+
+// newTestCA creates a fresh test CA.
+func newTestCA(t *testing.T) *testCA {
+	t.Helper()
+	ca, err := cfgcert.NewCA(&cfgcert.CAConfig{
+		Organization: "CFGMS Test",
+		Country:      "US",
+		ValidityDays: 1,
+		KeySize:      2048,
+	})
+	require.NoError(t, err)
+	require.NoError(t, ca.Initialize(nil))
+	caPEM, err := ca.GetCACertificate()
+	require.NoError(t, err)
+	return &testCA{ca: ca, caPEM: caPEM}
+}
+
+// serverTLSConfig returns a server TLS config signed by this CA.
+func (tc *testCA) serverTLSConfig(t *testing.T) *tls.Config {
+	t.Helper()
+	serverCert, err := tc.ca.GenerateServerCertificate(&cfgcert.ServerCertConfig{
+		CommonName:   "localhost",
+		DNSNames:     []string{"localhost"},
+		ValidityDays: 1,
+		KeySize:      2048,
+	})
+	require.NoError(t, err)
+
+	cfg, err := cfgcert.CreateServerTLSConfig(
+		serverCert.CertificatePEM, serverCert.PrivateKeyPEM,
+		tc.caPEM, tls.VersionTLS13,
+	)
+	require.NoError(t, err)
+	cfg.NextProtos = []string{quictransport.ALPNProtocol}
+	return cfg
+}
+
+// clientTLSConfig returns a client TLS config with CN set to stewardID.
+func (tc *testCA) clientTLSConfig(t *testing.T, stewardID string) *tls.Config {
+	t.Helper()
+	clientCert, err := tc.ca.GenerateClientCertificate(&cfgcert.ClientCertConfig{
+		CommonName:   stewardID,
+		ValidityDays: 1,
+		KeySize:      2048,
+	})
+	require.NoError(t, err)
+
+	cfg, err := cfgcert.CreateClientTLSConfig(
+		clientCert.CertificatePEM, clientCert.PrivateKeyPEM,
+		tc.caPEM, "localhost", tls.VersionTLS13,
+	)
+	require.NoError(t, err)
+	cfg.NextProtos = []string{quictransport.ALPNProtocol}
+	return cfg
+}
+
+// newTestTLSConfigs creates matched server and client TLS configs for testing.
+// Convenience wrapper that creates a fresh CA per call (fine for single-steward tests).
+func newTestTLSConfigs(t *testing.T, stewardID string) (serverTLS, clientTLS *tls.Config) {
+	t.Helper()
+	tc := newTestCA(t)
+	return tc.serverTLSConfig(t), tc.clientTLSConfig(t, stewardID)
+}
+
+// --- Integration Tests ---
+
+func TestControllerSendsCommand_StewardReceives(t *testing.T) {
+	env := newTestEnv(t, "steward-cmd-test")
+
+	received := make(chan *types.Command, 1)
+	err := env.client.SubscribeCommands(context.Background(), "steward-cmd-test", func(ctx context.Context, cmd *types.Command) error {
+		received <- cmd
+		return nil
+	})
+	require.NoError(t, err)
+
+	cmd := &types.Command{
+		ID:        "cmd-001",
+		Type:      types.CommandSyncConfig,
+		StewardID: "steward-cmd-test",
+		Timestamp: time.Now().Truncate(time.Microsecond),
+		Priority:  3,
+		Params:    map[string]interface{}{"version": "1.0"},
+	}
+
+	err = env.server.SendCommand(context.Background(), cmd)
+	require.NoError(t, err)
+
+	select {
+	case got := <-received:
+		assert.Equal(t, cmd.ID, got.ID)
+		assert.Equal(t, cmd.Type, got.Type)
+		assert.Equal(t, cmd.StewardID, got.StewardID)
+		assert.Equal(t, cmd.Priority, got.Priority)
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for command")
+	}
+}
+
+func TestStewardSendsEvent_ControllerReceives(t *testing.T) {
+	env := newTestEnv(t, "steward-evt-test")
+
+	received := make(chan *types.Event, 1)
+	err := env.server.SubscribeEvents(context.Background(), nil, func(ctx context.Context, event *types.Event) error {
+		received <- event
+		return nil
+	})
+	require.NoError(t, err)
+
+	event := &types.Event{
+		ID:        "evt-001",
+		Type:      types.EventConfigApplied,
+		StewardID: "steward-evt-test",
+		Timestamp: time.Now().Truncate(time.Microsecond),
+		Severity:  "info",
+		Details:   map[string]interface{}{"modules": "5"},
+	}
+
+	err = env.client.PublishEvent(context.Background(), event)
+	require.NoError(t, err)
+
+	select {
+	case got := <-received:
+		assert.Equal(t, event.ID, got.ID)
+		assert.Equal(t, event.Type, got.Type)
+		assert.Equal(t, event.StewardID, got.StewardID)
+		assert.Equal(t, event.Severity, got.Severity)
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for event")
+	}
+}
+
+func TestStewardSendsHeartbeat_ControllerReceives(t *testing.T) {
+	env := newTestEnv(t, "steward-hb-test")
+
+	received := make(chan *types.Heartbeat, 1)
+	err := env.server.SubscribeHeartbeats(context.Background(), func(ctx context.Context, hb *types.Heartbeat) error {
+		received <- hb
+		return nil
+	})
+	require.NoError(t, err)
+
+	hb := &types.Heartbeat{
+		StewardID: "steward-hb-test",
+		Status:    types.StatusHealthy,
+		Timestamp: time.Now().Truncate(time.Microsecond),
+		Version:   "2.0.0",
+	}
+
+	err = env.client.SendHeartbeat(context.Background(), hb)
+	require.NoError(t, err)
+
+	select {
+	case got := <-received:
+		assert.Equal(t, hb.StewardID, got.StewardID)
+		assert.Equal(t, hb.Status, got.Status)
+		assert.Equal(t, hb.Version, got.Version)
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for heartbeat")
+	}
+}
+
+func TestWaitForResponse(t *testing.T) {
+	env := newTestEnv(t, "steward-resp-test")
+
+	// Subscribe to commands so the steward can respond
+	err := env.client.SubscribeCommands(context.Background(), "steward-resp-test", func(ctx context.Context, cmd *types.Command) error {
+		// Send response back
+		return env.client.SendResponse(ctx, &types.Response{
+			CommandID: cmd.ID,
+			StewardID: "steward-resp-test",
+			Success:   true,
+			Message:   "done",
+			Timestamp: time.Now(),
+		})
+	})
+	require.NoError(t, err)
+
+	// Start waiting for response in background
+	var resp *types.Response
+	var respErr error
+	done := make(chan struct{})
+	go func() {
+		resp, respErr = env.server.WaitForResponse(context.Background(), "cmd-resp-001", 5*time.Second)
+		close(done)
+	}()
+
+	// Send the command
+	time.Sleep(50 * time.Millisecond) // let WaitForResponse register first
+	err = env.server.SendCommand(context.Background(), &types.Command{
+		ID:        "cmd-resp-001",
+		Type:      types.CommandSyncConfig,
+		StewardID: "steward-resp-test",
+		Timestamp: time.Now(),
+	})
+	require.NoError(t, err)
+
+	select {
+	case <-done:
+		require.NoError(t, respErr)
+		assert.Equal(t, "cmd-resp-001", resp.CommandID)
+		assert.True(t, resp.Success)
+		assert.Equal(t, "done", resp.Message)
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for response")
+	}
+}
+
+func TestWaitForResponse_Timeout(t *testing.T) {
+	env := newTestEnv(t, "steward-timeout-test")
+
+	_, err := env.server.WaitForResponse(context.Background(), "nonexistent-cmd", 100*time.Millisecond)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "timeout")
+}
+
+func TestEventFilter(t *testing.T) {
+	env := newTestEnv(t, "steward-filter-test")
+
+	received := make(chan *types.Event, 10)
+
+	// Subscribe with filter: only config_applied events
+	err := env.server.SubscribeEvents(context.Background(), &types.EventFilter{
+		EventTypes: []types.EventType{types.EventConfigApplied},
+	}, func(ctx context.Context, event *types.Event) error {
+		received <- event
+		return nil
+	})
+	require.NoError(t, err)
+
+	// Send an event that matches the filter
+	err = env.client.PublishEvent(context.Background(), &types.Event{
+		ID:        "evt-match",
+		Type:      types.EventConfigApplied,
+		StewardID: "steward-filter-test",
+		Timestamp: time.Now(),
+		Severity:  "info",
+	})
+	require.NoError(t, err)
+
+	// Send an event that does NOT match the filter
+	err = env.client.PublishEvent(context.Background(), &types.Event{
+		ID:        "evt-nomatch",
+		Type:      types.EventError,
+		StewardID: "steward-filter-test",
+		Timestamp: time.Now(),
+		Severity:  "error",
+	})
+	require.NoError(t, err)
+
+	// Should receive only the matching event
+	select {
+	case got := <-received:
+		assert.Equal(t, "evt-match", got.ID)
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for filtered event")
+	}
+
+	// Give a moment to ensure the non-matching event doesn't arrive
+	time.Sleep(200 * time.Millisecond)
+	assert.Empty(t, received, "non-matching event should not have been delivered")
+}
+
+func TestFanOutCommand(t *testing.T) {
+	// Shared CA so all certs are mutually trusted
+	tc := newTestCA(t)
+	reg := registry.NewRegistry()
+
+	server := New(ModeServer)
+	err := server.Initialize(context.Background(), map[string]interface{}{
+		"mode":       "server",
+		"addr":       "127.0.0.1:0",
+		"tls_config": tc.serverTLSConfig(t),
+		"registry":   reg,
+	})
+	require.NoError(t, err)
+	require.NoError(t, server.Start(context.Background()))
+	t.Cleanup(func() { _ = server.Stop(context.Background()) })
+
+	listenAddr := server.listener.Addr().String()
+
+	// Connect two stewards
+	received := make(map[string]chan *types.Command)
+	stewardIDs := []string{"steward-fan-1", "steward-fan-2"}
+
+	for _, id := range stewardIDs {
+		client := New(ModeClient)
+		err := client.Initialize(context.Background(), map[string]interface{}{
+			"mode":       "client",
+			"addr":       listenAddr,
+			"tls_config": tc.clientTLSConfig(t, id),
+			"steward_id": id,
+		})
+		require.NoError(t, err)
+		require.NoError(t, client.Start(context.Background()))
+		t.Cleanup(func() { _ = client.Stop(context.Background()) })
+
+		ch := make(chan *types.Command, 1)
+		received[id] = ch
+		id := id
+		require.NoError(t, client.SubscribeCommands(context.Background(), id, func(ctx context.Context, cmd *types.Command) error {
+			received[id] <- cmd
+			return nil
+		}))
+	}
+
+	// Wait for both stewards to register
+	require.Eventually(t, func() bool { return reg.Count() == 2 }, 5*time.Second, 10*time.Millisecond)
+
+	cmd := &types.Command{
+		ID:        "cmd-fan",
+		Type:      types.CommandSyncDNA,
+		Timestamp: time.Now(),
+	}
+
+	result, err := server.FanOutCommand(context.Background(), cmd, stewardIDs)
+	require.NoError(t, err)
+	assert.Len(t, result.Succeeded, 2)
+	assert.Empty(t, result.Failed)
+
+	// Both stewards should receive the command
+	for _, id := range stewardIDs {
+		select {
+		case got := <-received[id]:
+			assert.Equal(t, "cmd-fan", got.ID)
+		case <-time.After(5 * time.Second):
+			t.Fatalf("steward %s did not receive fan-out command", id)
+		}
+	}
+}
+
+func TestFanOutCommand_PartialFailure(t *testing.T) {
+	env := newTestEnv(t, "steward-fan-partial")
+
+	cmd := &types.Command{
+		ID:        "cmd-partial",
+		Type:      types.CommandSyncConfig,
+		Timestamp: time.Now(),
+	}
+
+	// Fan-out to one connected and one disconnected steward
+	result, err := env.server.FanOutCommand(context.Background(), cmd, []string{
+		"steward-fan-partial",
+		"steward-not-connected",
+	})
+	require.NoError(t, err)
+	assert.Contains(t, result.Succeeded, "steward-fan-partial")
+	assert.Contains(t, result.Failed, "steward-not-connected")
+}
+
+func TestDisconnectCleansUpRegistry(t *testing.T) {
+	serverTLS, clientTLS := newTestTLSConfigs(t, "steward-disconnect")
+	reg := registry.NewRegistry()
+
+	server := New(ModeServer)
+	err := server.Initialize(context.Background(), map[string]interface{}{
+		"mode":       "server",
+		"addr":       "127.0.0.1:0",
+		"tls_config": serverTLS,
+		"registry":   reg,
+	})
+	require.NoError(t, err)
+	require.NoError(t, server.Start(context.Background()))
+	t.Cleanup(func() { _ = server.Stop(context.Background()) })
+
+	listenAddr := server.listener.Addr().String()
+
+	client := New(ModeClient)
+	err = client.Initialize(context.Background(), map[string]interface{}{
+		"mode":       "client",
+		"addr":       listenAddr,
+		"tls_config": clientTLS,
+		"steward_id": "steward-disconnect",
+	})
+	require.NoError(t, err)
+	require.NoError(t, client.Start(context.Background()))
+
+	// Wait for registration
+	require.Eventually(t, func() bool {
+		_, ok := reg.Get("steward-disconnect")
+		return ok
+	}, 5*time.Second, 10*time.Millisecond)
+
+	// Disconnect the client
+	_ = client.Stop(context.Background())
+
+	// Steward should be unregistered
+	require.Eventually(t, func() bool {
+		_, ok := reg.Get("steward-disconnect")
+		return !ok
+	}, 5*time.Second, 10*time.Millisecond, "steward should be unregistered after disconnect")
+}
+
+func TestMultipleConcurrentStewards(t *testing.T) {
+	tc := newTestCA(t)
+	reg := registry.NewRegistry()
+
+	server := New(ModeServer)
+	err := server.Initialize(context.Background(), map[string]interface{}{
+		"mode":       "server",
+		"addr":       "127.0.0.1:0",
+		"tls_config": tc.serverTLSConfig(t),
+		"registry":   reg,
+	})
+	require.NoError(t, err)
+	require.NoError(t, server.Start(context.Background()))
+	t.Cleanup(func() { _ = server.Stop(context.Background()) })
+
+	listenAddr := server.listener.Addr().String()
+
+	const numStewards = 5
+
+	// Pre-generate client TLS configs (cert generation is not goroutine-safe with testing.T)
+	clientConfigs := make(map[string]*tls.Config, numStewards)
+	for i := 0; i < numStewards; i++ {
+		id := fmt.Sprintf("steward-%d", i)
+		clientConfigs[id] = tc.clientTLSConfig(t, id)
+	}
+
+	var wg sync.WaitGroup
+	for i := 0; i < numStewards; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			id := fmt.Sprintf("steward-%d", idx)
+
+			client := New(ModeClient)
+			err := client.Initialize(context.Background(), map[string]interface{}{
+				"mode":       "client",
+				"addr":       listenAddr,
+				"tls_config": clientConfigs[id],
+				"steward_id": id,
+			})
+			if err != nil {
+				t.Errorf("steward %s init failed: %v", id, err)
+				return
+			}
+			if err := client.Start(context.Background()); err != nil {
+				t.Errorf("steward %s start failed: %v", id, err)
+				return
+			}
+			t.Cleanup(func() { _ = client.Stop(context.Background()) })
+		}(i)
+	}
+
+	wg.Wait()
+
+	// All stewards should be registered
+	require.Eventually(t, func() bool {
+		return reg.Count() == numStewards
+	}, 10*time.Second, 50*time.Millisecond, "all %d stewards should be registered", numStewards)
+}
+
+func TestStatsTracking(t *testing.T) {
+	env := newTestEnv(t, "steward-stats-test")
+
+	// Subscribe handlers
+	require.NoError(t, env.server.SubscribeEvents(context.Background(), nil, func(ctx context.Context, event *types.Event) error {
+		return nil
+	}))
+	require.NoError(t, env.server.SubscribeHeartbeats(context.Background(), func(ctx context.Context, hb *types.Heartbeat) error {
+		return nil
+	}))
+	require.NoError(t, env.client.SubscribeCommands(context.Background(), "steward-stats-test", func(ctx context.Context, cmd *types.Command) error {
+		return nil
+	}))
+
+	now := time.Now()
+
+	// Send one of each message type
+	require.NoError(t, env.server.SendCommand(context.Background(), &types.Command{
+		ID: "cmd-stats", Type: types.CommandSyncConfig, StewardID: "steward-stats-test", Timestamp: now,
+	}))
+	require.NoError(t, env.client.PublishEvent(context.Background(), &types.Event{
+		ID: "evt-stats", Type: types.EventConfigApplied, StewardID: "steward-stats-test", Timestamp: now, Severity: "info",
+	}))
+	require.NoError(t, env.client.SendHeartbeat(context.Background(), &types.Heartbeat{
+		StewardID: "steward-stats-test", Status: types.StatusHealthy, Timestamp: now,
+	}))
+
+	// Give dispatchers time to process
+	time.Sleep(200 * time.Millisecond)
+
+	// Check server stats
+	serverStats, err := env.server.GetStats(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), serverStats.CommandsSent)
+	assert.Equal(t, int64(1), serverStats.EventsReceived)
+	assert.Equal(t, int64(1), serverStats.HeartbeatsReceived)
+	assert.Equal(t, int64(1), serverStats.ConnectedStewards)
+	assert.Equal(t, int64(2), serverStats.ActiveSubscriptions) // 1 event + 1 heartbeat
+	assert.True(t, serverStats.Uptime > 0)
+
+	// Check client stats
+	clientStats, err := env.client.GetStats(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), clientStats.EventsPublished)
+	assert.Equal(t, int64(1), clientStats.HeartbeatsSent)
+	assert.Equal(t, int64(1), clientStats.CommandsReceived)
+}
+
+func TestProviderRegistration(t *testing.T) {
+	provider := interfaces.GetProvider("grpc")
+	require.NotNil(t, provider)
+	assert.Equal(t, "grpc", provider.Name())
+}
+
+func TestAvailable(t *testing.T) {
+	p := New(ModeServer)
+	ok, err := p.Available()
+	assert.False(t, ok)
+	assert.Error(t, err)
+
+	p.addr = ":50051"
+	p.tlsConfig = &tls.Config{}
+	ok, err = p.Available()
+	assert.True(t, ok)
+	assert.NoError(t, err)
+}
+
+func TestModeValidation(t *testing.T) {
+	// Server-only methods fail in client mode
+	client := New(ModeClient)
+	client.stewardID = "test"
+	client.addr = "localhost:50051"
+	client.tlsConfig = &tls.Config{}
+
+	err := client.SendCommand(context.Background(), &types.Command{})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "server mode")
+
+	_, err = client.FanOutCommand(context.Background(), &types.Command{}, []string{"a"})
+	assert.Error(t, err)
+
+	err = client.SubscribeEvents(context.Background(), nil, nil)
+	assert.Error(t, err)
+
+	err = client.SubscribeHeartbeats(context.Background(), nil)
+	assert.Error(t, err)
+
+	_, err = client.WaitForResponse(context.Background(), "x", time.Second)
+	assert.Error(t, err)
+
+	// Client-only methods fail in server mode
+	server := New(ModeServer)
+	server.addr = ":50051"
+	server.tlsConfig = &tls.Config{}
+
+	err = server.SubscribeCommands(context.Background(), "x", nil)
+	assert.Error(t, err)
+
+	err = server.PublishEvent(context.Background(), &types.Event{})
+	assert.Error(t, err)
+
+	err = server.SendHeartbeat(context.Background(), &types.Heartbeat{})
+	assert.Error(t, err)
+
+	err = server.SendResponse(context.Background(), &types.Response{})
+	assert.Error(t, err)
+}

--- a/pkg/controlplane/providers/grpc/provider.go
+++ b/pkg/controlplane/providers/grpc/provider.go
@@ -1,0 +1,831 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+
+// Package grpc provides a gRPC-over-QUIC control plane provider implementation.
+//
+// This provider implements the ControlPlaneProvider interface using a persistent
+// bidirectional gRPC ControlChannel stream per steward, replacing the MQTT broker
+// with direct controller-steward communication over QUIC.
+package grpc
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"log/slog"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	commonpb "github.com/cfgis/cfgms/api/proto/common"
+	controllerpb "github.com/cfgis/cfgms/api/proto/controller"
+	transportpb "github.com/cfgis/cfgms/api/proto/transport"
+	"github.com/cfgis/cfgms/pkg/controlplane/interfaces"
+	"github.com/cfgis/cfgms/pkg/controlplane/types"
+	quictransport "github.com/cfgis/cfgms/pkg/transport/quic"
+	"github.com/cfgis/cfgms/pkg/transport/registry"
+	quicgo "github.com/quic-go/quic-go"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/peer"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+func init() {
+	interfaces.RegisterProvider(New(ModeServer))
+}
+
+// Mode defines the provider operating mode.
+type Mode string
+
+const (
+	// ModeServer indicates controller (server) mode.
+	ModeServer Mode = "server"
+
+	// ModeClient indicates steward (client) mode.
+	ModeClient Mode = "client"
+)
+
+// Provider implements the ControlPlaneProvider interface using gRPC-over-QUIC.
+type Provider struct {
+	mu sync.RWMutex
+
+	name        string
+	description string
+	mode        Mode
+
+	// Server-side components
+	grpcServer *grpc.Server
+	listener   *quictransport.Listener
+	registry   registry.Registry
+	serverImpl *transportServer
+
+	// Client-side components
+	grpcConn      *grpc.ClientConn
+	grpcClient    transportpb.StewardTransportClient
+	controlStream grpc.BidiStreamingClient[transportpb.ControlMessage, transportpb.ControlMessage]
+	sendMu        sync.Mutex // serializes writes to controlStream
+
+	// Shared configuration
+	config          map[string]interface{}
+	addr            string
+	tlsConfig       *tls.Config
+	keepalivePeriod time.Duration // 0 = use QUIC default (25s)
+	idleTimeout     time.Duration // 0 = use QUIC default (90s)
+	stewardID       string
+	tenantID        string
+	logger          *slog.Logger
+	startTime       time.Time
+
+	// Subscription handlers (client mode)
+	commandHandler interfaces.CommandHandler
+
+	// Subscription handlers (server mode)
+	eventHandlers     []eventSubscription
+	heartbeatHandlers []interfaces.HeartbeatHandler
+
+	// Response tracking (server mode: WaitForResponse)
+	pendingResponses map[string]chan *types.Response
+	responseMu       sync.Mutex
+
+	// Lifecycle
+	ctx    context.Context
+	cancel context.CancelFunc
+
+	// Statistics (atomic for lock-free updates)
+	commandsSent       atomic.Int64
+	commandsReceived   atomic.Int64
+	eventsPublished    atomic.Int64
+	eventsReceived     atomic.Int64
+	heartbeatsSent     atomic.Int64
+	heartbeatsReceived atomic.Int64
+	responsesSent      atomic.Int64
+	responsesReceived  atomic.Int64
+	deliveryFailures   atomic.Int64
+}
+
+// eventSubscription represents an event subscription with filter.
+type eventSubscription struct {
+	filter  *types.EventFilter
+	handler interfaces.EventHandler
+}
+
+// New creates a new gRPC control plane provider.
+func New(mode Mode) *Provider {
+	return &Provider{
+		name:              "grpc",
+		description:       "gRPC-over-QUIC control plane provider",
+		mode:              mode,
+		eventHandlers:     []eventSubscription{},
+		heartbeatHandlers: []interfaces.HeartbeatHandler{},
+		pendingResponses:  make(map[string]chan *types.Response),
+		logger:            slog.Default(),
+	}
+}
+
+func (p *Provider) Name() string        { return p.name }
+func (p *Provider) Description() string { return p.description }
+
+// Initialize configures the provider.
+//
+// Common config keys:
+//   - "mode": string - "server" or "client"
+//   - "addr": string - Listen address (server) or controller address (client)
+//   - "tls_config": *tls.Config - TLS configuration for mTLS
+//   - "logger": *slog.Logger - Logger (optional)
+//   - "keepalive_period": time.Duration - QUIC keepalive interval (optional, default 25s)
+//   - "idle_timeout": time.Duration - QUIC idle timeout (optional, default 90s)
+//
+// Server mode additional keys:
+//   - "registry": registry.Registry - Connection registry (optional, creates one if nil)
+//
+// Client mode additional keys:
+//   - "steward_id": string - This steward's ID
+//   - "tenant_id": string - Tenant ID (optional)
+func (p *Provider) Initialize(ctx context.Context, config map[string]interface{}) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	p.config = config
+
+	if modeStr, ok := config["mode"].(string); ok {
+		p.mode = Mode(modeStr)
+	}
+
+	if logger, ok := config["logger"].(*slog.Logger); ok {
+		p.logger = logger
+	}
+
+	if addr, ok := config["addr"].(string); ok {
+		p.addr = addr
+	}
+
+	if tlsCfg, ok := config["tls_config"].(*tls.Config); ok {
+		p.tlsConfig = tlsCfg
+	}
+
+	if kp, ok := config["keepalive_period"].(time.Duration); ok {
+		p.keepalivePeriod = kp
+	}
+	if it, ok := config["idle_timeout"].(time.Duration); ok {
+		p.idleTimeout = it
+	}
+
+	switch p.mode {
+	case ModeServer:
+		return p.initializeServer(config)
+	case ModeClient:
+		return p.initializeClient(config)
+	default:
+		return fmt.Errorf("invalid mode: %s (must be 'server' or 'client')", p.mode)
+	}
+}
+
+func (p *Provider) initializeServer(config map[string]interface{}) error {
+	if p.addr == "" {
+		return fmt.Errorf("server mode requires 'addr' in config")
+	}
+	if p.tlsConfig == nil {
+		return fmt.Errorf("server mode requires 'tls_config' in config")
+	}
+
+	if reg, ok := config["registry"].(registry.Registry); ok {
+		p.registry = reg
+	} else {
+		p.registry = registry.NewRegistry()
+	}
+
+	return nil
+}
+
+func (p *Provider) initializeClient(config map[string]interface{}) error {
+	if p.addr == "" {
+		return fmt.Errorf("client mode requires 'addr' in config")
+	}
+	if p.tlsConfig == nil {
+		return fmt.Errorf("client mode requires 'tls_config' in config")
+	}
+
+	stewardID, ok := config["steward_id"].(string)
+	if !ok || stewardID == "" {
+		return fmt.Errorf("client mode requires 'steward_id' in config")
+	}
+	p.stewardID = stewardID
+
+	if tenantID, ok := config["tenant_id"].(string); ok {
+		p.tenantID = tenantID
+	}
+
+	return nil
+}
+
+// Start begins control plane operation.
+func (p *Provider) Start(ctx context.Context) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	p.ctx, p.cancel = context.WithCancel(ctx)
+	p.startTime = time.Now()
+
+	switch p.mode {
+	case ModeServer:
+		return p.startServer()
+	case ModeClient:
+		return p.startClient()
+	default:
+		return fmt.Errorf("provider not initialized")
+	}
+}
+
+// quicConfig returns a *quicgo.Config with any user overrides, or nil for defaults.
+func (p *Provider) quicConfig() *quicgo.Config {
+	if p.keepalivePeriod == 0 && p.idleTimeout == 0 {
+		return nil // use QUIC transport defaults
+	}
+	cfg := &quicgo.Config{}
+	if p.keepalivePeriod > 0 {
+		cfg.KeepAlivePeriod = p.keepalivePeriod
+	}
+	if p.idleTimeout > 0 {
+		cfg.MaxIdleTimeout = p.idleTimeout
+	}
+	return cfg
+}
+
+func (p *Provider) startServer() error {
+	ql, err := quictransport.Listen(p.addr, p.tlsConfig, p.quicConfig())
+	if err != nil {
+		return fmt.Errorf("failed to start QUIC listener: %w", err)
+	}
+	p.listener = ql
+
+	p.serverImpl = &transportServer{provider: p}
+	p.grpcServer = grpc.NewServer(
+		grpc.Creds(quictransport.TransportCredentials()),
+	)
+	transportpb.RegisterStewardTransportServer(p.grpcServer, p.serverImpl)
+
+	go func() {
+		if err := p.grpcServer.Serve(ql); err != nil {
+			p.logger.Error("gRPC server stopped", "error", err)
+		}
+	}()
+
+	p.logger.Info("gRPC control plane server started", "addr", p.addr)
+	return nil
+}
+
+func (p *Provider) startClient() error {
+	dialer := quictransport.NewDialer(p.tlsConfig, p.quicConfig())
+
+	// TLS happens at the QUIC layer. We use quictransport.TransportCredentials()
+	// to bridge the QUIC TLS state into gRPC's AuthInfo for peer identity.
+	conn, err := grpc.NewClient(
+		p.addr,
+		grpc.WithContextDialer(dialer),
+		grpc.WithTransportCredentials(quictransport.TransportCredentials()),
+	)
+	if err != nil {
+		return fmt.Errorf("failed to create gRPC client: %w", err)
+	}
+	p.grpcConn = conn
+	p.grpcClient = transportpb.NewStewardTransportClient(conn)
+
+	stream, err := p.grpcClient.ControlChannel(p.ctx)
+	if err != nil {
+		_ = conn.Close()
+		return fmt.Errorf("failed to open ControlChannel: %w", err)
+	}
+	p.controlStream = stream
+
+	go p.clientReceiveLoop()
+
+	p.logger.Info("gRPC control plane client connected", "addr", p.addr, "steward_id", p.stewardID)
+	return nil
+}
+
+// clientReceiveLoop reads messages from the ControlChannel and dispatches them.
+func (p *Provider) clientReceiveLoop() {
+	for {
+		msg, err := p.controlStream.Recv()
+		if err != nil {
+			select {
+			case <-p.ctx.Done():
+				return
+			default:
+			}
+			p.logger.Error("ControlChannel receive error", "error", err)
+			return
+		}
+
+		switch payload := msg.GetPayload().(type) {
+		case *transportpb.ControlMessage_Command:
+			cmd := commandFromProto(payload.Command)
+			p.commandsReceived.Add(1)
+
+			p.mu.RLock()
+			handler := p.commandHandler
+			p.mu.RUnlock()
+
+			if handler != nil {
+				go func() {
+					if err := handler(p.ctx, cmd); err != nil {
+						p.logger.Error("command handler error", "command_id", cmd.ID, "error", err)
+					}
+				}()
+			}
+		}
+	}
+}
+
+// Stop gracefully shuts down the control plane.
+func (p *Provider) Stop(ctx context.Context) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if p.cancel != nil {
+		p.cancel()
+	}
+
+	switch p.mode {
+	case ModeServer:
+		return p.stopServer()
+	case ModeClient:
+		return p.stopClient()
+	default:
+		return nil
+	}
+}
+
+func (p *Provider) stopServer() error {
+	if p.grpcServer != nil {
+		p.grpcServer.GracefulStop()
+	}
+	if p.listener != nil {
+		_ = p.listener.Close()
+	}
+	p.eventHandlers = nil
+	p.heartbeatHandlers = nil
+	return nil
+}
+
+func (p *Provider) stopClient() error {
+	if p.controlStream != nil {
+		_ = p.controlStream.CloseSend()
+	}
+	if p.grpcConn != nil {
+		_ = p.grpcConn.Close()
+	}
+	return nil
+}
+
+// --- Commands (Controller → Steward) ---
+
+func (p *Provider) SendCommand(ctx context.Context, cmd *types.Command) error {
+	if p.mode != ModeServer {
+		return fmt.Errorf("SendCommand is only available in server mode")
+	}
+
+	conn, ok := p.registry.Get(cmd.StewardID)
+	if !ok {
+		p.deliveryFailures.Add(1)
+		return fmt.Errorf("steward %s not connected", cmd.StewardID)
+	}
+
+	msg := &transportpb.ControlMessage{
+		Payload: &transportpb.ControlMessage_Command{Command: commandToProto(cmd)},
+	}
+
+	if err := conn.Send(msg); err != nil {
+		p.deliveryFailures.Add(1)
+		return fmt.Errorf("failed to send command to steward %s: %w", cmd.StewardID, err)
+	}
+
+	p.commandsSent.Add(1)
+	return nil
+}
+
+func (p *Provider) FanOutCommand(ctx context.Context, cmd *types.Command, stewardIDs []string) (*types.FanOutResult, error) {
+	if p.mode != ModeServer {
+		return nil, fmt.Errorf("FanOutCommand is only available in server mode")
+	}
+	if len(stewardIDs) == 0 {
+		return nil, fmt.Errorf("stewardIDs must not be empty")
+	}
+
+	result := &types.FanOutResult{
+		Failed: make(map[string]error),
+	}
+
+	msg := &transportpb.ControlMessage{
+		Payload: &transportpb.ControlMessage_Command{Command: commandToProto(cmd)},
+	}
+
+	conns := p.registry.GetMany(stewardIDs)
+
+	for _, id := range stewardIDs {
+		conn, ok := conns[id]
+		if !ok {
+			result.Failed[id] = fmt.Errorf("steward not connected")
+			p.deliveryFailures.Add(1)
+			continue
+		}
+
+		if err := conn.Send(msg); err != nil {
+			result.Failed[id] = err
+			p.deliveryFailures.Add(1)
+			continue
+		}
+
+		result.Succeeded = append(result.Succeeded, id)
+		p.commandsSent.Add(1)
+	}
+
+	return result, nil
+}
+
+func (p *Provider) SubscribeCommands(ctx context.Context, stewardID string, handler interfaces.CommandHandler) error {
+	if p.mode != ModeClient {
+		return fmt.Errorf("SubscribeCommands is only available in client mode")
+	}
+
+	p.mu.Lock()
+	p.commandHandler = handler
+	p.mu.Unlock()
+
+	return nil
+}
+
+// --- Events (Steward → Controller) ---
+
+func (p *Provider) PublishEvent(ctx context.Context, event *types.Event) error {
+	if p.mode != ModeClient {
+		return fmt.Errorf("PublishEvent is only available in client mode")
+	}
+
+	msg := &transportpb.ControlMessage{
+		Payload: &transportpb.ControlMessage_Event{Event: eventToProto(event)},
+	}
+
+	p.sendMu.Lock()
+	err := p.controlStream.Send(msg)
+	p.sendMu.Unlock()
+
+	if err != nil {
+		p.deliveryFailures.Add(1)
+		return fmt.Errorf("failed to publish event: %w", err)
+	}
+
+	p.eventsPublished.Add(1)
+	return nil
+}
+
+func (p *Provider) SubscribeEvents(ctx context.Context, filter *types.EventFilter, handler interfaces.EventHandler) error {
+	if p.mode != ModeServer {
+		return fmt.Errorf("SubscribeEvents is only available in server mode")
+	}
+
+	p.mu.Lock()
+	p.eventHandlers = append(p.eventHandlers, eventSubscription{
+		filter:  filter,
+		handler: handler,
+	})
+	p.mu.Unlock()
+
+	return nil
+}
+
+// --- Heartbeats ---
+
+func (p *Provider) SendHeartbeat(ctx context.Context, heartbeat *types.Heartbeat) error {
+	if p.mode != ModeClient {
+		return fmt.Errorf("SendHeartbeat is only available in client mode")
+	}
+
+	msg := &transportpb.ControlMessage{
+		Payload: &transportpb.ControlMessage_Heartbeat{Heartbeat: heartbeatToProto(heartbeat)},
+	}
+
+	p.sendMu.Lock()
+	err := p.controlStream.Send(msg)
+	p.sendMu.Unlock()
+
+	if err != nil {
+		p.deliveryFailures.Add(1)
+		return fmt.Errorf("failed to send heartbeat: %w", err)
+	}
+
+	p.heartbeatsSent.Add(1)
+	return nil
+}
+
+func (p *Provider) SubscribeHeartbeats(ctx context.Context, handler interfaces.HeartbeatHandler) error {
+	if p.mode != ModeServer {
+		return fmt.Errorf("SubscribeHeartbeats is only available in server mode")
+	}
+
+	p.mu.Lock()
+	p.heartbeatHandlers = append(p.heartbeatHandlers, handler)
+	p.mu.Unlock()
+
+	return nil
+}
+
+// --- Responses ---
+
+func (p *Provider) SendResponse(ctx context.Context, response *types.Response) error {
+	if p.mode != ModeClient {
+		return fmt.Errorf("SendResponse is only available in client mode")
+	}
+
+	msg := &transportpb.ControlMessage{
+		Payload: &transportpb.ControlMessage_Response{Response: responseToProto(response)},
+	}
+
+	p.sendMu.Lock()
+	err := p.controlStream.Send(msg)
+	p.sendMu.Unlock()
+
+	if err != nil {
+		p.deliveryFailures.Add(1)
+		return fmt.Errorf("failed to send response: %w", err)
+	}
+
+	p.responsesSent.Add(1)
+	return nil
+}
+
+func (p *Provider) WaitForResponse(ctx context.Context, commandID string, timeout time.Duration) (*types.Response, error) {
+	if p.mode != ModeServer {
+		return nil, fmt.Errorf("WaitForResponse is only available in server mode")
+	}
+
+	ch := make(chan *types.Response, 1)
+
+	p.responseMu.Lock()
+	p.pendingResponses[commandID] = ch
+	p.responseMu.Unlock()
+
+	defer func() {
+		p.responseMu.Lock()
+		delete(p.pendingResponses, commandID)
+		p.responseMu.Unlock()
+	}()
+
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+
+	select {
+	case resp := <-ch:
+		p.responsesReceived.Add(1)
+		return resp, nil
+	case <-timer.C:
+		return nil, fmt.Errorf("timeout waiting for response to command %s", commandID)
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+}
+
+// dispatchResponse routes an incoming response to a waiting WaitForResponse call.
+func (p *Provider) dispatchResponse(resp *types.Response) {
+	p.responseMu.Lock()
+	ch, ok := p.pendingResponses[resp.CommandID]
+	p.responseMu.Unlock()
+
+	if ok {
+		select {
+		case ch <- resp:
+		default:
+		}
+	}
+}
+
+// dispatchEvent routes an incoming event to matching event handlers.
+func (p *Provider) dispatchEvent(event *types.Event) {
+	p.eventsReceived.Add(1)
+
+	p.mu.RLock()
+	handlers := make([]eventSubscription, len(p.eventHandlers))
+	copy(handlers, p.eventHandlers)
+	p.mu.RUnlock()
+
+	for _, sub := range handlers {
+		if sub.filter != nil && !sub.filter.Match(event) {
+			continue
+		}
+		handler := sub.handler
+		go func() {
+			if err := handler(p.ctx, event); err != nil {
+				p.logger.Error("event handler error", "event_id", event.ID, "error", err)
+			}
+		}()
+	}
+}
+
+// dispatchHeartbeat routes an incoming heartbeat to all heartbeat handlers.
+func (p *Provider) dispatchHeartbeat(hb *types.Heartbeat) {
+	p.heartbeatsReceived.Add(1)
+
+	p.mu.RLock()
+	handlers := make([]interfaces.HeartbeatHandler, len(p.heartbeatHandlers))
+	copy(handlers, p.heartbeatHandlers)
+	p.mu.RUnlock()
+
+	for _, handler := range handlers {
+		handler := handler
+		go func() {
+			if err := handler(p.ctx, hb); err != nil {
+				p.logger.Error("heartbeat handler error", "steward_id", hb.StewardID, "error", err)
+			}
+		}()
+	}
+}
+
+// --- Status & Monitoring ---
+
+func (p *Provider) GetStats(ctx context.Context) (*types.ControlPlaneStats, error) {
+	stats := &types.ControlPlaneStats{
+		CommandsSent:       p.commandsSent.Load(),
+		CommandsReceived:   p.commandsReceived.Load(),
+		EventsPublished:    p.eventsPublished.Load(),
+		EventsReceived:     p.eventsReceived.Load(),
+		HeartbeatsSent:     p.heartbeatsSent.Load(),
+		HeartbeatsReceived: p.heartbeatsReceived.Load(),
+		ResponsesSent:      p.responsesSent.Load(),
+		ResponsesReceived:  p.responsesReceived.Load(),
+		DeliveryFailures:   p.deliveryFailures.Load(),
+	}
+
+	p.mu.RLock()
+	if !p.startTime.IsZero() {
+		stats.Uptime = time.Since(p.startTime)
+	}
+	numEventHandlers := int64(len(p.eventHandlers))
+	numHeartbeatHandlers := int64(len(p.heartbeatHandlers))
+	p.mu.RUnlock()
+
+	stats.ActiveSubscriptions = numEventHandlers + numHeartbeatHandlers
+
+	if p.mode == ModeServer && p.registry != nil {
+		stats.ConnectedStewards = int64(p.registry.Count())
+	}
+
+	return stats, nil
+}
+
+func (p *Provider) Available() (bool, error) {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+
+	switch p.mode {
+	case ModeServer:
+		if p.addr == "" || p.tlsConfig == nil {
+			return false, fmt.Errorf("server mode requires addr and tls_config")
+		}
+		return true, nil
+	case ModeClient:
+		if p.addr == "" || p.tlsConfig == nil || p.stewardID == "" {
+			return false, fmt.Errorf("client mode requires addr, tls_config, and steward_id")
+		}
+		return true, nil
+	default:
+		return false, fmt.Errorf("provider not initialized")
+	}
+}
+
+func (p *Provider) IsConnected() bool {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+
+	switch p.mode {
+	case ModeServer:
+		return p.grpcServer != nil && p.listener != nil
+	case ModeClient:
+		return p.controlStream != nil
+	default:
+		return false
+	}
+}
+
+// --- gRPC StewardTransportServer implementation ---
+
+// transportServer implements the gRPC StewardTransportServer interface,
+// delegating to the Provider for handler dispatch and registry management.
+type transportServer struct {
+	transportpb.UnimplementedStewardTransportServer
+	provider *Provider
+}
+
+func (s *transportServer) Register(ctx context.Context, req *controllerpb.RegisterRequest) (*controllerpb.RegisterResponse, error) {
+	// Extract steward identity from the request
+	stewardID := req.GetCredentials().GetClientId()
+	if stewardID == "" {
+		return nil, status.Error(codes.InvalidArgument, "client_id is required in credentials")
+	}
+
+	s.provider.logger.Info("steward registered", "steward_id", stewardID, "version", req.GetVersion())
+
+	return &controllerpb.RegisterResponse{
+		StewardId: stewardID,
+		Status: &commonpb.Status{
+			Code:    commonpb.Status_OK,
+			Message: "registered",
+		},
+	}, nil
+}
+
+func (s *transportServer) Ping(ctx context.Context, req *transportpb.PingRequest) (*transportpb.PingResponse, error) {
+	return &transportpb.PingResponse{
+		RequestTimestampNs:  req.GetTimestampNs(),
+		ResponseTimestampNs: timestamppb.Now().AsTime().UnixNano(),
+	}, nil
+}
+
+func (s *transportServer) ControlChannel(stream grpc.BidiStreamingServer[transportpb.ControlMessage, transportpb.ControlMessage]) error {
+	// Extract steward identity from mTLS peer certificate
+	p, ok := peer.FromContext(stream.Context())
+	if !ok {
+		return status.Error(codes.Unauthenticated, "no peer info")
+	}
+
+	stewardID, err := extractStewardIDFromPeer(stream.Context())
+	if err != nil {
+		return status.Errorf(codes.Unauthenticated, "failed to extract steward identity: %v", err)
+	}
+
+	// Create a stream sender adapter for the registry
+	sender := &streamSender{stream: stream}
+
+	conn := &registry.StewardConnection{
+		StewardID:   stewardID,
+		Sender:      sender,
+		ConnectedAt: time.Now(),
+		RemoteAddr:  p.Addr.String(),
+	}
+
+	if err := s.provider.registry.Register(conn); err != nil {
+		return status.Errorf(codes.Internal, "failed to register steward: %v", err)
+	}
+	defer s.provider.registry.Unregister(stewardID)
+
+	s.provider.logger.Info("steward connected to ControlChannel", "steward_id", stewardID, "remote_addr", p.Addr.String())
+
+	// Receive loop: read messages from steward and dispatch
+	for {
+		msg, err := stream.Recv()
+		if err != nil {
+			s.provider.logger.Info("steward ControlChannel closed", "steward_id", stewardID, "error", err)
+			return nil
+		}
+
+		conn.UpdateActivity()
+
+		switch payload := msg.GetPayload().(type) {
+		case *transportpb.ControlMessage_Event:
+			event := eventFromProto(payload.Event)
+			s.provider.dispatchEvent(event)
+
+		case *transportpb.ControlMessage_Heartbeat:
+			hb := heartbeatFromProto(payload.Heartbeat)
+			s.provider.dispatchHeartbeat(hb)
+
+		case *transportpb.ControlMessage_Response:
+			resp := responseFromProto(payload.Response)
+			s.provider.dispatchResponse(resp)
+		}
+	}
+}
+
+// extractStewardIDFromPeer extracts the steward ID from the peer's TLS certificate CN.
+//
+// The QUIC transport credentials (quictransport.TransportCredentials) bridge the
+// QUIC-layer TLS state into gRPC's peer AuthInfo as credentials.TLSInfo. This
+// function reads the peer certificates from that TLS state and extracts the CN.
+func extractStewardIDFromPeer(ctx context.Context) (string, error) {
+	p, ok := peer.FromContext(ctx)
+	if !ok {
+		return "", fmt.Errorf("no peer info in context")
+	}
+
+	tlsInfo, ok := p.AuthInfo.(credentials.TLSInfo)
+	if !ok {
+		return "", fmt.Errorf("no TLS auth info in peer (got %T)", p.AuthInfo)
+	}
+
+	return quictransport.PeerStewardID(tlsInfo.State)
+}
+
+// streamSender adapts a gRPC server stream to the registry.MessageSender interface.
+type streamSender struct {
+	stream grpc.BidiStreamingServer[transportpb.ControlMessage, transportpb.ControlMessage]
+}
+
+func (s *streamSender) SendMsg(msg interface{}) error {
+	cm, ok := msg.(*transportpb.ControlMessage)
+	if !ok {
+		return fmt.Errorf("expected *ControlMessage, got %T", msg)
+	}
+	return s.stream.Send(cm)
+}

--- a/pkg/transport/quic/creds.go
+++ b/pkg/transport/quic/creds.go
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+
+package quic
+
+import (
+	"context"
+	"fmt"
+	"net"
+
+	"google.golang.org/grpc/credentials"
+)
+
+// TransportCredentials returns a gRPC TransportCredentials that reads TLS state
+// from the underlying QUIC connection instead of performing its own TLS handshake.
+//
+// When gRPC runs over QUIC, TLS happens at the QUIC layer during connection
+// establishment. gRPC does not need to (and must not) do TLS again. However,
+// gRPC's peer context and AuthInfo need access to the TLS state (specifically
+// peer certificates) for authorization decisions.
+//
+// This credentials implementation bridges the gap: its ServerHandshake reads
+// the TLS state from the net.Conn (which must be a *quic.Conn) and wraps it
+// as credentials.TLSInfo so that gRPC handlers can access peer certificates
+// through the standard peer.FromContext() mechanism.
+func TransportCredentials() credentials.TransportCredentials {
+	return &quicCreds{}
+}
+
+type quicCreds struct{}
+
+func (c *quicCreds) ClientHandshake(ctx context.Context, authority string, rawConn net.Conn) (net.Conn, credentials.AuthInfo, error) {
+	info, err := authInfoFromConn(rawConn)
+	if err != nil {
+		return nil, nil, err
+	}
+	return rawConn, info, nil
+}
+
+func (c *quicCreds) ServerHandshake(rawConn net.Conn) (net.Conn, credentials.AuthInfo, error) {
+	info, err := authInfoFromConn(rawConn)
+	if err != nil {
+		return nil, nil, err
+	}
+	return rawConn, info, nil
+}
+
+func (c *quicCreds) Info() credentials.ProtocolInfo {
+	return credentials.ProtocolInfo{
+		SecurityProtocol: "quic-tls",
+		SecurityVersion:  "1.3",
+	}
+}
+
+func (c *quicCreds) Clone() credentials.TransportCredentials {
+	return &quicCreds{}
+}
+
+func (c *quicCreds) OverrideServerName(_ string) error {
+	return nil
+}
+
+// authInfoFromConn extracts TLS state from a *quic.Conn and wraps it as
+// credentials.TLSInfo. Returns an error if the conn is not a *Conn or has
+// no TLS state (which should never happen with a properly configured QUIC listener).
+func authInfoFromConn(rawConn net.Conn) (credentials.AuthInfo, error) {
+	qc, ok := rawConn.(*Conn)
+	if !ok {
+		return nil, fmt.Errorf("expected *quic.Conn, got %T", rawConn)
+	}
+	state := qc.TLSConnectionState()
+	if state == nil {
+		return nil, fmt.Errorf("QUIC connection has no TLS state")
+	}
+	return credentials.TLSInfo{State: *state}, nil
+}

--- a/pkg/transport/quic/listener.go
+++ b/pkg/transport/quic/listener.go
@@ -12,12 +12,25 @@ import (
 	quicgo "github.com/quic-go/quic-go"
 )
 
-// defaultQuicConfig returns the default QUIC configuration for the transport
-// adapter. Callers may override individual fields by passing their own config.
+// defaultQuicConfig returns the default QUIC configuration for the transport adapter.
+//
+// Keepalive tuning rationale (Story #504):
+//
+//   - KeepAlivePeriod 25s: Under the 30s worst-case NAT/firewall UDP pinhole timeout.
+//     At 50k stewards this produces ~2,000 PING frames/sec (vs 5,000 at 10s).
+//     Application heartbeats (default 30s) provide additional traffic that keeps
+//     connections alive, so QUIC keepalives are a safety net, not the primary signal.
+//
+//   - MaxIdleTimeout 90s: 3.6× the keepalive period. A connection is torn down only
+//     after ~3 missed keepalives AND no application traffic. This is generous enough
+//     to survive transient network blips while still detecting genuinely dead connections
+//     well before the controller's heartbeat timeout (default 15s detection + this).
+//
+// Both values can be overridden by passing a custom *quic.Config to Listen/Dial.
 func defaultQuicConfig() *quicgo.Config {
 	return &quicgo.Config{
-		MaxIdleTimeout:  30 * time.Second,
-		KeepAlivePeriod: 10 * time.Second,
+		MaxIdleTimeout:  90 * time.Second,
+		KeepAlivePeriod: 25 * time.Second,
 	}
 }
 
@@ -46,8 +59,8 @@ var _ net.Listener = (*Listener)(nil)
 // Listen creates a new QUIC listener on the given address.
 //
 // tlsConfig must have NextProtos set to a value agreed with the client.
-// If quicConfig is nil, sensible defaults (MaxIdleTimeout: 30s,
-// KeepAlivePeriod: 10s) are used.
+// If quicConfig is nil, sensible defaults (MaxIdleTimeout: 90s,
+// KeepAlivePeriod: 25s) are used. See defaultQuicConfig for rationale.
 func Listen(addr string, tlsConfig *tls.Config, quicConfig *quicgo.Config) (*Listener, error) {
 	ql, err := quicgo.ListenAddr(addr, tlsConfig, mergeQuicConfig(quicConfig))
 	if err != nil {

--- a/pkg/transport/quic/tls.go
+++ b/pkg/transport/quic/tls.go
@@ -9,9 +9,11 @@ import (
 	"fmt"
 )
 
-// alpnProtocol is the ALPN protocol identifier for gRPC-over-QUIC in CFGMS.
+// ALPNProtocol is the ALPN protocol identifier for gRPC-over-QUIC in CFGMS.
 // Both sides must agree on this value for the TLS handshake to succeed.
-const alpnProtocol = "cfgms-grpc"
+// Use this constant when configuring TLS NextProtos outside of the
+// ServerTLSConfig/ClientTLSConfig helpers.
+const ALPNProtocol = "cfgms-grpc"
 
 // ServerTLSConfig returns a *tls.Config suitable for the QUIC listener (controller side).
 //
@@ -32,7 +34,7 @@ func ServerTLSConfig(serverCert tls.Certificate, clientCAs *x509.CertPool) (*tls
 		ClientAuth:   tls.RequireAndVerifyClientCert,
 		ClientCAs:    clientCAs,
 		MinVersion:   tls.VersionTLS13,
-		NextProtos:   []string{alpnProtocol},
+		NextProtos:   []string{ALPNProtocol},
 	}, nil
 }
 
@@ -54,7 +56,7 @@ func ClientTLSConfig(clientCert tls.Certificate, rootCAs *x509.CertPool) (*tls.C
 		Certificates: []tls.Certificate{clientCert},
 		RootCAs:      rootCAs,
 		MinVersion:   tls.VersionTLS13,
-		NextProtos:   []string{alpnProtocol},
+		NextProtos:   []string{ALPNProtocol},
 	}, nil
 }
 

--- a/pkg/transport/quic/tls_test.go
+++ b/pkg/transport/quic/tls_test.go
@@ -90,7 +90,7 @@ func TestServerTLSConfig_Valid(t *testing.T) {
 
 	assert.Equal(t, uint16(tls.VersionTLS13), cfg.MinVersion, "must enforce TLS 1.3")
 	assert.Equal(t, tls.RequireAndVerifyClientCert, cfg.ClientAuth, "must require client certificate")
-	assert.Equal(t, []string{alpnProtocol}, cfg.NextProtos, "must set ALPN to cfgms-grpc")
+	assert.Equal(t, []string{ALPNProtocol}, cfg.NextProtos, "must set ALPN to cfgms-grpc")
 	assert.Len(t, cfg.Certificates, 1)
 }
 
@@ -121,7 +121,7 @@ func TestClientTLSConfig_Valid(t *testing.T) {
 	require.NotNil(t, cfg)
 
 	assert.Equal(t, uint16(tls.VersionTLS13), cfg.MinVersion, "must enforce TLS 1.3")
-	assert.Equal(t, []string{alpnProtocol}, cfg.NextProtos, "must set ALPN to cfgms-grpc")
+	assert.Equal(t, []string{ALPNProtocol}, cfg.NextProtos, "must set ALPN to cfgms-grpc")
 	assert.Len(t, cfg.Certificates, 1)
 	assert.NotNil(t, cfg.RootCAs)
 }
@@ -334,7 +334,7 @@ func TestGRPCOverQUIC_mTLS_NoCert(t *testing.T) {
 		RootCAs:    caPool,
 		ServerName: "localhost",
 		MinVersion: tls.VersionTLS13,
-		NextProtos: []string{alpnProtocol},
+		NextProtos: []string{ALPNProtocol},
 	}
 
 	lis, err := Listen("127.0.0.1:0", serverTLS, nil)


### PR DESCRIPTION
## Summary

Implements a new `ControlPlaneProvider` named `"grpc"` that is a drop-in replacement for the existing MQTT provider. Carries all control plane traffic (commands, events, heartbeats, responses) over a persistent bidirectional gRPC `ControlChannel` stream per steward, eliminating the MQTT broker from the critical path. Includes a QUIC `TransportCredentials` bridge that exposes QUIC-layer mTLS state to gRPC for cryptographic steward identity extraction.

## Problem Context

The MQTT-based control plane adds a broker hop to every message and requires a stateful broker in the critical path. At 50k+ steward scale, this creates unnecessary latency and a single point of failure. Phases 1-4 and 7 built the foundation (interface evolution, proto definitions, QUIC adapter, connection registry, mTLS wiring). This phase wires them into a working provider.

## Changes

- New gRPC ControlPlaneProvider at `pkg/controlplane/providers/grpc/` implementing all 14 `ControlPlaneProvider` interface methods
- QUIC `TransportCredentials` bridge at `pkg/transport/quic/creds.go` — reads TLS state from QUIC connections and exposes it as gRPC `credentials.TLSInfo` for peer certificate access
- Bidirectional type converters between semantic types (`pkg/controlplane/types`) and proto wire format (`api/proto/transport`)
- QUIC keepalive tuned from 10s→25s (60% overhead reduction at scale) with 90s idle timeout — documented rationale for layering with application heartbeats
- Keepalive period and idle timeout configurable via provider config
- Exported `ALPNProtocol` constant for external TLS config consumers

## Measured Impact

- 32 tests passing: 20 unit tests (type converters, enum mappings) + 12 integration tests over real QUIC+mTLS
- Integration tests cover: command delivery, event/heartbeat/response flow, FanOutCommand (multi-steward), partial failure, WaitForResponse with timeout, EventFilter, disconnect registry cleanup, 5 concurrent stewards, stats tracking, mode validation, SendCommand after disconnect
- Zero `time.Sleep` synchronization — all async coordination uses `require.Eventually`/`require.Never`

## Testing

### QA Test Runner: PASS
- All quality validation gates passed (unit tests with race detection, linting, license headers, production critical tests, cross-platform builds, Docker integration)

### QA Code Review: PASS (after fixes)
- Initial review found 5 blocking issues (time.Sleep synchronization, missing error path)
- All fixed: replaced with require.Eventually/require.Never, added SendCommand-after-disconnect test, restructured concurrent steward test for safe t.Cleanup

### Security Review: PASS
- All automated scans passed (gosec, staticcheck, Trivy, Nancy, gitleaks, architecture)
- Manual review: no hardcoded secrets, no injection vectors, no central provider violations, correct mTLS enforcement, proper input validation

Fixes #504

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>