### PR TITLE
po: run cron inline + add /po-live for dedicated PO sessions

### DIFF
--- a/.claude/commands/po-live.md
+++ b/.claude/commands/po-live.md
@@ -1,0 +1,89 @@
+---
+name: po-live
+description: PO Live — launch a Product Owner session in a docker container in a new tmux pane, pre-seeded with /po <args>
+parameters:
+  - name: subcommand
+    description: "Args to pass to /po inside the live container (e.g., 'intent certificate rotation', 'next', 'status')"
+    required: false
+---
+
+# PO Live Command
+
+Launch an interactive PO session in a docker container running in a new tmux pane to the right of the current pane. The container is pre-seeded with `/po $ARGUMENTS` so the PO conversation starts in role immediately. State persists via the host-mounted `~/.claude` session storage — you can `claude --continue` later to resume.
+
+## Why use this instead of `/po`
+
+- **Dedicated token budget** — the live container runs its own Claude session, doesn't compete with the main session for context window or rate limits
+- **Persistent across sessions** — close tmux, come back tomorrow, `claude --continue` from the same workspace
+- **Suited for multi-turn work** — intent capture (5-question structured conversation) and Planning Team orchestration both benefit from a dedicated long-running session
+- **Doesn't share context with cron** — the autonomous `/po cron` cycle stays in the main session; founder-driven product conversations live in the live container
+
+## Execution
+
+Run **one** bash command (no `$TMUX` check beforehand — the script handles tmux detection internally and errors out cleanly if not in tmux):
+
+```bash
+/home/jrdn/git/cfg.is/cfgms/.claude/scripts/agent-dispatch.sh po-live $ARGUMENTS
+```
+
+Inspect the exit code:
+
+### Exit 0 — success (script split a pane and started the container)
+
+Confirm to the founder:
+- Container name `cfg-agent-live-po`
+- Initial prompt: `/po $ARGUMENTS` (or just `/po` if no args)
+- Workspace: `worktrees/po-live` (shared across PO live sessions)
+- Resume later: `claude --continue` inside the container, or `claude --resume <session-id>` from any host (sessions are mounted via `~/.claude`)
+
+### Exit 1 with stderr message "po-live requires an interactive tmux session"
+
+Live mode is unavailable. Two-part fallback:
+
+1. **Run `/po $ARGUMENTS` inline** by spawning the PO subagent (Path B of the existing `/po` slash command):
+
+   ```
+   Agent tool:
+     subagent_type: po
+     prompt: "Start a PO session. Arguments: $ARGUMENTS"
+     mode: auto
+   ```
+
+2. **Tell the founder the one-liner** they can paste into a real terminal to launch live mode manually:
+
+   ```
+   /home/jrdn/git/cfg.is/cfgms/.claude/scripts/agent-dispatch.sh po-live $ARGUMENTS
+   ```
+
+   (To use it: open a tmux session — `tmux new -s cfgms` — then paste the command. The script will then split a pane and start the live PO container.)
+
+### Any other non-zero exit
+
+Surface the script's stderr to the founder verbatim and stop. Don't auto-fall-back since the failure may need investigation.
+
+## Permissions
+
+`Bash(/home/jrdn/git/cfg.is/cfgms/.claude/scripts/agent-dispatch.sh po-live *)` and `Bash(./.claude/scripts/agent-dispatch.sh *)` are both pre-approved in `.claude/settings.local.json`, so this command should run without permission prompts.
+
+## Cap impact
+
+`po-live` is a founder-controlled interactive session, like `cfg-agent-live-develop`. It does NOT count toward the 4-container cap on autonomous workers per `feedback_max_running_agents.md`. Steady-state ceiling becomes 4 autonomous + (live-develop, po-live, ...) interactive sessions.
+
+## Examples
+
+- `/po-live intent certificate rotation` — opens a new pane and starts intent capture for a "certificate rotation" epic (or falls back to inline + one-liner if not in tmux)
+- `/po-live next` — opens a new pane and asks PO for the single highest-leverage next action
+- `/po-live` (no args) — opens a new pane at the PO dashboard
+- `/po-live unblock #501` — opens a new pane to handle a targeted unblock conversation
+
+## Behavior inside the live container
+
+The pre-seeded `/po $ARGUMENTS` invokes the existing `/po` slash command (Path B — interactive PO subagent). All standard PO behaviors work: intent capture (5-question structured), targeted unblocks, story status queries, next-action recommendations. The live container can also spawn the Planning Team for epic decomposition since it's a fresh top-level Claude session (not a nested subagent).
+
+## Cleaning up
+
+The container uses `--rm` and removes itself on exit. To exit:
+- Type `/exit` or `exit` in the live Claude session, then `exit` the bash shell
+- Or close the tmux pane (`Ctrl-b x`) — Docker will clean up
+
+The shared `worktrees/po-live` clone persists between sessions; remove manually with `rm -rf worktrees/po-live` if you want a fresh workspace.

