### PR TITLE
workflow: convert planning phase to collaborative team model

### DIFF
--- a/.claude/agents/acceptance-reviewer.md
+++ b/.claude/agents/acceptance-reviewer.md
@@ -114,11 +114,14 @@ Apply fix label and post findings:
 
 ### Any Findings — Second Review (Fix Cycle)
 
-Escalate to founder:
+Escalate to founder and clean up the agent container (the dev agent is done regardless):
 
 ```bash
 ./scripts/pipeline-helper.sh label-swap <STORY_NUM> "pipeline:fix" "pipeline:blocked"
 gh issue edit <STORY_NUM> --repo cfg-is/cfgms --add-assignee "jrdnr"
+
+# Clean up — agent is done, founder takes over
+./scripts/agent-dispatch.sh cleanup-issue <STORY_NUM>
 ```
 
 ## Structured Review Comment

--- a/.claude/agents/ba.md
+++ b/.claude/agents/ba.md
@@ -184,3 +184,42 @@ rm /tmp/ba-summary.md
 - Story titles use the format: `<scope>: <description>` (e.g., `cert: add certificate rotation support`)
 - Every story references its parent epic in `## Parent Epic`
 - Every story lists dependencies on other stories in this decomposition
+
+## Team Mode
+
+When spawned as a teammate (with `team_name` parameter), you operate as part of a **Planning Team** alongside the PO (team lead) and Tech Lead. The collaboration protocol replaces the standalone workflow above.
+
+### How Team Mode Differs
+
+- **No GitHub writes.** Never call `pipeline-helper.sh` in team mode. The PO handles all GitHub issue creation after the team reaches consensus.
+- **Input comes from PO messages.** The PO sends the epic context (goal, success criteria, non-goals, constraints, PM notes) via `SendMessage`. You do NOT read the epic from GitHub.
+- **Output is story proposals via SendMessage.** Send proposed stories to the PO using `SendMessage(to: "po")`. Each proposal uses the same story body format (## Parent Epic, ## Goal, ## Dependencies, ## Files In Scope, etc.) but as message text, not a GitHub issue.
+- **Respond to Tech Lead feedback.** The Tech Lead reviews your proposals and may challenge scope, feasibility, or story boundaries. You receive feedback via messages from the PO or directly from the Tech Lead. Revise proposals, defend decisions, or propose alternative splits as needed.
+- **Signal completion.** When all stories are agreed upon, send a final message to the PO with subject "PROPOSALS FINAL" containing the complete list of stories in their final form. Each story must include: title, and the full story body content.
+
+### Team Mode Workflow
+
+1. **Receive context** — PO broadcasts epic details and architectural context
+2. **Survey the codebase** — use Read/Grep/Glob as usual to understand current implementation (unchanged)
+3. **Propose stories** — send all story proposals to PO in a single `SendMessage(to: "po")` message
+4. **Iterate on feedback** — Tech Lead reviews your proposals and sends feedback (via PO relay or direct message). For each story marked REVISION NEEDED:
+   - Read the specific objection
+   - Re-examine the codebase if needed
+   - Revise the proposal, split the story, or defend your original decision with justification
+   - Send updated proposals to PO
+5. **Converge** — when all stories are APPROVED by Tech Lead, send the "PROPOSALS FINAL" message to PO
+
+### Engaging with the Team
+
+- **Ask the PO product questions:** "Is offline support in scope for this epic?" — `SendMessage(to: "po")`
+- **Respond to Tech Lead challenges:** If Tech Lead says a story is too broad, propose a concrete split rather than arguing abstractly. Show the file boundaries.
+- **Challenge the Tech Lead back:** If you disagree with a Tech Lead objection, explain why with codebase evidence. "The files are in the same package and share internal types — splitting would require exporting internals."
+- **Escalate disagreements to PO:** If you and the Tech Lead can't agree after one round, ask the PO to make a product call: "PO — Tech Lead and I disagree on whether X belongs in this story or a separate one. My recommendation is Y because Z."
+
+### What Stays the Same
+
+- Story quality bar (self-contained, explicit files, testable criteria, single concern, no vague verbs)
+- Story body format
+- Decomposition process (understand epic → survey codebase → identify stories → order by dependency)
+- Codebase survey tools (Read, Grep, Glob)
+- Max 10 stories per epic rule

--- a/.claude/agents/po.md
+++ b/.claude/agents/po.md
@@ -238,7 +238,9 @@ Each step creates a `pipeline:blocked` issue on unrecoverable failure and contin
 **Step 1 — Unblock check:**
 Find recently merged PRs. Check if any `pipeline:draft` stories had `## Dependencies` referencing the merged story. If satisfied, they're eligible for Tech Lead review.
 
-**Step 2 — Tech Lead pass:**
+**Step 2 — Tech Lead pass (legacy only):**
+Handles `pipeline:draft` stories that were created before the Planning Team was introduced. New epics go through Step 6 (Planning Team) and produce `agent:ready` stories directly. Once the backlog of legacy drafts clears, this step becomes a no-op.
+
 Find `pipeline:draft` stories. Collect their issue numbers, then use the **Agent tool** (not Bash) to spawn the Tech Lead: subagent_type `tech-lead`, prompt `"Review draft stories for dev agent executability: #NNN #NNN #NNN"`, mode `auto`.
 
 The Tech Lead agent (`.claude/agents/tech-lead.md`) validates dependency ordering, implementation notes, scope, constraints, and ambiguity. Passing stories get promoted (`pipeline:draft` → `agent:ready`). Failing stories get a `pipeline:blocked` issue.
@@ -277,10 +279,102 @@ The Acceptance Reviewer (`.claude/agents/acceptance-reviewer.md`) verifies CI, c
 - Any findings (first review): apply `pipeline:fix` to story, post review comment on PR
 - Any findings (second review): apply `pipeline:blocked`, assign to founder
 
-**Step 6 — BA pass:**
-Find `pipeline:epic` issues with no sub-issues (`subIssuesSummary` total = 0). For each, use the **Agent tool** (not Bash) to spawn the BA agent: subagent_type `ba`, prompt `"Decompose epic #<NUM> into story sub-issues."`, mode `auto`.
+**Step 6 — Planning Team (BA + Tech Lead collaboration):**
+Find `pipeline:epic` issues with no sub-issues (`subIssuesSummary` total = 0). For each epic, orchestrate a collaborative planning session where BA and Tech Lead work together to produce stories that are ready on the first try.
 
-The BA agent (`.claude/agents/ba.md`) reads the epic, surveys the codebase, creates story sub-issues with `pipeline:story` + `pipeline:draft` labels, and links them via GraphQL `addSubIssue`.
+**6a. Read the epic and gather context:**
+```bash
+gh issue view <NUM> --repo cfg-is/cfgms --json number,title,body,labels
+```
+Extract the epic's Goal, Success Criteria, Non-Goals, Constraints, and PM Notes. Also read `CLAUDE.md` architecture rules and `docs/product/roadmap.md` for milestone context.
+
+**6b. Create the planning team:**
+```
+TeamCreate(team_name: "planning-epic-<NUM>")
+```
+
+**6c. Spawn BA and Tech Lead as teammates (in parallel):**
+
+Spawn both using the **Agent tool** with `team_name` and `name` parameters. Read each agent's `.claude/agents/*.md` file and include the **Team Mode** section instructions in the prompt. Use `subagent_type: "general-purpose"`, `model: "sonnet"`, `mode: "auto"`.
+
+- BA: `Agent(subagent_type: "general-purpose", team_name: "planning-epic-<NUM>", name: "ba", model: "sonnet", mode: "auto", prompt: <ba.md Team Mode instructions>)`
+- Tech Lead: `Agent(subagent_type: "general-purpose", team_name: "planning-epic-<NUM>", name: "tech-lead", model: "sonnet", mode: "auto", prompt: <tech-lead.md Team Mode instructions>)`
+
+**6d. Broadcast epic context to the team:**
+```
+SendMessage(to: "*", summary: "Epic context for planning", message: <epic body + architectural context from CLAUDE.md>)
+```
+
+**6e. Orchestrate the planning conversation:**
+
+The conversation follows this protocol:
+
+1. **BA proposes** — BA surveys the codebase and sends story proposals to PO via `SendMessage`
+2. **PO relays to Tech Lead** — forward BA's proposals: `SendMessage(to: "tech-lead", message: <proposals>)`
+3. **Tech Lead reviews** — validates proposals against the codebase (5-check validation) and sends per-story verdicts (APPROVED / REVISION NEEDED) to PO. Tech Lead may also message BA directly for clarifications.
+4. **If revisions needed** — PO relays Tech Lead feedback to BA: `SendMessage(to: "ba", message: <feedback>)`. BA revises and re-proposes. PO relays to Tech Lead for re-review. Only unresolved stories iterate — approved stories are locked.
+5. **PO product decisions** — if BA and Tech Lead disagree on scope, priority, or approach, PO makes the product call and sends the decision to both: `SendMessage(to: "*", message: "PO DECISION: ...")`
+
+**Maximum 3 revision rounds.** A round = BA revises + Tech Lead re-reviews. After 3 rounds, any remaining REVISION NEEDED stories are resolved by PO decision: either accept with a PO note, or drop and document in a `pipeline:blocked` issue.
+
+**6f. Create stories on GitHub (after consensus):**
+
+Once all stories are APPROVED (or PO-decided), create them on GitHub. For each story:
+```bash
+cat > /tmp/story-body.md <<'STORY_EOF'
+<full story body from final agreed proposal>
+STORY_EOF
+
+./scripts/pipeline-helper.sh create-ready-story <EPIC_NUM> "<scope>: <title>" /tmp/story-body.md
+rm /tmp/story-body.md
+```
+
+Stories are created with `pipeline:story` + `agent:ready` labels — they skip `pipeline:draft` entirely since the Tech Lead already validated them during the planning conversation.
+
+**6g. Post summary on epic:**
+```bash
+cat > /tmp/planning-summary.md <<'SUMMARY_EOF'
+## Planning Team — Decomposition Complete
+
+Stories created (agent:ready):
+- #NNN — <title>
+- #NNN — <title>
+
+Dependency order: #A → #B → #C
+
+Planning rounds: <N> (BA proposed, Tech Lead reviewed, <N-1> revision rounds)
+
+Blocked items: <none, or list with reasons>
+SUMMARY_EOF
+
+./scripts/pipeline-helper.sh comment <EPIC_NUM> /tmp/planning-summary.md
+rm /tmp/planning-summary.md
+```
+
+**6h. Shutdown the planning team:**
+Send shutdown to both teammates: `SendMessage(to: "*", message: {type: "shutdown_request"})`. Then clean up:
+```
+TeamDelete()
+```
+
+**6i. Fallback — convergence failure:**
+If the PO drops any stories (couldn't converge after 3 rounds), create a single `pipeline:blocked` issue:
+```bash
+cat > /tmp/blocked-body.md <<'BLOCK_EOF'
+## Planning Team: Could Not Converge
+
+Epic: #<NUM> — <title>
+
+## Stories Agreed
+- #NNN — <title> (created as agent:ready)
+
+## Stories Disputed
+- "<story title>": BA proposed: <summary>. Tech Lead objected: <objection>. PO recommendation: <what the founder should decide>.
+BLOCK_EOF
+
+./scripts/pipeline-helper.sh block <EPIC_NUM> "Planning team: convergence failure on epic #<NUM>" /tmp/blocked-body.md
+rm /tmp/blocked-body.md
+```
 
 **Step 7 — Forward edge:**
 If active milestone >80% complete and next milestone has no epics, create `pipeline:blocked` requesting intent capture.
@@ -292,7 +386,7 @@ Post timestamped summary on each active epic. Skip if no actions taken.
 
 Safe to run multiple times:
 - Don't dispatch for `agent:in-progress` issues
-- Don't spawn BA for epics with existing sub-issues
+- Don't spawn Planning Team for epics with existing sub-issues
 - Don't re-review PRs with existing Acceptance Reviewer comment
 - Check `pipeline:fix` history before fix vs. blocked decision
 

--- a/.claude/agents/po.md
+++ b/.claude/agents/po.md
@@ -238,6 +238,13 @@ Each step creates a `pipeline:blocked` issue on unrecoverable failure and contin
 **Step 1 — Unblock check:**
 Find recently merged PRs. Check if any `pipeline:draft` stories had `## Dependencies` referencing the merged story. If satisfied, they're eligible for Tech Lead review.
 
+**Step 1.5 — Agent cleanup:**
+Remove stale agent containers and clones. Run:
+```bash
+./scripts/agent-dispatch.sh cleanup-stale
+```
+This finds containers whose stories are closed, `agent:failed`, or `pipeline:blocked` and removes them. Runs before dispatch so re-dispatched stories start with a clean environment. Safe to run every cycle — idempotent, skips containers whose stories are still active.
+
 **Step 2 — Tech Lead pass (legacy only):**
 Handles `pipeline:draft` stories that were created before the Planning Team was introduced. New epics go through Step 6 (Planning Team) and produce `agent:ready` stories directly. Once the backlog of legacy drafts clears, this step becomes a no-op.
 

--- a/.claude/agents/tech-lead.md
+++ b/.claude/agents/tech-lead.md
@@ -165,3 +165,41 @@ rm /tmp/tl-summary.md
 - If you can fix an issue by editing the story body (adding notes, fixing a path), do that rather than blocking
 - Batch multiple stories efficiently — read shared files once, not per-story
 - The story quality bar (self-contained, explicit files, testable criteria, single concern, no vague verbs) is the BA's job. Your job is executability validation on top of that.
+
+## Team Mode
+
+When spawned as a teammate (with `team_name` parameter), you operate as part of a **Planning Team** alongside the PO (team lead) and BA. The collaboration protocol replaces the standalone workflow above.
+
+### How Team Mode Differs
+
+- **No GitHub writes.** Never call `pipeline-helper.sh` in team mode. The PO handles all GitHub operations after the team reaches consensus.
+- **Input comes from messages.** The PO relays the BA's story proposals to you via `SendMessage`. You do NOT read stories from GitHub issues.
+- **Output is structured verdicts via SendMessage.** Send your review to the PO using `SendMessage(to: "po")`. For each proposed story, give a clear verdict:
+  - **APPROVED** — story passes all 5 checks. Include any implementation notes to add.
+  - **REVISION NEEDED** — story fails one or more checks. State the specific check that failed, why, and what needs to change.
+- **Challenge the BA directly.** You can message the BA via `SendMessage(to: "ba")` for quick clarifications or to propose alternative splits. The PO sees summaries in idle notifications.
+- **Request PO product decisions.** When you and the BA disagree on scope or priority, escalate to the PO: `SendMessage(to: "po")` with the disagreement and your recommendation.
+
+### Team Mode Workflow
+
+1. **Receive context** — PO broadcasts epic details and architectural context
+2. **Receive proposals** — PO relays the BA's story proposals to you
+3. **Validate against the codebase** — apply the same 5-check validation (dependency ordering, implementation notes, scope, constraints, ambiguity). Use Read/Grep/Glob as usual.
+4. **Send verdicts** — for each story, send APPROVED or REVISION NEEDED to the PO with specifics
+5. **Iterate** — if BA revises proposals, re-review only the changed stories. Previously approved stories are locked.
+6. **Converge** — when all stories are APPROVED, confirm to the PO that the full set is ready
+
+### Engaging with the Team
+
+- **Challenge the BA on feasibility:** "Story 3 touches 6 files across 3 packages — too broad for a single dev agent. Split the provider implementation from the CLI wiring." — `SendMessage(to: "ba")`
+- **Flag file conflicts between proposals:** "Stories 2 and 4 both edit `pkg/cert/manager.go`. One must depend on the other or they'll conflict when dev agents run in parallel." — `SendMessage(to: "po")`
+- **Ask the PO about constraints:** "Does this need to work on Windows, or is Linux-only acceptable for the first pass?" — `SendMessage(to: "po")`
+- **Accept BA pushback with evidence:** If the BA defends a scope decision with codebase evidence (e.g., "these files share internal types"), re-evaluate. Don't block stories to prove a point — block them because a dev agent would fail.
+- **Escalate disagreements to PO:** "PO — BA and I disagree on whether the integration test belongs in this story or a separate one. I recommend separate because the test requires fixtures from story 1. BA says it's trivial to include. Your call."
+
+### What Stays the Same
+
+- The 5-check validation checklist (dependency ordering, implementation notes, scope, constraints, ambiguity)
+- Codebase validation tools (Read, Grep, Glob, Bash)
+- File conflict detection logic
+- The standard for what makes a story executable by a dev agent

--- a/.gitignore
+++ b/.gitignore
@@ -77,6 +77,7 @@ m365-test-creds/
 # Claude Code local settings
 .claude/settings.local.json
 .claude/worktrees/
+.claude/scheduled_tasks.lock
 
 # Test/development storage data
 features/controller/**/data/

--- a/docs/development/autonomous-dev-team.md
+++ b/docs/development/autonomous-dev-team.md
@@ -89,15 +89,25 @@ Agents run in parallel — multiple stories can be in flight simultaneously.
 
 The **Acceptance Reviewer** checks each PR against the story's acceptance criteria, CI status, and code quality. The outcome is fully automated:
 
-- **Zero findings**: PR is **auto-merged** — no human involvement needed
+- **Zero findings**: PR is **auto-merged**, agent container and clone cleaned up — no human involvement needed
 - **Any findings (1st review)**: A **fix agent** is dispatched in a container to address the findings
-- **Any findings (2nd review)**: **Escalated to PM** as a `pipeline:blocked` item — the agent team couldn't resolve it
+- **Any findings (2nd review)**: **Escalated to PM** as a `pipeline:blocked` item, agent container and clone cleaned up — the agent team couldn't resolve it
 
 The PM only sees PRs that agents failed to get right after two attempts. For those, the PM provides guidance (updated story spec, clarification, or direct code fix) and the cycle restarts.
 
 ### 5. Completion
 
 Merged PRs auto-close their story issues. The PO tracks epic completion via GitHub sub-issue progress and surfaces the next action.
+
+### Container Cleanup
+
+Agent containers and their clones are cleaned up automatically:
+
+- **On auto-merge** — Acceptance Reviewer removes the container and clone immediately
+- **On escalation** — Acceptance Reviewer cleans up when applying `pipeline:blocked` (2nd review failure)
+- **PO cron sweep** — each cycle runs `agent-dispatch.sh cleanup-stale` before dispatch, removing containers whose stories are closed, `agent:failed`, or `pipeline:blocked`
+
+Failed or stale containers are preserved until the PO cron sweep runs or the story is re-dispatched, so logs and results remain available for debugging.
 
 ## Pipeline State Machine
 

--- a/docs/development/autonomous-dev-team.md
+++ b/docs/development/autonomous-dev-team.md
@@ -9,9 +9,9 @@ The autonomous development pipeline mirrors a standard product delivery org. Hum
 | Role | Who | Responsibility |
 |------|-----|----------------|
 | **Product Manager** | Human operator | Vision, intent, unblocking agents when they get stuck |
-| **Product Owner** | Claude Code session | Pipeline orchestration, dashboard, intent capture |
-| **Business Analyst** | PO-spawned subagent | Decomposes epics into implementable stories |
-| **Tech Lead** | PO-spawned subagent | Validates stories for agent executability |
+| **Product Owner** | Claude Code session | Pipeline orchestration, dashboard, intent capture, planning team lead |
+| **Business Analyst** | Planning Team member | Proposes story decomposition, defends scope decisions, revises based on Tech Lead feedback |
+| **Tech Lead** | Planning Team member | Validates story proposals for dev agent executability, challenges BA on scope and feasibility |
 | **Developer** | Containerized agent | Implements code in isolated Docker containers, opens PR |
 | **Acceptance Reviewer** | PO-spawned subagent | Reviews PRs against acceptance criteria, auto-merges clean PRs |
 | **QA Reviewer** | PO-spawned subagent | Code quality, test correctness (manual review path) |
@@ -24,9 +24,10 @@ Multiple human operators can work in parallel — each owns one or more epics, a
 ```mermaid
 flowchart TD
     PM[PM captures intent]:::human --> PO[PO creates epic]:::agent
-    PO --> BA[BA decomposes into stories]:::agent
-    BA --> TL[Tech Lead validates stories]:::agent
-    TL --> DEV[Dev agent implements & opens PR]:::container
+    PO --> TEAM[Planning Team: PO + BA + Tech Lead]:::team
+    TEAM -->|consensus reached| STORIES[Stories created as agent:ready]:::agent
+    TEAM -->|can't converge| BLOCKED_PLAN[Escalate to PM]:::human
+    STORIES --> DEV[Dev agent implements & opens PR]:::container
     DEV --> AR[Acceptance Reviewer checks PR]:::agent
     AR -->|zero findings| MERGE[Auto-merged]:::agent
     AR -->|any findings, 1st review| FIX[Fix agent patches PR]:::container
@@ -39,9 +40,10 @@ flowchart TD
     classDef human fill:#4a90d9,stroke:#2c5f8a,color:#fff
     classDef agent fill:#6ab04c,stroke:#3e7a2a,color:#fff
     classDef container fill:#f0932b,stroke:#b5700f,color:#fff
+    classDef team fill:#9b59b6,stroke:#6c3483,color:#fff
 ```
 
-> **Legend:** 🔵 Human operator | 🟢 Agent (subagent) | 🟠 Agent (isolated container)
+> **Legend:** 🔵 Human operator | 🟢 Agent (subagent) | 🟠 Agent (isolated container) | 🟣 Agent team (collaborative)
 
 ## How It Works
 
@@ -51,20 +53,26 @@ A PM describes what they want built in conversation with the Product Owner. The 
 
 The PO creates a GitHub **epic issue** with the structured intent.
 
-### 2. Story Decomposition
+### 2. Collaborative Planning (Planning Team)
 
-The **Business Analyst** agent reads the epic, surveys the codebase, and breaks it into implementable stories. Each story is a GitHub sub-issue with:
+The PO creates a temporary **Planning Team** — spawning the BA and Tech Lead as teammates who collaborate in real time via `SendMessage`.
+
+The **Business Analyst** surveys the codebase and proposes story decompositions. The **Tech Lead** validates each proposal against the codebase — checking dependency ordering, file references, scope, constraints, and ambiguity. The **PO** mediates, makes product decisions when the BA and Tech Lead disagree, and breaks ties.
+
+The conversation iterates (max 3 rounds) until all stories are agreed upon:
+- BA proposes stories → Tech Lead reviews → feedback/revision → repeat
+- BA and Tech Lead can challenge each other directly
+- PO makes product calls when they disagree on scope or priority
+
+Once consensus is reached, the PO creates all stories on GitHub as sub-issues with `agent:ready` labels — they skip the draft phase entirely since the Tech Lead already validated them during the planning conversation. Each story includes:
 
 - Specific files in scope
 - Reference implementations to follow
 - Testable acceptance criteria
 - Dependency ordering
+- Implementation notes (added by Tech Lead during review)
 
-### 3. Tech Lead Review
-
-The **Tech Lead** agent validates each story for dev agent executability. It checks dependency ordering, verifies file references against current code, removes ambiguity, and adds implementation notes. Stories that pass are promoted to the dispatch queue. Stories with gaps get flagged.
-
-### 4. Development
+### 3. Development
 
 Each story is dispatched to an isolated **Docker container** running Claude Code. The dev agent:
 
@@ -77,7 +85,7 @@ Each story is dispatched to an isolated **Docker container** running Claude Code
 
 Agents run in parallel — multiple stories can be in flight simultaneously.
 
-### 5. Acceptance Review
+### 4. Acceptance Review
 
 The **Acceptance Reviewer** checks each PR against the story's acceptance criteria, CI status, and code quality. The outcome is fully automated:
 
@@ -87,7 +95,7 @@ The **Acceptance Reviewer** checks each PR against the story's acceptance criter
 
 The PM only sees PRs that agents failed to get right after two attempts. For those, the PM provides guidance (updated story spec, clarification, or direct code fix) and the cycle restarts.
 
-### 6. Completion
+### 5. Completion
 
 Merged PRs auto-close their story issues. The PO tracks epic completion via GitHub sub-issue progress and surfaces the next action.
 
@@ -98,9 +106,9 @@ All coordination happens through GitHub labels — no external state store.
 ```mermaid
 stateDiagram-v2
     [*] --> Epic: PO creates epic
-    Epic --> Draft: BA decomposes
-    Draft --> Ready: Tech Lead approves
-    Draft --> Blocked: Tech Lead finds gaps
+    Epic --> Planning: Planning Team convenes
+    Planning --> Ready: Team reaches consensus
+    Planning --> Blocked: Can't converge (3 rounds)
     Ready --> InProgress: Agent dispatched
     InProgress --> PR: Agent opens PR
     PR --> Merged: Zero findings, auto-merged
@@ -113,12 +121,13 @@ stateDiagram-v2
 
 | Label | Stage |
 |-------|-------|
-| `pipeline:epic` | Epic defined, awaiting decomposition |
-| `pipeline:draft` | Story written, awaiting Tech Lead review |
-| `agent:ready` | Story validated, queued for dispatch |
+| `pipeline:epic` | Epic defined, awaiting Planning Team |
+| `pipeline:story` | Story sub-issue of an epic (applied to all stories) |
+| `agent:ready` | Story validated by Planning Team, queued for dispatch |
 | `agent:in-progress` | Dev agent container running |
 | `pipeline:fix` | PR has findings, fix agent dispatched |
 | `pipeline:blocked` | Escalation — agents couldn't resolve, needs human input |
+| `pipeline:draft` | (Legacy) Story awaiting standalone Tech Lead review |
 
 ## Orchestration
 
@@ -131,11 +140,11 @@ The Product Owner operates in two modes:
 ```mermaid
 flowchart LR
     subgraph Scheduled Cycle
-        S1[Check unblocked stories]:::agent --> S2[Tech Lead review]:::agent
+        S1[Check unblocked stories]:::agent --> S2[Legacy Tech Lead review]:::agent
         S2 --> S3[Dispatch to containers]:::container
         S3 --> S4[Run fix cycles]:::container
         S4 --> S5[Acceptance review PRs]:::agent
-        S5 --> S6[Decompose new epics]:::agent
+        S5 --> S6[Planning Team for new epics]:::team
         S6 --> S7[Check forward edge]:::agent
     end
 
@@ -149,13 +158,14 @@ flowchart LR
     classDef human fill:#4a90d9,stroke:#2c5f8a,color:#fff
     classDef agent fill:#6ab04c,stroke:#3e7a2a,color:#fff
     classDef container fill:#f0932b,stroke:#b5700f,color:#fff
+    classDef team fill:#9b59b6,stroke:#6c3483,color:#fff
 ```
 
 ## Design Principles
 
 **GitHub is the single source of truth.** All pipeline state lives in GitHub issues, labels, and PRs. No local files, no external databases. Any team member can check status from their phone.
 
-**Agents don't guess.** Stories must be self-contained with explicit file references and testable criteria. Vague specs get rejected by the Tech Lead, not interpreted by the dev agent.
+**Agents don't guess.** Stories must be self-contained with explicit file references and testable criteria. The Planning Team debates and resolves ambiguity before stories are created — vague proposals get challenged by the Tech Lead and refined by the BA before any dev agent sees them.
 
 **One escalation surface.** Every blocker becomes a `pipeline:blocked` issue assigned to the responsible person. No Slack messages, no email, no notifications outside GitHub.
 

--- a/docs/product/autonomous-agent-system-prd.md
+++ b/docs/product/autonomous-agent-system-prd.md
@@ -208,14 +208,23 @@ The standalone Tech Lead pass (PO agent §4.1 Step 2) handles `pipeline:draft` s
 - Fix agent pushes changes
 - QA subagent re-reviews the PR
 - On pass: removes `pipeline:fix`, applies `pipeline:review`, assigns to founder
-- On second fail: removes `pipeline:fix`, applies `pipeline:blocked`, assigns to founder with specific failure detail
+- On second fail: removes `pipeline:fix`, applies `pipeline:blocked`, assigns to founder with specific failure detail. Agent container and clone are cleaned up.
 
 ### 5.7 Merge Decision (Founder, synchronous)
 
 - Founder runs `/po` — dashboard shows PRs with `pipeline:review` label
 - Founder reads QA verdict comment — no further investigation needed
 - Founder merges or requests changes
-- On merge: story Issue auto-closes, PO checks if any dependent draft stories are now unblocked
+- On merge: story Issue auto-closes, agent container and clone cleaned up, PO checks if any dependent draft stories are now unblocked
+
+### 5.8 Container Cleanup (PO cron, automatic)
+
+Agent containers and clones are cleaned up at three points:
+- **On auto-merge:** Acceptance Reviewer removes the container immediately after merge
+- **On escalation:** Acceptance Reviewer cleans up when a story is blocked after the fix cycle
+- **PO cron sweep:** Each cycle runs `agent-dispatch.sh cleanup-stale` before dispatch, removing any remaining containers whose stories are closed, `agent:failed`, or `pipeline:blocked`
+
+Failed or stale containers are preserved until the cron sweep so logs remain available for debugging.
 
 -----
 

--- a/docs/product/autonomous-agent-system-prd.md
+++ b/docs/product/autonomous-agent-system-prd.md
@@ -27,11 +27,13 @@ The system mirrors a standard product delivery org. Each role is either a Claude
 | Role | Type | Invokes | Primary Output |
 |------|------|---------|----------------|
 | **Founder (PM)** | Human | `/po` in terminal | Leader intent, roadmap direction, merge decisions |
-| **Product Owner** | Skill — `/po` (interactive) + Scheduled remote agent (cron) | BA, Tech Lead, QA subagents; `/dispatch` for dev agents | GitHub epics, pipeline orchestration, session dashboard |
-| **Business Analyst** | Subagent | `gh issue create`, `gh api graphql` (sub-issues) | Draft story Issues as children of epic |
-| **Tech Lead** | Subagent | `gh issue edit` | Stories validated for agent executability, promoted to `agent:ready` |
+| **Product Owner** | Skill — `/po` (interactive) + Scheduled remote agent (cron) | Planning Team (BA + Tech Lead), QA subagent; `/dispatch` for dev agents | GitHub epics, pipeline orchestration, session dashboard |
+| **Business Analyst** | Planning Team member | `SendMessage` (proposals to PO/Tech Lead) | Story proposals for team review; GitHub writes handled by PO after consensus |
+| **Tech Lead** | Planning Team member | `SendMessage` (verdicts to PO/BA) | Story validation verdicts; challenges BA on feasibility and scope |
 | **Developer** | Container Agent | `make test-complete`, `gh pr create` | PR against develop (existing infrastructure, unchanged) |
 | **QA** | Subagent | `gh pr review`, `gh issue edit` | Structured verdict comment on PR; `pipeline:review` or `pipeline:fix` label |
+
+> **Planning Team model:** During epic decomposition, the PO creates a temporary team (via `TeamCreate`) with BA and Tech Lead as teammates. All three communicate via `SendMessage` — BA proposes stories, Tech Lead challenges and validates, PO mediates and makes product decisions. Stories are only created on GitHub after all three agree. This replaces the previous sequential model where BA and Tech Lead operated independently.
 
 ### 2.1 PO Split — Interactive vs. Cron
 
@@ -152,29 +154,36 @@ Work moves through the pipeline in one direction. Each stage is triggered by a l
 - PO creates GitHub epic Issue with `pipeline:epic` label and full intent in body
 - Scratch file deleted — all state now in GitHub
 
-### 5.2 Decomposition (BA Subagent, async)
+### 5.2 Collaborative Planning (Planning Team, async)
+
+The PO creates a temporary team for epic decomposition. BA and Tech Lead collaborate in real time via `SendMessage`, with the PO mediating and making product decisions. Stories are only created on GitHub after all three agree.
 
 - PO cron cycle finds `pipeline:epic` Issues with no child stories
-- PO spawns BA subagent, passing epic Issue number
-- BA subagent reads epic body, `CLAUDE.md` architecture rules, relevant codebase patterns
-- BA subagent creates story Issues as sub-issues of the epic, labelled `pipeline:story` + `pipeline:draft`
-- Ambiguity that cannot be resolved: BA subagent creates `pipeline:blocked` Issue assigned to founder
-- BA subagent posts completion comment on epic with list of stories created
-- PO receives subagent response directly — knows if decomposition completed or failed. On failure, PO can re-run or escalate.
+- PO reads the epic body and gathers architectural context
+- PO creates a planning team: `TeamCreate(team_name: "planning-epic-<NUM>")`
+- PO spawns BA and Tech Lead as teammates (in parallel, both using `SendMessage` for communication)
+- PO broadcasts epic context (goal, success criteria, non-goals, constraints, PM notes) to both teammates
 
-### 5.3 Tech Lead Review (Tech Lead Subagent, async)
+**Planning conversation:**
+1. BA surveys the codebase and sends story proposals to PO via `SendMessage`
+2. PO relays proposals to Tech Lead for validation
+3. Tech Lead validates each proposal against the codebase (dependency ordering, implementation notes, scope, constraints, ambiguity) and sends per-story verdicts: APPROVED or REVISION NEEDED
+4. If revisions needed: PO relays feedback to BA → BA revises → PO relays to Tech Lead → repeat (max 3 rounds)
+5. BA and Tech Lead can also message each other directly for quick clarifications
+6. PO makes product decisions when BA and Tech Lead disagree on scope or priority
 
-- PO cron cycle finds story Issues with `pipeline:draft` label
-- PO spawns Tech Lead subagent, passing story Issue numbers
-- Tech Lead subagent validates each story for **dev agent executability**:
-  - **Dependency ordering** — identifies stories that require other stories' interfaces first
-  - **Implementation notes** — specifies which existing patterns/providers to use
-  - **Scope correction** — flags stories with multiple concerns for splitting
-  - **Constraint flagging** — catches stories that imply mocks, new providers, or `CLAUDE.md` modifications
-  - **Ambiguity removal** — resolves anything where two reasonable dev agents would make different choices
-- Passing stories: edits Issue body to add implementation notes, removes `pipeline:draft`, adds `agent:ready`
-- Failing stories: creates `pipeline:blocked` Issue with specific gap identified, story remains draft
-- Tech Lead subagent posts summary comment on parent epic Issue
+**After consensus:**
+- PO creates all agreed stories on GitHub via `pipeline-helper.sh create-ready-story` with labels `pipeline:story` + `agent:ready` — stories skip `pipeline:draft` entirely since the Tech Lead already validated them
+- PO posts a planning summary comment on the epic
+- PO shuts down the team (`TeamDelete`)
+
+**Convergence failure:** If BA and Tech Lead cannot agree after 3 revision rounds, PO makes a unilateral decision — accept, modify, or drop the disputed stories. Dropped stories produce a `pipeline:blocked` Issue with both perspectives documented.
+
+> **Legacy path:** Stories with `pipeline:draft` label from before the Planning Team was introduced are still processed by a standalone Tech Lead pass in the pipeline cycle. New epics always use the collaborative Planning Team.
+
+### 5.3 Legacy: Standalone Tech Lead Review
+
+The standalone Tech Lead pass (PO agent §4.1 Step 2) handles `pipeline:draft` stories created before the Planning Team model. It operates identically to the previous sequential approach: PO spawns Tech Lead as an independent subagent, Tech Lead validates and promotes or blocks stories. Once the backlog of legacy `pipeline:draft` stories clears, this step becomes a no-op. All new epics use the collaborative Planning Team (§5.2).
 
 ### 5.4 Dispatch (PO cron, async)
 
@@ -376,19 +385,25 @@ BA, Tech Lead, and QA subagents read these files for context. They do not modify
 
 ### 10.4 Agents Write Minimum Necessary GitHub State
 
-Agents do not create Issues speculatively or post incremental progress comments. BA creates stories only when the epic is fully intent-complete. QA posts one structured comment per PR. Verbosity degrades the signal-to-noise ratio of GitHub as a coordination surface.
+Agents do not create Issues speculatively or post incremental progress comments. The PO creates stories on GitHub only after the Planning Team (BA + Tech Lead) reaches consensus. QA posts one structured comment per PR. Verbosity degrades the signal-to-noise ratio of GitHub as a coordination surface.
 
 ### 10.5 Sub-Issues via GraphQL API
 
-GitHub's native sub-issues are GA. The BA subagent uses the `addSubIssue` GraphQL mutation to link story Issues as children of epic Issues. The PO queries `subIssues` and `subIssuesSummary` on epics to track completion. No fallback format needed.
+GitHub's native sub-issues are GA. The PO uses `pipeline-helper.sh create-ready-story` (which calls the `addSubIssue` GraphQL mutation) to link story Issues as children of epic Issues after Planning Team consensus. The PO queries `subIssues` and `subIssuesSummary` on epics to track completion. No fallback format needed.
 
 ### 10.6 Developer Agents Are Unchanged
 
 Docker containers, git worktrees, credential mounting, `cfg-agent:latest` image, `CFGMS_AGENT_MODE` execution, `make test-complete` validation — all unchanged. Dev agents and fix agents are the only containerised agents.
 
-### 10.7 Subagent Execution Model
+### 10.7 Agent Execution Models
 
-BA, Tech Lead, and QA run as subagents spawned by the PO with `mode: "auto"` (no approval prompts). They have read-only access to the repo and read/write access to GitHub via `gh`. They do not modify code files. No explicit timeout — subagents are short-lived by nature. The PO receives their response directly and knows if they completed or failed.
+Agents operate in two modes depending on the pipeline phase:
+
+**Team mode (Planning Team — BA + Tech Lead):** During epic decomposition, BA and Tech Lead are spawned as teammates via `TeamCreate`/`Agent` with `team_name` and `name` parameters. They communicate with each other and the PO via `SendMessage`. Team communication is ephemeral — not persisted to GitHub. The PO creates all GitHub state after the team reaches consensus. Teams are temporary and cleaned up via `TeamDelete` after each planning session.
+
+**Standalone subagent mode (QA, legacy Tech Lead pass):** QA runs as an independent subagent spawned by the PO with `mode: "auto"` (no approval prompts). It has read-only access to the repo and read/write access to GitHub via `gh`. The PO receives its response directly and knows if it completed or failed. The legacy standalone Tech Lead pass uses the same model for processing pre-existing `pipeline:draft` stories.
+
+All non-developer agents have read-only access to the repo and do not modify code files. No explicit timeout — agents are short-lived by nature.
 
 -----
 
@@ -409,7 +424,7 @@ The system is working when all of the following are true:
 ## 12. Out of Scope
 
 - Automated merge without founder approval — merge decisions remain human
-- Agent-to-agent direct communication — all state passes through GitHub
+- Agent-to-agent direct communication beyond the planning phase — the Planning Team uses `SendMessage` for ephemeral collaboration during epic decomposition, but all persistent pipeline state remains in GitHub
 - External project management tools (Jira, Linear, Notion)
 - Web UI for pipeline management — GitHub and terminal are the interface
 - Multi-PM support — single PM model, multi-person via epic ownership

--- a/scripts/agent-dispatch.sh
+++ b/scripts/agent-dispatch.sh
@@ -65,6 +65,7 @@ Commands:
   check-creds                                Check OAuth credential validity and remaining time
   cleanup-issue   <NUM>                     Remove container and clone for a specific issue
   cleanup-container <NAME>                  Remove container and associated clone by name
+  cleanup-stale                             Remove containers/clones for closed, blocked, or failed stories
   list-running                              List running agent containers
   list-exited                               List exited agent containers
   inspect-exit    <NUM>                     Print exit code of container
@@ -561,6 +562,65 @@ else:
     fi
 
     echo "HEALTH_DONE:warnings=${warnings}"
+    ;;
+
+  cleanup-stale)
+    # Find agent containers (running or exited) whose stories no longer need them.
+    # A container is stale if its story issue is CLOSED or has label agent:failed or pipeline:blocked.
+    cleaned=0
+
+    # Get all cfg-agent-<NUM> containers (running + exited)
+    containers=$(docker ps -a --filter "label=cfg-agent=true" --format "{{.Names}}" 2>/dev/null || true)
+
+    for container_name in $containers; do
+      # Extract issue number from container name (cfg-agent-<NUM>)
+      if [[ "$container_name" =~ ^cfg-agent-([0-9]+)$ ]]; then
+        num="${BASH_REMATCH[1]}"
+      else
+        # Skip non-issue containers (pr-fix, branch, interactive)
+        continue
+      fi
+
+      # Check issue state and labels
+      issue_json=$(gh issue view "$num" --repo cfg-is/cfgms --json state,labels 2>/dev/null || echo '{"state":"UNKNOWN","labels":[]}')
+      state=$(echo "$issue_json" | grep -oP '"state"\s*:\s*"\K[^"]+' || echo "UNKNOWN")
+      labels=$(echo "$issue_json" | grep -oP '"name"\s*:\s*"\K[^"]+' || true)
+
+      should_clean=false
+
+      # Clean if story is closed (merged or manually closed)
+      if [[ "$state" == "CLOSED" ]]; then
+        should_clean=true
+        reason="story closed"
+      fi
+
+      # Clean if story is failed or blocked (agent is done, needs human intervention)
+      if echo "$labels" | grep -q "agent:failed"; then
+        should_clean=true
+        reason="agent:failed"
+      fi
+      if echo "$labels" | grep -q "pipeline:blocked"; then
+        should_clean=true
+        reason="pipeline:blocked"
+      fi
+
+      if $should_clean; then
+        echo "STALE:${num}:${reason}"
+        # Reuse cleanup-issue logic
+        docker cp "cfg-agent-${num}:/tmp/agent-result.json" "/tmp/agent-result-${num}.json" 2>/dev/null || true
+        if docker rm -f "cfg-agent-${num}" >/dev/null 2>&1; then
+          echo "CLEANED:container:cfg-agent-${num}"
+        fi
+        clone_dir="${WORKTREE_BASE}/story-${num}"
+        if [[ -d "$clone_dir" ]]; then
+          rm -rf "$clone_dir"
+          echo "CLEANED:clone:${clone_dir}"
+        fi
+        cleaned=$((cleaned + 1))
+      fi
+    done
+
+    echo "CLEANUP_STALE_DONE:cleaned=${cleaned}"
     ;;
 
   *)

--- a/scripts/pipeline-helper.sh
+++ b/scripts/pipeline-helper.sh
@@ -16,6 +16,7 @@ Pipeline Helper — wraps gh CLI for subagent permission compatibility
 
 Story lifecycle:
   create-story <epic_num> <title> <body_file>   Create story issue, label, and link to epic
+  create-ready-story <epic_num> <title> <body_file>  Create story as agent:ready (skip draft)
   edit-body <issue_num> <body_file>              Replace issue body from file
   append-section <issue_num> <section> <file>    Append content after ## <section> heading
   promote <issue_num>                            pipeline:draft → agent:ready
@@ -67,6 +68,36 @@ case "$cmd" in
     story_url=$(gh issue create --repo "$REPO" \
       --title "$title" \
       --label "pipeline:story,pipeline:draft" \
+      --body-file "$body_file")
+
+    story_num=$(echo "$story_url" | grep -oP '\d+$')
+    echo "CREATED:${story_num}:${story_url}"
+
+    # Link as sub-issue of epic
+    epic_id=$(gh issue view "$epic_num" --repo "$REPO" --json id -q .id)
+    child_id=$(gh issue view "$story_num" --repo "$REPO" --json id -q .id)
+    gh api graphql \
+      -f query='mutation($parentId: ID!, $childId: ID!) { addSubIssue(input: {issueId: $parentId, subIssueId: $childId}) { issue { number } subIssue { number } } }' \
+      -f parentId="$epic_id" \
+      -f childId="$child_id" > /dev/null
+
+    echo "LINKED:${story_num}:epic-${epic_num}"
+    ;;
+
+  create-ready-story)
+    epic_num="${1:?Usage: create-ready-story <epic_num> <title> <body_file>}"
+    title="${2:?Usage: create-ready-story <epic_num> <title> <body_file>}"
+    body_file="${3:?Usage: create-ready-story <epic_num> <title> <body_file>}"
+
+    if [ ! -f "$body_file" ]; then
+      echo "ERROR: Body file not found: $body_file"
+      exit 1
+    fi
+
+    # Create the story issue with agent:ready (skip pipeline:draft)
+    story_url=$(gh issue create --repo "$REPO" \
+      --title "$title" \
+      --label "pipeline:story,agent:ready" \
       --body-file "$body_file")
 
     story_num=$(echo "$story_url" | grep -oP '\d+$')


### PR DESCRIPTION
## Summary

- Replace sequential BA → Tech Lead pipeline with a collaborative **Planning Team** where PO, BA, and Tech Lead work together via `TeamCreate`/`SendMessage` during epic decomposition
- Stories are debated and validated before GitHub creation, emerging as `agent:ready` on the first try (skipping `pipeline:draft` entirely)
- Add `create-ready-story` command to `pipeline-helper.sh` for creating stories with `agent:ready` labels directly

## Changes

**Agent definitions:**
- `.claude/agents/ba.md` — Added `## Team Mode` section: propose stories via SendMessage, respond to Tech Lead challenges, signal completion with "PROPOSALS FINAL"
- `.claude/agents/tech-lead.md` — Added `## Team Mode` section: review proposals from messages, send APPROVED/REVISION NEEDED verdicts, challenge BA directly
- `.claude/agents/po.md` — Rewrote Step 6 as Planning Team orchestration (create team, spawn BA + Tech Lead, mediate conversation, 3-round limit, create stories after consensus). Annotated Step 2 as legacy-only.

**Infrastructure:**
- `scripts/pipeline-helper.sh` — Added `create-ready-story` command (mirrors `create-story` but uses `pipeline:story,agent:ready` labels)
- `.gitignore` — Added `scheduled_tasks.lock`

**Documentation:**
- `docs/product/autonomous-agent-system-prd.md` — Updated §2 (team table), §5.2/5.3 (collaborative planning), §10.7 (execution models), §12 (out of scope)
- `docs/development/autonomous-dev-team.md` — Updated team table, flow/state diagrams, "How It Works" sections, design principles

## Design decisions

1. **PO-mediated relay** — formal proposals/verdicts flow through PO for visibility; BA and Tech Lead can message each other directly for quick clarifications
2. **Stories skip `pipeline:draft`** — Tech Lead validates during planning conversation, so stories go straight to `agent:ready`
3. **3-round limit** with PO tie-breaking authority prevents infinite iteration
4. **Backward compatible** — standalone BA/Tech Lead modes remain; legacy Step 2 handles existing `pipeline:draft` stories

## Test plan

- [ ] Run `/po cron` with an epic that has no sub-issues — verify Planning Team spawns and stories are created as `agent:ready`
- [ ] Verify `pipeline-helper.sh create-ready-story` creates issues with correct labels
- [ ] Verify Step 2 (legacy Tech Lead) still works on any remaining `pipeline:draft` stories
- [ ] Verify planning team shuts down and cleans up after convergence
- [ ] Test fallback: simulate BA/Tech Lead disagreement, verify `pipeline:blocked` is created

🤖 Generated with [Claude Code](https://claude.com/claude-code)