### PR TITLE
features/steward/client: address PR #942 follow-up findings (Issue #946)

### DIFF
--- a/cmd/steward/main.go
+++ b/cmd/steward/main.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"syscall"
 	"time"
@@ -574,10 +575,7 @@ func buildCertManagerAndSecretStore(clientCertPEM, clientKeyPEM string, logger l
 		return nil, secretStore
 	}
 
-	certStorePath := filepath.Join(os.TempDir(), "cfgms-steward", "certs")
-	if dataDir := os.Getenv("CFGMS_DATA_DIR"); dataDir != "" {
-		certStorePath = filepath.Join(dataDir, "certs")
-	}
+	certStorePath := defaultCertStoreDir()
 
 	// Try to load an existing local CA (created on a previous run).
 	certMgr, mgrErr := cert.NewManager(&cert.ManagerConfig{
@@ -610,4 +608,27 @@ func buildCertManagerAndSecretStore(clientCertPEM, clientKeyPEM string, logger l
 	}
 
 	return certMgr, secretStore
+}
+
+// defaultCertStoreDir returns the platform-specific stable directory for the
+// steward's on-demand client certificate store. Uses the same path convention
+// as the StewardProvider's defaultSecretsDir so operators find both under the
+// same platform root (e.g. /var/lib/cfgms/ on Linux).
+func defaultCertStoreDir() string {
+	switch runtime.GOOS {
+	case "windows":
+		programData := os.Getenv("ProgramData")
+		if programData == "" {
+			programData = `C:\ProgramData`
+		}
+		return filepath.Join(programData, "cfgms", "steward", "certs")
+	case "darwin":
+		home, _ := os.UserHomeDir()
+		if home == "" {
+			home = "/tmp"
+		}
+		return filepath.Join(home, "Library", "Application Support", "cfgms", "steward", "certs")
+	default:
+		return "/var/lib/cfgms/steward/certs"
+	}
 }

--- a/features/steward/client/client_transport.go
+++ b/features/steward/client/client_transport.go
@@ -1068,10 +1068,10 @@ func (c *TransportClient) buildVerifierOnDemand() signature.Verifier {
 	switch {
 	case signingCertPEM != "":
 		certPEM = []byte(signingCertPEM)
-		c.logger.Info("Using dedicated signing certificate for signature verification")
+		c.logger.Debug("Using dedicated signing certificate for signature verification")
 	case serverCertPEM != "":
 		certPEM = []byte(serverCertPEM)
-		c.logger.Info("Using server certificate for signature verification")
+		c.logger.Debug("Using server certificate for signature verification")
 	case certPath != "":
 		// Story #377: prefer signing.crt, fall back to server.crt.
 		signingPath := filepath.Join(certPath, "signing.crt")
@@ -1079,7 +1079,7 @@ func (c *TransportClient) buildVerifierOnDemand() signature.Verifier {
 		// #nosec G304 - Certificate paths are controlled via configuration
 		if raw, err := os.ReadFile(signingPath); err == nil {
 			certPEM = raw
-			c.logger.Info("Using signing.crt from disk for signature verification")
+			c.logger.Debug("Using signing.crt from disk for signature verification")
 		} else if raw, err := os.ReadFile(serverPath); err == nil {
 			certPEM = raw
 		} else if caCertPEM != "" {
@@ -1100,7 +1100,7 @@ func (c *TransportClient) buildVerifierOnDemand() signature.Verifier {
 		c.logger.Warn("Failed to create configuration verifier", "error", err)
 		return nil
 	}
-	c.logger.Info("Configuration signature verifier built", "key_fingerprint", verifier.KeyFingerprint())
+	c.logger.Debug("Configuration signature verifier built", "key_fingerprint", verifier.KeyFingerprint())
 	return verifier
 }
 

--- a/features/steward/client/offline_queue_test.go
+++ b/features/steward/client/offline_queue_test.go
@@ -23,6 +23,7 @@ import (
 	cpTypes "github.com/cfgis/cfgms/pkg/controlplane/types"
 	"github.com/cfgis/cfgms/pkg/logging"
 	secretsif "github.com/cfgis/cfgms/pkg/secrets/interfaces"
+	stewardprovider "github.com/cfgis/cfgms/pkg/secrets/providers/steward"
 )
 
 // ---------------------------------------------------------------------------
@@ -176,7 +177,7 @@ func TestOfflineQueue_DrainEmptyQueue(t *testing.T) {
 func TestOfflineQueue_PersistenceAcrossRestart(t *testing.T) {
 	dir := t.TempDir()
 	// Shared SecretStore so the encryption key persists across simulated restarts.
-	store := newInMemorySecretStore()
+	store := newTestSecretStore(t)
 
 	// First instance — enqueue three events.
 	q1, err := NewOfflineQueue(OfflineQueueConfig{Dir: dir, MaxSize: 10, MaxAge: time.Hour, SecretStore: store})
@@ -201,7 +202,7 @@ func TestOfflineQueue_PersistenceAcrossRestart(t *testing.T) {
 
 func TestOfflineQueue_PersistencePartialDrainThenRestart(t *testing.T) {
 	dir := t.TempDir()
-	store := newInMemorySecretStore()
+	store := newTestSecretStore(t)
 
 	q1, err := NewOfflineQueue(OfflineQueueConfig{Dir: dir, MaxSize: 10, MaxAge: time.Hour, SecretStore: store})
 	require.NoError(t, err)
@@ -524,67 +525,27 @@ func TestPublishEventWithQueue_DrainedOnReconnect(t *testing.T) {
 // Issue #920: Encryption tests
 // ---------------------------------------------------------------------------
 
-// inMemorySecretStore is a minimal SecretStore for testing that holds secrets in memory.
-type inMemorySecretStore struct {
-	mu      sync.Mutex
-	secrets map[string]string
-}
-
-func newInMemorySecretStore() *inMemorySecretStore {
-	return &inMemorySecretStore{secrets: make(map[string]string)}
-}
-
-func (s *inMemorySecretStore) StoreSecret(_ context.Context, req *secretsif.SecretRequest) error {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	s.secrets[req.Key] = req.Value
-	return nil
-}
-
-func (s *inMemorySecretStore) GetSecret(_ context.Context, key string) (*secretsif.Secret, error) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	v, ok := s.secrets[key]
-	if !ok {
-		return nil, secretsif.ErrSecretNotFound
+// newTestSecretStore creates a real StewardProvider-backed SecretStore in a
+// temporary directory. Skips the test when /etc/machine-id is unavailable —
+// the platform key derivation on Linux requires it.
+func newTestSecretStore(t *testing.T) secretsif.SecretStore {
+	t.Helper()
+	if _, err := os.Stat("/etc/machine-id"); os.IsNotExist(err) {
+		t.Skip("skipping: /etc/machine-id not available (required for platform key derivation on Linux)")
 	}
-	return &secretsif.Secret{Key: key, Value: v}, nil
+	provider := &stewardprovider.StewardProvider{}
+	store, err := provider.CreateSecretStore(map[string]interface{}{
+		"secrets_dir": t.TempDir(),
+	})
+	require.NoError(t, err, "failed to create test secret store")
+	return store
 }
-
-func (s *inMemorySecretStore) DeleteSecret(_ context.Context, _ string) error { return nil }
-func (s *inMemorySecretStore) ListSecrets(_ context.Context, _ *secretsif.SecretFilter) ([]*secretsif.SecretMetadata, error) {
-	return nil, nil
-}
-func (s *inMemorySecretStore) GetSecrets(_ context.Context, _ []string) (map[string]*secretsif.Secret, error) {
-	return nil, nil
-}
-func (s *inMemorySecretStore) StoreSecrets(_ context.Context, _ map[string]*secretsif.SecretRequest) error {
-	return nil
-}
-func (s *inMemorySecretStore) GetSecretVersion(_ context.Context, _ string, _ int) (*secretsif.Secret, error) {
-	return nil, nil
-}
-func (s *inMemorySecretStore) ListSecretVersions(_ context.Context, _ string) ([]*secretsif.SecretVersion, error) {
-	return nil, nil
-}
-func (s *inMemorySecretStore) GetSecretMetadata(_ context.Context, _ string) (*secretsif.SecretMetadata, error) {
-	return nil, nil
-}
-func (s *inMemorySecretStore) UpdateSecretMetadata(_ context.Context, _ string, _ map[string]string) error {
-	return nil
-}
-func (s *inMemorySecretStore) RotateSecret(_ context.Context, _ string, _ string) error {
-	return nil
-}
-func (s *inMemorySecretStore) ExpireSecret(_ context.Context, _ string) error { return nil }
-func (s *inMemorySecretStore) HealthCheck(_ context.Context) error            { return nil }
-func (s *inMemorySecretStore) Close() error                                   { return nil }
 
 // TestOfflineQueue_EncryptionRoundTrip verifies that enqueued events survive a
 // restart (load → decrypt → check) when a SecretStore is provided.
 func TestOfflineQueue_EncryptionRoundTrip(t *testing.T) {
 	dir := t.TempDir()
-	store := newInMemorySecretStore()
+	store := newTestSecretStore(t)
 
 	q1, err := NewOfflineQueue(OfflineQueueConfig{
 		Dir: dir, MaxSize: 10, MaxAge: time.Hour, SecretStore: store,
@@ -620,7 +581,7 @@ func TestOfflineQueue_EncryptionRoundTrip(t *testing.T) {
 // causes load to return an authentication error (GCM tag mismatch).
 func TestOfflineQueue_TamperDetection(t *testing.T) {
 	dir := t.TempDir()
-	store := newInMemorySecretStore()
+	store := newTestSecretStore(t)
 
 	q, err := NewOfflineQueue(OfflineQueueConfig{
 		Dir: dir, MaxSize: 10, MaxAge: time.Hour, SecretStore: store,
@@ -659,7 +620,7 @@ func TestOfflineQueue_LegacyPlaintextDeletion(t *testing.T) {
 	assert.FileExists(t, legacyPath)
 
 	logger := logging.NewLogger("debug")
-	store := newInMemorySecretStore()
+	store := newTestSecretStore(t)
 
 	_, err := NewOfflineQueue(OfflineQueueConfig{
 		Dir: dir, MaxSize: 10, MaxAge: time.Hour,


### PR DESCRIPTION
## Summary

Three post-merge findings from the PR #942 acceptance review (story #920 — offline queue encryption + on-demand cert loading).

- **Remove `inMemorySecretStore` mock** from `offline_queue_test.go` — replaced with real `StewardProvider` via `newTestSecretStore`, matching the established pattern in `features/modules/script/param_binding_test.go`. Tests skip on platforms without `/etc/machine-id`.
- **Downgrade `buildVerifierOnDemand` logs to `Debug`** — four `Info` calls fired on every command handler setup and every config delivery push. Two `Warn` calls that signal cert fallbacks remain at `Warn`.
- **Eliminate `os.TempDir()` + undocumented `CFGMS_DATA_DIR`** for cert store path — replaced with `defaultCertStoreDir()` mirroring the `StewardProvider` path convention (`/var/lib/cfgms/steward/certs` on Linux, etc.). Cert store now survives reboots without any operator configuration.

## Specialist Review Results

| Reviewer | Result |
|----------|--------|
| QA Test Runner (`make test-agent-complete`) | ✅ PASS |
| QA Code Reviewer | ✅ PASS — no mocks, no unexplained skips, no hacky workarounds |
| Security Engineer | ✅ PASS — all scans green; cert store change improves security posture |

Note: an intermittent pre-existing race in `features/monitoring/system_monitor_test.go` appeared on first test run but did not reproduce on re-run or in three subsequent direct invocations. It is in an untouched file (last modified before story #920) and is not part of this story's scope.

## Test Plan

- [x] `go test ./features/steward/client/...` — passes locally with real StewardProvider
- [x] `go build ./features/steward/client/... ./cmd/steward/...` — compiles cleanly
- [x] `make test-agent-complete` — all gates pass (Docker E2E deferred to CI)
- [x] `make security-precommit && make check-architecture && make security-scan` — all green

Fixes #946

🤖 Generated with [Claude Code](https://claude.ai/claude-code)