### PR TITLE
features/steward: encrypt offline queue at rest, load certs on-demand (Issue #920)

### DIFF
--- a/cmd/steward/main.go
+++ b/cmd/steward/main.go
@@ -10,6 +10,7 @@ import (
 	"log"
 	"os"
 	"os/signal"
+	"path/filepath"
 	"strings"
 	"syscall"
 	"time"
@@ -19,7 +20,9 @@ import (
 	"github.com/cfgis/cfgms/features/steward/client"
 	stewardconfig "github.com/cfgis/cfgms/features/steward/config"
 	"github.com/cfgis/cfgms/features/steward/registration"
+	"github.com/cfgis/cfgms/pkg/cert"
 	"github.com/cfgis/cfgms/pkg/logging"
+	secretsif "github.com/cfgis/cfgms/pkg/secrets/interfaces"
 	"github.com/cfgis/cfgms/pkg/version"
 	"github.com/spf13/cobra"
 
@@ -504,13 +507,18 @@ func registerAndConnect(ctx context.Context, token string, logger logging.Logger
 		commandMaxParamsBytes = cfg.Steward.SignedCommandMaxParamsBytes
 	}
 
+	// Build cert.Manager and SecretStore for on-demand TLS cert loading and
+	// offline queue encryption (Issue #920).
+	certMgr, secretStore := buildCertManagerAndSecretStore(regResp.ClientCert, regResp.ClientKey, logger)
+
 	transportClient, err := client.NewTransportClient(&client.TransportConfig{
 		ControllerURL:               regResp.TransportAddress,
 		RegistrationToken:           token,
 		CACertPEM:                   regResp.CACert,
 		ClientCertPEM:               regResp.ClientCert,
-		ClientKeyPEM:                regResp.ClientKey,
 		ServerCertPEM:               regResp.ServerCert,
+		CertManager:                 certMgr,
+		SecretStore:                 secretStore,
 		SignedCommandReplayWindow:   commandReplayWindow,
 		SignedCommandMaxParamsBytes: commandMaxParamsBytes,
 		Logger:                      logger,
@@ -540,4 +548,66 @@ func registerAndConnect(ctx context.Context, token string, logger logging.Logger
 	logger.Info("Configuration executor initialized", "tenant_id", regResp.TenantID)
 
 	return transportClient, nil
+}
+
+// buildCertManagerAndSecretStore initialises a cert.Manager (holding the
+// steward's client certificate for on-demand TLS loading) and a SecretStore
+// (for offline queue encryption key persistence). Both are best-effort — a nil
+// return from either does not prevent the steward from connecting, it just
+// disables the respective feature.
+func buildCertManagerAndSecretStore(clientCertPEM, clientKeyPEM string, logger logging.Logger) (*cert.Manager, secretsif.SecretStore) {
+	// ── SecretStore ──────────────────────────────────────────────────────────
+	var secretStore secretsif.SecretStore
+	secretsProvider, err := secretsif.GetSecretProvider("steward")
+	if err == nil {
+		if store, storeErr := secretsProvider.CreateSecretStore(map[string]interface{}{}); storeErr == nil {
+			secretStore = store
+		} else {
+			logger.Warn("Failed to create steward secret store; offline-queue key will not persist", "error", storeErr)
+		}
+	} else {
+		logger.Warn("Steward secrets provider unavailable; offline-queue key will not persist", "error", err)
+	}
+
+	// ── cert.Manager ─────────────────────────────────────────────────────────
+	if clientCertPEM == "" || clientKeyPEM == "" {
+		return nil, secretStore
+	}
+
+	certStorePath := filepath.Join(os.TempDir(), "cfgms-steward", "certs")
+	if dataDir := os.Getenv("CFGMS_DATA_DIR"); dataDir != "" {
+		certStorePath = filepath.Join(dataDir, "certs")
+	}
+
+	// Try to load an existing local CA (created on a previous run).
+	certMgr, mgrErr := cert.NewManager(&cert.ManagerConfig{
+		StoragePath:    certStorePath,
+		LoadExistingCA: true,
+	})
+	if mgrErr != nil {
+		// First run — create a local CA used only as a cert store.
+		certMgr, mgrErr = cert.NewManager(&cert.ManagerConfig{
+			StoragePath:    certStorePath,
+			LoadExistingCA: false,
+			CAConfig: &cert.CAConfig{
+				Organization: "CFGMS Steward",
+				Country:      "US",
+				ValidityDays: 3650,
+			},
+		})
+		if mgrErr != nil {
+			logger.Warn("Failed to create cert.Manager; on-demand TLS cert loading disabled", "error", mgrErr)
+			return nil, secretStore
+		}
+	}
+
+	// Import the client cert+key from the registration response.
+	if _, impErr := certMgr.ImportCertificate(
+		[]byte(clientCertPEM), []byte(clientKeyPEM), cert.CertificateTypeClient,
+	); impErr != nil {
+		logger.Warn("Failed to import client certificate into cert.Manager", "error", impErr)
+		return nil, secretStore
+	}
+
+	return certMgr, secretStore
 }

--- a/features/steward/SECURITY.md
+++ b/features/steward/SECURITY.md
@@ -56,3 +56,52 @@ When no `Verifier` is configured (e.g. in development or testing), signature ver
 - `pkg/controlplane/types/messages.go` — `SignedCommand` and `CommandSigningBytes` definitions
 - `features/steward/commands/handler.go` — verification implementation
 - `features/steward/commands/replay_cache.go` — bounded TTL deduplication cache
+
+---
+
+# Offline Queue Encryption
+
+Implemented in Story #920. The offline event queue file is encrypted at rest with AES-256-GCM.
+
+## Encryption Scheme
+
+- **Algorithm**: AES-256-GCM (AEAD — provides both confidentiality and authenticity)
+- **File**: `offline_queue.enc` (replaces legacy `offline_queue.json`)
+- **On-disk format**: `[12-byte random nonce][ciphertext + 16-byte GCM authentication tag]`
+- **Key source**: `pkg/secrets` slot `steward/offline-queue-key` (32 random bytes)
+- **Key generation**: If the slot is absent, 32 random bytes are generated via `crypto/rand` and persisted to the SecretStore on first run
+- **Authentication**: GCM's 128-bit authentication tag covers the entire ciphertext — tampering causes load failure with a clear authentication error
+
+## Key Management
+
+The encryption key is stored in the steward's SecretStore (OS-native encryption via the `steward` provider: DPAPI on Windows, AES-256-GCM on Linux/macOS). This provides defence-in-depth: the queue file is encrypted with a key that is itself encrypted by the OS.
+
+When no SecretStore is available (e.g., first boot), a per-session random key is generated. In this case the queue is not persisted across restarts (key is in-memory only).
+
+## Legacy File Handling
+
+On startup, any pre-920 plaintext `offline_queue.json` file found in the queue directory is deleted (cannot be decrypted). An `Info`-level log is emitted and the queue starts fresh.
+
+---
+
+# On-Demand Certificate Loading
+
+Implemented in Story #920. The steward's TLS client certificate is now loaded per-handshake rather than cached in memory at connection time.
+
+## Mechanism
+
+- `TransportConfig.CertManager` accepts a `*cert.Manager` at construction
+- When a `CertManager` is provided, `tls.Config.GetClientCertificate` is set to a closure that calls `certManager.GetClientCertificate(ctx)` on every TLS handshake
+- `cert.Manager.GetClientCertificate` reads the newest `CertificateTypeClient` entry from the certificate store and returns a `tls.Certificate` with both leaf and private key
+- If the renewer has rotated the certificate, the next handshake automatically uses the new cert — no restart required
+
+## Benefits
+
+- Certificate rotation is transparent to running stewards
+- The raw private key PEM (`clientKeyPEM`) is no longer cached in `TransportClient` memory — the key lives only in the cert store and in the transient `tls.Certificate` returned per handshake
+
+## References
+
+- `pkg/cert/manager.go` — `GetClientCertificate` implementation
+- `features/steward/client/client_transport.go` — `createTLSConfig` closure wiring
+- `cmd/steward/main.go` — `buildCertManagerAndSecretStore` initialisation

--- a/features/steward/client/client_transport.go
+++ b/features/steward/client/client_transport.go
@@ -36,6 +36,7 @@ import (
 	_ "github.com/cfgis/cfgms/pkg/dataplane/providers/grpc" // Register gRPC data plane provider
 	dpTypes "github.com/cfgis/cfgms/pkg/dataplane/types"
 	"github.com/cfgis/cfgms/pkg/logging"
+	secretsif "github.com/cfgis/cfgms/pkg/secrets/interfaces"
 	quictransport "github.com/cfgis/cfgms/pkg/transport/quic"
 )
 
@@ -63,19 +64,18 @@ type TransportClient struct {
 
 	// Certificate PEMs (from registration response)
 	caCertPEM      string
-	clientCertPEM  string
-	clientKeyPEM   string
 	serverCertPEM  string // Controller's server cert for config signature verification (Story #315)
 	signingCertPEM string // Story #377: Dedicated signing cert (preferred over serverCertPEM)
+
+	// certManager provides on-demand client certificate loading per TLS handshake (Issue #920).
+	// When non-nil, GetClientCertificate is used instead of static PEM certs.
+	certManager *cert.Manager
 
 	// Command handler
 	commandHandler *commands.Handler
 
 	// Configuration executor (unified engine — same as standalone mode)
 	configExecutor *execution.Executor
-
-	// Configuration signature verifier
-	configVerifier signature.Verifier
 
 	// Command authentication settings (Story #919)
 	commandReplayWindow   time.Duration
@@ -129,9 +129,6 @@ type TransportConfig struct {
 	// ClientCertPEM is the client certificate PEM (for mTLS)
 	ClientCertPEM string
 
-	// ClientKeyPEM is the client private key PEM (for mTLS)
-	ClientKeyPEM string
-
 	// ServerCertPEM is the controller's server certificate PEM (for config signature verification)
 	// Story #315: Used to verify configurations signed by the controller
 	ServerCertPEM string
@@ -166,6 +163,16 @@ type TransportConfig struct {
 	// Zero means the commands.Handler default (65536 bytes) applies.
 	SignedCommandMaxParamsBytes int
 
+	// CertManager provides on-demand client certificate loading for TLS handshakes
+	// (Issue #920). When non-nil, GetClientCertificate is used per handshake so
+	// certificate rotations are picked up automatically. When nil the client falls
+	// back to disk-path or environment-variable certificate loading.
+	CertManager *cert.Manager
+
+	// SecretStore is used by the offline queue to persist its AES-256-GCM
+	// encryption key across restarts (Issue #920). May be nil.
+	SecretStore secretsif.SecretStore
+
 	// Logger for client logging
 	Logger logging.Logger
 }
@@ -185,11 +192,13 @@ func NewTransportClient(cfg *TransportConfig) (*TransportClient, error) {
 	}
 
 	// Initialize offline queue for durable report persistence (Issue #419).
+	// Pass the SecretStore so the encryption key is persisted across restarts (Issue #920).
 	offlineQueue, err := NewOfflineQueue(OfflineQueueConfig{
-		Dir:     cfg.QueueDir,
-		MaxSize: cfg.MaxQueueSize,
-		MaxAge:  cfg.MaxQueueAge,
-		Logger:  cfg.Logger,
+		Dir:         cfg.QueueDir,
+		MaxSize:     cfg.MaxQueueSize,
+		MaxAge:      cfg.MaxQueueAge,
+		SecretStore: cfg.SecretStore,
+		Logger:      cfg.Logger,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize offline queue: %w", err)
@@ -203,10 +212,9 @@ func NewTransportClient(cfg *TransportConfig) (*TransportClient, error) {
 		transportAddress:      cfg.ControllerURL,
 		certPath:              cfg.TLSCertPath,
 		caCertPEM:             cfg.CACertPEM,
-		clientCertPEM:         cfg.ClientCertPEM,
-		clientKeyPEM:          cfg.ClientKeyPEM,
 		serverCertPEM:         cfg.ServerCertPEM,
 		signingCertPEM:        cfg.SigningCertPEM,
+		certManager:           cfg.CertManager,
 		offlineQueue:          offlineQueue,
 		commandReplayWindow:   cfg.SignedCommandReplayWindow,
 		commandMaxParamsBytes: cfg.SignedCommandMaxParamsBytes,
@@ -380,12 +388,9 @@ func (c *TransportClient) setupCommandHandler(ctx context.Context, stewardID str
 		}
 	}
 
-	// Create command handler with the same verifier used for config signature
-	// verification (Story #919). Replay window and params limit come from the
-	// steward config (via TransportConfig); zero values use handler defaults.
-	c.mu.RLock()
-	verifier := c.configVerifier
-	c.mu.RUnlock()
+	// Build the verifier on demand from the stored signing/server cert PEMs.
+	// Not cached — Issue #920 removes the configVerifier field.
+	verifier := c.buildVerifierOnDemand()
 
 	handler, err := commands.New(&commands.Config{
 		StewardID:      stewardID,
@@ -435,10 +440,8 @@ func (c *TransportClient) setupCommandHandler(ctx context.Context, stewardID str
 			return fmt.Errorf("failed to unmarshal protobuf config: %w", err)
 		}
 
-		// Verify configuration signature
-		c.mu.RLock()
-		verifier := c.configVerifier
-		c.mu.RUnlock()
+		// Verify configuration signature — verifier obtained on demand (Issue #920).
+		verifier := c.buildVerifierOnDemand()
 
 		var unsignedProtoConfig *controller.StewardConfig
 		if verifier != nil {
@@ -949,26 +952,41 @@ func (c *TransportClient) SetTenantID(id string) {
 
 // createTLSConfig creates a TLS configuration for gRPC-over-QUIC with mTLS.
 // Sets ALPN to "cfgms-grpc" required by the QUIC transport layer.
-// Sources: PEM certs from registration (preferred), disk path, or environment variables.
+//
+// Source priority (Issue #920):
+//  1. certManager path: GetClientCertificate callback (on-demand per handshake)
+//  2. Disk path (TLSCertPath): static cert loaded from files
+//  3. Environment variables: CFGMS_TLS_CERT_PATH / KEY / CA
 func (c *TransportClient) createTLSConfig() (*tls.Config, error) {
 	c.mu.RLock()
 	caCertPEMStr := c.caCertPEM
-	clientCertPEMStr := c.clientCertPEM
-	clientKeyPEMStr := c.clientKeyPEM
 	certPath := c.certPath
+	certMgr := c.certManager
 	c.mu.RUnlock()
 
-	var caCertPEM, clientCertPEM, clientKeyPEM []byte
+	var tlsConfig *tls.Config
+	var caCertPEM []byte // used for CA pool and verifier fallback
 	var err error
 
-	if caCertPEMStr != "" && clientCertPEMStr != "" && clientKeyPEMStr != "" {
-		// Primary path: PEM certs from HTTP registration response
-		c.logger.Info("Using TLS certificates from registration response")
-		caCertPEM = []byte(caCertPEMStr)
-		clientCertPEM = []byte(clientCertPEMStr)
-		clientKeyPEM = []byte(clientKeyPEMStr)
-	} else if certPath != "" {
-		// Secondary path: certificates on disk
+	if certMgr != nil {
+		// Primary path (Issue #920): on-demand client cert per TLS handshake.
+		c.logger.Info("Using on-demand TLS certificate loading via CertManager")
+		if caCertPEMStr != "" {
+			caCertPEM = []byte(caCertPEMStr)
+		}
+		tlsConfig, err = certMgr.CreateOnDemandClientTLSConfig(caCertPEM, tls.VersionTLS13)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create on-demand TLS config: %w", err)
+		}
+		tlsConfig.NextProtos = []string{quictransport.ALPNProtocol}
+		return tlsConfig, nil
+	}
+
+	// Fallback paths: build TLS config from static cert files.
+	var clientCertPEM, clientKeyPEM []byte
+
+	if certPath != "" {
+		// Secondary path: certificates on disk.
 		caCertPath := filepath.Join(certPath, "ca.crt")
 		// #nosec G304 - Certificate paths are controlled via configuration
 		caCertPEM, err = os.ReadFile(caCertPath)
@@ -991,13 +1009,13 @@ func (c *TransportClient) createTLSConfig() (*tls.Config, error) {
 
 		c.logger.Info("Loaded TLS configuration from disk", "cert_path", certPath)
 	} else {
-		// Tertiary path: environment variables
+		// Tertiary path: environment variables.
 		certFile := os.Getenv("CFGMS_TLS_CERT_PATH")
 		keyFile := os.Getenv("CFGMS_TLS_KEY_PATH")
 		caFile := os.Getenv("CFGMS_TLS_CA_PATH")
 
 		if certFile == "" || keyFile == "" || caFile == "" {
-			// No TLS config available — provider will connect without mTLS
+			// No TLS config available — provider will connect without mTLS.
 			return nil, nil
 		}
 
@@ -1020,66 +1038,70 @@ func (c *TransportClient) createTLSConfig() (*tls.Config, error) {
 		c.logger.Info("Loaded TLS configuration from environment variables")
 	}
 
-	tlsConfig, err := cert.CreateClientTLSConfig(clientCertPEM, clientKeyPEM, caCertPEM, "", tls.VersionTLS13)
+	tlsConfig, err = cert.CreateClientTLSConfig(clientCertPEM, clientKeyPEM, caCertPEM, "", tls.VersionTLS13)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create TLS config: %w", err)
 	}
 
-	// gRPC-over-QUIC requires the cfgms-grpc ALPN protocol
+	// gRPC-over-QUIC requires the cfgms-grpc ALPN protocol.
 	tlsConfig.NextProtos = []string{quictransport.ALPNProtocol}
 
-	// Initialize configuration signature verifier using controller's certificate.
-	// Story #377: Prefer dedicated signing cert over server cert.
-	c.mu.Lock()
-	if c.configVerifier == nil {
-		var serverCertPEM []byte
-
-		if c.signingCertPEM != "" {
-			serverCertPEM = []byte(c.signingCertPEM)
-			c.logger.Info("Using dedicated signing certificate for signature verification")
-		} else if c.serverCertPEM != "" {
-			serverCertPEM = []byte(c.serverCertPEM)
-			c.logger.Info("Using server certificate from registration for signature verification")
-		} else if certPath != "" {
-			// Story #377: Try signing.crt first, fall back to server.crt
-			signingCertPath := filepath.Join(certPath, "signing.crt")
-			serverCertPath := filepath.Join(certPath, "server.crt")
-
-			// #nosec G304 - Certificate paths are controlled via configuration
-			var readErr error
-			serverCertPEM, readErr = os.ReadFile(signingCertPath)
-			if readErr != nil {
-				// Fall back to server.crt
-				// #nosec G304 - Certificate paths are controlled via configuration
-				serverCertPEM, readErr = os.ReadFile(serverCertPath)
-				if readErr != nil {
-					c.logger.Warn("Failed to load signing/server certificate for signature verification, using CA")
-					serverCertPEM = caCertPEM
-				}
-			} else {
-				c.logger.Info("Using signing.crt from disk for signature verification")
-			}
-		} else {
-			c.logger.Warn("No server certificate available, using CA for signature verification")
-			serverCertPEM = caCertPEM
-		}
-
-		if len(serverCertPEM) > 0 {
-			verifier, verErr := signature.NewVerifier(&signature.VerifierConfig{
-				CertificatePEM: serverCertPEM,
-			})
-			if verErr != nil {
-				c.logger.Warn("Failed to create configuration verifier", "error", verErr)
-			} else {
-				c.configVerifier = verifier
-				c.logger.Info("Configuration signature verifier initialized",
-					"key_fingerprint", verifier.KeyFingerprint())
-			}
-		}
-	}
-	c.mu.Unlock()
-
 	return tlsConfig, nil
+}
+
+// buildVerifierOnDemand constructs a config/command signature verifier from the
+// controller's certificate PEMs stored in the client. Returns nil when no
+// certificate is available — callers treat a nil verifier as "skip verification".
+//
+// The verifier is NOT cached (Issue #920 removes the configVerifier field).
+// The cost is trivial — each call parses a PEM block and builds a verifier struct.
+func (c *TransportClient) buildVerifierOnDemand() signature.Verifier {
+	c.mu.RLock()
+	signingCertPEM := c.signingCertPEM
+	serverCertPEM := c.serverCertPEM
+	caCertPEM := c.caCertPEM
+	certPath := c.certPath
+	c.mu.RUnlock()
+
+	var certPEM []byte
+
+	switch {
+	case signingCertPEM != "":
+		certPEM = []byte(signingCertPEM)
+		c.logger.Info("Using dedicated signing certificate for signature verification")
+	case serverCertPEM != "":
+		certPEM = []byte(serverCertPEM)
+		c.logger.Info("Using server certificate for signature verification")
+	case certPath != "":
+		// Story #377: prefer signing.crt, fall back to server.crt.
+		signingPath := filepath.Join(certPath, "signing.crt")
+		serverPath := filepath.Join(certPath, "server.crt")
+		// #nosec G304 - Certificate paths are controlled via configuration
+		if raw, err := os.ReadFile(signingPath); err == nil {
+			certPEM = raw
+			c.logger.Info("Using signing.crt from disk for signature verification")
+		} else if raw, err := os.ReadFile(serverPath); err == nil {
+			certPEM = raw
+		} else if caCertPEM != "" {
+			certPEM = []byte(caCertPEM)
+			c.logger.Warn("Signing/server certificate not found; falling back to CA for signature verification")
+		}
+	case caCertPEM != "":
+		certPEM = []byte(caCertPEM)
+		c.logger.Warn("No server certificate available; using CA for signature verification")
+	}
+
+	if len(certPEM) == 0 {
+		return nil
+	}
+
+	verifier, err := signature.NewVerifier(&signature.VerifierConfig{CertificatePEM: certPEM})
+	if err != nil {
+		c.logger.Warn("Failed to create configuration verifier", "error", err)
+		return nil
+	}
+	c.logger.Info("Configuration signature verifier built", "key_fingerprint", verifier.KeyFingerprint())
+	return verifier
 }
 
 // publishEventWithQueue attempts to publish an event via the control plane.

--- a/features/steward/client/client_transport_test.go
+++ b/features/steward/client/client_transport_test.go
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+// Package client provides tests for the transport client.
+// Issue #920: on-demand cert loading via certManager.GetClientCertificate.
+package client
+
+import (
+	"context"
+	"crypto/tls"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// countingCertManager is a minimal stand-in for cert.Manager that counts how
+// many times GetClientCertificate is called and returns distinct certs on each
+// call. It embeds a counter so the test can assert re-fetch behaviour.
+type countingCertManager struct {
+	calls atomic.Int64
+	certs []*tls.Certificate // indexed by call count (modulo len)
+}
+
+func (m *countingCertManager) GetClientCertificate(_ context.Context) (*tls.Certificate, error) {
+	n := m.calls.Add(1)
+	idx := int(n-1) % len(m.certs)
+	return m.certs[idx], nil
+}
+
+// getCertManagerGetFunc returns the GetClientCertificate function for the given
+// countingCertManager, matching the signature expected by tls.Config.GetClientCertificate.
+func getCertManagerGetFunc(m *countingCertManager) func(*tls.CertificateRequestInfo) (*tls.Certificate, error) {
+	return func(_ *tls.CertificateRequestInfo) (*tls.Certificate, error) {
+		return m.GetClientCertificate(context.Background())
+	}
+}
+
+// TestTransportClient_CertReloadOnHandshake verifies that the tls.Config
+// GetClientCertificate callback re-calls certManager.GetClientCertificate on
+// each handshake. This directly validates the closure wired in createTLSConfig.
+func TestTransportClient_CertReloadOnHandshake(t *testing.T) {
+	// Two distinct (but syntactically valid-enough-for-test) TLS certs.
+	cert1 := &tls.Certificate{Certificate: [][]byte{[]byte("cert-bytes-1")}}
+	cert2 := &tls.Certificate{Certificate: [][]byte{[]byte("cert-bytes-2")}}
+
+	mgr := &countingCertManager{certs: []*tls.Certificate{cert1, cert2}}
+
+	// Wire the closure the same way createTLSConfig does.
+	fn := getCertManagerGetFunc(mgr)
+
+	// First simulated handshake.
+	got1, err := fn(nil)
+	require.NoError(t, err)
+	assert.Equal(t, cert1, got1, "first handshake must return cert1")
+
+	// Second simulated handshake — must call GetClientCertificate again.
+	got2, err := fn(nil)
+	require.NoError(t, err)
+	assert.Equal(t, cert2, got2, "second handshake must return cert2 (re-fetch)")
+
+	assert.Equal(t, int64(2), mgr.calls.Load(), "GetClientCertificate must be called once per handshake")
+}
+
+// TestTransportClient_CertNotCached verifies that the certManager is queried
+// on each invocation, not a cached value.
+func TestTransportClient_CertNotCached(t *testing.T) {
+	cert := &tls.Certificate{Certificate: [][]byte{[]byte("only-cert")}}
+	mgr := &countingCertManager{certs: []*tls.Certificate{cert}}
+	fn := getCertManagerGetFunc(mgr)
+
+	const iterations = 5
+	for i := 0; i < iterations; i++ {
+		_, err := fn(nil)
+		require.NoError(t, err)
+	}
+
+	assert.Equal(t, int64(iterations), mgr.calls.Load(),
+		"certManager must be called on every handshake, not just once")
+}

--- a/features/steward/client/client_transport_test.go
+++ b/features/steward/client/client_transport_test.go
@@ -5,76 +5,108 @@
 package client
 
 import (
-	"context"
-	"crypto/tls"
-	"sync/atomic"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/cfgis/cfgms/pkg/cert"
+	"github.com/cfgis/cfgms/pkg/logging"
 )
 
-// countingCertManager is a minimal stand-in for cert.Manager that counts how
-// many times GetClientCertificate is called and returns distinct certs on each
-// call. It embeds a counter so the test can assert re-fetch behaviour.
-type countingCertManager struct {
-	calls atomic.Int64
-	certs []*tls.Certificate // indexed by call count (modulo len)
-}
-
-func (m *countingCertManager) GetClientCertificate(_ context.Context) (*tls.Certificate, error) {
-	n := m.calls.Add(1)
-	idx := int(n-1) % len(m.certs)
-	return m.certs[idx], nil
-}
-
-// getCertManagerGetFunc returns the GetClientCertificate function for the given
-// countingCertManager, matching the signature expected by tls.Config.GetClientCertificate.
-func getCertManagerGetFunc(m *countingCertManager) func(*tls.CertificateRequestInfo) (*tls.Certificate, error) {
-	return func(_ *tls.CertificateRequestInfo) (*tls.Certificate, error) {
-		return m.GetClientCertificate(context.Background())
-	}
-}
-
-// TestTransportClient_CertReloadOnHandshake verifies that the tls.Config
-// GetClientCertificate callback re-calls certManager.GetClientCertificate on
-// each handshake. This directly validates the closure wired in createTLSConfig.
+// TestTransportClient_CertReloadOnHandshake verifies that createTLSConfig wires
+// GetClientCertificate as a per-handshake callback (not a cached value) so that
+// certificate rotations are picked up automatically.
 func TestTransportClient_CertReloadOnHandshake(t *testing.T) {
-	// Two distinct (but syntactically valid-enough-for-test) TLS certs.
-	cert1 := &tls.Certificate{Certificate: [][]byte{[]byte("cert-bytes-1")}}
-	cert2 := &tls.Certificate{Certificate: [][]byte{[]byte("cert-bytes-2")}}
-
-	mgr := &countingCertManager{certs: []*tls.Certificate{cert1, cert2}}
-
-	// Wire the closure the same way createTLSConfig does.
-	fn := getCertManagerGetFunc(mgr)
-
-	// First simulated handshake.
-	got1, err := fn(nil)
+	dir := t.TempDir()
+	mgr, err := cert.NewManager(&cert.ManagerConfig{
+		StoragePath: dir,
+		CAConfig: &cert.CAConfig{
+			Organization: "Test Org",
+			Country:      "US",
+			ValidityDays: 365,
+		},
+	})
 	require.NoError(t, err)
-	assert.Equal(t, cert1, got1, "first handshake must return cert1")
 
-	// Second simulated handshake — must call GetClientCertificate again.
-	got2, err := fn(nil)
+	// Generate the initial client certificate.
+	_, err = mgr.GenerateClientCertificate(&cert.ClientCertConfig{
+		CommonName:   "steward-test-001",
+		ValidityDays: 365,
+	})
 	require.NoError(t, err)
-	assert.Equal(t, cert2, got2, "second handshake must return cert2 (re-fetch)")
 
-	assert.Equal(t, int64(2), mgr.calls.Load(), "GetClientCertificate must be called once per handshake")
-}
-
-// TestTransportClient_CertNotCached verifies that the certManager is queried
-// on each invocation, not a cached value.
-func TestTransportClient_CertNotCached(t *testing.T) {
-	cert := &tls.Certificate{Certificate: [][]byte{[]byte("only-cert")}}
-	mgr := &countingCertManager{certs: []*tls.Certificate{cert}}
-	fn := getCertManagerGetFunc(mgr)
-
-	const iterations = 5
-	for i := 0; i < iterations; i++ {
-		_, err := fn(nil)
-		require.NoError(t, err)
+	// Wire a TransportClient with the real cert.Manager.
+	c := &TransportClient{
+		certManager: mgr,
+		logger:      logging.NewLogger("info"),
 	}
 
-	assert.Equal(t, int64(iterations), mgr.calls.Load(),
-		"certManager must be called on every handshake, not just once")
+	tlsCfg, err := c.createTLSConfig()
+	require.NoError(t, err)
+	require.NotNil(t, tlsCfg)
+	require.NotNil(t, tlsCfg.GetClientCertificate, "createTLSConfig must set GetClientCertificate")
+
+	// First handshake — returns the initial cert.
+	got1, err := tlsCfg.GetClientCertificate(nil)
+	require.NoError(t, err)
+	require.NotNil(t, got1)
+	require.NotEmpty(t, got1.Certificate, "first handshake must return a non-empty cert")
+
+	// Simulate rotation: generate a replacement client cert.
+	_, err = mgr.GenerateClientCertificate(&cert.ClientCertConfig{
+		CommonName:   "steward-test-001-renewed",
+		ValidityDays: 365,
+	})
+	require.NoError(t, err)
+
+	// Second handshake — must return the rotated cert (re-fetched from store, not cached).
+	got2, err := tlsCfg.GetClientCertificate(nil)
+	require.NoError(t, err)
+	require.NotNil(t, got2)
+	require.NotEmpty(t, got2.Certificate, "second handshake must return a non-empty cert")
+
+	// The leaf DER bytes differ between the original and rotated certs.
+	assert.NotEqual(t, got1.Certificate[0], got2.Certificate[0],
+		"second handshake must return the newer cert after rotation (re-fetch, not cached)")
+}
+
+// TestTransportClient_CertNotCached verifies that every call to the
+// GetClientCertificate callback reads from the cert store rather than a cached
+// value — even when the certificate has not changed.
+func TestTransportClient_CertNotCached(t *testing.T) {
+	dir := t.TempDir()
+	mgr, err := cert.NewManager(&cert.ManagerConfig{
+		StoragePath: dir,
+		CAConfig: &cert.CAConfig{
+			Organization: "Test Org",
+			Country:      "US",
+			ValidityDays: 365,
+		},
+	})
+	require.NoError(t, err)
+
+	_, err = mgr.GenerateClientCertificate(&cert.ClientCertConfig{
+		CommonName:   "steward-test-002",
+		ValidityDays: 365,
+	})
+	require.NoError(t, err)
+
+	c := &TransportClient{
+		certManager: mgr,
+		logger:      logging.NewLogger("info"),
+	}
+
+	tlsCfg, err := c.createTLSConfig()
+	require.NoError(t, err)
+	require.NotNil(t, tlsCfg)
+
+	// Multiple calls must each succeed (no caching failure, no stale state).
+	const iterations = 3
+	for i := 0; i < iterations; i++ {
+		got, err := tlsCfg.GetClientCertificate(nil)
+		require.NoError(t, err, "call %d must not return an error", i+1)
+		require.NotNil(t, got, "call %d must return a non-nil cert", i+1)
+		require.NotEmpty(t, got.Certificate, "call %d must return non-empty cert bytes", i+1)
+	}
 }

--- a/features/steward/client/offline_queue.go
+++ b/features/steward/client/offline_queue.go
@@ -4,10 +4,18 @@
 //
 // Issue #419: when the controller is unreachable, reports are queued locally
 // and delivered in order once connectivity is restored.
+// Issue #920: queue file is encrypted at rest with AES-256-GCM.
 package client
 
 import (
+	"context"
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"encoding/hex"
 	"encoding/json"
+	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"sync"
@@ -15,7 +23,11 @@ import (
 
 	cpTypes "github.com/cfgis/cfgms/pkg/controlplane/types"
 	"github.com/cfgis/cfgms/pkg/logging"
+	secretsif "github.com/cfgis/cfgms/pkg/secrets/interfaces"
 )
+
+// offlineQueueKeySlot is the secrets slot used to persist the AES-256 encryption key.
+const offlineQueueKeySlot = "steward/offline-queue-key"
 
 // OfflineQueueConfig configures the offline report queue.
 type OfflineQueueConfig struct {
@@ -32,6 +44,10 @@ type OfflineQueueConfig struct {
 	// MaxAge is the maximum time an event is retained before being discarded.
 	// Defaults to 24 hours.
 	MaxAge time.Duration
+
+	// SecretStore is used to persist the AES-256-GCM encryption key.
+	// If nil, a per-session random key is generated (not persisted across restarts).
+	SecretStore secretsif.SecretStore
 
 	// Logger receives diagnostic messages. May be nil.
 	Logger logging.Logger
@@ -52,11 +68,12 @@ type QueuedEvent struct {
 //
 // Thread-safe: all public methods can be called from multiple goroutines.
 type OfflineQueue struct {
-	mu      sync.Mutex
-	entries []*QueuedEvent
-	seenIDs map[string]struct{}
-	config  OfflineQueueConfig
-	seq     int64
+	mu            sync.Mutex
+	entries       []*QueuedEvent
+	seenIDs       map[string]struct{}
+	config        OfflineQueueConfig
+	seq           int64
+	encryptionKey []byte // 32-byte AES-256 key; nil only when Dir is empty
 }
 
 // queueState is the on-disk format.
@@ -81,6 +98,12 @@ func NewOfflineQueue(cfg OfflineQueueConfig) (*OfflineQueue, error) {
 	}
 
 	if cfg.Dir != "" {
+		key, err := q.loadOrGenerateKey(cfg.SecretStore)
+		if err != nil {
+			return nil, fmt.Errorf("failed to initialise offline-queue encryption key: %w", err)
+		}
+		q.encryptionKey = key
+
 		if err := q.load(); err != nil {
 			if cfg.Logger != nil {
 				cfg.Logger.Warn("Failed to load offline queue from disk, starting empty",
@@ -90,6 +113,45 @@ func NewOfflineQueue(cfg OfflineQueueConfig) (*OfflineQueue, error) {
 	}
 
 	return q, nil
+}
+
+// loadOrGenerateKey retrieves the AES-256 encryption key from the SecretStore,
+// generating and persisting 32 random bytes if the slot is absent.
+func (q *OfflineQueue) loadOrGenerateKey(store secretsif.SecretStore) ([]byte, error) {
+	ctx := context.Background()
+
+	if store != nil {
+		secret, err := store.GetSecret(ctx, offlineQueueKeySlot)
+		if err == nil && secret != nil && len(secret.Value) > 0 {
+			key, decErr := hex.DecodeString(secret.Value)
+			if decErr == nil && len(key) == 32 {
+				return key, nil
+			}
+		}
+	}
+
+	// Generate a fresh 32-byte key.
+	key := make([]byte, 32)
+	if _, err := io.ReadFull(rand.Reader, key); err != nil {
+		return nil, fmt.Errorf("failed to generate encryption key: %w", err)
+	}
+
+	if store != nil {
+		if storeErr := store.StoreSecret(ctx, &secretsif.SecretRequest{
+			Key:         offlineQueueKeySlot,
+			Value:       hex.EncodeToString(key),
+			Description: "AES-256-GCM key for offline event queue encryption",
+			CreatedBy:   "steward",
+		}); storeErr != nil {
+			// Key persists in memory only this session; queue contents are lost on restart.
+			if q.config.Logger != nil {
+				q.config.Logger.Warn("Failed to persist offline queue encryption key — queue will not survive restart",
+					map[string]interface{}{"error": storeErr.Error()})
+			}
+		}
+	}
+
+	return key, nil
 }
 
 // Enqueue adds an event to the queue. Returns true if the event was accepted,
@@ -201,12 +263,13 @@ func (q *OfflineQueue) evictExpiredLocked() {
 	q.entries = valid
 }
 
-// queueFilePath returns the path of the persistence file.
+// queueFilePath returns the path of the encrypted persistence file.
 func (q *OfflineQueue) queueFilePath() string {
-	return filepath.Join(q.config.Dir, "offline_queue.json")
+	return filepath.Join(q.config.Dir, "offline_queue.enc")
 }
 
-// saveLocked writes the current queue state to disk atomically.
+// saveLocked writes the current queue state to disk atomically, encrypted with
+// AES-256-GCM. Format: [12-byte nonce][ciphertext + 16-byte GCM auth tag].
 // Must be called with q.mu held.
 // A no-op when Dir is empty (in-memory mode).
 func (q *OfflineQueue) saveLocked() error {
@@ -218,27 +281,44 @@ func (q *OfflineQueue) saveLocked() error {
 		return err
 	}
 
-	state := &queueState{
-		Entries: q.entries,
-		NextSeq: q.seq,
-	}
-	data, err := json.Marshal(state)
+	data, err := json.Marshal(&queueState{Entries: q.entries, NextSeq: q.seq})
 	if err != nil {
 		return err
 	}
 
+	block, err := aes.NewCipher(q.encryptionKey)
+	if err != nil {
+		return fmt.Errorf("failed to create AES cipher: %w", err)
+	}
+	aead, err := cipher.NewGCM(block)
+	if err != nil {
+		return fmt.Errorf("failed to create GCM: %w", err)
+	}
+
+	nonce := make([]byte, aead.NonceSize())
+	if _, err := io.ReadFull(rand.Reader, nonce); err != nil {
+		return fmt.Errorf("failed to generate nonce: %w", err)
+	}
+	ciphertext := aead.Seal(nil, nonce, data, nil)
+	payload := append(nonce, ciphertext...) // nonce prepended for decrypt
+
 	// Atomic write: write to .tmp then rename so readers never see partial state.
 	tmpPath := q.queueFilePath() + ".tmp"
-	if err := os.WriteFile(tmpPath, data, 0600); err != nil {
+	if err := os.WriteFile(tmpPath, payload, 0600); err != nil {
 		return err
 	}
 	return os.Rename(tmpPath, q.queueFilePath())
 }
 
-// load reads persisted queue state from disk, filtering out expired entries.
-// Called once from NewOfflineQueue before the queue is used by any goroutine,
-// so no locking is required.
+// load reads and decrypts persisted queue state from disk, filtering out expired
+// entries. Called once from NewOfflineQueue before the queue is used by any
+// goroutine, so no locking is required.
+//
+// Legacy plaintext offline_queue.json files are deleted on startup with an
+// Info log — they cannot be decrypted and are treated as stale.
 func (q *OfflineQueue) load() error {
+	q.deleteLegacyPlaintextFile()
+
 	data, err := os.ReadFile(q.queueFilePath())
 	if os.IsNotExist(err) {
 		return nil // No file yet — start with an empty queue.
@@ -247,9 +327,30 @@ func (q *OfflineQueue) load() error {
 		return err
 	}
 
+	block, err := aes.NewCipher(q.encryptionKey)
+	if err != nil {
+		return fmt.Errorf("failed to create AES cipher for decryption: %w", err)
+	}
+	aead, err := cipher.NewGCM(block)
+	if err != nil {
+		return fmt.Errorf("failed to create GCM for decryption: %w", err)
+	}
+
+	nonceSize := aead.NonceSize()
+	if len(data) < nonceSize {
+		return fmt.Errorf("encrypted queue file is too short (len=%d)", len(data))
+	}
+	nonce, ciphertext := data[:nonceSize], data[nonceSize:]
+
+	plaintext, err := aead.Open(nil, nonce, ciphertext, nil)
+	if err != nil {
+		// Authentication failure — file is corrupted or tampered with.
+		return fmt.Errorf("failed to decrypt queue file (authentication failure): %w", err)
+	}
+
 	var state queueState
-	if err := json.Unmarshal(data, &state); err != nil {
-		return err
+	if err := json.Unmarshal(plaintext, &state); err != nil {
+		return fmt.Errorf("failed to unmarshal queue state: %w", err)
 	}
 
 	now := time.Now()
@@ -267,4 +368,19 @@ func (q *OfflineQueue) load() error {
 	}
 
 	return nil
+}
+
+// deleteLegacyPlaintextFile removes the pre-920 plaintext offline_queue.json if
+// present. It cannot be decrypted so we discard it and start fresh.
+func (q *OfflineQueue) deleteLegacyPlaintextFile() {
+	legacyPath := filepath.Join(q.config.Dir, "offline_queue.json")
+	if _, err := os.Stat(legacyPath); os.IsNotExist(err) {
+		return
+	}
+	if err := os.Remove(legacyPath); err == nil {
+		if q.config.Logger != nil {
+			q.config.Logger.Info("Deleted legacy plaintext offline queue file; starting fresh with encrypted queue",
+				"path", legacyPath)
+		}
+	}
 }

--- a/features/steward/client/offline_queue_test.go
+++ b/features/steward/client/offline_queue_test.go
@@ -2,13 +2,17 @@
 // Copyright 2026 Jordan Ritz
 // Package client provides tests for offline report queueing.
 // Issue #419: steward queues reports locally when controller is unreachable.
+// Issue #920: queue file is encrypted at rest with AES-256-GCM.
 package client
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"os"
 	"path/filepath"
+	"sync"
 	"testing"
 	"time"
 
@@ -18,6 +22,7 @@ import (
 	controlplaneInterfaces "github.com/cfgis/cfgms/pkg/controlplane/interfaces"
 	cpTypes "github.com/cfgis/cfgms/pkg/controlplane/types"
 	"github.com/cfgis/cfgms/pkg/logging"
+	secretsif "github.com/cfgis/cfgms/pkg/secrets/interfaces"
 )
 
 // ---------------------------------------------------------------------------
@@ -170,9 +175,11 @@ func TestOfflineQueue_DrainEmptyQueue(t *testing.T) {
 
 func TestOfflineQueue_PersistenceAcrossRestart(t *testing.T) {
 	dir := t.TempDir()
+	// Shared SecretStore so the encryption key persists across simulated restarts.
+	store := newInMemorySecretStore()
 
 	// First instance — enqueue three events.
-	q1, err := NewOfflineQueue(OfflineQueueConfig{Dir: dir, MaxSize: 10, MaxAge: time.Hour})
+	q1, err := NewOfflineQueue(OfflineQueueConfig{Dir: dir, MaxSize: 10, MaxAge: time.Hour, SecretStore: store})
 	require.NoError(t, err)
 	q1.Enqueue(makeTestEvent("evt-001", cpTypes.EventConfigApplied))
 	q1.Enqueue(makeTestEvent("evt-002", cpTypes.EventDNAChanged))
@@ -180,7 +187,7 @@ func TestOfflineQueue_PersistenceAcrossRestart(t *testing.T) {
 	assert.Equal(t, 3, q1.Len())
 
 	// Second instance simulates a restart from the same directory.
-	q2, err := NewOfflineQueue(OfflineQueueConfig{Dir: dir, MaxSize: 10, MaxAge: time.Hour})
+	q2, err := NewOfflineQueue(OfflineQueueConfig{Dir: dir, MaxSize: 10, MaxAge: time.Hour, SecretStore: store})
 	require.NoError(t, err)
 	assert.Equal(t, 3, q2.Len(), "events must survive restart")
 
@@ -194,8 +201,9 @@ func TestOfflineQueue_PersistenceAcrossRestart(t *testing.T) {
 
 func TestOfflineQueue_PersistencePartialDrainThenRestart(t *testing.T) {
 	dir := t.TempDir()
+	store := newInMemorySecretStore()
 
-	q1, err := NewOfflineQueue(OfflineQueueConfig{Dir: dir, MaxSize: 10, MaxAge: time.Hour})
+	q1, err := NewOfflineQueue(OfflineQueueConfig{Dir: dir, MaxSize: 10, MaxAge: time.Hour, SecretStore: store})
 	require.NoError(t, err)
 	for i := 1; i <= 4; i++ {
 		q1.Enqueue(makeTestEvent(fmt.Sprintf("evt-%03d", i), cpTypes.EventConfigApplied))
@@ -213,7 +221,7 @@ func TestOfflineQueue_PersistencePartialDrainThenRestart(t *testing.T) {
 	assert.Equal(t, 2, q1.Len())
 
 	// Restart: only the remaining 2 events should be present.
-	q2, err := NewOfflineQueue(OfflineQueueConfig{Dir: dir, MaxSize: 10, MaxAge: time.Hour})
+	q2, err := NewOfflineQueue(OfflineQueueConfig{Dir: dir, MaxSize: 10, MaxAge: time.Hour, SecretStore: store})
 	require.NoError(t, err)
 	assert.Equal(t, 2, q2.Len())
 
@@ -356,8 +364,8 @@ func TestOfflineQueue_QueueFileAtomicWrite(t *testing.T) {
 	q.Enqueue(makeTestEvent("evt-001", cpTypes.EventConfigApplied))
 
 	// The .tmp file must not exist after enqueue (atomic rename completed).
-	assert.FileExists(t, filepath.Join(dir, "offline_queue.json"))
-	assert.NoFileExists(t, filepath.Join(dir, "offline_queue.json.tmp"),
+	assert.FileExists(t, filepath.Join(dir, "offline_queue.enc"))
+	assert.NoFileExists(t, filepath.Join(dir, "offline_queue.enc.tmp"),
 		".tmp file must be cleaned up after atomic rename")
 }
 
@@ -510,4 +518,201 @@ func TestPublishEventWithQueue_DrainedOnReconnect(t *testing.T) {
 	assert.Len(t, cp.published, 2, "both queued events must be published")
 	assert.Equal(t, "queued-001", cp.published[0].ID, "events delivered in order")
 	assert.Equal(t, "queued-002", cp.published[1].ID, "events delivered in order")
+}
+
+// ---------------------------------------------------------------------------
+// Issue #920: Encryption tests
+// ---------------------------------------------------------------------------
+
+// inMemorySecretStore is a minimal SecretStore for testing that holds secrets in memory.
+type inMemorySecretStore struct {
+	mu      sync.Mutex
+	secrets map[string]string
+}
+
+func newInMemorySecretStore() *inMemorySecretStore {
+	return &inMemorySecretStore{secrets: make(map[string]string)}
+}
+
+func (s *inMemorySecretStore) StoreSecret(_ context.Context, req *secretsif.SecretRequest) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.secrets[req.Key] = req.Value
+	return nil
+}
+
+func (s *inMemorySecretStore) GetSecret(_ context.Context, key string) (*secretsif.Secret, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	v, ok := s.secrets[key]
+	if !ok {
+		return nil, secretsif.ErrSecretNotFound
+	}
+	return &secretsif.Secret{Key: key, Value: v}, nil
+}
+
+func (s *inMemorySecretStore) DeleteSecret(_ context.Context, _ string) error { return nil }
+func (s *inMemorySecretStore) ListSecrets(_ context.Context, _ *secretsif.SecretFilter) ([]*secretsif.SecretMetadata, error) {
+	return nil, nil
+}
+func (s *inMemorySecretStore) GetSecrets(_ context.Context, _ []string) (map[string]*secretsif.Secret, error) {
+	return nil, nil
+}
+func (s *inMemorySecretStore) StoreSecrets(_ context.Context, _ map[string]*secretsif.SecretRequest) error {
+	return nil
+}
+func (s *inMemorySecretStore) GetSecretVersion(_ context.Context, _ string, _ int) (*secretsif.Secret, error) {
+	return nil, nil
+}
+func (s *inMemorySecretStore) ListSecretVersions(_ context.Context, _ string) ([]*secretsif.SecretVersion, error) {
+	return nil, nil
+}
+func (s *inMemorySecretStore) GetSecretMetadata(_ context.Context, _ string) (*secretsif.SecretMetadata, error) {
+	return nil, nil
+}
+func (s *inMemorySecretStore) UpdateSecretMetadata(_ context.Context, _ string, _ map[string]string) error {
+	return nil
+}
+func (s *inMemorySecretStore) RotateSecret(_ context.Context, _ string, _ string) error {
+	return nil
+}
+func (s *inMemorySecretStore) ExpireSecret(_ context.Context, _ string) error { return nil }
+func (s *inMemorySecretStore) HealthCheck(_ context.Context) error            { return nil }
+func (s *inMemorySecretStore) Close() error                                   { return nil }
+
+// TestOfflineQueue_EncryptionRoundTrip verifies that enqueued events survive a
+// restart (load → decrypt → check) when a SecretStore is provided.
+func TestOfflineQueue_EncryptionRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	store := newInMemorySecretStore()
+
+	q1, err := NewOfflineQueue(OfflineQueueConfig{
+		Dir: dir, MaxSize: 10, MaxAge: time.Hour, SecretStore: store,
+	})
+	require.NoError(t, err)
+
+	q1.Enqueue(makeTestEvent("enc-001", cpTypes.EventConfigApplied))
+	q1.Enqueue(makeTestEvent("enc-002", cpTypes.EventDNAChanged))
+	require.Equal(t, 2, q1.Len())
+
+	// Verify the on-disk file exists and is NOT valid JSON (it's encrypted).
+	raw, err := os.ReadFile(filepath.Join(dir, "offline_queue.enc"))
+	require.NoError(t, err)
+	var js interface{}
+	assert.Error(t, json.Unmarshal(raw, &js), "file must not be plaintext JSON")
+
+	// Reload from the same directory and secret store.
+	q2, err := NewOfflineQueue(OfflineQueueConfig{
+		Dir: dir, MaxSize: 10, MaxAge: time.Hour, SecretStore: store,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 2, q2.Len(), "events must survive encrypted restart")
+
+	var ids []string
+	q2.Drain(func(e *cpTypes.Event) error {
+		ids = append(ids, e.ID)
+		return nil
+	})
+	assert.Equal(t, []string{"enc-001", "enc-002"}, ids, "events must be in insertion order")
+}
+
+// TestOfflineQueue_TamperDetection verifies that mutating the encrypted file
+// causes load to return an authentication error (GCM tag mismatch).
+func TestOfflineQueue_TamperDetection(t *testing.T) {
+	dir := t.TempDir()
+	store := newInMemorySecretStore()
+
+	q, err := NewOfflineQueue(OfflineQueueConfig{
+		Dir: dir, MaxSize: 10, MaxAge: time.Hour, SecretStore: store,
+	})
+	require.NoError(t, err)
+	q.Enqueue(makeTestEvent("tamper-001", cpTypes.EventConfigApplied))
+
+	// Flip a byte in the middle of the ciphertext to simulate tampering.
+	encPath := filepath.Join(dir, "offline_queue.enc")
+	data, err := os.ReadFile(encPath)
+	require.NoError(t, err)
+	require.True(t, len(data) > 20, "encrypted file must have enough bytes to tamper")
+	data[len(data)/2] ^= 0xFF
+	require.NoError(t, os.WriteFile(encPath, data, 0600))
+
+	// Loading must fail with an authentication/decryption error.
+	q2 := &OfflineQueue{
+		seenIDs:       make(map[string]struct{}),
+		config:        OfflineQueueConfig{Dir: dir},
+		encryptionKey: q.encryptionKey, // same key
+	}
+	err = q2.load()
+	assert.Error(t, err, "tampered file must cause a decryption error")
+	assert.Contains(t, err.Error(), "authentication failure",
+		"error must mention authentication failure")
+}
+
+// TestOfflineQueue_LegacyPlaintextDeletion verifies that a pre-920 plaintext
+// offline_queue.json is deleted at startup and an Info log is emitted.
+func TestOfflineQueue_LegacyPlaintextDeletion(t *testing.T) {
+	dir := t.TempDir()
+	legacyPath := filepath.Join(dir, "offline_queue.json")
+
+	// Write a fake plaintext file.
+	require.NoError(t, os.WriteFile(legacyPath, []byte(`{"entries":[],"next_seq":0}`), 0600))
+	assert.FileExists(t, legacyPath)
+
+	logger := logging.NewLogger("debug")
+	store := newInMemorySecretStore()
+
+	_, err := NewOfflineQueue(OfflineQueueConfig{
+		Dir: dir, MaxSize: 10, MaxAge: time.Hour,
+		SecretStore: store, Logger: logger,
+	})
+	require.NoError(t, err)
+
+	// Legacy file must be gone.
+	assert.NoFileExists(t, legacyPath, "legacy plaintext file must be deleted at startup")
+}
+
+// TestOfflineQueue_ConcurrentDrainSeenIDs verifies that concurrent Drain and
+// Enqueue calls do not corrupt seenIDs. Run with -race.
+func TestOfflineQueue_ConcurrentDrainSeenIDs(t *testing.T) {
+	q, err := NewOfflineQueue(OfflineQueueConfig{
+		MaxSize: 500,
+		MaxAge:  time.Hour,
+	})
+	require.NoError(t, err)
+
+	const enqueues = 200
+	var wg sync.WaitGroup
+
+	// Multiple concurrent producers.
+	for p := 0; p < 4; p++ {
+		p := p
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < enqueues/4; i++ {
+				id := fmt.Sprintf("p%d-evt-%04d", p, i)
+				q.Enqueue(makeTestEvent(id, cpTypes.EventConfigApplied))
+			}
+		}()
+	}
+
+	// Concurrent consumer.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < enqueues; i++ {
+			q.Drain(func(e *cpTypes.Event) error { return nil })
+		}
+	}()
+
+	wg.Wait()
+
+	// Final drain to catch any stragglers.
+	q.Drain(func(e *cpTypes.Event) error { return nil })
+
+	// seenIDs must be consistent with entries.
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	assert.Equal(t, len(q.entries), len(q.seenIDs),
+		"seenIDs count must match entries count after concurrent operations")
 }

--- a/pkg/cert/manager.go
+++ b/pkg/cert/manager.go
@@ -43,6 +43,8 @@
 package cert
 
 import (
+	"context"
+	"crypto/tls"
 	"fmt"
 	"path/filepath"
 )
@@ -532,6 +534,35 @@ type ManagerStats struct {
 	RenewalCandidates    int
 	CertificatesByType   map[CertificateType]int
 	CAInfo               *CertificateInfo
+}
+
+// GetClientCertificate returns the latest steward client certificate for TLS handshakes.
+// Each call reads the current certificate from the store so cert rotations are picked
+// up automatically — no explicit notification needed.
+func (m *Manager) GetClientCertificate(_ context.Context) (*tls.Certificate, error) {
+	clientCerts, err := m.store.GetCertificatesByType(CertificateTypeClient)
+	if err != nil {
+		return nil, fmt.Errorf("failed to retrieve client certificates: %w", err)
+	}
+	if len(clientCerts) == 0 {
+		return nil, fmt.Errorf("no client certificate found in store")
+	}
+
+	// GetCertificatesByType returns newest-first.
+	certInfo := clientCerts[0]
+	c, err := m.store.GetCertificate(certInfo.SerialNumber)
+	if err != nil {
+		return nil, fmt.Errorf("failed to retrieve client certificate data: %w", err)
+	}
+	if len(c.CertificatePEM) == 0 || len(c.PrivateKeyPEM) == 0 {
+		return nil, fmt.Errorf("client certificate or private key is missing from store")
+	}
+
+	tlsCert, err := tls.X509KeyPair(c.CertificatePEM, c.PrivateKeyPEM)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load client certificate key pair: %w", err)
+	}
+	return &tlsCert, nil
 }
 
 // GetStoragePath returns the certificate storage path

--- a/pkg/cert/manager_test.go
+++ b/pkg/cert/manager_test.go
@@ -3,6 +3,7 @@
 package cert
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -467,4 +468,53 @@ func TestManager_SaveCertificateFiles(t *testing.T) {
 	savedKeyPEM, err := os.ReadFile(keyPath)
 	require.NoError(t, err)
 	assert.Equal(t, cert.PrivateKeyPEM, savedKeyPEM)
+}
+
+func TestManager_GetClientCertificate(t *testing.T) {
+	tempDir := t.TempDir()
+	manager, err := NewManager(&ManagerConfig{
+		StoragePath: tempDir,
+		CAConfig: &CAConfig{
+			Organization: "Test",
+			Country:      "US",
+			ValidityDays: 365,
+		},
+	})
+	require.NoError(t, err)
+
+	ctx := context.Background()
+
+	// No client cert in store yet — must return an error.
+	_, err = manager.GetClientCertificate(ctx)
+	assert.Error(t, err, "should error when no client cert exists")
+
+	// Generate the first client certificate.
+	cert1, err := manager.GenerateClientCertificate(&ClientCertConfig{
+		CommonName:   "steward-001",
+		ValidityDays: 365,
+	})
+	require.NoError(t, err)
+
+	// GetClientCertificate must return the cert successfully.
+	tlsCert1, err := manager.GetClientCertificate(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, tlsCert1)
+	assert.NotEmpty(t, tlsCert1.Certificate, "TLS cert must contain the leaf certificate bytes")
+
+	// Generate a second client certificate (simulates rotation).
+	cert2, err := manager.GenerateClientCertificate(&ClientCertConfig{
+		CommonName:   "steward-001-renewed",
+		ValidityDays: 365,
+	})
+	require.NoError(t, err)
+
+	// GetClientCertificate must now return the newest cert — leaf bytes differ.
+	tlsCert2, err := manager.GetClientCertificate(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, tlsCert2)
+	assert.NotEqual(t, cert1.SerialNumber, cert2.SerialNumber,
+		"rotation must produce a cert with a different serial")
+	// The leaf DER bytes are different between the two generated certs.
+	assert.NotEqual(t, tlsCert1.Certificate[0], tlsCert2.Certificate[0],
+		"second call must return the newer cert after rotation")
 }

--- a/pkg/cert/tls.go
+++ b/pkg/cert/tls.go
@@ -3,6 +3,7 @@
 package cert
 
 import (
+	"context"
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
@@ -191,4 +192,27 @@ func (m *Manager) CreateClientTLSConfigFromManager(clientCertSerialNumber string
 	}
 
 	return CreateClientTLSConfig(clientCertPEM, clientKeyPEM, caCertPEM, serverName, minVersion)
+}
+
+// CreateOnDemandClientTLSConfig creates a client TLS config that fetches the client
+// certificate on every TLS handshake via the Manager, enabling transparent rotation.
+// When caCertPEM is non-empty it is used for server verification; otherwise system roots apply.
+func (m *Manager) CreateOnDemandClientTLSConfig(caCertPEM []byte, minVersion uint16) (*tls.Config, error) {
+	if minVersion < tls.VersionTLS12 {
+		return nil, fmt.Errorf("minimum TLS version must be 1.2 or higher, got 0x%04x", minVersion)
+	}
+	tlsConfig := &tls.Config{
+		MinVersion: minVersion, // #nosec G402 -- TLS 1.2+ enforced by validation above
+		GetClientCertificate: func(_ *tls.CertificateRequestInfo) (*tls.Certificate, error) {
+			return m.GetClientCertificate(context.Background())
+		},
+	}
+	if len(caCertPEM) > 0 {
+		pool := x509.NewCertPool()
+		if !pool.AppendCertsFromPEM(caCertPEM) {
+			return nil, fmt.Errorf("failed to append CA certificate to pool")
+		}
+		tlsConfig.RootCAs = pool
+	}
+	return tlsConfig, nil
 }

--- a/test/integration/testutil/test_helper.go
+++ b/test/integration/testutil/test_helper.go
@@ -252,7 +252,9 @@ func (e *TestEnv) Start() {
 		e.StewardCfg.ControllerAddr = e.dockerControllerAddr
 	} else {
 		// Start the in-process controller
-		_ = e.Controller.Start(e.ctx)
+		if err := e.Controller.Start(e.ctx); err != nil {
+			e.T.Fatalf("Failed to start controller: %v", err)
+		}
 
 		// Get actual controller addresses
 		controllerAddr := e.Controller.GetListenAddr()
@@ -262,11 +264,14 @@ func (e *TestEnv) Start() {
 		quicAddr = "localhost:4433"
 	}
 
-	// Create transport client for steward — uses gRPC-over-QUIC transport address
+	// Create transport client for steward — uses gRPC-over-QUIC transport address.
+	// Pass the CertManager from the test environment so on-demand cert loading is
+	// exercised in integration tests (Issue #920).
 	transportClient, err := client.NewTransportClient(&client.TransportConfig{
 		ControllerURL:     quicAddr,
 		RegistrationToken: e.registrationToken,
 		TLSCertPath:       e.StewardCfg.CertPath,
+		CertManager:       e.CertManager,
 		Logger:            e.Logger,
 	})
 	if err != nil {


### PR DESCRIPTION
## Summary

- **Offline queue encryption**: `offline_queue.enc` is now encrypted with AES-256-GCM. A 32-byte key is stored in `pkg/secrets` slot `steward/offline-queue-key` and generated via `crypto/rand` on first run. Pre-920 plaintext `offline_queue.json` files are deleted on startup with an `Info`-level log.
- **On-demand cert loading**: `pkg/cert.Manager.GetClientCertificate` returns the newest client cert from the store per call. `pkg/cert.Manager.CreateOnDemandClientTLSConfig` builds a `tls.Config` with a `GetClientCertificate` callback for per-handshake refresh — all `tls.Config{}` and `x509.NewCertPool()` calls are inside `pkg/cert` per architecture rules.
- **Transport wiring**: `TransportClient` uses the on-demand path when `CertManager` is non-nil. Dead fields `clientCertPEM` and `TransportConfig.ClientKeyPEM` removed. `cmd/steward/main.go` builds `CertManager` + `SecretStore` post-registration and passes them to `TransportConfig`.
- **Test coverage**: `TestManager_GetClientCertificate` (rotation, error-when-empty), `TestOfflineQueue_EncryptionRoundTrip`, `TestOfflineQueue_TamperDetection`, `TestOfflineQueue_LegacyPlaintextDeletion`, `TestOfflineQueue_ConcurrentDrainSeenIDs`, `TestTransportClient_CertReloadOnHandshake`, `TestTransportClient_CertNotCached`.
- **Bug fix**: `test/integration/testutil/test_helper.go` now propagates `Controller.Start` errors instead of silently discarding them.

## Test plan

- [x] `go test ./pkg/cert/... ./features/steward/client/...` — all pass
- [x] `make test-agent-complete` — all Go tests pass, lint clean, architecture check `✅ No central provider violations found`
- [x] Trivy scan skipped (no internet in agent container; not a code defect)
- [x] `gofmt -l` on all changed files — no violations
- [x] Architecture compliance: `tls.Config{}` and `x509.NewCertPool()` only inside `pkg/cert/tls.go`

Fixes #920

🤖 Generated with [Claude Code](https://claude.com/claude-code)