### PR TITLE
api: add Server.Close to stop background goroutines (Issue #862)

### DIFF
--- a/features/controller/api/handlers_registration_test.go
+++ b/features/controller/api/handlers_registration_test.go
@@ -85,9 +85,9 @@ func newHandleRegisterServer(t *testing.T, tokenStore registration.Store, certMg
 	)
 	require.NoError(t, rbacManager.Initialize(context.Background()))
 	t.Cleanup(func() {
-		flushCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		closeCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
-		_ = rbacManager.FlushAudit(flushCtx)
+		_ = rbacManager.Close(closeCtx)
 	})
 
 	tenantStore := tenant.NewStorageAdapter(storageManager.GetTenantStore())
@@ -111,6 +111,13 @@ func newHandleRegisterServer(t *testing.T, tokenStore registration.Store, certMg
 		auditMgr,
 	)
 	require.NoError(t, err)
+	t.Cleanup(func() {
+		closeCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		if err := server.Close(closeCtx); err != nil {
+			t.Errorf("server.Close: %v", err)
+		}
+	})
 	return server, auditMgr
 }
 

--- a/features/controller/api/handlers_registration_tokens_test.go
+++ b/features/controller/api/handlers_registration_tokens_test.go
@@ -53,9 +53,9 @@ func setupTestServerWithTokenStore(t *testing.T) (*Server, registration.Store) {
 	err = rbacManager.Initialize(context.Background())
 	require.NoError(t, err)
 	t.Cleanup(func() {
-		flushCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		closeCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
-		_ = rbacManager.FlushAudit(flushCtx)
+		_ = rbacManager.Close(closeCtx)
 	})
 
 	// Initialize tenant management with durable storage
@@ -107,6 +107,13 @@ func setupTestServerWithTokenStore(t *testing.T) (*Server, registration.Store) {
 		auditMgr, // Issue #775: registration audit events
 	)
 	require.NoError(t, err)
+	t.Cleanup(func() {
+		closeCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		if err := server.Close(closeCtx); err != nil {
+			t.Errorf("server.Close: %v", err)
+		}
+	})
 
 	return server, tokenStore
 }

--- a/features/controller/api/server.go
+++ b/features/controller/api/server.go
@@ -69,6 +69,9 @@ type Server struct {
 	fleetQuery              fleet.FleetQuery               // Issue #603: Single query path for device filtering
 	gitSyncWebhookHandler   http.Handler                   // Issue #666: git-sync webhook endpoint (optional)
 	auditManager            *audit.Manager                 // Issue #775: registration audit events
+	stopCleanup             chan struct{}                  // signals startAPIKeyCleanup to exit
+	cleanupDone             chan struct{}                  // closed when cleanup goroutine exits
+	closeOnce               sync.Once                      // idempotent Close
 }
 
 // APIKey represents an API key for external authentication
@@ -146,6 +149,8 @@ func New(
 		secretStore:             secretStore,              // M-AUTH-1: Central secrets provider
 		approvalHook:            &DefaultApprovalHook{},   // Issue #422: accept-all default
 		auditManager:            auditManager,             // Issue #775: registration audit events
+		stopCleanup:             make(chan struct{}),
+		cleanupDone:             make(chan struct{}),
 	}
 
 	// Story #380: Initialize three-tier auth defense system
@@ -429,29 +434,59 @@ func (s *Server) Start() error {
 	return nil
 }
 
