### PR TITLE
steward: redact cmd.Params, steward IDs, and DNA IDs in log calls (Issue #981)

### DIFF
--- a/features/steward/client/client_transport.go
+++ b/features/steward/client/client_transport.go
@@ -16,6 +16,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"sync"
 	"time"
 
@@ -275,7 +276,7 @@ func (c *TransportClient) Connect(ctx context.Context) error {
 	// Initialize gRPC control plane provider if not already set
 	if controlPlane == nil {
 		c.logger.Info("Initializing gRPC control plane provider",
-			"addr", transportAddress, "steward_id", stewardID)
+			"addr", transportAddress, "steward_id", logging.RedactedID(stewardID))
 
 		provider := grpcCP.New(grpcCP.ModeClient)
 
@@ -343,7 +344,7 @@ func (c *TransportClient) Connect(ctx context.Context) error {
 	c.dataPlaneSession = session
 	c.mu.Unlock()
 
-	c.logger.Info("gRPC data plane initialized", "session_id", session.ID())
+	c.logger.Info("gRPC data plane initialized", "session_id", logging.RedactedID(session.ID()))
 
 	// Setup command handler
 	cmdHandler, err := c.setupCommandHandler(ctx, stewardID)
@@ -356,7 +357,7 @@ func (c *TransportClient) Connect(ctx context.Context) error {
 	c.mu.Unlock()
 
 	// Subscribe to commands via gRPC control plane provider
-	c.logger.Info("Subscribing to commands", "steward_id", stewardID)
+	c.logger.Info("Subscribing to commands", "steward_id", logging.RedactedID(stewardID))
 	if err := controlPlane.SubscribeCommands(ctx, stewardID, func(ctx context.Context, sc *cpTypes.SignedCommand) error {
 		return cmdHandler.HandleCommand(ctx, sc)
 	}); err != nil {
@@ -408,7 +409,7 @@ func (c *TransportClient) setupCommandHandler(ctx context.Context, stewardID str
 
 	// Register sync_config handler — retrieves config via gRPC data plane ReceiveConfig()
 	handler.RegisterHandler(cpTypes.CommandSyncConfig, func(ctx context.Context, cmd *cpTypes.Command) error {
-		c.logger.Info("Received sync_config command", "command_id", cmd.ID, "params", cmd.Params)
+		c.logger.Info("Received sync_config command", "command_id", cmd.ID, "params_keys", paramKeys(cmd.Params))
 
 		// Get modules filter from command params (optional, passed as context but not used in gRPC request)
 		var modules []string
@@ -1232,6 +1233,17 @@ func computeDelta(oldAttrs, newAttrs map[string]string) map[string]string {
 		}
 	}
 	return delta
+}
+
+// paramKeys returns the sorted key names from a command params map.
+// Values are not logged — they may contain secret fingerprints, tokens, or paths.
+func paramKeys(params map[string]interface{}) []string {
+	keys := make([]string, 0, len(params))
+	for k := range params {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
 }
 
 // copyStringMap returns a shallow copy of a string→string map.

--- a/features/steward/client/client_transport_test.go
+++ b/features/steward/client/client_transport_test.go
@@ -5,7 +5,10 @@
 package client
 
 import (
+	"context"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -13,6 +16,96 @@ import (
 	"github.com/cfgis/cfgms/pkg/cert"
 	"github.com/cfgis/cfgms/pkg/logging"
 )
+
+// kvCapturingLogger captures Info and Warn log entries for security assertions.
+// It satisfies logging.Logger via embedding NoopLogger while recording key-value
+// arguments so tests can verify sensitive fields are absent or properly redacted.
+// Issue #981: used to assert steward IDs appear only in redacted form in Connect logs.
+type kvCapturingLogger struct {
+	logging.NoopLogger
+	mu      sync.Mutex
+	entries []kvLogEntry
+}
+
+type kvLogEntry struct {
+	msg string
+	kvs []interface{}
+}
+
+func (l *kvCapturingLogger) Info(msg string, kvs ...interface{}) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	kvcopy := make([]interface{}, len(kvs))
+	copy(kvcopy, kvs)
+	l.entries = append(l.entries, kvLogEntry{msg: msg, kvs: kvcopy})
+}
+
+func (l *kvCapturingLogger) Warn(msg string, kvs ...interface{}) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	kvcopy := make([]interface{}, len(kvs))
+	copy(kvcopy, kvs)
+	l.entries = append(l.entries, kvLogEntry{msg: msg, kvs: kvcopy})
+}
+
+func (l *kvCapturingLogger) allEntries() []kvLogEntry {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	out := make([]kvLogEntry, len(l.entries))
+	copy(out, l.entries)
+	return out
+}
+
+// TestConnect_StewardIDRedactedInLogs verifies that Connect never logs the literal
+// steward ID (a server-generated bearer-like identifier) in plain form. The log
+// entries captured before Connect fails must use logging.RedactedID output only.
+// Issue #981: steward_id from controller registration must be redacted at Info level.
+func TestConnect_StewardIDRedactedInLogs(t *testing.T) {
+	cap := &kvCapturingLogger{}
+	c := &TransportClient{
+		stewardID:        "steward-test-abc123xyz",
+		transportAddress: "localhost:0", // unreachable; Connect will fail before fully connecting
+		logger:           cap,
+		heartbeatStop:    make(chan struct{}),
+		convergenceStop:  make(chan struct{}),
+		convergeInterval: 30 * time.Minute,
+	}
+
+	ctx := context.Background()
+	// Connect is expected to fail (no real controller). The log entries captured
+	// before the failure are what we validate.
+	_ = c.Connect(ctx)
+
+	literal := "steward-test-abc123xyz"
+	redacted := logging.RedactedID(literal)
+
+	entries := cap.allEntries()
+	require.NotEmpty(t, entries, "Connect must emit at least one log entry before failing")
+
+	// Assert the literal steward ID never appears as a log value.
+	for _, e := range entries {
+		for i := 1; i < len(e.kvs); i += 2 {
+			if s, ok := e.kvs[i].(string); ok {
+				assert.NotContains(t, s, literal,
+					"log entry %q must not contain the literal steward ID", e.msg)
+			}
+		}
+	}
+
+	// Assert the redacted form appears under "steward_id" in at least one entry.
+	foundRedacted := false
+	for _, e := range entries {
+		for i := 0; i+1 < len(e.kvs); i += 2 {
+			if key, ok := e.kvs[i].(string); ok && key == "steward_id" {
+				if val, ok := e.kvs[i+1].(string); ok && val == redacted {
+					foundRedacted = true
+				}
+			}
+		}
+	}
+	assert.True(t, foundRedacted,
+		"redacted steward ID %q must appear under 'steward_id' key in at least one log entry", redacted)
+}
 
 // TestTransportClient_CertReloadOnHandshake verifies that createTLSConfig wires
 // GetClientCertificate as a per-handshake callback (not a cached value) so that

--- a/features/steward/steward.go
+++ b/features/steward/steward.go
@@ -335,8 +335,8 @@ func (s *Steward) detectUnmanagedDNADrift(ctx context.Context) ([]*drift.DriftEv
 	// knows not to proceed with stale comparison results.
 	if prevDNA.Id != currentDNA.Id {
 		s.logger.Error("DNA identity changed between convergence cycles — manual reconciliation required",
-			"previous_id", prevDNA.Id,
-			"current_id", currentDNA.Id)
+			"previous_id", logging.RedactedID(prevDNA.Id),
+			"current_id", logging.RedactedID(currentDNA.Id))
 		evt := &drift.DriftEvent{
 			Severity:    drift.SeverityCritical,
 			Category:    drift.CategoryConfiguration,


### PR DESCRIPTION
## Summary

- Wraps the server-generated `stewardID` (bearer-like identifier) with `logging.RedactedID` at two Info-level log sites in `Connect()` (`client_transport.go:~278` and `~359`)
- Wraps `session.ID()` with `logging.RedactedID` in the data plane init log (`~346`)
- Replaces `"params", cmd.Params` (full map, may contain secrets/tokens) with `"params_keys", paramKeys(cmd.Params)` — key names only, no values (`~411`)
- Wraps DNA identity IDs (`prevDNA.Id`, `currentDNA.Id`) with `logging.RedactedID` in the Error-level identity-mismatch log in `detectUnmanagedDNADrift` (`steward.go:338-339`)
- Adds `paramKeys` helper using `sort.Strings`; adds `kvCapturingLogger` test helper and `TestConnect_StewardIDRedactedInLogs` unit test

**Intentional exclusions (per spec):** `s.standaloneConfig.Steward.ID` at `steward.go:229, 268, 434` is operator-configured (e.g. `"steward-standalone"`), used for log correlation, not a bearer credential — left unredacted.

## Specialist Review Results

| Reviewer | Result |
|----------|--------|
| QA Test Runner | **PASS** — 75+ packages, race detection enabled, all tests green including `TestConnect_StewardIDRedactedInLogs`; cross-platform builds (linux/amd64, arm64, darwin, windows) verified |
| QA Code Reviewer | **PASS** — no mocks, no t.Skip(), no empty assertions; `kvCapturingLogger` correctly identified as a log-capture helper (not a mock), assertions validate both negative and positive properties |
| Security Engineer | **PASS** — security-precommit, check-architecture, security-scan all green; redaction logic verified correct at all 5 call sites; no hardcoded secrets, no information disclosure regressions |

## Test Plan

- [x] `TestConnect_StewardIDRedactedInLogs` — asserts literal steward ID never appears as a log value and redacted prefix form appears under `steward_id` key
- [x] All existing `features/steward/...` tests pass with race detection
- [x] `make test-agent-complete` passes (75+ packages, cross-platform builds, integration tests)
- [x] Operator-visible IDs at `steward.go:229, 268, 434` verified unchanged (grep confirmed)

Fixes #981 | Part of Epic #732

🤖 Generated with [Claude Code](https://claude.com/claude-code)