### PR TITLE
tooling: PO cycle preflight + one-approval action wrappers

### DIFF
--- a/.claude/agents/po.md
+++ b/.claude/agents/po.md
@@ -215,21 +215,38 @@ Analyze pipeline state and recommend the single most valuable action.
 
 ## 4. Pipeline Cycle
 
-Run the full autonomous pipeline cycle once. Use when the founder says "cron", "run cycle", "run pipeline", or via `/loop 1h /po cron`.
+Run the full autonomous pipeline cycle once. Use when the founder says "cron", "run cycle", "run pipeline", or via `/loop 20m /po cron`.
 
 This runs **locally** with full Docker access for dispatch and fix cycles. The remote `po-cron` trigger runs the same logic but creates `pipeline:blocked` for Docker-dependent steps (3 and 4) since it has no Docker access.
 
-### 4.0 Pre-Flight: Idle Check
+### Helper scripts (prefer these — one approval per action, no `/tmp` writes)
 
-Before running the cycle, check for actionable work. Run all queries in parallel:
+- `./.claude/scripts/po-act.sh <subcommand>` — every common action is a one-liner:
+  - `preflight` — gather state; writes `~/.cache/cfgms-po/preflight.json`, prints summary
+  - `state [jq_filter]` — read cached state with optional jq filter
+  - `dispatch <STORY>` — check-conflicts + clone + launch + label swap
+  - `dispatch-fix <PR>` — clean stale container + clone-pr + launch-generic
+  - `close-merged <ISSUE> <PR>` — close + clear stale `agent:*` labels (for PRs that missed `Fixes #NNN`)
+  - `enqueue <PR>` / `dequeue <PR>` — merge queue management
+  - `diagnose <PR>` — extract FAIL/panic lines from failed CI jobs
+  - `rerun <PR> [comment]` — rerun failed jobs, optionally post audit comment
+  - `log <ISSUE> <text>` — post timestamped session log (stdin if text is `-`)
+  - `merge-queue` — queue state as JSON
+  - `block <ISSUE> <reason>` — escalate to founder with `pipeline:blocked`
+- `./.claude/scripts/po-cycle-preflight.py` — the underlying preflight (called by `po-act.sh preflight`). Accepts `--stdout` for raw JSON or `--path` for the cache path.
+- `./.claude/scripts/agent-dispatch.sh` — lower-level primitives (called by `po-act.sh`)
+
+### 4.0 Pre-Flight
+
 ```bash
-gh issue list --repo cfg-is/cfgms --label "pipeline:epic" --state open --json number,title
-gh issue list --repo cfg-is/cfgms --label "pipeline:draft" --state open --json number,title
-gh issue list --repo cfg-is/cfgms --label "agent:ready" --state open --json number,title
-gh issue list --repo cfg-is/cfgms --label "pipeline:fix" --state open --json number,title
-gh pr list --repo cfg-is/cfgms --search "head:feature/story-" --state open --json number,title,headRefName
+./.claude/scripts/po-act.sh preflight
 ```
-If ALL queries return empty: report "No actionable work — skipping cycle" and exit.
+
+Emits a compact summary (counts, running containers, merge queue, recommendations). Full JSON cached at `~/.cache/cfgms-po/preflight.json` for further `po-act.sh state '.some.jq.filter'` queries.
+
+If `.counts.ready == 0` AND `.counts.open_pr == 0` AND `.pipeline_state.fix_cycle | length == 0`: report "No actionable work — skipping cycle" and exit.
+
+The preflight handles all label queries, PR CI summaries, merge queue state, and dispatch/review recommendations in one ~3-second call. Read `dispatch_recommendations` and `review_recommendations` to decide actions. Raw section text (`deps_raw`, `files_raw`) is included so the LLM can override any recommendation.
 
 ### 4.1 Processing Order
 
@@ -255,28 +272,19 @@ The Tech Lead agent (`.claude/agents/tech-lead.md`) validates dependency orderin
 **Step 3 — Dispatch:**
 Find `agent:ready` issues without `agent:in-progress`. Before dispatching, check for file conflicts with in-flight agents:
 
-1. **Dependency gate:** Extract `## Dependencies` from the story body. For each referenced issue number (`#NNN`), check its state:
-   ```bash
-   gh issue view <DEP_NUM> --repo cfg-is/cfgms --json state -q .state
-   ```
-   If ANY dependency is not `CLOSED`, **skip dispatch** — leave the story as `agent:ready`. It will be picked up in a future cycle after the dependency merges and closes.
-2. **File conflict gate:** Extract `## Files In Scope` from the story body. For each `agent:in-progress` story, extract the same section. If any ready story shares files with an in-progress story, **skip dispatch** — leave it as `agent:ready` until the conflicting story merges.
+Both gates are computed by the preflight script (`dispatch_recommendations` with `action: "dispatch"` vs `"hold"` and a `reason` string). Trust its recommendation by default, override only if `parse_warnings` are non-empty on the story.
 
-For stories that pass conflict checks:
+For each story the preflight recommends dispatching:
 ```bash
-./.claude/scripts/agent-dispatch.sh check-conflicts <NUM>
-./.claude/scripts/agent-dispatch.sh create-clone <NUM>
-./.claude/scripts/agent-dispatch.sh launch <NUM>
-gh issue edit <NUM> --remove-label "agent:ready" --add-label "agent:in-progress"
+./.claude/scripts/po-act.sh dispatch <NUM>
 ```
 
 **Step 4 — Fix cycle:**
