### PR TITLE
transport: gRPC authorization interceptor — replace MQTT ACL (Issue #488)

### DIFF
--- a/pkg/transport/auth/doc.go
+++ b/pkg/transport/auth/doc.go
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 CFGMS Contributors
+
+// Package auth provides gRPC interceptors for steward identity enforcement
+// in the CFGMS transport layer.
+//
+// # Security Model
+//
+// Every steward connects to the controller using mutual TLS (mTLS). The steward's
+// identity is the Common Name (CN) of its client certificate. This package
+// enforces that the identity embedded in gRPC messages matches the cryptographic
+// identity established during the TLS handshake.
+//
+// This is the gRPC equivalent of the MQTT ACL (features/controller/server/mqtt_acl.go)
+// — stewards can only act as themselves; they cannot impersonate other stewards or
+// send message types reserved for controllers.
+//
+// # Usage
+//
+// Register both interceptors when creating the gRPC server:
+//
+//	grpc.NewServer(
+//	    grpc.ChainUnaryInterceptor(auth.UnaryIdentityInterceptor()),
+//	    grpc.ChainStreamInterceptor(auth.StreamIdentityInterceptor()),
+//	)
+//
+// Inside handlers, retrieve the authenticated identity via:
+//
+//	identity, ok := auth.StewardIDFromContext(ctx)
+//
+// To validate ControlChannel message content, obtain a validator and call it
+// with the authenticated identity and the incoming message:
+//
+//	validator := auth.ControlChannelValidator()
+//	if err := validator(identity, msg); err != nil {
+//	    return err
+//	}
+package auth

--- a/pkg/transport/auth/interceptor.go
+++ b/pkg/transport/auth/interceptor.go
@@ -1,0 +1,145 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 CFGMS Contributors
+
+package auth
+
+import (
+	"context"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/peer"
+	"google.golang.org/grpc/status"
+
+	transportquic "github.com/cfgis/cfgms/pkg/transport/quic"
+)
+
+// StewardIdentity holds the authenticated identity extracted from mTLS.
+type StewardIdentity struct {
+	StewardID string
+}
+
+// stewardIDKey is the context key for the authenticated steward identity.
+type stewardIDKey struct{}
+
+// StewardIDFromContext extracts the authenticated steward identity from context.
+// Returns the identity and true if present, zero value and false if not.
+func StewardIDFromContext(ctx context.Context) (StewardIdentity, bool) {
+	id, ok := ctx.Value(stewardIDKey{}).(StewardIdentity)
+	return id, ok
+}
+
+// extractIdentity extracts the steward identity from the gRPC peer TLS state in ctx.
+// Returns a gRPC status error on failure so callers can return it directly.
+func extractIdentity(ctx context.Context) (StewardIdentity, error) {
+	p, ok := peer.FromContext(ctx)
+	if !ok {
+		return StewardIdentity{}, status.Error(codes.Unauthenticated, "mTLS certificate required")
+	}
+
+	tlsInfo, ok := p.AuthInfo.(credentials.TLSInfo)
+	if !ok {
+		return StewardIdentity{}, status.Error(codes.Unauthenticated, "mTLS certificate required")
+	}
+
+	id, err := transportquic.PeerStewardID(tlsInfo.State)
+	if err != nil {
+		return StewardIdentity{}, status.Error(codes.Unauthenticated, "steward identity not found in certificate")
+	}
+
+	return StewardIdentity{StewardID: id}, nil
+}
+
+// UnaryIdentityInterceptor returns a gRPC unary server interceptor that:
+//  1. Extracts the peer certificate from the TLS connection
+//  2. Reads the steward ID from the certificate CN
+//  3. Stores the StewardIdentity in the context for downstream handlers
+//  4. Rejects requests with no valid peer certificate
+func UnaryIdentityInterceptor() grpc.UnaryServerInterceptor {
+	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
+		identity, err := extractIdentity(ctx)
+		if err != nil {
+			return nil, err
+		}
+		ctx = context.WithValue(ctx, stewardIDKey{}, identity)
+		return handler(ctx, req)
+	}
+}
+
+// wrappedStream injects a replacement context into a grpc.ServerStream.
+type wrappedStream struct {
+	grpc.ServerStream
+	ctx context.Context
+}
+
+// Context returns the injected context, overriding the embedded stream's context.
+func (w *wrappedStream) Context() context.Context {
+	return w.ctx
+}
+
+// StreamIdentityInterceptor returns a gRPC stream server interceptor that:
+//  1. Extracts the peer certificate from the TLS connection
+//  2. Reads the steward ID from the certificate CN
+//  3. Wraps the stream to include StewardIdentity in the context
+//  4. Rejects streams with no valid peer certificate
+func StreamIdentityInterceptor() grpc.StreamServerInterceptor {
+	return func(srv interface{}, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+		identity, err := extractIdentity(ss.Context())
+		if err != nil {
+			return err
+		}
+		ctx := context.WithValue(ss.Context(), stewardIDKey{}, identity)
+		return handler(srv, &wrappedStream{ss, ctx})
+	}
+}
+
+// MessageValidator is a function that checks whether a message is authorized
+// for the given steward identity. Return nil to allow, non-nil error to reject.
+type MessageValidator func(identity StewardIdentity, msg interface{}) error
+
+// commandMessage is implemented by Command proto messages. Command is unique
+// among ControlMessage payloads in carrying a priority field; this interface
+// allows detection without importing the proto package.
+type commandMessage interface {
+	GetPriority() int32
+}
+
+// stewardMessage is implemented by Event, Heartbeat, and Response proto messages,
+// all of which carry a steward_id that must be validated against the TLS identity.
+type stewardMessage interface {
+	GetStewardId() string
+}
+
+// ControlChannelValidator returns a MessageValidator for ControlChannel messages.
+//
+// Rules:
+//   - Commands: REJECTED — only controllers send commands, never stewards
+//   - Events: event.steward_id must match authenticated identity
+//   - Heartbeats: heartbeat.steward_id must match authenticated identity
+//   - Responses: response.steward_id must match authenticated identity
+//   - Unknown types: allowed for forward compatibility
+//
+// The validator accepts interface{} to stay proto-version-agnostic and uses
+// structural type assertions (duck typing) to detect message types. This keeps
+// tests free of generated proto code.
+func ControlChannelValidator() MessageValidator {
+	return func(identity StewardIdentity, msg interface{}) error {
+		// Commands are controller-only. Stewards receiving a command message
+		// type on an inbound stream indicates a protocol violation.
+		if _, ok := msg.(commandMessage); ok {
+			return status.Error(codes.PermissionDenied, "stewards cannot send commands")
+		}
+
+		// Events, Heartbeats, and Responses must carry the authenticated steward ID.
+		if m, ok := msg.(stewardMessage); ok {
+			if m.GetStewardId() != identity.StewardID {
+				return status.Error(codes.PermissionDenied, "steward ID in message does not match authenticated identity")
+			}
+			return nil
+		}
+
+		// Unknown message types are allowed for forward compatibility.
+		return nil
+	}
+}

