### PR TITLE
perf(steward/dna): replace Windows external commands with native Go APIs (Issue #619)

### DIFF
--- a/features/steward/dna/dna.go
+++ b/features/steward/dna/dna.go
@@ -163,14 +163,34 @@ func (c *Collector) Collect(ctx context.Context) (*commonpb.DNA, error) {
 }
 
 // runBackgroundCollection collects slow software and security data asynchronously.
+// Software and security run concurrently since they write to separate attribute keys.
 // It merges results into slowAttrs and closes bgDone when finished.
 func (c *Collector) runBackgroundCollection(ctx context.Context) {
 	c.logger.Debug("Starting background DNA collection (software + security)")
 	start := time.Now()
 
-	slowAttrs := make(map[string]string)
-	c.collectSoftwareInfo(ctx, slowAttrs)
-	c.collectSecurityInfo(ctx, slowAttrs)
+	swAttrs := make(map[string]string)
+	secAttrs := make(map[string]string)
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		c.collectSoftwareInfo(ctx, swAttrs)
+	}()
+	go func() {
+		defer wg.Done()
+		c.collectSecurityInfo(ctx, secAttrs)
+	}()
+	wg.Wait()
+
+	slowAttrs := make(map[string]string, len(swAttrs)+len(secAttrs))
+	for k, v := range swAttrs {
+		slowAttrs[k] = v
+	}
+	for k, v := range secAttrs {
+		slowAttrs[k] = v
+	}
 
 	c.slowMu.Lock()
 	c.slowAttrs = slowAttrs

--- a/features/steward/dna/hardware_windows.go
+++ b/features/steward/dna/hardware_windows.go
@@ -13,6 +13,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"golang.org/x/sys/windows/registry"
 )
 
 // WindowsHardwareCollector handles Windows-specific hardware collection.
@@ -147,19 +149,8 @@ func (w *WindowsHardwareCollector) CollectMotherboard(ctx context.Context, attri
 		w.parseWMIUUIDOutput(uuidOutput, attributes)
 	}
 
-	// OS version for hardware context — primary: wmic
-	osOutput, err := runCommand(ctx, "wmic", "os", "get",
-		"Caption,Version,BuildNumber", "/format:csv")
-	if err == nil {
-		w.parseWMIOSVersionOutput(osOutput, attributes)
-	} else {
-		// Fallback: PowerShell
-		psOut, psErr := runCommand(ctx, "powershell", "-NoProfile", "-NonInteractive", "-Command",
-			"Get-CimInstance -ClassName Win32_OperatingSystem | Select-Object Caption,Version,BuildNumber | ConvertTo-Csv -NoTypeInformation")
-		if psErr == nil {
-			w.parsePowerShellOSOutput(psOut, attributes)
-		}
-	}
+	// OS version for hardware context — native registry reads (no process spawn)
+	w.collectOSVersionFromRegistry(attributes)
 
 	return nil
 }
@@ -524,54 +515,29 @@ func (w *WindowsHardwareCollector) parseWMIUUIDOutput(output string, attributes 
 	}
 }
 
