### PR TITLE
cfg: wire controller and trace commands through APIClient for TLS verification (Issue #1034)

### DIFF
--- a/cmd/cfg/cmd/api_client.go
+++ b/cmd/cfg/cmd/api_client.go
@@ -210,6 +210,12 @@ func (c *APIClient) RevokeToken(ctx context.Context, tokenStr string) (*APIToken
 	return &tokenResp, nil
 }
 
+// Get performs an HTTP GET request and returns the response.
+// Callers are responsible for closing resp.Body.
+func (c *APIClient) Get(ctx context.Context, path string) (*http.Response, error) {
+	return c.doRequest(ctx, "GET", path, nil)
+}
+
 // doRequest performs an HTTP request with authentication
 func (c *APIClient) doRequest(ctx context.Context, method, path string, body io.Reader) (*http.Response, error) {
 	url := c.baseURL + path

--- a/cmd/cfg/cmd/api_client_test.go
+++ b/cmd/cfg/cmd/api_client_test.go
@@ -565,3 +565,36 @@ func TestAPIClientRequestHeaders(t *testing.T) {
 		require.NoError(t, err)
 	})
 }
+
+func TestAPIClientGet(t *testing.T) {
+	t.Run("returns response for successful GET", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "GET", r.Method)
+			assert.Equal(t, "/api/v1/test", r.URL.Path)
+			assert.Equal(t, "Bearer test-key", r.Header.Get("Authorization"))
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"ok":true}`))
+		}))
+		defer server.Close()
+
+		cfg := &APIClientConfig{BaseURL: server.URL, APIKey: "test-key", TLSInsecure: true}
+		client, err := NewAPIClient(cfg)
+		require.NoError(t, err)
+
+		resp, err := client.Get(context.Background(), "/api/v1/test")
+		require.NoError(t, err)
+		defer func() { _ = resp.Body.Close() }()
+
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+	})
+
+	t.Run("returns error on connection failure", func(t *testing.T) {
+		cfg := &APIClientConfig{BaseURL: "http://127.0.0.1:0", TLSInsecure: true}
+		client, err := NewAPIClient(cfg)
+		require.NoError(t, err)
+
+		resp, err := client.Get(context.Background(), "/api/v1/test")
+		assert.Nil(t, resp)
+		assert.Error(t, err)
+	})
+}

--- a/cmd/cfg/cmd/client_helpers.go
+++ b/cmd/cfg/cmd/client_helpers.go
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+package cmd
+
+import (
+	"fmt"
+	"os"
+)
+
+// newClientFromFlags creates an APIClient from resolved flag values.
+// Reads the CA cert from disk if caCertPath is non-empty, then delegates to NewAPIClient.
+// Env var resolution is the responsibility of each command's get*Client() function.
+func newClientFromFlags(url, apiKey, caCertPath string, insecure bool) (*APIClient, error) {
+	var caCertPEM []byte
+	if caCertPath != "" {
+		var err error
+		// #nosec G304 - CA certificate path is intentionally provided by user via CLI flag or env var
+		caCertPEM, err = os.ReadFile(caCertPath)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read CA certificate: %w", err)
+		}
+	}
+
+	cfg := &APIClientConfig{
+		BaseURL:     url,
+		APIKey:      apiKey,
+		CACertPEM:   caCertPEM,
+		TLSInsecure: insecure,
+	}
+
+	return NewAPIClient(cfg)
+}

--- a/cmd/cfg/cmd/client_helpers_test.go
+++ b/cmd/cfg/cmd/client_helpers_test.go
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+package cmd
+
+import (
+	"net/http"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewClientFromFlags_EmptyCACert_SystemPool(t *testing.T) {
+	client, err := newClientFromFlags("https://example.com", "test-key", "", false)
+	require.NoError(t, err)
+	require.NotNil(t, client)
+
+	transport := client.httpClient.Transport.(*http.Transport)
+	assert.Nil(t, transport.TLSClientConfig.RootCAs)
+	assert.False(t, transport.TLSClientConfig.InsecureSkipVerify)
+}
+
+func TestNewClientFromFlags_Insecure(t *testing.T) {
+	client, err := newClientFromFlags("https://example.com", "test-key", "", true)
+	require.NoError(t, err)
+	require.NotNil(t, client)
+
+	transport := client.httpClient.Transport.(*http.Transport)
+	assert.True(t, transport.TLSClientConfig.InsecureSkipVerify)
+}
+
+func TestNewClientFromFlags_ValidCACert(t *testing.T) {
+	certPEM := generateTestCACert(t)
+
+	tmpFile, err := os.CreateTemp(t.TempDir(), "ca-cert-*.pem")
+	require.NoError(t, err)
+	_, err = tmpFile.Write(certPEM)
+	require.NoError(t, err)
+	require.NoError(t, tmpFile.Close())
+
+	client, err := newClientFromFlags("https://example.com", "test-key", tmpFile.Name(), false)
+	require.NoError(t, err)
+	require.NotNil(t, client)
+
+	transport := client.httpClient.Transport.(*http.Transport)
+	assert.NotNil(t, transport.TLSClientConfig.RootCAs)
+	assert.False(t, transport.TLSClientConfig.InsecureSkipVerify)
+}
+
+func TestNewClientFromFlags_MissingCACertFile(t *testing.T) {
+	client, err := newClientFromFlags("https://example.com", "test-key", "/nonexistent/path/ca.pem", false)
+	assert.Nil(t, client)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to read CA certificate")
+}

--- a/cmd/cfg/cmd/controller.go
+++ b/cmd/cfg/cmd/controller.go
@@ -4,6 +4,7 @@
 package cmd
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -17,9 +18,11 @@ import (
 
 var (
 	// Controller command flags
-	healthURL    string
-	healthAPIKey string
-	healthFormat string
+	healthURL             string
+	healthAPIKey          string
+	healthFormat          string
+	controllerTLSCACert   string
+	controllerTLSInsecure bool
 )
 
 // controllerCmd represents the controller command
@@ -90,6 +93,8 @@ func init() {
 	controllerCmd.PersistentFlags().StringVar(&healthURL, "url", "", "Controller API URL (required)")
 	controllerCmd.PersistentFlags().StringVar(&healthAPIKey, "api-key", "", "API key for authentication")
 	controllerCmd.PersistentFlags().StringVar(&healthFormat, "format", "text", "Output format (text, json)")
+	controllerCmd.PersistentFlags().StringVar(&controllerTLSCACert, "tls-ca-cert", "", "Path to CA certificate for TLS verification (env: CFGMS_TLS_CA_CERT)")
+	controllerCmd.PersistentFlags().BoolVar(&controllerTLSInsecure, "tls-insecure", false, "Skip TLS verification (development only, env: CFGMS_TLS_INSECURE)")
 
 	_ = controllerCmd.MarkPersistentFlagRequired("url")
 
@@ -98,10 +103,38 @@ func init() {
 	controllerCmd.AddCommand(controllerMetricsCmd)
 }
 
+// getControllerClient creates an API client using controller flags or environment variables
+func getControllerClient() (*APIClient, error) {
+	apiURL := strings.TrimSuffix(healthURL, "/")
+	if apiURL == "" {
+		apiURL = os.Getenv("CFGMS_API_URL")
+	}
+
+	apiKey := healthAPIKey
+	if apiKey == "" {
+		apiKey = os.Getenv("CFGMS_API_KEY")
+	}
+
+	tlsInsecure := controllerTLSInsecure
+	if !tlsInsecure && os.Getenv("CFGMS_TLS_INSECURE") == "true" {
+		tlsInsecure = true
+	}
+
+	tlsCACertPath := controllerTLSCACert
+	if tlsCACertPath == "" {
+		tlsCACertPath = os.Getenv("CFGMS_TLS_CA_CERT")
+	}
+
+	return newClientFromFlags(apiURL, apiKey, tlsCACertPath, tlsInsecure)
+}
+
 func runControllerStatus(cmd *cobra.Command, args []string) error {
-	// Make API request
-	url := strings.TrimSuffix(healthURL, "/") + "/api/v1/health/detailed"
-	resp, err := makeAPIRequest(url, healthAPIKey)
+	client, err := getControllerClient()
+	if err != nil {
+		return fmt.Errorf("failed to create API client: %w", err)
+	}
+
+	resp, err := client.Get(context.Background(), "/api/v1/health/detailed")
 	if err != nil {
 		return fmt.Errorf("failed to fetch health status: %w", err)
 	}
@@ -192,9 +225,12 @@ func runControllerStatus(cmd *cobra.Command, args []string) error {
 }
 
 func runControllerMetrics(cmd *cobra.Command, args []string) error {
-	// Make API request
-	url := strings.TrimSuffix(healthURL, "/") + "/api/v1/health/metrics"
-	resp, err := makeAPIRequest(url, healthAPIKey)
+	client, err := getControllerClient()
+	if err != nil {
+		return fmt.Errorf("failed to create API client: %w", err)
+	}
+
+	resp, err := client.Get(context.Background(), "/api/v1/health/metrics")
 	if err != nil {
 		return fmt.Errorf("failed to fetch metrics: %w", err)
 	}
@@ -320,23 +356,6 @@ func runControllerMetrics(cmd *cobra.Command, args []string) error {
 	}
 
 	return nil
-}
-
-func makeAPIRequest(url, apiKey string) (*http.Response, error) {
-	req, err := http.NewRequest("GET", url, nil)
-	if err != nil {
-		return nil, err
-	}
-
-	if apiKey != "" {
-		req.Header.Set("Authorization", "Bearer "+apiKey)
-	}
-
-	client := &http.Client{
-		Timeout: 10 * time.Second,
-	}
-
-	return client.Do(req)
 }
 
 func getStatusIcon(status string) string {

--- a/cmd/cfg/cmd/controller_test.go
+++ b/cmd/cfg/cmd/controller_test.go
@@ -1,0 +1,309 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+package cmd
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetControllerClient_TLSCACertFlagWired(t *testing.T) {
+	certPEM := generateTestCACert(t)
+
+	tmpFile, err := os.CreateTemp(t.TempDir(), "ca-cert-*.pem")
+	require.NoError(t, err)
+	_, err = tmpFile.Write(certPEM)
+	require.NoError(t, err)
+	require.NoError(t, tmpFile.Close())
+
+	origURL := healthURL
+	origCACert := controllerTLSCACert
+	origInsecure := controllerTLSInsecure
+	t.Cleanup(func() {
+		healthURL = origURL
+		controllerTLSCACert = origCACert
+		controllerTLSInsecure = origInsecure
+	})
+
+	healthURL = "https://controller.example.com"
+	controllerTLSCACert = tmpFile.Name()
+	controllerTLSInsecure = false
+
+	client, err := getControllerClient()
+	require.NoError(t, err)
+	require.NotNil(t, client)
+
+	transport := client.httpClient.Transport.(*http.Transport)
+	assert.NotNil(t, transport.TLSClientConfig.RootCAs)
+	assert.False(t, transport.TLSClientConfig.InsecureSkipVerify)
+}
+
+func TestGetControllerClient_TLSInsecureFlagWired(t *testing.T) {
+	origURL := healthURL
+	origCACert := controllerTLSCACert
+	origInsecure := controllerTLSInsecure
+	t.Cleanup(func() {
+		healthURL = origURL
+		controllerTLSCACert = origCACert
+		controllerTLSInsecure = origInsecure
+	})
+
+	healthURL = "https://controller.example.com"
+	controllerTLSCACert = ""
+	controllerTLSInsecure = true
+
+	client, err := getControllerClient()
+	require.NoError(t, err)
+	require.NotNil(t, client)
+
+	transport := client.httpClient.Transport.(*http.Transport)
+	assert.True(t, transport.TLSClientConfig.InsecureSkipVerify)
+}
+
+func TestGetControllerClient_TLSCACertEnvWired(t *testing.T) {
+	certPEM := generateTestCACert(t)
+
+	tmpFile, err := os.CreateTemp(t.TempDir(), "ca-cert-*.pem")
+	require.NoError(t, err)
+	_, err = tmpFile.Write(certPEM)
+	require.NoError(t, err)
+	require.NoError(t, tmpFile.Close())
+
+	origURL := healthURL
+	origCACert := controllerTLSCACert
+	origInsecure := controllerTLSInsecure
+	t.Cleanup(func() {
+		healthURL = origURL
+		controllerTLSCACert = origCACert
+		controllerTLSInsecure = origInsecure
+	})
+	t.Setenv("CFGMS_TLS_CA_CERT", tmpFile.Name())
+	t.Setenv("CFGMS_TLS_INSECURE", "")
+
+	healthURL = "https://controller.example.com"
+	controllerTLSCACert = ""
+	controllerTLSInsecure = false
+
+	client, err := getControllerClient()
+	require.NoError(t, err)
+	require.NotNil(t, client)
+
+	transport := client.httpClient.Transport.(*http.Transport)
+	assert.NotNil(t, transport.TLSClientConfig.RootCAs)
+}
+
+func TestGetControllerClient_TLSInsecureEnvWired(t *testing.T) {
+	origURL := healthURL
+	origCACert := controllerTLSCACert
+	origInsecure := controllerTLSInsecure
+	t.Cleanup(func() {
+		healthURL = origURL
+		controllerTLSCACert = origCACert
+		controllerTLSInsecure = origInsecure
+	})
+	t.Setenv("CFGMS_TLS_INSECURE", "true")
+
+	healthURL = "https://controller.example.com"
+	controllerTLSCACert = ""
+	controllerTLSInsecure = false
+
+	client, err := getControllerClient()
+	require.NoError(t, err)
+	require.NotNil(t, client)
+
+	transport := client.httpClient.Transport.(*http.Transport)
+	assert.True(t, transport.TLSClientConfig.InsecureSkipVerify)
+}
+
+func TestControllerCmd_TLSFlagsRegistered(t *testing.T) {
+	assert.NotNil(t, controllerCmd.PersistentFlags().Lookup("tls-ca-cert"), "--tls-ca-cert flag must be registered on controllerCmd")
+	assert.NotNil(t, controllerCmd.PersistentFlags().Lookup("tls-insecure"), "--tls-insecure flag must be registered on controllerCmd")
+}
+
+func newControllerHealthServer(t *testing.T) *httptest.Server {
+	t.Helper()
+
+	now := time.Now().UTC()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/api/v1/health/detailed":
+			resp := map[string]interface{}{
+				"status":         "healthy",
+				"timestamp":      now.Format(time.RFC3339),
+				"uptime_seconds": int64(3600),
+				"components":     map[string]interface{}{},
+				"alerts":         []interface{}{},
+			}
+			_ = json.NewEncoder(w).Encode(resp)
+		case "/api/v1/health/metrics":
+			resp := map[string]interface{}{
+				"timestamp": now.Format(time.RFC3339),
+				"transport": map[string]interface{}{
+					"connected_stewards": 5,
+					"stream_errors":      int64(0),
+					"messages_sent":      int64(100),
+					"messages_received":  int64(100),
+					"avg_latency_ns":     int64(1000),
+					"collected_at":       now.Format(time.RFC3339),
+				},
+			}
+			_ = json.NewEncoder(w).Encode(resp)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+}
+
+func TestRunControllerStatus_TextOutput(t *testing.T) {
+	server := newControllerHealthServer(t)
+	defer server.Close()
+
+	origURL := healthURL
+	origFormat := healthFormat
+	origInsecure := controllerTLSInsecure
+	t.Cleanup(func() {
+		healthURL = origURL
+		healthFormat = origFormat
+		controllerTLSInsecure = origInsecure
+	})
+
+	healthURL = server.URL
+	healthFormat = "text"
+	controllerTLSInsecure = true
+
+	output := captureStdout(t, func() {
+		err := runControllerStatus(controllerStatusCmd, nil)
+		require.NoError(t, err)
+	})
+
+	assert.Contains(t, output, "Controller Health Status")
+	assert.Contains(t, output, "HEALTHY")
+}
+
+func TestRunControllerStatus_JSONOutput(t *testing.T) {
+	server := newControllerHealthServer(t)
+	defer server.Close()
+
+	origURL := healthURL
+	origFormat := healthFormat
+	origInsecure := controllerTLSInsecure
+	t.Cleanup(func() {
+		healthURL = origURL
+		healthFormat = origFormat
+		controllerTLSInsecure = origInsecure
+	})
+
+	healthURL = server.URL
+	healthFormat = "json"
+	controllerTLSInsecure = true
+
+	output := captureStdout(t, func() {
+		err := runControllerStatus(controllerStatusCmd, nil)
+		require.NoError(t, err)
+	})
+
+	assert.True(t, json.Valid([]byte(output)), "output must be valid JSON")
+}
+
+func TestRunControllerStatus_APIError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+		_, _ = w.Write([]byte("service unavailable"))
+	}))
+	defer server.Close()
+
+	origURL := healthURL
+	origInsecure := controllerTLSInsecure
+	t.Cleanup(func() {
+		healthURL = origURL
+		controllerTLSInsecure = origInsecure
+	})
+
+	healthURL = server.URL
+	controllerTLSInsecure = true
+
+	err := runControllerStatus(controllerStatusCmd, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "API request failed")
+}
+
+func TestRunControllerMetrics_TextOutput(t *testing.T) {
+	server := newControllerHealthServer(t)
+	defer server.Close()
+
+	origURL := healthURL
+	origFormat := healthFormat
+	origInsecure := controllerTLSInsecure
+	t.Cleanup(func() {
+		healthURL = origURL
+		healthFormat = origFormat
+		controllerTLSInsecure = origInsecure
+	})
+
+	healthURL = server.URL
+	healthFormat = "text"
+	controllerTLSInsecure = true
+
+	output := captureStdout(t, func() {
+		err := runControllerMetrics(controllerMetricsCmd, nil)
+		require.NoError(t, err)
+	})
+
+	assert.Contains(t, output, "Controller Metrics")
+	assert.Contains(t, output, "Transport")
+}
+
+func TestRunControllerMetrics_JSONOutput(t *testing.T) {
+	server := newControllerHealthServer(t)
+	defer server.Close()
+
+	origURL := healthURL
+	origFormat := healthFormat
+	origInsecure := controllerTLSInsecure
+	t.Cleanup(func() {
+		healthURL = origURL
+		healthFormat = origFormat
+		controllerTLSInsecure = origInsecure
+	})
+
+	healthURL = server.URL
+	healthFormat = "json"
+	controllerTLSInsecure = true
+
+	output := captureStdout(t, func() {
+		err := runControllerMetrics(controllerMetricsCmd, nil)
+		require.NoError(t, err)
+	})
+
+	assert.True(t, json.Valid([]byte(output)), "output must be valid JSON")
+}
+
+func TestRunControllerMetrics_APIError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte("internal error"))
+	}))
+	defer server.Close()
+
+	origURL := healthURL
+	origInsecure := controllerTLSInsecure
+	t.Cleanup(func() {
+		healthURL = origURL
+		controllerTLSInsecure = origInsecure
+	})
+
+	healthURL = server.URL
+	controllerTLSInsecure = true
+
+	err := runControllerMetrics(controllerMetricsCmd, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "API request failed")
+}

--- a/cmd/cfg/cmd/token.go
+++ b/cmd/cfg/cmd/token.go
@@ -190,25 +190,7 @@ func getAPIClient() (*APIClient, error) {
 		tlsCACertPath = os.Getenv("CFGMS_TLS_CA_CERT")
 	}
 
-	// Load CA certificate if provided
-	var caCertPEM []byte
-	if tlsCACertPath != "" {
-		var err error
-		// #nosec G304 - CA certificate path is intentionally provided by user via CLI flag or env var
-		caCertPEM, err = os.ReadFile(tlsCACertPath)
-		if err != nil {
-			return nil, fmt.Errorf("failed to read CA certificate: %w", err)
-		}
-	}
-
-	cfg := &APIClientConfig{
-		BaseURL:     apiURL,
-		APIKey:      apiKey,
-		CACertPEM:   caCertPEM,
-		TLSInsecure: tlsInsecure,
-	}
-
-	return NewAPIClient(cfg)
+	return newClientFromFlags(apiURL, apiKey, tlsCACertPath, tlsInsecure)
 }
 
 func runTokenCreate(cmd *cobra.Command, args []string) error {

--- a/cmd/cfg/cmd/trace.go
+++ b/cmd/cfg/cmd/trace.go
@@ -4,6 +4,7 @@
 package cmd
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -17,9 +18,11 @@ import (
 
 var (
 	// Trace command flags
-	traceURL    string
-	traceAPIKey string
-	traceFormat string
+	traceURL         string
+	traceAPIKey      string
+	traceFormat      string
+	traceTLSCACert   string
+	traceTLSInsecure bool
 )
 
 // traceCmd represents the trace command
@@ -48,16 +51,46 @@ func init() {
 	traceCmd.Flags().StringVar(&traceURL, "url", "", "Controller API URL (required)")
 	traceCmd.Flags().StringVar(&traceAPIKey, "api-key", "", "API key for authentication")
 	traceCmd.Flags().StringVar(&traceFormat, "format", "text", "Output format (text, json)")
+	traceCmd.Flags().StringVar(&traceTLSCACert, "tls-ca-cert", "", "Path to CA certificate for TLS verification (env: CFGMS_TLS_CA_CERT)")
+	traceCmd.Flags().BoolVar(&traceTLSInsecure, "tls-insecure", false, "Skip TLS verification (development only, env: CFGMS_TLS_INSECURE)")
 
 	_ = traceCmd.MarkFlagRequired("url")
+}
+
+// getTraceClient creates an API client using trace flags or environment variables
+func getTraceClient() (*APIClient, error) {
+	apiURL := strings.TrimSuffix(traceURL, "/")
+	if apiURL == "" {
+		apiURL = os.Getenv("CFGMS_API_URL")
+	}
+
+	apiKey := traceAPIKey
+	if apiKey == "" {
+		apiKey = os.Getenv("CFGMS_API_KEY")
+	}
+
+	tlsInsecure := traceTLSInsecure
+	if !tlsInsecure && os.Getenv("CFGMS_TLS_INSECURE") == "true" {
+		tlsInsecure = true
+	}
+
+	tlsCACertPath := traceTLSCACert
+	if tlsCACertPath == "" {
+		tlsCACertPath = os.Getenv("CFGMS_TLS_CA_CERT")
+	}
+
+	return newClientFromFlags(apiURL, apiKey, tlsCACertPath, tlsInsecure)
 }
 
 func runTrace(cmd *cobra.Command, args []string) error {
 	requestID := args[0]
 
-	// Make API request
-	url := strings.TrimSuffix(traceURL, "/") + "/api/v1/health/trace/" + requestID
-	resp, err := makeAPIRequest(url, traceAPIKey)
+	client, err := getTraceClient()
+	if err != nil {
+		return fmt.Errorf("failed to create API client: %w", err)
+	}
+
+	resp, err := client.Get(context.Background(), "/api/v1/health/trace/"+requestID)
 	if err != nil {
 		return fmt.Errorf("failed to fetch trace: %w", err)
 	}

--- a/cmd/cfg/cmd/trace_test.go
+++ b/cmd/cfg/cmd/trace_test.go
@@ -1,0 +1,252 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+package cmd
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetTraceClient_TLSCACertFlagWired(t *testing.T) {
+	certPEM := generateTestCACert(t)
+
+	tmpFile, err := os.CreateTemp(t.TempDir(), "ca-cert-*.pem")
+	require.NoError(t, err)
+	_, err = tmpFile.Write(certPEM)
+	require.NoError(t, err)
+	require.NoError(t, tmpFile.Close())
+
+	origURL := traceURL
+	origCACert := traceTLSCACert
+	origInsecure := traceTLSInsecure
+	t.Cleanup(func() {
+		traceURL = origURL
+		traceTLSCACert = origCACert
+		traceTLSInsecure = origInsecure
+	})
+
+	traceURL = "https://controller.example.com"
+	traceTLSCACert = tmpFile.Name()
+	traceTLSInsecure = false
+
+	client, err := getTraceClient()
+	require.NoError(t, err)
+	require.NotNil(t, client)
+
+	transport := client.httpClient.Transport.(*http.Transport)
+	assert.NotNil(t, transport.TLSClientConfig.RootCAs)
+	assert.False(t, transport.TLSClientConfig.InsecureSkipVerify)
+}
+
+func TestGetTraceClient_TLSInsecureFlagWired(t *testing.T) {
+	origURL := traceURL
+	origCACert := traceTLSCACert
+	origInsecure := traceTLSInsecure
+	t.Cleanup(func() {
+		traceURL = origURL
+		traceTLSCACert = origCACert
+		traceTLSInsecure = origInsecure
+	})
+
+	traceURL = "https://controller.example.com"
+	traceTLSCACert = ""
+	traceTLSInsecure = true
+
+	client, err := getTraceClient()
+	require.NoError(t, err)
+	require.NotNil(t, client)
+
+	transport := client.httpClient.Transport.(*http.Transport)
+	assert.True(t, transport.TLSClientConfig.InsecureSkipVerify)
+}
+
+func TestGetTraceClient_TLSCACertEnvWired(t *testing.T) {
+	certPEM := generateTestCACert(t)
+
+	tmpFile, err := os.CreateTemp(t.TempDir(), "ca-cert-*.pem")
+	require.NoError(t, err)
+	_, err = tmpFile.Write(certPEM)
+	require.NoError(t, err)
+	require.NoError(t, tmpFile.Close())
+
+	origURL := traceURL
+	origCACert := traceTLSCACert
+	origInsecure := traceTLSInsecure
+	t.Cleanup(func() {
+		traceURL = origURL
+		traceTLSCACert = origCACert
+		traceTLSInsecure = origInsecure
+	})
+	t.Setenv("CFGMS_TLS_CA_CERT", tmpFile.Name())
+	t.Setenv("CFGMS_TLS_INSECURE", "")
+
+	traceURL = "https://controller.example.com"
+	traceTLSCACert = ""
+	traceTLSInsecure = false
+
+	client, err := getTraceClient()
+	require.NoError(t, err)
+	require.NotNil(t, client)
+
+	transport := client.httpClient.Transport.(*http.Transport)
+	assert.NotNil(t, transport.TLSClientConfig.RootCAs)
+}
+
+func TestGetTraceClient_TLSInsecureEnvWired(t *testing.T) {
+	origURL := traceURL
+	origCACert := traceTLSCACert
+	origInsecure := traceTLSInsecure
+	t.Cleanup(func() {
+		traceURL = origURL
+		traceTLSCACert = origCACert
+		traceTLSInsecure = origInsecure
+	})
+	t.Setenv("CFGMS_TLS_INSECURE", "true")
+
+	traceURL = "https://controller.example.com"
+	traceTLSCACert = ""
+	traceTLSInsecure = false
+
+	client, err := getTraceClient()
+	require.NoError(t, err)
+	require.NotNil(t, client)
+
+	transport := client.httpClient.Transport.(*http.Transport)
+	assert.True(t, transport.TLSClientConfig.InsecureSkipVerify)
+}
+
+func TestTraceCmd_TLSFlagsRegistered(t *testing.T) {
+	assert.NotNil(t, traceCmd.Flags().Lookup("tls-ca-cert"), "--tls-ca-cert flag must be registered on traceCmd")
+	assert.NotNil(t, traceCmd.Flags().Lookup("tls-insecure"), "--tls-insecure flag must be registered on traceCmd")
+}
+
+func newTraceServer(t *testing.T, requestID string) *httptest.Server {
+	t.Helper()
+
+	now := time.Now().UTC()
+	endTime := now.Add(50 * time.Millisecond)
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/api/v1/health/trace/" + requestID:
+			resp := map[string]interface{}{
+				"request_id":  requestID,
+				"trace_id":    "trace-abc",
+				"start_time":  now.Format(time.RFC3339Nano),
+				"end_time":    endTime.Format(time.RFC3339Nano),
+				"duration_ms": 50.0,
+				"operation":   "test-op",
+				"component":   "test",
+				"status":      "success",
+			}
+			_ = json.NewEncoder(w).Encode(resp)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+}
+
+func TestRunTrace_TextOutput(t *testing.T) {
+	const reqID = "req123abc"
+	server := newTraceServer(t, reqID)
+	defer server.Close()
+
+	origURL := traceURL
+	origFormat := traceFormat
+	origInsecure := traceTLSInsecure
+	t.Cleanup(func() {
+		traceURL = origURL
+		traceFormat = origFormat
+		traceTLSInsecure = origInsecure
+	})
+
+	traceURL = server.URL
+	traceFormat = "text"
+	traceTLSInsecure = true
+
+	output := captureStdout(t, func() {
+		err := runTrace(traceCmd, []string{reqID})
+		require.NoError(t, err)
+	})
+
+	assert.Contains(t, output, "Request Trace:")
+	assert.Contains(t, output, reqID)
+	assert.Contains(t, output, "SUCCESS")
+}
+
+func TestRunTrace_JSONOutput(t *testing.T) {
+	const reqID = "req123abc"
+	server := newTraceServer(t, reqID)
+	defer server.Close()
+
+	origURL := traceURL
+	origFormat := traceFormat
+	origInsecure := traceTLSInsecure
+	t.Cleanup(func() {
+		traceURL = origURL
+		traceFormat = origFormat
+		traceTLSInsecure = origInsecure
+	})
+
+	traceURL = server.URL
+	traceFormat = "json"
+	traceTLSInsecure = true
+
+	output := captureStdout(t, func() {
+		err := runTrace(traceCmd, []string{reqID})
+		require.NoError(t, err)
+	})
+
+	assert.True(t, json.Valid([]byte(output)), "output must be valid JSON")
+}
+
+func TestRunTrace_NotFound(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	origURL := traceURL
+	origInsecure := traceTLSInsecure
+	t.Cleanup(func() {
+		traceURL = origURL
+		traceTLSInsecure = origInsecure
+	})
+
+	traceURL = server.URL
+	traceTLSInsecure = true
+
+	err := runTrace(traceCmd, []string{"nonexistent-id"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "trace not found")
+	assert.Contains(t, err.Error(), "nonexistent-id")
+}
+
+func TestRunTrace_APIError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte("internal error"))
+	}))
+	defer server.Close()
+
+	origURL := traceURL
+	origInsecure := traceTLSInsecure
+	t.Cleanup(func() {
+		traceURL = origURL
+		traceTLSInsecure = origInsecure
+	})
+
+	traceURL = server.URL
+	traceTLSInsecure = true
+
+	err := runTrace(traceCmd, []string{"some-id"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "API request failed")
+}


### PR DESCRIPTION
## Summary

- Creates `client_helpers.go` with `newClientFromFlags` to centralise CA-cert loading and `APIClient` construction across all command groups
- Adds `APIClient.Get(ctx, path)` method; `doRequest` remains unexported
- Refactors `token.go` `getAPIClient()` to delegate to `newClientFromFlags`, eliminating duplicated CA-cert load logic
- Wires `cfg controller status/metrics` and `cfg trace` through `APIClient` with `--tls-ca-cert` and `--tls-insecure` persistent flags; deletes the bare-`http.Client` `makeAPIRequest` function

## Test plan

- [x] `client_helpers_test.go`: valid CA cert path, insecure mode, system pool (empty path), missing file returns error
- [x] `controller_test.go`: flag wiring, env-var fallbacks for `CFGMS_TLS_CA_CERT`/`CFGMS_TLS_INSECURE`, `runControllerStatus` and `runControllerMetrics` text/JSON/error paths
- [x] `trace_test.go`: flag wiring, env-var fallbacks, `runTrace` text/JSON/404/error paths
- [x] `api_client_test.go`: added `TestAPIClientGet` for the new `Get` method
- [x] `make test-agent-complete` passes (all tests, lint, architecture check, secret scan)

## Specialist Review Results

**QA Test Runner: PASS** — all unit tests pass with `-race`, lint clean after gofmt fix applied

**QA Code Reviewer: PASS** — no blocking issues; 3 warnings (missing `Get` unit test, env-var untested, no run-function tests) addressed before commit

**Security Engineer: PASS** — no blocking issues; story improves TLS posture (previous `makeAPIRequest` used bare `http.Client` with no TLS path; new code routes through `pkg/cert.CreateClientTLSConfig`); `InsecureSkipVerify` gated behind explicit opt-in; Trivy DB download blocked by sandbox network (environmental, not a code issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)