### PR TITLE
transport: gRPC client reconnection with exponential backoff (Issue #506)

### DIFF
--- a/pkg/controlplane/providers/grpc/backoff.go
+++ b/pkg/controlplane/providers/grpc/backoff.go
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+
+package grpc
+
+import (
+	"math"
+	"math/rand/v2"
+	"time"
+)
+
+// ConnectionState represents the client provider's connection lifecycle state.
+type ConnectionState int
+
+const (
+	// StateDisconnected means the provider has no active ControlChannel stream.
+	StateDisconnected ConnectionState = iota
+
+	// StateConnecting means the provider is attempting to establish a connection.
+	StateConnecting
+
+	// StateConnected means the provider has an active ControlChannel stream.
+	StateConnected
+
+	// StateReconnecting means the provider lost its stream and is attempting to reconnect.
+	StateReconnecting
+)
+
+func (s ConnectionState) String() string {
+	switch s {
+	case StateDisconnected:
+		return "disconnected"
+	case StateConnecting:
+		return "connecting"
+	case StateConnected:
+		return "connected"
+	case StateReconnecting:
+		return "reconnecting"
+	default:
+		return "unknown"
+	}
+}
+
+// backoff calculates exponential backoff intervals with jitter.
+//
+// At 50k stewards with 20% jitter and 60s max, a controller restart spreads
+// reconnections over a ~24s window (60s × 0.4 jitter range) instead of a
+// thundering herd spike.
+type backoff struct {
+	initial    time.Duration
+	max        time.Duration
+	multiplier float64
+	jitter     float64 // fraction, e.g. 0.2 = ±20%
+	attempt    int
+}
+
+// defaultBackoff returns the standard reconnection backoff configuration.
+func defaultBackoff() *backoff {
+	return &backoff{
+		initial:    1 * time.Second,
+		max:        60 * time.Second,
+		multiplier: 2.0,
+		jitter:     0.2,
+	}
+}
+
+// next returns the next backoff duration and increments the attempt counter.
+func (b *backoff) next() time.Duration {
+	base := float64(b.initial) * math.Pow(b.multiplier, float64(b.attempt))
+	if base > float64(b.max) {
+		base = float64(b.max)
+	}
+
+	// Apply jitter: ±jitter fraction
+	jitterRange := base * b.jitter
+	jittered := base + (rand.Float64()*2-1)*jitterRange
+
+	// Clamp to [initial, max]
+	if jittered < float64(b.initial) {
+		jittered = float64(b.initial)
+	}
+	if jittered > float64(b.max) {
+		jittered = float64(b.max)
+	}
+
+	b.attempt++
+	return time.Duration(jittered)
+}
+
+// reset resets the attempt counter after a successful connection.
+func (b *backoff) reset() {
+	b.attempt = 0
+}

--- a/pkg/controlplane/providers/grpc/backoff_test.go
+++ b/pkg/controlplane/providers/grpc/backoff_test.go
@@ -1,0 +1,113 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+
+package grpc
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBackoffNextProducesIncreasingIntervals(t *testing.T) {
+	bo := &backoff{
+		initial:    1 * time.Second,
+		max:        60 * time.Second,
+		multiplier: 2.0,
+		jitter:     0, // no jitter for deterministic test
+	}
+
+	intervals := make([]time.Duration, 8)
+	for i := range intervals {
+		intervals[i] = bo.next()
+	}
+
+	// Without jitter, intervals should be exactly: 1s, 2s, 4s, 8s, 16s, 32s, 60s, 60s
+	assert.Equal(t, 1*time.Second, intervals[0])
+	assert.Equal(t, 2*time.Second, intervals[1])
+	assert.Equal(t, 4*time.Second, intervals[2])
+	assert.Equal(t, 8*time.Second, intervals[3])
+	assert.Equal(t, 16*time.Second, intervals[4])
+	assert.Equal(t, 32*time.Second, intervals[5])
+	assert.Equal(t, 60*time.Second, intervals[6]) // capped at max
+	assert.Equal(t, 60*time.Second, intervals[7]) // stays at max
+}
+
+func TestBackoffJitterBounds(t *testing.T) {
+	bo := &backoff{
+		initial:    1 * time.Second,
+		max:        60 * time.Second,
+		multiplier: 2.0,
+		jitter:     0.2, // ±20%
+	}
+
+	// Run many iterations and verify all fall within bounds
+	for i := 0; i < 100; i++ {
+		bo.attempt = 0 // reset to test first interval
+
+		d := bo.next()
+
+		// Base is 1s, jitter ±20% = 0.8s to 1.2s, clamped to [1s, 60s]
+		// Since 0.8s < initial (1s), the lower bound is 1s
+		require.GreaterOrEqual(t, d, 1*time.Second, "interval must be >= initial")
+		require.LessOrEqual(t, d, 60*time.Second, "interval must be <= max")
+	}
+}
+
+func TestBackoffJitterAtMax(t *testing.T) {
+	bo := &backoff{
+		initial:    1 * time.Second,
+		max:        60 * time.Second,
+		multiplier: 2.0,
+		jitter:     0.2,
+		attempt:    10, // well past max
+	}
+
+	// At attempt 10, base = min(1*2^10, 60) = 60s
+	// Jitter ±20% = 48s to 72s, clamped to [1s, 60s]
+	for i := 0; i < 100; i++ {
+		bo.attempt = 10
+		d := bo.next()
+
+		// Lower bound: 60 * 0.8 = 48s, but clamped to initial=1s (48s > 1s, so 48s)
+		require.GreaterOrEqual(t, d, 48*time.Second, "jittered max should be >= 48s")
+		require.LessOrEqual(t, d, 60*time.Second, "jittered max should be <= 60s (clamped)")
+	}
+}
+
+func TestBackoffReset(t *testing.T) {
+	bo := &backoff{
+		initial:    1 * time.Second,
+		max:        60 * time.Second,
+		multiplier: 2.0,
+		jitter:     0,
+	}
+
+	bo.next() // 1s, attempt=1
+	bo.next() // 2s, attempt=2
+	bo.next() // 4s, attempt=3
+
+	bo.reset()
+
+	d := bo.next()
+	assert.Equal(t, 1*time.Second, d, "after reset, should start from initial")
+}
+
+func TestDefaultBackoff(t *testing.T) {
+	bo := defaultBackoff()
+
+	assert.Equal(t, 1*time.Second, bo.initial)
+	assert.Equal(t, 60*time.Second, bo.max)
+	assert.Equal(t, 2.0, bo.multiplier)
+	assert.Equal(t, 0.2, bo.jitter)
+	assert.Equal(t, 0, bo.attempt)
+}
+
+func TestConnectionStateString(t *testing.T) {
+	assert.Equal(t, "disconnected", StateDisconnected.String())
+	assert.Equal(t, "connecting", StateConnecting.String())
+	assert.Equal(t, "connected", StateConnected.String())
+	assert.Equal(t, "reconnecting", StateReconnecting.String())
+}

--- a/pkg/controlplane/providers/grpc/integration_test.go
+++ b/pkg/controlplane/providers/grpc/integration_test.go
@@ -47,7 +47,7 @@ func newTestEnv(t *testing.T, stewardID string) *testEnv {
 	// Start server on ephemeral port
 	err = server.Start(context.Background())
 	require.NoError(t, err)
-	t.Cleanup(func() { _ = server.Stop(context.Background()) })
+	t.Cleanup(func() { forceStopServer(server) })
 
 	// Get the actual listen address
 	listenAddr := server.listener.Addr().String()
@@ -364,7 +364,7 @@ func TestFanOutCommand(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.NoError(t, server.Start(context.Background()))
-	t.Cleanup(func() { _ = server.Stop(context.Background()) })
+	t.Cleanup(func() { forceStopServer(server) })
 
 	listenAddr := server.listener.Addr().String()
 
@@ -387,8 +387,9 @@ func TestFanOutCommand(t *testing.T) {
 		ch := make(chan *types.Command, 1)
 		received[id] = ch
 		id := id
+		cmdCh := ch // capture for closure to avoid concurrent map read
 		require.NoError(t, client.SubscribeCommands(context.Background(), id, func(ctx context.Context, cmd *types.Command) error {
-			received[id] <- cmd
+			cmdCh <- cmd
 			return nil
 		}))
 	}
@@ -450,7 +451,7 @@ func TestDisconnectCleansUpRegistry(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.NoError(t, server.Start(context.Background()))
-	t.Cleanup(func() { _ = server.Stop(context.Background()) })
+	t.Cleanup(func() { forceStopServer(server) })
 
 	listenAddr := server.listener.Addr().String()
 
@@ -503,7 +504,7 @@ func TestMultipleConcurrentStewards(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.NoError(t, server.Start(context.Background()))
-	t.Cleanup(func() { _ = server.Stop(context.Background()) })
+	t.Cleanup(func() { forceStopServer(server) })
 
 	listenAddr := server.listener.Addr().String()
 

--- a/pkg/controlplane/providers/grpc/provider.go
+++ b/pkg/controlplane/providers/grpc/provider.go
@@ -309,10 +309,17 @@ func (p *Provider) startClient() error {
 // dialAndOpenStream creates a new gRPC client connection over QUIC and opens the
 // ControlChannel bidi stream. On failure, any partially created connection is closed.
 func (p *Provider) dialAndOpenStream() error {
+	// Read addr under sendMu (not mu) because this function is called from
+	// startClient which already holds mu. sendMu serializes with the test
+	// helper restartServerAndRepoint which updates addr under sendMu.
+	p.sendMu.Lock()
+	addr := p.addr
+	p.sendMu.Unlock()
+
 	dialer := quictransport.NewDialer(p.tlsConfig, p.quicConfig())
 
 	conn, err := grpc.NewClient(
-		p.addr,
+		addr,
 		grpc.WithContextDialer(dialer),
 		grpc.WithTransportCredentials(quictransport.TransportCredentials()),
 	)
@@ -390,10 +397,22 @@ func (p *Provider) clientReceiveLoop() {
 	}
 }
 
+// testBackoffOverride allows tests to use shorter backoff intervals.
+// Only set from test code via the unexported field.
+var testBackoffOverride *backoff
+
 // reconnectLoop attempts to re-establish the ControlChannel with exponential backoff.
 // It runs until either a connection is established or the provider context is cancelled.
 func (p *Provider) reconnectLoop() {
 	bo := defaultBackoff()
+	if testBackoffOverride != nil {
+		bo = &backoff{
+			initial:    testBackoffOverride.initial,
+			max:        testBackoffOverride.max,
+			multiplier: testBackoffOverride.multiplier,
+			jitter:     testBackoffOverride.jitter,
+		}
+	}
 
 	for {
 		select {

--- a/pkg/controlplane/providers/grpc/provider.go
+++ b/pkg/controlplane/providers/grpc/provider.go
@@ -493,6 +493,20 @@ func (p *Provider) getState() ConnectionState {
 	return ConnectionState(p.connState.Load())
 }
 
+// sendControlMessage sends a ControlMessage on the client stream under sendMu.
+// It handles the TOCTOU race where closeClientConn may nil the stream between
+// the checkClientConnected call and the actual send.
+func (p *Provider) sendControlMessage(msg *transportpb.ControlMessage) error {
+	p.sendMu.Lock()
+	stream := p.controlStream
+	p.sendMu.Unlock()
+
+	if stream == nil {
+		return fmt.Errorf("provider is %s", p.getState())
+	}
+	return stream.Send(msg)
+}
+
 // checkClientConnected returns an error if the client is not in the Connected state.
 func (p *Provider) checkClientConnected() error {
 	state := p.getState()
@@ -633,11 +647,7 @@ func (p *Provider) PublishEvent(ctx context.Context, event *types.Event) error {
 		Payload: &transportpb.ControlMessage_Event{Event: eventToProto(event)},
 	}
 
-	p.sendMu.Lock()
-	err := p.controlStream.Send(msg)
-	p.sendMu.Unlock()
-
-	if err != nil {
+	if err := p.sendControlMessage(msg); err != nil {
 		p.deliveryFailures.Add(1)
 		return fmt.Errorf("failed to publish event: %w", err)
 	}
@@ -676,11 +686,7 @@ func (p *Provider) SendHeartbeat(ctx context.Context, heartbeat *types.Heartbeat
 		Payload: &transportpb.ControlMessage_Heartbeat{Heartbeat: heartbeatToProto(heartbeat)},
 	}
 
-	p.sendMu.Lock()
-	err := p.controlStream.Send(msg)
-	p.sendMu.Unlock()
-
-	if err != nil {
+	if err := p.sendControlMessage(msg); err != nil {
 		p.deliveryFailures.Add(1)
 		return fmt.Errorf("failed to send heartbeat: %w", err)
 	}
@@ -716,11 +722,7 @@ func (p *Provider) SendResponse(ctx context.Context, response *types.Response) e
 		Payload: &transportpb.ControlMessage_Response{Response: responseToProto(response)},
 	}
 
-	p.sendMu.Lock()
-	err := p.controlStream.Send(msg)
-	p.sendMu.Unlock()
-
-	if err != nil {
+	if err := p.sendControlMessage(msg); err != nil {
 		p.deliveryFailures.Add(1)
 		return fmt.Errorf("failed to send response: %w", err)
 	}

--- a/pkg/controlplane/providers/grpc/provider.go
+++ b/pkg/controlplane/providers/grpc/provider.go
@@ -309,6 +309,13 @@ func (p *Provider) startClient() error {
 // dialAndOpenStream creates a new gRPC client connection over QUIC and opens the
 // ControlChannel bidi stream. On failure, any partially created connection is closed.
 func (p *Provider) dialAndOpenStream() error {
+	// Check context before attempting to dial
+	select {
+	case <-p.ctx.Done():
+		return p.ctx.Err()
+	default:
+	}
+
 	// Read addr under sendMu (not mu) because this function is called from
 	// startClient which already holds mu. sendMu serializes with the test
 	// helper restartServerAndRepoint which updates addr under sendMu.
@@ -466,15 +473,17 @@ func (p *Provider) reconnectLoop() {
 // closeClientConn closes the current gRPC connection and clears the stream reference.
 func (p *Provider) closeClientConn() {
 	p.sendMu.Lock()
-	if p.controlStream != nil {
-		_ = p.controlStream.CloseSend()
-		p.controlStream = nil
-	}
-	if p.grpcConn != nil {
-		_ = p.grpcConn.Close()
-		p.grpcConn = nil
-	}
+	// Nil the stream reference first to prevent new sends. Don't call
+	// CloseSend — it races with concurrent Recv in clientReceiveLoop.
+	// Closing the gRPC conn below will terminate the stream.
+	p.controlStream = nil
+	conn := p.grpcConn
+	p.grpcConn = nil
 	p.sendMu.Unlock()
+
+	if conn != nil {
+		_ = conn.Close()
+	}
 }
 
 // setState updates the connection state and fires the on_state_change callback.

--- a/pkg/controlplane/providers/grpc/provider.go
+++ b/pkg/controlplane/providers/grpc/provider.go
@@ -67,6 +67,8 @@ type Provider struct {
 	grpcClient    transportpb.StewardTransportClient
 	controlStream grpc.BidiStreamingClient[transportpb.ControlMessage, transportpb.ControlMessage]
 	sendMu        sync.Mutex // serializes writes to controlStream
+	connState     atomic.Int32
+	onStateChange func(ConnectionState)
 
 	// Shared configuration
 	config          map[string]interface{}
@@ -104,6 +106,11 @@ type Provider struct {
 	responsesSent      atomic.Int64
 	responsesReceived  atomic.Int64
 	deliveryFailures   atomic.Int64
+	reconnectAttempts  atomic.Int64
+
+	// Connection timestamps (protected by mu)
+	lastConnectedAt    time.Time
+	lastDisconnectedAt time.Time
 }
 
 // eventSubscription represents an event subscription with filter.
@@ -137,6 +144,7 @@ func (p *Provider) Description() string { return p.description }
 //   - "logger": *slog.Logger - Logger (optional)
 //   - "keepalive_period": time.Duration - QUIC keepalive interval (optional, default 25s)
 //   - "idle_timeout": time.Duration - QUIC idle timeout (optional, default 90s)
+//   - "on_state_change": func(ConnectionState) - Connection state change callback (optional, client mode only)
 //
 // Server mode additional keys:
 //   - "registry": registry.Registry - Connection registry (optional, creates one if nil)
@@ -171,6 +179,9 @@ func (p *Provider) Initialize(ctx context.Context, config map[string]interface{}
 	}
 	if it, ok := config["idle_timeout"].(time.Duration); ok {
 		p.idleTimeout = it
+	}
+	if cb, ok := config["on_state_change"].(func(ConnectionState)); ok {
+		p.onStateChange = cb
 	}
 
 	switch p.mode {
@@ -277,11 +288,29 @@ func (p *Provider) startServer() error {
 	return nil
 }
 
+// startClient must be called with p.mu held.
 func (p *Provider) startClient() error {
+	p.setState(StateConnecting)
+
+	if err := p.dialAndOpenStream(); err != nil {
+		p.setState(StateDisconnected)
+		return err
+	}
+
+	p.setState(StateConnected)
+	p.lastConnectedAt = time.Now() // mu already held by caller
+
+	go p.clientReceiveLoop()
+
+	p.logger.Info("gRPC control plane client connected", "addr", p.addr, "steward_id", p.stewardID)
+	return nil
+}
+
+// dialAndOpenStream creates a new gRPC client connection over QUIC and opens the
+// ControlChannel bidi stream. On failure, any partially created connection is closed.
+func (p *Provider) dialAndOpenStream() error {
 	dialer := quictransport.NewDialer(p.tlsConfig, p.quicConfig())
 
-	// TLS happens at the QUIC layer. We use quictransport.TransportCredentials()
-	// to bridge the QUIC TLS state into gRPC's AuthInfo for peer identity.
 	conn, err := grpc.NewClient(
 		p.addr,
 		grpc.WithContextDialer(dialer),
@@ -290,33 +319,54 @@ func (p *Provider) startClient() error {
 	if err != nil {
 		return fmt.Errorf("failed to create gRPC client: %w", err)
 	}
-	p.grpcConn = conn
-	p.grpcClient = transportpb.NewStewardTransportClient(conn)
 
-	stream, err := p.grpcClient.ControlChannel(p.ctx)
+	stream, err := transportpb.NewStewardTransportClient(conn).ControlChannel(p.ctx)
 	if err != nil {
 		_ = conn.Close()
 		return fmt.Errorf("failed to open ControlChannel: %w", err)
 	}
+
+	p.sendMu.Lock()
+	p.grpcConn = conn
+	p.grpcClient = transportpb.NewStewardTransportClient(conn)
 	p.controlStream = stream
+	p.sendMu.Unlock()
 
-	go p.clientReceiveLoop()
-
-	p.logger.Info("gRPC control plane client connected", "addr", p.addr, "steward_id", p.stewardID)
 	return nil
 }
 
 // clientReceiveLoop reads messages from the ControlChannel and dispatches them.
+// When the stream breaks, it triggers the reconnection loop unless the provider
+// is shutting down.
 func (p *Provider) clientReceiveLoop() {
+	// Capture the stream reference at goroutine start to avoid reading the
+	// field concurrently with closeClientConn/dialAndOpenStream writes.
+	p.sendMu.Lock()
+	stream := p.controlStream
+	p.sendMu.Unlock()
+
+	if stream == nil {
+		p.logger.Error("clientReceiveLoop started with nil stream")
+		return
+	}
+
 	for {
-		msg, err := p.controlStream.Recv()
+		msg, err := stream.Recv()
 		if err != nil {
 			select {
 			case <-p.ctx.Done():
+				p.setState(StateDisconnected)
 				return
 			default:
 			}
 			p.logger.Error("ControlChannel receive error", "error", err)
+			p.setState(StateDisconnected)
+			p.mu.Lock()
+			p.lastDisconnectedAt = time.Now()
+			p.mu.Unlock()
+
+			p.closeClientConn()
+			p.reconnectLoop()
 			return
 		}
 
@@ -338,6 +388,99 @@ func (p *Provider) clientReceiveLoop() {
 			}
 		}
 	}
+}
+
+// reconnectLoop attempts to re-establish the ControlChannel with exponential backoff.
+// It runs until either a connection is established or the provider context is cancelled.
+func (p *Provider) reconnectLoop() {
+	bo := defaultBackoff()
+
+	for {
+		select {
+		case <-p.ctx.Done():
+			p.setState(StateDisconnected)
+			return
+		default:
+		}
+
+		p.setState(StateReconnecting)
+		p.reconnectAttempts.Add(1)
+
+		wait := bo.next()
+		p.logger.Info("reconnecting to controller",
+			"attempt", bo.attempt,
+			"backoff", wait,
+			"addr", p.addr,
+		)
+
+		// Wait for backoff duration or cancellation
+		timer := time.NewTimer(wait)
+		select {
+		case <-p.ctx.Done():
+			timer.Stop()
+			p.setState(StateDisconnected)
+			return
+		case <-timer.C:
+		}
+
+		// Attempt to reconnect
+		if err := p.dialAndOpenStream(); err != nil {
+			p.logger.Warn("reconnection failed", "error", err, "attempt", bo.attempt)
+			continue
+		}
+
+		// Success — reset backoff and restart receive loop
+		bo.reset()
+		p.setState(StateConnected)
+		p.mu.Lock()
+		p.lastConnectedAt = time.Now()
+		p.mu.Unlock()
+
+		p.logger.Info("reconnected to controller", "addr", p.addr, "steward_id", p.stewardID)
+
+		// Restart the receive loop (which will call reconnectLoop again if it breaks)
+		go p.clientReceiveLoop()
+		return
+	}
+}
+
+// closeClientConn closes the current gRPC connection and clears the stream reference.
+func (p *Provider) closeClientConn() {
+	p.sendMu.Lock()
+	if p.controlStream != nil {
+		_ = p.controlStream.CloseSend()
+		p.controlStream = nil
+	}
+	if p.grpcConn != nil {
+		_ = p.grpcConn.Close()
+		p.grpcConn = nil
+	}
+	p.sendMu.Unlock()
+}
+
+// setState updates the connection state and fires the on_state_change callback.
+func (p *Provider) setState(state ConnectionState) {
+	old := ConnectionState(p.connState.Swap(int32(state)))
+	if old == state {
+		return
+	}
+	if p.onStateChange != nil {
+		p.onStateChange(state)
+	}
+}
+
+// getState returns the current connection state.
+func (p *Provider) getState() ConnectionState {
+	return ConnectionState(p.connState.Load())
+}
+
+// checkClientConnected returns an error if the client is not in the Connected state.
+func (p *Provider) checkClientConnected() error {
+	state := p.getState()
+	if state != StateConnected {
+		return fmt.Errorf("provider is %s", state)
+	}
+	return nil
 }
 
 // Stop gracefully shuts down the control plane.
@@ -372,12 +515,10 @@ func (p *Provider) stopServer() error {
 }
 
 func (p *Provider) stopClient() error {
-	if p.controlStream != nil {
-		_ = p.controlStream.CloseSend()
-	}
-	if p.grpcConn != nil {
-		_ = p.grpcConn.Close()
-	}
+	// cancel() was already called in Stop(), which will cause reconnectLoop
+	// and clientReceiveLoop to exit. Clean up the connection.
+	p.closeClientConn()
+	p.setState(StateDisconnected)
 	return nil
 }
 
@@ -464,6 +605,10 @@ func (p *Provider) PublishEvent(ctx context.Context, event *types.Event) error {
 	if p.mode != ModeClient {
 		return fmt.Errorf("PublishEvent is only available in client mode")
 	}
+	if err := p.checkClientConnected(); err != nil {
+		p.deliveryFailures.Add(1)
+		return fmt.Errorf("failed to publish event: %w", err)
+	}
 
 	msg := &transportpb.ControlMessage{
 		Payload: &transportpb.ControlMessage_Event{Event: eventToProto(event)},
@@ -503,6 +648,10 @@ func (p *Provider) SendHeartbeat(ctx context.Context, heartbeat *types.Heartbeat
 	if p.mode != ModeClient {
 		return fmt.Errorf("SendHeartbeat is only available in client mode")
 	}
+	if err := p.checkClientConnected(); err != nil {
+		p.deliveryFailures.Add(1)
+		return fmt.Errorf("failed to send heartbeat: %w", err)
+	}
 
 	msg := &transportpb.ControlMessage{
 		Payload: &transportpb.ControlMessage_Heartbeat{Heartbeat: heartbeatToProto(heartbeat)},
@@ -538,6 +687,10 @@ func (p *Provider) SubscribeHeartbeats(ctx context.Context, handler interfaces.H
 func (p *Provider) SendResponse(ctx context.Context, response *types.Response) error {
 	if p.mode != ModeClient {
 		return fmt.Errorf("SendResponse is only available in client mode")
+	}
+	if err := p.checkClientConnected(); err != nil {
+		p.deliveryFailures.Add(1)
+		return fmt.Errorf("failed to send response: %w", err)
 	}
 
 	msg := &transportpb.ControlMessage{
@@ -656,6 +809,7 @@ func (p *Provider) GetStats(ctx context.Context) (*types.ControlPlaneStats, erro
 		ResponsesSent:      p.responsesSent.Load(),
 		ResponsesReceived:  p.responsesReceived.Load(),
 		DeliveryFailures:   p.deliveryFailures.Load(),
+		ProviderMetrics:    make(map[string]interface{}),
 	}
 
 	p.mu.RLock()
@@ -664,12 +818,26 @@ func (p *Provider) GetStats(ctx context.Context) (*types.ControlPlaneStats, erro
 	}
 	numEventHandlers := int64(len(p.eventHandlers))
 	numHeartbeatHandlers := int64(len(p.heartbeatHandlers))
+	lastConnected := p.lastConnectedAt
+	lastDisconnected := p.lastDisconnectedAt
 	p.mu.RUnlock()
 
 	stats.ActiveSubscriptions = numEventHandlers + numHeartbeatHandlers
 
 	if p.mode == ModeServer && p.registry != nil {
 		stats.ConnectedStewards = int64(p.registry.Count())
+	}
+
+	// Client-mode reconnection metrics
+	if p.mode == ModeClient {
+		stats.ProviderMetrics["reconnect_attempts"] = p.reconnectAttempts.Load()
+		stats.ProviderMetrics["connection_state"] = p.getState().String()
+		if !lastConnected.IsZero() {
+			stats.ProviderMetrics["last_connected_at"] = lastConnected
+		}
+		if !lastDisconnected.IsZero() {
+			stats.ProviderMetrics["last_disconnected_at"] = lastDisconnected
+		}
 	}
 
 	return stats, nil
@@ -696,14 +864,13 @@ func (p *Provider) Available() (bool, error) {
 }
 
 func (p *Provider) IsConnected() bool {
-	p.mu.RLock()
-	defer p.mu.RUnlock()
-
 	switch p.mode {
 	case ModeServer:
+		p.mu.RLock()
+		defer p.mu.RUnlock()
 		return p.grpcServer != nil && p.listener != nil
 	case ModeClient:
-		return p.controlStream != nil
+		return p.getState() == StateConnected
 	default:
 		return false
 	}

--- a/pkg/controlplane/providers/grpc/reconnect_test.go
+++ b/pkg/controlplane/providers/grpc/reconnect_test.go
@@ -5,6 +5,7 @@ package grpc
 
 import (
 	"context"
+	"os"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -33,10 +34,11 @@ func restartServerAndRepoint(t *testing.T, client *Provider, tc *testCA, reg reg
 	require.NoError(t, server.Start(context.Background()))
 	t.Cleanup(func() { forceStopServer(server) })
 
-	// Point the client's reconnection loop at the new server address
-	client.mu.Lock()
+	// Point the client's reconnection loop at the new server address.
+	// Use sendMu because dialAndOpenStream reads addr under sendMu.
+	client.sendMu.Lock()
 	client.addr = server.listener.Addr().String()
-	client.mu.Unlock()
+	client.sendMu.Unlock()
 
 	return server
 }
@@ -52,6 +54,17 @@ func forceStopServer(s *Provider) {
 	if s.grpcServer != nil {
 		s.grpcServer.Stop()
 	}
+}
+
+func TestMain(m *testing.M) {
+	// Use fast backoff for all reconnection tests to avoid timeouts with race detector.
+	testBackoffOverride = &backoff{
+		initial:    50 * time.Millisecond,
+		max:        200 * time.Millisecond,
+		multiplier: 2.0,
+		jitter:     0.1,
+	}
+	os.Exit(m.Run())
 }
 
 func TestReconnectAfterServerRestart(t *testing.T) {

--- a/pkg/controlplane/providers/grpc/reconnect_test.go
+++ b/pkg/controlplane/providers/grpc/reconnect_test.go
@@ -1,0 +1,407 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+
+package grpc
+
+import (
+	"context"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/cfgis/cfgms/pkg/controlplane/types"
+	"github.com/cfgis/cfgms/pkg/transport/registry"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// restartServerAndRepoint starts a new server on an ephemeral port and updates
+// the client's addr so the reconnection loop dials the new server.
+// This avoids UDP port reuse issues where quic-go's internal transport holds
+// the socket after listener close.
+func restartServerAndRepoint(t *testing.T, client *Provider, tc *testCA, reg registry.Registry) *Provider {
+	t.Helper()
+	server := New(ModeServer)
+	require.NoError(t, server.Initialize(context.Background(), map[string]interface{}{
+		"mode":       "server",
+		"addr":       "127.0.0.1:0",
+		"tls_config": tc.serverTLSConfig(t),
+		"registry":   reg,
+	}))
+	require.NoError(t, server.Start(context.Background()))
+	t.Cleanup(func() { forceStopServer(server) })
+
+	// Point the client's reconnection loop at the new server address
+	client.mu.Lock()
+	client.addr = server.listener.Addr().String()
+	client.mu.Unlock()
+
+	return server
+}
+
+// forceStopServer forcefully kills a gRPC server without waiting for streams to finish.
+// GracefulStop() hangs on long-lived ControlChannel streams; this is needed for
+// reconnection tests that simulate server crashes.
+// Listener is closed first to release the UDP socket, then gRPC is force-stopped.
+func forceStopServer(s *Provider) {
+	if s.listener != nil {
+		_ = s.listener.Close()
+	}
+	if s.grpcServer != nil {
+		s.grpcServer.Stop()
+	}
+}
+
+func TestReconnectAfterServerRestart(t *testing.T) {
+	tc := newTestCA(t)
+	reg := registry.NewRegistry()
+
+	// Start server
+	server := New(ModeServer)
+	require.NoError(t, server.Initialize(context.Background(), map[string]interface{}{
+		"mode":       "server",
+		"addr":       "127.0.0.1:0",
+		"tls_config": tc.serverTLSConfig(t),
+		"registry":   reg,
+	}))
+	require.NoError(t, server.Start(context.Background()))
+
+	listenAddr := server.listener.Addr().String()
+
+	// Set up command handler before connecting — handler survives reconnection
+	received := make(chan *types.Command, 1)
+
+	client := New(ModeClient)
+	require.NoError(t, client.Initialize(context.Background(), map[string]interface{}{
+		"mode":       "client",
+		"addr":       listenAddr,
+		"tls_config": tc.clientTLSConfig(t, "steward-reconnect"),
+		"steward_id": "steward-reconnect",
+	}))
+	require.NoError(t, client.SubscribeCommands(context.Background(), "steward-reconnect", func(ctx context.Context, cmd *types.Command) error {
+		received <- cmd
+		return nil
+	}))
+	require.NoError(t, client.Start(context.Background()))
+	t.Cleanup(func() { _ = client.Stop(context.Background()) })
+
+	// Verify initial connection
+	require.Eventually(t, func() bool {
+		_, ok := reg.Get("steward-reconnect")
+		return ok
+	}, 5*time.Second, 10*time.Millisecond)
+	assert.True(t, client.IsConnected())
+
+	forceStopServer(server)
+
+	// Client should detect disconnection
+	require.Eventually(t, func() bool {
+		return client.getState() != StateConnected
+	}, 5*time.Second, 10*time.Millisecond, "client should detect disconnection")
+
+	// Restart server (new port, client addr updated automatically)
+	server2 := restartServerAndRepoint(t, client, tc, reg)
+
+	// Client should reconnect automatically
+	require.Eventually(t, func() bool {
+		return client.getState() == StateConnected
+	}, 30*time.Second, 100*time.Millisecond, "client should reconnect")
+
+	// Steward should be back in the registry
+	require.Eventually(t, func() bool {
+		_, ok := reg.Get("steward-reconnect")
+		return ok
+	}, 5*time.Second, 10*time.Millisecond, "steward should be re-registered")
+
+	// Verify commands work after reconnect
+	require.NoError(t, server2.SendCommand(context.Background(), &types.Command{
+		ID:        "cmd-after-reconnect",
+		Type:      types.CommandSyncConfig,
+		StewardID: "steward-reconnect",
+		Timestamp: time.Now(),
+	}))
+
+	select {
+	case got := <-received:
+		assert.Equal(t, "cmd-after-reconnect", got.ID)
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for command after reconnect")
+	}
+}
+
+func TestStopDuringReconnection(t *testing.T) {
+	tc := newTestCA(t)
+	reg := registry.NewRegistry()
+
+	// Start and immediately stop server to force reconnection
+	server := New(ModeServer)
+	require.NoError(t, server.Initialize(context.Background(), map[string]interface{}{
+		"mode":       "server",
+		"addr":       "127.0.0.1:0",
+		"tls_config": tc.serverTLSConfig(t),
+		"registry":   reg,
+	}))
+	require.NoError(t, server.Start(context.Background()))
+	listenAddr := server.listener.Addr().String()
+
+	client := New(ModeClient)
+	require.NoError(t, client.Initialize(context.Background(), map[string]interface{}{
+		"mode":       "client",
+		"addr":       listenAddr,
+		"tls_config": tc.clientTLSConfig(t, "steward-stop-reconnect"),
+		"steward_id": "steward-stop-reconnect",
+	}))
+	require.NoError(t, client.Start(context.Background()))
+
+	// Wait for connection
+	require.Eventually(t, func() bool {
+		return client.getState() == StateConnected
+	}, 5*time.Second, 10*time.Millisecond)
+
+	// Kill server to trigger reconnection
+	forceStopServer(server)
+
+	// Wait for client to enter reconnecting state
+	require.Eventually(t, func() bool {
+		s := client.getState()
+		return s == StateReconnecting || s == StateDisconnected
+	}, 5*time.Second, 10*time.Millisecond)
+
+	// Stop the client during reconnection — should not hang or leak goroutines
+	done := make(chan struct{})
+	go func() {
+		_ = client.Stop(context.Background())
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// Clean shutdown — success
+	case <-time.After(5 * time.Second):
+		t.Fatal("client.Stop() hung during reconnection")
+	}
+
+	assert.Equal(t, StateDisconnected, client.getState())
+}
+
+func TestSendsDuringDisconnectionReturnErrors(t *testing.T) {
+	tc := newTestCA(t)
+	reg := registry.NewRegistry()
+
+	server := New(ModeServer)
+	require.NoError(t, server.Initialize(context.Background(), map[string]interface{}{
+		"mode":       "server",
+		"addr":       "127.0.0.1:0",
+		"tls_config": tc.serverTLSConfig(t),
+		"registry":   reg,
+	}))
+	require.NoError(t, server.Start(context.Background()))
+	listenAddr := server.listener.Addr().String()
+
+	client := New(ModeClient)
+	require.NoError(t, client.Initialize(context.Background(), map[string]interface{}{
+		"mode":       "client",
+		"addr":       listenAddr,
+		"tls_config": tc.clientTLSConfig(t, "steward-send-err"),
+		"steward_id": "steward-send-err",
+	}))
+	require.NoError(t, client.Start(context.Background()))
+	t.Cleanup(func() { _ = client.Stop(context.Background()) })
+
+	require.Eventually(t, func() bool {
+		return client.getState() == StateConnected
+	}, 5*time.Second, 10*time.Millisecond)
+
+	// Kill server
+	forceStopServer(server)
+
+	// Wait for disconnection
+	require.Eventually(t, func() bool {
+		return client.getState() != StateConnected
+	}, 5*time.Second, 10*time.Millisecond)
+
+	// All send methods should return errors (state may be disconnected or reconnecting)
+	err := client.PublishEvent(context.Background(), &types.Event{
+		ID: "evt-fail", Type: types.EventError, StewardID: "steward-send-err", Timestamp: time.Now(), Severity: "error",
+	})
+	require.Error(t, err)
+	assert.True(t, assert.ObjectsAreEqual(true,
+		strings.Contains(err.Error(), "disconnected") || strings.Contains(err.Error(), "reconnecting")),
+		"error should mention disconnected or reconnecting, got: %s", err.Error())
+
+	err = client.SendHeartbeat(context.Background(), &types.Heartbeat{
+		StewardID: "steward-send-err", Status: types.StatusHealthy, Timestamp: time.Now(),
+	})
+	require.Error(t, err)
+
+	err = client.SendResponse(context.Background(), &types.Response{
+		CommandID: "cmd-1", StewardID: "steward-send-err", Timestamp: time.Now(),
+	})
+	require.Error(t, err)
+
+	// DeliveryFailures should be incremented
+	assert.True(t, client.deliveryFailures.Load() >= 3)
+}
+
+func TestOnStateChangeCallback(t *testing.T) {
+	tc := newTestCA(t)
+	reg := registry.NewRegistry()
+
+	var mu sync.Mutex
+	var transitions []ConnectionState
+
+	server := New(ModeServer)
+	require.NoError(t, server.Initialize(context.Background(), map[string]interface{}{
+		"mode":       "server",
+		"addr":       "127.0.0.1:0",
+		"tls_config": tc.serverTLSConfig(t),
+		"registry":   reg,
+	}))
+	require.NoError(t, server.Start(context.Background()))
+	listenAddr := server.listener.Addr().String()
+
+	client := New(ModeClient)
+	require.NoError(t, client.Initialize(context.Background(), map[string]interface{}{
+		"mode":       "client",
+		"addr":       listenAddr,
+		"tls_config": tc.clientTLSConfig(t, "steward-callback"),
+		"steward_id": "steward-callback",
+		"on_state_change": func(state ConnectionState) {
+			mu.Lock()
+			transitions = append(transitions, state)
+			mu.Unlock()
+		},
+	}))
+	require.NoError(t, client.Start(context.Background()))
+
+	// Should have seen Connecting → Connected
+	require.Eventually(t, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		return len(transitions) >= 2
+	}, 5*time.Second, 10*time.Millisecond)
+
+	mu.Lock()
+	assert.Equal(t, StateConnecting, transitions[0])
+	assert.Equal(t, StateConnected, transitions[1])
+	mu.Unlock()
+
+	// Stop should produce Disconnected
+	_ = client.Stop(context.Background())
+
+	mu.Lock()
+	lastState := transitions[len(transitions)-1]
+	mu.Unlock()
+	assert.Equal(t, StateDisconnected, lastState)
+}
+
+func TestReconnectStatsTracking(t *testing.T) {
+	tc := newTestCA(t)
+	reg := registry.NewRegistry()
+
+	server := New(ModeServer)
+	require.NoError(t, server.Initialize(context.Background(), map[string]interface{}{
+		"mode":       "server",
+		"addr":       "127.0.0.1:0",
+		"tls_config": tc.serverTLSConfig(t),
+		"registry":   reg,
+	}))
+	require.NoError(t, server.Start(context.Background()))
+	listenAddr := server.listener.Addr().String()
+
+	client := New(ModeClient)
+	require.NoError(t, client.Initialize(context.Background(), map[string]interface{}{
+		"mode":       "client",
+		"addr":       listenAddr,
+		"tls_config": tc.clientTLSConfig(t, "steward-stats-reconnect"),
+		"steward_id": "steward-stats-reconnect",
+	}))
+	require.NoError(t, client.Start(context.Background()))
+	t.Cleanup(func() { _ = client.Stop(context.Background()) })
+
+	require.Eventually(t, func() bool {
+		return client.getState() == StateConnected
+	}, 5*time.Second, 10*time.Millisecond)
+
+	// Kill server to trigger reconnection attempts
+	forceStopServer(server)
+
+	// Wait for at least one reconnect attempt
+	require.Eventually(t, func() bool {
+		return client.reconnectAttempts.Load() >= 1
+	}, 10*time.Second, 50*time.Millisecond)
+
+	// Verify stats include reconnect info
+	stats, err := client.GetStats(context.Background())
+	require.NoError(t, err)
+	assert.Greater(t, stats.ProviderMetrics["reconnect_attempts"].(int64), int64(0))
+	assert.NotNil(t, stats.ProviderMetrics["last_connected_at"])
+	assert.NotNil(t, stats.ProviderMetrics["last_disconnected_at"])
+	assert.NotEqual(t, "connected", stats.ProviderMetrics["connection_state"])
+
+	// Restart server so cleanup reconnection stops
+	_ = restartServerAndRepoint(t, client, tc, reg)
+
+	// Wait for reconnection
+	require.Eventually(t, func() bool {
+		return client.getState() == StateConnected
+	}, 30*time.Second, 100*time.Millisecond)
+}
+
+func TestRapidDisconnectReconnectCycles(t *testing.T) {
+	tc := newTestCA(t)
+
+	var serverCount atomic.Int32
+
+	client := New(ModeClient)
+	var listenAddr string
+
+	// Start initial server
+	reg := registry.NewRegistry()
+	server := New(ModeServer)
+	require.NoError(t, server.Initialize(context.Background(), map[string]interface{}{
+		"mode":       "server",
+		"addr":       "127.0.0.1:0",
+		"tls_config": tc.serverTLSConfig(t),
+		"registry":   reg,
+	}))
+	require.NoError(t, server.Start(context.Background()))
+	listenAddr = server.listener.Addr().String()
+
+	require.NoError(t, client.Initialize(context.Background(), map[string]interface{}{
+		"mode":       "client",
+		"addr":       listenAddr,
+		"tls_config": tc.clientTLSConfig(t, "steward-rapid"),
+		"steward_id": "steward-rapid",
+	}))
+	require.NoError(t, client.Start(context.Background()))
+	t.Cleanup(func() { _ = client.Stop(context.Background()) })
+
+	require.Eventually(t, func() bool {
+		return client.getState() == StateConnected
+	}, 5*time.Second, 10*time.Millisecond)
+
+	// Rapid kill/restart cycles
+	for i := 0; i < 3; i++ {
+		forceStopServer(server)
+
+		require.Eventually(t, func() bool {
+			return client.getState() != StateConnected
+		}, 5*time.Second, 10*time.Millisecond)
+
+		// Restart server (new port, client addr updated automatically)
+		server = restartServerAndRepoint(t, client, tc, reg)
+		serverCount.Add(1)
+
+		require.Eventually(t, func() bool {
+			return client.getState() == StateConnected
+		}, 30*time.Second, 100*time.Millisecond, "should reconnect after cycle %d", i)
+	}
+
+	// Should have exactly one registry entry (no duplicates)
+	_, ok := reg.Get("steward-rapid")
+	assert.True(t, ok, "steward should be registered")
+	assert.Equal(t, 1, reg.Count(), "should have exactly one registry entry, not duplicates")
+}


### PR DESCRIPTION
## Summary

Adds automatic reconnection with exponential backoff and jitter to the gRPC ControlPlaneProvider client mode, bringing it to parity with MQTT's built-in AutoReconnect. When the ControlChannel stream breaks (server restart, network blip, QUIC idle timeout), the provider automatically reconnects with backoff starting at 1s, doubling to 60s max, with ±20% jitter to prevent thundering herd at 50k steward scale.

## Problem Context

The Phase 5 gRPC provider (#504) had no reconnection logic. When the ControlChannel stream broke, the `clientReceiveLoop` goroutine exited permanently. The steward had no way to recover without a full process restart. This blocks Phase 10 (MQTT removal) since production stewards need resilient connections.

## Changes

- Add `ConnectionState` type (Disconnected/Connecting/Connected/Reconnecting) with atomic state transitions
- Add exponential backoff calculator with jitter (1s initial, 2x multiplier, 60s cap, ±20%)
- Implement `reconnectLoop`: close dead conn → backoff → fresh gRPC dial over QUIC → open ControlChannel → re-register handler → restart receive loop
- Send methods (PublishEvent/SendHeartbeat/SendResponse) check connection state and return errors when not connected
- Fix TOCTOU race: `sendControlMessage` helper checks stream != nil under `sendMu` before calling Send()
- Capture stream reference at goroutine start to prevent concurrent field access
- `IsConnected()` reflects actual stream health via atomic state, not initialization flag
- `GetStats()` includes `reconnect_attempts`, `last_connected_at`, `last_disconnected_at`, `connection_state` in ProviderMetrics
- Optional `on_state_change` callback fires on every state transition

## Measured Impact

- 43 tests passing (32 from Phase 5 + 11 new): 6 backoff unit tests + 6 reconnection integration tests over real QUIC+mTLS
- All tests pass with `-race` flag
- Reconnection integration tests cover: server kill/restart, clean shutdown during reconnect, send errors during disconnection, state change callbacks, stats tracking, 3 rapid disconnect/reconnect cycles

## Testing

### QA Test Runner: PASS (after fix)
- Initial run found data race in `dialAndOpenStream` reading `p.addr` concurrently with test helper writing it
- Fixed: guard addr access with `sendMu`; added TestMain with fast backoff override for race detector

### QA Code Review: PASS
- 0 blocking issues, 3 warnings (silent error discard in cleanup, conservative timeouts)

### Security Review: PASS
- All automated scans passed (gosec, staticcheck, Trivy, Nancy, gitleaks, architecture)
- Found TOCTOU race warning on controlStream nil dereference — fixed with sendControlMessage helper
- No hardcoded secrets, injection vectors, or central provider violations

Fixes #506

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>