### PR TITLE
transport: replace mqtt_broker/quic_address with transport_address in registration API (Issue #513)

### DIFF
--- a/cmd/steward/main.go
+++ b/cmd/steward/main.go
@@ -485,14 +485,13 @@ func registerAndConnectMQTT(ctx context.Context, token string, logger logging.Lo
 		"steward_id", regResp.StewardID,
 		"tenant_id", regResp.TenantID,
 		"group", regResp.Group,
-		"mqtt_broker", regResp.MQTTBroker)
+		"transport_address", regResp.TransportAddress)
 
-	mqttBroker := regResp.MQTTBroker
-	quicAddress := regResp.QUICAddress
+	transportAddress := regResp.TransportAddress
 
 	mqttClient, err := client.NewMQTTClient(&client.MQTTConfig{
-		ControllerURL:     mqttBroker,
-		QUICAddress:       quicAddress,
+		ControllerURL:     transportAddress,
+		QUICAddress:       transportAddress,
 		RegistrationToken: token,
 		CACertPEM:         regResp.CACert,
 		ClientCertPEM:     regResp.ClientCert,
@@ -512,8 +511,7 @@ func registerAndConnectMQTT(ctx context.Context, token string, logger logging.Lo
 	}
 
 	logger.Info("Connected to controller via MQTT+QUIC",
-		"mqtt_broker", mqttBroker,
-		"quic_address", quicAddress)
+		"transport_address", transportAddress)
 
 	if err := mqttClient.SendHeartbeat(ctx, "healthy", nil); err != nil {
 		logger.Warn("Failed to send initial heartbeat", "error", err)

--- a/features/controller/api/handlers_registration.go
+++ b/features/controller/api/handlers_registration.go
@@ -20,12 +20,11 @@ type RegistrationRequest struct {
 
 // RegistrationResponse represents the steward registration response
 type RegistrationResponse struct {
-	StewardID     string `json:"steward_id"`
-	TenantID      string `json:"tenant_id"`
-	Group         string `json:"group"`
-	ControllerURL string `json:"controller_url"`
-	MQTTBroker    string `json:"mqtt_broker"`
-	QUICAddress   string `json:"quic_address"`
+	StewardID        string `json:"steward_id"`
+	TenantID         string `json:"tenant_id"`
+	Group            string `json:"group"`
+	ControllerURL    string `json:"controller_url"`
+	TransportAddress string `json:"transport_address"`
 
 	// Certificate information (optional for alpha, required for production mTLS)
 	ClientCert string `json:"client_cert,omitempty"`
@@ -125,12 +124,11 @@ func (s *Server) handleRegister(w http.ResponseWriter, r *http.Request) {
 
 	// Build response with connection details
 	resp := RegistrationResponse{
-		StewardID:     stewardID,
-		TenantID:      token.TenantID,
-		Group:         token.Group,
-		ControllerURL: token.ControllerURL,
-		MQTTBroker:    s.getMQTTBrokerURL(), // Story #294 Phase 3: Return proper MQTT broker URL
-		QUICAddress:   s.getQUICAddress(),
+		StewardID:        stewardID,
+		TenantID:         token.TenantID,
+		Group:            token.Group,
+		ControllerURL:    token.ControllerURL,
+		TransportAddress: s.getTransportAddress(),
 	}
 
 	// Story #294 Phase 3: Generate client certificates for mTLS (REQUIRED)
@@ -222,13 +220,12 @@ func (s *Server) handleRegister(w http.ResponseWriter, r *http.Request) {
 	// Store registered steward in memory for API queries
 	s.mu.Lock()
 	s.registeredStewards[stewardID] = &RegisteredSteward{
-		StewardID:    stewardID,
-		TenantID:     token.TenantID,
-		Group:        token.Group,
-		RegisteredAt: time.Now(),
-		Status:       "registered", // Initial status before first heartbeat
-		MQTTBroker:   resp.MQTTBroker,
-		QUICAddress:  resp.QUICAddress,
+		StewardID:        stewardID,
+		TenantID:         token.TenantID,
+		Group:            token.Group,
+		RegisteredAt:     time.Now(),
+		Status:           "registered", // Initial status before first heartbeat
+		TransportAddress: resp.TransportAddress,
 	}
 	s.mu.Unlock()
 
@@ -240,34 +237,16 @@ func (s *Server) handleRegister(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-// getQUICAddress returns the QUIC server address for steward connections
-func (s *Server) getQUICAddress() string {
-	addr := "localhost:4433" // Default QUIC address
-	if s.cfg.QUIC != nil && s.cfg.QUIC.Enabled {
-		addr = s.cfg.QUIC.ListenAddr
+// getTransportAddress returns the unified transport address for steward connections.
+// This is a host:port string (e.g., "controller:4433"); the transport provider handles protocol details.
+func (s *Server) getTransportAddress() string {
+	addr := "localhost:4433" // Default transport address
+	if s.cfg.Transport != nil && s.cfg.Transport.ListenAddr != "" {
+		addr = s.cfg.Transport.ListenAddr
 	}
 
 	// Replace 0.0.0.0 with external hostname if configured (Docker/test mode)
 	return replaceBindAddress(addr)
-}
-
-// getMQTTBrokerURL returns the MQTT broker URL for steward connections
-// Story #294 Phase 3: Return proper MQTT URL with ssl:// or tcp:// protocol
-func (s *Server) getMQTTBrokerURL() string {
-	if s.cfg.MQTT == nil || !s.cfg.MQTT.Enabled {
-		return "tcp://localhost:1883" // Default MQTT address
-	}
-
-	// Determine protocol based on TLS configuration
-	protocol := "tcp"
-	if s.cfg.MQTT.EnableTLS {
-		protocol = "ssl"
-	}
-
-	// Replace 0.0.0.0 with external hostname if configured (Docker/test mode)
-	addr := replaceBindAddress(s.cfg.MQTT.ListenAddr)
-
-	return fmt.Sprintf("%s://%s", protocol, addr)
 }
 
 // replaceBindAddress replaces 0.0.0.0 bind addresses with external hostname

--- a/features/controller/api/server.go
+++ b/features/controller/api/server.go
@@ -82,14 +82,13 @@ type APIKey struct {
 
 // RegisteredSteward represents a steward that has registered with the controller
 type RegisteredSteward struct {
-	StewardID     string    `json:"steward_id"`
-	TenantID      string    `json:"tenant_id"`
-	Group         string    `json:"group"`
-	RegisteredAt  time.Time `json:"registered_at"`
-	LastHeartbeat time.Time `json:"last_heartbeat,omitempty"`
-	Status        string    `json:"status"` // online, offline, unknown
-	MQTTBroker    string    `json:"mqtt_broker,omitempty"`
-	QUICAddress   string    `json:"quic_address,omitempty"`
+	StewardID        string    `json:"steward_id"`
+	TenantID         string    `json:"tenant_id"`
+	Group            string    `json:"group"`
+	RegisteredAt     time.Time `json:"registered_at"`
+	LastHeartbeat    time.Time `json:"last_heartbeat,omitempty"`
+	Status           string    `json:"status"` // online, offline, unknown
+	TransportAddress string    `json:"transport_address,omitempty"`
 }
 
 // ServerConfig contains configuration for the REST API server

--- a/features/steward/registration/client.go
+++ b/features/steward/registration/client.go
@@ -62,12 +62,13 @@ type RegistrationResponse struct {
 	Group         string `json:"group,omitempty"`
 	Error         string `json:"error,omitempty"`
 
-	// HTTP registration fields (Story #198)
-	MQTTBroker  string `json:"mqtt_broker,omitempty"`
-	QUICAddress string `json:"quic_address,omitempty"`
-	ClientCert  string `json:"client_cert,omitempty"`
-	ClientKey   string `json:"client_key,omitempty"`
-	CACert      string `json:"ca_cert,omitempty"`
+	// Unified transport address for gRPC-over-QUIC connection (Issue #513)
+	TransportAddress string `json:"transport_address,omitempty"`
+
+	// Certificate fields
+	ClientCert string `json:"client_cert,omitempty"`
+	ClientKey  string `json:"client_key,omitempty"`
+	CACert     string `json:"ca_cert,omitempty"`
 
 	// Controller's server certificate for configuration signature verification (Story #315)
 	// Used by steward to verify configurations signed by this controller

--- a/test/e2e/framework.go
+++ b/test/e2e/framework.go
@@ -38,18 +38,17 @@ import (
 // RegisteredSteward represents a steward registered with the controller via MQTT
 // Story #294 Phase 3: Track MQTT-connected stewards for E2E testing
 type RegisteredSteward struct {
-	StewardID      string
-	TenantID       string
-	Group          string
-	MQTTClient     mqtt.Client
-	MQTTBroker     string
-	QUICAddress    string
-	ControllerURL  string
-	ClientCert     string
-	ClientKey      string
-	CACert         string
-	heartbeatDone  chan bool
-	commandHandler mqtt.MessageHandler
+	StewardID        string
+	TenantID         string
+	Group            string
+	MQTTClient       mqtt.Client
+	TransportAddress string
+	ControllerURL    string
+	ClientCert       string
+	ClientKey        string
+	CACert           string
+	heartbeatDone    chan bool
+	commandHandler   mqtt.MessageHandler
 }
 
 // E2ETestFramework provides a comprehensive end-to-end testing environment
@@ -499,15 +498,14 @@ func (f *E2ETestFramework) CreateRegistrationToken(tenantID string) (string, err
 // RegistrationResponse represents the HTTP registration response
 // Story #294 Phase 3: Used for steward registration via controller API
 type RegistrationResponse struct {
-	StewardID     string `json:"steward_id"`
-	TenantID      string `json:"tenant_id"`
-	Group         string `json:"group"`
-	ControllerURL string `json:"controller_url"`
-	MQTTBroker    string `json:"mqtt_broker"`
-	QUICAddress   string `json:"quic_address"`
-	ClientCert    string `json:"client_cert,omitempty"`
-	ClientKey     string `json:"client_key,omitempty"`
-	CACert        string `json:"ca_cert,omitempty"`
+	StewardID        string `json:"steward_id"`
+	TenantID         string `json:"tenant_id"`
+	Group            string `json:"group"`
+	ControllerURL    string `json:"controller_url"`
+	TransportAddress string `json:"transport_address"`
+	ClientCert       string `json:"client_cert,omitempty"`
+	ClientKey        string `json:"client_key,omitempty"`
+	CACert           string `json:"ca_cert,omitempty"`
 }
 
 // RegisterStewardWithController performs full steward registration flow via HTTP + MQTT
@@ -590,7 +588,7 @@ func (f *E2ETestFramework) RegisterStewardWithController(stewardName, tenantID s
 	f.logger.Info("HTTP registration successful",
 		"steward_id", regResp.StewardID,
 		"tenant_id", regResp.TenantID,
-		"mqtt_broker", regResp.MQTTBroker)
+		"transport_address", regResp.TransportAddress)
 
 	// Step 4: Create TLS config from registration certificates
 	tlsConfig, err := f.createTLSConfigFromPEM(
@@ -604,7 +602,7 @@ func (f *E2ETestFramework) RegisterStewardWithController(stewardName, tenantID s
 
 	// Step 5: Create MQTT client with TLS
 	mqttOpts := mqtt.NewClientOptions()
-	mqttOpts.AddBroker(regResp.MQTTBroker)
+	mqttOpts.AddBroker(regResp.TransportAddress)
 	mqttOpts.SetClientID(regResp.StewardID)
 	mqttOpts.SetTLSConfig(tlsConfig)
 	mqttOpts.SetKeepAlive(30 * time.Second) // 30s keepalive for heartbeat
@@ -659,18 +657,17 @@ func (f *E2ETestFramework) RegisterStewardWithController(stewardName, tenantID s
 	// Step 8: Create RegisteredSteward and start heartbeat
 	heartbeatDone := make(chan bool)
 	registeredSteward := &RegisteredSteward{
-		StewardID:      regResp.StewardID,
-		TenantID:       regResp.TenantID,
-		Group:          regResp.Group,
-		MQTTClient:     mqttClient,
-		MQTTBroker:     regResp.MQTTBroker,
-		QUICAddress:    regResp.QUICAddress,
-		ControllerURL:  regResp.ControllerURL,
-		ClientCert:     regResp.ClientCert,
-		ClientKey:      regResp.ClientKey,
-		CACert:         regResp.CACert,
-		heartbeatDone:  heartbeatDone,
-		commandHandler: commandHandler,
+		StewardID:        regResp.StewardID,
+		TenantID:         regResp.TenantID,
+		Group:            regResp.Group,
+		MQTTClient:       mqttClient,
+		TransportAddress: regResp.TransportAddress,
+		ControllerURL:    regResp.ControllerURL,
+		ClientCert:       regResp.ClientCert,
+		ClientKey:        regResp.ClientKey,
+		CACert:           regResp.CACert,
+		heartbeatDone:    heartbeatDone,
+		commandHandler:   commandHandler,
 	}
 
 	// Start heartbeat publishing goroutine

--- a/test/e2e/scenarios_test.go
+++ b/test/e2e/scenarios_test.go
@@ -831,7 +831,7 @@ func (s *E2ETestSuite) TestFailoverDetection() {
 
 		// Configure observer MQTT client
 		observerOpts := mqtt.NewClientOptions()
-		observerOpts.AddBroker(registered.MQTTBroker)
+		observerOpts.AddBroker(registered.TransportAddress)
 		// Story #313: use test-observer- prefix to match ACL controller whitelist
 		observerOpts.SetClientID(fmt.Sprintf("test-observer-%d", time.Now().UnixNano()))
 		observerOpts.SetTLSConfig(observerTLSConfig)
@@ -974,7 +974,7 @@ func (s *E2ETestSuite) TestMQTTCommandResponse() {
 		}
 
 		controllerOpts := mqtt.NewClientOptions()
-		controllerOpts.AddBroker(registered.MQTTBroker)
+		controllerOpts.AddBroker(registered.TransportAddress)
 		controllerOpts.SetClientID(fmt.Sprintf("controller-%d", time.Now().UnixNano()))
 		controllerOpts.SetTLSConfig(controllerTLSConfig)
 		controllerOpts.SetKeepAlive(30 * time.Second)

--- a/test/integration/mqtt_quic/helpers_test.go
+++ b/test/integration/mqtt_quic/helpers_test.go
@@ -96,15 +96,14 @@ func (h *TestHelper) RegisterSteward(t *testing.T, token string) *RegistrationRe
 
 // RegistrationResponse represents the registration API response
 type RegistrationResponse struct {
-	StewardID     string `json:"steward_id"`
-	TenantID      string `json:"tenant_id"`
-	Group         string `json:"group"`
-	ControllerURL string `json:"controller_url"`
-	MQTTBroker    string `json:"mqtt_broker"`
-	QUICAddress   string `json:"quic_address"`
-	ClientCert    string `json:"client_cert,omitempty"`
-	ClientKey     string `json:"client_key,omitempty"`
-	CACert        string `json:"ca_cert,omitempty"`
+	StewardID        string `json:"steward_id"`
+	TenantID         string `json:"tenant_id"`
+	Group            string `json:"group"`
+	ControllerURL    string `json:"controller_url"`
+	TransportAddress string `json:"transport_address"`
+	ClientCert       string `json:"client_cert,omitempty"`
+	ClientKey        string `json:"client_key,omitempty"`
+	CACert           string `json:"ca_cert,omitempty"`
 }
 
 // WaitForCondition waits for a condition with timeout

--- a/test/integration/mqtt_quic/multi_tenant_test.go
+++ b/test/integration/mqtt_quic/multi_tenant_test.go
@@ -109,7 +109,7 @@ func (s *MultiTenantTestSuite) TestSimultaneousTenants() {
 	regCount := 0
 	for regResp := range registrations {
 		s.NotEmpty(regResp.StewardID, "Steward ID should be assigned")
-		s.NotEmpty(regResp.MQTTBroker, "MQTT broker should be assigned")
+		s.NotEmpty(regResp.TransportAddress, "Transport address should be assigned")
 		regCount++
 	}
 

--- a/test/integration/mqtt_quic/registration_test.go
+++ b/test/integration/mqtt_quic/registration_test.go
@@ -51,11 +51,10 @@ func (s *RegistrationTestSuite) TestHTTPRegistrationEndpoint() {
 	s.NotEmpty(regResp.StewardID, "Steward ID should be generated")
 	s.Equal(expectedTenantID, regResp.TenantID, "Tenant ID should match")
 	s.Equal(expectedGroup, regResp.Group, "Group should match")
-	s.NotEmpty(regResp.MQTTBroker, "MQTT broker address should be provided")
-	s.NotEmpty(regResp.QUICAddress, "QUIC address should be provided")
+	s.NotEmpty(regResp.TransportAddress, "Transport address should be provided")
 
-	s.T().Logf("Registration successful: steward_id=%s, tenant_id=%s, mqtt=%s, quic=%s",
-		regResp.StewardID, regResp.TenantID, regResp.MQTTBroker, regResp.QUICAddress)
+	s.T().Logf("Registration successful: steward_id=%s, tenant_id=%s, transport_address=%s",
+		regResp.StewardID, regResp.TenantID, regResp.TransportAddress)
 }
 
 // TestInvalidToken tests registration with invalid token

--- a/test/integration/mqtt_quic/tls_security_test.go
+++ b/test/integration/mqtt_quic/tls_security_test.go
@@ -741,7 +741,7 @@ func (s *TLSSecurityTestSuite) TestMTLSWithRegistrationAPI() {
 	require.NotEmpty(s.T(), resp.ClientCert, "Registration should return client certificate")
 	require.NotEmpty(s.T(), resp.ClientKey, "Registration should return client key")
 	require.NotEmpty(s.T(), resp.CACert, "Registration should return CA certificate")
-	require.NotEmpty(s.T(), resp.MQTTBroker, "Registration should return MQTT broker address")
+	require.NotEmpty(s.T(), resp.TransportAddress, "Registration should return transport address")
 
 	s.T().Logf("✓ Registered steward: %s", resp.StewardID)
 


### PR DESCRIPTION
## Summary

Replaces the separate `mqtt_broker` and `quic_address` fields in the HTTP registration response with a single `transport_address` field. With unified gRPC-over-QUIC transport, one address serves both control plane and data plane. The steward needs only one address to connect.

## Problem Context

The registration endpoint (`POST /api/v1/register`) returned `mqtt_broker` (MQTT URL with scheme) and `quic_address` (bare host:port) as separate fields reflecting the old dual-protocol architecture. With unified transport (Issue #512), a single `host:port` address identifies the gRPC-over-QUIC endpoint. The transport provider handles protocol details — no scheme in the address.

This is a clean break: controller and steward are updated together with no backward compatibility for old field names.

## Changes

- Remove `getMQTTBrokerURL()` and `getQUICAddress()` from `handlers_registration.go`; replace with `getTransportAddress()` reading `cfg.Transport.ListenAddr`
- Replace `MQTTBroker`/`QUICAddress` with `TransportAddress` in controller `RegistrationResponse` and `RegisteredSteward` structs
- Replace `MQTTBroker`/`QUICAddress` with `TransportAddress` in steward-side `RegistrationResponse` struct
- Update `registerAndConnectMQTT()` in `cmd/steward/main.go` to read `regResp.TransportAddress`
- Update integration test helpers and e2e framework structs to match new field

## Measured Impact

All registration-related tests pass:
- `features/controller/api`: ✅ passed (6.8s)
- `cmd/steward`: ✅ passed
- `features/steward/registration`: ✅ no test files (struct-only package)
- Build: ✅ clean compilation

Pre-existing failures in test run (missing `/etc/machine-id`, no syslog, no external network) are environment limitations unrelated to this change.

## Testing

Scenarios verified:
- Controller registration handler builds and tests pass
- Steward registration client struct updated correctly
- Integration test helpers updated with `transport_address` field
- E2E framework `RegisteredSteward` and `RegistrationResponse` structs updated

Fixes #513
Part of #511
Part of #482