### PR TITLE
docs: steward-first controller bootstrap (ADR-002, v0.9.5 roadmap)

### DIFF
--- a/docs/architecture/controller-operating-model.md
+++ b/docs/architecture/controller-operating-model.md
@@ -82,6 +82,26 @@ After initialization, the controller starts normally. If required infrastructure
 - Storage schema mismatch → error with migration instructions
 - Transport address conflict → error with port details and resolution steps
 
+### Node Management
+
+The controller is a self-sufficient application — it creates its own directories, certificates, and storage during `--init` and runs without external dependencies beyond the OS. For quick-start and development, no steward is needed.
+
+For production fleets, a steward runs alongside the controller on each node. The steward manages node-level infrastructure via its convergence loop, while the controller focuses on fleet operations.
+
+| Responsibility | Owner | Examples |
+|----------------|-------|----------|
+| OS packages | Steward | `git`, `sops`, system updates |
+| System directories | Steward | `/etc/cfgms/`, `/var/lib/cfgms/`, `/var/log/cfgms/` |
+| Firewall rules | Steward | Ports 8080/TCP, 4433/UDP |
+| OS service management | Steward | systemd unit, service restart on failure |
+| Controller config file | Steward | `/etc/cfgms/controller.cfg` |
+| CA and certificates | Controller | Generated during `--init`, managed in-memory |
+| RBAC and tenant data | Controller | Stored in durable storage backend |
+| Storage backend | Controller | Git repo or PostgreSQL operations |
+| Fleet orchestration | Controller | Config distribution, steward registration, workflows |
+
+See [Controller Bootstrap with Steward](../../deployment/controller-bootstrap-with-steward.md) for the production deployment guide and [ADR-002](decisions/002-steward-bootstrap-for-controllers.md) for the architectural decision.
+
 ### Normal Operation
 
 The controller runs several concurrent activities:

