### PR TITLE
sqlite: back-fill sequence_number and previous_checksum on legacy audit_entries (Issue #849)

### DIFF
--- a/pkg/storage/providers/sqlite/schema.go
+++ b/pkg/storage/providers/sqlite/schema.go
@@ -11,9 +11,85 @@ import (
 
 const currentSchemaVersion = 1
 
+// tableExists reports whether the named table is present in the SQLite catalog.
+func tableExists(ctx context.Context, db *sql.DB, name string) (bool, error) {
+	var count int
+	err := db.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name=?`, name,
+	).Scan(&count)
+	return count > 0, err
+}
+
+// columnExists reports whether the named column is present in the named table.
+// SQLite PRAGMA statements do not support parameter binding, so the caller
+// must pass only hard-coded, trusted table/column names — never user input.
+func columnExists(ctx context.Context, db *sql.DB, table, column string) (found bool, retErr error) {
+	// #nosec G202 -- PRAGMA does not support ? binding; caller passes only literals.
+	rows, err := db.QueryContext(ctx, "PRAGMA table_info("+table+")")
+	if err != nil {
+		return false, err
+	}
+	defer func() {
+		if err := rows.Close(); err != nil && retErr == nil {
+			retErr = err
+		}
+	}()
+	for rows.Next() {
+		var cid, notNull, pk int
+		var name, typ string
+		var dfltValue sql.NullString
+		if err := rows.Scan(&cid, &name, &typ, &notNull, &dfltValue, &pk); err != nil {
+			return false, err
+		}
+		if name == column {
+			return true, nil
+		}
+	}
+	return false, rows.Err()
+}
+
+// backfillAuditEntries adds sequence_number and previous_checksum to a
+// pre-existing audit_entries table that was created without those columns.
+// Fresh databases (table absent) are skipped. Column-existence is checked
+// via PRAGMA before each ALTER TABLE so the pass is fully idempotent without
+// relying on driver-specific error message text.
+func backfillAuditEntries(ctx context.Context, db *sql.DB) error {
+	exists, err := tableExists(ctx, db, "audit_entries")
+	if err != nil {
+		return fmt.Errorf("sqlite: back-fill probe failed: %w", err)
+	}
+	if !exists {
+		return nil
+	}
+	type col struct {
+		name string
+		ddl  string
+	}
+	for _, c := range []col{
+		{"sequence_number", `ALTER TABLE audit_entries ADD COLUMN sequence_number   INTEGER NOT NULL DEFAULT 0`},
+		{"previous_checksum", `ALTER TABLE audit_entries ADD COLUMN previous_checksum TEXT    NOT NULL DEFAULT ''`},
+	} {
+		present, err := columnExists(ctx, db, "audit_entries", c.name)
+		if err != nil {
+			return fmt.Errorf("sqlite: back-fill column probe failed (%s): %w", c.name, err)
+		}
+		if present {
+			continue
+		}
+		if _, err := db.ExecContext(ctx, c.ddl); err != nil {
+			return fmt.Errorf("sqlite: audit_entries back-fill failed: %w\nSQL: %s", err, c.ddl)
+		}
+	}
+	return nil
+}
+
 // initializeSchema creates all tables and tracks schema version.
 // It is safe to call multiple times (all statements use IF NOT EXISTS).
 func initializeSchema(ctx context.Context, db *sql.DB) error {
+	if err := backfillAuditEntries(ctx, db); err != nil {
+		return err
+	}
+
 	statements := []string{
 		// Schema version tracking
 		`CREATE TABLE IF NOT EXISTS schema_version (

--- a/pkg/storage/providers/sqlite/schema_backfill_test.go
+++ b/pkg/storage/providers/sqlite/schema_backfill_test.go
@@ -1,0 +1,182 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+package sqlite
+
+import (
+	"context"
+	"database/sql"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	_ "modernc.org/sqlite"
+)
+
+// legacyAuditSchema is the audit_entries DDL from before sequence_number /
+// previous_checksum were added. Tests use this to simulate a pre-existing DB.
+const legacyAuditSchema = `CREATE TABLE IF NOT EXISTS audit_entries (
+	id               TEXT PRIMARY KEY,
+	tenant_id        TEXT NOT NULL,
+	timestamp        TEXT NOT NULL,
+	event_type       TEXT NOT NULL,
+	action           TEXT NOT NULL,
+	user_id          TEXT NOT NULL,
+	user_type        TEXT NOT NULL,
+	session_id       TEXT NOT NULL DEFAULT '',
+	resource_type    TEXT NOT NULL,
+	resource_id      TEXT NOT NULL,
+	resource_name    TEXT NOT NULL DEFAULT '',
+	result           TEXT NOT NULL,
+	error_code       TEXT NOT NULL DEFAULT '',
+	error_message    TEXT NOT NULL DEFAULT '',
+	request_id       TEXT NOT NULL DEFAULT '',
+	ip_address       TEXT NOT NULL DEFAULT '',
+	user_agent       TEXT NOT NULL DEFAULT '',
+	method           TEXT NOT NULL DEFAULT '',
+	path             TEXT NOT NULL DEFAULT '',
+	details          TEXT NOT NULL DEFAULT '{}',
+	changes          TEXT NOT NULL DEFAULT '{}',
+	tags             TEXT NOT NULL DEFAULT '[]',
+	severity         TEXT NOT NULL,
+	source           TEXT NOT NULL,
+	version          TEXT NOT NULL DEFAULT '',
+	checksum         TEXT NOT NULL
+)`
+
+// openMemDB opens a shared in-memory SQLite database for testing.
+func openMemDB(t *testing.T) *sql.DB {
+	t.Helper()
+	db, err := openDB(":memory:")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+	return db
+}
+
+// hasColumn reports whether the named column exists in table.
+// SQLite PRAGMA does not support ? binding; table is always a hardcoded literal in these tests.
+func hasColumn(t *testing.T, db *sql.DB, table, column string) bool {
+	t.Helper()
+	// #nosec G202 -- PRAGMA does not support ? binding; caller passes only literals.
+	rows, err := db.Query("PRAGMA table_info(" + table + ")")
+	require.NoError(t, err)
+	defer func() { require.NoError(t, rows.Close()) }()
+	for rows.Next() {
+		var cid int
+		var name, typ string
+		var notNull, pk int
+		var dfltValue sql.NullString
+		require.NoError(t, rows.Scan(&cid, &name, &typ, &notNull, &dfltValue, &pk))
+		if name == column {
+			return true
+		}
+	}
+	require.NoError(t, rows.Err())
+	return false
+}
+
+// hasIndex reports whether the named index exists on table.
+func hasIndex(t *testing.T, db *sql.DB, table, index string) bool {
+	t.Helper()
+	var count int
+	err := db.QueryRow(
+		`SELECT COUNT(*) FROM sqlite_master WHERE type='index' AND tbl_name=? AND name=?`,
+		table, index,
+	).Scan(&count)
+	require.NoError(t, err)
+	return count > 0
+}
+
+// TestBackfill_LegacyAuditEntries verifies that initializeSchema adds the
+// missing columns and index to a pre-existing legacy audit_entries table.
+func TestBackfill_LegacyAuditEntries(t *testing.T) {
+	db := openMemDB(t)
+	ctx := context.Background()
+
+	// Seed a legacy-shape table without sequence_number / previous_checksum.
+	_, err := db.ExecContext(ctx, legacyAuditSchema)
+	require.NoError(t, err, "seed legacy schema")
+
+	assert.False(t, hasColumn(t, db, "audit_entries", "sequence_number"), "pre-condition: column absent before back-fill")
+	assert.False(t, hasColumn(t, db, "audit_entries", "previous_checksum"), "pre-condition: column absent before back-fill")
+
+	// First invocation — should back-fill the missing columns and create indexes.
+	require.NoError(t, initializeSchema(ctx, db), "first initializeSchema call")
+
+	assert.True(t, hasColumn(t, db, "audit_entries", "sequence_number"), "sequence_number present after back-fill")
+	assert.True(t, hasColumn(t, db, "audit_entries", "previous_checksum"), "previous_checksum present after back-fill")
+	assert.True(t, hasIndex(t, db, "audit_entries", "idx_audit_entries_tenant_seq"), "composite index present after back-fill")
+}
+
+// TestBackfill_Idempotent verifies that calling initializeSchema a second time
+// on an already-migrated database succeeds without errors.
+func TestBackfill_Idempotent(t *testing.T) {
+	db := openMemDB(t)
+	ctx := context.Background()
+
+	// Seed legacy table and migrate once.
+	_, err := db.ExecContext(ctx, legacyAuditSchema)
+	require.NoError(t, err, "seed legacy schema")
+	require.NoError(t, initializeSchema(ctx, db), "first initializeSchema call")
+
+	// Second invocation must also succeed.
+	require.NoError(t, initializeSchema(ctx, db), "second initializeSchema call (idempotency check)")
+
+	assert.True(t, hasColumn(t, db, "audit_entries", "sequence_number"), "sequence_number still present")
+	assert.True(t, hasColumn(t, db, "audit_entries", "previous_checksum"), "previous_checksum still present")
+	assert.True(t, hasIndex(t, db, "audit_entries", "idx_audit_entries_tenant_seq"), "composite index still present")
+}
+
+// TestBackfill_FreshDB verifies that a fresh database initializes cleanly
+// without the back-fill pass interfering with the full modern schema.
+func TestBackfill_FreshDB(t *testing.T) {
+	db := openMemDB(t)
+	ctx := context.Background()
+
+	// No legacy seeding — fresh DB path.
+	require.NoError(t, initializeSchema(ctx, db), "fresh DB initialization")
+
+	assert.True(t, hasColumn(t, db, "audit_entries", "sequence_number"), "sequence_number present on fresh DB")
+	assert.True(t, hasColumn(t, db, "audit_entries", "previous_checksum"), "previous_checksum present on fresh DB")
+	assert.True(t, hasIndex(t, db, "audit_entries", "idx_audit_entries_tenant_seq"), "composite index present on fresh DB")
+}
+
+// TestBackfill_ProbeFailure verifies that tableExists failures propagate
+// correctly and do not silently succeed.
+func TestBackfill_ProbeFailure(t *testing.T) {
+	ctx := context.Background()
+
+	// Open and immediately close the DB so all subsequent operations fail.
+	db, err := openDB(":memory:")
+	require.NoError(t, err)
+	require.NoError(t, db.Close())
+
+	err = backfillAuditEntries(ctx, db)
+	require.Error(t, err, "closed DB must return an error")
+	assert.Contains(t, err.Error(), "back-fill probe failed", "error must identify the probe stage")
+}
+
+// TestBackfill_AlterFailure verifies that an ALTER TABLE failure (not caused
+// by a duplicate column) propagates and is not silently ignored.
+func TestBackfill_AlterFailure(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "readonly.db")
+
+	// Create a file DB and seed the legacy table.
+	setup, err := openDB(dbPath)
+	require.NoError(t, err)
+	_, err = setup.ExecContext(context.Background(), legacyAuditSchema)
+	require.NoError(t, err)
+	require.NoError(t, setup.Close())
+
+	// Re-open in read-only mode — reads succeed but writes (ALTER) fail.
+	roDB, err := sql.Open("sqlite", "file:"+dbPath+"?mode=ro")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = roDB.Close() })
+	require.NoError(t, roDB.Ping())
+
+	err = backfillAuditEntries(context.Background(), roDB)
+	require.Error(t, err, "ALTER TABLE on read-only DB must return an error")
+	assert.Contains(t, err.Error(), "back-fill", "error must identify the back-fill stage")
+}


### PR DESCRIPTION
## Summary

- Adds `backfillAuditEntries()` called at the top of `initializeSchema()` to migrate pre-existing `audit_entries` tables that lack `sequence_number` / `previous_checksum` columns before dependent indexes are created
- Uses PRAGMA table_info column probe instead of string-matching on driver error messages — idempotent and driver-version agnostic
- Adds `tableExists()` + `columnExists()` helpers with proper `rows.Close()` error capture via named return + defer
- New regression test file `schema_backfill_test.go` with 5 tests covering legacy migration, idempotency, fresh DB, probe failure, and ALTER failure error paths

## Root Cause

`CREATE TABLE IF NOT EXISTS` is a no-op when `audit_entries` already exists from an older schema version. The subsequent `CREATE INDEX … ON audit_entries(tenant_id, sequence_number)` then fails because the column is genuinely absent. CI masked this because each job starts with an empty workspace; developer machines with historical data reliably reproduce the failure.

## Test Plan

- [x] `TestBackfill_LegacyAuditEntries` — seeds legacy-shape table, calls `initializeSchema`, verifies both columns + composite index present
- [x] `TestBackfill_Idempotent` — second `initializeSchema` call on already-migrated DB succeeds
- [x] `TestBackfill_FreshDB` — fresh DB initializes cleanly with full modern schema
- [x] `TestBackfill_ProbeFailure` — closed DB propagates error through `back-fill probe failed`
- [x] `TestBackfill_AlterFailure` — read-only DB propagates ALTER error, not silently ignored
- [x] All existing sqlite package tests pass (race detector enabled)

## Specialist Review Results

| Reviewer | Result | Notes |
|----------|--------|-------|
| QA Test Runner | **PASS** | All gates green: unit tests, linting, cross-platform builds (linux/amd64, linux/arm64, darwin/amd64, darwin/arm64, windows/amd64) |
| QA Code Reviewer | **PASS** | 0 blocking issues (2 advisory warnings, neither blocking) |
| Security Engineer | **PASS** | security-precommit PASS, check-architecture PASS, security-scan PASS; 0 blocking issues |

Fixes #849

🤖 Generated with [Claude Code](https://claude.com/claude-code)