--- a/pkg/transport/auth/interceptor_test.go
+++ b/pkg/transport/auth/interceptor_test.go
@@ -1,0 +1,398 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 CFGMS Contributors
+
+package auth
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/peer"
+	"google.golang.org/grpc/status"
+)
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+// otherAuthInfo is a credentials.AuthInfo that is not TLS, used to simulate
+// a peer connected without TLS.
+type otherAuthInfo struct{}
+
+func (o otherAuthInfo) AuthType() string { return "other" }
+
+// peerContextWithCN returns a context carrying a gRPC peer whose TLS state
+// contains a single peer certificate with the given Common Name.
+func peerContextWithCN(cn string) context.Context {
+	cert := &x509.Certificate{
+		Subject: pkix.Name{CommonName: cn},
+	}
+	p := &peer.Peer{
+		AuthInfo: credentials.TLSInfo{
+			State: tls.ConnectionState{
+				PeerCertificates: []*x509.Certificate{cert},
+			},
+		},
+	}
+	return peer.NewContext(context.Background(), p)
+}
+
+// peerContextNoTLS returns a context with a peer that has non-TLS auth info.
+func peerContextNoTLS() context.Context {
+	p := &peer.Peer{AuthInfo: otherAuthInfo{}}
+	return peer.NewContext(context.Background(), p)
+}
+
+// peerContextEmptyCN returns a context with a TLS peer whose certificate CN is empty.
+func peerContextEmptyCN() context.Context {
+	cert := &x509.Certificate{
+		Subject: pkix.Name{CommonName: ""},
+	}
+	p := &peer.Peer{
+		AuthInfo: credentials.TLSInfo{
+			State: tls.ConnectionState{
+				PeerCertificates: []*x509.Certificate{cert},
+			},
+		},
+	}
+	return peer.NewContext(context.Background(), p)
+}
+
+// mockStream is a minimal grpc.ServerStream whose Context() is controllable.
+type mockStream struct {
+	grpc.ServerStream
+	ctx context.Context
+}
+
+func (m *mockStream) Context() context.Context { return m.ctx }
+
+// captureStream records the stream passed to the handler so tests can inspect
+// the wrapped stream's context.
+type captureStream struct {
+	received grpc.ServerStream
+}
+
+// noopUnaryHandler is a grpc.UnaryHandler that succeeds without side effects.
+func noopUnaryHandler(_ context.Context, _ interface{}) (interface{}, error) {
+	return nil, nil
+}
+
+// ---------------------------------------------------------------------------
+// Message types for ControlChannelValidator tests
+// (No proto imports — duck typing via local test structs)
+// ---------------------------------------------------------------------------
+
+// testEvent satisfies stewardMessage (has GetStewardId).
+type testEvent struct{ stewardID string }
+
+func (e *testEvent) GetStewardId() string { return e.stewardID }
+
+// testHeartbeat satisfies stewardMessage.
+type testHeartbeat struct{ stewardID string }
+
+func (h *testHeartbeat) GetStewardId() string { return h.stewardID }
+
+// testResponse satisfies stewardMessage.
+type testResponse struct{ stewardID string }
+
+func (r *testResponse) GetStewardId() string { return r.stewardID }
+
+// testCommand satisfies both commandMessage (GetPriority) and stewardMessage.
+// A steward sending a testCommand must be rejected regardless of the steward ID.
+type testCommand struct {
+	stewardID string
+	priority  int32
+}
+
+func (c *testCommand) GetStewardId() string { return c.stewardID }
+func (c *testCommand) GetPriority() int32   { return c.priority }
+
+// unknownMessage satisfies neither commandMessage nor stewardMessage.
+type unknownMessage struct{ data string }
+
+// ---------------------------------------------------------------------------
+// Identity extraction — UnaryIdentityInterceptor
+// ---------------------------------------------------------------------------
+
+// TestUnaryIdentityInterceptor_ValidCert verifies that a request with a valid
+// TLS peer certificate stores the steward identity in the handler context and
+// calls the handler exactly once.
+func TestUnaryIdentityInterceptor_ValidCert(t *testing.T) {
+	ctx := peerContextWithCN("steward-abc")
+
+	handlerCalled := false
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		handlerCalled = true
+		identity, ok := StewardIDFromContext(ctx)
+		require.True(t, ok, "StewardIdentity must be present in handler context")
+		assert.Equal(t, "steward-abc", identity.StewardID)
+		return nil, nil
+	}
+
+	interceptor := UnaryIdentityInterceptor()
+	_, err := interceptor(ctx, nil, &grpc.UnaryServerInfo{}, handler)
+
+	require.NoError(t, err)
+	assert.True(t, handlerCalled, "handler must be called for valid cert")
+}
+
+// TestUnaryIdentityInterceptor_NoPeer verifies that a request with no peer
+// in context returns Unauthenticated and does not call the handler.
+func TestUnaryIdentityInterceptor_NoPeer(t *testing.T) {
+	ctx := context.Background() // no peer
+
+	handlerCalled := false
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		handlerCalled = true
+		return nil, nil
+	}
+
+	interceptor := UnaryIdentityInterceptor()
+	_, err := interceptor(ctx, nil, &grpc.UnaryServerInfo{}, handler)
+
+	require.Error(t, err)
+	assert.Equal(t, codes.Unauthenticated, status.Code(err))
+	assert.False(t, handlerCalled, "handler must not be called when peer is absent")
+}
+
+// TestUnaryIdentityInterceptor_NoTLS verifies that a peer with non-TLS auth
+// info returns Unauthenticated.
+func TestUnaryIdentityInterceptor_NoTLS(t *testing.T) {
+	ctx := peerContextNoTLS()
+
+	interceptor := UnaryIdentityInterceptor()
+	_, err := interceptor(ctx, nil, &grpc.UnaryServerInfo{}, noopUnaryHandler)
+
+	require.Error(t, err)
+	assert.Equal(t, codes.Unauthenticated, status.Code(err))
+}
+
+// TestUnaryIdentityInterceptor_EmptyCN verifies that a TLS peer whose
+// certificate has an empty Common Name returns Unauthenticated.
+func TestUnaryIdentityInterceptor_EmptyCN(t *testing.T) {
+	ctx := peerContextEmptyCN()
+
+	interceptor := UnaryIdentityInterceptor()
+	_, err := interceptor(ctx, nil, &grpc.UnaryServerInfo{}, noopUnaryHandler)
+
+	require.Error(t, err)
+	assert.Equal(t, codes.Unauthenticated, status.Code(err))
+}
+
+// ---------------------------------------------------------------------------
+// Identity extraction — StreamIdentityInterceptor
+// ---------------------------------------------------------------------------
+
+// TestStreamIdentityInterceptor_ValidCert verifies that a stream with a valid
+// TLS peer certificate stores the steward identity in the wrapped stream context.
+func TestStreamIdentityInterceptor_ValidCert(t *testing.T) {
+	ss := &mockStream{ctx: peerContextWithCN("steward-xyz")}
+
+	var capturedCtx context.Context
+	handler := func(srv interface{}, stream grpc.ServerStream) error {
+		capturedCtx = stream.Context()
+		return nil
+	}
+
+	interceptor := StreamIdentityInterceptor()
+	err := interceptor(nil, ss, &grpc.StreamServerInfo{}, handler)
+
+	require.NoError(t, err)
+	require.NotNil(t, capturedCtx)
+
+	identity, ok := StewardIDFromContext(capturedCtx)
+	require.True(t, ok, "StewardIdentity must be present in stream context")
+	assert.Equal(t, "steward-xyz", identity.StewardID)
+}
+
+// TestStreamIdentityInterceptor_NoPeer verifies that a stream with no peer
+// in context returns Unauthenticated and does not invoke the handler.
+func TestStreamIdentityInterceptor_NoPeer(t *testing.T) {
+	ss := &mockStream{ctx: context.Background()} // no peer
+
+	handlerCalled := false
+	handler := func(srv interface{}, stream grpc.ServerStream) error {
+		handlerCalled = true
+		return nil
+	}
+
+	interceptor := StreamIdentityInterceptor()
+	err := interceptor(nil, ss, &grpc.StreamServerInfo{}, handler)
+
+	require.Error(t, err)
+	assert.Equal(t, codes.Unauthenticated, status.Code(err))
+	assert.False(t, handlerCalled, "handler must not be called when peer is absent")
+}
+
+// ---------------------------------------------------------------------------
+// Context propagation — StewardIDFromContext
+// ---------------------------------------------------------------------------
+
+// TestStewardIDFromContext_Present verifies that a stored identity is retrieved
+// correctly and the boolean return is true.
+func TestStewardIDFromContext_Present(t *testing.T) {
+	expected := StewardIdentity{StewardID: "steward-present"}
+	ctx := context.WithValue(context.Background(), stewardIDKey{}, expected)
+
+	got, ok := StewardIDFromContext(ctx)
+
+	assert.True(t, ok)
+	assert.Equal(t, expected, got)
+}
+
+// TestStewardIDFromContext_Missing verifies that when no identity is stored the
+// function returns false and a zero-value StewardIdentity.
+func TestStewardIDFromContext_Missing(t *testing.T) {
+	ctx := context.Background()
+
+	got, ok := StewardIDFromContext(ctx)
+
+	assert.False(t, ok)
+	assert.Equal(t, StewardIdentity{}, got)
+}
+
+// ---------------------------------------------------------------------------
+// Message validation — ControlChannelValidator
+// ---------------------------------------------------------------------------
+
+// TestControlChannelValidator_EventMatchingID verifies that an Event whose
+// steward_id matches the authenticated identity is allowed.
+func TestControlChannelValidator_EventMatchingID(t *testing.T) {
+	identity := StewardIdentity{StewardID: "steward-1"}
+	validator := ControlChannelValidator()
+
+	err := validator(identity, &testEvent{stewardID: "steward-1"})
+	assert.NoError(t, err)
+}
+
+// TestControlChannelValidator_EventMismatchID verifies that an Event whose
+// steward_id differs from the authenticated identity is rejected.
+func TestControlChannelValidator_EventMismatchID(t *testing.T) {
+	identity := StewardIdentity{StewardID: "steward-1"}
+	validator := ControlChannelValidator()
+
+	err := validator(identity, &testEvent{stewardID: "steward-2"})
+	require.Error(t, err)
+	assert.Equal(t, codes.PermissionDenied, status.Code(err))
+}
+
+// TestControlChannelValidator_HeartbeatMatchingID verifies that a Heartbeat
+// with a matching steward_id is allowed.
+func TestControlChannelValidator_HeartbeatMatchingID(t *testing.T) {
+	identity := StewardIdentity{StewardID: "steward-hb"}
+	validator := ControlChannelValidator()
+
+	err := validator(identity, &testHeartbeat{stewardID: "steward-hb"})
+	assert.NoError(t, err)
+}
+
+// TestControlChannelValidator_HeartbeatMismatchID verifies that a Heartbeat
+// with a mismatched steward_id is rejected.
+func TestControlChannelValidator_HeartbeatMismatchID(t *testing.T) {
+	identity := StewardIdentity{StewardID: "steward-hb"}
+	validator := ControlChannelValidator()
+
+	err := validator(identity, &testHeartbeat{stewardID: "impostor"})
+	require.Error(t, err)
+	assert.Equal(t, codes.PermissionDenied, status.Code(err))
+}
+
+// TestControlChannelValidator_ResponseMatchingID verifies that a Response with
+// a matching steward_id is allowed.
+func TestControlChannelValidator_ResponseMatchingID(t *testing.T) {
+	identity := StewardIdentity{StewardID: "steward-resp"}
+	validator := ControlChannelValidator()
+
+	err := validator(identity, &testResponse{stewardID: "steward-resp"})
+	assert.NoError(t, err)
+}
+
+// TestControlChannelValidator_CommandFromSteward verifies that any Command
+// message sent by a steward is rejected regardless of the steward_id field,
+// because commands flow controller → steward, never the reverse.
+func TestControlChannelValidator_CommandFromSteward(t *testing.T) {
+	// Even if the steward_id in the command matches the authenticated identity,
+	// stewards are not permitted to send Command messages.
+	identity := StewardIdentity{StewardID: "steward-cmd"}
+	validator := ControlChannelValidator()
+
+	err := validator(identity, &testCommand{stewardID: "steward-cmd", priority: 1})
+	require.Error(t, err)
+	assert.Equal(t, codes.PermissionDenied, status.Code(err))
+}
+
+// TestControlChannelValidator_UnknownType verifies that an unrecognised message
+// type is allowed for forward compatibility.
+func TestControlChannelValidator_UnknownType(t *testing.T) {
+	identity := StewardIdentity{StewardID: "steward-1"}
+	validator := ControlChannelValidator()
+
+	err := validator(identity, &unknownMessage{data: "future-field"})
+	assert.NoError(t, err)
+}
+
+// ---------------------------------------------------------------------------
+// Security: error messages must not leak steward IDs
+// ---------------------------------------------------------------------------
+
+// TestErrorMessages_NoStewardIDLeaked verifies that all error messages
+// produced by the interceptors and validators do not contain any steward ID
+// string, preventing information disclosure to an attacker.
+func TestErrorMessages_NoStewardIDLeaked(t *testing.T) {
+	const authenticatedID = "secret-steward-id"
+	const messageID = "other-secret-id"
+
+	identity := StewardIdentity{StewardID: authenticatedID}
+	validator := ControlChannelValidator()
+
+	tests := []struct {
+		name string
+		msg  interface{}
+	}{
+		{
+			name: "event_mismatch",
+			msg:  &testEvent{stewardID: messageID},
+		},
+		{
+			name: "heartbeat_mismatch",
+			msg:  &testHeartbeat{stewardID: messageID},
+		},
+		{
+			name: "response_mismatch",
+			msg:  &testResponse{stewardID: messageID},
+		},
+		{
+			name: "command_from_steward",
+			msg:  &testCommand{stewardID: authenticatedID, priority: 1},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validator(identity, tc.msg)
+			require.Error(t, err)
+
+			msg := err.Error()
+			assert.NotContains(t, msg, authenticatedID,
+				"error must not leak the authenticated steward ID")
+			assert.NotContains(t, msg, messageID,
+				"error must not leak the message steward ID")
+		})
+	}
+
+	// Also verify interceptor errors don't leak.
+	t.Run("unauthenticated_no_peer", func(t *testing.T) {
+		interceptor := UnaryIdentityInterceptor()
+		_, err := interceptor(context.Background(), nil, &grpc.UnaryServerInfo{}, noopUnaryHandler)
+		require.Error(t, err)
+		assert.NotContains(t, err.Error(), authenticatedID)
+	})
+}


