### PR TITLE
tooling: bump Go to 1.25.9 across Dockerfiles, go.mod, and CI (fixes 5 stdlib CVEs)

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -5,7 +5,7 @@
 # Build: docker build -t cfg-agent:latest -f .devcontainer/Dockerfile .
 # Rebuild weekly to refresh Trivy DB: docker build --no-cache -t cfg-agent:latest -f .devcontainer/Dockerfile .
 
-FROM golang:1.25.8-bookworm
+FROM golang:1.25.9-bookworm
 
 # System dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -41,7 +41,7 @@ on:
   workflow_dispatch:
 
 env:
-  GO_VERSION: '1.23'
+  GO_VERSION: '1.25.9'
 
 jobs:
   analyze:

--- a/.github/workflows/cross-platform-build.yml
+++ b/.github/workflows/cross-platform-build.yml
@@ -15,7 +15,7 @@ on:
   workflow_dispatch:
 
 env:
-  GO_VERSION: '1.23'
+  GO_VERSION: '1.25.9'
 
 jobs:
   # Fast cross-compilation check (single runner, all platforms)

--- a/.github/workflows/docker-security.yml
+++ b/.github/workflows/docker-security.yml
@@ -29,7 +29,7 @@ on:
   workflow_dispatch:
 
 env:
-  GO_VERSION: '1.23'
+  GO_VERSION: '1.25.9'
   REGISTRY: ghcr.io
   IMAGE_PREFIX: cfg-is/cfgms
   TRIVY_VERSION: 'v0.69.3'

--- a/.github/workflows/license-check.yml
+++ b/.github/workflows/license-check.yml
@@ -22,7 +22,7 @@ on:
   workflow_dispatch:
 
 env:
-  GO_VERSION: '1.23'
+  GO_VERSION: '1.25.9'
 
 jobs:
   license-check:

--- a/.github/workflows/production-gates.yml
+++ b/.github/workflows/production-gates.yml
@@ -45,7 +45,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@7b8cf10d4e4a01d4992d18a89f4d7dc5a3e6d6f4 # v4
       with:
-        go-version: '1.23'
+        go-version: '1.25.9'
     
     - name: Install Security Tools
       run: |
@@ -233,7 +233,7 @@ jobs:
   #     - name: Set up Go
   #       uses: actions/setup-go@7b8cf10d4e4a01d4992d18a89f4d7dc5a3e6d6f4 # v4
   #       with:
-  #         go-version: '1.23'
+  #         go-version: '1.25.9'
     
   #     - name: Install dependencies
   #       run: go mod download
@@ -276,7 +276,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@7b8cf10d4e4a01d4992d18a89f4d7dc5a3e6d6f4 # v4
       with:
-        go-version: '1.23'
+        go-version: '1.25.9'
 
     - name: Install dependencies
       run: go mod download
@@ -353,7 +353,7 @@ jobs:
   #     - name: Set up Go
   #       uses: actions/setup-go@7b8cf10d4e4a01d4992d18a89f4d7dc5a3e6d6f4 # v4
   #       with:
-  #         go-version: '1.23'
+  #         go-version: '1.25.9'
     
   #     - name: Install dependencies
   #       run: go mod download
@@ -378,7 +378,7 @@ jobs:
   #     - name: Set up Go
   #       uses: actions/setup-go@7b8cf10d4e4a01d4992d18a89f4d7dc5a3e6d6f4 # v4
   #       with:
-  #         go-version: '1.23'
+  #         go-version: '1.25.9'
     
   #     - name: Install dependencies
   #       run: go mod download
@@ -410,7 +410,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@7b8cf10d4e4a01d4992d18a89f4d7dc5a3e6d6f4 # v4
       with:
-        go-version: '1.23'
+        go-version: '1.25.9'
 
     - name: Install dependencies
       run: go mod download
@@ -495,7 +495,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@7b8cf10d4e4a01d4992d18a89f4d7dc5a3e6d6f4 # v4
       with:
-        go-version: '1.23'
+        go-version: '1.25.9'
     
     - name: Install dependencies
       run: go mod download
@@ -546,7 +546,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@7b8cf10d4e4a01d4992d18a89f4d7dc5a3e6d6f4 # v4
       with:
-        go-version: '1.23'
+        go-version: '1.25.9'
     
     - name: Install dependencies
       run: go mod download
@@ -753,7 +753,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@7b8cf10d4e4a01d4992d18a89f4d7dc5a3e6d6f4 # v4
       with:
-        go-version: '1.23'
+        go-version: '1.25.9'
     
     - name: Install dependencies
       run: go mod download

