### PR TITLE
security: remove InsecureSkipVerify from all test helpers (Issue #717)

### DIFF
--- a/test/e2e/framework.go
+++ b/test/e2e/framework.go
@@ -556,13 +556,21 @@ func (f *E2ETestFramework) RegisterStewardWithController(stewardName, tenantID s
 		return nil, fmt.Errorf("failed to marshal registration request: %w", err)
 	}
 
-	// Create HTTP client with timeout
+	// Create HTTP client using the framework's cert manager for proper CA verification.
+	caCertPEM, err := f.certManager.GetCACertificate()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get CA cert for HTTP client: %w", err)
+	}
+	caCertPool := x509.NewCertPool()
+	if !caCertPool.AppendCertsFromPEM(caCertPEM) {
+		return nil, fmt.Errorf("failed to parse CA cert PEM")
+	}
 	httpClient := &http.Client{
 		Timeout: 10 * time.Second,
 		Transport: &http.Transport{
 			TLSClientConfig: &tls.Config{
-				MinVersion:         tls.VersionTLS12, // #nosec G402 -- TLS 1.2+ for test environment
-				InsecureSkipVerify: true,             // #nosec G402 -- Test environment with self-signed certs
+				MinVersion: tls.VersionTLS13,
+				RootCAs:    caCertPool,
 			},
 		},
 	}

--- a/test/integration/controller_test.go
+++ b/test/integration/controller_test.go
@@ -6,6 +6,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/tls"
+	"crypto/x509"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -58,11 +59,22 @@ func (s *ControllerTestSuite) waitForHTTPReady() {
 	s.T().Log("Warning: HTTP API may not be ready yet")
 }
 
-// tlsClient returns an HTTP client that skips TLS verification for self-signed test certs.
+// tlsClient returns an HTTP client configured with the test CA for TLS verification.
 func (s *ControllerTestSuite) tlsClient() *http.Client {
+	caCertPEM, err := s.env.CertManager.GetCACertificate()
+	if err != nil {
+		s.T().Fatalf("Failed to get CA certificate for test client: %v", err)
+	}
+	caCertPool := x509.NewCertPool()
+	if !caCertPool.AppendCertsFromPEM(caCertPEM) {
+		s.T().Fatal("Failed to parse CA certificate PEM")
+	}
 	return &http.Client{
 		Transport: &http.Transport{
-			TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, // #nosec G402 — test-only, self-signed cert
+			TLSClientConfig: &tls.Config{
+				MinVersion: tls.VersionTLS13,
+				RootCAs:    caCertPool,
+			},
 		},
 	}
 }

