### PR TITLE
service: tighten file permissions on steward/controller install (Issue #719)

### DIFF
--- a/cmd/controller/service/copy.go
+++ b/cmd/controller/service/copy.go
@@ -10,7 +10,8 @@ import (
 )
 
 // copyBinary copies src to dst atomically using a temp file.
-// The destination is created with 0755 permissions (owner rwx, group/other rx).
+// 0750: owner rwx (service binary), group rx (service group), no world access.
+// #nosec G302 -- binary requires execute permission; root-owned install, no world access
 func copyBinary(src, dst string) error {
 	in, err := os.Open(src)
 	if err != nil {
@@ -19,7 +20,7 @@ func copyBinary(src, dst string) error {
 	defer func() { _ = in.Close() }()
 
 	tmp := dst + ".tmp"
-	out, err := os.OpenFile(tmp, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0755)
+	out, err := os.OpenFile(tmp, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0750) // #nosec G302 -- see function comment
 	if err != nil {
 		return err
 	}

--- a/cmd/controller/service/manager_linux.go
+++ b/cmd/controller/service/manager_linux.go
@@ -53,7 +53,7 @@ func (m *linuxManager) Install(configPath string) error {
 
 	fmt.Println("Writing systemd unit...")
 	unit := generateSystemdUnit(configPath)
-	if err := os.WriteFile(linuxSystemdUnit, []byte(unit), 0644); err != nil {
+	if err := writeSystemdUnit(linuxSystemdUnit, []byte(unit)); err != nil {
 		return fmt.Errorf("failed to write systemd unit %s: %w", linuxSystemdUnit, err)
 	}
 
@@ -135,6 +135,13 @@ func (m *linuxManager) Status() (*ServiceStatus, error) {
 	}
 
 	return status, nil
+}
+
+// writeSystemdUnit writes a systemd unit file to path.
+// 0600: owner rw (root only); systemd reads unit files as root, group read is unnecessary
+// and would expose the config path to group members.
+func writeSystemdUnit(path string, content []byte) error {
+	return os.WriteFile(path, content, 0600)
 }
 
 // generateSystemdUnit returns a systemd unit that runs cfgms-controller with the

--- a/cmd/controller/service/manager_linux_test.go
+++ b/cmd/controller/service/manager_linux_test.go
@@ -7,6 +7,7 @@ package service
 
 import (
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -127,4 +128,28 @@ func TestLinuxManagerNew(t *testing.T) {
 	require.NotNil(t, m)
 	_, ok := m.(*linuxManager)
 	assert.True(t, ok, "New() should return a *linuxManager on Linux")
+}
+
+func TestCopyBinaryPermissions(t *testing.T) {
+	src := filepath.Join(t.TempDir(), "cfgms-controller-src")
+	require.NoError(t, os.WriteFile(src, []byte("binary content"), 0600))
+
+	dst := filepath.Join(t.TempDir(), "cfgms-controller")
+	require.NoError(t, copyBinary(src, dst))
+
+	info, err := os.Stat(dst)
+	require.NoError(t, err)
+	// 0750: owner rwx (service binary), group rx (service group), no world access
+	assert.Equal(t, os.FileMode(0750), info.Mode().Perm())
+}
+
+func TestSystemdUnitFilePermissions(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "cfgms-controller.service")
+	content := generateSystemdUnit("/etc/cfgms/controller.cfg")
+	require.NoError(t, writeSystemdUnit(path, []byte(content)))
+
+	info, err := os.Stat(path)
+	require.NoError(t, err)
+	// 0600: owner rw (root only); systemd reads as root, group read is unnecessary
+	assert.Equal(t, os.FileMode(0600), info.Mode().Perm())
 }

--- a/cmd/steward/service/copy.go
+++ b/cmd/steward/service/copy.go
@@ -10,7 +10,8 @@ import (
 )
 
 // copyBinary copies src to dst atomically using a temp file.
-// The destination is created with 0755 permissions (owner rwx, group/other rx).
+// 0750: owner rwx (service binary), group rx (service group), no world access.
+// #nosec G302 -- binary requires execute permission; root-owned install, no world access
 func copyBinary(src, dst string) error {
 	in, err := os.Open(src)
 	if err != nil {
@@ -19,7 +20,7 @@ func copyBinary(src, dst string) error {
 	defer func() { _ = in.Close() }()
 
 	tmp := dst + ".tmp"
-	out, err := os.OpenFile(tmp, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0755)
+	out, err := os.OpenFile(tmp, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0750) // #nosec G302 -- see function comment
 	if err != nil {
 		return err
 	}

--- a/cmd/steward/service/manager_linux.go
+++ b/cmd/steward/service/manager_linux.go
@@ -53,7 +53,7 @@ func (m *linuxManager) Install(token string) error {
 
 	fmt.Println("Writing systemd unit...")
 	unit := generateSystemdUnit(token)
-	if err := os.WriteFile(linuxSystemdUnit, []byte(unit), 0644); err != nil {
+	if err := writeSystemdUnit(linuxSystemdUnit, []byte(unit)); err != nil {
 		return fmt.Errorf("failed to write systemd unit %s: %w", linuxSystemdUnit, err)
 	}
 
@@ -132,6 +132,13 @@ func (m *linuxManager) Status() (*ServiceStatus, error) {
 	}
 
 	return status, nil
+}
+
+// writeSystemdUnit writes a systemd unit file to path.
+// 0600: owner rw (root only); systemd reads unit files as root, group read is unnecessary
+// and would expose the registration token to group members.
+func writeSystemdUnit(path string, content []byte) error {
+	return os.WriteFile(path, content, 0600)
 }
 
 // generateSystemdUnit returns a systemd unit that runs cfgms-steward with the

--- a/cmd/steward/service/manager_linux_test.go
+++ b/cmd/steward/service/manager_linux_test.go
@@ -7,6 +7,7 @@ package service
 
 import (
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -91,4 +92,28 @@ func TestLinuxManagerNew(t *testing.T) {
 	require.NotNil(t, m)
 	_, ok := m.(*linuxManager)
 	assert.True(t, ok, "New() should return a *linuxManager on Linux")
+}
+
+func TestCopyBinaryPermissions(t *testing.T) {
+	src := filepath.Join(t.TempDir(), "cfgms-steward-src")
+	require.NoError(t, os.WriteFile(src, []byte("binary content"), 0600))
+
+	dst := filepath.Join(t.TempDir(), "cfgms-steward")
+	require.NoError(t, copyBinary(src, dst))
+
+	info, err := os.Stat(dst)
+	require.NoError(t, err)
+	// 0750: owner rwx (service binary), group rx (service group), no world access
+	assert.Equal(t, os.FileMode(0750), info.Mode().Perm())
+}
+
+func TestSystemdUnitFilePermissions(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "cfgms-steward.service")
+	content := generateSystemdUnit("tok_test")
+	require.NoError(t, writeSystemdUnit(path, []byte(content)))
+
+	info, err := os.Stat(path)
+	require.NoError(t, err)
+	// 0600: owner rw (root only); systemd reads as root, group read exposes the token
+	assert.Equal(t, os.FileMode(0600), info.Mode().Perm())
 }


### PR DESCRIPTION
## Summary

- **Binary install (`copy.go`)**: `0755` → `0750` — owner rwx, group rx, no world access. Annotated with `#nosec G302` because execute permission is architecturally required for a service binary; justification documented in function comment.
- **Systemd unit (`manager_linux.go`)**: `0644` → `0600` — systemd reads unit files as root so group read is unnecessary; tightening to `0600` eliminates G306 without any suppression and avoids exposing the registration token / config path to group members.
- **New `writeSystemdUnit` helper**: wraps `os.WriteFile` at `0600`; extracted to make the permission directly testable without root or systemd.
- **Tests added** (`manager_linux_test.go`, both steward and controller): `TestCopyBinaryPermissions` and `TestSystemdUnitFilePermissions` verify exact `os.FileMode` values via `os.Stat().Mode().Perm()` on `t.TempDir()` paths.

## Acceptance Criteria

- [x] Gosec reports zero G306 findings under `cmd/` (unit file tightened to `0600`)
- [x] Gosec G302 findings on binary copy are documented suppressions with justification (binary must be executable; `make security-scan` reports DEPLOYMENT APPROVED)
- [x] Installed files have documented, minimal permissions (comments on each changed line)
- [x] Service install tests verify expected permission modes (`TestCopyBinaryPermissions`, `TestSystemdUnitFilePermissions`)

## Adversarial Review Results

| Specialist | Result | Notes |
|---|---|---|
| qa-test-runner | **PASS** | 226 packages, all passing with race detection |
| qa-code-reviewer | **PASS** | No blocking issues |
| security-engineer | **PASS** | `make security-scan`: DEPLOYMENT APPROVED; zero G306 findings; G302 suppressions reviewed and approved |

## Test Plan

- [ ] `go test ./cmd/steward/service/... ./cmd/controller/service/...` — all 20 tests pass
- [ ] `make security-scan` — reports DEPLOYMENT APPROVED
- [ ] `make check-architecture` — no central provider violations
- [ ] CI required checks: unit-tests, integration-tests, Build Gate, security-deployment-gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)