### PR TITLE
feat(controller): add install/uninstall/status subcommands for OS service registration (Issue #578)

### DIFF
--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -3,7 +3,6 @@
 package main
 
 import (
-	"flag"
 	"fmt"
 	"log"
 	"os"
@@ -12,10 +11,13 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/cfgis/cfgms/cmd/controller/service"
 	"github.com/cfgis/cfgms/features/controller/config"
 	"github.com/cfgis/cfgms/features/controller/initialization"
 	"github.com/cfgis/cfgms/features/controller/server"
 	"github.com/cfgis/cfgms/pkg/logging"
+	"github.com/cfgis/cfgms/pkg/version"
+	"github.com/spf13/cobra"
 
 	// Import logging providers to register them
 	_ "github.com/cfgis/cfgms/pkg/logging/providers/file"
@@ -27,20 +29,59 @@ import (
 )
 
 func main() {
-	// Parse CLI flags
-	configPath := flag.String("config", "", "Path to configuration file (default: search /etc/cfgms/controller.cfg, then ./controller.cfg)")
-	initMode := flag.Bool("init", false, "Perform first-run initialization (creates CA, storage, RBAC defaults)")
-	flag.Parse()
+	rootCmd := buildRootCommand()
+	if err := rootCmd.Execute(); err != nil {
+		os.Exit(1)
+	}
+}
 
+// buildRootCommand constructs the cobra command tree for cfgms-controller.
+func buildRootCommand() *cobra.Command {
+	var (
+		configPath string
+		initMode   bool
+	)
+
+	root := &cobra.Command{
+		Use:   "cfgms-controller",
+		Short: "CFGMS Controller — fleet configuration management controller",
+		Long: fmt.Sprintf(`CFGMS Controller %s
+
+Manages fleet-wide configuration distribution, CA issuance, and steward registration.
+
+Entry paths:
+  cfgms-controller --config /etc/cfgms/controller.cfg   Run in foreground
+  cfgms-controller --init --config /path/to/config      First-run initialization
+  cfgms-controller install --config /path/to/config     Install as OS service
+  cfgms-controller status                               Show service status`, version.Short()),
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runController(configPath, initMode)
+		},
+	}
+
+	root.Flags().StringVar(&configPath, "config", "", "Path to configuration file (default: search /etc/cfgms/controller.cfg, then ./controller.cfg)")
+	root.Flags().BoolVar(&initMode, "init", false, "Perform first-run initialization (creates CA, storage, RBAC defaults)")
+
+	root.AddCommand(
+		buildInstallCommand(),
+		buildUninstallCommand(),
+		buildStatusCommand(),
+	)
+
+	return root
+}
+
+// runController starts the controller server (or runs --init and exits).
+func runController(configPath string, initMode bool) error {
 	fmt.Printf("[DEBUG] main.go: Controller main() function started\n")
-	cfg, err := config.LoadWithPath(*configPath)
+	cfg, err := config.LoadWithPath(configPath)
 	if err != nil {
 		fmt.Printf("[DEBUG] main.go: Failed to load config: %v\n", err)
-		log.Fatalf("Failed to load configuration: %v", err)
+		return fmt.Errorf("failed to load configuration: %w", err)
 	}
 	fmt.Printf("[DEBUG] main.go: Configuration loaded successfully\n")
 
-	// Initialize global logging provider for central hub
 	loggingConfig := &logging.LoggingConfig{
 		Provider:          getLogProvider(cfg),
 		Level:             strings.ToUpper(cfg.LogLevel),
@@ -52,41 +93,37 @@ func main() {
 		AsyncWrites:       true,
 		BatchSize:         100,
 		FlushInterval:     5 * time.Second,
-		RetentionDays:     90, // Longer retention for central hub
+		RetentionDays:     90,
 		Config:            getLogProviderConfig(cfg),
 	}
 
 	if err := logging.InitializeGlobalLogging(loggingConfig); err != nil {
-		log.Fatalf("Failed to initialize global logging: %v", err)
+		return fmt.Errorf("failed to initialize global logging: %w", err)
 	}
 
-	// Initialize global logger factory
 	logging.InitializeGlobalLoggerFactory("controller", "main")
-
-	// Use global logging provider
 	logger := logging.ForComponent("controller")
 
-	// Handle --init mode: perform first-run initialization and exit
-	if *initMode {
+	// Handle --init mode: perform first-run initialization and exit.
+	if initMode {
 		logger.Info("Starting controller first-run initialization...", "operation", "init")
 		result, err := initialization.Run(cfg, logger)
 		if err != nil {
-			log.Fatalf("FATAL: Initialization failed: %v", err)
+			return fmt.Errorf("initialization failed: %w", err)
 		}
 
 		fmt.Println("Controller initialization complete:")
 		fmt.Printf("  CA Fingerprint:    %s\n", result.CAFingerprint)
 		fmt.Printf("  Storage Provider:  %s\n", result.StorageProvider)
 		fmt.Printf("  Initialized At:    %s\n", result.InitializedAt.Format(time.RFC3339))
-		fmt.Println("\nThe controller is now ready to start with: controller --config <path>")
-		os.Exit(0)
+		fmt.Println("\nThe controller is now ready to start with: cfgms-controller --config <path>")
+		return nil
 	}
 
-	// For backward compatibility, create legacy logger for server
 	legacyLogger := logging.GetLogger()
 	srv, err := server.New(cfg, legacyLogger)
 	if err != nil {
-		log.Fatalf("FATAL: Failed to create controller server: %v", err)
+		return fmt.Errorf("failed to create controller server: %w", err)
 	}
 
 	fmt.Printf("[DEBUG] main.go: Server created successfully, about to start\n")
@@ -96,12 +133,10 @@ func main() {
 		"service_name", "controller")
 
 	fmt.Printf("[DEBUG] main.go: Setting up signal handling\n")
-	// Set up signal handling
 	sigChan := make(chan os.Signal, 1)
 	signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
 
 	fmt.Printf("[DEBUG] main.go: Launching Start() goroutine\n")
-	// Start server in a goroutine
 	go func() {
 		fmt.Printf("[DEBUG] main.go: Inside goroutine, about to call srv.Start()\n")
 		if err := srv.Start(); err != nil {
@@ -113,13 +148,11 @@ func main() {
 		fmt.Printf("[DEBUG] main.go: srv.Start() completed successfully\n")
 	}()
 
-	// Wait for termination signal
 	sig := <-sigChan
 	logger.Info("Received signal, shutting down controller...",
 		"operation", "server_shutdown",
 		"signal", sig.String())
 
-	// Graceful shutdown
 	if err := srv.Stop(); err != nil {
 		logger.Error("Error during controller shutdown",
 			"operation", "server_shutdown",
@@ -129,33 +162,235 @@ func main() {
 	logger.Info("Controller shutdown completed",
 		"operation", "server_shutdown",
 		"status", "completed")
+	return nil
 }
 
-// getLogProvider determines the logging provider from configuration
-// Note: To customize, use config file with provider: ${CFGMS_LOG_PROVIDER:-file} syntax
+// buildInstallCommand builds the `cfgms-controller install` subcommand.
+func buildInstallCommand() *cobra.Command {
+	var configPath string
+
+	cmd := &cobra.Command{
+		Use:   "install",
+		Short: "Copy binary to platform path and register as OS service",
+		Long: `Install copies the cfgms-controller binary to the platform-standard location
+and registers it as a persistent OS service that starts automatically on boot.
+
+Platforms:
+  Windows  C:\Program Files\CFGMS\cfgms-controller.exe  (Windows Service)
+  Linux    /usr/local/bin/cfgms-controller               (systemd)
+  macOS    /usr/local/bin/cfgms-controller               (launchd)
+
+Requires elevated privileges (Administrator on Windows, root on Linux/macOS).
+Install is idempotent: running it again updates the binary and restarts the service.
+
+If the controller has not been initialized yet (no CA present), --init is run
+automatically before the service is started.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runInstall(configPath)
+		},
+	}
+
+	cmd.Flags().StringVar(&configPath, "config", "", "Path to configuration file (required)")
+	if err := cmd.MarkFlagRequired("config"); err != nil {
+		panic(err) // programming error: flag name mismatch
+	}
+
+	return cmd
+}
+
+// buildUninstallCommand builds the `cfgms-controller uninstall` subcommand.
+func buildUninstallCommand() *cobra.Command {
+	var purge bool
+
+	cmd := &cobra.Command{
+		Use:   "uninstall",
+		Short: "Stop and remove the OS service",
+		Long: `Uninstall stops the running cfgms-controller service and removes the service
+definition from the OS service manager. With --purge the installed binary is
+also deleted.
+
+Requires elevated privileges (Administrator on Windows, root on Linux/macOS).`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runUninstall(purge)
+		},
+	}
+
+	cmd.Flags().BoolVar(&purge, "purge", false, "Also remove the installed binary")
+
+	return cmd
+}
+
+// buildStatusCommand builds the `cfgms-controller status` subcommand.
+func buildStatusCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:   "status",
+		Short: "Show service state, install path, config path, and CA fingerprint",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runStatus()
+		},
+	}
+}
+
+// runInstall performs the install operation for the current platform.
+// If the controller has not been initialized, it runs --init before registering
+// the OS service.
+func runInstall(configPath string) error {
+	if configPath == "" {
+		return fmt.Errorf("--config is required for install")
+	}
+
+	exe, err := os.Executable()
+	if err != nil {
+		return fmt.Errorf("failed to determine executable path: %w", err)
+	}
+
+	mgr := service.New(exe)
+
+	if !mgr.IsElevated() {
+		return fmt.Errorf("install requires elevated privileges\n" +
+			"  Windows: right-click the binary and select 'Run as administrator'\n" +
+			"  Linux/macOS: re-run with sudo")
+	}
+
+	// Check whether the controller needs first-run initialization.
+	cfg, err := config.LoadWithPath(configPath)
+	if err != nil {
+		return fmt.Errorf("failed to load configuration from %s: %w", configPath, err)
+	}
+
+	caPath := ""
+	if cfg.Certificate != nil {
+		caPath = cfg.Certificate.CAPath
+	}
+
+	if caPath != "" && !initialization.IsInitialized(caPath) {
+		fmt.Println("Controller not yet initialized — running --init...")
+		loggingConfig := &logging.LoggingConfig{
+			Provider:    getLogProvider(cfg),
+			Level:       "INFO",
+			ServiceName: "controller",
+			Component:   "install",
+			Config:      getLogProviderConfig(cfg),
+		}
+		if err := logging.InitializeGlobalLogging(loggingConfig); err != nil {
+			return fmt.Errorf("failed to initialize logging: %w", err)
+		}
+		logging.InitializeGlobalLoggerFactory("controller", "install")
+		logger := logging.ForComponent("controller")
+
+		result, err := initialization.Run(cfg, logger)
+		if err != nil {
+			return fmt.Errorf("controller initialization failed: %w", err)
+		}
+		fmt.Printf("  CA Fingerprint:    %s\n", result.CAFingerprint)
+		fmt.Printf("  Storage Provider:  %s\n", result.StorageProvider)
+		fmt.Println()
+	}
+
+	return mgr.Install(configPath)
+}
+
+// runUninstall performs the uninstall operation for the current platform.
+func runUninstall(purge bool) error {
+	exe, err := os.Executable()
+	if err != nil {
+		return fmt.Errorf("failed to determine executable path: %w", err)
+	}
+
+	mgr := service.New(exe)
+
+	if !mgr.IsElevated() {
+		return fmt.Errorf("uninstall requires elevated privileges\n" +
+			"  Windows: right-click the binary and select 'Run as administrator'\n" +
+			"  Linux/macOS: re-run with sudo")
+	}
+
+	return mgr.Uninstall(purge)
+}
+
+// runStatus prints the current service state without requiring elevated privileges.
+func runStatus() error {
+	exe, err := os.Executable()
+	if err != nil {
+		return fmt.Errorf("failed to determine executable path: %w", err)
+	}
+
+	mgr := service.New(exe)
+	status, err := mgr.Status()
+	if err != nil {
+		return fmt.Errorf("failed to query service status: %w", err)
+	}
+
+	fmt.Printf("CFGMS Controller %s\n\n", version.Short())
+	fmt.Printf("  Service name:  %s\n", status.ServiceName)
+	fmt.Printf("  Install path:  %s\n", status.InstallPath)
+
+	configPath := status.ConfigPath
+	if configPath == "" {
+		configPath = "(not installed)"
+	}
+	fmt.Printf("  Config path:   %s\n", configPath)
+
+	// Try to read CA fingerprint from the initialization marker.
+	caFingerprint := caFingerprintFromConfig(configPath)
+	fmt.Printf("  CA fingerprint: %s\n", caFingerprint)
+
+	if !status.Installed {
+		fmt.Printf("  Status:        not installed\n")
+		fmt.Printf("\n  To install: cfgms-controller install --config /etc/cfgms/controller.cfg\n")
+		return nil
+	}
+
+	state := "stopped"
+	if status.Running {
+		state = "running"
+	}
+	fmt.Printf("  Status:        %s\n", state)
+	return nil
+}
+
+// caFingerprintFromConfig loads the controller config and reads the CA fingerprint
+// from the initialization marker. Returns a human-friendly string in all cases.
+func caFingerprintFromConfig(configPath string) string {
+	if configPath == "" || configPath == "(not installed)" {
+		return "(unknown — service not installed)"
+	}
+
+	cfg, err := config.LoadWithPath(configPath)
+	if err != nil {
+		return fmt.Sprintf("(unavailable — cannot load config: %v)", err)
+	}
+
+	if cfg.Certificate == nil || cfg.Certificate.CAPath == "" {
+		return "(unavailable — CA path not configured)"
+	}
+
+	marker, err := initialization.ReadInitMarker(cfg.Certificate.CAPath)
+	if err != nil {
+		return "(unavailable — controller not yet initialized)"
+	}
+
+	return marker.CAFingerprint
+}
+
+// getLogProvider determines the logging provider from configuration.
 func getLogProvider(cfg *config.Config) string {
-	// Use config value if available, otherwise default to file
 	if cfg.Logging != nil && cfg.Logging.Provider != "" {
 		return cfg.Logging.Provider
 	}
 	return "file"
 }
 
-// getLogProviderConfig creates provider-specific configuration
-// Note: To customize, use config file with logging.config section and ${ENV_VAR:-default} syntax
+// getLogProviderConfig creates provider-specific configuration.
 func getLogProviderConfig(cfg *config.Config) map[string]interface{} {
-	// Use config values if available
 	if cfg.Logging != nil && cfg.Logging.Config != nil && len(cfg.Logging.Config) > 0 {
 		return cfg.Logging.Config
 	}
 
-	// Return sensible defaults if no config provided
 	provider := getLogProvider(cfg)
 
 	switch provider {
 	case "timescale":
-		// TimescaleDB configuration from environment variables
-		// CFGMS_TIMESCALE_PASSWORD is REQUIRED — no hardcoded defaults
 		password := os.Getenv("CFGMS_TIMESCALE_PASSWORD")
 		if password == "" {
 			log.Fatal("FATAL: CFGMS_TIMESCALE_PASSWORD environment variable is required when using " +
@@ -192,10 +427,9 @@ func getLogProviderConfig(cfg *config.Config) map[string]interface{} {
 		}
 
 	default:
-		// File provider defaults
 		return map[string]interface{}{
 			"directory":        "/var/log/cfgms",
-			"max_file_size":    int64(100 * 1024 * 1024), // 100MB
+			"max_file_size":    int64(100 * 1024 * 1024),
 			"max_files":        10,
 			"compress_rotated": true,
 		}

--- a/cmd/controller/main_test.go
+++ b/cmd/controller/main_test.go
@@ -3,44 +3,92 @@
 package main
 
 import (
-	"context"
 	"testing"
-	"time"
+
+	"github.com/cfgis/cfgms/cmd/controller/service"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+// isElevated returns true if the test process has elevated privileges,
+// using the platform-specific check from the service package.
+func isElevated() bool {
+	return service.New("").IsElevated()
+}
+
+func TestBuildRootCommand(t *testing.T) {
+	cmd := buildRootCommand()
+	require.NotNil(t, cmd)
+	assert.Equal(t, "cfgms-controller", cmd.Use)
+
+	// Verify subcommands are registered.
+	names := make([]string, 0, len(cmd.Commands()))
+	for _, sub := range cmd.Commands() {
+		names = append(names, sub.Name())
+	}
+	assert.Contains(t, names, "install")
+	assert.Contains(t, names, "uninstall")
+	assert.Contains(t, names, "status")
+}
+
+func TestBuildRootCommandFlags(t *testing.T) {
+	cmd := buildRootCommand()
+
+	for _, name := range []string{"config", "init"} {
+		flag := cmd.Flags().Lookup(name)
+		assert.NotNil(t, flag, "expected flag %q to be registered", name)
+	}
+}
+
+func TestRunInstallRequiresConfig(t *testing.T) {
+	err := runInstall("")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--config is required")
+}
+
+func TestRunInstallRequiresElevation(t *testing.T) {
+	if isElevated() {
+		t.Skip("test requires non-elevated process — running as root")
+	}
+	err := runInstall("/etc/cfgms/controller.cfg")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "elevated privileges")
+}
+
+func TestRunUninstallRequiresElevation(t *testing.T) {
+	if isElevated() {
+		t.Skip("test requires non-elevated process — running as root")
+	}
+	err := runUninstall(false)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "elevated privileges")
+}
+
+func TestRunStatusNotInstalled(t *testing.T) {
+	// status should succeed even when the service is not installed.
+	err := runStatus()
+	assert.NoError(t, err)
+}
+
+func TestInstallCommandFlagRequired(t *testing.T) {
+	cmd := buildInstallCommand()
+	// Verify --config flag exists.
+	flag := cmd.Flags().Lookup("config")
+	require.NotNil(t, flag, "install command must have --config flag")
+
+	// Verify it is marked required: executing without --config returns an error.
+	cmd.SetArgs([]string{})
+	err := cmd.Execute()
+	require.Error(t, err, "install command should fail when --config is not provided")
+}
+
+func TestUninstallCommandHasPurgeFlag(t *testing.T) {
+	cmd := buildUninstallCommand()
+	flag := cmd.Flags().Lookup("purge")
+	require.NotNil(t, flag, "uninstall command must have --purge flag")
+	assert.Equal(t, "false", flag.DefValue)
+}
 
 // TestSignalHandling is implemented in platform-specific files:
 // - main_test_unix.go for Unix systems (uses syscall.Kill)
 // - main_test_windows.go for Windows (uses channel-based simulation)
-
-func TestGracefulShutdown(t *testing.T) {
-	// This is a more complex test that would require mocking the server
-	// and other dependencies. Here's a skeleton:
-
-	tests := []struct {
-		name    string
-		timeout time.Duration
-		wantErr bool
-	}{
-		{
-			name:    "graceful shutdown within timeout",
-			timeout: 1 * time.Second,
-			wantErr: false,
-		},
-		{
-			name:    "shutdown timeout exceeded",
-			timeout: 1 * time.Millisecond,
-			wantErr: true,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			ctx, cancel := context.WithTimeout(context.Background(), tt.timeout)
-			defer cancel()
-
-			// Test skeleton - requires server implementation to complete
-			// Use ctx to avoid unused variable error
-			_ = ctx
-		})
-	}
-}

--- a/cmd/controller/main_test_unix.go
+++ b/cmd/controller/main_test_unix.go
@@ -15,30 +15,28 @@ import (
 )
 
 func TestSignalHandling(t *testing.T) {
-	// Create a channel to coordinate test completion
 	done := make(chan struct{})
+	// ready is closed after signal.Notify is registered, ensuring the sender
+	// does not fire SIGINT before the receiver goroutine is listening.
+	ready := make(chan struct{})
 
-	// Start the main process in a goroutine
 	go func() {
-		// Simulate the main process
 		sigChan := make(chan os.Signal, 1)
 		signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
+		// Signal that registration is complete before waiting.
+		close(ready)
 
-		// Send a signal after a short delay
-		go func() {
-			time.Sleep(100 * time.Millisecond)
-			if err := syscall.Kill(syscall.Getpid(), syscall.SIGINT); err != nil {
-				t.Logf("Failed to send SIGINT: %v", err)
-			}
-		}()
-
-		// Wait for signal
 		sig := <-sigChan
 		assert.Equal(t, syscall.SIGINT, sig)
 		close(done)
 	}()
 
-	// Wait for test completion with timeout
+	// Wait until signal.Notify is registered before sending the signal.
+	<-ready
+	if err := syscall.Kill(syscall.Getpid(), syscall.SIGINT); err != nil {
+		t.Fatalf("Failed to send SIGINT: %v", err)
+	}
+
 	select {
 	case <-done:
 		// Test completed successfully

--- a/cmd/controller/main_test_windows.go
+++ b/cmd/controller/main_test_windows.go
@@ -14,31 +14,23 @@ import (
 )
 
 func TestSignalHandling(t *testing.T) {
-	// Create a channel to coordinate test completion
 	done := make(chan struct{})
 
-	// Start the main process in a goroutine
 	go func() {
-		// On Windows, we test with os.Interrupt which is the closest equivalent
-		// to SIGINT. Windows doesn't support SIGTERM or syscall.Kill in the same way.
+		// On Windows we test with os.Interrupt (no syscall.Kill equivalent).
+		// The channel is buffered so the send below does not block regardless of
+		// receive timing — no sleep needed.
 		sigChan := make(chan os.Signal, 1)
 		signal.Notify(sigChan, os.Interrupt)
 
-		// Send interrupt signal after a short delay
-		go func() {
-			time.Sleep(100 * time.Millisecond)
-			// On Windows, we can send to the channel directly for testing
-			// since there's no syscall.Kill equivalent
-			sigChan <- os.Interrupt
-		}()
+		// Send directly to the buffered channel; this is deterministic and races-free.
+		sigChan <- os.Interrupt
 
-		// Wait for signal
 		sig := <-sigChan
 		assert.Equal(t, os.Interrupt, sig)
 		close(done)
 	}()
 
-	// Wait for test completion with timeout
 	select {
 	case <-done:
 		// Test completed successfully

--- a/cmd/controller/service/configpath.go
+++ b/cmd/controller/service/configpath.go
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+
+package service
+
+import (
+	"fmt"
+	"strings"
+)
+
+// validateConfigPath rejects config paths that are empty or contain characters
+// that could corrupt service definition files:
+//   - systemd unit files: double-quote breaks out of ExecStart quoted argument
+//   - launchd plists (XML): <, >, & enable XML injection into ProgramArguments
+//   - all platforms: null byte is not a valid path character
+func validateConfigPath(configPath string) error {
+	if configPath == "" {
+		return fmt.Errorf("config path cannot be empty")
+	}
+	if strings.Contains(configPath, `"`) {
+		return fmt.Errorf("config path must not contain double-quote characters")
+	}
+	if strings.ContainsAny(configPath, "<>&\x00") {
+		return fmt.Errorf("config path must not contain XML-special or null characters (< > & \\0)")
+	}
+	return nil
+}

--- a/cmd/controller/service/configpath_test.go
+++ b/cmd/controller/service/configpath_test.go
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+
+package service
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateConfigPath(t *testing.T) {
+	tests := []struct {
+		name    string
+		path    string
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name:    "valid path",
+			path:    "/etc/cfgms/controller.cfg",
+			wantErr: false,
+		},
+		{
+			name:    "valid windows path",
+			path:    `C:\cfgms\controller.cfg`,
+			wantErr: false,
+		},
+		{
+			name:    "empty path",
+			path:    "",
+			wantErr: true,
+			errMsg:  "empty",
+		},
+		{
+			name:    "path with double quote injection",
+			path:    `/etc/cfgms/controller.cfg" --injected-arg`,
+			wantErr: true,
+			errMsg:  "double-quote",
+		},
+		{
+			name:    "path with XML tag injection",
+			path:    `/etc/cfgms</string><key>RunAtLoad</key>.cfg`,
+			wantErr: true,
+			errMsg:  "XML-special",
+		},
+		{
+			name:    "path with ampersand injection",
+			path:    `/etc/cfgms/controller.cfg&injected`,
+			wantErr: true,
+			errMsg:  "XML-special",
+		},
+		{
+			name:    "path with null byte",
+			path:    "/etc/cfgms/controller\x00.cfg",
+			wantErr: true,
+			errMsg:  "XML-special",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateConfigPath(tc.path)
+			if tc.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tc.errMsg)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}

--- a/cmd/controller/service/copy.go
+++ b/cmd/controller/service/copy.go
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+
+package service
+
+import (
+	"fmt"
+	"io"
+	"os"
+)
+
+// copyBinary copies src to dst atomically using a temp file.
+// The destination is created with 0755 permissions (owner rwx, group/other rx).
+func copyBinary(src, dst string) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = in.Close() }()
+
+	tmp := dst + ".tmp"
+	out, err := os.OpenFile(tmp, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0755)
+	if err != nil {
+		return err
+	}
+
+	if _, err := io.Copy(out, in); err != nil {
+		_ = out.Close()
+		_ = os.Remove(tmp)
+		return fmt.Errorf("copy failed: %w", err)
+	}
+	if err := out.Close(); err != nil {
+		_ = os.Remove(tmp)
+		return fmt.Errorf("close failed: %w", err)
+	}
+
+	return os.Rename(tmp, dst)
+}

--- a/cmd/controller/service/manager.go
+++ b/cmd/controller/service/manager.go
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+
+// Package service provides OS service management for the cfgms-controller binary.
+// It supports Linux (systemd), Windows (native service API), and macOS (launchd).
+//
+// Platform-specific implementations are separated by build tags:
+//   - manager_linux.go (//go:build linux)
+//   - manager_windows.go (//go:build windows)
+//   - manager_darwin.go (//go:build darwin)
+//   - manager_stub.go (//go:build !linux && !windows && !darwin)
+package service
+
+// ServiceStatus describes the current observed state of the controller OS service.
+type ServiceStatus struct {
+	// Installed is true if the service has been registered with the OS.
+	Installed bool
+	// Running is true if the service is currently active/running.
+	Running bool
+	// ServiceName is the OS-level service identifier.
+	ServiceName string
+	// InstallPath is the path where the binary is installed.
+	InstallPath string
+	// ConfigPath is the path to the controller configuration file,
+	// extracted from the service definition if available.
+	ConfigPath string
+}
+
+// Manager manages the controller OS service lifecycle.
+// Each platform provides its own implementation via the newManager factory.
+type Manager interface {
+	// Install copies the binary to the platform-standard location and registers
+	// the OS service configured to start automatically with --config configPath.
+	// Install is idempotent: if the service already exists it is stopped, the
+	// binary replaced, and the service restarted.
+	// Requires elevated privileges (root on Linux/macOS, Administrator on Windows).
+	Install(configPath string) error
+
+	// Uninstall stops and removes the OS service definition.
+	// If purge is true the installed binary is also deleted.
+	// Requires elevated privileges.
+	Uninstall(purge bool) error
+
+	// Status returns the current state of the OS service.
+	// Does not require elevated privileges.
+	Status() (*ServiceStatus, error)
+
+	// IsElevated returns true if the current process has the privileges
+	// required to install or uninstall the service.
+	IsElevated() bool
+
+	// InstallPath returns the platform-standard path the binary will be
+	// copied to during Install.
+	InstallPath() string
+}
+
+// New returns the platform-specific Manager for the current OS.
+// binaryPath should be the path returned by os.Executable().
+func New(binaryPath string) Manager {
+	return newManager(binaryPath)
+}

--- a/cmd/controller/service/manager_darwin.go
+++ b/cmd/controller/service/manager_darwin.go
@@ -1,0 +1,179 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+
+//go:build darwin
+
+package service
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+const (
+	darwinInstallPath = "/usr/local/bin/cfgms-controller"
+	darwinPlistPath   = "/Library/LaunchDaemons/com.cfgms.controller.plist"
+	darwinServiceName = "com.cfgms.controller"
+)
+
+func newManager(binaryPath string) Manager {
+	return &darwinManager{binaryPath: binaryPath}
+}
+
+type darwinManager struct {
+	binaryPath string
+}
+
+func (m *darwinManager) InstallPath() string { return darwinInstallPath }
+
+func (m *darwinManager) IsElevated() bool {
+	return os.Getuid() == 0
+}
+
+// Install copies the binary to /usr/local/bin, writes the launchd plist, and
+// loads it via launchctl. If already installed, the existing daemon is unloaded
+// first, the binary replaced, then reloaded.
+func (m *darwinManager) Install(configPath string) error {
+	if err := validateConfigPath(configPath); err != nil {
+		return err
+	}
+	if !m.IsElevated() {
+		return fmt.Errorf("install requires root privileges: re-run with sudo")
+	}
+
+	// Unload existing daemon if present (idempotent — ignore failure).
+	if _, err := os.Stat(darwinPlistPath); err == nil {
+		fmt.Println("Unloading existing daemon...")
+		_ = exec.Command("launchctl", "unload", darwinPlistPath).Run()
+	}
+
+	fmt.Printf("Installing to %s...\n", darwinInstallPath)
+	if err := copyBinary(m.binaryPath, darwinInstallPath); err != nil {
+		return fmt.Errorf("failed to copy binary: %w", err)
+	}
+
+	fmt.Println("Writing launchd plist...")
+	plist := generateLaunchdPlist(configPath)
+	if err := os.WriteFile(darwinPlistPath, []byte(plist), 0644); err != nil {
+		return fmt.Errorf("failed to write plist %s: %w", darwinPlistPath, err)
+	}
+
+	fmt.Println("Loading launchd daemon...")
+	if out, err := exec.Command("launchctl", "load", darwinPlistPath).CombinedOutput(); err != nil {
+		return fmt.Errorf("launchctl load failed: %w\n%s", err, out)
+	}
+
+	fmt.Printf("\nDone. CFGMS Controller installed and running.\n")
+	fmt.Printf("  Service name: %s\n", darwinServiceName)
+	fmt.Printf("  Config:  %s\n", configPath)
+	fmt.Printf("  Status:  cfgms-controller status\n")
+	fmt.Printf("  Remove:  cfgms-controller uninstall\n")
+	return nil
+}
+
+// Uninstall unloads and removes the launchd daemon. If purge is true the
+// installed binary is also removed.
+func (m *darwinManager) Uninstall(purge bool) error {
+	if !m.IsElevated() {
+		return fmt.Errorf("uninstall requires root privileges: re-run with sudo")
+	}
+
+	if _, err := os.Stat(darwinPlistPath); err == nil {
+		fmt.Println("Unloading daemon...")
+		_ = exec.Command("launchctl", "unload", darwinPlistPath).Run()
+
+		fmt.Printf("Removing %s...\n", darwinPlistPath)
+		if err := os.Remove(darwinPlistPath); err != nil {
+			return fmt.Errorf("failed to remove plist: %w", err)
+		}
+	} else {
+		fmt.Println("Daemon plist not found — nothing to remove.")
+	}
+
+	if purge {
+		if _, err := os.Stat(darwinInstallPath); err == nil {
+			fmt.Printf("Removing %s...\n", darwinInstallPath)
+			if err := os.Remove(darwinInstallPath); err != nil {
+				return fmt.Errorf("failed to remove binary: %w", err)
+			}
+		}
+	}
+
+	fmt.Println("CFGMS Controller uninstalled.")
+	return nil
+}
+
+// Status returns the current state of the launchd daemon without requiring
+// elevated privileges.
+func (m *darwinManager) Status() (*ServiceStatus, error) {
+	status := &ServiceStatus{
+		ServiceName: darwinServiceName,
+		InstallPath: darwinInstallPath,
+	}
+
+	// Installed if the plist exists.
+	plistContent, err := os.ReadFile(darwinPlistPath)
+	if err == nil {
+		status.Installed = true
+		status.ConfigPath = configPathFromPlist(string(plistContent))
+	}
+
+	// Check if running via launchctl list.
+	out, err := exec.Command("launchctl", "list", darwinServiceName).Output()
+	if err == nil && !strings.Contains(string(out), "Could not find service") {
+		status.Running = true
+	}
+
+	return status, nil
+}
+
+// generateLaunchdPlist returns a macOS launchd plist for the controller daemon.
+// KeepAlive ensures the daemon restarts on exit; RunAtLoad starts it immediately.
+func generateLaunchdPlist(configPath string) string {
+	return fmt.Sprintf(`<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>%s</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>%s</string>
+    <string>--config</string>
+    <string>%s</string>
+  </array>
+  <key>RunAtLoad</key>
+  <true/>
+  <key>KeepAlive</key>
+  <true/>
+  <key>StandardOutPath</key>
+  <string>/var/log/cfgms-controller.log</string>
+  <key>StandardErrorPath</key>
+  <string>/var/log/cfgms-controller.log</string>
+</dict>
+</plist>
+`, darwinServiceName, darwinInstallPath, configPath)
+}
+
+// configPathFromPlist extracts the --config argument from a launchd plist.
+// Returns an empty string if the argument cannot be found.
+func configPathFromPlist(content string) string {
+	idx := strings.Index(content, "<string>--config</string>")
+	if idx == -1 {
+		return ""
+	}
+	rest := content[idx+len("<string>--config</string>"):]
+	start := strings.Index(rest, "<string>")
+	if start == -1 {
+		return ""
+	}
+	rest = rest[start+len("<string>"):]
+	end := strings.Index(rest, "</string>")
+	if end == -1 {
+		return ""
+	}
+	return rest[:end]
+}

--- a/cmd/controller/service/manager_darwin_test.go
+++ b/cmd/controller/service/manager_darwin_test.go
@@ -1,0 +1,127 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+
+//go:build darwin
+
+package service
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDarwinManagerInstallPath(t *testing.T) {
+	m := New("/usr/local/bin/cfgms-controller")
+	assert.Equal(t, darwinInstallPath, m.InstallPath())
+}
+
+func TestDarwinManagerIsElevated(t *testing.T) {
+	m := New("/usr/local/bin/cfgms-controller")
+	expected := os.Getuid() == 0
+	assert.Equal(t, expected, m.IsElevated())
+}
+
+func TestDarwinManagerInstallRequiresElevation(t *testing.T) {
+	if os.Getuid() == 0 {
+		t.Skip("skipping elevation check — running as root")
+	}
+	m := New("/usr/local/bin/cfgms-controller")
+	err := m.Install("/etc/cfgms/controller.cfg")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "root")
+}
+
+func TestDarwinManagerInstallRejectsEmptyConfigPath(t *testing.T) {
+	m := New("/usr/local/bin/cfgms-controller")
+	err := m.Install("")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "empty")
+}
+
+func TestDarwinManagerUninstallRequiresElevation(t *testing.T) {
+	if os.Getuid() == 0 {
+		t.Skip("skipping elevation check — running as root")
+	}
+	m := New("/usr/local/bin/cfgms-controller")
+	err := m.Uninstall(false)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "root")
+}
+
+func TestDarwinManagerStatusNotInstalled(t *testing.T) {
+	m := New("/usr/local/bin/cfgms-controller")
+	status, err := m.Status()
+	require.NoError(t, err)
+	assert.Equal(t, darwinServiceName, status.ServiceName)
+	assert.Equal(t, darwinInstallPath, status.InstallPath)
+	if _, statErr := os.Stat(darwinPlistPath); os.IsNotExist(statErr) {
+		assert.False(t, status.Installed)
+		assert.False(t, status.Running)
+	}
+}
+
+func TestGenerateLaunchdPlist(t *testing.T) {
+	configPath := "/etc/cfgms/controller.cfg"
+	plist := generateLaunchdPlist(configPath)
+
+	assert.Contains(t, plist, "<?xml")
+	assert.Contains(t, plist, darwinServiceName)
+	assert.Contains(t, plist, darwinInstallPath)
+	assert.Contains(t, plist, "<string>--config</string>")
+	assert.Contains(t, plist, configPath)
+	assert.Contains(t, plist, "<key>KeepAlive</key>")
+	assert.Contains(t, plist, "<key>RunAtLoad</key>")
+	assert.Contains(t, plist, "<true/>")
+
+	// Config path appears exactly once.
+	count := strings.Count(plist, configPath)
+	assert.Equal(t, 1, count, "config path should appear exactly once in plist")
+}
+
+func TestGenerateLaunchdPlistKeepAliveRequired(t *testing.T) {
+	plist := generateLaunchdPlist("/etc/cfgms/controller.cfg")
+	assert.Contains(t, plist, "<key>KeepAlive</key>", "KeepAlive required")
+	assert.Contains(t, plist, "<key>RunAtLoad</key>", "RunAtLoad required")
+}
+
+func TestConfigPathFromPlist(t *testing.T) {
+	tests := []struct {
+		name     string
+		content  string
+		expected string
+	}{
+		{
+			name:     "valid plist with config",
+			content:  generateLaunchdPlist("/etc/cfgms/controller.cfg"),
+			expected: "/etc/cfgms/controller.cfg",
+		},
+		{
+			name:     "plist without config",
+			content:  "<plist><dict><key>Label</key><string>com.cfgms.controller</string></dict></plist>",
+			expected: "",
+		},
+		{
+			name:     "empty content",
+			content:  "",
+			expected: "",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := configPathFromPlist(tc.content)
+			assert.Equal(t, tc.expected, got)
+		})
+	}
+}
+
+func TestDarwinManagerNew(t *testing.T) {
+	m := New("/path/to/binary")
+	require.NotNil(t, m)
+	_, ok := m.(*darwinManager)
+	assert.True(t, ok, "New() should return a *darwinManager on macOS")
+}

--- a/cmd/controller/service/manager_linux.go
+++ b/cmd/controller/service/manager_linux.go
@@ -1,0 +1,184 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+
+//go:build linux
+
+package service
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+const (
+	linuxInstallPath = "/usr/local/bin/cfgms-controller"
+	linuxSystemdUnit = "/etc/systemd/system/cfgms-controller.service"
+	linuxServiceName = "cfgms-controller"
+)
+
+func newManager(binaryPath string) Manager {
+	return &linuxManager{binaryPath: binaryPath}
+}
+
+type linuxManager struct {
+	binaryPath string
+}
+
+func (m *linuxManager) InstallPath() string { return linuxInstallPath }
+
+func (m *linuxManager) IsElevated() bool {
+	return os.Getuid() == 0
+}
+
+// Install copies the binary to /usr/local/bin, writes the systemd unit, and
+// enables/starts the service. Running Install on an already-installed service
+// stops it first, replaces the binary, then restarts.
+func (m *linuxManager) Install(configPath string) error {
+	if err := validateConfigPath(configPath); err != nil {
+		return err
+	}
+	if !m.IsElevated() {
+		return fmt.Errorf("install requires root privileges: re-run with sudo")
+	}
+
+	// Stop existing service if running (idempotent: ignore failure if not running).
+	_ = exec.Command("systemctl", "stop", linuxServiceName).Run()
+
+	fmt.Printf("Installing to %s...\n", linuxInstallPath)
+	if err := copyBinary(m.binaryPath, linuxInstallPath); err != nil {
+		return fmt.Errorf("failed to copy binary: %w", err)
+	}
+
+	fmt.Println("Writing systemd unit...")
+	unit := generateSystemdUnit(configPath)
+	if err := os.WriteFile(linuxSystemdUnit, []byte(unit), 0644); err != nil {
+		return fmt.Errorf("failed to write systemd unit %s: %w", linuxSystemdUnit, err)
+	}
+
+	if out, err := exec.Command("systemctl", "daemon-reload").CombinedOutput(); err != nil {
+		return fmt.Errorf("systemctl daemon-reload failed: %w\n%s", err, out)
+	}
+
+	fmt.Println("Enabling and starting service...")
+	if out, err := exec.Command("systemctl", "enable", "--now", linuxServiceName).CombinedOutput(); err != nil {
+		return fmt.Errorf("systemctl enable --now %s failed: %w\n%s", linuxServiceName, err, out)
+	}
+
+	fmt.Printf("\nDone. CFGMS Controller installed and running.\n")
+	fmt.Printf("  Service name: %s\n", linuxServiceName)
+	fmt.Printf("  Config:  %s\n", configPath)
+	fmt.Printf("  Status:  cfgms-controller status\n")
+	fmt.Printf("  Remove:  cfgms-controller uninstall\n")
+	return nil
+}
+
+// Uninstall stops and removes the systemd service. If purge is true the
+// installed binary is also removed.
+func (m *linuxManager) Uninstall(purge bool) error {
+	if !m.IsElevated() {
+		return fmt.Errorf("uninstall requires root privileges: re-run with sudo")
+	}
+
+	fmt.Println("Stopping service...")
+	// Ignore stop error — service may already be stopped.
+	_ = exec.Command("systemctl", "stop", linuxServiceName).Run()
+
+	fmt.Println("Disabling service...")
+	// Ignore disable error — service may not be enabled.
+	_ = exec.Command("systemctl", "disable", linuxServiceName).Run()
+
+	if _, err := os.Stat(linuxSystemdUnit); err == nil {
+		fmt.Printf("Removing %s...\n", linuxSystemdUnit)
+		if err := os.Remove(linuxSystemdUnit); err != nil {
+			return fmt.Errorf("failed to remove systemd unit: %w", err)
+		}
+	}
+
+	if out, err := exec.Command("systemctl", "daemon-reload").CombinedOutput(); err != nil {
+		return fmt.Errorf("systemctl daemon-reload failed: %w\n%s", err, out)
+	}
+
+	if purge {
+		if _, err := os.Stat(linuxInstallPath); err == nil {
+			fmt.Printf("Removing %s...\n", linuxInstallPath)
+			if err := os.Remove(linuxInstallPath); err != nil {
+				return fmt.Errorf("failed to remove binary: %w", err)
+			}
+		}
+	}
+
+	fmt.Println("CFGMS Controller uninstalled.")
+	return nil
+}
+
+// Status returns the current state of the systemd service without requiring
+// elevated privileges.
+func (m *linuxManager) Status() (*ServiceStatus, error) {
+	status := &ServiceStatus{
+		ServiceName: linuxServiceName,
+		InstallPath: linuxInstallPath,
+	}
+
+	// Service is installed if the unit file exists.
+	unitContent, err := os.ReadFile(linuxSystemdUnit)
+	if err == nil {
+		status.Installed = true
+		status.ConfigPath = configPathFromUnit(string(unitContent))
+	}
+
+	// Check if active via systemctl is-active (exit 0 = active).
+	out, err := exec.Command("systemctl", "is-active", linuxServiceName).Output()
+	if err == nil && strings.TrimSpace(string(out)) == "active" {
+		status.Running = true
+	}
+
+	return status, nil
+}
+
+// generateSystemdUnit returns a systemd unit that runs cfgms-controller with the
+// given config path. Restart=always and RestartSec=10 ensure the controller
+// recovers from transient failures.
+func generateSystemdUnit(configPath string) string {
+	return fmt.Sprintf(`[Unit]
+Description=CFGMS Controller
+Documentation=https://docs.cfg.is/controller
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+ExecStart=%s --config "%s"
+Restart=always
+RestartSec=10
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=cfgms-controller
+
+[Install]
+WantedBy=multi-user.target
+`, linuxInstallPath, configPath)
+}
+
+// configPathFromUnit extracts the --config argument from a systemd unit file.
+// Returns an empty string if the argument cannot be found.
+func configPathFromUnit(content string) string {
+	for _, line := range strings.Split(content, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if !strings.HasPrefix(trimmed, "ExecStart=") {
+			continue
+		}
+		idx := strings.Index(trimmed, `--config "`)
+		if idx == -1 {
+			continue
+		}
+		rest := trimmed[idx+len(`--config "`):]
+		end := strings.Index(rest, `"`)
+		if end == -1 {
+			continue
+		}
+		return rest[:end]
+	}
+	return ""
+}

--- a/cmd/controller/service/manager_linux_test.go
+++ b/cmd/controller/service/manager_linux_test.go
@@ -1,0 +1,130 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+
+//go:build linux
+
+package service
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLinuxManagerInstallPath(t *testing.T) {
+	m := New("/usr/bin/cfgms-controller")
+	assert.Equal(t, linuxInstallPath, m.InstallPath())
+}
+
+func TestLinuxManagerIsElevated(t *testing.T) {
+	m := New("/usr/bin/cfgms-controller")
+	expected := os.Getuid() == 0
+	assert.Equal(t, expected, m.IsElevated())
+}
+
+func TestLinuxManagerInstallRequiresElevation(t *testing.T) {
+	if os.Getuid() == 0 {
+		t.Skip("skipping elevation check — running as root")
+	}
+	m := New("/usr/bin/cfgms-controller")
+	err := m.Install("/etc/cfgms/controller.cfg")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "root")
+}
+
+func TestLinuxManagerInstallRejectsEmptyConfigPath(t *testing.T) {
+	m := New("/usr/bin/cfgms-controller")
+	err := m.Install("")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "empty")
+}
+
+func TestLinuxManagerUninstallRequiresElevation(t *testing.T) {
+	if os.Getuid() == 0 {
+		t.Skip("skipping elevation check — running as root")
+	}
+	m := New("/usr/bin/cfgms-controller")
+	err := m.Uninstall(false)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "root")
+}
+
+func TestLinuxManagerStatusNotInstalled(t *testing.T) {
+	// Status must work without root; when the unit file does not exist the
+	// service is reported as not installed.
+	m := New("/usr/bin/cfgms-controller")
+	status, err := m.Status()
+	require.NoError(t, err)
+	if _, statErr := os.Stat(linuxSystemdUnit); os.IsNotExist(statErr) {
+		assert.False(t, status.Installed, "should not be installed when unit file is absent")
+		assert.False(t, status.Running, "should not be running when unit file is absent")
+	}
+	assert.Equal(t, linuxServiceName, status.ServiceName)
+	assert.Equal(t, linuxInstallPath, status.InstallPath)
+}
+
+func TestGenerateSystemdUnit(t *testing.T) {
+	configPath := "/etc/cfgms/controller.cfg"
+	unit := generateSystemdUnit(configPath)
+
+	assert.Contains(t, unit, "[Unit]")
+	assert.Contains(t, unit, "[Service]")
+	assert.Contains(t, unit, "[Install]")
+	assert.Contains(t, unit, "Restart=always")
+	assert.Contains(t, unit, "RestartSec=10")
+	assert.Contains(t, unit, `--config "`+configPath+`"`)
+	assert.Contains(t, unit, linuxInstallPath)
+	assert.Contains(t, unit, "WantedBy=multi-user.target")
+	assert.Contains(t, unit, "Description=CFGMS Controller")
+
+	// Config path appears exactly once (no duplication).
+	count := strings.Count(unit, configPath)
+	assert.Equal(t, 1, count, "config path should appear exactly once in unit file")
+}
+
+func TestGenerateSystemdUnitContainsRestartPolicy(t *testing.T) {
+	unit := generateSystemdUnit("/etc/cfgms/controller.cfg")
+	assert.Contains(t, unit, "Restart=always", "Restart=always required")
+	assert.Contains(t, unit, "RestartSec=10", "RestartSec=10 required")
+}
+
+func TestConfigPathFromUnit(t *testing.T) {
+	tests := []struct {
+		name     string
+		content  string
+		expected string
+	}{
+		{
+			name:     "valid unit with config",
+			content:  generateSystemdUnit("/etc/cfgms/controller.cfg"),
+			expected: "/etc/cfgms/controller.cfg",
+		},
+		{
+			name:     "unit without config",
+			content:  "[Service]\nExecStart=/usr/local/bin/cfgms-controller\n",
+			expected: "",
+		},
+		{
+			name:     "empty content",
+			content:  "",
+			expected: "",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := configPathFromUnit(tc.content)
+			assert.Equal(t, tc.expected, got)
+		})
+	}
+}
+
+func TestLinuxManagerNew(t *testing.T) {
+	m := New("/path/to/binary")
+	require.NotNil(t, m)
+	_, ok := m.(*linuxManager)
+	assert.True(t, ok, "New() should return a *linuxManager on Linux")
+}

