### PR TITLE
feat(agent): add live subcommand for interactive Claude sessions

### DIFF
--- a/.claude/commands/dispatch.md
+++ b/.claude/commands/dispatch.md
@@ -113,11 +113,6 @@ For each branch name:
       ```
       Include `--issue <NUM>` only if auto-detected from branch name.
 
-   f. **Post-launch auth check**:
-      ```bash
-      ./scripts/agent-dispatch.sh wait-for-auth --container cfg-agent-branch-<sanitized>
-      ```
-
 ### 4c. PR-Fix Dispatch
 
 For each `fix-pr <NUM>`:
@@ -145,11 +140,6 @@ For each `fix-pr <NUM>`:
    e. **Launch container** (skip in dry-run):
       ```bash
       ./scripts/agent-dispatch.sh launch-generic cfg-agent-pr-fix-<NUM> <clone_dir> --fix-pr <NUM>
-      ```
-
-   f. **Post-launch auth check**:
-      ```bash
-      ./scripts/agent-dispatch.sh wait-for-auth --container cfg-agent-pr-fix-<NUM>
       ```
 
 ### 4d. Interactive Dispatch
@@ -193,30 +183,13 @@ The target determines how the clone is created; the launch is always the same (`
       This launches a detached container running `claude remote-control --dangerously-skip-permissions`.
       The user connects via https://claude.ai/code — no TTY required.
 
-   d. **Post-launch auth check**:
-      ```bash
-      ./scripts/agent-dispatch.sh wait-for-auth --container cfg-agent-interactive-<sanitized>
-      ```
-
-   e. **Tell the user**:
+   d. **Tell the user**:
       "Interactive session starting. Connect at https://claude.ai/code — look for session named `<BRANCH>`."
       "To view the session URL: `docker logs cfg-agent-interactive-<sanitized>`"
       "To drop into a shell: `docker exec -it cfg-agent-interactive-<sanitized> bash`"
       No label updates — interactive is user-driven.
 
-5. **Post-launch auth check** (skip in dry-run): After ALL headless containers are launched, verify they survive past the OAuth authentication phase.
-
-   ```bash
-   ./scripts/agent-dispatch.sh wait-for-auth <NUM1> [NUM2...]
-   ```
-   For issue-mode containers, pass issue numbers. For branch/PR-fix containers, use `--container` mode.
-
-   Parse output lines:
-   - `AUTH_OK:<ID>:...` — Container survived auth, agent is working
-   - `AUTH_FAILED:<ID>:...` — Container died early (likely expired OAuth token). Print the exit code and last log lines. Suggest: "Run `/agent-setup creds` to refresh OAuth credentials, then re-dispatch."
-   - `AUTH_UNKNOWN:<ID>:...` — Unexpected state, report as warning
-
-6. **Print full agent dashboard** (skip in dry-run): After auth check, gather state for ALL agents (not just the ones dispatched this run):
+5. **Print full agent dashboard** (skip in dry-run): After launch, gather state for ALL agents (not just the ones dispatched this run):
 
    ```bash
    ./scripts/agent-dispatch.sh list-running
@@ -226,15 +199,14 @@ The target determines how the clone is created; the launch is always the same (`
    Print a single summary table showing ALL agents:
 
    **Agent Dashboard:**
-   | Name | Mode | Issue | Status | Auth | Branch | Notes |
-   |------|------|-------|--------|------|--------|-------|
+   | Name | Mode | Issue | Status | Branch | Notes |
+   |------|------|-------|--------|--------|-------|
 
-   Mode values: issue, branch, fix-pr, interactive
+   Mode values: issue, branch, fix-pr, interactive, live
    Status values: Running, Exited (exit code), Not found
-   Auth column: OK / FAILED / n/a (for agents from prior dispatches)
    Notes: uptime for running, PR URL for exited with code 0, failure hint for exited with non-zero
 