--- a/docs/architecture/decisions/002-steward-bootstrap-for-controllers.md
+++ b/docs/architecture/decisions/002-steward-bootstrap-for-controllers.md
@@ -1,0 +1,97 @@
+# ADR-002: Steward Bootstrap for Controller Nodes
+
+**Status**: Accepted
+**Date**: 2026-03-30
+**Context**: Controller deployment, node management separation
+
+## Decision
+
+Production CFGMS controller nodes run a steward alongside the controller process. The steward manages node-level infrastructure (directories, packages, firewall, OS services). The controller manages fleet-level operations (CA, certificates, RBAC, config distribution, workflows).
+
+The controller remains self-sufficient for quick-start deployments — it creates its own directories, certificates, and storage on first run without a steward.
+
+## Context
+
+### Two deployment stories
+
+1. **Quick start**: Download binary, run it, manage endpoints. The controller handles everything needed to start — directory creation, CA generation, storage initialization. Fewer steps than Ansible.
+
+2. **Production fleet**: Controller nodes managed at scale. A steward provides convergence-based node management — drift detection, automated recovery, consistent configuration across a fleet of controller nodes.
+
+### Current overlap
+
+The controller performs some operations that are both application-level (needed for quick start) and infrastructure-level (managed by steward in production):
+
+| Operation | Location | Quick start | Production |
+|-----------|----------|-------------|------------|
+| Create CA directory | `initialization.go:81` | Controller creates it during `--init` | Steward pre-creates it; controller's `MkdirAll` is a no-op |
+| Write cert PEM files to disk | `server.go:1159-1204` | Not needed — certs used in-memory | Not needed — exists only for integration test infrastructure |
+| Create data/log directories | Manual (`mkdir -p`) | Controller could create these | Steward creates and maintains them |
+| Install systemd service | Manual (create unit file) | Could use `controller install` | Steward manages the unit file |
+
+### What stays in the controller
+
+These are application-level operations needed for the "just works" experience:
+
+- **Directory creation during `--init`**: `os.MkdirAll(caPath)` — same as `git init` creating `.git/`
+- **CA and certificate generation**: Fleet-level security, not node management
+- **RBAC initialization**: Application data, not infrastructure
+- **Storage backend initialization**: Application data layer
+- **Init marker (`.cfgms-initialized`)**: Application state
+
+### What the steward adds for production
+
+- **Convergence**: Node drifts are automatically corrected (package removed, firewall rule dropped, service stopped)
+- **Consistency**: All controller nodes in a fleet share the same configuration
+- **Independence**: Steward keeps the node healthy even if the controller process is down
+- **Scalability**: New controller nodes bootstrapped via steward standalone mode
+
+## Code Changes Required
+
+The following changes support the production deployment model. Each has a corresponding GitHub issue in the v0.9.5 roadmap milestone.
+
+### Remove `writeTransportCertsToDir` (Issue #576)
+
+**File**: `features/controller/server/server.go:1179-1204`
+
+The function writes `server.crt`, `server.key`, and `ca.crt` to disk. The comment at line 1159 states this exists so "integration test infrastructure can find them." The certs are already used in-memory at line 1167 for the TLS config — the file write serves no production purpose.
+
+**Change**: Update integration test infrastructure (Makefile `generate-test-certificates`, Docker test configs) to obtain certs via the controller API or test helpers, then remove the function.
+
+### Implement `service` module for steward (Issue #577)
+
+The controller-node.cfg example uses the `script` module as a workaround for systemd service management. A dedicated `service` module provides idempotent Get/Set for OS service management (systemd, Windows Service, launchd).
+
+**Change**: Implement `service` module in `features/modules/` using the existing platform implementations in `cmd/steward/service/manager_*.go` as reference.
+
+### Add `controller install` subcommand (Issue #578)
+
+The steward has `install`/`uninstall`/`status` subcommands for OS service registration. The controller has no equivalent — service installation is manual.
+
+**Change**: Add the same pattern to `cmd/controller/`, reusing the service manager interfaces.
+
+## Consequences
+
+### Positive
+
+- Production controller nodes get convergence-based management — same as every other managed endpoint
+- CFGMS manages its own infrastructure (dog-fooding)
+- Quick-start experience unchanged — controller still "just works"
+- Clean separation: steward manages nodes, controller manages fleets
+
+### Negative
+
+- Two processes on controller nodes (steward + controller) — minor operational complexity
+- Bootstrap requires two steps (steward convergence + controller init) in production — but quick start remains one step
+
+### Neutral
+
+- Log rotation stays in `pkg/logging/providers/file/` as shared library code — both components use it internally, this is not node management
+- The `os.MkdirAll` in initialization stays — it's application-level and becomes a harmless no-op when steward pre-creates the directory
+
+## Related
+
+- [Controller Bootstrap with Steward](../../deployment/controller-bootstrap-with-steward.md) — deployment guide
+- [Controller Operating Model](../controller-operating-model.md) — startup sequence and node management boundary
+- [Steward Operating Model](../steward-operating-model.md) — convergence loop
+- [Example: controller-node.cfg](../../examples/controller-node.cfg) — standalone steward config for controller nodes

