### PR TITLE
tooling: add refresh-agent-creds.sh script and simplify agent-setup

### DIFF
--- a/.claude/commands/agent-setup.md
+++ b/.claude/commands/agent-setup.md
@@ -20,7 +20,11 @@ One-time bootstrap for agent dispatch. Builds the container image, sets up crede
    ```
    If either fails, provide specific fix instructions and stop.
 
-2. **If `$ARGUMENTS` is 'creds'**: Skip to step 5 (credentials only).
+2. **If `$ARGUMENTS` is 'creds'**: Tell the user to run the refresh script directly in their terminal:
+   ```
+   ./scripts/refresh-agent-creds.sh
+   ```
+   This script handles Docker volume creation, OAuth login, workspace trust, and remote-control consent interactively. It requires a TTY and cannot be run via the Bash tool. After the user confirms completion, verify credentials with `./scripts/agent-dispatch.sh check-creds` and stop (skip all other steps).
 
 3. **Health check** (runs when image already exists and `$ARGUMENTS` is NOT 'rebuild'):
    ```bash
@@ -45,53 +49,15 @@ One-time bootstrap for agent dispatch. Builds the container image, sets up crede
    While waiting, proceed with steps 6-8 (they're independent).
 
 6. **Set up Claude credentials and workspace trust**:
-   **IMPORTANT**: This step requires a real TTY for interactive login and trust acceptance. The Bash tool CANNOT provide this. Do NOT attempt to run the `docker run --rm -it` command via the Bash tool — it will fail with "the input device is not a TTY". Instead, print the command and tell the user to run it manually in their terminal.
+   **IMPORTANT**: This step requires a real TTY. Do NOT attempt to run it via the Bash tool.
 
-   - Create Docker volume: `docker volume create claude-creds` (idempotent)
-   - Check if credentials already exist in the volume:
+   - Check if credentials already exist:
      ```bash
      docker run --rm -v claude-creds:/persist --entrypoint test cfg-agent:latest \
        -f /persist/.credentials.json && echo "exists"
      ```
    - If credentials exist and `$ARGUMENTS` is not 'creds': skip
-   - If credentials missing or refreshing:
-     - Tell user: "Claude credentials need setup. This requires interactive login, workspace trust acceptance, and remote-control approval."
-     - Print the following command for the user to run manually in their terminal:
-       ```bash
-       docker run --rm -it \
-         -v claude-creds:/persist \
-         -w /workspace \
-         --cap-add NET_ADMIN \
-         --user root \
-         --entrypoint bash \
-         cfg-agent:latest \
-         -c "mkdir -p /workspace && npm update -g @anthropic-ai/claude-code && su agent -c '
-           init-firewall.sh
-           echo \"\"
-           echo \"Step 1/4: OAuth login...\"
-           claude --dangerously-skip-permissions -p ready
-           echo \"\"
-           echo \"Step 2/4: Accepting workspace trust...\"
-           echo \"  → Type yes to trust /workspace, then /exit to quit\"
-           cd /workspace && claude
-           echo \"\"
-           echo \"Step 3/4: Accepting remote-control consent...\"
-           echo \"  → Type y to enable remote control, then Ctrl+C after it starts\"
-           cd /workspace && claude remote-control --permission-mode bypassPermissions --name setup-test || true
-           echo \"\"
-           echo \"Step 4/4: Saving all state...\"
-           cp ~/.claude/.credentials.json /persist/
-           cp ~/.claude.json /persist/.claude-config.json 2>/dev/null || true
-           cp -r ~/.claude /persist/.claude-state
-           echo \"Done! Credentials, trust, and remote-control consent saved.\"
-         '"
-       ```
-     - **What the user will experience**:
-       1. OAuth browser login (automatic redirect)
-       2. Workspace trust dialog — type `yes`, then `/exit`
-       3. Remote-control consent — type `y`, then `Ctrl+C` after it starts listening
-     - The `npm update` ensures the container's Claude Code matches the latest version.
-     - `~/.claude.json` (trust + remote consent) and `~/.claude/` (sessions, plugins) are saved to the volume.
+   - If credentials missing: tell the user to run `./scripts/refresh-agent-creds.sh` in their terminal, then confirm when done.
 
 7. **Create directories**:
    ```bash
@@ -124,5 +90,5 @@ One-time bootstrap for agent dispatch. Builds the container image, sets up crede
 - **Docker not installed**: Provide install link, stop
 - **GitHub not authenticated**: Tell user to run `gh auth login`, stop
 - **Image build fails**: Show build output, suggest checking Dockerfile
-- **OAuth flow fails**: Tell user to retry with `/agent-setup creds`
+- **OAuth flow fails**: Tell user to retry with `./scripts/refresh-agent-creds.sh`
 - **Network issues during build**: Suggest checking internet connection

--- a/scripts/refresh-agent-creds.sh
+++ b/scripts/refresh-agent-creds.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Refresh Claude Code OAuth credentials for agent dispatch containers.
+# Run this script directly in a terminal (requires TTY for interactive login).
+#
+# Usage: ./scripts/refresh-agent-creds.sh
+
+set -euo pipefail
+
+# Ensure Docker is running
+if ! docker info >/dev/null 2>&1; then
+  echo "ERROR: Docker is not running. Start Docker and retry."
+  exit 1
+fi
+
+# Ensure agent image exists
+if ! docker image inspect cfg-agent:latest >/dev/null 2>&1; then
+  echo "ERROR: cfg-agent:latest image not found. Run /agent-setup first."
+  exit 1
+fi
+
+# Create volume if it doesn't exist
+docker volume create claude-creds >/dev/null 2>&1 || true
+
+echo "Refreshing Claude Code credentials for agent containers..."
+echo ""
+
+exec docker run --rm -it \
+  -v claude-creds:/persist \
+  -w /workspace \
+  --cap-add NET_ADMIN \
+  --user root \
+  --entrypoint bash \
+  cfg-agent:latest \
+  -c 'mkdir -p /workspace && npm update -g @anthropic-ai/claude-code && su agent -c '"'"'
+    init-firewall.sh
+    echo ""
+    echo "Step 1/4: OAuth login..."
+    claude --dangerously-skip-permissions -p ready
+    echo ""
+    echo "Step 2/4: Accepting workspace trust..."
+    echo "  → Type yes to trust /workspace, then /exit to quit"
+    cd /workspace && claude
+    echo ""
+    echo "Step 3/4: Accepting remote-control consent..."
+    echo "  → Type y to enable remote control, then Ctrl+C after it starts"
+    cd /workspace && claude remote-control --permission-mode bypassPermissions --name setup-test || true
+    echo ""
+    echo "Step 4/4: Saving all state..."
+    cp ~/.claude/.credentials.json /persist/
+    cp ~/.claude.json /persist/.claude-config.json 2>/dev/null || true
+    cp -r ~/.claude /persist/.claude-state
+    echo "Done! Credentials, trust, and remote-control consent saved."
+  '"'"''


### PR DESCRIPTION
## Summary

Adds a standalone bash script for refreshing agent OAuth credentials, replacing the need to copy a long docker command between terminals.

## Changes

- Add `scripts/refresh-agent-creds.sh` — handles Docker volume creation, OAuth login, workspace trust, and remote-control consent
- Update `.claude/commands/agent-setup.md` — `/agent-setup creds` now points to the script instead of inlining the docker command

## Test plan

- [ ] Run `./scripts/refresh-agent-creds.sh` in terminal — completes OAuth flow
- [ ] Run `./scripts/agent-dispatch.sh check-creds` after — reports `CREDS_OK`
- [ ] `/agent-setup creds` directs user to run the script

🤖 Generated with [Claude Code](https://claude.com/claude-code)