### PR TITLE
saas: wire real TenantDiscoverer into MultiTenantManager, delete discoverTenants mock (Issue #956)

### DIFF
--- a/features/saas/README.md
+++ b/features/saas/README.md
@@ -137,13 +137,45 @@ this implementation to verify round-trip fidelity for all fields.
 ```go
 // Zero value is ready to use, or construct explicitly:
 store := NewInMemoryConsentStore()
-manager := NewMultiTenantManager(credStore, store, httpClient)
+manager := NewMultiTenantManager(credStore, store, httpClient, discoverer)
 ```
 
 `CredentialStore` (`StoreClientSecret` / `GetClientSecret`) is **no longer used
 for consent state**. Those methods remain on the interface for auth flows only.
 Any legacy flat-string consent data (e.g. `consent_granted:true;tenants:1`) that
 arrives at `GetConsent` returns a hard error — re-grant admin consent to recover.
+
+### TenantDiscoverer wiring
+
+Tenant discovery is performed through the `TenantDiscoverer` interface (defined in
+`multitenant_store.go`):
+
+```go
+type TenantDiscoverer interface {
+    DiscoverTenants(ctx context.Context, token *TokenSet) (*TenantDiscoveryResult, error)
+}
+```
+
+**Production implementation:** `MicrosoftMultiTenantProvider` satisfies
+`TenantDiscoverer` via its `DiscoverTenants` method, which delegates to
+`DiscoverTenantsFromMicrosoft`. This makes a real HTTP GET to the Microsoft Graph
+`/v1.0/organization` endpoint and maps the response to `[]TenantInfo`.
+`NewMicrosoftMultiTenantProvider` wires itself as the discoverer at construction
+time:
+
+```go
+p := &MicrosoftMultiTenantProvider{...}
+p.multiTenantManager = NewMultiTenantManager(credStore, store, httpClient, p)
+```
+
+**Test implementation:** Unit tests use `stubTenantDiscoverer` (defined in
+`multitenant_test.go`) which returns a configurable fixed list of tenants without
+making any HTTP calls. Pass it to `NewMultiTenantManager` as the fourth argument:
+
+```go
+stub := newStubTenantDiscoverer(TenantInfo{TenantID: "test-tenant", HasAccess: true})
+mtm := NewMultiTenantManager(credStore, store, httpClient, stub)
+```
 
 ## Tenant-Scoped Operations
 

--- a/features/saas/microsoft_multitenant.go
+++ b/features/saas/microsoft_multitenant.go
@@ -53,11 +53,19 @@ func NewMicrosoftMultiTenantProvider(credStore CredentialStore, httpClient *http
 	baseProvider := NewBaseProvider(info, httpClient)
 	baseProvider.SetCredentialStore(credStore)
 
-	return &MicrosoftMultiTenantProvider{
-		BaseProvider:       baseProvider,
-		multiTenantManager: NewMultiTenantManager(credStore, NewInMemoryConsentStore(), httpClient),
-		baseURL:            "https://graph.microsoft.com/v1.0",
+	p := &MicrosoftMultiTenantProvider{
+		BaseProvider: baseProvider,
+		baseURL:      "https://graph.microsoft.com/v1.0",
 	}
+	// Wire self as the TenantDiscoverer so DiscoverTenantsFromMicrosoft is the
+	// production implementation used by MultiTenantManager.discoverTenants.
+	p.multiTenantManager = NewMultiTenantManager(credStore, NewInMemoryConsentStore(), httpClient, p)
+	return p
+}
+
+// DiscoverTenants implements TenantDiscoverer by delegating to DiscoverTenantsFromMicrosoft.
+func (p *MicrosoftMultiTenantProvider) DiscoverTenants(ctx context.Context, token *TokenSet) (*TenantDiscoveryResult, error) {
+	return p.DiscoverTenantsFromMicrosoft(ctx, token)
 }
 
 // Multi-Tenant specific configuration

--- a/features/saas/multitenant.go
+++ b/features/saas/multitenant.go
@@ -16,7 +16,7 @@
 //
 // Usage Example:
 //
-//	manager := NewMultiTenantManager(credStore, NewInMemoryConsentStore(), httpClient)
+//	manager := NewMultiTenantManager(credStore, NewInMemoryConsentStore(), httpClient, discoverer)
 //
 //	// Start admin consent flow
 //	consentURL, err := manager.StartAdminConsent(ctx, "microsoft", config)
@@ -41,10 +41,11 @@ import (
 
 // MultiTenantManager handles multi-tenant OAuth2 consent flows and token management
 type MultiTenantManager struct {
-	credStore    CredentialStore
-	consentStore ConsentStore
-	httpClient   *http.Client
-	oauth2Client OAuth2Client
+	credStore        CredentialStore
+	consentStore     ConsentStore
+	httpClient       *http.Client
+	oauth2Client     OAuth2Client
+	tenantDiscoverer TenantDiscoverer
 
 	// Cache of tenant discovery results to avoid repeated API calls
 	tenantCache map[string]*TenantDiscoveryResult
@@ -55,14 +56,17 @@ type MultiTenantManager struct {
 // NewMultiTenantManager creates a new multi-tenant manager.
 // consentStore persists admin-consent state; pass NewInMemoryConsentStore() for
 // pre-production use until a durable implementation is available.
-func NewMultiTenantManager(credStore CredentialStore, consentStore ConsentStore, httpClient *http.Client) *MultiTenantManager {
+// discoverer performs the actual tenant discovery API call after consent is
+// granted; MicrosoftMultiTenantProvider satisfies this interface in production.
+func NewMultiTenantManager(credStore CredentialStore, consentStore ConsentStore, httpClient *http.Client, discoverer TenantDiscoverer) *MultiTenantManager {
 	return &MultiTenantManager{
-		credStore:    credStore,
-		consentStore: consentStore,
-		httpClient:   httpClient,
-		oauth2Client: NewOAuth2Client(httpClient),
-		tenantCache:  make(map[string]*TenantDiscoveryResult),
-		cacheExpiry:  15 * time.Minute, // Cache tenant discovery for 15 minutes
+		credStore:        credStore,
+		consentStore:     consentStore,
+		httpClient:       httpClient,
+		oauth2Client:     NewOAuth2Client(httpClient),
+		tenantDiscoverer: discoverer,
+		tenantCache:      make(map[string]*TenantDiscoveryResult),
+		cacheExpiry:      15 * time.Minute,
 	}
 }
 
@@ -414,30 +418,10 @@ func (mtm *MultiTenantManager) completeOAuth2Flow(ctx context.Context, flow *OAu
 }
 
 func (mtm *MultiTenantManager) discoverTenants(ctx context.Context, provider string, tokenSet *TokenSet) (*TenantDiscoveryResult, error) {
-	// This would implement actual tenant discovery via provider APIs
-	// For Microsoft Graph, this would call /organizations or /tenants endpoints
-
-	// Mock implementation for now
-	result := &TenantDiscoveryResult{
-		Tenants: []TenantInfo{
-			{
-				TenantID:    "tenant-1",
-				DisplayName: "Customer Tenant 1",
-				Domain:      "customer1.onmicrosoft.com",
-				HasAccess:   true,
-			},
-			{
-				TenantID:    "tenant-2",
-				DisplayName: "Customer Tenant 2",
-				Domain:      "customer2.onmicrosoft.com",
-				HasAccess:   true,
-			},
-		},
-		DiscoveredAt: time.Now(),
-		Success:      true,
+	if mtm.tenantDiscoverer == nil {
+		return nil, fmt.Errorf("no tenant discoverer configured for provider %s", provider)
 	}
-
-	return result, nil
+	return mtm.tenantDiscoverer.DiscoverTenants(ctx, tokenSet)
 }
 
 func (mtm *MultiTenantManager) refreshTenantToken(ctx context.Context, provider, tenantID string) (*TokenSet, error) {

--- a/features/saas/multitenant_store.go
+++ b/features/saas/multitenant_store.go
@@ -7,6 +7,7 @@ package saas
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -18,6 +19,13 @@ import (
 // explicit *InTenant variants (CreateInTenant, ReadFromTenant, UpdateInTenant,
 // DeleteFromTenant, RawAPIInTenant) to target a specific tenant.
 var ErrNoTenantSelected = errors.New("no tenant selected: use CreateInTenant/ReadFromTenant/UpdateInTenant/DeleteFromTenant/RawAPIInTenant")
+
+// TenantDiscoverer discovers accessible tenants using a token obtained from a
+// completed OAuth2 admin-consent flow. The provider context (e.g. "microsoft")
+// is known to the caller and does not need to be part of the interface contract.
+type TenantDiscoverer interface {
+	DiscoverTenants(ctx context.Context, token *TokenSet) (*TenantDiscoveryResult, error)
+}
 
 // ConsentStore persists and retrieves admin-consent state for a provider.
 // Implementations must preserve all fields of ConsentStatus, including the

--- a/features/saas/multitenant_test.go
+++ b/features/saas/multitenant_test.go
@@ -18,6 +18,32 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// Test-only implementations
+
+// stubTenantDiscoverer is a test-only TenantDiscoverer that returns a fixed set of
+// deterministic tenants without making any HTTP calls. Configure tenants at construction
+// time; pass err to simulate discovery failures.
+type stubTenantDiscoverer struct {
+	tenants []TenantInfo
+	err     error
+}
+
+func (s *stubTenantDiscoverer) DiscoverTenants(_ context.Context, _ *TokenSet) (*TenantDiscoveryResult, error) {
+	if s.err != nil {
+		return nil, s.err
+	}
+	return &TenantDiscoveryResult{
+		Tenants:      s.tenants,
+		DiscoveredAt: time.Now(),
+		Success:      true,
+	}, nil
+}
+
+// newStubTenantDiscoverer returns a stub that returns the given tenants on every call.
+func newStubTenantDiscoverer(tenants ...TenantInfo) *stubTenantDiscoverer {
+	return &stubTenantDiscoverer{tenants: tenants}
+}
+
 // Mock implementations for testing
 
 // MockCredentialStore implements CredentialStore for testing token and client-secret
@@ -143,7 +169,7 @@ func TestMultiTenantManager_StartAdminConsent(t *testing.T) {
 			credStore := NewMockCredentialStore()
 			consentStore := NewInMemoryConsentStore()
 			httpClient := &http.Client{}
-			mtm := NewMultiTenantManager(credStore, consentStore, httpClient)
+			mtm := NewMultiTenantManager(credStore, consentStore, httpClient, newStubTenantDiscoverer())
 
 			// Mock OAuth2Client
 			mockOAuth2 := &MockOAuth2Client{}
@@ -178,6 +204,12 @@ func TestMultiTenantManager_StartAdminConsent(t *testing.T) {
 }
 
 func TestMultiTenantManager_CompleteAdminConsent(t *testing.T) {
+	// Deterministic tenants returned by the stub discoverer for success-path assertions.
+	stubTenants := []TenantInfo{
+		{TenantID: "stub-tenant-alpha", DisplayName: "Stub Alpha Corp", Domain: "alpha.example.com", HasAccess: true},
+		{TenantID: "stub-tenant-beta", DisplayName: "Stub Beta Corp", Domain: "beta.example.com", HasAccess: true},
+	}
+
 	tests := []struct {
 		name         string
 		authCode     string
@@ -228,7 +260,8 @@ func TestMultiTenantManager_CompleteAdminConsent(t *testing.T) {
 			credStore := NewMockCredentialStore()
 			consentStore := NewInMemoryConsentStore()
 			// Use the real DefaultOAuth2Client so ExchangeCode hits the httptest server.
-			mtm := NewMultiTenantManager(credStore, consentStore, &http.Client{})
+			// Wire a stub discoverer so discoverTenants returns stubTenants without HTTP calls.
+			mtm := NewMultiTenantManager(credStore, consentStore, &http.Client{}, newStubTenantDiscoverer(stubTenants...))
 
 			ctx := context.Background()
 			provider := "microsoft"
@@ -266,6 +299,78 @@ func TestMultiTenantManager_CompleteAdminConsent(t *testing.T) {
 			require.NoError(t, err)
 			assert.Equal(t, "real-access-token", storedTokens.AccessToken)
 			assert.Equal(t, "real-refresh-token", storedTokens.RefreshToken)
+
+			// Confirm the tenants returned by the stub discoverer were persisted
+			// unchanged — no fabrication occurs between discovery and storage.
+			require.Len(t, updatedStatus.AccessibleTenants, len(stubTenants))
+			for i, want := range stubTenants {
+				assert.Equal(t, want.TenantID, updatedStatus.AccessibleTenants[i].TenantID)
+				assert.Equal(t, want.DisplayName, updatedStatus.AccessibleTenants[i].DisplayName)
+				assert.Equal(t, want.Domain, updatedStatus.AccessibleTenants[i].Domain)
+				assert.Equal(t, want.HasAccess, updatedStatus.AccessibleTenants[i].HasAccess)
+			}
+		})
+	}
+}
+
+// TestMultiTenantManager_DiscoverTenantsErrors exercises the two new conditional
+// branches in discoverTenants: a nil discoverer and a discoverer that returns an error.
+// Both cases should cause CompleteAdminConsent to fail after a successful token exchange.
+func TestMultiTenantManager_DiscoverTenantsErrors(t *testing.T) {
+	// A token server that always returns a valid token so completeOAuth2Flow succeeds.
+	tokenServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(map[string]interface{}{
+			"access_token": "ok-token",
+			"token_type":   "Bearer",
+			"expires_in":   3600,
+		}); err != nil {
+			http.Error(w, "encode error", http.StatusInternalServerError)
+		}
+	}))
+	defer tokenServer.Close()
+
+	flow := &OAuth2Flow{
+		TokenURL:     tokenServer.URL,
+		ClientID:     "client-id",
+		ClientSecret: "client-secret",
+		RedirectURI:  "https://app.example.com/callback",
+		State:        "state",
+		Created:      time.Now(),
+		ExpiresAt:    time.Now().Add(10 * time.Minute),
+	}
+
+	tests := []struct {
+		name       string
+		discoverer TenantDiscoverer
+		wantErrMsg string
+	}{
+		{
+			name:       "nil discoverer returns error",
+			discoverer: nil,
+			wantErrMsg: "no tenant discoverer configured",
+		},
+		{
+			name:       "discoverer returns error propagates",
+			discoverer: &stubTenantDiscoverer{err: errors.New("graph unavailable")},
+			wantErrMsg: "graph unavailable",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			credStore := NewMockCredentialStore()
+			consentStore := NewInMemoryConsentStore()
+			mtm := NewMultiTenantManager(credStore, consentStore, &http.Client{}, tt.discoverer)
+
+			require.NoError(t, consentStore.StoreConsent("microsoft", &ConsentStatus{
+				Provider:    "microsoft",
+				ConsentFlow: flow,
+			}))
+
+			err := mtm.CompleteAdminConsent(context.Background(), "microsoft", "any-code")
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.wantErrMsg)
 		})
 	}
 }
@@ -386,7 +491,7 @@ func TestMultiTenantManager_GetTenantToken(t *testing.T) {
 	credStore := NewMockCredentialStore()
 	consentStore := NewInMemoryConsentStore()
 	httpClient := &http.Client{}
-	mtm := NewMultiTenantManager(credStore, consentStore, httpClient)
+	mtm := NewMultiTenantManager(credStore, consentStore, httpClient, newStubTenantDiscoverer())
 
 	ctx := context.Background()
 	provider := "microsoft"
@@ -424,7 +529,7 @@ func TestMultiTenantManager_GetTenantToken_NoAccess(t *testing.T) {
 	credStore := NewMockCredentialStore()
 	consentStore := NewInMemoryConsentStore()
 	httpClient := &http.Client{}
-	mtm := NewMultiTenantManager(credStore, consentStore, httpClient)
+	mtm := NewMultiTenantManager(credStore, consentStore, httpClient, newStubTenantDiscoverer())
 
 	ctx := context.Background()
 	provider := "microsoft"
@@ -458,7 +563,7 @@ func TestMultiTenantManager_ListAccessibleTenants(t *testing.T) {
 	credStore := NewMockCredentialStore()
 	consentStore := NewInMemoryConsentStore()
 	httpClient := &http.Client{}
-	mtm := NewMultiTenantManager(credStore, consentStore, httpClient)
+	mtm := NewMultiTenantManager(credStore, consentStore, httpClient, newStubTenantDiscoverer())
 
 	ctx := context.Background()
 	provider := "microsoft"
@@ -470,7 +575,7 @@ func TestMultiTenantManager_ListAccessibleTenants(t *testing.T) {
 		{
 			TenantID:    "explicit-tenant-alpha",
 			DisplayName: "Alpha Tenant",
-			Domain:      "alpha.onmicrosoft.com",
+			Domain:      "alpha.example.com",
 			HasAccess:   true,
 		},
 	}
@@ -497,7 +602,7 @@ func TestMultiTenantManager_RevokeConsent(t *testing.T) {
 	credStore := NewMockCredentialStore()
 	consentStore := NewInMemoryConsentStore()
 	httpClient := &http.Client{}
-	mtm := NewMultiTenantManager(credStore, consentStore, httpClient)
+	mtm := NewMultiTenantManager(credStore, consentStore, httpClient, newStubTenantDiscoverer())
 
 	ctx := context.Background()
 	provider := "microsoft"
@@ -829,7 +934,10 @@ func TestMultiTenantManager_TenantCacheConcurrency(t *testing.T) {
 	credStore := NewMockCredentialStore()
 	consentStore := NewInMemoryConsentStore()
 	httpClient := &http.Client{}
-	mtm := NewMultiTenantManager(credStore, consentStore, httpClient)
+	// Stub returns one deterministic tenant so RefreshTenantDiscovery writes a
+	// non-empty AccessibleTenants slice to the consent store on each call.
+	stub := newStubTenantDiscoverer(TenantInfo{TenantID: "stub-concurrent-tenant", HasAccess: true})
+	mtm := NewMultiTenantManager(credStore, consentStore, httpClient, stub)
 
 	ctx := context.Background()
 	provider := "microsoft"
@@ -951,7 +1059,7 @@ func BenchmarkMultiTenantManager_GetTenantToken(b *testing.B) {
 	credStore := NewMockCredentialStore()
 	consentStore := NewInMemoryConsentStore()
 	httpClient := &http.Client{}
-	mtm := NewMultiTenantManager(credStore, consentStore, httpClient)
+	mtm := NewMultiTenantManager(credStore, consentStore, httpClient, newStubTenantDiscoverer())
 
 	ctx := context.Background()
 	provider := "microsoft"


### PR DESCRIPTION
## Summary

- Deleted the hardcoded two-tenant mock in `discoverTenants`; replaced with delegation to an injected `TenantDiscoverer` interface
- `CompleteAdminConsent` now persists tenants returned by the real `MicrosoftMultiTenantProvider.DiscoverTenantsFromMicrosoft` (via Graph API) into `ConsentStore` — no more `tenant-1`/`customer1.onmicrosoft.com` fabrication
- `NewMultiTenantManager` accepts a `TenantDiscoverer` argument; `MicrosoftMultiTenantProvider` wires itself as the production implementation at construction time

## Changes

| File | Change |
|---|---|
| `multitenant_store.go` | Add `TenantDiscoverer` interface |
| `multitenant.go` | Add field + param; replace mock `discoverTenants` body |
| `microsoft_multitenant.go` | Add `DiscoverTenants` method; self-wire in constructor |
| `multitenant_test.go` | Add `stubTenantDiscoverer`; update call sites; add tenant assertions; add error-path tests; fix `.onmicrosoft.com` fixture |
| `README.md` | Add TenantDiscoverer wiring section |

`completeOAuth2Flow` is intentionally NOT modified (owned by Issue #698).

## Test plan

- [ ] `TestMultiTenantManager_CompleteAdminConsent` — asserts stub tenants are persisted unchanged to `ConsentStore` (no hardcoded values)
- [ ] `TestMultiTenantManager_DiscoverTenantsErrors` — covers nil-discoverer and discoverer-returns-error branches
- [ ] `TestMultiTenantManager_TenantCacheConcurrency` — verifies concurrent writes under `-race`
- [ ] All existing tests pass with stub discoverer wired in

## Specialist review results

- **QA Test Runner**: PASS — all packages pass including `features/saas` (race detector clean), cross-platform builds verified
- **QA Code Reviewer**: PASS (after 2 iterations) — error-path tests added for both `discoverTenants` branches; pre-existing `refreshTenantToken` mock confirmed out of scope (#697/#698)
- **Security Engineer**: PASS — no hardcoded secrets, no central provider violations, architecture compliance clean

Fixes #956

🤖 Generated with [Claude Code](https://claude.com/claude-code)