### PR TITLE
transport/registry: remove dead TenantPath field and add hook panic recovery (Issue #936)

### DIFF
--- a/pkg/dataplane/interfaces/provider_test.go
+++ b/pkg/dataplane/interfaces/provider_test.go
@@ -347,4 +347,3 @@ func TestSessionLifecycle(t *testing.T) {
 	require.NoError(t, err)
 	assert.True(t, session.IsClosed())
 }
-

--- a/pkg/transport/registry/connection.go
+++ b/pkg/transport/registry/connection.go
@@ -28,10 +28,6 @@ type StewardConnection struct {
 	// StewardID is the unique identifier for this steward.
 	StewardID string
 
-	// TenantPath is the tenant path for this steward (e.g. "root/msp-a/client-1").
-	// Informational only — the registry does not use this for routing.
-	TenantPath string
-
 	// Sender is the underlying transport stream.
 	Sender MessageSender
 
@@ -74,6 +70,8 @@ func (c *StewardConnection) UpdateActivity() {
 //
 // Thread-safe — acquires the internal mutex to read the timestamp
 // that is written by Send() and UpdateActivity().
+// This is a monitoring hook for future use (e.g. idle-connection reaping);
+// it is not called in production today.
 func (c *StewardConnection) GetLastActivity() time.Time {
 	c.mu.Lock()
 	defer c.mu.Unlock()

--- a/pkg/transport/registry/doc.go
+++ b/pkg/transport/registry/doc.go
@@ -25,7 +25,6 @@
 //
 //	conn := &registry.StewardConnection{
 //	    StewardID:   "steward-001",
-//	    TenantPath:  "root/msp-a/client-1",
 //	    Sender:      stream, // implements MessageSender
 //	    ConnectedAt: time.Now(),
 //	    RemoteAddr:  "10.0.0.1:50051",

--- a/pkg/transport/registry/registry.go
+++ b/pkg/transport/registry/registry.go
@@ -103,7 +103,10 @@ func (r *InMemoryRegistry) Register(conn *StewardConnection) error {
 	stewardID := conn.StewardID
 	for _, fn := range hooks {
 		fn := fn
-		go fn(stewardID)
+		go func() {
+			defer func() { recover() }() //nolint:errcheck // panic value intentionally discarded; no logger available in InMemoryRegistry yet
+			fn(stewardID)
+		}()
 	}
 
 	return nil
@@ -125,7 +128,10 @@ func (r *InMemoryRegistry) Unregister(stewardID string) {
 	if exists {
 		for _, fn := range hooks {
 			fn := fn
-			go fn(stewardID)
+			go func() {
+				defer func() { recover() }() //nolint:errcheck // panic value intentionally discarded; no logger available in InMemoryRegistry yet
+				fn(stewardID)
+			}()
 		}
 	}
 }

--- a/pkg/transport/registry/registry_test.go
+++ b/pkg/transport/registry/registry_test.go
@@ -41,7 +41,6 @@ func (m *mockSender) received() []interface{} {
 func newConn(stewardID string) *StewardConnection {
 	return &StewardConnection{
 		StewardID:   stewardID,
-		TenantPath:  "root/test",
 		Sender:      &mockSender{},
 		ConnectedAt: time.Now(),
 		RemoteAddr:  "127.0.0.1:50051",
@@ -516,5 +515,74 @@ func TestStewardConnection_NilSender(t *testing.T) {
 	err := reg.Register(conn)
 	if err == nil {
 		t.Error("Register() with nil Sender should return error, got nil")
+	}
+}
+
+// TestRegistry_HookPanicDoesNotCrashOnDisconnect verifies that a panicking OnDisconnect
+// callback does not crash the process or prevent the connection from being unregistered.
+func TestRegistry_HookPanicDoesNotCrashOnDisconnect(t *testing.T) {
+	reg := NewRegistry()
+
+	reg.OnDisconnect(func(string) {
+		panic("disconnect panic")
+	})
+
+	done := make(chan struct{}, 1)
+	reg.OnDisconnect(func(string) {
+		done <- struct{}{}
+	})
+
+	conn := newConn("steward-disconnect-panic-test")
+	if err := reg.Register(conn); err != nil {
+		t.Fatalf("Register() error = %v", err)
+	}
+	reg.Unregister("steward-disconnect-panic-test")
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("OnDisconnect callbacks did not complete within timeout")
+	}
+
+	_, ok := reg.Get("steward-disconnect-panic-test")
+	if ok {
+		t.Fatal("Get() returned true after Unregister(), want false")
+	}
+}
+
+// TestRegistry_HookPanicDoesNotCrash verifies that a panicking OnConnect callback
+// does not crash the process or prevent the connection from being registered.
+func TestRegistry_HookPanicDoesNotCrash(t *testing.T) {
+	reg := NewRegistry()
+
+	// Register a hook that panics.
+	reg.OnConnect(func(string) {
+		panic("test panic")
+	})
+
+	// Register a second hook that signals completion so we can verify the
+	// goroutine scheduler ran the hooks without crashing the test binary.
+	done := make(chan struct{}, 1)
+	reg.OnConnect(func(string) {
+		done <- struct{}{}
+	})
+
+	conn := newConn("steward-panic-test")
+	if err := reg.Register(conn); err != nil {
+		t.Fatalf("Register() error = %v", err)
+	}
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("OnConnect callbacks did not complete within timeout")
+	}
+
+	got, ok := reg.Get("steward-panic-test")
+	if !ok {
+		t.Fatal("Get() returned false after Register(), want true")
+	}
+	if got != conn {
+		t.Errorf("Get() returned wrong connection")
 	}
 }


### PR DESCRIPTION
## Summary

- Remove `StewardConnection.TenantPath` — confirmed never written at the sole production callsite (`pkg/controlplane/providers/grpc/provider.go:971-976`); zero production writes verified via grep
- Wrap hook goroutine bodies in `defer func() { recover() }()` in both `Register` and `Unregister` — a panicking callback previously crashed the process silently; recovery isolates failures to the offending hook
- Add `TestRegistry_HookPanicDoesNotCrash` (OnConnect) and `TestRegistry_HookPanicDoesNotCrashOnDisconnect` (Unregister) tests
- Update `doc.go` usage example and `newConn` test helper to remove `TenantPath`
- Add doc comment to `GetLastActivity()` noting it is a monitoring hook for future use
- Fix pre-existing gofmt trailing-blank-line in `pkg/dataplane/interfaces/provider_test.go`

## Specialist Review Results

| Reviewer | Result |
|----------|--------|
| QA Test Runner | **PASS** — all 22 registry tests pass (race detection), all cross-platform builds pass, lint clean |
| QA Code Reviewer | **PASS** — `//nolint:errcheck` directives have justification comments; both OnConnect and OnDisconnect panic recovery paths have tests |
| Security Engineer | **PASS** — no hardcoded secrets, no central provider violations, `make check-architecture` clean; panic recovery is a net security improvement (removes process-crash vector from third-party hook code) |

## Test plan

- [x] `go test ./pkg/transport/registry/... -race -count=1` — 22 tests PASS
- [x] `TestRegistry_HookPanicDoesNotCrash` — panicking OnConnect hook does not crash; connection is retrievable via `Get()`
- [x] `TestRegistry_HookPanicDoesNotCrashOnDisconnect` — panicking OnDisconnect hook does not crash; connection is removed
- [x] `grep -rn "\.TenantPath" --include="*.go" pkg/transport/ pkg/controlplane/` returns zero results
- [x] `make test-agent-complete` — all quality gates pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)