### PR TITLE
test(trigger): fix flaky HMAC timing assertion in security test (Issue #688)

### DIFF
--- a/features/workflow/trigger/security_test.go
+++ b/features/workflow/trigger/security_test.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -755,27 +756,20 @@ func TestSecurityEdgeCases_CryptographicSafety(t *testing.T) {
 
 			assert.Equal(t, expectedSignature, signature, tt.description)
 
-			// Test timing attack resistance
-			// Both comparisons should take similar time
-			start1 := time.Now()
-			hmac.Equal([]byte(signature), []byte(expectedSignature))
-			duration1 := time.Since(start1)
-
-			start2 := time.Now()
-			hmac.Equal([]byte("wrong-signature"), []byte(expectedSignature))
-			duration2 := time.Since(start2)
-
-			// The timing difference should be minimal (within reasonable bounds)
-			// This is a basic check - real timing attack detection would require more sophisticated testing
-			timingDiff := duration1 - duration2
-			if timingDiff < 0 {
-				timingDiff = -timingDiff
-			}
-
-			// Allow for up to 1ms difference (this is quite generous for testing)
-			assert.LessOrEqual(t, timingDiff, time.Millisecond, "HMAC comparison should be timing-safe")
+			// Constant-time HMAC comparison is verified by TestWebhookHandlerUsesHmacEqual below —
+			// wall-clock timing is statistically unreliable for single calls.
 		})
 	}
+}
+
+// TestWebhookHandlerUsesHmacEqual verifies that the production webhook handler uses
+// hmac.Equal for signature comparison, ensuring constant-time behavior. This fails
+// if a future refactor accidentally replaces it with bytes.Equal or ==.
+func TestWebhookHandlerUsesHmacEqual(t *testing.T) {
+	source, err := os.ReadFile("webhook.go")
+	require.NoError(t, err, "failed to read webhook.go")
+	assert.True(t, strings.Contains(string(source), "hmac.Equal("),
+		"webhook.go must use hmac.Equal() for signature comparison to ensure constant-time behavior")
 }
 
 // Helper function to generate random bytes for testing


### PR DESCRIPTION
## Summary

- Removes single-sample wall-clock timing block from `TestSecurityEdgeCases_CryptographicSafety` that was flaking on Windows CI (scheduler quantum ~15.6ms made the ≤1ms assertion unstable)
- Adds `TestWebhookHandlerUsesHmacEqual` — a deterministic static-source assertion that reads `webhook.go` and verifies `hmac.Equal(` is present, guarding against future replacement with `bytes.Equal` or `==`
- All 4 existing subtests (short secret, empty payload, binary payload, Unicode secret) and their `expectedSignature == signature` assertions are unchanged

## Specialist Review Results

| Agent | Result |
|-------|--------|
| qa-test-runner | PASS (story tests); pre-existing gofmt issue in unrelated file `pkg/storage/providers/flatfile/steward_store_test.go` (from commit `582b61d1`, not touched by this story) |
| qa-code-reviewer | Pre-existing mock usage in file not introduced by this change; static source check approach explicitly required by issue spec |
| security-engineer | **PASS** — 0 blocking issues |

## Test plan

- [x] `go test -race -count=3 ./features/workflow/trigger/...` — PASS
- [x] `TestSecurityEdgeCases_CryptographicSafety` 4 subtests still run and assert `expectedSignature == signature`
- [x] `TestWebhookHandlerUsesHmacEqual` — verifies `hmac.Equal(` in `webhook.go`
- [x] No `time.Since` or `time.Now()` inside `TestSecurityEdgeCases_CryptographicSafety`
- [x] No other test file modified

Fixes #688

🤖 Generated with [Claude Code](https://claude.com/claude-code)