### PR TITLE
storage/flatfile: prevent path traversal in config_store user-controlled key fields (Issue #1002)

### DIFF
--- a/features/config/rollback/storage_store.go
+++ b/features/config/rollback/storage_store.go
@@ -49,7 +49,7 @@ func (s *StorageRollbackStore) SaveOperation(ctx context.Context, operation *Rol
 	entry := &cfgconfig.ConfigEntry{
 		Key: &cfgconfig.ConfigKey{
 			TenantID:  "system", // System-level rollback operations
-			Namespace: "rollback/operations",
+			Namespace: "rollback-operations",
 			Name:      operation.ID,
 		},
 		Data:   yamlData,
@@ -80,7 +80,7 @@ func (s *StorageRollbackStore) SaveOperation(ctx context.Context, operation *Rol
 func (s *StorageRollbackStore) GetOperation(ctx context.Context, id string) (*RollbackOperation, error) {
 	key := &cfgconfig.ConfigKey{
 		TenantID:  "system",
-		Namespace: "rollback/operations",
+		Namespace: "rollback-operations",
 		Name:      id,
 	}
 
@@ -111,7 +111,7 @@ func (s *StorageRollbackStore) ListOperations(ctx context.Context, filters Rollb
 	// Build config filter from rollback filters
 	configFilter := &cfgconfig.ConfigFilter{
 		TenantID:  "system",
-		Namespace: "rollback/operations",
+		Namespace: "rollback-operations",
 		SortBy:    "created_at",
 		Order:     "desc",
 	}
@@ -213,7 +213,7 @@ func (s *StorageRollbackStore) UpdateOperation(ctx context.Context, operation *R
 	entry := &cfgconfig.ConfigEntry{
 		Key: &cfgconfig.ConfigKey{
 			TenantID:  "system",
-			Namespace: "rollback/operations",
+			Namespace: "rollback-operations",
 			Name:      operation.ID,
 		},
 		Data:   yamlData,

--- a/pkg/storage/providers/flatfile/config_store.go
+++ b/pkg/storage/providers/flatfile/config_store.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	cfgconfig "github.com/cfgis/cfgms/pkg/storage/interfaces/config"
+	"github.com/cfgis/cfgms/pkg/storage/providers/internal/keysafe"
 )
 
 // FlatFileConfigStore implements cfgconfig.ConfigStore using the local filesystem.
@@ -74,29 +75,45 @@ func configFileName(key *cfgconfig.ConfigKey, format cfgconfig.ConfigFormat) str
 	return name + "." + configExt(format)
 }
 
-// configDir returns the directory for a tenant's configs in the given namespace.
-func (s *FlatFileConfigStore) configDir(tenantID, namespace string) (string, error) {
-	return safeJoin(s.root, tenantID, "configs", namespace)
+// validateConfigKey checks all user-controlled fields of a ConfigKey for path-safety.
+// Must be called at the top of every public method that accepts a *ConfigKey before
+// any filesystem operation is performed.
+func (s *FlatFileConfigStore) validateConfigKey(key *cfgconfig.ConfigKey) error {
+	if key == nil {
+		return fmt.Errorf("config key must not be nil")
+	}
+	if err := keysafe.ValidateTenantID(key.TenantID); err != nil {
+		return err
+	}
+	if err := keysafe.ValidateLeafField("namespace", key.Namespace); err != nil {
+		return err
+	}
+	if err := keysafe.ValidateLeafField("name", key.Name); err != nil {
+		return err
+	}
+	if key.Scope != "" {
+		if err := keysafe.ValidateLeafField("scope", key.Scope); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // configPath returns the filesystem path for a config entry with the given format.
+// The entire path including the leaf filename is validated by safeJoin.
 func (s *FlatFileConfigStore) configPath(key *cfgconfig.ConfigKey, format cfgconfig.ConfigFormat) (string, error) {
-	dir, err := s.configDir(key.TenantID, key.Namespace)
-	if err != nil {
-		return "", err
-	}
-	return filepath.Join(dir, configFileName(key, format)), nil
+	return safeJoin(s.root, key.TenantID, "configs", key.Namespace, configFileName(key, format))
 }
 
 // findConfigFile locates the file for a config key, trying .yaml then .json.
-// Returns ErrConfigNotFound if neither exists.
+// Returns ErrConfigNotFound if neither exists. Path validation errors are
+// returned directly so rejections are not hidden as missing-config errors.
 func (s *FlatFileConfigStore) findConfigFile(key *cfgconfig.ConfigKey) (string, error) {
 	for _, format := range []cfgconfig.ConfigFormat{cfgconfig.ConfigFormatYAML, cfgconfig.ConfigFormatJSON} {
-		dir, err := s.configDir(key.TenantID, key.Namespace)
+		path, err := safeJoin(s.root, key.TenantID, "configs", key.Namespace, configFileName(key, format))
 		if err != nil {
-			continue
+			return "", fmt.Errorf("invalid path components: %w", err)
 		}
-		path := filepath.Join(dir, configFileName(key, format))
 		if _, err := os.Stat(path); err == nil {
 			return path, nil
 		}
@@ -156,7 +173,7 @@ func (s *FlatFileConfigStore) readConfigFile(key *cfgconfig.ConfigKey) (*cfgconf
 		return nil, cfgconfig.ErrConfigNotFound
 	}
 
-	// #nosec G304 — path is validated by safeJoin inside findConfigFile
+	// #nosec G304 — path is validated by validateConfigKey at every public entry point and safeJoin inside findConfigFile
 	raw, err := os.ReadFile(path)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -183,6 +200,9 @@ func (s *FlatFileConfigStore) StoreConfig(ctx context.Context, config *cfgconfig
 	}
 	if config.Key.Name == "" {
 		return cfgconfig.ErrNameRequired
+	}
+	if err := s.validateConfigKey(config.Key); err != nil {
+		return fmt.Errorf("invalid config key: %w", err)
 	}
 
 	s.mutex.Lock()
@@ -237,6 +257,9 @@ func (s *FlatFileConfigStore) StoreConfig(ctx context.Context, config *cfgconfig
 
 // GetConfig retrieves a configuration entry by key.
 func (s *FlatFileConfigStore) GetConfig(ctx context.Context, key *cfgconfig.ConfigKey) (*cfgconfig.ConfigEntry, error) {
+	if err := s.validateConfigKey(key); err != nil {
+		return nil, fmt.Errorf("invalid config key: %w", err)
+	}
 	s.mutex.RLock()
 	defer s.mutex.RUnlock()
 	return s.readConfigFile(key)
@@ -244,6 +267,9 @@ func (s *FlatFileConfigStore) GetConfig(ctx context.Context, key *cfgconfig.Conf
 
 // DeleteConfig removes a configuration entry.
 func (s *FlatFileConfigStore) DeleteConfig(ctx context.Context, key *cfgconfig.ConfigKey) error {
+	if err := s.validateConfigKey(key); err != nil {
+		return fmt.Errorf("invalid config key: %w", err)
+	}
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
 
@@ -263,6 +289,23 @@ func (s *FlatFileConfigStore) DeleteConfig(ctx context.Context, key *cfgconfig.C
 
 // ListConfigs returns all configuration entries matching the filter.
 func (s *FlatFileConfigStore) ListConfigs(ctx context.Context, filter *cfgconfig.ConfigFilter) ([]*cfgconfig.ConfigEntry, error) {
+	if filter != nil {
+		if filter.TenantID != "" {
+			if err := keysafe.ValidateTenantID(filter.TenantID); err != nil {
+				return nil, fmt.Errorf("invalid filter tenant ID: %w", err)
+			}
+		}
+		if filter.Namespace != "" {
+			if err := keysafe.ValidateLeafField("namespace", filter.Namespace); err != nil {
+				return nil, fmt.Errorf("invalid filter namespace: %w", err)
+			}
+		}
+		for _, name := range filter.Names {
+			if err := keysafe.ValidateLeafField("name", name); err != nil {
+				return nil, fmt.Errorf("invalid filter name: %w", err)
+			}
+		}
+	}
 	s.mutex.RLock()
 	defer s.mutex.RUnlock()
 
@@ -434,6 +477,9 @@ func paginateConfigs(results []*cfgconfig.ConfigEntry, filter *cfgconfig.ConfigF
 // The flat-file provider does not retain historical versions; only the
 // current state is stored. Use git-sync if you need PR-based change history.
 func (s *FlatFileConfigStore) GetConfigHistory(ctx context.Context, key *cfgconfig.ConfigKey, limit int) ([]*cfgconfig.ConfigEntry, error) {
+	if err := s.validateConfigKey(key); err != nil {
+		return nil, fmt.Errorf("invalid config key: %w", err)
+	}
 	s.mutex.RLock()
 	defer s.mutex.RUnlock()
 
@@ -447,6 +493,9 @@ func (s *FlatFileConfigStore) GetConfigHistory(ctx context.Context, key *cfgconf
 // GetConfigVersion returns the current entry if its version matches; otherwise ErrConfigNotFound.
 // The flat-file provider does not retain historical versions.
 func (s *FlatFileConfigStore) GetConfigVersion(ctx context.Context, key *cfgconfig.ConfigKey, version int64) (*cfgconfig.ConfigEntry, error) {
+	if err := s.validateConfigKey(key); err != nil {
+		return nil, fmt.Errorf("invalid config key: %w", err)
+	}
 	s.mutex.RLock()
 	defer s.mutex.RUnlock()
 
@@ -491,6 +540,9 @@ func (s *FlatFileConfigStore) DeleteConfigBatch(ctx context.Context, keys []*cfg
 //  2. root/msp-a/configs/<namespace>/<name>
 //  3. root/configs/<namespace>/<name>
 func (s *FlatFileConfigStore) ResolveConfigWithInheritance(ctx context.Context, key *cfgconfig.ConfigKey) (*cfgconfig.ConfigEntry, error) {
+	if err := s.validateConfigKey(key); err != nil {
+		return nil, fmt.Errorf("invalid config key: %w", err)
+	}
 	s.mutex.RLock()
 	defer s.mutex.RUnlock()
 
@@ -503,6 +555,10 @@ func (s *FlatFileConfigStore) ResolveConfigWithInheritance(ctx context.Context, 
 			Namespace: key.Namespace,
 			Name:      key.Name,
 			Scope:     key.Scope,
+		}
+		// Defense in depth: re-validate each synthesized key before filesystem access.
+		if err := s.validateConfigKey(searchKey); err != nil {
+			return nil, fmt.Errorf("invalid synthesized key at tenant %q: %w", tenantID, err)
 		}
 		entry, err := s.readConfigFile(searchKey)
 		if err == nil {
@@ -522,6 +578,9 @@ func (s *FlatFileConfigStore) ValidateConfig(ctx context.Context, config *cfgcon
 	}
 	if config.Key.Name == "" {
 		return cfgconfig.ErrNameRequired
+	}
+	if err := s.validateConfigKey(config.Key); err != nil {
+		return fmt.Errorf("invalid config key: %w", err)
 	}
 	if config.Format != "" &&
 		config.Format != cfgconfig.ConfigFormatYAML &&

--- a/pkg/storage/providers/flatfile/config_store_test.go
+++ b/pkg/storage/providers/flatfile/config_store_test.go
@@ -520,3 +520,193 @@ func TestCreatedAtPreservedOnUpdate(t *testing.T) {
 	// Version must have incremented
 	assert.Equal(t, int64(2), got2.Version)
 }
+
+// TestValidateConfigKey_RejectsMaliciousLeafFields verifies that malicious inputs in
+// Name, Scope, and Namespace are rejected as path traversal attempts.
+func TestValidateConfigKey_RejectsMaliciousLeafFields(t *testing.T) {
+	malicious := []string{
+		"../etc/passwd",
+		"foo/../bar",
+		"with\x00null",
+		"/abs",
+		`..\\windows`,
+		"C:foo",
+		".",
+		"foo.",
+		"foo ",
+		" foo",
+	}
+
+	store := newTestConfigStore(t)
+	ctx := context.Background()
+
+	for _, bad := range malicious {
+		bad := bad
+		t.Run("name="+bad, func(t *testing.T) {
+			err := store.StoreConfig(ctx, &cfgconfig.ConfigEntry{
+				Key: &cfgconfig.ConfigKey{
+					TenantID:  "tenant1",
+					Namespace: "ns",
+					Name:      bad,
+				},
+				Data:   []byte(`x`),
+				Format: cfgconfig.ConfigFormatJSON,
+			})
+			assert.Error(t, err, "expected rejection of malicious Name %q", bad)
+		})
+
+		t.Run("namespace="+bad, func(t *testing.T) {
+			err := store.StoreConfig(ctx, &cfgconfig.ConfigEntry{
+				Key: &cfgconfig.ConfigKey{
+					TenantID:  "tenant1",
+					Namespace: bad,
+					Name:      "cfg",
+				},
+				Data:   []byte(`x`),
+				Format: cfgconfig.ConfigFormatJSON,
+			})
+			assert.Error(t, err, "expected rejection of malicious Namespace %q", bad)
+		})
+
+		t.Run("scope="+bad, func(t *testing.T) {
+			err := store.StoreConfig(ctx, &cfgconfig.ConfigEntry{
+				Key: &cfgconfig.ConfigKey{
+					TenantID:  "tenant1",
+					Namespace: "ns",
+					Name:      "cfg",
+					Scope:     bad,
+				},
+				Data:   []byte(`x`),
+				Format: cfgconfig.ConfigFormatJSON,
+			})
+			assert.Error(t, err, "expected rejection of malicious Scope %q", bad)
+		})
+	}
+}
+
+// TestValidateConfigKey_AcceptsHierarchicalTenantID verifies that the TenantID
+// validator allows internal "/" but rejects structural anomalies and ".." segments.
+func TestValidateConfigKey_AcceptsHierarchicalTenantID(t *testing.T) {
+	store := newTestConfigStore(t)
+	ctx := context.Background()
+
+	t.Run("accepts root/msp-a/client-1", func(t *testing.T) {
+		// Storing creates the key, which must be accepted.
+		entry := testEntry("root/msp-a/client-1", "ns", "cfg", []byte(`x`), cfgconfig.ConfigFormatJSON)
+		assert.NoError(t, store.StoreConfig(ctx, entry))
+	})
+
+	t.Run("rejects root//msp-a", func(t *testing.T) {
+		entry := testEntry("root//msp-a", "ns", "cfg", []byte(`x`), cfgconfig.ConfigFormatJSON)
+		assert.Error(t, store.StoreConfig(ctx, entry))
+	})
+
+	t.Run("rejects /root (leading slash)", func(t *testing.T) {
+		entry := testEntry("/root", "ns", "cfg", []byte(`x`), cfgconfig.ConfigFormatJSON)
+		assert.Error(t, store.StoreConfig(ctx, entry))
+	})
+
+	t.Run("rejects root/.. (dotdot segment)", func(t *testing.T) {
+		entry := testEntry("root/..", "ns", "cfg", []byte(`x`), cfgconfig.ConfigFormatJSON)
+		assert.Error(t, store.StoreConfig(ctx, entry))
+	})
+}
+
+// TestValidateConfigKey_AcceptsEmptyScope is a regression guard ensuring that
+// unscoped configs (Scope == "") are not rejected by the validator.
+func TestValidateConfigKey_AcceptsEmptyScope(t *testing.T) {
+	store := newTestConfigStore(t)
+	ctx := context.Background()
+
+	entry := &cfgconfig.ConfigEntry{
+		Key: &cfgconfig.ConfigKey{
+			TenantID:  "t1",
+			Namespace: "ns",
+			Name:      "cfg",
+			Scope:     "", // explicitly empty
+		},
+		Data:   []byte(`x`),
+		Format: cfgconfig.ConfigFormatJSON,
+	}
+	assert.NoError(t, store.StoreConfig(ctx, entry))
+}
+
+// TestFlatFileConfigStore_RejectsTraversalAtPublicMethods verifies that every
+// public method that accepts a ConfigKey rejects malicious Name values and does
+// not perform any filesystem operations outside the configured root.
+func TestFlatFileConfigStore_RejectsTraversalAtPublicMethods(t *testing.T) {
+	store := newTestConfigStore(t)
+	ctx := context.Background()
+
+	maliciousKey := &cfgconfig.ConfigKey{
+		TenantID:  "tenant1",
+		Namespace: "ns",
+		Name:      "../etc/passwd",
+	}
+
+	t.Run("StoreConfig", func(t *testing.T) {
+		err := store.StoreConfig(ctx, &cfgconfig.ConfigEntry{
+			Key:    maliciousKey,
+			Data:   []byte(`bad`),
+			Format: cfgconfig.ConfigFormatJSON,
+		})
+		assert.Error(t, err)
+		assert.NotEqual(t, cfgconfig.ErrConfigNotFound, err)
+	})
+
+	t.Run("GetConfig", func(t *testing.T) {
+		_, err := store.GetConfig(ctx, maliciousKey)
+		assert.Error(t, err)
+		assert.NotEqual(t, cfgconfig.ErrConfigNotFound, err)
+	})
+
+	t.Run("DeleteConfig", func(t *testing.T) {
+		err := store.DeleteConfig(ctx, maliciousKey)
+		assert.Error(t, err)
+		assert.NotEqual(t, cfgconfig.ErrConfigNotFound, err)
+	})
+
+	t.Run("ListConfigs", func(t *testing.T) {
+		_, err := store.ListConfigs(ctx, &cfgconfig.ConfigFilter{
+			TenantID: "tenant1",
+			Names:    []string{"../etc/passwd"},
+		})
+		assert.Error(t, err)
+	})
+
+	t.Run("GetConfigHistory", func(t *testing.T) {
+		_, err := store.GetConfigHistory(ctx, maliciousKey, 10)
+		assert.Error(t, err)
+		assert.NotEqual(t, cfgconfig.ErrConfigNotFound, err)
+	})
+
+	t.Run("GetConfigVersion", func(t *testing.T) {
+		_, err := store.GetConfigVersion(ctx, maliciousKey, 1)
+		assert.Error(t, err)
+		assert.NotEqual(t, cfgconfig.ErrConfigNotFound, err)
+	})
+
+	t.Run("ResolveConfigWithInheritance", func(t *testing.T) {
+		_, err := store.ResolveConfigWithInheritance(ctx, maliciousKey)
+		assert.Error(t, err)
+		assert.NotEqual(t, cfgconfig.ErrConfigNotFound, err)
+	})
+}
+
+// TestFindConfigFile_ReturnsValidationErrorNotNotFound verifies that path traversal
+// attempts do not silently resolve to ErrConfigNotFound but return a validation error.
+func TestFindConfigFile_ReturnsValidationErrorNotNotFound(t *testing.T) {
+	store := newTestConfigStore(t)
+	ctx := context.Background()
+
+	// GetConfig exercises findConfigFile internally; with a malicious key the
+	// result must be a validation error, not ErrConfigNotFound.
+	_, err := store.GetConfig(ctx, &cfgconfig.ConfigKey{
+		TenantID:  "tenant1",
+		Namespace: "ns",
+		Name:      "../etc/passwd",
+	})
+	require.Error(t, err)
+	assert.NotEqual(t, cfgconfig.ErrConfigNotFound, err,
+		"path traversal must return a validation error, not ErrConfigNotFound")
+}

--- a/pkg/storage/providers/internal/keysafe/keysafe.go
+++ b/pkg/storage/providers/internal/keysafe/keysafe.go
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+// Package keysafe provides path-safety validators for storage key fields.
+// It uses only the standard library to avoid import cycles with other CFGMS packages.
+package keysafe
+
+import (
+	"fmt"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"unicode"
+)
+
+// windowsDriveRE matches Windows drive letter prefixes like "C:" or "c:".
+var windowsDriveRE = regexp.MustCompile(`^[A-Za-z]:`)
+
+// ValidateLeafField validates a single path component that must not contain
+// any directory separators or traversal sequences.
+//
+// Rejects: "/", "\", "..", "." (single dot), null bytes, leading/trailing
+// whitespace, leading dot, trailing dot or space, absolute paths, and
+// Windows drive letters. Empty string is allowed — callers enforce non-emptiness
+// when required.
+func ValidateLeafField(fieldName, value string) error {
+	if value == "" {
+		return nil
+	}
+	if strings.ContainsRune(value, '\x00') {
+		return fmt.Errorf("invalid %s %q: must not contain null bytes", fieldName, sanitize(value))
+	}
+	if value != strings.TrimFunc(value, unicode.IsSpace) {
+		return fmt.Errorf("invalid %s %q: must not have leading or trailing whitespace", fieldName, sanitize(value))
+	}
+	if strings.HasSuffix(value, ".") {
+		return fmt.Errorf("invalid %s %q: must not end with '.'", fieldName, sanitize(value))
+	}
+	if strings.HasPrefix(value, ".") {
+		return fmt.Errorf("invalid %s %q: must not start with '.'", fieldName, sanitize(value))
+	}
+	if strings.ContainsAny(value, `/\`) {
+		return fmt.Errorf("invalid %s %q: must not contain path separators", fieldName, sanitize(value))
+	}
+	if filepath.IsAbs(value) {
+		return fmt.Errorf("invalid %s %q: must not be an absolute path", fieldName, sanitize(value))
+	}
+	if windowsDriveRE.MatchString(value) {
+		return fmt.Errorf("invalid %s %q: must not contain a Windows drive letter", fieldName, sanitize(value))
+	}
+	return nil
+}
+
+// ValidateTenantID validates a hierarchical tenant ID where internal "/" separators
+// are legitimate (e.g. "root/msp-a/client-1") but traversal sequences and
+// structural anomalies are not.
+//
+// Rejects: empty string, null bytes, backslash, leading/trailing "/", "//" runs,
+// and any segment equal to ".." or ".".
+func ValidateTenantID(value string) error {
+	if value == "" {
+		return fmt.Errorf("tenant ID must not be empty")
+	}
+	if strings.ContainsRune(value, '\x00') {
+		return fmt.Errorf("invalid tenant ID %q: must not contain null bytes", sanitize(value))
+	}
+	if strings.ContainsRune(value, '\\') {
+		return fmt.Errorf("invalid tenant ID %q: must not contain backslash", sanitize(value))
+	}
+	if strings.HasPrefix(value, "/") {
+		return fmt.Errorf("invalid tenant ID %q: must not start with '/'", sanitize(value))
+	}
+	if strings.HasSuffix(value, "/") {
+		return fmt.Errorf("invalid tenant ID %q: must not end with '/'", sanitize(value))
+	}
+	if strings.Contains(value, "//") {
+		return fmt.Errorf("invalid tenant ID %q: must not contain '//'", sanitize(value))
+	}
+	for _, seg := range strings.Split(value, "/") {
+		if seg == ".." {
+			return fmt.Errorf("invalid tenant ID %q: must not contain '..' segments", sanitize(value))
+		}
+		if seg == "." {
+			return fmt.Errorf("invalid tenant ID %q: must not contain '.' segments", sanitize(value))
+		}
+	}
+	return nil
+}
+
+// sanitize strips control characters and limits length to prevent log injection
+// when the value is included in error messages.
+func sanitize(value string) string {
+	const maxLen = 100
+	var sb strings.Builder
+	count := 0
+	for _, r := range value {
+		if count >= maxLen {
+			sb.WriteString("...")
+			break
+		}
+		if r < 0x20 || r == 0x7f {
+			sb.WriteRune('?')
+		} else {
+			sb.WriteRune(r)
+		}
+		count++
+	}
+	return sb.String()
+}

--- a/pkg/storage/providers/internal/keysafe/keysafe_test.go
+++ b/pkg/storage/providers/internal/keysafe/keysafe_test.go
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+package keysafe_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cfgis/cfgms/pkg/storage/providers/internal/keysafe"
+)
+
+func TestValidateLeafField_RejectsTraversalInputs(t *testing.T) {
+	cases := []struct {
+		name  string
+		value string
+	}{
+		{"path traversal relative", "../etc/passwd"},
+		{"path traversal embedded", "foo/../bar"},
+		{"null byte", "with\x00null"},
+		{"absolute path", "/abs"},
+		{"backslash traversal", `..\\windows`},
+		{"windows drive letter", "C:foo"},
+		{"single dot", "."},
+		{"trailing dot", "foo."},
+		{"trailing space", "foo "},
+		{"leading space", " foo"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := keysafe.ValidateLeafField("test_field", tc.value)
+			assert.Error(t, err, "expected rejection of %q", tc.value)
+		})
+	}
+}
+
+func TestValidateLeafField_AcceptsValidInputs(t *testing.T) {
+	valid := []string{
+		"",
+		"config",
+		"my-config",
+		"my_config",
+		"config123",
+		"UPPER",
+		"mixedCase",
+	}
+	for _, v := range valid {
+		t.Run(v, func(t *testing.T) {
+			err := keysafe.ValidateLeafField("test_field", v)
+			assert.NoError(t, err, "expected acceptance of %q", v)
+		})
+	}
+}
+
+func TestValidateLeafField_EmptyAllowed(t *testing.T) {
+	require.NoError(t, keysafe.ValidateLeafField("scope", ""))
+}
+
+func TestValidateTenantID_RejectsInvalidInputs(t *testing.T) {
+	cases := []struct {
+		name  string
+		value string
+	}{
+		{"empty", ""},
+		{"double slash", "root//msp-a"},
+		{"leading slash", "/root"},
+		{"trailing slash", "root/"},
+		{"dotdot segment", "root/.."},
+		{"dot segment", "root/."},
+		{"backslash", `root\msp-a`},
+		{"null byte", "root/\x00tenant"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := keysafe.ValidateTenantID(tc.value)
+			assert.Error(t, err, "expected rejection of %q", tc.value)
+		})
+	}
+}
+
+func TestValidateTenantID_AcceptsHierarchicalID(t *testing.T) {
+	valid := []string{
+		"root",
+		"root/msp-a",
+		"root/msp-a/client-1",
+		"root/msp-a/client-1/sub-tenant",
+		"single-tenant",
+	}
+	for _, v := range valid {
+		t.Run(v, func(t *testing.T) {
+			err := keysafe.ValidateTenantID(v)
+			assert.NoError(t, err, "expected acceptance of %q", v)
+		})
+	}
+}
+
+func TestValidateTenantID_ErrorContainsFieldInfo(t *testing.T) {
+	err := keysafe.ValidateTenantID("root/../escaped")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "tenant ID")
+}
+
+func TestValidateLeafField_ErrorContainsFieldName(t *testing.T) {
+	err := keysafe.ValidateLeafField("namespace", "../etc")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "namespace")
+}
+
+func TestValidateLeafField_SanitizesControlCharsInError(t *testing.T) {
+	err := keysafe.ValidateLeafField("name", "abc\x00def")
+	require.Error(t, err)
+	// The raw null byte must not appear verbatim in the error string.
+	assert.NotContains(t, err.Error(), "\x00")
+}


### PR DESCRIPTION
## Summary

- Closes 6 high-severity CodeQL `go/path-injection` alerts (#515, #516, #517, #519, #520, #521) on `pkg/storage/providers/flatfile/config_store.go`
- New `pkg/storage/providers/internal/keysafe` package with `ValidateLeafField` and `ValidateTenantID` helpers (stdlib-only, no import cycles)
- All user-controlled `ConfigKey` fields validated at every public entry point before any filesystem operation; `configPath` and `findConfigFile` rewritten to pull the leaf filename inside the `safeJoin` boundary
- Fixed `features/config/rollback/storage_store.go` namespace `"rollback/operations"` → `"rollback-operations"` (slash was a pre-existing violation now caught by the new validator)

## Specialist Review Results

**QA Test Runner:** PASS — all validation gates passed after fixing `features/config/rollback/storage_store.go` (slash-in-namespace that the new validator correctly rejected). `make test-agent-complete` passed.

**QA Code Reviewer:** PASS — no blocking issues. 2 warnings (non-blocking): missing subtests for `ListConfigs` with malicious TenantID/Namespace in filter, and missing `ValidateConfig`/`StoreConfigBatch`/`DeleteConfigBatch` subtests in the traversal-rejection test. Production code paths are protected; tests cover the primary attack surface.

**Security Engineer:** PASS — all automated scans passed (`security-precommit`, `check-architecture`, `security-scan`). No blocking issues. The `#nosec G304` annotations are correctly justified. Defense in depth is in place via re-validation inside `ResolveConfigWithInheritance`. Error message injection is prevented via the `sanitize` helper.

## Test plan

- [ ] `make test-agent-complete` passes (verified locally)
- [ ] New `TestValidateConfigKey_RejectsMaliciousLeafFields` — 10 malicious inputs × 3 field positions all return errors
- [ ] New `TestValidateConfigKey_AcceptsHierarchicalTenantID` — `root/msp-a/client-1` accepted; `root//msp-a`, `/root`, `root/..` rejected
- [ ] New `TestValidateConfigKey_AcceptsEmptyScope` — empty scope not rejected (regression guard)
- [ ] New `TestFlatFileConfigStore_RejectsTraversalAtPublicMethods` — 7 public methods all reject malicious Name
- [ ] New `TestFindConfigFile_ReturnsValidationErrorNotNotFound` — traversal returns validation error, not `ErrConfigNotFound`
- [ ] Existing `TestPathTraversalPrevention` (line 269) unchanged and still passes
- [ ] All keysafe unit tests pass with `-race`

🤖 Generated with [Claude Code](https://claude.com/claude-code)