### PR TITLE
rbac: add Manager.Close to eliminate TempDir cleanup race (Issue #848)

### DIFF
--- a/features/controller/controller_test.go
+++ b/features/controller/controller_test.go
@@ -48,8 +48,12 @@ func TestControllerCreation(t *testing.T) {
 				if tt.cfg.Certificate != nil {
 					tt.cfg.Certificate.CAPath = tempDir + "/certs/ca"
 				}
-				if tt.cfg.Storage != nil && tt.cfg.Storage.Config != nil {
-					tt.cfg.Storage.Config["repository_path"] = tempDir + "/storage"
+				if tt.cfg.Storage != nil {
+					tt.cfg.Storage.FlatfileRoot = tempDir + "/flatfile"
+					tt.cfg.Storage.SQLitePath = tempDir + "/cfgms.db"
+					if tt.cfg.Storage.Config != nil {
+						tt.cfg.Storage.Config["repository_path"] = tempDir + "/storage"
+					}
 				}
 				// Pre-initialize if cert management is enabled (Story #410)
 				if tt.cfg.Certificate != nil && tt.cfg.Certificate.EnableCertManagement {
@@ -85,8 +89,12 @@ func TestControllerLifecycle(t *testing.T) {
 	if cfg.Certificate != nil {
 		cfg.Certificate.CAPath = tempDir + "/certs/ca"
 	}
-	if cfg.Storage != nil && cfg.Storage.Config != nil {
-		cfg.Storage.Config["repository_path"] = tempDir + "/storage"
+	if cfg.Storage != nil {
+		cfg.Storage.FlatfileRoot = tempDir + "/flatfile"
+		cfg.Storage.SQLitePath = tempDir + "/cfgms.db"
+		if cfg.Storage.Config != nil {
+			cfg.Storage.Config["repository_path"] = tempDir + "/storage"
+		}
 	}
 
 	// Pre-initialize (Story #410: controller requires explicit init)
@@ -167,8 +175,12 @@ func TestModuleRegistration(t *testing.T) {
 	if cfg.Certificate != nil {
 		cfg.Certificate.CAPath = tempDir + "/certs/ca"
 	}
-	if cfg.Storage != nil && cfg.Storage.Config != nil {
-		cfg.Storage.Config["repository_path"] = tempDir + "/storage"
+	if cfg.Storage != nil {
+		cfg.Storage.FlatfileRoot = tempDir + "/flatfile"
+		cfg.Storage.SQLitePath = tempDir + "/cfgms.db"
+		if cfg.Storage.Config != nil {
+			cfg.Storage.Config["repository_path"] = tempDir + "/storage"
+		}
 	}
 	pkgtestutil.PreInitControllerForTest(t, cfg.CertPath, cfg.Certificate.CAPath)
 	ctrl, err := New(cfg, logger)
@@ -219,8 +231,12 @@ func TestControllerSingleHTTPServer(t *testing.T) {
 	if cfg.Certificate != nil {
 		cfg.Certificate.CAPath = tempDir + "/certs/ca"
 	}
-	if cfg.Storage != nil && cfg.Storage.Config != nil {
-		cfg.Storage.Config["repository_path"] = tempDir + "/storage"
+	if cfg.Storage != nil {
+		cfg.Storage.FlatfileRoot = tempDir + "/flatfile"
+		cfg.Storage.SQLitePath = tempDir + "/cfgms.db"
+		if cfg.Storage.Config != nil {
+			cfg.Storage.Config["repository_path"] = tempDir + "/storage"
+		}
 	}
 	if cfg.Transport != nil {
 		cfg.Transport.ListenAddr = "127.0.0.1:0"

--- a/features/controller/server/server_security_test.go
+++ b/features/controller/server/server_security_test.go
@@ -37,8 +37,12 @@ func createTestStorageConfig(tempDir, suffix string) *config.StorageConfig {
 	}
 }
 
-// createDockerTestStorageConfig creates storage configs for Docker-based testing
-func createDockerTestStorageConfig(provider string) *config.StorageConfig {
+// createDockerTestStorageConfig creates storage configs for Docker-based testing.
+// For non-database providers, the flatfile+sqlite paths are scoped to t.TempDir()
+// so each test gets a fresh directory and no state persists in /tmp across runs —
+// stale on-disk schemas had previously broken tests after audit_entries migrations.
+func createDockerTestStorageConfig(t *testing.T, provider string) *config.StorageConfig {
+	t.Helper()
 	switch provider {
 	case "database":
 		return &config.StorageConfig{
@@ -53,7 +57,7 @@ func createDockerTestStorageConfig(provider string) *config.StorageConfig {
 			},
 		}
 	default:
-		return createTestStorageConfig(os.TempDir(), provider)
+		return createTestStorageConfig(t.TempDir(), provider)
 	}
 }
 
@@ -221,7 +225,7 @@ func TestServer_StorageProviderValidation(t *testing.T) {
 
 				// Use Docker test configuration if available, otherwise fall back to local test
 				if isDockerTestEnvironment() {
-					storageConfig = createDockerTestStorageConfig(providerInfo.Name)
+					storageConfig = createDockerTestStorageConfig(t, providerInfo.Name)
 					t.Logf("Using Docker test configuration for provider '%s'", providerInfo.Name)
 				} else {
 					// For local testing, use appropriate configuration per provider

--- a/features/rbac/advanced_permissions_test.go
+++ b/features/rbac/advanced_permissions_test.go
@@ -41,11 +41,7 @@ func TestAdvancedPermissionManagement(t *testing.T) {
 	err = manager.Initialize(ctx)
 	require.NoError(t, err)
 
-	t.Cleanup(func() {
-		stopCtx, stopCancel := context.WithTimeout(context.Background(), 5*time.Second)
-		defer stopCancel()
-		_ = manager.auditManager.Stop(stopCtx)
-	})
+	// Drain shutdown is handled by manager.Close cleanup registered above (Issue #848).
 
 	flushAudit := func(t *testing.T) {
 		t.Helper()

--- a/features/rbac/advanced_permissions_test.go
+++ b/features/rbac/advanced_permissions_test.go
@@ -31,6 +31,11 @@ func TestAdvancedPermissionManagement(t *testing.T) {
 		storageManager.GetClientTenantStore(),
 		storageManager.GetRBACStore(),
 	)
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_ = manager.Close(ctx)
+	})
 	ctx := context.Background()
 
 	err = manager.Initialize(ctx)

--- a/features/rbac/audit_integration_test.go
+++ b/features/rbac/audit_integration_test.go
@@ -33,6 +33,11 @@ func TestRBACManager_AuditIntegration(t *testing.T) {
 		storageManager.GetClientTenantStore(),
 		storageManager.GetRBACStore(),
 	)
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_ = manager.Close(ctx)
+	})
 	require.NotNil(t, manager)
 	require.NotNil(t, manager.auditManager)
 
@@ -332,6 +337,11 @@ func TestRBACManager_AuditFailureHandling(t *testing.T) {
 		storageManager.GetClientTenantStore(),
 		storageManager.GetRBACStore(),
 	)
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_ = manager.Close(ctx)
+	})
 	require.NotNil(t, manager)
 
 	ctx := context.Background()
@@ -377,6 +387,11 @@ func TestRBACManager_AuditFailureHandling(t *testing.T) {
 			storageManager.GetClientTenantStore(),
 			storageManager.GetRBACStore(),
 		)
+		t.Cleanup(func() {
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+			_ = manager.Close(ctx)
+		})
 		err = manager.Initialize(ctx)
 		require.NoError(t, err)
 

--- a/features/rbac/audit_integration_test.go
+++ b/features/rbac/audit_integration_test.go
@@ -46,13 +46,8 @@ func TestRBACManager_AuditIntegration(t *testing.T) {
 	require.NoError(t, err)
 
 	// Issue #764: audit writes are now asynchronous. Tests that query the audit
-	// store must Flush first to guarantee pending entries have landed.
-	t.Cleanup(func() {
-		stopCtx, stopCancel := context.WithTimeout(context.Background(), 5*time.Second)
-		defer stopCancel()
-		_ = manager.auditManager.Stop(stopCtx)
-	})
-
+	// store must Flush first to guarantee pending entries have landed. Drain
+	// shutdown is handled by manager.Close cleanup registered above (Issue #848).
 	flushAudit := func(t *testing.T) {
 		t.Helper()
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
@@ -266,37 +261,39 @@ func TestRBACManager_AuditIntegration(t *testing.T) {
 	})
 
 	t.Run("Failed operations generate error audit events", func(t *testing.T) {
-		// Try to create a role with invalid data (empty ID)
+		// Use a case that deterministically fails at the manager level:
+		// a role claiming a non-existent parent triggers the explicit error
+		// path in Manager.CreateRole (RBAC_PARENT_ROLE_NOT_FOUND), which
+		// synchronously emits an error audit event.
 		invalidRole := &common.Role{
-			Id:       "", // Invalid - empty ID
-			Name:     "Invalid Role",
-			TenantId: "test-tenant",
+			Id:           "test-role-parent-missing",
+			Name:         "Role with missing parent",
+			TenantId:     "test-tenant",
+			ParentRoleId: "does-not-exist",
 		}
 
-		_ = manager.CreateRole(ctx, invalidRole)
-		// This should fail, but let's check if we still get an audit event
+		err := manager.CreateRole(ctx, invalidRole)
+		require.Error(t, err, "CreateRole must return an error when parent role does not exist")
+		require.Contains(t, err.Error(), "not found")
 
-		// Query for any audit entries with error result
 		auditFilter := &business.AuditFilter{
-			TenantID:   "test-tenant",
-			EventTypes: []business.AuditEventType{business.AuditEventUserManagement},
-			Actions:    []string{"create_role"},
-			Results:    []business.AuditResult{business.AuditResultError},
-			Limit:      10,
+			TenantID:      "test-tenant",
+			EventTypes:    []business.AuditEventType{business.AuditEventUserManagement},
+			Actions:       []string{"create_role"},
+			Results:       []business.AuditResult{business.AuditResultError},
+			ResourceIDs:   []string{"test-role-parent-missing"},
+			Limit:         10,
 		}
 
-		// Note: This test depends on whether the underlying store validates the role
-		// If validation passes through, we won't get an error audit event
 		flushAudit(t)
 		auditEntries, err := manager.auditManager.QueryEntries(ctx, auditFilter)
 		require.NoError(t, err)
+		require.Len(t, auditEntries, 1, "failed CreateRole must produce exactly one error audit entry")
 
-		// If there are error entries, verify they have proper error information
-		for _, entry := range auditEntries {
-			assert.Equal(t, business.AuditResultError, entry.Result)
-			assert.NotEmpty(t, entry.ErrorCode)
-			assert.NotEmpty(t, entry.ErrorMessage)
-		}
+		entry := auditEntries[0]
+		assert.Equal(t, business.AuditResultError, entry.Result)
+		assert.Equal(t, "RBAC_PARENT_ROLE_NOT_FOUND", entry.ErrorCode)
+		assert.NotEmpty(t, entry.ErrorMessage)
 	})
 
 	t.Run("Audit entries maintain integrity", func(t *testing.T) {

--- a/features/rbac/audit_integration_test.go
+++ b/features/rbac/audit_integration_test.go
@@ -277,12 +277,12 @@ func TestRBACManager_AuditIntegration(t *testing.T) {
 		require.Contains(t, err.Error(), "not found")
 
 		auditFilter := &business.AuditFilter{
-			TenantID:      "test-tenant",
-			EventTypes:    []business.AuditEventType{business.AuditEventUserManagement},
-			Actions:       []string{"create_role"},
-			Results:       []business.AuditResult{business.AuditResultError},
-			ResourceIDs:   []string{"test-role-parent-missing"},
-			Limit:         10,
+			TenantID:    "test-tenant",
+			EventTypes:  []business.AuditEventType{business.AuditEventUserManagement},
+			Actions:     []string{"create_role"},
+			Results:     []business.AuditResult{business.AuditResultError},
+			ResourceIDs: []string{"test-role-parent-missing"},
+			Limit:       10,
 		}
 
 		flushAudit(t)

--- a/features/rbac/manager.go
+++ b/features/rbac/manager.go
@@ -109,6 +109,23 @@ func NewManagerWithStorage(auditStore business.AuditStore, clientTenantStore bus
 	return manager
 }
 
+// Close flushes pending audit entries and stops the audit drain goroutine.
+// It is idempotent via the underlying audit.Manager's stopOnce.
+//
+// Callers that construct a Manager and back it with per-test temporary storage
+// (e.g., via `t.TempDir()`) MUST register a t.Cleanup that calls Close before
+// the temp directory is removed. Without this, the audit drain goroutine may
+// still be writing files when `TempDir` RemoveAll runs, producing flaky
+// "directory not empty" cleanup errors on slower filesystems (macOS, Windows).
+//
+// Returns nil if no audit manager was configured.
+func (m *Manager) Close(ctx context.Context) error {
+	if m.auditManager == nil {
+		return nil
+	}
+	return m.auditManager.Stop(ctx)
+}
+
 // Initialize sets up the RBAC system with default roles and permissions
 func (m *Manager) Initialize(ctx context.Context) error {
 	if err := m.store.Initialize(ctx); err != nil {

--- a/features/rbac/manager_hierarchy_test.go
+++ b/features/rbac/manager_hierarchy_test.go
@@ -5,6 +5,7 @@ package rbac
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -29,6 +30,11 @@ func TestManager_CreateRoleWithParent(t *testing.T) {
 		storageManager.GetClientTenantStore(),
 		storageManager.GetRBACStore(),
 	)
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_ = manager.Close(ctx)
+	})
 	ctx := context.Background()
 
 	// Initialize manager
@@ -166,6 +172,11 @@ func TestManager_GetRoleHierarchy(t *testing.T) {
 		storageManager.GetClientTenantStore(),
 		storageManager.GetRBACStore(),
 	)
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_ = manager.Close(ctx)
+	})
 	ctx := context.Background()
 
 	// Initialize and set up test hierarchy
@@ -256,6 +267,11 @@ func TestManager_SetAndRemoveRoleParent(t *testing.T) {
 		storageManager.GetClientTenantStore(),
 		storageManager.GetRBACStore(),
 	)
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_ = manager.Close(ctx)
+	})
 	ctx := context.Background()
 
 	err = manager.Initialize(ctx)
@@ -326,6 +342,11 @@ func TestManager_ComputeRolePermissions(t *testing.T) {
 		storageManager.GetClientTenantStore(),
 		storageManager.GetRBACStore(),
 	)
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_ = manager.Close(ctx)
+	})
 	ctx := context.Background()
 
 	err = manager.Initialize(ctx)
@@ -395,6 +416,11 @@ func TestManager_ValidateHierarchyOperation(t *testing.T) {
 		storageManager.GetClientTenantStore(),
 		storageManager.GetRBACStore(),
 	)
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_ = manager.Close(ctx)
+	})
 	ctx := context.Background()
 
 	err = manager.Initialize(ctx)

--- a/features/rbac/manager_storage_test.go
+++ b/features/rbac/manager_storage_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	business "github.com/cfgis/cfgms/pkg/storage/interfaces/business"
 	_ "github.com/cfgis/cfgms/pkg/storage/providers/database"
 	_ "github.com/cfgis/cfgms/pkg/storage/providers/flatfile"
 	_ "github.com/cfgis/cfgms/pkg/storage/providers/sqlite"
@@ -22,21 +21,14 @@ import (
 
 // TestNewManagerWithStorage tests the new constructor that accepts storage interfaces
 func TestNewManagerWithStorage(t *testing.T) {
+	// The database provider is exercised by its own provider-specific tests
+	// under pkg/storage/providers/database/. This test covers the OSS
+	// flatfile+sqlite composite path that the controller actually uses.
 	tests := []struct {
 		name         string
 		setupStorage func(t *testing.T) (*interfaces.StorageManager, error)
 		wantErr      bool
 	}{
-		{
-			name: "with database storage provider (if configured)",
-			setupStorage: func(t *testing.T) (*interfaces.StorageManager, error) {
-				// Skip database tests for now due to configuration complexity
-				// In production, database provider will be properly configured
-				t.Skip("database provider requires complex configuration - skipping for basic test")
-				return nil, nil
-			},
-			wantErr: false,
-		},
 		{
 			name: "with flatfile+sqlite storage provider",
 			setupStorage: func(t *testing.T) (*interfaces.StorageManager, error) {
@@ -156,34 +148,13 @@ func TestNewManagerWithStorage(t *testing.T) {
 // deliberately removed to eliminate package-level storage mechanisms
 // All RBAC managers now require explicit storage configuration via NewManagerWithStorage()
 
-// TestNewManagerWithStorage_NilStorageHandling tests error handling for nil storage interfaces
+// TestNewManagerWithStorage_NilStorageHandling verifies that NewManagerWithStorage
+// panics when any required store is nil. All three stores (audit, clientTenant,
+// rbac) are required — passing nil for any of them is a programmer error.
 func TestNewManagerWithStorage_NilStorageHandling(t *testing.T) {
-	tests := []struct {
-		name              string
-		auditStore        business.AuditStore
-		clientTenantStore business.ClientTenantStore
-		expectPanic       bool
-	}{
-		{
-			name:              "nil audit store",
-			auditStore:        nil,
-			clientTenantStore: nil,
-			expectPanic:       true,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if tt.expectPanic {
-				assert.Panics(t, func() {
-					NewManagerWithStorage(tt.auditStore, tt.clientTenantStore, nil)
-				})
-			} else {
-				manager := NewManagerWithStorage(tt.auditStore, tt.clientTenantStore, nil)
-				assert.NotNil(t, manager)
-			}
-		})
-	}
+	assert.Panics(t, func() {
+		NewManagerWithStorage(nil, nil, nil)
+	}, "NewManagerWithStorage must panic when all stores are nil")
 }
 
 // TestManagerWithStorage_TenantIsolation tests that tenant isolation works correctly with pluggable storage

--- a/features/rbac/manager_storage_test.go
+++ b/features/rbac/manager_storage_test.go
@@ -5,6 +5,7 @@ package rbac
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/cfgis/cfgms/api/proto/common"
 	"github.com/cfgis/cfgms/pkg/storage/interfaces"
@@ -63,6 +64,11 @@ func TestNewManagerWithStorage(t *testing.T) {
 				storageManager.GetClientTenantStore(),
 				storageManager.GetRBACStore(),
 			)
+			t.Cleanup(func() {
+				ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+				defer cancel()
+				_ = manager.Close(ctx)
+			})
 			require.NotNil(t, manager)
 
 			// Verify manager initializes correctly with pluggable storage
@@ -193,6 +199,11 @@ func TestManagerWithStorage_TenantIsolation(t *testing.T) {
 		storageManager.GetClientTenantStore(),
 		storageManager.GetRBACStore(),
 	)
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_ = manager.Close(ctx)
+	})
 	require.NotNil(t, manager)
 
 	ctx := context.Background()
@@ -262,6 +273,11 @@ func TestManagerWithStorage_AuditTrail(t *testing.T) {
 		storageManager.GetClientTenantStore(),
 		storageManager.GetRBACStore(),
 	)
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_ = manager.Close(ctx)
+	})
 	require.NotNil(t, manager)
 
 	ctx := context.Background()

--- a/features/rbac/manager_test.go
+++ b/features/rbac/manager_test.go
@@ -5,6 +5,7 @@ package rbac
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -29,6 +30,11 @@ func TestManager_Initialize(t *testing.T) {
 		storageManager.GetClientTenantStore(),
 		storageManager.GetRBACStore(),
 	)
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_ = manager.Close(ctx)
+	})
 	ctx := context.Background()
 
 	err = manager.Initialize(ctx)
@@ -69,6 +75,11 @@ func TestManager_CreateTenantDefaultRoles(t *testing.T) {
 		storageManager.GetClientTenantStore(),
 		storageManager.GetRBACStore(),
 	)
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_ = manager.Close(ctx)
+	})
 	ctx := context.Background()
 
 	err = manager.Initialize(ctx)
@@ -108,6 +119,11 @@ func TestManager_SubjectManagement(t *testing.T) {
 		storageManager.GetClientTenantStore(),
 		storageManager.GetRBACStore(),
 	)
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_ = manager.Close(ctx)
+	})
 	ctx := context.Background()
 
 	err = manager.Initialize(ctx)
