### PR TITLE
dispatch: refuse agent dispatch when open PR already fixes the issue

### DIFF
--- a/.claude/scripts/agent-dispatch.sh
+++ b/.claude/scripts/agent-dispatch.sh
@@ -28,6 +28,47 @@ sanitize_branch() {
   echo "$1" | sed 's|/|--|g'
 }
 
+# Emit OPEN_PR_EXISTS:<ISSUE>:<PR>:<TITLE> for each open PR that references
+# this issue. Uses two signals:
+#   1. GitHub's authoritative "closing PR" linkage (body Fixes/Closes/Resolves
+#      or manual UI link) via the issue.closedByPullRequestsReferences field
+#   2. Title-pattern fallback: "(Issue #<N>)" or "#<N>" in an open PR title,
+#      which catches agent PRs whose bodies omit the Fixes keyword
+check_existing_prs_for_issue() {
+  local issue_num="$1"
+  # Test hook: canned output for hermetic unit tests. Format is newline-separated
+  # OPEN_PR_EXISTS:<issue>:<pr>:<title> lines (empty = no conflicts).
+  if [[ -n "${CFGMS_TEST_MOCK_EXISTING_PRS:-}" ]]; then
+    printf '%s\n' "${CFGMS_TEST_MOCK_EXISTING_PRS}" | grep -E "^OPEN_PR_EXISTS:${issue_num}:" || true
+    return 0
+  fi
+  local graphql_out title_out
+  # Authoritative linkage via GraphQL (closing-PR references: body Fixes/Closes/Resolves or manual UI link).
+  # Non-existent issues return an error; we swallow it and produce no output.
+  graphql_out=$(gh api graphql -f query="
+      query(\$num: Int!) {
+        repository(owner: \"cfg-is\", name: \"cfgms\") {
+          issue(number: \$num) {
+            closedByPullRequestsReferences(first: 20, includeClosedPrs: false) {
+              nodes { number title state }
+            }
+          }
+        }
+      }" -F num="$issue_num" --jq '
+        .data.repository.issue.closedByPullRequestsReferences.nodes[]?
+        | select(.state == "OPEN")
+        | "OPEN_PR_EXISTS:'"$issue_num"':\(.number):\(.title | gsub(":"; " "))"
+      ' 2>/dev/null) || graphql_out=""
+  # Title-pattern fallback for PRs that reference the issue without Fixes keyword.
+  title_out=$(gh pr list --repo cfg-is/cfgms --state open --limit 50 \
+        --search "in:title #${issue_num}" \
+        --json number,title --jq '
+      .[] | "OPEN_PR_EXISTS:'"$issue_num"':\(.number):\(.title | gsub(":"; " "))"
+    ' 2>/dev/null || true)
+  printf '%s\n%s\n' "$graphql_out" "$title_out" | grep -v '^$' | sort -u || true
+  return 0
+}
+
 # Refresh agent credentials from the host's Claude session.
 # Copies ~/.claude/.credentials.json into the claude-creds Docker volume
 # so agents always start with a fresh token. No interactive OAuth needed.
@@ -54,10 +95,14 @@ Commands:
   check-conflicts <NUM> [NUM...]            Check for existing containers/clones (issue mode)
   check-conflicts --branch <NAME>           Check for existing containers/clones (branch mode)
   check-conflicts --pr <NUM>                Check for existing containers/clones (PR-fix mode)
-  create-clone    <NUM> [--keep-remote]     Clone repo and create feature branch (issue mode)
+  create-clone    <NUM> [--keep-remote] [--allow-duplicate-pr]
+                                            Clone repo and create feature branch (issue mode)
                                             If remote branch feature/story-<NUM>-agent already exists,
                                             it is force-deleted before the fresh branch is created.
                                             Pass --keep-remote to preserve the stale branch (forensics).
+                                            Refuses to dispatch if an open PR already references the
+                                            issue via Fixes/Closes/Resolves (exit 2). Pass
+                                            --allow-duplicate-pr to override for parallel-work cases.
   create-clone-branch <BRANCH>              Clone repo and checkout/create branch
   create-clone-pr <PR_NUM>                  Clone repo and checkout PR branch
   launch          <NUM>                     Launch agent container (issue mode)
@@ -129,6 +174,7 @@ case "$cmd" in
           if [[ -d "${WORKTREE_BASE}/story-${num}" ]]; then
             echo "CLONE_EXISTS:${num}:${WORKTREE_BASE}/story-${num}"
           fi
+          check_existing_prs_for_issue "$num"
         done
         echo "CHECK_DONE"
         ;;
@@ -137,9 +183,11 @@ case "$cmd" in
 
   create-clone)
     keep_remote=false
+    allow_duplicate_pr=false
     while [[ $# -gt 0 && "$1" == --* ]]; do
       case "$1" in
         --keep-remote) keep_remote=true; shift ;;
+        --allow-duplicate-pr) allow_duplicate_pr=true; shift ;;
         *) echo "Unknown flag for create-clone: $1"; exit 1 ;;
       esac
     done
