### PR TITLE
controller/api: sanitize audit log fields and fix map-drop in authorization audit (Issue #1003)

### DIFF
--- a/features/controller/api/middleware.go
+++ b/features/controller/api/middleware.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"sort"
 	"strings"
 	"time"
 
@@ -412,40 +413,50 @@ func (s *Server) writeAuthorizationError(w http.ResponseWriter, message, code st
 
 // auditAuthorizationDecision logs authorization decisions for security auditing
 func (s *Server) auditAuthorizationDecision(r *http.Request, decision *AuthorizationDecision) {
-	// Create comprehensive audit log entry
 	auditFields := map[string]interface{}{
 		"event_type":     "api_authorization",
 		"timestamp":      decision.CheckedAt.UTC().Format(time.RFC3339Nano),
-		"subject_id":     decision.SubjectID,
-		"tenant_id":      decision.TenantID,
-		"permission_id":  decision.PermissionID,
-		"resource":       decision.Resource,
-		"action":         decision.Action,
-		"decision":       decision.Decision,
+		"subject_id":     logging.SanitizeLogValue(decision.SubjectID),
+		"tenant_id":      logging.SanitizeLogValue(decision.TenantID),
+		"permission_id":  logging.SanitizeLogValue(decision.PermissionID),
+		"resource":       logging.SanitizeLogValue(decision.Resource),
+		"action":         logging.SanitizeLogValue(decision.Action),
+		"decision":       logging.SanitizeLogValue(decision.Decision),
 		"granted":        decision.Granted,
-		"reason":         decision.Reason,
+		"reason":         logging.SanitizeLogValue(decision.Reason),
 		"duration_ms":    decision.DurationMs,
 		"request_path":   logging.SanitizeLogValue(r.URL.Path),
-		"request_method": r.Method,
+		"request_method": logging.SanitizeLogValue(r.Method),
 		"remote_addr":    logging.SanitizeLogValue(r.RemoteAddr),
 		"user_agent":     logging.SanitizeLogValue(r.Header.Get("User-Agent")),
-		"request_id":     s.getRequestID(r),
+		"request_id":     logging.SanitizeLogValue(s.getRequestID(r)),
 		"severity":       s.getAuditSeverity(decision),
 	}
 
-	// Add conditional variables if present
 	if decision.ConditionalVars != nil {
-		auditFields["conditional_vars"] = decision.ConditionalVars
+		auditFields["conditional_vars"] = logging.SanitizeFieldsRecursive(decision.ConditionalVars)
 	}
 
-	// Log at appropriate level based on decision outcome
 	if decision.Granted {
-		s.logger.Info("Authorization audit", auditFields)
+		s.logger.Info("Authorization audit", flattenFieldsToKV(auditFields)...)
 	} else {
-		// Failed authorization attempts need higher visibility
-		s.logger.Warn("Authorization audit - access denied", auditFields)
+		s.logger.Warn("Authorization audit - access denied", flattenFieldsToKV(auditFields)...)
 	}
+}
 
+// flattenFieldsToKV converts a map to a sorted flat key/value slice for variadic logger calls.
+// Keys are sorted alphabetically to make log output deterministic.
+func flattenFieldsToKV(fields map[string]interface{}) []interface{} {
+	keys := make([]string, 0, len(fields))
+	for k := range fields {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	out := make([]interface{}, 0, 2*len(fields))
+	for _, k := range keys {
+		out = append(out, k, fields[k])
+	}
+	return out
 }
 
 // getRequestID extracts or generates a request ID for audit correlation

--- a/features/controller/api/middleware_test.go
+++ b/features/controller/api/middleware_test.go
@@ -3,14 +3,125 @@
 package api
 
 import (
+	"context"
+	"fmt"
 	"net/http"
+	"strings"
 	"sync"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/cfgis/cfgms/pkg/logging"
 )
+
+// auditCapturingLogger records Info and Warn calls for audit log assertions.
+// It is a real implementation backed by a test buffer — not a mock of any
+// CFGMS component (same pattern as the terminal log-redaction stories #979, #981).
+type auditCapturingLogger struct {
+	logging.NoopLogger
+	mu      sync.Mutex
+	entries []auditLogEntry
+}
+
+type auditLogEntry struct {
+	level string
+	msg   string
+	kvs   []interface{}
+}
+
+func (l *auditCapturingLogger) Info(msg string, kvs ...interface{}) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.entries = append(l.entries, auditLogEntry{level: "INFO", msg: msg, kvs: kvs})
+}
+
+func (l *auditCapturingLogger) Warn(msg string, kvs ...interface{}) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.entries = append(l.entries, auditLogEntry{level: "WARN", msg: msg, kvs: kvs})
+}
+
+// formattedOutput renders all captured entries as "key=value" pairs for substring assertions.
+func (l *auditCapturingLogger) formattedOutput() string {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	var b strings.Builder
+	for _, e := range l.entries {
+		b.WriteString(e.level)
+		b.WriteByte(' ')
+		b.WriteString(e.msg)
+		for i := 0; i+1 < len(e.kvs); i += 2 {
+			fmt.Fprintf(&b, " %v=%v", e.kvs[i], e.kvs[i+1])
+		}
+		b.WriteByte('\n')
+	}
+	return b.String()
+}
+
+// kvValue returns the value associated with key across all captured entries, or nil.
+func (l *auditCapturingLogger) kvValue(key string) interface{} {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	for _, e := range l.entries {
+		for i := 0; i+1 < len(e.kvs); i += 2 {
+			if k, ok := e.kvs[i].(string); ok && k == key {
+				return e.kvs[i+1]
+			}
+		}
+	}
+	return nil
+}
+
+// hasLevel reports whether any entry was captured at the given level.
+func (l *auditCapturingLogger) hasLevel(level string) bool {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	for _, e := range l.entries {
+		if e.level == level {
+			return true
+		}
+	}
+	return false
+}
+
+func TestFlattenFieldsToKV_SortedDeterministic(t *testing.T) {
+	fields := map[string]interface{}{
+		"zebra":  "z",
+		"apple":  "a",
+		"mango":  "m",
+		"banana": "b",
+	}
+	kv := flattenFieldsToKV(fields)
+	require.Equal(t, 8, len(kv), "2 entries per field")
+
+	// Keys must appear in alphabetical order.
+	keys := make([]string, 0, 4)
+	for i := 0; i < len(kv); i += 2 {
+		k, ok := kv[i].(string)
+		require.True(t, ok, "key at index %d must be string", i)
+		keys = append(keys, k)
+	}
+	assert.Equal(t, []string{"apple", "banana", "mango", "zebra"}, keys)
+
+	// Second call must return the same order.
+	kv2 := flattenFieldsToKV(fields)
+	for i := 0; i < len(kv); i++ {
+		assert.Equal(t, kv[i], kv2[i], "index %d must be identical across calls", i)
+	}
+}
+
+func TestFlattenFieldsToKV_EmptyMap(t *testing.T) {
+	kv := flattenFieldsToKV(map[string]interface{}{})
+	assert.Empty(t, kv)
+}
+
+func TestFlattenFieldsToKV_NilMap(t *testing.T) {
+	kv := flattenFieldsToKV(nil)
+	assert.Empty(t, kv)
+}
 
 func TestGenerateRequestID_UniqueUnderConcurrency(t *testing.T) {
 	server := setupTestServer(t)
@@ -109,4 +220,159 @@ func TestAuditAuthorizationDecision_DoesNotPanic(t *testing.T) {
 			})
 		})
 	}
