### PR TITLE
test: replace hardcoded registration token with generated credential (Issue #718)

### DIFF
--- a/test/integration/testutil/test_helper.go
+++ b/test/integration/testutil/test_helper.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cfgis/cfgms/features/steward/client"
 	"github.com/cfgis/cfgms/pkg/cert"
 	dataplaneInterfaces "github.com/cfgis/cfgms/pkg/dataplane/interfaces"
+	"github.com/cfgis/cfgms/pkg/registration"
 	testpkg "github.com/cfgis/cfgms/pkg/testing"
 )
 
@@ -195,9 +196,31 @@ func createTestEnv(t *testing.T, tempDir string, logger *testpkg.MockLogger, ctx
 		t.Logf("Note: Client certificate generation failed: %v (may already exist)", err)
 	}
 
-	// Create simple registration token for testing
-	// Format: cfgms_reg_{tenant_id}_{steward_id}_{random}
-	regToken := "cfgms_reg_test_tenant_test_steward_12345"
+	// Generate a cryptographically-random registration token.
+	// Hardcoded credentials are banned by CLAUDE.md and flagged by gosec G101.
+	tokenStoreIface := ctrl.GetRegistrationTokenStore()
+	if tokenStoreIface == nil {
+		t.Fatalf("registration token store is nil — controller not initialized")
+	}
+	tokenStore, ok := tokenStoreIface.(registration.Store)
+	if !ok {
+		t.Fatalf("failed to obtain registration token store: unexpected type %T", tokenStoreIface)
+	}
+	tokenReq := &registration.TokenCreateRequest{
+		TenantID:      "test-tenant",
+		ControllerURL: "grpc://localhost:0",
+		Group:         "test-group",
+		ExpiresIn:     "",
+		SingleUse:     false,
+	}
+	regTokenObj, regTokenErr := registration.CreateToken(tokenReq)
+	if regTokenErr != nil {
+		t.Fatalf("failed to create test registration token: %v", regTokenErr)
+	}
+	if err := tokenStore.SaveToken(ctx, regTokenObj); err != nil {
+		t.Fatalf("failed to save test registration token: %v", err)
+	}
+	regToken := regTokenObj.Token
 
 	return &TestEnv{
 		T:                 t,


### PR DESCRIPTION
## Summary

- Removes hardcoded credential literal `"cfgms_reg_test_tenant_test_steward_12345"` from `test/integration/testutil/test_helper.go` (gosec G101 finding)
- Replaces it with `registration.CreateToken()` + `tokenStore.SaveToken()`, generating a `crypto/rand`-seeded token at test setup — the same pattern as `test/e2e/framework.go:CreateRegistrationToken`
- Adds nil guard and comma-ok type assertion to surface initialization failures as `t.Fatalf` rather than a nil-pointer panic

## Specialist Review Results

| Reviewer | Result |
|---|---|
| QA Test Runner | ✅ PASS — 100+ packages, all cross-platform builds, 0 G101 findings |
| QA Code Reviewer | ✅ PASS — nil guard in place, no blocking issues in PR diff |
| Security Engineer | ✅ PASS — `crypto/rand`-based token, 0 hardcoded secrets, architecture clean |

## Test plan

- [ ] `gosec -include=G101 ./test/integration/testutil/...` → `Issues: 0`
- [ ] `make test-agent-complete` passes (all unit + integration + cross-platform builds)
- [ ] Token generated fresh per test run via `crypto/rand`; no static literal in source

Fixes #718

🤖 Generated with [Claude Code](https://claude.com/claude-code)