-Find stories with `pipeline:fix` label. Dispatch fix agent via:
+For each `pipeline:fix` story, find its PR and dispatch the fix agent in one call:
 ```bash
-gh pr list --repo cfg-is/cfgms --search "head:feature/story-<NUM>" --json number -q '.[0].number'
-./.claude/scripts/agent-dispatch.sh create-clone-pr <PR_NUM>
-./.claude/scripts/agent-dispatch.sh launch-generic cfg-agent-pr-fix-<PR_NUM> <clone_dir> --fix-pr <PR_NUM>
+./.claude/scripts/po-act.sh dispatch-fix <PR_NUM>
 ```
+This cleans any stale container from a prior failed attempt, re-clones, and launches.
 
 **Step 5 — QA pass (Acceptance Reviewer) — FIFO order:**
 Find agent PRs (branch `feature/story-*`) without Acceptance Reviewer comment, sorted by creation timestamp ascending (oldest first). FIFO order minimizes rebase churn: the oldest PR was based on the earliest develop snapshot, so it has the fewest accumulated conflicts. Once it lands, the next-oldest only needs to rebase against one new merge instead of an arbitrary set.
@@ -294,7 +302,7 @@ Process PRs **serially in FIFO order** (do not spawn reviewers in parallel — p
 3. **Wait for the reviewer to complete** before spawning the next one. This ensures merges happen in FIFO order and the next PR in the queue is reviewed against an up-to-date develop.
 
 The Acceptance Reviewer (`.claude/agents/acceptance-reviewer.md`) verifies CI, checks acceptance criteria against the diff, and renders a verdict:
-- Zero findings: auto-merge via `gh pr merge --squash --auto`, clean up container/worktree
+- Zero findings: enqueue via `gh pr merge <PR_NUM> --squash` (merge queue handles rebase + re-validation), clean up container/worktree
 - Any findings (first review): apply `pipeline:fix` to story, post review comment on PR
 - Any findings (second review): apply `pipeline:blocked`, assign to founder
 

--- a/.claude/scripts/po-act.sh
+++ b/.claude/scripts/po-act.sh
@@ -1,0 +1,220 @@
+#!/usr/bin/env bash
+# po-act.sh — bundle common PO cycle actions into single invocations so each
+# is one approvable command. Companion to po-cycle-preflight.py.
+#
+# All actions target the cfg-is/cfgms repo and the develop branch queue.
+#
+# Subcommands:
+#   dispatch <STORY_NUM>            Fresh story: check-conflicts + clone + launch + label swap
+#   dispatch-fix <PR_NUM>           Fix cycle: remove stale container + clone-pr + launch
+#   close-merged <ISSUE> <PR>       Close issue that didn't auto-close after PR merge
+#   enqueue <PR_NUM>                Add PR to merge queue (no strategy flag)
+#   dequeue <PR_NUM>                Remove PR from merge queue
+#   diagnose <PR_NUM>               Extract FAIL/panic lines from PR's failed CI jobs
+#   rerun <PR_NUM> [comment_body]   Rerun failed CI jobs; optional audit comment
+#   log <ISSUE_OR_EPIC> <text>      Post timestamped session log (reads stdin if text is -)
+#   merge-queue                     Emit current queue state as JSON
+#   block <ISSUE> <reason>          Apply pipeline:blocked, clear other labels, post escalation
+#   unblock <ISSUE> <reason> [--as-fix]  Remove pipeline:blocked, optionally add pipeline:fix
+#   preflight                       Run preflight (writes ~/.cache/cfgms-po/preflight.json, prints summary)
+#   state [jq_filter]               Read cached preflight and apply optional jq filter
+
+set -euo pipefail
+
+REPO="cfg-is/cfgms"
+WORKTREE_BASE="$(cd "$(dirname "$0")/../.." && pwd)/../worktrees"
+WORKTREE_BASE="$(cd "$WORKTREE_BASE" 2>/dev/null && pwd || echo "/home/jrdn/git/cfg.is/worktrees")"
+DISPATCH="$(dirname "$0")/agent-dispatch.sh"
+PREFLIGHT="$(dirname "$0")/po-cycle-preflight.py"
+
+# Cache path (matches po-cycle-preflight.py defaults). No /tmp writes.
+if [ -n "${PO_CACHE_DIR:-}" ]; then
+  CACHE_DIR="$PO_CACHE_DIR"
+elif [ -n "${XDG_CACHE_HOME:-}" ]; then
+  CACHE_DIR="$XDG_CACHE_HOME/cfgms-po"
+else
+  CACHE_DIR="$HOME/.cache/cfgms-po"
+fi
+CACHE_FILE="$CACHE_DIR/preflight.json"
+
+cmd="${1:-}"
+shift || true
+
+case "$cmd" in
+  dispatch)
+    story="${1:?story number required}"
+    "$DISPATCH" check-conflicts "$story" >/dev/null
+    "$DISPATCH" create-clone "$story" | tail -1
+    "$DISPATCH" launch "$story" | tail -1
+    gh issue edit "$story" --repo "$REPO" \
+      --remove-label "agent:ready" --add-label "agent:in-progress" >/dev/null
+    echo "DISPATCHED:$story"
+    ;;
+
+  dispatch-fix)
+    pr="${1:?PR number required}"
+    container="cfg-agent-pr-fix-${pr}"
+    # Remove any stale exited container from a previous attempt
+    docker rm -f "$container" >/dev/null 2>&1 || true
+    # Remove any stale worktree directory
+    rm -rf "${WORKTREE_BASE}/pr-fix-${pr}" 2>/dev/null || true
+    "$DISPATCH" create-clone-pr "$pr" | tail -1
+    "$DISPATCH" launch-generic "$container" "${WORKTREE_BASE}/pr-fix-${pr}" --fix-pr "$pr" | tail -1
+    echo "DISPATCHED_FIX:$pr"
+    ;;
+
+  close-merged)
+    issue="${1:?issue number required}"
+    pr="${2:?PR number required}"
+    msg="Closed by merged PR #${pr}. PR body was missing the \`Fixes #${issue}\` keyword so GitHub did not auto-close."
+    gh issue close "$issue" --repo "$REPO" --comment "$msg" >/dev/null
+    # Remove stale agent labels if present; ignore failures
+    for lbl in "agent:failed" "agent:success" "agent:in-progress"; do
+      gh issue edit "$issue" --repo "$REPO" --remove-label "$lbl" >/dev/null 2>&1 || true
+    done
+    echo "CLOSED:$issue via PR #$pr"
+    ;;
+
+  enqueue)
+    pr="${1:?PR number required}"
+    gh pr merge "$pr" --repo "$REPO" --squash >/dev/null 2>&1 || {
+      # "already queued" is success for our purposes
+      gh pr merge "$pr" --repo "$REPO" --squash 2>&1 | grep -qi "already queued" && {
+        echo "ALREADY_QUEUED:$pr"; exit 0;
+      }
+      echo "ENQUEUE_FAILED:$pr" >&2; exit 1;
+    }
+    echo "ENQUEUED:$pr"
+    ;;
+
+  dequeue)
+    pr="${1:?PR number required}"
+    pr_id=$(gh pr view "$pr" --repo "$REPO" --json id -q .id)
+    gh api graphql \
+      -f query='mutation($prId: ID!) { dequeuePullRequest(input: {id: $prId}) { mergeQueueEntry { state } } }' \
+      -F prId="$pr_id" >/dev/null
+    echo "DEQUEUED:$pr"
+    ;;
+
+  diagnose)
+    pr="${1:?PR number required}"
+    job_ids=$(gh pr view "$pr" --repo "$REPO" --json statusCheckRollup \
+      -q '.statusCheckRollup[]? | select(.conclusion == "FAILURE") | .detailsUrl' \
+      | grep -oE '/job/[0-9]+' | grep -oE '[0-9]+' | sort -u)
+    if [ -z "$job_ids" ]; then
+      echo "no_failing_jobs"
+      exit 0
+    fi
+    for jid in $job_ids; do
+      echo "=== job $jid ==="
+      gh api "repos/${REPO}/actions/jobs/${jid}/logs" 2>/dev/null \
+        | grep -iE "^\S+Z (--- FAIL|FAIL\s|panic:|Error:)" \
+        | head -15 || true
+    done
+    ;;
+
+  rerun)
+    pr="${1:?PR number required}"
+    comment="${2:-}"
+    run_ids=$(gh pr view "$pr" --repo "$REPO" --json statusCheckRollup \
+      -q '.statusCheckRollup[]? | select(.conclusion == "FAILURE") | .detailsUrl' \
+      | grep -oE '/runs/[0-9]+' | grep -oE '[0-9]+' | sort -u)
+    if [ -z "$run_ids" ]; then
+      echo "no_failing_runs"
+      exit 0
+    fi
+    for rid in $run_ids; do
+      gh run rerun --repo "$REPO" "$rid" --failed >/dev/null 2>&1 || true
+      echo "RERUN:$rid"
+    done
+    if [ -n "$comment" ]; then
+      printf '%s\n' "$comment" | gh pr comment "$pr" --repo "$REPO" --body-file - >/dev/null
+      echo "COMMENT_POSTED:$pr"
+    fi
+    ;;
+
+  log)
+    target="${1:?issue/epic number required}"
+    body="${2:?message required (use - to read stdin)}"
+    ts=$(date -u +"%Y-%m-%d %H:%MZ")
+    if [ "$body" = "-" ]; then
+      body=$(cat)
+    fi
+    printf '## PO cycle — %s\n\n%s\n' "$ts" "$body" \
+      | gh issue comment "$target" --repo "$REPO" --body-file - >/dev/null
+    echo "LOGGED:$target"
+    ;;
+
+  merge-queue)
+    gh api graphql \
+      -f query='query { repository(owner: "cfg-is", name: "cfgms") { mergeQueue(branch: "develop") { entries(first: 50) { nodes { position state enqueuedAt pullRequest { number title } } } } } }' \
+      -q '.data.repository.mergeQueue.entries.nodes'
+    ;;
+
+  preflight)
+    # Run preflight; it writes full JSON to CACHE_FILE and prints summary to stdout
+    "$PREFLIGHT"
+    ;;
+
+  state)
+    # Usage: po-act.sh state [jq_filter]
+    # Apply jq filter to cached preflight JSON. Default filter: full summary.
+    filter="${1:-.}"
+    if [ ! -f "$CACHE_FILE" ]; then
+      echo "ERROR: cache file not found: $CACHE_FILE" >&2
+      echo "Run: $0 preflight" >&2
+      exit 1
+    fi
+    jq "$filter" "$CACHE_FILE"
+    ;;
+
+  block)
+    # Usage: po-act.sh block <ISSUE_NUM> <reason>
+    # Applies pipeline:blocked label, assigns to founder, posts escalation comment.
+    # Removes pipeline:fix and agent:* labels to clear the state.
+    issue="${1:?issue number required}"
+    reason="${2:?reason required (use - to read stdin)}"
+    ts=$(date -u +"%Y-%m-%d %H:%MZ")
+    if [ "$reason" = "-" ]; then
+      reason=$(cat)
+    fi
+    body=$(printf '## Pipeline blocked — %s\n\n%s\n\n_Escalated to founder by PO cycle._\n' "$ts" "$reason")
+    # Clear contradicting labels
+    for lbl in "pipeline:fix" "agent:failed" "agent:in-progress" "agent:success"; do
+      gh issue edit "$issue" --repo "$REPO" --remove-label "$lbl" >/dev/null 2>&1 || true
+    done
+    gh issue edit "$issue" --repo "$REPO" --add-label "pipeline:blocked" >/dev/null
+    printf '%s\n' "$body" | gh issue comment "$issue" --repo "$REPO" --body-file - >/dev/null
+    echo "BLOCKED:$issue"
+    ;;
+
+  unblock)
+    # Usage: po-act.sh unblock <ISSUE_NUM> <reason> [--as-fix]
+    # Removes pipeline:blocked, optionally re-applies pipeline:fix, posts resolution comment.
+    issue="${1:?issue number required}"
+    reason="${2:?reason required (use - to read stdin)}"
+    mode="${3:-}"
+    ts=$(date -u +"%Y-%m-%d %H:%MZ")
+    if [ "$reason" = "-" ]; then
+      reason=$(cat)
+    fi
+    body=$(printf '## Pipeline unblocked — %s\n\n%s\n' "$ts" "$reason")
+    gh issue edit "$issue" --repo "$REPO" --remove-label "pipeline:blocked" >/dev/null 2>&1 || true
+    if [ "$mode" = "--as-fix" ]; then
+      gh issue edit "$issue" --repo "$REPO" --add-label "pipeline:fix" >/dev/null
+    fi
+    printf '%s\n' "$body" | gh issue comment "$issue" --repo "$REPO" --body-file - >/dev/null
+    echo "UNBLOCKED:$issue${mode:+ ($mode)}"
+    ;;
+
+  ""|-h|--help|help)
+    sed -n '/^# po-act.sh/,/^$/p' "$0" | sed 's/^# \{0,1\}//'
+    [ "$cmd" = "" ] && exit 2 || exit 0
+    ;;
+
+  *)
+    echo "Unknown subcommand: $cmd" >&2
+    echo "Run '$0 help' for usage" >&2
+    exit 2
+    ;;
+esac

