### PR TITLE
saas: add sync.RWMutex to MultiTenantManager.tenantCache (Issue #955)

### DIFF
--- a/features/saas/multitenant.go
+++ b/features/saas/multitenant.go
@@ -35,6 +35,7 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"sync"
 	"time"
 )
 
@@ -47,6 +48,7 @@ type MultiTenantManager struct {
 
 	// Cache of tenant discovery results to avoid repeated API calls
 	tenantCache map[string]*TenantDiscoveryResult
+	cacheMu     sync.RWMutex
 	cacheExpiry time.Duration
 }
 
@@ -238,7 +240,9 @@ func (mtm *MultiTenantManager) CompleteAdminConsent(ctx context.Context, provide
 	}
 
 	// Cache the discovery result
+	mtm.cacheMu.Lock()
 	mtm.tenantCache[provider] = discoveryResult
+	mtm.cacheMu.Unlock()
 
 	return nil
 }
@@ -338,7 +342,9 @@ func (mtm *MultiTenantManager) RefreshTenantDiscovery(ctx context.Context, provi
 	}
 
 	// Update cache
+	mtm.cacheMu.Lock()
 	mtm.tenantCache[provider] = discoveryResult
+	mtm.cacheMu.Unlock()
 
 	return nil
 }
@@ -367,7 +373,9 @@ func (mtm *MultiTenantManager) RevokeConsent(ctx context.Context, provider strin
 	}
 
 	// Clear cache
+	mtm.cacheMu.Lock()
 	delete(mtm.tenantCache, provider)
+	mtm.cacheMu.Unlock()
 
 	return nil
 }

--- a/features/saas/multitenant_test.go
+++ b/features/saas/multitenant_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"sync"
 	"testing"
 	"time"
 
@@ -632,6 +633,75 @@ func TestTenantOnboardingWorkflow_ValidateRequest(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestMultiTenantManager_TenantCacheConcurrency verifies that concurrent writes
+// to tenantCache (from RefreshTenantDiscovery triggered directly and via
+// ListAccessibleTenants) do not cause data races under go test -race.
+// tenantCache has no direct read paths in the current code, so this test exercises
+// write-write safety. The RWMutex is chosen to be forward-compatible with future reads.
+func TestMultiTenantManager_TenantCacheConcurrency(t *testing.T) {
+	credStore := NewMockCredentialStore()
+	consentStore := NewInMemoryConsentStore()
+	httpClient := &http.Client{}
+	mtm := NewMultiTenantManager(credStore, consentStore, httpClient)
+
+	ctx := context.Background()
+	provider := "microsoft"
+
+	// Pre-populate the base token. Only reads occur on this key during concurrent
+	// execution — concurrent map reads in Go are safe without a mutex.
+	err := credStore.StoreTokenSet(provider, &TokenSet{
+		AccessToken:  "base-token",
+		RefreshToken: "base-refresh-token",
+		TokenType:    "Bearer",
+		ExpiresAt:    time.Now().Add(1 * time.Hour),
+	})
+	require.NoError(t, err)
+
+	// Set LastTenantDiscovery in the past so ListAccessibleTenants triggers a
+	// RefreshTenantDiscovery call, maximising concurrent write contention on tenantCache.
+	err = consentStore.StoreConsent(provider, &ConsentStatus{
+		Provider:            provider,
+		HasAdminConsent:     true,
+		ConsentGrantedAt:    time.Now(),
+		LastTenantDiscovery: time.Now().Add(-30 * time.Minute),
+		AccessibleTenants: []TenantInfo{
+			{TenantID: "tenant-1", HasAccess: true},
+		},
+	})
+	require.NoError(t, err)
+
+	const goroutines = 10
+	errs := make([]error, goroutines)
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+
+	for i := 0; i < goroutines; i++ {
+		go func(i int) {
+			defer wg.Done()
+			<-start // block until all goroutines are released simultaneously
+			if i%2 == 0 {
+				_, errs[i] = mtm.ListAccessibleTenants(ctx, provider)
+			} else {
+				errs[i] = mtm.RefreshTenantDiscovery(ctx, provider)
+			}
+		}(i)
+	}
+
+	close(start) // release all goroutines at once to maximise contention
+	wg.Wait()    // establishes happens-before for errs reads below
+
+	for i, goroutineErr := range errs {
+		assert.NoError(t, goroutineErr, "goroutine %d returned unexpected error", i)
+	}
+
+	// Verify that at least one refresh updated the consent store's accessible tenants.
+	status, err := mtm.GetConsentStatus(ctx, provider)
+	require.NoError(t, err)
+	assert.True(t, status.HasAdminConsent)
+	assert.NotEmpty(t, status.AccessibleTenants)
 }
 
 // Benchmarks


### PR DESCRIPTION
## Summary

- Add `cacheMu sync.RWMutex` field to `MultiTenantManager` alongside `tenantCache`
- Acquire write-lock around all three `tenantCache` mutation sites: `CompleteAdminConsent`, `RefreshTenantDiscovery`, `RevokeConsent`
- Add `TestMultiTenantManager_TenantCacheConcurrency`: 10 goroutines burst simultaneously via a start channel, alternating `ListAccessibleTenants` and `RefreshTenantDiscovery`, with per-goroutine error collection and post-`wg.Wait()` assertions — passes `go test -race`

Fixes #955

## Specialist Review Results

| Specialist | Result |
|---|---|
| QA Test Runner | **PASS** — all quality validation gates passed, `go test -race ./features/saas/...` clean |
| QA Code Reviewer | **PASS** — lock placement correct at all 3 write sites; concurrent test uses channel-gated start (no `time.Sleep`); errors collected and asserted; no blocking issues in diff |
| Security Engineer | **PASS** — no hardcoded secrets, no central provider violations, `make security-scan` / `make check-architecture` / `make security-precommit` all passed |

## Test Plan

- [x] `go test -race ./features/saas/...` — passes (zero race-detector reports)
- [x] `TestMultiTenantManager_TenantCacheConcurrency` — 10-goroutine concurrent write test passes
- [x] All existing saas tests unchanged and passing
- [x] `make test-agent-complete` — full suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)