### PR TITLE
cfg: wire versionCmd to pkg/version and remove dead --config flag (Issue #1035)

### DIFF
--- a/cmd/cfg/cmd/root.go
+++ b/cmd/cfg/cmd/root.go
@@ -4,8 +4,7 @@
 package cmd
 
 import (
-	"fmt"
-
+	"github.com/cfgis/cfgms/pkg/version"
 	"github.com/spf13/cobra"
 )
 
@@ -13,7 +12,6 @@ var (
 	// Global flags
 	verbose bool
 	output  string
-	config  string
 )
 
 // rootCmd represents the base command when called without any subcommands
@@ -37,7 +35,6 @@ func init() {
 	// Global flags
 	rootCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "verbose output")
 	rootCmd.PersistentFlags().StringVarP(&output, "output", "o", "text", "output format (text, json, html, unified, side-by-side, markdown)")
-	rootCmd.PersistentFlags().StringVarP(&config, "config", "c", "", "config file path")
 
 	// Add subcommands
 	rootCmd.AddCommand(diffCmd)
@@ -54,7 +51,7 @@ var versionCmd = &cobra.Command{
 	Use:   "version",
 	Short: "Show version information",
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println("cfg version 0.3.0-alpha")
-		fmt.Println("CFGMS Configuration Management System")
+		cmd.Printf("cfg %s\n", version.Info())
+		cmd.Println("CFGMS Configuration Management System")
 	},
 }

--- a/cmd/cfg/cmd/root_test.go
+++ b/cmd/cfg/cmd/root_test.go
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+// Package cmd implements the CLI commands for cfg
+package cmd
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/cfgis/cfgms/pkg/version"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestVersionCmd_OutputContainsPkgVersion(t *testing.T) {
+	buf := new(bytes.Buffer)
+	versionCmd.SetOut(buf)
+	versionCmd.SetErr(buf)
+	t.Cleanup(func() { versionCmd.SetOut(nil); versionCmd.SetErr(nil) })
+
+	versionCmd.Run(versionCmd, []string{})
+
+	out := buf.String()
+	require.NotEmpty(t, out, "version command produced no output")
+	assert.True(t, strings.HasPrefix(out, "cfg "), "output must start with 'cfg ', got: %q", out)
+	assert.Contains(t, out, version.Info(), "output must contain the string from pkg/version.Info()")
+	assert.NotContains(t, out, "0.3.0-alpha", "output must not contain the old hardcoded version")
+}
+
+func TestRootCmd_ConfigFlagNotRegistered(t *testing.T) {
+	flag := rootCmd.PersistentFlags().Lookup("config")
+	assert.Nil(t, flag, "--config flag must not be registered on rootCmd")
+
+	shortFlag := rootCmd.PersistentFlags().ShorthandLookup("c")
+	assert.Nil(t, shortFlag, "-c shorthand must not be registered on rootCmd")
+}


### PR DESCRIPTION
## Summary

- `versionCmd` now delegates to `pkg/version.Info()` instead of printing a hardcoded `0.3.0-alpha` literal — version output is driven by ldflags-injected build metadata
- Dead `--config`/`-c` persistent flag and its unread `config string` variable removed from `rootCmd`
- `fmt.Printf/Println` → `cmd.Printf/Println` in `versionCmd.Run` so output flows through cobra's writer (enables unit-testable capture via `SetOut`)
- New `root_test.go` with `TestVersionCmd_OutputContainsPkgVersion` and `TestRootCmd_ConfigFlagNotRegistered`

## Specialist Review Results

| Reviewer | Result |
|----------|--------|
| QA Test Runner | **PASS** — all quality gates pass; both new tests pass; cross-platform builds verified |
| QA Code Reviewer | **PASS** — no blocking issues; 1 non-blocking warning (writer cleanup) addressed |
| Security Engineer | **PASS** — no security issues; architecture checks clean; no central provider violations |

## Test plan

- [ ] `go test ./cmd/cfg/cmd/... -run TestVersionCmd` — verifies output format and pkg/version delegation
- [ ] `go test ./cmd/cfg/cmd/... -run TestRootCmd_ConfigFlagNotRegistered` — verifies --config/-c absent
- [ ] `make test-agent-complete` — all quality gates

Fixes #1035

🤖 Generated with [Claude Code](https://claude.com/claude-code)