### PR TITLE
steward: remove dead --log-level/--log-provider flags and lib/pq from binary (Issue #810)

### DIFF
--- a/cmd/steward/libpq_integration_test.go
+++ b/cmd/steward/libpq_integration_test.go
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+
+//go:build integration
+
+package main
+
+import (
+	"bytes"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestBinaryExcludesLibPQ verifies that github.com/lib/pq is not in the steward
+// binary's transitive dependency graph. The PostgreSQL driver must not be linked
+// into the endpoint binary — it belongs only in cmd/controller.
+func TestBinaryExcludesLibPQ(t *testing.T) {
+	// Locate the repository root (two directories up from cmd/steward).
+	_, filename, _, ok := runtime.Caller(0)
+	require.True(t, ok, "runtime.Caller failed")
+	repoRoot := filepath.Join(filepath.Dir(filename), "..", "..")
+
+	cmd := exec.Command("go", "list", "-f", `{{join .Deps "\n"}}`, "./cmd/steward/")
+	cmd.Dir = repoRoot
+
+	var out bytes.Buffer
+	var errOut bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errOut
+
+	err := cmd.Run()
+	require.NoError(t, err, "go list failed: %s", errOut.String())
+
+	deps := out.String()
+	assert.False(t, strings.Contains(deps, "github.com/lib/pq"),
+		"steward binary must not depend on github.com/lib/pq (PostgreSQL driver belongs in controller only)\nfull dep list:\n%s", deps)
+}

--- a/cmd/steward/main.go
+++ b/cmd/steward/main.go
@@ -24,10 +24,6 @@ import (
 
 	// Import logging providers to register them
 	_ "github.com/cfgis/cfgms/pkg/logging/providers/file"
-	_ "github.com/cfgis/cfgms/pkg/logging/providers/timescale"
-
-	// Import storage providers to register them
-	_ "github.com/cfgis/cfgms/pkg/storage/providers/database"
 
 	// Import secrets providers to register them
 	_ "github.com/cfgis/cfgms/pkg/secrets/providers/steward"
@@ -55,11 +51,9 @@ func main() {
 // buildRootCommand constructs the cobra command tree for cfgms-steward.
 func buildRootCommand() *cobra.Command {
 	var (
-		configPath  string
-		opMode      string
-		logLevel    string
-		logProvider string
-		regToken    string
+		configPath string
+		opMode     string
+		regToken   string
 	)
 
 	root := &cobra.Command{
@@ -77,15 +71,13 @@ Entry paths:
 		// SilenceUsage prevents cobra printing usage on every error.
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runRootCommand(cmd, regToken, configPath, opMode, logLevel, logProvider)
+			return runRootCommand(cmd, regToken, configPath, opMode)
 		},
 	}
 
 	// Flags used by the root command (foreground run mode).
 	root.Flags().StringVar(&configPath, "config", "", "Path to configuration file (enables standalone mode)")
 	root.Flags().StringVar(&opMode, "mode", "", "Operation mode: 'standalone' or 'controller'")
-	root.Flags().StringVar(&logLevel, "log-level", "info", "Log level: debug, info, warn, error")
-	root.Flags().StringVar(&logProvider, "log-provider", "file", "Logging provider: file, timescale")
 	root.Flags().StringVar(&regToken, "regtoken", "", "Registration token for controller registration")
 
 	// Subcommands.
@@ -100,10 +92,10 @@ Entry paths:
 
 // runRootCommand implements the default (foreground) run behaviour.
 // When no meaningful flags are provided it enters interactive mode.
-func runRootCommand(cmd *cobra.Command, regToken, configPath, opMode, logLevel, logProvider string) error {
+func runRootCommand(cmd *cobra.Command, regToken, configPath, opMode string) error {
 	// Interactive mode: no flags set and no subcommand selected.
 	noFlags := regToken == "" && configPath == "" && opMode == ""
-	if noFlags && !cmd.Flags().Changed("log-level") && !cmd.Flags().Changed("log-provider") {
+	if noFlags {
 		return runInteractive()
 	}
 
@@ -117,17 +109,23 @@ func runRootCommand(cmd *cobra.Command, regToken, configPath, opMode, logLevel, 
 		cancel()
 	}()
 
-	return runSteward(ctx, regToken, configPath, opMode, logLevel, logProvider)
+	return runSteward(ctx, regToken, configPath, opMode)
 }
 
 // runSteward starts the steward with the given configuration and blocks until
 // ctx is cancelled. It is called from both the root cobra command and the
 // Windows service handler.
-func runSteward(ctx context.Context, regToken, configPath, opMode, logLevel, logProvider string) error {
-	// Initialize global logging provider
+func runSteward(ctx context.Context, regToken, configPath, opMode string) error {
+	// Initialize global logging provider. File is the only supported provider
+	// for the steward binary. Log level is read from CFGMS_LOG_LEVEL (default INFO).
+	logDir := os.Getenv("CFGMS_LOG_DIR")
+	if logDir == "" {
+		logDir = "/tmp/cfgms"
+		log.Printf("WARNING: Using /tmp/cfgms for logs — set CFGMS_LOG_DIR for production deployments")
+	}
 	loggingConfig := &logging.LoggingConfig{
-		Provider:          logProvider,
-		Level:             strings.ToUpper(logLevel),
+		Provider:          "file",
+		Level:             logLevelFromEnv(),
 		ServiceName:       "steward",
 		Component:         "main",
 		TenantIsolation:   true,
@@ -137,16 +135,9 @@ func runSteward(ctx context.Context, regToken, configPath, opMode, logLevel, log
 		BatchSize:         100,
 		FlushInterval:     5 * time.Second,
 		RetentionDays:     30,
-		Config:            make(map[string]interface{}),
-	}
-
-	if logProvider == "file" {
-		logDir := os.Getenv("CFGMS_LOG_DIR")
-		if logDir == "" {
-			logDir = "/tmp/cfgms"
-			log.Printf("WARNING: Using /tmp/cfgms for logs — set CFGMS_LOG_DIR for production deployments")
-		}
-		loggingConfig.Config["directory"] = logDir
+		Config: map[string]interface{}{
+			"directory": logDir,
+		},
 	}
 
 	if err := logging.InitializeGlobalLogging(loggingConfig); err != nil {
@@ -241,11 +232,7 @@ func runSteward(ctx context.Context, regToken, configPath, opMode, logLevel, log
 
 // buildInstallCommand builds the `cfgms-steward install` subcommand.
 func buildInstallCommand() *cobra.Command {
-	var (
-		regToken    string
-		logLevel    string
-		logProvider string
-	)
+	var regToken string
 
 	cmd := &cobra.Command{
 		Use:   "install",
@@ -261,13 +248,11 @@ Platforms:
 Requires elevated privileges (Administrator on Windows, root on Linux/macOS).
 Install is idempotent: running it again updates the binary and restarts the service.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runInstall(regToken, logLevel, logProvider)
+			return runInstall(regToken)
 		},
 	}
 
 	cmd.Flags().StringVar(&regToken, "regtoken", "", "Registration token (required)")
-	cmd.Flags().StringVar(&logLevel, "log-level", "info", "Log level: debug, info, warn, error")
-	cmd.Flags().StringVar(&logProvider, "log-provider", "file", "Logging provider: file, timescale")
 	_ = cmd.MarkFlagRequired("regtoken")
 
 	return cmd
@@ -307,7 +292,7 @@ func buildStatusCommand() *cobra.Command {
 }
 
 // runInstall performs the install operation for the current platform.
-func runInstall(regToken, logLevel, logProvider string) error {
+func runInstall(regToken string) error {
 	if regToken == "" {
 		return fmt.Errorf("--regtoken is required for install")
 	}
@@ -429,7 +414,7 @@ func runInteractive() error {
 
 	switch choice {
 	case "1":
-		return runInstall(token, "info", "file")
+		return runInstall(token)
 	case "2":
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
@@ -442,12 +427,24 @@ func runInteractive() error {
 		}()
 
 		fmt.Println("Running in foreground. Press Ctrl+C to stop.")
-		return runSteward(ctx, token, "", "", "info", "file")
+		return runSteward(ctx, token, "", "")
 	case "3", "":
 		fmt.Println("Exiting.")
 		return nil
 	default:
 		return fmt.Errorf("invalid choice %q — enter 1, 2, or 3", choice)
+	}
+}
+
+// logLevelFromEnv reads CFGMS_LOG_LEVEL and returns the uppercased level string.
+// Accepts debug, info, warn, error (case-insensitive). Returns "INFO" for empty
+// or unrecognised values.
+func logLevelFromEnv() string {
+	switch strings.ToLower(os.Getenv("CFGMS_LOG_LEVEL")) {
+	case "debug", "info", "warn", "error":
+		return strings.ToUpper(os.Getenv("CFGMS_LOG_LEVEL"))
+	default:
+		return "INFO"
 	}
 }
 

--- a/cmd/steward/main_test.go
+++ b/cmd/steward/main_test.go
@@ -37,18 +37,18 @@ func TestBuildRootCommand(t *testing.T) {
 func TestBuildRootCommandFlags(t *testing.T) {
 	cmd := buildRootCommand()
 
-	for _, name := range []string{"config", "mode", "log-level", "log-provider", "regtoken"} {
+	for _, name := range []string{"config", "mode", "regtoken"} {
 		flag := cmd.Flags().Lookup(name)
 		assert.NotNil(t, flag, "expected flag %q to be registered", name)
 	}
 
-	// Verify defaults.
-	assert.Equal(t, "info", cmd.Flags().Lookup("log-level").DefValue)
-	assert.Equal(t, "file", cmd.Flags().Lookup("log-provider").DefValue)
+	// log-level and log-provider must not be registered as CLI flags.
+	assert.Nil(t, cmd.Flags().Lookup("log-level"), "log-level flag must not be registered")
+	assert.Nil(t, cmd.Flags().Lookup("log-provider"), "log-provider flag must not be registered")
 }
 
 func TestRunInstallRequiresToken(t *testing.T) {
-	err := runInstall("", "info", "file")
+	err := runInstall("")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "--regtoken is required")
 }
@@ -57,7 +57,7 @@ func TestRunInstallRequiresElevation(t *testing.T) {
 	if isElevated() {
 		t.Skip("test requires non-elevated process — running as root")
 	}
-	err := runInstall("tok_test_abc123", "info", "file")
+	err := runInstall("tok_test_abc123")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "elevated privileges")
 }
@@ -106,4 +106,30 @@ func TestControllerURLOrUnknown(t *testing.T) {
 
 	ControllerURL = "https://ctrl.example.com"
 	assert.Equal(t, "https://ctrl.example.com", controllerURLOrUnknown())
+}
+
+func TestLogLevelFromEnv(t *testing.T) {
+	tests := []struct {
+		env      string
+		expected string
+	}{
+		{"", "INFO"},
+		{"invalid", "INFO"},
+		{"info", "INFO"},
+		{"INFO", "INFO"},
+		{"debug", "DEBUG"},
+		{"DEBUG", "DEBUG"},
+		{"warn", "WARN"},
+		{"WARN", "WARN"},
+		{"error", "ERROR"},
+		{"ERROR", "ERROR"},
+		{"verbose", "INFO"},
+	}
+
+	for _, tc := range tests {
+		t.Run("env="+tc.env, func(t *testing.T) {
+			t.Setenv("CFGMS_LOG_LEVEL", tc.env)
+			assert.Equal(t, tc.expected, logLevelFromEnv())
+		})
+	}
 }

--- a/cmd/steward/windows_service.go
+++ b/cmd/steward/windows_service.go
@@ -55,11 +55,9 @@ func (h *stewardServiceHandler) Execute(
 	status <- svc.Status{State: svc.StartPending}
 
 	// Parse the flags directly from os.Args so the service handler can read
-	// --regtoken, --log-level, etc. that were stored in the service definition.
+	// --regtoken etc. that were stored in the service definition.
 	flags := pflag.NewFlagSet("steward-service", pflag.ContinueOnError)
 	regToken := flags.String("regtoken", "", "registration token")
-	logLevel := flags.String("log-level", "info", "log level")
-	logProvider := flags.String("log-provider", "file", "log provider")
 	configPath := flags.String("config", "", "config path")
 	opMode := flags.String("mode", "", "operation mode")
 	// Ignore unknown flags (e.g. subcommand names) so the service can start even
@@ -72,7 +70,7 @@ func (h *stewardServiceHandler) Execute(
 
 	errCh := make(chan error, 1)
 	go func() {
-		errCh <- runSteward(ctx, *regToken, *configPath, *opMode, *logLevel, *logProvider)
+		errCh <- runSteward(ctx, *regToken, *configPath, *opMode)
 	}()
 
 	status <- svc.Status{

--- a/docs/architecture/steward-operating-model.md
+++ b/docs/architecture/steward-operating-model.md
@@ -236,6 +236,14 @@ If the controller connection is lost, the steward continues converging on schedu
 
 The `--regtoken` flag establishes the controller channel — it does not change the steward's fundamental convergence behaviour.
 
+## Logging
+
+The steward writes structured logs using the file logging provider. This is the only supported logging provider for the steward binary — the timescale (database) provider is a controller-only feature.
+
+Log level is controlled by the `CFGMS_LOG_LEVEL` environment variable (default `INFO`). Accepted values are `debug`, `info`, `warn`, and `error` (case-insensitive). Invalid or empty values fall back to `INFO`.
+
+Log directory is controlled by `CFGMS_LOG_DIR` (default `/tmp/cfgms` with a warning; set this for production deployments).
+
 ## Controller-Connected Capabilities
 
 These behaviors require an active controller connection and are not available in standalone mode.

--- a/features/controller/api/handlers_registration_test.go
+++ b/features/controller/api/handlers_registration_test.go
@@ -219,8 +219,8 @@ func TestHandleRegister_ExpiredToken_Returns401(t *testing.T) {
 func TestHandleRegister_StoreError_Returns500(t *testing.T) {
 	storeErr := fmt.Errorf("failed to persist token state: %w", fmt.Errorf("connection refused"))
 	tokenStore := &controlledConsumeStore{
-		Store: newTestRegistrationStore(t),
-		consumeErr:   storeErr,
+		Store:      newTestRegistrationStore(t),
+		consumeErr: storeErr,
 	}
 	server, _ := newHandleRegisterServer(t, tokenStore, nil)
 
@@ -387,8 +387,8 @@ func TestHandleRegister_ConcurrentSingleUseToken_ExactlyOneSucceeds(t *testing.T
 func TestHandleRegister_ErrTokenAlreadyUsed_IsDistinctFrom500(t *testing.T) {
 	// This test uses the sentinel directly to confirm the error distinction matters.
 	tokenStore := &controlledConsumeStore{
-		Store: newTestRegistrationStore(t),
-		consumeErr:   business.ErrTokenAlreadyUsed,
+		Store:      newTestRegistrationStore(t),
+		consumeErr: business.ErrTokenAlreadyUsed,
 	}
 	server, _ := newHandleRegisterServer(t, tokenStore, nil)
 

--- a/features/steward/dna/drift/drift_test.go
+++ b/features/steward/dna/drift/drift_test.go
@@ -4,6 +4,7 @@ package drift
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -26,8 +27,55 @@ func createTestDNA(id string, attributes map[string]string) *commonpb.DNA {
 }
 
 func createTestLogger() logging.Logger {
-	// Return nil logger for tests - will be handled by the code
-	return nil
+	return logging.NewLogger("debug")
+}
+
+// testDNAStorage is a real in-memory DNAStorage implementation for tests.
+// It satisfies the DNAStorage interface without mocking.
+type testDNAStorage struct {
+	current map[string]*DNAStorageRecord
+	history map[string][]*DNAStorageRecord
+}
+
+func newTestDNAStorage() *testDNAStorage {
+	return &testDNAStorage{
+		current: make(map[string]*DNAStorageRecord),
+		history: make(map[string][]*DNAStorageRecord),
+	}
+}
+
+func (s *testDNAStorage) store(deviceID string, dna *commonpb.DNA) {
+	r := &DNAStorageRecord{
+		DeviceID: deviceID,
+		DNA:      dna,
+		StoredAt: time.Now(),
+		Version:  int64(len(s.history[deviceID]) + 1),
+	}
+	s.current[deviceID] = r
+	s.history[deviceID] = append(s.history[deviceID], r)
+}
+
+func (s *testDNAStorage) GetCurrent(_ context.Context, deviceID string) (*DNAStorageRecord, error) {
+	r, ok := s.current[deviceID]
+	if !ok {
+		return nil, fmt.Errorf("no record for device %s", deviceID)
+	}
+	return r, nil
+}
+
+func (s *testDNAStorage) GetHistory(_ context.Context, deviceID string, opts *DNAHistoryQuery) (*DNAHistoryResult, error) {
+	all := s.history[deviceID]
+	var filtered []*DNAStorageRecord
+	for _, r := range all {
+		if (opts.StartTime.IsZero() || !r.StoredAt.Before(opts.StartTime)) &&
+			(opts.EndTime.IsZero() || !r.StoredAt.After(opts.EndTime)) {
+			filtered = append(filtered, r)
+		}
+	}
+	if opts.Limit > 0 && len(filtered) > opts.Limit {
+		filtered = filtered[:opts.Limit]
+	}
+	return &DNAHistoryResult{Records: filtered}, nil
 }
 
 // Detector Tests
@@ -602,55 +650,52 @@ func TestRuleEngine_TestRule(t *testing.T) {
 
 func TestMonitor_AddRemoveDevice(t *testing.T) {
 	config := DefaultMonitorConfig()
-	detector, _ := NewDetector(DefaultDetectorConfig(), createTestLogger())
-	// Note: In real implementation, would need actual storage.Manager
-	// For testing, would use mock
-	monitor := &monitor{
-		logger:           createTestLogger(),
-		config:           config,
-		detector:         detector,
-		monitoredDevices: make(map[string]*DeviceMonitorInfo),
-		stats:            &MonitorStats{},
-	}
+	detector, err := NewDetector(DefaultDetectorConfig(), createTestLogger())
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = detector.Close() })
 
-	// Add device
-	err := monitor.AddDevice("device1")
+	mon, err := NewMonitor(config, detector, newTestDNAStorage(), createTestLogger())
 	require.NoError(t, err)
 
-	devices := monitor.GetMonitoredDevices()
+	// Add device
+	err = mon.AddDevice("device1")
+	require.NoError(t, err)
+
+	devices := mon.GetMonitoredDevices()
 	assert.Contains(t, devices, "device1")
 
 	// Remove device
-	err = monitor.RemoveDevice("device1")
+	err = mon.RemoveDevice("device1")
 	require.NoError(t, err)
 
-	devices = monitor.GetMonitoredDevices()
+	devices = mon.GetMonitoredDevices()
 	assert.NotContains(t, devices, "device1")
 }
 
 func TestMonitor_SetInterval(t *testing.T) {
 	config := DefaultMonitorConfig()
-	monitor := &monitor{
-		logger:       createTestLogger(),
-		config:       config,
-		scanInterval: config.DefaultScanInterval,
-		stats:        &MonitorStats{},
-	}
+	detector, err := NewDetector(DefaultDetectorConfig(), createTestLogger())
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = detector.Close() })
+
+	mon, err := NewMonitor(config, detector, newTestDNAStorage(), createTestLogger())
+	require.NoError(t, err)
 
 	// Set valid interval
 	newInterval := 2 * time.Minute
-	monitor.SetInterval(newInterval)
-	assert.Equal(t, newInterval, monitor.scanInterval)
+	mon.SetInterval(newInterval)
+	m := mon.(*monitor)
+	assert.Equal(t, newInterval, m.scanInterval)
 
 	// Set interval too small (should be clamped to minimum)
 	tooSmall := 30 * time.Second
-	monitor.SetInterval(tooSmall)
-	assert.Equal(t, config.MinScanInterval, monitor.scanInterval)
+	mon.SetInterval(tooSmall)
+	assert.Equal(t, config.MinScanInterval, m.scanInterval)
 
 	// Set interval too large (should be clamped to maximum)
 	tooLarge := 2 * time.Hour
-	monitor.SetInterval(tooLarge)
-	assert.Equal(t, config.MaxScanInterval, monitor.scanInterval)
+	mon.SetInterval(tooLarge)
+	assert.Equal(t, config.MaxScanInterval, m.scanInterval)
 }
 
 // Configuration Tests
@@ -838,4 +883,113 @@ func BenchmarkFilter_FilterEvents(b *testing.B) {
 			b.Fatal(err)
 		}
 	}
+}
+
+// Constructor error path tests
+
+func TestNewMonitor_NilDetectorReturnsError(t *testing.T) {
+	_, err := NewMonitor(DefaultMonitorConfig(), nil, newTestDNAStorage(), createTestLogger())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "detector is required")
+}
+
+func TestNewMonitor_NilStorageReturnsError(t *testing.T) {
+	detector, err := NewDetector(DefaultDetectorConfig(), createTestLogger())
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = detector.Close() })
+
+	_, err = NewMonitor(DefaultMonitorConfig(), detector, nil, createTestLogger())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "storage manager is required")
+}
+
+func TestNewMonitor_ValidParameters(t *testing.T) {
+	detector, err := NewDetector(DefaultDetectorConfig(), createTestLogger())
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = detector.Close() })
+
+	mon, err := NewMonitor(DefaultMonitorConfig(), detector, newTestDNAStorage(), createTestLogger())
+	require.NoError(t, err)
+	assert.NotNil(t, mon)
+}
+
+func TestNewEventMonitor_NilDetectorReturnsError(t *testing.T) {
+	_, err := NewEventMonitor(DefaultEventMonitorConfig(), nil, newTestDNAStorage(), createTestLogger())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "detector is required")
+}
+
+func TestNewEventMonitor_NilStorageReturnsError(t *testing.T) {
+	detector, err := NewDetector(DefaultDetectorConfig(), createTestLogger())
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = detector.Close() })
+
+	_, err = NewEventMonitor(DefaultEventMonitorConfig(), detector, nil, createTestLogger())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "storage manager is required")
+}
+
+func TestNewEventMonitor_ValidParameters(t *testing.T) {
+	detector, err := NewDetector(DefaultDetectorConfig(), createTestLogger())
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = detector.Close() })
+
+	mon, err := NewEventMonitor(DefaultEventMonitorConfig(), detector, newTestDNAStorage(), createTestLogger())
+	require.NoError(t, err)
+	assert.NotNil(t, mon)
+}
+
+func TestNewDNADriftIntegrator_NilStorageReturnsError(t *testing.T) {
+	service, err := NewDriftService(DefaultDetectorConfig(), nil, nil, DefaultMonitorConfig(), createTestLogger())
+	require.NoError(t, err)
+
+	_, err = NewDNADriftIntegrator(nil, service, DefaultIntegrationConfig(), createTestLogger())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "storage manager is required")
+}
+
+func TestNewDNADriftIntegrator_NilServiceReturnsError(t *testing.T) {
+	_, err := NewDNADriftIntegrator(newTestDNAStorage(), nil, DefaultIntegrationConfig(), createTestLogger())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "drift service is required")
+}
+
+func TestNewDNADriftIntegrator_DefaultConfig(t *testing.T) {
+	service, err := NewDriftService(DefaultDetectorConfig(), nil, nil, DefaultMonitorConfig(), createTestLogger())
+	require.NoError(t, err)
+
+	integrator, err := NewDNADriftIntegrator(newTestDNAStorage(), service, nil, createTestLogger())
+	require.NoError(t, err)
+	assert.NotNil(t, integrator)
+}
+
+// testDNAStorage contract tests
+
+func TestTestDNAStorage_GetCurrentReturnsErrorForUnknownDevice(t *testing.T) {
+	store := newTestDNAStorage()
+	_, err := store.GetCurrent(context.Background(), "unknown-device")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no record for device")
+}
+
+func TestTestDNAStorage_GetCurrentReturnsStoredRecord(t *testing.T) {
+	store := newTestDNAStorage()
+	dna := createTestDNA("dev1", map[string]string{"hostname": "srv1"})
+	store.store("dev1", dna)
+
+	rec, err := store.GetCurrent(context.Background(), "dev1")
+	require.NoError(t, err)
+	assert.Equal(t, "dev1", rec.DeviceID)
+	assert.Equal(t, dna, rec.DNA)
+}
+
+func TestTestDNAStorage_GetHistoryReturnsFilteredRecords(t *testing.T) {
+	store := newTestDNAStorage()
+	dna := createTestDNA("dev1", map[string]string{"x": "1"})
+	store.store("dev1", dna)
+	store.store("dev1", dna)
+
+	result, err := store.GetHistory(context.Background(), "dev1", &DNAHistoryQuery{Limit: 1})
+	require.NoError(t, err)
+	assert.Len(t, result.Records, 1)
 }

--- a/features/steward/dna/drift/event_monitor.go
+++ b/features/steward/dna/drift/event_monitor.go
@@ -10,7 +10,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/cfgis/cfgms/features/controller/fleet/storage"
 	"github.com/cfgis/cfgms/features/steward/dna/events"
 	"github.com/cfgis/cfgms/pkg/logging"
 )
