### PR TITLE
quic: harden defaultQuicConfig with DoS-resilience fields and address validation (Issue #931)

### DIFF
--- a/pkg/dataplane/interfaces/provider_test.go
+++ b/pkg/dataplane/interfaces/provider_test.go
@@ -347,4 +347,3 @@ func TestSessionLifecycle(t *testing.T) {
 	require.NoError(t, err)
 	assert.True(t, session.IsClosed())
 }
-

--- a/pkg/transport/quic/dialer.go
+++ b/pkg/transport/quic/dialer.go
@@ -21,7 +21,10 @@ import (
 // paired with grpc.WithTransportCredentials(insecure.NewCredentials()), since
 // TLS is handled at the QUIC layer.
 func Dial(ctx context.Context, addr string, tlsConfig *tls.Config, quicConfig *quicgo.Config) (net.Conn, error) {
-	quicConn, err := quicgo.DialAddr(ctx, addr, tlsConfig, mergeQuicConfig(quicConfig))
+	if quicConfig == nil {
+		quicConfig = defaultQuicConfig()
+	}
+	quicConn, err := quicgo.DialAddr(ctx, addr, tlsConfig, quicConfig)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/transport/quic/doc.go
+++ b/pkg/transport/quic/doc.go
@@ -14,7 +14,8 @@
 // One QUIC connection maps to one gRPC connection. gRPC handles its own HTTP/2
 // stream multiplexing within that single QUIC stream. This is the correct
 // mapping: each QUIC connection carries exactly one bidirectional stream, which
-// gRPC uses for its entire HTTP/2 connection lifetime.
+// gRPC uses for its entire HTTP/2 connection lifetime. MaxIncomingStreams=1 is
+// enforced by the default QUIC config to prevent stream-flood attacks.
 //
 // # Server usage
 //
@@ -38,6 +39,13 @@
 // TLS is handled entirely by the QUIC layer. Callers must provide a *tls.Config
 // with NextProtos set to a common value on both ends. gRPC should be configured
 // with insecure credentials since security is provided by the QUIC transport.
+//
+// Listen() enforces QUIC address validation (Retry) on every inbound connection
+// as an anti-amplification measure. Connections from unverified source addresses
+// are rejected via GetConfigForClient, causing quic-go to refuse the initial
+// packet. Honest clients whose address has been verified via the QUIC Retry
+// round-trip proceed normally. Callers may supply their own GetConfigForClient
+// callback to override this behaviour.
 //
 // This package contains no CFGMS business logic and may be used independently.
 package quic

--- a/pkg/transport/quic/integration_test.go
+++ b/pkg/transport/quic/integration_test.go
@@ -398,13 +398,13 @@ func TestGRPCOverQUIC_ClientDisconnect(t *testing.T) {
 	// Cancel before receiving the response.
 	cancel()
 
-	// The stream operations after cancel should return a context error.
+	// The stream operations after cancel must return a context error (Canceled or EOF).
 	var msg echoMsg
 	err = stream.RecvMsg(&msg)
 	if err != nil {
-		// Expected: context canceled or EOF.
 		t.Logf("RecvMsg after cancel returned (expected): %v", err)
 	}
+	assert.Error(t, err, "RecvMsg after context cancellation must return an error, not succeed")
 }
 
 // TestGRPCOverQUIC_TLSRequired verifies that a connection attempt with a

--- a/pkg/transport/quic/listener.go
+++ b/pkg/transport/quic/listener.go
@@ -6,6 +6,7 @@ package quic
 import (
 	"context"
 	"crypto/tls"
+	"errors"
 	"net"
 	"time"
 
@@ -32,21 +33,51 @@ import (
 //     TLS handshake timeout used by HTTP/2 clients and is still well within acceptable
 //     connection-establishment latency for a management plane.
 //
+// DoS resilience fields (Issue #931):
+//
+//   - MaxIncomingStreams 1: one bidirectional stream per QUIC connection is the design
+//     contract (see doc.go). Restricting to 1 prevents stream-flood attacks.
+//
+//   - MaxIncomingUniStreams -1: disable unidirectional streams entirely. gRPC uses only
+//     bidirectional streams, so any unidirectional stream is unexpected traffic.
+//
+//   - InitialStreamReceiveWindow 512 KB: quic-go default; set explicitly so the choice
+//     is documented and testable.
+//
+//   - InitialConnectionReceiveWindow 1 MB: with MaxIncomingStreams=1, this is effectively
+//     the same as the stream window in practice.
+//
+//   - Allow0RTT false: 0-RTT allows replay of early data, which is insecure for mTLS
+//     connections. Always disabled.
+//
+//   - DisablePathMTUDiscovery false: MTU discovery is safe and useful; set explicitly
+//     to document intent and prevent accidental regression.
+//
 // All values can be overridden by passing a custom *quic.Config to Listen/Dial.
 func defaultQuicConfig() *quicgo.Config {
 	return &quicgo.Config{
-		MaxIdleTimeout:       90 * time.Second,
-		KeepAlivePeriod:      25 * time.Second,
-		HandshakeIdleTimeout: 30 * time.Second,
+		MaxIdleTimeout:                 90 * time.Second,
+		KeepAlivePeriod:                25 * time.Second,
+		HandshakeIdleTimeout:           30 * time.Second,
+		MaxIncomingStreams:             1,
+		MaxIncomingUniStreams:          -1,
+		InitialStreamReceiveWindow:     512 * 1024,
+		InitialConnectionReceiveWindow: 1 * 1024 * 1024,
+		Allow0RTT:                      false,
+		DisablePathMTUDiscovery:        false,
 	}
 }
 
-// mergeQuicConfig returns cfg if non-nil, otherwise returns the default config.
-func mergeQuicConfig(cfg *quicgo.Config) *quicgo.Config {
-	if cfg != nil {
-		return cfg
+// requireAddressValidation is a GetConfigForClient callback that rejects any
+// connection whose source address has not been verified via QUIC's Retry mechanism.
+// It is defense-in-depth: Listen() also sets Transport.VerifySourceAddress so that
+// the Retry round-trip always completes before this callback is invoked, ensuring
+// that AddrVerified is true for every legitimate connection that reaches this gate.
+func requireAddressValidation(info *quicgo.ClientInfo) (*quicgo.Config, error) {
+	if !info.AddrVerified {
+		return nil, errors.New("quic: address validation required")
 	}
-	return defaultQuicConfig()
+	return nil, nil
 }
 
 // Listener wraps a QUIC listener to implement net.Listener.
@@ -56,6 +87,8 @@ func mergeQuicConfig(cfg *quicgo.Config) *quicgo.Config {
 // multiplexing within that stream.
 type Listener struct {
 	ql     *quicgo.Listener
+	tr     *quicgo.Transport // non-nil: Listen() owns this transport's UDP socket
+	cfg    *quicgo.Config    // effective config after Listen() injection
 	ctx    context.Context
 	cancel context.CancelFunc
 }
@@ -67,16 +100,52 @@ var _ net.Listener = (*Listener)(nil)
 //
 // tlsConfig must have NextProtos set to a value agreed with the client.
 // If quicConfig is nil, sensible defaults (MaxIdleTimeout: 90s,
-// KeepAlivePeriod: 25s, HandshakeIdleTimeout: 30s) are used. See defaultQuicConfig for rationale.
+// KeepAlivePeriod: 25s, HandshakeIdleTimeout: 30s, MaxIncomingStreams: 1,
+// and other DoS-resilience fields) are used. See defaultQuicConfig for rationale.
+//
+// Listen enforces QUIC address validation (Retry) on every inbound connection
+// as an anti-amplification measure. The Transport's VerifySourceAddress triggers a
+// Retry round-trip for every first-attempt connection; GetConfigForClient =
+// requireAddressValidation then gates the now-verified connection. Caller-provided
+// GetConfigForClient callbacks are preserved unchanged.
 func Listen(addr string, tlsConfig *tls.Config, quicConfig *quicgo.Config) (*Listener, error) {
-	ql, err := quicgo.ListenAddr(addr, tlsConfig, mergeQuicConfig(quicConfig))
+	if quicConfig == nil {
+		quicConfig = defaultQuicConfig()
+	}
+	// Shallow copy to avoid mutating the caller's config pointer in-place.
+	cfgCopy := *quicConfig
+	quicConfig = &cfgCopy
+	if quicConfig.GetConfigForClient == nil {
+		quicConfig.GetConfigForClient = requireAddressValidation
+	}
+
+	udpAddr, err := net.ResolveUDPAddr("udp", addr)
 	if err != nil {
+		return nil, err
+	}
+	udpConn, err := net.ListenUDP("udp", udpAddr)
+	if err != nil {
+		return nil, err
+	}
+	// VerifySourceAddress triggers a QUIC Retry for every first-attempt
+	// connection. Honest clients respond to the Retry token automatically
+	// via quic-go's built-in handling. IP-spoofed senders cannot complete
+	// the round-trip, so they are silently dropped after the Retry.
+	tr := &quicgo.Transport{
+		Conn:                udpConn,
+		VerifySourceAddress: func(net.Addr) bool { return true },
+	}
+	ql, err := tr.Listen(tlsConfig, quicConfig)
+	if err != nil {
+		_ = udpConn.Close()
 		return nil, err
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
 	return &Listener{
 		ql:     ql,
+		tr:     tr,
+		cfg:    quicConfig,
 		ctx:    ctx,
 		cancel: cancel,
 	}, nil
@@ -106,7 +175,16 @@ func (l *Listener) Accept() (net.Conn, error) {
 // Close stops the listener. Any blocked Accept call will return with an error.
 func (l *Listener) Close() error {
 	l.cancel()
-	return l.ql.Close()
+	err := l.ql.Close()
+	if l.tr != nil {
+		_ = l.tr.Close()
+		// Transport.Close with createdConn=false does not close the underlying UDP
+		// socket; close it explicitly to release the file descriptor.
+		if cerr := l.tr.Conn.Close(); cerr != nil && err == nil {
+			err = cerr
+		}
+	}
+	return err
 }
 
 // Addr returns the listener's network address.

--- a/pkg/transport/quic/listener_test.go
+++ b/pkg/transport/quic/listener_test.go
@@ -8,14 +8,10 @@ import (
 	"testing"
 	"time"
 
+	quicgo "github.com/quic-go/quic-go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
-
-// TestListener_ImplementsNetListener verifies the compile-time interface contract.
-func TestListener_ImplementsNetListener(t *testing.T) {
-	var _ net.Listener = (*Listener)(nil)
-}
 
 // TestDefaultQuicConfig_TunedValues guards the intentional tuning decisions in
 // defaultQuicConfig so that future refactors cannot silently regress them.
@@ -82,6 +78,129 @@ func TestListener_AcceptAndClose(t *testing.T) {
 	}
 
 	require.NoError(t, lis.Close())
+}
+
+// TestDefaultQuicConfig_Fields verifies all DoS-resilience field values set by
+// defaultQuicConfig so that future refactors cannot silently regress them.
+func TestDefaultQuicConfig_Fields(t *testing.T) {
+	cfg := defaultQuicConfig()
+
+	assert.Equal(t, int64(1), cfg.MaxIncomingStreams,
+		"MaxIncomingStreams: one bidirectional stream per QUIC connection is the design contract (doc.go:17)")
+	assert.Equal(t, int64(-1), cfg.MaxIncomingUniStreams,
+		"MaxIncomingUniStreams: gRPC uses only bidirectional streams; unidirectional must be disabled")
+	assert.Equal(t, uint64(512*1024), cfg.InitialStreamReceiveWindow,
+		"InitialStreamReceiveWindow: 512 KB explicit default; set to document and protect the choice")
+	assert.Equal(t, uint64(1*1024*1024), cfg.InitialConnectionReceiveWindow,
+		"InitialConnectionReceiveWindow: 1 MB; with MaxIncomingStreams=1 effectively same as stream window")
+	assert.False(t, cfg.Allow0RTT,
+		"Allow0RTT: false; 0-RTT allows replay of early data, insecure for mTLS connections")
+	assert.False(t, cfg.DisablePathMTUDiscovery,
+		"DisablePathMTUDiscovery: false; MTU discovery is safe and useful, set explicitly to document intent")
+}
+
+// TestRequireAddressValidation verifies that requireAddressValidation allows verified
+// addresses and rejects unverified ones.
+func TestRequireAddressValidation(t *testing.T) {
+	verified := &quicgo.ClientInfo{AddrVerified: true}
+	cfg, err := requireAddressValidation(verified)
+	assert.Nil(t, cfg, "verified address: config override should be nil (use server defaults)")
+	assert.NoError(t, err, "verified address must be allowed")
+
+	unverified := &quicgo.ClientInfo{AddrVerified: false}
+	cfg, err = requireAddressValidation(unverified)
+	assert.Nil(t, cfg, "unverified address: config override should be nil")
+	assert.Error(t, err, "unverified address must be rejected")
+}
+
+// TestListen_RequiresAddressValidation verifies that address validation is configured
+// on every listener and that honest clients are not blocked.
+func TestListen_RequiresAddressValidation(t *testing.T) {
+	// This test verifies Retry transparency: honest clients respond to Retry
+	// tokens automatically via quic-go's built-in handling. It does NOT test
+	// adversarial IP-spoofing rejection, which requires a crafted UDP packet
+	// outside the scope of unit testing.
+
+	tlsPair := newTestTLSPair(t)
+
+	lis, err := Listen("127.0.0.1:0", tlsPair.server, nil)
+	require.NoError(t, err)
+	defer func() { _ = lis.Close() }()
+
+	// (1) GetConfigForClient must be non-nil on the effective listener config.
+	require.NotNil(t, lis.cfg, "effective QUIC config must be stored on the listener")
+	assert.NotNil(t, lis.cfg.GetConfigForClient,
+		"GetConfigForClient must be injected by Listen() for address validation")
+
+	// (2) A normal Dial+Listen round-trip must succeed: honest clients are not blocked.
+	acceptCh := make(chan error, 1)
+	go func() {
+		conn, aerr := lis.Accept()
+		if aerr == nil {
+			_ = conn.Close()
+		}
+		acceptCh <- aerr
+	}()
+
+	clientConn, err := Dial(t.Context(), lis.Addr().String(), tlsPair.client, nil)
+	require.NoError(t, err, "honest client must connect successfully despite address validation")
+	defer func() { _ = clientConn.Close() }()
+
+	_, err = clientConn.Write([]byte{0x00})
+	require.NoError(t, err)
+
+	select {
+	case aerr := <-acceptCh:
+		require.NoError(t, aerr, "honest client must not be blocked by address validation")
+	case <-time.After(10 * time.Second):
+		t.Fatal("timed out waiting for Accept — honest client may have been blocked")
+	}
+}
+
+// TestListen_PreservesCallerGetConfigForClient verifies that Listen() does not
+// overwrite a caller-provided GetConfigForClient callback.
+func TestListen_PreservesCallerGetConfigForClient(t *testing.T) {
+	tlsPair := newTestTLSPair(t)
+
+	customCalled := false
+	customCallback := func(info *quicgo.ClientInfo) (*quicgo.Config, error) {
+		customCalled = true
+		return nil, nil
+	}
+
+	customCfg := &quicgo.Config{
+		GetConfigForClient: customCallback,
+	}
+
+	lis, err := Listen("127.0.0.1:0", tlsPair.server, customCfg)
+	require.NoError(t, err)
+	defer func() { _ = lis.Close() }()
+
+	// The caller's GetConfigForClient must be preserved, not overwritten.
+	assert.NotNil(t, lis.cfg.GetConfigForClient, "GetConfigForClient must remain non-nil")
+
+	// Verify it's the caller's callback (not requireAddressValidation) by calling it.
+	_, _ = lis.cfg.GetConfigForClient(&quicgo.ClientInfo{AddrVerified: true})
+	assert.True(t, customCalled, "Listen() must not overwrite a caller-provided GetConfigForClient")
+}
+
+// TestListen_DoesNotMutateCallerConfig verifies that Listen() does not modify
+// the caller's *quicgo.Config pointer in-place.
+func TestListen_DoesNotMutateCallerConfig(t *testing.T) {
+	tlsPair := newTestTLSPair(t)
+
+	callerCfg := &quicgo.Config{
+		MaxIdleTimeout: 60 * time.Second,
+		// GetConfigForClient is intentionally nil to verify Listen() doesn't set it on the caller's struct.
+	}
+
+	lis, err := Listen("127.0.0.1:0", tlsPair.server, callerCfg)
+	require.NoError(t, err)
+	defer func() { _ = lis.Close() }()
+
+	// Listen() must inject GetConfigForClient only on its internal copy, not on the caller's struct.
+	assert.Nil(t, callerCfg.GetConfigForClient,
+		"Listen() must not mutate the caller's *quicgo.Config in-place")
 }
 
 // TestListener_CloseUnblocksAccept verifies that Close causes a blocked Accept

--- a/pkg/transport/quic/tls_test.go
+++ b/pkg/transport/quic/tls_test.go
@@ -366,11 +366,9 @@ func TestGRPCOverQUIC_mTLS_NoCert(t *testing.T) {
 	defer func() { _ = conn.Close() }()
 
 	// Write data to trigger the server to process our (absent) certificate.
+	// The server sends certificate_required (CRYPTO_ERROR 0x174); the 3-second
+	// read deadline is sufficient for the alert to arrive without a sleep.
 	_, _ = conn.Write([]byte{0x00})
-
-	// The server sends certificate_required (CRYPTO_ERROR 0x174). Give the
-	// server a moment to send the alert before reading.
-	time.Sleep(100 * time.Millisecond)
 	require.NoError(t, conn.SetReadDeadline(time.Now().Add(3*time.Second)))
 	buf := make([]byte, 1)
 	_, readErr := conn.Read(buf)
@@ -426,8 +424,8 @@ func TestGRPCOverQUIC_mTLS_WrongCA(t *testing.T) {
 	}
 	defer func() { _ = conn.Close() }()
 
+	// Write to trigger server-side cert processing; alert arrives within the read deadline.
 	_, _ = conn.Write([]byte{0x00})
-	time.Sleep(100 * time.Millisecond)
 	require.NoError(t, conn.SetReadDeadline(time.Now().Add(3*time.Second)))
 	buf := make([]byte, 1)
 	_, readErr := conn.Read(buf)


### PR DESCRIPTION
## Summary

- **6 DoS-resilience fields** added to `defaultQuicConfig()`: `MaxIncomingStreams=1` (stream-flood prevention), `MaxIncomingUniStreams=-1` (no unidirectional streams), `InitialStreamReceiveWindow=512KB`, `InitialConnectionReceiveWindow=1MB`, `Allow0RTT=false` (no replay for mTLS), `DisablePathMTUDiscovery=false`
- **QUIC address validation** enforced in `Listen()` via `Transport.VerifySourceAddress=always-true` (triggers Retry round-trip for every first-attempt connection) + `GetConfigForClient=requireAddressValidation` (defense-in-depth gate that rejects any connection where `AddrVerified=false`). Honest clients complete transparently; IP-spoofed senders cannot complete the round-trip.
- **`mergeQuicConfig()` removed**; nil-check inlined at both call sites (`Listen`, `Dial`)
- **Pre-existing test quality fixes** in `pkg/transport/quic`: removed vacuous `TestListener_ImplementsNetListener`, added missing assertion to `TestGRPCOverQUIC_ClientDisconnect`, replaced `time.Sleep` synchronization with read deadline in mTLS negative tests

## Implementation note: GetConfigForClient + VerifySourceAddress

The issue specifies `GetConfigForClient` as the v0.59.0 mechanism for address validation. Investigation of the quic-go v0.59.0 source confirmed that returning an error from `GetConfigForClient` sends `CONNECTION_REFUSED` (not a Retry). To actually trigger Retry (so `AddrVerified` is `true` when `GetConfigForClient` is called), `Transport.VerifySourceAddress` must be set. Both are now configured: `VerifySourceAddress` is the primary Retry trigger; `requireAddressValidation` is defense-in-depth.

## Test plan

- [ ] `TestDefaultQuicConfig_Fields` — asserts all 6 new field values
- [ ] `TestRequireAddressValidation` — asserts both branches (verified/unverified)
- [ ] `TestListen_RequiresAddressValidation` — verifies `GetConfigForClient` is non-nil and a normal Dial+Listen round-trip succeeds (Retry transparency)
- [ ] `TestListen_PreservesCallerGetConfigForClient` — caller callback is not overwritten
- [ ] `TestListen_DoesNotMutateCallerConfig` — shallow copy verified
- [ ] All existing tests pass (35 tests in `pkg/transport/quic`)

## Specialist review results

- **QA Test Runner**: PASS — all OSS+commercial unit tests, lint, license, cross-platform builds (Trivy skipped: container network restriction, not a code defect)
- **QA Code Reviewer**: PASS — all new tests have real assertions, no mocks, no t.Skip() abuse
- **Security Engineer**: PASS — no hardcoded secrets, no information disclosure, no central provider violations, gosec/staticcheck clean

Fixes #931

🤖 Generated with [Claude Code](https://claude.com/claude-code)