### PR TITLE
audit: add internal write queue and Flush for shutdown guarantee (Issue #764)

### DIFF
--- a/features/controller/server/server.go
+++ b/features/controller/server/server.go
@@ -980,13 +980,19 @@ func (s *Server) Stop() error {
 		}
 	}
 
-	// Record system shutdown audit event
+	// Record system shutdown audit event then flush the audit queue before
+	// tearing down storage so in-flight entries reach the store.
 	if s.auditManager != nil {
 		ctx := context.Background()
 		// TODO(#751): controller identity as a real tenant — replace audit.SystemTenantID with proper identity.
 		event := audit.SystemEvent(audit.SystemTenantID, "controller_stop", "Controller server shutting down")
 		if err := s.auditManager.RecordEvent(ctx, event); err != nil {
 			s.logger.Warn("Failed to record shutdown audit event", "error", err)
+		}
+		stopCtx, stopCancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer stopCancel()
+		if err := s.auditManager.Stop(stopCtx); err != nil {
+			s.logger.Warn("Failed to flush audit queue on shutdown", "error", err)
 		}
 	}
 

--- a/features/rbac/audit_integration_test.go
+++ b/features/rbac/audit_integration_test.go
@@ -61,6 +61,7 @@ func TestRBACManager_AuditIntegration(t *testing.T) {
 			Limit:         10,
 		}
 
+		require.NoError(t, manager.auditManager.Flush(ctx), "Flush must drain queue before query")
 		auditEntries, err := manager.auditManager.QueryEntries(ctx, auditFilter)
 		require.NoError(t, err)
 		require.Len(t, auditEntries, 1, "Should have exactly one audit entry for role creation")
@@ -114,6 +115,7 @@ func TestRBACManager_AuditIntegration(t *testing.T) {
 			Limit:         10,
 		}
 
+		require.NoError(t, manager.auditManager.Flush(ctx), "Flush must drain queue before query")
 		auditEntries, err := manager.auditManager.QueryEntries(ctx, auditFilter)
 		require.NoError(t, err)
 		require.Len(t, auditEntries, 1, "Should have exactly one audit entry for role update")
@@ -160,6 +162,7 @@ func TestRBACManager_AuditIntegration(t *testing.T) {
 			Limit:         10,
 		}
 
+		require.NoError(t, manager.auditManager.Flush(ctx), "Flush must drain queue before query")
 		auditEntries, err := manager.auditManager.QueryEntries(ctx, auditFilter)
 		require.NoError(t, err)
 		require.Len(t, auditEntries, 1, "Should have exactly one audit entry for role deletion")
@@ -222,6 +225,7 @@ func TestRBACManager_AuditIntegration(t *testing.T) {
 			Limit:         10,
 		}
 
+		require.NoError(t, manager.auditManager.Flush(ctx), "Flush must drain queue before query")
 		auditEntries, err := manager.auditManager.QueryEntries(ctx, auditFilter)
 		require.NoError(t, err)
 		require.Len(t, auditEntries, 1, "Should have exactly one audit entry for role revocation")
@@ -261,6 +265,7 @@ func TestRBACManager_AuditIntegration(t *testing.T) {
 
 		// Note: This test depends on whether the underlying store validates the role
 		// If validation passes through, we won't get an error audit event
+		require.NoError(t, manager.auditManager.Flush(ctx), "Flush must drain queue before query")
 		auditEntries, err := manager.auditManager.QueryEntries(ctx, auditFilter)
 		require.NoError(t, err)
 
@@ -280,6 +285,7 @@ func TestRBACManager_AuditIntegration(t *testing.T) {
 			Limit:      100,
 		}
 
+		require.NoError(t, manager.auditManager.Flush(ctx), "Flush must drain queue before query")
 		auditEntries, err := manager.auditManager.QueryEntries(ctx, auditFilter)
 		require.NoError(t, err)
 		assert.NotEmpty(t, auditEntries, "Should have audit entries from previous tests")

--- a/features/rbac/manager.go
+++ b/features/rbac/manager.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 
 	"github.com/cfgis/cfgms/api/proto/common"
 	"github.com/cfgis/cfgms/features/rbac/memory"
@@ -305,7 +306,9 @@ func (m *Manager) CreateRole(ctx context.Context, role *common.Role) error {
 					Error("RBAC_PARENT_ROLE_NOT_FOUND", fmt.Sprintf("parent role %s not found: %v", role.ParentRoleId, err)).
 					Detail("parent_role_id", role.ParentRoleId).
 					Severity(interfaces.AuditSeverityCritical)
-				_ = m.auditManager.RecordEvent(ctx, event)
+				if err := m.auditManager.RecordEvent(ctx, event); err != nil {
+					slog.Warn("audit: failed to record event", "error", err)
+				}
 			}
 			return fmt.Errorf("parent role %s not found: %w", role.ParentRoleId, err)
 		}
