### PR TITLE
transport: unified TransportConfig replacing MQTTConfig and QUICConfig (Issue #512)

### DIFF
--- a/features/controller/config/config.go
+++ b/features/controller/config/config.go
@@ -4,6 +4,7 @@ package config
 
 import (
 	"fmt"
+	"log"
 	"os"
 	"regexp"
 	"strconv"
@@ -100,6 +101,10 @@ type Config struct {
 
 	// QUIC server configuration for data plane communication
 	QUIC *QUICConfig `yaml:"quic"`
+
+	// Transport is the unified, protocol-agnostic transport configuration.
+	// Replaces the separate MQTT and QUIC sections. Old sections map here with deprecation warnings.
+	Transport *TransportConfig `yaml:"transport"`
 }
 
 // CertificateConfig contains certificate management settings
@@ -439,6 +444,72 @@ type QUICConfig struct {
 	SessionTimeout int `yaml:"session_timeout"`
 }
 
+// Duration is a time.Duration that supports YAML string parsing ("30s", "5m", etc.)
+// This allows human-readable duration values in configuration files.
+type Duration time.Duration
+
+// UnmarshalYAML parses duration strings like "30s", "5m", "1h" from YAML.
+func (d *Duration) UnmarshalYAML(value *yaml.Node) error {
+	dur, err := time.ParseDuration(value.Value)
+	if err != nil {
+		return fmt.Errorf("invalid duration %q: %w", value.Value, err)
+	}
+	*d = Duration(dur)
+	return nil
+}
+
+// MarshalYAML serializes the duration as a human-readable string.
+func (d Duration) MarshalYAML() (interface{}, error) {
+	return time.Duration(d).String(), nil
+}
+
+// AsDuration returns the underlying time.Duration value.
+func (d Duration) AsDuration() time.Duration {
+	return time.Duration(d)
+}
+
+// TransportConfig is the unified, protocol-agnostic transport configuration.
+// It replaces the separate MQTTConfig and QUICConfig sections.
+// A single listen address serves both control plane and data plane over gRPC-over-QUIC,
+// and can accommodate future transport implementations without config changes.
+type TransportConfig struct {
+	// ListenAddr is the address for the unified transport server (e.g., "0.0.0.0:4433")
+	ListenAddr string `yaml:"listen_addr"`
+
+	// UseCertManager enables the controller's certificate manager for TLS.
+	// When true (default), certificates are managed automatically.
+	UseCertManager bool `yaml:"use_cert_manager"`
+
+	// MaxConnections is the maximum number of concurrent client connections.
+	MaxConnections int `yaml:"max_connections"`
+
+	// KeepalivePeriod is how often keepalive probes are sent to detect dead connections.
+	// Minimum: 1s. Default: 30s.
+	KeepalivePeriod Duration `yaml:"keepalive_period"`
+
+	// IdleTimeout is how long a connection can remain idle before being closed.
+	// Default: 5m.
+	IdleTimeout Duration `yaml:"idle_timeout"`
+}
+
+// Validate checks the TransportConfig for invalid values.
+// Returns an error if listen_addr is empty, max_connections < 1, or keepalive_period < 1s.
+func (t *TransportConfig) Validate() error {
+	if t == nil {
+		return fmt.Errorf("transport config must not be nil")
+	}
+	if t.ListenAddr == "" {
+		return fmt.Errorf("transport.listen_addr must not be empty")
+	}
+	if t.MaxConnections < 1 {
+		return fmt.Errorf("transport.max_connections must be at least 1, got %d", t.MaxConnections)
+	}
+	if t.KeepalivePeriod.AsDuration() < time.Second {
+		return fmt.Errorf("transport.keepalive_period must be at least 1s, got %v", t.KeepalivePeriod.AsDuration())
+	}
+	return nil
+}
+
 // DefaultConfig returns a Config with reasonable defaults
 func DefaultConfig() *Config {
 	return &Config{
@@ -565,6 +636,71 @@ func DefaultConfig() *Config {
 			UseCertManager: true, // Use controller's certificate manager
 			SessionTimeout: 300,  // 5 minutes
 		},
+		Transport: &TransportConfig{
+			ListenAddr:      "0.0.0.0:4433",
+			UseCertManager:  true,
+			MaxConnections:  50000,
+			KeepalivePeriod: Duration(30 * time.Second),
+			IdleTimeout:     Duration(5 * time.Minute),
+		},
+	}
+}
+
+// migrateTransportConfig detects deprecated mqtt: and quic: sections in the raw YAML
+// and migrates their fields to the Transport section with deprecation warnings.
+//
+// Migration rules:
+//   - If transport: is present and old sections are also present: new section wins, log warning
+//   - If only mqtt: is present: migrate listen_addr and use_cert_manager to transport
+//   - If only quic: is present: migrate listen_addr and use_cert_manager to transport
+//   - If both mqtt: and quic: are present (no transport:): quic takes priority over mqtt
+func migrateTransportConfig(cfg *Config, rawYAML []byte) {
+	var raw map[string]interface{}
+	if err := yaml.Unmarshal(rawYAML, &raw); err != nil {
+		return // Can't detect keys, skip migration
+	}
+
+	_, hasTransport := raw["transport"]
+	_, hasMQTT := raw["mqtt"]
+	_, hasQUIC := raw["quic"]
+
+	if !hasMQTT && !hasQUIC {
+		return // Nothing to migrate
+	}
+
+	if hasTransport {
+		// New section wins; warn that old sections are ignored
+		log.Printf("[WARN] config: transport: section overrides deprecated mqtt:/quic: sections — old sections are ignored")
+		return
+	}
+
+	// No transport: section in YAML — migrate from old sections
+	if cfg.Transport == nil {
+		cfg.Transport = &TransportConfig{
+			ListenAddr:      "0.0.0.0:4433",
+			UseCertManager:  true,
+			MaxConnections:  50000,
+			KeepalivePeriod: Duration(30 * time.Second),
+			IdleTimeout:     Duration(5 * time.Minute),
+		}
+	}
+
+	// MQTT migration (older protocol)
+	if hasMQTT && cfg.MQTT != nil {
+		log.Printf("[WARN] config: mqtt: section is deprecated; please migrate to transport: section")
+		if cfg.MQTT.ListenAddr != "" {
+			cfg.Transport.ListenAddr = cfg.MQTT.ListenAddr
+		}
+		cfg.Transport.UseCertManager = cfg.MQTT.UseCertManager
+	}
+
+	// QUIC migration takes priority over MQTT (more recent transport)
+	if hasQUIC && cfg.QUIC != nil {
+		log.Printf("[WARN] config: quic: section is deprecated; please migrate to transport: section")
+		if cfg.QUIC.ListenAddr != "" {
+			cfg.Transport.ListenAddr = cfg.QUIC.ListenAddr
+		}
+		cfg.Transport.UseCertManager = cfg.QUIC.UseCertManager
 	}
 }
 
@@ -652,10 +788,14 @@ func LoadWithPath(configPath string) (*Config, error) {
 		// Expand environment variables in the configuration content
 		// This supports ${VAR} and ${VAR:-default} syntax for explicit env var references
 		expandedData := expandEnvWithDefaults(content)
+		expandedBytes := []byte(expandedData)
 
-		if err := yaml.Unmarshal([]byte(expandedData), cfg); err != nil {
+		if err := yaml.Unmarshal(expandedBytes, cfg); err != nil {
 			return nil, fmt.Errorf("failed to parse config file %s: %w", foundPath, err)
 		}
+
+		// Migrate deprecated mqtt:/quic: sections to the unified transport: section
+		migrateTransportConfig(cfg, expandedBytes)
 	}
 
 	// Override with environment variables if set
@@ -851,6 +991,11 @@ func LoadWithPath(configPath string) (*Config, error) {
 
 	if mqttListenAddr := os.Getenv("CFGMS_MQTT_LISTEN_ADDR"); mqttListenAddr != "" {
 		cfg.MQTT.ListenAddr = mqttListenAddr
+		// Deprecated: also apply to transport if CFGMS_TRANSPORT_LISTEN_ADDR is not set
+		if os.Getenv("CFGMS_TRANSPORT_LISTEN_ADDR") == "" && cfg.Transport != nil {
+			cfg.Transport.ListenAddr = mqttListenAddr
+			log.Printf("[WARN] env: CFGMS_MQTT_LISTEN_ADDR is deprecated; use CFGMS_TRANSPORT_LISTEN_ADDR instead")
+		}
 	}
 
 	if mqttEnableTLS := os.Getenv("CFGMS_MQTT_ENABLE_TLS"); mqttEnableTLS != "" {
@@ -897,6 +1042,35 @@ func LoadWithPath(configPath string) (*Config, error) {
 	if quicUseCertManager := os.Getenv("CFGMS_QUIC_USE_CERT_MANAGER"); quicUseCertManager != "" {
 		if val, err := strconv.ParseBool(quicUseCertManager); err == nil {
 			cfg.QUIC.UseCertManager = val
+		}
+	}
+
+	// Transport configuration environment variables
+	if transportListenAddr := os.Getenv("CFGMS_TRANSPORT_LISTEN_ADDR"); transportListenAddr != "" && cfg.Transport != nil {
+		cfg.Transport.ListenAddr = transportListenAddr
+	}
+
+	if transportUseCertManager := os.Getenv("CFGMS_TRANSPORT_USE_CERT_MANAGER"); transportUseCertManager != "" && cfg.Transport != nil {
+		if val, err := strconv.ParseBool(transportUseCertManager); err == nil {
+			cfg.Transport.UseCertManager = val
+		}
+	}
+
+	if transportMaxConns := os.Getenv("CFGMS_TRANSPORT_MAX_CONNECTIONS"); transportMaxConns != "" && cfg.Transport != nil {
+		if val, err := strconv.Atoi(transportMaxConns); err == nil {
+			cfg.Transport.MaxConnections = val
+		}
+	}
+
+	if transportKeepalive := os.Getenv("CFGMS_TRANSPORT_KEEPALIVE_PERIOD"); transportKeepalive != "" && cfg.Transport != nil {
+		if dur, err := time.ParseDuration(transportKeepalive); err == nil {
+			cfg.Transport.KeepalivePeriod = Duration(dur)
+		}
+	}
+
+	if transportIdleTimeout := os.Getenv("CFGMS_TRANSPORT_IDLE_TIMEOUT"); transportIdleTimeout != "" && cfg.Transport != nil {
+		if dur, err := time.ParseDuration(transportIdleTimeout); err == nil {
+			cfg.Transport.IdleTimeout = Duration(dur)
 		}
 	}
 

--- a/features/controller/config/config_test.go
+++ b/features/controller/config/config_test.go
@@ -1,0 +1,338 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestDefaultConfig_TransportPopulated verifies DefaultConfig returns a Transport section with sensible defaults.
+func TestDefaultConfig_TransportPopulated(t *testing.T) {
+	cfg := DefaultConfig()
+	require.NotNil(t, cfg.Transport, "Transport must be populated in DefaultConfig")
+
+	assert.Equal(t, "0.0.0.0:4433", cfg.Transport.ListenAddr)
+	assert.True(t, cfg.Transport.UseCertManager)
+	assert.Equal(t, 50000, cfg.Transport.MaxConnections)
+	assert.Equal(t, 30*time.Second, cfg.Transport.KeepalivePeriod.AsDuration())
+	assert.Equal(t, 5*time.Minute, cfg.Transport.IdleTimeout.AsDuration())
+}
+
+// TestTransportConfig_Validate_Valid verifies that a valid TransportConfig passes validation.
+func TestTransportConfig_Validate_Valid(t *testing.T) {
+	tc := &TransportConfig{
+		ListenAddr:      "0.0.0.0:4433",
+		UseCertManager:  true,
+		MaxConnections:  1000,
+		KeepalivePeriod: Duration(30 * time.Second),
+		IdleTimeout:     Duration(5 * time.Minute),
+	}
+	assert.NoError(t, tc.Validate())
+}
+
+// TestTransportConfig_Validate_RejectsEmptyListenAddr verifies validation rejects empty listen_addr.
+func TestTransportConfig_Validate_RejectsEmptyListenAddr(t *testing.T) {
+	tc := &TransportConfig{
+		ListenAddr:      "",
+		MaxConnections:  1000,
+		KeepalivePeriod: Duration(30 * time.Second),
+	}
+	err := tc.Validate()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "listen_addr")
+}
+
+// TestTransportConfig_Validate_RejectsZeroMaxConnections verifies validation rejects max_connections < 1.
+func TestTransportConfig_Validate_RejectsZeroMaxConnections(t *testing.T) {
+	tests := []struct {
+		name string
+		val  int
+	}{
+		{name: "zero", val: 0},
+		{name: "negative", val: -1},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tc := &TransportConfig{
+				ListenAddr:      "0.0.0.0:4433",
+				MaxConnections:  tt.val,
+				KeepalivePeriod: Duration(30 * time.Second),
+			}
+			err := tc.Validate()
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "max_connections")
+		})
+	}
+}
+
+// TestTransportConfig_Validate_RejectsShortKeepalive verifies validation rejects keepalive_period < 1s.
+func TestTransportConfig_Validate_RejectsShortKeepalive(t *testing.T) {
+	tests := []struct {
+		name string
+		dur  time.Duration
+	}{
+		{name: "zero", dur: 0},
+		{name: "500ms", dur: 500 * time.Millisecond},
+		{name: "999ms", dur: 999 * time.Millisecond},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tc := &TransportConfig{
+				ListenAddr:      "0.0.0.0:4433",
+				MaxConnections:  1000,
+				KeepalivePeriod: Duration(tt.dur),
+			}
+			err := tc.Validate()
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "keepalive_period")
+		})
+	}
+}
+
+// TestTransportConfig_Validate_AcceptsExactlyOneSecondKeepalive verifies exactly 1s keepalive is valid.
+func TestTransportConfig_Validate_AcceptsExactlyOneSecondKeepalive(t *testing.T) {
+	tc := &TransportConfig{
+		ListenAddr:      "0.0.0.0:4433",
+		MaxConnections:  1,
+		KeepalivePeriod: Duration(time.Second),
+	}
+	assert.NoError(t, tc.Validate())
+}
+
+// TestLoadWithPath_TransportSectionLoaded verifies the transport: YAML section is loaded correctly.
+func TestLoadWithPath_TransportSectionLoaded(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "controller.cfg")
+
+	content := `
+transport:
+  listen_addr: "0.0.0.0:5555"
+  use_cert_manager: true
+  max_connections: 25000
+  keepalive_period: 1m
+  idle_timeout: 10m
+`
+	require.NoError(t, os.WriteFile(configPath, []byte(content), 0600))
+
+	cfg, err := LoadWithPath(configPath)
+	require.NoError(t, err)
+	require.NotNil(t, cfg.Transport)
+
+	assert.Equal(t, "0.0.0.0:5555", cfg.Transport.ListenAddr)
+	assert.True(t, cfg.Transport.UseCertManager)
+	assert.Equal(t, 25000, cfg.Transport.MaxConnections)
+	assert.Equal(t, time.Minute, cfg.Transport.KeepalivePeriod.AsDuration())
+	assert.Equal(t, 10*time.Minute, cfg.Transport.IdleTimeout.AsDuration())
+}
+
+// TestLoadWithPath_MigrationFromMQTT verifies deprecated mqtt: section is migrated to transport:.
+func TestLoadWithPath_MigrationFromMQTT(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "controller.cfg")
+
+	content := `
+mqtt:
+  listen_addr: "0.0.0.0:1883"
+  use_cert_manager: false
+`
+	require.NoError(t, os.WriteFile(configPath, []byte(content), 0600))
+
+	cfg, err := LoadWithPath(configPath)
+	require.NoError(t, err)
+	require.NotNil(t, cfg.Transport, "Transport must be populated after MQTT migration")
+
+	assert.Equal(t, "0.0.0.0:1883", cfg.Transport.ListenAddr,
+		"mqtt.listen_addr must be migrated to transport.listen_addr")
+	assert.False(t, cfg.Transport.UseCertManager,
+		"mqtt.use_cert_manager must be migrated to transport.use_cert_manager")
+}
+
+// TestLoadWithPath_MigrationFromQUIC verifies deprecated quic: section is migrated to transport:.
+func TestLoadWithPath_MigrationFromQUIC(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "controller.cfg")
+
+	content := `
+quic:
+  listen_addr: "0.0.0.0:9999"
+  use_cert_manager: true
+`
+	require.NoError(t, os.WriteFile(configPath, []byte(content), 0600))
+
+	cfg, err := LoadWithPath(configPath)
+	require.NoError(t, err)
+	require.NotNil(t, cfg.Transport, "Transport must be populated after QUIC migration")
+
+	assert.Equal(t, "0.0.0.0:9999", cfg.Transport.ListenAddr,
+		"quic.listen_addr must be migrated to transport.listen_addr")
+	assert.True(t, cfg.Transport.UseCertManager,
+		"quic.use_cert_manager must be migrated to transport.use_cert_manager")
+}
+
+// TestLoadWithPath_QUICOverridesMQTTInMigration verifies that quic: takes priority over mqtt: when both present.
+func TestLoadWithPath_QUICOverridesMQTTInMigration(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "controller.cfg")
+
+	content := `
+mqtt:
+  listen_addr: "0.0.0.0:1883"
+  use_cert_manager: false
+quic:
+  listen_addr: "0.0.0.0:4433"
+  use_cert_manager: true
+`
+	require.NoError(t, os.WriteFile(configPath, []byte(content), 0600))
+
+	cfg, err := LoadWithPath(configPath)
+	require.NoError(t, err)
+	require.NotNil(t, cfg.Transport)
+
+	// QUIC takes priority when both old sections are present
+	assert.Equal(t, "0.0.0.0:4433", cfg.Transport.ListenAddr,
+		"quic.listen_addr must take priority over mqtt.listen_addr")
+	assert.True(t, cfg.Transport.UseCertManager,
+		"quic.use_cert_manager must take priority over mqtt.use_cert_manager")
+}
+
+// TestLoadWithPath_NewSectionOverridesOld verifies transport: wins when both old and new sections present.
+func TestLoadWithPath_NewSectionOverridesOld(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "controller.cfg")
+
+	content := `
+mqtt:
+  listen_addr: "0.0.0.0:1883"
+  use_cert_manager: false
+transport:
+  listen_addr: "0.0.0.0:4433"
+  use_cert_manager: true
+  max_connections: 50000
+  keepalive_period: 30s
+  idle_timeout: 5m
+`
+	require.NoError(t, os.WriteFile(configPath, []byte(content), 0600))
+
+	cfg, err := LoadWithPath(configPath)
+	require.NoError(t, err)
+	require.NotNil(t, cfg.Transport)
+
+	// transport: section wins
+	assert.Equal(t, "0.0.0.0:4433", cfg.Transport.ListenAddr,
+		"transport: section must win over mqtt: section")
+	assert.True(t, cfg.Transport.UseCertManager)
+}
+
+// TestLoadWithPath_TransportEnvVar verifies CFGMS_TRANSPORT_LISTEN_ADDR overrides config.
+func TestLoadWithPath_TransportEnvVar(t *testing.T) {
+	t.Setenv("CFGMS_TRANSPORT_LISTEN_ADDR", "0.0.0.0:7777")
+
+	cfg, err := Load()
+	require.NoError(t, err)
+	require.NotNil(t, cfg.Transport)
+	assert.Equal(t, "0.0.0.0:7777", cfg.Transport.ListenAddr)
+}
+
+// TestLoadWithPath_TransportMaxConnectionsEnvVar verifies CFGMS_TRANSPORT_MAX_CONNECTIONS env var.
+func TestLoadWithPath_TransportMaxConnectionsEnvVar(t *testing.T) {
+	t.Setenv("CFGMS_TRANSPORT_MAX_CONNECTIONS", "12345")
+
+	cfg, err := Load()
+	require.NoError(t, err)
+	require.NotNil(t, cfg.Transport)
+	assert.Equal(t, 12345, cfg.Transport.MaxConnections)
+}
+
+// TestLoadWithPath_TransportKeepaliveEnvVar verifies CFGMS_TRANSPORT_KEEPALIVE_PERIOD env var.
+func TestLoadWithPath_TransportKeepaliveEnvVar(t *testing.T) {
+	t.Setenv("CFGMS_TRANSPORT_KEEPALIVE_PERIOD", "2m")
+
+	cfg, err := Load()
+	require.NoError(t, err)
+	require.NotNil(t, cfg.Transport)
+	assert.Equal(t, 2*time.Minute, cfg.Transport.KeepalivePeriod.AsDuration())
+}
+
+// TestLoadWithPath_MQTTListenAddrDeprecatedEnvVar verifies CFGMS_MQTT_LISTEN_ADDR maps to transport with deprecation.
+func TestLoadWithPath_MQTTListenAddrDeprecatedEnvVar(t *testing.T) {
+	// Ensure the new transport env var is not set
+	t.Setenv("CFGMS_MQTT_LISTEN_ADDR", "0.0.0.0:9876")
+
+	cfg, err := Load()
+	require.NoError(t, err)
+	require.NotNil(t, cfg.Transport)
+	// Deprecated CFGMS_MQTT_LISTEN_ADDR should propagate to Transport when CFGMS_TRANSPORT_LISTEN_ADDR is not set
+	assert.Equal(t, "0.0.0.0:9876", cfg.Transport.ListenAddr,
+		"deprecated CFGMS_MQTT_LISTEN_ADDR must propagate to transport.listen_addr")
+}
+
+// TestLoadWithPath_TransportEnvVarWinsOverMQTTDeprecated verifies CFGMS_TRANSPORT_LISTEN_ADDR takes priority.
+func TestLoadWithPath_TransportEnvVarWinsOverMQTTDeprecated(t *testing.T) {
+	t.Setenv("CFGMS_MQTT_LISTEN_ADDR", "0.0.0.0:9876")
+	t.Setenv("CFGMS_TRANSPORT_LISTEN_ADDR", "0.0.0.0:4433")
+
+	cfg, err := Load()
+	require.NoError(t, err)
+	require.NotNil(t, cfg.Transport)
+	assert.Equal(t, "0.0.0.0:4433", cfg.Transport.ListenAddr,
+		"CFGMS_TRANSPORT_LISTEN_ADDR must win over deprecated CFGMS_MQTT_LISTEN_ADDR")
+}
+
+// TestDuration_UnmarshalYAML verifies Duration type parses human-readable strings from YAML.
+func TestDuration_UnmarshalYAML(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "controller.cfg")
+
+	content := `
+transport:
+  listen_addr: "0.0.0.0:4433"
+  use_cert_manager: true
+  max_connections: 1000
+  keepalive_period: 45s
+  idle_timeout: 15m
+`
+	require.NoError(t, os.WriteFile(configPath, []byte(content), 0600))
+
+	cfg, err := LoadWithPath(configPath)
+	require.NoError(t, err)
+	require.NotNil(t, cfg.Transport)
+
+	assert.Equal(t, 45*time.Second, cfg.Transport.KeepalivePeriod.AsDuration())
+	assert.Equal(t, 15*time.Minute, cfg.Transport.IdleTimeout.AsDuration())
+}
+
+// TestDuration_AsDuration verifies AsDuration returns the underlying time.Duration.
+func TestDuration_AsDuration(t *testing.T) {
+	d := Duration(30 * time.Second)
+	assert.Equal(t, 30*time.Second, d.AsDuration())
+}
+
+// TestLoadWithPath_DefaultConfigHasTransportAlongsideLegacy verifies Config has Transport alongside MQTT and QUIC.
+func TestLoadWithPath_DefaultConfigHasTransportAlongsideLegacy(t *testing.T) {
+	cfg := DefaultConfig()
+
+	// All three sections must exist during Phase 10 transition
+	require.NotNil(t, cfg.MQTT, "MQTT must remain for backward compat during Phase 10")
+	require.NotNil(t, cfg.QUIC, "QUIC must remain for backward compat during Phase 10")
+	require.NotNil(t, cfg.Transport, "Transport must be present as new unified section")
+}
+
+// TestLoadWithPath_NoConfigFileUsesDefaults verifies defaults are used when no config file exists.
+func TestLoadWithPath_NoConfigFileUsesDefaults(t *testing.T) {
+	cfg, err := Load()
+	require.NoError(t, err)
+	require.NotNil(t, cfg.Transport)
+
+	// Should have the same defaults as DefaultConfig
+	defaults := DefaultConfig()
+	assert.Equal(t, defaults.Transport.ListenAddr, cfg.Transport.ListenAddr)
+	assert.Equal(t, defaults.Transport.MaxConnections, cfg.Transport.MaxConnections)
+	assert.Equal(t, defaults.Transport.KeepalivePeriod, cfg.Transport.KeepalivePeriod)
+	assert.Equal(t, defaults.Transport.IdleTimeout, cfg.Transport.IdleTimeout)
+}