@@ -20,7 +19,7 @@ type eventMonitor struct {
 	logger   logging.Logger
 	config   *EventMonitorConfig
 	detector Detector
-	storage  *storage.Manager
+	storage  DNAStorage
 
 	// Event system
 	eventPublisher  events.EventPublisher
@@ -113,7 +112,7 @@ type EventMonitorStats struct {
 }
 
 // NewEventMonitor creates a new event-driven drift monitoring service.
-func NewEventMonitor(config *EventMonitorConfig, detector Detector, storage *storage.Manager, logger logging.Logger) (Monitor, error) {
+func NewEventMonitor(config *EventMonitorConfig, detector Detector, storage DNAStorage, logger logging.Logger) (Monitor, error) {
 	if config == nil {
 		config = DefaultEventMonitorConfig()
 	}

--- a/features/steward/dna/drift/integration.go
+++ b/features/steward/dna/drift/integration.go
@@ -9,13 +9,12 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/cfgis/cfgms/features/controller/fleet/storage"
 	"github.com/cfgis/cfgms/pkg/logging"
 )
 
 // DNADriftIntegrator provides integration between drift detection and DNA storage.
 type DNADriftIntegrator struct {
-	storage      *storage.Manager
+	storage      DNAStorage
 	driftService *DriftService
 	logger       logging.Logger
 	config       *IntegrationConfig
@@ -43,7 +42,7 @@ type IntegrationConfig struct {
 
 // NewDNADriftIntegrator creates a new integrator for DNA storage and drift detection.
 func NewDNADriftIntegrator(
-	storageManager *storage.Manager,
+	storageManager DNAStorage,
 	driftService *DriftService,
 	config *IntegrationConfig,
 	logger logging.Logger,
@@ -163,12 +162,13 @@ func (di *DNADriftIntegrator) DetectDriftForAllDevices(ctx context.Context) (map
 }
 
 // GetDriftHistory retrieves drift events for a device within a time range.
-func (di *DNADriftIntegrator) GetDriftHistory(ctx context.Context, deviceID string, timeRange *storage.TimeRange) ([]*DriftEvent, error) {
+func (di *DNADriftIntegrator) GetDriftHistory(ctx context.Context, deviceID string, timeRange *DNAHistoryQuery) ([]*DriftEvent, error) {
 	// This would typically query a separate drift events storage
 	// For now, we'll reconstruct events from DNA history
 
-	options := &storage.QueryOptions{
-		TimeRange:   timeRange,
+	options := &DNAHistoryQuery{
+		StartTime:   timeRange.StartTime,
+		EndTime:     timeRange.EndTime,
 		IncludeData: true,
 		Limit:       100, // Reasonable limit for drift analysis
 	}
@@ -252,15 +252,13 @@ func (di *DNADriftIntegrator) StartAutoDetection(ctx context.Context) error {
 
 // Private methods
 
-func (di *DNADriftIntegrator) getPreviousDNAForComparison(ctx context.Context, deviceID string) (*storage.DNARecord, error) {
+func (di *DNADriftIntegrator) getPreviousDNAForComparison(ctx context.Context, deviceID string) (*DNAStorageRecord, error) {
 	// Get DNA from the comparison window ago
 	comparisonTime := time.Now().Add(-di.config.ComparisonWindow)
 
-	options := &storage.QueryOptions{
-		TimeRange: &storage.TimeRange{
-			Start: comparisonTime.Add(-time.Minute), // Small window around comparison time
-			End:   comparisonTime.Add(time.Minute),
-		},
+	options := &DNAHistoryQuery{
+		StartTime:   comparisonTime.Add(-time.Minute),
+		EndTime:     comparisonTime.Add(time.Minute),
 		Limit:       1,
 		IncludeData: true,
 	}
@@ -272,10 +270,8 @@ func (di *DNADriftIntegrator) getPreviousDNAForComparison(ctx context.Context, d
 
 	if len(history.Records) == 0 {
 		// Try getting the most recent record before comparison time
-		options.TimeRange = &storage.TimeRange{
-			Start: time.Time{}, // Beginning of time
-			End:   comparisonTime,
-		}
+		options.StartTime = time.Time{}
+		options.EndTime = comparisonTime
 
 		history, err = di.storage.GetHistory(ctx, deviceID, options)
 		if err != nil {

--- a/features/steward/dna/drift/monitor.go
+++ b/features/steward/dna/drift/monitor.go
@@ -8,10 +8,10 @@ import (
 	"context"
 	"fmt"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	commonpb "github.com/cfgis/cfgms/api/proto/common"
-	"github.com/cfgis/cfgms/features/controller/fleet/storage"
 	"github.com/cfgis/cfgms/pkg/logging"
 )
 
@@ -20,7 +20,7 @@ type monitor struct {
 	logger   logging.Logger
 	config   *MonitorConfig
 	detector Detector
-	storage  *storage.Manager
+	storage  DNAStorage
 
 	// Monitoring state
 	running          bool
@@ -131,7 +131,7 @@ const (
 )
 
 // NewMonitor creates a new drift monitoring service.
-func NewMonitor(config *MonitorConfig, detector Detector, storage *storage.Manager, logger logging.Logger) (Monitor, error) {
+func NewMonitor(config *MonitorConfig, detector Detector, storage DNAStorage, logger logging.Logger) (Monitor, error) {
 	if config == nil {
 		config = DefaultMonitorConfig()
 	}
@@ -469,12 +469,12 @@ func (m *monitor) performParallelScan(ctx context.Context, devices []string) int
 
 	semaphore := make(chan struct{}, concurrency)
 	var wg sync.WaitGroup
-	scannedCount := 0
+	var scannedCount atomic.Int64
 
 	for _, deviceID := range devices {
 		select {
 		case <-ctx.Done():
-			return scannedCount
+			return int(scannedCount.Load())
 		case semaphore <- struct{}{}:
 			wg.Add(1)
 			go func(devID string) {
@@ -482,14 +482,14 @@ func (m *monitor) performParallelScan(ctx context.Context, devices []string) int
 				defer func() { <-semaphore }()
 
 				if m.scanDevice(ctx, devID) {
-					scannedCount++
+					scannedCount.Add(1)
 				}
 			}(deviceID)
 		}
 	}
 
 	wg.Wait()
-	return scannedCount
+	return int(scannedCount.Load())
 }
 
 func (m *monitor) performSequentialScan(ctx context.Context, devices []string) int {
@@ -582,11 +582,9 @@ func (m *monitor) getCurrentDNA(ctx context.Context, deviceID string) (*commonpb
 
 func (m *monitor) getPreviousDNA(ctx context.Context, deviceID string) (*commonpb.DNA, error) {
 	// Get DNA from comparison window ago
-	options := &storage.QueryOptions{
-		TimeRange: &storage.TimeRange{
-			Start: time.Now().Add(-m.config.ComparisonWindow),
-			End:   time.Now().Add(-m.config.ComparisonWindow + time.Minute), // Small window
-		},
+	options := &DNAHistoryQuery{
+		StartTime:   time.Now().Add(-m.config.ComparisonWindow),
+		EndTime:     time.Now().Add(-m.config.ComparisonWindow + time.Minute),
 		Limit:       1,
 		IncludeData: true,
 	}

--- a/features/steward/dna/drift/storage.go
+++ b/features/steward/dna/drift/storage.go
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+
+package drift
+
+import (
+	"context"
+	"time"
+
+	commonpb "github.com/cfgis/cfgms/api/proto/common"
+)
+
+// DNAStorage is the minimal storage interface needed by drift monitoring.
+// Callers supply concrete implementations (e.g. fleet/storage.Manager adapter)
+// so this package has no dependency on any specific storage backend.
+type DNAStorage interface {
+	GetCurrent(ctx context.Context, deviceID string) (*DNAStorageRecord, error)
+	GetHistory(ctx context.Context, deviceID string, opts *DNAHistoryQuery) (*DNAHistoryResult, error)
+}
+
+// DNAStorageRecord is a storage-agnostic DNA snapshot.
+type DNAStorageRecord struct {
+	DeviceID string
+	DNA      *commonpb.DNA
+	StoredAt time.Time
+	Version  int64
+}
+
+// DNAHistoryQuery specifies parameters for a historical DNA query.
+type DNAHistoryQuery struct {
+	StartTime   time.Time
+	EndTime     time.Time
+	Limit       int
+	IncludeData bool
+}
+
+// DNAHistoryResult holds a page of historical DNA records.
+type DNAHistoryResult struct {
+	Records []*DNAStorageRecord
+}


### PR DESCRIPTION
## Summary

- Removes dead `--log-level` and `--log-provider` CLI flags from `buildRootCommand`, `buildInstallCommand`, and the Windows service handler; log level now reads `CFGMS_LOG_LEVEL` env var (default `INFO`)
- Deletes blank-imports of `pkg/logging/providers/timescale` and `pkg/storage/providers/database` from `cmd/steward/main.go`
- Fixes root cause of `lib/pq` in the steward binary: `features/steward/dna/drift` was importing `features/controller/fleet/storage` (which blank-imports `lib/pq`); replaced the concrete dependency with a new `DNAStorage` interface defined in the drift package
- Adds `TestBinaryExcludesLibPQ` (`//go:build integration`) as a permanent regression guard
- Fixes data race in `performParallelScan` (`atomic.Int64` replaces unsynchronized `int`)
- Adds constructor error-path tests for `NewMonitor`, `NewEventMonitor`, `NewDNADriftIntegrator`; adds real `testDNAStorage` in-memory implementation for use in tests

## Acceptance Criteria Status

- [x] `cmd/steward/main.go` has no blank-import of `pkg/logging/providers/timescale`
- [x] `cmd/steward/main.go` has no blank-import of `pkg/storage/providers/database`
- [x] `--log-level` and `--log-provider` flags absent from `buildRootCommand` and `buildInstallCommand`
- [x] `runSteward` and `runInstall` signatures do not accept `logLevel` or `logProvider` parameters
- [x] `cmd/steward/windows_service.go` declares neither `logLevel` nor `logProvider` pflag variables
- [x] `TestBinaryExcludesLibPQ` integration test passes
- [x] `TestBuildRootCommandFlags` updated — no assertions on log-level or log-provider
- [x] Log level reads `CFGMS_LOG_LEVEL` env var (fallback INFO)
- [x] Tests added/updated for all behavior changes
- [x] Docs updated — `docs/architecture/steward-operating-model.md`

## Specialist Review Results

- **QA Test Runner**: PASS — all quality gates passed; cross-platform build verified; Trivy skipped (no network in container — covered by CI `security-deployment-gate`)
- **QA Code Reviewer**: PASS — 0 blocking issues; resolved: nil storage/mock-comment bypass, data race, missing constructor tests
- **Security Engineer**: PASS — no hardcoded secrets, no injection vectors, no central provider violations; `logLevelFromEnv()` uses allowlist, `lib/pq` confirmed absent from steward dep graph

## Test Plan

- [ ] `go test ./cmd/steward/ -race` — all unit tests pass
- [ ] `go test -tags integration ./cmd/steward/ -run TestBinaryExcludesLibPQ` — lib/pq absent
- [ ] `go test ./features/steward/dna/drift/ -race` — all drift tests pass including new constructor tests
- [ ] CI required checks: unit-tests, integration-tests, Build Gate, security-deployment-gate

🤖 Generated with [Claude Code](https://claude.ai/claude-code)