### PR TITLE
config: implement ConfigSourceRouter for per-tenant config source routing (Issue #555)

### DIFF
--- a/pkg/config/config_source_router.go
+++ b/pkg/config/config_source_router.go
@@ -1,0 +1,211 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+// Package config provides configuration management including per-tenant config source routing.
+package config
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/cfgis/cfgms/pkg/storage/interfaces"
+)
+
+// Well-known metadata keys used in TenantData.Metadata to declare config source routing.
+// A tenant that does not declare a source inherits from its nearest ancestor that does.
+// The root tenant defaults to ConfigSourceTypeController when no metadata is set.
+const (
+	// MetadataKeyConfigSourceType is "controller" (default) or "git".
+	MetadataKeyConfigSourceType = "config_source_type"
+	// MetadataKeyConfigSourceURL is the remote URL for a git source.
+	MetadataKeyConfigSourceURL = "config_source_url"
+	// MetadataKeyConfigSourceBranch is the branch to check out (git sources only).
+	MetadataKeyConfigSourceBranch = "config_source_branch"
+	// MetadataKeyConfigSourcePath is an optional sub-directory within the repository.
+	MetadataKeyConfigSourcePath = "config_source_path"
+	// MetadataKeyConfigSourceCredential references a secret for authentication.
+	MetadataKeyConfigSourceCredential = "config_source_credential"
+	// MetadataKeyConfigSourcePollInterval controls how often to sync from git (e.g. "5m").
+	MetadataKeyConfigSourcePollInterval = "config_source_poll_interval"
+)
+
+// Config source type values.
+const (
+	// ConfigSourceTypeController routes config fetches to the controller's storage provider.
+	// This is the default for all tenants and is backward compatible.
+	ConfigSourceTypeController = "controller"
+	// ConfigSourceTypeGit routes config fetches to an external git repository.
+	// External git integration is implemented in Phase 2 (separate story).
+	ConfigSourceTypeGit = "git"
+)
+
+// ConfigSourceInfo holds the resolved config source for a tenant.
+type ConfigSourceInfo struct {
+	// TenantID is the tenant this info was resolved for.
+	TenantID string
+	// SourceType is ConfigSourceTypeController or ConfigSourceTypeGit.
+	SourceType string
+	// URL is the remote URL (git sources only).
+	URL string
+	// Branch is the git branch (git sources only).
+	Branch string
+	// Path is the optional sub-directory within the repository (git sources only).
+	Path string
+	// Credential is a secret reference for authentication (git sources only).
+	Credential string
+	// PollInterval is the sync frequency as a duration string (git sources only).
+	PollInterval string
+	// InheritedFrom is the ancestor tenant ID this source was inherited from.
+	// Empty when the tenant declares its own source.
+	InheritedFrom string
+}
+
+// ConfigSourceRouter implements interfaces.ConfigStore and routes each config
+// operation to the appropriate per-tenant store.
+//
+// Phase 1 behavior: all tenants route to the controller's default store.
+// Routing metadata is read and resolved so that callers can inspect the
+// declared source, but the actual storage backend does not change until
+// Phase 2 (external git integration).
+//
+// The router sits between InheritanceResolver and ConfigStore:
+//
+//	InheritanceResolver → ConfigSourceRouter → ConfigStore (per-tenant)
+type ConfigSourceRouter struct {
+	// defaultStore is the controller's storage provider, used for all phase-1 routing.
+	defaultStore interfaces.ConfigStore
+	// tenantStore resolves tenant metadata and hierarchy paths.
+	tenantStore interfaces.TenantStore
+}
+
+// NewConfigSourceRouter creates a ConfigSourceRouter backed by defaultStore.
+// All config operations are forwarded to defaultStore until Phase 2 adds
+// external git backing stores.
+func NewConfigSourceRouter(defaultStore interfaces.ConfigStore, tenantStore interfaces.TenantStore) *ConfigSourceRouter {
+	return &ConfigSourceRouter{
+		defaultStore: defaultStore,
+		tenantStore:  tenantStore,
+	}
+}
+
+// GetEffectiveConfigSource resolves the config source for tenantID by walking
+// up the tenant hierarchy until an explicit source declaration is found.
+// If no ancestor declares a source the function returns the controller default.
+//
+// Inheritance rules (nearest-ancestor wins):
+//  1. Tenant owns MetadataKeyConfigSourceType → use it, InheritedFrom=""
+//  2. Walk parent chain root-ward; first ancestor with the key wins
+//  3. No ancestor → return ConfigSourceTypeController, InheritedFrom=""
+func (r *ConfigSourceRouter) GetEffectiveConfigSource(ctx context.Context, tenantID string) (*ConfigSourceInfo, error) {
+	// Verify the tenant exists first so we surface a clear error for unknown IDs.
+	if _, err := r.tenantStore.GetTenant(ctx, tenantID); err != nil {
+		return nil, fmt.Errorf("tenant %q not found: %w", tenantID, err)
+	}
+
+	// GetTenantPath returns [root, …, tenantID] (root-first ordering).
+	path, err := r.tenantStore.GetTenantPath(ctx, tenantID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve tenant path for %q: %w", tenantID, err)
+	}
+
+	// Walk from the target tenant upward (leaf → root) to find the nearest
+	// ancestor that declares a config source.
+	for i := len(path) - 1; i >= 0; i-- {
+		ancestor := path[i]
+		tenant, err := r.tenantStore.GetTenant(ctx, ancestor)
+		if err != nil {
+			// Ancestor disappeared mid-walk; skip gracefully.
+			continue
+		}
+		sourceType, ok := tenant.Metadata[MetadataKeyConfigSourceType]
+		if !ok || sourceType == "" {
+			continue
+		}
+
+		info := &ConfigSourceInfo{
+			TenantID:     tenantID,
+			SourceType:   sourceType,
+			URL:          tenant.Metadata[MetadataKeyConfigSourceURL],
+			Branch:       tenant.Metadata[MetadataKeyConfigSourceBranch],
+			Path:         tenant.Metadata[MetadataKeyConfigSourcePath],
+			Credential:   tenant.Metadata[MetadataKeyConfigSourceCredential],
+			PollInterval: tenant.Metadata[MetadataKeyConfigSourcePollInterval],
+		}
+		if ancestor != tenantID {
+			info.InheritedFrom = ancestor
+		}
+		return info, nil
+	}
+
+	// No ancestor declared a source: default to controller.
+	return &ConfigSourceInfo{
+		TenantID:   tenantID,
+		SourceType: ConfigSourceTypeController,
+	}, nil
+}
+
+// storeFor returns the ConfigStore to use for the given tenantID.
+// In Phase 1 this always returns the default store.
+// Phase 2 will swap in a git-backed store when the effective source is "git".
+func (r *ConfigSourceRouter) storeFor(_ context.Context, _ string) interfaces.ConfigStore {
+	// Phase 1: always use the default (controller) store.
+	return r.defaultStore
+}
+
+// -----------------------------------------------------------------------
+// interfaces.ConfigStore implementation — all methods delegate to storeFor.
+// -----------------------------------------------------------------------
+
+func (r *ConfigSourceRouter) StoreConfig(ctx context.Context, config *interfaces.ConfigEntry) error {
+	return r.storeFor(ctx, config.Key.TenantID).StoreConfig(ctx, config)
+}
+
+func (r *ConfigSourceRouter) GetConfig(ctx context.Context, key *interfaces.ConfigKey) (*interfaces.ConfigEntry, error) {
+	return r.storeFor(ctx, key.TenantID).GetConfig(ctx, key)
+}
+
+func (r *ConfigSourceRouter) DeleteConfig(ctx context.Context, key *interfaces.ConfigKey) error {
+	return r.storeFor(ctx, key.TenantID).DeleteConfig(ctx, key)
+}
+
+func (r *ConfigSourceRouter) ListConfigs(ctx context.Context, filter *interfaces.ConfigFilter) ([]*interfaces.ConfigEntry, error) {
+	return r.storeFor(ctx, filter.TenantID).ListConfigs(ctx, filter)
+}
+
+func (r *ConfigSourceRouter) GetConfigHistory(ctx context.Context, key *interfaces.ConfigKey, limit int) ([]*interfaces.ConfigEntry, error) {
+	return r.storeFor(ctx, key.TenantID).GetConfigHistory(ctx, key, limit)
+}
+
+func (r *ConfigSourceRouter) GetConfigVersion(ctx context.Context, key *interfaces.ConfigKey, version int64) (*interfaces.ConfigEntry, error) {
+	return r.storeFor(ctx, key.TenantID).GetConfigVersion(ctx, key, version)
+}
+
+func (r *ConfigSourceRouter) StoreConfigBatch(ctx context.Context, configs []*interfaces.ConfigEntry) error {
+	if len(configs) == 0 {
+		return nil
+	}
+	// All entries in a batch share the same effective store for Phase 1.
+	return r.storeFor(ctx, configs[0].Key.TenantID).StoreConfigBatch(ctx, configs)
+}
+
+func (r *ConfigSourceRouter) DeleteConfigBatch(ctx context.Context, keys []*interfaces.ConfigKey) error {
+	if len(keys) == 0 {
+		return nil
+	}
+	return r.storeFor(ctx, keys[0].TenantID).DeleteConfigBatch(ctx, keys)
+}
+
+func (r *ConfigSourceRouter) ResolveConfigWithInheritance(ctx context.Context, key *interfaces.ConfigKey) (*interfaces.ConfigEntry, error) {
+	return r.storeFor(ctx, key.TenantID).ResolveConfigWithInheritance(ctx, key)
+}
+
+func (r *ConfigSourceRouter) ValidateConfig(ctx context.Context, config *interfaces.ConfigEntry) error {
+	tenantID := ""
+	if config.Key != nil {
+		tenantID = config.Key.TenantID
+	}
+	return r.storeFor(ctx, tenantID).ValidateConfig(ctx, config)
+}
+
+func (r *ConfigSourceRouter) GetConfigStats(ctx context.Context) (*interfaces.ConfigStats, error) {
+	return r.defaultStore.GetConfigStats(ctx)
+}

