### PR TITLE
terminal: redact session IDs in manager.go and session.go log calls (Issue #979)

### DIFF
--- a/features/terminal/manager.go
+++ b/features/terminal/manager.go
@@ -98,7 +98,7 @@ func (m *DefaultSessionManager) CreateSession(ctx context.Context, req *SessionR
 		metadata := session.GetMetadata()
 		if recorder, ok := m.recorder.(*DefaultSessionRecorder); ok {
 			if err := recorder.StartRecording(session.ID, metadata); err != nil {
-				m.logger.Warn("Failed to start session recording", "session_id", session.ID, "error", err)
+				m.logger.Warn("Failed to start session recording", "session_id", logging.RedactedID(session.ID), "error", err)
 			}
 		}
 	}
@@ -107,7 +107,7 @@ func (m *DefaultSessionManager) CreateSession(ctx context.Context, req *SessionR
 	m.sessions[session.ID] = session
 
 	m.logger.Info("Session created",
-		"session_id", session.ID,
+		"session_id", logging.RedactedID(session.ID),
 		"steward_id", session.StewardID,
 		"user_id", session.UserID,
 		"active_sessions", len(m.sessions))
@@ -140,14 +140,14 @@ func (m *DefaultSessionManager) TerminateSession(ctx context.Context, sessionID 
 
 	// Close the session
 	if err := session.Close(ctx); err != nil {
-		m.logger.Warn("Error closing session", "session_id", sessionID, "error", err)
+		m.logger.Warn("Error closing session", "session_id", logging.RedactedID(sessionID), "error", err)
 	}
 
 	// End recording if recorder is available
 	if m.recorder != nil {
 		if recorder, ok := m.recorder.(*DefaultSessionRecorder); ok {
 			if err := recorder.EndRecording(sessionID); err != nil {
-				m.logger.Warn("Failed to end session recording", "session_id", sessionID, "error", err)
+				m.logger.Warn("Failed to end session recording", "session_id", logging.RedactedID(sessionID), "error", err)
 			}
 		}
 	}
@@ -156,7 +156,7 @@ func (m *DefaultSessionManager) TerminateSession(ctx context.Context, sessionID 
 	delete(m.sessions, sessionID)
 
 	m.logger.Info("Session terminated",
-		"session_id", sessionID,
+		"session_id", logging.RedactedID(sessionID),
 		"active_sessions", len(m.sessions))
 
 	return nil
@@ -230,7 +230,7 @@ func (m *DefaultSessionManager) CleanupTimedOutSessions() {
 	for _, id := range timedOut {
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		if err := m.TerminateSession(ctx, id); err != nil {
-			m.logger.Warn("Failed to terminate timed-out session", "session_id", id, "error", err)
+			m.logger.Warn("Failed to terminate timed-out session", "session_id", logging.RedactedID(id), "error", err)
 		}
 		cancel()
 	}
@@ -246,7 +246,7 @@ func (m *DefaultSessionManager) cleanupSession(sessionID string) {
 	defer cancel()
 
 	if err := m.TerminateSession(ctx, sessionID); err != nil {
-		m.logger.Warn("Failed to cleanup session", "session_id", sessionID, "error", err)
+		m.logger.Warn("Failed to cleanup session", "session_id", logging.RedactedID(sessionID), "error", err)
 	}
 }
 
@@ -255,7 +255,7 @@ func (m *DefaultSessionManager) RequestCleanup(sessionID string) {
 	select {
 	case m.cleanupCh <- sessionID:
 	default:
-		m.logger.Warn("Cleanup channel full, session may not be cleaned up immediately", "session_id", sessionID)
+		m.logger.Warn("Cleanup channel full, session may not be cleaned up immediately", "session_id", logging.RedactedID(sessionID))
 	}
 }
 
@@ -270,7 +270,7 @@ func (m *DefaultSessionManager) Stop(ctx context.Context) error {
 	// Close all active sessions
 	for sessionID, session := range m.sessions {
 		if err := session.Close(ctx); err != nil {
-			m.logger.Warn("Error closing session during shutdown", "session_id", sessionID, "error", err)
+			m.logger.Warn("Error closing session during shutdown", "session_id", logging.RedactedID(sessionID), "error", err)
 		}
 	}
 

--- a/features/terminal/manager_test.go
+++ b/features/terminal/manager_test.go
@@ -5,6 +5,7 @@ package terminal
 import (
 	"context"
 	"fmt"
+	"sync"
 	"testing"
 	"time"
 
@@ -15,6 +16,66 @@ import (
 	"github.com/cfgis/cfgms/pkg/logging"
 	testutil "github.com/cfgis/cfgms/pkg/testing"
 )
+
+// kvCapturingLogger captures Info and Warn log calls for security assertions.
+// It satisfies logging.Logger via embedding NoopLogger while recording key-value
+// arguments so tests can verify sensitive fields are redacted.
+type kvCapturingLogger struct {
+	logging.NoopLogger
+	mu      sync.Mutex
+	entries []kvLogEntry
+}
+
+type kvLogEntry struct {
+	msg string
+	kvs []interface{}
+}
+
+func (l *kvCapturingLogger) Info(msg string, kvs ...interface{}) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	kvcopy := make([]interface{}, len(kvs))
+	copy(kvcopy, kvs)
+	l.entries = append(l.entries, kvLogEntry{msg: msg, kvs: kvcopy})
+}
+
+func (l *kvCapturingLogger) Warn(msg string, kvs ...interface{}) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	kvcopy := make([]interface{}, len(kvs))
+	copy(kvcopy, kvs)
+	l.entries = append(l.entries, kvLogEntry{msg: msg, kvs: kvcopy})
+}
+
+// allKVContains reports whether any captured entry has a kv value equal to v.
+func (l *kvCapturingLogger) allKVContains(v string) bool {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	for _, entry := range l.entries {
+		for i := 1; i < len(entry.kvs); i += 2 {
+			if s, ok := entry.kvs[i].(string); ok && s == v {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// anyKVKeyHasValue reports whether any captured entry has the given key mapped to the given value.
+func (l *kvCapturingLogger) anyKVKeyHasValue(key, value string) bool {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	for _, entry := range l.entries {
+		for i := 0; i < len(entry.kvs)-1; i += 2 {
+			if k, ok := entry.kvs[i].(string); ok && k == key {
+				if v, ok2 := entry.kvs[i+1].(string); ok2 && v == value {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}
 
 func TestSessionManagerCreation(t *testing.T) {
 	logger := testutil.NewMockLogger(true)
@@ -543,4 +604,83 @@ func TestCreateSession_TenantIDRequired(t *testing.T) {
 		err = manager.TerminateSession(ctx, session.ID)
 		require.NoError(t, err)
 	})
+}
+
+// TestCreateSession_RedactsSessionID verifies that CreateSession never logs
+// the raw session UUID and always logs the redacted prefix form.
+func TestCreateSession_RedactsSessionID(t *testing.T) {
+	capLogger := &kvCapturingLogger{}
+	config := &Config{
+		SessionTimeout: 30 * time.Minute,
+		MaxSessions:    100,
+		RecordSessions: false,
+	}
+
+	manager, err := NewSessionManager(config, capLogger)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	req := &SessionRequest{
+		TenantID:  "test-tenant",
+		StewardID: "test-steward-001",
+		UserID:    "test-user",
+		Shell:     shell.GetDefaultShell(),
+		Cols:      80,
+		Rows:      24,
+	}
+
+	session, err := manager.CreateSession(ctx, req)
+	require.NoError(t, err)
+	require.NotNil(t, session)
+
+	// Full UUID must not appear in any logged kv value.
+	assert.False(t, capLogger.allKVContains(session.ID),
+		"raw session UUID must not appear in any log kv value after CreateSession")
+
+	// Redacted form must be present under the session_id key.
+	redacted := logging.RedactedID(session.ID)
+	assert.True(t, capLogger.anyKVKeyHasValue("session_id", redacted),
+		"redacted session_id (%q) must appear in log kv values after CreateSession", redacted)
+
+	require.NoError(t, manager.TerminateSession(ctx, session.ID))
+}
+
+// TestTerminateSession_RedactsSessionID verifies that TerminateSession never logs
+// the raw session UUID and always logs the redacted prefix form.
+func TestTerminateSession_RedactsSessionID(t *testing.T) {
+	capLogger := &kvCapturingLogger{}
+	config := &Config{
+		SessionTimeout: 30 * time.Minute,
+		MaxSessions:    100,
+		RecordSessions: false,
+	}
+
+	manager, err := NewSessionManager(config, capLogger)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	req := &SessionRequest{
+		TenantID:  "test-tenant",
+		StewardID: "test-steward-001",
+		UserID:    "test-user",
+		Shell:     shell.GetDefaultShell(),
+		Cols:      80,
+		Rows:      24,
+	}
+
+	session, err := manager.CreateSession(ctx, req)
+	require.NoError(t, err)
+
+	sessionID := session.ID
+	err = manager.TerminateSession(ctx, sessionID)
+	require.NoError(t, err)
+
+	// Full UUID must not appear in any logged kv value.
+	assert.False(t, capLogger.allKVContains(sessionID),
+		"raw session UUID must not appear in any log kv value after TerminateSession")
+
+	// Redacted form must be present under the session_id key.
+	redacted := logging.RedactedID(sessionID)
+	assert.True(t, capLogger.anyKVKeyHasValue("session_id", redacted),
+		"redacted session_id (%q) must appear in log kv values after TerminateSession", redacted)
 }

--- a/features/terminal/session.go
+++ b/features/terminal/session.go
@@ -75,7 +75,7 @@ func NewSession(req *SessionRequest, logger logging.Logger) (*Session, error) {
 	session.executor = executor
 
 	logger.Info("Created new terminal session",
-		"session_id", sessionID,
+		"session_id", logging.RedactedID(sessionID),
 		"steward_id", req.StewardID,
 		"user_id", req.UserID,
 		"shell", req.Shell,

--- a/features/terminal/session_test.go
+++ b/features/terminal/session_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/cfgis/cfgms/features/terminal/shell"
+	"github.com/cfgis/cfgms/pkg/logging"
 	testutil "github.com/cfgis/cfgms/pkg/testing"
 )
 
@@ -124,10 +125,6 @@ func TestSessionCreation(t *testing.T) {
 }
 
 func TestSessionDataHandling(t *testing.T) {
-	if testing.Short() {
-		t.Skip("Skipping shell integration test in short mode")
-	}
-
 	logger := testutil.NewMockLogger(true)
 	request := &SessionRequest{
 		StewardID: "test-steward-001",
@@ -245,45 +242,57 @@ func TestSessionRecordingIntegration(t *testing.T) {
 	session, err := NewSession(request, logger)
 	require.NoError(t, err)
 
-	// Enable recording
-	recorder := &MockRecorder{}
+	recorderConfig := &RecorderConfig{
+		StoragePath:    t.TempDir(),
+		MaxRecordingMB: 10,
+		Compression:    false,
+	}
+	recorder, err := NewSessionRecorder(recorderConfig, logger)
+	require.NoError(t, err)
+
 	session.SetRecorder(recorder)
 
 	ctx := context.Background()
 
-	// Test recording without starting shell (just the recording mechanism)
-	// Simulate output data (this doesn't require shell to be running)
+	// Simulate output data (does not require shell to be running)
 	outputData := []byte("total 0\ndrwxr-xr-x  2 user user 4096 Jan  1 00:00 .\n")
 	err = session.HandleOutput(ctx, outputData)
 	assert.NoError(t, err)
 
-	// Verify output was recorded
-	assert.True(t, recorder.RecordDataCalled)
-	assert.Equal(t, outputData, recorder.LastData)
-	assert.Equal(t, DataDirectionOutput, recorder.LastDirection)
+	// Flush recording to disk before reading it back
+	err = recorder.EndRecording(session.ID)
+	require.NoError(t, err)
+
+	// Verify output was persisted by the real recorder
+	recording, err := recorder.GetRecording(session.ID)
+	require.NoError(t, err)
+	require.NotNil(t, recording)
+	assert.Equal(t, session.ID, recording.SessionID)
+	assert.Contains(t, string(recording.Data), "drwxr-xr-x")
 }
 
-// MockRecorder for testing
-type MockRecorder struct {
-	RecordDataCalled bool
-	LastData         []byte
-	LastDirection    DataDirection
-}
+// TestNewSession_RedactsSessionID verifies that NewSession never logs the raw
+// session UUID and always logs the redacted prefix form under the session_id key.
+func TestNewSession_RedactsSessionID(t *testing.T) {
+	capLogger := &kvCapturingLogger{}
+	req := &SessionRequest{
+		StewardID: "test-steward-001",
+		UserID:    "test-user",
+		Shell:     shell.GetDefaultShell(),
+		Cols:      80,
+		Rows:      24,
+	}
 
-func (m *MockRecorder) RecordData(sessionID string, data []byte, direction DataDirection) error {
-	m.RecordDataCalled = true
-	m.LastData = data
-	m.LastDirection = direction
-	return nil
-}
+	session, err := NewSession(req, capLogger)
+	require.NoError(t, err)
+	require.NotNil(t, session)
 
-func (m *MockRecorder) GetRecording(sessionID string) (*SessionRecording, error) {
-	return &SessionRecording{
-		SessionID: sessionID,
-		Data:      m.LastData,
-	}, nil
-}
+	// Full UUID must not appear in any logged kv value.
+	assert.False(t, capLogger.allKVContains(session.ID),
+		"raw session UUID must not appear in any log kv value after NewSession")
 
-func (m *MockRecorder) Close() error {
-	return nil
+	// Redacted form must be present under the session_id key.
+	redacted := logging.RedactedID(session.ID)
+	assert.True(t, capLogger.anyKVKeyHasValue("session_id", redacted),
+		"redacted session_id (%q) must appear in log kv values after NewSession", redacted)
 }


### PR DESCRIPTION
## Summary

- Wraps all `"session_id"` values at Info/Warn log level in `features/terminal/manager.go` (8 sites) and `features/terminal/session.go` (1 site) with `logging.RedactedID()`, eliminating raw UUIDs from structured log output
- `steward_id` at `manager.go:111` is intentionally left unredacted — it is an operator-visible machine identifier, not a bearer credential (documented in issue implementation notes)
- Adds three new unit tests using a local `kvCapturingLogger` that assert both absence of the raw UUID and presence of the redacted form under `session_id`
- Remediates two pre-existing violations in touched files: replaces `MockRecorder` with real `DefaultSessionRecorder` in `TestSessionRecordingIntegration`, and removes the `testing.Short()` skip gate from `TestSessionDataHandling`

## Specialist Review Results

| Reviewer | Result | Notes |
|----------|--------|-------|
| QA Test Runner | **PASS** | All packages pass; cross-platform builds verified; validation marker written |
| QA Code Reviewer | **PASS** (after 1 fix cycle) | Fixed MockRecorder→real recorder, removed testing.Short() skip, used logging.RedactedID() for expected values in tests |
| Security Engineer | **PASS** | No blocking issues; security-precommit, check-architecture, security-scan all green |

## Test plan

- [ ] `go test ./features/terminal/... -race` passes
- [ ] `TestCreateSession_RedactsSessionID` — raw UUID absent, redacted form present in Info log after CreateSession
- [ ] `TestTerminateSession_RedactsSessionID` — raw UUID absent, redacted form present in Info log after TerminateSession
- [ ] `TestNewSession_RedactsSessionID` — raw UUID absent, redacted form present in Info log from NewSession
- [ ] `TestSessionRecordingIntegration` — uses real DefaultSessionRecorder, verifies data persisted to disk
- [ ] `TestSessionDataHandling` — shell integration test runs unconditionally (short-mode skip removed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)