### PR TITLE
registration: fix TOCTOU race and save-failure abort in handleRegister (Issue #774)

### DIFF
--- a/features/controller/api/handlers_registration.go
+++ b/features/controller/api/handlers_registration.go
@@ -4,6 +4,7 @@ package api
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"os"
@@ -12,6 +13,7 @@ import (
 
 	"github.com/cfgis/cfgms/pkg/cert"
 	"github.com/cfgis/cfgms/pkg/logging"
+	business "github.com/cfgis/cfgms/pkg/storage/interfaces/business"
 )
 
 // RegistrationRequest represents the steward registration request
@@ -81,7 +83,7 @@ func (s *Server) handleRegister(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Validate token
+	// Retrieve token metadata (tenant, group, controller URL) for building the response
 	token, err := s.registrationTokenStore.GetToken(r.Context(), req.Token)
 	if err != nil {
 		s.logger.Warn("Invalid registration token", "error", err)
@@ -103,17 +105,28 @@ func (s *Server) handleRegister(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Check if single-use token was already used
-	if token.SingleUse && token.UsedAt != nil {
-		s.logger.Warn("Attempted reuse of single-use token", "token", req.Token, "used_at", token.UsedAt, "used_by", token.UsedBy)
-		http.Error(w, "Registration token has already been used", http.StatusUnauthorized)
+	// Generate steward ID before the atomic claim so it is recorded inside ConsumeToken
+	stewardID := fmt.Sprintf("steward-%d", time.Now().UnixNano())
+
+	// Atomically claim the token. For single-use tokens this is the TOCTOU gate:
+	// if two goroutines both pass GetToken and the revoke/expire checks, only the
+	// first ConsumeToken caller wins; the second gets ErrTokenAlreadyUsed.
+	if err := s.registrationTokenStore.ConsumeToken(r.Context(), req.Token, stewardID); err != nil {
+		if errors.Is(err, business.ErrTokenAlreadyUsed) {
+			s.logger.Warn("Single-use token already consumed",
+				"token_prefix", req.Token[:min(len(req.Token), 6)])
+			http.Error(w, "Registration token has already been used", http.StatusConflict)
+			return
+		}
+		s.logger.Error("Failed to consume registration token", "error", err)
+		http.Error(w, "Registration service error", http.StatusInternalServerError)
 		return
 	}
 
-	// Issue #422: Run registration approval hook.
-	// The hook evaluates the token metadata and source IP against the configured workflow.
-	// Hook errors are non-fatal: we log and fall back to approve so transient failures
-	// do not block legitimate registrations.
+	// Issue #422: Run registration approval hook after token consumption.
+	// The token is consumed before the hook runs, preventing a second attempt while
+	// the hook is evaluating. Hook errors are non-fatal: we log and fall back to approve
+	// so transient failures do not block legitimate registrations.
 	quarantined := false
 	{
 		input := RegistrationInput{
@@ -138,19 +151,6 @@ func (s *Server) handleRegister(w http.ResponseWriter, r *http.Request) {
 				s.logger.Info("Registration quarantined by approval workflow",
 					"tenant_id", token.TenantID)
 			}
-		}
-	}
-
-	// Generate steward ID
-	stewardID := fmt.Sprintf("steward-%d", time.Now().UnixNano())
-
-	// Mark token as used if it's single-use
-	if token.SingleUse {
-		token.UsedAt = timePtr(time.Now())
-		token.UsedBy = stewardID
-		if err := s.registrationTokenStore.SaveToken(r.Context(), token); err != nil {
-			s.logger.Error("Failed to mark token as used", "error", err)
-			// Continue anyway - registration should succeed
 		}
 	}
 
@@ -332,11 +332,6 @@ func extractSourceIP(r *http.Request) string {
 		return addr[:idx]
 	}
 	return addr
-}
-
-// Helper function to create a time pointer
-func timePtr(t time.Time) *time.Time {
-	return &t
 }
 
 // Helper function to get minimum of two integers

--- a/features/controller/api/handlers_registration_test.go
+++ b/features/controller/api/handlers_registration_test.go
@@ -1,0 +1,345 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+package api
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cfgis/cfgms/features/controller/config"
+	"github.com/cfgis/cfgms/features/controller/service"
+	"github.com/cfgis/cfgms/features/rbac"
+	"github.com/cfgis/cfgms/features/tenant"
+	"github.com/cfgis/cfgms/pkg/cert"
+	"github.com/cfgis/cfgms/pkg/logging"
+	"github.com/cfgis/cfgms/pkg/registration"
+	"github.com/cfgis/cfgms/pkg/storage/interfaces"
+	business "github.com/cfgis/cfgms/pkg/storage/interfaces/business"
+	_ "github.com/cfgis/cfgms/pkg/storage/providers/flatfile"
+	_ "github.com/cfgis/cfgms/pkg/storage/providers/sqlite"
+)
+
+// controlledConsumeStore wraps MemoryStore and injects a fixed error from ConsumeToken.
+type controlledConsumeStore struct {
+	*registration.MemoryStore
+	consumeErr error
+}
+
+func (c *controlledConsumeStore) ConsumeToken(ctx context.Context, tokenStr, stewardID string) error {
+	if c.consumeErr != nil {
+		return c.consumeErr
+	}
+	return c.MemoryStore.ConsumeToken(ctx, tokenStr, stewardID)
+}
+
+// newHandleRegisterServer creates a minimal server for handleRegister unit tests.
+// Pass a non-nil certMgr only when you need the handler to reach cert generation (200 path).
+func newHandleRegisterServer(t *testing.T, tokenStore registration.Store, certMgr *cert.Manager) *Server {
+	t.Helper()
+
+	cfg := config.DefaultConfig()
+	cfg.Certificate.EnableCertManagement = false
+
+	logger := logging.NewNoopLogger()
+	tempDir := t.TempDir()
+
+	storageManager, err := interfaces.CreateOSSStorageManager(tempDir+"/flatfile", tempDir+"/cfgms.db")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = storageManager.Close() })
+
+	rbacManager := rbac.NewManagerWithStorage(
+		storageManager.GetAuditStore(),
+		storageManager.GetClientTenantStore(),
+		storageManager.GetRBACStore(),
+	)
+	require.NoError(t, rbacManager.Initialize(context.Background()))
+
+	tenantStore := tenant.NewStorageAdapter(storageManager.GetTenantStore())
+	tenantManager := tenant.NewManager(tenantStore, rbacManager)
+
+	controllerService := service.NewControllerService(logger)
+	configService := service.NewConfigurationServiceV2(logger, storageManager, controllerService)
+	rbacService := service.NewRBACService(rbacManager)
+
+	server, err := New(
+		cfg, logger, controllerService, configService, nil, rbacService,
+		certMgr, tenantManager, rbacManager,
+		nil, nil, nil, nil,
+		tokenStore,
+		"",
+		nil,
+	)
+	require.NoError(t, err)
+	return server
+}
+
+// newTestCertManager creates a real cert manager backed by a temp dir.
+func newTestCertManager(t *testing.T) *cert.Manager {
+	t.Helper()
+	mgr, err := cert.NewManager(&cert.ManagerConfig{
+		StoragePath: t.TempDir(),
+		CAConfig: &cert.CAConfig{
+			Organization: "Test CFGMS",
+			Country:      "US",
+			ValidityDays: 365,
+		},
+	})
+	require.NoError(t, err)
+	return mgr
+}
+
+// postRegister sends a POST /api/v1/register request and returns the recorder.
+func postRegister(server *Server, token string) *httptest.ResponseRecorder {
+	body, _ := json.Marshal(RegistrationRequest{Token: token})
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/register", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	server.handleRegister(rec, req)
+	return rec
+}
+
+func TestHandleRegister_AlreadyUsedSingleUseToken_Returns409(t *testing.T) {
+	tokenStore := registration.NewMemoryStore()
+	server := newHandleRegisterServer(t, tokenStore, nil)
+
+	usedAt := time.Now().Add(-time.Hour)
+	tok := &registration.Token{
+		Token:         "cfgms_reg_used_token",
+		TenantID:      "test-tenant",
+		ControllerURL: "grpc://controller:7443",
+		SingleUse:     true,
+		UsedAt:        &usedAt,
+		UsedBy:        "steward-previous",
+	}
+	require.NoError(t, tokenStore.SaveToken(context.Background(), tok))
+
+	rec := postRegister(server, "cfgms_reg_used_token")
+
+	assert.Equal(t, http.StatusConflict, rec.Code)
+	assert.Contains(t, rec.Body.String(), "already been used")
+}
+
+func TestHandleRegister_RevokedToken_Returns401(t *testing.T) {
+	tokenStore := registration.NewMemoryStore()
+	server := newHandleRegisterServer(t, tokenStore, nil)
+
+	revokedAt := time.Now().Add(-time.Hour)
+	tok := &registration.Token{
+		Token:         "cfgms_reg_revoked_token",
+		TenantID:      "test-tenant",
+		ControllerURL: "grpc://controller:7443",
+		Revoked:       true,
+		RevokedAt:     &revokedAt,
+	}
+	require.NoError(t, tokenStore.SaveToken(context.Background(), tok))
+
+	rec := postRegister(server, "cfgms_reg_revoked_token")
+
+	assert.Equal(t, http.StatusUnauthorized, rec.Code)
+	assert.Contains(t, rec.Body.String(), "revoked")
+}
+
+func TestHandleRegister_ExpiredToken_Returns401(t *testing.T) {
+	tokenStore := registration.NewMemoryStore()
+	server := newHandleRegisterServer(t, tokenStore, nil)
+
+	pastExpiry := time.Now().Add(-time.Hour)
+	tok := &registration.Token{
+		Token:         "cfgms_reg_expired_token",
+		TenantID:      "test-tenant",
+		ControllerURL: "grpc://controller:7443",
+		ExpiresAt:     &pastExpiry,
+	}
+	require.NoError(t, tokenStore.SaveToken(context.Background(), tok))
+
+	rec := postRegister(server, "cfgms_reg_expired_token")
+
+	assert.Equal(t, http.StatusUnauthorized, rec.Code)
+	assert.Contains(t, rec.Body.String(), "expired")
+}
+
+func TestHandleRegister_StoreError_Returns500(t *testing.T) {
+	storeErr := fmt.Errorf("failed to persist token state: %w", fmt.Errorf("connection refused"))
+	tokenStore := &controlledConsumeStore{
+		MemoryStore: registration.NewMemoryStore(),
+		consumeErr:  storeErr,
+	}
+	server := newHandleRegisterServer(t, tokenStore, nil)
+
+	tok := &registration.Token{
+		Token:         "cfgms_reg_store_err_token",
+		TenantID:      "test-tenant",
+		ControllerURL: "grpc://controller:7443",
+		SingleUse:     true,
+	}
+	require.NoError(t, tokenStore.SaveToken(context.Background(), tok))
+
+	rec := postRegister(server, "cfgms_reg_store_err_token")
+
+	assert.Equal(t, http.StatusInternalServerError, rec.Code)
+}
+
+func TestHandleRegister_ValidSingleUseToken_Returns200ThenSubsequent409(t *testing.T) {
+	tokenStore := registration.NewMemoryStore()
+	certMgr := newTestCertManager(t)
+	server := newHandleRegisterServer(t, tokenStore, certMgr)
+
+	tok := &registration.Token{
+		Token:         "cfgms_reg_singleuse_valid",
+		TenantID:      "test-tenant",
+		ControllerURL: "grpc://controller:7443",
+		SingleUse:     true,
+	}
+	require.NoError(t, tokenStore.SaveToken(context.Background(), tok))
+
+	// First request should succeed
+	rec1 := postRegister(server, "cfgms_reg_singleuse_valid")
+	assert.Equal(t, http.StatusOK, rec1.Code)
+
+	var resp RegistrationResponse
+	require.NoError(t, json.Unmarshal(rec1.Body.Bytes(), &resp))
+	assert.NotEmpty(t, resp.StewardID)
+	assert.Equal(t, "test-tenant", resp.TenantID)
+
+	// Second request with same token must be rejected as already used
+	rec2 := postRegister(server, "cfgms_reg_singleuse_valid")
+	assert.Equal(t, http.StatusConflict, rec2.Code)
+}
+
+func TestHandleRegister_ValidMultiUseToken_AllowsTwoRegistrations(t *testing.T) {
+	tokenStore := registration.NewMemoryStore()
+	certMgr := newTestCertManager(t)
+	server := newHandleRegisterServer(t, tokenStore, certMgr)
+
+	tok := &registration.Token{
+		Token:         "cfgms_reg_multiuse_valid",
+		TenantID:      "test-tenant",
+		ControllerURL: "grpc://controller:7443",
+		SingleUse:     false,
+	}
+	require.NoError(t, tokenStore.SaveToken(context.Background(), tok))
+
+	rec1 := postRegister(server, "cfgms_reg_multiuse_valid")
+	assert.Equal(t, http.StatusOK, rec1.Code)
+
+	rec2 := postRegister(server, "cfgms_reg_multiuse_valid")
+	assert.Equal(t, http.StatusOK, rec2.Code)
+
+	// Both registrations should have distinct steward IDs
+	var resp1, resp2 RegistrationResponse
+	require.NoError(t, json.Unmarshal(rec1.Body.Bytes(), &resp1))
+	require.NoError(t, json.Unmarshal(rec2.Body.Bytes(), &resp2))
+	assert.NotEqual(t, resp1.StewardID, resp2.StewardID)
+}
+
+func TestHandleRegister_ConsumeToken_NoSaveTokenCall(t *testing.T) {
+	// Verify that a successful registration does NOT call SaveToken (ConsumeToken handles it).
+	// We use the real MemoryStore and verify token state after registration.
+	tokenStore := registration.NewMemoryStore()
+	certMgr := newTestCertManager(t)
+	server := newHandleRegisterServer(t, tokenStore, certMgr)
+
+	tok := &registration.Token{
+		Token:         "cfgms_reg_nosave_check",
+		TenantID:      "test-tenant",
+		ControllerURL: "grpc://controller:7443",
+		SingleUse:     true,
+	}
+	require.NoError(t, tokenStore.SaveToken(context.Background(), tok))
+
+	rec := postRegister(server, "cfgms_reg_nosave_check")
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	// Token should now be marked as used by ConsumeToken
+	updated, err := tokenStore.GetToken(context.Background(), "cfgms_reg_nosave_check")
+	require.NoError(t, err)
+	assert.NotNil(t, updated.UsedAt, "ConsumeToken must have marked the token as used")
+	assert.NotEmpty(t, updated.UsedBy, "ConsumeToken must have recorded the steward ID")
+}
+
+func TestHandleRegister_ConcurrentSingleUseToken_ExactlyOneSucceeds(t *testing.T) {
+	tokenStore := registration.NewMemoryStore()
+	certMgr := newTestCertManager(t)
+	server := newHandleRegisterServer(t, tokenStore, certMgr)
+
+	tok := &registration.Token{
+		Token:         "cfgms_reg_concurrent_token",
+		TenantID:      "test-tenant",
+		ControllerURL: "grpc://controller:7443",
+		SingleUse:     true,
+	}
+	require.NoError(t, tokenStore.SaveToken(context.Background(), tok))
+
+	// Use an httptest.Server so goroutines share a real HTTP stack
+	ts := httptest.NewServer(server.router)
+	t.Cleanup(ts.Close)
+
+	type result struct {
+		code int
+	}
+	results := make([]result, 2)
+	var wg sync.WaitGroup
+	for i := 0; i < 2; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			body, _ := json.Marshal(RegistrationRequest{Token: "cfgms_reg_concurrent_token"})
+			resp, err := ts.Client().Post(ts.URL+"/api/v1/register", "application/json", bytes.NewReader(body))
+			if err != nil {
+				return
+			}
+			defer func() { _ = resp.Body.Close() }()
+			results[idx] = result{code: resp.StatusCode}
+		}(i)
+	}
+	wg.Wait()
+
+	codes := []int{results[0].code, results[1].code}
+	assert.Contains(t, codes, http.StatusOK, "exactly one goroutine must succeed")
+	assert.Contains(t, codes, http.StatusConflict, "exactly one goroutine must get 409")
+
+	okCount := 0
+	conflictCount := 0
+	for _, r := range results {
+		switch r.code {
+		case http.StatusOK:
+			okCount++
+		case http.StatusConflict:
+			conflictCount++
+		}
+	}
+	assert.Equal(t, 1, okCount, "exactly one registration must succeed")
+	assert.Equal(t, 1, conflictCount, "exactly one registration must return 409")
+}
+
+// TestHandleRegister_ConsumeTokenNotAlreadyUsed_Returns401 verifies that ConsumeToken
+// returns ErrTokenAlreadyUsed (not a plain error) for the 409 path.
+func TestHandleRegister_ErrTokenAlreadyUsed_IsDistinctFrom500(t *testing.T) {
+	// This test uses the sentinel directly to confirm the error distinction matters.
+	tokenStore := &controlledConsumeStore{
+		MemoryStore: registration.NewMemoryStore(),
+		consumeErr:  business.ErrTokenAlreadyUsed,
+	}
+	server := newHandleRegisterServer(t, tokenStore, nil)
+
+	tok := &registration.Token{
+		Token:         "cfgms_reg_sentinel_test",
+		TenantID:      "test-tenant",
+		ControllerURL: "grpc://controller:7443",
+		SingleUse:     true,
+	}
+	require.NoError(t, tokenStore.SaveToken(context.Background(), tok))
+
+	rec := postRegister(server, "cfgms_reg_sentinel_test")
+	assert.Equal(t, http.StatusConflict, rec.Code, "ErrTokenAlreadyUsed must map to 409 not 500")
+}