--- a/docs/deployment/controller-bootstrap-with-steward.md
+++ b/docs/deployment/controller-bootstrap-with-steward.md
@@ -1,0 +1,174 @@
+# Controller Bootstrap with Steward
+
+Production deployment guide for CFGMS controller nodes managed by stewards.
+
+## When to use this guide
+
+Use this guide when you are deploying controller nodes as part of a managed fleet — multiple controllers, automated provisioning, or infrastructure managed by CFGMS itself.
+
+For quick-start and development deployments, the controller is self-sufficient: see the [Home Lab Deployment Guide](home-lab-deployment-guide.md) or [QUICK_START.md](../../QUICK_START.md). The controller creates its own directories, certificates, and storage on first run — no steward required.
+
+## Architecture
+
+```
+┌──────────────────────────────────────────────┐
+│           Controller Node (Linux)            │
+│                                              │
+│  ┌────────────────────────────────────────┐  │
+│  │  Steward (standalone → connected)      │  │
+│  │                                        │  │
+│  │  Manages: directories, packages,       │  │
+│  │  firewall, systemd, config files       │  │
+│  │  Mode: convergence loop (30 min)       │  │
+│  └────────────────────────────────────────┘  │
+│                                              │
+│  ┌────────────────────────────────────────┐  │
+│  │  Controller                            │  │
+│  │                                        │  │
+│  │  Manages: fleet orchestration, RBAC,   │  │
+│  │  config distribution, workflows,       │  │
+│  │  CA + certificates, storage            │  │
+│  │  Listens: :8080 (REST), :4433 (gRPC)   │  │
+│  └────────────────────────────────────────┘  │
+└──────────────────────────────────────────────┘
+```
+
+**Steward manages the node.** Directories, packages, firewall rules, systemd services, and the controller config file. If the node drifts (package removed, firewall rule dropped, service stopped), the steward converges it back.
+
+**Controller manages the fleet.** CA and certificates, RBAC, config distribution, workflow engine, storage. The controller is an application running on a steward-managed node.
+
+## Prerequisites
+
+- Vanilla Linux VM (Debian/Ubuntu, RHEL/CentOS, or similar)
+- `cfgms-steward` and `cfgms-controller` binaries (built or downloaded)
+- Network: ports 8080/TCP and 4433/UDP accessible to stewards
+
+## Bootstrap Sequence
+
+### Phase 1: Steward prepares the node
+
+Place the steward binary and the controller-node config on the machine:
+
+```bash
+# Copy binaries
+sudo cp cfgms-steward /usr/local/bin/cfgms-steward
+sudo cp cfgms-controller /usr/local/bin/cfgms-controller
+sudo chmod +x /usr/local/bin/cfgms-steward /usr/local/bin/cfgms-controller
+
+# Copy the example config (customize for your environment first)
+sudo mkdir -p /etc/cfgms
+sudo cp controller-node.cfg /etc/cfgms/controller-node.cfg
+```
+
+Before running, edit `/etc/cfgms/controller-node.cfg` and replace `controller.example.com` with your controller's actual hostname or IP address. See [docs/examples/controller-node.cfg](../examples/controller-node.cfg) for the full example.
+
+Run the steward in standalone mode:
+
+```bash
+sudo cfgms-steward --config /etc/cfgms/controller-node.cfg
+```
+
+The steward converges the node:
+- Creates `/etc/cfgms/`, `/var/lib/cfgms/`, `/var/log/cfgms/`, cert directories
+- Installs `git` package
+- Writes `/etc/cfgms/controller.cfg` with your configuration
+- Opens firewall ports 8080/TCP and 4433/UDP
+- Writes the systemd unit file for `cfgms-controller`
+- Checks for initialization marker — prints instructions if not yet initialized
+
+### Phase 2: Initialize the controller
+
+This is a one-time operation that creates the CA, certificates, RBAC defaults, and initialization marker:
+
+```bash
+sudo cfgms-controller --init --config /etc/cfgms/controller.cfg
+```
+
+You should see:
+```
+Initializing storage backend... provider=git
+Storage backend initialized
+Creating Certificate Authority... ca_path=/var/lib/cfgms/certs/ca
+Certificate Authority created
+RBAC store initialized
+Controller initialized successfully
+  CA fingerprint: SHA256:xxxx...
+```
+
+Save the CA fingerprint — stewards will verify it during registration.
+
+### Phase 3: Start the controller service
+
+Run the steward again to start the controller (it detects the init marker):
+
+```bash
+sudo cfgms-steward --config /etc/cfgms/controller-node.cfg
+```
+
+This time the script resource finds `.cfgms-initialized` and enables/starts the systemd service.
+
+Verify:
+
+```bash
+sudo systemctl status cfgms-controller
+curl -k https://localhost:8080/health
+```
+
+### Phase 4: Switch steward to controller-connected mode (optional)
+
+Once the controller is running, the steward can register with it and receive configuration updates from the controller instead of the local file:
+
+```bash
+# Create a registration token
+cfg token create --tenant-id=infrastructure --expires=30d
+
+# Re-install the steward in connected mode
+sudo cfgms-steward install --regtoken <TOKEN>
+```
+
+The steward now connects to its own controller for config updates. The controller manages the steward's cfg going forward, including the controller node's own infrastructure.
+
+## Scaling: Adding Controller Nodes
+
+In a multi-node deployment, the pattern is:
+
+1. **Controller** decides a new node is needed (scaling policy, workflow trigger)
+2. **Controller** provisions the VM via workflow engine (cloud API, Hyper-V, etc.)
+3. **Controller** generates a registration token for the new node
+4. **Steward** on the new node runs standalone with `controller-node.cfg` (Phase 1)
+5. **Operator or automation** runs `cfgms-controller --init` (Phase 2)
+6. **Steward** starts the controller service (Phase 3)
+7. **New controller** joins the cluster
+
+The steward on existing controller nodes has no role in provisioning — that's the controller's job (orchestration). Each steward only manages its own node.
+
+## Ongoing Node Management
+
+With the steward running in connected mode (Phase 4), node management is automatic:
+
+- **Drift detection**: If a firewall rule is removed or a package uninstalled, the steward's convergence loop restores the desired state
+- **Config updates**: Push updated controller configuration from the controller to the steward — the steward writes the new `controller.cfg` and restarts the service
+- **Independent failure**: If the controller process crashes, the steward keeps the node healthy (directories, firewall, packages) and restarts the service via systemd
+
+## Troubleshooting
+
+### Steward says "Controller not yet initialized"
+
+This is expected on first run. Run `cfgms-controller --init` (Phase 2), then run the steward again.
+
+### Controller fails to start after init
+
+Check the systemd journal:
+
+```bash
+sudo journalctl -u cfgms-controller -n 50
+```
+
+Common issues:
+- Port already in use: another process on 8080 or 4433
+- Certificate path permissions: CA directory should be 0700
+- Storage directory not writable
+
+### Steward can't connect in Phase 4
+
+The steward connects to the controller URL compiled into the binary. Ensure the binary was built with the correct `-ldflags "-X main.ControllerURL=..."` pointing to this controller.

