### PR TITLE
file: fix path traversal — add required AllowedBasePath to FileConfig (Issue #875)

### DIFF
--- a/docs/modules/file.md
+++ b/docs/modules/file.md
@@ -1,0 +1,55 @@
+# File Module
+
+## Overview
+
+The file module manages file content, permissions, and ownership on managed endpoints. It enforces path-traversal protection via a required `allowed_base_path` field.
+
+## Configuration
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `state` | string | No | `"present"` (default) or `"absent"` |
+| `content` | string | Yes (when present) | File content |
+| `permissions` | int | No | Unix permission bits (e.g. `0644`). Not supported on Windows. |
+| `owner` | string | No | File owner username |
+| `group` | string | No | File group name |
+| `allowed_base_path` | string | **Yes** | Absolute path that constrains all filesystem operations |
+
+## `allowed_base_path`
+
+`allowed_base_path` is a required security field. Every OS call (read, write, remove, chown) is validated against this path to prevent path-traversal attacks. The value must be an absolute path set by the operator in YAML — there is no default.
+
+If the field is absent or not an absolute path, the module returns `ErrAllowedBasePathRequired` and performs no filesystem operations.
+
+**Note:** `allowed_base_path` uses `filepath.Clean` + `filepath.Abs` internally. Symlink escapes outside the base path are **not** blocked.
+
+### Example
+
+```yaml
+file:
+  state: present
+  content: |
+    [Unit]
+    Description=My Service
+  permissions: 0644
+  allowed_base_path: /var/cfgms/managed
+```
+
+## Migration
+
+Existing configurations that omit `allowed_base_path` will fail validation after this change. Add the field pointing to the directory that contains the managed files:
+
+```yaml
+# Before
+file:
+  state: present
+  content: "hello"
+
+# After
+file:
+  state: present
+  content: "hello"
+  allowed_base_path: /var/cfgms/managed
+```
+
+The resource ID (file path) must remain within `allowed_base_path`. Attempts to reference paths outside the base path are rejected with an error.

--- a/features/modules/file/errors.go
+++ b/features/modules/file/errors.go
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+package file
+
+import "errors"
+
+var (
+	// ErrAllowedBasePathRequired is returned when AllowedBasePath is missing or non-absolute.
+	// See docs/modules/file.md for configuration guidance and migration instructions.
+	ErrAllowedBasePathRequired = errors.New("AllowedBasePath is required and must be an absolute path; see docs/modules/file.md")
+)

--- a/features/modules/file/implementation.go
+++ b/features/modules/file/implementation.go
@@ -30,6 +30,23 @@ func New() modules.Module {
 	return &fileModule{}
 }
 
+// Configure extracts AllowedBasePath from the operator config so that Get() can
+// safely read the current resource state before Set() is called.
+// This implements modules.Configurable and is called by the execution engine
+// before the Get→Compare→Set→Verify cycle begins.
+func (m *fileModule) Configure(config modules.ConfigState) error {
+	if config == nil {
+		return ErrAllowedBasePathRequired
+	}
+	configMap := config.AsMap()
+	basePath, _ := configMap["allowed_base_path"].(string)
+	if basePath == "" || !filepath.IsAbs(basePath) {
+		return ErrAllowedBasePathRequired
+	}
+	m.configuredBasePath = basePath
+	return nil
+}
+
 // Get returns the current configuration of the file.
 //
 // If the file does not exist, returns a FileConfig with State: "absent".
@@ -216,14 +233,22 @@ func (m *fileModule) Set(ctx context.Context, resourceID string, config modules.
 				if err != nil {
 					return err
 				}
-				uid, _ = strconv.Atoi(userInfo.Uid)
+				parsedUID, err := strconv.Atoi(userInfo.Uid)
+				if err != nil {
+					return fmt.Errorf("failed to parse UID %q: %w", userInfo.Uid, err)
+				}
+				uid = parsedUID
 			}
 			if fileConfig.Group != "" {
 				groupInfo, err := user.LookupGroup(fileConfig.Group)
 				if err != nil {
 					return err
 				}
-				gid, _ = strconv.Atoi(groupInfo.Gid)
+				parsedGID, err := strconv.Atoi(groupInfo.Gid)
+				if err != nil {
+					return fmt.Errorf("failed to parse GID %q: %w", groupInfo.Gid, err)
+				}
+				gid = parsedGID
 			}
 
 			// Change owner and group

--- a/features/modules/file/implementation.go
+++ b/features/modules/file/implementation.go
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2026 Jordan Ritz
-// #nosec G304 - File module requires file system access for configuration management
 package file
 
 import (
@@ -8,17 +7,22 @@ import (
 	"fmt"
 	"os"
 	"os/user"
+	"path/filepath"
 	"runtime"
 	"strconv"
 
 	"github.com/cfgis/cfgms/features/modules"
 	"github.com/cfgis/cfgms/pkg/logging"
+	"github.com/cfgis/cfgms/pkg/security"
 )
 
 // fileModule implements the Module interface for file management
 type fileModule struct {
 	// Embed default logging support for automatic injection capability
 	modules.DefaultLoggingSupport
+	// configuredBasePath is populated by Set() from the operator's AllowedBasePath YAML field.
+	// It has no default — Get() returns ErrAllowedBasePathRequired until Set() is called.
+	configuredBasePath string
 }
 
 // New creates a new instance of the file module
@@ -35,7 +39,18 @@ func (m *fileModule) Get(ctx context.Context, resourceID string) (modules.Config
 		return nil, modules.ErrInvalidResourceID
 	}
 
-	info, err := os.Stat(resourceID)
+	if m.configuredBasePath == "" {
+		return nil, ErrAllowedBasePathRequired
+	}
+
+	// NOTE: symlink escapes not blocked by ValidateAndCleanPath
+	cleanPath, err := security.ValidateAndCleanPath(m.configuredBasePath, resourceID)
+	if err != nil {
+		return nil, err
+	}
+
+	// #nosec G304 -- path validated by security.ValidateAndCleanPath above
+	info, err := os.Stat(cleanPath)
 	if err != nil {
 		if os.IsNotExist(err) {
 			// File doesn't exist - return state: absent
@@ -46,7 +61,8 @@ func (m *fileModule) Get(ctx context.Context, resourceID string) (modules.Config
 		return nil, err
 	}
 
-	content, err := os.ReadFile(resourceID)
+	// NOTE: symlink escapes not blocked by ValidateAndCleanPath
+	content, err := security.SecureReadFile(m.configuredBasePath, resourceID)
 	if err != nil {
 		return nil, err
 	}
@@ -58,11 +74,12 @@ func (m *fileModule) Get(ctx context.Context, resourceID string) (modules.Config
 	}
 
 	config := &FileConfig{
-		State:       "present",
-		Content:     string(content),
-		Permissions: getFilePermissions(info),
-		Owner:       owner,
-		Group:       group,
+		State:           "present",
+		Content:         string(content),
+		Permissions:     getFilePermissions(info),
+		Owner:           owner,
+		Group:           group,
+		AllowedBasePath: m.configuredBasePath,
 	}
 
 	return config, nil
@@ -116,10 +133,26 @@ func (m *fileModule) Set(ctx context.Context, resourceID string, config modules.
 	if group, ok := configMap["group"].(string); ok {
 		fileConfig.Group = group
 	}
+	if basePath, ok := configMap["allowed_base_path"].(string); ok {
+		fileConfig.AllowedBasePath = basePath
+	}
+
+	// AllowedBasePath must be validated before any OS call, including os.Remove in the absent branch.
+	if fileConfig.AllowedBasePath == "" || !filepath.IsAbs(fileConfig.AllowedBasePath) {
+		return ErrAllowedBasePathRequired
+	}
+
+	// NOTE: symlink escapes not blocked by ValidateAndCleanPath
+	cleanPath, err := security.ValidateAndCleanPath(fileConfig.AllowedBasePath, resourceID)
+	if err != nil {
+		return err
+	}
+	m.configuredBasePath = fileConfig.AllowedBasePath
 
 	// Handle state: absent - delete the file
 	if fileConfig.State == "absent" {
-		if err := os.Remove(resourceID); err != nil {
+		// #nosec G304 -- path validated by security.ValidateAndCleanPath above
+		if err := os.Remove(cleanPath); err != nil {
 			if os.IsNotExist(err) {
 				// File already doesn't exist - desired state achieved
 				logger.InfoCtx(ctx, "File already absent",
@@ -167,7 +200,8 @@ func (m *fileModule) Set(ctx context.Context, resourceID string, config modules.
 	if fileConfig.Permissions < 0 || fileConfig.Permissions > 0777 {
 		return modules.ErrInvalidInput
 	}
-	if err := os.WriteFile(resourceID, []byte(fileConfig.Content), os.FileMode(fileConfig.Permissions)); err != nil {
+	// NOTE: symlink escapes not blocked by ValidateAndCleanPath
+	if err := security.SecureWriteFileWithPerms(fileConfig.AllowedBasePath, resourceID, []byte(fileConfig.Content), os.FileMode(fileConfig.Permissions)); err != nil {
 		return err
 	}
 
@@ -193,7 +227,8 @@ func (m *fileModule) Set(ctx context.Context, resourceID string, config modules.
 			}
 
 			// Change owner and group
-			if err := os.Chown(resourceID, uid, gid); err != nil {
+			// #nosec G304 -- path validated by security.ValidateAndCleanPath above
+			if err := os.Chown(cleanPath, uid, gid); err != nil {
 				return err
 			}
 		case "windows":

--- a/features/modules/file/interface.go
+++ b/features/modules/file/interface.go
@@ -12,12 +12,12 @@ import (
 
 // FileConfig represents the configuration for a file resource
 type FileConfig struct {
-	State           string `yaml:"state"`                    // "present" or "absent"
-	Content         string `yaml:"content,omitempty"`        // File content (required when state is "present")
-	Permissions     int    `yaml:"permissions,omitempty"`    // File permissions (e.g., 0644)
-	Owner           string `yaml:"owner,omitempty"`          // File owner
-	Group           string `yaml:"group,omitempty"`          // File group
-	AllowedBasePath string `yaml:"allowed_base_path"`        // Required: absolute base path constraining all OS calls
+	State           string `yaml:"state"`                 // "present" or "absent"
+	Content         string `yaml:"content,omitempty"`     // File content (required when state is "present")
+	Permissions     int    `yaml:"permissions,omitempty"` // File permissions (e.g., 0644)
+	Owner           string `yaml:"owner,omitempty"`       // File owner
+	Group           string `yaml:"group,omitempty"`       // File group
+	AllowedBasePath string `yaml:"allowed_base_path"`     // Required: absolute base path constraining all OS calls
 }
 
 // AsMap returns the configuration as a map for efficient field-by-field comparison

--- a/features/modules/file/interface.go
+++ b/features/modules/file/interface.go
@@ -3,6 +3,8 @@
 package file
 
 import (
+	"path/filepath"
+
 	"gopkg.in/yaml.v3"
 
 	"github.com/cfgis/cfgms/features/modules"
@@ -10,11 +12,12 @@ import (
 
 // FileConfig represents the configuration for a file resource
 type FileConfig struct {
-	State       string `yaml:"state"`                 // "present" or "absent"
-	Content     string `yaml:"content,omitempty"`     // File content (required when state is "present")
-	Permissions int    `yaml:"permissions,omitempty"` // File permissions (e.g., 0644)
-	Owner       string `yaml:"owner,omitempty"`       // File owner
-	Group       string `yaml:"group,omitempty"`       // File group
+	State           string `yaml:"state"`                    // "present" or "absent"
+	Content         string `yaml:"content,omitempty"`        // File content (required when state is "present")
+	Permissions     int    `yaml:"permissions,omitempty"`    // File permissions (e.g., 0644)
+	Owner           string `yaml:"owner,omitempty"`          // File owner
+	Group           string `yaml:"group,omitempty"`          // File group
+	AllowedBasePath string `yaml:"allowed_base_path"`        // Required: absolute base path constraining all OS calls
 }
 
 // AsMap returns the configuration as a map for efficient field-by-field comparison
@@ -27,6 +30,9 @@ func (c *FileConfig) AsMap() map[string]interface{} {
 	} else {
 		result["state"] = "present" // Default to present
 	}
+
+	// Always include the required security base path
+	result["allowed_base_path"] = c.AllowedBasePath
 
 	// Only include content/permissions for present state
 	if c.State != "absent" {
@@ -56,6 +62,11 @@ func (c *FileConfig) FromYAML(data []byte) error {
 
 // Validate ensures the configuration is valid
 func (c *FileConfig) Validate() error {
+	// AllowedBasePath is required and must be an absolute path for all states.
+	if c.AllowedBasePath == "" || !filepath.IsAbs(c.AllowedBasePath) {
+		return ErrAllowedBasePathRequired
+	}
+
 	// State "absent" doesn't require content or permissions
 	if c.State == "absent" {
 		return nil

--- a/features/modules/file/module_test.go
+++ b/features/modules/file/module_test.go
@@ -4,6 +4,7 @@ package file
 
 import (
 	"context"
+	"errors"
 	"os"
 	"os/user"
 	"path/filepath"
@@ -48,7 +49,7 @@ func getTestUser(t *testing.T) (string, string) {
 		}
 		return currentUser.Username, "Users" // Common Windows group
 	default:
-		t.Skipf("Unsupported platform: %s", runtime.GOOS)
+		t.Fatalf("Unsupported platform for file module test: %s", runtime.GOOS)
 		return "", ""
 	}
 }
@@ -106,10 +107,9 @@ func TestFileModule(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "Invalid content (empty)",
-			configData: "content: \"\"\npermissions: 420\nallowed_base_path: " + tempDir,
-			// On Windows, permissions error fires before content validation
-			wantErr: true,
+			name:       "Invalid content (empty)",
+			configData: "content: \"\"\nallowed_base_path: " + tempDir,
+			wantErr:    true,
 		},
 		{
 			name:       "Invalid permissions",
@@ -154,19 +154,13 @@ func TestFileModule(t *testing.T) {
 				return
 			}
 
-			// Test Set
-			if configState == nil && !tt.wantErr {
-				t.Errorf("configState is nil but test should not expect error")
-				return
-			}
-
 			err := module.Set(context.Background(), testFile, configState)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Set() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
 
-			// Test Get
+			// Test Get — verify the round-trip, not just absence of error
 			if !tt.wantErr {
 				config, err := module.Get(context.Background(), testFile)
 				if err != nil {
@@ -174,7 +168,20 @@ func TestFileModule(t *testing.T) {
 					return
 				}
 				if config == nil {
-					t.Error("Get() returned nil config")
+					t.Fatal("Get() returned nil config")
+				}
+				fileState, ok := config.(*FileConfig)
+				if !ok {
+					t.Fatalf("Get() returned %T, want *FileConfig", config)
+				}
+				if fileState.State != "present" {
+					t.Errorf("Get() State = %q, want %q", fileState.State, "present")
+				}
+				if fileState.Content != testContent {
+					t.Errorf("Get() Content = %q, want %q", fileState.Content, testContent)
+				}
+				if fileState.AllowedBasePath != tempDir {
+					t.Errorf("Get() AllowedBasePath = %q, want %q", fileState.AllowedBasePath, tempDir)
 				}
 			}
 		})
@@ -209,8 +216,15 @@ func TestFileModule_EdgeCases(t *testing.T) {
 	if err != nil {
 		t.Errorf("Get() with non-existent file should not error: %v", err)
 	}
-	if fileState, ok := state.(*FileConfig); !ok || fileState.State != "absent" {
-		t.Error("Get() with non-existent file should return State: 'absent'")
+	if state == nil {
+		t.Fatal("Get() should not return nil state for non-existent file")
+	}
+	fileState, ok := state.(*FileConfig)
+	if !ok {
+		t.Fatalf("Get() should return *FileConfig, got %T", state)
+	}
+	if fileState.State != "absent" {
+		t.Errorf("Get() State = %q, want %q", fileState.State, "absent")
 	}
 
 	// Test file creation and verification
@@ -319,12 +333,48 @@ func TestFileModule_Security(t *testing.T) {
 
 	t.Run("Path traversal rejected", func(t *testing.T) {
 		module := New()
-		// filepath.Join cleans the path but keeps the traversal semantics before ValidateAndCleanPath resolves it
 		traversalPath := tempDir + "/../secret.txt"
 		configState := createConfigFromYAML("content: \"evil\"\nallowed_base_path: " + tempDir)
 		err := module.Set(context.Background(), traversalPath, configState)
 		if err == nil {
 			t.Error("Set() with path traversal should fail")
+		}
+		// Must be a traversal error, not the unrelated ErrAllowedBasePathRequired
+		if errors.Is(err, ErrAllowedBasePathRequired) {
+			t.Errorf("Set() with path traversal should fail with traversal error, not ErrAllowedBasePathRequired: %v", err)
+		}
+	})
+
+	t.Run("Configure with valid AllowedBasePath enables Get", func(t *testing.T) {
+		module := New()
+		configurable, ok := module.(modules.Configurable)
+		if !ok {
+			t.Fatal("file module must implement modules.Configurable")
+		}
+		if err := configurable.Configure(createConfigFromYAML("allowed_base_path: " + tempDir)); err != nil {
+			t.Fatalf("Configure() with valid path failed: %v", err)
+		}
+		// After Configure, Get should work for a non-existent file (returns absent)
+		testFile := filepath.Join(tempDir, "configured-get.txt")
+		state, err := module.Get(context.Background(), testFile)
+		if err != nil {
+			t.Fatalf("Get() after Configure() failed: %v", err)
+		}
+		fileState, ok := state.(*FileConfig)
+		if !ok || fileState.State != "absent" {
+			t.Error("Get() after Configure() should return absent state for non-existent file")
+		}
+	})
+
+	t.Run("Configure with missing AllowedBasePath returns ErrAllowedBasePathRequired", func(t *testing.T) {
+		module := New()
+		configurable, ok := module.(modules.Configurable)
+		if !ok {
+			t.Fatal("file module must implement modules.Configurable")
+		}
+		err := configurable.Configure(createConfigFromYAML("content: \"test\""))
+		if err != ErrAllowedBasePathRequired {
+			t.Errorf("Configure() with missing AllowedBasePath: got %v, want ErrAllowedBasePathRequired", err)
 		}
 	})
 
@@ -352,6 +402,9 @@ func TestFileModule_Security(t *testing.T) {
 		}
 		if fileState.Content != "valid content" {
 			t.Errorf("Content mismatch: got %q, want %q", fileState.Content, "valid content")
+		}
+		if fileState.AllowedBasePath != tempDir {
+			t.Errorf("AllowedBasePath mismatch: got %q, want %q", fileState.AllowedBasePath, tempDir)
 		}
 	})
 }

--- a/features/modules/file/module_test.go
+++ b/features/modules/file/module_test.go
@@ -54,8 +54,9 @@ func getTestUser(t *testing.T) (string, string) {
 }
 
 // testFileConfigYAML returns a file config YAML string appropriate for the platform.
+// basePath is the AllowedBasePath that constrains all OS calls; it must be an absolute path.
 // On Windows, omits permissions since NTFS does not support Unix permission bits.
-func testFileConfigYAML(content, owner, group string) string {
+func testFileConfigYAML(content, owner, group, basePath string) string {
 	cfg := `content: "` + content + `"`
 	if platformSupportsPermissions() {
 		cfg += "\npermissions: 420"
@@ -65,6 +66,9 @@ func testFileConfigYAML(content, owner, group string) string {
 	}
 	if group != "" {
 		cfg += "\ngroup: " + group
+	}
+	if basePath != "" {
+		cfg += "\nallowed_base_path: " + basePath
 	}
 	return cfg
 }
@@ -87,7 +91,7 @@ func TestFileModule(t *testing.T) {
 	}{
 		{
 			name:       "Create new file",
-			configData: testFileConfigYAML(testContent, "", ""),
+			configData: testFileConfigYAML(testContent, "", "", tempDir),
 			cleanup: func() error {
 				return os.Remove(testFile)
 			},
@@ -95,7 +99,7 @@ func TestFileModule(t *testing.T) {
 		},
 		{
 			name:       "Create file with ownership",
-			configData: testFileConfigYAML(testContent, testUser, testGroup),
+			configData: testFileConfigYAML(testContent, testUser, testGroup, tempDir),
 			cleanup: func() error {
 				return os.Remove(testFile)
 			},
@@ -103,25 +107,23 @@ func TestFileModule(t *testing.T) {
 		},
 		{
 			name: "Invalid content (empty)",
-			configData: `content: ""
-permissions: 420`,
+			configData: "content: \"\"\npermissions: 420\nallowed_base_path: " + tempDir,
 			// On Windows, permissions error fires before content validation
 			wantErr: true,
 		},
 		{
-			name: "Invalid permissions",
-			configData: `content: "` + testContent + `"
-permissions: 9999`,
-			wantErr: true,
+			name:       "Invalid permissions",
+			configData: "content: \"" + testContent + "\"\npermissions: 9999\nallowed_base_path: " + tempDir,
+			wantErr:    true,
 		},
 		{
 			name:       "Invalid owner",
-			configData: testFileConfigYAML(testContent, "nonexistentuser", ""),
+			configData: testFileConfigYAML(testContent, "nonexistentuser", "", tempDir),
 			wantErr:    true,
 		},
 		{
 			name:       "Invalid group",
-			configData: testFileConfigYAML(testContent, "", "nonexistentgroup"),
+			configData: testFileConfigYAML(testContent, "", "nonexistentgroup", tempDir),
 			// Windows doesn't have Unix groups, so this won't error on Windows
 			wantErr: runtime.GOOS != "windows",
 		},
@@ -186,7 +188,7 @@ func TestFileModule_EdgeCases(t *testing.T) {
 	module := New()
 
 	// Test with empty resource ID
-	configData := testFileConfigYAML("test content", "", "")
+	configData := testFileConfigYAML("test content", "", "", tempDir)
 	configState := createConfigFromYAML(configData)
 
 	err := module.Set(context.Background(), "", configState)
@@ -194,8 +196,16 @@ func TestFileModule_EdgeCases(t *testing.T) {
 		t.Error("Set() with empty resource ID should fail")
 	}
 
+	// Set up configuredBasePath by calling Set with absent state for a non-existent file.
+	// os.Remove on a missing file returns ErrNotExist, which Set treats as success.
+	absConfigState := createConfigFromYAML("state: absent\nallowed_base_path: " + tempDir)
+	nonExistentFile := filepath.Join(tempDir, "nonexistent.txt")
+	if err := module.Set(context.Background(), nonExistentFile, absConfigState); err != nil {
+		t.Fatalf("Set() with absent state on non-existent file should not error: %v", err)
+	}
+
 	// Test Get with non-existent file - should return State: "absent"
-	state, err := module.Get(context.Background(), filepath.Join(tempDir, "nonexistent.txt"))
+	state, err := module.Get(context.Background(), nonExistentFile)
 	if err != nil {
 		t.Errorf("Get() with non-existent file should not error: %v", err)
 	}
@@ -204,7 +214,7 @@ func TestFileModule_EdgeCases(t *testing.T) {
 	}
 
 	// Test file creation and verification
-	verifyConfig := `content: "test content for verification"`
+	verifyConfig := "content: \"test content for verification\"\nallowed_base_path: " + tempDir
 	if platformSupportsPermissions() {
 		verifyConfig += "\npermissions: 493"
 	}
@@ -248,12 +258,100 @@ func TestFileModule_PermissionsRejectedOnWindows(t *testing.T) {
 	testFile := filepath.Join(tempDir, "test.txt")
 	module := New()
 
-	configData := `content: "test content"
-permissions: 420`
+	configData := "content: \"test content\"\npermissions: 420\nallowed_base_path: " + tempDir
 	configState := createConfigFromYAML(configData)
 
 	err := module.Set(context.Background(), testFile, configState)
 	if err == nil {
 		t.Error("Set() with Unix permissions on Windows should fail")
 	}
+}
+
+func TestFileModule_Security(t *testing.T) {
+	tempDir := t.TempDir()
+
+	t.Run("Validate rejects empty AllowedBasePath", func(t *testing.T) {
+		cfg := &FileConfig{
+			State:           "present",
+			Content:         "test",
+			AllowedBasePath: "",
+		}
+		err := cfg.Validate()
+		if err != ErrAllowedBasePathRequired {
+			t.Errorf("Validate() with empty AllowedBasePath: got %v, want ErrAllowedBasePathRequired", err)
+		}
+	})
+
+	t.Run("Validate rejects relative AllowedBasePath", func(t *testing.T) {
+		cfg := &FileConfig{
+			State:           "present",
+			Content:         "test",
+			AllowedBasePath: "relative/path",
+		}
+		err := cfg.Validate()
+		if err != ErrAllowedBasePathRequired {
+			t.Errorf("Validate() with relative AllowedBasePath: got %v, want ErrAllowedBasePathRequired", err)
+		}
+	})
+
+	t.Run("Set rejects missing AllowedBasePath before any OS call", func(t *testing.T) {
+		module := New()
+		testFile := filepath.Join(tempDir, "should-not-be-created.txt")
+		configState := createConfigFromYAML("content: \"test\"\nstate: present")
+		err := module.Set(context.Background(), testFile, configState)
+		if err != ErrAllowedBasePathRequired {
+			t.Errorf("Set() with missing AllowedBasePath: got %v, want ErrAllowedBasePathRequired", err)
+		}
+		// File must not have been created
+		if _, statErr := os.Stat(testFile); !os.IsNotExist(statErr) {
+			t.Error("Set() with missing AllowedBasePath must not create any file")
+		}
+	})
+
+	t.Run("Get before Set returns ErrAllowedBasePathRequired", func(t *testing.T) {
+		module := New()
+		testFile := filepath.Join(tempDir, "any.txt")
+		_, err := module.Get(context.Background(), testFile)
+		if err != ErrAllowedBasePathRequired {
+			t.Errorf("Get() before Set(): got %v, want ErrAllowedBasePathRequired", err)
+		}
+	})
+
+	t.Run("Path traversal rejected", func(t *testing.T) {
+		module := New()
+		// filepath.Join cleans the path but keeps the traversal semantics before ValidateAndCleanPath resolves it
+		traversalPath := tempDir + "/../secret.txt"
+		configState := createConfigFromYAML("content: \"evil\"\nallowed_base_path: " + tempDir)
+		err := module.Set(context.Background(), traversalPath, configState)
+		if err == nil {
+			t.Error("Set() with path traversal should fail")
+		}
+	})
+
+	t.Run("Valid path within base succeeds end-to-end", func(t *testing.T) {
+		module := New()
+		testFile := filepath.Join(tempDir, "valid.txt")
+		configYAML := "content: \"valid content\"\nallowed_base_path: " + tempDir
+		if platformSupportsPermissions() {
+			configYAML += "\npermissions: 420"
+		}
+		configState := createConfigFromYAML(configYAML)
+
+		if err := module.Set(context.Background(), testFile, configState); err != nil {
+			t.Fatalf("Set() with valid path failed: %v", err)
+		}
+
+		state, err := module.Get(context.Background(), testFile)
+		if err != nil {
+			t.Fatalf("Get() with valid path failed: %v", err)
+		}
+
+		fileState, ok := state.(*FileConfig)
+		if !ok {
+			t.Fatal("Get() did not return *FileConfig")
+		}
+		if fileState.Content != "valid content" {
+			t.Errorf("Content mismatch: got %q, want %q", fileState.Content, "valid content")
+		}
+	})
 }

--- a/features/modules/module.go
+++ b/features/modules/module.go
@@ -33,6 +33,15 @@ type ConfigState interface {
 	GetManagedFields() []string
 }
 
+// Configurable is implemented by modules that require initialization from
+// operator config before Get() can safely read the current resource state.
+// The execution engine calls Configure(desiredState) before Get() when the
+// module implements this interface, allowing security boundaries to be
+// established without modifying any files.
+type Configurable interface {
+	Configure(config ConfigState) error
+}
+
 // Monitor interface for modules that support real-time monitoring (optional)
 type Monitor interface {
 	// Monitor watches for changes to a resource and triggers events

--- a/features/steward/execution/drift_event_test.go
+++ b/features/steward/execution/drift_event_test.go
@@ -93,9 +93,10 @@ func TestExecuteResource_DriftHandlerCalledOnDrift(t *testing.T) {
 		Name:   "test-file",
 		Module: "file",
 		Config: map[string]interface{}{
-			"path":    filePath,
-			"state":   "present",
-			"content": "desired content",
+			"path":              filePath,
+			"state":             "present",
+			"content":           "desired content",
+			"allowed_base_path": dir,
 		},
 	}
 
@@ -139,9 +140,10 @@ func TestExecuteResource_DriftHandlerNotCalledWhenNoDrift(t *testing.T) {
 		Name:   "test-file",
 		Module: "file",
 		Config: map[string]interface{}{
-			"path":    filePath,
-			"state":   "present",
-			"content": "desired content",
+			"path":              filePath,
+			"state":             "present",
+			"content":           "desired content",
+			"allowed_base_path": dir,
 		},
 	}
 
@@ -214,18 +216,20 @@ func TestExecuteConfiguration_DriftHandlerCalledForDriftingResources(t *testing.
 				Name:   "file1",
 				Module: "file",
 				Config: map[string]interface{}{
-					"path":    filePath1,
-					"state":   "present",
-					"content": "desired content",
+					"path":              filePath1,
+					"state":             "present",
+					"content":           "desired content",
+					"allowed_base_path": dir,
 				},
 			},
 			{
 				Name:   "file2",
 				Module: "file",
 				Config: map[string]interface{}{
-					"path":    filePath2,
-					"state":   "present",
-					"content": "correct content",
+					"path":              filePath2,
+					"state":             "present",
+					"content":           "correct content",
+					"allowed_base_path": dir,
 				},
 			},
 		},

--- a/features/steward/execution/execution.go
+++ b/features/steward/execution/execution.go
@@ -206,6 +206,17 @@ func (e *ExecutionEngine) ExecuteResource(ctx context.Context, resource config.R
 		return result
 	}
 
+	// If the module requires initialization before Get() (e.g., file module needs
+	// AllowedBasePath to validate paths before reading), configure it now.
+	if configurable, ok := module.(modules.Configurable); ok {
+		if err := configurable.Configure(desiredState); err != nil {
+			result.Error = fmt.Sprintf("failed to configure module: %v", err)
+			result.ExecutionTime = time.Since(startTime)
+			e.handleResourceError(resource, err)
+			return result
+		}
+	}
+
 	// Get current state using the appropriate resource identifier
 	currentState, err := module.Get(ctx, resourceID)
 	if err != nil {

--- a/features/steward/execution/executor_test.go
+++ b/features/steward/execution/executor_test.go
@@ -23,17 +23,20 @@ import (
 // Always includes "state": "present" so the genericConfigState comparator has a
 // managed field to compare (path is excluded as an identifier field).
 func testFileConfig(path, content string) string {
+	dir := filepath.ToSlash(filepath.Dir(path))
 	if runtime.GOOS == "windows" {
 		return `{
         "state": "present",
         "path": "` + filepath.ToSlash(path) + `",
-        "content": "` + content + `"
+        "content": "` + content + `",
+        "allowed_base_path": "` + dir + `"
       }`
 	}
 	return `{
         "path": "` + filepath.ToSlash(path) + `",
         "content": "` + content + `",
-        "permissions": 420
+        "permissions": 420,
+        "allowed_base_path": "` + dir + `"
       }`
 }
 
@@ -266,7 +269,8 @@ func TestExecutor_ApplyConfiguration_PermissionsRejectedOnWindows(t *testing.T) 
       "config": {
         "path": "` + filepath.ToSlash(filepath.Join(tempDir, "rejected.txt")) + `",
         "content": "should fail on Windows\n",
-        "permissions": 420
+        "permissions": 420,
+        "allowed_base_path": "` + filepath.ToSlash(tempDir) + `"
       }
     }
   ]

--- a/test/integration/standalone_steward_test.go
+++ b/test/integration/standalone_steward_test.go
@@ -93,6 +93,7 @@ resources:
         No controller, no network, no complexity!
       state: present
       mode: "0644"
+      allowed_base_path: ` + s.tempDir + `
 
   # Create a directory
   - name: test-directory
@@ -109,6 +110,7 @@ resources:
       path: ` + infoFile + `
       content: "CFGMS standalone mode is working!"
       state: present
+      allowed_base_path: ` + s.tempDir + `
 `
 	err := os.WriteFile(s.configPath, []byte(configContent), 0644)
 	require.NoError(s.T(), err, "Should write config file")
@@ -172,6 +174,7 @@ resources:
       path: ` + testFile + `
       content: "Initial content"
       state: present
+      allowed_base_path: ` + s.tempDir + `
 `
 	err := os.WriteFile(s.configPath, []byte(initialConfig), 0644)
 	require.NoError(s.T(), err)
@@ -199,6 +202,7 @@ resources:
       path: ` + testFile + `
       content: "Updated content! CFGMS detects changes."
       state: present
+      allowed_base_path: ` + s.tempDir + `
 `
 	err = os.WriteFile(s.configPath, []byte(updatedConfig), 0644)
 	require.NoError(s.T(), err)
@@ -234,6 +238,7 @@ resources:
     config:
       path: ` + testFile + `
       state: absent
+      allowed_base_path: ` + s.tempDir + `
 `
 	err := os.WriteFile(s.configPath, []byte(configContent), 0644)
 	require.NoError(s.T(), err)
@@ -294,6 +299,7 @@ resources:
         }
       state: present
       mode: "0644"
+      allowed_base_path: ` + s.tempDir + `
 `
 	err := os.WriteFile(s.configPath, []byte(configContent), 0644)
 	require.NoError(s.T(), err)
@@ -331,6 +337,7 @@ resources:
       path: ` + testFile + `
       content: "` + expectedContent + `"
       state: present
+      allowed_base_path: ` + s.tempDir + `
 `
 	err := os.WriteFile(s.configPath, []byte(configContent), 0644)
 	require.NoError(s.T(), err)
@@ -368,6 +375,7 @@ resources:
       path: ` + testFile + `
       content: "Created via ExecuteConfiguration"
       state: present
+      allowed_base_path: ` + s.tempDir + `
 `
 	err := os.WriteFile(s.configPath, []byte(configContent), 0644)
 	require.NoError(s.T(), err)
@@ -408,6 +416,7 @@ resources:
       path: /tmp/test.txt
       content: "test"
       state: present
+      allowed_base_path: /tmp
 `
 	err := os.WriteFile(s.configPath, []byte(configContent), 0644)
 	require.NoError(s.T(), err)


### PR DESCRIPTION
Agent session failed with exit code 1. Review container logs for details.