### PR DESCRIPTION
## Summary

Adds a unified, protocol-agnostic `TransportConfig` struct to the controller config (Issue #512). A single `transport:` YAML section replaces the separate `mqtt:` and `quic:` sections. Old sections continue to load with deprecation warnings and automatically migrate to the new structure, so no existing deployments break.

Also introduces a `Duration` type with custom YAML support for human-readable duration strings ("30s", "5m").

## Problem Context

The controller config had two transport-specific sections: `MQTTConfig` (10+ fields) and `QUICConfig`. With unified gRPC-over-QUIC transport, a single listen address serves both control and data plane. The config should reflect this — one `transport:` section that works regardless of which transport implementation is used.

During Phase 10 transition, `MQTTConfig` and `QUICConfig` structs remain in the codebase; they are removed in issues #10.9 and #10.10. Other Phase 10 issues will read from `cfg.Transport` instead of `cfg.MQTT`/`cfg.QUIC`.

## Changes

- Add `Duration` type with YAML (un)marshal supporting "30s", "5m" string format
- Add `TransportConfig` struct: `ListenAddr`, `UseCertManager`, `MaxConnections`, `KeepalivePeriod`, `IdleTimeout`
- Add `Validate()` rejecting empty listen_addr, max_connections < 1, keepalive_period < 1s
- Add `Transport *TransportConfig` to `Config` alongside retained `MQTT` and `QUIC` fields
- Update `DefaultConfig()`: listen `0.0.0.0:4433`, cert_manager true, 50000 conns, 30s keepalive, 5m idle
- Add `migrateTransportConfig()` detecting old sections via raw YAML parsing and migrating fields with deprecation warnings
- Add `CFGMS_TRANSPORT_LISTEN_ADDR` env var; deprecated `CFGMS_MQTT_LISTEN_ADDR` maps to transport with log warning

## Testing

Test scenarios in `config_test.go`:
- DefaultConfig has Transport populated with correct defaults
- Validate rejects empty listen_addr, max_connections < 1, keepalive < 1s
- YAML `transport:` section loads with duration strings ("45s", "15m")
- Migration from `mqtt:` section (listen_addr, use_cert_manager mapped)
- Migration from `quic:` section (listen_addr, use_cert_manager mapped)
- QUIC overrides MQTT when both old sections present (no transport: section)
- New `transport:` section wins when both old and new sections present
- CFGMS_TRANSPORT_LISTEN_ADDR env var and deprecated CFGMS_MQTT_LISTEN_ADDR priority

Results:
✅ All controller/config tests pass
✅ Architecture check clean (no central provider violations)
✅ go vet clean
✅ No behavioral changes — old config format still accepted

Fixes #512
Part of #511
Part of #482