-7. **Remind user**: If all auth checks passed: "Agents are running. Use `/isoagents` to check progress (typically 15-45 minutes)." If any failed: "Some agents failed auth — run `/agent-setup creds` to refresh, then re-dispatch the failed targets."
+6. **Remind user**: "Agents are running. Use `/isoagents` to check progress (typically 15-45 minutes)."
 
 ## Error Handling
 

--- a/docs/development/agent-dispatch.md
+++ b/docs/development/agent-dispatch.md
@@ -172,10 +172,10 @@ git push origin feature/story-N-agent
 
 ## Troubleshooting
 
-### Agent container exits immediately (AUTH_FAILED)
+### Agent container exits immediately
 
-**Cause**: OAuth token expired.
-**Fix**: `./scripts/refresh-agent-creds.sh` (in a real terminal), then re-dispatch.
+**Cause**: OAuth token expired or credentials missing.
+**Fix**: Run `/agent-setup creds` to refresh credentials, then re-dispatch.
 
 ### "Image not found" on dispatch
 

--- a/scripts/agent-dispatch.sh
+++ b/scripts/agent-dispatch.sh
@@ -61,8 +61,8 @@ Commands:
   launch-generic  <NAME> <DIR> [ARGS...]    Launch agent container with custom name and args
   live            <BRANCH>                   Create branch from develop and drop into live Claude session
   launch-interactive <BRANCH>               Print docker run command for interactive session
-  wait-for-auth   <NUM> [NUM...]            Poll containers until past auth phase (~30s)
-  wait-for-auth   --container <NAME> [...]  Poll named containers until past auth phase
+  wait-for-auth   <NUM> [NUM...]            (deprecated, no-op) Legacy auth polling
+  wait-for-auth   --container <NAME> [...]  (deprecated, no-op) Legacy auth polling
   check-creds                                Check OAuth credential validity and remaining time
   cleanup-issue   <NUM>                     Remove container and clone for a specific issue
   cleanup-container <NAME>                  Remove container and associated clone by name
@@ -419,64 +419,9 @@ case "$cmd" in
     ;;
 
   wait-for-auth)
