### PR TITLE
tenant: cascade RBAC cleanup on DeleteTenant (Issue #868)

### DIFF
--- a/features/rbac/manager.go
+++ b/features/rbac/manager.go
@@ -652,6 +652,62 @@ func (m *Manager) DeleteSubject(ctx context.Context, id string) error {
 	return m.store.DeleteSubject(ctx, id)
 }
 
+// ListAllSubjects returns all subjects scoped to a tenant, across all subject types.
+func (m *Manager) ListAllSubjects(ctx context.Context, tenantID string) ([]*common.Subject, error) {
+	return m.store.ListSubjects(ctx, tenantID, common.SubjectType_SUBJECT_TYPE_UNSPECIFIED)
+}
+
+// DeleteSubjectsByTenant removes all subjects scoped to a tenant.
+// Failures on individual deletes are logged and the loop continues (best-effort).
+func (m *Manager) DeleteSubjectsByTenant(ctx context.Context, tenantID string) error {
+	if tenantID == "" {
+		return fmt.Errorf("tenantID must not be empty")
+	}
+	subjects, err := m.ListAllSubjects(ctx, tenantID)
+	if err != nil {
+		return fmt.Errorf("failed to list subjects for tenant %s: %w", tenantID, err)
+	}
+	for _, subject := range subjects {
+		if delErr := m.DeleteSubject(ctx, subject.Id); delErr != nil {
+			slog.Warn("rbac: failed to delete subject during tenant cascade cleanup",
+				"tenant_id", tenantID,
+				"subject_id", subject.Id,
+				"error", delErr,
+			)
+		}
+	}
+	return nil
+}
+
+// DeleteRolesByTenant removes all non-system roles scoped to a tenant.
+// System roles are global and are never touched by this operation.
+// Failures on individual deletes are logged and the loop continues (best-effort).
+// The context is enriched with a cascade justification required by the M-AUTH-2 sensitive-operation gate.
+func (m *Manager) DeleteRolesByTenant(ctx context.Context, tenantID string) error {
+	if tenantID == "" {
+		return fmt.Errorf("tenantID must not be empty")
+	}
+	roles, err := m.ListRoles(ctx, tenantID)
+	if err != nil {
+		return fmt.Errorf("failed to list roles for tenant %s: %w", tenantID, err)
+	}
+	ctxWithJustification := WithSensitiveOperationJustification(ctx, "tenant deletion cascade: removing all roles scoped to deleted tenant")
+	for _, role := range roles {
+		// ListRoles includes system roles; never delete those during tenant cleanup.
+		if role.IsSystemRole || role.TenantId != tenantID {
+			continue
+		}
+		if delErr := m.DeleteRole(ctxWithJustification, role.Id); delErr != nil {
+			slog.Warn("rbac: failed to delete role during tenant cascade cleanup",
+				"tenant_id", tenantID,
+				"role_id", role.Id,
+				"error", delErr,
+			)
+		}
+	}
+	return nil
+}
+
 func (m *Manager) GetSubjectRoles(ctx context.Context, subjectID string, tenantID string) ([]*common.Role, error) {
 	return m.store.GetSubjectRoles(ctx, subjectID, tenantID)
 }

--- a/features/rbac/manager_test.go
+++ b/features/rbac/manager_test.go
@@ -528,3 +528,143 @@ func TestManager_InactiveSubjectPermissions(t *testing.T) {
 	assert.False(t, response.Granted)
 	assert.Contains(t, response.Reason, "inactive")
 }
+
+func TestManager_ListAllSubjects(t *testing.T) {
+	tmpDir := t.TempDir()
+	storageManager, err := interfaces.CreateOSSStorageManager(tmpDir+"/flatfile", tmpDir+"/cfgms.db")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = storageManager.Close() })
+
+	manager := NewManagerWithStorage(
+		storageManager.GetAuditStore(),
+		storageManager.GetClientTenantStore(),
+		storageManager.GetRBACStore(),
+	)
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_ = manager.Close(ctx)
+	})
+	ctx := context.Background()
+
+	require.NoError(t, manager.Initialize(ctx))
+
+	tenantID := "list-all-subjects-tenant"
+
+	subjects := []*common.Subject{
+		{Id: "user-1", Type: common.SubjectType_SUBJECT_TYPE_USER, TenantId: tenantID, IsActive: true},
+		{Id: "svc-1", Type: common.SubjectType_SUBJECT_TYPE_SERVICE, TenantId: tenantID, IsActive: true},
+		{Id: "steward-1", Type: common.SubjectType_SUBJECT_TYPE_STEWARD, TenantId: tenantID, IsActive: true},
+		{Id: "other-tenant-user", Type: common.SubjectType_SUBJECT_TYPE_USER, TenantId: "other-tenant", IsActive: true},
+	}
+	for _, s := range subjects {
+		require.NoError(t, manager.CreateSubject(ctx, s))
+	}
+
+	all, err := manager.ListAllSubjects(ctx, tenantID)
+	require.NoError(t, err)
+	assert.Len(t, all, 3, "expected only subjects scoped to the tenant")
+
+	ids := make([]string, len(all))
+	for i, s := range all {
+		ids[i] = s.Id
+	}
+	assert.ElementsMatch(t, []string{"user-1", "svc-1", "steward-1"}, ids)
+}
+
+func TestManager_DeleteSubjectsByTenant(t *testing.T) {
+	tmpDir := t.TempDir()
+	storageManager, err := interfaces.CreateOSSStorageManager(tmpDir+"/flatfile", tmpDir+"/cfgms.db")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = storageManager.Close() })
+
+	manager := NewManagerWithStorage(
+		storageManager.GetAuditStore(),
+		storageManager.GetClientTenantStore(),
+		storageManager.GetRBACStore(),
+	)
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_ = manager.Close(ctx)
+	})
+	ctx := context.Background()
+
+	require.NoError(t, manager.Initialize(ctx))
+
+	tenantID := "delete-subjects-tenant"
+	otherTenantID := "other-tenant"
+
+	for _, s := range []*common.Subject{
+		{Id: "subj-a", Type: common.SubjectType_SUBJECT_TYPE_USER, TenantId: tenantID, IsActive: true},
+		{Id: "subj-b", Type: common.SubjectType_SUBJECT_TYPE_SERVICE, TenantId: tenantID, IsActive: true},
+		{Id: "subj-other", Type: common.SubjectType_SUBJECT_TYPE_USER, TenantId: otherTenantID, IsActive: true},
+	} {
+		require.NoError(t, manager.CreateSubject(ctx, s))
+	}
+
+	err = manager.DeleteSubjectsByTenant(ctx, tenantID)
+	require.NoError(t, err)
+
+	remaining, err := manager.ListAllSubjects(ctx, tenantID)
+	require.NoError(t, err)
+	assert.Empty(t, remaining, "expected no subjects for deleted tenant")
+
+	// Other tenant's subjects must be untouched
+	others, err := manager.ListAllSubjects(ctx, otherTenantID)
+	require.NoError(t, err)
+	assert.Len(t, others, 1)
+}
+
+func TestManager_DeleteRolesByTenant(t *testing.T) {
+	tmpDir := t.TempDir()
+	storageManager, err := interfaces.CreateOSSStorageManager(tmpDir+"/flatfile", tmpDir+"/cfgms.db")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = storageManager.Close() })
+
+	manager := NewManagerWithStorage(
+		storageManager.GetAuditStore(),
+		storageManager.GetClientTenantStore(),
+		storageManager.GetRBACStore(),
+	)
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_ = manager.Close(ctx)
+	})
+	ctx := context.Background()
+
+	require.NoError(t, manager.Initialize(ctx))
+
+	tenantID := "delete-roles-tenant"
+	otherTenantID := "other-roles-tenant"
+
+	for _, r := range []*common.Role{
+		{Id: tenantID + ".role-a", Name: "Role A", TenantId: tenantID},
+		{Id: tenantID + ".role-b", Name: "Role B", TenantId: tenantID},
+		{Id: otherTenantID + ".role-x", Name: "Role X", TenantId: otherTenantID},
+	} {
+		require.NoError(t, manager.CreateRole(ctx, r))
+	}
+
+	err = manager.DeleteRolesByTenant(ctx, tenantID)
+	require.NoError(t, err)
+
+	// ListRoles includes system roles; verify only tenant-scoped roles are gone
+	all, err := manager.ListRoles(ctx, tenantID)
+	require.NoError(t, err)
+	for _, r := range all {
+		assert.NotEqual(t, tenantID, r.TenantId, "tenant-scoped role should have been deleted: %s", r.Id)
+	}
+
+	// Verify individual roles are gone
+	_, err = manager.GetRole(ctx, tenantID+".role-a")
+	assert.Error(t, err, "role-a should not exist after DeleteRolesByTenant")
+	_, err = manager.GetRole(ctx, tenantID+".role-b")
+	assert.Error(t, err, "role-b should not exist after DeleteRolesByTenant")
+
+	// Other tenant's role must be untouched
+	otherRole, err := manager.GetRole(ctx, otherTenantID+".role-x")
+	require.NoError(t, err)
+	assert.Equal(t, otherTenantID, otherRole.TenantId)
+}

