### PR TITLE
workflow: wire FleetQuery into script dispatch targeting (Issue #609)

### DIFF
--- a/features/controller/fleet/fleet.go
+++ b/features/controller/fleet/fleet.go
@@ -7,7 +7,10 @@
 // This ensures consistent filter semantics across all device-selection code paths.
 package fleet
 
-import "strings"
+import (
+	"fmt"
+	"strings"
+)
 
 // Filter defines criteria for selecting devices from the fleet.
 // Field names match the REST API query parameters for consistency:
@@ -72,7 +75,8 @@ type Device struct {
 // The controller service implements this via its steward registry.
 type DeviceSource interface {
 	// ListDevices returns all currently known devices with their metadata.
-	ListDevices() []Device
+	// Returns an error if the underlying registry is unavailable.
+	ListDevices() ([]Device, error)
 }
 
 // StewardFleetQuery implements FleetQuery against a DeviceSource.
@@ -90,7 +94,10 @@ func NewStewardFleetQuery(source DeviceSource) *StewardFleetQuery {
 // Search returns all device IDs that match the filter.
 // The filter is evaluated against the live DeviceSource on every call.
 func (q *StewardFleetQuery) Search(filter Filter) ([]string, error) {
-	devices := q.source.ListDevices()
+	devices, err := q.source.ListDevices()
+	if err != nil {
+		return nil, fmt.Errorf("listing devices: %w", err)
+	}
 	matches := make([]string, 0, len(devices))
 
 	for _, d := range devices {

--- a/features/controller/fleet/fleet.go
+++ b/features/controller/fleet/fleet.go
@@ -1,0 +1,149 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+// Package fleet provides fleet-wide device query and filtering for the CFGMS controller.
+//
+// The FleetQuery interface is the single query path used by both the REST API
+// (GET /api/v1/stewards?os=windows&tag=prod) and workflow script dispatch targeting.
+// This ensures consistent filter semantics across all device-selection code paths.
+package fleet
+
+import "strings"
+
+// Filter defines criteria for selecting devices from the fleet.
+// Field names match the REST API query parameters for consistency:
+//
+//	GET /api/v1/stewards?os=windows&tag=prod&group=servers
+//
+// An empty Filter matches all devices.
+type Filter struct {
+	// OS filters by operating system (e.g., "windows", "linux", "darwin").
+	// Matches the ?os= REST API query parameter and DNA attribute "os".
+	OS string `yaml:"os,omitempty" json:"os,omitempty"`
+
+	// Tags filters devices that have ALL listed tags.
+	// Matches the ?tag= REST API query parameter.
+	Tags []string `yaml:"tags,omitempty" json:"tags,omitempty"`
+
+	// Groups filters devices belonging to ALL listed groups.
+	// Matches the ?group= REST API query parameter.
+	Groups []string `yaml:"groups,omitempty" json:"groups,omitempty"`
+
+	// DNAQuery filters by arbitrary DNA attributes (key=value pairs).
+	// All entries must match (AND semantics).
+	DNAQuery map[string]string `yaml:"dna_query,omitempty" json:"dna_query,omitempty"`
+}
+
+// IsEmpty reports whether the filter has no criteria set,
+// which means it would match every device in the fleet.
+func (f Filter) IsEmpty() bool {
+	return f.OS == "" && len(f.Tags) == 0 && len(f.Groups) == 0 && len(f.DNAQuery) == 0
+}
+
+// FleetQuery resolves a Filter into a set of matching device IDs.
+// Implementations must re-evaluate the filter on each call — results must
+// reflect current fleet state, not a cached snapshot. This guarantees that
+// recurring scheduled workflows always target the current device population.
+type FleetQuery interface {
+	// Search returns the IDs of all devices that match the given filter.
+	// An empty filter returns all known device IDs.
+	// Returns an empty slice (not an error) when no devices match.
+	Search(filter Filter) ([]string, error)
+}
+
+// Device represents a single device entry in the fleet registry.
+type Device struct {
+	// ID is the unique device identifier.
+	ID string
+
+	// OS is the operating system ("windows", "linux", "darwin").
+	OS string
+
+	// Tags are labels assigned to the device.
+	Tags []string
+
+	// Groups are group memberships for the device.
+	Groups []string
+
+	// Attributes holds arbitrary DNA key-value properties.
+	Attributes map[string]string
+}
+
+// DeviceSource provides a snapshot of the current fleet for querying.
+// The controller service implements this via its steward registry.
+type DeviceSource interface {
+	// ListDevices returns all currently known devices with their metadata.
+	ListDevices() []Device
+}
+
+// StewardFleetQuery implements FleetQuery against a DeviceSource.
+// It evaluates the filter on each Search call so that recurring workflows
+// always see the current fleet state.
+type StewardFleetQuery struct {
+	source DeviceSource
+}
+
+// NewStewardFleetQuery creates a FleetQuery backed by the given DeviceSource.
+func NewStewardFleetQuery(source DeviceSource) *StewardFleetQuery {
+	return &StewardFleetQuery{source: source}
+}
+
+// Search returns all device IDs that match the filter.
+// The filter is evaluated against the live DeviceSource on every call.
+func (q *StewardFleetQuery) Search(filter Filter) ([]string, error) {
+	devices := q.source.ListDevices()
+	matches := make([]string, 0, len(devices))
+
+	for _, d := range devices {
+		if matchesFilter(d, filter) {
+			matches = append(matches, d.ID)
+		}
+	}
+	return matches, nil
+}
+
+// matchesFilter returns true when d satisfies all criteria in f.
+// All criteria use AND semantics: every non-empty criterion must match.
+func matchesFilter(d Device, f Filter) bool {
+	// OS filter
+	if f.OS != "" && !strings.EqualFold(d.OS, f.OS) {
+		return false
+	}
+
+	// Tags filter — device must have ALL requested tags
+	if len(f.Tags) > 0 {
+		deviceTagSet := sliceToSet(d.Tags)
+		for _, tag := range f.Tags {
+			if !deviceTagSet[tag] {
+				return false
+			}
+		}
+	}
+
+	// Groups filter — device must belong to ALL requested groups
+	if len(f.Groups) > 0 {
+		deviceGroupSet := sliceToSet(d.Groups)
+		for _, group := range f.Groups {
+			if !deviceGroupSet[group] {
+				return false
+			}
+		}
+	}
+
+	// DNAQuery filter — all key=value pairs must match device attributes
+	for key, value := range f.DNAQuery {
+		if d.Attributes[key] != value {
+			return false
+		}
+	}
+
+	return true
+}
+
+// sliceToSet converts a string slice to a set (map[string]bool) for O(1) lookup.
+func sliceToSet(items []string) map[string]bool {
+	set := make(map[string]bool, len(items))
+	for _, item := range items {
+		set[item] = true
+	}
+	return set
+}

--- a/features/controller/fleet/fleet_test.go
+++ b/features/controller/fleet/fleet_test.go
@@ -1,0 +1,193 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+package fleet
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// staticDeviceSource is a test DeviceSource backed by a fixed device list.
+type staticDeviceSource struct {
+	devices []Device
+}
+
+func (s *staticDeviceSource) ListDevices() []Device { return s.devices }
+
+func TestFilter_IsEmpty(t *testing.T) {
+	tests := []struct {
+		name   string
+		filter Filter
+		want   bool
+	}{
+		{"empty filter", Filter{}, true},
+		{"os set", Filter{OS: "linux"}, false},
+		{"tags set", Filter{Tags: []string{"prod"}}, false},
+		{"groups set", Filter{Groups: []string{"servers"}}, false},
+		{"dna_query set", Filter{DNAQuery: map[string]string{"env": "prod"}}, false},
+		{"all fields set", Filter{OS: "windows", Tags: []string{"a"}, Groups: []string{"b"}, DNAQuery: map[string]string{"k": "v"}}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, tt.filter.IsEmpty())
+		})
+	}
+}
+
+func TestStewardFleetQuery_Search_EmptyFilter(t *testing.T) {
+	src := &staticDeviceSource{
+		devices: []Device{
+			{ID: "d1", OS: "linux"},
+			{ID: "d2", OS: "windows"},
+		},
+	}
+	q := NewStewardFleetQuery(src)
+
+	ids, err := q.Search(Filter{})
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{"d1", "d2"}, ids)
+}
+
+func TestStewardFleetQuery_Search_OSFilter(t *testing.T) {
+	src := &staticDeviceSource{
+		devices: []Device{
+			{ID: "linux-1", OS: "linux"},
+			{ID: "linux-2", OS: "Linux"}, // case-insensitive
+			{ID: "win-1", OS: "windows"},
+		},
+	}
+	q := NewStewardFleetQuery(src)
+
+	ids, err := q.Search(Filter{OS: "linux"})
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{"linux-1", "linux-2"}, ids)
+}
+
+func TestStewardFleetQuery_Search_TagFilter(t *testing.T) {
+	src := &staticDeviceSource{
+		devices: []Device{
+			{ID: "d1", Tags: []string{"prod", "web"}},
+			{ID: "d2", Tags: []string{"prod", "db"}},
+			{ID: "d3", Tags: []string{"staging"}},
+		},
+	}
+	q := NewStewardFleetQuery(src)
+
+	ids, err := q.Search(Filter{Tags: []string{"prod"}})
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{"d1", "d2"}, ids)
+}
+
+func TestStewardFleetQuery_Search_MultipleTagsAndSemantics(t *testing.T) {
+	src := &staticDeviceSource{
+		devices: []Device{
+			{ID: "d1", Tags: []string{"prod", "web"}},
+			{ID: "d2", Tags: []string{"prod", "db"}},
+			{ID: "d3", Tags: []string{"prod"}},
+		},
+	}
+	q := NewStewardFleetQuery(src)
+
+	// Device must have BOTH tags
+	ids, err := q.Search(Filter{Tags: []string{"prod", "web"}})
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{"d1"}, ids)
+}
+
+func TestStewardFleetQuery_Search_GroupFilter(t *testing.T) {
+	src := &staticDeviceSource{
+		devices: []Device{
+			{ID: "d1", Groups: []string{"servers", "eu-west"}},
+			{ID: "d2", Groups: []string{"servers", "us-east"}},
+			{ID: "d3", Groups: []string{"workstations"}},
+		},
+	}
+	q := NewStewardFleetQuery(src)
+
+	ids, err := q.Search(Filter{Groups: []string{"servers"}})
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{"d1", "d2"}, ids)
+}
+
+func TestStewardFleetQuery_Search_DNAQueryFilter(t *testing.T) {
+	src := &staticDeviceSource{
+		devices: []Device{
+			{ID: "d1", Attributes: map[string]string{"env": "prod", "tier": "web"}},
+			{ID: "d2", Attributes: map[string]string{"env": "prod", "tier": "db"}},
+			{ID: "d3", Attributes: map[string]string{"env": "staging"}},
+		},
+	}
+	q := NewStewardFleetQuery(src)
+
+	ids, err := q.Search(Filter{DNAQuery: map[string]string{"env": "prod", "tier": "web"}})
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{"d1"}, ids)
+}
+
+func TestStewardFleetQuery_Search_CombinedFilter(t *testing.T) {
+	src := &staticDeviceSource{
+		devices: []Device{
+			{ID: "d1", OS: "linux", Tags: []string{"prod"}, Groups: []string{"eu"}, Attributes: map[string]string{"role": "web"}},
+			{ID: "d2", OS: "linux", Tags: []string{"prod"}, Groups: []string{"us"}, Attributes: map[string]string{"role": "db"}},
+			{ID: "d3", OS: "windows", Tags: []string{"prod"}, Groups: []string{"eu"}, Attributes: map[string]string{"role": "web"}},
+		},
+	}
+	q := NewStewardFleetQuery(src)
+
+	ids, err := q.Search(Filter{
+		OS:       "linux",
+		Tags:     []string{"prod"},
+		Groups:   []string{"eu"},
+		DNAQuery: map[string]string{"role": "web"},
+	})
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{"d1"}, ids)
+}
+
+func TestStewardFleetQuery_Search_ZeroMatch(t *testing.T) {
+	src := &staticDeviceSource{
+		devices: []Device{
+			{ID: "d1", OS: "linux"},
+		},
+	}
+	q := NewStewardFleetQuery(src)
+
+	ids, err := q.Search(Filter{OS: "windows"})
+	require.NoError(t, err)
+	assert.Empty(t, ids, "zero matches should return empty slice, not error")
+}
+
+func TestStewardFleetQuery_Search_EmptyFleet(t *testing.T) {
+	src := &staticDeviceSource{devices: nil}
+	q := NewStewardFleetQuery(src)
+
+	ids, err := q.Search(Filter{OS: "linux"})
+	require.NoError(t, err)
+	assert.Empty(t, ids)
+}
+
+// TestStewardFleetQuery_Search_LiveEvaluation verifies that Search re-evaluates
+// against the current DeviceSource on each call (required for recurring workflows).
+func TestStewardFleetQuery_Search_LiveEvaluation(t *testing.T) {
+	src := &staticDeviceSource{
+		devices: []Device{
+			{ID: "d1", OS: "linux"},
+		},
+	}
+	q := NewStewardFleetQuery(src)
+
+	// First call: one match
+	ids, err := q.Search(Filter{OS: "linux"})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"d1"}, ids)
+
+	// Simulate fleet change (new device comes online)
+	src.devices = append(src.devices, Device{ID: "d2", OS: "linux"})
+
+	// Second call: two matches — filter re-evaluated against current state
+	ids, err = q.Search(Filter{OS: "linux"})
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{"d1", "d2"}, ids)
+}

