### PR TITLE
audit: fix SystemEvent/SecurityEvent validator bug and NewManager panic (Issue #763)

### DIFF
--- a/features/controller/server/server.go
+++ b/features/controller/server/server.go
@@ -150,7 +150,10 @@ func New(cfg *config.Config, logger logging.Logger) (*Server, error) {
 
 	// Initialize unified audit system with pluggable storage only
 	logger.Info("Creating audit manager...")
-	auditManager := audit.NewManager(storageManager.GetAuditStore(), "controller")
+	auditManager, auditErr := audit.NewManager(storageManager.GetAuditStore(), "controller")
+	if auditErr != nil {
+		return nil, fmt.Errorf("failed to initialize audit manager: %w", auditErr)
+	}
 	logger.Info("Audit manager created")
 
 	logger.Info("RBAC and Audit systems initialized with pluggable storage", "provider", cfg.Storage.Provider)
@@ -932,7 +935,8 @@ func (s *Server) Start() error {
 	// Record system startup audit event
 	if s.auditManager != nil {
 		ctx := context.Background()
-		event := audit.SystemEvent("system", "controller_start", fmt.Sprintf("Controller server started on %s", s.cfg.ListenAddr))
+		// TODO(#751): controller identity as a real tenant — replace audit.SystemTenantID with proper identity.
+		event := audit.SystemEvent(audit.SystemTenantID, "controller_start", fmt.Sprintf("Controller server started on %s", s.cfg.ListenAddr))
 		if err := s.auditManager.RecordEvent(ctx, event); err != nil {
 			s.logger.Warn("Failed to record startup audit event", "error", err)
 		}
@@ -979,7 +983,8 @@ func (s *Server) Stop() error {
 	// Record system shutdown audit event
 	if s.auditManager != nil {
 		ctx := context.Background()
-		event := audit.SystemEvent("system", "controller_stop", "Controller server shutting down")
+		// TODO(#751): controller identity as a real tenant — replace audit.SystemTenantID with proper identity.
+		event := audit.SystemEvent(audit.SystemTenantID, "controller_stop", "Controller server shutting down")
 		if err := s.auditManager.RecordEvent(ctx, event); err != nil {
 			s.logger.Warn("Failed to record shutdown audit event", "error", err)
 		}

--- a/features/rbac/manager.go
+++ b/features/rbac/manager.go
@@ -65,7 +65,10 @@ func NewManagerWithStorage(auditStore interfaces.AuditStore, clientTenantStore i
 	hierarchyEngine := NewHierarchyEngine(ephemeralStore, ephemeralStore)
 
 	// Create audit manager for RBAC operations
-	auditManager := audit.NewManager(auditStore, "rbac")
+	auditManager, auditErr := audit.NewManager(auditStore, "rbac")
+	if auditErr != nil {
+		panic(fmt.Sprintf("NewManagerWithStorage: failed to create audit manager: %v", auditErr))
+	}
 
 	// Create manager instance with pluggable storage
 	manager := &Manager{

--- a/features/reports/advanced_test.go
+++ b/features/reports/advanced_test.go
@@ -86,7 +86,8 @@ func TestAdvancedServiceWithConfig(t *testing.T) {
 	t.Cleanup(func() { _ = globalStorageManager.Close() })
 
 	auditStore := globalStorageManager.GetAuditStore()
-	auditManager := audit.NewManager(auditStore, "test-reports")
+	auditManager, err := audit.NewManager(auditStore, "test-reports")
+	require.NoError(t, err)
 
 	rbacManager := rbac.NewManagerWithStorage(
 		auditStore,
@@ -607,7 +608,8 @@ func createTestAdvancedService(t *testing.T) *AdvancedService {
 	t.Cleanup(func() { _ = globalStorageManager.Close() })
 
 	auditStore := globalStorageManager.GetAuditStore()
-	auditManager := audit.NewManager(auditStore, "test-reports")
+	auditManager, err := audit.NewManager(auditStore, "test-reports")
+	require.NoError(t, err, "Failed to create audit manager")
 
 	// Create RBAC manager
 	rbacManager := rbac.NewManagerWithStorage(

--- a/pkg/audit/README.md
+++ b/pkg/audit/README.md
@@ -1,0 +1,49 @@
+# pkg/audit
+
+Unified audit system for all CFGMS components. Provides tamper-evident, validated audit entries stored via pluggable storage backends.
+
+## Sentinel Constants
+
+System-internal events use these sentinel values so callers are not scattered with raw string literals:
+
+| Constant | Value | Purpose |
+|---|---|---|
+| `SystemTenantID` | `"system"` | Tenant ID for controller-internal events |
+| `SystemUserID` | `"system"` | User ID for system-originated events |
+
+> **Note:** These are a known workaround for controller identity. See TODO(#751) for the planned replacement with real tenant/user identity.
+
+## Constructor
+
+`NewManager` returns `(*Manager, error)` — callers must handle the error:
+
+```go
+auditManager, err := audit.NewManager(store, "controller")
+if err != nil {
+    return nil, fmt.Errorf("failed to initialize audit manager: %w", err)
+}
+```
+
+Errors are returned (not panicked) when `store` is nil or `source` is empty.
+
+## Minimal SystemEvent Example
+
+```go
+event := audit.SystemEvent(audit.SystemTenantID, "controller_start", "Controller started on :8443")
+if err := auditManager.RecordEvent(ctx, event); err != nil {
+    logger.Warn("Failed to record startup audit event", "error", err)
+}
+```
+
+`SystemEvent` sets `ResourceID` to `"controller"` so the entry passes `validateEntry`. No additional builder calls are required.
+
+## Minimal SecurityEvent Example
+
+```go
+event := audit.SecurityEvent(tenantID, userID, "brute_force_detected", "5 failed logins in 60s", audit.AuditSeverityHigh)
+if err := auditManager.RecordEvent(ctx, event); err != nil {
+    logger.Warn("Failed to record security audit event", "error", err)
+}
+```
+
+`SecurityEvent` uses `userID` as both the user and the `ResourceID`, satisfying validation.

--- a/pkg/audit/compliance_test.go
+++ b/pkg/audit/compliance_test.go
@@ -16,7 +16,7 @@ import (
 
 // TestNewComplianceReporter tests compliance reporter creation
 func TestNewComplianceReporter(t *testing.T) {
-	manager := NewManager(&mockAuditStore{}, "test")
+	manager := newTestManager(t, "test")
 	reporter := NewComplianceReporter(manager)
 
 	assert.NotNil(t, reporter)
@@ -25,15 +25,13 @@ func TestNewComplianceReporter(t *testing.T) {
 
 // TestGenerateReport tests compliance report generation
 func TestGenerateReport(t *testing.T) {
-	// Setup mock audit store with test data
-	mockStore := &mockAuditStore{}
-	manager := NewManager(mockStore, "test")
+	manager := newTestManager(t, "test")
 	reporter := NewComplianceReporter(manager)
 
 	ctx := context.Background()
 	now := time.Now().UTC()
 
-	// Create test audit entries
+	// Create and store test audit entries via the manager's store directly
 	testEntries := []*interfaces.AuditEntry{
 		{
 			ID:           "entry1",
@@ -82,13 +80,11 @@ func TestGenerateReport(t *testing.T) {
 		},
 	}
 
-	// Store test entries
 	for _, entry := range testEntries {
-		err := mockStore.StoreAuditEntry(ctx, entry)
+		err := manager.store.StoreAuditEntry(ctx, entry)
 		require.NoError(t, err)
 	}
 
-	// Generate compliance report
 	req := &ComplianceReportRequest{
 		TenantID:    "test-tenant",
 		ReportType:  ComplianceReportGeneral,
@@ -103,7 +99,6 @@ func TestGenerateReport(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, report)
 
-	// Validate report structure
 	assert.Equal(t, "test-tenant", report.TenantID)
 	assert.Equal(t, ComplianceReportGeneral, report.ReportType)
 	assert.Equal(t, "test-user", report.GeneratedBy)
@@ -111,41 +106,34 @@ func TestGenerateReport(t *testing.T) {
 	assert.Equal(t, int64(1), report.FailedActionsCount)
 	assert.Equal(t, int64(1), report.SecurityEventsCount)
 
-	// Validate event counts by type
 	assert.Equal(t, int64(1), report.EventsByType["authentication"])
 	assert.Equal(t, int64(1), report.EventsByType["security_event"])
 	assert.Equal(t, int64(1), report.EventsByType["authorization"])
 
-	// Validate event counts by result
 	assert.Equal(t, int64(1), report.EventsByResult["success"])
 	assert.Equal(t, int64(1), report.EventsByResult["failure"])
 	assert.Equal(t, int64(1), report.EventsByResult["denied"])
 
-	// Validate findings
 	assert.NotEmpty(t, report.SecurityFindings)
 	assert.NotEmpty(t, report.AccessFindings)
 
-	// Validate user activity report
 	assert.Len(t, report.UserActivityReport, 3)
 	for _, userActivity := range report.UserActivityReport {
 		assert.Equal(t, int64(1), userActivity.TotalActions)
 	}
 
-	// Validate resource access report
 	assert.Len(t, report.ResourceAccessReport, 3)
 
-	// Validate compliance status assessment
-	assert.NotEqual(t, ComplianceStatusCompliant, report.ComplianceStatus) // Should have warnings due to security events
+	assert.NotEqual(t, ComplianceStatusCompliant, report.ComplianceStatus)
 }
 
 // TestGenerateReport_ValidationErrors tests validation error handling
 func TestGenerateReport_ValidationErrors(t *testing.T) {
-	manager := NewManager(&mockAuditStore{}, "test")
+	manager := newTestManager(t, "test")
 	reporter := NewComplianceReporter(manager)
 
 	ctx := context.Background()
 
-	// Test missing tenant ID
 	req := &ComplianceReportRequest{
 		TenantID:    "",
 		ReportType:  ComplianceReportGeneral,
@@ -160,13 +148,12 @@ func TestGenerateReport_ValidationErrors(t *testing.T) {
 
 // TestExportReport tests report export functionality
 func TestExportReport(t *testing.T) {
-	manager := NewManager(&mockAuditStore{}, "test")
+	manager := newTestManager(t, "test")
 	reporter := NewComplianceReporter(manager)
 
 	ctx := context.Background()
 	now := time.Now().UTC()
 
-	// Create a test report
 	report := &ComplianceReport{
 		ID:          "test-report",
 		TenantID:    "test-tenant",
@@ -218,7 +205,6 @@ func TestExportReport(t *testing.T) {
 		require.NoError(t, err)
 		assert.NotEmpty(t, data)
 
-		// Validate it's valid JSON by checking it contains expected fields
 		jsonStr := string(data)
 		assert.Contains(t, jsonStr, "test-report")
 		assert.Contains(t, jsonStr, "test-tenant")
@@ -231,15 +217,12 @@ func TestExportReport(t *testing.T) {
 		require.NoError(t, err)
 		assert.NotEmpty(t, data)
 
-		// Validate CSV structure
 		csvStr := string(data)
 		lines := strings.Split(csvStr, "\n")
-		assert.GreaterOrEqual(t, len(lines), 2) // At least header + one data row
+		assert.GreaterOrEqual(t, len(lines), 2)
 
-		// Check header
 		assert.Contains(t, lines[0], "Category,Type,Count,Description,Severity,First Seen,Last Seen")
 
-		// Check data rows contain our findings
 		assert.Contains(t, csvStr, "Security")
 		assert.Contains(t, csvStr, "Access Control")
 	})
@@ -249,7 +232,6 @@ func TestExportReport(t *testing.T) {
 		require.NoError(t, err)
 		assert.NotEmpty(t, data)
 
-		// Validate HTML structure
 		htmlStr := string(data)
 		assert.Contains(t, htmlStr, "<!DOCTYPE html>")
 		assert.Contains(t, htmlStr, "<title>Compliance Report")
@@ -267,7 +249,7 @@ func TestExportReport(t *testing.T) {
 
 // TestComplianceStatusAssessment tests compliance status determination
 func TestComplianceStatusAssessment(t *testing.T) {
-	manager := NewManager(&mockAuditStore{}, "test")
+	manager := newTestManager(t, "test")
 	reporter := NewComplianceReporter(manager)
 
 	tests := []struct {
@@ -298,7 +280,7 @@ func TestComplianceStatusAssessment(t *testing.T) {
 				{Severity: interfaces.AuditSeverityHigh},
 				{Severity: interfaces.AuditSeverityHigh},
 				{Severity: interfaces.AuditSeverityHigh},
-				{Severity: interfaces.AuditSeverityHigh}, // 6 high findings
+				{Severity: interfaces.AuditSeverityHigh},
 			},
 			failedActions:  50,
 			expectedStatus: ComplianceStatusViolations,
@@ -328,7 +310,7 @@ func TestComplianceStatusAssessment(t *testing.T) {
 
 // TestComplianceFindingGeneration tests finding generation logic
 func TestComplianceFindingGeneration(t *testing.T) {
-	manager := NewManager(&mockAuditStore{}, "test")
+	manager := newTestManager(t, "test")
 	reporter := NewComplianceReporter(manager)
 
 	now := time.Now().UTC()
@@ -370,15 +352,13 @@ func TestComplianceFindingGeneration(t *testing.T) {
 	report := &ComplianceReport{}
 	reporter.generateFindings(report, entries)
 
-	// Validate security findings
 	require.Len(t, report.SecurityFindings, 1)
 	securityFinding := report.SecurityFindings[0]
 	assert.Equal(t, "security-intrusion_attempt", securityFinding.ID)
 	assert.Equal(t, "Security", securityFinding.Category)
 	assert.Equal(t, interfaces.AuditSeverityCritical, securityFinding.Severity)
-	assert.Equal(t, int64(2), securityFinding.Count) // Two intrusion attempts
+	assert.Equal(t, int64(2), securityFinding.Count)
 
-	// Validate access findings
 	require.Len(t, report.AccessFindings, 1)
 	accessFinding := report.AccessFindings[0]
 	assert.Equal(t, "access-denied-access_resource", accessFinding.ID)
@@ -386,7 +366,6 @@ func TestComplianceFindingGeneration(t *testing.T) {
 	assert.Equal(t, interfaces.AuditSeverityHigh, accessFinding.Severity)
 	assert.Equal(t, int64(1), accessFinding.Count)
 
-	// Validate configuration findings
 	require.Len(t, report.ConfigFindings, 1)
 	configFinding := report.ConfigFindings[0]
 	assert.Equal(t, "config-failed-update_config", configFinding.ID)
@@ -397,7 +376,7 @@ func TestComplianceFindingGeneration(t *testing.T) {
 
 // TestRecommendationGeneration tests recommendation generation logic
 func TestRecommendationGeneration(t *testing.T) {
-	manager := NewManager(&mockAuditStore{}, "test")
+	manager := newTestManager(t, "test")
 	reporter := NewComplianceReporter(manager)
 
 	tests := []struct {
@@ -419,28 +398,28 @@ func TestRecommendationGeneration(t *testing.T) {
 			failedActions:           100,
 			securityEvents:          5,
 			accessFindingsCount:     2,
-			expectedRecommendations: 1, // Reduce failures recommendation
+			expectedRecommendations: 1,
 		},
 		{
 			name:                    "high security events",
 			failedActions:           10,
 			securityEvents:          50,
 			accessFindingsCount:     2,
-			expectedRecommendations: 1, // Investigate security recommendation
+			expectedRecommendations: 1,
 		},
 		{
 			name:                    "many access findings",
 			failedActions:           10,
 			securityEvents:          5,
 			accessFindingsCount:     10,
-			expectedRecommendations: 1, // Review access controls recommendation
+			expectedRecommendations: 1,
 		},
 		{
 			name:                    "all issues",
 			failedActions:           100,
 			securityEvents:          50,
 			accessFindingsCount:     10,
-			expectedRecommendations: 3, // All recommendations
+			expectedRecommendations: 3,
 		},
 	}
 
@@ -455,7 +434,6 @@ func TestRecommendationGeneration(t *testing.T) {
 			reporter.generateRecommendations(report)
 			assert.Len(t, report.Recommendations, tt.expectedRecommendations)
 
-			// Validate recommendation categories
 			categories := make(map[string]bool)
 			for _, rec := range report.Recommendations {
 				categories[rec.Category] = true

--- a/pkg/audit/manager.go
+++ b/pkg/audit/manager.go
@@ -15,6 +15,14 @@ import (
 	"github.com/cfgis/cfgms/pkg/storage/interfaces"
 )
 
+// SystemTenantID is the sentinel tenant ID used for controller-internal system events.
+// TODO(#751): controller identity as a real tenant — replace with proper tenant identity.
+const SystemTenantID = "system"
+
+// SystemUserID is the sentinel user ID used for system-originated audit events.
+// TODO(#751): controller identity as a real tenant — replace with proper user identity.
+const SystemUserID = "system"
+
 // Manager provides centralized audit functionality using pluggable storage
 type Manager struct {
 	store  interfaces.AuditStore
@@ -22,18 +30,18 @@ type Manager struct {
 }
 
 // NewManager creates a new audit manager with the specified storage backend
-func NewManager(store interfaces.AuditStore, source string) *Manager {
+func NewManager(store interfaces.AuditStore, source string) (*Manager, error) {
 	if store == nil {
-		panic("audit manager requires non-nil audit store")
+		return nil, fmt.Errorf("audit manager requires non-nil audit store")
 	}
 	if source == "" {
-		panic("audit manager requires non-empty source identifier")
+		return nil, fmt.Errorf("audit manager requires non-empty source identifier")
 	}
 
 	return &Manager{
 		store:  store,
 		source: source,
-	}
+	}, nil
 }
 
 // RecordEvent records an audit event with automatic metadata generation
@@ -352,7 +360,7 @@ func AuthenticationEvent(tenantID, userID, action string, result interfaces.Audi
 		Type(interfaces.AuditEventAuthentication).
 		Action(action).
 		User(userID, interfaces.AuditUserTypeHuman).
-		Resource("session", "", "").
+		Resource("session", userID, "").
 		Result(result).
 		Severity(interfaces.AuditSeverityHigh)
 }
@@ -410,7 +418,7 @@ func SecurityEvent(tenantID, userID, action, description string, severity interf
 		Type(interfaces.AuditEventSecurityEvent).
 		Action(action).
 		User(userID, interfaces.AuditUserTypeSystem).
-		Resource("security", "", "").
+		Resource("security", userID, "").
 		Detail("description", description).
 		Severity(severity)
 }
@@ -421,8 +429,8 @@ func SystemEvent(tenantID, action, description string) *AuditEventBuilder {
 		Tenant(tenantID).
 		Type(interfaces.AuditEventSystemEvent).
 		Action(action).
-		User("system", interfaces.AuditUserTypeSystem).
-		Resource("system", "", "").
+		User(SystemUserID, interfaces.AuditUserTypeSystem).
+		Resource("system", "controller", "").
 		Detail("description", description).
 		Severity(interfaces.AuditSeverityLow)
 }

--- a/pkg/audit/manager_test.go
+++ b/pkg/audit/manager_test.go
@@ -17,6 +17,19 @@ import (
 	_ "github.com/cfgis/cfgms/pkg/storage/providers/sqlite"
 )
 
+// newTestManager creates a real audit manager backed by OSS storage in a temp dir.
+func newTestManager(t *testing.T, source string) *Manager {
+	t.Helper()
+	tmpDir := t.TempDir()
+	storageManager, err := interfaces.CreateOSSStorageManager(tmpDir+"/flatfile", tmpDir+"/cfgms.db")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = storageManager.Close() })
+
+	m, err := NewManager(storageManager.GetAuditStore(), source)
+	require.NoError(t, err)
+	return m
+}
+
 // TestNewManager tests audit manager creation
 func TestNewManager(t *testing.T) {
 	tests := []struct {
@@ -49,15 +62,21 @@ func TestNewManager(t *testing.T) {
 			require.NoError(t, err)
 			require.NotNil(t, auditStore)
 
-			// Test creating audit manager
-			manager := NewManager(auditStore, "test")
+			manager, err := NewManager(auditStore, "test")
+			require.NoError(t, err)
 			require.NotNil(t, manager)
 		})
 	}
 }
 
-// TestNewManager_PanicConditions tests panic conditions
-func TestNewManager_PanicConditions(t *testing.T) {
+// TestNewManager_ErrorConditions tests error conditions (previously tested as panics)
+func TestNewManager_ErrorConditions(t *testing.T) {
+	tmpDir := t.TempDir()
+	storageManager, err := interfaces.CreateOSSStorageManager(tmpDir+"/flatfile", tmpDir+"/cfgms.db")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = storageManager.Close() })
+	realStore := storageManager.GetAuditStore()
+
 	tests := []struct {
 		name   string
 		store  interfaces.AuditStore
@@ -70,31 +89,25 @@ func TestNewManager_PanicConditions(t *testing.T) {
 		},
 		{
 			name:   "empty source",
-			store:  &mockAuditStore{},
+			store:  realStore,
 			source: "",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Panics(t, func() {
-				NewManager(tt.store, tt.source)
-			})
+			m, err := NewManager(tt.store, tt.source)
+			assert.Error(t, err)
+			assert.Nil(t, m)
 		})
 	}
 }
 
 // TestManager_RecordEvent tests basic event recording
 func TestManager_RecordEvent(t *testing.T) {
-	tmpDir := t.TempDir()
-	storageManager, err := interfaces.CreateOSSStorageManager(tmpDir+"/flatfile", tmpDir+"/cfgms.db")
-	require.NoError(t, err)
-	t.Cleanup(func() { _ = storageManager.Close() })
-
-	manager := NewManager(storageManager.GetAuditStore(), "test")
+	manager := newTestManager(t, "test")
 	ctx := context.Background()
 
-	// Test basic event recording
 	event := NewEventBuilder().
 		Tenant("test-tenant").
 		Type(interfaces.AuditEventConfiguration).
@@ -104,21 +117,15 @@ func TestManager_RecordEvent(t *testing.T) {
 		Detail("test_key", "test_value").
 		Severity(interfaces.AuditSeverityMedium)
 
-	err = manager.RecordEvent(ctx, event)
+	err := manager.RecordEvent(ctx, event)
 	assert.NoError(t, err)
 }
 
 // TestManager_RecordBatch tests batch event recording
 func TestManager_RecordBatch(t *testing.T) {
-	tmpDir := t.TempDir()
-	storageManager, err := interfaces.CreateOSSStorageManager(tmpDir+"/flatfile", tmpDir+"/cfgms.db")
-	require.NoError(t, err)
-	t.Cleanup(func() { _ = storageManager.Close() })
-
-	manager := NewManager(storageManager.GetAuditStore(), "test")
+	manager := newTestManager(t, "test")
 	ctx := context.Background()
 
-	// Create multiple events
 	events := []*AuditEventBuilder{
 		NewEventBuilder().
 			Tenant("test-tenant").
@@ -136,13 +143,13 @@ func TestManager_RecordBatch(t *testing.T) {
 			Severity(interfaces.AuditSeverityMedium),
 	}
 
-	err = manager.RecordBatch(ctx, events)
+	err := manager.RecordBatch(ctx, events)
 	assert.NoError(t, err)
 }
 
 // TestManager_ValidationErrors tests validation error handling
 func TestManager_ValidationErrors(t *testing.T) {
-	manager := NewManager(&mockAuditStore{}, "test")
+	manager := newTestManager(t, "test")
 	ctx := context.Background()
 
 	tests := []struct {
@@ -199,7 +206,6 @@ func TestManager_ValidationErrors(t *testing.T) {
 
 // TestAuditEventBuilder tests the fluent builder interface
 func TestAuditEventBuilder(t *testing.T) {
-	// Test complete event building
 	event := NewEventBuilder().
 		Tenant("test-tenant").
 		Type(interfaces.AuditEventAuthentication).
@@ -215,11 +221,9 @@ func TestAuditEventBuilder(t *testing.T) {
 		Tag("authentication").
 		Severity(interfaces.AuditSeverityHigh)
 
-	// Build into audit entry
 	entry := &interfaces.AuditEntry{}
 	event.build(entry)
 
-	// Validate all fields are set correctly
 	assert.Equal(t, "test-tenant", entry.TenantID)
 	assert.Equal(t, interfaces.AuditEventAuthentication, entry.EventType)
 	assert.Equal(t, "login", entry.Action)
@@ -254,6 +258,8 @@ func TestPredefinedEventBuilders(t *testing.T) {
 		assert.Equal(t, "login", entry.Action)
 		assert.Equal(t, "user1", entry.UserID)
 		assert.Equal(t, interfaces.AuditUserTypeHuman, entry.UserType)
+		assert.Equal(t, "session", entry.ResourceType)
+		assert.Equal(t, "user1", entry.ResourceID)
 		assert.Equal(t, interfaces.AuditResultSuccess, entry.Result)
 		assert.Equal(t, interfaces.AuditSeverityHigh, entry.Severity)
 	})
@@ -296,9 +302,10 @@ func TestPredefinedEventBuilders(t *testing.T) {
 		assert.Equal(t, "tenant1", entry.TenantID)
 		assert.Equal(t, interfaces.AuditEventSystemEvent, entry.EventType)
 		assert.Equal(t, "startup", entry.Action)
-		assert.Equal(t, "system", entry.UserID)
+		assert.Equal(t, SystemUserID, entry.UserID)
 		assert.Equal(t, interfaces.AuditUserTypeSystem, entry.UserType)
 		assert.Equal(t, "system", entry.ResourceType)
+		assert.Equal(t, "controller", entry.ResourceID)
 		assert.Equal(t, "System started successfully", entry.Details["description"])
 		assert.Equal(t, interfaces.AuditSeverityLow, entry.Severity)
 	})
@@ -313,16 +320,49 @@ func TestPredefinedEventBuilders(t *testing.T) {
 		assert.Equal(t, "intrusion_detected", entry.Action)
 		assert.Equal(t, "user1", entry.UserID)
 		assert.Equal(t, "security", entry.ResourceType)
+		assert.Equal(t, "user1", entry.ResourceID)
 		assert.Equal(t, "Multiple failed login attempts", entry.Details["description"])
 		assert.Equal(t, interfaces.AuditSeverityCritical, entry.Severity)
 	})
 }
 
+// TestAuthenticationEvent_Persists verifies AuthenticationEvent produces an entry that passes
+// validateEntry and is successfully stored via RecordEvent.
+func TestAuthenticationEvent_Persists(t *testing.T) {
+	manager := newTestManager(t, "controller")
+	ctx := context.Background()
+
+	event := AuthenticationEvent("tenant1", "user1", "login", interfaces.AuditResultSuccess)
+	err := manager.RecordEvent(ctx, event)
+	assert.NoError(t, err, "AuthenticationEvent must not return a validation error")
+}
+
+// TestSystemEvent_Persists verifies SystemEvent produces an entry that passes validateEntry
+// and is successfully stored via RecordEvent.
+func TestSystemEvent_Persists(t *testing.T) {
+	manager := newTestManager(t, "controller")
+	ctx := context.Background()
+
+	event := SystemEvent(SystemTenantID, "startup", "Controller started")
+	err := manager.RecordEvent(ctx, event)
+	assert.NoError(t, err, "SystemEvent must not return a validation error")
+}
+
+// TestSecurityEvent_Persists verifies SecurityEvent produces an entry that passes validateEntry
+// and is successfully stored via RecordEvent.
+func TestSecurityEvent_Persists(t *testing.T) {
+	manager := newTestManager(t, "controller")
+	ctx := context.Background()
+
+	event := SecurityEvent(SystemTenantID, SystemUserID, "brute_force_detected", "Multiple failed auth attempts", interfaces.AuditSeverityHigh)
+	err := manager.RecordEvent(ctx, event)
+	assert.NoError(t, err, "SecurityEvent must not return a validation error")
+}
+
 // TestManager_IntegrityVerification tests audit integrity verification
 func TestManager_IntegrityVerification(t *testing.T) {
-	manager := NewManager(&mockAuditStore{}, "test")
+	manager := newTestManager(t, "test")
 
-	// Create a test entry
 	entry := &interfaces.AuditEntry{
 		ID:           "test-id",
 		TenantID:     "test-tenant",
@@ -339,106 +379,14 @@ func TestManager_IntegrityVerification(t *testing.T) {
 		Version:      "1.0",
 	}
 
-	// Generate checksum
 	entry.Checksum = manager.generateChecksum(entry)
 
-	// Verify integrity (should pass)
 	assert.True(t, manager.VerifyIntegrity(entry))
 
-	// Tamper with the entry
 	originalAction := entry.Action
 	entry.Action = "tampered_action"
-
-	// Verify integrity (should fail)
 	assert.False(t, manager.VerifyIntegrity(entry))
 
-	// Restore original action
 	entry.Action = originalAction
-
-	// Verify integrity (should pass again)
 	assert.True(t, manager.VerifyIntegrity(entry))
-}
-
-// mockAuditStore is a simple mock implementation for testing
-type mockAuditStore struct {
-	entries map[string]*interfaces.AuditEntry
-}
-
-func (m *mockAuditStore) StoreAuditEntry(ctx context.Context, entry *interfaces.AuditEntry) error {
-	if m.entries == nil {
-		m.entries = make(map[string]*interfaces.AuditEntry)
-	}
-	m.entries[entry.ID] = entry
-	return nil
-}
-
-func (m *mockAuditStore) GetAuditEntry(ctx context.Context, id string) (*interfaces.AuditEntry, error) {
-	if m.entries == nil {
-		return nil, interfaces.ErrAuditNotFound
-	}
-	entry, ok := m.entries[id]
-	if !ok {
-		return nil, interfaces.ErrAuditNotFound
-	}
-	return entry, nil
-}
-
-func (m *mockAuditStore) ListAuditEntries(ctx context.Context, filter *interfaces.AuditFilter) ([]*interfaces.AuditEntry, error) {
-	if m.entries == nil {
-		return []*interfaces.AuditEntry{}, nil
-	}
-
-	result := make([]*interfaces.AuditEntry, 0, len(m.entries))
-	for _, entry := range m.entries {
-		result = append(result, entry)
-	}
-	return result, nil
-}
-
-func (m *mockAuditStore) StoreAuditBatch(ctx context.Context, entries []*interfaces.AuditEntry) error {
-	for _, entry := range entries {
-		if err := m.StoreAuditEntry(ctx, entry); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-func (m *mockAuditStore) GetAuditsByUser(ctx context.Context, userID string, timeRange *interfaces.TimeRange) ([]*interfaces.AuditEntry, error) {
-	return []*interfaces.AuditEntry{}, nil
-}
-
-func (m *mockAuditStore) GetAuditsByResource(ctx context.Context, resourceType, resourceID string, timeRange *interfaces.TimeRange) ([]*interfaces.AuditEntry, error) {
-	return []*interfaces.AuditEntry{}, nil
-}
-
-func (m *mockAuditStore) GetAuditsByAction(ctx context.Context, action string, timeRange *interfaces.TimeRange) ([]*interfaces.AuditEntry, error) {
-	return []*interfaces.AuditEntry{}, nil
-}
-
-func (m *mockAuditStore) GetFailedActions(ctx context.Context, timeRange *interfaces.TimeRange, limit int) ([]*interfaces.AuditEntry, error) {
-	return []*interfaces.AuditEntry{}, nil
-}
-
-func (m *mockAuditStore) GetSuspiciousActivity(ctx context.Context, tenantID string, timeRange *interfaces.TimeRange) ([]*interfaces.AuditEntry, error) {
-	return []*interfaces.AuditEntry{}, nil
-}
-
-func (m *mockAuditStore) GetAuditStats(ctx context.Context) (*interfaces.AuditStats, error) {
-	return &interfaces.AuditStats{
-		TotalEntries: int64(len(m.entries)),
-		LastUpdated:  time.Now(),
-	}, nil
-}
-
-func (m *mockAuditStore) ArchiveAuditEntries(ctx context.Context, beforeDate time.Time) (int64, error) {
-	return 0, nil
-}
-
-func (m *mockAuditStore) PurgeAuditEntries(ctx context.Context, beforeDate time.Time) (int64, error) {
-	return 0, nil
-}
-
-func (m *mockAuditStore) Close() error {
-	return nil
 }

--- a/pkg/testing/storage_helper.go
+++ b/pkg/testing/storage_helper.go
@@ -65,6 +65,11 @@ func SetupTestRBACManager(t *testing.T) *rbac.Manager {
 
 // SetupTestAuditManager creates an audit manager with git storage for testing
 func SetupTestAuditManager(t *testing.T) *audit.Manager {
+	t.Helper()
 	storageManager := SetupTestStorage(t)
-	return audit.NewManager(storageManager.GetAuditStore(), "test")
+	m, err := audit.NewManager(storageManager.GetAuditStore(), "test")
+	if err != nil {
+		t.Fatalf("Failed to initialize test audit manager: %v", err)
+	}
+	return m
 }


### PR DESCRIPTION
## Summary

- `SystemEvent`, `SecurityEvent`, and `AuthenticationEvent` produced entries with empty `ResourceID` that silently failed `validateEntry` — controller start/stop and security incidents were never persisted. Fixed by using non-empty stable identifiers as `ResourceID` in each builder.
- `NewManager` panicked on nil/empty inputs instead of returning `(*Manager, error)`. Changed to standard Go constructor contract; all call sites updated.
- `mockAuditStore` (CLAUDE.md no-mocks violation) removed entirely; all tests now use real `interfaces.CreateOSSStorageManager` backed by `t.TempDir()`.
- Added `SystemTenantID`/`SystemUserID` sentinel constants to replace raw `"system"` string literals.
- Created `pkg/audit/README.md` documenting sentinel constants, `NewManager` error contract, and minimal event examples.

## Files Changed

| File | Change |
|------|--------|
| `pkg/audit/manager.go` | NewManager→error, fix 3 event builders, add sentinel constants |
| `pkg/audit/manager_test.go` | Remove mockAuditStore, add 3 persistence tests |
| `pkg/audit/compliance_test.go` | Remove mockAuditStore |
| `pkg/audit/README.md` | Created |
| `features/controller/server/server.go` | Handle NewManager error, use SystemTenantID |
| `features/rbac/manager.go` | Handle NewManager error (forward-panic) |
| `features/reports/advanced_test.go` | Handle NewManager error |
| `pkg/testing/storage_helper.go` | Handle NewManager error |

## Specialist Review Results

**QA Test Runner: PASS**
- All quality validation gates passed (unit tests, linting, license headers, architecture checks)
- pkg/audit, features/controller/server, features/rbac, features/reports all PASS
- Trivy deferred to CI (sandbox DNS failure — not a code defect)

**QA Code Reviewer: PASS** (after 1 fix iteration)
- Initial: found AuthenticationEvent empty ResourceID + missing persistence test
- Fixed: AuthenticationEvent now uses userID as ResourceID; TestAuthenticationEvent_Persists added
- Re-review: PASS — 0 blocking issues, 0 warnings

**Security Engineer: PASS**
- security-precommit: PASS
- check-architecture: PASS
- security-scan (gosec, staticcheck): PASS
- No hardcoded secrets, SQL injection, information disclosure, or central provider violations

Fixes #763