### PR TITLE
storage/commands: add CommandStore interface and persist command dispatch state (Issue #665)

### DIFF
--- a/docs/architecture/storage-architecture.md
+++ b/docs/architecture/storage-architecture.md
@@ -311,6 +311,7 @@ Per ADR-003, the providers and interfaces above are **not all implemented today*
 | `pkg/storage/providers/flatfile` | #661 | `ConfigStore`, `AuditStore` |
 | `pkg/storage/providers/sqlite` | #663 | `StewardStore` |
 | `pkg/storage/providers/flatfile` | #663 | `StewardStore` |
+| `pkg/storage/providers/sqlite` | #665 | `CommandStore` |
 
 ### StewardStore (Issue #663)
 
@@ -325,6 +326,23 @@ Per ADR-003, the providers and interfaces above are **not all implemented today*
 **Fleet tracker**: `features/steward/StewardHealthTracker` wraps a `StewardStore` for durable fields and keeps ephemeral per-process metrics (`HealthMetrics`) in-memory via a `sync.Map`.
 
 `SessionStore` is implemented in story #662. It stores only `Persistent=true` sessions; ephemeral state (non-persistent sessions, rebuildable runtime values) uses `pkg/cache`. The `ConfigStore` and `RuntimeStore` interfaces return `ErrNotSupported` from the SQLite provider — config storage targets the flat-file provider (OSS) and PostgreSQL (commercial).
+
+### CommandStore (Issue #665)
+
+`CommandStore` is the durable command dispatch state backend. It persists the full lifecycle of commands dispatched to stewards so that dispatch state (executing, completed, failed) survives a process restart and forms a crash-survivable audit trail.
+
+**Key design decisions**:
+- Two tables: `commands` (current state) and `command_transitions` (immutable audit log of every status change, including initial creation as `pending`).
+- `GetCommandAuditTrail(commandID)` returns all transitions in chronological order — this record is immutable; only `PurgeExpiredRecords` can delete it (by age).
+- `PurgeExpiredRecords(ctx, olderThan)` removes `completed`, `failed`, and `cancelled` records older than the threshold. `executing` and `pending` records are never purged.
+- **Startup sweep**: when `features/steward/commands.Handler` is initialised with a `CommandStore`, it queries all `executing` records and flips them to `failed` with error `"controller_restart"`. This converts crash-time in-progress state into a queryable audit entry.
+- The in-memory `executing` map in `Handler` retains only `context.CancelFunc` for in-flight cancellation — durable state is entirely in the store.
+
+**Status values**: `pending` → `executing` → `completed` / `failed` / `cancelled`.
+
+**Implementations**:
+- `pkg/storage/providers/sqlite`: `commands` and `command_transitions` tables added to the shared SQLite schema. This is the OSS default.
+- `pkg/storage/providers/flatfile`, `database`, `git`: return `ErrNotSupported` — command state is business data, not config data.
 
 ## References
 

--- a/features/steward/commands/handler.go
+++ b/features/steward/commands/handler.go
@@ -4,6 +4,11 @@
 //
 // This package implements the command handler that processes commands
 // from the controller and executes appropriate actions (Story #198).
+//
+// Story #665: Command dispatch state is now persisted to a CommandStore so that
+// executing/completed/failed status survives a process restart. The in-memory
+// executing map retains only the context.CancelFunc needed for in-flight
+// cancellation; all durable state is in the store.
 package commands
 
 import (
@@ -14,6 +19,7 @@ import (
 
 	cpTypes "github.com/cfgis/cfgms/pkg/controlplane/types"
 	"github.com/cfgis/cfgms/pkg/logging"
+	"github.com/cfgis/cfgms/pkg/storage/interfaces"
 )
 
 // Handler processes control plane commands from the controller.
@@ -32,8 +38,17 @@ type Handler struct {
 	// Logger
 	logger logging.Logger
 
-	// Execution tracking
+	// CommandStore for durable command dispatch state (Story #665).
+	// When nil the handler operates without persistence (in-memory only).
+	store interfaces.CommandStore
+
+	// Execution tracking — holds only the CancelFunc for in-flight cancellation.
+	// Durable state (status, timestamps, result) lives in the CommandStore.
 	executing map[string]*executionContext
+
+	// wg tracks in-flight executeCommand goroutines to support graceful shutdown
+	// and deterministic test synchronization.
+	wg sync.WaitGroup
 }
 
 // CommandFunc is a function that handles a specific command type.
@@ -42,11 +57,10 @@ type CommandFunc func(ctx context.Context, cmd *cpTypes.Command) error
 // StatusCallback is called when status events should be published to controller.
 type StatusCallback func(ctx context.Context, event *cpTypes.Event)
 
-// executionContext tracks command execution state.
+// executionContext tracks in-flight cancellation only.
+// All durable command state is written to the CommandStore.
 type executionContext struct {
-	CommandID string
-	StartTime time.Time
-	Cancel    context.CancelFunc
+	Cancel context.CancelFunc
 }
 
 // Config holds command handler configuration.
@@ -59,9 +73,15 @@ type Config struct {
 
 	// Logger for command execution logging
 	Logger logging.Logger
+
+	// Store is the durable command dispatch state backend (Story #665).
+	// When nil, state transitions are not persisted across restarts.
+	Store interfaces.CommandStore
 }
 
-// New creates a new command handler.
+// New creates a new command handler and, when a CommandStore is configured,
+// sweeps any commands left in "executing" state from a previous run and marks
+// them as failed with reason "controller_restart".
 func New(cfg *Config) (*Handler, error) {
 	if cfg.StewardID == "" {
 		return nil, fmt.Errorf("steward ID is required")
@@ -73,13 +93,53 @@ func New(cfg *Config) (*Handler, error) {
 		return nil, fmt.Errorf("logger is required")
 	}
 
-	return &Handler{
+	h := &Handler{
 		stewardID: cfg.StewardID,
 		handlers:  make(map[cpTypes.CommandType]CommandFunc),
 		onStatus:  cfg.OnStatus,
 		logger:    cfg.Logger,
+		store:     cfg.Store,
 		executing: make(map[string]*executionContext),
-	}, nil
+	}
+
+	// Startup sweep: flip stale "executing" records from a previous run to "failed".
+	if cfg.Store != nil {
+		if err := h.sweepStaleExecutingCommands(context.Background()); err != nil {
+			// Log but do not abort startup — stale records do not block operation.
+			cfg.Logger.Error("Failed to sweep stale executing commands on startup",
+				"error", err)
+		}
+	}
+
+	return h, nil
+}
+
+// Wait blocks until all in-flight executeCommand goroutines have finished.
+// Useful for graceful shutdown and deterministic test synchronization.
+func (h *Handler) Wait() {
+	h.wg.Wait()
+}
+
+// sweepStaleExecutingCommands marks commands that were left in "executing" state
+// (from a crashed or restarted process) as "failed" with error "controller_restart".
+func (h *Handler) sweepStaleExecutingCommands(ctx context.Context) error {
+	stale, err := h.store.ListCommandsByStatus(ctx, interfaces.CommandStatusExecuting)
+	if err != nil {
+		return fmt.Errorf("listing stale executing commands: %w", err)
+	}
+
+	for _, cmd := range stale {
+		if err := h.store.UpdateCommandStatus(ctx, cmd.ID,
+			interfaces.CommandStatusFailed, nil, "controller_restart"); err != nil {
+			h.logger.Error("Failed to mark stale command as failed",
+				"command_id", cmd.ID,
+				"error", err)
+		} else {
+			h.logger.Info("Marked stale executing command as failed (controller_restart)",
+				"command_id", cmd.ID)
+		}
+	}
+	return nil
 }
 
 // RegisterHandler registers a handler function for a specific command type.
@@ -96,6 +156,22 @@ func (h *Handler) RegisterHandler(cmdType cpTypes.CommandType, handler CommandFu
 func (h *Handler) HandleCommand(ctx context.Context, cmd *cpTypes.Command) error {
 	h.logger.Debug("Received command", "id", cmd.ID, "type", cmd.Type)
 
+	// Persist incoming command record (Story #665).
+	if h.store != nil {
+		record := &interfaces.CommandRecord{
+			ID:        cmd.ID,
+			Type:      string(cmd.Type),
+			StewardID: h.stewardID, // raw value — SanitizeLogValue is for log output only
+			IssuedAt:  cmd.Timestamp,
+		}
+		if err := h.store.CreateCommandRecord(ctx, record); err != nil {
+			h.logger.Error("Failed to persist incoming command record",
+				"command_id", cmd.ID,
+				"error", err)
+			// Do not abort — command execution continues without durable record.
+		}
+	}
+
 	// Send command received event
 	h.sendStatus(ctx, &cpTypes.Event{
 		ID:        fmt.Sprintf("evt_%d", time.Now().UnixNano()),
@@ -108,7 +184,8 @@ func (h *Handler) HandleCommand(ctx context.Context, cmd *cpTypes.Command) error
 		},
 	})
 
-	// Execute command in background
+	// Execute command in background; wg.Done is called inside executeCommand.
+	h.wg.Add(1)
 	go h.executeCommand(cmd)
 
 	return nil
@@ -116,6 +193,8 @@ func (h *Handler) HandleCommand(ctx context.Context, cmd *cpTypes.Command) error
 
 // executeCommand executes a command with timeout and error handling.
 func (h *Handler) executeCommand(cmd *cpTypes.Command) {
+	defer h.wg.Done()
+
 	h.logger.Info("Executing command",
 		"command_id", cmd.ID,
 		"type", cmd.Type,
@@ -130,16 +209,22 @@ func (h *Handler) executeCommand(cmd *cpTypes.Command) {
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 
-	// Track execution
+	// Track in-flight cancellation (CancelFunc only — not persisted).
 	h.mu.Lock()
-	h.executing[cmd.ID] = &executionContext{
-		CommandID: cmd.ID,
-		StartTime: time.Now(),
-		Cancel:    cancel,
-	}
+	h.executing[cmd.ID] = &executionContext{Cancel: cancel}
 	h.mu.Unlock()
 
-	// Clean up execution tracking
+	// Transition to executing state in the store.
+	if h.store != nil {
+		if err := h.store.UpdateCommandStatus(ctx, cmd.ID,
+			interfaces.CommandStatusExecuting, nil, ""); err != nil {
+			h.logger.Error("Failed to update command status to executing",
+				"command_id", cmd.ID,
+				"error", err)
+		}
+	}
+
+	// Clean up in-flight tracking on exit.
 	defer func() {
 		h.mu.Lock()
 		delete(h.executing, cmd.ID)
@@ -155,6 +240,15 @@ func (h *Handler) executeCommand(cmd *cpTypes.Command) {
 		h.logger.Error("No handler registered for command type",
 			"command_id", cmd.ID,
 			"type", cmd.Type)
+
+		if h.store != nil {
+			if err := h.store.UpdateCommandStatus(ctx, cmd.ID, interfaces.CommandStatusFailed, nil,
+				fmt.Sprintf("no handler for command type: %s", cmd.Type)); err != nil {
+				h.logger.Error("Failed to update command status to failed (no handler)",
+					"command_id", cmd.ID,
+					"error", err)
+			}
+		}
 
 		h.sendStatus(ctx, &cpTypes.Event{
 			ID:        fmt.Sprintf("evt_%d", time.Now().UnixNano()),
@@ -181,6 +275,15 @@ func (h *Handler) executeCommand(cmd *cpTypes.Command) {
 			"error", err.Error(),
 			"execution_time", executionTime)
 
+		if h.store != nil {
+			if storeErr := h.store.UpdateCommandStatus(ctx, cmd.ID,
+				interfaces.CommandStatusFailed, nil, err.Error()); storeErr != nil {
+				h.logger.Error("Failed to update command status to failed",
+					"command_id", cmd.ID,
+					"error", storeErr)
+			}
+		}
+
 		h.sendStatus(ctx, &cpTypes.Event{
 			ID:        fmt.Sprintf("evt_%d", time.Now().UnixNano()),
 			Type:      cpTypes.EventCommandFailed,
@@ -199,6 +302,18 @@ func (h *Handler) executeCommand(cmd *cpTypes.Command) {
 		"command_id", cmd.ID,
 		"type", cmd.Type,
 		"execution_time", executionTime)
+
+	if h.store != nil {
+		result := map[string]interface{}{
+			"execution_time_ms": executionTime.Milliseconds(),
+		}
+		if storeErr := h.store.UpdateCommandStatus(ctx, cmd.ID,
+			interfaces.CommandStatusCompleted, result, ""); storeErr != nil {
+			h.logger.Error("Failed to update command status to completed",
+				"command_id", cmd.ID,
+				"error", storeErr)
+		}
+	}
 
 	h.sendStatus(ctx, &cpTypes.Event{
 		ID:        fmt.Sprintf("evt_%d", time.Now().UnixNano()),

--- a/features/steward/commands/handler_test.go
+++ b/features/steward/commands/handler_test.go
@@ -1,0 +1,434 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+package commands
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	cpTypes "github.com/cfgis/cfgms/pkg/controlplane/types"
+	"github.com/cfgis/cfgms/pkg/logging"
+	"github.com/cfgis/cfgms/pkg/storage/interfaces"
+)
+
+// ---------------------------------------------------------------------------
+// In-memory CommandStore for tests (real implementation, no mocks)
+// ---------------------------------------------------------------------------
+
+// memCommandStore is a minimal in-memory CommandStore backed by maps.
+// It is a real implementation — not a mock.
+type memCommandStore struct {
+	mu          sync.Mutex
+	records     map[string]*interfaces.CommandRecord
+	transitions map[string][]*interfaces.CommandTransition
+
+	// updateErr, if non-nil, is returned by UpdateCommandStatus calls.
+	// Used for error-path testing.
+	updateErr error
+}
+
+func newMemCommandStore() *memCommandStore {
+	return &memCommandStore{
+		records:     make(map[string]*interfaces.CommandRecord),
+		transitions: make(map[string][]*interfaces.CommandTransition),
+	}
+}
+
+func (m *memCommandStore) CreateCommandRecord(_ context.Context, rec *interfaces.CommandRecord) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if rec == nil {
+		return fmt.Errorf("record is nil")
+	}
+	if rec.ID == "" {
+		return interfaces.ErrCommandIDRequired
+	}
+	if rec.StewardID == "" {
+		return interfaces.ErrCommandStewardIDRequired
+	}
+	if _, exists := m.records[rec.ID]; exists {
+		return fmt.Errorf("duplicate command ID: %s", rec.ID)
+	}
+	cp := *rec
+	cp.Status = interfaces.CommandStatusPending
+	if cp.IssuedAt.IsZero() {
+		cp.IssuedAt = time.Now()
+	}
+	m.records[rec.ID] = &cp
+	m.transitions[rec.ID] = append(m.transitions[rec.ID], &interfaces.CommandTransition{
+		CommandID: rec.ID,
+		Status:    interfaces.CommandStatusPending,
+		Timestamp: cp.IssuedAt,
+	})
+	return nil
+}
+
+func (m *memCommandStore) UpdateCommandStatus(_ context.Context, id string, status interfaces.CommandStatus, result map[string]interface{}, errMsg string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.updateErr != nil {
+		return m.updateErr
+	}
+	rec, ok := m.records[id]
+	if !ok {
+		return interfaces.ErrCommandNotFound
+	}
+	rec.Status = status
+	rec.ErrorMessage = errMsg
+	rec.Result = result
+	now := time.Now()
+	switch status {
+	case interfaces.CommandStatusExecuting:
+		rec.StartedAt = &now
+	case interfaces.CommandStatusCompleted, interfaces.CommandStatusFailed, interfaces.CommandStatusCancelled:
+		rec.CompletedAt = &now
+	}
+	m.transitions[id] = append(m.transitions[id], &interfaces.CommandTransition{
+		CommandID:    id,
+		Status:       status,
+		Timestamp:    now,
+		ErrorMessage: errMsg,
+	})
+	return nil
+}
+
+func (m *memCommandStore) GetCommandRecord(_ context.Context, id string) (*interfaces.CommandRecord, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	rec, ok := m.records[id]
+	if !ok {
+		return nil, interfaces.ErrCommandNotFound
+	}
+	cp := *rec
+	return &cp, nil
+}
+
+func (m *memCommandStore) ListCommandRecords(_ context.Context, filter *interfaces.CommandFilter) ([]*interfaces.CommandRecord, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	var out []*interfaces.CommandRecord
+	for _, rec := range m.records {
+		if filter != nil {
+			if filter.Status != "" && rec.Status != filter.Status {
+				continue
+			}
+			if filter.StewardID != "" && rec.StewardID != filter.StewardID {
+				continue
+			}
+		}
+		cp := *rec
+		out = append(out, &cp)
+	}
+	return out, nil
+}
+
+func (m *memCommandStore) ListCommandsByDevice(ctx context.Context, stewardID string) ([]*interfaces.CommandRecord, error) {
+	return m.ListCommandRecords(ctx, &interfaces.CommandFilter{StewardID: stewardID})
+}
+
+func (m *memCommandStore) ListCommandsByStatus(ctx context.Context, status interfaces.CommandStatus) ([]*interfaces.CommandRecord, error) {
+	return m.ListCommandRecords(ctx, &interfaces.CommandFilter{Status: status})
+}
+
+func (m *memCommandStore) GetCommandAuditTrail(_ context.Context, commandID string) ([]*interfaces.CommandTransition, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	transitions := m.transitions[commandID]
+	out := make([]*interfaces.CommandTransition, len(transitions))
+	copy(out, transitions)
+	return out, nil
+}
+
+func (m *memCommandStore) PurgeExpiredRecords(_ context.Context, _ time.Time) (int64, error) {
+	return 0, nil
+}
+
+func (m *memCommandStore) HealthCheck(_ context.Context) error { return nil }
+func (m *memCommandStore) Close() error                        { return nil }
+
+// Compile-time assertion.
+var _ interfaces.CommandStore = (*memCommandStore)(nil)
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+func newTestLogger(t *testing.T) logging.Logger {
+	t.Helper()
+	logger, err := logging.NewLogger(logging.Config{
+		Level:  "debug",
+		Format: "text",
+	})
+	require.NoError(t, err)
+	return logger
+}
+
+func noopStatus(_ context.Context, _ *cpTypes.Event) {}
+
+func newTestHandler(t *testing.T, store interfaces.CommandStore) *Handler {
+	t.Helper()
+	h, err := New(&Config{
+		StewardID: "steward-test",
+		OnStatus:  noopStatus,
+		Logger:    newTestLogger(t),
+		Store:     store,
+	})
+	require.NoError(t, err)
+	return h
+}
+
+func testCommand(id string, cmdType cpTypes.CommandType) *cpTypes.Command {
+	return &cpTypes.Command{
+		ID:        id,
+		Type:      cmdType,
+		StewardID: "steward-test",
+		Timestamp: time.Now(),
+		Params:    map[string]interface{}{},
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Constructor tests
+// ---------------------------------------------------------------------------
+
+func TestNew_RequiresStewardID(t *testing.T) {
+	_, err := New(&Config{
+		OnStatus: noopStatus,
+		Logger:   newTestLogger(t),
+	})
+	require.Error(t, err)
+}
+
+func TestNew_RequiresOnStatus(t *testing.T) {
+	_, err := New(&Config{
+		StewardID: "s1",
+		Logger:    newTestLogger(t),
+	})
+	require.Error(t, err)
+}
+
+func TestNew_RequiresLogger(t *testing.T) {
+	_, err := New(&Config{
+		StewardID: "s1",
+		OnStatus:  noopStatus,
+	})
+	require.Error(t, err)
+}
+
+func TestNew_NilStoreAllowed(t *testing.T) {
+	h, err := New(&Config{
+		StewardID: "s1",
+		OnStatus:  noopStatus,
+		Logger:    newTestLogger(t),
+		Store:     nil,
+	})
+	require.NoError(t, err)
+	assert.NotNil(t, h)
+}
+
+// ---------------------------------------------------------------------------
+// Startup sweep test
+// ---------------------------------------------------------------------------
+
+func TestNew_SweepsStaleExecutingCommands(t *testing.T) {
+	store := newMemCommandStore()
+	ctx := context.Background()
+
+	// Pre-populate an executing record to simulate a crashed previous run.
+	rec := &interfaces.CommandRecord{
+		ID:        "stale-cmd",
+		Type:      "sync_config",
+		StewardID: "steward-test",
+	}
+	require.NoError(t, store.CreateCommandRecord(ctx, rec))
+	require.NoError(t, store.UpdateCommandStatus(ctx, "stale-cmd",
+		interfaces.CommandStatusExecuting, nil, ""))
+
+	// Creating the handler should trigger the startup sweep.
+	_, err := New(&Config{
+		StewardID: "steward-test",
+		OnStatus:  noopStatus,
+		Logger:    newTestLogger(t),
+		Store:     store,
+	})
+	require.NoError(t, err)
+
+	got, err := store.GetCommandRecord(ctx, "stale-cmd")
+	require.NoError(t, err)
+	assert.Equal(t, interfaces.CommandStatusFailed, got.Status)
+	assert.Equal(t, "controller_restart", got.ErrorMessage)
+}
+
+// ---------------------------------------------------------------------------
+// HandleCommand / executeCommand tests
+// Use h.Wait() for deterministic synchronization — no time.Sleep.
+// ---------------------------------------------------------------------------
+
+func TestHandleCommand_PersistsRecord(t *testing.T) {
+	store := newMemCommandStore()
+	h := newTestHandler(t, store)
+	ctx := context.Background()
+
+	cmd := testCommand("hc-001", cpTypes.CommandSyncConfig)
+
+	// Register a no-op handler so execution succeeds.
+	h.RegisterHandler(cpTypes.CommandSyncConfig, func(ctx context.Context, c *cpTypes.Command) error {
+		return nil
+	})
+
+	require.NoError(t, h.HandleCommand(ctx, cmd))
+	h.Wait() // synchronise with the goroutine
+
+	got, err := store.GetCommandRecord(ctx, "hc-001")
+	require.NoError(t, err)
+	assert.Equal(t, interfaces.CommandStatusCompleted, got.Status)
+}
+
+func TestHandleCommand_NoHandlerMarkedFailed(t *testing.T) {
+	store := newMemCommandStore()
+	h := newTestHandler(t, store)
+	ctx := context.Background()
+
+	cmd := testCommand("hc-002", cpTypes.CommandSyncConfig)
+	// No handler registered — should fail.
+	require.NoError(t, h.HandleCommand(ctx, cmd))
+	h.Wait()
+
+	got, err := store.GetCommandRecord(ctx, "hc-002")
+	require.NoError(t, err)
+	assert.Equal(t, interfaces.CommandStatusFailed, got.Status)
+}
+
+func TestHandleCommand_HandlerErrorMarkedFailed(t *testing.T) {
+	store := newMemCommandStore()
+	h := newTestHandler(t, store)
+	ctx := context.Background()
+
+	h.RegisterHandler(cpTypes.CommandSyncConfig, func(ctx context.Context, c *cpTypes.Command) error {
+		return fmt.Errorf("something went wrong")
+	})
+
+	cmd := testCommand("hc-003", cpTypes.CommandSyncConfig)
+	require.NoError(t, h.HandleCommand(ctx, cmd))
+	h.Wait()
+
+	got, err := store.GetCommandRecord(ctx, "hc-003")
+	require.NoError(t, err)
+	assert.Equal(t, interfaces.CommandStatusFailed, got.Status)
+	assert.Contains(t, got.ErrorMessage, "something went wrong")
+}
+
+// ---------------------------------------------------------------------------
+// UpdateCommandStatus error-path tests
+// Verifies the handler does not panic or swallow store errors silently.
+// ---------------------------------------------------------------------------
+
+func TestHandleCommand_StoreUpdateErrorOnExecuting_DoesNotPanic(t *testing.T) {
+	store := newMemCommandStore()
+	// Inject a store error — UpdateCommandStatus will fail after CreateCommandRecord succeeds.
+	store.updateErr = fmt.Errorf("store unavailable")
+
+	h := newTestHandler(t, store)
+	ctx := context.Background()
+
+	h.RegisterHandler(cpTypes.CommandSyncConfig, func(ctx context.Context, c *cpTypes.Command) error {
+		return nil
+	})
+
+	cmd := testCommand("err-001", cpTypes.CommandSyncConfig)
+	require.NoError(t, h.HandleCommand(ctx, cmd))
+	h.Wait() // must not panic even when store returns errors
+}
+
+func TestHandleCommand_StoreUpdateErrorOnFailed_DoesNotPanic(t *testing.T) {
+	store := newMemCommandStore()
+	store.updateErr = fmt.Errorf("store unavailable")
+
+	h := newTestHandler(t, store)
+	ctx := context.Background()
+	// No handler registered; will try to write "failed" to store.
+	cmd := testCommand("err-002", cpTypes.CommandSyncConfig)
+	require.NoError(t, h.HandleCommand(ctx, cmd))
+	h.Wait()
+}
+
+func TestHandleCommand_StoreUpdateErrorOnCompleted_DoesNotPanic(t *testing.T) {
+	store := newMemCommandStore()
+	store.updateErr = fmt.Errorf("store unavailable")
+
+	h := newTestHandler(t, store)
+	ctx := context.Background()
+
+	h.RegisterHandler(cpTypes.CommandSyncConfig, func(ctx context.Context, c *cpTypes.Command) error {
+		return nil
+	})
+
+	cmd := testCommand("err-003", cpTypes.CommandSyncConfig)
+	require.NoError(t, h.HandleCommand(ctx, cmd))
+	h.Wait()
+}
+
+// ---------------------------------------------------------------------------
+// executionContext retains only CancelFunc — behavioral verification
+// ---------------------------------------------------------------------------
+
+func TestExecutionContext_CancelFuncIsInvokable(t *testing.T) {
+	// Verify that an executionContext's Cancel function can be invoked and cancels
+	// a context derived from context.WithCancel. This tests the actual runtime
+	// behaviour of the cancel mechanism, not struct field layout.
+	ctx, cancel := context.WithCancel(context.Background())
+	ec := &executionContext{Cancel: cancel}
+
+	// The context should not be cancelled yet.
+	select {
+	case <-ctx.Done():
+		t.Fatal("context should not be done before Cancel() is called")
+	default:
+	}
+
+	ec.Cancel()
+
+	// After Cancel(), the context must be done.
+	select {
+	case <-ctx.Done():
+		// expected
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("context was not cancelled after executionContext.Cancel() was called")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// CancelCommand / GetExecutingCommands
+// ---------------------------------------------------------------------------
+
+func TestCancelCommand_NotFound(t *testing.T) {
+	h := newTestHandler(t, nil)
+	err := h.CancelCommand("nonexistent")
+	require.Error(t, err)
+}
+
+func TestGetExecutingCommands_Empty(t *testing.T) {
+	h := newTestHandler(t, nil)
+	cmds := h.GetExecutingCommands()
+	assert.Empty(t, cmds)
+}
+
+func TestHandleCommand_NilStore_StillWorks(t *testing.T) {
+	// When store is nil the handler must operate normally without panicking.
+	h := newTestHandler(t, nil)
+	ctx := context.Background()
+
+	h.RegisterHandler(cpTypes.CommandSyncConfig, func(ctx context.Context, c *cpTypes.Command) error {
+		return nil
+	})
+
+	cmd := testCommand("no-store-001", cpTypes.CommandSyncConfig)
+	require.NoError(t, h.HandleCommand(ctx, cmd))
+	h.Wait() // deterministic synchronization — no panic
+}

--- a/features/steward/commands/handler_test.go
+++ b/features/steward/commands/handler_test.go
@@ -161,12 +161,7 @@ var _ interfaces.CommandStore = (*memCommandStore)(nil)
 
 func newTestLogger(t *testing.T) logging.Logger {
 	t.Helper()
-	logger, err := logging.NewLogger(logging.Config{
-		Level:  "debug",
-		Format: "text",
-	})
-	require.NoError(t, err)
-	return logger
+	return logging.NewLogger("debug")
 }
 
 func noopStatus(_ context.Context, _ *cpTypes.Event) {}

--- a/features/workflow/trigger/integration_test.go
+++ b/features/workflow/trigger/integration_test.go
@@ -146,6 +146,10 @@ func (t *TestStorageProvider) CreateStewardStore(_ map[string]interface{}) (inte
 	return nil, interfaces.ErrNotSupported
 }
 
+func (t *TestStorageProvider) CreateCommandStore(_ map[string]interface{}) (interfaces.CommandStore, error) {
+	return nil, interfaces.ErrNotSupported
+}
+
 func (t *TestStorageProvider) GetCapabilities() interfaces.ProviderCapabilities {
 	return interfaces.ProviderCapabilities{
 		MaxBatchSize:          100,

--- a/features/workflow/trigger/manager_test.go
+++ b/features/workflow/trigger/manager_test.go
@@ -113,6 +113,10 @@ func (m *MockStorageProvider) CreateStewardStore(_ map[string]interface{}) (inte
 	return nil, interfaces.ErrNotSupported
 }
 
+func (m *MockStorageProvider) CreateCommandStore(_ map[string]interface{}) (interfaces.CommandStore, error) {
+	return nil, interfaces.ErrNotSupported
+}
+
 func (m *MockStorageProvider) GetCapabilities() interfaces.ProviderCapabilities {
 	args := m.Called()
 	return args.Get(0).(interfaces.ProviderCapabilities)

--- a/pkg/storage/interfaces/README.md
+++ b/pkg/storage/interfaces/README.md
@@ -25,6 +25,7 @@ The files in this directory today:
 | `runtime_store.go` | `RuntimeStore` | Ephemeral/session runtime state |
 | `session_store.go` | `SessionStore` | Durable session state (persistent sessions only; ephemeral state lives in `pkg/cache`) |
 | `steward_store.go` | `StewardStore` | Durable fleet registry (steward status, last_seen, heartbeat); implemented by flat-file and SQLite providers |
+| `command_store.go` | `CommandStore` | Durable command dispatch state (status, audit trail); implemented by SQLite provider (Issue #665) |
 | `hybrid_manager.go` | `HybridStorageManager` | Composes multiple provider instances |
 
 ## Target Layout (per ADR-003)

--- a/pkg/storage/interfaces/command_store.go
+++ b/pkg/storage/interfaces/command_store.go
@@ -1,0 +1,130 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+// Package interfaces defines global storage contracts used by all CFGMS modules
+package interfaces
+
+import (
+	"context"
+	"time"
+)
+
+// CommandStatus is a typed string enum for command execution states.
+type CommandStatus string
+
+const (
+	CommandStatusPending   CommandStatus = "pending"
+	CommandStatusExecuting CommandStatus = "executing"
+	CommandStatusCompleted CommandStatus = "completed"
+	CommandStatusFailed    CommandStatus = "failed"
+	CommandStatusCancelled CommandStatus = "cancelled"
+)
+
+// CommandRecord persists the full lifecycle of a command dispatched to a steward.
+// It is the durable state backing the steward command handler so that dispatch
+// state survives a process restart and forms a crash-survivable audit trail.
+type CommandRecord struct {
+	ID           string                 `json:"id"`
+	Type         string                 `json:"type"`
+	StewardID    string                 `json:"steward_id"`
+	TenantID     string                 `json:"tenant_id"`
+	Payload      map[string]interface{} `json:"payload,omitempty"`
+	Status       CommandStatus          `json:"status"`
+	IssuedAt     time.Time              `json:"issued_at"`
+	StartedAt    *time.Time             `json:"started_at,omitempty"`
+	CompletedAt  *time.Time             `json:"completed_at,omitempty"`
+	Result       map[string]interface{} `json:"result,omitempty"`
+	ErrorMessage string                 `json:"error_message,omitempty"`
+	IssuedBy     string                 `json:"issued_by,omitempty"`
+}
+
+// CommandTransition records a single state change in the command audit trail.
+// Transitions are immutable — once recorded they are never updated or deleted
+// by anything other than PurgeExpiredRecords (which purges by parent record age).
+type CommandTransition struct {
+	CommandID    string        `json:"command_id"`
+	Status       CommandStatus `json:"status"`
+	Timestamp    time.Time     `json:"timestamp"`
+	ErrorMessage string        `json:"error_message,omitempty"`
+}
+
+// CommandFilter constrains ListCommandRecords queries.
+type CommandFilter struct {
+	StewardID string        // filter by steward
+	TenantID  string        // filter by tenant
+	Status    CommandStatus // filter by status ("" = all)
+	IssuedBy  string        // filter by issuer
+	Limit     int           // 0 = no limit
+	Offset    int
+}
+
+// CommandStore defines the storage interface for command dispatch state.
+// Implementations must be safe for concurrent use.
+type CommandStore interface {
+	// CreateCommandRecord creates a new command record.
+	// The record must have a non-empty ID; status is set to pending on creation.
+	// A corresponding transition entry is recorded for audit purposes.
+	CreateCommandRecord(ctx context.Context, record *CommandRecord) error
+
+	// UpdateCommandStatus transitions a command to a new status.
+	// result is serialised to JSON and stored in the result column.
+	// A corresponding transition entry is appended to the audit trail.
+	UpdateCommandStatus(ctx context.Context, id string, status CommandStatus, result map[string]interface{}, errorMessage string) error
+
+	// GetCommandRecord retrieves the current state of a command by ID.
+	GetCommandRecord(ctx context.Context, id string) (*CommandRecord, error)
+
+	// ListCommandRecords returns commands matching the optional filter.
+	ListCommandRecords(ctx context.Context, filter *CommandFilter) ([]*CommandRecord, error)
+
+	// ListCommandsByDevice returns all commands dispatched to the given steward.
+	ListCommandsByDevice(ctx context.Context, stewardID string) ([]*CommandRecord, error)
+
+	// ListCommandsByStatus returns all commands in the given status.
+	ListCommandsByStatus(ctx context.Context, status CommandStatus) ([]*CommandRecord, error)
+
+	// GetCommandAuditTrail returns all state transitions for a command in
+	// chronological order (oldest first). The initial creation counts as the
+	// first transition (status = pending).
+	GetCommandAuditTrail(ctx context.Context, commandID string) ([]*CommandTransition, error)
+
+	// PurgeExpiredRecords deletes commands in completed or failed status whose
+	// issued_at is older than olderThan. Executing and pending records are never
+	// purged. Returns the number of records deleted.
+	PurgeExpiredRecords(ctx context.Context, olderThan time.Time) (int64, error)
+
+	// HealthCheck verifies the store is operational.
+	HealthCheck(ctx context.Context) error
+
+	// Close releases the store's resources.
+	Close() error
+}
+
+// Common CommandStore errors.
+var (
+	ErrCommandNotFound = &CommandValidationError{
+		Field:   "id",
+		Message: "command record not found",
+		Code:    "COMMAND_NOT_FOUND",
+	}
+	ErrCommandIDRequired = &CommandValidationError{
+		Field:   "id",
+		Message: "command ID is required",
+		Code:    "COMMAND_ID_REQUIRED",
+	}
+	ErrCommandStewardIDRequired = &CommandValidationError{
+		Field:   "steward_id",
+		Message: "steward ID is required",
+		Code:    "COMMAND_STEWARD_ID_REQUIRED",
+	}
+)
+
+// CommandValidationError represents a validation failure for CommandStore operations.
+type CommandValidationError struct {
+	Field   string `json:"field"`
+	Message string `json:"message"`
+	Code    string `json:"code"`
+}
+
+func (e *CommandValidationError) Error() string {
+	return e.Field + ": " + e.Message
+}

--- a/pkg/storage/interfaces/hybrid_manager_test.go
+++ b/pkg/storage/interfaces/hybrid_manager_test.go
@@ -354,6 +354,10 @@ func (p *mockProvider) CreateStewardStore(config map[string]interface{}) (Stewar
 	return nil, ErrNotSupported
 }
 
+func (p *mockProvider) CreateCommandStore(config map[string]interface{}) (CommandStore, error) {
+	return nil, ErrNotSupported
+}
+
 func (p *mockProvider) GetCapabilities() ProviderCapabilities {
 	return ProviderCapabilities{
 		SupportsTransactions:   true,

--- a/pkg/storage/interfaces/provider.go
+++ b/pkg/storage/interfaces/provider.go
@@ -26,6 +26,7 @@ type StorageProvider interface {
 	CreateRegistrationTokenStore(config map[string]interface{}) (RegistrationTokenStore, error)
 	CreateSessionStore(config map[string]interface{}) (SessionStore, error)
 	CreateStewardStore(config map[string]interface{}) (StewardStore, error)
+	CreateCommandStore(config map[string]interface{}) (CommandStore, error)
 
 	// Future: CreateDNAStore for DNA storage integration (Epic 6)
 	// CreateDNAStore(config map[string]interface{}) (DNAStore, error)
@@ -435,6 +436,11 @@ func CreateAllStoresFromConfig(providerName string, config map[string]interface{
 		return nil, fmt.Errorf("failed to create steward store: %w", err)
 	}
 
+	commandStore, err := provider.CreateCommandStore(config)
+	if err != nil && err != ErrNotSupported {
+		return nil, fmt.Errorf("failed to create command store: %w", err)
+	}
+
 	return &StorageManager{
 		providerName:           providerName,
 		provider:               provider,
@@ -447,7 +453,17 @@ func CreateAllStoresFromConfig(providerName string, config map[string]interface{
 		registrationTokenStore: registrationTokenStore,
 		sessionStore:           sessionStore,
 		stewardStore:           stewardStore,
+		commandStore:           commandStore,
 	}, nil
+}
+
+// CreateCommandStoreFromConfig creates a CommandStore from configuration.
+func CreateCommandStoreFromConfig(providerName string, config map[string]interface{}) (CommandStore, error) {
+	provider, err := GetStorageProvider(providerName)
+	if err != nil {
+		return nil, fmt.Errorf("storage provider '%s' not available: %w", providerName, err)
+	}
+	return provider.CreateCommandStore(config)
 }
 
 // StorageManager provides unified access to all storage interfaces
@@ -463,6 +479,7 @@ type StorageManager struct {
 	registrationTokenStore RegistrationTokenStore
 	sessionStore           SessionStore
 	stewardStore           StewardStore
+	commandStore           CommandStore
 }
 
 // GetProviderName returns the name of the storage provider
@@ -518,6 +535,11 @@ func (sm *StorageManager) GetSessionStore() SessionStore {
 // GetStewardStore returns the steward fleet registry interface (nil if not supported by provider)
 func (sm *StorageManager) GetStewardStore() StewardStore {
 	return sm.stewardStore
+}
+
+// GetCommandStore returns the command dispatch state interface (nil if not supported by provider)
+func (sm *StorageManager) GetCommandStore() CommandStore {
+	return sm.commandStore
 }
 
 // GetCapabilities returns the provider's capabilities

--- a/pkg/storage/interfaces/provider_test.go
+++ b/pkg/storage/interfaces/provider_test.go
@@ -98,6 +98,10 @@ func (m *MockStorageProvider) CreateStewardStore(config map[string]interface{}) 
 	return nil, ErrNotSupported
 }
 
+func (m *MockStorageProvider) CreateCommandStore(config map[string]interface{}) (CommandStore, error) {
+	return nil, ErrNotSupported
+}
+
 // Mock implementations of store interfaces
 type MockClientTenantStore struct{}
 

--- a/pkg/storage/providers/database/plugin.go
+++ b/pkg/storage/providers/database/plugin.go
@@ -193,6 +193,12 @@ func (p *DatabaseProvider) CreateStewardStore(config map[string]interface{}) (in
 	return nil, interfaces.ErrNotSupported
 }
 
+// CreateCommandStore is not supported by the database provider.
+// Command dispatch state belongs in the business-data tier (SQLite for OSS).
+func (p *DatabaseProvider) CreateCommandStore(config map[string]interface{}) (interfaces.CommandStore, error) {
+	return nil, interfaces.ErrNotSupported
+}
+
 func (p *DatabaseProvider) CreateRegistrationTokenStore(config map[string]interface{}) (interfaces.RegistrationTokenStore, error) {
 	// Get database connection string from config
 	dsn, err := p.getDSN(config)

--- a/pkg/storage/providers/database/plugin_test.go
+++ b/pkg/storage/providers/database/plugin_test.go
@@ -472,6 +472,15 @@ func TestDatabaseProvider_ErrorHandling(t *testing.T) {
 	assert.Contains(t, err.Error(), "password is required")
 }
 
+func TestDatabaseProvider_CreateCommandStoreReturnsErrNotSupported(t *testing.T) {
+	provider := &DatabaseProvider{}
+
+	store, err := provider.CreateCommandStore(map[string]interface{}{})
+	assert.Nil(t, store)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, interfaces.ErrNotSupported)
+}
+
 func TestUtilityFunctions(t *testing.T) {
 	// Test getStringFromConfig
 	config := map[string]interface{}{

--- a/pkg/storage/providers/flatfile/plugin.go
+++ b/pkg/storage/providers/flatfile/plugin.go
@@ -200,6 +200,12 @@ func (p *FlatFileProvider) CreateStewardStore(config map[string]interface{}) (in
 	return store, nil
 }
 
+// CreateCommandStore returns ErrNotSupported.
+// Command dispatch state belongs in the business-data tier (SQLite).
+func (p *FlatFileProvider) CreateCommandStore(config map[string]interface{}) (interfaces.CommandStore, error) {
+	return nil, ErrNotSupported
+}
+
 // init auto-registers the flat-file provider so that a blank import is sufficient.
 func init() {
 	interfaces.RegisterStorageProvider(&FlatFileProvider{})

--- a/pkg/storage/providers/flatfile/plugin_test.go
+++ b/pkg/storage/providers/flatfile/plugin_test.go
@@ -113,6 +113,13 @@ func TestUnsupportedStoresReturnErrNotSupported(t *testing.T) {
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "not supported")
 	})
+
+	t.Run("CreateCommandStore", func(t *testing.T) {
+		store, err := p.CreateCommandStore(cfg)
+		assert.Nil(t, store)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not supported")
+	})
 }
 
 func TestCreateConfigStoreRequiresRoot(t *testing.T) {

--- a/pkg/storage/providers/git/plugin.go
+++ b/pkg/storage/providers/git/plugin.go
@@ -222,6 +222,12 @@ func (p *GitProvider) CreateStewardStore(config map[string]interface{}) (interfa
 	return nil, interfaces.ErrNotSupported
 }
 
+// CreateCommandStore is not supported by the git provider.
+// Command dispatch state belongs in the business-data tier (SQLite).
+func (p *GitProvider) CreateCommandStore(config map[string]interface{}) (interfaces.CommandStore, error) {
+	return nil, interfaces.ErrNotSupported
+}
+
 // Auto-register this provider (Salt-style)
 func init() {
 	interfaces.RegisterStorageProvider(&GitProvider{})

--- a/pkg/storage/providers/git/plugin_test.go
+++ b/pkg/storage/providers/git/plugin_test.go
@@ -828,6 +828,15 @@ func TestGitProvider_CreateStores(t *testing.T) {
 	assert.NotNil(t, auditStore)
 }
 
+func TestGitProvider_CreateCommandStoreReturnsErrNotSupported(t *testing.T) {
+	provider := &GitProvider{}
+
+	store, err := provider.CreateCommandStore(map[string]interface{}{})
+	assert.Nil(t, store)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, interfaces.ErrNotSupported)
+}
+
 func TestGitConfigStore_ErrorCases(t *testing.T) {
 	tempDir := t.TempDir()
 	repoPath := filepath.Join(tempDir, "test-error-repo")

--- a/pkg/storage/providers/sqlite/command_store.go
+++ b/pkg/storage/providers/sqlite/command_store.go
@@ -1,0 +1,405 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+// Package sqlite implements CommandStore using SQLite for durable command dispatch state.
+package sqlite
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"time"
+
+	"github.com/cfgis/cfgms/pkg/storage/interfaces"
+)
+
+// SQLiteCommandStore implements interfaces.CommandStore using a SQLite database.
+// Command records and their audit trail are stored in the `commands` and
+// `command_transitions` tables, which are created by initializeSchema.
+type SQLiteCommandStore struct {
+	db *sql.DB
+}
+
+// Compile-time assertion that SQLiteCommandStore satisfies CommandStore.
+var _ interfaces.CommandStore = (*SQLiteCommandStore)(nil)
+
+// Initialize is a no-op; schema is applied in openAndInit before this store is returned.
+func (s *SQLiteCommandStore) Initialize(_ context.Context) error { return nil }
+
+// Close closes the underlying database connection.
+func (s *SQLiteCommandStore) Close() error {
+	if s.db != nil {
+		return s.db.Close()
+	}
+	return nil
+}
+
+// CreateCommandRecord inserts a new command record with status=pending and records
+// the initial transition in the audit trail.
+func (s *SQLiteCommandStore) CreateCommandRecord(ctx context.Context, record *interfaces.CommandRecord) error {
+	if record == nil {
+		return fmt.Errorf("sqlite: command record cannot be nil")
+	}
+	if record.ID == "" {
+		return interfaces.ErrCommandIDRequired
+	}
+	if record.StewardID == "" {
+		return interfaces.ErrCommandStewardIDRequired
+	}
+
+	now := nowUTC()
+	if record.IssuedAt.IsZero() {
+		record.IssuedAt = now
+	}
+	// Always start in pending state.
+	record.Status = interfaces.CommandStatusPending
+
+	payload, err := marshalJSON(record.Payload)
+	if err != nil {
+		return fmt.Errorf("sqlite: failed to marshal command payload: %w", err)
+	}
+	result, err := marshalJSON(record.Result)
+	if err != nil {
+		return fmt.Errorf("sqlite: failed to marshal command result: %w", err)
+	}
+
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("sqlite: failed to begin transaction: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	_, err = tx.ExecContext(ctx, `
+		INSERT INTO commands
+			(id, type, steward_id, tenant_id, payload, status,
+			 issued_at, started_at, completed_at, result, error_message, issued_by)
+		VALUES (?, ?, ?, ?, ?, ?, ?, NULL, NULL, ?, ?, ?)`,
+		record.ID,
+		record.Type,
+		record.StewardID,
+		record.TenantID,
+		payload,
+		string(interfaces.CommandStatusPending),
+		formatTime(record.IssuedAt),
+		result,
+		record.ErrorMessage,
+		record.IssuedBy,
+	)
+	if err != nil {
+		return fmt.Errorf("sqlite: failed to create command record %s: %w", record.ID, err)
+	}
+
+	// Record initial transition (creation counts as first audit entry).
+	if err := insertTransition(ctx, tx, record.ID, interfaces.CommandStatusPending, now, ""); err != nil {
+		return err
+	}
+
+	return tx.Commit()
+}
+
+// UpdateCommandStatus transitions a command to the given status and appends a
+// transition entry to the audit trail.
+func (s *SQLiteCommandStore) UpdateCommandStatus(
+	ctx context.Context,
+	id string,
+	status interfaces.CommandStatus,
+	result map[string]interface{},
+	errorMessage string,
+) error {
+	if id == "" {
+		return interfaces.ErrCommandIDRequired
+	}
+
+	now := nowUTC()
+
+	resultJSON, err := marshalJSON(result)
+	if err != nil {
+		return fmt.Errorf("sqlite: failed to marshal command result: %w", err)
+	}
+
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("sqlite: failed to begin transaction: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	// Build the UPDATE: set timestamps based on the new status.
+	var res sql.Result
+	switch status {
+	case interfaces.CommandStatusExecuting:
+		res, err = tx.ExecContext(ctx, `
+			UPDATE commands SET status = ?, started_at = ?, result = ?, error_message = ?
+			WHERE id = ?`,
+			string(status), formatTime(now), resultJSON, errorMessage, id)
+	case interfaces.CommandStatusCompleted, interfaces.CommandStatusFailed, interfaces.CommandStatusCancelled:
+		res, err = tx.ExecContext(ctx, `
+			UPDATE commands SET status = ?, completed_at = ?, result = ?, error_message = ?
+			WHERE id = ?`,
+			string(status), formatTime(now), resultJSON, errorMessage, id)
+	default:
+		res, err = tx.ExecContext(ctx, `
+			UPDATE commands SET status = ?, result = ?, error_message = ?
+			WHERE id = ?`,
+			string(status), resultJSON, errorMessage, id)
+	}
+	if err != nil {
+		return fmt.Errorf("sqlite: failed to update command %s: %w", id, err)
+	}
+	n, _ := res.RowsAffected()
+	if n == 0 {
+		return interfaces.ErrCommandNotFound
+	}
+
+	if err := insertTransition(ctx, tx, id, status, now, errorMessage); err != nil {
+		return err
+	}
+
+	return tx.Commit()
+}
+
+// GetCommandRecord retrieves the current state of a command by ID.
+func (s *SQLiteCommandStore) GetCommandRecord(ctx context.Context, id string) (*interfaces.CommandRecord, error) {
+	if id == "" {
+		return nil, interfaces.ErrCommandIDRequired
+	}
+
+	row := s.db.QueryRowContext(ctx, `
+		SELECT id, type, steward_id, tenant_id, payload, status,
+		       issued_at, started_at, completed_at, result, error_message, issued_by
+		FROM commands WHERE id = ?`, id)
+
+	return scanCommandRecord(row)
+}
+
+// ListCommandRecords returns commands matching the optional filter.
+func (s *SQLiteCommandStore) ListCommandRecords(ctx context.Context, filter *interfaces.CommandFilter) ([]*interfaces.CommandRecord, error) {
+	query := `
+		SELECT id, type, steward_id, tenant_id, payload, status,
+		       issued_at, started_at, completed_at, result, error_message, issued_by
+		FROM commands WHERE 1=1`
+	var args []interface{}
+
+	if filter != nil {
+		if filter.StewardID != "" {
+			query += ` AND steward_id = ?`
+			args = append(args, filter.StewardID)
+		}
+		if filter.TenantID != "" {
+			query += ` AND tenant_id = ?`
+			args = append(args, filter.TenantID)
+		}
+		if filter.Status != "" {
+			query += ` AND status = ?`
+			args = append(args, string(filter.Status))
+		}
+		if filter.IssuedBy != "" {
+			query += ` AND issued_by = ?`
+			args = append(args, filter.IssuedBy)
+		}
+	}
+
+	query += ` ORDER BY issued_at DESC`
+
+	if filter != nil && filter.Limit > 0 {
+		query += ` LIMIT ?`
+		args = append(args, filter.Limit)
+		if filter.Offset > 0 {
+			query += ` OFFSET ?`
+			args = append(args, filter.Offset)
+		}
+	}
+
+	rows, err := s.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("sqlite: failed to list commands: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var records []*interfaces.CommandRecord
+	for rows.Next() {
+		rec, err := scanCommandRow(rows)
+		if err != nil {
+			return nil, err
+		}
+		records = append(records, rec)
+	}
+	return records, rows.Err()
+}
+
+// ListCommandsByDevice returns all commands dispatched to the given steward.
+func (s *SQLiteCommandStore) ListCommandsByDevice(ctx context.Context, stewardID string) ([]*interfaces.CommandRecord, error) {
+	return s.ListCommandRecords(ctx, &interfaces.CommandFilter{StewardID: stewardID})
+}
+
+// ListCommandsByStatus returns all commands in the given status.
+func (s *SQLiteCommandStore) ListCommandsByStatus(ctx context.Context, status interfaces.CommandStatus) ([]*interfaces.CommandRecord, error) {
+	return s.ListCommandRecords(ctx, &interfaces.CommandFilter{Status: status})
+}
+
+// GetCommandAuditTrail returns all state transitions for the command in
+// chronological order (oldest first).
+func (s *SQLiteCommandStore) GetCommandAuditTrail(ctx context.Context, commandID string) ([]*interfaces.CommandTransition, error) {
+	if commandID == "" {
+		return nil, interfaces.ErrCommandIDRequired
+	}
+
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT command_id, status, timestamp, error_message
+		FROM command_transitions
+		WHERE command_id = ?
+		ORDER BY id ASC`, commandID)
+	if err != nil {
+		return nil, fmt.Errorf("sqlite: failed to query audit trail for %s: %w", commandID, err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var transitions []*interfaces.CommandTransition
+	for rows.Next() {
+		var t interfaces.CommandTransition
+		var tsStr, statusStr string
+		if err := rows.Scan(&t.CommandID, &statusStr, &tsStr, &t.ErrorMessage); err != nil {
+			return nil, fmt.Errorf("sqlite: failed to scan transition: %w", err)
+		}
+		t.Status = interfaces.CommandStatus(statusStr)
+		t.Timestamp = parseTime(tsStr)
+		transitions = append(transitions, &t)
+	}
+	return transitions, rows.Err()
+}
+
+// PurgeExpiredRecords deletes completed or failed commands whose issued_at is
+// older than olderThan. Executing and pending records are never purged.
+// Returns the count of command records deleted.
+func (s *SQLiteCommandStore) PurgeExpiredRecords(ctx context.Context, olderThan time.Time) (int64, error) {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return 0, fmt.Errorf("sqlite: failed to begin purge transaction: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	cutoff := formatTime(olderThan)
+
+	// First collect IDs to purge so we can also remove their transitions.
+	rows, err := tx.QueryContext(ctx, `
+		SELECT id FROM commands
+		WHERE status IN ('completed', 'failed', 'cancelled')
+		  AND issued_at < ?`, cutoff)
+	if err != nil {
+		return 0, fmt.Errorf("sqlite: failed to query expired commands: %w", err)
+	}
+
+	var ids []interface{}
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			_ = rows.Close()
+			return 0, fmt.Errorf("sqlite: failed to scan expired command id: %w", err)
+		}
+		ids = append(ids, id)
+	}
+	if err := rows.Close(); err != nil {
+		return 0, fmt.Errorf("sqlite: rows close error: %w", err)
+	}
+
+	if len(ids) == 0 {
+		return 0, tx.Commit()
+	}
+
+	// Delete transitions first (no FK constraint, but keep data consistent).
+	for _, id := range ids {
+		if _, err := tx.ExecContext(ctx, `DELETE FROM command_transitions WHERE command_id = ?`, id); err != nil {
+			return 0, fmt.Errorf("sqlite: failed to delete transitions for %v: %w", id, err)
+		}
+	}
+
+	// Delete the command records.
+	res, err := tx.ExecContext(ctx, `
+		DELETE FROM commands
+		WHERE status IN ('completed', 'failed', 'cancelled')
+		  AND issued_at < ?`, cutoff)
+	if err != nil {
+		return 0, fmt.Errorf("sqlite: failed to purge expired commands: %w", err)
+	}
+
+	n, _ := res.RowsAffected()
+	return n, tx.Commit()
+}
+
+// HealthCheck verifies the store is operational.
+func (s *SQLiteCommandStore) HealthCheck(ctx context.Context) error {
+	var dummy int
+	return s.db.QueryRowContext(ctx, `SELECT 1`).Scan(&dummy)
+}
+
+// ---- internal helpers -------------------------------------------------------
+
+// insertTransition appends a single row to command_transitions within tx.
+func insertTransition(ctx context.Context, tx *sql.Tx, commandID string, status interfaces.CommandStatus, ts time.Time, errorMessage string) error {
+	_, err := tx.ExecContext(ctx, `
+		INSERT INTO command_transitions (command_id, status, timestamp, error_message)
+		VALUES (?, ?, ?, ?)`,
+		commandID, string(status), formatTime(ts), errorMessage)
+	if err != nil {
+		return fmt.Errorf("sqlite: failed to insert command transition for %s: %w", commandID, err)
+	}
+	return nil
+}
+
+// scanCommandRecord scans a *sql.Row (single QueryRow result) into a CommandRecord.
+func scanCommandRecord(row *sql.Row) (*interfaces.CommandRecord, error) {
+	var rec interfaces.CommandRecord
+	var payloadStr, statusStr, issuedAtStr, resultStr string
+	var startedAt, completedAt sql.NullString
+
+	err := row.Scan(
+		&rec.ID, &rec.Type, &rec.StewardID, &rec.TenantID,
+		&payloadStr, &statusStr,
+		&issuedAtStr, &startedAt, &completedAt,
+		&resultStr, &rec.ErrorMessage, &rec.IssuedBy,
+	)
+	if err == sql.ErrNoRows {
+		return nil, interfaces.ErrCommandNotFound
+	}
+	if err != nil {
+		return nil, fmt.Errorf("sqlite: failed to scan command record: %w", err)
+	}
+	return populateCommandRecord(&rec, payloadStr, statusStr, issuedAtStr, startedAt, completedAt, resultStr)
+}
+
+// scanCommandRow scans a *sql.Rows (multi-row Query result) into a CommandRecord.
+func scanCommandRow(rows *sql.Rows) (*interfaces.CommandRecord, error) {
+	var rec interfaces.CommandRecord
+	var payloadStr, statusStr, issuedAtStr, resultStr string
+	var startedAt, completedAt sql.NullString
+
+	if err := rows.Scan(
+		&rec.ID, &rec.Type, &rec.StewardID, &rec.TenantID,
+		&payloadStr, &statusStr,
+		&issuedAtStr, &startedAt, &completedAt,
+		&resultStr, &rec.ErrorMessage, &rec.IssuedBy,
+	); err != nil {
+		return nil, fmt.Errorf("sqlite: failed to scan command row: %w", err)
+	}
+	return populateCommandRecord(&rec, payloadStr, statusStr, issuedAtStr, startedAt, completedAt, resultStr)
+}
+
+// populateCommandRecord deserialises JSON columns and nullable timestamps.
+func populateCommandRecord(
+	rec *interfaces.CommandRecord,
+	payloadStr, statusStr, issuedAtStr string,
+	startedAt, completedAt sql.NullString,
+	resultStr string,
+) (*interfaces.CommandRecord, error) {
+	rec.Status = interfaces.CommandStatus(statusStr)
+	rec.IssuedAt = parseTime(issuedAtStr)
+	rec.StartedAt = parseNullTime(startedAt)
+	rec.CompletedAt = parseNullTime(completedAt)
+
+	if payload, err := unmarshalJSONMap(payloadStr); err == nil {
+		rec.Payload = payload
+	}
+	if result, err := unmarshalJSONMap(resultStr); err == nil {
+		rec.Result = result
+	}
+
+	return rec, nil
+}

--- a/pkg/storage/providers/sqlite/command_store_test.go
+++ b/pkg/storage/providers/sqlite/command_store_test.go
@@ -1,0 +1,321 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+package sqlite
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cfgis/cfgms/pkg/storage/interfaces"
+)
+
+// newTestCommandStore opens an in-memory SQLite CommandStore for tests.
+func newTestCommandStore(t *testing.T) *SQLiteCommandStore {
+	t.Helper()
+	db, err := openAndInit(":memory:")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+	return &SQLiteCommandStore{db: db}
+}
+
+// testCommandRecord returns a CommandRecord with sensible defaults.
+func testCommandRecord(id string) *interfaces.CommandRecord {
+	return &interfaces.CommandRecord{
+		ID:        id,
+		Type:      "sync_config",
+		StewardID: "steward-001",
+		TenantID:  "tenant-001",
+		Payload: map[string]interface{}{
+			"modules": []string{"dns", "firewall"},
+		},
+		IssuedBy: "admin@example.com",
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Happy-path lifecycle tests
+// ---------------------------------------------------------------------------
+
+func TestSQLiteCommandStore_CreateAndGet(t *testing.T) {
+	store := newTestCommandStore(t)
+	ctx := context.Background()
+
+	rec := testCommandRecord("cmd-001")
+	require.NoError(t, store.CreateCommandRecord(ctx, rec))
+
+	got, err := store.GetCommandRecord(ctx, "cmd-001")
+	require.NoError(t, err)
+	assert.Equal(t, "cmd-001", got.ID)
+	assert.Equal(t, "sync_config", got.Type)
+	assert.Equal(t, "steward-001", got.StewardID)
+	assert.Equal(t, "tenant-001", got.TenantID)
+	assert.Equal(t, interfaces.CommandStatusPending, got.Status)
+	assert.Equal(t, "admin@example.com", got.IssuedBy)
+	assert.Nil(t, got.StartedAt)
+	assert.Nil(t, got.CompletedAt)
+}
+
+func TestSQLiteCommandStore_LifecycleAuditTrail(t *testing.T) {
+	// Contract test: create → executing → completed; audit trail has three entries.
+	store := newTestCommandStore(t)
+	ctx := context.Background()
+
+	rec := testCommandRecord("cmd-lifecycle")
+	require.NoError(t, store.CreateCommandRecord(ctx, rec))
+
+	require.NoError(t, store.UpdateCommandStatus(ctx, "cmd-lifecycle",
+		interfaces.CommandStatusExecuting, nil, ""))
+
+	result := map[string]interface{}{"exit_code": float64(0)}
+	require.NoError(t, store.UpdateCommandStatus(ctx, "cmd-lifecycle",
+		interfaces.CommandStatusCompleted, result, ""))
+
+	// Verify final state.
+	got, err := store.GetCommandRecord(ctx, "cmd-lifecycle")
+	require.NoError(t, err)
+	assert.Equal(t, interfaces.CommandStatusCompleted, got.Status)
+	assert.NotNil(t, got.StartedAt)
+	assert.NotNil(t, got.CompletedAt)
+
+	// Verify audit trail has exactly three entries in order.
+	trail, err := store.GetCommandAuditTrail(ctx, "cmd-lifecycle")
+	require.NoError(t, err)
+	require.Len(t, trail, 3)
+	assert.Equal(t, interfaces.CommandStatusPending, trail[0].Status)
+	assert.Equal(t, interfaces.CommandStatusExecuting, trail[1].Status)
+	assert.Equal(t, interfaces.CommandStatusCompleted, trail[2].Status)
+
+	// Timestamps must be non-zero and in chronological order.
+	assert.False(t, trail[0].Timestamp.IsZero())
+	assert.True(t, !trail[1].Timestamp.Before(trail[0].Timestamp))
+	assert.True(t, !trail[2].Timestamp.Before(trail[1].Timestamp))
+}
+
+// ---------------------------------------------------------------------------
+// Restart simulation
+// ---------------------------------------------------------------------------
+
+func TestSQLiteCommandStore_RestartSweep(t *testing.T) {
+	// Acceptance criterion: mark a command executing, create a NEW store instance
+	// on the same DB, run the startup sweep, verify record is failed with
+	// "controller_restart" reason.
+	db, err := openAndInit(":memory:")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+
+	ctx := context.Background()
+	store1 := &SQLiteCommandStore{db: db}
+
+	rec := testCommandRecord("cmd-restart")
+	require.NoError(t, store1.CreateCommandRecord(ctx, rec))
+	require.NoError(t, store1.UpdateCommandStatus(ctx, "cmd-restart",
+		interfaces.CommandStatusExecuting, nil, ""))
+
+	// Simulate restart: new store instance on the same DB.
+	store2 := &SQLiteCommandStore{db: db}
+
+	// Startup sweep: flip all "executing" records to "failed" with controller_restart reason.
+	executing, err := store2.ListCommandsByStatus(ctx, interfaces.CommandStatusExecuting)
+	require.NoError(t, err)
+	require.Len(t, executing, 1)
+
+	for _, cmd := range executing {
+		err = store2.UpdateCommandStatus(ctx, cmd.ID,
+			interfaces.CommandStatusFailed, nil, "controller_restart")
+		require.NoError(t, err)
+	}
+
+	got, err := store2.GetCommandRecord(ctx, "cmd-restart")
+	require.NoError(t, err)
+	assert.Equal(t, interfaces.CommandStatusFailed, got.Status)
+	assert.Equal(t, "controller_restart", got.ErrorMessage)
+}
+
+// ---------------------------------------------------------------------------
+// List methods
+// ---------------------------------------------------------------------------
+
+func TestSQLiteCommandStore_ListCommandsByDevice(t *testing.T) {
+	store := newTestCommandStore(t)
+	ctx := context.Background()
+
+	for i, id := range []string{"c1", "c2", "c3"} {
+		rec := testCommandRecord(id)
+		if i == 2 {
+			rec.StewardID = "steward-002"
+		}
+		require.NoError(t, store.CreateCommandRecord(ctx, rec))
+	}
+
+	list, err := store.ListCommandsByDevice(ctx, "steward-001")
+	require.NoError(t, err)
+	assert.Len(t, list, 2)
+	for _, r := range list {
+		assert.Equal(t, "steward-001", r.StewardID)
+	}
+}
+
+func TestSQLiteCommandStore_ListCommandsByStatus(t *testing.T) {
+	store := newTestCommandStore(t)
+	ctx := context.Background()
+
+	require.NoError(t, store.CreateCommandRecord(ctx, testCommandRecord("s1")))
+	require.NoError(t, store.CreateCommandRecord(ctx, testCommandRecord("s2")))
+	require.NoError(t, store.UpdateCommandStatus(ctx, "s1", interfaces.CommandStatusExecuting, nil, ""))
+
+	pending, err := store.ListCommandsByStatus(ctx, interfaces.CommandStatusPending)
+	require.NoError(t, err)
+	assert.Len(t, pending, 1)
+	assert.Equal(t, "s2", pending[0].ID)
+
+	executing, err := store.ListCommandsByStatus(ctx, interfaces.CommandStatusExecuting)
+	require.NoError(t, err)
+	assert.Len(t, executing, 1)
+	assert.Equal(t, "s1", executing[0].ID)
+}
+
+func TestSQLiteCommandStore_ListCommandRecords_Filter(t *testing.T) {
+	store := newTestCommandStore(t)
+	ctx := context.Background()
+
+	r1 := testCommandRecord("f1")
+	r1.TenantID = "tenant-A"
+	r2 := testCommandRecord("f2")
+	r2.TenantID = "tenant-B"
+	require.NoError(t, store.CreateCommandRecord(ctx, r1))
+	require.NoError(t, store.CreateCommandRecord(ctx, r2))
+
+	results, err := store.ListCommandRecords(ctx, &interfaces.CommandFilter{TenantID: "tenant-A"})
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	assert.Equal(t, "f1", results[0].ID)
+}
+
+// ---------------------------------------------------------------------------
+// PurgeExpiredRecords
+// ---------------------------------------------------------------------------
+
+func TestSQLiteCommandStore_PurgeExpiredRecords(t *testing.T) {
+	store := newTestCommandStore(t)
+	ctx := context.Background()
+
+	// Create records with explicit past issued_at times.
+	old := testCommandRecord("old-completed")
+	old.IssuedAt = time.Now().Add(-48 * time.Hour)
+	require.NoError(t, store.CreateCommandRecord(ctx, old))
+	require.NoError(t, store.UpdateCommandStatus(ctx, "old-completed",
+		interfaces.CommandStatusCompleted, nil, ""))
+
+	recent := testCommandRecord("recent-completed")
+	recent.IssuedAt = time.Now().Add(-1 * time.Hour)
+	require.NoError(t, store.CreateCommandRecord(ctx, recent))
+	require.NoError(t, store.UpdateCommandStatus(ctx, "recent-completed",
+		interfaces.CommandStatusCompleted, nil, ""))
+
+	still := testCommandRecord("still-executing")
+	still.IssuedAt = time.Now().Add(-48 * time.Hour)
+	require.NoError(t, store.CreateCommandRecord(ctx, still))
+	require.NoError(t, store.UpdateCommandStatus(ctx, "still-executing",
+		interfaces.CommandStatusExecuting, nil, ""))
+
+	// Purge records older than 24 hours.
+	cutoff := time.Now().Add(-24 * time.Hour)
+	deleted, err := store.PurgeExpiredRecords(ctx, cutoff)
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), deleted, "only the old completed record should be purged")
+
+	// old-completed should be gone.
+	_, err = store.GetCommandRecord(ctx, "old-completed")
+	assert.Error(t, err, "old-completed should not exist after purge")
+
+	// recent-completed must remain.
+	_, err = store.GetCommandRecord(ctx, "recent-completed")
+	assert.NoError(t, err, "recent-completed should still exist")
+
+	// still-executing must remain (never purged regardless of age).
+	_, err = store.GetCommandRecord(ctx, "still-executing")
+	assert.NoError(t, err, "executing record should never be purged")
+}
+
+// ---------------------------------------------------------------------------
+// Error path tests
+// ---------------------------------------------------------------------------
+
+func TestSQLiteCommandStore_CreateRecord_NilRecord(t *testing.T) {
+	store := newTestCommandStore(t)
+	ctx := context.Background()
+	err := store.CreateCommandRecord(ctx, nil)
+	require.Error(t, err)
+}
+
+func TestSQLiteCommandStore_CreateRecord_EmptyID(t *testing.T) {
+	store := newTestCommandStore(t)
+	ctx := context.Background()
+	rec := testCommandRecord("")
+	err := store.CreateCommandRecord(ctx, rec)
+	require.Error(t, err)
+}
+
+func TestSQLiteCommandStore_CreateRecord_EmptyStewardID(t *testing.T) {
+	store := newTestCommandStore(t)
+	ctx := context.Background()
+	rec := testCommandRecord("cmd-no-steward")
+	rec.StewardID = ""
+	err := store.CreateCommandRecord(ctx, rec)
+	require.Error(t, err)
+}
+
+func TestSQLiteCommandStore_GetRecord_NotFound(t *testing.T) {
+	store := newTestCommandStore(t)
+	ctx := context.Background()
+	_, err := store.GetCommandRecord(ctx, "nonexistent")
+	require.Error(t, err)
+}
+
+func TestSQLiteCommandStore_UpdateStatus_NotFound(t *testing.T) {
+	store := newTestCommandStore(t)
+	ctx := context.Background()
+	err := store.UpdateCommandStatus(ctx, "nonexistent", interfaces.CommandStatusCompleted, nil, "")
+	require.Error(t, err)
+}
+
+func TestSQLiteCommandStore_UpdateStatus_EmptyID(t *testing.T) {
+	store := newTestCommandStore(t)
+	ctx := context.Background()
+	err := store.UpdateCommandStatus(ctx, "", interfaces.CommandStatusCompleted, nil, "")
+	require.Error(t, err)
+}
+
+func TestSQLiteCommandStore_GetAuditTrail_EmptyID(t *testing.T) {
+	store := newTestCommandStore(t)
+	ctx := context.Background()
+	_, err := store.GetCommandAuditTrail(ctx, "")
+	require.Error(t, err)
+}
+
+// ---------------------------------------------------------------------------
+// HealthCheck
+// ---------------------------------------------------------------------------
+
+func TestSQLiteCommandStore_HealthCheck(t *testing.T) {
+	store := newTestCommandStore(t)
+	ctx := context.Background()
+	require.NoError(t, store.HealthCheck(ctx))
+}
+
+// ---------------------------------------------------------------------------
+// Duplicate ID
+// ---------------------------------------------------------------------------
+
+func TestSQLiteCommandStore_CreateRecord_DuplicateID(t *testing.T) {
+	store := newTestCommandStore(t)
+	ctx := context.Background()
+	rec := testCommandRecord("dup")
+	require.NoError(t, store.CreateCommandRecord(ctx, rec))
+	err := store.CreateCommandRecord(ctx, rec)
+	require.Error(t, err, "duplicate command ID must be rejected")
+}

--- a/pkg/storage/providers/sqlite/plugin.go
+++ b/pkg/storage/providers/sqlite/plugin.go
@@ -231,6 +231,15 @@ func (p *SQLiteProvider) CreateStewardStore(config map[string]interface{}) (inte
 	return &SQLiteStewardStore{db: db}, nil
 }
 
+// CreateCommandStore returns a SQLite-backed CommandStore for durable command dispatch state.
+func (p *SQLiteProvider) CreateCommandStore(config map[string]interface{}) (interfaces.CommandStore, error) {
+	db, err := openAndInit(getPath(config))
+	if err != nil {
+		return nil, err
+	}
+	return &SQLiteCommandStore{db: db}, nil
+}
+
 // init auto-registers the SQLite provider so it is available after a blank import.
 func init() {
 	interfaces.RegisterStorageProvider(&SQLiteProvider{})

--- a/pkg/storage/providers/sqlite/schema.go
+++ b/pkg/storage/providers/sqlite/schema.go
@@ -201,6 +201,39 @@ func initializeSchema(ctx context.Context, db *sql.DB) error {
 		`CREATE INDEX IF NOT EXISTS idx_stewards_status    ON stewards(status)`,
 		`CREATE INDEX IF NOT EXISTS idx_stewards_last_seen ON stewards(last_seen)`,
 
+		// Commands — durable command dispatch state (ADR-003 §1 Deficiency #5, Issue #665)
+		// Records are append-only for audit purposes; PurgeExpiredRecords removes
+		// completed/failed records older than the configured threshold.
+		`CREATE TABLE IF NOT EXISTS commands (
+			id            TEXT PRIMARY KEY,
+			type          TEXT NOT NULL,
+			steward_id    TEXT NOT NULL,
+			tenant_id     TEXT NOT NULL DEFAULT '',
+			payload       TEXT NOT NULL DEFAULT '{}',
+			status        TEXT NOT NULL DEFAULT 'pending',
+			issued_at     TEXT NOT NULL,
+			started_at    TEXT,
+			completed_at  TEXT,
+			result        TEXT NOT NULL DEFAULT '{}',
+			error_message TEXT NOT NULL DEFAULT '',
+			issued_by     TEXT NOT NULL DEFAULT ''
+		)`,
+		`CREATE INDEX IF NOT EXISTS idx_commands_steward_id  ON commands(steward_id)`,
+		`CREATE INDEX IF NOT EXISTS idx_commands_status      ON commands(status)`,
+		`CREATE INDEX IF NOT EXISTS idx_commands_issued_at   ON commands(issued_at)`,
+		`CREATE INDEX IF NOT EXISTS idx_commands_tenant_id   ON commands(tenant_id)`,
+
+		// Command audit trail — immutable log of each state transition
+		`CREATE TABLE IF NOT EXISTS command_transitions (
+			id            INTEGER PRIMARY KEY AUTOINCREMENT,
+			command_id    TEXT NOT NULL,
+			status        TEXT NOT NULL,
+			timestamp     TEXT NOT NULL,
+			error_message TEXT NOT NULL DEFAULT ''
+		)`,
+		`CREATE INDEX IF NOT EXISTS idx_command_transitions_command_id ON command_transitions(command_id)`,
+		`CREATE INDEX IF NOT EXISTS idx_command_transitions_timestamp  ON command_transitions(timestamp)`,
+
 		// Durable sessions (Persistent=true only)
 		`CREATE TABLE IF NOT EXISTS sessions (
 			session_id       TEXT PRIMARY KEY,


### PR DESCRIPTION
## Summary

- Implements `CommandStore` interface (`pkg/storage/interfaces/command_store.go`) for durable command dispatch state with `CommandRecord` and `CommandTransition` audit trail types
- SQLite provider implementation (`pkg/storage/providers/sqlite/command_store.go`) backed by `commands` + `command_transitions` tables; all SQL parameterized; `PurgeExpiredRecords` respects pending/executing safety
- `features/steward/commands/handler.go` replaced in-memory persistence with `CommandStore` write-through; `executionContext` retains only `context.CancelFunc`; startup sweep flips stale `executing` → `failed` with `"controller_restart"` reason; `Wait()` added for graceful shutdown
- `StorageProvider` interface extended with `CreateCommandStore`; database, git, and flatfile providers return `ErrNotSupported`
- Architecture docs and interface README updated

Fixes #665 (Parent Epic: #647)

## Test plan

- [ ] `pkg/storage/providers/sqlite/command_store_test.go`: lifecycle audit trail (3 transitions), restart simulation, list/filter, purge, error paths
- [ ] `features/steward/commands/handler_test.go`: startup sweep, store write-through, nil-store fallback, UpdateCommandStatus error-path handling using `h.Wait()` (no `time.Sleep`)
- [ ] `pkg/storage/interfaces/` tests: StorageProvider interface contract with mock stubs updated
- [ ] `make test` — 45 packages PASS, 73 pre-existing setup failures (module cache permission issue, confirmed pre-dating this story)
- [ ] `make check-architecture` — PASS (no central provider violations)
- [ ] `make security-precommit` — PASS (no secrets)

## Adversarial Review Results

| Reviewer | Result | Notes |
|----------|--------|-------|
| QA Test Runner | PASS | All story-changed packages pass; 73 pre-existing setup failures from module cache |
| QA Code Reviewer | PASS | Fixed: time.Sleep→WaitGroup, error swallowing→logged, structural test→behavioral, error path coverage added |
| Security Engineer | PASS | No blocking issues; architecture PASS; SQL parameterized; SanitizeLogValue bug fixed (was corrupting DB record) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)