### PR TITLE
ci: enable strict branch up-to-date requirement on develop ruleset (Issue #793)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,7 +98,7 @@ All must pass before merge to `develop`:
 
 Docs-only PRs get instant green checks via stub jobs (<2 min merge path).
 
-**Branch protection config:** Squash merge only, no review requirements (solo-friendly), relaxed up-to-date policy (PRs don't need latest develop to merge).
+**Branch protection config:** Squash merge only, no review requirements (solo-friendly), strict up-to-date policy (PRs must be rebased to latest develop tip before merge is allowed — enforced by `strict_required_status_checks_policy: true` on the develop ruleset, enabled after PR #777).
 
 **Merging:** Interactive mode uses `gh pr merge --squash --auto` after `/pr-review` approval. Agent-dispatched PRs are auto-merged by the acceptance reviewer when there are zero findings. If the acceptance reviewer finds any issues (even low severity), it must post the concerns on the PR and tag it for manual `/pr-review` — no auto-merge with findings.
 

--- a/docs/development/branch-protection-rules.md
+++ b/docs/development/branch-protection-rules.md
@@ -80,15 +80,19 @@ CFGMS uses GitHub Rulesets to protect branches in a GitFlow-style branching mode
 | Require approval of most recent push | ✅ Yes | Prevent last-minute self-approval |
 | Require conversation resolution | ✅ Yes | All PR comments must be resolved |
 | Status checks required | ✅ Yes | CI checks must pass |
+| Require branch up to date | ✅ Enabled | Prevent merging PRs with CI run against stale develop base |
 
-### Required Status Checks (4 total)
+### Required Status Checks (5 total)
 
 - `unit-tests` - Core functionality validation
 - `integration-tests` - Fast comprehensive + production-critical tests
 - `Build Gate` - Cross-platform compilation + Docker integration tests
 - `security-deployment-gate` - Security vulnerability blocking
+- `Controller Integration Tests (Linux)` - Controller integration test suite
 
-**Rationale**: Direct required checks pattern (Story #322) replaced the previous 10-check approach. These 4 checks cover unit tests, integration tests, cross-platform builds, and security scanning. Production-specific gates (`production-risk-assessment`, `integration-test-gate`) are excluded to allow faster iteration.
+**Rationale**: Direct required checks pattern (Story #322) replaced the previous 10-check approach. These checks cover unit tests, integration tests, cross-platform builds, and security scanning. Production-specific gates (`production-risk-assessment`, `integration-test-gate`) are excluded to allow faster iteration.
+
+**Strict up-to-date requirement**: Enabled after PR #777 broke develop because CI ran against a pre-#772 base; strict mode (`strict_required_status_checks_policy: true`) forces developers to rebase their branch to the latest develop tip and re-run all required checks before merge is allowed. This eliminates the failure mode where a PR's CI passes against a stale base but would fail against current develop.
 
 ---
 

--- a/docs/development/git-workflow.md
+++ b/docs/development/git-workflow.md
@@ -150,6 +150,25 @@ EOF
 )"
 ```
 
+### Keeping Your Branch Up to Date
+
+GitHub blocks the merge button if your branch is behind `develop`. This is enforced via `strict_required_status_checks_policy` on the develop ruleset (enabled after PR #777 broke develop by merging CI results validated against a stale base).
+
+When GitHub shows "This branch is out-of-date with the base branch":
+
+```bash
+# Rebase your branch onto the latest develop
+git fetch origin develop
+git rebase origin/develop
+
+# Push the rebased branch (force-with-lease is safe — it won't overwrite remote changes you haven't seen)
+git push --force-with-lease origin <your-branch>
+```
+
+After the push, GitHub will re-run all required CI checks against the updated branch. The merge button will unblock only when all checks pass on the rebased state.
+
+**Why rebase instead of merge?** Develop enforces squash-merge, so a merge commit on your feature branch adds noise and can cause confusion. Rebasing keeps history clean and ensures CI validates exactly what will land in develop.
+
 ### PR Merge Settings
 
 Merge methods are enforced by branch protection rulesets — GitHub only shows allowed options:

--- a/pkg/audit/manager_test.go
+++ b/pkg/audit/manager_test.go
@@ -7,12 +7,13 @@ import (
 	"testing"
 	"time"
 
-	"github.com/cfgis/cfgms/pkg/storage/interfaces"
-	business "github.com/cfgis/cfgms/pkg/storage/interfaces/business"
-	// Import storage providers to register them
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/cfgis/cfgms/pkg/storage/interfaces"
+	"github.com/cfgis/cfgms/pkg/storage/interfaces/business"
+
+	// Import storage providers to register them
 	_ "github.com/cfgis/cfgms/pkg/storage/providers/database"
 	_ "github.com/cfgis/cfgms/pkg/storage/providers/flatfile"
 	_ "github.com/cfgis/cfgms/pkg/storage/providers/sqlite"


### PR DESCRIPTION
## Summary

- Enables `strict_required_status_checks_policy: true` on the develop branch GitHub Ruleset (ID 11647684), closing the failure mode where CI passed against a stale base (root cause of PR #777 breaking develop)
- Updates branch protection docs to reflect the new strict up-to-date requirement with rationale referencing PR #777
- Adds "Keeping Your Branch Up to Date" subsection to git-workflow.md with rebase instructions
- Fixes pre-existing goimports lint error in `pkg/audit/manager_test.go` (redundant import alias)

## Acceptance Criteria Verification

- ✅ `gh api repos/cfg-is/cfgms/rulesets/11647684 | jq '.rules[0].parameters.strict_required_status_checks_policy'` returns `true`
- ✅ All five required checks preserved: unit-tests, integration-tests, Build Gate, security-deployment-gate, Controller Integration Tests (Linux)
- ✅ `docs/development/branch-protection-rules.md` develop section includes "Require branch up to date | Enabled" row with PR #777 rationale
- ✅ `docs/development/git-workflow.md` includes "Keeping Your Branch Up to Date" subsection with rebase commands
- ✅ CLAUDE.md updated to reflect strict (not relaxed) up-to-date policy

## Specialist Review Results

| Reviewer | Result | Notes |
|----------|--------|-------|
| QA Test Runner | ✅ PASS | All unit tests, lint, license headers, cross-platform builds pass |
| QA Code Reviewer | ✅ PASS | Docs complete and correct; manager_test.go lint fix validated (real components, error paths covered) |
| Security Engineer | ✅ PASS | No secrets, no architecture violations; Trivy env failure unrelated to this change |

## Side Effects

Open PRs targeting develop that are behind HEAD will now show "branch out of date" block. Developers must rebase before merging. This is the intended behavior.

Fixes #793

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>