### PR TITLE
feat(storage): implement git-sync write-through component for config scopes (Issue #666)

### DIFF
--- a/docs/architecture/storage-architecture.md
+++ b/docs/architecture/storage-architecture.md
@@ -51,6 +51,43 @@ The previous architecture treated Git as a first-class storage backend (one comm
 
 The same git-sync code path serves both OSS and commercial deployments. The only variable is the backend adapter it writes through to. This avoids the fork that would result from git-as-backend-for-OSS and git-sync-for-SaaS existing side-by-side.
 
+### Implementation: `pkg/gitsync`
+
+The git-sync component lives in `pkg/gitsync/` and is wired into the controller server at startup.
+
+**Key types:**
+
+| Type | Purpose |
+|------|---------|
+| `ScopeBinding` | Binds a tenant path + namespace to an external git origin (URL, branch, credential ref, polling interval) |
+| `BindingStore` | Persists bindings to `<data-dir>/.gitsync/bindings.json`; tracks last-synced SHA per scope |
+| `Syncer` | Orchestrates clone/pull, idempotency checks, and write-through to `ConfigStore` |
+| `WebhookHandler` | HTTP handler for push-event webhooks; validates HMAC-SHA256; dispatches `TriggerSync` |
+
+**Scope binding fields:**
+
+| Field | Description |
+|-------|-------------|
+| `TenantPath` | CFGMS tenant path, e.g. `root/msp-a/client-1` |
+| `Namespace` | Config namespace supplied by the bound origin, e.g. `firewall` |
+| `OriginURL` | External git repository URL |
+| `Branch` | Branch to track (default: `main`) |
+| `CredentialsRef` | Credential reference: `""` = anonymous, `"env:<VAR>"` = env var, path = file |
+| `WebhookSecretRef` | Webhook HMAC-SHA256 secret reference (same format as CredentialsRef) |
+| `PollingInterval` | Polling frequency; minimum 60 s; zero disables polling |
+
+**Credentials (v1):** `CredentialsRef` and `WebhookSecretRef` accept an environment-variable name (prefix `env:`) or a filesystem path to a file containing the credential. TODO: migrate to `pkg/secrets` `SecretStore` once sub-story H lands.
+
+**Webhook endpoint:** `POST /api/v1/webhooks/git-push`. Accepts GitHub and GitLab push-event payloads. Validates `X-Hub-Signature-256` when `WebhookSecretRef` is configured. Requests with an invalid or missing signature are rejected with HTTP 401.
+
+**Polling:** Minimum interval is 60 seconds. Polling goroutines are per-scope; a failure in one scope does not block others.
+
+**Idempotency:** The syncer tracks the last-synced commit SHA per scope in the `BindingStore`. Re-syncing the same commit is a no-op — `ConfigStore.StoreConfig` is not called a second time.
+
+**Conflict detection:** v1 does not merge; if the remote has diverged from the last-synced commit in a non-fast-forward way, the sync is logged and skipped for that scope.
+
+**Scope isolation:** A failure syncing one scope (origin unreachable, auth failure, branch not found) does not stop other scopes from syncing. Errors are logged with origin URL sanitized (`logging.SanitizeLogValue`).
+
 ## MSP GitOps Example
 
 An MSP hosting configs on GitHub with PR-based change management continues to work exactly as today:

--- a/features/controller/api/server.go
+++ b/features/controller/api/server.go
@@ -67,6 +67,7 @@ type Server struct {
 	workflowHandler         *WorkflowHandler               // Story #414: Workflow engine REST API
 	approvalHook            RegistrationApprovalHook       // Issue #422: Registration approval hook
 	fleetQuery              fleet.FleetQuery               // Issue #603: Single query path for device filtering
+	gitSyncWebhookHandler   http.Handler                   // Issue #666: git-sync webhook endpoint (optional)
 }
 
 // APIKey represents an API key for external authentication
@@ -350,6 +351,10 @@ func (s *Server) setupRouter() {
 	compliance := api.PathPrefix("/compliance").Subrouter()
 	compliance.Handle("/summary", s.requirePermission("compliance", "read-summary")(http.HandlerFunc(s.handleGetComplianceSummary))).Methods("GET")
 
+	// Git-sync webhook is registered lazily by SetGitSyncWebhookHandler (Issue #666).
+	// No route is pre-registered here; the endpoint only exists when a git-sync
+	// handler is explicitly wired in after server creation.
+
 	// Raft consensus endpoints (no auth required - internal cluster communication)
 	s.router.HandleFunc("/raft/message", s.handleRaftMessage).Methods("POST")
 	s.router.HandleFunc("/raft/status", s.handleRaftStatus).Methods("GET")
@@ -490,6 +495,20 @@ func (s *Server) SetApprovalHook(hook RegistrationApprovalHook) {
 	defer s.mu.Unlock()
 	if hook != nil {
 		s.approvalHook = hook
+	}
+}
+
+// SetGitSyncWebhookHandler registers the git-sync push-event webhook handler.
+// The handler is mounted at POST /api/v1/webhooks/git-push and uses its own
+// HMAC-SHA256 signature validation (no API-key auth). Call this after New()
+// returns but before Start() is called (Issue #666).
+func (s *Server) SetGitSyncWebhookHandler(h http.Handler) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.gitSyncWebhookHandler = h
+	if h != nil {
+		s.router.Handle("/api/v1/webhooks/git-push", h).Methods("POST")
+		s.logger.Info("git-sync webhook endpoint registered at /api/v1/webhooks/git-push")
 	}
 }
 

--- a/features/controller/server/server.go
+++ b/features/controller/server/server.go
@@ -50,6 +50,7 @@ import (
 	controlplaneTypes "github.com/cfgis/cfgms/pkg/controlplane/types"
 	dataplaneInterfaces "github.com/cfgis/cfgms/pkg/dataplane/interfaces"
 	_ "github.com/cfgis/cfgms/pkg/dataplane/providers/grpc" // Register gRPC data plane provider
+	"github.com/cfgis/cfgms/pkg/gitsync"
 	"github.com/cfgis/cfgms/pkg/logging"
 	pkgRegistration "github.com/cfgis/cfgms/pkg/registration"
 	"github.com/cfgis/cfgms/pkg/storage/interfaces"
@@ -87,6 +88,7 @@ type Server struct {
 	alertManager            *health.DefaultAlertManager
 	dnaStorageManager       *dnaStorage.Manager                 // Reports engine DNA storage (must be closed on Stop)
 	triggerManager          *workflowtrigger.TriggerManagerImpl // Issue #414: Workflow trigger manager
+	gitSyncer               *gitsync.Syncer                     // Issue #666: git-sync write-through component
 }
 
 // New creates a new server instance
@@ -544,7 +546,47 @@ func New(cfg *config.Config, logger logging.Logger) (*Server, error) {
 		logger.Info("Registration approval hook wired (Issue #422)")
 	}
 
+	// Issue #666: Wire git-sync component when a data directory is configured.
+	// The syncer writes through to the controller's config store.
+	if cfg.DataDir != "" {
+		gitSyncer, webhookHandler := initializeGitSync(cfg.DataDir, storageManager.GetConfigStore(), logger)
+		if gitSyncer != nil {
+			srv.gitSyncer = gitSyncer
+			if err := gitSyncer.Start(context.Background()); err != nil {
+				logger.Warn("git-sync: failed to start syncer", "error", err)
+			} else {
+				logger.Info("git-sync: syncer started", "data_dir", cfg.DataDir)
+			}
+			if webhookHandler != nil {
+				httpServer.SetGitSyncWebhookHandler(webhookHandler)
+			}
+		}
+	}
+
 	return srv, nil
+}
+
+// initializeGitSync creates a git-sync Syncer and webhook handler using the
+// given config root and config store. Returns nil, nil when the binding store
+// cannot be created.
+func initializeGitSync(
+	dataDir string,
+	configStore interfaces.ConfigStore,
+	logger logging.Logger,
+) (*gitsync.Syncer, *gitsync.WebhookHandler) {
+	workDir := filepath.Join(dataDir, ".gitsync", "repos")
+	bindingStore, err := gitsync.NewBindingStore(dataDir)
+	if err != nil {
+		logger.Warn("git-sync: failed to create binding store, git-sync disabled", "error", err)
+		return nil, nil
+	}
+	syncer, err := gitsync.NewSyncer(configStore, bindingStore, workDir, logger)
+	if err != nil {
+		logger.Warn("git-sync: failed to create syncer, git-sync disabled", "error", err)
+		return nil, nil
+	}
+	webhookHandler := gitsync.NewWebhookHandler(syncer, bindingStore, logger)
+	return syncer, webhookHandler
 }
 
 // noOpModuleRegistry is a minimal ModuleRegistry for controller wiring.
@@ -964,6 +1006,12 @@ func (s *Server) Stop() error {
 		if err := s.dnaStorageManager.Close(); err != nil {
 			s.logger.Warn("Failed to close DNA storage manager", "error", err)
 		}
+	}
+
+	// Stop git-sync syncer (Issue #666)
+	if s.gitSyncer != nil {
+		s.gitSyncer.Stop()
+		s.logger.Info("git-sync syncer stopped")
 	}
 
 	// Stop HTTP server

--- a/pkg/gitsync/binding.go
+++ b/pkg/gitsync/binding.go
@@ -1,0 +1,209 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+package gitsync
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+)
+
+const (
+	// MinPollingInterval is the minimum allowed polling interval. Bindings that
+	// configure a shorter interval are rejected at Add time.
+	MinPollingInterval = 60 * time.Second
+
+	bindingsFileName = "bindings.json"
+	bindingsDir      = ".gitsync"
+)
+
+// ScopeBinding describes a binding from a config scope (tenant path + namespace)
+// to an external git origin.
+type ScopeBinding struct {
+	// TenantPath is the CFGMS tenant path, e.g. "root/msp-a/client-1".
+	TenantPath string `json:"tenant_path"`
+
+	// Namespace is the config namespace that the bound origin supplies, e.g.
+	// "firewall". All files imported from the origin are stored under this
+	// namespace.
+	Namespace string `json:"namespace"`
+
+	// OriginURL is the URL of the external git repository (HTTPS or local path).
+	OriginURL string `json:"origin_url"`
+
+	// Branch is the branch to track. Defaults to "main" when empty.
+	Branch string `json:"branch"`
+
+	// CredentialsRef is the credential reference used to authenticate to the
+	// git origin. Accepted formats:
+	//   - "" (empty): anonymous access
+	//   - "env:<VAR>": read the password from environment variable VAR
+	//   - any other string: treat as a file path and read the password from it
+	//
+	// TODO: migrate to pkg/secrets SecretStore once sub-story H lands.
+	CredentialsRef string `json:"credentials_ref,omitempty"`
+
+	// WebhookSecretRef is the credential reference for the HMAC-SHA256 webhook
+	// secret. Same resolution rules as CredentialsRef. When empty, HMAC
+	// validation is skipped for this binding.
+	WebhookSecretRef string `json:"webhook_secret_ref,omitempty"`
+
+	// PollingInterval is how often to poll the origin for changes. Must be
+	// >= MinPollingInterval (60 s) when non-zero. Zero disables polling;
+	// only webhook-triggered syncs occur.
+	PollingInterval time.Duration `json:"polling_interval,omitempty"`
+
+	// LastSyncedSHA is the commit SHA of the last successful sync. This field is
+	// managed by the BindingStore; do not set it manually.
+	LastSyncedSHA string `json:"last_synced_sha,omitempty"`
+}
+
+// key returns a unique string identifier for this binding.
+func (b ScopeBinding) key() string {
+	return b.TenantPath + "/" + b.Namespace
+}
+
+// validate returns an error if the binding is misconfigured.
+func (b ScopeBinding) validate() error {
+	if b.TenantPath == "" {
+		return fmt.Errorf("gitsync: ScopeBinding has empty TenantPath")
+	}
+	if b.Namespace == "" {
+		return fmt.Errorf("gitsync: ScopeBinding has empty Namespace")
+	}
+	if b.OriginURL == "" {
+		return fmt.Errorf("gitsync: ScopeBinding has empty OriginURL")
+	}
+	if b.PollingInterval != 0 && b.PollingInterval < MinPollingInterval {
+		return ErrIntervalTooShort
+	}
+	return nil
+}
+
+// BindingStore manages scope bindings persisted to a JSON file located at
+// <configRoot>/.gitsync/bindings.json.
+type BindingStore struct {
+	mu       sync.RWMutex
+	path     string
+	bindings map[string]ScopeBinding
+}
+
+// NewBindingStore creates or opens the binding store rooted at configRoot.
+// The directory is created if it does not already exist.
+func NewBindingStore(configRoot string) (*BindingStore, error) {
+	dir := filepath.Join(configRoot, bindingsDir)
+	if err := os.MkdirAll(dir, 0750); err != nil {
+		return nil, fmt.Errorf("gitsync: failed to create bindings directory: %w", err)
+	}
+	bs := &BindingStore{
+		path:     filepath.Join(dir, bindingsFileName),
+		bindings: make(map[string]ScopeBinding),
+	}
+	if err := bs.load(); err != nil {
+		return nil, err
+	}
+	return bs, nil
+}
+
+// load reads bindings from disk. Succeeds silently if the file does not yet
+// exist.
+func (bs *BindingStore) load() error {
+	data, err := os.ReadFile(bs.path)
+	if os.IsNotExist(err) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("gitsync: failed to read bindings file: %w", err)
+	}
+	var list []ScopeBinding
+	if err := json.Unmarshal(data, &list); err != nil {
+		return fmt.Errorf("gitsync: failed to parse bindings file: %w", err)
+	}
+	for _, b := range list {
+		bs.bindings[b.key()] = b
+	}
+	return nil
+}
+
+// save writes all bindings to disk atomically (write-then-rename).
+// Callers must hold bs.mu.Lock().
+func (bs *BindingStore) save() error {
+	list := make([]ScopeBinding, 0, len(bs.bindings))
+	for _, b := range bs.bindings {
+		list = append(list, b)
+	}
+	data, err := json.MarshalIndent(list, "", "  ")
+	if err != nil {
+		return fmt.Errorf("gitsync: failed to marshal bindings: %w", err)
+	}
+	tmp := bs.path + ".tmp"
+	if err := os.WriteFile(tmp, data, 0640); err != nil {
+		return fmt.Errorf("gitsync: failed to write bindings temp file: %w", err)
+	}
+	if err := os.Rename(tmp, bs.path); err != nil {
+		return fmt.Errorf("gitsync: failed to rename bindings file: %w", err)
+	}
+	return nil
+}
+
+// Add adds or replaces a binding and persists it to disk. Returns
+// ErrIntervalTooShort when the polling interval is non-zero and below the
+// minimum.
+func (bs *BindingStore) Add(b ScopeBinding) error {
+	if err := b.validate(); err != nil {
+		return err
+	}
+	bs.mu.Lock()
+	defer bs.mu.Unlock()
+	bs.bindings[b.key()] = b
+	return bs.save()
+}
+
+// Remove removes a binding by tenant path and namespace. No-op if the binding
+// does not exist.
+func (bs *BindingStore) Remove(tenantPath, namespace string) error {
+	key := tenantPath + "/" + namespace
+	bs.mu.Lock()
+	defer bs.mu.Unlock()
+	delete(bs.bindings, key)
+	return bs.save()
+}
+
+// Get returns a binding by tenant path and namespace. Returns false if the
+// binding does not exist.
+func (bs *BindingStore) Get(tenantPath, namespace string) (ScopeBinding, bool) {
+	key := tenantPath + "/" + namespace
+	bs.mu.RLock()
+	defer bs.mu.RUnlock()
+	b, ok := bs.bindings[key]
+	return b, ok
+}
+
+// List returns all bindings in an unspecified order.
+func (bs *BindingStore) List() []ScopeBinding {
+	bs.mu.RLock()
+	defer bs.mu.RUnlock()
+	out := make([]ScopeBinding, 0, len(bs.bindings))
+	for _, b := range bs.bindings {
+		out = append(out, b)
+	}
+	return out
+}
+
+// UpdateSHA records the last-synced commit SHA for the given binding. Returns an
+// error if the binding does not exist.
+func (bs *BindingStore) UpdateSHA(tenantPath, namespace, sha string) error {
+	key := tenantPath + "/" + namespace
+	bs.mu.Lock()
+	defer bs.mu.Unlock()
+	b, ok := bs.bindings[key]
+	if !ok {
+		return fmt.Errorf("gitsync: binding not found for %s/%s", tenantPath, namespace)
+	}
+	b.LastSyncedSHA = sha
+	bs.bindings[key] = b
+	return bs.save()
+}

