### PR TITLE
dataplane: fix session-map leak in Session.Close (Issue #892)

### DIFF
--- a/pkg/dataplane/providers/grpc/provider.go
+++ b/pkg/dataplane/providers/grpc/provider.go
@@ -259,9 +259,10 @@ func (p *Provider) Stop(ctx context.Context) error {
 		return nil
 	}
 
-	// Close all sessions
+	// Mark all sessions closed; the map is replaced below.
+	// Session.Close() acquires p.mu, so we cannot call it while holding the lock.
 	for _, s := range p.sessions {
-		_ = s.Close(ctx)
+		s.closed.Store(true)
 	}
 	p.sessions = make(map[string]*Session)
 

--- a/pkg/dataplane/providers/grpc/session.go
+++ b/pkg/dataplane/providers/grpc/session.go
@@ -495,9 +495,12 @@ func (s *Session) AcceptStream(_ context.Context) (interfaces.Stream, types.Stre
 
 // --- Session Management ---
 
-// Close gracefully closes the session.
+// Close gracefully closes the session and removes it from the provider's sessions map.
 func (s *Session) Close(_ context.Context) error {
 	s.closed.Store(true)
+	s.provider.mu.Lock()
+	delete(s.provider.sessions, s.id)
+	s.provider.mu.Unlock()
 	return nil
 }
 

--- a/pkg/dataplane/providers/grpc/session_test.go
+++ b/pkg/dataplane/providers/grpc/session_test.go
@@ -6,6 +6,8 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
+	"sync"
 	"testing"
 	"time"
 
@@ -301,4 +303,99 @@ func TestChunksToDNATransfer_EmptyChunks(t *testing.T) {
 func TestChunksToBulkTransfer_EmptyChunks(t *testing.T) {
 	_, err := chunksToBulkTransfer(nil)
 	require.Error(t, err)
+}
+
+// TestSession_Close_RemovesFromProviderMap verifies that Close removes the session
+// from the provider's sessions map, preventing unbounded map growth.
+func TestSession_Close_RemovesFromProviderMap(t *testing.T) {
+	p := New()
+
+	const n = 5
+	sessions := make([]*Session, n)
+	for i := 0; i < n; i++ {
+		id := fmt.Sprintf("session-%d", i)
+		s := &Session{
+			id:       id,
+			mode:     "client",
+			provider: p,
+		}
+		p.mu.Lock()
+		p.sessions[id] = s
+		p.mu.Unlock()
+		sessions[i] = s
+	}
+
+	p.mu.RLock()
+	assert.Equal(t, n, len(p.sessions), "sessions should be in map before close")
+	p.mu.RUnlock()
+
+	for _, s := range sessions {
+		require.NoError(t, s.Close(context.Background()))
+	}
+
+	p.mu.RLock()
+	assert.Equal(t, 0, len(p.sessions), "sessions map should be empty after all closed")
+	p.mu.RUnlock()
+}
+
+// TestSession_Close_Twice_NoPanic verifies that calling Close twice does not panic.
+func TestSession_Close_Twice_NoPanic(t *testing.T) {
+	p := New()
+	s := &Session{
+		id:       "double-close-session",
+		mode:     "client",
+		provider: p,
+	}
+	p.mu.Lock()
+	p.sessions[s.id] = s
+	p.mu.Unlock()
+
+	require.NoError(t, s.Close(context.Background()))
+	require.NoError(t, s.Close(context.Background()))
+
+	p.mu.RLock()
+	assert.Equal(t, 0, len(p.sessions))
+	p.mu.RUnlock()
+}
+
+// TestSession_Close_Concurrent verifies that concurrent Close calls do not data-race.
+// Runs N goroutines each calling Close() on a distinct session that shares a single
+// provider — exercises the mutex in Close() under go test -race.
+func TestSession_Close_Concurrent(t *testing.T) {
+	p := New()
+
+	const n = 20
+	sessions := make([]*Session, n)
+	for i := 0; i < n; i++ {
+		id := fmt.Sprintf("concurrent-session-%d", i)
+		s := &Session{
+			id:       id,
+			mode:     "client",
+			provider: p,
+		}
+		p.mu.Lock()
+		p.sessions[id] = s
+		p.mu.Unlock()
+		sessions[i] = s
+	}
+
+	errCh := make(chan error, n)
+	var wg sync.WaitGroup
+	for _, s := range sessions {
+		wg.Add(1)
+		go func(s *Session) {
+			defer wg.Done()
+			errCh <- s.Close(context.Background())
+		}(s)
+	}
+	wg.Wait()
+	close(errCh)
+
+	for err := range errCh {
+		require.NoError(t, err)
+	}
+
+	p.mu.RLock()
+	assert.Equal(t, 0, len(p.sessions), "all sessions must be removed from map after concurrent closes")
+	p.mu.RUnlock()
 }


### PR DESCRIPTION
## Summary

- `Session.Close()` now removes the session from `provider.sessions` under `p.mu.Lock()`, preventing the map from growing unboundedly over the process lifetime
- `Stop()` deadlock fixed: it previously called `s.Close()` while holding `p.mu.Lock()`, which would have blocked on the new lock acquisition in `Close()`. Fixed by setting `s.closed.Store(true)` directly and replacing the map — identical observable behavior, no deadlock
- Three new tests validate the fix including a concurrent close test (`TestSession_Close_Concurrent`) that passes under `go test -race`

## Specialist Review Results

| Reviewer | Result | Notes |
|---|---|---|
| QA Test Runner | PASS | All dataplane packages pass; one pre-existing flaky timing test in unrelated `features/rbac/zerotrust/` package |
| QA Code Reviewer | PASS | No mocks, no skips, no error discards, concurrent test validates lock discipline under -race |
| Security Engineer | PASS | No hardcoded secrets, no central provider violations, gosec and staticcheck clean |

## Test plan

- [ ] `go test ./pkg/dataplane/providers/grpc/... -race` — all pass
- [ ] `TestSession_Close_RemovesFromProviderMap` — N sessions closed, map empty
- [ ] `TestSession_Close_Twice_NoPanic` — double-close is idempotent
- [ ] `TestSession_Close_Concurrent` — 20 goroutines, no data race

Fixes #892

🤖 Generated with [Claude Code](https://claude.com/claude-code)