### PR TITLE
api: fix generateRequestID to produce unique IDs; delete auditToRBACManager (Issue #783)

### DIFF
--- a/features/controller/api/middleware.go
+++ b/features/controller/api/middleware.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/gorilla/mux"
 
 	"github.com/cfgis/cfgms/features/controller/ctxkeys"
@@ -387,7 +388,7 @@ func (s *Server) buildPermissionID(resourceType, action string) string {
 
 // generateRequestID generates a unique request ID for tracing
 func (s *Server) generateRequestID() string {
-	return time.Now().Format("20060102150405.999999999")
+	return uuid.New().String()
 }
 
 // writeAuthorizationError writes an authorization error response with decision metadata
@@ -445,10 +446,6 @@ func (s *Server) auditAuthorizationDecision(r *http.Request, decision *Authoriza
 		s.logger.Warn("Authorization audit - access denied", auditFields)
 	}
 
-	// If RBAC manager supports audit trail, also log there
-	if s.rbacManager != nil {
-		s.auditToRBACManager(decision, r)
-	}
 }
 
 // getRequestID extracts or generates a request ID for audit correlation
@@ -517,15 +514,4 @@ func (s *Server) hasAPIKeyPermission(apiKey *APIKey, permissionID string) bool {
 		"required_permission", permissionID,
 		"available_permissions", apiKey.Permissions)
 	return false
-}
-
-// auditToRBACManager sends audit information to RBAC manager if supported
-func (s *Server) auditToRBACManager(decision *AuthorizationDecision, r *http.Request) {
-	// This would integrate with the RBAC manager's audit trail
-	// For now, we'll just log that we would send it
-	s.logger.Debug("Would audit to RBAC manager",
-		"subject_id", decision.SubjectID,
-		"decision", decision.Decision,
-		"resource", decision.Resource,
-	)
 }

--- a/features/controller/api/middleware_test.go
+++ b/features/controller/api/middleware_test.go
@@ -1,0 +1,112 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+package api
+
+import (
+	"net/http"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGenerateRequestID_UniqueUnderConcurrency(t *testing.T) {
+	server := setupTestServer(t)
+
+	const count = 1000
+	ids := make([]string, count)
+	var wg sync.WaitGroup
+	wg.Add(count)
+
+	for i := 0; i < count; i++ {
+		i := i
+		go func() {
+			defer wg.Done()
+			ids[i] = server.generateRequestID()
+		}()
+	}
+	wg.Wait()
+
+	seen := make(map[string]struct{}, count)
+	for _, id := range ids {
+		require.NotEmpty(t, id)
+		_, duplicate := seen[id]
+		assert.False(t, duplicate, "duplicate request ID: %s", id)
+		seen[id] = struct{}{}
+	}
+	assert.Len(t, seen, count)
+}
+
+func TestGenerateRequestID_UUIDv4Format(t *testing.T) {
+	server := setupTestServer(t)
+	id := server.generateRequestID()
+	// UUID v4 format: xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx (36 chars)
+	require.Len(t, id, 36)
+	assert.Equal(t, '4', rune(id[14]), "UUID version nibble must be 4")
+	assert.Contains(t, "89ab", string(id[19]), "UUID variant nibble must be 8, 9, a, or b")
+}
+
+func TestAuditAuthorizationDecision_DoesNotPanic(t *testing.T) {
+	server := setupTestServer(t)
+
+	req, err := http.NewRequest(http.MethodGet, "/api/v1/stewards", nil)
+	require.NoError(t, err)
+
+	tests := []struct {
+		name     string
+		decision *AuthorizationDecision
+	}{
+		{
+			name: "granted",
+			decision: &AuthorizationDecision{
+				Granted:      true,
+				PermissionID: "steward:read",
+				Resource:     "steward:test-id",
+				Action:       "read",
+				Decision:     "ALLOW",
+				Reason:       "API key has required permission: steward:read",
+				CheckedAt:    time.Now(),
+				SubjectID:    "user-1",
+				TenantID:     "tenant-1",
+			},
+		},
+		{
+			name: "denied",
+			decision: &AuthorizationDecision{
+				Granted:      false,
+				PermissionID: "rbac:admin",
+				Resource:     "rbac:*",
+				Action:       "admin",
+				Decision:     "DENY",
+				Reason:       "API key lacks required permission: rbac:admin",
+				CheckedAt:    time.Now(),
+				SubjectID:    "user-1",
+				TenantID:     "tenant-1",
+			},
+		},
+		{
+			name: "cross-tenant denial produces CRITICAL severity without panic",
+			decision: &AuthorizationDecision{
+				Granted:      false,
+				PermissionID: "steward:read",
+				Resource:     "steward:*",
+				Action:       "read",
+				Decision:     "DENY",
+				Reason:       "Cross-tenant access attempt",
+				CheckedAt:    time.Now(),
+				SubjectID:    "user-1",
+				TenantID:     "tenant-other",
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.NotPanics(t, func() {
+				server.auditAuthorizationDecision(req, tc.decision)
+			})
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- **`generateRequestID`**: replaced `time.Now().Format(...)` with `uuid.New().String()` (UUID v4, crypto/rand-backed) — eliminating collision risk for concurrent requests within the same nanosecond
- **`auditToRBACManager`**: deleted dead stub that only logged `"Would audit to RBAC manager"` without persisting anything; removed its call site in `auditAuthorizationDecision` — the full authorization audit record is still emitted via `s.logger.Info/Warn`
- **`middleware_test.go`** (new): 3 tests covering UUID uniqueness under 1000-goroutine concurrency, UUID v4 format validation, and `auditAuthorizationDecision` behavior across ALLOW/DENY/cross-tenant paths

Fixes #783

## Specialist Review Results

| Reviewer | Result |
|----------|--------|
| QA Test Runner | **PASS** — all packages pass, cross-platform builds pass, lint clean |
| QA Code Reviewer | **PASS** — no mocks, no skips, table-driven tests cover real code branches |
| Security Engineer | **PASS** — UUID v4 strengthens unpredictability; no secrets, no central provider violations |

## Test plan

- [x] `go test ./features/controller/api/... -run TestGenerateRequestID` — 1000 concurrent IDs, zero duplicates; UUID v4 format verified
- [x] `go test ./features/controller/api/... -run TestAuditAuthorizationDecision` — ALLOW, DENY, cross-tenant CRITICAL severity path all pass without panic
- [x] `make test-agent-complete` — full quality gate pass (run by QA test runner agent)
- [x] `grep "Would audit to RBAC manager" .` — no matches

🤖 Generated with [Claude Code](https://claude.com/claude-code)