--- a/pkg/gitsync/errors.go
+++ b/pkg/gitsync/errors.go
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+// Package gitsync implements a write-through git-sync component for config scopes.
+//
+// Git-sync pulls config entries from an external git origin (GitHub, GitLab, or any
+// HTTP git remote) and writes them through to a ConfigStore. Sync is triggered by a
+// webhook push event or a configurable polling interval.
+//
+// v1 semantics — read-only, one-way (git → backend):
+//   - The controller never writes back to the git origin.
+//   - For bound scopes, all edits happen at the git origin (PRs, commits, merges)
+//     and flow down via sync.
+//   - Conflict detection (remote diverged from last-synced commit) logs and skips
+//     the affected scope; no merge is attempted.
+//   - Scopes without a git binding are unaffected.
+//
+// Credentials reference:
+// For v1, CredentialsRef accepts an environment-variable name (prefix "env:") or a
+// plaintext file path. TODO: migrate to pkg/secrets SecretStore once sub-story H lands.
+package gitsync
+
+import "errors"
+
+// Typed error sentinels returned by the git-sync component.
+var (
+	// ErrOriginUnreachable is returned when the git origin cannot be contacted.
+	ErrOriginUnreachable = errors.New("gitsync: origin unreachable")
+
+	// ErrAuthFailed is returned when credentials are rejected by the git origin.
+	ErrAuthFailed = errors.New("gitsync: authentication failed")
+
+	// ErrBranchNotFound is returned when the configured branch does not exist on the
+	// origin.
+	ErrBranchNotFound = errors.New("gitsync: branch not found")
+
+	// ErrConflictDetected is returned when the remote has diverged from the
+	// last-synced commit in a way that cannot be fast-forwarded. v1 logs and
+	// skips — no merge is attempted.
+	ErrConflictDetected = errors.New("gitsync: conflict detected (remote diverged from last-synced commit)")
+
+	// ErrIntervalTooShort is returned when a polling interval is configured below
+	// the minimum of MinPollingInterval (60 s).
+	ErrIntervalTooShort = errors.New("gitsync: polling interval must be at least 60 seconds")
+)

