### PR TITLE
controlplane: delete pendingResponses/WaitForResponse and relocate SendResponse (Issue #829)

### DIFF
--- a/features/controller/heartbeat/service_dna_test.go
+++ b/features/controller/heartbeat/service_dna_test.go
@@ -58,12 +58,6 @@ func (p *testControlPlane) SubscribeHeartbeats(_ context.Context, handler cpinte
 	p.heartbeatHandler = handler
 	return nil
 }
-func (p *testControlPlane) SendResponse(_ context.Context, _ *controlplaneTypes.Response) error {
-	return nil
-}
-func (p *testControlPlane) WaitForResponse(_ context.Context, _ string, _ time.Duration) (*controlplaneTypes.Response, error) {
-	return nil, nil
-}
 func (p *testControlPlane) GetStats(_ context.Context) (*controlplaneTypes.ControlPlaneStats, error) {
 	return &controlplaneTypes.ControlPlaneStats{}, nil
 }

--- a/features/steward/client/offline_queue_test.go
+++ b/features/steward/client/offline_queue_test.go
@@ -62,10 +62,6 @@ func (n *noopControlPlane) SendHeartbeat(_ context.Context, _ *cpTypes.Heartbeat
 func (n *noopControlPlane) SubscribeHeartbeats(_ context.Context, _ controlplaneInterfaces.HeartbeatHandler) error {
 	return nil
 }
-func (n *noopControlPlane) SendResponse(_ context.Context, _ *cpTypes.Response) error { return nil }
-func (n *noopControlPlane) WaitForResponse(_ context.Context, _ string, _ time.Duration) (*cpTypes.Response, error) {
-	return nil, nil
-}
 func (n *noopControlPlane) GetStats(_ context.Context) (*cpTypes.ControlPlaneStats, error) {
 	return &cpTypes.ControlPlaneStats{}, nil
 }

--- a/pkg/controlplane/interfaces/contract_test.go
+++ b/pkg/controlplane/interfaces/contract_test.go
@@ -72,15 +72,6 @@ func RunCPContractTests(t *testing.T, factory CPProviderFactory) {
 	t.Run("FanOutPartialFailure", func(t *testing.T) {
 		testCPFanOutPartialFailure(t, factory)
 	})
-	t.Run("RequestResponse", func(t *testing.T) {
-		testCPRequestResponse(t, factory)
-	})
-	t.Run("ResponseTimeout", func(t *testing.T) {
-		testCPResponseTimeout(t, factory)
-	})
-	t.Run("ResponseContextCancellation", func(t *testing.T) {
-		testCPResponseContextCancellation(t, factory)
-	})
 	t.Run("EventFilteringByType", func(t *testing.T) {
 		testCPEventFilteringByType(t, factory)
 	})
@@ -279,97 +270,6 @@ func testCPFanOutPartialFailure(t *testing.T, factory CPProviderFactory) {
 	require.NoError(t, err)
 	assert.Contains(t, result.Succeeded, "contract-steward-0")
 	assert.Contains(t, result.Failed, "steward-never-connected")
-}
-
-// testCPRequestResponse verifies server sends a command, steward responds,
-// and server receives the response via WaitForResponse.
-func testCPRequestResponse(t *testing.T, factory CPProviderFactory) {
-	t.Helper()
-	server, clients, cleanup := factory(t)
-	defer cleanup()
-
-	ctx := context.Background()
-	client := clients["contract-steward-0"]
-
-	// Subscribe to commands so the client can respond
-	require.NoError(t, client.SubscribeCommands(ctx, "contract-steward-0", func(ctx context.Context, cmd *cptypes.Command) error {
-		return client.SendResponse(ctx, &cptypes.Response{
-			CommandID: cmd.ID,
-			StewardID: "contract-steward-0",
-			Success:   true,
-			Message:   "ack",
-			Timestamp: time.Now(),
-		})
-	}))
-
-	var resp *cptypes.Response
-	var respErr error
-	done := make(chan struct{})
-
-	go func() {
-		resp, respErr = server.WaitForResponse(ctx, "contract-cmd-resp", 10*time.Second)
-		close(done)
-	}()
-
-	// Give WaitForResponse time to register its pending channel
-	time.Sleep(50 * time.Millisecond)
-
-	require.NoError(t, server.SendCommand(ctx, &cptypes.Command{
-		ID:        "contract-cmd-resp",
-		Type:      cptypes.CommandSyncConfig,
-		StewardID: "contract-steward-0",
-		Timestamp: time.Now(),
-	}))
-
-	select {
-	case <-done:
-		require.NoError(t, respErr)
-		require.NotNil(t, resp)
-		assert.Equal(t, "contract-cmd-resp", resp.CommandID)
-		assert.True(t, resp.Success)
-	case <-time.After(10 * time.Second):
-		t.Fatal("timed out waiting for request-response")
-	}
-}
-
-// testCPResponseTimeout verifies WaitForResponse returns an error when no
-// response arrives within the timeout.
-func testCPResponseTimeout(t *testing.T, factory CPProviderFactory) {
-	t.Helper()
-	server, _, cleanup := factory(t)
-	defer cleanup()
-
-	_, err := server.WaitForResponse(context.Background(), "nonexistent-cmd", 100*time.Millisecond)
-	require.Error(t, err)
-	// The error should mention timeout or context — implementation defined, just verify non-nil
-	assert.NotEmpty(t, err.Error())
-}
-
-// testCPResponseContextCancellation verifies WaitForResponse respects context
-// cancellation.
-func testCPResponseContextCancellation(t *testing.T, factory CPProviderFactory) {
-	t.Helper()
-	server, _, cleanup := factory(t)
-	defer cleanup()
-
-	ctx, cancel := context.WithCancel(context.Background())
-
-	done := make(chan error, 1)
-	go func() {
-		_, err := server.WaitForResponse(ctx, "contract-cmd-ctx-cancel", 30*time.Second)
-		done <- err
-	}()
-
-	// Give WaitForResponse time to register its pending channel
-	time.Sleep(50 * time.Millisecond)
-	cancel()
-
-	select {
-	case err := <-done:
-		require.Error(t, err)
-	case <-time.After(3 * time.Second):
-		t.Fatal("WaitForResponse did not respect context cancellation")
-	}
 }
 
 // testCPEventFilteringByType verifies the server only delivers events that
@@ -681,13 +581,6 @@ func testCPSendDuringDisconnection(t *testing.T, factory CPProviderFactory) {
 		Timestamp: time.Now(),
 	})
 	require.Error(t, err, "SendHeartbeat must fail when disconnected")
-
-	err = client.SendResponse(ctx, &cptypes.Response{
-		CommandID: "cmd-1",
-		StewardID: "contract-steward-0",
-		Timestamp: time.Now(),
-	})
-	require.Error(t, err, "SendResponse must fail when disconnected")
 }
 
 // testCPMalformedMessageHandling verifies the provider does not panic when
@@ -712,10 +605,6 @@ func testCPMalformedMessageHandling(t *testing.T, factory CPProviderFactory) {
 	assert.NotPanics(t, func() {
 		_ = client.SendHeartbeat(ctx, nil)
 	}, "SendHeartbeat with nil heartbeat must not panic")
-
-	assert.NotPanics(t, func() {
-		_ = client.SendResponse(ctx, nil)
-	}, "SendResponse with nil response must not panic")
 }
 
 // =============================================================================

--- a/pkg/controlplane/interfaces/provider.go
+++ b/pkg/controlplane/interfaces/provider.go
@@ -8,7 +8,6 @@ package interfaces
 
 import (
 	"context"
-	"time"
 
 	"github.com/cfgis/cfgms/pkg/controlplane/types"
 )
@@ -18,6 +17,8 @@ import (
 // The control plane is responsible for command/event/heartbeat communication
 // between controllers and stewards. It provides semantic methods that hide
 // transport-specific details like topics, QoS levels, and subscriptions.
+// SendResponse is not part of this interface — it lives on the concrete
+// *grpc.Provider to prevent cross-steward response injection (epic #747).
 //
 // Implementations must be thread-safe and support concurrent operations.
 type ControlPlaneProvider interface {
@@ -106,22 +107,6 @@ type ControlPlaneProvider interface {
 	// The handler is called for each heartbeat received. Use this to
 	// detect steward connectivity and health status changes.
 	SubscribeHeartbeats(ctx context.Context, handler HeartbeatHandler) error
-
-	// =================================================================
-	// Responses (Steward → Controller, synchronous acknowledgment)
-	// =================================================================
-
-	// SendResponse sends a command response/acknowledgment (steward-side)
-	//
-	// Responses provide immediate feedback about command acceptance/rejection,
-	// distinct from Events which provide asynchronous progress updates.
-	SendResponse(ctx context.Context, response *types.Response) error
-
-	// WaitForResponse waits for a command response with timeout (controller-side)
-	//
-	// Blocks until a response is received for the given commandID or the
-	// context/timeout expires. Returns error if timeout occurs.
-	WaitForResponse(ctx context.Context, commandID string, timeout time.Duration) (*types.Response, error)
 
 	// =================================================================
 	// Status & Monitoring

--- a/pkg/controlplane/interfaces/provider_test.go
+++ b/pkg/controlplane/interfaces/provider_test.go
@@ -5,7 +5,6 @@ package interfaces
 import (
 	"context"
 	"testing"
-	"time"
 
 	"github.com/cfgis/cfgms/pkg/controlplane/types"
 	"github.com/stretchr/testify/assert"
@@ -76,14 +75,6 @@ func (m *mockProvider) SendHeartbeat(ctx context.Context, heartbeat *types.Heart
 
 func (m *mockProvider) SubscribeHeartbeats(ctx context.Context, handler HeartbeatHandler) error {
 	return nil
-}
-
-func (m *mockProvider) SendResponse(ctx context.Context, response *types.Response) error {
-	return nil
-}
-
-func (m *mockProvider) WaitForResponse(ctx context.Context, commandID string, timeout time.Duration) (*types.Response, error) {
-	return nil, nil
 }
 
 func (m *mockProvider) GetStats(ctx context.Context) (*types.ControlPlaneStats, error) {

--- a/pkg/controlplane/providers/grpc/integration_test.go
+++ b/pkg/controlplane/providers/grpc/integration_test.go
@@ -242,66 +242,6 @@ func TestStewardSendsHeartbeat_ControllerReceives(t *testing.T) {
 	}
 }
 
-func TestWaitForResponse(t *testing.T) {
-	env := newTestEnv(t, "steward-resp-test")
-
-	// Subscribe to commands so the steward can respond
-	err := env.client.SubscribeCommands(context.Background(), "steward-resp-test", func(ctx context.Context, cmd *types.Command) error {
-		// Send response back
-		return env.client.SendResponse(ctx, &types.Response{
-			CommandID: cmd.ID,
-			StewardID: "steward-resp-test",
-			Success:   true,
-			Message:   "done",
-			Timestamp: time.Now(),
-		})
-	})
-	require.NoError(t, err)
-
-	// Start waiting for response in background
-	var resp *types.Response
-	var respErr error
-	done := make(chan struct{})
-	go func() {
-		resp, respErr = env.server.WaitForResponse(context.Background(), "cmd-resp-001", 5*time.Second)
-		close(done)
-	}()
-
-	// Wait for the pending response channel to be registered before sending
-	require.Eventually(t, func() bool {
-		env.server.responseMu.Lock()
-		_, ok := env.server.pendingResponses["cmd-resp-001"]
-		env.server.responseMu.Unlock()
-		return ok
-	}, 5*time.Second, time.Millisecond)
-
-	err = env.server.SendCommand(context.Background(), &types.Command{
-		ID:        "cmd-resp-001",
-		Type:      types.CommandSyncConfig,
-		StewardID: "steward-resp-test",
-		Timestamp: time.Now(),
-	})
-	require.NoError(t, err)
-
-	select {
-	case <-done:
-		require.NoError(t, respErr)
-		assert.Equal(t, "cmd-resp-001", resp.CommandID)
-		assert.True(t, resp.Success)
-		assert.Equal(t, "done", resp.Message)
-	case <-time.After(5 * time.Second):
-		t.Fatal("timed out waiting for response")
-	}
-}
-
-func TestWaitForResponse_Timeout(t *testing.T) {
-	env := newTestEnv(t, "steward-timeout-test")
-
-	_, err := env.server.WaitForResponse(context.Background(), "nonexistent-cmd", 100*time.Millisecond)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "timeout")
-}
-
 func TestEventFilter(t *testing.T) {
 	env := newTestEnv(t, "steward-filter-test")
 
@@ -642,9 +582,6 @@ func TestModeValidation(t *testing.T) {
 	assert.Error(t, err)
 
 	err = client.SubscribeHeartbeats(context.Background(), nil)
-	assert.Error(t, err)
-
-	_, err = client.WaitForResponse(context.Background(), "x", time.Second)
 	assert.Error(t, err)
 
 	// Client-only methods fail in server mode

--- a/pkg/controlplane/providers/grpc/provider.go
+++ b/pkg/controlplane/providers/grpc/provider.go
@@ -90,10 +90,6 @@ type Provider struct {
 	eventHandlers     []eventSubscription
 	heartbeatHandlers []interfaces.HeartbeatHandler
 
-	// Response tracking (server mode: WaitForResponse)
-	pendingResponses map[string]chan *types.Response
-	responseMu       sync.Mutex
-
 	// Lifecycle
 	ctx    context.Context
 	cancel context.CancelFunc
@@ -130,7 +126,6 @@ func New(mode Mode) *Provider {
 		mode:              mode,
 		eventHandlers:     []eventSubscription{},
 		heartbeatHandlers: []interfaces.HeartbeatHandler{},
-		pendingResponses:  make(map[string]chan *types.Response),
 		logger:            slog.Default(),
 	}
 }
@@ -756,8 +751,6 @@ func (p *Provider) SubscribeHeartbeats(ctx context.Context, handler interfaces.H
 	return nil
 }
 
-// --- Responses ---
-
 func (p *Provider) SendResponse(ctx context.Context, response *types.Response) error {
 	if p.mode != ModeClient {
 		return fmt.Errorf("SendResponse is only available in client mode")
@@ -781,51 +774,6 @@ func (p *Provider) SendResponse(ctx context.Context, response *types.Response) e
 
 	p.responsesSent.Add(1)
 	return nil
-}
-
-func (p *Provider) WaitForResponse(ctx context.Context, commandID string, timeout time.Duration) (*types.Response, error) {
-	if p.mode != ModeServer {
-		return nil, fmt.Errorf("WaitForResponse is only available in server mode")
-	}
-
-	ch := make(chan *types.Response, 1)
-
-	p.responseMu.Lock()
-	p.pendingResponses[commandID] = ch
-	p.responseMu.Unlock()
-
-	defer func() {
-		p.responseMu.Lock()
-		delete(p.pendingResponses, commandID)
-		p.responseMu.Unlock()
-	}()
-
-	timer := time.NewTimer(timeout)
-	defer timer.Stop()
-
-	select {
-	case resp := <-ch:
-		p.responsesReceived.Add(1)
-		return resp, nil
-	case <-timer.C:
-		return nil, fmt.Errorf("timeout waiting for response to command %s", commandID)
-	case <-ctx.Done():
-		return nil, ctx.Err()
-	}
-}
-
-// dispatchResponse routes an incoming response to a waiting WaitForResponse call.
-func (p *Provider) dispatchResponse(resp *types.Response) {
-	p.responseMu.Lock()
-	ch, ok := p.pendingResponses[resp.CommandID]
-	p.responseMu.Unlock()
-
-	if ok {
-		select {
-		case ch <- resp:
-		default:
-		}
-	}
 }
 
 // dispatchEvent routes an incoming event to matching event handlers.
@@ -1102,7 +1050,14 @@ func (s *transportServer) ControlChannel(stream grpc.BidiStreamingServer[transpo
 				s.provider.identityMismatches.Add(1)
 				continue
 			}
-			s.provider.dispatchResponse(resp)
+			// Response handling is currently receive-only — no controller logic
+			// awaits responses. See epic #747 for the rationale (WaitForResponse
+			// had zero callers). If sync-ack becomes a product need, reinstate a
+			// per-(CN, CommandID)-scoped waiter with a ceiling at that time.
+			s.provider.responsesReceived.Add(1)
+			s.provider.logger.Debug("controlchannel response received",
+				"command_id", logging.SanitizeLogValue(resp.CommandID),
+				"steward_id", logging.SanitizeLogValue(resp.StewardID))
 		}
 	}
 }

--- a/pkg/controlplane/providers/grpc/provider_controlchannel_identity_test.go
+++ b/pkg/controlplane/providers/grpc/provider_controlchannel_identity_test.go
@@ -277,13 +277,11 @@ func TestControlChannel_Heartbeat_MismatchedStewardID(t *testing.T) {
 }
 
 // TestControlChannel_Response_MatchingStewardID verifies that a Response with a
-// matching payload StewardID is dispatched normally.
+// matching payload StewardID is received without identity mismatch.
 func TestControlChannel_Response_MatchingStewardID(t *testing.T) {
 	t.Parallel()
 	env := newMultiStewardEnv(t)
 
-	// Subscribe to commands and reply so SendResponse is triggered via the
-	// happy path. We validate via WaitForResponse that the response arrived.
 	cmdID := "resp-match-cmd"
 	require.NoError(t, env.clientA.SubscribeCommands(context.Background(), "steward-a", func(ctx context.Context, cmd *types.Command) error {
 		return env.clientA.SendResponse(ctx, &types.Response{
@@ -294,21 +292,6 @@ func TestControlChannel_Response_MatchingStewardID(t *testing.T) {
 		})
 	}))
 
-	var respErr error
-	gotResp := make(chan struct{})
-	go func() {
-		_, respErr = env.server.WaitForResponse(context.Background(), cmdID, 5*time.Second)
-		close(gotResp)
-	}()
-
-	// Wait for the pending channel to register before sending
-	require.Eventually(t, func() bool {
-		env.server.responseMu.Lock()
-		_, ok := env.server.pendingResponses[cmdID]
-		env.server.responseMu.Unlock()
-		return ok
-	}, 5*time.Second, time.Millisecond)
-
 	require.NoError(t, env.server.SendCommand(context.Background(), &types.Command{
 		ID:        cmdID,
 		Type:      types.CommandSyncConfig,
@@ -316,12 +299,10 @@ func TestControlChannel_Response_MatchingStewardID(t *testing.T) {
 		Timestamp: time.Now(),
 	}))
 
-	select {
-	case <-gotResp:
-		require.NoError(t, respErr)
-	case <-time.After(5 * time.Second):
-		t.Fatal("timed out waiting for response")
-	}
+	require.Eventually(t, func() bool {
+		stats, err := env.server.GetStats(context.Background())
+		return err == nil && stats.ResponsesReceived >= 1
+	}, 3*time.Second, 50*time.Millisecond, "server should have received the response")
 
 	stats, err := env.server.GetStats(context.Background())
 	require.NoError(t, err)
@@ -329,7 +310,8 @@ func TestControlChannel_Response_MatchingStewardID(t *testing.T) {
 }
 
 // TestControlChannel_Response_EmptyStewardIDGetsCNStamped verifies that a
-// Response with an empty payload StewardID is stamped with the CN.
+// Response with an empty payload StewardID is not rejected (stamped with CN,
+// no identity mismatch counted).
 func TestControlChannel_Response_EmptyStewardIDGetsCNStamped(t *testing.T) {
 	t.Parallel()
 	env := newMultiStewardEnv(t)
@@ -338,26 +320,11 @@ func TestControlChannel_Response_EmptyStewardIDGetsCNStamped(t *testing.T) {
 	require.NoError(t, env.clientA.SubscribeCommands(context.Background(), "steward-a", func(ctx context.Context, cmd *types.Command) error {
 		return env.clientA.SendResponse(ctx, &types.Response{
 			CommandID: cmd.ID,
-			StewardID: "", // empty — should be stamped with CN
+			StewardID: "", // empty — should be stamped with CN before discard
 			Success:   true,
 			Timestamp: time.Now(),
 		})
 	}))
-
-	var gotResp *types.Response
-	var respErr error
-	done := make(chan struct{})
-	go func() {
-		gotResp, respErr = env.server.WaitForResponse(context.Background(), cmdID, 5*time.Second)
-		close(done)
-	}()
-
-	require.Eventually(t, func() bool {
-		env.server.responseMu.Lock()
-		_, ok := env.server.pendingResponses[cmdID]
-		env.server.responseMu.Unlock()
-		return ok
-	}, 5*time.Second, time.Millisecond)
 
 	require.NoError(t, env.server.SendCommand(context.Background(), &types.Command{
 		ID:        cmdID,
@@ -366,13 +333,11 @@ func TestControlChannel_Response_EmptyStewardIDGetsCNStamped(t *testing.T) {
 		Timestamp: time.Now(),
 	}))
 
-	select {
-	case <-done:
-		require.NoError(t, respErr)
-		assert.Equal(t, "steward-a", gotResp.StewardID, "empty StewardID should be stamped with CN")
-	case <-time.After(5 * time.Second):
-		t.Fatal("timed out waiting for stamped response")
-	}
+	// CN-stamped responses are received without mismatch
+	require.Eventually(t, func() bool {
+		stats, err := env.server.GetStats(context.Background())
+		return err == nil && stats.ResponsesReceived >= 1
+	}, 3*time.Second, 50*time.Millisecond, "server should have received the response without mismatch")
 
 	stats, err := env.server.GetStats(context.Background())
 	require.NoError(t, err)
@@ -395,35 +360,12 @@ func TestControlChannel_Response_MismatchedStewardID(t *testing.T) {
 		})
 	}))
 
-	var respErr error
-	done := make(chan struct{})
-	go func() {
-		// Short timeout — response will never arrive because it's rejected
-		_, respErr = env.server.WaitForResponse(context.Background(), cmdID, 500*time.Millisecond)
-		close(done)
-	}()
-
-	require.Eventually(t, func() bool {
-		env.server.responseMu.Lock()
-		_, ok := env.server.pendingResponses[cmdID]
-		env.server.responseMu.Unlock()
-		return ok
-	}, 5*time.Second, time.Millisecond)
-
 	require.NoError(t, env.server.SendCommand(context.Background(), &types.Command{
 		ID:        cmdID,
 		Type:      types.CommandSyncConfig,
 		StewardID: "steward-a",
 		Timestamp: time.Now(),
 	}))
-
-	select {
-	case <-done:
-		// WaitForResponse must time out (response was rejected)
-		require.Error(t, respErr, "WaitForResponse should time out when response is rejected")
-	case <-time.After(5 * time.Second):
-		t.Fatal("WaitForResponse goroutine did not return")
-	}
 
 	require.Eventually(t, func() bool {
 		stats, err := env.server.GetStats(context.Background())

--- a/test/e2e/framework.go
+++ b/test/e2e/framework.go
@@ -17,7 +17,6 @@ import (
 	"testing"
 	"time"
 
-	controlplaneInterfaces "github.com/cfgis/cfgms/pkg/controlplane/interfaces"
 	controlplaneGRPC "github.com/cfgis/cfgms/pkg/controlplane/providers/grpc"
 	controlplaneTypes "github.com/cfgis/cfgms/pkg/controlplane/types"
 	quictransport "github.com/cfgis/cfgms/pkg/transport/quic"
@@ -45,7 +44,7 @@ type RegisteredSteward struct {
 	StewardID        string
 	TenantID         string
 	Group            string
-	ControlPlane     controlplaneInterfaces.ControlPlaneProvider
+	ControlPlane     *controlplaneGRPC.Provider
 	TransportAddress string
 	ControllerURL    string
 	ClientCert       string


### PR DESCRIPTION
## Summary

- Removes the dead-code response plumbing (`pendingResponses` map, `responseMu` mutex, `WaitForResponse` method, `dispatchResponse` function) from `pkg/controlplane/providers/grpc/provider.go`. The global `pendingResponses` map was the cross-steward response injection vector identified in epic #747 (F4) — any authenticated steward could race a `WaitForResponse` call for a command belonging to a different steward. Deletion is safe because `WaitForResponse` had zero external callers.
- Removes `SendResponse` and `WaitForResponse` from the `ControlPlaneProvider` interface; `SendResponse` is retained as a public concrete method on `*grpc.Provider`.
- Retypes `test/e2e/framework.go` `ControlPlane` field from the interface to `*controlplaneGRPC.Provider`; the sole e2e caller (`scenarios_test.go:877`) still compiles.
- The ControlChannel recv loop's Response branch still enforces the authenticated-CN validation from #828, then logs-and-discards with a comment citing epic #747.
- Net: **-312 lines** (336 deleted, 24 added for log-and-discard branch + comment).

## Verification

```
# WaitForResponse zero hits outside pkg/controlplane (non-test production code)
grep -rn "WaitForResponse" --include="*.go" . | grep -v "_test.go" | grep -v "pkg/controlplane/" | grep -v ".cache/"
# (zero results)

# SendResponse — only external caller is test/e2e/scenarios_test.go:877
grep -rn "\.SendResponse(" --include="*.go" . | grep -v ".cache/"
# test/e2e/scenarios_test.go:877 (only external caller, via *grpcprovider.Provider concrete type)
```

## Specialist Review Results

| Specialist | Result |
|---|---|
| QA Test Runner (`make test-agent-complete`) | ✅ PASS — 139 packages, integration, cross-platform builds |
| QA Code Reviewer | ✅ PASS — no issues introduced by this story (pre-existing stubs are unmodified; SendResponse disconnect coverage in `reconnect_test.go:252`) |
| Security Engineer | ✅ PASS — epic #747 F4 vector structurally eliminated; CN validation preserved; `SanitizeLogValue` on all log fields |

## Test plan

- [x] `go build ./...` — clean
- [x] `go test ./pkg/controlplane/... ./features/steward/client/... ./features/controller/heartbeat/... ./features/controller/server/...` — all pass
- [x] `make test-agent-complete` — all gates pass (QA Test Runner)
- [x] `make check-architecture` — no central provider violations
- [x] `make security-scan` — clean

Fixes #829

🤖 Generated with [Claude Code](https://claude.com/claude-code)