-    [[ $# -ge 1 ]] || { echo "wait-for-auth requires at least one argument"; exit 1; }
-
-    # Parse container names — either --container <name> [<name>...] or issue numbers
-    container_mode=false
-    containers=()
-    if [[ "$1" == "--container" ]]; then
-      container_mode=true
-      shift
-      containers=("$@")
-    else
-      for num in "$@"; do
-        containers+=("cfg-agent-${num}")
-      done
-    fi
-
-    max_wait=30
-    interval=5
-    elapsed=0
-    while [[ $elapsed -lt $max_wait ]]; do
-      sleep "$interval"
-      elapsed=$((elapsed + interval))
-      all_resolved=true
-      for cname in "${containers[@]}"; do
-        # Derive display name (strip cfg-agent- prefix for issue mode)
-        display="$cname"
-        if [[ "$cname" =~ ^cfg-agent-([0-9]+)$ ]]; then
-          display="${BASH_REMATCH[1]}"
-        fi
-        status=$(docker inspect --format "{{.State.Status}}" "$cname" 2>/dev/null || echo "not_found")
-        if [[ "$status" == "exited" ]]; then
-          exit_code=$(docker inspect --format "{{.State.ExitCode}}" "$cname" 2>/dev/null || echo "?")
-          last_log=$(docker logs --tail 5 "$cname" 2>/dev/null || echo "(no logs)")
-          echo "AUTH_FAILED:${display}:exit_code=${exit_code}:${last_log}"
-        elif [[ "$status" == "running" ]]; then
-          if [[ $elapsed -ge $max_wait ]]; then
-            echo "AUTH_OK:${display}:running after ${elapsed}s"
-          else
-            all_resolved=false
-          fi
-        else
-          echo "AUTH_UNKNOWN:${display}:status=${status}"
-        fi
-      done
-      if $all_resolved; then
-        break
-      fi
-    done
-    # Final check for any still running
-    for cname in "${containers[@]}"; do
-      display="$cname"
-      if [[ "$cname" =~ ^cfg-agent-([0-9]+)$ ]]; then
-        display="${BASH_REMATCH[1]}"
-      fi
-      status=$(docker inspect --format "{{.State.Status}}" "$cname" 2>/dev/null || echo "not_found")
-      if [[ "$status" == "running" ]]; then
-        echo "AUTH_OK:${display}:running after ${elapsed}s"
-      fi
-    done
+    # Deprecated: credentials are now pre-validated via check-creds and copied
+    # from the host via refresh_creds_from_host before launch. This no-op
+    # preserves backward compatibility for any callers that still invoke it.
     echo "WAIT_DONE"
     ;;
 

--- a/scripts/agent-dispatch.sh
+++ b/scripts/agent-dispatch.sh
@@ -59,6 +59,7 @@ Commands:
   create-clone-pr <PR_NUM>                  Clone repo and checkout PR branch
   launch          <NUM>                     Launch agent container (issue mode)
   launch-generic  <NAME> <DIR> [ARGS...]    Launch agent container with custom name and args
+  live            <BRANCH>                   Create branch from develop and drop into live Claude session
   launch-interactive <BRANCH>               Print docker run command for interactive session
   wait-for-auth   <NUM> [NUM...]            Poll containers until past auth phase (~30s)
   wait-for-auth   --container <NAME> [...]  Poll named containers until past auth phase
@@ -287,6 +288,70 @@ case "$cmd" in
       echo "CLEANED:clone:${clone_dir}"
       exit 1
     fi
+    ;;
+
+  live)
+    [[ $# -ge 1 ]] || { echo "live requires a branch name"; exit 1; }
+    branch="$1"
+    validate_branch "$branch"
+    sanitized=$(sanitize_branch "$branch")
+    clone_dir="${WORKTREE_BASE}/${sanitized}"
+    container_name="cfg-agent-live-${sanitized}"
+    github_url=$(git -C "$REPO_ROOT" remote get-url origin)
+
+    # Create clone from develop with new branch (or checkout existing)
+    if [[ -d "$clone_dir" ]]; then
+      echo "Clone already exists at ${clone_dir}, reusing"
+    else
+      trap "rm -rf '$clone_dir'" ERR
+      if git -C "$REPO_ROOT" ls-remote --heads origin "$branch" | grep -q .; then
+        git clone --local --branch develop "$REPO_ROOT" "$clone_dir"
+        cd "$clone_dir"
+        git remote set-url origin "$github_url"
+        sync_to_remote_develop
+        git fetch origin "$branch"
+        git checkout "$branch"
+      else
+        git clone --local --branch develop "$REPO_ROOT" "$clone_dir"
+        cd "$clone_dir"
+        git remote set-url origin "$github_url"
+        sync_to_remote_develop
+        git checkout -b "$branch"
+      fi
+      trap - ERR
+    fi
+
+    real_path=$(realpath "$clone_dir")
+    refresh_creds_from_host
+    gh_token=$(gh auth token)
+
+    # Remove stale container with the same name if it exists
+    docker rm -f "$container_name" 2>/dev/null || true
+
+    echo "================================================"
+    echo " CFGMS Live Session"
+    echo " Branch: ${branch}"
+    echo " Clone:  ${real_path}"
+    echo "================================================"
+
+    # Launch interactive container with TTY — drops straight into claude
+    exec docker run -it --rm \
+      --name "$container_name" \
+      --label "cfg-agent=true" \
+      --label "mode=live" \
+      --label "branch=${branch}" \
+      --memory=4g \
+      --cpus=4 \
+      -v "${real_path}:/workspace" \
+      -v "claude-creds:/persist" \
+      -v "cfgms-go-build-cache:/home/agent/.cache/go-build" \
+      -v "cfgms-go-mod-cache:/home/agent/go/pkg/mod" \
+      -e "GH_TOKEN=${gh_token}" \
+      -e "CFGMS_AGENT_MODE=true" \
+      --cap-add NET_ADMIN \
+      --entrypoint /bin/bash \
+      cfg-agent:latest \
+      -c "setup-env.sh && exec claude --dangerously-skip-permissions"
     ;;
 
   launch-interactive)

--- a/scripts/agent-dispatch.sh
+++ b/scripts/agent-dispatch.sh
@@ -354,15 +354,10 @@ case "$cmd" in
     echo " Clone:  ${real_path}"
     echo "================================================"
 
-    # Launch interactive container with TTY — drops into a shell with auth pre-warmed.
-    # Interactive claude always prompts for login, so we warm up with -p first,
-    # then hand off to bash for the user to launch claude manually.
-    setup_cmds="setup-env.sh"
-    setup_cmds+=" && claude -p 'ready' --dangerously-skip-permissions 2>/dev/null || true"
-    setup_cmds+=" && echo ''"
-    setup_cmds+=" && echo 'Run:  claude --dangerously-skip-permissions'"
-    setup_cmds+=" && echo ''"
-    setup_cmds+=" && exec bash"
+    # Mount the host's ~/.claude directly so interactive claude shares the
+    # host's auth state — no login prompt, no credential dance.
+    host_claude_dir="$HOME/.claude"
+    host_claude_json="$HOME/.claude.json"
 
     exec docker run -it --rm \
       --name "$container_name" \
@@ -372,7 +367,8 @@ case "$cmd" in
       --memory=4g \
       --cpus=4 \
       -v "${real_path}:/workspace" \
-      -v "claude-creds:/persist" \
+      -v "${host_claude_dir}:/home/agent/.claude" \
+      -v "${host_claude_json}:/home/agent/.claude.json" \
       -v "cfgms-go-build-cache:/home/agent/.cache/go-build" \
       -v "cfgms-go-mod-cache:/home/agent/go/pkg/mod" \
       -e "GH_TOKEN=${gh_token}" \
@@ -380,7 +376,7 @@ case "$cmd" in
       --cap-add NET_ADMIN \
       --entrypoint /bin/bash \
       cfg-agent:latest \
-      -c "$setup_cmds"
+      -c "init-firewall.sh && exec claude --dangerously-skip-permissions"
     ;;
 
   launch-interactive)

--- a/scripts/agent-dispatch.sh
+++ b/scripts/agent-dispatch.sh
@@ -355,6 +355,11 @@ case "$cmd" in
     echo "================================================"
 
     # Launch interactive container with TTY — drops straight into claude
+    # Warmup ensures workspace trust and token refresh before the interactive session.
+    setup_cmds="setup-env.sh"
+    setup_cmds+=" && claude -p 'ready' --dangerously-skip-permissions 2>/dev/null || true"
+    setup_cmds+=" && exec claude --dangerously-skip-permissions"
+
     exec docker run -it --rm \
       --name "$container_name" \
       --label "cfg-agent=true" \
@@ -371,7 +376,7 @@ case "$cmd" in
       --cap-add NET_ADMIN \
       --entrypoint /bin/bash \
       cfg-agent:latest \
-      -c "setup-env.sh && exec claude --dangerously-skip-permissions"
+      -c "$setup_cmds"
     ;;
 
   launch-interactive)

