### PR TITLE
logging: add RedactedID helper and SensitiveLogConfig debug gate (Issue #978)

### DIFF
--- a/pkg/logging/README.md
+++ b/pkg/logging/README.md
@@ -1,0 +1,71 @@
+# pkg/logging
+
+Structured logging package for CFGMS. Provides log-injection–safe helpers, correlation ID injection, and a pluggable provider backend.
+
+## Helpers
+
+### SanitizeLogValue
+
+Replaces all Unicode control characters (C0, DEL, C1) with underscores and truncates values exceeding 1024 bytes. Use for arbitrary user-supplied strings (path segments, query parameters, header values).
+
+```go
+logger.Info("request received", "steward_id", logging.SanitizeLogValue(stewardID))
+```
+
+### RedactedID
+
+Truncates an opaque identifier to an 8-character prefix followed by `…` (U+2026). Applies `SanitizeLogValue` to the prefix so control characters cannot leak. Use for session IDs, bearer tokens, correlation IDs, or any high-entropy identifier where the full value must not appear in production logs.
+
+```go
+logger.Info("session opened", "session_id", logging.RedactedID(sessionID))
+// output: session_id=abc12345…
+```
+
+**Contract:**
+
+| Input length | Output |
+|---|---|
+| 0 | `""` (unchanged) |
+| 1–8 bytes | full value + `…` |
+| 9+ bytes | first 8 bytes (sanitized) + `…` |
+
+When `SensitiveLogConfig.UnredactedSensitiveValues` is `true`, the full sanitized value is returned without truncation (see debug gate below).
+
+**When to use `RedactedID` vs `SanitizeLogValue`:**
+
+- `SanitizeLogValue` — general-purpose; strips control characters and truncates long strings. Does not shorten the value.
+- `RedactedID` — for high-entropy secrets and identifiers where the full value must not appear in logs even in normal operation. Truncates to 8 chars by design.
+
+## Redacting Sensitive Identifiers
+
+## SensitiveLogConfig and the Debug Gate
+
+`SensitiveLogConfig` is a package-level configuration struct that gates unredacted debug logging behind an explicit opt-in. The default zero value keeps redaction enabled.
+
+```go
+type SensitiveLogConfig struct {
+    // UnredactedSensitiveValues, when true, causes RedactedID to return the
+    // full value rather than the 8-char prefix. Development only.
+    // Default: false.
+    UnredactedSensitiveValues bool
+}
+```
+
+**Accessors:**
+
+```go
+logging.SetSensitiveLogConfig(logging.SensitiveLogConfig{UnredactedSensitiveValues: true})
+cfg := logging.GetSensitiveLogConfig()
+```
+
+Both accessors are safe for concurrent use (protected by `sync.RWMutex`).
+
+**Debug gate pattern** — enable full IDs only in development via explicit configuration:
+
+```go
+if cfg.Debug {
+    logging.SetSensitiveLogConfig(logging.SensitiveLogConfig{UnredactedSensitiveValues: true})
+}
+```
+
+Never set `UnredactedSensitiveValues: true` in production code paths or as a default value.

--- a/pkg/logging/sanitize.go
+++ b/pkg/logging/sanitize.go
@@ -120,6 +120,32 @@ func SanitizeLogValue(s string) string {
 	return s
 }
 
+// RedactedID truncates an opaque identifier to an 8-character prefix followed by
+// "…" (U+2026) for safe log inclusion. Short identifiers (≤8 bytes) are returned
+// in full with the ellipsis appended. The empty string is returned unchanged.
+//
+// Control characters in the prefix are neutralised via SanitizeLogValue so that
+// callers need not pre-clean token or session ID values before logging.
+//
+// When SensitiveLogConfig.UnredactedSensitiveValues is true (development opt-in),
+// the full sanitized value is returned without truncation.
+//
+// Usage:
+//
+//	logger.Info("session opened", "session_id", logging.RedactedID(sessionID))
+func RedactedID(s string) string {
+	if s == "" {
+		return ""
+	}
+	if GetSensitiveLogConfig().UnredactedSensitiveValues {
+		return SanitizeLogValue(s)
+	}
+	if len(s) <= 8 {
+		return SanitizeLogValue(s) + "…"
+	}
+	return SanitizeLogValue(s[:8]) + "…"
+}
+
 // sanitizeMapValues sanitizes all string values in a map for safe logging.
 // Non-string values are left unchanged.
 func sanitizeMapValues(fields map[string]any) {

--- a/pkg/logging/sanitize_test.go
+++ b/pkg/logging/sanitize_test.go
@@ -270,3 +270,154 @@ func TestFormatKeysAndValues(t *testing.T) {
 func isControl(r rune) bool {
 	return r < 0x20 || (r >= 0x7f && r <= 0x9f)
 }
+
+func TestRedactedID_Empty(t *testing.T) {
+	got := RedactedID("")
+	assert.Equal(t, "", got)
+}
+
+func TestRedactedID_ShortString(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"three chars", "abc", "abc…"},
+		{"one char", "x", "x…"},
+		{"seven chars", "1234567", "1234567…"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := RedactedID(tt.input)
+			assert.Equal(t, tt.want, got)
+			assert.True(t, len([]rune(got)) > 0)
+			assert.Equal(t, "…", string([]rune(got)[len([]rune(got))-1:]))
+		})
+	}
+}
+
+func TestRedactedID_ExactlyEightChars(t *testing.T) {
+	got := RedactedID("12345678")
+	assert.Equal(t, "12345678…", got)
+}
+
+func TestRedactedID_NineOrMoreChars(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"nine chars", "123456789", "12345678…"},
+		{"long token", "abcdefghijklmnopqrstuvwxyz", "abcdefgh…"},
+		{"UUID-like", "550e8400-e29b-41d4-a716-446655440000", "550e8400…"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := RedactedID(tt.input)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestRedactedID_ControlCharsInPrefix(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+	}{
+		{"newline in prefix", "abc\ndef_extra_suffix"},
+		{"carriage return in prefix", "abc\rdef_extra_suffix"},
+		{"ESC in prefix", "\x1babcdefghijklmn"},
+		{"null byte in prefix", "\x00abcdefghijklmn"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := RedactedID(tt.input)
+			// Must end with Unicode ellipsis
+			assert.True(t, len(got) > 0)
+			runes := []rune(got)
+			assert.Equal(t, '…', runes[len(runes)-1])
+			// No control characters in the prefix portion
+			prefix := string(runes[:len(runes)-1])
+			for _, r := range prefix {
+				assert.False(t, isControl(r), "control character U+%04X found in RedactedID prefix output", r)
+			}
+		})
+	}
+}
+
+func TestRedactedID_UnicodeSafe(t *testing.T) {
+	// Multi-byte Unicode that is shorter than 8 bytes by rune count but >8 by byte count
+	// The function slices by bytes, so we just ensure it doesn't panic and sanitizes correctly
+	input := "café résumé"
+	got := RedactedID(input)
+	assert.NotEmpty(t, got)
+	runes := []rune(got)
+	assert.Equal(t, '…', runes[len(runes)-1])
+}
+
+func TestRedactedID_UnredactedMode(t *testing.T) {
+	// Restore default config after test
+	orig := GetSensitiveLogConfig()
+	t.Cleanup(func() { SetSensitiveLogConfig(orig) })
+
+	SetSensitiveLogConfig(SensitiveLogConfig{UnredactedSensitiveValues: true})
+
+	// Full value returned (sanitized, no truncation to 8 chars)
+	got := RedactedID("123456789")
+	assert.Equal(t, "123456789", got)
+
+	// Still sanitizes control characters
+	got = RedactedID("abc\ndef")
+	assert.NotContains(t, got, "\n")
+	assert.Equal(t, "abc_def", got)
+}
+
+func TestSensitiveLogConfig_Defaults(t *testing.T) {
+	// The zero value defaults UnredactedSensitiveValues to false
+	cfg := SensitiveLogConfig{}
+	assert.False(t, cfg.UnredactedSensitiveValues)
+}
+
+func TestSensitiveLogConfig_GetSet(t *testing.T) {
+	orig := GetSensitiveLogConfig()
+	t.Cleanup(func() { SetSensitiveLogConfig(orig) })
+
+	SetSensitiveLogConfig(SensitiveLogConfig{UnredactedSensitiveValues: true})
+	got := GetSensitiveLogConfig()
+	assert.True(t, got.UnredactedSensitiveValues)
+
+	SetSensitiveLogConfig(SensitiveLogConfig{UnredactedSensitiveValues: false})
+	got = GetSensitiveLogConfig()
+	assert.False(t, got.UnredactedSensitiveValues)
+}
+
+func TestSensitiveLogConfig_ConcurrentAccess(t *testing.T) {
+	orig := GetSensitiveLogConfig()
+	t.Cleanup(func() { SetSensitiveLogConfig(orig) })
+
+	const goroutines = 50
+	done := make(chan struct{})
+
+	// Writers
+	for i := 0; i < goroutines; i++ {
+		go func(i int) {
+			SetSensitiveLogConfig(SensitiveLogConfig{UnredactedSensitiveValues: i%2 == 0})
+			done <- struct{}{}
+		}(i)
+	}
+
+	// Readers
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			_ = GetSensitiveLogConfig()
+			done <- struct{}{}
+		}()
+	}
+
+	for i := 0; i < goroutines*2; i++ {
+		<-done
+	}
+}