@@ -326,7 +329,9 @@ func (m *Manager) CreateRole(ctx context.Context, role *common.Role) error {
 					Detail("parent_role_id", role.ParentRoleId).
 					Detail("security_finding", "M-TENANT-2").
 					Severity(interfaces.AuditSeverityCritical)
-				_ = m.auditManager.RecordEvent(ctx, event)
+				if err := m.auditManager.RecordEvent(ctx, event); err != nil {
+					slog.Warn("audit: failed to record event", "error", err)
+				}
 			}
 
 			return errors.New(errMsg)
@@ -343,7 +348,9 @@ func (m *Manager) CreateRole(ctx context.Context, role *common.Role) error {
 				Result(interfaces.AuditResultError).
 				Error("RBAC_CREATE_ROLE_FAILED", err.Error()).
 				Severity(interfaces.AuditSeverityHigh)
-			_ = m.auditManager.RecordEvent(ctx, event)
+			if err := m.auditManager.RecordEvent(ctx, event); err != nil {
+				slog.Warn("audit: failed to record event", "error", err)
+			}
 		}
 		return err
 	}
@@ -361,7 +368,9 @@ func (m *Manager) CreateRole(ctx context.Context, role *common.Role) error {
 					Result(interfaces.AuditResultError).
 					Error("RBAC_CREATE_ROLE_PERSISTENCE_FAILED", persistErr.Error()).
 					Severity(interfaces.AuditSeverityHigh)
-				_ = m.auditManager.RecordEvent(ctx, event)
+				if err := m.auditManager.RecordEvent(ctx, event); err != nil {
+					slog.Warn("audit: failed to record event", "error", err)
+				}
 			}
 			return fmt.Errorf("failed to persist role: %w", persistErr)
 		}
@@ -375,7 +384,9 @@ func (m *Manager) CreateRole(ctx context.Context, role *common.Role) error {
 			Detail("role_permissions", len(role.PermissionIds)).
 			Detail("role_description", role.Description).
 			Severity(interfaces.AuditSeverityHigh)
-		_ = m.auditManager.RecordEvent(ctx, event)
+		if err := m.auditManager.RecordEvent(ctx, event); err != nil {
+			slog.Warn("audit: failed to record event", "error", err)
+		}
 	}
 
 	return nil
@@ -406,7 +417,9 @@ func (m *Manager) UpdateRole(ctx context.Context, role *common.Role) error {
 				Result(interfaces.AuditResultError).
 				Error("RBAC_UPDATE_ROLE_FAILED", err.Error()).
 				Severity(interfaces.AuditSeverityHigh)
-			_ = m.auditManager.RecordEvent(ctx, event)
+			if err := m.auditManager.RecordEvent(ctx, event); err != nil {
+				slog.Warn("audit: failed to record event", "error", err)
+			}
 		}
 		return err
 	}