--- a/docs/deployment/home-lab-deployment-guide.md
+++ b/docs/deployment/home-lab-deployment-guide.md
@@ -30,6 +30,14 @@ A modular guide to deploying CFGMS with a controller and stewards. Follow the se
 
 **Ports**: Controller listens on 8080/TCP (REST) and 4433/UDP (transport). Stewards make outbound connections only — no ports to open.
 
+## Production: Steward-Managed Controller
+
+For production fleets and multi-node deployments, controller nodes should be managed by a steward — the same way every other endpoint is managed. The steward handles directories, packages, firewall rules, and systemd services via its convergence loop, while the controller focuses on fleet orchestration.
+
+See [Controller Bootstrap with Steward](controller-bootstrap-with-steward.md) for the production deployment guide and [ADR-002](../architecture/decisions/002-steward-bootstrap-for-controllers.md) for the architectural rationale.
+
+The steps below are the manual deployment path — suitable for home labs, development, and single-server setups where a steward isn't needed.
+
 ## Prerequisites
 
 - **Controller**: Debian/Ubuntu Linux VM with `git` and `sops` installed

--- a/docs/examples/controller-node.cfg
+++ b/docs/examples/controller-node.cfg
@@ -1,0 +1,207 @@
+# controller-node.cfg
+#
+# Standalone steward configuration for bootstrapping a CFGMS controller node.
+#
+# This cfg prepares a Linux node to run the CFGMS controller by creating
+# required directories, installing prerequisites, deploying the controller
+# configuration, opening firewall ports, and installing the systemd service.
+#
+# Usage:
+#   1. Place cfgms-steward binary and this file on the target node
+#   2. Run:  cfgms-steward --config /etc/cfgms/controller-node.cfg
+#   3. Initialize the controller:  cfgms-controller --init --config /etc/cfgms/controller.cfg
+#   4. Run steward again to start the controller service (detects init marker)
+#
+# See docs/deployment/controller-bootstrap-with-steward.md for full instructions.
+
+steward:
+  name: "controller-node"
+  log_level: "info"
+  execution:
+    mode: "apply"
+    timeout: "300s"
+
+resources:
+  # ── Directories ──────────────────────────────────────────────
+
+  - name: "cfgms-config-dir"
+    module: "directory"
+    config:
+      path: "/etc/cfgms"
+      owner: "root"
+      group: "root"
+      permissions: 755
+
+  - name: "cfgms-data-dir"
+    module: "directory"
+    config:
+      path: "/var/lib/cfgms"
+      owner: "root"
+      group: "root"
+      permissions: 755
+
+  - name: "cfgms-ca-dir"
+    module: "directory"
+    config:
+      path: "/var/lib/cfgms/certs/ca"
+      owner: "root"
+      group: "root"
+      permissions: 700
+
+  - name: "cfgms-cert-dir"
+    module: "directory"
+    config:
+      path: "/var/lib/cfgms/certs"
+      owner: "root"
+      group: "root"
+      permissions: 750
+
+  - name: "cfgms-log-dir"
+    module: "directory"
+    config:
+      path: "/var/log/cfgms"
+      owner: "root"
+      group: "root"
+      permissions: 755
+
+  - name: "cfgms-storage-dir"
+    module: "directory"
+    config:
+      path: "/var/lib/cfgms/storage"
+      owner: "root"
+      group: "root"
+      permissions: 755
+
+  # ── Prerequisites ────────────────────────────────────────────
+
+  - name: "install-git"
+    module: "package"
+    config:
+      packages:
+        - name: "git"
+          state: "installed"
+
+  # ── Controller configuration ─────────────────────────────────
+  # Customize the values below for your environment.
+  # At minimum, replace controller.example.com with your hostname or IP.
+
+  - name: "controller-config"
+    module: "file"
+    config:
+      path: "/etc/cfgms/controller.cfg"
+      owner: "root"
+      group: "root"
+      permissions: 600
+      content: |
+        listen_addr: "0.0.0.0:8080"
+
+        certificate:
+          enable_cert_management: true
+          ca_path: "/var/lib/cfgms/certs/ca"
+          cert_path: "/var/lib/cfgms/certs"
+          renewal_threshold_days: 30
+          server_cert_validity_days: 365
+          client_cert_validity_days: 365
+          server:
+            common_name: "controller.example.com"
+            dns_names:
+              - "controller.example.com"
+              - "localhost"
+            ip_addresses:
+              - "127.0.0.1"
+            organization: "My Organization"
+
+        storage:
+          provider: "git"
+          config:
+            repository_path: "/var/lib/cfgms/storage"
+            branch: "main"
+            auto_init: true
+
+        logging:
+          level: "info"
+          provider: "file"
+          config:
+            directory: "/var/log/cfgms"
+            max_file_size: 10485760
+            max_files: 5
+
+        transport:
+          listen_addr: "0.0.0.0:4433"
+          use_cert_manager: true
+          max_connections: 50000
+          keepalive_period: "30s"
+          idle_timeout: "5m"
+
+  # ── Firewall ─────────────────────────────────────────────────
+
+  - name: "controller-rest-port"
+    module: "firewall"
+    config:
+      rules:
+        - name: "allow-cfgms-rest"
+          port: 8080
+          protocol: "tcp"
+          action: "allow"
+          source: "0.0.0.0/0"
+
+  - name: "controller-transport-port"
+    module: "firewall"
+    config:
+      rules:
+        - name: "allow-cfgms-transport"
+          port: 4433
+          protocol: "udp"
+          action: "allow"
+          source: "0.0.0.0/0"
+
+  # ── Systemd service ──────────────────────────────────────────
+
+  - name: "controller-systemd-unit"
+    module: "file"
+    config:
+      path: "/etc/systemd/system/cfgms-controller.service"
+      owner: "root"
+      group: "root"
+      permissions: 644
+      content: |
+        [Unit]
+        Description=CFGMS Controller
+        After=network-online.target
+        Wants=network-online.target
+
+        [Service]
+        Type=simple
+        ExecStart=/usr/local/bin/cfgms-controller --config /etc/cfgms/controller.cfg
+        Restart=on-failure
+        RestartSec=5
+        User=root
+        WorkingDirectory=/var/lib/cfgms
+        StandardOutput=journal
+        StandardError=journal
+        SyslogIdentifier=cfgms-controller
+
+        [Install]
+        WantedBy=multi-user.target
+
+  # ── Start controller (only after initialization) ─────────────
+
+  - name: "enable-controller-service"
+    module: "script"
+    config:
+      interpreter: "/bin/bash"
+      content: |
+        #!/bin/bash
+        # Only enable and start the controller if it has been initialized.
+        # The .cfgms-initialized marker is created by: cfgms-controller --init
+        if [ -f /var/lib/cfgms/certs/ca/.cfgms-initialized ]; then
+          systemctl daemon-reload
+          systemctl enable cfgms-controller
+          if ! systemctl is-active --quiet cfgms-controller; then
+            systemctl start cfgms-controller
+          fi
+        else
+          echo "Controller not yet initialized."
+          echo "Run: cfgms-controller --init --config /etc/cfgms/controller.cfg"
+        fi
+      timeout: "30s"

