### PR TITLE
feat(config): add unified script_signing config block with trust modes (Issue #599)

### DIFF
--- a/features/modules/script/config.go
+++ b/features/modules/script/config.go
@@ -114,6 +114,23 @@ func (c *ScriptConfig) Validate() error {
 	return nil
 }
 
+// EffectiveSigningPolicy returns the more restrictive of the script's own signing policy
+// and the steward-level minimum enforced by the operator. This allows the steward config
+// to mandate a floor (e.g. "required") without having to modify every individual script config.
+func (c *ScriptConfig) EffectiveSigningPolicy(stewardMinimum SigningPolicy) SigningPolicy {
+	level := map[SigningPolicy]int{
+		SigningPolicyNone:     0,
+		SigningPolicyOptional: 1,
+		SigningPolicyRequired: 2,
+	}
+	scriptLevel := level[c.SigningPolicy]
+	stewardLevel := level[stewardMinimum]
+	if stewardLevel > scriptLevel {
+		return stewardMinimum
+	}
+	return c.SigningPolicy
+}
+
 // GetManagedFields returns the list of fields this configuration manages
 func (c *ScriptConfig) GetManagedFields() []string {
 	fields := []string{"content", "shell", "timeout", "signing_policy"}

--- a/features/modules/script/config_test.go
+++ b/features/modules/script/config_test.go
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+package script
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEffectiveSigningPolicy(t *testing.T) {
+	tests := []struct {
+		name            string
+		scriptPolicy    SigningPolicy
+		stewardMinimum  SigningPolicy
+		expectedPolicy  SigningPolicy
+	}{
+		{
+			name:           "script none, steward none — returns none",
+			scriptPolicy:   SigningPolicyNone,
+			stewardMinimum: SigningPolicyNone,
+			expectedPolicy: SigningPolicyNone,
+		},
+		{
+			name:           "script required, steward none — script wins (more restrictive)",
+			scriptPolicy:   SigningPolicyRequired,
+			stewardMinimum: SigningPolicyNone,
+			expectedPolicy: SigningPolicyRequired,
+		},
+		{
+			name:           "script none, steward required — steward wins (floor enforced)",
+			scriptPolicy:   SigningPolicyNone,
+			stewardMinimum: SigningPolicyRequired,
+			expectedPolicy: SigningPolicyRequired,
+		},
+		{
+			name:           "script optional, steward required — steward wins",
+			scriptPolicy:   SigningPolicyOptional,
+			stewardMinimum: SigningPolicyRequired,
+			expectedPolicy: SigningPolicyRequired,
+		},
+		{
+			name:           "script required, steward optional — script wins",
+			scriptPolicy:   SigningPolicyRequired,
+			stewardMinimum: SigningPolicyOptional,
+			expectedPolicy: SigningPolicyRequired,
+		},
+		{
+			name:           "script optional, steward optional — returns optional",
+			scriptPolicy:   SigningPolicyOptional,
+			stewardMinimum: SigningPolicyOptional,
+			expectedPolicy: SigningPolicyOptional,
+		},
+		{
+			name:           "script none, steward optional — steward floor applied",
+			scriptPolicy:   SigningPolicyNone,
+			stewardMinimum: SigningPolicyOptional,
+			expectedPolicy: SigningPolicyOptional,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &ScriptConfig{
+				SigningPolicy: tt.scriptPolicy,
+			}
+			result := cfg.EffectiveSigningPolicy(tt.stewardMinimum)
+			assert.Equal(t, tt.expectedPolicy, result)
+		})
+	}
+}

--- a/features/steward/config/config.go
+++ b/features/steward/config/config.go
@@ -155,6 +155,10 @@ type StewardSettings struct {
 	// (e.g. "30m", "5m", "1h"). Defaults to "30m" when not specified.
 	// Applies in both standalone and controller-connected modes.
 	ConvergeInterval string `yaml:"converge_interval,omitempty"`
+
+	// ScriptSigning configures script signing policy, trust modes, and trusted key allowlist.
+	// Child tenants inherit this config and may only tighten (not loosen) the policy.
+	ScriptSigning ScriptSigningConfig `yaml:"script_signing,omitempty"`
 }
 
 // SecretsConfig defines configuration for steward-side secret storage.
@@ -164,6 +168,70 @@ type SecretsConfig struct {
 
 	// Provider selects the secrets provider (default: "steward")
 	Provider string `yaml:"provider,omitempty"`
+}
+
+// ScriptSigningPolicy defines the enforcement level for script signatures at the steward level.
+type ScriptSigningPolicy string
+
+const (
+	// ScriptSigningPolicyNone does not require or validate script signatures.
+	ScriptSigningPolicyNone ScriptSigningPolicy = "none"
+
+	// ScriptSigningPolicyOptional validates signatures when present but does not require them.
+	ScriptSigningPolicyOptional ScriptSigningPolicy = "optional"
+
+	// ScriptSigningPolicyRequired rejects any script that lacks a valid signature.
+	ScriptSigningPolicyRequired ScriptSigningPolicy = "required"
+)
+
+// ScriptTrustMode defines which signing keys or CAs are considered trustworthy.
+type ScriptTrustMode string
+
+const (
+	// TrustModeAnyValid accepts any valid signature from a well-formed key.
+	TrustModeAnyValid ScriptTrustMode = "any_valid"
+
+	// TrustModeTrustedKeys accepts signatures only from keys in TrustedKeys.
+	TrustModeTrustedKeys ScriptTrustMode = "trusted_keys"
+
+	// TrustModeTrustedKeysAndPublic accepts TrustedKeys and, when AllowPublicCA is true, public CAs.
+	TrustModeTrustedKeysAndPublic ScriptTrustMode = "trusted_keys_and_public"
+)
+
+// TrustedKeyRef identifies a trusted signing key or certificate by name, thumbprint, or key reference.
+type TrustedKeyRef struct {
+	// Name is a human-readable label for this key entry.
+	Name string `yaml:"name"`
+
+	// Thumbprint is the certificate thumbprint used to identify the key.
+	Thumbprint string `yaml:"thumbprint,omitempty"`
+
+	// PublicKeyRef is an opaque reference to a public key stored in the secrets provider.
+	PublicKeyRef string `yaml:"public_key_ref,omitempty"`
+}
+
+// ScriptSigningConfig defines the steward-level script signing policy and trust configuration.
+//
+// Config inheritance: child tenants inherit parent config via MergeScriptSigningConfig.
+// Children may tighten policy (e.g. optional→required) but may not loosen it.
+type ScriptSigningConfig struct {
+	// Policy sets the enforcement level: none, optional, or required.
+	Policy ScriptSigningPolicy `yaml:"policy,omitempty"`
+
+	// TrustMode defines which keys are accepted: any_valid, trusted_keys, or trusted_keys_and_public.
+	TrustMode ScriptTrustMode `yaml:"trust_mode,omitempty"`
+
+	// TrustedKeys lists keys/certificates that are allowed to sign scripts.
+	// Required when TrustMode is trusted_keys or trusted_keys_and_public.
+	TrustedKeys []TrustedKeyRef `yaml:"trusted_keys,omitempty"`
+
+	// AllowPublicCA, when true alongside trusted_keys_and_public mode, also accepts
+	// signatures from public certificate authorities.
+	AllowPublicCA bool `yaml:"allow_public_ca,omitempty"`
+
+	// ScriptRepoURL is the MSP-level Git repository URL for the tenant's script store.
+	// Tenant-scoped; child tenants may override this to point to their own repo.
+	ScriptRepoURL string `yaml:"script_repo_url,omitempty"`
 }
 
 // ResourceConfig defines a single resource to be managed by the steward.
@@ -401,6 +469,108 @@ func applyDefaults(config *StewardConfig) {
 	}
 }
 
