### PR TITLE
po: run /po cron inline; skip Planning Team in cron mode

### DIFF
--- a/.claude/commands/po.md
+++ b/.claude/commands/po.md
@@ -9,11 +9,29 @@ parameters:
 
 # Product Owner Command
 
-Launch the PO agent, which stays in role for the rest of the session. The PO manages the autonomous pipeline: dashboard, intent capture, targeted unblocks, and orchestration.
+The PO manages the autonomous pipeline: dashboard, intent capture, targeted unblocks, and orchestration.
 
 ## Execution
 
-Spawn the PO agent using the Agent tool:
+Two execution paths depending on `$ARGUMENTS`:
+
+### Path A — `cron` (run inline in the main session)
+
+If `$ARGUMENTS` starts with `cron` (with or without further sub-arguments), do **NOT** spawn the PO as a subagent. Instead, execute the pipeline cycle inline in the main session.
+
+**Why:** A subagent cannot reliably spawn nested subagents (Acceptance Reviewer, BA, Tech Lead, Planning Team), and its bash commands trigger approval prompts despite `mode: auto`. Running inline gives the cycle full Agent-tool access and the parent session's allow list. This is documented in memory `feedback_po_run_inline.md`.
+
+**How:**
+1. Read `.claude/agents/po.md` to load the PO's behavioral rules and the Pipeline Cycle (§4) steps.
+2. Execute Pipeline Cycle (§4) directly in the main session — preflight, unblock check, agent cleanup, Tech Lead pass, dispatch, fix cycle, Acceptance Reviewer (§4.1 Step 5), forward edge, session log.
+3. Honor the 4-container cap from `feedback_max_running_agents.md` — the cap is on docker containers (`./.claude/scripts/agent-dispatch.sh list-running` count) only. Acceptance Reviewer subagents are in-process and do NOT count.
+4. Spawn the Acceptance Reviewer subagent for each review-ready PR (use the Agent tool with `subagent_type: acceptance-reviewer`, `mode: auto`). Process PRs serially in FIFO order per `.claude/agents/po.md` §4.1 Step 5.
+5. **Skip Step 6 (Planning Team) entirely in cron mode.** Planning Team is interactive-only — epic decomposition only runs when the founder invokes `/po` interactively. If undecomposed epics are blocking forward progress, mention it in the cycle summary so the founder can run an interactive session.
+6. Report the cycle summary back to the founder using the same format the PO subagent uses.
+
+### Path B — anything else (spawn the PO subagent)
+
+For `status` (default), `intent <topic>`, `next`, or natural-language input, spawn the PO agent so it stays in role for the rest of the session:
 
 ```
 Agent tool:
@@ -25,6 +43,6 @@ Agent tool:
 The PO agent definition is at `.claude/agents/po.md`. It will:
 1. Display the pipeline dashboard on startup
 2. Stay in role for ongoing conversation with the founder
-3. Handle intent capture, unblocks, next action, and pipeline cycles
+3. Handle intent capture, unblocks, next action, and story status queries
 
 If `$ARGUMENTS` contains a subcommand (e.g., `intent certificate rotation`), pass it to the agent so it routes to the correct action immediately.


### PR DESCRIPTION
## Summary
- `/po cron` now executes the pipeline cycle inline in the main session instead of spawning the PO as a subagent. Subagent execution silently degrades — nested `Agent` calls fail (Acceptance Reviewer / Planning Team don't run) and bash hits approval prompts despite `mode: auto`.
- Cron mode now skips Step 6 (Planning Team) entirely. Epic decomposition is interactive-only because spawning the planning team alongside docker dev agents burns through the 5-hour token budget and causes mid-flight pauses.
- Interactive paths (`/po status`, `/po intent`, `/po next`) keep spawning the persistent PO subagent.

## Validation
Verified on the 2026-04-29T03:35Z cycle: 5 review-ready PRs all processed serially in FIFO order — 3 enqueued for merge (#908, #917, #918), 2 escalated to `pipeline:blocked` for founder decisions (#914, #916). No nested-subagent or harness limit failures.

## Test plan
- [x] `/po cron` runs the cycle inline and spawns the Acceptance Reviewer for each review-ready PR
- [x] `po-act.sh dispatch <STORY>` runs without approval prompts (parent allow list applies)
- [x] `/po status` (and other non-cron args) still spawns the persistent PO subagent

🤖 Generated with [Claude Code](https://claude.com/claude-code)