### PR TITLE
controller/api: fix Windows CI timeout via context-bounded Close and per-test store isolation (Issue #945)

### DIFF
--- a/features/controller/api/handlers_registration_test.go
+++ b/features/controller/api/handlers_registration_test.go
@@ -63,6 +63,9 @@ func (c *controlledConsumeStore) ConsumeToken(ctx context.Context, tokenStr, ste
 func newHandleRegisterServer(t *testing.T, tokenStore registration.Store, certMgr *cert.Manager, loggers ...logging.Logger) (*Server, *audit.Manager) {
 	t.Helper()
 
+	// Isolate secrets storage per test to prevent shared-path contention on Windows CI.
+	t.Setenv("CFGMS_SECRETS_REPO_PATH", t.TempDir())
+
 	cfg := config.DefaultConfig()
 	cfg.Certificate.EnableCertManagement = false
 

--- a/features/controller/api/handlers_registration_tokens_test.go
+++ b/features/controller/api/handlers_registration_tokens_test.go
@@ -30,6 +30,9 @@ import (
 func setupTestServerWithTokenStore(t *testing.T) (*Server, registration.Store) {
 	t.Helper()
 
+	// Isolate secrets storage per test to prevent shared-path contention on Windows CI.
+	t.Setenv("CFGMS_SECRETS_REPO_PATH", t.TempDir())
+
 	// Create test configuration
 	cfg := config.DefaultConfig()
 	cfg.Certificate.EnableCertManagement = false // Disable for testing

--- a/features/controller/api/server.go
+++ b/features/controller/api/server.go
@@ -459,15 +459,33 @@ func (s *Server) Close(ctx context.Context) error {
 		s.mu.Lock()
 		defer s.mu.Unlock()
 
-		// Story #380: Stop auth defense system
-		if s.authDefense != nil {
-			s.authDefense.Stop()
-		}
-
-		// M-AUTH-1: Close secret store to stop its internal cache cleanup goroutine.
-		if s.secretStore != nil {
-			if err := s.secretStore.Close(); err != nil && firstErr == nil {
-				firstErr = err
+		// authDefense.Stop() and secretStore.Close() both call cache.Close() →
+		// c.cleanupDone.Wait() with no built-in timeout. On Windows, slower goroutine
+		// scheduling can cause them to block well past ctx's deadline. Run them in a
+		// single goroutine so Close() always honours the caller's context.
+		authDef := s.authDefense
+		secStore := s.secretStore
+		cacheDone := make(chan error, 1)
+		go func() {
+			// Story #380: Stop auth defense system
+			if authDef != nil {
+				authDef.Stop()
+			}
+			// M-AUTH-1: Close secret store to stop its internal cache cleanup goroutine.
+			var storeErr error
+			if secStore != nil {
+				storeErr = secStore.Close()
+			}
+			cacheDone <- storeErr
+		}()
+		select {
+		case storeErr := <-cacheDone:
+			if storeErr != nil && firstErr == nil {
+				firstErr = storeErr
+			}
+		case <-ctx.Done():
+			if firstErr == nil {
+				firstErr = fmt.Errorf("api server close: timed out stopping auth defense and secret store: %w", ctx.Err())
 			}
 		}
 

--- a/features/controller/api/server_test.go
+++ b/features/controller/api/server_test.go
@@ -30,6 +30,10 @@ import (
 )
 
 func setupTestServer(t *testing.T) *Server {
+	// Isolate secrets storage per test. initializeSecretStore() defaults to a
+	// shared os.TempDir() path, which causes file-lock contention on Windows CI.
+	t.Setenv("CFGMS_SECRETS_REPO_PATH", t.TempDir())
+
 	// Create test configuration
 	cfg := config.DefaultConfig()
 	cfg.Certificate.EnableCertManagement = false // Disable for testing
@@ -840,6 +844,9 @@ func (l *capturingWarnLogger) warnMessages() []string {
 // setupTestServerWithLogger creates a test server using the provided logger.
 // Use this when you need to capture log output for assertions.
 func setupTestServerWithLogger(t *testing.T, logger logging.Logger) *Server {
+	// Isolate secrets storage per test (same reason as setupTestServer).
+	t.Setenv("CFGMS_SECRETS_REPO_PATH", t.TempDir())
+
 	cfg := config.DefaultConfig()
 	cfg.Certificate.EnableCertManagement = false
 


### PR DESCRIPTION
## Summary

- **Root cause 1 (primary):** `server.Close()` called `authDefense.Stop()` and `secretStore.Close()` outside any deadline. Both chains terminate at `cache.Close()` → `sync.WaitGroup.Wait()` with no timeout. On Windows CI (slower goroutine scheduler, ~15ms timeslice vs Linux ~1ms) this blocked past the 5-minute test timeout, killing the entire test binary with `panic: test timed out after 5m0s`. Fixed by running both operations in a goroutine with a buffered channel and `select { case <-ctx.Done(): }` so the caller's context deadline is honoured.

- **Root cause 2 (secondary):** All four test helpers shared a single secrets-store path (`os.TempDir()/cfgms-secrets-test`). Parallel test processes on Windows contended over the same directory (Windows Defender scanning + slower FS operations). Fixed by `t.Setenv("CFGMS_SECRETS_REPO_PATH", t.TempDir())` in each helper for full per-test isolation.

## Files changed

| File | Change |
|------|--------|
| `features/controller/api/server.go` | Goroutine + buffered channel + `ctx.Done()` select in `Close()` |
| `features/controller/api/server_test.go` | Per-test secrets path isolation in `setupTestServer` and `setupTestServerWithLogger` |
| `features/controller/api/handlers_registration_test.go` | Same isolation in `newHandleRegisterServer` |
| `features/controller/api/handlers_registration_tokens_test.go` | Same isolation in `setupTestServerWithTokenStore` |

## Test plan

- [x] `features/controller/api` unit tests: PASS (98s, all sub-packages)
- [x] Full `make test-agent-complete`: PASS — unit, integration, cross-platform compilation (linux/amd64, linux/arm64, darwin/amd64, darwin/arm64, windows/amd64)
- [x] `gosec` / `staticcheck` / `golangci-lint`: 0 issues
- [x] Architecture compliance (`make check-architecture`): no central provider violations
- [x] Security scan (Trivy, Nancy): PASS
- [x] QA code review: 0 blocking findings
- [x] Security review: 0 blocking findings

Fixes #945

🤖 Generated with [Claude Code](https://claude.com/claude-code)