+// scriptSigningPolicyLevel returns the numeric strictness level of a signing policy.
+// Higher values are more restrictive. Returns -1 for unknown values.
+func scriptSigningPolicyLevel(p ScriptSigningPolicy) int {
+	switch p {
+	case ScriptSigningPolicyNone, "":
+		return 0
+	case ScriptSigningPolicyOptional:
+		return 1
+	case ScriptSigningPolicyRequired:
+		return 2
+	}
+	return -1
+}
+
+// validateScriptSigningConfig validates a ScriptSigningConfig for internal consistency.
+func validateScriptSigningConfig(cfg ScriptSigningConfig) error {
+	// Validate policy value
+	switch cfg.Policy {
+	case ScriptSigningPolicyNone, ScriptSigningPolicyOptional, ScriptSigningPolicyRequired, "":
+		// valid
+	default:
+		return fmt.Errorf("invalid script_signing policy %q: must be none, optional, or required", cfg.Policy)
+	}
+
+	// Validate trust_mode value
+	switch cfg.TrustMode {
+	case TrustModeAnyValid, TrustModeTrustedKeys, TrustModeTrustedKeysAndPublic, "":
+		// valid
+	default:
+		return fmt.Errorf("invalid script_signing trust_mode %q: must be any_valid, trusted_keys, or trusted_keys_and_public", cfg.TrustMode)
+	}
+
+	// trusted_keys and trusted_keys_and_public require a non-empty key list
+	if cfg.TrustMode == TrustModeTrustedKeys || cfg.TrustMode == TrustModeTrustedKeysAndPublic {
+		if len(cfg.TrustedKeys) == 0 {
+			return fmt.Errorf("script_signing trust_mode %q requires at least one entry in trusted_keys", cfg.TrustMode)
+		}
+	}
+
+	// Each key ref must have at least a thumbprint or public_key_ref
+	for i, key := range cfg.TrustedKeys {
+		if key.Thumbprint == "" && key.PublicKeyRef == "" {
+			return fmt.Errorf("script_signing trusted_keys[%d] (%q): must provide thumbprint or public_key_ref", i, key.Name)
+		}
+	}
+
+	return nil
+}
+
+// MergeScriptSigningConfig merges a parent ScriptSigningConfig into a child, applying inheritance rules.
+//
+// The child inherits all parent settings that the child has not explicitly set.
+// Policy may only be tightened (none→optional→required) — if the child specifies a policy
+// less restrictive than the parent's, an error is returned.
+func MergeScriptSigningConfig(parent, child ScriptSigningConfig) (ScriptSigningConfig, error) {
+	// Apply parent defaults where child has not set values
+	result := child
+
+	// Inherit policy from parent if child has none
+	if result.Policy == "" {
+		result.Policy = parent.Policy
+	}
+	if result.Policy == "" {
+		result.Policy = ScriptSigningPolicyNone
+	}
+
+	// Enforce tightening-only: child cannot loosen what parent has set
+	parentLevel := scriptSigningPolicyLevel(parent.Policy)
+	childLevel := scriptSigningPolicyLevel(result.Policy)
+	if parentLevel < 0 || childLevel < 0 {
+		return ScriptSigningConfig{}, fmt.Errorf("invalid signing policy value")
+	}
+	if childLevel < parentLevel {
+		return ScriptSigningConfig{}, fmt.Errorf(
+			"child tenant cannot loosen script_signing policy: parent requires %q, child specified %q",
+			parent.Policy, child.Policy,
+		)
+	}
+
+	// Inherit trust_mode from parent if child has none
+	if result.TrustMode == "" {
+		result.TrustMode = parent.TrustMode
+	}
+
+	// Inherit trusted_keys from parent if child has none
+	if len(result.TrustedKeys) == 0 && len(parent.TrustedKeys) > 0 {
+		result.TrustedKeys = parent.TrustedKeys
+	}
+
+	// AllowPublicCA: child inherits parent value if not set (bool — treat parent true as inherited)
+	if !result.AllowPublicCA && parent.AllowPublicCA {
+		result.AllowPublicCA = parent.AllowPublicCA
+	}
+
+	// ScriptRepoURL: child overrides parent; inherit if child has none
+	if result.ScriptRepoURL == "" {
+		result.ScriptRepoURL = parent.ScriptRepoURL
+	}
+
+	return result, nil
+}
+
 // ValidateConfiguration checks if the configuration is valid
 func ValidateConfiguration(config StewardConfig) error {
 	// Validate steward settings
@@ -438,6 +608,11 @@ func ValidateConfiguration(config StewardConfig) error {
 		if d <= 0 {
 			return fmt.Errorf("converge_interval must be positive, got %q", config.Steward.ConvergeInterval)
 		}
+	}
+
+	// Validate script signing config
+	if err := validateScriptSigningConfig(config.Steward.ScriptSigning); err != nil {
+		return fmt.Errorf("script_signing configuration invalid: %w", err)
 	}
 
 	// Validate resources

--- a/features/steward/config/config_test.go
+++ b/features/steward/config/config_test.go
@@ -577,3 +577,340 @@ resources:
 	assert.Equal(t, "15m", cfg.Steward.ConvergeInterval)
 	assert.Equal(t, 15*time.Minute, GetConvergeInterval(cfg))
 }
