### PR TITLE
feat(modules): add idempotent service module for OS service management (Issue #577)

### DIFF
--- a/features/controller/api/registration_hook.go
+++ b/features/controller/api/registration_hook.go
@@ -113,7 +113,7 @@ func (h *WorkflowApprovalHook) Evaluate(ctx context.Context, input RegistrationI
 	}
 
 	// Short-circuit: built-in accept-all policy via Variables["policy"] = "accept".
-	if policy, ok := vw.Workflow.Variables["policy"].(string); ok && policy == "accept" {
+	if policy, ok := vw.Variables["policy"].(string); ok && policy == "accept" {
 		return DecisionApprove, "", nil
 	}
 

--- a/features/modules/service/README.md
+++ b/features/modules/service/README.md
@@ -1,0 +1,92 @@
+# Service Module
+
+## Purpose and scope
+
+The Service Module provides idempotent configuration management for OS services.
+It implements the core Module interface (Get/Set/Test) to manage service runtime
+state (running/stopped) and boot-enable configuration (enabled/disabled) through
+the native OS service manager.
+
+Platform support:
+- **Linux**: systemd via `systemctl`
+- **Windows**: Windows Service Control Manager via `sc.exe`
+- **macOS**: launchd via `launchctl`
+
+The module follows the Get→Compare→Set→Verify convergence model: Get reports current
+state, the steward framework compares it to desired state, and Set converges to the
+desired state if drift is detected.
+
+## Configuration options
+
+The module accepts configuration in YAML format with the following fields:
+
+```yaml
+state: "running"      # Required: "running" or "stopped"
+enabled: true         # Required: true = start on boot, false = manual start only
+restart_on: ""        # Optional: hint for the resource dependency engine to restart
+                      # this service when a named related resource changes
+```
+
+The `resourceID` parameter (the service name) must match the OS-level service
+identifier:
+- Linux: systemd unit name without `.service` suffix (e.g., `cfgms-controller`)
+- Windows: service name as registered with SCM (e.g., `CFGMSController`)
+- macOS: launchd label (e.g., `com.cfgms.controller`)
+
+Service names are validated to contain only safe characters
+(`[a-zA-Z0-9._@-]`) before being passed to OS commands.
+
+## Usage examples
+
+1. Ensure a service is running and starts on boot:
+
+    ```yaml
+    - name: "cfgms-controller"
+      module: "service"
+      config:
+        state: "running"
+        enabled: true
+    ```
+
+2. Stop a service and prevent it from starting on boot:
+
+    ```yaml
+    - name: "some-service"
+      module: "service"
+      config:
+        state: "stopped"
+        enabled: false
+    ```
+
+3. Service that restarts when a related config file changes:
+
+    ```yaml
+    - name: "cfgms-controller"
+      module: "service"
+      config:
+        state: "running"
+        enabled: true
+        restart_on: "cfgms-controller-config"
+    ```
+
+## Known limitations
+
+1. Start/stop/enable/disable operations require elevated privileges (root on
+   Linux/macOS, Administrator on Windows).
+2. `Get` does not require elevated privileges on Linux (systemctl is-active/is-enabled
+   work as a regular user).
+3. The `restart_on` field is a dependency hint for the steward's resource dependency
+   engine — the module itself does not watch for changes or trigger restarts.
+4. macOS launchd `enabled` detection is based on whether the service is currently
+   loaded. A service loaded without the `-w` flag may not persist across reboots.
+5. Tests that interact with the OS service manager are skipped in environments
+   without a running init system (e.g., Docker containers without systemd).
+
+## Security considerations
+
+1. Service names are validated against a strict allowlist
+   (`^[a-zA-Z0-9][a-zA-Z0-9._@-]{0,254}$`) before being passed to OS commands.
+2. `exec.Command` is used without invoking a shell, preventing shell injection.
+3. The `resourceID` is sanitized in log output via `logging.SanitizeLogValue`.
+4. The module requires elevated privileges for write operations — the steward
+   should be configured to run with appropriate permissions.

--- a/features/modules/service/executor.go
+++ b/features/modules/service/executor.go
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+package service
+
+// serviceState holds the observed current state of an OS service.
+type serviceState struct {
+	Running bool
+	Enabled bool
+}
+
+// serviceExecutor is the platform-specific backend for OS service operations.
+// Each platform (Linux, Windows, macOS) provides its own implementation via
+// build tags. Unsupported platforms use the stub implementation that returns
+// ErrUnsupportedPlatform.
+type serviceExecutor interface {
+	// getState returns the current running and enabled state of the named service.
+	// If the service does not exist on the system, it returns (false, false, nil).
+	getState(name string) (serviceState, error)
+
+	// setState applies the desired running state and boot-enable configuration
+	// to the named service. It is idempotent: calling setState when the service
+	// is already in the desired state is a no-op.
+	setState(name string, desiredRunning bool, desiredEnabled bool) error
+}

--- a/features/modules/service/executor_darwin.go
+++ b/features/modules/service/executor_darwin.go
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+
+//go:build darwin
+
+package service
+
+import (
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+// darwinExecutor manages OS services via launchctl on macOS systems.
+type darwinExecutor struct{}
+
+func newExecutor() serviceExecutor {
+	return &darwinExecutor{}
+}
+
+// getState queries launchctl for the current running and enabled state.
+// On macOS, a loaded service is considered "enabled"; a running PID means "running".
+func (e *darwinExecutor) getState(name string) (serviceState, error) {
+	// launchctl list outputs: PID  Status  Label
+	// A positive PID in column 1 means the service is running.
+	out, err := exec.Command("launchctl", "list", name).CombinedOutput() // #nosec G204 - name validated by caller
+	output := strings.TrimSpace(string(out))
+
+	if err != nil {
+		// launchctl list exits non-zero when the service is not loaded.
+		if strings.Contains(output, "Could not find service") ||
+			strings.Contains(output, "No such process") {
+			return serviceState{Running: false, Enabled: false}, nil
+		}
+		return serviceState{}, fmt.Errorf("launchctl list %s: %w (output: %s)", name, err, output)
+	}
+
+	// Output format: "{ ... \"PID\" = <pid>; ... }"
+	// If PID is present and non-zero, the service is running.
+	running := strings.Contains(output, "\"PID\"") && !strings.Contains(output, "\"PID\" = 0;")
+	// A successfully listed service is loaded (enabled).
+	enabled := true
+
+	return serviceState{Running: running, Enabled: enabled}, nil
+}
+
+// setState applies the desired running and enabled states via launchctl.
+func (e *darwinExecutor) setState(name string, desiredRunning bool, desiredEnabled bool) error {
+	current, err := e.getState(name)
+	if err != nil {
+		return err
+	}
+
+	if desiredEnabled && !current.Enabled {
+		if out, err := exec.Command("launchctl", "load", "-w", name).CombinedOutput(); err != nil { // #nosec G204 - name validated by caller
+			return fmt.Errorf("launchctl load %s: %w (output: %s)", name, err, strings.TrimSpace(string(out)))
+		}
+	} else if !desiredEnabled && current.Enabled {
+		if out, err := exec.Command("launchctl", "unload", "-w", name).CombinedOutput(); err != nil { // #nosec G204 - name validated by caller
+			return fmt.Errorf("launchctl unload %s: %w (output: %s)", name, err, strings.TrimSpace(string(out)))
+		}
+	}
+
+	if desiredRunning && !current.Running {
+		if out, err := exec.Command("launchctl", "start", name).CombinedOutput(); err != nil { // #nosec G204 - name validated by caller
+			return fmt.Errorf("launchctl start %s: %w (output: %s)", name, err, strings.TrimSpace(string(out)))
+		}
+	} else if !desiredRunning && current.Running {
+		if out, err := exec.Command("launchctl", "stop", name).CombinedOutput(); err != nil { // #nosec G204 - name validated by caller
+			return fmt.Errorf("launchctl stop %s: %w (output: %s)", name, err, strings.TrimSpace(string(out)))
+		}
+	}
+
+	return nil
+}

--- a/features/modules/service/executor_linux.go
+++ b/features/modules/service/executor_linux.go
@@ -1,0 +1,114 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+
+//go:build linux
+
+package service
+
+import (
+	"errors"
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+// linuxExecutor manages OS services via systemctl on Linux systems.
+type linuxExecutor struct{}
+
+func newExecutor() serviceExecutor {
+	return &linuxExecutor{}
+}
+
+// getState queries systemctl for the current running and enabled state.
+// A non-existent service is treated as stopped and disabled (not an error),
+// matching how other modules report absent resources.
+func (e *linuxExecutor) getState(name string) (serviceState, error) {
+	running, err := systemctlIsActive(name)
+	if err != nil {
+		return serviceState{}, err
+	}
+
+	enabled, err := systemctlIsEnabled(name)
+	if err != nil {
+		return serviceState{}, err
+	}
+
+	return serviceState{Running: running, Enabled: enabled}, nil
+}
+
+// setState applies the desired running and enabled states via systemctl.
+// Operations are applied in the order: enable/disable first, then start/stop,
+// which matches systemd best practices for service lifecycle management.
+func (e *linuxExecutor) setState(name string, desiredRunning bool, desiredEnabled bool) error {
+	if desiredEnabled {
+		if out, err := exec.Command("systemctl", "enable", name).CombinedOutput(); err != nil { // #nosec G204 - name validated by caller
+			return fmt.Errorf("systemctl enable %s: %w (output: %s)", name, err, strings.TrimSpace(string(out)))
+		}
+	} else {
+		if out, err := exec.Command("systemctl", "disable", name).CombinedOutput(); err != nil { // #nosec G204 - name validated by caller
+			return fmt.Errorf("systemctl disable %s: %w (output: %s)", name, err, strings.TrimSpace(string(out)))
+		}
+	}
+
+	if desiredRunning {
+		if out, err := exec.Command("systemctl", "start", name).CombinedOutput(); err != nil { // #nosec G204 - name validated by caller
+			return fmt.Errorf("systemctl start %s: %w (output: %s)", name, err, strings.TrimSpace(string(out)))
+		}
+	} else {
+		if out, err := exec.Command("systemctl", "stop", name).CombinedOutput(); err != nil { // #nosec G204 - name validated by caller
+			return fmt.Errorf("systemctl stop %s: %w (output: %s)", name, err, strings.TrimSpace(string(out)))
+		}
+	}
+
+	return nil
+}
+
+// systemctlIsActive returns true if the named unit is in the "active" state.
+// Exit codes from is-active are meaningful: 0=active, 3=inactive/failed/unknown.
+// Any other error (e.g., systemd not running) is propagated as an error.
+func systemctlIsActive(name string) (bool, error) {
+	cmd := exec.Command("systemctl", "is-active", name) // #nosec G204 - name validated by caller
+	out, err := cmd.CombinedOutput()
+	output := strings.TrimSpace(string(out))
+
+	if err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			// is-active exits non-zero for inactive/failed/unknown — these are valid states.
+			switch output {
+			case "inactive", "failed", "activating", "deactivating", "unknown":
+				return false, nil
+			}
+			// Any other non-zero exit (e.g., systemd not running) is an actual error.
+			return false, fmt.Errorf("systemctl is-active %s: %w (output: %s)", name, err, output)
+		}
+		return false, fmt.Errorf("failed to run systemctl: %w", err)
+	}
+
+	return output == "active", nil
+}
+
+// systemctlIsEnabled returns true if the named unit is configured to start on boot.
+// Exit codes from is-enabled: 0=enabled, 1=disabled or not-found.
+// Non-zero for "disabled"/"static"/"masked" is normal; other errors are propagated.
+func systemctlIsEnabled(name string) (bool, error) {
+	cmd := exec.Command("systemctl", "is-enabled", name) // #nosec G204 - name validated by caller
+	out, err := cmd.CombinedOutput()
+	output := strings.TrimSpace(string(out))
+
+	if err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			// is-enabled exits non-zero for disabled/static/masked/not-found — valid states.
+			switch output {
+			case "disabled", "static", "masked", "indirect", "not-found", "bad":
+				return false, nil
+			}
+			// Any other non-zero exit indicates systemd is not available.
+			return false, fmt.Errorf("systemctl is-enabled %s: %w (output: %s)", name, err, output)
+		}
+		return false, fmt.Errorf("failed to run systemctl: %w", err)
+	}
+
+	return output == "enabled", nil
+}

