### PR TITLE
transport: remove remaining MQTT naming artifacts (Issue #511)

### DIFF
--- a/cmd/cfg/cmd/controller.go
+++ b/cmd/cfg/cmd/controller.go
@@ -30,7 +30,7 @@ var controllerCmd = &cobra.Command{
 
 Provides operational visibility into controller status including:
 - Overall health status and component health
-- Performance metrics (MQTT, storage, application, system)
+- Performance metrics (transport, storage, application, system)
 - Active alerts and threshold breaches
 - Request traces for debugging
 
@@ -51,7 +51,7 @@ var controllerStatusCmd = &cobra.Command{
 	Short: "Show controller health status",
 	Long: `Display human-readable controller health status including:
 - Overall health (healthy, degraded, unhealthy)
-- Component status (MQTT, storage, application, system)
+- Component status (transport, storage, application, system)
 - Active alerts
 - Uptime
 
@@ -69,7 +69,7 @@ var controllerMetricsCmd = &cobra.Command{
 	Use:   "metrics",
 	Short: "Show detailed controller metrics",
 	Long: `Display detailed controller performance metrics including:
-- MQTT broker: connections, queue depth, throughput
+- Transport: connected stewards, stream errors, message throughput
 - Storage: latency, pool utilization, slow queries
 - Application: workflow/script queue depths, active executions
 - System: CPU, memory, goroutines
@@ -212,15 +212,15 @@ func runControllerMetrics(cmd *cobra.Command, args []string) error {
 	// Parse response
 	var metrics struct {
 		Timestamp time.Time `json:"timestamp"`
-		MQTT      *struct {
-			ActiveConnections     int64     `json:"active_connections"`
-			MessageQueueDepth     int64     `json:"message_queue_depth"`
-			MessageThroughput     float64   `json:"message_throughput"`
-			TotalMessagesSent     int64     `json:"total_messages_sent"`
-			TotalMessagesReceived int64     `json:"total_messages_received"`
-			ConnectionErrors      int64     `json:"connection_errors"`
+		Transport *struct {
+			ConnectedStewards     int       `json:"connected_stewards"`
+			StreamErrors          int64     `json:"stream_errors"`
+			MessagesSent          int64     `json:"messages_sent"`
+			MessagesReceived      int64     `json:"messages_received"`
+			ReconnectionAttempts  int64     `json:"reconnection_attempts"`
+			AvgLatencyNs          int64     `json:"avg_latency_ns"`
 			CollectedAt           time.Time `json:"collected_at"`
-		} `json:"mqtt"`
+		} `json:"transport"`
 		Storage *struct {
 			Provider          string    `json:"provider"`
 			PoolUtilization   float64   `json:"pool_utilization"`
@@ -268,15 +268,15 @@ func runControllerMetrics(cmd *cobra.Command, args []string) error {
 	fmt.Printf("\nController Metrics - %s\n", metrics.Timestamp.Format("2006-01-02 15:04:05 MST"))
 	fmt.Println()
 
-	// MQTT metrics
-	if metrics.MQTT != nil {
-		fmt.Println("=== MQTT Broker ===")
-		fmt.Printf("Active Connections:     %d\n", metrics.MQTT.ActiveConnections)
-		fmt.Printf("Message Queue Depth:    %d\n", metrics.MQTT.MessageQueueDepth)
-		fmt.Printf("Message Throughput:     %.2f msg/sec\n", metrics.MQTT.MessageThroughput)
-		fmt.Printf("Total Messages Sent:    %d\n", metrics.MQTT.TotalMessagesSent)
-		fmt.Printf("Total Messages Received: %d\n", metrics.MQTT.TotalMessagesReceived)
-		fmt.Printf("Connection Errors:      %d\n", metrics.MQTT.ConnectionErrors)
+	// Transport metrics
+	if metrics.Transport != nil {
+		fmt.Println("=== Transport (gRPC-over-QUIC) ===")
+		fmt.Printf("Connected Stewards:     %d\n", metrics.Transport.ConnectedStewards)
+		fmt.Printf("Stream Errors:          %d\n", metrics.Transport.StreamErrors)
+		fmt.Printf("Messages Sent:          %d\n", metrics.Transport.MessagesSent)
+		fmt.Printf("Messages Received:      %d\n", metrics.Transport.MessagesReceived)
+		fmt.Printf("Reconnection Attempts:  %d\n", metrics.Transport.ReconnectionAttempts)
+		fmt.Printf("Avg Latency:            %dns\n", metrics.Transport.AvgLatencyNs)
 		fmt.Println()
 	}
 

--- a/cmd/cfg/cmd/regcode.go
+++ b/cmd/cfg/cmd/regcode.go
@@ -17,7 +17,7 @@ type RegistrationCode struct {
 	// TenantID is the unique identifier for the tenant
 	TenantID string `json:"tenant_id"`
 
-	// ControllerURL is the MQTT broker URL (e.g., "mqtt://controller.example.com:8883")
+	// ControllerURL is the controller address (e.g., "controller.example.com:4433")
 	ControllerURL string `json:"controller_url"`
 
 	// Group is an optional group identifier for organization
@@ -47,10 +47,10 @@ to the steward installer.
 
 Examples:
   # Generate a registration code
-  cfg regcode --tenant-id=acme-corp --controller-url=mqtt://controller.acme.com:8883
+  cfg regcode --tenant-id=acme-corp --controller-url=controller.acme.com:4433
 
   # Generate with optional group
-  cfg regcode --tenant-id=acme-corp --controller-url=mqtt://controller.acme.com:8883 --group=production
+  cfg regcode --tenant-id=acme-corp --controller-url=controller.acme.com:4433 --group=production
 
   # Decode a registration code
   cfg regcode --decode eyJ0ZW5hbnRfaWQi...`,
@@ -59,7 +59,7 @@ Examples:
 
 func init() {
 	regcodeCmd.Flags().StringVar(&tenantID, "tenant-id", "", "Tenant ID (required for generation)")
-	regcodeCmd.Flags().StringVar(&controllerURL, "controller-url", "", "Controller MQTT URL (required for generation)")
+	regcodeCmd.Flags().StringVar(&controllerURL, "controller-url", "", "Controller address host:port (required for generation)")
 	regcodeCmd.Flags().StringVar(&group, "group", "", "Optional group identifier")
 	regcodeCmd.Flags().BoolVar(&decode, "decode", false, "Decode a registration code (provide code as argument)")
 }
@@ -75,15 +75,15 @@ func runRegCode(cmd *cobra.Command, args []string) error {
 func generateRegistrationCode() error {
 	// Validate required fields
 	if tenantID == "" {
-		return fmt.Errorf("--tenant-id is required for generation\n\nThe tenant ID is your organization's unique identifier (e.g., 'acme-corp', 'contoso')\n\nExample:\n  cfg regcode --tenant-id=acme-corp --controller-url=mqtts://controller.example.com:8883")
+		return fmt.Errorf("--tenant-id is required for generation\n\nThe tenant ID is your organization's unique identifier (e.g., 'acme-corp', 'contoso')\n\nExample:\n  cfg regcode --tenant-id=acme-corp --controller-url=controller.example.com:4433")
 	}
 	if controllerURL == "" {
-		return fmt.Errorf("--controller-url is required for generation\n\nThe controller URL is the MQTT broker endpoint where stewards connect\n\nFormat: mqtt://HOST:PORT or mqtts://HOST:PORT (mqtts recommended for production)\n\nExample:\n  cfg regcode --tenant-id=acme-corp --controller-url=mqtts://controller.example.com:8883")
+		return fmt.Errorf("--controller-url is required for generation\n\nThe controller URL is the transport address where stewards connect\n\nFormat: HOST:PORT\n\nExample:\n  cfg regcode --tenant-id=acme-corp --controller-url=controller.example.com:4433")
 	}
 
-	// Validate controller URL format
-	if !strings.HasPrefix(controllerURL, "mqtt://") && !strings.HasPrefix(controllerURL, "mqtts://") {
-		return fmt.Errorf("controller URL must start with mqtt:// or mqtts://\n\nYour URL: %s\n\nValid formats:\n  mqtts://HOST:PORT  (TLS-encrypted, recommended for production)\n  mqtt://HOST:PORT   (unencrypted, development only)\n\nExample:\n  mqtts://controller.example.com:8883", controllerURL)
+	// Validate controller URL format (host:port)
+	if !strings.Contains(controllerURL, ":") {
+		return fmt.Errorf("controller URL must be in HOST:PORT format\n\nYour URL: %s\n\nExample:\n  controller.example.com:4433", controllerURL)
 	}
 
 	// Create registration code structure

--- a/cmd/cfg/cmd/token.go
+++ b/cmd/cfg/cmd/token.go
@@ -45,10 +45,10 @@ The controller URL and API key can be provided via flags or environment variable
 
 Examples:
   # Create a token that expires in 7 days
-  cfg token create --tenant-id=acme-corp --controller-url=mqtt://controller.acme.com:8883 --expires=7d
+  cfg token create --tenant-id=acme-corp --controller-url=controller.acme.com:4433 --expires=7d
 
   # Create a single-use token for production group
-  cfg token create --tenant-id=acme-corp --controller-url=mqtt://controller.acme.com:8883 --group=production --single-use
+  cfg token create --tenant-id=acme-corp --controller-url=controller.acme.com:4433 --group=production --single-use
 
   # List all tokens for a tenant
   cfg token list --tenant-id=acme-corp
@@ -74,13 +74,13 @@ Expiration formats:
 
 Examples:
   # 7-day expiring token
-  cfg token create --tenant-id=acme-corp --controller-url=mqtt://controller.acme.com:8883 --expires=7d
+  cfg token create --tenant-id=acme-corp --controller-url=controller.acme.com:4433 --expires=7d
 
   # Single-use token
-  cfg token create --tenant-id=acme-corp --controller-url=mqtt://controller.acme.com:8883 --single-use
+  cfg token create --tenant-id=acme-corp --controller-url=controller.acme.com:4433 --single-use
 
   # Token for specific group
-  cfg token create --tenant-id=acme-corp --controller-url=mqtt://controller.acme.com:8883 --group=production`,
+  cfg token create --tenant-id=acme-corp --controller-url=controller.acme.com:4433 --group=production`,
 	RunE: runTokenCreate,
 }
 

--- a/features/steward/steward.go
+++ b/features/steward/steward.go
@@ -162,13 +162,13 @@ type Steward struct {
 	executionEngine *execution.ExecutionEngine
 
 	// Controller mode components - DEPRECATED (Story #198)
-	// The old gRPC-based controller mode is replaced by MQTT+QUIC registration
+	// The old gRPC-based controller mode is replaced by gRPC-over-QUIC registration
 	// Use cmd/steward/main.go with --regtoken parameter instead
 	// controllerClient *client.Client
 	dnaCollector *dna.Collector
 
-	// MQTT+QUIC client for controller testing mode (Story #198)
-	mqttClient interface{} // *client.MQTTClient - interface{} to avoid import cycle
+	// Transport client for controller testing mode (interface{} to avoid import cycle)
+	transportClient interface{}
 
 	// Secret store for steward-side secret management
 	secretStore secretsif.SecretStore
@@ -191,21 +191,21 @@ type Steward struct {
 // Returns an error if controller client or DNA collector initialization fails.
 func New(cfg *Config, logger logging.Logger) (*Steward, error) {
 	// DEPRECATED: gRPC-based controller mode removed in Story #198
-	// Use NewStandalone() or cmd/steward --regtoken for MQTT+QUIC mode
-	return nil, fmt.Errorf("steward controller mode with gRPC is deprecated (Story #198) - use NewStandalone() or cmd/steward --regtoken=<token> for MQTT+QUIC mode")
+	// Use NewStandalone() or cmd/steward --regtoken for gRPC-over-QUIC mode
+	return nil, fmt.Errorf("steward controller mode with gRPC is deprecated (Story #198) - use NewStandalone() or cmd/steward --regtoken=<token> for gRPC-over-QUIC mode")
 }
 
-// NewForControllerTesting creates a new Steward instance for integration testing with MQTT+QUIC.
+// NewForControllerTesting creates a new Steward instance for integration testing with gRPC-over-QUIC.
 //
 // This constructor is specifically for integration tests that need to validate
-// steward-controller communication using the new MQTT+QUIC architecture.
+// steward-controller communication using the new gRPC-over-QUIC architecture.
 // It creates a minimal steward with only the components needed for testing:
 // - DNA collector for system fingerprinting
-// - MQTT client for communication
+// - transport client for communication
 // - Health monitoring
 //
 // The steward will register with the controller using certificates from cfg.CertPath
-// and communicate via MQTT broker at cfg.ControllerAddr.
+// and communicate via controller at cfg.ControllerAddr.
 //
 // This is NOT for production use - use cmd/steward with --regtoken for production.
 func NewForControllerTesting(cfg *Config, logger logging.Logger) (*Steward, error) {
@@ -378,30 +378,30 @@ func (s *Steward) startStandalone(ctx context.Context) error {
 
 // startController starts the steward in controller mode with full gRPC integration.
 //
-// DEPRECATED: Controller mode removed in Story #198 (MQTT+QUIC Migration)
-// Use cmd/steward --regtoken for MQTT+QUIC registration instead
+// DEPRECATED: Controller mode removed in Story #198 (gRPC-over-QUIC Migration)
+// Use cmd/steward --regtoken for gRPC-over-QUIC registration instead
 //
 // Returns an error indicating the mode is deprecated.
 func (s *Steward) startController(ctx context.Context) error {
-	// Check if this is the new testing mode with MQTT client
-	if s.mqttClient != nil {
+	// Check if this is the new testing mode with transport client
+	if s.transportClient != nil {
 		return s.startControllerTesting(ctx)
 	}
-	return fmt.Errorf("controller mode deprecated (Story #198) - use cmd/steward --regtoken for MQTT+QUIC mode")
+	return fmt.Errorf("controller mode deprecated (Story #198) - use cmd/steward --regtoken for gRPC-over-QUIC mode")
 }
 
-// startControllerTesting starts the steward in controller testing mode with MQTT+QUIC.
+// startControllerTesting starts the steward in controller testing mode with gRPC-over-QUIC.
 //
 // This method implements the integration test workflow:
 //  1. Start health monitoring
-//  2. Connect to MQTT broker
+//  2. Connect to controller
 //  3. Collect system DNA
 //  4. Register with controller
 //  5. Start heartbeat loop
 //
-// This mirrors the old startController behavior but uses MQTT+QUIC instead of gRPC.
+// This mirrors the old startController behavior but uses gRPC-over-QUIC instead of gRPC.
 func (s *Steward) startControllerTesting(ctx context.Context) error {
-	s.logger.Info("Starting steward in controller testing mode (MQTT+QUIC)", "id", s.legacyConfig.ID)
+	s.logger.Info("Starting steward in controller testing mode (gRPC-over-QUIC)", "id", s.legacyConfig.ID)
 
 	// Start health monitoring in background
 	go func() {
@@ -413,7 +413,7 @@ func (s *Steward) startControllerTesting(ctx context.Context) error {
 
 	// For testing mode, we expect a specific interface - use reflection to call methods
 	// This avoids import cycles with the client package
-	type mqttClientInterface interface {
+	type transportClientInterface interface {
 		Connect(context.Context) error
 		Disconnect(context.Context) error
 		SendHeartbeat(context.Context, string, map[string]string) error
@@ -421,17 +421,16 @@ func (s *Steward) startControllerTesting(ctx context.Context) error {
 		GetTenantID() string
 	}
 
-	mqttClient, ok := s.mqttClient.(mqttClientInterface)
+	tc, ok := s.transportClient.(transportClientInterface)
 	if !ok {
-		return fmt.Errorf("invalid MQTT client type: expected mqttClientInterface, got %T", s.mqttClient)
+		return fmt.Errorf("invalid transport client type: expected transportClientInterface, got %T", s.transportClient)
 	}
 
-	// Connect to MQTT broker (for testing, we log success even if connection details aren't fully set up)
-	connectErr := mqttClient.Connect(ctx)
+	// Connect to transport (for testing, we log success even if connection details aren't fully set up)
+	connectErr := tc.Connect(ctx)
 	if connectErr != nil {
-		// For integration testing, we still log connection messages even if MQTT setup is incomplete
-		// The tests verify logging behavior, not actual MQTT connectivity
-		s.logger.Warn("MQTT connection incomplete (test mode)", "error", connectErr.Error())
+		// For integration testing, we still log connection messages even if setup is incomplete
+		s.logger.Warn("Transport connection incomplete (test mode)", "error", connectErr.Error())
 	}
 
 	// Always log successful connection for integration tests
@@ -450,23 +449,23 @@ func (s *Steward) startControllerTesting(ctx context.Context) error {
 			"attributes", len(systemDNA.Attributes))
 	}
 
-	// Get steward ID from MQTT client
-	stewardID := mqttClient.GetStewardID()
+	// Get steward ID from transport client
+	stewardID := tc.GetStewardID()
 	if stewardID != "" {
 		s.logger.Info("Steward registered successfully",
 			"steward_id", stewardID,
-			"tenant_id", mqttClient.GetTenantID())
+			"tenant_id", tc.GetTenantID())
 	}
 
 	// Start heartbeat loop in background
-	go s.heartbeatLoopTesting(ctx, mqttClient)
+	go s.heartbeatLoopTesting(ctx, tc)
 
 	s.logger.Info("Steward started successfully in controller testing mode")
 	return nil
 }
 
-// heartbeatLoopTesting sends periodic heartbeats to the controller via MQTT.
-func (s *Steward) heartbeatLoopTesting(ctx context.Context, mqttClient interface {
+// heartbeatLoopTesting sends periodic heartbeats to the controller via transport client.
+func (s *Steward) heartbeatLoopTesting(ctx context.Context, transportClient interface {
 	SendHeartbeat(ctx context.Context, status string, metrics map[string]string) error
 }) {
 	ticker := time.NewTicker(30 * time.Second)
@@ -480,7 +479,7 @@ func (s *Steward) heartbeatLoopTesting(ctx context.Context, mqttClient interface
 			return
 		case <-ticker.C:
 			// Send heartbeat
-			if err := mqttClient.SendHeartbeat(ctx, "healthy", nil); err != nil {
+			if err := transportClient.SendHeartbeat(ctx, "healthy", nil); err != nil {
 				s.logger.Warn("Failed to send heartbeat", "error", err)
 				s.healthCheck.RecordHeartbeatError()
 			} else {
@@ -590,15 +589,15 @@ func (s *Steward) Stop(ctx context.Context) error {
 			s.moduleFactory.UnloadAllModules()
 		}
 	} else {
-		// Controller testing mode: disconnect MQTT client if present
-		if s.mqttClient != nil {
-			if mqttClient, ok := s.mqttClient.(interface {
+		// Controller testing mode: disconnect transport client if present
+		if s.transportClient != nil {
+			if tc, ok := s.transportClient.(interface {
 				Disconnect(ctx context.Context) error
 			}); ok {
-				if err := mqttClient.Disconnect(ctx); err != nil {
-					s.logger.Warn("Failed to disconnect MQTT client", "error", err)
+				if err := tc.Disconnect(ctx); err != nil {
+					s.logger.Warn("Failed to disconnect transport client", "error", err)
 				} else {
-					s.logger.Info("MQTT client disconnected successfully")
+					s.logger.Info("Transport client disconnected successfully")
 				}
 			}
 		} else {
@@ -681,7 +680,7 @@ func (s *Steward) GetSystemDNA(ctx context.Context) (*commonpb.DNA, error) {
 // to the controller, or if DNA collection or synchronization fails.
 func (s *Steward) SyncDNAWithController(ctx context.Context) error {
 	// DEPRECATED: Controller mode removed (Story #198)
-	return fmt.Errorf("controller mode deprecated (Story #198) - use cmd/steward --regtoken for MQTT+QUIC mode")
+	return fmt.Errorf("controller mode deprecated (Story #198) - use cmd/steward --regtoken for gRPC-over-QUIC mode")
 }
 
 // GetControllerConnectionStatus returns the connection status with the controller.
@@ -742,7 +741,7 @@ func initializeStewardCertificateManager(cfg *Config, logger logging.Logger) (*c
 
 // createControllerClient creates a controller client with optional certificate management.
 // DEPRECATED: createControllerClient removed in Story #198
-// Use MQTT+QUIC client via cmd/steward --regtoken instead
+// Use gRPC-over-QUIC client via cmd/steward --regtoken instead
 /*
 func createControllerClient(cfg *Config, certManager *cert.Manager, logger logging.Logger) (*client.Client, error) {
 	certPath := cfg.CertPath
@@ -772,9 +771,9 @@ func createControllerClient(cfg *Config, certManager *cert.Manager, logger loggi
 }
 */
 
-// SetMQTTClientForTesting injects an MQTT client for integration testing.
-// This is used by the test helper to set up the MQTT client before calling Start().
+// SetTransportClientForTesting injects a transport client for integration testing.
+// This is used by the test helper to set up the transport client before calling Start().
 // FOR TESTING ONLY - not for production use.
-func (s *Steward) SetMQTTClientForTesting(mqttClient interface{}) {
-	s.mqttClient = mqttClient
+func (s *Steward) SetTransportClientForTesting(tc interface{}) {
+	s.transportClient = tc
 }

--- a/test/integration/testutil/test_helper.go
+++ b/test/integration/testutil/test_helper.go
@@ -282,7 +282,7 @@ func (e *TestEnv) Start() {
 	// The client will be configured when we call Connect() in the steward Start() method
 
 	// Inject transport client into steward for testing
-	e.Steward.SetMQTTClientForTesting(transportClient)
+	e.Steward.SetTransportClientForTesting(transportClient)
 
 	// Start the steward (will use injected transport client)
 	if err := e.Steward.Start(e.ctx); err != nil {


### PR DESCRIPTION
## Summary

Removes the last MQTT naming artifacts from production Go code to satisfy
Phase 10 completion criteria #3: `grep -r "mqtt" --include="*.go"` = zero hits.

## Changes

- Rename `mqttClient` → `transportClient`, `SetMQTTClientForTesting` →
  `SetTransportClientForTesting` in `features/steward/steward.go`
- Update `cmd/cfg/cmd/regcode.go`: replace `mqtt://` URL scheme with `host:port` format
- Update `cmd/cfg/cmd/token.go`: replace `mqtt://` examples with `host:port`
- Update `cmd/cfg/cmd/controller.go`: replace MQTT metrics struct with Transport
  metrics matching the health API from Issue #517

## Test plan

- [x] `go build ./...` passes
- [x] `grep -rn "mqtt" --include="*.go" pkg/ features/ cmd/` = zero production hits
- [x] Pre-push validation passes (all tests green)

Fixes #511

🤖 Generated with [Claude Code](https://claude.com/claude-code)