### PR TITLE
tenant/security: route auditSecretOperation through pkg/audit.Manager (Issue #864)

### DIFF
--- a/features/tenant/security/secret_manager.go
+++ b/features/tenant/security/secret_manager.go
@@ -11,10 +11,13 @@ import (
 	"encoding/base64"
 	"fmt"
 	"io"
+	"log/slog"
 	"sync"
 	"time"
 
-	"github.com/cfgis/cfgms/pkg/security"
+	"github.com/cfgis/cfgms/pkg/audit"
+	pkgsecurity "github.com/cfgis/cfgms/pkg/security"
+	business "github.com/cfgis/cfgms/pkg/storage/interfaces/business"
 )
 
 // TenantSecretManager provides encrypted storage and management of tenant-specific secrets
@@ -22,7 +25,9 @@ type TenantSecretManager struct {
 	isolationEngine *TenantIsolationEngine
 	keyCache        map[string]*tenantEncryptionKey
 	keyMutex        sync.RWMutex
-	validator       *security.Validator
+	validator       *pkgsecurity.Validator
+	auditManager    *audit.Manager
+	logger          *slog.Logger
 }
 
 // tenantEncryptionKey represents an encryption key for a specific tenant
@@ -98,13 +103,17 @@ type TenantSecretAuditEntry struct {
 	UserAgent string    `json:"user_agent,omitempty"`
 }
 
-// NewTenantSecretManager creates a new tenant secret manager
-func NewTenantSecretManager(isolationEngine *TenantIsolationEngine) *TenantSecretManager {
+// NewTenantSecretManager creates a new tenant secret manager.
+// auditManager may be nil, in which case secret operations are not persisted
+// to the durable audit store (observable via a log warning on each operation).
+func NewTenantSecretManager(isolationEngine *TenantIsolationEngine, auditManager *audit.Manager) *TenantSecretManager {
 	return &TenantSecretManager{
 		isolationEngine: isolationEngine,
 		keyCache:        make(map[string]*tenantEncryptionKey),
 		keyMutex:        sync.RWMutex{},
-		validator:       security.NewValidator(),
+		validator:       pkgsecurity.NewValidator(),
+		auditManager:    auditManager,
+		logger:          slog.Default().With("component", "tenant_secret_manager"),
 	}
 }
 
@@ -398,7 +407,7 @@ func (tsm *TenantSecretManager) decryptData(encryptedData string, key *tenantEnc
 
 // validateSecretRequest validates a secret storage request
 func (tsm *TenantSecretManager) validateSecretRequest(request *SecretRequest) error {
-	result := &security.ValidationResult{Valid: true}
+	result := &pkgsecurity.ValidationResult{Valid: true}
 
 	// Validate tenant ID
 	tsm.validator.ValidateString(result, "tenant_id", request.TenantID, "required", "uuid")
@@ -463,20 +472,43 @@ func (tsm *TenantSecretManager) generateSecretID() string {
 	return fmt.Sprintf("secret_%x", hash[:16])
 }
 
-// auditSecretOperation logs secret management operations for audit purposes
+// auditSecretOperation routes secret management operations through the central audit manager.
+// Audit failures are logged but never propagate to the caller — secret operations must not
+// be blocked by a slow or unavailable audit store.
 func (tsm *TenantSecretManager) auditSecretOperation(ctx context.Context, tenantID, secretID, operation string, success bool, errorMsg string) {
-	entry := &TenantSecretAuditEntry{
-		ID:        tsm.generateSecretID(),
-		TenantID:  tenantID,
-		SecretID:  secretID,
-		Operation: operation,
-		Success:   success,
-		Error:     errorMsg,
-		Timestamp: time.Now(),
+	if tsm.auditManager == nil {
+		tsm.logger.Warn("audit manager not configured; secret operation not persisted to audit store",
+			"tenant_id", tenantID,
+			"operation", operation,
+		)
+		return
 	}
 
-	// In real implementation, this would be sent to audit logging system
-	_ = entry
+	eventType := business.AuditEventDataModification
+	if operation == "retrieve" {
+		eventType = business.AuditEventDataAccess
+	}
+
+	event := audit.NewEventBuilder().
+		Tenant(tenantID).
+		Type(eventType).
+		Action("secret."+operation).
+		User(audit.SystemUserID, business.AuditUserTypeSystem).
+		Resource("secret", secretID, "").
+		Severity(business.AuditSeverityHigh)
+
+	if !success && errorMsg != "" {
+		event = event.Error("SECRET_OP_FAILED", errorMsg)
+	}
+
+	if err := tsm.auditManager.RecordEvent(ctx, event); err != nil {
+		tsm.logger.Warn("failed to record secret operation audit event",
+			"error", err,
+			"tenant_id", tenantID,
+			"operation", operation,
+			"secret_id", secretID,
+		)
+	}
 }
 
 // ListSecrets returns a list of secrets for a tenant (metadata only, no secret data)

--- a/features/tenant/security/secret_manager_test.go
+++ b/features/tenant/security/secret_manager_test.go
@@ -9,6 +9,12 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/cfgis/cfgms/pkg/audit"
+	"github.com/cfgis/cfgms/pkg/storage/interfaces"
+	business "github.com/cfgis/cfgms/pkg/storage/interfaces/business"
+	_ "github.com/cfgis/cfgms/pkg/storage/providers/flatfile"
+	_ "github.com/cfgis/cfgms/pkg/storage/providers/sqlite"
 )
 
 func TestTenantSecretManager_StoreSecret(t *testing.T) {
@@ -25,7 +31,7 @@ func TestTenantSecretManager_StoreSecret(t *testing.T) {
 		},
 	}
 
-	tsm := NewTenantSecretManager(isolationEngine)
+	tsm := NewTenantSecretManager(isolationEngine, nil)
 	ctx := context.Background()
 
 	tests := []struct {
@@ -149,7 +155,7 @@ func TestTenantSecretManager_RetrieveSecret(t *testing.T) {
 		},
 	}
 
-	tsm := NewTenantSecretManager(isolationEngine)
+	tsm := NewTenantSecretManager(isolationEngine, nil)
 	ctx := context.Background()
 
 	tests := []struct {
@@ -205,7 +211,7 @@ func TestTenantSecretManager_EncryptDecryptCycle(t *testing.T) {
 	isolationEngine := &TenantIsolationEngine{
 		isolationRules: make(map[string]*IsolationRule),
 	}
-	tsm := NewTenantSecretManager(isolationEngine)
+	tsm := NewTenantSecretManager(isolationEngine, nil)
 	ctx := context.Background()
 
 	// Test data
@@ -246,7 +252,7 @@ func TestTenantSecretManager_KeyRotation(t *testing.T) {
 		},
 	}
 
-	tsm := NewTenantSecretManager(isolationEngine)
+	tsm := NewTenantSecretManager(isolationEngine, nil)
 	ctx := context.Background()
 
 	tenantID := "test-tenant-id"
@@ -276,7 +282,7 @@ func TestTenantSecretManager_KeyRotationNeeded(t *testing.T) {
 	isolationEngine := &TenantIsolationEngine{
 		isolationRules: make(map[string]*IsolationRule),
 	}
-	tsm := NewTenantSecretManager(isolationEngine)
+	tsm := NewTenantSecretManager(isolationEngine, nil)
 	ctx := context.Background()
 
 	tenantID := "test-tenant-123"
@@ -330,7 +336,7 @@ func TestTenantSecretManager_DeleteSecret(t *testing.T) {
 		},
 	}
 
-	tsm := NewTenantSecretManager(isolationEngine)
+	tsm := NewTenantSecretManager(isolationEngine, nil)
 	ctx := context.Background()
 
 	tests := []struct {
@@ -393,7 +399,7 @@ func TestTenantSecretManager_ListSecrets(t *testing.T) {
 		},
 	}
 
-	tsm := NewTenantSecretManager(isolationEngine)
+	tsm := NewTenantSecretManager(isolationEngine, nil)
 	ctx := context.Background()
 
 	tests := []struct {
@@ -455,7 +461,7 @@ func TestTenantSecretManager_ValidateSecretRequest(t *testing.T) {
 	isolationEngine := &TenantIsolationEngine{
 		isolationRules: make(map[string]*IsolationRule),
 	}
-	tsm := NewTenantSecretManager(isolationEngine)
+	tsm := NewTenantSecretManager(isolationEngine, nil)
 
 	tests := []struct {
 		name    string
@@ -524,7 +530,7 @@ func TestTenantSecretManager_GenerateSecretID(t *testing.T) {
 	isolationEngine := &TenantIsolationEngine{
 		isolationRules: make(map[string]*IsolationRule),
 	}
-	tsm := NewTenantSecretManager(isolationEngine)
+	tsm := NewTenantSecretManager(isolationEngine, nil)
 
 	// Generate multiple IDs and ensure they are unique
 	ids := make(map[string]bool)
@@ -542,15 +548,22 @@ func BenchmarkTenantSecretManager_EncryptData(b *testing.B) {
 	isolationEngine := &TenantIsolationEngine{
 		isolationRules: make(map[string]*IsolationRule),
 	}
-	tsm := NewTenantSecretManager(isolationEngine)
+	tsm := NewTenantSecretManager(isolationEngine, nil)
 	ctx := context.Background()
 
-	key, _ := tsm.getTenantEncryptionKey(ctx, "bench-tenant")
+	key, err := tsm.getTenantEncryptionKey(ctx, "bench-tenant")
+	if err != nil {
+		b.Fatal(err)
+	}
 	data := []byte("benchmark-secret-data-for-encryption-testing")
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_, _ = tsm.encryptData(data, key)
+		out, err := tsm.encryptData(data, key)
+		if err != nil {
+			b.Fatal(err)
+		}
+		_ = out
 	}
 }
 
@@ -558,15 +571,200 @@ func BenchmarkTenantSecretManager_DecryptData(b *testing.B) {
 	isolationEngine := &TenantIsolationEngine{
 		isolationRules: make(map[string]*IsolationRule),
 	}
-	tsm := NewTenantSecretManager(isolationEngine)
+	tsm := NewTenantSecretManager(isolationEngine, nil)
 	ctx := context.Background()
 
-	key, _ := tsm.getTenantEncryptionKey(ctx, "bench-tenant")
+	key, err := tsm.getTenantEncryptionKey(ctx, "bench-tenant")
+	if err != nil {
+		b.Fatal(err)
+	}
 	data := []byte("benchmark-secret-data-for-decryption-testing")
-	encryptedData, _ := tsm.encryptData(data, key)
+	encryptedData, err := tsm.encryptData(data, key)
+	if err != nil {
+		b.Fatal(err)
+	}
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_, _ = tsm.decryptData(encryptedData, key)
+		out, err := tsm.decryptData(encryptedData, key)
+		if err != nil {
+			b.Fatal(err)
+		}
+		_ = out
 	}
+}
+
+// TestTenantSecretManager_AuditIntegration verifies that secret operations produce
+// durable audit entries in the central pkg/audit.Manager store.
+func TestTenantSecretManager_AuditIntegration(t *testing.T) {
+	tmpDir := t.TempDir()
+	storageManager, err := interfaces.CreateOSSStorageManager(tmpDir+"/flatfile", tmpDir+"/cfgms.db")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = storageManager.Close() })
+
+	auditMgr, err := audit.NewManager(storageManager.GetAuditStore(), "tenant_secret_manager")
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_ = auditMgr.Stop(ctx)
+	})
+
+	tenantID := "550e8400-e29b-41d4-a716-446655440000"
+	isolationEngine := &TenantIsolationEngine{
+		isolationRules: map[string]*IsolationRule{
+			tenantID: {
+				TenantID: tenantID,
+				ResourceIsolation: ResourceRule{
+					IsolatedStorage:      true,
+					AllowResourceSharing: true,
+				},
+			},
+			"unauthorized-tenant": {
+				TenantID: "unauthorized-tenant",
+				ResourceIsolation: ResourceRule{
+					IsolatedStorage:      true,
+					AllowResourceSharing: false,
+					RestrictedResources:  []string{"secrets"},
+				},
+			},
+		},
+	}
+
+	tsm := NewTenantSecretManager(isolationEngine, auditMgr)
+	ctx := context.Background()
+
+	flushAudit := func(t *testing.T) {
+		t.Helper()
+		fCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+		defer cancel()
+		require.NoError(t, auditMgr.Flush(fCtx))
+	}
+
+	t.Run("StoreSecret produces audit entry with correct fields", func(t *testing.T) {
+		resp, err := tsm.StoreSecret(ctx, &SecretRequest{
+			TenantID:   tenantID,
+			Name:       "audit-test-key",
+			SecretType: SecretTypeAPIKey,
+			Data:       []byte("super-secret-value"),
+		})
+		require.NoError(t, err)
+		require.Empty(t, resp.Error)
+		secretID := resp.Secret.ID
+
+		flushAudit(t)
+		entries, err := auditMgr.QueryEntries(ctx, &business.AuditFilter{
+			TenantID:      tenantID,
+			Actions:       []string{"secret.store"},
+			ResourceTypes: []string{"secret"},
+			ResourceIDs:   []string{secretID},
+			Limit:         10,
+		})
+		require.NoError(t, err)
+		require.Len(t, entries, 1)
+
+		e := entries[0]
+		assert.Equal(t, tenantID, e.TenantID)
+		assert.Equal(t, "secret.store", e.Action)
+		assert.Equal(t, "secret", e.ResourceType)
+		assert.Equal(t, secretID, e.ResourceID)
+		assert.Equal(t, business.AuditResultSuccess, e.Result)
+		assert.Equal(t, "tenant_secret_manager", e.Source)
+	})
+
+	t.Run("RetrieveSecret produces audit entry with correct fields", func(t *testing.T) {
+		secretID := "retrieve-audit-test"
+		_, err := tsm.RetrieveSecret(ctx, tenantID, secretID)
+		require.NoError(t, err)
+
+		flushAudit(t)
+		entries, err := auditMgr.QueryEntries(ctx, &business.AuditFilter{
+			TenantID:      tenantID,
+			Actions:       []string{"secret.retrieve"},
+			ResourceTypes: []string{"secret"},
+			ResourceIDs:   []string{secretID},
+			Limit:         10,
+		})
+		require.NoError(t, err)
+		require.Len(t, entries, 1)
+
+		e := entries[0]
+		assert.Equal(t, tenantID, e.TenantID)
+		assert.Equal(t, "secret.retrieve", e.Action)
+		assert.Equal(t, "secret", e.ResourceType)
+		assert.Equal(t, secretID, e.ResourceID)
+		assert.Equal(t, business.AuditResultSuccess, e.Result)
+	})
+
+	t.Run("RotateSecret produces audit entry with correct fields", func(t *testing.T) {
+		secretID := "rotate-audit-test"
+		_, err := tsm.RotateSecret(ctx, tenantID, secretID, []byte("new-rotated-value"))
+		require.NoError(t, err)
+
+		flushAudit(t)
+		entries, err := auditMgr.QueryEntries(ctx, &business.AuditFilter{
+			TenantID:      tenantID,
+			Actions:       []string{"secret.rotate"},
+			ResourceTypes: []string{"secret"},
+			ResourceIDs:   []string{secretID},
+			Limit:         10,
+		})
+		require.NoError(t, err)
+		require.Len(t, entries, 1)
+
+		e := entries[0]
+		assert.Equal(t, tenantID, e.TenantID)
+		assert.Equal(t, "secret.rotate", e.Action)
+		assert.Equal(t, "secret", e.ResourceType)
+		assert.Equal(t, secretID, e.ResourceID)
+		assert.Equal(t, business.AuditResultSuccess, e.Result)
+	})
+
+	t.Run("Failed RetrieveSecret produces error audit entry", func(t *testing.T) {
+		secretID := "denied-retrieve-test"
+		resp, err := tsm.RetrieveSecret(ctx, "unauthorized-tenant", secretID)
+		require.NoError(t, err)
+		assert.NotEmpty(t, resp.Error)
+
+		flushAudit(t)
+		entries, err := auditMgr.QueryEntries(ctx, &business.AuditFilter{
+			TenantID:      "unauthorized-tenant",
+			Actions:       []string{"secret.retrieve"},
+			ResourceTypes: []string{"secret"},
+			ResourceIDs:   []string{secretID},
+			Results:       []business.AuditResult{business.AuditResultError},
+			Limit:         10,
+		})
+		require.NoError(t, err)
+		require.Len(t, entries, 1)
+
+		e := entries[0]
+		assert.Equal(t, "unauthorized-tenant", e.TenantID)
+		assert.Equal(t, business.AuditResultError, e.Result)
+		assert.Equal(t, "SECRET_OP_FAILED", e.ErrorCode)
+	})
+
+	t.Run("DeleteSecret produces audit entry with correct fields", func(t *testing.T) {
+		secretID := "delete-audit-test"
+		err := tsm.DeleteSecret(ctx, tenantID, secretID)
+		require.NoError(t, err)
+
+		flushAudit(t)
+		entries, err := auditMgr.QueryEntries(ctx, &business.AuditFilter{
+			TenantID:      tenantID,
+			Actions:       []string{"secret.delete"},
+			ResourceTypes: []string{"secret"},
+			ResourceIDs:   []string{secretID},
+			Limit:         10,
+		})
+		require.NoError(t, err)
+		require.Len(t, entries, 1)
+
+		e := entries[0]
+		assert.Equal(t, tenantID, e.TenantID)
+		assert.Equal(t, "secret.delete", e.Action)
+		assert.Equal(t, "secret", e.ResourceType)
+		assert.Equal(t, secretID, e.ResourceID)
+		assert.Equal(t, business.AuditResultSuccess, e.Result)
+	})
 }

--- a/pkg/audit/README.md
+++ b/pkg/audit/README.md
@@ -271,6 +271,34 @@ tr := &business.TimeRange{Start: &lookback}
 failedActions, err := rbacManager.AuditManager().GetFailedActions(ctx, tr, 100)
 ```
 
+## Secret Manager Events (Issue #864)
+
+Secret store, retrieve, rotate, and delete operations in `features/tenant/security.TenantSecretManager`
+are recorded via `pkg/audit.Manager`. Each entry has:
+
+| `AuditEntry` field | Value |
+|---|---|
+| `EventType` | `AuditEventDataModification` (store/rotate/delete) or `AuditEventDataAccess` (retrieve) |
+| `ResourceType` | `"secret"` |
+| `ResourceID` | The secret ID |
+| `UserID` | `SystemUserID` (`"system"`) — operations are initiated by the secret manager itself |
+| `Action` | `"secret.store"`, `"secret.retrieve"`, `"secret.rotate"`, or `"secret.delete"` |
+| `Result` | `AuditResultSuccess` on success; `AuditResultError` on failure |
+| `ErrorCode` | `"SECRET_OP_FAILED"` when result is `AuditResultError` |
+| `Severity` | `AuditSeverityHigh` — all secret operations are sensitive |
+| `Source` | `"tenant_secret_manager"` |
+
+### Migration from TenantSecretAuditEntry (Issue #864)
+
+The former `TenantSecretAuditEntry` was constructed in `auditSecretOperation` and discarded
+(`_ = entry`). All secret-operation audit events now flow through `pkg/audit.Manager` backed
+by durable storage and survive process restarts.
+
+| Old behaviour | Replacement |
+|---|---|
+| `auditSecretOperation` building a local struct and discarding it | `auditManager.RecordEvent` routes the event to the durable audit store |
+| `TenantSecretAuditEntry` struct (still present for in-memory use) | Central `AuditEntry` in the durable store, queryable via `Manager.QueryEntries` |
+
 ### Migration from rbac.AuditLogger (Issue #768)
 
 The former `rbac.AuditLogger` in-memory store and its associated types


### PR DESCRIPTION
## Summary

- `auditSecretOperation` in `TenantSecretManager` now calls `auditManager.RecordEvent` — the `_ = entry` discard pattern is removed entirely
- `TenantSecretManager` accepts a `*pkg/audit.Manager` via the updated `NewTenantSecretManager` constructor; all call sites updated
- Audit failures are logged via `slog.Warn` and never propagate to the caller — secret operations are unaffected by a slow or unavailable audit store
- New `TestTenantSecretManager_AuditIntegration` test uses real `interfaces.CreateOSSStorageManager` + real `audit.NewManager` backed by `t.TempDir()`; asserts durable entries for store, retrieve, rotate, delete, and failure paths
- Pre-existing benchmark issue fixed: setup errors and loop-body errors in both `Benchmark*` functions are now handled with `b.Fatal`
- `pkg/audit/README.md` updated with a "Secret Manager Events" consumer section

## Test plan

- [ ] `go test ./features/tenant/security/... -v -run TestTenantSecretManager_AuditIntegration` — confirms all four operations produce durable audit entries with correct fields
- [ ] `go test ./features/tenant/security/...` — all package tests pass
- [ ] `go test ./pkg/audit/...` — audit package unaffected
- [ ] `make test-agent-complete` — all CI gates pass (verified by qa-test-runner specialist)

## Specialist Review Results

| Reviewer | Result |
|---|---|
| qa-test-runner | **PASS** — all quality gates passed including cross-platform builds and production-critical tests |
| qa-code-reviewer | **PASS** — no blocking issues; benchmarks fixed, DeleteSecret audit path covered |
| security-engineer | **PASS** — no blocking issues; architecture compliance confirmed, no secrets in logs, tenant isolation preserved |

Fixes #864

🤖 Generated with [Claude Code](https://claude.com/claude-code)