### PR TITLE
siem: fix correlator alert flood — one CorrelatedEvent per window lifetime (Issue #1040)

### DIFF
--- a/features/siem/event_correlator.go
+++ b/features/siem/event_correlator.go
@@ -52,6 +52,7 @@ type EventWindow struct {
 	TenantID   string
 	GroupKey   string
 	Metadata   map[string]interface{}
+	Triggered  bool // true after the window has emitted one CorrelatedEvent
 }
 
 // NewEventCorrelator creates a new event correlator
@@ -446,6 +447,10 @@ func (ec *EventCorrelatorImpl) addEventToWindow(window *EventWindow, event *Secu
 
 // checkCorrelationConditions checks if correlation conditions are met for a window
 func (ec *EventCorrelatorImpl) checkCorrelationConditions(window *EventWindow, rule *CorrelationRule) *CorrelatedEvent {
+	if window.Triggered {
+		return nil
+	}
+
 	eventCount := len(window.Events)
 
 	// Check minimum events requirement
@@ -459,7 +464,9 @@ func (ec *EventCorrelatorImpl) checkCorrelationConditions(window *EventWindow, r
 	}
 
 	// Correlation conditions met, create correlated event
-	return ec.createCorrelatedEvent(window, rule)
+	correlated := ec.createCorrelatedEvent(window, rule)
+	window.Triggered = true
+	return correlated
 }
 
 // createCorrelatedEvent creates a correlated event from a window

--- a/features/siem/event_correlator_test.go
+++ b/features/siem/event_correlator_test.go
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+package siem
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func makeRule(id string, minEvents int, window time.Duration) *CorrelationRule {
+	return &CorrelationRule{
+		ID:         id,
+		Name:       id,
+		EventTypes: []string{"test"},
+		TimeWindow: window,
+		MinEvents:  minEvents,
+		Enabled:    true,
+	}
+}
+
+func makeEvent(ruleID string) *SecurityEvent {
+	return &SecurityEvent{
+		ID:        "e-" + ruleID + "-" + time.Now().Format("150405.000000000"),
+		Timestamp: time.Now(),
+		EventType: "test",
+		Severity:  SeverityLow,
+		TenantID:  "tenant-1",
+		RuleID:    ruleID,
+		Fields:    map[string]interface{}{},
+	}
+}
+
+// TestCorrelator_ExactMinEvents verifies that a window reaching exactly MinEvents
+// produces exactly one CorrelatedEvent.
+func TestCorrelator_ExactMinEvents(t *testing.T) {
+	ec := NewEventCorrelator(0)
+	rule := makeRule("rule-exact", 3, 5*time.Second)
+	require.NoError(t, ec.AddCorrelationRule(rule))
+
+	ctx := context.Background()
+	events := []*SecurityEvent{makeEvent("rule-exact"), makeEvent("rule-exact"), makeEvent("rule-exact")}
+
+	result, err := ec.CorrelateEvents(ctx, events, rule.TimeWindow)
+	require.NoError(t, err)
+	require.Len(t, result, 1, "exactly one CorrelatedEvent for a window that hits MinEvents")
+}
+
+// TestCorrelator_ExtraEventsStillOneCorrelation verifies that receiving more than
+// MinEvents within the same window still produces exactly one CorrelatedEvent.
+func TestCorrelator_ExtraEventsStillOneCorrelation(t *testing.T) {
+	ec := NewEventCorrelator(0)
+	rule := makeRule("rule-extra", 3, 5*time.Second)
+	require.NoError(t, ec.AddCorrelationRule(rule))
+
+	ctx := context.Background()
+
+	var total []*CorrelatedEvent
+	for i := 0; i < 10; i++ {
+		result, err := ec.CorrelateEvents(ctx, []*SecurityEvent{makeEvent("rule-extra")}, rule.TimeWindow)
+		require.NoError(t, err)
+		total = append(total, result...)
+	}
+
+	require.Len(t, total, 1, "exactly one CorrelatedEvent regardless of how many events arrive in the same window")
+}
+
+// TestCorrelator_FreshWindowAfterExpiry verifies that after the original window
+// expires, a new window can fire once more when it reaches MinEvents.
+func TestCorrelator_FreshWindowAfterExpiry(t *testing.T) {
+	ec := NewEventCorrelator(0)
+	rule := makeRule("rule-expiry", 3, 100*time.Millisecond)
+	require.NoError(t, ec.AddCorrelationRule(rule))
+
+	ctx := context.Background()
+
+	// First window: send 5 events — should produce exactly 1 correlated event.
+	var firstPass []*CorrelatedEvent
+	for i := 0; i < 5; i++ {
+		result, err := ec.CorrelateEvents(ctx, []*SecurityEvent{makeEvent("rule-expiry")}, rule.TimeWindow)
+		require.NoError(t, err)
+		firstPass = append(firstPass, result...)
+	}
+	require.Len(t, firstPass, 1, "first window should produce exactly one CorrelatedEvent")
+
+	// Wait for the window to expire.
+	time.Sleep(150 * time.Millisecond)
+
+	// Second window: send another MinEvents worth of events — should produce exactly 1 new event.
+	var secondPass []*CorrelatedEvent
+	for i := 0; i < 3; i++ {
+		result, err := ec.CorrelateEvents(ctx, []*SecurityEvent{makeEvent("rule-expiry")}, rule.TimeWindow)
+		require.NoError(t, err)
+		secondPass = append(secondPass, result...)
+	}
+	require.Len(t, secondPass, 1, "fresh window after expiry should produce exactly one new CorrelatedEvent")
+}


### PR DESCRIPTION
## Summary

- Adds `Triggered bool` field to `EventWindow` struct — gates emission to one `CorrelatedEvent` per window lifetime
- `checkCorrelationConditions` returns `nil` immediately when `window.Triggered == true`
- Sets `window.Triggered = true` after `createCorrelatedEvent` succeeds
- New test file covers all three acceptance-criteria scenarios using real time windows (no mocks)

## Changes

- `features/siem/event_correlator.go` — `Triggered` field on `EventWindow`; guard + flag in `checkCorrelationConditions`
- `features/siem/event_correlator_test.go` — 3 new tests (exact MinEvents, MinEvents+N overflow, post-expiry fresh window)

## Specialist Review Results

| Reviewer | Result | Notes |
|----------|--------|-------|
| QA Test Runner | **PASS** | All unit tests pass with race detection; cross-platform builds verified; Trivy blocked by sandbox DNS (environmental, not code) |
| QA Code Reviewer | **PASS** (new code) | `time.Sleep` usage for expiry testing is explicitly mandated by the story implementation notes ("Tests use real time windows (e.g., 100ms); `time.Sleep` to exercise expiry. No mocks."); pre-existing `siem_engine_test.go` mock violations are out of scope for this story |
| Security Engineer | **PASS** | No secrets, no SQL injection, no central provider violations, no insecure defaults; `Triggered` flag accessed under existing `ec.mutex.Lock()` — concurrency safe; tenant isolation preserved via `buildWindowKey` |

## Test Plan

- [x] `TestCorrelator_ExactMinEvents` — window reaching exactly `MinEvents=3` → 1 `CorrelatedEvent`
- [x] `TestCorrelator_ExtraEventsStillOneCorrelation` — 10 events into `MinEvents=3` window → still 1 `CorrelatedEvent`
- [x] `TestCorrelator_FreshWindowAfterExpiry` — 5 events → 1 correlation; wait 150ms for 100ms window to expire; 3 more events → 1 new `CorrelatedEvent`
- [x] `make test-agent-complete` passes

Fixes #1040

🤖 Generated with [Claude Code](https://claude.com/claude-code)