@@ -421,7 +434,9 @@ func (m *Manager) UpdateRole(ctx context.Context, role *common.Role) error {
 					Result(interfaces.AuditResultError).
 					Error("RBAC_UPDATE_ROLE_PERSISTENCE_FAILED", persistErr.Error()).
 					Severity(interfaces.AuditSeverityHigh)
-				_ = m.auditManager.RecordEvent(ctx, event)
+				if err := m.auditManager.RecordEvent(ctx, event); err != nil {
+					slog.Warn("audit: failed to record event", "error", err)
+				}
 			}
 			return fmt.Errorf("failed to persist role update: %w", persistErr)
 		}
@@ -466,7 +481,9 @@ func (m *Manager) UpdateRole(ctx context.Context, role *common.Role) error {
 			}
 		}
 
-		_ = m.auditManager.RecordEvent(ctx, event)
+		if err := m.auditManager.RecordEvent(ctx, event); err != nil {
+			slog.Warn("audit: failed to record event", "error", err)
+		}
 	}
 
 	return nil
@@ -517,7 +534,9 @@ func (m *Manager) DeleteRole(ctx context.Context, id string) error {
 				Result(interfaces.AuditResultError).
 				Error("RBAC_DELETE_ROLE_FAILED", err.Error()).
 				Severity(interfaces.AuditSeverityCritical)
-			_ = m.auditManager.RecordEvent(ctx, event)
+			if err := m.auditManager.RecordEvent(ctx, event); err != nil {
+				slog.Warn("audit: failed to record event", "error", err)
+			}
 		}
 		return err
 	}
@@ -539,7 +558,9 @@ func (m *Manager) DeleteRole(ctx context.Context, id string) error {
 					Result(interfaces.AuditResultError).
 					Error("RBAC_DELETE_ROLE_PERSISTENCE_FAILED", persistErr.Error()).
 					Severity(interfaces.AuditSeverityCritical)
-				_ = m.auditManager.RecordEvent(ctx, event)
+				if err := m.auditManager.RecordEvent(ctx, event); err != nil {
+					slog.Warn("audit: failed to record event", "error", err)
+				}
 			}
 			return fmt.Errorf("failed to persist role deletion: %w", persistErr)
 		}
@@ -565,7 +586,9 @@ func (m *Manager) DeleteRole(ctx context.Context, id string) error {
 				Detail("role_description", deletedRole.Description)
 		}
 
-		_ = m.auditManager.RecordEvent(ctx, event)
+		if err := m.auditManager.RecordEvent(ctx, event); err != nil {
+			slog.Warn("audit: failed to record event", "error", err)
+		}
 	}
 
 	return nil
@@ -633,7 +656,9 @@ func (m *Manager) RevokeRole(ctx context.Context, subjectID, roleID, tenantID st
 				Detail("revoked_role", roleID).
 				Detail("subject_id", subjectID).
 				Severity(interfaces.AuditSeverityHigh)
-			_ = m.auditManager.RecordEvent(ctx, event)
+			if err := m.auditManager.RecordEvent(ctx, event); err != nil {
+				slog.Warn("audit: failed to record event", "error", err)
+			}
 		}
 		return err
 	}
@@ -650,7 +675,9 @@ func (m *Manager) RevokeRole(ctx context.Context, subjectID, roleID, tenantID st
 					Detail("revoked_role", roleID).
 					Detail("subject_id", subjectID).
 					Severity(interfaces.AuditSeverityHigh)
-				_ = m.auditManager.RecordEvent(ctx, event)
+				if err := m.auditManager.RecordEvent(ctx, event); err != nil {
+					slog.Warn("audit: failed to record event", "error", err)
+				}
 			}
 			return fmt.Errorf("failed to persist role revocation: %w", persistErr)
 		}
@@ -664,7 +691,9 @@ func (m *Manager) RevokeRole(ctx context.Context, subjectID, roleID, tenantID st
 			Detail("revoked_role", roleID).
 			Detail("subject_id", subjectID).
 			Severity(interfaces.AuditSeverityHigh)
-		_ = m.auditManager.RecordEvent(ctx, event)
+		if err := m.auditManager.RecordEvent(ctx, event); err != nil {
+			slog.Warn("audit: failed to record event", "error", err)
+		}
 	}
 
 	return nil

