### PR TITLE
fix(dataplane): skip QUIC integration tests in short mode (Issue #595)

### DIFF
--- a/pkg/dataplane/providers/grpc/integration_test.go
+++ b/pkg/dataplane/providers/grpc/integration_test.go
@@ -129,6 +129,9 @@ func newTestTLSConfigs(t *testing.T) (serverTLS, clientTLS *tls.Config) {
 
 // TestGRPC_ConfigSync verifies server and client exchange config via SyncConfig RPC.
 func TestGRPC_ConfigSync(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping QUIC integration test in short mode — requires UDP buffer allocation")
+	}
 	env := newIntegrationEnv(t)
 	serverSess, clientSess := env.getSessions(t)
 
@@ -166,6 +169,9 @@ func TestGRPC_ConfigSync(t *testing.T) {
 
 // TestGRPC_DNASync verifies a steward streams DNA to the controller via SyncDNA RPC.
 func TestGRPC_DNASync(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping QUIC integration test in short mode — requires UDP buffer allocation")
+	}
 	env := newIntegrationEnv(t)
 	serverSess, clientSess := env.getSessions(t)
 
@@ -202,6 +208,9 @@ func TestGRPC_DNASync(t *testing.T) {
 
 // TestGRPC_BulkTransfer verifies bidirectional bulk transfer via BulkTransfer RPC.
 func TestGRPC_BulkTransfer(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping QUIC integration test in short mode — requires UDP buffer allocation")
+	}
 	env := newIntegrationEnv(t)
 	_, clientSess := env.getSessions(t)
 
@@ -224,6 +233,9 @@ func TestGRPC_BulkTransfer(t *testing.T) {
 
 // TestGRPC_LargeConfigSync verifies a 1 MB config syncs correctly over multiple chunks.
 func TestGRPC_LargeConfigSync(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping QUIC integration test in short mode — requires UDP buffer allocation")
+	}
 	env := newIntegrationEnv(t)
 	serverSess, clientSess := env.getSessions(t)
 
@@ -267,6 +279,9 @@ func TestGRPC_LargeConfigSync(t *testing.T) {
 // It does not assert a 1-to-1 mapping between a specific server session and
 // the client goroutine that sent the matching config.
 func TestGRPC_ConcurrentTransfers(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping QUIC integration test in short mode — requires UDP buffer allocation")
+	}
 	env := newIntegrationEnv(t)
 
 	const numTransfers = 5


### PR DESCRIPTION
## Summary

- Adds `testing.Short()` guards to all 5 QUIC-dependent integration tests in `pkg/dataplane/providers/grpc/integration_test.go`
- Fixes intermittent macOS CI failures in `TestGRPC_BulkTransfer` caused by insufficient UDP receive buffer on GitHub Actions runners (768 KiB available vs 7168 KiB requested by quic-go)
- Follows the exact pattern established in `pkg/transport/quic/dialer_test.go` (commit d234d23e, #564)

## Test plan

- [ ] `go test ./pkg/dataplane/providers/grpc/ -v` — all 5 QUIC tests run and pass
- [ ] `go test ./pkg/dataplane/providers/grpc/ -v -short` — all 5 QUIC tests skip with correct message
- [ ] macOS CI no longer fails intermittently on `TestGRPC_BulkTransfer`

## Specialist Review Results

| Reviewer | Result |
|----------|--------|
| QA Test Runner | **PASS** — 88 packages, all passing; cross-platform builds verified; linting clean |
| QA Code Reviewer | **PASS** — 0 blocking issues; `t.Skip` guards are legitimate infrastructure skips consistent with established pattern |
| Security Engineer | **PASS** — 0 blocking issues; no security concerns; architecture compliance verified |

Fixes #595

🤖 Generated with [Claude Code](https://claude.com/claude-code)