### PR TITLE
api: fix three security defects — tenant scoping and token logging (Issue #782)

### DIFF
--- a/features/controller/api/handlers_apikeys.go
+++ b/features/controller/api/handlers_apikeys.go
@@ -17,19 +17,27 @@ import (
 	"github.com/google/uuid"
 	"github.com/gorilla/mux"
 
+	"github.com/cfgis/cfgms/features/controller/ctxkeys"
 	secretsif "github.com/cfgis/cfgms/pkg/secrets/interfaces"
 )
 
 // handleListAPIKeys handles GET /api/v1/api-keys
-// M-AUTH-1: List API keys from central secret store
+// M-AUTH-1: List API keys from central secret store, filtered to the authenticated tenant
 func (s *Server) handleListAPIKeys(w http.ResponseWriter, r *http.Request) {
-	// M-AUTH-1: For now, list ALL API keys across all tenants from memory cache
-	// TODO: Add proper tenant filtering based on RBAC permissions
+	tenantID, _ := r.Context().Value(ctxkeys.TenantID).(string)
+	if tenantID == "" {
+		s.writeErrorResponse(w, http.StatusUnauthorized, "Authentication required", "AUTHENTICATION_REQUIRED")
+		return
+	}
+
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	apiKeys := make([]APIKeyInfo, 0, len(s.apiKeys))
+	apiKeys := make([]APIKeyInfo, 0)
 	for _, key := range s.apiKeys {
+		if key.TenantID != tenantID {
+			continue
+		}
 		apiKeys = append(apiKeys, APIKeyInfo{
 			ID:          key.ID,
 			Name:        key.Name,

--- a/features/controller/api/handlers_apikeys_test.go
+++ b/features/controller/api/handlers_apikeys_test.go
@@ -1,0 +1,154 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cfgis/cfgms/features/controller/ctxkeys"
+)
+
+// callHandleListAPIKeys calls handleListAPIKeys directly with the given context tenant.
+func callHandleListAPIKeys(server *Server, contextTenantID string) *httptest.ResponseRecorder {
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/api-keys", nil)
+	if contextTenantID != "" {
+		req = req.WithContext(context.WithValue(req.Context(), ctxkeys.TenantID, contextTenantID))
+	}
+	rec := httptest.NewRecorder()
+	server.handleListAPIKeys(rec, req)
+	return rec
+}
+
+// injectAPIKey directly inserts an APIKey into the server's in-memory cache (bypassing secret store)
+// so tests can assert on tenant filtering without needing a full secret store round-trip.
+func injectAPIKey(server *Server, key *APIKey) {
+	server.mu.Lock()
+	server.apiKeys[key.Key] = key
+	server.mu.Unlock()
+}
+
+// TestHandleListAPIKeys_FiltersByAuthenticatedTenant verifies that a tenant only sees
+// its own API keys and never another tenant's keys.
+func TestHandleListAPIKeys_FiltersByAuthenticatedTenant(t *testing.T) {
+	server := setupTestServer(t)
+
+	now := time.Now().UTC()
+
+	keyA := &APIKey{
+		ID:          "key-a-id",
+		Key:         "key-a-secret",
+		Name:        "Tenant A Key",
+		Permissions: []string{"steward:list"},
+		CreatedAt:   now,
+		TenantID:    "tenant-a",
+	}
+	keyB := &APIKey{
+		ID:          "key-b-id",
+		Key:         "key-b-secret",
+		Name:        "Tenant B Key",
+		Permissions: []string{"steward:list"},
+		CreatedAt:   now,
+		TenantID:    "tenant-b",
+	}
+
+	injectAPIKey(server, keyA)
+	injectAPIKey(server, keyB)
+
+	// Authenticated as tenant-a — must only see tenant-a's key.
+	rec := callHandleListAPIKeys(server, "tenant-a")
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var resp APIResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+
+	keys, ok := resp.Data.([]interface{})
+	require.True(t, ok, "expected array in Data")
+
+	require.Len(t, keys, 1, "tenant-a should only see one key")
+	keyMap := keys[0].(map[string]interface{})
+	assert.Equal(t, "key-a-id", keyMap["id"])
+	assert.Equal(t, "tenant-a", keyMap["tenant_id"])
+}
+
+// TestHandleListAPIKeys_DoesNotExposeOtherTenantKeys verifies tenant-b's key is invisible
+// to a request authenticated as tenant-a.
+func TestHandleListAPIKeys_DoesNotExposeOtherTenantKeys(t *testing.T) {
+	server := setupTestServer(t)
+
+	now := time.Now().UTC()
+	injectAPIKey(server, &APIKey{
+		ID: "only-b-key", Key: "only-b-secret", Name: "B Key",
+		Permissions: []string{}, CreatedAt: now, TenantID: "tenant-b",
+	})
+
+	rec := callHandleListAPIKeys(server, "tenant-a")
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var resp APIResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+
+	keys, ok := resp.Data.([]interface{})
+	require.True(t, ok)
+	assert.Empty(t, keys, "tenant-a should see no keys when it has none")
+}
+
+// TestHandleListAPIKeys_NoContextTenant_Returns401 verifies that a missing context tenant
+// results in HTTP 401.
+func TestHandleListAPIKeys_NoContextTenant_Returns401(t *testing.T) {
+	server := setupTestServer(t)
+	rec := callHandleListAPIKeys(server, "")
+	assert.Equal(t, http.StatusUnauthorized, rec.Code)
+}
+
+// TestHandleListAPIKeys_RouterPath_FiltersByAuthenticatedTenant verifies tenant isolation
+// through the full router and authentication middleware — not just direct handler invocation.
+// This exercises the path where the auth middleware reads the API key, looks it up in
+// s.apiKeys, sets ctxkeys.TenantID from key.TenantID, and the handler filters on that value.
+func TestHandleListAPIKeys_RouterPath_FiltersByAuthenticatedTenant(t *testing.T) {
+	server := setupTestServer(t)
+
+	// Create an API key for tenant-a via generateEphemeralKey, which registers the key in
+	// s.apiKeys with TenantID="tenant-a". The auth middleware uses this TenantID to populate
+	// the context, which handleListAPIKeys then reads for filtering.
+	tenantAKey := NewEphemeralTestKey(t, server, []string{"api-key:list"}, "tenant-a", 5*time.Minute)
+
+	// Inject a second key belonging to tenant-b directly into the cache.
+	injectAPIKey(server, &APIKey{
+		ID:          "tenant-b-key-id",
+		Key:         "tenant-b-key-secret",
+		Name:        "Tenant B Key",
+		Permissions: []string{},
+		CreatedAt:   time.Now().UTC(),
+		TenantID:    "tenant-b",
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/api-keys", nil)
+	req.Header.Set("X-API-Key", tenantAKey)
+	rec := httptest.NewRecorder()
+	server.router.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var resp APIResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+
+	keys, ok := resp.Data.([]interface{})
+	require.True(t, ok, "expected array in Data")
+
+	for _, k := range keys {
+		keyMap, ok := k.(map[string]interface{})
+		require.True(t, ok)
+		assert.Equal(t, "tenant-a", keyMap["tenant_id"],
+			"router path must return only tenant-a keys when authenticated as tenant-a")
+		assert.NotEqual(t, "tenant-b-key-id", keyMap["id"],
+			"tenant-b key must not be visible through the router to tenant-a")
+	}
+}

--- a/features/controller/api/handlers_rbac.go
+++ b/features/controller/api/handlers_rbac.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/cfgis/cfgms/api/proto/common"
 	controller "github.com/cfgis/cfgms/api/proto/controller"
+	"github.com/cfgis/cfgms/features/controller/ctxkeys"
 )
 
 // handleListPermissions handles GET /api/v1/rbac/permissions
@@ -99,8 +100,11 @@ func (s *Server) handleListRoles(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Get tenant_id filter from query params
-	tenantID := r.URL.Query().Get("tenant_id")
+	tenantID, _ := r.Context().Value(ctxkeys.TenantID).(string)
+	if tenantID == "" {
+		s.writeErrorResponse(w, http.StatusUnauthorized, "Authentication required", "AUTHENTICATION_REQUIRED")
+		return
+	}
 
 	// Create gRPC request
 	req := &controller.ListRolesRequest{

--- a/features/controller/api/handlers_rbac_test.go
+++ b/features/controller/api/handlers_rbac_test.go
@@ -1,0 +1,121 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cfgis/cfgms/api/proto/common"
+	controller "github.com/cfgis/cfgms/api/proto/controller"
+	"github.com/cfgis/cfgms/features/controller/ctxkeys"
+)
+
+// createRoleForTenant creates a role for a specific tenant via the RBAC service.
+func createRoleForTenant(t *testing.T, server *Server, tenantID, roleID, roleName string) {
+	t.Helper()
+	ctx := context.Background()
+	_, err := server.rbacService.CreateRole(ctx, &controller.CreateRoleRequest{
+		Role: &common.Role{
+			Id:          roleID,
+			Name:        roleName,
+			Description: "test role for " + tenantID,
+			TenantId:    tenantID,
+		},
+	})
+	require.NoError(t, err)
+}
+
+// callHandleListRoles calls handleListRoles directly with the given context tenant,
+// bypassing the router/middleware so we can inject context values explicitly.
+func callHandleListRoles(server *Server, contextTenantID, queryTenantID string) *httptest.ResponseRecorder {
+	url := "/api/v1/rbac/roles"
+	if queryTenantID != "" {
+		url += "?tenant_id=" + queryTenantID
+	}
+	req := httptest.NewRequest(http.MethodGet, url, nil)
+	if contextTenantID != "" {
+		req = req.WithContext(context.WithValue(req.Context(), ctxkeys.TenantID, contextTenantID))
+	}
+	rec := httptest.NewRecorder()
+	server.handleListRoles(rec, req)
+	return rec
+}
+
+// roleIDsFromResponse extracts the "id" field from each role in the API response data.
+func roleIDsFromResponse(t *testing.T, resp APIResponse) []string {
+	t.Helper()
+	roles, ok := resp.Data.([]interface{})
+	require.True(t, ok, "expected array in Data")
+	ids := make([]string, 0, len(roles))
+	for _, r := range roles {
+		roleMap, ok := r.(map[string]interface{})
+		require.True(t, ok)
+		if id, ok := roleMap["id"].(string); ok {
+			ids = append(ids, id)
+		}
+	}
+	return ids
+}
+
+// TestHandleListRoles_IgnoresQueryParamTenantID verifies that a tenant_id query param
+// cannot be used to access another tenant's roles (tenant scoping must come from context).
+func TestHandleListRoles_IgnoresQueryParamTenantID(t *testing.T) {
+	server := setupTestServer(t)
+
+	// Create roles for two different tenants.
+	createRoleForTenant(t, server, "tenant-a", "tenant-a.role1", "Tenant A Role")
+	createRoleForTenant(t, server, "tenant-b", "tenant-b.role1", "Tenant B Role")
+
+	// Authenticated as tenant-a, but supplying ?tenant_id=tenant-b in the query string.
+	// The handler must ignore the query param and use the context tenant.
+	rec := callHandleListRoles(server, "tenant-a", "tenant-b")
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	var resp APIResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+
+	ids := roleIDsFromResponse(t, resp)
+
+	// tenant-a's role must be present.
+	assert.Contains(t, ids, "tenant-a.role1",
+		"tenant-a role must appear when authenticated as tenant-a")
+
+	// tenant-b's role must not appear even though ?tenant_id=tenant-b was supplied.
+	assert.NotContains(t, ids, "tenant-b.role1",
+		"tenant-b role must not be visible to tenant-a; query param must be ignored")
+}
+
+// TestHandleListRoles_ReturnsOnlyOwnTenantRoles verifies that a tenant only sees its own roles.
+func TestHandleListRoles_ReturnsOnlyOwnTenantRoles(t *testing.T) {
+	server := setupTestServer(t)
+
+	createRoleForTenant(t, server, "tenant-a", "tenant-a.admin", "Tenant A Admin")
+	createRoleForTenant(t, server, "tenant-b", "tenant-b.admin", "Tenant B Admin")
+
+	rec := callHandleListRoles(server, "tenant-a", "")
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var resp APIResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+
+	ids := roleIDsFromResponse(t, resp)
+	assert.Contains(t, ids, "tenant-a.admin", "tenant-a's own role must be present")
+	assert.NotContains(t, ids, "tenant-b.admin", "tenant-b role must not appear in tenant-a response")
+}
+
+// TestHandleListRoles_NoContextTenant_Returns401 verifies that a missing context tenant
+// (unauthenticated path) results in HTTP 401 rather than forwarding an empty tenant ID.
+func TestHandleListRoles_NoContextTenant_Returns401(t *testing.T) {
+	server := setupTestServer(t)
+
+	// No tenant in context simulates an unauthenticated/misconfigured request.
+	rec := callHandleListRoles(server, "", "")
+	assert.Equal(t, http.StatusUnauthorized, rec.Code)
+}

--- a/features/controller/api/handlers_registration.go
+++ b/features/controller/api/handlers_registration.go
@@ -98,7 +98,7 @@ func (s *Server) handleRegister(w http.ResponseWriter, r *http.Request) {
 
 	// Check if token is revoked
 	if token.Revoked {
-		s.logger.Warn("Attempted use of revoked token", "token_prefix", req.Token[:min(len(req.Token), 8)])
+		s.logger.Warn("Attempted use of revoked token", "token_prefix", logging.SanitizeLogValue(req.Token[:min(len(req.Token), 8)]))
 		s.emitRegistrationAudit(r.Context(), req.Token, token.TenantID, "unknown",
 			business.AuditEventSecurityEvent, "registration_rejected",
 			business.AuditResultFailure, business.AuditSeverityCritical, nil)
@@ -108,7 +108,7 @@ func (s *Server) handleRegister(w http.ResponseWriter, r *http.Request) {
 
 	// Check if token is expired
 	if token.ExpiresAt != nil && token.ExpiresAt.Before(time.Now()) {
-		s.logger.Warn("Attempted use of expired token", "token_prefix", req.Token[:min(len(req.Token), 8)], "expired_at", token.ExpiresAt)
+		s.logger.Warn("Attempted use of expired token", "token_prefix", logging.SanitizeLogValue(req.Token[:min(len(req.Token), 8)]), "expired_at", token.ExpiresAt)
 		s.emitRegistrationAudit(r.Context(), req.Token, token.TenantID, "unknown",
 			business.AuditEventSecurityEvent, "registration_rejected",
 			business.AuditResultFailure, business.AuditSeverityCritical, nil)

--- a/features/controller/api/handlers_registration.go
+++ b/features/controller/api/handlers_registration.go
@@ -98,7 +98,7 @@ func (s *Server) handleRegister(w http.ResponseWriter, r *http.Request) {
 
 	// Check if token is revoked
 	if token.Revoked {
-		s.logger.Warn("Attempted use of revoked token", "token", req.Token)
+		s.logger.Warn("Attempted use of revoked token", "token_prefix", req.Token[:min(len(req.Token), 8)])
 		s.emitRegistrationAudit(r.Context(), req.Token, token.TenantID, "unknown",
 			business.AuditEventSecurityEvent, "registration_rejected",
 			business.AuditResultFailure, business.AuditSeverityCritical, nil)
@@ -108,7 +108,7 @@ func (s *Server) handleRegister(w http.ResponseWriter, r *http.Request) {
 
 	// Check if token is expired
 	if token.ExpiresAt != nil && token.ExpiresAt.Before(time.Now()) {
-		s.logger.Warn("Attempted use of expired token", "token", req.Token, "expired_at", token.ExpiresAt)
+		s.logger.Warn("Attempted use of expired token", "token_prefix", req.Token[:min(len(req.Token), 8)], "expired_at", token.ExpiresAt)
 		s.emitRegistrationAudit(r.Context(), req.Token, token.TenantID, "unknown",
 			business.AuditEventSecurityEvent, "registration_rejected",
 			business.AuditResultFailure, business.AuditSeverityCritical, nil)

--- a/features/controller/api/handlers_registration_test.go
+++ b/features/controller/api/handlers_registration_test.go
@@ -58,14 +58,20 @@ func (c *controlledConsumeStore) ConsumeToken(ctx context.Context, tokenStr, ste
 
 // newHandleRegisterServer creates a minimal server for handleRegister unit tests.
 // Pass a non-nil certMgr only when you need the handler to reach cert generation (200 path).
+// Pass a non-nil logger to capture log output in tests; defaults to NoopLogger.
 // Returns the server and the audit manager so tests can Flush and query audit entries.
-func newHandleRegisterServer(t *testing.T, tokenStore registration.Store, certMgr *cert.Manager) (*Server, *audit.Manager) {
+func newHandleRegisterServer(t *testing.T, tokenStore registration.Store, certMgr *cert.Manager, loggers ...logging.Logger) (*Server, *audit.Manager) {
 	t.Helper()
 
 	cfg := config.DefaultConfig()
 	cfg.Certificate.EnableCertManagement = false
 
-	logger := logging.NewNoopLogger()
+	var logger logging.Logger
+	if len(loggers) > 0 && loggers[0] != nil {
+		logger = loggers[0]
+	} else {
+		logger = logging.NewNoopLogger()
+	}
 	tempDir := t.TempDir()
 
 	storageManager, err := interfaces.CreateOSSStorageManager(tempDir+"/flatfile", tempDir+"/cfgms.db")
@@ -455,10 +461,8 @@ func (l *kvCapturingLogger) warnKVContains(v string) bool {
 // warn path logs only a truncated token_prefix (max 8 chars) and never the full token value.
 func TestHandleRegister_RevokedToken_LogsTokenPrefixNotFullToken(t *testing.T) {
 	tokenStore := newTestRegistrationStore(t)
-	server, _ := newHandleRegisterServer(t, tokenStore, nil)
-
 	capLogger := &kvCapturingLogger{}
-	server.logger = capLogger
+	server, _ := newHandleRegisterServer(t, tokenStore, nil, capLogger)
 
 	fullToken := "cfgms_reg_revoked_loggingtest_12345"
 	revokedAt := time.Now().Add(-time.Hour)
@@ -488,10 +492,8 @@ func TestHandleRegister_RevokedToken_LogsTokenPrefixNotFullToken(t *testing.T) {
 // warn path logs only a truncated token_prefix (max 8 chars) and never the full token value.
 func TestHandleRegister_ExpiredToken_LogsTokenPrefixNotFullToken(t *testing.T) {
 	tokenStore := newTestRegistrationStore(t)
-	server, _ := newHandleRegisterServer(t, tokenStore, nil)
-
 	capLogger := &kvCapturingLogger{}
-	server.logger = capLogger
+	server, _ := newHandleRegisterServer(t, tokenStore, nil, capLogger)
 
 	fullToken := "cfgms_reg_expired_loggingtest_12345"
 	pastExpiry := time.Now().Add(-time.Hour)

--- a/features/controller/api/handlers_registration_test.go
+++ b/features/controller/api/handlers_registration_test.go
@@ -408,3 +408,108 @@ func TestHandleRegister_ErrTokenAlreadyUsed_IsDistinctFrom500(t *testing.T) {
 	rec := postRegister(server, "cfgms_reg_sentinel_test")
 	assert.Equal(t, http.StatusConflict, rec.Code, "ErrTokenAlreadyUsed must map to 409 not 500")
 }
+
+// kvCapturingLogger captures both Warn message and key-value pairs for security assertions.
+// It is not a mock — it satisfies logging.Logger via embedding NoopLogger while recording
+// the key-value arguments so tests can verify sensitive fields are absent or truncated.
+type kvCapturingLogger struct {
+	logging.NoopLogger
+	mu      sync.Mutex
+	entries []kvLogEntry
+}
+
+type kvLogEntry struct {
+	msg string
+	kvs []interface{}
+}
+
+func (l *kvCapturingLogger) Warn(msg string, kvs ...interface{}) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	kvcopy := make([]interface{}, len(kvs))
+	copy(kvcopy, kvs)
+	l.entries = append(l.entries, kvLogEntry{msg: msg, kvs: kvcopy})
+}
+
+func (l *kvCapturingLogger) warnEntries() []kvLogEntry {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	out := make([]kvLogEntry, len(l.entries))
+	copy(out, l.entries)
+	return out
+}
+
+// warnKVContains checks whether any warn entry has a kv value that equals v.
+func (l *kvCapturingLogger) warnKVContains(v string) bool {
+	for _, entry := range l.warnEntries() {
+		for i := 1; i < len(entry.kvs); i += 2 {
+			if s, ok := entry.kvs[i].(string); ok && s == v {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// TestHandleRegister_RevokedToken_LogsTokenPrefixNotFullToken verifies that the revoked-token
+// warn path logs only a truncated token_prefix (max 8 chars) and never the full token value.
+func TestHandleRegister_RevokedToken_LogsTokenPrefixNotFullToken(t *testing.T) {
+	tokenStore := newTestRegistrationStore(t)
+	server, _ := newHandleRegisterServer(t, tokenStore, nil)
+
+	capLogger := &kvCapturingLogger{}
+	server.logger = capLogger
+
+	fullToken := "cfgms_reg_revoked_loggingtest_12345"
+	revokedAt := time.Now().Add(-time.Hour)
+	tok := &registration.Token{
+		Token:         fullToken,
+		TenantID:      "test-tenant",
+		ControllerURL: "grpc://controller:7443",
+		Revoked:       true,
+		RevokedAt:     &revokedAt,
+	}
+	require.NoError(t, tokenStore.SaveToken(context.Background(), tok))
+
+	rec := postRegister(server, fullToken)
+	assert.Equal(t, http.StatusUnauthorized, rec.Code)
+
+	// The full token must not appear in any warn kv value.
+	assert.False(t, capLogger.warnKVContains(fullToken),
+		"full token must not be logged in the revoked-token path")
+
+	// A truncated prefix must be present (at most 8 chars).
+	expectedPrefix := fullToken[:8]
+	assert.True(t, capLogger.warnKVContains(expectedPrefix),
+		"token_prefix (first 8 chars) must be logged in the revoked-token path")
+}
+
+// TestHandleRegister_ExpiredToken_LogsTokenPrefixNotFullToken verifies that the expired-token
+// warn path logs only a truncated token_prefix (max 8 chars) and never the full token value.
+func TestHandleRegister_ExpiredToken_LogsTokenPrefixNotFullToken(t *testing.T) {
+	tokenStore := newTestRegistrationStore(t)
+	server, _ := newHandleRegisterServer(t, tokenStore, nil)
+
+	capLogger := &kvCapturingLogger{}
+	server.logger = capLogger
+
+	fullToken := "cfgms_reg_expired_loggingtest_12345"
+	pastExpiry := time.Now().Add(-time.Hour)
+	tok := &registration.Token{
+		Token:         fullToken,
+		TenantID:      "test-tenant",
+		ControllerURL: "grpc://controller:7443",
+		ExpiresAt:     &pastExpiry,
+	}
+	require.NoError(t, tokenStore.SaveToken(context.Background(), tok))
+
+	rec := postRegister(server, fullToken)
+	assert.Equal(t, http.StatusUnauthorized, rec.Code)
+
+	assert.False(t, capLogger.warnKVContains(fullToken),
+		"full token must not be logged in the expired-token path")
+
+	expectedPrefix := fullToken[:8]
+	assert.True(t, capLogger.warnKVContains(expectedPrefix),
+		"token_prefix (first 8 chars) must be logged in the expired-token path")
+}


### PR DESCRIPTION
## Summary

- **handleListRoles**: removed `?tenant_id` query param injection vector; handler now reads authenticated tenant exclusively from `r.Context().Value(ctxkeys.TenantID)`; returns 401 when context tenant is absent
- **handleListAPIKeys**: added tenant filter — only returns API keys belonging to the authenticated tenant; removes cross-tenant data exposure; returns 401 when context tenant is absent
- **handlers_registration.go**: replaced raw `"token", req.Token` log fields on the revoked/expired warn paths with `"token_prefix", req.Token[:min(len(req.Token), 8)]`, preventing registration token leakage in structured log output

## Test plan

- [ ] `handlers_rbac_test.go` (new): `?tenant_id` query param ignored; only context-tenant roles returned; 401 on missing context tenant
- [ ] `handlers_apikeys_test.go` (new): direct-handler filtering by context tenant; router-path integration test through full auth middleware; 401 on missing context tenant
- [ ] `handlers_registration_test.go` (appended): `kvCapturingLogger` tests assert full token absent, 8-char prefix present, for revoked and expired warn paths
- [ ] `go test ./features/controller/api/...` — all 100+ tests pass

## Specialist review results

- **QA test runner**: PASS — all unit tests pass; Trivy skipped (no network in container, not a code defect)
- **QA code reviewer**: PASS (after fix iteration for token logging test coverage and router-path tenant isolation test)
- **Security engineer**: PASS — gosec, staticcheck, architecture checks all clean; all three defects confirmed remediated

Fixes #782

🤖 Generated with [Claude Code](https://claude.com/claude-code)