### PR DESCRIPTION
## Summary

Adds `pkg/transport/auth/` with gRPC stream and unary interceptors that enforce
steward identity on all RPCs. This is the gRPC equivalent of the MQTT ACL
(`features/controller/server/mqtt_acl.go`) — stewards can only act as themselves,
and Commands are controller → steward only. All 16 specified test cases pass.

## Problem Context

The MQTT ACL enforces namespace isolation via topic patterns
(`cfgms/steward/{clientID}/#`). With gRPC over QUIC, point-to-point streams
replace topic routing. Authorization must move to interceptors that validate
the mTLS identity (from the TLS peer certificate CN) against the steward ID
embedded in each message.

An mTLS certificate provides cryptographic proof of identity. If the steward ID
in a message differs from the authenticated CN, the steward is either buggy or
attempting impersonation — both must be rejected.

## Changes

- `pkg/transport/auth/interceptor.go`: `UnaryIdentityInterceptor` and
  `StreamIdentityInterceptor` extract steward identity from TLS peer via
  `pkg/transport/quic.PeerStewardID` and store it in context; `StewardIDFromContext`
  retrieves it; `ControlChannelValidator` enforces message-level identity and
  rejects Commands from stewards
- `pkg/transport/auth/doc.go`: package documentation with usage example
- `pkg/transport/auth/interceptor_test.go`: all 16 specified test cases using
  duck-typed test structs — no generated proto imports required

