### PR TITLE
rbac: enforce ValidateSensitiveOperation on all sensitive manager paths (Issue #974)

### DIFF
--- a/features/controller/api/handlers_rbac.go
+++ b/features/controller/api/handlers_rbac.go
@@ -3,7 +3,6 @@
 package api
 
 import (
-	"context"
 	"encoding/json"
 	"net/http"
 	"time"
@@ -12,6 +11,7 @@ import (
 
 	"github.com/cfgis/cfgms/api/proto/common"
 	controller "github.com/cfgis/cfgms/api/proto/controller"
+	"github.com/cfgis/cfgms/features/rbac"
 	"github.com/cfgis/cfgms/pkg/ctxkeys"
 )
 
@@ -31,7 +31,7 @@ func (s *Server) handleListPermissions(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Call gRPC service
-	resp, err := s.rbacService.ListPermissions(context.Background(), req)
+	resp, err := s.rbacService.ListPermissions(r.Context(), req)
 	if err != nil {
 		s.logger.Error("Failed to list permissions", "error", err)
 		s.writeErrorResponse(w, http.StatusInternalServerError, "Failed to list permissions", "INTERNAL_ERROR")
@@ -74,7 +74,7 @@ func (s *Server) handleGetPermission(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Call gRPC service
-	resp, err := s.rbacService.GetPermission(context.Background(), req)
+	resp, err := s.rbacService.GetPermission(r.Context(), req)
 	if err != nil {
 		s.logger.Error("Failed to get permission", "permission_id", permissionID, "error", err)
 		s.writeErrorResponse(w, http.StatusNotFound, "Permission not found", "PERMISSION_NOT_FOUND")
@@ -112,7 +112,7 @@ func (s *Server) handleListRoles(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Call gRPC service
-	resp, err := s.rbacService.ListRoles(context.Background(), req)
+	resp, err := s.rbacService.ListRoles(r.Context(), req)
 	if err != nil {
 		s.logger.Error("Failed to list roles", "error", err)
 		s.writeErrorResponse(w, http.StatusInternalServerError, "Failed to list roles", "INTERNAL_ERROR")
@@ -166,8 +166,14 @@ func (s *Server) handleCreateRole(w http.ResponseWriter, r *http.Request) {
 		},
 	}
 
+	// M-AUTH-2: Inject justification from X-Justification HTTP header when present.
+	ctx := r.Context()
+	if justification := r.Header.Get("X-Justification"); justification != "" {
+		ctx = rbac.WithSensitiveOperationJustification(ctx, justification)
+	}
+
 	// Call gRPC service
-	resp, err := s.rbacService.CreateRole(context.Background(), req)
+	resp, err := s.rbacService.CreateRole(ctx, req)
 	if err != nil {
 		s.logger.Error("Failed to create role", "name", roleInfo.Name, "error", err)
 		s.writeErrorResponse(w, http.StatusInternalServerError, "Failed to create role", "INTERNAL_ERROR")
@@ -209,7 +215,7 @@ func (s *Server) handleGetRole(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Call gRPC service
-	resp, err := s.rbacService.GetRole(context.Background(), req)
+	resp, err := s.rbacService.GetRole(r.Context(), req)
 	if err != nil {
 		s.logger.Error("Failed to get role", "role_id", roleID, "error", err)
 		s.writeErrorResponse(w, http.StatusNotFound, "Role not found", "ROLE_NOT_FOUND")
@@ -266,8 +272,14 @@ func (s *Server) handleUpdateRole(w http.ResponseWriter, r *http.Request) {
 		},
 	}
 
+	// M-AUTH-2: Inject justification from X-Justification HTTP header when present.
+	ctx := r.Context()
+	if justification := r.Header.Get("X-Justification"); justification != "" {
+		ctx = rbac.WithSensitiveOperationJustification(ctx, justification)
+	}
+
 	// Call gRPC service
-	resp, err := s.rbacService.UpdateRole(context.Background(), req)
+	resp, err := s.rbacService.UpdateRole(ctx, req)
 	if err != nil {
 		s.logger.Error("Failed to update role", "role_id", roleID, "error", err)
 		s.writeErrorResponse(w, http.StatusInternalServerError, "Failed to update role", "INTERNAL_ERROR")
@@ -308,8 +320,14 @@ func (s *Server) handleDeleteRole(w http.ResponseWriter, r *http.Request) {
 		RoleId: roleID,
 	}
 
+	// M-AUTH-2: Inject justification from X-Justification HTTP header when present.
+	ctx := r.Context()
+	if justification := r.Header.Get("X-Justification"); justification != "" {
+		ctx = rbac.WithSensitiveOperationJustification(ctx, justification)
+	}
+
 	// Call gRPC service
-	resp, err := s.rbacService.DeleteRole(context.Background(), req)
+	resp, err := s.rbacService.DeleteRole(ctx, req)
 	if err != nil {
 		s.logger.Error("Failed to delete role", "role_id", roleID, "error", err)
 		s.writeErrorResponse(w, http.StatusInternalServerError, "Failed to delete role", "INTERNAL_ERROR")

--- a/features/controller/api/handlers_rbac_test.go
+++ b/features/controller/api/handlers_rbac_test.go
@@ -14,13 +14,15 @@ import (
 
 	"github.com/cfgis/cfgms/api/proto/common"
 	controller "github.com/cfgis/cfgms/api/proto/controller"
+	"github.com/cfgis/cfgms/features/rbac"
 	"github.com/cfgis/cfgms/pkg/ctxkeys"
 )
 
 // createRoleForTenant creates a role for a specific tenant via the RBAC service.
 func createRoleForTenant(t *testing.T, server *Server, tenantID, roleID, roleName string) {
 	t.Helper()
-	ctx := context.Background()
+	// M-AUTH-2: CreateRole requires justification in context
+	ctx := rbac.WithSensitiveOperationJustification(context.Background(), "test: role setup for RBAC handler test")
 	_, err := server.rbacService.CreateRole(ctx, &controller.CreateRoleRequest{
 		Role: &common.Role{
 			Id:          roleID,

--- a/features/controller/service/rbac_service.go
+++ b/features/controller/service/rbac_service.go
@@ -6,10 +6,33 @@ import (
 	"context"
 	"fmt"
 
+	"google.golang.org/grpc/metadata"
+
 	"github.com/cfgis/cfgms/api/proto/controller"
 	"github.com/cfgis/cfgms/features/rbac"
 	"github.com/cfgis/cfgms/features/rbac/memory"
 )
+
+// injectJustification extracts a sensitive-operation justification from gRPC incoming
+// metadata (key "x-justification") and adds it to the context via
+// rbac.WithSensitiveOperationJustification. Callers that already carry justification
+// in ctx (e.g. test helpers) are unaffected — the context value set by the caller
+// takes precedence because rbac.GetSensitiveOperationJustification reads it directly.
+func injectJustification(ctx context.Context) context.Context {
+	// Already has justification — don't overwrite.
+	if rbac.GetSensitiveOperationJustification(ctx) != "" {
+		return ctx
+	}
+	md, ok := metadata.FromIncomingContext(ctx)
+	if !ok {
+		return ctx
+	}
+	vals := md.Get("x-justification")
+	if len(vals) == 0 {
+		return ctx
+	}
+	return rbac.WithSensitiveOperationJustification(ctx, vals[0])
+}
 
 // RBACService implements the RBAC service
 type RBACService struct {
@@ -62,6 +85,8 @@ func (s *RBACService) CreateRole(ctx context.Context, req *controller.CreateRole
 		return nil, fmt.Errorf("role.id is required")
 	}
 
+	// M-AUTH-2: surface justification from gRPC metadata when not already in ctx.
+	ctx = injectJustification(ctx)
 	err := s.rbacManager.CreateRole(ctx, req.Role)
 	if err != nil {
 		return nil, fmt.Errorf("role already exists: %w", err)
@@ -107,6 +132,8 @@ func (s *RBACService) UpdateRole(ctx context.Context, req *controller.UpdateRole
 		return nil, fmt.Errorf("role.id is required")
 	}
 
+	// M-AUTH-2: surface justification from gRPC metadata when not already in ctx.
+	ctx = injectJustification(ctx)
 	err := s.rbacManager.UpdateRole(ctx, req.Role)
 	if err != nil {
 		return nil, fmt.Errorf("%w", err)
@@ -233,6 +260,8 @@ func (s *RBACService) AssignRole(ctx context.Context, req *controller.AssignRole
 		return nil, fmt.Errorf("assignment.role_id is required")
 	}
 
+	// M-AUTH-2: surface justification from gRPC metadata when not already in ctx.
+	ctx = injectJustification(ctx)
 	err := s.rbacManager.AssignRole(ctx, req.Assignment)
 	if err != nil {
 		return nil, fmt.Errorf("%w", err)
@@ -252,6 +281,8 @@ func (s *RBACService) RevokeRole(ctx context.Context, req *controller.RevokeRole
 		return nil, fmt.Errorf("role_id is required")
 	}
 
+	// M-AUTH-2: surface justification from gRPC metadata when not already in ctx.
+	ctx = injectJustification(ctx)
 	err := s.rbacManager.RevokeRole(ctx, req.SubjectId, req.RoleId, req.TenantId)
 	if err != nil {
 		return nil, fmt.Errorf("%w", err)
@@ -328,6 +359,8 @@ func (s *RBACService) CreateRoleWithParent(ctx context.Context, req *controller.
 		return nil, fmt.Errorf("role.id is required")
 	}
 
+	// M-AUTH-2: surface justification from gRPC metadata when not already in ctx.
+	ctx = injectJustification(ctx)
 	err := s.rbacManager.CreateRoleWithParent(ctx, req.Role, req.ParentRoleId, req.InheritanceType)
 	if err != nil {
 		return nil, fmt.Errorf("%w", err)

--- a/features/controller/service/rbac_service_test.go
+++ b/features/controller/service/rbac_service_test.go
@@ -33,6 +33,8 @@ func TestRBACService_Integration(t *testing.T) {
 		storageManager.GetRBACStore(),
 	)
 	ctx := context.Background()
+	// M-AUTH-2: inject justification so sensitive RBAC operations pass the gate
+	ctx = rbac.WithSensitiveOperationJustification(ctx, "test: RBAC service integration")
 
 	err = rbacManager.Initialize(ctx)
 	require.NoError(t, err)

--- a/features/rbac/advanced_permissions_test.go
+++ b/features/rbac/advanced_permissions_test.go
@@ -37,6 +37,8 @@ func TestAdvancedPermissionManagement(t *testing.T) {
 		_ = manager.Close(ctx)
 	})
 	ctx := context.Background()
+	// M-AUTH-2: sensitive operations require justification in context
+	ctx = WithSensitiveOperationJustification(ctx, "test: advanced permission management")
 
 	err = manager.Initialize(ctx)
 	require.NoError(t, err)

--- a/features/rbac/audit_integration_test.go
+++ b/features/rbac/audit_integration_test.go
@@ -42,6 +42,8 @@ func TestRBACManager_AuditIntegration(t *testing.T) {
 	require.NotNil(t, manager.auditManager)
 
 	ctx := context.Background()
+	// M-AUTH-2: sensitive operations require justification in context
+	ctx = WithSensitiveOperationJustification(ctx, "test: RBAC audit integration")
 	err = manager.Initialize(ctx)
 	require.NoError(t, err)
 
@@ -342,6 +344,8 @@ func TestRBACManager_AuditFailureHandling(t *testing.T) {
 	require.NotNil(t, manager)
 
 	ctx := context.Background()
+	// M-AUTH-2: sensitive operations require justification in context
+	ctx = WithSensitiveOperationJustification(ctx, "test: audit failure handling")
 	err = manager.Initialize(ctx)
 	require.NoError(t, err)
 

--- a/features/rbac/delegation_test.go
+++ b/features/rbac/delegation_test.go
@@ -62,7 +62,9 @@ func createTestSubjectWithAdmin(t *testing.T, ctx context.Context, manager *Mana
 		RoleId:    "system.admin",
 		TenantId:  "root",
 	}
-	require.NoError(t, manager.AssignRole(ctx, assignment))
+	// M-AUTH-2: AssignRole requires justification in context
+	ctxJ := WithSensitiveOperationJustification(ctx, "test: system admin role setup for delegation test subject")
+	require.NoError(t, manager.AssignRole(ctxJ, assignment))
 }
 
 // createTestSubjectBasic creates a delegatee subject with no special roles.

--- a/features/rbac/jit/integration.go
+++ b/features/rbac/jit/integration.go
@@ -425,8 +425,12 @@ func (jim *JITIntegrationManager) initializeJITPermissions(ctx context.Context) 
 		},
 	}
 
+	// Inject system justification for the M-AUTH-2 sensitive-operation gate.
+	// TODO(#742): SubjectID should be plumbed from auth context once that infrastructure exists.
+	ctxWithJustification := rbac.WithSensitiveOperationJustification(ctx,
+		"system: JIT integration initialization — creating JIT-specific permissions")
 	for _, permission := range jitPermissions {
-		if err := jim.rbacManager.CreatePermission(ctx, permission); err != nil {
+		if err := jim.rbacManager.CreatePermission(ctxWithJustification, permission); err != nil {
 			// Permission might already exist, which is okay
 			continue
 		}
@@ -472,8 +476,12 @@ func (jim *JITIntegrationManager) initializeJITRoles(ctx context.Context) error 
 		},
 	}
 
+	// Inject system justification for the M-AUTH-2 sensitive-operation gate.
+	// TODO(#742): SubjectID should be plumbed from auth context once that infrastructure exists.
+	ctxWithJustification := rbac.WithSensitiveOperationJustification(ctx,
+		"system: JIT integration initialization — creating JIT-specific roles")
 	for _, role := range jitRoles {
-		if err := jim.rbacManager.CreateRole(ctx, role); err != nil {
+		if err := jim.rbacManager.CreateRole(ctxWithJustification, role); err != nil {
 			// Role might already exist, which is okay
 			continue
 		}

--- a/features/rbac/manager.go
+++ b/features/rbac/manager.go
@@ -270,7 +270,8 @@ func (m *Manager) loadDefaultRoles(ctx context.Context) error {
 	return nil
 }
 
-// CreateTenantDefaultRoles creates default roles for a new tenant
+// CreateTenantDefaultRoles creates default roles for a new tenant.
+// Internal path: bypasses ValidateSensitiveOperation by calling store.LoadRoles directly.
 func (m *Manager) CreateTenantDefaultRoles(ctx context.Context, tenantID string) error {
 	tenantRoles := make([]*common.Role, 0)
 	for _, template := range GetTenantRoleTemplates() {
@@ -291,6 +292,21 @@ func (m *Manager) CreateTenantDefaultRoles(ctx context.Context, tenantID string)
 
 // Permission Store Methods
 func (m *Manager) CreatePermission(ctx context.Context, permission *common.Permission) error {
+	// M-AUTH-2: Validate justification for sensitive operation (security audit finding)
+	justification := GetSensitiveOperationJustification(ctx)
+	opCtx := &SensitiveOperationContext{
+		OperationType: SensitiveOpCreatePermission,
+		// TODO(#742): SubjectID should be plumbed from auth context once that infrastructure exists.
+		SubjectID:     "system",
+		TenantID:      "system",
+		ResourceID:    permission.Id,
+		Justification: justification,
+	}
+	if validateErr := ValidateSensitiveOperation(opCtx); validateErr != nil {
+		m.AuditSensitiveOperation(ctx, opCtx, business.AuditResultError, validateErr)
+		return validateErr
+	}
+
 	// Write-through: persist to both ephemeral and persistent storage
 	if err := m.store.CreatePermission(ctx, permission); err != nil {
 		return err
@@ -333,6 +349,21 @@ func (m *Manager) UpdatePermission(ctx context.Context, permission *common.Permi
 }
 
 func (m *Manager) DeletePermission(ctx context.Context, id string) error {
+	// M-AUTH-2: Validate justification for sensitive operation (security audit finding)
+	justification := GetSensitiveOperationJustification(ctx)
+	opCtx := &SensitiveOperationContext{
+		OperationType: SensitiveOpDeletePermission,
+		// TODO(#742): SubjectID should be plumbed from auth context once that infrastructure exists.
+		SubjectID:     "system",
+		TenantID:      "system",
+		ResourceID:    id,
+		Justification: justification,
+	}
+	if validateErr := ValidateSensitiveOperation(opCtx); validateErr != nil {
+		m.AuditSensitiveOperation(ctx, opCtx, business.AuditResultError, validateErr)
+		return validateErr
+	}
+
 	// Write-through: remove from both ephemeral and persistent storage
 	if err := m.store.DeletePermission(ctx, id); err != nil {
 		return err
@@ -350,6 +381,21 @@ func (m *Manager) DeletePermission(ctx context.Context, id string) error {
 
 // Role Store Methods
 func (m *Manager) CreateRole(ctx context.Context, role *common.Role) error {
+	// M-AUTH-2: Validate justification for sensitive operation (security audit finding)
+	justification := GetSensitiveOperationJustification(ctx)
+	opCtx := &SensitiveOperationContext{
+		OperationType: SensitiveOpCreateRole,
+		// TODO(#742): SubjectID should be plumbed from auth context once that infrastructure exists.
+		SubjectID:     "system",
+		TenantID:      role.TenantId,
+		ResourceID:    role.Id,
+		Justification: justification,
+	}
+	if validateErr := ValidateSensitiveOperation(opCtx); validateErr != nil {
+		m.AuditSensitiveOperation(ctx, opCtx, business.AuditResultError, validateErr)
+		return validateErr
+	}
+
 	// M-TENANT-2: Validate tenant boundary for role inheritance (security audit finding)
 	// Prevent cross-tenant role inheritance which could allow privilege escalation across tenants
 	if role.ParentRoleId != "" {
@@ -458,6 +504,21 @@ func (m *Manager) ListRoles(ctx context.Context, tenantID string) ([]*common.Rol
 }
 
 func (m *Manager) UpdateRole(ctx context.Context, role *common.Role) error {
+	// M-AUTH-2: Validate justification for sensitive operation (security audit finding)
+	justification := GetSensitiveOperationJustification(ctx)
+	opCtx := &SensitiveOperationContext{
+		OperationType: SensitiveOpModifyRole,
+		// TODO(#742): SubjectID should be plumbed from auth context once that infrastructure exists.
+		SubjectID:     "system",
+		TenantID:      role.TenantId,
+		ResourceID:    role.Id,
+		Justification: justification,
+	}
+	if validateErr := ValidateSensitiveOperation(opCtx); validateErr != nil {
+		m.AuditSensitiveOperation(ctx, opCtx, business.AuditResultError, validateErr)
+		return validateErr
+	}
+
 	// Get the old role for change tracking
 	var oldRole *common.Role
 	if m.auditManager != nil {
@@ -735,6 +796,7 @@ func (m *Manager) DeleteRolesByTenant(ctx context.Context, tenantID string) erro
 		if role.IsSystemRole || role.TenantId != tenantID {
 			continue
 		}
+		// DeleteRole enforces ValidateSensitiveOperation; ctxWithJustification satisfies the gate.
 		if delErr := m.DeleteRole(ctxWithJustification, role.Id); delErr != nil {
 			slog.Warn("rbac: failed to delete role during tenant cascade cleanup",
 				"tenant_id", tenantID,
@@ -765,11 +827,41 @@ func (m *Manager) GetSubjectRoles(ctx context.Context, subjectID string, tenantI
 
 // Role Assignment Store Methods
 func (m *Manager) AssignRole(ctx context.Context, assignment *common.RoleAssignment) error {
+	// M-AUTH-2: Validate justification for sensitive operation (security audit finding)
+	justification := GetSensitiveOperationJustification(ctx)
+	opCtx := &SensitiveOperationContext{
+		OperationType: SensitiveOpAssignRole,
+		// TODO(#742): SubjectID should be plumbed from auth context once that infrastructure exists.
+		SubjectID:     "system",
+		TenantID:      assignment.TenantId,
+		ResourceID:    assignment.SubjectId,
+		Justification: justification,
+	}
+	if validateErr := ValidateSensitiveOperation(opCtx); validateErr != nil {
+		m.AuditSensitiveOperation(ctx, opCtx, business.AuditResultError, validateErr)
+		return validateErr
+	}
+
 	// Use escalation prevention manager for enhanced security
 	return m.escalationPreventionMgr.ValidateAndAssignRole(ctx, assignment)
 }
 
 func (m *Manager) RevokeRole(ctx context.Context, subjectID, roleID, tenantID string) error {
+	// M-AUTH-2: Validate justification for sensitive operation (security audit finding)
+	justification := GetSensitiveOperationJustification(ctx)
+	opCtx := &SensitiveOperationContext{
+		OperationType: SensitiveOpRevokeRole,
+		// TODO(#742): SubjectID should be plumbed from auth context once that infrastructure exists.
+		SubjectID:     "system",
+		TenantID:      tenantID,
+		ResourceID:    subjectID,
+		Justification: justification,
+	}
+	if validateErr := ValidateSensitiveOperation(opCtx); validateErr != nil {
+		m.AuditSensitiveOperation(ctx, opCtx, business.AuditResultError, validateErr)
+		return validateErr
+	}
+
 	// Write-through: remove from both ephemeral and persistent storage
 	err := m.store.RevokeRole(ctx, subjectID, roleID, tenantID)
 	if err != nil {
@@ -879,14 +971,16 @@ func (m *Manager) CreateStewardSubject(ctx context.Context, stewardID, tenantID 
 		return err
 	}
 
-	// Assign steward service role
+	// Assign steward service role; inject system justification for the M-AUTH-2 gate.
+	// TODO(#742): SubjectID should be plumbed from auth context once that infrastructure exists.
+	ctxWithJustification := WithSensitiveOperationJustification(ctx, "system: steward service account automated role assignment during registration")
 	assignment := &common.RoleAssignment{
 		SubjectId: stewardID,
 		RoleId:    "steward.service",
 		TenantId:  tenantID,
 	}
 
-	return m.AssignRole(ctx, assignment)
+	return m.AssignRole(ctxWithJustification, assignment)
 }
 
 // CreateServiceSubject creates a subject for a service account
@@ -907,7 +1001,9 @@ func (m *Manager) CreateServiceSubject(ctx context.Context, serviceID, serviceNa
 		return err
 	}
 
-	// Assign requested roles
+	// Assign requested roles; inject system justification for the M-AUTH-2 gate.
+	// TODO(#742): SubjectID should be plumbed from auth context once that infrastructure exists.
+	ctxWithJustification := WithSensitiveOperationJustification(ctx, "system: service account automated role assignment during subject creation")
 	for _, roleID := range roleIDs {
 		assignment := &common.RoleAssignment{
 			SubjectId: serviceID,
@@ -915,7 +1011,7 @@ func (m *Manager) CreateServiceSubject(ctx context.Context, serviceID, serviceNa
 			TenantId:  tenantID,
 		}
 
-		if err := m.AssignRole(ctx, assignment); err != nil {
+		if err := m.AssignRole(ctxWithJustification, assignment); err != nil {
 			return err
 		}
 	}

--- a/features/rbac/manager_hierarchy_test.go
+++ b/features/rbac/manager_hierarchy_test.go
@@ -41,6 +41,9 @@ func TestManager_CreateRoleWithParent(t *testing.T) {
 	err = manager.Initialize(ctx)
 	require.NoError(t, err)
 
+	// M-AUTH-2: sensitive operations require justification in context
+	ctxJ := WithSensitiveOperationJustification(ctx, "test: create role with parent for hierarchy validation")
+
 	// Create parent role first
 	parentRole := &common.Role{
 		Id:              "parent.test",
@@ -51,7 +54,7 @@ func TestManager_CreateRoleWithParent(t *testing.T) {
 		TenantId:        "tenant-1",
 		InheritanceType: common.RoleInheritanceType_ROLE_INHERITANCE_NONE,
 	}
-	require.NoError(t, manager.CreateRole(ctx, parentRole))
+	require.NoError(t, manager.CreateRole(ctxJ, parentRole))
 
 	tests := []struct {
 		name            string
@@ -123,7 +126,7 @@ func TestManager_CreateRoleWithParent(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := manager.CreateRoleWithParent(ctx, tt.role, tt.parentRoleID, tt.inheritanceType)
+			err := manager.CreateRoleWithParent(ctxJ, tt.role, tt.parentRoleID, tt.inheritanceType)
 
 			if tt.expectError {
 				assert.Error(t, err)
@@ -277,6 +280,9 @@ func TestManager_SetAndRemoveRoleParent(t *testing.T) {
 	err = manager.Initialize(ctx)
 	require.NoError(t, err)
 
+	// M-AUTH-2: sensitive operations require justification in context
+	ctxJ := WithSensitiveOperationJustification(ctx, "test: create roles for set/remove parent validation")
+
 	// Create test roles
 	parentRole := &common.Role{
 		Id:            "parent.role",
@@ -284,7 +290,7 @@ func TestManager_SetAndRemoveRoleParent(t *testing.T) {
 		PermissionIds: []string{},
 		TenantId:      "tenant-1",
 	}
-	require.NoError(t, manager.CreateRole(ctx, parentRole))
+	require.NoError(t, manager.CreateRole(ctxJ, parentRole))
 
 	childRole := &common.Role{
 		Id:            "child.role",
@@ -292,7 +298,7 @@ func TestManager_SetAndRemoveRoleParent(t *testing.T) {
 		PermissionIds: []string{},
 		TenantId:      "tenant-1",
 	}
-	require.NoError(t, manager.CreateRole(ctx, childRole))
+	require.NoError(t, manager.CreateRole(ctxJ, childRole))
 
 	// Test SetRoleParent
 	t.Run("Set role parent", func(t *testing.T) {
@@ -426,11 +432,14 @@ func TestManager_ValidateHierarchyOperation(t *testing.T) {
 	err = manager.Initialize(ctx)
 	require.NoError(t, err)
 
+	// M-AUTH-2: sensitive operations require justification in context
+	ctxJ := WithSensitiveOperationJustification(ctx, "test: create roles for hierarchy operation validation")
+
 	// Create roles for testing
 	role1 := &common.Role{Id: "role1", Name: "Role 1", TenantId: "tenant-1"}
 	role2 := &common.Role{Id: "role2", Name: "Role 2", TenantId: "tenant-1"}
-	require.NoError(t, manager.CreateRole(ctx, role1))
-	require.NoError(t, manager.CreateRole(ctx, role2))
+	require.NoError(t, manager.CreateRole(ctxJ, role1))
+	require.NoError(t, manager.CreateRole(ctxJ, role2))
 
 	tests := []struct {
 		name         string
@@ -474,6 +483,8 @@ func TestManager_ValidateHierarchyOperation(t *testing.T) {
 
 func setupManagerHierarchyTestData(t *testing.T, manager *Manager) {
 	ctx := context.Background()
+	// M-AUTH-2: sensitive operations require justification in context
+	ctx = WithSensitiveOperationJustification(ctx, "test: setup hierarchy test data")
 
 	// Create a 3-level hierarchy: root -> middle -> leaf
 	roles := []*common.Role{
@@ -515,6 +526,8 @@ func setupManagerHierarchyTestData(t *testing.T, manager *Manager) {
 
 func setupManagerPermissionTestData(t *testing.T, manager *Manager) {
 	ctx := context.Background()
+	// M-AUTH-2: sensitive operations require justification in context
+	ctx = WithSensitiveOperationJustification(ctx, "test: setup permission test data")
 
 	// Create permissions
 	permissions := []*common.Permission{

--- a/features/rbac/manager_storage_test.go
+++ b/features/rbac/manager_storage_test.go
@@ -65,6 +65,8 @@ func TestNewManagerWithStorage(t *testing.T) {
 
 			// Verify manager initializes correctly with pluggable storage
 			ctx := context.Background()
+			// M-AUTH-2: sensitive operations require justification in context
+			ctx = WithSensitiveOperationJustification(ctx, "test: storage backend operations")
 			err = manager.Initialize(ctx)
 			require.NoError(t, err)
 
@@ -178,6 +180,8 @@ func TestManagerWithStorage_TenantIsolation(t *testing.T) {
 	require.NotNil(t, manager)
 
 	ctx := context.Background()
+	// M-AUTH-2: sensitive operations require justification in context
+	ctx = WithSensitiveOperationJustification(ctx, "test: tenant isolation operations")
 	err = manager.Initialize(ctx)
 	require.NoError(t, err)
 
@@ -252,6 +256,8 @@ func TestManagerWithStorage_AuditTrail(t *testing.T) {
 	require.NotNil(t, manager)
 
 	ctx := context.Background()
+	// M-AUTH-2: sensitive operations require justification in context
+	ctx = WithSensitiveOperationJustification(ctx, "test: audit trail operations")
 	err = manager.Initialize(ctx)
 	require.NoError(t, err)
 

--- a/features/rbac/manager_test.go
+++ b/features/rbac/manager_test.go
@@ -215,6 +215,9 @@ func TestManager_RoleAssignment(t *testing.T) {
 	err = manager.CreateSubject(ctx, subject)
 	require.NoError(t, err)
 
+	// M-AUTH-2: sensitive operations require justification in context
+	ctxJ := WithSensitiveOperationJustification(ctx, "test: role assignment management for rbac validation")
+
 	// Assign a role
 	assignment := &common.RoleAssignment{
 		SubjectId: "test-user-1",
@@ -222,7 +225,7 @@ func TestManager_RoleAssignment(t *testing.T) {
 		TenantId:  tenantID,
 	}
 
-	err = manager.AssignRole(ctx, assignment)
+	err = manager.AssignRole(ctxJ, assignment)
 	require.NoError(t, err)
 
 	// Verify role assignment
@@ -237,7 +240,7 @@ func TestManager_RoleAssignment(t *testing.T) {
 	assert.Len(t, assignments, 1)
 
 	// Revoke role
-	err = manager.RevokeRole(ctx, "test-user-1", tenantID+".tenant.admin", tenantID)
+	err = manager.RevokeRole(ctxJ, "test-user-1", tenantID+".tenant.admin", tenantID)
 	require.NoError(t, err)
 
 	// Verify role was revoked
@@ -284,6 +287,9 @@ func TestManager_PermissionChecking(t *testing.T) {
 	err = manager.CreateSubject(ctx, subject)
 	require.NoError(t, err)
 
+	// M-AUTH-2: sensitive operations require justification in context
+	ctxJ := WithSensitiveOperationJustification(ctx, "test: assign role for permission checking validation")
+
 	// Assign tenant admin role
 	assignment := &common.RoleAssignment{
 		SubjectId: "test-user-1",
@@ -291,7 +297,7 @@ func TestManager_PermissionChecking(t *testing.T) {
 		TenantId:  tenantID,
 	}
 
-	err = manager.AssignRole(ctx, assignment)
+	err = manager.AssignRole(ctxJ, assignment)
 	require.NoError(t, err)
 
 	// Test permission checking
@@ -371,6 +377,9 @@ func TestManager_SystemAdminPermissions(t *testing.T) {
 	err = manager.CreateSubject(ctx, subject)
 	require.NoError(t, err)
 
+	// M-AUTH-2: sensitive operations require justification in context
+	ctxJ := WithSensitiveOperationJustification(ctx, "test: assign system admin role for permission validation")
+
 	// Assign system admin role
 	assignment := &common.RoleAssignment{
 		SubjectId: "system-admin",
@@ -378,7 +387,7 @@ func TestManager_SystemAdminPermissions(t *testing.T) {
 		TenantId:  "root",
 	}
 
-	err = manager.AssignRole(ctx, assignment)
+	err = manager.AssignRole(ctxJ, assignment)
 	require.NoError(t, err)
 
 	// System admin should have access to everything
@@ -508,6 +517,9 @@ func TestManager_InactiveSubjectPermissions(t *testing.T) {
 	err = manager.CreateSubject(ctx, subject)
 	require.NoError(t, err)
 
+	// M-AUTH-2: sensitive operations require justification in context
+	ctxJ := WithSensitiveOperationJustification(ctx, "test: assign role to inactive subject for permission gate validation")
+
 	// Assign a role
 	assignment := &common.RoleAssignment{
 		SubjectId: "inactive-user",
@@ -515,7 +527,7 @@ func TestManager_InactiveSubjectPermissions(t *testing.T) {
 		TenantId:  tenantID,
 	}
 
-	err = manager.AssignRole(ctx, assignment)
+	err = manager.AssignRole(ctxJ, assignment)
 	require.NoError(t, err)
 
 	// Inactive subject should not have permissions
@@ -641,12 +653,15 @@ func TestManager_DeleteRolesByTenant(t *testing.T) {
 	tenantID := "delete-roles-tenant"
 	otherTenantID := "other-roles-tenant"
 
+	// M-AUTH-2: sensitive operations require justification in context
+	ctxJ := WithSensitiveOperationJustification(ctx, "test: create roles for DeleteRolesByTenant validation")
+
 	for _, r := range []*common.Role{
 		{Id: tenantID + ".role-a", Name: "Role A", TenantId: tenantID},
 		{Id: tenantID + ".role-b", Name: "Role B", TenantId: tenantID},
 		{Id: otherTenantID + ".role-x", Name: "Role X", TenantId: otherTenantID},
 	} {
-		require.NoError(t, manager.CreateRole(ctx, r))
+		require.NoError(t, manager.CreateRole(ctxJ, r))
 	}
 
 	err = manager.DeleteRolesByTenant(ctx, tenantID)
@@ -742,7 +757,10 @@ func TestManager_RevokeRole_InvalidatesSubjectCache(t *testing.T) {
 		TenantId: tenantID,
 		IsActive: true,
 	}))
-	require.NoError(t, manager.AssignRole(ctx, &common.RoleAssignment{
+	// M-AUTH-2: sensitive operations require justification in context
+	ctxJ := WithSensitiveOperationJustification(ctx, "test: assign and revoke role for cache invalidation validation")
+
+	require.NoError(t, manager.AssignRole(ctxJ, &common.RoleAssignment{
 		SubjectId: subjectID,
 		RoleId:    roleID,
 		TenantId:  tenantID,
@@ -750,7 +768,7 @@ func TestManager_RevokeRole_InvalidatesSubjectCache(t *testing.T) {
 
 	req := primeSubjectCache(t, cm, subjectID, tenantID)
 
-	require.NoError(t, manager.RevokeRole(ctx, subjectID, roleID, tenantID))
+	require.NoError(t, manager.RevokeRole(ctxJ, subjectID, roleID, tenantID))
 
 	assert.Nil(t, cm.GetCachedAuth(req),
 		"GetCachedAuth must return nil after RevokeRole invalidates the subject cache")
@@ -910,10 +928,13 @@ func TestManager_DeleteRolesByTenant_InvalidatesTenantCache(t *testing.T) {
 	tenantID := "cache-delete-roles-tenant"
 	otherTenantID := "cache-other-tenant"
 
+	// M-AUTH-2: sensitive operations require justification in context
+	ctxJ := WithSensitiveOperationJustification(ctx, "test: create role for tenant cache invalidation validation")
+
 	for _, r := range []*common.Role{
 		{Id: tenantID + ".role-a", Name: "Role A", TenantId: tenantID},
 	} {
-		require.NoError(t, manager.CreateRole(ctx, r))
+		require.NoError(t, manager.CreateRole(ctxJ, r))
 	}
 
 	// Prime cache for two different subjects in the target tenant.

--- a/features/rbac/sensitive_operations.go
+++ b/features/rbac/sensitive_operations.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"strings"
 
 	"github.com/cfgis/cfgms/pkg/audit"
 	business "github.com/cfgis/cfgms/pkg/storage/interfaces/business"
@@ -37,18 +38,27 @@ const (
 	SensitiveOpDeletePermission SensitiveOperationType = "delete_permission"
 
 	// User management operations
+	// TODO(#742): enforce when user management moves through Manager
 	SensitiveOpCreateUser SensitiveOperationType = "create_user"
+	// TODO(#742): enforce when user management moves through Manager
 	SensitiveOpDeleteUser SensitiveOperationType = "delete_user"
+	// TODO(#742): enforce when user management moves through Manager
 	SensitiveOpModifyUser SensitiveOperationType = "modify_user"
 
 	// System configuration operations
-	SensitiveOpModifyConfig    SensitiveOperationType = "modify_config"
+	// TODO(#742): enforce when user management moves through Manager
+	SensitiveOpModifyConfig SensitiveOperationType = "modify_config"
+	// TODO(#742): enforce when user management moves through Manager
 	SensitiveOpDisableSecurity SensitiveOperationType = "disable_security"
-	SensitiveOpViewAuditLogs   SensitiveOperationType = "view_audit_logs"
+	// TODO(#742): enforce when user management moves through Manager
+	SensitiveOpViewAuditLogs SensitiveOperationType = "view_audit_logs"
+	// TODO(#742): enforce when user management moves through Manager
 	SensitiveOpModifyAuditLogs SensitiveOperationType = "modify_audit_logs"
 
 	// Data operations
+	// TODO(#742): enforce when user management moves through Manager
 	SensitiveOpBulkDelete SensitiveOperationType = "bulk_delete"
+	// TODO(#742): enforce when user management moves through Manager
 	SensitiveOpDataExport SensitiveOperationType = "data_export"
 )
 
@@ -71,13 +81,14 @@ func ValidateSensitiveOperation(opCtx *SensitiveOperationContext) error {
 	}
 
 	// M-AUTH-2: Justification is mandatory for all sensitive operations
-	if opCtx.Justification == "" {
+	trimmed := strings.TrimSpace(opCtx.Justification)
+	if trimmed == "" {
 		return fmt.Errorf("%w: operation '%s' requires justification",
 			ErrJustificationRequired, opCtx.OperationType)
 	}
 
 	// M-AUTH-2: Minimum justification length (prevent empty/trivial justifications)
-	if len(opCtx.Justification) < 10 {
+	if len(trimmed) < 10 {
 		return fmt.Errorf("justification too short (minimum 10 characters): operation '%s'",
 			opCtx.OperationType)
 	}

--- a/features/rbac/sensitive_operations_test.go
+++ b/features/rbac/sensitive_operations_test.go
@@ -6,11 +6,17 @@ package rbac
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/cfgis/cfgms/api/proto/common"
+	"github.com/cfgis/cfgms/pkg/storage/interfaces"
 	business "github.com/cfgis/cfgms/pkg/storage/interfaces/business"
+
+	_ "github.com/cfgis/cfgms/pkg/storage/providers/flatfile"
+	_ "github.com/cfgis/cfgms/pkg/storage/providers/sqlite"
 )
 
 // TestValidateSensitiveOperation tests validation of sensitive operations
@@ -167,6 +173,151 @@ func TestAuditSensitiveOperation(t *testing.T) {
 	// Should not panic with nil audit manager
 	require.NotPanics(t, func() {
 		manager.AuditSensitiveOperation(context.Background(), opCtx, business.AuditResultSuccess, nil)
+	})
+}
+
+// TestManagerSensitiveGates verifies that each newly-gated Manager operation returns
+// ErrJustificationRequired when called without a justification in context and succeeds
+// when WithSensitiveOperationJustification is used.
+func TestManagerSensitiveGates(t *testing.T) {
+	tmpDir := t.TempDir()
+	storageManager, err := interfaces.CreateOSSStorageManager(tmpDir+"/flatfile", tmpDir+"/cfgms.db")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = storageManager.Close() })
+
+	manager := NewManagerWithStorage(
+		storageManager.GetAuditStore(),
+		storageManager.GetClientTenantStore(),
+		storageManager.GetRBACStore(),
+	)
+	t.Cleanup(func() {
+		stopCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_ = manager.Close(stopCtx)
+	})
+
+	ctx := context.Background()
+	require.NoError(t, manager.Initialize(ctx))
+	require.NoError(t, manager.CreateTenantDefaultRoles(ctx, "gate-test-tenant"))
+
+	justCtx := WithSensitiveOperationJustification(ctx, "test: validating sensitive operation gate for rbac story #742")
+
+	// -- CreatePermission --
+	t.Run("CreatePermission/missing_justification", func(t *testing.T) {
+		perm := &common.Permission{
+			Id:           "gate.test.perm1",
+			Name:         "Gate Test Permission 1",
+			ResourceType: "gate",
+			Actions:      []string{"read"},
+		}
+		err := manager.CreatePermission(ctx, perm)
+		require.Error(t, err)
+		assert.ErrorIs(t, err, ErrJustificationRequired)
+	})
+	t.Run("CreatePermission/with_justification", func(t *testing.T) {
+		perm := &common.Permission{
+			Id:           "gate.test.perm2",
+			Name:         "Gate Test Permission 2",
+			ResourceType: "gate",
+			Actions:      []string{"read"},
+		}
+		err := manager.CreatePermission(justCtx, perm)
+		require.NoError(t, err)
+	})
+
+	// -- DeletePermission --
+	t.Run("DeletePermission/missing_justification", func(t *testing.T) {
+		err := manager.DeletePermission(ctx, "gate.test.perm2")
+		require.Error(t, err)
+		assert.ErrorIs(t, err, ErrJustificationRequired)
+	})
+	t.Run("DeletePermission/with_justification", func(t *testing.T) {
+		err := manager.DeletePermission(justCtx, "gate.test.perm2")
+		require.NoError(t, err)
+	})
+
+	// -- CreateRole --
+	t.Run("CreateRole/missing_justification", func(t *testing.T) {
+		role := &common.Role{
+			Id:       "gate-test-tenant.gate.role1",
+			Name:     "Gate Test Role 1",
+			TenantId: "gate-test-tenant",
+		}
+		err := manager.CreateRole(ctx, role)
+		require.Error(t, err)
+		assert.ErrorIs(t, err, ErrJustificationRequired)
+	})
+	t.Run("CreateRole/with_justification", func(t *testing.T) {
+		role := &common.Role{
+			Id:       "gate-test-tenant.gate.role2",
+			Name:     "Gate Test Role 2",
+			TenantId: "gate-test-tenant",
+		}
+		err := manager.CreateRole(justCtx, role)
+		require.NoError(t, err)
+	})
+
+	// -- UpdateRole --
+	t.Run("UpdateRole/missing_justification", func(t *testing.T) {
+		role := &common.Role{
+			Id:          "gate-test-tenant.gate.role2",
+			Name:        "Gate Test Role 2 Updated",
+			TenantId:    "gate-test-tenant",
+			Description: "Updated description",
+		}
+		err := manager.UpdateRole(ctx, role)
+		require.Error(t, err)
+		assert.ErrorIs(t, err, ErrJustificationRequired)
+	})
+	t.Run("UpdateRole/with_justification", func(t *testing.T) {
+		role := &common.Role{
+			Id:          "gate-test-tenant.gate.role2",
+			Name:        "Gate Test Role 2 Updated",
+			TenantId:    "gate-test-tenant",
+			Description: "Updated description",
+		}
+		err := manager.UpdateRole(justCtx, role)
+		require.NoError(t, err)
+	})
+
+	// -- AssignRole --
+	subject := &common.Subject{
+		Id:       "gate-test-subject",
+		Type:     common.SubjectType_SUBJECT_TYPE_USER,
+		TenantId: "gate-test-tenant",
+		IsActive: true,
+	}
+	require.NoError(t, manager.CreateSubject(ctx, subject))
+
+	t.Run("AssignRole/missing_justification", func(t *testing.T) {
+		assignment := &common.RoleAssignment{
+			SubjectId: "gate-test-subject",
+			RoleId:    "gate-test-tenant.gate.role2",
+			TenantId:  "gate-test-tenant",
+		}
+		err := manager.AssignRole(ctx, assignment)
+		require.Error(t, err)
+		assert.ErrorIs(t, err, ErrJustificationRequired)
+	})
+	t.Run("AssignRole/with_justification", func(t *testing.T) {
+		assignment := &common.RoleAssignment{
+			SubjectId: "gate-test-subject",
+			RoleId:    "gate-test-tenant.gate.role2",
+			TenantId:  "gate-test-tenant",
+		}
+		err := manager.AssignRole(justCtx, assignment)
+		require.NoError(t, err)
+	})
+
+	// -- RevokeRole --
+	t.Run("RevokeRole/missing_justification", func(t *testing.T) {
+		err := manager.RevokeRole(ctx, "gate-test-subject", "gate-test-tenant.gate.role2", "gate-test-tenant")
+		require.Error(t, err)
+		assert.ErrorIs(t, err, ErrJustificationRequired)
+	})
+	t.Run("RevokeRole/with_justification", func(t *testing.T) {
+		err := manager.RevokeRole(justCtx, "gate-test-subject", "gate-test-tenant.gate.role2", "gate-test-tenant")
+		require.NoError(t, err)
 	})
 }
 

--- a/features/rbac/templates.go
+++ b/features/rbac/templates.go
@@ -126,8 +126,14 @@ func (t *TemplateManager) ApplyTemplate(ctx context.Context, templateID, subject
 		UpdatedAt:     time.Now().Unix(),
 	}
 
+	// Inject system justification for the M-AUTH-2 sensitive-operation gate. Template
+	// application is an automated system operation; justification records the template origin.
+	// TODO(#742): SubjectID should be plumbed from auth context once that infrastructure exists.
+	ctxWithJustification := WithSensitiveOperationJustification(ctx,
+		fmt.Sprintf("system: role created from template %s during automated template application", templateID))
+
 	// Create the role
-	if err := t.rbacManager.CreateRole(ctx, role); err != nil {
+	if err := t.rbacManager.CreateRole(ctxWithJustification, role); err != nil {
 		return fmt.Errorf("failed to create role from template: %w", err)
 	}
 
@@ -142,9 +148,11 @@ func (t *TemplateManager) ApplyTemplate(ctx context.Context, templateID, subject
 		assignment.ExpiresAt = time.Now().Add(4 * time.Hour).Unix()
 	}
 
-	if err := t.rbacManager.AssignRole(ctx, assignment); err != nil {
+	if err := t.rbacManager.AssignRole(ctxWithJustification, assignment); err != nil {
 		// Cleanup: delete the created role if assignment fails
-		_ = t.rbacManager.DeleteRole(ctx, role.Id)
+		ctxWithDeleteJustification := WithSensitiveOperationJustification(ctx,
+			fmt.Sprintf("system: rollback — deleting role created from template %s after failed assignment", templateID))
+		_ = t.rbacManager.DeleteRole(ctxWithDeleteJustification, role.Id)
 		return fmt.Errorf("failed to assign template role: %w", err)
 	}
 

--- a/features/tenant/manager_test.go
+++ b/features/tenant/manager_test.go
@@ -533,6 +533,8 @@ func TestDeleteTenant_CascadesRBACCleanup(t *testing.T) {
 	rbacManager := cfgmstesting.SetupTestRBACManager(t)
 	manager := setupRealTenantManager(t, rbacManager)
 	ctx := context.Background()
+	// M-AUTH-2: CreateRole requires justification in context
+	ctx = rbac.WithSensitiveOperationJustification(ctx, "test: tenant RBAC cleanup cascade")
 
 	// Create a tenant — this also calls CreateTenantDefaultRoles (in-memory only)
 	tenant, err := manager.CreateTenant(ctx, &TenantRequest{Name: "RBACCleanupTenant"})

--- a/features/tenant/security/integration_cross_tenant_isolation_test.go
+++ b/features/tenant/security/integration_cross_tenant_isolation_test.go
@@ -28,6 +28,8 @@ import (
 // This is an integration test that validates the complete authorization pipeline
 func TestCrossTenantPermissionIsolationIntegration(t *testing.T) {
 	ctx := context.Background()
+	// M-AUTH-2: inject justification so sensitive RBAC operations pass the gate
+	ctx = rbac.WithSensitiveOperationJustification(ctx, "test: cross-tenant isolation integration")
 
 	// Setup REAL RBAC and tenant infrastructure with git storage
 	tmpDir := t.TempDir()

--- a/test/integration/chaos_security_test.go
+++ b/test/integration/chaos_security_test.go
@@ -103,6 +103,8 @@ func NewChaosSecurityTestFramework(t *testing.T) *ChaosSecurityTestFramework {
 // Setup initializes the chaos test framework
 func (framework *ChaosSecurityTestFramework) Setup() error {
 	ctx := framework.env.GetContext()
+	// M-AUTH-2: inject justification so sensitive RBAC operations pass the gate
+	ctx = rbac.WithSensitiveOperationJustification(ctx, "test: chaos security test setup")
 
 	// Initialize RBAC system
 	err := framework.rbacManager.Initialize(ctx)

--- a/test/integration/component_failure_security_test.go
+++ b/test/integration/component_failure_security_test.go
@@ -69,6 +69,8 @@ func NewComponentFailureSecurityTestFramework(t *testing.T) *ComponentFailureSec
 // Setup initializes the test framework with test data
 func (framework *ComponentFailureSecurityTestFramework) Setup() error {
 	ctx := framework.env.GetContext()
+	// M-AUTH-2: inject justification so sensitive RBAC operations pass the gate
+	ctx = rbac.WithSensitiveOperationJustification(ctx, "test: component failure security test setup")
 
 	// Initialize RBAC system
 	err := framework.rbacManager.Initialize(ctx)

--- a/test/integration/degraded_mode_security_test.go
+++ b/test/integration/degraded_mode_security_test.go
@@ -110,6 +110,8 @@ func NewDegradedModeSecurityTestFramework(t *testing.T) *DegradedModeSecurityTes
 // Setup initializes the degraded mode test framework
 func (framework *DegradedModeSecurityTestFramework) Setup() error {
 	ctx := framework.env.GetContext()
+	// M-AUTH-2: inject justification so sensitive RBAC operations pass the gate
+	ctx = rbac.WithSensitiveOperationJustification(ctx, "test: degraded mode security test setup")
 
 	// Initialize RBAC system
 	err := framework.rbacManager.Initialize(ctx)

--- a/test/integration/privilege_escalation_test.go
+++ b/test/integration/privilege_escalation_test.go
@@ -40,6 +40,8 @@ func NewPrivilegeEscalationTestFramework(t *testing.T) *PrivilegeEscalationTestF
 	rbacManager := testutil.SetupTestRBACManager(t)
 
 	ctx := context.Background()
+	// M-AUTH-2: inject justification so sensitive RBAC operations pass the gate
+	ctx = rbac.WithSensitiveOperationJustification(ctx, "test: privilege escalation framework setup and operations")
 	err := rbacManager.Initialize(ctx)
 	require.NoError(t, err)
 

--- a/test/integration/security_state_consistency_test.go
+++ b/test/integration/security_state_consistency_test.go
@@ -94,6 +94,8 @@ func NewSecurityStateConsistencyTestFramework(t *testing.T) *SecurityStateConsis
 // Setup initializes the state consistency test framework
 func (framework *SecurityStateConsistencyTestFramework) Setup() error {
 	ctx := framework.env.GetContext()
+	// M-AUTH-2: inject justification so sensitive RBAC operations pass the gate
+	ctx = rbac.WithSensitiveOperationJustification(ctx, "test: security state consistency setup")
 
 	// Initialize RBAC system
 	err := framework.rbacManager.Initialize(ctx)


### PR DESCRIPTION
## Summary

- Gates `CreatePermission`, `DeletePermission`, `CreateRole`, `UpdateRole`, `AssignRole`, and `RevokeRole` behind `ValidateSensitiveOperation`, returning `ErrJustificationRequired` when no justification is in context (M-AUTH-2 security audit finding)
- Fixes whitespace-only justification bypass by applying `strings.TrimSpace` before the empty/length checks
- Internal system paths (`CreateTenantDefaultRoles`, `DeleteRolesByTenant`, service-account role assignment, JIT init, template application) correctly inject `"system: <reason>"` justification without requiring callers to supply it
- `RBACService` extracts `x-justification` from gRPC incoming metadata for `CreateRole`, `UpdateRole`, `AssignRole`, `RevokeRole`, and `CreateRoleWithParent`
- HTTP handlers extract `X-Justification` header for `CreateRole`, `UpdateRole`, and `DeleteRole` mutations
- All 22 callers updated (test files, integration suites, tenant manager, cross-tenant isolation tests)

## Test plan

- [x] `TestManagerSensitiveGates` in `sensitive_operations_test.go` covers all 6 gates: reject path (`ErrJustificationRequired` without justification) and success path (with justification) for each operation
- [x] `go test ./features/rbac/... ./features/controller/... ./features/tenant/...` — all pass
- [x] `make test-agent-complete` — all validation gates pass
- [x] QA code review: no blocking issues (handleDeleteRole gap fixed during review)
- [x] Security review: no blocking issues (whitespace bypass fixed during review)

Fixes #974

🤖 Generated with [Claude Code](https://claude.com/claude-code)