### PR TITLE
controller: gate test token seeding behind CFGMS_SEED_TEST_TOKENS env var (Issue #700)

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -457,6 +457,8 @@ services:
       CFGMS_TIMESCALE_PASSWORD: "${TIMESCALEDB_PASSWORD}"
       # Disable HA to run in standalone mode
       CFGMS_HA_ENABLED: "false"
+      # Seed well-known test tokens for integration test suites (Issue #700)
+      CFGMS_SEED_TEST_TOKENS: "1"
       # Enable test endpoints for integration testing (auth bypass for /api/v1/test/*)
       CFGMS_ENABLE_TEST_ENDPOINTS: "true"
       CFGMS_CERT_PATH: "/app/certs"

--- a/features/controller/server/server.go
+++ b/features/controller/server/server.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
+	"os"
 	"path/filepath"
 	"sync"
 	"time"
@@ -281,69 +282,71 @@ func New(cfg *config.Config, logger logging.Logger) (*Server, error) {
 		}
 		regStore = pkgRegistration.NewStorageAdapter(regTokenStore)
 
-		// For Docker testing: Create pre-configured test tokens
-		// These tokens are used by integration tests in test/integration/
-		now := time.Now()
-		expiredTime := now.Add(-1 * time.Hour)
-		testTokens := []*pkgRegistration.Token{
-			{
-				Token:         "dockertest_standalone",
-				TenantID:      "test-tenant",
-				ControllerURL: "tcp://controller-standalone:1883",
-				Group:         "test-group",
-				CreatedAt:     now,
-				ExpiresAt:     nil,   // Never expires for testing
-				SingleUse:     false, // Can be reused for testing
-				Revoked:       false,
-			},
-			{
-				Token:         "integration_reusable",
-				TenantID:      "test-tenant-integration",
-				ControllerURL: "tcp://localhost:1886",
-				Group:         "production",
-				CreatedAt:     now,
-				ExpiresAt:     nil,   // Never expires for testing
-				SingleUse:     false, // Can be reused for integration tests
-				Revoked:       false,
-			},
-			{
-				Token:         "integration_expired",
-				TenantID:      "test-tenant-integration",
-				ControllerURL: "tcp://localhost:1886",
-				Group:         "production",
-				CreatedAt:     now.Add(-2 * time.Hour),
-				ExpiresAt:     &expiredTime, // Expired 1 hour ago
-				SingleUse:     true,
-				Revoked:       false,
-			},
-			{
-				Token:         "integration_revoked",
-				TenantID:      "test-tenant-integration",
-				ControllerURL: "tcp://localhost:1886",
-				Group:         "production",
-				CreatedAt:     now,
-				ExpiresAt:     nil,
-				SingleUse:     true,
-				Revoked:       true, // Revoked token
-				RevokedAt:     &now,
-			},
-			{
-				Token:         "integration_singleuse",
-				TenantID:      "test-tenant-integration",
-				ControllerURL: "tcp://localhost:1886",
-				Group:         "production",
-				CreatedAt:     now,
-				ExpiresAt:     nil,
-				SingleUse:     true, // Single-use token
-				Revoked:       false,
-			},
-		}
+		// Seed test tokens only when explicitly requested via environment variable.
+		// Never runs in production — must be set deliberately in test environments.
+		if os.Getenv("CFGMS_SEED_TEST_TOKENS") == "1" {
+			now := time.Now()
+			expiredTime := now.Add(-1 * time.Hour)
+			testTokens := []*pkgRegistration.Token{
+				{
+					Token:         "dockertest_standalone", //nolint:gosec // test-only seeding, env-gated
+					TenantID:      "test-tenant",
+					ControllerURL: "tcp://controller-standalone:1883",
+					Group:         "test-group",
+					CreatedAt:     now,
+					ExpiresAt:     nil,
+					SingleUse:     false,
+					Revoked:       false,
+				},
+				{
+					Token:         "integration_reusable", //nolint:gosec // test-only seeding, env-gated
+					TenantID:      "test-tenant-integration",
+					ControllerURL: "tcp://localhost:1886",
+					Group:         "production",
+					CreatedAt:     now,
+					ExpiresAt:     nil,
+					SingleUse:     false,
+					Revoked:       false,
+				},
+				{
+					Token:         "integration_expired", //nolint:gosec // test-only seeding, env-gated
+					TenantID:      "test-tenant-integration",
+					ControllerURL: "tcp://localhost:1886",
+					Group:         "production",
+					CreatedAt:     now.Add(-2 * time.Hour),
+					ExpiresAt:     &expiredTime,
+					SingleUse:     true,
+					Revoked:       false,
+				},
+				{
+					Token:         "integration_revoked", //nolint:gosec // test-only seeding, env-gated
+					TenantID:      "test-tenant-integration",
+					ControllerURL: "tcp://localhost:1886",
+					Group:         "production",
+					CreatedAt:     now,
+					ExpiresAt:     nil,
+					SingleUse:     true,
+					Revoked:       true,
+					RevokedAt:     &now,
+				},
+				{
+					Token:         "integration_singleuse", //nolint:gosec // test-only seeding, env-gated
+					TenantID:      "test-tenant-integration",
+					ControllerURL: "tcp://localhost:1886",
+					Group:         "production",
+					CreatedAt:     now,
+					ExpiresAt:     nil,
+					SingleUse:     true,
+					Revoked:       false,
+				},
+			}
 
-		for _, testToken := range testTokens {
-			if err := regStore.SaveToken(context.Background(), testToken); err != nil {
-				logger.Warn("Failed to create test token for Docker testing", "error", err, "token", testToken.Token)
-			} else {
-				logger.Info("Created test registration token for Docker testing", "token", testToken.Token, "tenant", testToken.TenantID)
+			for _, testToken := range testTokens {
+				if err := regStore.SaveToken(context.Background(), testToken); err != nil {
+					logger.Warn("Failed to seed test token", "error", err, "token", testToken.Token)
+				} else {
+					logger.Info("Seeded test registration token", "token", testToken.Token, "tenant", testToken.TenantID)
+				}
 			}
 		}
 	}

--- a/features/controller/server/server_test.go
+++ b/features/controller/server/server_test.go
@@ -1,0 +1,175 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+package server
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cfgis/cfgms/features/controller/config"
+	"github.com/cfgis/cfgms/pkg/logging"
+
+	_ "github.com/cfgis/cfgms/pkg/storage/providers/flatfile"
+	_ "github.com/cfgis/cfgms/pkg/storage/providers/sqlite"
+)
+
+// hardcodedTestTokens lists the token strings that must never appear in a
+// production-mode controller store.  This list is the source of truth for
+// the no-seeding assertion; update it if token names change.
+var hardcodedTestTokens = []string{
+	"dockertest_standalone",
+	"integration_reusable",
+	"integration_expired",
+	"integration_revoked",
+	"integration_singleuse",
+}
+
+// TestServer_ProductionStartup_NoHardcodedTokens verifies that a controller
+// started without CFGMS_SEED_TEST_TOKENS does not create any well-known test
+// tokens in the registration store.
+func TestServer_ProductionStartup_NoHardcodedTokens(t *testing.T) {
+	// Ensure the guard env var is absent — t.Setenv restores on cleanup.
+	t.Setenv("CFGMS_SEED_TEST_TOKENS", "")
+
+	tempDir := t.TempDir()
+	cfg := &config.Config{
+		ListenAddr: "127.0.0.1:0",
+		Certificate: &config.CertificateConfig{
+			EnableCertManagement: false,
+		},
+		Storage: &config.StorageConfig{
+			Provider:     "flatfile",
+			FlatfileRoot: tempDir + "/flatfile",
+			SQLitePath:   tempDir + "/cfgms.db",
+		},
+	}
+
+	srv, err := New(cfg, logging.NewNoopLogger())
+	require.NoError(t, err)
+	require.NotNil(t, srv)
+	t.Cleanup(func() { _ = srv.Stop() })
+
+	store := srv.GetRegistrationTokenStore()
+	require.NotNil(t, store, "registration token store must be initialized")
+
+	ctx := context.Background()
+	for _, tokenStr := range hardcodedTestTokens {
+		tok, err := store.GetToken(ctx, tokenStr)
+		assert.Error(t, err, "token %q must not exist in production startup", tokenStr)
+		assert.Nil(t, tok, "token %q must not be returned in production startup", tokenStr)
+	}
+}
+
+// TestServer_SeedTestTokens_WhenEnvVarEnabled verifies that setting
+// CFGMS_SEED_TEST_TOKENS=1 causes the controller to create all expected test
+// tokens in the registration store.
+func TestServer_SeedTestTokens_WhenEnvVarEnabled(t *testing.T) {
+	t.Setenv("CFGMS_SEED_TEST_TOKENS", "1")
+
+	tempDir := t.TempDir()
+	cfg := &config.Config{
+		ListenAddr: "127.0.0.1:0",
+		Certificate: &config.CertificateConfig{
+			EnableCertManagement: false,
+		},
+		Storage: &config.StorageConfig{
+			Provider:     "flatfile",
+			FlatfileRoot: tempDir + "/flatfile",
+			SQLitePath:   tempDir + "/cfgms.db",
+		},
+	}
+
+	srv, err := New(cfg, logging.NewNoopLogger())
+	require.NoError(t, err)
+	require.NotNil(t, srv)
+	t.Cleanup(func() { _ = srv.Stop() })
+
+	store := srv.GetRegistrationTokenStore()
+	require.NotNil(t, store, "registration token store must be initialized")
+
+	ctx := context.Background()
+	for _, tokenStr := range hardcodedTestTokens {
+		tok, err := store.GetToken(ctx, tokenStr)
+		assert.NoError(t, err, "token %q should exist when CFGMS_SEED_TEST_TOKENS=1", tokenStr)
+		if assert.NotNil(t, tok, "token %q should be retrievable when CFGMS_SEED_TEST_TOKENS=1", tokenStr) {
+			assert.Equal(t, tokenStr, tok.Token)
+		}
+	}
+}
+
+// TestServer_SeedTestTokens_DefaultOff confirms the env var must be exactly "1"
+// to enable seeding — empty string, "true", "yes", and "0" must all leave the
+// store empty.
+func TestServer_SeedTestTokens_DefaultOff(t *testing.T) {
+	for _, val := range []string{"", "0", "true", "yes", "false"} {
+		t.Run("env="+val, func(t *testing.T) {
+			t.Setenv("CFGMS_SEED_TEST_TOKENS", val)
+
+			tempDir := t.TempDir()
+			cfg := &config.Config{
+				ListenAddr: "127.0.0.1:0",
+				Certificate: &config.CertificateConfig{
+					EnableCertManagement: false,
+				},
+				Storage: &config.StorageConfig{
+					Provider:     "flatfile",
+					FlatfileRoot: tempDir + "/flatfile",
+					SQLitePath:   tempDir + "/cfgms.db",
+				},
+			}
+
+			srv, err := New(cfg, logging.NewNoopLogger())
+			require.NoError(t, err)
+			require.NotNil(t, srv)
+			t.Cleanup(func() { _ = srv.Stop() })
+
+			store := srv.GetRegistrationTokenStore()
+			require.NotNil(t, store)
+
+			ctx := context.Background()
+			for _, tokenStr := range hardcodedTestTokens {
+				tok, err := store.GetToken(ctx, tokenStr)
+				assert.Error(t, err, "token %q must not exist when CFGMS_SEED_TEST_TOKENS=%q", tokenStr, val)
+				assert.Nil(t, tok)
+			}
+		})
+	}
+}
+
+// TestServer_ProductionStartup_EnvVarNotSet confirms the guard is off when
+// the env var has not been set to "1".
+func TestServer_ProductionStartup_EnvVarNotSet(t *testing.T) {
+	// Use t.Setenv so the restore-on-cleanup hook runs and the test is race-safe.
+	t.Setenv("CFGMS_SEED_TEST_TOKENS", "")
+
+	tempDir := t.TempDir()
+	cfg := &config.Config{
+		ListenAddr: "127.0.0.1:0",
+		Certificate: &config.CertificateConfig{
+			EnableCertManagement: false,
+		},
+		Storage: &config.StorageConfig{
+			Provider:     "flatfile",
+			FlatfileRoot: tempDir + "/flatfile",
+			SQLitePath:   tempDir + "/cfgms.db",
+		},
+	}
+
+	srv, err := New(cfg, logging.NewNoopLogger())
+	require.NoError(t, err)
+	require.NotNil(t, srv)
+	t.Cleanup(func() { _ = srv.Stop() })
+
+	store := srv.GetRegistrationTokenStore()
+	require.NotNil(t, store)
+
+	ctx := context.Background()
+	for _, tokenStr := range hardcodedTestTokens {
+		tok, err := store.GetToken(ctx, tokenStr)
+		assert.Error(t, err, "token %q must not exist when env var is absent", tokenStr)
+		assert.Nil(t, tok)
+	}
+}

--- a/test/integration/transport/helpers_test.go
+++ b/test/integration/transport/helpers_test.go
@@ -61,15 +61,18 @@ func (h *TestHelper) BaseURL() string {
 	return h.baseURL
 }
 
-// CreateToken returns a pre-created reusable test token.
-// The controller pre-creates test tokens on startup when transport is enabled.
+// CreateToken returns the pre-seeded reusable integration test token.
+//
+// The controller only seeds this token when started with CFGMS_SEED_TEST_TOKENS=1.
+// Integration test environments (Docker Compose, CI) must set that variable on
+// the controller process before it starts; see docker-compose.test.yml.
 //
 // NOTE: tenantID and group parameters are currently ignored — all registrations
 // use the same shared token with pre-configured metadata. Multi-tenant isolation
 // tests verify unique steward IDs but do NOT validate per-tenant token boundaries.
 // Per-tenant tokens require seeding distinct tokens in the controller test setup.
 func (h *TestHelper) CreateToken(_ *testing.T, _, _ string) string {
-	return "integration_reusable"
+	return "integration_reusable" //nolint:gosec // test-only token, requires CFGMS_SEED_TEST_TOKENS=1 on the controller
 }
 
 // RegisterSteward registers a steward via HTTP API and returns the response.


### PR DESCRIPTION
## Summary

- Five well-known registration tokens were seeded unconditionally on every controller startup, making them valid credentials against any production deployment built from this source
- Wrapped the entire seeding block in `features/controller/server/server.go` with `if os.Getenv("CFGMS_SEED_TEST_TOKENS") == "1"` — strict equality, outermost guard, no seeding code runs without the opt-in
- Added `CFGMS_SEED_TEST_TOKENS: "1"` to `docker-compose.test.yml` `controller-standalone` so integration test suites remain unaffected
- Added `server_test.go` with four tests that lock in the production-no-tokens / env-gated-seeding contract

## Changed Files

| File | Change |
|------|--------|
| `features/controller/server/server.go` | Add `os` import; wrap 5-token seeding block with env var guard; `//nolint:gosec` with justification on each literal |
| `features/controller/server/server_test.go` | **New** — 4 tests covering: no tokens when env unset, all tokens when env=1, strict equality (0/true/yes/false all skip seeding) |
| `test/integration/transport/helpers_test.go` | Update `CreateToken` comment to document env var dependency; `//nolint:gosec` on return literal |
| `docker-compose.test.yml` | Add `CFGMS_SEED_TEST_TOKENS: "1"` to `controller-standalone` environment |

## Specialist Review Results

- **QA Test Runner**: PASS — all packages pass including `features/controller/server` (27s), cross-platform builds verified, production-critical integration tests pass
- **QA Code Reviewer**: PASS — no mocks, no skips, all assertions real, `//nolint` directives justified, error paths covered (env absent/empty/wrong-value all tested)
- **Security Engineer**: PASS — `security-precommit` clean, `check-architecture` clean, `security-scan` clean (Trivy/Nancy/gosec/staticcheck); env var guard is outermost check; no new attack surface; token literals unreachable without explicit opt-in

## Test Plan

- [x] `TestServer_ProductionStartup_NoHardcodedTokens` — creates server with empty env var, asserts all 5 token strings absent from store
- [x] `TestServer_SeedTestTokens_WhenEnvVarEnabled` — creates server with `CFGMS_SEED_TEST_TOKENS=1`, asserts all 5 tokens present
- [x] `TestServer_SeedTestTokens_DefaultOff` — parameterized: "0", "true", "yes", "false" all leave store empty
- [x] `TestServer_ProductionStartup_EnvVarNotSet` — uses `t.Setenv("")` for race-safe absent-env coverage
- [x] All existing `server_security_test.go` tests continue to pass
- [x] `make test-agent-complete` fully green

Fixes #700

🤖 Generated with [Claude Code](https://claude.com/claude-code)