### PR TITLE
m365/auth: move MemoryClientTenantStore to test-only file (Issue #880)

### DIFF
--- a/features/modules/m365/auth/memory_client_store_test.go
+++ b/features/modules/m365/auth/memory_client_store_test.go
@@ -15,9 +15,8 @@ import (
 var _ business.ClientTenantStore = (*MemoryClientTenantStore)(nil)
 
 // MemoryClientTenantStore provides an in-memory implementation of business.ClientTenantStore
-// TEST ONLY: This implementation is for testing purposes only and should NEVER be used in production.
-// For production deployments, use StorageClientTenantStoreAdapter with pkg/storage providers.
-// Story #274: This is a test-only implementation that should be migrated to storage-backed stores.
+// for use in tests only. For production deployments, use StorageClientTenantStoreAdapter
+// with pkg/storage providers.
 type MemoryClientTenantStore struct {
 	// Client tenant storage
 	clientTenants      map[string]*business.ClientTenant // tenantID -> ClientTenant
@@ -352,8 +351,7 @@ func containsIgnoreCase(s, substr string) bool {
 
 // Simple lowercase conversion (basic implementation)
 func stringToLower(s string) string {
-	// This is a simplified implementation for the memory store
-	// In production, use strings.ToLower()
+	// ASCII-only lowercase; sufficient for the identifiers this store searches.
 	result := make([]byte, len(s))
 	for i, r := range []byte(s) {
 		if r >= 'A' && r <= 'Z' {


### PR DESCRIPTION
## Summary

- Renames `memory_client_store.go` → `memory_client_store_test.go` so the Go toolchain excludes `MemoryClientTenantStore` from all production builds
- Retains `package auth` (not `package auth_test`) so the type remains accessible to same-package test files
- Keeps `var _ business.ClientTenantStore = (*MemoryClientTenantStore)(nil)` compile-time assertion
- Removes stale `// TEST ONLY` warning comment (the `_test.go` suffix is self-documenting)

## Verification

```
grep -rn "MemoryClientTenantStore|NewMemoryClientTenantStore" features/ cmd/ --include="*.go" | grep -v "_test.go"
# (empty — zero production references)
```

`msp_simple_integration_test.go:357` — the string literal `"MemoryClientTenantStore": true` in a diagnostic map is unaffected (plain string, not a type reference).

## Specialist Review Results

| Reviewer | Result |
|----------|--------|
| QA Test Runner (`make test-agent-complete`) | **PASS** — all packages pass including m365/auth; cross-platform builds verified |
| QA Code Reviewer | **PASS** — no mocks, no `t.Skip()`, no empty assertions, no hacky workarounds in changed files |
| Security Engineer | **PASS** — no hardcoded secrets, no central provider violations, no TLS issues; all automated scans green |

Fixes #880

🤖 Generated with [Claude Code](https://claude.com/claude-code)