--- a/pkg/config/config_source_router_test.go
+++ b/pkg/config/config_source_router_test.go
@@ -1,0 +1,542 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+package config
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cfgis/cfgms/pkg/storage/interfaces"
+)
+
+// inMemoryTenantStore is a minimal in-memory TenantStore for testing
+type inMemoryTenantStore struct {
+	tenants map[string]*interfaces.TenantData
+}
+
+func newInMemoryTenantStore() *inMemoryTenantStore {
+	return &inMemoryTenantStore{
+		tenants: make(map[string]*interfaces.TenantData),
+	}
+}
+
+func (s *inMemoryTenantStore) CreateTenant(_ context.Context, tenant *interfaces.TenantData) error {
+	s.tenants[tenant.ID] = tenant
+	return nil
+}
+
+func (s *inMemoryTenantStore) GetTenant(_ context.Context, tenantID string) (*interfaces.TenantData, error) {
+	t, ok := s.tenants[tenantID]
+	if !ok {
+		return nil, &interfaces.ConfigValidationError{Field: "tenant_id", Message: "tenant not found", Code: "TENANT_NOT_FOUND"}
+	}
+	return t, nil
+}
+
+func (s *inMemoryTenantStore) UpdateTenant(_ context.Context, tenant *interfaces.TenantData) error {
+	s.tenants[tenant.ID] = tenant
+	return nil
+}
+
+func (s *inMemoryTenantStore) DeleteTenant(_ context.Context, tenantID string) error {
+	delete(s.tenants, tenantID)
+	return nil
+}
+
+func (s *inMemoryTenantStore) ListTenants(_ context.Context, _ *interfaces.TenantFilter) ([]*interfaces.TenantData, error) {
+	var result []*interfaces.TenantData
+	for _, t := range s.tenants {
+		result = append(result, t)
+	}
+	return result, nil
+}
+
+func (s *inMemoryTenantStore) GetTenantHierarchy(_ context.Context, tenantID string) (*interfaces.TenantHierarchy, error) {
+	path, err := s.GetTenantPath(context.Background(), tenantID)
+	if err != nil {
+		return nil, err
+	}
+	children, _ := s.GetChildTenants(context.Background(), tenantID)
+	childIDs := make([]string, 0, len(children))
+	for _, c := range children {
+		childIDs = append(childIDs, c.ID)
+	}
+	return &interfaces.TenantHierarchy{
+		TenantID: tenantID,
+		Path:     path,
+		Depth:    len(path) - 1,
+		Children: childIDs,
+	}, nil
+}
+
+func (s *inMemoryTenantStore) GetChildTenants(_ context.Context, parentID string) ([]*interfaces.TenantData, error) {
+	var result []*interfaces.TenantData
+	for _, t := range s.tenants {
+		if t.ParentID == parentID {
+			result = append(result, t)
+		}
+	}
+	return result, nil
+}
+
+// GetTenantPath returns the path from root to the given tenant (root first).
+func (s *inMemoryTenantStore) GetTenantPath(_ context.Context, tenantID string) ([]string, error) {
+	var path []string
+	current := tenantID
+	seen := make(map[string]bool)
+	for {
+		if seen[current] {
+			return nil, &interfaces.ConfigValidationError{Field: "tenant_id", Message: "circular hierarchy detected", Code: "CIRCULAR_HIERARCHY"}
+		}
+		seen[current] = true
+		path = append([]string{current}, path...)
+		t, ok := s.tenants[current]
+		if !ok {
+			break
+		}
+		if t.ParentID == "" {
+			break
+		}
+		current = t.ParentID
+	}
+	return path, nil
+}
+
+func (s *inMemoryTenantStore) IsTenantAncestor(_ context.Context, ancestorID, descendantID string) (bool, error) {
+	current := descendantID
+	seen := make(map[string]bool)
+	for {
+		if seen[current] {
+			return false, nil
+		}
+		seen[current] = true
+		t, ok := s.tenants[current]
+		if !ok {
+			return false, nil
+		}
+		if t.ParentID == ancestorID {
+			return true, nil
+		}
+		if t.ParentID == "" {
+			return false, nil
+		}
+		current = t.ParentID
+	}
+}
+
+func (s *inMemoryTenantStore) Initialize(_ context.Context) error { return nil }
+func (s *inMemoryTenantStore) Close() error                       { return nil }
+
+// helpers for building test tenant hierarchies
+
+func newTenant(id, parentID string, metadata map[string]string) *interfaces.TenantData {
+	return &interfaces.TenantData{
+		ID:        id,
+		Name:      id,
+		ParentID:  parentID,
+		Metadata:  metadata,
+		Status:    interfaces.TenantStatusActive,
+		CreatedAt: time.Now(),
+		UpdatedAt: time.Now(),
+	}
+}
+
+// -----------------------------------------------------------------------
+// Tests
+// -----------------------------------------------------------------------
+
+// TestConfigSourceMetadataKeys verifies constants are defined and non-empty.
+func TestConfigSourceMetadataKeys(t *testing.T) {
+	assert.NotEmpty(t, MetadataKeyConfigSourceType)
+	assert.NotEmpty(t, MetadataKeyConfigSourceURL)
+	assert.NotEmpty(t, MetadataKeyConfigSourceBranch)
+	assert.NotEmpty(t, MetadataKeyConfigSourcePath)
+	assert.NotEmpty(t, MetadataKeyConfigSourceCredential)
+	assert.NotEmpty(t, MetadataKeyConfigSourcePollInterval)
+	assert.Equal(t, "controller", ConfigSourceTypeController)
+	assert.Equal(t, "git", ConfigSourceTypeGit)
+}
+
+// TestNewConfigSourceRouter verifies constructor returns a non-nil, functional
+// router that implements interfaces.ConfigStore.
+func TestNewConfigSourceRouter(t *testing.T) {
+	store := NewMockConfigStore()
+	ts := newInMemoryTenantStore()
+
+	router := NewConfigSourceRouter(store, ts)
+	require.NotNil(t, router)
+
+	// Verify it satisfies the interface at compile time and is usable at runtime.
+	var cs interfaces.ConfigStore = router
+	require.NotNil(t, cs)
+
+	// GetConfigStats is a zero-dependency operation that confirms the router
+	// correctly delegates to the underlying store.
+	stats, err := router.GetConfigStats(context.Background())
+	require.NoError(t, err)
+	require.NotNil(t, stats)
+}
+
+// TestGetEffectiveConfigSource_ExplicitController verifies that a tenant with
+// config_source_type=controller resolves to a controller source.
+func TestGetEffectiveConfigSource_ExplicitController(t *testing.T) {
+	ctx := context.Background()
+	store := NewMockConfigStore()
+	ts := newInMemoryTenantStore()
+
+	require.NoError(t, ts.CreateTenant(ctx, newTenant("root", "", map[string]string{
+		MetadataKeyConfigSourceType: ConfigSourceTypeController,
+	})))
+
+	router := NewConfigSourceRouter(store, ts)
+	info, err := router.GetEffectiveConfigSource(ctx, "root")
+	require.NoError(t, err)
+	assert.Equal(t, "root", info.TenantID)
+	assert.Equal(t, ConfigSourceTypeController, info.SourceType)
+	assert.Empty(t, info.InheritedFrom)
+}
+
+// TestGetEffectiveConfigSource_ExplicitGit verifies that a tenant with
+// config_source_type=git resolves to a git source with all metadata fields.
+func TestGetEffectiveConfigSource_ExplicitGit(t *testing.T) {
+	ctx := context.Background()
+	store := NewMockConfigStore()
+	ts := newInMemoryTenantStore()
+
+	require.NoError(t, ts.CreateTenant(ctx, newTenant("msp", "", map[string]string{
+		MetadataKeyConfigSourceType:         ConfigSourceTypeGit,
+		MetadataKeyConfigSourceURL:          "git@github.com:clientG/cfgs.git",
+		MetadataKeyConfigSourceBranch:       "main",
+		MetadataKeyConfigSourcePath:         "stewards/",
+		MetadataKeyConfigSourceCredential:   "secret:clientG-deploy-key",
+		MetadataKeyConfigSourcePollInterval: "5m",
+	})))
+
+	router := NewConfigSourceRouter(store, ts)
+	info, err := router.GetEffectiveConfigSource(ctx, "msp")
+	require.NoError(t, err)
+	assert.Equal(t, ConfigSourceTypeGit, info.SourceType)
+	assert.Equal(t, "git@github.com:clientG/cfgs.git", info.URL)
+	assert.Equal(t, "main", info.Branch)
+	assert.Equal(t, "stewards/", info.Path)
+	assert.Equal(t, "secret:clientG-deploy-key", info.Credential)
+	assert.Equal(t, "5m", info.PollInterval)
+	assert.Empty(t, info.InheritedFrom)
+}
+
+// TestGetEffectiveConfigSource_Default verifies that a tenant with no metadata
+// at any level defaults to controller source.
+func TestGetEffectiveConfigSource_Default(t *testing.T) {
+	ctx := context.Background()
+	store := NewMockConfigStore()
+	ts := newInMemoryTenantStore()
+
+	require.NoError(t, ts.CreateTenant(ctx, newTenant("root", "", nil)))
+	require.NoError(t, ts.CreateTenant(ctx, newTenant("child", "root", nil)))
+
+	router := NewConfigSourceRouter(store, ts)
+	info, err := router.GetEffectiveConfigSource(ctx, "child")
+	require.NoError(t, err)
+	assert.Equal(t, ConfigSourceTypeController, info.SourceType)
+}
+
+// TestGetEffectiveConfigSource_InheritedFromParent verifies that a tenant
+// without its own config source declaration inherits from its parent.
+func TestGetEffectiveConfigSource_InheritedFromParent(t *testing.T) {
+	ctx := context.Background()
+	store := NewMockConfigStore()
+	ts := newInMemoryTenantStore()
+
+	require.NoError(t, ts.CreateTenant(ctx, newTenant("msp", "", map[string]string{
+		MetadataKeyConfigSourceType: ConfigSourceTypeGit,
+		MetadataKeyConfigSourceURL:  "git@github.com:msp/cfgs.git",
+	})))
+	require.NoError(t, ts.CreateTenant(ctx, newTenant("client", "msp", nil)))
+
+	router := NewConfigSourceRouter(store, ts)
+	info, err := router.GetEffectiveConfigSource(ctx, "client")
+	require.NoError(t, err)
+	assert.Equal(t, ConfigSourceTypeGit, info.SourceType)
+	assert.Equal(t, "git@github.com:msp/cfgs.git", info.URL)
+	assert.Equal(t, "msp", info.InheritedFrom)
+}
+
+// TestGetEffectiveConfigSource_InheritedFromGrandparent verifies multi-level
+// inheritance: child → parent (no source) → grandparent (has source).
+func TestGetEffectiveConfigSource_InheritedFromGrandparent(t *testing.T) {
+	ctx := context.Background()
+	store := NewMockConfigStore()
+	ts := newInMemoryTenantStore()
+
+	require.NoError(t, ts.CreateTenant(ctx, newTenant("root", "", map[string]string{
+		MetadataKeyConfigSourceType: ConfigSourceTypeGit,
+		MetadataKeyConfigSourceURL:  "git@github.com:root/cfgs.git",
+	})))
+	require.NoError(t, ts.CreateTenant(ctx, newTenant("mid", "root", nil)))
+	require.NoError(t, ts.CreateTenant(ctx, newTenant("leaf", "mid", nil)))
+
+	router := NewConfigSourceRouter(store, ts)
+	info, err := router.GetEffectiveConfigSource(ctx, "leaf")
+	require.NoError(t, err)
+	assert.Equal(t, ConfigSourceTypeGit, info.SourceType)
+	assert.Equal(t, "root", info.InheritedFrom)
+}
+
+// TestGetEffectiveConfigSource_ChildOverridesParent verifies that a child's
+// explicit declaration takes precedence over the parent's.
+func TestGetEffectiveConfigSource_ChildOverridesParent(t *testing.T) {
+	ctx := context.Background()
+	store := NewMockConfigStore()
+	ts := newInMemoryTenantStore()
+
+	require.NoError(t, ts.CreateTenant(ctx, newTenant("msp", "", map[string]string{
+		MetadataKeyConfigSourceType: ConfigSourceTypeGit,
+		MetadataKeyConfigSourceURL:  "git@github.com:msp/cfgs.git",
+	})))
+	require.NoError(t, ts.CreateTenant(ctx, newTenant("client", "msp", map[string]string{
+		MetadataKeyConfigSourceType: ConfigSourceTypeController,
+	})))
+
+	router := NewConfigSourceRouter(store, ts)
+	info, err := router.GetEffectiveConfigSource(ctx, "client")
+	require.NoError(t, err)
+	assert.Equal(t, ConfigSourceTypeController, info.SourceType)
+	assert.Empty(t, info.InheritedFrom) // own declaration, not inherited
+}
+
+// TestGetEffectiveConfigSource_MultipleTenantsDifferentSources tests multiple
+// tenants with different declared sources resolve independently.
+func TestGetEffectiveConfigSource_MultipleTenantsDifferentSources(t *testing.T) {
+	ctx := context.Background()
+	store := NewMockConfigStore()
+	ts := newInMemoryTenantStore()
+
+	require.NoError(t, ts.CreateTenant(ctx, newTenant("msp", "", map[string]string{
+		MetadataKeyConfigSourceType: ConfigSourceTypeController,
+	})))
+	require.NoError(t, ts.CreateTenant(ctx, newTenant("clientA", "msp", map[string]string{
+		MetadataKeyConfigSourceType: ConfigSourceTypeGit,
+		MetadataKeyConfigSourceURL:  "git@github.com:clientA/cfgs.git",
+	})))
+	require.NoError(t, ts.CreateTenant(ctx, newTenant("clientB", "msp", nil)))
+	require.NoError(t, ts.CreateTenant(ctx, newTenant("clientC", "msp", map[string]string{
+		MetadataKeyConfigSourceType: ConfigSourceTypeController,
+	})))
+
+	router := NewConfigSourceRouter(store, ts)
+
+	// clientA: own git declaration
+	infoA, err := router.GetEffectiveConfigSource(ctx, "clientA")
+	require.NoError(t, err)
+	assert.Equal(t, ConfigSourceTypeGit, infoA.SourceType)
+	assert.Equal(t, "git@github.com:clientA/cfgs.git", infoA.URL)
+	assert.Empty(t, infoA.InheritedFrom)
+
+	// clientB: no metadata → inherits controller from msp
+	infoB, err := router.GetEffectiveConfigSource(ctx, "clientB")
+	require.NoError(t, err)
+	assert.Equal(t, ConfigSourceTypeController, infoB.SourceType)
+	assert.Equal(t, "msp", infoB.InheritedFrom)
+
+	// clientC: explicit controller
+	infoC, err := router.GetEffectiveConfigSource(ctx, "clientC")
+	require.NoError(t, err)
+	assert.Equal(t, ConfigSourceTypeController, infoC.SourceType)
+	assert.Empty(t, infoC.InheritedFrom)
+}
+
+// TestGetEffectiveConfigSource_UnknownTenant verifies that requesting the
+// effective source for a completely unknown tenant returns an error.
+func TestGetEffectiveConfigSource_UnknownTenant(t *testing.T) {
+	ctx := context.Background()
+	store := NewMockConfigStore()
+	ts := newInMemoryTenantStore()
+
+	router := NewConfigSourceRouter(store, ts)
+	_, err := router.GetEffectiveConfigSource(ctx, "does-not-exist")
+	assert.Error(t, err)
+}
+
+// -----------------------------------------------------------------------
+// ConfigStore interface delegation tests
+// -----------------------------------------------------------------------
+
+// TestConfigSourceRouter_DelegatesStoreConfig verifies that StoreConfig
+// forwards to the default store (backward-compatible, phase 1).
+func TestConfigSourceRouter_DelegatesStoreConfig(t *testing.T) {
+	ctx := context.Background()
+	store := NewMockConfigStore()
+	ts := newInMemoryTenantStore()
+
+	require.NoError(t, ts.CreateTenant(ctx, newTenant("t1", "", nil)))
+
+	router := NewConfigSourceRouter(store, ts)
+
+	entry := &interfaces.ConfigEntry{
+		Key:    &interfaces.ConfigKey{TenantID: "t1", Namespace: "stewards", Name: "s1"},
+		Data:   []byte("key: value"),
+		Format: interfaces.ConfigFormatYAML,
+	}
+	require.NoError(t, router.StoreConfig(ctx, entry))
+
+	got, err := router.GetConfig(ctx, entry.Key)
+	require.NoError(t, err)
+	assert.Equal(t, entry.Data, got.Data)
+}
+
+// TestConfigSourceRouter_DelegatesDeleteConfig verifies delete forwarding.
+func TestConfigSourceRouter_DelegatesDeleteConfig(t *testing.T) {
+	ctx := context.Background()
+	store := NewMockConfigStore()
+	ts := newInMemoryTenantStore()
+	require.NoError(t, ts.CreateTenant(ctx, newTenant("t1", "", nil)))
+
+	router := NewConfigSourceRouter(store, ts)
+
+	entry := &interfaces.ConfigEntry{
+		Key:    &interfaces.ConfigKey{TenantID: "t1", Namespace: "stewards", Name: "s1"},
+		Data:   []byte("key: value"),
+		Format: interfaces.ConfigFormatYAML,
+	}
+	require.NoError(t, router.StoreConfig(ctx, entry))
+	require.NoError(t, router.DeleteConfig(ctx, entry.Key))
+
+	_, err := router.GetConfig(ctx, entry.Key)
+	assert.Error(t, err)
+}
+
+// TestConfigSourceRouter_DelegatesListConfigs verifies list forwarding.
+func TestConfigSourceRouter_DelegatesListConfigs(t *testing.T) {
+	ctx := context.Background()
+	store := NewMockConfigStore()
+	ts := newInMemoryTenantStore()
+	require.NoError(t, ts.CreateTenant(ctx, newTenant("t1", "", nil)))
+
+	router := NewConfigSourceRouter(store, ts)
+
+	for _, name := range []string{"s1", "s2"} {
+		require.NoError(t, router.StoreConfig(ctx, &interfaces.ConfigEntry{
+			Key:    &interfaces.ConfigKey{TenantID: "t1", Namespace: "stewards", Name: name},
+			Data:   []byte("key: val"),
+			Format: interfaces.ConfigFormatYAML,
+		}))
+	}
+
+	list, err := router.ListConfigs(ctx, &interfaces.ConfigFilter{TenantID: "t1"})
+	require.NoError(t, err)
+	assert.Len(t, list, 2)
+}
+
+// TestConfigSourceRouter_DelegatesHistory verifies history forwarding.
+func TestConfigSourceRouter_DelegatesHistory(t *testing.T) {
+	ctx := context.Background()
+	store := NewMockConfigStore()
+	ts := newInMemoryTenantStore()
+	require.NoError(t, ts.CreateTenant(ctx, newTenant("t1", "", nil)))
+
+	router := NewConfigSourceRouter(store, ts)
+	key := &interfaces.ConfigKey{TenantID: "t1", Namespace: "stewards", Name: "s1"}
+
+	for i := 0; i < 3; i++ {
+		require.NoError(t, router.StoreConfig(ctx, &interfaces.ConfigEntry{
+			Key:    key,
+			Data:   []byte("v"),
+			Format: interfaces.ConfigFormatYAML,
+		}))
+	}
+
+	history, err := router.GetConfigHistory(ctx, key, 10)
+	require.NoError(t, err)
+	assert.NotEmpty(t, history)
+}
+
+// TestConfigSourceRouter_DelegatesStats verifies stats delegation.
+func TestConfigSourceRouter_DelegatesStats(t *testing.T) {
+	ctx := context.Background()
+	store := NewMockConfigStore()
+	ts := newInMemoryTenantStore()
+
+	router := NewConfigSourceRouter(store, ts)
+	stats, err := router.GetConfigStats(ctx)
+	require.NoError(t, err)
+	assert.NotNil(t, stats)
+}
+
+// TestConfigSourceRouter_DelegatesValidateConfig verifies validate delegation.
+func TestConfigSourceRouter_DelegatesValidateConfig(t *testing.T) {
+	ctx := context.Background()
+	store := NewMockConfigStore()
+	ts := newInMemoryTenantStore()
+
+	router := NewConfigSourceRouter(store, ts)
+	err := router.ValidateConfig(ctx, &interfaces.ConfigEntry{
+		Key: &interfaces.ConfigKey{TenantID: "t1", Namespace: "ns", Name: "n"},
+	})
+	assert.NoError(t, err)
+}
+
+// TestConfigSourceRouter_DelegatesResolveWithInheritance verifies
+// ResolveConfigWithInheritance delegation.
+func TestConfigSourceRouter_DelegatesResolveWithInheritance(t *testing.T) {
+	ctx := context.Background()
+	store := NewMockConfigStore()
+	ts := newInMemoryTenantStore()
+
+	router := NewConfigSourceRouter(store, ts)
+	key := &interfaces.ConfigKey{TenantID: "t1", Namespace: "ns", Name: "n"}
+
+	require.NoError(t, store.StoreConfig(ctx, &interfaces.ConfigEntry{
+		Key:    key,
+		Data:   []byte("ok: true"),
+		Format: interfaces.ConfigFormatYAML,
+	}))
+
+	got, err := router.ResolveConfigWithInheritance(ctx, key)
+	require.NoError(t, err)
+	assert.Equal(t, []byte("ok: true"), got.Data)
+}
+
+// TestConfigSourceRouter_DelegatesBatchOperations verifies batch operation
+// forwarding.
+func TestConfigSourceRouter_DelegatesBatchOperations(t *testing.T) {
+	ctx := context.Background()
+	store := NewMockConfigStore()
+	ts := newInMemoryTenantStore()
+
+	router := NewConfigSourceRouter(store, ts)
+
+	entries := []*interfaces.ConfigEntry{
+		{Key: &interfaces.ConfigKey{TenantID: "t1", Namespace: "ns", Name: "a"}, Data: []byte("a: 1"), Format: interfaces.ConfigFormatYAML},
+		{Key: &interfaces.ConfigKey{TenantID: "t1", Namespace: "ns", Name: "b"}, Data: []byte("b: 2"), Format: interfaces.ConfigFormatYAML},
+	}
+	require.NoError(t, router.StoreConfigBatch(ctx, entries))
+
+	keys := []*interfaces.ConfigKey{entries[0].Key, entries[1].Key}
+	require.NoError(t, router.DeleteConfigBatch(ctx, keys))
+
+	_, err := router.GetConfig(ctx, entries[0].Key)
+	assert.Error(t, err)
+}
+
+// TestConfigSourceRouter_GetConfigVersion delegates to default store.
+func TestConfigSourceRouter_GetConfigVersion(t *testing.T) {
+	ctx := context.Background()
+	store := NewMockConfigStore()
+	ts := newInMemoryTenantStore()
+
+	router := NewConfigSourceRouter(store, ts)
+	key := &interfaces.ConfigKey{TenantID: "t1", Namespace: "ns", Name: "cfg"}
+
+	// Store two versions
+	require.NoError(t, router.StoreConfig(ctx, &interfaces.ConfigEntry{Key: key, Data: []byte("v1"), Format: interfaces.ConfigFormatYAML}))
+	require.NoError(t, router.StoreConfig(ctx, &interfaces.ConfigEntry{Key: key, Data: []byte("v2"), Format: interfaces.ConfigFormatYAML}))
+
+	// Version 1 should be in history
+	entry, err := router.GetConfigVersion(ctx, key, 1)
+	require.NoError(t, err)
+	assert.Equal(t, []byte("v1"), entry.Data)
+}