+
+// --- ScriptSigningConfig tests ---
+
+func TestValidateScriptSigningConfig(t *testing.T) {
+	tests := []struct {
+		name    string
+		cfg     ScriptSigningConfig
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name:    "empty config is valid (no signing)",
+			cfg:     ScriptSigningConfig{},
+			wantErr: false,
+		},
+		{
+			name: "none policy with no trust mode is valid",
+			cfg: ScriptSigningConfig{
+				Policy: ScriptSigningPolicyNone,
+			},
+			wantErr: false,
+		},
+		{
+			name: "optional policy with any_valid trust mode is valid",
+			cfg: ScriptSigningConfig{
+				Policy:    ScriptSigningPolicyOptional,
+				TrustMode: TrustModeAnyValid,
+			},
+			wantErr: false,
+		},
+		{
+			name: "required policy with trusted_keys and non-empty key list is valid",
+			cfg: ScriptSigningConfig{
+				Policy:    ScriptSigningPolicyRequired,
+				TrustMode: TrustModeTrustedKeys,
+				TrustedKeys: []TrustedKeyRef{
+					{Name: "corp-signing-key", Thumbprint: "abc123"},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "trusted_keys mode with empty key list is invalid",
+			cfg: ScriptSigningConfig{
+				Policy:      ScriptSigningPolicyRequired,
+				TrustMode:   TrustModeTrustedKeys,
+				TrustedKeys: []TrustedKeyRef{},
+			},
+			wantErr: true,
+			errMsg:  "trusted_keys",
+		},
+		{
+			name: "trusted_keys_and_public mode with keys and AllowPublicCA is valid",
+			cfg: ScriptSigningConfig{
+				Policy:    ScriptSigningPolicyRequired,
+				TrustMode: TrustModeTrustedKeysAndPublic,
+				TrustedKeys: []TrustedKeyRef{
+					{Name: "corp-signing-key", Thumbprint: "abc123"},
+				},
+				AllowPublicCA: true,
+			},
+			wantErr: false,
+		},
+		{
+			name: "trusted_keys_and_public mode with empty key list is invalid",
+			cfg: ScriptSigningConfig{
+				Policy:        ScriptSigningPolicyRequired,
+				TrustMode:     TrustModeTrustedKeysAndPublic,
+				TrustedKeys:   []TrustedKeyRef{},
+				AllowPublicCA: true,
+			},
+			wantErr: true,
+			errMsg:  "trusted_keys",
+		},
+		{
+			name: "invalid policy value is rejected",
+			cfg: ScriptSigningConfig{
+				Policy: ScriptSigningPolicy("bogus"),
+			},
+			wantErr: true,
+			errMsg:  "invalid",
+		},
+		{
+			name: "invalid trust mode value is rejected",
+			cfg: ScriptSigningConfig{
+				Policy:    ScriptSigningPolicyRequired,
+				TrustMode: ScriptTrustMode("bogus"),
+			},
+			wantErr: true,
+			errMsg:  "invalid",
+		},
+		{
+			name: "key ref with neither thumbprint nor public_key_ref is invalid",
+			cfg: ScriptSigningConfig{
+				Policy:    ScriptSigningPolicyRequired,
+				TrustMode: TrustModeTrustedKeys,
+				TrustedKeys: []TrustedKeyRef{
+					{Name: "incomplete-key"},
+				},
+			},
+			wantErr: true,
+			errMsg:  "thumbprint or public_key_ref",
+		},
+		{
+			name: "script_repo_url is optional and does not affect validation",
+			cfg: ScriptSigningConfig{
+				Policy:        ScriptSigningPolicyNone,
+				ScriptRepoURL: "https://git.example.com/msp/scripts.git",
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateScriptSigningConfig(tt.cfg)
+			if tt.wantErr {
+				require.Error(t, err)
+				if tt.errMsg != "" {
+					assert.Contains(t, err.Error(), tt.errMsg)
+				}
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestMergeScriptSigningConfig(t *testing.T) {
+	tests := []struct {
+		name        string
+		parent      ScriptSigningConfig
+		child       ScriptSigningConfig
+		wantErr     bool
+		errMsg      string
+		wantPolicy  ScriptSigningPolicy
+		wantMode    ScriptTrustMode
+		wantRepoURL string
+	}{
+		{
+			name:       "empty parent and child returns empty",
+			parent:     ScriptSigningConfig{},
+			child:      ScriptSigningConfig{},
+			wantPolicy: ScriptSigningPolicyNone,
+		},
+		{
+			name: "child inherits parent policy when child is empty",
+			parent: ScriptSigningConfig{
+				Policy:    ScriptSigningPolicyOptional,
+				TrustMode: TrustModeAnyValid,
+			},
+			child:      ScriptSigningConfig{},
+			wantPolicy: ScriptSigningPolicyOptional,
+			wantMode:   TrustModeAnyValid,
+		},
+		{
+			name: "child can tighten policy from optional to required",
+			parent: ScriptSigningConfig{
+				Policy:    ScriptSigningPolicyOptional,
+				TrustMode: TrustModeAnyValid,
+			},
+			child: ScriptSigningConfig{
+				Policy:    ScriptSigningPolicyRequired,
+				TrustMode: TrustModeTrustedKeys,
+				TrustedKeys: []TrustedKeyRef{
+					{Name: "child-key", Thumbprint: "def456"},
+				},
+			},
+			wantPolicy: ScriptSigningPolicyRequired,
+			wantMode:   TrustModeTrustedKeys,
+		},
+		{
+			name: "child can tighten policy from none to required",
+			parent: ScriptSigningConfig{
+				Policy: ScriptSigningPolicyNone,
+			},
+			child: ScriptSigningConfig{
+				Policy:    ScriptSigningPolicyRequired,
+				TrustMode: TrustModeAnyValid,
+			},
+			wantPolicy: ScriptSigningPolicyRequired,
+			wantMode:   TrustModeAnyValid,
+		},
+		{
+			name: "child cannot loosen policy from required to optional",
+			parent: ScriptSigningConfig{
+				Policy:    ScriptSigningPolicyRequired,
+				TrustMode: TrustModeAnyValid,
+			},
+			child: ScriptSigningConfig{
+				Policy: ScriptSigningPolicyOptional,
+			},
+			wantErr: true,
+			errMsg:  "loosen",
+		},
+		{
+			name: "child cannot loosen policy from required to none",
+			parent: ScriptSigningConfig{
+				Policy:    ScriptSigningPolicyRequired,
+				TrustMode: TrustModeAnyValid,
+			},
+			child: ScriptSigningConfig{
+				Policy: ScriptSigningPolicyNone,
+			},
+			wantErr: true,
+			errMsg:  "loosen",
+		},
+		{
+			name: "child cannot loosen policy from optional to none",
+			parent: ScriptSigningConfig{
+				Policy: ScriptSigningPolicyOptional,
+			},
+			child: ScriptSigningConfig{
+				Policy: ScriptSigningPolicyNone,
+			},
+			wantErr: true,
+			errMsg:  "loosen",
+		},
+		{
+			name: "child overrides script_repo_url",
+			parent: ScriptSigningConfig{
+				Policy:        ScriptSigningPolicyNone,
+				ScriptRepoURL: "https://parent.example.com/scripts.git",
+			},
+			child: ScriptSigningConfig{
+				ScriptRepoURL: "https://child.example.com/scripts.git",
+			},
+			wantPolicy:  ScriptSigningPolicyNone,
+			wantRepoURL: "https://child.example.com/scripts.git",
+		},
+		{
+			name: "child inherits parent script_repo_url when not set",
+			parent: ScriptSigningConfig{
+				Policy:        ScriptSigningPolicyNone,
+				ScriptRepoURL: "https://parent.example.com/scripts.git",
+			},
+			child:       ScriptSigningConfig{},
+			wantPolicy:  ScriptSigningPolicyNone,
+			wantRepoURL: "https://parent.example.com/scripts.git",
+		},
+		{
+			name: "child overrides trusted keys",
+			parent: ScriptSigningConfig{
+				Policy:    ScriptSigningPolicyRequired,
+				TrustMode: TrustModeTrustedKeys,
+				TrustedKeys: []TrustedKeyRef{
+					{Name: "parent-key", Thumbprint: "parent123"},
+				},
+			},
+			child: ScriptSigningConfig{
+				TrustedKeys: []TrustedKeyRef{
+					{Name: "child-key", Thumbprint: "child456"},
+				},
+			},
+			wantPolicy: ScriptSigningPolicyRequired,
+			wantMode:   TrustModeTrustedKeys,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := MergeScriptSigningConfig(tt.parent, tt.child)
+			if tt.wantErr {
+				require.Error(t, err)
+				if tt.errMsg != "" {
+					assert.Contains(t, err.Error(), tt.errMsg)
+				}
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantPolicy, result.Policy)
+			if tt.wantMode != "" {
+				assert.Equal(t, tt.wantMode, result.TrustMode)
+			}
+			if tt.wantRepoURL != "" {
+				assert.Equal(t, tt.wantRepoURL, result.ScriptRepoURL)
+			}
+		})
+	}
+}
+
+func TestScriptSigningConfigInConfigFile(t *testing.T) {
+	tempDir := t.TempDir()
+	configFile := filepath.Join(tempDir, "test.cfg")
+
+	configData := `steward:
+  id: test-steward
+  script_signing:
+    policy: required
+    trust_mode: trusted_keys
+    trusted_keys:
+      - name: corp-cert
+        thumbprint: abc123def456
+    script_repo_url: https://git.example.com/msp/scripts.git
+
+resources:
+  - name: test-resource
+    module: test-module
+    config:
+      key: value
+`
+	require.NoError(t, os.WriteFile(configFile, []byte(configData), 0644))
+
+	cfg, err := LoadConfiguration(configFile)
+	require.NoError(t, err)
+	assert.Equal(t, ScriptSigningPolicyRequired, cfg.Steward.ScriptSigning.Policy)
+	assert.Equal(t, TrustModeTrustedKeys, cfg.Steward.ScriptSigning.TrustMode)
+	assert.Len(t, cfg.Steward.ScriptSigning.TrustedKeys, 1)
+	assert.Equal(t, "corp-cert", cfg.Steward.ScriptSigning.TrustedKeys[0].Name)
+	assert.Equal(t, "abc123def456", cfg.Steward.ScriptSigning.TrustedKeys[0].Thumbprint)
+	assert.Equal(t, "https://git.example.com/msp/scripts.git", cfg.Steward.ScriptSigning.ScriptRepoURL)
+}
+
+func TestScriptSigningConfigValidationInLoadConfiguration(t *testing.T) {
+	tempDir := t.TempDir()
+	configFile := filepath.Join(tempDir, "test.cfg")
+
+	// trusted_keys mode with empty key list should fail validation
+	configData := `steward:
+  id: test-steward
+  script_signing:
+    policy: required
+    trust_mode: trusted_keys
+    trusted_keys: []
+
+resources:
+  - name: test-resource
+    module: test-module
+    config:
+      key: value
+`
+	require.NoError(t, os.WriteFile(configFile, []byte(configData), 0644))
+
+	_, err := LoadConfiguration(configFile)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "trusted_keys")
+}


### PR DESCRIPTION
## Summary

- Adds `ScriptSigningConfig` to `StewardSettings` with `Policy` (none/optional/required), `TrustMode` (any_valid/trusted_keys/trusted_keys_and_public), `TrustedKeys` allowlist, `AllowPublicCA`, and `ScriptRepoURL` (MSP-level tenant-scoped Git repo URL)
- Adds `MergeScriptSigningConfig(parent, child)` for tenant inheritance — children may tighten but not loosen parent policy
- Adds `validateScriptSigningConfig` wired into `ValidateConfiguration` — rejects invalid enums and `trusted_keys` mode with empty key list
- Adds `EffectiveSigningPolicy(stewardMinimum)` to `ScriptConfig` in the script module — returns the more restrictive of per-script vs steward-level policy
- Full test coverage: 11 validation cases, 10 inheritance/merge cases, YAML round-trip, load-time validation, 7-case EffectiveSigningPolicy table

Fixes #599
Parent Epic: #598

## Specialist Review Results

| Reviewer | Result |
|----------|--------|
| qa-test-runner | **PASS** — all story tests pass with race detection |
| qa-code-reviewer | **PASS** — no mocks, no skips, full error path coverage |
| security-engineer | **PASS** — no hardcoded secrets, no provider violations, tenant isolation enforced |

## Test plan

- [x] `go test -race ./features/steward/config/... ./features/modules/script/...` passes
- [x] `make test-agent-complete` — story packages pass; pre-existing env failures unrelated to this branch
- [x] Architecture check passes (`make check-architecture`)
- [x] Security pre-commit passes (`make security-precommit`)
- [x] gofmt formatting verified clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)