--- a/features/controller/api/server.go
+++ b/features/controller/api/server.go
@@ -488,6 +488,11 @@ func (s *Server) SetWorkflowHandler(h *WorkflowHandler) {
 	}
 }
 
+// GetRouter returns the HTTP router for testing purposes.
+func (s *Server) GetRouter() http.Handler {
+	return s.router
+}
+
 // SetApprovalHook replaces the registration approval hook (Issue #422).
 // Called during server startup when a workflow engine is available.
 func (s *Server) SetApprovalHook(hook RegistrationApprovalHook) {

--- a/test/integration/registration_token_persistence_test.go
+++ b/test/integration/registration_token_persistence_test.go
@@ -5,18 +5,31 @@
 package integration
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"os"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	controllerapi "github.com/cfgis/cfgms/features/controller/api"
+	"github.com/cfgis/cfgms/features/controller/config"
+	"github.com/cfgis/cfgms/features/controller/service"
+	"github.com/cfgis/cfgms/features/rbac"
+	"github.com/cfgis/cfgms/features/tenant"
+	"github.com/cfgis/cfgms/pkg/cert"
+	"github.com/cfgis/cfgms/pkg/logging"
 	"github.com/cfgis/cfgms/pkg/registration"
 	"github.com/cfgis/cfgms/pkg/storage/interfaces"
-	_ "github.com/cfgis/cfgms/pkg/storage/providers/sqlite"
 	business "github.com/cfgis/cfgms/pkg/storage/interfaces/business"
+	_ "github.com/cfgis/cfgms/pkg/storage/providers/flatfile"
+	_ "github.com/cfgis/cfgms/pkg/storage/providers/sqlite"
 )
 
 // TestRegistrationTokenPersistence_AcrossRestart validates that registration tokens
