### PR TITLE
feat(storage): implement flat-file config and audit storage provider (Issue #661)

### DIFF
--- a/docs/architecture/storage-architecture.md
+++ b/docs/architecture/storage-architecture.md
@@ -67,17 +67,40 @@ Commercial deployments: the imported configs land in PostgreSQL. HA, replication
 
 ## Flat-File Provider (OSS)
 
-The flat-file provider is the replacement for the deprecated git provider. It stores configs and runtime data as files under a configured root directory.
+The flat-file provider (`pkg/storage/providers/flatfile`) is the OSS default for config storage and the replacement for the deprecated git provider. It stores configs and audit logs as files under a configured root directory.
+
+**File layout**:
+
+```
+<root>/
+  <tenantID>/
+    configs/
+      <namespace>/
+        <name>.<format>    # JSON-encoded ConfigEntry; extension = data format
+    audit/
+      <YYYY-MM-DD>.jsonl   # Append-only JSONL; one entry per line
+```
 
 **Admin responsibilities**:
-- Backups. CFGMS does not version at the storage layer. Use filesystem snapshots, rsync, restic, or an equivalent.
+- Backups. CFGMS does not version at the storage layer. Use filesystem snapshots, rsync, restic, or an equivalent. A `cfg backup` CLI helper is planned (sub-story B).
 - Filesystem durability. SSD + regular snapshots is sufficient for single-controller OSS.
 - Access control. Directory is readable/writable only by the controller process.
 
+**What the flat-file provider implements**:
+- `ConfigStore`: store, retrieve, list, delete configs; inheritance resolution via tenant path
+- `AuditStore`: append-only JSONL per day per tenant; immutable entries; purge/archive by date
+
 **What the flat-file provider does not do**:
-- Automatic version history. (Use git-sync if you want PR-based change management.)
+- Automatic version history. (`GetConfigHistory` returns the current version only. Use git-sync if you want PR-based change management.)
 - Replication. (Use PostgreSQL if you need HA.)
 - Arbitration. (Single-writer; not safe for multiple controllers to share the same root.)
+- Business-data stores (`RBACStore`, `TenantStore`, `RuntimeStore`, etc.) — these belong in SQLite/PostgreSQL.
+
+**Registration**: The provider auto-registers on import via `init()`. A blank import is sufficient:
+
+```go
+import _ "github.com/cfgis/cfgms/pkg/storage/providers/flatfile"
+```
 
 ## Interface Layout
 

--- a/docs/product/feature-boundaries.md
+++ b/docs/product/feature-boundaries.md
@@ -24,7 +24,7 @@ This maximizes trust, community velocity for integrations, and follows proven mo
 | Feature | OSS | Commercial (includes all OSS) | Notes |
 |---------|-----|-------------------------------|-------|
 | **Architecture** | ✅ Single controller | ✅ Single controller + HA clustering | HA: Raft consensus, auto-failover |
-| **Storage** | ✅ Git, SQLite, PostgreSQL | ✅ Same + HA-optimized PostgreSQL | All providers support encryption |
+| **Storage** | ✅ Flat-file (config), SQLite (business data), PostgreSQL (optional) | ✅ Same + HA-optimized PostgreSQL | All providers support encryption. Git is not a storage backend — it is an optional sync source. |
 | **Communication** | ✅ gRPC-over-QUIC | ✅ Same | No difference |
 | **CLI/API** | ✅ All | ✅ Same | Complete CLI access in both |
 | **Web UI** | ❌ None | ✅ Full UI | Graphical workflow builder, dashboards |

--- a/pkg/storage/interfaces/README.md
+++ b/pkg/storage/interfaces/README.md
@@ -64,6 +64,14 @@ Per ADR-003, no controller-side storage/logging interface may remain under `feat
 - `features/steward/dna/events/drift_subscriber.go` — `StorageManager` interface (controller-side drift event persistence); move under the appropriate type directory here.
 - `features/modules/m365/auth/admin_consent_flow.go` — duplicate `ClientTenantStore` interface; consolidate with the canonical `ClientTenantStore` in this package.
 
+## Provider Inventory
+
+| Provider | Package | Implements | Status |
+|----------|---------|------------|--------|
+| `flatfile` | `pkg/storage/providers/flatfile` | `ConfigStore`, `AuditStore` | Available — OSS default for config storage |
+| `database` | `pkg/storage/providers/database` | All stores | Available — commercial PostgreSQL backend |
+| `git` | `pkg/storage/providers/git` | All stores | Deprecated — use `flatfile` + git-sync |
+
 ## Backend Selection (per type)
 
 Per ADR-003, deployments compose one provider per type:
@@ -71,7 +79,7 @@ Per ADR-003, deployments compose one provider per type:
 | Type | OSS backend | Commercial/SaaS backend |
 |------|-------------|-------------------------|
 | Business data | SQLite | PostgreSQL |
-| Config storage | Flat file | PostgreSQL |
+| Config storage | **Flat file** (`flatfile`) | PostgreSQL (`database`) |
 | Secrets | SOPS files | Key vault (AWS Secrets Manager / Vault / Azure Key Vault) |
 | Timeseries | Local log files | ClickHouse / Timescale / Influx |
 | Blobs | Local filesystem | S3-compatible object storage |

--- a/pkg/storage/providers/flatfile/audit_store.go
+++ b/pkg/storage/providers/flatfile/audit_store.go
@@ -1,0 +1,685 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+package flatfile
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/cfgis/cfgms/pkg/storage/interfaces"
+)
+
+// FlatFileAuditStore implements interfaces.AuditStore using append-only JSONL files.
+//
+// File layout: <root>/<tenantID>/audit/<YYYY-MM-DD>.jsonl
+//
+// Each line in a JSONL file is a JSON-encoded AuditEntry. Files are append-only;
+// entries are immutable. Methods that would mutate existing entries return ErrImmutable.
+//
+// StoreAuditEntry returns ErrImmutable when the entry's timestamp predates the
+// configured retention period — those time slots are considered sealed.
+type FlatFileAuditStore struct {
+	root             string
+	maxRetentionDays int
+	mutex            sync.Mutex // serialises appends across goroutines
+}
+
+// NewFlatFileAuditStore creates a new FlatFileAuditStore rooted at root.
+// maxRetentionDays controls how far back new entries may be stored; defaults to 90.
+func NewFlatFileAuditStore(root string, maxRetentionDays int) (*FlatFileAuditStore, error) {
+	if err := os.MkdirAll(root, 0750); err != nil {
+		return nil, fmt.Errorf("failed to create audit root: %w", err)
+	}
+	if maxRetentionDays <= 0 {
+		maxRetentionDays = 90
+	}
+	return &FlatFileAuditStore{
+		root:             root,
+		maxRetentionDays: maxRetentionDays,
+	}, nil
+}
+
+// retentionCutoff returns the oldest timestamp that may be stored.
+func (s *FlatFileAuditStore) retentionCutoff() time.Time {
+	return time.Now().UTC().AddDate(0, 0, -s.maxRetentionDays)
+}
+
+// auditDir returns the audit directory for tenantID (validated against traversal).
+func (s *FlatFileAuditStore) auditDir(tenantID string) (string, error) {
+	return safeJoin(s.root, tenantID, "audit")
+}
+
+// dailyFilePath returns the path to the JSONL file for tenantID on date t.
+func (s *FlatFileAuditStore) dailyFilePath(tenantID string, t time.Time) (string, error) {
+	dir, err := s.auditDir(tenantID)
+	if err != nil {
+		return "", err
+	}
+	filename := t.UTC().Format("2006-01-02") + ".jsonl"
+	return filepath.Join(dir, filename), nil
+}
+
+// StoreAuditEntry appends an immutable audit entry to the daily JSONL file.
+// Returns ErrImmutable if the entry's timestamp predates the retention period.
+func (s *FlatFileAuditStore) StoreAuditEntry(ctx context.Context, entry *interfaces.AuditEntry) error {
+	if entry.TenantID == "" {
+		return interfaces.ErrTenantIDRequired
+	}
+	if entry.UserID == "" {
+		return interfaces.ErrUserIDRequired
+	}
+	if entry.Action == "" {
+		return interfaces.ErrActionRequired
+	}
+	if entry.ResourceType == "" {
+		return interfaces.ErrResourceTypeRequired
+	}
+	if entry.ResourceID == "" {
+		return interfaces.ErrResourceIDRequired
+	}
+
+	if entry.Timestamp.IsZero() {
+		entry.Timestamp = time.Now().UTC()
+	}
+
+	// Entries older than maxRetentionDays are considered sealed/immutable.
+	if entry.Timestamp.Before(s.retentionCutoff()) {
+		return ErrImmutable
+	}
+
+	path, err := s.dailyFilePath(entry.TenantID, entry.Timestamp)
+	if err != nil {
+		return fmt.Errorf("invalid tenant ID: %w", err)
+	}
+
+	raw, err := json.Marshal(entry)
+	if err != nil {
+		return fmt.Errorf("failed to marshal audit entry: %w", err)
+	}
+	raw = append(raw, '\n')
+
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+
+	if err := os.MkdirAll(filepath.Dir(path), 0750); err != nil {
+		return fmt.Errorf("failed to create audit dir: %w", err)
+	}
+
+	// #nosec G304 — path validated by safeJoin inside dailyFilePath
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0640)
+	if err != nil {
+		return fmt.Errorf("failed to open audit file: %w", err)
+	}
+	defer func() { _ = f.Close() }()
+
+	if _, err := f.Write(raw); err != nil {
+		return fmt.Errorf("failed to append audit entry: %w", err)
+	}
+	return nil
+}
+
+// StoreAuditBatch stores multiple audit entries, stopping on first error.
+func (s *FlatFileAuditStore) StoreAuditBatch(ctx context.Context, entries []*interfaces.AuditEntry) error {
+	for _, entry := range entries {
+		if err := s.StoreAuditEntry(ctx, entry); err != nil {
+			return fmt.Errorf("batch store failed for entry %q: %w", entry.ID, err)
+		}
+	}
+	return nil
+}
+
+// GetAuditEntry retrieves an audit entry by ID, scanning daily JSONL files newest-first.
+func (s *FlatFileAuditStore) GetAuditEntry(ctx context.Context, id string) (*interfaces.AuditEntry, error) {
+	tenantDirs, err := os.ReadDir(s.root)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, interfaces.ErrAuditNotFound
+		}
+		return nil, fmt.Errorf("failed to read audit root: %w", err)
+	}
+
+	for _, tenantDir := range tenantDirs {
+		if !tenantDir.IsDir() {
+			continue
+		}
+		auditDir := filepath.Join(s.root, tenantDir.Name(), "audit")
+		entry, err := s.scanDirForID(auditDir, id)
+		if err == nil {
+			return entry, nil
+		}
+	}
+	return nil, interfaces.ErrAuditNotFound
+}
+
+// scanDirForID scans all JSONL files in auditDir for an entry matching id.
+func (s *FlatFileAuditStore) scanDirForID(auditDir, id string) (*interfaces.AuditEntry, error) {
+	files, err := os.ReadDir(auditDir)
+	if err != nil {
+		return nil, fmt.Errorf("cannot read dir: %w", err)
+	}
+
+	// Newest first for faster lookup of recent entries
+	sort.Slice(files, func(i, j int) bool {
+		return files[i].Name() > files[j].Name()
+	})
+
+	for _, f := range files {
+		if f.IsDir() || !strings.HasSuffix(f.Name(), ".jsonl") {
+			continue
+		}
+		entry, err := s.scanFileForID(filepath.Join(auditDir, f.Name()), id)
+		if err == nil {
+			return entry, nil
+		}
+	}
+	return nil, interfaces.ErrAuditNotFound
+}
+
+// scanFileForID scans a single JSONL file for an entry matching id.
+func (s *FlatFileAuditStore) scanFileForID(path, id string) (*interfaces.AuditEntry, error) {
+	// #nosec G304 — path from trusted os.ReadDir rooted at s.root
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = f.Close() }()
+
+	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, 1024*1024), 1024*1024)
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		if len(line) == 0 {
+			continue
+		}
+		var entry interfaces.AuditEntry
+		if err := json.Unmarshal(line, &entry); err != nil {
+			continue
+		}
+		if entry.ID == id {
+			return &entry, nil
+		}
+	}
+	return nil, interfaces.ErrAuditNotFound
+}
+
+// ListAuditEntries returns audit entries matching the filter.
+func (s *FlatFileAuditStore) ListAuditEntries(ctx context.Context, filter *interfaces.AuditFilter) ([]*interfaces.AuditEntry, error) {
+	tenantIDs, err := s.tenantIDsForFilter(filter)
+	if err != nil {
+		return nil, err
+	}
+
+	var results []*interfaces.AuditEntry
+	for _, tenantID := range tenantIDs {
+		auditDir, err := s.auditDir(tenantID)
+		if err != nil {
+			continue
+		}
+		entries, err := s.scanDirForEntries(auditDir, filter)
+		if err != nil {
+			continue
+		}
+		results = append(results, entries...)
+	}
+
+	// Sort by timestamp (default: descending)
+	sortOrder := "desc"
+	if filter != nil && filter.Order == "asc" {
+		sortOrder = "asc"
+	}
+	sort.Slice(results, func(i, j int) bool {
+		if sortOrder == "asc" {
+			return results[i].Timestamp.Before(results[j].Timestamp)
+		}
+		return results[i].Timestamp.After(results[j].Timestamp)
+	})
+
+	return paginateAudit(results, filter), nil
+}
+
+// tenantIDsForFilter returns the list of tenant IDs to scan, based on the filter.
+func (s *FlatFileAuditStore) tenantIDsForFilter(filter *interfaces.AuditFilter) ([]string, error) {
+	if filter != nil && filter.TenantID != "" {
+		return []string{filter.TenantID}, nil
+	}
+	dirs, err := os.ReadDir(s.root)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to list tenants: %w", err)
+	}
+	var ids []string
+	for _, d := range dirs {
+		if d.IsDir() {
+			ids = append(ids, d.Name())
+		}
+	}
+	return ids, nil
+}
+
+// scanDirForEntries scans all JSONL files in auditDir matching the filter.
+func (s *FlatFileAuditStore) scanDirForEntries(auditDir string, filter *interfaces.AuditFilter) ([]*interfaces.AuditEntry, error) {
+	files, err := os.ReadDir(auditDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	var results []*interfaces.AuditEntry
+	for _, f := range files {
+		if f.IsDir() || !strings.HasSuffix(f.Name(), ".jsonl") {
+			continue
+		}
+		if filter != nil && filter.TimeRange != nil {
+			if !fileInTimeRange(f.Name(), filter.TimeRange) {
+				continue
+			}
+		}
+		entries, err := s.readJSONLFile(filepath.Join(auditDir, f.Name()), filter)
+		if err != nil {
+			continue
+		}
+		results = append(results, entries...)
+	}
+	return results, nil
+}
+
+// fileInTimeRange checks whether a YYYY-MM-DD.jsonl file may contain entries in tr.
+func fileInTimeRange(filename string, tr *interfaces.TimeRange) bool {
+	dateStr := strings.TrimSuffix(filename, ".jsonl")
+	fileDate, err := time.Parse("2006-01-02", dateStr)
+	if err != nil {
+		return true // include unparseable filenames
+	}
+	fileEnd := fileDate.AddDate(0, 0, 1)
+	if tr.Start != nil && fileEnd.Before(*tr.Start) {
+		return false
+	}
+	if tr.End != nil && fileDate.After(*tr.End) {
+		return false
+	}
+	return true
+}
+
+// readJSONLFile reads all entries from a JSONL file, applying the filter.
+func (s *FlatFileAuditStore) readJSONLFile(path string, filter *interfaces.AuditFilter) ([]*interfaces.AuditEntry, error) {
+	// #nosec G304 — path from trusted os.ReadDir rooted at s.root
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = f.Close() }()
+
+	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, 1024*1024), 1024*1024)
+
+	var results []*interfaces.AuditEntry
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		if len(line) == 0 {
+			continue
+		}
+		var entry interfaces.AuditEntry
+		if err := json.Unmarshal(line, &entry); err != nil {
+			continue
+		}
+		if applyAuditFilter(&entry, filter) {
+			results = append(results, &entry)
+		}
+	}
+	return results, scanner.Err()
+}
+
+// applyAuditFilter returns true if the entry matches all filter criteria.
+func applyAuditFilter(entry *interfaces.AuditEntry, filter *interfaces.AuditFilter) bool {
+	if filter == nil {
+		return true
+	}
+	if filter.TenantID != "" && entry.TenantID != filter.TenantID {
+		return false
+	}
+	if len(filter.EventTypes) > 0 && !containsEventType(filter.EventTypes, entry.EventType) {
+		return false
+	}
+	if len(filter.Actions) > 0 && !containsString(filter.Actions, entry.Action) {
+		return false
+	}
+	if len(filter.UserIDs) > 0 && !containsString(filter.UserIDs, entry.UserID) {
+		return false
+	}
+	if len(filter.UserTypes) > 0 && !containsUserType(filter.UserTypes, entry.UserType) {
+		return false
+	}
+	if len(filter.Results) > 0 && !containsResult(filter.Results, entry.Result) {
+		return false
+	}
+	if len(filter.Severities) > 0 && !containsSeverity(filter.Severities, entry.Severity) {
+		return false
+	}
+	if len(filter.ResourceTypes) > 0 && !containsString(filter.ResourceTypes, entry.ResourceType) {
+		return false
+	}
+	if len(filter.ResourceIDs) > 0 && !containsString(filter.ResourceIDs, entry.ResourceID) {
+		return false
+	}
+	if filter.TimeRange != nil {
+		if filter.TimeRange.Start != nil && entry.Timestamp.Before(*filter.TimeRange.Start) {
+			return false
+		}
+		if filter.TimeRange.End != nil && entry.Timestamp.After(*filter.TimeRange.End) {
+			return false
+		}
+	}
+	for _, tag := range filter.Tags {
+		if !containsString(entry.Tags, tag) {
+			return false
+		}
+	}
+	return true
+}
+
+// paginateAudit applies offset and limit from the filter.
+func paginateAudit(results []*interfaces.AuditEntry, filter *interfaces.AuditFilter) []*interfaces.AuditEntry {
+	if filter == nil {
+		return results
+	}
+	if filter.Offset > 0 {
+		if filter.Offset >= len(results) {
+			return nil
+		}
+		results = results[filter.Offset:]
+	}
+	if filter.Limit > 0 && filter.Limit < len(results) {
+		results = results[:filter.Limit]
+	}
+	return results
+}
+
+// GetAuditsByUser retrieves audit entries for a specific user in the given time range.
+func (s *FlatFileAuditStore) GetAuditsByUser(ctx context.Context, userID string, timeRange *interfaces.TimeRange) ([]*interfaces.AuditEntry, error) {
+	return s.ListAuditEntries(ctx, &interfaces.AuditFilter{
+		UserIDs:   []string{userID},
+		TimeRange: timeRange,
+	})
+}
+
+// GetAuditsByResource retrieves audit entries for a specific resource.
+func (s *FlatFileAuditStore) GetAuditsByResource(ctx context.Context, resourceType, resourceID string, timeRange *interfaces.TimeRange) ([]*interfaces.AuditEntry, error) {
+	return s.ListAuditEntries(ctx, &interfaces.AuditFilter{
+		ResourceTypes: []string{resourceType},
+		ResourceIDs:   []string{resourceID},
+		TimeRange:     timeRange,
+	})
+}
+
+// GetAuditsByAction retrieves audit entries for a specific action.
+func (s *FlatFileAuditStore) GetAuditsByAction(ctx context.Context, action string, timeRange *interfaces.TimeRange) ([]*interfaces.AuditEntry, error) {
+	return s.ListAuditEntries(ctx, &interfaces.AuditFilter{
+		Actions:   []string{action},
+		TimeRange: timeRange,
+	})
+}
+
+// GetFailedActions retrieves audit entries with failure, error, or denied results.
+func (s *FlatFileAuditStore) GetFailedActions(ctx context.Context, timeRange *interfaces.TimeRange, limit int) ([]*interfaces.AuditEntry, error) {
+	return s.ListAuditEntries(ctx, &interfaces.AuditFilter{
+		Results: []interfaces.AuditResult{
+			interfaces.AuditResultFailure,
+			interfaces.AuditResultError,
+			interfaces.AuditResultDenied,
+		},
+		TimeRange: timeRange,
+		Limit:     limit,
+	})
+}
+
+// GetSuspiciousActivity retrieves high and critical severity entries for a tenant.
+func (s *FlatFileAuditStore) GetSuspiciousActivity(ctx context.Context, tenantID string, timeRange *interfaces.TimeRange) ([]*interfaces.AuditEntry, error) {
+	return s.ListAuditEntries(ctx, &interfaces.AuditFilter{
+		TenantID: tenantID,
+		Severities: []interfaces.AuditSeverity{
+			interfaces.AuditSeverityHigh,
+			interfaces.AuditSeverityCritical,
+		},
+		TimeRange: timeRange,
+	})
+}
+
+// GetAuditStats scans all JSONL files and returns aggregate statistics.
+func (s *FlatFileAuditStore) GetAuditStats(ctx context.Context) (*interfaces.AuditStats, error) {
+	stats := &interfaces.AuditStats{
+		EntriesByTenant:   make(map[string]int64),
+		EntriesByType:     make(map[string]int64),
+		EntriesByResult:   make(map[string]int64),
+		EntriesBySeverity: make(map[string]int64),
+		LastUpdated:       time.Now().UTC(),
+	}
+
+	now := time.Now().UTC()
+	last24h := now.Add(-24 * time.Hour)
+	last7d := now.AddDate(0, 0, -7)
+	last30d := now.AddDate(0, 0, -30)
+
+	var oldest, newest *time.Time
+
+	walkErr := filepath.WalkDir(s.root, func(path string, d os.DirEntry, ferr error) error {
+		if ferr != nil || d.IsDir() {
+			return nil
+		}
+		if !strings.HasSuffix(path, ".jsonl") {
+			return nil
+		}
+
+		// #nosec G304 — path from WalkDir rooted at s.root
+		f, err := os.Open(path)
+		if err != nil {
+			return nil
+		}
+		defer func() { _ = f.Close() }()
+
+		scanner := bufio.NewScanner(f)
+		scanner.Buffer(make([]byte, 1024*1024), 1024*1024)
+
+		for scanner.Scan() {
+			line := scanner.Bytes()
+			if len(line) == 0 {
+				continue
+			}
+			var entry interfaces.AuditEntry
+			if err := json.Unmarshal(line, &entry); err != nil {
+				continue
+			}
+
+			stats.TotalEntries++
+			stats.TotalSize += int64(len(line))
+			stats.EntriesByTenant[entry.TenantID]++
+			stats.EntriesByType[string(entry.EventType)]++
+			stats.EntriesByResult[string(entry.Result)]++
+			stats.EntriesBySeverity[string(entry.Severity)]++
+
+			if entry.Timestamp.After(last24h) {
+				stats.EntriesLast24h++
+			}
+			if entry.Timestamp.After(last7d) {
+				stats.EntriesLast7d++
+			}
+			if entry.Timestamp.After(last30d) {
+				stats.EntriesLast30d++
+			}
+			if entry.Result == interfaces.AuditResultFailure ||
+				entry.Result == interfaces.AuditResultError ||
+				entry.Result == interfaces.AuditResultDenied {
+				if entry.Timestamp.After(last24h) {
+					stats.FailedActionsLast24h++
+				}
+			}
+			if entry.Severity == interfaces.AuditSeverityHigh ||
+				entry.Severity == interfaces.AuditSeverityCritical {
+				stats.SuspiciousActivityCount++
+				if stats.LastSecurityIncident == nil || entry.Timestamp.After(*stats.LastSecurityIncident) {
+					t := entry.Timestamp
+					stats.LastSecurityIncident = &t
+				}
+			}
+
+			if oldest == nil || entry.Timestamp.Before(*oldest) {
+				t := entry.Timestamp
+				oldest = &t
+			}
+			if newest == nil || entry.Timestamp.After(*newest) {
+				t := entry.Timestamp
+				newest = &t
+			}
+		}
+		return nil
+	})
+	if walkErr != nil && !os.IsNotExist(walkErr) {
+		return nil, fmt.Errorf("failed to compute audit stats: %w", walkErr)
+	}
+
+	stats.OldestEntry = oldest
+	stats.NewestEntry = newest
+	if stats.TotalEntries > 0 {
+		stats.AverageSize = stats.TotalSize / stats.TotalEntries
+	}
+	return stats, nil
+}
+
+// ArchiveAuditEntries moves daily JSONL files older than beforeDate into an archive
+// subdirectory under each tenant's audit directory.
+func (s *FlatFileAuditStore) ArchiveAuditEntries(ctx context.Context, beforeDate time.Time) (int64, error) {
+	var count int64
+
+	walkErr := filepath.WalkDir(s.root, func(path string, d os.DirEntry, ferr error) error {
+		if ferr != nil || d.IsDir() {
+			return nil
+		}
+		if !strings.HasSuffix(path, ".jsonl") {
+			return nil
+		}
+		dateStr := strings.TrimSuffix(filepath.Base(path), ".jsonl")
+		fileDate, err := time.Parse("2006-01-02", dateStr)
+		if err != nil || !fileDate.Before(beforeDate) {
+			return nil
+		}
+
+		archiveDir := filepath.Join(filepath.Dir(path), "archive")
+		if err := os.MkdirAll(archiveDir, 0750); err != nil {
+			return nil
+		}
+		archivePath := filepath.Join(archiveDir, filepath.Base(path))
+		if err := os.Rename(path, archivePath); err != nil {
+			return nil
+		}
+
+		// Count entries in the archived file
+		// #nosec G304 — archivePath constructed from controlled path
+		raw, err := os.ReadFile(archivePath)
+		if err == nil {
+			for _, line := range strings.Split(string(raw), "\n") {
+				if strings.TrimSpace(line) != "" {
+					count++
+				}
+			}
+		}
+		return nil
+	})
+	if walkErr != nil {
+		return count, fmt.Errorf("archive walk failed: %w", walkErr)
+	}
+	return count, nil
+}
+
+// PurgeAuditEntries deletes daily JSONL files older than beforeDate.
+func (s *FlatFileAuditStore) PurgeAuditEntries(ctx context.Context, beforeDate time.Time) (int64, error) {
+	var count int64
+
+	walkErr := filepath.WalkDir(s.root, func(path string, d os.DirEntry, ferr error) error {
+		if ferr != nil || d.IsDir() {
+			return nil
+		}
+		if !strings.HasSuffix(path, ".jsonl") {
+			return nil
+		}
+		dateStr := strings.TrimSuffix(filepath.Base(path), ".jsonl")
+		fileDate, err := time.Parse("2006-01-02", dateStr)
+		if err != nil || !fileDate.Before(beforeDate) {
+			return nil
+		}
+
+		// Count entries before deleting
+		// #nosec G304 — path from trusted WalkDir rooted at s.root
+		raw, err := os.ReadFile(path)
+		if err == nil {
+			for _, line := range strings.Split(string(raw), "\n") {
+				if strings.TrimSpace(line) != "" {
+					count++
+				}
+			}
+		}
+		_ = os.Remove(path)
+		return nil
+	})
+	if walkErr != nil {
+		return count, fmt.Errorf("purge walk failed: %w", walkErr)
+	}
+	return count, nil
+}
+
+// Helper functions for slice membership checks.
+
+func containsEventType(slice []interfaces.AuditEventType, v interfaces.AuditEventType) bool {
+	for _, s := range slice {
+		if s == v {
+			return true
+		}
+	}
+	return false
+}
+
+func containsUserType(slice []interfaces.AuditUserType, v interfaces.AuditUserType) bool {
+	for _, s := range slice {
+		if s == v {
+			return true
+		}
+	}
+	return false
+}
+
+func containsResult(slice []interfaces.AuditResult, v interfaces.AuditResult) bool {
+	for _, s := range slice {
+		if s == v {
+			return true
+		}
+	}
+	return false
+}
+
+func containsSeverity(slice []interfaces.AuditSeverity, v interfaces.AuditSeverity) bool {
+	for _, s := range slice {
+		if s == v {
+			return true
+		}
+	}
+	return false
+}
+
+func containsString(slice []string, v string) bool {
+	for _, s := range slice {
+		if s == v {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/storage/providers/flatfile/audit_store_test.go
+++ b/pkg/storage/providers/flatfile/audit_store_test.go
@@ -1,0 +1,473 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+package flatfile_test
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cfgis/cfgms/pkg/storage/interfaces"
+	"github.com/cfgis/cfgms/pkg/storage/providers/flatfile"
+)
+
+// newTestAuditStore creates a FlatFileAuditStore backed by a temporary directory.
+func newTestAuditStore(t *testing.T) *flatfile.FlatFileAuditStore {
+	t.Helper()
+	store, err := flatfile.NewFlatFileAuditStore(t.TempDir(), 90)
+	require.NoError(t, err)
+	return store
+}
+
+// minimalEntry returns a minimal valid AuditEntry with the given timestamp.
+func minimalEntry(id, tenantID string, ts time.Time) *interfaces.AuditEntry {
+	return &interfaces.AuditEntry{
+		ID:           id,
+		TenantID:     tenantID,
+		Timestamp:    ts,
+		Action:       "read",
+		UserID:       "user1",
+		UserType:     interfaces.AuditUserTypeHuman,
+		ResourceType: "config",
+		ResourceID:   "cfg-1",
+		Result:       interfaces.AuditResultSuccess,
+		Severity:     interfaces.AuditSeverityLow,
+		Source:       "test",
+		EventType:    interfaces.AuditEventDataAccess,
+	}
+}
+
+// TestStoreAndGetAuditEntry verifies a round-trip store and retrieve by ID.
+func TestStoreAndGetAuditEntry(t *testing.T) {
+	store := newTestAuditStore(t)
+	ctx := context.Background()
+
+	entry := minimalEntry("entry-1", "tenant1", time.Now().UTC())
+	require.NoError(t, store.StoreAuditEntry(ctx, entry))
+
+	got, err := store.GetAuditEntry(ctx, "entry-1")
+	require.NoError(t, err)
+	assert.Equal(t, "entry-1", got.ID)
+	assert.Equal(t, "tenant1", got.TenantID)
+	assert.Equal(t, "read", got.Action)
+}
+
+// TestGetAuditEntryNotFound verifies ErrAuditNotFound for missing entries.
+func TestGetAuditEntryNotFound(t *testing.T) {
+	store := newTestAuditStore(t)
+	ctx := context.Background()
+
+	_, err := store.GetAuditEntry(ctx, "nonexistent")
+	assert.Equal(t, interfaces.ErrAuditNotFound, err)
+}
+
+// TestStoreAuditEntryValidation verifies required field validation.
+func TestStoreAuditEntryValidation(t *testing.T) {
+	store := newTestAuditStore(t)
+	ctx := context.Background()
+	now := time.Now().UTC()
+
+	t.Run("missing tenant", func(t *testing.T) {
+		e := minimalEntry("e1", "", now)
+		err := store.StoreAuditEntry(ctx, e)
+		assert.Error(t, err)
+	})
+
+	t.Run("missing user", func(t *testing.T) {
+		e := minimalEntry("e2", "t1", now)
+		e.UserID = ""
+		err := store.StoreAuditEntry(ctx, e)
+		assert.Error(t, err)
+	})
+
+	t.Run("missing action", func(t *testing.T) {
+		e := minimalEntry("e3", "t1", now)
+		e.Action = ""
+		err := store.StoreAuditEntry(ctx, e)
+		assert.Error(t, err)
+	})
+
+	t.Run("missing resource type", func(t *testing.T) {
+		e := minimalEntry("e4", "t1", now)
+		e.ResourceType = ""
+		err := store.StoreAuditEntry(ctx, e)
+		assert.Error(t, err)
+	})
+
+	t.Run("missing resource ID", func(t *testing.T) {
+		e := minimalEntry("e5", "t1", now)
+		e.ResourceID = ""
+		err := store.StoreAuditEntry(ctx, e)
+		assert.Error(t, err)
+	})
+}
+
+// TestStoreAuditEntryErrImmutable verifies that entries older than retention period are rejected.
+func TestStoreAuditEntryErrImmutable(t *testing.T) {
+	// Use a 10-day retention window for this test
+	store, err := flatfile.NewFlatFileAuditStore(t.TempDir(), 10)
+	require.NoError(t, err)
+	ctx := context.Background()
+
+	// Entry 11 days old — beyond retention
+	oldTS := time.Now().UTC().AddDate(0, 0, -11)
+	entry := minimalEntry("old-entry", "tenant1", oldTS)
+
+	err = store.StoreAuditEntry(ctx, entry)
+	assert.ErrorIs(t, err, flatfile.ErrImmutable, "expected ErrImmutable for expired-retention entry")
+}
+
+// TestStoreAuditEntryWithinRetention verifies that entries inside retention are accepted.
+func TestStoreAuditEntryWithinRetention(t *testing.T) {
+	store, err := flatfile.NewFlatFileAuditStore(t.TempDir(), 10)
+	require.NoError(t, err)
+	ctx := context.Background()
+
+	// Entry 5 days old — within retention
+	ts := time.Now().UTC().AddDate(0, 0, -5)
+	entry := minimalEntry("recent-entry", "tenant1", ts)
+	assert.NoError(t, store.StoreAuditEntry(ctx, entry))
+}
+
+// TestListAuditEntries verifies filtering by tenant.
+func TestListAuditEntries(t *testing.T) {
+	store := newTestAuditStore(t)
+	ctx := context.Background()
+	now := time.Now().UTC()
+
+	for i := 0; i < 3; i++ {
+		e := minimalEntry(fmt.Sprintf("e-%d", i), "t1", now)
+		require.NoError(t, store.StoreAuditEntry(ctx, e))
+	}
+	// Entry for a different tenant
+	require.NoError(t, store.StoreAuditEntry(ctx, minimalEntry("e-other", "t2", now)))
+
+	results, err := store.ListAuditEntries(ctx, &interfaces.AuditFilter{TenantID: "t1"})
+	require.NoError(t, err)
+	assert.Len(t, results, 3)
+}
+
+// TestListAuditEntriesByTimeRange verifies time-range filtering.
+func TestListAuditEntriesByTimeRange(t *testing.T) {
+	store := newTestAuditStore(t)
+	ctx := context.Background()
+
+	yesterday := time.Now().UTC().AddDate(0, 0, -1)
+	today := time.Now().UTC()
+
+	require.NoError(t, store.StoreAuditEntry(ctx, minimalEntry("yesterday", "t1", yesterday)))
+	require.NoError(t, store.StoreAuditEntry(ctx, minimalEntry("today", "t1", today)))
+
+	// Filter: only today
+	start := today.Add(-time.Minute)
+	results, err := store.ListAuditEntries(ctx, &interfaces.AuditFilter{
+		TenantID:  "t1",
+		TimeRange: &interfaces.TimeRange{Start: &start},
+	})
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	assert.Equal(t, "today", results[0].ID)
+}
+
+// TestGetAuditsByUser verifies user-based query.
+func TestGetAuditsByUser(t *testing.T) {
+	store := newTestAuditStore(t)
+	ctx := context.Background()
+	now := time.Now().UTC()
+
+	e1 := minimalEntry("u1-e1", "t1", now)
+	e1.UserID = "alice"
+	e2 := minimalEntry("u1-e2", "t1", now)
+	e2.UserID = "bob"
+
+	require.NoError(t, store.StoreAuditEntry(ctx, e1))
+	require.NoError(t, store.StoreAuditEntry(ctx, e2))
+
+	results, err := store.GetAuditsByUser(ctx, "alice", nil)
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	assert.Equal(t, "alice", results[0].UserID)
+}
+
+// TestGetAuditsByResource verifies resource-based query.
+func TestGetAuditsByResource(t *testing.T) {
+	store := newTestAuditStore(t)
+	ctx := context.Background()
+	now := time.Now().UTC()
+
+	e := minimalEntry("res-entry", "t1", now)
+	e.ResourceType = "certificate"
+	e.ResourceID = "cert-123"
+	require.NoError(t, store.StoreAuditEntry(ctx, e))
+
+	results, err := store.GetAuditsByResource(ctx, "certificate", "cert-123", nil)
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	assert.Equal(t, "cert-123", results[0].ResourceID)
+}
+
+// TestGetAuditsByAction verifies action-based query.
+func TestGetAuditsByAction(t *testing.T) {
+	store := newTestAuditStore(t)
+	ctx := context.Background()
+	now := time.Now().UTC()
+
+	e1 := minimalEntry("act-1", "t1", now)
+	e1.Action = "write"
+	e2 := minimalEntry("act-2", "t1", now)
+	e2.Action = "read"
+	require.NoError(t, store.StoreAuditEntry(ctx, e1))
+	require.NoError(t, store.StoreAuditEntry(ctx, e2))
+
+	results, err := store.GetAuditsByAction(ctx, "write", nil)
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	assert.Equal(t, "write", results[0].Action)
+}
+
+// TestGetFailedActions verifies that failure, error, and denied entries are all returned.
+func TestGetFailedActions(t *testing.T) {
+	store := newTestAuditStore(t)
+	ctx := context.Background()
+	now := time.Now().UTC()
+
+	succeed := minimalEntry("s1", "t1", now)
+	succeed.Result = interfaces.AuditResultSuccess
+
+	fail := minimalEntry("f1", "t1", now)
+	fail.Result = interfaces.AuditResultFailure
+
+	errEntry := minimalEntry("e1", "t1", now)
+	errEntry.Result = interfaces.AuditResultError
+
+	denied := minimalEntry("d1", "t1", now)
+	denied.Result = interfaces.AuditResultDenied
+
+	require.NoError(t, store.StoreAuditEntry(ctx, succeed))
+	require.NoError(t, store.StoreAuditEntry(ctx, fail))
+	require.NoError(t, store.StoreAuditEntry(ctx, errEntry))
+	require.NoError(t, store.StoreAuditEntry(ctx, denied))
+
+	results, err := store.GetFailedActions(ctx, nil, 100)
+	require.NoError(t, err)
+	// All three failure variants must be returned; success must not be
+	assert.Len(t, results, 3, "expected failure, error, and denied entries")
+	for _, r := range results {
+		assert.NotEqual(t, interfaces.AuditResultSuccess, r.Result,
+			"success entries must not appear in GetFailedActions")
+	}
+
+	// Verify each variant is present
+	resultIDs := make(map[string]bool)
+	for _, r := range results {
+		resultIDs[r.ID] = true
+	}
+	assert.True(t, resultIDs["f1"], "AuditResultFailure entry must be included")
+	assert.True(t, resultIDs["e1"], "AuditResultError entry must be included")
+	assert.True(t, resultIDs["d1"], "AuditResultDenied entry must be included")
+}
+
+// TestGetSuspiciousActivity verifies high/critical severity filter.
+func TestGetSuspiciousActivity(t *testing.T) {
+	store := newTestAuditStore(t)
+	ctx := context.Background()
+	now := time.Now().UTC()
+
+	low := minimalEntry("low-1", "t1", now)
+	low.Severity = interfaces.AuditSeverityLow
+
+	high := minimalEntry("high-1", "t1", now)
+	high.Severity = interfaces.AuditSeverityHigh
+
+	crit := minimalEntry("crit-1", "t1", now)
+	crit.Severity = interfaces.AuditSeverityCritical
+
+	require.NoError(t, store.StoreAuditEntry(ctx, low))
+	require.NoError(t, store.StoreAuditEntry(ctx, high))
+	require.NoError(t, store.StoreAuditEntry(ctx, crit))
+
+	results, err := store.GetSuspiciousActivity(ctx, "t1", nil)
+	require.NoError(t, err)
+	assert.Len(t, results, 2)
+}
+
+// TestStoreAuditBatch verifies batch storage.
+func TestStoreAuditBatch(t *testing.T) {
+	store := newTestAuditStore(t)
+	ctx := context.Background()
+	now := time.Now().UTC()
+
+	entries := []*interfaces.AuditEntry{
+		minimalEntry("b1", "t1", now),
+		minimalEntry("b2", "t1", now),
+		minimalEntry("b3", "t1", now),
+	}
+	require.NoError(t, store.StoreAuditBatch(ctx, entries))
+
+	for _, e := range entries {
+		got, err := store.GetAuditEntry(ctx, e.ID)
+		require.NoError(t, err)
+		assert.Equal(t, e.ID, got.ID)
+	}
+}
+
+// TestGetAuditStats verifies aggregate statistics computation.
+func TestGetAuditStats(t *testing.T) {
+	store := newTestAuditStore(t)
+	ctx := context.Background()
+	now := time.Now().UTC()
+
+	entries := []*interfaces.AuditEntry{
+		minimalEntry("s1", "t1", now),
+		minimalEntry("s2", "t2", now),
+	}
+	for _, e := range entries {
+		require.NoError(t, store.StoreAuditEntry(ctx, e))
+	}
+
+	stats, err := store.GetAuditStats(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, int64(2), stats.TotalEntries)
+	assert.Greater(t, stats.TotalSize, int64(0))
+	assert.NotNil(t, stats.NewestEntry)
+}
+
+// TestListAuditEntriesPagination verifies limit and offset.
+func TestListAuditEntriesPagination(t *testing.T) {
+	store := newTestAuditStore(t)
+	ctx := context.Background()
+	now := time.Now().UTC()
+
+	for i := 0; i < 5; i++ {
+		e := minimalEntry(fmt.Sprintf("page-%d", i), "t1", now)
+		require.NoError(t, store.StoreAuditEntry(ctx, e))
+	}
+
+	results, err := store.ListAuditEntries(ctx, &interfaces.AuditFilter{
+		TenantID: "t1",
+		Limit:    2,
+		Offset:   1,
+	})
+	require.NoError(t, err)
+	assert.Len(t, results, 2)
+}
+
+// TestAuditStorePathTraversalPrevention ensures directory traversal is rejected.
+func TestAuditStorePathTraversalPrevention(t *testing.T) {
+	store := newTestAuditStore(t)
+	ctx := context.Background()
+
+	e := minimalEntry("traversal", "../../../escaped", time.Now().UTC())
+	err := store.StoreAuditEntry(ctx, e)
+	require.Error(t, err)
+}
+
+// TestPurgeAuditEntries verifies that old files are deleted by PurgeAuditEntries.
+func TestPurgeAuditEntries(t *testing.T) {
+	store := newTestAuditStore(t)
+	ctx := context.Background()
+
+	// Store an entry from 5 days ago
+	oldTS := time.Now().UTC().AddDate(0, 0, -5)
+	old := minimalEntry("old", "t1", oldTS)
+	require.NoError(t, store.StoreAuditEntry(ctx, old))
+
+	// Store a recent entry
+	recent := minimalEntry("recent", "t1", time.Now().UTC())
+	require.NoError(t, store.StoreAuditEntry(ctx, recent))
+
+	// Purge everything older than 2 days ago
+	cutoff := time.Now().UTC().AddDate(0, 0, -2)
+	count, err := store.PurgeAuditEntries(ctx, cutoff)
+	require.NoError(t, err)
+	assert.Greater(t, count, int64(0))
+
+	// The old entry should no longer be found
+	_, err = store.GetAuditEntry(ctx, "old")
+	assert.Error(t, err)
+
+	// The recent entry should still be present
+	got, err := store.GetAuditEntry(ctx, "recent")
+	require.NoError(t, err)
+	assert.Equal(t, "recent", got.ID)
+}
+
+// TestArchiveAuditEntries verifies that old files are moved to archive.
+func TestArchiveAuditEntries(t *testing.T) {
+	store := newTestAuditStore(t)
+	ctx := context.Background()
+
+	// Store an entry from 5 days ago
+	oldTS := time.Now().UTC().AddDate(0, 0, -5)
+	old := minimalEntry("archive-old", "t1", oldTS)
+	require.NoError(t, store.StoreAuditEntry(ctx, old))
+
+	cutoff := time.Now().UTC().AddDate(0, 0, -2)
+	count, err := store.ArchiveAuditEntries(ctx, cutoff)
+	require.NoError(t, err)
+	assert.Greater(t, count, int64(0))
+}
+
+// TestConcurrentAuditWrites verifies no data corruption with 10 goroutines appending entries.
+func TestConcurrentAuditWrites(t *testing.T) {
+	store := newTestAuditStore(t)
+	ctx := context.Background()
+	now := time.Now().UTC()
+
+	const numGoroutines = 10
+	var wg sync.WaitGroup
+	errs := make([]error, numGoroutines)
+
+	for i := 0; i < numGoroutines; i++ {
+		wg.Add(1)
+		i := i
+		go func() {
+			defer wg.Done()
+			e := minimalEntry(fmt.Sprintf("concurrent-%d", i), "concurrent-tenant", now)
+			errs[i] = store.StoreAuditEntry(ctx, e)
+		}()
+	}
+	wg.Wait()
+
+	for i, err := range errs {
+		assert.NoError(t, err, "goroutine %d returned error", i)
+	}
+
+	// Verify all entries are readable and not corrupted
+	results, err := store.ListAuditEntries(ctx, &interfaces.AuditFilter{TenantID: "concurrent-tenant"})
+	require.NoError(t, err)
+	assert.Len(t, results, numGoroutines, "all concurrent entries must be persisted")
+
+	for _, r := range results {
+		assert.NotEmpty(t, r.ID)
+		assert.Equal(t, "concurrent-tenant", r.TenantID)
+	}
+}
+
+// TestListAuditEntriesEmptyStore returns empty slice, not error.
+func TestListAuditEntriesEmptyStore(t *testing.T) {
+	store := newTestAuditStore(t)
+	ctx := context.Background()
+
+	results, err := store.ListAuditEntries(ctx, &interfaces.AuditFilter{TenantID: "t1"})
+	require.NoError(t, err)
+	assert.Empty(t, results)
+}
+
+// TestAuditDefaultTimestamp verifies zero timestamp is filled with now.
+func TestAuditDefaultTimestamp(t *testing.T) {
+	store := newTestAuditStore(t)
+	ctx := context.Background()
+
+	e := minimalEntry("ts-default", "t1", time.Time{}) // zero time
+	require.NoError(t, store.StoreAuditEntry(ctx, e))
+
+	got, err := store.GetAuditEntry(ctx, "ts-default")
+	require.NoError(t, err)
+	assert.False(t, got.Timestamp.IsZero(), "timestamp must be set automatically")
+}

--- a/pkg/storage/providers/flatfile/config_store.go
+++ b/pkg/storage/providers/flatfile/config_store.go
@@ -1,0 +1,597 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+package flatfile
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/cfgis/cfgms/pkg/storage/interfaces"
+)
+
+// FlatFileConfigStore implements interfaces.ConfigStore using the local filesystem.
+//
+// File layout: <root>/<tenantID>/configs/<namespace>/<name>.<format>
+//
+// The entire ConfigEntry struct is JSON-encoded and written to the file; the
+// file extension reflects the format of the Data field (.yaml or .json).
+//
+// Atomic writes: write to a temp file in the same directory, then os.Rename.
+// This is crash-safe on Linux when both files are on the same filesystem. On
+// Windows, renames across volumes may fail — keep root on a single filesystem.
+type FlatFileConfigStore struct {
+	root  string
+	mutex sync.RWMutex
+}
+
+// NewFlatFileConfigStore creates a new FlatFileConfigStore rooted at root.
+// The root directory is created (with MkdirAll) if it does not already exist.
+func NewFlatFileConfigStore(root string) (*FlatFileConfigStore, error) {
+	if err := os.MkdirAll(root, 0750); err != nil {
+		return nil, fmt.Errorf("failed to create config root: %w", err)
+	}
+	return &FlatFileConfigStore{root: root}, nil
+}
+
+// safeJoin validates and joins path components to prevent directory traversal.
+// Returns an error if the resulting path escapes base.
+func safeJoin(base string, parts ...string) (string, error) {
+	joined := filepath.Join(append([]string{base}, parts...)...)
+	cleaned := filepath.Clean(joined)
+	cleanBase := filepath.Clean(base)
+	if cleaned != cleanBase &&
+		!strings.HasPrefix(cleaned, cleanBase+string(os.PathSeparator)) {
+		return "", fmt.Errorf("path traversal detected in path components")
+	}
+	return cleaned, nil
+}
+
+// configExt returns the file extension for a given config format.
+func configExt(format interfaces.ConfigFormat) string {
+	switch format {
+	case interfaces.ConfigFormatYAML:
+		return "yaml"
+	default:
+		return "json"
+	}
+}
+
+// configFileName returns the base filename for a config key.
+func configFileName(key *interfaces.ConfigKey, format interfaces.ConfigFormat) string {
+	name := key.Name
+	if key.Scope != "" {
+		name = key.Name + "@" + key.Scope
+	}
+	return name + "." + configExt(format)
+}
+
+// configDir returns the directory for a tenant's configs in the given namespace.
+func (s *FlatFileConfigStore) configDir(tenantID, namespace string) (string, error) {
+	return safeJoin(s.root, tenantID, "configs", namespace)
+}
+
+// configPath returns the filesystem path for a config entry with the given format.
+func (s *FlatFileConfigStore) configPath(key *interfaces.ConfigKey, format interfaces.ConfigFormat) (string, error) {
+	dir, err := s.configDir(key.TenantID, key.Namespace)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, configFileName(key, format)), nil
+}
+
+// findConfigFile locates the file for a config key, trying .yaml then .json.
+// Returns ErrConfigNotFound if neither exists.
+func (s *FlatFileConfigStore) findConfigFile(key *interfaces.ConfigKey) (string, error) {
+	for _, format := range []interfaces.ConfigFormat{interfaces.ConfigFormatYAML, interfaces.ConfigFormatJSON} {
+		dir, err := s.configDir(key.TenantID, key.Namespace)
+		if err != nil {
+			continue
+		}
+		path := filepath.Join(dir, configFileName(key, format))
+		if _, err := os.Stat(path); err == nil {
+			return path, nil
+		}
+	}
+	return "", interfaces.ErrConfigNotFound
+}
+
+// writeAtomic writes data to path atomically via a temp file in the same directory.
+// The directory is created if it does not exist.
+func writeAtomic(path string, data []byte) error {
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0750); err != nil {
+		return fmt.Errorf("failed to create directory: %w", err)
+	}
+
+	tmpFile, err := os.CreateTemp(dir, ".tmp-cfg-*")
+	if err != nil {
+		return fmt.Errorf("failed to create temp file: %w", err)
+	}
+	tmpPath := tmpFile.Name()
+
+	success := false
+	defer func() {
+		if !success {
+			_ = os.Remove(tmpPath)
+		}
+	}()
+
+	if _, err := tmpFile.Write(data); err != nil {
+		_ = tmpFile.Close()
+		return fmt.Errorf("failed to write temp file: %w", err)
+	}
+	if err := tmpFile.Sync(); err != nil {
+		_ = tmpFile.Close()
+		return fmt.Errorf("failed to sync temp file: %w", err)
+	}
+	if err := tmpFile.Close(); err != nil {
+		return fmt.Errorf("failed to close temp file: %w", err)
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		return fmt.Errorf("atomic rename failed: %w", err)
+	}
+	success = true
+	return nil
+}
+
+// dataChecksum computes a SHA-256 hex checksum of data.
+func dataChecksum(data []byte) string {
+	h := sha256.Sum256(data)
+	return hex.EncodeToString(h[:])
+}
+
+// readConfigFile reads and unmarshals a config file. Must be called without holding mutex.
+func (s *FlatFileConfigStore) readConfigFile(key *interfaces.ConfigKey) (*interfaces.ConfigEntry, error) {
+	path, err := s.findConfigFile(key)
+	if err != nil {
+		return nil, interfaces.ErrConfigNotFound
+	}
+
+	// #nosec G304 — path is validated by safeJoin inside findConfigFile
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, interfaces.ErrConfigNotFound
+		}
+		return nil, fmt.Errorf("failed to read config file: %w", err)
+	}
+
+	var entry interfaces.ConfigEntry
+	if err := json.Unmarshal(raw, &entry); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal config entry: %w", err)
+	}
+	return &entry, nil
+}
+
+// StoreConfig stores a configuration entry atomically.
+// If an entry already exists, its version is incremented and CreatedAt/CreatedBy are preserved.
+func (s *FlatFileConfigStore) StoreConfig(ctx context.Context, config *interfaces.ConfigEntry) error {
+	if config.Key == nil || config.Key.TenantID == "" {
+		return interfaces.ErrTenantRequired
+	}
+	if config.Key.Namespace == "" {
+		return interfaces.ErrNamespaceRequired
+	}
+	if config.Key.Name == "" {
+		return interfaces.ErrNameRequired
+	}
+
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+
+	now := time.Now().UTC()
+
+	existing, _ := s.readConfigFile(config.Key)
+
+	entry := *config
+	if existing != nil {
+		entry.Version = existing.Version + 1
+		entry.CreatedAt = existing.CreatedAt
+		entry.CreatedBy = existing.CreatedBy
+	} else {
+		entry.Version = 1
+		entry.CreatedAt = now
+	}
+	entry.UpdatedAt = now
+	entry.Checksum = dataChecksum(config.Data)
+
+	if entry.Format == "" {
+		entry.Format = interfaces.ConfigFormatJSON
+	}
+
+	// Remove old file if format changed
+	if existing != nil && existing.Format != entry.Format {
+		if oldPath, err := s.configPath(config.Key, existing.Format); err == nil {
+			_ = os.Remove(oldPath)
+		}
+	}
+
+	path, err := s.configPath(config.Key, entry.Format)
+	if err != nil {
+		return fmt.Errorf("invalid config key: %w", err)
+	}
+
+	raw, err := json.Marshal(&entry)
+	if err != nil {
+		return fmt.Errorf("failed to marshal config entry: %w", err)
+	}
+
+	if err := writeAtomic(path, raw); err != nil {
+		return fmt.Errorf("failed to write config: %w", err)
+	}
+	return nil
+}
+
+// GetConfig retrieves a configuration entry by key.
+func (s *FlatFileConfigStore) GetConfig(ctx context.Context, key *interfaces.ConfigKey) (*interfaces.ConfigEntry, error) {
+	s.mutex.RLock()
+	defer s.mutex.RUnlock()
+	return s.readConfigFile(key)
+}
+
+// DeleteConfig removes a configuration entry.
+func (s *FlatFileConfigStore) DeleteConfig(ctx context.Context, key *interfaces.ConfigKey) error {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+
+	path, err := s.findConfigFile(key)
+	if err != nil {
+		return interfaces.ErrConfigNotFound
+	}
+
+	if err := os.Remove(path); err != nil {
+		if os.IsNotExist(err) {
+			return interfaces.ErrConfigNotFound
+		}
+		return fmt.Errorf("failed to delete config: %w", err)
+	}
+	return nil
+}
+
+// ListConfigs returns all configuration entries matching the filter.
+func (s *FlatFileConfigStore) ListConfigs(ctx context.Context, filter *interfaces.ConfigFilter) ([]*interfaces.ConfigEntry, error) {
+	s.mutex.RLock()
+	defer s.mutex.RUnlock()
+
+	searchRoot, err := s.listSearchRoot(filter)
+	if err != nil {
+		return nil, err
+	}
+
+	var results []*interfaces.ConfigEntry
+
+	walkErr := filepath.WalkDir(searchRoot, func(path string, d os.DirEntry, ferr error) error {
+		if ferr != nil {
+			if os.IsNotExist(ferr) {
+				return nil
+			}
+			return ferr
+		}
+		if d.IsDir() {
+			return nil
+		}
+		ext := filepath.Ext(path)
+		if ext != ".yaml" && ext != ".json" {
+			return nil
+		}
+
+		// #nosec G304 — path originates from WalkDir rooted at s.root
+		raw, err := os.ReadFile(path)
+		if err != nil {
+			return nil // skip unreadable files
+		}
+		var entry interfaces.ConfigEntry
+		if err := json.Unmarshal(raw, &entry); err != nil {
+			return nil // skip malformed files
+		}
+		if applyConfigFilter(&entry, filter) {
+			results = append(results, &entry)
+		}
+		return nil
+	})
+	if walkErr != nil && !os.IsNotExist(walkErr) {
+		return nil, fmt.Errorf("failed to list configs: %w", walkErr)
+	}
+
+	sortConfigs(results, filter)
+	results = paginateConfigs(results, filter)
+	return results, nil
+}
+
+// listSearchRoot returns the directory to start the WalkDir from, based on filter.
+func (s *FlatFileConfigStore) listSearchRoot(filter *interfaces.ConfigFilter) (string, error) {
+	if filter == nil || filter.TenantID == "" {
+		return s.root, nil
+	}
+	base, err := safeJoin(s.root, filter.TenantID, "configs")
+	if err != nil {
+		return "", fmt.Errorf("invalid tenant ID in filter: %w", err)
+	}
+	if filter.Namespace != "" {
+		ns, err := safeJoin(base, filter.Namespace)
+		if err != nil {
+			return "", fmt.Errorf("invalid namespace in filter: %w", err)
+		}
+		return ns, nil
+	}
+	return base, nil
+}
+
+// applyConfigFilter returns true if the entry matches all filter criteria.
+func applyConfigFilter(entry *interfaces.ConfigEntry, filter *interfaces.ConfigFilter) bool {
+	if filter == nil {
+		return true
+	}
+	if filter.TenantID != "" && (entry.Key == nil || entry.Key.TenantID != filter.TenantID) {
+		return false
+	}
+	if filter.Namespace != "" && (entry.Key == nil || entry.Key.Namespace != filter.Namespace) {
+		return false
+	}
+	if len(filter.Names) > 0 {
+		found := false
+		for _, n := range filter.Names {
+			if entry.Key != nil && entry.Key.Name == n {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return false
+		}
+	}
+	if filter.CreatedBy != "" && entry.CreatedBy != filter.CreatedBy {
+		return false
+	}
+	if filter.UpdatedBy != "" && entry.UpdatedBy != filter.UpdatedBy {
+		return false
+	}
+	if filter.CreatedAfter != nil && entry.CreatedAt.Before(*filter.CreatedAfter) {
+		return false
+	}
+	if filter.CreatedBefore != nil && entry.CreatedAt.After(*filter.CreatedBefore) {
+		return false
+	}
+	if filter.UpdatedAfter != nil && entry.UpdatedAt.Before(*filter.UpdatedAfter) {
+		return false
+	}
+	if filter.UpdatedBefore != nil && entry.UpdatedAt.After(*filter.UpdatedBefore) {
+		return false
+	}
+	for _, filterTag := range filter.Tags {
+		found := false
+		for _, tag := range entry.Tags {
+			if tag == filterTag {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return false
+		}
+	}
+	return true
+}
+
+// sortConfigs sorts results according to the filter's SortBy and Order fields.
+func sortConfigs(results []*interfaces.ConfigEntry, filter *interfaces.ConfigFilter) {
+	if filter == nil || filter.SortBy == "" {
+		return
+	}
+	ascending := filter.Order != "desc"
+	sort.Slice(results, func(i, j int) bool {
+		var less bool
+		switch filter.SortBy {
+		case "name":
+			if results[i].Key != nil && results[j].Key != nil {
+				less = results[i].Key.Name < results[j].Key.Name
+			}
+		case "updated_at":
+			less = results[i].UpdatedAt.Before(results[j].UpdatedAt)
+		case "version":
+			less = results[i].Version < results[j].Version
+		default: // "created_at"
+			less = results[i].CreatedAt.Before(results[j].CreatedAt)
+		}
+		if ascending {
+			return less
+		}
+		return !less
+	})
+}
+
+// paginateConfigs applies offset and limit from the filter.
+func paginateConfigs(results []*interfaces.ConfigEntry, filter *interfaces.ConfigFilter) []*interfaces.ConfigEntry {
+	if filter == nil {
+		return results
+	}
+	if filter.Offset > 0 {
+		if filter.Offset >= len(results) {
+			return nil
+		}
+		results = results[filter.Offset:]
+	}
+	if filter.Limit > 0 && filter.Limit < len(results) {
+		results = results[:filter.Limit]
+	}
+	return results
+}
+
+// GetConfigHistory returns the current entry as the only history item.
+// The flat-file provider does not retain historical versions; only the
+// current state is stored. Use git-sync if you need PR-based change history.
+func (s *FlatFileConfigStore) GetConfigHistory(ctx context.Context, key *interfaces.ConfigKey, limit int) ([]*interfaces.ConfigEntry, error) {
+	s.mutex.RLock()
+	defer s.mutex.RUnlock()
+
+	entry, err := s.readConfigFile(key)
+	if err != nil {
+		return nil, err
+	}
+	return []*interfaces.ConfigEntry{entry}, nil
+}
+
+// GetConfigVersion returns the current entry if its version matches; otherwise ErrConfigNotFound.
+// The flat-file provider does not retain historical versions.
+func (s *FlatFileConfigStore) GetConfigVersion(ctx context.Context, key *interfaces.ConfigKey, version int64) (*interfaces.ConfigEntry, error) {
+	s.mutex.RLock()
+	defer s.mutex.RUnlock()
+
+	entry, err := s.readConfigFile(key)
+	if err != nil {
+		return nil, err
+	}
+	if entry.Version != version {
+		return nil, fmt.Errorf("%w: version %d not available (current: %d)",
+			interfaces.ErrConfigNotFound, version, entry.Version)
+	}
+	return entry, nil
+}
+
+// StoreConfigBatch stores multiple configuration entries, stopping on first error.
+func (s *FlatFileConfigStore) StoreConfigBatch(ctx context.Context, configs []*interfaces.ConfigEntry) error {
+	for _, config := range configs {
+		if err := s.StoreConfig(ctx, config); err != nil {
+			return fmt.Errorf("batch store failed at %v: %w", config.Key, err)
+		}
+	}
+	return nil
+}
+
+// DeleteConfigBatch deletes multiple configuration entries, ignoring not-found entries.
+func (s *FlatFileConfigStore) DeleteConfigBatch(ctx context.Context, keys []*interfaces.ConfigKey) error {
+	for _, key := range keys {
+		err := s.DeleteConfig(ctx, key)
+		if err != nil && err != interfaces.ErrConfigNotFound {
+			return fmt.Errorf("batch delete failed at %v: %w", key, err)
+		}
+	}
+	return nil
+}
+
+// ResolveConfigWithInheritance resolves a config by walking up the tenant hierarchy.
+// TenantIDs must be path-based (e.g., "root/msp-a/client-1"). The method returns
+// the config at the most specific level, falling back to ancestors.
+//
+// Example resolution order for tenant "root/msp-a/client-1":
+//  1. root/msp-a/client-1/configs/<namespace>/<name>
+//  2. root/msp-a/configs/<namespace>/<name>
+//  3. root/configs/<namespace>/<name>
+func (s *FlatFileConfigStore) ResolveConfigWithInheritance(ctx context.Context, key *interfaces.ConfigKey) (*interfaces.ConfigEntry, error) {
+	s.mutex.RLock()
+	defer s.mutex.RUnlock()
+
+	parts := strings.Split(key.TenantID, "/")
+
+	for i := len(parts); i > 0; i-- {
+		tenantID := strings.Join(parts[:i], "/")
+		searchKey := &interfaces.ConfigKey{
+			TenantID:  tenantID,
+			Namespace: key.Namespace,
+			Name:      key.Name,
+			Scope:     key.Scope,
+		}
+		entry, err := s.readConfigFile(searchKey)
+		if err == nil {
+			return entry, nil
+		}
+	}
+	return nil, interfaces.ErrConfigNotFound
+}
+
+// ValidateConfig validates the required fields of a configuration entry.
+func (s *FlatFileConfigStore) ValidateConfig(ctx context.Context, config *interfaces.ConfigEntry) error {
+	if config.Key == nil || config.Key.TenantID == "" {
+		return interfaces.ErrTenantRequired
+	}
+	if config.Key.Namespace == "" {
+		return interfaces.ErrNamespaceRequired
+	}
+	if config.Key.Name == "" {
+		return interfaces.ErrNameRequired
+	}
+	if config.Format != "" &&
+		config.Format != interfaces.ConfigFormatYAML &&
+		config.Format != interfaces.ConfigFormatJSON {
+		return interfaces.ErrInvalidFormat
+	}
+	if config.Checksum != "" && len(config.Data) > 0 {
+		if config.Checksum != dataChecksum(config.Data) {
+			return interfaces.ErrChecksumMismatch
+		}
+	}
+	return nil
+}
+
+// GetConfigStats scans the root directory and returns aggregate statistics.
+func (s *FlatFileConfigStore) GetConfigStats(ctx context.Context) (*interfaces.ConfigStats, error) {
+	s.mutex.RLock()
+	defer s.mutex.RUnlock()
+
+	stats := &interfaces.ConfigStats{
+		ConfigsByTenant:    make(map[string]int64),
+		ConfigsByFormat:    make(map[string]int64),
+		ConfigsByNamespace: make(map[string]int64),
+		LastUpdated:        time.Now().UTC(),
+	}
+
+	var oldest, newest *time.Time
+
+	walkErr := filepath.WalkDir(s.root, func(path string, d os.DirEntry, ferr error) error {
+		if ferr != nil || d.IsDir() {
+			return nil
+		}
+		ext := filepath.Ext(path)
+		if ext != ".yaml" && ext != ".json" {
+			return nil
+		}
+
+		// #nosec G304 — path from WalkDir rooted at s.root
+		raw, err := os.ReadFile(path)
+		if err != nil {
+			return nil
+		}
+		var entry interfaces.ConfigEntry
+		if err := json.Unmarshal(raw, &entry); err != nil {
+			return nil
+		}
+
+		stats.TotalConfigs++
+		stats.TotalSize += int64(len(raw))
+
+		if entry.Key != nil {
+			stats.ConfigsByTenant[entry.Key.TenantID]++
+			stats.ConfigsByNamespace[entry.Key.Namespace]++
+		}
+		stats.ConfigsByFormat[string(entry.Format)]++
+
+		if oldest == nil || entry.CreatedAt.Before(*oldest) {
+			t := entry.CreatedAt
+			oldest = &t
+		}
+		if newest == nil || entry.CreatedAt.After(*newest) {
+			t := entry.CreatedAt
+			newest = &t
+		}
+		return nil
+	})
+	if walkErr != nil && !os.IsNotExist(walkErr) {
+		return nil, fmt.Errorf("failed to compute config stats: %w", walkErr)
+	}
+
+	stats.OldestConfig = oldest
+	stats.NewestConfig = newest
+	if stats.TotalConfigs > 0 {
+		stats.AverageSize = stats.TotalSize / stats.TotalConfigs
+	}
+	return stats, nil
+}

--- a/pkg/storage/providers/flatfile/config_store_test.go
+++ b/pkg/storage/providers/flatfile/config_store_test.go
@@ -1,0 +1,522 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+package flatfile_test
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cfgis/cfgms/pkg/storage/interfaces"
+	"github.com/cfgis/cfgms/pkg/storage/providers/flatfile"
+)
+
+// newTestConfigStore creates a FlatFileConfigStore backed by a temporary directory.
+func newTestConfigStore(t *testing.T) *flatfile.FlatFileConfigStore {
+	t.Helper()
+	store, err := flatfile.NewFlatFileConfigStore(t.TempDir())
+	require.NoError(t, err)
+	return store
+}
+
+// testEntry builds a minimal ConfigEntry for testing.
+func testEntry(tenantID, namespace, name string, data []byte, format interfaces.ConfigFormat) *interfaces.ConfigEntry {
+	return &interfaces.ConfigEntry{
+		Key: &interfaces.ConfigKey{
+			TenantID:  tenantID,
+			Namespace: namespace,
+			Name:      name,
+		},
+		Data:      data,
+		Format:    format,
+		CreatedBy: "test",
+		UpdatedBy: "test",
+	}
+}
+
+// TestStoreAndGetConfig verifies basic store and retrieve round-trip.
+func TestStoreAndGetConfig(t *testing.T) {
+	store := newTestConfigStore(t)
+	ctx := context.Background()
+
+	entry := testEntry("tenant1", "default", "policy", []byte(`{"key":"value"}`), interfaces.ConfigFormatJSON)
+	require.NoError(t, store.StoreConfig(ctx, entry))
+
+	got, err := store.GetConfig(ctx, entry.Key)
+	require.NoError(t, err)
+	assert.Equal(t, entry.Key.Name, got.Key.Name)
+	assert.Equal(t, entry.Key.TenantID, got.Key.TenantID)
+	assert.Equal(t, entry.Data, got.Data)
+	assert.Equal(t, int64(1), got.Version)
+	assert.NotEmpty(t, got.Checksum)
+	assert.False(t, got.CreatedAt.IsZero())
+	assert.False(t, got.UpdatedAt.IsZero())
+}
+
+// TestStoreConfigYAML verifies YAML-format storage.
+func TestStoreConfigYAML(t *testing.T) {
+	store := newTestConfigStore(t)
+	ctx := context.Background()
+
+	entry := testEntry("tenant1", "ns", "rules", []byte("key: value\n"), interfaces.ConfigFormatYAML)
+	require.NoError(t, store.StoreConfig(ctx, entry))
+
+	got, err := store.GetConfig(ctx, entry.Key)
+	require.NoError(t, err)
+	assert.Equal(t, interfaces.ConfigFormatYAML, got.Format)
+	assert.Equal(t, entry.Data, got.Data)
+}
+
+// TestStoreConfigVersionIncrement verifies that re-storing a config increments the version.
+func TestStoreConfigVersionIncrement(t *testing.T) {
+	store := newTestConfigStore(t)
+	ctx := context.Background()
+
+	entry := testEntry("tenant1", "ns", "cfg", []byte(`v1`), interfaces.ConfigFormatJSON)
+	require.NoError(t, store.StoreConfig(ctx, entry))
+
+	entry.Data = []byte(`v2`)
+	require.NoError(t, store.StoreConfig(ctx, entry))
+
+	got, err := store.GetConfig(ctx, entry.Key)
+	require.NoError(t, err)
+	assert.Equal(t, int64(2), got.Version)
+	assert.Equal(t, []byte(`v2`), got.Data)
+}
+
+// TestGetConfigNotFound verifies that a missing config returns ErrConfigNotFound.
+func TestGetConfigNotFound(t *testing.T) {
+	store := newTestConfigStore(t)
+	ctx := context.Background()
+
+	_, err := store.GetConfig(ctx, &interfaces.ConfigKey{
+		TenantID:  "tenant1",
+		Namespace: "ns",
+		Name:      "nonexistent",
+	})
+	assert.Equal(t, interfaces.ErrConfigNotFound, err)
+}
+
+// TestDeleteConfig verifies that a stored config can be deleted.
+func TestDeleteConfig(t *testing.T) {
+	store := newTestConfigStore(t)
+	ctx := context.Background()
+
+	entry := testEntry("t1", "ns", "cfg", []byte(`data`), interfaces.ConfigFormatJSON)
+	require.NoError(t, store.StoreConfig(ctx, entry))
+	require.NoError(t, store.DeleteConfig(ctx, entry.Key))
+
+	_, err := store.GetConfig(ctx, entry.Key)
+	assert.Equal(t, interfaces.ErrConfigNotFound, err)
+}
+
+// TestDeleteConfigNotFound verifies that deleting a non-existent config returns ErrConfigNotFound.
+func TestDeleteConfigNotFound(t *testing.T) {
+	store := newTestConfigStore(t)
+	ctx := context.Background()
+
+	err := store.DeleteConfig(ctx, &interfaces.ConfigKey{
+		TenantID:  "t1",
+		Namespace: "ns",
+		Name:      "gone",
+	})
+	assert.Equal(t, interfaces.ErrConfigNotFound, err)
+}
+
+// TestListConfigs verifies that stored configs can be listed.
+func TestListConfigs(t *testing.T) {
+	store := newTestConfigStore(t)
+	ctx := context.Background()
+
+	entries := []*interfaces.ConfigEntry{
+		testEntry("t1", "ns", "alpha", []byte(`a`), interfaces.ConfigFormatJSON),
+		testEntry("t1", "ns", "beta", []byte(`b`), interfaces.ConfigFormatJSON),
+		testEntry("t1", "ns2", "gamma", []byte(`c`), interfaces.ConfigFormatJSON),
+	}
+	for _, e := range entries {
+		require.NoError(t, store.StoreConfig(ctx, e))
+	}
+
+	t.Run("all entries", func(t *testing.T) {
+		results, err := store.ListConfigs(ctx, &interfaces.ConfigFilter{TenantID: "t1"})
+		require.NoError(t, err)
+		assert.Len(t, results, 3)
+	})
+
+	t.Run("filter by namespace", func(t *testing.T) {
+		results, err := store.ListConfigs(ctx, &interfaces.ConfigFilter{TenantID: "t1", Namespace: "ns"})
+		require.NoError(t, err)
+		assert.Len(t, results, 2)
+	})
+
+	t.Run("filter by name", func(t *testing.T) {
+		results, err := store.ListConfigs(ctx, &interfaces.ConfigFilter{TenantID: "t1", Names: []string{"alpha"}})
+		require.NoError(t, err)
+		require.Len(t, results, 1)
+		assert.Equal(t, "alpha", results[0].Key.Name)
+	})
+
+	t.Run("empty result", func(t *testing.T) {
+		results, err := store.ListConfigs(ctx, &interfaces.ConfigFilter{TenantID: "notexist"})
+		require.NoError(t, err)
+		assert.Empty(t, results)
+	})
+}
+
+// TestListConfigsPagination verifies offset and limit in ListConfigs.
+func TestListConfigsPagination(t *testing.T) {
+	store := newTestConfigStore(t)
+	ctx := context.Background()
+
+	for i := 0; i < 5; i++ {
+		e := testEntry("t1", "ns", fmt.Sprintf("cfg%d", i), []byte(`x`), interfaces.ConfigFormatJSON)
+		require.NoError(t, store.StoreConfig(ctx, e))
+	}
+
+	results, err := store.ListConfigs(ctx, &interfaces.ConfigFilter{
+		TenantID: "t1",
+		Limit:    2,
+		Offset:   1,
+	})
+	require.NoError(t, err)
+	assert.Len(t, results, 2)
+}
+
+// TestResolveConfigWithInheritanceTwoLevel tests two-level tenant inheritance.
+func TestResolveConfigWithInheritanceTwoLevel(t *testing.T) {
+	store := newTestConfigStore(t)
+	ctx := context.Background()
+
+	// Store at parent level (root/msp-a)
+	parent := testEntry("root/msp-a", "firewall", "rules", []byte(`parent`), interfaces.ConfigFormatJSON)
+	require.NoError(t, store.StoreConfig(ctx, parent))
+
+	// Resolve from child (root/msp-a/client-1) — should fall back to parent
+	childKey := &interfaces.ConfigKey{
+		TenantID:  "root/msp-a/client-1",
+		Namespace: "firewall",
+		Name:      "rules",
+	}
+	got, err := store.ResolveConfigWithInheritance(ctx, childKey)
+	require.NoError(t, err)
+	assert.Equal(t, []byte(`parent`), got.Data)
+	assert.Equal(t, "root/msp-a", got.Key.TenantID)
+
+	// Now store a child-level override
+	child := testEntry("root/msp-a/client-1", "firewall", "rules", []byte(`child`), interfaces.ConfigFormatJSON)
+	require.NoError(t, store.StoreConfig(ctx, child))
+
+	// Resolve again — should now return child override
+	got, err = store.ResolveConfigWithInheritance(ctx, childKey)
+	require.NoError(t, err)
+	assert.Equal(t, []byte(`child`), got.Data)
+}
+
+// TestResolveConfigWithInheritanceNotFound returns ErrConfigNotFound when absent at all levels.
+func TestResolveConfigWithInheritanceNotFound(t *testing.T) {
+	store := newTestConfigStore(t)
+	ctx := context.Background()
+
+	_, err := store.ResolveConfigWithInheritance(ctx, &interfaces.ConfigKey{
+		TenantID:  "root/msp-a/client-1",
+		Namespace: "ns",
+		Name:      "nope",
+	})
+	assert.Equal(t, interfaces.ErrConfigNotFound, err)
+}
+
+// TestStoreConfigValidation verifies required-field validation.
+func TestStoreConfigValidation(t *testing.T) {
+	store := newTestConfigStore(t)
+	ctx := context.Background()
+
+	t.Run("missing tenant", func(t *testing.T) {
+		err := store.StoreConfig(ctx, &interfaces.ConfigEntry{
+			Key:  &interfaces.ConfigKey{Namespace: "ns", Name: "n"},
+			Data: []byte(`x`),
+		})
+		assert.Error(t, err)
+	})
+
+	t.Run("missing namespace", func(t *testing.T) {
+		err := store.StoreConfig(ctx, &interfaces.ConfigEntry{
+			Key:  &interfaces.ConfigKey{TenantID: "t1", Name: "n"},
+			Data: []byte(`x`),
+		})
+		assert.Error(t, err)
+	})
+
+	t.Run("missing name", func(t *testing.T) {
+		err := store.StoreConfig(ctx, &interfaces.ConfigEntry{
+			Key:  &interfaces.ConfigKey{TenantID: "t1", Namespace: "ns"},
+			Data: []byte(`x`),
+		})
+		assert.Error(t, err)
+	})
+
+	t.Run("nil key", func(t *testing.T) {
+		err := store.StoreConfig(ctx, &interfaces.ConfigEntry{Data: []byte(`x`)})
+		assert.Error(t, err)
+	})
+}
+
+// TestPathTraversalPrevention ensures directory traversal is rejected.
+func TestPathTraversalPrevention(t *testing.T) {
+	store := newTestConfigStore(t)
+	ctx := context.Background()
+
+	err := store.StoreConfig(ctx, &interfaces.ConfigEntry{
+		Key: &interfaces.ConfigKey{
+			TenantID:  "../escaped",
+			Namespace: "ns",
+			Name:      "cfg",
+		},
+		Data:   []byte(`bad`),
+		Format: interfaces.ConfigFormatJSON,
+	})
+	require.Error(t, err)
+}
+
+// TestConcurrentWrites verifies no data corruption with 10 goroutines writing to the same namespace.
+func TestConcurrentWrites(t *testing.T) {
+	store := newTestConfigStore(t)
+	ctx := context.Background()
+
+	const numGoroutines = 10
+	var wg sync.WaitGroup
+	errs := make([]error, numGoroutines)
+
+	for i := 0; i < numGoroutines; i++ {
+		wg.Add(1)
+		i := i
+		go func() {
+			defer wg.Done()
+			entry := &interfaces.ConfigEntry{
+				Key: &interfaces.ConfigKey{
+					TenantID:  "concurrent-tenant",
+					Namespace: "shared-ns",
+					Name:      fmt.Sprintf("cfg-%d", i),
+				},
+				Data:   []byte(fmt.Sprintf(`{"writer":%d}`, i)),
+				Format: interfaces.ConfigFormatJSON,
+			}
+			errs[i] = store.StoreConfig(ctx, entry)
+		}()
+	}
+	wg.Wait()
+
+	for i, err := range errs {
+		assert.NoError(t, err, "goroutine %d returned error", i)
+	}
+
+	// Verify all writes are readable without corruption
+	results, err := store.ListConfigs(ctx, &interfaces.ConfigFilter{
+		TenantID:  "concurrent-tenant",
+		Namespace: "shared-ns",
+	})
+	require.NoError(t, err)
+	assert.Len(t, results, numGoroutines)
+
+	for _, r := range results {
+		assert.NotNil(t, r.Key)
+		assert.NotEmpty(t, r.Data)
+	}
+}
+
+// TestStoreConfigBatch verifies batch store and retrieval.
+func TestStoreConfigBatch(t *testing.T) {
+	store := newTestConfigStore(t)
+	ctx := context.Background()
+
+	entries := []*interfaces.ConfigEntry{
+		testEntry("t1", "ns", "a", []byte(`1`), interfaces.ConfigFormatJSON),
+		testEntry("t1", "ns", "b", []byte(`2`), interfaces.ConfigFormatJSON),
+	}
+	require.NoError(t, store.StoreConfigBatch(ctx, entries))
+
+	for _, e := range entries {
+		got, err := store.GetConfig(ctx, e.Key)
+		require.NoError(t, err)
+		assert.Equal(t, e.Data, got.Data)
+	}
+}
+
+// TestDeleteConfigBatch verifies batch deletion.
+func TestDeleteConfigBatch(t *testing.T) {
+	store := newTestConfigStore(t)
+	ctx := context.Background()
+
+	entries := []*interfaces.ConfigEntry{
+		testEntry("t1", "ns", "a", []byte(`1`), interfaces.ConfigFormatJSON),
+		testEntry("t1", "ns", "b", []byte(`2`), interfaces.ConfigFormatJSON),
+	}
+	require.NoError(t, store.StoreConfigBatch(ctx, entries))
+
+	keys := []*interfaces.ConfigKey{entries[0].Key, entries[1].Key}
+	require.NoError(t, store.DeleteConfigBatch(ctx, keys))
+
+	for _, key := range keys {
+		_, err := store.GetConfig(ctx, key)
+		assert.Equal(t, interfaces.ErrConfigNotFound, err)
+	}
+}
+
+// TestGetConfigHistory returns at least the current version.
+func TestGetConfigHistory(t *testing.T) {
+	store := newTestConfigStore(t)
+	ctx := context.Background()
+
+	entry := testEntry("t1", "ns", "cfg", []byte(`v1`), interfaces.ConfigFormatJSON)
+	require.NoError(t, store.StoreConfig(ctx, entry))
+
+	history, err := store.GetConfigHistory(ctx, entry.Key, 10)
+	require.NoError(t, err)
+	assert.NotEmpty(t, history)
+	assert.Equal(t, entry.Key.Name, history[0].Key.Name)
+}
+
+// TestGetConfigVersion returns current version on match, error on mismatch.
+func TestGetConfigVersion(t *testing.T) {
+	store := newTestConfigStore(t)
+	ctx := context.Background()
+
+	entry := testEntry("t1", "ns", "cfg", []byte(`v1`), interfaces.ConfigFormatJSON)
+	require.NoError(t, store.StoreConfig(ctx, entry))
+
+	got, err := store.GetConfigVersion(ctx, entry.Key, 1)
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), got.Version)
+
+	_, err = store.GetConfigVersion(ctx, entry.Key, 999)
+	assert.Error(t, err)
+}
+
+// TestValidateConfig verifies validation helper.
+func TestValidateConfig(t *testing.T) {
+	store := newTestConfigStore(t)
+	ctx := context.Background()
+
+	t.Run("valid entry", func(t *testing.T) {
+		err := store.ValidateConfig(ctx, testEntry("t1", "ns", "cfg", []byte(`x`), interfaces.ConfigFormatJSON))
+		assert.NoError(t, err)
+	})
+
+	t.Run("invalid format", func(t *testing.T) {
+		e := testEntry("t1", "ns", "cfg", []byte(`x`), "")
+		e.Format = "xml" // unsupported
+		err := store.ValidateConfig(ctx, e)
+		assert.Error(t, err)
+	})
+
+	t.Run("checksum mismatch", func(t *testing.T) {
+		e := testEntry("t1", "ns", "cfg", []byte(`data`), interfaces.ConfigFormatJSON)
+		e.Checksum = "badhash"
+		err := store.ValidateConfig(ctx, e)
+		assert.Error(t, err)
+	})
+}
+
+// TestGetConfigStats returns stats for stored configs.
+func TestGetConfigStats(t *testing.T) {
+	store := newTestConfigStore(t)
+	ctx := context.Background()
+
+	entries := []*interfaces.ConfigEntry{
+		testEntry("t1", "ns", "a", []byte(`data1`), interfaces.ConfigFormatJSON),
+		testEntry("t1", "ns", "b", []byte(`data2`), interfaces.ConfigFormatYAML),
+	}
+	for _, e := range entries {
+		require.NoError(t, store.StoreConfig(ctx, e))
+	}
+
+	stats, err := store.GetConfigStats(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, int64(2), stats.TotalConfigs)
+	assert.Greater(t, stats.TotalSize, int64(0))
+	assert.NotNil(t, stats.OldestConfig)
+	assert.NotNil(t, stats.NewestConfig)
+}
+
+// TestConfigScopeInKey verifies that scope is used in the filename.
+func TestConfigScopeInKey(t *testing.T) {
+	store := newTestConfigStore(t)
+	ctx := context.Background()
+
+	entry := &interfaces.ConfigEntry{
+		Key: &interfaces.ConfigKey{
+			TenantID:  "t1",
+			Namespace: "ns",
+			Name:      "cfg",
+			Scope:     "group1",
+		},
+		Data:   []byte(`scoped`),
+		Format: interfaces.ConfigFormatJSON,
+	}
+	require.NoError(t, store.StoreConfig(ctx, entry))
+
+	got, err := store.GetConfig(ctx, entry.Key)
+	require.NoError(t, err)
+	assert.Equal(t, entry.Data, got.Data)
+}
+
+// TestListConfigsSortByName verifies sort ordering.
+func TestListConfigsSortByName(t *testing.T) {
+	store := newTestConfigStore(t)
+	ctx := context.Background()
+
+	for _, name := range []string{"zzz", "aaa", "mmm"} {
+		require.NoError(t, store.StoreConfig(ctx, testEntry("t1", "ns", name, []byte(`x`), interfaces.ConfigFormatJSON)))
+	}
+
+	results, err := store.ListConfigs(ctx, &interfaces.ConfigFilter{
+		TenantID: "t1",
+		SortBy:   "name",
+		Order:    "asc",
+	})
+	require.NoError(t, err)
+	require.Len(t, results, 3)
+	assert.Equal(t, "aaa", results[0].Key.Name)
+	assert.Equal(t, "mmm", results[1].Key.Name)
+	assert.Equal(t, "zzz", results[2].Key.Name)
+}
+
+// TestCreatedAtPreservedOnUpdate verifies CreatedAt is not overwritten on subsequent stores.
+func TestCreatedAtPreservedOnUpdate(t *testing.T) {
+	store := newTestConfigStore(t)
+	ctx := context.Background()
+
+	beforeFirst := time.Now().UTC()
+	entry := testEntry("t1", "ns", "cfg", []byte(`v1`), interfaces.ConfigFormatJSON)
+	require.NoError(t, store.StoreConfig(ctx, entry))
+
+	got1, err := store.GetConfig(ctx, entry.Key)
+	require.NoError(t, err)
+	originalCreatedAt := got1.CreatedAt
+
+	// Verify CreatedAt was set after we began
+	assert.True(t, !originalCreatedAt.Before(beforeFirst), "CreatedAt must be >= before first store")
+
+	// Perform the second store without any sleep; rely on ordering not wall-clock comparison
+	beforeSecond := time.Now().UTC()
+	entry.Data = []byte(`v2`)
+	require.NoError(t, store.StoreConfig(ctx, entry))
+
+	got2, err := store.GetConfig(ctx, entry.Key)
+	require.NoError(t, err)
+
+	// CreatedAt must be unchanged across updates
+	assert.Equal(t, originalCreatedAt.UnixNano(), got2.CreatedAt.UnixNano(),
+		"CreatedAt must not change on update")
+
+	// UpdatedAt must be set to at least the time before the second store
+	assert.True(t, !got2.UpdatedAt.Before(beforeSecond),
+		"UpdatedAt must be >= before second store call")
+
+	// Version must have incremented
+	assert.Equal(t, int64(2), got2.Version)
+}

--- a/pkg/storage/providers/flatfile/plugin.go
+++ b/pkg/storage/providers/flatfile/plugin.go
@@ -1,0 +1,185 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+
+// Package flatfile implements a flat-file storage provider for CFGMS.
+//
+// # Overview
+//
+// The flat-file provider stores configuration and audit data as files under a
+// configured root directory. It is the OSS default for config storage (ADR-003).
+//
+// # Backup Responsibility
+//
+// The flat-file provider does NOT manage version history or replication. Backup
+// is the operator's responsibility. Use filesystem snapshots, rsync, restic, or
+// an equivalent tool to protect the root directory. A built-in helper is planned
+// for sub-story B (cfg backup CLI).
+//
+// # File Layout
+//
+//	Config storage: <root>/<tenantID>/configs/<namespace>/<name>.<format>
+//	Audit storage:  <root>/<tenantID>/audit/<YYYY-MM-DD>.jsonl
+//
+// # Limitations
+//
+//   - No automatic version history (use git-sync if you want PR-based change management)
+//   - No replication (use PostgreSQL if you need HA)
+//   - Single-writer only (not safe for multiple controllers sharing the same root)
+//   - Atomic writes use temp-file + rename (crash-safe on Linux; Windows rename
+//     across volumes may fail — keep root on a single filesystem)
+//
+// # Supported Stores
+//
+// This provider implements ConfigStore and AuditStore. All other store factory
+// methods (CreateRuntimeStore, CreateRBACStore, CreateTenantStore,
+// CreateRegistrationTokenStore, CreateClientTenantStore) return ErrNotSupported,
+// as these belong to the business-data tier (SQLite, sub-story C).
+package flatfile
+
+import (
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/cfgis/cfgms/pkg/storage/interfaces"
+)
+
+// ErrNotSupported is returned by store factory methods that are not implemented
+// by the flat-file provider. These stores belong to the business-data tier.
+var ErrNotSupported = errors.New("flatfile: operation not supported by flat-file provider")
+
+// ErrImmutable is returned when attempting to mutate immutable data, such as
+// adding an audit entry with a timestamp that falls before the configured
+// retention period cutoff.
+var ErrImmutable = errors.New("flatfile: data is immutable and cannot be modified")
+
+// FlatFileProvider implements StorageProvider using the local filesystem.
+// It is automatically registered on import via init().
+type FlatFileProvider struct{}
+
+// Name returns the provider name used for registration and configuration.
+func (p *FlatFileProvider) Name() string {
+	return "flatfile"
+}
+
+// Description returns a human-readable description of the provider.
+func (p *FlatFileProvider) Description() string {
+	return "Flat-file storage provider for OSS config and audit data; operator is responsible for backups"
+}
+
+// GetVersion returns the provider version.
+func (p *FlatFileProvider) GetVersion() string {
+	return "1.0.0"
+}
+
+// GetCapabilities returns the provider capabilities.
+// SupportsVersioning is false: flat-file does not auto-commit history.
+func (p *FlatFileProvider) GetCapabilities() interfaces.ProviderCapabilities {
+	return interfaces.ProviderCapabilities{
+		SupportsTransactions:   false,
+		SupportsVersioning:     false, // flat-file does not auto-commit history
+		SupportsFullTextSearch: false,
+		SupportsEncryption:     false,
+		SupportsCompression:    false,
+		SupportsReplication:    false,
+		SupportsSharding:       false,
+		MaxBatchSize:           100,
+		MaxConfigSize:          10 * 1024 * 1024, // 10MB per config
+		MaxAuditRetentionDays:  3650,             // 10 years; operator manages disk
+	}
+}
+
+// Available returns true if the flat-file provider can operate on this system.
+// The flat-file provider only requires the OS filesystem and is always available.
+func (p *FlatFileProvider) Available() (bool, error) {
+	return true, nil
+}
+
+// getRootFromConfig extracts and validates the root directory from provider configuration.
+func getRootFromConfig(config map[string]interface{}) (string, error) {
+	root, ok := config["root"].(string)
+	if !ok || root == "" {
+		return "", fmt.Errorf("flatfile: 'root' directory is required in provider configuration")
+	}
+
+	// Ensure the root exists and is accessible
+	info, err := os.Stat(root)
+	if err != nil {
+		if os.IsNotExist(err) {
+			// Root does not exist yet; Create* methods will create it.
+			return root, nil
+		}
+		return "", fmt.Errorf("flatfile: cannot stat root directory: %w", err)
+	}
+	if !info.IsDir() {
+		return "", fmt.Errorf("flatfile: root path is not a directory")
+	}
+	return root, nil
+}
+
+// CreateConfigStore creates a flat-file-based configuration store.
+// Config map must contain "root" (string): the root directory for config files.
+func (p *FlatFileProvider) CreateConfigStore(config map[string]interface{}) (interfaces.ConfigStore, error) {
+	root, err := getRootFromConfig(config)
+	if err != nil {
+		return nil, err
+	}
+	store, err := NewFlatFileConfigStore(root)
+	if err != nil {
+		return nil, fmt.Errorf("flatfile: failed to create config store: %w", err)
+	}
+	return store, nil
+}
+
+// CreateAuditStore creates a flat-file-based audit store.
+// Config map must contain "root" (string). Optional: "max_retention_days" (int, default 90).
+func (p *FlatFileProvider) CreateAuditStore(config map[string]interface{}) (interfaces.AuditStore, error) {
+	root, err := getRootFromConfig(config)
+	if err != nil {
+		return nil, err
+	}
+	maxRetentionDays := 90
+	if days, ok := config["max_retention_days"].(int); ok && days > 0 {
+		maxRetentionDays = days
+	}
+	store, err := NewFlatFileAuditStore(root, maxRetentionDays)
+	if err != nil {
+		return nil, fmt.Errorf("flatfile: failed to create audit store: %w", err)
+	}
+	return store, nil
+}
+
+// CreateClientTenantStore returns ErrNotSupported.
+// Client tenant data belongs in the business-data tier (SQLite / PostgreSQL).
+func (p *FlatFileProvider) CreateClientTenantStore(config map[string]interface{}) (interfaces.ClientTenantStore, error) {
+	return nil, ErrNotSupported
+}
+
+// CreateRBACStore returns ErrNotSupported.
+// RBAC data belongs in the business-data tier.
+func (p *FlatFileProvider) CreateRBACStore(config map[string]interface{}) (interfaces.RBACStore, error) {
+	return nil, ErrNotSupported
+}
+
+// CreateRuntimeStore returns ErrNotSupported.
+// Runtime state belongs in the business-data tier.
+func (p *FlatFileProvider) CreateRuntimeStore(config map[string]interface{}) (interfaces.RuntimeStore, error) {
+	return nil, ErrNotSupported
+}
+
+// CreateTenantStore returns ErrNotSupported.
+// Tenant data belongs in the business-data tier.
+func (p *FlatFileProvider) CreateTenantStore(config map[string]interface{}) (interfaces.TenantStore, error) {
+	return nil, ErrNotSupported
+}
+
+// CreateRegistrationTokenStore returns ErrNotSupported.
+// Registration token data belongs in the business-data tier.
+func (p *FlatFileProvider) CreateRegistrationTokenStore(config map[string]interface{}) (interfaces.RegistrationTokenStore, error) {
+	return nil, ErrNotSupported
+}
+
+// init auto-registers the flat-file provider so that a blank import is sufficient.
+func init() {
+	interfaces.RegisterStorageProvider(&FlatFileProvider{})
+}

--- a/pkg/storage/providers/flatfile/plugin_test.go
+++ b/pkg/storage/providers/flatfile/plugin_test.go
@@ -1,0 +1,156 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+package flatfile_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cfgis/cfgms/pkg/storage/interfaces"
+	// blank import triggers init() registration
+	_ "github.com/cfgis/cfgms/pkg/storage/providers/flatfile"
+)
+
+func TestProviderRegistration(t *testing.T) {
+	names := interfaces.GetRegisteredProviderNames()
+	found := false
+	for _, n := range names {
+		if n == "flatfile" {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found, "flatfile provider must be registered after blank import")
+}
+
+func TestGetStorageProviderSucceeds(t *testing.T) {
+	// GetStorageProvider calls Available() internally; flatfile is always available.
+	p, err := interfaces.GetStorageProvider("flatfile")
+	require.NoError(t, err)
+	assert.Equal(t, "flatfile", p.Name())
+}
+
+func TestProviderAvailable(t *testing.T) {
+	names := interfaces.GetRegisteredProviderNames()
+	var p interfaces.StorageProvider
+	for _, n := range names {
+		if n == "flatfile" {
+			pp, err := interfaces.GetStorageProvider("flatfile")
+			require.NoError(t, err)
+			p = pp
+			break
+		}
+	}
+	require.NotNil(t, p)
+
+	ok, err := p.Available()
+	assert.True(t, ok)
+	assert.NoError(t, err)
+}
+
+func TestProviderCapabilities(t *testing.T) {
+	p, err := interfaces.GetStorageProvider("flatfile")
+	require.NoError(t, err)
+
+	caps := p.GetCapabilities()
+	assert.False(t, caps.SupportsVersioning, "flat-file must not claim versioning support")
+	assert.False(t, caps.SupportsTransactions)
+	assert.Greater(t, caps.MaxBatchSize, 0)
+	assert.Greater(t, caps.MaxConfigSize, 0)
+}
+
+func TestProviderVersion(t *testing.T) {
+	p, err := interfaces.GetStorageProvider("flatfile")
+	require.NoError(t, err)
+	assert.NotEmpty(t, p.GetVersion())
+}
+
+func TestProviderDescription(t *testing.T) {
+	p, err := interfaces.GetStorageProvider("flatfile")
+	require.NoError(t, err)
+	assert.NotEmpty(t, p.Description())
+}
+
+func TestUnsupportedStoresReturnErrNotSupported(t *testing.T) {
+	p, err := interfaces.GetStorageProvider("flatfile")
+	require.NoError(t, err)
+
+	cfg := map[string]interface{}{}
+
+	t.Run("CreateClientTenantStore", func(t *testing.T) {
+		store, err := p.CreateClientTenantStore(cfg)
+		assert.Nil(t, store)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not supported")
+	})
+
+	t.Run("CreateRBACStore", func(t *testing.T) {
+		store, err := p.CreateRBACStore(cfg)
+		assert.Nil(t, store)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not supported")
+	})
+
+	t.Run("CreateRuntimeStore", func(t *testing.T) {
+		store, err := p.CreateRuntimeStore(cfg)
+		assert.Nil(t, store)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not supported")
+	})
+
+	t.Run("CreateTenantStore", func(t *testing.T) {
+		store, err := p.CreateTenantStore(cfg)
+		assert.Nil(t, store)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not supported")
+	})
+
+	t.Run("CreateRegistrationTokenStore", func(t *testing.T) {
+		store, err := p.CreateRegistrationTokenStore(cfg)
+		assert.Nil(t, store)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not supported")
+	})
+}
+
+func TestCreateConfigStoreRequiresRoot(t *testing.T) {
+	p, err := interfaces.GetStorageProvider("flatfile")
+	require.NoError(t, err)
+
+	store, err := p.CreateConfigStore(map[string]interface{}{})
+	assert.Nil(t, store)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "root")
+}
+
+func TestCreateAuditStoreRequiresRoot(t *testing.T) {
+	p, err := interfaces.GetStorageProvider("flatfile")
+	require.NoError(t, err)
+
+	store, err := p.CreateAuditStore(map[string]interface{}{})
+	assert.Nil(t, store)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "root")
+}
+
+func TestCreateConfigStoreWithRoot(t *testing.T) {
+	root := t.TempDir()
+	p, err := interfaces.GetStorageProvider("flatfile")
+	require.NoError(t, err)
+
+	store, err := p.CreateConfigStore(map[string]interface{}{"root": root})
+	require.NoError(t, err)
+	assert.NotNil(t, store)
+}
+
+func TestCreateAuditStoreWithRoot(t *testing.T) {
+	root := t.TempDir()
+	p, err := interfaces.GetStorageProvider("flatfile")
+	require.NoError(t, err)
+
+	store, err := p.CreateAuditStore(map[string]interface{}{"root": root})
+	require.NoError(t, err)
+	assert.NotNil(t, store)
+}


### PR DESCRIPTION
## Summary

- Implements `FlatFileConfigStore` and `FlatFileAuditStore` at `pkg/storage/providers/flatfile/`
- Provider auto-registers via `init()` — blank import is sufficient
- Atomic writes via temp-file + `os.Rename` (crash-safe on Linux single-filesystem)
- Path traversal prevention via `safeJoin()` using `filepath.Clean` + prefix check
- Config inheritance walks tenant path from leaf to root (split on "/")
- Audit store enforces immutability for entries older than retention cutoff (`ErrImmutable`)
- `ErrNotSupported` returned for all business-data stores (RBAC, Tenant, Runtime, etc.)
- Comprehensive test suite: contract tests, concurrent write tests (10-goroutine race check), path traversal rejection, batch ops, stats, pagination

## File layout implemented

```
<root>/<tenantID>/configs/<namespace>/<name>.<format>
<root>/<tenantID>/audit/<YYYY-MM-DD>.jsonl
```

## Test plan

- [x] `plugin_test.go`: provider registration, capabilities, unsupported stores return `ErrNotSupported`
- [x] `config_store_test.go`: store/get/delete/list, YAML format, inheritance, validation, concurrent writes (race detector), pagination, batch ops
- [x] `audit_store_test.go`: append/list/purge/archive, immutability enforcement, time-range filtering, concurrent writes, `GetFailedActions` (Failure+Error+Denied variants)
- [x] `make test-agent-complete` passes

Fixes #661

🤖 Generated with [Claude Code](https://claude.com/claude-code)