--- a/features/rbac/sensitive_operations.go
+++ b/features/rbac/sensitive_operations.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 
 	"github.com/cfgis/cfgms/pkg/audit"
 	"github.com/cfgis/cfgms/pkg/storage/interfaces"
@@ -148,7 +149,9 @@ func (m *Manager) AuditSensitiveOperation(ctx context.Context, opCtx *SensitiveO
 	}
 
 	// Record the audit event
-	_ = m.auditManager.RecordEvent(ctx, event)
+	if err := m.auditManager.RecordEvent(ctx, event); err != nil {
+		slog.Warn("audit: failed to record sensitive operation event", "error", err)
+	}
 }
 
 // GetSensitiveOperationJustification retrieves justification from context

--- a/pkg/audit/README.md
+++ b/pkg/audit/README.md
@@ -48,6 +48,41 @@ if err := auditManager.RecordEvent(ctx, event); err != nil {
 
 `SecurityEvent` uses `userID` as both the user and the `ResourceID`, satisfying validation.
 
+## Shutdown Guarantee
+
+`Manager` has an internal bounded write queue (`defaultQueueCapacity = 1024`) and a background drain goroutine started by `NewManager`. All `RecordEvent` and `RecordBatch` calls enqueue entries for async storage rather than writing synchronously. Two methods guarantee emission completeness during shutdown:
+
+### `Flush(ctx context.Context) error`
+
+Waits until all entries enqueued **before** the call have been persisted. Returns `ctx.Err()` if the context expires before draining completes. Callers should use a generous timeout (e.g. 10 s) to allow the drain loop to finish writing.
+
+```go
+flushCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+defer cancel()
+if err := auditManager.Flush(flushCtx); err != nil {
+    logger.Warn("audit Flush timed out", "error", err)
+}
+```
+
+### `Stop(ctx context.Context) error`
+
+Calls `Flush` then shuts down the drain goroutine. **Must be called before the storage backend is closed** so in-flight entries are not lost. `Stop` is idempotent — safe to call multiple times.
+
+```go
+// In shutdown path, before closing the storage manager:
+stopCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+defer cancel()
+if err := auditManager.Stop(stopCtx); err != nil {
+    logger.Warn("audit Stop error", "error", err)
+}
+```
+
+### Queue-full behaviour
+
+When the queue is at capacity, `RecordEvent` logs a warning via `slog.Default()` and returns `errQueueFull` — **it does not block the caller**. This is an intentional design choice: audit must never stall application code. The `defaultQueueCapacity = 1024` constant is defined in `manager.go` and easy to tune.
+
+Storage errors (e.g. the underlying store returning an error) are logged by the drain goroutine but do not propagate back to the original caller, because the write is asynchronous.
+
 ## Compliance Reporting
 
 Compliance report generation is handled by `features/reports/`, not by this package.

--- a/pkg/audit/manager.go
+++ b/pkg/audit/manager.go
@@ -7,7 +7,10 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"fmt"
+	"log/slog"
+	"sync"
 	"time"
 
 	"github.com/google/uuid"
@@ -23,13 +26,32 @@ const SystemTenantID = "system"
 // TODO(#751): controller identity as a real tenant — replace with proper user identity.
 const SystemUserID = "system"
 
+// defaultQueueCapacity is the bounded capacity of the internal write queue.
+// When the queue is full, RecordEvent logs a warning and drops the entry rather
+// than blocking the caller — audit must not stall application code.
+const defaultQueueCapacity = 1024
+
+// errQueueFull is returned when the audit queue has no remaining capacity.
+var errQueueFull = errors.New("audit queue full: entry dropped")
+
+// errManagerStopped is returned when RecordEvent is called after Stop.
+var errManagerStopped = errors.New("audit manager stopped")
+
 // Manager provides centralized audit functionality using pluggable storage
 type Manager struct {
 	store  interfaces.AuditStore
-	source string // Component identifier for audit source
+	source string
+	logger *slog.Logger
+
+	queue     chan *interfaces.AuditEntry
+	flushCh   chan chan struct{}
+	stopCh    chan struct{}
+	stopOnce  sync.Once
+	drainDone chan struct{}
 }
 
-// NewManager creates a new audit manager with the specified storage backend
+// NewManager creates a new audit manager with the specified storage backend.
+// A background drain goroutine is started; call Stop to shut it down cleanly.
 func NewManager(store interfaces.AuditStore, source string) (*Manager, error) {
 	if store == nil {
 		return nil, fmt.Errorf("audit manager requires non-nil audit store")
@@ -38,15 +60,111 @@ func NewManager(store interfaces.AuditStore, source string) (*Manager, error) {
 		return nil, fmt.Errorf("audit manager requires non-empty source identifier")
 	}
 
-	return &Manager{
-		store:  store,
-		source: source,
-	}, nil
+	m := &Manager{
+		store:     store,
+		source:    source,
+		logger:    slog.Default(),
+		queue:     make(chan *interfaces.AuditEntry, defaultQueueCapacity),
+		flushCh:   make(chan chan struct{}),
+		stopCh:    make(chan struct{}),
+		drainDone: make(chan struct{}),
+	}
+
+	go m.drainLoop()
+
+	return m, nil
 }
 
-// RecordEvent records an audit event with automatic metadata generation
+// drainLoop reads entries from the queue and stores them one at a time.
+// On a flush request it drains all pending entries before acknowledging.
+// On stop it drains remaining entries then exits.
+func (m *Manager) drainLoop() {
+	defer close(m.drainDone)
+
+	storeEntry := func(entry *interfaces.AuditEntry) {
+		ctx := context.Background()
+		if err := m.store.StoreAuditEntry(ctx, entry); err != nil {
+			m.logger.Warn("audit: failed to store entry", "error", err, "id", entry.ID)
+		}
+	}
+
+	drainQueue := func() {
+		for {
+			select {
+			case entry := <-m.queue:
+				storeEntry(entry)
+			default:
+				return
+			}
+		}
+	}
+
+	for {
+		select {
+		case entry := <-m.queue:
+			storeEntry(entry)
+
+		case ack := <-m.flushCh:
+			// Drain all entries currently queued before acknowledging.
+			drainQueue()
+			close(ack)
+
+		case <-m.stopCh:
+			// Drain any entries that arrived between the last Flush and Stop.
+			drainQueue()
+			return
+		}
+	}
+}
+
+// Flush waits until all entries enqueued before this call have been stored.
+// Returns ctx.Err() if the context is cancelled before draining completes.
+func (m *Manager) Flush(ctx context.Context) error {
+	ack := make(chan struct{})
+	select {
+	case m.flushCh <- ack:
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+	select {
+	case <-ack:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+// Stop flushes all queued entries and shuts down the drain goroutine.
+// Stop is idempotent and safe to call multiple times.
+func (m *Manager) Stop(ctx context.Context) error {
+	var firstErr error
+	m.stopOnce.Do(func() {
+		if err := m.Flush(ctx); err != nil {
+			firstErr = err
+		}
+		close(m.stopCh)
+		select {
+		case <-m.drainDone:
+		case <-ctx.Done():
+			if firstErr == nil {
+				firstErr = ctx.Err()
+			}
+		}
+	})
+	return firstErr
+}
+
+// RecordEvent records an audit event with automatic metadata generation.
+// The entry is validated synchronously, then enqueued for async storage.
+// If the queue is full the entry is dropped and errQueueFull is returned.
 func (m *Manager) RecordEvent(ctx context.Context, event *AuditEventBuilder) error {
-	// Build the complete audit entry
+	// Check if the manager has been stopped.
+	select {
+	case <-m.stopCh:
+		return errManagerStopped
+	default:
+	}
+
 	entry := &interfaces.AuditEntry{
 		ID:        uuid.New().String(),
 		Timestamp: time.Now().UTC(),
@@ -54,25 +172,35 @@ func (m *Manager) RecordEvent(ctx context.Context, event *AuditEventBuilder) err
 		Version:   "1.0",
 	}
 
-	// Apply the builder to the entry
 	event.build(entry)
 
-	// Validate required fields
 	if err := m.validateEntry(entry); err != nil {
 		return fmt.Errorf("audit validation failed: %w", err)
 	}
 
-	// Generate integrity checksum
 	entry.Checksum = m.generateChecksum(entry)
 
-	// Store the audit entry
-	return m.store.StoreAuditEntry(ctx, entry)
+	select {
+	case m.queue <- entry:
+		return nil
+	default:
+		m.logger.Warn("audit queue full: dropping entry", "id", entry.ID, "action", entry.Action, "source", m.source)
+		return errQueueFull
+	}
 }
 
-// RecordBatch records multiple audit events atomically
+// RecordBatch records multiple audit events. Each entry is enqueued individually;
+// batch delivery is no longer atomic with respect to store transactions.
+// Returns an error listing how many entries were dropped if the queue is full.
 func (m *Manager) RecordBatch(ctx context.Context, events []*AuditEventBuilder) error {
-	entries := make([]*interfaces.AuditEntry, len(events))
+	// Check if the manager has been stopped.
+	select {
+	case <-m.stopCh:
+		return errManagerStopped
+	default:
+	}
 
+	dropped := 0
 	for i, event := range events {
 		entry := &interfaces.AuditEntry{
 			ID:        uuid.New().String(),
@@ -88,10 +216,19 @@ func (m *Manager) RecordBatch(ctx context.Context, events []*AuditEventBuilder) 
 		}
 
 		entry.Checksum = m.generateChecksum(entry)
-		entries[i] = entry
+
+		select {
+		case m.queue <- entry:
+		default:
+			m.logger.Warn("audit queue full: dropping batch entry", "id", entry.ID, "action", entry.Action, "source", m.source)
+			dropped++
+		}
 	}
 
-	return m.store.StoreAuditBatch(ctx, entries)
+	if dropped > 0 {
+		return fmt.Errorf("audit queue full: %d of %d batch entries dropped", dropped, len(events))
+	}
+	return nil
 }
 
 // GetEntry retrieves an audit entry by ID

--- a/pkg/audit/manager_test.go
+++ b/pkg/audit/manager_test.go
@@ -4,6 +4,7 @@ package audit
 
 import (
 	"context"
+	"sync"
 	"testing"
 	"time"
 
@@ -18,6 +19,7 @@ import (
 )
 
 // newTestManager creates a real audit manager backed by OSS storage in a temp dir.
+// It registers a cleanup to call Stop so background goroutines do not leak.
 func newTestManager(t *testing.T, source string) *Manager {
 	t.Helper()
 	tmpDir := t.TempDir()
@@ -27,7 +29,56 @@ func newTestManager(t *testing.T, source string) *Manager {
 
 	m, err := NewManager(storageManager.GetAuditStore(), source)
 	require.NoError(t, err)
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_ = m.Stop(ctx)
+	})
 	return m
+}
+
+// slowAuditStore wraps a real AuditStore and adds a configurable delay to
+// StoreAuditEntry so tests can verify Flush waits for completion.
+type slowAuditStore struct {
+	interfaces.AuditStore
+	delay time.Duration
+	mu    sync.Mutex
+	count int
+}
+
+func (s *slowAuditStore) StoreAuditEntry(ctx context.Context, entry *interfaces.AuditEntry) error {
+	time.Sleep(s.delay)
+	err := s.AuditStore.StoreAuditEntry(ctx, entry)
+	if err == nil {
+		s.mu.Lock()
+		s.count++
+		s.mu.Unlock()
+	}
+	return err
+}
+
+func (s *slowAuditStore) stored() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.count
+}
+
+// holdAuditStore blocks every StoreAuditEntry call until release is closed.
+// ready receives a signal when the first call blocks, allowing the test to
+// deterministically fill the queue before releasing.
+type holdAuditStore struct {
+	interfaces.AuditStore
+	ready   chan struct{}
+	release chan struct{}
+}
+
+func (s *holdAuditStore) StoreAuditEntry(ctx context.Context, entry *interfaces.AuditEntry) error {
+	select {
+	case s.ready <- struct{}{}:
+	default:
+	}
+	<-s.release
+	return s.AuditStore.StoreAuditEntry(ctx, entry)
 }
 
 // TestNewManager tests audit manager creation
@@ -389,4 +440,160 @@ func TestManager_IntegrityVerification(t *testing.T) {
 
 	entry.Action = originalAction
 	assert.True(t, manager.VerifyIntegrity(entry))
+}
+
+// TestManager_Flush verifies that after Flush returns, all previously recorded
+// events are queryable from the real store.
+func TestManager_Flush(t *testing.T) {
+	manager := newTestManager(t, "test-flush")
+	ctx := context.Background()
+
+	const n = 20
+	for i := 0; i < n; i++ {
+		event := NewEventBuilder().
+			Tenant("test-tenant").
+			Type(interfaces.AuditEventConfiguration).
+			Action("flush_test").
+			User("test-user", interfaces.AuditUserTypeHuman).
+			Resource("resource", "res-id", "Res")
+		err := manager.RecordEvent(ctx, event)
+		require.NoError(t, err)
+	}
+
+	flushCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+	require.NoError(t, manager.Flush(flushCtx), "Flush must not return error")
+
+	entries, err := manager.QueryEntries(ctx, &interfaces.AuditFilter{Actions: []string{"flush_test"}})
+	require.NoError(t, err)
+	assert.Len(t, entries, n, "all %d events must be in the store after Flush", n)
+}
+
+// TestManager_ShutdownOrderGuarantee verifies that Flush waits for a slow store
+// to finish writing before returning, rather than dropping in-flight entries.
+func TestManager_ShutdownOrderGuarantee(t *testing.T) {
+	tmpDir := t.TempDir()
+	storageManager, err := interfaces.CreateOSSStorageManager(tmpDir+"/flatfile", tmpDir+"/cfgms.db")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = storageManager.Close() })
+
+	slow := &slowAuditStore{
+		AuditStore: storageManager.GetAuditStore(),
+		delay:      20 * time.Millisecond,
+	}
+
+	manager, err := NewManager(slow, "test-slow")
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		_ = manager.Stop(ctx)
+	})
+
+	ctx := context.Background()
+	const n = 5
+	for i := 0; i < n; i++ {
+		event := NewEventBuilder().
+			Tenant("test-tenant").
+			Type(interfaces.AuditEventConfiguration).
+			Action("slow_test").
+			User("test-user", interfaces.AuditUserTypeHuman).
+			Resource("resource", "res-id", "Res")
+		require.NoError(t, manager.RecordEvent(ctx, event))
+	}
+
+	flushCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+	require.NoError(t, manager.Flush(flushCtx))
+
+	// After Flush returns, all entries must have been persisted.
+	assert.Equal(t, n, slow.stored(), "Flush must wait for all slow-store writes to complete")
+}
+
+// TestManager_StopIsIdempotent verifies that calling Stop multiple times is safe.
+func TestManager_StopIsIdempotent(t *testing.T) {
+	manager := newTestManager(t, "test-idempotent")
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	require.NoError(t, manager.Stop(ctx))
+	require.NoError(t, manager.Stop(ctx)) // second call must not panic or error
+}
+
+// TestManager_RecordEventAfterStop verifies that RecordEvent returns an error
+// when called after the manager has been stopped.
+func TestManager_RecordEventAfterStop(t *testing.T) {
+	manager := newTestManager(t, "test-after-stop")
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	require.NoError(t, manager.Stop(ctx))
+
+	event := NewEventBuilder().
+		Tenant("test-tenant").
+		Type(interfaces.AuditEventConfiguration).
+		Action("post_stop").
+		User("test-user", interfaces.AuditUserTypeHuman).
+		Resource("resource", "res-id", "Res")
+	err := manager.RecordEvent(context.Background(), event)
+	assert.ErrorIs(t, err, errManagerStopped)
+}
+
+// TestManager_QueueFull verifies that RecordEvent returns errQueueFull when the
+// internal write queue is at capacity, without blocking the caller.
+func TestManager_QueueFull(t *testing.T) {
+	tmpDir := t.TempDir()
+	storageManager, err := interfaces.CreateOSSStorageManager(tmpDir+"/flatfile", tmpDir+"/cfgms.db")
+	require.NoError(t, err)
+
+	release := make(chan struct{})
+	hold := &holdAuditStore{
+		AuditStore: storageManager.GetAuditStore(),
+		ready:      make(chan struct{}, 1),
+		release:    release,
+	}
+
+	manager, err := NewManager(hold, "test-full")
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		// Unblock store so Stop/Flush can complete.
+		select {
+		case <-release:
+		default:
+			close(release)
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_ = manager.Stop(ctx)
+		_ = storageManager.Close()
+	})
+
+	ctx := context.Background()
+	newEvent := func() *AuditEventBuilder {
+		return NewEventBuilder().
+			Tenant("test-tenant").
+			Type(interfaces.AuditEventConfiguration).
+			Action("queue_full_test").
+			User("test-user", interfaces.AuditUserTypeHuman).
+			Resource("resource", "res-id", "Res")
+	}
+
+	// The drain loop takes the first entry and blocks inside StoreAuditEntry.
+	require.NoError(t, manager.RecordEvent(ctx, newEvent()))
+
+	// Wait until the drain loop is confirmed blocked.
+	select {
+	case <-hold.ready:
+	case <-time.After(5 * time.Second):
+		t.Fatal("drain loop did not block within timeout")
+	}
+
+	// Fill the queue buffer to capacity — all enqueues must succeed.
+	for i := 0; i < defaultQueueCapacity; i++ {
+		require.NoError(t, manager.RecordEvent(ctx, newEvent()), "entry %d must fit in queue", i)
+	}
+
+	// The next entry overflows the queue and must return errQueueFull.
+	err = manager.RecordEvent(ctx, newEvent())
+	assert.ErrorIs(t, err, errQueueFull, "RecordEvent must return errQueueFull when queue is full")
 }


