### PR TITLE
cfg: remove dead --base-ref flag from diff command (Issue #1036)

### DIFF
--- a/cmd/cfg/cmd/diff.go
+++ b/cmd/cfg/cmd/diff.go
@@ -32,7 +32,6 @@ var (
 	colorizeOutput   bool
 	lineNumbers      bool
 	threeWay         bool
-	baseRef          string
 )
 
 // diffCmd represents the diff command
@@ -53,7 +52,7 @@ Examples:
   cfg diff --output json config-old.yaml config-new.yaml
 
   # Three-way comparison
-  cfg diff --three-way --base-ref main config-branch-1.yaml config-branch-2.yaml
+  cfg diff --three-way base.yaml config-branch-1.yaml config-branch-2.yaml
 
   # Show only high impact changes
   cfg diff --filter-by-impact high,critical config-old.yaml config-new.yaml
@@ -87,7 +86,6 @@ func init() {
 
 	// Three-way diff options
 	diffCmd.Flags().BoolVar(&threeWay, "three-way", false, "perform three-way comparison")
-	diffCmd.Flags().StringVar(&baseRef, "base-ref", "", "base reference for three-way comparison")
 }
 
 func runDiff(cmd *cobra.Command, args []string) error {

--- a/cmd/cfg/cmd/diff_test.go
+++ b/cmd/cfg/cmd/diff_test.go
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+package cmd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestDiffCmdBaseRefFlagRemoved asserts that the dead --base-ref flag is not
+// registered on diffCmd. The flag was never read by runDiff or runThreeWayDiff;
+// args[0] is used directly as the base reference.
+func TestDiffCmdBaseRefFlagRemoved(t *testing.T) {
+	flag := diffCmd.Flags().Lookup("base-ref")
+	assert.Nil(t, flag, "--base-ref must not be registered on diffCmd")
+}
+
+// TestDiffCmdThreeWayFlagPresent confirms the --three-way flag is still
+// registered, so removing --base-ref did not accidentally drop it.
+func TestDiffCmdThreeWayFlagPresent(t *testing.T) {
+	flag := diffCmd.Flags().Lookup("three-way")
+	require.NotNil(t, flag, "--three-way flag must still be registered on diffCmd")
+	assert.Equal(t, "bool", flag.Value.Type())
+}
+
+// TestDiffCmdArgsValidationThreeWay verifies that the cobra Args validator on
+// diffCmd accepts exactly three positional arguments (the three-way path).
+func TestDiffCmdArgsValidationThreeWay(t *testing.T) {
+	err := diffCmd.Args(diffCmd, []string{"base.yaml", "left.yaml", "right.yaml"})
+	assert.NoError(t, err, "three positional args must satisfy diffCmd.Args validator")
+}
+
+// TestDiffCmdArgsValidationTwoWay verifies two positional args are still accepted.
+func TestDiffCmdArgsValidationTwoWay(t *testing.T) {
+	err := diffCmd.Args(diffCmd, []string{"old.yaml", "new.yaml"})
+	assert.NoError(t, err, "two positional args must satisfy diffCmd.Args validator")
+}
+
+// TestDiffCmdArgsValidationRejectsOne ensures fewer than two args are rejected.
+func TestDiffCmdArgsValidationRejectsOne(t *testing.T) {
+	err := diffCmd.Args(diffCmd, []string{"only.yaml"})
+	assert.Error(t, err, "one positional arg must be rejected by diffCmd.Args validator")
+}


### PR DESCRIPTION
## Summary

- Deletes `baseRef string` package-level var from `cmd/cfg/cmd/diff.go` — the variable was declared and bound to a cobra flag but never read anywhere in the diff command or the wider `cmd/cfg/` tree.
- Removes the `--base-ref` flag registration from `diffCmd.Flags()` — `runThreeWayDiff` already uses `args[0]` directly as the base reference.
- Updates the stale `--base-ref` example in the `Long` help description to match actual CLI usage.
- Adds `cmd/cfg/cmd/diff_test.go` with 5 tests asserting flag absence, three-way flag retention, and cobra arity validation.

No behavior changes. Three-way and two-way diff paths are unaffected.

Fixes #1036
Part of epic #759

## Specialist Review Results

| Specialist | Result |
|---|---|
| QA Test Runner | ✅ PASS — all 5 new tests pass; all packages pass; cross-platform compilation clean |
| QA Code Reviewer | ✅ PASS — no blocking issues; 3 non-blocking warnings about untested `runDiff` runtime guards (pre-existing gap, out of scope for this dead-code removal) |
| Security Engineer | ✅ PASS — no blocking issues; gosec/staticcheck/architecture/precommit all clean; Trivy skipped (sandbox DNS, CI will run it) |

## Test plan

- [x] `TestDiffCmdBaseRefFlagRemoved` — asserts `--base-ref` not registered on `diffCmd`
- [x] `TestDiffCmdThreeWayFlagPresent` — asserts `--three-way` is still registered
- [x] `TestDiffCmdArgsValidationThreeWay` — cobra validator accepts 3 positional args
- [x] `TestDiffCmdArgsValidationTwoWay` — cobra validator accepts 2 positional args
- [x] `TestDiffCmdArgsValidationRejectsOne` — cobra validator rejects 1 positional arg
- [x] `go build ./cmd/cfg/...` passes cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)