@@ -282,4 +295,127 @@ func TestRegistrationTokenPersistence_DeletePersists(t *testing.T) {
 	_, err = adapter2.GetToken(ctx, "cfgms_reg_delete_test")
 	assert.Error(t, err, "Deleted token should not exist after reload")
 	assert.Contains(t, err.Error(), "not found")
+}
+
+// TestConcurrentRegistration_SingleUseToken_ExactlyOneSucceeds validates that two
+// concurrent HTTP POST /api/v1/register requests with the same single-use token
+// produce exactly one 200 OK and one 409 Conflict against a real Server backed
+// by SQLite storage. This proves the TOCTOU race fixed in Issue #774 holds under
+// real concurrent HTTP load.
+func TestConcurrentRegistration_SingleUseToken_ExactlyOneSucceeds(t *testing.T) {
+	tempDir, err := os.MkdirTemp("", "reg-concurrent-*")
+	require.NoError(t, err)
+	defer func() { _ = os.RemoveAll(tempDir) }()
+
+	ctx := context.Background()
+
+	// Build storage manager (RBAC + tenant)
+	storageManager, err := interfaces.CreateOSSStorageManager(
+		tempDir+"/flatfile",
+		tempDir+"/cfgms.db",
+	)
+	require.NoError(t, err)
+	defer func() { _ = storageManager.Close() }()
+
+	rbacManager := rbac.NewManagerWithStorage(
+		storageManager.GetAuditStore(),
+		storageManager.GetClientTenantStore(),
+		storageManager.GetRBACStore(),
+	)
+	require.NoError(t, rbacManager.Initialize(ctx))
+
+	tenantStore := tenant.NewStorageAdapter(storageManager.GetTenantStore())
+	tenantManager := tenant.NewManager(tenantStore, rbacManager)
+
+	// Build cert manager so handleRegister can reach the 200 path
+	certMgr, err := cert.NewManager(&cert.ManagerConfig{
+		StoragePath: tempDir + "/certs",
+		CAConfig: &cert.CAConfig{
+			Organization: "Test CFGMS Concurrent",
+			Country:      "US",
+			ValidityDays: 365,
+		},
+	})
+	require.NoError(t, err)
+
+	// Build SQLite-backed registration token store
+	regTokenStore, err := interfaces.CreateRegistrationTokenStoreFromConfig(
+		"sqlite",
+		map[string]interface{}{"path": tempDir + "/tokens.db"},
+	)
+	require.NoError(t, err)
+	defer func() { _ = regTokenStore.Close() }()
+	require.NoError(t, regTokenStore.Initialize(ctx))
+
+	tokenStore := registration.NewStorageAdapter(regTokenStore)
+
+	// Build minimal controller services
+	logger := logging.NewNoopLogger()
+	cfg := config.DefaultConfig()
+	cfg.Certificate.EnableCertManagement = false
+
+	controllerService := service.NewControllerService(logger)
+	configService := service.NewConfigurationServiceV2(logger, storageManager, controllerService)
+	rbacService := service.NewRBACService(rbacManager)
+
+	server, err := controllerapi.New(
+		cfg, logger, controllerService, configService, nil, rbacService,
+		certMgr, tenantManager, rbacManager,
+		nil, nil, nil, nil,
+		tokenStore,
+		"",
+		nil,
+	)
+	require.NoError(t, err)
+
+	// Seed a single-use token
+	tok := &registration.Token{
+		Token:         "cfgms_reg_concurrent_integ_test",
+		TenantID:      "integ-tenant",
+		ControllerURL: "grpc://controller:7443",
+		SingleUse:     true,
+	}
+	require.NoError(t, tokenStore.SaveToken(ctx, tok))
+
+	// Serve over a real HTTP test server
+	ts := httptest.NewServer(server.GetRouter())
+	defer ts.Close()
+
+	type result struct{ code int }
+	results := make([]result, 2)
+	var wg sync.WaitGroup
+	for i := 0; i < 2; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			body, _ := json.Marshal(map[string]string{"token": "cfgms_reg_concurrent_integ_test"})
+			resp, postErr := ts.Client().Post(
+				ts.URL+"/api/v1/register",
+				"application/json",
+				bytes.NewReader(body),
+			)
+			if postErr != nil {
+				return
+			}
+			defer resp.Body.Close()
+			results[idx] = result{code: resp.StatusCode}
+		}(i)
+	}
+	wg.Wait()
+
+	codes := []int{results[0].code, results[1].code}
+	assert.Contains(t, codes, http.StatusOK, "exactly one goroutine must succeed with 200")
+	assert.Contains(t, codes, http.StatusConflict, "exactly one goroutine must get 409")
+
+	okCount, conflictCount := 0, 0
+	for _, r := range results {
+		switch r.code {
+		case http.StatusOK:
+			okCount++
+		case http.StatusConflict:
+			conflictCount++
+		}
+	}
+	assert.Equal(t, 1, okCount, "exactly one 200")
+	assert.Equal(t, 1, conflictCount, "exactly one 409")
 }

