### PR TITLE
steward: implement offline report queueing for controller reconnect (Issue #419)

### DIFF
--- a/features/steward/client/client_transport.go
+++ b/features/steward/client/client_transport.go
@@ -90,6 +90,10 @@ type TransportClient struct {
 	heartbeatInterval time.Duration
 	heartbeatStop     chan struct{}
 
+	// offlineQueue persists reports locally when the controller is unreachable.
+	// Issue #419: drained in order after a successful reconnect.
+	offlineQueue *OfflineQueue
+
 	// Logger
 	logger logging.Logger
 }
@@ -126,6 +130,20 @@ type TransportConfig struct {
 	// HeartbeatInterval for periodic heartbeats
 	HeartbeatInterval time.Duration
 
+	// QueueDir is the directory used to persist the offline report queue.
+	// If empty the queue operates in-memory only (events are lost on restart).
+	// Issue #419: set this to a stable path (e.g. steward data directory) for
+	// durable offline queueing across restarts.
+	QueueDir string
+
+	// MaxQueueSize is the maximum number of events to retain in the offline
+	// queue before the oldest is evicted. Defaults to 1000.
+	MaxQueueSize int
+
+	// MaxQueueAge is the maximum time an event is kept in the offline queue
+	// before being discarded. Defaults to 24 hours.
+	MaxQueueAge time.Duration
+
 	// Logger for client logging
 	Logger logging.Logger
 }
@@ -144,6 +162,17 @@ func NewTransportClient(cfg *TransportConfig) (*TransportClient, error) {
 		heartbeatInterval = 30 * time.Second
 	}
 
+	// Initialize offline queue for durable report persistence (Issue #419).
+	offlineQueue, err := NewOfflineQueue(OfflineQueueConfig{
+		Dir:     cfg.QueueDir,
+		MaxSize: cfg.MaxQueueSize,
+		MaxAge:  cfg.MaxQueueAge,
+		Logger:  cfg.Logger,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to initialize offline queue: %w", err)
+	}
+
 	c := &TransportClient{
 		heartbeatInterval: heartbeatInterval,
 		heartbeatStop:     make(chan struct{}),
@@ -156,6 +185,7 @@ func NewTransportClient(cfg *TransportConfig) (*TransportClient, error) {
 		clientKeyPEM:      cfg.ClientKeyPEM,
 		serverCertPEM:     cfg.ServerCertPEM,
 		signingCertPEM:    cfg.SigningCertPEM,
+		offlineQueue:      offlineQueue,
 		logger:            cfg.Logger,
 	}
 
@@ -306,6 +336,11 @@ func (c *TransportClient) Connect(ctx context.Context) error {
 	c.connected = true
 	c.mu.Unlock()
 
+	// Drain any events queued during the offline period (Issue #419).
+	// Done synchronously before starting the heartbeat so the controller
+	// receives a complete history before the next heartbeat arrives.
+	c.drainOfflineQueue(ctx)
+
 	// Start heartbeat
 	go c.startHeartbeat()
 
@@ -316,16 +351,11 @@ func (c *TransportClient) Connect(ctx context.Context) error {
 // setupCommandHandler creates and configures the command handler with all command types.
 // Story #516: connect_dataplane handler removed — DP is initialized eagerly in Connect().
 func (c *TransportClient) setupCommandHandler(ctx context.Context, stewardID string) (*commands.Handler, error) {
-	// Create status callback that publishes events via gRPC control plane provider
+	// Create status callback that publishes events via the offline-queued path
+	// so events are not lost if the controller is temporarily unreachable (Issue #419).
 	statusCallback := func(ctx context.Context, event *cpTypes.Event) {
-		c.mu.RLock()
-		cp := c.controlPlane
-		c.mu.RUnlock()
-
-		if cp != nil {
-			if err := cp.PublishEvent(ctx, event); err != nil {
-				c.logger.Error("Failed to publish status event", "error", err)
-			}
+		if err := c.publishEventWithQueue(ctx, event); err != nil {
+			c.logger.Error("Failed to publish status event", "error", err)
 		}
 	}
 
@@ -571,19 +601,15 @@ func (c *TransportClient) SendHeartbeat(ctx context.Context, status string, metr
 }
 
 // PublishDNAUpdate publishes DNA changes to the controller via the gRPC control plane provider.
+// If the controller is unreachable the event is queued locally and delivered on reconnect (Issue #419).
 func (c *TransportClient) PublishDNAUpdate(ctx context.Context, dna map[string]string, configHash, syncFingerprint string) error {
 	c.mu.RLock()
 	stewardID := c.stewardID
 	tenantID := c.tenantID
-	cp := c.controlPlane
 	c.mu.RUnlock()
 
 	if stewardID == "" {
 		return fmt.Errorf("not registered")
-	}
-
-	if cp == nil {
-		return fmt.Errorf("control plane not connected")
 	}
 
 	event := &cpTypes.Event{
@@ -599,7 +625,7 @@ func (c *TransportClient) PublishDNAUpdate(ctx context.Context, dna map[string]s
 		},
 	}
 
-	if err := cp.PublishEvent(ctx, event); err != nil {
+	if err := c.publishEventWithQueue(ctx, event); err != nil {
 		return fmt.Errorf("failed to publish DNA update: %w", err)
 	}
 
@@ -614,6 +640,7 @@ func (c *TransportClient) publishConfigStatus(report *cpTypes.ConfigStatusReport
 }
 
 // ReportConfigurationStatus reports detailed configuration execution status to the controller.
+// If the controller is unreachable the report is queued locally and delivered on reconnect (Issue #419).
 func (c *TransportClient) ReportConfigurationStatus(
 	ctx context.Context,
 	configVersion string,
@@ -624,15 +651,10 @@ func (c *TransportClient) ReportConfigurationStatus(
 	c.mu.RLock()
 	stewardID := c.stewardID
 	tenantID := c.tenantID
-	cp := c.controlPlane
 	c.mu.RUnlock()
 
 	if stewardID == "" {
 		return fmt.Errorf("not registered")
-	}
-
-	if cp == nil {
-		return fmt.Errorf("control plane not connected")
 	}
 
 	event := &cpTypes.Event{
@@ -649,7 +671,7 @@ func (c *TransportClient) ReportConfigurationStatus(
 		},
 	}
 
-	if err := cp.PublishEvent(ctx, event); err != nil {
+	if err := c.publishEventWithQueue(ctx, event); err != nil {
 		return fmt.Errorf("failed to publish config status: %w", err)
 	}
 
@@ -964,7 +986,66 @@ func (c *TransportClient) createTLSConfig() (*tls.Config, error) {
 	return tlsConfig, nil
 }
 
+// publishEventWithQueue attempts to publish an event via the control plane.
+// If the control plane is unavailable or the publish fails, the event is
+// queued locally for delivery when the connection is restored (Issue #419).
+//
+// Returns nil when the event was either published or queued successfully.
+// Returns an error only when the control plane is unavailable AND no offline
+// queue is configured.
+func (c *TransportClient) publishEventWithQueue(ctx context.Context, event *cpTypes.Event) error {
+	c.mu.RLock()
+	cp := c.controlPlane
+	q := c.offlineQueue
+	c.mu.RUnlock()
+
+	if cp != nil {
+		if err := cp.PublishEvent(ctx, event); err == nil {
+			return nil
+		}
+		// Fall through to queue the event.
+		c.logger.Warn("Failed to publish event to controller, queuing for later delivery",
+			"event_id", event.ID, "event_type", event.Type)
+	}
+
+	if q != nil {
+		if q.Enqueue(event) {
+			c.logger.Info("Event queued for offline delivery",
+				"event_id", event.ID, "event_type", event.Type, "queue_depth", q.Len())
+		}
+		return nil
+	}
+
+	return fmt.Errorf("control plane unavailable and no offline queue configured")
+}
+
+// drainOfflineQueue delivers all queued events to the controller in order.
+// Called immediately after a successful Connect() to resync reports that
+// accumulated during any offline period (Issue #419).
+func (c *TransportClient) drainOfflineQueue(ctx context.Context) {
+	c.mu.RLock()
+	q := c.offlineQueue
+	cp := c.controlPlane
+	c.mu.RUnlock()
+
+	if q == nil || q.Len() == 0 {
+		return
+	}
+
+	depth := q.Len()
+	c.logger.Info("Draining offline event queue after reconnect", "depth", depth)
+
+	delivered := q.Drain(func(event *cpTypes.Event) error {
+		return cp.PublishEvent(ctx, event)
+	})
+
+	c.logger.Info("Offline queue drain complete",
+		"delivered", delivered, "remaining", q.Len())
+}
+
 // startHeartbeat starts the periodic heartbeat goroutine.
+// After each successful heartbeat, any events queued during a transient
+// offline period are drained so the controller receives them promptly (Issue #419).
 func (c *TransportClient) startHeartbeat() {
 	ticker := time.NewTicker(c.heartbeatInterval)
 	defer ticker.Stop()
@@ -977,6 +1058,10 @@ func (c *TransportClient) startHeartbeat() {
 			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 			if err := c.SendHeartbeat(ctx, "healthy", nil); err != nil {
 				c.logger.Warn("Failed to send heartbeat", "error", err)
+			} else {
+				// Heartbeat succeeded — drain any events queued during a
+				// transient disconnect that did not trigger a full reconnect.
+				c.drainOfflineQueue(ctx)
 			}
 			cancel()
 		}

--- a/features/steward/client/offline_queue.go
+++ b/features/steward/client/offline_queue.go
@@ -1,0 +1,270 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+// Package client provides offline report queueing for steward-to-controller reports.
+//
+// Issue #419: when the controller is unreachable, reports are queued locally
+// and delivered in order once connectivity is restored.
+package client
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+
+	cpTypes "github.com/cfgis/cfgms/pkg/controlplane/types"
+	"github.com/cfgis/cfgms/pkg/logging"
+)
+
+// OfflineQueueConfig configures the offline report queue.
+type OfflineQueueConfig struct {
+	// Dir is the directory used for durable persistence of queued events.
+	// If empty the queue is in-memory only — events are lost on restart but
+	// the queue is otherwise fully functional.
+	Dir string
+
+	// MaxSize is the maximum number of events to retain in the queue.
+	// When the queue is full the oldest event is evicted to make room.
+	// Defaults to 1000.
+	MaxSize int
+
+	// MaxAge is the maximum time an event is retained before being discarded.
+	// Defaults to 24 hours.
+	MaxAge time.Duration
+
+	// Logger receives diagnostic messages. May be nil.
+	Logger logging.Logger
+}
+
+// QueuedEvent wraps an event with persistence metadata.
+type QueuedEvent struct {
+	Event     *cpTypes.Event `json:"event"`
+	QueuedAt  time.Time      `json:"queued_at"`
+	ExpiresAt time.Time      `json:"expires_at"`
+	// Sequence is a monotonically increasing counter used to verify ordering
+	// after a load-from-disk round-trip.
+	Sequence int64 `json:"sequence"`
+}
+
+// OfflineQueue persists steward-to-controller events locally while the
+// controller is unreachable and delivers them in order on reconnect.
+//
+// Thread-safe: all public methods can be called from multiple goroutines.
+type OfflineQueue struct {
+	mu      sync.Mutex
+	entries []*QueuedEvent
+	seenIDs map[string]struct{}
+	config  OfflineQueueConfig
+	seq     int64
+}
+
+// queueState is the on-disk format.
+type queueState struct {
+	Entries []*QueuedEvent `json:"entries"`
+	NextSeq int64          `json:"next_seq"`
+}
+
+// NewOfflineQueue creates a new offline queue, applying defaults and loading
+// any events persisted on disk from a previous run.
+func NewOfflineQueue(cfg OfflineQueueConfig) (*OfflineQueue, error) {
+	if cfg.MaxSize <= 0 {
+		cfg.MaxSize = 1000
+	}
+	if cfg.MaxAge <= 0 {
+		cfg.MaxAge = 24 * time.Hour
+	}
+
+	q := &OfflineQueue{
+		seenIDs: make(map[string]struct{}),
+		config:  cfg,
+	}
+
+	if cfg.Dir != "" {
+		if err := q.load(); err != nil {
+			if cfg.Logger != nil {
+				cfg.Logger.Warn("Failed to load offline queue from disk, starting empty",
+					"dir", cfg.Dir, "error", err)
+			}
+		}
+	}
+
+	return q, nil
+}
+
+// Enqueue adds an event to the queue. Returns true if the event was accepted,
+// false if it was rejected (duplicate ID).
+//
+// When the queue is at MaxSize the oldest entry is evicted to make room. This
+// ensures the queue never grows unbounded while still making forward progress.
+func (q *OfflineQueue) Enqueue(event *cpTypes.Event) bool {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+
+	// Deduplication: reject events whose IDs are already present.
+	if _, seen := q.seenIDs[event.ID]; seen {
+		return false
+	}
+
+	// Evict expired entries before checking capacity.
+	q.evictExpiredLocked()
+
+	// If at capacity, drop the oldest event to make room.
+	if len(q.entries) >= q.config.MaxSize {
+		if len(q.entries) > 0 {
+			oldest := q.entries[0]
+			delete(q.seenIDs, oldest.Event.ID)
+			q.entries = q.entries[1:]
+		}
+	}
+
+	q.seq++
+	entry := &QueuedEvent{
+		Event:     event,
+		QueuedAt:  time.Now(),
+		ExpiresAt: time.Now().Add(q.config.MaxAge),
+		Sequence:  q.seq,
+	}
+	q.entries = append(q.entries, entry)
+	q.seenIDs[event.ID] = struct{}{}
+
+	if err := q.saveLocked(); err != nil && q.config.Logger != nil {
+		q.config.Logger.Warn("Failed to persist offline queue to disk after enqueue",
+			"error", err, "queue_depth", len(q.entries))
+	}
+	return true
+}
+
+// Drain calls publishFn for each queued event in insertion order. It stops at
+// the first error to preserve delivery ordering — the failed event and all
+// subsequent events remain in the queue for the next attempt.
+//
+// Returns the number of events successfully delivered.
+func (q *OfflineQueue) Drain(publishFn func(*cpTypes.Event) error) int {
+	delivered := 0
+
+	for {
+		// Peek at the head of queue under the lock.
+		q.mu.Lock()
+		q.evictExpiredLocked()
+		if len(q.entries) == 0 {
+			q.mu.Unlock()
+			break
+		}
+		entry := q.entries[0]
+		q.mu.Unlock()
+
+		// Call publishFn outside the lock — it may block.
+		if err := publishFn(entry.Event); err != nil {
+			// Stop on first failure to maintain strict ordering.
+			break
+		}
+
+		// Remove the successfully delivered entry.
+		q.mu.Lock()
+		// Re-verify the head is still the same entry (concurrent drain safety).
+		if len(q.entries) > 0 && q.entries[0].Sequence == entry.Sequence {
+			delete(q.seenIDs, q.entries[0].Event.ID)
+			q.entries = q.entries[1:]
+			if err := q.saveLocked(); err != nil && q.config.Logger != nil {
+				q.config.Logger.Warn("Failed to persist offline queue to disk after drain",
+					"error", err, "queue_depth", len(q.entries))
+			}
+		}
+		q.mu.Unlock()
+
+		delivered++
+	}
+
+	return delivered
+}
+
+// Len returns the number of events currently in the queue.
+func (q *OfflineQueue) Len() int {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	return len(q.entries)
+}
+
+// evictExpiredLocked removes entries whose ExpiresAt is in the past.
+// Must be called with q.mu held.
+func (q *OfflineQueue) evictExpiredLocked() {
+	now := time.Now()
+	valid := q.entries[:0]
+	for _, e := range q.entries {
+		if e.ExpiresAt.After(now) {
+			valid = append(valid, e)
+		} else {
+			delete(q.seenIDs, e.Event.ID)
+		}
+	}
+	q.entries = valid
+}
+
+// queueFilePath returns the path of the persistence file.
+func (q *OfflineQueue) queueFilePath() string {
+	return filepath.Join(q.config.Dir, "offline_queue.json")
+}
+
+// saveLocked writes the current queue state to disk atomically.
+// Must be called with q.mu held.
+// A no-op when Dir is empty (in-memory mode).
+func (q *OfflineQueue) saveLocked() error {
+	if q.config.Dir == "" {
+		return nil
+	}
+
+	if err := os.MkdirAll(q.config.Dir, 0700); err != nil {
+		return err
+	}
+
+	state := &queueState{
+		Entries: q.entries,
+		NextSeq: q.seq,
+	}
+	data, err := json.Marshal(state)
+	if err != nil {
+		return err
+	}
+
+	// Atomic write: write to .tmp then rename so readers never see partial state.
+	tmpPath := q.queueFilePath() + ".tmp"
+	if err := os.WriteFile(tmpPath, data, 0600); err != nil {
+		return err
+	}
+	return os.Rename(tmpPath, q.queueFilePath())
+}
+
+// load reads persisted queue state from disk, filtering out expired entries.
+// Called once from NewOfflineQueue before the queue is used by any goroutine,
+// so no locking is required.
+func (q *OfflineQueue) load() error {
+	data, err := os.ReadFile(q.queueFilePath())
+	if os.IsNotExist(err) {
+		return nil // No file yet — start with an empty queue.
+	}
+	if err != nil {
+		return err
+	}
+
+	var state queueState
+	if err := json.Unmarshal(data, &state); err != nil {
+		return err
+	}
+
+	now := time.Now()
+	q.seq = state.NextSeq
+
+	for _, entry := range state.Entries {
+		if entry == nil || entry.Event == nil {
+			continue
+		}
+		if !entry.ExpiresAt.After(now) {
+			continue // Expired during downtime — discard.
+		}
+		q.entries = append(q.entries, entry)
+		q.seenIDs[entry.Event.ID] = struct{}{}
+	}
+
+	return nil
+}

--- a/features/steward/client/offline_queue_test.go
+++ b/features/steward/client/offline_queue_test.go
@@ -1,0 +1,519 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+// Package client provides tests for offline report queueing.
+// Issue #419: steward queues reports locally when controller is unreachable.
+package client
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	controlplaneInterfaces "github.com/cfgis/cfgms/pkg/controlplane/interfaces"
+	cpTypes "github.com/cfgis/cfgms/pkg/controlplane/types"
+	"github.com/cfgis/cfgms/pkg/logging"
+)
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+func makeTestEvent(id string, eventType cpTypes.EventType) *cpTypes.Event {
+	return &cpTypes.Event{
+		ID:        id,
+		Type:      eventType,
+		StewardID: "test-steward-001",
+		TenantID:  "test-tenant",
+		Timestamp: time.Now(),
+		Details:   map[string]interface{}{"test": "data"},
+	}
+}
+
+// noopControlPlane is a minimal real implementation of ControlPlaneProvider
+// that satisfies the interface without performing any network operations.
+// Embed in test-specific providers to override only the methods you need.
+type noopControlPlane struct{}
+
+func (n *noopControlPlane) Name() string        { return "noop" }
+func (n *noopControlPlane) Description() string { return "noop test provider" }
+func (n *noopControlPlane) Initialize(_ context.Context, _ map[string]interface{}) error {
+	return nil
+}
+func (n *noopControlPlane) Start(_ context.Context) error { return nil }
+func (n *noopControlPlane) Stop(_ context.Context) error  { return nil }
+func (n *noopControlPlane) SendCommand(_ context.Context, _ *cpTypes.Command) error { return nil }
+func (n *noopControlPlane) FanOutCommand(_ context.Context, _ *cpTypes.Command, ids []string) (*cpTypes.FanOutResult, error) {
+	return &cpTypes.FanOutResult{Succeeded: ids, Failed: make(map[string]error)}, nil
+}
+func (n *noopControlPlane) SubscribeCommands(_ context.Context, _ string, _ controlplaneInterfaces.CommandHandler) error {
+	return nil
+}
+func (n *noopControlPlane) PublishEvent(_ context.Context, _ *cpTypes.Event) error { return nil }
+func (n *noopControlPlane) SubscribeEvents(_ context.Context, _ *cpTypes.EventFilter, _ controlplaneInterfaces.EventHandler) error {
+	return nil
+}
+func (n *noopControlPlane) SendHeartbeat(_ context.Context, _ *cpTypes.Heartbeat) error { return nil }
+func (n *noopControlPlane) SubscribeHeartbeats(_ context.Context, _ controlplaneInterfaces.HeartbeatHandler) error {
+	return nil
+}
+func (n *noopControlPlane) SendResponse(_ context.Context, _ *cpTypes.Response) error { return nil }
+func (n *noopControlPlane) WaitForResponse(_ context.Context, _ string, _ time.Duration) (*cpTypes.Response, error) {
+	return nil, nil
+}
+func (n *noopControlPlane) GetStats(_ context.Context) (*cpTypes.ControlPlaneStats, error) {
+	return &cpTypes.ControlPlaneStats{}, nil
+}
+func (n *noopControlPlane) Available() (bool, error) { return true, nil }
+func (n *noopControlPlane) IsConnected() bool        { return false }
+
+// failingControlPlane always returns publishErr from PublishEvent.
+type failingControlPlane struct {
+	noopControlPlane
+	publishErr error
+}
+
+func (f *failingControlPlane) PublishEvent(_ context.Context, _ *cpTypes.Event) error {
+	return f.publishErr
+}
+
+// recordingControlPlane records every published event successfully.
+type recordingControlPlane struct {
+	noopControlPlane
+	published []*cpTypes.Event
+}
+
+func (r *recordingControlPlane) PublishEvent(_ context.Context, e *cpTypes.Event) error {
+	r.published = append(r.published, e)
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// OfflineQueue unit tests
+// ---------------------------------------------------------------------------
+
+func TestOfflineQueue_BasicEnqueue(t *testing.T) {
+	q, err := NewOfflineQueue(OfflineQueueConfig{
+		Dir:     t.TempDir(),
+		MaxSize: 10,
+		MaxAge:  time.Hour,
+	})
+	require.NoError(t, err)
+
+	evt := makeTestEvent("evt-001", cpTypes.EventConfigApplied)
+	accepted := q.Enqueue(evt)
+	assert.True(t, accepted, "new event should be accepted")
+	assert.Equal(t, 1, q.Len())
+}
+
+func TestOfflineQueue_DrainOrderedDelivery(t *testing.T) {
+	q, err := NewOfflineQueue(OfflineQueueConfig{
+		Dir:     t.TempDir(),
+		MaxSize: 20,
+		MaxAge:  time.Hour,
+	})
+	require.NoError(t, err)
+
+	ids := []string{"evt-001", "evt-002", "evt-003", "evt-004"}
+	for _, id := range ids {
+		q.Enqueue(makeTestEvent(id, cpTypes.EventConfigApplied))
+	}
+	assert.Equal(t, 4, q.Len())
+
+	var received []string
+	delivered := q.Drain(func(e *cpTypes.Event) error {
+		received = append(received, e.ID)
+		return nil
+	})
+
+	assert.Equal(t, 4, delivered, "all 4 events should be delivered")
+	assert.Equal(t, 0, q.Len(), "queue should be empty after drain")
+	assert.Equal(t, ids, received, "events must be delivered in insertion order")
+}
+
+func TestOfflineQueue_DrainStopsOnFirstFailure(t *testing.T) {
+	q, err := NewOfflineQueue(OfflineQueueConfig{
+		Dir:     t.TempDir(),
+		MaxSize: 20,
+		MaxAge:  time.Hour,
+	})
+	require.NoError(t, err)
+
+	for i := 1; i <= 5; i++ {
+		q.Enqueue(makeTestEvent(fmt.Sprintf("evt-%03d", i), cpTypes.EventDNAChanged))
+	}
+
+	callCount := 0
+	delivered := q.Drain(func(e *cpTypes.Event) error {
+		callCount++
+		if callCount >= 3 {
+			return errors.New("simulated network error")
+		}
+		return nil
+	})
+
+	assert.Equal(t, 2, delivered, "first 2 events should be delivered before failure")
+	assert.Equal(t, 3, q.Len(), "3 un-delivered events should remain")
+}
+
+func TestOfflineQueue_DrainEmptyQueue(t *testing.T) {
+	q, err := NewOfflineQueue(OfflineQueueConfig{
+		Dir:     t.TempDir(),
+		MaxSize: 10,
+		MaxAge:  time.Hour,
+	})
+	require.NoError(t, err)
+
+	delivered := q.Drain(func(e *cpTypes.Event) error { return nil })
+	assert.Equal(t, 0, delivered)
+	assert.Equal(t, 0, q.Len())
+}
+
+func TestOfflineQueue_PersistenceAcrossRestart(t *testing.T) {
+	dir := t.TempDir()
+
+	// First instance — enqueue three events.
+	q1, err := NewOfflineQueue(OfflineQueueConfig{Dir: dir, MaxSize: 10, MaxAge: time.Hour})
+	require.NoError(t, err)
+	q1.Enqueue(makeTestEvent("evt-001", cpTypes.EventConfigApplied))
+	q1.Enqueue(makeTestEvent("evt-002", cpTypes.EventDNAChanged))
+	q1.Enqueue(makeTestEvent("evt-003", cpTypes.EventError))
+	assert.Equal(t, 3, q1.Len())
+
+	// Second instance simulates a restart from the same directory.
+	q2, err := NewOfflineQueue(OfflineQueueConfig{Dir: dir, MaxSize: 10, MaxAge: time.Hour})
+	require.NoError(t, err)
+	assert.Equal(t, 3, q2.Len(), "events must survive restart")
+
+	var ids []string
+	q2.Drain(func(e *cpTypes.Event) error {
+		ids = append(ids, e.ID)
+		return nil
+	})
+	assert.Equal(t, []string{"evt-001", "evt-002", "evt-003"}, ids)
+}
+
+func TestOfflineQueue_PersistencePartialDrainThenRestart(t *testing.T) {
+	dir := t.TempDir()
+
+	q1, err := NewOfflineQueue(OfflineQueueConfig{Dir: dir, MaxSize: 10, MaxAge: time.Hour})
+	require.NoError(t, err)
+	for i := 1; i <= 4; i++ {
+		q1.Enqueue(makeTestEvent(fmt.Sprintf("evt-%03d", i), cpTypes.EventConfigApplied))
+	}
+
+	// Deliver only the first two events.
+	calls := 0
+	q1.Drain(func(e *cpTypes.Event) error {
+		calls++
+		if calls > 2 {
+			return errors.New("stop here")
+		}
+		return nil
+	})
+	assert.Equal(t, 2, q1.Len())
+
+	// Restart: only the remaining 2 events should be present.
+	q2, err := NewOfflineQueue(OfflineQueueConfig{Dir: dir, MaxSize: 10, MaxAge: time.Hour})
+	require.NoError(t, err)
+	assert.Equal(t, 2, q2.Len())
+
+	var ids []string
+	q2.Drain(func(e *cpTypes.Event) error {
+		ids = append(ids, e.ID)
+		return nil
+	})
+	assert.Equal(t, []string{"evt-003", "evt-004"}, ids)
+}
+
+func TestOfflineQueue_Deduplication(t *testing.T) {
+	q, err := NewOfflineQueue(OfflineQueueConfig{
+		Dir:     t.TempDir(),
+		MaxSize: 10,
+		MaxAge:  time.Hour,
+	})
+	require.NoError(t, err)
+
+	evt := makeTestEvent("evt-dup", cpTypes.EventConfigApplied)
+
+	accepted1 := q.Enqueue(evt)
+	accepted2 := q.Enqueue(evt) // Same ID
+	assert.True(t, accepted1, "first enqueue should be accepted")
+	assert.False(t, accepted2, "duplicate ID should be rejected")
+	assert.Equal(t, 1, q.Len(), "only one entry should be in queue")
+}
+
+func TestOfflineQueue_MaxSizeEvictsOldest(t *testing.T) {
+	q, err := NewOfflineQueue(OfflineQueueConfig{
+		Dir:     t.TempDir(),
+		MaxSize: 3,
+		MaxAge:  time.Hour,
+	})
+	require.NoError(t, err)
+
+	q.Enqueue(makeTestEvent("evt-001", cpTypes.EventConfigApplied))
+	q.Enqueue(makeTestEvent("evt-002", cpTypes.EventConfigApplied))
+	q.Enqueue(makeTestEvent("evt-003", cpTypes.EventConfigApplied))
+	assert.Equal(t, 3, q.Len())
+
+	// This should evict evt-001 to make room.
+	q.Enqueue(makeTestEvent("evt-004", cpTypes.EventConfigApplied))
+	assert.Equal(t, 3, q.Len(), "queue must not exceed MaxSize")
+
+	var ids []string
+	q.Drain(func(e *cpTypes.Event) error {
+		ids = append(ids, e.ID)
+		return nil
+	})
+	assert.Equal(t, []string{"evt-002", "evt-003", "evt-004"}, ids, "oldest event evicted")
+}
+
+func TestOfflineQueue_MaxSizeDefaultsTo1000(t *testing.T) {
+	q, err := NewOfflineQueue(OfflineQueueConfig{
+		Dir:    t.TempDir(),
+		MaxAge: time.Hour,
+		// MaxSize intentionally omitted — should default to 1000.
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 1000, q.config.MaxSize)
+}
+
+func TestOfflineQueue_MaxAgeDefaultsTo24Hours(t *testing.T) {
+	q, err := NewOfflineQueue(OfflineQueueConfig{
+		Dir:     t.TempDir(),
+		MaxSize: 10,
+		// MaxAge intentionally omitted — should default to 24h.
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 24*time.Hour, q.config.MaxAge)
+}
+
+// TestOfflineQueue_ExpiresOldEntries verifies that entries past their ExpiresAt
+// are silently dropped during Drain. It directly injects an already-expired
+// entry into the queue's internal state (same package access) to avoid any
+// time.Sleep — making the test deterministic and instant.
+func TestOfflineQueue_ExpiresOldEntries(t *testing.T) {
+	q, err := NewOfflineQueue(OfflineQueueConfig{
+		Dir:     t.TempDir(),
+		MaxSize: 10,
+		MaxAge:  time.Hour,
+	})
+	require.NoError(t, err)
+
+	// Inject an already-expired entry directly (no sleep needed).
+	past := time.Now().Add(-time.Hour)
+	expiredEntry := &QueuedEvent{
+		Event:     makeTestEvent("evt-old", cpTypes.EventConfigApplied),
+		QueuedAt:  past,
+		ExpiresAt: past,
+		Sequence:  1,
+	}
+	q.mu.Lock()
+	q.entries = append(q.entries, expiredEntry)
+	q.seenIDs[expiredEntry.Event.ID] = struct{}{}
+	q.seq = 1
+	q.mu.Unlock()
+
+	// Add a fresh event via the normal Enqueue path.
+	q.Enqueue(makeTestEvent("evt-fresh", cpTypes.EventConfigApplied))
+
+	var ids []string
+	q.Drain(func(e *cpTypes.Event) error {
+		ids = append(ids, e.ID)
+		return nil
+	})
+
+	assert.NotContains(t, ids, "evt-old", "expired event must not be delivered")
+	assert.Contains(t, ids, "evt-fresh", "non-expired event must be delivered")
+}
+
+func TestOfflineQueue_InMemoryFallback(t *testing.T) {
+	// Dir intentionally empty — in-memory only (events lost on restart but
+	// otherwise fully functional).
+	q, err := NewOfflineQueue(OfflineQueueConfig{
+		MaxSize: 5,
+		MaxAge:  time.Hour,
+	})
+	require.NoError(t, err)
+
+	q.Enqueue(makeTestEvent("evt-mem-001", cpTypes.EventDNAChanged))
+	q.Enqueue(makeTestEvent("evt-mem-002", cpTypes.EventDNAChanged))
+	assert.Equal(t, 2, q.Len())
+
+	var ids []string
+	q.Drain(func(e *cpTypes.Event) error {
+		ids = append(ids, e.ID)
+		return nil
+	})
+	assert.Equal(t, []string{"evt-mem-001", "evt-mem-002"}, ids)
+	assert.Equal(t, 0, q.Len())
+}
+
+func TestOfflineQueue_QueueFileAtomicWrite(t *testing.T) {
+	dir := t.TempDir()
+	q, err := NewOfflineQueue(OfflineQueueConfig{Dir: dir, MaxSize: 10, MaxAge: time.Hour})
+	require.NoError(t, err)
+
+	q.Enqueue(makeTestEvent("evt-001", cpTypes.EventConfigApplied))
+
+	// The .tmp file must not exist after enqueue (atomic rename completed).
+	assert.FileExists(t, filepath.Join(dir, "offline_queue.json"))
+	assert.NoFileExists(t, filepath.Join(dir, "offline_queue.json.tmp"),
+		".tmp file must be cleaned up after atomic rename")
+}
+
+func TestOfflineQueue_ConcurrentEnqueueDrain(t *testing.T) {
+	q, err := NewOfflineQueue(OfflineQueueConfig{
+		Dir:     t.TempDir(),
+		MaxSize: 100,
+		MaxAge:  time.Hour,
+	})
+	require.NoError(t, err)
+
+	done := make(chan struct{})
+
+	// Producer: enqueue 50 events.
+	go func() {
+		for i := 0; i < 50; i++ {
+			q.Enqueue(makeTestEvent(fmt.Sprintf("concurrent-%03d", i), cpTypes.EventConfigApplied))
+		}
+		close(done)
+	}()
+
+	// Consumer: continuously drain until producer finishes.
+	for {
+		select {
+		case <-done:
+			// Final drain.
+			q.Drain(func(e *cpTypes.Event) error { return nil })
+			goto finished
+		default:
+			q.Drain(func(e *cpTypes.Event) error { return nil })
+		}
+	}
+finished:
+	assert.Equal(t, 0, q.Len(), "queue should be empty after all drains")
+}
+
+// ---------------------------------------------------------------------------
+// Integration tests: publishEventWithQueue behaviour
+// ---------------------------------------------------------------------------
+
+func TestPublishEventWithQueue_QueuesWhenCPNil(t *testing.T) {
+	q, err := NewOfflineQueue(OfflineQueueConfig{
+		Dir:     t.TempDir(),
+		MaxSize: 10,
+		MaxAge:  time.Hour,
+	})
+	require.NoError(t, err)
+
+	c := &TransportClient{
+		offlineQueue: q,
+		logger:       logging.NewLogger("info"),
+		stewardID:    "s-001",
+		tenantID:     "tenant-001",
+		// controlPlane is nil — simulates not-yet-connected state.
+	}
+
+	evt := makeTestEvent("evt-cp-nil", cpTypes.EventConfigApplied)
+	err = c.publishEventWithQueue(context.Background(), evt)
+	require.NoError(t, err, "must not return error when event is queued")
+	assert.Equal(t, 1, q.Len(), "event must be in queue")
+}
+
+func TestPublishEventWithQueue_QueuesOnPublishError(t *testing.T) {
+	q, err := NewOfflineQueue(OfflineQueueConfig{
+		Dir:     t.TempDir(),
+		MaxSize: 10,
+		MaxAge:  time.Hour,
+	})
+	require.NoError(t, err)
+
+	cp := &failingControlPlane{publishErr: errors.New("connection refused")}
+	c := &TransportClient{
+		controlPlane: cp,
+		offlineQueue: q,
+		logger:       logging.NewLogger("info"),
+		stewardID:    "s-001",
+		tenantID:     "tenant-001",
+	}
+
+	evt := makeTestEvent("evt-cp-fail", cpTypes.EventDNAChanged)
+	err = c.publishEventWithQueue(context.Background(), evt)
+	require.NoError(t, err, "must not return error when event is queued")
+	assert.Equal(t, 1, q.Len(), "event must be in queue after publish failure")
+}
+
+func TestPublishEventWithQueue_NoQueueAndCPFails(t *testing.T) {
+	cp := &failingControlPlane{publishErr: errors.New("connection refused")}
+	c := &TransportClient{
+		controlPlane: cp,
+		offlineQueue: nil, // No queue configured.
+		logger:       logging.NewLogger("info"),
+		stewardID:    "s-001",
+		tenantID:     "tenant-001",
+	}
+
+	evt := makeTestEvent("evt-no-q", cpTypes.EventError)
+	err := c.publishEventWithQueue(context.Background(), evt)
+	assert.Error(t, err, "must return error when there is no queue and CP fails")
+}
+
+func TestPublishEventWithQueue_SuccessDoesNotQueue(t *testing.T) {
+	q, err := NewOfflineQueue(OfflineQueueConfig{
+		Dir:     t.TempDir(),
+		MaxSize: 10,
+		MaxAge:  time.Hour,
+	})
+	require.NoError(t, err)
+
+	cp := &recordingControlPlane{}
+	c := &TransportClient{
+		controlPlane: cp,
+		offlineQueue: q,
+		logger:       logging.NewLogger("info"),
+		stewardID:    "s-001",
+		tenantID:     "tenant-001",
+	}
+
+	evt := makeTestEvent("evt-ok", cpTypes.EventConfigApplied)
+	err = c.publishEventWithQueue(context.Background(), evt)
+	require.NoError(t, err)
+	assert.Equal(t, 0, q.Len(), "successful publish must not add to queue")
+	assert.Len(t, cp.published, 1, "event must be published to CP")
+}
+
+// TestPublishEventWithQueue_DrainedOnReconnect verifies that after connecting
+// with a pre-populated offline queue the events are drained immediately.
+func TestPublishEventWithQueue_DrainedOnReconnect(t *testing.T) {
+	dir := t.TempDir()
+
+	// Pre-populate the queue (simulates events queued during offline period).
+	q, err := NewOfflineQueue(OfflineQueueConfig{Dir: dir, MaxSize: 10, MaxAge: time.Hour})
+	require.NoError(t, err)
+	q.Enqueue(makeTestEvent("queued-001", cpTypes.EventConfigApplied))
+	q.Enqueue(makeTestEvent("queued-002", cpTypes.EventDNAChanged))
+	require.Equal(t, 2, q.Len())
+
+	cp := &recordingControlPlane{}
+
+	// drainOfflineQueue should publish all queued events via the CP.
+	c := &TransportClient{
+		controlPlane: cp,
+		offlineQueue: q,
+		logger:       logging.NewLogger("info"),
+		stewardID:    "s-001",
+		tenantID:     "tenant-001",
+	}
+	c.drainOfflineQueue(context.Background())
+
+	assert.Equal(t, 0, q.Len(), "queue must be empty after drain")
+	assert.Len(t, cp.published, 2, "both queued events must be published")
+	assert.Equal(t, "queued-001", cp.published[0].ID, "events delivered in order")
+	assert.Equal(t, "queued-002", cp.published[1].ID, "events delivered in order")
+}


### PR DESCRIPTION
## Summary

- Adds `OfflineQueue` — a file-backed, bounded FIFO queue that persists steward events when the controller is unreachable
- Integrates queue into `TransportClient` via `publishEventWithQueue`: all three event-publishing callsites now queue on failure instead of discarding
- Events are delivered in order on reconnect (both after full `Connect()` and after a successful heartbeat for transient disconnects)

## Changes

**New files:**
- `features/steward/client/offline_queue.go` — queue implementation (atomic writes, deduplication, MaxSize eviction, MaxAge expiry, persistence across restart, in-memory fallback)
- `features/steward/client/offline_queue_test.go` — 19 tests covering all acceptance criteria

**Modified:**
- `features/steward/client/client_transport.go` — wires queue into `TransportClient`, updates all `PublishEvent` callsites, drains queue on reconnect and successful heartbeat

## Acceptance Criteria

- [x] Reports queued locally when controller is unreachable
- [x] Queue persists across steward restarts (`QueueDir` → `offline_queue.json`, atomic writes)
- [x] Queued reports delivered in order on reconnect (`Drain` stops at first failure)
- [x] Configurable queue size/retention limits (`MaxQueueSize`, `MaxQueueAge` in `TransportConfig`)
- [x] All existing tests pass

## Specialist Review Results

| Reviewer | Result |
|----------|--------|
| QA Test Runner | **PASS** — all 19 new tests + all existing steward tests pass; cross-platform builds pass |
| QA Code Reviewer | **PASS** — after fixing: (1) silent `saveLocked()` error discards now logged; (2) `time.Sleep` replaced with deterministic expired-entry injection |
| Security Engineer | **PASS** — no blocking issues; file permissions `0700`/`0600`, atomic writes, no secrets in event logs, no central provider violations |

Fixes #419