### PR TITLE
chore(pipeline): enforce docs and tests currency in agent workflow

### DIFF
--- a/.claude/agents/acceptance-reviewer.md
+++ b/.claude/agents/acceptance-reviewer.md
@@ -70,6 +70,21 @@ Extract acceptance criteria from the story body (`- [ ]` checkboxes). For each c
 
 A criterion is "met" only if there is concrete evidence in the diff. "Probably met" is not met.
 
+### Docs & Tests Currency Gate
+
+If the story body has a `## Docs In Scope` section listing files, **every file listed must appear in the PR diff**. If any listed doc file is missing from the diff, that is a finding:
+
+- **Severity**: High — docs currency is a product-shape commitment from the Tech Lead
+- **Description**: "Story lists `<file>` in Docs In Scope but no change present in PR diff"
+
+If the story changes product shape (adds/removes a backend, changes a public interface, changes CLI/API surface, changes the OSS/commercial boundary) but the PR has **no doc changes at all**, that is also a finding — even if the story body didn't list them. Check for obvious missed updates:
+
+- Backend or provider added/removed → `docs/product/feature-boundaries.md` expected
+- Public interface changed → the relevant `pkg/*/README.md` expected
+- Architecture changed → relevant `docs/architecture/*.md` expected
+
+Same rule for tests: if the PR changes behavior but has no corresponding test diffs, flag it as a finding. "Docs will come later" and "tests in a follow-up" are not acceptable — the story should have been split by the Tech Lead, not deferred here.
+
 ## Phase 4: Code Review
 
 Review the PR diff for:

--- a/.claude/agents/ba.md
+++ b/.claude/agents/ba.md
@@ -75,6 +75,13 @@ Each story must use this exact format:
 - `path/to/file.go` — <what to do with this file>
 - `path/to/file_test.go` — <what tests to add>
 
+## Docs In Scope
+
+- `docs/path/to/doc.md` — <what to update / add / remove>
+- `pkg/path/to/README.md` — <what to update>
+
+(Use "None" only if the story genuinely does not change product shape. See "Documentation & Tests Currency" rule below.)
+
 ## Reference Implementation
 
 - <Pointers to existing patterns in the codebase to follow>
@@ -92,8 +99,36 @@ Each story must use this exact format:
 
 - [ ] <Specific, testable criterion>
 - [ ] <Another criterion>
+- [ ] Tests added/updated for all behavior changes (unit + integration where applicable)
+- [ ] Docs updated — enumerate files here, or write "N/A — no product-shape change" with justification
 - [ ] `make test-complete` passes
 ```
+
+## Documentation & Tests Currency
+
+Every story that **changes the shape of the product** must include both docs updates and test updates in the same story (no follow-ups, no "docs will come later"). Product-shape changes include:
+
+- Adding, removing, or renaming a public interface, type, or package
+- Adding, removing, or renaming a backend, provider, or configuration key
+- Changing the OSS/commercial boundary or licensing surface
+- Changing a CLI command, flag, or output format
+- Changing an API endpoint or payload shape
+- Changing architecture (central providers, storage layout, communication patterns)
+
+When decomposing an epic, for each story:
+
+1. **Identify the product-shape delta.** If the story changes behavior a user or operator observes, it changes product shape.
+2. **List affected docs in `## Docs In Scope`.** Candidates to check:
+   - `docs/product/feature-boundaries.md` — OSS/commercial line, backend lists
+   - `docs/architecture/*.md` — architecture docs under the relevant area
+   - `docs/architecture/decisions/*.md` — any ADR referenced by the change
+   - `pkg/*/README.md` — package-level docs for affected packages
+   - `docs/deployment/*`, `docs/testing/*`, `docs/troubleshooting/*` — user-facing guides
+   - `CLAUDE.md` (only if the epic authorizes it — otherwise flag as PO-review needed)
+3. **List test updates in `## Files In Scope`** alongside the source files. Tests covering the changed behavior (unit + integration, per the testing taxonomy in CLAUDE.md) must be in the same PR as the code.
+4. **Include acceptance-criteria checkboxes** for docs and tests — the Acceptance Reviewer will verify these against the diff.
+
+A story that changes product shape without listing docs and tests is **not ready for a dev agent** and will be blocked by the Tech Lead.
 
 ## Decomposition Process
 

--- a/.claude/agents/tech-lead.md
+++ b/.claude/agents/tech-lead.md
@@ -23,7 +23,7 @@ Also read `CLAUDE.md` for architecture rules, central providers, and anti-patter
 
 ## Validation Checklist
 
-For each story, run all 5 checks. A story must pass ALL checks to be promoted.
+For each story, run all 6 checks. A story must pass ALL checks to be promoted.
 
 ### 1. Dependency Ordering & File Conflict Detection
 