--- a/features/modules/service/executor_stub.go
+++ b/features/modules/service/executor_stub.go
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+
+//go:build !linux && !windows && !darwin
+
+package service
+
+import "github.com/cfgis/cfgms/features/modules"
+
+// stubExecutor is used on platforms where service management is not supported.
+type stubExecutor struct{}
+
+func newExecutor() serviceExecutor {
+	return &stubExecutor{}
+}
+
+func (e *stubExecutor) getState(_ string) (serviceState, error) {
+	return serviceState{}, modules.ErrUnsupportedPlatform
+}
+
+func (e *stubExecutor) setState(_ string, _ bool, _ bool) error {
+	return modules.ErrUnsupportedPlatform
+}

--- a/features/modules/service/executor_windows.go
+++ b/features/modules/service/executor_windows.go
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+
+//go:build windows
+
+package service
+
+import (
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+// windowsExecutor manages OS services via sc.exe on Windows systems.
+type windowsExecutor struct{}
+
+func newExecutor() serviceExecutor {
+	return &windowsExecutor{}
+}
+
+// getState queries the Windows Service Control Manager for the service state.
+func (e *windowsExecutor) getState(name string) (serviceState, error) {
+	// sc query returns SERVICE_STOPPED, SERVICE_RUNNING, etc.
+	out, err := exec.Command("sc", "query", name).CombinedOutput() // #nosec G204 - name validated by caller
+	output := strings.TrimSpace(string(out))
+
+	if err != nil {
+		// sc query exits non-zero when the service doesn't exist.
+		if strings.Contains(output, "does not exist") ||
+			strings.Contains(output, "1060") { // ERROR_SERVICE_DOES_NOT_EXIST
+			return serviceState{Running: false, Enabled: false}, nil
+		}
+		return serviceState{}, fmt.Errorf("sc query %s: %w (output: %s)", name, err, output)
+	}
+
+	running := strings.Contains(output, "RUNNING")
+
+	// Check start type via sc qc (query configuration).
+	out, err = exec.Command("sc", "qc", name).CombinedOutput() // #nosec G204 - name validated by caller
+	if err != nil {
+		return serviceState{}, fmt.Errorf("sc qc %s: %w (output: %s)", name, err, strings.TrimSpace(string(out)))
+	}
+	// AUTO_START means enabled (starts on boot); DEMAND_START/DISABLED means not auto.
+	enabled := strings.Contains(string(out), "AUTO_START")
+
+	return serviceState{Running: running, Enabled: enabled}, nil
+}
+
+// setState applies the desired running and enabled states via sc.exe.
+func (e *windowsExecutor) setState(name string, desiredRunning bool, desiredEnabled bool) error {
+	startType := "demand"
+	if desiredEnabled {
+		startType = "auto"
+	}
+	if out, err := exec.Command("sc", "config", name, "start=", startType).CombinedOutput(); err != nil { // #nosec G204 - name validated by caller
+		return fmt.Errorf("sc config %s start=%s: %w (output: %s)", name, startType, err, strings.TrimSpace(string(out)))
+	}
+
+	if desiredRunning {
+		if out, err := exec.Command("sc", "start", name).CombinedOutput(); err != nil { // #nosec G204 - name validated by caller
+			output := strings.TrimSpace(string(out))
+			// Ignore "already running" error (1056 = ERROR_SERVICE_ALREADY_RUNNING).
+			if !strings.Contains(output, "1056") {
+				return fmt.Errorf("sc start %s: %w (output: %s)", name, err, output)
+			}
+		}
+	} else {
+		if out, err := exec.Command("sc", "stop", name).CombinedOutput(); err != nil { // #nosec G204 - name validated by caller
+			output := strings.TrimSpace(string(out))
+			// Ignore "not started" error (1062 = ERROR_SERVICE_NOT_ACTIVE).
+			if !strings.Contains(output, "1062") {
+				return fmt.Errorf("sc stop %s: %w (output: %s)", name, err, output)
+			}
+		}
+	}
+
+	return nil
+}

--- a/features/modules/service/implementation.go
+++ b/features/modules/service/implementation.go
@@ -1,0 +1,175 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+
+// Package service provides idempotent Get/Set management of OS services for
+// the CFGMS steward. It supports Linux (systemd), Windows (SCM), and macOS
+// (launchd) through platform-specific executor implementations selected at
+// compile time via build tags.
+//
+// The module follows the Get→Compare→Set→Verify convergence model used by all
+// steward modules. Get reports the current service state (running/stopped,
+// enabled/disabled). The steward framework compares that to the desired state
+// declared in the resource configuration. If drift is detected, Set is called
+// to converge to the desired state.
+package service
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+
+	"github.com/cfgis/cfgms/features/modules"
+	"github.com/cfgis/cfgms/pkg/logging"
+)
+
+// serviceNamePattern restricts service names to characters that are safe to
+// pass as arguments to systemctl, sc.exe, and launchctl without shell quoting.
+// Allows alphanumeric characters, dots, hyphens, underscores, and @ (needed
+// for systemd template units like getty@tty1.service).
+// The name must start with an alphanumeric character to prevent flag injection.
+var serviceNamePattern = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9._@-]{0,254}$`)
+
+// validateServiceName rejects names that could cause argument injection when
+// passed to OS service management commands.
+func validateServiceName(name string) error {
+	if !serviceNamePattern.MatchString(name) {
+		return fmt.Errorf("%w: service name %q contains invalid characters (allowed: alphanumeric, '.', '_', '-', '@')", modules.ErrInvalidInput, name)
+	}
+	return nil
+}
+
+// serviceModule implements modules.Module for OS service management.
+type serviceModule struct {
+	modules.DefaultLoggingSupport
+	executor serviceExecutor
+}
+
+// New creates a new instance of the service module with the platform-appropriate
+// OS service executor.
+func New() modules.Module {
+	return &serviceModule{
+		executor: newExecutor(),
+	}
+}
+
+// Get returns the current state of the named OS service.
+//
+// The resourceID is the OS-level service name (e.g., "cfgms-controller" on
+// Linux, "CFGMSController" on Windows, "com.cfgms.controller" on macOS).
+//
+// If the service does not exist on the system, Get returns a ServiceConfig
+// with State: "stopped" and Enabled: false — analogous to how the file module
+// returns State: "absent" for non-existent files.
+func (m *serviceModule) Get(ctx context.Context, resourceID string) (modules.ConfigState, error) {
+	if resourceID == "" {
+		return nil, modules.ErrInvalidResourceID
+	}
+	if err := validateServiceName(resourceID); err != nil {
+		return nil, err
+	}
+
+	logger := m.GetEffectiveLogger(logging.ForModule("service"))
+	tenantID := logging.ExtractTenantFromContext(ctx)
+
+	logger.InfoCtx(ctx, "Getting service state",
+		"operation", "service_get",
+		"resource_id", logging.SanitizeLogValue(resourceID),
+		"tenant_id", tenantID,
+		"resource_type", "service")
+
+	state, err := m.executor.getState(resourceID)
+	if err != nil {
+		logger.ErrorCtx(ctx, "Failed to get service state",
+			"operation", "service_get",
+			"resource_id", logging.SanitizeLogValue(resourceID),
+			"error_code", "SERVICE_GET_FAILED",
+			"error_details", err.Error())
+		return nil, err
+	}
+
+	serviceState := "stopped"
+	if state.Running {
+		serviceState = "running"
+	}
+
+	config := &ServiceConfig{
+		State:   serviceState,
+		Enabled: state.Enabled,
+	}
+
+	logger.InfoCtx(ctx, "Service state retrieved",
+		"operation", "service_get",
+		"resource_id", logging.SanitizeLogValue(resourceID),
+		"state", serviceState,
+		"enabled", state.Enabled,
+		"status", "completed")
+
+	return config, nil
+}
+
+// Set applies the desired service configuration.
+//
+// The resourceID is the OS-level service name. The config must be a ServiceConfig
+// (or any ConfigState whose AsMap contains "state" and "enabled" keys).
+//
+// Set is idempotent: calling it when the service is already in the desired state
+// performs no observable change. The convergence loop relies on this property.
+func (m *serviceModule) Set(ctx context.Context, resourceID string, config modules.ConfigState) error {
+	if resourceID == "" {
+		return modules.ErrInvalidResourceID
+	}
+	if err := validateServiceName(resourceID); err != nil {
+		return err
+	}
+	if config == nil {
+		return modules.ErrInvalidInput
+	}
+
+	logger := m.GetEffectiveLogger(logging.ForModule("service"))
+	tenantID := logging.ExtractTenantFromContext(ctx)
+
+	logger.InfoCtx(ctx, "Setting service state",
+		"operation", "service_set",
+		"resource_id", logging.SanitizeLogValue(resourceID),
+		"tenant_id", tenantID,
+		"resource_type", "service")
+
+	configMap := config.AsMap()
+	svcConfig := &ServiceConfig{}
+
+	if state, ok := configMap["state"].(string); ok {
+		svcConfig.State = state
+	}
+	if enabled, ok := configMap["enabled"].(bool); ok {
+		svcConfig.Enabled = enabled
+	}
+
+	if err := svcConfig.Validate(); err != nil {
+		logger.ErrorCtx(ctx, "Service configuration validation failed",
+			"operation", "service_set",
+			"resource_id", logging.SanitizeLogValue(resourceID),
+			"error_code", "CONFIG_VALIDATION_FAILED",
+			"error_details", err.Error())
+		return err
+	}
+
+	desiredRunning := svcConfig.State == "running"
+
+	if err := m.executor.setState(resourceID, desiredRunning, svcConfig.Enabled); err != nil {
+		logger.ErrorCtx(ctx, "Failed to set service state",
+			"operation", "service_set",
+			"resource_id", logging.SanitizeLogValue(resourceID),
+			"error_code", "SERVICE_SET_FAILED",
+			"error_details", err.Error())
+		return fmt.Errorf("service %s: %w", logging.SanitizeLogValue(resourceID), err)
+	}
+
+	logger.InfoCtx(ctx, "Service configuration completed successfully",
+		"operation", "service_set",
+		"resource_id", logging.SanitizeLogValue(resourceID),
+		"state", svcConfig.State,
+		"enabled", svcConfig.Enabled,
+		"status", "completed")
+
+	return nil
+}

--- a/features/modules/service/interface.go
+++ b/features/modules/service/interface.go
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+package service
+
+import (
+	"fmt"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/cfgis/cfgms/features/modules"
+)
+
+// ServiceConfig represents the desired state of an OS service resource.
+type ServiceConfig struct {
+	// State is the desired runtime state: "running" or "stopped".
+	State string `yaml:"state"`
+	// Enabled controls whether the service starts automatically on boot.
+	Enabled bool `yaml:"enabled"`
+	// RestartOn is an optional hint for the resource dependency system to
+	// restart this service when a named related resource changes. The module
+	// itself does not act on this field; it is reserved for the steward's
+	// resource dependency engine.
+	RestartOn string `yaml:"restart_on,omitempty"`
+}
+
+// AsMap returns the configuration as a map for field-by-field comparison.
+// RestartOn is omitted because it is a dependency hint, not observable state.
+func (c *ServiceConfig) AsMap() map[string]interface{} {
+	result := map[string]interface{}{
+		"enabled": c.Enabled,
+	}
+	if c.State != "" {
+		result["state"] = c.State
+	} else {
+		result["state"] = "stopped"
+	}
+	return result
+}
+
+// ToYAML serializes the configuration to YAML.
+func (c *ServiceConfig) ToYAML() ([]byte, error) {
+	return yaml.Marshal(c)
+}
+
+// FromYAML deserializes YAML data into the configuration.
+func (c *ServiceConfig) FromYAML(data []byte) error {
+	return yaml.Unmarshal(data, c)
+}
+
+// Validate checks that the configuration is valid before applying it.
+func (c *ServiceConfig) Validate() error {
+	switch c.State {
+	case "running", "stopped":
+		// valid
+	case "":
+		return fmt.Errorf("%w: state is required (running or stopped)", modules.ErrInvalidInput)
+	default:
+		return fmt.Errorf("%w: state must be 'running' or 'stopped', got %q", modules.ErrInvalidInput, c.State)
+	}
+	return nil
+}
+
+// GetManagedFields returns the list of fields this configuration manages.
+func (c *ServiceConfig) GetManagedFields() []string {
+	return []string{"state", "enabled"}
+}

--- a/features/modules/service/module.yaml
+++ b/features/modules/service/module.yaml
@@ -1,0 +1,33 @@
+name: service
+version: 0.1.0
+description: >
+  Manages OS service resources on the system.
+  Provides idempotent Get/Set management of service running state and boot-enable
+  configuration via the native service manager (systemd on Linux, SCM on Windows,
+  launchd on macOS).
+
+# Supported execution environments
+executors:
+  - steward  # Local service management on steward systems
+
+dependencies: []
+
+requirements:
+  os: [windows, linux, darwin]
+  arch: [amd64, arm64]
+  min_memory: "64MB"
+  min_disk: "1MB"
+
+interfaces:
+  - Get
+  - Set
+  - Test
+
+security:
+  requires_root: true  # start/stop/enable/disable require elevated privileges
+  capabilities: []
+  ports: []
+
+documentation:
+  api: "docs/api.md"
+  examples: "docs/examples/"

--- a/features/modules/service/module_test.go
+++ b/features/modules/service/module_test.go
@@ -1,0 +1,414 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+package service
+
+import (
+	"context"
+	"os/exec"
+	"runtime"
+	"testing"
+
+	"github.com/cfgis/cfgms/features/modules"
+	"github.com/cfgis/cfgms/pkg/logging"
+)
+
+// initSystemAvailable returns true when the platform init system (systemd,
+// launchctl, SCM) is accessible to the test process. Service management tests
+// that interact with the OS service manager are skipped when this returns false.
+//
+// Justification for skip: starting/stopping/enabling OS services requires
+// a running init system and elevated privileges. These conditions are not
+// present in CI containers without systemd. Config-layer tests run regardless.
+func initSystemAvailable() bool {
+	switch runtime.GOOS {
+	case "linux":
+		// systemctl list-units succeeds only when systemd is PID 1 and the
+		// session bus is reachable. Exit 0 = systemd is running.
+		return exec.Command("systemctl", "list-units", "--no-pager", "--quiet").Run() == nil
+	case "darwin":
+		return exec.Command("launchctl", "list").Run() == nil
+	case "windows":
+		return exec.Command("sc", "query", "type=", "all").Run() == nil
+	default:
+		return false
+	}
+}
+
+// TestServiceModule_New verifies the module constructor returns a non-nil Module.
+func TestServiceModule_New(t *testing.T) {
+	m := New()
+	if m == nil {
+		t.Fatal("New() returned nil")
+	}
+}
+
+// TestServiceConfig_Validate covers the Validate() method for all valid and
+// invalid state values without making any OS calls.
+func TestServiceConfig_Validate(t *testing.T) {
+	tests := []struct {
+		name    string
+		config  ServiceConfig
+		wantErr bool
+	}{
+		{
+			name:    "running state is valid",
+			config:  ServiceConfig{State: "running", Enabled: true},
+			wantErr: false,
+		},
+		{
+			name:    "stopped state is valid",
+			config:  ServiceConfig{State: "stopped", Enabled: false},
+			wantErr: false,
+		},
+		{
+			name:    "stopped with enabled true is valid",
+			config:  ServiceConfig{State: "stopped", Enabled: true},
+			wantErr: false,
+		},
+		{
+			name:    "running with enabled false is valid",
+			config:  ServiceConfig{State: "running", Enabled: false},
+			wantErr: false,
+		},
+		{
+			name:    "empty state is invalid",
+			config:  ServiceConfig{State: ""},
+			wantErr: true,
+		},
+		{
+			name:    "unknown state is invalid",
+			config:  ServiceConfig{State: "started"},
+			wantErr: true,
+		},
+		{
+			name:    "restarting state is invalid",
+			config:  ServiceConfig{State: "restarting"},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.config.Validate()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Validate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+// TestServiceConfig_AsMap verifies AsMap returns the expected keys and values.
+func TestServiceConfig_AsMap(t *testing.T) {
+	tests := []struct {
+		name     string
+		config   ServiceConfig
+		wantKeys []string
+		checks   map[string]interface{}
+	}{
+		{
+			name:     "running enabled",
+			config:   ServiceConfig{State: "running", Enabled: true},
+			wantKeys: []string{"state", "enabled"},
+			checks:   map[string]interface{}{"state": "running", "enabled": true},
+		},
+		{
+			name:     "stopped disabled",
+			config:   ServiceConfig{State: "stopped", Enabled: false},
+			wantKeys: []string{"state", "enabled"},
+			checks:   map[string]interface{}{"state": "stopped", "enabled": false},
+		},
+		{
+			name:     "empty state defaults to stopped",
+			config:   ServiceConfig{State: "", Enabled: false},
+			wantKeys: []string{"state", "enabled"},
+			checks:   map[string]interface{}{"state": "stopped", "enabled": false},
+		},
+		{
+			name:     "empty state with enabled true defaults to stopped",
+			config:   ServiceConfig{State: "", Enabled: true},
+			wantKeys: []string{"state", "enabled"},
+			checks:   map[string]interface{}{"state": "stopped", "enabled": true},
+		},
+		{
+			name:     "restart_on is excluded from map",
+			config:   ServiceConfig{State: "running", Enabled: true, RestartOn: "some-resource"},
+			wantKeys: []string{"state", "enabled"},
+			checks:   map[string]interface{}{"state": "running", "enabled": true},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := tt.config.AsMap()
+			for k, wantV := range tt.checks {
+				got, ok := m[k]
+				if !ok {
+					t.Errorf("AsMap() missing key %q", k)
+					continue
+				}
+				if got != wantV {
+					t.Errorf("AsMap()[%q] = %v, want %v", k, got, wantV)
+				}
+			}
+			// RestartOn must never appear in the map.
+			if _, found := m["restart_on"]; found {
+				t.Error("AsMap() must not include restart_on (dependency hint, not observable state)")
+			}
+		})
+	}
+}
+
+// TestServiceConfig_YAMLRoundTrip verifies ToYAML and FromYAML are inverse operations.
+func TestServiceConfig_YAMLRoundTrip(t *testing.T) {
+	original := &ServiceConfig{
+		State:     "running",
+		Enabled:   true,
+		RestartOn: "my-config-file",
+	}
+
+	data, err := original.ToYAML()
+	if err != nil {
+		t.Fatalf("ToYAML() error: %v", err)
+	}
+
+	decoded := &ServiceConfig{}
+	if err := decoded.FromYAML(data); err != nil {
+		t.Fatalf("FromYAML() error: %v", err)
+	}
+
+	if decoded.State != original.State {
+		t.Errorf("State: got %q, want %q", decoded.State, original.State)
+	}
+	if decoded.Enabled != original.Enabled {
+		t.Errorf("Enabled: got %v, want %v", decoded.Enabled, original.Enabled)
+	}
+	if decoded.RestartOn != original.RestartOn {
+		t.Errorf("RestartOn: got %q, want %q", decoded.RestartOn, original.RestartOn)
+	}
+}
+
+// TestServiceConfig_GetManagedFields verifies the fields reported as managed.
+func TestServiceConfig_GetManagedFields(t *testing.T) {
+	config := &ServiceConfig{State: "running", Enabled: true}
+	fields := config.GetManagedFields()
+
+	required := map[string]bool{"state": false, "enabled": false}
+	for _, f := range fields {
+		required[f] = true
+	}
+	for field, found := range required {
+		if !found {
+			t.Errorf("GetManagedFields() missing required field %q", field)
+		}
+	}
+}
+
+// TestServiceModule_Get_InvalidResourceID verifies Get rejects an empty resource ID.
+func TestServiceModule_Get_InvalidResourceID(t *testing.T) {
+	m := New()
+	_, err := m.Get(context.Background(), "")
+	if err == nil {
+		t.Error("Get() with empty resource ID must return an error")
+	}
+}
+
+// TestServiceModule_Get_InvalidServiceName verifies Get rejects names with unsafe characters.
+func TestServiceModule_Get_InvalidServiceName(t *testing.T) {
+	m := New()
+	ctx := context.Background()
+
+	invalidNames := []string{
+		"--force",           // flag injection attempt
+		"service; rm -rf /", // command injection attempt
+		"svc with spaces",   // spaces not allowed
+		"svc\x00null",       // null byte
+		"../etc/passwd",     // path traversal
+	}
+
+	for _, name := range invalidNames {
+		t.Run(name, func(t *testing.T) {
+			_, err := m.Get(ctx, name)
+			if err == nil {
+				t.Errorf("Get(%q) must return an error for invalid service name", name)
+			}
+		})
+	}
+}
+
+// TestServiceModule_Set_InvalidInputs verifies Set rejects empty resource IDs and nil configs.
+func TestServiceModule_Set_InvalidInputs(t *testing.T) {
+	m := New()
+	ctx := context.Background()
+
+	validConfig := &ServiceConfig{State: "running", Enabled: true}
+
+	if err := m.Set(ctx, "", validConfig); err == nil {
+		t.Error("Set() with empty resource ID must return an error")
+	}
+
+	if err := m.Set(ctx, "some-service", nil); err == nil {
+		t.Error("Set() with nil config must return an error")
+	}
+}
+
+// TestServiceModule_Set_InvalidServiceName verifies Set rejects names with unsafe characters.
+func TestServiceModule_Set_InvalidServiceName(t *testing.T) {
+	m := New()
+	ctx := context.Background()
+	validConfig := &ServiceConfig{State: "running", Enabled: true}
+
+	invalidNames := []string{
+		"--user",        // flag injection
+		"svc && reboot", // shell command chaining
+		"svc\nother",    // newline injection
+	}
+
+	for _, name := range invalidNames {
+		t.Run(name, func(t *testing.T) {
+			err := m.Set(ctx, name, validConfig)
+			if err == nil {
+				t.Errorf("Set(%q) must return an error for invalid service name", name)
+			}
+		})
+	}
+}
+
+// TestServiceModule_Set_InvalidState verifies Set rejects configs with invalid state values.
+func TestServiceModule_Set_InvalidState(t *testing.T) {
+	m := New()
+	ctx := context.Background()
+
+	badConfig := &ServiceConfig{State: "invalid-state"}
+	if err := m.Set(ctx, "some-service", badConfig); err == nil {
+		t.Error("Set() with invalid state must return an error")
+	}
+}
+
+// TestValidateServiceName verifies the service name validation function directly.
+func TestValidateServiceName(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		wantErr bool
+	}{
+		{"simple name", "cfgms-controller", false},
+		{"with dots", "com.cfgms.controller", false},
+		{"with underscore", "cfgms_controller", false},
+		{"with at sign", "getty@tty1", false},
+		{"numeric", "123service", false},
+		{"max length boundary", "a" + func() string {
+			b := make([]byte, 254)
+			for i := range b {
+				b[i] = 'a'
+			}
+			return string(b)
+		}(), false},
+		{"empty", "", true},
+		{"starts with dash", "-cfgms", true},
+		{"starts with dot", ".hidden", true},
+		{"spaces", "my service", true},
+		{"semicolon", "svc;reboot", true},
+		{"ampersand", "svc&&evil", true},
+		{"dollar sign", "$PATH", true},
+		{"backtick", "`whoami`", true},
+		{"null byte", "svc\x00", true},
+		{"newline", "svc\n", true},
+		{"path traversal", "../etc/passwd", true},
+		{"flag injection", "--force", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateServiceName(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("validateServiceName(%q) error = %v, wantErr %v", tt.input, err, tt.wantErr)
+			}
+		})
+	}
+}
+
+// TestServiceModule_Get_NonExistentService verifies that querying a non-existent service
+// returns a stopped/disabled state rather than an error, when the init system is available.
+// This mirrors the file module's behaviour of returning State: "absent" for missing files.
+func TestServiceModule_Get_NonExistentService(t *testing.T) {
+	if !initSystemAvailable() {
+		t.Skip("skipping: OS service manager is not available (no running init system); " +
+			"this is expected in containers without systemd/launchd/SCM")
+	}
+
+	m := New()
+	// Use a name that will never exist on any real system.
+	const phantomService = "cfgms-test-phantom-service-xyzzy"
+	state, err := m.Get(context.Background(), phantomService)
+	if err != nil {
+		t.Fatalf("Get() on non-existent service returned unexpected error: %v", err)
+	}
+	if state == nil {
+		t.Fatal("Get() returned nil state for non-existent service")
+	}
+
+	m2 := state.AsMap()
+	if s, ok := m2["state"].(string); !ok || s != "stopped" {
+		t.Errorf("expected state='stopped' for non-existent service, got %v", m2["state"])
+	}
+	if e, ok := m2["enabled"].(bool); !ok || e {
+		t.Errorf("expected enabled=false for non-existent service, got %v", m2["enabled"])
+	}
+}
+
+// TestServiceModule_Set_NonExistentService verifies that Set returns an error when
+// applied to a non-existent service, when the init system is available.
+func TestServiceModule_Set_NonExistentService(t *testing.T) {
+	if !initSystemAvailable() {
+		t.Skip("skipping: OS service manager is not available (no running init system); " +
+			"this is expected in containers without systemd/launchd/SCM")
+	}
+
+	m := New()
+	const phantomService = "cfgms-test-phantom-service-xyzzy"
+	config := &ServiceConfig{State: "running", Enabled: true}
+
+	// Attempting to start or enable a non-existent service must fail.
+	err := m.Set(context.Background(), phantomService, config)
+	if err == nil {
+		t.Error("Set() on a non-existent service must return an error")
+	}
+}
+
+// TestServiceModule_LoggingInjection verifies the module implements LoggingInjectable
+// and that SetLogger actually stores the logger for use by subsequent operations.
+func TestServiceModule_LoggingInjection(t *testing.T) {
+	m := New()
+
+	// The module must implement LoggingInjectable via DefaultLoggingSupport.
+	injectable, ok := m.(modules.LoggingInjectable)
+	if !ok {
+		t.Fatal("New() must return a value implementing modules.LoggingInjectable")
+	}
+
+	// Before injection, GetLogger should report no injected logger.
+	_, injected := injectable.GetLogger()
+	if injected {
+		t.Error("GetLogger() must return injected=false before SetLogger is called")
+	}
+
+	// Inject a real logger and verify the injection succeeds.
+	testLogger := logging.ForModule("service-test")
+	if err := injectable.SetLogger(testLogger); err != nil {
+		t.Fatalf("SetLogger() returned unexpected error: %v", err)
+	}
+
+	// After injection, GetLogger must return the injected logger.
+	got, injected := injectable.GetLogger()
+	if !injected {
+		t.Error("GetLogger() must return injected=true after SetLogger succeeds")
+	}
+	if got == nil {
+		t.Error("GetLogger() must return a non-nil logger after SetLogger")
+	}
+
+	// SetLogger with nil must return an error (DefaultLoggingSupport contract).
+	if err := injectable.SetLogger(nil); err == nil {
+		t.Error("SetLogger(nil) must return an error")
+	}
+}

--- a/features/modules/service/tests/basic_test.yaml
+++ b/features/modules/service/tests/basic_test.yaml
@@ -1,0 +1,34 @@
+name: Basic Service Management
+description: Tests basic service state management via the convergence model
+tests:
+  - name: Ensure service running and enabled
+    config:
+      state: "running"
+      enabled: true
+    expected:
+      state: "running"
+      enabled: true
+
+  - name: Ensure service stopped and disabled
+    config:
+      state: "stopped"
+      enabled: false
+    expected:
+      state: "stopped"
+      enabled: false
+
+  - name: Service running but not enabled on boot
+    config:
+      state: "running"
+      enabled: false
+    expected:
+      state: "running"
+      enabled: false
+
+  - name: Service stopped but enabled on boot
+    config:
+      state: "stopped"
+      enabled: true
+    expected:
+      state: "stopped"
+      enabled: true


### PR DESCRIPTION
## Summary

- Implements `features/modules/service/` module providing idempotent Get/Set management of OS services via the steward's convergence model
- Platform support: Linux (systemd/systemctl), Windows (SCM/sc.exe), macOS (launchd/launchctl), with stub for unsupported platforms
- Adds service name validation enforcing `^[a-zA-Z0-9][a-zA-Z0-9._@-]{0,254}$` allowlist before any exec.Command call, preventing flag injection and shell metacharacter attacks
- Fixes pre-existing staticcheck QF1008 in `features/controller/api/registration_hook.go`

## Motivation

The `script` module was used as a workaround for service management (e.g., `systemctl enable --now`), but scripts are not idempotent and cannot report current state. Per ADR-002, steward-first controller bootstrap requires proper service management for the `cfgms-controller` systemd unit.

## Changes

- `features/modules/service/interface.go` — `ServiceConfig` implementing `modules.ConfigState`
- `features/modules/service/executor.go` — internal `serviceExecutor` interface
- `features/modules/service/executor_linux.go` — systemd executor (build: linux)
- `features/modules/service/executor_windows.go` — SCM executor (build: windows)
- `features/modules/service/executor_darwin.go` — launchd executor (build: darwin)
- `features/modules/service/executor_stub.go` — unsupported platform stub
- `features/modules/service/implementation.go` — `serviceModule` with input validation
- `features/modules/service/module.yaml`, `README.md`, `tests/basic_test.yaml`
- `features/modules/service/module_test.go` — unit tests
- `features/controller/api/registration_hook.go` — fix pre-existing staticcheck QF1008

## Test plan

- [ ] Config layer tests pass without init system (always run in CI)
- [ ] Input validation: 17 validateServiceName cases, flag/injection/traversal rejection
- [ ] Logging injection test verifies real SetLogger/GetLogger contract
- [ ] Init-system-gated tests skip with clear justification in CI containers
- [ ] Cross-platform compilation: Linux/Windows/Darwin AMD64+ARM64

## Specialist Review Results

- **QA Test Runner**: PASS
- **QA Code Reviewer**: PASS — no blocking issues
- **Security Engineer**: PASS — service name validation verified, no injection risks

Fixes #577

🤖 Generated with [Claude Code](https://claude.com/claude-code)