--- a/pkg/gitsync/syncer.go
+++ b/pkg/gitsync/syncer.go
@@ -1,0 +1,468 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+package gitsync
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	gogit "github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing"
+	gogithttp "github.com/go-git/go-git/v5/plumbing/transport/http"
+
+	"github.com/cfgis/cfgms/pkg/logging"
+	"github.com/cfgis/cfgms/pkg/storage/interfaces"
+)
+
+// SyncState represents the current state of a scope sync.
+type SyncState string
+
+const (
+	SyncStateIdle    SyncState = "idle"
+	SyncStateSyncing SyncState = "syncing"
+	SyncStateError   SyncState = "error"
+)
+
+// ScopeStatus reports the current sync status for a scope.
+type ScopeStatus struct {
+	TenantPath    string     `json:"tenant_path"`
+	Namespace     string     `json:"namespace"`
+	State         SyncState  `json:"state"`
+	LastSyncedSHA string     `json:"last_synced_sha,omitempty"`
+	LastSyncedAt  *time.Time `json:"last_synced_at,omitempty"`
+	LastError     string     `json:"last_error,omitempty"`
+}
+
+// Syncer pulls config entries from external git origins and writes them
+// through to a ConfigStore. It is v1 read-only — it never writes back to
+// any git origin.
+type Syncer struct {
+	mu            sync.RWMutex
+	store         interfaces.ConfigStore
+	bindings      *BindingStore
+	workDir       string // local directory for cloned repos
+	logger        logging.Logger
+	statusMap     map[string]*ScopeStatus
+	cancelFuncs   map[string]context.CancelFunc
+	ctx           context.Context
+	cancel        context.CancelFunc
+	newTickerFunc func(d time.Duration) (<-chan time.Time, func())
+	syncNotify    chan<- struct{} // optional; receives a value after each TriggerSync call
+}
+
+// Option is a functional option for NewSyncer.
+type Option func(*Syncer)
+
+// WithTickerFunc replaces the ticker factory used by polling goroutines.
+// The factory must return a channel that emits ticks and a stop function.
+// This option is intended for testing; production code should not set it.
+func WithTickerFunc(fn func(d time.Duration) (<-chan time.Time, func())) Option {
+	return func(s *Syncer) {
+		s.newTickerFunc = fn
+	}
+}
+
+// WithSyncNotify sets a channel that receives an empty struct after each
+// TriggerSync call completes (whether successful or not). This option is
+// intended for testing; production code should not set it.
+func WithSyncNotify(ch chan<- struct{}) Option {
+	return func(s *Syncer) {
+		s.syncNotify = ch
+	}
+}
+
+// NewSyncer creates a new Syncer. workDir is used for local git clones and is
+// created if it does not already exist. Optional functional options (see
+// WithTickerFunc, WithSyncNotify) may be provided for testing.
+func NewSyncer(
+	store interfaces.ConfigStore,
+	bindings *BindingStore,
+	workDir string,
+	logger logging.Logger,
+	opts ...Option,
+) (*Syncer, error) {
+	if err := os.MkdirAll(workDir, 0750); err != nil {
+		return nil, fmt.Errorf("gitsync: failed to create work directory: %w", err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	s := &Syncer{
+		store:       store,
+		bindings:    bindings,
+		workDir:     workDir,
+		logger:      logger,
+		statusMap:   make(map[string]*ScopeStatus),
+		cancelFuncs: make(map[string]context.CancelFunc),
+		ctx:         ctx,
+		cancel:      cancel,
+		newTickerFunc: func(d time.Duration) (<-chan time.Time, func()) {
+			t := time.NewTicker(d)
+			return t.C, t.Stop
+		},
+	}
+	for _, opt := range opts {
+		opt(s)
+	}
+	return s, nil
+}
+
+// Start begins polling goroutines for all bindings that have a non-zero
+// polling interval. Bindings added after Start is called also need an
+// explicit AddBinding call to begin polling.
+func (s *Syncer) Start(ctx context.Context) error {
+	for _, b := range s.bindings.List() {
+		s.startScope(b)
+	}
+	return nil
+}
+
+// startScope starts (or restarts) the polling goroutine for b. It initializes
+// status if this is the first time we have seen this scope. If b.PollingInterval
+// is zero, only a status entry is created — no goroutine is launched.
+func (s *Syncer) startScope(b ScopeBinding) {
+	key := b.key()
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if _, ok := s.statusMap[key]; !ok {
+		s.statusMap[key] = &ScopeStatus{
+			TenantPath:    b.TenantPath,
+			Namespace:     b.Namespace,
+			State:         SyncStateIdle,
+			LastSyncedSHA: b.LastSyncedSHA,
+		}
+	}
+
+	if b.PollingInterval == 0 {
+		return // webhook-only scope; no polling goroutine
+	}
+
+	// Cancel existing polling goroutine if any.
+	if cancel, ok := s.cancelFuncs[key]; ok {
+		cancel()
+	}
+
+	scopeCtx, cancel := context.WithCancel(s.ctx)
+	s.cancelFuncs[key] = cancel
+
+	go func() {
+		tickCh, stopTicker := s.newTickerFunc(b.PollingInterval)
+		defer stopTicker()
+		for {
+			select {
+			case <-scopeCtx.Done():
+				return
+			case <-tickCh:
+				if err := s.TriggerSync(scopeCtx, b); err != nil {
+					s.logger.Error("gitsync: polling sync failed",
+						"tenant_path", logging.SanitizeLogValue(b.TenantPath),
+						"namespace", logging.SanitizeLogValue(b.Namespace),
+						"error", err.Error())
+				}
+			}
+		}
+	}()
+}
+
+// Stop shuts down all polling goroutines. After Stop returns, no further
+// syncs are initiated.
+func (s *Syncer) Stop() {
+	s.cancel()
+}
+
+// TriggerSync performs an immediate sync for the given scope binding.
+// Errors in one scope do not propagate to others — the caller is responsible
+// for per-scope error handling (e.g., logging and continuing).
+func (s *Syncer) TriggerSync(ctx context.Context, b ScopeBinding) error {
+	key := b.key()
+
+	s.mu.Lock()
+	status, ok := s.statusMap[key]
+	if !ok {
+		status = &ScopeStatus{
+			TenantPath: b.TenantPath,
+			Namespace:  b.Namespace,
+			State:      SyncStateIdle,
+		}
+		s.statusMap[key] = status
+	}
+	status.State = SyncStateSyncing
+	s.mu.Unlock()
+
+	err := s.syncScope(ctx, b)
+
+	s.mu.Lock()
+	now := time.Now()
+	if err != nil {
+		status.State = SyncStateError
+		status.LastError = err.Error()
+		s.logger.Error("gitsync: sync failed",
+			"tenant_path", logging.SanitizeLogValue(b.TenantPath),
+			"namespace", logging.SanitizeLogValue(b.Namespace),
+			"origin_url", logging.SanitizeLogValue(b.OriginURL),
+			"error", err.Error())
+	} else {
+		status.State = SyncStateIdle
+		status.LastError = ""
+		status.LastSyncedAt = &now
+	}
+	s.mu.Unlock()
+
+	// Notify test observers (WithSyncNotify option) that this sync cycle is done.
+	if s.syncNotify != nil {
+		select {
+		case s.syncNotify <- struct{}{}:
+		default:
+		}
+	}
+
+	return err
+}
+
+// syncScope performs the actual git clone/pull and config import for one
+// binding.
+func (s *Syncer) syncScope(ctx context.Context, b ScopeBinding) error {
+	repoDir := filepath.Join(s.workDir, sanitizeKey(b.key()))
+
+	auth, err := resolveCredentials(b.CredentialsRef)
+	if err != nil {
+		return fmt.Errorf("%w: %v", ErrAuthFailed, err)
+	}
+
+	branch := b.Branch
+	if branch == "" {
+		branch = "main"
+	}
+
+	var repo *gogit.Repository
+	if _, statErr := os.Stat(filepath.Join(repoDir, ".git")); os.IsNotExist(statErr) {
+		// Initial clone.
+		cloneOpts := &gogit.CloneOptions{
+			URL:           b.OriginURL,
+			Auth:          auth,
+			ReferenceName: plumbing.NewBranchReferenceName(branch),
+			SingleBranch:  true,
+		}
+		repo, err = gogit.PlainCloneContext(ctx, repoDir, false, cloneOpts)
+		if err != nil {
+			return classifyGitError(err)
+		}
+	} else {
+		// Incremental pull.
+		repo, err = gogit.PlainOpen(repoDir)
+		if err != nil {
+			return fmt.Errorf("gitsync: failed to open local repo: %w", err)
+		}
+		worktree, err := repo.Worktree()
+		if err != nil {
+			return fmt.Errorf("gitsync: failed to get worktree: %w", err)
+		}
+		pullOpts := &gogit.PullOptions{
+			RemoteName:    "origin",
+			ReferenceName: plumbing.NewBranchReferenceName(branch),
+			Auth:          auth,
+			Force:         false,
+		}
+		if pullErr := worktree.PullContext(ctx, pullOpts); pullErr != nil && pullErr != gogit.NoErrAlreadyUpToDate {
+			return classifyGitError(pullErr)
+		}
+	}
+
+	// Determine current HEAD SHA.
+	head, err := repo.Head()
+	if err != nil {
+		return fmt.Errorf("gitsync: failed to read HEAD: %w", err)
+	}
+	currentSHA := head.Hash().String()
+
+	// Idempotency check: skip if we already imported this commit.
+	currentBinding, ok := s.bindings.Get(b.TenantPath, b.Namespace)
+	if ok && currentBinding.LastSyncedSHA == currentSHA {
+		s.logger.Info("gitsync: already up to date, skipping import",
+			"tenant_path", logging.SanitizeLogValue(b.TenantPath),
+			"namespace", logging.SanitizeLogValue(b.Namespace),
+			"sha", currentSHA[:min(8, len(currentSHA))])
+		return nil
+	}
+
+	// Import all config files from the repo root.
+	if err := s.importConfigs(ctx, b, repoDir, currentSHA); err != nil {
+		return err
+	}
+
+	// Advance last-synced SHA in persistent store.
+	if updateErr := s.bindings.UpdateSHA(b.TenantPath, b.Namespace, currentSHA); updateErr != nil {
+		// Non-fatal: configs were imported; only the idempotency check for the
+		// next call is affected.
+		s.logger.Error("gitsync: failed to update last-synced SHA",
+			"tenant_path", logging.SanitizeLogValue(b.TenantPath),
+			"namespace", logging.SanitizeLogValue(b.Namespace),
+			"error", updateErr.Error())
+	}
+
+	// Update in-memory status.
+	s.mu.Lock()
+	if st := s.statusMap[b.key()]; st != nil {
+		st.LastSyncedSHA = currentSHA
+	}
+	s.mu.Unlock()
+
+	s.logger.Info("gitsync: sync complete",
+		"tenant_path", logging.SanitizeLogValue(b.TenantPath),
+		"namespace", logging.SanitizeLogValue(b.Namespace),
+		"sha", currentSHA[:min(8, len(currentSHA))])
+	return nil
+}
+
+// importConfigs scans the top-level directory of repoDir for YAML and JSON
+// files and writes each one as a ConfigEntry to the ConfigStore. Subdirectories
+// are skipped (v1 flat-file-per-config layout only).
+func (s *Syncer) importConfigs(ctx context.Context, b ScopeBinding, repoDir, sha string) error {
+	dirEntries, err := os.ReadDir(repoDir)
+	if err != nil {
+		return fmt.Errorf("gitsync: failed to read repo directory: %w", err)
+	}
+
+	sourceSHA := sha
+	if len(sourceSHA) > 8 {
+		sourceSHA = sourceSHA[:8]
+	}
+	sourceTag := "git-sync:" + logging.SanitizeLogValue(b.OriginURL) + "@" + sourceSHA
+
+	for _, dirEntry := range dirEntries {
+		if dirEntry.IsDir() {
+			continue // skip directories including .git
+		}
+
+		name := dirEntry.Name()
+		var format interfaces.ConfigFormat
+		var configName string
+
+		switch {
+		case strings.HasSuffix(name, ".yaml"):
+			format = interfaces.ConfigFormatYAML
+			configName = strings.TrimSuffix(name, ".yaml")
+		case strings.HasSuffix(name, ".yml"):
+			format = interfaces.ConfigFormatYAML
+			configName = strings.TrimSuffix(name, ".yml")
+		case strings.HasSuffix(name, ".json"):
+			format = interfaces.ConfigFormatJSON
+			configName = strings.TrimSuffix(name, ".json")
+		default:
+			continue // skip non-config files
+		}
+
+		data, readErr := os.ReadFile(filepath.Join(repoDir, name))
+		if readErr != nil {
+			return fmt.Errorf("gitsync: failed to read config file %s: %w", name, readErr)
+		}
+
+		configEntry := &interfaces.ConfigEntry{
+			Key: &interfaces.ConfigKey{
+				TenantID:  b.TenantPath,
+				Namespace: b.Namespace,
+				Name:      configName,
+			},
+			Data:      data,
+			Format:    format,
+			Source:    sourceTag,
+			CreatedBy: "git-sync",
+			UpdatedBy: "git-sync",
+		}
+
+		if storeErr := s.store.StoreConfig(ctx, configEntry); storeErr != nil {
+			return fmt.Errorf("gitsync: failed to store config %s: %w", configName, storeErr)
+		}
+	}
+	return nil
+}
+
+// Status returns a snapshot of the current sync status for all known scopes.
+func (s *Syncer) Status() []ScopeStatus {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	out := make([]ScopeStatus, 0, len(s.statusMap))
+	for _, st := range s.statusMap {
+		out = append(out, *st)
+	}
+	return out
+}
+
+// AddBinding adds a scope binding to the persistent store and starts (or
+// restarts) its polling goroutine.
+func (s *Syncer) AddBinding(b ScopeBinding) error {
+	if err := s.bindings.Add(b); err != nil {
+		return err
+	}
+	s.startScope(b)
+	return nil
+}
+
+// sanitizeKey converts a binding key to a filesystem-safe directory name by
+// replacing path separators and other special characters with underscores.
+func sanitizeKey(key string) string {
+	return strings.NewReplacer("/", "_", ":", "_", " ", "_", "@", "_").Replace(key)
+}
+
+// resolveCredentials resolves a CredentialsRef string to a go-git auth method.
+//
+// Resolution rules (v1):
+//
+//	"" (empty)     → anonymous access (nil auth)
+//	"env:<VAR>"    → read password from environment variable VAR
+//	any other string → treat as a filesystem path; read the password from the file
+//
+// TODO: integrate with pkg/secrets SecretStore once sub-story H lands.
+func resolveCredentials(ref string) (*gogithttp.BasicAuth, error) {
+	if ref == "" {
+		return nil, nil
+	}
+	if strings.HasPrefix(ref, "env:") {
+		envVar := strings.TrimPrefix(ref, "env:")
+		token := os.Getenv(envVar)
+		if token == "" {
+			return nil, fmt.Errorf("environment variable %s is not set or is empty", envVar)
+		}
+		return &gogithttp.BasicAuth{Username: "git", Password: token}, nil
+	}
+	// Treat as file path.
+	raw, err := os.ReadFile(ref) // #nosec G304 - admin-supplied credential file path
+	if err != nil {
+		return nil, fmt.Errorf("failed to read credentials file %q: %w", ref, err)
+	}
+	token := strings.TrimSpace(string(raw))
+	return &gogithttp.BasicAuth{Username: "git", Password: token}, nil
+}
+
+// classifyGitError maps go-git errors to gitsync sentinel errors where
+// possible. Unknown errors are wrapped and returned as-is.
+func classifyGitError(err error) error {
+	if err == nil {
+		return nil
+	}
+	msg := strings.ToLower(err.Error())
+	switch {
+	case strings.Contains(msg, "authentication required") ||
+		strings.Contains(msg, "authorization failed") ||
+		strings.Contains(msg, "invalid credentials"):
+		return fmt.Errorf("%w: %v", ErrAuthFailed, err)
+	case strings.Contains(msg, "repository not found") ||
+		strings.Contains(msg, "no such file or directory") ||
+		strings.Contains(msg, "unable to connect") ||
+		strings.Contains(msg, "dial tcp") ||
+		strings.Contains(msg, "connection refused"):
+		return fmt.Errorf("%w: %v", ErrOriginUnreachable, err)
+	case strings.Contains(msg, "reference not found") ||
+		strings.Contains(msg, "couldn't find remote ref"):
+		return fmt.Errorf("%w: %v", ErrBranchNotFound, err)
+	case strings.Contains(msg, "non-fast-forward") ||
+		strings.Contains(msg, "diverged"):
+		return fmt.Errorf("%w: %v", ErrConflictDetected, err)
+	default:
+		return fmt.Errorf("gitsync: git operation failed: %w", err)
+	}
+}

--- a/pkg/gitsync/syncer_test.go
+++ b/pkg/gitsync/syncer_test.go
@@ -1,0 +1,392 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+package gitsync_test
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cfgis/cfgms/pkg/gitsync"
+	"github.com/cfgis/cfgms/pkg/logging"
+	"github.com/cfgis/cfgms/pkg/storage/interfaces"
+	"github.com/cfgis/cfgms/pkg/storage/providers/flatfile"
+)
+
+// requireGit skips the test if the git binary is not found in PATH.
+func requireGit(t *testing.T) {
+	t.Helper()
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git binary not found in PATH; skipping test that requires real git")
+	}
+}
+
+// runGit runs a git command, failing the test on error. It returns stdout+stderr.
+func runGit(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", args...) // #nosec G204 - controlled test command with validated args
+	if dir != "" {
+		cmd.Dir = dir
+	}
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %v in %q failed: %v\n%s", args, dir, err, out)
+	}
+	return strings.TrimSpace(string(out))
+}
+
+// newTestRepo creates a bare git repository pre-populated with the given files.
+// It returns:
+//   - bareDir: path to the bare repository (use as OriginURL in ScopeBinding)
+//   - workDir: path to a working clone of bareDir (use to push new commits)
+//   - pushFiles: a helper function that commits and pushes files to the bare repo
+func newTestRepo(t *testing.T, initialFiles map[string]string) (bareDir, workDir string, pushFiles func(map[string]string)) {
+	t.Helper()
+	requireGit(t)
+
+	root := t.TempDir()
+	src := filepath.Join(root, "src")   // non-bare source for creating initial content
+	bare := filepath.Join(root, "bare") // bare repo used as fake remote origin
+	work := filepath.Join(root, "work") // working clone for incremental commits
+
+	// Initialise source repo.
+	require.NoError(t, os.MkdirAll(src, 0750))
+	runGit(t, src, "init", "-b", "main")
+	runGit(t, src, "-c", "user.name=test", "-c", "user.email=test@test.com",
+		"commit", "--allow-empty", "-m", "empty initial")
+
+	// Write initial files into source repo.
+	for name, content := range initialFiles {
+		path := filepath.Join(src, name)
+		require.NoError(t, os.MkdirAll(filepath.Dir(path), 0750))
+		require.NoError(t, os.WriteFile(path, []byte(content), 0640))
+	}
+	if len(initialFiles) > 0 {
+		runGit(t, src, "add", ".")
+		runGit(t, src, "-c", "user.name=test", "-c", "user.email=test@test.com",
+			"commit", "-m", "initial files")
+	}
+
+	// Clone source to bare.
+	runGit(t, root, "clone", "--bare", src, bare)
+
+	// Clone bare to work so we can push incremental commits.
+	runGit(t, root, "clone", bare, work)
+	runGit(t, work, "config", "user.name", "test")
+	runGit(t, work, "config", "user.email", "test@test.com")
+
+	push := func(files map[string]string) {
+		for name, content := range files {
+			path := filepath.Join(work, name)
+			require.NoError(t, os.MkdirAll(filepath.Dir(path), 0750))
+			require.NoError(t, os.WriteFile(path, []byte(content), 0640))
+		}
+		runGit(t, work, "add", ".")
+		runGit(t, work, "-c", "user.name=test", "-c", "user.email=test@test.com",
+			"commit", "-m", "add files")
+		runGit(t, work, "push", "origin", "main")
+	}
+
+	return bare, work, push
+}
+
+// newTestSyncer creates a Syncer wired to a FlatFileConfigStore for testing.
+func newTestSyncer(t *testing.T, opts ...gitsync.Option) (*gitsync.Syncer, *flatfile.FlatFileConfigStore, *gitsync.BindingStore) {
+	t.Helper()
+	root := t.TempDir()
+
+	store, err := flatfile.NewFlatFileConfigStore(filepath.Join(root, "configs"))
+	require.NoError(t, err)
+
+	bindings, err := gitsync.NewBindingStore(root)
+	require.NoError(t, err)
+
+	logger := logging.ForComponent("gitsync-test")
+	syncer, err := gitsync.NewSyncer(store, bindings, filepath.Join(root, "repos"), logger, opts...)
+	require.NoError(t, err)
+
+	return syncer, store, bindings
+}
+
+// TestInitialSync verifies that the first TriggerSync call clones the origin
+// and imports YAML/JSON config files into the ConfigStore.
+func TestInitialSync(t *testing.T) {
+	bareDir, _, _ := newTestRepo(t, map[string]string{
+		"policy1.yaml": "key: value\n",
+	})
+
+	syncer, store, bindings := newTestSyncer(t)
+
+	binding := gitsync.ScopeBinding{
+		TenantPath: "root/test-tenant",
+		Namespace:  "policies",
+		OriginURL:  bareDir,
+		Branch:     "main",
+	}
+	require.NoError(t, bindings.Add(binding))
+
+	ctx := context.Background()
+	err := syncer.TriggerSync(ctx, binding)
+	require.NoError(t, err)
+
+	entry, err := store.GetConfig(ctx, &interfaces.ConfigKey{
+		TenantID:  "root/test-tenant",
+		Namespace: "policies",
+		Name:      "policy1",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "key: value\n", string(entry.Data))
+	assert.Equal(t, interfaces.ConfigFormatYAML, entry.Format)
+	assert.Equal(t, "git-sync", entry.CreatedBy)
+}
+
+// TestIncrementalSync verifies that adding a commit to the origin and
+// triggering sync again updates the ConfigStore and advances the last-synced
+// SHA.
+func TestIncrementalSync(t *testing.T) {
+	bareDir, _, pushFiles := newTestRepo(t, map[string]string{
+		"policy1.yaml": "key: value\n",
+	})
+
+	syncer, store, bindings := newTestSyncer(t)
+
+	binding := gitsync.ScopeBinding{
+		TenantPath: "root/test-tenant",
+		Namespace:  "policies",
+		OriginURL:  bareDir,
+		Branch:     "main",
+	}
+	require.NoError(t, bindings.Add(binding))
+
+	ctx := context.Background()
+
+	// First sync: imports policy1.
+	err := syncer.TriggerSync(ctx, binding)
+	require.NoError(t, err)
+
+	sha1, ok := bindings.Get("root/test-tenant", "policies")
+	require.True(t, ok)
+	assert.NotEmpty(t, sha1.LastSyncedSHA)
+
+	// Push a second commit.
+	pushFiles(map[string]string{"policy2.yaml": "key2: value2\n"})
+
+	// Second sync: should pull the new commit and import policy2.
+	err = syncer.TriggerSync(ctx, binding)
+	require.NoError(t, err)
+
+	sha2, ok := bindings.Get("root/test-tenant", "policies")
+	require.True(t, ok)
+	assert.NotEmpty(t, sha2.LastSyncedSHA)
+	assert.NotEqual(t, sha1.LastSyncedSHA, sha2.LastSyncedSHA, "SHA must advance on new commit")
+
+	entry, err := store.GetConfig(ctx, &interfaces.ConfigKey{
+		TenantID:  "root/test-tenant",
+		Namespace: "policies",
+		Name:      "policy2",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "key2: value2\n", string(entry.Data))
+}
+
+// TestIdempotentSync verifies that triggering a sync twice on the same commit
+// does not increment the ConfigEntry version (StoreConfig is called once, not
+// twice).
+func TestIdempotentSync(t *testing.T) {
+	bareDir, _, _ := newTestRepo(t, map[string]string{
+		"policy1.yaml": "key: value\n",
+	})
+
+	syncer, store, bindings := newTestSyncer(t)
+
+	binding := gitsync.ScopeBinding{
+		TenantPath: "root/test-tenant",
+		Namespace:  "policies",
+		OriginURL:  bareDir,
+		Branch:     "main",
+	}
+	require.NoError(t, bindings.Add(binding))
+
+	ctx := context.Background()
+
+	// First sync: imports policy1 at version 1.
+	require.NoError(t, syncer.TriggerSync(ctx, binding))
+
+	entry, err := store.GetConfig(ctx, &interfaces.ConfigKey{
+		TenantID:  "root/test-tenant",
+		Namespace: "policies",
+		Name:      "policy1",
+	})
+	require.NoError(t, err)
+	versionAfterFirstSync := entry.Version
+
+	// Second sync on the same commit: SHA unchanged → import skipped.
+	require.NoError(t, syncer.TriggerSync(ctx, binding))
+
+	entry2, err := store.GetConfig(ctx, &interfaces.ConfigKey{
+		TenantID:  "root/test-tenant",
+		Namespace: "policies",
+		Name:      "policy1",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, versionAfterFirstSync, entry2.Version,
+		"version must not advance when SHA has not changed (idempotent import)")
+}
+
+// TestScopeIsolation verifies that a failure syncing one scope does not prevent
+// other scopes from syncing successfully.
+func TestScopeIsolation(t *testing.T) {
+	bareDir, _, _ := newTestRepo(t, map[string]string{
+		"policy1.yaml": "key: value\n",
+	})
+
+	syncer, store, bindings := newTestSyncer(t)
+
+	reachable := gitsync.ScopeBinding{
+		TenantPath: "root/good-tenant",
+		Namespace:  "policies",
+		OriginURL:  bareDir,
+		Branch:     "main",
+	}
+	unreachable := gitsync.ScopeBinding{
+		TenantPath: "root/bad-tenant",
+		Namespace:  "policies",
+		OriginURL:  "/nonexistent/path/that/does/not/exist",
+		Branch:     "main",
+	}
+	require.NoError(t, bindings.Add(reachable))
+	require.NoError(t, bindings.Add(unreachable))
+
+	ctx := context.Background()
+
+	// Unreachable scope must return an error.
+	err := syncer.TriggerSync(ctx, unreachable)
+	assert.Error(t, err)
+	assert.ErrorIs(t, err, gitsync.ErrOriginUnreachable)
+
+	// Reachable scope must sync successfully regardless.
+	err = syncer.TriggerSync(ctx, reachable)
+	require.NoError(t, err)
+
+	entry, err := store.GetConfig(ctx, &interfaces.ConfigKey{
+		TenantID:  "root/good-tenant",
+		Namespace: "policies",
+		Name:      "policy1",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "key: value\n", string(entry.Data))
+}
+
+// TestPollingInterval verifies that a polling goroutine fires TriggerSync when
+// the ticker fires.
+//
+// A controllable ticker (via WithTickerFunc) and a sync-done channel (via
+// WithSyncNotify) are injected so the test does not need to sleep and does
+// not depend on wall-clock timing. MinPollingInterval (60 s) is still
+// respected at the binding level; only the ticker delivery is accelerated.
+func TestPollingInterval(t *testing.T) {
+	requireGit(t)
+
+	bareDir, _, _ := newTestRepo(t, map[string]string{
+		"policy1.yaml": "key: value\n",
+	})
+
+	// fakeTick delivers ticks on demand; syncDone signals when each TriggerSync
+	// call has finished so we can assert without sleeping.
+	fakeTick := make(chan time.Time, 1)
+	syncDone := make(chan struct{}, 1)
+
+	syncer, store, bindings := newTestSyncer(t,
+		gitsync.WithTickerFunc(func(_ time.Duration) (<-chan time.Time, func()) {
+			return fakeTick, func() {}
+		}),
+		gitsync.WithSyncNotify(syncDone),
+	)
+
+	binding := gitsync.ScopeBinding{
+		TenantPath:      "root/poll-tenant",
+		Namespace:       "policies",
+		OriginURL:       bareDir,
+		Branch:          "main",
+		PollingInterval: gitsync.MinPollingInterval, // 60 s (minimum) — real interval, fake delivery
+	}
+	require.NoError(t, bindings.Add(binding))
+
+	ctx := context.Background()
+	require.NoError(t, syncer.Start(ctx))
+	t.Cleanup(syncer.Stop)
+
+	// Deliver one tick to trigger a polling sync cycle.
+	fakeTick <- time.Now()
+
+	// Wait for TriggerSync to complete without sleeping.
+	select {
+	case <-syncDone:
+	case <-time.After(10 * time.Second):
+		t.Fatal("polling sync did not complete within 10 seconds")
+	}
+
+	entry, err := store.GetConfig(ctx, &interfaces.ConfigKey{
+		TenantID:  "root/poll-tenant",
+		Namespace: "policies",
+		Name:      "policy1",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "key: value\n", string(entry.Data))
+}
+
+// TestPollingIntervalTooShort verifies that configuring a polling interval
+// shorter than MinPollingInterval is rejected at binding-add time.
+func TestPollingIntervalTooShort(t *testing.T) {
+	root := t.TempDir()
+	bindings, err := gitsync.NewBindingStore(root)
+	require.NoError(t, err)
+
+	binding := gitsync.ScopeBinding{
+		TenantPath:      "root/test",
+		Namespace:       "policies",
+		OriginURL:       "https://example.com/repo.git",
+		Branch:          "main",
+		PollingInterval: 30 * time.Second, // below MinPollingInterval
+	}
+	err = bindings.Add(binding)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, gitsync.ErrIntervalTooShort)
+}
+
+// TestJSONConfigImport verifies that JSON config files are imported with the
+// correct format.
+func TestJSONConfigImport(t *testing.T) {
+	bareDir, _, _ := newTestRepo(t, map[string]string{
+		"settings.json": `{"debug": true}`,
+	})
+
+	syncer, store, bindings := newTestSyncer(t)
+
+	binding := gitsync.ScopeBinding{
+		TenantPath: "root/json-tenant",
+		Namespace:  "settings",
+		OriginURL:  bareDir,
+		Branch:     "main",
+	}
+	require.NoError(t, bindings.Add(binding))
+
+	ctx := context.Background()
+	require.NoError(t, syncer.TriggerSync(ctx, binding))
+
+	entry, err := store.GetConfig(ctx, &interfaces.ConfigKey{
+		TenantID:  "root/json-tenant",
+		Namespace: "settings",
+		Name:      "settings",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, interfaces.ConfigFormatJSON, entry.Format)
+	assert.Contains(t, string(entry.Data), `"debug"`)
+}

--- a/pkg/gitsync/webhook.go
+++ b/pkg/gitsync/webhook.go
@@ -1,0 +1,205 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+package gitsync
+
+import (
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"sync"
+
+	"github.com/cfgis/cfgms/pkg/logging"
+)
+
+// WebhookHandler handles incoming push-event webhooks (GitHub or GitLab) and
+// triggers git-sync for matching scope bindings.
+//
+// Signature validation: when a binding has a WebhookSecretRef configured, the
+// handler validates the X-Hub-Signature-256 header against an HMAC-SHA256 of
+// the request body. Requests with an invalid or missing signature are rejected
+// with HTTP 401.
+type WebhookHandler struct {
+	syncer   *Syncer
+	bindings *BindingStore
+	logger   logging.Logger
+	wg       sync.WaitGroup // tracks in-flight background sync goroutines
+}
+
+// NewWebhookHandler creates a new WebhookHandler.
+func NewWebhookHandler(syncer *Syncer, bindings *BindingStore, logger logging.Logger) *WebhookHandler {
+	return &WebhookHandler{
+		syncer:   syncer,
+		bindings: bindings,
+		logger:   logger,
+	}
+}
+
+// pushPayload is a minimal parse of GitHub / GitLab push-event JSON payloads.
+// Both providers include ref and repository clone URLs.
+type pushPayload struct {
+	Ref        string `json:"ref"`
+	Repository struct {
+		CloneURL string `json:"clone_url"` // GitHub HTTPS clone URL
+		HTTPURL  string `json:"http_url"`  // GitLab HTTPS clone URL
+		SSHURL   string `json:"ssh_url"`   // GitHub/GitLab SSH URL
+	} `json:"repository"`
+}
+
+// ServeHTTP implements http.Handler.
+//
+// Accepts POST only. Returns:
+//   - 202 Accepted — one or more matching bindings found and sync triggered
+//   - 204 No Content — no matching bindings
+//   - 400 Bad Request — unreadable or unparseable body
+//   - 401 Unauthorized — HMAC validation failed
+//   - 405 Method Not Allowed — non-POST request
+func (h *WebhookHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	// Read the body once for HMAC validation and payload parsing.
+	body, err := io.ReadAll(io.LimitReader(r.Body, 1<<20)) // 1 MiB limit
+	if err != nil {
+		h.logger.Error("gitsync: failed to read webhook body", "error", err.Error())
+		http.Error(w, "failed to read request body", http.StatusBadRequest)
+		return
+	}
+
+	var payload pushPayload
+	if err := json.Unmarshal(body, &payload); err != nil {
+		http.Error(w, "invalid JSON payload", http.StatusBadRequest)
+		return
+	}
+
+	// Determine pushed branch from the ref field (e.g. "refs/heads/main" → "main").
+	branch := strings.TrimPrefix(payload.Ref, "refs/heads/")
+
+	allBindings := h.bindings.List()
+	triggered := 0
+
+	for _, b := range allBindings {
+		if !matchesOrigin(b.OriginURL,
+			payload.Repository.CloneURL,
+			payload.Repository.HTTPURL,
+			payload.Repository.SSHURL) {
+			continue
+		}
+
+		bindingBranch := b.Branch
+		if bindingBranch == "" {
+			bindingBranch = "main"
+		}
+		if bindingBranch != branch {
+			continue
+		}
+
+		// Validate HMAC-SHA256 if a webhook secret is configured.
+		if b.WebhookSecretRef != "" {
+			secret, secretErr := resolveWebhookSecret(b.WebhookSecretRef)
+			if secretErr != nil {
+				h.logger.Error("gitsync: failed to resolve webhook secret",
+					"tenant_path", logging.SanitizeLogValue(b.TenantPath),
+					"namespace", logging.SanitizeLogValue(b.Namespace),
+					"error", secretErr.Error())
+				http.Error(w, "internal error resolving webhook secret", http.StatusInternalServerError)
+				return
+			}
+			sig := r.Header.Get("X-Hub-Signature-256")
+			if !validateHMAC(body, sig, secret) {
+				h.logger.Warn("gitsync: webhook HMAC validation failed",
+					"tenant_path", logging.SanitizeLogValue(b.TenantPath),
+					"namespace", logging.SanitizeLogValue(b.Namespace))
+				http.Error(w, "invalid or missing signature", http.StatusUnauthorized)
+				return
+			}
+		}
+
+		// Fire sync in the background so the webhook returns quickly.
+		bindingCopy := b
+		h.wg.Add(1)
+		go func() {
+			defer h.wg.Done()
+			if syncErr := h.syncer.TriggerSync(context.Background(), bindingCopy); syncErr != nil {
+				h.logger.Error("gitsync: webhook-triggered sync failed",
+					"tenant_path", logging.SanitizeLogValue(bindingCopy.TenantPath),
+					"namespace", logging.SanitizeLogValue(bindingCopy.Namespace),
+					"error", syncErr.Error())
+			}
+		}()
+		triggered++
+	}
+
+	if triggered == 0 {
+		w.WriteHeader(http.StatusNoContent)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusAccepted)
+	if _, err := fmt.Fprintf(w, `{"triggered":%d}`, triggered); err != nil {
+		h.logger.Error("gitsync: failed to write webhook response", "error", err.Error())
+	}
+}
+
+// WaitForPendingSyncs blocks until all background sync goroutines dispatched by
+// ServeHTTP have completed. This is primarily useful in tests.
+func (h *WebhookHandler) WaitForPendingSyncs() {
+	h.wg.Wait()
+}
+
+// validateHMAC returns true if signature is a valid X-Hub-Signature-256 value
+// for the given body and secret.
+func validateHMAC(body []byte, signature, secret string) bool {
+	if !strings.HasPrefix(signature, "sha256=") {
+		return false
+	}
+	got, err := hex.DecodeString(strings.TrimPrefix(signature, "sha256="))
+	if err != nil {
+		return false
+	}
+	mac := hmac.New(sha256.New, []byte(secret))
+	mac.Write(body)
+	expected := mac.Sum(nil)
+	return hmac.Equal(got, expected)
+}
+
+// matchesOrigin returns true if bindingURL equals any of the repository URLs
+// carried in the push event payload.
+func matchesOrigin(bindingURL string, payloadURLs ...string) bool {
+	for _, u := range payloadURLs {
+		if u != "" && bindingURL == u {
+			return true
+		}
+	}
+	return false
+}
+
+// resolveWebhookSecret resolves a WebhookSecretRef to its plaintext secret
+// value using the same rules as resolveCredentials.
+func resolveWebhookSecret(ref string) (string, error) {
+	if ref == "" {
+		return "", nil
+	}
+	if strings.HasPrefix(ref, "env:") {
+		envVar := strings.TrimPrefix(ref, "env:")
+		val := os.Getenv(envVar)
+		if val == "" {
+			return "", fmt.Errorf("environment variable %s is not set or is empty", envVar)
+		}
+		return val, nil
+	}
+	// Treat as file path.
+	raw, err := os.ReadFile(ref) // #nosec G304 - admin-supplied secret file path
+	if err != nil {
+		return "", fmt.Errorf("failed to read webhook secret file %q: %w", ref, err)
+	}
+	return strings.TrimSpace(string(raw)), nil
+}

--- a/pkg/gitsync/webhook_test.go
+++ b/pkg/gitsync/webhook_test.go
@@ -1,0 +1,322 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+package gitsync_test
+
+import (
+	"bytes"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cfgis/cfgms/pkg/gitsync"
+	"github.com/cfgis/cfgms/pkg/logging"
+	"github.com/cfgis/cfgms/pkg/storage/providers/flatfile"
+)
+
+// buildPushPayload returns a JSON push-event payload for the given origin URL
+// and ref (e.g. "refs/heads/main").
+func buildPushPayload(originURL, ref string) []byte {
+	payload := map[string]interface{}{
+		"ref": ref,
+		"repository": map[string]string{
+			"clone_url": originURL,
+			"ssh_url":   "",
+			"http_url":  "",
+		},
+	}
+	data, _ := json.Marshal(payload)
+	return data
+}
+
+// hmacSHA256Signature returns the X-Hub-Signature-256 header value for body
+// signed with secret.
+func hmacSHA256Signature(body []byte, secret string) string {
+	mac := hmac.New(sha256.New, []byte(secret))
+	mac.Write(body)
+	return "sha256=" + hex.EncodeToString(mac.Sum(nil))
+}
+
+// webhookTestSetup holds the components of a webhook test fixture.
+type webhookTestSetup struct {
+	handler  *gitsync.WebhookHandler
+	syncer   *gitsync.Syncer
+	bindings *gitsync.BindingStore
+}
+
+// newWebhookSetup creates a WebhookHandler backed by a real FlatFileConfigStore
+// and a BindingStore pre-populated with the given bindings.
+func newWebhookSetup(t *testing.T, bs []gitsync.ScopeBinding) *webhookTestSetup {
+	t.Helper()
+	root := t.TempDir()
+
+	store, err := flatfile.NewFlatFileConfigStore(filepath.Join(root, "configs"))
+	require.NoError(t, err)
+
+	bindings, err := gitsync.NewBindingStore(root)
+	require.NoError(t, err)
+
+	for _, b := range bs {
+		require.NoError(t, bindings.Add(b))
+	}
+
+	logger := logging.ForComponent("webhook-test")
+	syncer, err := gitsync.NewSyncer(store, bindings, filepath.Join(root, "repos"), logger)
+	require.NoError(t, err)
+
+	handler := gitsync.NewWebhookHandler(syncer, bindings, logger)
+
+	// Ensure all background goroutines finish before the test's temp dir is
+	// removed, preventing "directory not empty" cleanup failures.
+	t.Cleanup(handler.WaitForPendingSyncs)
+	t.Cleanup(syncer.Stop)
+
+	return &webhookTestSetup{handler: handler, syncer: syncer, bindings: bindings}
+}
+
+// TestWebhookNoMatchingBinding verifies that a push payload that does not match
+// any binding returns HTTP 204.
+func TestWebhookNoMatchingBinding(t *testing.T) {
+	setup := newWebhookSetup(t, []gitsync.ScopeBinding{
+		{
+			TenantPath: "root/t1",
+			Namespace:  "policies",
+			OriginURL:  "https://github.com/org/other-repo.git",
+			Branch:     "main",
+		},
+	})
+
+	body := buildPushPayload("https://github.com/org/different-repo.git", "refs/heads/main")
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/webhooks/git-push", bytes.NewReader(body))
+	rec := httptest.NewRecorder()
+	setup.handler.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusNoContent, rec.Code)
+}
+
+// TestWebhookMatchingBinding verifies that a push payload matching a binding
+// (without HMAC validation) returns HTTP 202, and that a background sync is
+// dispatched successfully using a local bare repo.
+func TestWebhookMatchingBinding(t *testing.T) {
+	requireGit(t)
+
+	bareDir, _, _ := newTestRepo(t, map[string]string{
+		"policy1.yaml": "key: value\n",
+	})
+
+	setup := newWebhookSetup(t, []gitsync.ScopeBinding{
+		{
+			TenantPath: "root/t1",
+			Namespace:  "policies",
+			OriginURL:  bareDir,
+			Branch:     "main",
+		},
+	})
+
+	body := buildPushPayload(bareDir, "refs/heads/main")
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/webhooks/git-push", bytes.NewReader(body))
+	rec := httptest.NewRecorder()
+	setup.handler.ServeHTTP(rec, req)
+
+	// 202 Accepted means TriggerSync was dispatched.
+	assert.Equal(t, http.StatusAccepted, rec.Code)
+
+	// Wait for the background sync goroutine to finish.
+	setup.handler.WaitForPendingSyncs()
+}
+
+// TestWebhookBranchMismatch verifies that a push to a different branch than the
+// configured binding returns HTTP 204 (no match).
+func TestWebhookBranchMismatch(t *testing.T) {
+	const originURL = "https://github.com/org/cfgms-configs.git"
+	setup := newWebhookSetup(t, []gitsync.ScopeBinding{
+		{
+			TenantPath: "root/t1",
+			Namespace:  "policies",
+			OriginURL:  originURL,
+			Branch:     "main",
+		},
+	})
+
+	// Payload for a push to the "feature/foo" branch.
+	body := buildPushPayload(originURL, "refs/heads/feature/foo")
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/webhooks/git-push", bytes.NewReader(body))
+	rec := httptest.NewRecorder()
+	setup.handler.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusNoContent, rec.Code)
+}
+
+// TestWebhookValidHMAC verifies that a request with a valid HMAC-SHA256
+// signature is accepted (HTTP 202) when the binding has WebhookSecretRef set.
+func TestWebhookValidHMAC(t *testing.T) {
+	requireGit(t)
+
+	const secret = "super-secret-webhook-token"
+	bareDir, _, _ := newTestRepo(t, map[string]string{
+		"policy1.yaml": "key: value\n",
+	})
+
+	// Write the secret to a temp file so WebhookSecretRef resolves it.
+	secretFile := filepath.Join(t.TempDir(), "webhook-secret.txt")
+	require.NoError(t, os.WriteFile(secretFile, []byte(secret), 0600))
+
+	setup := newWebhookSetup(t, []gitsync.ScopeBinding{
+		{
+			TenantPath:       "root/t1",
+			Namespace:        "policies",
+			OriginURL:        bareDir,
+			Branch:           "main",
+			WebhookSecretRef: secretFile,
+		},
+	})
+
+	body := buildPushPayload(bareDir, "refs/heads/main")
+	sig := hmacSHA256Signature(body, secret)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/webhooks/git-push", bytes.NewReader(body))
+	req.Header.Set("X-Hub-Signature-256", sig)
+	rec := httptest.NewRecorder()
+	setup.handler.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusAccepted, rec.Code)
+
+	// Wait for the background sync goroutine.
+	setup.handler.WaitForPendingSyncs()
+}
+
+// TestWebhookInvalidHMAC verifies that a request with an invalid HMAC-SHA256
+// signature is rejected with HTTP 401.
+func TestWebhookInvalidHMAC(t *testing.T) {
+	const (
+		originURL = "https://github.com/org/cfgms-configs.git"
+		secret    = "super-secret-webhook-token"
+	)
+
+	secretFile := filepath.Join(t.TempDir(), "webhook-secret.txt")
+	require.NoError(t, os.WriteFile(secretFile, []byte(secret), 0600))
+
+	setup := newWebhookSetup(t, []gitsync.ScopeBinding{
+		{
+			TenantPath:       "root/t1",
+			Namespace:        "policies",
+			OriginURL:        originURL,
+			Branch:           "main",
+			WebhookSecretRef: secretFile,
+		},
+	})
+
+	body := buildPushPayload(originURL, "refs/heads/main")
+
+	// Use a wrong secret to generate a bad signature.
+	badSig := hmacSHA256Signature(body, "wrong-secret")
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/webhooks/git-push", bytes.NewReader(body))
+	req.Header.Set("X-Hub-Signature-256", badSig)
+	rec := httptest.NewRecorder()
+	setup.handler.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusUnauthorized, rec.Code)
+}
+
+// TestWebhookMissingSignatureWhenRequired verifies that a request without a
+// signature header is rejected with HTTP 401 when the binding has a webhook
+// secret configured.
+func TestWebhookMissingSignatureWhenRequired(t *testing.T) {
+	const (
+		originURL = "https://github.com/org/cfgms-configs.git"
+		secret    = "super-secret-webhook-token"
+	)
+
+	secretFile := filepath.Join(t.TempDir(), "webhook-secret.txt")
+	require.NoError(t, os.WriteFile(secretFile, []byte(secret), 0600))
+
+	setup := newWebhookSetup(t, []gitsync.ScopeBinding{
+		{
+			TenantPath:       "root/t1",
+			Namespace:        "policies",
+			OriginURL:        originURL,
+			Branch:           "main",
+			WebhookSecretRef: secretFile,
+		},
+	})
+
+	body := buildPushPayload(originURL, "refs/heads/main")
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/webhooks/git-push", bytes.NewReader(body))
+	// No X-Hub-Signature-256 header.
+	rec := httptest.NewRecorder()
+	setup.handler.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusUnauthorized, rec.Code)
+}
+
+// TestWebhookMethodNotAllowed verifies that non-POST requests return HTTP 405.
+func TestWebhookMethodNotAllowed(t *testing.T) {
+	setup := newWebhookSetup(t, nil)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/webhooks/git-push", nil)
+	rec := httptest.NewRecorder()
+	setup.handler.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusMethodNotAllowed, rec.Code)
+}
+
+// TestWebhookInvalidJSON verifies that a request with a non-JSON body returns
+// HTTP 400.
+func TestWebhookInvalidJSON(t *testing.T) {
+	setup := newWebhookSetup(t, nil)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/webhooks/git-push",
+		bytes.NewReader([]byte("not json")))
+	rec := httptest.NewRecorder()
+	setup.handler.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+// TestWebhookEnvVarHMAC verifies that WebhookSecretRef with "env:" prefix
+// resolves the secret from an environment variable.
+func TestWebhookEnvVarHMAC(t *testing.T) {
+	requireGit(t)
+
+	const (
+		envVar = "CFGMS_TEST_WEBHOOK_SECRET_XYZ"
+		secret = "env-var-secret"
+	)
+	t.Setenv(envVar, secret)
+
+	bareDir, _, _ := newTestRepo(t, map[string]string{
+		"policy1.yaml": "key: value\n",
+	})
+
+	setup := newWebhookSetup(t, []gitsync.ScopeBinding{
+		{
+			TenantPath:       "root/t1",
+			Namespace:        "policies",
+			OriginURL:        bareDir,
+			Branch:           "main",
+			WebhookSecretRef: "env:" + envVar,
+		},
+	})
+
+	body := buildPushPayload(bareDir, "refs/heads/main")
+	sig := hmacSHA256Signature(body, secret)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/webhooks/git-push", bytes.NewReader(body))
+	req.Header.Set("X-Hub-Signature-256", sig)
+	rec := httptest.NewRecorder()
+	setup.handler.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusAccepted, rec.Code)
+
+	// Wait for the background sync goroutine.
+	setup.handler.WaitForPendingSyncs()
+}

