### PR TITLE
fix(agent): fix live container environment for Go modules and git auth

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -93,6 +93,8 @@ RUN chmod +x /usr/local/bin/init-firewall.sh /usr/local/bin/setup-env.sh /usr/lo
 # Agent environment — 4GB RAM is sufficient for go test/build + Claude API calls
 ENV CFGMS_AGENT_MODE=true
 ENV TRIVY_CACHE_DIR=/home/agent/.cache/trivy
+ENV GOMODCACHE=/home/agent/go/pkg/mod
+ENV GOFLAGS=-modcacherw
 
 USER agent
 WORKDIR /workspace

--- a/.devcontainer/scripts/setup-env.sh
+++ b/.devcontainer/scripts/setup-env.sh
@@ -15,17 +15,21 @@ fi
 # and out, we symlink so that token refreshes persist immediately to the volume.
 mkdir -p ~/.claude
 
-if [ -f /persist/.credentials.json ]; then
+if [ -f ~/.claude/.credentials.json ]; then
+    : # Credentials already present (e.g. host mount) — nothing to do
+elif [ -f /persist/.credentials.json ]; then
     ln -sf /persist/.credentials.json ~/.claude/.credentials.json
 else
-    echo "WARN: No Claude credentials found at /persist/.credentials.json"
+    echo "WARN: No Claude credentials found"
     echo "Run: /agent-setup creds on host to configure"
 fi
 
-# Onboarding config — symlink if saved by refresh-agent-creds.sh, else create
-if [ -f /persist/.claude-config.json ]; then
+# Onboarding config — skip if present (host mount), symlink from persist, or create
+if [ -f ~/.claude.json ]; then
+    : # Already present (e.g. host mount)
+elif [ -f /persist/.claude-config.json ]; then
     ln -sf /persist/.claude-config.json ~/.claude.json
-elif [ ! -f ~/.claude.json ]; then
+else
     cat > ~/.claude.json <<'ONBOARD'
 {"hasCompletedOnboarding":true,"installMethod":"native"}
 ONBOARD
@@ -36,7 +40,8 @@ if [ -d /persist/.claude-state ]; then
     cp -rn /persist/.claude-state/. ~/.claude/ 2>/dev/null || true
 fi
 
-# --- Git identity ---
+# --- Git identity and auth ---
 git config --global user.name "cfg-agent"
 git config --global user.email "agent@cfg.is"
 git config --global push.autoSetupRemote true
+gh auth setup-git 2>/dev/null || true

--- a/scripts/agent-dispatch.sh
+++ b/scripts/agent-dispatch.sh
@@ -369,14 +369,17 @@ case "$cmd" in
       -v "${real_path}:/workspace" \
       -v "${host_claude_dir}:/home/agent/.claude" \
       -v "${host_claude_json}:/home/agent/.claude.json" \
+      -v "${REPO_ROOT}/.devcontainer/scripts/setup-env.sh:/usr/local/bin/setup-env.sh:ro" \
       -v "cfgms-go-build-cache:/home/agent/.cache/go-build" \
       -v "cfgms-go-mod-cache:/home/agent/go/pkg/mod" \
       -e "GH_TOKEN=${gh_token}" \
       -e "CFGMS_AGENT_MODE=true" \
+      -e "GOMODCACHE=/home/agent/go/pkg/mod" \
+      -e "GOFLAGS=-modcacherw" \
       --cap-add NET_ADMIN \
       --entrypoint /bin/bash \
       cfg-agent:latest \
-      -c "init-firewall.sh && exec claude --dangerously-skip-permissions"
+      -c "setup-env.sh && exec claude --dangerously-skip-permissions"
     ;;
 
   launch-interactive)


### PR DESCRIPTION
## Summary
- Fix Go module cache ownership: set `GOMODCACHE=/home/agent/go/pkg/mod` (base golang image defaults to root-owned `/go/pkg/mod`)
- Set `GOFLAGS=-modcacherw` to keep module cache files writable (Go defaults to 0444)
- Use `setup-env.sh` in live command for consistent setup (firewall, git identity, gh auth)
- Make `setup-env.sh` skip credential symlinks when files already exist (host mount path)
- Add `gh auth setup-git` to `setup-env.sh` so git push works with `GH_TOKEN`
- Mount local `setup-env.sh` in live containers so changes work without image rebuild

## Test plan
- [ ] `./scripts/agent-dispatch.sh live feature/test` — verify no auth prompt, git configured, `go mod tidy` works
- [ ] Headless agent dispatch still works (setup-env.sh changes are backward compatible)

🤖 Generated with [Claude Code](https://claude.com/claude-code)