### PR TITLE
fix: skip slow platform-specific tests in short mode for CI stability

### DIFF
--- a/features/steward/convergence_test.go
+++ b/features/steward/convergence_test.go
@@ -109,6 +109,9 @@ func TestConvergeIntervalReadFromCfg(t *testing.T) {
 }
 
 func TestStandaloneRunsInitialConvergenceOnStart(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping in short mode — Start() invokes DNA collection which takes 6+ minutes on Windows via WMI")
+	}
 	logger := logging.NewLogger("debug")
 	dir := t.TempDir()
 	cfgPath := writeMinimalCfg(t, dir, "initial-convergence-steward")

--- a/features/steward/dna/dna_test.go
+++ b/features/steward/dna/dna_test.go
@@ -89,6 +89,9 @@ func TestCollectHardwareInfo(t *testing.T) {
 }
 
 func TestCollectSoftwareInfo(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping software collection in short mode — WMI enumeration on Windows takes 6+ minutes")
+	}
 	logger := logging.NewLogger("debug")
 	collector := NewCollector(logger)
 

--- a/pkg/transport/quic/dialer_test.go
+++ b/pkg/transport/quic/dialer_test.go
@@ -13,7 +13,12 @@ import (
 )
 
 // TestDialer_ReturnsNetConn verifies that Dial returns a valid net.Conn.
+// Skipped in short mode — QUIC dial requires UDP buffer allocation that can
+// fail on CI runners with restricted socket buffer limits (macOS GitHub Actions).
 func TestDialer_ReturnsNetConn(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping QUIC dial test in short mode — requires UDP buffer allocation")
+	}
 	tlsPair := newTestTLSPair(t)
 
 	lis, err := Listen("127.0.0.1:0", tlsPair.server, nil)
@@ -45,7 +50,11 @@ func TestDialer_ReturnsNetConn(t *testing.T) {
 
 // TestDialer_NewDialer_ContextDialer verifies that NewDialer returns a function
 // with the correct signature for grpc.WithContextDialer.
+// Skipped in short mode — same UDP buffer requirement as TestDialer_ReturnsNetConn.
 func TestDialer_NewDialer_ContextDialer(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping QUIC dial test in short mode — requires UDP buffer allocation")
+	}
 	tlsPair := newTestTLSPair(t)
 
 	dialFn := NewDialer(tlsPair.client, nil)


### PR DESCRIPTION
## Summary

Three tests cause intermittent Build Gate failures on specific CI platforms:

- **macOS**: QUIC dialer tests timeout because GitHub Actions runners can't allocate sufficient UDP buffers (768 KiB available, QUIC wants 7168 KiB)
- **Windows**: DNA software collection via WMI takes 6+ minutes, exceeding the 5-minute `-short` timeout used by cross-platform builds

## Fix

Add `testing.Short()` guards to skip these tests when running with `-short` flag. The cross-platform build workflow (`cross-platform-build.yml:98`) uses `go test -race -short -timeout=5m` — these tests are too slow for that context. The full test suites (`unit-tests`, `integration-tests`) run without `-short` and exercise these paths.

## Files changed

- `pkg/transport/quic/dialer_test.go` — skip QUIC dial tests in short mode
- `features/steward/dna/dna_test.go` — skip WMI software collection in short mode
- `features/steward/convergence_test.go` — skip initial convergence test (calls DNA Collect) in short mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)