### PR TITLE
steward: remove CFGMS_HTTP_INSECURE_SKIP_VERIFY registration MITM escape hatch (Issue #809)

### DIFF
--- a/cmd/steward/main.go
+++ b/cmd/steward/main.go
@@ -451,6 +451,17 @@ func runInteractive() error {
 	}
 }
 
+// buildHTTPConfig constructs an HTTPConfig from environment variables and the provided arguments.
+// CFGMS_HTTP_CA_CERT_PATH, when set, is used to verify the controller's TLS certificate during registration.
+func buildHTTPConfig(controllerURL string, timeout time.Duration, logger logging.Logger) *registration.HTTPConfig {
+	return &registration.HTTPConfig{
+		ControllerURL: controllerURL,
+		Timeout:       timeout,
+		CACertPath:    os.Getenv("CFGMS_HTTP_CA_CERT_PATH"),
+		Logger:        logger,
+	}
+}
+
 // registerAndConnect registers the steward using HTTP REST API
 // and then establishes gRPC-over-QUIC connections for ongoing communication.
 // Both control plane and data plane use the transport_address from the registration response.
@@ -464,18 +475,7 @@ func registerAndConnect(ctx context.Context, token string, logger logging.Logger
 			"See docs/deployment/ for build instructions")
 	}
 
-	insecureSkipVerify := false
-	if skipVerify := os.Getenv("CFGMS_HTTP_INSECURE_SKIP_VERIFY"); skipVerify == "true" {
-		insecureSkipVerify = true
-		logger.Warn("HTTP TLS verification disabled (test mode only)")
-	}
-
-	httpClient, err := registration.NewHTTPClient(&registration.HTTPConfig{
-		ControllerURL:      controllerURL,
-		Timeout:            30 * time.Second,
-		InsecureSkipVerify: insecureSkipVerify,
-		Logger:             logger,
-	})
+	httpClient, err := registration.NewHTTPClient(buildHTTPConfig(controllerURL, 30*time.Second, logger))
 	if err != nil {
 		return nil, fmt.Errorf("failed to create HTTP registration client: %w", err)
 	}

