### PR TITLE
controller: fix srv.Start() goroutine — call srv.Stop() on failure, unblock on clean exit (Issue #791)

### DIFF
--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -142,28 +142,56 @@ func runController(configPath string, initMode bool) error {
 	sigChan := make(chan os.Signal, 1)
 	signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
 
+	return runControllerServer(srv, sigChan)
+}
+
+// controllerServer is the interface used by runControllerServer so that tests
+// can inject a fake without depending on the real server implementation.
+type controllerServer interface {
+	Start() error
+	Stop() error
+}
+
+// runControllerServer blocks until a signal arrives on sigChan or Start()
+// returns a non-nil error. It always calls Stop() before returning.
+func runControllerServer(srv controllerServer, sigChan <-chan os.Signal) error {
+	logger := logging.ForComponent("controller")
+
+	errCh := make(chan error, 1)
 	go func() {
 		if err := srv.Start(); err != nil {
-			logger.Fatal("Controller server failed",
-				"operation", "server_run",
-				"error", err.Error())
+			errCh <- err
 		}
+		// nil return from Start() means services launched successfully;
+		// goroutine exits silently and errCh stays empty so the main
+		// goroutine continues waiting for sigChan.
 	}()
 
-	sig := <-sigChan
-	logger.Info("Received signal, shutting down controller...",
-		"operation", "server_shutdown",
-		"signal", sig.String())
+	var runErr error
+	select {
+	case sig := <-sigChan:
+		logger.Info("Received signal, shutting down controller...",
+			"operation", "server_shutdown",
+			"signal", sig.String())
+	case runErr = <-errCh:
+		logger.Error("Controller server failed",
+			"operation", "server_run",
+			"error", runErr.Error())
+	}
 
-	if err := srv.Stop(); err != nil {
+	if stopErr := srv.Stop(); stopErr != nil {
 		logger.Error("Error during controller shutdown",
 			"operation", "server_shutdown",
-			"error", err.Error())
+			"error", stopErr.Error())
 	}
 
 	logger.Info("Controller shutdown completed",
 		"operation", "server_shutdown",
 		"status", "completed")
+
+	if runErr != nil {
+		return fmt.Errorf("controller server failed: %w", runErr)
+	}
 	return nil
 }
 

--- a/cmd/controller/main_test.go
+++ b/cmd/controller/main_test.go
@@ -4,9 +4,12 @@ package main
 
 import (
 	"bytes"
+	"fmt"
 	"io"
 	"os"
+	"syscall"
 	"testing"
+	"time"
 
 	"github.com/cfgis/cfgms/cmd/controller/service"
 	"github.com/cfgis/cfgms/features/controller/config"
@@ -162,3 +165,118 @@ func TestGetLogProviderConfigTimescaleWithPassword(t *testing.T) {
 // TestSignalHandling is implemented in platform-specific files:
 // - main_test_unix.go for Unix systems (uses syscall.Kill)
 // - main_test_windows.go for Windows (uses channel-based simulation)
+
+// fakeServer is a test double for the controllerServer interface defined in
+// main.go. It does NOT mock any CFGMS business-logic component; it models
+// the OS-process lifecycle boundary (Start/Stop) with controllable return
+// values so that runControllerServer's goroutine-supervision logic can be
+// tested without requiring a full TLS+storage+gRPC stack.
+type fakeServer struct {
+	startErr   error
+	stopErr    error
+	startBlock chan struct{} // nil means return immediately
+	startDone  chan struct{} // closed when Start() returns
+	stopCalled chan struct{}
+}
+
+func newFakeServer(startErr error, block bool) *fakeServer {
+	f := &fakeServer{
+		startErr:   startErr,
+		startDone:  make(chan struct{}),
+		stopCalled: make(chan struct{}, 1),
+	}
+	if block {
+		f.startBlock = make(chan struct{})
+	}
+	return f
+}
+
+func (f *fakeServer) Start() error {
+	defer close(f.startDone)
+	if f.startBlock != nil {
+		<-f.startBlock
+	}
+	return f.startErr
+}
+
+func (f *fakeServer) Stop() error {
+	f.stopCalled <- struct{}{}
+	return f.stopErr
+}
+
+// TestRunControllerStartFailureCallsStop verifies that when Start() returns an
+// error, runControllerServer calls Stop() and returns a wrapped non-nil error.
+func TestRunControllerStartFailureCallsStop(t *testing.T) {
+	srv := newFakeServer(fmt.Errorf("boom"), false)
+	sigChan := make(chan os.Signal, 1)
+
+	err := runControllerServer(srv, sigChan)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "boom")
+	assert.Len(t, srv.stopCalled, 1, "Stop() must be called exactly once on Start() error")
+}
+
+// TestRunControllerServerIgnoresNilStart is the regression test for PR #815:
+// when Start() returns nil (non-blocking success), runControllerServer must NOT
+// return — it must keep waiting for sigChan. We verify this by confirming the
+// function is still blocked after a short delay, then unblock it via sigChan.
+func TestRunControllerServerIgnoresNilStart(t *testing.T) {
+	srv := newFakeServer(nil, false) // Start() returns nil immediately
+	sigChan := make(chan os.Signal, 1)
+
+	done := make(chan error, 1)
+	go func() {
+		done <- runControllerServer(srv, sigChan)
+	}()
+
+	// Confirm runControllerServer has NOT returned ~50 ms after Start() returned nil.
+	select {
+	case got := <-done:
+		t.Fatalf("runControllerServer returned early (runErr=%v) — nil Start() must not unblock it", got)
+	case <-time.After(50 * time.Millisecond):
+		// Still blocked — correct behaviour.
+	}
+
+	// Now send a signal to trigger clean shutdown.
+	sigChan <- os.Interrupt
+
+	select {
+	case err := <-done:
+		assert.NoError(t, err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("runControllerServer did not unblock after signal")
+	}
+	assert.Len(t, srv.stopCalled, 1, "Stop() must be called exactly once")
+}
+
+// TestRunControllerSignalPath verifies that a signal on sigChan causes
+// runControllerServer to call Stop() and return nil.
+func TestRunControllerSignalPath(t *testing.T) {
+	srv := newFakeServer(nil, true) // Start() blocks until Stop path closes startBlock
+	sigChan := make(chan os.Signal, 1)
+
+	done := make(chan error, 1)
+	go func() {
+		done <- runControllerServer(srv, sigChan)
+	}()
+
+	// Unblock Start() so it can return nil; then wait for the goroutine to
+	// actually return before sending the signal — no sleep needed.
+	close(srv.startBlock)
+	select {
+	case <-srv.startDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Start() goroutine did not return within timeout")
+	}
+
+	sigChan <- syscall.SIGTERM
+
+	select {
+	case err := <-done:
+		assert.NoError(t, err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("runControllerServer did not return after signal")
+	}
+	assert.Len(t, srv.stopCalled, 1, "Stop() must be called exactly once")
+}


### PR DESCRIPTION
## Summary

- Extracts `runControllerServer(srv controllerServer, sigChan <-chan os.Signal)` with a two-method interface for testability
- Fixes the `errCh` pattern: only sends on non-nil Start() error, so nil return (services launched) does NOT unblock the select
- Removes `logger.Fatal` from all goroutines; `srv.Stop()` is always called before returning

## Root Cause

PR #815 used `errCh <- srv.Start()` (always send). Since `Start()` is non-blocking and returns nil in ~200ms, the select unblocked immediately, `Stop()` was called, and the controller exited with code 0. The `controller-standalone` docker-compose container then exited, breaking steward registration and failing `TestV020BasicIntegration`, `Controller Integration Tests`, and `Integration Tests (Docker)`.

## Regression Test

`TestRunControllerServerIgnoresNilStart` proves that a nil return from `Start()` does NOT cause `runControllerServer` to return. It sends a signal into `sigChan` after a 50ms window to prove the function was still blocked.

## Specialist Review Results

| Specialist | Result |
|-----------|--------|
| QA Test Runner (`make test-agent-complete`) | **PASS** — all gates pass; Trivy blocked by container network isolation (pre-existing infra limit) |
| QA Code Reviewer | **PASS** — no blocking issues; `fakeServer` is an OS lifecycle boundary test double, not a CFGMS business-logic mock |
| Security Engineer | **PASS** — no security issues; gosec findings are pre-existing on `develop`; no central provider violations |

## Tests Added

- `TestRunControllerStartFailureCallsStop` — Start() error → Stop() called once, wrapped error returned
- `TestRunControllerServerIgnoresNilStart` — Start() returns nil → function stays blocked until signal (PR #815 regression test)
- `TestRunControllerSignalPath` — signal → Stop() called once, nil returned; uses channel synchronization (no sleep)

Fixes #791