### PR TITLE
saas: replace hardcoded mock tokens with real OAuth2 code exchange (Issue #698)

### DIFF
--- a/features/saas/README.md
+++ b/features/saas/README.md
@@ -18,7 +18,7 @@ Virtual Steward (M365)
 ## Key Components
 
 ### 1. Authentication Framework
-- **OAuth2 with PKCE**: Enhanced security for public clients
+- **OAuth2 with PKCE**: Authorization code exchange performs a real HTTP POST to the provider token endpoint; PKCE `code_verifier` is included when set
 - **Token Management**: Automatic refresh before expiration
 - **Secure Storage**: OS keychain integration where available
 - **Multi-Provider Support**: Extensible authentication providers

--- a/features/saas/auth.go
+++ b/features/saas/auth.go
@@ -20,7 +20,9 @@ package saas
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"net/url"
 	"strings"
@@ -388,6 +390,7 @@ func parseJWTConfig(config map[string]interface{}) (*JWTConfig, error) {
 // OAuth2Client interface for OAuth2 operations
 type OAuth2Client interface {
 	StartFlow(ctx context.Context, config *ExtendedOAuth2Config) (*OAuth2Flow, error)
+	ExchangeCode(ctx context.Context, flow *OAuth2Flow, authCode string) (*TokenSet, error)
 	ClientCredentialsGrant(ctx context.Context, config *ExtendedOAuth2Config) (*TokenSet, error)
 	RefreshToken(ctx context.Context, refreshToken string) (*TokenSet, error)
 }
@@ -413,11 +416,67 @@ func NewOAuth2Client(httpClient *http.Client) OAuth2Client {
 func (c *DefaultOAuth2Client) StartFlow(ctx context.Context, config *ExtendedOAuth2Config) (*OAuth2Flow, error) {
 	// Implementation would create OAuth2 flow with PKCE
 	return &OAuth2Flow{
-		AuthURL:     config.AuthURL,
-		RedirectURI: config.RedirectURL,
-		Created:     time.Now(),
-		ExpiresAt:   time.Now().Add(10 * time.Minute),
+		AuthURL:      config.AuthURL,
+		RedirectURI:  config.RedirectURL,
+		TokenURL:     config.TokenURL,
+		ClientID:     config.ClientID,
+		ClientSecret: config.ClientSecret,
+		Created:      time.Now(),
+		ExpiresAt:    time.Now().Add(10 * time.Minute),
 	}, nil
+}
+
+func (c *DefaultOAuth2Client) ExchangeCode(ctx context.Context, flow *OAuth2Flow, authCode string) (*TokenSet, error) {
+	data := url.Values{}
+	data.Set("grant_type", "authorization_code")
+	data.Set("code", authCode)
+	data.Set("redirect_uri", flow.RedirectURI)
+	data.Set("client_id", flow.ClientID)
+	data.Set("client_secret", flow.ClientSecret)
+	if flow.CodeVerifier != "" {
+		data.Set("code_verifier", flow.CodeVerifier)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, "POST", flow.TokenURL, strings.NewReader(data.Encode()))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create token request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("token request failed: %w", err)
+	}
+	defer func() {
+		_ = resp.Body.Close()
+	}()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("token endpoint returned status %d: %s", resp.StatusCode, string(body))
+	}
+
+	var tokenResp struct {
+		AccessToken  string `json:"access_token"`
+		RefreshToken string `json:"refresh_token"`
+		TokenType    string `json:"token_type"`
+		ExpiresIn    int    `json:"expires_in"`
+		Scope        string `json:"scope"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&tokenResp); err != nil {
+		return nil, fmt.Errorf("failed to decode token response: %w", err)
+	}
+
+	tokenSet := &TokenSet{
+		AccessToken:  tokenResp.AccessToken,
+		RefreshToken: tokenResp.RefreshToken,
+		TokenType:    tokenResp.TokenType,
+		ExpiresAt:    time.Now().Add(time.Duration(tokenResp.ExpiresIn) * time.Second),
+	}
+	if tokenResp.Scope != "" {
+		tokenSet.Scopes = strings.Fields(tokenResp.Scope)
+	}
+	return tokenSet, nil
 }
 
 func (c *DefaultOAuth2Client) ClientCredentialsGrant(ctx context.Context, config *ExtendedOAuth2Config) (*TokenSet, error) {

--- a/features/saas/multitenant.go
+++ b/features/saas/multitenant.go
@@ -410,14 +410,7 @@ func (mtm *MultiTenantManager) isTenantAccessible(status *ConsentStatus, tenantI
 }
 
 func (mtm *MultiTenantManager) completeOAuth2Flow(ctx context.Context, flow *OAuth2Flow, authCode string) (*TokenSet, error) {
-	// This would implement the actual OAuth2 authorization code exchange
-	// For now, return a mock token set
-	return &TokenSet{
-		AccessToken:  "admin-consent-token",
-		RefreshToken: "admin-refresh-token",
-		TokenType:    "Bearer",
-		ExpiresAt:    time.Now().Add(1 * time.Hour),
-	}, nil
+	return mtm.oauth2Client.ExchangeCode(ctx, flow, authCode)
 }
 
 func (mtm *MultiTenantManager) discoverTenants(ctx context.Context, provider string, tokenSet *TokenSet) (*TenantDiscoveryResult, error) {

--- a/features/saas/multitenant_test.go
+++ b/features/saas/multitenant_test.go
@@ -4,6 +4,7 @@ package saas
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
@@ -80,6 +81,11 @@ func (m *MockOAuth2Client) StartFlow(ctx context.Context, config *ExtendedOAuth2
 
 func (m *MockOAuth2Client) ClientCredentialsGrant(ctx context.Context, config *ExtendedOAuth2Config) (*TokenSet, error) {
 	args := m.Called(ctx, config)
+	return args.Get(0).(*TokenSet), args.Error(1)
+}
+
+func (m *MockOAuth2Client) ExchangeCode(ctx context.Context, flow *OAuth2Flow, authCode string) (*TokenSet, error) {
+	args := m.Called(ctx, flow, authCode)
 	return args.Get(0).(*TokenSet), args.Error(1)
 }
 
@@ -172,53 +178,208 @@ func TestMultiTenantManager_StartAdminConsent(t *testing.T) {
 }
 
 func TestMultiTenantManager_CompleteAdminConsent(t *testing.T) {
-	credStore := NewMockCredentialStore()
-	consentStore := NewInMemoryConsentStore()
-	httpClient := &http.Client{}
-	mtm := NewMultiTenantManager(credStore, consentStore, httpClient)
-
-	// Set up mock OAuth2 client
-	mockOAuth2 := &MockOAuth2Client{}
-	mtm.oauth2Client = mockOAuth2
-
-	ctx := context.Background()
-	provider := "microsoft"
-	authCode := "test-auth-code"
-
-	// First, start a consent flow to set up state in the ConsentStore.
-	config := &MultiTenantConfig{
-		OAuth2Config: OAuth2Config{
-			ClientID:     "test-client-id",
-			ClientSecret: "test-client-secret",
-			AuthURL:      "https://login.microsoftonline.com/{tenant}/oauth2/v2.0/authorize",
-			TokenURL:     "https://login.microsoftonline.com/{tenant}/oauth2/v2.0/token",
-			Scopes:       []string{"https://graph.microsoft.com/.default"},
+	tests := []struct {
+		name         string
+		authCode     string
+		serverResp   map[string]interface{}
+		serverStatus int
+		wantErr      bool
+	}{
+		{
+			name:     "successful consent completion",
+			authCode: "test-auth-code",
+			serverResp: map[string]interface{}{
+				"access_token":  "real-access-token",
+				"refresh_token": "real-refresh-token",
+				"token_type":    "Bearer",
+				"expires_in":    3600,
+				"scope":         "https://graph.microsoft.com/.default",
+			},
+			serverStatus: http.StatusOK,
+			wantErr:      false,
 		},
-		IsMultiTenant: true,
+		{
+			name:         "token endpoint returns error",
+			authCode:     "bad-code",
+			serverResp:   map[string]interface{}{"error": "invalid_grant"},
+			serverStatus: http.StatusBadRequest,
+			wantErr:      true,
+		},
 	}
 
-	mockFlow := &OAuth2Flow{
-		AuthURL:   "https://test-auth-url.com",
-		State:     "test-state",
-		Created:   time.Now(),
-		ExpiresAt: time.Now().Add(10 * time.Minute),
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Token exchange server verifies form fields and returns configured response.
+			tokenServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				require.NoError(t, r.ParseForm())
+				assert.Equal(t, "authorization_code", r.FormValue("grant_type"))
+				assert.Equal(t, tt.authCode, r.FormValue("code"))
+				assert.Equal(t, "test-client-id", r.FormValue("client_id"))
+				assert.NotEmpty(t, r.FormValue("redirect_uri"))
+
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(tt.serverStatus)
+				if err := json.NewEncoder(w).Encode(tt.serverResp); err != nil {
+					http.Error(w, "encode error", http.StatusInternalServerError)
+				}
+			}))
+			defer tokenServer.Close()
+
+			credStore := NewMockCredentialStore()
+			consentStore := NewInMemoryConsentStore()
+			// Use the real DefaultOAuth2Client so ExchangeCode hits the httptest server.
+			mtm := NewMultiTenantManager(credStore, consentStore, &http.Client{})
+
+			ctx := context.Background()
+			provider := "microsoft"
+
+			// Directly inject a ConsentStatus whose flow points at the test token server.
+			// This is equivalent to what StartAdminConsent stores after calling StartFlow.
+			flow := &OAuth2Flow{
+				TokenURL:     tokenServer.URL,
+				ClientID:     "test-client-id",
+				ClientSecret: "test-client-secret",
+				RedirectURI:  "https://app.example.com/callback",
+				State:        "test-state",
+				Created:      time.Now(),
+				ExpiresAt:    time.Now().Add(10 * time.Minute),
+			}
+			require.NoError(t, consentStore.StoreConsent(provider, &ConsentStatus{
+				Provider:    provider,
+				ConsentFlow: flow,
+			}))
+
+			err := mtm.CompleteAdminConsent(ctx, provider, tt.authCode)
+
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+
+			updatedStatus, err := mtm.GetConsentStatus(ctx, provider)
+			require.NoError(t, err)
+			assert.True(t, updatedStatus.HasAdminConsent)
+
+			// Confirm stored token came from the httptest server, not hardcoded literals.
+			storedTokens, err := credStore.GetTokenSet(provider)
+			require.NoError(t, err)
+			assert.Equal(t, "real-access-token", storedTokens.AccessToken)
+			assert.Equal(t, "real-refresh-token", storedTokens.RefreshToken)
+		})
+	}
+}
+
+func TestDefaultOAuth2Client_ExchangeCode(t *testing.T) {
+	tests := []struct {
+		name         string
+		flow         *OAuth2Flow
+		authCode     string
+		serverResp   map[string]interface{}
+		serverStatus int
+		wantErr      bool
+		validate     func(t *testing.T, ts *TokenSet)
+	}{
+		{
+			name:     "successful exchange with all fields",
+			authCode: "auth-code-abc",
+			flow: &OAuth2Flow{
+				ClientID:     "client-123",
+				ClientSecret: "secret-xyz",
+				RedirectURI:  "https://app.example.com/callback",
+				CodeVerifier: "verifier-pkce",
+			},
+			serverResp: map[string]interface{}{
+				"access_token":  "exchanged-access-token",
+				"refresh_token": "exchanged-refresh-token",
+				"token_type":    "Bearer",
+				"expires_in":    7200,
+				"scope":         "openid profile email",
+			},
+			serverStatus: http.StatusOK,
+			wantErr:      false,
+			validate: func(t *testing.T, ts *TokenSet) {
+				assert.Equal(t, "exchanged-access-token", ts.AccessToken)
+				assert.Equal(t, "exchanged-refresh-token", ts.RefreshToken)
+				assert.Equal(t, "Bearer", ts.TokenType)
+				assert.ElementsMatch(t, []string{"openid", "profile", "email"}, ts.Scopes)
+				assert.True(t, ts.ExpiresAt.After(time.Now()))
+			},
+		},
+		{
+			name:     "exchange without PKCE code_verifier",
+			authCode: "auth-code-nopkce",
+			flow: &OAuth2Flow{
+				ClientID:     "client-123",
+				ClientSecret: "secret-xyz",
+				RedirectURI:  "https://app.example.com/callback",
+				CodeVerifier: "",
+			},
+			serverResp: map[string]interface{}{
+				"access_token": "access-nopkce",
+				"token_type":   "Bearer",
+				"expires_in":   3600,
+			},
+			serverStatus: http.StatusOK,
+			wantErr:      false,
+			validate: func(t *testing.T, ts *TokenSet) {
+				assert.Equal(t, "access-nopkce", ts.AccessToken)
+			},
+		},
+		{
+			name:     "token endpoint returns 400",
+			authCode: "bad-code",
+			flow: &OAuth2Flow{
+				ClientID:     "client-123",
+				ClientSecret: "secret-xyz",
+				RedirectURI:  "https://app.example.com/callback",
+			},
+			serverResp:   map[string]interface{}{"error": "invalid_grant", "error_description": "code expired"},
+			serverStatus: http.StatusBadRequest,
+			wantErr:      true,
+		},
 	}
 
-	mockOAuth2.On("StartFlow", mock.Anything, mock.Anything).Return(mockFlow, nil)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tokenServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				require.NoError(t, r.ParseForm())
+				assert.Equal(t, "authorization_code", r.FormValue("grant_type"))
+				assert.Equal(t, tt.authCode, r.FormValue("code"))
+				assert.Equal(t, tt.flow.RedirectURI, r.FormValue("redirect_uri"))
+				assert.Equal(t, tt.flow.ClientID, r.FormValue("client_id"))
+				assert.Equal(t, tt.flow.ClientSecret, r.FormValue("client_secret"))
+				if tt.flow.CodeVerifier != "" {
+					assert.Equal(t, tt.flow.CodeVerifier, r.FormValue("code_verifier"))
+				} else {
+					assert.Empty(t, r.FormValue("code_verifier"))
+				}
 
-	_, err := mtm.StartAdminConsent(ctx, provider, config)
-	require.NoError(t, err)
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(tt.serverStatus)
+				if err := json.NewEncoder(w).Encode(tt.serverResp); err != nil {
+					http.Error(w, "encode error", http.StatusInternalServerError)
+				}
+			}))
+			defer tokenServer.Close()
 
-	// StartAdminConsent stored the consent status (with ConsentFlow) in consentStore.
-	// CompleteAdminConsent reads it back from there — no manual setup needed.
+			tt.flow.TokenURL = tokenServer.URL
+			client := &DefaultOAuth2Client{httpClient: &http.Client{}}
 
-	err = mtm.CompleteAdminConsent(ctx, provider, authCode)
-	assert.NoError(t, err)
+			ts, err := client.ExchangeCode(context.Background(), tt.flow, tt.authCode)
 
-	// Verify consent status was updated
-	updatedStatus, err := mtm.GetConsentStatus(ctx, provider)
-	assert.NoError(t, err)
-	assert.True(t, updatedStatus.HasAdminConsent)
+			if tt.wantErr {
+				assert.Error(t, err)
+				assert.Nil(t, ts)
+				return
+			}
+			require.NoError(t, err)
+			require.NotNil(t, ts)
+			if tt.validate != nil {
+				tt.validate(t, ts)
+			}
+		})
+	}
 }
 
 func TestMultiTenantManager_GetTenantToken(t *testing.T) {

--- a/features/saas/types.go
+++ b/features/saas/types.go
@@ -180,6 +180,15 @@ type OAuth2Flow struct {
 	// RedirectURI for OAuth2 callback
 	RedirectURI string `json:"redirect_uri"`
 
+	// TokenURL is the token endpoint for the authorization code exchange
+	TokenURL string `json:"token_url"`
+
+	// ClientID for the authorization code exchange
+	ClientID string `json:"client_id"`
+
+	// ClientSecret for the authorization code exchange
+	ClientSecret string `json:"client_secret"`
+
 	// Created timestamp
 	Created time.Time `json:"created"`
 


### PR DESCRIPTION
## Summary

- Removes hardcoded `"admin-consent-token"` / `"admin-refresh-token"` literals from `MultiTenantManager.completeOAuth2Flow`; delegates to `oauth2Client.ExchangeCode`
- Adds `ExchangeCode(ctx, flow, authCode) (*TokenSet, error)` to the `OAuth2Client` interface and implements it in `DefaultOAuth2Client` with a real RFC 6749 HTTP POST form exchange
- Adds `TokenURL`, `ClientID`, `ClientSecret` fields to `OAuth2Flow` (populated by `StartFlow`) so the exchange config travels with the flow
- Updates `features/saas/README.md` to reflect real HTTP token exchange

## Test plan

- [ ] `TestDefaultOAuth2Client_ExchangeCode` (new): verifies correct form fields (`grant_type`, `code`, `redirect_uri`, `client_id`, `client_secret`, `code_verifier`), JSON token parsing, error path on non-200 — all against `httptest.NewServer`
- [ ] `TestMultiTenantManager_CompleteAdminConsent` (rewritten): uses `httptest.NewServer` for token exchange; asserts stored token comes from server response, not literals
- [ ] `MockOAuth2Client.ExchangeCode` added for interface compliance in other tests
- [ ] All 136 packages pass `make test-agent-complete` including race detection

## Specialist Review Results

**QA Test Runner: PASS** — All quality validation gates passed (136 packages, integration tests, cross-platform builds, security scans)

**Security Engineer: PASS** — No blocking issues. Confirmed: `http.NewRequestWithContext` with caller context, `Content-Type: application/x-www-form-urlencoded`, no logging of auth code or client_secret, no central provider violations

**QA Code Reviewer: FAIL on pre-existing scope** — All 9 blocking findings are pre-existing stubs explicitly out of scope per issue AC: `ClientCredentialsGrant`/`RefreshToken`/`discoverTenants` stubs (issue says "DO NOT fix — out of scope"), `generateJWT`/`refreshTenantToken`/benchmark patterns (pre-existing, not introduced by this story). No issues with the new `ExchangeCode` implementation itself.

## Scope constraints respected

- `discoverTenants` not modified (owned by #956)
- `DefaultOAuth2Client.ClientCredentialsGrant` and `RefreshToken` stubs not changed (explicitly excluded by issue AC)

Fixes #698

🤖 Generated with [Claude Code](https://claude.com/claude-code)