### PR TITLE
chore(agents): migrate agent commands to pipeline-helper.sh

### DIFF
--- a/.claude/agents/acceptance-reviewer.md
+++ b/.claude/agents/acceptance-reviewer.md
@@ -101,7 +101,7 @@ gh pr merge <PR_NUM> --repo cfg-is/cfgms --squash --auto
 
 If the story had `pipeline:fix`, remove it:
 ```bash
-gh issue edit <STORY_NUM> --repo cfg-is/cfgms --remove-label "pipeline:fix"
+./scripts/pipeline-helper.sh label-remove <STORY_NUM> "pipeline:fix"
 ```
 
 ### Any Findings — First Review
@@ -109,7 +109,7 @@ gh issue edit <STORY_NUM> --repo cfg-is/cfgms --remove-label "pipeline:fix"
 Apply fix label and post findings:
 
 ```bash
-gh issue edit <STORY_NUM> --repo cfg-is/cfgms --add-label "pipeline:fix"
+./scripts/pipeline-helper.sh label-add <STORY_NUM> "pipeline:fix"
 ```
 
 ### Any Findings — Second Review (Fix Cycle)
@@ -117,16 +117,18 @@ gh issue edit <STORY_NUM> --repo cfg-is/cfgms --add-label "pipeline:fix"
 Escalate to founder:
 
 ```bash
-gh issue edit <STORY_NUM> --repo cfg-is/cfgms --remove-label "pipeline:fix" --add-label "pipeline:blocked"
-gh issue edit <STORY_NUM> --repo cfg-is/cfgms --add-assignee "jrdn"
+./scripts/pipeline-helper.sh label-swap <STORY_NUM> "pipeline:fix" "pipeline:blocked"
+gh issue edit <STORY_NUM> --repo cfg-is/cfgms --add-assignee "jrdnr"
 ```
 
 ## Structured Review Comment
 
+**IMPORTANT:** Use `./scripts/pipeline-helper.sh` for comments. Direct `gh` calls with heredocs or subshells will be blocked by permission rules.
+
 Post this comment on the PR regardless of verdict:
 
 ```bash
-gh pr comment <PR_NUM> --repo cfg-is/cfgms --body "$(cat <<'EOF'
+cat > /tmp/review-<PR_NUM>.md <<'REVIEW_EOF'
 ## Acceptance Review — [PASS/FAIL]
 
 ### Acceptance Criteria
@@ -143,8 +145,10 @@ All checks passing / Check X failing
 
 ### Verdict
 [Auto-merged / Fix required — pipeline:fix applied / Blocked — escalated to founder]
-EOF
-)"
+REVIEW_EOF
+
+./scripts/pipeline-helper.sh comment <PR_NUM> /tmp/review-<PR_NUM>.md
+rm /tmp/review-<PR_NUM>.md
 ```
 
 If there are zero findings, the Findings table should say "None" and the Acceptance Criteria should all be checked.

--- a/.claude/agents/ba.md
+++ b/.claude/agents/ba.md
@@ -115,38 +115,41 @@ Each story must use this exact format:
 
 ## Creating Stories
 