@@ -148,6 +196,19 @@ case "$cmd" in
     branch_name="feature/story-${num}-agent"
     dest="${WORKTREE_BASE}/story-${num}"
     github_url=$(git -C "$REPO_ROOT" remote get-url origin)
+
+    # Refuse to dispatch if an open PR already references this issue via
+    # Fixes/Closes/Resolves. Override with --allow-duplicate-pr for genuine
+    # parallel-work cases. Prevents wasted agent cycles on already-solved bugs.
+    if ! $allow_duplicate_pr; then
+      existing_pr_lines=$(check_existing_prs_for_issue "$num")
+      if [[ -n "$existing_pr_lines" ]]; then
+        echo "$existing_pr_lines"
+        echo "ERROR: Open PR(s) already reference issue #${num}. Refusing to dispatch duplicate work."
+        echo "       Review and merge/close the existing PR, or re-run with --allow-duplicate-pr."
+        exit 2
+      fi
+    fi
 
     # Check for stale remote branch before cloning. A stale branch causes history
     # corruption when the new container pushes (git merges the two histories).

--- a/scripts/test-scripts.sh
+++ b/scripts/test-scripts.sh
@@ -385,6 +385,70 @@ HOOKEOF
     rm -rf "$tmp_dir"
 }
 
+# Test 11: create-clone refuses dispatch when an open PR already fixes the issue
+test_create_clone_duplicate_pr_gate() {
+    log_test "Testing create-clone refuses dispatch when open PR already fixes the issue..."
+
+    local tmp_dir
+    tmp_dir=$(mktemp -d)
+    local remote_dir="${tmp_dir}/remote.git"
+    local host_dir="${tmp_dir}/host"
+    local worktree_dir="${tmp_dir}/worktrees"
+    local story_num="99995"
+    local dispatch_script
+    dispatch_script="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/../.claude/scripts/agent-dispatch.sh"
+
+    git init --bare -b develop "$remote_dir" >/dev/null 2>&1
+    git init -b develop "$host_dir" >/dev/null 2>&1
+    git -C "$host_dir" config user.email "test@test.com"
+    git -C "$host_dir" config user.name "Test"
+    git -C "$host_dir" remote add origin "$remote_dir"
+    git -C "$host_dir" commit --allow-empty -m "initial commit" >/dev/null 2>&1
+    git -C "$host_dir" push origin develop >/dev/null 2>&1
+
+    mkdir -p "$worktree_dir"
+
+    # Canned "open PR 777 fixes 99995" — gate must refuse and exit 2
+    local mock_output="OPEN_PR_EXISTS:${story_num}:777:duplicate work for issue ${story_num}"
+    local output exit_code=0
+    output=$(CFGMS_TEST_REPO_ROOT="$host_dir" CFGMS_TEST_WORKTREE_BASE="$worktree_dir" \
+        CFGMS_TEST_MOCK_EXISTING_PRS="$mock_output" \
+        bash "$dispatch_script" create-clone "$story_num" 2>&1) || exit_code=$?
+
+    if [[ $exit_code -eq 2 ]]; then
+        log_pass "create-clone: Exits 2 when open PR already references the issue"
+    else
+        log_fail "create-clone: Expected exit 2 when duplicate PR exists, got ${exit_code} (output: ${output})"
+    fi
+
+    if echo "$output" | grep -q "Open PR(s) already reference issue #${story_num}"; then
+        log_pass "create-clone: Prints clear duplicate-PR refusal message"
+    else
+        log_fail "create-clone: Missing duplicate-PR refusal message (output: ${output})"
+    fi
+
+    if [[ ! -d "${worktree_dir}/story-${story_num}" ]]; then
+        log_pass "create-clone: Clone directory not created when duplicate PR gate trips"
+    else
+        log_fail "create-clone: Clone directory was created despite duplicate PR gate"
+        rm -rf "${worktree_dir}/story-${story_num}"
+    fi
+
+    # --allow-duplicate-pr override must bypass the gate and proceed with the clone
+    exit_code=0
+    output=$(CFGMS_TEST_REPO_ROOT="$host_dir" CFGMS_TEST_WORKTREE_BASE="$worktree_dir" \
+        CFGMS_TEST_MOCK_EXISTING_PRS="$mock_output" \
+        bash "$dispatch_script" create-clone --allow-duplicate-pr "$story_num" 2>&1) || exit_code=$?
+
+    if [[ $exit_code -eq 0 ]]; then
+        log_pass "create-clone --allow-duplicate-pr: Overrides gate and proceeds"
+    else
+        log_fail "create-clone --allow-duplicate-pr: Should succeed despite open PR (exit ${exit_code}, output: ${output})"
+    fi
+
+    rm -rf "$tmp_dir"
+}
+
 # Main execution
 echo "🔍 Script Validation Test Suite"
 echo "================================"
