### PR TITLE
fix: close agent dispatch quality gaps with adversarial review and enforcement (Issue #557)

### DIFF
--- a/.devcontainer/entrypoint.sh
+++ b/.devcontainer/entrypoint.sh
@@ -86,13 +86,92 @@ else
     echo "OAuth token valid (${TOKEN_REMAINING}s remaining)"
 fi
 
+# --- Helper: GitHub API with retry ---
+# Fetches from GitHub API with one retry on failure. Hard-fails if both attempts fail.
+# Usage: gh_api_with_retry <description> <command...>
+gh_api_with_retry() {
+    local desc="$1"
+    shift
+    local result
+    if result=$("$@" 2>&1); then
+        echo "$result"
+        return 0
+    fi
+    echo "WARN: ${desc} failed, retrying once..." >&2
+    sleep 2
+    if result=$("$@" 2>&1); then
+        echo "$result"
+        return 0
+    fi
+    echo "ERROR: ${desc} failed after retry: ${result}" >&2
+    return 1
+}
+
+# --- Shared prompt sections ---
+# These are appended to ALL mode prompts for consistent quality standards.
+
+# Self-review checklist — identical across all modes
+SELF_REVIEW_SECTION='## Phase 3: Self-Review
+
+Review your own changes for quality issues before proceeding:
+- Check for mocks, t.Skip(), empty assertions, hacky workarounds
+- Check for hardcoded secrets, SQL injection, information disclosure
+- Check for central provider violations (see CLAUDE.md Central Provider System)
+- Check for unsanitized user input in logs (use logging.SanitizeLogValue())
+- Verify every new .go file has a corresponding _test.go file with functional tests
+- Verify tests exercise error paths, not just happy paths
+- Fix any issues found'
+
+# Adversarial review phase — the 3-specialist review that catches issues the
+# implementing agent is blind to. Uses the same agents as /story-complete.
+ADVERSARIAL_REVIEW_SECTION='## Phase 4: Adversarial Team Review (MANDATORY)
+
+Before committing, you MUST spawn three specialist review agents in parallel using
+the Agent tool. These agents review your work with fresh context. Read each agent
+definition file and include its full instructions in the agent prompt.
+
+**IMPORTANT**: Do NOT skip this phase. Do NOT commit or create a PR before all
+three specialists have reported PASS.
+
+### Spawn these three agents in parallel:
+
+1. **qa-test-runner** (subagent_type: qa-test-runner)
+   - Read `.claude/agents/qa-test-runner.md` for instructions
+   - OVERRIDE: Run `make test-agent-complete` instead of `make test-quality` (no Docker in container)
+   - Reports pass/fail with specific test names and error details
+   - After it passes, write the marker file: `touch /tmp/agent-validation-passed`
+
+2. **qa-code-reviewer** (subagent_type: qa-code-reviewer)
+   - Read `.claude/agents/qa-code-reviewer.md` for instructions
+   - Reviews all changed files for test quality, missing tests, mocks, hacky workarounds
+   - MUST verify: every new .go file has corresponding _test.go with functional tests
+   - MUST reject: new production code without tests, tests without error path coverage
+
+3. **security-engineer** (subagent_type: security-engineer)
+   - Read `.claude/agents/security-engineer.md` for instructions
+   - Runs security scans and reviews for vulnerabilities, central provider violations
+   - Reports blocking issues with file:line references
+
+### After all three report back:
+
+- If ALL three report PASS: proceed to commit phase
+- If ANY report BLOCKING issues: fix the issues, then re-run ONLY the failing specialists
+- Maximum 3 fix iterations. If issues persist after 3 rounds, commit as draft PR with failure details.'
+
+# Scope constraints — identical across all modes
+SCOPE_CONSTRAINTS_SECTION='## Scope Constraints
+
+- Do NOT modify: CLAUDE.md, Makefile root targets, .github/*, docs/product/roadmap.md
+- Do NOT add external dependencies without justification
+- Do NOT skip tests or create PRs targeting main
+- ALWAYS check central providers in pkg/ before creating new functionality'
+
 # --- Phase 1: Compose prompt based on mode ---
 
 compose_issue_prompt() {
     echo "Fetching issue #${ISSUE_NUM}..."
-    ISSUE_JSON=$(gh issue view "$ISSUE_NUM" --json title,body,labels 2>&1) || {
-        echo "ERROR: Failed to fetch issue #${ISSUE_NUM}"
-        echo "$ISSUE_JSON"
+    ISSUE_JSON=$(gh_api_with_retry "fetch issue #${ISSUE_NUM}" gh issue view "$ISSUE_NUM" --json title,body,labels) || {
+        echo "ERROR: Cannot proceed without issue context"
         exit 1
     }
 
@@ -117,30 +196,25 @@ architecture rules, and coding standards. CFGMS_AGENT_MODE=true is set.
 1. Read and understand the full issue including acceptance criteria
 2. Read CLAUDE.md for project conventions (central providers, storage architecture, etc.)
 3. If the issue mentions reference files or patterns, read them first
-4. Implement the change following existing patterns and TDD approach
+4. Write tests FIRST for the expected behavior (TDD — tests must fail before implementation)
+5. Implement the change to make the tests pass, following existing patterns
 
-## Phase 2: Validate
+## Phase 2: Validate (quick self-check before specialist review)
 
-5. Run \`make test-agent-complete\` which runs all validation that works without Docker:
-   - test-commit (tests + lint + security + architecture checks)
-   - test-fast (fast comprehensive tests)
-   - test-production-critical (production critical tests)
-   - build-cross-validate (cross-platform compilation)
-6. If validation fails, fix issues and retry. Maximum 3 fix iterations.
+6. Run \`go test ./path/to/changed/packages/...\` to verify your tests pass locally
+7. Fix any compilation or test errors before proceeding to review phase
 
-## Phase 3: Self-Review
+PROMPT_EOF
+    # Append shared sections (contain backticks — must not be inside unquoted heredoc)
+    printf '%s\n\n' "$SELF_REVIEW_SECTION" >> "$PROMPT_FILE"
+    printf '%s\n\n' "$ADVERSARIAL_REVIEW_SECTION" >> "$PROMPT_FILE"
+    cat >> "$PROMPT_FILE" <<PROMPT_EOF
+## Phase 5: Commit and PR
 
-7. Review your own changes for quality issues:
-   - Check for mocks, t.Skip(), empty assertions, hacky workarounds
-   - Check for hardcoded secrets, SQL injection, information disclosure
-   - Check for central provider violations (see CLAUDE.md Central Provider System)
-   - Check for unsanitized user input in logs
-   - Fix any issues found
-
-## Phase 4: Commit and PR
+After all three specialists report PASS:
 
 8. Run \`go mod tidy\` if dependencies changed
-9. Stage all changes
+9. Stage all changes with \`git add <specific files>\` (never git add . or git add -A)
 10. Commit with message: \`<scope>: <description> (Issue #${ISSUE_NUM})\`
     - Follow commit message format in CLAUDE.md (15-25 lines, WHY + WHAT)
     - Include \`Fixes #${ISSUE_NUM}\` in the commit body
@@ -148,22 +222,18 @@ architecture rules, and coding standards. CFGMS_AGENT_MODE=true is set.
 11. Push branch: \`git push -u origin \$(git branch --show-current)\`
 12. Open PR targeting \`develop\` (NEVER \`main\`):
     \`gh pr create --base develop --title "<scope>: <title> (Issue #${ISSUE_NUM})"\`
+    Include specialist review results (PASS/FAIL summaries) in the PR body.
 
 ## Failure Handling
 
-If \`make test-commit\` fails after 3 fix iterations:
+If specialists report issues that cannot be fixed after 3 iterations:
 - Stage all changes and commit with message describing what was attempted
 - Push the branch
-- Open a DRAFT PR with failure details in the description body
+- Open a DRAFT PR with failure details and specialist reports in the description body
 - Exit non-zero
 
-## Scope Constraints
-
-- Do NOT modify: CLAUDE.md, Makefile root targets, .github/*, docs/product/roadmap.md
-- Do NOT add external dependencies without justification
-- Do NOT skip tests or create PRs targeting main
-- ALWAYS check central providers in pkg/ before creating new functionality
 PROMPT_EOF
+    printf '%s\n' "$SCOPE_CONSTRAINTS_SECTION" >> "$PROMPT_FILE"
 }
 
 compose_branch_prompt() {
@@ -178,8 +248,11 @@ compose_branch_prompt() {
     # Fetch issue context if available
     if [[ -n "$ISSUE_NUM" ]]; then
         echo "Fetching issue #${ISSUE_NUM} for context..."
-        ISSUE_JSON=$(gh issue view "$ISSUE_NUM" --json title,body,labels 2>&1) || true
-        if [[ -n "$ISSUE_JSON" ]] && echo "$ISSUE_JSON" | jq -e '.title' >/dev/null 2>&1; then
+        ISSUE_JSON=$(gh_api_with_retry "fetch issue #${ISSUE_NUM}" gh issue view "$ISSUE_NUM" --json title,body,labels) || {
+            echo "ERROR: Cannot proceed without issue context"
+            exit 1
+        }
+        if echo "$ISSUE_JSON" | jq -e '.title' >/dev/null 2>&1; then
             TITLE=$(echo "$ISSUE_JSON" | jq -r '.title')
             BODY=$(echo "$ISSUE_JSON" | jq -r '.body')
             issue_context="## Issue Context
@@ -193,7 +266,8 @@ ${BODY}
 
     # Detect if a PR already exists for this branch
     local pr_instruction="13. Open PR targeting \`develop\` (NEVER \`main\`):
-    \`gh pr create --base develop\`"
+    \`gh pr create --base develop\`
+    Include specialist review results (PASS/FAIL summaries) in the PR body."
     EXISTING_PR=$(gh pr list --head "$BRANCH" --json url -q '.[0].url' 2>/dev/null || echo "")
     if [[ -n "$EXISTING_PR" ]]; then
         pr_instruction="13. A PR already exists for this branch (${EXISTING_PR}). Push your changes — do NOT create a new PR."
@@ -227,30 +301,25 @@ architecture rules, and coding standards. CFGMS_AGENT_MODE=true is set.
 
 1. Review existing work on this branch first
 2. Read CLAUDE.md for project conventions (central providers, storage architecture, etc.)
-3. Continue implementation following existing patterns and TDD approach
+3. Write tests FIRST for new behavior (TDD — tests must fail before implementation)
+4. Continue implementation following existing patterns
 
-## Phase 2: Validate
+## Phase 2: Validate (quick self-check before specialist review)
 
-4. Run \`make test-agent-complete\` which runs all validation that works without Docker:
-   - test-commit (tests + lint + security + architecture checks)
-   - test-fast (fast comprehensive tests)
-   - test-production-critical (production critical tests)
-   - build-cross-validate (cross-platform compilation)
-5. If validation fails, fix issues and retry. Maximum 3 fix iterations.
+5. Run \`go test ./path/to/changed/packages/...\` to verify your tests pass locally
+6. Fix any compilation or test errors before proceeding to review phase
 
-## Phase 3: Self-Review
+PROMPT_EOF
+    # Append shared sections (contain backticks — must not be inside unquoted heredoc)
+    printf '%s\n\n' "$SELF_REVIEW_SECTION" >> "$PROMPT_FILE"
+    printf '%s\n\n' "$ADVERSARIAL_REVIEW_SECTION" >> "$PROMPT_FILE"
+    cat >> "$PROMPT_FILE" <<PROMPT_EOF
+## Phase 5: Commit and Push
 
-6. Review your own changes for quality issues:
-   - Check for mocks, t.Skip(), empty assertions, hacky workarounds
-   - Check for hardcoded secrets, SQL injection, information disclosure
-   - Check for central provider violations (see CLAUDE.md Central Provider System)
-   - Check for unsanitized user input in logs
-   - Fix any issues found
-
-## Phase 4: Commit and Push
+After all three specialists report PASS:
 
 7. Run \`go mod tidy\` if dependencies changed
-8. Stage all changes
+8. Stage all changes with \`git add <specific files>\` (never git add . or git add -A)
 9. Commit with message following CLAUDE.md format
     - Include \`Co-Authored-By: Claude <noreply@anthropic.com>\`${issue_ref}
 10. Push branch: \`git push -u origin \$(git branch --show-current)\`
@@ -258,26 +327,20 @@ ${pr_instruction}
 
 ## Failure Handling
 
-If \`make test-commit\` fails after 3 fix iterations:
+If specialists report issues that cannot be fixed after 3 iterations:
 - Stage all changes and commit with message describing what was attempted
 - Push the branch
-- If no PR exists, open a DRAFT PR with failure details
+- If no PR exists, open a DRAFT PR with failure details and specialist reports
 - Exit non-zero
 
-## Scope Constraints
-
-- Do NOT modify: CLAUDE.md, Makefile root targets, .github/*, docs/product/roadmap.md
-- Do NOT add external dependencies without justification
-- Do NOT skip tests or create PRs targeting main
-- ALWAYS check central providers in pkg/ before creating new functionality
 PROMPT_EOF
+    printf '%s\n' "$SCOPE_CONSTRAINTS_SECTION" >> "$PROMPT_FILE"
 }
 
 compose_pr_fix_prompt() {
     echo "Fetching PR #${PR_NUM} metadata..."
-    PR_JSON=$(gh pr view "$PR_NUM" --json number,title,body,headRefName,reviews 2>&1) || {
-        echo "ERROR: Failed to fetch PR #${PR_NUM}"
-        echo "$PR_JSON"
+    PR_JSON=$(gh_api_with_retry "fetch PR #${PR_NUM}" gh pr view "$PR_NUM" --json number,title,body,headRefName,reviews) || {
+        echo "ERROR: Cannot proceed without PR context"
         exit 1
     }
 
@@ -287,17 +350,19 @@ compose_pr_fix_prompt() {
     pr_branch=$(echo "$PR_JSON" | jq -r '.headRefName')
     BRANCH="$pr_branch"
 
-    # Fetch review comments
+    # Fetch review comments — hard fail if fetch fails (agent needs these to do its job)
     echo "Fetching review comments..."
     local owner repo
     owner=$(gh repo view --json owner -q '.owner.login' 2>/dev/null || echo "")
     repo=$(gh repo view --json name -q '.name' 2>/dev/null || echo "")
     if [[ -z "$owner" ]] || [[ -z "$repo" ]]; then
-        echo "WARN: Could not determine repo owner/name; skipping review comments fetch"
-        REVIEW_COMMENTS="[]"
-    else
-        REVIEW_COMMENTS=$(gh api "repos/${owner}/${repo}/pulls/${PR_NUM}/comments" 2>/dev/null || echo "[]")
+        echo "ERROR: Could not determine repo owner/name — cannot fetch review comments"
+        exit 1
     fi
+    REVIEW_COMMENTS=$(gh_api_with_retry "fetch review comments for PR #${PR_NUM}" gh api "repos/${owner}/${repo}/pulls/${PR_NUM}/comments") || {
+        echo "ERROR: Cannot proceed without review comments"
+        exit 1
+    }
 
     # Extract review body comments (top-level review comments, not inline)
     REVIEWS=$(echo "$PR_JSON" | jq -r '.reviews[] | select(.body != "") | "**\(.author.login)** (\(.state)):\n\(.body)\n"' 2>/dev/null || echo "")
@@ -323,7 +388,7 @@ compose_pr_fix_prompt() {
     PROMPT_FILE=$(mktemp)
     printf 'You are fixing review comments on PR #%s: %s%s\n\n## PR Description\n\n' "$PR_NUM" "$pr_title" "$issue_ref" > "$PROMPT_FILE"
     printf '%s\n\n' "$pr_body" >> "$PROMPT_FILE"
-    printf '## Review Comments to Fix\n\n### Review-Level Comments\n' >> "$PROMPT_FILE"
+    printf '## Review Comments to Address\n\n### Review-Level Comments\n' >> "$PROMPT_FILE"
     printf '%s\n\n' "${REVIEWS:-No review-level comments.}" >> "$PROMPT_FILE"
     printf '### Inline Comments\n' >> "$PROMPT_FILE"
     printf '%s\n\n' "${INLINE_COMMENTS:-No inline comments.}" >> "$PROMPT_FILE"
@@ -336,38 +401,45 @@ Follow the CLAUDE.md file in the repository root. CFGMS_AGENT_MODE=true is set.
 
 ## Phase 1: Understand and Fix
 
-1. Read each review comment carefully
-2. Review the code at the mentioned locations
-3. Fix each issue following the reviewer's guidance
+1. Read ALL review comments carefully — both review-level and inline comments above
+2. Read the code at the mentioned locations
+3. For each review comment:
+   - If it requests new tests: write tests FIRST (TDD), then implement the fix
+   - If it identifies a bug: write a test that reproduces it, then fix it
+   - If it requests a refactor: ensure existing tests still pass after the change
 4. If a comment is unclear, make your best judgment following CLAUDE.md conventions
 
-## Phase 2: Validate
+## Phase 2: Validate (quick self-check before specialist review)
 
-5. Run \`make test-agent-complete\` to verify all fixes pass validation
-6. If validation fails, fix issues and retry. Maximum 3 fix iterations.
+5. Run \`go test ./path/to/changed/packages/...\` to verify your fixes compile and pass
+6. Fix any compilation or test errors before proceeding to review phase
 
-## Phase 3: Self-Review
+PROMPT_EOF
+    # Append shared sections (contain backticks — must not be inside unquoted heredoc)
+    printf '%s\n\n' "$SELF_REVIEW_SECTION" >> "$PROMPT_FILE"
+    printf '%s\n\n' "$ADVERSARIAL_REVIEW_SECTION" >> "$PROMPT_FILE"
+    cat >> "$PROMPT_FILE" <<PROMPT_EOF
+## Phase 5: Commit and Push
 
-7. Verify each review comment has been addressed
-8. Check for regressions from the fixes
-
-## Phase 4: Commit and Push
+After all three specialists report PASS:
 
 9. Run \`go mod tidy\` if dependencies changed
-10. Stage all changes
+10. Stage all changes with \`git add <specific files>\` (never git add . or git add -A)
 11. Commit with message: \`fix: address PR #${PR_NUM} review comments${issue_ref}\`
     - Include \`Co-Authored-By: Claude <noreply@anthropic.com>\`
     - List which review comments were addressed
 12. Push to the existing branch: \`git push\`
 13. Do NOT create a new PR — changes will appear on the existing PR #${PR_NUM}
 
-## Scope Constraints
+## Failure Handling
 
-- Only fix issues raised in review comments — do not refactor unrelated code
-- Do NOT modify: CLAUDE.md, Makefile root targets, .github/*, docs/product/roadmap.md
-- Do NOT add external dependencies without justification
-- Do NOT skip tests
+If specialists report issues that cannot be fixed after 3 iterations:
+- Stage all changes and commit with message describing what was attempted and what failed
+- Push to the existing branch
+- Exit non-zero
+
 PROMPT_EOF
+    printf '%s\n' "$SCOPE_CONSTRAINTS_SECTION" >> "$PROMPT_FILE"
 }
 
 # Compose prompt based on mode
@@ -392,6 +464,9 @@ if [[ -n "$ISSUE_NUM" ]]; then
     gh issue edit "$ISSUE_NUM" --add-label "agent:in-progress" 2>/dev/null || true
 fi
 
+# Clean validation marker from any previous run
+rm -f /tmp/agent-validation-passed
+
 echo "Starting Claude agent (mode=${MODE})..."
 EXIT_CODE=0
 # Read prompt from file to avoid shell metacharacter corruption.
@@ -401,6 +476,23 @@ claude --dangerously-skip-permissions --model claude-sonnet-4-6 -p "$PROMPT_CONT
 rm -f "$PROMPT_FILE"
 
 # Credentials persist automatically via symlink to /persist volume — no writeback needed.
+
+# --- Phase 2b: Shell-level validation enforcement ---
+# The agent is instructed to have qa-test-runner write /tmp/agent-validation-passed
+# after make test-agent-complete passes. If the marker is missing, tests either
+# failed or were never run — both are failures.
+if [ "$EXIT_CODE" -eq 0 ] && [ ! -f /tmp/agent-validation-passed ]; then
+    echo "ERROR: Agent exited 0 but validation marker not found"
+    echo "The qa-test-runner specialist either failed or was not run."
+    echo "Running make test-agent-complete as fallback enforcement..."
+    if make test-agent-complete; then
+        echo "Fallback validation passed — proceeding"
+        touch /tmp/agent-validation-passed
+    else
+        echo "ERROR: make test-agent-complete failed — marking agent as failed"
+        EXIT_CODE=1
+    fi
+fi
 
 # --- Phase 3: Cleanup and reporting ---
 
@@ -417,6 +509,7 @@ cat > /tmp/agent-result.json <<RESULT_EOF
   "exit_code": ${EXIT_CODE},
   "pr_url": "${PR_URL}",
   "branch": "${CURRENT_BRANCH}",
+  "validation_passed": $([ -f /tmp/agent-validation-passed ] && echo "true" || echo "false"),
   "timestamp": "$(date -Iseconds)"
 }
 RESULT_EOF


### PR DESCRIPTION
## Summary

- Agent-dispatched PRs now run the same 3-specialist adversarial review (qa-test-runner, qa-code-reviewer, security-engineer) as interactive `/story-complete`
- Shell-level enforcement ensures tests actually ran — fallback `make test-agent-complete` if marker file missing
- Fix-pr and branch mode prompts strengthened to match issue mode quality standards
- GitHub API failures hard-fail after one retry instead of silently proceeding with empty data

## Context

Recent agent PRs exposed systematic quality gaps:
- **PR #556**: 377 lines of HTTP handlers shipped with zero tests
- **PR #556 fix-pr**: Agent ignored human review comments, only addressed security bot findings, exited 0 without running tests
- **PR #552**: Windows permissions panic discovered only by CI, not agent self-review

Root cause: the agent container workflow had no adversarial review, weaker prompts for fix-pr/branch modes, and no enforcement of test execution.

## Test plan

- [x] `bash -n .devcontainer/entrypoint.sh` — syntax valid
- [x] `make test` — all existing tests pass (no Go code changed)
- [x] `make check-architecture` — no violations
- [ ] Dispatch fix-pr for PR #556 to validate improved agent output quality

Fixes #557

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>