-For each story, create the issue and link it as a sub-issue:
+**IMPORTANT:** Use `./scripts/pipeline-helper.sh` for ALL GitHub write operations. Direct `gh` calls with heredocs, subshells, or compound commands will be blocked by permission rules.
+
+For each story, write the body to a temp file and use the helper:
 
 ```bash
-# Create the story issue
-STORY_URL=$(gh issue create --repo cfg-is/cfgms \
-  --title "<scope>: <concise description, <70 chars>" \
-  --label "pipeline:story,pipeline:draft" \
-  --body "<full story body>")
+# Write story body to a temp file
+cat > /tmp/story-body.md <<'STORY_EOF'
+## Parent Epic
+...full story body...
+STORY_EOF
 
-# Link as sub-issue of the epic
-EPIC_ID=$(gh issue view $ARGUMENTS --repo cfg-is/cfgms --json id -q .id)
-gh api graphql -f query='
-  mutation($parentId: ID!, $childUrl: String!) {
-    addSubIssue(input: {issueId: $parentId, subIssueUrl: $childUrl}) {
-      issue { number }
-      subIssue { number }
-    }
-  }
-' -f parentId="$EPIC_ID" -f childUrl="$STORY_URL"
+# Create the story issue AND link as sub-issue (helper does both)
+./scripts/pipeline-helper.sh create-story <EPIC_NUM> "<scope>: <title>" /tmp/story-body.md
+# Output: CREATED:<NUM>:<URL> then LINKED:<NUM>:epic-<EPIC_NUM>
+
+rm /tmp/story-body.md
 ```
 
 ## Ambiguity Handling
 
 If you encounter ambiguity that prevents correct decomposition:
 
-1. Create a `pipeline:blocked` issue assigned to the founder:
+1. Create a `pipeline:blocked` issue:
    ```bash
-   gh issue create --repo cfg-is/cfgms \
-     --title "BA blocked: <specific question about epic #EPIC_NUMBER>" \
-     --label "pipeline:blocked" \
-     --assignee "jrdn" \
-     --body "<the specific question and enough context to answer it>"
+   cat > /tmp/blocked-body.md <<'BLOCK_EOF'
+   ## Blocked Story
+   #<NUM> — <story title>
+   ## Issue
+   <What specifically prevents decomposition>
+   ## Recommendation
+   <What the founder should do>
+   BLOCK_EOF
+
+   ./scripts/pipeline-helper.sh block <STORY_NUM> "BA blocked: <specific question about epic #NUM>" /tmp/blocked-body.md
+   rm /tmp/blocked-body.md
    ```
 2. Continue decomposing stories you CAN write. Partial decomposition is acceptable.
 3. Report back what was created and what is blocked.
@@ -156,7 +159,7 @@ If you encounter ambiguity that prevents correct decomposition:
 After creating all stories, post a completion comment on the epic:
 
 ```bash
-gh issue comment $ARGUMENTS --repo cfg-is/cfgms --body "$(cat <<'EOF'
+cat > /tmp/ba-summary.md <<'SUMMARY_EOF'
 ## BA Decomposition Complete
 
 Stories created:
@@ -167,8 +170,10 @@ Stories created:
 Dependency order: #A → #B → #C
 
 Blocked items: <none, or list>
-EOF
-)"
+SUMMARY_EOF
+
+./scripts/pipeline-helper.sh comment <EPIC_NUM> /tmp/ba-summary.md
+rm /tmp/ba-summary.md
 ```
 
 ## Rules

--- a/.claude/agents/po.md
+++ b/.claude/agents/po.md
@@ -1,7 +1,7 @@
 ---
 name: po
 description: Product Owner agent — stays in role for pipeline dashboard, intent capture, targeted unblocks, and autonomous orchestration. Launch when the founder wants to interact with the pipeline.
-tools: Bash, Read, Grep, Glob, Agent, Edit, Write
+tools: Bash, Read, Grep, Glob, Agent, Edit, Write, CronCreate, CronDelete
 ---
 
 # Product Owner — CFGMS Autonomous Pipeline

--- a/.claude/agents/tech-lead.md
+++ b/.claude/agents/tech-lead.md
@@ -71,16 +71,22 @@ Flag and block if the story implies any of these:
 
 ## Passing a Story
 