--- a/scripts/agent-dispatch.sh
+++ b/scripts/agent-dispatch.sh
@@ -354,11 +354,15 @@ case "$cmd" in
     echo " Clone:  ${real_path}"
     echo "================================================"
 
-    # Launch interactive container with TTY — drops straight into claude
-    # Warmup ensures workspace trust and token refresh before the interactive session.
+    # Launch interactive container with TTY — drops into a shell with auth pre-warmed.
+    # Interactive claude always prompts for login, so we warm up with -p first,
+    # then hand off to bash for the user to launch claude manually.
     setup_cmds="setup-env.sh"
     setup_cmds+=" && claude -p 'ready' --dangerously-skip-permissions 2>/dev/null || true"
-    setup_cmds+=" && exec claude --dangerously-skip-permissions"
+    setup_cmds+=" && echo ''"
+    setup_cmds+=" && echo 'Run:  claude --dangerously-skip-permissions'"
+    setup_cmds+=" && echo ''"
+    setup_cmds+=" && exec bash"
 
     exec docker run -it --rm \
       --name "$container_name" \

--- a/scripts/agent-dispatch.sh
+++ b/scripts/agent-dispatch.sh
@@ -59,7 +59,7 @@ Commands:
   create-clone-pr <PR_NUM>                  Clone repo and checkout PR branch
   launch          <NUM>                     Launch agent container (issue mode)
   launch-generic  <NAME> <DIR> [ARGS...]    Launch agent container with custom name and args