--- a/features/tenant/manager.go
+++ b/features/tenant/manager.go
@@ -5,6 +5,7 @@ package tenant
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"regexp"
 	"time"
 
@@ -108,6 +109,24 @@ func (m *Manager) DeleteTenant(ctx context.Context, tenantID string) error {
 	}
 	if len(children) > 0 {
 		return ErrTenantHasChildren
+	}
+
+	// Cascade RBAC cleanup: remove subjects then roles scoped to this tenant.
+	// Subjects first — they reference roles. Both loops are best-effort: a single
+	// child failure is logged and the cascade continues rather than aborting.
+	if m.rbacManager != nil {
+		if err := m.rbacManager.DeleteSubjectsByTenant(ctx, tenantID); err != nil {
+			slog.Warn("tenant: failed to list subjects for RBAC cascade cleanup",
+				"tenant_id", tenantID,
+				"error", err,
+			)
+		}
+		if err := m.rbacManager.DeleteRolesByTenant(ctx, tenantID); err != nil {
+			slog.Warn("tenant: failed to list roles for RBAC cascade cleanup",
+				"tenant_id", tenantID,
+				"error", err,
+			)
+		}
 	}
 
 	// Delete the tenant (soft delete)

--- a/features/tenant/manager_test.go
+++ b/features/tenant/manager_test.go
@@ -12,8 +12,10 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/cfgis/cfgms/api/proto/common"
 	"github.com/cfgis/cfgms/features/rbac"
 	"github.com/cfgis/cfgms/pkg/storage/interfaces"
