### PR TITLE
controller: collapse api.Server.registeredStewards into ControllerService (Issue #780)

### DIFF
--- a/features/controller/api/handlers_compliance.go
+++ b/features/controller/api/handlers_compliance.go
@@ -109,43 +109,25 @@ func (s *Server) handleGetStewardCompliance(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
-	// Look up steward status from registered stewards
-	s.mu.RLock()
-	registered, exists := s.registeredStewards[stewardID]
-	s.mu.RUnlock()
-
 	// Derive compliance status from steward connection status
 	complianceStatus := "compliant"
 	alertLevel := "info"
 	daysUntilBreach := 0
 	var lastChecked string
 
-	if exists {
-		if registered.LastHeartbeat.IsZero() {
-			lastChecked = registered.RegisteredAt.UTC().Format(time.RFC3339)
-		} else {
-			lastChecked = registered.LastHeartbeat.UTC().Format(time.RFC3339)
-		}
-		switch registered.Status {
-		case "offline":
-			complianceStatus = "critical"
-			alertLevel = "critical"
-		case "unknown":
-			complianceStatus = "warning"
-			alertLevel = "warning"
-		}
-	} else {
-		// Check active stewards via controller service
-		if stewardInfo, found := s.controllerService.GetStewardInfo(stewardID); found {
-			lastChecked = stewardInfo.LastHeartbeat.UTC().Format(time.RFC3339)
-			if stewardInfo.Status != "online" {
-				complianceStatus = "warning"
-				alertLevel = "warning"
-			}
-		} else {
-			http.Error(w, "steward not found", http.StatusNotFound)
-			return
-		}
+	stewardInfo, found := s.controllerService.GetStewardInfo(stewardID)
+	if !found {
+		http.Error(w, "steward not found", http.StatusNotFound)
+		return
+	}
+	lastChecked = stewardInfo.LastHeartbeat.UTC().Format(time.RFC3339)
+	switch stewardInfo.Status {
+	case "offline":
+		complianceStatus = "critical"
+		alertLevel = "critical"
+	case "unknown", "quarantined":
+		complianceStatus = "warning"
+		alertLevel = "warning"
 	}
 
 	response := ComplianceStatusResponse{
@@ -215,38 +197,21 @@ func (s *Server) handleGetStewardComplianceReport(w http.ResponseWriter, r *http
 		return
 	}
 
-	// Look up steward from registered stewards or active controller service
-	s.mu.RLock()
-	registered, exists := s.registeredStewards[stewardID]
-	s.mu.RUnlock()
-
 	complianceStatus := "compliant"
 	reportGeneratedAt := time.Now().UTC().Format(time.RFC3339)
 	lastPatchDate := ""
 
-	if exists {
-		if registered.LastHeartbeat.IsZero() {
-			lastPatchDate = registered.RegisteredAt.UTC().Format(time.RFC3339)
-		} else {
-			lastPatchDate = registered.LastHeartbeat.UTC().Format(time.RFC3339)
-		}
-		switch registered.Status {
-		case "offline":
-			complianceStatus = "critical"
-		case "unknown":
-			complianceStatus = "warning"
-		}
-	} else {
-		// Check active stewards via controller service
-		if stewardInfo, found := s.controllerService.GetStewardInfo(stewardID); found {
-			lastPatchDate = stewardInfo.LastHeartbeat.UTC().Format(time.RFC3339)
-			if stewardInfo.Status != "online" {
-				complianceStatus = "warning"
-			}
-		} else {
-			http.Error(w, "steward not found", http.StatusNotFound)
-			return
-		}
+	stewardInfo, found := s.controllerService.GetStewardInfo(stewardID)
+	if !found {
+		http.Error(w, "steward not found", http.StatusNotFound)
+		return
+	}
+	lastPatchDate = stewardInfo.LastHeartbeat.UTC().Format(time.RFC3339)
+	switch stewardInfo.Status {
+	case "offline":
+		complianceStatus = "critical"
+	case "unknown", "quarantined":
+		complianceStatus = "warning"
 	}
 
 	// Return real steward data; patch details require patch module integration
@@ -311,10 +276,9 @@ func (s *Server) handleGetComplianceSummary(w http.ResponseWriter, r *http.Reque
 	// Get optional tenant_id filter from query params
 	tenantID := r.URL.Query().Get("tenant_id")
 
-	// Build compliance summary from registered stewards
-	s.mu.RLock()
+	// Build compliance summary from the single authoritative steward registry
 	tenantStats := make(map[string]*TenantComplianceStatus)
-	for stewardID, st := range s.registeredStewards {
+	for _, st := range s.controllerService.GetAllStewards() {
 		if tenantID != "" && st.TenantID != tenantID {
 			continue
 		}
@@ -335,9 +299,7 @@ func (s *Server) handleGetComplianceSummary(w http.ResponseWriter, r *http.Reque
 		default:
 			tcs.WarningDevices++
 		}
-		_ = stewardID // used as map key above
 	}
-	s.mu.RUnlock()
 
 	// Aggregate totals
 	totalDevices := 0

--- a/features/controller/api/handlers_compliance_test.go
+++ b/features/controller/api/handlers_compliance_test.go
@@ -7,7 +7,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -26,20 +25,11 @@ func TestHandleGetStewardCompliance(t *testing.T) {
 		assert.Equal(t, http.StatusNotFound, rec.Code)
 	})
 
-	t.Run("registered steward online returns compliant", func(t *testing.T) {
+	t.Run("online steward returns compliant", func(t *testing.T) {
 		server := setupTestServer(t)
 		apiKey := NewTestKey(t, server, []string{"steward:read-compliance"})
 
-		now := time.Now().UTC()
-		server.mu.Lock()
-		server.registeredStewards["steward-1"] = &RegisteredSteward{
-			StewardID:     "steward-1",
-			TenantID:      "tenant-1",
-			RegisteredAt:  now.Add(-1 * time.Hour),
-			LastHeartbeat: now.Add(-10 * time.Second),
-			Status:        "online",
-		}
-		server.mu.Unlock()
+		require.NoError(t, server.controllerService.RegisterSteward("steward-1", "tenant-1", "addr-1", "online"))
 
 		req := httptest.NewRequest("GET", "/api/v1/stewards/steward-1/compliance", nil)
 		req.Header.Set("X-API-Key", apiKey)
@@ -56,20 +46,11 @@ func TestHandleGetStewardCompliance(t *testing.T) {
 		assert.Equal(t, "info", resp.AlertLevel)
 	})
 
-	t.Run("registered steward offline returns critical", func(t *testing.T) {
+	t.Run("offline steward returns critical", func(t *testing.T) {
 		server := setupTestServer(t)
 		apiKey := NewTestKey(t, server, []string{"steward:read-compliance"})
 
-		now := time.Now().UTC()
-		server.mu.Lock()
-		server.registeredStewards["steward-1"] = &RegisteredSteward{
-			StewardID:     "steward-1",
-			TenantID:      "tenant-1",
-			RegisteredAt:  now.Add(-1 * time.Hour),
-			LastHeartbeat: now.Add(-10 * time.Minute),
-			Status:        "offline",
-		}
-		server.mu.Unlock()
+		require.NoError(t, server.controllerService.RegisterSteward("steward-1", "tenant-1", "addr-1", "offline"))
 
 		req := httptest.NewRequest("GET", "/api/v1/stewards/steward-1/compliance", nil)
 		req.Header.Set("X-API-Key", apiKey)
@@ -85,20 +66,11 @@ func TestHandleGetStewardCompliance(t *testing.T) {
 		assert.Equal(t, "critical", resp.AlertLevel)
 	})
 
-	t.Run("zero LastHeartbeat falls back to RegisteredAt", func(t *testing.T) {
+	t.Run("registered steward returns compliant with non-zero last_checked", func(t *testing.T) {
 		server := setupTestServer(t)
 		apiKey := NewTestKey(t, server, []string{"steward:read-compliance"})
 
-		registeredAt := time.Date(2026, 3, 15, 10, 0, 0, 0, time.UTC)
-		server.mu.Lock()
-		server.registeredStewards["steward-1"] = &RegisteredSteward{
-			StewardID:    "steward-1",
-			TenantID:     "tenant-1",
-			RegisteredAt: registeredAt,
-			// LastHeartbeat is zero value
-			Status: "online",
-		}
-		server.mu.Unlock()
+		require.NoError(t, server.controllerService.RegisterSteward("steward-1", "tenant-1", "addr-1", "registered"))
 
 		req := httptest.NewRequest("GET", "/api/v1/stewards/steward-1/compliance", nil)
 		req.Header.Set("X-API-Key", apiKey)
@@ -110,7 +82,8 @@ func TestHandleGetStewardCompliance(t *testing.T) {
 		var resp ComplianceStatusResponse
 		err := json.NewDecoder(rec.Body).Decode(&resp)
 		require.NoError(t, err)
-		assert.Equal(t, registeredAt.Format(time.RFC3339), resp.LastChecked)
+		assert.Equal(t, "compliant", resp.Status)
+		assert.NotEmpty(t, resp.LastChecked)
 	})
 }
 
@@ -127,21 +100,11 @@ func TestHandleGetStewardComplianceReport(t *testing.T) {
 		assert.Equal(t, http.StatusNotFound, rec.Code)
 	})
 
-	t.Run("registered steward with heartbeat returns report", func(t *testing.T) {
+	t.Run("online steward returns compliant report", func(t *testing.T) {
 		server := setupTestServer(t)
 		apiKey := NewTestKey(t, server, []string{"steward:read-compliance"})
 
-		now := time.Now().UTC()
-		heartbeat := now.Add(-5 * time.Minute)
-		server.mu.Lock()
-		server.registeredStewards["steward-1"] = &RegisteredSteward{
-			StewardID:     "steward-1",
-			TenantID:      "tenant-1",
-			RegisteredAt:  now.Add(-1 * time.Hour),
-			LastHeartbeat: heartbeat,
-			Status:        "online",
-		}
-		server.mu.Unlock()
+		require.NoError(t, server.controllerService.RegisterSteward("steward-1", "tenant-1", "addr-1", "online"))
 
 		req := httptest.NewRequest("GET", "/api/v1/stewards/steward-1/compliance/report", nil)
 		req.Header.Set("X-API-Key", apiKey)
@@ -155,24 +118,15 @@ func TestHandleGetStewardComplianceReport(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, "steward-1", resp.DeviceID)
 		assert.Equal(t, "compliant", resp.Status)
-		assert.Equal(t, heartbeat.Format(time.RFC3339), resp.LastPatchDate)
+		assert.NotEmpty(t, resp.LastPatchDate)
 		assert.NotEmpty(t, resp.ReportGeneratedAt)
 	})
 
-	t.Run("zero LastHeartbeat falls back to RegisteredAt", func(t *testing.T) {
+	t.Run("registered steward returns non-zero last_patch_date", func(t *testing.T) {
 		server := setupTestServer(t)
 		apiKey := NewTestKey(t, server, []string{"steward:read-compliance"})
 
-		registeredAt := time.Date(2026, 3, 15, 10, 0, 0, 0, time.UTC)
-		server.mu.Lock()
-		server.registeredStewards["steward-1"] = &RegisteredSteward{
-			StewardID:    "steward-1",
-			TenantID:     "tenant-1",
-			RegisteredAt: registeredAt,
-			// LastHeartbeat is zero value
-			Status: "online",
-		}
-		server.mu.Unlock()
+		require.NoError(t, server.controllerService.RegisterSteward("steward-1", "tenant-1", "addr-1", "registered"))
 
 		req := httptest.NewRequest("GET", "/api/v1/stewards/steward-1/compliance/report", nil)
 		req.Header.Set("X-API-Key", apiKey)
@@ -184,23 +138,14 @@ func TestHandleGetStewardComplianceReport(t *testing.T) {
 		var resp ComplianceReportResponse
 		err := json.NewDecoder(rec.Body).Decode(&resp)
 		require.NoError(t, err)
-		assert.Equal(t, registeredAt.Format(time.RFC3339), resp.LastPatchDate)
+		assert.NotEmpty(t, resp.LastPatchDate)
 	})
 
 	t.Run("offline steward returns critical status", func(t *testing.T) {
 		server := setupTestServer(t)
 		apiKey := NewTestKey(t, server, []string{"steward:read-compliance"})
 
-		now := time.Now().UTC()
-		server.mu.Lock()
-		server.registeredStewards["steward-1"] = &RegisteredSteward{
-			StewardID:     "steward-1",
-			TenantID:      "tenant-1",
-			RegisteredAt:  now.Add(-1 * time.Hour),
-			LastHeartbeat: now.Add(-10 * time.Minute),
-			Status:        "offline",
-		}
-		server.mu.Unlock()
+		require.NoError(t, server.controllerService.RegisterSteward("steward-1", "tenant-1", "addr-1", "offline"))
 
 		req := httptest.NewRequest("GET", "/api/v1/stewards/steward-1/compliance/report", nil)
 		req.Header.Set("X-API-Key", apiKey)
@@ -242,25 +187,10 @@ func TestHandleGetComplianceSummary(t *testing.T) {
 		server := setupTestServer(t)
 		apiKey := NewTestKey(t, server, []string{"compliance:read-summary"})
 
-		now := time.Now().UTC()
-		server.mu.Lock()
-		server.registeredStewards["s1"] = &RegisteredSteward{
-			StewardID: "s1", TenantID: "tenant-1", Status: "online",
-			RegisteredAt: now, LastHeartbeat: now,
-		}
-		server.registeredStewards["s2"] = &RegisteredSteward{
-			StewardID: "s2", TenantID: "tenant-1", Status: "offline",
-			RegisteredAt: now, LastHeartbeat: now,
-		}
-		server.registeredStewards["s3"] = &RegisteredSteward{
-			StewardID: "s3", TenantID: "tenant-2", Status: "online",
-			RegisteredAt: now, LastHeartbeat: now,
-		}
-		server.registeredStewards["s4"] = &RegisteredSteward{
-			StewardID: "s4", TenantID: "tenant-2", Status: "unknown",
-			RegisteredAt: now, LastHeartbeat: now,
-		}
-		server.mu.Unlock()
+		require.NoError(t, server.controllerService.RegisterSteward("s1", "tenant-1", "addr-1", "online"))
+		require.NoError(t, server.controllerService.RegisterSteward("s2", "tenant-1", "addr-2", "offline"))
+		require.NoError(t, server.controllerService.RegisterSteward("s3", "tenant-2", "addr-3", "online"))
+		require.NoError(t, server.controllerService.RegisterSteward("s4", "tenant-2", "addr-4", "unknown"))
 
 		req := httptest.NewRequest("GET", "/api/v1/compliance/summary", nil)
 		req.Header.Set("X-API-Key", apiKey)
@@ -283,17 +213,8 @@ func TestHandleGetComplianceSummary(t *testing.T) {
 		server := setupTestServer(t)
 		apiKey := NewTestKey(t, server, []string{"compliance:read-summary"})
 
-		now := time.Now().UTC()
-		server.mu.Lock()
-		server.registeredStewards["s1"] = &RegisteredSteward{
-			StewardID: "s1", TenantID: "tenant-1", Status: "online",
-			RegisteredAt: now, LastHeartbeat: now,
-		}
-		server.registeredStewards["s2"] = &RegisteredSteward{
-			StewardID: "s2", TenantID: "tenant-2", Status: "online",
-			RegisteredAt: now, LastHeartbeat: now,
-		}
-		server.mu.Unlock()
+		require.NoError(t, server.controllerService.RegisterSteward("s1", "tenant-1", "addr-1", "online"))
+		require.NoError(t, server.controllerService.RegisterSteward("s2", "tenant-2", "addr-2", "online"))
 
 		req := httptest.NewRequest("GET", "/api/v1/compliance/summary?tenant_id=tenant-1", nil)
 		req.Header.Set("X-API-Key", apiKey)
@@ -315,13 +236,7 @@ func TestHandleGetComplianceSummary(t *testing.T) {
 		server := setupTestServer(t)
 		apiKey := NewTestKey(t, server, []string{"compliance:read-summary"})
 
-		now := time.Now().UTC()
-		server.mu.Lock()
-		server.registeredStewards["s1"] = &RegisteredSteward{
-			StewardID: "s1", TenantID: "tenant-1", Status: "online",
-			RegisteredAt: now, LastHeartbeat: now,
-		}
-		server.mu.Unlock()
+		require.NoError(t, server.controllerService.RegisterSteward("s1", "tenant-1", "addr-1", "online"))
 
 		req := httptest.NewRequest("GET", "/api/v1/compliance/summary?tenant_id=nonexistent", nil)
 		req.Header.Set("X-API-Key", apiKey)

--- a/features/controller/api/handlers_registration.go
+++ b/features/controller/api/handlers_registration.go
@@ -276,21 +276,18 @@ func (s *Server) handleRegister(w http.ResponseWriter, r *http.Request) {
 		resp.Quarantined = true
 	}
 
-	// Store registered steward in memory for API queries
+	// Register steward in the single authoritative registry
 	initialStatus := "registered" // Initial status before first heartbeat
 	if quarantined {
 		initialStatus = "quarantined"
 	}
-	s.mu.Lock()
-	s.registeredStewards[stewardID] = &RegisteredSteward{
-		StewardID:        stewardID,
-		TenantID:         token.TenantID,
-		Group:            token.Group,
-		RegisteredAt:     time.Now(),
-		Status:           initialStatus,
-		TransportAddress: resp.TransportAddress,
+	// A registry write failure is non-fatal: the steward already has valid certificates and
+	// will re-appear in the registry on its first heartbeat. Blocking the response here would
+	// leave the steward with credentials it cannot use and no way to recover without re-registering.
+	if err := s.controllerService.RegisterSteward(stewardID, token.TenantID, resp.TransportAddress, initialStatus); err != nil {
+		s.logger.Error("Failed to register steward in controller service",
+			"steward_id", stewardID, "error", err)
 	}
-	s.mu.Unlock()
 
 	// Emit success audit event before writing the response
 	successAction := "steward_registered"

--- a/features/controller/api/handlers_stewards.go
+++ b/features/controller/api/handlers_stewards.go
@@ -76,7 +76,6 @@ func (s *Server) handleListStewards(w http.ResponseWriter, r *http.Request) {
 	stewards := s.controllerService.GetAllStewards()
 
 	stewardList := make([]StewardInfo, 0, len(stewards))
-	seenStewards := make(map[string]bool)
 
 	for _, steward := range stewards {
 		info := StewardInfo{
@@ -98,22 +97,7 @@ func (s *Server) handleListStewards(w http.ResponseWriter, r *http.Request) {
 		}
 
 		stewardList = append(stewardList, info)
-		seenStewards[steward.ID] = true
 	}
-
-	s.mu.RLock()
-	for stewardID, registered := range s.registeredStewards {
-		if !seenStewards[stewardID] {
-			info := StewardInfo{
-				ID:          stewardID,
-				Status:      registered.Status,
-				ConnectedAt: registered.RegisteredAt,
-				LastSeen:    registered.LastHeartbeat,
-			}
-			stewardList = append(stewardList, info)
-		}
-	}
-	s.mu.RUnlock()
 
 	s.logger.Info("Listed stewards", "count", len(stewardList))
 	s.writeSuccessResponse(w, stewardList)

--- a/features/controller/api/handlers_stewards_test.go
+++ b/features/controller/api/handlers_stewards_test.go
@@ -309,3 +309,51 @@ func TestHandleListStewards_NoMatch_ReturnsEmptyArray(t *testing.T) {
 	assert.NotNil(t, resp.Data)
 	assert.Empty(t, resp.Data)
 }
+
+// TestHandleListStewards_HTTPRegisteredSteward_AppearsInList verifies that a steward
+// registered via the HTTP path (RegisterSteward on ControllerService) appears in the
+// list response.
+func TestHandleListStewards_HTTPRegisteredSteward_AppearsInList(t *testing.T) {
+	server := setupTestServer(t)
+	apiKey := NewTestKey(t, server, []string{"steward:list"})
+
+	// Simulate HTTP registration writing into the single authoritative registry
+	require.NoError(t, server.controllerService.RegisterSteward("http-steward-1", "test-tenant", "addr-1", "registered"))
+
+	req := httptest.NewRequest("GET", "/api/v1/stewards", nil)
+	req.Header.Set("X-API-Key", apiKey)
+	rec := httptest.NewRecorder()
+	server.router.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	var resp struct {
+		Data []StewardInfo `json:"data"`
+	}
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
+	require.Len(t, resp.Data, 1)
+	assert.Equal(t, "http-steward-1", resp.Data[0].ID)
+	assert.Equal(t, "registered", resp.Data[0].Status)
+}
+
+// TestHandleListStewards_HTTPRegistration_NoDuplicates verifies that registering the same
+// steward ID twice produces exactly one entry in the list.
+func TestHandleListStewards_HTTPRegistration_NoDuplicates(t *testing.T) {
+	server := setupTestServer(t)
+	apiKey := NewTestKey(t, server, []string{"steward:list"})
+
+	require.NoError(t, server.controllerService.RegisterSteward("dup-steward", "test-tenant", "addr-1", "registered"))
+	require.NoError(t, server.controllerService.RegisterSteward("dup-steward", "test-tenant", "addr-2", "quarantined"))
+
+	req := httptest.NewRequest("GET", "/api/v1/stewards", nil)
+	req.Header.Set("X-API-Key", apiKey)
+	rec := httptest.NewRecorder()
+	server.router.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	var resp struct {
+		Data []StewardInfo `json:"data"`
+	}
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
+	assert.Len(t, resp.Data, 1, "duplicate steward ID should produce exactly one entry")
+	assert.Equal(t, "quarantined", resp.Data[0].Status)
+}

--- a/features/controller/api/server.go
+++ b/features/controller/api/server.go
@@ -59,7 +59,6 @@ type Server struct {
 	apiKeys                 map[string]*APIKey             // In-memory cache for fast lookup
 	secretStore             secretsif.SecretStore          // M-AUTH-1: Central secrets provider for API keys
 	registrationTokenStore  registration.Store             // Registration token store for steward registration
-	registeredStewards      map[string]*RegisteredSteward  // In-memory store for registered stewards
 	corsConfig              *CORSConfig                    // CORS configuration
 	signerCertSerial        string                         // Story #378: Serial of cert used for config signing
 	authDefense             *authdefense.AuthDefenseSystem // Story #380: Three-tier auth defense
@@ -81,17 +80,6 @@ type APIKey struct {
 	CreatedAt   time.Time  `json:"created_at"`
 	ExpiresAt   *time.Time `json:"expires_at,omitempty"`
 	TenantID    string     `json:"tenant_id"`
-}
-
-// RegisteredSteward represents a steward that has registered with the controller
-type RegisteredSteward struct {
-	StewardID        string    `json:"steward_id"`
-	TenantID         string    `json:"tenant_id"`
-	Group            string    `json:"group"`
-	RegisteredAt     time.Time `json:"registered_at"`
-	LastHeartbeat    time.Time `json:"last_heartbeat,omitempty"`
-	Status           string    `json:"status"` // online, offline, unknown
-	TransportAddress string    `json:"transport_address,omitempty"`
 }
 
 // ServerConfig contains configuration for the REST API server
@@ -153,12 +141,11 @@ func New(
 		tracer:                  tracer,
 		haManager:               haManager,
 		registrationTokenStore:  registrationTokenStore,
-		signerCertSerial:        signerCertSerial,                    // Story #378: For registration handler
-		apiKeys:                 make(map[string]*APIKey),            // In-memory cache
-		secretStore:             secretStore,                         // M-AUTH-1: Central secrets provider
-		registeredStewards:      make(map[string]*RegisteredSteward), // In-memory steward registry
-		approvalHook:            &DefaultApprovalHook{},              // Issue #422: accept-all default
-		auditManager:            auditManager,                        // Issue #775: registration audit events
+		signerCertSerial:        signerCertSerial,         // Story #378: For registration handler
+		apiKeys:                 make(map[string]*APIKey), // In-memory cache
+		secretStore:             secretStore,              // M-AUTH-1: Central secrets provider
+		approvalHook:            &DefaultApprovalHook{},   // Issue #422: accept-all default
+		auditManager:            auditManager,             // Issue #775: registration audit events
 	}
 
 	// Story #380: Initialize three-tier auth defense system

--- a/features/controller/service/controller_service.go
+++ b/features/controller/service/controller_service.go
@@ -364,6 +364,21 @@ func (s *ControllerService) GetStewardInfo(stewardID string) (*StewardInfo, bool
 	return info, exists
 }
 
+// RegisterSteward records or updates a steward that registered via the HTTP path.
+// It is idempotent: calling it twice with the same stewardID overwrites the entry.
+func (s *ControllerService) RegisterSteward(stewardID, tenantID, transportAddr, status string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.stewards[stewardID] = &StewardInfo{
+		ID:            stewardID,
+		TenantID:      tenantID,
+		LastHeartbeat: time.Now(),
+		Status:        status,
+		Metrics:       make(map[string]string),
+	}
+	return nil
+}
+
 // GetAllStewards returns a list of all registered stewards
 func (s *ControllerService) GetAllStewards() []*StewardInfo {
 	s.mu.RLock()

--- a/features/controller/service/controller_service_test.go
+++ b/features/controller/service/controller_service_test.go
@@ -236,8 +236,6 @@ func TestDNASurvivesControllerRestart(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, commonpb.Status_OK, resp.Code)
 
-	// Wait for async write to complete
-
 	// --- Session 2: new service instance, same storage (simulates restart) ---
 	svc2 := NewControllerServiceWithStorage(logging.NewNoopLogger(), storage)
 	require.NoError(t, svc2.LoadFromStorage(ctx))
@@ -259,4 +257,50 @@ func TestLoadFromStorage_NilStorage(t *testing.T) {
 	// LoadFromStorage with no storage should be a no-op, not a panic
 	err := svc.LoadFromStorage(context.Background())
 	require.NoError(t, err)
+}
+
+func TestRegisterSteward_Idempotent(t *testing.T) {
+	svc := NewControllerService(logging.NewNoopLogger())
+
+	require.NoError(t, svc.RegisterSteward("steward-1", "tenant-a", "addr-1", "registered"))
+
+	// Second call with same ID overwrites (idempotent)
+	require.NoError(t, svc.RegisterSteward("steward-1", "tenant-a", "addr-2", "quarantined"))
+
+	all := svc.GetAllStewards()
+	assert.Len(t, all, 1)
+	assert.Equal(t, "quarantined", all[0].Status)
+}
+
+func TestRegisterSteward_MultipleStewards(t *testing.T) {
+	svc := NewControllerService(logging.NewNoopLogger())
+
+	require.NoError(t, svc.RegisterSteward("steward-1", "tenant-a", "addr-1", "registered"))
+	require.NoError(t, svc.RegisterSteward("steward-2", "tenant-b", "addr-2", "registered"))
+
+	all := svc.GetAllStewards()
+	assert.Len(t, all, 2)
+
+	ids := make(map[string]bool)
+	for _, s := range all {
+		ids[s.ID] = true
+	}
+	assert.True(t, ids["steward-1"])
+	assert.True(t, ids["steward-2"])
+}
+
+func TestRegisterSteward_FieldsPopulated(t *testing.T) {
+	svc := NewControllerService(logging.NewNoopLogger())
+
+	before := time.Now()
+	require.NoError(t, svc.RegisterSteward("steward-1", "tenant-x", "addr-1", "registered"))
+	after := time.Now()
+
+	info, ok := svc.GetStewardInfo("steward-1")
+	require.True(t, ok)
+	assert.Equal(t, "steward-1", info.ID)
+	assert.Equal(t, "tenant-x", info.TenantID)
+	assert.Equal(t, "registered", info.Status)
+	assert.True(t, !info.LastHeartbeat.Before(before))
+	assert.True(t, !info.LastHeartbeat.After(after))
 }


### PR DESCRIPTION
## Summary

- Deletes `api.Server.registeredStewards` map and `RegisteredSteward` type — the HTTP-path-only steward registry that diverged from the gRPC-path registry in `ControllerService`
- Adds `ControllerService.RegisterSteward(stewardID, tenantID, transportAddr, status)` as the single write path for both registration routes
- Removes the `handleListStewards` fallback loop that merged two maps at read time; list handler now reads exclusively from `controllerService.GetAllStewards()`
- Updates compliance handlers to use `GetStewardInfo` / `GetAllStewards` instead of the deleted map

## Test plan

- [x] `TestRegisterSteward_Idempotent` — same ID twice produces one entry
- [x] `TestRegisterSteward_MultipleStewards` — both IDs appear in GetAllStewards
- [x] `TestRegisterSteward_FieldsPopulated` — ID, TenantID, Status, LastHeartbeat set correctly
- [x] `TestHandleListStewards_HTTPRegisteredSteward_AppearsInList` — HTTP-registered steward visible in `GET /api/v1/stewards`
- [x] `TestHandleListStewards_HTTPRegistration_NoDuplicates` — second register overwrites, list returns exactly one entry
- [x] All compliance tests rewritten to use `controllerService.RegisterSteward`
- [x] `grep -rn "registeredStewards\|RegisteredSteward" features/controller/` returns zero results
- [x] `make test-agent-complete` passes

## Specialist Review Results

| Agent | Result |
|-------|--------|
| QA Test Runner | PASS — all unit tests pass, cross-platform builds pass, linting clean |
| QA Code Reviewer | PASS — 0 blocking issues |
| Security Engineer | PASS — 0 blocking issues; gosec/staticcheck/architecture checks clean |

## Dependencies

Per issue spec: must not be merged before #775 (audit events) and #778 (dual-start fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)