### PR TITLE
cfg: add token get subcommand wiring APIClient.GetToken (Issue #1038)

### DIFF
--- a/cmd/cfg/cmd/token.go
+++ b/cmd/cfg/cmd/token.go
@@ -133,6 +133,19 @@ Examples:
 	RunE: runTokenDelete,
 }
 
+// tokenGetCmd represents the token get command
+var tokenGetCmd = &cobra.Command{
+	Use:   "get <token>",
+	Short: "Get a registration token by value",
+	Long: `Retrieve a single registration token by its string value.
+
+Examples:
+  cfg token get abcdefghijklmnopqrstuvwxyz
+  cfg token get abcdefghijklmnopqrstuvwxyz --json`,
+	Args: cobra.ExactArgs(1),
+	RunE: runTokenGet,
+}
+
 func init() {
 	// Global token command flags (for API connection)
 	tokenCmd.PersistentFlags().StringVar(&tokenAPIURL, "api-url", "", "Controller REST API URL (env: CFGMS_API_URL)")
@@ -155,11 +168,15 @@ func init() {
 	tokenListCmd.Flags().StringVar(&tokenTenantID, "tenant-id", "", "Filter by tenant ID (optional)")
 	tokenListCmd.Flags().BoolVar(&tokenJSONOutput, "json", false, "Emit JSON output instead of human-readable text")
 
+	// Get command flags
+	tokenGetCmd.Flags().BoolVar(&tokenJSONOutput, "json", false, "Emit JSON output instead of human-readable text")
+
 	// Add subcommands
 	tokenCmd.AddCommand(tokenCreateCmd)
 	tokenCmd.AddCommand(tokenListCmd)
 	tokenCmd.AddCommand(tokenRevokeCmd)
 	tokenCmd.AddCommand(tokenDeleteCmd)
+	tokenCmd.AddCommand(tokenGetCmd)
 }
 
 // getAPIClient creates an API client using flags or environment variables
@@ -335,6 +352,53 @@ func runTokenDelete(cmd *cobra.Command, args []string) error {
 	}
 
 	fmt.Printf("Token deleted successfully: %s\n", tokenStr)
+
+	return nil
+}
+
+func runTokenGet(cmd *cobra.Command, args []string) error {
+	tokenStr := args[0]
+	client, err := getAPIClient()
+	if err != nil {
+		return fmt.Errorf("failed to create API client: %w", err)
+	}
+
+	token, err := client.GetToken(context.Background(), tokenStr)
+	if err != nil {
+		return fmt.Errorf("failed to get token %s: %w", tokenStr, err)
+	}
+
+	if tokenJSONOutput {
+		return json.NewEncoder(os.Stdout).Encode(token)
+	}
+
+	fmt.Printf("Token: %s\n", token.Token)
+	fmt.Printf("  Tenant ID:      %s\n", token.TenantID)
+	fmt.Printf("  Controller URL: %s\n", token.ControllerURL)
+	if token.Group != "" {
+		fmt.Printf("  Group:          %s\n", token.Group)
+	}
+	fmt.Printf("  Created:        %s\n", token.CreatedAt)
+	if token.ExpiresAt != nil {
+		fmt.Printf("  Expires:        %s\n", *token.ExpiresAt)
+	} else {
+		fmt.Printf("  Expires:        Never\n")
+	}
+	fmt.Printf("  Single Use:     %v\n", token.SingleUse)
+	if token.UsedAt != nil {
+		fmt.Printf("  Used At:        %s\n", *token.UsedAt)
+		fmt.Printf("  Used By:        %s\n", token.UsedBy)
+	}
+	if token.Revoked {
+		fmt.Printf("  Status:         REVOKED")
+		if token.RevokedAt != nil {
+			fmt.Printf(" (at %s)", *token.RevokedAt)
+		}
+		fmt.Println()
+	} else {
+		fmt.Printf("  Status:         Active\n")
+	}
+	fmt.Println()
 
 	return nil
 }

--- a/cmd/cfg/cmd/token_test.go
+++ b/cmd/cfg/cmd/token_test.go
@@ -65,6 +65,8 @@ func newTokenServer(t *testing.T) *httptest.Server {
 				Total:  1,
 			}
 			_ = json.NewEncoder(w).Encode(resp)
+		case r.Method == "GET" && strings.HasPrefix(r.URL.Path, "/api/v1/registration/tokens/"):
+			_ = json.NewEncoder(w).Encode(token)
 		default:
 			w.WriteHeader(http.StatusNotFound)
 		}