## Measured Impact

Test run: `go test -v -race -count=1 ./pkg/transport/auth/...`

| Test | Result |
|------|--------|
| UnaryIdentityInterceptor_ValidCert | PASS |
| UnaryIdentityInterceptor_NoPeer | PASS |
| UnaryIdentityInterceptor_NoTLS | PASS |
| UnaryIdentityInterceptor_EmptyCN | PASS |
| StreamIdentityInterceptor_ValidCert | PASS |
| StreamIdentityInterceptor_NoPeer | PASS |
| StewardIDFromContext_Present | PASS |
| StewardIDFromContext_Missing | PASS |
| ControlChannelValidator_EventMatchingID | PASS |
| ControlChannelValidator_EventMismatchID | PASS |
| ControlChannelValidator_HeartbeatMatchingID | PASS |
| ControlChannelValidator_HeartbeatMismatchID | PASS |
| ControlChannelValidator_ResponseMatchingID | PASS |
| ControlChannelValidator_CommandFromSteward | PASS |
| ControlChannelValidator_UnknownType | PASS |
| ErrorMessages_NoStewardIDLeaked | PASS |

All 16/16 tests pass with race detector enabled.

## Testing

- All 16 specified test cases pass
- `go vet ./pkg/transport/auth/...` — clean
- Architecture check (`make check-architecture`) — no violations
- License headers — all SPDX headers present
- No imports of `features/` or `pkg/controlplane`/`pkg/mqtt`/`pkg/quic/` in non-test code
- Error messages verified to not leak steward IDs (TestErrorMessages_NoStewardIDLeaked)

Fixes #488