### PR TITLE
docs: update merge policy — acceptance reviewer auto-merges clean PRs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,7 +100,7 @@ Docs-only PRs get instant green checks via stub jobs (<2 min merge path).
 
 **Branch protection config:** Squash merge only, no review requirements (solo-friendly), relaxed up-to-date policy (PRs don't need latest develop to merge).
 
-**Merging:** Interactive mode uses `gh pr merge --squash --auto` after `/pr-review` approval. Agent-dispatched PRs must NOT auto-merge — they require manual `/pr-review` before merging.
+**Merging:** Interactive mode uses `gh pr merge --squash --auto` after `/pr-review` approval. Agent-dispatched PRs are auto-merged by the acceptance reviewer when there are zero findings. If the acceptance reviewer finds any issues (even low severity), it must post the concerns on the PR and tag it for manual `/pr-review` — no auto-merge with findings.
 
 **`make test-complete` coverage:**
 - All pre-commit validation, fast comprehensive tests, production-critical tests


### PR DESCRIPTION
## Summary
- Updates CLAUDE.md merge policy: acceptance reviewer auto-merges agent PRs with zero findings
- Any findings (even low severity) require manual `/pr-review` before merge
- Removes the blanket "agent PRs must NOT auto-merge" rule that was blocking the pipeline

## Test plan
- [ ] Next acceptance review cycle auto-merges a zero-finding PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)