### PR TITLE
po: extend Path A (inline) to team-relevant args

### DIFF
--- a/.claude/commands/po.md
+++ b/.claude/commands/po.md
@@ -3,7 +3,7 @@ name: po
 description: Product Owner — pipeline dashboard, intent capture, and autonomous orchestration
 parameters:
   - name: subcommand
-    description: "Optional: 'status' (default), 'intent <topic>', 'next', or 'cron'"
+    description: "Optional: 'status' (default), 'intent <topic>', 'next', 'cron', 'cycle', 'decompose [<epic#>]', or 'plan [<epic#>]'"
     required: false
 ---
 
@@ -13,25 +13,33 @@ The PO manages the autonomous pipeline: dashboard, intent capture, targeted unbl
 
 ## Execution
 
-Two execution paths depending on `$ARGUMENTS`:
+Two execution paths depending on `$ARGUMENTS`. The dividing line is whether the action needs to spawn nested subagents or an agent team — those need the parent session's full tool access, so they run inline.
 
-### Path A — `cron` (run inline in the main session)
+### Path A — team-relevant args (run inline in the main session)
 
-If `$ARGUMENTS` starts with `cron` (with or without further sub-arguments), do **NOT** spawn the PO as a subagent. Instead, execute the pipeline cycle inline in the main session.
+If `$ARGUMENTS` starts with any of `cron`, `cycle`, `decompose`, or `plan`, do **NOT** spawn the PO as a subagent. Instead, execute directly in the main session.
 
-**Why:** A subagent cannot reliably spawn nested subagents (Acceptance Reviewer, BA, Tech Lead, Planning Team), and its bash commands trigger approval prompts despite `mode: auto`. Running inline gives the cycle full Agent-tool access and the parent session's allow list. This is documented in memory `feedback_po_run_inline.md`.
+**Why:** A subagent cannot reliably spawn nested subagents (Acceptance Reviewer, BA, Tech Lead, Planning Team) — its `tools:` field is restricted (no `TeamCreate`, `TeamDelete`, `SendMessage`), and its bash commands trigger approval prompts despite `mode: auto`. Running inline gives the cycle full Agent-tool access and the parent session's allow list. Documented in memory `feedback_po_run_inline.md`.
+
+**Routing within Path A:**
+
+| Args | Action |
+|------|--------|
+| `cron` | Pipeline Cycle (§4) — **skip Step 6 (Planning Team)**. Autonomous; cheap; runs every interval. |
+| `cycle` | Pipeline Cycle (§4) — **including Step 6**. Manual; full cycle on demand. |
+| `decompose [<epic#>]` | Run §4.1 Step 6 (Planning Team) only — for the named epic, or every `pipeline:epic` with no sub-issues if no number is given. |
+| `plan [<epic#>]` | Alias for `decompose`. |
 
 **How:**
-1. Read `.claude/agents/po.md` to load the PO's behavioral rules and the Pipeline Cycle (§4) steps.
-2. Execute Pipeline Cycle (§4) directly in the main session — preflight, unblock check, agent cleanup, Tech Lead pass, dispatch, fix cycle, Acceptance Reviewer (§4.1 Step 5), forward edge, session log.
-3. Honor the 4-container cap from `feedback_max_running_agents.md` — the cap is on docker containers (`./.claude/scripts/agent-dispatch.sh list-running` count) only. Acceptance Reviewer subagents are in-process and do NOT count.
-4. Spawn the Acceptance Reviewer subagent for each review-ready PR (use the Agent tool with `subagent_type: acceptance-reviewer`, `mode: auto`). Process PRs serially in FIFO order per `.claude/agents/po.md` §4.1 Step 5.
-5. **Skip Step 6 (Planning Team) entirely in cron mode.** Planning Team is interactive-only — epic decomposition only runs when the founder invokes `/po` interactively. If undecomposed epics are blocking forward progress, mention it in the cycle summary so the founder can run an interactive session.
-6. Report the cycle summary back to the founder using the same format the PO subagent uses.
+1. Read `.claude/agents/po.md` to load the PO's behavioral rules and the relevant section.
+2. Execute the section directly in the main session — preflight, unblock check, agent cleanup, Tech Lead pass, dispatch, fix cycle, Acceptance Reviewer (§4.1 Step 5), Planning Team (§4.1 Step 6 — see routing table above), forward edge, session log.
+3. Honor the 4-container cap from `feedback_max_running_agents.md` — the cap is on docker containers (`./.claude/scripts/agent-dispatch.sh list-running` count) only. Acceptance Reviewer, BA, and Tech Lead subagents are in-process and do NOT count.
+4. Spawn nested subagents via the Agent tool with `mode: auto`. Spawn the Planning Team via `TeamCreate` + Agent calls with `team_name` (per `.claude/agents/po.md` §4.1 Step 6c).
+5. Report the summary back to the founder using the same format the PO subagent uses.
 
-### Path B — anything else (spawn the PO subagent)
+### Path B — lightweight conversation (spawn the PO subagent)
 
-For `status` (default), `intent <topic>`, `next`, or natural-language input, spawn the PO agent so it stays in role for the rest of the session:
+For `status` (default), `intent <topic>`, `next`, `unblock #NNN`, or any natural-language pipeline query, spawn the PO agent so it stays in role for the rest of the session:
 
 ```
 Agent tool:
@@ -46,3 +54,5 @@ The PO agent definition is at `.claude/agents/po.md`. It will:
 3. Handle intent capture, unblocks, next action, and story status queries
 
 If `$ARGUMENTS` contains a subcommand (e.g., `intent certificate rotation`), pass it to the agent so it routes to the correct action immediately.
+
+**Note:** Intent capture (§2) runs in Path B because it's a structured conversation that ends in a `gh issue create` — no Planning Team, no agent dispatch. The created epic is later picked up by `/po cycle` or `/po decompose <#>` (Path A) for BA/Tech Lead orchestration.


### PR DESCRIPTION
## Summary

- Path B (PO subagent) tool field excludes \`TeamCreate\`, \`TeamDelete\`, \`SendMessage\` — Planning Team flow (po.md §6) couldn't run from any subagent context, including \`/po-live\` (which spawns the subagent via the \`/po\` slash command on startup)
- Extend Path A (inline) trigger from \`cron\` alone to \`{cron, cycle, decompose, plan}\` so any args that need team tools run inline with full parent-session tool access
- Path B remains for lightweight conversation: \`status\`, \`intent <topic>\`, \`next\`, \`unblock\`, story queries

## Routing within Path A

| Args | Action |
|------|--------|
| \`cron\` | Pipeline Cycle, skip Step 6 (autonomous interval — keep cheap) |
| \`cycle\` | Pipeline Cycle, including Step 6 (manual full cycle) |
| \`decompose [<epic#>]\` | Step 6 only — named epic, or all undecomposed |
| \`plan [<epic#>]\` | Alias for \`decompose\` |

## Test plan

- [ ] \`/po\` (no args) — Path B, dashboard renders, no regression
- [ ] \`/po cron\` — Path A, runs preflight, skips Planning Team
- [ ] \`/po cycle\` — Path A, runs Planning Team for one undecomposed epic
- [ ] \`/po decompose <#>\` — Path A, only runs Planning Team on the named epic
- [ ] \`/po-live decompose <#>\` — initial prompt \`/po decompose <#>\` → Path A → Planning Team works inside live container

🤖 Generated with [Claude Code](https://claude.com/claude-code)