-// Stop gracefully shuts down the HTTP server
-func (s *Server) Stop() error {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
-	s.logger.Info("Shutting down REST API server")
-
-	// Story #380: Stop auth defense system
-	if s.authDefense != nil {
-		s.authDefense.Stop()
-	}
-
-	if s.httpServer != nil {
-		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-		defer cancel()
-
-		if err := s.httpServer.Shutdown(ctx); err != nil {
-			s.logger.Error("Failed to shutdown HTTP server gracefully", "error", err)
-			return err
+// Close gracefully stops all background goroutines owned by this Server and
+// shuts down the HTTP listener. It is safe to call more than once (idempotent).
+func (s *Server) Close(ctx context.Context) error {
+	var firstErr error
+	s.closeOnce.Do(func() {
+		// Signal the cleanup goroutine to exit — do this before acquiring s.mu
+		// to avoid deadlock: cleanupExpiredAPIKeys also holds s.mu.
+		close(s.stopCleanup)
+		select {
+		case <-s.cleanupDone:
+		case <-ctx.Done():
+			firstErr = fmt.Errorf("api server close: timed out waiting for cleanup goroutine: %w", ctx.Err())
 		}
-	}
 
-	return nil
+		// Stop audit manager before closing the HTTP server so that any
+		// in-flight audit writes can still reach storage.
+		if s.auditManager != nil {
+			if err := s.auditManager.Stop(ctx); err != nil && firstErr == nil {
+				firstErr = err
+			}
+		}
+
+		s.mu.Lock()
+		defer s.mu.Unlock()
+
+		// Story #380: Stop auth defense system
+		if s.authDefense != nil {
+			s.authDefense.Stop()
+		}
+
+		// M-AUTH-1: Close secret store to stop its internal cache cleanup goroutine.
+		if s.secretStore != nil {
+			if err := s.secretStore.Close(); err != nil && firstErr == nil {
+				firstErr = err
+			}
+		}
+
+		if s.httpServer != nil {
+			if err := s.httpServer.Shutdown(ctx); err != nil && firstErr == nil {
+				s.logger.Error("Failed to shutdown HTTP server gracefully", "error", err)
+				firstErr = err
+			}
+		}
+	})
+	return firstErr
+}
+
+// Stop gracefully shuts down the HTTP server. Prefer Close when a context is available.
+func (s *Server) Stop() error {
+	s.logger.Info("Shutting down REST API server")
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	return s.Close(ctx)
 }
 
 // SetRollbackManager sets the rollback manager for rollback API routes (Story #416)
@@ -702,16 +737,23 @@ func (s *Server) GetListenAddr() string {
 	return s.getHTTPListenAddr()
 }
 
-// startAPIKeyCleanup starts a background goroutine to clean up expired API keys
+// startAPIKeyCleanup starts a background goroutine to clean up expired API keys.
+// The goroutine exits when Close is called.
 func (s *Server) startAPIKeyCleanup() {
 	go func() {
-		ticker := time.NewTicker(10 * time.Minute) // Clean up every 10 minutes
+		defer close(s.cleanupDone)
+		ticker := time.NewTicker(10 * time.Minute)
 		defer ticker.Stop()
 
 		s.logger.Info("Started API key cleanup background process", "interval", "10 minutes")
 
-		for range ticker.C {
-			s.cleanupExpiredAPIKeys()
+		for {
+			select {
+			case <-s.stopCleanup:
+				return
+			case <-ticker.C:
+				s.cleanupExpiredAPIKeys()
+			}
 		}
 	}()
 }

--- a/features/controller/api/server_test.go
+++ b/features/controller/api/server_test.go
@@ -51,9 +51,9 @@ func setupTestServer(t *testing.T) *Server {
 	err = rbacManager.Initialize(context.Background())
 	require.NoError(t, err)
 	t.Cleanup(func() {
-		flushCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		closeCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
-		_ = rbacManager.FlushAudit(flushCtx)
+		_ = rbacManager.Close(closeCtx)
 	})
 
 	// Initialize tenant management with durable storage (git-backed)
@@ -91,6 +91,13 @@ func setupTestServer(t *testing.T) *Server {
 		auditMgr, // Issue #775: registration audit events
 	)
 	require.NoError(t, err)
+	t.Cleanup(func() {
+		closeCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		if err := server.Close(closeCtx); err != nil {
+			t.Errorf("server.Close: %v", err)
+		}
+	})
 
 	return server
 }
@@ -849,9 +856,9 @@ func setupTestServerWithLogger(t *testing.T, logger logging.Logger) *Server {
 	err = rbacManager.Initialize(context.Background())
 	require.NoError(t, err)
 	t.Cleanup(func() {
-		flushCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		closeCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
-		_ = rbacManager.FlushAudit(flushCtx)
+		_ = rbacManager.Close(closeCtx)
 	})
 
 	tenantStore := tenant.NewStorageAdapter(storageManager.GetTenantStore())
@@ -871,6 +878,13 @@ func setupTestServerWithLogger(t *testing.T, logger logging.Logger) *Server {
 		nil, nil, nil, nil, nil, "", nil, auditMgr,
 	)
 	require.NoError(t, err)
+	t.Cleanup(func() {
+		closeCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		if err := server.Close(closeCtx); err != nil {
+			t.Errorf("server.Close: %v", err)
+		}
+	})
 
 	return server
 }
@@ -1111,6 +1125,47 @@ func TestAPIServerStartStop(t *testing.T) {
 	// cleanly even if ListenAndServe hasn't bound yet — no sleep required.
 	err = server.Stop()
 	assert.NoError(t, err, "api.Server.Stop() must return no error")
+}
+
+// TestServerClose_Idempotent verifies the Close contract: calling Close more than once
+// must not panic and must return nil on every call (Issue #862).
+func TestServerClose_Idempotent(t *testing.T) {
+	server := setupTestServer(t)
+	ctx := context.Background()
+
+	err := server.Close(ctx)
+	assert.NoError(t, err, "first Close must succeed")
+
+	// Second call must be a no-op: no panic, no error.
+	err = server.Close(ctx)
+	assert.NoError(t, err, "second Close must be idempotent and return nil")
+
+	// Third call via Stop (which delegates to Close) must also be safe.
+	err = server.Stop()
+	assert.NoError(t, err, "Stop after Close must be idempotent")
+}
+
+// TestServerClose_CancelledContext verifies that Close with an already-cancelled
+// context does not panic and returns a wrapped context.Canceled error or nil
+// (non-deterministic: the cleanup goroutine may exit before the select checks ctx.Done).
+// What matters is that the server is safely stopped in either case (Issue #862).
+func TestServerClose_CancelledContext(t *testing.T) {
+	server := setupTestServer(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancel immediately before calling Close
+
+	err := server.Close(ctx)
+	// Either nil (goroutine exited via stopCleanup before ctx.Done) or context.Canceled.
+	if err != nil {
+		assert.ErrorIs(t, err, context.Canceled,
+			"non-nil error must wrap context.Canceled, got: %v", err)
+	}
+
+	// Server must be fully stopped regardless of which select arm won.
+	// A subsequent close with a valid context must be a no-op.
+	err2 := server.Close(context.Background())
+	assert.NoError(t, err2, "subsequent Close after cancelled-context Close must be idempotent")
 }
 
 // TestTenantContextKeyType verifies that ctxkeys.TenantID can be retrieved from a context

--- a/features/controller/server/server_security_test.go
+++ b/features/controller/server/server_security_test.go
@@ -178,6 +178,13 @@ func TestServer_New_SecurityValidation(t *testing.T) {
 			} else {
 				assert.NoError(t, err)
 				assert.NotNil(t, server)
+				if server != nil {
+					t.Cleanup(func() {
+						if err := server.Stop(); err != nil {
+							t.Errorf("server.Stop: %v", err)
+						}
+					})
+				}
 
 				// Verify security components are initialized
 				assert.NotNil(t, server.rbacManager)
@@ -269,6 +276,11 @@ func TestServer_StorageProviderValidation(t *testing.T) {
 				assert.NotNil(t, server, "Server should be created with valid provider '%s'", providerInfo.Name)
 
 				if server != nil {
+					t.Cleanup(func() {
+						if err := server.Stop(); err != nil {
+							t.Errorf("server.Stop: %v", err)
+						}
+					})
 					// Verify all storage interfaces are properly initialized
 					assert.NotNil(t, server.rbacManager, "RBAC manager should be initialized with provider '%s'", providerInfo.Name)
 					assert.NotNil(t, server.tenantManager, "Tenant manager should be initialized with provider '%s'", providerInfo.Name)
@@ -427,6 +439,11 @@ func TestServer_SecurityConfiguration(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			server, err := New(tt.config, logger)
 			require.NoError(t, err)
+			t.Cleanup(func() {
+				if err := server.Stop(); err != nil {
+					t.Errorf("server.Stop: %v", err)
+				}
+			})
 
 			// Run security checks
 			for _, check := range tt.securityChecks {
@@ -583,6 +600,13 @@ func TestServer_SecurityEdgeCases_And_AttackVectors(t *testing.T) {
 			} else {
 				assert.NoError(t, err, tt.description)
 				assert.NotNil(t, server)
+				if server != nil {
+					t.Cleanup(func() {
+						if err := server.Stop(); err != nil {
+							t.Errorf("server.Stop: %v", err)
+						}
+					})
+				}
 
 				// Validate security components are still initialized
 				assert.NotNil(t, server.rbacManager)
@@ -637,6 +661,7 @@ func TestServer_ConcurrentSecurity_And_RaceConditions(t *testing.T) {
 	// Collect results
 	successCount := 0
 	errorCount := 0
+	var createdServers []*Server
 
 	for i := 0; i < numConcurrent; i++ {
 		select {
@@ -644,6 +669,7 @@ func TestServer_ConcurrentSecurity_And_RaceConditions(t *testing.T) {
 			assert.NotNil(t, server)
 			assert.NotNil(t, server.rbacManager)
 			successCount++
+			createdServers = append(createdServers, server)
 		case err := <-errors:
 			t.Errorf("Unexpected error in concurrent server creation: %v", err)
 			errorCount++
@@ -654,6 +680,15 @@ func TestServer_ConcurrentSecurity_And_RaceConditions(t *testing.T) {
 
 	assert.Equal(t, numConcurrent, successCount)
 	assert.Equal(t, 0, errorCount)
+
+	// Stop all successfully created servers to prevent goroutine leaks.
+	t.Cleanup(func() {
+		for i, s := range createdServers {
+			if err := s.Stop(); err != nil {
+				t.Errorf("server[%d].Stop(): %v", i, err)
+			}
+		}
+	})
 }
 
 func TestServer_RBAC_SecurityIntegration(t *testing.T) {
@@ -676,6 +711,11 @@ func TestServer_RBAC_SecurityIntegration(t *testing.T) {
 	server, err := New(config, logger)
 	require.NoError(t, err)
 	require.NotNil(t, server)
+	t.Cleanup(func() {
+		if err := server.Stop(); err != nil {
+			t.Errorf("server.Stop: %v", err)
+		}
+	})
 
 	// Verify RBAC integration
 	assert.NotNil(t, server.rbacManager)
@@ -744,6 +784,13 @@ func TestServer_NetworkSecurity_And_Binding(t *testing.T) {
 			} else {
 				assert.NoError(t, err, tt.description)
 				assert.NotNil(t, server)
+				if server != nil {
+					t.Cleanup(func() {
+						if err := server.Stop(); err != nil {
+							t.Errorf("server.Stop: %v", err)
+						}
+					})
+				}
 			}
 		})
 	}
@@ -842,6 +889,11 @@ func TestServer_CertificateSecurityValidation(t *testing.T) {
 			server, err := New(cfg, logger)
 			require.NoError(t, err)
 			require.NotNil(t, server)
+			t.Cleanup(func() {
+				if err := server.Stop(); err != nil {
+					t.Errorf("server.Stop: %v", err)
+				}
+			})
 
 			// Run security checks
 			for _, check := range tt.securityChecks {
@@ -901,10 +953,20 @@ func TestServer_EnvironmentSecurityIsolation(t *testing.T) {
 	server1, err := New(config1, logger)
 	require.NoError(t, err)
 	require.NotNil(t, server1)
+	t.Cleanup(func() {
+		if err := server1.Stop(); err != nil {
+			t.Errorf("server1.Stop: %v", err)
+		}
+	})
 
 	server2, err := New(config2, logger)
 	require.NoError(t, err)
 	require.NotNil(t, server2)
+	t.Cleanup(func() {
+		if err := server2.Stop(); err != nil {
+			t.Errorf("server2.Stop: %v", err)
+		}
+	})
 
 	// Verify isolation
 	assert.NotEqual(t, server1.cfg.DataDir, server2.cfg.DataDir,
@@ -940,6 +1002,11 @@ func TestServer_DataDirectorySecurity(t *testing.T) {
 	server, err := New(config, logger)
 	require.NoError(t, err)
 	require.NotNil(t, server)
+	t.Cleanup(func() {
+		if err := server.Stop(); err != nil {
+			t.Errorf("server.Stop: %v", err)
+		}
+	})
 
 	// Verify data directory configuration is preserved
 	assert.Equal(t, tempDir, server.cfg.DataDir)
@@ -1018,6 +1085,13 @@ func TestServer_New_LegacyCompatibility(t *testing.T) {
 	srv, err := New(cfg, logger)
 	assert.NoError(t, err, "Server should start with legacy CA (auto-creates marker)")
 	assert.NotNil(t, srv)
+	if srv != nil {
+		t.Cleanup(func() {
+			if err := srv.Stop(); err != nil {
+				t.Errorf("srv.Stop: %v", err)
+			}
+		})
+	}
 
 	// Verify marker was created
 	assert.True(t, initialization.IsInitialized(certDir), "Marker should be auto-created for legacy CA")


### PR DESCRIPTION
## Summary

- **Root cause**: `features/controller/api.Server` started three background goroutines (`startAPIKeyCleanup`, `pkg/audit.drainLoop`, `pkg/cache.startCleanupRoutine` via SOPS secret store) but had no `Close` method. Tests constructing multiple Servers without cleanup accumulated unbounded goroutines, exposing as `panic: test timed out after 5m0s` on Windows (#861).
- **Fix**: Added `Server.Close(ctx context.Context) error` — idempotent, stops all owned goroutines. Updated all test setup helpers to register `t.Cleanup(server.Close)`. Replaced `rbacManager.FlushAudit` with `rbacManager.Close` in test cleanup (FlushAudit only flushed; Close also stops the drain goroutine). Added `server.Stop()` cleanup to `features/controller/server` tests.
- **Verified**: `go test -race -count=2 ./features/controller/api/...` scales linearly (~77s/run × 2 = ~155s) with no goroutine accumulation, confirming leaks are eliminated.

## Specialist Review Results

- **QA Test Runner**: PASS — All 88 packages pass, cross-platform builds pass, integration tests pass. Marker `/tmp/agent-validation-passed` written.
- **QA Code Reviewer**: PASS (Round 3) — No blocking issues. New tests `TestServerClose_Idempotent` and `TestServerClose_CancelledContext` cover the Close contract. All cleanup callsites use `t.Errorf` on error.
- **Security Engineer**: PASS — No security issues. `secretStore.Close()` uses the `SecretStore` interface, respects central provider abstraction, no sensitive data in errors.

## Test plan

- [x] `go test -race -count=2 ./features/controller/api/...` — PASS (~155s, linear scaling)
- [x] `go test -race -count=2 ./features/controller/server/...` — PASS
- [x] `TestServerClose_Idempotent` — Close called 3× returns nil each time
- [x] `TestServerClose_CancelledContext` — handles pre-cancelled context gracefully
- [x] `make test-agent-complete` — all gates pass

Fixes #862

🤖 Generated with [Claude Code](https://claude.com/claude-code)