### PR TITLE
siem: delete dead ProcessingWorker pool and route ProcessLogEntry through StreamProcessor (Issue #1041)

### DIFF
--- a/features/siem/batch_processor.go
+++ b/features/siem/batch_processor.go
@@ -88,6 +88,11 @@ func (bp *BatchProcessor) addEntryToBatch(ctx context.Context, entry interfaces.
 	bp.batchMutex.Lock()
 	defer bp.batchMutex.Unlock()
 
+	// Re-initialize batch if it was flushed by a timeout between calls
+	if bp.currentBatch == nil {
+		bp.currentBatch = bp.newBatch(entry.TenantID)
+	}
+
 	// Ensure tenant consistency within batch
 	if bp.currentBatch.TenantID != "" && bp.currentBatch.TenantID != entry.TenantID {
 		// Different tenant, flush current batch first

--- a/features/siem/interfaces.go
+++ b/features/siem/interfaces.go
@@ -25,6 +25,10 @@ type StreamProcessor interface {
 	// ProcessStream processes a stream of log entries
 	ProcessStream(ctx context.Context, entries <-chan interfaces.LogEntry) error
 
+	// ProcessEntry sends a single log entry into the processing pipeline.
+	// Non-blocking: returns an error if the internal buffer is full.
+	ProcessEntry(ctx context.Context, entry interfaces.LogEntry) error
+
 	// GetMetrics returns current processing metrics
 	GetMetrics(ctx context.Context) (*ProcessingMetrics, error)
 }
@@ -326,8 +330,7 @@ type ProcessingConfig struct {
 	BatchTimeout time.Duration `json:"batch_timeout" yaml:"batch_timeout"`
 
 	// Worker configuration
-	WorkerCount     int `json:"worker_count" yaml:"worker_count"`
-	WorkerQueueSize int `json:"worker_queue_size" yaml:"worker_queue_size"`
+	WorkerCount int `json:"worker_count" yaml:"worker_count"`
 
 	// Performance configuration
 	MaxLatency       time.Duration `json:"max_latency" yaml:"max_latency"`

--- a/features/siem/pattern_matcher.go
+++ b/features/siem/pattern_matcher.go
@@ -7,6 +7,7 @@ import (
 	"regexp"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/cfgis/cfgms/pkg/logging"
@@ -36,9 +37,11 @@ type CompiledPattern struct {
 	*DetectionPattern
 	CompiledRegex  *regexp.Regexp
 	FieldMatchers  map[string]*regexp.Regexp
-	LastUsed       time.Time
-	MatchCount     int64
 	ProcessingTime time.Duration
+	// lastUsedNs and matchCount are updated concurrently by parallel goroutines in
+	// processEntriesParallel; they use atomic operations to avoid data races.
+	lastUsedNs int64 // unix nanoseconds, read via atomic.LoadInt64
+	MatchCount int64 // read/written via atomic.AddInt64 / atomic.LoadInt64
 }
 
 // NewPatternMatcher creates a new pattern matcher with optimization features
@@ -73,8 +76,8 @@ func (pm *PatternMatcherImpl) AddPattern(pattern *DetectionPattern) error {
 	compiled := &CompiledPattern{
 		DetectionPattern: pattern,
 		FieldMatchers:    make(map[string]*regexp.Regexp),
-		LastUsed:         time.Now(),
 	}
+	atomic.StoreInt64(&compiled.lastUsedNs, time.Now().UnixNano())
 
 	var err error
 	switch pattern.PatternType {
@@ -234,10 +237,11 @@ func (pm *PatternMatcherImpl) matchEntryAgainstPatterns(entry interfaces.LogEntr
 		entryMatches := pm.matchEntryAgainstPattern(entry, pattern)
 		matches = append(matches, entryMatches...)
 
-		// Update pattern statistics
-		pattern.LastUsed = time.Now()
+		// Update pattern statistics — use atomic ops since multiple goroutines in
+		// processEntriesParallel may update the same CompiledPattern concurrently.
+		atomic.StoreInt64(&pattern.lastUsedNs, time.Now().UnixNano())
 		if len(entryMatches) > 0 {
-			pattern.MatchCount += int64(len(entryMatches))
+			atomic.AddInt64(&pattern.MatchCount, int64(len(entryMatches)))
 		}
 	}
 
@@ -425,8 +429,8 @@ func (pm *PatternMatcherImpl) GetStatistics() map[string]interface{} {
 		patternDetails[id] = map[string]interface{}{
 			"name":            pattern.Name,
 			"type":            pattern.PatternType,
-			"match_count":     pattern.MatchCount,
-			"last_used":       pattern.LastUsed,
+			"match_count":     atomic.LoadInt64(&pattern.MatchCount),
+			"last_used":       time.Unix(0, atomic.LoadInt64(&pattern.lastUsedNs)),
 			"processing_time": pattern.ProcessingTime,
 			"enabled":         pattern.Enabled,
 		}

--- a/features/siem/siem_engine.go
+++ b/features/siem/siem_engine.go
@@ -33,18 +33,9 @@ type SIEMEngine struct {
 	// Configuration
 	config ProcessingConfig
 
-	// Log entry input
-	logEntryChannel chan interfaces.LogEntry
-	inputBuffer     chan interfaces.LogEntry
-
 	// State management
-	running     int32 // atomic
-	stopChan    chan struct{}
-	workerGroup sync.WaitGroup
-
-	// Performance optimization
-	workers      []*ProcessingWorker
-	loadBalancer *LoadBalancer
+	running  int32 // atomic
+	stopChan chan struct{}
 
 	// Metrics and monitoring
 	metrics     *SIEMMetrics
@@ -54,29 +45,6 @@ type SIEMEngine struct {
 	// Memory management
 	memoryMonitor *MemoryMonitor
 	gcController  *GCController
-}
-
-// ProcessingWorker handles parallel processing of log entry batches
-type ProcessingWorker struct {
-	id            int
-	engine        *SIEMEngine
-	inputChan     chan *ProcessingBatch
-	logger        *logging.ModuleLogger
-	workerMetrics *WorkerMetrics
-}
-
-// WorkerMetrics tracks individual worker performance
-type WorkerMetrics struct {
-	ProcessedBatches int64
-	ProcessedEntries int64
-	ProcessingTime   time.Duration
-	LastActivity     time.Time
-	ErrorCount       int64
-}
-
-// LoadBalancer distributes work across processing workers
-type LoadBalancer struct {
-	workers []*ProcessingWorker
 }
 
 // SIEMMetrics aggregates all SIEM processing metrics
@@ -101,7 +69,6 @@ type SIEMMetrics struct {
 	PatternsMatched           int64
 
 	// Performance metrics
-	ActiveWorkers     int32
 	BufferUtilization float64
 	MemoryUsage       int64
 	CPUUsage          float64
@@ -192,8 +159,7 @@ func NewSIEMEngine(config ProcessingConfig, triggerManager trigger.TriggerManage
 		targetGCPercent: 100,
 	}
 
-	// Create SIEM engine
-	engine := &SIEMEngine{
+	return &SIEMEngine{
 		logger:              logger,
 		streamProcessor:     streamProcessor,
 		patternMatcher:      patternMatcher,
@@ -201,20 +167,13 @@ func NewSIEMEngine(config ProcessingConfig, triggerManager trigger.TriggerManage
 		ruleManager:         ruleManager,
 		workflowIntegration: workflowIntegration,
 		config:              config,
-		logEntryChannel:     make(chan interfaces.LogEntry, config.BufferSize),
-		inputBuffer:         make(chan interfaces.LogEntry, config.BufferSize*2),
 		stopChan:            make(chan struct{}),
 		metrics: &SIEMMetrics{
 			StartTime: time.Now(),
 		},
 		memoryMonitor: memoryMonitor,
 		gcController:  gcController,
-	}
-
-	// Initialize load balancer and workers
-	engine.initializeWorkers()
-
-	return engine, nil
+	}, nil
 }
 
 // Start initializes and starts the SIEM processing engine
@@ -244,29 +203,13 @@ func (se *SIEMEngine) Start(ctx context.Context) error {
 		return fmt.Errorf("failed to start event correlator: %w", err)
 	}
 
-	// Start processing workers
-	for _, worker := range se.workers {
-		se.workerGroup.Add(1)
-		go worker.Run(ctx, &se.workerGroup)
-	}
-
-	// Start input processing
-	se.workerGroup.Add(1)
-	go se.processInputLoop(ctx, &se.workerGroup)
-
 	// Start metrics collection
 	if se.config.EnableMetrics {
-		se.workerGroup.Add(1)
-		go se.metricsCollectionLoop(ctx, &se.workerGroup)
+		go se.metricsCollectionLoop(ctx)
 	}
 
 	// Start memory monitoring
-	se.workerGroup.Add(1)
-	go se.memoryMonitoringLoop(ctx, &se.workerGroup)
-
-	// Start load balancing optimization
-	se.workerGroup.Add(1)
-	go se.loadBalancingLoop(ctx, &se.workerGroup)
+	go se.memoryMonitoringLoop(ctx)
 
 	logger.InfoCtx(ctx, "SIEM processing engine started successfully")
 	return nil
@@ -283,10 +226,10 @@ func (se *SIEMEngine) Stop(ctx context.Context) error {
 
 	logger.InfoCtx(ctx, "Stopping SIEM processing engine")
 
-	// Signal shutdown
+	// Signal engine goroutines (metricsCollectionLoop, memoryMonitoringLoop) to exit
 	close(se.stopChan)
 
-	// Stop core components
+	// Stop core components — each has its own internal shutdown and timeout
 	if se.streamProcessor != nil {
 		if err := se.streamProcessor.Stop(ctx); err != nil {
 			logger.WarnCtx(ctx, "Failed to stop stream processor", "error", err)
@@ -298,51 +241,24 @@ func (se *SIEMEngine) Stop(ctx context.Context) error {
 		}
 	}
 
-	// Wait for workers with timeout
-	done := make(chan struct{})
-	go func() {
-		defer func() {
-			if r := recover(); r != nil {
-				// Handle WaitGroup panics during shutdown
-				logger.WarnCtx(ctx, "WaitGroup panic during engine shutdown", "error", r)
-			}
-			close(done)
-		}()
-		se.workerGroup.Wait()
-	}()
-
-	select {
-	case <-done:
-		logger.InfoCtx(ctx, "SIEM processing engine stopped gracefully")
-	case <-time.After(5 * time.Second): // Reduce timeout for tests
-		logger.WarnCtx(ctx, "SIEM processing engine shutdown timeout")
-	}
-
-	// Close channels
-	close(se.logEntryChannel)
-	close(se.inputBuffer)
-
+	logger.InfoCtx(ctx, "SIEM processing engine stopped gracefully")
 	return nil
 }
 
-// ProcessLogEntry is the main entry point for log processing
+// ProcessLogEntry is the main entry point for log processing.
+// It routes entries directly into StreamProcessor.ProcessEntry.
 func (se *SIEMEngine) ProcessLogEntry(ctx context.Context, entry interfaces.LogEntry) error {
 	if atomic.LoadInt32(&se.running) == 0 {
 		return fmt.Errorf("SIEM engine not running")
 	}
 
-	// Track input metrics
 	atomic.AddInt64(&se.metrics.TotalEntriesProcessed, 1)
 
-	// Non-blocking send to prevent backpressure
-	select {
-	case se.logEntryChannel <- entry:
-		return nil
-	default:
-		// Buffer full, drop entry and track
+	if err := se.streamProcessor.ProcessEntry(ctx, entry); err != nil {
 		atomic.AddInt64(&se.metrics.DroppedEntries, 1)
-		return fmt.Errorf("input buffer full, entry dropped")
+		return err
 	}
+	return nil
 }
 
 // ProcessLogStream processes a continuous stream of log entries
@@ -354,65 +270,8 @@ func (se *SIEMEngine) ProcessLogStream(ctx context.Context, entries <-chan inter
 	return se.streamProcessor.ProcessStream(ctx, entries)
 }
 
-// initializeWorkers creates and initializes processing workers
-func (se *SIEMEngine) initializeWorkers() {
-	se.workers = make([]*ProcessingWorker, se.config.WorkerCount)
-
-	for i := 0; i < se.config.WorkerCount; i++ {
-		worker := &ProcessingWorker{
-			id:            i,
-			engine:        se,
-			inputChan:     make(chan *ProcessingBatch, se.config.WorkerQueueSize),
-			logger:        se.logger.WithField("worker_id", i),
-			workerMetrics: &WorkerMetrics{},
-		}
-		se.workers[i] = worker
-	}
-
-	se.loadBalancer = &LoadBalancer{
-		workers: se.workers,
-	}
-
-	// Safe conversion to prevent integer overflow
-	workerCount := len(se.workers)
-	if workerCount > math.MaxInt32 {
-		atomic.StoreInt32(&se.metrics.ActiveWorkers, math.MaxInt32)
-	} else {
-		atomic.StoreInt32(&se.metrics.ActiveWorkers, int32(workerCount))
-	}
-}
-
-// processInputLoop processes incoming log entries
-func (se *SIEMEngine) processInputLoop(ctx context.Context, wg *sync.WaitGroup) {
-	defer wg.Done()
-
-	for {
-		select {
-		case <-ctx.Done():
-			return
-		case <-se.stopChan:
-			return
-		case entry, ok := <-se.logEntryChannel:
-			if !ok {
-				return
-			}
-
-			// Send to input buffer for batching
-			select {
-			case se.inputBuffer <- entry:
-				// Successfully buffered
-			default:
-				// Buffer full, drop entry
-				atomic.AddInt64(&se.metrics.DroppedEntries, 1)
-			}
-		}
-	}
-}
-
 // metricsCollectionLoop periodically collects and updates metrics
-func (se *SIEMEngine) metricsCollectionLoop(ctx context.Context, wg *sync.WaitGroup) {
-	defer wg.Done()
-
+func (se *SIEMEngine) metricsCollectionLoop(ctx context.Context) {
 	ticker := time.NewTicker(1 * time.Second)
 	defer ticker.Stop()
 
@@ -429,9 +288,7 @@ func (se *SIEMEngine) metricsCollectionLoop(ctx context.Context, wg *sync.WaitGr
 }
 
 // memoryMonitoringLoop monitors memory usage and triggers GC when needed
-func (se *SIEMEngine) memoryMonitoringLoop(ctx context.Context, wg *sync.WaitGroup) {
-	defer wg.Done()
-
+func (se *SIEMEngine) memoryMonitoringLoop(ctx context.Context) {
 	ticker := time.NewTicker(5 * time.Second)
 	defer ticker.Stop()
 
@@ -447,148 +304,6 @@ func (se *SIEMEngine) memoryMonitoringLoop(ctx context.Context, wg *sync.WaitGro
 	}
 }
 
-// loadBalancingLoop optimizes load balancing based on worker performance
-func (se *SIEMEngine) loadBalancingLoop(ctx context.Context, wg *sync.WaitGroup) {
-	defer wg.Done()
-
-	ticker := time.NewTicker(10 * time.Second)
-	defer ticker.Stop()
-
-	for {
-		select {
-		case <-ctx.Done():
-			return
-		case <-se.stopChan:
-			return
-		case <-ticker.C:
-			se.optimizeLoadBalancing()
-		}
-	}
-}
-
-// Run executes the main worker processing loop
-func (pw *ProcessingWorker) Run(ctx context.Context, wg *sync.WaitGroup) {
-	defer wg.Done()
-
-	pw.logger.InfoCtx(ctx, "Starting processing worker")
-
-	for {
-		select {
-		case <-ctx.Done():
-			pw.logger.InfoCtx(ctx, "Worker stopped due to context cancellation")
-			return
-		case <-pw.engine.stopChan:
-			pw.logger.InfoCtx(ctx, "Worker stopped due to stop signal")
-			return
-		case batch, ok := <-pw.inputChan:
-			if !ok {
-				pw.logger.InfoCtx(ctx, "Worker input channel closed")
-				return
-			}
-
-			pw.processBatchOptimized(ctx, batch)
-		}
-	}
-}
-
-// processBatchOptimized processes a batch with performance optimizations
-func (pw *ProcessingWorker) processBatchOptimized(ctx context.Context, batch *ProcessingBatch) {
-	startTime := time.Now()
-	defer func() {
-		processingTime := time.Since(startTime)
-		pw.workerMetrics.ProcessingTime += processingTime
-		pw.workerMetrics.LastActivity = time.Now()
-		pw.workerMetrics.ProcessedBatches++
-		pw.workerMetrics.ProcessedEntries += int64(len(batch.Entries))
-
-		// Update engine latency metrics
-		pw.engine.updateLatencyMetrics(processingTime)
-	}()
-
-	// Pattern matching phase (optimized for batch processing)
-	if pw.engine.config.EnablePatternMatching && pw.engine.patternMatcher != nil {
-		matches, err := pw.engine.patternMatcher.MatchBatch(batch.Entries)
-		if err != nil {
-			pw.workerMetrics.ErrorCount++
-			atomic.AddInt64(&pw.engine.metrics.ProcessingErrors, 1)
-			pw.logger.ErrorCtx(ctx, "Pattern matching failed",
-				"batch_id", batch.ID,
-				"error", err.Error())
-			return
-		}
-
-		if len(matches) > 0 {
-			securityEvents := pw.convertMatchesToSecurityEvents(matches, batch.TenantID)
-			atomic.AddInt64(&pw.engine.metrics.PatternsMatched, int64(len(matches)))
-			atomic.AddInt64(&pw.engine.metrics.SecurityEventsGenerated, int64(len(securityEvents)))
-
-			// Process individual security events
-			for _, event := range securityEvents {
-				if err := pw.engine.workflowIntegration.ProcessSecurityEvent(ctx, event); err != nil {
-					pw.logger.ErrorCtx(ctx, "Failed to process security event",
-						"event_id", event.ID,
-						"error", err.Error())
-				}
-			}
-
-			// Event correlation phase (only if we have events)
-			if pw.engine.config.EnableEventCorrelation && pw.engine.eventCorrelator != nil {
-				correlatedEvents, err := pw.engine.eventCorrelator.CorrelateEvents(
-					ctx, securityEvents, pw.engine.config.CorrelationWindow)
-				if err != nil {
-					pw.workerMetrics.ErrorCount++
-					atomic.AddInt64(&pw.engine.metrics.ProcessingErrors, 1)
-					pw.logger.ErrorCtx(ctx, "Event correlation failed",
-						"batch_id", batch.ID,
-						"error", err.Error())
-					return
-				}
-
-				if len(correlatedEvents) > 0 {
-					atomic.AddInt64(&pw.engine.metrics.CorrelatedEventsGenerated, int64(len(correlatedEvents)))
-
-					// Process correlated events
-					for _, event := range correlatedEvents {
-						if err := pw.engine.workflowIntegration.ProcessCorrelatedEvent(ctx, event); err != nil {
-							pw.logger.ErrorCtx(ctx, "Failed to process correlated event",
-								"correlation_id", event.ID,
-								"error", err.Error())
-						}
-					}
-				}
-			}
-		}
-	}
-}
-
-// convertMatchesToSecurityEvents converts pattern matches to security events
-func (pw *ProcessingWorker) convertMatchesToSecurityEvents(matches []*PatternMatch, tenantID string) []*SecurityEvent {
-	events := make([]*SecurityEvent, 0, len(matches))
-
-	for _, match := range matches {
-		event := &SecurityEvent{
-			ID:          fmt.Sprintf("evt_%d_%d", time.Now().UnixNano(), pw.id),
-			Timestamp:   match.Timestamp,
-			EventType:   "pattern_match",
-			Severity:    SeverityMedium,
-			Source:      match.LogEntry.ServiceName,
-			Description: fmt.Sprintf("Pattern '%s' matched in %s", match.PatternID, match.Field),
-			RuleID:      match.PatternID,
-			TenantID:    tenantID,
-			Fields: map[string]interface{}{
-				"matched_text": match.MatchedText,
-				"field":        match.Field,
-				"confidence":   match.Confidence,
-				"worker_id":    pw.id,
-			},
-			RawLog: match.LogEntry,
-		}
-		events = append(events, event)
-	}
-
-	return events
-}
-
 // updateMetrics updates comprehensive SIEM metrics
 func (se *SIEMEngine) updateMetrics() {
 	se.metricsLock.Lock()
@@ -597,12 +312,6 @@ func (se *SIEMEngine) updateMetrics() {
 	now := time.Now()
 	se.metrics.LastUpdateTime = now
 	se.metrics.Uptime = now.Sub(se.metrics.StartTime)
-
-	// Update buffer utilization
-	if se.logEntryChannel != nil {
-		utilization := float64(len(se.logEntryChannel)) / float64(cap(se.logEntryChannel)) * 100
-		se.metrics.BufferUtilization = utilization
-	}
 
 	// Update system metrics
 	var memStats runtime.MemStats
@@ -632,26 +341,6 @@ func (se *SIEMEngine) updateMetrics() {
 	}
 }
 
-// updateLatencyMetrics updates latency tracking
-func (se *SIEMEngine) updateLatencyMetrics(latency time.Duration) {
-	se.metricsLock.Lock()
-	defer se.metricsLock.Unlock()
-
-	latencyMs := float64(latency.Nanoseconds()) / 1e6
-
-	// Simple moving average for latency
-	if se.metrics.AverageLatency == 0 {
-		se.metrics.AverageLatency = latencyMs
-	} else {
-		se.metrics.AverageLatency = 0.9*se.metrics.AverageLatency + 0.1*latencyMs
-	}
-
-	// Track max latency
-	if latencyMs > se.metrics.MaxLatency {
-		se.metrics.MaxLatency = latencyMs
-	}
-}
-
 // monitorMemoryUsage monitors memory usage and triggers optimization
 func (se *SIEMEngine) monitorMemoryUsage() {
 	var memStats runtime.MemStats
@@ -668,12 +357,6 @@ func (se *SIEMEngine) monitorMemoryUsage() {
 		// Warning threshold - optimize GC settings
 		se.gcController.optimizeGC()
 	}
-}
-
-// optimizeLoadBalancing optimizes worker load distribution
-func (se *SIEMEngine) optimizeLoadBalancing() {
-	// Simple round-robin optimization based on worker performance
-	// More sophisticated algorithms could be implemented here
 }
 
 // optimizeGC optimizes garbage collection settings

--- a/features/siem/siem_engine_test.go
+++ b/features/siem/siem_engine_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"runtime"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -140,7 +141,6 @@ func createTestConfig() ProcessingConfig {
 		BatchSize:              100,
 		BatchTimeout:           10 * time.Millisecond,
 		WorkerCount:            4,
-		WorkerQueueSize:        100,
 		MaxLatency:             100 * time.Millisecond,
 		TargetThroughput:       10000,
 		CorrelationWindow:      5 * time.Minute,
@@ -201,6 +201,37 @@ func TestSIEMEngine_StartStop(t *testing.T) {
 	assert.Contains(t, err.Error(), "not running")
 }
 
+// TestSIEMEngine_ProcessLogEntry_RoutesToStreamProcessor is a non-skippable test
+// that verifies ProcessLogEntry sends entries directly to StreamProcessor.ProcessEntry.
+// EntriesProcessed is incremented synchronously in ProcessEntry, so no sleep is needed.
+func TestSIEMEngine_ProcessLogEntry_RoutesToStreamProcessor(t *testing.T) {
+	triggerManager := NewMockTriggerManager()
+	workflowTrigger := NewMockWorkflowTrigger()
+	config := createTestConfig()
+
+	engine, err := NewSIEMEngine(config, triggerManager, workflowTrigger)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	err = engine.Start(ctx)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, engine.Stop(ctx)) }()
+
+	entry := createTestLogEntry("ERROR", "routing test", "test-tenant")
+	err = engine.ProcessLogEntry(ctx, entry)
+	require.NoError(t, err)
+
+	// EntriesProcessed is incremented synchronously in ProcessEntry — no sleep needed
+	spMetrics, err := engine.streamProcessor.GetMetrics(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), spMetrics.EntriesProcessed,
+		"ProcessLogEntry must route directly through StreamProcessor.ProcessEntry")
+
+	metrics, err := engine.GetMetrics(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), metrics.TotalEntriesProcessed)
+}
+
 func TestSIEMEngine_ProcessLogEntry(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping SIEM engine test in short mode")
@@ -216,20 +247,127 @@ func TestSIEMEngine_ProcessLogEntry(t *testing.T) {
 	ctx := context.Background()
 	err = engine.Start(ctx)
 	require.NoError(t, err)
-	defer func() { _ = engine.Stop(ctx) }()
+	defer func() { assert.NoError(t, engine.Stop(ctx)) }()
 
 	// Process a log entry
 	entry := createTestLogEntry("ERROR", "Test error message", "test-tenant")
 	err = engine.ProcessLogEntry(ctx, entry)
 	require.NoError(t, err)
 
-	// Give some time for processing
-	time.Sleep(100 * time.Millisecond)
-
-	// Check metrics
+	// TotalEntriesProcessed and EntriesProcessed are updated synchronously — no sleep needed
 	metrics, err := engine.GetMetrics(ctx)
 	require.NoError(t, err)
 	assert.GreaterOrEqual(t, metrics.TotalEntriesProcessed, int64(1))
+
+	// Verify entry reached the stream processor
+	spMetrics, err := engine.streamProcessor.GetMetrics(ctx)
+	require.NoError(t, err)
+	assert.GreaterOrEqual(t, spMetrics.EntriesProcessed, int64(1),
+		"entry should have reached StreamProcessor.ProcessEntry")
+}
+
+func TestStreamProcessor_ProcessEntry(t *testing.T) {
+	config := createTestConfig()
+	patternMatcher := NewPatternMatcher()
+	eventCorrelator := NewEventCorrelator(5 * time.Minute)
+	ruleManager := NewRuleManager(patternMatcher, eventCorrelator)
+
+	sp := NewStreamProcessor(config, patternMatcher, eventCorrelator, ruleManager)
+
+	ctx := context.Background()
+
+	// ProcessEntry before Start should fail
+	entry := createTestLogEntry("ERROR", "test message", "test-tenant")
+	err := sp.ProcessEntry(ctx, entry)
+	assert.Error(t, err, "ProcessEntry should fail when stream processor is not running")
+	assert.Contains(t, err.Error(), "not running")
+
+	// Start the processor
+	err = sp.Start(ctx)
+	require.NoError(t, err)
+	defer func() { assert.NoError(t, sp.Stop(ctx)) }()
+
+	// ProcessEntry should succeed when running
+	err = sp.ProcessEntry(ctx, entry)
+	require.NoError(t, err)
+
+	// EntriesProcessed is incremented synchronously — no sleep needed
+	metrics, err := sp.GetMetrics(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), metrics.EntriesProcessed)
+}
+
+// TestStreamProcessor_ProcessEntry_BufferFull verifies the drop-on-full contract.
+// It uses direct struct access (same package) to set up a tiny buffer without
+// starting goroutines, making the test deterministic without timing dependencies.
+func TestStreamProcessor_ProcessEntry_BufferFull(t *testing.T) {
+	config := createTestConfig()
+	patternMatcher := NewPatternMatcher()
+	eventCorrelator := NewEventCorrelator(5 * time.Minute)
+	ruleManager := NewRuleManager(patternMatcher, eventCorrelator)
+
+	sp := NewStreamProcessor(config, patternMatcher, eventCorrelator, ruleManager)
+
+	// Manually configure a tiny buffer and mark running to isolate the drop-on-full
+	// path without goroutine scheduling races.
+	atomic.StoreInt32(&sp.running, 1)
+	sp.inputBuffer = make(chan interfaces.LogEntry, 2)
+	defer atomic.StoreInt32(&sp.running, 0)
+
+	ctx := context.Background()
+	entry := createTestLogEntry("ERROR", "test", "test-tenant")
+
+	// Fill the buffer to capacity
+	require.NoError(t, sp.ProcessEntry(ctx, entry))
+	require.NoError(t, sp.ProcessEntry(ctx, entry))
+
+	// Third call must fail with buffer-full error
+	err := sp.ProcessEntry(ctx, entry)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "input buffer full")
+
+	// DroppedEntries incremented; all 3 calls count toward EntriesProcessed
+	metrics, err := sp.GetMetrics(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), metrics.DroppedEntries)
+	assert.Equal(t, int64(3), metrics.EntriesProcessed)
+}
+
+func TestSIEMEngine_NoGoroutineLeak(t *testing.T) {
+	runtime.GC()
+	beforeCount := runtime.NumGoroutine()
+
+	triggerManager := NewMockTriggerManager()
+	workflowTrigger := NewMockWorkflowTrigger()
+	config := createTestConfig()
+
+	engine, err := NewSIEMEngine(config, triggerManager, workflowTrigger)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	err = engine.Start(ctx)
+	require.NoError(t, err)
+
+	// Give goroutines time to start
+	time.Sleep(50 * time.Millisecond)
+
+	err = engine.Stop(ctx)
+	require.NoError(t, err)
+
+	// Poll for goroutines to clean up (stopChan fires immediately, so should be fast)
+	var afterCount int
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		runtime.GC()
+		afterCount = runtime.NumGoroutine()
+		if afterCount <= beforeCount+2 {
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+
+	assert.LessOrEqual(t, afterCount, beforeCount+2,
+		"goroutine leak detected: started with %d goroutines, ended with %d", beforeCount, afterCount)
 }
 
 func TestPatternMatcher_BasicMatching(t *testing.T) {
@@ -323,7 +461,7 @@ func BenchmarkSIEMEngine_ThroughputTest(b *testing.B) {
 	ctx := context.Background()
 	err = engine.Start(ctx)
 	require.NoError(b, err)
-	defer func() { _ = engine.Stop(ctx) }()
+	defer func() { assert.NoError(b, engine.Stop(ctx)) }()
 
 	b.ResetTimer()
 	b.RunParallel(func(pb *testing.PB) {
@@ -400,7 +538,7 @@ func TestSIEMEngine_EndToEndProcessing(t *testing.T) {
 	ctx := context.Background()
 	err = engine.Start(ctx)
 	require.NoError(t, err)
-	defer func() { _ = engine.Stop(ctx) }()
+	defer func() { assert.NoError(t, engine.Stop(ctx)) }()
 
 	// Add a test pattern
 	pattern := &DetectionPattern{
@@ -469,7 +607,7 @@ func TestSIEMEngine_ThroughputRequirement(t *testing.T) {
 	ctx := context.Background()
 	err = engine.Start(ctx)
 	require.NoError(t, err)
-	defer func() { _ = engine.Stop(ctx) }()
+	defer func() { assert.NoError(t, engine.Stop(ctx)) }()
 
 	// Test processing 10,000+ entries per second
 	startTime := time.Now()
@@ -533,7 +671,7 @@ func TestSIEMEngine_LatencyRequirement(t *testing.T) {
 	ctx := context.Background()
 	err = engine.Start(ctx)
 	require.NoError(t, err)
-	defer func() { _ = engine.Stop(ctx) }()
+	defer func() { assert.NoError(t, engine.Stop(ctx)) }()
 
 	// Add pattern for latency testing
 	pattern := &DetectionPattern{
@@ -547,35 +685,38 @@ func TestSIEMEngine_LatencyRequirement(t *testing.T) {
 	err = engine.GetPatternMatcher().AddPattern(pattern)
 	require.NoError(t, err)
 
-	// Measure end-to-end latency for pattern detection
+	// Measure the actual ProcessLogEntry call latency (non-blocking send to stream processor).
+	// ProcessEntry increments EntriesProcessed synchronously, so this measures the real
+	// pipeline entry cost, not artificial sleep time.
 	numTests := 100
 	var totalLatency time.Duration
+	var maxLatency time.Duration
 
 	for i := 0; i < numTests; i++ {
-		startTime := time.Now()
 		entry := createTestLogEntry("INFO", "LATENCY_TEST message", "test-tenant")
+		startTime := time.Now()
 		err = engine.ProcessLogEntry(ctx, entry)
 		require.NoError(t, err)
-
-		// Wait for processing (this is a simplified latency test)
-		// In a real system, we'd measure actual processing completion
-		time.Sleep(1 * time.Millisecond)
 		latency := time.Since(startTime)
 		totalLatency += latency
+		if latency > maxLatency {
+			maxLatency = latency
+		}
 	}
 
 	averageLatency := totalLatency / time.Duration(numTests)
-	t.Logf("Average latency: %v", averageLatency)
+	t.Logf("ProcessLogEntry latency: avg=%v max=%v", averageLatency, maxLatency)
 
-	// Verify latency meets requirement (<100ms)
+	// Non-blocking send to an in-process channel must complete well under 100ms
 	assert.Less(t, averageLatency, 100*time.Millisecond,
-		"Latency requirement not met: got %v, need <100ms", averageLatency)
+		"ProcessLogEntry avg latency %v exceeds 100ms target", averageLatency)
+	assert.Less(t, maxLatency, 100*time.Millisecond,
+		"ProcessLogEntry max latency %v exceeds 100ms target", maxLatency)
 
-	// Check metrics
-	metrics, err := engine.GetMetrics(ctx)
+	// Verify all entries were tracked
+	spMetrics, err := engine.streamProcessor.GetMetrics(ctx)
 	require.NoError(t, err)
-	t.Logf("Engine metrics - Average latency: %.2fms, Max latency: %.2fms",
-		metrics.AverageLatency, metrics.MaxLatency)
+	assert.GreaterOrEqual(t, spMetrics.EntriesProcessed, int64(numTests))
 }
 
 func TestSIEMEngine_MemoryUsage(t *testing.T) {
@@ -608,7 +749,7 @@ func TestSIEMEngine_MemoryUsage(t *testing.T) {
 	// Wait for processing
 	time.Sleep(1 * time.Second)
 
-	_ = engine.Stop(ctx)
+	require.NoError(t, engine.Stop(ctx))
 
 	// Force GC and check memory
 	runtime.GC()
@@ -640,7 +781,7 @@ func TestSIEMEngine_StressTest(t *testing.T) {
 	ctx := context.Background()
 	err = engine.Start(ctx)
 	require.NoError(t, err)
-	defer func() { _ = engine.Stop(ctx) }()
+	defer func() { assert.NoError(t, engine.Stop(ctx)) }()
 
 	// Add multiple patterns
 	for i := 0; i < 10; i++ {

--- a/features/siem/stream_processor.go
+++ b/features/siem/stream_processor.go
@@ -75,6 +75,9 @@ type WorkerStats struct {
 	Errors           int64
 }
 
+// streamWorkerQueueSize is the per-worker batch queue depth inside StreamProcessorImpl.
+const streamWorkerQueueSize = 1000
+
 // NewStreamProcessor creates a new high-performance stream processor
 func NewStreamProcessor(config ProcessingConfig, patternMatcher PatternMatcher,
 	eventCorrelator EventCorrelator, ruleManager RuleManager) *StreamProcessorImpl {
@@ -93,9 +96,6 @@ func NewStreamProcessor(config ProcessingConfig, patternMatcher PatternMatcher,
 	}
 	if config.WorkerCount == 0 {
 		config.WorkerCount = runtime.NumCPU() * 2 // CPU-bound optimization
-	}
-	if config.WorkerQueueSize == 0 {
-		config.WorkerQueueSize = 1000
 	}
 	if config.MaxLatency == 0 {
 		config.MaxLatency = 100 * time.Millisecond // Target latency
@@ -149,7 +149,7 @@ func (sp *StreamProcessorImpl) Start(ctx context.Context) error {
 		sp.workers[i] = &StreamWorker{
 			id:              i,
 			processor:       sp,
-			inputChan:       make(chan *ProcessingBatch, sp.config.WorkerQueueSize),
+			inputChan:       make(chan *ProcessingBatch, streamWorkerQueueSize),
 			logger:          logger.WithField("worker_id", i),
 			processingStats: &WorkerStats{},
 		}
@@ -223,6 +223,24 @@ func (sp *StreamProcessorImpl) Stop(ctx context.Context) error {
 	}
 
 	return nil
+}
+
+// ProcessEntry sends a single log entry into the processing pipeline.
+// Non-blocking: drops the entry and returns an error when the internal buffer is full.
+func (sp *StreamProcessorImpl) ProcessEntry(ctx context.Context, entry interfaces.LogEntry) error {
+	if atomic.LoadInt32(&sp.running) == 0 {
+		return fmt.Errorf("stream processor not running")
+	}
+
+	atomic.AddInt64(&sp.metrics.EntriesProcessed, 1)
+
+	select {
+	case sp.inputBuffer <- entry:
+		return nil
+	default:
+		atomic.AddInt64(&sp.metrics.DroppedEntries, 1)
+		return fmt.Errorf("input buffer full, entry dropped")
+	}
 }
 
 // ProcessStream processes a continuous stream of log entries
@@ -367,14 +385,47 @@ func (sp *StreamProcessorImpl) updateMetrics() {
 	sp.metrics.GoroutineCount = runtime.NumGoroutine()
 }
 
-// GetMetrics returns current processing metrics
+// GetMetrics returns current processing metrics.
+// Counter fields updated via atomic.AddInt64 outside metricsLock are read with
+// atomic.LoadInt64 to avoid races with the struct copy of non-atomic fields.
 func (sp *StreamProcessorImpl) GetMetrics(ctx context.Context) (*ProcessingMetrics, error) {
+	// Read non-atomic fields under the RLock (updated only in updateMetrics).
 	sp.metricsLock.RLock()
-	defer sp.metricsLock.RUnlock()
+	uptime := sp.metrics.Uptime
+	lastProcessedTime := sp.metrics.LastProcessedTime
+	startTime := sp.metrics.StartTime
+	entriesPerSecond := sp.metrics.EntriesPerSecond
+	batchesProcessed := sp.metrics.BatchesProcessed
+	averageLatency := sp.metrics.AverageLatency
+	p95Latency := sp.metrics.P95Latency
+	p99Latency := sp.metrics.P99Latency
+	bufferUtilization := sp.metrics.BufferUtilization
+	memoryUsage := sp.metrics.MemoryUsage
+	goroutineCount := sp.metrics.GoroutineCount
+	workflowsTriggered := sp.metrics.WorkflowsTriggered
+	sp.metricsLock.RUnlock()
 
-	// Return a copy to prevent concurrent modification
-	metricsCopy := *sp.metrics
-	return &metricsCopy, nil
+	// Atomic loads for fields updated via atomic.AddInt64 without holding metricsLock.
+	return &ProcessingMetrics{
+		EntriesProcessed:        atomic.LoadInt64(&sp.metrics.EntriesProcessed),
+		DroppedEntries:          atomic.LoadInt64(&sp.metrics.DroppedEntries),
+		ProcessingErrors:        atomic.LoadInt64(&sp.metrics.ProcessingErrors),
+		PatternsMatched:         atomic.LoadInt64(&sp.metrics.PatternsMatched),
+		EventsCorrelated:        atomic.LoadInt64(&sp.metrics.EventsCorrelated),
+		SecurityEventsGenerated: atomic.LoadInt64(&sp.metrics.SecurityEventsGenerated),
+		WorkflowsTriggered:      workflowsTriggered,
+		BatchesProcessed:        batchesProcessed,
+		EntriesPerSecond:        entriesPerSecond,
+		AverageLatency:          averageLatency,
+		P95Latency:              p95Latency,
+		P99Latency:              p99Latency,
+		BufferUtilization:       bufferUtilization,
+		MemoryUsage:             memoryUsage,
+		GoroutineCount:          goroutineCount,
+		StartTime:               startTime,
+		LastProcessedTime:       lastProcessedTime,
+		Uptime:                  uptime,
+	}, nil
 }
 
 // Run executes the main worker processing loop


### PR DESCRIPTION
## Summary

- **Deletes the dead ProcessingWorker pool** (`ProcessingWorker`, `WorkerMetrics`, `LoadBalancer` types; `initializeWorkers`, `processInputLoop`, `loadBalancingLoop`, `optimizeLoadBalancing` methods; `workers`, `loadBalancer`, `logEntryChannel`, `inputBuffer`, `workerGroup` struct fields) — every `ProcessLogEntry` call was being silently dropped into a dead channel that nothing consumed.
- **Routes `ProcessLogEntry` directly to `StreamProcessor.ProcessEntry`** — a new method added to the `StreamProcessor` interface and implemented on `StreamProcessorImpl` with a non-blocking drop-on-full contract mirroring `ProcessStream`.
- **Simplifies `Stop()`** — signals `stopChan` then calls `streamProcessor.Stop()` + `eventCorrelator.Stop()` only; no orphaned `workerGroup.Wait()` or channel closes.
- **Removes `WorkerQueueSize` from `ProcessingConfig`** (replaced by local constant `streamWorkerQueueSize=1000` inside `StreamProcessorImpl`).
- **Removes `ActiveWorkers` from `SIEMMetrics`** (only set by the deleted `initializeWorkers`).
- **Fixes three pre-existing defects** exposed by the new code path: nil pointer in `BatchProcessor.addEntryToBatch` after timer flush; data race in `PatternMatcherImpl.matchEntryAgainstPatterns` (concurrent `LastUsed`/`MatchCount` writes); data race in `StreamProcessorImpl.GetMetrics` (struct copy under RLock racing with `atomic.AddInt64` writes without the lock).

## Specialist Review Results

| Reviewer | Round 1 | Round 2 | Round 3 |
|---|---|---|---|
| **QA Test Runner** | FAIL (race detector: 4 races) | FAIL (lint: unused `updateLatencyMetrics`) | **PASS** |
| **QA Code Reviewer** | FAIL (5 blocking) | FAIL (2 blocking) | **PASS** |
| **Security Engineer** | **PASS** | — | — |

All specialists report PASS. Marker file written at `/tmp/agent-validation-passed`.

**Note on pre-existing `MockTriggerManager`/`MockWorkflowTrigger`:** These workflow boundary test doubles predate this story and are not introduced by it. The story's own Implementation Notes scope "no mocks" to SIEM components (`SIEMEngine` + `StreamProcessorImpl`). Removal of workflow trigger mocks is tracked as pre-existing technical debt.

## Test plan

- [x] `TestSIEMEngine_ProcessLogEntry_RoutesToStreamProcessor` — non-skippable, verifies routing synchronously
- [x] `TestStreamProcessor_ProcessEntry` — stopped-state error, running-state success, synchronous metric assertion
- [x] `TestStreamProcessor_ProcessEntry_BufferFull` — deterministic buffer-full contract (DroppedEntries, EntriesProcessed)
- [x] `TestSIEMEngine_NoGoroutineLeak` — start+stop cycle with goroutine count polling
- [x] All existing tests pass with `-race` flag
- [x] `make test-agent-complete`: unit, integration, linting, architecture, cross-platform builds (linux/amd64, linux/arm64, darwin/amd64, darwin/arm64, windows/amd64)

Fixes #1041

🤖 Generated with [Claude Code](https://claude.ai/claude-code)