--- a/.claude/scripts/po-cycle-preflight.py
+++ b/.claude/scripts/po-cycle-preflight.py
@@ -1,0 +1,683 @@
+#!/usr/bin/env python3
+"""
+po-cycle-preflight: Gather pipeline state and cache it for the PO cron cycle.
+
+Default: writes full JSON to a cache file under $HOME (no /tmp writes needed)
+and prints a short summary to stdout. The cache path is auto-discovered from:
+  1. $PO_CACHE_DIR (explicit override)
+  2. $XDG_CACHE_HOME/cfgms-po/
+  3. $HOME/.cache/cfgms-po/
+
+Flags:
+  --stdout / -s    Print full JSON to stdout, skip cache file
+  --path           Print the cache file path only (useful for jq piping)
+
+Design: the LLM is the decision-maker. This script is a cache + pre-filter. It
+emits raw section text alongside parsed data so the LLM can re-check anything
+suspicious, and flags degraded state explicitly rather than silently miscounting.
+
+Exits non-zero only on fatal infra errors. Partial failures set degraded=true
+but still exit 0 with best-effort output.
+"""
+
+import json
+import os
+import re
+import subprocess
+import sys
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from datetime import datetime, timezone
+from pathlib import Path
+
+REPO = "cfg-is/cfgms"
+
+LABELS_TO_QUERY = [
+    "pipeline:epic",
+    "pipeline:draft",
+    "agent:ready",
+    "pipeline:fix",
+    "agent:in-progress",
+    "agent:failed",
+    "pipeline:blocked",
+]
+
+SECTION_RE = re.compile(r"(?m)^##\s+(.+?)\s*$")
+ISSUE_NUM_RE = re.compile(r"#(\d+)")
+BACKTICK_PATH_RE = re.compile(
+    r"`([^`\n]+?\.(?:go|md|proto|sh|yaml|yml|json|toml|ts|tsx))`"
+)
+BARE_PATH_RE = re.compile(
+    r"(?:^|[\s(\[])"
+    r"([a-zA-Z0-9_./-]+/[a-zA-Z0-9_./-]+\.(?:go|md|proto|sh|yaml|yml|json|toml|ts|tsx))"
+)
+BRANCH_STORY_RE = re.compile(r"feature/story-(\d+)")
+
+
+def cache_dir():
+    """Auto-discover a cache directory under $HOME so we don't hit /tmp."""
+    override = os.environ.get("PO_CACHE_DIR")
+    if override:
+        return Path(override)
+    xdg = os.environ.get("XDG_CACHE_HOME")
+    if xdg:
+        return Path(xdg) / "cfgms-po"
+    return Path.home() / ".cache" / "cfgms-po"
+
+
+CACHE_FILE_NAME = "preflight.json"
+
+
+def gh(*args, check=True):
+    """Run gh and return parsed JSON. Raises RuntimeError on failure when check=True."""
+    result = subprocess.run(
+        ["gh", *args], capture_output=True, text=True, check=False, timeout=60
+    )
+    if result.returncode != 0:
+        if check:
+            raise RuntimeError(
+                f"gh {' '.join(args[:4])}... failed (rc={result.returncode}): "
+                f"{result.stderr.strip()[:500]}"
+            )
+        return None
+    if not result.stdout.strip():
+        return None
+    try:
+        return json.loads(result.stdout)
+    except json.JSONDecodeError:
+        return result.stdout
+
+
+def gh_issue_list(label):
+    return gh(
+        "issue", "list",
+        "--repo", REPO,
+        "--label", label,
+        "--state", "open",
+        "--json", "number,title",
+        "--limit", "200",
+    )
+
+
+def gh_issue_body(number):
+    return gh(
+        "issue", "view", str(number),
+        "--repo", REPO,
+        "--json", "number,title,body,state,labels",
+    )
+
+
+def gh_issue_state(number):
+    data = gh(
+        "issue", "view", str(number),
+        "--repo", REPO,
+        "--json", "state",
+        check=False,
+    )
+    if data is None:
+        return None
+    return data.get("state")
+
+
+def gh_pr_list_story_prs():
+    return gh(
+        "pr", "list",
+        "--repo", REPO,
+        "--search", "head:feature/story-",
+        "--state", "open",
+        "--json", "number,title,headRefName,labels,comments,statusCheckRollup,mergeStateStatus,mergeable,autoMergeRequest",
+        "--limit", "50",
+    )
+
+
+def gh_graphql_epic_summary():
+    query = (
+        "query { repository(owner: \"cfg-is\", name: \"cfgms\") { "
+        "issues(first: 100, labels: [\"pipeline:epic\"], states: OPEN) { "
+        "nodes { number title subIssuesSummary { total completed } } } } }"
+    )
+    data = gh("api", "graphql", "-f", f"query={query}")
+    try:
+        return data["data"]["repository"]["issues"]["nodes"]
+    except (KeyError, TypeError):
+        return []
+
+
+def gh_graphql_merge_queue():
+    """Return list of {pr_number, position, state, enqueued_at} for PRs in develop's merge queue."""
+    query = (
+        "query { repository(owner: \"cfg-is\", name: \"cfgms\") { "
+        "mergeQueue(branch: \"develop\") { entries(first: 50) { "
+        "nodes { position state enqueuedAt pullRequest { number } } } } } }"
+    )
+    data = gh("api", "graphql", "-f", f"query={query}", check=False)
+    if not data:
+        return []
+    try:
+        nodes = data["data"]["repository"]["mergeQueue"]["entries"]["nodes"]
+    except (KeyError, TypeError):
+        return []
+    return [
+        {
+            "pr_number": n["pullRequest"]["number"],
+            "position": n["position"],
+            "state": n["state"],
+            "enqueued_at": n["enqueuedAt"],
+        }
+        for n in (nodes or [])
+        if n.get("pullRequest")
+    ]
+
+
+def running_containers():
+    """Return list of running cfg-agent-* container names, or None if docker unavailable."""
+    try:
+        result = subprocess.run(
+            ["docker", "ps", "--filter", "name=cfg-agent-", "--format", "{{.Names}}"],
+            capture_output=True, text=True, check=True, timeout=10,
+        )
+        return [n for n in result.stdout.splitlines() if n.strip()]
+    except (subprocess.CalledProcessError, subprocess.TimeoutExpired, FileNotFoundError):
+        return None
+
+
+def extract_section(body, section_name):
+    """Extract text under `## <section_name>` until the next `## ` or EOF."""
+    if not body:
+        return None
+    headers = list(SECTION_RE.finditer(body))
+    for i, m in enumerate(headers):
+        if m.group(1).strip().lower() == section_name.lower():
+            start = m.end()
+            end = headers[i + 1].start() if i + 1 < len(headers) else len(body)
+            return body[start:end].strip()
+    return None
+
+
+def parse_story(issue):
+    """Parse a story into structured dispatch-gating data.
+
+    Emits both parsed fields AND raw section text / loose-regex diagnostic fields
+    so the LLM can override if parsing missed something.
+    """
+    body = issue.get("body") or ""
+    number = issue["number"]
+    warnings = []
+
+    deps_raw = extract_section(body, "Dependencies")
+    files_raw = extract_section(body, "Files In Scope")
+
+    deps_parsed = []
+    if deps_raw is None:
+        warnings.append("no '## Dependencies' section found")
+    elif deps_raw.strip().lower() in ("", "none", "none.", "n/a"):
+        pass
+    else:
+        deps_parsed = sorted(
+            {int(n) for n in ISSUE_NUM_RE.findall(deps_raw) if int(n) != number}
+        )
+        if not deps_parsed:
+            warnings.append("'## Dependencies' section had content but no #NNN references found")
+
+    files_parsed = []
+    if files_raw is None:
+        warnings.append("no '## Files In Scope' section found")
+    else:
+        backtick_hits = set(BACKTICK_PATH_RE.findall(files_raw))
+        bare_hits = set(BARE_PATH_RE.findall(files_raw))
+        files_parsed = sorted(backtick_hits | bare_hits)
+        if not files_parsed:
+            warnings.append("'## Files In Scope' section had content but no file paths detected")
+
+    all_nums = sorted({int(n) for n in ISSUE_NUM_RE.findall(body) if int(n) != number})
+    all_paths = sorted(set(BACKTICK_PATH_RE.findall(body)) | set(BARE_PATH_RE.findall(body)))
+
+    return {
+        "number": number,
+        "title": issue.get("title", ""),
+        "parse_ok": len(warnings) == 0,
+        "parse_warnings": warnings,
+        "deps_parsed": deps_parsed,
+        "deps_raw": deps_raw,
+        "files_parsed": files_parsed,
+        "files_raw": files_raw,
+        "all_issue_numbers_in_body": all_nums,
+        "all_paths_in_body": all_paths,
+    }
+
+
+def ci_summary(checks):
+    """Summarize a PR's statusCheckRollup into pass/pending/fail counts + overall verdict."""
+    pass_count = pending_count = fail_count = skipped_count = 0
+    pending_names = []
+    failed_names = []
+    for c in checks or []:
+        status = (c.get("status") or "").upper()
+        conclusion = (c.get("conclusion") or "").upper()
+        name = c.get("name", "?")
+        if status in ("IN_PROGRESS", "QUEUED", "PENDING") or (not status and not conclusion):
+            pending_count += 1
+            pending_names.append(name)
+        elif conclusion == "SUCCESS":
+            pass_count += 1
+        elif conclusion in ("FAILURE", "TIMED_OUT", "CANCELLED", "ACTION_REQUIRED"):
+            fail_count += 1
+            failed_names.append(name)
+        elif conclusion in ("SKIPPED", "NEUTRAL"):
+            skipped_count += 1
+        else:
+            pending_count += 1
+            pending_names.append(f"{name}(unknown:{status}/{conclusion})")
+
+    if fail_count > 0:
+        overall = "red"
+    elif pending_count > 0:
+        overall = "pending"
+    else:
+        overall = "green"
+
+    return {
+        "pass": pass_count,
+        "pending": pending_count,
+        "fail": fail_count,
+        "skipped": skipped_count,
+        "overall": overall,
+        "pending_checks": pending_names,
+        "failed_checks": failed_names,
+    }
+
+
+def compute_dispatch_recommendations(ready_stories, active_stories, dep_states):
+    """Greedy conflict-free selection.
+
+    Order: ascending story number (stable, predictable).
+    Skip if any dep is not CLOSED.
+    Skip if files overlap with an active story (agent:in-progress or open PR) or a
+    story already picked this cycle.
+    """
+    active_file_sets = [
+        (s["number"], set(s["files_parsed"])) for s in active_stories
+    ]
+
+    recommendations = []
+    picked_file_sets = []
+
+    for s in sorted(ready_stories, key=lambda x: x["number"]):
+        num = s["number"]
+        open_deps = [d for d in s["deps_parsed"] if dep_states.get(d) != "CLOSED"]
+        if open_deps:
+            dep_desc = ", ".join(
+                f"#{d}({dep_states.get(d, 'UNKNOWN')})" for d in open_deps
+            )
+            recommendations.append({
+                "number": num,
+                "action": "hold",
+                "reason": f"deps not closed: {dep_desc}",
+            })
+            continue
+
+        my_files = set(s["files_parsed"])
+        if not my_files:
+            recommendations.append({
+                "number": num,
+                "action": "dispatch",
+                "reason": "deps clear; no files parsed from Files In Scope",
+                "caveat": "no_files_parsed_cannot_check_conflicts — LLM should verify manually",
+            })
+            picked_file_sets.append((num, set()))
+            continue
+
+        active_hit = next(
+            ((n, my_files & f) for n, f in active_file_sets if my_files & f),
+            None,
+        )
+        if active_hit:
+            n, shared = active_hit
+            recommendations.append({
+                "number": num,
+                "action": "hold",
+                "reason": f"file-conflict with active #{n} (in-progress or open PR) on: {', '.join(sorted(shared))}",
+            })
+            continue
+
+        picked_hit = next(
+            ((n, my_files & f) for n, f in picked_file_sets if my_files & f),
+            None,
+        )
+        if picked_hit:
+            n, shared = picked_hit
+            recommendations.append({
+                "number": num,
+                "action": "hold",
+                "reason": f"file-conflict with dispatch-candidate #{n} on: {', '.join(sorted(shared))}",
+            })
+            continue
+
+        recommendations.append({
+            "number": num,
+            "action": "dispatch",
+            "reason": "deps clear; no file overlap with in-progress or dispatch set",
+        })
+        picked_file_sets.append((num, my_files))
+
+    return recommendations
+
+
+def compute_review_recommendations(pr_summaries, queued_pr_numbers):
+    recs = []
+    for pr in pr_summaries:
+        overall = pr["ci_summary"]["overall"]
+        if pr["has_acceptance_review_comment"]:
+            # Review done. Flag as stuck if CI green + mergeable but not in queue
+            # and not already auto-merge-enabled (the two "enqueued" signals).
+            in_queue = pr["pr"] in queued_pr_numbers
+            if (
+                overall == "green"
+                and pr.get("mergeable") == "MERGEABLE"
+                and not pr.get("auto_merge_enabled")
+                and not in_queue
+            ):
+                recs.append({
+                    "pr": pr["pr"],
+                    "story": pr["story_number"],
+                    "action": "enqueue_merge",
+                    "reason": "reviewed + CI green + mergeable but not in merge queue — run `gh pr merge <N> --squash`",
+                })
+            else:
+                reason = "acceptance review comment already present"
+                if in_queue:
+                    reason += " (PR currently in merge queue)"
+                elif pr.get("auto_merge_enabled"):
+                    reason += " (auto-merge armed, awaiting CI)"
+                recs.append({
+                    "pr": pr["pr"],
+                    "story": pr["story_number"],
+                    "action": "skip",
+                    "reason": reason,
+                })
+        elif overall == "green":
+            recs.append({
+                "pr": pr["pr"],
+                "story": pr["story_number"],
+                "action": "spawn_acceptance_reviewer",
+                "reason": "CI all green; no existing acceptance-review comment",
+            })
+        elif overall == "pending":
+            pending = pr["ci_summary"]["pending_checks"][:3]
+            recs.append({
+                "pr": pr["pr"],
+                "story": pr["story_number"],
+                "action": "defer",
+                "reason": f"CI pending: {', '.join(pending)}",
+            })
+        else:
+            failed = pr["ci_summary"]["failed_checks"][:3]
+            recs.append({
+                "pr": pr["pr"],
+                "story": pr["story_number"],
+                "action": "investigate",
+                "reason": f"CI red: {', '.join(failed)}",
+            })
+    return recs
+
+
+def main():
+    degraded_reasons = []
+    out = {
+        "cycle_generated_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "repo": REPO,
+        "degraded": False,
+        "degraded_reasons": degraded_reasons,
+    }
+
+    # Phase 1: parallel top-level queries
+    with ThreadPoolExecutor(max_workers=12) as ex:
+        label_futures = {ex.submit(gh_issue_list, lbl): lbl for lbl in LABELS_TO_QUERY}
+        pr_future = ex.submit(gh_pr_list_story_prs)
+        epic_future = ex.submit(gh_graphql_epic_summary)
+        queue_future = ex.submit(gh_graphql_merge_queue)
+        container_future = ex.submit(running_containers)
+
+        label_results = {}
+        for fut, lbl in list(label_futures.items()):
+            try:
+                label_results[lbl] = fut.result() or []
+            except Exception as e:
+                degraded_reasons.append(f"gh issue list {lbl} failed: {e}")
+                label_results[lbl] = []
+
+        try:
+            prs = pr_future.result() or []
+        except Exception as e:
+            degraded_reasons.append(f"gh pr list failed: {e}")
+            prs = []
+
+        try:
+            epics_summary = epic_future.result() or []
+        except Exception as e:
+            degraded_reasons.append(f"graphql epic summary failed: {e}")
+            epics_summary = []
+
+        try:
+            merge_queue = queue_future.result() or []
+        except Exception as e:
+            degraded_reasons.append(f"graphql merge queue query failed: {e}")
+            merge_queue = []
+
+        containers = container_future.result()
+        if containers is None:
+            degraded_reasons.append("docker ps unavailable — container list incomplete")
+            containers = []
+
+    out["pipeline_state"] = {
+        "epics_open": label_results["pipeline:epic"],
+        "drafts": label_results["pipeline:draft"],
+        "ready": label_results["agent:ready"],
+        "fix_cycle": label_results["pipeline:fix"],
+        "in_progress": label_results["agent:in-progress"],
+        "failed": label_results["agent:failed"],
+        "blocked": label_results["pipeline:blocked"],
+    }
+    out["running_containers"] = containers
+    out["merge_queue"] = merge_queue
+    queued_pr_numbers = {e["pr_number"] for e in merge_queue}
+
+    out["epics"] = [
+        {
+            "number": e["number"],
+            "title": e["title"],
+            "sub_issues_total": (e.get("subIssuesSummary") or {}).get("total", 0),
+            "sub_issues_completed": (e.get("subIssuesSummary") or {}).get("completed", 0),
+        }
+        for e in epics_summary
+    ]
+    out["epics_undecomposed"] = [e for e in out["epics"] if e["sub_issues_total"] == 0]
+    out["epics_caveat"] = (
+        "sub_issues_total is GitHub sub-issue link count. Stories that reference "
+        "an epic via body-only '## Parent Epic' text will not be counted here. "
+        "Before decomposing, LLM should check story bodies for Parent Epic references."
+    )
+
+    # Phase 2: parallel fetch of story bodies relevant to conflict detection.
+    # Conflict-detection set = agent:in-progress + stories with open PRs (files in flight
+    # until merge). Ready stories are always fetched for gating.
+    ready_nums = [s["number"] for s in label_results["agent:ready"]]
+    in_progress_nums = [s["number"] for s in label_results["agent:in-progress"]]
+    pr_story_nums = []
+    for pr in prs:
+        m = BRANCH_STORY_RE.match(pr.get("headRefName", ""))
+        if m:
+            pr_story_nums.append(int(m.group(1)))
+    active_story_nums = sorted(set(in_progress_nums + pr_story_nums))
+    all_story_nums = sorted(set(ready_nums + active_story_nums))
+
+    story_bodies = {}
+    if all_story_nums:
+        with ThreadPoolExecutor(max_workers=10) as ex:
+            futures = {ex.submit(gh_issue_body, n): n for n in all_story_nums}
+            for fut in as_completed(futures):
+                n = futures[fut]
+                try:
+                    story_bodies[n] = fut.result()
+                except Exception as e:
+                    degraded_reasons.append(f"gh issue view #{n} failed: {e}")
+
+    ready_parsed = [
+        parse_story(story_bodies[n]) for n in ready_nums if n in story_bodies
+    ]
+    in_progress_parsed = [
+        parse_story(story_bodies[n]) for n in in_progress_nums if n in story_bodies
+    ]
+    active_parsed = [
+        parse_story(story_bodies[n]) for n in active_story_nums if n in story_bodies
+    ]
+
+    # Phase 3: fetch states for every unique dep referenced across ready stories
+    dep_nums = set()
+    for s in ready_parsed:
+        dep_nums.update(s["deps_parsed"])
+
+    dep_states = {}
+    if dep_nums:
+        with ThreadPoolExecutor(max_workers=10) as ex:
+            futures = {ex.submit(gh_issue_state, n): n for n in dep_nums}
+            for fut in as_completed(futures):
+                n = futures[fut]
+                try:
+                    state = fut.result()
+                    dep_states[n] = state if state else "UNKNOWN"
+                except Exception as e:
+                    dep_states[n] = "UNKNOWN"
+                    degraded_reasons.append(f"gh issue view #{n} state failed: {e}")
+
+    for s in ready_parsed:
+        s["deps_states"] = {str(d): dep_states.get(d, "UNKNOWN") for d in s["deps_parsed"]}
+
+    out["ready_stories"] = ready_parsed
+    out["in_progress_stories"] = [
+        {
+            "number": s["number"],
+            "title": s["title"],
+            "files_parsed": s["files_parsed"],
+            "parse_warnings": s["parse_warnings"],
+            "source": "agent:in-progress" + (
+                " + open-pr" if s["number"] in pr_story_nums else ""
+            ),
+        }
+        for s in in_progress_parsed
+    ]
+    out["open_pr_stories"] = [
+        {
+            "number": s["number"],
+            "title": s["title"],
+            "files_parsed": s["files_parsed"],
+            "parse_warnings": s["parse_warnings"],
+        }
+        for s in active_parsed
+        if s["number"] in pr_story_nums and s["number"] not in in_progress_nums
+    ]
+
+    # Phase 4: PR summaries
+    pr_summaries = []
+    for pr in prs:
+        head = pr.get("headRefName", "")
+        m = BRANCH_STORY_RE.match(head)
+        story_number = int(m.group(1)) if m else None
+        comments = pr.get("comments") or []
+        has_review_comment = any(
+            "acceptance review" in (c.get("body") or "").lower()
+            for c in comments
+        )
+        pr_summaries.append({
+            "pr": pr["number"],
+            "title": pr.get("title", ""),
+            "head_ref": head,
+            "story_number": story_number,
+            "comment_count": len(comments),
+            "has_acceptance_review_comment": has_review_comment,
+            "merge_state_status": pr.get("mergeStateStatus"),
+            "mergeable": pr.get("mergeable"),
+            "auto_merge_enabled": pr.get("autoMergeRequest") is not None,
+            "ci_summary": ci_summary(pr.get("statusCheckRollup") or []),
+        })
+    out["prs_open"] = pr_summaries
+
+    out["dispatch_recommendations"] = compute_dispatch_recommendations(
+        ready_parsed, active_parsed, dep_states,
+    )
+    out["review_recommendations"] = compute_review_recommendations(
+        pr_summaries, queued_pr_numbers,
+    )
+
+    parse_warning_count = sum(
+        len(s["parse_warnings"]) for s in ready_parsed + in_progress_parsed
+    )
+    if parse_warning_count > 0:
+        degraded_reasons.append(
+            f"{parse_warning_count} parse warnings across story bodies — LLM should inspect *_raw fields"
+        )
+
+    out["degraded"] = len(degraded_reasons) > 0
+
+    return out
+
+
+def write_output(out, mode):
+    """mode: 'stdout' | 'path' | 'cache' (default)."""
+    if mode == "stdout":
+        json.dump(out, sys.stdout, indent=2, default=str)
+        sys.stdout.write("\n")
+        return
+
+    cache = cache_dir()
+    cache.mkdir(parents=True, exist_ok=True)
+    cache_path = cache / CACHE_FILE_NAME
+    cache_path.write_text(json.dumps(out, indent=2, default=str) + "\n")
+
+    if mode == "path":
+        print(cache_path)
+        return
+
+    # Default: emit a short summary to stdout + path reference
+    summary = {
+        "cache_file": str(cache_path),
+        "cycle_generated_at": out["cycle_generated_at"],
+        "degraded": out["degraded"],
+        "degraded_reasons": out["degraded_reasons"],
+        "counts": {
+            "ready": len(out.get("ready_stories", [])),
+            "in_progress": len(out.get("in_progress_stories", [])),
+            "open_pr": len(out.get("open_pr_stories", [])),
+            "running_containers": len(out.get("running_containers", [])),
+            "failed": len(out.get("pipeline_state", {}).get("failed", [])),
+            "blocked": len(out.get("pipeline_state", {}).get("blocked", [])),
+            "merge_queue": len(out.get("merge_queue", [])),
+            "undecomposed_epics": len(out.get("epics_undecomposed", [])),
+        },
+        "running_containers": out.get("running_containers", []),
+        "merge_queue": out.get("merge_queue", []),
+        "dispatch_recommendations": out.get("dispatch_recommendations", []),
+        "review_recommendations": out.get("review_recommendations", []),
+    }
+    json.dump(summary, sys.stdout, indent=2, default=str)
+    sys.stdout.write("\n")
+
+
+if __name__ == "__main__":
+    mode = "cache"
+    for arg in sys.argv[1:]:
+        if arg in ("-s", "--stdout"):
+            mode = "stdout"
+        elif arg == "--path":
+            mode = "path"
+        elif arg in ("-h", "--help"):
+            sys.stdout.write(__doc__)
+            sys.exit(0)
+    try:
+        data = main()
+        write_output(data, mode)
+        sys.exit(0)
+    except RuntimeError as e:
+        sys.stderr.write(f"FATAL: {e}\n")
+        sys.exit(2)
+    except KeyboardInterrupt:
+        sys.exit(130)


