### PR TITLE
fix(api): fail open on cancelled context in WorkflowApprovalHook (Issue #637)

### DIFF
--- a/features/controller/api/registration_hook.go
+++ b/features/controller/api/registration_hook.go
@@ -106,7 +106,7 @@ func NewWorkflowApprovalHook(
 func (h *WorkflowApprovalHook) Evaluate(ctx context.Context, input RegistrationInput) (ApprovalDecision, string, error) {
 	// Fail open on cancelled context to avoid blocking legitimate registrations.
 	if err := ctx.Err(); err != nil {
-		return DecisionApprove, "", nil
+		return DecisionApprove, "", ctx.Err()
 	}
 
 	store := workflow.NewWorkflowStore(h.configStore, input.Token.TenantID)

--- a/features/controller/api/registration_hook.go
+++ b/features/controller/api/registration_hook.go
@@ -104,6 +104,11 @@ func NewWorkflowApprovalHook(
 // The workflow is looked up using the token's TenantID so that different tenants
 // can configure different approval policies.
 func (h *WorkflowApprovalHook) Evaluate(ctx context.Context, input RegistrationInput) (ApprovalDecision, string, error) {
+	// Fail open on cancelled context to avoid blocking legitimate registrations.
+	if err := ctx.Err(); err != nil {
+		return DecisionApprove, "", nil
+	}
+
 	store := workflow.NewWorkflowStore(h.configStore, input.Token.TenantID)
 	vw, err := store.GetLatestWorkflow(ctx, registrationWorkflowName)
 	if err != nil {


### PR DESCRIPTION
## Summary

- Fix race condition in `WorkflowApprovalHook.Evaluate()` where a pre-cancelled context could return `DecisionReject` instead of the expected fail-open `DecisionApprove`
- Fix 4 pre-existing lint failures blocking `make test-quality`

Fixes #637

## Changes

**Bug fix** (`features/controller/api/registration_hook.go`):
- Add `ctx.Err()` check at top of `Evaluate()` to short-circuit before workflow execution when context is already cancelled
- Returns `DecisionApprove` with `ctx.Err()` (not nil) for consistency with the mid-execution cancellation path at line 146

**Lint fixes** (pre-existing, blocking `make test-quality`):
- `cmd/cfg/cmd/script_verify.go`: suppress errcheck on CLI output
- `features/modules/script/execution_queue.go`: gofmt whitespace
- `features/modules/script/queue_store.go`: gofmt whitespace
- `features/workflow/nodes/script_node_test.go`: gofmt whitespace

## Test results

- QA Test Runner: PASS (after lint fixes)
- QA Code Review: PASS — 0 blocking issues
- Security Review: PASS — 0 blocking issues, 1 warning addressed (ctx.Err() consistency)
- Verified fix with `-count=50`: 50/50 passes (was intermittently failing)

## Test plan

- [ ] `go test -race -run TestWorkflowApprovalHook -count=50 ./features/controller/api/` — 50/50 passes
- [ ] `make lint` — 0 issues
- [ ] `make test-quality` — all gates pass
- [ ] CI checks pass

Co-Authored-By: Claude <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)