--- a/test/integration/ha/cluster_formation_test.go
+++ b/test/integration/ha/cluster_formation_test.go
@@ -8,7 +8,6 @@ package ha
 
 import (
 	"context"
-	"crypto/tls"
 	"encoding/json"
 	"fmt"
 	"net"
@@ -262,14 +261,23 @@ func getAPIKeyForURL(url string) string {
 	return "test-api-key-east" // default
 }
 
+// containerNameForURL maps a controller URL to its Docker container name.
+func containerNameForURL(url string) string {
+	switch {
+	case strings.Contains(url, "9080"):
+		return "controller-east"
+	case strings.Contains(url, "9081"):
+		return "controller-central"
+	case strings.Contains(url, "9082"):
+		return "controller-west"
+	default:
+		return "controller-east"
+	}
+}
+
 // getControllerState gets the basic state of a controller
 func getControllerState(url string) (ControllerInstance, error) {
-	client := &http.Client{
-		Timeout: 10 * time.Second,
-		Transport: &http.Transport{
-			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
-		},
-	}
+	client := buildTLSClient(containerNameForURL(url))
 
 	// Use TCP health check since HTTP endpoint might not be available yet
 	health := "unhealthy"
@@ -329,12 +337,7 @@ func getControllerState(url string) (ControllerInstance, error) {
 
 // getClusterView gets the cluster view from a controller
 func getClusterView(url string) (ClusterView, error) {
-	client := &http.Client{
-		Timeout: 10 * time.Second,
-		Transport: &http.Transport{
-			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
-		},
-	}
+	client := buildTLSClient(containerNameForURL(url))
 
 	req, err := http.NewRequest("GET", fmt.Sprintf("%s/api/v1/ha/cluster", url), nil)
 	if err != nil {

--- a/test/integration/ha/geographic_test.go
+++ b/test/integration/ha/geographic_test.go
@@ -8,7 +8,6 @@ package ha
 
 import (
 	"context"
-	"crypto/tls"
 	"encoding/json"
 	"fmt"
 	"math"
@@ -319,15 +318,7 @@ func TestGeographicLoadBalancing(t *testing.T) {
 			// For testing, we'll verify that all regions are accessible
 			accessibleRegions := make(map[string]bool)
 
-			// Create HTTP client with TLS skip verify for test certificates
-			client := &http.Client{
-				Timeout: 10 * time.Second,
-				Transport: &http.Transport{
-					TLSClientConfig: &tls.Config{
-						InsecureSkipVerify: true, //nolint:gosec // Test environment with self-signed certs
-					},
-				},
-			}
+			client := buildMultiControllerTLSClient("controller-east", "controller-central", "controller-west")
 
 			for i, url := range controllers {
 				resp, err := client.Get(fmt.Sprintf("%s/api/v1/health", url))
@@ -413,14 +404,7 @@ type ClusterNodesResponse struct {
 
 // getNodeInfo gets node information from a controller
 func getNodeInfo(url string) (*NodeInfoResponse, error) {
-	client := &http.Client{
-		Timeout: 10 * time.Second,
-		Transport: &http.Transport{
-			TLSClientConfig: &tls.Config{
-				InsecureSkipVerify: true, //nolint:gosec // Test environment with self-signed certs
-			},
-		},
-	}
+	client := buildTLSClient(containerNameForURL(url))
 
 	resp, err := client.Get(fmt.Sprintf("%s/api/v1/ha/node", url))
 	if err != nil {
@@ -442,14 +426,7 @@ func getNodeInfo(url string) (*NodeInfoResponse, error) {
 
 // getClusterNodes gets cluster nodes information from a controller
 func getClusterNodes(url string) ([]ha.NodeInfo, error) {
-	client := &http.Client{
-		Timeout: 10 * time.Second,
-		Transport: &http.Transport{
-			TLSClientConfig: &tls.Config{
-				InsecureSkipVerify: true, //nolint:gosec // Test environment with self-signed certs
-			},
-		},
-	}
+	client := buildTLSClient(containerNameForURL(url))
 
 	resp, err := client.Get(fmt.Sprintf("%s/api/v1/ha/cluster/nodes", url))
 	if err != nil {

--- a/test/integration/ha/setup_test.go
+++ b/test/integration/ha/setup_test.go
@@ -8,7 +8,10 @@ package ha
 
 import (
 	"context"
+	"crypto/tls"
+	"crypto/x509"
 	"fmt"
+	"net/http"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -16,6 +19,63 @@ import (
 	"testing"
 	"time"
 )
+
+// getDockerCACert extracts the CA certificate PEM from a Docker container.
+// The certificate is read from /app/certs/ca/ca.crt (default CFGMS cert path inside Docker).
+func getDockerCACert(containerName string) ([]byte, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "docker", "exec", containerName, "cat", "/app/certs/ca/ca.crt")
+	output, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("failed to read CA cert from container %s: %w", containerName, err)
+	}
+	return output, nil
+}
+
+// buildTLSClient creates an HTTP client with the CA cert from the given Docker container.
+// Falls back to the system root pool when Docker is unavailable.
+func buildTLSClient(containerName string) *http.Client {
+	tlsConfig := &tls.Config{MinVersion: tls.VersionTLS13}
+	if caCertPEM, err := getDockerCACert(containerName); err == nil {
+		caCertPool := x509.NewCertPool()
+		if caCertPool.AppendCertsFromPEM(caCertPEM) {
+			tlsConfig.RootCAs = caCertPool
+		}
+	}
+	return &http.Client{
+		Timeout: 10 * time.Second,
+		Transport: &http.Transport{
+			TLSClientConfig: tlsConfig,
+		},
+	}
+}
+
+// buildMultiControllerTLSClient creates an HTTP client with CA certs from all specified containers.
+// This allows a single client to talk to multiple controllers that have different CAs.
+// RootCAs is only set when at least one cert is successfully parsed; otherwise the system root pool
+// is used so the client never proceeds with an empty trust pool.
+func buildMultiControllerTLSClient(containerNames ...string) *http.Client {
+	caCertPool := x509.NewCertPool()
+	certsAdded := false
+	for _, name := range containerNames {
+		if caCertPEM, err := getDockerCACert(name); err == nil {
+			if caCertPool.AppendCertsFromPEM(caCertPEM) {
+				certsAdded = true
+			}
+		}
+	}
+	tlsConfig := &tls.Config{MinVersion: tls.VersionTLS13}
+	if certsAdded {
+		tlsConfig.RootCAs = caCertPool
+	}
+	return &http.Client{
+		Timeout: 10 * time.Second,
+		Transport: &http.Transport{
+			TLSClientConfig: tlsConfig,
+		},
+	}
+}
 
 var (
 	isDockerRunning bool

--- a/test/integration/transport/helpers_test.go
+++ b/test/integration/transport/helpers_test.go
@@ -25,22 +25,40 @@ type TestHelper struct {
 
 // NewTestHelper creates a new test helper.
 // Uses CFGMS_TEST_HTTP_ADDR environment variable if set, otherwise defaults to baseURL parameter.
+// Attempts to extract the CA cert from the controller-standalone Docker container for TLS
+// verification; falls back to the system root pool when Docker is unavailable.
 func NewTestHelper(baseURL string) *TestHelper {
 	if envURL := os.Getenv("CFGMS_TEST_HTTP_ADDR"); envURL != "" {
 		baseURL = envURL
 	}
 
-	transport := &http.Transport{
-		TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, //nolint:gosec // test helper
+	tlsConfig := &tls.Config{MinVersion: tls.VersionTLS13}
+	if caCertPEM, err := GetCACertFromContainer("controller-standalone"); err == nil {
+		caCertPool := x509.NewCertPool()
+		if caCertPool.AppendCertsFromPEM(caCertPEM) {
+			tlsConfig.RootCAs = caCertPool
+		}
 	}
 
 	return &TestHelper{
 		httpClient: &http.Client{
-			Timeout:   10 * time.Second,
-			Transport: transport,
+			Timeout: 10 * time.Second,
+			Transport: &http.Transport{
+				TLSClientConfig: tlsConfig,
+			},
 		},
 		baseURL: baseURL,
 	}
+}
+
+// Client returns the underlying HTTP client for direct use in tests.
+func (h *TestHelper) Client() *http.Client {
+	return h.httpClient
+}
+
+// BaseURL returns the base URL for direct use in tests.
+func (h *TestHelper) BaseURL() string {
+	return h.baseURL
 }
 
 // CreateToken returns a pre-created reusable test token.

--- a/test/integration/transport/module_execution_test.go
+++ b/test/integration/transport/module_execution_test.go
@@ -86,7 +86,7 @@ func (s *ModuleExecutionTestSuite) SetupSuite() {
 	regResp := s.testHelper.RegisterSteward(s.T(), token)
 	s.stewardID = regResp.StewardID
 
-	s.helper = NewModuleTestHelper(GetTestHTTPAddr("https://localhost:8080"))
+	s.helper = NewModuleTestHelper(GetTestHTTPAddr("https://localhost:8080"), []byte(regResp.CACert))
 }
 
 func (s *ModuleExecutionTestSuite) SetupTest() {

--- a/test/integration/transport/module_helpers.go
+++ b/test/integration/transport/module_helpers.go
@@ -6,6 +6,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/tls"
+	"crypto/x509"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -69,17 +70,43 @@ type ModuleTestHelper struct {
 	timeouts   E2ETimeouts
 }
 
+// GetCACertFromContainer extracts the CA certificate PEM from a Docker container.
+// The certificate is read from /app/certs/ca/ca.crt, which is the default path
+// for the CFGMS controller when running inside Docker.
+func GetCACertFromContainer(containerName string) ([]byte, error) {
+	if err := validateContainerName(containerName); err != nil {
+		return nil, err
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "docker", "exec", containerName, "cat", "/app/certs/ca/ca.crt")
+	output, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("failed to read CA cert from container %s: %w", containerName, err)
+	}
+	return output, nil
+}
+
 // NewModuleTestHelper creates a new module test helper with default timeouts.
-func NewModuleTestHelper(baseURL string) *ModuleTestHelper {
-	return NewModuleTestHelperWithTimeouts(baseURL, DefaultE2ETimeouts())
+// Pass a non-nil caCertPEM to use a specific CA for TLS verification; nil uses the system root pool.
+func NewModuleTestHelper(baseURL string, caCertPEM []byte) *ModuleTestHelper {
+	return NewModuleTestHelperWithTimeouts(baseURL, caCertPEM, DefaultE2ETimeouts())
 }
 
 // NewModuleTestHelperWithTimeouts creates a new module test helper with custom timeouts.
-func NewModuleTestHelperWithTimeouts(baseURL string, timeouts E2ETimeouts) *ModuleTestHelper {
+// Pass a non-nil caCertPEM to use a specific CA for TLS verification; nil uses the system root pool.
+func NewModuleTestHelperWithTimeouts(baseURL string, caCertPEM []byte, timeouts E2ETimeouts) *ModuleTestHelper {
+	tlsConfig := &tls.Config{MinVersion: tls.VersionTLS13}
+	if len(caCertPEM) > 0 {
+		caCertPool := x509.NewCertPool()
+		if caCertPool.AppendCertsFromPEM(caCertPEM) {
+			tlsConfig.RootCAs = caCertPool
+		}
+	}
 	httpClient := &http.Client{
 		Timeout: timeouts.HTTP,
 		Transport: &http.Transport{
-			TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, //nolint:gosec // test helper
+			TLSClientConfig: tlsConfig,
 		},
 	}
 

--- a/test/integration/transport/tls_security_test.go
+++ b/test/integration/transport/tls_security_test.go
@@ -11,7 +11,6 @@ import (
 	"os/exec"
 	"path/filepath"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
@@ -216,16 +215,11 @@ func (s *TLSSecurityTestSuite) TestClientCertificateFromRegistration() {
 func (s *TLSSecurityTestSuite) TestExpiredCertificateRejectedByRegistration() {
 	s.T().Log("Testing expired token rejection")
 
-	transport := &http.Transport{
-		TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, //nolint:gosec // test helper
-	}
-	client := &http.Client{Timeout: 10 * time.Second, Transport: transport}
-
 	req, err := http.NewRequest(http.MethodPost,
-		fmt.Sprintf("%s/api/v1/register", s.helper.baseURL), nil)
+		fmt.Sprintf("%s/api/v1/register", s.helper.BaseURL()), nil)
 	require.NoError(s.T(), err)
 
-	resp, err := client.Do(req)
+	resp, err := s.helper.Client().Do(req)
 	if err != nil {
 		s.T().Logf("Request failed (expected for expired/invalid credentials): %v", err)
 		return


### PR DESCRIPTION
## Summary

- Removes all `InsecureSkipVerify: true` occurrences from `test/` (9 files, 10 call sites) and replaces each with proper CA pool-based TLS verification using `MinVersion: tls.VersionTLS13`
- In-process tests (`e2e/framework.go`, `controller_test.go`) use `pkg/cert.Manager.GetCACertificate()` — the established project pattern
- Docker-based transport tests extract the CA cert via `docker exec <container> cat /app/certs/ca/ca.crt`; system root pool is the safe fallback when Docker is unavailable
- Commercial HA tests get shared helpers (`getDockerCACert`, `buildTLSClient`, `buildMultiControllerTLSClient`) added to `setup_test.go`

## Test plan

- [ ] `go vet ./test/...` passes — verified, zero errors
- [ ] `make test-agent-complete` passes — verified by QA test runner agent (all 90+ packages, cross-platform builds)
- [ ] `grep -r InsecureSkipVerify test/` returns empty — verified
- [ ] `make security-scan` passes — verified by security engineer agent (gosec, staticcheck, Trivy, Nancy all green)
- [ ] `make check-architecture` passes — no central provider violations

## Specialist Review Results

| Reviewer | Result | Notes |
|---|---|---|
| QA Test Runner | ✅ PASS | All unit/integration tests pass; cross-platform builds verified |
| QA Code Reviewer | ✅ PASS | One blocking issue found (empty trust pool in `buildMultiControllerTLSClient`) and fixed before merge |
| Security Engineer | ✅ PASS | Zero G402 findings in `test/`; all new `tls.Config` blocks use TLS 1.3 minimum |

Fixes #717

🤖 Generated with [Claude Code](https://claude.com/claude-code)