### PR DESCRIPTION
## Summary

Consolidate the autonomous PO cycle's recurring operations into single-call invocations so each action is one approvable command instead of 3-4 chained `gh`/`docker`/`git` calls.

## Changes

**New: `.claude/scripts/po-cycle-preflight.py`** (~683 lines)
- Gathers full pipeline state in one ~3s call: label counts, PR CI summaries, dep gates, conflict matrix, merge queue, dispatch/review recommendations.
- Caches to `$HOME/.cache/cfgms-po/` by default (auto-discovered via `$PO_CACHE_DIR` or `$XDG_CACHE_HOME`). **Never writes to `/tmp`** — permissions don't persist across reboots.
- Emits raw section text alongside parsed fields so the LLM can override any recommendation.

**New: `.claude/scripts/po-act.sh`** (~220 lines)
- Bundled subcommands that replace 2-4 chained commands each: `preflight`, `state`, `dispatch`, `dispatch-fix`, `close-merged`, `enqueue`, `dequeue`, `diagnose`, `rerun`, `log`, `merge-queue`, `block`, `unblock`.
- `dispatch-fix` also cleans stale containers/worktrees before relaunching.

**Modified: `.claude/agents/po.md`**
- Lead cron Step 4.0 now uses `po-act.sh preflight` instead of raw `gh` calls.
- References `po-act.sh` subcommands in Steps 3 and 4.

## Rebase notes

Branch was rebased onto current develop; during rebase, three stale `gh pr merge ... --auto` references (a pre-merge-queue pattern from before Issue #801) were updated to `--squash` so the tooling aligns with the current queue behaviour documented in `CLAUDE.md` and `acceptance-reviewer.md`. No `gh pr merge` call remains that would silently close on enqueue.

## Test plan

- [x] `bash -n .claude/scripts/po-act.sh` — syntax OK
- [x] `python3 -m py_compile .claude/scripts/po-cycle-preflight.py` — syntax OK
- [x] Pre-push validation passed (`make test` via git hook)
- [ ] CI required checks (unit-tests, integration-tests, Build Gate, security-deployment-gate)

No Go code changed; this is pure tooling.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>