--- a/pkg/logging/sensitive_config.go
+++ b/pkg/logging/sensitive_config.go
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+package logging
+
+import "sync"
+
+// SensitiveLogConfig controls whether sensitive values are redacted in logs.
+// Defaults to zero value (UnredactedSensitiveValues = false → redact by default).
+type SensitiveLogConfig struct {
+	// UnredactedSensitiveValues, when true, causes RedactedID to return the
+	// full value rather than the 8-char prefix. Should only be set to true
+	// in development environments via explicit configuration.
+	// Default: false.
+	UnredactedSensitiveValues bool
+}
+
+var (
+	sensitiveLogConfig SensitiveLogConfig
+	sensitiveLogMu     sync.RWMutex
+)
+
+// SetSensitiveLogConfig replaces the package-level sensitive log configuration.
+// Safe for concurrent use.
+func SetSensitiveLogConfig(cfg SensitiveLogConfig) {
+	sensitiveLogMu.Lock()
+	defer sensitiveLogMu.Unlock()
+	sensitiveLogConfig = cfg
+}
+
+// GetSensitiveLogConfig returns the current package-level sensitive log configuration.
+// Safe for concurrent use.
+func GetSensitiveLogConfig() SensitiveLogConfig {
+	sensitiveLogMu.RLock()
+	defer sensitiveLogMu.RUnlock()
+	return sensitiveLogConfig
+}


