### PR TITLE
tooling(devcontainer): pin golangci-lint, add go-licenses, harden Trivy install

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -37,18 +37,19 @@ RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
     && rm -rf /var/lib/apt/lists/*
 
 # Go-based security and quality tools
+# Versions MUST match .github/workflows/dependency-pin-check.yml
 RUN go install github.com/securego/gosec/v2/cmd/gosec@v2.25.0 \
     && go install honnef.co/go/tools/cmd/staticcheck@2026.1 \
     && go install github.com/zricethezav/gitleaks/v8@v8.30.1 \
-    && curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh | sh -s -- -b "$(go env GOPATH)/bin"
+    && go install github.com/google/go-licenses/v2@v2.0.1 \
+    && curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh \
+       | sh -s -- -b "$(go env GOPATH)/bin" v2.11.4
 
-# Trivy (apt repo for stable releases)
-RUN curl -fsSL https://aquasecurity.github.io/trivy-repo/deb/public.key \
-      | gpg --dearmor -o /usr/share/keyrings/trivy.gpg \
-    && echo "deb [signed-by=/usr/share/keyrings/trivy.gpg] https://aquasecurity.github.io/trivy-repo/deb bookworm main" \
-      > /etc/apt/sources.list.d/trivy.list \
-    && apt-get update && apt-get install -y trivy=0.69.3 \
-    && rm -rf /var/lib/apt/lists/*
+# Trivy — pinned to v0.69.3 via install.sh because v0.69.4+ are compromised
+# (CVE-2026-33634). The apt repo no longer ships v0.69.3, so we use the
+# official install script against the still-available GitHub release.
+RUN curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh \
+    | sh -s -- -b /usr/local/bin v0.69.3
 
 # Nancy (Go dependency scanner)
 RUN GOPATH=$(go env GOPATH) \

--- a/.github/workflows/production-gates.yml
+++ b/.github/workflows/production-gates.yml
@@ -52,14 +52,11 @@ jobs:
         echo "🔧 Installing Security Tools for Production Gate"
         echo "=============================================="
         
-        # Install Trivy
-        sudo apt-get update
-        sudo apt-get install wget apt-transport-https gnupg lsb-release
-        wget -qO - https://aquasecurity.github.io/trivy-repo/deb/public.key | sudo apt-key add -
-        echo "deb https://aquasecurity.github.io/trivy-repo/deb $(lsb_release -sc) main" | sudo tee -a /etc/apt/sources.list.d/trivy.list
-        sudo apt-get update
-        sudo apt-get install -y trivy=0.69.3  # Pinned: v0.69.4+ are compromised (CVE-2026-33634)
-        
+        # Install Trivy — v0.69.4+ are compromised (CVE-2026-33634); apt repo
+        # no longer ships v0.69.3. Install from the official install.sh against
+        # the still-available GitHub release.
+        curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sudo sh -s -- -b /usr/local/bin v0.69.3
+
         # Install other security tools
         make install-nancy
         go install github.com/securego/gosec/v2/cmd/gosec@v2.25.0

--- a/.github/workflows/release-automation.yml
+++ b/.github/workflows/release-automation.yml
@@ -203,13 +203,10 @@ jobs:
           echo "🔧 Installing development and security tools..."
           echo "=============================================="
 
-          # Install Trivy
-          sudo apt-get update
-          sudo apt-get install wget apt-transport-https gnupg lsb-release
-          wget -qO - https://aquasecurity.github.io/trivy-repo/deb/public.key | sudo apt-key add -
-          echo "deb https://aquasecurity.github.io/trivy-repo/deb $(lsb_release -sc) main" | sudo tee -a /etc/apt/sources.list.d/trivy.list
-          sudo apt-get update
-          sudo apt-get install -y trivy=0.69.3  # Pinned: v0.69.4+ are compromised (CVE-2026-33634)
+          # Install Trivy — v0.69.4+ are compromised (CVE-2026-33634); apt
+          # repo no longer ships v0.69.3. Install from the official install.sh
+          # against the still-available GitHub release.
+          curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sudo sh -s -- -b /usr/local/bin v0.69.3
 
           # Install security scanning tools
           make install-nancy

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -45,13 +45,11 @@ jobs:
     
     - name: Install Trivy
       run: |
-        sudo apt-get update
-        sudo apt-get install wget apt-transport-https gnupg lsb-release
-        wget -qO - https://aquasecurity.github.io/trivy-repo/deb/public.key | sudo apt-key add -
-        echo "deb https://aquasecurity.github.io/trivy-repo/deb $(lsb_release -sc) main" | sudo tee -a /etc/apt/sources.list.d/trivy.list
-        sudo apt-get update
-        sudo apt-get install -y trivy=0.69.3  # Pinned: v0.69.4+ are compromised (CVE-2026-33634)
-    
+        # Trivy v0.69.4+ are compromised (CVE-2026-33634); apt repo no longer
+        # ships v0.69.3. Install from the official install.sh against the
+        # still-available GitHub release.
+        curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sudo sh -s -- -b /usr/local/bin v0.69.3
+
     - name: Run Trivy Scan
       id: scan
       run: |
@@ -298,14 +296,11 @@ jobs:
         # Only install tools if we need to generate remediation report
         make install-nancy
         
-        # Install Trivy
-        sudo apt-get update
-        sudo apt-get install wget apt-transport-https gnupg lsb-release
-        wget -qO - https://aquasecurity.github.io/trivy-repo/deb/public.key | sudo apt-key add -
-        echo "deb https://aquasecurity.github.io/trivy-repo/deb $(lsb_release -sc) main" | sudo tee -a /etc/apt/sources.list.d/trivy.list
-        sudo apt-get update
-        sudo apt-get install -y trivy=0.69.3  # Pinned: v0.69.4+ are compromised (CVE-2026-33634)
-        
+        # Install Trivy — v0.69.4+ are compromised (CVE-2026-33634); apt repo
+        # no longer ships v0.69.3. Install from the official install.sh against
+        # the still-available GitHub release.
+        curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sudo sh -s -- -b /usr/local/bin v0.69.3
+
         # Install gosec and staticcheck
         go install github.com/securego/gosec/v2/cmd/gosec@v2.25.0
         go install honnef.co/go/tools/cmd/staticcheck@2026.1


### PR DESCRIPTION
## Summary

Pin floating devcontainer tooling versions and switch Trivy install to avoid CVE-2026-33634 compromised releases.

- Pin `golangci-lint` to `v2.11.4` (was floating HEAD — causes drift from `.github/workflows/dependency-pin-check.yml`)
- Add `go-licenses v2.0.1` install (required by the license-compliance workflow)
- Switch Trivy install from apt repo to official `install.sh` pinned at `v0.69.3`. The apt repo no longer ships `v0.69.3`, and `v0.69.4+` are compromised per CVE-2026-33634
- Add header comment pointing to `.github/workflows/dependency-pin-check.yml` so future agents keep devcontainer and CI pin in sync

## Test plan

- [x] Pre-push \`make test\` passes
- [ ] Agent dispatch image builds cleanly with the new install commands
- [ ] \`/agent-setup\` rebuild produces a working container
- [ ] Spot-check: \`golangci-lint version\`, \`trivy --version\`, \`go-licenses --help\` all work inside the new image