--- a/docs/product/roadmap.md
+++ b/docs/product/roadmap.md
@@ -251,10 +251,17 @@ Authorization hardening + fixes from deployment validation.
 - [ ] Complete high availability validation on real cluster (multi-node, beyond Docker E2E)
 - [ ] Deployment validation fixes (TBD based on v0.9.2 findings)
 
+#### v0.9.5 — Steward-First Controller Bootstrap (~18 pts, ~2 weeks)
+
+Controller nodes managed by stewards — clean separation of node management from fleet orchestration. See [ADR-002](../architecture/decisions/002-steward-bootstrap-for-controllers.md).
+
+- [ ] Controller: remove writeTransportCertsToDir — certs used in-memory only (Issue #576 - 5 points) - File export exists only for test infrastructure; update tests to get certs via API
+- [ ] Steward: implement service module for idempotent OS service management (Issue #577 - 8 points) - systemd/Windows Service/launchd Get→Compare→Set→Verify, replaces script workaround
+- [ ] Controller: add install/uninstall/status subcommands (Issue #578 - 5 points) - Mirror steward self-install pattern for OS service registration
+
 #### v0.10.0 - Web Interface Foundation & Deferred Features
 
 **Deferred from v0.9.x** (functional but not on beta critical path):
-- [ ] Service module implementation (script module covers as workaround)
 - [ ] Workflow management REST API (engine works internally, API needed for Web UI)
 - [ ] Config broadcast push API (individual `PUT /stewards/{id}/config` works)
 - [ ] Session/connection monitoring API (steward list + health endpoints cover beta)


### PR DESCRIPTION
## Summary
- Establishes production model: steward manages the node, controller manages the fleet
- Controller remains self-sufficient for quick-start (no steward needed to get started)
- ADR-002 documents the decision, overlap inventory, and code changes needed
- Example `controller-node.cfg` for standalone steward bootstrapping a controller node
- v0.9.5 roadmap milestone with 3 issues (#576, #577, #578) totaling 18 story points

## New files
- `docs/architecture/decisions/002-steward-bootstrap-for-controllers.md`
- `docs/deployment/controller-bootstrap-with-steward.md`
- `docs/examples/controller-node.cfg`

## Updated files
- `docs/deployment/home-lab-deployment-guide.md` — links to steward-managed deployment
- `docs/architecture/controller-operating-model.md` — node management boundary table
- `docs/product/roadmap.md` — v0.9.5 milestone, service module moved from v0.10.0

## Test plan
- [ ] Docs-only change, no code impact
- [ ] `controller-node.cfg` validated as parseable YAML

🤖 Generated with [Claude Code](https://claude.com/claude-code)