--- a/cmd/controller/service/manager_stub.go
+++ b/cmd/controller/service/manager_stub.go
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+
+//go:build !linux && !windows && !darwin
+
+package service
+
+import (
+	"fmt"
+	"runtime"
+)
+
+func newManager(binaryPath string) Manager {
+	return &stubManager{}
+}
+
+type stubManager struct{}
+
+func (m *stubManager) InstallPath() string { return "" }
+
+func (m *stubManager) IsElevated() bool { return false }
+
+func (m *stubManager) Install(configPath string) error {
+	return fmt.Errorf("service install is not supported on %s", runtime.GOOS)
+}
+
+func (m *stubManager) Uninstall(purge bool) error {
+	return fmt.Errorf("service uninstall is not supported on %s", runtime.GOOS)
+}
+
+func (m *stubManager) Status() (*ServiceStatus, error) {
+	return &ServiceStatus{}, fmt.Errorf("service status is not supported on %s", runtime.GOOS)
+}

--- a/cmd/controller/service/manager_windows.go
+++ b/cmd/controller/service/manager_windows.go
@@ -1,0 +1,259 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+
+//go:build windows
+
+package service
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"golang.org/x/sys/windows/svc"
+	"golang.org/x/sys/windows/svc/mgr"
+)
+
+const (
+	windowsInstallDir  = `C:\Program Files\CFGMS`
+	windowsInstallPath = `C:\Program Files\CFGMS\cfgms-controller.exe`
+	windowsServiceName = "CFGMSController"
+	windowsDisplayName = "CFGMS Controller"
+	windowsDescription = "CFGMS fleet configuration management controller"
+)
+
+func newManager(binaryPath string) Manager {
+	return &windowsManager{binaryPath: binaryPath}
+}
+
+type windowsManager struct {
+	binaryPath string
+}
+
+func (m *windowsManager) InstallPath() string { return windowsInstallPath }
+
+// IsElevated returns true if the current process has Administrator privileges.
+// It checks by attempting to open the service control manager, which requires
+// Administrator — the canonical check without additional packages.
+func (m *windowsManager) IsElevated() bool {
+	scm, err := mgr.Connect()
+	if err != nil {
+		return false
+	}
+	scm.Disconnect()
+	return true
+}
+
+// Install copies the binary to C:\Program Files\CFGMS\, creates a Windows
+// service configured to start automatically with failure-restart recovery,
+// and starts it. If the service already exists it is stopped, the binary
+// replaced, and the service restarted.
+//
+// Uses the native Windows Service API via golang.org/x/sys/windows/svc/mgr.
+// Does NOT shell out to sc.exe.
+func (m *windowsManager) Install(configPath string) error {
+	if err := validateConfigPath(configPath); err != nil {
+		return err
+	}
+	if !m.IsElevated() {
+		return fmt.Errorf("install requires Administrator privileges: right-click the binary and select 'Run as administrator'")
+	}
+
+	scm, err := mgr.Connect()
+	if err != nil {
+		return fmt.Errorf("failed to connect to Windows Service Control Manager: %w", err)
+	}
+	defer scm.Disconnect()
+
+	// Stop and delete existing service to allow binary replacement (idempotent).
+	if existing, err := scm.OpenService(windowsServiceName); err == nil {
+		fmt.Println("Stopping existing service...")
+		_, _ = existing.Control(svc.Stop)
+		if err := waitForStop(existing, 30*time.Second); err != nil {
+			fmt.Printf("Warning: %v — proceeding anyway\n", err)
+		}
+		fmt.Println("Removing existing service definition...")
+		if err := existing.Delete(); err != nil {
+			existing.Close()
+			return fmt.Errorf("failed to delete existing service: %w", err)
+		}
+		existing.Close()
+	}
+
+	// Create install directory.
+	if err := os.MkdirAll(windowsInstallDir, 0755); err != nil {
+		return fmt.Errorf("failed to create install directory %s: %w", windowsInstallDir, err)
+	}
+
+	fmt.Printf("Installing to %s...\n", windowsInstallPath)
+	if err := copyBinary(m.binaryPath, windowsInstallPath); err != nil {
+		return fmt.Errorf("failed to copy binary: %w", err)
+	}
+
+	fmt.Println("Registering Windows service...")
+	newSvc, err := scm.CreateService(
+		windowsServiceName,
+		windowsInstallPath,
+		mgr.Config{
+			StartType:   mgr.StartAutomatic,
+			DisplayName: windowsDisplayName,
+			Description: windowsDescription,
+		},
+		// Arguments appended to the binary path; received as os.Args on service start.
+		"--config", configPath,
+	)
+	if err != nil {
+		return fmt.Errorf("failed to create Windows service: %w", err)
+	}
+	defer newSvc.Close()
+
+	// Configure automatic restart on failure (3 escalating delays, 1-day reset).
+	recoveryActions := []mgr.RecoveryAction{
+		{Type: mgr.ServiceRestart, Delay: 10 * time.Second},
+		{Type: mgr.ServiceRestart, Delay: 30 * time.Second},
+		{Type: mgr.ServiceRestart, Delay: 60 * time.Second},
+	}
+	if err := newSvc.SetRecoveryActions(recoveryActions, 86400); err != nil {
+		// Non-fatal: service still works without recovery options.
+		fmt.Printf("Warning: could not set service recovery options: %v\n", err)
+	}
+
+	fmt.Println("Starting service...")
+	if err := newSvc.Start(); err != nil {
+		return fmt.Errorf("failed to start Windows service: %w", err)
+	}
+
+	fmt.Printf("\nDone. CFGMS Controller installed and running.\n")
+	fmt.Printf("  Service name: %s\n", windowsServiceName)
+	fmt.Printf("  Config:  %s\n", configPath)
+	fmt.Printf("  Status:  cfgms-controller status\n")
+	fmt.Printf("  Remove:  cfgms-controller uninstall\n")
+	return nil
+}
+
+// Uninstall stops and removes the Windows service. If purge is true the
+// installed binary at windowsInstallPath is also deleted.
+func (m *windowsManager) Uninstall(purge bool) error {
+	if !m.IsElevated() {
+		return fmt.Errorf("uninstall requires Administrator privileges: right-click the binary and select 'Run as administrator'")
+	}
+
+	scm, err := mgr.Connect()
+	if err != nil {
+		return fmt.Errorf("failed to connect to Windows Service Control Manager: %w", err)
+	}
+	defer scm.Disconnect()
+
+	existing, err := scm.OpenService(windowsServiceName)
+	if err != nil {
+		fmt.Println("Service not registered — nothing to remove.")
+	} else {
+		fmt.Println("Stopping service...")
+		_, _ = existing.Control(svc.Stop)
+		if err := waitForStop(existing, 30*time.Second); err != nil {
+			fmt.Printf("Warning: %v — proceeding anyway\n", err)
+		}
+
+		fmt.Println("Removing service definition...")
+		if err := existing.Delete(); err != nil {
+			existing.Close()
+			return fmt.Errorf("failed to delete service: %w", err)
+		}
+		existing.Close()
+	}
+
+	if purge {
+		if _, err := os.Stat(windowsInstallPath); err == nil {
+			fmt.Printf("Removing %s...\n", windowsInstallPath)
+			if err := os.Remove(windowsInstallPath); err != nil {
+				return fmt.Errorf("failed to remove binary: %w", err)
+			}
+		}
+	}
+
+	fmt.Println("CFGMS Controller uninstalled.")
+	return nil
+}
+
+// Status returns the current service state without requiring elevated privileges.
+func (m *windowsManager) Status() (*ServiceStatus, error) {
+	status := &ServiceStatus{
+		ServiceName: windowsServiceName,
+		InstallPath: windowsInstallPath,
+	}
+
+	scm, err := mgr.Connect()
+	if err != nil {
+		// Cannot connect to SCM — report not installed.
+		return status, nil
+	}
+	defer scm.Disconnect()
+
+	existing, err := scm.OpenService(windowsServiceName)
+	if err != nil {
+		// Service not registered.
+		return status, nil
+	}
+	defer existing.Close()
+
+	status.Installed = true
+
+	// Extract config path from service binary path arguments.
+	cfg, err := existing.Config()
+	if err == nil {
+		status.ConfigPath = configPathFromBinaryPath(cfg.BinaryPathName)
+	}
+
+	q, err := existing.Query()
+	if err != nil {
+		return status, nil
+	}
+	status.Running = q.State == svc.Running
+
+	return status, nil
+}
+
+// configPathFromBinaryPath extracts the --config argument from a Windows
+// service binary path (which includes arguments).
+func configPathFromBinaryPath(binaryPath string) string {
+	idx := strings.Index(binaryPath, "--config ")
+	if idx == -1 {
+		return ""
+	}
+	rest := strings.TrimSpace(binaryPath[idx+len("--config "):])
+	if len(rest) == 0 {
+		return ""
+	}
+	// May be quoted.
+	if rest[0] == '"' {
+		end := strings.Index(rest[1:], `"`)
+		if end == -1 {
+			return rest[1:]
+		}
+		return rest[1 : end+1]
+	}
+	// Unquoted: take until whitespace.
+	end := strings.IndexAny(rest, " \t")
+	if end == -1 {
+		return rest
+	}
+	return rest[:end]
+}
+
+// waitForStop polls the service state until it reaches Stopped or the timeout
+// expires.
+func waitForStop(s *mgr.Service, timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		status, err := s.Query()
+		if err != nil {
+			return fmt.Errorf("failed to query service state: %w", err)
+		}
+		if status.State == svc.Stopped {
+			return nil
+		}
+		time.Sleep(250 * time.Millisecond)
+	}
+	return fmt.Errorf("service did not stop within %s", timeout)
+}