-// parseWMIOSVersionOutput parses minimal OS info from wmic for hardware context
-func (w *WindowsHardwareCollector) parseWMIOSVersionOutput(output string, attributes map[string]string) {
-	lines := strings.Split(output, "\n")
-	for _, line := range lines {
-		line = strings.TrimSpace(line)
-		if line == "" || strings.HasPrefix(line, "Node") {
-			continue
-		}
-
-		fields := strings.Split(line, ",")
-		if len(fields) >= 4 {
-			if fields[1] != "" {
-				attributes["windows_build_number"] = fields[1]
-			}
-			if fields[2] != "" {
-				attributes["windows_caption"] = fields[2]
-			}
-			if fields[3] != "" {
-				attributes["windows_version"] = fields[3]
-			}
-		}
+// collectOSVersionFromRegistry reads Windows version info directly from the
+// registry for the hardware cache fast path. No process spawn required.
+func (w *WindowsHardwareCollector) collectOSVersionFromRegistry(attributes map[string]string) {
+	key, err := registry.OpenKey(registry.LOCAL_MACHINE,
+		`SOFTWARE\Microsoft\Windows NT\CurrentVersion`, registry.QUERY_VALUE)
+	if err != nil {
+		return
 	}
-}
+	defer key.Close()
 
-func (w *WindowsHardwareCollector) parsePowerShellOSOutput(output string, attributes map[string]string) {
-	lines := strings.Split(output, "\n")
-	for i, line := range lines {
-		if i == 0 { // Skip header
-			continue
-		}
-		line = strings.TrimSpace(line)
-		if line == "" {
-			continue
-		}
+	if product, _, err := key.GetStringValue("ProductName"); err == nil {
+		attributes["windows_caption"] = product
+	}
 
-		fields := w.parseCSVLine(line)
-		if len(fields) >= 3 {
-			if fields[0] != "" {
-				attributes["windows_build_number"] = fields[0]
-			}
-			if fields[1] != "" {
-				attributes["windows_caption"] = fields[1]
-			}
-			if fields[2] != "" {
-				attributes["windows_version"] = fields[2]
-			}
-		}
-		break // Only process first OS entry
+	if build, _, err := key.GetStringValue("CurrentBuildNumber"); err == nil {
+		attributes["windows_build_number"] = build
+	}
+
+	major, _, majorErr := key.GetIntegerValue("CurrentMajorVersionNumber")
+	minor, _, minorErr := key.GetIntegerValue("CurrentMinorVersionNumber")
+	buildStr, _, buildErr := key.GetStringValue("CurrentBuildNumber")
+	if majorErr == nil && minorErr == nil && buildErr == nil {
+		attributes["windows_version"] = fmt.Sprintf("%d.%d.%s", major, minor, buildStr)
 	}
 }
 

--- a/features/steward/dna/software_windows.go
+++ b/features/steward/dna/software_windows.go
@@ -9,18 +9,28 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"os/user"
 	"runtime"
 	"strings"
+	"sync"
+	"time"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+	"golang.org/x/sys/windows/registry"
+	"golang.org/x/sys/windows/svc"
+	"golang.org/x/sys/windows/svc/mgr"
 )
 
-// WindowsSoftwareCollector handles Windows-specific software collection.
-// Each method accepts a context to enforce per-command timeouts on WMI and PowerShell calls.
+// WindowsSoftwareCollector handles Windows-specific software collection using
+// native Windows APIs (registry, SCM, process snapshots) instead of external
+// commands for significantly improved performance.
 type WindowsSoftwareCollector struct{}
 
-// CollectOS gathers detailed operating system information on Windows.
-// wmic is attempted first; PowerShell is used only as a fallback.
+// CollectOS gathers OS information using native registry reads.
+// External calls are kept only for PowerShell version and .NET Core runtimes
+// (no native Go API available) and run concurrently.
 func (w *WindowsSoftwareCollector) CollectOS(ctx context.Context, attributes map[string]string) error {
-	// Basic OS information
 	attributes["os"] = runtime.GOOS
 	attributes["go_version"] = runtime.Version()
 	attributes["runtime_version"] = runtime.Version()
@@ -28,244 +38,297 @@ func (w *WindowsSoftwareCollector) CollectOS(ctx context.Context, attributes map
 	attributes["runtime_os"] = runtime.GOOS
 	attributes["runtime_compiler"] = runtime.Compiler
 
-	// Windows version — primary: wmic
-	if output, err := runCommand(ctx, "wmic", "os", "get",
-		"Caption,Version,BuildNumber,ServicePackMajorVersion,OSArchitecture", "/format:csv"); err == nil {
-		w.parseWMIOSOutput(output, attributes)
-	} else {
-		// Fallback: PowerShell Get-CimInstance
-		if psOutput, psErr := runCommand(ctx, "powershell", "-NoProfile", "-NonInteractive", "-Command",
-			"Get-CimInstance -ClassName Win32_OperatingSystem | Select-Object Caption,Version,BuildNumber,OSArchitecture,InstallDate,LastBootUpTime | ConvertTo-Csv -NoTypeInformation"); psErr == nil {
-			w.parsePowerShellOSOutput(psOutput, attributes)
+	// Native: OS version from registry (sub-millisecond)
+	w.collectOSVersion(attributes)
+
+	// Native: .NET Framework versions from registry (sub-millisecond)
+	w.collectDotNetVersions(attributes)
+
+	// External calls (no native API) — run concurrently
+	var wg sync.WaitGroup
+	var mu sync.Mutex
+
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		if output, err := runCommand(ctx, "powershell", "-NoProfile", "-NonInteractive", "-Command",
+			"$PSVersionTable.PSVersion.ToString()"); err == nil {
+			mu.Lock()
+			attributes["powershell_version"] = strings.TrimSpace(output)
+			mu.Unlock()
 		}
-	}
-
-	// .NET Framework versions
-	w.collectDotNetVersions(ctx, attributes)
-
-	// PowerShell version
-	if output, err := runCommand(ctx, "powershell", "-NoProfile", "-NonInteractive", "-Command",
-		"$PSVersionTable.PSVersion.ToString()"); err == nil {
-		attributes["powershell_version"] = strings.TrimSpace(output)
-	}
+	}()
+	go func() {
+		defer wg.Done()
+		if output, err := runCommand(ctx, "dotnet", "--list-runtimes"); err == nil {
+			mu.Lock()
+			attributes["dotnet_core_runtimes"] = strings.TrimSpace(output)
+			mu.Unlock()
+		}
+	}()
+	wg.Wait()
 
 	return nil
 }
 
-// CollectPackages gathers installed packages/applications on Windows.
-// Uses registry enumeration instead of Win32_Product to avoid MSI reconfiguration.
+// CollectPackages gathers installed packages using native registry reads and
+// concurrent external calls for third-party package managers.
 func (w *WindowsSoftwareCollector) CollectPackages(ctx context.Context, attributes map[string]string) error {
-	// Installed programs via registry scan (fast — no MSI reconfiguration)
-	w.collectInstalledPrograms(ctx, attributes)
+	// Native: installed programs via registry (fast, <100ms)
+	w.collectInstalledPrograms(attributes)
 
-	// Windows Features
-	w.collectWindowsFeatures(ctx, attributes)
+	// Native: system updates/hotfixes via CBS registry
+	w.collectInstalledUpdates(attributes)
 
-	// Chocolatey packages (if available)
-	w.collectChocolateyPackages(ctx, attributes)
+	// External package manager calls — run concurrently
+	type externalCollector func(context.Context, map[string]string)
+	collectors := []externalCollector{
+		w.collectChocolateyPackages,
+		w.collectWingetPackages,
+		w.collectWindowsStoreApps,
+	}
 
-	// Winget packages (if available)
-	w.collectWingetPackages(ctx, attributes)
+	// Opt-in: Windows Features via DISM (notoriously slow)
+	if os.Getenv("CFGMS_DNA_COLLECT_DISM_FEATURES") != "" {
+		collectors = append(collectors, w.collectWindowsFeatures)
+	}
 
-	// Windows Store apps
-	w.collectWindowsStoreApps(ctx, attributes)
-
-	// System updates/hotfixes
-	w.collectInstalledUpdates(ctx, attributes)
+	var wg sync.WaitGroup
+	var mu sync.Mutex
+	for _, fn := range collectors {
+		wg.Add(1)
+		go func(collect externalCollector) {
+			defer wg.Done()
+			localAttrs := make(map[string]string)
+			collect(ctx, localAttrs)
+			mu.Lock()
+			for k, v := range localAttrs {
+				attributes[k] = v
+			}
+			mu.Unlock()
+		}(fn)
+	}
+	wg.Wait()
 
 	return nil
 }
 
-// CollectServices gathers installed and running services on Windows.
+// CollectServices gathers service information using the native Service Control
+// Manager API with wmic fallback, process count via snapshot, and startup
+// programs from registry.
 func (w *WindowsSoftwareCollector) CollectServices(ctx context.Context, attributes map[string]string) error {
-	// Windows services — primary: wmic
-	if output, err := runCommand(ctx, "wmic", "service", "get",
-		"Name,State,StartMode,ServiceType", "/format:csv"); err == nil {
-		w.parseWMIServicesOutput(output, attributes)
-	} else {
-		// Fallback: PowerShell
-		if psOutput, psErr := runCommand(ctx, "powershell", "-NoProfile", "-NonInteractive", "-Command",
-			"Get-CimInstance -ClassName Win32_Service | Select-Object Name,State,StartMode,ServiceType | ConvertTo-Csv -NoTypeInformation"); psErr == nil {
-			w.parseWMIServicesOutput(psOutput, attributes)
+	// Primary: native SCM API (requires service manager access — steward runs as SYSTEM)
+	if err := w.collectServicesViaSCM(attributes); err != nil {
+		// Fallback: wmic (works with limited access)
+		if output, wmicErr := runCommand(ctx, "wmic", "service", "get",
+			"Name,State,StartMode,ServiceType", "/format:csv"); wmicErr == nil {
+			w.parseWMIServicesOutput(output, attributes)
 		}
 	}
 
-	// Running processes count
-	if output, err := runCommand(ctx, "tasklist", "/fo", "csv"); err == nil {
-		lines := strings.Split(output, "\n")
-		attributes["running_process_count"] = fmt.Sprintf("%d", len(lines)-1) // -1 for header
-	}
+	// Native: process count via snapshot
+	attributes["running_process_count"] = fmt.Sprintf("%d", countProcesses())
 
-	// Startup programs
-	w.collectStartupPrograms(ctx, attributes)
+	// Native: startup programs from Run/RunOnce registry keys
+	w.collectStartupPrograms(attributes)
 
 	return nil
 }
 
-// CollectProcesses gathers information about running processes on Windows.
+// CollectProcesses gathers process information using CreateToolhelp32Snapshot
+// and native token lookups for process owners.
 func (w *WindowsSoftwareCollector) CollectProcesses(ctx context.Context, attributes map[string]string) error {
-	// Basic process information
 	attributes["current_pid"] = fmt.Sprintf("%d", os.Getpid())
 	attributes["parent_pid"] = fmt.Sprintf("%d", os.Getppid())
 
-	// Current user
-	if user, err := runCommand(ctx, "whoami"); err == nil {
-		attributes["current_user"] = strings.TrimSpace(user)
+	// Native: current user via os/user (no whoami process spawn)
+	if u, err := user.Current(); err == nil {
+		attributes["current_user"] = u.Username
 	}
 
-	// Number of goroutines
 	attributes["goroutine_count"] = fmt.Sprintf("%d", runtime.NumGoroutine())
 
-	// Detailed process information using tasklist
-	if output, err := runCommand(ctx, "tasklist", "/fo", "csv", "/v"); err == nil {
-		w.parseTasklistOutput(output, attributes)
-	}
-
-	// Process statistics using PowerShell
-	if output, err := runCommand(ctx, "powershell", "-NoProfile", "-NonInteractive", "-Command",
-		"Get-Process | Group-Object ProcessName | Select-Object Count,Name | Sort-Object Count -Descending | Select-Object -First 10 | ConvertTo-Csv -NoTypeInformation"); err == nil {
-		w.parsePowerShellProcessStatsOutput(output, attributes)
-	}
+	// Native: process snapshot with owner lookups
+	w.collectProcessSnapshot(attributes)
 
 	return nil
 }
 
-// parseWMIOSOutput parses WMI OS output
-func (w *WindowsSoftwareCollector) parseWMIOSOutput(output string, attributes map[string]string) {
-	lines := strings.Split(output, "\n")
-	for _, line := range lines {
-		line = strings.TrimSpace(line)
-		if line == "" || strings.HasPrefix(line, "Node") {
-			continue
-		}
+// ---------- OS info helpers ----------
 
-		fields := strings.Split(line, ",")
-		if len(fields) >= 6 {
-			if fields[1] != "" {
-				attributes["windows_build_number"] = fields[1]
-			}
-			if fields[2] != "" {
-				attributes["windows_caption"] = fields[2]
-			}
-			if fields[3] != "" {
-				attributes["windows_os_architecture"] = fields[3]
-			}
-			if fields[4] != "" {
-				attributes["windows_service_pack"] = fields[4]
-			}
-			if fields[5] != "" {
-				attributes["windows_version"] = fields[5]
+// collectOSVersion reads Windows version information directly from the registry.
+// Replaces wmic os and PowerShell Get-CimInstance calls.
+func (w *WindowsSoftwareCollector) collectOSVersion(attributes map[string]string) {
+	key, err := registry.OpenKey(registry.LOCAL_MACHINE,
+		`SOFTWARE\Microsoft\Windows NT\CurrentVersion`, registry.QUERY_VALUE)
+	if err != nil {
+		return
+	}
+	defer key.Close()
+
+	if product, _, err := key.GetStringValue("ProductName"); err == nil {
+		attributes["windows_caption"] = product
+	}
+
+	if build, _, err := key.GetStringValue("CurrentBuildNumber"); err == nil {
+		attributes["windows_build_number"] = build
+	}
+
+	// Full version string (e.g., "10.0.19045")
+	major, _, majorErr := key.GetIntegerValue("CurrentMajorVersionNumber")
+	minor, _, minorErr := key.GetIntegerValue("CurrentMinorVersionNumber")
+	buildStr, _, buildErr := key.GetStringValue("CurrentBuildNumber")
+	if majorErr == nil && minorErr == nil && buildErr == nil {
+		attributes["windows_version"] = fmt.Sprintf("%d.%d.%s", major, minor, buildStr)
+	}
+
+	// Service pack (empty on Windows 10+)
+	if csd, _, err := key.GetStringValue("CSDVersion"); err == nil && csd != "" {
+		attributes["windows_service_pack"] = csd
+	} else {
+		attributes["windows_service_pack"] = "0"
+	}
+
+	// Install date (stored as Unix timestamp DWORD)
+	if installDate, _, err := key.GetIntegerValue("InstallDate"); err == nil && installDate > 0 {
+		t := time.Unix(int64(installDate), 0)
+		attributes["windows_install_date"] = t.Format("2006-01-02 15:04:05")
+	}
+
+	// OS architecture from processor environment registry
+	envKey, err := registry.OpenKey(registry.LOCAL_MACHINE,
+		`SYSTEM\CurrentControlSet\Control\Session Manager\Environment`, registry.QUERY_VALUE)
+	if err == nil {
+		if arch, _, err := envKey.GetStringValue("PROCESSOR_ARCHITECTURE"); err == nil {
+			switch arch {
+			case "AMD64":
+				attributes["windows_os_architecture"] = "64-bit"
+			case "x86":
+				attributes["windows_os_architecture"] = "32-bit"
+			case "ARM64":
+				attributes["windows_os_architecture"] = "ARM 64-bit"
+			default:
+				attributes["windows_os_architecture"] = arch
 			}
 		}
+		envKey.Close()
+	}
+
+	// Last boot time derived from system uptime via kernel32.GetTickCount64
+	kernel32 := windows.NewLazySystemDLL("kernel32.dll")
+	getTickCount64 := kernel32.NewProc("GetTickCount64")
+	if getTickCount64.Find() == nil {
+		ret, _, _ := getTickCount64.Call()
+		uptimeMs := uint64(ret)
+		bootTime := time.Now().Add(-time.Duration(uptimeMs) * time.Millisecond)
+		attributes["windows_last_boot_time"] = bootTime.Format("2006-01-02 15:04:05")
 	}
 }
 
-// parsePowerShellOSOutput parses PowerShell OS output
-func (w *WindowsSoftwareCollector) parsePowerShellOSOutput(output string, attributes map[string]string) {
-	lines := strings.Split(output, "\n")
-	for i, line := range lines {
-		if i == 0 { // Skip header
-			continue
-		}
-		line = strings.TrimSpace(line)
-		if line == "" {
-			continue
-		}
-
-		fields := w.parseCSVLine(line)
-		if len(fields) >= 6 {
-			if fields[0] != "" {
-				attributes["windows_build_number_ps"] = fields[0]
-			}
-			if fields[1] != "" {
-				attributes["windows_caption_ps"] = fields[1]
-			}
-			if fields[2] != "" {
-				attributes["windows_install_date"] = fields[2]
-			}
-			if fields[3] != "" {
-				attributes["windows_last_boot_time"] = fields[3]
-			}
-			if fields[4] != "" {
-				attributes["windows_os_architecture_ps"] = fields[4]
-			}
-			if fields[5] != "" {
-				attributes["windows_version_ps"] = fields[5]
-			}
-		}
-		break // Only process first OS entry
-	}
-}
-
-// collectDotNetVersions collects .NET Framework versions
-func (w *WindowsSoftwareCollector) collectDotNetVersions(ctx context.Context, attributes map[string]string) {
-	// .NET Framework versions via registry (using PowerShell)
-	if output, err := runCommand(ctx, "powershell", "-NoProfile", "-NonInteractive", "-Command",
-		"Get-ChildItem 'HKLM:SOFTWARE\\Microsoft\\NET Framework Setup\\NDP' -recurse | Get-ItemProperty -name Version,Release -EA 0 | Where { $_.PSChildName -match '^(?!S)\\p{L}'} | Select PSChildName, Version, Release"); err == nil {
-		lines := strings.Split(output, "\n")
-		var dotnetVersions []string
-		for _, line := range lines {
-			line = strings.TrimSpace(line)
-			if strings.Contains(line, "Version") {
-				dotnetVersions = append(dotnetVersions, line)
-			}
-		}
-		if len(dotnetVersions) > 0 {
-			attributes["dotnet_framework_versions"] = strings.Join(dotnetVersions, "; ")
-		}
-	}
-
-	// .NET Core/5+ versions
-	if output, err := runCommand(ctx, "dotnet", "--list-runtimes"); err == nil {
-		attributes["dotnet_core_runtimes"] = strings.TrimSpace(output)
-	}
-}
-
-// collectInstalledPrograms collects installed programs via registry scan.
-//
-// This replaces the old wmic product get approach which used Win32_Product — a
-// known anti-pattern that triggers MSI repair/reconfiguration for every installed
-// product and takes 5-15 minutes on typical Windows systems.
-//
-// The registry scan reads directly from the Uninstall keys and completes in
-// under 2 seconds.
-func (w *WindowsSoftwareCollector) collectInstalledPrograms(ctx context.Context, attributes map[string]string) {
-	// Read from both 64-bit and 32-bit uninstall registry hives
-	output, err := runCommand(ctx, "powershell", "-NoProfile", "-NonInteractive", "-Command",
-		"Get-ItemProperty "+
-			"'HKLM:\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\*',"+
-			"'HKLM:\\SOFTWARE\\WOW6432Node\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\*' "+
-			"2>$null "+
-			"| Select-Object DisplayName,DisplayVersion,Publisher,InstallDate "+
-			"| Where-Object { $_.DisplayName -ne $null -and $_.DisplayName -ne '' } "+
-			"| ConvertTo-Csv -NoTypeInformation")
+// collectDotNetVersions reads .NET Framework versions directly from the registry.
+// Replaces the PowerShell Get-ChildItem HKLM:SOFTWARE\Microsoft\NET Framework Setup\NDP call.
+func (w *WindowsSoftwareCollector) collectDotNetVersions(attributes map[string]string) {
+	ndpPath := `SOFTWARE\Microsoft\NET Framework Setup\NDP`
+	ndpKey, err := registry.OpenKey(registry.LOCAL_MACHINE, ndpPath, registry.READ)
 	if err != nil {
 		return
 	}
 
-	lines := strings.Split(output, "\n")
-	var programCount int
+	subkeys, err := ndpKey.ReadSubKeyNames(-1)
+	ndpKey.Close()
+	if err != nil {
+		return
+	}
+
+	var versions []string
+	for _, name := range subkeys {
+		if !strings.HasPrefix(name, "v") {
+			continue
+		}
+
+		subPath := ndpPath + `\` + name
+		sk, err := registry.OpenKey(registry.LOCAL_MACHINE, subPath, registry.READ)
+		if err != nil {
+			continue
+		}
+
+		// Try to read Version directly from this key (v2.x, v3.x)
+		if ver, _, err := sk.GetStringValue("Version"); err == nil && ver != "" {
+			versions = append(versions, name+" "+ver)
+			sk.Close()
+			continue
+		}
+
+		// Check Full/Client subkeys (v4+)
+		childKeys, _ := sk.ReadSubKeyNames(-1)
+		sk.Close()
+
+		for _, child := range childKeys {
+			if child != "Full" && child != "Client" {
+				continue
+			}
+			childKey, err := registry.OpenKey(registry.LOCAL_MACHINE, subPath+`\`+child, registry.QUERY_VALUE)
+			if err != nil {
+				continue
+			}
+			if ver, _, err := childKey.GetStringValue("Version"); err == nil && ver != "" {
+				versions = append(versions, name+"/"+child+" "+ver)
+			}
+			childKey.Close()
+		}
+	}
+
+	if len(versions) > 0 {
+		attributes["dotnet_framework_versions"] = strings.Join(versions, "; ")
+	}
+}
+
+// ---------- Package/update helpers ----------
+
+// collectInstalledPrograms reads installed programs directly from the Uninstall
+// registry keys (both 64-bit and WOW6432Node). Replaces the PowerShell registry scan.
+func (w *WindowsSoftwareCollector) collectInstalledPrograms(attributes map[string]string) {
+	paths := []string{
+		`SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall`,
+		`SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall`,
+	}
+
 	var programs []string
+	var programCount int
 
-	for i, line := range lines {
-		if i == 0 { // Skip CSV header
-			continue
-		}
-		line = strings.TrimSpace(line)
-		if line == "" {
+	for _, path := range paths {
+		key, err := registry.OpenKey(registry.LOCAL_MACHINE, path, registry.READ)
+		if err != nil {
 			continue
 		}
 
-		fields := w.parseCSVLine(line)
-		if len(fields) >= 1 && fields[0] != "" {
+		subkeys, err := key.ReadSubKeyNames(-1)
+		key.Close()
+		if err != nil {
+			continue
+		}
+
+		for _, subkey := range subkeys {
+			sk, err := registry.OpenKey(registry.LOCAL_MACHINE, path+`\`+subkey, registry.QUERY_VALUE)
+			if err != nil {
+				continue
+			}
+
+			displayName, _, err := sk.GetStringValue("DisplayName")
+			if err != nil || displayName == "" {
+				sk.Close()
+				continue
+			}
+
 			programCount++
-			if programCount <= 20 { // Store first 20 as sample
-				programInfo := fields[0] // DisplayName
-				if len(fields) > 1 && fields[1] != "" {
-					programInfo += " " + fields[1] // DisplayVersion
+			if len(programs) < 20 {
+				programInfo := displayName
+				if version, _, verr := sk.GetStringValue("DisplayVersion"); verr == nil && version != "" {
+					programInfo += " " + version
 				}
 				programs = append(programs, programInfo)
 			}
+			sk.Close()
 		}
 	}
 
@@ -275,7 +338,52 @@ func (w *WindowsSoftwareCollector) collectInstalledPrograms(ctx context.Context,
 	}
 }
 
-// collectWindowsFeatures collects Windows features
+// collectInstalledUpdates reads hotfix/KB information from the CBS packages
+// registry. Replaces wmic qfe.
+func (w *WindowsSoftwareCollector) collectInstalledUpdates(attributes map[string]string) {
+	key, err := registry.OpenKey(registry.LOCAL_MACHINE,
+		`SOFTWARE\Microsoft\Windows\CurrentVersion\Component Based Servicing\Packages`,
+		registry.READ)
+	if err != nil {
+		return
+	}
+	defer key.Close()
+
+	subkeys, err := key.ReadSubKeyNames(-1)
+	if err != nil {
+		return
+	}
+
+	// Deduplicate KB numbers (multiple packages per KB)
+	kbs := make(map[string]bool)
+	for _, name := range subkeys {
+		if !strings.HasPrefix(name, "Package_for_KB") {
+			continue
+		}
+		parts := strings.SplitN(name, "~", 2)
+		if len(parts) > 0 {
+			kb := strings.TrimPrefix(parts[0], "Package_for_")
+			kbs[kb] = true
+		}
+	}
+
+	attributes["installed_update_count"] = fmt.Sprintf("%d", len(kbs))
+
+	var updates []string
+	for kb := range kbs {
+		if len(updates) >= 10 {
+			break
+		}
+		updates = append(updates, kb)
+	}
+	if len(updates) > 0 {
+		attributes["installed_updates_sample"] = strings.Join(updates, "; ")
+	}
+}
+
+// collectWindowsFeatures collects Windows optional features via DISM PowerShell.
+// Gated behind CFGMS_DNA_COLLECT_DISM_FEATURES env var because
+// Get-WindowsOptionalFeature is notoriously slow.
 func (w *WindowsSoftwareCollector) collectWindowsFeatures(ctx context.Context, attributes map[string]string) {
 	if output, err := runCommand(ctx, "powershell", "-NoProfile", "-NonInteractive", "-Command",
 		"Get-WindowsOptionalFeature -Online | Where-Object {$_.State -eq 'Enabled'} | Select-Object FeatureName | ConvertTo-Csv -NoTypeInformation"); err == nil {
@@ -284,7 +392,6 @@ func (w *WindowsSoftwareCollector) collectWindowsFeatures(ctx context.Context, a
 		if featureCount > 0 {
 			attributes["windows_features_enabled_count"] = fmt.Sprintf("%d", featureCount)
 
-			// Store first 10 features as sample
 			var features []string
 			for i := 1; i <= 10 && i < len(lines); i++ {
 				feature := strings.Trim(strings.TrimSpace(lines[i]), "\"")
@@ -299,7 +406,8 @@ func (w *WindowsSoftwareCollector) collectWindowsFeatures(ctx context.Context, a
 	}
 }
 
-// collectChocolateyPackages collects Chocolatey packages if available
+// collectChocolateyPackages collects Chocolatey packages if available.
+// Kept as external call — chocolatey is a third-party package manager.
 func (w *WindowsSoftwareCollector) collectChocolateyPackages(ctx context.Context, attributes map[string]string) {
 	if output, err := runCommand(ctx, "choco", "list", "--local-only"); err == nil {
 		lines := strings.Split(output, "\n")
@@ -312,7 +420,7 @@ func (w *WindowsSoftwareCollector) collectChocolateyPackages(ctx context.Context
 				continue
 			}
 			packageCount++
-			if packageCount <= 10 { // Store first 10 as sample
+			if packageCount <= 10 {
 				packages = append(packages, line)
 			}
 		}
@@ -324,9 +432,9 @@ func (w *WindowsSoftwareCollector) collectChocolateyPackages(ctx context.Context
 	}
 }
 
-// collectWingetPackages collects Winget packages if available
+// collectWingetPackages collects Winget packages if available.
+// Kept as external call — winget is a third-party package manager.
 func (w *WindowsSoftwareCollector) collectWingetPackages(ctx context.Context, attributes map[string]string) {
-	// List installed packages
 	if output, err := runCommand(ctx, "winget", "list"); err == nil {
 		lines := strings.Split(output, "\n")
 		var packageCount int
@@ -339,7 +447,6 @@ func (w *WindowsSoftwareCollector) collectWingetPackages(ctx context.Context, at
 				continue
 			}
 
-			// Skip until we find the header line with "Name" and "Id"
 			if !headerFound {
 				if strings.Contains(line, "Name") && strings.Contains(line, "Id") {
 					headerFound = true
@@ -347,20 +454,18 @@ func (w *WindowsSoftwareCollector) collectWingetPackages(ctx context.Context, at
 				continue
 			}
 
-			// Skip separator line (dashes)
 			if strings.Contains(line, "---") {
 				continue
 			}
 
-			// Parse package line
 			fields := strings.Fields(line)
 			if len(fields) >= 2 {
 				packageCount++
-				if packageCount <= 15 { // Store first 15 as sample
+				if packageCount <= 15 {
 					packageInfo := fields[0]
 					if len(fields) > 2 {
 						for _, field := range fields {
-							if strings.Contains(field, ".") && (strings.ContainsAny(field, "0123456789")) {
+							if strings.Contains(field, ".") && strings.ContainsAny(field, "0123456789") {
 								packageInfo += " " + field
 								break
 							}
@@ -377,7 +482,6 @@ func (w *WindowsSoftwareCollector) collectWingetPackages(ctx context.Context, at
 		}
 	}
 
-	// Get winget version for diagnostics
 	if output, err := runCommand(ctx, "winget", "--version"); err == nil {
 		version := strings.TrimSpace(output)
 		if version != "" {
@@ -385,7 +489,6 @@ func (w *WindowsSoftwareCollector) collectWingetPackages(ctx context.Context, at
 		}
 	}
 
-	// Check for winget sources
 	if output, err := runCommand(ctx, "winget", "source", "list"); err == nil {
 		lines := strings.Split(output, "\n")
 		var sourceCount int
@@ -411,7 +514,8 @@ func (w *WindowsSoftwareCollector) collectWingetPackages(ctx context.Context, at
 	}
 }
 
-// collectWindowsStoreApps collects Windows Store apps
+// collectWindowsStoreApps collects Windows Store apps.
+// Kept as external call — requires PowerShell AppX cmdlets.
 func (w *WindowsSoftwareCollector) collectWindowsStoreApps(ctx context.Context, attributes map[string]string) {
 	if output, err := runCommand(ctx, "powershell", "-NoProfile", "-NonInteractive", "-Command",
 		"Get-AppxPackage | Select-Object Name,Version | ConvertTo-Csv -NoTypeInformation"); err == nil {
@@ -420,7 +524,6 @@ func (w *WindowsSoftwareCollector) collectWindowsStoreApps(ctx context.Context, 
 		if appCount > 0 {
 			attributes["windows_store_app_count"] = fmt.Sprintf("%d", appCount)
 
-			// Store first 10 apps as sample
 			var apps []string
 			for i := 1; i <= 10 && i < len(lines); i++ {
 				fields := w.parseCSVLine(lines[i])
@@ -439,41 +542,63 @@ func (w *WindowsSoftwareCollector) collectWindowsStoreApps(ctx context.Context, 
 	}
 }
 
-// collectInstalledUpdates collects system updates/hotfixes
-func (w *WindowsSoftwareCollector) collectInstalledUpdates(ctx context.Context, attributes map[string]string) {
-	if output, err := runCommand(ctx, "wmic", "qfe", "get",
-		"HotFixID,InstalledOn,Description", "/format:csv"); err == nil {
-		lines := strings.Split(output, "\n")
-		var updateCount int
-		var updates []string
+// ---------- Service helpers ----------
 
-		for _, line := range lines {
-			line = strings.TrimSpace(line)
-			if line == "" || strings.HasPrefix(line, "Node") {
-				continue
-			}
-
-			fields := strings.Split(line, ",")
-			if len(fields) >= 4 && fields[2] != "" { // HotFixID field
-				updateCount++
-				if updateCount <= 10 { // Store first 10 as sample
-					updateInfo := fields[2]                 // HotFixID
-					if len(fields) > 3 && fields[3] != "" { // InstalledOn
-						updateInfo += " (" + fields[3] + ")"
-					}
-					updates = append(updates, updateInfo)
-				}
-			}
-		}
-
-		attributes["installed_update_count"] = fmt.Sprintf("%d", updateCount)
-		if len(updates) > 0 {
-			attributes["installed_updates_sample"] = strings.Join(updates, "; ")
-		}
+// collectServicesViaSCM enumerates Windows services using the native Service
+// Control Manager API. Replaces wmic service.
+func (w *WindowsSoftwareCollector) collectServicesViaSCM(attributes map[string]string) error {
+	m, err := mgr.Connect()
+	if err != nil {
+		return err
 	}
+	defer m.Disconnect()
+
+	serviceNames, err := m.ListServices()
+	if err != nil {
+		return err
+	}
+
+	totalServices := len(serviceNames)
+	var runningServices, stoppedServices int
+	var autoStartServices, manualStartServices int
+
+	for _, name := range serviceNames {
+		s, err := m.OpenService(name)
+		if err != nil {
+			// Skip services we can't access (permission restricted)
+			continue
+		}
+
+		if status, err := s.Query(); err == nil {
+			switch status.State {
+			case svc.Running:
+				runningServices++
+			case svc.Stopped:
+				stoppedServices++
+			}
+		}
+
+		if config, err := s.Config(); err == nil {
+			switch config.StartType {
+			case windows.SERVICE_AUTO_START:
+				autoStartServices++
+			case windows.SERVICE_DEMAND_START:
+				manualStartServices++
+			}
+		}
+
+		s.Close()
+	}
+
+	attributes["total_service_count"] = fmt.Sprintf("%d", totalServices)
+	attributes["running_service_count"] = fmt.Sprintf("%d", runningServices)
+	attributes["stopped_service_count"] = fmt.Sprintf("%d", stoppedServices)
+	attributes["auto_start_service_count"] = fmt.Sprintf("%d", autoStartServices)
+	attributes["manual_start_service_count"] = fmt.Sprintf("%d", manualStartServices)
+	return nil
 }
 
-// parseWMIServicesOutput parses WMI services output
+// parseWMIServicesOutput parses WMI services output (fallback for non-admin contexts).
 func (w *WindowsSoftwareCollector) parseWMIServicesOutput(output string, attributes map[string]string) {
 	lines := strings.Split(output, "\n")
 	var totalServices, runningServices, stoppedServices int
@@ -489,7 +614,6 @@ func (w *WindowsSoftwareCollector) parseWMIServicesOutput(output string, attribu
 		if len(fields) >= 5 {
 			totalServices++
 
-			// Service state
 			if len(fields) > 3 && fields[3] != "" {
 				switch strings.ToLower(fields[3]) {
 				case "running":
@@ -499,7 +623,6 @@ func (w *WindowsSoftwareCollector) parseWMIServicesOutput(output string, attribu
 				}
 			}
 
-			// Start mode
 			if len(fields) > 2 && fields[2] != "" {
 				switch strings.ToLower(fields[2]) {
 				case "auto":
@@ -518,81 +641,116 @@ func (w *WindowsSoftwareCollector) parseWMIServicesOutput(output string, attribu
 	attributes["manual_start_service_count"] = fmt.Sprintf("%d", manualStartServices)
 }
 
-// collectStartupPrograms collects startup programs
-func (w *WindowsSoftwareCollector) collectStartupPrograms(ctx context.Context, attributes map[string]string) {
-	if output, err := runCommand(ctx, "wmic", "startup", "get",
-		"Name,Command,Location", "/format:csv"); err == nil {
-		lines := strings.Split(output, "\n")
-		var startupCount int
-		var startupPrograms []string
+// collectStartupPrograms reads startup programs from Run/RunOnce registry keys.
+// Replaces wmic startup.
+func (w *WindowsSoftwareCollector) collectStartupPrograms(attributes map[string]string) {
+	paths := []string{
+		`SOFTWARE\Microsoft\Windows\CurrentVersion\Run`,
+		`SOFTWARE\Microsoft\Windows\CurrentVersion\RunOnce`,
+	}
 
-		for _, line := range lines {
-			line = strings.TrimSpace(line)
-			if line == "" || strings.HasPrefix(line, "Node") {
-				continue
-			}
+	var startupPrograms []string
+	var startupCount int
 
-			fields := strings.Split(line, ",")
-			if len(fields) >= 4 && fields[2] != "" { // Name field
+	for _, path := range paths {
+		// Machine-level
+		if key, err := registry.OpenKey(registry.LOCAL_MACHINE, path, registry.QUERY_VALUE); err == nil {
+			names, _ := key.ReadValueNames(-1)
+			for _, name := range names {
 				startupCount++
-				if startupCount <= 10 { // Store first 10 as sample
-					startupPrograms = append(startupPrograms, fields[2])
+				if len(startupPrograms) < 10 {
+					startupPrograms = append(startupPrograms, name)
 				}
 			}
+			key.Close()
 		}
 
-		attributes["startup_program_count"] = fmt.Sprintf("%d", startupCount)
-		if len(startupPrograms) > 0 {
-			attributes["startup_programs_sample"] = strings.Join(startupPrograms, "; ")
+		// User-level
+		if key, err := registry.OpenKey(registry.CURRENT_USER, path, registry.QUERY_VALUE); err == nil {
+			names, _ := key.ReadValueNames(-1)
+			for _, name := range names {
+				startupCount++
+				if len(startupPrograms) < 10 {
+					startupPrograms = append(startupPrograms, name)
+				}
+			}
+			key.Close()
 		}
+	}
+
+	attributes["startup_program_count"] = fmt.Sprintf("%d", startupCount)
+	if len(startupPrograms) > 0 {
+		attributes["startup_programs_sample"] = strings.Join(startupPrograms, "; ")
 	}
 }
 
-// parseTasklistOutput parses tasklist output for process information
-func (w *WindowsSoftwareCollector) parseTasklistOutput(output string, attributes map[string]string) {
-	lines := strings.Split(output, "\n")
-	if len(lines) <= 1 {
+// ---------- Process helpers ----------
+
+// countProcesses returns the total number of running processes via a snapshot.
+func countProcesses() int {
+	snapshot, err := windows.CreateToolhelp32Snapshot(windows.TH32CS_SNAPPROCESS, 0)
+	if err != nil {
+		return 0
+	}
+	defer windows.CloseHandle(snapshot)
+
+	var entry windows.ProcessEntry32
+	entry.Size = uint32(unsafe.Sizeof(entry))
+	count := 0
+
+	err = windows.Process32First(snapshot, &entry)
+	for err == nil {
+		count++
+		entry.Size = uint32(unsafe.Sizeof(entry))
+		err = windows.Process32Next(snapshot, &entry)
+	}
+	return count
+}
+
+// collectProcessSnapshot gathers detailed process information using
+// CreateToolhelp32Snapshot. Replaces tasklist and PowerShell Get-Process.
+func (w *WindowsSoftwareCollector) collectProcessSnapshot(attributes map[string]string) {
+	snapshot, err := windows.CreateToolhelp32Snapshot(windows.TH32CS_SNAPPROCESS, 0)
+	if err != nil {
 		return
 	}
+	defer windows.CloseHandle(snapshot)
 
-	processCount := len(lines) - 1 // -1 for header
-	attributes["total_process_count"] = fmt.Sprintf("%d", processCount)
+	var entry windows.ProcessEntry32
+	entry.Size = uint32(unsafe.Sizeof(entry))
 
-	// Count unique process names and users
 	processes := make(map[string]int)
 	users := make(map[string]bool)
+	sidCache := make(map[string]string)
+	var totalCount int
 
-	for i := 1; i < len(lines); i++ {
-		line := strings.TrimSpace(lines[i])
-		if line == "" {
-			continue
+	err = windows.Process32First(snapshot, &entry)
+	for err == nil {
+		totalCount++
+		name := windows.UTF16ToString(entry.ExeFile[:])
+		processes[name]++
+
+		if owner := lookupProcessOwner(entry.ProcessID, sidCache); owner != "" {
+			users[owner] = true
 		}
 
-		fields := w.parseCSVLine(line)
-		if len(fields) >= 8 {
-			processName := fields[0]
-			userName := fields[6]
-
-			processes[processName]++
-			users[userName] = true
-		}
+		entry.Size = uint32(unsafe.Sizeof(entry))
+		err = windows.Process32Next(snapshot, &entry)
 	}
 
+	attributes["total_process_count"] = fmt.Sprintf("%d", totalCount)
 	attributes["unique_process_names"] = fmt.Sprintf("%d", len(processes))
 	attributes["unique_process_users"] = fmt.Sprintf("%d", len(users))
 
-	// Find top processes by count
+	// Top processes by instance count (descending)
 	type processInfo struct {
 		name  string
 		count int
 	}
-
 	var topProcesses []processInfo
-	for name, count := range processes {
-		topProcesses = append(topProcesses, processInfo{name, count})
+	for pName, count := range processes {
+		topProcesses = append(topProcesses, processInfo{pName, count})
 	}
-
-	// Simple sort by count (descending)
 	for i := 0; i < len(topProcesses)-1; i++ {
 		for j := i + 1; j < len(topProcesses); j++ {
 			if topProcesses[j].count > topProcesses[i].count {
@@ -601,39 +759,55 @@ func (w *WindowsSoftwareCollector) parseTasklistOutput(output string, attributes
 		}
 	}
 
-	// Store top 5 processes
-	var topProcessNames []string
+	var topNames []string
 	for i := 0; i < 5 && i < len(topProcesses); i++ {
-		topProcessNames = append(topProcessNames, fmt.Sprintf("%s(%d)", topProcesses[i].name, topProcesses[i].count))
+		topNames = append(topNames, fmt.Sprintf("%s(%d)", topProcesses[i].name, topProcesses[i].count))
 	}
-	if len(topProcessNames) > 0 {
-		attributes["top_processes"] = strings.Join(topProcessNames, ", ")
-	}
-}
-
-// parsePowerShellProcessStatsOutput parses PowerShell process statistics output
-func (w *WindowsSoftwareCollector) parsePowerShellProcessStatsOutput(output string, attributes map[string]string) {
-	lines := strings.Split(output, "\n")
-	var processStats []string
-
-	for i := 1; i < len(lines) && i <= 6; i++ { // Skip header, get top 5
-		line := strings.TrimSpace(lines[i])
-		if line == "" {
-			continue
-		}
-
-		fields := w.parseCSVLine(line)
-		if len(fields) >= 2 {
-			processStats = append(processStats, fmt.Sprintf("%s(%s)", fields[1], fields[0]))
-		}
-	}
-
-	if len(processStats) > 0 {
-		attributes["top_processes_ps"] = strings.Join(processStats, ", ")
+	if len(topNames) > 0 {
+		attributes["top_processes"] = strings.Join(topNames, ", ")
 	}
 }
 
-// parseCSVLine handles basic CSV parsing with quoted fields
+// lookupProcessOwner resolves the owner of a process by PID using token lookups.
+// Results are cached by SID to avoid repeated domain controller queries.
+func lookupProcessOwner(pid uint32, cache map[string]string) string {
+	handle, err := windows.OpenProcess(windows.PROCESS_QUERY_LIMITED_INFORMATION, false, pid)
+	if err != nil {
+		return ""
+	}
+	defer windows.CloseHandle(handle)
+
+	var token windows.Token
+	if err := windows.OpenProcessToken(handle, windows.TOKEN_QUERY, &token); err != nil {
+		return ""
+	}
+	defer token.Close()
+
+	tokenUser, err := token.GetTokenUser()
+	if err != nil {
+		return ""
+	}
+
+	sidStr := tokenUser.User.Sid.String()
+	if cached, ok := cache[sidStr]; ok {
+		return cached
+	}
+
+	account, domain, _, err := tokenUser.User.Sid.LookupAccount("")
+	if err != nil {
+		cache[sidStr] = ""
+		return ""
+	}
+
+	username := domain + `\` + account
+	cache[sidStr] = username
+	return username
+}
+
+// ---------- Utility ----------
+
+// parseCSVLine handles basic CSV parsing with quoted fields.
+// Needed for Windows Store apps output parsing.
 func (w *WindowsSoftwareCollector) parseCSVLine(line string) []string {
 	var fields []string
 	var current strings.Builder
@@ -655,7 +829,6 @@ func (w *WindowsSoftwareCollector) parseCSVLine(line string) []string {
 		}
 	}
 
-	// Add the last field
 	fields = append(fields, strings.TrimSpace(current.String()))
 
 	return fields


### PR DESCRIPTION
## Summary

Replace 15+ external command calls (`wmic`, `powershell`, `tasklist`) in Windows DNA collectors with native Go implementations using `golang.org/x/sys/windows` APIs for significantly improved collection performance.

Fixes #619

## Changes

- **software_windows.go**: Complete rewrite — installed programs via `windows/registry`, services via `windows/svc/mgr` SCM API, processes via `CreateToolhelp32Snapshot`, OS info/hotfixes/startup/.NET via registry reads, DISM made opt-in, remaining external calls (choco/winget/store) run concurrently
- **hardware_windows.go**: Replaced `wmic os` call with native registry reads for OS version in hardware cache fast path
- **dna.go**: `runBackgroundCollection` now runs `collectSoftwareInfo` and `collectSecurityInfo` concurrently via `sync.WaitGroup`

## Test Results

### QA Test Runner: PASS
- All unit tests: PASS (all packages)
- OSS + Commercial builds: PASS
- Shell scripts: PASS (32/32)
- Cross-compilation: Windows AMD64 + ARM64 PASS
- Lint failures are pre-existing on develop (script module gofmt)

### QA Code Review: PASS
- 0 blocking issues
- 2 warnings: Windows-native functions only testable on Windows CI (expected gap), concurrent merge covered by existing background collection tests

### Security Review: PASS
- 0 blocking issues, 0 warnings in changed files
- security-precommit: PASS
- check-architecture: PASS
- security-scan: PASS (Trivy CVEs pre-existing on develop)
- Manual review: No injection risks, read-only registry access, minimum-privilege process tokens, SID-cached lookups

## Test plan

- [x] Windows AMD64 cross-compilation passes
- [x] Windows ARM64 cross-compilation passes
- [x] All existing Linux DNA tests pass
- [x] `make test` full suite passes
- [ ] Windows CI validates native API calls work correctly
- [ ] CI time for `features/steward/dna` drops from ~180s to under 60s on Windows

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>