+}
+
+// TestAuditAuthorizationDecision_FieldsAppearInLogOutput verifies that after fixing
+// the map-drop bug (passing a map as a single arg to a variadic logger), audit fields
+// actually appear in the captured log output.
+func TestAuditAuthorizationDecision_FieldsAppearInLogOutput(t *testing.T) {
+	capLog := &auditCapturingLogger{}
+	server := setupTestServerWithLogger(t, capLog)
+
+	req, err := http.NewRequest(http.MethodGet, "/api/v1/stewards", nil)
+	require.NoError(t, err)
+
+	t.Run("granted path uses Info and fields appear", func(t *testing.T) {
+		capLog.mu.Lock()
+		capLog.entries = nil
+		capLog.mu.Unlock()
+
+		decision := &AuthorizationDecision{
+			Granted:      true,
+			PermissionID: "steward:read",
+			Resource:     "steward:test-id",
+			Action:       "read",
+			Decision:     "ALLOW",
+			Reason:       "API key has required permission: steward:read",
+			CheckedAt:    time.Now(),
+			SubjectID:    "subject-abc",
+			TenantID:     "tenant-xyz",
+		}
+		server.auditAuthorizationDecision(req, decision)
+
+		out := capLog.formattedOutput()
+		assert.True(t, capLog.hasLevel("INFO"), "granted path must log at INFO")
+		assert.Contains(t, out, "subject_id=subject-abc")
+		assert.Contains(t, out, "tenant_id=tenant-xyz")
+		assert.Contains(t, out, "resource=steward:test-id")
+	})
+
+	t.Run("denied path uses Warn and fields appear", func(t *testing.T) {
+		capLog.mu.Lock()
+		capLog.entries = nil
+		capLog.mu.Unlock()
+
+		decision := &AuthorizationDecision{
+			Granted:      false,
+			PermissionID: "rbac:admin",
+			Resource:     "rbac:*",
+			Action:       "admin",
+			Decision:     "DENY",
+			Reason:       "API key lacks required permission: rbac:admin",
+			CheckedAt:    time.Now(),
+			SubjectID:    "subject-abc",
+			TenantID:     "tenant-xyz",
+		}
+		server.auditAuthorizationDecision(req, decision)
+
+		out := capLog.formattedOutput()
+		assert.True(t, capLog.hasLevel("WARN"), "denied path must log at WARN")
+		assert.Contains(t, out, "subject_id=subject-abc")
+		assert.Contains(t, out, "tenant_id=tenant-xyz")
+		assert.Contains(t, out, "resource=rbac:*")
+	})
+}
+
+// TestAuditAuthorizationDecision_SanitizesUserInput verifies that attacker-controlled
+// fields (Reason, SubjectID, Resource, X-Request-ID header) are sanitized before
+// reaching the logger — closing CodeQL go/log-injection alert #528 (CWE-117).
+func TestAuditAuthorizationDecision_SanitizesUserInput(t *testing.T) {
+	capLog := &auditCapturingLogger{}
+	server := setupTestServerWithLogger(t, capLog)
+
+	req, err := http.NewRequest(http.MethodGet, "/api/v1/stewards", nil)
+	require.NoError(t, err)
+	req = req.WithContext(context.Background())
+	req.Header.Set("X-Request-ID", "rid\nFAKE")
+
+	decision := &AuthorizationDecision{
+		Granted:      false,
+		PermissionID: "steward:read",
+		Resource:     "res\x1b[31mevil\x1b[0m",
+		Action:       "read",
+		Decision:     "DENY",
+		Reason:       "denied\n[FAKE LOG] admin granted access",
+		CheckedAt:    time.Now(),
+		SubjectID:    "user\x00inj",
+		TenantID:     "tenant-1",
+	}
+	server.auditAuthorizationDecision(req, decision)
+
+	// Assert the sanitized replacement char is present in the logged value — not just
+	// absence of the bad char (absence-of-newline is insufficient because JSON encoding
+	// masks newlines, but the replacement underscore is a positive signal).
+	assert.Equal(t, "denied_[FAKE LOG] admin granted access", capLog.kvValue("reason"),
+		"newline in Reason must be replaced with underscore")
+	assert.Equal(t, "user_inj", capLog.kvValue("subject_id"),
+		"null byte in SubjectID must be replaced with underscore")
+	assert.Equal(t, "res_[31mevil_[0m", capLog.kvValue("resource"),
+		"ESC bytes in Resource must be replaced with underscore")
+	assert.Equal(t, "rid_FAKE", capLog.kvValue("request_id"),
+		"newline in X-Request-ID header must be replaced with underscore")
+
+	// Check no raw control characters in the individual logged string values.
+	for _, key := range []string{"reason", "subject_id", "resource", "request_id"} {
+		if s, ok := capLog.kvValue(key).(string); ok {
+			assert.NotContains(t, s, "\n", "key %q must not contain LF", key)
+			assert.NotContains(t, s, "\r", "key %q must not contain CR", key)
+			assert.NotContains(t, s, "\x00", "key %q must not contain NUL", key)
+			assert.NotContains(t, s, "\x1b", "key %q must not contain ESC", key)
+		}
+	}
+}
+
+// TestAuditAuthorizationDecision_SanitizesNestedConditionalVars verifies that
+// SanitizeFieldsRecursive is applied to ConditionalVars, recursing into nested
+// maps and slices to neutralise injected control characters.
+func TestAuditAuthorizationDecision_SanitizesNestedConditionalVars(t *testing.T) {
+	capLog := &auditCapturingLogger{}
+	server := setupTestServerWithLogger(t, capLog)
+
+	req, err := http.NewRequest(http.MethodGet, "/api/v1/stewards", nil)
+	require.NoError(t, err)
+
+	decision := &AuthorizationDecision{
+		Granted:      true,
+		PermissionID: "steward:read",
+		Resource:     "steward:*",
+		Action:       "read",
+		Decision:     "ALLOW",
+		Reason:       "allowed",
+		CheckedAt:    time.Now(),
+		SubjectID:    "user-1",
+		TenantID:     "tenant-1",
+		ConditionalVars: map[string]interface{}{
+			"k": []interface{}{"a\nb"},
+			"m": map[string]interface{}{"deep": "v\x00x"},
+		},
+	}
+	server.auditAuthorizationDecision(req, decision)
+
+	// Retrieve the sanitized conditional_vars from the captured key/value pairs.
+	cv := capLog.kvValue("conditional_vars")
+	require.NotNil(t, cv, "conditional_vars must be present in log output")
+
+	cvMap, ok := cv.(map[string]interface{})
+	require.True(t, ok, "conditional_vars must be a map after sanitization")
+
+	// Nested slice: "k" → ["a_b"] (newline replaced)
+	kSlice, ok := cvMap["k"].([]interface{})
+	require.True(t, ok, "conditional_vars[k] must be a slice")
+	require.Len(t, kSlice, 1)
+	assert.Equal(t, "a_b", kSlice[0], "newline in slice element must be replaced")
+
+	// Nested map: "m" → {"deep": "v_x"} (null byte replaced)
+	mMap, ok := cvMap["m"].(map[string]interface{})
+	require.True(t, ok, "conditional_vars[m] must be a nested map")
+	assert.Equal(t, "v_x", mMap["deep"], "null byte in nested map value must be replaced")
 }

