### PR TITLE
dispatch: delete stale remote branch before re-dispatch (Issue #799)

### DIFF
--- a/.claude/scripts/agent-dispatch.sh
+++ b/.claude/scripts/agent-dispatch.sh
@@ -4,8 +4,8 @@
 # can invoke them without triggering manual-approval prompts.
 set -euo pipefail
 
-REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
-WORKTREE_BASE="$(cd "$REPO_ROOT/.." && pwd)/worktrees"
+REPO_ROOT="${CFGMS_TEST_REPO_ROOT:-$(cd "$(dirname "$0")/../.." && pwd)}"
+WORKTREE_BASE="${CFGMS_TEST_WORKTREE_BASE:-$(cd "$REPO_ROOT/.." && pwd)/worktrees}"
 
 # Ensure clone is based on latest remote develop, not stale local state.
 # Called inside fresh clones after setting the remote URL.
@@ -54,7 +54,10 @@ Commands:
   check-conflicts <NUM> [NUM...]            Check for existing containers/clones (issue mode)
   check-conflicts --branch <NAME>           Check for existing containers/clones (branch mode)
   check-conflicts --pr <NUM>                Check for existing containers/clones (PR-fix mode)
-  create-clone    <NUM>                     Clone repo and create feature branch (issue mode)
+  create-clone    <NUM> [--keep-remote]     Clone repo and create feature branch (issue mode)
+                                            If remote branch feature/story-<NUM>-agent already exists,
+                                            it is force-deleted before the fresh branch is created.
+                                            Pass --keep-remote to preserve the stale branch (forensics).
   create-clone-branch <BRANCH>              Clone repo and checkout/create branch
   create-clone-pr <PR_NUM>                  Clone repo and checkout PR branch
   launch          <NUM>                     Launch agent container (issue mode)
@@ -133,16 +136,39 @@ case "$cmd" in
     ;;
 
   create-clone)