### PR DESCRIPTION
## Summary

- Adds `ConfigSourceRouter` in `pkg/config/` that implements `interfaces.ConfigStore`, routing config fetches based on per-tenant metadata declarations
- Defines six well-known metadata keys (`config_source_type`, `_url`, `_branch`, `_path`, `_credential`, `_poll_interval`) and source type constants (`controller`, `git`)
- `GetEffectiveConfigSource(ctx, tenantID)` walks the tenant hierarchy root-ward and inherits the nearest ancestor's declared source, defaulting to `controller` (backward-compatible)
- Phase 1 of #428 — all operations delegate to the controller's default store; Phase 2 adds external git backing stores

## Acceptance Criteria Status

- [x] Well-known metadata keys defined for config source declarations
- [x] `ConfigSourceRouter` implements `ConfigStore` interface
- [x] Router reads tenant metadata and resolves inherited source
- [x] `GetEffectiveConfigSource(ctx, tenantID) (*ConfigSourceInfo, error)` resolves inherited source
- [x] Default behavior: all tenants route to controller's storage provider (backward compatible)
- [x] Unit tests with multiple tenants using different declared sources
- [x] All existing tests pass

## Test plan

- [ ] Review `pkg/config/config_source_router_test.go` — 19 tests covering metadata constants, constructor, explicit/inherited sources, multi-tenant independence, unknown-tenant error path, and all ConfigStore delegation methods
- [ ] `go test ./pkg/config/...` — all 29 tests pass
- [ ] Verify inheritance scenarios: parent→child, grandparent→grandchild, child-overrides-parent

## Adversarial Review Results

- **QA Test Runner**: PASS — all 29 pkg/config tests pass, no new failures introduced
- **QA Code Reviewer**: PASS — no blocking issues (fixed unused field caught in review)
- **Security Engineer**: PASS — no blocking issues; code uses `pkg/storage/interfaces` correctly, no hardcoded secrets, backward-compatible controller default

Fixes #555
Parent: #428

🤖 Generated with [Claude Code](https://claude.com/claude-code)