+	cfgmstesting "github.com/cfgis/cfgms/pkg/testing"
 
 	// Import storage providers for testing
 	_ "github.com/cfgis/cfgms/pkg/storage/providers/flatfile"
@@ -517,4 +519,98 @@ func TestManager_IsTenantAncestor(t *testing.T) {
 	isAncestor, err = manager.IsTenantAncestor(ctx, child.ID, parent.ID)
 	require.NoError(t, err)
 	assert.False(t, isAncestor)
+}
+
+// setupRealTenantManager creates a Manager backed by real SQLite storage for cascade tests.
+func setupRealTenantManager(t *testing.T, rbacManager *rbac.Manager) *Manager {
+	t.Helper()
+	storageManager := cfgmstesting.SetupTestStorage(t)
+	tenantStore := NewStorageAdapter(storageManager.GetTenantStore())
+	return NewManager(tenantStore, rbacManager)
+}
+
+func TestDeleteTenant_CascadesRBACCleanup(t *testing.T) {
+	rbacManager := cfgmstesting.SetupTestRBACManager(t)
+	manager := setupRealTenantManager(t, rbacManager)
+	ctx := context.Background()
+
+	// Create a tenant — this also calls CreateTenantDefaultRoles (in-memory only)
+	tenant, err := manager.CreateTenant(ctx, &TenantRequest{Name: "RBACCleanupTenant"})
+	require.NoError(t, err)
+	tenantID := tenant.ID
+
+	// Explicitly create a persisted role and two subjects for this tenant
+	role := &common.Role{
+		Id:       tenantID + ".custom-role",
+		Name:     "Custom Role",
+		TenantId: tenantID,
+	}
+	require.NoError(t, rbacManager.CreateRole(ctx, role))
+
+	for _, s := range []*common.Subject{
+		{Id: "user-" + tenantID, Type: common.SubjectType_SUBJECT_TYPE_USER, TenantId: tenantID, IsActive: true},
+		{Id: "svc-" + tenantID, Type: common.SubjectType_SUBJECT_TYPE_SERVICE, TenantId: tenantID, IsActive: true},
+	} {
+		require.NoError(t, rbacManager.CreateSubject(ctx, s))
+	}
+
+	// Verify the persisted role and subjects exist before deletion
+	_, err = rbacManager.GetRole(ctx, role.Id)
+	require.NoError(t, err, "custom role must exist before deletion")
+
+	subjectsBefore, err := rbacManager.ListAllSubjects(ctx, tenantID)
+	require.NoError(t, err)
+	assert.NotEmpty(t, subjectsBefore, "expected subjects before tenant deletion")
+
+	// Delete the tenant — must cascade RBAC cleanup
+	require.NoError(t, manager.DeleteTenant(ctx, tenantID))
+
+	// Persisted role must be gone
+	_, err = rbacManager.GetRole(ctx, role.Id)
+	assert.Error(t, err, "custom role should not exist after tenant deletion")
+
+	// No subjects must remain for this tenant
+	subjectsAfter, err := rbacManager.ListAllSubjects(ctx, tenantID)
+	require.NoError(t, err)
+	assert.Empty(t, subjectsAfter, "expected no subjects after tenant deletion")
+
+	// No tenant-scoped roles must remain (ListRoles also returns system roles; skip those)
+	rolesAfter, err := rbacManager.ListRoles(ctx, tenantID)
+	require.NoError(t, err)
+	for _, r := range rolesAfter {
+		assert.NotEqual(t, tenantID, r.TenantId, "tenant-scoped role should have been deleted: %s", r.Id)
+	}
+}
+
+func TestDeleteTenant_CascadesRBACCleanup_NilRBACManager(t *testing.T) {
+	// Manager with nil rbacManager — must not panic, must succeed
+	manager := setupRealTenantManager(t, nil)
+	ctx := context.Background()
+
+	tenant, err := manager.CreateTenant(ctx, &TenantRequest{Name: "NoRBACTenant"})
+	require.NoError(t, err)
+
+	require.NoError(t, manager.DeleteTenant(ctx, tenant.ID))
+}
+
+// TestDeleteTenant_CascadesRBACCleanup_PartialFailureContinues verifies that
+// DeleteTenant returns nil even when individual RBAC cascade deletions encounter
+// errors. CreateTenant loads default tenant roles into the in-memory RBAC store
+// without persisting them to durable storage. The cascade deletes them from
+// in-memory but the durable delete fails; the warning is logged and the tenant
+// deletion proceeds successfully.
+func TestDeleteTenant_CascadesRBACCleanup_PartialFailureContinues(t *testing.T) {
+	rbacManager := cfgmstesting.SetupTestRBACManager(t)
+	manager := setupRealTenantManager(t, rbacManager)
+	ctx := context.Background()
+
+	// CreateTenant triggers CreateTenantDefaultRoles which loads roles into the
+	// in-memory store only (not the durable RBAC store). The cascade will
+	// encounter "role not found" errors from the durable layer — those must be
+	// logged as warnings, not returned as failures.
+	tenant, err := manager.CreateTenant(ctx, &TenantRequest{Name: "PartialFailureTenant"})
+	require.NoError(t, err)
+
+	// DeleteTenant must return nil despite individual cascade errors
+	require.NoError(t, manager.DeleteTenant(ctx, tenant.ID))
 }


