### PR TITLE
secrets: future-proof SecretStore interface with Policy metadata and LeasedSecret mixin (Issue #675)

### DIFF
--- a/docs/architecture/decisions/003-storage-data-taxonomy.md
+++ b/docs/architecture/decisions/003-storage-data-taxonomy.md
@@ -251,3 +251,9 @@ Rule of thumb: **if a steward does not use the interface, it does not belong und
 - `features/steward/commands/handler.go` — in-memory command dispatch (motivates `CommandStore`)
 - `pkg/storage/interfaces/` — current interface layout being reorganized
 - CLAUDE.md — 50k+ steward scale target, pluggable-by-default rule
+
+## Addendum — SecretStore Package Location
+
+The ADR's Interface Mapping table specifies `secrets/SecretStore` under `pkg/storage/interfaces/`. During pre-implementation audit (Issue #671), a fully-formed `SecretStore` interface was found at `pkg/secrets/interfaces/secret_store.go`, with a SOPS implementation at `pkg/secrets/providers/sops/` and a steward implementation at `pkg/secrets/providers/steward/`. Creating a parallel interface at `pkg/storage/interfaces/secrets/` would produce a duplicate registry and duplicate provider pattern.
+
+Decision (PO, 2026-04-13): `SecretStore` stays in `pkg/secrets/`. The taxonomy holds — secrets are their own type with their own providers. The path is a footnote. Sub-story I (interface reorganization) does NOT move `pkg/secrets/` into `pkg/storage/interfaces/`.

--- a/docs/architecture/storage-architecture.md
+++ b/docs/architecture/storage-architecture.md
@@ -139,6 +139,38 @@ The flat-file provider (`pkg/storage/providers/flatfile`) is the OSS default for
 import _ "github.com/cfgis/cfgms/pkg/storage/providers/flatfile"
 ```
 
+## Secrets
+
+Secrets (credentials, API keys, certificates) are always encrypted at rest. The secrets
+tier lives in **`pkg/secrets/`** — a pre-existing pluggable package with its own provider
+registry, separate from `pkg/storage/interfaces/`. Sub-story I (interfaces reorganization)
+does NOT move `pkg/secrets/` — see [ADR-003 Addendum](decisions/003-storage-data-taxonomy.md#addendum--secretstore-package-location).
+
+**Interface location**: `pkg/secrets/interfaces/` — see the [README](../../pkg/secrets/interfaces/README.md)
+for the full interface surface.
+
+**Providers**:
+
+| Provider | Package | Secret model |
+|----------|---------|-------------|
+| SOPS | `pkg/secrets/providers/sops` | Static — AES-256-GCM encrypted files backed by a ConfigStore |
+| Steward | `pkg/secrets/providers/steward` | Static — OS-native encrypted blobs (DPAPI/AES-256-GCM) |
+| OpenBao / HashiCorp Vault (future) | `pkg/secrets/providers/openbao` | Static + dynamic leased |
+| AWS Secrets Manager (future) | `pkg/secrets/providers/awssm` | Static + dynamic leased |
+| Azure Key Vault (future) | `pkg/secrets/providers/azkv` | Static + dynamic leased |
+
+**`LeasedSecret` mixin**: Future vault-class providers that generate per-request dynamic
+credentials implement the optional `interfaces.LeasedSecret` mixin in addition to
+`SecretStore`. Callers check for the capability at runtime:
+
+```go
+if ls, ok := store.(interfaces.LeasedSecret); ok {
+    secret, lease, err := ls.LeaseSecret(ctx, "db/creds", req)
+}
+```
+
+SOPS and steward are static-secret providers and do **not** implement `LeasedSecret`.
+
 ## Interface Layout
 
 Target layout (tracked under the ADR-003 epic):
@@ -148,9 +180,13 @@ pkg/storage/interfaces/
   business/       # TenantStore, ClientTenantStore, StewardStore, CommandStore,
                   # AuditStore, RBACStore, SessionStore, RegistrationTokenStore
   config/         # ConfigStore
-  secrets/        # SecretStore
   timeseries/     # MetricsStore, LogStore
   blob/           # BlobStore
+
+pkg/secrets/interfaces/   # SecretStore lives here (pre-existing pluggable package)
+  secret_store.go         # SecretStore, SecretMetadata, Secret, SecretRequest, ...
+  leased_secret.go        # LeasedSecret mixin, Lease, LeaseRequest
+  provider.go             # SecretProvider registry (auto-registration via init())
 ```
 
 **Naming rule**: anything ending in `*Store` is durable. Anything ephemeral (resolved configs, inheritance memoization, rebuildable-on-restart state) is named `*Cache` and lives under [`pkg/cache/`](../../pkg/cache/). The old `RuntimeStore` mixed both and has been retired — its durable parts moved to `business/SessionStore`, its ephemeral parts moved to `pkg/cache`.

--- a/pkg/secrets/interfaces/README.md
+++ b/pkg/secrets/interfaces/README.md
@@ -1,0 +1,79 @@
+# pkg/secrets/interfaces
+
+This package defines the contracts for CFGMS secret storage. All secret backends —
+SOPS, steward, and future vault-class providers — implement the interfaces here.
+
+## Interface Surface
+
+| Interface | File | Purpose |
+|-----------|------|---------|
+| `SecretStore` | `secret_store.go` | Core CRUD, versioning, rotation, metadata, lifecycle |
+| `SecretProvider` | `provider.go` | Auto-registration pattern; creates `SecretStore` instances |
+| `LeasedSecret` | `leased_secret.go` | Optional mixin for dynamic-secret leasing (vault-class only) |
+
+## Mixin Pattern
+
+`LeasedSecret` is an **optional mixin**. It is not part of `SecretStore` because most
+providers are static-secret providers that do not support per-request dynamic credentials.
+Callers check for the capability at runtime with a type assertion:
+
+```go
+// Always safe — falls back gracefully if provider is static-only.
+if ls, ok := store.(interfaces.LeasedSecret); ok {
+    secret, lease, err := ls.LeaseSecret(ctx, "db/creds", &interfaces.LeaseRequest{
+        TTL:       time.Hour,
+        Renewable: true,
+    })
+    // ... use secret, remember to revoke lease when done
+    defer ls.RevokeLease(ctx, lease.ID)
+}
+```
+
+Never call lease methods without the type-assertion guard. Static providers will simply
+not satisfy the interface.
+
+## When to Implement `LeasedSecret`
+
+Implement `LeasedSecret` when the provider generates credentials **on-demand per request**
+and the credential has a bounded lifetime that the provider tracks (a lease). Classic
+examples:
+
+- HashiCorp Vault / OpenBao database secrets engine — generates a unique DB user per lease
+- AWS Secrets Manager dynamic credentials — scoped IAM credentials with automatic rotation
+- Azure Key Vault managed identities — time-bounded access tokens
+
+**Do not implement `LeasedSecret` for**:
+
+- File-based providers (SOPS, flat-file) — secrets are stored, not generated
+- OS-keychain providers (steward) — secrets are stored and retrieved, not leased
+- Any provider where the same credential value is returned on every `GetSecret` call
+
+## Provider Capability Matrix
+
+| Provider | Package | Secret model | `LeasedSecret` |
+|----------|---------|-------------|----------------|
+| SOPS | `pkg/secrets/providers/sops` | Static — encrypted files in git | No |
+| Steward | `pkg/secrets/providers/steward` | Static — OS-native encrypted blobs | No |
+| OpenBao (future) | `pkg/secrets/providers/openbao` | Static + dynamic leased | Yes |
+| AWS Secrets Manager (future) | `pkg/secrets/providers/awssm` | Static + dynamic leased | Yes |
+| Azure Key Vault (future) | `pkg/secrets/providers/azkv` | Static + dynamic leased | Yes |
+
+## `Policy` Field on `SecretMetadata`
+
+`SecretMetadata.Policy map[string]any` carries provider-specific access-control and
+lease-policy parameters as an opaque map. SOPS and steward providers always leave it
+`nil`. Vault-class providers may populate it with fields such as `ttl`, `max_leases`,
+or `bound_ips`.
+
+**Security note**: Never log or expose `Policy` contents — they may contain sensitive
+policy identifiers. Use `logging.SanitizeLogValue` for any secret key or lease ID that
+appears in log lines.
+
+## `ProviderCapabilities.SupportsLeasing`
+
+`ProviderCapabilities.SupportsLeasing` (declared in `provider.go`) is the static
+flag a provider sets in `GetCapabilities()` to advertise that it supports dynamic
+leasing. `LeasedSecret` is the runtime-checkable counterpart: if a store value
+satisfies `LeasedSecret`, the provider supports leasing for that store instance.
+Both should be consistent, but callers must use the type assertion — not the flag —
+when dispatching actual lease operations.

--- a/pkg/secrets/interfaces/leased_secret.go
+++ b/pkg/secrets/interfaces/leased_secret.go
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+// Package interfaces defines the optional LeasedSecret mixin for vault-class providers.
+package interfaces
+
+import (
+	"context"
+	"time"
+)
+
+// LeasedSecret is an optional mixin interface for SecretStore providers that support
+// dynamic-secret leasing (e.g., OpenBao, HashiCorp Vault, AWS Secrets Manager
+// dynamic credentials).
+//
+// Callers type-assert to LeasedSecret before calling lease operations:
+//
+//	if ls, ok := store.(interfaces.LeasedSecret); ok {
+//	    secret, lease, err := ls.LeaseSecret(ctx, key, req)
+//	}
+//
+// SOPS and steward providers do NOT implement this interface — they are static-secret
+// providers. Only vault-class providers with per-request dynamic credentials implement it.
+//
+// A provider advertises static support for leasing via ProviderCapabilities.SupportsLeasing;
+// LeasedSecret is the runtime-checkable counterpart that callers use to dispatch lease
+// operations at call time.
+type LeasedSecret interface {
+	// LeaseSecret requests a dynamic secret lease from the provider. The returned Lease
+	// describes the lease ID, TTL, and expiry. The caller is responsible for renewing or
+	// revoking the lease when finished.
+	LeaseSecret(ctx context.Context, key string, req *LeaseRequest) (*Secret, *Lease, error)
+
+	// RenewLease extends an active lease by increment. The returned Lease reflects the
+	// new TTL and expiry after renewal.
+	RenewLease(ctx context.Context, leaseID string, increment time.Duration) (*Lease, error)
+
+	// RevokeLease immediately invalidates a lease. After revocation the dynamic secret
+	// associated with the lease is no longer valid.
+	RevokeLease(ctx context.Context, leaseID string) error
+}
+
+// Lease represents an active dynamic-secret lease returned by a vault-class provider.
+// Lease IDs must not be logged in plaintext — use logging.SanitizeLogValue when a lease
+// ID appears in a log line.
+type Lease struct {
+	// ID is the opaque provider-assigned lease identifier.
+	ID string `json:"id"`
+
+	// TTL is the remaining lifetime of the lease at the time it was issued or last renewed.
+	TTL time.Duration `json:"ttl"`
+
+	// Renewable indicates whether the provider allows RenewLease calls for this lease.
+	Renewable bool `json:"renewable"`
+
+	// IssuedAt is the time the lease was created or last renewed.
+	IssuedAt time.Time `json:"issued_at"`
+
+	// ExpiresAt is the absolute expiry time. Callers should treat the secret as invalid
+	// at or after this time even if no explicit revocation occurred.
+	ExpiresAt time.Time `json:"expires_at"`
+}
+
+// LeaseRequest carries parameters for a dynamic secret lease creation request.
+type LeaseRequest struct {
+	// TTL is the requested lease duration. Providers may cap or adjust the TTL according
+	// to their own policy. Zero means use the provider default.
+	TTL time.Duration `json:"ttl,omitempty"`
+
+	// Renewable requests a renewable lease when true. Providers may ignore this if the
+	// secret type does not support renewal.
+	Renewable bool `json:"renewable"`
+
+	// Parameters are provider-specific inputs for the dynamic credential generation
+	// (e.g., database role, IAM policy ARN). Callers must not embed secret values here.
+	Parameters map[string]any `json:"parameters,omitempty"`
+}

--- a/pkg/secrets/interfaces/leased_secret_test.go
+++ b/pkg/secrets/interfaces/leased_secret_test.go
@@ -1,0 +1,332 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+package interfaces_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/cfgis/cfgms/pkg/secrets/interfaces"
+	_ "github.com/cfgis/cfgms/pkg/secrets/providers/sops"
+	sopspkg "github.com/cfgis/cfgms/pkg/secrets/providers/sops"
+	"github.com/cfgis/cfgms/pkg/secrets/providers/steward"
+	_ "github.com/cfgis/cfgms/pkg/storage/providers/flatfile"
+	"github.com/stretchr/testify/require"
+)
+
+// errUnknownKey is a sentinel returned by mockLeasedStore for unknown lease IDs and keys,
+// allowing error-path tests to verify the interface propagates errors correctly.
+var errUnknownKey = errors.New("unknown key or lease ID")
+
+// mockLeasedStore is a minimal in-process implementation of both SecretStore and LeasedSecret
+// used exclusively to verify the type-assertion dispatch pattern and interface mechanics.
+//
+// No real vault-class LeasedSecret provider exists in the codebase yet (OpenBao, AWS Secrets
+// Manager, and Azure Key Vault are planned — see pkg/secrets/interfaces/README.md). Until one
+// is available, this concrete type is the only way to exercise the LeasedSecret interface
+// surface; it is not replacing a real CFGMS component. The non-implementation tests below
+// (SOPS, steward) use real providers.
+type mockLeasedStore struct {
+	noopSecretStore
+	leases map[string]*interfaces.Lease
+}
+
+func newMockLeasedStore() *mockLeasedStore {
+	return &mockLeasedStore{
+		leases: make(map[string]*interfaces.Lease),
+	}
+}
+
+func (m *mockLeasedStore) LeaseSecret(_ context.Context, key string, req *interfaces.LeaseRequest) (*interfaces.Secret, *interfaces.Lease, error) {
+	if key == "" {
+		return nil, nil, errUnknownKey
+	}
+	ttl := req.TTL
+	if ttl == 0 {
+		ttl = time.Hour // provider default
+	}
+	lease := &interfaces.Lease{
+		ID:        "lease-" + key,
+		TTL:       ttl,
+		Renewable: req.Renewable,
+		IssuedAt:  time.Now(),
+		ExpiresAt: time.Now().Add(ttl),
+	}
+	m.leases[lease.ID] = lease
+	return &interfaces.Secret{Key: key}, lease, nil
+}
+
+func (m *mockLeasedStore) RenewLease(_ context.Context, leaseID string, increment time.Duration) (*interfaces.Lease, error) {
+	lease, ok := m.leases[leaseID]
+	if !ok {
+		return nil, errUnknownKey
+	}
+	lease.TTL = increment
+	lease.ExpiresAt = time.Now().Add(increment)
+	return lease, nil
+}
+
+func (m *mockLeasedStore) RevokeLease(_ context.Context, leaseID string) error {
+	if _, ok := m.leases[leaseID]; !ok {
+		return errUnknownKey
+	}
+	delete(m.leases, leaseID)
+	return nil
+}
+
+// noopSecretStore is a no-operation base that satisfies interfaces.SecretStore so that
+// mockLeasedStore can embed it. Its methods return zero values; they are never called
+// directly in the tests below — only the LeasedSecret methods are under test.
+type noopSecretStore struct{}
+
+func (n *noopSecretStore) StoreSecret(_ context.Context, _ *interfaces.SecretRequest) error {
+	return nil
+}
+func (n *noopSecretStore) GetSecret(_ context.Context, _ string) (*interfaces.Secret, error) {
+	return nil, nil
+}
+func (n *noopSecretStore) DeleteSecret(_ context.Context, _ string) error { return nil }
+func (n *noopSecretStore) ListSecrets(_ context.Context, _ *interfaces.SecretFilter) ([]*interfaces.SecretMetadata, error) {
+	return nil, nil
+}
+func (n *noopSecretStore) GetSecrets(_ context.Context, _ []string) (map[string]*interfaces.Secret, error) {
+	return nil, nil
+}
+func (n *noopSecretStore) StoreSecrets(_ context.Context, _ map[string]*interfaces.SecretRequest) error {
+	return nil
+}
+func (n *noopSecretStore) GetSecretVersion(_ context.Context, _ string, _ int) (*interfaces.Secret, error) {
+	return nil, nil
+}
+func (n *noopSecretStore) ListSecretVersions(_ context.Context, _ string) ([]*interfaces.SecretVersion, error) {
+	return nil, nil
+}
+func (n *noopSecretStore) GetSecretMetadata(_ context.Context, _ string) (*interfaces.SecretMetadata, error) {
+	return nil, nil
+}
+func (n *noopSecretStore) UpdateSecretMetadata(_ context.Context, _ string, _ map[string]string) error {
+	return nil
+}
+func (n *noopSecretStore) RotateSecret(_ context.Context, _ string, _ string) error { return nil }
+func (n *noopSecretStore) ExpireSecret(_ context.Context, _ string) error           { return nil }
+func (n *noopSecretStore) HealthCheck(_ context.Context) error                      { return nil }
+func (n *noopSecretStore) Close() error                                             { return nil }
+
+// TestLeasedSecret_TypeAssertionPattern verifies that the type-assertion guard pattern
+// works correctly for vault-class stores, and that the three LeasedSecret methods are
+// callable through the interface — including their error paths.
+func TestLeasedSecret_TypeAssertionPattern(t *testing.T) {
+	var store interfaces.SecretStore = newMockLeasedStore()
+
+	ls, ok := store.(interfaces.LeasedSecret)
+	require.True(t, ok, "mockLeasedStore must satisfy interfaces.LeasedSecret")
+	require.NotNil(t, ls)
+
+	ctx := context.Background()
+
+	t.Run("happy path: lease, renew, revoke", func(t *testing.T) {
+		secret, lease, err := ls.LeaseSecret(ctx, "db/creds", &interfaces.LeaseRequest{
+			TTL:       time.Hour,
+			Renewable: true,
+		})
+		require.NoError(t, err)
+		require.NotNil(t, secret)
+		require.Equal(t, "db/creds", secret.Key)
+		require.NotNil(t, lease)
+		require.Equal(t, "lease-db/creds", lease.ID)
+		require.Equal(t, time.Hour, lease.TTL)
+		require.True(t, lease.Renewable)
+		require.False(t, lease.ExpiresAt.IsZero())
+
+		renewed, err := ls.RenewLease(ctx, lease.ID, 30*time.Minute)
+		require.NoError(t, err)
+		require.NotNil(t, renewed)
+		require.Equal(t, 30*time.Minute, renewed.TTL)
+
+		err = ls.RevokeLease(ctx, lease.ID)
+		require.NoError(t, err)
+	})
+
+	t.Run("error path: LeaseSecret with empty key", func(t *testing.T) {
+		_, _, err := ls.LeaseSecret(ctx, "", &interfaces.LeaseRequest{TTL: time.Hour})
+		require.Error(t, err, "LeaseSecret must propagate error for empty key")
+		require.ErrorIs(t, err, errUnknownKey)
+	})
+
+	t.Run("error path: RenewLease with unknown lease ID", func(t *testing.T) {
+		_, err := ls.RenewLease(ctx, "nonexistent-lease-id", time.Hour)
+		require.Error(t, err, "RenewLease must propagate error for unknown lease ID")
+		require.ErrorIs(t, err, errUnknownKey)
+	})
+
+	t.Run("error path: RevokeLease with unknown lease ID", func(t *testing.T) {
+		err := ls.RevokeLease(ctx, "nonexistent-lease-id")
+		require.Error(t, err, "RevokeLease must propagate error for unknown lease ID")
+		require.ErrorIs(t, err, errUnknownKey)
+	})
+
+	t.Run("default TTL applied when zero", func(t *testing.T) {
+		_, lease, err := ls.LeaseSecret(ctx, "iam/role", &interfaces.LeaseRequest{
+			TTL:       0, // zero means use provider default
+			Renewable: false,
+		})
+		require.NoError(t, err)
+		require.Greater(t, lease.TTL, time.Duration(0), "provider must apply a non-zero default TTL")
+	})
+}
+
+// TestSOPSStore_DoesNotImplementLeasedSecret verifies that the static-secret SOPS provider
+// does not satisfy the LeasedSecret mixin.
+func TestSOPSStore_DoesNotImplementLeasedSecret(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	store, err := sopspkg.NewSOPSSecretStore(&sopspkg.SOPSSecretStoreConfig{
+		StorageProvider: "flatfile",
+		StorageConfig: map[string]interface{}{
+			"root": tmpDir,
+		},
+		CacheEnabled: false,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = store.Close() })
+
+	var secretStore interfaces.SecretStore = store
+	_, ok := secretStore.(interfaces.LeasedSecret)
+	require.False(t, ok, "SOPSSecretStore must NOT implement interfaces.LeasedSecret (static-secret provider)")
+}
+
+// TestStewardStore_DoesNotImplementLeasedSecret verifies that the static-secret steward provider
+// does not satisfy the LeasedSecret mixin.
+func TestStewardStore_DoesNotImplementLeasedSecret(t *testing.T) {
+	// The steward provider requires /etc/machine-id for platform key derivation on Linux.
+	// Skip when it is absent or unreadable (e.g., minimal containers without systemd).
+	if _, err := os.Stat("/etc/machine-id"); err != nil {
+		t.Skip("skipping: /etc/machine-id not available or not readable (required for steward platform key derivation)")
+	}
+
+	tmpDir := t.TempDir()
+
+	provider := &steward.StewardProvider{}
+	store, err := provider.CreateSecretStore(map[string]interface{}{
+		"secrets_dir": tmpDir,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = store.Close() })
+
+	_, ok := store.(interfaces.LeasedSecret)
+	require.False(t, ok, "StewardSecretStore must NOT implement interfaces.LeasedSecret (static-secret provider)")
+}
+
+// TestLease_JSONRoundTrip verifies Lease serialises and deserialises correctly.
+func TestLease_JSONRoundTrip(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Second)
+	original := interfaces.Lease{
+		ID:        "vault-lease-abc123",
+		TTL:       2 * time.Hour,
+		Renewable: true,
+		IssuedAt:  now,
+		ExpiresAt: now.Add(2 * time.Hour),
+	}
+
+	data, err := json.Marshal(original)
+	require.NoError(t, err)
+
+	var decoded interfaces.Lease
+	err = json.Unmarshal(data, &decoded)
+	require.NoError(t, err)
+
+	require.Equal(t, original.ID, decoded.ID)
+	require.Equal(t, original.TTL, decoded.TTL)
+	require.Equal(t, original.Renewable, decoded.Renewable)
+	require.True(t, original.IssuedAt.Equal(decoded.IssuedAt), "IssuedAt mismatch")
+	require.True(t, original.ExpiresAt.Equal(decoded.ExpiresAt), "ExpiresAt mismatch")
+}
+
+// TestLeaseRequest_JSONRoundTrip verifies LeaseRequest serialises and deserialises correctly.
+func TestLeaseRequest_JSONRoundTrip(t *testing.T) {
+	t.Run("with parameters", func(t *testing.T) {
+		original := interfaces.LeaseRequest{
+			TTL:       30 * time.Minute,
+			Renewable: true,
+			Parameters: map[string]any{
+				"role":       "read-only",
+				"ttl_max":    "1h",
+				"max_leases": float64(5), // JSON numbers unmarshal as float64
+			},
+		}
+
+		data, err := json.Marshal(original)
+		require.NoError(t, err)
+
+		var decoded interfaces.LeaseRequest
+		err = json.Unmarshal(data, &decoded)
+		require.NoError(t, err)
+
+		require.Equal(t, original.TTL, decoded.TTL)
+		require.Equal(t, original.Renewable, decoded.Renewable)
+		require.Equal(t, "read-only", decoded.Parameters["role"])
+		require.Equal(t, "1h", decoded.Parameters["ttl_max"])
+		require.Equal(t, float64(5), decoded.Parameters["max_leases"])
+	})
+
+	t.Run("zero value", func(t *testing.T) {
+		original := interfaces.LeaseRequest{}
+
+		data, err := json.Marshal(original)
+		require.NoError(t, err)
+
+		var decoded interfaces.LeaseRequest
+		err = json.Unmarshal(data, &decoded)
+		require.NoError(t, err)
+
+		require.Equal(t, time.Duration(0), decoded.TTL)
+		require.False(t, decoded.Renewable)
+		require.Nil(t, decoded.Parameters)
+	})
+}
+
+// TestSecretMetadata_Policy_JSONRoundTrip verifies the Policy field added to SecretMetadata
+// serialises correctly with and without a value.
+func TestSecretMetadata_Policy_JSONRoundTrip(t *testing.T) {
+	t.Run("without policy", func(t *testing.T) {
+		m := interfaces.SecretMetadata{
+			Key:     "api/key",
+			Version: 1,
+		}
+		data, err := json.Marshal(m)
+		require.NoError(t, err)
+
+		// policy field must be absent when nil (omitempty)
+		require.NotContains(t, string(data), "policy")
+
+		var decoded interfaces.SecretMetadata
+		require.NoError(t, json.Unmarshal(data, &decoded))
+		require.Nil(t, decoded.Policy)
+	})
+
+	t.Run("with policy", func(t *testing.T) {
+		m := interfaces.SecretMetadata{
+			Key:     "api/key",
+			Version: 2,
+			Policy: map[string]any{
+				"ttl":        "24h",
+				"max_leases": float64(10), // JSON numbers unmarshal as float64
+				"bound_ips":  []any{"10.0.0.0/8"},
+			},
+		}
+		data, err := json.Marshal(m)
+		require.NoError(t, err)
+		require.Contains(t, string(data), "policy")
+
+		var decoded interfaces.SecretMetadata
+		require.NoError(t, json.Unmarshal(data, &decoded))
+		require.NotNil(t, decoded.Policy)
+		require.Equal(t, "24h", decoded.Policy["ttl"])
+		require.Equal(t, float64(10), decoded.Policy["max_leases"])
+		require.NotEmpty(t, decoded.Policy["bound_ips"])
+	})
+}

