### PR TITLE
security: fix non-deterministic policy selection causing flaky E2E test (Issue #366)

### DIFF
--- a/features/tenant/security/enhanced_multi_tenant_security_test.go
+++ b/features/tenant/security/enhanced_multi_tenant_security_test.go
@@ -558,6 +558,7 @@ func TestEnhancedMultiTenantSecurity(t *testing.T) {
 			ResourceID:   "patient-data/records",
 			Context: map[string]string{
 				"mfa_verified": "true",
+				"encrypted":    "true",
 			},
 			Permissions: []string{"patient_read"},
 		}

--- a/features/tenant/security/policy_engine.go
+++ b/features/tenant/security/policy_engine.go
@@ -5,6 +5,7 @@ package security
 import (
 	"context"
 	"fmt"
+	"sort"
 	"sync"
 	"time"
 
@@ -317,9 +318,10 @@ func (tspe *TenantSecurityPolicyEngine) CreateSecurityPolicy(ctx context.Context
 		return fmt.Errorf("invalid security policy: %w", err)
 	}
 
-	// Generate ID if not provided
+	// Generate ID if not provided. Use nanosecond precision to ensure uniqueness
+	// even when two policies for the same tenant are created within the same second.
 	if policy.ID == "" {
-		policy.ID = fmt.Sprintf("policy-%s-%d", policy.TenantID, time.Now().Unix())
+		policy.ID = fmt.Sprintf("policy-%s-%d", policy.TenantID, time.Now().UnixNano())
 	}
 
 	// Set timestamps
@@ -393,13 +395,28 @@ func (tspe *TenantSecurityPolicyEngine) evaluateTenantSecurityPolicy(ctx context
 		AppliedRules:   []string{},
 	}
 
-	// Get tenant policy
-	var tenantPolicy *TenantSecurityPolicy
+	// Collect all active policies for this tenant, then select the most recently
+	// created one. Without sorting, Go map iteration is randomized, which causes
+	// non-deterministic policy selection when multiple active policies exist for
+	// the same tenant (e.g. a HIPAA policy created in an earlier test phase and
+	// an E2E policy created in a later phase both targeting client-healthcare).
+	var matchingPolicies []*TenantSecurityPolicy
 	for _, policy := range tspe.policies {
 		if policy.TenantID == request.TenantID && policy.Status == PolicyStatusActive {
-			tenantPolicy = policy
-			break
+			matchingPolicies = append(matchingPolicies, policy)
 		}
+	}
+	// SliceStable with an ID tiebreaker ensures a fully deterministic order
+	// even if two policies share an identical nanosecond CreatedAt timestamp.
+	sort.SliceStable(matchingPolicies, func(i, j int) bool {
+		if matchingPolicies[i].CreatedAt.Equal(matchingPolicies[j].CreatedAt) {
+			return matchingPolicies[i].ID > matchingPolicies[j].ID
+		}
+		return matchingPolicies[i].CreatedAt.After(matchingPolicies[j].CreatedAt)
+	})
+	var tenantPolicy *TenantSecurityPolicy
+	if len(matchingPolicies) > 0 {
+		tenantPolicy = matchingPolicies[0]
 	}
 
 	if tenantPolicy == nil {


### PR DESCRIPTION
## Summary

- **Root cause** — `evaluateTenantSecurityPolicy()` iterated `tspe.policies` (a `map[string]*TenantSecurityPolicy`) and took the first active policy for the tenant via `for range; break`. Go map iteration is randomized per run. After an earlier subtest created a HIPAA policy for `client-healthcare` (requiring `encrypted=true`, critical severity) and `EndToEndSecurityValidation` created an E2E Test Policy for the same tenant (MFA-only), both policies coexisted in the map. Whichever Go's hash returned first determined whether `Allowed` was `true` or `false` at line 567.
- **macOS-specific** — macOS CI runners are slower than Linux. The HIPAA and E2E policies were created in different wall-clock seconds, giving them distinct `time.Now().Unix()` IDs and allowing both to coexist. Fast Linux runs collided on the same second-precision ID, silently overwriting the HIPAA policy with the E2E policy — masking the bug.
- **Precedent** — This is distinct from the dual audit logger fix in commit `12775378` / PR #368, which fixed logger plumbing. That fix was sufficient on Linux (ID collision masked the map non-determinism) but insufficient on macOS (no collision → both policies present → randomised selection).

## Changes

**`features/tenant/security/policy_engine.go`**
- **ID generation**: changed from `time.Now().Unix()` (second precision) to `time.Now().UnixNano()` — every policy now receives a unique key, eliminating silent overwrites that masked the map non-determinism on fast machines.
- **`evaluateTenantSecurityPolicy()`**: replaced `for range; break` (non-deterministic) with collect → `sort.SliceStable` (by `CreatedAt` desc, ID as tiebreaker) → select index 0. The most recently created active policy is always selected, regardless of map iteration order or machine speed. Fully deterministic total order: no two-policy scenario can produce a different result on re-run.

**`features/tenant/security/enhanced_multi_tenant_security_test.go`**
- Added `"encrypted": "true"` to the E2E `policyRequest.Context`. The E2E scenario represents access to encrypted PHI — this is semantically correct and provides defence-in-depth in case the HIPAA policy (which requires encryption) is ever evaluated against this request.

## Specialist Review Results

| Reviewer | Result | Notes |
|---|---|---|
| QA test runner | **PASS** | All gates green; `make test-agent-complete` passed; cross-platform compilation OK; `-race -count=20` stable |
| QA code reviewer | **PASS** (2nd pass) | Blocking issues from 1st pass resolved (UnixNano ID, `sort.SliceStable` + tiebreaker); 2 pre-existing warnings in unmodified subtests noted, out of scope for #366 |
| Security engineer | **PASS** | No new vulnerabilities; no central provider violations; pre-existing Trivy MEDIUM and gosec findings are unrelated to this story |

## Test plan

- [x] `go test ./features/tenant/security/ -run TestEnhancedMultiTenantSecurity -count=20 -race` — PASS
- [x] `go test ./features/tenant/security/... -count=1` — PASS (full package, no regressions)
- [x] Cross-platform compilation: linux/amd64, linux/arm64, darwin/amd64, darwin/arm64, windows/amd64 — all PASS
- [ ] CI required checks on `macos-latest` — the critical signal per the issue (merge queue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)