### PR DESCRIPTION
## Summary

- `DeleteTenant` now cascades RBAC cleanup: all subjects and roles scoped to the deleted tenant are removed via `rbacManager` before the tenant record itself is deleted
- Added three new `rbac.Manager` convenience methods: `ListAllSubjects`, `DeleteSubjectsByTenant`, `DeleteRolesByTenant`
- Both cascade loops are best-effort — per-entity failures are logged via `slog.Warn` and the loop continues; `DeleteTenant` never aborts on a single RBAC failure
- `rbacManager == nil` guard added, preserving backward compatibility for test paths that don't wire RBAC
- Empty `tenantID` guard added to both bulk-delete methods to prevent accidental cross-tenant wipe (security depth-in-defense)

## Specialist Review Results

| Reviewer | Result | Notes |
|----------|--------|-------|
| QA Test Runner | **PASS** | All 6 story-specific tests pass; cross-platform builds (5/5 targets); no test failures |
| QA Code Reviewer | **PASS** | 0 blocking issues; new tests use real storage via `cfgmstesting.SetupTestRBACManager` and `NewStorageAdapter`; error path test included |
| Security Engineer | **PASS** | 0 blocking issues; gosec/staticcheck/architecture scans clean; M-AUTH-2 gate honored; empty-tenantID MEDIUM warning addressed |

## Test plan

- [x] `TestDeleteTenant_CascadesRBACCleanup` — creates tenant + persisted role + subjects, asserts all tenant-scoped RBAC entries gone after delete
- [x] `TestDeleteTenant_CascadesRBACCleanup_NilRBACManager` — verifies nil guard: no panic, tenant deleted
- [x] `TestDeleteTenant_CascadesRBACCleanup_PartialFailureContinues` — exercises partial-failure path (default roles not persisted to durable store); `DeleteTenant` returns nil despite cascade warnings
- [x] `TestManager_ListAllSubjects` — all subject types returned for tenant, other tenants excluded
- [x] `TestManager_DeleteSubjectsByTenant` — target tenant subjects deleted, other tenant untouched
- [x] `TestManager_DeleteRolesByTenant` — target tenant roles deleted, system roles and other tenant roles untouched

Closes #868

🤖 Generated with [Claude Code](https://claude.com/claude-code)