### PR TITLE
cert: fix GetCertificateInfo DaysUntilExpiration formula (Issue #1016)

### DIFF
--- a/pkg/cert/utils.go
+++ b/pkg/cert/utils.go
@@ -143,8 +143,8 @@ func GetCertificateInfo(cert *x509.Certificate) *CertificateInfo {
 		}
 	}
 
-	daysUntilExpiration := int(cert.NotAfter.Sub(cert.NotBefore).Hours() / 24)
-	if cert.NotAfter.Before(cert.NotBefore) {
+	daysUntilExpiration := int(time.Until(cert.NotAfter).Hours() / 24)
+	if daysUntilExpiration < 0 {
 		daysUntilExpiration = 0
 	}
 
@@ -154,7 +154,7 @@ func GetCertificateInfo(cert *x509.Certificate) *CertificateInfo {
 		SerialNumber:        cert.SerialNumber.String(),
 		CreatedAt:           cert.NotBefore,
 		ExpiresAt:           cert.NotAfter,
-		IsValid:             cert.NotBefore.Before(cert.NotAfter),
+		IsValid:             time.Now().Before(cert.NotAfter) && time.Now().After(cert.NotBefore),
 		Fingerprint:         GetCertificateFingerprint(cert),
 		Issuer:              cert.Issuer.CommonName,
 		DaysUntilExpiration: daysUntilExpiration,

--- a/pkg/cert/utils_test.go
+++ b/pkg/cert/utils_test.go
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+package cert
+
+import (
+	"crypto/x509"
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// makeTestCert returns a minimal *x509.Certificate with the given validity window.
+// The cert does not need to be signed for GetCertificateInfo; it only reads fields.
+func makeTestCert(notBefore, notAfter time.Time) *x509.Certificate {
+	return &x509.Certificate{
+		SerialNumber: big.NewInt(42),
+		NotBefore:    notBefore,
+		NotAfter:     notAfter,
+	}
+}
+
+func TestGetCertificateInfo_DaysUntilExpiration_IsRemainingNotLifetime(t *testing.T) {
+	// Cert issued 300 days ago, valid for 365 days → ~65 days remaining.
+	notBefore := time.Now().Add(-300 * 24 * time.Hour)
+	notAfter := notBefore.Add(365 * 24 * time.Hour)
+
+	cert := makeTestCert(notBefore, notAfter)
+	info := GetCertificateInfo(cert)
+	require.NotNil(t, info)
+
+	// Must be the remaining days (~65), not the total lifetime (365).
+	assert.InDelta(t, 65, info.DaysUntilExpiration, 1,
+		"DaysUntilExpiration should be remaining days (~65), got %d", info.DaysUntilExpiration)
+}
+
+func TestGetCertificateInfo_IsValid_ReflectsCurrentTime(t *testing.T) {
+	now := time.Now()
+
+	tests := []struct {
+		name      string
+		notBefore time.Time
+		notAfter  time.Time
+		wantValid bool
+	}{
+		{
+			name:      "currently valid",
+			notBefore: now.Add(-24 * time.Hour),
+			notAfter:  now.Add(30 * 24 * time.Hour),
+			wantValid: true,
+		},
+		{
+			name:      "expired",
+			notBefore: now.Add(-365 * 24 * time.Hour),
+			notAfter:  now.Add(-1 * time.Hour),
+			wantValid: false,
+		},
+		{
+			name:      "not yet valid",
+			notBefore: now.Add(24 * time.Hour),
+			notAfter:  now.Add(365 * 24 * time.Hour),
+			wantValid: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cert := makeTestCert(tt.notBefore, tt.notAfter)
+			info := GetCertificateInfo(cert)
+			require.NotNil(t, info)
+			assert.Equal(t, tt.wantValid, info.IsValid)
+		})
+	}
+}
+
+func TestGetCertificateInfo_NeedsRenewal(t *testing.T) {
+	now := time.Now()
+
+	// Cert expiring in 15 days → needs renewal.
+	soonCert := makeTestCert(now.Add(-350*24*time.Hour), now.Add(15*24*time.Hour))
+	info := GetCertificateInfo(soonCert)
+	require.NotNil(t, info)
+	assert.True(t, info.NeedsRenewal, "cert expiring in 15 days should need renewal")
+
+	// Cert expiring in 60 days → does not need renewal yet.
+	laterCert := makeTestCert(now.Add(-300*24*time.Hour), now.Add(60*24*time.Hour))
+	info = GetCertificateInfo(laterCert)
+	require.NotNil(t, info)
+	assert.False(t, info.NeedsRenewal, "cert expiring in 60 days should not need renewal")
+}
+
+func TestGetCertificateInfo_ExpiredCert_DaysFlooredAtZero(t *testing.T) {
+	now := time.Now()
+	cert := makeTestCert(now.Add(-365*24*time.Hour), now.Add(-1*time.Hour))
+	info := GetCertificateInfo(cert)
+	require.NotNil(t, info)
+	assert.Equal(t, 0, info.DaysUntilExpiration, "expired cert DaysUntilExpiration must be clamped to 0, not negative")
+}
+
+func TestGetCertificateInfo_NilCert(t *testing.T) {
+	assert.Nil(t, GetCertificateInfo(nil))
+}


### PR DESCRIPTION
## Summary

- `GetCertificateInfo` computed `DaysUntilExpiration` as total certificate lifetime (`NotAfter - NotBefore`) instead of remaining days until expiration — a brand-new 365-day cert and one with a day left both reported 365, making `NeedsRenewal` permanently false
- `IsValid` used `cert.NotBefore.Before(cert.NotAfter)` — a structural tautology that reported expired and not-yet-valid certs as valid
- Both fields now use `time.Now()` / `time.Until()` consistent with every other function in the package

## Changes

- `pkg/cert/utils.go` — replace `NotAfter.Sub(NotBefore)` with `time.Until(cert.NotAfter)` (clamp negative to 0); replace tautological `IsValid` with `time.Now().Before(NotAfter) && time.Now().After(NotBefore)`
- `pkg/cert/utils_test.go` — new regression tests: remaining-days vs lifetime, IsValid for valid/expired/not-yet-valid certs, expired-cert floor guard

## Test plan

- [ ] `TestGetCertificateInfo_DaysUntilExpiration_IsRemainingNotLifetime` — cert issued 300 days ago on 365-day validity asserts ~65 days remaining (±1), not 365
- [ ] `TestGetCertificateInfo_IsValid_ReflectsCurrentTime` — three subtests: currently valid, expired, not-yet-valid
- [ ] `TestGetCertificateInfo_ExpiredCert_DaysFlooredAtZero` — expired cert returns 0, not negative
- [ ] `TestGetCertificateInfo_NeedsRenewal` — 15-day cert needs renewal; 60-day cert does not
- [ ] All existing `pkg/cert/` tests pass

## Specialist Review Results

| Reviewer | Result | Notes |
|----------|--------|-------|
| QA Test Runner | **PASS** | All packages, cross-platform builds, integration tests |
| QA Code Reviewer | **PASS** | 0 blocking issues; 1 warning (explicit floor assertion) — addressed |
| Security Engineer | **PASS** | 0 blocking issues; all automated scans green |

Fixes #1016