--- a/cmd/controller/service/manager_windows_test.go
+++ b/cmd/controller/service/manager_windows_test.go
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+
+//go:build windows
+
+package service
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWindowsManagerInstallPath(t *testing.T) {
+	m := New(`C:\cfgms-controller.exe`)
+	assert.Equal(t, windowsInstallPath, m.InstallPath())
+}
+
+func TestWindowsManagerInstallRequiresElevation(t *testing.T) {
+	if m := New(`C:\cfgms-controller.exe`); m.IsElevated() {
+		t.Skip("skipping elevation check — running as Administrator")
+	}
+	m := New(`C:\cfgms-controller.exe`)
+	err := m.Install(`C:\cfgms\controller.cfg`)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "Administrator")
+}
+
+func TestWindowsManagerInstallRejectsEmptyConfigPath(t *testing.T) {
+	m := New(`C:\cfgms-controller.exe`)
+	err := m.Install("")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "empty")
+}
+
+func TestWindowsManagerUninstallRequiresElevation(t *testing.T) {
+	if m := New(`C:\cfgms-controller.exe`); m.IsElevated() {
+		t.Skip("skipping elevation check — running as Administrator")
+	}
+	m := New(`C:\cfgms-controller.exe`)
+	err := m.Uninstall(false)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "Administrator")
+}
+
+func TestWindowsManagerStatusNotInstalled(t *testing.T) {
+	m := New(`C:\cfgms-controller.exe`)
+	status, err := m.Status()
+	require.NoError(t, err)
+	assert.Equal(t, windowsServiceName, status.ServiceName)
+	assert.Equal(t, windowsInstallPath, status.InstallPath)
+}
+
+func TestConfigPathFromBinaryPath(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "unquoted config path",
+			input:    `C:\Program Files\CFGMS\cfgms-controller.exe --config C:\cfgms\controller.cfg`,
+			expected: `C:\cfgms\controller.cfg`,
+		},
+		{
+			name:     "quoted config path",
+			input:    `"C:\Program Files\CFGMS\cfgms-controller.exe" --config "C:\cfgms\controller.cfg"`,
+			expected: `C:\cfgms\controller.cfg`,
+		},
+		{
+			name:     "no config argument",
+			input:    `C:\Program Files\CFGMS\cfgms-controller.exe`,
+			expected: "",
+		},
+		{
+			name:     "empty input",
+			input:    "",
+			expected: "",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := configPathFromBinaryPath(tc.input)
+			assert.Equal(t, tc.expected, got)
+		})
+	}
+}
+
+func TestWindowsManagerNew(t *testing.T) {
+	m := New(`C:\path\to\binary`)
+	require.NotNil(t, m)
+	_, ok := m.(*windowsManager)
+	assert.True(t, ok, "New() should return a *windowsManager on Windows")
+}

