### PR TITLE
features/terminal: refactor CleanupTimedOutSessions to release lock before TerminateSession (Issue #911)

### DIFF
--- a/features/terminal/manager.go
+++ b/features/terminal/manager.go
@@ -20,6 +20,10 @@ type DefaultSessionManager struct {
 	recorder  Recorder
 	cleanupCh chan string
 	stopCh    chan struct{}
+	// afterCollectHook, if non-nil, is called after the timed-out ID slice is
+	// collected and m.mu is released, but before the termination loop begins.
+	// Used in tests to inject deterministic race conditions.
+	afterCollectHook func(ids []string)
 }
 
 // NewSessionManager creates a new session manager
@@ -214,6 +218,10 @@ func (m *DefaultSessionManager) CleanupTimedOutSessions() {
 		}
 	}
 	m.mu.Unlock()
+
+	if m.afterCollectHook != nil {
+		m.afterCollectHook(timedOut)
+	}
 
 	for _, id := range timedOut {
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)

--- a/features/terminal/manager.go
+++ b/features/terminal/manager.go
@@ -202,51 +202,29 @@ func (m *DefaultSessionManager) cleanupRoutine() {
 	}
 }
 
-// CleanupTimedOutSessions removes sessions that have timed out
+// CleanupTimedOutSessions removes sessions that have timed out.
+// The lock is released before any blocking operation: TerminateSession acquires
+// its own lock, so holding m.mu during that call would deadlock.
 func (m *DefaultSessionManager) CleanupTimedOutSessions() {
 	m.mu.Lock()
-	defer m.mu.Unlock()
-
-	timedOutSessions := make([]string, 0)
-
-	for sessionID, session := range m.sessions {
-		if session.IsTimedOut(m.config.SessionTimeout) {
-			timedOutSessions = append(timedOutSessions, sessionID)
+	timedOut := make([]string, 0)
+	for id, sess := range m.sessions {
+		if sess.IsTimedOut(m.config.SessionTimeout) {
+			timedOut = append(timedOut, id)
 		}
 	}
+	m.mu.Unlock()
 
-	// Clean up timed-out sessions
-	for _, sessionID := range timedOutSessions {
-		session := m.sessions[sessionID]
-
-		// Close the session
+	for _, id := range timedOut {
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-		if err := session.Close(ctx); err != nil {
-			m.logger.Warn("Error closing timed-out session", "session_id", sessionID, "error", err)
+		if err := m.TerminateSession(ctx, id); err != nil {
+			m.logger.Warn("Failed to terminate timed-out session", "session_id", id, "error", err)
 		}
 		cancel()
-
-		// End recording if available
-		if m.recorder != nil {
-			if recorder, ok := m.recorder.(*DefaultSessionRecorder); ok {
-				if err := recorder.EndRecording(sessionID); err != nil {
-					m.logger.Warn("Failed to end recording for timed-out session", "session_id", sessionID, "error", err)
-				}
-			}
-		}
-
-		// Remove from active sessions
-		delete(m.sessions, sessionID)
-
-		m.logger.Info("Session timed out and cleaned up",
-			"session_id", sessionID,
-			"timeout", m.config.SessionTimeout)
 	}
 
-	if len(timedOutSessions) > 0 {
-		m.logger.Info("Cleaned up timed-out sessions",
-			"count", len(timedOutSessions),
-			"active_sessions", len(m.sessions))
+	if len(timedOut) > 0 {
+		m.logger.Info("Cleaned up timed-out sessions", "count", len(timedOut))
 	}
 }
 

--- a/features/terminal/manager_test.go
+++ b/features/terminal/manager_test.go
@@ -171,8 +171,10 @@ func TestSessionTimeout(t *testing.T) {
 	session, err := manager.CreateSession(ctx, sessionReq)
 	require.NoError(t, err)
 
-	// Wait for timeout plus cleanup cycle
-	time.Sleep(200 * time.Millisecond)
+	// Poll until the session has actually timed out before triggering cleanup.
+	require.Eventually(t, func() bool {
+		return session.IsTimedOut(config.SessionTimeout)
+	}, time.Second, time.Millisecond)
 
 	// Manually trigger cleanup to ensure it runs in test
 	defaultManager := manager.(*DefaultSessionManager)
@@ -239,7 +241,7 @@ func TestCleanupTimedOutSessions_AllSessionsCleaned(t *testing.T) {
 	ctx := context.Background()
 
 	const sessionCount = 10
-	sessionIDs := make([]string, sessionCount)
+	sessions := make([]*Session, sessionCount)
 
 	for i := 0; i < sessionCount; i++ {
 		req := &SessionRequest{
@@ -251,16 +253,25 @@ func TestCleanupTimedOutSessions_AllSessionsCleaned(t *testing.T) {
 		}
 		sess, err := manager.CreateSession(ctx, req)
 		require.NoError(t, err)
-		sessionIDs[i] = sess.ID
+		sessions[i] = sess
 	}
 
-	time.Sleep(100 * time.Millisecond)
+	// Poll until every session has timed out. Sessions are created sequentially,
+	// so the last one timed out means all have; checking all is unambiguous.
+	require.Eventually(t, func() bool {
+		for _, sess := range sessions {
+			if !sess.IsTimedOut(config.SessionTimeout) {
+				return false
+			}
+		}
+		return true
+	}, time.Second, time.Millisecond)
 
 	manager.(*DefaultSessionManager).CleanupTimedOutSessions()
 
-	for _, id := range sessionIDs {
-		_, err := manager.GetSession(id)
-		assert.Error(t, err, "timed-out session %s should be removed", id)
+	for _, sess := range sessions {
+		_, err := manager.GetSession(sess.ID)
+		assert.Error(t, err, "timed-out session %s should be removed", sess.ID)
 	}
 }
 
@@ -286,7 +297,7 @@ func TestCleanupTimedOutSessions_ContinuesAfterPerSessionError(t *testing.T) {
 	ctx := context.Background()
 
 	const sessionCount = 10
-	sessionIDs := make([]string, sessionCount)
+	sessions := make([]*Session, sessionCount)
 
 	for i := 0; i < sessionCount; i++ {
 		req := &SessionRequest{
@@ -298,30 +309,42 @@ func TestCleanupTimedOutSessions_ContinuesAfterPerSessionError(t *testing.T) {
 		}
 		sess, err := manager.CreateSession(ctx, req)
 		require.NoError(t, err)
-		sessionIDs[i] = sess.ID
+		sessions[i] = sess
 	}
 
-	time.Sleep(10 * time.Millisecond)
+	// Poll until all sessions have timed out before installing the hook and triggering cleanup.
+	require.Eventually(t, func() bool {
+		for _, sess := range sessions {
+			if !sess.IsTimedOut(config.SessionTimeout) {
+				return false
+			}
+		}
+		return true
+	}, time.Second, time.Millisecond)
 
 	defaultManager := manager.(*DefaultSessionManager)
 
 	// Install a hook that terminates every collected session before the
 	// termination loop begins. This guarantees the loop sees "session not
 	// found" for all IDs in a deterministic, race-free way.
+	//
+	// The hook runs synchronously on the test goroutine (CleanupTimedOutSessions
+	// is called directly below), so require.NoError is safe.
 	defaultManager.afterCollectHook = func(ids []string) {
 		hookCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
 		for _, id := range ids {
-			_ = defaultManager.TerminateSession(hookCtx, id)
+			require.NoError(t, defaultManager.TerminateSession(hookCtx, id),
+				"hook: pre-termination of session %s must succeed", id)
 		}
 	}
 
 	defaultManager.CleanupTimedOutSessions()
 
 	// All sessions must be gone (pre-terminated by the hook).
-	for _, id := range sessionIDs {
-		_, err := manager.GetSession(id)
-		assert.Error(t, err, "session %s must be terminated", id)
+	for _, sess := range sessions {
+		_, err := manager.GetSession(sess.ID)
+		assert.Error(t, err, "session %s must be terminated", sess.ID)
 	}
 
 	// The termination loop must have logged a warning for each "session not
@@ -333,18 +356,17 @@ func TestCleanupTimedOutSessions_ContinuesAfterPerSessionError(t *testing.T) {
 // TestCleanupTimedOutSessions_GetSessionDuringCleanup verifies that the lock is
 // released before TerminateSession is called, allowing concurrent read operations.
 //
-// Because TerminateSession itself acquires m.mu.Lock(), if CleanupTimedOutSessions
-// held the lock during TerminateSession it would deadlock. Non-completion within 5 s
-// is treated as a deadlock.
+// The afterCollectHook acts as a rendezvous: it signals when m.mu has been released
+// and blocks until GetSession has confirmed concurrent access, proving the lock is
+// not held during the termination loop.
 func TestCleanupTimedOutSessions_GetSessionDuringCleanup(t *testing.T) {
-	logger := testutil.NewMockLogger(true)
 	config := &Config{
 		SessionTimeout: 1 * time.Millisecond,
 		MaxSessions:    100,
 		RecordSessions: false,
 	}
 
-	manager, err := NewSessionManager(config, logger)
+	manager, err := NewSessionManager(config, logging.NewNoopLogger())
 	require.NoError(t, err)
 
 	ctx := context.Background()
@@ -369,12 +391,24 @@ func TestCleanupTimedOutSessions_GetSessionDuringCleanup(t *testing.T) {
 	activeSession, err := manager.CreateSession(ctx, activeReq)
 	require.NoError(t, err)
 
-	time.Sleep(10 * time.Millisecond)
+	// Poll until the timed-out session has actually timed out.
+	require.Eventually(t, func() bool {
+		return timedOutSession.IsTimedOut(config.SessionTimeout)
+	}, time.Second, time.Millisecond)
 
 	// Bump the active session's LastActivity so it is NOT timed out.
 	activeSession.UpdateActivity()
 
 	defaultManager := manager.(*DefaultSessionManager)
+
+	// hookReached is closed when cleanup has released m.mu and entered the hook.
+	// hookDone is closed by the test goroutine to let cleanup proceed to TerminateSession.
+	hookReached := make(chan struct{})
+	hookDone := make(chan struct{})
+	defaultManager.afterCollectHook = func(_ []string) {
+		close(hookReached)
+		<-hookDone
+	}
 
 	done := make(chan struct{})
 	go func() {
@@ -382,12 +416,21 @@ func TestCleanupTimedOutSessions_GetSessionDuringCleanup(t *testing.T) {
 		close(done)
 	}()
 
-	// GetSession (RLock) must succeed; if the write lock were held for the full
-	// cleanup it would block until cleanup finishes (or deadlock if TerminateSession
-	// is called while the lock is held).
+	// Wait until cleanup has released m.mu and is blocked in the hook.
+	select {
+	case <-hookReached:
+	case <-time.After(5 * time.Second):
+		t.Fatal("cleanup goroutine never released m.mu (hook not called within 5s)")
+	}
+
+	// GetSession (RLock) must succeed while the cleanup goroutine holds no lock.
+	// If m.mu were still held this would block indefinitely.
 	retrieved, err := manager.GetSession(activeSession.ID)
-	assert.NoError(t, err, "GetSession must not block while CleanupTimedOutSessions is in its termination loop")
+	assert.NoError(t, err, "GetSession must succeed while CleanupTimedOutSessions is in its termination loop")
 	assert.Equal(t, activeSession.ID, retrieved.ID)
+
+	// Unblock the cleanup goroutine so it can call TerminateSession.
+	close(hookDone)
 
 	select {
 	case <-done:

--- a/features/terminal/manager_test.go
+++ b/features/terminal/manager_test.go
@@ -5,7 +5,6 @@ package terminal
 import (
 	"context"
 	"fmt"
-	"sync"
 	"testing"
 	"time"
 
@@ -269,10 +268,10 @@ func TestCleanupTimedOutSessions_AllSessionsCleaned(t *testing.T) {
 // per-session TerminateSession failure is logged as a warning and does not
 // abort the remaining sessions in the batch.
 //
-// Two concurrent CleanupTimedOutSessions calls both collect the same session IDs
-// (under lock, before any termination). When both loops then call TerminateSession
-// concurrently, the second caller encounters "session not found" for sessions the
-// first already removed — these must be warned and skipped, not panicked or aborted.
+// afterCollectHook pre-terminates every timed-out session before the
+// CleanupTimedOutSessions termination loop runs. The loop then gets
+// "session not found" for each ID, which must produce a warn log and
+// continue — not panic or abort.
 func TestCleanupTimedOutSessions_ContinuesAfterPerSessionError(t *testing.T) {
 	logger := testutil.NewMockLogger(true)
 	config := &Config{
@@ -306,37 +305,29 @@ func TestCleanupTimedOutSessions_ContinuesAfterPerSessionError(t *testing.T) {
 
 	defaultManager := manager.(*DefaultSessionManager)
 
-	// Both goroutines collect identical ID slices (both under lock, before any
-	// termination has started). Their termination loops then race; the second
-	// caller gets "session not found" for sessions the first already deleted.
-	var ready sync.WaitGroup
-	ready.Add(2)
-	var done sync.WaitGroup
-	done.Add(2)
-	go func() {
-		defer done.Done()
-		ready.Done()
-		ready.Wait()
-		defaultManager.CleanupTimedOutSessions()
-	}()
-	go func() {
-		defer done.Done()
-		ready.Done()
-		ready.Wait()
-		defaultManager.CleanupTimedOutSessions()
-	}()
-	done.Wait()
+	// Install a hook that terminates every collected session before the
+	// termination loop begins. This guarantees the loop sees "session not
+	// found" for all IDs in a deterministic, race-free way.
+	defaultManager.afterCollectHook = func(ids []string) {
+		hookCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		for _, id := range ids {
+			_ = defaultManager.TerminateSession(hookCtx, id)
+		}
+	}
 
-	// All sessions must be terminated regardless of which goroutine did the work.
+	defaultManager.CleanupTimedOutSessions()
+
+	// All sessions must be gone (pre-terminated by the hook).
 	for _, id := range sessionIDs {
 		_, err := manager.GetSession(id)
 		assert.Error(t, err, "session %s must be terminated", id)
 	}
 
-	// At least some warn logs must have been emitted for the "session not found"
-	// errors encountered by the goroutine that lost the race on each session.
+	// The termination loop must have logged a warning for each "session not
+	// found" error instead of aborting.
 	warnLogs := logger.GetLogs("warn")
-	assert.NotEmpty(t, warnLogs, "warn logs should have been emitted for sessions that could not be found by the second cleanup")
+	assert.NotEmpty(t, warnLogs, "warn logs should have been emitted for sessions that could not be found")
 }
 
 // TestCleanupTimedOutSessions_GetSessionDuringCleanup verifies that the lock is
@@ -377,7 +368,6 @@ func TestCleanupTimedOutSessions_GetSessionDuringCleanup(t *testing.T) {
 	}
 	activeSession, err := manager.CreateSession(ctx, activeReq)
 	require.NoError(t, err)
-	_ = timedOutSession
 
 	time.Sleep(10 * time.Millisecond)
 

--- a/features/terminal/manager_test.go
+++ b/features/terminal/manager_test.go
@@ -4,6 +4,8 @@ package terminal
 
 import (
 	"context"
+	"fmt"
+	"sync"
 	"testing"
 	"time"
 
@@ -11,6 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/cfgis/cfgms/features/terminal/shell"
+	"github.com/cfgis/cfgms/pkg/logging"
 	testutil "github.com/cfgis/cfgms/pkg/testing"
 )
 
@@ -220,6 +223,196 @@ func TestMaxSessionsLimit(t *testing.T) {
 	_, err = manager.CreateSession(ctx, sessionReq)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "maximum number of sessions")
+}
+
+// TestCleanupTimedOutSessions_AllSessionsCleaned verifies that all 10 timed-out
+// sessions are torn down by CleanupTimedOutSessions.
+func TestCleanupTimedOutSessions_AllSessionsCleaned(t *testing.T) {
+	config := &Config{
+		SessionTimeout: 10 * time.Millisecond,
+		MaxSessions:    100,
+		RecordSessions: false,
+	}
+
+	manager, err := NewSessionManager(config, logging.NewNoopLogger())
+	require.NoError(t, err)
+
+	ctx := context.Background()
+
+	const sessionCount = 10
+	sessionIDs := make([]string, sessionCount)
+
+	for i := 0; i < sessionCount; i++ {
+		req := &SessionRequest{
+			StewardID: fmt.Sprintf("steward-%d", i),
+			UserID:    fmt.Sprintf("user-%d", i),
+			Shell:     shell.GetDefaultShell(),
+			Cols:      80,
+			Rows:      24,
+		}
+		sess, err := manager.CreateSession(ctx, req)
+		require.NoError(t, err)
+		sessionIDs[i] = sess.ID
+	}
+
+	time.Sleep(100 * time.Millisecond)
+
+	manager.(*DefaultSessionManager).CleanupTimedOutSessions()
+
+	for _, id := range sessionIDs {
+		_, err := manager.GetSession(id)
+		assert.Error(t, err, "timed-out session %s should be removed", id)
+	}
+}
+
+// TestCleanupTimedOutSessions_ContinuesAfterPerSessionError verifies that a
+// per-session TerminateSession failure is logged as a warning and does not
+// abort the remaining sessions in the batch.
+//
+// Two concurrent CleanupTimedOutSessions calls both collect the same session IDs
+// (under lock, before any termination). When both loops then call TerminateSession
+// concurrently, the second caller encounters "session not found" for sessions the
+// first already removed — these must be warned and skipped, not panicked or aborted.
+func TestCleanupTimedOutSessions_ContinuesAfterPerSessionError(t *testing.T) {
+	logger := testutil.NewMockLogger(true)
+	config := &Config{
+		SessionTimeout: 1 * time.Millisecond,
+		MaxSessions:    100,
+		RecordSessions: false,
+	}
+
+	manager, err := NewSessionManager(config, logger)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+
+	const sessionCount = 10
+	sessionIDs := make([]string, sessionCount)
+
+	for i := 0; i < sessionCount; i++ {
+		req := &SessionRequest{
+			StewardID: fmt.Sprintf("steward-%d", i),
+			UserID:    fmt.Sprintf("user-%d", i),
+			Shell:     shell.GetDefaultShell(),
+			Cols:      80,
+			Rows:      24,
+		}
+		sess, err := manager.CreateSession(ctx, req)
+		require.NoError(t, err)
+		sessionIDs[i] = sess.ID
+	}
+
+	time.Sleep(10 * time.Millisecond)
+
+	defaultManager := manager.(*DefaultSessionManager)
+
+	// Both goroutines collect identical ID slices (both under lock, before any
+	// termination has started). Their termination loops then race; the second
+	// caller gets "session not found" for sessions the first already deleted.
+	var ready sync.WaitGroup
+	ready.Add(2)
+	var done sync.WaitGroup
+	done.Add(2)
+	go func() {
+		defer done.Done()
+		ready.Done()
+		ready.Wait()
+		defaultManager.CleanupTimedOutSessions()
+	}()
+	go func() {
+		defer done.Done()
+		ready.Done()
+		ready.Wait()
+		defaultManager.CleanupTimedOutSessions()
+	}()
+	done.Wait()
+
+	// All sessions must be terminated regardless of which goroutine did the work.
+	for _, id := range sessionIDs {
+		_, err := manager.GetSession(id)
+		assert.Error(t, err, "session %s must be terminated", id)
+	}
+
+	// At least some warn logs must have been emitted for the "session not found"
+	// errors encountered by the goroutine that lost the race on each session.
+	warnLogs := logger.GetLogs("warn")
+	assert.NotEmpty(t, warnLogs, "warn logs should have been emitted for sessions that could not be found by the second cleanup")
+}
+
+// TestCleanupTimedOutSessions_GetSessionDuringCleanup verifies that the lock is
+// released before TerminateSession is called, allowing concurrent read operations.
+//
+// Because TerminateSession itself acquires m.mu.Lock(), if CleanupTimedOutSessions
+// held the lock during TerminateSession it would deadlock. Non-completion within 5 s
+// is treated as a deadlock.
+func TestCleanupTimedOutSessions_GetSessionDuringCleanup(t *testing.T) {
+	logger := testutil.NewMockLogger(true)
+	config := &Config{
+		SessionTimeout: 1 * time.Millisecond,
+		MaxSessions:    100,
+		RecordSessions: false,
+	}
+
+	manager, err := NewSessionManager(config, logger)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+
+	timedOutReq := &SessionRequest{
+		StewardID: "steward-timed-out",
+		UserID:    "user-timed-out",
+		Shell:     shell.GetDefaultShell(),
+		Cols:      80,
+		Rows:      24,
+	}
+	timedOutSession, err := manager.CreateSession(ctx, timedOutReq)
+	require.NoError(t, err)
+
+	activeReq := &SessionRequest{
+		StewardID: "steward-active",
+		UserID:    "user-active",
+		Shell:     shell.GetDefaultShell(),
+		Cols:      80,
+		Rows:      24,
+	}
+	activeSession, err := manager.CreateSession(ctx, activeReq)
+	require.NoError(t, err)
+	_ = timedOutSession
+
+	time.Sleep(10 * time.Millisecond)
+
+	// Bump the active session's LastActivity so it is NOT timed out.
+	activeSession.UpdateActivity()
+
+	defaultManager := manager.(*DefaultSessionManager)
+
+	done := make(chan struct{})
+	go func() {
+		defaultManager.CleanupTimedOutSessions()
+		close(done)
+	}()
+
+	// GetSession (RLock) must succeed; if the write lock were held for the full
+	// cleanup it would block until cleanup finishes (or deadlock if TerminateSession
+	// is called while the lock is held).
+	retrieved, err := manager.GetSession(activeSession.ID)
+	assert.NoError(t, err, "GetSession must not block while CleanupTimedOutSessions is in its termination loop")
+	assert.Equal(t, activeSession.ID, retrieved.ID)
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("CleanupTimedOutSessions deadlocked — m.mu was not released before calling TerminateSession")
+	}
+
+	_, err = manager.GetSession(timedOutSession.ID)
+	assert.Error(t, err, "timed-out session should have been removed")
+
+	_, err = manager.GetSession(activeSession.ID)
+	assert.NoError(t, err, "active session should still exist")
+
+	err = manager.TerminateSession(ctx, activeSession.ID)
+	require.NoError(t, err)
 }
 
 func TestSessionRecording(t *testing.T) {

--- a/pkg/controlplane/providers/grpc/reconnect_test.go
+++ b/pkg/controlplane/providers/grpc/reconnect_test.go
@@ -46,13 +46,17 @@ func restartServerAndRepoint(t *testing.T, client *Provider, tc *testCA, reg reg
 // forceStopServer forcefully kills a gRPC server without waiting for streams to finish.
 // GracefulStop() hangs on long-lived ControlChannel streams; this is needed for
 // reconnection tests that simulate server crashes.
-// Listener is closed first to release the UDP socket, then gRPC is force-stopped.
+//
+// gRPC is stopped before the listener so that Stop() can send stream RST frames to
+// clients over the still-open QUIC connections. Closing the listener first tears down
+// the underlying UDP socket, preventing gRPC from notifying clients and causing them
+// to wait for the QUIC idle timeout (~90 s) instead of detecting the failure immediately.
 func forceStopServer(s *Provider) {
-	if s.listener != nil {
-		_ = s.listener.Close()
-	}
 	if s.grpcServer != nil {
 		s.grpcServer.Stop()
+	}
+	if s.listener != nil {
+		_ = s.listener.Close()
 	}
 }
 


### PR DESCRIPTION
Agent session failed with exit code 1. Review container logs for details.