--- a/.github/workflows/release-automation.yml
+++ b/.github/workflows/release-automation.yml
@@ -44,7 +44,7 @@ on:
         type: boolean
 
 env:
-  GO_VERSION: '1.23'
+  GO_VERSION: '1.25.9'
 
 permissions:
   contents: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ on:
         type: string
 
 env:
-  GO_VERSION: '1.23'
+  GO_VERSION: '1.25.9'
 
 permissions:
   contents: write

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -29,7 +29,7 @@ on:
         - remediation-report
 
 env:
-  GO_VERSION: '1.23'
+  GO_VERSION: '1.25.9'
 
 jobs:
   # Parallel security scanning jobs for optimal performance

--- a/.github/workflows/template-validation.yml
+++ b/.github/workflows/template-validation.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
-          go-version: '1.21'
+          go-version: '1.25.9'
           cache: true
 
       - name: Install dependencies
@@ -111,7 +111,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
-          go-version: '1.21'
+          go-version: '1.25.9'
           cache: true
 
       - name: Test template rendering

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -29,7 +29,7 @@ on:
         - full
 
 env:
-  GO_VERSION: '1.23'
+  GO_VERSION: '1.25.9'
 
 jobs:
   # Fast unit tests - runs on every push/PR

--- a/Dockerfile.test-runner
+++ b/Dockerfile.test-runner
@@ -1,4 +1,4 @@
-FROM golang:1.25.8
+FROM golang:1.25.9
 WORKDIR /workspace
 
 # Install dependencies needed by tests

--- a/cmd/controller/Dockerfile
+++ b/cmd/controller/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM golang:1.25.8-alpine3.23 AS builder
+FROM golang:1.25.9-alpine3.23 AS builder
 
 # Install build dependencies
 RUN apk add --no-cache git ca-certificates

--- a/cmd/steward/Dockerfile
+++ b/cmd/steward/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM golang:1.25.8-alpine3.23 AS builder
+FROM golang:1.25.9-alpine3.23 AS builder
 
 # Install build dependencies
 RUN apk add --no-cache git ca-certificates

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/cfgis/cfgms
 
 go 1.25.0
 
-toolchain go1.25.8
+toolchain go1.25.9
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.41.5


### PR DESCRIPTION
## Summary

Fixes 5 Go stdlib CVEs baked into the controller and steward container binaries by Go 1.25.8 — currently blocking the **Scan Controller Image** and **Scan Steward Image** checks on every PR (e.g. #725).

- CVE-2026-32280 (HIGH) — \`crypto/x509\` chain-building DoS
- CVE-2026-32282 (HIGH) — \`internal/syscall/unix\` \`Root.Chmod\` symlink escape
- CVE-2026-32281 (MEDIUM) — \`crypto/x509\` chain validation DoS
- CVE-2026-32288 (MEDIUM) — \`archive/tar\` DoS
- CVE-2026-32289 (MEDIUM) — \`html/template\` XSS

All fixed in Go 1.25.9 (patch release, drop-in replacement for 1.25.8).

## Also aligned Go version pins

The 8 workflow \`GO_VERSION\` env pins and 6 inline \`go-version\` pins were at \`'1.23'\` — below the \`go 1.25.0\` requirement in \`go.mod\`. They worked because Go's \`toolchain\` directive auto-upgrades, but the pin was misleading and hid drift between CI setup-go and the compiled toolchain. Now all aligned to \`'1.25.9'\`.

## Files changed

- \`cmd/controller/Dockerfile\`, \`cmd/steward/Dockerfile\`, \`.devcontainer/Dockerfile\`, \`Dockerfile.test-runner\` — \`golang:1.25.8\` → \`golang:1.25.9\`
- \`go.mod\` — \`toolchain go1.25.8\` → \`go1.25.9\`
- 8 workflow files — \`GO_VERSION: '1.23'\` → \`'1.25.9'\`
- \`production-gates.yml\` — 6 active \`go-version: '1.23'\` → \`'1.25.9'\` (3 commented-out copies also bumped for consistency)
- \`template-validation.yml\` — 2 \`go-version: '1.21'\` → \`'1.25.9'\`

## Test plan

- [ ] \`go build ./...\` clean (passed locally)
- [ ] CI \`unit-tests\` / \`integration-tests\` pass with Go 1.25.9 toolchain
- [ ] \`docker-security\` \`Scan Controller Image\` and \`Scan Steward Image\` go green (no more stdlib CVE findings)
- [ ] \`trivy-scan\` still clean
- [ ] PR #725 unblocks after rebase once this merges

🤖 Generated with [Claude Code](https://claude.com/claude-code)