### PR TITLE
fix: refresh credentials from host before check-creds validation

### DIFF
--- a/scripts/agent-dispatch.sh
+++ b/scripts/agent-dispatch.sh
@@ -415,7 +415,9 @@ case "$cmd" in
     ;;
 
   check-creds)
-    # Check OAuth credential validity in the shared volume
+    # Refresh from host session first so we check what agents will actually use
+    refresh_creds_from_host >/dev/null 2>&1
+    # Then check OAuth credential validity in the shared volume
     if ! docker volume inspect claude-creds >/dev/null 2>&1; then
       echo "CREDS_MISSING:no claude-creds volume"
     elif ! docker run --rm -v claude-creds:/persist --entrypoint test cfg-agent:latest -f /persist/.credentials.json 2>/dev/null; then


### PR DESCRIPTION
## Summary
- `check-creds` now calls `refresh_creds_from_host()` before checking validity
- Prevents false "expired" reports when host session has valid credentials
- Launch commands already refresh on each run — this aligns the check with actual behavior

## Test plan
- [ ] `./scripts/agent-dispatch.sh check-creds` reports valid time matching host session

🤖 Generated with [Claude Code](https://claude.com/claude-code)