### PR TITLE
controlplane: stamp authenticated CN on ControlChannel messages (Issue #828)

### DIFF
--- a/pkg/controlplane/providers/grpc/provider.go
+++ b/pkg/controlplane/providers/grpc/provider.go
@@ -22,6 +22,7 @@ import (
 	transportpb "github.com/cfgis/cfgms/api/proto/transport"
 	"github.com/cfgis/cfgms/pkg/controlplane/interfaces"
 	"github.com/cfgis/cfgms/pkg/controlplane/types"
+	"github.com/cfgis/cfgms/pkg/logging"
 	quictransport "github.com/cfgis/cfgms/pkg/transport/quic"
 	"github.com/cfgis/cfgms/pkg/transport/registry"
 	quicgo "github.com/quic-go/quic-go"
@@ -108,6 +109,7 @@ type Provider struct {
 	responsesReceived  atomic.Int64
 	deliveryFailures   atomic.Int64
 	reconnectAttempts  atomic.Int64
+	identityMismatches atomic.Int64
 
 	// Connection timestamps (protected by mu)
 	lastConnectedAt    time.Time
@@ -880,6 +882,7 @@ func (p *Provider) GetStats(ctx context.Context) (*types.ControlPlaneStats, erro
 		ResponsesSent:      p.responsesSent.Load(),
 		ResponsesReceived:  p.responsesReceived.Load(),
 		DeliveryFailures:   p.deliveryFailures.Load(),
+		IdentityMismatches: p.identityMismatches.Load(),
 		ProviderMetrics:    make(map[string]interface{}),
 	}
 
@@ -1048,7 +1051,10 @@ func (s *transportServer) ControlChannel(stream grpc.BidiStreamingServer[transpo
 
 	s.provider.logger.Info("steward connected to ControlChannel", "steward_id", stewardID, "remote_addr", p.Addr.String())
 
-	// Receive loop: read messages from steward and dispatch
+	// Receive loop: authenticated-CN-wins contract — the mTLS peer CN is the
+	// authoritative steward identity. Empty payload StewardIDs are stamped with
+	// the CN; mismatched payload StewardIDs are rejected and counted without
+	// tearing down the stream (misconfiguration tolerance per Issue #828).
 	for {
 		msg, err := stream.Recv()
 		if err != nil {
@@ -1061,14 +1067,41 @@ func (s *transportServer) ControlChannel(stream grpc.BidiStreamingServer[transpo
 		switch payload := msg.GetPayload().(type) {
 		case *transportpb.ControlMessage_Event:
 			event := eventFromProto(payload.Event)
+			if event.StewardID == "" {
+				event.StewardID = stewardID
+			} else if event.StewardID != stewardID {
+				s.provider.logger.Warn("controlchannel event stewardID mismatch",
+					"authenticated_cn", logging.SanitizeLogValue(stewardID),
+					"payload_steward_id", logging.SanitizeLogValue(event.StewardID))
+				s.provider.identityMismatches.Add(1)
+				continue
+			}
 			s.provider.dispatchEvent(event)
 
 		case *transportpb.ControlMessage_Heartbeat:
 			hb := heartbeatFromProto(payload.Heartbeat)
+			if hb.StewardID == "" {
+				hb.StewardID = stewardID
+			} else if hb.StewardID != stewardID {
+				s.provider.logger.Warn("controlchannel heartbeat stewardID mismatch",
+					"authenticated_cn", logging.SanitizeLogValue(stewardID),
+					"payload_steward_id", logging.SanitizeLogValue(hb.StewardID))
+				s.provider.identityMismatches.Add(1)
+				continue
+			}
 			s.provider.dispatchHeartbeat(hb)
 
 		case *transportpb.ControlMessage_Response:
 			resp := responseFromProto(payload.Response)
+			if resp.StewardID == "" {
+				resp.StewardID = stewardID
+			} else if resp.StewardID != stewardID {
+				s.provider.logger.Warn("controlchannel response stewardID mismatch",
+					"authenticated_cn", logging.SanitizeLogValue(stewardID),
+					"payload_steward_id", logging.SanitizeLogValue(resp.StewardID))
+				s.provider.identityMismatches.Add(1)
+				continue
+			}
 			s.provider.dispatchResponse(resp)
 		}
 	}

--- a/pkg/controlplane/providers/grpc/provider_controlchannel_identity_test.go
+++ b/pkg/controlplane/providers/grpc/provider_controlchannel_identity_test.go
@@ -1,0 +1,503 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+
+package grpc
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/cfgis/cfgms/pkg/controlplane/types"
+	"github.com/cfgis/cfgms/pkg/transport/registry"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newMultiStewardEnv sets up a server and two clients connected with different CNs.
+// clientA uses stewardID "steward-a"; clientB uses stewardID "steward-b".
+type multiStewardEnv struct {
+	server   *Provider
+	clientA  *Provider
+	clientB  *Provider
+	registry registry.Registry
+}
+
+func newMultiStewardEnv(t *testing.T) *multiStewardEnv {
+	t.Helper()
+
+	tc := newTestCA(t)
+	reg := registry.NewRegistry()
+
+	server := New(ModeServer)
+	err := server.Initialize(context.Background(), map[string]interface{}{
+		"mode":       "server",
+		"addr":       "127.0.0.1:0",
+		"tls_config": tc.serverTLSConfig(t),
+		"registry":   reg,
+	})
+	require.NoError(t, err)
+	require.NoError(t, server.Start(context.Background()))
+	t.Cleanup(func() { forceStopServer(server) })
+
+	listenAddr := server.listener.Addr().String()
+
+	clientA := New(ModeClient)
+	err = clientA.Initialize(context.Background(), map[string]interface{}{
+		"mode":       "client",
+		"addr":       listenAddr,
+		"tls_config": tc.clientTLSConfig(t, "steward-a"),
+		"steward_id": "steward-a",
+	})
+	require.NoError(t, err)
+	require.NoError(t, clientA.Start(context.Background()))
+	t.Cleanup(func() { _ = clientA.Stop(context.Background()) })
+
+	clientB := New(ModeClient)
+	err = clientB.Initialize(context.Background(), map[string]interface{}{
+		"mode":       "client",
+		"addr":       listenAddr,
+		"tls_config": tc.clientTLSConfig(t, "steward-b"),
+		"steward_id": "steward-b",
+	})
+	require.NoError(t, err)
+	require.NoError(t, clientB.Start(context.Background()))
+	t.Cleanup(func() { _ = clientB.Stop(context.Background()) })
+
+	// Wait for both stewards to be registered
+	require.Eventually(t, func() bool {
+		return reg.Count() == 2
+	}, 5*time.Second, 10*time.Millisecond, "both stewards should register")
+
+	return &multiStewardEnv{
+		server:   server,
+		clientA:  clientA,
+		clientB:  clientB,
+		registry: reg,
+	}
+}
+
+// TestControlChannel_Event_MatchingStewardID verifies that an Event with a
+// payload StewardID matching the authenticated CN is dispatched normally and
+// does not increment IdentityMismatches.
+func TestControlChannel_Event_MatchingStewardID(t *testing.T) {
+	env := newMultiStewardEnv(t)
+
+	received := make(chan *types.Event, 1)
+	require.NoError(t, env.server.SubscribeEvents(context.Background(), nil, func(_ context.Context, e *types.Event) error {
+		received <- e
+		return nil
+	}))
+
+	event := &types.Event{
+		ID:        "evt-match",
+		Type:      types.EventConfigApplied,
+		StewardID: "steward-a",
+		Timestamp: time.Now().Truncate(time.Microsecond),
+		Severity:  "info",
+	}
+	require.NoError(t, env.clientA.PublishEvent(context.Background(), event))
+
+	select {
+	case got := <-received:
+		assert.Equal(t, "evt-match", got.ID)
+		assert.Equal(t, "steward-a", got.StewardID)
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for matching event")
+	}
+
+	stats, err := env.server.GetStats(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), stats.IdentityMismatches)
+}
+
+// TestControlChannel_Event_EmptyStewardIDGetsCNStamped verifies that an Event
+// with an empty payload StewardID is stamped with the authenticated CN before
+// dispatch, and IdentityMismatches is not incremented.
+func TestControlChannel_Event_EmptyStewardIDGetsCNStamped(t *testing.T) {
+	env := newMultiStewardEnv(t)
+
+	received := make(chan *types.Event, 1)
+	require.NoError(t, env.server.SubscribeEvents(context.Background(), nil, func(_ context.Context, e *types.Event) error {
+		received <- e
+		return nil
+	}))
+
+	event := &types.Event{
+		ID:        "evt-empty-id",
+		Type:      types.EventConfigApplied,
+		StewardID: "", // empty — should be stamped with CN
+		Timestamp: time.Now().Truncate(time.Microsecond),
+		Severity:  "info",
+	}
+	require.NoError(t, env.clientA.PublishEvent(context.Background(), event))
+
+	select {
+	case got := <-received:
+		assert.Equal(t, "evt-empty-id", got.ID)
+		assert.Equal(t, "steward-a", got.StewardID, "empty StewardID should be stamped with CN")
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for stamped event")
+	}
+
+	stats, err := env.server.GetStats(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), stats.IdentityMismatches)
+}
+
+// TestControlChannel_Event_MismatchedStewardID verifies that an Event whose
+// payload StewardID disagrees with the authenticated CN is rejected (not
+// dispatched) and increments IdentityMismatches.
+func TestControlChannel_Event_MismatchedStewardID(t *testing.T) {
+	env := newMultiStewardEnv(t)
+
+	dispatched := make(chan *types.Event, 5)
+	require.NoError(t, env.server.SubscribeEvents(context.Background(), nil, func(_ context.Context, e *types.Event) error {
+		dispatched <- e
+		return nil
+	}))
+
+	// clientA (CN=steward-a) sends event claiming to be steward-b
+	mismatch := &types.Event{
+		ID:        "evt-mismatch",
+		Type:      types.EventConfigApplied,
+		StewardID: "steward-b",
+		Timestamp: time.Now().Truncate(time.Microsecond),
+		Severity:  "info",
+	}
+	require.NoError(t, env.clientA.PublishEvent(context.Background(), mismatch))
+
+	// Mismatched event must not be dispatched
+	require.Never(t, func() bool {
+		return len(dispatched) > 0
+	}, 300*time.Millisecond, 20*time.Millisecond, "mismatched event should not be dispatched")
+
+	// IdentityMismatches must be 1
+	require.Eventually(t, func() bool {
+		stats, err := env.server.GetStats(context.Background())
+		return err == nil && stats.IdentityMismatches == 1
+	}, 3*time.Second, 50*time.Millisecond, "IdentityMismatches should be 1")
+}
+
+// TestControlChannel_Heartbeat_MatchingStewardID verifies that a Heartbeat with
+// a matching payload StewardID is dispatched and does not increment mismatches.
+func TestControlChannel_Heartbeat_MatchingStewardID(t *testing.T) {
+	env := newMultiStewardEnv(t)
+
+	received := make(chan *types.Heartbeat, 1)
+	require.NoError(t, env.server.SubscribeHeartbeats(context.Background(), func(_ context.Context, hb *types.Heartbeat) error {
+		received <- hb
+		return nil
+	}))
+
+	hb := &types.Heartbeat{
+		StewardID: "steward-a",
+		Status:    types.StatusHealthy,
+		Timestamp: time.Now().Truncate(time.Microsecond),
+		Version:   "1.0.0",
+	}
+	require.NoError(t, env.clientA.SendHeartbeat(context.Background(), hb))
+
+	select {
+	case got := <-received:
+		assert.Equal(t, "steward-a", got.StewardID)
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for heartbeat")
+	}
+
+	stats, err := env.server.GetStats(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), stats.IdentityMismatches)
+}
+
+// TestControlChannel_Heartbeat_EmptyStewardIDGetsCNStamped verifies that a
+// Heartbeat with an empty payload StewardID is stamped with the authenticated CN.
+func TestControlChannel_Heartbeat_EmptyStewardIDGetsCNStamped(t *testing.T) {
+	env := newMultiStewardEnv(t)
+
+	received := make(chan *types.Heartbeat, 1)
+	require.NoError(t, env.server.SubscribeHeartbeats(context.Background(), func(_ context.Context, hb *types.Heartbeat) error {
+		received <- hb
+		return nil
+	}))
+
+	hb := &types.Heartbeat{
+		StewardID: "", // empty — should be stamped
+		Status:    types.StatusHealthy,
+		Timestamp: time.Now().Truncate(time.Microsecond),
+		Version:   "1.0.0",
+	}
+	require.NoError(t, env.clientA.SendHeartbeat(context.Background(), hb))
+
+	select {
+	case got := <-received:
+		assert.Equal(t, "steward-a", got.StewardID, "empty StewardID should be stamped with CN")
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for stamped heartbeat")
+	}
+
+	stats, err := env.server.GetStats(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), stats.IdentityMismatches)
+}
+
+// TestControlChannel_Heartbeat_MismatchedStewardID verifies that a Heartbeat
+// whose payload StewardID disagrees with the CN is rejected and counted.
+func TestControlChannel_Heartbeat_MismatchedStewardID(t *testing.T) {
+	env := newMultiStewardEnv(t)
+
+	dispatched := make(chan *types.Heartbeat, 5)
+	require.NoError(t, env.server.SubscribeHeartbeats(context.Background(), func(_ context.Context, hb *types.Heartbeat) error {
+		dispatched <- hb
+		return nil
+	}))
+
+	hb := &types.Heartbeat{
+		StewardID: "steward-b", // CN is steward-a — mismatch
+		Status:    types.StatusHealthy,
+		Timestamp: time.Now().Truncate(time.Microsecond),
+		Version:   "1.0.0",
+	}
+	require.NoError(t, env.clientA.SendHeartbeat(context.Background(), hb))
+
+	require.Never(t, func() bool {
+		return len(dispatched) > 0
+	}, 300*time.Millisecond, 20*time.Millisecond, "mismatched heartbeat should not be dispatched")
+
+	require.Eventually(t, func() bool {
+		stats, err := env.server.GetStats(context.Background())
+		return err == nil && stats.IdentityMismatches == 1
+	}, 3*time.Second, 50*time.Millisecond, "IdentityMismatches should be 1")
+}
+
+// TestControlChannel_Response_MatchingStewardID verifies that a Response with a
+// matching payload StewardID is dispatched normally.
+func TestControlChannel_Response_MatchingStewardID(t *testing.T) {
+	env := newMultiStewardEnv(t)
+
+	// Subscribe to commands and reply so SendResponse is triggered via the
+	// happy path. We validate via WaitForResponse that the response arrived.
+	cmdID := "resp-match-cmd"
+	require.NoError(t, env.clientA.SubscribeCommands(context.Background(), "steward-a", func(ctx context.Context, cmd *types.Command) error {
+		return env.clientA.SendResponse(ctx, &types.Response{
+			CommandID: cmd.ID,
+			StewardID: "steward-a",
+			Success:   true,
+			Timestamp: time.Now(),
+		})
+	}))
+
+	var respErr error
+	gotResp := make(chan struct{})
+	go func() {
+		_, respErr = env.server.WaitForResponse(context.Background(), cmdID, 5*time.Second)
+		close(gotResp)
+	}()
+
+	// Wait for the pending channel to register before sending
+	require.Eventually(t, func() bool {
+		env.server.responseMu.Lock()
+		_, ok := env.server.pendingResponses[cmdID]
+		env.server.responseMu.Unlock()
+		return ok
+	}, 5*time.Second, time.Millisecond)
+
+	require.NoError(t, env.server.SendCommand(context.Background(), &types.Command{
+		ID:        cmdID,
+		Type:      types.CommandSyncConfig,
+		StewardID: "steward-a",
+		Timestamp: time.Now(),
+	}))
+
+	select {
+	case <-gotResp:
+		require.NoError(t, respErr)
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for response")
+	}
+
+	stats, err := env.server.GetStats(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), stats.IdentityMismatches)
+}
+
+// TestControlChannel_Response_EmptyStewardIDGetsCNStamped verifies that a
+// Response with an empty payload StewardID is stamped with the CN.
+func TestControlChannel_Response_EmptyStewardIDGetsCNStamped(t *testing.T) {
+	env := newMultiStewardEnv(t)
+
+	cmdID := "resp-empty-cmd"
+	require.NoError(t, env.clientA.SubscribeCommands(context.Background(), "steward-a", func(ctx context.Context, cmd *types.Command) error {
+		return env.clientA.SendResponse(ctx, &types.Response{
+			CommandID: cmd.ID,
+			StewardID: "", // empty — should be stamped with CN
+			Success:   true,
+			Timestamp: time.Now(),
+		})
+	}))
+
+	var gotResp *types.Response
+	var respErr error
+	done := make(chan struct{})
+	go func() {
+		gotResp, respErr = env.server.WaitForResponse(context.Background(), cmdID, 5*time.Second)
+		close(done)
+	}()
+
+	require.Eventually(t, func() bool {
+		env.server.responseMu.Lock()
+		_, ok := env.server.pendingResponses[cmdID]
+		env.server.responseMu.Unlock()
+		return ok
+	}, 5*time.Second, time.Millisecond)
+
+	require.NoError(t, env.server.SendCommand(context.Background(), &types.Command{
+		ID:        cmdID,
+		Type:      types.CommandSyncConfig,
+		StewardID: "steward-a",
+		Timestamp: time.Now(),
+	}))
+
+	select {
+	case <-done:
+		require.NoError(t, respErr)
+		assert.Equal(t, "steward-a", gotResp.StewardID, "empty StewardID should be stamped with CN")
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for stamped response")
+	}
+
+	stats, err := env.server.GetStats(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), stats.IdentityMismatches)
+}
+
+// TestControlChannel_Response_MismatchedStewardID verifies that a Response whose
+// payload StewardID disagrees with the CN is rejected and counted.
+func TestControlChannel_Response_MismatchedStewardID(t *testing.T) {
+	env := newMultiStewardEnv(t)
+
+	cmdID := "resp-mismatch-cmd"
+	require.NoError(t, env.clientA.SubscribeCommands(context.Background(), "steward-a", func(ctx context.Context, cmd *types.Command) error {
+		return env.clientA.SendResponse(ctx, &types.Response{
+			CommandID: cmd.ID,
+			StewardID: "steward-b", // CN is steward-a — mismatch
+			Success:   true,
+			Timestamp: time.Now(),
+		})
+	}))
+
+	var respErr error
+	done := make(chan struct{})
+	go func() {
+		// Short timeout — response will never arrive because it's rejected
+		_, respErr = env.server.WaitForResponse(context.Background(), cmdID, 500*time.Millisecond)
+		close(done)
+	}()
+
+	require.Eventually(t, func() bool {
+		env.server.responseMu.Lock()
+		_, ok := env.server.pendingResponses[cmdID]
+		env.server.responseMu.Unlock()
+		return ok
+	}, 5*time.Second, time.Millisecond)
+
+	require.NoError(t, env.server.SendCommand(context.Background(), &types.Command{
+		ID:        cmdID,
+		Type:      types.CommandSyncConfig,
+		StewardID: "steward-a",
+		Timestamp: time.Now(),
+	}))
+
+	select {
+	case <-done:
+		// WaitForResponse must time out (response was rejected)
+		require.Error(t, respErr, "WaitForResponse should time out when response is rejected")
+	case <-time.After(5 * time.Second):
+		t.Fatal("WaitForResponse goroutine did not return")
+	}
+
+	require.Eventually(t, func() bool {
+		stats, err := env.server.GetStats(context.Background())
+		return err == nil && stats.IdentityMismatches == 1
+	}, 3*time.Second, 50*time.Millisecond, "IdentityMismatches should be 1")
+}
+
+// TestControlChannel_IdentityMismatches_MultipleRejections verifies that after
+// N mismatches, GetStats returns IdentityMismatches == N (tested for N=1 and N=3).
+func TestControlChannel_IdentityMismatches_MultipleRejections(t *testing.T) {
+	env := newMultiStewardEnv(t)
+
+	dispatched := make(chan *types.Event, 10)
+	require.NoError(t, env.server.SubscribeEvents(context.Background(), nil, func(_ context.Context, e *types.Event) error {
+		dispatched <- e
+		return nil
+	}))
+
+	// Send 3 mismatched events from clientA claiming to be steward-b
+	for i := 0; i < 3; i++ {
+		require.NoError(t, env.clientA.PublishEvent(context.Background(), &types.Event{
+			ID:        "evt-multi-mismatch",
+			Type:      types.EventConfigApplied,
+			StewardID: "steward-b",
+			Timestamp: time.Now().Truncate(time.Microsecond),
+			Severity:  "info",
+		}))
+	}
+
+	// Wait for all 3 to be counted
+	require.Eventually(t, func() bool {
+		stats, err := env.server.GetStats(context.Background())
+		return err == nil && stats.IdentityMismatches == 3
+	}, 5*time.Second, 50*time.Millisecond, "IdentityMismatches should be 3")
+
+	// No mismatched events should have been dispatched
+	assert.Equal(t, 0, len(dispatched), "no mismatched events should be dispatched")
+
+	// Confirm exact value
+	stats, err := env.server.GetStats(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, int64(3), stats.IdentityMismatches)
+}
+
+// TestControlChannel_StreamRemainsOpenAfterMismatch verifies that the stream is
+// not torn down after a single mismatch — a subsequent valid message is dispatched.
+func TestControlChannel_StreamRemainsOpenAfterMismatch(t *testing.T) {
+	env := newMultiStewardEnv(t)
+
+	dispatched := make(chan *types.Event, 5)
+	require.NoError(t, env.server.SubscribeEvents(context.Background(), nil, func(_ context.Context, e *types.Event) error {
+		dispatched <- e
+		return nil
+	}))
+
+	// Send a mismatched event first
+	require.NoError(t, env.clientA.PublishEvent(context.Background(), &types.Event{
+		ID:        "evt-bad",
+		Type:      types.EventConfigApplied,
+		StewardID: "steward-b",
+		Timestamp: time.Now().Truncate(time.Microsecond),
+		Severity:  "warn",
+	}))
+
+	// Wait for the mismatch to be counted before sending the valid event
+	require.Eventually(t, func() bool {
+		stats, err := env.server.GetStats(context.Background())
+		return err == nil && stats.IdentityMismatches == 1
+	}, 3*time.Second, 20*time.Millisecond)
+
+	// Now send a valid event — stream should still be alive
+	require.NoError(t, env.clientA.PublishEvent(context.Background(), &types.Event{
+		ID:        "evt-good",
+		Type:      types.EventConfigApplied,
+		StewardID: "steward-a",
+		Timestamp: time.Now().Truncate(time.Microsecond),
+		Severity:  "info",
+	}))
+
+	select {
+	case got := <-dispatched:
+		assert.Equal(t, "evt-good", got.ID, "valid event should be dispatched after mismatch")
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out — stream should remain open after a single mismatch")
+	}
+}

--- a/pkg/controlplane/providers/grpc/provider_controlchannel_identity_test.go
+++ b/pkg/controlplane/providers/grpc/provider_controlchannel_identity_test.go
@@ -81,6 +81,7 @@ func newMultiStewardEnv(t *testing.T) *multiStewardEnv {
 // payload StewardID matching the authenticated CN is dispatched normally and
 // does not increment IdentityMismatches.
 func TestControlChannel_Event_MatchingStewardID(t *testing.T) {
+	t.Parallel()
 	env := newMultiStewardEnv(t)
 
 	received := make(chan *types.Event, 1)
@@ -115,6 +116,7 @@ func TestControlChannel_Event_MatchingStewardID(t *testing.T) {
 // with an empty payload StewardID is stamped with the authenticated CN before
 // dispatch, and IdentityMismatches is not incremented.
 func TestControlChannel_Event_EmptyStewardIDGetsCNStamped(t *testing.T) {
+	t.Parallel()
 	env := newMultiStewardEnv(t)
 
 	received := make(chan *types.Event, 1)
@@ -149,6 +151,7 @@ func TestControlChannel_Event_EmptyStewardIDGetsCNStamped(t *testing.T) {
 // payload StewardID disagrees with the authenticated CN is rejected (not
 // dispatched) and increments IdentityMismatches.
 func TestControlChannel_Event_MismatchedStewardID(t *testing.T) {
+	t.Parallel()
 	env := newMultiStewardEnv(t)
 
 	dispatched := make(chan *types.Event, 5)
@@ -182,6 +185,7 @@ func TestControlChannel_Event_MismatchedStewardID(t *testing.T) {
 // TestControlChannel_Heartbeat_MatchingStewardID verifies that a Heartbeat with
 // a matching payload StewardID is dispatched and does not increment mismatches.
 func TestControlChannel_Heartbeat_MatchingStewardID(t *testing.T) {
+	t.Parallel()
 	env := newMultiStewardEnv(t)
 
 	received := make(chan *types.Heartbeat, 1)
@@ -213,6 +217,7 @@ func TestControlChannel_Heartbeat_MatchingStewardID(t *testing.T) {
 // TestControlChannel_Heartbeat_EmptyStewardIDGetsCNStamped verifies that a
 // Heartbeat with an empty payload StewardID is stamped with the authenticated CN.
 func TestControlChannel_Heartbeat_EmptyStewardIDGetsCNStamped(t *testing.T) {
+	t.Parallel()
 	env := newMultiStewardEnv(t)
 
 	received := make(chan *types.Heartbeat, 1)
@@ -244,6 +249,7 @@ func TestControlChannel_Heartbeat_EmptyStewardIDGetsCNStamped(t *testing.T) {
 // TestControlChannel_Heartbeat_MismatchedStewardID verifies that a Heartbeat
 // whose payload StewardID disagrees with the CN is rejected and counted.
 func TestControlChannel_Heartbeat_MismatchedStewardID(t *testing.T) {
+	t.Parallel()
 	env := newMultiStewardEnv(t)
 
 	dispatched := make(chan *types.Heartbeat, 5)
@@ -273,6 +279,7 @@ func TestControlChannel_Heartbeat_MismatchedStewardID(t *testing.T) {
 // TestControlChannel_Response_MatchingStewardID verifies that a Response with a
 // matching payload StewardID is dispatched normally.
 func TestControlChannel_Response_MatchingStewardID(t *testing.T) {
+	t.Parallel()
 	env := newMultiStewardEnv(t)
 
 	// Subscribe to commands and reply so SendResponse is triggered via the
@@ -324,6 +331,7 @@ func TestControlChannel_Response_MatchingStewardID(t *testing.T) {
 // TestControlChannel_Response_EmptyStewardIDGetsCNStamped verifies that a
 // Response with an empty payload StewardID is stamped with the CN.
 func TestControlChannel_Response_EmptyStewardIDGetsCNStamped(t *testing.T) {
+	t.Parallel()
 	env := newMultiStewardEnv(t)
 
 	cmdID := "resp-empty-cmd"
@@ -374,6 +382,7 @@ func TestControlChannel_Response_EmptyStewardIDGetsCNStamped(t *testing.T) {
 // TestControlChannel_Response_MismatchedStewardID verifies that a Response whose
 // payload StewardID disagrees with the CN is rejected and counted.
 func TestControlChannel_Response_MismatchedStewardID(t *testing.T) {
+	t.Parallel()
 	env := newMultiStewardEnv(t)
 
 	cmdID := "resp-mismatch-cmd"
@@ -425,6 +434,7 @@ func TestControlChannel_Response_MismatchedStewardID(t *testing.T) {
 // TestControlChannel_IdentityMismatches_MultipleRejections verifies that after
 // N mismatches, GetStats returns IdentityMismatches == N (tested for N=1 and N=3).
 func TestControlChannel_IdentityMismatches_MultipleRejections(t *testing.T) {
+	t.Parallel()
 	env := newMultiStewardEnv(t)
 
 	dispatched := make(chan *types.Event, 10)
@@ -462,6 +472,7 @@ func TestControlChannel_IdentityMismatches_MultipleRejections(t *testing.T) {
 // TestControlChannel_StreamRemainsOpenAfterMismatch verifies that the stream is
 // not torn down after a single mismatch — a subsequent valid message is dispatched.
 func TestControlChannel_StreamRemainsOpenAfterMismatch(t *testing.T) {
+	t.Parallel()
 	env := newMultiStewardEnv(t)
 
 	dispatched := make(chan *types.Event, 5)

--- a/pkg/controlplane/types/stats.go
+++ b/pkg/controlplane/types/stats.go
@@ -44,6 +44,10 @@ type ControlPlaneStats struct {
 	// Message delivery failures
 	DeliveryFailures int64 `json:"delivery_failures"`
 
+	// IdentityMismatches counts ControlChannel messages whose payload StewardID
+	// disagreed with the mTLS-authenticated CN and were rejected without dispatch.
+	IdentityMismatches int64 `json:"identity_mismatches"`
+
 	// Average message latency (if measurable)
 	AvgLatency time.Duration `json:"avg_latency,omitempty"`
 


### PR DESCRIPTION
## Summary

- `ControlChannel` Recv loop now enforces the authenticated-CN-wins contract for all three payload types (Event, Heartbeat, Response): empty StewardIDs are stamped with the mTLS peer CN; mismatched StewardIDs are rejected, logged with sanitized values, and counted without tearing down the stream
- `ControlPlaneStats` gains `IdentityMismatches int64 \`json:"identity_mismatches"\`` populated from a new `identityMismatches atomic.Int64` on the `Provider` struct
- 11 new tests in `provider_controlchannel_identity_test.go` using real mTLS certs (no mocks) cover all empty/match/mismatch cases for all three types, cumulative counter accuracy at N=1 and N=3, and stream-resilience after a mismatch

## Test plan

- [ ] `TestControlChannel_Event_MatchingStewardID` — matching ID dispatches, no mismatch counted
- [ ] `TestControlChannel_Event_EmptyStewardIDGetsCNStamped` — stamped correctly, no mismatch counted
- [ ] `TestControlChannel_Event_MismatchedStewardID` — rejected, `IdentityMismatches == 1`
- [ ] Same coverage for Heartbeat and Response (6 more tests)
- [ ] `TestControlChannel_IdentityMismatches_MultipleRejections` — N=3 exact value asserted
- [ ] `TestControlChannel_StreamRemainsOpenAfterMismatch` — valid message dispatched after prior mismatch
- [ ] All existing tests in `external_server_test.go` and `integration_test.go` still pass

## Specialist review results

- **QA Test Runner**: PASS — 106 packages pass, 0 linting issues, no secrets, no architecture violations (Trivy skipped due to container network restriction; will run in CI)
- **QA Code Reviewer**: PASS — 0 blocking issues, 0 warnings; confirms real mTLS certs, no mocks, all error paths covered
- **Security Engineer**: PASS — 0 blocking issues; confirms log injection sanitization applied, atomic counter is race-free, no information disclosure, no central provider violations

Fixes #828

🤖 Generated with [Claude Code](https://claude.com/claude-code)