### PR TITLE
steward: remove dead --mode flag and opMode parameter chain (Issue #812)

### DIFF
--- a/cmd/steward/main.go
+++ b/cmd/steward/main.go
@@ -52,7 +52,6 @@ func main() {
 func buildRootCommand() *cobra.Command {
 	var (
 		configPath string
-		opMode     string
 		regToken   string
 	)
 
@@ -71,13 +70,12 @@ Entry paths:
 		// SilenceUsage prevents cobra printing usage on every error.
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runRootCommand(cmd, regToken, configPath, opMode)
+			return runRootCommand(cmd, regToken, configPath)
 		},
 	}
 
 	// Flags used by the root command (foreground run mode).
 	root.Flags().StringVar(&configPath, "config", "", "Path to configuration file (enables standalone mode)")
-	root.Flags().StringVar(&opMode, "mode", "", "Operation mode: 'standalone' or 'controller'")
 	root.Flags().StringVar(&regToken, "regtoken", "", "Registration token for controller registration")
 
 	// Subcommands.
@@ -92,9 +90,9 @@ Entry paths:
 
 // runRootCommand implements the default (foreground) run behaviour.
 // When no meaningful flags are provided it enters interactive mode.
-func runRootCommand(cmd *cobra.Command, regToken, configPath, opMode string) error {
+func runRootCommand(cmd *cobra.Command, regToken, configPath string) error {
 	// Interactive mode: no flags set and no subcommand selected.
-	noFlags := regToken == "" && configPath == "" && opMode == ""
+	noFlags := regToken == "" && configPath == ""
 	if noFlags {
 		return runInteractive()
 	}
@@ -109,13 +107,13 @@ func runRootCommand(cmd *cobra.Command, regToken, configPath, opMode string) err
 		cancel()
 	}()
 
-	return runSteward(ctx, regToken, configPath, opMode)
+	return runSteward(ctx, regToken, configPath)
 }
 
 // runSteward starts the steward with the given configuration and blocks until
 // ctx is cancelled. It is called from both the root cobra command and the
 // Windows service handler.
-func runSteward(ctx context.Context, regToken, configPath, opMode string) error {
+func runSteward(ctx context.Context, regToken, configPath string) error {
 	// Initialize global logging provider. File is the only supported provider
 	// for the steward binary. Log level is read from CFGMS_LOG_LEVEL (default INFO).
 	logDir := os.Getenv("CFGMS_LOG_DIR")
@@ -195,46 +193,42 @@ func runSteward(ctx context.Context, regToken, configPath, opMode string) error 
 		return nil
 	}
 
-	// Standalone or legacy controller mode.
-	useStandalone := configPath != "" || opMode == "standalone"
-
-	var s *steward.Steward
-	var err error
-
-	legacyLogger := logging.GetLogger()
+	// Standalone mode: --config was provided.
+	useStandalone := configPath != ""
 	if useStandalone {
-		s, err = steward.NewStandalone(configPath, legacyLogger)
+		legacyLogger := logging.GetLogger()
+		s, err := steward.NewStandalone(configPath, legacyLogger)
 		if err != nil {
 			return fmt.Errorf("failed to create standalone steward: %w", err)
 		}
 		logger.Info("Starting steward in standalone mode",
 			"operation", "steward_start", "mode", "standalone", "config_path", configPath)
-	} else {
-		// Legacy controller mode was removed in Story #198.
-		// Controller-connected stewards use --regtoken (gRPC transport) handled above.
-		return fmt.Errorf("standalone mode requires --config flag; for controller mode use --regtoken")
+
+		errCh := make(chan error, 1)
+		go func() {
+			errCh <- s.Start(ctx)
+		}()
+
+		<-ctx.Done()
+		logger.Info("Shutdown signal received", "operation", "steward_shutdown")
+
+		stopCtx, stopCancel := context.WithTimeout(context.Background(), 15*time.Second)
+		defer stopCancel()
+		if stopErr := s.Stop(stopCtx); stopErr != nil {
+			logger.Error("Error during shutdown", "operation", "steward_shutdown", "error", stopErr.Error())
+		}
+
+		if startErr := <-errCh; startErr != nil && startErr != context.Canceled {
+			logger.Error("Steward start failed", "operation", "steward_run", "error", startErr.Error())
+			return fmt.Errorf("steward start failed: %w", startErr)
+		}
+
+		logger.Info("Steward shutdown completed", "operation", "steward_shutdown", "status", "completed")
+		return nil
 	}
 
-	errCh := make(chan error, 1)
-	go func() {
-		errCh <- s.Start(ctx)
-	}()
-
-	<-ctx.Done()
-	logger.Info("Shutdown signal received", "operation", "steward_shutdown")
-
-	stopCtx, stopCancel := context.WithTimeout(context.Background(), 15*time.Second)
-	defer stopCancel()
-	if err := s.Stop(stopCtx); err != nil {
-		logger.Error("Error during shutdown", "operation", "steward_shutdown", "error", err.Error())
-	}
-
-	if startErr := <-errCh; startErr != nil && startErr != context.Canceled {
-		logger.Error("Steward start failed", "operation", "steward_run", "error", startErr.Error())
-		return fmt.Errorf("steward start failed: %w", startErr)
-	}
-
-	logger.Info("Steward shutdown completed", "operation", "steward_shutdown", "status", "completed")
+	// Structurally unreachable: runRootCommand's noFlags guard prevents calling
+	// runSteward with both regToken and configPath empty.
 	return nil
 }
 
@@ -435,7 +429,7 @@ func runInteractive() error {
 		}()
 
 		fmt.Println("Running in foreground. Press Ctrl+C to stop.")
-		return runSteward(ctx, token, "", "")
+		return runSteward(ctx, token, "")
 	case "3", "":
 		fmt.Println("Exiting.")
 		return nil

--- a/cmd/steward/main_test.go
+++ b/cmd/steward/main_test.go
@@ -38,7 +38,7 @@ func TestBuildRootCommand(t *testing.T) {
 func TestBuildRootCommandFlags(t *testing.T) {
 	cmd := buildRootCommand()
 
-	for _, name := range []string{"config", "mode", "regtoken"} {
+	for _, name := range []string{"config", "regtoken"} {
 		flag := cmd.Flags().Lookup(name)
 		assert.NotNil(t, flag, "expected flag %q to be registered", name)
 	}
@@ -46,6 +46,11 @@ func TestBuildRootCommandFlags(t *testing.T) {
 	// log-level and log-provider must not be registered as CLI flags.
 	assert.Nil(t, cmd.Flags().Lookup("log-level"), "log-level flag must not be registered")
 	assert.Nil(t, cmd.Flags().Lookup("log-provider"), "log-provider flag must not be registered")
+}
+
+func TestBuildRootCommandNoModeFlag(t *testing.T) {
+	cmd := buildRootCommand()
+	assert.Nil(t, cmd.Flags().Lookup("mode"), "mode flag must not be registered")
 }
 
 func TestRunInstallRequiresToken(t *testing.T) {
@@ -145,22 +150,7 @@ func TestStandaloneStartErrorPropagatesToRunSteward(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	err := runSteward(ctx, "", "/nonexistent/cfgms-config-does-not-exist.yaml", "")
+	err := runSteward(ctx, "", "/nonexistent/cfgms-config-does-not-exist.yaml")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to create standalone steward")
-}
-
-// TestRunStewardStandaloneRequiresConfig verifies that standalone mode without a
-// config path returns an error rather than panicking or calling os.Exit.
-func TestRunStewardStandaloneRequiresConfig(t *testing.T) {
-	t.Setenv("CFGMS_LOG_DIR", t.TempDir())
-
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	// opMode="standalone" with empty configPath — no config file found in search
-	// paths in a temp environment, so NewStandalone returns an error that must be
-	// propagated rather than swallowed.
-	err := runSteward(ctx, "", "", "standalone")
-	require.Error(t, err)
 }

--- a/cmd/steward/windows_service.go
+++ b/cmd/steward/windows_service.go
@@ -59,7 +59,6 @@ func (h *stewardServiceHandler) Execute(
 	flags := pflag.NewFlagSet("steward-service", pflag.ContinueOnError)
 	regToken := flags.String("regtoken", "", "registration token")
 	configPath := flags.String("config", "", "config path")
-	opMode := flags.String("mode", "", "operation mode")
 	// Ignore unknown flags (e.g. subcommand names) so the service can start even
 	// if the arg list changes between versions.
 	flags.ParseErrorsAllowlist.UnknownFlags = true
@@ -70,7 +69,7 @@ func (h *stewardServiceHandler) Execute(
 
 	errCh := make(chan error, 1)
 	go func() {
-		errCh <- runSteward(ctx, *regToken, *configPath, *opMode)
+		errCh <- runSteward(ctx, *regToken, *configPath)
 	}()
 
 	status <- svc.Status{

--- a/docs/architecture/steward-operating-model.md
+++ b/docs/architecture/steward-operating-model.md
@@ -236,6 +236,19 @@ If the controller connection is lost, the steward continues converging on schedu
 
 The `--regtoken` flag establishes the controller channel — it does not change the steward's fundamental convergence behaviour.
 
+## Entry Paths
+
+The steward binary supports four entry paths:
+
+| Invocation | Mode | Description |
+|------------|------|-------------|
+| `cfgms-steward --regtoken TOKEN` | Controller-connected (foreground) | Registers with the controller via HTTP REST API, receives mTLS certificates, then establishes a gRPC-over-QUIC transport connection. Registration is called on every invocation — there is no stored-certificate resume path. |
+| `cfgms-steward --config path.cfg` | Standalone (foreground) | Loads cfg from the specified local file. No controller connection is established. All convergence, DNA, health, and local logging operate as normal. |
+| `cfgms-steward install --regtoken TOKEN` | Controller-connected (service) | Installs the steward as a native OS service (systemd on Linux, SCM on Windows, launchd on macOS) and starts it. |
+| `cfgms-steward` (no arguments) | Interactive | Prompts for a registration token, then presents a menu: [1] Install as service, [2] Run once in foreground, [3] Exit. |
+
+When both `--regtoken` and `--config` are supplied, the `--regtoken` path takes precedence and `--config` is ignored.
+
 ## Logging
 
 The steward writes structured logs using the file logging provider. This is the only supported logging provider for the steward binary — the timescale (database) provider is a controller-only feature.
@@ -281,7 +294,7 @@ How a steward joins a controller.
 6. Steward checks for a cfg from the controller
 7. Normal operation begins
 
-After initial registration, the steward reconnects automatically on restart using its stored certificates. The registration token is only used once.
+The `--regtoken` flag must be supplied each time the steward starts — there is no stored-certificate resume path in the current implementation. Every invocation re-registers via HTTP and receives fresh mTLS certificates from the controller.
 
 ### Bootstrap TLS Trust
 


### PR DESCRIPTION
## Summary

- Deletes the `--mode` flag (`standalone`/`controller`) from `buildRootCommand` — it has been dead since Story #198 removed legacy controller mode
- Removes the `opMode` parameter from `runRootCommand` and `runSteward` signatures throughout the codebase
- Simplifies `useStandalone` to `configPath != ""`; deletes the unreachable else-branch that returned a `standalone mode requires --config flag` error
- Cleans up `windows_service.go` — the SCM handler no longer declares or passes `opMode`
- Updates `main_test.go`: removes mode-flag assertion, adds `TestBuildRootCommandNoModeFlag`, removes the now-invalid `TestRunStewardStandaloneRequiresConfig` (tested `opMode=standalone` path)

## Specialist Review Results

| Reviewer | Result | Notes |
|----------|--------|-------|
| QA Test Runner | **PASS** | All unit tests pass with race detection; lint, license, secret scan, architecture checks clean. Trivy DB download failed due to container DNS — deferred to CI. |
| QA Code Reviewer | **PASS** | No mocks, no `t.Skip()` abuse, full error-path coverage retained, new regression test added |
| Security Engineer | **PASS** | Dead-code removal reduces attack surface; no new I/O, credentials, or sanitization changes; gosec/staticcheck/go vet clean |

## Test plan

- [ ] `TestBuildRootCommandNoModeFlag` — `cmd.Flags().Lookup("mode")` returns nil
- [ ] `TestBuildRootCommandFlags` — `config` and `regtoken` flags present; `mode` not asserted
- [ ] `TestStandaloneStartErrorPropagatesToRunSteward` — bad config path returns error (not panic/exit)
- [ ] CI unit-tests, integration-tests, Build Gate, security-deployment-gate

Fixes #812

🤖 Generated with [Claude Code](https://claude.com/claude-code)