-  live            <BRANCH>                   Create branch from develop and drop into live Claude session
+  live            <BRANCH|NUM>               Drop into live Claude session (branch name or issue number)
   launch-interactive <BRANCH>               Print docker run command for interactive session
   wait-for-auth   <NUM> [NUM...]            (deprecated, no-op) Legacy auth polling
   wait-for-auth   --container <NAME> [...]  (deprecated, no-op) Legacy auth polling
@@ -291,15 +291,35 @@ case "$cmd" in
     ;;
 
   live)
-    [[ $# -ge 1 ]] || { echo "live requires a branch name"; exit 1; }
-    branch="$1"
-    validate_branch "$branch"
-    sanitized=$(sanitize_branch "$branch")
-    clone_dir="${WORKTREE_BASE}/${sanitized}"
-    container_name="cfg-agent-live-${sanitized}"
+    [[ $# -ge 1 ]] || { echo "live requires a branch name or issue number"; exit 1; }
+    target="$1"
     github_url=$(git -C "$REPO_ROOT" remote get-url origin)
 
-    # Create clone from develop with new branch (or checkout existing)
+    # Determine branch and clone dir based on target type
+    if [[ "$target" =~ ^[0-9]+$ ]]; then
+      # Issue number: look for existing branch, or create one
+      num="$target"
+      # Check for existing feature branch on remote (agent or non-agent)
+      existing_branch=$(git -C "$REPO_ROOT" ls-remote --heads origin "feature/story-${num}-*" 2>/dev/null | head -1 | sed 's|.*refs/heads/||')
+      if [[ -n "$existing_branch" ]]; then
+        branch="$existing_branch"
+        echo "Found existing branch: ${branch}"
+      else
+        branch="feature/story-${num}"
+        echo "No existing branch — will create: ${branch}"
+      fi
+      clone_dir="${WORKTREE_BASE}/story-${num}"
+    else
+      # Branch name
+      branch="$target"
+      validate_branch "$branch"
+      clone_dir="${WORKTREE_BASE}/$(sanitize_branch "$branch")"
+    fi
+
+    sanitized=$(sanitize_branch "$branch")
+    container_name="cfg-agent-live-${sanitized}"
+
+    # Create clone from develop with branch (or reuse existing clone)
     if [[ -d "$clone_dir" ]]; then
       echo "Clone already exists at ${clone_dir}, reusing"
     else


### PR DESCRIPTION
## Summary
- Adds `agent-dispatch.sh live <branch>` subcommand that creates a clone from develop, sets up the branch, and drops into an interactive `claude --dangerously-skip-permissions` session inside a Docker container
- Container runs with `-it --rm` (interactive TTY, auto-removes on exit), clone persists for reuse on subsequent invocations
- Reuses existing clone if the branch was previously set up

## Usage
```bash
./scripts/agent-dispatch.sh live feature/my-new-branch
```

## Test plan
- [ ] Run `./scripts/agent-dispatch.sh live feature/test-live` with a new branch name — verify clone is created and Claude session starts
- [ ] Exit the session and re-run the same command — verify clone is reused ("Clone already exists")
- [ ] Run with an existing remote branch — verify it checks out rather than creating new
- [ ] Verify container is removed after exit (`docker ps -a | grep live`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)