### PR TITLE
tenant/security: replace isIPInRange placeholder with net.ParseCIDR (Issue #866)

### DIFF
--- a/features/tenant/security/isolation.go
+++ b/features/tenant/security/isolation.go
@@ -5,6 +5,7 @@ package security
 import (
 	"context"
 	"fmt"
+	"net"
 	"strings"
 	"sync"
 	"time"
@@ -464,25 +465,19 @@ func (tie *TenantIsolationEngine) isAccessLevelSufficient(maxLevel, requestedLev
 	return levels[maxLevel] >= levels[requestedLevel]
 }
 
-// isIPInRange checks if an IP address is within a CIDR range
+// isIPInRange returns true iff ip is a valid IP and cidrRange is a valid CIDR
+// and the IP falls within the network, per RFC 4632 / RFC 4291 semantics.
+// Returns false (no panic) when either argument is empty or malformed.
 func (tie *TenantIsolationEngine) isIPInRange(ip, cidrRange string) bool {
-	// Simplified CIDR matching for test purposes
-	// In production, use net.ParseCIDR and proper subnet matching
-
-	if cidrRange == "0.0.0.0/0" {
-		return true // Match all IPs
+	_, ipNet, err := net.ParseCIDR(cidrRange)
+	if err != nil {
+		return false
 	}
-
-	if cidrRange == "192.168.1.0/24" {
-		return strings.HasPrefix(ip, "192.168.1.")
+	parsedIP := net.ParseIP(ip)
+	if parsedIP == nil {
+		return false
 	}
-
-	if cidrRange == "10.0.0.0/8" {
-		return strings.HasPrefix(ip, "10.")
-	}
-
-	// Exact match
-	return ip == cidrRange
+	return ipNet.Contains(parsedIP)
 }
 
 // getDefaultIsolationRule returns a default isolation rule for a tenant

--- a/features/tenant/security/isolation_test.go
+++ b/features/tenant/security/isolation_test.go
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+package security
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsIPInRange(t *testing.T) {
+	engine := &TenantIsolationEngine{}
+
+	tests := []struct {
+		name      string
+		ip        string
+		cidrRange string
+		want      bool
+	}{
+		// Match-all wildcard
+		{"all-match cidr 0.0.0.0/0 with arbitrary IP", "1.2.3.4", "0.0.0.0/0", true},
+		{"all-match cidr 0.0.0.0/0 with another IP", "255.255.255.255", "0.0.0.0/0", true},
+
+		// /24 network
+		{"192.168.1.0/24 matches host in range", "192.168.1.5", "192.168.1.0/24", true},
+		{"192.168.1.0/24 rejects host outside range", "192.168.2.5", "192.168.1.0/24", false},
+
+		// /8 network
+		{"10.0.0.0/8 matches highest host", "10.255.255.255", "10.0.0.0/8", true},
+		{"10.0.0.0/8 rejects 11.0.0.0", "11.0.0.0", "10.0.0.0/8", false},
+
+		// /12 network (172.16.0.0 – 172.31.255.255)
+		{"172.16.0.0/12 matches lower bound", "172.16.0.1", "172.16.0.0/12", true},
+		{"172.16.0.0/12 matches upper bound", "172.31.255.255", "172.16.0.0/12", true},
+		{"172.16.0.0/12 rejects address just above range", "172.32.0.0", "172.16.0.0/12", false},
+
+		// /16 network
+		{"10.0.0.0/16 matches host in range", "10.0.0.1", "10.0.0.0/16", true},
+		{"10.0.0.0/16 rejects 10.1.0.0", "10.1.0.0", "10.0.0.0/16", false},
+
+		// IPv6 /32 network
+		{"2001:db8::/32 matches address in range", "2001:db8:1::1", "2001:db8::/32", true},
+		{"2001:db8::/32 rejects address outside range", "2001:db9::1", "2001:db8::/32", false},
+
+		// Invalid inputs — must return false, no panic
+		{"invalid CIDR returns false", "192.168.1.1", "not-a-cidr", false},
+		{"invalid IP returns false", "not-an-ip", "192.168.1.0/24", false},
+		{"empty IP returns false", "", "192.168.1.0/24", false},
+		{"empty CIDR returns false", "192.168.1.1", "", false},
+		{"both empty returns false", "", "", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := engine.isIPInRange(tt.ip, tt.cidrRange)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Replaced the three-branch `strings.HasPrefix` placeholder in `isIPInRange` with `net.ParseCIDR` + `(*net.IPNet).Contains` (stdlib only, no new dependencies)
- Any CIDR now resolves correctly: `/8`, `/12`, `/16`, `/24`, `/0`, IPv6 `/32`, and beyond
- Invalid CIDRs and invalid IPs return `false` with no panic — fail-closed at a security boundary
- Added `TestIsIPInRange` table-driven test (18 cases) covering IPv4 /0 /8 /12 /16 /24, IPv6 /32, and all invalid-input paths

## Files Changed

- `features/tenant/security/isolation.go` — replaced `isIPInRange` lines 468-486, added `"net"` import
- `features/tenant/security/isolation_test.go` — new file with `TestIsIPInRange`

## Specialist Review Results

| Reviewer | Result | Notes |
|----------|--------|-------|
| QA Test Runner | **PASS** | `features/tenant/security` package: all tests pass. Pre-existing unrelated failure in `features/monitoring/export` (not introduced by this story). |
| QA Code Reviewer | **PASS** | No mocks, no skips, no empty assertions, no hacky workarounds. Error paths fully covered. |
| Security Engineer | **PASS** | `security-precommit`, `check-architecture`, `security-scan` all green. Change strengthens tenant isolation (fail-closed on malformed input). |

## Test Plan

- [x] `go test ./features/tenant/security/... -run TestIsIPInRange -v` — all 18 cases pass
- [x] `make test-agent-complete` — story package passes; pre-existing unrelated failure in monitoring/export package confirmed not introduced by this PR
- [x] No new module dependencies (`net` is stdlib)
- [x] Function comment updated to reference RFC 4632 / RFC 4291

Fixes #866

🤖 Generated with [Claude Code](https://claude.com/claude-code)