### PR TITLE
controller: wire workflow engine into REST API and startup (Issue #414)

### DIFF
--- a/features/controller/api/handlers_health.go
+++ b/features/controller/api/handlers_health.go
@@ -69,6 +69,13 @@ func (s *Server) handleHealth(w http.ResponseWriter, r *http.Request) {
 		health.Status = "degraded"
 	}
 
+	// Workflow engine status (Issue #414)
+	if s.workflowHandler != nil && s.workflowHandler.engine != nil {
+		health.Services["workflow_engine"] = "healthy"
+	} else {
+		health.Services["workflow_engine"] = "unavailable"
+	}
+
 	// Return appropriate HTTP status
 	statusCode := http.StatusOK
 	if health.Status == "degraded" {

--- a/features/controller/api/handlers_workflows.go
+++ b/features/controller/api/handlers_workflows.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/gorilla/mux"
@@ -147,7 +148,9 @@ func (h *WorkflowHandler) handleCreateWorkflow(w http.ResponseWriter, r *http.Re
 	}
 
 	store := h.workflowStoreForRequest(r)
-	nameForLog := logging.SanitizeLogValue(req.Name)
+	// Apply strings.ReplaceAll directly after SanitizeLogValue so CodeQL's taint analysis
+	// recognises the CWE-117 sanitisation at the variable assignment site (not inside a wrapper).
+	nameForLog := strings.ReplaceAll(strings.ReplaceAll(logging.SanitizeLogValue(req.Name), "\n", "_"), "\r", "_")
 	if err := store.StoreWorkflow(r.Context(), vw); err != nil {
 		h.logger.Error("Failed to create workflow", "name", nameForLog, "error", err)
 		h.sendError(w, http.StatusInternalServerError, "failed to create workflow")
@@ -170,7 +173,7 @@ func (h *WorkflowHandler) handleGetWorkflow(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
-	nameForLog := logging.SanitizeLogValue(name)
+	nameForLog := strings.ReplaceAll(strings.ReplaceAll(logging.SanitizeLogValue(name), "\n", "_"), "\r", "_")
 	store := h.workflowStoreForRequest(r)
 	vw, err := store.GetLatestWorkflow(r.Context(), name)
 	if err != nil {
@@ -228,7 +231,7 @@ func (h *WorkflowHandler) handleUpdateWorkflow(w http.ResponseWriter, r *http.Re
 		SemanticVersion: *semver,
 	}
 
-	nameForLog := logging.SanitizeLogValue(name)
+	nameForLog := strings.ReplaceAll(strings.ReplaceAll(logging.SanitizeLogValue(name), "\n", "_"), "\r", "_")
 	store := h.workflowStoreForRequest(r)
 	if err := store.StoreWorkflow(r.Context(), vw); err != nil {
 		h.logger.Error("Failed to update workflow", "name", nameForLog, "error", err)
@@ -252,7 +255,7 @@ func (h *WorkflowHandler) handleDeleteWorkflow(w http.ResponseWriter, r *http.Re
 		return
 	}
 
-	nameForLog := logging.SanitizeLogValue(name)
+	nameForLog := strings.ReplaceAll(strings.ReplaceAll(logging.SanitizeLogValue(name), "\n", "_"), "\r", "_")
 	store := h.workflowStoreForRequest(r)
 
 	// Retrieve all versions to delete
@@ -269,7 +272,7 @@ func (h *WorkflowHandler) handleDeleteWorkflow(w http.ResponseWriter, r *http.Re
 
 	for _, vw := range versions {
 		if err := store.DeleteWorkflow(r.Context(), name, vw.SemanticVersion); err != nil {
-			versionForLog := logging.SanitizeLogValue(vw.SemanticVersion.String())
+			versionForLog := strings.ReplaceAll(strings.ReplaceAll(logging.SanitizeLogValue(vw.SemanticVersion.String()), "\n", "_"), "\r", "_")
 			h.logger.Error("Failed to delete workflow version", "name", nameForLog, "version", versionForLog, "error", err)
 			h.sendError(w, http.StatusInternalServerError, "failed to delete workflow")
 			return
@@ -313,7 +316,7 @@ func (h *WorkflowHandler) handleExecuteWorkflow(w http.ResponseWriter, r *http.R
 		return
 	}
 
-	nameForLog := logging.SanitizeLogValue(name)
+	nameForLog := strings.ReplaceAll(strings.ReplaceAll(logging.SanitizeLogValue(name), "\n", "_"), "\r", "_")
 	execution, err := h.engine.ExecuteWorkflow(r.Context(), vw.Workflow, req.Variables)
 	if err != nil {
 		h.logger.Error("Failed to execute workflow", "name", nameForLog, "error", err)
@@ -324,7 +327,7 @@ func (h *WorkflowHandler) handleExecuteWorkflow(w http.ResponseWriter, r *http.R
 	h.sendJSON(w, http.StatusAccepted, map[string]interface{}{
 		"execution_id":  execution.ID,
 		"workflow_name": execution.WorkflowName,
-		"status":        execution.Status,
+		"status":        execution.GetStatus(),
 		"start_time":    execution.StartTime,
 	})
 }
@@ -342,7 +345,7 @@ func (h *WorkflowHandler) handleGetWorkflowExecutions(w http.ResponseWriter, r *
 		return
 	}
 
-	nameForLog := logging.SanitizeLogValue(name)
+	nameForLog := strings.ReplaceAll(strings.ReplaceAll(logging.SanitizeLogValue(name), "\n", "_"), "\r", "_")
 	all, err := h.engine.ListExecutions()
 	if err != nil {
 		h.logger.Error("Failed to list workflow executions", "name", nameForLog, "error", err)

--- a/features/controller/api/handlers_workflows.go
+++ b/features/controller/api/handlers_workflows.go
@@ -148,7 +148,7 @@ func (h *WorkflowHandler) handleCreateWorkflow(w http.ResponseWriter, r *http.Re
 
 	store := h.workflowStoreForRequest(r)
 	if err := store.StoreWorkflow(r.Context(), vw); err != nil {
-		h.logger.Error("Failed to create workflow", "name", req.Name, "error", err)
+		h.logger.Error("Failed to create workflow", "name", logging.SanitizeLogValue(req.Name), "error", err)
 		h.sendError(w, http.StatusInternalServerError, "failed to create workflow")
 		return
 	}
@@ -172,7 +172,7 @@ func (h *WorkflowHandler) handleGetWorkflow(w http.ResponseWriter, r *http.Reque
 	store := h.workflowStoreForRequest(r)
 	vw, err := store.GetLatestWorkflow(r.Context(), name)
 	if err != nil {
-		h.logger.Error("Failed to get workflow", "name", name, "error", err)
+		h.logger.Error("Failed to get workflow", "name", logging.SanitizeLogValue(name), "error", err)
 		h.sendError(w, http.StatusNotFound, fmt.Sprintf("workflow %q not found", name))
 		return
 	}
@@ -228,7 +228,7 @@ func (h *WorkflowHandler) handleUpdateWorkflow(w http.ResponseWriter, r *http.Re
 
 	store := h.workflowStoreForRequest(r)
 	if err := store.StoreWorkflow(r.Context(), vw); err != nil {
-		h.logger.Error("Failed to update workflow", "name", name, "error", err)
+		h.logger.Error("Failed to update workflow", "name", logging.SanitizeLogValue(name), "error", err)
 		h.sendError(w, http.StatusInternalServerError, "failed to update workflow")
 		return
 	}
@@ -254,7 +254,7 @@ func (h *WorkflowHandler) handleDeleteWorkflow(w http.ResponseWriter, r *http.Re
 	// Retrieve all versions to delete
 	versions, err := store.ListWorkflowVersions(r.Context(), name)
 	if err != nil {
-		h.logger.Error("Failed to list workflow versions for deletion", "name", name, "error", err)
+		h.logger.Error("Failed to list workflow versions for deletion", "name", logging.SanitizeLogValue(name), "error", err)
 		h.sendError(w, http.StatusInternalServerError, "failed to delete workflow")
 		return
 	}
@@ -265,7 +265,7 @@ func (h *WorkflowHandler) handleDeleteWorkflow(w http.ResponseWriter, r *http.Re
 
 	for _, vw := range versions {
 		if err := store.DeleteWorkflow(r.Context(), name, vw.SemanticVersion); err != nil {
-			h.logger.Error("Failed to delete workflow version", "name", name, "version", vw.SemanticVersion.String(), "error", err)
+			h.logger.Error("Failed to delete workflow version", "name", logging.SanitizeLogValue(name), "version", vw.SemanticVersion.String(), "error", err)
 			h.sendError(w, http.StatusInternalServerError, "failed to delete workflow")
 			return
 		}
@@ -310,7 +310,7 @@ func (h *WorkflowHandler) handleExecuteWorkflow(w http.ResponseWriter, r *http.R
 
 	execution, err := h.engine.ExecuteWorkflow(r.Context(), vw.Workflow, req.Variables)
 	if err != nil {
-		h.logger.Error("Failed to execute workflow", "name", name, "error", err)
+		h.logger.Error("Failed to execute workflow", "name", logging.SanitizeLogValue(name), "error", err)
 		h.sendError(w, http.StatusInternalServerError, "failed to start workflow execution")
 		return
 	}
@@ -338,7 +338,7 @@ func (h *WorkflowHandler) handleGetWorkflowExecutions(w http.ResponseWriter, r *
 
 	all, err := h.engine.ListExecutions()
 	if err != nil {
-		h.logger.Error("Failed to list workflow executions", "name", name, "error", err)
+		h.logger.Error("Failed to list workflow executions", "name", logging.SanitizeLogValue(name), "error", err)
 		h.sendError(w, http.StatusInternalServerError, "failed to retrieve executions")
 		return
 	}

--- a/features/controller/api/handlers_workflows.go
+++ b/features/controller/api/handlers_workflows.go
@@ -1,0 +1,377 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/gorilla/mux"
+
+	"github.com/cfgis/cfgms/features/controller/ctxkeys"
+	"github.com/cfgis/cfgms/features/workflow"
+	"github.com/cfgis/cfgms/features/workflow/trigger"
+	"github.com/cfgis/cfgms/pkg/logging"
+	storageif "github.com/cfgis/cfgms/pkg/storage/interfaces"
+)
+
+// WorkflowHandler handles workflow and trigger REST API requests.
+// It bridges the controller REST layer with the workflow engine and trigger manager.
+type WorkflowHandler struct {
+	engine         *workflow.Engine
+	configStore    storageif.ConfigStore
+	triggerManager trigger.TriggerManager
+	triggerAPI     *trigger.APIHandler
+	logger         logging.Logger
+}
+
+// NewWorkflowHandler creates a new WorkflowHandler.
+func NewWorkflowHandler(
+	engine *workflow.Engine,
+	configStore storageif.ConfigStore,
+	triggerManager trigger.TriggerManager,
+	logger logging.Logger,
+) *WorkflowHandler {
+	h := &WorkflowHandler{
+		engine:         engine,
+		configStore:    configStore,
+		triggerManager: triggerManager,
+		logger:         logger,
+	}
+	if triggerManager != nil {
+		h.triggerAPI = trigger.NewAPIHandler(triggerManager)
+	}
+	return h
+}
+
+// RegisterWorkflowRoutes registers workflow CRUD and execution routes on the provided subrouter.
+func (h *WorkflowHandler) RegisterWorkflowRoutes(router *mux.Router) {
+	router.HandleFunc("", h.handleListWorkflows).Methods("GET")
+	router.HandleFunc("", h.handleCreateWorkflow).Methods("POST")
+	router.HandleFunc("/{id}", h.handleGetWorkflow).Methods("GET")
+	router.HandleFunc("/{id}", h.handleUpdateWorkflow).Methods("PUT")
+	router.HandleFunc("/{id}", h.handleDeleteWorkflow).Methods("DELETE")
+	router.HandleFunc("/{id}/execute", h.handleExecuteWorkflow).Methods("POST")
+	router.HandleFunc("/{id}/executions", h.handleGetWorkflowExecutions).Methods("GET")
+}
+
+// RegisterTriggerRoutes registers trigger management routes on the provided subrouter.
+func (h *WorkflowHandler) RegisterTriggerRoutes(router *mux.Router) {
+	if h.triggerAPI == nil {
+		return
+	}
+	h.triggerAPI.RegisterRoutes(router)
+}
+
+// workflowStoreForRequest returns a WorkflowStore scoped to the tenant in the request context.
+func (h *WorkflowHandler) workflowStoreForRequest(r *http.Request) *workflow.WorkflowStore {
+	tenantID, _ := r.Context().Value(ctxkeys.TenantID).(string)
+	return workflow.NewWorkflowStore(h.configStore, tenantID)
+}
+
+// handleListWorkflows handles GET /api/v1/workflows
+func (h *WorkflowHandler) handleListWorkflows(w http.ResponseWriter, r *http.Request) {
+	if h.engine == nil || h.configStore == nil {
+		h.sendError(w, http.StatusServiceUnavailable, "workflow engine not available")
+		return
+	}
+
+	store := h.workflowStoreForRequest(r)
+	workflows, err := store.ListWorkflows(r.Context())
+	if err != nil {
+		h.logger.Error("Failed to list workflows", "error", err)
+		h.sendError(w, http.StatusInternalServerError, "failed to list workflows")
+		return
+	}
+
+	h.sendJSON(w, http.StatusOK, map[string]interface{}{
+		"workflows": workflows,
+		"count":     len(workflows),
+	})
+}
+
+// CreateWorkflowRequest is the request body for creating a workflow.
+type CreateWorkflowRequest struct {
+	Name        string                 `json:"name"`
+	Description string                 `json:"description,omitempty"`
+	Version     string                 `json:"version,omitempty"`
+	Steps       []workflow.Step        `json:"steps"`
+	Variables   map[string]interface{} `json:"variables,omitempty"`
+	Timeout     time.Duration          `json:"timeout,omitempty"`
+}
+
+// handleCreateWorkflow handles POST /api/v1/workflows
+func (h *WorkflowHandler) handleCreateWorkflow(w http.ResponseWriter, r *http.Request) {
+	if h.engine == nil || h.configStore == nil {
+		h.sendError(w, http.StatusServiceUnavailable, "workflow engine not available")
+		return
+	}
+
+	var req CreateWorkflowRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		h.sendError(w, http.StatusBadRequest, "invalid JSON payload")
+		return
+	}
+
+	if req.Name == "" {
+		h.sendError(w, http.StatusBadRequest, "workflow name is required")
+		return
+	}
+	if len(req.Steps) == 0 {
+		h.sendError(w, http.StatusBadRequest, "workflow must have at least one step")
+		return
+	}
+
+	version := req.Version
+	if version == "" {
+		version = "1.0.0"
+	}
+	semver, err := workflow.ParseSemanticVersion(version)
+	if err != nil {
+		h.sendError(w, http.StatusBadRequest, fmt.Sprintf("invalid version format: %s", err))
+		return
+	}
+
+	vw := &workflow.VersionedWorkflow{
+		Workflow: workflow.Workflow{
+			Name:        req.Name,
+			Description: req.Description,
+			Version:     version,
+			Steps:       req.Steps,
+			Variables:   req.Variables,
+			Timeout:     req.Timeout,
+		},
+		SemanticVersion: *semver,
+	}
+
+	store := h.workflowStoreForRequest(r)
+	if err := store.StoreWorkflow(r.Context(), vw); err != nil {
+		h.logger.Error("Failed to create workflow", "name", req.Name, "error", err)
+		h.sendError(w, http.StatusInternalServerError, "failed to create workflow")
+		return
+	}
+
+	h.sendJSON(w, http.StatusCreated, vw)
+}
+
+// handleGetWorkflow handles GET /api/v1/workflows/{id}
+func (h *WorkflowHandler) handleGetWorkflow(w http.ResponseWriter, r *http.Request) {
+	if h.engine == nil || h.configStore == nil {
+		h.sendError(w, http.StatusServiceUnavailable, "workflow engine not available")
+		return
+	}
+
+	name := mux.Vars(r)["id"]
+	if name == "" {
+		h.sendError(w, http.StatusBadRequest, "workflow name is required")
+		return
+	}
+
+	store := h.workflowStoreForRequest(r)
+	vw, err := store.GetLatestWorkflow(r.Context(), name)
+	if err != nil {
+		h.logger.Error("Failed to get workflow", "name", name, "error", err)
+		h.sendError(w, http.StatusNotFound, fmt.Sprintf("workflow %q not found", name))
+		return
+	}
+
+	h.sendJSON(w, http.StatusOK, vw)
+}
+
+// handleUpdateWorkflow handles PUT /api/v1/workflows/{id}
+func (h *WorkflowHandler) handleUpdateWorkflow(w http.ResponseWriter, r *http.Request) {
+	if h.engine == nil || h.configStore == nil {
+		h.sendError(w, http.StatusServiceUnavailable, "workflow engine not available")
+		return
+	}
+
+	name := mux.Vars(r)["id"]
+	if name == "" {
+		h.sendError(w, http.StatusBadRequest, "workflow name is required")
+		return
+	}
+
+	var req CreateWorkflowRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		h.sendError(w, http.StatusBadRequest, "invalid JSON payload")
+		return
+	}
+
+	if len(req.Steps) == 0 {
+		h.sendError(w, http.StatusBadRequest, "workflow must have at least one step")
+		return
+	}
+
+	version := req.Version
+	if version == "" {
+		version = "1.0.0"
+	}
+	semver, err := workflow.ParseSemanticVersion(version)
+	if err != nil {
+		h.sendError(w, http.StatusBadRequest, fmt.Sprintf("invalid version format: %s", err))
+		return
+	}
+
+	vw := &workflow.VersionedWorkflow{
+		Workflow: workflow.Workflow{
+			Name:        name,
+			Description: req.Description,
+			Version:     version,
+			Steps:       req.Steps,
+			Variables:   req.Variables,
+			Timeout:     req.Timeout,
+		},
+		SemanticVersion: *semver,
+	}
+
+	store := h.workflowStoreForRequest(r)
+	if err := store.StoreWorkflow(r.Context(), vw); err != nil {
+		h.logger.Error("Failed to update workflow", "name", name, "error", err)
+		h.sendError(w, http.StatusInternalServerError, "failed to update workflow")
+		return
+	}
+
+	h.sendJSON(w, http.StatusOK, vw)
+}
+
+// handleDeleteWorkflow handles DELETE /api/v1/workflows/{id}
+func (h *WorkflowHandler) handleDeleteWorkflow(w http.ResponseWriter, r *http.Request) {
+	if h.engine == nil || h.configStore == nil {
+		h.sendError(w, http.StatusServiceUnavailable, "workflow engine not available")
+		return
+	}
+
+	name := mux.Vars(r)["id"]
+	if name == "" {
+		h.sendError(w, http.StatusBadRequest, "workflow name is required")
+		return
+	}
+
+	store := h.workflowStoreForRequest(r)
+
+	// Retrieve all versions to delete
+	versions, err := store.ListWorkflowVersions(r.Context(), name)
+	if err != nil {
+		h.logger.Error("Failed to list workflow versions for deletion", "name", name, "error", err)
+		h.sendError(w, http.StatusInternalServerError, "failed to delete workflow")
+		return
+	}
+	if len(versions) == 0 {
+		h.sendError(w, http.StatusNotFound, fmt.Sprintf("workflow %q not found", name))
+		return
+	}
+
+	for _, vw := range versions {
+		if err := store.DeleteWorkflow(r.Context(), name, vw.SemanticVersion); err != nil {
+			h.logger.Error("Failed to delete workflow version", "name", name, "version", vw.SemanticVersion.String(), "error", err)
+			h.sendError(w, http.StatusInternalServerError, "failed to delete workflow")
+			return
+		}
+	}
+
+	h.sendJSON(w, http.StatusOK, map[string]interface{}{
+		"deleted":  name,
+		"versions": len(versions),
+	})
+}
+
+// ExecuteWorkflowRequest is the request body for manually triggering a workflow.
+type ExecuteWorkflowRequest struct {
+	Variables map[string]interface{} `json:"variables,omitempty"`
+}
+
+// handleExecuteWorkflow handles POST /api/v1/workflows/{id}/execute
+func (h *WorkflowHandler) handleExecuteWorkflow(w http.ResponseWriter, r *http.Request) {
+	if h.engine == nil || h.configStore == nil {
+		h.sendError(w, http.StatusServiceUnavailable, "workflow engine not available")
+		return
+	}
+
+	name := mux.Vars(r)["id"]
+	if name == "" {
+		h.sendError(w, http.StatusBadRequest, "workflow name is required")
+		return
+	}
+
+	var req ExecuteWorkflowRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		// Body is optional; continue with empty variables
+		req.Variables = nil
+	}
+
+	store := h.workflowStoreForRequest(r)
+	vw, err := store.GetLatestWorkflow(r.Context(), name)
+	if err != nil {
+		h.sendError(w, http.StatusNotFound, fmt.Sprintf("workflow %q not found", name))
+		return
+	}
+
+	execution, err := h.engine.ExecuteWorkflow(r.Context(), vw.Workflow, req.Variables)
+	if err != nil {
+		h.logger.Error("Failed to execute workflow", "name", name, "error", err)
+		h.sendError(w, http.StatusInternalServerError, "failed to start workflow execution")
+		return
+	}
+
+	h.sendJSON(w, http.StatusAccepted, map[string]interface{}{
+		"execution_id":  execution.ID,
+		"workflow_name": execution.WorkflowName,
+		"status":        execution.Status,
+		"start_time":    execution.StartTime,
+	})
+}
+
+// handleGetWorkflowExecutions handles GET /api/v1/workflows/{id}/executions
+func (h *WorkflowHandler) handleGetWorkflowExecutions(w http.ResponseWriter, r *http.Request) {
+	if h.engine == nil {
+		h.sendError(w, http.StatusServiceUnavailable, "workflow engine not available")
+		return
+	}
+
+	name := mux.Vars(r)["id"]
+	if name == "" {
+		h.sendError(w, http.StatusBadRequest, "workflow name is required")
+		return
+	}
+
+	all, err := h.engine.ListExecutions()
+	if err != nil {
+		h.logger.Error("Failed to list workflow executions", "name", name, "error", err)
+		h.sendError(w, http.StatusInternalServerError, "failed to retrieve executions")
+		return
+	}
+
+	// Filter to the requested workflow
+	var executions []*workflow.WorkflowExecution
+	for _, ex := range all {
+		if ex.WorkflowName == name {
+			executions = append(executions, ex)
+		}
+	}
+	if executions == nil {
+		executions = []*workflow.WorkflowExecution{}
+	}
+
+	h.sendJSON(w, http.StatusOK, map[string]interface{}{
+		"executions": executions,
+		"count":      len(executions),
+	})
+}
+
+// sendJSON writes a JSON response with the given status code.
+func (h *WorkflowHandler) sendJSON(w http.ResponseWriter, status int, data interface{}) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	if err := json.NewEncoder(w).Encode(data); err != nil {
+		_ = err
+	}
+}
+
+// sendError writes a JSON error response.
+func (h *WorkflowHandler) sendError(w http.ResponseWriter, status int, message string) {
+	h.sendJSON(w, status, map[string]interface{}{
+		"error": message,
+	})
+}

--- a/features/controller/api/handlers_workflows.go
+++ b/features/controller/api/handlers_workflows.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"strings"
 	"time"
 
 	"github.com/gorilla/mux"
@@ -148,9 +147,7 @@ func (h *WorkflowHandler) handleCreateWorkflow(w http.ResponseWriter, r *http.Re
 	}
 
 	store := h.workflowStoreForRequest(r)
-	// Apply strings.ReplaceAll directly after SanitizeLogValue so CodeQL's taint analysis
-	// recognises the CWE-117 sanitisation at the variable assignment site (not inside a wrapper).
-	nameForLog := strings.ReplaceAll(strings.ReplaceAll(logging.SanitizeLogValue(req.Name), "\n", "_"), "\r", "_")
+	nameForLog := logging.SanitizeLogValue(req.Name)
 	if err := store.StoreWorkflow(r.Context(), vw); err != nil {
 		h.logger.Error("Failed to create workflow", "name", nameForLog, "error", err)
 		h.sendError(w, http.StatusInternalServerError, "failed to create workflow")
@@ -173,7 +170,7 @@ func (h *WorkflowHandler) handleGetWorkflow(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
-	nameForLog := strings.ReplaceAll(strings.ReplaceAll(logging.SanitizeLogValue(name), "\n", "_"), "\r", "_")
+	nameForLog := logging.SanitizeLogValue(name)
 	store := h.workflowStoreForRequest(r)
 	vw, err := store.GetLatestWorkflow(r.Context(), name)
 	if err != nil {
@@ -231,7 +228,7 @@ func (h *WorkflowHandler) handleUpdateWorkflow(w http.ResponseWriter, r *http.Re
 		SemanticVersion: *semver,
 	}
 
-	nameForLog := strings.ReplaceAll(strings.ReplaceAll(logging.SanitizeLogValue(name), "\n", "_"), "\r", "_")
+	nameForLog := logging.SanitizeLogValue(name)
 	store := h.workflowStoreForRequest(r)
 	if err := store.StoreWorkflow(r.Context(), vw); err != nil {
 		h.logger.Error("Failed to update workflow", "name", nameForLog, "error", err)
@@ -255,7 +252,7 @@ func (h *WorkflowHandler) handleDeleteWorkflow(w http.ResponseWriter, r *http.Re
 		return
 	}
 
-	nameForLog := strings.ReplaceAll(strings.ReplaceAll(logging.SanitizeLogValue(name), "\n", "_"), "\r", "_")
+	nameForLog := logging.SanitizeLogValue(name)
 	store := h.workflowStoreForRequest(r)
 
 	// Retrieve all versions to delete
@@ -272,7 +269,7 @@ func (h *WorkflowHandler) handleDeleteWorkflow(w http.ResponseWriter, r *http.Re
 
 	for _, vw := range versions {
 		if err := store.DeleteWorkflow(r.Context(), name, vw.SemanticVersion); err != nil {
-			versionForLog := strings.ReplaceAll(strings.ReplaceAll(logging.SanitizeLogValue(vw.SemanticVersion.String()), "\n", "_"), "\r", "_")
+			versionForLog := logging.SanitizeLogValue(vw.SemanticVersion.String())
 			h.logger.Error("Failed to delete workflow version", "name", nameForLog, "version", versionForLog, "error", err)
 			h.sendError(w, http.StatusInternalServerError, "failed to delete workflow")
 			return
@@ -316,7 +313,7 @@ func (h *WorkflowHandler) handleExecuteWorkflow(w http.ResponseWriter, r *http.R
 		return
 	}
 
-	nameForLog := strings.ReplaceAll(strings.ReplaceAll(logging.SanitizeLogValue(name), "\n", "_"), "\r", "_")
+	nameForLog := logging.SanitizeLogValue(name)
 	execution, err := h.engine.ExecuteWorkflow(r.Context(), vw.Workflow, req.Variables)
 	if err != nil {
 		h.logger.Error("Failed to execute workflow", "name", nameForLog, "error", err)
@@ -345,7 +342,7 @@ func (h *WorkflowHandler) handleGetWorkflowExecutions(w http.ResponseWriter, r *
 		return
 	}
 
-	nameForLog := strings.ReplaceAll(strings.ReplaceAll(logging.SanitizeLogValue(name), "\n", "_"), "\r", "_")
+	nameForLog := logging.SanitizeLogValue(name)
 	all, err := h.engine.ListExecutions()
 	if err != nil {
 		h.logger.Error("Failed to list workflow executions", "name", nameForLog, "error", err)

--- a/features/controller/api/handlers_workflows.go
+++ b/features/controller/api/handlers_workflows.go
@@ -147,8 +147,9 @@ func (h *WorkflowHandler) handleCreateWorkflow(w http.ResponseWriter, r *http.Re
 	}
 
 	store := h.workflowStoreForRequest(r)
+	nameForLog := logging.SanitizeLogValue(req.Name)
 	if err := store.StoreWorkflow(r.Context(), vw); err != nil {
-		h.logger.Error("Failed to create workflow", "name", logging.SanitizeLogValue(req.Name), "error", err)
+		h.logger.Error("Failed to create workflow", "name", nameForLog, "error", err)
 		h.sendError(w, http.StatusInternalServerError, "failed to create workflow")
 		return
 	}
@@ -169,10 +170,11 @@ func (h *WorkflowHandler) handleGetWorkflow(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
+	nameForLog := logging.SanitizeLogValue(name)
 	store := h.workflowStoreForRequest(r)
 	vw, err := store.GetLatestWorkflow(r.Context(), name)
 	if err != nil {
-		h.logger.Error("Failed to get workflow", "name", logging.SanitizeLogValue(name), "error", err)
+		h.logger.Error("Failed to get workflow", "name", nameForLog, "error", err)
 		h.sendError(w, http.StatusNotFound, fmt.Sprintf("workflow %q not found", name))
 		return
 	}
@@ -226,9 +228,10 @@ func (h *WorkflowHandler) handleUpdateWorkflow(w http.ResponseWriter, r *http.Re
 		SemanticVersion: *semver,
 	}
 
+	nameForLog := logging.SanitizeLogValue(name)
 	store := h.workflowStoreForRequest(r)
 	if err := store.StoreWorkflow(r.Context(), vw); err != nil {
-		h.logger.Error("Failed to update workflow", "name", logging.SanitizeLogValue(name), "error", err)
+		h.logger.Error("Failed to update workflow", "name", nameForLog, "error", err)
 		h.sendError(w, http.StatusInternalServerError, "failed to update workflow")
 		return
 	}
@@ -249,12 +252,13 @@ func (h *WorkflowHandler) handleDeleteWorkflow(w http.ResponseWriter, r *http.Re
 		return
 	}
 
+	nameForLog := logging.SanitizeLogValue(name)
 	store := h.workflowStoreForRequest(r)
 
 	// Retrieve all versions to delete
 	versions, err := store.ListWorkflowVersions(r.Context(), name)
 	if err != nil {
-		h.logger.Error("Failed to list workflow versions for deletion", "name", logging.SanitizeLogValue(name), "error", err)
+		h.logger.Error("Failed to list workflow versions for deletion", "name", nameForLog, "error", err)
 		h.sendError(w, http.StatusInternalServerError, "failed to delete workflow")
 		return
 	}
@@ -265,7 +269,8 @@ func (h *WorkflowHandler) handleDeleteWorkflow(w http.ResponseWriter, r *http.Re
 
 	for _, vw := range versions {
 		if err := store.DeleteWorkflow(r.Context(), name, vw.SemanticVersion); err != nil {
-			h.logger.Error("Failed to delete workflow version", "name", logging.SanitizeLogValue(name), "version", vw.SemanticVersion.String(), "error", err)
+			versionForLog := logging.SanitizeLogValue(vw.SemanticVersion.String())
+			h.logger.Error("Failed to delete workflow version", "name", nameForLog, "version", versionForLog, "error", err)
 			h.sendError(w, http.StatusInternalServerError, "failed to delete workflow")
 			return
 		}
@@ -308,9 +313,10 @@ func (h *WorkflowHandler) handleExecuteWorkflow(w http.ResponseWriter, r *http.R
 		return
 	}
 
+	nameForLog := logging.SanitizeLogValue(name)
 	execution, err := h.engine.ExecuteWorkflow(r.Context(), vw.Workflow, req.Variables)
 	if err != nil {
-		h.logger.Error("Failed to execute workflow", "name", logging.SanitizeLogValue(name), "error", err)
+		h.logger.Error("Failed to execute workflow", "name", nameForLog, "error", err)
 		h.sendError(w, http.StatusInternalServerError, "failed to start workflow execution")
 		return
 	}
@@ -336,9 +342,10 @@ func (h *WorkflowHandler) handleGetWorkflowExecutions(w http.ResponseWriter, r *
 		return
 	}
 
+	nameForLog := logging.SanitizeLogValue(name)
 	all, err := h.engine.ListExecutions()
 	if err != nil {
-		h.logger.Error("Failed to list workflow executions", "name", logging.SanitizeLogValue(name), "error", err)
+		h.logger.Error("Failed to list workflow executions", "name", nameForLog, "error", err)
 		h.sendError(w, http.StatusInternalServerError, "failed to retrieve executions")
 		return
 	}
@@ -365,7 +372,7 @@ func (h *WorkflowHandler) sendJSON(w http.ResponseWriter, status int, data inter
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(status)
 	if err := json.NewEncoder(w).Encode(data); err != nil {
-		_ = err
+		h.logger.Error("Failed to encode JSON response", "error", err)
 	}
 }
 

--- a/features/controller/api/handlers_workflows_test.go
+++ b/features/controller/api/handlers_workflows_test.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"testing"
 
 	"github.com/gorilla/mux"
@@ -448,20 +449,78 @@ func TestWorkflowHandler_RegisterTriggerRoutes_NilManager_NoRegistration(t *test
 
 // --- log injection safety ----------------------------------------------------
 
+// capturingLogger records Error calls so tests can assert that user-supplied values
+// are sanitised before they reach the logger (CWE-117 / go/log-injection).
+type capturingLogger struct {
+	logging.NoopLogger
+	mu      sync.Mutex
+	entries []struct {
+		msg string
+		kvs []interface{}
+	}
+}
+
+func (l *capturingLogger) Error(msg string, kvs ...interface{}) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.entries = append(l.entries, struct {
+		msg string
+		kvs []interface{}
+	}{msg: msg, kvs: kvs})
+}
+
+// loggedNameValues returns all "name" key values captured across Error calls.
+func (l *capturingLogger) loggedNameValues() []string {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	var names []string
+	for _, e := range l.entries {
+		for i := 0; i+1 < len(e.kvs); i += 2 {
+			if k, ok := e.kvs[i].(string); ok && k == "name" {
+				if v, ok := e.kvs[i+1].(string); ok {
+					names = append(names, v)
+				}
+			}
+		}
+	}
+	return names
+}
+
 // TestWorkflowHandler_SpecialCharsInName_HandledSafely verifies that workflow names
-// containing characters that would be dangerous in log entries are handled safely.
-// The code sanitizes user-provided values via logging.SanitizeLogValue before logging.
+// containing CWE-117 log-injection characters (LF, CR) are stripped before they reach
+// the logger. The test uses a GET for a nonexistent workflow, which always exercises the
+// error path in handleGetWorkflow and guarantees logger.Error is called — making the
+// sanitisation assertion unconditional, not vacuous.
+//
+// URL path parameters may carry encoded control characters: gorilla/mux decodes %0a → \n
+// and %0d → \r when extracting path variables, so injecting them is realistic.
 func TestWorkflowHandler_SpecialCharsInName_HandledSafely(t *testing.T) {
-	h, _ := newTestWorkflowHandler(t)
+	_, configStore := newTestWorkflowHandler(t)
+	capLogger := &capturingLogger{}
+
+	registry := make(discovery.ModuleRegistry)
+	errCfg := stewardconfig.ErrorHandlingConfig{ModuleLoadFailure: stewardconfig.ActionContinue}
+	engine := workflow.NewEngine(factory.New(registry, errCfg), capLogger)
+	h := NewWorkflowHandler(engine, configStore, nil, capLogger)
 	router := newWorkflowRouter(h)
 
-	// URL-safe name that includes tab and other control characters
-	// (newlines cannot appear in HTTP request-URIs; they are rejected by Go's HTTP library)
-	req := httptest.NewRequest("GET", "/workflows/wf%09injected", nil)
+	// %0a = LF (\n), %0d = CR (\r) — gorilla/mux decodes these from the URL path.
+	// The workflow does not exist, so handleGetWorkflow always calls logger.Error,
+	// ensuring the sanitisation assertion below is never vacuous.
+	req := httptest.NewRequest("GET", "/workflows/wf%0ainjected%0dfake-log-line", nil)
 	req = withTenantContext(req, "test-tenant")
 	rec := httptest.NewRecorder()
 	router.ServeHTTP(rec, req)
 
-	// Handler must not return 5xx — the workflow simply won't be found
-	assert.True(t, rec.Code < 500, "handler must not return 5xx for special-char workflow name, got %d", rec.Code)
+	// Handler returns 404 (not 5xx) — the special-char name doesn't cause a crash.
+	assert.Equal(t, http.StatusNotFound, rec.Code, "nonexistent workflow must return 404")
+
+	// logger.Error must have been called with the sanitised name — exactly once because
+	// the workflow is not found and GetLatestWorkflow returns an error.
+	names := capLogger.loggedNameValues()
+	require.NotEmpty(t, names, "logger.Error must have been called with a 'name' key")
+	for _, name := range names {
+		assert.NotContains(t, name, "\n", "logger must not receive raw LF in workflow name")
+		assert.NotContains(t, name, "\r", "logger must not receive raw CR in workflow name")
+	}
 }

--- a/features/controller/api/handlers_workflows_test.go
+++ b/features/controller/api/handlers_workflows_test.go
@@ -1,0 +1,467 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+package api
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gorilla/mux"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cfgis/cfgms/features/controller/ctxkeys"
+	stewardconfig "github.com/cfgis/cfgms/features/steward/config"
+	"github.com/cfgis/cfgms/features/steward/discovery"
+	"github.com/cfgis/cfgms/features/steward/factory"
+	"github.com/cfgis/cfgms/features/workflow"
+	"github.com/cfgis/cfgms/pkg/logging"
+	"github.com/cfgis/cfgms/pkg/storage/interfaces"
+
+	// Auto-register git storage provider
+	_ "github.com/cfgis/cfgms/pkg/storage/providers/git"
+)
+
+// newTestWorkflowHandler creates a WorkflowHandler backed by real git storage and a real engine.
+func newTestWorkflowHandler(t *testing.T) (*WorkflowHandler, interfaces.ConfigStore) {
+	t.Helper()
+
+	storageConfig := map[string]interface{}{
+		"repository_path": t.TempDir(),
+		"branch":          "main",
+		"auto_init":       true,
+	}
+	storageManager, err := interfaces.CreateAllStoresFromConfig("git", storageConfig)
+	require.NoError(t, err)
+	configStore := storageManager.GetConfigStore()
+
+	registry := make(discovery.ModuleRegistry)
+	errorConfig := stewardconfig.ErrorHandlingConfig{
+		ModuleLoadFailure: stewardconfig.ActionContinue,
+	}
+	moduleFactory := factory.New(registry, errorConfig)
+	logger := logging.NewNoopLogger()
+	engine := workflow.NewEngine(moduleFactory, logger)
+
+	handler := NewWorkflowHandler(engine, configStore, nil, logger)
+	return handler, configStore
+}
+
+// withTenantContext injects a tenant ID into the request context, as the auth middleware does.
+func withTenantContext(r *http.Request, tenantID string) *http.Request {
+	ctx := context.WithValue(r.Context(), ctxkeys.TenantID, tenantID)
+	return r.WithContext(ctx)
+}
+
+// newWorkflowRouter wires a WorkflowHandler onto a fresh mux.Router.
+func newWorkflowRouter(h *WorkflowHandler) *mux.Router {
+	router := mux.NewRouter()
+	sub := router.PathPrefix("/workflows").Subrouter()
+	h.RegisterWorkflowRoutes(sub)
+	return router
+}
+
+// minimalWorkflowBody returns a valid JSON create-workflow request body.
+func minimalWorkflowBody(name string) []byte {
+	return mustMarshal(CreateWorkflowRequest{
+		Name: name,
+		Steps: []workflow.Step{
+			{Name: "step1", Type: workflow.StepTypeTask},
+		},
+	})
+}
+
+// mustMarshal marshals v to JSON and panics on error (test helper only).
+func mustMarshal(v interface{}) []byte {
+	b, err := json.Marshal(v)
+	if err != nil {
+		panic("mustMarshal: " + err.Error())
+	}
+	return b
+}
+
+// --- handler nil-check tests -------------------------------------------------
+
+func TestWorkflowHandler_NilEngine_ReturnsServiceUnavailable(t *testing.T) {
+	logger := logging.NewNoopLogger()
+	// Handler with nil engine and nil configStore
+	h := NewWorkflowHandler(nil, nil, nil, logger)
+	router := newWorkflowRouter(h)
+
+	tests := []struct {
+		method string
+		path   string
+		body   []byte
+	}{
+		{"GET", "/workflows", nil},
+		{"POST", "/workflows", minimalWorkflowBody("wf")},
+		{"GET", "/workflows/wf", nil},
+		{"PUT", "/workflows/wf", minimalWorkflowBody("wf")},
+		{"DELETE", "/workflows/wf", nil},
+		{"POST", "/workflows/wf/execute", nil},
+	}
+	for _, tc := range tests {
+		t.Run(tc.method+" "+tc.path, func(t *testing.T) {
+			var bodyReader *bytes.Reader
+			if tc.body != nil {
+				bodyReader = bytes.NewReader(tc.body)
+			} else {
+				bodyReader = bytes.NewReader(nil)
+			}
+			req := httptest.NewRequest(tc.method, tc.path, bodyReader)
+			req = withTenantContext(req, "test-tenant")
+			rec := httptest.NewRecorder()
+			router.ServeHTTP(rec, req)
+			assert.Equal(t, http.StatusServiceUnavailable, rec.Code, "expected 503 for path %s", tc.path)
+		})
+	}
+}
+
+// --- list workflows ----------------------------------------------------------
+
+func TestWorkflowHandler_ListWorkflows_EmptyReturnsEmpty(t *testing.T) {
+	h, _ := newTestWorkflowHandler(t)
+	router := newWorkflowRouter(h)
+
+	req := httptest.NewRequest("GET", "/workflows", nil)
+	req = withTenantContext(req, "test-tenant")
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	var resp map[string]interface{}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.EqualValues(t, 0, resp["count"])
+}
+
+// --- create workflow ---------------------------------------------------------
+
+func TestWorkflowHandler_CreateWorkflow_InvalidJSON_Returns400(t *testing.T) {
+	h, _ := newTestWorkflowHandler(t)
+	router := newWorkflowRouter(h)
+
+	req := httptest.NewRequest("POST", "/workflows", bytes.NewBufferString("not-json"))
+	req = withTenantContext(req, "test-tenant")
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestWorkflowHandler_CreateWorkflow_MissingName_Returns400(t *testing.T) {
+	h, _ := newTestWorkflowHandler(t)
+	router := newWorkflowRouter(h)
+
+	body := mustMarshal(CreateWorkflowRequest{
+		Steps: []workflow.Step{{Name: "s1", Type: workflow.StepTypeTask}},
+	})
+	req := httptest.NewRequest("POST", "/workflows", bytes.NewReader(body))
+	req = withTenantContext(req, "test-tenant")
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestWorkflowHandler_CreateWorkflow_NoSteps_Returns400(t *testing.T) {
+	h, _ := newTestWorkflowHandler(t)
+	router := newWorkflowRouter(h)
+
+	body := mustMarshal(CreateWorkflowRequest{Name: "wf"})
+	req := httptest.NewRequest("POST", "/workflows", bytes.NewReader(body))
+	req = withTenantContext(req, "test-tenant")
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestWorkflowHandler_CreateWorkflow_InvalidVersion_Returns400(t *testing.T) {
+	h, _ := newTestWorkflowHandler(t)
+	router := newWorkflowRouter(h)
+
+	body := mustMarshal(CreateWorkflowRequest{
+		Name:    "wf",
+		Version: "not-semver",
+		Steps:   []workflow.Step{{Name: "s1", Type: workflow.StepTypeTask}},
+	})
+	req := httptest.NewRequest("POST", "/workflows", bytes.NewReader(body))
+	req = withTenantContext(req, "test-tenant")
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestWorkflowHandler_CreateWorkflow_ValidRequest_Returns201(t *testing.T) {
+	h, _ := newTestWorkflowHandler(t)
+	router := newWorkflowRouter(h)
+
+	req := httptest.NewRequest("POST", "/workflows", bytes.NewReader(minimalWorkflowBody("my-workflow")))
+	req = withTenantContext(req, "test-tenant")
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusCreated, rec.Code)
+	var vw workflow.VersionedWorkflow
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &vw))
+	assert.Equal(t, "my-workflow", vw.Name)
+	assert.Equal(t, "1.0.0", vw.Version)
+}
+
+// --- get workflow ------------------------------------------------------------
+
+func TestWorkflowHandler_GetWorkflow_NotFound_Returns404(t *testing.T) {
+	h, _ := newTestWorkflowHandler(t)
+	router := newWorkflowRouter(h)
+
+	req := httptest.NewRequest("GET", "/workflows/nonexistent", nil)
+	req = withTenantContext(req, "test-tenant")
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+}
+
+func TestWorkflowHandler_GetWorkflow_ExistingWorkflow_Returns200(t *testing.T) {
+	h, _ := newTestWorkflowHandler(t)
+	router := newWorkflowRouter(h)
+
+	// Create first
+	createReq := httptest.NewRequest("POST", "/workflows", bytes.NewReader(minimalWorkflowBody("get-test")))
+	createReq = withTenantContext(createReq, "test-tenant")
+	createRec := httptest.NewRecorder()
+	router.ServeHTTP(createRec, createReq)
+	require.Equal(t, http.StatusCreated, createRec.Code)
+
+	// Then get
+	req := httptest.NewRequest("GET", "/workflows/get-test", nil)
+	req = withTenantContext(req, "test-tenant")
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	var vw workflow.VersionedWorkflow
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &vw))
+	assert.Equal(t, "get-test", vw.Name)
+}
+
+// --- update workflow ---------------------------------------------------------
+
+func TestWorkflowHandler_UpdateWorkflow_NoSteps_Returns400(t *testing.T) {
+	h, _ := newTestWorkflowHandler(t)
+	router := newWorkflowRouter(h)
+
+	body := mustMarshal(CreateWorkflowRequest{Name: "wf"})
+	req := httptest.NewRequest("PUT", "/workflows/wf", bytes.NewReader(body))
+	req = withTenantContext(req, "test-tenant")
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestWorkflowHandler_UpdateWorkflow_ValidRequest_Returns200(t *testing.T) {
+	h, _ := newTestWorkflowHandler(t)
+	router := newWorkflowRouter(h)
+
+	// Create first
+	createReq := httptest.NewRequest("POST", "/workflows", bytes.NewReader(minimalWorkflowBody("upd-wf")))
+	createReq = withTenantContext(createReq, "test-tenant")
+	createRec := httptest.NewRecorder()
+	router.ServeHTTP(createRec, createReq)
+	require.Equal(t, http.StatusCreated, createRec.Code)
+
+	// Update with new version
+	body := mustMarshal(CreateWorkflowRequest{
+		Name:    "upd-wf",
+		Version: "2.0.0",
+		Steps:   []workflow.Step{{Name: "step2", Type: workflow.StepTypeTask}},
+	})
+	req := httptest.NewRequest("PUT", "/workflows/upd-wf", bytes.NewReader(body))
+	req = withTenantContext(req, "test-tenant")
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	var vw workflow.VersionedWorkflow
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &vw))
+	assert.Equal(t, "2.0.0", vw.Version)
+}
+
+// --- delete workflow ---------------------------------------------------------
+
+func TestWorkflowHandler_DeleteWorkflow_NotFound_Returns404(t *testing.T) {
+	h, _ := newTestWorkflowHandler(t)
+	router := newWorkflowRouter(h)
+
+	req := httptest.NewRequest("DELETE", "/workflows/nosuchworkflow", nil)
+	req = withTenantContext(req, "test-tenant")
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+}
+
+func TestWorkflowHandler_DeleteWorkflow_ExistingWorkflow_Returns200(t *testing.T) {
+	h, _ := newTestWorkflowHandler(t)
+	router := newWorkflowRouter(h)
+
+	// Create first
+	createReq := httptest.NewRequest("POST", "/workflows", bytes.NewReader(minimalWorkflowBody("del-wf")))
+	createReq = withTenantContext(createReq, "test-tenant")
+	createRec := httptest.NewRecorder()
+	router.ServeHTTP(createRec, createReq)
+	require.Equal(t, http.StatusCreated, createRec.Code)
+
+	// Delete
+	req := httptest.NewRequest("DELETE", "/workflows/del-wf", nil)
+	req = withTenantContext(req, "test-tenant")
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	var resp map[string]interface{}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Equal(t, "del-wf", resp["deleted"])
+
+	// Subsequent GET should 404
+	getReq := httptest.NewRequest("GET", "/workflows/del-wf", nil)
+	getReq = withTenantContext(getReq, "test-tenant")
+	getRec := httptest.NewRecorder()
+	router.ServeHTTP(getRec, getReq)
+	assert.Equal(t, http.StatusNotFound, getRec.Code)
+}
+
+// --- list after create -------------------------------------------------------
+
+func TestWorkflowHandler_ListWorkflows_AfterCreate_ReturnsWorkflow(t *testing.T) {
+	h, _ := newTestWorkflowHandler(t)
+	router := newWorkflowRouter(h)
+
+	// Create a workflow
+	createReq := httptest.NewRequest("POST", "/workflows", bytes.NewReader(minimalWorkflowBody("list-wf")))
+	createReq = withTenantContext(createReq, "test-tenant")
+	createRec := httptest.NewRecorder()
+	router.ServeHTTP(createRec, createReq)
+	require.Equal(t, http.StatusCreated, createRec.Code)
+
+	// List
+	req := httptest.NewRequest("GET", "/workflows", nil)
+	req = withTenantContext(req, "test-tenant")
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	var resp map[string]interface{}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.EqualValues(t, 1, resp["count"])
+}
+
+// --- execute workflow --------------------------------------------------------
+
+func TestWorkflowHandler_ExecuteWorkflow_WorkflowNotFound_Returns404(t *testing.T) {
+	h, _ := newTestWorkflowHandler(t)
+	router := newWorkflowRouter(h)
+
+	req := httptest.NewRequest("POST", "/workflows/nosuchworkflow/execute", nil)
+	req = withTenantContext(req, "test-tenant")
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+}
+
+func TestWorkflowHandler_ExecuteWorkflow_ExistingWorkflow_Returns202WithFields(t *testing.T) {
+	h, _ := newTestWorkflowHandler(t)
+	router := newWorkflowRouter(h)
+
+	// Create the workflow first
+	createReq := httptest.NewRequest("POST", "/workflows", bytes.NewReader(minimalWorkflowBody("exec-wf")))
+	createReq = withTenantContext(createReq, "test-tenant")
+	createRec := httptest.NewRecorder()
+	router.ServeHTTP(createRec, createReq)
+	require.Equal(t, http.StatusCreated, createRec.Code)
+
+	// Execute the workflow
+	req := httptest.NewRequest("POST", "/workflows/exec-wf/execute", nil)
+	req = withTenantContext(req, "test-tenant")
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusAccepted, rec.Code)
+	var resp map[string]interface{}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.NotEmpty(t, resp["execution_id"], "execution_id must be non-empty")
+	assert.Equal(t, "exec-wf", resp["workflow_name"])
+	assert.NotEmpty(t, resp["status"], "status must be non-empty")
+	assert.Contains(t, resp, "start_time")
+}
+
+// --- executions --------------------------------------------------------------
+
+func TestWorkflowHandler_GetWorkflowExecutions_NoEngine_Returns503(t *testing.T) {
+	logger := logging.NewNoopLogger()
+	h := NewWorkflowHandler(nil, nil, nil, logger)
+	router := newWorkflowRouter(h)
+
+	req := httptest.NewRequest("GET", "/workflows/wf/executions", nil)
+	req = withTenantContext(req, "test-tenant")
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusServiceUnavailable, rec.Code)
+}
+
+func TestWorkflowHandler_GetWorkflowExecutions_EmptyResult_Returns200(t *testing.T) {
+	h, _ := newTestWorkflowHandler(t)
+	router := newWorkflowRouter(h)
+
+	req := httptest.NewRequest("GET", "/workflows/nonexistent/executions", nil)
+	req = withTenantContext(req, "test-tenant")
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	var resp map[string]interface{}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.EqualValues(t, 0, resp["count"])
+}
+
+// --- trigger routes ----------------------------------------------------------
+
+func TestWorkflowHandler_RegisterTriggerRoutes_NilManager_NoRegistration(t *testing.T) {
+	logger := logging.NewNoopLogger()
+	h := NewWorkflowHandler(nil, nil, nil, logger)
+
+	router := mux.NewRouter()
+	sub := router.PathPrefix("/triggers").Subrouter()
+	// Should not panic when trigger manager is nil
+	assert.NotPanics(t, func() {
+		h.RegisterTriggerRoutes(sub)
+	})
+}
+
+// --- log injection safety ----------------------------------------------------
+
+// TestWorkflowHandler_SpecialCharsInName_HandledSafely verifies that workflow names
+// containing characters that would be dangerous in log entries are handled safely.
+// The code sanitizes user-provided values via logging.SanitizeLogValue before logging.
+func TestWorkflowHandler_SpecialCharsInName_HandledSafely(t *testing.T) {
+	h, _ := newTestWorkflowHandler(t)
+	router := newWorkflowRouter(h)
+
+	// URL-safe name that includes tab and other control characters
+	// (newlines cannot appear in HTTP request-URIs; they are rejected by Go's HTTP library)
+	req := httptest.NewRequest("GET", "/workflows/wf%09injected", nil)
+	req = withTenantContext(req, "test-tenant")
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	// Handler must not return 5xx — the workflow simply won't be found
+	assert.True(t, rec.Code < 500, "handler must not return 5xx for special-char workflow name, got %d", rec.Code)
+}

--- a/features/controller/api/server.go
+++ b/features/controller/api/server.go
@@ -63,6 +63,7 @@ type Server struct {
 	authDefense             *authdefense.AuthDefenseSystem // Story #380: Three-tier auth defense
 	rollbackManager         rollback.RollbackManager       // Story #416: Rollback system
 	reportsHandler          *reportapi.Handler             // Story #416: Reports engine
+	workflowHandler         *WorkflowHandler               // Story #414: Workflow engine REST API
 }
 
 // APIKey represents an API key for external authentication
@@ -336,6 +337,16 @@ func (s *Server) setupRouter() {
 		s.reportsHandler.RegisterRoutes(reportsRouter)
 		s.logger.Info("Reports API routes registered")
 	}
+
+	// Workflow engine endpoints (Issue #414)
+	if s.workflowHandler != nil {
+		workflowRouter := api.PathPrefix("/workflows").Subrouter()
+		s.workflowHandler.RegisterWorkflowRoutes(workflowRouter)
+
+		triggerRouter := api.PathPrefix("/triggers").Subrouter()
+		s.workflowHandler.RegisterTriggerRoutes(triggerRouter)
+		s.logger.Info("Workflow and trigger API routes registered")
+	}
 }
 
 // Start starts the HTTP server
@@ -428,6 +439,13 @@ func (s *Server) SetReportsHandler(h *reportapi.Handler) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.reportsHandler = h
+}
+
+// SetWorkflowHandler sets the workflow handler for workflow and trigger API routes (Issue #414)
+func (s *Server) SetWorkflowHandler(h *WorkflowHandler) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.workflowHandler = h
 }
 
 // getHTTPListenAddr determines the HTTP listen address

--- a/features/controller/server/server.go
+++ b/features/controller/server/server.go
@@ -38,7 +38,12 @@ import (
 	reportstemplates "github.com/cfgis/cfgms/features/reports/templates"
 	dnadrift "github.com/cfgis/cfgms/features/steward/dna/drift"
 	dnaStorage "github.com/cfgis/cfgms/features/steward/dna/storage"
+	stewardconfig "github.com/cfgis/cfgms/features/steward/config"
+	"github.com/cfgis/cfgms/features/steward/discovery"
+	stewardfactory "github.com/cfgis/cfgms/features/steward/factory"
 	"github.com/cfgis/cfgms/features/tenant"
+	"github.com/cfgis/cfgms/features/workflow"
+	workflowtrigger "github.com/cfgis/cfgms/features/workflow/trigger"
 	"github.com/cfgis/cfgms/pkg/audit"
 	"github.com/cfgis/cfgms/pkg/cert"
 	controlplaneInterfaces "github.com/cfgis/cfgms/pkg/controlplane/interfaces"
@@ -81,7 +86,8 @@ type Server struct {
 	signerCertSerial        string                  // Serial number of server cert used for config signing (Story #378)
 	healthCollector         *health.Collector
 	alertManager            *health.DefaultAlertManager
-	dnaStorageManager       *dnaStorage.Manager // Reports engine DNA storage (must be closed on Stop)
+	dnaStorageManager       *dnaStorage.Manager             // Reports engine DNA storage (must be closed on Stop)
+	triggerManager          *workflowtrigger.TriggerManagerImpl // Issue #414: Workflow trigger manager
 }
 
 // New creates a new server instance
@@ -448,7 +454,8 @@ func New(cfg *config.Config, logger logging.Logger) (*Server, error) {
 		storageStats := NewBasicStorageStats(cfg.Storage.Provider)
 		storageCollector := health.NewDefaultStorageCollector(storageStats)
 
-		// Application stats — no-op until workflow engine exists
+		// Application stats — uses no-op queue stats; workflow engine health
+		// is surfaced via the /api/v1/health endpoint (Issue #414)
 		appCollector := health.NewDefaultApplicationCollector(&NoOpApplicationQueueStats{})
 
 		// System stats (CPU, memory, goroutines)
@@ -524,6 +531,14 @@ func New(cfg *config.Config, logger logging.Logger) (*Server, error) {
 		logger.Info("Reports engine wired to HTTP API server")
 	}
 
+	// Issue #414: Wire workflow engine and trigger manager into API server
+	workflowHandler, triggerMgr := initializeWorkflowHandler(storageManager, logger)
+	if workflowHandler != nil {
+		httpServer.SetWorkflowHandler(workflowHandler)
+		srv.triggerManager = triggerMgr
+		logger.Info("Workflow engine wired to HTTP API server")
+	}
+
 	return srv, nil
 }
 
@@ -597,6 +612,80 @@ func initializeReportsHandler(cfg *config.Config, logger logging.Logger) (*repor
 
 	logger.Info("Reports engine initialized")
 	return reportapi.New(reportEngine, exporter, logger), dnaStorageManager
+}
+
+// initializeWorkflowHandler creates the workflow engine, trigger manager, and API handler.
+// Returns nil, nil on failure so the controller starts without workflow support rather than failing.
+func initializeWorkflowHandler(storageManager *interfaces.StorageManager, logger logging.Logger) (*api.WorkflowHandler, *workflowtrigger.TriggerManagerImpl) {
+	// Create a minimal module factory for the workflow engine.
+	// The controller does not load steward modules directly; the factory is
+	// required by the engine constructor but not exercised during REST API use.
+	moduleFactory := stewardfactory.New(
+		discovery.ModuleRegistry{},
+		stewardconfig.ErrorHandlingConfig{},
+	)
+
+	workflowEngine := workflow.NewEngine(moduleFactory, logger)
+
+	configStore := storageManager.GetConfigStore()
+
+	// workflowEngineAdapter bridges workflow.Engine to trigger.WorkflowTrigger.
+	// Triggers resolve workflows by name from the default tenant store.
+	adapter := &workflowEngineAdapter{
+		engine:      workflowEngine,
+		configStore: configStore,
+	}
+
+	storageProvider := storageManager.GetProvider()
+	triggerMgr := workflowtrigger.NewControllerTriggerManager(storageProvider, adapter)
+
+	handler := api.NewWorkflowHandler(workflowEngine, configStore, triggerMgr, logger)
+
+	logger.Info("Workflow engine and trigger manager initialized (Issue #414)")
+	return handler, triggerMgr
+}
+
+// workflowEngineAdapter implements trigger.WorkflowTrigger by delegating to the workflow engine.
+type workflowEngineAdapter struct {
+	engine      *workflow.Engine
+	configStore interfaces.ConfigStore
+}
+
+func (a *workflowEngineAdapter) TriggerWorkflow(ctx context.Context, trig *workflowtrigger.Trigger, data map[string]interface{}) (*workflowtrigger.WorkflowExecution, error) {
+	// Resolve workflow from storage using a system-level (empty) tenant scope.
+	store := workflow.NewWorkflowStore(a.configStore, trig.TenantID)
+	vw, err := store.GetLatestWorkflow(ctx, trig.WorkflowName)
+	if err != nil {
+		return nil, fmt.Errorf("workflow %q not found for trigger %q: %w", trig.WorkflowName, trig.ID, err)
+	}
+
+	// Merge trigger default variables with runtime data
+	vars := make(map[string]interface{})
+	for k, v := range trig.Variables {
+		vars[k] = v
+	}
+	for k, v := range data {
+		vars[k] = v
+	}
+
+	exec, err := a.engine.ExecuteWorkflow(ctx, vw.Workflow, vars)
+	if err != nil {
+		return nil, fmt.Errorf("failed to start workflow %q: %w", trig.WorkflowName, err)
+	}
+
+	return &workflowtrigger.WorkflowExecution{
+		ID:           exec.ID,
+		WorkflowName: exec.WorkflowName,
+		Status:       string(exec.Status),
+		StartTime:    exec.StartTime,
+	}, nil
+}
+
+func (a *workflowEngineAdapter) ValidateTrigger(_ context.Context, trig *workflowtrigger.Trigger) error {
+	if trig.WorkflowName == "" {
+		return fmt.Errorf("trigger %q must specify a workflow_name", trig.ID)
+	}
+	return nil
 }
 
 // Start initializes and starts the controller server (gRPC-over-QUIC mode)
@@ -725,6 +814,15 @@ func (s *Server) Start() error {
 		}
 	}
 
+	// Start workflow trigger manager (Issue #414)
+	if s.triggerManager != nil {
+		if err := s.triggerManager.Start(context.Background()); err != nil {
+			s.logger.Warn("Failed to start trigger manager", "error", err)
+		} else {
+			s.logger.Info("Workflow trigger manager started")
+		}
+	}
+
 	// Start health collector and alert manager (Story #417)
 	if s.healthCollector != nil {
 		if err := s.healthCollector.Start(context.Background(), 30*time.Second); err != nil {
@@ -784,6 +882,15 @@ func (s *Server) Stop() error {
 	if s.alertManager != nil {
 		if err := s.alertManager.Stop(); err != nil {
 			s.logger.Warn("Failed to stop alert manager", "error", err)
+		}
+	}
+
+	// Stop workflow trigger manager (Issue #414)
+	if s.triggerManager != nil {
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		if err := s.triggerManager.Stop(ctx); err != nil {
+			s.logger.Warn("Failed to stop trigger manager", "error", err)
 		}
 	}
 

--- a/features/controller/server/server.go
+++ b/features/controller/server/server.go
@@ -676,7 +676,7 @@ func (a *workflowEngineAdapter) TriggerWorkflow(ctx context.Context, trig *workf
 	return &workflowtrigger.WorkflowExecution{
 		ID:           exec.ID,
 		WorkflowName: exec.WorkflowName,
-		Status:       string(exec.Status),
+		Status:       string(exec.GetStatus()),
 		StartTime:    exec.StartTime,
 	}, nil
 }

--- a/features/workflow/trigger/controller_factory.go
+++ b/features/workflow/trigger/controller_factory.go
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+package trigger
+
+import (
+	"github.com/cfgis/cfgms/pkg/storage/interfaces"
+)
+
+// NewControllerTriggerManager creates a fully-wired TriggerManagerImpl for controller use.
+//
+// The trigger system has a circular dependency: TriggerManagerImpl holds Scheduler,
+// WebhookHandler, and SIEMIntegration, while each component also holds a reference
+// back to the TriggerManager for execution tracking. This factory resolves the
+// dependency via two-phase initialization within the package boundary.
+func NewControllerTriggerManager(
+	storage interfaces.StorageProvider,
+	workflowTrigger WorkflowTrigger,
+) *TriggerManagerImpl {
+	// Phase 1: Create the manager with nil components to break the circular dependency.
+	// The manager's Start() guards against nil components, so this is safe during wiring.
+	manager := NewTriggerManager(storage, nil, nil, nil, workflowTrigger)
+
+	// Phase 2: Create each component with the manager reference.
+	scheduler := NewCronScheduler(manager, workflowTrigger)
+
+	// Webhook handler binds to port 0 (disabled) by default.
+	// The controller's existing REST API handles inbound webhook delivery.
+	webhookHandler := NewHTTPWebhookHandler(manager, workflowTrigger, "localhost", 0)
+
+	siemProcessor := NewSIEMProcessor(manager, workflowTrigger)
+
+	// Phase 3: Wire components back into the manager now that all are constructed.
+	manager.scheduler = scheduler
+	manager.webhookHandler = webhookHandler
+	manager.siemIntegration = siemProcessor
+
+	return manager
+}

--- a/features/workflow/trigger/controller_factory_test.go
+++ b/features/workflow/trigger/controller_factory_test.go
@@ -1,0 +1,145 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+package trigger
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	stewardconfig "github.com/cfgis/cfgms/features/steward/config"
+	"github.com/cfgis/cfgms/features/steward/discovery"
+	"github.com/cfgis/cfgms/features/steward/factory"
+	"github.com/cfgis/cfgms/features/workflow"
+	"github.com/cfgis/cfgms/pkg/logging"
+	storageif "github.com/cfgis/cfgms/pkg/storage/interfaces"
+	gitprovider "github.com/cfgis/cfgms/pkg/storage/providers/git"
+)
+
+// workflowEngineAdapter implements WorkflowTrigger using a real *workflow.Engine and a real
+// ConfigStore. This mirrors the unexported workflowEngineAdapter in
+// features/controller/server/server.go; it is re-declared here because importing that
+// package would create a circular dependency (controller/server → trigger → controller/server).
+type workflowEngineAdapter struct {
+	engine      *workflow.Engine
+	configStore storageif.ConfigStore
+}
+
+func (a *workflowEngineAdapter) TriggerWorkflow(ctx context.Context, trig *Trigger, data map[string]interface{}) (*WorkflowExecution, error) {
+	store := workflow.NewWorkflowStore(a.configStore, trig.TenantID)
+	vw, err := store.GetLatestWorkflow(ctx, trig.WorkflowName)
+	if err != nil {
+		return nil, fmt.Errorf("workflow %q not found for trigger %q: %w", trig.WorkflowName, trig.ID, err)
+	}
+	vars := make(map[string]interface{})
+	for k, v := range trig.Variables {
+		vars[k] = v
+	}
+	for k, v := range data {
+		vars[k] = v
+	}
+	exec, err := a.engine.ExecuteWorkflow(ctx, vw.Workflow, vars)
+	if err != nil {
+		return nil, fmt.Errorf("failed to start workflow %q: %w", trig.WorkflowName, err)
+	}
+	return &WorkflowExecution{
+		ID:           exec.ID,
+		WorkflowName: exec.WorkflowName,
+		Status:       string(exec.GetStatus()),
+		StartTime:    exec.StartTime,
+	}, nil
+}
+
+func (a *workflowEngineAdapter) ValidateTrigger(_ context.Context, trig *Trigger) error {
+	if trig.WorkflowName == "" {
+		return fmt.Errorf("trigger %q must specify a workflow_name", trig.ID)
+	}
+	return nil
+}
+
+// newRealWorkflowTrigger creates a WorkflowTrigger backed by a real *workflow.Engine and
+// real git-based ConfigStore, matching the production wiring in server.go.
+func newRealWorkflowTrigger(tb testing.TB) WorkflowTrigger {
+	tb.Helper()
+	storageConfig := map[string]interface{}{
+		"repository_path": tb.TempDir(),
+		"branch":          "main",
+		"auto_init":       true,
+	}
+	storageManager, err := storageif.CreateAllStoresFromConfig("git", storageConfig)
+	require.NoError(tb, err)
+
+	registry := make(discovery.ModuleRegistry)
+	errCfg := stewardconfig.ErrorHandlingConfig{ModuleLoadFailure: stewardconfig.ActionContinue}
+	eng := workflow.NewEngine(factory.New(registry, errCfg), logging.NewNoopLogger())
+
+	return &workflowEngineAdapter{
+		engine:      eng,
+		configStore: storageManager.GetConfigStore(),
+	}
+}
+
+// TestNewControllerTriggerManager_ReturnsWiredManager verifies that the factory creates a
+// manager with all three components (scheduler, webhookHandler, siemIntegration) non-nil.
+func TestNewControllerTriggerManager_ReturnsWiredManager(t *testing.T) {
+	storage := &gitprovider.GitProvider{}
+	wt := newRealWorkflowTrigger(t)
+
+	manager := NewControllerTriggerManager(storage, wt)
+
+	require.NotNil(t, manager, "manager must not be nil")
+	assert.NotNil(t, manager.scheduler, "scheduler must be wired")
+	assert.NotNil(t, manager.webhookHandler, "webhookHandler must be wired")
+	assert.NotNil(t, manager.siemIntegration, "siemIntegration must be wired")
+	assert.Equal(t, wt, manager.workflowTrigger, "workflowTrigger must be the provided WorkflowTrigger")
+	assert.False(t, manager.running, "manager must not be running after construction")
+}
+
+// TestNewControllerTriggerManager_ComponentsReferenceManager verifies that the two-phase
+// circular-dependency resolution wires each component back to the parent manager.
+func TestNewControllerTriggerManager_ComponentsReferenceManager(t *testing.T) {
+	storage := &gitprovider.GitProvider{}
+	wt := newRealWorkflowTrigger(t)
+
+	manager := NewControllerTriggerManager(storage, wt)
+	require.NotNil(t, manager)
+
+	cs, ok := manager.scheduler.(*CronScheduler)
+	require.True(t, ok, "scheduler must be a *CronScheduler")
+	assert.Equal(t, manager, cs.triggerManager, "CronScheduler must reference the parent manager")
+
+	wh, ok := manager.webhookHandler.(*HTTPWebhookHandler)
+	require.True(t, ok, "webhookHandler must be an *HTTPWebhookHandler")
+	assert.Equal(t, manager, wh.triggerManager, "HTTPWebhookHandler must reference the parent manager")
+
+	sp, ok := manager.siemIntegration.(*SIEMProcessor)
+	require.True(t, ok, "siemIntegration must be a *SIEMProcessor")
+	assert.Equal(t, manager, sp.triggerManager, "SIEMProcessor must reference the parent manager")
+}
+
+// TestNewControllerTriggerManager_StartStopLifecycle verifies that the manager created by
+// the factory starts and stops cleanly using the real component implementations.
+func TestNewControllerTriggerManager_StartStopLifecycle(t *testing.T) {
+	storage := &gitprovider.GitProvider{}
+	wt := newRealWorkflowTrigger(t)
+
+	manager := NewControllerTriggerManager(storage, wt)
+	require.NotNil(t, manager)
+
+	ctx := context.Background()
+
+	err := manager.Start(ctx)
+	assert.NoError(t, err, "Start must succeed with real components")
+	assert.True(t, manager.running, "manager must be running after Start")
+
+	// Double-start must fail.
+	err = manager.Start(ctx)
+	assert.Error(t, err, "second Start must fail")
+
+	err = manager.Stop(ctx)
+	assert.NoError(t, err, "Stop must succeed")
+	assert.False(t, manager.running, "manager must not be running after Stop")
+}

--- a/features/workflow/trigger/scheduler.go
+++ b/features/workflow/trigger/scheduler.go
@@ -90,6 +90,7 @@ func (cs *CronScheduler) Start(ctx context.Context) error {
 	logger.InfoCtx(ctx, "Starting cron scheduler")
 
 	cs.running = true
+	cs.stopChan = make(chan struct{}) // Reinitialize for restartability after Stop()
 	go cs.schedulerLoop(ctx)
 
 	logger.InfoCtx(ctx, "Cron scheduler started successfully")


### PR DESCRIPTION
## Summary

- Wires the existing workflow engine (`features/workflow/`) into the controller startup lifecycle and REST API — no new business logic, purely integration work
- Adds workflow CRUD + execution + history REST endpoints (`/api/v1/workflows`) and trigger management endpoints (`/api/v1/triggers`) behind API key authentication
- Starts `TriggerManager` on controller startup and stops it gracefully on shutdown

## What changed

| File | Change |
|------|--------|
| `features/workflow/trigger/controller_factory.go` | New: `NewControllerTriggerManager()` resolves circular init dependency between `TriggerManagerImpl` and its components via two-phase wiring |
| `features/controller/api/handlers_workflows.go` | New: `WorkflowHandler` with workflow CRUD, manual execute, execution history, and trigger route delegation |
| `features/controller/api/server.go` | Added `workflowHandler` field, `SetWorkflowHandler()` setter, route registration in `setupRouter()` |
| `features/controller/api/handlers_health.go` | Health endpoint now reports `workflow_engine` service status |
| `features/controller/server/server.go` | `initializeWorkflowHandler()` creates Engine + TriggerManager; `workflowEngineAdapter` implements `trigger.WorkflowTrigger`; Start/Stop lifecycle wiring |

## Acceptance criteria status

- [x] Workflow engine instantiated during controller startup
- [x] Trigger manager started during controller startup, stopped on shutdown
- [x] Workflow CRUD REST endpoints available and tenant-scoped
- [x] Manual workflow execution via REST API works
- [x] Workflow execution history queryable via REST API
- [x] Trigger CRUD endpoints available (via existing `trigger.APIHandler`)
- [x] Workflow health stats visible in controller health monitoring
- [x] All existing tests pass

## Test plan

- [ ] `GET /api/v1/health` — verify `workflow_engine: healthy` in services map
- [ ] `POST /api/v1/workflows` — create a workflow, expect 201 with versioned workflow body
- [ ] `GET /api/v1/workflows` — list workflows, tenant-scoped
- [ ] `GET /api/v1/workflows/{name}` — retrieve latest version
- [ ] `PUT /api/v1/workflows/{name}` — update (new version stored)
- [ ] `POST /api/v1/workflows/{name}/execute` — trigger manual execution, expect 202 with execution ID
- [ ] `GET /api/v1/workflows/{name}/executions` — execution history
- [ ] `DELETE /api/v1/workflows/{name}` — deletes all versions
- [ ] `POST /api/v1/triggers` — create schedule/webhook/SIEM trigger
- [ ] `GET /api/v1/triggers` — list triggers
- [ ] `DELETE /api/v1/triggers/{id}` — remove trigger

🤖 Generated with [Claude Code](https://claude.com/claude-code)