### PR TITLE
gitsync: document HMAC early-return semantics in webhook ServeHTTP (Issue #682)

### DIFF
--- a/pkg/gitsync/webhook.go
+++ b/pkg/gitsync/webhook.go
@@ -118,6 +118,11 @@ func (h *WebhookHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				h.logger.Warn("gitsync: webhook HMAC validation failed",
 					"tenant_path", logging.SanitizeLogValue(b.TenantPath),
 					"namespace", logging.SanitizeLogValue(b.Namespace))
+				// Intentional early return: reject the entire request (HTTP 401)
+				// when any matched binding's HMAC check fails, halting further
+				// iteration. We do not fall through to remaining bindings — a
+				// single HMAC failure poisons the whole response so the caller
+				// always sees rejection, not a partial 202.
 				http.Error(w, "invalid or missing signature", http.StatusUnauthorized)
 				return
 			}

--- a/pkg/gitsync/webhook_test.go
+++ b/pkg/gitsync/webhook_test.go
@@ -282,6 +282,55 @@ func TestWebhookInvalidJSON(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, rec.Code)
 }
 
+// TestWebhookHMACFailureRejectsEntireRequest verifies that when multiple
+// bindings match a push event but any one of them fails HMAC validation, the
+// handler returns HTTP 401 — not HTTP 202. This guards against a future
+// contributor changing the early return to a continue, which would cause the
+// handler to return 202 Accepted even when some bindings' HMAC checks fail.
+func TestWebhookHMACFailureRejectsEntireRequest(t *testing.T) {
+	const (
+		originURL = "https://github.com/org/cfgms-configs.git"
+		secretA   = "secret-for-binding-a"
+		secretB   = "secret-for-binding-b"
+	)
+
+	tmpDir := t.TempDir()
+	secretFileA := filepath.Join(tmpDir, "secret-a.txt")
+	secretFileB := filepath.Join(tmpDir, "secret-b.txt")
+	require.NoError(t, os.WriteFile(secretFileA, []byte(secretA), 0600))
+	require.NoError(t, os.WriteFile(secretFileB, []byte(secretB), 0600))
+
+	setup := newWebhookSetup(t, []gitsync.ScopeBinding{
+		{
+			TenantPath:       "root/t1",
+			Namespace:        "ns1",
+			OriginURL:        originURL,
+			Branch:           "main",
+			WebhookSecretRef: secretFileA,
+		},
+		{
+			TenantPath:       "root/t2",
+			Namespace:        "ns2",
+			OriginURL:        originURL,
+			Branch:           "main",
+			WebhookSecretRef: secretFileB,
+		},
+	})
+
+	body := buildPushPayload(originURL, "refs/heads/main")
+	// Sign only with secretA — binding B's check will fail.
+	sig := hmacSHA256Signature(body, secretA)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/webhooks/git-push", bytes.NewReader(body))
+	req.Header.Set("X-Hub-Signature-256", sig)
+	rec := httptest.NewRecorder()
+	setup.handler.ServeHTTP(rec, req)
+
+	// HTTP 401 is the expected response when any binding fails HMAC,
+	// regardless of which other bindings may have passed validation.
+	assert.Equal(t, http.StatusUnauthorized, rec.Code)
+}
+
 // TestWebhookEnvVarHMAC verifies that WebhookSecretRef with "env:" prefix
 // resolves the secret from an environment variable.
 func TestWebhookEnvVarHMAC(t *testing.T) {


### PR DESCRIPTION
## Summary

- Added a 4-line comment in `pkg/gitsync/webhook.go` (`ServeHTTP`) immediately before the HMAC-failure `http.Error` / `return`, explaining that the early return is intentional: a single failing binding's HMAC check poisons the whole HTTP response to 401 so the caller never receives a partial 202.
- Added `TestWebhookHMACFailureRejectsEntireRequest` in `pkg/gitsync/webhook_test.go` to machine-document this behavior — two bindings on the same origin/branch with different secrets, request signed with only one, assertion that the response is HTTP 401.

## Motivation

Discovered during PR #677 review (git-sync write-through, Issue #666). The undocumented early `return` risked being misread as a bug by a future contributor and "fixed" to a `continue`, silently weakening the security posture. No behavior change — comment + regression test only.

## Specialist Review Results

- **QA Test Runner**: PASS — 136 packages, all passing; cross-platform builds verified; integration tests pass.
- **QA Code Reviewer**: PASS (after one fix iteration) — initial review flagged the test comment as overclaiming "no syncs dispatched" when it only tested HTTP response; comments updated to accurately scope the invariant; re-review confirmed PASS.
- **Security Engineer**: PASS — `security-precommit`, `check-architecture`, `security-scan` all passed; no blocking findings.

## Test plan

- [x] `go test ./pkg/gitsync/... -race` passes
- [x] `make test-agent-complete` passes (all 136 packages, integration tests, cross-platform builds)
- [x] New test `TestWebhookHMACFailureRejectsEntireRequest` verifies HTTP 401 response when any binding fails HMAC

Fixes #682

🤖 Generated with [Claude Code](https://claude.com/claude-code)