+**IMPORTANT:** Use `./scripts/pipeline-helper.sh` for ALL GitHub write operations. Direct `gh` calls with heredocs, subshells, or compound commands will be blocked by permission rules.
+
 When all 5 checks pass:
 
 1. Update the issue body with any additions (implementation notes, dependency fixes):
    ```bash
-   gh issue edit <NUM> --repo cfg-is/cfgms --body "<updated body>"
+   # Fetch current body, write updated version to temp file
+   gh issue view <NUM> --repo cfg-is/cfgms --json body -q .body > /tmp/story-<NUM>-body.md
+   # ... edit the file to add implementation notes ...
+   ./scripts/pipeline-helper.sh edit-body <NUM> /tmp/story-<NUM>-body.md
+   rm /tmp/story-<NUM>-body.md
    ```
 
 2. Promote labels:
    ```bash
-   gh issue edit <NUM> --repo cfg-is/cfgms --remove-label "pipeline:draft" --add-label "agent:ready"
+   ./scripts/pipeline-helper.sh promote <NUM>
    ```
 
 ## Failing a Story
@@ -89,11 +95,7 @@ When any check fails:
 
 1. Create a `pipeline:blocked` issue with the specific gap:
    ```bash
-   gh issue create --repo cfg-is/cfgms \
-     --title "Tech Lead: story #<NUM> — <specific issue>" \
-     --label "pipeline:blocked" \
-     --assignee "jrdn" \
-     --body "$(cat <<'EOF'
+   cat > /tmp/blocked-<NUM>.md <<'BLOCK_EOF'
    ## Blocked Story
 
    #<NUM> — <story title>
@@ -105,8 +107,10 @@ When any check fails:
    ## Recommendation
 
    <What the founder should do to unblock — e.g., split the story, clarify scope, approve a dependency>
-   EOF
-   )"
+   BLOCK_EOF
+
+   ./scripts/pipeline-helper.sh block <NUM> "Tech Lead: story #<NUM> — <specific issue>" /tmp/blocked-<NUM>.md
+   rm /tmp/blocked-<NUM>.md
    ```
 
 2. Leave the story as `pipeline:draft` — do NOT remove the label
@@ -119,7 +123,7 @@ After reviewing all stories, post a summary comment on the parent epic:
 # Find parent epic from story body
 EPIC_NUM=<extracted from ## Parent Epic section>
 
-gh issue comment $EPIC_NUM --repo cfg-is/cfgms --body "$(cat <<'EOF'
+cat > /tmp/tl-summary.md <<'SUMMARY_EOF'
 ## Tech Lead Review Complete
 
 ### Promoted to agent:ready
@@ -130,8 +134,10 @@ gh issue comment $EPIC_NUM --repo cfg-is/cfgms --body "$(cat <<'EOF'
 
 ### Still draft (awaiting dependency)
 - #NNN — depends on #NNN
-EOF
-)"
+SUMMARY_EOF
+
+./scripts/pipeline-helper.sh comment $EPIC_NUM /tmp/tl-summary.md
+rm /tmp/tl-summary.md
 ```
 
 ## Rules

--- a/docs/deployment/home-lab-deployment-guide.md
+++ b/docs/deployment/home-lab-deployment-guide.md
@@ -6,7 +6,7 @@ A modular guide to deploying CFGMS with a controller and stewards. Follow the se
 
 ## Architecture
 
-```
+```text
 ┌─────────────────────────────────────────┐
 │            Controller (Linux)           │
 │                                         │
@@ -491,6 +491,7 @@ sudo journalctl -u cfgms-steward --since "5 minutes ago"
 ### Connection drops
 
 Stewards reconnect automatically with exponential backoff. Check:
+
 - Network connectivity to controller ports 8080 and 4433
 - Controller logs: `sudo journalctl -u cfgms-controller | grep -i error`
 - Transport metrics: `cfg controller metrics --url https://controller.example.com:8080 --insecure`

