### PR TITLE
chore(ci): add .claude/** to CI paths-ignore for docs-only PRs (Issue #639)

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -19,8 +19,22 @@ name: CodeQL Security Analysis
 on:
   push:
     branches: [ main, develop ]
+    paths-ignore:
+      - 'docs/**'
+      - '*.md'
+      - '.claude/**'
+      - 'LICENSE'
+      - '.gitignore'
+      - '.editorconfig'
   pull_request:
     branches: [ main, develop ]
+    paths-ignore:
+      - 'docs/**'
+      - '*.md'
+      - '.claude/**'
+      - 'LICENSE'
+      - '.gitignore'
+      - '.editorconfig'
   schedule:
     # Run weekly security scan on Wednesdays at 3 AM UTC
     - cron: '0 3 * * 3'

--- a/.github/workflows/cross-platform-build.yml
+++ b/.github/workflows/cross-platform-build.yml
@@ -8,6 +8,7 @@ on:
     paths-ignore:
       - 'docs/**'
       - '*.md'
+      - '.claude/**'
       - 'LICENSE'
       - '.gitignore'
       - '.editorconfig'

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -3,11 +3,12 @@ name: Documentation Validation
 on:
   pull_request:
     branches: [ main, develop ]
-    # ONLY run when documentation actually changes
+    # ONLY run when documentation or agent definitions change
     # Does NOT run on code-only PRs
     paths:
       - 'docs/**'
       - '*.md'
+      - '.claude/**'
   push:
     branches:
       - main
@@ -16,6 +17,7 @@ on:
     paths:
       - 'docs/**'
       - '*.md'
+      - '.claude/**'
   workflow_dispatch:
 
 env:

--- a/.github/workflows/production-gates.yml
+++ b/.github/workflows/production-gates.yml
@@ -8,6 +8,7 @@ on:
     paths-ignore:
       - 'docs/**'
       - '*.md'
+      - '.claude/**'
       - 'LICENSE'
       - '.gitignore'
       - '.editorconfig'

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -8,6 +8,7 @@ on:
     paths-ignore:
       - 'docs/**'
       - '*.md'
+      - '.claude/**'
       - 'LICENSE'
       - '.gitignore'
       - '.editorconfig'

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -8,6 +8,7 @@ on:
     paths-ignore:
       - 'docs/**'
       - '*.md'              # Root-level markdown only (README.md, CONTRIBUTING.md)
+      - '.claude/**'
       - 'LICENSE'
       - '.gitignore'
       - '.editorconfig'


### PR DESCRIPTION
## Summary

- Add `.claude/**` to `paths-ignore` in 4 CI workflow files (`test-suite.yml`, `cross-platform-build.yml`, `security-scan.yml`, `production-gates.yml`) so agent/skill-only PRs skip full CI
- Add `.claude/**` to `documentation.yml` trigger paths so stub jobs fire for agent definition changes
- Add `paths-ignore` block to `codeql-analysis.yml` (previously had no path filtering on push/PR triggers)

Fixes #639

## Changes Made

| File | Change |
|------|--------|
| `test-suite.yml` | Added `.claude/**` to paths-ignore |
| `cross-platform-build.yml` | Added `.claude/**` to paths-ignore |
| `security-scan.yml` | Added `.claude/**` to paths-ignore |
| `production-gates.yml` | Added `.claude/**` to paths-ignore |
| `documentation.yml` | Added `.claude/**` to paths trigger (both PR and push) |
| `codeql-analysis.yml` | Added full paths-ignore block to push and PR triggers |

## Safety Notes

- CodeQL `schedule` (weekly) and `workflow_dispatch` triggers remain unfiltered — full-codebase security analysis still runs weekly
- `.claude/` contains only markdown agent definitions and JSON settings — zero Go code, zero scripts
- All paths-ignore entries are consistent across workflows

## Test Results

- **QA Test Runner**: PASS — all unit tests, cross-platform builds, commercial builds, script validation passing. Docker/PostgreSQL integration tests skipped (infrastructure not available locally, CI-only)
- **QA Code Review**: PASS — YAML syntax valid, paths-ignore entries consistent, no test quality issues
- **Security Review**: PASS — no security blind spots, no secrets, no vulnerabilities, all automated scans clean

## Test Plan

- [ ] Verify CI runs full suite on PRs with Go code changes (no regression)
- [ ] Verify `.claude/`-only PRs get instant green stubs from documentation.yml
- [ ] Verify CodeQL weekly schedule still runs unfiltered

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>