### PR TITLE
cfg: consolidate spanType in trace command, eliminate copy loop (Issue #1037)

### DIFF
--- a/cmd/cfg/cmd/trace.go
+++ b/cmd/cfg/cmd/trace.go
@@ -122,16 +122,7 @@ func runTrace(cmd *cobra.Command, args []string) error {
 		Status          string                 `json:"status"`
 		Error           string                 `json:"error,omitempty"`
 		Metadata        map[string]interface{} `json:"metadata,omitempty"`
-		Spans           []struct {
-			SpanID       string            `json:"span_id"`
-			ParentSpanID string            `json:"parent_span_id,omitempty"`
-			Operation    string            `json:"operation"`
-			StartTime    time.Time         `json:"start_time"`
-			EndTime      *time.Time        `json:"end_time,omitempty"`
-			DurationMs   float64           `json:"duration_ms,omitempty"`
-			Status       string            `json:"status"`
-			Tags         map[string]string `json:"tags,omitempty"`
-		} `json:"spans,omitempty"`
+		Spans           []spanType             `json:"spans,omitempty"`
 	}
 
 	if err := json.NewDecoder(resp.Body).Decode(&trace); err != nil {
@@ -182,21 +173,7 @@ func runTrace(cmd *cobra.Command, args []string) error {
 	// Spans
 	if len(trace.Spans) > 0 {
 		fmt.Println("\n=== Sub-Operations (Spans) ===")
-		// Convert anonymous struct to spanType
-		spans := make([]spanType, len(trace.Spans))
-		for i, s := range trace.Spans {
-			spans[i] = spanType{
-				SpanID:       s.SpanID,
-				ParentSpanID: s.ParentSpanID,
-				Operation:    s.Operation,
-				StartTime:    s.StartTime,
-				EndTime:      s.EndTime,
-				DurationMs:   s.DurationMs,
-				Status:       s.Status,
-				Tags:         s.Tags,
-			}
-		}
-		printSpans(spans, "", make(map[string]bool))
+		printSpans(trace.Spans, "", make(map[string]bool))
 	}
 
 	fmt.Println()

--- a/cmd/cfg/cmd/trace_test.go
+++ b/cmd/cfg/cmd/trace_test.go
@@ -250,3 +250,106 @@ func TestRunTrace_APIError(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "API request failed")
 }
+
+func TestPrintSpans_OutputMatchesConsolidation(t *testing.T) {
+	now := time.Now().UTC()
+	endTime := now.Add(10 * time.Millisecond)
+
+	spans := []spanType{
+		{
+			SpanID:     "span-1",
+			Operation:  "root-op",
+			StartTime:  now,
+			EndTime:    &endTime,
+			DurationMs: 10.0,
+			Status:     "success",
+		},
+		{
+			SpanID:       "span-2",
+			ParentSpanID: "span-1",
+			Operation:    "child-op",
+			StartTime:    now,
+			EndTime:      &endTime,
+			DurationMs:   5.0,
+			Status:       "success",
+			Tags:         map[string]string{"key": "value"},
+		},
+	}
+
+	output := captureStdout(t, func() {
+		printSpans(spans, "", make(map[string]bool))
+	})
+
+	assert.Contains(t, output, "root-op")
+	assert.Contains(t, output, "child-op")
+	assert.Contains(t, output, "SUCCESS")
+	assert.Contains(t, output, "key: value")
+	assert.Contains(t, output, "10.00 ms")
+	assert.Contains(t, output, "5.00 ms")
+}
+
+func TestRunTrace_WithSpans(t *testing.T) {
+	const reqID = "req-with-spans"
+	now := time.Now().UTC()
+	endTime := now.Add(50 * time.Millisecond)
+	childEnd := now.Add(20 * time.Millisecond)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		resp := map[string]interface{}{
+			"request_id":  reqID,
+			"trace_id":    "trace-xyz",
+			"start_time":  now.Format(time.RFC3339Nano),
+			"end_time":    endTime.Format(time.RFC3339Nano),
+			"duration_ms": 50.0,
+			"operation":   "test-op",
+			"component":   "test",
+			"status":      "success",
+			"spans": []map[string]interface{}{
+				{
+					"span_id":     "s1",
+					"operation":   "fetch",
+					"start_time":  now.Format(time.RFC3339Nano),
+					"end_time":    endTime.Format(time.RFC3339Nano),
+					"duration_ms": 50.0,
+					"status":      "success",
+				},
+				{
+					"span_id":        "s2",
+					"parent_span_id": "s1",
+					"operation":      "db-query",
+					"start_time":     now.Format(time.RFC3339Nano),
+					"end_time":       childEnd.Format(time.RFC3339Nano),
+					"duration_ms":    20.0,
+					"status":         "success",
+					"tags":           map[string]string{"table": "configs"},
+				},
+			},
+		}
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	origURL := traceURL
+	origFormat := traceFormat
+	origInsecure := traceTLSInsecure
+	t.Cleanup(func() {
+		traceURL = origURL
+		traceFormat = origFormat
+		traceTLSInsecure = origInsecure
+	})
+
+	traceURL = server.URL
+	traceFormat = "text"
+	traceTLSInsecure = true
+
+	output := captureStdout(t, func() {
+		err := runTrace(traceCmd, []string{reqID})
+		require.NoError(t, err)
+	})
+
+	assert.Contains(t, output, "Sub-Operations (Spans)")
+	assert.Contains(t, output, "fetch")
+	assert.Contains(t, output, "db-query")
+	assert.Contains(t, output, "table: configs")
+}


### PR DESCRIPTION
## Summary

- Replaced the inline anonymous struct (duplicating `spanType` fields) in `runTrace`'s local `trace` response struct with `[]spanType` directly
- Deleted the manual field-copy loop that converted `[]anonymous` to `[]spanType` (13 lines removed)
- `printSpans(trace.Spans, "", make(map[string]bool))` is now called directly — no intermediate slice needed
- Added two tests: `TestPrintSpans_OutputMatchesConsolidation` (unit) and `TestRunTrace_WithSpans` (integration via httptest)

## Acceptance Criteria

- [x] `trace.go` has no anonymous struct duplicating `spanType` fields
- [x] The `Spans` field in the local `trace` response struct is typed `[]spanType`
- [x] The manual field-copy loop (was lines 152-165) is deleted
- [x] `printSpans(trace.Spans, ...)` is called directly
- [x] Test added in `trace_test.go` verifying span output is correct after consolidation
- [x] Docs updated — N/A — internal refactor with no observable behavior change
- [x] `make test-agent-complete` passes

## Specialist Review Results

**QA Test Runner: PASS**
- All 11 trace tests pass with race detection
- Unit tests: all packages passing
- Cross-platform builds: verified (linux/amd64, linux/arm64, darwin/amd64, darwin/arm64, windows/amd64)
- Trivy blocked by container DNS isolation (pre-existing infra gap, not a code issue)

**QA Code Review: PASS**
- 0 blocking issues, 0 warnings
- No mocks, no `t.Skip()`, all tests have real assertions
- Error paths tested (HTTP 404, HTTP 500, TLS misconfiguration)

**Security Review: PASS**
- 0 blocking issues, 0 warnings
- `security-precommit`: PASS — no secrets detected
- `check-architecture`: PASS — no central provider violations
- `security-scan`: staticcheck and gosec clean for changed files

Fixes #1037