### PR TITLE
quic: accept QUIC connections concurrently to prevent stream-stall DoS (Issue #932)

### DIFF
--- a/pkg/transport/quic/doc.go
+++ b/pkg/transport/quic/doc.go
@@ -17,6 +17,14 @@
 // gRPC uses for its entire HTTP/2 connection lifetime. MaxIncomingStreams=1 is
 // enforced by the default QUIC config to prevent stream-flood attacks.
 //
+// Listen() starts a background goroutine (acceptLoop) that accepts QUIC
+// connections concurrently. Each accepted connection gets its own goroutine
+// (acceptStream) that waits up to 5 seconds for the peer to open its first
+// bidirectional stream. Peers that stall are closed via CloseWithError and do
+// not prevent other peers from being accepted. Ready connections are queued in
+// a buffered channel (capacity 64); Accept() returns the next queued connection
+// or blocks until one is available.
+//
 // # Server usage
 //
 //	lis, err := quic.Listen(addr, tlsConfig, nil)

--- a/pkg/transport/quic/integration_test.go
+++ b/pkg/transport/quic/integration_test.go
@@ -5,10 +5,8 @@ package quic
 
 import (
 	"context"
-	"crypto/tls"
 	"errors"
 	"io"
-	"net"
 	"sync"
 	"testing"
 	"time"
@@ -401,35 +399,24 @@ func TestGRPCOverQUIC_ClientDisconnect(t *testing.T) {
 	// The stream operations after cancel must return a context error (Canceled or EOF).
 	var msg echoMsg
 	err = stream.RecvMsg(&msg)
-	if err != nil {
-		t.Logf("RecvMsg after cancel returned (expected): %v", err)
-	}
-	assert.Error(t, err, "RecvMsg after context cancellation must return an error, not succeed")
+	require.Error(t, err, "RecvMsg after context cancellation must return an error, not succeed")
 }
 
 // TestGRPCOverQUIC_TLSRequired verifies that a connection attempt with a
-// mismatched or missing TLS configuration fails.
+// wrong ALPN fails, validating ALPN enforcement at the transport layer.
 func TestGRPCOverQUIC_TLSRequired(t *testing.T) {
 	tlsPair := newTestTLSPair(t)
 	_, addr := startEchoServer(t, tlsPair)
 
-	// Build a "bad" client TLS config with a different CA (no valid cert).
-	badCA := newTestTLSPair(t)
-
-	// Use a client TLS config from a different CA that the server will reject.
-	// The server requires client cert verification against its own CA.
-	wrongCATLS := &tls.Config{
-		InsecureSkipVerify: false, //nolint:gosec // intentional bad cert for negative test
-		NextProtos:         []string{testALPN},
-		ServerName:         "localhost",
-		RootCAs:            badCA.client.RootCAs, // wrong CA pool
-	}
+	// Use the correct CA but a wrong ALPN to test ALPN enforcement specifically.
+	wrongALPNTLS := tlsPair.client.Clone()
+	wrongALPNTLS.NextProtos = []string{"wrong-protocol"}
 
 	ctx, cancel := context.WithTimeout(t.Context(), 3*time.Second)
 	defer cancel()
 
-	_, dialErr := Dial(ctx, addr, wrongCATLS, nil)
-	assert.Error(t, dialErr, "dial with wrong CA should fail TLS verification")
+	_, dialErr := Dial(ctx, addr, wrongALPNTLS, nil)
+	assert.Error(t, dialErr, "dial with wrong ALPN should fail ALPN negotiation")
 }
 
 // TestGRPCOverQUIC_AddrWrapper verifies that our Addr wrapper is used for
@@ -452,7 +439,6 @@ func TestGRPCOverQUIC_AddrWrapper(t *testing.T) {
 // TestAddr_NetworkAndString verifies the Addr type satisfies net.Addr.
 func TestAddr_NetworkAndString(t *testing.T) {
 	a := newAddr("127.0.0.1:4433")
-	var _ net.Addr = a
 	assert.Equal(t, "quic", a.Network())
 	assert.Equal(t, "127.0.0.1:4433", a.String())
 }

--- a/pkg/transport/quic/listener.go
+++ b/pkg/transport/quic/listener.go
@@ -85,12 +85,18 @@ func requireAddressValidation(info *quicgo.ClientInfo) (*quicgo.Config, error) {
 // Each accepted QUIC connection opens its first bidirectional stream, which is
 // wrapped as a net.Conn for gRPC to use. gRPC handles its own HTTP/2
 // multiplexing within that stream.
+//
+// Connections are accepted concurrently: Listen() starts a background goroutine
+// that accepts QUIC connections and spawns a per-connection goroutine to wait
+// for the first stream. Each connection has a 5-second deadline to open its
+// first stream; peers that stall are disconnected and do not block other peers.
 type Listener struct {
 	ql     *quicgo.Listener
 	tr     *quicgo.Transport // non-nil: Listen() owns this transport's UDP socket
 	cfg    *quicgo.Config    // effective config after Listen() injection
 	ctx    context.Context
 	cancel context.CancelFunc
+	conns  chan net.Conn // buffered queue of ready connections
 }
 
 // Compile-time check that Listener implements net.Listener.
@@ -142,34 +148,63 @@ func Listen(addr string, tlsConfig *tls.Config, quicConfig *quicgo.Config) (*Lis
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
-	return &Listener{
+	l := &Listener{
 		ql:     ql,
 		tr:     tr,
 		cfg:    quicConfig,
 		ctx:    ctx,
 		cancel: cancel,
-	}, nil
+		conns:  make(chan net.Conn, 64),
+	}
+	go l.acceptLoop()
+	return l, nil
+}
+
+// acceptLoop runs in a background goroutine started by Listen(). It accepts
+// QUIC connections and spawns a per-connection goroutine for stream acceptance,
+// so no single slow peer can block others from being accepted.
+func (l *Listener) acceptLoop() {
+	for {
+		quicConn, err := l.ql.Accept(l.ctx)
+		if err != nil {
+			return
+		}
+		go l.acceptStream(quicConn)
+	}
+}
+
+// acceptStream waits up to 5 seconds for the peer to open its first
+// bidirectional stream. On success the wrapped Conn is pushed to l.conns.
+// On timeout the QUIC connection is closed so the peer is not left dangling.
+func (l *Listener) acceptStream(quicConn *quicgo.Conn) {
+	ctx, cancel := context.WithTimeout(l.ctx, 5*time.Second)
+	defer cancel()
+	stream, err := quicConn.AcceptStream(ctx)
+	if err != nil {
+		_ = quicConn.CloseWithError(1, "stream accept timeout")
+		return
+	}
+	local := newAddr(quicConn.LocalAddr().String())
+	remote := newAddr(quicConn.RemoteAddr().String())
+	select {
+	case l.conns <- newConn(quicConn, stream, local, remote):
+	case <-l.ctx.Done():
+		_ = quicConn.CloseWithError(1, "listener closed")
+	}
 }
 
 // Accept waits for and returns the next connection.
 //
-// It accepts the next QUIC connection, waits for the first bidirectional
-// stream to be opened, and returns that stream as a net.Conn.
+// It returns connections from the internal accept queue, which is populated
+// concurrently by acceptLoop and acceptStream. Accept returns immediately once
+// a peer has completed the TLS handshake and opened its first stream.
 func (l *Listener) Accept() (net.Conn, error) {
-	quicConn, err := l.ql.Accept(l.ctx)
-	if err != nil {
-		return nil, err
+	select {
+	case conn := <-l.conns:
+		return conn, nil
+	case <-l.ctx.Done():
+		return nil, l.ctx.Err()
 	}
-
-	stream, err := quicConn.AcceptStream(l.ctx)
-	if err != nil {
-		_ = quicConn.CloseWithError(1, "stream accept failed")
-		return nil, err
-	}
-
-	localAddr := newAddr(quicConn.LocalAddr().String())
-	remoteAddr := newAddr(quicConn.RemoteAddr().String())
-	return newConn(quicConn, stream, localAddr, remoteAddr), nil
 }
 
 // Close stops the listener. Any blocked Accept call will return with an error.

--- a/pkg/transport/quic/listener_test.go
+++ b/pkg/transport/quic/listener_test.go
@@ -203,6 +203,52 @@ func TestListen_DoesNotMutateCallerConfig(t *testing.T) {
 		"Listen() must not mutate the caller's *quicgo.Config in-place")
 }
 
+// TestListener_SlowHandshakePeerDoesNotBlockOthers verifies that a peer which
+// completes the TLS handshake but never opens a stream does not prevent other
+// peers from being accepted. This is the core DoS-resilience property of the
+// concurrent accept queue introduced in Issue #932.
+func TestListener_SlowHandshakePeerDoesNotBlockOthers(t *testing.T) {
+	tlsPair := newTestTLSPair(t)
+
+	lis, err := Listen("127.0.0.1:0", tlsPair.server, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = lis.Close() })
+
+	type acceptResult struct {
+		conn net.Conn
+		err  error
+	}
+	acceptCh := make(chan acceptResult, 1)
+	go func() {
+		conn, aerr := lis.Accept()
+		acceptCh <- acceptResult{conn: conn, err: aerr}
+	}()
+
+	// Peer-1: complete TLS handshake but never open a stream (simulates stalling peer).
+	peer1, err := quicgo.DialAddr(t.Context(), lis.Addr().String(), tlsPair.client, nil)
+	require.NoError(t, err)
+	defer func() { _ = peer1.CloseWithError(0, "") }()
+
+	// Peer-2: dial normally and open a stream.
+	peer2, err := Dial(t.Context(), lis.Addr().String(), tlsPair.client, nil)
+	require.NoError(t, err)
+	defer func() { _ = peer2.Close() }()
+
+	// Write a byte to trigger stream notification on the server side.
+	_, err = peer2.Write([]byte{0x00})
+	require.NoError(t, err)
+
+	// Accept must deliver peer-2's conn within 2 seconds despite peer-1 stalling.
+	select {
+	case result := <-acceptCh:
+		require.NoError(t, result.err)
+		require.NotNil(t, result.conn)
+		_ = result.conn.Close()
+	case <-time.After(2 * time.Second):
+		t.Fatal("Accept blocked for >2s: slow-peer stalled the accept loop")
+	}
+}
+
 // TestListener_CloseUnblocksAccept verifies that Close causes a blocked Accept
 // to return with an error rather than hanging indefinitely.
 func TestListener_CloseUnblocksAccept(t *testing.T) {


### PR DESCRIPTION
## Summary

- Redesigns `Listener` with a concurrent accept queue (`conns chan net.Conn`, capacity 64): `Listen()` starts `acceptLoop()` in background; each accepted QUIC connection gets its own `acceptStream()` goroutine with a 5-second stream deadline; `Accept()` selects from the queue rather than blocking in-line.
- A peer that completes TLS but never opens a stream is disconnected via `CloseWithError` after 5 seconds and does not stall acceptance for other peers.
- Fixes `TestGRPCOverQUIC_ClientDisconnect` (adds `require.Error`), `TestGRPCOverQUIC_TLSRequired` (switches from wrong-CA to wrong-ALPN), removes tautological compile-time check from `TestAddr_NetworkAndString`, and updates `doc.go`.

## Acceptance Criteria Coverage

- [x] `Listener.Accept()` no longer calls `AcceptStream` in the calling goroutine
- [x] Stalling peer disconnected after 5 seconds via `CloseWithError`
- [x] `TestListener_SlowHandshakePeerDoesNotBlockOthers` passes (peer-2 accepted within 2s)
- [x] All existing `TestGRPCOverQUIC_*` integration tests pass
- [x] `TestGRPCOverQUIC_ClientDisconnect` asserts non-nil error from `RecvMsg`
- [x] `TestGRPCOverQUIC_TLSRequired` tests wrong ALPN enforcement
- [x] Duplicate compile-time interface check removed from `integration_test.go`
- [x] `doc.go` updated with accept queue description

## Specialist Review Results

**QA Test Runner: PASS**
- All packages passing; `pkg/transport/quic` PASS (8.954s)
- Cross-platform builds (linux/amd64, linux/arm64, darwin/amd64, darwin/arm64, windows/amd64): PASS
- Integration tests: PASS; linting: 0 issues

**QA Code Reviewer: PASS**
- 0 blocking issues, 0 warnings
- No mocks, no `t.Skip`, no `time.Sleep` for sync, all error paths tested

**Security Engineer: PASS**
- 0 blocking issues, 0 warnings
- security-precommit: PASS; check-architecture: PASS; security-scan: PASS
- Goroutine lifecycle verified: all goroutines terminate on context cancellation

## Test Plan

- [ ] `go test ./pkg/transport/quic/... -race -v` — all 31 tests pass
- [ ] `TestListener_SlowHandshakePeerDoesNotBlockOthers` — peer-2 accepted in <2s while peer-1 stalls
- [ ] `TestGRPCOverQUIC_ClientDisconnect` — `require.Error` enforces non-nil return
- [ ] `TestGRPCOverQUIC_TLSRequired` — wrong-ALPN dial fails
- [ ] `make test-agent-complete` — full suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)