+    keep_remote=false
+    while [[ $# -gt 0 && "$1" == --* ]]; do
+      case "$1" in
+        --keep-remote) keep_remote=true; shift ;;
+        *) echo "Unknown flag for create-clone: $1"; exit 1 ;;
+      esac
+    done
     [[ $# -eq 1 ]] || { echo "create-clone requires exactly one issue number"; exit 1; }
     num="$1"
+    branch_name="feature/story-${num}-agent"
     dest="${WORKTREE_BASE}/story-${num}"
     github_url=$(git -C "$REPO_ROOT" remote get-url origin)
+
+    # Check for stale remote branch before cloning. A stale branch causes history
+    # corruption when the new container pushes (git merges the two histories).
+    if git -C "$REPO_ROOT" ls-remote --heads origin "$branch_name" 2>/dev/null | grep -q .; then
+      if $keep_remote; then
+        echo "INFO: Stale remote branch exists: ${branch_name} (keeping due to --keep-remote)"
+      else
+        echo "Cleaning stale remote branch: ${branch_name}"
+        if ! git -C "$REPO_ROOT" push origin --delete "$branch_name" 2>&1; then
+          echo "ERROR: Failed to delete stale remote branch '${branch_name}'. Refusing to dispatch to prevent history corruption."
+          exit 1
+        fi
+      fi
+    fi
+
     trap "rm -rf '$dest'" ERR
     git clone --local --branch develop "$REPO_ROOT" "$dest"
     cd "$dest"
     git remote set-url origin "$github_url"
     sync_to_remote_develop
-    git checkout -b "feature/story-${num}-agent"
+    git checkout -b "$branch_name"
     trap - ERR
     echo "CLONE_OK:${num}:$(git branch --show-current)"
     ;;

--- a/docs/development/agent-dispatch.md
+++ b/docs/development/agent-dispatch.md
@@ -160,6 +160,15 @@ gh issue edit 123 --body "$(gh issue view 123 --json body -q .body)\n\n## CI Fai
 /dispatch 123           # re-dispatch with updated context
 ```
 
+> **Stale remote branch cleanup:** When re-dispatching, `create-clone` automatically detects and
+> force-deletes the old `feature/story-N-agent` remote branch before creating a fresh one. This
+> prevents the new container from pushing on top of stale history and causing tangled merge commits.
+> The dispatch log will show `Cleaning stale remote branch: feature/story-N-agent` when this happens.
+>
+> To preserve the old branch for forensic investigation, pass `--keep-remote` to `create-clone`
+> (or use `/dispatch --keep-remote N` if the skill exposes it). Be aware that with `--keep-remote`
+> the new container's eventual push will conflict with the preserved branch.
+
 ### Option 3: Fix in interactive session on agent branch
 
 ```bash

--- a/scripts/test-scripts.sh
+++ b/scripts/test-scripts.sh
@@ -177,6 +177,214 @@ test_executable_permissions() {
     done
 }
 
+
+# Test 8: create-clone deletes stale remote branch before cloning
+test_create_clone_stale_branch_deletion() {
+    log_test "Testing create-clone deletes stale remote branch..."
+
+    local tmp_dir
+    tmp_dir=$(mktemp -d)
+    local remote_dir="${tmp_dir}/remote.git"
+    local host_dir="${tmp_dir}/host"
+    local worktree_dir="${tmp_dir}/worktrees"
+    local story_num="99997"
+    local branch_name="feature/story-${story_num}-agent"
+    local dispatch_script
+    dispatch_script="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/../.claude/scripts/agent-dispatch.sh"
+
+    # Create a bare "remote" repo with a develop branch
+    git init --bare -b develop "$remote_dir" >/dev/null 2>&1
+    git init -b develop "$host_dir" >/dev/null 2>&1
+    git -C "$host_dir" config user.email "test@test.com"
+    git -C "$host_dir" config user.name "Test"
+    git -C "$host_dir" remote add origin "$remote_dir"
+    git -C "$host_dir" commit --allow-empty -m "initial commit" >/dev/null 2>&1
+    git -C "$host_dir" push origin develop >/dev/null 2>&1
+
+    # Create a stale feature branch on the remote with a marker commit
+    git -C "$host_dir" checkout -b "$branch_name" >/dev/null 2>&1
+    git -C "$host_dir" commit --allow-empty -m "stale marker commit" >/dev/null 2>&1
+    local marker_sha
+    marker_sha=$(git -C "$host_dir" rev-parse HEAD)
+    git -C "$host_dir" push origin "$branch_name" >/dev/null 2>&1
+    git -C "$host_dir" checkout develop >/dev/null 2>&1
+
+    mkdir -p "$worktree_dir"
+
+    local output
+    output=$(CFGMS_TEST_REPO_ROOT="$host_dir" CFGMS_TEST_WORKTREE_BASE="$worktree_dir"         bash "$dispatch_script" create-clone "$story_num" 2>&1)
+    local exit_code=$?
+
+    if [[ $exit_code -ne 0 ]]; then
+        log_fail "create-clone: Command failed (exit ${exit_code}): ${output}"
+        rm -rf "$tmp_dir"
+        return
+    fi
+
+    # Log line must appear for dispatch trail visibility
+    if echo "$output" | grep -q "Cleaning stale remote branch: ${branch_name}"; then
+        log_pass "create-clone: Logs 'Cleaning stale remote branch' message"
+    else
+        log_fail "create-clone: Missing 'Cleaning stale remote branch' log line"
+    fi
+
+    # Stale branch must be gone from remote
+    if ! git -C "$host_dir" ls-remote --heads origin "$branch_name" | grep -q .; then
+        log_pass "create-clone: Stale remote branch deleted before cloning"
+    else
+        log_fail "create-clone: Stale remote branch still exists after create-clone"
+    fi
+
+    # New clone HEAD must match develop on remote (not the stale marker commit)
+    local clone_head develop_sha
+    clone_head=$(git -C "$worktree_dir/story-${story_num}" rev-parse HEAD 2>/dev/null || echo "missing")
+    develop_sha=$(git -C "$remote_dir" rev-parse develop 2>/dev/null || echo "unknown")
+    if [[ "$clone_head" == "$develop_sha" && "$clone_head" != "$marker_sha" ]]; then
+        log_pass "create-clone: New branch based on develop HEAD, not stale marker commit"
+    else
+        log_fail "create-clone: New branch HEAD (${clone_head}) does not match develop (${develop_sha})"
+    fi
+
+    rm -rf "$tmp_dir"
+}
+
+# Test 9: create-clone --keep-remote preserves existing remote branch
+test_create_clone_keep_remote() {
+    log_test "Testing create-clone --keep-remote preserves stale remote branch..."
+
+    local tmp_dir
+    tmp_dir=$(mktemp -d)
+    local remote_dir="${tmp_dir}/remote.git"
+    local host_dir="${tmp_dir}/host"
+    local worktree_dir="${tmp_dir}/worktrees"
+    local story_num="99998"
+    local branch_name="feature/story-${story_num}-agent"
+    local dispatch_script
+    dispatch_script="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/../.claude/scripts/agent-dispatch.sh"
+
+    # Create a bare "remote" repo with a develop branch
+    git init --bare -b develop "$remote_dir" >/dev/null 2>&1
+    git init -b develop "$host_dir" >/dev/null 2>&1
+    git -C "$host_dir" config user.email "test@test.com"
+    git -C "$host_dir" config user.name "Test"
+    git -C "$host_dir" remote add origin "$remote_dir"
+    git -C "$host_dir" commit --allow-empty -m "initial commit" >/dev/null 2>&1
+    git -C "$host_dir" push origin develop >/dev/null 2>&1
+
+    # Create a stale feature branch on the remote
+    git -C "$host_dir" checkout -b "$branch_name" >/dev/null 2>&1
+    git -C "$host_dir" commit --allow-empty -m "stale marker commit" >/dev/null 2>&1
+    local stale_sha
+    stale_sha=$(git -C "$host_dir" rev-parse HEAD)
+    git -C "$host_dir" push origin "$branch_name" >/dev/null 2>&1
+    git -C "$host_dir" checkout develop >/dev/null 2>&1
+
+    mkdir -p "$worktree_dir"
+
+    local output
+    output=$(CFGMS_TEST_REPO_ROOT="$host_dir" CFGMS_TEST_WORKTREE_BASE="$worktree_dir"         bash "$dispatch_script" create-clone --keep-remote "$story_num" 2>&1)
+    local exit_code=$?
+
+    if [[ $exit_code -ne 0 ]]; then
+        log_fail "create-clone --keep-remote: Command failed (exit ${exit_code}): ${output}"
+        rm -rf "$tmp_dir"
+        return
+    fi
+
+    # Remote branch must still exist
+    if git -C "$host_dir" ls-remote --heads origin "$branch_name" | grep -q .; then
+        log_pass "create-clone --keep-remote: Stale remote branch preserved"
+    else
+        log_fail "create-clone --keep-remote: Stale remote branch was deleted (should be preserved)"
+    fi
+
+    # Remote branch must still point at the stale commit
+    local remote_branch_sha
+    remote_branch_sha=$(git -C "$remote_dir" rev-parse "$branch_name" 2>/dev/null || echo "missing")
+    if [[ "$remote_branch_sha" == "$stale_sha" ]]; then
+        log_pass "create-clone --keep-remote: Remote branch still points at original stale commit"
+    else
+        log_fail "create-clone --keep-remote: Remote branch SHA changed (expected ${stale_sha}, got ${remote_branch_sha})"
+    fi
+
+    rm -rf "$tmp_dir"
+}
+
+
+# Test 10: create-clone exits 1 when stale branch deletion fails (no silent proceed)
+test_create_clone_deletion_failure() {
+    log_test "Testing create-clone exits 1 when stale branch deletion fails..."
+
+    local tmp_dir
+    tmp_dir=$(mktemp -d)
+    local remote_dir="${tmp_dir}/remote.git"
+    local host_dir="${tmp_dir}/host"
+    local worktree_dir="${tmp_dir}/worktrees"
+    local story_num="99996"
+    local branch_name="feature/story-${story_num}-agent"
+    local dispatch_script
+    dispatch_script="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/../.claude/scripts/agent-dispatch.sh"
+
+    # Create a bare "remote" repo with a develop branch
+    git init --bare -b develop "$remote_dir" >/dev/null 2>&1
+    git init -b develop "$host_dir" >/dev/null 2>&1
+    git -C "$host_dir" config user.email "test@test.com"
+    git -C "$host_dir" config user.name "Test"
+    git -C "$host_dir" remote add origin "$remote_dir"
+    git -C "$host_dir" commit --allow-empty -m "initial commit" >/dev/null 2>&1
+    git -C "$host_dir" push origin develop >/dev/null 2>&1
+
+    # Create a stale feature branch on the remote
+    git -C "$host_dir" checkout -b "$branch_name" >/dev/null 2>&1
+    git -C "$host_dir" commit --allow-empty -m "stale marker commit" >/dev/null 2>&1
+    git -C "$host_dir" push origin "$branch_name" >/dev/null 2>&1
+    git -C "$host_dir" checkout develop >/dev/null 2>&1
+
+    # Install a pre-receive hook that rejects branch deletions — simulates a
+    # protected branch or insufficient permissions on the remote.
+    mkdir -p "${remote_dir}/hooks"
+    cat > "${remote_dir}/hooks/pre-receive" << 'HOOKEOF'
+#!/bin/bash
+while read old_sha new_sha ref; do
+    if [[ "$new_sha" == "0000000000000000000000000000000000000000" ]]; then
+        echo "ERROR: Branch deletion rejected (protected branch)" >&2
+        exit 1
+    fi
+done
+HOOKEOF
+    chmod +x "${remote_dir}/hooks/pre-receive"
+
+    mkdir -p "$worktree_dir"
+
+    local output exit_code=0
+    # Use || to prevent set -e from aborting the test on expected non-zero exit
+    output=$(CFGMS_TEST_REPO_ROOT="$host_dir" CFGMS_TEST_WORKTREE_BASE="$worktree_dir" \
+        bash "$dispatch_script" create-clone "$story_num" 2>&1) || exit_code=$?
+
+    if [[ $exit_code -ne 0 ]]; then
+        log_pass "create-clone: Exits non-zero when stale branch deletion fails"
+    else
+        log_fail "create-clone: Should have failed when branch deletion is rejected (exit was 0)"
+    fi
+
+    if echo "$output" | grep -q "ERROR:"; then
+        log_pass "create-clone: Prints ERROR message when deletion fails"
+    else
+        log_fail "create-clone: Missing ERROR message when deletion fails (output: ${output})"
+    fi
+
+    # Clone directory must NOT exist — script must not proceed after deletion failure
+    local clone_dir="${worktree_dir}/story-${story_num}"
+    if [[ ! -d "$clone_dir" ]]; then
+        log_pass "create-clone: Clone directory not created when deletion fails (no partial state)"
+    else
+        log_fail "create-clone: Clone directory was created despite deletion failure"
+        rm -rf "$clone_dir"
+    fi
+
+    rm -rf "$tmp_dir"
+}
+
 # Main execution
 echo "🔍 Script Validation Test Suite"
 echo "================================"
@@ -196,6 +404,13 @@ test_wait_for_services
 echo ""
 test_executable_permissions
 
+echo ""
+test_create_clone_stale_branch_deletion
+echo ""
+test_create_clone_keep_remote
+echo ""
+test_create_clone_deletion_failure
+echo ""
 echo ""
 echo "📊 Test Summary"
 echo "==============="


### PR DESCRIPTION
## Summary

- `create-clone` now checks for a stale `feature/story-<N>-agent` remote branch before cloning and force-deletes it, preventing history corruption on re-dispatch
- New `--keep-remote` flag suppresses deletion for forensic investigation; deletion failure causes explicit `exit 1` (no silent proceed)
- Three bash tests added covering: deletion success, `--keep-remote` preservation, and deletion-failure abort with no partial clone state

## Problem

When re-dispatching a story after a prior attempt, the new container's push could merge against the stale remote branch history. PR #787 (story #764) hit this: the old branch was pre-#773 develop, the merge commit silently dropped the ConsumeToken feature, and CI passed on the stale tests.

## Specialist Review Results

- **QA Test Runner**: PASS — 40/40 script tests pass; all Go tests pass; 0 lint issues
- **QA Code Reviewer**: PASS — deletion-failure exit-1 path tested; real git operations with local bare repos; no mocks; `|| exit_code=$?` correctly handles `set -e` for expected-failure tests
- **Security Engineer**: PASS — no shell injection (branch_name always quoted and prefixed with `feature/story-`); no hardcoded secrets; no central provider violations; 0 leaks (gitleaks/truffleHog)

## Test Plan

- [ ] `bash scripts/test-scripts.sh` — 40 tests pass including 3 new create-clone tests
- [ ] Re-dispatch a story with a prior stale remote branch — dispatch log shows "Cleaning stale remote branch: ..."
- [ ] Re-dispatch with `--keep-remote` — stale branch preserved on remote
- [ ] Simulate a protected branch rejection — `create-clone` exits non-zero with ERROR, no clone directory created

Fixes #799

🤖 Generated with [Claude Code](https://claude.com/claude-code)