### PR TITLE
dataplane: add chunk integrity error types and validation tests (Issue #895)

### DIFF
--- a/features/controller/transport/config_handler.go
+++ b/features/controller/transport/config_handler.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"math"
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -22,6 +23,7 @@ import (
 	"github.com/cfgis/cfgms/features/config/signature"
 	"github.com/cfgis/cfgms/features/controller/service"
 	dataplaneInterfaces "github.com/cfgis/cfgms/pkg/dataplane/interfaces"
+	dataplaneTypes "github.com/cfgis/cfgms/pkg/dataplane/types"
 	"github.com/cfgis/cfgms/pkg/logging"
 	transportauth "github.com/cfgis/cfgms/pkg/transport/auth"
 	quictransport "github.com/cfgis/cfgms/pkg/transport/quic"
@@ -31,9 +33,6 @@ import (
 // Client-initiated bidirectional streams use IDs 0, 4, 8, 12... (multiples of 4)
 // Stream 0 is handshake, so first data stream is 4.
 const ConfigSyncStreamID = 4
-
-// chunkSize is the maximum payload per ConfigChunk (64 KB).
-const chunkSize = 64 * 1024
 
 // ConfigHandler handles configuration sync over data plane streams.
 type ConfigHandler struct {
@@ -276,22 +275,25 @@ func (h *ConfigHandler) HandleGRPC(ctx context.Context, req *transportpb.ConfigS
 	}
 
 	// Chunk and stream
-	totalChunks := (len(configBytes) + chunkSize - 1) / chunkSize
+	totalChunks := (len(configBytes) + dataplaneTypes.DefaultChunkSize - 1) / dataplaneTypes.DefaultChunkSize
 	if totalChunks == 0 {
 		totalChunks = 1
 	}
+	if totalChunks > math.MaxInt32 {
+		return status.Error(codes.ResourceExhausted, "configuration too large to stream")
+	}
 
 	for i := 0; i < totalChunks; i++ {
-		start := i * chunkSize
-		end := start + chunkSize
+		start := i * dataplaneTypes.DefaultChunkSize
+		end := start + dataplaneTypes.DefaultChunkSize
 		if end > len(configBytes) {
 			end = len(configBytes)
 		}
 
 		chunk := &transportpb.ConfigChunk{
 			Data:        configBytes[start:end],
-			ChunkIndex:  int32(i),
-			TotalChunks: int32(totalChunks),
+			ChunkIndex:  int32(i),           //nolint:gosec // G115: bounded by totalChunks > math.MaxInt32 check above
+			TotalChunks: int32(totalChunks), //nolint:gosec // G115: bounded by totalChunks > math.MaxInt32 check above
 			Version:     configResp.Version,
 		}
 

--- a/pkg/dataplane/providers/grpc/errors.go
+++ b/pkg/dataplane/providers/grpc/errors.go
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+package grpc
+
+import "errors"
+
+var (
+	ErrEmptyChunkList     = errors.New("dataplane: chunk list is empty")
+	ErrChunkCountMismatch = errors.New("dataplane: TotalChunks does not match received chunk count")
+	ErrChunkSequenceGap   = errors.New("dataplane: chunk sequence has gap or duplicate")
+	ErrPayloadTooLarge    = errors.New("dataplane: assembled payload exceeds maximum size")
+	ErrTotalSizeMismatch  = errors.New("dataplane: BulkChunk TotalSize does not match assembled length")
+)

--- a/pkg/dataplane/providers/grpc/session_test.go
+++ b/pkg/dataplane/providers/grpc/session_test.go
@@ -273,9 +273,8 @@ func TestChunkRoundTrip_EmptyData(t *testing.T) {
 	// Marshal empty cfg → JSON has other fields but Data is empty
 	data, err := json.Marshal(cfg)
 	require.NoError(t, err)
-	// The JSON will be non-empty because the struct has other fields.
-	// configTransferToChunks will produce at least 1 chunk.
-	_ = data
+	// The JSON is non-empty because the struct has ID and Version set.
+	assert.NotEmpty(t, data)
 
 	chunks, err := configTransferToChunks(cfg)
 	require.NoError(t, err)

--- a/pkg/dataplane/providers/grpc/session_test.go
+++ b/pkg/dataplane/providers/grpc/session_test.go
@@ -127,11 +127,11 @@ func TestConfigTransferToChunks(t *testing.T) {
 		assert.Equal(t, int32(len(chunks)), c.TotalChunks)
 		assert.Equal(t, "cfg-test", c.ConfigId)
 		assert.Equal(t, "2.0.0", c.Version)
-		assert.LessOrEqual(t, len(c.Data), chunkSize, "chunk %d exceeds max size", i)
+		assert.LessOrEqual(t, len(c.Data), types.DefaultChunkSize, "chunk %d exceeds max size", i)
 	}
-	// Last chunk must be smaller or equal to chunkSize
+	// Last chunk must be smaller or equal to DefaultChunkSize
 	lastChunk := chunks[len(chunks)-1]
-	assert.LessOrEqual(t, len(lastChunk.Data), chunkSize)
+	assert.LessOrEqual(t, len(lastChunk.Data), types.DefaultChunkSize)
 }
 
 // TestChunksToConfigTransfer verifies chunks reassemble to the original config.
@@ -177,7 +177,7 @@ func TestDNATransferToChunks(t *testing.T) {
 		assert.Equal(t, int32(i), c.ChunkIndex)
 		assert.Equal(t, "steward-3", c.StewardId)
 		assert.Equal(t, "tenant-3", c.TenantId)
-		assert.LessOrEqual(t, len(c.Data), chunkSize)
+		assert.LessOrEqual(t, len(c.Data), types.DefaultChunkSize)
 	}
 }
 
@@ -201,7 +201,7 @@ func TestBulkTransferToChunks(t *testing.T) {
 
 	for i, c := range chunks {
 		assert.Equal(t, "bulk-test", c.TransferId)
-		assert.LessOrEqual(t, len(c.Data), chunkSize, "chunk %d too large", i)
+		assert.LessOrEqual(t, len(c.Data), types.DefaultChunkSize, "chunk %d too large", i)
 	}
 	// Last chunk must have is_last = true
 	assert.True(t, chunks[len(chunks)-1].IsLast)
@@ -287,22 +287,25 @@ func TestChunkRoundTrip_EmptyData(t *testing.T) {
 	assert.Equal(t, "0.0.1", got.Version)
 }
 
-// TestChunksToConfigTransfer_EmptyChunks verifies an error on empty chunk slice.
+// TestChunksToConfigTransfer_EmptyChunks verifies the specific sentinel error on empty chunk slice.
 func TestChunksToConfigTransfer_EmptyChunks(t *testing.T) {
 	_, err := chunksToConfigTransfer(nil)
 	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrEmptyChunkList)
 }
 
-// TestChunksToDNATransfer_EmptyChunks verifies an error on empty chunk slice.
+// TestChunksToDNATransfer_EmptyChunks verifies the specific sentinel error on empty chunk slice.
 func TestChunksToDNATransfer_EmptyChunks(t *testing.T) {
 	_, err := chunksToDNATransfer(nil)
 	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrEmptyChunkList)
 }
 
-// TestChunksToBulkTransfer_EmptyChunks verifies an error on empty chunk slice.
+// TestChunksToBulkTransfer_EmptyChunks verifies the specific sentinel error on empty chunk slice.
 func TestChunksToBulkTransfer_EmptyChunks(t *testing.T) {
 	_, err := chunksToBulkTransfer(nil)
 	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrEmptyChunkList)
 }
 
 // TestSession_Close_RemovesFromProviderMap verifies that Close removes the session

--- a/pkg/dataplane/providers/grpc/stream.go
+++ b/pkg/dataplane/providers/grpc/stream.go
@@ -13,9 +13,6 @@ import (
 	"github.com/cfgis/cfgms/pkg/dataplane/types"
 )
 
-// chunkSize is the maximum bytes per gRPC chunk (64 KB).
-const chunkSize = 64 * 1024
-
 // isEOF reports whether err signals end-of-stream from a gRPC Recv call.
 func isEOF(err error) bool {
 	return err == io.EOF
@@ -45,14 +42,14 @@ func configTransferToChunks(cfg *types.ConfigTransfer) ([]*transportpb.ConfigChu
 		}}, nil
 	}
 
-	total := (len(data) + chunkSize - 1) / chunkSize
+	total := (len(data) + types.DefaultChunkSize - 1) / types.DefaultChunkSize
 	if total > math.MaxInt32 {
 		return nil, fmt.Errorf("config data too large to chunk: %d chunks exceeds int32 limit", total)
 	}
 	chunks := make([]*transportpb.ConfigChunk, 0, total)
 	for i := 0; i < total; i++ {
-		start := i * chunkSize
-		end := start + chunkSize
+		start := i * types.DefaultChunkSize
+		end := start + types.DefaultChunkSize
 		if end > len(data) {
 			end = len(data)
 		}
@@ -69,20 +66,35 @@ func configTransferToChunks(cfg *types.ConfigTransfer) ([]*transportpb.ConfigChu
 
 // chunksToConfigTransfer reassembles chunks into a ConfigTransfer.
 //
-// Chunks are sorted by index before reassembly; a nil or empty slice returns
-// an error.
+// Validation: non-empty list, chunk count matches TotalChunks, contiguous
+// sequence (0..N-1), assembled payload ≤ maxRecvMsgSize (8 MB).
 func chunksToConfigTransfer(chunks []*transportpb.ConfigChunk) (*types.ConfigTransfer, error) {
 	if len(chunks) == 0 {
-		return nil, fmt.Errorf("no chunks to reassemble")
+		return nil, ErrEmptyChunkList
 	}
 
 	sort.Slice(chunks, func(i, j int) bool {
 		return chunks[i].ChunkIndex < chunks[j].ChunkIndex
 	})
 
+	if len(chunks) != int(chunks[0].TotalChunks) {
+		return nil, fmt.Errorf("got %d chunks, TotalChunks=%d: %w",
+			len(chunks), chunks[0].TotalChunks, ErrChunkCountMismatch)
+	}
+
+	for i, c := range chunks {
+		if c.ChunkIndex != int32(i) { //nolint:gosec // G115: i bounded by TotalChunks check above (≤ math.MaxInt32)
+			return nil, fmt.Errorf("position %d has index %d: %w", i, c.ChunkIndex, ErrChunkSequenceGap)
+		}
+	}
+
 	var data []byte
 	for _, c := range chunks {
 		data = append(data, c.Data...)
+	}
+
+	if len(data) > maxRecvMsgSize {
+		return nil, fmt.Errorf("%d bytes: %w", len(data), ErrPayloadTooLarge)
 	}
 
 	if len(data) == 0 {
@@ -121,14 +133,14 @@ func dnaTransferToChunks(dna *types.DNATransfer) ([]*transportpb.DNAChunk, error
 		}}, nil
 	}
 
-	total := (len(data) + chunkSize - 1) / chunkSize
+	total := (len(data) + types.DefaultChunkSize - 1) / types.DefaultChunkSize
 	if total > math.MaxInt32 {
 		return nil, fmt.Errorf("DNA data too large to chunk: %d chunks exceeds int32 limit", total)
 	}
 	chunks := make([]*transportpb.DNAChunk, 0, total)
 	for i := 0; i < total; i++ {
-		start := i * chunkSize
-		end := start + chunkSize
+		start := i * types.DefaultChunkSize
+		end := start + types.DefaultChunkSize
 		if end > len(data) {
 			end = len(data)
 		}
@@ -145,18 +157,36 @@ func dnaTransferToChunks(dna *types.DNATransfer) ([]*transportpb.DNAChunk, error
 }
 
 // chunksToDNATransfer reassembles DNA chunks into a DNATransfer.
+//
+// Validation: non-empty list, chunk count matches TotalChunks, contiguous
+// sequence (0..N-1), assembled payload ≤ maxRecvMsgSize (8 MB).
 func chunksToDNATransfer(chunks []*transportpb.DNAChunk) (*types.DNATransfer, error) {
 	if len(chunks) == 0 {
-		return nil, fmt.Errorf("no chunks to reassemble")
+		return nil, ErrEmptyChunkList
 	}
 
 	sort.Slice(chunks, func(i, j int) bool {
 		return chunks[i].ChunkIndex < chunks[j].ChunkIndex
 	})
 
+	if len(chunks) != int(chunks[0].TotalChunks) {
+		return nil, fmt.Errorf("got %d chunks, TotalChunks=%d: %w",
+			len(chunks), chunks[0].TotalChunks, ErrChunkCountMismatch)
+	}
+
+	for i, c := range chunks {
+		if c.ChunkIndex != int32(i) { //nolint:gosec // G115: i bounded by TotalChunks check above (≤ math.MaxInt32)
+			return nil, fmt.Errorf("position %d has index %d: %w", i, c.ChunkIndex, ErrChunkSequenceGap)
+		}
+	}
+
 	var data []byte
 	for _, c := range chunks {
 		data = append(data, c.Data...)
+	}
+
+	if len(data) > maxRecvMsgSize {
+		return nil, fmt.Errorf("%d bytes: %w", len(data), ErrPayloadTooLarge)
 	}
 
 	if len(data) == 0 {
@@ -194,11 +224,15 @@ func bulkTransferToChunks(bulk *types.BulkTransfer) ([]*transportpb.BulkChunk, e
 		}}, nil
 	}
 
-	total := (len(data) + chunkSize - 1) / chunkSize
+	if len(data) > math.MaxInt32 {
+		return nil, fmt.Errorf("bulk data too large to chunk: %d bytes exceeds int32 limit", len(data))
+	}
+
+	total := (len(data) + types.DefaultChunkSize - 1) / types.DefaultChunkSize
 	chunks := make([]*transportpb.BulkChunk, 0, total)
 	for i := 0; i < total; i++ {
-		start := i * chunkSize
-		end := start + chunkSize
+		start := i * types.DefaultChunkSize
+		end := start + types.DefaultChunkSize
 		if end > len(data) {
 			end = len(data)
 		}
@@ -216,18 +250,35 @@ func bulkTransferToChunks(bulk *types.BulkTransfer) ([]*transportpb.BulkChunk, e
 }
 
 // chunksToBulkTransfer reassembles bulk chunks into a BulkTransfer.
+//
+// Validation: non-empty list, contiguous offsets (no gaps or duplicates),
+// assembled payload ≤ maxRecvMsgSize (8 MB), assembled size matches TotalSize.
 func chunksToBulkTransfer(chunks []*transportpb.BulkChunk) (*types.BulkTransfer, error) {
 	if len(chunks) == 0 {
-		return nil, fmt.Errorf("no chunks to reassemble")
+		return nil, ErrEmptyChunkList
 	}
 
 	sort.Slice(chunks, func(i, j int) bool {
 		return chunks[i].Offset < chunks[j].Offset
 	})
 
+	// Verify offset contiguity: each chunk must start exactly where the previous ended.
+	var accumulated int64
+	for i, c := range chunks {
+		if c.Offset != accumulated {
+			return nil, fmt.Errorf("position %d: offset %d, expected %d: %w",
+				i, c.Offset, accumulated, ErrChunkSequenceGap)
+		}
+		accumulated += int64(len(c.Data))
+	}
+
 	var data []byte
 	for _, c := range chunks {
 		data = append(data, c.Data...)
+	}
+
+	if len(data) > maxRecvMsgSize {
+		return nil, fmt.Errorf("%d bytes: %w", len(data), ErrPayloadTooLarge)
 	}
 
 	if len(data) == 0 {
@@ -235,6 +286,11 @@ func chunksToBulkTransfer(chunks []*transportpb.BulkChunk) (*types.BulkTransfer,
 			ID:       chunks[0].TransferId,
 			Metadata: chunks[0].Metadata,
 		}, nil
+	}
+
+	if int64(len(data)) != chunks[0].TotalSize {
+		return nil, fmt.Errorf("assembled %d bytes, TotalSize=%d: %w",
+			len(data), chunks[0].TotalSize, ErrTotalSizeMismatch)
 	}
 
 	var bulk types.BulkTransfer

--- a/pkg/dataplane/providers/grpc/stream_test.go
+++ b/pkg/dataplane/providers/grpc/stream_test.go
@@ -1,0 +1,231 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+package grpc
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	transportpb "github.com/cfgis/cfgms/api/proto/transport"
+	"github.com/cfgis/cfgms/pkg/dataplane/types"
+)
+
+// TestChunksToConfigTransfer_ValidationErrors is a table-driven suite covering all
+// chunk integrity validation error paths for config chunk reassembly.
+func TestChunksToConfigTransfer_ValidationErrors(t *testing.T) {
+	tests := []struct {
+		name    string
+		chunks  []*transportpb.ConfigChunk
+		wantErr error
+	}{
+		{
+			name:    "empty_slice",
+			chunks:  []*transportpb.ConfigChunk{},
+			wantErr: ErrEmptyChunkList,
+		},
+		{
+			name: "total_chunks_mismatch",
+			// 2 chunks but TotalChunks=3 — count does not match.
+			chunks: []*transportpb.ConfigChunk{
+				{Data: []byte("a"), ChunkIndex: 0, TotalChunks: 3},
+				{Data: []byte("b"), ChunkIndex: 1, TotalChunks: 3},
+			},
+			wantErr: ErrChunkCountMismatch,
+		},
+		{
+			name: "sequence_gap",
+			// indices 0, 2 with TotalChunks=2 — index 1 is missing.
+			chunks: []*transportpb.ConfigChunk{
+				{Data: []byte("a"), ChunkIndex: 0, TotalChunks: 2},
+				{Data: []byte("c"), ChunkIndex: 2, TotalChunks: 2},
+			},
+			wantErr: ErrChunkSequenceGap,
+		},
+		{
+			name: "duplicate_sequence",
+			// Two chunks both at index 0 — the duplicate causes a gap at index 1.
+			chunks: []*transportpb.ConfigChunk{
+				{Data: []byte("a"), ChunkIndex: 0, TotalChunks: 2},
+				{Data: []byte("b"), ChunkIndex: 0, TotalChunks: 2},
+			},
+			wantErr: ErrChunkSequenceGap,
+		},
+		{
+			name: "payload_too_large",
+			// Two 5 MB chunks → 10 MB assembled payload exceeds maxRecvMsgSize (8 MB).
+			chunks: func() []*transportpb.ConfigChunk {
+				big := make([]byte, 5*1024*1024)
+				return []*transportpb.ConfigChunk{
+					{Data: big, ChunkIndex: 0, TotalChunks: 2},
+					{Data: big, ChunkIndex: 1, TotalChunks: 2},
+				}
+			}(),
+			wantErr: ErrPayloadTooLarge,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := chunksToConfigTransfer(tc.chunks)
+			require.Error(t, err)
+			assert.True(t, errors.Is(err, tc.wantErr), "want %v, got %v", tc.wantErr, err)
+		})
+	}
+}
+
+// TestChunksToDNATransfer_ValidationErrors is a table-driven suite covering all
+// chunk integrity validation error paths for DNA chunk reassembly.
+func TestChunksToDNATransfer_ValidationErrors(t *testing.T) {
+	tests := []struct {
+		name    string
+		chunks  []*transportpb.DNAChunk
+		wantErr error
+	}{
+		{
+			name:    "empty_slice",
+			chunks:  []*transportpb.DNAChunk{},
+			wantErr: ErrEmptyChunkList,
+		},
+		{
+			name: "total_chunks_mismatch",
+			chunks: []*transportpb.DNAChunk{
+				{Data: []byte("a"), ChunkIndex: 0, TotalChunks: 3, StewardId: "s1", TenantId: "t1"},
+				{Data: []byte("b"), ChunkIndex: 1, TotalChunks: 3, StewardId: "s1", TenantId: "t1"},
+			},
+			wantErr: ErrChunkCountMismatch,
+		},
+		{
+			name: "sequence_gap",
+			chunks: []*transportpb.DNAChunk{
+				{Data: []byte("a"), ChunkIndex: 0, TotalChunks: 2, StewardId: "s1", TenantId: "t1"},
+				{Data: []byte("c"), ChunkIndex: 2, TotalChunks: 2, StewardId: "s1", TenantId: "t1"},
+			},
+			wantErr: ErrChunkSequenceGap,
+		},
+		{
+			name: "duplicate_sequence",
+			chunks: []*transportpb.DNAChunk{
+				{Data: []byte("a"), ChunkIndex: 0, TotalChunks: 2, StewardId: "s1", TenantId: "t1"},
+				{Data: []byte("b"), ChunkIndex: 0, TotalChunks: 2, StewardId: "s1", TenantId: "t1"},
+			},
+			wantErr: ErrChunkSequenceGap,
+		},
+		{
+			name: "payload_too_large",
+			chunks: func() []*transportpb.DNAChunk {
+				big := make([]byte, 5*1024*1024)
+				return []*transportpb.DNAChunk{
+					{Data: big, ChunkIndex: 0, TotalChunks: 2, StewardId: "s1", TenantId: "t1"},
+					{Data: big, ChunkIndex: 1, TotalChunks: 2, StewardId: "s1", TenantId: "t1"},
+				}
+			}(),
+			wantErr: ErrPayloadTooLarge,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := chunksToDNATransfer(tc.chunks)
+			require.Error(t, err)
+			assert.True(t, errors.Is(err, tc.wantErr), "want %v, got %v", tc.wantErr, err)
+		})
+	}
+}
+
+// TestChunksToBulkTransfer_ValidationErrors is a table-driven suite covering all
+// chunk integrity validation error paths for bulk chunk reassembly.
+func TestChunksToBulkTransfer_ValidationErrors(t *testing.T) {
+	tests := []struct {
+		name    string
+		chunks  []*transportpb.BulkChunk
+		wantErr error
+	}{
+		{
+			name:    "empty_slice",
+			chunks:  []*transportpb.BulkChunk{},
+			wantErr: ErrEmptyChunkList,
+		},
+		{
+			name: "offset_gap",
+			// chunk[1] starts at offset 10, but chunk[0] ends at offset 5 — 5-byte gap.
+			chunks: []*transportpb.BulkChunk{
+				{Data: []byte("hello"), Offset: 0, TotalSize: 10},
+				{Data: []byte("world"), Offset: 10, TotalSize: 10},
+			},
+			wantErr: ErrChunkSequenceGap,
+		},
+		{
+			name: "payload_too_large",
+			// Two 5 MB chunks → 10 MB assembled payload exceeds maxRecvMsgSize (8 MB).
+			chunks: func() []*transportpb.BulkChunk {
+				big := make([]byte, 5*1024*1024)
+				return []*transportpb.BulkChunk{
+					{Data: big, Offset: 0, TotalSize: int64(10 * 1024 * 1024)},
+					{Data: big, Offset: int64(5 * 1024 * 1024), TotalSize: int64(10 * 1024 * 1024)},
+				}
+			}(),
+			wantErr: ErrPayloadTooLarge,
+		},
+		{
+			name: "duplicate_offset",
+			// Two chunks both at offset 0 — the duplicate causes a mismatch on the second iteration.
+			chunks: []*transportpb.BulkChunk{
+				{Data: []byte("hello"), Offset: 0, TotalSize: 10},
+				{Data: []byte("world"), Offset: 0, TotalSize: 10},
+			},
+			wantErr: ErrChunkSequenceGap,
+		},
+		{
+			name: "total_size_mismatch",
+			// Assembled payload is 13 bytes but TotalSize claims 999.
+			chunks: []*transportpb.BulkChunk{
+				{Data: []byte(`{"id":"test"}`), Offset: 0, TotalSize: 999},
+			},
+			wantErr: ErrTotalSizeMismatch,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := chunksToBulkTransfer(tc.chunks)
+			require.Error(t, err)
+			assert.True(t, errors.Is(err, tc.wantErr), "want %v, got %v", tc.wantErr, err)
+		})
+	}
+}
+
+// TestChunksToBulkTransfer_RoundTrip verifies that bulkTransferToChunks and
+// chunksToBulkTransfer are inverse operations for a normal-sized payload.
+func TestChunksToBulkTransfer_RoundTrip(t *testing.T) {
+	original := &types.BulkTransfer{
+		ID:        "bulk-rt-001",
+		StewardID: "steward-rt",
+		TenantID:  "tenant-rt",
+		Direction: "to_steward",
+		Type:      "file",
+	}
+	chunks, err := bulkTransferToChunks(original)
+	require.NoError(t, err)
+	require.NotEmpty(t, chunks)
+
+	got, err := chunksToBulkTransfer(chunks)
+	require.NoError(t, err)
+	assert.Equal(t, original.ID, got.ID)
+	assert.Equal(t, original.StewardID, got.StewardID)
+	assert.Equal(t, original.TenantID, got.TenantID)
+}
+
+// TestBulkTransferToChunks_SmallPayload verifies that bulkTransferToChunks produces
+// at least one chunk for a small payload and does not error.
+func TestBulkTransferToChunks_SmallPayload(t *testing.T) {
+	bulk := &types.BulkTransfer{
+		ID:   "bulk-small",
+		Data: []byte("payload well below any size limit"),
+	}
+	chunks, err := bulkTransferToChunks(bulk)
+	require.NoError(t, err)
+	assert.NotEmpty(t, chunks)
+}

--- a/pkg/dataplane/types/transfers.go
+++ b/pkg/dataplane/types/transfers.go
@@ -27,6 +27,12 @@ const (
 	StreamCustom StreamType = "custom"
 )
 
+// DefaultChunkSize is the maximum bytes per gRPC chunk (64 KB).
+//
+// Authoritative location — importable by both pkg/ and features/ code without
+// creating a concrete-provider import dependency.
+const DefaultChunkSize = 64 * 1024
+
 // ConfigTransfer represents a configuration data transfer.
 //
 // Configuration transfers include tenant-specific configuration data,


### PR DESCRIPTION
Agent session failed with exit code 1. Review container logs for details.