@@ -171,6 +187,11 @@ func TestManager_RoleAssignment(t *testing.T) {
 		storageManager.GetClientTenantStore(),
 		storageManager.GetRBACStore(),
 	)
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_ = manager.Close(ctx)
+	})
 	ctx := context.Background()
 
 	err = manager.Initialize(ctx)
@@ -235,6 +256,11 @@ func TestManager_PermissionChecking(t *testing.T) {
 		storageManager.GetClientTenantStore(),
 		storageManager.GetRBACStore(),
 	)
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_ = manager.Close(ctx)
+	})
 	ctx := context.Background()
 
 	err = manager.Initialize(ctx)
@@ -321,6 +347,11 @@ func TestManager_SystemAdminPermissions(t *testing.T) {
 		storageManager.GetClientTenantStore(),
 		storageManager.GetRBACStore(),
 	)
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_ = manager.Close(ctx)
+	})
 	ctx := context.Background()
 
 	err = manager.Initialize(ctx)
@@ -386,6 +417,11 @@ func TestManager_CreateStewardSubject(t *testing.T) {
 		storageManager.GetClientTenantStore(),
 		storageManager.GetRBACStore(),
 	)
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_ = manager.Close(ctx)
+	})
 	ctx := context.Background()
 
 	err = manager.Initialize(ctx)
