### PR TITLE
controlplane: enforce mTLS CN on Register RPC (Issue #827)

### DIFF
--- a/pkg/controlplane/providers/grpc/provider.go
+++ b/pkg/controlplane/providers/grpc/provider.go
@@ -22,6 +22,7 @@ import (
 	transportpb "github.com/cfgis/cfgms/api/proto/transport"
 	"github.com/cfgis/cfgms/pkg/controlplane/interfaces"
 	"github.com/cfgis/cfgms/pkg/controlplane/types"
+	"github.com/cfgis/cfgms/pkg/logging"
 	quictransport "github.com/cfgis/cfgms/pkg/transport/quic"
 	"github.com/cfgis/cfgms/pkg/transport/registry"
 	quicgo "github.com/quic-go/quic-go"
@@ -994,13 +995,26 @@ type transportServer struct {
 	provider *Provider
 }
 
+// Register handles steward registration. The authenticated peer CN from the mTLS
+// handshake is the authoritative steward identity. If the request carries a non-empty
+// ClientId it must exactly match the peer CN; a mismatched ClientId returns
+// PermissionDenied. An empty ClientId is accepted and the steward ID is derived
+// from the cert CN. Missing or invalid peer TLS info returns Unauthenticated.
 func (s *transportServer) Register(ctx context.Context, req *controllerpb.RegisterRequest) (*controllerpb.RegisterResponse, error) {
-	// Extract steward identity from the request
-	stewardID := req.GetCredentials().GetClientId()
-	if stewardID == "" {
-		return nil, status.Error(codes.InvalidArgument, "client_id is required in credentials")
+	cnStewardID, err := extractStewardIDFromPeer(ctx)
+	if err != nil {
+		return nil, status.Errorf(codes.Unauthenticated, "failed to extract steward identity from peer certificate: %v", err)
 	}
 
+	reqStewardID := req.GetCredentials().GetClientId()
+	if reqStewardID != "" && reqStewardID != cnStewardID {
+		s.provider.logger.Warn("steward ID mismatch: client_id does not match peer CN",
+			"req_steward_id", logging.SanitizeLogValue(reqStewardID),
+			"cn_steward_id", logging.SanitizeLogValue(cnStewardID))
+		return nil, status.Errorf(codes.PermissionDenied, "client_id %q does not match authenticated peer CN %q", reqStewardID, cnStewardID)
+	}
+
+	stewardID := cnStewardID
 	s.provider.logger.Info("steward registered", "steward_id", stewardID, "version", req.GetVersion())
 
 	return &controllerpb.RegisterResponse{

--- a/pkg/controlplane/providers/grpc/provider_register_identity_test.go
+++ b/pkg/controlplane/providers/grpc/provider_register_identity_test.go
@@ -1,0 +1,149 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+
+package grpc
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"testing"
+
+	commonpb "github.com/cfgis/cfgms/api/proto/common"
+	controllerpb "github.com/cfgis/cfgms/api/proto/controller"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/peer"
+	"google.golang.org/grpc/status"
+)
+
+// newPeerCtxWithCN creates a context with peer info containing a real TLS certificate
+// with the given CN, signed by the provided test CA.
+func newPeerCtxWithCN(t *testing.T, tc *testCA, cn string) context.Context {
+	t.Helper()
+	clientTLS := tc.clientTLSConfig(t, cn)
+
+	cert, err := x509.ParseCertificate(clientTLS.Certificates[0].Certificate[0])
+	require.NoError(t, err)
+
+	tlsState := tls.ConnectionState{
+		PeerCertificates: []*x509.Certificate{cert},
+	}
+	p := &peer.Peer{
+		AuthInfo: credentials.TLSInfo{State: tlsState},
+	}
+	return peer.NewContext(context.Background(), p)
+}
+
+func TestRegister_MatchingCNAndClientId_Succeeds(t *testing.T) {
+	tc := newTestCA(t)
+	ctx := newPeerCtxWithCN(t, tc, "steward-match")
+
+	s := &transportServer{provider: New(ModeServer)}
+
+	resp, err := s.Register(ctx, &controllerpb.RegisterRequest{
+		Version: "v0.1.0",
+		Credentials: &commonpb.Credentials{
+			ClientId: "steward-match",
+		},
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, "steward-match", resp.GetStewardId())
+	assert.Equal(t, commonpb.Status_OK, resp.GetStatus().GetCode())
+}
+
+func TestRegister_MismatchedCNAndClientId_ReturnsPermissionDenied(t *testing.T) {
+	tc := newTestCA(t)
+	ctx := newPeerCtxWithCN(t, tc, "steward-real")
+
+	s := &transportServer{provider: New(ModeServer)}
+
+	_, err := s.Register(ctx, &controllerpb.RegisterRequest{
+		Version: "v0.1.0",
+		Credentials: &commonpb.Credentials{
+			ClientId: "steward-imposter",
+		},
+	})
+
+	require.Error(t, err)
+	assert.Equal(t, codes.PermissionDenied, status.Code(err))
+}
+
+func TestRegister_EmptyClientId_DerivesFromCN_Succeeds(t *testing.T) {
+	tc := newTestCA(t)
+	ctx := newPeerCtxWithCN(t, tc, "steward-cn-only")
+
+	s := &transportServer{provider: New(ModeServer)}
+
+	resp, err := s.Register(ctx, &controllerpb.RegisterRequest{
+		Version: "v0.1.0",
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, "steward-cn-only", resp.GetStewardId())
+	assert.Equal(t, commonpb.Status_OK, resp.GetStatus().GetCode())
+}
+
+func TestRegister_NoPeerInfo_ReturnsUnauthenticated(t *testing.T) {
+	s := &transportServer{provider: New(ModeServer)}
+
+	_, err := s.Register(context.Background(), &controllerpb.RegisterRequest{
+		Version: "v0.1.0",
+		Credentials: &commonpb.Credentials{
+			ClientId: "any-steward",
+		},
+	})
+
+	require.Error(t, err)
+	assert.Equal(t, codes.Unauthenticated, status.Code(err))
+}
+
+func TestRegister_PeerWithNoCertificates_ReturnsUnauthenticated(t *testing.T) {
+	// Peer context present with TLSInfo but no client certificate presented.
+	tlsState := tls.ConnectionState{} // PeerCertificates is nil/empty
+	p := &peer.Peer{
+		AuthInfo: credentials.TLSInfo{State: tlsState},
+	}
+	ctx := peer.NewContext(context.Background(), p)
+
+	s := &transportServer{provider: New(ModeServer)}
+
+	_, err := s.Register(ctx, &controllerpb.RegisterRequest{
+		Version: "v0.1.0",
+	})
+
+	require.Error(t, err)
+	assert.Equal(t, codes.Unauthenticated, status.Code(err))
+}
+
+func TestRegister_PeerWithEmptyCN_ReturnsUnauthenticated(t *testing.T) {
+	// Peer context present with a certificate that has an empty Common Name.
+	tc := newTestCA(t)
+	clientTLS := tc.clientTLSConfig(t, "steward-valid")
+
+	cert, err := x509.ParseCertificate(clientTLS.Certificates[0].Certificate[0])
+	require.NoError(t, err)
+
+	// Clear the CN to simulate a cert with no CN.
+	cert.Subject.CommonName = ""
+
+	tlsState := tls.ConnectionState{
+		PeerCertificates: []*x509.Certificate{cert},
+	}
+	p := &peer.Peer{
+		AuthInfo: credentials.TLSInfo{State: tlsState},
+	}
+	ctx := peer.NewContext(context.Background(), p)
+
+	s := &transportServer{provider: New(ModeServer)}
+
+	_, err = s.Register(ctx, &controllerpb.RegisterRequest{
+		Version: "v0.1.0",
+	})
+
+	require.Error(t, err)
+	assert.Equal(t, codes.Unauthenticated, status.Code(err))
+}


### PR DESCRIPTION
## Summary

- `transportServer.Register` now treats the authenticated peer CN from the mTLS handshake as the sole authoritative steward identity. A non-empty `ClientId` that does not match the peer CN returns `codes.PermissionDenied`; an empty `ClientId` accepts the CN as the steward ID; missing/invalid peer TLS info returns `codes.Unauthenticated`.
- Added `pkg/logging` import to `provider.go`; mismatch events logged at `Warn` with `logging.SanitizeLogValue()` applied to both IDs.
- 6 new tests in `provider_register_identity_test.go` cover all branches using real mTLS certs (no mocks).

## Client-side call path trace

The only steward code that references `controllerClient.Register()` is at `features/steward/steward.go:726`, which is inside a commented-out block (`/* ... */` wrapping lines ~695–739). `TransportClient` in `features/steward/client/client_transport.go` carries no `Register` method. No live code path currently sends a `RegisterRequest` to the gRPC server. The server-side enforcement cannot break any existing caller, and when the client-side path is eventually wired up it will naturally use the cert CN as the authoritative identity.

## Specialist Review Results

| Reviewer | Result |
|---|---|
| QA Test Runner | PASS — all 6 story tests pass; full package suite passes; Trivy failure is pre-existing environment DNS issue (confirmed out-of-scope) |
| QA Code Reviewer | PASS — after adding two additional error-path tests for empty PeerCertificates and empty CN branches |
| Security Engineer | PASS — no blocking issues, architecture clean, `logging.SanitizeLogValue()` correctly applied |

## Test plan

- [ ] `go test ./pkg/controlplane/providers/grpc/... -run TestRegister -v` — all 6 identity tests pass
- [ ] `go test ./pkg/controlplane/providers/grpc/...` — full package suite passes
- [ ] Verify `codes.PermissionDenied` on mismatched `ClientId` via test `TestRegister_MismatchedCNAndClientId_ReturnsPermissionDenied`
- [ ] Verify `codes.Unauthenticated` on missing peer info via three Unauthenticated tests

Fixes #827

🤖 Generated with [Claude Code](https://claude.com/claude-code)