--- a/.claude/commands/po.md
+++ b/.claude/commands/po.md
@@ -9,11 +9,29 @@ parameters:
 
 # Product Owner Command
 
-Launch the PO agent, which stays in role for the rest of the session. The PO manages the autonomous pipeline: dashboard, intent capture, targeted unblocks, and orchestration.
+The PO manages the autonomous pipeline: dashboard, intent capture, targeted unblocks, and orchestration.
 
 ## Execution
 
-Spawn the PO agent using the Agent tool:
+Two execution paths depending on `$ARGUMENTS`:
+
+### Path A — `cron` (run inline in the main session)
+
+If `$ARGUMENTS` starts with `cron` (with or without further sub-arguments), do **NOT** spawn the PO as a subagent. Instead, execute the pipeline cycle inline in the main session.
+
+**Why:** A subagent cannot reliably spawn nested subagents (Acceptance Reviewer, BA, Tech Lead, Planning Team), and its bash commands trigger approval prompts despite `mode: auto`. Running inline gives the cycle full Agent-tool access and the parent session's allow list. This is documented in memory `feedback_po_run_inline.md`.
+
+**How:**
+1. Read `.claude/agents/po.md` to load the PO's behavioral rules and the Pipeline Cycle (§4) steps.
+2. Execute Pipeline Cycle (§4) directly in the main session — preflight, unblock check, agent cleanup, Tech Lead pass, dispatch, fix cycle, Acceptance Reviewer (§4.1 Step 5), forward edge, session log.
+3. Honor the 4-container cap from `feedback_max_running_agents.md` — the cap is on docker containers (`./.claude/scripts/agent-dispatch.sh list-running` count) only. Acceptance Reviewer subagents are in-process and do NOT count.
+4. Spawn the Acceptance Reviewer subagent for each review-ready PR (use the Agent tool with `subagent_type: acceptance-reviewer`, `mode: auto`). Process PRs serially in FIFO order per `.claude/agents/po.md` §4.1 Step 5.
+5. **Skip Step 6 (Planning Team) entirely in cron mode.** Planning Team is interactive-only — epic decomposition only runs when the founder invokes `/po` interactively. If undecomposed epics are blocking forward progress, mention it in the cycle summary so the founder can run an interactive session.
+6. Report the cycle summary back to the founder using the same format the PO subagent uses.
+
+### Path B — anything else (spawn the PO subagent)
+
+For `status` (default), `intent <topic>`, `next`, or natural-language input, spawn the PO agent so it stays in role for the rest of the session:
 
 ```
 Agent tool:
@@ -25,6 +43,6 @@ Agent tool:
 The PO agent definition is at `.claude/agents/po.md`. It will:
 1. Display the pipeline dashboard on startup
 2. Stay in role for ongoing conversation with the founder
-3. Handle intent capture, unblocks, next action, and pipeline cycles
+3. Handle intent capture, unblocks, next action, and story status queries
 
 If `$ARGUMENTS` contains a subcommand (e.g., `intent certificate rotation`), pass it to the agent so it routes to the correct action immediately.

--- a/.claude/scripts/agent-dispatch.sh
+++ b/.claude/scripts/agent-dispatch.sh
@@ -108,6 +108,7 @@ Commands:
   launch          <NUM>                     Launch agent container (issue mode)
   launch-generic  <NAME> <DIR> [ARGS...]    Launch agent container with custom name and args
   live            <BRANCH|NUM>               Drop into live Claude session (branch name or issue number)
+  po-live         [PO_ARGS...]               Drop into live Claude session pre-seeded with /po <args> (intent capture, planning team, etc.)
   launch-interactive <BRANCH>               Print docker run command for interactive session
   wait-for-auth   <NUM> [NUM...]            (deprecated, no-op) Legacy auth polling
   wait-for-auth   --container <NAME> [...]  (deprecated, no-op) Legacy auth polling
@@ -467,6 +468,106 @@ case "$cmd" in
       --entrypoint /bin/bash \
       cfg-agent:latest \
       -c "setup-env.sh && exec claude --dangerously-skip-permissions"
+    ;;
+
+  po-live)
+    # Launch an interactive PO session in a docker container, pre-seeded with
+    # /po <args> so the conversation is already in role. All args are joined
+    # and passed as the initial prompt; e.g. `po-live intent certificate
+    # rotation` opens a session with first message `/po intent certificate
+    # rotation`. With no args the session opens at `/po` (dashboard).
+    #
+    # Interactive shell required: docker run -it needs a real TTY.
+    # If invoked from inside tmux and POLIVE_INNER is unset, this command
+    # splits a new pane to the right and re-invokes itself there with
+    # POLIVE_INNER=1 set, so the docker run lands in the new pane.
+    # If invoked outside tmux, the script refuses (the slash command should
+    # have detected this upfront and fallen back to /po).
+    if [[ -n "$TMUX" && -z "${POLIVE_INNER:-}" ]]; then
+      # Build the re-invocation as a single quoted command. Use printf %q to
+      # safely escape each arg (handles spaces, quotes, slashes in topics).
+      escaped=""
+      for a in "$@"; do
+        escaped+=" $(printf '%q' "$a")"
+      done
+      exec tmux split-window -h "POLIVE_INNER=1 $0 po-live${escaped}"
+    fi
+
+    if [[ -z "$TMUX" && -z "${POLIVE_INNER:-}" ]]; then
+      echo "ERROR: po-live requires an interactive tmux session (docker run -it needs a real TTY)." >&2
+      echo "       Run this command from a tmux pane, OR use /po inline if you can't open one." >&2
+      exit 1
+    fi
+
+    args="$*"
+    container_name="cfg-agent-live-po"
+    clone_dir="${WORKTREE_BASE}/po-live"
+    github_url=$(git -C "$REPO_ROOT" remote get-url origin)
+
+    # Reuse or create the shared po-live clone (PO sessions don't edit code,
+    # so a single shared workspace on develop is fine).
+    if [[ -d "$clone_dir" ]]; then
+      echo "Clone already exists at ${clone_dir}, reusing"
+    else
+      trap "rm -rf '$clone_dir'" ERR
+      git clone --local --branch develop "$REPO_ROOT" "$clone_dir"
+      cd "$clone_dir"
+      git remote set-url origin "$github_url"
+      sync_to_remote_develop
+      trap - ERR
+    fi
+
+    real_path=$(realpath "$clone_dir")
+    refresh_creds_from_host
+    gh_token=$(gh auth token)
+
+    # Remove stale container with the same name (only one PO live at a time)
+    docker rm -f "$container_name" 2>/dev/null || true
+
+    # Build the initial prompt without trailing space when args are empty.
+    # Trailing space leaves Claude's input box mid-word and shows the slash-
+    # command autocomplete dropdown instead of submitting on Enter.
+    if [[ -n "$args" ]]; then
+      po_prompt="/po ${args}"
+      po_name="PO: ${args}"
+    else
+      po_prompt="/po"
+      po_name="PO"
+    fi
+
+    echo "================================================"
+    echo " CFGMS PO Live Session"
+    echo " Initial prompt: ${po_prompt}"
+    echo " Clone:          ${real_path}"
+    echo "================================================"
+
+    host_claude_dir="$HOME/.claude"
+    host_claude_json="$HOME/.claude.json"
+
+    # Pass $1 (display name) and $2 (initial prompt) via bash -c positional
+    # args to avoid shell-quote escaping pain when args contain special chars.
+    exec docker run -it --rm \
+      --name "$container_name" \
+      --label "cfg-agent=true" \
+      --label "mode=po-live" \
+      --memory=4g \
+      --cpus=4 \
+      -v "${real_path}:/workspace" \
+      -v "${host_claude_dir}:/home/agent/.claude" \
+      -v "${host_claude_json}:/home/agent/.claude.json" \
+      -v "${REPO_ROOT}/.devcontainer/scripts/setup-env.sh:/usr/local/bin/setup-env.sh:ro" \
+      -v "cfgms-go-build-cache:/home/agent/.cache/go-build" \
+      -v "cfgms-go-mod-cache:/home/agent/go/pkg/mod" \
+      -e "GH_TOKEN=${gh_token}" \
+      -e "GOMODCACHE=/home/agent/go/pkg/mod" \
+      -e "GOFLAGS=-modcacherw" \
+      --cap-add NET_ADMIN \
+      --entrypoint /bin/bash \
+      cfg-agent:latest \
+      -c 'setup-env.sh && exec claude --dangerously-skip-permissions --name "$1" "$2"' \
+      cfg-agent-live-po \
+      "$po_name" \
+      "$po_prompt"
     ;;
 
   launch-interactive)


### PR DESCRIPTION
## Summary
- `/po cron` now runs inline in the main session (skips Planning Team subagent) so it can spawn agent teams and avoid permission prompts
- New `/po-live` slash command splits a tmux pane and starts a docker container pre-seeded with `/po <args>`, giving founder-driven PO conversations a dedicated token budget separate from the cron loop

## Test plan
- [x] `make test` passes (script + OSS validation)
- [x] `bash -n` syntax check on agent-dispatch.sh
- [x] Smoke-tested `/po-live show total epics...` — pane split, container started, prompt seeded

🤖 Generated with [Claude Code](https://claude.com/claude-code)