### PR TITLE
cfg: add --json output flag to token create and token list (Issue #1033)

### DIFF
--- a/cmd/cfg/cmd/token.go
+++ b/cmd/cfg/cmd/token.go
@@ -5,6 +5,7 @@ package cmd
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
 
@@ -18,6 +19,7 @@ var (
 	tokenGroup         string
 	tokenExpiresIn     string
 	tokenSingleUse     bool
+	tokenJSONOutput    bool
 
 	// API connection flags
 	tokenAPIURL      string
@@ -144,12 +146,14 @@ func init() {
 	tokenCreateCmd.Flags().StringVar(&tokenGroup, "group", "", "Optional group identifier")
 	tokenCreateCmd.Flags().StringVar(&tokenExpiresIn, "expires", "", "Expiration duration (e.g., 24h, 7d, 30d)")
 	tokenCreateCmd.Flags().BoolVar(&tokenSingleUse, "single-use", false, "Token can only be used once")
+	tokenCreateCmd.Flags().BoolVar(&tokenJSONOutput, "json", false, "Emit JSON output instead of human-readable text")
 
 	_ = tokenCreateCmd.MarkFlagRequired("tenant-id")
 	_ = tokenCreateCmd.MarkFlagRequired("controller-url")
 
 	// List command flags
 	tokenListCmd.Flags().StringVar(&tokenTenantID, "tenant-id", "", "Filter by tenant ID (optional)")
+	tokenListCmd.Flags().BoolVar(&tokenJSONOutput, "json", false, "Emit JSON output instead of human-readable text")
 
 	// Add subcommands
 	tokenCmd.AddCommand(tokenCreateCmd)
@@ -227,6 +231,10 @@ func runTokenCreate(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to create token: %w", err)
 	}
 
+	if tokenJSONOutput {
+		return json.NewEncoder(os.Stdout).Encode(token)
+	}
+
 	// Output results
 	fmt.Printf("Registration Token: %s\n\n", token.Token)
 
@@ -267,6 +275,10 @@ func runTokenList(cmd *cobra.Command, args []string) error {
 	resp, err := client.ListTokens(context.Background(), tokenTenantID)
 	if err != nil {
 		return fmt.Errorf("failed to list tokens: %w", err)
+	}
+
+	if tokenJSONOutput {
+		return json.NewEncoder(os.Stdout).Encode(resp)
 	}
 
 	if resp.Total == 0 {

--- a/cmd/cfg/cmd/token_test.go
+++ b/cmd/cfg/cmd/token_test.go
@@ -1,0 +1,337 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+// Package cmd implements the CLI commands for cfg
+package cmd
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// captureStdout replaces os.Stdout with a pipe, calls fn, and returns the captured output.
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+
+	orig := os.Stdout
+	os.Stdout = w
+
+	fn()
+
+	require.NoError(t, w.Close())
+	os.Stdout = orig
+
+	data, err := io.ReadAll(r)
+	require.NoError(t, err)
+
+	return string(data)
+}
+
+// newTokenServer creates an httptest server that serves canned token API responses.
+func newTokenServer(t *testing.T) *httptest.Server {
+	t.Helper()
+
+	expiresAt := "2026-06-01T00:00:00Z"
+	token := APITokenResponse{
+		Token:         "abc123testtoken",
+		TenantID:      "test-tenant",
+		ControllerURL: "controller.example.com:4433",
+		Group:         "production",
+		CreatedAt:     "2026-05-01T00:00:00Z",
+		ExpiresAt:     &expiresAt,
+		SingleUse:     false,
+		Revoked:       false,
+	}
+
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == "POST" && r.URL.Path == "/api/v1/registration/tokens":
+			w.WriteHeader(http.StatusCreated)
+			_ = json.NewEncoder(w).Encode(token)
+		case r.Method == "GET" && r.URL.Path == "/api/v1/registration/tokens":
+			resp := APITokenListResponse{
+				Tokens: []APITokenResponse{token},
+				Total:  1,
+			}
+			_ = json.NewEncoder(w).Encode(resp)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+}
+
+func TestRunTokenCreate_JSONOutput(t *testing.T) {
+	server := newTokenServer(t)
+	defer server.Close()
+
+	// Save and restore package-level flag vars
+	origAPIURL := tokenAPIURL
+	origAPIKey := tokenAPIKey
+	origTLSInsecure := tokenTLSInsecure
+	origTenantID := tokenTenantID
+	origControllerURL := tokenControllerURL
+	origGroup := tokenGroup
+	origExpiresIn := tokenExpiresIn
+	origSingleUse := tokenSingleUse
+	origJSON := tokenJSONOutput
+	t.Cleanup(func() {
+		tokenAPIURL = origAPIURL
+		tokenAPIKey = origAPIKey
+		tokenTLSInsecure = origTLSInsecure
+		tokenTenantID = origTenantID
+		tokenControllerURL = origControllerURL
+		tokenGroup = origGroup
+		tokenExpiresIn = origExpiresIn
+		tokenSingleUse = origSingleUse
+		tokenJSONOutput = origJSON
+	})
+
+	tokenAPIURL = server.URL
+	tokenTLSInsecure = true
+	tokenTenantID = "test-tenant"
+	tokenControllerURL = "controller.example.com:4433"
+	tokenGroup = ""
+	tokenExpiresIn = ""
+	tokenSingleUse = false
+	tokenJSONOutput = true
+
+	output := captureStdout(t, func() {
+		err := runTokenCreate(tokenCreateCmd, nil)
+		require.NoError(t, err)
+	})
+
+	// Output must be valid JSON parseable as APITokenResponse
+	var parsed APITokenResponse
+	require.NoError(t, json.Unmarshal([]byte(output), &parsed), "output must be valid JSON")
+
+	assert.Equal(t, "abc123testtoken", parsed.Token)
+	assert.Equal(t, "test-tenant", parsed.TenantID)
+	assert.Equal(t, "controller.example.com:4433", parsed.ControllerURL)
+
+	// No human-readable text on stdout
+	assert.NotContains(t, output, "Registration Token:")
+	assert.NotContains(t, output, "Deployment Examples:")
+}
+
+func TestRunTokenCreate_TextOutput(t *testing.T) {
+	server := newTokenServer(t)
+	defer server.Close()
+
+	origAPIURL := tokenAPIURL
+	origAPIKey := tokenAPIKey
+	origTLSInsecure := tokenTLSInsecure
+	origTenantID := tokenTenantID
+	origControllerURL := tokenControllerURL
+	origGroup := tokenGroup
+	origExpiresIn := tokenExpiresIn
+	origSingleUse := tokenSingleUse
+	origJSON := tokenJSONOutput
+	t.Cleanup(func() {
+		tokenAPIURL = origAPIURL
+		tokenAPIKey = origAPIKey
+		tokenTLSInsecure = origTLSInsecure
+		tokenTenantID = origTenantID
+		tokenControllerURL = origControllerURL
+		tokenGroup = origGroup
+		tokenExpiresIn = origExpiresIn
+		tokenSingleUse = origSingleUse
+		tokenJSONOutput = origJSON
+	})
+
+	tokenAPIURL = server.URL
+	tokenTLSInsecure = true
+	tokenTenantID = "test-tenant"
+	tokenControllerURL = "controller.example.com:4433"
+	tokenGroup = ""
+	tokenExpiresIn = ""
+	tokenSingleUse = false
+	tokenJSONOutput = false
+
+	output := captureStdout(t, func() {
+		err := runTokenCreate(tokenCreateCmd, nil)
+		require.NoError(t, err)
+	})
+
+	// Human-readable output must be present
+	assert.Contains(t, output, "Registration Token:")
+	assert.Contains(t, output, "abc123testtoken")
+	assert.Contains(t, output, "Deployment Examples:")
+
+	// Must not be bare JSON
+	assert.False(t, json.Valid([]byte(strings.TrimSpace(output))), "text output must not be valid JSON")
+}
+
+func TestRunTokenCreate_APIError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"error":"internal server error"}`))
+	}))
+	defer server.Close()
+
+	origAPIURL := tokenAPIURL
+	origTLSInsecure := tokenTLSInsecure
+	origTenantID := tokenTenantID
+	origControllerURL := tokenControllerURL
+	origJSON := tokenJSONOutput
+	t.Cleanup(func() {
+		tokenAPIURL = origAPIURL
+		tokenTLSInsecure = origTLSInsecure
+		tokenTenantID = origTenantID
+		tokenControllerURL = origControllerURL
+		tokenJSONOutput = origJSON
+	})
+
+	tokenAPIURL = server.URL
+	tokenTLSInsecure = true
+	tokenTenantID = "test-tenant"
+	tokenControllerURL = "controller.example.com:4433"
+	tokenJSONOutput = false
+
+	err := runTokenCreate(tokenCreateCmd, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to create token")
+}
+
+func TestRunTokenList_JSONOutput(t *testing.T) {
+	server := newTokenServer(t)
+	defer server.Close()
+
+	origAPIURL := tokenAPIURL
+	origTLSInsecure := tokenTLSInsecure
+	origTenantID := tokenTenantID
+	origJSON := tokenJSONOutput
+	t.Cleanup(func() {
+		tokenAPIURL = origAPIURL
+		tokenTLSInsecure = origTLSInsecure
+		tokenTenantID = origTenantID
+		tokenJSONOutput = origJSON
+	})
+
+	tokenAPIURL = server.URL
+	tokenTLSInsecure = true
+	tokenTenantID = ""
+	tokenJSONOutput = true
+
+	output := captureStdout(t, func() {
+		err := runTokenList(tokenListCmd, nil)
+		require.NoError(t, err)
+	})
+
+	// Output must be valid JSON parseable as APITokenListResponse
+	var parsed APITokenListResponse
+	require.NoError(t, json.Unmarshal([]byte(output), &parsed), "output must be valid JSON")
+
+	assert.Equal(t, 1, parsed.Total)
+	require.Len(t, parsed.Tokens, 1)
+	assert.Equal(t, "abc123testtoken", parsed.Tokens[0].Token)
+
+	// No human-readable text on stdout
+	assert.NotContains(t, output, "Found")
+	assert.NotContains(t, output, "token(s):")
+}
+
+func TestRunTokenList_TextOutput(t *testing.T) {
+	server := newTokenServer(t)
+	defer server.Close()
+
+	origAPIURL := tokenAPIURL
+	origTLSInsecure := tokenTLSInsecure
+	origTenantID := tokenTenantID
+	origJSON := tokenJSONOutput
+	t.Cleanup(func() {
+		tokenAPIURL = origAPIURL
+		tokenTLSInsecure = origTLSInsecure
+		tokenTenantID = origTenantID
+		tokenJSONOutput = origJSON
+	})
+
+	tokenAPIURL = server.URL
+	tokenTLSInsecure = true
+	tokenTenantID = ""
+	tokenJSONOutput = false
+
+	output := captureStdout(t, func() {
+		err := runTokenList(tokenListCmd, nil)
+		require.NoError(t, err)
+	})
+
+	// Human-readable output must be present
+	assert.Contains(t, output, "Found 1 token(s):")
+	assert.Contains(t, output, "abc123testtoken")
+}
+
+func TestRunTokenList_JSONOutput_EmptyList(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		resp := APITokenListResponse{Tokens: []APITokenResponse{}, Total: 0}
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	origAPIURL := tokenAPIURL
+	origTLSInsecure := tokenTLSInsecure
+	origTenantID := tokenTenantID
+	origJSON := tokenJSONOutput
+	t.Cleanup(func() {
+		tokenAPIURL = origAPIURL
+		tokenTLSInsecure = origTLSInsecure
+		tokenTenantID = origTenantID
+		tokenJSONOutput = origJSON
+	})
+
+	tokenAPIURL = server.URL
+	tokenTLSInsecure = true
+	tokenTenantID = ""
+	tokenJSONOutput = true
+
+	output := captureStdout(t, func() {
+		err := runTokenList(tokenListCmd, nil)
+		require.NoError(t, err)
+	})
+
+	// Even with zero tokens, JSON path must emit valid JSON
+	var parsed APITokenListResponse
+	require.NoError(t, json.Unmarshal([]byte(output), &parsed), "output must be valid JSON")
+	assert.Equal(t, 0, parsed.Total)
+}
+
+func TestRunTokenList_APIError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusServiceUnavailable)
+		_, _ = w.Write([]byte(`{"error":"service unavailable"}`))
+	}))
+	defer server.Close()
+
+	origAPIURL := tokenAPIURL
+	origTLSInsecure := tokenTLSInsecure
+	origTenantID := tokenTenantID
+	origJSON := tokenJSONOutput
+	t.Cleanup(func() {
+		tokenAPIURL = origAPIURL
+		tokenTLSInsecure = origTLSInsecure
+		tokenTenantID = origTenantID
+		tokenJSONOutput = origJSON
+	})
+
+	tokenAPIURL = server.URL
+	tokenTLSInsecure = true
+	tokenTenantID = ""
+	tokenJSONOutput = false
+
+	err := runTokenList(tokenListCmd, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to list tokens")
+}


### PR DESCRIPTION
## Summary

- Adds `--json` bool flag to `cfg token create` and `cfg token list`
- When set, each command emits a single compact JSON object to stdout (suppressing all human-readable output), enabling scripted consumers to parse token data without screen-scraping
- Default text output is entirely unchanged; flag defaults to `false`

## Implementation

`cmd/cfg/cmd/token.go`:
- Added `tokenJSONOutput bool` to the flag var block
- Registered `--json` on both `tokenCreateCmd` and `tokenListCmd` in `init()`
- `runTokenCreate`: JSON branch calls `json.NewEncoder(os.Stdout).Encode(token)` after the API call and returns immediately, suppressing the installer-command echo block
- `runTokenList`: JSON branch calls `json.NewEncoder(os.Stdout).Encode(resp)` before the empty-list check so zero-token responses also emit valid JSON

Follows the existing `trace.go:109-113` JSON branch pattern.

`cmd/cfg/cmd/token_test.go` (new file, 7 tests):
- `TestRunTokenCreate_JSONOutput` — valid JSON, parses as `APITokenResponse`, no human-readable text
- `TestRunTokenCreate_TextOutput` — text output unchanged, not valid bare JSON
- `TestRunTokenCreate_APIError` — API error propagates as `runTokenCreate` error return
- `TestRunTokenList_JSONOutput` — valid JSON, parses as `APITokenListResponse` with `tokens` + `total`
- `TestRunTokenList_TextOutput` — text output unchanged
- `TestRunTokenList_JSONOutput_EmptyList` — zero-token JSON path emits valid JSON (not "No tokens found.")
- `TestRunTokenList_APIError` — API error propagates as `runTokenList` error return

## Specialist Review Results

- **QA Test Runner**: PASS — all 7 token tests pass, full `make test-agent-complete` passes, lint clean
- **QA Code Reviewer**: PASS — 0 blocking issues (3 initial findings fixed: pipe close error now surfaced, redundant test replaced with error-path test, error paths covered for both commands)
- **Security Engineer**: PASS — 0 blocking issues, no hardcoded secrets, no central provider violations, no insecure defaults introduced

## Test plan

- [ ] `go test ./cmd/cfg/cmd/...` passes locally (7 new token tests + all existing)
- [ ] `cfg token create --tenant-id=X --controller-url=Y:4433 --json` outputs parseable JSON
- [ ] `cfg token list --json` outputs JSON with `tokens` array and `total` field
- [ ] Both commands without `--json` produce identical human-readable output as before

Fixes #1033

🤖 Generated with [Claude Code](https://claude.com/claude-code)