### PR TITLE
cert: gate RSA key-size warning on actual bit length (Issue #1019)

### DIFF
--- a/pkg/cert/validator.go
+++ b/pkg/cert/validator.go
@@ -3,6 +3,7 @@
 package cert
 
 import (
+	"crypto/rsa"
 	"crypto/x509"
 	"fmt"
 	"strings"
@@ -257,9 +258,10 @@ func (v *Validator) validateBasicConstraints(cert *x509.Certificate, result *Val
 
 	// Check key size (for RSA keys)
 	if cert.PublicKeyAlgorithm == x509.RSA {
-		// This is a simplified check - in practice you'd need to cast to *rsa.PublicKey
-		// and check the key size properly
-		result.Warnings = append(result.Warnings, "consider verifying RSA key size is adequate (2048+ bits)")
+		if rsaKey, ok := cert.PublicKey.(*rsa.PublicKey); ok && rsaKey.N.BitLen() < 2048 {
+			result.Warnings = append(result.Warnings,
+				fmt.Sprintf("RSA key size %d bits is below minimum recommended 2048 bits", rsaKey.N.BitLen()))
+		}
 	}
 
 	return nil

--- a/pkg/cert/validator_test.go
+++ b/pkg/cert/validator_test.go
@@ -1,0 +1,129 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+package cert
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"math/big"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// generateSelfSignedRSA creates a minimal self-signed RSA cert with the given key size.
+func generateSelfSignedRSA(t *testing.T, bits int) *x509.Certificate {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, bits)
+	require.NoError(t, err)
+
+	template := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "test"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(24 * time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+	}
+	derBytes, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+	require.NoError(t, err)
+	cert, err := x509.ParseCertificate(derBytes)
+	require.NoError(t, err)
+	return cert
+}
+
+// generateSelfSignedEC creates a minimal self-signed EC P-256 cert.
+func generateSelfSignedEC(t *testing.T) *x509.Certificate {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	template := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "test"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(24 * time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+	}
+	derBytes, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+	require.NoError(t, err)
+	cert, err := x509.ParseCertificate(derBytes)
+	require.NoError(t, err)
+	return cert
+}
+
+func hasRSAKeySizeWarning(warnings []string) bool {
+	for _, w := range warnings {
+		if strings.Contains(w, "RSA key size") {
+			return true
+		}
+	}
+	return false
+}
+
+func TestValidateBasicConstraints_RSAKeySize(t *testing.T) {
+	tests := []struct {
+		name        string
+		cert        func() *x509.Certificate
+		wantWarning bool
+	}{
+		{
+			name:        "2048-bit RSA cert emits no warning",
+			cert:        func() *x509.Certificate { return generateSelfSignedRSA(t, 2048) },
+			wantWarning: false,
+		},
+		{
+			name:        "4096-bit RSA cert emits no warning",
+			cert:        func() *x509.Certificate { return generateSelfSignedRSA(t, 4096) },
+			wantWarning: false,
+		},
+		{
+			name:        "1024-bit RSA cert emits warning",
+			cert:        func() *x509.Certificate { return generateSelfSignedRSA(t, 1024) },
+			wantWarning: true,
+		},
+		{
+			name:        "EC P-256 cert emits no RSA warning",
+			cert:        func() *x509.Certificate { return generateSelfSignedEC(t) },
+			wantWarning: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			v := NewValidator(nil)
+			result, err := v.ValidateCertificate(tt.cert())
+			require.NoError(t, err)
+			require.NotNil(t, result)
+			assert.True(t, result.IsValid, "cert should be valid regardless of key size; warnings: %v", result.Warnings)
+
+			gotWarning := hasRSAKeySizeWarning(result.Warnings)
+			if tt.wantWarning {
+				assert.True(t, gotWarning, "expected RSA key-size warning but got none; warnings: %v", result.Warnings)
+			} else {
+				assert.False(t, gotWarning, "unexpected RSA key-size warning; warnings: %v", result.Warnings)
+			}
+		})
+	}
+}
+
+func TestValidateBasicConstraints_RSAWarningSaysActualBitLen(t *testing.T) {
+	v := NewValidator(nil)
+	cert := generateSelfSignedRSA(t, 1024)
+	result, err := v.ValidateCertificate(cert)
+	require.NoError(t, err)
+
+	found := false
+	for _, w := range result.Warnings {
+		if strings.Contains(w, "1024") {
+			found = true
+		}
+	}
+	assert.True(t, found, "warning should include actual bit length 1024; warnings: %v", result.Warnings)
+}


### PR DESCRIPTION
## Summary

- `validateBasicConstraints` previously warned on every RSA certificate regardless of key size; a 4096-bit cert was indistinguishable from a 512-bit one
- Cast `cert.PublicKey` to `*rsa.PublicKey` and check `N.BitLen() < 2048`; only emit the warning when the key is genuinely weak, with the exact bit count in the message
- Added `pkg/cert/validator_test.go` covering 2048-bit RSA (no warn), 4096-bit RSA (no warn), 1024-bit RSA (warn with bit length), EC P-256 (no RSA warn)

## Specialist Review Results

- **QA Test Runner**: pkg/cert PASS — all cert tests pass; one unrelated pre-existing flaky test in `features/monitoring/export` confirmed to pass on `develop` independently
- **QA Code Reviewer**: PASS — no blocking issues; style warnings addressed (switched to `strings.Contains`, added `result.IsValid` assertions)
- **Security Engineer**: PASS — no security issues; automated scans (security-precommit, check-architecture, security-scan) all clean

## Test plan

- [ ] `go test ./pkg/cert/... -race` — all pass
- [ ] Verify 1024-bit RSA warning message contains actual bit count
- [ ] Verify 2048-bit and 4096-bit RSA certs produce no RSA key-size warning
- [ ] Verify EC P-256 cert produces no RSA key-size warning

Fixes #1019

🤖 Generated with [Claude Code](https://claude.com/claude-code)