@@ -334,4 +336,125 @@ func TestRunTokenList_APIError(t *testing.T) {
 	err := runTokenList(tokenListCmd, nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to list tokens")
+}
+
+func TestRunTokenGet_TextOutput(t *testing.T) {
+	server := newTokenServer(t)
+	defer server.Close()
+
+	origAPIURL := tokenAPIURL
+	origTLSInsecure := tokenTLSInsecure
+	origJSON := tokenJSONOutput
+	t.Cleanup(func() {
+		tokenAPIURL = origAPIURL
+		tokenTLSInsecure = origTLSInsecure
+		tokenJSONOutput = origJSON
+	})
+
+	tokenAPIURL = server.URL
+	tokenTLSInsecure = true
+	tokenJSONOutput = false
+
+	output := captureStdout(t, func() {
+		err := runTokenGet(tokenGetCmd, []string{"abc123testtoken"})
+		require.NoError(t, err)
+	})
+
+	assert.Contains(t, output, "Token: abc123testtoken")
+	assert.Contains(t, output, "Tenant ID:")
+	assert.Contains(t, output, "test-tenant")
+	assert.Contains(t, output, "Controller URL:")
+	assert.Contains(t, output, "controller.example.com:4433")
+	assert.Contains(t, output, "Status:")
+
+	// Must not be bare JSON
+	assert.False(t, json.Valid([]byte(strings.TrimSpace(output))), "text output must not be valid JSON")
+}
+
+func TestRunTokenGet_JSONOutput(t *testing.T) {
+	server := newTokenServer(t)
+	defer server.Close()
+
+	origAPIURL := tokenAPIURL
+	origTLSInsecure := tokenTLSInsecure
+	origJSON := tokenJSONOutput
+	t.Cleanup(func() {
+		tokenAPIURL = origAPIURL
+		tokenTLSInsecure = origTLSInsecure
+		tokenJSONOutput = origJSON
+	})
+
+	tokenAPIURL = server.URL
+	tokenTLSInsecure = true
+	tokenJSONOutput = true
+
+	output := captureStdout(t, func() {
+		err := runTokenGet(tokenGetCmd, []string{"abc123testtoken"})
+		require.NoError(t, err)
+	})
+
+	// Output must be valid JSON parseable as APITokenResponse
+	var parsed APITokenResponse
+	require.NoError(t, json.Unmarshal([]byte(output), &parsed), "output must be valid JSON")
+
+	assert.Equal(t, "abc123testtoken", parsed.Token)
+	assert.Equal(t, "test-tenant", parsed.TenantID)
+	assert.Equal(t, "controller.example.com:4433", parsed.ControllerURL)
+
+	// No human-readable text on stdout
+	assert.NotContains(t, output, "Token:")
+	assert.NotContains(t, output, "Tenant ID:")
+}
+
+func TestRunTokenGet_NotFound(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"error":"token not found"}`))
+	}))
+	defer server.Close()
+
+	origAPIURL := tokenAPIURL
+	origTLSInsecure := tokenTLSInsecure
+	origJSON := tokenJSONOutput
+	t.Cleanup(func() {
+		tokenAPIURL = origAPIURL
+		tokenTLSInsecure = origTLSInsecure
+		tokenJSONOutput = origJSON
+	})
+
+	tokenAPIURL = server.URL
+	tokenTLSInsecure = true
+	tokenJSONOutput = false
+
+	err := runTokenGet(tokenGetCmd, []string{"nonexistenttoken"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to get token nonexistenttoken")
+}
+
+func TestRunTokenGet_APIError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"error":"internal server error"}`))
+	}))
+	defer server.Close()
+
+	origAPIURL := tokenAPIURL
+	origTLSInsecure := tokenTLSInsecure
+	origJSON := tokenJSONOutput
+	t.Cleanup(func() {
+		tokenAPIURL = origAPIURL
+		tokenTLSInsecure = origTLSInsecure
+		tokenJSONOutput = origJSON
+	})
+
+	tokenAPIURL = server.URL
+	tokenTLSInsecure = true
+	tokenJSONOutput = false
+
+	err := runTokenGet(tokenGetCmd, []string{"sometesttoken"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to get token sometesttoken")
+	assert.Contains(t, err.Error(), "internal server error")
 }


### PR DESCRIPTION
## Summary

- Adds `cfg token get <token>` subcommand under `tokenCmd`, wiring the already-implemented `APIClient.GetToken` to a CLI entry point
- Human-readable output matches `token list` single-entry block style (Token, Tenant ID, Controller URL, Group, Created, Expires, Single Use, Used At/By, Status)
- `--json` flag emits a JSON object matching `APITokenResponse` schema, consistent with `token create` and `token list`
- Error wrapping uses `fmt.Errorf("failed to get token %s: %w", tokenStr, err)` so non-404 failures surface their actual root cause

## Test plan

- [ ] `TestRunTokenGet_TextOutput` — human-readable output contains all token fields, is not valid JSON
- [ ] `TestRunTokenGet_JSONOutput` — output parses as `APITokenResponse` with correct field values
- [ ] `TestRunTokenGet_NotFound` — 404 response produces error containing token value
- [ ] `TestRunTokenGet_APIError` — 500 response propagates error message through wrapping
- [ ] All pre-existing token tests continue to pass

## Specialist review results

- **QA Test Runner**: PASS — all 11 token tests pass, 110+ packages pass, cross-platform builds verified, lint clean
- **QA Code Reviewer**: PASS — no mocks, no skips, no empty assertions, proper error wrapping with `%w`, error path coverage for both 404 and 5xx
- **Security Engineer**: PASS — no hardcoded secrets, no central provider violations, no insecure defaults introduced; `InsecureSkipVerify` only in `_test.go`; architecture check clean

Fixes #1038

🤖 Generated with [Claude Code](https://claude.com/claude-code)