--- a/pkg/logging/sanitize.go
+++ b/pkg/logging/sanitize.go
@@ -7,6 +7,9 @@ import (
 	"strings"
 )
 
+// maxRecursionDepth is the maximum recursion depth for SanitizeFieldsRecursive.
+const maxRecursionDepth = 10
+
 // maxLogValueLength is the maximum length for a sanitized log value.
 // Values exceeding this length are truncated with a [truncated] suffix.
 const maxLogValueLength = 1024
@@ -207,5 +210,56 @@ func sanitizeKeysAndValues(keysAndValues []any) []any {
 		}
 	}
 
+	return result
+}
+
+// SanitizeFieldsRecursive sanitizes all string keys and values in fields for safe
+// log inclusion. It recurses into nested map[string]interface{} and []interface{}
+// values up to 10 levels deep. Values implementing error have Error() sanitized;
+// fmt.Stringer values have String() sanitized. Non-string scalars pass through
+// unchanged. Maps at depth >= 10 are replaced with {"_truncated": "max depth exceeded"}.
+func SanitizeFieldsRecursive(fields map[string]interface{}) map[string]interface{} {
+	return sanitizeMapRecursive(fields, 0)
+}
+
+func sanitizeMapRecursive(fields map[string]interface{}, depth int) map[string]interface{} {
+	if depth >= maxRecursionDepth {
+		return map[string]interface{}{"_truncated": "max depth exceeded"}
+	}
+	result := make(map[string]interface{}, len(fields))
+	for k, v := range fields {
+		result[SanitizeLogValue(k)] = sanitizeValueRecursive(v, depth+1)
+	}
+	return result
+}
+
+func sanitizeValueRecursive(v interface{}, depth int) interface{} {
+	if v == nil {
+		return nil
+	}
+	switch val := v.(type) {
+	case string:
+		return SanitizeLogValue(val)
+	case map[string]interface{}:
+		return sanitizeMapRecursive(val, depth)
+	case []interface{}:
+		return sanitizeSliceRecursive(val, depth)
+	case error:
+		return SanitizeLogValue(val.Error())
+	case fmt.Stringer:
+		return SanitizeLogValue(val.String())
+	default:
+		return v
+	}
+}
+
+func sanitizeSliceRecursive(items []interface{}, depth int) []interface{} {
+	if depth >= maxRecursionDepth {
+		return []interface{}{"_truncated: max depth exceeded"}
+	}
+	result := make([]interface{}, len(items))
+	for i, item := range items {
+		result[i] = sanitizeValueRecursive(item, depth+1)
+	}
 	return result
 }

