### PR TITLE
fix: QA review findings for MQTT naming cleanup (Issue #511)

### DIFF
--- a/cmd/cfg/cmd/api_client_test.go
+++ b/cmd/cfg/cmd/api_client_test.go
@@ -165,7 +165,7 @@ func TestAPIClientCreateToken(t *testing.T) {
 			require.NoError(t, err)
 
 			assert.Equal(t, "test-tenant", req.TenantID)
-			assert.Equal(t, "mqtt://controller:8883", req.ControllerURL)
+			assert.Equal(t, "controller:4433", req.ControllerURL)
 
 			// Return created token
 			resp := APITokenResponse{
@@ -194,7 +194,7 @@ func TestAPIClientCreateToken(t *testing.T) {
 
 		req := &APITokenCreateRequest{
 			TenantID:      "test-tenant",
-			ControllerURL: "mqtt://controller:8883",
+			ControllerURL: "controller:4433",
 		}
 
 		resp, err := client.CreateToken(context.Background(), req)
@@ -220,7 +220,7 @@ func TestAPIClientCreateToken(t *testing.T) {
 		require.NoError(t, err)
 
 		req := &APITokenCreateRequest{
-			ControllerURL: "mqtt://controller:8883",
+			ControllerURL: "controller:4433",
 		}
 
 		resp, err := client.CreateToken(context.Background(), req)
@@ -305,7 +305,7 @@ func TestAPIClientGetToken(t *testing.T) {
 			resp := APITokenResponse{
 				Token:         "test-token",
 				TenantID:      "test-tenant",
-				ControllerURL: "mqtt://controller:8883",
+				ControllerURL: "controller:4433",
 			}
 
 			w.Header().Set("Content-Type", "application/json")
@@ -558,7 +558,7 @@ func TestAPIClientRequestHeaders(t *testing.T) {
 
 		req := &APITokenCreateRequest{
 			TenantID:      "test",
-			ControllerURL: "mqtt://test:8883",
+			ControllerURL: "test:4433",
 		}
 
 		_, err = client.CreateToken(context.Background(), req)

--- a/cmd/cfg/cmd/controller.go
+++ b/cmd/cfg/cmd/controller.go
@@ -213,13 +213,13 @@ func runControllerMetrics(cmd *cobra.Command, args []string) error {
 	var metrics struct {
 		Timestamp time.Time `json:"timestamp"`
 		Transport *struct {
-			ConnectedStewards     int       `json:"connected_stewards"`
-			StreamErrors          int64     `json:"stream_errors"`
-			MessagesSent          int64     `json:"messages_sent"`
-			MessagesReceived      int64     `json:"messages_received"`
-			ReconnectionAttempts  int64     `json:"reconnection_attempts"`
-			AvgLatencyNs          int64     `json:"avg_latency_ns"`
-			CollectedAt           time.Time `json:"collected_at"`
+			ConnectedStewards    int       `json:"connected_stewards"`
+			StreamErrors         int64     `json:"stream_errors"`
+			MessagesSent         int64     `json:"messages_sent"`
+			MessagesReceived     int64     `json:"messages_received"`
+			ReconnectionAttempts int64     `json:"reconnection_attempts"`
+			AvgLatencyNs         int64     `json:"avg_latency_ns"`
+			CollectedAt          time.Time `json:"collected_at"`
 		} `json:"transport"`
 		Storage *struct {
 			Provider          string    `json:"provider"`

--- a/cmd/cfg/cmd/regcode.go
+++ b/cmd/cfg/cmd/regcode.go
@@ -7,7 +7,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"strings"
+	"net"
 
 	"github.com/spf13/cobra"
 )
@@ -81,8 +81,10 @@ func generateRegistrationCode() error {
 		return fmt.Errorf("--controller-url is required for generation\n\nThe controller URL is the transport address where stewards connect\n\nFormat: HOST:PORT\n\nExample:\n  cfg regcode --tenant-id=acme-corp --controller-url=controller.example.com:4433")
 	}
 
-	// Validate controller URL format (host:port)
-	if !strings.Contains(controllerURL, ":") {
+	// Validate controller URL format (host:port) using net.SplitHostPort
+	// This rejects scheme-prefixed URLs (e.g., mqtt://host:port) and bare hostnames
+	host, port, err := net.SplitHostPort(controllerURL)
+	if err != nil || host == "" || port == "" {
 		return fmt.Errorf("controller URL must be in HOST:PORT format\n\nYour URL: %s\n\nExample:\n  controller.example.com:4433", controllerURL)
 	}
 

--- a/cmd/cfg/cmd/regcode_test.go
+++ b/cmd/cfg/cmd/regcode_test.go
@@ -1,0 +1,142 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+// Package cmd implements the CLI commands for cfg
+package cmd
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGenerateRegistrationCode_Validation(t *testing.T) {
+	// Save and restore package-level flag vars
+	origTenantID := tenantID
+	origControllerURL := controllerURL
+	origGroup := group
+	t.Cleanup(func() {
+		tenantID = origTenantID
+		controllerURL = origControllerURL
+		group = origGroup
+	})
+
+	t.Run("valid host:port format accepted", func(t *testing.T) {
+		tenantID = "test-tenant"
+		controllerURL = "controller.example.com:4433"
+		group = ""
+
+		err := generateRegistrationCode()
+		require.NoError(t, err)
+	})
+
+	t.Run("valid host:port with IP address accepted", func(t *testing.T) {
+		tenantID = "test-tenant"
+		controllerURL = "192.168.1.1:4433"
+		group = ""
+
+		err := generateRegistrationCode()
+		require.NoError(t, err)
+	})
+
+	t.Run("bare hostname without port rejected", func(t *testing.T) {
+		tenantID = "test-tenant"
+		controllerURL = "controller.example.com"
+		group = ""
+
+		err := generateRegistrationCode()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "HOST:PORT")
+	})
+
+	t.Run("old mqtt:// scheme format rejected", func(t *testing.T) {
+		tenantID = "test-tenant"
+		controllerURL = "mqtt://controller.example.com:8883"
+		group = ""
+
+		err := generateRegistrationCode()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "HOST:PORT")
+	})
+
+	t.Run("empty controller URL rejected", func(t *testing.T) {
+		tenantID = "test-tenant"
+		controllerURL = ""
+		group = ""
+
+		err := generateRegistrationCode()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "--controller-url is required")
+	})
+
+	t.Run("empty tenant ID rejected", func(t *testing.T) {
+		tenantID = ""
+		controllerURL = "controller:4433"
+		group = ""
+
+		err := generateRegistrationCode()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "--tenant-id is required")
+	})
+
+	t.Run("host:port with empty host rejected", func(t *testing.T) {
+		tenantID = "test-tenant"
+		controllerURL = ":4433"
+		group = ""
+
+		err := generateRegistrationCode()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "HOST:PORT")
+	})
+
+	t.Run("host:port with empty port rejected", func(t *testing.T) {
+		tenantID = "test-tenant"
+		controllerURL = "controller:"
+		group = ""
+
+		err := generateRegistrationCode()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "HOST:PORT")
+	})
+
+	t.Run("error message includes example", func(t *testing.T) {
+		tenantID = "test-tenant"
+		controllerURL = "bad-format"
+		group = ""
+
+		err := generateRegistrationCode()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "controller.example.com:4433")
+	})
+}
+
+func TestDecodeRegistrationCode(t *testing.T) {
+	t.Run("valid registration code decoded", func(t *testing.T) {
+		regCode := RegistrationCode{
+			TenantID:      "test-tenant",
+			ControllerURL: "controller.example.com:4433",
+			Group:         "production",
+			Version:       1,
+		}
+		jsonData, err := json.Marshal(regCode)
+		require.NoError(t, err)
+		encoded := base64.StdEncoding.EncodeToString(jsonData)
+
+		err = decodeRegistrationCode([]string{encoded})
+		require.NoError(t, err)
+	})
+
+	t.Run("no arguments rejected", func(t *testing.T) {
+		err := decodeRegistrationCode([]string{})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "registration code is required")
+	})
+
+	t.Run("invalid base64 rejected", func(t *testing.T) {
+		err := decodeRegistrationCode([]string{"not-valid-base64!!!"})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid base64")
+	})
+}

--- a/test/e2e/framework.go
+++ b/test/e2e/framework.go
@@ -689,7 +689,7 @@ func (f *E2ETestFramework) createTLSConfigFromPEM(caCertPEM, clientCertPEM, clie
 		Certificates: []tls.Certificate{clientCert},
 		RootCAs:      caCertPool,
 		MinVersion:   tls.VersionTLS12,
-		ServerName:   "localhost",                    // Connect via localhost in tests
+		ServerName:   "localhost",                          // Connect via localhost in tests
 		NextProtos:   []string{quictransport.ALPNProtocol}, // Required for QUIC transport
 	}
 


### PR DESCRIPTION
## Summary

Addresses QA review findings from story-complete review of #511. These fixes
were pushed to the original PR #538 but the auto-merge triggered before they
were included in the squash.

## Changes

- Fix gofmt formatting in `controller.go` and `framework.go`
- Update 5 stale `mqtt://` URLs in `api_client_test.go` to `host:port` format
- Create `regcode_test.go` with 11 test cases for registration code validation
- Replace weak `strings.Contains(":")` validation with `net.SplitHostPort()`
  in `regcode.go` (addresses security engineer warning)

## Test plan

- [x] `go test -race ./cmd/cfg/cmd/...` passes (11 new regcode tests)
- [x] `gofmt -l` clean on all changed files
- [x] Pre-push validation passes

Part of #511

🤖 Generated with [Claude Code](https://claude.com/claude-code)