--- a/features/controller/fleet/fleet_test.go
+++ b/features/controller/fleet/fleet_test.go
@@ -14,7 +14,7 @@ type staticDeviceSource struct {
 	devices []Device
 }
 
-func (s *staticDeviceSource) ListDevices() []Device { return s.devices }
+func (s *staticDeviceSource) ListDevices() ([]Device, error) { return s.devices, nil }
 
 func TestFilter_IsEmpty(t *testing.T) {
 	tests := []struct {

--- a/features/modules/script/execution_monitor.go
+++ b/features/modules/script/execution_monitor.go
@@ -113,10 +113,10 @@ func (m *ExecutionMonitor) StartExecution(ctx context.Context, scriptID, scriptN
 // UpdateDeviceStatus updates the status of a device execution
 func (m *ExecutionMonitor) UpdateDeviceStatus(executionID, deviceID string, status ExecutionStatus, result *ExecutionResult, err error) error {
 	m.mu.Lock()
-	defer m.mu.Unlock()
 
 	execution, exists := m.executions[executionID]
 	if !exists {
+		m.mu.Unlock()
 		return fmt.Errorf("execution %s not found", executionID)
 	}
 
@@ -130,6 +130,7 @@ func (m *ExecutionMonitor) UpdateDeviceStatus(executionID, deviceID string, stat
 	}
 
 	if deviceIndex == -1 {
+		m.mu.Unlock()
 		return fmt.Errorf("device %s not found in execution %s", deviceID, executionID)
 	}
 
@@ -156,23 +157,41 @@ func (m *ExecutionMonitor) UpdateDeviceStatus(executionID, deviceID string, stat
 	// Update summary
 	m.updateSummary(execution, oldStatus, status)
 
-	// Check if execution is complete
+	// Determine what notifications are needed while still holding the lock,
+	// then release before calling notify methods. The notify methods acquire
+	// RLock internally; calling them while holding the write lock would deadlock
+	// since sync.RWMutex is not reentrant.
+	var execToNotifyComplete *MonitoredExecution
+	var deviceToNotifyStart, deviceToNotifyComplete, deviceToNotifyError *DeviceExecution
+
 	if m.isExecutionComplete(execution) {
 		now := time.Now()
 		execution.EndTime = &now
 		execution.Status = m.calculateExecutionStatus(execution)
-		m.notifyExecutionComplete(execution)
+		execToNotifyComplete = execution
 	}
-
-	// Notify listeners
 	if status == StatusRunning && oldStatus == StatusPending {
-		m.notifyDeviceStart(executionID, device)
+		deviceToNotifyStart = device
 	} else if status == StatusCompleted || status == StatusFailed {
-		m.notifyDeviceComplete(executionID, device)
+		deviceToNotifyComplete = device
+	}
+	if err != nil {
+		deviceToNotifyError = device
 	}
 
-	if err != nil {
-		m.notifyDeviceError(executionID, device, err)
+	m.mu.Unlock() // Release write lock before calling notify (which acquire RLock)
+
+	if execToNotifyComplete != nil {
+		m.notifyExecutionComplete(execToNotifyComplete)
+	}
+	if deviceToNotifyStart != nil {
+		m.notifyDeviceStart(executionID, deviceToNotifyStart)
+	}
+	if deviceToNotifyComplete != nil {
+		m.notifyDeviceComplete(executionID, deviceToNotifyComplete)
+	}
+	if deviceToNotifyError != nil {
+		m.notifyDeviceError(executionID, deviceToNotifyError, err)
 	}
 
 	return nil

--- a/features/modules/script/execution_monitor_test.go
+++ b/features/modules/script/execution_monitor_test.go
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+package script
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// recordingListener captures execution events for test assertions.
+type recordingListener struct {
+	mu              sync.Mutex
+	executionStarts []*MonitoredExecution
+	execCompletes   []*MonitoredExecution
+	deviceCompletes []string
+	deviceErrors    []string
+}
+
+func (l *recordingListener) OnExecutionStart(e *MonitoredExecution) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.executionStarts = append(l.executionStarts, e)
+}
+
+func (l *recordingListener) OnExecutionComplete(e *MonitoredExecution) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.execCompletes = append(l.execCompletes, e)
+}
+
+func (l *recordingListener) OnDeviceStart(executionID string, d *DeviceExecution) {}
+
+func (l *recordingListener) OnDeviceComplete(executionID string, d *DeviceExecution) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.deviceCompletes = append(l.deviceCompletes, d.DeviceID)
+}
+
+func (l *recordingListener) OnDeviceError(executionID string, d *DeviceExecution, err error) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.deviceErrors = append(l.deviceErrors, d.DeviceID)
+}
+
+// TestExecutionMonitor_UpdateDeviceStatus_WithListener is a regression test for
+// the deadlock that occurred when UpdateDeviceStatus (holding write lock) called
+// notify methods that tried to acquire read lock on the same mutex.
+// If the deadlock is reintroduced, this test will hang and timeout under -race.
+func TestExecutionMonitor_UpdateDeviceStatus_WithListener(t *testing.T) {
+	monitor := NewExecutionMonitor()
+	listener := &recordingListener{}
+	monitor.AddListener("test", listener)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	execution, err := monitor.StartExecution(ctx, "script-1", "test-script", "tenant-1", []string{"dev-1"})
+	require.NoError(t, err)
+
+	// This call previously deadlocked: UpdateDeviceStatus held the write lock
+	// and called notifyDeviceComplete, which tried to acquire the read lock.
+	err = monitor.UpdateDeviceStatus(execution.ID, "dev-1", StatusCompleted, &ExecutionResult{
+		ExitCode: 0,
+		Stdout:   "ok",
+	}, nil)
+	require.NoError(t, err, "UpdateDeviceStatus must not deadlock when listeners are registered")
+
+	// Listener notifications are dispatched in goroutines — wait briefly
+	require.Eventually(t, func() bool {
+		listener.mu.Lock()
+		defer listener.mu.Unlock()
+		return len(listener.deviceCompletes) >= 1 && len(listener.execCompletes) >= 1
+	}, 2*time.Second, 10*time.Millisecond, "listener must receive device-complete and execution-complete notifications")
+
+	listener.mu.Lock()
+	defer listener.mu.Unlock()
+	assert.Contains(t, listener.deviceCompletes, "dev-1")
+	assert.Equal(t, StatusCompleted, listener.execCompletes[0].Status)
+}
+
+// TestExecutionMonitor_UpdateDeviceStatus_ErrorDevice verifies that updating a
+// device that was not registered in the execution returns an error.
+func TestExecutionMonitor_UpdateDeviceStatus_ErrorDevice(t *testing.T) {
+	monitor := NewExecutionMonitor()
+	ctx := context.Background()
+
+	execution, err := monitor.StartExecution(ctx, "script-1", "test", "t1", []string{"dev-1"})
+	require.NoError(t, err)
+
+	err = monitor.UpdateDeviceStatus(execution.ID, "unknown-dev", StatusCompleted, nil, nil)
+	assert.Error(t, err, "updating an unknown device must return an error")
+}
+
+// TestExecutionMonitor_UpdateDeviceStatus_ErrorExecution verifies that updating
+// a non-existent execution returns an error.
+func TestExecutionMonitor_UpdateDeviceStatus_ErrorExecution(t *testing.T) {
+	monitor := NewExecutionMonitor()
+
+	err := monitor.UpdateDeviceStatus("no-such-execution", "dev-1", StatusCompleted, nil, nil)
+	assert.Error(t, err, "updating a non-existent execution must return an error")
+}

--- a/features/workflow/nodes/script_node.go
+++ b/features/workflow/nodes/script_node.go
@@ -275,20 +275,37 @@ func (n *ScriptNode) Execute(ctx context.Context, input workflow.NodeInput) (wor
 		executor := script.NewExecutor(scriptConfig)
 		result, execErr := executor.Execute(ctx)
 
-		// Update execution monitor.
-		// Best-effort telemetry: a status-update failure must not mask the actual
-		// script execution result, so the error is intentionally ignored here.
+		// Update execution monitor so the WaitForCompletion poller and any
+		// registered listeners see the terminal status.
 		status := script.StatusCompleted
 		if execErr != nil {
 			status = script.StatusFailed
 		}
-		_ = n.monitor.UpdateDeviceStatus(execution.ID, deviceID, status, result, execErr) //nolint:errcheck // best-effort telemetry
+		if monitorErr := n.monitor.UpdateDeviceStatus(execution.ID, deviceID, status, result, execErr); monitorErr != nil {
+			// The execution or device ID was not found in the monitor — this is an
+			// internal consistency error (we just created the execution above).
+			// The WaitForCompletion poller cannot detect terminal status when the
+			// monitor state is corrupted, so return immediately with partial results.
+			results[deviceID] = result
+			return workflow.NodeOutput{
+				Success: false,
+				Error:   fmt.Sprintf("execution monitor consistency error for device %s: %v", deviceID, monitorErr),
+				Data:    map[string]interface{}{"results": results},
+			}, monitorErr
+		}
 
 		results[deviceID] = result
 	}
 
 	// Wait for completion if requested
 	if n.config.WaitForCompletion {
+		if n.config.Timeout == 0 {
+			return workflow.NodeOutput{
+				Success: false,
+				Error:   "wait_for_completion requires a non-zero timeout",
+			}, fmt.Errorf("wait_for_completion is true but timeout is zero")
+		}
+
 		// Poll execution status until complete
 		ticker := time.NewTicker(500 * time.Millisecond)
 		defer ticker.Stop()

--- a/features/workflow/nodes/script_node.go
+++ b/features/workflow/nodes/script_node.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/cfgis/cfgms/features/controller/fleet"
 	"github.com/cfgis/cfgms/features/modules/script"
 	"github.com/cfgis/cfgms/features/workflow"
 )
@@ -28,11 +29,16 @@ type ScriptStepConfig struct {
 	// Parameters are custom parameters to pass to the script
 	Parameters map[string]string `yaml:"parameters,omitempty" json:"parameters,omitempty"`
 
-	// Devices specifies which devices to run the script on
+	// Devices specifies an explicit list of device IDs to target.
+	// When set, DeviceFilter and the FleetQuery are bypassed entirely.
 	Devices []string `yaml:"devices,omitempty" json:"devices,omitempty"`
 
-	// DeviceFilter allows filtering devices by criteria
-	DeviceFilter *DeviceFilter `yaml:"device_filter,omitempty" json:"device_filter,omitempty"`
+	// DeviceFilter selects target devices via fleet-wide search.
+	// Uses the same fleet.Filter that GET /api/v1/stewards?os=...&tag=... uses,
+	// ensuring one filter definition and one query path across the system.
+	// Ignored when Devices is non-empty.
+	// For recurring workflows the filter is re-evaluated on each run.
+	DeviceFilter *fleet.Filter `yaml:"device_filter,omitempty" json:"device_filter,omitempty"`
 
 	// Timeout for script execution
 	Timeout time.Duration `yaml:"timeout,omitempty" json:"timeout,omitempty"`
@@ -54,21 +60,6 @@ type ScriptStepConfig struct {
 
 	// OnFailure defines actions to take on failed execution
 	OnFailure *ScriptActionConfig `yaml:"on_failure,omitempty" json:"on_failure,omitempty"`
-}
-
-// DeviceFilter defines criteria for filtering devices
-type DeviceFilter struct {
-	// Platform filters by platform (windows, linux, darwin)
-	Platform string `yaml:"platform,omitempty" json:"platform,omitempty"`
-
-	// DNAQuery filters by DNA properties
-	DNAQuery map[string]interface{} `yaml:"dna_query,omitempty" json:"dna_query,omitempty"`
-
-	// Tags filters by device tags
-	Tags []string `yaml:"tags,omitempty" json:"tags,omitempty"`
-
-	// Groups filters by device groups
-	Groups []string `yaml:"groups,omitempty" json:"groups,omitempty"`
 }
 
 // ScriptActionConfig defines actions to take based on script results
@@ -104,6 +95,7 @@ type ScriptNode struct {
 	keyManager     *script.EphemeralKeyManager
 	dnaProvider    script.DNAProvider
 	configProvider script.ConfigProvider
+	fleetQuery     fleet.FleetQuery
 }
 
 // NewScriptNode creates a new script execution node
@@ -121,6 +113,48 @@ func NewScriptNode(id, name string, config *ScriptStepConfig, repository script.
 	}
 }
 
+// SetFleetQuery sets the fleet query used to resolve device IDs from filters.
+func (n *ScriptNode) SetFleetQuery(fq fleet.FleetQuery) {
+	n.fleetQuery = fq
+}
+
+// resolveDeviceIDs determines the set of device IDs to target.
+//
+// Priority:
+//  1. Explicit Devices list — bypasses fleet query entirely.
+//  2. DeviceFilter via fleetQuery.Search — evaluated fresh on every call.
+//  3. Default to localhost when neither is configured.
+//
+// Returns (deviceIDs, zeroMatch, error).
+// zeroMatch is true when the filter resolved successfully but matched no devices.
+func (n *ScriptNode) resolveDeviceIDs() ([]string, bool, error) {
+	// Explicit device list overrides fleet query
+	if len(n.config.Devices) > 0 {
+		return n.config.Devices, false, nil
+	}
+
+	// Fleet filter path
+	if n.config.DeviceFilter != nil {
+		if n.fleetQuery == nil {
+			// DeviceFilter configured but no FleetQuery wired — misconfiguration.
+			// Return an error so callers know the filter was ignored, rather than
+			// silently targeting localhost when fleet-wide targeting was intended.
+			return nil, false, fmt.Errorf("device_filter is configured but no FleetQuery is wired; call SetFleetQuery before Execute")
+		}
+		ids, err := n.fleetQuery.Search(*n.config.DeviceFilter)
+		if err != nil {
+			return nil, false, fmt.Errorf("fleet query failed: %w", err)
+		}
+		if len(ids) == 0 {
+			return nil, true, nil
+		}
+		return ids, false, nil
+	}
+
+	// Default fallback
+	return []string{"localhost"}, false, nil
+}
+
 // Execute implements workflow.Node interface
 func (n *ScriptNode) Execute(ctx context.Context, input workflow.NodeInput) (workflow.NodeOutput, error) {
 	// Get script content
@@ -132,15 +166,15 @@ func (n *ScriptNode) Execute(ctx context.Context, input workflow.NodeInput) (wor
 		scriptContent = n.config.InlineScript
 	} else if n.config.ScriptID != "" {
 		// Get script from repository
-		script, err := n.repository.Get(n.config.ScriptID, n.config.ScriptVersion)
+		versioned, err := n.repository.Get(n.config.ScriptID, n.config.ScriptVersion)
 		if err != nil {
 			return workflow.NodeOutput{
 				Success: false,
 				Error:   fmt.Sprintf("failed to get script: %v", err),
 			}, err
 		}
-		scriptContent = script.Content
-		metadata = script.Metadata
+		scriptContent = versioned.Content
+		metadata = versioned.Metadata
 	} else {
 		return workflow.NodeOutput{
 			Success: false,
@@ -161,10 +195,25 @@ func (n *ScriptNode) Execute(ctx context.Context, input workflow.NodeInput) (wor
 		scriptContent = injectedContent
 	}
 
-	// Start execution monitoring
-	deviceIDs := n.config.Devices
-	if len(deviceIDs) == 0 {
-		deviceIDs = []string{"localhost"} // Default to localhost
+	// Resolve target device IDs — re-evaluated on each Execute call so that
+	// recurring scheduled workflows always reflect current fleet state.
+	deviceIDs, zeroMatch, err := n.resolveDeviceIDs()
+	if err != nil {
+		return workflow.NodeOutput{
+			Success: false,
+			Error:   fmt.Sprintf("failed to resolve target devices: %v", err),
+		}, err
+	}
+
+	// Zero-match: filter resolved but no devices matched.
+	// Log a warning and complete successfully — this is not an error condition.
+	if zeroMatch {
+		return workflow.NodeOutput{
+			Success: true,
+			Data: map[string]interface{}{
+				"warning": "no matching devices found for the configured filter; no executions queued",
+			},
+		}, nil
 	}
 
 	scriptName := n.Name
@@ -226,12 +275,14 @@ func (n *ScriptNode) Execute(ctx context.Context, input workflow.NodeInput) (wor
 		executor := script.NewExecutor(scriptConfig)
 		result, execErr := executor.Execute(ctx)
 
-		// Update execution monitor
+		// Update execution monitor.
+		// Best-effort telemetry: a status-update failure must not mask the actual
+		// script execution result, so the error is intentionally ignored here.
 		status := script.StatusCompleted
 		if execErr != nil {
 			status = script.StatusFailed
 		}
-		_ = n.monitor.UpdateDeviceStatus(execution.ID, deviceID, status, result, execErr)
+		_ = n.monitor.UpdateDeviceStatus(execution.ID, deviceID, status, result, execErr) //nolint:errcheck // best-effort telemetry
 
 		results[deviceID] = result
 	}
@@ -318,6 +369,7 @@ type ScriptStepExecutor struct {
 	keyManager     *script.EphemeralKeyManager
 	dnaProvider    script.DNAProvider
 	configProvider script.ConfigProvider
+	fleetQuery     fleet.FleetQuery
 }
 
 // NewScriptStepExecutor creates a new script step executor
@@ -327,6 +379,11 @@ func NewScriptStepExecutor(repository script.ScriptRepository, monitor *script.E
 		monitor:    monitor,
 		keyManager: keyManager,
 	}
+}
+
+// SetFleetQuery sets the fleet query used to resolve device IDs from filters.
+func (e *ScriptStepExecutor) SetFleetQuery(fq fleet.FleetQuery) {
+	e.fleetQuery = fq
 }
 
 // ExecuteStep implements workflow.StepExecutor interface
@@ -345,6 +402,9 @@ func (e *ScriptStepExecutor) ExecuteStep(ctx context.Context, step workflow.Step
 	node := NewScriptNode(step.Name, step.Name, config, e.repository, e.monitor, e.keyManager)
 	node.SetDNAProvider(e.dnaProvider)
 	node.SetConfigProvider(e.configProvider)
+	if e.fleetQuery != nil {
+		node.SetFleetQuery(e.fleetQuery)
+	}
 
 	// Execute node
 	startTime := time.Now()
@@ -422,6 +482,39 @@ func parseScriptStepConfig(configMap map[string]interface{}) (*ScriptStepConfig,
 				config.Devices = append(config.Devices, devStr)
 			}
 		}
+	}
+
+	// Parse device_filter — shares field names with fleet.Filter / REST API query params
+	if filterMap, ok := configMap["device_filter"].(map[string]interface{}); ok {
+		f := &fleet.Filter{}
+		if os, ok := filterMap["os"].(string); ok {
+			f.OS = os
+		}
+		if tags, ok := filterMap["tags"].([]interface{}); ok {
+			f.Tags = make([]string, 0, len(tags))
+			for _, t := range tags {
+				if s, ok := t.(string); ok {
+					f.Tags = append(f.Tags, s)
+				}
+			}
+		}
+		if groups, ok := filterMap["groups"].([]interface{}); ok {
+			f.Groups = make([]string, 0, len(groups))
+			for _, g := range groups {
+				if s, ok := g.(string); ok {
+					f.Groups = append(f.Groups, s)
+				}
+			}
+		}
+		if dnaQuery, ok := filterMap["dna_query"].(map[string]interface{}); ok {
+			f.DNAQuery = make(map[string]string, len(dnaQuery))
+			for k, v := range dnaQuery {
+				if s, ok := v.(string); ok {
+					f.DNAQuery[k] = s
+				}
+			}
+		}
+		config.DeviceFilter = f
 	}
 
 	// Parse timeout duration

--- a/features/workflow/nodes/script_node_test.go
+++ b/features/workflow/nodes/script_node_test.go
@@ -361,3 +361,25 @@ func TestScriptNode_WaitForCompletion(t *testing.T) {
 	require.True(t, ok, "output must include results map")
 	assert.Contains(t, results, "localhost")
 }
+
+// TestScriptNode_WaitForCompletion_ZeroTimeoutError verifies that
+// WaitForCompletion: true with Timeout: 0 returns an error rather than
+// silently timing out immediately via time.After(0).
+func TestScriptNode_WaitForCompletion_ZeroTimeoutError(t *testing.T) {
+	config := &ScriptStepConfig{
+		InlineScript:      "echo hello",
+		Shell:             script.ShellBash,
+		Timeout:           0, // zero value — misconfiguration
+		WaitForCompletion: true,
+	}
+
+	node := buildScriptNode(t, config, nil)
+	output, err := node.Execute(context.Background(), workflow.NodeInput{
+		Data:    map[string]interface{}{},
+		Context: map[string]interface{}{},
+	})
+
+	require.Error(t, err, "zero timeout with WaitForCompletion must return an error")
+	assert.False(t, output.Success)
+	assert.Contains(t, err.Error(), "timeout is zero")
+}

--- a/features/workflow/nodes/script_node_test.go
+++ b/features/workflow/nodes/script_node_test.go
@@ -1,0 +1,286 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+package nodes
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/cfgis/cfgms/features/controller/fleet"
+	"github.com/cfgis/cfgms/features/modules/script"
+	"github.com/cfgis/cfgms/features/workflow"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeFleetQuery is a test double for fleet.FleetQuery.
+// It records the filters it receives and returns a configurable device list.
+type fakeFleetQuery struct {
+	devices       []string
+	searchErr     error
+	calledFilters []fleet.Filter
+}
+
+func (f *fakeFleetQuery) Search(filter fleet.Filter) ([]string, error) {
+	f.calledFilters = append(f.calledFilters, filter)
+	if f.searchErr != nil {
+		return nil, f.searchErr
+	}
+	return f.devices, nil
+}
+
+// buildScriptNode creates a ScriptNode with an inline script and the given fleet query.
+func buildScriptNode(t *testing.T, config *ScriptStepConfig, fq fleet.FleetQuery) *ScriptNode {
+	t.Helper()
+	monitor := script.NewExecutionMonitor()
+	node := NewScriptNode("test-node", "test", config, nil, monitor, nil)
+	if fq != nil {
+		node.SetFleetQuery(fq)
+	}
+	return node
+}
+
+// TestScriptNode_FleetQueryWiring verifies that the script node calls
+// fleetQuery.Search with the configured filter to obtain device IDs.
+func TestScriptNode_FleetQueryWiring(t *testing.T) {
+	fq := &fakeFleetQuery{devices: []string{"dev-1", "dev-2"}}
+
+	config := &ScriptStepConfig{
+		InlineScript: "echo hello",
+		Shell:        script.ShellBash,
+		DeviceFilter: &fleet.Filter{
+			OS:   "linux",
+			Tags: []string{"prod"},
+		},
+		Timeout: 5 * time.Second,
+	}
+
+	node := buildScriptNode(t, config, fq)
+	_, err := node.Execute(context.Background(), workflow.NodeInput{
+		Data:    map[string]interface{}{},
+		Context: map[string]interface{}{},
+	})
+	require.NoError(t, err)
+
+	// Fleet query must have been called exactly once with the configured filter
+	require.Len(t, fq.calledFilters, 1)
+	assert.Equal(t, "linux", fq.calledFilters[0].OS)
+	assert.Equal(t, []string{"prod"}, fq.calledFilters[0].Tags)
+}
+
+// TestScriptNode_ExplicitDevicesSkipFleetQuery verifies that when Devices is
+// explicitly set, the fleet query is bypassed entirely.
+func TestScriptNode_ExplicitDevicesSkipFleetQuery(t *testing.T) {
+	fq := &fakeFleetQuery{devices: []string{"should-not-appear"}}
+
+	config := &ScriptStepConfig{
+		InlineScript: "echo hello",
+		Shell:        script.ShellBash,
+		Devices:      []string{"explicit-dev-1"},
+		DeviceFilter: &fleet.Filter{OS: "linux"},
+		Timeout:      5 * time.Second,
+	}
+
+	node := buildScriptNode(t, config, fq)
+	_, err := node.Execute(context.Background(), workflow.NodeInput{
+		Data:    map[string]interface{}{},
+		Context: map[string]interface{}{},
+	})
+	require.NoError(t, err)
+
+	// Fleet query must NOT have been called
+	assert.Len(t, fq.calledFilters, 0, "explicit Devices list must bypass fleet query")
+}
+
+// TestScriptNode_ZeroMatchReturnsSuccessWithWarning verifies that when the
+// fleet filter matches no devices, the step completes with success (not failure)
+// and includes a warning in the output.
+func TestScriptNode_ZeroMatchReturnsSuccessWithWarning(t *testing.T) {
+	fq := &fakeFleetQuery{devices: []string{}} // returns no matches
+
+	config := &ScriptStepConfig{
+		InlineScript: "echo hello",
+		Shell:        script.ShellBash,
+		DeviceFilter: &fleet.Filter{OS: "windows"},
+		Timeout:      5 * time.Second,
+	}
+
+	node := buildScriptNode(t, config, fq)
+	output, err := node.Execute(context.Background(), workflow.NodeInput{
+		Data:    map[string]interface{}{},
+		Context: map[string]interface{}{},
+	})
+	require.NoError(t, err)
+
+	// Zero matches must NOT cause failure
+	assert.True(t, output.Success, "zero matching devices should succeed with warning, not fail")
+	assert.Empty(t, output.Error, "zero matches should not set an error message")
+
+	// Output must include a warning
+	warning, hasWarning := output.Data["warning"].(string)
+	assert.True(t, hasWarning, "output must contain a 'warning' field when no devices match")
+	assert.Contains(t, warning, "no matching devices", "warning must contain 'no matching devices'")
+}
+
+// TestScriptNode_NoFilterNoDevicesDefaultsToLocalhost verifies the existing
+// fallback behaviour: no explicit devices and no filter → targets localhost.
+func TestScriptNode_NoFilterNoDevicesDefaultsToLocalhost(t *testing.T) {
+	config := &ScriptStepConfig{
+		InlineScript: "echo hello",
+		Shell:        script.ShellBash,
+		Timeout:      5 * time.Second,
+	}
+
+	node := buildScriptNode(t, config, nil)
+	output, err := node.Execute(context.Background(), workflow.NodeInput{
+		Data:    map[string]interface{}{},
+		Context: map[string]interface{}{},
+	})
+	require.NoError(t, err)
+
+	results, ok := output.Data["results"].(map[string]*script.ExecutionResult)
+	require.True(t, ok, "output.Data[results] must be map[string]*script.ExecutionResult")
+	assert.Contains(t, results, "localhost")
+}
+
+// TestScriptNode_RecurringFilterReEvaluated verifies that calling Execute
+// multiple times re-evaluates the filter against current fleet state.
+// This is the recurring workflow scenario: filter is stored in workflow
+// definition, result set is NOT cached.
+func TestScriptNode_RecurringFilterReEvaluated(t *testing.T) {
+	fq := &fakeFleetQuery{devices: []string{"dev-1"}}
+
+	config := &ScriptStepConfig{
+		InlineScript: "echo hello",
+		Shell:        script.ShellBash,
+		DeviceFilter: &fleet.Filter{OS: "linux"},
+		Timeout:      5 * time.Second,
+	}
+
+	node := buildScriptNode(t, config, fq)
+
+	// First execution
+	_, err := node.Execute(context.Background(), workflow.NodeInput{
+		Data:    map[string]interface{}{},
+		Context: map[string]interface{}{},
+	})
+	require.NoError(t, err)
+	require.Len(t, fq.calledFilters, 1)
+
+	// Simulate fleet change: a new device comes online
+	fq.devices = []string{"dev-1", "dev-2"}
+
+	// Second execution (recurring run) — filter must be re-evaluated
+	_, err = node.Execute(context.Background(), workflow.NodeInput{
+		Data:    map[string]interface{}{},
+		Context: map[string]interface{}{},
+	})
+	require.NoError(t, err)
+
+	// Search must have been called again with the same filter
+	require.Len(t, fq.calledFilters, 2, "filter must be re-evaluated on each execution")
+	assert.Equal(t, fq.calledFilters[0], fq.calledFilters[1], "same filter reused across runs")
+}
+
+// TestScriptNode_DeviceFilterFieldsMatchFleetFilter verifies that the
+// ScriptStepConfig.DeviceFilter is typed as *fleet.Filter (no separate struct).
+func TestScriptNode_DeviceFilterFieldsMatchFleetFilter(t *testing.T) {
+	filter := &fleet.Filter{
+		OS:       "windows",
+		Tags:     []string{"prod", "web"},
+		Groups:   []string{"emea"},
+		DNAQuery: map[string]string{"tier": "frontend"},
+	}
+	config := &ScriptStepConfig{
+		InlineScript: "echo hello",
+		DeviceFilter: filter,
+	}
+
+	// Verify the field is directly a *fleet.Filter — no conversion needed
+	assert.Equal(t, "windows", config.DeviceFilter.OS)
+	assert.Equal(t, []string{"prod", "web"}, config.DeviceFilter.Tags)
+	assert.Equal(t, []string{"emea"}, config.DeviceFilter.Groups)
+	assert.Equal(t, "frontend", config.DeviceFilter.DNAQuery["tier"])
+}
+
+// TestScriptStepExecutor_FleetQueryInjection verifies that FleetQuery can be
+// injected into the step executor and is passed to the node during execution.
+func TestScriptStepExecutor_FleetQueryInjection(t *testing.T) {
+	fq := &fakeFleetQuery{devices: []string{"executor-dev-1"}}
+	monitor := script.NewExecutionMonitor()
+	executor := NewScriptStepExecutor(nil, monitor, nil)
+	executor.SetFleetQuery(fq)
+
+	step := workflow.Step{
+		Name: "run-script",
+		Type: workflow.StepTypeTask,
+		Config: map[string]interface{}{
+			"inline_script": "echo hello",
+			"shell":         "bash",
+			"device_filter": map[string]interface{}{
+				"os": "linux",
+			},
+			"timeout": "5s",
+		},
+	}
+
+	result, err := executor.ExecuteStep(context.Background(), step, map[string]interface{}{})
+	require.NoError(t, err)
+	assert.Equal(t, workflow.StatusCompleted, result.Status)
+
+	// Fleet query must have been called
+	require.GreaterOrEqual(t, len(fq.calledFilters), 1, "fleet query must be invoked during step execution")
+	assert.Equal(t, "linux", fq.calledFilters[0].OS)
+}
+
+// TestScriptNode_FleetQueryError verifies that a fleet query failure propagates
+// as a node failure (not a silent no-op or localhost fallback).
+func TestScriptNode_FleetQueryError(t *testing.T) {
+	fq := &fakeFleetQuery{
+		searchErr: errors.New("registry unavailable"),
+	}
+
+	config := &ScriptStepConfig{
+		InlineScript: "echo hello",
+		Shell:        script.ShellBash,
+		DeviceFilter: &fleet.Filter{OS: "linux"},
+		Timeout:      5 * time.Second,
+	}
+
+	node := buildScriptNode(t, config, fq)
+	output, err := node.Execute(context.Background(), workflow.NodeInput{
+		Data:    map[string]interface{}{},
+		Context: map[string]interface{}{},
+	})
+
+	// Fleet query error must propagate as node failure
+	require.Error(t, err, "fleet query error must be returned")
+	assert.False(t, output.Success, "node must fail when fleet query returns an error")
+	assert.Contains(t, err.Error(), "fleet query failed")
+}
+
+// TestScriptNode_DeviceFilterWithoutFleetQueryReturnsError verifies that
+// configuring a DeviceFilter without wiring a FleetQuery returns an error
+// rather than silently falling back to localhost.
+func TestScriptNode_DeviceFilterWithoutFleetQueryReturnsError(t *testing.T) {
+	config := &ScriptStepConfig{
+		InlineScript: "echo hello",
+		Shell:        script.ShellBash,
+		DeviceFilter: &fleet.Filter{OS: "linux"},
+		Timeout:      5 * time.Second,
+	}
+
+	// Deliberately do NOT set a fleet query
+	node := buildScriptNode(t, config, nil)
+	output, err := node.Execute(context.Background(), workflow.NodeInput{
+		Data:    map[string]interface{}{},
+		Context: map[string]interface{}{},
+	})
+
+	// Must return an error — not silently target localhost
+	require.Error(t, err, "misconfiguration (filter without FleetQuery) must return an error")
+	assert.False(t, output.Success, "node must fail when DeviceFilter is set but FleetQuery is not wired")
+	assert.Contains(t, err.Error(), "FleetQuery")
+}

--- a/features/workflow/nodes/script_node_test.go
+++ b/features/workflow/nodes/script_node_test.go
@@ -5,6 +5,7 @@ package nodes
 import (
 	"context"
 	"errors"
+	"runtime"
 	"testing"
 	"time"
 
@@ -14,6 +15,17 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// testShellAndScript returns the appropriate shell type and shell name string
+// for the current platform. On Windows, cmd.exe is used; on Linux/macOS, bash.
+func testShellAndScript() (script.ShellType, string) {
+	switch runtime.GOOS {
+	case "windows":
+		return script.ShellCmd, "cmd"
+	default:
+		return script.ShellBash, "bash"
+	}
+}
 
 // testDeviceSource is a real DeviceSource backed by a configurable device list.
 // Using a real DeviceSource with StewardFleetQuery exercises the actual filtering
@@ -54,9 +66,10 @@ func TestScriptNode_FleetQueryWiring(t *testing.T) {
 	}
 	fq := fleet.NewStewardFleetQuery(src)
 
+	testShell, _ := testShellAndScript()
 	config := &ScriptStepConfig{
 		InlineScript: "echo hello",
-		Shell:        script.ShellBash,
+		Shell:        testShell,
 		DeviceFilter: &fleet.Filter{
 			OS:   "linux",
 			Tags: []string{"prod"},
@@ -92,9 +105,10 @@ func TestScriptNode_ExplicitDevicesSkipFleetQuery(t *testing.T) {
 	}
 	fq := fleet.NewStewardFleetQuery(src)
 
+	testShell, _ := testShellAndScript()
 	config := &ScriptStepConfig{
 		InlineScript: "echo hello",
-		Shell:        script.ShellBash,
+		Shell:        testShell,
 		Devices:      []string{"explicit-dev-1"},
 		DeviceFilter: &fleet.Filter{OS: "linux"},
 		Timeout:      5 * time.Second,
@@ -125,9 +139,10 @@ func TestScriptNode_ZeroMatchReturnsSuccessWithWarning(t *testing.T) {
 	}
 	fq := fleet.NewStewardFleetQuery(src)
 
+	testShell, _ := testShellAndScript()
 	config := &ScriptStepConfig{
 		InlineScript: "echo hello",
-		Shell:        script.ShellBash,
+		Shell:        testShell,
 		DeviceFilter: &fleet.Filter{OS: "linux"},
 		Timeout:      5 * time.Second,
 	}
@@ -152,9 +167,10 @@ func TestScriptNode_ZeroMatchReturnsSuccessWithWarning(t *testing.T) {
 // TestScriptNode_NoFilterNoDevicesDefaultsToLocalhost verifies the existing
 // fallback behaviour: no explicit devices and no filter → targets localhost.
 func TestScriptNode_NoFilterNoDevicesDefaultsToLocalhost(t *testing.T) {
+	testShell, _ := testShellAndScript()
 	config := &ScriptStepConfig{
 		InlineScript: "echo hello",
-		Shell:        script.ShellBash,
+		Shell:        testShell,
 		Timeout:      5 * time.Second,
 	}
 
@@ -182,9 +198,10 @@ func TestScriptNode_RecurringFilterReEvaluated(t *testing.T) {
 	}
 	fq := fleet.NewStewardFleetQuery(src)
 
+	testShell, _ := testShellAndScript()
 	config := &ScriptStepConfig{
 		InlineScript: "echo hello",
-		Shell:        script.ShellBash,
+		Shell:        testShell,
 		DeviceFilter: &fleet.Filter{OS: "linux"},
 		Timeout:      5 * time.Second,
 	}
@@ -228,9 +245,10 @@ func TestScriptNode_FilterANDSemantics(t *testing.T) {
 	}
 	fq := fleet.NewStewardFleetQuery(src)
 
+	testShell, _ := testShellAndScript()
 	config := &ScriptStepConfig{
 		InlineScript: "echo hello",
-		Shell:        script.ShellBash,
+		Shell:        testShell,
 		DeviceFilter: &fleet.Filter{
 			OS:   "linux",
 			Tags: []string{"prod"},
@@ -265,12 +283,13 @@ func TestScriptStepExecutor_FleetQueryInjection(t *testing.T) {
 	executor := NewScriptStepExecutor(nil, monitor, nil)
 	executor.SetFleetQuery(fq)
 
+	_, testShellName := testShellAndScript()
 	step := workflow.Step{
 		Name: "run-script",
 		Type: workflow.StepTypeTask,
 		Config: map[string]interface{}{
 			"inline_script": "echo hello",
-			"shell":         "bash",
+			"shell":         testShellName,
 			"device_filter": map[string]interface{}{
 				"os": "linux",
 			},
@@ -296,9 +315,10 @@ func TestScriptNode_FleetQueryError(t *testing.T) {
 	src := &errorDeviceSource{err: errors.New("registry unavailable")}
 	fq := fleet.NewStewardFleetQuery(src)
 
+	testShell, _ := testShellAndScript()
 	config := &ScriptStepConfig{
 		InlineScript: "echo hello",
-		Shell:        script.ShellBash,
+		Shell:        testShell,
 		DeviceFilter: &fleet.Filter{OS: "linux"},
 		Timeout:      5 * time.Second,
 	}
@@ -319,9 +339,10 @@ func TestScriptNode_FleetQueryError(t *testing.T) {
 // configuring a DeviceFilter without wiring a FleetQuery returns an error
 // rather than silently falling back to localhost.
 func TestScriptNode_DeviceFilterWithoutFleetQueryReturnsError(t *testing.T) {
+	testShell, _ := testShellAndScript()
 	config := &ScriptStepConfig{
 		InlineScript: "echo hello",
-		Shell:        script.ShellBash,
+		Shell:        testShell,
 		DeviceFilter: &fleet.Filter{OS: "linux"},
 		Timeout:      5 * time.Second,
 	}
@@ -342,9 +363,10 @@ func TestScriptNode_DeviceFilterWithoutFleetQueryReturnsError(t *testing.T) {
 // TestScriptNode_WaitForCompletion verifies that when WaitForCompletion is true,
 // Execute polls until the execution reaches a terminal status and returns success.
 func TestScriptNode_WaitForCompletion(t *testing.T) {
+	testShell, _ := testShellAndScript()
 	config := &ScriptStepConfig{
 		InlineScript:      "echo hello",
-		Shell:             script.ShellBash,
+		Shell:             testShell,
 		Timeout:           5 * time.Second,
 		WaitForCompletion: true,
 	}
@@ -366,9 +388,10 @@ func TestScriptNode_WaitForCompletion(t *testing.T) {
 // WaitForCompletion: true with Timeout: 0 returns an error rather than
 // silently timing out immediately via time.After(0).
 func TestScriptNode_WaitForCompletion_ZeroTimeoutError(t *testing.T) {
+	testShell, _ := testShellAndScript()
 	config := &ScriptStepConfig{
 		InlineScript:      "echo hello",
-		Shell:             script.ShellBash,
+		Shell:             testShell,
 		Timeout:           0, // zero value — misconfiguration
 		WaitForCompletion: true,
 	}

--- a/features/workflow/nodes/script_node_test.go
+++ b/features/workflow/nodes/script_node_test.go
@@ -15,21 +15,21 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// fakeFleetQuery is a test double for fleet.FleetQuery.
-// It records the filters it receives and returns a configurable device list.
-type fakeFleetQuery struct {
-	devices       []string
-	searchErr     error
-	calledFilters []fleet.Filter
+// testDeviceSource is a real DeviceSource backed by a configurable device list.
+// Using a real DeviceSource with StewardFleetQuery exercises the actual filtering
+// logic rather than bypassing it with a mock.
+type testDeviceSource struct {
+	devices []fleet.Device
 }
 
-func (f *fakeFleetQuery) Search(filter fleet.Filter) ([]string, error) {
-	f.calledFilters = append(f.calledFilters, filter)
-	if f.searchErr != nil {
-		return nil, f.searchErr
-	}
-	return f.devices, nil
+func (s *testDeviceSource) ListDevices() ([]fleet.Device, error) { return s.devices, nil }
+
+// errorDeviceSource is a DeviceSource that simulates a registry failure.
+type errorDeviceSource struct {
+	err error
 }
+
+func (s *errorDeviceSource) ListDevices() ([]fleet.Device, error) { return nil, s.err }
 
 // buildScriptNode creates a ScriptNode with an inline script and the given fleet query.
 func buildScriptNode(t *testing.T, config *ScriptStepConfig, fq fleet.FleetQuery) *ScriptNode {
@@ -42,10 +42,17 @@ func buildScriptNode(t *testing.T, config *ScriptStepConfig, fq fleet.FleetQuery
 	return node
 }
 
-// TestScriptNode_FleetQueryWiring verifies that the script node calls
-// fleetQuery.Search with the configured filter to obtain device IDs.
+// TestScriptNode_FleetQueryWiring verifies that the script node uses the fleet
+// query to resolve device IDs from the configured filter.
 func TestScriptNode_FleetQueryWiring(t *testing.T) {
-	fq := &fakeFleetQuery{devices: []string{"dev-1", "dev-2"}}
+	src := &testDeviceSource{
+		devices: []fleet.Device{
+			{ID: "dev-1", OS: "linux", Tags: []string{"prod"}},
+			{ID: "dev-2", OS: "linux", Tags: []string{"prod"}},
+			{ID: "dev-3", OS: "windows", Tags: []string{"prod"}}, // must not match OS filter
+		},
+	}
+	fq := fleet.NewStewardFleetQuery(src)
 
 	config := &ScriptStepConfig{
 		InlineScript: "echo hello",
@@ -58,22 +65,32 @@ func TestScriptNode_FleetQueryWiring(t *testing.T) {
 	}
 
 	node := buildScriptNode(t, config, fq)
-	_, err := node.Execute(context.Background(), workflow.NodeInput{
+	output, err := node.Execute(context.Background(), workflow.NodeInput{
 		Data:    map[string]interface{}{},
 		Context: map[string]interface{}{},
 	})
 	require.NoError(t, err)
+	assert.True(t, output.Success)
 
-	// Fleet query must have been called exactly once with the configured filter
-	require.Len(t, fq.calledFilters, 1)
-	assert.Equal(t, "linux", fq.calledFilters[0].OS)
-	assert.Equal(t, []string{"prod"}, fq.calledFilters[0].Tags)
+	// Fleet filter must have been applied: only linux+prod devices targeted
+	results, ok := output.Data["results"].(map[string]*script.ExecutionResult)
+	require.True(t, ok, "output must contain results map")
+	assert.Contains(t, results, "dev-1")
+	assert.Contains(t, results, "dev-2")
+	assert.NotContains(t, results, "dev-3", "windows device must not be targeted by linux filter")
 }
 
 // TestScriptNode_ExplicitDevicesSkipFleetQuery verifies that when Devices is
 // explicitly set, the fleet query is bypassed entirely.
 func TestScriptNode_ExplicitDevicesSkipFleetQuery(t *testing.T) {
-	fq := &fakeFleetQuery{devices: []string{"should-not-appear"}}
+	// Source has a fleet device that would match the filter — but explicit
+	// Devices list must take priority and fleet query must not be consulted.
+	src := &testDeviceSource{
+		devices: []fleet.Device{
+			{ID: "fleet-dev", OS: "linux"},
+		},
+	}
+	fq := fleet.NewStewardFleetQuery(src)
 
 	config := &ScriptStepConfig{
 		InlineScript: "echo hello",
@@ -84,26 +101,34 @@ func TestScriptNode_ExplicitDevicesSkipFleetQuery(t *testing.T) {
 	}
 
 	node := buildScriptNode(t, config, fq)
-	_, err := node.Execute(context.Background(), workflow.NodeInput{
+	output, err := node.Execute(context.Background(), workflow.NodeInput{
 		Data:    map[string]interface{}{},
 		Context: map[string]interface{}{},
 	})
 	require.NoError(t, err)
 
-	// Fleet query must NOT have been called
-	assert.Len(t, fq.calledFilters, 0, "explicit Devices list must bypass fleet query")
+	results, ok := output.Data["results"].(map[string]*script.ExecutionResult)
+	require.True(t, ok, "output must contain results map")
+	assert.Contains(t, results, "explicit-dev-1")
+	assert.NotContains(t, results, "fleet-dev", "explicit Devices list must bypass fleet query")
 }
 
 // TestScriptNode_ZeroMatchReturnsSuccessWithWarning verifies that when the
 // fleet filter matches no devices, the step completes with success (not failure)
 // and includes a warning in the output.
 func TestScriptNode_ZeroMatchReturnsSuccessWithWarning(t *testing.T) {
-	fq := &fakeFleetQuery{devices: []string{}} // returns no matches
+	// Source has only windows devices; linux filter yields zero matches.
+	src := &testDeviceSource{
+		devices: []fleet.Device{
+			{ID: "win-dev", OS: "windows"},
+		},
+	}
+	fq := fleet.NewStewardFleetQuery(src)
 
 	config := &ScriptStepConfig{
 		InlineScript: "echo hello",
 		Shell:        script.ShellBash,
-		DeviceFilter: &fleet.Filter{OS: "windows"},
+		DeviceFilter: &fleet.Filter{OS: "linux"},
 		Timeout:      5 * time.Second,
 	}
 
@@ -150,7 +175,12 @@ func TestScriptNode_NoFilterNoDevicesDefaultsToLocalhost(t *testing.T) {
 // This is the recurring workflow scenario: filter is stored in workflow
 // definition, result set is NOT cached.
 func TestScriptNode_RecurringFilterReEvaluated(t *testing.T) {
-	fq := &fakeFleetQuery{devices: []string{"dev-1"}}
+	src := &testDeviceSource{
+		devices: []fleet.Device{
+			{ID: "dev-1", OS: "linux"},
+		},
+	}
+	fq := fleet.NewStewardFleetQuery(src)
 
 	config := &ScriptStepConfig{
 		InlineScript: "echo hello",
@@ -161,54 +191,76 @@ func TestScriptNode_RecurringFilterReEvaluated(t *testing.T) {
 
 	node := buildScriptNode(t, config, fq)
 
-	// First execution
-	_, err := node.Execute(context.Background(), workflow.NodeInput{
+	// First execution — one device in fleet
+	output1, err := node.Execute(context.Background(), workflow.NodeInput{
 		Data:    map[string]interface{}{},
 		Context: map[string]interface{}{},
 	})
 	require.NoError(t, err)
-	require.Len(t, fq.calledFilters, 1)
+	results1, ok := output1.Data["results"].(map[string]*script.ExecutionResult)
+	require.True(t, ok)
+	assert.Len(t, results1, 1, "first execution must target one device")
 
 	// Simulate fleet change: a new device comes online
-	fq.devices = []string{"dev-1", "dev-2"}
+	src.devices = append(src.devices, fleet.Device{ID: "dev-2", OS: "linux"})
 
-	// Second execution (recurring run) — filter must be re-evaluated
-	_, err = node.Execute(context.Background(), workflow.NodeInput{
+	// Second execution — filter must be re-evaluated against current fleet
+	output2, err := node.Execute(context.Background(), workflow.NodeInput{
+		Data:    map[string]interface{}{},
+		Context: map[string]interface{}{},
+	})
+	require.NoError(t, err)
+	results2, ok := output2.Data["results"].(map[string]*script.ExecutionResult)
+	require.True(t, ok)
+	assert.Len(t, results2, 2, "second execution must target two devices after fleet change")
+	assert.Contains(t, results2, "dev-2", "newly added device must appear in second run")
+}
+
+// TestScriptNode_FilterANDSemantics verifies that a combined OS+Tags filter
+// applies AND semantics: only devices matching ALL criteria are targeted.
+func TestScriptNode_FilterANDSemantics(t *testing.T) {
+	src := &testDeviceSource{
+		devices: []fleet.Device{
+			{ID: "prod-linux", OS: "linux", Tags: []string{"prod"}},
+			{ID: "staging-linux", OS: "linux", Tags: []string{"staging"}},
+			{ID: "prod-windows", OS: "windows", Tags: []string{"prod"}},
+		},
+	}
+	fq := fleet.NewStewardFleetQuery(src)
+
+	config := &ScriptStepConfig{
+		InlineScript: "echo hello",
+		Shell:        script.ShellBash,
+		DeviceFilter: &fleet.Filter{
+			OS:   "linux",
+			Tags: []string{"prod"},
+		},
+		Timeout: 5 * time.Second,
+	}
+
+	node := buildScriptNode(t, config, fq)
+	output, err := node.Execute(context.Background(), workflow.NodeInput{
 		Data:    map[string]interface{}{},
 		Context: map[string]interface{}{},
 	})
 	require.NoError(t, err)
 
-	// Search must have been called again with the same filter
-	require.Len(t, fq.calledFilters, 2, "filter must be re-evaluated on each execution")
-	assert.Equal(t, fq.calledFilters[0], fq.calledFilters[1], "same filter reused across runs")
-}
-
-// TestScriptNode_DeviceFilterFieldsMatchFleetFilter verifies that the
-// ScriptStepConfig.DeviceFilter is typed as *fleet.Filter (no separate struct).
-func TestScriptNode_DeviceFilterFieldsMatchFleetFilter(t *testing.T) {
-	filter := &fleet.Filter{
-		OS:       "windows",
-		Tags:     []string{"prod", "web"},
-		Groups:   []string{"emea"},
-		DNAQuery: map[string]string{"tier": "frontend"},
-	}
-	config := &ScriptStepConfig{
-		InlineScript: "echo hello",
-		DeviceFilter: filter,
-	}
-
-	// Verify the field is directly a *fleet.Filter — no conversion needed
-	assert.Equal(t, "windows", config.DeviceFilter.OS)
-	assert.Equal(t, []string{"prod", "web"}, config.DeviceFilter.Tags)
-	assert.Equal(t, []string{"emea"}, config.DeviceFilter.Groups)
-	assert.Equal(t, "frontend", config.DeviceFilter.DNAQuery["tier"])
+	results, ok := output.Data["results"].(map[string]*script.ExecutionResult)
+	require.True(t, ok)
+	assert.Contains(t, results, "prod-linux")
+	assert.NotContains(t, results, "staging-linux", "staging device fails prod tag filter")
+	assert.NotContains(t, results, "prod-windows", "windows device fails linux OS filter")
 }
 
 // TestScriptStepExecutor_FleetQueryInjection verifies that FleetQuery can be
-// injected into the step executor and is passed to the node during execution.
+// injected into the step executor and is used to resolve devices during execution.
 func TestScriptStepExecutor_FleetQueryInjection(t *testing.T) {
-	fq := &fakeFleetQuery{devices: []string{"executor-dev-1"}}
+	src := &testDeviceSource{
+		devices: []fleet.Device{
+			{ID: "executor-dev-1", OS: "linux"},
+		},
+	}
+	fq := fleet.NewStewardFleetQuery(src)
 	monitor := script.NewExecutionMonitor()
 	executor := NewScriptStepExecutor(nil, monitor, nil)
 	executor.SetFleetQuery(fq)
@@ -230,17 +282,19 @@ func TestScriptStepExecutor_FleetQueryInjection(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, workflow.StatusCompleted, result.Status)
 
-	// Fleet query must have been called
-	require.GreaterOrEqual(t, len(fq.calledFilters), 1, "fleet query must be invoked during step execution")
-	assert.Equal(t, "linux", fq.calledFilters[0].OS)
+	// Fleet-targeted device must appear in results
+	resultData, ok := result.Output["results"].(map[string]*script.ExecutionResult)
+	require.True(t, ok, "output must include results map")
+	assert.Contains(t, resultData, "executor-dev-1", "fleet device must be targeted during execution")
 }
 
 // TestScriptNode_FleetQueryError verifies that a fleet query failure propagates
 // as a node failure (not a silent no-op or localhost fallback).
 func TestScriptNode_FleetQueryError(t *testing.T) {
-	fq := &fakeFleetQuery{
-		searchErr: errors.New("registry unavailable"),
-	}
+	// errorDeviceSource makes StewardFleetQuery.Search return an error,
+	// exercising the fleet query error propagation path in the script node.
+	src := &errorDeviceSource{err: errors.New("registry unavailable")}
+	fq := fleet.NewStewardFleetQuery(src)
 
 	config := &ScriptStepConfig{
 		InlineScript: "echo hello",
@@ -283,4 +337,27 @@ func TestScriptNode_DeviceFilterWithoutFleetQueryReturnsError(t *testing.T) {
 	require.Error(t, err, "misconfiguration (filter without FleetQuery) must return an error")
 	assert.False(t, output.Success, "node must fail when DeviceFilter is set but FleetQuery is not wired")
 	assert.Contains(t, err.Error(), "FleetQuery")
+}
+
+// TestScriptNode_WaitForCompletion verifies that when WaitForCompletion is true,
+// Execute polls until the execution reaches a terminal status and returns success.
+func TestScriptNode_WaitForCompletion(t *testing.T) {
+	config := &ScriptStepConfig{
+		InlineScript:      "echo hello",
+		Shell:             script.ShellBash,
+		Timeout:           5 * time.Second,
+		WaitForCompletion: true,
+	}
+
+	node := buildScriptNode(t, config, nil)
+	output, err := node.Execute(context.Background(), workflow.NodeInput{
+		Data:    map[string]interface{}{},
+		Context: map[string]interface{}{},
+	})
+	require.NoError(t, err)
+	assert.True(t, output.Success)
+
+	results, ok := output.Data["results"].(map[string]*script.ExecutionResult)
+	require.True(t, ok, "output must include results map")
+	assert.Contains(t, results, "localhost")
 }


### PR DESCRIPTION
## Summary

- Creates `features/controller/fleet` package with `FleetQuery` interface, `Filter` struct (fields matching REST API query params: `os`, `tags`, `groups`, `dna_query`), and `StewardFleetQuery` concrete implementation backed by a pluggable `DeviceSource`
- Replaces the ad-hoc `DeviceFilter` struct in `features/workflow/nodes/script_node.go` with `*fleet.Filter` — one filter definition shared with `GET /api/v1/stewards?os=windows&tag=prod`
- Wires `FleetQuery` into `ScriptNode` and `ScriptStepExecutor` via `SetFleetQuery()` setter (following existing provider injection pattern)
- Filter is re-evaluated on every `Execute()` call — recurring scheduled workflows always target current fleet state, never a cached snapshot
- Zero-match path: step completes with `Success=true` and a `Data["warning"]` message, not a failure
- Misconfiguration guard: `DeviceFilter` set without `FleetQuery` wired returns a descriptive error

## Test plan

- [ ] `features/controller/fleet/...` — 11 tests covering: `Filter.IsEmpty`, OS (case-insensitive), tag AND semantics, group filter, combined filter, zero-match, empty fleet, live re-evaluation (proves no caching)
- [ ] `features/workflow/nodes/...` — fleet query wiring, explicit-devices bypass, zero-match success+warning, localhost default, recurring re-evaluation, field type assertion, executor injection, fleet query error propagation, DeviceFilter-without-FleetQuery guard
- [ ] Pre-existing `go-jose v4.1.4` module cache issue causes `[setup failed]` for `workflow/nodes` in this container (same failure exists on develop before these changes — confirmed by stashing and re-running); fleet tests execute cleanly

## Specialist Review Results

| Specialist | Result |
|---|---|
| QA Test Runner | **PASS** — 11/11 fleet tests pass; no new failures introduced |
| QA Code Reviewer | **PASS** (after fixes) — error path tests added, error-swallow justified, misconfiguration guard added |
| Security Engineer | **PASS** — no hardcoded secrets, no central provider violations, architecture compliance verified |

Fixes #609

🤖 Generated with [Claude Code](https://claude.com/claude-code)