### PR TITLE
saas: remove placeholder credentials from startAdminConsentFlow (Issue #699)

### DIFF
--- a/features/saas/README.md
+++ b/features/saas/README.md
@@ -100,6 +100,28 @@ resources:
           # Client-specific user configuration
 ```
 
+### TenantOnboardingWorkflow construction
+
+`NewTenantOnboardingWorkflow` requires a `*MicrosoftMultiTenantConfig` as its second
+argument. This config must carry real `ClientID`, `ClientSecret`, and `RedirectURI`
+values sourced from secure storage (e.g. OS keychain via `pkg/secrets`). Placeholder
+strings such as `"your-client-id"` must never be passed — `startAdminConsentFlow`
+will propagate these values directly into Microsoft's OAuth2 authorization endpoint,
+and placeholder values will cause consent to fail or silently target the wrong
+application registration.
+
+```go
+cfg := &MicrosoftMultiTenantConfig{
+    ClientID:     credentialStore.GetClientID(),
+    ClientSecret: credentialStore.GetClientSecret(),
+    RedirectURI:  "https://your-app.example.com/oauth/callback",
+}
+workflow := NewTenantOnboardingWorkflow(provider, cfg)
+```
+
+If `cfg` is `nil`, `startAdminConsentFlow` returns an error immediately rather than
+panicking — but callers should always supply a populated config.
+
 ## Security Features
 
 - **OAuth2 PKCE**: Prevents authorization code interception

--- a/features/saas/multitenant.go
+++ b/features/saas/multitenant.go
@@ -176,6 +176,13 @@ func (mtm *MultiTenantManager) StartAdminConsent(ctx context.Context, provider s
 
 	query := authURL.Query()
 
+	// Required OAuth2 authorization request parameters.
+	query.Set("client_id", flow.ClientID)
+	query.Set("response_type", "code")
+	if flow.RedirectURI != "" {
+		query.Set("redirect_uri", flow.RedirectURI)
+	}
+
 	// Add admin consent specific parameters
 	if config.ConsentPrompt != "" {
 		query.Set("prompt", config.ConsentPrompt)

--- a/features/saas/multitenant_integration.go
+++ b/features/saas/multitenant_integration.go
@@ -18,13 +18,17 @@ import (
 type TenantOnboardingWorkflow struct {
 	multiTenantManager *MultiTenantManager
 	provider           *MicrosoftMultiTenantProvider
+	providerConfig     *MicrosoftMultiTenantConfig
 }
 
-// NewTenantOnboardingWorkflow creates a new tenant onboarding workflow
-func NewTenantOnboardingWorkflow(provider *MicrosoftMultiTenantProvider) *TenantOnboardingWorkflow {
+// NewTenantOnboardingWorkflow creates a new tenant onboarding workflow.
+// cfg must be a non-nil *MicrosoftMultiTenantConfig carrying real ClientID,
+// ClientSecret, and RedirectURI — placeholder strings must never be passed here.
+func NewTenantOnboardingWorkflow(provider *MicrosoftMultiTenantProvider, cfg *MicrosoftMultiTenantConfig) *TenantOnboardingWorkflow {
 	return &TenantOnboardingWorkflow{
 		multiTenantManager: provider.multiTenantManager,
 		provider:           provider,
+		providerConfig:     cfg,
 	}
 }
 
@@ -269,11 +273,14 @@ func (tow *TenantOnboardingWorkflow) validateOnboardingRequest(request *Onboardi
 }
 
 func (tow *TenantOnboardingWorkflow) startAdminConsentFlow(ctx context.Context, request *OnboardingRequest) (string, error) {
-	// Build multi-tenant config from onboarding request
+	if tow.providerConfig == nil {
+		return "", fmt.Errorf("startAdminConsentFlow: providerConfig is required; NewTenantOnboardingWorkflow must be called with a non-nil *MicrosoftMultiTenantConfig")
+	}
+
 	mtConfig := &MicrosoftMultiTenantConfig{
-		ClientID:           "your-client-id", // This would come from provider config
-		ClientSecret:       "your-client-secret",
-		RedirectURI:        "your-redirect-uri",
+		ClientID:           tow.providerConfig.ClientID,
+		ClientSecret:       tow.providerConfig.ClientSecret,
+		RedirectURI:        tow.providerConfig.RedirectURI,
 		Scopes:             request.ConsentConfig.RequiredScopes,
 		AdminConsentScopes: append(request.ConsentConfig.RequiredScopes, request.ConsentConfig.OptionalScopes...),
 	}

--- a/features/saas/multitenant_test.go
+++ b/features/saas/multitenant_test.go
@@ -768,7 +768,12 @@ func TestTenantOnboardingWorkflow_StartTenantOnboarding(t *testing.T) {
 	credStore := NewMockCredentialStore()
 	httpClient := NewGraphHTTPClient(100, 1000)
 	provider := NewMicrosoftMultiTenantProvider(credStore, httpClient)
-	workflow := NewTenantOnboardingWorkflow(provider)
+	providerCfg := &MicrosoftMultiTenantConfig{
+		ClientID:     "test-client-id",
+		ClientSecret: "test-client-secret",
+		RedirectURI:  "https://localhost/callback",
+	}
+	workflow := NewTenantOnboardingWorkflow(provider, providerCfg)
 
 	request := &OnboardingRequest{
 		ProviderName: "microsoft-multitenant",
@@ -800,6 +805,74 @@ func TestTenantOnboardingWorkflow_StartTenantOnboarding(t *testing.T) {
 	assert.NotEmpty(t, result.OnboardingID)
 	assert.NotEmpty(t, result.ConsentURL)
 	assert.Contains(t, result.NextSteps, "Visit the consent URL to grant admin consent")
+}
+
+func TestTenantOnboardingWorkflow_StartAdminConsentFlow_UsesProviderConfig(t *testing.T) {
+	credStore := NewMockCredentialStore()
+	httpClient := NewGraphHTTPClient(100, 1000)
+	provider := NewMicrosoftMultiTenantProvider(credStore, httpClient)
+
+	providerCfg := &MicrosoftMultiTenantConfig{
+		ClientID:     "test-client-id",
+		ClientSecret: "test-client-secret",
+		RedirectURI:  "https://localhost/callback",
+	}
+	workflow := NewTenantOnboardingWorkflow(provider, providerCfg)
+
+	request := &OnboardingRequest{
+		ProviderName: "microsoft-multitenant",
+		MSPInfo: MSPInfo{
+			MSPName:      "Test MSP",
+			MSPTenantID:  "msp-tenant-123",
+			ContactEmail: "admin@msp.com",
+		},
+		ClientInfo: ClientInfo{
+			ClientName:    "Test Client",
+			PrimaryDomain: "testclient.com",
+		},
+		ConsentConfig: ConsentConfiguration{
+			RequiredScopes: []string{"https://graph.microsoft.com/.default"},
+			ConsentTimeout: 30 * time.Minute,
+		},
+	}
+
+	ctx := context.Background()
+	result, err := workflow.StartTenantOnboarding(ctx, request)
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.NotEmpty(t, result.ConsentURL, "expected a consent URL from StartTenantOnboarding")
+
+	assert.Contains(t, result.ConsentURL, "test-client-id",
+		"consent URL must contain the ClientID from providerConfig, not a placeholder")
+
+	assert.NotContains(t, result.ConsentURL, "your-client-id")
+	assert.NotContains(t, result.ConsentURL, "your-client-secret")
+	assert.NotContains(t, result.ConsentURL, "your-redirect-uri")
+}
+
+func TestTenantOnboardingWorkflow_StartAdminConsentFlow_NilConfig(t *testing.T) {
+	credStore := NewMockCredentialStore()
+	httpClient := NewGraphHTTPClient(100, 1000)
+	provider := NewMicrosoftMultiTenantProvider(credStore, httpClient)
+	workflow := NewTenantOnboardingWorkflow(provider, nil)
+
+	request := &OnboardingRequest{
+		ProviderName: "microsoft-multitenant",
+		MSPInfo:      MSPInfo{MSPName: "Test MSP"},
+		ClientInfo:   ClientInfo{ClientName: "Test Client"},
+		ConsentConfig: ConsentConfiguration{
+			RequiredScopes: []string{"https://graph.microsoft.com/.default"},
+			ConsentTimeout: 30 * time.Minute,
+		},
+	}
+
+	ctx := context.Background()
+	result, err := workflow.StartTenantOnboarding(ctx, request)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "providerConfig is required")
+	assert.NotNil(t, result)
 }
 
 func TestTenantOnboardingWorkflow_ValidateRequest(t *testing.T) {


### PR DESCRIPTION
## Summary

- Removes three hardcoded placeholder strings (`"your-client-id"`, `"your-client-secret"`, `"your-redirect-uri"`) from `startAdminConsentFlow` in `multitenant_integration.go`
- Extends `TenantOnboardingWorkflow` with a `providerConfig *MicrosoftMultiTenantConfig` field; `NewTenantOnboardingWorkflow` now requires a non-nil config carrying real credentials
- Adds nil guard: missing config returns a descriptive error, not a panic
- Fixes `MultiTenantManager.StartAdminConsent` to include `client_id`, `response_type`, and `redirect_uri` in the OAuth2 authorization URL (required fields that were missing)
- Documents the updated constructor signature in `features/saas/README.md`

## Specialist Review Results

| Reviewer | Result | Notes |
|---|---|---|
| QA Test Runner | **PASS** | All unit, integration, cross-platform builds green. Docker/E2E deferred to CI (no Docker in container). |
| QA Code Reviewer | FAIL→accepted | Blocking finding: new tests use `NewMockCredentialStore()`. Story spec §"Test requirements" explicitly instructs this. `MockCredentialStore` is a pre-existing in-memory real implementation (no `mock.Mock`, no `EXPECT()`), not a generated mock. Renaming is out of scope for this story. |
| Security Engineer | **PASS** | Placeholders eliminated, `ClientSecret` never logged, nil config fails closed, no central provider violations, all automated scans (security-precommit, check-architecture, security-scan) green. |

## Test plan

- [ ] `TestTenantOnboardingWorkflow_StartAdminConsentFlow_UsesProviderConfig` — consent URL contains real `ClientID`, does NOT contain `"your-client-id"`, `"your-client-secret"`, `"your-redirect-uri"`
- [ ] `TestTenantOnboardingWorkflow_StartAdminConsentFlow_NilConfig` — nil `providerConfig` returns error, no panic
- [ ] `TestTenantOnboardingWorkflow_StartTenantOnboarding` — updated to pass real config; still asserts consent URL returned and next steps populated
- [ ] CI: unit-tests, integration-tests, Build Gate, security-deployment-gate

Fixes #699

🤖 Generated with [Claude Code](https://claude.com/claude-code)