### PR TITLE
cert: strengthen Manager.ValidateCertificate to use Validator chain (Issue #1018)

### DIFF
--- a/pkg/cert/manager.go
+++ b/pkg/cert/manager.go
@@ -356,7 +356,7 @@ func (m *Manager) GetCertificateByCommonName(commonName string) ([]*CertificateI
 
 // ValidateCertificate validates a certificate
 func (m *Manager) ValidateCertificate(certPEM []byte) (*ValidationResult, error) {
-	return m.ca.ValidateCertificate(certPEM)
+	return m.validator.ValidateCertificateFile(certPEM)
 }
 
 // GetExpiringCertificates returns certificates expiring within the specified days

--- a/pkg/cert/manager_test.go
+++ b/pkg/cert/manager_test.go
@@ -4,8 +4,15 @@ package cert
 
 import (
 	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -517,4 +524,86 @@ func TestManager_GetClientCertificate(t *testing.T) {
 	// The leaf DER bytes are different between the two generated certs.
 	assert.NotEqual(t, tlsCert1.Certificate[0], tlsCert2.Certificate[0],
 		"second call must return the newer cert after rotation")
+}
+
+func TestManager_ValidateCertificate_SignedByDifferentCA(t *testing.T) {
+	tempDir1 := t.TempDir()
+	tempDir2 := t.TempDir()
+
+	manager1, err := NewManager(&ManagerConfig{
+		StoragePath: tempDir1,
+		CAConfig:    &CAConfig{Organization: "TestOrg1", Country: "US", ValidityDays: 365},
+	})
+	require.NoError(t, err)
+
+	manager2, err := NewManager(&ManagerConfig{
+		StoragePath: tempDir2,
+		CAConfig:    &CAConfig{Organization: "TestOrg2", Country: "US", ValidityDays: 365},
+	})
+	require.NoError(t, err)
+
+	// Cert issued by manager2's CA — manager1 should reject it.
+	cert, err := manager2.GenerateServerCertificate(&ServerCertConfig{
+		CommonName:   "cross-ca-server",
+		ValidityDays: 365,
+	})
+	require.NoError(t, err)
+
+	result, err := manager1.ValidateCertificate(cert.CertificatePEM)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	assert.False(t, result.IsValid, "cert signed by a different CA must not be valid")
+	require.NotEmpty(t, result.Errors, "expected at least one error")
+	foundSig := false
+	for _, e := range result.Errors {
+		if strings.Contains(e, "signature") {
+			foundSig = true
+			break
+		}
+	}
+	assert.True(t, foundSig, "expected a signature error; got: %v", result.Errors)
+}
+
+func TestManager_ValidateCertificate_Expired(t *testing.T) {
+	tempDir := t.TempDir()
+	manager, err := NewManager(&ManagerConfig{
+		StoragePath: tempDir,
+		CAConfig:    &CAConfig{Organization: "Test", Country: "US", ValidityDays: 365},
+	})
+	require.NoError(t, err)
+
+	ca := manager.ca.(*CA)
+	expiredPEM := generateExpiredCertPEM(t, ca)
+
+	result, err := manager.ValidateCertificate(expiredPEM)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	assert.False(t, result.IsValid, "expired cert must not be valid")
+	assert.True(t, result.IsExpired, "IsExpired must be true for expired cert")
+}
+
+// generateExpiredCertPEM creates a cert signed by ca with NotAfter in the past.
+func generateExpiredCertPEM(t *testing.T, ca *CA) []byte {
+	t.Helper()
+
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	serial, err := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
+	require.NoError(t, err)
+
+	template := &x509.Certificate{
+		SerialNumber: serial,
+		Subject:      pkix.Name{CommonName: "expired-test"},
+		NotBefore:    time.Now().Add(-48 * time.Hour),
+		NotAfter:     time.Now().Add(-24 * time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+	}
+
+	certDER, err := x509.CreateCertificate(rand.Reader, template, ca.certificate, &key.PublicKey, ca.privateKey)
+	require.NoError(t, err)
+
+	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER})
 }


### PR DESCRIPTION
## Summary

- `Manager.ValidateCertificate` (manager.go:359) previously delegated to `CA.ValidateCertificate`, which only ran a manual expiry check and `cert.CheckSignatureFrom`. The stronger `Validator.ValidateCertificateFile` path — covering expiry, basic constraints, and signature verification — was already available but unused.
- Changed delegation to `m.validator.ValidateCertificateFile(certPEM)` so both call-sites (`cmd/cert-manager/main.go`, `features/terminal/auth_integration.go`) get the richer validation with no call-site changes.
- `CA.ValidateCertificate` is preserved; it still satisfies the `CAManager` interface.

## New tests

- `TestManager_ValidateCertificate_SignedByDifferentCA` — cert issued by a different CA is rejected with `IsValid: false` and a signature error.
- `TestManager_ValidateCertificate_Expired` — cert with `NotAfter` in the past returns `IsValid: false`, `IsExpired: true`.

## Specialist review results

| Reviewer | Result |
|----------|--------|
| QA Test Runner | **PASS** — all packages pass including cross-platform builds (linux/amd64, linux/arm64, darwin/amd64, darwin/arm64, windows/amd64) |
| QA Code Reviewer | **PASS** — no mocks, no skips, no empty assertions, no workarounds |
| Security Engineer | **PASS** — `make check-architecture`, `make security-precommit`, `make security-scan` all clean; crypto uses `crypto/rand.Reader`, RSA-2048, no insecure defaults |

## Test plan

- [x] `go test ./pkg/cert/... -race` passes
- [x] `make test-agent-complete` passes
- [x] Cross-platform compilation verified
- [x] Two new tests exercise both failure modes (wrong CA, expired cert)

Fixes #1018

🤖 Generated with [Claude Code](https://claude.com/claude-code)