### PR TITLE
activedirectory: fix PowerShell injection via objectID allowlist (Issue #877)

### DIFF
--- a/features/modules/activedirectory/module.go
+++ b/features/modules/activedirectory/module.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os/exec"
+	"regexp"
 	"strings"
 	"sync"
 	"time"
@@ -16,6 +17,7 @@ import (
 	"github.com/cfgis/cfgms/features/modules"
 	"github.com/cfgis/cfgms/pkg/directory/interfaces"
 	"github.com/cfgis/cfgms/pkg/logging"
+	"github.com/cfgis/cfgms/pkg/security"
 )
 
 // ADModuleConfig represents the configuration for the system-context AD module
@@ -245,6 +247,22 @@ type DomainInfo struct {
 	NetBIOSName      string `json:"netbios_name"`
 }
 
+// objectIDPattern accepts SAM account names, UPNs, and GUIDs; rejects raw DNs and shell metacharacters.
+var objectIDPattern = regexp.MustCompile(`^[a-zA-Z0-9._@\-]+$`)
+
+// validateObjectID rejects any objectID containing characters outside the strict allowlist before
+// interpolation into PowerShell scripts, preventing command injection.
+func validateObjectID(objectID string) error {
+	matched, err := security.MatchStringWithTimeout(objectIDPattern, objectID)
+	if err != nil {
+		return fmt.Errorf("invalid objectID %q: validation error: %w", objectID, err)
+	}
+	if !matched {
+		return fmt.Errorf("invalid objectID %q: must match [a-zA-Z0-9._@-]+ (SAM account names, UPNs, and GUIDs only)", objectID)
+	}
+	return nil
+}
+
 // activeDirectoryModule implements the Module interface for local Active Directory management
 // using Windows system context and native AD APIs
 type activeDirectoryModule struct {
@@ -430,6 +448,10 @@ func (m *activeDirectoryModule) getSystemStatus(ctx context.Context) (modules.Co
 
 // queryADObjectSystem queries AD objects using Windows system context
 func (m *activeDirectoryModule) queryADObjectSystem(ctx context.Context, objectType, objectID string) (modules.ConfigState, error) {
+	if err := validateObjectID(objectID); err != nil {
+		return nil, err
+	}
+
 	m.updateStats(true)
 	startTime := time.Now()
 

--- a/features/modules/activedirectory/module_test.go
+++ b/features/modules/activedirectory/module_test.go
@@ -503,6 +503,71 @@ func TestActiveDirectoryModule_GetHostname(t *testing.T) {
 	// On non-Windows systems this might return "unknown" but should not panic
 }
 
+func TestValidateObjectID(t *testing.T) {
+	tests := []struct {
+		name      string
+		objectID  string
+		wantError bool
+	}{
+		{
+			name:      "injection with quote and ampersand",
+			objectID:  "' & Remove-ADUser",
+			wantError: true,
+		},
+		{
+			name:      "injection with semicolon",
+			objectID:  "user;whoami",
+			wantError: true,
+		},
+		{
+			name:      "injection with subshell",
+			objectID:  "admin$(rm -rf)",
+			wantError: true,
+		},
+		{
+			name:      "raw DN with comma and space",
+			objectID:  "CN=John,DC=domain,DC=com",
+			wantError: true,
+		},
+		{
+			name:      "simple dotted username",
+			objectID:  "john.doe",
+			wantError: false,
+		},
+		{
+			name:      "UPN format",
+			objectID:  "john.doe@domain.com",
+			wantError: false,
+		},
+		{
+			name:      "computer name with hyphen",
+			objectID:  "DOMAIN-PC01",
+			wantError: false,
+		},
+		{
+			name:      "GUID format",
+			objectID:  "550e8400-e29b-41d4-a716-446655440000",
+			wantError: false,
+		},
+		{
+			name:      "empty objectID rejected",
+			objectID:  "",
+			wantError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateObjectID(tt.objectID)
+			if tt.wantError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
 // Integration test functions that would run on actual Windows AD systems
 // These are marked as skipped in non-AD environments
 


### PR DESCRIPTION
## Summary

- Adds `validateObjectID(objectID string) error` in `features/modules/activedirectory/module.go` using a strict allowlist regex `^[a-zA-Z0-9._@\-]+$` evaluated through `security.MatchStringWithTimeout` (ReDoS-safe via the central `pkg/security` provider)
- Calls `validateObjectID` at the start of `queryADObjectSystem` before the `switch objectType` block, guarding all four `fmt.Sprintf` PowerShell interpolation sites (Get-ADUser ~line 497, Get-ADGroup ~line 527, Get-ADOrganizationalUnit ~line 555, Get-ADComputer ~line 587)
- Adds `TestValidateObjectID` with 9 table-driven subtests covering injection vectors and valid formats

## Specialist Review Results

**QA Test Runner: PASS**
- All unit, integration, and cross-platform build gates passed
- `features/modules/activedirectory`: PASS
- Integration tests (transport, controller, logging, standalone): PASS
- Cross-platform builds (linux/amd64, linux/arm64, darwin/amd64, darwin/arm64, windows/amd64): PASS

**QA Code Reviewer: PASS**
- 0 blocking issues
- No mocks, no t.Skip() bypasses, full error path coverage in TestValidateObjectID
- 1 warning (non-blocking): no end-to-end test through the public Get API for the injection path — acceptable given the direct call-through and exhaustive unit tests

**Security Engineer: PASS**
- 0 blocking issues, 0 new warnings
- security-precommit: PASS, check-architecture: PASS, security-scan: PASS
- Confirmed all four interpolation sites are upstream of validateObjectID
- Confirmed ReDoS-safe via security.MatchStringWithTimeout central provider
- No hardcoded secrets, no information disclosure, no insecure defaults

Fixes #877

🤖 Generated with [Claude Code](https://claude.com/claude-code)