### PR TITLE
rbac: fix audit drain goroutine race with t.TempDir() cleanup (Issue #848)

### DIFF
--- a/features/rbac/advanced_permissions_test.go
+++ b/features/rbac/advanced_permissions_test.go
@@ -39,7 +39,7 @@ func TestAdvancedPermissionManagement(t *testing.T) {
 	t.Cleanup(func() {
 		stopCtx, stopCancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer stopCancel()
-		_ = manager.auditManager.Stop(stopCtx)
+		_ = manager.Close(stopCtx)
 	})
 
 	flushAudit := func(t *testing.T) {

--- a/features/rbac/audit_integration_test.go
+++ b/features/rbac/audit_integration_test.go
@@ -42,10 +42,12 @@ func TestRBACManager_AuditIntegration(t *testing.T) {
 
 	// Issue #764: audit writes are now asynchronous. Tests that query the audit
 	// store must Flush first to guarantee pending entries have landed.
+	// Issue #848: Close must be registered after storageManager.Close so it runs
+	// first (LIFO), stopping the drain goroutine before the store is closed.
 	t.Cleanup(func() {
 		stopCtx, stopCancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer stopCancel()
-		_ = manager.auditManager.Stop(stopCtx)
+		_ = manager.Close(stopCtx)
 	})
 
 	flushAudit := func(t *testing.T) {
@@ -333,6 +335,12 @@ func TestRBACManager_AuditFailureHandling(t *testing.T) {
 		storageManager.GetRBACStore(),
 	)
 	require.NotNil(t, manager)
+	// Issue #848: registered after storageManager.Close so it runs first (LIFO).
+	t.Cleanup(func() {
+		stopCtx, stopCancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer stopCancel()
+		_ = manager.Close(stopCtx)
+	})
 
 	ctx := context.Background()
 	err = manager.Initialize(ctx)
@@ -377,6 +385,12 @@ func TestRBACManager_AuditFailureHandling(t *testing.T) {
 			storageManager.GetClientTenantStore(),
 			storageManager.GetRBACStore(),
 		)
+		// Issue #848: registered after storageManager.Close so it runs first (LIFO).
+		t.Cleanup(func() {
+			stopCtx, stopCancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer stopCancel()
+			_ = manager.Close(stopCtx)
+		})
 		err = manager.Initialize(ctx)
 		require.NoError(t, err)
 

--- a/features/rbac/manager.go
+++ b/features/rbac/manager.go
@@ -985,6 +985,19 @@ func (m *Manager) FlushAudit(ctx context.Context) error {
 	return m.auditManager.Flush(ctx)
 }
 
+// Close stops the internal audit drain goroutine and waits for all pending
+// audit events to reach durable storage. Callers MUST call Close before
+// closing the underlying storage stores or removing the backing directory
+// (e.g. t.TempDir()); the drain goroutine writes entries until Close returns,
+// and failing to call it first races with filesystem cleanup. Repeated calls
+// return nil immediately (idempotent).
+func (m *Manager) Close(ctx context.Context) error {
+	if m.auditManager != nil {
+		return m.auditManager.Stop(ctx)
+	}
+	return nil
+}
+
 // CreateTemplate creates a new permission template
 func (m *Manager) CreateTemplate(ctx context.Context, req *TemplateCreateRequest) (*common.PermissionTemplate, error) {
 	return m.templateManager.CreateTemplate(ctx, req)

--- a/features/rbac/manager_hierarchy_test.go
+++ b/features/rbac/manager_hierarchy_test.go
@@ -29,6 +29,7 @@ func TestManager_CreateRoleWithParent(t *testing.T) {
 		storageManager.GetClientTenantStore(),
 		storageManager.GetRBACStore(),
 	)
+	t.Cleanup(func() { _ = manager.Close(context.Background()) })
 	ctx := context.Background()
 
 	// Initialize manager
@@ -166,6 +167,7 @@ func TestManager_GetRoleHierarchy(t *testing.T) {
 		storageManager.GetClientTenantStore(),
 		storageManager.GetRBACStore(),
 	)
+	t.Cleanup(func() { _ = manager.Close(context.Background()) })
 	ctx := context.Background()
 
 	// Initialize and set up test hierarchy
@@ -256,6 +258,7 @@ func TestManager_SetAndRemoveRoleParent(t *testing.T) {
 		storageManager.GetClientTenantStore(),
 		storageManager.GetRBACStore(),
 	)
+	t.Cleanup(func() { _ = manager.Close(context.Background()) })
 	ctx := context.Background()
 
 	err = manager.Initialize(ctx)
@@ -326,6 +329,7 @@ func TestManager_ComputeRolePermissions(t *testing.T) {
 		storageManager.GetClientTenantStore(),
 		storageManager.GetRBACStore(),
 	)
+	t.Cleanup(func() { _ = manager.Close(context.Background()) })
 	ctx := context.Background()
 
 	err = manager.Initialize(ctx)
@@ -395,6 +399,7 @@ func TestManager_ValidateHierarchyOperation(t *testing.T) {
 		storageManager.GetClientTenantStore(),
 		storageManager.GetRBACStore(),
 	)
+	t.Cleanup(func() { _ = manager.Close(context.Background()) })
 	ctx := context.Background()
 
 	err = manager.Initialize(ctx)

--- a/features/rbac/manager_storage_test.go
+++ b/features/rbac/manager_storage_test.go
@@ -64,6 +64,7 @@ func TestNewManagerWithStorage(t *testing.T) {
 				storageManager.GetRBACStore(),
 			)
 			require.NotNil(t, manager)
+			t.Cleanup(func() { _ = manager.Close(context.Background()) })
 
 			// Verify manager initializes correctly with pluggable storage
 			ctx := context.Background()
@@ -194,6 +195,7 @@ func TestManagerWithStorage_TenantIsolation(t *testing.T) {
 		storageManager.GetRBACStore(),
 	)
 	require.NotNil(t, manager)
+	t.Cleanup(func() { _ = manager.Close(context.Background()) })
 
 	ctx := context.Background()
 	err = manager.Initialize(ctx)
@@ -263,6 +265,7 @@ func TestManagerWithStorage_AuditTrail(t *testing.T) {
 		storageManager.GetRBACStore(),
 	)
 	require.NotNil(t, manager)
+	t.Cleanup(func() { _ = manager.Close(context.Background()) })
 
 	ctx := context.Background()
 	err = manager.Initialize(ctx)

--- a/features/rbac/manager_test.go
+++ b/features/rbac/manager_test.go
@@ -29,6 +29,7 @@ func TestManager_Initialize(t *testing.T) {
 		storageManager.GetClientTenantStore(),
 		storageManager.GetRBACStore(),
 	)
+	t.Cleanup(func() { _ = manager.Close(context.Background()) })
 	ctx := context.Background()
 
 	err = manager.Initialize(ctx)
@@ -69,6 +70,7 @@ func TestManager_CreateTenantDefaultRoles(t *testing.T) {
 		storageManager.GetClientTenantStore(),
 		storageManager.GetRBACStore(),
 	)
+	t.Cleanup(func() { _ = manager.Close(context.Background()) })
 	ctx := context.Background()
 
 	err = manager.Initialize(ctx)
@@ -108,6 +110,7 @@ func TestManager_SubjectManagement(t *testing.T) {
 		storageManager.GetClientTenantStore(),
 		storageManager.GetRBACStore(),
 	)
+	t.Cleanup(func() { _ = manager.Close(context.Background()) })
 	ctx := context.Background()
 
 	err = manager.Initialize(ctx)
@@ -171,6 +174,7 @@ func TestManager_RoleAssignment(t *testing.T) {
 		storageManager.GetClientTenantStore(),
 		storageManager.GetRBACStore(),
 	)
+	t.Cleanup(func() { _ = manager.Close(context.Background()) })
 	ctx := context.Background()
 
 	err = manager.Initialize(ctx)
@@ -235,6 +239,7 @@ func TestManager_PermissionChecking(t *testing.T) {
 		storageManager.GetClientTenantStore(),
 		storageManager.GetRBACStore(),
 	)
+	t.Cleanup(func() { _ = manager.Close(context.Background()) })
 	ctx := context.Background()
 
 	err = manager.Initialize(ctx)
@@ -321,6 +326,7 @@ func TestManager_SystemAdminPermissions(t *testing.T) {
 		storageManager.GetClientTenantStore(),
 		storageManager.GetRBACStore(),
 	)
+	t.Cleanup(func() { _ = manager.Close(context.Background()) })
 	ctx := context.Background()
 
 	err = manager.Initialize(ctx)
@@ -386,6 +392,7 @@ func TestManager_CreateStewardSubject(t *testing.T) {
 		storageManager.GetClientTenantStore(),
 		storageManager.GetRBACStore(),
 	)
+	t.Cleanup(func() { _ = manager.Close(context.Background()) })
 	ctx := context.Background()
 
 	err = manager.Initialize(ctx)
@@ -444,6 +451,7 @@ func TestManager_InactiveSubjectPermissions(t *testing.T) {
 		storageManager.GetClientTenantStore(),
 		storageManager.GetRBACStore(),
 	)
+	t.Cleanup(func() { _ = manager.Close(context.Background()) })
 	ctx := context.Background()
 
 	err = manager.Initialize(ctx)
@@ -486,4 +494,62 @@ func TestManager_InactiveSubjectPermissions(t *testing.T) {
 	require.NoError(t, err)
 	assert.False(t, response.Granted)
 	assert.Contains(t, response.Reason, "inactive")
+}
+
+func TestManager_Close(t *testing.T) {
+	t.Run("returns nil and stops audit drain goroutine", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		storageManager, err := interfaces.CreateOSSStorageManager(tmpDir+"/flatfile", tmpDir+"/cfgms.db")
+		require.NoError(t, err)
+		t.Cleanup(func() { _ = storageManager.Close() })
+
+		manager := NewManagerWithStorage(
+			storageManager.GetAuditStore(),
+			storageManager.GetClientTenantStore(),
+			storageManager.GetRBACStore(),
+		)
+		t.Cleanup(func() { _ = manager.Close(context.Background()) })
+
+		err = manager.Close(context.Background())
+		require.NoError(t, err)
+	})
+
+	t.Run("idempotent — second call returns nil", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		storageManager, err := interfaces.CreateOSSStorageManager(tmpDir+"/flatfile", tmpDir+"/cfgms.db")
+		require.NoError(t, err)
+		t.Cleanup(func() { _ = storageManager.Close() })
+
+		manager := NewManagerWithStorage(
+			storageManager.GetAuditStore(),
+			storageManager.GetClientTenantStore(),
+			storageManager.GetRBACStore(),
+		)
+		t.Cleanup(func() { _ = manager.Close(context.Background()) })
+
+		require.NoError(t, manager.Close(context.Background()))
+		require.NoError(t, manager.Close(context.Background()))
+	})
+
+	t.Run("nil auditManager guard returns nil without panic", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		storageManager, err := interfaces.CreateOSSStorageManager(tmpDir+"/flatfile", tmpDir+"/cfgms.db")
+		require.NoError(t, err)
+		t.Cleanup(func() { _ = storageManager.Close() })
+
+		manager := NewManagerWithStorage(
+			storageManager.GetAuditStore(),
+			storageManager.GetClientTenantStore(),
+			storageManager.GetRBACStore(),
+		)
+		// Simulate an edge-case where auditManager was cleared.
+		savedAudit := manager.auditManager
+		manager.auditManager = nil
+		t.Cleanup(func() {
+			manager.auditManager = savedAudit
+			_ = manager.Close(context.Background())
+		})
+
+		require.NoError(t, manager.Close(context.Background()))
+	})
 }

--- a/pkg/audit/manager.go
+++ b/pkg/audit/manager.go
@@ -429,8 +429,12 @@ func (m *Manager) Flush(ctx context.Context) error {
 }
 
 // Stop flushes pending entries and shuts down the drain goroutine. It is
-// idempotent — repeated calls return nil immediately. Callers should call Stop
-// during graceful shutdown to guarantee audit durability.
+// idempotent — repeated calls return nil immediately.
+//
+// Callers MUST call Stop before closing the backing store or removing the
+// directory that backs it (e.g. t.TempDir()). The drain goroutine writes
+// entries into the store until Stop returns; failing to call Stop first races
+// with filesystem cleanup and produces "directory not empty" errors.
 //
 // If ctx is cancelled before the flush completes, Stop returns the context
 // error but still signals the drain goroutine to exit. The goroutine will


### PR DESCRIPTION
## Summary

- Adds `Manager.Close(ctx)` to `features/rbac` — synchronously stops the `pkg/audit.Manager` drain goroutine and drains all pending entries before returning. Callers **must** call this before closing storage or removing the backing directory.
- Strengthens `pkg/audit.Manager.Stop()` godoc to state the MUST-call contract explicitly.
- Fixes all 17 test call sites across 5 files so cleanup runs in the correct LIFO order: `manager.Close` → `storageManager.Close` → `t.TempDir()` removal.
- Adds `TestManager_Close` with 3 subtests covering: goroutine drain, idempotency, and nil-auditManager guard.

## Root cause

`audit.Manager.drainLoop` starts in `NewManager` and is only stopped by `Stop(ctx)`. Nothing in `features/rbac` called it at test teardown, so the goroutine was still writing atomic-rename `.tmp-cfg-*` files into the flatfile root when `t.TempDir()`'s `RemoveAll` ran. This races on macOS-latest CI runners and produces:

```
TempDir RemoveAll cleanup: unlinkat .../flatfile: directory not empty
```

## Files changed with cleanup registration order

All 17 sites now follow the LIFO pattern: `storageManager.Close` registered first (runs second), `manager.Close` registered second (runs first):

| File | Sites fixed |
|------|-------------|
| `features/rbac/manager_test.go` | 8 top-level tests + new `TestManager_Close` |
| `features/rbac/manager_storage_test.go` | 3 tests |
| `features/rbac/manager_hierarchy_test.go` | 5 tests |
| `features/rbac/advanced_permissions_test.go` | 1 test (replaced direct `auditManager.Stop`) |
| `features/rbac/audit_integration_test.go` | 3 tests (2 new + replaced direct `auditManager.Stop`) |

## Specialist review results

- **QA Test Runner**: All quality gates PASS. Trivy FAIL is pre-existing on `develop` (`github.com/Azure/go-ntlmssp CVE-2026-32952` — unrelated indirect dep, go.mod unchanged by this branch).
- **QA Code Reviewer**: PASS — no blocking issues. Two warnings addressed: added `TestManager_Close` covering all code paths.
- **Security Engineer**: PASS — no security issues introduced. Pre-existing Trivy CVE noted as separate dependency-update concern.

## Test plan

- [x] `go test ./features/rbac/ -count=1 -race` passes
- [x] `go test ./features/rbac/ -count=5 -race` passes (50× total with race detector)
- [x] `go test ./features/rbac/ -run 'TestManager_CreateStewardSubject|TestManager_SystemAdminPermissions' -count=10 -race` — the two originally-reported flaking tests — passes
- [x] `TestManager_Close` subtests all pass: drain, idempotency, nil guard

Fixes #848

🤖 Generated with [Claude Code](https://claude.com/claude-code)