### PR DESCRIPTION
## Summary

- Adds `logging.RedactedID(s string) string` — truncates any opaque identifier to an 8-byte prefix + U+2026 (`…`), sanitizing control characters via `SanitizeLogValue`. Foundation primitive for epic #732 (redact session IDs and bearer tokens across 4 subsystems).
- Adds `SensitiveLogConfig` struct with `UnredactedSensitiveValues bool` field (default `false`), protected by `sync.RWMutex` — gates full-value debug logging behind an explicit development opt-in.
- Adds `pkg/logging/README.md` documenting both helpers, the debug-gate pattern, and when to use `RedactedID` vs `SanitizeLogValue`.

## Test plan

- [ ] `go test ./pkg/logging/... -race` — all new `TestRedactedID_*` and `TestSensitiveLogConfig_*` tests pass
- [ ] `make test-agent-complete` — all quality gates green (unit, lint, license, security, cross-platform builds)
- [ ] Concurrent race test (`TestSensitiveLogConfig_ConcurrentAccess`) exercises 50 writers + 50 readers under `-race` — clean

## Specialist Review Results

| Agent | Result |
|---|---|
| QA Test Runner | **PASS** — all quality gates, cross-platform builds, race-detection clean |
| QA Code Reviewer | **PASS** — no mocks, no skips, full coverage including error/control-char paths |
| Security Engineer | **PASS** — security-precommit, check-architecture, security-scan all green; safe-by-default verified (`UnredactedSensitiveValues=false` is the zero value) |

Fixes #978

🤖 Generated with [Claude Code](https://claude.com/claude-code)