### PR TITLE
modules/directory: remove stale comments contradicting ValidateAndCleanPath (Issue #998)

### DIFF
--- a/features/modules/directory/module.go
+++ b/features/modules/directory/module.go
@@ -237,7 +237,6 @@ func (m *directoryModule) Set(ctx context.Context, resourceID string, config mod
 	}
 
 	// Step 4: Validate path is within AllowedBasePath — return on any error, storing nothing in m
-	// NOTE: symlink escapes outside AllowedBasePath are not blocked by ValidateAndCleanPath
 	cleanPath, err := security.ValidateAndCleanPath(dirConfig.AllowedBasePath, dirConfig.Path)
 	if err != nil {
 		logger.ErrorCtx(ctx, "Directory path traversal check failed",
@@ -272,7 +271,6 @@ func (m *directoryModule) Set(ctx context.Context, resourceID string, config mod
 				return fmt.Errorf("failed to create directory: %w", err)
 			}
 		} else {
-			// NOTE: symlink escapes outside AllowedBasePath are not blocked by ValidateAndCleanPath
 			parent := filepath.Dir(cleanPath)
 			if _, err := os.Stat(parent); err != nil {
 				if os.IsNotExist(err) {
@@ -364,7 +362,6 @@ func (m *directoryModule) Get(ctx context.Context, resourceID string) (modules.C
 		return nil, ErrAllowedBasePathRequired
 	}
 
-	// NOTE: symlink escapes outside AllowedBasePath are not blocked by ValidateAndCleanPath
 	cleanPath, err := security.ValidateAndCleanPath(m.configuredBasePath, resourceID)
 	if err != nil {
 		return nil, fmt.Errorf("path security check failed: %w", err)


### PR DESCRIPTION
## Summary

- Removed three `// NOTE: symlink escapes outside AllowedBasePath are not blocked by ValidateAndCleanPath` comment lines from `features/modules/directory/module.go` (former lines 240, 275, 367).
- These comments were factually wrong: `pkg/security.ValidateAndCleanPath` does block symlink escapes via `filepath.EvalSymlinks` + ancestor-walk + `filepath.Rel` containment check (`pkg/security/fileaccess.go:117`).
- Existing tests (`TestValidateAndCleanPathSymlinks/symlink_escape_rejected`, `nonexistent_with_malicious_ancestor_symlink`) already prove the claim. No new tests required — no behavior changed.
- Fixes a future-contributor risk: a developer seeing the false assertion might skip an additional containment check when adding new code.

## Changes

- `features/modules/directory/module.go`: 3 comment lines deleted, nothing else.

## Specialist Review Results

| Specialist | Result | Notes |
|---|---|---|
| QA Test Runner | **PASS** | `make test-agent-complete` — 100+ packages, linting, security scans, cross-platform builds all pass |
| QA Code Reviewer | **PASS** | Comment-only deletion confirmed; no mocks, no logic changes, no new tests required |
| Security Engineer | **PASS** | gosec/staticcheck/Trivy/Nancy all pass; no security regression possible from comment removal |

Fixes #998

🤖 Generated with [Claude Code](https://claude.com/claude-code)