@@ -85,6 +85,34 @@ Flag and block if the story implies any of these:
   - "Add tests" — specify which test cases and what assertions
   - Unclear whether something belongs in controller vs steward
 - Add clarifying notes to `## Implementation Notes` to make the correct choice unambiguous
+
+### 6. Documentation & Tests Currency
+
+Stories that change product shape must update docs and tests in the same PR. Determine whether the story changes product shape — signals:
+
+- Adds, removes, or renames a public interface, type, package, backend, provider, or config key
+- Changes CLI commands, flags, output; API endpoints or payloads
+- Changes the OSS/commercial boundary or licensing surface
+- Changes architecture (central providers, storage layout, communication patterns)
+
+If yes, verify the story contains **all three**:
+
+1. **`## Docs In Scope` section** listing each affected doc file with what to update. Candidates to audit against:
+   - `docs/product/feature-boundaries.md` (OSS/commercial backend lists)
+   - Relevant `docs/architecture/*.md` and any ADR referenced by the change
+   - `pkg/*/README.md` for affected packages
+   - `docs/deployment/*`, `docs/testing/*`, `docs/troubleshooting/*` for user-facing guides
+2. **Test files listed in `## Files In Scope`** alongside the source files — unit + integration where applicable per the CLAUDE.md testing taxonomy
+3. **Acceptance criteria checkboxes** for "Docs updated — enumerate files" and "Tests added/updated for all behavior changes"
+
+If the story does not change product shape (e.g., internal refactor with no observable behavior change), either accept `## Docs In Scope: None` with a justification note, or require the BA to add the justification.
+
+**Failure modes to block on**:
+- Story changes product shape but lists no docs — BLOCK, request BA to add `## Docs In Scope`
+- Story changes a public interface but has no test updates — BLOCK, request test coverage
+- Story claims "docs will come in a follow-up" — BLOCK. Documentation currency is not deferrable.
+
+When you find the docs list is obviously incomplete (e.g., story changes a storage backend but doesn't list `feature-boundaries.md`), add the missing entries yourself as part of your `## Implementation Notes` write-up rather than blocking — but only when the gap is obvious. Anything judgment-heavy goes back to the BA.
 
 ## Passing a Story
 
@@ -199,7 +227,7 @@ When spawned as a teammate (with `team_name` parameter), you operate as part of 
 
 ### What Stays the Same
 
-- The 5-check validation checklist (dependency ordering, implementation notes, scope, constraints, ambiguity)
+- The 6-check validation checklist (dependency ordering, implementation notes, scope, constraints, ambiguity, docs+tests currency)
 - Codebase validation tools (Read, Grep, Glob, Bash)
 - File conflict detection logic
 - The standard for what makes a story executable by a dev agent


### PR DESCRIPTION
## Summary

Adds an explicit **Documentation & Tests Currency** rule across the three agents in the story validation and review chain (BA, Tech Lead, Acceptance Reviewer). The rule requires stories that change product shape to carry docs and tests updates in the same PR — no follow-ups, no deferrals.

Prompted by PO feedback during ADR-003 review (#658): the ADR codified the rule for its own epic (#647); this PR codifies it in the pipeline for all future stories.

## What Counts As Product Shape

Adding/removing/renaming public interfaces, types, backends, providers, config keys; changing CLI/API surface; changing the OSS/commercial boundary; changing architecture.

## Changes

### BA (`ba.md`)
- `Docs In Scope` section added to canonical story body template
- Acceptance criteria template now includes "Tests added/updated" and "Docs updated" checkboxes
- New "Documentation & Tests Currency" policy section enumerates candidate doc locations to audit

### Tech Lead (`tech-lead.md`)
- Validation checklist grows from 5 to 6 checks — new check #6: Documentation & Tests Currency
- Defines block conditions (missing Docs In Scope when shape changes, missing test updates for interface changes, "docs later" language)
- Tech Lead auto-fills obvious doc omissions; judgment calls go back to BA

### Acceptance Reviewer (`acceptance-reviewer.md`)
- Phase 3 gains a "Docs & Tests Currency Gate"
- Every file listed in story's `Docs In Scope` must appear in the PR diff — missing entries are high-severity findings
- Shape-changing PRs with no doc changes are findings even if the story body missed them
- Tests missing for behavior changes are findings

## Test Plan

- [ ] Docs-only fast-path CI passes (no code changes)
- [ ] Next pipeline cycle that decomposes an epic uses the new BA template
- [ ] Next Tech Lead validation run applies check #6
- [ ] Next Acceptance Reviewer pass enforces the Docs & Tests Currency Gate

Refs #647