### PR TITLE
saas: define ConsentStore interface and replace fmt.Sprintf consent serialisation (Issue #954)

### DIFF
--- a/features/saas/README.md
+++ b/features/saas/README.md
@@ -108,6 +108,43 @@ resources:
 - **Audit Logging**: All API calls logged for compliance
 - **Scope Limitation**: Minimal required permissions
 
+## Consent State Storage
+
+Admin-consent state (granted/revoked, accessible tenants, active OAuth2 flow) is
+persisted through the `ConsentStore` interface defined in `multitenant_store.go`.
+
+### ConsentStore interface
+
+```go
+type ConsentStore interface {
+    StoreConsent(provider string, status *ConsentStatus) error
+    GetConsent(provider string) (*ConsentStatus, error)   // (nil, nil) = not found
+    DeleteConsent(provider string) error                  // idempotent
+}
+```
+
+`StoreConsent` and `GetConsent` round-trip the complete `ConsentStatus` struct,
+including `AccessibleTenants []TenantInfo` and the nested `*OAuth2Flow` pointer.
+
+### InMemoryConsentStore
+
+`InMemoryConsentStore` is the pre-production implementation. It serialises each
+`ConsentStatus` to JSON before storing (using a `sync.RWMutex`-protected `[]byte`
+map), which exercises the same serialisation path a durable store would use. The
+contract test in `multitenant_store_test.go` runs `contractConsentStore` against
+this implementation to verify round-trip fidelity for all fields.
+
+```go
+// Zero value is ready to use, or construct explicitly:
+store := NewInMemoryConsentStore()
+manager := NewMultiTenantManager(credStore, store, httpClient)
+```
+
+`CredentialStore` (`StoreClientSecret` / `GetClientSecret`) is **no longer used
+for consent state**. Those methods remain on the interface for auth flows only.
+Any legacy flat-string consent data (e.g. `consent_granted:true;tenants:1`) that
+arrives at `GetConsent` returns a hard error — re-grant admin consent to recover.
+
 ## Development
 
 The SaaS Steward is designed to be:
@@ -115,4 +152,4 @@ The SaaS Steward is designed to be:
 - **Secure**: Industry-standard OAuth2 implementation
 - **Extensible**: Plugin architecture for new providers
 - **Observable**: Comprehensive logging and monitoring
-- **Testable**: Mocked providers for unit testing
+- **Testable**: Real components (InMemoryConsentStore, MockCredentialStore) for unit testing

--- a/features/saas/microsoft_multitenant.go
+++ b/features/saas/microsoft_multitenant.go
@@ -55,7 +55,7 @@ func NewMicrosoftMultiTenantProvider(credStore CredentialStore, httpClient *http
 
 	return &MicrosoftMultiTenantProvider{
 		BaseProvider:       baseProvider,
-		multiTenantManager: NewMultiTenantManager(credStore, httpClient),
+		multiTenantManager: NewMultiTenantManager(credStore, NewInMemoryConsentStore(), httpClient),
 		baseURL:            "https://graph.microsoft.com/v1.0",
 	}
 }

--- a/features/saas/multitenant.go
+++ b/features/saas/multitenant.go
@@ -16,7 +16,7 @@
 //
 // Usage Example:
 //
-//	manager := NewMultiTenantManager(credStore, httpClient)
+//	manager := NewMultiTenantManager(credStore, NewInMemoryConsentStore(), httpClient)
 //
 //	// Start admin consent flow
 //	consentURL, err := manager.StartAdminConsent(ctx, "microsoft", config)
@@ -41,6 +41,7 @@ import (
 // MultiTenantManager handles multi-tenant OAuth2 consent flows and token management
 type MultiTenantManager struct {
 	credStore    CredentialStore
+	consentStore ConsentStore
 	httpClient   *http.Client
 	oauth2Client OAuth2Client
 
@@ -49,10 +50,13 @@ type MultiTenantManager struct {
 	cacheExpiry time.Duration
 }
 
-// NewMultiTenantManager creates a new multi-tenant manager
-func NewMultiTenantManager(credStore CredentialStore, httpClient *http.Client) *MultiTenantManager {
+// NewMultiTenantManager creates a new multi-tenant manager.
+// consentStore persists admin-consent state; pass NewInMemoryConsentStore() for
+// pre-production use until a durable implementation is available.
+func NewMultiTenantManager(credStore CredentialStore, consentStore ConsentStore, httpClient *http.Client) *MultiTenantManager {
 	return &MultiTenantManager{
 		credStore:    credStore,
+		consentStore: consentStore,
 		httpClient:   httpClient,
 		oauth2Client: NewOAuth2Client(httpClient),
 		tenantCache:  make(map[string]*TenantDiscoveryResult),
@@ -187,7 +191,7 @@ func (mtm *MultiTenantManager) StartAdminConsent(ctx context.Context, provider s
 		ConsentFlow:     flow,
 	}
 
-	if err := mtm.storeConsentStatus(provider, status); err != nil {
+	if err := mtm.consentStore.StoreConsent(provider, status); err != nil {
 		return "", fmt.Errorf("failed to store consent status: %w", err)
 	}
 
@@ -196,13 +200,12 @@ func (mtm *MultiTenantManager) StartAdminConsent(ctx context.Context, provider s
 
 // CompleteAdminConsent completes the admin consent flow and discovers tenants
 func (mtm *MultiTenantManager) CompleteAdminConsent(ctx context.Context, provider, authCode string) error {
-	// Get stored consent status
-	status, err := mtm.getConsentStatus(provider)
+	status, err := mtm.consentStore.GetConsent(provider)
 	if err != nil {
 		return fmt.Errorf("failed to get consent status: %w", err)
 	}
 
-	if status.ConsentFlow == nil {
+	if status == nil || status.ConsentFlow == nil {
 		return fmt.Errorf("no active consent flow found for provider %s", provider)
 	}
 
@@ -230,7 +233,7 @@ func (mtm *MultiTenantManager) CompleteAdminConsent(ctx context.Context, provide
 	status.AccessibleTenants = discoveryResult.Tenants
 	status.ConsentFlow = nil // Clear the flow as it's complete
 
-	if err := mtm.storeConsentStatus(provider, status); err != nil {
+	if err := mtm.consentStore.StoreConsent(provider, status); err != nil {
 		return fmt.Errorf("failed to update consent status: %w", err)
 	}
 
@@ -242,13 +245,12 @@ func (mtm *MultiTenantManager) CompleteAdminConsent(ctx context.Context, provide
 
 // GetTenantToken retrieves a valid access token for a specific tenant
 func (mtm *MultiTenantManager) GetTenantToken(ctx context.Context, provider, tenantID string) (*TokenSet, error) {
-	// Check if admin consent has been granted
-	status, err := mtm.getConsentStatus(provider)
+	status, err := mtm.consentStore.GetConsent(provider)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get consent status: %w", err)
 	}
 
-	if !status.HasAdminConsent {
+	if status == nil || !status.HasAdminConsent {
 		return nil, fmt.Errorf("admin consent not granted for provider %s", provider)
 	}
 
@@ -274,12 +276,12 @@ func (mtm *MultiTenantManager) GetTenantToken(ctx context.Context, provider, ten
 
 // ListAccessibleTenants returns all tenants accessible by the provider
 func (mtm *MultiTenantManager) ListAccessibleTenants(ctx context.Context, provider string) ([]TenantInfo, error) {
-	status, err := mtm.getConsentStatus(provider)
+	status, err := mtm.consentStore.GetConsent(provider)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get consent status: %w", err)
 	}
 
-	if !status.HasAdminConsent {
+	if status == nil || !status.HasAdminConsent {
 		return nil, fmt.Errorf("admin consent not granted for provider %s", provider)
 	}
 
@@ -292,7 +294,13 @@ func (mtm *MultiTenantManager) ListAccessibleTenants(ctx context.Context, provid
 			}
 		} else {
 			// Get updated status after refresh
-			status, _ = mtm.getConsentStatus(provider)
+			refreshed, refreshErr := mtm.consentStore.GetConsent(provider)
+			if refreshErr != nil {
+				return nil, fmt.Errorf("failed to read updated consent status: %w", refreshErr)
+			}
+			if refreshed != nil {
+				status = refreshed
+			}
 		}
 	}
 
@@ -314,15 +322,18 @@ func (mtm *MultiTenantManager) RefreshTenantDiscovery(ctx context.Context, provi
 	}
 
 	// Update consent status
-	status, err := mtm.getConsentStatus(provider)
+	status, err := mtm.consentStore.GetConsent(provider)
 	if err != nil {
 		return fmt.Errorf("failed to get consent status: %w", err)
+	}
+	if status == nil {
+		status = &ConsentStatus{Provider: provider}
 	}
 
 	status.LastTenantDiscovery = time.Now()
 	status.AccessibleTenants = discoveryResult.Tenants
 
-	if err := mtm.storeConsentStatus(provider, status); err != nil {
+	if err := mtm.consentStore.StoreConsent(provider, status); err != nil {
 		return fmt.Errorf("failed to update consent status: %w", err)
 	}
 
@@ -334,29 +345,25 @@ func (mtm *MultiTenantManager) RefreshTenantDiscovery(ctx context.Context, provi
 
 // RevokeConsent revokes admin consent and cleans up all tenant tokens
 func (mtm *MultiTenantManager) RevokeConsent(ctx context.Context, provider string) error {
-	status, err := mtm.getConsentStatus(provider)
+	status, err := mtm.consentStore.GetConsent(provider)
 	if err != nil {
 		return fmt.Errorf("failed to get consent status: %w", err)
 	}
 
 	// Clean up all tenant-specific tokens
-	for _, tenant := range status.AccessibleTenants {
-		tenantKey := mtm.getTenantKey(provider, tenant.TenantID)
-		_ = mtm.credStore.DeleteTokenSet(tenantKey) // Ignore errors for cleanup
+	if status != nil {
+		for _, tenant := range status.AccessibleTenants {
+			tenantKey := mtm.getTenantKey(provider, tenant.TenantID)
+			_ = mtm.credStore.DeleteTokenSet(tenantKey) // Ignore errors for cleanup
+		}
 	}
 
 	// Clean up base provider token
 	_ = mtm.credStore.DeleteTokenSet(provider)
 
-	// Reset consent status
-	status.HasAdminConsent = false
-	status.ConsentGrantedAt = time.Time{}
-	status.LastTenantDiscovery = time.Time{}
-	status.AccessibleTenants = nil
-	status.ConsentFlow = nil
-
-	if err := mtm.storeConsentStatus(provider, status); err != nil {
-		return fmt.Errorf("failed to reset consent status: %w", err)
+	// Delete consent status
+	if err := mtm.consentStore.DeleteConsent(provider); err != nil {
+		return fmt.Errorf("failed to delete consent status: %w", err)
 	}
 
 	// Clear cache
@@ -365,79 +372,24 @@ func (mtm *MultiTenantManager) RevokeConsent(ctx context.Context, provider strin
 	return nil
 }
 
-// GetConsentStatus returns the current consent status for a provider
+// GetConsentStatus returns the current consent status for a provider.
+// Returns a default empty ConsentStatus (HasAdminConsent: false) when no
+// consent has been stored yet.
 func (mtm *MultiTenantManager) GetConsentStatus(ctx context.Context, provider string) (*ConsentStatus, error) {
-	return mtm.getConsentStatus(provider)
+	status, err := mtm.consentStore.GetConsent(provider)
+	if err != nil {
+		return nil, err
+	}
+	if status == nil {
+		return &ConsentStatus{Provider: provider, HasAdminConsent: false}, nil
+	}
+	return status, nil
 }
 
 // Private helper methods
 
 func (mtm *MultiTenantManager) getTenantKey(provider, tenantID string) string {
 	return fmt.Sprintf("%s:tenant:%s", provider, tenantID)
-}
-
-func (mtm *MultiTenantManager) getConsentStatusKey(provider string) string {
-	return fmt.Sprintf("%s:consent_status", provider)
-}
-
-func (mtm *MultiTenantManager) storeConsentStatus(provider string, status *ConsentStatus) error {
-	// This is a simplified implementation - in practice, you'd want proper serialization
-	// For now, store as client secret (this could be improved with dedicated consent storage)
-	key := mtm.getConsentStatusKey(provider)
-
-	// Include more detailed status information
-	flowInfo := "none"
-	if status.ConsentFlow != nil {
-		flowInfo = "active"
-	}
-
-	data := fmt.Sprintf("consent_granted:%t;tenants:%d;flow:%s",
-		status.HasAdminConsent, len(status.AccessibleTenants), flowInfo)
-	return mtm.credStore.StoreClientSecret(key, data)
-}
-
-func (mtm *MultiTenantManager) getConsentStatus(provider string) (*ConsentStatus, error) {
-	// This is a simplified implementation - in practice, you'd want proper deserialization
-	key := mtm.getConsentStatusKey(provider)
-	data, err := mtm.credStore.GetClientSecret(key)
-
-	if err != nil {
-		// Return default status if not found
-		return &ConsentStatus{
-			Provider:        provider,
-			HasAdminConsent: false,
-		}, nil
-	}
-
-	status := &ConsentStatus{
-		Provider: provider,
-	}
-
-	// Parse the simple status data format
-	if strings.Contains(data, "consent_granted:true") {
-		status.HasAdminConsent = true
-		status.ConsentGrantedAt = time.Now().Add(-24 * time.Hour) // Mock: granted yesterday
-		status.AccessibleTenants = []TenantInfo{
-			{
-				TenantID:    "tenant-1",
-				DisplayName: "Customer Tenant 1",
-				Domain:      "customer1.onmicrosoft.com",
-				HasAccess:   true,
-			},
-		}
-	}
-
-	// Check if there's an active flow
-	if strings.Contains(data, "flow:active") {
-		status.ConsentFlow = &OAuth2Flow{
-			AuthURL:   "https://test-auth-url.com",
-			State:     "test-state",
-			Created:   time.Now(),
-			ExpiresAt: time.Now().Add(10 * time.Minute),
-		}
-	}
-
-	return status, nil
 }
 
 func (mtm *MultiTenantManager) isTenantAccessible(status *ConsentStatus, tenantID string) bool {

--- a/features/saas/multitenant_store.go
+++ b/features/saas/multitenant_store.go
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+// Package saas multitenant_store defines the ConsentStore interface for persisting
+// and retrieving admin-consent state, and provides InMemoryConsentStore as the
+// pre-production implementation used until a durable store is wired up.
+package saas
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"sync"
+)
+
+// ConsentStore persists and retrieves admin-consent state for a provider.
+// Implementations must preserve all fields of ConsentStatus, including the
+// AccessibleTenants slice and the nested ConsentFlow pointer.
+type ConsentStore interface {
+	// StoreConsent persists the consent status for the given provider, replacing
+	// any previously stored value.
+	StoreConsent(provider string, status *ConsentStatus) error
+
+	// GetConsent retrieves the consent status for the given provider.
+	// Returns (nil, nil) when no entry exists — callers must handle the nil case.
+	GetConsent(provider string) (*ConsentStatus, error)
+
+	// DeleteConsent removes the consent status for the given provider.
+	// It is idempotent: deleting a non-existent entry returns nil.
+	DeleteConsent(provider string) error
+}
+
+// InMemoryConsentStore is the pre-production ConsentStore implementation.
+// It serialises each ConsentStatus to JSON before storing, which enforces the
+// same round-trip fidelity that a durable store would require and allows the
+// contract test to catch field loss early.
+//
+// The zero value is ready to use; NewInMemoryConsentStore is provided for
+// explicit initialisation.
+type InMemoryConsentStore struct {
+	mu   sync.RWMutex
+	data map[string][]byte // JSON-encoded ConsentStatus per provider
+}
+
+// NewInMemoryConsentStore returns an initialised InMemoryConsentStore.
+func NewInMemoryConsentStore() *InMemoryConsentStore {
+	return &InMemoryConsentStore{
+		data: make(map[string][]byte),
+	}
+}
+
+// StoreConsent serialises status to JSON and stores it under provider.
+func (s *InMemoryConsentStore) StoreConsent(provider string, status *ConsentStatus) error {
+	encoded, err := json.Marshal(status)
+	if err != nil {
+		return fmt.Errorf("consent store: failed to serialise status for %q: %w", provider, err)
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.data == nil {
+		s.data = make(map[string][]byte)
+	}
+	s.data[provider] = encoded
+	return nil
+}
+
+// GetConsent deserialises and returns the stored ConsentStatus for provider.
+// Returns (nil, nil) when no entry exists.
+// Returns an error — with message "re-grant admin consent" — when the stored
+// bytes are in the pre-#954 flat-string format or are otherwise unparseable.
+// No attempt is made to parse old-format data; callers must trigger a fresh
+// consent flow.
+func (s *InMemoryConsentStore) GetConsent(provider string) (*ConsentStatus, error) {
+	s.mu.RLock()
+	encoded, ok := s.data[provider]
+	s.mu.RUnlock()
+	if !ok {
+		return nil, nil
+	}
+
+	// Reject the pre-#954 flat-string format (e.g. "consent_granted:true;tenants:1").
+	// These bytes will never be written by StoreConsent, but can appear when tests
+	// or future migration code inject raw data directly.
+	if bytes.Contains(encoded, []byte("consent_granted:")) {
+		return nil, fmt.Errorf("consent store: unrecognised format — re-grant admin consent")
+	}
+
+	var status ConsentStatus
+	if err := json.Unmarshal(encoded, &status); err != nil {
+		return nil, fmt.Errorf("consent store: unrecognised format — re-grant admin consent")
+	}
+	return &status, nil
+}
+
+// DeleteConsent removes the stored consent status for provider.
+// It is idempotent.
+func (s *InMemoryConsentStore) DeleteConsent(provider string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.data, provider)
+	return nil
+}

--- a/features/saas/multitenant_store_test.go
+++ b/features/saas/multitenant_store_test.go
@@ -1,0 +1,243 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+package saas
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// contractConsentStore verifies that any ConsentStore implementation preserves all
+// ConsentStatus fields through a store/retrieve round-trip. Run this against every
+// implementation to confirm contract compliance.
+func contractConsentStore(t *testing.T, store ConsentStore) {
+	t.Helper()
+	provider := "contract-provider"
+
+	flow := &OAuth2Flow{
+		Provider:      provider,
+		State:         "state-abc123",
+		CodeVerifier:  "verifier-xyz",
+		CodeChallenge: "challenge-xyz",
+		AuthURL:       "https://auth.example.com/authorize",
+		RedirectURI:   "https://app.example.com/callback",
+		Created:       time.Now().UTC().Truncate(time.Millisecond),
+		ExpiresAt:     time.Now().UTC().Add(10 * time.Minute).Truncate(time.Millisecond),
+	}
+
+	original := &ConsentStatus{
+		Provider:            provider,
+		HasAdminConsent:     true,
+		ConsentGrantedAt:    time.Now().UTC().Truncate(time.Millisecond),
+		LastTenantDiscovery: time.Now().UTC().Truncate(time.Millisecond),
+		AccessibleTenants: []TenantInfo{
+			{
+				TenantID:         "tenant-aaa",
+				DisplayName:      "Tenant AAA",
+				Domain:           "aaa.example.com",
+				CountryCode:      "US",
+				TenantType:       "AAD",
+				HasAccess:        true,
+				LastTokenRefresh: time.Now().UTC().Truncate(time.Millisecond),
+			},
+			{
+				TenantID:    "tenant-bbb",
+				DisplayName: "Tenant BBB",
+				Domain:      "bbb.example.com",
+				HasAccess:   false,
+			},
+		},
+		ConsentFlow: flow,
+	}
+
+	// Round-trip: store then retrieve.
+	err := store.StoreConsent(provider, original)
+	require.NoError(t, err)
+
+	got, err := store.GetConsent(provider)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+
+	assert.Equal(t, original.Provider, got.Provider)
+	assert.Equal(t, original.HasAdminConsent, got.HasAdminConsent)
+	assert.True(t, original.ConsentGrantedAt.Equal(got.ConsentGrantedAt),
+		"ConsentGrantedAt mismatch: want %v got %v", original.ConsentGrantedAt, got.ConsentGrantedAt)
+	assert.True(t, original.LastTenantDiscovery.Equal(got.LastTenantDiscovery),
+		"LastTenantDiscovery mismatch")
+
+	require.Len(t, got.AccessibleTenants, 2, "AccessibleTenants slice length must be preserved")
+	assert.Equal(t, original.AccessibleTenants[0].TenantID, got.AccessibleTenants[0].TenantID)
+	assert.Equal(t, original.AccessibleTenants[0].DisplayName, got.AccessibleTenants[0].DisplayName)
+	assert.Equal(t, original.AccessibleTenants[0].Domain, got.AccessibleTenants[0].Domain)
+	assert.Equal(t, original.AccessibleTenants[0].CountryCode, got.AccessibleTenants[0].CountryCode)
+	assert.Equal(t, original.AccessibleTenants[0].TenantType, got.AccessibleTenants[0].TenantType)
+	assert.Equal(t, original.AccessibleTenants[0].HasAccess, got.AccessibleTenants[0].HasAccess)
+	assert.True(t, original.AccessibleTenants[0].LastTokenRefresh.Equal(got.AccessibleTenants[0].LastTokenRefresh),
+		"LastTokenRefresh mismatch")
+	assert.Equal(t, original.AccessibleTenants[1].TenantID, got.AccessibleTenants[1].TenantID)
+	assert.Equal(t, original.AccessibleTenants[1].HasAccess, got.AccessibleTenants[1].HasAccess)
+
+	require.NotNil(t, got.ConsentFlow, "ConsentFlow must be preserved")
+	assert.Equal(t, original.ConsentFlow.Provider, got.ConsentFlow.Provider)
+	assert.Equal(t, original.ConsentFlow.State, got.ConsentFlow.State)
+	assert.Equal(t, original.ConsentFlow.CodeVerifier, got.ConsentFlow.CodeVerifier)
+	assert.Equal(t, original.ConsentFlow.CodeChallenge, got.ConsentFlow.CodeChallenge)
+	assert.Equal(t, original.ConsentFlow.AuthURL, got.ConsentFlow.AuthURL)
+	assert.Equal(t, original.ConsentFlow.RedirectURI, got.ConsentFlow.RedirectURI)
+
+	// Overwrite with minimal status (nil flow, empty tenants).
+	cleared := &ConsentStatus{
+		Provider:          provider,
+		HasAdminConsent:   false,
+		AccessibleTenants: []TenantInfo{},
+		ConsentFlow:       nil,
+	}
+	err = store.StoreConsent(provider, cleared)
+	require.NoError(t, err)
+
+	got2, err := store.GetConsent(provider)
+	require.NoError(t, err)
+	require.NotNil(t, got2)
+	assert.False(t, got2.HasAdminConsent)
+	assert.Empty(t, got2.AccessibleTenants)
+	assert.Nil(t, got2.ConsentFlow)
+
+	// Delete then confirm nil-not-found.
+	err = store.DeleteConsent(provider)
+	require.NoError(t, err)
+
+	missing, err := store.GetConsent(provider)
+	assert.NoError(t, err)
+	assert.Nil(t, missing, "GetConsent after delete must return nil, nil")
+}
+
+func TestInMemoryConsentStore_ContractRoundTrip(t *testing.T) {
+	contractConsentStore(t, NewInMemoryConsentStore())
+}
+
+func TestInMemoryConsentStore_NilNotFound(t *testing.T) {
+	store := NewInMemoryConsentStore()
+	result, err := store.GetConsent("nonexistent-provider")
+	assert.NoError(t, err)
+	assert.Nil(t, result)
+}
+
+func TestInMemoryConsentStore_Delete(t *testing.T) {
+	store := NewInMemoryConsentStore()
+
+	err := store.StoreConsent("p", &ConsentStatus{Provider: "p", HasAdminConsent: true})
+	require.NoError(t, err)
+
+	got, err := store.GetConsent("p")
+	require.NoError(t, err)
+	require.NotNil(t, got)
+
+	err = store.DeleteConsent("p")
+	require.NoError(t, err)
+
+	gone, err := store.GetConsent("p")
+	assert.NoError(t, err)
+	assert.Nil(t, gone)
+
+	// Deleting a non-existent entry is idempotent.
+	err = store.DeleteConsent("p")
+	assert.NoError(t, err)
+}
+
+func TestInMemoryConsentStore_MultipleProviders(t *testing.T) {
+	store := NewInMemoryConsentStore()
+	providers := []string{"microsoft", "google", "okta"}
+
+	for _, p := range providers {
+		err := store.StoreConsent(p, &ConsentStatus{Provider: p, HasAdminConsent: true})
+		require.NoError(t, err)
+	}
+
+	for _, p := range providers {
+		got, err := store.GetConsent(p)
+		require.NoError(t, err)
+		require.NotNil(t, got)
+		assert.Equal(t, p, got.Provider)
+		assert.True(t, got.HasAdminConsent)
+	}
+
+	err := store.DeleteConsent("google")
+	require.NoError(t, err)
+
+	for _, p := range []string{"microsoft", "okta"} {
+		got, err := store.GetConsent(p)
+		require.NoError(t, err)
+		assert.NotNil(t, got)
+	}
+
+	deleted, err := store.GetConsent("google")
+	assert.NoError(t, err)
+	assert.Nil(t, deleted)
+}
+
+func TestInMemoryConsentStore_OldFormatReturnsError(t *testing.T) {
+	store := NewInMemoryConsentStore()
+
+	// Inject old flat-string format directly to simulate encountering legacy data.
+	store.mu.Lock()
+	if store.data == nil {
+		store.data = make(map[string][]byte)
+	}
+	store.data["microsoft"] = []byte("consent_granted:true;tenants:1;flow:none")
+	store.mu.Unlock()
+
+	result, err := store.GetConsent("microsoft")
+	assert.Error(t, err, "old-format data must return an error")
+	assert.Nil(t, result)
+	assert.Contains(t, err.Error(), "re-grant admin consent")
+}
+
+func TestInMemoryConsentStore_InvalidJSONReturnsError(t *testing.T) {
+	store := NewInMemoryConsentStore()
+
+	// Inject malformed JSON to simulate storage corruption.
+	store.mu.Lock()
+	if store.data == nil {
+		store.data = make(map[string][]byte)
+	}
+	store.data["broken"] = []byte("{invalid json")
+	store.mu.Unlock()
+
+	result, err := store.GetConsent("broken")
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	assert.Contains(t, err.Error(), "re-grant admin consent")
+}
+
+func TestInMemoryConsentStore_AccessibleTenantsPreserved(t *testing.T) {
+	store := NewInMemoryConsentStore()
+	provider := "microsoft"
+
+	tenants := []TenantInfo{
+		{TenantID: "t1", DisplayName: "Alpha Corp", Domain: "alpha.com", HasAccess: true},
+		{TenantID: "t2", DisplayName: "Beta Corp", Domain: "beta.com", HasAccess: true},
+		{TenantID: "t3", DisplayName: "Gamma Corp", Domain: "gamma.com", HasAccess: false},
+	}
+
+	err := store.StoreConsent(provider, &ConsentStatus{
+		Provider:          provider,
+		HasAdminConsent:   true,
+		AccessibleTenants: tenants,
+	})
+	require.NoError(t, err)
+
+	got, err := store.GetConsent(provider)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	require.Len(t, got.AccessibleTenants, 3)
+
+	for i, want := range tenants {
+		assert.Equal(t, want.TenantID, got.AccessibleTenants[i].TenantID)
+		assert.Equal(t, want.DisplayName, got.AccessibleTenants[i].DisplayName)
+		assert.Equal(t, want.Domain, got.AccessibleTenants[i].Domain)
+		assert.Equal(t, want.HasAccess, got.AccessibleTenants[i].HasAccess)
+	}
+}

--- a/features/saas/multitenant_test.go
+++ b/features/saas/multitenant_test.go
@@ -17,7 +17,8 @@ import (
 
 // Mock implementations for testing
 
-// MockCredentialStore implements CredentialStore for testing
+// MockCredentialStore implements CredentialStore for testing token and client-secret
+// operations. It must NOT be used for consent state — use InMemoryConsentStore instead.
 type MockCredentialStore struct {
 	tokens  map[string]*TokenSet
 	secrets map[string]string
@@ -63,7 +64,9 @@ func (m *MockCredentialStore) IsAvailable() bool {
 	return true
 }
 
-// MockOAuth2Client implements OAuth2Client for testing
+// MockOAuth2Client implements OAuth2Client for testing.
+// Uses testify/mock because OAuth2Client is a features/saas-local interface,
+// not a pkg/ central provider — the mock carve-out in the story applies.
 type MockOAuth2Client struct {
 	mock.Mock
 }
@@ -130,8 +133,9 @@ func TestMultiTenantManager_StartAdminConsent(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			credStore := NewMockCredentialStore()
+			consentStore := NewInMemoryConsentStore()
 			httpClient := &http.Client{}
-			mtm := NewMultiTenantManager(credStore, httpClient)
+			mtm := NewMultiTenantManager(credStore, consentStore, httpClient)
 
 			// Mock OAuth2Client
 			mockOAuth2 := &MockOAuth2Client{}
@@ -167,8 +171,9 @@ func TestMultiTenantManager_StartAdminConsent(t *testing.T) {
 
 func TestMultiTenantManager_CompleteAdminConsent(t *testing.T) {
 	credStore := NewMockCredentialStore()
+	consentStore := NewInMemoryConsentStore()
 	httpClient := &http.Client{}
-	mtm := NewMultiTenantManager(credStore, httpClient)
+	mtm := NewMultiTenantManager(credStore, consentStore, httpClient)
 
 	// Set up mock OAuth2 client
 	mockOAuth2 := &MockOAuth2Client{}
@@ -178,7 +183,7 @@ func TestMultiTenantManager_CompleteAdminConsent(t *testing.T) {
 	provider := "microsoft"
 	authCode := "test-auth-code"
 
-	// First, start a consent flow to set up state
+	// First, start a consent flow to set up state in the ConsentStore.
 	config := &MultiTenantConfig{
 		OAuth2Config: OAuth2Config{
 			ClientID:     "test-client-id",
@@ -202,14 +207,10 @@ func TestMultiTenantManager_CompleteAdminConsent(t *testing.T) {
 	_, err := mtm.StartAdminConsent(ctx, provider, config)
 	require.NoError(t, err)
 
-	// Store the flow state using the simplified format to match the complete consent expectation
-	err = credStore.StoreClientSecret(mtm.getConsentStatusKey(provider), "consent_granted:false;tenants:0;flow:active")
-	require.NoError(t, err)
+	// StartAdminConsent stored the consent status (with ConsentFlow) in consentStore.
+	// CompleteAdminConsent reads it back from there — no manual setup needed.
 
-	// Now test completing the consent
 	err = mtm.CompleteAdminConsent(ctx, provider, authCode)
-
-	// Since we have mock implementations, this should succeed
 	assert.NoError(t, err)
 
 	// Verify consent status was updated
@@ -220,15 +221,23 @@ func TestMultiTenantManager_CompleteAdminConsent(t *testing.T) {
 
 func TestMultiTenantManager_GetTenantToken(t *testing.T) {
 	credStore := NewMockCredentialStore()
+	consentStore := NewInMemoryConsentStore()
 	httpClient := &http.Client{}
-	mtm := NewMultiTenantManager(credStore, httpClient)
+	mtm := NewMultiTenantManager(credStore, consentStore, httpClient)
 
 	ctx := context.Background()
 	provider := "microsoft"
-	tenantID := "tenant-1" // Use the default tenant ID from the mock
+	tenantID := "tenant-1"
 
-	// Set up consent status to simulate successful consent - store it using the simplified format
-	err := credStore.StoreClientSecret(mtm.getConsentStatusKey(provider), "consent_granted:true;tenants:1")
+	// Store real consent status with explicit accessible tenants.
+	err := consentStore.StoreConsent(provider, &ConsentStatus{
+		Provider:         provider,
+		HasAdminConsent:  true,
+		ConsentGrantedAt: time.Now(),
+		AccessibleTenants: []TenantInfo{
+			{TenantID: tenantID, HasAccess: true},
+		},
+	})
 	require.NoError(t, err)
 
 	// Store a valid token for the tenant
@@ -250,8 +259,9 @@ func TestMultiTenantManager_GetTenantToken(t *testing.T) {
 
 func TestMultiTenantManager_GetTenantToken_NoAccess(t *testing.T) {
 	credStore := NewMockCredentialStore()
+	consentStore := NewInMemoryConsentStore()
 	httpClient := &http.Client{}
-	mtm := NewMultiTenantManager(credStore, httpClient)
+	mtm := NewMultiTenantManager(credStore, consentStore, httpClient)
 
 	ctx := context.Background()
 	provider := "microsoft"
@@ -271,7 +281,7 @@ func TestMultiTenantManager_GetTenantToken_NoAccess(t *testing.T) {
 		},
 	}
 
-	err := mtm.storeConsentStatus(provider, status)
+	err := consentStore.StoreConsent(provider, status)
 	require.NoError(t, err)
 
 	// Test getting token for inaccessible tenant
@@ -283,39 +293,48 @@ func TestMultiTenantManager_GetTenantToken_NoAccess(t *testing.T) {
 
 func TestMultiTenantManager_ListAccessibleTenants(t *testing.T) {
 	credStore := NewMockCredentialStore()
+	consentStore := NewInMemoryConsentStore()
 	httpClient := &http.Client{}
-	mtm := NewMultiTenantManager(credStore, httpClient)
+	mtm := NewMultiTenantManager(credStore, consentStore, httpClient)
 
 	ctx := context.Background()
 	provider := "microsoft"
 
-	// Set up consent status using the simplified format - this will return the mock tenant
-	err := credStore.StoreClientSecret(mtm.getConsentStatusKey(provider), "consent_granted:true;tenants:1;flow:none")
+	// Store explicit consent status with known tenants.
+	// LastTenantDiscovery is set to now so the cache-expiry check does not
+	// trigger a RefreshTenantDiscovery call, keeping the test self-contained.
+	expectedTenants := []TenantInfo{
+		{
+			TenantID:    "explicit-tenant-alpha",
+			DisplayName: "Alpha Tenant",
+			Domain:      "alpha.onmicrosoft.com",
+			HasAccess:   true,
+		},
+	}
+	err := consentStore.StoreConsent(provider, &ConsentStatus{
+		Provider:            provider,
+		HasAdminConsent:     true,
+		ConsentGrantedAt:    time.Now(),
+		LastTenantDiscovery: time.Now(),
+		AccessibleTenants:   expectedTenants,
+	})
 	require.NoError(t, err)
 
-	// Test listing tenants
 	tenants, err := mtm.ListAccessibleTenants(ctx, provider)
 	assert.NoError(t, err)
-	assert.Len(t, tenants, 1)
+	require.Len(t, tenants, 1)
 
-	// Verify the tenant data matches what the mock implementation returns
-	expectedTenant := TenantInfo{
-		TenantID:    "tenant-1",
-		DisplayName: "Customer Tenant 1",
-		Domain:      "customer1.onmicrosoft.com",
-		HasAccess:   true,
-	}
-
-	assert.Equal(t, expectedTenant.TenantID, tenants[0].TenantID)
-	assert.Equal(t, expectedTenant.DisplayName, tenants[0].DisplayName)
-	assert.Equal(t, expectedTenant.Domain, tenants[0].Domain)
-	assert.Equal(t, expectedTenant.HasAccess, tenants[0].HasAccess)
+	assert.Equal(t, expectedTenants[0].TenantID, tenants[0].TenantID)
+	assert.Equal(t, expectedTenants[0].DisplayName, tenants[0].DisplayName)
+	assert.Equal(t, expectedTenants[0].Domain, tenants[0].Domain)
+	assert.Equal(t, expectedTenants[0].HasAccess, tenants[0].HasAccess)
 }
 
 func TestMultiTenantManager_RevokeConsent(t *testing.T) {
 	credStore := NewMockCredentialStore()
+	consentStore := NewInMemoryConsentStore()
 	httpClient := &http.Client{}
-	mtm := NewMultiTenantManager(credStore, httpClient)
+	mtm := NewMultiTenantManager(credStore, consentStore, httpClient)
 
 	ctx := context.Background()
 	provider := "microsoft"
@@ -333,7 +352,7 @@ func TestMultiTenantManager_RevokeConsent(t *testing.T) {
 		},
 	}
 
-	err := mtm.storeConsentStatus(provider, status)
+	err := consentStore.StoreConsent(provider, status)
 	require.NoError(t, err)
 
 	// Store some tenant tokens
@@ -353,7 +372,7 @@ func TestMultiTenantManager_RevokeConsent(t *testing.T) {
 	err = mtm.RevokeConsent(ctx, provider)
 	assert.NoError(t, err)
 
-	// Verify consent status was reset
+	// Verify consent status was reset (GetConsentStatus returns default when deleted)
 	newStatus, err := mtm.GetConsentStatus(ctx, provider)
 	assert.NoError(t, err)
 	assert.False(t, newStatus.HasAdminConsent)
@@ -428,17 +447,24 @@ func TestMicrosoftMultiTenantProvider_CreateInTenant(t *testing.T) {
 	provider := NewMicrosoftMultiTenantProvider(credStore, httpClient)
 
 	ctx := context.Background()
-	tenantID := "tenant-1" // Use the mock tenant ID
+	tenantID := "tenant-1"
 	resourceType := "users"
 	data := map[string]interface{}{
 		"displayName":       "John Doe",
 		"userPrincipalName": "john@test.com",
 	}
 
-	// Set up consent status using the simplified format that matches the mock
-	err := credStore.StoreClientSecret(
-		provider.multiTenantManager.getConsentStatusKey(provider.GetInfo().Name),
-		"consent_granted:true;tenants:1;flow:none")
+	// Store real consent status via the provider's consentStore.
+	err := provider.multiTenantManager.consentStore.StoreConsent(
+		provider.GetInfo().Name,
+		&ConsentStatus{
+			Provider:         provider.GetInfo().Name,
+			HasAdminConsent:  true,
+			ConsentGrantedAt: time.Now(),
+			AccessibleTenants: []TenantInfo{
+				{TenantID: tenantID, HasAccess: true},
+			},
+		})
 	require.NoError(t, err)
 
 	tenantKey := provider.multiTenantManager.getTenantKey(provider.GetInfo().Name, tenantID)
@@ -612,8 +638,9 @@ func TestTenantOnboardingWorkflow_ValidateRequest(t *testing.T) {
 
 func BenchmarkMultiTenantManager_GetTenantToken(b *testing.B) {
 	credStore := NewMockCredentialStore()
+	consentStore := NewInMemoryConsentStore()
 	httpClient := &http.Client{}
-	mtm := NewMultiTenantManager(credStore, httpClient)
+	mtm := NewMultiTenantManager(credStore, consentStore, httpClient)
 
 	ctx := context.Background()
 	provider := "microsoft"
@@ -631,7 +658,9 @@ func BenchmarkMultiTenantManager_GetTenantToken(b *testing.B) {
 		},
 	}
 
-	_ = mtm.storeConsentStatus(provider, status)
+	if err := consentStore.StoreConsent(provider, status); err != nil {
+		b.Fatal(err)
+	}
 
 	tenantKey := mtm.getTenantKey(provider, tenantID)
 	validToken := &TokenSet{
@@ -639,7 +668,9 @@ func BenchmarkMultiTenantManager_GetTenantToken(b *testing.B) {
 		TokenType:   "Bearer",
 		ExpiresAt:   time.Now().Add(1 * time.Hour),
 	}
-	_ = credStore.StoreTokenSet(tenantKey, validToken)
+	if err := credStore.StoreTokenSet(tenantKey, validToken); err != nil {
+		b.Fatal(err)
+	}
 
 	b.ResetTimer()
 
@@ -672,7 +703,9 @@ func BenchmarkMicrosoftMultiTenantProvider_CreateInTenant(b *testing.B) {
 		},
 	}
 
-	_ = provider.multiTenantManager.storeConsentStatus(provider.GetInfo().Name, status)
+	if err := provider.multiTenantManager.consentStore.StoreConsent(provider.GetInfo().Name, status); err != nil {
+		b.Fatal(err)
+	}
 
 	tenantKey := provider.multiTenantManager.getTenantKey(provider.GetInfo().Name, tenantID)
 	validToken := &TokenSet{
@@ -680,7 +713,9 @@ func BenchmarkMicrosoftMultiTenantProvider_CreateInTenant(b *testing.B) {
 		TokenType:   "Bearer",
 		ExpiresAt:   time.Now().Add(1 * time.Hour),
 	}
-	_ = credStore.StoreTokenSet(tenantKey, validToken)
+	if err := credStore.StoreTokenSet(tenantKey, validToken); err != nil {
+		b.Fatal(err)
+	}
 
 	b.ResetTimer()
 


### PR DESCRIPTION
## Summary

- Defines `ConsentStore` interface (`StoreConsent` / `GetConsent` / `DeleteConsent`) in `features/saas/multitenant_store.go`
- Adds `InMemoryConsentStore` — JSON round-trip over `sync.RWMutex`-protected `[]byte` map — as the pre-production implementation
- Deletes `storeConsentStatus`, `getConsentStatus`, `getConsentStatusKey` from `MultiTenantManager`; removes all `CredentialStore.StoreClientSecret`/`GetClientSecret` calls from consent-state paths
- Rewrites `TestMultiTenantManager_ListAccessibleTenants` to store explicit `ConsentStatus` with real tenants — removes assertions against fabricated `tenant-1`/`Customer Tenant 1`/`customer1.onmicrosoft.com` values
- Fixes silenced error in `ListAccessibleTenants` post-refresh `GetConsent` call
- Adds `features/saas/README.md` ConsentStore section

The old `getConsentStatus` fabricated `AccessibleTenants` (always `[{TenantID:"tenant-1",...}]`) whenever it saw `consent_granted:true`, regardless of which tenants were actually consented to. JSON round-trip eliminates the fabrication; old-format data triggers a hard "re-grant admin consent" error rather than silently producing fake tenant data.

Fixes #954

## Specialist Review Results

| Specialist | Result | Notes |
|---|---|---|
| QA Test Runner (`make test-agent-complete`) | **PASS** | All 100+ packages pass including `features/saas`; cross-platform builds verified |
| QA Code Reviewer | **PASS** | New files meet CFGMS standards; error silencing fix and benchmark setup fix verified |
| Security Engineer | **PASS** | 0 blocking issues; notes that story removes a pre-existing tenant-isolation footgun |

## Test plan

- [x] `go test ./features/saas/...` — all tests pass (1 network-skip in CI expected for `TestMicrosoftMultiTenantProvider_CreateInTenant`)
- [x] `make test-agent-complete` — full validation suite passes
- [x] `make check-architecture` — no central provider violations
- [x] `make security-scan` — no new security findings

🤖 Generated with [Claude Code](https://claude.ai/claude-code)