--- a/cmd/steward/main_test.go
+++ b/cmd/steward/main_test.go
@@ -5,8 +5,10 @@ package main
 
 import (
 	"testing"
+	"time"
 
 	"github.com/cfgis/cfgms/cmd/steward/service"
+	"github.com/cfgis/cfgms/pkg/logging"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -73,6 +75,25 @@ func TestRunStatusNotInstalled(t *testing.T) {
 	// status should succeed even when the service is not installed.
 	err := runStatus()
 	assert.NoError(t, err)
+}
+
+func TestBuildHTTPConfig(t *testing.T) {
+	logger := logging.NewLogger("debug")
+
+	t.Run("empty CFGMS_HTTP_CA_CERT_PATH produces empty CACertPath", func(t *testing.T) {
+		t.Setenv("CFGMS_HTTP_CA_CERT_PATH", "")
+		cfg := buildHTTPConfig("https://controller.example.com", 30*time.Second, logger)
+		require.NotNil(t, cfg)
+		assert.Equal(t, "https://controller.example.com", cfg.ControllerURL)
+		assert.Equal(t, "", cfg.CACertPath)
+	})
+
+	t.Run("CFGMS_HTTP_CA_CERT_PATH is forwarded to HTTPConfig.CACertPath", func(t *testing.T) {
+		t.Setenv("CFGMS_HTTP_CA_CERT_PATH", "/etc/cfgms/ca.crt")
+		cfg := buildHTTPConfig("https://controller.example.com", 30*time.Second, logger)
+		require.NotNil(t, cfg)
+		assert.Equal(t, "/etc/cfgms/ca.crt", cfg.CACertPath)
+	})
 }
 
 func TestControllerURLOrUnknown(t *testing.T) {

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -498,7 +498,7 @@ services:
         STEWARD_CONTROLLER_URL: "https://controller-standalone:9080"
     environment:
       CFGMS_REGISTRATION_TOKEN: "${REG_TOKEN_STANDALONE}"
-      CFGMS_HTTP_INSECURE_SKIP_VERIFY: "true"  # Story #312: Test mode - skip TLS verification for HTTP registration
+      CFGMS_HTTP_CA_CERT_PATH: "/app/controller-certs/ca/ca.crt"
       # gRPC transport uses TLS auto-negotiated via registration response (no static cert paths needed)
       CFGMS_LOG_LEVEL: "debug"
       CFGMS_LOG_PROVIDER: "file"
@@ -506,6 +506,7 @@ services:
     command: ["sh", "-c", "./steward --log-level debug --log-provider file --regtoken $$CFGMS_REGISTRATION_TOKEN"]
     volumes:
       - steward_standalone_data:/app/data
+      - controller_standalone_certs:/app/controller-certs:ro
     tmpfs:
       # Story #315: Use tmpfs for module execution test workspace (writable, fast, ephemeral)
       # Simulates real-world endpoint with writable directory, no permission issues
@@ -538,7 +539,7 @@ services:
     environment:
       CFGMS_TENANT_ID: "tenant1"  # Story 12.5: Tenant isolation
       CFGMS_REGISTRATION_TOKEN: "${REG_TOKEN_TENANT1}"
-      CFGMS_HTTP_INSECURE_SKIP_VERIFY: "true"  # Story #312: Test mode - skip TLS verification for HTTP registration
+      CFGMS_HTTP_CA_CERT_PATH: "/app/controller-certs/ca/ca.crt"
       CFGMS_LOG_LEVEL: "debug"
       CFGMS_LOG_PROVIDER: "file"
       CFGMS_LOG_DIR: "/tmp/cfgms"
@@ -546,6 +547,7 @@ services:
     volumes:
       - steward_tenant1_data:/app/data
       - ./test/module-execution:/test-workspace:rw
+      - controller_standalone_certs:/app/controller-certs:ro
     depends_on:
       controller-standalone:
         condition: service_healthy
@@ -564,7 +566,7 @@ services:
     environment:
       CFGMS_TENANT_ID: "tenant2"  # Story 12.5: Tenant isolation
       CFGMS_REGISTRATION_TOKEN: "${REG_TOKEN_TENANT2}"
-      CFGMS_HTTP_INSECURE_SKIP_VERIFY: "true"  # Story #312: Test mode - skip TLS verification for HTTP registration
+      CFGMS_HTTP_CA_CERT_PATH: "/app/controller-certs/ca/ca.crt"
       CFGMS_LOG_LEVEL: "debug"
       CFGMS_LOG_PROVIDER: "file"
       CFGMS_LOG_DIR: "/tmp/cfgms"
@@ -572,6 +574,7 @@ services:
     volumes:
       - steward_tenant2_data:/app/data
       - ./test/module-execution:/test-workspace:rw
+      - controller_standalone_certs:/app/controller-certs:ro
     depends_on:
       controller-standalone:
         condition: service_healthy
@@ -590,7 +593,7 @@ services:
     environment:
       CFGMS_TENANT_ID: "tenant3"  # Story 12.5: Tenant isolation
       CFGMS_REGISTRATION_TOKEN: "${REG_TOKEN_TENANT3}"
-      CFGMS_HTTP_INSECURE_SKIP_VERIFY: "true"  # Story #312: Test mode - skip TLS verification for HTTP registration
+      CFGMS_HTTP_CA_CERT_PATH: "/app/controller-certs/ca/ca.crt"
       CFGMS_LOG_LEVEL: "debug"
       CFGMS_LOG_PROVIDER: "file"
       CFGMS_LOG_DIR: "/tmp/cfgms"
@@ -598,6 +601,7 @@ services:
     volumes:
       - steward_tenant3_data:/app/data
       - ./test/module-execution:/test-workspace:rw
+      - controller_standalone_certs:/app/controller-certs:ro
     depends_on:
       controller-standalone:
         condition: service_healthy

--- a/docs/architecture/steward-operating-model.md
+++ b/docs/architecture/steward-operating-model.md
@@ -275,6 +275,20 @@ How a steward joins a controller.
 
 After initial registration, the steward reconnects automatically on restart using its stored certificates. The registration token is only used once.
 
+### Bootstrap TLS Trust
+
+The initial registration call is an HTTPS request to a controller whose TLS certificate is signed by a CA the steward has never seen. By default the steward validates against system root CAs. For MSPs that deploy controllers with a private CA (self-signed or internal PKI), set:
+
+```
+CFGMS_HTTP_CA_CERT_PATH=/path/to/controller-ca.crt
+```
+
+The steward loads the PEM-encoded CA certificate at startup and uses it exclusively to verify the controller's TLS certificate during registration. Once registration succeeds, all subsequent communication uses the mTLS certificates issued by the controller — the CA cert file is not needed again.
+
+The controller writes its CA certificate to `<CFGMS_CERT_PATH>/ca/ca.crt` on first boot. In Docker or containerised deployments, mount the controller's cert volume read-only into each steward container and point `CFGMS_HTTP_CA_CERT_PATH` at the mounted path.
+
+TLS verification is always enforced. There is no environment variable to disable it.
+
 ## Cfg Fields Governing Convergence
 
 The convergence loop behaviour is controlled by fields in the cfg:

--- a/features/steward/registration/client_http.go
+++ b/features/steward/registration/client_http.go
@@ -10,8 +10,11 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
+	"os"
 	"time"
 
+	"github.com/cfgis/cfgms/pkg/cert"
 	"github.com/cfgis/cfgms/pkg/logging"
 )
 
@@ -56,10 +59,12 @@ type HTTPClient struct {
 
 // HTTPConfig holds configuration for HTTP registration
 type HTTPConfig struct {
-	ControllerURL      string
-	Timeout            time.Duration
-	InsecureSkipVerify bool // Skip TLS verification (test mode only)
-	Logger             logging.Logger
+	ControllerURL string
+	Timeout       time.Duration
+	// CACertPath is the optional path to a PEM-encoded CA certificate used to verify
+	// the controller's TLS certificate during registration. When empty, system root CAs are used.
+	CACertPath string
+	Logger     logging.Logger
 }
 
 // NewHTTPClient creates a new HTTP-based registration client
@@ -76,12 +81,23 @@ func NewHTTPClient(cfg *HTTPConfig) (*HTTPClient, error) {
 		timeout = 30 * time.Second
 	}
 
-	// Configure TLS if needed (test mode support)
 	transport := &http.Transport{}
-	if cfg.InsecureSkipVerify {
-		transport.TLSClientConfig = &tls.Config{
-			InsecureSkipVerify: true, // #nosec G402 - Test mode only, controlled by explicit configuration
+	if cfg.CACertPath != "" {
+		caPEM, err := os.ReadFile(cfg.CACertPath)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read CA cert from %q: %w", cfg.CACertPath, err)
 		}
+
+		parsed, err := url.Parse(cfg.ControllerURL)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse controller URL: %w", err)
+		}
+
+		tlsCfg, err := cert.CreateClientTLSConfig(nil, nil, caPEM, parsed.Hostname(), tls.VersionTLS12)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create TLS config from CA cert: %w", err)
+		}
+		transport.TLSClientConfig = tlsCfg
 	}
 
 	return &HTTPClient{

--- a/features/steward/registration/client_http_test.go
+++ b/features/steward/registration/client_http_test.go
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+package registration
+
+import (
+	"net/http"
+	"os"
+	"path/filepath"
+	"testing"
+
+	cfgcert "github.com/cfgis/cfgms/pkg/cert"
+	"github.com/cfgis/cfgms/pkg/logging"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewHTTPClientAlwaysVerifiesTLS(t *testing.T) {
+	logger := logging.NewLogger("debug")
+
+	t.Run("empty CACertPath uses system roots with nil TLSClientConfig", func(t *testing.T) {
+		client, err := NewHTTPClient(&HTTPConfig{
+			ControllerURL: "https://controller.example.com",
+			Logger:        logger,
+		})
+		require.NoError(t, err)
+
+		transport, ok := client.httpClient.Transport.(*http.Transport)
+		require.True(t, ok, "transport must be *http.Transport")
+		assert.Nil(t, transport.TLSClientConfig, "nil TLSClientConfig means system root CAs are used")
+	})
+
+	t.Run("valid CACertPath populates RootCAs and never sets InsecureSkipVerify", func(t *testing.T) {
+		tmpDir := t.TempDir()
+
+		ca, err := cfgcert.NewCA(&cfgcert.CAConfig{
+			Organization: "Test CA",
+			Country:      "US",
+			ValidityDays: 365,
+		})
+		require.NoError(t, err)
+		require.NoError(t, ca.Initialize(nil))
+
+		caPEM, err := ca.GetCACertificate()
+		require.NoError(t, err)
+
+		caPath := filepath.Join(tmpDir, "ca.crt")
+		require.NoError(t, os.WriteFile(caPath, caPEM, 0600))
+
+		client, err := NewHTTPClient(&HTTPConfig{
+			ControllerURL: "https://controller.example.com",
+			CACertPath:    caPath,
+			Logger:        logger,
+		})
+		require.NoError(t, err)
+
+		transport, ok := client.httpClient.Transport.(*http.Transport)
+		require.True(t, ok, "transport must be *http.Transport")
+		require.NotNil(t, transport.TLSClientConfig, "TLSClientConfig must be set when CACertPath is provided")
+		assert.NotNil(t, transport.TLSClientConfig.RootCAs, "RootCAs must be populated from the CA cert file")
+		assert.False(t, transport.TLSClientConfig.InsecureSkipVerify, "InsecureSkipVerify must never be true")
+	})
+
+	t.Run("missing CACertPath file returns error", func(t *testing.T) {
+		_, err := NewHTTPClient(&HTTPConfig{
+			ControllerURL: "https://controller.example.com",
+			CACertPath:    "/nonexistent/path/ca.crt",
+			Logger:        logger,
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to read CA cert")
+	})
+
+	t.Run("invalid PEM in CACertPath file returns error", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		caPath := filepath.Join(tmpDir, "ca.crt")
+		require.NoError(t, os.WriteFile(caPath, []byte("not-valid-pem"), 0600))
+
+		_, err := NewHTTPClient(&HTTPConfig{
+			ControllerURL: "https://controller.example.com",
+			CACertPath:    caPath,
+			Logger:        logger,
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to create TLS config")
+	})
+
+	t.Run("empty ControllerURL returns error", func(t *testing.T) {
+		_, err := NewHTTPClient(&HTTPConfig{
+			ControllerURL: "",
+			Logger:        logger,
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "controller URL is required")
+	})
+
+	t.Run("nil Logger returns error", func(t *testing.T) {
+		_, err := NewHTTPClient(&HTTPConfig{
+			ControllerURL: "https://controller.example.com",
+			Logger:        nil,
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "logger is required")
+	})
+}


### PR DESCRIPTION
## Summary

- Deletes `CFGMS_HTTP_INSECURE_SKIP_VERIFY` — no environment variable can now disable TLS verification on the steward registration handshake
- Replaces it with `CFGMS_HTTP_CA_CERT_PATH`: an optional path to a PEM-encoded CA cert; when set, `NewHTTPClient` builds a `TLSClientConfig` with `RootCAs` populated via `cert.CreateClientTLSConfig` (central cert provider) and TLS 1.2+ enforced; when empty, system root CAs are used
- All four standalone/tenant steward services in `docker-compose.test.yml` now mount the controller's cert volume read-only and set `CFGMS_HTTP_CA_CERT_PATH` instead of the removed insecure flag

## Test plan

- [ ] `TestNewHTTPClientAlwaysVerifiesTLS` — covers nil TLSClientConfig (system roots), populated RootCAs (valid CA file), InsecureSkipVerify always false, missing file error, invalid PEM error, empty URL guard, nil logger guard
- [ ] `TestBuildHTTPConfig` — verifies `CFGMS_HTTP_CA_CERT_PATH` is forwarded to `HTTPConfig.CACertPath` at runtime
- [ ] `grep` clean: `CFGMS_HTTP_INSECURE_SKIP_VERIFY` does not appear in any production file
- [ ] `make test-agent-complete` passes

## Specialist Review Results

| Reviewer | Result | Notes |
|----------|--------|-------|
| QA Test Runner | **PASS** | All unit, integration, lint, architecture gates passed |
| Security Engineer | **PASS** | No G402 findings; `InsecureSkipVerify` removed from production path; `pkg/cert` central provider used correctly; docker volume mounts are `:ro` |
| QA Code Reviewer | FAIL → **PASS** | 3 blocking issues found and fixed: (1) replaced source-text grep test with behavioral `TestBuildHTTPConfig` + extracted `buildHTTPConfig()` helper; (2) corrected misleading subtest name; (3) added missing guard clause error-path tests |

Fixes #809

🤖 Generated with [Claude Code](https://claude.com/claude-code)