### PR TITLE
ci: enable merge queue on develop, retire strict-mode requirement (Issue #801)

### DIFF
--- a/.claude/agents/acceptance-reviewer.md
+++ b/.claude/agents/acceptance-reviewer.md
@@ -103,11 +103,11 @@ Classify each finding by severity:
 
 ### Zero Findings (PASS)
 
-Auto-merge the PR and clean up:
+Enqueue the PR for merge and clean up:
 
 ```bash
-# Auto-merge
-gh pr merge <PR_NUM> --repo cfg-is/cfgms --squash --auto
+# Enqueue for merge — the merge queue handles rebase + re-validation automatically
+gh pr merge <PR_NUM> --repo cfg-is/cfgms --squash
 
 # Extract story number from branch for cleanup
 # Branch pattern: feature/story-<NUM>-*
@@ -177,6 +177,6 @@ If there are zero findings, the Findings table should say "None" and the Accepta
 - Never merge a PR with failing CI checks — CI is a hard gate
 - Never skip acceptance criteria verification — every checkbox must be checked against the diff
 - The fix cycle gets exactly one attempt. First failure = `pipeline:fix`. Second failure = `pipeline:blocked`. No third attempt.
-- Auto-merge uses `--squash --auto` — consistent with project merge strategy
+- Merge enqueue uses `--squash` — merge queue handles the rest (rebase + re-validation + actual merge)
 - Clean up agent container/worktree on auto-merge — the agent infrastructure is no longer needed
 - If the PR targets `main` instead of `develop`, this is a BLOCKING workflow violation. Report it and do not merge.

--- a/.github/WORKFLOW-STANDARDS.md
+++ b/.github/WORKFLOW-STANDARDS.md
@@ -36,7 +36,7 @@ This document defines standards and best practices for GitHub Actions workflows 
 **Configuration**:
 - No review requirements (solo-friendly)
 - Squash merge only
-- Strict up-to-date branch enforcement
+- Merge queue enabled (Story #801) — replaces strict up-to-date enforcement; queue auto-rebases and re-validates before merge
 - No admin bypass needed (tests provide sufficient protection)
 
 ### Main Branch

--- a/.github/workflows/cross-platform-build.yml
+++ b/.github/workflows/cross-platform-build.yml
@@ -12,6 +12,7 @@ on:
       - 'LICENSE'
       - '.gitignore'
       - '.editorconfig'
+  merge_group:
   workflow_dispatch:
 
 env:

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -18,6 +18,7 @@ on:
       - 'docs/**'
       - '*.md'
       - '.claude/**'
+  merge_group:
   workflow_dispatch:
 
 env:
@@ -229,7 +230,7 @@ jobs:
   unit-tests:
     name: unit-tests
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
     steps:
       - name: Docs-only PR validation
         run: |
@@ -240,7 +241,7 @@ jobs:
   security-deployment-gate:
     name: security-deployment-gate
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
     steps:
       - name: Docs-only security validation
         run: |
@@ -251,7 +252,7 @@ jobs:
   build-gate:
     name: Build Gate
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
     steps:
       - name: Docs-only build validation
         run: |
@@ -262,7 +263,7 @@ jobs:
   integration-tests:
     name: integration-tests
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
     steps:
       - name: Docs-only integration test validation
         run: |
@@ -273,7 +274,7 @@ jobs:
   integration-tests-controller:
     name: Controller Integration Tests (Linux)
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
     steps:
       - name: Docs-only controller integration test validation
         run: |

--- a/.github/workflows/production-gates.yml
+++ b/.github/workflows/production-gates.yml
@@ -12,6 +12,7 @@ on:
       - 'LICENSE'
       - '.gitignore'
       - '.editorconfig'
+  merge_group:
   push:
     branches:
       - main  # Run on main for production deployment validation and production-readiness-validation (load testing, benchmarks)

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -12,6 +12,7 @@ on:
       - 'LICENSE'
       - '.gitignore'
       - '.editorconfig'
+  merge_group:
   push:
     branches:
       - main  # Run on main for release security validation

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -12,6 +12,7 @@ on:
       - 'LICENSE'
       - '.gitignore'
       - '.editorconfig'
+  merge_group:
   push:
     branches:
       - main  # Run on main for release validation

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,9 +98,9 @@ All must pass before merge to `develop`:
 
 Docs-only PRs get instant green checks via stub jobs (<2 min merge path).
 
-**Branch protection config:** Squash merge only, no review requirements (solo-friendly), strict up-to-date policy (PRs must be rebased to latest develop tip before merge is allowed — enforced by `strict_required_status_checks_policy: true` on the develop ruleset, enabled after PR #777).
+**Branch protection config:** Squash merge only, no review requirements (solo-friendly), merge queue enabled on develop (Story #801) — the queue auto-rebases each PR against current develop tip and re-runs all required checks before merging. Manual rebase is only needed for genuine content conflicts.
 
-**Merging:** Interactive mode uses `gh pr merge --squash --auto` after `/pr-review` approval. Agent-dispatched PRs are auto-merged by the acceptance reviewer when there are zero findings. If the acceptance reviewer finds any issues (even low severity), it must post the concerns on the PR and tag it for manual `/pr-review` — no auto-merge with findings.
+**Merging:** PRs merge via the GitHub merge queue. Interactive mode: use `gh pr merge --squash` after `/pr-review` approval (the queue handles rebase + re-validation). Agent-dispatched PRs: acceptance reviewer uses `gh pr merge --squash` to enqueue when there are zero findings. If the acceptance reviewer finds any issues (even low severity), it must post the concerns on the PR and tag it for manual `/pr-review` — no auto-merge with findings.
 
 **`make test-complete` coverage:**
 - All pre-commit validation, fast comprehensive tests, production-critical tests

--- a/docs/development/branch-protection-rules.md
+++ b/docs/development/branch-protection-rules.md
@@ -80,7 +80,7 @@ CFGMS uses GitHub Rulesets to protect branches in a GitFlow-style branching mode
 | Require approval of most recent push | ✅ Yes | Prevent last-minute self-approval |
 | Require conversation resolution | ✅ Yes | All PR comments must be resolved |
 | Status checks required | ✅ Yes | CI checks must pass |
-| Require branch up to date | ✅ Enabled | Prevent merging PRs with CI run against stale develop base |
+| Merge queue | ✅ Enabled | Serialized merge with post-rebase validation (replaces strict mode) |
 
 ### Required Status Checks (5 total)
 
@@ -92,7 +92,26 @@ CFGMS uses GitHub Rulesets to protect branches in a GitFlow-style branching mode
 
 **Rationale**: Direct required checks pattern (Story #322) replaced the previous 10-check approach. These checks cover unit tests, integration tests, cross-platform builds, and security scanning. Production-specific gates (`production-risk-assessment`, `integration-test-gate`) are excluded to allow faster iteration.
 
-**Strict up-to-date requirement**: Enabled after PR #777 broke develop because CI ran against a pre-#772 base; strict mode (`strict_required_status_checks_policy: true`) forces developers to rebase their branch to the latest develop tip and re-run all required checks before merge is allowed. This eliminates the failure mode where a PR's CI passes against a stale base but would fail against current develop.
+### Merge Queue
+
+Enabled in Story #801. The merge queue replaces the previous `strict_required_status_checks_policy` (strict mode, enabled in #793).
+
+**How it works:**
+1. A PR marked for merge enters a serial queue
+2. GitHub creates a temporary merge-queue branch: current develop tip + the PR's changes
+3. All 5 required checks run against that combined (post-rebase) state
+4. If checks pass, the PR is squash-merged into develop
+5. If checks fail, the PR is ejected from the queue and the author is notified
+
+**Configuration** (Ruleset 11647684):
+- Merge method: squash (preserves commit convention)
+- Max entries to merge: 1 (serial — prevents ordering bugs like #785)
+- Check response timeout: 60 minutes
+- Grouping strategy: ALLGREEN (each PR must pass individually)
+
+**Why merge queue instead of strict mode**: Strict mode required every PR author/agent to manually rebase before merge, which was manual work that compounded across the autonomous pipeline. Merge queues perform the rebase and re-validation automatically, eliminating that work for the ~80% of PRs with no genuine content conflict.
+
+**Manual rebases are still needed** for genuine content conflicts (estimated ~20% of cases). A rebase is required only when `git merge` would produce a conflict that GitHub cannot auto-resolve.
 
 ---
 

--- a/docs/development/merge-protocol.md
+++ b/docs/development/merge-protocol.md
@@ -1,0 +1,66 @@
+# Merge Protocol
+
+This document describes how PRs merge into `develop` in CFGMS.
+
+## Overview
+
+PRs targeting `develop` merge via the **GitHub merge queue**. The queue auto-rebases each PR against the current develop tip, re-runs all required checks against the combined state, and squash-merges if checks pass.
+
+This replaced the `strict_required_status_checks_policy` (strict mode, Story #793) in Story #801.
+
+## How the Queue Works
+
+1. A PR is marked for merge (`gh pr merge --squash` or the GitHub UI)
+2. GitHub creates a temporary branch: `develop` tip + the PR's changes
+3. All 5 required checks run against that combined state:
+   - `unit-tests`
+   - `integration-tests`
+   - `Build Gate`
+   - `security-deployment-gate`
+   - `Controller Integration Tests (Linux)`
+4. If all checks pass → PR is squash-merged into develop
+5. If any check fails → PR is ejected from the queue; author/agent is notified
+
+## For Interactive Mode
+
+After `/pr-review` approves:
+
+```bash
+gh pr merge <PR_NUM> --squash
+```
+
+Do **not** use `--auto`. The merge queue (`--squash` without `--auto`) enqueues the PR. GitHub drives it from there.
+
+## For Agent-Dispatched PRs
+
+The acceptance reviewer agent calls `gh pr merge <PR_NUM> --repo cfg-is/cfgms --squash` when all acceptance criteria are met and CI is green. The queue then validates the post-rebase state and merges if checks pass.
+
+## When to Rebase Manually
+
+Manual rebase is only needed for **genuine content conflicts** — cases where `git merge` would produce a conflict that GitHub cannot auto-resolve. Estimated at ~20% of PRs.
+
+Signs you need a manual rebase:
+- GitHub shows "This branch has conflicts that must be resolved"
+- The merge queue ejects the PR with a conflict message
+
+Steps:
+```bash
+git fetch origin develop
+git rebase origin/develop
+# resolve conflicts
+git add <resolved files>
+git rebase --continue
+git push --force-with-lease
+```
+
+Do **not** rebase preemptively. Let the queue handle it.
+
+## Configuration
+
+Ruleset 11647684 (Develop Branch Protection):
+- Merge method: squash
+- Max entries to merge: 1 (serial queue)
+- Check response timeout: 60 minutes
+- Grouping strategy: ALLGREEN (each PR validated independently)
+
+See [branch-protection-rules.md](./branch-protection-rules.md) for full ruleset details.


### PR DESCRIPTION
## Summary

- Add `merge_group:` trigger to all 4 code-validation workflows so required checks fire during merge queue runs
- Add `merge_group:` trigger to `documentation.yml` and update stub job guards so docs-only PRs pass through the queue
- Update docs (`branch-protection-rules.md`, new `merge-protocol.md`, `WORKFLOW-STANDARDS.md`) to describe queue behavior
- Update `CLAUDE.md` and `acceptance-reviewer.md` to use `gh pr merge --squash` (not `--squash --auto`)

## Context

The GitHub ruleset (11647684) already has `merge_queue` configured with squash method and `strict_required_status_checks_policy: false`. This PR wires up the GitHub Actions side (workflow triggers) and updates all documentation/agent instructions.

## Specialist Review Results

- **qa-test-runner**: PASS — all Go tests pass, architecture checks clean, no secrets (Trivy skipped: network-blocked container)
- **qa-code-reviewer**: PASS (after 2 fix iterations) — fixed invalid `branches:` sub-key on merge_group triggers; fixed documentation.yml missing merge_group trigger; fixed WORKFLOW-STANDARDS.md strict-mode reference
- **security-engineer**: PASS — no security issues; merge_group trigger inherits same GITHUB_TOKEN scope as pull_request; no new permissions or third-party actions

## Test Plan

- [ ] Verify `merge_group:` triggers appear in `.github/workflows/` for the 5 required-check workflows
- [ ] Run a docs-only test PR through the queue to confirm stub jobs fire under `merge_group` event
- [ ] Confirm CI checks pass on this PR itself (no regressions)

Fixes #801

🤖 Generated with [Claude Code](https://claude.com/claude-code)