### PR TITLE
controller: extract buildLoggingConfig helper, unify duplicated init-and-logging path (Issue #792)

### DIFF
--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -86,23 +86,9 @@ func runController(configPath string, initMode bool) error {
 			"then update your configuration to use 'flatfile' or 'database'")
 	}
 
-	logProviderConfig, err := getLogProviderConfig(cfg)
+	loggingConfig, err := buildLoggingConfig(cfg, "main")
 	if err != nil {
-		return fmt.Errorf("failed to build log provider config: %w", err)
-	}
-	loggingConfig := &logging.LoggingConfig{
-		Provider:          getLogProvider(cfg),
-		Level:             strings.ToUpper(cfg.LogLevel),
-		ServiceName:       "controller",
-		Component:         "main",
-		TenantIsolation:   true,
-		EnableCorrelation: true,
-		EnableTracing:     true,
-		AsyncWrites:       true,
-		BatchSize:         100,
-		FlushInterval:     5 * time.Second,
-		RetentionDays:     90,
-		Config:            logProviderConfig,
+		return err
 	}
 
 	if err := logging.InitializeGlobalLogging(loggingConfig); err != nil {
@@ -288,23 +274,16 @@ func runInstall(configPath string) error {
 		return fmt.Errorf("failed to load configuration from %s: %w", configPath, err)
 	}
 
-	caPath := ""
-	if cfg.Certificate != nil {
-		caPath = cfg.Certificate.CAPath
+	caPath, err := resolveInstallCAPath(cfg, configPath)
+	if err != nil {
+		return err
 	}
 
-	if caPath != "" && !initialization.IsInitialized(caPath) {
+	if !initialization.IsInitialized(caPath) {
 		fmt.Println("Controller not yet initialized — running --init...")
-		logProviderConfig, err := getLogProviderConfig(cfg)
+		loggingConfig, err := buildLoggingConfig(cfg, "install")
 		if err != nil {
-			return fmt.Errorf("failed to build log provider config: %w", err)
-		}
-		loggingConfig := &logging.LoggingConfig{
-			Provider:    getLogProvider(cfg),
-			Level:       "INFO",
-			ServiceName: "controller",
-			Component:   "install",
-			Config:      logProviderConfig,
+			return fmt.Errorf("failed to initialize logging: %w", err)
 		}
 		if err := logging.InitializeGlobalLogging(loggingConfig); err != nil {
 			return fmt.Errorf("failed to initialize logging: %w", err)
@@ -405,6 +384,41 @@ func caFingerprintFromConfig(configPath string) string {
 	}
 
 	return marker.CAFingerprint
+}
+
+// resolveInstallCAPath extracts the CA path from the config, returning an error
+// when the certificate configuration is absent. The prior silent-skip when
+// cfg.Certificate is nil is replaced by an explicit failure so the operator
+// gets a clear actionable message.
+func resolveInstallCAPath(cfg *config.Config, configPath string) (string, error) {
+	if cfg.Certificate == nil {
+		return "", fmt.Errorf("certificate configuration is required for initialization; set certificate.ca_path in %s", configPath)
+	}
+	return cfg.Certificate.CAPath, nil
+}
+
+// buildLoggingConfig constructs a complete LoggingConfig for the given component.
+// All fields are set identically regardless of call site so runController and
+// runInstall share the same logging shape.
+func buildLoggingConfig(cfg *config.Config, component string) (*logging.LoggingConfig, error) {
+	logProviderConfig, err := getLogProviderConfig(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("failed to build log provider config: %w", err)
+	}
+	return &logging.LoggingConfig{
+		Provider:          getLogProvider(cfg),
+		Level:             strings.ToUpper(cfg.LogLevel),
+		ServiceName:       "controller",
+		Component:         component,
+		TenantIsolation:   true,
+		EnableCorrelation: true,
+		EnableTracing:     true,
+		AsyncWrites:       true,
+		BatchSize:         100,
+		FlushInterval:     5 * time.Second,
+		RetentionDays:     90,
+		Config:            logProviderConfig,
+	}, nil
 }
 
 // getLogProvider determines the logging provider from configuration.

--- a/cmd/controller/main_test.go
+++ b/cmd/controller/main_test.go
@@ -162,6 +162,74 @@ func TestGetLogProviderConfigTimescaleWithPassword(t *testing.T) {
 	assert.Equal(t, "secret123", result["password"])
 }
 
+// TestBuildLoggingConfigFieldsComplete asserts that buildLoggingConfig populates
+// all required fields for a config with LogLevel = "debug" and no timescale provider.
+func TestBuildLoggingConfigFieldsComplete(t *testing.T) {
+	cfg := &config.Config{
+		LogLevel: "debug",
+	}
+	lc, err := buildLoggingConfig(cfg, "test")
+	require.NoError(t, err)
+	require.NotNil(t, lc)
+
+	assert.Equal(t, "DEBUG", lc.Level, "Level must be uppercased from cfg.LogLevel")
+	assert.True(t, lc.TenantIsolation, "TenantIsolation must be true")
+	assert.True(t, lc.EnableCorrelation, "EnableCorrelation must be true")
+	assert.True(t, lc.EnableTracing, "EnableTracing must be true")
+	assert.True(t, lc.AsyncWrites, "AsyncWrites must be true")
+	assert.Equal(t, 100, lc.BatchSize, "BatchSize must be 100")
+	assert.Equal(t, 5*time.Second, lc.FlushInterval, "FlushInterval must be 5s")
+	assert.Equal(t, 90, lc.RetentionDays, "RetentionDays must be 90")
+	assert.Equal(t, "test", lc.Component, "Component must match argument")
+}
+
+// TestRunInstallLoggingConfigMatchesRunController asserts that buildLoggingConfig
+// produces equivalent field values for install and main paths given identical config.
+func TestRunInstallLoggingConfigMatchesRunController(t *testing.T) {
+	cfg := &config.Config{
+		LogLevel: "info",
+	}
+
+	mainCfg, err := buildLoggingConfig(cfg, "main")
+	require.NoError(t, err)
+
+	installCfg, err := buildLoggingConfig(cfg, "install")
+	require.NoError(t, err)
+
+	assert.Equal(t, mainCfg.Level, installCfg.Level)
+	assert.Equal(t, mainCfg.TenantIsolation, installCfg.TenantIsolation)
+	assert.Equal(t, mainCfg.EnableCorrelation, installCfg.EnableCorrelation)
+	assert.Equal(t, mainCfg.EnableTracing, installCfg.EnableTracing)
+	assert.Equal(t, mainCfg.AsyncWrites, installCfg.AsyncWrites)
+	assert.Equal(t, mainCfg.BatchSize, installCfg.BatchSize)
+	assert.Equal(t, mainCfg.FlushInterval, installCfg.FlushInterval)
+	assert.Equal(t, mainCfg.RetentionDays, installCfg.RetentionDays)
+}
+
+// TestResolveInstallCAPathNilCertificateErrors asserts that resolveInstallCAPath
+// returns a clear error when cfg.Certificate is nil and initialization is needed.
+func TestResolveInstallCAPathNilCertificateErrors(t *testing.T) {
+	cfg := &config.Config{}
+	_, err := resolveInstallCAPath(cfg, "/etc/cfgms/controller.cfg")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "certificate configuration is required for initialization")
+	assert.Contains(t, err.Error(), "/etc/cfgms/controller.cfg")
+}
+
+// TestResolveInstallCAPathWithCertificate asserts that resolveInstallCAPath
+// returns the CA path without error when cfg.Certificate is set.
+func TestResolveInstallCAPathWithCertificate(t *testing.T) {
+	dir := t.TempDir()
+	cfg := &config.Config{
+		Certificate: &config.CertificateConfig{
+			CAPath: dir,
+		},
+	}
+	caPath, err := resolveInstallCAPath(cfg, "/etc/cfgms/controller.cfg")
+	require.NoError(t, err)
+	assert.Equal(t, dir, caPath)
+}
+
 // TestSignalHandling is implemented in platform-specific files:
 // - main_test_unix.go for Unix systems (uses syscall.Kill)
 // - main_test_windows.go for Windows (uses channel-based simulation)

--- a/features/controller/api/handlers_registration_test.go
+++ b/features/controller/api/handlers_registration_test.go
@@ -219,8 +219,8 @@ func TestHandleRegister_ExpiredToken_Returns401(t *testing.T) {
 func TestHandleRegister_StoreError_Returns500(t *testing.T) {
 	storeErr := fmt.Errorf("failed to persist token state: %w", fmt.Errorf("connection refused"))
 	tokenStore := &controlledConsumeStore{
-		Store: newTestRegistrationStore(t),
-		consumeErr:   storeErr,
+		Store:      newTestRegistrationStore(t),
+		consumeErr: storeErr,
 	}
 	server, _ := newHandleRegisterServer(t, tokenStore, nil)
 
@@ -387,8 +387,8 @@ func TestHandleRegister_ConcurrentSingleUseToken_ExactlyOneSucceeds(t *testing.T
 func TestHandleRegister_ErrTokenAlreadyUsed_IsDistinctFrom500(t *testing.T) {
 	// This test uses the sentinel directly to confirm the error distinction matters.
 	tokenStore := &controlledConsumeStore{
-		Store: newTestRegistrationStore(t),
-		consumeErr:   business.ErrTokenAlreadyUsed,
+		Store:      newTestRegistrationStore(t),
+		consumeErr: business.ErrTokenAlreadyUsed,
 	}
 	server, _ := newHandleRegisterServer(t, tokenStore, nil)
 


### PR DESCRIPTION
## Summary

- Extracted `buildLoggingConfig(cfg *config.Config, component string) (*logging.LoggingConfig, error)` helper that builds the complete `LoggingConfig` with all fields — both `runController` and `runInstall` now delegate to this shared function
- Eliminated the partial `LoggingConfig` in `runInstall` that was missing `TenantIsolation`, `EnableCorrelation`, `EnableTracing`, `AsyncWrites`, `BatchSize`, `FlushInterval`, `RetentionDays` and hardcoded `Level: "INFO"` instead of respecting `cfg.LogLevel`
- Extracted `resolveInstallCAPath(cfg *config.Config, configPath string) (string, error)` that replaces the silent skip-of-init when `cfg.Certificate == nil` with a clear `fmt.Errorf` pointing the operator to the missing config key

## Test plan

- [ ] `TestBuildLoggingConfigFieldsComplete` — all required fields populated for `LogLevel="debug"` with file provider
- [ ] `TestRunInstallLoggingConfigMatchesRunController` — both call sites produce identical field values for same config input
- [ ] `TestResolveInstallCAPathNilCertificateErrors` — returns error with actionable message when `cfg.Certificate == nil`
- [ ] `TestResolveInstallCAPathWithCertificate` — returns CA path without error when certificate config is present
- [ ] `go build ./cmd/controller/...` passes
- [ ] `go test ./cmd/controller/...` all pass

## Specialist review results

- **QA Test Runner**: PASS — all quality validation gates passed
- **QA Code Reviewer**: PASS — no blocking issues; 2 minor warnings (both pre-existing, out of scope)
- **Security Engineer**: PASS — no blocking issues; change strengthens fail-closed behavior (nil cert now errors instead of silently skipping init)

Fixes #792

🤖 Generated with [Claude Code](https://claude.com/claude-code)