### PR TITLE
.claude: track settings.json with Managed Agents env flag

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,36 @@
+{
+  "env": {
+    "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1"
+  },
+  "permissions": {
+    "allow": [
+      "Bash(./.claude/scripts/po-act.sh preflight)",
+      "Bash(./.claude/scripts/po-act.sh preflight *)",
+      "Bash(./.claude/scripts/po-act.sh diagnose *)",
+      "Bash(./.claude/scripts/po-act.sh state *)",
+      "Bash(./.claude/scripts/po-act.sh merge-queue)",
+      "Bash(./.claude/scripts/po-act.sh merge-queue *)",
+      "Bash(./.claude/scripts/po-cycle-preflight.py)",
+      "Bash(./.claude/scripts/po-cycle-preflight.py *)",
+      "Bash(./.claude/scripts/agent-dispatch.sh list-running)",
+      "Bash(./.claude/scripts/agent-dispatch.sh list-exited)",
+      "Bash(./.claude/scripts/agent-dispatch.sh check-conflicts *)",
+      "Bash(./.claude/scripts/agent-dispatch.sh check-creds *)",
+      "Bash(./.claude/scripts/agent-dispatch.sh health-check *)",
+      "Bash(./.claude/scripts/agent-dispatch.sh inspect-exit *)",
+      "Bash(./.claude/scripts/agent-dispatch.sh inspect-detail *)",
+      "Bash(./.claude/scripts/agent-dispatch.sh inspect-container *)",
+      "Bash(./.claude/scripts/agent-dispatch.sh inspect-exit-container *)",
+      "Bash(./.claude/scripts/pr-review-helper.sh pre-review *)",
+      "Bash(./.claude/scripts/pr-review-helper.sh pr-overview *)",
+      "Bash(./.claude/scripts/pr-review-helper.sh pr-checks *)",
+      "Bash(./.claude/scripts/pr-review-helper.sh ci-details *)",
+      "Bash(./.claude/scripts/pr-review-helper.sh diff-scan *)",
+      "Bash(./.claude/scripts/pr-review-helper.sh doc-scan)",
+      "Bash(./scripts/pipeline-helper.sh view *)",
+      "Bash(./scripts/pipeline-helper.sh list-by-label *)",
+      "Bash(./scripts/pipeline-helper.sh list-prs *)",
+      "Bash(./scripts/pipeline-helper.sh sub-issue-summary *)"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

- Track \`.claude/settings.json\` (previously untracked despite not being in \`.gitignore\`)
- Add \`env: { CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS: \"1\" }\` to expose Managed Agents primitives (\`TeamCreate\`, \`TeamDelete\`, \`SendMessage\`) inside agent containers
- \`settings.local.json\` remains gitignored — per-user permission overrides stay personal

## Why

The PO Planning Team flow (\`.claude/agents/po.md\` §6, invoked via \`/po decompose\` or \`/po cycle\`) requires \`TeamCreate\` to spawn the BA + Tech Lead as collaborating teammates. The host Claude Code session has Managed Agents enabled by default, but agent containers spawned from \`cfg-agent:latest\` did not — silently breaking team-mode in \`/po-live\` and any other in-container PO invocation.

Verified empirically (2026-05-01):
- Same \`claude\` binary version (2.1.126) on host and in container
- Same \`~/.claude\` and \`~/.claude.json\` mounted in container
- Same network egress
- Host saw \`TeamCreate\` in deferred tools; container did not

Setting \`CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1\` in the project-level settings.json's \`env\` block fixes this for any Claude session opened inside the cfgms workspace.

## Test plan

- [ ] Restart \`/po-live\` container — Managed Agents tools (\`TeamCreate\`, \`TeamDelete\`, \`SendMessage\`) appear via ToolSearch
- [ ] \`/po decompose <epic#>\` inside a live container completes a Planning Team round (BA + Tech Lead via team_name) without falling back to the legacy serial Tech Lead pass
- [ ] Existing \`/po cron\` cycles unaffected (cron skips Step 6 by design)
- [ ] No regression in host PO sessions (the env only affects when Claude reads this settings.json — host already had Managed Agents)

🤖 Generated with [Claude Code](https://claude.com/claude-code)