--- a/pkg/logging/sanitize_test.go
+++ b/pkg/logging/sanitize_test.go
@@ -3,6 +3,7 @@
 package logging
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
@@ -392,6 +393,126 @@ func TestSensitiveLogConfig_GetSet(t *testing.T) {
 	SetSensitiveLogConfig(SensitiveLogConfig{UnredactedSensitiveValues: false})
 	got = GetSensitiveLogConfig()
 	assert.False(t, got.UnredactedSensitiveValues)
+}
+
+func TestSanitizeFieldsRecursive_StringValues(t *testing.T) {
+	fields := map[string]interface{}{
+		"clean":     "value",
+		"injected":  "bad\nvalue",
+		"null_byte": "a\x00b",
+		"ansi":      "\x1b[31mred\x1b[0m",
+	}
+	result := SanitizeFieldsRecursive(fields)
+	assert.Equal(t, "value", result["clean"])
+	assert.Equal(t, "bad_value", result["injected"])
+	assert.Equal(t, "a_b", result["null_byte"])
+	assert.Equal(t, "_[31mred_[0m", result["ansi"])
+}
+
+func TestSanitizeFieldsRecursive_NonStringPassThrough(t *testing.T) {
+	fields := map[string]interface{}{
+		"count":   42,
+		"enabled": true,
+		"ratio":   3.14,
+		"nothing": nil,
+	}
+	result := SanitizeFieldsRecursive(fields)
+	assert.Equal(t, 42, result["count"])
+	assert.Equal(t, true, result["enabled"])
+	assert.Equal(t, 3.14, result["ratio"])
+	assert.Nil(t, result["nothing"])
+}
+
+func TestSanitizeFieldsRecursive_SanitizesKeys(t *testing.T) {
+	fields := map[string]interface{}{
+		"key\ninjected": "value",
+	}
+	result := SanitizeFieldsRecursive(fields)
+	_, hasInjected := result["key\ninjected"]
+	assert.False(t, hasInjected, "injected key should be sanitized")
+	assert.Equal(t, "value", result["key_injected"])
+}
+
+func TestSanitizeFieldsRecursive_NestedMap(t *testing.T) {
+	fields := map[string]interface{}{
+		"outer": map[string]interface{}{
+			"inner": "bad\nvalue",
+			"count": 99,
+		},
+	}
+	result := SanitizeFieldsRecursive(fields)
+	inner, ok := result["outer"].(map[string]interface{})
+	require.True(t, ok, "outer should be a map")
+	assert.Equal(t, "bad_value", inner["inner"])
+	assert.Equal(t, 99, inner["count"])
+}
+
+func TestSanitizeFieldsRecursive_NestedSlice(t *testing.T) {
+	fields := map[string]interface{}{
+		"items": []interface{}{"a\nb", "clean", 42, nil},
+	}
+	result := SanitizeFieldsRecursive(fields)
+	items, ok := result["items"].([]interface{})
+	require.True(t, ok, "items should be a slice")
+	assert.Equal(t, "a_b", items[0])
+	assert.Equal(t, "clean", items[1])
+	assert.Equal(t, 42, items[2])
+	assert.Nil(t, items[3])
+}
+
+func TestSanitizeFieldsRecursive_ErrorValue(t *testing.T) {
+	fields := map[string]interface{}{
+		"err": fmt.Errorf("failed\nwith newline"),
+	}
+	result := SanitizeFieldsRecursive(fields)
+	assert.Equal(t, "failed_with newline", result["err"])
+}
+
+type testStringer struct{ val string }
+
+func (s testStringer) String() string { return s.val }
+
+func TestSanitizeFieldsRecursive_StringerValue(t *testing.T) {
+	fields := map[string]interface{}{
+		"stringer": testStringer{"stringer\nvalue"},
+	}
+	result := SanitizeFieldsRecursive(fields)
+	assert.Equal(t, "stringer_value", result["stringer"])
+}
+
+func TestSanitizeFieldsRecursive_DepthLimit(t *testing.T) {
+	// Build an 11-level deep map; the 10th level should be replaced with a truncation marker.
+	var buildNested func(depth int) map[string]interface{}
+	buildNested = func(depth int) map[string]interface{} {
+		if depth == 0 {
+			return map[string]interface{}{"leaf": "value\ninjected"}
+		}
+		return map[string]interface{}{"child": buildNested(depth - 1)}
+	}
+
+	// 11 levels: top-level + 10 child maps — the 10th child triggers truncation.
+	nested := buildNested(11)
+	result := SanitizeFieldsRecursive(nested)
+
+	// Traverse down to find the truncation marker without recursing 11 levels in test.
+	// We know truncation kicks in at depth 10. Walk down level by level.
+	current := result
+	for i := 0; i < 9; i++ {
+		child, ok := current["child"].(map[string]interface{})
+		require.True(t, ok, "expected child map at level %d", i+1)
+		current = child
+	}
+	// At this point, current["child"] should be the truncated map.
+	truncated, ok := current["child"].(map[string]interface{})
+	require.True(t, ok, "truncated value should be a map")
+	assert.Equal(t, "max depth exceeded", truncated["_truncated"])
+}
+
+func TestSanitizeFieldsRecursive_NilInput(t *testing.T) {
+	// A nil map should not panic.
+	result := SanitizeFieldsRecursive(nil)
+	assert.NotNil(t, result)
+	assert.Len(t, result, 0)
 }
 
 func TestSensitiveLogConfig_ConcurrentAccess(t *testing.T) {


### PR DESCRIPTION
## Summary

- **Fixes latent map-drop bug**: `auditAuthorizationDecision` was passing the entire `auditFields` map as a single variadic argument to `s.logger.Info/Warn`. With `len == 1` the `i += 2` loop never ran — the complete audit map was silently dropped from every log entry. Fixed by `flattenFieldsToKV` (alphabetically sorted, spread via `...`).
- **Closes CodeQL #528 (CWE-117 go/log-injection)**: All user-influenced audit fields — `subject_id`, `tenant_id`, `permission_id`, `resource`, `action`, `decision`, `reason`, and `request_id` (from `X-Request-ID`/`X-Correlation-ID` headers, fully attacker-controlled) — are now wrapped in `logging.SanitizeLogValue`. Nested `conditional_vars` are sanitized recursively via the new `SanitizeFieldsRecursive` helper.
- **New public helper `logging.SanitizeFieldsRecursive`**: Recurses into nested `map[string]interface{}` and `[]interface{}` up to 10 levels, sanitizing strings, error messages, and Stringer output; non-string scalars pass through unchanged; depth >= 10 returns a `_truncated` marker.

## Files Changed

| File | Change |
|------|--------|
| `pkg/logging/sanitize.go` | Add `SanitizeFieldsRecursive` + private recursive helpers |
| `pkg/logging/sanitize_test.go` | 9 new tests (string values, pass-through, key sanitization, nested map, nested slice, error, Stringer, nil, depth limit) |
| `features/controller/api/middleware.go` | Sanitize all audit fields, add `flattenFieldsToKV`, fix `Info`/`Warn` call shape |
| `features/controller/api/middleware_test.go` | `auditCapturingLogger` (real buffer, not a mock), `TestFlattenFieldsToKV_*`, 3 new audit tests |

## Specialist Review Results

- **QA Test Runner**: PASS — all packages, cross-platform builds, linting, license headers
- **QA Code Reviewer**: PASS — no blocking issues; warning about missing `flattenFieldsToKV` sort test addressed (tests added before commit)
- **Security Engineer**: PASS — 0 blocking issues; all scans clean (`security-precommit`, `check-architecture`, `security-scan`); CWE-117 closure confirmed; depth-limit stack-overflow prevention verified

## Test Plan

- [ ] `go test ./pkg/logging/...` — all logging tests pass including 9 new `SanitizeFieldsRecursive` tests
- [ ] `go test ./features/controller/api/...` — all middleware tests pass including 3 new audit tests + 3 `flattenFieldsToKV` tests
- [ ] `make test-agent-complete` — full suite passes (confirmed by QA test runner)
- [ ] `TestAuditAuthorizationDecision_FieldsAppearInLogOutput` — verifies fields actually appear after fixing map-drop
- [ ] `TestAuditAuthorizationDecision_SanitizesUserInput` — positive underscore assertion for each injected field (not just absence of control chars)
- [ ] `TestAuditAuthorizationDecision_SanitizesNestedConditionalVars` — recursive sanitization of nested maps and slices

Fixes #1003

🤖 Generated with [Claude Code](https://claude.com/claude-code)