### PR TITLE
cert: fix LoadCA to support PKCS8/EC keys and verify key-cert match (Issue #1015)

### DIFF
--- a/pkg/cert/ca.go
+++ b/pkg/cert/ca.go
@@ -145,18 +145,22 @@ func (ca *CA) LoadCA(storagePath string) error {
 		return fmt.Errorf("failed to read CA private key: %w", err)
 	}
 
-	keyBlock, _ := pem.Decode(caKeyPEM)
-	if keyBlock == nil {
-		return fmt.Errorf("failed to decode CA private key PEM")
-	}
-
-	caKey, err := x509.ParsePKCS1PrivateKey(keyBlock.Bytes)
+	parsedKey, err := ParsePrivateKeyFromPEM(caKeyPEM)
 	if err != nil {
 		return fmt.Errorf("failed to parse CA private key: %w", err)
 	}
 
+	rsaKey, ok := parsedKey.(*rsa.PrivateKey)
+	if !ok {
+		return fmt.Errorf("CA private key must be RSA, got unsupported key type")
+	}
+
+	if err := ValidateKeyPair(caCertPEM, caKeyPEM); err != nil {
+		return fmt.Errorf("CA key does not match certificate: %w", err)
+	}
+
 	ca.certificate = caCert
-	ca.privateKey = caKey
+	ca.privateKey = rsaKey
 	ca.initialized = true
 
 	return nil

--- a/pkg/cert/ca_test.go
+++ b/pkg/cert/ca_test.go
@@ -3,8 +3,14 @@
 package cert
 
 import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
 	"crypto/x509"
+	"encoding/pem"
 	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -357,6 +363,109 @@ func TestCA_SerialNumberUniqueness(t *testing.T) {
 		assert.False(t, serialNumbers[cert.SerialNumber], "Serial number %s is not unique", cert.SerialNumber)
 		serialNumbers[cert.SerialNumber] = true
 	}
+}
+
+func TestCA_LoadCA_PKCS8Key(t *testing.T) {
+	dir := t.TempDir()
+
+	cfg := &CAConfig{
+		Organization: "Test CA",
+		Country:      "US",
+		ValidityDays: 365,
+		KeySize:      2048,
+		StoragePath:  dir,
+	}
+	ca, err := NewCA(cfg)
+	require.NoError(t, err)
+	err = ca.Initialize(cfg)
+	require.NoError(t, err)
+
+	// Read the saved PKCS1 key and re-encode as PKCS8
+	keyPath := filepath.Join(dir, "ca.key")
+	keyPEM, err := os.ReadFile(keyPath)
+	require.NoError(t, err)
+
+	keyBlock, _ := pem.Decode(keyPEM)
+	require.NotNil(t, keyBlock)
+
+	rsaKey, err := x509.ParsePKCS1PrivateKey(keyBlock.Bytes)
+	require.NoError(t, err)
+
+	pkcs8Bytes, err := x509.MarshalPKCS8PrivateKey(rsaKey)
+	require.NoError(t, err)
+
+	pkcs8PEM := pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: pkcs8Bytes})
+	require.NoError(t, os.WriteFile(keyPath, pkcs8PEM, 0600))
+
+	// LoadCA must succeed with a PKCS8-wrapped RSA key
+	loaded := &CA{}
+	require.NoError(t, loaded.LoadCA(dir))
+	assert.True(t, loaded.IsInitialized())
+
+	cert, err := loaded.GenerateServerCertificate(&ServerCertConfig{
+		CommonName:   "test-server",
+		ValidityDays: 365,
+	})
+	require.NoError(t, err)
+	assert.NotNil(t, cert)
+}
+
+func TestCA_LoadCA_MismatchedKeyPair(t *testing.T) {
+	dir1 := t.TempDir()
+	dir2 := t.TempDir()
+
+	cfg1 := &CAConfig{Organization: "Test CA 1", Country: "US", ValidityDays: 365, KeySize: 2048, StoragePath: dir1}
+	ca1, err := NewCA(cfg1)
+	require.NoError(t, err)
+	require.NoError(t, ca1.Initialize(cfg1))
+
+	cfg2 := &CAConfig{Organization: "Test CA 2", Country: "US", ValidityDays: 365, KeySize: 2048, StoragePath: dir2}
+	ca2, err := NewCA(cfg2)
+	require.NoError(t, err)
+	require.NoError(t, ca2.Initialize(cfg2))
+
+	// Write CA1's cert alongside CA2's key to a new dir to create a mismatch
+	mismatchDir := t.TempDir()
+
+	ca1Cert, err := os.ReadFile(filepath.Join(dir1, "ca.crt"))
+	require.NoError(t, err)
+	ca2Key, err := os.ReadFile(filepath.Join(dir2, "ca.key"))
+	require.NoError(t, err)
+
+	require.NoError(t, os.WriteFile(filepath.Join(mismatchDir, "ca.crt"), ca1Cert, 0600))
+	require.NoError(t, os.WriteFile(filepath.Join(mismatchDir, "ca.key"), ca2Key, 0600))
+
+	loaded := &CA{}
+	err = loaded.LoadCA(mismatchDir)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "key does not match certificate")
+}
+
+func TestCA_LoadCA_ECKeyRejected(t *testing.T) {
+	dir := t.TempDir()
+
+	cfg := &CAConfig{Organization: "Test CA", Country: "US", ValidityDays: 365, KeySize: 2048, StoragePath: dir}
+	ca, err := NewCA(cfg)
+	require.NoError(t, err)
+	require.NoError(t, ca.Initialize(cfg))
+
+	// Replace the RSA key file with an EC key
+	ecKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	ecKeyBytes, err := x509.MarshalECPrivateKey(ecKey)
+	require.NoError(t, err)
+
+	ecKeyPEM := pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: ecKeyBytes})
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "ca.key"), ecKeyPEM, 0600))
+
+	loaded := &CA{}
+	err = loaded.LoadCA(dir)
+	require.Error(t, err)
+	assert.True(t,
+		strings.Contains(err.Error(), "unsupported") || strings.Contains(err.Error(), "RSA"),
+		"expected error about unsupported key type or RSA requirement, got: %s", err.Error(),
+	)
 }
 
 func TestCA_CertificateValidityPeriods(t *testing.T) {


### PR DESCRIPTION
## Summary

- `LoadCA` now calls `ParsePrivateKeyFromPEM` instead of `x509.ParsePKCS1PrivateKey` directly, enabling PKCS8 and EC PEM blocks to be parsed without error
- Non-RSA keys (e.g. ECDSA) are rejected with a clear error — `ca.privateKey` field type and `saveToStorage` are unchanged
- `ValidateKeyPair(caCertPEM, caKeyPEM)` is called before `ca.initialized = true`, so a mismatched cert/key pair now returns an error instead of silently initialising a broken CA

## Test plan

- [x] `TestCA_LoadCA_PKCS8Key` — PKCS8-wrapped RSA key loads and CA can sign
- [x] `TestCA_LoadCA_MismatchedKeyPair` — mismatched cert/key returns error containing "key does not match certificate"
- [x] `TestCA_LoadCA_ECKeyRejected` — EC key against RSA cert returns error containing "unsupported"/"RSA"
- [x] Existing `TestCA_LoadCA` passes unchanged
- [x] Full `pkg/cert` suite: 36 tests, all passing

## Specialist Review Results

**QA Test Runner**: PASS — all quality validation gates passed (unit tests, linting, license headers, security scan, architecture compliance, cross-platform builds)

**QA Code Reviewer**: PASS — 0 blocking issues, 0 warnings. All three new tests use real components, cover error paths, use `t.TempDir()`, and contain substantive assertions.

**Security Engineer**: PASS — 0 blocking issues, 0 warnings. x509/crypto usage is inside `pkg/cert/` (correct location). Error messages do not leak key material or internal paths. All automated scans (security-precommit, check-architecture, security-scan) passed.

Fixes #1015

🤖 Generated with [Claude Code](https://claude.com/claude-code)