### PR TITLE
dataplane: retire orphaned BulkTransfer contract subtest (Issue #1012)

### DIFF
--- a/pkg/dataplane/interfaces/contract_test.go
+++ b/pkg/dataplane/interfaces/contract_test.go
@@ -5,9 +5,11 @@
 // DataPlaneProvider and DataPlaneSession interfaces.
 //
 // These tests validate that any DataPlaneProvider implementation exhibits
-// correct behavioral contracts: config sync, DNA sync, bulk transfer, large
-// payloads, session identification, session lifecycle, stats tracking, and
-// security requirements (mTLS enforcement, cert validation).
+// correct behavioral contracts: session identification, session lifecycle,
+// stats tracking, and security requirements (mTLS enforcement, cert
+// validation). Transfer-RPC round-trip behaviour (config, DNA, bulk) is
+// verified at the handler layer in features/controller/transport/, where the
+// server-side handlers are actually wired onto the gRPC server.
 //
 // # Usage by Provider Implementors
 //
@@ -37,7 +39,6 @@ import (
 	cfgcert "github.com/cfgis/cfgms/pkg/cert"
 	dpinterfaces "github.com/cfgis/cfgms/pkg/dataplane/interfaces"
 	dpgrpc "github.com/cfgis/cfgms/pkg/dataplane/providers/grpc"
-	dptypes "github.com/cfgis/cfgms/pkg/dataplane/types"
 	quictransport "github.com/cfgis/cfgms/pkg/transport/quic"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -56,12 +57,16 @@ type DPProviderFactory func(t *testing.T) (
 
 // RunDPContractTests runs the full DataPlaneProvider contract test suite using
 // the provided factory. Each contract is a subtest for granular reporting.
+//
+// Bulk/DNA/Config transfer round-trip coverage lives with the handler tests in
+// features/controller/transport/{bulk,dna}_handler_test.go. After Issue #898
+// the dataplane provider no longer registers server-side handlers itself, so
+// transfer RPCs are tested where the handler is wired up rather than against a
+// bare provider. Issue #1012 retired the orphaned BulkTransfer subtest that
+// remained here, which raced an Unimplemented status on a serviceless server.
 func RunDPContractTests(t *testing.T, factory DPProviderFactory) {
 	t.Helper()
 
-	t.Run("BulkTransfer", func(t *testing.T) {
-		testDPBulkTransfer(t, factory)
-	})
 	t.Run("SessionIdentification", func(t *testing.T) {
 		testDPSessionIdentification(t, factory)
 	})
@@ -83,32 +88,6 @@ func RunDPContractTests(t *testing.T, factory DPProviderFactory) {
 }
 
 // --- Contract Implementations ---
-
-// testDPBulkTransfer verifies bidirectional bulk data transfer completes with
-// data integrity.
-func testDPBulkTransfer(t *testing.T, factory DPProviderFactory) {
-	t.Helper()
-	server, client, cleanup := factory(t)
-	defer cleanup()
-
-	_, clientSess := dpGetSessions(t, server, client)
-
-	data := []byte("bulk payload data for contract test — log upload simulation")
-	bulk := &dptypes.BulkTransfer{
-		ID:        "contract-bulk",
-		StewardID: "contract-steward",
-		TenantID:  "contract-tenant",
-		Direction: "to_controller",
-		Type:      "logs",
-		TotalSize: int64(len(data)),
-		Data:      data,
-		Checksum:  "sha256:placeholder",
-		Metadata:  map[string]string{"filename": "app.log"},
-	}
-
-	// SendBulk should complete without error
-	require.NoError(t, clientSess.SendBulk(context.Background(), bulk))
-}
 
 // testDPSessionIdentification verifies session ID and peer IDs are non-empty
 // and consistent.


### PR DESCRIPTION
## Summary

- Delete the `testDPBulkTransfer` contract subtest and its `t.Run` registration in `pkg/dataplane/interfaces/contract_test.go` — it raced an `Unimplemented` reply on the contract factory's serviceless gRPC server and produced flaky `failed to send bulk chunk: EOF` failures across CI runs.
- Drop the now-unused `dptypes` import; refresh the package and `RunDPContractTests` doc comments to reflect the new scope (lifecycle + identification + stats + mTLS rejection).
- No production code touched. No new dependencies.

## Why

Issue #898 / PR #967 moved server-side bulk handling out of `pkg/dataplane/providers/grpc` into `features/controller/transport/BulkHandler`, and migrated `ConfigSync`, `DNASync`, and `LargePayload` from this same contract suite into handler-tier tests. `BulkTransfer` was overlooked.

Post-#967, the contract factory's gRPC server starts with no service handlers registered. When `clientSendBulk` opened a `BulkTransfer` bidi stream, the server returned `Unimplemented` immediately. The client's `stream.Send()` then raced against that status arriving on the response side — winning the race meant the test passed; losing meant `EOF`. Five real failures observed in merge-queue runs (PRs 1007, 1014, 1022, 1024) between 21:08Z and 01:08Z on 2026-05-01/02.

## Coverage check — nothing regresses

Bulk-transfer behaviour remains tested:

| Concern | Test |
|---------|------|
| Round-trip over real QUIC + mTLS + gRPC | `features/controller/transport/bulk_handler_test.go::TestBulkTransfer_RoundTrip` |
| Round-trip without peer auth (mTLS-only) | `features/controller/transport/bulk_handler_test.go::TestBulkTransfer_RoundTrip_NoAuth` |
| Chunk integrity / checksum tampering | `pkg/dataplane/providers/grpc/stream_test.go::TestBulkChecksum_RoundTrip` + `TestBulkChecksum_TamperedData` |
| Handler unit semantics (5 cases) | `features/controller/transport/bulk_handler_test.go::TestBulkHandler_*` |

The handler-tier tests properly drain the response side of the bidi stream, which is the step the deleted contract test omitted — that omission was the racy root cause.

## Test plan

- [x] `go test -count=20 -race ./pkg/dataplane/... ./features/controller/transport/...` — green
- [x] `go vet ./pkg/dataplane/... ./features/controller/transport/...` — clean
- [x] `make check-architecture` — no central provider violations
- [x] `golangci-lint run` — clean
- [x] Pre-commit secret scan — clean
- [ ] CI required checks (unit-tests, integration-tests, Build Gate, security-deployment-gate) — verify on PR

Fixes #1012

🤖 Generated with [Claude Code](https://claude.com/claude-code)