--- a/features/controller/api/registration_hook.go
+++ b/features/controller/api/registration_hook.go
@@ -113,7 +113,7 @@ func (h *WorkflowApprovalHook) Evaluate(ctx context.Context, input RegistrationI
 	}
 
 	// Short-circuit: built-in accept-all policy via Variables["policy"] = "accept".
-	if policy, ok := vw.Workflow.Variables["policy"].(string); ok && policy == "accept" {
+	if policy, ok := vw.Variables["policy"].(string); ok && policy == "accept" {
 		return DecisionApprove, "", nil
 	}
 


### PR DESCRIPTION
## Summary

- Adds `install --config`, `uninstall [--purge]`, and `status` subcommands to `cfgms-controller`, mirroring the steward's self-install pattern
- Creates `cmd/controller/service/` package with cross-platform OS service management (Linux systemd, macOS launchd, Windows Service API)
- Input validation in `configpath.go` blocks injection into service definition files: double-quotes (systemd) and XML-special characters `<>&\0` (launchd plist)
- `install` auto-runs `--init` if controller has not yet been initialized
- `status` shows service state, install path, config path, and CA fingerprint

## Test plan

- [ ] `cmd/controller/service/` tests: elevation checks, config path injection, unit/plist generation, configPathFrom* parsing
- [ ] `cmd/controller/` tests: Cobra command structure, required-flag enforcement, elevation requirements for install/uninstall, status without elevation
- [ ] Cross-platform builds: linux/amd64, linux/arm64, darwin/amd64, darwin/arm64, windows/amd64 — all verified
- [ ] Pre-existing lint fix: `registration_hook.go` QF1008 resolved

## Specialist Review Results

| Agent | Result | Notes |
|-------|--------|-------|
| QA Test Runner | **PASS** | All quality gates pass; marker written |
| QA Code Reviewer | **PASS** | 0 blocking issues (4 non-blocking warnings: copy.go coverage gap, redundant restart-policy tests, Windows signal test limitation, untested helpers) |
| Security Engineer | **PASS** | XML injection fix verified; gosec/staticcheck pass; Trivy skipped (network isolation) |

## Pre-existing Issues Fixed

- `features/controller/api/registration_hook.go:116` — staticcheck QF1008: embedded field selector simplified
- `cmd/controller/main_test_unix.go` — time.Sleep synchronization race replaced with ready-channel rendezvous
- `cmd/controller/main_test_windows.go` — unnecessary time.Sleep removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)