@@ -444,6 +480,11 @@ func TestManager_InactiveSubjectPermissions(t *testing.T) {
 		storageManager.GetClientTenantStore(),
 		storageManager.GetRBACStore(),
 	)
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_ = manager.Close(ctx)
+	})
 	ctx := context.Background()
 
 	err = manager.Initialize(ctx)


### PR DESCRIPTION
Fixes #848.

## Summary

`TestManager_CreateStewardSubject` had a flaky cleanup race where the audit drain goroutine was still writing to files inside `t.TempDir()` when Go's test runner tried to remove the directory, producing intermittent "directory not empty" failures on Linux, macOS, and Windows CI runners.

## Root cause

`audit.Manager` runs a background drain goroutine to flush queued audit entries. RBAC tests constructed the manager but never stopped that goroutine before `t.TempDir()` cleanup ran. On slower filesystems the goroutine would still be holding SQLite file handles when RemoveAll started, and on Windows the DLL-style open-file lock made removal fail outright.

## Fix

- `features/rbac/manager.go` adds `Manager.Close(ctx)` which delegates to `audit.Manager.Stop(ctx)`. `Stop` is idempotent via `sync.Once`, flushes pending entries, and waits for the drain goroutine to exit before returning.
- Every RBAC test that constructs a `Manager` with `t.TempDir()`-backed storage now registers `t.Cleanup(func() { _ = manager.Close(ctx) })`. `t.Cleanup` runs LIFO, so the audit drain is shut down before the underlying storage cleanup or the `TempDir` RemoveAll.
- Root-cause documentation is captured in a code comment directly above `Manager.Close` for future maintainers.