--- a/pkg/secrets/interfaces/secret_store.go
+++ b/pkg/secrets/interfaces/secret_store.go
@@ -83,6 +83,11 @@ type SecretMetadata struct {
 	UpdatedBy   string            `json:"updated_by"`
 	TenantID    string            `json:"tenant_id"`
 	Description string            `json:"description,omitempty"`
+	// Policy carries provider-specific access-control and lease-policy parameters as an
+	// opaque map. Each provider populates only the fields it understands; all others leave
+	// it nil. Callers must not log or expose Policy values — they may contain sensitive
+	// policy identifiers. SOPS and steward providers always leave this nil.
+	Policy map[string]any `json:"policy,omitempty"`
 }
 
 // SecretVersion represents a historical version of a secret


### PR DESCRIPTION
## Summary

- Add `Policy map[string]any` field to `SecretMetadata` for opaque provider-specific access-control and lease-policy parameters (SOPS/steward leave it nil; additive, no existing tests affected)
- Create `pkg/secrets/interfaces/leased_secret.go`: optional `LeasedSecret` mixin interface with `LeaseSecret`/`RenewLease`/`RevokeLease`, plus `Lease` and `LeaseRequest` structs — enables vault-class providers (OpenBao, AWS SM, Azure KV) without forcing static providers to implement stubs
- Create `pkg/secrets/interfaces/leased_secret_test.go`: type-assertion dispatch pattern (happy + error paths), real-provider non-implementation assertions (SOPS, steward), JSON round-trips for all new types
- Create `pkg/secrets/interfaces/README.md`: interface surface table, mixin pattern, "when to implement", provider capability matrix
- Append `## Addendum — SecretStore Package Location` to ADR-003: ratifies `pkg/secrets/` as canonical location; sub-story I does not relocate it
- Update `docs/architecture/storage-architecture.md`: new Secrets section with provider table, `LeasedSecret` usage snippet, corrected interface layout

## Specialist Review Results

| Agent | Result |
|-------|--------|
| qa-test-runner | **PASS** — 87 packages tested, 0 failures; marker file written |
| qa-code-reviewer | **PASS** (after 1 fix iteration: added error-path subtests, fixed `t.Skip` guard, asserted all JSON parameters) |
| security-engineer | **PASS** — 0 blocking issues; 0 new findings; pre-existing gosec G101 false positive on unchanged constant |

## Test plan

- [ ] `go test ./pkg/secrets/interfaces/...` passes
- [ ] `TestSOPSStore_DoesNotImplementLeasedSecret` uses real SOPS provider with flatfile backend
- [ ] `TestStewardStore_DoesNotImplementLeasedSecret` uses real steward provider (skips if `/etc/machine-id` absent — expected in minimal containers)
- [ ] All three `LeasedSecret` method error paths are covered
- [ ] `Lease`, `LeaseRequest`, `SecretMetadata.Policy` JSON round-trips pass

Fixes #675

🤖 Generated with [Claude Code](https://claude.com/claude-code)