### PR TITLE
po: review PRs in FIFO order to minimize rebase churn (Issue #800)

### DIFF
--- a/.claude/agents/po.md
+++ b/.claude/agents/po.md
@@ -278,8 +278,20 @@ gh pr list --repo cfg-is/cfgms --search "head:feature/story-<NUM>" --json number
 ./.claude/scripts/agent-dispatch.sh launch-generic cfg-agent-pr-fix-<PR_NUM> <clone_dir> --fix-pr <PR_NUM>
 ```
 
-**Step 5 — QA pass (Acceptance Reviewer):**
-Find agent PRs (branch `feature/story-*`) without Acceptance Reviewer comment. For each, extract the story number from the branch name and use the **Agent tool** (not Bash) to spawn the Acceptance Reviewer: subagent_type `acceptance-reviewer`, prompt `"Review agent PR. pr:<PR_NUM> story:<STORY_NUM>"`, mode `auto`. Launch multiple reviewers in parallel when there are multiple PRs to review.
+**Step 5 — QA pass (Acceptance Reviewer) — FIFO order:**
+Find agent PRs (branch `feature/story-*`) without Acceptance Reviewer comment, sorted by creation timestamp ascending (oldest first). FIFO order minimizes rebase churn: the oldest PR was based on the earliest develop snapshot, so it has the fewest accumulated conflicts. Once it lands, the next-oldest only needs to rebase against one new merge instead of an arbitrary set.
+
+```bash
+gh pr list --repo cfg-is/cfgms --search "head:feature/story-" --state open \
+  --json number,headRefName,createdAt,comments \
+  --jq '[.[] | select(.comments | map(.author.login) | contains(["acceptance-reviewer"]) | not)] | sort_by(.createdAt)'
+```
+
+Process PRs **serially in FIFO order** (do not spawn reviewers in parallel — parallel spawn creates a race where two reviewers both decide to auto-merge PRs that conflict with each other). For each PR in ascending `createdAt` order:
+
+1. **Dependency/conflict check**: If this PR shares files with a currently-merging or in-progress PR that is *older*, skip it and continue to the next PR in the queue. A PR held for a conflict gate does **not** block strictly-younger PRs from being reviewed if they don't share that dependency.
+2. **Spawn Acceptance Reviewer**: Use the **Agent tool** (not Bash): subagent_type `acceptance-reviewer`, prompt `"Review agent PR. pr:<PR_NUM> story:<STORY_NUM>"`, mode `auto`.
+3. **Wait for the reviewer to complete** before spawning the next one. This ensures merges happen in FIFO order and the next PR in the queue is reviewed against an up-to-date develop.
 
 The Acceptance Reviewer (`.claude/agents/acceptance-reviewer.md`) verifies CI, checks acceptance criteria against the diff, and renders a verdict:
 - Zero findings: auto-merge via `gh pr merge --squash --auto`, clean up container/worktree

--- a/docs/development/autonomous-dev-team.md
+++ b/docs/development/autonomous-dev-team.md
@@ -95,6 +95,18 @@ The **Acceptance Reviewer** checks each PR against the story's acceptance criter
 
 The PM only sees PRs that agents failed to get right after two attempts. For those, the PM provides guidance (updated story spec, clarification, or direct code fix) and the cycle restarts.
 
+#### FIFO Review Order
+
+When multiple PRs are ready for acceptance review simultaneously, the PO processes them in **FIFO order** (oldest PR first, by `createdAt` timestamp ascending). This policy minimizes rebase churn:
+
+- The oldest PR was based on the earliest develop snapshot and has the fewest accumulated conflicts.
+- Once it merges, the next-oldest PR only needs to rebase against one new commit, not an arbitrary set.
+- Reviewing in arbitrary or reverse order causes a cascade: PR-B merges first → PR-A needs rebase against PR-B → PR-C also needs rebase → churn compounds.
+
+PRs are processed **serially** — one acceptance reviewer at a time — so that each subsequent review is against an up-to-date develop tip. A PR held due to a file conflict gate does **not** block strictly-younger PRs that don't share the conflicting files; those skip ahead in the queue.
+
+This policy was adopted after PRs #770–772 and #777 landed out-of-order in close succession, leaving #777 stale by 4 merges and triggering hotfix #785.
+
 ### 5. Completion
 
 Merged PRs auto-close their story issues. The PO tracks epic completion via GitHub sub-issue progress and surfaces the next action.


### PR DESCRIPTION
## Summary

- **po.md Step 5**: Sort agent PRs by `createdAt` ascending (oldest first) before spawning acceptance reviewers. Process serially — wait for each reviewer to complete before starting the next. Documents the conflict-gate exception (a held PR does not block strictly-younger PRs without shared file dependencies).
- **autonomous-dev-team.md**: Adds a "FIFO Review Order" subsection under Acceptance Review explaining the policy, rationale, and the real incident (#770–#772 + #777 causing hotfix #785) that motivated it.

## Problem

Arbitrary (or parallel) acceptance review order creates rebase cascades. The oldest PR was based on the earliest develop snapshot — reviewing it first means each subsequent PR only needs to rebase against one new merge. Parallel review creates a race where two reviewers can both auto-merge conflicting PRs.

## Specialist Review Results

- **QA Test Runner**: PASS — 80+ packages, race detection, lint, license headers, secret scan, architecture compliance all green
- **QA Code Reviewer**: PASS (initial run was procedural fail due to uncommitted state; changes are documentation-only with no test quality concerns)
- **Security Engineer**: PASS — no secrets, no architecture violations, `gh pr list` query uses fixed repo + static jq filter with no user-controlled interpolation

## Test plan

- [ ] Operator-observable: dispatch 3 fake PRs in known timestamp order, run PO cron, confirm review order matches FIFO (oldest first)
- [ ] `make test-agent-complete` passes (documentation-only change — all existing tests unaffected)

Fixes #800

🤖 Generated with [Claude Code](https://claude.com/claude-code)