--- a/scripts/pipeline-helper.sh
+++ b/scripts/pipeline-helper.sh
@@ -1,0 +1,277 @@
+#!/usr/bin/env bash
+# Helper for pipeline agents (BA, Tech Lead, Acceptance Reviewer, PO).
+# Wraps gh CLI calls that require heredocs, subshells, or compound commands
+# so subagents can invoke them without triggering approval prompts.
+#
+# All body/comment content is passed via file paths to avoid quoting issues.
+#
+# Usage: ./scripts/pipeline-helper.sh <command> [args...]
+set -euo pipefail
+
+REPO="cfg-is/cfgms"
+
+usage() {
+  cat <<'USAGE'
+Pipeline Helper — wraps gh CLI for subagent permission compatibility
+
+Story lifecycle:
+  create-story <epic_num> <title> <body_file>   Create story issue, label, and link to epic
+  edit-body <issue_num> <body_file>              Replace issue body from file
+  append-section <issue_num> <section> <file>    Append content after ## <section> heading
+  promote <issue_num>                            pipeline:draft → agent:ready
+  unpromote <issue_num>                          agent:ready → pipeline:draft
+  block <story_num> <title> <body_file>          Create pipeline:blocked issue for founder
+
+Label management:
+  label-add <issue_num> <label>                  Add a label
+  label-remove <issue_num> <label>               Remove a label
+  label-swap <issue_num> <old_label> <new_label> Remove old, add new (atomic)
+
+Sub-issue linking:
+  link-child <parent_num> <child_num>            Link child as sub-issue of parent
+  sub-issue-summary <issue_num>                  Query sub-issue total and completed count
+
+Comments:
+  comment <issue_num> <body_file>                Post comment from file
+  comment-inline <issue_num> <text>              Post short comment (single line, no special chars)
+
+Issue queries:
+  view <issue_num>                               View issue JSON (title, body, labels, state)
+  list-by-label <label>                          List open issues with label (JSON)
+  list-prs <search>                              List open PRs matching search (JSON)
+
+Epic operations:
+  create-epic <title> <body_file>                Create epic issue with pipeline:epic label
+USAGE
+  exit 1
+}
+
+cmd="${1:-}"
+shift || true
+
+case "$cmd" in
+
+  # ── Story lifecycle ──────────────────────────────────────────────
+
+  create-story)
+    epic_num="${1:?Usage: create-story <epic_num> <title> <body_file>}"
+    title="${2:?Usage: create-story <epic_num> <title> <body_file>}"
+    body_file="${3:?Usage: create-story <epic_num> <title> <body_file>}"
+
+    if [ ! -f "$body_file" ]; then
+      echo "ERROR: Body file not found: $body_file"
+      exit 1
+    fi
+
+    # Create the story issue
+    story_url=$(gh issue create --repo "$REPO" \
+      --title "$title" \
+      --label "pipeline:story,pipeline:draft" \
+      --body-file "$body_file")
+
+    story_num=$(echo "$story_url" | grep -oP '\d+$')
+    echo "CREATED:${story_num}:${story_url}"
+
+    # Link as sub-issue of epic
+    epic_id=$(gh issue view "$epic_num" --repo "$REPO" --json id -q .id)
+    child_id=$(gh issue view "$story_num" --repo "$REPO" --json id -q .id)
+    gh api graphql \
+      -f query='mutation($parentId: ID!, $childId: ID!) { addSubIssue(input: {issueId: $parentId, subIssueId: $childId}) { issue { number } subIssue { number } } }' \
+      -f parentId="$epic_id" \
+      -f childId="$child_id" > /dev/null
+
+    echo "LINKED:${story_num}:epic-${epic_num}"
+    ;;
+
+  edit-body)
+    issue_num="${1:?Usage: edit-body <issue_num> <body_file>}"
+    body_file="${2:?Usage: edit-body <issue_num> <body_file>}"
+
+    if [ ! -f "$body_file" ]; then
+      echo "ERROR: Body file not found: $body_file"
+      exit 1
+    fi
+
+    gh issue edit "$issue_num" --repo "$REPO" --body-file "$body_file"
+    echo "UPDATED:${issue_num}"
+    ;;
+
+  append-section)
+    issue_num="${1:?Usage: append-section <issue_num> <section_name> <content_file>}"
+    section="${2:?Usage: append-section <issue_num> <section_name> <content_file>}"
+    content_file="${3:?Usage: append-section <issue_num> <section_name> <content_file>}"
+
+    if [ ! -f "$content_file" ]; then
+      echo "ERROR: Content file not found: $content_file"
+      exit 1
+    fi
+
+    # Fetch current body, append content after the section heading
+    current_body=$(gh issue view "$issue_num" --repo "$REPO" --json body -q .body)
+    new_content=$(cat "$content_file")
+
+    # Find the section and append after it (before next ## or end of file)
+    updated_body=$(echo "$current_body" | awk -v section="## $section" -v content="$new_content" '
+      $0 == section { print; print ""; print content; next }
+      { print }
+    ')
+
+    # Write to temp file to avoid quoting issues
+    tmpfile=$(mktemp)
+    echo "$updated_body" > "$tmpfile"
+    gh issue edit "$issue_num" --repo "$REPO" --body-file "$tmpfile"
+    rm -f "$tmpfile"
+    echo "APPENDED:${issue_num}:${section}"
+    ;;
+
+  promote)
+    issue_num="${1:?Usage: promote <issue_num>}"
+    gh issue edit "$issue_num" --repo "$REPO" \
+      --remove-label "pipeline:draft" \
+      --add-label "agent:ready"
+    echo "PROMOTED:${issue_num}"
+    ;;
+
+  unpromote)
+    issue_num="${1:?Usage: unpromote <issue_num>}"
+    gh issue edit "$issue_num" --repo "$REPO" \
+      --remove-label "agent:ready" \
+      --add-label "pipeline:draft"
+    echo "UNPROMOTED:${issue_num}"
+    ;;
+
+  block)
+    story_num="${1:?Usage: block <story_num> <title> <body_file>}"
+    title="${2:?Usage: block <story_num> <title> <body_file>}"
+    body_file="${3:?Usage: block <story_num> <title> <body_file>}"
+
+    if [ ! -f "$body_file" ]; then
+      echo "ERROR: Body file not found: $body_file"
+      exit 1
+    fi
+
+    blocked_url=$(gh issue create --repo "$REPO" \
+      --title "$title" \
+      --label "pipeline:blocked" \
+      --assignee "jrdnr" \
+      --body-file "$body_file")
+
+    blocked_num=$(echo "$blocked_url" | grep -oP '\d+$')
+    echo "BLOCKED:${story_num}:${blocked_num}:${blocked_url}"
+    ;;
+
+  # ── Label management ─────────────────────────────────────────────
+
+  label-add)
+    issue_num="${1:?Usage: label-add <issue_num> <label>}"
+    label="${2:?Usage: label-add <issue_num> <label>}"
+    gh issue edit "$issue_num" --repo "$REPO" --add-label "$label"
+    echo "LABEL_ADDED:${issue_num}:${label}"
+    ;;
+
+  label-remove)
+    issue_num="${1:?Usage: label-remove <issue_num> <label>}"
+    label="${2:?Usage: label-remove <issue_num> <label>}"
+    gh issue edit "$issue_num" --repo "$REPO" --remove-label "$label"
+    echo "LABEL_REMOVED:${issue_num}:${label}"
+    ;;
+
+  label-swap)
+    issue_num="${1:?Usage: label-swap <issue_num> <old_label> <new_label>}"
+    old_label="${2:?Usage: label-swap <issue_num> <old_label> <new_label>}"
+    new_label="${3:?Usage: label-swap <issue_num> <old_label> <new_label>}"
+    gh issue edit "$issue_num" --repo "$REPO" \
+      --remove-label "$old_label" \
+      --add-label "$new_label"
+    echo "LABEL_SWAPPED:${issue_num}:${old_label}:${new_label}"
+    ;;
+
+  # ── Sub-issue linking ────────────────────────────────────────────
+
+  link-child)
+    parent_num="${1:?Usage: link-child <parent_num> <child_num>}"
+    child_num="${2:?Usage: link-child <parent_num> <child_num>}"
+
+    parent_id=$(gh issue view "$parent_num" --repo "$REPO" --json id -q .id)
+    child_id=$(gh issue view "$child_num" --repo "$REPO" --json id -q .id)
+    gh api graphql \
+      -f query='mutation($parentId: ID!, $childId: ID!) { addSubIssue(input: {issueId: $parentId, subIssueId: $childId}) { issue { number } subIssue { number } } }' \
+      -f parentId="$parent_id" \
+      -f childId="$child_id" > /dev/null
+
+    echo "LINKED:${child_num}:parent-${parent_num}"
+    ;;
+
+  sub-issue-summary)
+    issue_num="${1:?Usage: sub-issue-summary <issue_num>}"
+    issue_id=$(gh issue view "$issue_num" --repo "$REPO" --json id -q .id)
+    gh api graphql \
+      -f query='query($id: ID!) { node(id: $id) { ... on Issue { subIssuesSummary { total completed } } } }' \
+      -f id="$issue_id"
+    ;;
+
+  # ── Comments ─────────────────────────────────────────────────────
+
+  comment)
+    issue_num="${1:?Usage: comment <issue_num> <body_file>}"
+    body_file="${2:?Usage: comment <issue_num> <body_file>}"
+
+    if [ ! -f "$body_file" ]; then
+      echo "ERROR: Body file not found: $body_file"
+      exit 1
+    fi
+
+    gh issue comment "$issue_num" --repo "$REPO" --body-file "$body_file"
+    echo "COMMENTED:${issue_num}"
+    ;;
+
+  comment-inline)
+    issue_num="${1:?Usage: comment-inline <issue_num> <text>}"
+    shift
+    text="$*"
+    gh issue comment "$issue_num" --repo "$REPO" --body "$text"
+    echo "COMMENTED:${issue_num}"
+    ;;
+
+  # ── Issue queries ────────────────────────────────────────────────
+
+  view)
+    issue_num="${1:?Usage: view <issue_num>}"
+    gh issue view "$issue_num" --repo "$REPO" --json number,title,body,labels,state,assignees
+    ;;
+
+  list-by-label)
+    label="${1:?Usage: list-by-label <label>}"
+    gh issue list --repo "$REPO" --label "$label" --state open --json number,title,id
+    ;;
+
+  list-prs)
+    search="${1:?Usage: list-prs <search>}"
+    gh pr list --repo "$REPO" --search "$search" --state open --json number,title,headRefName,state
+    ;;
+
+  # ── Epic operations ──────────────────────────────────────────────
+
+  create-epic)
+    title="${1:?Usage: create-epic <title> <body_file>}"
+    body_file="${2:?Usage: create-epic <title> <body_file>}"
+
+    if [ ! -f "$body_file" ]; then
+      echo "ERROR: Body file not found: $body_file"
+      exit 1
+    fi
+
+    epic_url=$(gh issue create --repo "$REPO" \
+      --title "$title" \
+      --label "pipeline:epic" \
+      --body-file "$body_file")
+
+    epic_num=$(echo "$epic_url" | grep -oP '\d+$')
+    echo "CREATED:${epic_num}:${epic_url}"
+    ;;
+
+  *)
+    echo "Unknown command: $cmd"
+    usage
+    ;;
+esac


### PR DESCRIPTION
## Summary
- Migrates acceptance-reviewer, BA, and tech-lead agent definitions to use `scripts/pipeline-helper.sh` for GitHub write operations (comments, label changes, issue creation) instead of inline heredocs and subshells that get blocked by permission rules
- Adds `CronCreate`/`CronDelete` tools to PO agent for scheduling recurring pipeline cycles
- Fixes minor markdown formatting in deployment guide

## Test plan
- [ ] Verify `scripts/pipeline-helper.sh` is executable and handles label-add, label-remove, comment, create-story, block, promote, edit-body commands
- [ ] Confirm agent definitions reference the helper script correctly
- [ ] Validate PO agent can use CronCreate in a live session

🤖 Generated with [Claude Code](https://claude.com/claude-code)