### PR TITLE
controller: change getLogProviderConfig to return error, remove stdlib log (Issue #790)

### DIFF
--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -4,7 +4,6 @@ package main
 
 import (
 	"fmt"
-	"log"
 	"os"
 	"os/signal"
 	"strings"
@@ -87,6 +86,10 @@ func runController(configPath string, initMode bool) error {
 			"then update your configuration to use 'flatfile' or 'database'")
 	}
 
+	logProviderConfig, err := getLogProviderConfig(cfg)
+	if err != nil {
+		return fmt.Errorf("failed to build log provider config: %w", err)
+	}
 	loggingConfig := &logging.LoggingConfig{
 		Provider:          getLogProvider(cfg),
 		Level:             strings.ToUpper(cfg.LogLevel),
@@ -99,7 +102,7 @@ func runController(configPath string, initMode bool) error {
 		BatchSize:         100,
 		FlushInterval:     5 * time.Second,
 		RetentionDays:     90,
-		Config:            getLogProviderConfig(cfg),
+		Config:            logProviderConfig,
 	}
 
 	if err := logging.InitializeGlobalLogging(loggingConfig); err != nil {
@@ -264,12 +267,16 @@ func runInstall(configPath string) error {
 
 	if caPath != "" && !initialization.IsInitialized(caPath) {
 		fmt.Println("Controller not yet initialized — running --init...")
+		logProviderConfig, err := getLogProviderConfig(cfg)
+		if err != nil {
+			return fmt.Errorf("failed to build log provider config: %w", err)
+		}
 		loggingConfig := &logging.LoggingConfig{
 			Provider:    getLogProvider(cfg),
 			Level:       "INFO",
 			ServiceName: "controller",
 			Component:   "install",
-			Config:      getLogProviderConfig(cfg),
+			Config:      logProviderConfig,
 		}
 		if err := logging.InitializeGlobalLogging(loggingConfig); err != nil {
 			return fmt.Errorf("failed to initialize logging: %w", err)
@@ -381,9 +388,9 @@ func getLogProvider(cfg *config.Config) string {
 }
 
 // getLogProviderConfig creates provider-specific configuration.
-func getLogProviderConfig(cfg *config.Config) map[string]interface{} {
+func getLogProviderConfig(cfg *config.Config) (map[string]interface{}, error) {
 	if cfg.Logging != nil && cfg.Logging.Config != nil && len(cfg.Logging.Config) > 0 {
-		return cfg.Logging.Config
+		return cfg.Logging.Config, nil
 	}
 
 	provider := getLogProvider(cfg)
@@ -392,9 +399,9 @@ func getLogProviderConfig(cfg *config.Config) map[string]interface{} {
 	case "timescale":
 		password := os.Getenv("CFGMS_TIMESCALE_PASSWORD")
 		if password == "" {
-			log.Fatal("FATAL: CFGMS_TIMESCALE_PASSWORD environment variable is required when using " +
-				"timescale logging provider. Set this variable or configure logging.config.password " +
-				"in the config file. See QUICK_START.md for configuration examples.")
+			return nil, fmt.Errorf("CFGMS_TIMESCALE_PASSWORD environment variable is required when " +
+				"using timescale logging provider; configure logging.config.password in the config " +
+				"file or set CFGMS_TIMESCALE_PASSWORD (see QUICK_START.md for examples)")
 		}
 		host := os.Getenv("CFGMS_TIMESCALE_HOST")
 		if host == "" {
@@ -423,7 +430,7 @@ func getLogProviderConfig(cfg *config.Config) map[string]interface{} {
 			"username": username,
 			"password": password,
 			"ssl_mode": sslMode,
-		}
+		}, nil
 
 	default:
 		return map[string]interface{}{
@@ -431,6 +438,6 @@ func getLogProviderConfig(cfg *config.Config) map[string]interface{} {
 			"max_file_size":    int64(100 * 1024 * 1024),
 			"max_files":        10,
 			"compress_rotated": true,
-		}
+		}, nil
 	}
 }

--- a/cmd/controller/main_test.go
+++ b/cmd/controller/main_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/cfgis/cfgms/cmd/controller/service"
+	"github.com/cfgis/cfgms/features/controller/config"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -124,6 +125,38 @@ func TestRunControllerNoDebugOutput(t *testing.T) {
 
 	assert.NotContains(t, buf.String(), "[DEBUG]",
 		"runController must not write [DEBUG] output to stdout")
+}
+
+// TestGetLogProviderConfigTimescaleMissingPassword verifies that getLogProviderConfig
+// returns a non-nil error when the timescale provider is configured but
+// CFGMS_TIMESCALE_PASSWORD is not set.
+func TestGetLogProviderConfigTimescaleMissingPassword(t *testing.T) {
+	t.Setenv("CFGMS_TIMESCALE_PASSWORD", "")
+	cfg := &config.Config{
+		Logging: &config.LoggingConfig{
+			Provider: "timescale",
+		},
+	}
+	result, err := getLogProviderConfig(cfg)
+	require.Error(t, err, "expected error when CFGMS_TIMESCALE_PASSWORD is unset")
+	assert.Nil(t, result)
+	assert.Contains(t, err.Error(), "CFGMS_TIMESCALE_PASSWORD")
+}
+
+// TestGetLogProviderConfigTimescaleWithPassword verifies that getLogProviderConfig
+// returns a nil error and a map containing the "password" key when
+// CFGMS_TIMESCALE_PASSWORD is set.
+func TestGetLogProviderConfigTimescaleWithPassword(t *testing.T) {
+	t.Setenv("CFGMS_TIMESCALE_PASSWORD", "secret123")
+	cfg := &config.Config{
+		Logging: &config.LoggingConfig{
+			Provider: "timescale",
+		},
+	}
+	result, err := getLogProviderConfig(cfg)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, "secret123", result["password"])
 }
 
 // TestSignalHandling is implemented in platform-specific files:


### PR DESCRIPTION
## Summary

- `getLogProviderConfig` now returns `(map[string]interface{}, error)` instead of calling `log.Fatal`
- Both callers (`runController` and `runInstall`) propagate the error as a wrapped `fmt.Errorf`
- stdlib `"log"` import removed from `cmd/controller/main.go`

## Why

`log.Fatal` called `os.Exit(1)` directly, bypassing `pkg/logging` cleanup on startup failure. Returning an error lets cobra handle it through the normal error path.

## Tests Added

- `TestGetLogProviderConfigTimescaleMissingPassword` — verifies non-nil error when `CFGMS_TIMESCALE_PASSWORD` is unset and provider is timescale
- `TestGetLogProviderConfigTimescaleWithPassword` — verifies nil error and correct `"password"` key in map when env var is set

## Specialist Review Results

- **QA Test Runner**: PASS — all gates passed, lint ST1005 fix confirmed, marker written
- **QA Code Reviewer**: PASS — no blocking issues; 1 warning (optional branch coverage for default/file provider path, non-blocking)
- **Security Engineer**: PASS — no blocking issues; `ssl_mode` default remains `"require"`, no hardcoded secrets, `check-architecture` clean

Fixes #790

🤖 Generated with [Claude Code](https://claude.com/claude-code)