### PR TITLE
controller: fix srv.Start() goroutine — call srv.Stop() on failure, unblock on clean exit (Issue #791)

### DIFF
--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -72,6 +72,12 @@ Entry paths:
 	return root
 }
 
+// Server defines the lifecycle interface for the controller server.
+type Server interface {
+	Start() error
+	Stop() error
+}
+
 // runController starts the controller server (or runs --init and exits).
 func runController(configPath string, initMode bool) error {
 	cfg, err := config.LoadWithPath(configPath)
@@ -142,28 +148,47 @@ func runController(configPath string, initMode bool) error {
 	sigChan := make(chan os.Signal, 1)
 	signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
 
+	return runControllerServer(srv, logger, sigChan)
+}
+
+// runControllerServer manages the server lifecycle with proper cleanup on both
+// signal-triggered shutdown and clean/error exit from srv.Start().
+func runControllerServer(srv Server, logger logging.Logger, sigChan <-chan os.Signal) error {
+	errCh := make(chan error, 1)
 	go func() {
-		if err := srv.Start(); err != nil {
-			logger.Fatal("Controller server failed",
-				"operation", "server_run",
-				"error", err.Error())
-		}
+		errCh <- srv.Start()
 	}()
 
-	sig := <-sigChan
-	logger.Info("Received signal, shutting down controller...",
-		"operation", "server_shutdown",
-		"signal", sig.String())
+	var runErr error
+	select {
+	case sig := <-sigChan:
+		logger.Info("Received signal, shutting down controller...",
+			"operation", "server_shutdown",
+			"signal", sig.String())
+	case runErr = <-errCh:
+		if runErr != nil {
+			logger.Error("Controller server failed",
+				"operation", "server_run",
+				"error", runErr.Error())
+		} else {
+			logger.Info("Controller server exited cleanly",
+				"operation", "server_run")
+		}
+	}
 
-	if err := srv.Stop(); err != nil {
+	if stopErr := srv.Stop(); stopErr != nil {
 		logger.Error("Error during controller shutdown",
 			"operation", "server_shutdown",
-			"error", err.Error())
+			"error", stopErr.Error())
 	}
 
 	logger.Info("Controller shutdown completed",
 		"operation", "server_shutdown",
 		"status", "completed")
+
+	if runErr != nil {
+		return fmt.Errorf("controller server failed: %w", runErr)
+	}
 	return nil
 }
 

--- a/cmd/controller/main_test.go
+++ b/cmd/controller/main_test.go
@@ -4,12 +4,15 @@ package main
 
 import (
 	"bytes"
+	"errors"
 	"io"
 	"os"
+	"sync"
 	"testing"
 
 	"github.com/cfgis/cfgms/cmd/controller/service"
 	"github.com/cfgis/cfgms/features/controller/config"
+	"github.com/cfgis/cfgms/pkg/logging"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -162,3 +165,54 @@ func TestGetLogProviderConfigTimescaleWithPassword(t *testing.T) {
 // TestSignalHandling is implemented in platform-specific files:
 // - main_test_unix.go for Unix systems (uses syscall.Kill)
 // - main_test_windows.go for Windows (uses channel-based simulation)
+
+// fakeServer is a test stub satisfying the Server interface.
+type fakeServer struct {
+	startErr  error
+	stopErr   error
+	mu        sync.Mutex
+	stopCalls int
+}
+
+func (f *fakeServer) Start() error { return f.startErr }
+
+func (f *fakeServer) Stop() error {
+	f.mu.Lock()
+	f.stopCalls++
+	f.mu.Unlock()
+	return f.stopErr
+}
+
+func (f *fakeServer) StopCallCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.stopCalls
+}
+
+// TestRunControllerStartFailureCallsStop verifies that when srv.Start() returns
+// an error, runControllerServer calls srv.Stop() before returning a non-nil error.
+func TestRunControllerStartFailureCallsStop(t *testing.T) {
+	startErr := errors.New("start failed")
+	stub := &fakeServer{startErr: startErr}
+	logger := logging.NewNoopLogger()
+	sigChan := make(chan os.Signal, 1)
+
+	err := runControllerServer(stub, logger, sigChan)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "start failed")
+	assert.Equal(t, 1, stub.StopCallCount(), "srv.Stop() must be called exactly once after Start() error")
+}
+
+// TestRunControllerCleanExitCallsStop verifies that when srv.Start() returns nil
+// (clean exit), runControllerServer still calls srv.Stop() and returns nil.
+func TestRunControllerCleanExitCallsStop(t *testing.T) {
+	stub := &fakeServer{startErr: nil}
+	logger := logging.NewNoopLogger()
+	sigChan := make(chan os.Signal, 1)
+
+	err := runControllerServer(stub, logger, sigChan)
+
+	require.NoError(t, err)
+	assert.Equal(t, 1, stub.StopCallCount(), "srv.Stop() must be called exactly once after clean Start() exit")
+}

--- a/cmd/controller/main_test_windows.go
+++ b/cmd/controller/main_test_windows.go
@@ -6,35 +6,72 @@ package main
 
 import (
 	"os"
-	"os/signal"
+	"sync"
 	"testing"
 	"time"
 
+	"github.com/cfgis/cfgms/pkg/logging"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
+// blockingServer is a Server whose Start() blocks until Stop() is called.
+// This allows signal-path tests to exercise the signal branch of
+// runControllerServer without a race between signal delivery and Start() return.
+type blockingServer struct {
+	mu        sync.Mutex
+	stopCalls int
+	done      chan struct{}
+}
+
+func newBlockingServer() *blockingServer {
+	return &blockingServer{done: make(chan struct{})}
+}
+
+func (b *blockingServer) Start() error {
+	<-b.done
+	return nil
+}
+
+func (b *blockingServer) Stop() error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.stopCalls++
+	if b.stopCalls == 1 {
+		close(b.done)
+	}
+	return nil
+}
+
+func (b *blockingServer) StopCallCount() int {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.stopCalls
+}
+
+// TestSignalHandling verifies that runControllerServer shuts down when a signal
+// arrives on sigChan, calls srv.Stop() exactly once, and returns nil.
+// On Windows there is no syscall.Kill equivalent, so we test via the sigChan
+// seam directly — the OS signal wiring is tested by the integration build.
 func TestSignalHandling(t *testing.T) {
-	done := make(chan struct{})
+	srv := newBlockingServer()
+	logger := logging.NewNoopLogger()
+	sigChan := make(chan os.Signal, 1)
 
+	// Pre-buffer the signal so runControllerServer's select fires the signal
+	// path before srv.Start() can return on its own.
+	sigChan <- os.Interrupt
+
+	result := make(chan error, 1)
 	go func() {
-		// On Windows we test with os.Interrupt (no syscall.Kill equivalent).
-		// The channel is buffered so the send below does not block regardless of
-		// receive timing — no sleep needed.
-		sigChan := make(chan os.Signal, 1)
-		signal.Notify(sigChan, os.Interrupt)
-
-		// Send directly to the buffered channel; this is deterministic and races-free.
-		sigChan <- os.Interrupt
-
-		sig := <-sigChan
-		assert.Equal(t, os.Interrupt, sig)
-		close(done)
+		result <- runControllerServer(srv, logger, sigChan)
 	}()
 
 	select {
-	case <-done:
-		// Test completed successfully
+	case err := <-result:
+		require.NoError(t, err)
+		assert.Equal(t, 1, srv.StopCallCount(), "srv.Stop() must be called exactly once on signal")
 	case <-time.After(1 * time.Second):
-		t.Fatal("Test timed out")
+		t.Fatal("TestSignalHandling timed out — runControllerServer did not return after signal")
 	}
 }


### PR DESCRIPTION
## Summary

- Replaces fire-and-forget goroutine with an `errCh`-based pattern so `srv.Stop()` is always called before the process exits — on signal, on `Start()` error, and on clean `Start()` return
- Removes `logger.Fatal` from the goroutine; errors now propagate via `runControllerServer` return value
- Introduces a `Server` interface at the cmd layer for testability without starting a real network server

## Acceptance Criteria

- [x] `srv.Start()` error path calls `srv.Stop()` before the process exits
- [x] `srv.Start()` nil return causes `runControllerServer` to perform orderly shutdown and return nil
- [x] `logger.Fatal` is not called anywhere in `cmd/controller/main.go` goroutines
- [x] The main goroutine does not block indefinitely when `srv.Start()` exits cleanly
- [x] `go build ./cmd/controller/...` succeeds
- [x] `TestRunControllerStartFailureCallsStop` passes
- [x] `make test-agent-complete` passes

## Specialist Review Results

| Reviewer | Result | Notes |
|----------|--------|-------|
| QA Test Runner | **PASS** | All unit tests, lint, cross-platform builds pass; Trivy skipped (no network in container — runs in CI) |
| QA Code Reviewer | **PASS** | `fakeServer` correctly identified as cmd-layer seam stub, not a CFGMS component mock; all assertions present |
| Security Engineer | **PASS** | No secrets, no injection, no central provider violations; `check-architecture` clean |

Fixes #791