### PR TITLE
transport: remove MQTT/QUIC go.mod dependencies and Makefile cleanup (Issue #522)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -40,13 +40,6 @@ updates:
           - "patch"
 
       # Production dependencies grouped by domain
-      mqtt-dependencies:
-        patterns:
-          - "github.com/mochi-mqtt/*"
-        update-types:
-          - "minor"
-          - "patch"
-
       quic-dependencies:
         patterns:
           - "github.com/quic-go/*"

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build test test-unit test-integration-factory test-watch test-commit test-complete test-e2e-local test-e2e-parallel test-e2e-ci test-e2e-mqtt-quic test-e2e-controller test-e2e-scenarios test-ci test-integration test-security test-performance test-performance-baseline test-data-consistency test-docker test-cross-feature-integration test-failure-propagation proto proto-gen lint clean security-trivy security-deps security-scan security-check security-precommit check-architecture check-license-headers generate-test-certificates
+.PHONY: build test test-unit test-integration-factory test-watch test-commit test-complete test-e2e-local test-e2e-parallel test-e2e-ci test-e2e-controller test-e2e-scenarios test-ci test-integration test-security test-performance test-performance-baseline test-data-consistency test-docker test-cross-feature-integration test-failure-propagation proto proto-gen lint clean security-trivy security-deps security-scan security-check security-precommit check-architecture check-license-headers generate-test-certificates
 
 # Use bash for all recipe commands (required for credential loading scripts)
 SHELL := /bin/bash
@@ -1511,8 +1511,8 @@ test-integration-unified:
 	@echo "⏳ Waiting for standalone controller to be healthy..."
 	@sleep 10
 	@echo ""
-	@echo "🧪 Running standalone Docker controller tests (MQTT+QUIC)..."
-	@CFGMS_TEST_DOCKER_MQTT=localhost:1883 go test -v -race ./test/integration -run TestDocker -timeout=10m || (echo "❌ Standalone tests failed"; exit 1)
+	@echo "🧪 Running standalone Docker controller tests..."
+	@go test -v -race ./test/integration -run TestDocker -timeout=10m || (echo "❌ Standalone tests failed"; exit 1)
 	@echo ""
 	@echo "🧪 Running in-process integration tests..."
 	@go test -v -race ./test/integration -run TestDetailedIntegration -timeout=10m || (echo "❌ In-process tests failed"; exit 1)
@@ -1611,11 +1611,6 @@ test-integration-docker:
 # Transport Integration Testing (Story #519: replaces MQTT+QUIC tests)
 # Tests gRPC-over-QUIC transport architecture with real Docker infrastructure
 .PHONY: test-transport test-transport-setup test-transport-cleanup
-# Keep old names as aliases for backwards compatibility during transition
-.PHONY: test-mqtt-quic test-mqtt-quic-setup test-mqtt-quic-cleanup
-test-mqtt-quic: test-transport
-test-mqtt-quic-setup: test-transport-setup
-test-mqtt-quic-cleanup: test-transport-cleanup
 
 test-transport: test-transport-setup
 	@echo ""
@@ -1654,7 +1649,7 @@ test-transport-setup:
 		echo "Generating test credentials..."; \
 		./scripts/generate-test-credentials.sh; \
 	fi
-	@echo "Starting TimescaleDB and standalone controller with MQTT+QUIC..."
+	@echo "Starting TimescaleDB and standalone controller (gRPC transport)..."
 	@echo "🔨 Force rebuilding Docker images (no cache)..."
 	@set -a && . ./.env.test && set +a && \
 	DOCKER_BUILDKIT=1 docker compose -f docker-compose.test.yml --profile ha build --no-cache controller-standalone steward-standalone && \
@@ -1735,7 +1730,7 @@ test-transport-cleanup:
 # Phase 2: Parallelizable E2E test targets (Story #297)
 # These targets can run independently and be parallelized with make -j3
 
-.PHONY: test-e2e-ci test-e2e-transport test-e2e-mqtt-quic test-e2e-controller test-e2e-scenarios
+.PHONY: test-e2e-ci test-e2e-transport test-e2e-controller test-e2e-scenarios
 
 # CI-style E2E tests - matches GitHub Actions production-gates.yml exactly
 # Self-contained: sets up infrastructure, runs tests, cleans up
@@ -1777,9 +1772,8 @@ test-e2e-ci:
 	@echo ""
 	@echo "✅ CI-style E2E tests completed successfully"
 
-# Aliases: Use test-e2e-ci or test-e2e-transport instead
+# Alias: Use test-e2e-ci instead
 test-e2e-transport: test-e2e-ci
-test-e2e-mqtt-quic: test-e2e-ci
 
 test-e2e-controller:
 	@echo "🧪 Running controller E2E tests (Docker deployment)..."
@@ -1922,7 +1916,7 @@ test-complete-full: test-commit test-fast test-production-critical build-cross-v
 	@echo "- ✅ Production critical tests passed (test-production-critical)"
 	@echo "- ✅ Cross-platform compilation validated (build-cross-validate)"
 	@echo "- ✅ Docker integration tests passed (storage/controller)"
-	@echo "- ✅ E2E tests passed (MQTT+QUIC + Controller - PARALLEL)"
+	@echo "- ✅ E2E tests passed (Transport + Controller - PARALLEL)"
 	@echo ""
 	@echo "🎯 Story is FULLY validated - matches all CI required checks"
 	@echo ""
@@ -1952,7 +1946,7 @@ test-agent-complete: test-commit test-fast test-production-critical build-cross-
 	@echo ""
 	@echo "⏩ Deferred to CI (requires Docker daemon):"
 	@echo "   - test-integration-docker (storage/controller Docker tests)"
-	@echo "   - test-e2e-fast (MQTT+QUIC + Controller E2E tests)"
+	@echo "   - test-e2e-fast (Transport + Controller E2E tests)"
 	@echo ""
 	@echo "ℹ️  Acceptable CI-only gaps:"
 	@echo "   - Native Windows/macOS builds (requires Windows/macOS runners)"

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,6 @@ toolchain go1.25.8
 
 require (
 	github.com/creack/pty v1.1.24
-	github.com/eclipse/paho.mqtt.golang v1.5.1
 	github.com/go-acme/lego/v4 v4.32.0
 	github.com/go-git/go-git/v5 v5.16.5
 	github.com/go-ldap/ldap/v3 v3.4.11
@@ -19,7 +18,6 @@ require (
 	github.com/joho/godotenv v1.5.1
 	github.com/lib/pq v1.10.9
 	github.com/mattn/go-sqlite3 v1.14.32
-	github.com/mochi-mqtt/server/v2 v2.7.9
 	github.com/quic-go/quic-go v0.57.0
 	github.com/shirou/gopsutil/v3 v3.24.5
 	github.com/spf13/cobra v1.8.0
@@ -99,7 +97,6 @@ require (
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c // indirect
-	github.com/rs/xid v1.4.0 // indirect
 	github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3 // indirect
 	github.com/shoenig/go-m1cpu v0.1.6 // indirect
 	github.com/skeema/knownhosts v1.3.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -83,8 +83,6 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/eclipse/paho.mqtt.golang v1.5.1 h1:/VSOv3oDLlpqR2Epjn1Q7b2bSTplJIeV2ISgCl2W7nE=
-github.com/eclipse/paho.mqtt.golang v1.5.1/go.mod h1:1/yJCneuyOoCOzKSsOTUc0AJfpsItBGWvYpBLimhArU=
 github.com/elazarl/goproxy v1.7.2 h1:Y2o6urb7Eule09PjlhQRGNsqRfPmYI3KKQLFpCAV3+o=
 github.com/elazarl/goproxy v1.7.2/go.mod h1:82vkLNir0ALaW14Rc399OTTjyNREgmdL2cVoIbS6XaE=
 github.com/emirpasic/gods v1.18.1 h1:FXtiHYKDGKCW2KzwZKx0iC0PQmdlorYgdFG9jPXJ1Bc=
@@ -154,8 +152,6 @@ github.com/jcmturner/gokrb5/v8 v8.4.4 h1:x1Sv4HaTpepFkXbt2IkL29DXRf8sOfZXo8eRKh6
 github.com/jcmturner/gokrb5/v8 v8.4.4/go.mod h1:1btQEpgT6k+unzCwX1KdWMEwPPkkgBtP+F6aCACiMrs=
 github.com/jcmturner/rpc/v2 v2.0.3 h1:7FXXj8Ti1IaVFpSAziCZWNzbNuZmnvw/i6CqLNdWfZY=
 github.com/jcmturner/rpc/v2 v2.0.3/go.mod h1:VUJYCIDm3PVOEHw8sgt091/20OJjskO/YJki3ELg/Hc=
-github.com/jinzhu/copier v0.3.5 h1:GlvfUwHk62RokgqVNvYsku0TATCF7bAHVwEXoBh3iJg=
-github.com/jinzhu/copier v0.3.5/go.mod h1:DfbEm0FYsaqBcKcFuvmOZb218JkPGtvSHsKg8S8hyyg=
 github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=
 github.com/joho/godotenv v1.5.1/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=
 github.com/kevinburke/ssh_config v1.2.0 h1:x584FjTGwHzMwvHx18PXxbBVzfnxogHaAReU4gf13a4=
@@ -181,8 +177,6 @@ github.com/mattn/go-sqlite3 v1.14.32 h1:JD12Ag3oLy1zQA+BNn74xRgaBbdhbNIDYvQUEuuE
 github.com/mattn/go-sqlite3 v1.14.32/go.mod h1:Uh1q+B4BYcTPb+yiD3kU8Ct7aC0hY9fxUwlHK0RXw+Y=
 github.com/miekg/dns v1.1.72 h1:vhmr+TF2A3tuoGNkLDFK9zi36F2LS+hKTRW0Uf8kbzI=
 github.com/miekg/dns v1.1.72/go.mod h1:+EuEPhdHOsfk6Wk5TT2CzssZdqkmFhf8r+aVyDEToIs=
-github.com/mochi-mqtt/server/v2 v2.7.9 h1:y0g4vrSLAag7T07l2oCzOa/+nKVLoazKEWAArwqBNYI=
-github.com/mochi-mqtt/server/v2 v2.7.9/go.mod h1:lZD3j35AVNqJL5cezlnSkuG05c0FCHSsfAKSPBOSbqc=
 github.com/onsi/gomega v1.34.1 h1:EUMJIKUjM8sKjYbtxQI9A4z2o+rruxnzNvpknOXie6k=
 github.com/onsi/gomega v1.34.1/go.mod h1:kU1QgUvBDLXBJq618Xvm2LUX6rSAfRaFRTcdOeDLwwY=
 github.com/pjbgf/sha1cd v0.3.2 h1:a9wb0bp1oC2TGwStyn0Umc/IGKQnEgF0vVaZ8QF8eo4=
@@ -200,8 +194,6 @@ github.com/quic-go/quic-go v0.57.0 h1:AsSSrrMs4qI/hLrKlTH/TGQeTMY0ib1pAOX7vA3Adq
 github.com/quic-go/quic-go v0.57.0/go.mod h1:ly4QBAjHA2VhdnxhojRsCUOeJwKYg+taDlos92xb1+s=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
-github.com/rs/xid v1.4.0 h1:qd7wPTDkN6KQx2VmMBLrpHkiyQwgFXRnkOLacUiaSNY=
-github.com/rs/xid v1.4.0/go.mod h1:trrq9SKmegXys3aeAKXMUTdJsYXVwGY3RLcfgqegfbg=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3 h1:n661drycOFuPLCN3Uc8sB6B/s6Z4t2xvBgU1htSHuq8=
 github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3/go.mod h1:A0bzQcvG0E7Rwjx0REVgAGH58e96+X0MeOfepqsbeW4=

--- a/test/integration/docker_test.go
+++ b/test/integration/docker_test.go
@@ -4,280 +4,32 @@ package integration
 
 import (
 	"context"
-	"encoding/json"
-	"fmt"
-	"net"
-	"os"
 	"os/exec"
-	"path/filepath"
-	"sync"
 	"testing"
-	"time"
 
-	mqtt "github.com/eclipse/paho.mqtt.golang"
 	"github.com/stretchr/testify/suite"
 )
 
-// DockerIntegrationTestSuite tests against actual Docker containers
-// This verifies real-world MQTT+QUIC communication between containerized
-// steward and controller binaries (not in-process components)
-//
-// Phase 10 (Story 12.2): Replaces log inspection with actual MQTT message validation
+// DockerIntegrationTestSuite tests against actual Docker containers.
+// MQTT-based tests (TestStewardHeartbeat, TestStewardDNACollection,
+// TestStewardStatusReporting, TestMQTTPortAccessibility) have been removed
+// as part of Phase 10.11 (Issue #522) — MQTT transport was replaced by
+// gRPC-over-QUIC. Equivalent validation is in test/integration/transport/.
 type DockerIntegrationTestSuite struct {
 	suite.Suite
-	mqttClient mqtt.Client
-	mqttAddr   string
 }
 
 func (s *DockerIntegrationTestSuite) SetupSuite() {
 	// Skip in short mode - requires Docker infrastructure
 	if testing.Short() {
 		s.T().Skip("Skipping Docker integration tests in short mode - requires Docker infrastructure")
-		return
-	}
-
-	// Check if Docker controller MQTT broker is available
-	s.mqttAddr = os.Getenv("CFGMS_TEST_DOCKER_MQTT")
-	if s.mqttAddr == "" {
-		s.mqttAddr = "localhost:1886" // Default standalone controller MQTT port
-	}
-
-	// Add tcp:// prefix if not present
-	if s.mqttAddr[:6] != "tcp://" {
-		s.mqttAddr = "tcp://" + s.mqttAddr
-	}
-
-	// Test if Docker controller MQTT broker is reachable (strip tcp://)
-	tcpAddr := s.mqttAddr[6:]
-	conn, err := net.DialTimeout("tcp", tcpAddr, 2*time.Second)
-	if err != nil {
-		s.T().Skipf("Docker controller MQTT broker not available at %s: %v", tcpAddr, err)
-		return
-	}
-	_ = conn.Close()
-
-	s.T().Logf("Docker controller MQTT broker accessible at %s", s.mqttAddr)
-
-	// Start steward-standalone container
-	s.T().Log("Starting steward-standalone container...")
-
-	// Get project root (assuming tests run from project root or test directory)
-	wd, _ := os.Getwd()
-	projectRoot := filepath.Join(wd, "../..")
-	if _, err := os.Stat(filepath.Join(projectRoot, "docker-compose.test.yml")); os.IsNotExist(err) {
-		// Already at project root
-		projectRoot = wd
-	}
-
-	composePath := filepath.Join(projectRoot, "docker-compose.test.yml")
-	cmd := exec.Command("docker", "compose", "-f", composePath, "--profile", "ha", "up", "-d", "steward-standalone")
-	if output, err := cmd.CombinedOutput(); err != nil {
-		s.T().Fatalf("Failed to start steward-standalone: %v\nOutput: %s", err, output)
-	}
-
-	// Wait for steward to initialize
-	time.Sleep(5 * time.Second)
-
-	// Create MQTT client for message validation
-	opts := mqtt.NewClientOptions()
-	opts.AddBroker(s.mqttAddr)
-	opts.SetClientID(fmt.Sprintf("docker-test-%d", time.Now().UnixNano()))
-	opts.SetConnectTimeout(10 * time.Second)
-	opts.SetKeepAlive(30 * time.Second)
-	opts.SetAutoReconnect(true)
-
-	s.mqttClient = mqtt.NewClient(opts)
-	token := s.mqttClient.Connect()
-	if !token.WaitTimeout(10 * time.Second) {
-		s.T().Fatalf("MQTT connection timeout to %s", s.mqttAddr)
-	}
-	if token.Error() != nil {
-		s.T().Fatalf("MQTT connection error: %v", token.Error())
-	}
-
-	s.T().Logf("MQTT test client connected successfully to %s", s.mqttAddr)
-}
-
-func (s *DockerIntegrationTestSuite) TearDownSuite() {
-	// Disconnect MQTT client
-	if s.mqttClient != nil && s.mqttClient.IsConnected() {
-		s.mqttClient.Disconnect(250)
-		s.T().Log("MQTT test client disconnected")
-	}
-
-	// Stop steward container (leave controller running for other tests)
-	s.T().Log("Stopping steward-standalone container...")
-
-	wd, _ := os.Getwd()
-	projectRoot := filepath.Join(wd, "../..")
-	if _, err := os.Stat(filepath.Join(projectRoot, "docker-compose.test.yml")); os.IsNotExist(err) {
-		projectRoot = wd
-	}
-
-	composePath := filepath.Join(projectRoot, "docker-compose.test.yml")
-	cmd := exec.Command("docker", "compose", "-f", composePath, "stop", "steward-standalone")
-	_ = cmd.Run()
-}
-
-// TestStewardHeartbeat validates steward sends heartbeat messages via MQTT
-// Replaces log string check with actual MQTT message subscription and validation
-func (s *DockerIntegrationTestSuite) TestStewardHeartbeat() {
-	heartbeatTopic := "cfgms/steward/+/heartbeat"
-
-	heartbeatReceived := make(chan map[string]interface{}, 1)
-	var mu sync.Mutex
-	var lastHeartbeat map[string]interface{}
-
-	// Subscribe to heartbeat topic
-	token := s.mqttClient.Subscribe(heartbeatTopic, 1, func(client mqtt.Client, msg mqtt.Message) {
-		mu.Lock()
-		defer mu.Unlock()
-
-		var heartbeat map[string]interface{}
-		if err := json.Unmarshal(msg.Payload(), &heartbeat); err != nil {
-			s.T().Logf("Failed to parse heartbeat: %v", err)
-			return
-		}
-
-		s.T().Logf("Received heartbeat from topic %s: %+v", msg.Topic(), heartbeat)
-		lastHeartbeat = heartbeat
-		select {
-		case heartbeatReceived <- heartbeat:
-		default:
-			// Channel full, skip
-		}
-	})
-
-	s.True(token.WaitTimeout(5*time.Second), "Subscribe should not timeout")
-	s.NoError(token.Error(), "Subscribe should succeed")
-
-	// Wait for heartbeat message (stewards send every 30s, but we'll wait up to 45s)
-	select {
-	case heartbeat := <-heartbeatReceived:
-		s.Contains(heartbeat, "steward_id", "Heartbeat should contain steward_id")
-		s.Contains(heartbeat, "status", "Heartbeat should contain status")
-		s.Contains(heartbeat, "timestamp", "Heartbeat should contain timestamp")
-		s.T().Logf("✅ Heartbeat validated: steward_id=%s, status=%s", heartbeat["steward_id"], heartbeat["status"])
-	case <-time.After(45 * time.Second):
-		mu.Lock()
-		if lastHeartbeat != nil {
-			s.T().Logf("Heartbeat was received but channel was full. Last heartbeat: %+v", lastHeartbeat)
-			s.Contains(lastHeartbeat, "steward_id", "Heartbeat should contain steward_id")
-		} else {
-			s.Fail("No heartbeat received within 45 seconds")
-		}
-		mu.Unlock()
-	}
-}
-
-// TestStewardDNACollection validates steward collects and transmits DNA via MQTT
-// Replaces log string check with actual MQTT message subscription and validation
-func (s *DockerIntegrationTestSuite) TestStewardDNACollection() {
-	dnaTopic := "cfgms/steward/+/dna"
-
-	dnaReceived := make(chan map[string]interface{}, 1)
-	var mu sync.Mutex
-	var lastDNA map[string]interface{}
-
-	// Subscribe to DNA topic
-	token := s.mqttClient.Subscribe(dnaTopic, 1, func(client mqtt.Client, msg mqtt.Message) {
-		mu.Lock()
-		defer mu.Unlock()
-
-		var dna map[string]interface{}
-		if err := json.Unmarshal(msg.Payload(), &dna); err != nil {
-			s.T().Logf("Failed to parse DNA: %v", err)
-			return
-		}
-
-		s.T().Logf("Received DNA from topic %s: %+v", msg.Topic(), dna)
-		lastDNA = dna
-		select {
-		case dnaReceived <- dna:
-		default:
-			// Channel full, skip
-		}
-	})
-
-	s.True(token.WaitTimeout(5*time.Second), "Subscribe should not timeout")
-	s.NoError(token.Error(), "Subscribe should succeed")
-
-	// Wait for DNA message (stewards send periodically, wait up to 60s)
-	select {
-	case dna := <-dnaReceived:
-		s.Contains(dna, "steward_id", "DNA should contain steward_id")
-		s.Contains(dna, "timestamp", "DNA should contain timestamp")
-		// DNA should contain system information
-		if dnaData, ok := dna["dna"]; ok {
-			s.T().Logf("✅ DNA validated: steward_id=%s, fields=%d", dna["steward_id"], len(dnaData.(map[string]interface{})))
-		} else {
-			s.T().Logf("⚠️  DNA message received but 'dna' field not present: %+v", dna)
-		}
-	case <-time.After(60 * time.Second):
-		mu.Lock()
-		if lastDNA != nil {
-			s.T().Logf("DNA was received but channel was full. Last DNA: %+v", lastDNA)
-			s.Contains(lastDNA, "steward_id", "DNA should contain steward_id")
-		} else {
-			s.T().Logf("⚠️  No DNA message received within 60 seconds (may be expected if steward doesn't publish DNA immediately)")
-		}
-		mu.Unlock()
-	}
-}
-
-// TestStewardStatusReporting validates steward reports status via MQTT
-// Replaces log string check with actual MQTT message subscription and validation
-func (s *DockerIntegrationTestSuite) TestStewardStatusReporting() {
-	statusTopic := "cfgms/steward/+/status"
-
-	statusReceived := make(chan map[string]interface{}, 1)
-	var mu sync.Mutex
-	var lastStatus map[string]interface{}
-
-	// Subscribe to status topic
-	token := s.mqttClient.Subscribe(statusTopic, 1, func(client mqtt.Client, msg mqtt.Message) {
-		mu.Lock()
-		defer mu.Unlock()
-
-		var status map[string]interface{}
-		if err := json.Unmarshal(msg.Payload(), &status); err != nil {
-			s.T().Logf("Failed to parse status: %v", err)
-			return
-		}
-
-		s.T().Logf("Received status from topic %s: %+v", msg.Topic(), status)
-		lastStatus = status
-		select {
-		case statusReceived <- status:
-		default:
-			// Channel full, skip
-		}
-	})
-
-	s.True(token.WaitTimeout(5*time.Second), "Subscribe should not timeout")
-	s.NoError(token.Error(), "Subscribe should succeed")
-
-	// Wait for status message (may not be sent immediately, wait up to 30s)
-	select {
-	case status := <-statusReceived:
-		s.Contains(status, "steward_id", "Status should contain steward_id")
-		s.T().Logf("✅ Status report validated: steward_id=%s", status["steward_id"])
-	case <-time.After(30 * time.Second):
-		mu.Lock()
-		if lastStatus != nil {
-			s.T().Logf("Status was received but channel was full. Last status: %+v", lastStatus)
-			s.Contains(lastStatus, "steward_id", "Status should contain steward_id")
-		} else {
-			s.T().Logf("⚠️  No status message received within 30 seconds (may be expected if no config changes)")
-		}
-		mu.Unlock()
 	}
 }
 
 // TestContainerHealth validates both containers are running
 func (s *DockerIntegrationTestSuite) TestContainerHealth() {
 	// Check controller is healthy
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*1e9)
 	defer cancel()
 
 	cmd := exec.CommandContext(ctx, "docker", "ps", "--filter", "name=controller-standalone", "--filter", "health=healthy", "--format", "{{.Names}}")
@@ -290,15 +42,6 @@ func (s *DockerIntegrationTestSuite) TestContainerHealth() {
 	output, err = cmd.CombinedOutput()
 	s.NoError(err, "Docker command should succeed")
 	s.Contains(string(output), "steward-standalone", "Steward should be running")
-}
-
-// TestMQTTPortAccessibility validates MQTT port is accessible
-func (s *DockerIntegrationTestSuite) TestMQTTPortAccessibility() {
-	conn, err := net.DialTimeout("tcp", "localhost:1886", 2*time.Second)
-	s.NoError(err, "Should be able to connect to MQTT port 1886")
-	if conn != nil {
-		_ = conn.Close()
-	}
 }
 
 func TestDockerIntegration(t *testing.T) {


### PR DESCRIPTION
## Summary

Removes the last MQTT dependencies from go.mod as part of Phase 10.11 of the transport migration. With all MQTT code deleted (Issue #520) and standalone QUIC deleted (Issue #521), `paho.mqtt.golang` and `mochi-mqtt/server/v2` are no longer used anywhere in the codebase and must be removed.

Also removes backward-compat Makefile aliases (transition from MQTT+QUIC naming to transport naming is now complete) and cleans up the dependabot.yml mochi-mqtt tracking group.

## Problem Context

After Issues #520 and #521 deleted all MQTT and standalone QUIC code, the direct dependencies in go.mod remained. Running `go mod tidy` with these entries would try to re-add the packages. Additionally, `test/integration/docker_test.go` still imported `paho.mqtt.golang` to validate steward behavior via MQTT subscriptions — tests that were testing a removed transport protocol. The file needed to be updated to remove the dead import.

The Makefile still had `test-mqtt-quic` backward-compat aliases from the Story #519 transition and echo messages referencing "MQTT+QUIC". These were transition scaffolding that is now removable.

## Changes

- Remove `github.com/eclipse/paho.mqtt.golang` and `github.com/mochi-mqtt/server/v2` from go.mod direct dependencies
- Run `go mod tidy` — cleans up transitive go.sum entries
- Remove `test-mqtt-quic`/`test-mqtt-quic-setup`/`test-mqtt-quic-cleanup` aliases from Makefile (transition complete)
- Remove `test-e2e-mqtt-quic` alias and .PHONY entry from Makefile
- Update three echo messages referencing "MQTT+QUIC" to "Transport"/"gRPC transport"
- Remove `mqtt-dependencies` group from `.github/dependabot.yml`
- Rewrite `test/integration/docker_test.go` to remove paho.mqtt import and obsolete MQTT-based tests (covered by `test/integration/transport/`)

## Measured Impact

- `grep "paho.mqtt" go.mod` → zero results
- `grep "mochi-mqtt" go.mod` → zero results
- `go mod tidy` → exit 0, no errors
- `build-cross-validate` → all 5 platforms pass (linux/amd64, linux/arm64, darwin/amd64, darwin/arm64, windows/amd64)
- go.mod direct deps section: 2 entries removed
- go.sum: 8 entries removed (transitive deps of paho/mochi)

## Testing

- Cross-platform compilation validated: all platforms pass
- Pre-existing test failures (pkg/secrets/providers/steward, features/saas) confirmed present on unmodified branch — caused by missing `/etc/machine-id` and no network access in agent container, unrelated to this change

Fixes #522
Part of #511
Part of #482

🤖 Generated with [Claude Code](https://claude.com/claude-code)