--- a/pkg/storage/interfaces/README.md
+++ b/pkg/storage/interfaces/README.md
@@ -88,6 +88,8 @@ The OSS column is the zero-config default, not a limit. Any Commercial backend i
 
 Git is **not** a backend. It is an optional sync source bound to admin-designated config scopes; see ADR-003 for the sync model.
 
+**`pkg/gitsync` is a write-through adapter, not a storage provider.** It sits in front of a `ConfigStore` (flat-file for OSS, PostgreSQL for commercial) and forwards imported configs via `ConfigStore.StoreConfig`. It does not implement the `ConfigStore` interface itself, and it is not registered through the provider system. Modules that read config data always target the `ConfigStore` directly — git-sync is invisible at read time. The adapter is wired at controller startup when `cfg.DataDir` is set and scope bindings exist.
+
 ## Module Usage Pattern
 
 Modules receive interfaces, never specific providers:


### PR DESCRIPTION
## Summary

- Implements `pkg/gitsync/` package: a write-through adapter that pulls config entries from external git origins and forwards them to a `ConfigStore` via `StoreConfig` (ADR-003, sub-story F)
- Scope bindings (TenantPath, Namespace, OriginURL, Branch, CredentialsRef, WebhookSecretRef, PollingInterval) are persisted to `<data-dir>/.gitsync/bindings.json` with atomic write-then-rename; minimum polling interval enforced at 60 s
- Webhook handler (`POST /api/v1/webhooks/git-push`) validates HMAC-SHA256 signatures, fires background syncs, and returns 202/204/400/401/405 as appropriate; controller startup wires the syncer and webhook route when `cfg.DataDir` is set

