### PR TITLE
storage/sqlite: implement SQLite business-data provider and SessionStore interface (Issue #662)

### DIFF
--- a/docs/architecture/storage-architecture.md
+++ b/docs/architecture/storage-architecture.md
@@ -177,6 +177,14 @@ controller:
 
 Per ADR-003, the providers and interfaces above are **not all implemented today**. The ADR ratifies the direction; implementation is tracked by the **Storage Architecture: Five-Type Data Taxonomy (ADR-003)** epic and its sub-stories. See the ADR's [Code Changes Required](decisions/003-storage-data-taxonomy.md#code-changes-required) section for the authoritative sub-story list and priorities.
 
+### Completed (as of Epic #647)
+
+| Provider | Story | Stores implemented |
+|----------|-------|--------------------|
+| `pkg/storage/providers/sqlite` | #662 | `TenantStore`, `ClientTenantStore`, `AuditStore`, `RBACStore`, `RegistrationTokenStore`, `SessionStore` |
+
+`SessionStore` is implemented in this story (#662). It stores only `Persistent=true` sessions; ephemeral state (non-persistent sessions, rebuildable runtime values) uses `pkg/cache`. The `ConfigStore` and `RuntimeStore` interfaces return `ErrNotSupported` from the SQLite provider — config storage targets the flat-file provider (OSS) and PostgreSQL (commercial).
+
 ## References
 
 - [ADR-003: Storage Data Taxonomy](decisions/003-storage-data-taxonomy.md) — authoritative design document

--- a/features/workflow/trigger/integration_test.go
+++ b/features/workflow/trigger/integration_test.go
@@ -138,6 +138,10 @@ func (t *TestStorageProvider) CreateRegistrationTokenStore(config map[string]int
 	return nil, fmt.Errorf("not implemented in test provider")
 }
 
+func (t *TestStorageProvider) CreateSessionStore(_ map[string]interface{}) (interfaces.SessionStore, error) {
+	return nil, interfaces.ErrNotSupported
+}
+
 func (t *TestStorageProvider) GetCapabilities() interfaces.ProviderCapabilities {
 	return interfaces.ProviderCapabilities{
 		MaxBatchSize:          100,

--- a/features/workflow/trigger/manager_test.go
+++ b/features/workflow/trigger/manager_test.go
@@ -105,6 +105,10 @@ func (m *MockStorageProvider) CreateRegistrationTokenStore(config map[string]int
 	return args.Get(0).(interfaces.RegistrationTokenStore), args.Error(1)
 }
 
+func (m *MockStorageProvider) CreateSessionStore(_ map[string]interface{}) (interfaces.SessionStore, error) {
+	return nil, interfaces.ErrNotSupported
+}
+
 func (m *MockStorageProvider) GetCapabilities() interfaces.ProviderCapabilities {
 	args := m.Called()
 	return args.Get(0).(interfaces.ProviderCapabilities)

--- a/pkg/audit/manager_test.go
+++ b/pkg/audit/manager_test.go
@@ -448,3 +448,7 @@ func (m *mockAuditStore) ArchiveAuditEntries(ctx context.Context, beforeDate tim
 func (m *mockAuditStore) PurgeAuditEntries(ctx context.Context, beforeDate time.Time) (int64, error) {
 	return 0, nil
 }
+
+func (m *mockAuditStore) Close() error {
+	return nil
+}

--- a/pkg/storage/interfaces/README.md
+++ b/pkg/storage/interfaces/README.md
@@ -21,6 +21,7 @@ The files in this directory today:
 | `rbac_store.go` | `RBACStore` | RBAC policy and role data |
 | `registration_store.go` | `RegistrationStore` (tokens) | Steward registration tokens |
 | `runtime_store.go` | `RuntimeStore` | Ephemeral/session runtime state |
+| `session_store.go` | `SessionStore` | Durable session state (persistent sessions only; ephemeral state lives in `pkg/cache`) |
 | `hybrid_manager.go` | `HybridStorageManager` | Composes multiple provider instances |
 
 ## Target Layout (per ADR-003)

--- a/pkg/storage/interfaces/audit_store.go
+++ b/pkg/storage/interfaces/audit_store.go
@@ -34,6 +34,9 @@ type AuditStore interface {
 	// Retention and archival (implementation dependent)
 	ArchiveAuditEntries(ctx context.Context, beforeDate time.Time) (int64, error)
 	PurgeAuditEntries(ctx context.Context, beforeDate time.Time) (int64, error)
+
+	// Lifecycle
+	Close() error
 }
 
 // AuditEntry represents an immutable audit log entry

--- a/pkg/storage/interfaces/client_tenant.go
+++ b/pkg/storage/interfaces/client_tenant.go
@@ -22,6 +22,9 @@ type ClientTenantStore interface {
 	StoreAdminConsentRequest(request *AdminConsentRequest) error
 	GetAdminConsentRequest(state string) (*AdminConsentRequest, error)
 	DeleteAdminConsentRequest(state string) error
+
+	// Lifecycle
+	Close() error
 }
 
 // ClientTenant represents an MSP client organization

--- a/pkg/storage/interfaces/hybrid_manager_test.go
+++ b/pkg/storage/interfaces/hybrid_manager_test.go
@@ -346,6 +346,10 @@ func (p *mockProvider) CreateRegistrationTokenStore(config map[string]interface{
 	return &mockRegistrationTokenStore{}, nil
 }
 
+func (p *mockProvider) CreateSessionStore(config map[string]interface{}) (SessionStore, error) {
+	return nil, ErrNotSupported
+}
+
 func (p *mockProvider) GetCapabilities() ProviderCapabilities {
 	return ProviderCapabilities{
 		SupportsTransactions:   true,

--- a/pkg/storage/interfaces/hybrid_manager_test.go
+++ b/pkg/storage/interfaces/hybrid_manager_test.go
@@ -408,6 +408,10 @@ func (s *mockClientTenantStore) DeleteAdminConsentRequest(state string) error {
 	return nil
 }
 
+func (s *mockClientTenantStore) Close() error {
+	return nil
+}
+
 type mockConfigStore struct{}
 
 func (s *mockConfigStore) StoreConfig(ctx context.Context, config *ConfigEntry) error {
@@ -520,6 +524,10 @@ func (s *mockAuditStore) ArchiveAuditEntries(ctx context.Context, beforeDate tim
 
 func (s *mockAuditStore) PurgeAuditEntries(ctx context.Context, beforeDate time.Time) (int64, error) {
 	return 0, nil
+}
+
+func (s *mockAuditStore) Close() error {
+	return nil
 }
 
 type mockRBACStore struct{}

--- a/pkg/storage/interfaces/provider.go
+++ b/pkg/storage/interfaces/provider.go
@@ -24,6 +24,7 @@ type StorageProvider interface {
 	CreateRuntimeStore(config map[string]interface{}) (RuntimeStore, error)
 	CreateTenantStore(config map[string]interface{}) (TenantStore, error)
 	CreateRegistrationTokenStore(config map[string]interface{}) (RegistrationTokenStore, error)
+	CreateSessionStore(config map[string]interface{}) (SessionStore, error)
 
 	// Future: CreateDNAStore for DNA storage integration (Epic 6)
 	// CreateDNAStore(config map[string]interface{}) (DNAStore, error)
@@ -349,6 +350,16 @@ func CreateRegistrationTokenStoreFromConfig(providerName string, config map[stri
 	return provider.CreateRegistrationTokenStore(config)
 }
 
+// CreateSessionStoreFromConfig creates a SessionStore from configuration
+func CreateSessionStoreFromConfig(providerName string, config map[string]interface{}) (SessionStore, error) {
+	provider, err := GetStorageProvider(providerName)
+	if err != nil {
+		return nil, fmt.Errorf("storage provider '%s' not available: %w", providerName, err)
+	}
+
+	return provider.CreateSessionStore(config)
+}
+
 // CreateAllStoresFromConfig creates all storage interfaces from a single configuration
 // This is the main entry point for unified storage configuration (legacy single-backend)
 func CreateAllStoresFromConfig(providerName string, config map[string]interface{}) (*StorageManager, error) {
@@ -399,6 +410,11 @@ func CreateAllStoresFromConfig(providerName string, config map[string]interface{
 		return nil, fmt.Errorf("failed to create registration token store: %w", err)
 	}
 
+	sessionStore, err := provider.CreateSessionStore(config)
+	if err != nil && err != ErrNotSupported {
+		return nil, fmt.Errorf("failed to create session store: %w", err)
+	}
+
 	return &StorageManager{
 		providerName:           providerName,
 		provider:               provider,
@@ -409,6 +425,7 @@ func CreateAllStoresFromConfig(providerName string, config map[string]interface{
 		runtimeStore:           runtimeStore,
 		tenantStore:            tenantStore,
 		registrationTokenStore: registrationTokenStore,
+		sessionStore:           sessionStore,
 	}, nil
 }
 
@@ -423,6 +440,7 @@ type StorageManager struct {
 	runtimeStore           RuntimeStore
 	tenantStore            TenantStore
 	registrationTokenStore RegistrationTokenStore
+	sessionStore           SessionStore
 }
 
 // GetProviderName returns the name of the storage provider
@@ -468,6 +486,11 @@ func (sm *StorageManager) GetTenantStore() TenantStore {
 // GetRegistrationTokenStore returns the registration token storage interface
 func (sm *StorageManager) GetRegistrationTokenStore() RegistrationTokenStore {
 	return sm.registrationTokenStore
+}
+
+// GetSessionStore returns the session storage interface (nil if not supported by provider)
+func (sm *StorageManager) GetSessionStore() SessionStore {
+	return sm.sessionStore
 }
 
 // GetCapabilities returns the provider's capabilities

--- a/pkg/storage/interfaces/provider_test.go
+++ b/pkg/storage/interfaces/provider_test.go
@@ -90,6 +90,10 @@ func (m *MockStorageProvider) CreateRegistrationTokenStore(config map[string]int
 	return &MockRegistrationTokenStore{}, nil
 }
 
+func (m *MockStorageProvider) CreateSessionStore(config map[string]interface{}) (SessionStore, error) {
+	return nil, ErrNotSupported
+}
+
 // Mock implementations of store interfaces
 type MockClientTenantStore struct{}
 

--- a/pkg/storage/interfaces/provider_test.go
+++ b/pkg/storage/interfaces/provider_test.go
@@ -118,6 +118,7 @@ func (m *MockClientTenantStore) GetAdminConsentRequest(state string) (*AdminCons
 	return nil, ErrTenantNotFound
 }
 func (m *MockClientTenantStore) DeleteAdminConsentRequest(state string) error { return nil }
+func (m *MockClientTenantStore) Close() error                                  { return nil }
 
 type MockConfigStore struct{}
 
@@ -183,6 +184,7 @@ func (m *MockAuditStore) ArchiveAuditEntries(ctx context.Context, beforeDate tim
 func (m *MockAuditStore) PurgeAuditEntries(ctx context.Context, beforeDate time.Time) (int64, error) {
 	return 0, nil
 }
+func (m *MockAuditStore) Close() error { return nil }
 
 type MockRBACStore struct{}
 

--- a/pkg/storage/interfaces/provider_test.go
+++ b/pkg/storage/interfaces/provider_test.go
@@ -118,7 +118,7 @@ func (m *MockClientTenantStore) GetAdminConsentRequest(state string) (*AdminCons
 	return nil, ErrTenantNotFound
 }
 func (m *MockClientTenantStore) DeleteAdminConsentRequest(state string) error { return nil }
-func (m *MockClientTenantStore) Close() error                                  { return nil }
+func (m *MockClientTenantStore) Close() error                                 { return nil }
 
 type MockConfigStore struct{}
 

--- a/pkg/storage/interfaces/session_store.go
+++ b/pkg/storage/interfaces/session_store.go
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+// Package interfaces defines the SessionStore interface for durable session persistence
+package interfaces
+
+import (
+	"context"
+	"errors"
+	"time"
+)
+
+// ErrNotSupported is returned when a provider does not implement a particular store type.
+var ErrNotSupported = errors.New("operation not supported by this provider")
+
+// ErrImmutable is returned when an attempt is made to modify or delete an immutable record.
+var ErrImmutable = errors.New("record is immutable and cannot be modified or deleted")
+
+// SessionStore defines storage interface for durable session data.
+// Only sessions with Persistent=true should be written here.
+// Ephemeral sessions (Persistent=false) belong in pkg/cache and are out of scope.
+//
+// Methods from RuntimeStore that manage ephemeral runtime state
+// (SetRuntimeState, GetRuntimeState, DeleteRuntimeState, ListRuntimeKeys)
+// are intentionally absent — those belong in pkg/cache.
+type SessionStore interface {
+	// Session CRUD
+	CreateSession(ctx context.Context, session *Session) error
+	GetSession(ctx context.Context, sessionID string) (*Session, error)
+	UpdateSession(ctx context.Context, sessionID string, session *Session) error
+	DeleteSession(ctx context.Context, sessionID string) error
+	ListSessions(ctx context.Context, filters *SessionFilter) ([]*Session, error)
+
+	// Session lifecycle
+	SetSessionTTL(ctx context.Context, sessionID string, ttl time.Duration) error
+	CleanupExpiredSessions(ctx context.Context) (int, error)
+
+	// Session queries
+	GetSessionsByUser(ctx context.Context, userID string) ([]*Session, error)
+	GetSessionsByTenant(ctx context.Context, tenantID string) ([]*Session, error)
+	GetSessionsByType(ctx context.Context, sessionType SessionType) ([]*Session, error)
+	GetActiveSessionsCount(ctx context.Context) (int64, error)
+
+	// Health and diagnostics
+	HealthCheck(ctx context.Context) error
+	GetStats(ctx context.Context) (*RuntimeStoreStats, error)
+
+	// Lifecycle
+	Initialize(ctx context.Context) error
+	Close() error
+}
+
+// SessionStoreProvider is an optional extension interface that providers implement
+// when they support durable session storage.
+type SessionStoreProvider interface {
+	CreateSessionStore(config map[string]interface{}) (SessionStore, error)
+}

--- a/pkg/storage/providers/database/plugin.go
+++ b/pkg/storage/providers/database/plugin.go
@@ -180,6 +180,13 @@ func (p *DatabaseProvider) CreateTenantStore(config map[string]interface{}) (int
 	return store, nil
 }
 
+// CreateSessionStore is not supported by the database provider in this release.
+// The database provider exposes session data via CreateRuntimeStore.
+// Use the SQLite provider for SessionStore, or extend this provider in a future story.
+func (p *DatabaseProvider) CreateSessionStore(config map[string]interface{}) (interfaces.SessionStore, error) {
+	return nil, interfaces.ErrNotSupported
+}
+
 func (p *DatabaseProvider) CreateRegistrationTokenStore(config map[string]interface{}) (interfaces.RegistrationTokenStore, error) {
 	// Get database connection string from config
 	dsn, err := p.getDSN(config)

--- a/pkg/storage/providers/flatfile/audit_store.go
+++ b/pkg/storage/providers/flatfile/audit_store.go
@@ -637,6 +637,12 @@ func (s *FlatFileAuditStore) PurgeAuditEntries(ctx context.Context, beforeDate t
 	return count, nil
 }
 
+// Close satisfies interfaces.AuditStore. FlatFileAuditStore opens files
+// per-write, so there is no persistent handle to release.
+func (s *FlatFileAuditStore) Close() error {
+	return nil
+}
+
 // Helper functions for slice membership checks.
 
 func containsEventType(slice []interfaces.AuditEventType, v interfaces.AuditEventType) bool {

--- a/pkg/storage/providers/flatfile/plugin.go
+++ b/pkg/storage/providers/flatfile/plugin.go
@@ -179,6 +179,12 @@ func (p *FlatFileProvider) CreateRegistrationTokenStore(config map[string]interf
 	return nil, ErrNotSupported
 }
 
+// CreateSessionStore is not supported by the flatfile provider.
+// Use the SQLite provider for durable session storage.
+func (p *FlatFileProvider) CreateSessionStore(config map[string]interface{}) (interfaces.SessionStore, error) {
+	return nil, ErrNotSupported
+}
+
 // init auto-registers the flat-file provider so that a blank import is sufficient.
 func init() {
 	interfaces.RegisterStorageProvider(&FlatFileProvider{})

--- a/pkg/storage/providers/git/audit_store.go
+++ b/pkg/storage/providers/git/audit_store.go
@@ -757,3 +757,8 @@ func (s *GitAuditStore) SetRemoteURL(remoteURL string) error {
 
 	return nil
 }
+
+// Close is a no-op for the git-based audit store (no persistent connections to release).
+func (s *GitAuditStore) Close() error {
+	return nil
+}

--- a/pkg/storage/providers/git/client_tenant_store.go
+++ b/pkg/storage/providers/git/client_tenant_store.go
@@ -163,3 +163,8 @@ func (s *GitClientTenantStore) DeleteAdminConsentRequest(state string) error {
 	delete(s.storage.requests, state)
 	return nil
 }
+
+// Close is a no-op for the git-based client tenant store (no persistent connections to release).
+func (s *GitClientTenantStore) Close() error {
+	return nil
+}

--- a/pkg/storage/providers/git/plugin.go
+++ b/pkg/storage/providers/git/plugin.go
@@ -210,6 +210,12 @@ func (p *GitProvider) CreateRegistrationTokenStore(config map[string]interface{}
 	return store, nil
 }
 
+// CreateSessionStore is not supported by the git provider.
+// Use the SQLite provider for durable session storage.
+func (p *GitProvider) CreateSessionStore(config map[string]interface{}) (interfaces.SessionStore, error) {
+	return nil, interfaces.ErrNotSupported
+}
+
 // Auto-register this provider (Salt-style)
 func init() {
 	interfaces.RegisterStorageProvider(&GitProvider{})

--- a/pkg/storage/providers/sqlite/audit_store.go
+++ b/pkg/storage/providers/sqlite/audit_store.go
@@ -487,7 +487,8 @@ func populateAuditEntry(e *interfaces.AuditEntry, tsStr, detailsStr, changesStr,
 
 func computeChecksum(entry *interfaces.AuditEntry) string {
 	h := sha256.New()
-	fmt.Fprintf(h, "%s|%s|%s|%s|%s|%s",
+	// sha256.Hash.Write never returns an error; the return values are intentionally ignored.
+	_, _ = fmt.Fprintf(h, "%s|%s|%s|%s|%s|%s",
 		entry.ID, entry.TenantID, entry.Timestamp.UTC().Format(time.RFC3339Nano),
 		entry.Action, entry.UserID, entry.ResourceID)
 	return hex.EncodeToString(h.Sum(nil))

--- a/pkg/storage/providers/sqlite/audit_store.go
+++ b/pkg/storage/providers/sqlite/audit_store.go
@@ -1,0 +1,492 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+// Package sqlite implements AuditStore using SQLite (append-only)
+package sqlite
+
+import (
+	"context"
+	"crypto/sha256"
+	"database/sql"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/cfgis/cfgms/pkg/storage/interfaces"
+)
+
+// SQLiteAuditStore implements interfaces.AuditStore using SQLite.
+// Entries are append-only: StoreAuditEntry returns ErrImmutable if an entry with the
+// same ID already exists. ArchiveAuditEntries and PurgeAuditEntries both return
+// ErrImmutable to enforce the immutability contract at the SQLite tier.
+type SQLiteAuditStore struct {
+	db *sql.DB
+}
+
+// StoreAuditEntry appends a single audit entry. The entry's checksum is computed and
+// set here if empty. Returns ErrImmutable if an entry with that ID already exists.
+func (s *SQLiteAuditStore) StoreAuditEntry(ctx context.Context, entry *interfaces.AuditEntry) error {
+	if entry == nil {
+		return fmt.Errorf("audit entry cannot be nil")
+	}
+	if entry.ID == "" {
+		return fmt.Errorf("audit entry ID cannot be empty")
+	}
+
+	if entry.Checksum == "" {
+		entry.Checksum = computeChecksum(entry)
+	}
+
+	details, err := marshalJSON(entry.Details)
+	if err != nil {
+		return fmt.Errorf("failed to marshal details: %w", err)
+	}
+	changesJSON := "{}"
+	if entry.Changes != nil {
+		b, err := json.Marshal(entry.Changes)
+		if err != nil {
+			return fmt.Errorf("failed to marshal changes: %w", err)
+		}
+		changesJSON = string(b)
+	}
+	tags, err := marshalJSONSlice(entry.Tags)
+	if err != nil {
+		return fmt.Errorf("failed to marshal tags: %w", err)
+	}
+
+	_, err = s.db.ExecContext(ctx, `
+		INSERT INTO audit_entries
+			(id, tenant_id, timestamp, event_type, action, user_id, user_type, session_id,
+			 resource_type, resource_id, resource_name, result, error_code, error_message,
+			 request_id, ip_address, user_agent, method, path,
+			 details, changes, tags, severity, source, version, checksum)
+		VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`,
+		entry.ID,
+		entry.TenantID,
+		formatTime(entry.Timestamp),
+		string(entry.EventType),
+		entry.Action,
+		entry.UserID,
+		string(entry.UserType),
+		entry.SessionID,
+		entry.ResourceType,
+		entry.ResourceID,
+		entry.ResourceName,
+		string(entry.Result),
+		entry.ErrorCode,
+		entry.ErrorMessage,
+		entry.RequestID,
+		entry.IPAddress,
+		entry.UserAgent,
+		entry.Method,
+		entry.Path,
+		details,
+		changesJSON,
+		tags,
+		string(entry.Severity),
+		entry.Source,
+		entry.Version,
+		entry.Checksum,
+	)
+	if err != nil {
+		if strings.Contains(err.Error(), "UNIQUE constraint failed") {
+			return interfaces.ErrImmutable
+		}
+		return fmt.Errorf("failed to store audit entry %s: %w", entry.ID, err)
+	}
+	return nil
+}
+
+// GetAuditEntry retrieves a single audit entry by ID.
+func (s *SQLiteAuditStore) GetAuditEntry(ctx context.Context, id string) (*interfaces.AuditEntry, error) {
+	row := s.db.QueryRowContext(ctx, `
+		SELECT id, tenant_id, timestamp, event_type, action, user_id, user_type, session_id,
+		       resource_type, resource_id, resource_name, result, error_code, error_message,
+		       request_id, ip_address, user_agent, method, path,
+		       details, changes, tags, severity, source, version, checksum
+		FROM audit_entries WHERE id = ?`, id)
+	return scanAuditEntry(row)
+}
+
+// ListAuditEntries returns audit entries matching the filter.
+func (s *SQLiteAuditStore) ListAuditEntries(ctx context.Context, filter *interfaces.AuditFilter) ([]*interfaces.AuditEntry, error) {
+	query, args := buildAuditQuery(filter)
+	rows, err := s.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list audit entries: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var entries []*interfaces.AuditEntry
+	for rows.Next() {
+		e, err := scanAuditRow(rows)
+		if err != nil {
+			return nil, err
+		}
+		entries = append(entries, e)
+	}
+	return entries, rows.Err()
+}
+
+// StoreAuditBatch appends multiple entries in a single transaction.
+func (s *SQLiteAuditStore) StoreAuditBatch(ctx context.Context, entries []*interfaces.AuditEntry) error {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("failed to begin transaction: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	for _, e := range entries {
+		if err := s.storeAuditEntryTx(ctx, tx, e); err != nil {
+			return err
+		}
+	}
+	return tx.Commit()
+}
+
+// GetAuditsByUser returns audit entries for a specific user within an optional time range.
+func (s *SQLiteAuditStore) GetAuditsByUser(ctx context.Context, userID string, timeRange *interfaces.TimeRange) ([]*interfaces.AuditEntry, error) {
+	return s.ListAuditEntries(ctx, &interfaces.AuditFilter{
+		UserIDs:   []string{userID},
+		TimeRange: timeRange,
+	})
+}
+
+// GetAuditsByResource returns audit entries for a specific resource.
+func (s *SQLiteAuditStore) GetAuditsByResource(ctx context.Context, resourceType, resourceID string, timeRange *interfaces.TimeRange) ([]*interfaces.AuditEntry, error) {
+	return s.ListAuditEntries(ctx, &interfaces.AuditFilter{
+		ResourceTypes: []string{resourceType},
+		ResourceIDs:   []string{resourceID},
+		TimeRange:     timeRange,
+	})
+}
+
+// GetAuditsByAction returns audit entries for a specific action.
+func (s *SQLiteAuditStore) GetAuditsByAction(ctx context.Context, action string, timeRange *interfaces.TimeRange) ([]*interfaces.AuditEntry, error) {
+	return s.ListAuditEntries(ctx, &interfaces.AuditFilter{
+		Actions:   []string{action},
+		TimeRange: timeRange,
+	})
+}
+
+// GetFailedActions returns the most recent failed audit entries.
+func (s *SQLiteAuditStore) GetFailedActions(ctx context.Context, timeRange *interfaces.TimeRange, limit int) ([]*interfaces.AuditEntry, error) {
+	return s.ListAuditEntries(ctx, &interfaces.AuditFilter{
+		Results:   []interfaces.AuditResult{interfaces.AuditResultFailure, interfaces.AuditResultError, interfaces.AuditResultDenied},
+		TimeRange: timeRange,
+		Limit:     limit,
+	})
+}
+
+// GetSuspiciousActivity returns high/critical severity security events for a tenant.
+func (s *SQLiteAuditStore) GetSuspiciousActivity(ctx context.Context, tenantID string, timeRange *interfaces.TimeRange) ([]*interfaces.AuditEntry, error) {
+	return s.ListAuditEntries(ctx, &interfaces.AuditFilter{
+		TenantID:   tenantID,
+		EventTypes: []interfaces.AuditEventType{interfaces.AuditEventSecurityEvent},
+		Severities: []interfaces.AuditSeverity{interfaces.AuditSeverityHigh, interfaces.AuditSeverityCritical},
+		TimeRange:  timeRange,
+	})
+}
+
+// GetAuditStats returns aggregate statistics about stored audit entries.
+func (s *SQLiteAuditStore) GetAuditStats(ctx context.Context) (*interfaces.AuditStats, error) {
+	stats := &interfaces.AuditStats{
+		EntriesByTenant:   make(map[string]int64),
+		EntriesByType:     make(map[string]int64),
+		EntriesByResult:   make(map[string]int64),
+		EntriesBySeverity: make(map[string]int64),
+		LastUpdated:       nowUTC(),
+	}
+
+	if err := s.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM audit_entries`).Scan(&stats.TotalEntries); err != nil {
+		return nil, fmt.Errorf("failed to count audit entries: %w", err)
+	}
+
+	rows, err := s.db.QueryContext(ctx, `SELECT event_type, COUNT(*) FROM audit_entries GROUP BY event_type`)
+	if err != nil {
+		return nil, fmt.Errorf("failed to aggregate by event_type: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	for rows.Next() {
+		var k string
+		var v int64
+		if err := rows.Scan(&k, &v); err == nil {
+			stats.EntriesByType[k] = v
+		}
+	}
+
+	rows2, err := s.db.QueryContext(ctx, `SELECT result, COUNT(*) FROM audit_entries GROUP BY result`)
+	if err != nil {
+		return nil, fmt.Errorf("failed to aggregate by result: %w", err)
+	}
+	defer func() { _ = rows2.Close() }()
+	for rows2.Next() {
+		var k string
+		var v int64
+		if err := rows2.Scan(&k, &v); err == nil {
+			stats.EntriesByResult[k] = v
+		}
+	}
+
+	rows3, err := s.db.QueryContext(ctx, `SELECT severity, COUNT(*) FROM audit_entries GROUP BY severity`)
+	if err != nil {
+		return nil, fmt.Errorf("failed to aggregate by severity: %w", err)
+	}
+	defer func() { _ = rows3.Close() }()
+	for rows3.Next() {
+		var k string
+		var v int64
+		if err := rows3.Scan(&k, &v); err == nil {
+			stats.EntriesBySeverity[k] = v
+		}
+	}
+
+	return stats, nil
+}
+
+// ArchiveAuditEntries returns ErrImmutable — audit entries are immutable at this tier.
+func (s *SQLiteAuditStore) ArchiveAuditEntries(_ context.Context, _ time.Time) (int64, error) {
+	return 0, interfaces.ErrImmutable
+}
+
+// PurgeAuditEntries returns ErrImmutable — audit entries are immutable at this tier.
+func (s *SQLiteAuditStore) PurgeAuditEntries(_ context.Context, _ time.Time) (int64, error) {
+	return 0, interfaces.ErrImmutable
+}
+
+// ---- helpers ----------------------------------------------------------------
+
+func (s *SQLiteAuditStore) storeAuditEntryTx(ctx context.Context, tx *sql.Tx, entry *interfaces.AuditEntry) error {
+	if entry.Checksum == "" {
+		entry.Checksum = computeChecksum(entry)
+	}
+	details, err := marshalJSON(entry.Details)
+	if err != nil {
+		return fmt.Errorf("audit: failed to marshal details: %w", err)
+	}
+	changesJSON := "{}"
+	if entry.Changes != nil {
+		b, err := json.Marshal(entry.Changes)
+		if err != nil {
+			return fmt.Errorf("audit: failed to marshal changes: %w", err)
+		}
+		changesJSON = string(b)
+	}
+	tags, err := marshalJSONSlice(entry.Tags)
+	if err != nil {
+		return fmt.Errorf("audit: failed to marshal tags: %w", err)
+	}
+
+	_, err = tx.ExecContext(ctx, `
+		INSERT INTO audit_entries
+			(id, tenant_id, timestamp, event_type, action, user_id, user_type, session_id,
+			 resource_type, resource_id, resource_name, result, error_code, error_message,
+			 request_id, ip_address, user_agent, method, path,
+			 details, changes, tags, severity, source, version, checksum)
+		VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`,
+		entry.ID, entry.TenantID, formatTime(entry.Timestamp),
+		string(entry.EventType), entry.Action, entry.UserID, string(entry.UserType), entry.SessionID,
+		entry.ResourceType, entry.ResourceID, entry.ResourceName,
+		string(entry.Result), entry.ErrorCode, entry.ErrorMessage,
+		entry.RequestID, entry.IPAddress, entry.UserAgent, entry.Method, entry.Path,
+		details, changesJSON, tags,
+		string(entry.Severity), entry.Source, entry.Version, entry.Checksum,
+	)
+	if err != nil {
+		if strings.Contains(err.Error(), "UNIQUE constraint failed") {
+			return interfaces.ErrImmutable
+		}
+		return fmt.Errorf("failed to store audit entry %s in batch: %w", entry.ID, err)
+	}
+	return nil
+}
+
+func buildAuditQuery(filter *interfaces.AuditFilter) (string, []interface{}) {
+	base := `SELECT id, tenant_id, timestamp, event_type, action, user_id, user_type, session_id,
+	                resource_type, resource_id, resource_name, result, error_code, error_message,
+	                request_id, ip_address, user_agent, method, path,
+	                details, changes, tags, severity, source, version, checksum
+	         FROM audit_entries`
+
+	if filter == nil {
+		return base + ` ORDER BY timestamp DESC`, nil
+	}
+
+	var conditions []string
+	var args []interface{}
+
+	if filter.TenantID != "" {
+		conditions = append(conditions, `tenant_id = ?`)
+		args = append(args, filter.TenantID)
+	}
+	if len(filter.EventTypes) > 0 {
+		ps := make([]string, len(filter.EventTypes))
+		for i, et := range filter.EventTypes {
+			ps[i] = "?"
+			args = append(args, string(et))
+		}
+		conditions = append(conditions, `event_type IN (`+strings.Join(ps, ",")+`)`)
+	}
+	if len(filter.Actions) > 0 {
+		ps := make([]string, len(filter.Actions))
+		for i, a := range filter.Actions {
+			ps[i] = "?"
+			args = append(args, a)
+		}
+		conditions = append(conditions, `action IN (`+strings.Join(ps, ",")+`)`)
+	}
+	if len(filter.UserIDs) > 0 {
+		ps := make([]string, len(filter.UserIDs))
+		for i, u := range filter.UserIDs {
+			ps[i] = "?"
+			args = append(args, u)
+		}
+		conditions = append(conditions, `user_id IN (`+strings.Join(ps, ",")+`)`)
+	}
+	if len(filter.Results) > 0 {
+		ps := make([]string, len(filter.Results))
+		for i, r := range filter.Results {
+			ps[i] = "?"
+			args = append(args, string(r))
+		}
+		conditions = append(conditions, `result IN (`+strings.Join(ps, ",")+`)`)
+	}
+	if len(filter.Severities) > 0 {
+		ps := make([]string, len(filter.Severities))
+		for i, sv := range filter.Severities {
+			ps[i] = "?"
+			args = append(args, string(sv))
+		}
+		conditions = append(conditions, `severity IN (`+strings.Join(ps, ",")+`)`)
+	}
+	if len(filter.ResourceTypes) > 0 {
+		ps := make([]string, len(filter.ResourceTypes))
+		for i, rt := range filter.ResourceTypes {
+			ps[i] = "?"
+			args = append(args, rt)
+		}
+		conditions = append(conditions, `resource_type IN (`+strings.Join(ps, ",")+`)`)
+	}
+	if len(filter.ResourceIDs) > 0 {
+		ps := make([]string, len(filter.ResourceIDs))
+		for i, ri := range filter.ResourceIDs {
+			ps[i] = "?"
+			args = append(args, ri)
+		}
+		conditions = append(conditions, `resource_id IN (`+strings.Join(ps, ",")+`)`)
+	}
+	if filter.TimeRange != nil {
+		if filter.TimeRange.Start != nil {
+			conditions = append(conditions, `timestamp >= ?`)
+			args = append(args, formatTime(*filter.TimeRange.Start))
+		}
+		if filter.TimeRange.End != nil {
+			conditions = append(conditions, `timestamp <= ?`)
+			args = append(args, formatTime(*filter.TimeRange.End))
+		}
+	}
+
+	query := base
+	if len(conditions) > 0 {
+		query += ` WHERE ` + strings.Join(conditions, ` AND `)
+	}
+
+	sortCol := "timestamp"
+	switch filter.SortBy {
+	case "severity":
+		sortCol = "severity"
+	case "user_id":
+		sortCol = "user_id"
+	}
+	order := "DESC"
+	if filter.Order == "asc" {
+		order = "ASC"
+	}
+	query += fmt.Sprintf(` ORDER BY %s %s`, sortCol, order)
+
+	if filter.Limit > 0 {
+		query += fmt.Sprintf(` LIMIT %d`, filter.Limit)
+	}
+	if filter.Offset > 0 {
+		query += fmt.Sprintf(` OFFSET %d`, filter.Offset)
+	}
+
+	return query, args
+}
+
+func scanAuditEntry(row *sql.Row) (*interfaces.AuditEntry, error) {
+	e := &interfaces.AuditEntry{}
+	var tsStr, detailsStr, changesStr, tagsStr string
+
+	err := row.Scan(
+		&e.ID, &e.TenantID, &tsStr,
+		&e.EventType, &e.Action, &e.UserID, &e.UserType, &e.SessionID,
+		&e.ResourceType, &e.ResourceID, &e.ResourceName,
+		&e.Result, &e.ErrorCode, &e.ErrorMessage,
+		&e.RequestID, &e.IPAddress, &e.UserAgent, &e.Method, &e.Path,
+		&detailsStr, &changesStr, &tagsStr,
+		&e.Severity, &e.Source, &e.Version, &e.Checksum,
+	)
+	if err == sql.ErrNoRows {
+		return nil, fmt.Errorf("audit entry not found")
+	}
+	if err != nil {
+		return nil, fmt.Errorf("failed to scan audit entry: %w", err)
+	}
+	return populateAuditEntry(e, tsStr, detailsStr, changesStr, tagsStr)
+}
+
+func scanAuditRow(rows *sql.Rows) (*interfaces.AuditEntry, error) {
+	e := &interfaces.AuditEntry{}
+	var tsStr, detailsStr, changesStr, tagsStr string
+
+	if err := rows.Scan(
+		&e.ID, &e.TenantID, &tsStr,
+		&e.EventType, &e.Action, &e.UserID, &e.UserType, &e.SessionID,
+		&e.ResourceType, &e.ResourceID, &e.ResourceName,
+		&e.Result, &e.ErrorCode, &e.ErrorMessage,
+		&e.RequestID, &e.IPAddress, &e.UserAgent, &e.Method, &e.Path,
+		&detailsStr, &changesStr, &tagsStr,
+		&e.Severity, &e.Source, &e.Version, &e.Checksum,
+	); err != nil {
+		return nil, fmt.Errorf("failed to scan audit row: %w", err)
+	}
+	return populateAuditEntry(e, tsStr, detailsStr, changesStr, tagsStr)
+}
+
+func populateAuditEntry(e *interfaces.AuditEntry, tsStr, detailsStr, changesStr, tagsStr string) (*interfaces.AuditEntry, error) {
+	e.Timestamp = parseTime(tsStr)
+
+	details, err := unmarshalJSONMap(detailsStr)
+	if err != nil {
+		return nil, fmt.Errorf("failed to unmarshal audit entry details: %w", err)
+	}
+	e.Details = details
+
+	if changesStr != "" && changesStr != "{}" {
+		var changes interfaces.AuditChanges
+		if err := json.Unmarshal([]byte(changesStr), &changes); err == nil {
+			e.Changes = &changes
+		}
+	}
+
+	tags, err := unmarshalJSONSlice(tagsStr)
+	if err != nil {
+		return nil, fmt.Errorf("failed to unmarshal audit entry tags: %w", err)
+	}
+	e.Tags = tags
+
+	return e, nil
+}
+
+func computeChecksum(entry *interfaces.AuditEntry) string {
+	h := sha256.New()
+	fmt.Fprintf(h, "%s|%s|%s|%s|%s|%s",
+		entry.ID, entry.TenantID, entry.Timestamp.UTC().Format(time.RFC3339Nano),
+		entry.Action, entry.UserID, entry.ResourceID)
+	return hex.EncodeToString(h.Sum(nil))
+}
+
+// ensure SQLiteAuditStore satisfies the interface at compile time
+var _ interfaces.AuditStore = (*SQLiteAuditStore)(nil)

--- a/pkg/storage/providers/sqlite/audit_store.go
+++ b/pkg/storage/providers/sqlite/audit_store.go
@@ -245,6 +245,11 @@ func (s *SQLiteAuditStore) GetAuditStats(ctx context.Context) (*interfaces.Audit
 	return stats, nil
 }
 
+// Close releases the underlying database connection.
+func (s *SQLiteAuditStore) Close() error {
+	return s.db.Close()
+}
+
 // ArchiveAuditEntries returns ErrImmutable — audit entries are immutable at this tier.
 func (s *SQLiteAuditStore) ArchiveAuditEntries(_ context.Context, _ time.Time) (int64, error) {
 	return 0, interfaces.ErrImmutable

--- a/pkg/storage/providers/sqlite/audit_store_test.go
+++ b/pkg/storage/providers/sqlite/audit_store_test.go
@@ -21,6 +21,7 @@ func newAuditStore(t *testing.T) interfaces.AuditStore {
 	p := sqlite.NewSQLiteProvider(dir)
 	store, err := p.CreateAuditStore(map[string]interface{}{"path": filepath.Join(dir, "audit.db")})
 	require.NoError(t, err)
+	t.Cleanup(func() { _ = store.Close() })
 	return store
 }
 

--- a/pkg/storage/providers/sqlite/audit_store_test.go
+++ b/pkg/storage/providers/sqlite/audit_store_test.go
@@ -1,0 +1,179 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+package sqlite_test
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cfgis/cfgms/pkg/storage/interfaces"
+	"github.com/cfgis/cfgms/pkg/storage/providers/sqlite"
+)
+
+func newAuditStore(t *testing.T) interfaces.AuditStore {
+	t.Helper()
+	dir := t.TempDir()
+	p := sqlite.NewSQLiteProvider(dir)
+	store, err := p.CreateAuditStore(map[string]interface{}{"path": filepath.Join(dir, "audit.db")})
+	require.NoError(t, err)
+	return store
+}
+
+func sampleAuditEntry(id string) *interfaces.AuditEntry {
+	return &interfaces.AuditEntry{
+		ID:           id,
+		TenantID:     "tenant-audit",
+		Timestamp:    time.Now().UTC().Truncate(time.Millisecond),
+		EventType:    interfaces.AuditEventAuthentication,
+		Action:       "login",
+		UserID:       "user-1",
+		UserType:     interfaces.AuditUserTypeHuman,
+		ResourceType: "session",
+		ResourceID:   "sess-1",
+		Result:       interfaces.AuditResultSuccess,
+		Severity:     interfaces.AuditSeverityLow,
+		Source:       "controller",
+		Checksum:     "",
+	}
+}
+
+func TestAuditStore_StoreAndGet(t *testing.T) {
+	store := newAuditStore(t)
+	ctx := context.Background()
+
+	entry := sampleAuditEntry("audit-001")
+	require.NoError(t, store.StoreAuditEntry(ctx, entry))
+
+	got, err := store.GetAuditEntry(ctx, "audit-001")
+	require.NoError(t, err)
+	assert.Equal(t, entry.ID, got.ID)
+	assert.Equal(t, entry.TenantID, got.TenantID)
+	assert.Equal(t, entry.Action, got.Action)
+	assert.Equal(t, entry.Result, got.Result)
+	assert.NotEmpty(t, got.Checksum, "checksum must be auto-computed")
+}
+
+func TestAuditStore_GetNotFound(t *testing.T) {
+	store := newAuditStore(t)
+	ctx := context.Background()
+	_, err := store.GetAuditEntry(ctx, "nonexistent")
+	assert.Error(t, err)
+}
+
+func TestAuditStore_Immutability(t *testing.T) {
+	store := newAuditStore(t)
+	ctx := context.Background()
+
+	entry := sampleAuditEntry("audit-immutable")
+	require.NoError(t, store.StoreAuditEntry(ctx, entry))
+
+	// Attempting to store the same ID again must return ErrImmutable
+	err := store.StoreAuditEntry(ctx, sampleAuditEntry("audit-immutable"))
+	assert.ErrorIs(t, err, interfaces.ErrImmutable)
+}
+
+func TestAuditStore_ArchivePurgeReturnImmutable(t *testing.T) {
+	store := newAuditStore(t)
+	ctx := context.Background()
+
+	_, err := store.ArchiveAuditEntries(ctx, time.Now())
+	assert.ErrorIs(t, err, interfaces.ErrImmutable)
+
+	_, err = store.PurgeAuditEntries(ctx, time.Now())
+	assert.ErrorIs(t, err, interfaces.ErrImmutable)
+}
+
+func TestAuditStore_ListByTimeRange(t *testing.T) {
+	store := newAuditStore(t)
+	ctx := context.Background()
+
+	base := time.Now().UTC()
+	for i, ts := range []time.Time{
+		base.Add(-3 * time.Hour),
+		base.Add(-2 * time.Hour),
+		base.Add(-1 * time.Hour),
+		base.Add(0),
+	} {
+		e := sampleAuditEntry(string(rune('a' + i)))
+		e.Timestamp = ts
+		require.NoError(t, store.StoreAuditEntry(ctx, e))
+	}
+
+	start := base.Add(-2*time.Hour - 1*time.Minute)
+	end := base.Add(-30 * time.Minute)
+	results, err := store.ListAuditEntries(ctx, &interfaces.AuditFilter{
+		TimeRange: &interfaces.TimeRange{Start: &start, End: &end},
+	})
+	require.NoError(t, err)
+	// Should include entries at -2h and -1h
+	assert.Len(t, results, 2)
+}
+
+func TestAuditStore_Batch(t *testing.T) {
+	store := newAuditStore(t)
+	ctx := context.Background()
+
+	entries := []*interfaces.AuditEntry{
+		sampleAuditEntry("batch-1"),
+		sampleAuditEntry("batch-2"),
+		sampleAuditEntry("batch-3"),
+	}
+	require.NoError(t, store.StoreAuditBatch(ctx, entries))
+
+	all, err := store.ListAuditEntries(ctx, nil)
+	require.NoError(t, err)
+	assert.Len(t, all, 3)
+}
+
+func TestAuditStore_GetAuditsByUser(t *testing.T) {
+	store := newAuditStore(t)
+	ctx := context.Background()
+
+	e1 := sampleAuditEntry("u-1")
+	e1.UserID = "alice"
+	e2 := sampleAuditEntry("u-2")
+	e2.UserID = "bob"
+	require.NoError(t, store.StoreAuditEntry(ctx, e1))
+	require.NoError(t, store.StoreAuditEntry(ctx, e2))
+
+	results, err := store.GetAuditsByUser(ctx, "alice", nil)
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	assert.Equal(t, "alice", results[0].UserID)
+}
+
+func TestAuditStore_GetStats(t *testing.T) {
+	store := newAuditStore(t)
+	ctx := context.Background()
+
+	for i := 0; i < 5; i++ {
+		e := sampleAuditEntry(string(rune('0' + i)))
+		require.NoError(t, store.StoreAuditEntry(ctx, e))
+	}
+
+	stats, err := store.GetAuditStats(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, int64(5), stats.TotalEntries)
+}
+
+func TestAuditStore_GetFailedActions(t *testing.T) {
+	store := newAuditStore(t)
+	ctx := context.Background()
+
+	ok := sampleAuditEntry("ok-1")
+	fail := sampleAuditEntry("fail-1")
+	fail.Result = interfaces.AuditResultFailure
+
+	require.NoError(t, store.StoreAuditEntry(ctx, ok))
+	require.NoError(t, store.StoreAuditEntry(ctx, fail))
+
+	results, err := store.GetFailedActions(ctx, nil, 10)
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	assert.Equal(t, interfaces.AuditResultFailure, results[0].Result)
+}

--- a/pkg/storage/providers/sqlite/client_tenant_store.go
+++ b/pkg/storage/providers/sqlite/client_tenant_store.go
@@ -286,7 +286,7 @@ func (s *SQLiteClientTenantStore) DeleteAdminConsentRequest(state string) error 
 func scanClientTenant(row *sql.Row) (*interfaces.ClientTenant, error) {
 	c := &interfaces.ClientTenant{}
 	var (
-		statusStr, consentedStr, createdStr, updatedStr, metaStr string
+		statusStr, consentedStr, createdStr, updatedStr, metaStr  string
 		m365TenantID, m365AdminEmail, m365ConsentedAt, m365Status sql.NullString
 	)
 	err := row.Scan(
@@ -308,7 +308,7 @@ func scanClientTenant(row *sql.Row) (*interfaces.ClientTenant, error) {
 func scanClientTenantRow(rows *sql.Rows) (*interfaces.ClientTenant, error) {
 	c := &interfaces.ClientTenant{}
 	var (
-		statusStr, consentedStr, createdStr, updatedStr, metaStr string
+		statusStr, consentedStr, createdStr, updatedStr, metaStr  string
 		m365TenantID, m365AdminEmail, m365ConsentedAt, m365Status sql.NullString
 	)
 	err := rows.Scan(

--- a/pkg/storage/providers/sqlite/client_tenant_store.go
+++ b/pkg/storage/providers/sqlite/client_tenant_store.go
@@ -1,0 +1,369 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+// Package sqlite implements ClientTenantStore using SQLite
+package sqlite
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"time"
+
+	"github.com/cfgis/cfgms/pkg/storage/interfaces"
+)
+
+// SQLiteClientTenantStore implements interfaces.ClientTenantStore using SQLite.
+// It includes nullable M365 extension columns to round-trip M365 consent fields
+// without requiring the separate M365ClientTenantStore interface (ADR-003 §2).
+type SQLiteClientTenantStore struct {
+	db *sql.DB
+}
+
+// StoreClientTenant inserts or replaces a client tenant record.
+func (s *SQLiteClientTenantStore) StoreClientTenant(client *interfaces.ClientTenant) error {
+	if client == nil {
+		return fmt.Errorf("client tenant cannot be nil")
+	}
+
+	now := nowUTC()
+	if client.CreatedAt.IsZero() {
+		client.CreatedAt = now
+	}
+	client.UpdatedAt = now
+	if client.ID == "" {
+		client.ID = client.TenantID
+	}
+
+	meta, err := marshalJSON(client.Metadata)
+	if err != nil {
+		return fmt.Errorf("failed to marshal metadata: %w", err)
+	}
+
+	// Extract M365 extension fields from Metadata if present
+	var m365TenantID, m365AdminEmail, m365ConsentedAt, m365Status sql.NullString
+	if client.Metadata != nil {
+		if v, ok := client.Metadata["m365_tenant_id"].(string); ok {
+			m365TenantID = nullString(v)
+		}
+		if v, ok := client.Metadata["m365_admin_email"].(string); ok {
+			m365AdminEmail = nullString(v)
+		}
+		if v, ok := client.Metadata["m365_consented_at"].(string); ok {
+			m365ConsentedAt = nullString(v)
+		}
+		if v, ok := client.Metadata["m365_status"].(string); ok {
+			m365Status = nullString(v)
+		}
+	}
+
+	ctx := context.Background()
+	_, err = s.db.ExecContext(ctx, `
+		INSERT INTO client_tenants
+			(id, tenant_id, tenant_name, domain_name, admin_email, consented_at,
+			 status, client_identifier, metadata,
+			 m365_tenant_id, m365_admin_email, m365_consented_at, m365_status,
+			 created_at, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		ON CONFLICT(tenant_id) DO UPDATE SET
+			tenant_name       = excluded.tenant_name,
+			domain_name       = excluded.domain_name,
+			admin_email       = excluded.admin_email,
+			consented_at      = excluded.consented_at,
+			status            = excluded.status,
+			client_identifier = excluded.client_identifier,
+			metadata          = excluded.metadata,
+			m365_tenant_id    = excluded.m365_tenant_id,
+			m365_admin_email  = excluded.m365_admin_email,
+			m365_consented_at = excluded.m365_consented_at,
+			m365_status       = excluded.m365_status,
+			updated_at        = excluded.updated_at`,
+		client.ID,
+		client.TenantID,
+		client.TenantName,
+		client.DomainName,
+		client.AdminEmail,
+		formatTime(client.ConsentedAt),
+		string(client.Status),
+		client.ClientIdentifier,
+		meta,
+		m365TenantID,
+		m365AdminEmail,
+		m365ConsentedAt,
+		m365Status,
+		formatTime(client.CreatedAt),
+		formatTime(client.UpdatedAt),
+	)
+	if err != nil {
+		return fmt.Errorf("failed to store client tenant %s: %w", client.TenantID, err)
+	}
+	return nil
+}
+
+// GetClientTenant retrieves a client tenant by Azure AD tenant ID.
+func (s *SQLiteClientTenantStore) GetClientTenant(tenantID string) (*interfaces.ClientTenant, error) {
+	ctx := context.Background()
+	row := s.db.QueryRowContext(ctx, `
+		SELECT id, tenant_id, tenant_name, domain_name, admin_email, consented_at,
+		       status, client_identifier, metadata,
+		       m365_tenant_id, m365_admin_email, m365_consented_at, m365_status,
+		       created_at, updated_at
+		FROM client_tenants WHERE tenant_id = ?`, tenantID)
+	return scanClientTenant(row)
+}
+
+// GetClientTenantByIdentifier retrieves a client tenant by its CFGMS internal identifier.
+func (s *SQLiteClientTenantStore) GetClientTenantByIdentifier(clientIdentifier string) (*interfaces.ClientTenant, error) {
+	ctx := context.Background()
+	row := s.db.QueryRowContext(ctx, `
+		SELECT id, tenant_id, tenant_name, domain_name, admin_email, consented_at,
+		       status, client_identifier, metadata,
+		       m365_tenant_id, m365_admin_email, m365_consented_at, m365_status,
+		       created_at, updated_at
+		FROM client_tenants WHERE client_identifier = ?`, clientIdentifier)
+	return scanClientTenant(row)
+}
+
+// ListClientTenants returns all client tenants, optionally filtered by status.
+func (s *SQLiteClientTenantStore) ListClientTenants(status interfaces.ClientTenantStatus) ([]*interfaces.ClientTenant, error) {
+	ctx := context.Background()
+
+	var (
+		rows *sql.Rows
+		err  error
+	)
+	if status == "" {
+		rows, err = s.db.QueryContext(ctx, `
+			SELECT id, tenant_id, tenant_name, domain_name, admin_email, consented_at,
+			       status, client_identifier, metadata,
+			       m365_tenant_id, m365_admin_email, m365_consented_at, m365_status,
+			       created_at, updated_at
+			FROM client_tenants ORDER BY created_at DESC`)
+	} else {
+		rows, err = s.db.QueryContext(ctx, `
+			SELECT id, tenant_id, tenant_name, domain_name, admin_email, consented_at,
+			       status, client_identifier, metadata,
+			       m365_tenant_id, m365_admin_email, m365_consented_at, m365_status,
+			       created_at, updated_at
+			FROM client_tenants WHERE status = ? ORDER BY created_at DESC`, string(status))
+	}
+	if err != nil {
+		return nil, fmt.Errorf("failed to list client tenants: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var clients []*interfaces.ClientTenant
+	for rows.Next() {
+		c, err := scanClientTenantRow(rows)
+		if err != nil {
+			return nil, err
+		}
+		clients = append(clients, c)
+	}
+	return clients, rows.Err()
+}
+
+// UpdateClientTenantStatus updates only the status and updated_at fields of a client tenant.
+func (s *SQLiteClientTenantStore) UpdateClientTenantStatus(tenantID string, status interfaces.ClientTenantStatus) error {
+	ctx := context.Background()
+	res, err := s.db.ExecContext(ctx, `
+		UPDATE client_tenants SET status = ?, updated_at = ? WHERE tenant_id = ?`,
+		string(status), formatTime(nowUTC()), tenantID)
+	if err != nil {
+		return fmt.Errorf("failed to update client tenant status: %w", err)
+	}
+	n, _ := res.RowsAffected()
+	if n == 0 {
+		return fmt.Errorf("client tenant %s not found", tenantID)
+	}
+	return nil
+}
+
+// DeleteClientTenant removes a client tenant by Azure AD tenant ID.
+func (s *SQLiteClientTenantStore) DeleteClientTenant(tenantID string) error {
+	ctx := context.Background()
+	res, err := s.db.ExecContext(ctx, `DELETE FROM client_tenants WHERE tenant_id = ?`, tenantID)
+	if err != nil {
+		return fmt.Errorf("failed to delete client tenant %s: %w", tenantID, err)
+	}
+	n, _ := res.RowsAffected()
+	if n == 0 {
+		return fmt.Errorf("client tenant %s not found", tenantID)
+	}
+	return nil
+}
+
+// StoreAdminConsentRequest persists an admin consent request (upsert on state).
+func (s *SQLiteClientTenantStore) StoreAdminConsentRequest(request *interfaces.AdminConsentRequest) error {
+	if request == nil {
+		return fmt.Errorf("admin consent request cannot be nil")
+	}
+	if request.CreatedAt.IsZero() {
+		request.CreatedAt = nowUTC()
+	}
+
+	meta, err := marshalJSON(request.Metadata)
+	if err != nil {
+		return fmt.Errorf("failed to marshal metadata: %w", err)
+	}
+
+	ctx := context.Background()
+	_, err = s.db.ExecContext(ctx, `
+		INSERT INTO admin_consent_requests
+			(state, client_identifier, client_name, requested_by, expires_at, created_at, metadata)
+		VALUES (?, ?, ?, ?, ?, ?, ?)
+		ON CONFLICT(state) DO UPDATE SET
+			client_identifier = excluded.client_identifier,
+			client_name       = excluded.client_name,
+			requested_by      = excluded.requested_by,
+			expires_at        = excluded.expires_at,
+			metadata          = excluded.metadata`,
+		request.State,
+		request.ClientIdentifier,
+		request.ClientName,
+		request.RequestedBy,
+		formatTime(request.ExpiresAt),
+		formatTime(request.CreatedAt),
+		meta,
+	)
+	if err != nil {
+		return fmt.Errorf("failed to store admin consent request %s: %w", request.State, err)
+	}
+	return nil
+}
+
+// GetAdminConsentRequest retrieves an admin consent request by OAuth2 state token.
+func (s *SQLiteClientTenantStore) GetAdminConsentRequest(state string) (*interfaces.AdminConsentRequest, error) {
+	ctx := context.Background()
+	row := s.db.QueryRowContext(ctx, `
+		SELECT state, client_identifier, client_name, requested_by, expires_at, created_at, metadata
+		FROM admin_consent_requests WHERE state = ?`, state)
+
+	req := &interfaces.AdminConsentRequest{}
+	var expiresStr, createdStr, metaStr string
+
+	if err := row.Scan(
+		&req.State,
+		&req.ClientIdentifier,
+		&req.ClientName,
+		&req.RequestedBy,
+		&expiresStr,
+		&createdStr,
+		&metaStr,
+	); err == sql.ErrNoRows {
+		return nil, fmt.Errorf("admin consent request %s not found", state)
+	} else if err != nil {
+		return nil, fmt.Errorf("failed to get admin consent request: %w", err)
+	}
+
+	req.ExpiresAt = parseTime(expiresStr)
+	req.CreatedAt = parseTime(createdStr)
+
+	if time.Now().After(req.ExpiresAt) {
+		return nil, fmt.Errorf("admin consent request %s has expired", state)
+	}
+
+	meta, err := unmarshalJSONMap(metaStr)
+	if err != nil {
+		return nil, fmt.Errorf("failed to unmarshal metadata: %w", err)
+	}
+	req.Metadata = meta
+
+	return req, nil
+}
+
+// DeleteAdminConsentRequest removes an admin consent request by state.
+func (s *SQLiteClientTenantStore) DeleteAdminConsentRequest(state string) error {
+	ctx := context.Background()
+	_, err := s.db.ExecContext(ctx, `DELETE FROM admin_consent_requests WHERE state = ?`, state)
+	if err != nil {
+		return fmt.Errorf("failed to delete admin consent request %s: %w", state, err)
+	}
+	return nil
+}
+
+// ---- helpers ----------------------------------------------------------------
+
+func scanClientTenant(row *sql.Row) (*interfaces.ClientTenant, error) {
+	c := &interfaces.ClientTenant{}
+	var (
+		statusStr, consentedStr, createdStr, updatedStr, metaStr string
+		m365TenantID, m365AdminEmail, m365ConsentedAt, m365Status sql.NullString
+	)
+	err := row.Scan(
+		&c.ID, &c.TenantID, &c.TenantName, &c.DomainName, &c.AdminEmail,
+		&consentedStr, &statusStr, &c.ClientIdentifier, &metaStr,
+		&m365TenantID, &m365AdminEmail, &m365ConsentedAt, &m365Status,
+		&createdStr, &updatedStr,
+	)
+	if err == sql.ErrNoRows {
+		return nil, fmt.Errorf("client tenant not found")
+	}
+	if err != nil {
+		return nil, fmt.Errorf("failed to scan client tenant: %w", err)
+	}
+	return populateClientTenant(c, statusStr, consentedStr, createdStr, updatedStr, metaStr,
+		m365TenantID, m365AdminEmail, m365ConsentedAt, m365Status)
+}
+
+func scanClientTenantRow(rows *sql.Rows) (*interfaces.ClientTenant, error) {
+	c := &interfaces.ClientTenant{}
+	var (
+		statusStr, consentedStr, createdStr, updatedStr, metaStr string
+		m365TenantID, m365AdminEmail, m365ConsentedAt, m365Status sql.NullString
+	)
+	err := rows.Scan(
+		&c.ID, &c.TenantID, &c.TenantName, &c.DomainName, &c.AdminEmail,
+		&consentedStr, &statusStr, &c.ClientIdentifier, &metaStr,
+		&m365TenantID, &m365AdminEmail, &m365ConsentedAt, &m365Status,
+		&createdStr, &updatedStr,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to scan client tenant row: %w", err)
+	}
+	return populateClientTenant(c, statusStr, consentedStr, createdStr, updatedStr, metaStr,
+		m365TenantID, m365AdminEmail, m365ConsentedAt, m365Status)
+}
+
+func populateClientTenant(
+	c *interfaces.ClientTenant,
+	statusStr, consentedStr, createdStr, updatedStr, metaStr string,
+	m365TenantID, m365AdminEmail, m365ConsentedAt, m365Status sql.NullString,
+) (*interfaces.ClientTenant, error) {
+	c.Status = interfaces.ClientTenantStatus(statusStr)
+	c.ConsentedAt = parseTime(consentedStr)
+	c.CreatedAt = parseTime(createdStr)
+	c.UpdatedAt = parseTime(updatedStr)
+
+	meta, err := unmarshalJSONMap(metaStr)
+	if err != nil {
+		return nil, fmt.Errorf("failed to unmarshal client tenant metadata: %w", err)
+	}
+	c.Metadata = meta
+
+	// Store M365 extension columns back into Metadata so callers can read them
+	if m365TenantID.Valid {
+		c.Metadata["m365_tenant_id"] = m365TenantID.String
+	}
+	if m365AdminEmail.Valid {
+		c.Metadata["m365_admin_email"] = m365AdminEmail.String
+	}
+	if m365ConsentedAt.Valid {
+		c.Metadata["m365_consented_at"] = m365ConsentedAt.String
+	}
+	if m365Status.Valid {
+		c.Metadata["m365_status"] = m365Status.String
+	}
+
+	return c, nil
+}
+
+// Close closes the underlying database connection.
+func (s *SQLiteClientTenantStore) Close() error {
+	if s.db != nil {
+		return s.db.Close()
+	}
+	return nil
+}
+
+// ensure SQLiteClientTenantStore satisfies the interface at compile time
+var _ interfaces.ClientTenantStore = (*SQLiteClientTenantStore)(nil)

--- a/pkg/storage/providers/sqlite/client_tenant_store_test.go
+++ b/pkg/storage/providers/sqlite/client_tenant_store_test.go
@@ -1,0 +1,207 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+package sqlite_test
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cfgis/cfgms/pkg/storage/interfaces"
+	"github.com/cfgis/cfgms/pkg/storage/providers/sqlite"
+)
+
+func newClientTenantStore(t *testing.T) interfaces.ClientTenantStore {
+	t.Helper()
+	dir := t.TempDir()
+	p := sqlite.NewSQLiteProvider(dir)
+	store, err := p.CreateClientTenantStore(map[string]interface{}{"path": filepath.Join(dir, "ct.db")})
+	require.NoError(t, err)
+	// DB is in t.TempDir() which is auto-cleaned; no explicit Close needed
+	return store
+}
+
+func TestClientTenantStore_StoreAndGet(t *testing.T) {
+	store := newClientTenantStore(t)
+
+	client := &interfaces.ClientTenant{
+		TenantID:         "azure-tenant-001",
+		TenantName:       "Contoso Ltd",
+		DomainName:       "contoso.com",
+		AdminEmail:       "admin@contoso.com",
+		ConsentedAt:      time.Now().UTC().Truncate(time.Second),
+		Status:           interfaces.ClientTenantStatusActive,
+		ClientIdentifier: "cfgms-contoso",
+		Metadata:         map[string]interface{}{"region": "us-east"},
+	}
+
+	require.NoError(t, store.StoreClientTenant(client))
+
+	got, err := store.GetClientTenant("azure-tenant-001")
+	require.NoError(t, err)
+	assert.Equal(t, client.TenantID, got.TenantID)
+	assert.Equal(t, client.TenantName, got.TenantName)
+	assert.Equal(t, client.AdminEmail, got.AdminEmail)
+	assert.Equal(t, client.Status, got.Status)
+	assert.Equal(t, "us-east", got.Metadata["region"])
+}
+
+func TestClientTenantStore_GetNotFound(t *testing.T) {
+	store := newClientTenantStore(t)
+	_, err := store.GetClientTenant("nonexistent")
+	assert.Error(t, err)
+}
+
+func TestClientTenantStore_GetByIdentifier(t *testing.T) {
+	store := newClientTenantStore(t)
+
+	client := &interfaces.ClientTenant{
+		TenantID:         "azure-tenant-002",
+		TenantName:       "Fabrikam",
+		DomainName:       "fabrikam.com",
+		AdminEmail:       "admin@fabrikam.com",
+		ConsentedAt:      time.Now().UTC(),
+		Status:           interfaces.ClientTenantStatusActive,
+		ClientIdentifier: "cfgms-fabrikam",
+	}
+	require.NoError(t, store.StoreClientTenant(client))
+
+	got, err := store.GetClientTenantByIdentifier("cfgms-fabrikam")
+	require.NoError(t, err)
+	assert.Equal(t, "azure-tenant-002", got.TenantID)
+}
+
+func TestClientTenantStore_M365ExtensionFields(t *testing.T) {
+	store := newClientTenantStore(t)
+
+	// Store a client tenant with M365 extension fields embedded in Metadata
+	client := &interfaces.ClientTenant{
+		TenantID:         "azure-m365",
+		TenantName:       "M365 Corp",
+		DomainName:       "m365corp.com",
+		AdminEmail:       "admin@m365corp.com",
+		ConsentedAt:      time.Now().UTC(),
+		Status:           interfaces.ClientTenantStatusActive,
+		ClientIdentifier: "cfgms-m365",
+		Metadata: map[string]interface{}{
+			"m365_tenant_id":    "m365-tenant-uuid",
+			"m365_admin_email":  "m365admin@m365corp.com",
+			"m365_consented_at": time.Now().UTC().Format(time.RFC3339Nano),
+			"m365_status":       "active",
+		},
+	}
+	require.NoError(t, store.StoreClientTenant(client))
+
+	got, err := store.GetClientTenant("azure-m365")
+	require.NoError(t, err)
+
+	// M365 extension fields must round-trip without the separate M365 interface
+	assert.Equal(t, "m365-tenant-uuid", got.Metadata["m365_tenant_id"])
+	assert.Equal(t, "m365admin@m365corp.com", got.Metadata["m365_admin_email"])
+	assert.Equal(t, "active", got.Metadata["m365_status"])
+}
+
+func TestClientTenantStore_UpdateStatus(t *testing.T) {
+	store := newClientTenantStore(t)
+
+	client := &interfaces.ClientTenant{
+		TenantID:         "azure-tenant-upd",
+		TenantName:       "UpdateTest",
+		DomainName:       "update.com",
+		AdminEmail:       "a@update.com",
+		ConsentedAt:      time.Now().UTC(),
+		Status:           interfaces.ClientTenantStatusPending,
+		ClientIdentifier: "cfgms-upd",
+	}
+	require.NoError(t, store.StoreClientTenant(client))
+	require.NoError(t, store.UpdateClientTenantStatus("azure-tenant-upd", interfaces.ClientTenantStatusActive))
+
+	got, err := store.GetClientTenant("azure-tenant-upd")
+	require.NoError(t, err)
+	assert.Equal(t, interfaces.ClientTenantStatusActive, got.Status)
+}
+
+func TestClientTenantStore_UpdateStatus_NotFound(t *testing.T) {
+	store := newClientTenantStore(t)
+	assert.Error(t, store.UpdateClientTenantStatus("nonexistent", interfaces.ClientTenantStatusActive))
+}
+
+func TestClientTenantStore_Delete(t *testing.T) {
+	store := newClientTenantStore(t)
+
+	client := &interfaces.ClientTenant{
+		TenantID:         "azure-del",
+		TenantName:       "ToDelete",
+		DomainName:       "del.com",
+		AdminEmail:       "a@del.com",
+		ConsentedAt:      time.Now().UTC(),
+		Status:           interfaces.ClientTenantStatusActive,
+		ClientIdentifier: "cfgms-del",
+	}
+	require.NoError(t, store.StoreClientTenant(client))
+	require.NoError(t, store.DeleteClientTenant("azure-del"))
+	_, err := store.GetClientTenant("azure-del")
+	assert.Error(t, err)
+}
+
+func TestClientTenantStore_List(t *testing.T) {
+	store := newClientTenantStore(t)
+
+	for _, c := range []*interfaces.ClientTenant{
+		{TenantID: "az-1", TenantName: "A", DomainName: "a.com", AdminEmail: "x@a.com", ConsentedAt: time.Now().UTC(), Status: interfaces.ClientTenantStatusActive, ClientIdentifier: "ci-1"},
+		{TenantID: "az-2", TenantName: "B", DomainName: "b.com", AdminEmail: "x@b.com", ConsentedAt: time.Now().UTC(), Status: interfaces.ClientTenantStatusPending, ClientIdentifier: "ci-2"},
+		{TenantID: "az-3", TenantName: "C", DomainName: "c.com", AdminEmail: "x@c.com", ConsentedAt: time.Now().UTC(), Status: interfaces.ClientTenantStatusActive, ClientIdentifier: "ci-3"},
+	} {
+		require.NoError(t, store.StoreClientTenant(c))
+	}
+
+	all, err := store.ListClientTenants("")
+	require.NoError(t, err)
+	assert.Len(t, all, 3)
+
+	active, err := store.ListClientTenants(interfaces.ClientTenantStatusActive)
+	require.NoError(t, err)
+	assert.Len(t, active, 2)
+}
+
+func TestClientTenantStore_AdminConsentRequest(t *testing.T) {
+	store := newClientTenantStore(t)
+
+	req := &interfaces.AdminConsentRequest{
+		ClientIdentifier: "cfgms-consent",
+		ClientName:       "Consent Corp",
+		RequestedBy:      "msp@example.com",
+		State:            "oauth2-state-xyz",
+		ExpiresAt:        time.Now().UTC().Add(1 * time.Hour),
+		Metadata:         map[string]interface{}{"source": "api"},
+	}
+	require.NoError(t, store.StoreAdminConsentRequest(req))
+
+	got, err := store.GetAdminConsentRequest("oauth2-state-xyz")
+	require.NoError(t, err)
+	assert.Equal(t, req.ClientIdentifier, got.ClientIdentifier)
+	assert.Equal(t, req.State, got.State)
+
+	require.NoError(t, store.DeleteAdminConsentRequest("oauth2-state-xyz"))
+	_, err = store.GetAdminConsentRequest("oauth2-state-xyz")
+	assert.Error(t, err)
+}
+
+func TestClientTenantStore_AdminConsentRequest_Expired(t *testing.T) {
+	store := newClientTenantStore(t)
+
+	req := &interfaces.AdminConsentRequest{
+		ClientIdentifier: "cfgms-expired",
+		ClientName:       "Expired Corp",
+		RequestedBy:      "msp@example.com",
+		State:            "expired-state",
+		ExpiresAt:        time.Now().UTC().Add(-1 * time.Hour), // already expired
+	}
+	require.NoError(t, store.StoreAdminConsentRequest(req))
+
+	_, err := store.GetAdminConsentRequest("expired-state")
+	assert.Error(t, err, "expected error for expired request")
+}

--- a/pkg/storage/providers/sqlite/client_tenant_store_test.go
+++ b/pkg/storage/providers/sqlite/client_tenant_store_test.go
@@ -20,7 +20,7 @@ func newClientTenantStore(t *testing.T) interfaces.ClientTenantStore {
 	p := sqlite.NewSQLiteProvider(dir)
 	store, err := p.CreateClientTenantStore(map[string]interface{}{"path": filepath.Join(dir, "ct.db")})
 	require.NoError(t, err)
-	// DB is in t.TempDir() which is auto-cleaned; no explicit Close needed
+	t.Cleanup(func() { _ = store.Close() })
 	return store
 }
 

--- a/pkg/storage/providers/sqlite/plugin.go
+++ b/pkg/storage/providers/sqlite/plugin.go
@@ -1,0 +1,228 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+// Package sqlite implements the SQLite storage provider for CFGMS business data.
+//
+// This is the default OSS backend for the business-data tier (ADR-003).
+// It requires CGo because it uses github.com/mattn/go-sqlite3.
+// Cross-compile targets that disable CGo should use the modernc.org/sqlite driver instead;
+// see docs/architecture/storage-architecture.md for guidance.
+package sqlite
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	_ "github.com/mattn/go-sqlite3" // SQLite driver (requires CGo)
+
+	"github.com/cfgis/cfgms/pkg/storage/interfaces"
+)
+
+// Compile-time assertion that SQLiteProvider satisfies StorageProvider.
+var _ interfaces.StorageProvider = (*SQLiteProvider)(nil)
+
+// SQLiteProvider implements the StorageProvider interface using SQLite for persistence.
+// It is the default OSS backend for all business-data stores.
+type SQLiteProvider struct {
+	// basePath is an optional directory used by Available() to verify writability.
+	// The registered provider (from init()) leaves basePath empty, which means
+	// Available() always returns true (the SQLite library is present).
+	basePath string
+}
+
+// NewSQLiteProvider creates a provider that checks the given directory for writability.
+func NewSQLiteProvider(basePath string) *SQLiteProvider {
+	return &SQLiteProvider{basePath: basePath}
+}
+
+// Name returns the provider name used for registration and lookup.
+func (p *SQLiteProvider) Name() string { return "sqlite" }
+
+// Description returns a human-readable description of the provider.
+func (p *SQLiteProvider) Description() string {
+	return "SQLite business-data provider — OSS default for tenants, RBAC, audit, sessions, and registration tokens"
+}
+
+// GetVersion returns the provider version.
+func (p *SQLiteProvider) GetVersion() string { return "1.0.0" }
+
+// GetCapabilities describes what this provider supports.
+func (p *SQLiteProvider) GetCapabilities() interfaces.ProviderCapabilities {
+	return interfaces.ProviderCapabilities{
+		SupportsTransactions:   true,
+		SupportsVersioning:     false,
+		SupportsFullTextSearch: false,
+		SupportsEncryption:     false,
+		SupportsCompression:    false,
+		SupportsReplication:    false,
+		SupportsSharding:       false,
+		MaxBatchSize:           500,
+		MaxConfigSize:          10 * 1024 * 1024, // 10 MB
+		MaxAuditRetentionDays:  3650,              // 10 years
+	}
+}
+
+// Available reports whether the SQLite library is usable and, when basePath is set,
+// whether that directory exists and is writable.
+//
+// For in-memory paths (":memory:" or paths containing "mode=memory") it always returns true.
+// For a non-existent path it returns false.
+func (p *SQLiteProvider) Available() (bool, error) {
+	if p.basePath == "" {
+		return true, nil // library is available; no specific path to verify
+	}
+
+	// In-memory databases are always available
+	if p.basePath == ":memory:" || strings.Contains(p.basePath, "mode=memory") {
+		return true, nil
+	}
+
+	dir := p.basePath
+	if ext := filepath.Ext(p.basePath); ext != "" {
+		// basePath looks like a file path — check its parent directory
+		dir = filepath.Dir(p.basePath)
+	}
+
+	info, err := os.Stat(dir)
+	if err != nil {
+		return false, fmt.Errorf("sqlite: directory %s does not exist or is not accessible: %w", dir, err)
+	}
+	if !info.IsDir() {
+		return false, fmt.Errorf("sqlite: %s is not a directory", dir)
+	}
+
+	// Probe write access with a temporary marker file
+	probe := filepath.Join(dir, ".cfgms_sqlite_probe")
+	f, err := os.Create(probe)
+	if err != nil {
+		return false, fmt.Errorf("sqlite: directory %s is not writable: %w", dir, err)
+	}
+	_ = f.Close()
+	_ = os.Remove(probe)
+
+	return true, nil
+}
+
+// openDB opens (or creates) a SQLite database at path and enables WAL mode and foreign keys.
+func openDB(path string) (*sql.DB, error) {
+	// mattn/go-sqlite3 accepts DSN parameters via the path.
+	// Append shared-cache for in-memory so multiple connections in tests share state.
+	dsn := path
+	if path == ":memory:" {
+		dsn = "file::memory:?cache=shared&_journal_mode=WAL&_foreign_keys=on"
+	} else if !strings.HasPrefix(path, "file:") {
+		dsn = fmt.Sprintf("file:%s?_journal_mode=WAL&_foreign_keys=on", path)
+	}
+
+	db, err := sql.Open("sqlite3", dsn)
+	if err != nil {
+		return nil, fmt.Errorf("sqlite: failed to open %s: %w", path, err)
+	}
+	if err := db.Ping(); err != nil {
+		_ = db.Close()
+		return nil, fmt.Errorf("sqlite: failed to ping %s: %w", path, err)
+	}
+	return db, nil
+}
+
+// getPath extracts the SQLite file path from the config map.
+func getPath(config map[string]interface{}) string {
+	if v, ok := config["path"].(string); ok && v != "" {
+		return v
+	}
+	return ":memory:"
+}
+
+// nowUTC returns the current time in UTC (facilitates testing overrides if needed).
+func nowUTC() time.Time { return time.Now().UTC() }
+
+// openAndInit opens a SQLite DB at the given path, applies WAL pragma, and runs schema DDL.
+func openAndInit(path string) (*sql.DB, error) {
+	db, err := openDB(path)
+	if err != nil {
+		return nil, err
+	}
+	ctx := context.Background()
+	if err := initializeSchema(ctx, db); err != nil {
+		_ = db.Close()
+		return nil, fmt.Errorf("sqlite: schema initialisation failed: %w", err)
+	}
+	return db, nil
+}
+
+// ---- Factory methods --------------------------------------------------------
+
+// CreateTenantStore returns a SQLite-backed TenantStore.
+func (p *SQLiteProvider) CreateTenantStore(config map[string]interface{}) (interfaces.TenantStore, error) {
+	db, err := openAndInit(getPath(config))
+	if err != nil {
+		return nil, err
+	}
+	return &SQLiteTenantStore{db: db}, nil
+}
+
+// CreateClientTenantStore returns a SQLite-backed ClientTenantStore with M365 extension columns.
+func (p *SQLiteProvider) CreateClientTenantStore(config map[string]interface{}) (interfaces.ClientTenantStore, error) {
+	db, err := openAndInit(getPath(config))
+	if err != nil {
+		return nil, err
+	}
+	return &SQLiteClientTenantStore{db: db}, nil
+}
+
+// CreateAuditStore returns a SQLite-backed AuditStore (append-only).
+func (p *SQLiteProvider) CreateAuditStore(config map[string]interface{}) (interfaces.AuditStore, error) {
+	db, err := openAndInit(getPath(config))
+	if err != nil {
+		return nil, err
+	}
+	return &SQLiteAuditStore{db: db}, nil
+}
+
+// CreateRBACStore returns a SQLite-backed RBACStore.
+func (p *SQLiteProvider) CreateRBACStore(config map[string]interface{}) (interfaces.RBACStore, error) {
+	db, err := openAndInit(getPath(config))
+	if err != nil {
+		return nil, err
+	}
+	return &SQLiteRBACStore{db: db}, nil
+}
+
+// CreateRegistrationTokenStore returns a SQLite-backed RegistrationTokenStore.
+func (p *SQLiteProvider) CreateRegistrationTokenStore(config map[string]interface{}) (interfaces.RegistrationTokenStore, error) {
+	db, err := openAndInit(getPath(config))
+	if err != nil {
+		return nil, err
+	}
+	return &SQLiteRegistrationTokenStore{db: db}, nil
+}
+
+// CreateSessionStore returns a SQLite-backed SessionStore (durable Persistent=true sessions only).
+func (p *SQLiteProvider) CreateSessionStore(config map[string]interface{}) (interfaces.SessionStore, error) {
+	db, err := openAndInit(getPath(config))
+	if err != nil {
+		return nil, err
+	}
+	return &SQLiteSessionStore{db: db}, nil
+}
+
+// CreateConfigStore is not implemented by the SQLite provider.
+// Config data uses the flat-file provider (OSS) or PostgreSQL (commercial).
+func (p *SQLiteProvider) CreateConfigStore(config map[string]interface{}) (interfaces.ConfigStore, error) {
+	return nil, interfaces.ErrNotSupported
+}
+
+// CreateRuntimeStore is not implemented by the SQLite provider.
+// Durable session state is provided by CreateSessionStore; ephemeral state belongs in pkg/cache.
+func (p *SQLiteProvider) CreateRuntimeStore(config map[string]interface{}) (interfaces.RuntimeStore, error) {
+	return nil, interfaces.ErrNotSupported
+}
+
+// init auto-registers the SQLite provider so it is available after a blank import.
+func init() {
+	interfaces.RegisterStorageProvider(&SQLiteProvider{})
+}

--- a/pkg/storage/providers/sqlite/plugin.go
+++ b/pkg/storage/providers/sqlite/plugin.go
@@ -62,7 +62,7 @@ func (p *SQLiteProvider) GetCapabilities() interfaces.ProviderCapabilities {
 		SupportsSharding:       false,
 		MaxBatchSize:           500,
 		MaxConfigSize:          10 * 1024 * 1024, // 10 MB
-		MaxAuditRetentionDays:  3650,              // 10 years
+		MaxAuditRetentionDays:  3650,             // 10 years
 	}
 }
 

--- a/pkg/storage/providers/sqlite/plugin_test.go
+++ b/pkg/storage/providers/sqlite/plugin_test.go
@@ -5,6 +5,7 @@ package sqlite_test
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -60,6 +61,9 @@ func TestAvailable_InMemory(t *testing.T) {
 
 // TestAvailable_NonWritableDir returns false for a non-writable directory.
 func TestAvailable_NonWritableDir(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("os.Chmod does not enforce POSIX directory permissions on Windows")
+	}
 	if os.Getuid() == 0 {
 		t.Skip("skipping non-writable dir test when running as root")
 	}
@@ -105,6 +109,7 @@ func TestCreateTenantStore_InMemory(t *testing.T) {
 	store, err := p.CreateTenantStore(map[string]interface{}{"path": ":memory:"})
 	require.NoError(t, err)
 	require.NotNil(t, store)
+	t.Cleanup(func() { _ = store.Close() })
 }
 
 // TestCreateSessionStore_InMemory verifies session store can be created.
@@ -114,6 +119,7 @@ func TestCreateSessionStore_InMemory(t *testing.T) {
 	store, err := p.CreateSessionStore(map[string]interface{}{"path": ":memory:"})
 	require.NoError(t, err)
 	require.NotNil(t, store)
+	t.Cleanup(func() { _ = store.Close() })
 }
 
 // TestCreateAuditStore_FileDB verifies audit store with a file-based SQLite DB.
@@ -126,4 +132,5 @@ func TestCreateAuditStore_FileDB(t *testing.T) {
 	store, err := p.CreateAuditStore(map[string]interface{}{"path": dbPath})
 	require.NoError(t, err)
 	require.NotNil(t, store)
+	t.Cleanup(func() { _ = store.Close() })
 }

--- a/pkg/storage/providers/sqlite/plugin_test.go
+++ b/pkg/storage/providers/sqlite/plugin_test.go
@@ -1,0 +1,129 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+package sqlite_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	_ "github.com/cfgis/cfgms/pkg/storage/providers/sqlite" // blank import triggers init()
+
+	"github.com/cfgis/cfgms/pkg/storage/interfaces"
+	"github.com/cfgis/cfgms/pkg/storage/providers/sqlite"
+)
+
+// TestInit verifies that a blank import registers the "sqlite" provider.
+func TestInit(t *testing.T) {
+	p, err := interfaces.GetStorageProvider("sqlite")
+	require.NoError(t, err)
+	require.NotNil(t, p)
+	assert.Equal(t, "sqlite", p.Name())
+}
+
+// TestAvailable_DefaultProvider verifies the default registered provider (no path) is available.
+func TestAvailable_DefaultProvider(t *testing.T) {
+	p, err := interfaces.GetStorageProvider("sqlite")
+	require.NoError(t, err)
+	avail, err := p.Available()
+	assert.True(t, avail)
+	assert.NoError(t, err)
+}
+
+// TestAvailable_WritableDir returns true for a writable temporary directory.
+func TestAvailable_WritableDir(t *testing.T) {
+	dir := t.TempDir()
+	p := sqlite.NewSQLiteProvider(dir)
+	avail, err := p.Available()
+	assert.True(t, avail)
+	assert.NoError(t, err)
+}
+
+// TestAvailable_NonExistentPath returns false for a path that does not exist.
+func TestAvailable_NonExistentPath(t *testing.T) {
+	p := sqlite.NewSQLiteProvider("/nonexistent/path/that/does/not/exist")
+	avail, err := p.Available()
+	assert.False(t, avail)
+	assert.Error(t, err)
+}
+
+// TestAvailable_InMemory always returns true for in-memory databases.
+func TestAvailable_InMemory(t *testing.T) {
+	p := sqlite.NewSQLiteProvider(":memory:")
+	avail, err := p.Available()
+	assert.True(t, avail)
+	assert.NoError(t, err)
+}
+
+// TestAvailable_NonWritableDir returns false for a non-writable directory.
+func TestAvailable_NonWritableDir(t *testing.T) {
+	if os.Getuid() == 0 {
+		t.Skip("skipping non-writable dir test when running as root")
+	}
+	dir := t.TempDir()
+	require.NoError(t, os.Chmod(dir, 0o500)) // read+execute only
+	t.Cleanup(func() { _ = os.Chmod(dir, 0o700) })
+
+	p := sqlite.NewSQLiteProvider(dir)
+	avail, err := p.Available()
+	assert.False(t, avail)
+	assert.Error(t, err)
+}
+
+// TestGetCapabilities verifies capabilities are sensible.
+func TestGetCapabilities(t *testing.T) {
+	p, err := interfaces.GetStorageProvider("sqlite")
+	require.NoError(t, err)
+	caps := p.GetCapabilities()
+	assert.True(t, caps.SupportsTransactions)
+	assert.Greater(t, caps.MaxBatchSize, 0)
+}
+
+// TestCreateConfigStore_NotSupported verifies config store is not supported.
+func TestCreateConfigStore_NotSupported(t *testing.T) {
+	p, err := interfaces.GetStorageProvider("sqlite")
+	require.NoError(t, err)
+	_, err = p.CreateConfigStore(map[string]interface{}{})
+	assert.ErrorIs(t, err, interfaces.ErrNotSupported)
+}
+
+// TestCreateRuntimeStore_NotSupported verifies runtime store is not supported.
+func TestCreateRuntimeStore_NotSupported(t *testing.T) {
+	p, err := interfaces.GetStorageProvider("sqlite")
+	require.NoError(t, err)
+	_, err = p.CreateRuntimeStore(map[string]interface{}{})
+	assert.ErrorIs(t, err, interfaces.ErrNotSupported)
+}
+
+// TestCreateTenantStore_InMemory verifies tenant store can be created.
+func TestCreateTenantStore_InMemory(t *testing.T) {
+	p, err := interfaces.GetStorageProvider("sqlite")
+	require.NoError(t, err)
+	store, err := p.CreateTenantStore(map[string]interface{}{"path": ":memory:"})
+	require.NoError(t, err)
+	require.NotNil(t, store)
+}
+
+// TestCreateSessionStore_InMemory verifies session store can be created.
+func TestCreateSessionStore_InMemory(t *testing.T) {
+	p, err := interfaces.GetStorageProvider("sqlite")
+	require.NoError(t, err)
+	store, err := p.CreateSessionStore(map[string]interface{}{"path": ":memory:"})
+	require.NoError(t, err)
+	require.NotNil(t, store)
+}
+
+// TestCreateAuditStore_FileDB verifies audit store with a file-based SQLite DB.
+func TestCreateAuditStore_FileDB(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "test_audit.db")
+
+	p, err := interfaces.GetStorageProvider("sqlite")
+	require.NoError(t, err)
+	store, err := p.CreateAuditStore(map[string]interface{}{"path": dbPath})
+	require.NoError(t, err)
+	require.NotNil(t, store)
+}

--- a/pkg/storage/providers/sqlite/rbac_store.go
+++ b/pkg/storage/providers/sqlite/rbac_store.go
@@ -1,0 +1,726 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+// Package sqlite implements RBACStore using SQLite
+package sqlite
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/cfgis/cfgms/api/proto/common"
+	"github.com/cfgis/cfgms/pkg/storage/interfaces"
+)
+
+// SQLiteRBACStore implements interfaces.RBACStore using SQLite.
+type SQLiteRBACStore struct {
+	db *sql.DB
+}
+
+// Initialize is a no-op; schema is applied in openAndInit.
+func (s *SQLiteRBACStore) Initialize(_ context.Context) error { return nil }
+
+// Close closes the database connection.
+func (s *SQLiteRBACStore) Close() error {
+	if s.db != nil {
+		return s.db.Close()
+	}
+	return nil
+}
+
+// ---- Permissions ------------------------------------------------------------
+
+func (s *SQLiteRBACStore) StorePermission(ctx context.Context, perm *common.Permission) error {
+	if perm == nil {
+		return fmt.Errorf("permission cannot be nil")
+	}
+	actions, err := marshalJSONSlice(perm.Actions)
+	if err != nil {
+		return err
+	}
+	now := time.Now().UTC().Format(time.RFC3339Nano)
+	_, err = s.db.ExecContext(ctx, `
+		INSERT INTO rbac_permissions (id, name, description, resource_type, actions, created_at, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?)
+		ON CONFLICT(id) DO UPDATE SET
+			name          = excluded.name,
+			description   = excluded.description,
+			resource_type = excluded.resource_type,
+			actions       = excluded.actions,
+			updated_at    = excluded.updated_at`,
+		perm.Id, perm.Name, perm.Description, perm.ResourceType, actions, now, now,
+	)
+	return wrapErr(err, "store permission")
+}
+
+func (s *SQLiteRBACStore) GetPermission(ctx context.Context, id string) (*common.Permission, error) {
+	row := s.db.QueryRowContext(ctx,
+		`SELECT id, name, description, resource_type, actions FROM rbac_permissions WHERE id = ?`, id)
+	p := &common.Permission{}
+	var actionsStr string
+	if err := row.Scan(&p.Id, &p.Name, &p.Description, &p.ResourceType, &actionsStr); err == sql.ErrNoRows {
+		return nil, fmt.Errorf("permission %s not found", id)
+	} else if err != nil {
+		return nil, wrapErr(err, "get permission")
+	}
+	acts, err := unmarshalJSONSlice(actionsStr)
+	if err != nil {
+		return nil, err
+	}
+	p.Actions = acts
+	return p, nil
+}
+
+func (s *SQLiteRBACStore) ListPermissions(ctx context.Context, resourceType string) ([]*common.Permission, error) {
+	var (
+		rows *sql.Rows
+		err  error
+	)
+	if resourceType == "" {
+		rows, err = s.db.QueryContext(ctx, `SELECT id, name, description, resource_type, actions FROM rbac_permissions ORDER BY name`)
+	} else {
+		rows, err = s.db.QueryContext(ctx, `SELECT id, name, description, resource_type, actions FROM rbac_permissions WHERE resource_type = ? ORDER BY name`, resourceType)
+	}
+	if err != nil {
+		return nil, wrapErr(err, "list permissions")
+	}
+	defer func() { _ = rows.Close() }()
+
+	var perms []*common.Permission
+	for rows.Next() {
+		p := &common.Permission{}
+		var actionsStr string
+		if err := rows.Scan(&p.Id, &p.Name, &p.Description, &p.ResourceType, &actionsStr); err != nil {
+			return nil, wrapErr(err, "scan permission row")
+		}
+		acts, _ := unmarshalJSONSlice(actionsStr)
+		p.Actions = acts
+		perms = append(perms, p)
+	}
+	return perms, rows.Err()
+}
+
+func (s *SQLiteRBACStore) UpdatePermission(ctx context.Context, perm *common.Permission) error {
+	return s.StorePermission(ctx, perm)
+}
+
+func (s *SQLiteRBACStore) DeletePermission(ctx context.Context, id string) error {
+	res, err := s.db.ExecContext(ctx, `DELETE FROM rbac_permissions WHERE id = ?`, id)
+	if err != nil {
+		return wrapErr(err, "delete permission")
+	}
+	n, _ := res.RowsAffected()
+	if n == 0 {
+		return fmt.Errorf("permission %s not found", id)
+	}
+	return nil
+}
+
+// ---- Roles ------------------------------------------------------------------
+
+func (s *SQLiteRBACStore) StoreRole(ctx context.Context, role *common.Role) error {
+	if role == nil {
+		return fmt.Errorf("role cannot be nil")
+	}
+	permIDs, err := marshalJSONSlice(role.PermissionIds)
+	if err != nil {
+		return err
+	}
+	childIDs, err := marshalJSONSlice(role.ChildRoleIds)
+	if err != nil {
+		return err
+	}
+	now := time.Now().UTC().UnixNano()
+	createdAt := role.CreatedAt
+	if createdAt == 0 {
+		createdAt = now
+	}
+	_, err = s.db.ExecContext(ctx, `
+		INSERT INTO rbac_roles
+			(id, name, description, permission_ids, is_system_role, tenant_id,
+			 parent_role_id, child_role_ids, inheritance_type, created_at, updated_at)
+		VALUES (?,?,?,?,?,?,?,?,?,?,?)
+		ON CONFLICT(id) DO UPDATE SET
+			name             = excluded.name,
+			description      = excluded.description,
+			permission_ids   = excluded.permission_ids,
+			is_system_role   = excluded.is_system_role,
+			tenant_id        = excluded.tenant_id,
+			parent_role_id   = excluded.parent_role_id,
+			child_role_ids   = excluded.child_role_ids,
+			inheritance_type = excluded.inheritance_type,
+			updated_at       = excluded.updated_at`,
+		role.Id, role.Name, role.Description, permIDs,
+		boolToInt(role.IsSystemRole), role.TenantId,
+		role.ParentRoleId, childIDs, int32(role.InheritanceType),
+		createdAt, now,
+	)
+	return wrapErr(err, "store role")
+}
+
+func (s *SQLiteRBACStore) GetRole(ctx context.Context, id string) (*common.Role, error) {
+	row := s.db.QueryRowContext(ctx, `
+		SELECT id, name, description, permission_ids, is_system_role, tenant_id,
+		       parent_role_id, child_role_ids, inheritance_type, created_at, updated_at
+		FROM rbac_roles WHERE id = ?`, id)
+	return scanRole(row)
+}
+
+func (s *SQLiteRBACStore) ListRoles(ctx context.Context, tenantID string) ([]*common.Role, error) {
+	var (
+		rows *sql.Rows
+		err  error
+	)
+	if tenantID == "" {
+		rows, err = s.db.QueryContext(ctx, `
+			SELECT id, name, description, permission_ids, is_system_role, tenant_id,
+			       parent_role_id, child_role_ids, inheritance_type, created_at, updated_at
+			FROM rbac_roles ORDER BY name`)
+	} else {
+		rows, err = s.db.QueryContext(ctx, `
+			SELECT id, name, description, permission_ids, is_system_role, tenant_id,
+			       parent_role_id, child_role_ids, inheritance_type, created_at, updated_at
+			FROM rbac_roles WHERE tenant_id = ? OR is_system_role = 1 ORDER BY name`, tenantID)
+	}
+	if err != nil {
+		return nil, wrapErr(err, "list roles")
+	}
+	defer func() { _ = rows.Close() }()
+
+	var roles []*common.Role
+	for rows.Next() {
+		r, err := scanRoleRow(rows)
+		if err != nil {
+			return nil, err
+		}
+		roles = append(roles, r)
+	}
+	return roles, rows.Err()
+}
+
+func (s *SQLiteRBACStore) UpdateRole(ctx context.Context, role *common.Role) error {
+	return s.StoreRole(ctx, role)
+}
+
+func (s *SQLiteRBACStore) DeleteRole(ctx context.Context, id string) error {
+	res, err := s.db.ExecContext(ctx, `DELETE FROM rbac_roles WHERE id = ?`, id)
+	if err != nil {
+		return wrapErr(err, "delete role")
+	}
+	n, _ := res.RowsAffected()
+	if n == 0 {
+		return fmt.Errorf("role %s not found", id)
+	}
+	return nil
+}
+
+// ---- Subjects ---------------------------------------------------------------
+
+func (s *SQLiteRBACStore) StoreSubject(ctx context.Context, subj *common.Subject) error {
+	if subj == nil {
+		return fmt.Errorf("subject cannot be nil")
+	}
+	roleIDs, err := marshalJSONSlice(subj.RoleIds)
+	if err != nil {
+		return err
+	}
+	attrsJSON, err := json.Marshal(subj.Attributes)
+	if err != nil {
+		return fmt.Errorf("failed to marshal subject attributes: %w", err)
+	}
+	now := time.Now().UTC().UnixNano()
+	createdAt := subj.CreatedAt
+	if createdAt == 0 {
+		createdAt = now
+	}
+	_, err = s.db.ExecContext(ctx, `
+		INSERT INTO rbac_subjects
+			(id, type, display_name, tenant_id, role_ids, attributes, is_active, created_at, updated_at)
+		VALUES (?,?,?,?,?,?,?,?,?)
+		ON CONFLICT(id) DO UPDATE SET
+			type         = excluded.type,
+			display_name = excluded.display_name,
+			tenant_id    = excluded.tenant_id,
+			role_ids     = excluded.role_ids,
+			attributes   = excluded.attributes,
+			is_active    = excluded.is_active,
+			updated_at   = excluded.updated_at`,
+		subj.Id, int32(subj.Type), subj.DisplayName, subj.TenantId,
+		roleIDs, string(attrsJSON), boolToInt(subj.IsActive),
+		createdAt, now,
+	)
+	return wrapErr(err, "store subject")
+}
+
+func (s *SQLiteRBACStore) GetSubject(ctx context.Context, id string) (*common.Subject, error) {
+	row := s.db.QueryRowContext(ctx, `
+		SELECT id, type, display_name, tenant_id, role_ids, attributes, is_active, created_at, updated_at
+		FROM rbac_subjects WHERE id = ?`, id)
+	return scanSubject(row)
+}
+
+func (s *SQLiteRBACStore) ListSubjects(ctx context.Context, tenantID string, subjectType common.SubjectType) ([]*common.Subject, error) {
+	var (
+		rows *sql.Rows
+		err  error
+	)
+	switch {
+	case tenantID != "" && subjectType != common.SubjectType_SUBJECT_TYPE_UNSPECIFIED:
+		rows, err = s.db.QueryContext(ctx, `
+			SELECT id, type, display_name, tenant_id, role_ids, attributes, is_active, created_at, updated_at
+			FROM rbac_subjects WHERE tenant_id = ? AND type = ? ORDER BY display_name`,
+			tenantID, int32(subjectType))
+	case tenantID != "":
+		rows, err = s.db.QueryContext(ctx, `
+			SELECT id, type, display_name, tenant_id, role_ids, attributes, is_active, created_at, updated_at
+			FROM rbac_subjects WHERE tenant_id = ? ORDER BY display_name`, tenantID)
+	case subjectType != common.SubjectType_SUBJECT_TYPE_UNSPECIFIED:
+		rows, err = s.db.QueryContext(ctx, `
+			SELECT id, type, display_name, tenant_id, role_ids, attributes, is_active, created_at, updated_at
+			FROM rbac_subjects WHERE type = ? ORDER BY display_name`, int32(subjectType))
+	default:
+		rows, err = s.db.QueryContext(ctx, `
+			SELECT id, type, display_name, tenant_id, role_ids, attributes, is_active, created_at, updated_at
+			FROM rbac_subjects ORDER BY display_name`)
+	}
+	if err != nil {
+		return nil, wrapErr(err, "list subjects")
+	}
+	defer func() { _ = rows.Close() }()
+
+	var subjects []*common.Subject
+	for rows.Next() {
+		subj, err := scanSubjectRow(rows)
+		if err != nil {
+			return nil, err
+		}
+		subjects = append(subjects, subj)
+	}
+	return subjects, rows.Err()
+}
+
+func (s *SQLiteRBACStore) UpdateSubject(ctx context.Context, subj *common.Subject) error {
+	return s.StoreSubject(ctx, subj)
+}
+
+func (s *SQLiteRBACStore) DeleteSubject(ctx context.Context, id string) error {
+	res, err := s.db.ExecContext(ctx, `DELETE FROM rbac_subjects WHERE id = ?`, id)
+	if err != nil {
+		return wrapErr(err, "delete subject")
+	}
+	n, _ := res.RowsAffected()
+	if n == 0 {
+		return fmt.Errorf("subject %s not found", id)
+	}
+	return nil
+}
+
+// ---- Role Assignments -------------------------------------------------------
+
+func (s *SQLiteRBACStore) StoreRoleAssignment(ctx context.Context, a *common.RoleAssignment) error {
+	if a == nil {
+		return fmt.Errorf("role assignment cannot be nil")
+	}
+	conds, err := marshalJSONSlice(a.Conditions)
+	if err != nil {
+		return err
+	}
+	now := time.Now().UTC().UnixNano()
+	assignedAt := a.AssignedAt
+	if assignedAt == 0 {
+		assignedAt = now
+	}
+	var expiresAt sql.NullInt64
+	if a.ExpiresAt != 0 {
+		expiresAt = sql.NullInt64{Int64: a.ExpiresAt, Valid: true}
+	}
+	_, err = s.db.ExecContext(ctx, `
+		INSERT INTO rbac_role_assignments
+			(id, subject_id, role_id, tenant_id, conditions, expires_at, assigned_at, assigned_by)
+		VALUES (?,?,?,?,?,?,?,?)
+		ON CONFLICT(id) DO UPDATE SET
+			subject_id  = excluded.subject_id,
+			role_id     = excluded.role_id,
+			tenant_id   = excluded.tenant_id,
+			conditions  = excluded.conditions,
+			expires_at  = excluded.expires_at,
+			assigned_at = excluded.assigned_at,
+			assigned_by = excluded.assigned_by`,
+		a.Id, a.SubjectId, a.RoleId, a.TenantId,
+		conds, expiresAt, assignedAt, a.AssignedBy,
+	)
+	return wrapErr(err, "store role assignment")
+}
+
+func (s *SQLiteRBACStore) GetRoleAssignment(ctx context.Context, id string) (*common.RoleAssignment, error) {
+	row := s.db.QueryRowContext(ctx, `
+		SELECT id, subject_id, role_id, tenant_id, conditions, expires_at, assigned_at, assigned_by
+		FROM rbac_role_assignments WHERE id = ?`, id)
+	return scanRoleAssignment(row)
+}
+
+func (s *SQLiteRBACStore) ListRoleAssignments(ctx context.Context, subjectID, roleID, tenantID string) ([]*common.RoleAssignment, error) {
+	conditions := []string{}
+	args := []interface{}{}
+
+	if subjectID != "" {
+		conditions = append(conditions, "subject_id = ?")
+		args = append(args, subjectID)
+	}
+	if roleID != "" {
+		conditions = append(conditions, "role_id = ?")
+		args = append(args, roleID)
+	}
+	if tenantID != "" {
+		conditions = append(conditions, "tenant_id = ?")
+		args = append(args, tenantID)
+	}
+
+	query := `SELECT id, subject_id, role_id, tenant_id, conditions, expires_at, assigned_at, assigned_by FROM rbac_role_assignments`
+	if len(conditions) > 0 {
+		query += ` WHERE ` + strings.Join(conditions, ` AND `)
+	}
+	query += ` ORDER BY assigned_at DESC`
+
+	rows, err := s.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, wrapErr(err, "list role assignments")
+	}
+	defer func() { _ = rows.Close() }()
+
+	var assignments []*common.RoleAssignment
+	for rows.Next() {
+		a, err := scanRoleAssignmentRow(rows)
+		if err != nil {
+			return nil, err
+		}
+		assignments = append(assignments, a)
+	}
+	return assignments, rows.Err()
+}
+
+func (s *SQLiteRBACStore) DeleteRoleAssignment(ctx context.Context, subjectID, roleID, tenantID string) error {
+	_, err := s.db.ExecContext(ctx,
+		`DELETE FROM rbac_role_assignments WHERE subject_id = ? AND role_id = ? AND tenant_id = ?`,
+		subjectID, roleID, tenantID)
+	return wrapErr(err, "delete role assignment")
+}
+
+// ---- Bulk operations --------------------------------------------------------
+
+func (s *SQLiteRBACStore) StoreBulkPermissions(ctx context.Context, perms []*common.Permission) error {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("failed to begin transaction: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	now := time.Now().UTC().Format(time.RFC3339Nano)
+	for _, p := range perms {
+		if p == nil {
+			continue
+		}
+		actions, err := marshalJSONSlice(p.Actions)
+		if err != nil {
+			return err
+		}
+		_, err = tx.ExecContext(ctx, `
+			INSERT INTO rbac_permissions (id, name, description, resource_type, actions, created_at, updated_at)
+			VALUES (?, ?, ?, ?, ?, ?, ?)
+			ON CONFLICT(id) DO UPDATE SET
+				name          = excluded.name,
+				description   = excluded.description,
+				resource_type = excluded.resource_type,
+				actions       = excluded.actions,
+				updated_at    = excluded.updated_at`,
+			p.Id, p.Name, p.Description, p.ResourceType, actions, now, now)
+		if err != nil {
+			return wrapErr(err, "bulk store permission")
+		}
+	}
+	return tx.Commit()
+}
+
+func (s *SQLiteRBACStore) StoreBulkRoles(ctx context.Context, roles []*common.Role) error {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("failed to begin transaction: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	now := time.Now().UTC().UnixNano()
+	for _, r := range roles {
+		if r == nil {
+			continue
+		}
+		permIDs, err := marshalJSONSlice(r.PermissionIds)
+		if err != nil {
+			return err
+		}
+		childIDs, err := marshalJSONSlice(r.ChildRoleIds)
+		if err != nil {
+			return err
+		}
+		createdAt := r.CreatedAt
+		if createdAt == 0 {
+			createdAt = now
+		}
+		_, err = tx.ExecContext(ctx, `
+			INSERT INTO rbac_roles
+				(id, name, description, permission_ids, is_system_role, tenant_id,
+				 parent_role_id, child_role_ids, inheritance_type, created_at, updated_at)
+			VALUES (?,?,?,?,?,?,?,?,?,?,?)
+			ON CONFLICT(id) DO UPDATE SET
+				name             = excluded.name,
+				description      = excluded.description,
+				permission_ids   = excluded.permission_ids,
+				is_system_role   = excluded.is_system_role,
+				tenant_id        = excluded.tenant_id,
+				parent_role_id   = excluded.parent_role_id,
+				child_role_ids   = excluded.child_role_ids,
+				inheritance_type = excluded.inheritance_type,
+				updated_at       = excluded.updated_at`,
+			r.Id, r.Name, r.Description, permIDs,
+			boolToInt(r.IsSystemRole), r.TenantId,
+			r.ParentRoleId, childIDs, int32(r.InheritanceType),
+			createdAt, now)
+		if err != nil {
+			return wrapErr(err, "bulk store role")
+		}
+	}
+	return tx.Commit()
+}
+
+func (s *SQLiteRBACStore) StoreBulkSubjects(ctx context.Context, subjects []*common.Subject) error {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("failed to begin transaction: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	now := time.Now().UTC().UnixNano()
+	for _, subj := range subjects {
+		if subj == nil {
+			continue
+		}
+		roleIDs, err := marshalJSONSlice(subj.RoleIds)
+		if err != nil {
+			return err
+		}
+		attrsJSON, err := json.Marshal(subj.Attributes)
+		if err != nil {
+			return fmt.Errorf("failed to marshal subject attributes: %w", err)
+		}
+		createdAt := subj.CreatedAt
+		if createdAt == 0 {
+			createdAt = now
+		}
+		_, err = tx.ExecContext(ctx, `
+			INSERT INTO rbac_subjects
+				(id, type, display_name, tenant_id, role_ids, attributes, is_active, created_at, updated_at)
+			VALUES (?,?,?,?,?,?,?,?,?)
+			ON CONFLICT(id) DO UPDATE SET
+				type         = excluded.type,
+				display_name = excluded.display_name,
+				tenant_id    = excluded.tenant_id,
+				role_ids     = excluded.role_ids,
+				attributes   = excluded.attributes,
+				is_active    = excluded.is_active,
+				updated_at   = excluded.updated_at`,
+			subj.Id, int32(subj.Type), subj.DisplayName, subj.TenantId,
+			roleIDs, string(attrsJSON), boolToInt(subj.IsActive),
+			createdAt, now)
+		if err != nil {
+			return wrapErr(err, "bulk store subject")
+		}
+	}
+	return tx.Commit()
+}
+
+// ---- Query helpers ----------------------------------------------------------
+
+func (s *SQLiteRBACStore) GetSubjectRoles(ctx context.Context, subjectID, tenantID string) ([]*common.Role, error) {
+	assignments, err := s.ListRoleAssignments(ctx, subjectID, "", tenantID)
+	if err != nil {
+		return nil, err
+	}
+	var roles []*common.Role
+	for _, a := range assignments {
+		r, err := s.GetRole(ctx, a.RoleId)
+		if err != nil {
+			continue // role may have been deleted
+		}
+		roles = append(roles, r)
+	}
+	return roles, nil
+}
+
+func (s *SQLiteRBACStore) GetRolePermissions(ctx context.Context, roleID string) ([]*common.Permission, error) {
+	role, err := s.GetRole(ctx, roleID)
+	if err != nil {
+		return nil, err
+	}
+	var perms []*common.Permission
+	for _, pid := range role.PermissionIds {
+		p, err := s.GetPermission(ctx, pid)
+		if err != nil {
+			continue // permission may have been deleted
+		}
+		perms = append(perms, p)
+	}
+	return perms, nil
+}
+
+func (s *SQLiteRBACStore) GetSubjectAssignments(ctx context.Context, subjectID, tenantID string) ([]*common.RoleAssignment, error) {
+	return s.ListRoleAssignments(ctx, subjectID, "", tenantID)
+}
+
+// ---- scan helpers -----------------------------------------------------------
+
+func scanRole(row *sql.Row) (*common.Role, error) {
+	r := &common.Role{}
+	var permIDsStr, childIDsStr string
+	var isSystem int
+	var inheritType int32
+
+	err := row.Scan(
+		&r.Id, &r.Name, &r.Description, &permIDsStr,
+		&isSystem, &r.TenantId, &r.ParentRoleId, &childIDsStr,
+		&inheritType, &r.CreatedAt, &r.UpdatedAt,
+	)
+	if err == sql.ErrNoRows {
+		return nil, fmt.Errorf("role not found")
+	}
+	if err != nil {
+		return nil, wrapErr(err, "scan role")
+	}
+	r.IsSystemRole = isSystem != 0
+	r.InheritanceType = common.RoleInheritanceType(inheritType)
+	r.PermissionIds, _ = unmarshalJSONSlice(permIDsStr)
+	r.ChildRoleIds, _ = unmarshalJSONSlice(childIDsStr)
+	return r, nil
+}
+
+func scanRoleRow(rows *sql.Rows) (*common.Role, error) {
+	r := &common.Role{}
+	var permIDsStr, childIDsStr string
+	var isSystem int
+	var inheritType int32
+
+	if err := rows.Scan(
+		&r.Id, &r.Name, &r.Description, &permIDsStr,
+		&isSystem, &r.TenantId, &r.ParentRoleId, &childIDsStr,
+		&inheritType, &r.CreatedAt, &r.UpdatedAt,
+	); err != nil {
+		return nil, wrapErr(err, "scan role row")
+	}
+	r.IsSystemRole = isSystem != 0
+	r.InheritanceType = common.RoleInheritanceType(inheritType)
+	r.PermissionIds, _ = unmarshalJSONSlice(permIDsStr)
+	r.ChildRoleIds, _ = unmarshalJSONSlice(childIDsStr)
+	return r, nil
+}
+
+func scanSubject(row *sql.Row) (*common.Subject, error) {
+	subj := &common.Subject{}
+	var roleIDsStr, attrsStr string
+	var isActive int
+	var subjType int32
+
+	err := row.Scan(
+		&subj.Id, &subjType, &subj.DisplayName, &subj.TenantId,
+		&roleIDsStr, &attrsStr, &isActive, &subj.CreatedAt, &subj.UpdatedAt,
+	)
+	if err == sql.ErrNoRows {
+		return nil, fmt.Errorf("subject not found")
+	}
+	if err != nil {
+		return nil, wrapErr(err, "scan subject")
+	}
+	subj.Type = common.SubjectType(subjType)
+	subj.IsActive = isActive != 0
+	subj.RoleIds, _ = unmarshalJSONSlice(roleIDsStr)
+	attrs, _ := unmarshalJSONStringMap(attrsStr)
+	subj.Attributes = attrs
+	return subj, nil
+}
+
+func scanSubjectRow(rows *sql.Rows) (*common.Subject, error) {
+	subj := &common.Subject{}
+	var roleIDsStr, attrsStr string
+	var isActive int
+	var subjType int32
+
+	if err := rows.Scan(
+		&subj.Id, &subjType, &subj.DisplayName, &subj.TenantId,
+		&roleIDsStr, &attrsStr, &isActive, &subj.CreatedAt, &subj.UpdatedAt,
+	); err != nil {
+		return nil, wrapErr(err, "scan subject row")
+	}
+	subj.Type = common.SubjectType(subjType)
+	subj.IsActive = isActive != 0
+	subj.RoleIds, _ = unmarshalJSONSlice(roleIDsStr)
+	attrs, _ := unmarshalJSONStringMap(attrsStr)
+	subj.Attributes = attrs
+	return subj, nil
+}
+
+func scanRoleAssignment(row *sql.Row) (*common.RoleAssignment, error) {
+	a := &common.RoleAssignment{}
+	var condsStr string
+	var expiresAt sql.NullInt64
+
+	err := row.Scan(
+		&a.Id, &a.SubjectId, &a.RoleId, &a.TenantId,
+		&condsStr, &expiresAt, &a.AssignedAt, &a.AssignedBy,
+	)
+	if err == sql.ErrNoRows {
+		return nil, fmt.Errorf("role assignment not found")
+	}
+	if err != nil {
+		return nil, wrapErr(err, "scan role assignment")
+	}
+	a.Conditions, _ = unmarshalJSONSlice(condsStr)
+	if expiresAt.Valid {
+		a.ExpiresAt = expiresAt.Int64
+	}
+	return a, nil
+}
+
+func scanRoleAssignmentRow(rows *sql.Rows) (*common.RoleAssignment, error) {
+	a := &common.RoleAssignment{}
+	var condsStr string
+	var expiresAt sql.NullInt64
+
+	if err := rows.Scan(
+		&a.Id, &a.SubjectId, &a.RoleId, &a.TenantId,
+		&condsStr, &expiresAt, &a.AssignedAt, &a.AssignedBy,
+	); err != nil {
+		return nil, wrapErr(err, "scan role assignment row")
+	}
+	a.Conditions, _ = unmarshalJSONSlice(condsStr)
+	if expiresAt.Valid {
+		a.ExpiresAt = expiresAt.Int64
+	}
+	return a, nil
+}
+
+func boolToInt(b bool) int {
+	if b {
+		return 1
+	}
+	return 0
+}
+
+func wrapErr(err error, op string) error {
+	if err == nil {
+		return nil
+	}
+	return fmt.Errorf("sqlite rbac %s: %w", op, err)
+}
+
+// ensure SQLiteRBACStore satisfies the interface at compile time
+var _ interfaces.RBACStore = (*SQLiteRBACStore)(nil)

--- a/pkg/storage/providers/sqlite/rbac_store_test.go
+++ b/pkg/storage/providers/sqlite/rbac_store_test.go
@@ -1,0 +1,223 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+package sqlite_test
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cfgis/cfgms/api/proto/common"
+	"github.com/cfgis/cfgms/pkg/storage/interfaces"
+	"github.com/cfgis/cfgms/pkg/storage/providers/sqlite"
+)
+
+func newRBACStore(t *testing.T) interfaces.RBACStore {
+	t.Helper()
+	dir := t.TempDir()
+	p := sqlite.NewSQLiteProvider(dir)
+	store, err := p.CreateRBACStore(map[string]interface{}{"path": filepath.Join(dir, "rbac.db")})
+	require.NoError(t, err)
+	return store
+}
+
+func TestRBACStore_Permission_CRUD(t *testing.T) {
+	store := newRBACStore(t)
+	ctx := context.Background()
+
+	perm := &common.Permission{
+		Id:           "perm-1",
+		Name:         "steward.read",
+		Description:  "Read steward data",
+		ResourceType: "steward",
+		Actions:      []string{"read", "list"},
+	}
+	require.NoError(t, store.StorePermission(ctx, perm))
+
+	got, err := store.GetPermission(ctx, "perm-1")
+	require.NoError(t, err)
+	assert.Equal(t, perm.Id, got.Id)
+	assert.Equal(t, perm.Name, got.Name)
+	assert.Equal(t, perm.Actions, got.Actions)
+
+	// Update
+	perm.Actions = []string{"read"}
+	require.NoError(t, store.UpdatePermission(ctx, perm))
+	updated, err := store.GetPermission(ctx, "perm-1")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"read"}, updated.Actions)
+
+	// Delete
+	require.NoError(t, store.DeletePermission(ctx, "perm-1"))
+	_, err = store.GetPermission(ctx, "perm-1")
+	assert.Error(t, err)
+}
+
+func TestRBACStore_Permission_NotFound(t *testing.T) {
+	store := newRBACStore(t)
+	ctx := context.Background()
+	_, err := store.GetPermission(ctx, "nonexistent")
+	assert.Error(t, err)
+}
+
+func TestRBACStore_ListPermissions(t *testing.T) {
+	store := newRBACStore(t)
+	ctx := context.Background()
+
+	for _, p := range []*common.Permission{
+		{Id: "p-1", ResourceType: "steward", Name: "p1", Actions: []string{"read"}},
+		{Id: "p-2", ResourceType: "tenant", Name: "p2", Actions: []string{"write"}},
+		{Id: "p-3", ResourceType: "steward", Name: "p3", Actions: []string{"delete"}},
+	} {
+		require.NoError(t, store.StorePermission(ctx, p))
+	}
+
+	all, err := store.ListPermissions(ctx, "")
+	require.NoError(t, err)
+	assert.Len(t, all, 3)
+
+	steward, err := store.ListPermissions(ctx, "steward")
+	require.NoError(t, err)
+	assert.Len(t, steward, 2)
+}
+
+func TestRBACStore_Role_CRUD(t *testing.T) {
+	store := newRBACStore(t)
+	ctx := context.Background()
+
+	role := &common.Role{
+		Id:            "role-1",
+		Name:          "admin",
+		Description:   "Administrator",
+		PermissionIds: []string{"p-1", "p-2"},
+		IsSystemRole:  false,
+		TenantId:      "tenant-a",
+	}
+	require.NoError(t, store.StoreRole(ctx, role))
+
+	got, err := store.GetRole(ctx, "role-1")
+	require.NoError(t, err)
+	assert.Equal(t, role.Id, got.Id)
+	assert.Equal(t, role.Name, got.Name)
+	assert.Equal(t, role.PermissionIds, got.PermissionIds)
+	assert.False(t, got.IsSystemRole)
+
+	// Delete
+	require.NoError(t, store.DeleteRole(ctx, "role-1"))
+	_, err = store.GetRole(ctx, "role-1")
+	assert.Error(t, err)
+}
+
+func TestRBACStore_ListRoles_TenantScoped(t *testing.T) {
+	store := newRBACStore(t)
+	ctx := context.Background()
+
+	require.NoError(t, store.StoreRole(ctx, &common.Role{Id: "sys-role", Name: "system", IsSystemRole: true}))
+	require.NoError(t, store.StoreRole(ctx, &common.Role{Id: "ta-role", Name: "ta-admin", TenantId: "tenant-a"}))
+	require.NoError(t, store.StoreRole(ctx, &common.Role{Id: "tb-role", Name: "tb-admin", TenantId: "tenant-b"}))
+
+	roles, err := store.ListRoles(ctx, "tenant-a")
+	require.NoError(t, err)
+	// Should include the system role and tenant-a role
+	ids := make(map[string]bool)
+	for _, r := range roles {
+		ids[r.Id] = true
+	}
+	assert.True(t, ids["sys-role"])
+	assert.True(t, ids["ta-role"])
+	assert.False(t, ids["tb-role"])
+}
+
+func TestRBACStore_Subject_CRUD(t *testing.T) {
+	store := newRBACStore(t)
+	ctx := context.Background()
+
+	subj := &common.Subject{
+		Id:          "subj-1",
+		Type:        common.SubjectType_SUBJECT_TYPE_USER,
+		DisplayName: "Alice",
+		TenantId:    "tenant-a",
+		RoleIds:     []string{"role-1"},
+		IsActive:    true,
+	}
+	require.NoError(t, store.StoreSubject(ctx, subj))
+
+	got, err := store.GetSubject(ctx, "subj-1")
+	require.NoError(t, err)
+	assert.Equal(t, subj.Id, got.Id)
+	assert.Equal(t, subj.DisplayName, got.DisplayName)
+	assert.Equal(t, common.SubjectType_SUBJECT_TYPE_USER, got.Type)
+	assert.True(t, got.IsActive)
+	assert.Equal(t, []string{"role-1"}, got.RoleIds)
+
+	require.NoError(t, store.DeleteSubject(ctx, "subj-1"))
+	_, err = store.GetSubject(ctx, "subj-1")
+	assert.Error(t, err)
+}
+
+func TestRBACStore_RoleAssignment_CRUD(t *testing.T) {
+	store := newRBACStore(t)
+	ctx := context.Background()
+
+	a := &common.RoleAssignment{
+		Id:         "assign-1",
+		SubjectId:  "user-1",
+		RoleId:     "role-1",
+		TenantId:   "tenant-a",
+		AssignedBy: "admin",
+	}
+	require.NoError(t, store.StoreRoleAssignment(ctx, a))
+
+	got, err := store.GetRoleAssignment(ctx, "assign-1")
+	require.NoError(t, err)
+	assert.Equal(t, a.Id, got.Id)
+	assert.Equal(t, a.SubjectId, got.SubjectId)
+
+	require.NoError(t, store.DeleteRoleAssignment(ctx, "user-1", "role-1", "tenant-a"))
+	_, err = store.GetRoleAssignment(ctx, "assign-1")
+	assert.Error(t, err)
+}
+
+func TestRBACStore_BulkOperations(t *testing.T) {
+	store := newRBACStore(t)
+	ctx := context.Background()
+
+	perms := []*common.Permission{
+		{Id: "bp-1", Name: "bp1", ResourceType: "r", Actions: []string{"read"}},
+		{Id: "bp-2", Name: "bp2", ResourceType: "r", Actions: []string{"write"}},
+	}
+	require.NoError(t, store.StoreBulkPermissions(ctx, perms))
+
+	list, err := store.ListPermissions(ctx, "r")
+	require.NoError(t, err)
+	assert.Len(t, list, 2)
+
+	roles := []*common.Role{
+		{Id: "br-1", Name: "br1"},
+		{Id: "br-2", Name: "br2"},
+	}
+	require.NoError(t, store.StoreBulkRoles(ctx, roles))
+
+	subjects := []*common.Subject{
+		{Id: "bs-1", Type: common.SubjectType_SUBJECT_TYPE_USER, DisplayName: "Bob", TenantId: "t", IsActive: true},
+	}
+	require.NoError(t, store.StoreBulkSubjects(ctx, subjects))
+}
+
+func TestRBACStore_GetSubjectRoles(t *testing.T) {
+	store := newRBACStore(t)
+	ctx := context.Background()
+
+	require.NoError(t, store.StoreRole(ctx, &common.Role{Id: "r-1", Name: "admin"}))
+	require.NoError(t, store.StoreRoleAssignment(ctx, &common.RoleAssignment{
+		Id: "a-1", SubjectId: "u-1", RoleId: "r-1", TenantId: "t-1", AssignedBy: "admin",
+	}))
+
+	roles, err := store.GetSubjectRoles(ctx, "u-1", "t-1")
+	require.NoError(t, err)
+	require.Len(t, roles, 1)
+	assert.Equal(t, "r-1", roles[0].Id)
+}

--- a/pkg/storage/providers/sqlite/rbac_store_test.go
+++ b/pkg/storage/providers/sqlite/rbac_store_test.go
@@ -21,6 +21,7 @@ func newRBACStore(t *testing.T) interfaces.RBACStore {
 	p := sqlite.NewSQLiteProvider(dir)
 	store, err := p.CreateRBACStore(map[string]interface{}{"path": filepath.Join(dir, "rbac.db")})
 	require.NoError(t, err)
+	t.Cleanup(func() { _ = store.Close() })
 	return store
 }
 

--- a/pkg/storage/providers/sqlite/registration_store.go
+++ b/pkg/storage/providers/sqlite/registration_store.go
@@ -1,0 +1,226 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+// Package sqlite implements RegistrationTokenStore using SQLite
+package sqlite
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+
+	"github.com/cfgis/cfgms/pkg/storage/interfaces"
+)
+
+// SQLiteRegistrationTokenStore implements interfaces.RegistrationTokenStore using SQLite.
+type SQLiteRegistrationTokenStore struct {
+	db *sql.DB
+}
+
+// Initialize is a no-op; schema is applied in openAndInit.
+func (s *SQLiteRegistrationTokenStore) Initialize(_ context.Context) error { return nil }
+
+// Close closes the database connection.
+func (s *SQLiteRegistrationTokenStore) Close() error {
+	if s.db != nil {
+		return s.db.Close()
+	}
+	return nil
+}
+
+// SaveToken persists a new registration token.
+func (s *SQLiteRegistrationTokenStore) SaveToken(ctx context.Context, token *interfaces.RegistrationTokenData) error {
+	if token == nil {
+		return fmt.Errorf("token cannot be nil")
+	}
+	if token.Token == "" {
+		return fmt.Errorf("token string cannot be empty")
+	}
+	if token.CreatedAt.IsZero() {
+		token.CreatedAt = nowUTC()
+	}
+
+	_, err := s.db.ExecContext(ctx, `
+		INSERT INTO registration_tokens
+			(token, tenant_id, controller_url, group_name, created_at,
+			 expires_at, single_use, used_at, used_by, revoked, revoked_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		token.Token,
+		token.TenantID,
+		token.ControllerURL,
+		token.Group,
+		formatTime(token.CreatedAt),
+		nullTime(token.ExpiresAt),
+		boolToInt(token.SingleUse),
+		nullTime(token.UsedAt),
+		token.UsedBy,
+		boolToInt(token.Revoked),
+		nullTime(token.RevokedAt),
+	)
+	if err != nil {
+		return fmt.Errorf("failed to save registration token: %w", err)
+	}
+	return nil
+}
+
+// GetToken retrieves a registration token by its token string.
+func (s *SQLiteRegistrationTokenStore) GetToken(ctx context.Context, tokenStr string) (*interfaces.RegistrationTokenData, error) {
+	row := s.db.QueryRowContext(ctx, `
+		SELECT token, tenant_id, controller_url, group_name, created_at,
+		       expires_at, single_use, used_at, used_by, revoked, revoked_at
+		FROM registration_tokens WHERE token = ?`, tokenStr)
+	return scanToken(row)
+}
+
+// UpdateToken replaces a registration token's mutable state.
+func (s *SQLiteRegistrationTokenStore) UpdateToken(ctx context.Context, token *interfaces.RegistrationTokenData) error {
+	if token == nil {
+		return fmt.Errorf("token cannot be nil")
+	}
+
+	res, err := s.db.ExecContext(ctx, `
+		UPDATE registration_tokens
+		SET tenant_id = ?, controller_url = ?, group_name = ?,
+		    expires_at = ?, single_use = ?, used_at = ?, used_by = ?,
+		    revoked = ?, revoked_at = ?
+		WHERE token = ?`,
+		token.TenantID,
+		token.ControllerURL,
+		token.Group,
+		nullTime(token.ExpiresAt),
+		boolToInt(token.SingleUse),
+		nullTime(token.UsedAt),
+		token.UsedBy,
+		boolToInt(token.Revoked),
+		nullTime(token.RevokedAt),
+		token.Token,
+	)
+	if err != nil {
+		return fmt.Errorf("failed to update registration token: %w", err)
+	}
+	n, _ := res.RowsAffected()
+	if n == 0 {
+		return fmt.Errorf("registration token not found")
+	}
+	return nil
+}
+
+// DeleteToken removes a registration token.
+func (s *SQLiteRegistrationTokenStore) DeleteToken(ctx context.Context, tokenStr string) error {
+	res, err := s.db.ExecContext(ctx, `DELETE FROM registration_tokens WHERE token = ?`, tokenStr)
+	if err != nil {
+		return fmt.Errorf("failed to delete registration token: %w", err)
+	}
+	n, _ := res.RowsAffected()
+	if n == 0 {
+		return fmt.Errorf("registration token not found")
+	}
+	return nil
+}
+
+// ListTokens returns registration tokens matching an optional filter.
+func (s *SQLiteRegistrationTokenStore) ListTokens(ctx context.Context, filter *interfaces.RegistrationTokenFilter) ([]*interfaces.RegistrationTokenData, error) {
+	query := `SELECT token, tenant_id, controller_url, group_name, created_at,
+	                 expires_at, single_use, used_at, used_by, revoked, revoked_at
+	          FROM registration_tokens WHERE 1=1`
+	var args []interface{}
+
+	if filter != nil {
+		if filter.TenantID != "" {
+			query += ` AND tenant_id = ?`
+			args = append(args, filter.TenantID)
+		}
+		if filter.Group != "" {
+			query += ` AND group_name = ?`
+			args = append(args, filter.Group)
+		}
+		if filter.Revoked != nil {
+			query += ` AND revoked = ?`
+			args = append(args, boolToInt(*filter.Revoked))
+		}
+		if filter.SingleUse != nil {
+			query += ` AND single_use = ?`
+			args = append(args, boolToInt(*filter.SingleUse))
+		}
+		if filter.Used != nil {
+			if *filter.Used {
+				query += ` AND used_at IS NOT NULL`
+			} else {
+				query += ` AND used_at IS NULL`
+			}
+		}
+	}
+
+	query += ` ORDER BY created_at DESC`
+
+	rows, err := s.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list registration tokens: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var tokens []*interfaces.RegistrationTokenData
+	for rows.Next() {
+		t, err := scanTokenRow(rows)
+		if err != nil {
+			return nil, err
+		}
+		tokens = append(tokens, t)
+	}
+	return tokens, rows.Err()
+}
+
+// ---- helpers ----------------------------------------------------------------
+
+func scanToken(row *sql.Row) (*interfaces.RegistrationTokenData, error) {
+	t := &interfaces.RegistrationTokenData{}
+	var createdStr string
+	var expiresAt, usedAt, revokedAt sql.NullString
+	var singleUse, revoked int
+
+	err := row.Scan(
+		&t.Token, &t.TenantID, &t.ControllerURL, &t.Group,
+		&createdStr, &expiresAt, &singleUse, &usedAt, &t.UsedBy,
+		&revoked, &revokedAt,
+	)
+	if err == sql.ErrNoRows {
+		return nil, fmt.Errorf("registration token not found")
+	}
+	if err != nil {
+		return nil, fmt.Errorf("failed to scan registration token: %w", err)
+	}
+	return populateToken(t, createdStr, singleUse, revoked, expiresAt, usedAt, revokedAt)
+}
+
+func scanTokenRow(rows *sql.Rows) (*interfaces.RegistrationTokenData, error) {
+	t := &interfaces.RegistrationTokenData{}
+	var createdStr string
+	var expiresAt, usedAt, revokedAt sql.NullString
+	var singleUse, revoked int
+
+	if err := rows.Scan(
+		&t.Token, &t.TenantID, &t.ControllerURL, &t.Group,
+		&createdStr, &expiresAt, &singleUse, &usedAt, &t.UsedBy,
+		&revoked, &revokedAt,
+	); err != nil {
+		return nil, fmt.Errorf("failed to scan registration token row: %w", err)
+	}
+	return populateToken(t, createdStr, singleUse, revoked, expiresAt, usedAt, revokedAt)
+}
+
+func populateToken(
+	t *interfaces.RegistrationTokenData,
+	createdStr string,
+	singleUse, revoked int,
+	expiresAt, usedAt, revokedAt sql.NullString,
+) (*interfaces.RegistrationTokenData, error) {
+	t.CreatedAt = parseTime(createdStr)
+	t.SingleUse = singleUse != 0
+	t.Revoked = revoked != 0
+	t.ExpiresAt = parseNullTime(expiresAt)
+	t.UsedAt = parseNullTime(usedAt)
+	t.RevokedAt = parseNullTime(revokedAt)
+	return t, nil
+}
+
+// ensure SQLiteRegistrationTokenStore satisfies the interface at compile time
+var _ interfaces.RegistrationTokenStore = (*SQLiteRegistrationTokenStore)(nil)

--- a/pkg/storage/providers/sqlite/registration_store_test.go
+++ b/pkg/storage/providers/sqlite/registration_store_test.go
@@ -21,6 +21,7 @@ func newRegistrationStore(t *testing.T) interfaces.RegistrationTokenStore {
 	p := sqlite.NewSQLiteProvider(dir)
 	store, err := p.CreateRegistrationTokenStore(map[string]interface{}{"path": filepath.Join(dir, "reg.db")})
 	require.NoError(t, err)
+	t.Cleanup(func() { _ = store.Close() })
 	return store
 }
 

--- a/pkg/storage/providers/sqlite/registration_store_test.go
+++ b/pkg/storage/providers/sqlite/registration_store_test.go
@@ -1,0 +1,210 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+package sqlite_test
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cfgis/cfgms/pkg/storage/interfaces"
+	"github.com/cfgis/cfgms/pkg/storage/providers/sqlite"
+)
+
+func newRegistrationStore(t *testing.T) interfaces.RegistrationTokenStore {
+	t.Helper()
+	dir := t.TempDir()
+	p := sqlite.NewSQLiteProvider(dir)
+	store, err := p.CreateRegistrationTokenStore(map[string]interface{}{"path": filepath.Join(dir, "reg.db")})
+	require.NoError(t, err)
+	return store
+}
+
+func TestRegistrationStore_SaveAndGet(t *testing.T) {
+	store := newRegistrationStore(t)
+	ctx := context.Background()
+
+	token := &interfaces.RegistrationTokenData{
+		Token:         "tok-abc123",
+		TenantID:      "tenant-1",
+		ControllerURL: "https://controller.example.com",
+		Group:         "servers",
+		SingleUse:     true,
+	}
+	require.NoError(t, store.SaveToken(ctx, token))
+
+	got, err := store.GetToken(ctx, "tok-abc123")
+	require.NoError(t, err)
+	assert.Equal(t, token.Token, got.Token)
+	assert.Equal(t, token.TenantID, got.TenantID)
+	assert.Equal(t, token.ControllerURL, got.ControllerURL)
+	assert.Equal(t, token.Group, got.Group)
+	assert.True(t, got.SingleUse)
+	assert.False(t, got.Revoked)
+	assert.Nil(t, got.UsedAt)
+	assert.Nil(t, got.ExpiresAt)
+}
+
+func TestRegistrationStore_GetNotFound(t *testing.T) {
+	store := newRegistrationStore(t)
+	ctx := context.Background()
+	_, err := store.GetToken(ctx, "nonexistent")
+	assert.Error(t, err)
+}
+
+func TestRegistrationStore_Update(t *testing.T) {
+	store := newRegistrationStore(t)
+	ctx := context.Background()
+
+	token := &interfaces.RegistrationTokenData{
+		Token:         "tok-upd",
+		TenantID:      "tenant-1",
+		ControllerURL: "https://c.example.com",
+		SingleUse:     true,
+	}
+	require.NoError(t, store.SaveToken(ctx, token))
+
+	// Mark as used
+	token.MarkUsed("steward-xyz")
+	require.NoError(t, store.UpdateToken(ctx, token))
+
+	got, err := store.GetToken(ctx, "tok-upd")
+	require.NoError(t, err)
+	assert.NotNil(t, got.UsedAt)
+	assert.Equal(t, "steward-xyz", got.UsedBy)
+}
+
+func TestRegistrationStore_Delete(t *testing.T) {
+	store := newRegistrationStore(t)
+	ctx := context.Background()
+
+	token := &interfaces.RegistrationTokenData{
+		Token:         "tok-del",
+		TenantID:      "tenant-1",
+		ControllerURL: "https://c.example.com",
+	}
+	require.NoError(t, store.SaveToken(ctx, token))
+	require.NoError(t, store.DeleteToken(ctx, "tok-del"))
+	_, err := store.GetToken(ctx, "tok-del")
+	assert.Error(t, err)
+}
+
+func TestRegistrationStore_Delete_NotFound(t *testing.T) {
+	store := newRegistrationStore(t)
+	ctx := context.Background()
+	assert.Error(t, store.DeleteToken(ctx, "nonexistent"))
+}
+
+func TestRegistrationStore_Expiry(t *testing.T) {
+	store := newRegistrationStore(t)
+	ctx := context.Background()
+
+	past := time.Now().UTC().Add(-1 * time.Hour)
+	future := time.Now().UTC().Add(1 * time.Hour)
+
+	expired := &interfaces.RegistrationTokenData{
+		Token:         "tok-expired",
+		TenantID:      "t",
+		ControllerURL: "https://c.example.com",
+		ExpiresAt:     &past,
+	}
+	valid := &interfaces.RegistrationTokenData{
+		Token:         "tok-valid",
+		TenantID:      "t",
+		ControllerURL: "https://c.example.com",
+		ExpiresAt:     &future,
+	}
+
+	require.NoError(t, store.SaveToken(ctx, expired))
+	require.NoError(t, store.SaveToken(ctx, valid))
+
+	gotExpired, err := store.GetToken(ctx, "tok-expired")
+	require.NoError(t, err)
+	assert.False(t, gotExpired.IsValid(), "expired token should not be valid")
+
+	gotValid, err := store.GetToken(ctx, "tok-valid")
+	require.NoError(t, err)
+	assert.True(t, gotValid.IsValid(), "non-expired token should be valid")
+}
+
+func TestRegistrationStore_Revoke(t *testing.T) {
+	store := newRegistrationStore(t)
+	ctx := context.Background()
+
+	token := &interfaces.RegistrationTokenData{
+		Token:         "tok-rev",
+		TenantID:      "t",
+		ControllerURL: "https://c.example.com",
+	}
+	require.NoError(t, store.SaveToken(ctx, token))
+	token.Revoke()
+	require.NoError(t, store.UpdateToken(ctx, token))
+
+	got, err := store.GetToken(ctx, "tok-rev")
+	require.NoError(t, err)
+	assert.True(t, got.Revoked)
+	assert.False(t, got.IsValid())
+}
+
+func TestRegistrationStore_List(t *testing.T) {
+	store := newRegistrationStore(t)
+	ctx := context.Background()
+
+	for _, tok := range []*interfaces.RegistrationTokenData{
+		{Token: "l-1", TenantID: "t-a", ControllerURL: "https://c.example.com", Group: "servers"},
+		{Token: "l-2", TenantID: "t-b", ControllerURL: "https://c.example.com", Group: "servers"},
+		{Token: "l-3", TenantID: "t-a", ControllerURL: "https://c.example.com", Group: "workstations"},
+	} {
+		require.NoError(t, store.SaveToken(ctx, tok))
+	}
+
+	all, err := store.ListTokens(ctx, nil)
+	require.NoError(t, err)
+	assert.Len(t, all, 3)
+
+	byTenant, err := store.ListTokens(ctx, &interfaces.RegistrationTokenFilter{TenantID: "t-a"})
+	require.NoError(t, err)
+	assert.Len(t, byTenant, 2)
+
+	byGroup, err := store.ListTokens(ctx, &interfaces.RegistrationTokenFilter{Group: "servers"})
+	require.NoError(t, err)
+	assert.Len(t, byGroup, 2)
+}
+
+func TestRegistrationStore_ListUsedFilter(t *testing.T) {
+	store := newRegistrationStore(t)
+	ctx := context.Background()
+
+	tok := &interfaces.RegistrationTokenData{
+		Token:         "tok-used",
+		TenantID:      "t",
+		ControllerURL: "https://c.example.com",
+		SingleUse:     true,
+	}
+	require.NoError(t, store.SaveToken(ctx, tok))
+	tok.MarkUsed("s-1")
+	require.NoError(t, store.UpdateToken(ctx, tok))
+
+	require.NoError(t, store.SaveToken(ctx, &interfaces.RegistrationTokenData{
+		Token:         "tok-unused",
+		TenantID:      "t",
+		ControllerURL: "https://c.example.com",
+	}))
+
+	trueVal := true
+	falseVal := false
+
+	used, err := store.ListTokens(ctx, &interfaces.RegistrationTokenFilter{Used: &trueVal})
+	require.NoError(t, err)
+	assert.Len(t, used, 1)
+	assert.Equal(t, "tok-used", used[0].Token)
+
+	unused, err := store.ListTokens(ctx, &interfaces.RegistrationTokenFilter{Used: &falseVal})
+	require.NoError(t, err)
+	assert.Len(t, unused, 1)
+	assert.Equal(t, "tok-unused", unused[0].Token)
+}

--- a/pkg/storage/providers/sqlite/schema.go
+++ b/pkg/storage/providers/sqlite/schema.go
@@ -1,0 +1,241 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+// Package sqlite provides schema management for the SQLite storage provider
+package sqlite
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+)
+
+const currentSchemaVersion = 1
+
+// initializeSchema creates all tables and tracks schema version.
+// It is safe to call multiple times (all statements use IF NOT EXISTS).
+func initializeSchema(ctx context.Context, db *sql.DB) error {
+	statements := []string{
+		// Schema version tracking
+		`CREATE TABLE IF NOT EXISTS schema_version (
+			id       INTEGER PRIMARY KEY,
+			version  INTEGER NOT NULL,
+			applied_at TEXT NOT NULL
+		)`,
+
+		// Tenants
+		`CREATE TABLE IF NOT EXISTS tenants (
+			id          TEXT PRIMARY KEY,
+			name        TEXT NOT NULL,
+			description TEXT NOT NULL DEFAULT '',
+			parent_id   TEXT,
+			metadata    TEXT NOT NULL DEFAULT '{}',
+			status      TEXT NOT NULL DEFAULT 'active',
+			created_at  TEXT NOT NULL,
+			updated_at  TEXT NOT NULL
+		)`,
+		`CREATE INDEX IF NOT EXISTS idx_tenants_parent_id  ON tenants(parent_id)`,
+		`CREATE INDEX IF NOT EXISTS idx_tenants_status      ON tenants(status)`,
+		`CREATE INDEX IF NOT EXISTS idx_tenants_name        ON tenants(name)`,
+
+		// Client tenants (with M365 extension columns per ADR-003 §2)
+		`CREATE TABLE IF NOT EXISTS client_tenants (
+			id                TEXT PRIMARY KEY,
+			tenant_id         TEXT UNIQUE NOT NULL,
+			tenant_name       TEXT NOT NULL,
+			domain_name       TEXT NOT NULL,
+			admin_email       TEXT NOT NULL,
+			consented_at      TEXT NOT NULL,
+			status            TEXT NOT NULL DEFAULT 'pending',
+			client_identifier TEXT NOT NULL,
+			metadata          TEXT NOT NULL DEFAULT '{}',
+			m365_tenant_id    TEXT,
+			m365_admin_email  TEXT,
+			m365_consented_at TEXT,
+			m365_status       TEXT,
+			created_at        TEXT NOT NULL,
+			updated_at        TEXT NOT NULL
+		)`,
+		`CREATE INDEX IF NOT EXISTS idx_client_tenants_client_identifier ON client_tenants(client_identifier)`,
+		`CREATE INDEX IF NOT EXISTS idx_client_tenants_status            ON client_tenants(status)`,
+
+		// Admin consent requests
+		`CREATE TABLE IF NOT EXISTS admin_consent_requests (
+			state             TEXT PRIMARY KEY,
+			client_identifier TEXT NOT NULL,
+			client_name       TEXT NOT NULL,
+			requested_by      TEXT NOT NULL,
+			expires_at        TEXT NOT NULL,
+			created_at        TEXT NOT NULL,
+			metadata          TEXT NOT NULL DEFAULT '{}'
+		)`,
+		`CREATE INDEX IF NOT EXISTS idx_admin_consent_requests_client_identifier ON admin_consent_requests(client_identifier)`,
+		`CREATE INDEX IF NOT EXISTS idx_admin_consent_requests_expires_at        ON admin_consent_requests(expires_at)`,
+
+		// Audit entries (append-only, no UPDATE/DELETE)
+		`CREATE TABLE IF NOT EXISTS audit_entries (
+			id            TEXT PRIMARY KEY,
+			tenant_id     TEXT NOT NULL,
+			timestamp     TEXT NOT NULL,
+			event_type    TEXT NOT NULL,
+			action        TEXT NOT NULL,
+			user_id       TEXT NOT NULL,
+			user_type     TEXT NOT NULL,
+			session_id    TEXT NOT NULL DEFAULT '',
+			resource_type TEXT NOT NULL,
+			resource_id   TEXT NOT NULL,
+			resource_name TEXT NOT NULL DEFAULT '',
+			result        TEXT NOT NULL,
+			error_code    TEXT NOT NULL DEFAULT '',
+			error_message TEXT NOT NULL DEFAULT '',
+			request_id    TEXT NOT NULL DEFAULT '',
+			ip_address    TEXT NOT NULL DEFAULT '',
+			user_agent    TEXT NOT NULL DEFAULT '',
+			method        TEXT NOT NULL DEFAULT '',
+			path          TEXT NOT NULL DEFAULT '',
+			details       TEXT NOT NULL DEFAULT '{}',
+			changes       TEXT NOT NULL DEFAULT '{}',
+			tags          TEXT NOT NULL DEFAULT '[]',
+			severity      TEXT NOT NULL,
+			source        TEXT NOT NULL,
+			version       TEXT NOT NULL DEFAULT '',
+			checksum      TEXT NOT NULL
+		)`,
+		`CREATE INDEX IF NOT EXISTS idx_audit_entries_tenant_id    ON audit_entries(tenant_id)`,
+		`CREATE INDEX IF NOT EXISTS idx_audit_entries_timestamp    ON audit_entries(timestamp)`,
+		`CREATE INDEX IF NOT EXISTS idx_audit_entries_user_id      ON audit_entries(user_id)`,
+		`CREATE INDEX IF NOT EXISTS idx_audit_entries_event_type   ON audit_entries(event_type)`,
+		`CREATE INDEX IF NOT EXISTS idx_audit_entries_result       ON audit_entries(result)`,
+		`CREATE INDEX IF NOT EXISTS idx_audit_entries_severity     ON audit_entries(severity)`,
+		`CREATE INDEX IF NOT EXISTS idx_audit_entries_resource_id  ON audit_entries(resource_id)`,
+
+		// RBAC permissions
+		`CREATE TABLE IF NOT EXISTS rbac_permissions (
+			id            TEXT PRIMARY KEY,
+			name          TEXT NOT NULL,
+			description   TEXT NOT NULL DEFAULT '',
+			resource_type TEXT NOT NULL,
+			actions       TEXT NOT NULL DEFAULT '[]',
+			created_at    TEXT NOT NULL,
+			updated_at    TEXT NOT NULL
+		)`,
+		`CREATE INDEX IF NOT EXISTS idx_rbac_permissions_resource_type ON rbac_permissions(resource_type)`,
+
+		// RBAC roles
+		`CREATE TABLE IF NOT EXISTS rbac_roles (
+			id               TEXT PRIMARY KEY,
+			name             TEXT NOT NULL,
+			description      TEXT NOT NULL DEFAULT '',
+			permission_ids   TEXT NOT NULL DEFAULT '[]',
+			is_system_role   INTEGER NOT NULL DEFAULT 0,
+			tenant_id        TEXT NOT NULL DEFAULT '',
+			parent_role_id   TEXT NOT NULL DEFAULT '',
+			child_role_ids   TEXT NOT NULL DEFAULT '[]',
+			inheritance_type INTEGER NOT NULL DEFAULT 0,
+			created_at       INTEGER NOT NULL DEFAULT 0,
+			updated_at       INTEGER NOT NULL DEFAULT 0
+		)`,
+		`CREATE INDEX IF NOT EXISTS idx_rbac_roles_tenant_id      ON rbac_roles(tenant_id)`,
+		`CREATE INDEX IF NOT EXISTS idx_rbac_roles_is_system_role  ON rbac_roles(is_system_role)`,
+
+		// RBAC subjects
+		`CREATE TABLE IF NOT EXISTS rbac_subjects (
+			id           TEXT PRIMARY KEY,
+			type         INTEGER NOT NULL DEFAULT 0,
+			display_name TEXT NOT NULL,
+			tenant_id    TEXT NOT NULL,
+			role_ids     TEXT NOT NULL DEFAULT '[]',
+			attributes   TEXT NOT NULL DEFAULT '{}',
+			is_active    INTEGER NOT NULL DEFAULT 1,
+			created_at   INTEGER NOT NULL DEFAULT 0,
+			updated_at   INTEGER NOT NULL DEFAULT 0
+		)`,
+		`CREATE INDEX IF NOT EXISTS idx_rbac_subjects_tenant_id ON rbac_subjects(tenant_id)`,
+		`CREATE INDEX IF NOT EXISTS idx_rbac_subjects_type      ON rbac_subjects(type)`,
+
+		// RBAC role assignments
+		`CREATE TABLE IF NOT EXISTS rbac_role_assignments (
+			id          TEXT PRIMARY KEY,
+			subject_id  TEXT NOT NULL,
+			role_id     TEXT NOT NULL,
+			tenant_id   TEXT NOT NULL,
+			conditions  TEXT NOT NULL DEFAULT '[]',
+			expires_at  INTEGER,
+			assigned_at INTEGER NOT NULL DEFAULT 0,
+			assigned_by TEXT NOT NULL DEFAULT ''
+		)`,
+		`CREATE INDEX IF NOT EXISTS idx_rbac_role_assignments_subject_id ON rbac_role_assignments(subject_id)`,
+		`CREATE INDEX IF NOT EXISTS idx_rbac_role_assignments_role_id    ON rbac_role_assignments(role_id)`,
+		`CREATE INDEX IF NOT EXISTS idx_rbac_role_assignments_tenant_id  ON rbac_role_assignments(tenant_id)`,
+
+		// Registration tokens
+		`CREATE TABLE IF NOT EXISTS registration_tokens (
+			token          TEXT PRIMARY KEY,
+			tenant_id      TEXT NOT NULL,
+			controller_url TEXT NOT NULL,
+			group_name     TEXT NOT NULL DEFAULT '',
+			created_at     TEXT NOT NULL,
+			expires_at     TEXT,
+			single_use     INTEGER NOT NULL DEFAULT 0,
+			used_at        TEXT,
+			used_by        TEXT NOT NULL DEFAULT '',
+			revoked        INTEGER NOT NULL DEFAULT 0,
+			revoked_at     TEXT
+		)`,
+		`CREATE INDEX IF NOT EXISTS idx_registration_tokens_tenant_id  ON registration_tokens(tenant_id)`,
+		`CREATE INDEX IF NOT EXISTS idx_registration_tokens_group_name ON registration_tokens(group_name)`,
+
+		// Durable sessions (Persistent=true only)
+		`CREATE TABLE IF NOT EXISTS sessions (
+			session_id       TEXT PRIMARY KEY,
+			user_id          TEXT NOT NULL,
+			tenant_id        TEXT NOT NULL,
+			session_type     TEXT NOT NULL,
+			created_at       TEXT NOT NULL,
+			last_activity    TEXT NOT NULL,
+			expires_at       TEXT NOT NULL,
+			status           TEXT NOT NULL DEFAULT 'active',
+			persistent       INTEGER NOT NULL DEFAULT 1,
+			client_info      TEXT NOT NULL DEFAULT '{}',
+			metadata         TEXT NOT NULL DEFAULT '{}',
+			session_data     TEXT NOT NULL DEFAULT '{}',
+			security_context TEXT NOT NULL DEFAULT '{}',
+			compliance_flags TEXT NOT NULL DEFAULT '[]',
+			created_by       TEXT NOT NULL DEFAULT '',
+			modified_at      TEXT,
+			modified_by      TEXT NOT NULL DEFAULT ''
+		)`,
+		`CREATE INDEX IF NOT EXISTS idx_sessions_user_id      ON sessions(user_id)`,
+		`CREATE INDEX IF NOT EXISTS idx_sessions_tenant_id    ON sessions(tenant_id)`,
+		`CREATE INDEX IF NOT EXISTS idx_sessions_session_type ON sessions(session_type)`,
+		`CREATE INDEX IF NOT EXISTS idx_sessions_status       ON sessions(status)`,
+		`CREATE INDEX IF NOT EXISTS idx_sessions_expires_at   ON sessions(expires_at)`,
+	}
+
+	for _, stmt := range statements {
+		if _, err := db.ExecContext(ctx, stmt); err != nil {
+			return fmt.Errorf("schema statement failed: %w\nSQL: %s", err, stmt)
+		}
+	}
+
+	// Record or verify schema version
+	if err := recordSchemaVersion(ctx, db); err != nil {
+		return fmt.Errorf("failed to record schema version: %w", err)
+	}
+
+	return nil
+}
+
+func recordSchemaVersion(ctx context.Context, db *sql.DB) error {
+	var count int
+	if err := db.QueryRowContext(ctx, "SELECT COUNT(*) FROM schema_version").Scan(&count); err != nil {
+		return fmt.Errorf("failed to count schema versions: %w", err)
+	}
+	if count > 0 {
+		return nil // already recorded
+	}
+	_, err := db.ExecContext(ctx,
+		`INSERT INTO schema_version (id, version, applied_at) VALUES (1, ?, ?)`,
+		currentSchemaVersion, formatTime(nowUTC()),
+	)
+	return err
+}

--- a/pkg/storage/providers/sqlite/session_store.go
+++ b/pkg/storage/providers/sqlite/session_store.go
@@ -374,11 +374,11 @@ func buildSessionQuery(filter *interfaces.SessionFilter) (string, []interface{})
 func scanSession(row *sql.Row) (*interfaces.Session, error) {
 	sess := &interfaces.Session{}
 	var (
-		sessionTypeStr, statusStr                                    string
-		createdStr, lastActivityStr, expiresStr                      string
-		clientInfoStr, metaStr, sessionDataStr, secCtxStr, flagsStr  string
-		persistentInt                                                 int
-		modifiedAt                                                    sql.NullString
+		sessionTypeStr, statusStr                                   string
+		createdStr, lastActivityStr, expiresStr                     string
+		clientInfoStr, metaStr, sessionDataStr, secCtxStr, flagsStr string
+		persistentInt                                               int
+		modifiedAt                                                  sql.NullString
 	)
 	err := row.Scan(
 		&sess.SessionID, &sess.UserID, &sess.TenantID, &sessionTypeStr,
@@ -399,11 +399,11 @@ func scanSession(row *sql.Row) (*interfaces.Session, error) {
 func scanSessionRow(rows *sql.Rows) (*interfaces.Session, error) {
 	sess := &interfaces.Session{}
 	var (
-		sessionTypeStr, statusStr                                    string
-		createdStr, lastActivityStr, expiresStr                      string
-		clientInfoStr, metaStr, sessionDataStr, secCtxStr, flagsStr  string
-		persistentInt                                                 int
-		modifiedAt                                                    sql.NullString
+		sessionTypeStr, statusStr                                   string
+		createdStr, lastActivityStr, expiresStr                     string
+		clientInfoStr, metaStr, sessionDataStr, secCtxStr, flagsStr string
+		persistentInt                                               int
+		modifiedAt                                                  sql.NullString
 	)
 	if err := rows.Scan(
 		&sess.SessionID, &sess.UserID, &sess.TenantID, &sessionTypeStr,

--- a/pkg/storage/providers/sqlite/session_store.go
+++ b/pkg/storage/providers/sqlite/session_store.go
@@ -1,0 +1,503 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+// Package sqlite implements SessionStore using SQLite (durable Persistent=true sessions only)
+package sqlite
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/cfgis/cfgms/pkg/storage/interfaces"
+)
+
+// SQLiteSessionStore implements interfaces.SessionStore using SQLite.
+// Only sessions with Persistent=true should be written here; ephemeral sessions
+// (Persistent=false) belong in pkg/cache.
+type SQLiteSessionStore struct {
+	db *sql.DB
+}
+
+// Initialize is a no-op; schema is applied in openAndInit.
+func (s *SQLiteSessionStore) Initialize(_ context.Context) error { return nil }
+
+// Close closes the database connection.
+func (s *SQLiteSessionStore) Close() error {
+	if s.db != nil {
+		return s.db.Close()
+	}
+	return nil
+}
+
+// CreateSession inserts a new durable session. Only Persistent=true sessions may be stored here;
+// ephemeral sessions (Persistent=false) belong in pkg/cache.
+func (s *SQLiteSessionStore) CreateSession(ctx context.Context, session *interfaces.Session) error {
+	if session == nil {
+		return fmt.Errorf("session cannot be nil")
+	}
+	if !session.Persistent {
+		return fmt.Errorf("session %s is not persistent: durable SessionStore only accepts Persistent=true sessions", session.SessionID)
+	}
+	if err := session.Validate(); err != nil {
+		return fmt.Errorf("invalid session: %w", err)
+	}
+
+	clientInfoJSON, err := marshalClientInfo(session.ClientInfo)
+	if err != nil {
+		return err
+	}
+	metaJSON, err := marshalJSON(stringMapToInterface(session.Metadata))
+	if err != nil {
+		return err
+	}
+	sessionDataJSON, err := marshalSessionData(session.SessionData)
+	if err != nil {
+		return err
+	}
+	secCtxJSON, err := marshalJSON(session.SecurityContext)
+	if err != nil {
+		return err
+	}
+	flags, err := marshalJSONSlice(session.ComplianceFlags)
+	if err != nil {
+		return err
+	}
+
+	_, err = s.db.ExecContext(ctx, `
+		INSERT INTO sessions
+			(session_id, user_id, tenant_id, session_type,
+			 created_at, last_activity, expires_at, status, persistent,
+			 client_info, metadata, session_data, security_context, compliance_flags,
+			 created_by, modified_at, modified_by)
+		VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`,
+		session.SessionID,
+		session.UserID,
+		session.TenantID,
+		string(session.SessionType),
+		formatTime(session.CreatedAt),
+		formatTime(session.LastActivity),
+		formatTime(session.ExpiresAt),
+		string(session.Status),
+		boolToInt(session.Persistent),
+		clientInfoJSON,
+		metaJSON,
+		sessionDataJSON,
+		secCtxJSON,
+		flags,
+		session.CreatedBy,
+		nullTime(session.ModifiedAt),
+		session.ModifiedBy,
+	)
+	if err != nil {
+		if strings.Contains(err.Error(), "UNIQUE constraint failed") {
+			return fmt.Errorf("session %s already exists", session.SessionID)
+		}
+		return fmt.Errorf("failed to create session %s: %w", session.SessionID, err)
+	}
+	return nil
+}
+
+// GetSession retrieves a session by ID.
+func (s *SQLiteSessionStore) GetSession(ctx context.Context, sessionID string) (*interfaces.Session, error) {
+	row := s.db.QueryRowContext(ctx, `
+		SELECT session_id, user_id, tenant_id, session_type,
+		       created_at, last_activity, expires_at, status, persistent,
+		       client_info, metadata, session_data, security_context, compliance_flags,
+		       created_by, modified_at, modified_by
+		FROM sessions WHERE session_id = ?`, sessionID)
+	return scanSession(row)
+}
+
+// UpdateSession replaces all mutable fields of an existing session.
+func (s *SQLiteSessionStore) UpdateSession(ctx context.Context, sessionID string, session *interfaces.Session) error {
+	if session == nil {
+		return fmt.Errorf("session cannot be nil")
+	}
+
+	now := nowUTC()
+	session.ModifiedAt = &now
+	session.SessionID = sessionID
+
+	clientInfoJSON, err := marshalClientInfo(session.ClientInfo)
+	if err != nil {
+		return err
+	}
+	metaJSON, err := marshalJSON(stringMapToInterface(session.Metadata))
+	if err != nil {
+		return err
+	}
+	sessionDataJSON, err := marshalSessionData(session.SessionData)
+	if err != nil {
+		return err
+	}
+	secCtxJSON, err := marshalJSON(session.SecurityContext)
+	if err != nil {
+		return err
+	}
+	flags, err := marshalJSONSlice(session.ComplianceFlags)
+	if err != nil {
+		return err
+	}
+
+	res, err := s.db.ExecContext(ctx, `
+		UPDATE sessions
+		SET user_id = ?, tenant_id = ?, session_type = ?,
+		    last_activity = ?, expires_at = ?, status = ?, persistent = ?,
+		    client_info = ?, metadata = ?, session_data = ?,
+		    security_context = ?, compliance_flags = ?,
+		    modified_at = ?, modified_by = ?
+		WHERE session_id = ?`,
+		session.UserID,
+		session.TenantID,
+		string(session.SessionType),
+		formatTime(session.LastActivity),
+		formatTime(session.ExpiresAt),
+		string(session.Status),
+		boolToInt(session.Persistent),
+		clientInfoJSON,
+		metaJSON,
+		sessionDataJSON,
+		secCtxJSON,
+		flags,
+		nullTime(session.ModifiedAt),
+		session.ModifiedBy,
+		sessionID,
+	)
+	if err != nil {
+		return fmt.Errorf("failed to update session %s: %w", sessionID, err)
+	}
+	n, _ := res.RowsAffected()
+	if n == 0 {
+		return fmt.Errorf("session %s not found", sessionID)
+	}
+	return nil
+}
+
+// DeleteSession removes a session by ID.
+func (s *SQLiteSessionStore) DeleteSession(ctx context.Context, sessionID string) error {
+	res, err := s.db.ExecContext(ctx, `DELETE FROM sessions WHERE session_id = ?`, sessionID)
+	if err != nil {
+		return fmt.Errorf("failed to delete session %s: %w", sessionID, err)
+	}
+	n, _ := res.RowsAffected()
+	if n == 0 {
+		return fmt.Errorf("session %s not found", sessionID)
+	}
+	return nil
+}
+
+// ListSessions returns sessions matching the filter.
+func (s *SQLiteSessionStore) ListSessions(ctx context.Context, filter *interfaces.SessionFilter) ([]*interfaces.Session, error) {
+	query, args := buildSessionQuery(filter)
+	rows, err := s.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list sessions: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var sessions []*interfaces.Session
+	for rows.Next() {
+		sess, err := scanSessionRow(rows)
+		if err != nil {
+			return nil, err
+		}
+		sessions = append(sessions, sess)
+	}
+	return sessions, rows.Err()
+}
+
+// SetSessionTTL updates the expiry time of a session.
+func (s *SQLiteSessionStore) SetSessionTTL(ctx context.Context, sessionID string, ttl time.Duration) error {
+	newExpiry := nowUTC().Add(ttl)
+	res, err := s.db.ExecContext(ctx, `
+		UPDATE sessions SET expires_at = ?, modified_at = ? WHERE session_id = ?`,
+		formatTime(newExpiry), formatTime(nowUTC()), sessionID)
+	if err != nil {
+		return fmt.Errorf("failed to set session TTL: %w", err)
+	}
+	n, _ := res.RowsAffected()
+	if n == 0 {
+		return fmt.Errorf("session %s not found", sessionID)
+	}
+	return nil
+}
+
+// CleanupExpiredSessions removes sessions whose expires_at is in the past.
+// Returns the number of sessions deleted.
+func (s *SQLiteSessionStore) CleanupExpiredSessions(ctx context.Context) (int, error) {
+	res, err := s.db.ExecContext(ctx,
+		`DELETE FROM sessions WHERE expires_at < ?`, formatTime(nowUTC()))
+	if err != nil {
+		return 0, fmt.Errorf("failed to cleanup expired sessions: %w", err)
+	}
+	n, _ := res.RowsAffected()
+	return int(n), nil
+}
+
+// GetSessionsByUser returns all sessions for a user.
+func (s *SQLiteSessionStore) GetSessionsByUser(ctx context.Context, userID string) ([]*interfaces.Session, error) {
+	return s.ListSessions(ctx, &interfaces.SessionFilter{UserID: userID})
+}
+
+// GetSessionsByTenant returns all sessions for a tenant.
+func (s *SQLiteSessionStore) GetSessionsByTenant(ctx context.Context, tenantID string) ([]*interfaces.Session, error) {
+	return s.ListSessions(ctx, &interfaces.SessionFilter{TenantID: tenantID})
+}
+
+// GetSessionsByType returns all sessions of a specific type.
+func (s *SQLiteSessionStore) GetSessionsByType(ctx context.Context, sessionType interfaces.SessionType) ([]*interfaces.Session, error) {
+	return s.ListSessions(ctx, &interfaces.SessionFilter{Type: sessionType})
+}
+
+// GetActiveSessionsCount returns the number of non-expired active sessions.
+func (s *SQLiteSessionStore) GetActiveSessionsCount(ctx context.Context) (int64, error) {
+	var count int64
+	err := s.db.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM sessions WHERE status = ? AND expires_at > ?`,
+		string(interfaces.SessionStatusActive), formatTime(nowUTC()),
+	).Scan(&count)
+	if err != nil {
+		return 0, fmt.Errorf("failed to count active sessions: %w", err)
+	}
+	return count, nil
+}
+
+// HealthCheck verifies the database is reachable.
+func (s *SQLiteSessionStore) HealthCheck(ctx context.Context) error {
+	return s.db.PingContext(ctx)
+}
+
+// GetStats returns aggregate statistics about stored sessions.
+func (s *SQLiteSessionStore) GetStats(ctx context.Context) (*interfaces.RuntimeStoreStats, error) {
+	stats := &interfaces.RuntimeStoreStats{
+		SessionsByType:   make(map[string]int64),
+		SessionsByStatus: make(map[string]int64),
+	}
+
+	if err := s.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM sessions`).Scan(&stats.TotalSessions); err != nil {
+		return nil, fmt.Errorf("failed to count total sessions: %w", err)
+	}
+
+	rows, err := s.db.QueryContext(ctx, `SELECT session_type, COUNT(*) FROM sessions GROUP BY session_type`)
+	if err != nil {
+		return nil, fmt.Errorf("failed to aggregate sessions by type: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	for rows.Next() {
+		var k string
+		var v int64
+		if err := rows.Scan(&k, &v); err == nil {
+			stats.SessionsByType[k] = v
+		}
+	}
+
+	rows2, err := s.db.QueryContext(ctx, `SELECT status, COUNT(*) FROM sessions GROUP BY status`)
+	if err != nil {
+		return nil, fmt.Errorf("failed to aggregate sessions by status: %w", err)
+	}
+	defer func() { _ = rows2.Close() }()
+	for rows2.Next() {
+		var k string
+		var v int64
+		if err := rows2.Scan(&k, &v); err == nil {
+			stats.SessionsByStatus[k] = v
+		}
+	}
+
+	if v, ok := stats.SessionsByStatus[string(interfaces.SessionStatusActive)]; ok {
+		stats.ActiveSessions = v
+	}
+
+	return stats, nil
+}
+
+// ---- helpers ----------------------------------------------------------------
+
+func buildSessionQuery(filter *interfaces.SessionFilter) (string, []interface{}) {
+	base := `SELECT session_id, user_id, tenant_id, session_type,
+	                created_at, last_activity, expires_at, status, persistent,
+	                client_info, metadata, session_data, security_context, compliance_flags,
+	                created_by, modified_at, modified_by
+	         FROM sessions`
+
+	if filter == nil {
+		return base + ` ORDER BY created_at DESC`, nil
+	}
+
+	var conditions []string
+	var args []interface{}
+
+	if filter.UserID != "" {
+		conditions = append(conditions, `user_id = ?`)
+		args = append(args, filter.UserID)
+	}
+	if filter.TenantID != "" {
+		conditions = append(conditions, `tenant_id = ?`)
+		args = append(args, filter.TenantID)
+	}
+	if filter.Type != "" {
+		conditions = append(conditions, `session_type = ?`)
+		args = append(args, string(filter.Type))
+	}
+	if filter.Status != "" {
+		conditions = append(conditions, `status = ?`)
+		args = append(args, string(filter.Status))
+	}
+	if filter.CreatedAfter != nil {
+		conditions = append(conditions, `created_at >= ?`)
+		args = append(args, formatTime(*filter.CreatedAfter))
+	}
+	if filter.CreatedBefore != nil {
+		conditions = append(conditions, `created_at <= ?`)
+		args = append(args, formatTime(*filter.CreatedBefore))
+	}
+
+	query := base
+	if len(conditions) > 0 {
+		query += ` WHERE ` + strings.Join(conditions, ` AND `)
+	}
+	query += ` ORDER BY created_at DESC`
+
+	if filter.Limit > 0 {
+		query += fmt.Sprintf(` LIMIT %d`, filter.Limit)
+	}
+	if filter.Offset > 0 {
+		query += fmt.Sprintf(` OFFSET %d`, filter.Offset)
+	}
+
+	return query, args
+}
+
+func scanSession(row *sql.Row) (*interfaces.Session, error) {
+	sess := &interfaces.Session{}
+	var (
+		sessionTypeStr, statusStr                                    string
+		createdStr, lastActivityStr, expiresStr                      string
+		clientInfoStr, metaStr, sessionDataStr, secCtxStr, flagsStr  string
+		persistentInt                                                 int
+		modifiedAt                                                    sql.NullString
+	)
+	err := row.Scan(
+		&sess.SessionID, &sess.UserID, &sess.TenantID, &sessionTypeStr,
+		&createdStr, &lastActivityStr, &expiresStr, &statusStr, &persistentInt,
+		&clientInfoStr, &metaStr, &sessionDataStr, &secCtxStr, &flagsStr,
+		&sess.CreatedBy, &modifiedAt, &sess.ModifiedBy,
+	)
+	if err == sql.ErrNoRows {
+		return nil, fmt.Errorf("session not found")
+	}
+	if err != nil {
+		return nil, fmt.Errorf("failed to scan session: %w", err)
+	}
+	return populateSession(sess, sessionTypeStr, statusStr, createdStr, lastActivityStr, expiresStr,
+		persistentInt, clientInfoStr, metaStr, sessionDataStr, secCtxStr, flagsStr, modifiedAt)
+}
+
+func scanSessionRow(rows *sql.Rows) (*interfaces.Session, error) {
+	sess := &interfaces.Session{}
+	var (
+		sessionTypeStr, statusStr                                    string
+		createdStr, lastActivityStr, expiresStr                      string
+		clientInfoStr, metaStr, sessionDataStr, secCtxStr, flagsStr  string
+		persistentInt                                                 int
+		modifiedAt                                                    sql.NullString
+	)
+	if err := rows.Scan(
+		&sess.SessionID, &sess.UserID, &sess.TenantID, &sessionTypeStr,
+		&createdStr, &lastActivityStr, &expiresStr, &statusStr, &persistentInt,
+		&clientInfoStr, &metaStr, &sessionDataStr, &secCtxStr, &flagsStr,
+		&sess.CreatedBy, &modifiedAt, &sess.ModifiedBy,
+	); err != nil {
+		return nil, fmt.Errorf("failed to scan session row: %w", err)
+	}
+	return populateSession(sess, sessionTypeStr, statusStr, createdStr, lastActivityStr, expiresStr,
+		persistentInt, clientInfoStr, metaStr, sessionDataStr, secCtxStr, flagsStr, modifiedAt)
+}
+
+func populateSession(
+	sess *interfaces.Session,
+	sessionTypeStr, statusStr,
+	createdStr, lastActivityStr, expiresStr string,
+	persistentInt int,
+	clientInfoStr, metaStr, sessionDataStr, secCtxStr, flagsStr string,
+	modifiedAt sql.NullString,
+) (*interfaces.Session, error) {
+	sess.SessionType = interfaces.SessionType(sessionTypeStr)
+	sess.Status = interfaces.SessionStatus(statusStr)
+	sess.CreatedAt = parseTime(createdStr)
+	sess.LastActivity = parseTime(lastActivityStr)
+	sess.ExpiresAt = parseTime(expiresStr)
+	sess.Persistent = persistentInt != 0
+	sess.ModifiedAt = parseNullTime(modifiedAt)
+
+	// ClientInfo
+	if clientInfoStr != "" && clientInfoStr != "{}" {
+		ci := &interfaces.ClientInfo{}
+		if err := json.Unmarshal([]byte(clientInfoStr), ci); err == nil {
+			sess.ClientInfo = ci
+		}
+	}
+
+	// Metadata (map[string]string)
+	meta, err := unmarshalJSONStringMap(metaStr)
+	if err == nil {
+		sess.Metadata = meta
+	}
+
+	// SessionData (arbitrary interface{})
+	if sessionDataStr != "" && sessionDataStr != "{}" && sessionDataStr != "null" {
+		var sd interface{}
+		if err := json.Unmarshal([]byte(sessionDataStr), &sd); err == nil {
+			sess.SessionData = sd
+		}
+	}
+
+	// SecurityContext
+	secCtx, _ := unmarshalJSONMap(secCtxStr)
+	sess.SecurityContext = secCtx
+
+	// ComplianceFlags
+	flags, _ := unmarshalJSONSlice(flagsStr)
+	sess.ComplianceFlags = flags
+
+	return sess, nil
+}
+
+func marshalClientInfo(ci *interfaces.ClientInfo) (string, error) {
+	if ci == nil {
+		return "{}", nil
+	}
+	b, err := json.Marshal(ci)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal client info: %w", err)
+	}
+	return string(b), nil
+}
+
+func marshalSessionData(data interface{}) (string, error) {
+	if data == nil {
+		return "{}", nil
+	}
+	b, err := json.Marshal(data)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal session data: %w", err)
+	}
+	return string(b), nil
+}
+
+func stringMapToInterface(m map[string]string) map[string]interface{} {
+	if m == nil {
+		return nil
+	}
+	out := make(map[string]interface{}, len(m))
+	for k, v := range m {
+		out[k] = v
+	}
+	return out
+}
+
+// ensure SQLiteSessionStore satisfies the interface at compile time
+var _ interfaces.SessionStore = (*SQLiteSessionStore)(nil)

--- a/pkg/storage/providers/sqlite/session_store_test.go
+++ b/pkg/storage/providers/sqlite/session_store_test.go
@@ -21,6 +21,7 @@ func newSessionStore(t *testing.T) interfaces.SessionStore {
 	p := sqlite.NewSQLiteProvider(dir)
 	store, err := p.CreateSessionStore(map[string]interface{}{"path": filepath.Join(dir, "sessions.db")})
 	require.NoError(t, err)
+	t.Cleanup(func() { _ = store.Close() })
 	return store
 }
 

--- a/pkg/storage/providers/sqlite/session_store_test.go
+++ b/pkg/storage/providers/sqlite/session_store_test.go
@@ -1,0 +1,312 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+package sqlite_test
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cfgis/cfgms/pkg/storage/interfaces"
+	"github.com/cfgis/cfgms/pkg/storage/providers/sqlite"
+)
+
+func newSessionStore(t *testing.T) interfaces.SessionStore {
+	t.Helper()
+	dir := t.TempDir()
+	p := sqlite.NewSQLiteProvider(dir)
+	store, err := p.CreateSessionStore(map[string]interface{}{"path": filepath.Join(dir, "sessions.db")})
+	require.NoError(t, err)
+	return store
+}
+
+func sampleSession(id string) *interfaces.Session {
+	now := time.Now().UTC().Truncate(time.Millisecond)
+	return &interfaces.Session{
+		SessionID:    id,
+		UserID:       "user-1",
+		TenantID:     "tenant-1",
+		SessionType:  interfaces.SessionTypeAPI,
+		CreatedAt:    now,
+		LastActivity: now,
+		ExpiresAt:    now.Add(1 * time.Hour),
+		Status:       interfaces.SessionStatusActive,
+		Persistent:   true,
+	}
+}
+
+func TestSessionStore_CreateAndGet(t *testing.T) {
+	store := newSessionStore(t)
+	ctx := context.Background()
+
+	sess := sampleSession("sess-001")
+	sess.CreatedBy = "admin"
+	sess.Metadata = map[string]string{"source": "api"}
+	sess.ClientInfo = &interfaces.ClientInfo{
+		IPAddress: "192.168.1.1",
+		Platform:  "linux",
+	}
+
+	require.NoError(t, store.CreateSession(ctx, sess))
+
+	got, err := store.GetSession(ctx, "sess-001")
+	require.NoError(t, err)
+	assert.Equal(t, sess.SessionID, got.SessionID)
+	assert.Equal(t, sess.UserID, got.UserID)
+	assert.Equal(t, sess.TenantID, got.TenantID)
+	assert.Equal(t, interfaces.SessionTypeAPI, got.SessionType)
+	assert.Equal(t, interfaces.SessionStatusActive, got.Status)
+	assert.True(t, got.Persistent)
+	assert.Equal(t, "api", got.Metadata["source"])
+	require.NotNil(t, got.ClientInfo)
+	assert.Equal(t, "192.168.1.1", got.ClientInfo.IPAddress)
+}
+
+func TestSessionStore_GetNotFound(t *testing.T) {
+	store := newSessionStore(t)
+	ctx := context.Background()
+	_, err := store.GetSession(ctx, "nonexistent")
+	assert.Error(t, err)
+}
+
+func TestSessionStore_Update(t *testing.T) {
+	store := newSessionStore(t)
+	ctx := context.Background()
+
+	sess := sampleSession("sess-upd")
+	require.NoError(t, store.CreateSession(ctx, sess))
+
+	sess.Status = interfaces.SessionStatusInactive
+	sess.LastActivity = time.Now().UTC()
+	require.NoError(t, store.UpdateSession(ctx, "sess-upd", sess))
+
+	got, err := store.GetSession(ctx, "sess-upd")
+	require.NoError(t, err)
+	assert.Equal(t, interfaces.SessionStatusInactive, got.Status)
+	assert.NotNil(t, got.ModifiedAt)
+}
+
+func TestSessionStore_Update_NotFound(t *testing.T) {
+	store := newSessionStore(t)
+	ctx := context.Background()
+	sess := sampleSession("nonexistent")
+	assert.Error(t, store.UpdateSession(ctx, "nonexistent", sess))
+}
+
+func TestSessionStore_Delete(t *testing.T) {
+	store := newSessionStore(t)
+	ctx := context.Background()
+
+	sess := sampleSession("sess-del")
+	require.NoError(t, store.CreateSession(ctx, sess))
+	require.NoError(t, store.DeleteSession(ctx, "sess-del"))
+	_, err := store.GetSession(ctx, "sess-del")
+	assert.Error(t, err)
+}
+
+func TestSessionStore_Delete_NotFound(t *testing.T) {
+	store := newSessionStore(t)
+	ctx := context.Background()
+	assert.Error(t, store.DeleteSession(ctx, "nonexistent"))
+}
+
+func TestSessionStore_SetSessionTTL(t *testing.T) {
+	store := newSessionStore(t)
+	ctx := context.Background()
+
+	sess := sampleSession("sess-ttl")
+	require.NoError(t, store.CreateSession(ctx, sess))
+
+	require.NoError(t, store.SetSessionTTL(ctx, "sess-ttl", 2*time.Hour))
+
+	got, err := store.GetSession(ctx, "sess-ttl")
+	require.NoError(t, err)
+	// New expiry should be roughly 2 hours from now
+	assert.True(t, got.ExpiresAt.After(time.Now().UTC().Add(90*time.Minute)))
+}
+
+func TestSessionStore_CleanupExpiredSessions(t *testing.T) {
+	store := newSessionStore(t)
+	ctx := context.Background()
+
+	// Create a session already expired (CreatedAt must be before ExpiresAt to pass validation)
+	pastCreated := time.Now().UTC().Add(-3 * time.Hour)
+	pastExpired := time.Now().UTC().Add(-1 * time.Hour)
+	expired := &interfaces.Session{
+		SessionID:    "sess-exp",
+		UserID:       "user-1",
+		TenantID:     "tenant-1",
+		SessionType:  interfaces.SessionTypeAPI,
+		CreatedAt:    pastCreated,
+		LastActivity: pastCreated,
+		ExpiresAt:    pastExpired, // expired 1 hour ago
+		Status:       interfaces.SessionStatusExpired,
+		Persistent:   true,
+	}
+	require.NoError(t, store.CreateSession(ctx, expired))
+
+	// Create a valid session
+	valid := sampleSession("sess-ok")
+	require.NoError(t, store.CreateSession(ctx, valid))
+
+	n, err := store.CleanupExpiredSessions(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 1, n, "exactly one expired session should be cleaned up")
+
+	// Valid session must still exist
+	_, err = store.GetSession(ctx, "sess-ok")
+	assert.NoError(t, err)
+
+	// Expired session must be gone
+	_, err = store.GetSession(ctx, "sess-exp")
+	assert.Error(t, err)
+}
+
+func TestSessionStore_GetSessionsByUser(t *testing.T) {
+	store := newSessionStore(t)
+	ctx := context.Background()
+
+	s1 := sampleSession("by-user-1")
+	s1.UserID = "alice"
+	s2 := sampleSession("by-user-2")
+	s2.UserID = "bob"
+	require.NoError(t, store.CreateSession(ctx, s1))
+	require.NoError(t, store.CreateSession(ctx, s2))
+
+	results, err := store.GetSessionsByUser(ctx, "alice")
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	assert.Equal(t, "alice", results[0].UserID)
+}
+
+func TestSessionStore_GetSessionsByTenant(t *testing.T) {
+	store := newSessionStore(t)
+	ctx := context.Background()
+
+	s1 := sampleSession("by-tenant-1")
+	s1.TenantID = "ta"
+	s2 := sampleSession("by-tenant-2")
+	s2.TenantID = "tb"
+	require.NoError(t, store.CreateSession(ctx, s1))
+	require.NoError(t, store.CreateSession(ctx, s2))
+
+	results, err := store.GetSessionsByTenant(ctx, "ta")
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	assert.Equal(t, "ta", results[0].TenantID)
+}
+
+func TestSessionStore_GetSessionsByType(t *testing.T) {
+	store := newSessionStore(t)
+	ctx := context.Background()
+
+	s1 := sampleSession("by-type-api")
+	s1.SessionType = interfaces.SessionTypeAPI
+	s2 := sampleSession("by-type-web")
+	s2.SessionType = interfaces.SessionTypeWeb
+	require.NoError(t, store.CreateSession(ctx, s1))
+	require.NoError(t, store.CreateSession(ctx, s2))
+
+	results, err := store.GetSessionsByType(ctx, interfaces.SessionTypeAPI)
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	assert.Equal(t, interfaces.SessionTypeAPI, results[0].SessionType)
+}
+
+func TestSessionStore_GetActiveSessionsCount(t *testing.T) {
+	store := newSessionStore(t)
+	ctx := context.Background()
+
+	active1 := sampleSession("active-1")
+	active2 := sampleSession("active-2")
+	inactive := sampleSession("inactive-1")
+	inactive.Status = interfaces.SessionStatusInactive
+
+	require.NoError(t, store.CreateSession(ctx, active1))
+	require.NoError(t, store.CreateSession(ctx, active2))
+	require.NoError(t, store.CreateSession(ctx, inactive))
+
+	count, err := store.GetActiveSessionsCount(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, int64(2), count)
+}
+
+func TestSessionStore_HealthCheck(t *testing.T) {
+	store := newSessionStore(t)
+	ctx := context.Background()
+	assert.NoError(t, store.HealthCheck(ctx))
+}
+
+func TestSessionStore_GetStats(t *testing.T) {
+	store := newSessionStore(t)
+	ctx := context.Background()
+
+	for _, sess := range []*interfaces.Session{
+		sampleSession("stats-1"),
+		sampleSession("stats-2"),
+		{SessionID: "stats-3", UserID: "u", TenantID: "t",
+			SessionType: interfaces.SessionTypeWeb,
+			CreatedAt:   time.Now().UTC(), LastActivity: time.Now().UTC(),
+			ExpiresAt: time.Now().UTC().Add(time.Hour),
+			Status:    interfaces.SessionStatusActive, Persistent: true},
+	} {
+		require.NoError(t, store.CreateSession(ctx, sess))
+	}
+
+	stats, err := store.GetStats(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, int64(3), stats.TotalSessions)
+	assert.Greater(t, stats.ActiveSessions, int64(0))
+}
+
+func TestSessionStore_ListSessions_Filter(t *testing.T) {
+	store := newSessionStore(t)
+	ctx := context.Background()
+
+	now := time.Now().UTC()
+	for _, sess := range []*interfaces.Session{
+		{SessionID: "f-1", UserID: "u1", TenantID: "t1", SessionType: interfaces.SessionTypeAPI,
+			CreatedAt: now, LastActivity: now, ExpiresAt: now.Add(time.Hour),
+			Status: interfaces.SessionStatusActive, Persistent: true},
+		{SessionID: "f-2", UserID: "u2", TenantID: "t1", SessionType: interfaces.SessionTypeWeb,
+			CreatedAt: now, LastActivity: now, ExpiresAt: now.Add(time.Hour),
+			Status: interfaces.SessionStatusActive, Persistent: true},
+		{SessionID: "f-3", UserID: "u1", TenantID: "t2", SessionType: interfaces.SessionTypeAPI,
+			CreatedAt: now, LastActivity: now, ExpiresAt: now.Add(time.Hour),
+			Status: interfaces.SessionStatusInactive, Persistent: true},
+	} {
+		require.NoError(t, store.CreateSession(ctx, sess))
+	}
+
+	// Filter by tenant
+	byTenant, err := store.ListSessions(ctx, &interfaces.SessionFilter{TenantID: "t1"})
+	require.NoError(t, err)
+	assert.Len(t, byTenant, 2)
+
+	// Filter by status
+	active, err := store.ListSessions(ctx, &interfaces.SessionFilter{Status: interfaces.SessionStatusActive})
+	require.NoError(t, err)
+	assert.Len(t, active, 2)
+
+	// Filter by limit
+	limited, err := store.ListSessions(ctx, &interfaces.SessionFilter{Limit: 1})
+	require.NoError(t, err)
+	assert.Len(t, limited, 1)
+}
+
+// TestSessionStore_NoEphemeralMethods verifies that SessionStore only persists
+// durable (Persistent=true) sessions and that non-persistent sessions are rejected.
+func TestSessionStore_NoEphemeralMethods(t *testing.T) {
+	store := newSessionStore(t)
+	ctx := context.Background()
+
+	ephemeral := sampleSession("sess-ephemeral")
+	ephemeral.Persistent = false
+
+	err := store.CreateSession(ctx, ephemeral)
+	assert.Error(t, err, "non-persistent session must be rejected by the durable SessionStore")
+}

--- a/pkg/storage/providers/sqlite/tenant_store.go
+++ b/pkg/storage/providers/sqlite/tenant_store.go
@@ -1,0 +1,319 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+// Package sqlite implements TenantStore using SQLite
+package sqlite
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"time"
+
+	"github.com/cfgis/cfgms/pkg/storage/interfaces"
+)
+
+// SQLiteTenantStore implements interfaces.TenantStore using SQLite.
+type SQLiteTenantStore struct {
+	db *sql.DB
+}
+
+// Initialize is a no-op: schema is created in openAndInit before this store is returned.
+func (s *SQLiteTenantStore) Initialize(ctx context.Context) error { return nil }
+
+// Close closes the underlying database connection.
+func (s *SQLiteTenantStore) Close() error {
+	if s.db != nil {
+		return s.db.Close()
+	}
+	return nil
+}
+
+// CreateTenant persists a new tenant.
+func (s *SQLiteTenantStore) CreateTenant(ctx context.Context, tenant *interfaces.TenantData) error {
+	if tenant == nil {
+		return fmt.Errorf("tenant cannot be nil")
+	}
+	if tenant.ID == "" {
+		return fmt.Errorf("tenant ID cannot be empty")
+	}
+
+	now := nowUTC()
+	if tenant.CreatedAt.IsZero() {
+		tenant.CreatedAt = now
+	}
+	if tenant.UpdatedAt.IsZero() {
+		tenant.UpdatedAt = now
+	}
+
+	meta, err := marshalJSON(tenant.Metadata)
+	if err != nil {
+		return fmt.Errorf("failed to marshal tenant metadata: %w", err)
+	}
+
+	_, err = s.db.ExecContext(ctx, `
+		INSERT INTO tenants (id, name, description, parent_id, metadata, status, created_at, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+		tenant.ID,
+		tenant.Name,
+		tenant.Description,
+		nullString(tenant.ParentID),
+		meta,
+		string(tenant.Status),
+		formatTime(tenant.CreatedAt),
+		formatTime(tenant.UpdatedAt),
+	)
+	if err != nil {
+		return fmt.Errorf("failed to create tenant %s: %w", tenant.ID, err)
+	}
+	return nil
+}
+
+// GetTenant retrieves a tenant by ID.
+func (s *SQLiteTenantStore) GetTenant(ctx context.Context, tenantID string) (*interfaces.TenantData, error) {
+	if tenantID == "" {
+		return nil, fmt.Errorf("tenant ID cannot be empty")
+	}
+
+	row := s.db.QueryRowContext(ctx, `
+		SELECT id, name, description, parent_id, metadata, status, created_at, updated_at
+		FROM tenants WHERE id = ?`, tenantID)
+
+	return scanTenant(row)
+}
+
+// UpdateTenant replaces all mutable fields of an existing tenant.
+func (s *SQLiteTenantStore) UpdateTenant(ctx context.Context, tenant *interfaces.TenantData) error {
+	if tenant == nil {
+		return fmt.Errorf("tenant cannot be nil")
+	}
+	if tenant.ID == "" {
+		return fmt.Errorf("tenant ID cannot be empty")
+	}
+
+	tenant.UpdatedAt = nowUTC()
+
+	meta, err := marshalJSON(tenant.Metadata)
+	if err != nil {
+		return fmt.Errorf("failed to marshal tenant metadata: %w", err)
+	}
+
+	res, err := s.db.ExecContext(ctx, `
+		UPDATE tenants
+		SET name = ?, description = ?, parent_id = ?, metadata = ?, status = ?, updated_at = ?
+		WHERE id = ?`,
+		tenant.Name,
+		tenant.Description,
+		nullString(tenant.ParentID),
+		meta,
+		string(tenant.Status),
+		formatTime(tenant.UpdatedAt),
+		tenant.ID,
+	)
+	if err != nil {
+		return fmt.Errorf("failed to update tenant %s: %w", tenant.ID, err)
+	}
+	n, _ := res.RowsAffected()
+	if n == 0 {
+		return fmt.Errorf("tenant %s not found", tenant.ID)
+	}
+	return nil
+}
+
+// DeleteTenant removes a tenant by ID.
+func (s *SQLiteTenantStore) DeleteTenant(ctx context.Context, tenantID string) error {
+	if tenantID == "" {
+		return fmt.Errorf("tenant ID cannot be empty")
+	}
+
+	res, err := s.db.ExecContext(ctx, `DELETE FROM tenants WHERE id = ?`, tenantID)
+	if err != nil {
+		return fmt.Errorf("failed to delete tenant %s: %w", tenantID, err)
+	}
+	n, _ := res.RowsAffected()
+	if n == 0 {
+		return fmt.Errorf("tenant %s not found", tenantID)
+	}
+	return nil
+}
+
+// ListTenants returns tenants matching the optional filter.
+func (s *SQLiteTenantStore) ListTenants(ctx context.Context, filter *interfaces.TenantFilter) ([]*interfaces.TenantData, error) {
+	query := `SELECT id, name, description, parent_id, metadata, status, created_at, updated_at FROM tenants WHERE 1=1`
+	args := []interface{}{}
+
+	if filter != nil {
+		if filter.ParentID != "" {
+			query += ` AND parent_id = ?`
+			args = append(args, filter.ParentID)
+		}
+		if filter.Status != "" {
+			query += ` AND status = ?`
+			args = append(args, string(filter.Status))
+		}
+		if filter.Name != "" {
+			query += ` AND LOWER(name) LIKE LOWER(?)`
+			args = append(args, "%"+filter.Name+"%")
+		}
+	}
+
+	query += ` ORDER BY created_at DESC`
+
+	rows, err := s.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list tenants: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var tenants []*interfaces.TenantData
+	for rows.Next() {
+		t, err := scanTenantRow(rows)
+		if err != nil {
+			return nil, err
+		}
+		tenants = append(tenants, t)
+	}
+	return tenants, rows.Err()
+}
+
+// GetTenantHierarchy returns the hierarchy (path, depth, direct children) for a tenant.
+func (s *SQLiteTenantStore) GetTenantHierarchy(ctx context.Context, tenantID string) (*interfaces.TenantHierarchy, error) {
+	if tenantID == "" {
+		return nil, fmt.Errorf("tenant ID cannot be empty")
+	}
+
+	path, err := s.GetTenantPath(ctx, tenantID)
+	if err != nil {
+		return nil, err
+	}
+
+	children, err := s.GetChildTenants(ctx, tenantID)
+	if err != nil {
+		return nil, err
+	}
+	childIDs := make([]string, len(children))
+	for i, c := range children {
+		childIDs[i] = c.ID
+	}
+
+	return &interfaces.TenantHierarchy{
+		TenantID: tenantID,
+		Path:     path,
+		Depth:    len(path) - 1,
+		Children: childIDs,
+	}, nil
+}
+
+// GetChildTenants returns direct children of the given parent.
+func (s *SQLiteTenantStore) GetChildTenants(ctx context.Context, parentID string) ([]*interfaces.TenantData, error) {
+	return s.ListTenants(ctx, &interfaces.TenantFilter{ParentID: parentID})
+}
+
+// GetTenantPath returns the path from root to the specified tenant (root first).
+func (s *SQLiteTenantStore) GetTenantPath(ctx context.Context, tenantID string) ([]string, error) {
+	if tenantID == "" {
+		return nil, fmt.Errorf("tenant ID cannot be empty")
+	}
+
+	var path []string
+	current := tenantID
+
+	for current != "" {
+		t, err := s.GetTenant(ctx, current)
+		if err != nil {
+			return nil, err
+		}
+		path = append([]string{current}, path...)
+		current = t.ParentID
+
+		if len(path) > 100 {
+			return nil, fmt.Errorf("tenant hierarchy depth exceeded (possible circular reference)")
+		}
+	}
+	return path, nil
+}
+
+// IsTenantAncestor returns true if ancestorID is an ancestor of descendantID.
+func (s *SQLiteTenantStore) IsTenantAncestor(ctx context.Context, ancestorID, descendantID string) (bool, error) {
+	if ancestorID == "" || descendantID == "" {
+		return false, fmt.Errorf("ancestor and descendant IDs cannot be empty")
+	}
+	path, err := s.GetTenantPath(ctx, descendantID)
+	if err != nil {
+		return false, err
+	}
+	for _, id := range path {
+		if id == ancestorID {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// scanTenant scans a single Row (QueryRow) into a TenantData.
+func scanTenant(row *sql.Row) (*interfaces.TenantData, error) {
+	var t interfaces.TenantData
+	var parentID sql.NullString
+	var metaStr, statusStr, createdStr, updatedStr string
+
+	err := row.Scan(
+		&t.ID, &t.Name, &t.Description,
+		&parentID, &metaStr, &statusStr,
+		&createdStr, &updatedStr,
+	)
+	if err == sql.ErrNoRows {
+		return nil, fmt.Errorf("tenant not found")
+	}
+	if err != nil {
+		return nil, fmt.Errorf("failed to scan tenant: %w", err)
+	}
+
+	return populateTenant(&t, parentID, metaStr, statusStr, createdStr, updatedStr)
+}
+
+// scanTenantRow scans a Rows (Query) into a TenantData.
+func scanTenantRow(rows *sql.Rows) (*interfaces.TenantData, error) {
+	var t interfaces.TenantData
+	var parentID sql.NullString
+	var metaStr, statusStr, createdStr, updatedStr string
+
+	if err := rows.Scan(
+		&t.ID, &t.Name, &t.Description,
+		&parentID, &metaStr, &statusStr,
+		&createdStr, &updatedStr,
+	); err != nil {
+		return nil, fmt.Errorf("failed to scan tenant row: %w", err)
+	}
+
+	return populateTenant(&t, parentID, metaStr, statusStr, createdStr, updatedStr)
+}
+
+func populateTenant(t *interfaces.TenantData, parentID sql.NullString, metaStr, statusStr, createdStr, updatedStr string) (*interfaces.TenantData, error) {
+	if parentID.Valid {
+		t.ParentID = parentID.String
+	}
+	t.Status = interfaces.TenantStatus(statusStr)
+	t.CreatedAt = parseTime(createdStr)
+	t.UpdatedAt = parseTime(updatedStr)
+
+	meta, err := unmarshalJSONMap(metaStr)
+	if err != nil {
+		return nil, fmt.Errorf("failed to unmarshal tenant metadata: %w", err)
+	}
+	// Convert map[string]interface{} to map[string]string
+	t.Metadata = make(map[string]string, len(meta))
+	for k, v := range meta {
+		if sv, ok := v.(string); ok {
+			t.Metadata[k] = sv
+		} else {
+			t.Metadata[k] = fmt.Sprintf("%v", v)
+		}
+	}
+
+	return t, nil
+}
+
+// ensure SQLiteTenantStore satisfies the interface at compile time
+var _ interfaces.TenantStore = (*SQLiteTenantStore)(nil)
+
+// nowForTenant returns current time (extracted so tests can verify timestamps are recent)
+func nowForTenant() time.Time { return nowUTC() }

--- a/pkg/storage/providers/sqlite/tenant_store.go
+++ b/pkg/storage/providers/sqlite/tenant_store.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
-	"time"
 
 	"github.com/cfgis/cfgms/pkg/storage/interfaces"
 )
@@ -314,6 +313,3 @@ func populateTenant(t *interfaces.TenantData, parentID sql.NullString, metaStr, 
 
 // ensure SQLiteTenantStore satisfies the interface at compile time
 var _ interfaces.TenantStore = (*SQLiteTenantStore)(nil)
-
-// nowForTenant returns current time (extracted so tests can verify timestamps are recent)
-func nowForTenant() time.Time { return nowUTC() }

--- a/pkg/storage/providers/sqlite/tenant_store_test.go
+++ b/pkg/storage/providers/sqlite/tenant_store_test.go
@@ -1,0 +1,194 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+package sqlite_test
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cfgis/cfgms/pkg/storage/interfaces"
+	"github.com/cfgis/cfgms/pkg/storage/providers/sqlite"
+)
+
+func newTenantStore(t *testing.T) interfaces.TenantStore {
+	t.Helper()
+	dir := t.TempDir()
+	p := sqlite.NewSQLiteProvider(dir)
+	store, err := p.CreateTenantStore(map[string]interface{}{"path": filepath.Join(dir, "tenants.db")})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = store.Close() })
+	return store
+}
+
+func TestTenantStore_CreateAndGet(t *testing.T) {
+	store := newTenantStore(t)
+	ctx := context.Background()
+
+	tenant := &interfaces.TenantData{
+		ID:          "tenant-1",
+		Name:        "Acme Corp",
+		Description: "Test tenant",
+		Status:      interfaces.TenantStatusActive,
+		CreatedAt:   time.Now().UTC().Truncate(time.Second),
+		UpdatedAt:   time.Now().UTC().Truncate(time.Second),
+		Metadata:    map[string]string{"key": "value"},
+	}
+
+	require.NoError(t, store.CreateTenant(ctx, tenant))
+
+	got, err := store.GetTenant(ctx, "tenant-1")
+	require.NoError(t, err)
+	assert.Equal(t, tenant.ID, got.ID)
+	assert.Equal(t, tenant.Name, got.Name)
+	assert.Equal(t, tenant.Description, got.Description)
+	assert.Equal(t, tenant.Status, got.Status)
+	assert.Equal(t, "value", got.Metadata["key"])
+}
+
+func TestTenantStore_GetNotFound(t *testing.T) {
+	store := newTenantStore(t)
+	ctx := context.Background()
+
+	_, err := store.GetTenant(ctx, "nonexistent")
+	assert.Error(t, err)
+}
+
+func TestTenantStore_Update(t *testing.T) {
+	store := newTenantStore(t)
+	ctx := context.Background()
+
+	tenant := &interfaces.TenantData{
+		ID:     "tenant-2",
+		Name:   "Original",
+		Status: interfaces.TenantStatusActive,
+	}
+	require.NoError(t, store.CreateTenant(ctx, tenant))
+
+	tenant.Name = "Updated"
+	tenant.Status = interfaces.TenantStatusSuspended
+	require.NoError(t, store.UpdateTenant(ctx, tenant))
+
+	got, err := store.GetTenant(ctx, "tenant-2")
+	require.NoError(t, err)
+	assert.Equal(t, "Updated", got.Name)
+	assert.Equal(t, interfaces.TenantStatusSuspended, got.Status)
+}
+
+func TestTenantStore_UpdateNotFound(t *testing.T) {
+	store := newTenantStore(t)
+	ctx := context.Background()
+
+	err := store.UpdateTenant(ctx, &interfaces.TenantData{ID: "nonexistent", Name: "X"})
+	assert.Error(t, err)
+}
+
+func TestTenantStore_Delete(t *testing.T) {
+	store := newTenantStore(t)
+	ctx := context.Background()
+
+	tenant := &interfaces.TenantData{
+		ID:     "tenant-del",
+		Name:   "ToDelete",
+		Status: interfaces.TenantStatusActive,
+	}
+	require.NoError(t, store.CreateTenant(ctx, tenant))
+	require.NoError(t, store.DeleteTenant(ctx, "tenant-del"))
+
+	_, err := store.GetTenant(ctx, "tenant-del")
+	assert.Error(t, err)
+}
+
+func TestTenantStore_DeleteNotFound(t *testing.T) {
+	store := newTenantStore(t)
+	ctx := context.Background()
+
+	assert.Error(t, store.DeleteTenant(ctx, "nonexistent"))
+}
+
+func TestTenantStore_List(t *testing.T) {
+	store := newTenantStore(t)
+	ctx := context.Background()
+
+	for _, td := range []interfaces.TenantData{
+		{ID: "t-1", Name: "Alpha", Status: interfaces.TenantStatusActive},
+		{ID: "t-2", Name: "Beta", Status: interfaces.TenantStatusSuspended},
+		{ID: "t-3", Name: "Gamma", Status: interfaces.TenantStatusActive},
+	} {
+		td := td
+		require.NoError(t, store.CreateTenant(ctx, &td))
+	}
+
+	all, err := store.ListTenants(ctx, nil)
+	require.NoError(t, err)
+	assert.Len(t, all, 3)
+
+	active, err := store.ListTenants(ctx, &interfaces.TenantFilter{Status: interfaces.TenantStatusActive})
+	require.NoError(t, err)
+	assert.Len(t, active, 2)
+}
+
+func TestTenantStore_Hierarchy(t *testing.T) {
+	store := newTenantStore(t)
+	ctx := context.Background()
+
+	root := &interfaces.TenantData{ID: "root", Name: "Root", Status: interfaces.TenantStatusActive}
+	child := &interfaces.TenantData{ID: "child", Name: "Child", ParentID: "root", Status: interfaces.TenantStatusActive}
+	grand := &interfaces.TenantData{ID: "grand", Name: "Grandchild", ParentID: "child", Status: interfaces.TenantStatusActive}
+
+	require.NoError(t, store.CreateTenant(ctx, root))
+	require.NoError(t, store.CreateTenant(ctx, child))
+	require.NoError(t, store.CreateTenant(ctx, grand))
+
+	// Path
+	path, err := store.GetTenantPath(ctx, "grand")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"root", "child", "grand"}, path)
+
+	// IsAncestor
+	isAncestor, err := store.IsTenantAncestor(ctx, "root", "grand")
+	require.NoError(t, err)
+	assert.True(t, isAncestor)
+
+	notAncestor, err := store.IsTenantAncestor(ctx, "grand", "root")
+	require.NoError(t, err)
+	assert.False(t, notAncestor)
+
+	// Children
+	children, err := store.GetChildTenants(ctx, "root")
+	require.NoError(t, err)
+	require.Len(t, children, 1)
+	assert.Equal(t, "child", children[0].ID)
+
+	// Hierarchy struct
+	hier, err := store.GetTenantHierarchy(ctx, "child")
+	require.NoError(t, err)
+	assert.Equal(t, 1, hier.Depth) // child is depth 1
+	assert.Equal(t, []string{"grand"}, hier.Children)
+}
+
+func TestTenantStore_MultiTenantIsolation(t *testing.T) {
+	store := newTenantStore(t)
+	ctx := context.Background()
+
+	t1 := &interfaces.TenantData{ID: "msp-a", Name: "MSP A", Status: interfaces.TenantStatusActive}
+	t2 := &interfaces.TenantData{ID: "msp-b", Name: "MSP B", Status: interfaces.TenantStatusActive}
+
+	require.NoError(t, store.CreateTenant(ctx, t1))
+	require.NoError(t, store.CreateTenant(ctx, t2))
+
+	got1, err := store.GetTenant(ctx, "msp-a")
+	require.NoError(t, err)
+	assert.Equal(t, "MSP A", got1.Name)
+
+	got2, err := store.GetTenant(ctx, "msp-b")
+	require.NoError(t, err)
+	assert.Equal(t, "MSP B", got2.Name)
+
+	// Verify they don't cross-contaminate
+	assert.NotEqual(t, got1.ID, got2.ID)
+}

--- a/pkg/storage/providers/sqlite/utils.go
+++ b/pkg/storage/providers/sqlite/utils.go
@@ -1,0 +1,137 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+// Package sqlite provides shared utilities for the SQLite storage provider
+package sqlite
+
+import (
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"time"
+)
+
+// nullString returns a sql.NullString that is NULL when the input is empty.
+func nullString(s string) sql.NullString {
+	if s == "" {
+		return sql.NullString{Valid: false}
+	}
+	return sql.NullString{String: s, Valid: true}
+}
+
+// nullTime returns a sql.NullString storing a time value as RFC3339, or NULL when zero.
+func nullTime(t *time.Time) sql.NullString {
+	if t == nil || t.IsZero() {
+		return sql.NullString{Valid: false}
+	}
+	return sql.NullString{String: t.UTC().Format(time.RFC3339Nano), Valid: true}
+}
+
+// parseNullTime parses a sql.NullString as an RFC3339 time pointer.
+func parseNullTime(ns sql.NullString) *time.Time {
+	if !ns.Valid || ns.String == "" {
+		return nil
+	}
+	t, err := time.Parse(time.RFC3339Nano, ns.String)
+	if err != nil {
+		return nil
+	}
+	return &t
+}
+
+// formatTime formats a time.Time to RFC3339Nano for SQLite storage.
+func formatTime(t time.Time) string {
+	return t.UTC().Format(time.RFC3339Nano)
+}
+
+// parseTime parses an RFC3339Nano string back to time.Time.
+func parseTime(s string) time.Time {
+	t, err := time.Parse(time.RFC3339Nano, s)
+	if err != nil {
+		return time.Time{}
+	}
+	return t
+}
+
+// marshalJSON serialises a value to a JSON string, returning "{}" for nil maps.
+func marshalJSON(v interface{}) (string, error) {
+	if v == nil {
+		return "{}", nil
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal JSON: %w", err)
+	}
+	return string(b), nil
+}
+
+// marshalJSONSlice serialises a string slice to a JSON array string.
+func marshalJSONSlice(v []string) (string, error) {
+	if v == nil {
+		return "[]", nil
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal JSON array: %w", err)
+	}
+	return string(b), nil
+}
+
+// unmarshalJSONSlice parses a JSON array string into a string slice.
+func unmarshalJSONSlice(s string) ([]string, error) {
+	if s == "" || s == "null" {
+		return nil, nil
+	}
+	var result []string
+	if err := json.Unmarshal([]byte(s), &result); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal JSON array: %w", err)
+	}
+	return result, nil
+}
+
+// unmarshalJSONMap parses a JSON object string into a map.
+func unmarshalJSONMap(s string) (map[string]interface{}, error) {
+	if s == "" || s == "null" || s == "{}" {
+		return make(map[string]interface{}), nil
+	}
+	var result map[string]interface{}
+	if err := json.Unmarshal([]byte(s), &result); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal JSON map: %w", err)
+	}
+	return result, nil
+}
+
+// unmarshalJSONStringMap parses a JSON object string into a map[string]string.
+func unmarshalJSONStringMap(s string) (map[string]string, error) {
+	if s == "" || s == "null" || s == "{}" {
+		return make(map[string]string), nil
+	}
+	var result map[string]string
+	if err := json.Unmarshal([]byte(s), &result); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal JSON string map: %w", err)
+	}
+	return result, nil
+}
+
+// placeholders returns a comma-separated list of n `?` placeholders for use in SQL IN clauses.
+func placeholders(n int) string {
+	if n <= 0 {
+		return ""
+	}
+	b := make([]byte, n*2-1)
+	for i := 0; i < n; i++ {
+		b[i*2] = '?'
+		if i < n-1 {
+			b[i*2+1] = ','
+		}
+	}
+	return string(b)
+}
+
+// stringSliceToInterface converts []string to []interface{} for use as variadic SQL args.
+func stringSliceToInterface(ss []string) []interface{} {
+	out := make([]interface{}, len(ss))
+	for i, s := range ss {
+		out[i] = s
+	}
+	return out
+}

--- a/pkg/storage/providers/sqlite/utils.go
+++ b/pkg/storage/providers/sqlite/utils.go
@@ -111,27 +111,3 @@ func unmarshalJSONStringMap(s string) (map[string]string, error) {
 	}
 	return result, nil
 }
-
-// placeholders returns a comma-separated list of n `?` placeholders for use in SQL IN clauses.
-func placeholders(n int) string {
-	if n <= 0 {
-		return ""
-	}
-	b := make([]byte, n*2-1)
-	for i := 0; i < n; i++ {
-		b[i*2] = '?'
-		if i < n-1 {
-			b[i*2+1] = ','
-		}
-	}
-	return string(b)
-}
-
-// stringSliceToInterface converts []string to []interface{} for use as variadic SQL args.
-func stringSliceToInterface(ss []string) []interface{} {
-	out := make([]interface{}, len(ss))
-	for i, s := range ss {
-		out[i] = s
-	}
-	return out
-}


### PR DESCRIPTION
## Summary

- Adds `pkg/storage/providers/sqlite/` — full SQLite implementation of the business-data tier (ADR-003 §2): `TenantStore`, `ClientTenantStore`, `AuditStore`, `RBACStore`, `RegistrationTokenStore`, `SessionStore`
- Adds `pkg/storage/interfaces/session_store.go` — new `SessionStore` interface for durable (`Persistent=true`) sessions only; ephemeral sessions belong in `pkg/cache`
- Extends `StorageProvider` interface with `CreateSessionStore`; all existing providers (database, git) and test mocks updated with `ErrNotSupported` stubs
- Bulk RBAC operations (`StoreBulkPermissions`, `StoreBulkRoles`, `StoreBulkSubjects`) execute atomically via `sql.Tx`
- Audit batch path (`storeAuditEntryTx`) propagates marshal errors instead of silently writing corrupted records
- `ConfigStore` and `RuntimeStore` return `ErrNotSupported` — config uses flat-file/PostgreSQL; ephemeral state uses `pkg/cache`

## Test plan

- [x] All 62 tests in `pkg/storage/providers/sqlite/` pass (`go test ./pkg/storage/providers/sqlite/... -count=1`)
- [x] `pkg/storage/interfaces/` tests pass
- [x] Three specialist review agents (qa-test-runner, qa-code-reviewer, security-engineer) ran in parallel; all blocking findings resolved before commit
- [x] Security scan: no blocking issues; gosec/staticcheck clean; architecture check passes
- [x] `go vet ./pkg/storage/providers/sqlite/...` clean

Fixes #662

🤖 Generated with [Claude Code](https://claude.com/claude-code)