### PR TITLE
ci: add post-merge develop build sanity workflow (Issue #794)

### DIFF
--- a/.github/workflows/develop-sanity.yml
+++ b/.github/workflows/develop-sanity.yml
@@ -1,0 +1,93 @@
+name: Develop Branch Sanity
+
+on:
+  push:
+    branches:
+      - develop
+
+permissions:
+  contents: read
+  issues: write
+
+env:
+  GO_VERSION: '1.25.9'
+
+jobs:
+  build-sanity:
+    name: Post-merge build check
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Set up Go
+        uses: actions/setup-go@7b8cf10d4e4a01d4992d18a89f4d7dc5a3e6d6f4 # v4
+        with:
+          go-version: ${{ env.GO_VERSION }}
+
+      - name: Build
+        id: build
+        run: |
+          DELIM=$(openssl rand -hex 16)
+          BUILD_OUTPUT=$(go build ./... 2>&1)
+          BUILD_EXIT=$?
+          echo "output<<${DELIM}" >> $GITHUB_OUTPUT
+          echo "$BUILD_OUTPUT" >> $GITHUB_OUTPUT
+          echo "${DELIM}" >> $GITHUB_OUTPUT
+          exit $BUILD_EXIT
+        continue-on-error: true
+
+      - name: Create incident issue on build failure
+        if: steps.build.outcome == 'failure'
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        env:
+          BUILD_OUTPUT: ${{ steps.build.outputs.output }}
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const sha = context.sha;
+            const shortSha = sha.substring(0, 7);
+            const actor = context.actor;
+            const runUrl = `https://github.com/${owner}/${repo}/actions/runs/${context.runId}`;
+            const buildOutput = process.env.BUILD_OUTPUT || '(no output captured)';
+
+            // Ensure pipeline:incident label exists
+            try {
+              await github.rest.issues.getLabel({ owner, repo, name: 'pipeline:incident' });
+            } catch (e) {
+              if (e.status === 404) {
+                await github.rest.issues.createLabel({
+                  owner,
+                  repo,
+                  name: 'pipeline:incident',
+                  color: 'E11D48',
+                  description: 'Develop branch is broken — requires immediate hotfix'
+                });
+              }
+            }
+
+            await github.rest.issues.create({
+              owner,
+              repo,
+              title: `develop build broken after merge — ${shortSha}`,
+              labels: ['pipeline:incident', 'bug'],
+              body: [
+                '## Develop Build Failure',
+                '',
+                `**Commit**: ${sha}`,
+                `**Merged by**: @${actor}`,
+                `**Actions run**: ${runUrl}`,
+                '',
+                '## Build Output',
+                '```',
+                buildOutput,
+                '```',
+                '',
+                '## Resolution',
+                'Fix the build on a feature branch, open a PR targeting `develop`, and close this issue when the build is green.'
+              ].join('\n')
+            });
+
+      - name: Fail job if build failed
+        if: steps.build.outcome == 'failure'
+        run: exit 1

--- a/docs/development/branch-protection-rules.md
+++ b/docs/development/branch-protection-rules.md
@@ -94,6 +94,8 @@ CFGMS uses GitHub Rulesets to protect branches in a GitFlow-style branching mode
 
 **Strict up-to-date requirement**: Enabled after PR #777 broke develop because CI ran against a pre-#772 base; strict mode (`strict_required_status_checks_policy: true`) forces developers to rebase their branch to the latest develop tip and re-run all required checks before merge is allowed. This eliminates the failure mode where a PR's CI passes against a stale base but would fail against current develop.
 
+**Post-merge sanity catch**: `.github/workflows/develop-sanity.yml` runs `go build ./...` on every push to develop (i.e., after every squash-merge). If the build fails it automatically opens a `pipeline:incident` issue linking to the failed run. This is a complementary catch mechanism for the residual cases not covered by pre-merge validation — it does not replace the required status checks above.
+
 ---
 
 ## Release Branches (`release/*`)

--- a/docs/development/ci-infrastructure-setup.md
+++ b/docs/development/ci-infrastructure-setup.md
@@ -213,4 +213,37 @@ make test-with-real-storage  # Tests storage providers with real infrastructure
 
 ---
 
+## Post-merge Develop Sanity
+
+### What it is
+
+`.github/workflows/develop-sanity.yml` triggers on every push to `develop` and runs `go build ./...` against the merged commit. It is the safety net for the rare case where a squash-merge lands a broken build on develop.
+
+### When it triggers
+
+On every push to `develop` — which in practice means every squash-merge from a feature PR. It does not run on feature branches or PRs.
+
+### What it runs
+
+A single `go build ./...` with a 10-minute timeout. The build is fast (under 2 minutes in CI); the generous timeout absorbs occasional runner delays without masking real failures.
+
+### What failure means
+
+If the build fails, the workflow automatically opens a GitHub issue tagged `pipeline:incident` and `bug`. The issue includes:
+
+- The commit SHA that broke the build
+- The GitHub username of the actor who merged
+- A direct link to the failed Actions run
+- The captured `go build` output
+
+The `pipeline:incident` label (color `#E11D48`) is created automatically if it does not yet exist.
+
+**When you see a `pipeline:incident` issue**: develop is broken and no one should merge new work until it is resolved. Fix the build on a feature branch, open a PR targeting `develop`, and close the incident issue once the post-merge sanity run is green.
+
+### How this relates to pre-merge validation
+
+Pre-merge CI (the required status checks on the develop ruleset) validates that a PR's branch compiles and passes tests. The strict up-to-date policy added in Story #793 means CI must run against the rebased tip of develop, which eliminates most breakage scenarios. The post-merge sanity workflow is a complementary catch for the residual cases — for example, if two PRs are merged in rapid succession and the second one was rebased against the first's pre-merge state.
+
+---
+
 **Note**: This infrastructure setup is critical for Epic 6 storage architecture testing and ensures all storage providers work correctly in production-like environments.


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/develop-sanity.yml` — triggers on `push` to `develop`, runs `go build ./...` within 10 minutes of merge
- On build failure, automatically opens a GitHub issue tagged `pipeline:incident` + `bug` with commit SHA, actor, Actions run link, and captured build output
- `pipeline:incident` label auto-created in-workflow if absent; also pre-created in the repo as part of this story
- All action SHAs pinned to the same commit hashes already used in other workflows; isolated to new file (no changes to `test-suite.yml` or `production-gates.yml`)
- Docs: `ci-infrastructure-setup.md` gains a Post-merge Develop Sanity section
- Docs: `branch-protection-rules.md` develop section notes the new workflow as a complementary catch mechanism

## Security Note

Build output is passed via `env:` to `github-script` and read as `process.env.BUILD_OUTPUT` — not template-interpolated into the JS source — preventing script injection. Heredoc delimiter is randomised to prevent output-collision attacks.

## Specialist Review Results

- **QA Test Runner**: PASS — all unit/integration/compilation tests pass; no regressions (no Go code changed)
- **QA Code Reviewer**: PASS — all acceptance criteria met; action SHAs correct; docs complete
- **Security Engineer**: PASS (after fix) — script injection vector remediated; permissions minimal; all SHAs pinned

## Closes

Fixes #794

🤖 Generated with [Claude Code](https://claude.com/claude-code)