--- a/test/integration/transport/registration_test.go
+++ b/test/integration/transport/registration_test.go
@@ -110,7 +110,7 @@ func (s *RegistrationTestSuite) TestSingleUseToken() {
 	s.NoError(err)
 	defer func() { _ = resp2.Body.Close() }()
 
-	s.Equal(http.StatusUnauthorized, resp2.StatusCode, "Second registration with single-use token should fail")
+	s.Equal(http.StatusConflict, resp2.StatusCode, "Second registration with single-use token should be rejected with 409 Conflict (token already consumed)")
 }
 
 // TestStewardIDUniqueness tests that each registration produces a unique steward ID.


### PR DESCRIPTION
## Summary

- Replace the inline get→check→save sequence in `handleRegister` with atomic `GetToken` + `ConsumeToken` to close the TOCTOU race on single-use tokens
- Two concurrent requests both pass `GetToken`, but only the first `ConsumeToken` caller wins; the second gets HTTP 409 Conflict (`ErrTokenAlreadyUsed`)
- Silent save-failure (`// Continue anyway - registration should succeed`) is removed; `ConsumeToken` errors now abort with HTTP 500 (fail-closed)
- Approval hook moved to after `ConsumeToken` to prevent token re-attempts during hook evaluation

## Test plan

- [x] `TestHandleRegister_AlreadyUsedSingleUseToken_Returns409` — already-used single-use token → 409
- [x] `TestHandleRegister_RevokedToken_Returns401` — revoked token → 401
- [x] `TestHandleRegister_ExpiredToken_Returns401` — expired token → 401
- [x] `TestHandleRegister_StoreError_Returns500` — store-layer error → 500
- [x] `TestHandleRegister_ValidSingleUseToken_Returns200ThenSubsequent409` — valid → 200, then same token → 409
- [x] `TestHandleRegister_ValidMultiUseToken_AllowsTwoRegistrations` — multi-use → 200 twice with distinct steward IDs
- [x] `TestHandleRegister_ConcurrentSingleUseToken_ExactlyOneSucceeds` — two goroutines via real httptest.Server → exactly one 200 and one 409
- [x] Integration test `TestConcurrentRegistration_SingleUseToken_ExactlyOneSucceeds` (build tag: integration) — same concurrency scenario against SQLite-backed real server
- [x] All unit tests pass (`go test -race ./features/controller/api/...`)
- [x] `make test-fast test-production-critical build-cross-validate` — PASS
- [x] `golangci-lint run` — 0 issues
- [x] `make check-architecture` — no central provider violations
- [x] `make security-gosec security-staticcheck security-precommit` — PASS (Trivy requires network, not available in container)

## Specialist Review Results

- **QA Test Runner**: PASS (after lint fixes)
- **QA Code Reviewer**: PASS — 0 blocking issues, 2 minor warnings (pre-existing logging and t.TempDir style, not blocking)
- **Security Engineer**: PASS — 0 blocking issues; TOCTOU race correctly closed; ErrTokenAlreadyUsed sentinel import verified; fail-closed on store errors; token prefix logging (H-AUTH-4) applied on new code path

🤖 Generated with [Claude Code](https://claude.com/claude-code)