### PR TITLE
dataplane: add DoS limits to gRPC server construction (Issue #893)

### DIFF
--- a/features/controller/server/server.go
+++ b/features/controller/server/server.go
@@ -49,7 +49,7 @@ import (
 	grpcCP "github.com/cfgis/cfgms/pkg/controlplane/providers/grpc" // gRPC control plane provider
 	controlplaneTypes "github.com/cfgis/cfgms/pkg/controlplane/types"
 	dataplaneInterfaces "github.com/cfgis/cfgms/pkg/dataplane/interfaces"
-	_ "github.com/cfgis/cfgms/pkg/dataplane/providers/grpc" // Register gRPC data plane provider
+	dataplaneGRPC "github.com/cfgis/cfgms/pkg/dataplane/providers/grpc" // Register gRPC data plane provider; exported for ServerOptions
 	"github.com/cfgis/cfgms/pkg/gitsync"
 	"github.com/cfgis/cfgms/pkg/logging"
 	pkgRegistration "github.com/cfgis/cfgms/pkg/registration"
@@ -795,7 +795,9 @@ func (s *Server) Start() error {
 
 		// Create fresh shared gRPC server + QUIC listener per Start() cycle.
 		// grpc.Server is not reusable after Stop(), so we create a new one each time.
-		s.grpcServer = grpc.NewServer(grpc.Creds(quictransport.TransportCredentials()))
+		s.grpcServer = grpc.NewServer(
+			append([]grpc.ServerOption{grpc.Creds(quictransport.TransportCredentials())}, dataplaneGRPC.ServerOptions()...)...,
+		)
 		ql, err := quictransport.Listen(s.cfg.Transport.ListenAddr, grpcTLSConfig, nil)
 		if err != nil {
 			return fmt.Errorf("failed to start shared QUIC listener: %w", err)

--- a/pkg/dataplane/providers/grpc/doc.go
+++ b/pkg/dataplane/providers/grpc/doc.go
@@ -34,4 +34,22 @@
 //
 // OpenStream and AcceptStream are not supported by this provider. Use the
 // typed transfer methods (SendConfig, SendDNA, SendBulk) instead.
+//
+// # DoS Limits
+//
+// Every gRPC server created by this package enforces the following limits to
+// prevent a malicious steward from OOM-ing the controller:
+//
+//   - MaxRecvMsgSize: 8 MB — a single inbound gRPC message larger than this
+//     is rejected with codes.ResourceExhausted. The 64 KB chunk size used by
+//     the transfer helpers keeps normal traffic well within the limit.
+//   - MaxSendMsgSize: 8 MB — symmetric cap on outbound messages.
+//   - MaxConcurrentStreams: 100 — limits active gRPC streams per connection,
+//     preventing stream-flood attacks from overwhelming the server.
+//   - KeepaliveParams: ping every 30 s, close if no ACK within 60 s.
+//   - KeepaliveEnforcementPolicy: clients must wait at least 10 s between pings.
+//
+// Constants are defined in limits.go. Both call sites (provider.go startServer
+// and features/controller/server/server.go Start) use the shared ServerOptions()
+// helper so the limits stay in sync.
 package grpc

--- a/pkg/dataplane/providers/grpc/integration_test.go
+++ b/pkg/dataplane/providers/grpc/integration_test.go
@@ -11,12 +11,16 @@ import (
 	"testing"
 	"time"
 
+	transportpb "github.com/cfgis/cfgms/api/proto/transport"
 	cfgcert "github.com/cfgis/cfgms/pkg/cert"
 	"github.com/cfgis/cfgms/pkg/dataplane/interfaces"
 	"github.com/cfgis/cfgms/pkg/dataplane/types"
 	quictransport "github.com/cfgis/cfgms/pkg/transport/quic"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 // integrationEnv holds a matched server + client provider pair for integration tests.
@@ -338,4 +342,90 @@ func TestGRPC_ConcurrentTransfers(t *testing.T) {
 	mu.Lock()
 	assert.Len(t, completedIDs, numTransfers, "all concurrent transfers should complete")
 	mu.Unlock()
+}
+
+// TestGRPC_OversizedMessageRejected verifies that a single gRPC message larger
+// than maxRecvMsgSize (8 MB) is rejected by the server with codes.ResourceExhausted.
+//
+// The test bypasses the 64 KB chunk helper to send a raw 9 MB DNAChunk directly.
+// The server's MaxRecvMsgSize option must reject the message before it reaches
+// application code.
+func TestGRPC_OversizedMessageRejected(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping QUIC integration test in short mode — requires UDP buffer allocation")
+	}
+
+	serverTLS, clientTLS := newTestTLSConfigs(t)
+
+	sp := New()
+	err := sp.Initialize(context.Background(), map[string]interface{}{
+		"mode":        "server",
+		"listen_addr": "127.0.0.1:0",
+		"tls_config":  serverTLS,
+	})
+	require.NoError(t, err)
+
+	err = sp.Start(context.Background())
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = sp.Stop(context.Background()) })
+
+	listenAddr := sp.ListenAddr()
+
+	// Pre-allocate a server session so the handler queue is serviced.
+	serverSess, err := sp.AcceptConnection(context.Background())
+	require.NoError(t, err)
+
+	// Drain incoming DNA in the background. ReceiveDNA calls Recv() on the stream,
+	// which triggers the server's MaxRecvMsgSize check and fails for the 9 MB chunk.
+	var serverErr error
+	serverDone := make(chan struct{})
+	go func() {
+		defer close(serverDone)
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		_, serverErr = serverSess.ReceiveDNA(ctx)
+	}()
+
+	// Allow the server goroutine to block on the handler queue before the client sends.
+	time.Sleep(20 * time.Millisecond)
+
+	// Create a raw gRPC client with the default 2 GB send limit so it can
+	// transmit a message that exceeds the server's 8 MB receive limit.
+	dialer := quictransport.NewDialer(clientTLS, nil)
+	conn, err := grpc.NewClient(
+		listenAddr,
+		grpc.WithContextDialer(dialer),
+		grpc.WithTransportCredentials(quictransport.TransportCredentials()),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = conn.Close() })
+
+	client := transportpb.NewStewardTransportClient(conn)
+
+	stream, err := client.SyncDNA(context.Background())
+	require.NoError(t, err)
+
+	// 9 MB > maxRecvMsgSize (8 MB): the server must reject this message.
+	oversizedData := bytes.Repeat([]byte("X"), 9*1024*1024)
+	chunk := &transportpb.DNAChunk{
+		StewardId:   "dos-test-steward",
+		TenantId:    "dos-test-tenant",
+		Data:        oversizedData,
+		ChunkIndex:  0,
+		TotalChunks: 1,
+	}
+
+	sendErr := stream.Send(chunk)
+	if sendErr == nil {
+		_, sendErr = stream.CloseAndRecv()
+	}
+
+	<-serverDone
+
+	// Both sides must observe a failure: the server because Recv() hit the size
+	// limit, and the client because the server returned an error status.
+	require.Error(t, serverErr, "server-side ReceiveDNA must fail for an oversized message")
+	require.Error(t, sendErr, "client must receive an error when the server rejects an oversized message")
+	assert.Equal(t, codes.ResourceExhausted, status.Code(sendErr),
+		"oversized message must yield codes.ResourceExhausted")
 }

--- a/pkg/dataplane/providers/grpc/limits.go
+++ b/pkg/dataplane/providers/grpc/limits.go
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+package grpc
+
+import (
+	"time"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/keepalive"
+)
+
+// DoS limits applied to every gRPC server created by this package.
+//
+// Values are set per the product specification to prevent a malicious steward
+// from OOM-ing the controller via oversized messages or stream flooding.
+const (
+	maxRecvMsgSize       = 8 * 1024 * 1024 // 8 MB — caps each inbound message
+	maxSendMsgSize       = 8 * 1024 * 1024 // 8 MB — caps each outbound message
+	maxConcurrentStreams = 100             // max active streams per connection
+
+	keepalivePingTime = 30 * time.Second // interval between server-initiated pings
+	keepaliveTimeout  = 60 * time.Second // time to wait for ping ACK before closing
+	keepaliveMinTime  = 10 * time.Second // minimum client ping interval enforced
+)
+
+// ServerOptions returns gRPC server options that enforce DoS limits for all
+// CFGMS data plane servers.
+//
+// Both the standalone data plane server (provider.go startServer) and the
+// controller's shared gRPC server (server.go Start) must use these options so a
+// malicious steward cannot OOM the controller via oversized messages or stream
+// flooding. Credentials must be prepended by each call site since they vary.
+func ServerOptions() []grpc.ServerOption {
+	return []grpc.ServerOption{
+		grpc.MaxRecvMsgSize(maxRecvMsgSize),
+		grpc.MaxSendMsgSize(maxSendMsgSize),
+		grpc.MaxConcurrentStreams(maxConcurrentStreams),
+		grpc.KeepaliveParams(keepalive.ServerParameters{
+			Time:    keepalivePingTime,
+			Timeout: keepaliveTimeout,
+		}),
+		grpc.KeepaliveEnforcementPolicy(keepalive.EnforcementPolicy{
+			MinTime: keepaliveMinTime,
+		}),
+	}
+}

--- a/pkg/dataplane/providers/grpc/provider.go
+++ b/pkg/dataplane/providers/grpc/provider.go
@@ -206,7 +206,7 @@ func (p *Provider) startServer() error {
 		p.listenAddr = ql.Addr().String() // capture actual port if ":0"
 
 		p.grpcServer = grpc.NewServer(
-			grpc.Creds(quictransport.TransportCredentials()),
+			append([]grpc.ServerOption{grpc.Creds(quictransport.TransportCredentials())}, ServerOptions()...)...,
 		)
 		transportpb.RegisterStewardTransportServer(p.grpcServer, p.handler)
 

--- a/pkg/dataplane/providers/grpc/provider_test.go
+++ b/pkg/dataplane/providers/grpc/provider_test.go
@@ -3,14 +3,20 @@
 package grpc
 
 import (
+	"bytes"
 	"context"
 	"crypto/tls"
+	"net"
 	"testing"
 
+	transportpb "github.com/cfgis/cfgms/api/proto/transport"
 	"github.com/cfgis/cfgms/pkg/dataplane/interfaces"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/status"
 )
 
 // TestProvider_Registration verifies the provider registers itself as "grpc" via init().
@@ -237,4 +243,59 @@ func TestProvider_Handler_WithExternalServer(t *testing.T) {
 
 func grpcNewServer() *grpc.Server {
 	return grpc.NewServer()
+}
+
+// TestProvider_ServerOptions_Applied verifies that a gRPC server built with
+// ServerOptions() actually rejects a message larger than 8 MB with
+// codes.ResourceExhausted. Uses a plain TCP listener so no QUIC/mTLS is needed.
+//
+// The test would fail if maxRecvMsgSize were changed to a value > 9 MB because
+// the 9 MB payload would no longer be rejected.
+func TestProvider_ServerOptions_Applied(t *testing.T) {
+	opts := ServerOptions()
+	require.Len(t, opts, 5,
+		"ServerOptions must return 5 options: MaxRecvMsgSize, MaxSendMsgSize, MaxConcurrentStreams, KeepaliveParams, KeepaliveEnforcementPolicy")
+
+	// Start a real TCP gRPC server with the DoS limits applied.
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	srv := grpc.NewServer(opts...)
+	transportpb.RegisterStewardTransportServer(srv, &dosLimitTestHandler{})
+	go func() { _ = srv.Serve(lis) }()
+	t.Cleanup(srv.GracefulStop)
+
+	conn, err := grpc.NewClient(lis.Addr().String(),
+		grpc.WithTransportCredentials(insecure.NewCredentials()))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = conn.Close() })
+
+	client := transportpb.NewStewardTransportClient(conn)
+	stream, err := client.SyncDNA(context.Background())
+	require.NoError(t, err)
+
+	// 9 MB is 1 MB over the 8 MB maxRecvMsgSize limit.
+	sendErr := stream.Send(&transportpb.DNAChunk{
+		StewardId: "dos-unit-test",
+		Data:      bytes.Repeat([]byte("X"), 9*1024*1024),
+	})
+	if sendErr == nil {
+		_, sendErr = stream.CloseAndRecv()
+	}
+
+	require.Error(t, sendErr, "server built with ServerOptions must reject messages > 8 MB")
+	assert.Equal(t, codes.ResourceExhausted, status.Code(sendErr),
+		"oversized message must yield codes.ResourceExhausted, got %v", sendErr)
+}
+
+// dosLimitTestHandler is a minimal StewardTransportServer that calls Recv()
+// on the first SyncDNA message, triggering the gRPC MaxRecvMsgSize check.
+// The handler returns the Recv error directly so gRPC propagates it to the client.
+type dosLimitTestHandler struct {
+	transportpb.UnimplementedStewardTransportServer
+}
+
+func (h *dosLimitTestHandler) SyncDNA(stream grpc.ClientStreamingServer[transportpb.DNAChunk, transportpb.DNASyncResponse]) error {
+	_, err := stream.Recv()
+	return err
 }


### PR DESCRIPTION
## Summary

- Adds `pkg/dataplane/providers/grpc/limits.go` with named constants (`maxRecvMsgSize=8MB`, `maxSendMsgSize=8MB`, `maxConcurrentStreams=100`, keepalive timings) and exported `ServerOptions()` helper
- Replaces the bare `grpc.NewServer(grpc.Creds(...))` at `provider.go:208` and `server.go:798` with `ServerOptions()`-based construction, ensuring both call sites stay in sync
- Documents the limits in `doc.go` with a "# DoS Limits" section

## Test plan

- [x] `TestProvider_ServerOptions_Applied` — starts a real TCP gRPC server with `ServerOptions()`, sends a 9 MB `DNAChunk`, asserts `codes.ResourceExhausted`
- [x] `TestGRPC_OversizedMessageRejected` — same verification over the full QUIC+mTLS path; both server-side and client-side errors asserted
- [x] All pre-existing integration tests pass (ConfigSync, DNASync, BulkTransfer, LargeConfigSync, ConcurrentTransfers)
- [x] `make check-architecture` — 0 central-provider violations
- [x] Cross-platform builds pass (linux/amd64, linux/arm64, darwin/amd64, darwin/arm64, windows/amd64)

## Specialist review results

- **QA test runner**: PASS — all unit, integration, lint, and cross-platform gates pass
- **QA code reviewer**: PASS — behavioral tests verified, no blocking issues, no mocks
- **Security engineer**: PASS — gosec 0 issues, no secrets, no information disclosure, architecture clean

Fixes #893

🤖 Generated with [Claude Code](https://claude.com/claude-code)