### PR TITLE
docs: update stale StewardHealthTracker references to fleet.HealthTracker (Issue #1031)

### DIFF
--- a/docs/architecture/controller-operating-model.md
+++ b/docs/architecture/controller-operating-model.md
@@ -178,7 +178,7 @@ The fleet registry is backed by a `StewardStore` (see `pkg/storage/interfaces/st
 
 **Steward lifecycle states**: `registered` → `active` → `lost` / `deregistered`. Records are retained indefinitely for audit; a `lost` steward can re-register and will have its record updated in place.
 
-**Implementation**: `features/steward/StewardHealthTracker` wraps a `StewardStore` for durable fields and keeps ephemeral per-process metrics (`HealthMetrics`: task latency counters, config error counts, recovery attempts) in-memory only. The in-memory metrics are not persisted and reset on restart — this is by design.
+**Implementation**: `features/controller/fleet/fleet.HealthTracker` wraps a `StewardStore` for durable fields and keeps ephemeral per-process metrics (`HealthMetrics`: task latency counters, config error counts, recovery attempts) in-memory only. The in-memory metrics are not persisted and reset on restart — this is by design.
 
 **After a restart**: On startup, the controller can call `ListStewards()` or `ListStewardsByStatus()` to enumerate the fleet without waiting for stewards to check in. The stored `last_seen` and `last_heartbeat_at` timestamps allow the controller to identify stewards that went silent before or during the restart.
 

--- a/docs/architecture/storage-architecture.md
+++ b/docs/architecture/storage-architecture.md
@@ -364,7 +364,7 @@ Per ADR-003, the providers and interfaces above are **not all implemented today*
 - `pkg/storage/providers/flatfile`: one JSON file per steward at `<root>/stewards/<stewardID>.json`. `ListStewards` is O(n) in the number of stewards — a known limitation for large fleets; prefer SQLite for fleets where query performance matters.
 - `pkg/storage/providers/sqlite`: stewards stored in the `stewards` table; `ListStewardsByStatus` uses an indexed query on `status`.
 
-**Fleet tracker**: `features/steward/StewardHealthTracker` wraps a `StewardStore` for durable fields and keeps ephemeral per-process metrics (`HealthMetrics`) in-memory via a `sync.Map`.
+**Fleet tracker**: `features/controller/fleet/fleet.HealthTracker` wraps a `StewardStore` for durable fields and keeps ephemeral per-process metrics (`HealthMetrics`) in-memory via a `sync.Map`.
 
 `SessionStore` is implemented in story #662. It stores only `Persistent=true` sessions; ephemeral state (non-persistent sessions, rebuildable runtime values) uses `pkg/cache`. The `ConfigStore` interface returns `ErrNotSupported` from the SQLite provider — config storage targets the flat-file provider (OSS) and PostgreSQL (commercial).
 


### PR DESCRIPTION
## Summary

- Story #923 relocated `StewardHealthTracker` from `features/steward/` to `features/controller/fleet/fleet.HealthTracker` but did not update two architecture docs
- `docs/architecture/controller-operating-model.md:181` — replaced stale path with `features/controller/fleet/fleet.HealthTracker`
- `docs/architecture/storage-architecture.md:367` — same replacement

Pure documentation correction. No code, no tests, no behavior changes.

## Specialist Review Results

| Reviewer | Result |
|----------|--------|
| QA Test Runner | **PASS** — all unit tests, linting, license headers, architecture checks, and cross-platform builds passed |
| QA Code Reviewer | **PASS** — only the two specified lines changed in only the two doc files; no test quality concerns applicable |
| Security Engineer | **PASS** — no secrets, no central provider violations, no security surface; `check-architecture` and `security-precommit` clean |

## Acceptance Criteria

- [x] `grep -rn "features/steward/StewardHealthTracker" docs/` returns zero matches
- [x] `docs/architecture/controller-operating-model.md` references `features/controller/fleet/fleet.HealthTracker`
- [x] `docs/architecture/storage-architecture.md` references `features/controller/fleet/fleet.HealthTracker`
- [x] No other lines in either file modified
- [x] No source files modified
- [x] No test changes
- [x] `make test-agent-complete` passes
- [x] `make check-architecture` passes

Fixes #1031