## Fixes

Fixes #666

## Test plan

- [x] `TestInitialSync` — PlainClone + StoreConfig for YAML files
- [x] `TestIncrementalSync` — PullContext advances LastSyncedSHA and imports new config
- [x] `TestIdempotentSync` — second sync on same SHA leaves Version at 1
- [x] `TestScopeIsolation` — unreachable origin returns `ErrOriginUnreachable`; reachable scope syncs fine
- [x] `TestPollingInterval` — `WithTickerFunc` + `WithSyncNotify` inject controllable ticker; no wall-clock sleeps
- [x] `TestPollingIntervalTooShort` — 30 s interval rejected with `ErrIntervalTooShort`
- [x] `TestJSONConfigImport` — `.json` file imported with `ConfigFormatJSON`
- [x] `TestWebhook*` — 9 webhook scenarios (match, no-match, branch mismatch, valid/invalid/missing HMAC, method not allowed, invalid JSON, env-var secret)

## Specialist review results

| Agent | Result |
|-------|--------|
| qa-test-runner | **PASS** — all unit, integration, cross-platform builds pass; golangci-lint clean; gofmt clean |
| qa-code-reviewer | **PASS** — functional options pattern for test injection, no public test-only methods, no time.Sleep in tests, checked fmt.Fprintf error |
| security-engineer | **PASS** — HMAC constant-time comparison, 1 MiB body limit, SanitizeLogValue on all user-influenced log values, G304 nosec justified for admin-supplied paths |

🤖 Generated with [Claude Code](https://claude.ai/claude-code)