### PR TITLE
saas: replace bare http.Client with NewGraphHTTPClient factory and per-process rate limiter (Issue #959)

### DIFF
--- a/features/saas/README.md
+++ b/features/saas/README.md
@@ -108,6 +108,38 @@ resources:
 - **Audit Logging**: All API calls logged for compliance
 - **Scope Limitation**: Minimal required permissions
 
+## HTTP Client
+
+All Microsoft Graph API calls use an `*http.Client` built by `NewGraphHTTPClient`:
+
+```go
+// Default values: 10 req/s sustained, burst of 20
+client := saas.NewGraphHTTPClient(10, 20)
+
+// High limits for tests (avoids flakiness from rate limiting)
+testClient := saas.NewGraphHTTPClient(100, 1000)
+```
+
+### Rate limiting
+
+`NewGraphHTTPClient` wraps `http.DefaultTransport` with a `rateLimitedTransport`
+that enforces a per-process token-bucket rate limit using `golang.org/x/time/rate`.
+The limiter is shared across all tenants in the process (per-process, not per-tenant).
+Per-tenant limiting is a future optimization.
+
+Default values (10 req/s, burst 20) are conservative enough to avoid Microsoft Graph
+throttling under normal MSP workloads while still allowing short bursts for startup
+discovery.
+
+### Why not `pkg/cert`?
+
+`pkg/cert` manages CFGMS-internal mTLS certificates used for gRPC-over-QUIC between
+controller and steward. Microsoft Graph uses Microsoft's own public CA infrastructure —
+there is no mutual TLS or CFGMS certificate authority involved. `http.DefaultTransport`
+uses system root CAs, which already trust Microsoft's certificates. Using `pkg/cert`
+here would be incorrect: it would attempt to validate Microsoft's certificate against
+the CFGMS CA rather than the system trust store.
+
 ## Consent State Storage
 
 Admin-consent state (granted/revoked, accessible tenants, active OAuth2 flow) is

--- a/features/saas/examples/microsoft_provider.go
+++ b/features/saas/examples/microsoft_provider.go
@@ -9,7 +9,6 @@ import (
 	"context"
 	"fmt"
 	"log"
-	"net/http"
 	"strings"
 
 	"github.com/cfgis/cfgms/features/saas"
@@ -41,7 +40,7 @@ func NewMicrosoftProvider() saas.Provider {
 		},
 	}
 
-	httpClient := &http.Client{}
+	httpClient := saas.NewGraphHTTPClient(10, 20)
 
 	return &MicrosoftProvider{
 		BaseProvider: saas.NewBaseProvider(info, httpClient),
@@ -261,10 +260,12 @@ func (p *MicrosoftProvider) createUser(ctx context.Context, data map[string]inte
 		graphData["accountEnabled"] = active
 	}
 
-	// Add required password profile for new users
-	graphData["passwordProfile"] = map[string]interface{}{
-		"forceChangePasswordNextSignIn": true,
-		"password":                      "TempPassword123!",
+	// Add password profile if caller supplies an initial_password; never hardcode credentials.
+	if password, exists := data["initial_password"]; exists {
+		graphData["passwordProfile"] = map[string]interface{}{
+			"forceChangePasswordNextSignIn": true,
+			"password":                      password,
+		}
 	}
 
 	return p.RawAPI(ctx, "POST", "/users", graphData)
@@ -323,16 +324,14 @@ func ExampleUsage() {
 
 	fmt.Printf("User created successfully: %+v\n", result.Data)
 
-	// Example: Raw API call for advanced operations
+	// Example: Raw API call for advanced operations.
+	// Caller must supply credentials at runtime (OS keychain, secret manager, etc.) —
+	// never hardcode passwords or secrets in source code.
 	customData := map[string]interface{}{
 		"@odata.type":       "#microsoft.graph.user",
 		"displayName":       "Jane Smith",
 		"userPrincipalName": "jane.smith@company.com",
 		"accountEnabled":    true,
-		"passwordProfile": map[string]interface{}{
-			"forceChangePasswordNextSignIn": true,
-			"password":                      "TempPassword456!",
-		},
 	}
 
 	rawResult, err := provider.RawAPI(ctx, "POST", "/users", customData)

--- a/features/saas/m365_tenant_manager.go
+++ b/features/saas/m365_tenant_manager.go
@@ -55,7 +55,7 @@ func NewM365TenantManager(
 		m365Provider:       m365Provider,
 		adminConsentFlow:   adminConsentFlow,
 		gdapProvider:       gdapProvider,
-		httpClient:         &http.Client{Timeout: 30 * time.Second},
+		httpClient:         NewGraphHTTPClient(10, 20),
 	}
 }
 

--- a/features/saas/m365_tenant_manager_test.go
+++ b/features/saas/m365_tenant_manager_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"net/http"
 	"testing"
 	"time"
 
@@ -101,37 +100,6 @@ func (m *mockTenantStore) IsTenantAncestor(ctx context.Context, ancestorID, desc
 	return false, nil
 }
 
-type mockCredentialStore struct{}
-
-func (m *mockCredentialStore) StoreTokenSet(provider string, tokens *TokenSet) error {
-	return nil
-}
-
-func (m *mockCredentialStore) GetTokenSet(provider string) (*TokenSet, error) {
-	return &TokenSet{
-		AccessToken:  "mock-token",
-		TokenType:    "Bearer",
-		ExpiresAt:    time.Now().Add(1 * time.Hour),
-		RefreshToken: "mock-refresh",
-	}, nil
-}
-
-func (m *mockCredentialStore) DeleteTokenSet(provider string) error {
-	return nil
-}
-
-func (m *mockCredentialStore) StoreClientSecret(provider, clientSecret string) error {
-	return nil
-}
-
-func (m *mockCredentialStore) GetClientSecret(provider string) (string, error) {
-	return "mock-secret", nil
-}
-
-func (m *mockCredentialStore) IsAvailable() bool {
-	return true
-}
-
 // Test setup helper
 func setupTestManager(t *testing.T) (*M365TenantManager, *mockTenantStore, context.Context) {
 	ctx := context.Background()
@@ -143,11 +111,11 @@ func setupTestManager(t *testing.T) (*M365TenantManager, *mockTenantStore, conte
 	// (M365 integration tests don't need full RBAC setup)
 	cfgmsTenantManager := tenant.NewManager(mockStore, nil)
 
-	// Create mock credential store
-	mockCredStore := &mockCredentialStore{}
+	// Create credential store
+	mockCredStore := NewMockCredentialStore()
 
 	// Create M365 provider
-	httpClient := &http.Client{Timeout: 30 * time.Second}
+	httpClient := NewGraphHTTPClient(100, 1000)
 	m365Provider := NewMicrosoftMultiTenantProvider(mockCredStore, httpClient)
 
 	// Create admin consent flow (can be nil for basic tests)
@@ -564,7 +532,7 @@ func setupTestManagerWithCountingStore(t *testing.T) (*M365TenantManager, *count
 	ctx := context.Background()
 	counting := &countingTenantStore{mockTenantStore: newMockTenantStore()}
 	cfgmsTenantManager := tenant.NewManager(counting, nil)
-	m365Provider := NewMicrosoftMultiTenantProvider(&mockCredentialStore{}, &http.Client{Timeout: 30 * time.Second})
+	m365Provider := NewMicrosoftMultiTenantProvider(NewMockCredentialStore(), NewGraphHTTPClient(100, 1000))
 	manager := NewM365TenantManager(cfgmsTenantManager, m365Provider, nil, nil)
 	return manager, counting, ctx
 }
@@ -624,7 +592,7 @@ func TestM365TenantManager_GetTenantByM365ID_ListTenantsError(t *testing.T) {
 		listErr:         fmt.Errorf("storage unavailable"),
 	}
 	cfgmsTenantManager := tenant.NewManager(failing, nil)
-	m365Provider := NewMicrosoftMultiTenantProvider(&mockCredentialStore{}, &http.Client{Timeout: 30 * time.Second})
+	m365Provider := NewMicrosoftMultiTenantProvider(NewMockCredentialStore(), NewGraphHTTPClient(100, 1000))
 	manager := NewM365TenantManager(cfgmsTenantManager, m365Provider, nil, nil)
 
 	// ListTenants fails → getTenantByM365ID must propagate the error.
@@ -677,7 +645,7 @@ func BenchmarkM365TenantManager_DiscoverAndSyncTenants(b *testing.B) {
 
 		mockStore := newMockTenantStore()
 		cfgmsTenantManager := tenant.NewManager(mockStore, nil)
-		m365Provider := NewMicrosoftMultiTenantProvider(&mockCredentialStore{}, &http.Client{Timeout: 30 * time.Second})
+		m365Provider := NewMicrosoftMultiTenantProvider(NewMockCredentialStore(), NewGraphHTTPClient(100, 1000))
 		gdap := &mockGDAPProvider{relationships: relationships}
 		manager := NewM365TenantManager(cfgmsTenantManager, m365Provider, nil, gdap)
 

--- a/features/saas/multitenant.go
+++ b/features/saas/multitenant.go
@@ -424,29 +424,9 @@ func (mtm *MultiTenantManager) discoverTenants(ctx context.Context, provider str
 	return mtm.tenantDiscoverer.DiscoverTenants(ctx, tokenSet)
 }
 
-func (mtm *MultiTenantManager) refreshTenantToken(ctx context.Context, provider, tenantID string) (*TokenSet, error) {
-	// Get the base refresh token
-	_, err := mtm.credStore.GetTokenSet(provider)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get base token set: %w", err)
-	}
-
-	// This would implement tenant-specific token refresh using the base token
-	// For Microsoft Graph, this involves using the refresh token with the specific tenant endpoint
-
-	// Mock implementation - create tenant-specific token
-	tenantToken := &TokenSet{
-		AccessToken:  fmt.Sprintf("tenant-%s-access-token", tenantID),
-		RefreshToken: fmt.Sprintf("tenant-%s-refresh-token", tenantID),
-		TokenType:    "Bearer",
-		ExpiresAt:    time.Now().Add(1 * time.Hour),
-	}
-
-	// Store the tenant-specific token
-	tenantKey := mtm.getTenantKey(provider, tenantID)
-	if err := mtm.credStore.StoreTokenSet(tenantKey, tenantToken); err != nil {
-		return nil, fmt.Errorf("failed to store tenant token: %w", err)
-	}
-
-	return tenantToken, nil
+func (mtm *MultiTenantManager) refreshTenantToken(_ context.Context, provider, tenantID string) (*TokenSet, error) {
+	// Per-tenant token refresh requires a real OAuth2 token exchange with the tenant's
+	// authorization endpoint. Callers must pre-populate the credential store (e.g. after
+	// admin consent completes) or re-run the admin consent flow to obtain a fresh token.
+	return nil, fmt.Errorf("tenant token refresh not yet implemented for provider %q tenantID %q: re-run admin consent to obtain a fresh token", provider, tenantID)
 }

--- a/features/saas/multitenant_test.go
+++ b/features/saas/multitenant_test.go
@@ -14,7 +14,6 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
 
@@ -93,33 +92,6 @@ func (m *MockCredentialStore) IsAvailable() bool {
 	return true
 }
 
-// MockOAuth2Client implements OAuth2Client for testing.
-// Uses testify/mock because OAuth2Client is a features/saas-local interface,
-// not a pkg/ central provider — the mock carve-out in the story applies.
-type MockOAuth2Client struct {
-	mock.Mock
-}
-
-func (m *MockOAuth2Client) StartFlow(ctx context.Context, config *ExtendedOAuth2Config) (*OAuth2Flow, error) {
-	args := m.Called(ctx, config)
-	return args.Get(0).(*OAuth2Flow), args.Error(1)
-}
-
-func (m *MockOAuth2Client) ClientCredentialsGrant(ctx context.Context, config *ExtendedOAuth2Config) (*TokenSet, error) {
-	args := m.Called(ctx, config)
-	return args.Get(0).(*TokenSet), args.Error(1)
-}
-
-func (m *MockOAuth2Client) ExchangeCode(ctx context.Context, flow *OAuth2Flow, authCode string) (*TokenSet, error) {
-	args := m.Called(ctx, flow, authCode)
-	return args.Get(0).(*TokenSet), args.Error(1)
-}
-
-func (m *MockOAuth2Client) RefreshToken(ctx context.Context, refreshToken string) (*TokenSet, error) {
-	args := m.Called(ctx, refreshToken)
-	return args.Get(0).(*TokenSet), args.Error(1)
-}
-
 // Test MultiTenantManager
 
 func TestMultiTenantManager_StartAdminConsent(t *testing.T) {
@@ -168,21 +140,8 @@ func TestMultiTenantManager_StartAdminConsent(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			credStore := NewMockCredentialStore()
 			consentStore := NewInMemoryConsentStore()
-			httpClient := &http.Client{}
+			httpClient := NewGraphHTTPClient(100, 1000)
 			mtm := NewMultiTenantManager(credStore, consentStore, httpClient, newStubTenantDiscoverer())
-
-			// Mock OAuth2Client
-			mockOAuth2 := &MockOAuth2Client{}
-			mtm.oauth2Client = mockOAuth2
-
-			if !tt.wantErr {
-				mockOAuth2.On("StartFlow", mock.Anything, mock.Anything).Return(&OAuth2Flow{
-					AuthURL:   "https://login.microsoftonline.com/common/oauth2/v2.0/authorize?client_id=test",
-					State:     "test-state",
-					Created:   time.Now(),
-					ExpiresAt: time.Now().Add(10 * time.Minute),
-				}, nil)
-			}
 
 			ctx := context.Background()
 			url, err := mtm.StartAdminConsent(ctx, "microsoft", tt.config)
@@ -197,7 +156,6 @@ func TestMultiTenantManager_StartAdminConsent(t *testing.T) {
 				if tt.validate != nil {
 					tt.validate(t, url)
 				}
-				mockOAuth2.AssertExpectations(t)
 			}
 		})
 	}
@@ -261,7 +219,7 @@ func TestMultiTenantManager_CompleteAdminConsent(t *testing.T) {
 			consentStore := NewInMemoryConsentStore()
 			// Use the real DefaultOAuth2Client so ExchangeCode hits the httptest server.
 			// Wire a stub discoverer so discoverTenants returns stubTenants without HTTP calls.
-			mtm := NewMultiTenantManager(credStore, consentStore, &http.Client{}, newStubTenantDiscoverer(stubTenants...))
+			mtm := NewMultiTenantManager(credStore, consentStore, NewGraphHTTPClient(100, 1000), newStubTenantDiscoverer(stubTenants...))
 
 			ctx := context.Background()
 			provider := "microsoft"
@@ -361,7 +319,7 @@ func TestMultiTenantManager_DiscoverTenantsErrors(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			credStore := NewMockCredentialStore()
 			consentStore := NewInMemoryConsentStore()
-			mtm := NewMultiTenantManager(credStore, consentStore, &http.Client{}, tt.discoverer)
+			mtm := NewMultiTenantManager(credStore, consentStore, NewGraphHTTPClient(100, 1000), tt.discoverer)
 
 			require.NoError(t, consentStore.StoreConsent("microsoft", &ConsentStatus{
 				Provider:    "microsoft",
@@ -469,7 +427,7 @@ func TestDefaultOAuth2Client_ExchangeCode(t *testing.T) {
 			defer tokenServer.Close()
 
 			tt.flow.TokenURL = tokenServer.URL
-			client := &DefaultOAuth2Client{httpClient: &http.Client{}}
+			client := &DefaultOAuth2Client{httpClient: NewGraphHTTPClient(100, 1000)}
 
 			ts, err := client.ExchangeCode(context.Background(), tt.flow, tt.authCode)
 
@@ -490,7 +448,7 @@ func TestDefaultOAuth2Client_ExchangeCode(t *testing.T) {
 func TestMultiTenantManager_GetTenantToken(t *testing.T) {
 	credStore := NewMockCredentialStore()
 	consentStore := NewInMemoryConsentStore()
-	httpClient := &http.Client{}
+	httpClient := NewGraphHTTPClient(100, 1000)
 	mtm := NewMultiTenantManager(credStore, consentStore, httpClient, newStubTenantDiscoverer())
 
 	ctx := context.Background()
@@ -528,7 +486,7 @@ func TestMultiTenantManager_GetTenantToken(t *testing.T) {
 func TestMultiTenantManager_GetTenantToken_NoAccess(t *testing.T) {
 	credStore := NewMockCredentialStore()
 	consentStore := NewInMemoryConsentStore()
-	httpClient := &http.Client{}
+	httpClient := NewGraphHTTPClient(100, 1000)
 	mtm := NewMultiTenantManager(credStore, consentStore, httpClient, newStubTenantDiscoverer())
 
 	ctx := context.Background()
@@ -559,10 +517,41 @@ func TestMultiTenantManager_GetTenantToken_NoAccess(t *testing.T) {
 	assert.Contains(t, err.Error(), "tenant inaccessible-tenant is not accessible")
 }
 
+func TestMultiTenantManager_GetTenantToken_ExpiredToken_RefreshNotImplemented(t *testing.T) {
+	credStore := NewMockCredentialStore()
+	consentStore := NewInMemoryConsentStore()
+	mtm := NewMultiTenantManager(credStore, consentStore, NewGraphHTTPClient(100, 1000), newStubTenantDiscoverer())
+
+	ctx := context.Background()
+	provider := "microsoft"
+	tenantID := "tenant-1"
+
+	require.NoError(t, consentStore.StoreConsent(provider, &ConsentStatus{
+		Provider:        provider,
+		HasAdminConsent: true,
+		AccessibleTenants: []TenantInfo{
+			{TenantID: tenantID, HasAccess: true},
+		},
+	}))
+
+	// Store an expired token; refreshTenantToken is called and must return an error.
+	tenantKey := mtm.getTenantKey(provider, tenantID)
+	require.NoError(t, credStore.StoreTokenSet(tenantKey, &TokenSet{
+		AccessToken: "expired-token",
+		TokenType:   "Bearer",
+		ExpiresAt:   time.Now().Add(-1 * time.Hour),
+	}))
+
+	token, err := mtm.GetTenantToken(ctx, provider, tenantID)
+	assert.Nil(t, token)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to refresh tenant token")
+}
+
 func TestMultiTenantManager_ListAccessibleTenants(t *testing.T) {
 	credStore := NewMockCredentialStore()
 	consentStore := NewInMemoryConsentStore()
-	httpClient := &http.Client{}
+	httpClient := NewGraphHTTPClient(100, 1000)
 	mtm := NewMultiTenantManager(credStore, consentStore, httpClient, newStubTenantDiscoverer())
 
 	ctx := context.Background()
@@ -601,7 +590,7 @@ func TestMultiTenantManager_ListAccessibleTenants(t *testing.T) {
 func TestMultiTenantManager_RevokeConsent(t *testing.T) {
 	credStore := NewMockCredentialStore()
 	consentStore := NewInMemoryConsentStore()
-	httpClient := &http.Client{}
+	httpClient := NewGraphHTTPClient(100, 1000)
 	mtm := NewMultiTenantManager(credStore, consentStore, httpClient, newStubTenantDiscoverer())
 
 	ctx := context.Background()
@@ -658,7 +647,7 @@ func TestMultiTenantManager_RevokeConsent(t *testing.T) {
 
 func TestMicrosoftMultiTenantProvider_Creation(t *testing.T) {
 	credStore := NewMockCredentialStore()
-	httpClient := &http.Client{}
+	httpClient := NewGraphHTTPClient(100, 1000)
 
 	provider := NewMicrosoftMultiTenantProvider(credStore, httpClient)
 
@@ -669,7 +658,7 @@ func TestMicrosoftMultiTenantProvider_Creation(t *testing.T) {
 
 func TestMicrosoftMultiTenantProvider_StartAdminConsent(t *testing.T) {
 	credStore := NewMockCredentialStore()
-	httpClient := &http.Client{}
+	httpClient := NewGraphHTTPClient(100, 1000)
 	provider := NewMicrosoftMultiTenantProvider(credStore, httpClient)
 
 	config := &MicrosoftMultiTenantConfig{
@@ -682,23 +671,11 @@ func TestMicrosoftMultiTenantProvider_StartAdminConsent(t *testing.T) {
 
 	ctx := context.Background()
 
-	// Mock the underlying multi-tenant manager
-	mockOAuth2 := &MockOAuth2Client{}
-	provider.multiTenantManager.oauth2Client = mockOAuth2
-
-	mockOAuth2.On("StartFlow", mock.Anything, mock.Anything).Return(&OAuth2Flow{
-		AuthURL:   "https://login.microsoftonline.com/common/oauth2/v2.0/authorize?test",
-		State:     "test-state",
-		Created:   time.Now(),
-		ExpiresAt: time.Now().Add(10 * time.Minute),
-	}, nil)
-
 	url, err := provider.StartAdminConsent(ctx, config)
 
 	assert.NoError(t, err)
 	assert.NotEmpty(t, url)
 	assert.Contains(t, url, "common/oauth2/v2.0/authorize")
-	mockOAuth2.AssertExpectations(t)
 }
 
 func TestMicrosoftMultiTenantProvider_CreateInTenant(t *testing.T) {
@@ -789,7 +766,7 @@ func TestMicrosoftMultiTenantProvider_CreateInTenant(t *testing.T) {
 
 func TestTenantOnboardingWorkflow_StartTenantOnboarding(t *testing.T) {
 	credStore := NewMockCredentialStore()
-	httpClient := &http.Client{}
+	httpClient := NewGraphHTTPClient(100, 1000)
 	provider := NewMicrosoftMultiTenantProvider(credStore, httpClient)
 	workflow := NewTenantOnboardingWorkflow(provider)
 
@@ -815,17 +792,6 @@ func TestTenantOnboardingWorkflow_StartTenantOnboarding(t *testing.T) {
 	}
 
 	ctx := context.Background()
-
-	// Mock OAuth2 client for consent flow
-	mockOAuth2 := &MockOAuth2Client{}
-	provider.multiTenantManager.oauth2Client = mockOAuth2
-
-	mockOAuth2.On("StartFlow", mock.Anything, mock.Anything).Return(&OAuth2Flow{
-		AuthURL:   "https://login.microsoftonline.com/common/oauth2/v2.0/authorize?test",
-		State:     "test-state",
-		Created:   time.Now(),
-		ExpiresAt: time.Now().Add(10 * time.Minute),
-	}, nil)
 
 	result, err := workflow.StartTenantOnboarding(ctx, request)
 
@@ -933,7 +899,7 @@ func TestTenantOnboardingWorkflow_ValidateRequest(t *testing.T) {
 func TestMultiTenantManager_TenantCacheConcurrency(t *testing.T) {
 	credStore := NewMockCredentialStore()
 	consentStore := NewInMemoryConsentStore()
-	httpClient := &http.Client{}
+	httpClient := NewGraphHTTPClient(100, 1000)
 	// Stub returns one deterministic tenant so RefreshTenantDiscovery writes a
 	// non-empty AccessibleTenants slice to the consent store on each call.
 	stub := newStubTenantDiscoverer(TenantInfo{TenantID: "stub-concurrent-tenant", HasAccess: true})
@@ -1002,7 +968,7 @@ func TestMultiTenantManager_TenantCacheConcurrency(t *testing.T) {
 // Callers that need to act on a specific tenant must use the *InTenant variants.
 func TestMicrosoftMultiTenantProvider_TenantlessCRUD(t *testing.T) {
 	credStore := NewMockCredentialStore()
-	httpClient := &http.Client{}
+	httpClient := NewGraphHTTPClient(100, 1000)
 	provider := NewMicrosoftMultiTenantProvider(credStore, httpClient)
 	ctx := context.Background()
 
@@ -1058,7 +1024,7 @@ func TestMicrosoftMultiTenantProvider_TenantlessCRUD(t *testing.T) {
 func BenchmarkMultiTenantManager_GetTenantToken(b *testing.B) {
 	credStore := NewMockCredentialStore()
 	consentStore := NewInMemoryConsentStore()
-	httpClient := &http.Client{}
+	httpClient := NewGraphHTTPClient(100, 1000)
 	mtm := NewMultiTenantManager(credStore, consentStore, httpClient, newStubTenantDiscoverer())
 
 	ctx := context.Background()
@@ -1094,13 +1060,15 @@ func BenchmarkMultiTenantManager_GetTenantToken(b *testing.B) {
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
-		_, _ = mtm.GetTenantToken(ctx, provider, tenantID)
+		if _, err := mtm.GetTenantToken(ctx, provider, tenantID); err != nil {
+			b.Fatal(err)
+		}
 	}
 }
 
 func BenchmarkMicrosoftMultiTenantProvider_CreateInTenant(b *testing.B) {
 	credStore := NewMockCredentialStore()
-	httpClient := &http.Client{}
+	httpClient := NewGraphHTTPClient(100, 1000)
 	provider := NewMicrosoftMultiTenantProvider(credStore, httpClient)
 
 	ctx := context.Background()
@@ -1139,6 +1107,8 @@ func BenchmarkMicrosoftMultiTenantProvider_CreateInTenant(b *testing.B) {
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
-		_, _ = provider.CreateInTenant(ctx, tenantID, resourceType, data)
+		if _, err := provider.CreateInTenant(ctx, tenantID, resourceType, data); err != nil {
+			b.Fatal(err)
+		}
 	}
 }

--- a/features/saas/transport.go
+++ b/features/saas/transport.go
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+// Package saas transport provides the HTTP client factory for Microsoft Graph API calls.
+// Graph API uses Microsoft's public CA infrastructure, so http.DefaultTransport
+// (system root CAs) is appropriate here — pkg/cert mTLS is for CFGMS-internal gRPC only.
+package saas
+
+import (
+	"net/http"
+	"time"
+
+	"golang.org/x/time/rate"
+)
+
+// rateLimitedTransport wraps an http.RoundTripper with a token-bucket rate limiter.
+// A single limiter is shared across all tenants in the process (per-process, not
+// per-tenant). Per-tenant limiting is a future optimization.
+type rateLimitedTransport struct {
+	base    http.RoundTripper
+	limiter *rate.Limiter
+}
+
+// RoundTrip implements http.RoundTripper. It blocks until the rate limiter grants
+// a token before forwarding the request to the underlying transport.
+func (t *rateLimitedTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	if err := t.limiter.Wait(req.Context()); err != nil {
+		return nil, err
+	}
+	return t.base.RoundTrip(req)
+}
+
+// NewGraphHTTPClient returns an *http.Client suitable for Microsoft Graph API calls.
+// It wraps http.DefaultTransport (system root CAs, standard TLS) with a per-process
+// token-bucket rate limiter.
+//
+// rps is the sustained request rate (requests per second); burst is the maximum
+// number of requests that may exceed the rate in a short window. Defaults are
+// 10 req/s and burst 20.
+func NewGraphHTTPClient(rps float64, burst int) *http.Client {
+	return &http.Client{
+		Timeout: 30 * time.Second,
+		Transport: &rateLimitedTransport{
+			base:    http.DefaultTransport,
+			limiter: rate.NewLimiter(rate.Limit(rps), burst),
+		},
+	}
+}

--- a/features/saas/transport_test.go
+++ b/features/saas/transport_test.go
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+package saas
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewGraphHTTPClient_WithinBurst_NoDelay(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	// 10 requests within burst=20 — all fit in the token bucket; no rate-limiting delay
+	client := NewGraphHTTPClient(10, 20)
+
+	start := time.Now()
+	for i := 0; i < 10; i++ {
+		req, err := http.NewRequest(http.MethodGet, server.URL, nil)
+		require.NoError(t, err)
+		resp, err := client.Do(req)
+		require.NoError(t, err)
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+		require.NoError(t, resp.Body.Close())
+	}
+	assert.Less(t, time.Since(start), 500*time.Millisecond,
+		"10 requests within burst=20 should complete without rate-limiting delay")
+}
+
+func TestNewGraphHTTPClient_ExceedBurst_DelaysRequests(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	// 100 rps, burst=5: 25 requests → first 5 free, next 20 at 100/s ≈ 200ms total delay
+	client := NewGraphHTTPClient(100, 5)
+
+	start := time.Now()
+	for i := 0; i < 25; i++ {
+		req, err := http.NewRequest(http.MethodGet, server.URL, nil)
+		require.NoError(t, err)
+		resp, err := client.Do(req)
+		require.NoError(t, err)
+		require.NoError(t, resp.Body.Close())
+	}
+	elapsed := time.Since(start)
+	// 20 extra requests at 100 rps = 200ms expected; assert at least 100ms as a conservative floor
+	assert.Greater(t, elapsed, 100*time.Millisecond,
+		"25 requests with burst=5 at 100 rps should be delayed by the rate limiter")
+}
+
+func TestNewGraphHTTPClient_HasTimeout(t *testing.T) {
+	client := NewGraphHTTPClient(10, 20)
+	assert.Greater(t, client.Timeout, time.Duration(0), "client must have a non-zero timeout")
+}
+
+func TestNewGraphHTTPClient_HasRateLimitedTransport(t *testing.T) {
+	client := NewGraphHTTPClient(10, 20)
+	_, ok := client.Transport.(*rateLimitedTransport)
+	assert.True(t, ok, "client transport must be a *rateLimitedTransport")
+}


### PR DESCRIPTION
## Summary

- Creates `features/saas/transport.go` with `rateLimitedTransport` (unexported `http.RoundTripper`) and `NewGraphHTTPClient(rps, burst)` factory wrapping `http.DefaultTransport` with a per-process token-bucket rate limiter (`golang.org/x/time/rate`, already a direct dependency)
- Replaces `&http.Client{Timeout: 30s}` in `NewM365TenantManager` with `NewGraphHTTPClient(10, 20)` — the single non-test change site per the story spec
- Removes bare `&http.Client{}` literals from all non-test `features/saas/` files including `examples/microsoft_provider.go`
- Fixes `refreshTenantToken` stub: replaces fabricated token strings with an explicit error return so the unimplemented state is surfaced to callers; adds error-path test
- Removes `MockOAuth2Client` (testify/mock) from `multitenant_test.go`; affected tests now use the real `DefaultOAuth2Client`
- Replaces `mockCredentialStore` (hardcoded returns) with `NewMockCredentialStore()` (map-backed real state)
- Removes hardcoded password literals from `examples/microsoft_provider.go`
- Adds `features/saas/README.md` "HTTP Client" section

## Specialist Review Results

| Specialist | Result |
|---|---|
| QA Test Runner | **PASS** — all unit tests, lint, license headers, cross-platform builds pass |
| QA Code Reviewer | **PASS** (3rd pass) — 0 blocking issues, 0 warnings |
| Security Engineer | **PASS** — no hardcoded secrets, no InsecureSkipVerify, no central provider violations; all automated scans clean |

## Test plan

- [ ] `go test ./features/saas/...` — all tests pass including new transport and error-path tests
- [ ] Rate-limit behaviour: 10 requests within burst=20 complete < 500ms; 25 requests with burst=5 take > 100ms
- [ ] No `InsecureSkipVerify` in the diff
- [ ] No bare `&http.Client{}` in non-test `features/saas/` files
- [ ] CI required checks: unit-tests, integration-tests, Build Gate, security-deployment-gate

Fixes #959

🤖 Generated with [Claude Code](https://claude.com/claude-code)