### PR TITLE
test(controlplane): fix flaky TestRapidDisconnectReconnectCycles (Issue #853)

### DIFF
--- a/pkg/controlplane/providers/grpc/reconnect_test.go
+++ b/pkg/controlplane/providers/grpc/reconnect_test.go
@@ -413,8 +413,11 @@ func TestRapidDisconnectReconnectCycles(t *testing.T) {
 		}, 30*time.Second, 100*time.Millisecond, "should reconnect after cycle %d", i)
 	}
 
-	// Should have exactly one registry entry (no duplicates)
-	_, ok := reg.Get("steward-rapid")
-	assert.True(t, ok, "steward should be registered")
-	assert.Equal(t, 1, reg.Count(), "should have exactly one registry entry, not duplicates")
+	// Should have exactly one registry entry (no duplicates).
+	// Both conditions are checked atomically inside the closure to avoid a
+	// TOCTOU window between two separate Eventually calls.
+	require.Eventually(t, func() bool {
+		_, ok := reg.Get("steward-rapid")
+		return ok && reg.Count() == 1
+	}, 5*time.Second, 10*time.Millisecond, "steward should be registered with no duplicates")
 }


### PR DESCRIPTION
## Summary

`TestRapidDisconnectReconnectCycles` flaked on CI under parallel load because the final registry assertion fired immediately after the QUIC state flipped to `StateConnected`, with no wait for the server-side `registry.Register(conn)` call to complete. On a loaded CI runner the goroutine scheduling gap between those two events is enough to produce "registry count is 0 instead of 1".

**Root cause:** Lines 417–419 used bare `assert.True` / `assert.Equal` with no polling wait after the reconnect-state check at line 411–413. The `StateConnected` flip and the in-process registry write are not atomic from the test's perspective.

**Fix:** Replace the two bare asserts with a single `require.Eventually` closure that polls both `reg.Get("steward-rapid")` and `reg.Count() == 1` in one tick. Combining both conditions in one closure avoids the TOCTOU window that two separate `Eventually` calls would introduce. Timeout/poll interval (5 s / 10 ms) match the existing pattern at line 126–129 (`TestReconnectAfterServerRestart`).

No production code changed. No `t.Skip()`, no `time.Sleep()`.

## Stress-test results (acceptance criteria)

```
go test -race -count=100 -timeout 25m \
  -run TestRapidDisconnectReconnectCycles \
  ./pkg/controlplane/providers/grpc/

ok  	github.com/cfgis/cfgms/pkg/controlplane/providers/grpc	1049.053s
EXIT:0
```

Zero failures across 100 races-enabled iterations.

## Note on QUIC UDP receive buffer warning

CI logs may show `failed to sufficiently increase receive buffer size` from quic-go. This is a host kernel configuration issue (`net.core.rmem_max`), not a test defect, and is entirely unrelated to this fix.

## Adversarial team review

| Specialist | Result |
|---|---|
| QA Test Runner (`make test-agent-complete`) | **PASS** — all packages, cross-platform builds, integration suite |
| QA Code Reviewer | **PASS** — no mocks, no `t.Skip()`, no `time.Sleep()`, no error swallowing |
| Security Engineer | **PASS** — `security-precommit`, `check-architecture`, `security-scan` all green |

## Files changed

- `pkg/controlplane/providers/grpc/reconnect_test.go` — test-only change, 4 lines replaced with 5

Fixes #853