### PR DESCRIPTION
## Summary

- **`pkg/audit/Manager`** gains a bounded internal write queue (`defaultQueueCapacity = 1024`) and a background drain goroutine so `RecordEvent`/`RecordBatch` never block callers on I/O.
- **`Flush(ctx)`** waits until all entries enqueued before the call are persisted; **`Stop(ctx)`** = Flush + shut down drain goroutine (idempotent via `sync.Once`).
- **`features/controller/server/server.go`** calls `auditManager.Stop(ctx)` in the shutdown path before storage teardown, guaranteeing the shutdown audit event reaches durable storage.
- All `_ = m.auditManager.RecordEvent(...)` blanket-discards in `features/rbac/manager.go` and `features/rbac/sensitive_operations.go` replaced with `slog.Warn` error logging.
- `pkg/audit/README.md` documents the shutdown guarantee, queue capacity constant, and drop-with-log behaviour when the queue is full.

## Specialist Review Results

| Agent | Result |
|-------|--------|
| qa-test-runner | **PASS** — all tests green; also fixed `audit_integration_test.go` Flush-before-QueryEntries (async change) |
| qa-code-reviewer | **PASS** — no blocking issues; errQueueFull path test added in follow-up before commit |
| security-engineer | **PASS** — race detector clean; no double-close, nil channel, or leak paths; architecture compliance confirmed |

## Test plan

- [ ] `go test ./pkg/audit/...` — TestManager_Flush, TestManager_ShutdownOrderGuarantee, TestManager_StopIsIdempotent, TestManager_RecordEventAfterStop, TestManager_QueueFull all pass
- [ ] `go test ./features/rbac/...` — audit integration tests pass with Flush calls before QueryEntries
- [ ] `go build ./...` — full codebase compiles
- [ ] `make test-agent-complete` — passed in CI runner

Fixes #764

🤖 Generated with [Claude Code](https://claude.com/claude-code)