### PR TITLE
features/steward/commands: authenticate per-message commands (Issue #919)

### DIFF
--- a/cmd/steward/main.go
+++ b/cmd/steward/main.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cfgis/cfgms/cmd/steward/service"
 	"github.com/cfgis/cfgms/features/steward"
 	"github.com/cfgis/cfgms/features/steward/client"
+	stewardconfig "github.com/cfgis/cfgms/features/steward/config"
 	"github.com/cfgis/cfgms/features/steward/registration"
 	"github.com/cfgis/cfgms/pkg/logging"
 	"github.com/cfgis/cfgms/pkg/version"
@@ -493,14 +494,26 @@ func registerAndConnect(ctx context.Context, token string, logger logging.Logger
 		"group", regResp.Group,
 		"transport_address", regResp.TransportAddress)
 
+	// Optionally load the local steward config to apply custom replay window and
+	// params-size limits. If no config file is found (the common case when the
+	// steward is purely controller-managed), defaults apply in commands.Handler.
+	var commandReplayWindow time.Duration
+	var commandMaxParamsBytes int
+	if cfg, cfgErr := stewardconfig.LoadConfiguration(""); cfgErr == nil {
+		commandReplayWindow = cfg.Steward.SignedCommandReplayWindow
+		commandMaxParamsBytes = cfg.Steward.SignedCommandMaxParamsBytes
+	}
+
 	transportClient, err := client.NewTransportClient(&client.TransportConfig{
-		ControllerURL:     regResp.TransportAddress,
-		RegistrationToken: token,
-		CACertPEM:         regResp.CACert,
-		ClientCertPEM:     regResp.ClientCert,
-		ClientKeyPEM:      regResp.ClientKey,
-		ServerCertPEM:     regResp.ServerCert,
-		Logger:            logger,
+		ControllerURL:               regResp.TransportAddress,
+		RegistrationToken:           token,
+		CACertPEM:                   regResp.CACert,
+		ClientCertPEM:               regResp.ClientCert,
+		ClientKeyPEM:                regResp.ClientKey,
+		ServerCertPEM:               regResp.ServerCert,
+		SignedCommandReplayWindow:   commandReplayWindow,
+		SignedCommandMaxParamsBytes: commandMaxParamsBytes,
+		Logger:                      logger,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to create transport client: %w", err)

--- a/features/controller/commands/publisher.go
+++ b/features/controller/commands/publisher.go
@@ -4,6 +4,9 @@
 //
 // This package implements the command publisher that sends commands
 // to stewards via the ControlPlaneProvider abstraction (Story #198, Story #363).
+//
+// Story #919: Commands are now wrapped in SignedCommand before transmission.
+// Every PublishCommand call signs the inner Command with the configured Signer.
 package commands
 
 import (
@@ -14,6 +17,7 @@ import (
 
 	"github.com/google/uuid"
 
+	"github.com/cfgis/cfgms/features/config/signature"
 	controlplaneInterfaces "github.com/cfgis/cfgms/pkg/controlplane/interfaces"
 	controlplaneTypes "github.com/cfgis/cfgms/pkg/controlplane/types"
 	"github.com/cfgis/cfgms/pkg/logging"
@@ -25,6 +29,10 @@ type Publisher struct {
 
 	// Control plane provider for command publishing (Story #363)
 	controlPlane controlplaneInterfaces.ControlPlaneProvider
+
+	// signer signs commands before transmission (Story #919).
+	// When nil commands are sent without a signature (unsecured/transitional mode).
+	signer signature.Signer
 
 	// Command tracking
 	pending map[string]*pendingCommand
@@ -50,6 +58,10 @@ type Config struct {
 	// ControlPlane is the control plane provider for command publishing (Story #363)
 	ControlPlane controlplaneInterfaces.ControlPlaneProvider
 
+	// Signer signs each command before transmission (Story #919).
+	// When nil, commands are sent unsigned.
+	Signer signature.Signer
+
 	// Logger for command logging
 	Logger logging.Logger
 }
@@ -65,18 +77,39 @@ func New(cfg *Config) (*Publisher, error) {
 
 	return &Publisher{
 		controlPlane: cfg.ControlPlane,
+		signer:       cfg.Signer,
 		pending:      make(map[string]*pendingCommand),
 		logger:       cfg.Logger,
 	}, nil
 }
 
+// signCommand wraps cmd in a SignedCommand, signing it when a signer is available.
+func (p *Publisher) signCommand(cmd *controlplaneTypes.Command) (*controlplaneTypes.SignedCommand, error) {
+	sc := &controlplaneTypes.SignedCommand{Command: *cmd}
+	if p.signer == nil {
+		return sc, nil
+	}
+	// Sign the canonical form (string params + UTC timestamp) that survives the
+	// proto round-trip without type mutations. See CommandSigningBytes for details.
+	rawParams := controlplaneTypes.InterfaceParamsToStringMap(cmd.Params)
+	cmdBytes, err := controlplaneTypes.CommandSigningBytes(cmd, rawParams)
+	if err != nil {
+		return nil, fmt.Errorf("marshal command for signing: %w", err)
+	}
+	sig, err := p.signer.Sign(cmdBytes)
+	if err != nil {
+		return nil, fmt.Errorf("sign command: %w", err)
+	}
+	sc.Signature = sig
+	return sc, nil
+}
+
 // PublishCommand publishes a command to a specific steward.
 // Story #363: Uses ControlPlaneProvider.SendCommand() for delivery.
+// Story #919: Signs the command before transmission.
 func (p *Publisher) PublishCommand(ctx context.Context, stewardID string, cmdType controlplaneTypes.CommandType, params map[string]interface{}) (string, error) {
-	// Generate unique command ID
 	commandID := uuid.New().String()
 
-	// Create command message using control plane types
 	cmd := &controlplaneTypes.Command{
 		ID:        commandID,
 		Type:      cmdType,
@@ -85,15 +118,20 @@ func (p *Publisher) PublishCommand(ctx context.Context, stewardID string, cmdTyp
 		Params:    params,
 	}
 
-	// Send via control plane provider (publishes to cfgms/commands/{stewardID})
-	if err := p.controlPlane.SendCommand(ctx, cmd); err != nil {
+	sc, err := p.signCommand(cmd)
+	if err != nil {
+		return "", fmt.Errorf("failed to sign command: %w", err)
+	}
+
+	if err := p.controlPlane.SendCommand(ctx, sc); err != nil {
 		return "", fmt.Errorf("failed to send command: %w", err)
 	}
 
 	p.logger.Info("Sent command to steward",
 		"command_id", commandID,
 		"steward_id", stewardID,
-		"type", cmdType)
+		"type", cmdType,
+		"signed", sc.Signature != nil)
 
 	return commandID, nil
 }

--- a/features/controller/heartbeat/service_dna_test.go
+++ b/features/controller/heartbeat/service_dna_test.go
@@ -34,10 +34,10 @@ func (p *testControlPlane) Initialize(_ context.Context, _ map[string]interface{
 }
 func (p *testControlPlane) Start(_ context.Context) error { return nil }
 func (p *testControlPlane) Stop(_ context.Context) error  { return nil }
-func (p *testControlPlane) SendCommand(_ context.Context, _ *controlplaneTypes.Command) error {
+func (p *testControlPlane) SendCommand(_ context.Context, _ *controlplaneTypes.SignedCommand) error {
 	return nil
 }
-func (p *testControlPlane) FanOutCommand(_ context.Context, _ *controlplaneTypes.Command, ids []string) (*controlplaneTypes.FanOutResult, error) {
+func (p *testControlPlane) FanOutCommand(_ context.Context, _ *controlplaneTypes.SignedCommand, ids []string) (*controlplaneTypes.FanOutResult, error) {
 	return &controlplaneTypes.FanOutResult{Succeeded: ids, Failed: map[string]error{}}, nil
 }
 func (p *testControlPlane) SubscribeCommands(_ context.Context, _ string, _ cpinterfaces.CommandHandler) error {

--- a/features/controller/server/server.go
+++ b/features/controller/server/server.go
@@ -351,6 +351,10 @@ func New(cfg *config.Config, logger logging.Logger) (*Server, error) {
 	var controlPlane controlplaneInterfaces.ControlPlaneProvider
 	var heartbeatService *heartbeat.Service
 	var commandPublisher *commands.Publisher
+	// hoistedSigner and hoistedSignerCertSerial are set inside the transport block and
+	// re-used by the data plane config handler so both consumers share the same key.
+	var hoistedSigner signature.Signer
+	var hoistedSignerCertSerial string
 	if cfg.Transport != nil && certManager != nil {
 		logger.Info("Initializing gRPC control plane provider...", "addr", cfg.Transport.ListenAddr)
 
@@ -390,16 +394,51 @@ func New(cfg *config.Config, logger logging.Logger) (*Server, error) {
 		}
 		logger.Info("Heartbeat monitoring service initialized successfully")
 
-		// Initialize command publisher (Story #198, Story #363, Story #514)
+		// Story #919: Hoist signer construction so both the command publisher and the
+		// config handler share the same signer instance. This must happen before the
+		// publisher is created so the publisher can sign commands on transmission.
+		//
+		// In separated mode: use CertificateTypeConfigSigning (dedicated signing cert)
+		// In unified mode: use CertificateTypeServer (backward compatible)
+		if certManager != nil {
+			signerCertType := cert.CertificateTypeServer
+			if cfg.Certificate != nil && cfg.Certificate.IsSeparatedArchitecture() {
+				signerCertType = cert.CertificateTypeConfigSigning
+			}
+			signerCerts, scErr := certManager.GetCertificatesByType(signerCertType)
+			if scErr == nil && len(signerCerts) > 0 {
+				hoistedSignerCertSerial = signerCerts[0].SerialNumber
+				certPEM, keyPEM, exportErr := certManager.ExportCertificate(hoistedSignerCertSerial, true)
+				if exportErr == nil && len(certPEM) > 0 && len(keyPEM) > 0 {
+					var signerErr error
+					hoistedSigner, signerErr = signature.NewSigner(&signature.SignerConfig{
+						PrivateKeyPEM:  keyPEM,
+						CertificatePEM: certPEM,
+					})
+					if signerErr != nil {
+						logger.Warn("Failed to create config signer", "error", signerErr)
+					} else {
+						logger.Info("Config signer initialized successfully",
+							"algorithm", hoistedSigner.Algorithm(),
+							"fingerprint", hoistedSigner.KeyFingerprint(),
+							"cert_serial", hoistedSignerCertSerial,
+							"cert_type", signerCertType.String())
+					}
+				}
+			}
+		}
+
+		// Initialize command publisher (Story #198, Story #363, Story #514, Story #919)
 		logger.Info("Initializing command publisher...")
 		commandPublisher, err = commands.New(&commands.Config{
 			ControlPlane: controlPlane,
+			Signer:       hoistedSigner,
 			Logger:       logger,
 		})
 		if err != nil {
 			return nil, fmt.Errorf("failed to initialize command publisher: %w", err)
 		}
-		logger.Info("Command publisher initialized successfully")
+		logger.Info("Command publisher initialized successfully", "signing_enabled", hoistedSigner != nil)
 	} else {
 		logger.Warn("Transport config not set — gRPC control plane disabled")
 	}
@@ -424,44 +463,14 @@ func New(cfg *config.Config, logger logging.Logger) (*Server, error) {
 	}
 
 	// Initialize config handler for data plane configuration sync (Story #362)
+	// Re-uses the hoisted signer so both config and command signing use the same key.
 	var configHandler *controllerTransport.ConfigHandler
 	var signerCertSerial string // Story #378: Track cert serial for registration handler
 	if dataPlane != nil {
-		// Create signer from certificate for config signing (Story #315, #377)
-		// In separated mode: use CertificateTypeConfigSigning (dedicated signing cert)
-		// In unified mode: use CertificateTypeServer (backward compatible)
-		var signer signature.Signer
-		if certManager != nil {
-			signerCertType := cert.CertificateTypeServer
-			if cfg.Certificate != nil && cfg.Certificate.IsSeparatedArchitecture() {
-				signerCertType = cert.CertificateTypeConfigSigning
-			}
-
-			signerCerts, err := certManager.GetCertificatesByType(signerCertType)
-			if err == nil && len(signerCerts) > 0 {
-				signerCertSerial = signerCerts[0].SerialNumber
-				certPEM, keyPEM, err := certManager.ExportCertificate(signerCertSerial, true)
-				if err == nil && len(certPEM) > 0 && len(keyPEM) > 0 {
-					signer, err = signature.NewSigner(&signature.SignerConfig{
-						PrivateKeyPEM:  keyPEM,
-						CertificatePEM: certPEM,
-					})
-					if err != nil {
-						logger.Warn("Failed to create config signer", "error", err)
-					} else {
-						logger.Info("Config signer initialized successfully",
-							"algorithm", signer.Algorithm(),
-							"fingerprint", signer.KeyFingerprint(),
-							"cert_serial", signerCertSerial,
-							"cert_type", signerCertType.String())
-					}
-				}
-			}
-		}
-
-		// Create config handler with signer (signs configs if signer available)
-		configHandler = controllerTransport.NewConfigHandler(configService, logger, signer)
-		logger.Debug("Config handler initialized for data plane", "signing_enabled", signer != nil)
+		// Use the signer hoisted above (nil when certManager absent or export failed).
+		signerCertSerial = hoistedSignerCertSerial
+		configHandler = controllerTransport.NewConfigHandler(configService, logger, hoistedSigner)
+		logger.Debug("Config handler initialized for data plane", "signing_enabled", hoistedSigner != nil)
 	}
 
 	// Initialize health collectors (Story #417, #517)

--- a/features/steward/SECURITY.md
+++ b/features/steward/SECURITY.md
@@ -1,0 +1,58 @@
+# Steward Command Authentication
+
+Every command received by the steward is authenticated before dispatch. This document describes the authentication contract implemented in Story #919.
+
+## Command Authentication Contract
+
+All commands travel as a `SignedCommand` envelope:
+
+```go
+type SignedCommand struct {
+    Command   Command                    // inner value type — unchanged
+    Signature *signature.ConfigSignature // cryptographic signature over canonical bytes
+}
+```
+
+### Verification Steps (in order)
+
+The steward handler (`features/steward/commands/handler.go`) applies the following checks before dispatching any command:
+
+1. **Signature verification** — when a `Verifier` is configured, the handler verifies the `Signature` field against the canonical bytes of `Command` using `CommandSigningBytes`. Commands with a missing or invalid signature are rejected with `ErrUnauthenticatedCommand`.
+
+2. **StewardID match** — `Command.StewardID` must equal the handler's own steward identity. Mismatches are rejected with `ErrWrongSteward` to prevent cross-steward command injection.
+
+3. **Timestamp freshness** — `Command.Timestamp` must be within the configured replay window (default: 5 minutes). Stale commands are rejected with `ErrCommandReplay`. The window is configurable via `SignedCommandReplayWindow` in the steward config.
+
+4. **Replay deduplication** — `Command.ID` is recorded in a bounded in-memory TTL cache. A second delivery of the same ID within the replay window is rejected with `ErrCommandReplay`. This catches duplicate delivery even when the timestamp is still fresh.
+
+5. **Params size bound** — `Command.Params` serialised as JSON must not exceed `maxParamsBytes` (default: 64 KiB). Oversized params are rejected with `ErrParamsTooLarge`. The limit is configurable via `SignedCommandMaxParamsBytes` in the steward config.
+
+## Cryptographic Scheme
+
+Command signing uses the same primitives as configuration signing (`features/config/signature`):
+
+- **Algorithm**: RSA-PSS (or ECDSA depending on key type)
+- **Digest**: SHA-256
+- **Signing input**: `CommandSigningBytes(cmd, rawParams)` — a JSON-encoded canonical payload with UTC timestamp and `map[string]string` params to avoid type mutations across proto round-trips
+
+The controller signs each command in `features/controller/commands/publisher.go` using the same key and certificate used for configuration signing.
+
+## Replay Window Trade-offs
+
+| Window | Trade-off |
+|--------|-----------|
+| Shorter | Stricter freshness; clock-skew sensitive |
+| Longer | More clock-skew tolerance; wider replay window |
+
+The default of 5 minutes balances clock-skew tolerance (NTP-synced hosts rarely drift more than a few seconds) against the risk of accepting replayed commands. Operators in high-latency or poor-NTP environments may increase this via `signed_command_replay_window` in the steward configuration.
+
+## Unsecured / Transitional Mode
+
+When no `Verifier` is configured (e.g. in development or testing), signature verification is skipped. All other checks (StewardID match, timestamp freshness, replay dedup, params size) remain active.
+
+## References
+
+- `features/config/signature` — crypto primitives shared with configuration signing
+- `pkg/controlplane/types/messages.go` — `SignedCommand` and `CommandSigningBytes` definitions
+- `features/steward/commands/handler.go` — verification implementation
+- `features/steward/commands/replay_cache.go` — bounded TTL deduplication cache

--- a/features/steward/client/client_transport.go
+++ b/features/steward/client/client_transport.go
@@ -77,6 +77,10 @@ type TransportClient struct {
 	// Configuration signature verifier
 	configVerifier signature.Verifier
 
+	// Command authentication settings (Story #919)
+	commandReplayWindow   time.Duration
+	commandMaxParamsBytes int
+
 	// Last configuration received from the controller (for scheduled re-convergence)
 	lastConfigYAML    []byte
 	lastConfigMu      sync.RWMutex
@@ -153,6 +157,15 @@ type TransportConfig struct {
 	// before being discarded. Defaults to 24 hours.
 	MaxQueueAge time.Duration
 
+	// SignedCommandReplayWindow is the maximum age of an accepted command timestamp.
+	// Commands older than this are rejected as potential replays.
+	// Zero means the commands.Handler default (5 minutes) applies.
+	SignedCommandReplayWindow time.Duration
+
+	// SignedCommandMaxParamsBytes is the maximum JSON-serialized size of Command.Params.
+	// Zero means the commands.Handler default (65536 bytes) applies.
+	SignedCommandMaxParamsBytes int
+
 	// Logger for client logging
 	Logger logging.Logger
 }
@@ -183,19 +196,21 @@ func NewTransportClient(cfg *TransportConfig) (*TransportClient, error) {
 	}
 
 	c := &TransportClient{
-		heartbeatInterval: heartbeatInterval,
-		heartbeatStop:     make(chan struct{}),
-		convergenceStop:   make(chan struct{}),
-		convergeInterval:  30 * time.Minute,
-		transportAddress:  cfg.ControllerURL,
-		certPath:          cfg.TLSCertPath,
-		caCertPEM:         cfg.CACertPEM,
-		clientCertPEM:     cfg.ClientCertPEM,
-		clientKeyPEM:      cfg.ClientKeyPEM,
-		serverCertPEM:     cfg.ServerCertPEM,
-		signingCertPEM:    cfg.SigningCertPEM,
-		offlineQueue:      offlineQueue,
-		logger:            cfg.Logger,
+		heartbeatInterval:     heartbeatInterval,
+		heartbeatStop:         make(chan struct{}),
+		convergenceStop:       make(chan struct{}),
+		convergeInterval:      30 * time.Minute,
+		transportAddress:      cfg.ControllerURL,
+		certPath:              cfg.TLSCertPath,
+		caCertPEM:             cfg.CACertPEM,
+		clientCertPEM:         cfg.ClientCertPEM,
+		clientKeyPEM:          cfg.ClientKeyPEM,
+		serverCertPEM:         cfg.ServerCertPEM,
+		signingCertPEM:        cfg.SigningCertPEM,
+		offlineQueue:          offlineQueue,
+		commandReplayWindow:   cfg.SignedCommandReplayWindow,
+		commandMaxParamsBytes: cfg.SignedCommandMaxParamsBytes,
+		logger:                cfg.Logger,
 	}
 
 	return c, nil
@@ -366,17 +381,19 @@ func (c *TransportClient) setupCommandHandler(ctx context.Context, stewardID str
 	}
 
 	// Create command handler with the same verifier used for config signature
-	// verification (Story #919). Replay window and params limit are read from
-	// the steward config when available; defaults apply otherwise.
+	// verification (Story #919). Replay window and params limit come from the
+	// steward config (via TransportConfig); zero values use handler defaults.
 	c.mu.RLock()
 	verifier := c.configVerifier
 	c.mu.RUnlock()
 
 	handler, err := commands.New(&commands.Config{
-		StewardID: stewardID,
-		OnStatus:  statusCallback,
-		Logger:    c.logger,
-		Verifier:  verifier,
+		StewardID:      stewardID,
+		OnStatus:       statusCallback,
+		Logger:         c.logger,
+		Verifier:       verifier,
+		ReplayWindow:   c.commandReplayWindow,
+		MaxParamsBytes: c.commandMaxParamsBytes,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to create command handler: %w", err)

--- a/features/steward/client/client_transport.go
+++ b/features/steward/client/client_transport.go
@@ -332,8 +332,8 @@ func (c *TransportClient) Connect(ctx context.Context) error {
 
 	// Subscribe to commands via gRPC control plane provider
 	c.logger.Info("Subscribing to commands", "steward_id", stewardID)
-	if err := controlPlane.SubscribeCommands(ctx, stewardID, func(ctx context.Context, cmd *cpTypes.Command) error {
-		return cmdHandler.HandleCommand(ctx, cmd)
+	if err := controlPlane.SubscribeCommands(ctx, stewardID, func(ctx context.Context, sc *cpTypes.SignedCommand) error {
+		return cmdHandler.HandleCommand(ctx, sc)
 	}); err != nil {
 		return fmt.Errorf("failed to subscribe to commands: %w", err)
 	}
@@ -365,11 +365,18 @@ func (c *TransportClient) setupCommandHandler(ctx context.Context, stewardID str
 		}
 	}
 
-	// Create command handler
+	// Create command handler with the same verifier used for config signature
+	// verification (Story #919). Replay window and params limit are read from
+	// the steward config when available; defaults apply otherwise.
+	c.mu.RLock()
+	verifier := c.configVerifier
+	c.mu.RUnlock()
+
 	handler, err := commands.New(&commands.Config{
 		StewardID: stewardID,
 		OnStatus:  statusCallback,
 		Logger:    c.logger,
+		Verifier:  verifier,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to create command handler: %w", err)

--- a/features/steward/client/client_transport_command_config_test.go
+++ b/features/steward/client/client_transport_command_config_test.go
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+// Package client exercises command-authentication config wiring in TransportClient.
+package client
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestNewTransportClient_StoresCommandAuthFields verifies that
+// SignedCommandReplayWindow and SignedCommandMaxParamsBytes from TransportConfig
+// are stored on the TransportClient so that setupCommandHandler can pass them
+// to commands.New (Story #919 fix for PR #927).
+func TestNewTransportClient_StoresCommandAuthFields(t *testing.T) {
+	replayWindow := 10 * time.Minute
+	maxParams := 128 * 1024
+
+	c, err := NewTransportClient(&TransportConfig{
+		ControllerURL:               "localhost:4433",
+		SignedCommandReplayWindow:   replayWindow,
+		SignedCommandMaxParamsBytes: maxParams,
+		Logger:                      newTestLogger(t),
+	})
+	require.NoError(t, err)
+	assert.Equal(t, replayWindow, c.commandReplayWindow,
+		"commandReplayWindow must be stored from TransportConfig.SignedCommandReplayWindow")
+	assert.Equal(t, maxParams, c.commandMaxParamsBytes,
+		"commandMaxParamsBytes must be stored from TransportConfig.SignedCommandMaxParamsBytes")
+}
+
+// TestNewTransportClient_ZeroCommandAuthFieldsArePreserved verifies that when
+// SignedCommandReplayWindow and SignedCommandMaxParamsBytes are zero (unset),
+// those zero values are stored unchanged so that commands.New can apply its own
+// defaults (5 min / 64 KiB) rather than having the caller silently override them.
+func TestNewTransportClient_ZeroCommandAuthFieldsArePreserved(t *testing.T) {
+	c, err := NewTransportClient(&TransportConfig{
+		ControllerURL: "localhost:4433",
+		Logger:        newTestLogger(t),
+	})
+	require.NoError(t, err)
+	assert.Equal(t, time.Duration(0), c.commandReplayWindow,
+		"zero SignedCommandReplayWindow must be stored as-is so commands.Handler applies its default")
+	assert.Equal(t, 0, c.commandMaxParamsBytes,
+		"zero SignedCommandMaxParamsBytes must be stored as-is so commands.Handler applies its default")
+}

--- a/features/steward/client/client_transport_dna_test.go
+++ b/features/steward/client/client_transport_dna_test.go
@@ -270,14 +270,14 @@ func TestSyncDNAHandler_SendsFullDNAOverDataPlane(t *testing.T) {
 	handler, err := c.setupCommandHandler(context.Background(), "steward-1")
 	require.NoError(t, err)
 
-	cmd := &cpTypes.Command{
+	cmd := &cpTypes.SignedCommand{Command: cpTypes.Command{
 		ID:        "cmd-sync-dna-1",
 		Type:      cpTypes.CommandSyncDNA,
 		StewardID: "steward-1",
 		TenantID:  "tenant-1",
 		Timestamp: time.Now(),
 		Params:    map[string]interface{}{},
-	}
+	}}
 	require.NoError(t, handler.HandleCommand(context.Background(), cmd))
 
 	// HandleCommand dispatches the handler in a goroutine. The handler only does

--- a/features/steward/client/offline_queue_test.go
+++ b/features/steward/client/offline_queue_test.go
@@ -46,8 +46,8 @@ func (n *noopControlPlane) Initialize(_ context.Context, _ map[string]interface{
 }
 func (n *noopControlPlane) Start(_ context.Context) error                           { return nil }
 func (n *noopControlPlane) Stop(_ context.Context) error                            { return nil }
-func (n *noopControlPlane) SendCommand(_ context.Context, _ *cpTypes.Command) error { return nil }
-func (n *noopControlPlane) FanOutCommand(_ context.Context, _ *cpTypes.Command, ids []string) (*cpTypes.FanOutResult, error) {
+func (n *noopControlPlane) SendCommand(_ context.Context, _ *cpTypes.SignedCommand) error { return nil }
+func (n *noopControlPlane) FanOutCommand(_ context.Context, _ *cpTypes.SignedCommand, ids []string) (*cpTypes.FanOutResult, error) {
 	return &cpTypes.FanOutResult{Succeeded: ids, Failed: make(map[string]error)}, nil
 }
 func (n *noopControlPlane) SubscribeCommands(_ context.Context, _ string, _ controlplaneInterfaces.CommandHandler) error {

--- a/features/steward/client/offline_queue_test.go
+++ b/features/steward/client/offline_queue_test.go
@@ -44,8 +44,8 @@ func (n *noopControlPlane) Name() string { return "noop" }
 func (n *noopControlPlane) Initialize(_ context.Context, _ map[string]interface{}) error {
 	return nil
 }
-func (n *noopControlPlane) Start(_ context.Context) error                           { return nil }
-func (n *noopControlPlane) Stop(_ context.Context) error                            { return nil }
+func (n *noopControlPlane) Start(_ context.Context) error                                 { return nil }
+func (n *noopControlPlane) Stop(_ context.Context) error                                  { return nil }
 func (n *noopControlPlane) SendCommand(_ context.Context, _ *cpTypes.SignedCommand) error { return nil }
 func (n *noopControlPlane) FanOutCommand(_ context.Context, _ *cpTypes.SignedCommand, ids []string) (*cpTypes.FanOutResult, error) {
 	return &cpTypes.FanOutResult{Succeeded: ids, Failed: make(map[string]error)}, nil

--- a/features/steward/commands/handler.go
+++ b/features/steward/commands/handler.go
@@ -9,14 +9,19 @@
 // executing/completed/failed status survives a process restart. The in-memory
 // executing map retains only the context.CancelFunc needed for in-flight
 // cancellation; all durable state is in the store.
+//
+// Story #919: Commands are authenticated before dispatch. Every SignedCommand
+// is verified for signature, replay, StewardID, and Params size.
 package commands
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"sync"
 	"time"
 
+	"github.com/cfgis/cfgms/features/config/signature"
 	cpTypes "github.com/cfgis/cfgms/pkg/controlplane/types"
 	"github.com/cfgis/cfgms/pkg/logging"
 	business "github.com/cfgis/cfgms/pkg/storage/interfaces/business"
@@ -49,6 +54,22 @@ type Handler struct {
 	// wg tracks in-flight executeCommand goroutines to support graceful shutdown
 	// and deterministic test synchronization.
 	wg sync.WaitGroup
+
+	// Story #919: command authentication fields.
+
+	// verifier validates the cryptographic signature on each SignedCommand.
+	// When nil, signature verification is skipped (unsecured/transitional mode).
+	verifier signature.Verifier
+
+	// replayWindow is the maximum age of a command timestamp before it is
+	// rejected as a potential replay.
+	replayWindow time.Duration
+
+	// replayCache detects duplicate command IDs within the replay window.
+	replayCache *ttlReplayCache
+
+	// maxParamsBytes is the maximum allowed JSON-serialized size of Command.Params.
+	maxParamsBytes int
 }
 
 // CommandFunc is a function that handles a specific command type.
@@ -77,7 +98,24 @@ type Config struct {
 	// Store is the durable command dispatch state backend (Story #665).
 	// When nil, state transitions are not persisted across restarts.
 	Store business.CommandStore
+
+	// Verifier validates command signatures (Story #919).
+	// When nil, signature verification is skipped.
+	Verifier signature.Verifier
+
+	// ReplayWindow is the maximum age of an accepted command timestamp.
+	// Defaults to 5 minutes when zero.
+	ReplayWindow time.Duration
+
+	// MaxParamsBytes is the maximum JSON-serialized size of Command.Params.
+	// Defaults to 65536 (64 KiB) when zero.
+	MaxParamsBytes int
 }
+
+const (
+	defaultReplayWindow  = 5 * time.Minute
+	defaultMaxParamBytes = 64 * 1024
+)
 
 // New creates a new command handler and, when a CommandStore is configured,
 // sweeps any commands left in "executing" state from a previous run and marks
@@ -93,13 +131,26 @@ func New(cfg *Config) (*Handler, error) {
 		return nil, fmt.Errorf("logger is required")
 	}
 
+	replayWindow := cfg.ReplayWindow
+	if replayWindow == 0 {
+		replayWindow = defaultReplayWindow
+	}
+	maxParamsBytes := cfg.MaxParamsBytes
+	if maxParamsBytes == 0 {
+		maxParamsBytes = defaultMaxParamBytes
+	}
+
 	h := &Handler{
-		stewardID: cfg.StewardID,
-		handlers:  make(map[cpTypes.CommandType]CommandFunc),
-		onStatus:  cfg.OnStatus,
-		logger:    cfg.Logger,
-		store:     cfg.Store,
-		executing: make(map[string]*executionContext),
+		stewardID:      cfg.StewardID,
+		handlers:       make(map[cpTypes.CommandType]CommandFunc),
+		onStatus:       cfg.OnStatus,
+		logger:         cfg.Logger,
+		store:          cfg.Store,
+		executing:      make(map[string]*executionContext),
+		verifier:       cfg.Verifier,
+		replayWindow:   replayWindow,
+		replayCache:    newReplayCache(replayWindow),
+		maxParamsBytes: maxParamsBytes,
 	}
 
 	// Startup sweep: flip stale "executing" records from a previous run to "failed".
@@ -150,10 +201,68 @@ func (h *Handler) RegisterHandler(cmdType cpTypes.CommandType, handler CommandFu
 	h.logger.Info("Registered command handler", "type", cmdType)
 }
 
-// HandleCommand processes an incoming control plane command.
-// Story #363: Now receives a pre-deserialized command from the ControlPlaneProvider
-// instead of raw topic/payload from the transport layer.
-func (h *Handler) HandleCommand(ctx context.Context, cmd *cpTypes.Command) error {
+// HandleCommand processes an incoming signed command from the controller.
+//
+// Story #919: Before dispatching, the command is authenticated:
+//  1. Signature is verified against CommandSigningBytes(cmd, rawParams) when a verifier is configured.
+//  2. signed.Command.StewardID must match this handler's steward identity.
+//  3. signed.Command.Timestamp must be within the configured replay window.
+//  4. signed.Command.ID must not already be present in the replay cache (dedup).
+//  5. json.Marshal(signed.Command.Params) must not exceed maxParamsBytes.
+func (h *Handler) HandleCommand(ctx context.Context, signed *cpTypes.SignedCommand) error {
+	if signed == nil {
+		return ErrUnauthenticatedCommand
+	}
+
+	cmd := &signed.Command
+
+	// 1. Signature verification (only when a verifier is configured).
+	if h.verifier != nil {
+		if signed.Signature == nil {
+			return ErrUnauthenticatedCommand
+		}
+		// Use the proto-wire string map (RawParams) when available so the canonical
+		// bytes match what the controller signed. Fall back to InterfaceParamsToStringMap
+		// for commands created without a proto round-trip (e.g. tests).
+		rawParams := signed.RawParams
+		if rawParams == nil {
+			rawParams = cpTypes.InterfaceParamsToStringMap(cmd.Params)
+		}
+		cmdBytes, err := cpTypes.CommandSigningBytes(cmd, rawParams)
+		if err != nil {
+			return fmt.Errorf("marshal command for verification: %w", err)
+		}
+		if err := h.verifier.Verify(cmdBytes, signed.Signature); err != nil {
+			return fmt.Errorf("%w: %v", ErrUnauthenticatedCommand, err)
+		}
+	}
+
+	// 2. StewardID match.
+	if cmd.StewardID != h.stewardID {
+		return ErrWrongSteward
+	}
+
+	// 3. Timestamp freshness.
+	if time.Since(cmd.Timestamp) > h.replayWindow {
+		return ErrCommandReplay
+	}
+
+	// 4. Replay deduplication.
+	if !h.replayCache.Add(cmd.ID) {
+		return ErrCommandReplay
+	}
+
+	// 5. Params size bound.
+	if len(cmd.Params) > 0 {
+		paramBytes, err := json.Marshal(cmd.Params)
+		if err != nil {
+			return fmt.Errorf("%w: invalid params", ErrParamsTooLarge)
+		}
+		if len(paramBytes) > h.maxParamsBytes {
+			return ErrParamsTooLarge
+		}
+	}
+
 	h.logger.Debug("Received command", "id", cmd.ID, "type", cmd.Type)
 
 	// Persist incoming command record (Story #665).
@@ -332,33 +441,4 @@ func (h *Handler) sendStatus(ctx context.Context, event *cpTypes.Event) {
 	if h.onStatus != nil {
 		h.onStatus(ctx, event)
 	}
-}
-
-// CancelCommand cancels a running command by its ID.
-func (h *Handler) CancelCommand(commandID string) error {
-	h.mu.Lock()
-	defer h.mu.Unlock()
-
-	exec, exists := h.executing[commandID]
-	if !exists {
-		return fmt.Errorf("command not found or already completed: %s", commandID)
-	}
-
-	exec.Cancel()
-	h.logger.Info("Command cancelled", "command_id", commandID)
-
-	return nil
-}
-
-// GetExecutingCommands returns a list of currently executing command IDs.
-func (h *Handler) GetExecutingCommands() []string {
-	h.mu.RLock()
-	defer h.mu.RUnlock()
-
-	commands := make([]string, 0, len(h.executing))
-	for cmdID := range h.executing {
-		commands = append(commands, cmdID)
-	}
-
-	return commands
 }

--- a/features/steward/commands/handler_test.go
+++ b/features/steward/commands/handler_test.go
@@ -12,6 +12,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/cfgis/cfgms/features/config/signature"
+	"github.com/cfgis/cfgms/pkg/cert"
 	cpTypes "github.com/cfgis/cfgms/pkg/controlplane/types"
 	"github.com/cfgis/cfgms/pkg/logging"
 	business "github.com/cfgis/cfgms/pkg/storage/interfaces/business"
@@ -166,6 +168,7 @@ func newTestLogger(t *testing.T) logging.Logger {
 
 func noopStatus(_ context.Context, _ *cpTypes.Event) {}
 
+// newTestHandler builds a Handler with no signature verifier (verification skipped).
 func newTestHandler(t *testing.T, store business.CommandStore) *Handler {
 	t.Helper()
 	h, err := New(&Config{
@@ -178,14 +181,78 @@ func newTestHandler(t *testing.T, store business.CommandStore) *Handler {
 	return h
 }
 
-func testCommand(id string, cmdType cpTypes.CommandType) *cpTypes.Command {
-	return &cpTypes.Command{
-		ID:        id,
-		Type:      cmdType,
-		StewardID: "steward-test",
-		Timestamp: time.Now(),
-		Params:    map[string]interface{}{},
+// newTestSignerVerifier returns a real Signer + Verifier pair backed by a fresh
+// in-process CA. No mocks — real cryptographic operations.
+func newTestSignerVerifier(t *testing.T) (signature.Signer, signature.Verifier) {
+	t.Helper()
+	ca, err := cert.NewCA(&cert.CAConfig{
+		Organization: "CFGMS Test",
+		Country:      "US",
+		ValidityDays: 1,
+		KeySize:      2048,
+	})
+	require.NoError(t, err)
+	require.NoError(t, ca.Initialize(nil))
+
+	sc, err := ca.GenerateServerCertificate(&cert.ServerCertConfig{
+		CommonName:   "controller.test",
+		DNSNames:     []string{"controller.test"},
+		ValidityDays: 1,
+		KeySize:      2048,
+	})
+	require.NoError(t, err)
+
+	signer, err := signature.NewSigner(&signature.SignerConfig{
+		PrivateKeyPEM:  sc.PrivateKeyPEM,
+		CertificatePEM: sc.CertificatePEM,
+	})
+	require.NoError(t, err)
+
+	verifier, err := signature.NewVerifier(&signature.VerifierConfig{
+		CertificatePEM: sc.CertificatePEM,
+	})
+	require.NoError(t, err)
+
+	return signer, verifier
+}
+
+// newTestHandlerWithVerifier builds a Handler with a real Verifier.
+func newTestHandlerWithVerifier(t *testing.T, store business.CommandStore, verifier signature.Verifier) *Handler {
+	t.Helper()
+	h, err := New(&Config{
+		StewardID:    "steward-test",
+		OnStatus:     noopStatus,
+		Logger:       newTestLogger(t),
+		Store:        store,
+		Verifier:     verifier,
+		ReplayWindow: 5 * time.Minute,
+	})
+	require.NoError(t, err)
+	return h
+}
+
+// testSignedCommand builds a SignedCommand with no signature (used when verifier is nil).
+func testSignedCommand(id string, cmdType cpTypes.CommandType) *cpTypes.SignedCommand {
+	return &cpTypes.SignedCommand{
+		Command: cpTypes.Command{
+			ID:        id,
+			Type:      cmdType,
+			StewardID: "steward-test",
+			Timestamp: time.Now(),
+			Params:    map[string]interface{}{},
+		},
 	}
+}
+
+// signTestCommand signs cmd with signer using the canonical signing form.
+func signTestCommand(t *testing.T, signer signature.Signer, cmd *cpTypes.Command) *cpTypes.SignedCommand {
+	t.Helper()
+	rawParams := cpTypes.InterfaceParamsToStringMap(cmd.Params)
+	cmdBytes, err := cpTypes.CommandSigningBytes(cmd, rawParams)
+	require.NoError(t, err)
+	sig, err := signer.Sign(cmdBytes)
+	require.NoError(t, err)
+	return &cpTypes.SignedCommand{Command: *cmd, Signature: sig}
 }
 
 // ---------------------------------------------------------------------------
@@ -261,7 +328,7 @@ func TestNew_SweepsStaleExecutingCommands(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// HandleCommand / executeCommand tests
+// HandleCommand / executeCommand tests (no verifier — skip signature check)
 // Use h.Wait() for deterministic synchronization — no time.Sleep.
 // ---------------------------------------------------------------------------
 
@@ -270,15 +337,14 @@ func TestHandleCommand_PersistsRecord(t *testing.T) {
 	h := newTestHandler(t, store)
 	ctx := context.Background()
 
-	cmd := testCommand("hc-001", cpTypes.CommandSyncConfig)
+	sc := testSignedCommand("hc-001", cpTypes.CommandSyncConfig)
 
-	// Register a no-op handler so execution succeeds.
 	h.RegisterHandler(cpTypes.CommandSyncConfig, func(ctx context.Context, c *cpTypes.Command) error {
 		return nil
 	})
 
-	require.NoError(t, h.HandleCommand(ctx, cmd))
-	h.Wait() // synchronise with the goroutine
+	require.NoError(t, h.HandleCommand(ctx, sc))
+	h.Wait()
 
 	got, err := store.GetCommandRecord(ctx, "hc-001")
 	require.NoError(t, err)
@@ -290,9 +356,8 @@ func TestHandleCommand_NoHandlerMarkedFailed(t *testing.T) {
 	h := newTestHandler(t, store)
 	ctx := context.Background()
 
-	cmd := testCommand("hc-002", cpTypes.CommandSyncConfig)
-	// No handler registered — should fail.
-	require.NoError(t, h.HandleCommand(ctx, cmd))
+	sc := testSignedCommand("hc-002", cpTypes.CommandSyncConfig)
+	require.NoError(t, h.HandleCommand(ctx, sc))
 	h.Wait()
 
 	got, err := store.GetCommandRecord(ctx, "hc-002")
@@ -309,8 +374,8 @@ func TestHandleCommand_HandlerErrorMarkedFailed(t *testing.T) {
 		return fmt.Errorf("something went wrong")
 	})
 
-	cmd := testCommand("hc-003", cpTypes.CommandSyncConfig)
-	require.NoError(t, h.HandleCommand(ctx, cmd))
+	sc := testSignedCommand("hc-003", cpTypes.CommandSyncConfig)
+	require.NoError(t, h.HandleCommand(ctx, sc))
 	h.Wait()
 
 	got, err := store.GetCommandRecord(ctx, "hc-003")
@@ -321,12 +386,10 @@ func TestHandleCommand_HandlerErrorMarkedFailed(t *testing.T) {
 
 // ---------------------------------------------------------------------------
 // UpdateCommandStatus error-path tests
-// Verifies the handler does not panic or swallow store errors silently.
 // ---------------------------------------------------------------------------
 
 func TestHandleCommand_StoreUpdateErrorOnExecuting_DoesNotPanic(t *testing.T) {
 	store := newMemCommandStore()
-	// Inject a store error — UpdateCommandStatus will fail after CreateCommandRecord succeeds.
 	store.updateErr = fmt.Errorf("store unavailable")
 
 	h := newTestHandler(t, store)
@@ -336,9 +399,9 @@ func TestHandleCommand_StoreUpdateErrorOnExecuting_DoesNotPanic(t *testing.T) {
 		return nil
 	})
 
-	cmd := testCommand("err-001", cpTypes.CommandSyncConfig)
-	require.NoError(t, h.HandleCommand(ctx, cmd))
-	h.Wait() // must not panic even when store returns errors
+	sc := testSignedCommand("err-001", cpTypes.CommandSyncConfig)
+	require.NoError(t, h.HandleCommand(ctx, sc))
+	h.Wait()
 }
 
 func TestHandleCommand_StoreUpdateErrorOnFailed_DoesNotPanic(t *testing.T) {
@@ -347,9 +410,8 @@ func TestHandleCommand_StoreUpdateErrorOnFailed_DoesNotPanic(t *testing.T) {
 
 	h := newTestHandler(t, store)
 	ctx := context.Background()
-	// No handler registered; will try to write "failed" to store.
-	cmd := testCommand("err-002", cpTypes.CommandSyncConfig)
-	require.NoError(t, h.HandleCommand(ctx, cmd))
+	sc := testSignedCommand("err-002", cpTypes.CommandSyncConfig)
+	require.NoError(t, h.HandleCommand(ctx, sc))
 	h.Wait()
 }
 
@@ -364,8 +426,8 @@ func TestHandleCommand_StoreUpdateErrorOnCompleted_DoesNotPanic(t *testing.T) {
 		return nil
 	})
 
-	cmd := testCommand("err-003", cpTypes.CommandSyncConfig)
-	require.NoError(t, h.HandleCommand(ctx, cmd))
+	sc := testSignedCommand("err-003", cpTypes.CommandSyncConfig)
+	require.NoError(t, h.HandleCommand(ctx, sc))
 	h.Wait()
 }
 
@@ -374,13 +436,9 @@ func TestHandleCommand_StoreUpdateErrorOnCompleted_DoesNotPanic(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestExecutionContext_CancelFuncIsInvokable(t *testing.T) {
-	// Verify that an executionContext's Cancel function can be invoked and cancels
-	// a context derived from context.WithCancel. This tests the actual runtime
-	// behaviour of the cancel mechanism, not struct field layout.
 	ctx, cancel := context.WithCancel(context.Background())
 	ec := &executionContext{Cancel: cancel}
 
-	// The context should not be cancelled yet.
 	select {
 	case <-ctx.Done():
 		t.Fatal("context should not be done before Cancel() is called")
@@ -389,7 +447,6 @@ func TestExecutionContext_CancelFuncIsInvokable(t *testing.T) {
 
 	ec.Cancel()
 
-	// After Cancel(), the context must be done.
 	select {
 	case <-ctx.Done():
 		// expected
@@ -399,23 +456,86 @@ func TestExecutionContext_CancelFuncIsInvokable(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// CancelCommand / GetExecutingCommands
+// Story #919: Authentication rejection path tests
 // ---------------------------------------------------------------------------
 
-func TestCancelCommand_NotFound(t *testing.T) {
+func TestHandleCommand_NilSignedCommand_ReturnsErrUnauthenticated(t *testing.T) {
 	h := newTestHandler(t, nil)
-	err := h.CancelCommand("nonexistent")
-	require.Error(t, err)
+	ctx := context.Background()
+	err := h.HandleCommand(ctx, nil)
+	require.ErrorIs(t, err, ErrUnauthenticatedCommand)
 }
 
-func TestGetExecutingCommands_Empty(t *testing.T) {
-	h := newTestHandler(t, nil)
-	cmds := h.GetExecutingCommands()
-	assert.Empty(t, cmds)
+func TestHandleCommand_VerifierSet_MissingSignature_ReturnsErrUnauthenticated(t *testing.T) {
+	_, verifier := newTestSignerVerifier(t)
+	h := newTestHandlerWithVerifier(t, nil, verifier)
+	ctx := context.Background()
+
+	sc := &cpTypes.SignedCommand{
+		Command: cpTypes.Command{
+			ID:        "auth-001",
+			Type:      cpTypes.CommandSyncConfig,
+			StewardID: "steward-test",
+			Timestamp: time.Now(),
+		},
+		Signature: nil,
+	}
+	err := h.HandleCommand(ctx, sc)
+	require.ErrorIs(t, err, ErrUnauthenticatedCommand)
 }
 
-func TestHandleCommand_NilStore_StillWorks(t *testing.T) {
-	// When store is nil the handler must operate normally without panicking.
+func TestHandleCommand_VerifierSet_BadSignature_ReturnsErrUnauthenticated(t *testing.T) {
+	signer, verifier := newTestSignerVerifier(t)
+	h := newTestHandlerWithVerifier(t, nil, verifier)
+	ctx := context.Background()
+
+	cmd := &cpTypes.Command{
+		ID:        "auth-002",
+		Type:      cpTypes.CommandSyncConfig,
+		StewardID: "steward-test",
+		Timestamp: time.Now(),
+	}
+	sc := signTestCommand(t, signer, cmd)
+	// Corrupt the signature bytes.
+	sc.Signature.Signature = "AAAAAAAAAA=="
+
+	err := h.HandleCommand(ctx, sc)
+	require.ErrorIs(t, err, ErrUnauthenticatedCommand)
+}
+
+func TestHandleCommand_WrongStewardID_ReturnsErrWrongSteward(t *testing.T) {
+	h := newTestHandler(t, nil)
+	ctx := context.Background()
+
+	sc := &cpTypes.SignedCommand{
+		Command: cpTypes.Command{
+			ID:        "auth-003",
+			Type:      cpTypes.CommandSyncConfig,
+			StewardID: "other-steward", // mismatch with handler's "steward-test"
+			Timestamp: time.Now(),
+		},
+	}
+	err := h.HandleCommand(ctx, sc)
+	require.ErrorIs(t, err, ErrWrongSteward)
+}
+
+func TestHandleCommand_ExpiredTimestamp_ReturnsErrCommandReplay(t *testing.T) {
+	h := newTestHandler(t, nil) // replayWindow defaults to 5 min
+	ctx := context.Background()
+
+	sc := &cpTypes.SignedCommand{
+		Command: cpTypes.Command{
+			ID:        "auth-004",
+			Type:      cpTypes.CommandSyncConfig,
+			StewardID: "steward-test",
+			Timestamp: time.Now().Add(-10 * time.Minute), // 10 min > 5 min window
+		},
+	}
+	err := h.HandleCommand(ctx, sc)
+	require.ErrorIs(t, err, ErrCommandReplay)
+}
+
+func TestHandleCommand_DuplicateID_ReturnsErrCommandReplay(t *testing.T) {
 	h := newTestHandler(t, nil)
 	ctx := context.Background()
 
@@ -423,7 +543,81 @@ func TestHandleCommand_NilStore_StillWorks(t *testing.T) {
 		return nil
 	})
 
-	cmd := testCommand("no-store-001", cpTypes.CommandSyncConfig)
-	require.NoError(t, h.HandleCommand(ctx, cmd))
-	h.Wait() // deterministic synchronization — no panic
+	sc := testSignedCommand("dup-001", cpTypes.CommandSyncConfig)
+
+	// First delivery succeeds.
+	require.NoError(t, h.HandleCommand(ctx, sc))
+	h.Wait()
+
+	// Second delivery of same ID is a replay.
+	err := h.HandleCommand(ctx, sc)
+	require.ErrorIs(t, err, ErrCommandReplay)
+}
+
+func TestHandleCommand_ParamsTooLarge_ReturnsErrParamsTooLarge(t *testing.T) {
+	h, err := New(&Config{
+		StewardID:      "steward-test",
+		OnStatus:       noopStatus,
+		Logger:         newTestLogger(t),
+		MaxParamsBytes: 16, // tiny limit for testing
+	})
+	require.NoError(t, err)
+	ctx := context.Background()
+
+	sc := &cpTypes.SignedCommand{
+		Command: cpTypes.Command{
+			ID:        "big-001",
+			Type:      cpTypes.CommandSyncConfig,
+			StewardID: "steward-test",
+			Timestamp: time.Now(),
+			Params: map[string]interface{}{
+				"data": "this-string-is-definitely-longer-than-16-bytes",
+			},
+		},
+	}
+	handlerErr := h.HandleCommand(ctx, sc)
+	require.ErrorIs(t, handlerErr, ErrParamsTooLarge)
+}
+
+func TestHandleCommand_ValidSignedCommand_Dispatches(t *testing.T) {
+	signer, verifier := newTestSignerVerifier(t)
+	h := newTestHandlerWithVerifier(t, nil, verifier)
+	ctx := context.Background()
+
+	dispatched := make(chan struct{}, 1)
+	h.RegisterHandler(cpTypes.CommandSyncConfig, func(ctx context.Context, c *cpTypes.Command) error {
+		dispatched <- struct{}{}
+		return nil
+	})
+
+	cmd := &cpTypes.Command{
+		ID:        "valid-001",
+		Type:      cpTypes.CommandSyncConfig,
+		StewardID: "steward-test",
+		Timestamp: time.Now(),
+	}
+	sc := signTestCommand(t, signer, cmd)
+
+	require.NoError(t, h.HandleCommand(ctx, sc))
+	h.Wait()
+
+	select {
+	case <-dispatched:
+		// expected
+	case <-time.After(time.Second):
+		t.Fatal("handler was not dispatched for a valid signed command")
+	}
+}
+
+func TestHandleCommand_NilStore_StillWorks(t *testing.T) {
+	h := newTestHandler(t, nil)
+	ctx := context.Background()
+
+	h.RegisterHandler(cpTypes.CommandSyncConfig, func(ctx context.Context, c *cpTypes.Command) error {
+		return nil
+	})
+
+	sc := testSignedCommand("no-store-001", cpTypes.CommandSyncConfig)
+	require.NoError(t, h.HandleCommand(ctx, sc))
+	h.Wait()
 }

--- a/features/steward/commands/replay_cache.go
+++ b/features/steward/commands/replay_cache.go
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+package commands
+
+import (
+	"sync"
+	"time"
+)
+
+const maxReplayCacheEntries = 10_000
+
+// ttlReplayCache is a bounded in-memory deduplication cache keyed by command ID.
+// Add returns false when an ID is already present within the TTL window, providing
+// replay protection for authenticated commands. Entries are evicted when older than
+// the configured TTL or when the entry cap is reached (oldest evicted first).
+type ttlReplayCache struct {
+	mu  sync.Mutex
+	ttl time.Duration
+
+	// entries maps command ID → insertion time.
+	entries map[string]time.Time
+
+	// order tracks insertion order for bounded eviction (oldest first).
+	order []string
+}
+
+// newReplayCache creates a replay cache with the given time-to-live.
+func newReplayCache(ttl time.Duration) *ttlReplayCache {
+	return &ttlReplayCache{
+		ttl:     ttl,
+		entries: make(map[string]time.Time),
+	}
+}
+
+// Add records id in the cache and returns true if this is the first time the id
+// has been seen within the TTL window. Returns false if the id is already present
+// (i.e. a replay was detected). Expired entries are evicted on each call.
+func (c *ttlReplayCache) Add(id string) bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	now := time.Now()
+	c.evictExpiredLocked(now)
+
+	if t, exists := c.entries[id]; exists && now.Sub(t) < c.ttl {
+		return false
+	}
+
+	// Enforce the hard cap by evicting the oldest entries first.
+	for len(c.entries) >= maxReplayCacheEntries {
+		c.evictOldestLocked()
+	}
+
+	c.entries[id] = now
+	c.order = append(c.order, id)
+	return true
+}
+
+// evictExpiredLocked removes entries whose age exceeds the TTL.
+// Must be called with c.mu held.
+func (c *ttlReplayCache) evictExpiredLocked(now time.Time) {
+	cutoff := now.Add(-c.ttl)
+	newOrder := c.order[:0]
+	for _, id := range c.order {
+		t, exists := c.entries[id]
+		if !exists {
+			continue
+		}
+		if t.Before(cutoff) {
+			delete(c.entries, id)
+		} else {
+			newOrder = append(newOrder, id)
+		}
+	}
+	c.order = newOrder
+}
+
+// evictOldestLocked removes the single oldest entry from the cache.
+// Must be called with c.mu held.
+func (c *ttlReplayCache) evictOldestLocked() {
+	for len(c.order) > 0 {
+		oldest := c.order[0]
+		c.order = c.order[1:]
+		if _, exists := c.entries[oldest]; exists {
+			delete(c.entries, oldest)
+			return
+		}
+	}
+}

--- a/features/steward/commands/replay_cache_test.go
+++ b/features/steward/commands/replay_cache_test.go
@@ -23,10 +23,13 @@ func TestReplayCache_AddDuplicateWithinWindow_ReturnsFalse(t *testing.T) {
 }
 
 func TestReplayCache_AddExpiredID_ReturnsTrue(t *testing.T) {
-	// Use a tiny TTL so the entry expires immediately.
-	c := newReplayCache(time.Millisecond)
-	require.True(t, c.Add("cmd-exp"))
-	time.Sleep(10 * time.Millisecond)
+	// Inject a past timestamp directly to avoid time.Sleep races under -race / load.
+	ttl := 5 * time.Minute
+	c := newReplayCache(ttl)
+	c.mu.Lock()
+	c.entries["cmd-exp"] = time.Now().Add(-ttl - time.Second)
+	c.order = append(c.order, "cmd-exp")
+	c.mu.Unlock()
 	assert.True(t, c.Add("cmd-exp"), "ID added after TTL expiry must return true (not a replay)")
 }
 
@@ -53,9 +56,13 @@ func TestReplayCache_MultipleDistinctIDs_AllAccepted(t *testing.T) {
 }
 
 func TestReplayCache_EvictExpiredOnAdd(t *testing.T) {
-	c := newReplayCache(10 * time.Millisecond)
-	require.True(t, c.Add("old"))
-	time.Sleep(20 * time.Millisecond)
+	// Inject an expired entry directly to avoid time.Sleep races under -race / load.
+	ttl := 5 * time.Minute
+	c := newReplayCache(ttl)
+	c.mu.Lock()
+	c.entries["old"] = time.Now().Add(-ttl - time.Second)
+	c.order = append(c.order, "old")
+	c.mu.Unlock()
 
 	// Adding a new entry triggers eviction of the expired "old" entry.
 	require.True(t, c.Add("new"))

--- a/features/steward/commands/replay_cache_test.go
+++ b/features/steward/commands/replay_cache_test.go
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+package commands
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestReplayCache_AddNewID_ReturnsTrue(t *testing.T) {
+	c := newReplayCache(5 * time.Minute)
+	assert.True(t, c.Add("cmd-001"), "first Add of a new ID must return true")
+}
+
+func TestReplayCache_AddDuplicateWithinWindow_ReturnsFalse(t *testing.T) {
+	c := newReplayCache(5 * time.Minute)
+	require.True(t, c.Add("cmd-dup"))
+	assert.False(t, c.Add("cmd-dup"), "duplicate within window must return false")
+}
+
+func TestReplayCache_AddExpiredID_ReturnsTrue(t *testing.T) {
+	// Use a tiny TTL so the entry expires immediately.
+	c := newReplayCache(time.Millisecond)
+	require.True(t, c.Add("cmd-exp"))
+	time.Sleep(10 * time.Millisecond)
+	assert.True(t, c.Add("cmd-exp"), "ID added after TTL expiry must return true (not a replay)")
+}
+
+func TestReplayCache_BoundEnforcement(t *testing.T) {
+	// Fill the cache to the hard cap + 1 to trigger eviction.
+	c := newReplayCache(time.Hour)
+	for i := range maxReplayCacheEntries + 1 {
+		id := fmt.Sprintf("cmd-%d", i)
+		assert.True(t, c.Add(id), "Add of unique ID %q must return true", id)
+	}
+	c.mu.Lock()
+	size := len(c.entries)
+	c.mu.Unlock()
+	assert.LessOrEqual(t, size, maxReplayCacheEntries,
+		"cache must not exceed %d entries", maxReplayCacheEntries)
+}
+
+func TestReplayCache_MultipleDistinctIDs_AllAccepted(t *testing.T) {
+	c := newReplayCache(5 * time.Minute)
+	ids := []string{"a", "b", "c", "d", "e"}
+	for _, id := range ids {
+		assert.True(t, c.Add(id), "unique ID %q must be accepted", id)
+	}
+}
+
+func TestReplayCache_EvictExpiredOnAdd(t *testing.T) {
+	c := newReplayCache(10 * time.Millisecond)
+	require.True(t, c.Add("old"))
+	time.Sleep(20 * time.Millisecond)
+
+	// Adding a new entry triggers eviction of the expired "old" entry.
+	require.True(t, c.Add("new"))
+
+	c.mu.Lock()
+	_, oldPresent := c.entries["old"]
+	c.mu.Unlock()
+	assert.False(t, oldPresent, "expired entry must be evicted on the next Add call")
+}

--- a/features/steward/commands/types.go
+++ b/features/steward/commands/types.go
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+package commands
+
+import "errors"
+
+// Sentinel errors returned by HandleCommand for each authentication rejection path.
+var (
+	// ErrUnauthenticatedCommand is returned when a command has no signature or the
+	// signature verification fails.
+	ErrUnauthenticatedCommand = errors.New("unauthenticated command")
+
+	// ErrCommandReplay is returned when a command timestamp exceeds the replay window
+	// or when the command ID has already been processed within the current window.
+	ErrCommandReplay = errors.New("command replay detected")
+
+	// ErrWrongSteward is returned when the command's StewardID does not match this
+	// handler's steward identity.
+	ErrWrongSteward = errors.New("command addressed to wrong steward")
+
+	// ErrParamsTooLarge is returned when the JSON-serialized Params exceed the
+	// configured maxParamsBytes limit.
+	ErrParamsTooLarge = errors.New("command params too large")
+)

--- a/features/steward/config/config.go
+++ b/features/steward/config/config.go
@@ -159,6 +159,17 @@ type StewardSettings struct {
 	// ScriptSigning configures script signing policy, trust modes, and trusted key allowlist.
 	// Child tenants inherit this config and may only tighten (not loosen) the policy.
 	ScriptSigning ScriptSigningConfig `yaml:"script_signing,omitempty"`
+
+	// SignedCommandReplayWindow is the maximum age of an accepted command timestamp.
+	// Commands with a Timestamp older than this window are rejected as potential replays.
+	// Shorter windows enforce stricter freshness; longer windows tolerate clock skew.
+	// Defaults to 5 minutes when zero.
+	SignedCommandReplayWindow time.Duration `yaml:"signed_command_replay_window,omitempty"`
+
+	// SignedCommandMaxParamsBytes is the maximum JSON-serialized size of Command.Params
+	// in bytes. Commands whose Params serialise to more than this limit are rejected
+	// before dispatch. Defaults to 65536 (64 KiB) when zero.
+	SignedCommandMaxParamsBytes int `yaml:"signed_command_max_params_bytes,omitempty"`
 }
 
 // SecretsConfig defines configuration for steward-side secret storage.

--- a/pkg/controlplane/interfaces/contract_test.go
+++ b/pkg/controlplane/interfaces/contract_test.go
@@ -100,8 +100,8 @@ func RunCPContractTests(t *testing.T, factory CPProviderFactory) {
 
 // --- Contract Implementations ---
 
-// testCPCommandDelivery verifies server sends a command to a specific steward
-// and that steward receives it with fields intact.
+// testCPCommandDelivery verifies server sends a signed command to a specific steward
+// and that steward receives it with inner Command fields intact.
 func testCPCommandDelivery(t *testing.T, factory CPProviderFactory) {
 	t.Helper()
 	server, clients, cleanup := factory(t)
@@ -110,26 +110,28 @@ func testCPCommandDelivery(t *testing.T, factory CPProviderFactory) {
 	ctx := context.Background()
 	client := clients["contract-steward-0"]
 
-	received := make(chan *cptypes.Command, 1)
-	require.NoError(t, client.SubscribeCommands(ctx, "contract-steward-0", func(_ context.Context, cmd *cptypes.Command) error {
-		received <- cmd
+	received := make(chan *cptypes.SignedCommand, 1)
+	require.NoError(t, client.SubscribeCommands(ctx, "contract-steward-0", func(_ context.Context, sc *cptypes.SignedCommand) error {
+		received <- sc
 		return nil
 	}))
 
-	cmd := &cptypes.Command{
-		ID:        "contract-cmd-delivery",
-		Type:      cptypes.CommandSyncConfig,
-		StewardID: "contract-steward-0",
-		Timestamp: time.Now().Truncate(time.Microsecond),
-		Params:    map[string]interface{}{"version": "1.0"},
+	sc := &cptypes.SignedCommand{
+		Command: cptypes.Command{
+			ID:        "contract-cmd-delivery",
+			Type:      cptypes.CommandSyncConfig,
+			StewardID: "contract-steward-0",
+			Timestamp: time.Now().Truncate(time.Microsecond),
+			Params:    map[string]interface{}{"version": "1.0"},
+		},
 	}
-	require.NoError(t, server.SendCommand(ctx, cmd))
+	require.NoError(t, server.SendCommand(ctx, sc))
 
 	select {
 	case got := <-received:
-		assert.Equal(t, cmd.ID, got.ID)
-		assert.Equal(t, cmd.Type, got.Type)
-		assert.Equal(t, cmd.StewardID, got.StewardID)
+		assert.Equal(t, sc.Command.ID, got.Command.ID)
+		assert.Equal(t, sc.Command.Type, got.Command.Type)
+		assert.Equal(t, sc.Command.StewardID, got.Command.StewardID)
 	case <-time.After(5 * time.Second):
 		t.Fatal("timed out waiting for command delivery")
 	}
@@ -205,7 +207,7 @@ func testCPHeartbeatDelivery(t *testing.T, factory CPProviderFactory) {
 	}
 }
 
-// testCPFanOutCommand verifies server sends a command to all N stewards and
+// testCPFanOutCommand verifies server sends a signed command to all N stewards and
 // all receive it.
 func testCPFanOutCommand(t *testing.T, factory CPProviderFactory) {
 	t.Helper()
@@ -214,23 +216,25 @@ func testCPFanOutCommand(t *testing.T, factory CPProviderFactory) {
 
 	ctx := context.Background()
 
-	received := make(map[string]chan *cptypes.Command)
+	received := make(map[string]chan *cptypes.SignedCommand)
 	for _, id := range cpContractStewardIDs {
 		id := id
-		ch := make(chan *cptypes.Command, 1)
+		ch := make(chan *cptypes.SignedCommand, 1)
 		received[id] = ch
-		require.NoError(t, clients[id].SubscribeCommands(ctx, id, func(_ context.Context, cmd *cptypes.Command) error {
-			ch <- cmd
+		require.NoError(t, clients[id].SubscribeCommands(ctx, id, func(_ context.Context, sc *cptypes.SignedCommand) error {
+			ch <- sc
 			return nil
 		}))
 	}
 
-	cmd := &cptypes.Command{
-		ID:        "contract-cmd-fanout",
-		Type:      cptypes.CommandSyncDNA,
-		Timestamp: time.Now(),
+	sc := &cptypes.SignedCommand{
+		Command: cptypes.Command{
+			ID:        "contract-cmd-fanout",
+			Type:      cptypes.CommandSyncDNA,
+			Timestamp: time.Now(),
+		},
 	}
-	result, err := server.FanOutCommand(ctx, cmd, cpContractStewardIDs)
+	result, err := server.FanOutCommand(ctx, sc, cpContractStewardIDs)
 	require.NoError(t, err)
 	assert.Len(t, result.Succeeded, len(cpContractStewardIDs))
 	assert.Empty(t, result.Failed)
@@ -238,7 +242,7 @@ func testCPFanOutCommand(t *testing.T, factory CPProviderFactory) {
 	for _, id := range cpContractStewardIDs {
 		select {
 		case got := <-received[id]:
-			assert.Equal(t, cmd.ID, got.ID)
+			assert.Equal(t, sc.Command.ID, got.Command.ID)
 		case <-time.After(5 * time.Second):
 			t.Fatalf("steward %s did not receive fan-out command", id)
 		}
@@ -254,14 +258,16 @@ func testCPFanOutPartialFailure(t *testing.T, factory CPProviderFactory) {
 
 	ctx := context.Background()
 
-	cmd := &cptypes.Command{
-		ID:        "contract-cmd-partial",
-		Type:      cptypes.CommandSyncConfig,
-		Timestamp: time.Now(),
+	sc := &cptypes.SignedCommand{
+		Command: cptypes.Command{
+			ID:        "contract-cmd-partial",
+			Type:      cptypes.CommandSyncConfig,
+			Timestamp: time.Now(),
+		},
 	}
 
 	// Fan-out to one connected steward and one that never connected
-	result, err := server.FanOutCommand(ctx, cmd, []string{
+	result, err := server.FanOutCommand(ctx, sc, []string{
 		"contract-steward-0",
 		"steward-never-connected",
 	})
@@ -405,8 +411,8 @@ func testCPMultipleHeartbeatHandlers(t *testing.T, factory CPProviderFactory) {
 	}
 }
 
-// testCPMultiTenantIsolation verifies that a command sent to steward A is not
-// delivered to steward B.
+// testCPMultiTenantIsolation verifies that a signed command sent to steward A is
+// not delivered to steward B.
 func testCPMultiTenantIsolation(t *testing.T, factory CPProviderFactory) {
 	t.Helper()
 	server, clients, cleanup := factory(t)
@@ -414,32 +420,34 @@ func testCPMultiTenantIsolation(t *testing.T, factory CPProviderFactory) {
 
 	ctx := context.Background()
 
-	receivedA := make(chan *cptypes.Command, 1)
-	receivedB := make(chan *cptypes.Command, 1)
+	receivedA := make(chan *cptypes.SignedCommand, 1)
+	receivedB := make(chan *cptypes.SignedCommand, 1)
 
 	require.NoError(t, clients["contract-steward-0"].SubscribeCommands(ctx, "contract-steward-0",
-		func(_ context.Context, cmd *cptypes.Command) error {
-			receivedA <- cmd
+		func(_ context.Context, sc *cptypes.SignedCommand) error {
+			receivedA <- sc
 			return nil
 		}))
 	require.NoError(t, clients["contract-steward-1"].SubscribeCommands(ctx, "contract-steward-1",
-		func(_ context.Context, cmd *cptypes.Command) error {
-			receivedB <- cmd
+		func(_ context.Context, sc *cptypes.SignedCommand) error {
+			receivedB <- sc
 			return nil
 		}))
 
 	// Send command only to steward-0
-	require.NoError(t, server.SendCommand(ctx, &cptypes.Command{
-		ID:        "contract-cmd-isolation",
-		Type:      cptypes.CommandSyncConfig,
-		StewardID: "contract-steward-0",
-		Timestamp: time.Now(),
+	require.NoError(t, server.SendCommand(ctx, &cptypes.SignedCommand{
+		Command: cptypes.Command{
+			ID:        "contract-cmd-isolation",
+			Type:      cptypes.CommandSyncConfig,
+			StewardID: "contract-steward-0",
+			Timestamp: time.Now(),
+		},
 	}))
 
 	// steward-0 must receive
 	select {
 	case got := <-receivedA:
-		assert.Equal(t, "contract-cmd-isolation", got.ID)
+		assert.Equal(t, "contract-cmd-isolation", got.Command.ID)
 	case <-time.After(5 * time.Second):
 		t.Fatal("steward-0 did not receive its command")
 	}
@@ -467,11 +475,13 @@ func testCPDisconnectCleanup(t *testing.T, factory CPProviderFactory) {
 
 	// Server should eventually reflect disconnection
 	require.Eventually(t, func() bool {
-		err := server.SendCommand(ctx, &cptypes.Command{
-			ID:        "contract-cmd-after-disconnect",
-			Type:      cptypes.CommandSyncConfig,
-			StewardID: "contract-steward-0",
-			Timestamp: time.Now(),
+		err := server.SendCommand(ctx, &cptypes.SignedCommand{
+			Command: cptypes.Command{
+				ID:        "contract-cmd-after-disconnect",
+				Type:      cptypes.CommandSyncConfig,
+				StewardID: "contract-steward-0",
+				Timestamp: time.Now(),
+			},
 		})
 		return err != nil
 	}, 5*time.Second, 50*time.Millisecond,
@@ -491,15 +501,17 @@ func testCPStatsTracking(t *testing.T, factory CPProviderFactory) {
 	// Register handlers so dispatched messages are counted
 	require.NoError(t, server.SubscribeEvents(ctx, nil, func(_ context.Context, _ *cptypes.Event) error { return nil }))
 	require.NoError(t, server.SubscribeHeartbeats(ctx, func(_ context.Context, _ *cptypes.Heartbeat) error { return nil }))
-	require.NoError(t, client.SubscribeCommands(ctx, "contract-steward-0", func(_ context.Context, _ *cptypes.Command) error { return nil }))
+	require.NoError(t, client.SubscribeCommands(ctx, "contract-steward-0", func(_ context.Context, _ *cptypes.SignedCommand) error { return nil }))
 
 	now := time.Now()
 
-	require.NoError(t, server.SendCommand(ctx, &cptypes.Command{
-		ID:        "contract-cmd-stats",
-		Type:      cptypes.CommandSyncConfig,
-		StewardID: "contract-steward-0",
-		Timestamp: now,
+	require.NoError(t, server.SendCommand(ctx, &cptypes.SignedCommand{
+		Command: cptypes.Command{
+			ID:        "contract-cmd-stats",
+			Type:      cptypes.CommandSyncConfig,
+			StewardID: "contract-steward-0",
+			Timestamp: now,
+		},
 	}))
 	require.NoError(t, client.PublishEvent(ctx, &cptypes.Event{
 		ID:        "contract-evt-stats",
@@ -594,7 +606,7 @@ func testCPMalformedMessageHandling(t *testing.T, factory CPProviderFactory) {
 	// nil messages — must not panic (may return error or no-op)
 	assert.NotPanics(t, func() {
 		_ = server.SendCommand(ctx, nil)
-	}, "SendCommand with nil command must not panic")
+	}, "SendCommand with nil SignedCommand must not panic")
 
 	assert.NotPanics(t, func() {
 		_ = client.PublishEvent(ctx, nil)

--- a/pkg/controlplane/interfaces/provider.go
+++ b/pkg/controlplane/interfaces/provider.go
@@ -50,13 +50,17 @@ type ControlPlaneProvider interface {
 	// Commands (Controller → Steward)
 	// =================================================================
 
-	// SendCommand sends a command to a specific steward
+	// SendCommand sends a signed command to a specific steward.
+	//
+	// The cmd envelope must already be signed by the controller before calling
+	// this method. The transport layer carries the signature intact; verification
+	// is performed by the steward handler on receipt.
 	//
 	// Returns an error if the command cannot be delivered. Does not wait
-	// for command execution - use SubscribeEvents to receive completion events.
-	SendCommand(ctx context.Context, cmd *types.Command) error
+	// for command execution — use SubscribeEvents to receive completion events.
+	SendCommand(ctx context.Context, cmd *types.SignedCommand) error
 
-	// FanOutCommand sends a command to a specific list of stewards.
+	// FanOutCommand sends a signed command to a specific list of stewards.
 	//
 	// The caller is responsible for resolving target steward IDs (by tenant,
 	// search results, online status, etc.). The transport layer delivers to
@@ -65,7 +69,7 @@ type ControlPlaneProvider interface {
 	// Returns FanOutResult with per-steward delivery status. The error return
 	// is for systemic failures (provider not started, etc.), not per-steward
 	// delivery failures which are reported in FanOutResult.Failed.
-	FanOutCommand(ctx context.Context, cmd *types.Command, stewardIDs []string) (*types.FanOutResult, error)
+	FanOutCommand(ctx context.Context, cmd *types.SignedCommand, stewardIDs []string) (*types.FanOutResult, error)
 
 	// SubscribeCommands subscribes to commands (steward-side)
 	//
@@ -119,11 +123,13 @@ type ControlPlaneProvider interface {
 	IsConnected() bool
 }
 
-// CommandHandler is called when a command is received (steward-side).
+// CommandHandler is called when a signed command is received (steward-side).
 //
-// The handler should process the command and publish events/responses
-// to notify the controller of progress and completion.
-type CommandHandler func(ctx context.Context, cmd *types.Command) error
+// The handler receives the full SignedCommand envelope so that it can verify
+// the signature and metadata (StewardID, replay window) before dispatching.
+// The handler should publish events/responses to notify the controller of
+// progress and completion.
+type CommandHandler func(ctx context.Context, cmd *types.SignedCommand) error
 
 // EventHandler is called when an event is received (controller-side).
 //

--- a/pkg/controlplane/interfaces/provider_test.go
+++ b/pkg/controlplane/interfaces/provider_test.go
@@ -45,11 +45,11 @@ func (m *testProvider) Stop(ctx context.Context) error {
 	return nil
 }
 
-func (m *testProvider) SendCommand(ctx context.Context, cmd *types.Command) error {
+func (m *testProvider) SendCommand(ctx context.Context, cmd *types.SignedCommand) error {
 	return nil
 }
 
-func (m *testProvider) FanOutCommand(ctx context.Context, cmd *types.Command, stewardIDs []string) (*types.FanOutResult, error) {
+func (m *testProvider) FanOutCommand(ctx context.Context, cmd *types.SignedCommand, stewardIDs []string) (*types.FanOutResult, error) {
 	return &types.FanOutResult{Succeeded: stewardIDs, Failed: make(map[string]error)}, nil
 }
 
@@ -107,17 +107,17 @@ func TestProviderLifecycle(t *testing.T) {
 }
 
 func TestCommandHandler(t *testing.T) {
-	// Verify CommandHandler signature
-	var handler CommandHandler = func(ctx context.Context, cmd *types.Command) error {
+	// Verify CommandHandler signature accepts SignedCommand
+	var handler CommandHandler = func(ctx context.Context, sc *types.SignedCommand) error {
 		assert.NotNil(t, ctx)
-		assert.NotNil(t, cmd)
+		assert.NotNil(t, sc)
 		return nil
 	}
 
 	// Call handler
 	ctx := context.Background()
-	cmd := &types.Command{ID: "test-cmd", Type: types.CommandSyncConfig}
-	err := handler(ctx, cmd)
+	sc := &types.SignedCommand{Command: types.Command{ID: "test-cmd", Type: types.CommandSyncConfig}}
+	err := handler(ctx, sc)
 	assert.NoError(t, err)
 }
 

--- a/pkg/controlplane/providers/grpc/convert.go
+++ b/pkg/controlplane/providers/grpc/convert.go
@@ -9,9 +9,15 @@ import (
 	"time"
 
 	transportpb "github.com/cfgis/cfgms/api/proto/transport"
+	"github.com/cfgis/cfgms/features/config/signature"
 	"github.com/cfgis/cfgms/pkg/controlplane/types"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
+
+// sigParamKey is the reserved params key used to carry the signature through
+// the existing proto Command.params wire field without requiring a proto change.
+// Two leading underscores prevent collision with user-defined command params.
+const sigParamKey = "__sig"
 
 // --- Command conversion ---
 
@@ -63,6 +69,80 @@ func commandFromProto(pb *transportpb.Command) *types.Command {
 		cmd.Params = stringMapToInterfaceMap(pb.GetParams())
 	}
 	return cmd
+}
+
+// signedCommandToProto serialises a SignedCommand to the wire proto Command.
+//
+// The signature (when present) is JSON-encoded and embedded in the proto params
+// map under sigParamKey so no proto schema change is required.
+func signedCommandToProto(sc *types.SignedCommand) *transportpb.Command {
+	if sc == nil {
+		return nil
+	}
+	pb := commandToProto(&sc.Command)
+	if pb == nil {
+		return nil
+	}
+	if sc.Signature != nil {
+		sigJSON, err := json.Marshal(sc.Signature)
+		if err == nil {
+			if pb.Params == nil {
+				pb.Params = make(map[string]string)
+			}
+			pb.Params[sigParamKey] = string(sigJSON)
+		}
+	}
+	return pb
+}
+
+// signedCommandFromProto reconstructs a SignedCommand from the wire proto Command.
+//
+// It extracts the signature from the reserved sigParamKey entry (if present)
+// and strips that key from the params so it does not appear in Command.Params.
+func signedCommandFromProto(pb *transportpb.Command) *types.SignedCommand {
+	if pb == nil {
+		return nil
+	}
+
+	var sig *signature.ConfigSignature
+	filteredParams := make(map[string]string, len(pb.GetParams()))
+	for k, v := range pb.GetParams() {
+		if k == sigParamKey {
+			var s signature.ConfigSignature
+			if err := json.Unmarshal([]byte(v), &s); err == nil {
+				sig = &s
+			}
+			continue
+		}
+		filteredParams[k] = v
+	}
+
+	// Rebuild the proto Command without the sig key so commandFromProto sees
+	// only the real user params.
+	pbClean := &transportpb.Command{
+		Id:        pb.GetId(),
+		Type:      pb.GetType(),
+		StewardId: pb.GetStewardId(),
+		TenantId:  pb.GetTenantId(),
+		Timestamp: pb.GetTimestamp(),
+		Params:    filteredParams,
+	}
+	cmd := commandFromProto(pbClean)
+	if cmd == nil {
+		return nil
+	}
+	sc := &types.SignedCommand{
+		Command:   *cmd,
+		Signature: sig,
+	}
+	// Preserve the proto-wire string map for signature verification. The handler
+	// must verify against this form, not cmd.Params, because stringMapToInterfaceMap
+	// JSON-decodes numeric-looking strings (e.g. "1.0" → float64) making the bytes
+	// differ from what the controller signed.
+	if len(filteredParams) > 0 {
+		sc.RawParams = filteredParams
+	}
+	return sc
 }
 
 // --- Event conversion ---

--- a/pkg/controlplane/providers/grpc/integration_test.go
+++ b/pkg/controlplane/providers/grpc/integration_test.go
@@ -148,29 +148,31 @@ func newTestTLSConfigs(t *testing.T, stewardID string) (serverTLS, clientTLS *tl
 func TestControllerSendsCommand_StewardReceives(t *testing.T) {
 	env := newTestEnv(t, "steward-cmd-test")
 
-	received := make(chan *types.Command, 1)
-	err := env.client.SubscribeCommands(context.Background(), "steward-cmd-test", func(ctx context.Context, cmd *types.Command) error {
-		received <- cmd
+	received := make(chan *types.SignedCommand, 1)
+	err := env.client.SubscribeCommands(context.Background(), "steward-cmd-test", func(ctx context.Context, sc *types.SignedCommand) error {
+		received <- sc
 		return nil
 	})
 	require.NoError(t, err)
 
-	cmd := &types.Command{
-		ID:        "cmd-001",
-		Type:      types.CommandSyncConfig,
-		StewardID: "steward-cmd-test",
-		Timestamp: time.Now().Truncate(time.Microsecond),
-		Params:    map[string]interface{}{"version": "1.0"},
+	sc := &types.SignedCommand{
+		Command: types.Command{
+			ID:        "cmd-001",
+			Type:      types.CommandSyncConfig,
+			StewardID: "steward-cmd-test",
+			Timestamp: time.Now().Truncate(time.Microsecond),
+			Params:    map[string]interface{}{"version": "1.0"},
+		},
 	}
 
-	err = env.server.SendCommand(context.Background(), cmd)
+	err = env.server.SendCommand(context.Background(), sc)
 	require.NoError(t, err)
 
 	select {
 	case got := <-received:
-		assert.Equal(t, cmd.ID, got.ID)
-		assert.Equal(t, cmd.Type, got.Type)
-		assert.Equal(t, cmd.StewardID, got.StewardID)
+		assert.Equal(t, sc.Command.ID, got.Command.ID)
+		assert.Equal(t, sc.Command.Type, got.Command.Type)
+		assert.Equal(t, sc.Command.StewardID, got.Command.StewardID)
 	case <-time.After(5 * time.Second):
 		t.Fatal("timed out waiting for command")
 	}
@@ -306,7 +308,7 @@ func TestFanOutCommand(t *testing.T) {
 	listenAddr := server.listener.Addr().String()
 
 	// Connect two stewards
-	received := make(map[string]chan *types.Command)
+	received := make(map[string]chan *types.SignedCommand)
 	stewardIDs := []string{"steward-fan-1", "steward-fan-2"}
 
 	for _, id := range stewardIDs {
@@ -321,12 +323,12 @@ func TestFanOutCommand(t *testing.T) {
 		require.NoError(t, client.Start(context.Background()))
 		t.Cleanup(func() { _ = client.Stop(context.Background()) })
 
-		ch := make(chan *types.Command, 1)
+		ch := make(chan *types.SignedCommand, 1)
 		received[id] = ch
 		id := id
 		cmdCh := ch // capture for closure to avoid concurrent map read
-		require.NoError(t, client.SubscribeCommands(context.Background(), id, func(ctx context.Context, cmd *types.Command) error {
-			cmdCh <- cmd
+		require.NoError(t, client.SubscribeCommands(context.Background(), id, func(ctx context.Context, sc *types.SignedCommand) error {
+			cmdCh <- sc
 			return nil
 		}))
 	}
@@ -334,13 +336,15 @@ func TestFanOutCommand(t *testing.T) {
 	// Wait for both stewards to register
 	require.Eventually(t, func() bool { return reg.Count() == 2 }, 5*time.Second, 10*time.Millisecond)
 
-	cmd := &types.Command{
-		ID:        "cmd-fan",
-		Type:      types.CommandSyncDNA,
-		Timestamp: time.Now(),
+	sc := &types.SignedCommand{
+		Command: types.Command{
+			ID:        "cmd-fan",
+			Type:      types.CommandSyncDNA,
+			Timestamp: time.Now(),
+		},
 	}
 
-	result, err := server.FanOutCommand(context.Background(), cmd, stewardIDs)
+	result, err := server.FanOutCommand(context.Background(), sc, stewardIDs)
 	require.NoError(t, err)
 	assert.Len(t, result.Succeeded, 2)
 	assert.Empty(t, result.Failed)
@@ -349,7 +353,7 @@ func TestFanOutCommand(t *testing.T) {
 	for _, id := range stewardIDs {
 		select {
 		case got := <-received[id]:
-			assert.Equal(t, "cmd-fan", got.ID)
+			assert.Equal(t, "cmd-fan", got.Command.ID)
 		case <-time.After(5 * time.Second):
 			t.Fatalf("steward %s did not receive fan-out command", id)
 		}
@@ -359,14 +363,16 @@ func TestFanOutCommand(t *testing.T) {
 func TestFanOutCommand_PartialFailure(t *testing.T) {
 	env := newTestEnv(t, "steward-fan-partial")
 
-	cmd := &types.Command{
-		ID:        "cmd-partial",
-		Type:      types.CommandSyncConfig,
-		Timestamp: time.Now(),
+	sc := &types.SignedCommand{
+		Command: types.Command{
+			ID:        "cmd-partial",
+			Type:      types.CommandSyncConfig,
+			Timestamp: time.Now(),
+		},
 	}
 
 	// Fan-out to one connected and one disconnected steward
-	result, err := env.server.FanOutCommand(context.Background(), cmd, []string{
+	result, err := env.server.FanOutCommand(context.Background(), sc, []string{
 		"steward-fan-partial",
 		"steward-not-connected",
 	})
@@ -418,11 +424,13 @@ func TestDisconnectCleansUpRegistry(t *testing.T) {
 	}, 5*time.Second, 10*time.Millisecond, "steward should be unregistered after disconnect")
 
 	// SendCommand to the disconnected steward should return an error
-	err = server.SendCommand(context.Background(), &types.Command{
-		ID:        "cmd-after-disconnect",
-		Type:      types.CommandSyncConfig,
-		StewardID: "steward-disconnect",
-		Timestamp: time.Now(),
+	err = server.SendCommand(context.Background(), &types.SignedCommand{
+		Command: types.Command{
+			ID:        "cmd-after-disconnect",
+			Type:      types.CommandSyncConfig,
+			StewardID: "steward-disconnect",
+			Timestamp: time.Now(),
+		},
 	})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "not connected")
@@ -500,15 +508,17 @@ func TestStatsTracking(t *testing.T) {
 	require.NoError(t, env.server.SubscribeHeartbeats(context.Background(), func(ctx context.Context, hb *types.Heartbeat) error {
 		return nil
 	}))
-	require.NoError(t, env.client.SubscribeCommands(context.Background(), "steward-stats-test", func(ctx context.Context, cmd *types.Command) error {
+	require.NoError(t, env.client.SubscribeCommands(context.Background(), "steward-stats-test", func(ctx context.Context, sc *types.SignedCommand) error {
 		return nil
 	}))
 
 	now := time.Now()
 
 	// Send one of each message type
-	require.NoError(t, env.server.SendCommand(context.Background(), &types.Command{
-		ID: "cmd-stats", Type: types.CommandSyncConfig, StewardID: "steward-stats-test", Timestamp: now,
+	require.NoError(t, env.server.SendCommand(context.Background(), &types.SignedCommand{
+		Command: types.Command{
+			ID: "cmd-stats", Type: types.CommandSyncConfig, StewardID: "steward-stats-test", Timestamp: now,
+		},
 	}))
 	require.NoError(t, env.client.PublishEvent(context.Background(), &types.Event{
 		ID: "evt-stats", Type: types.EventConfigApplied, StewardID: "steward-stats-test", Timestamp: now, Severity: "info",
@@ -549,11 +559,11 @@ func TestModeValidation(t *testing.T) {
 	client.addr = "localhost:50051"
 	client.tlsConfig = &tls.Config{}
 
-	err := client.SendCommand(context.Background(), &types.Command{})
+	err := client.SendCommand(context.Background(), &types.SignedCommand{})
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "server mode")
 
-	_, err = client.FanOutCommand(context.Background(), &types.Command{}, []string{"a"})
+	_, err = client.FanOutCommand(context.Background(), &types.SignedCommand{}, []string{"a"})
 	assert.Error(t, err)
 
 	err = client.SubscribeEvents(context.Background(), nil, nil)

--- a/pkg/controlplane/providers/grpc/provider.go
+++ b/pkg/controlplane/providers/grpc/provider.go
@@ -398,7 +398,7 @@ func (p *Provider) clientReceiveLoop() {
 
 		switch payload := msg.GetPayload().(type) {
 		case *transportpb.ControlMessage_Command:
-			cmd := commandFromProto(payload.Command)
+			sc := signedCommandFromProto(payload.Command)
 			p.commandsReceived.Add(1)
 
 			p.mu.RLock()
@@ -407,8 +407,8 @@ func (p *Provider) clientReceiveLoop() {
 
 			if handler != nil {
 				go func() {
-					if err := handler(p.ctx, cmd); err != nil {
-						p.logger.Error("command handler error", "command_id", cmd.ID, "error", err)
+					if err := handler(p.ctx, sc); err != nil {
+						p.logger.Error("command handler error", "command_id", sc.Command.ID, "error", err)
 					}
 				}()
 			}
@@ -585,7 +585,7 @@ func (p *Provider) stopClient() error {
 
 // --- Commands (Controller → Steward) ---
 
-func (p *Provider) SendCommand(ctx context.Context, cmd *types.Command) error {
+func (p *Provider) SendCommand(ctx context.Context, cmd *types.SignedCommand) error {
 	if p.mode != ModeServer {
 		return fmt.Errorf("SendCommand is only available in server mode")
 	}
@@ -593,26 +593,26 @@ func (p *Provider) SendCommand(ctx context.Context, cmd *types.Command) error {
 		return fmt.Errorf("SendCommand: command must not be nil")
 	}
 
-	conn, ok := p.registry.Get(cmd.StewardID)
+	conn, ok := p.registry.Get(cmd.Command.StewardID)
 	if !ok {
 		p.deliveryFailures.Add(1)
-		return fmt.Errorf("steward %s not connected", cmd.StewardID)
+		return fmt.Errorf("steward %s not connected", cmd.Command.StewardID)
 	}
 
 	msg := &transportpb.ControlMessage{
-		Payload: &transportpb.ControlMessage_Command{Command: commandToProto(cmd)},
+		Payload: &transportpb.ControlMessage_Command{Command: signedCommandToProto(cmd)},
 	}
 
 	if err := conn.Send(msg); err != nil {
 		p.deliveryFailures.Add(1)
-		return fmt.Errorf("failed to send command to steward %s: %w", cmd.StewardID, err)
+		return fmt.Errorf("failed to send command to steward %s: %w", cmd.Command.StewardID, err)
 	}
 
 	p.commandsSent.Add(1)
 	return nil
 }
 
-func (p *Provider) FanOutCommand(ctx context.Context, cmd *types.Command, stewardIDs []string) (*types.FanOutResult, error) {
+func (p *Provider) FanOutCommand(ctx context.Context, cmd *types.SignedCommand, stewardIDs []string) (*types.FanOutResult, error) {
 	if p.mode != ModeServer {
 		return nil, fmt.Errorf("FanOutCommand is only available in server mode")
 	}
@@ -625,7 +625,7 @@ func (p *Provider) FanOutCommand(ctx context.Context, cmd *types.Command, stewar
 	}
 
 	msg := &transportpb.ControlMessage{
-		Payload: &transportpb.ControlMessage_Command{Command: commandToProto(cmd)},
+		Payload: &transportpb.ControlMessage_Command{Command: signedCommandToProto(cmd)},
 	}
 
 	conns := p.registry.GetMany(stewardIDs)

--- a/pkg/controlplane/providers/grpc/provider.go
+++ b/pkg/controlplane/providers/grpc/provider.go
@@ -255,6 +255,9 @@ func (p *Provider) Start(ctx context.Context) error {
 
 // quicConfig returns a *quicgo.Config with any user overrides, or nil for defaults.
 func (p *Provider) quicConfig() *quicgo.Config {
+	if testQUICConfig != nil {
+		return testQUICConfig
+	}
 	if p.keepalivePeriod == 0 && p.idleTimeout == 0 {
 		return nil // use QUIC transport defaults
 	}
@@ -419,6 +422,13 @@ func (p *Provider) clientReceiveLoop() {
 // testBackoffOverride allows tests to use shorter backoff intervals.
 // Only set from test code via the unexported field.
 var testBackoffOverride *backoff
+
+// testQUICConfig allows tests to override the QUIC configuration.
+// Setting a short MaxIdleTimeout and KeepAlivePeriod ensures that
+// server failures are detected quickly on loaded CI machines even
+// when CONNECTION_CLOSE frames are delayed by goroutine scheduling.
+// Only set from test code via the unexported field.
+var testQUICConfig *quicgo.Config
 
 // reconnectLoop attempts to re-establish the ControlChannel with exponential backoff.
 // It runs until either a connection is established or the provider context is cancelled.

--- a/pkg/controlplane/providers/grpc/provider_controlchannel_identity_test.go
+++ b/pkg/controlplane/providers/grpc/provider_controlchannel_identity_test.go
@@ -283,21 +283,21 @@ func TestControlChannel_Response_MatchingStewardID(t *testing.T) {
 	env := newMultiStewardEnv(t)
 
 	cmdID := "resp-match-cmd"
-	require.NoError(t, env.clientA.SubscribeCommands(context.Background(), "steward-a", func(ctx context.Context, cmd *types.Command) error {
+	require.NoError(t, env.clientA.SubscribeCommands(context.Background(), "steward-a", func(ctx context.Context, sc *types.SignedCommand) error {
 		return env.clientA.SendResponse(ctx, &types.Response{
-			CommandID: cmd.ID,
+			CommandID: sc.Command.ID,
 			StewardID: "steward-a",
 			Success:   true,
 			Timestamp: time.Now(),
 		})
 	}))
 
-	require.NoError(t, env.server.SendCommand(context.Background(), &types.Command{
+	require.NoError(t, env.server.SendCommand(context.Background(), &types.SignedCommand{Command: types.Command{
 		ID:        cmdID,
 		Type:      types.CommandSyncConfig,
 		StewardID: "steward-a",
 		Timestamp: time.Now(),
-	}))
+	}}))
 
 	require.Eventually(t, func() bool {
 		stats, err := env.server.GetStats(context.Background())
@@ -317,21 +317,21 @@ func TestControlChannel_Response_EmptyStewardIDGetsCNStamped(t *testing.T) {
 	env := newMultiStewardEnv(t)
 
 	cmdID := "resp-empty-cmd"
-	require.NoError(t, env.clientA.SubscribeCommands(context.Background(), "steward-a", func(ctx context.Context, cmd *types.Command) error {
+	require.NoError(t, env.clientA.SubscribeCommands(context.Background(), "steward-a", func(ctx context.Context, sc *types.SignedCommand) error {
 		return env.clientA.SendResponse(ctx, &types.Response{
-			CommandID: cmd.ID,
+			CommandID: sc.Command.ID,
 			StewardID: "", // empty — should be stamped with CN before discard
 			Success:   true,
 			Timestamp: time.Now(),
 		})
 	}))
 
-	require.NoError(t, env.server.SendCommand(context.Background(), &types.Command{
+	require.NoError(t, env.server.SendCommand(context.Background(), &types.SignedCommand{Command: types.Command{
 		ID:        cmdID,
 		Type:      types.CommandSyncConfig,
 		StewardID: "steward-a",
 		Timestamp: time.Now(),
-	}))
+	}}))
 
 	// CN-stamped responses are received without mismatch
 	require.Eventually(t, func() bool {
@@ -351,21 +351,21 @@ func TestControlChannel_Response_MismatchedStewardID(t *testing.T) {
 	env := newMultiStewardEnv(t)
 
 	cmdID := "resp-mismatch-cmd"
-	require.NoError(t, env.clientA.SubscribeCommands(context.Background(), "steward-a", func(ctx context.Context, cmd *types.Command) error {
+	require.NoError(t, env.clientA.SubscribeCommands(context.Background(), "steward-a", func(ctx context.Context, sc *types.SignedCommand) error {
 		return env.clientA.SendResponse(ctx, &types.Response{
-			CommandID: cmd.ID,
+			CommandID: sc.Command.ID,
 			StewardID: "steward-b", // CN is steward-a — mismatch
 			Success:   true,
 			Timestamp: time.Now(),
 		})
 	}))
 
-	require.NoError(t, env.server.SendCommand(context.Background(), &types.Command{
+	require.NoError(t, env.server.SendCommand(context.Background(), &types.SignedCommand{Command: types.Command{
 		ID:        cmdID,
 		Type:      types.CommandSyncConfig,
 		StewardID: "steward-a",
 		Timestamp: time.Now(),
-	}))
+	}}))
 
 	require.Eventually(t, func() bool {
 		stats, err := env.server.GetStats(context.Background())

--- a/pkg/controlplane/providers/grpc/reconnect_test.go
+++ b/pkg/controlplane/providers/grpc/reconnect_test.go
@@ -84,7 +84,7 @@ func TestReconnectAfterServerRestart(t *testing.T) {
 	listenAddr := server.listener.Addr().String()
 
 	// Set up command handler before connecting — handler survives reconnection
-	received := make(chan *types.Command, 1)
+	received := make(chan *types.SignedCommand, 1)
 
 	client := New(ModeClient)
 	require.NoError(t, client.Initialize(context.Background(), map[string]interface{}{
@@ -93,8 +93,8 @@ func TestReconnectAfterServerRestart(t *testing.T) {
 		"tls_config": tc.clientTLSConfig(t, "steward-reconnect"),
 		"steward_id": "steward-reconnect",
 	}))
-	require.NoError(t, client.SubscribeCommands(context.Background(), "steward-reconnect", func(ctx context.Context, cmd *types.Command) error {
-		received <- cmd
+	require.NoError(t, client.SubscribeCommands(context.Background(), "steward-reconnect", func(ctx context.Context, sc *types.SignedCommand) error {
+		received <- sc
 		return nil
 	}))
 	require.NoError(t, client.Start(context.Background()))
@@ -129,16 +129,16 @@ func TestReconnectAfterServerRestart(t *testing.T) {
 	}, 5*time.Second, 10*time.Millisecond, "steward should be re-registered")
 
 	// Verify commands work after reconnect
-	require.NoError(t, server2.SendCommand(context.Background(), &types.Command{
+	require.NoError(t, server2.SendCommand(context.Background(), &types.SignedCommand{Command: types.Command{
 		ID:        "cmd-after-reconnect",
 		Type:      types.CommandSyncConfig,
 		StewardID: "steward-reconnect",
 		Timestamp: time.Now(),
-	}))
+	}}))
 
 	select {
 	case got := <-received:
-		assert.Equal(t, "cmd-after-reconnect", got.ID)
+		assert.Equal(t, "cmd-after-reconnect", got.Command.ID)
 	case <-time.After(5 * time.Second):
 		t.Fatal("timed out waiting for command after reconnect")
 	}

--- a/pkg/controlplane/providers/grpc/reconnect_test.go
+++ b/pkg/controlplane/providers/grpc/reconnect_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/cfgis/cfgms/pkg/controlplane/types"
 	"github.com/cfgis/cfgms/pkg/transport/registry"
+	quicgo "github.com/quic-go/quic-go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -63,6 +64,14 @@ func TestMain(m *testing.M) {
 		max:        200 * time.Millisecond,
 		multiplier: 2.0,
 		jitter:     0.1,
+	}
+	// Use short QUIC timeouts so server failures are detected quickly on loaded
+	// CI machines even when CONNECTION_CLOSE frames are delayed by goroutine
+	// scheduling under the race detector. KeepAlivePeriod keeps established
+	// connections alive; MaxIdleTimeout bounds worst-case failure detection.
+	testQUICConfig = &quicgo.Config{
+		MaxIdleTimeout:  3 * time.Second,
+		KeepAlivePeriod: 200 * time.Millisecond,
 	}
 	os.Exit(m.Run())
 }
@@ -176,11 +185,13 @@ func TestStopDuringReconnection(t *testing.T) {
 	// Kill server to trigger reconnection
 	forceStopServer(server)
 
-	// Wait for client to enter reconnecting state
+	// Wait for client to enter reconnecting state. Use 15s to accommodate
+	// loaded CI machines where goroutine scheduling under the race detector
+	// can delay QUIC disconnect propagation beyond the default 5s budget.
 	require.Eventually(t, func() bool {
 		s := client.getState()
 		return s == StateReconnecting || s == StateDisconnected
-	}, 5*time.Second, 10*time.Millisecond)
+	}, 15*time.Second, 10*time.Millisecond)
 
 	// Stop the client during reconnection — should not hang or leak goroutines
 	done := make(chan struct{})

--- a/pkg/controlplane/types/messages.go
+++ b/pkg/controlplane/types/messages.go
@@ -7,7 +7,11 @@
 package types
 
 import (
+	"encoding/json"
+	"fmt"
 	"time"
+
+	"github.com/cfgis/cfgms/features/config/signature"
 )
 
 // CommandType defines the type of command being sent.
@@ -225,6 +229,81 @@ type ConfigStatusReport struct {
 
 	// ExecutionTimeMs is how long the configuration took to apply (milliseconds)
 	ExecutionTimeMs int64 `json:"execution_time_ms,omitempty"`
+}
+
+// SignedCommand wraps a Command with a cryptographic signature for authenticated delivery.
+//
+// The Signature field contains the signature over CommandSigningBytes(Command, rawParams).
+// The inner Command stays a pure value type; the wire envelope is SignedCommand.
+// Verification happens in the steward handler before dispatch.
+type SignedCommand struct {
+	// Command is the inner command value.
+	Command Command `json:"command"`
+
+	// Signature is the cryptographic signature over CommandSigningBytes(Command, rawParams).
+	// Nil when the controller is not configured with a signer (unsecured mode).
+	Signature *signature.ConfigSignature `json:"signature,omitempty"`
+
+	// RawParams holds the proto-wire string map of Command.Params, populated only
+	// by the gRPC transport on receive. Used for signature verification to avoid
+	// round-trip type mutations from stringMapToInterfaceMap.
+	// Never transmitted on the wire or serialised to JSON.
+	RawParams map[string]string `json:"-"`
+}
+
+// commandSigningPayload is the stable canonical form used when signing/verifying commands.
+// Using map[string]string for Params avoids mutations from JSON-decoding proto string values,
+// and UTC normalisation avoids timezone-dependent JSON output.
+type commandSigningPayload struct {
+	ID        string            `json:"id"`
+	Type      CommandType       `json:"type"`
+	StewardID string            `json:"steward_id,omitempty"`
+	TenantID  string            `json:"tenant_id,omitempty"`
+	Timestamp time.Time         `json:"timestamp"`
+	Params    map[string]string `json:"params,omitempty"`
+}
+
+// InterfaceParamsToStringMap converts map[string]interface{} command params to the
+// proto-wire-stable map[string]string form. String values are stored as-is; other
+// values are JSON-encoded to strings. This is identical to what the gRPC transport
+// does in interfaceMapToStringMap, so signing with this form matches the wire form.
+func InterfaceParamsToStringMap(m map[string]interface{}) map[string]string {
+	if len(m) == 0 {
+		return nil
+	}
+	result := make(map[string]string, len(m))
+	for k, v := range m {
+		if s, ok := v.(string); ok {
+			result[k] = s
+		} else {
+			data, err := json.Marshal(v)
+			if err != nil {
+				result[k] = fmt.Sprintf("%v", v)
+			} else {
+				result[k] = string(data)
+			}
+		}
+	}
+	return result
+}
+
+// CommandSigningBytes returns the canonical JSON bytes for signing or verifying a Command.
+//
+// rawParams must be the proto-wire string map of cmd.Params — either the map produced
+// by the gRPC transport on receive (RawParams field of SignedCommand), or the result of
+// InterfaceParamsToStringMap(cmd.Params) on the originating side. Using this canonical
+// form ensures that both the signer (controller) and verifier (steward) produce identical
+// bytes regardless of JSON-decode type coercions and timezone differences.
+func CommandSigningBytes(cmd *Command, rawParams map[string]string) ([]byte, error) {
+	payload := commandSigningPayload{
+		ID:        cmd.ID,
+		Type:      cmd.Type,
+		StewardID: cmd.StewardID,
+		TenantID:  cmd.TenantID,
+		Timestamp: cmd.Timestamp.UTC(),
+		Params:    rawParams,
+	}
+	return json.Marshal(payload)
 }
 
 // FanOutResult reports per-steward delivery status from a FanOutCommand.

--- a/test/e2e/framework.go
+++ b/test/e2e/framework.go
@@ -624,11 +624,11 @@ func (f *E2ETestFramework) RegisterStewardWithController(stewardName, tenantID s
 	f.logger.Info("gRPC control plane connected", "steward_id", regResp.StewardID)
 
 	// Step 7: Subscribe to commands
-	if err := controlPlane.SubscribeCommands(f.ctx, regResp.StewardID, func(ctx context.Context, cmd *controlplaneTypes.Command) error {
+	if err := controlPlane.SubscribeCommands(f.ctx, regResp.StewardID, func(ctx context.Context, sc *controlplaneTypes.SignedCommand) error {
 		f.logger.Info("Received command",
 			"steward_id", regResp.StewardID,
-			"command_id", cmd.ID,
-			"type", string(cmd.Type))
+			"command_id", sc.Command.ID,
+			"type", string(sc.Command.Type))
 		return nil
 	}); err != nil {
 		_ = controlPlane.Stop(f.ctx)

--- a/test/e2e/scenarios_test.go
+++ b/test/e2e/scenarios_test.go
@@ -868,14 +868,14 @@ func (s *E2ETestSuite) TestTransportCommandResponse() {
 
 		// Step 2: Set up steward to respond to commands via gRPC control plane
 		commandReceived := make(chan string, 1)
-		if err := registered.ControlPlane.SubscribeCommands(context.Background(), registered.StewardID, func(ctx context.Context, cmd *controlplaneTypes.Command) error {
-			s.T().Logf("Steward received command: id=%s type=%s", cmd.ID, string(cmd.Type))
+		if err := registered.ControlPlane.SubscribeCommands(context.Background(), registered.StewardID, func(ctx context.Context, sc *controlplaneTypes.SignedCommand) error {
+			s.T().Logf("Steward received command: id=%s type=%s", sc.Command.ID, string(sc.Command.Type))
 			select {
-			case commandReceived <- cmd.ID:
+			case commandReceived <- sc.Command.ID:
 			default:
 			}
 			return registered.ControlPlane.SendResponse(ctx, &controlplaneTypes.Response{
-				CommandID: cmd.ID,
+				CommandID: sc.Command.ID,
 				StewardID: registered.StewardID,
 				Success:   true,
 				Message:   "success",


### PR DESCRIPTION
Agent session failed with exit code 1. Review container logs for details.