@@ -410,6 +474,8 @@ echo ""
 test_create_clone_keep_remote
 echo ""
 test_create_clone_deletion_failure
+echo ""
+test_create_clone_duplicate_pr_gate
 echo ""
 echo ""
 echo "📊 Test Summary"


### PR DESCRIPTION
## Summary

Adds a duplicate-PR gate to the agent dispatch flow. Today's session caught the gap: when issue #848 already had open PR #851, the PO still dispatched `cfg-agent-848`, which independently produced PR #857 with the same root cause. That's wasted agent-hours and reviewer attention. This change makes that path fail loudly instead.

## Behavior

- `agent-dispatch.sh check-conflicts <NUM>` now also emits `OPEN_PR_EXISTS:<issue>:<pr>:<title>` for any open PR that references the issue (advisory output for dispatch tooling).
- `agent-dispatch.sh create-clone <NUM>` refuses to clone with **exit 2** and a clear error if such an open PR exists. Override with `--allow-duplicate-pr` for deliberate parallel-work cases.
- Detection uses two signals: GitHub's authoritative `closedByPullRequestsReferences` (GraphQL — captures body Fixes/Closes/Resolves keywords plus manual UI links), with a title-pattern fallback (`#<NUM>` in title) for agent PRs whose bodies omit the linkage keyword.

## Test coverage

`scripts/test-scripts.sh` gains four new assertions in a hermetic test (uses `CFGMS_TEST_MOCK_EXISTING_PRS` env var to inject canned PR data — no live GitHub calls):

- `create-clone` exits 2 when an open PR already references the issue
- The error message clearly names the issue number and the override flag
- The clone directory is **not** created when the gate trips (no partial state)
- `--allow-duplicate-pr` cleanly overrides the gate and proceeds

Total script tests: 41 → 45, all passing.

## Test plan

- [x] `make test` — 45/45 script tests pass
- [x] `make security-trivy` — clean (only expected dev-cert findings)
- [x] Live smoke test: `check-conflicts 366 848` correctly identifies open PR #856 against #366
- [x] Live smoke test: `create-clone 366` exits 2 with the expected error message
- [ ] CI required checks pass on this PR

## Out of scope

- Generalizing the check to non-issue-mode dispatches (`create-clone-pr`, `create-clone-branch`) — those have different semantics; can follow up if needed.
- Reaching into the PO skill to refuse dispatch-readiness review when an open PR exists — the script-level gate is sufficient because dispatch ultimately calls `create-clone`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)