### PR TITLE
siem: fix FileWatcher data race in HasChanges (Issue #1039)

### DIFF
--- a/features/siem/rule_manager.go
+++ b/features/siem/rule_manager.go
@@ -757,8 +757,8 @@ func (fw *FileWatcher) AddPath(path string) {
 
 // HasChanges checks if any watched files have changed
 func (fw *FileWatcher) HasChanges() bool {
-	fw.mutex.RLock()
-	defer fw.mutex.RUnlock()
+	fw.mutex.Lock()
+	defer fw.mutex.Unlock()
 
 	for path, lastMod := range fw.watchedPaths {
 		if stat, err := os.Stat(path); err == nil {

--- a/features/siem/rule_manager_test.go
+++ b/features/siem/rule_manager_test.go
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+package siem
+
+import (
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestFileWatcherHasChangesConcurrent verifies HasChanges is race-free under
+// concurrent callers (mirrors the autoReloadLoop tick pattern).
+func TestFileWatcherHasChangesConcurrent(t *testing.T) {
+	dir := t.TempDir()
+	watchedFile := filepath.Join(dir, "rules.yaml")
+	if err := os.WriteFile(watchedFile, []byte("rule: 1"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	fw := NewFileWatcher()
+	fw.AddPath(watchedFile)
+
+	const goroutines = 5
+	const duration = 100 * time.Millisecond
+
+	var wg sync.WaitGroup
+	deadline := time.Now().Add(duration)
+
+	for i := 0; i < goroutines; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for time.Now().Before(deadline) {
+				fw.HasChanges()
+			}
+		}()
+	}
+
+	// Modify the file mid-run so HasChanges actually writes watchedPaths.
+	time.Sleep(duration / 2)
+	if err := os.WriteFile(watchedFile, []byte("rule: 2"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	wg.Wait()
+}
+
+// TestFileWatcherHasChangesDetectsModification verifies HasChanges returns
+// true after a file is modified and false before any modification.
+func TestFileWatcherHasChangesDetectsModification(t *testing.T) {
+	dir := t.TempDir()
+	f := filepath.Join(dir, "test.yaml")
+	if err := os.WriteFile(f, []byte("v1"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	fw := NewFileWatcher()
+	fw.AddPath(f)
+
+	assert.False(t, fw.HasChanges(), "no change expected immediately after AddPath")
+
+	// Ensure mtime advances past what the OS may round to.
+	time.Sleep(10 * time.Millisecond)
+	if err := os.WriteFile(f, []byte("v2"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	// Touch the mtime explicitly so the test is not flaky on fast filesystems.
+	future := time.Now().Add(time.Second)
+	if err := os.Chtimes(f, future, future); err != nil {
+		t.Fatal(err)
+	}
+
+	assert.True(t, fw.HasChanges(), "change expected after file modification")
+	assert.False(t, fw.HasChanges(), "no change expected after HasChanges resets the timestamp")
+}
+
+// TestFileWatcherHasChangesNoWatchedPaths verifies HasChanges returns false
+// when no paths have been registered.
+func TestFileWatcherHasChangesNoWatchedPaths(t *testing.T) {
+	fw := NewFileWatcher()
+	assert.False(t, fw.HasChanges())
+}
+
+// TestFileWatcherAddPathMissingFile verifies AddPath handles a non-existent
+// path without panicking and HasChanges still returns false.
+func TestFileWatcherAddPathMissingFile(t *testing.T) {
+	fw := NewFileWatcher()
+	fw.AddPath("/nonexistent/path/rules.yaml")
+	assert.False(t, fw.HasChanges())
+}


### PR DESCRIPTION
## Summary

- `FileWatcher.HasChanges` was acquiring `fw.mutex.RLock()` (read lock) while writing `fw.watchedPaths[path]` on the modification-detected branch — an unconditional data race under concurrent `autoReloadLoop` ticks
- Fix: one-line change to `fw.mutex.Lock()` / `defer fw.mutex.Unlock()` so the write is protected by an exclusive lock
- Added `features/siem/rule_manager_test.go` with 4 tests including a ≥5-goroutine concurrent test that runs for ≥100ms and passes cleanly under `go test -race`

## Test plan

- [x] `go test -race ./features/siem/... -run TestFileWatcher` — all 4 tests PASS, zero race detector reports
- [x] `TestFileWatcherHasChangesConcurrent` — ≥5 goroutines call `HasChanges` concurrently for ≥100ms with a mid-run file write to exercise the write path
- [x] `TestFileWatcherHasChangesDetectsModification` — verifies true-then-false semantics (timestamp reset)
- [x] `TestFileWatcherHasChangesNoWatchedPaths` — empty watcher returns false
- [x] `TestFileWatcherAddPathMissingFile` — non-existent path handled without panic

## Specialist Review Results

| Reviewer | Result | Notes |
|----------|--------|-------|
| QA Test Runner | PASS* | All code gates green; Trivy skipped — no network egress in agent container (will run in CI) |
| QA Code Reviewer | PASS | 0 blocking issues; 3 minor style warnings (non-blocking) |
| Security Engineer | PASS | 0 blocking issues; `check-architecture` clean; gosec clean for changed code |

Fixes #1039

🤖 Generated with [Claude Code](https://claude.com/claude-code)