## Secondary test-hygiene fixes (surfaced during story-complete validation)

Two unrelated tests were writing SQLite databases to persistent paths outside `t.TempDir()`. When an earlier schema migration added `audit_entries.sequence_number`, old on-disk databases broke fresh test runs with `no such column: sequence_number`.

- `features/controller/controller_test.go`: four test spots were setting `cfg.Storage.Config["repository_path"]` (a key the code doesn't read). They now set `cfg.Storage.FlatfileRoot` and `cfg.Storage.SQLitePath` to `t.TempDir()`-scoped paths.
- `features/controller/server/server_security_test.go`: `createDockerTestStorageConfig` was using `os.TempDir()`. It now takes `*testing.T` and uses `t.TempDir()`.

Both violated CLAUDE.md's "never write to repo root — use `t.TempDir()`" rule and were thematically aligned with the #848 fix.

## Acceptance criteria

- [x] `TestManager_CreateStewardSubject` passes 100 consecutive `-race` runs on Linux (verified locally: 100/100 pass in 51.8s). macOS/Windows covered by CI matrix.
- [x] Root cause documented in a code comment above `Manager.Close` (see `features/rbac/manager.go`).
- [x] No new `t.Skip()` introduced (`git diff` confirms zero additions).

## Test plan

- [x] `make test` (unit tests + race detection)
- [x] `make lint` (gofmt + golangci-lint clean)
- [x] `make check-architecture` (no central provider violations)
- [x] `make security-scan` (Trivy, Nancy, gosec, staticcheck all clean)
- [x] `go test -race -count=100 -run TestManager_CreateStewardSubject ./features/rbac/...` — 100/100 pass
- [x] Adversarial review team (qa-code-reviewer + security-engineer): 0 blocking issues
- [ ] CI required checks (unit-tests, integration-tests, Build Gate, security-deployment-gate)

## Commits

- `e8f8723f` rbac: add Manager.Close to shut down audit drain goroutine before TempDir cleanup
- `375c09c6` rbac: address qa-code-reviewer findings from #848 story-complete review
- `85abe053` test: fix controller tempdir violation and gofmt audit_integration_test
- `4d2c00c8` test: scope docker test storage paths to t.TempDir

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>