### PR TITLE
rbac: remove down-cast, dead field, duplicate enum, and O(n) cache scan (Issue #977)

### DIFF
--- a/features/rbac/continuous/cache_manager.go
+++ b/features/rbac/continuous/cache_manager.go
@@ -30,11 +30,13 @@ type CacheManager struct {
 	l2Cache *cache.Cache
 
 	// Forward indexes for O(1) invalidation by dimension.
-	// Each maps an identifier to the list of cache keys associated with it.
-	sessionIndex    map[string][]string // sessionID → keys
-	subjectIndex    map[string][]string // subjectID → keys
-	tenantIndex     map[string][]string // tenantID → keys
-	permissionIndex map[string][]string // permissionID → keys
+	// Each maps an identifier to the set of cache keys associated with it.
+	// Sets (map[string]struct{}) provide O(1) insertion and O(1) deletion,
+	// avoiding the linear scan required by slices.
+	sessionIndex    map[string]map[string]struct{} // sessionID → key set
+	subjectIndex    map[string]map[string]struct{} // subjectID → key set
+	tenantIndex     map[string]map[string]struct{} // tenantID → key set
+	permissionIndex map[string]map[string]struct{} // permissionID → key set
 
 	// Reverse index: cache key → metadata. Enables O(1) cross-index cleanup when
 	// a key is removed via one dimension (e.g., subject invalidation must also
@@ -221,10 +223,51 @@ func NewCacheManager(ttl time.Duration, maxLatencyMs int) *CacheManager {
 	return &CacheManager{
 		l1Cache:         cache.NewCache(l1Config),
 		l2Cache:         cache.NewCache(l2Config),
-		sessionIndex:    make(map[string][]string),
-		subjectIndex:    make(map[string][]string),
-		tenantIndex:     make(map[string][]string),
-		permissionIndex: make(map[string][]string),
+		sessionIndex:    make(map[string]map[string]struct{}),
+		subjectIndex:    make(map[string]map[string]struct{}),
+		tenantIndex:     make(map[string]map[string]struct{}),
+		permissionIndex: make(map[string]map[string]struct{}),
+		keyMeta:         make(map[string]cacheKeyMeta),
+		config:          config,
+	}
+}
+
+// newCacheManagerSized creates a CacheManager with custom L1/L2 max sizes.
+// Use in benchmarks to avoid L1 eviction overhead during setup.
+func newCacheManagerSized(ttl time.Duration, maxLatencyMs, l1MaxSize, l2MaxSize int) *CacheManager {
+	config := &CacheConfig{
+		L1MaxSize:            l1MaxSize,
+		L1TTL:                ttl,
+		L1CleanupInterval:    1 * time.Minute,
+		L2MaxSize:            l2MaxSize,
+		L2TTL:                ttl * 2,
+		L2CleanupInterval:    5 * time.Minute,
+		MaxLatencyMs:         maxLatencyMs,
+		CacheNegativeResults: false,
+		CacheFailures:        false,
+		RefreshThreshold:     0.8,
+	}
+	l1Config := cache.CacheConfig{
+		Name:            "continuous-auth-l1",
+		MaxRuntimeItems: config.L1MaxSize,
+		DefaultTTL:      config.L1TTL,
+		CleanupInterval: config.L1CleanupInterval,
+		EvictionPolicy:  cache.EvictionLRU,
+	}
+	l2Config := cache.CacheConfig{
+		Name:            "continuous-auth-l2",
+		MaxRuntimeItems: config.L2MaxSize,
+		DefaultTTL:      config.L2TTL,
+		CleanupInterval: config.L2CleanupInterval,
+		EvictionPolicy:  cache.EvictionLRU,
+	}
+	return &CacheManager{
+		l1Cache:         cache.NewCache(l1Config),
+		l2Cache:         cache.NewCache(l2Config),
+		sessionIndex:    make(map[string]map[string]struct{}),
+		subjectIndex:    make(map[string]map[string]struct{}),
+		tenantIndex:     make(map[string]map[string]struct{}),
+		permissionIndex: make(map[string]map[string]struct{}),
 		keyMeta:         make(map[string]cacheKeyMeta),
 		config:          config,
 	}
@@ -329,10 +372,10 @@ func (cm *CacheManager) CacheAuth(request *ContinuousAuthRequest, response *Cont
 
 	// Update all indexes for O(1) invalidation by any dimension.
 	cm.indexMutex.Lock()
-	cm.sessionIndex[request.SessionID] = append(cm.sessionIndex[request.SessionID], cacheKey)
-	cm.subjectIndex[request.SubjectId] = append(cm.subjectIndex[request.SubjectId], cacheKey)
-	cm.tenantIndex[request.TenantId] = append(cm.tenantIndex[request.TenantId], cacheKey)
-	cm.permissionIndex[request.PermissionId] = append(cm.permissionIndex[request.PermissionId], cacheKey)
+	addToIndex(cm.sessionIndex, request.SessionID, cacheKey)
+	addToIndex(cm.subjectIndex, request.SubjectId, cacheKey)
+	addToIndex(cm.tenantIndex, request.TenantId, cacheKey)
+	addToIndex(cm.permissionIndex, request.PermissionId, cacheKey)
 	cm.keyMeta[cacheKey] = cacheKeyMeta{
 		sessionID:    request.SessionID,
 		subjectID:    request.SubjectId,
@@ -379,7 +422,7 @@ func (cm *CacheManager) EvictSessionCache(sessionID string) {
 func (cm *CacheManager) EvictSubjectPermissions(sessionID string, permissions []string) {
 	// Get all keys for this session
 	cm.indexMutex.RLock()
-	keys, exists := cm.sessionIndex[sessionID]
+	keySet, exists := cm.sessionIndex[sessionID]
 	cm.indexMutex.RUnlock()
 
 	if !exists {
@@ -388,7 +431,7 @@ func (cm *CacheManager) EvictSubjectPermissions(sessionID string, permissions []
 
 	// Remove specific permissions and clean up all indexes for deleted keys.
 	for _, permission := range permissions {
-		for _, key := range keys {
+		for key := range keySet {
 			if cm.keyContainsPermission(key, permission) {
 				cm.l1Cache.Delete(key)
 				cm.l2Cache.Delete(key)
@@ -465,16 +508,16 @@ func (cm *CacheManager) promoteToL1(cacheKey string, cached *CachedAuthDecision)
 
 func (cm *CacheManager) invalidateSession(sessionID, reason string) error {
 	cm.indexMutex.Lock()
-	keys, exists := cm.sessionIndex[sessionID]
+	keySet, exists := cm.sessionIndex[sessionID]
 	if exists {
 		delete(cm.sessionIndex, sessionID)
-		for _, key := range keys {
+		for key := range keySet {
 			cm.removeKeyFromAllIndexesLocked(key)
 		}
 	}
 	cm.indexMutex.Unlock()
 
-	for _, key := range keys {
+	for key := range keySet {
 		cm.l1Cache.Delete(key)
 		cm.l2Cache.Delete(key)
 	}
@@ -491,16 +534,16 @@ func (cm *CacheManager) InvalidateSubject(subjectID string) error {
 
 func (cm *CacheManager) invalidateSubject(subjectID, reason string) error {
 	cm.indexMutex.Lock()
-	keys, exists := cm.subjectIndex[subjectID]
+	keySet, exists := cm.subjectIndex[subjectID]
 	if exists {
 		delete(cm.subjectIndex, subjectID)
-		for _, key := range keys {
+		for key := range keySet {
 			cm.removeKeyFromAllIndexesLocked(key)
 		}
 	}
 	cm.indexMutex.Unlock()
 
-	for _, key := range keys {
+	for key := range keySet {
 		cm.l1Cache.Delete(key)
 		cm.l2Cache.Delete(key)
 	}
@@ -516,16 +559,16 @@ func (cm *CacheManager) InvalidateTenant(tenantID string) error {
 
 func (cm *CacheManager) invalidateTenant(tenantID, reason string) error {
 	cm.indexMutex.Lock()
-	keys, exists := cm.tenantIndex[tenantID]
+	keySet, exists := cm.tenantIndex[tenantID]
 	if exists {
 		delete(cm.tenantIndex, tenantID)
-		for _, key := range keys {
+		for key := range keySet {
 			cm.removeKeyFromAllIndexesLocked(key)
 		}
 	}
 	cm.indexMutex.Unlock()
 
-	for _, key := range keys {
+	for key := range keySet {
 		cm.l1Cache.Delete(key)
 		cm.l2Cache.Delete(key)
 	}
@@ -535,16 +578,16 @@ func (cm *CacheManager) invalidateTenant(tenantID, reason string) error {
 
 func (cm *CacheManager) invalidatePermission(permissionID, reason string) error {
 	cm.indexMutex.Lock()
-	keys, exists := cm.permissionIndex[permissionID]
+	keySet, exists := cm.permissionIndex[permissionID]
 	if exists {
 		delete(cm.permissionIndex, permissionID)
-		for _, key := range keys {
+		for key := range keySet {
 			cm.removeKeyFromAllIndexesLocked(key)
 		}
 	}
 	cm.indexMutex.Unlock()
 
-	for _, key := range keys {
+	for key := range keySet {
 		cm.l1Cache.Delete(key)
 		cm.l2Cache.Delete(key)
 	}
@@ -557,10 +600,10 @@ func (cm *CacheManager) invalidateAll(reason string) error {
 	cm.l2Cache.Clear()
 
 	cm.indexMutex.Lock()
-	cm.sessionIndex = make(map[string][]string)
-	cm.subjectIndex = make(map[string][]string)
-	cm.tenantIndex = make(map[string][]string)
-	cm.permissionIndex = make(map[string][]string)
+	cm.sessionIndex = make(map[string]map[string]struct{})
+	cm.subjectIndex = make(map[string]map[string]struct{})
+	cm.tenantIndex = make(map[string]map[string]struct{})
+	cm.permissionIndex = make(map[string]map[string]struct{})
 	cm.keyMeta = make(map[string]cacheKeyMeta)
 	cm.indexMutex.Unlock()
 
@@ -570,7 +613,7 @@ func (cm *CacheManager) invalidateAll(reason string) error {
 // Helper methods
 
 // removeKeyFromSessionIndex removes a key from all indexes.
-// Uses keyMeta for O(1) reverse lookup so cleanup is not a linear scan.
+// Uses keyMeta for O(1) reverse lookup and set-based O(1) deletion.
 func (cm *CacheManager) removeKeyFromSessionIndex(key string) {
 	cm.indexMutex.Lock()
 	defer cm.indexMutex.Unlock()
@@ -578,6 +621,7 @@ func (cm *CacheManager) removeKeyFromSessionIndex(key string) {
 }
 
 // removeKeyFromAllIndexesLocked removes a key from all forward indexes and the reverse keyMeta map.
+// Uses set-based O(1) deletion for each index.
 // Caller MUST hold indexMutex.Lock().
 func (cm *CacheManager) removeKeyFromAllIndexesLocked(key string) {
 	meta, ok := cm.keyMeta[key]
@@ -585,28 +629,29 @@ func (cm *CacheManager) removeKeyFromAllIndexesLocked(key string) {
 		return
 	}
 	delete(cm.keyMeta, key)
-	removeKeyFromIndex(cm.sessionIndex, meta.sessionID, key)
-	removeKeyFromIndex(cm.subjectIndex, meta.subjectID, key)
-	removeKeyFromIndex(cm.tenantIndex, meta.tenantID, key)
-	removeKeyFromIndex(cm.permissionIndex, meta.permissionID, key)
+	removeFromIndex(cm.sessionIndex, meta.sessionID, key)
+	removeFromIndex(cm.subjectIndex, meta.subjectID, key)
+	removeFromIndex(cm.tenantIndex, meta.tenantID, key)
+	removeFromIndex(cm.permissionIndex, meta.permissionID, key)
 }
 
-// removeKeyFromIndex removes key from index[id], deleting the map entry when empty.
-func removeKeyFromIndex(index map[string][]string, id, key string) {
-	keys, ok := index[id]
+// addToIndex adds key to index[id], creating the inner set if needed.
+func addToIndex(index map[string]map[string]struct{}, id, key string) {
+	if index[id] == nil {
+		index[id] = make(map[string]struct{})
+	}
+	index[id][key] = struct{}{}
+}
+
+// removeFromIndex removes key from index[id] in O(1), deleting the map entry when empty.
+func removeFromIndex(index map[string]map[string]struct{}, id, key string) {
+	keySet, ok := index[id]
 	if !ok {
 		return
 	}
-	for i, k := range keys {
-		if k == key {
-			last := len(keys) - 1
-			keys[i] = keys[last]
-			index[id] = keys[:last]
-			if len(index[id]) == 0 {
-				delete(index, id)
-			}
-			return
-		}
+	delete(keySet, key)
+	if len(keySet) == 0 {
+		delete(index, id)
 	}
 }
 

--- a/features/rbac/continuous/cache_manager.go
+++ b/features/rbac/continuous/cache_manager.go
@@ -12,8 +12,16 @@ import (
 	"github.com/cfgis/cfgms/pkg/cache"
 )
 
+// cacheKeyMeta holds the index identifiers for a cache key, enabling O(1) cross-index cleanup.
+type cacheKeyMeta struct {
+	sessionID    string
+	subjectID    string
+	tenantID     string
+	permissionID string
+}
+
 // CacheManager provides high-performance caching for authorization decisions
-// Now uses centralized pkg/cache with session indexing for O(1) invalidation
+// Now uses centralized pkg/cache with index-based O(1) invalidation for all dimensions.
 type CacheManager struct {
 	// L1 Cache (in-memory, fastest access) - uses pkg/cache
 	l1Cache *cache.Cache
@@ -21,10 +29,18 @@ type CacheManager struct {
 	// L2 Cache (session-based, longer retention) - uses pkg/cache
 	l2Cache *cache.Cache
 
-	// Session index for O(1) session invalidation
-	// Maps sessionID -> list of cache keys
-	sessionIndex map[string][]string
-	indexMutex   sync.RWMutex
+	// Forward indexes for O(1) invalidation by dimension.
+	// Each maps an identifier to the list of cache keys associated with it.
+	sessionIndex    map[string][]string // sessionID → keys
+	subjectIndex    map[string][]string // subjectID → keys
+	tenantIndex     map[string][]string // tenantID → keys
+	permissionIndex map[string][]string // permissionID → keys
+
+	// Reverse index: cache key → metadata. Enables O(1) cross-index cleanup when
+	// a key is removed via one dimension (e.g., subject invalidation must also
+	// remove the key from the session, tenant, and permission indexes).
+	keyMeta    map[string]cacheKeyMeta
+	indexMutex sync.RWMutex
 
 	// Cache configuration
 	config *CacheConfig
@@ -203,10 +219,14 @@ func NewCacheManager(ttl time.Duration, maxLatencyMs int) *CacheManager {
 	}
 
 	return &CacheManager{
-		l1Cache:      cache.NewCache(l1Config),
-		l2Cache:      cache.NewCache(l2Config),
-		sessionIndex: make(map[string][]string),
-		config:       config,
+		l1Cache:         cache.NewCache(l1Config),
+		l2Cache:         cache.NewCache(l2Config),
+		sessionIndex:    make(map[string][]string),
+		subjectIndex:    make(map[string][]string),
+		tenantIndex:     make(map[string][]string),
+		permissionIndex: make(map[string][]string),
+		keyMeta:         make(map[string]cacheKeyMeta),
+		config:          config,
 	}
 }
 
@@ -307,9 +327,18 @@ func (cm *CacheManager) CacheAuth(request *ContinuousAuthRequest, response *Cont
 		return fmt.Errorf("failed to cache auth in L2: %w", err)
 	}
 
-	// Update session index for O(1) session invalidation
+	// Update all indexes for O(1) invalidation by any dimension.
 	cm.indexMutex.Lock()
 	cm.sessionIndex[request.SessionID] = append(cm.sessionIndex[request.SessionID], cacheKey)
+	cm.subjectIndex[request.SubjectId] = append(cm.subjectIndex[request.SubjectId], cacheKey)
+	cm.tenantIndex[request.TenantId] = append(cm.tenantIndex[request.TenantId], cacheKey)
+	cm.permissionIndex[request.PermissionId] = append(cm.permissionIndex[request.PermissionId], cacheKey)
+	cm.keyMeta[cacheKey] = cacheKeyMeta{
+		sessionID:    request.SessionID,
+		subjectID:    request.SubjectId,
+		tenantID:     request.TenantId,
+		permissionID: request.PermissionId,
+	}
 	cm.indexMutex.Unlock()
 
 	return nil
@@ -357,13 +386,13 @@ func (cm *CacheManager) EvictSubjectPermissions(sessionID string, permissions []
 		return
 	}
 
-	// Remove specific permissions
+	// Remove specific permissions and clean up all indexes for deleted keys.
 	for _, permission := range permissions {
 		for _, key := range keys {
-			// Check if cache key contains the permission
 			if cm.keyContainsPermission(key, permission) {
 				cm.l1Cache.Delete(key)
 				cm.l2Cache.Delete(key)
+				cm.removeKeyFromSessionIndex(key)
 			}
 		}
 	}
@@ -435,19 +464,16 @@ func (cm *CacheManager) promoteToL1(cacheKey string, cached *CachedAuthDecision)
 // Cache invalidation methods
 
 func (cm *CacheManager) invalidateSession(sessionID, reason string) error {
-	// Use session index for O(1) lookup of all keys for this session
 	cm.indexMutex.Lock()
 	keys, exists := cm.sessionIndex[sessionID]
 	if exists {
 		delete(cm.sessionIndex, sessionID)
+		for _, key := range keys {
+			cm.removeKeyFromAllIndexesLocked(key)
+		}
 	}
 	cm.indexMutex.Unlock()
 
-	if !exists {
-		return nil // No entries for this session
-	}
-
-	// Remove all keys from both caches using pkg/cache
 	for _, key := range keys {
 		cm.l1Cache.Delete(key)
 		cm.l2Cache.Delete(key)
@@ -457,117 +483,85 @@ func (cm *CacheManager) invalidateSession(sessionID, reason string) error {
 }
 
 // InvalidateSubject removes all cached authorization decisions for the given subject
-// from both L1 and L2. L2 is scanned independently of L1 so entries that have already
-// been evicted from L1 but have not yet expired in L2 are still removed.
+// from both L1 and L2. Uses the subject index for O(1) key lookup; L2 is covered
+// independently because CacheAuth writes every entry to both L1 and L2 under the same key.
 func (cm *CacheManager) InvalidateSubject(subjectID string) error {
 	return cm.invalidateSubject(subjectID, "subject_invalidated")
 }
 
 func (cm *CacheManager) invalidateSubject(subjectID, reason string) error {
-	// Use a set to avoid double-deleting keys found in both L1 and L2.
-	keysToRemove := make(map[string]struct{})
-
-	// Scan L1 for matching entries.
-	for _, key := range cm.l1Cache.Keys() {
-		if value, found := cm.l1Cache.Get(key); found {
-			if cached, ok := value.(*CachedAuthDecision); ok && cached.SubjectID == subjectID {
-				keysToRemove[key] = struct{}{}
-			}
+	cm.indexMutex.Lock()
+	keys, exists := cm.subjectIndex[subjectID]
+	if exists {
+		delete(cm.subjectIndex, subjectID)
+		for _, key := range keys {
+			cm.removeKeyFromAllIndexesLocked(key)
 		}
 	}
+	cm.indexMutex.Unlock()
 
-	// Scan L2 independently — entries evicted from L1 may still be live in L2.
-	for _, key := range cm.l2Cache.Keys() {
-		if value, found := cm.l2Cache.Get(key); found {
-			if cached, ok := value.(*CachedAuthDecision); ok && cached.SubjectID == subjectID {
-				keysToRemove[key] = struct{}{}
-			}
-		}
-	}
-
-	for key := range keysToRemove {
+	for _, key := range keys {
 		cm.l1Cache.Delete(key)
 		cm.l2Cache.Delete(key)
-		cm.removeKeyFromSessionIndex(key)
 	}
 
 	return nil
 }
 
 // InvalidateTenant removes all cached authorization decisions for the given tenant
-// from both L1 and L2. L2 is scanned independently of L1.
+// from both L1 and L2. Uses the tenant index for O(1) key lookup.
 func (cm *CacheManager) InvalidateTenant(tenantID string) error {
 	return cm.invalidateTenant(tenantID, "tenant_invalidated")
 }
 
 func (cm *CacheManager) invalidateTenant(tenantID, reason string) error {
-	keysToRemove := make(map[string]struct{})
-
-	// Scan L1 for matching entries.
-	for _, key := range cm.l1Cache.Keys() {
-		if value, found := cm.l1Cache.Get(key); found {
-			if cached, ok := value.(*CachedAuthDecision); ok && cached.TenantID == tenantID {
-				keysToRemove[key] = struct{}{}
-			}
+	cm.indexMutex.Lock()
+	keys, exists := cm.tenantIndex[tenantID]
+	if exists {
+		delete(cm.tenantIndex, tenantID)
+		for _, key := range keys {
+			cm.removeKeyFromAllIndexesLocked(key)
 		}
 	}
+	cm.indexMutex.Unlock()
 
-	// Scan L2 independently — entries evicted from L1 may still be live in L2.
-	for _, key := range cm.l2Cache.Keys() {
-		if value, found := cm.l2Cache.Get(key); found {
-			if cached, ok := value.(*CachedAuthDecision); ok && cached.TenantID == tenantID {
-				keysToRemove[key] = struct{}{}
-			}
-		}
-	}
-
-	for key := range keysToRemove {
+	for _, key := range keys {
 		cm.l1Cache.Delete(key)
 		cm.l2Cache.Delete(key)
-		cm.removeKeyFromSessionIndex(key)
 	}
 
 	return nil
 }
 
 func (cm *CacheManager) invalidatePermission(permissionID, reason string) error {
-	keysToRemove := make(map[string]struct{})
-
-	// Scan L1 for matching entries.
-	for _, key := range cm.l1Cache.Keys() {
-		if value, found := cm.l1Cache.Get(key); found {
-			if cached, ok := value.(*CachedAuthDecision); ok && cached.PermissionID == permissionID {
-				keysToRemove[key] = struct{}{}
-			}
+	cm.indexMutex.Lock()
+	keys, exists := cm.permissionIndex[permissionID]
+	if exists {
+		delete(cm.permissionIndex, permissionID)
+		for _, key := range keys {
+			cm.removeKeyFromAllIndexesLocked(key)
 		}
 	}
+	cm.indexMutex.Unlock()
 
-	// Scan L2 independently — entries evicted from L1 may still be live in L2.
-	for _, key := range cm.l2Cache.Keys() {
-		if value, found := cm.l2Cache.Get(key); found {
-			if cached, ok := value.(*CachedAuthDecision); ok && cached.PermissionID == permissionID {
-				keysToRemove[key] = struct{}{}
-			}
-		}
-	}
-
-	for key := range keysToRemove {
+	for _, key := range keys {
 		cm.l1Cache.Delete(key)
 		cm.l2Cache.Delete(key)
-		cm.removeKeyFromSessionIndex(key)
 	}
 
 	return nil
 }
 
 func (cm *CacheManager) invalidateAll(reason string) error {
-	// Simplified - use pkg/cache Clear() method
 	cm.l1Cache.Clear()
 	cm.l2Cache.Clear()
 
-	// Clear session index
 	cm.indexMutex.Lock()
 	cm.sessionIndex = make(map[string][]string)
+	cm.subjectIndex = make(map[string][]string)
+	cm.tenantIndex = make(map[string][]string)
+	cm.permissionIndex = make(map[string][]string)
+	cm.keyMeta = make(map[string]cacheKeyMeta)
 	cm.indexMutex.Unlock()
 
 	return nil
@@ -575,23 +569,43 @@ func (cm *CacheManager) invalidateAll(reason string) error {
 
 // Helper methods
 
-// removeKeyFromSessionIndex removes a key from the session index
+// removeKeyFromSessionIndex removes a key from all indexes.
+// Uses keyMeta for O(1) reverse lookup so cleanup is not a linear scan.
 func (cm *CacheManager) removeKeyFromSessionIndex(key string) {
 	cm.indexMutex.Lock()
 	defer cm.indexMutex.Unlock()
+	cm.removeKeyFromAllIndexesLocked(key)
+}
 
-	// Find and remove the key from all session indices
-	for sessionID, keys := range cm.sessionIndex {
-		for i, k := range keys {
-			if k == key {
-				// Remove key from slice
-				cm.sessionIndex[sessionID] = append(keys[:i], keys[i+1:]...)
-				// If session now has no keys, remove the session entry
-				if len(cm.sessionIndex[sessionID]) == 0 {
-					delete(cm.sessionIndex, sessionID)
-				}
-				return
+// removeKeyFromAllIndexesLocked removes a key from all forward indexes and the reverse keyMeta map.
+// Caller MUST hold indexMutex.Lock().
+func (cm *CacheManager) removeKeyFromAllIndexesLocked(key string) {
+	meta, ok := cm.keyMeta[key]
+	if !ok {
+		return
+	}
+	delete(cm.keyMeta, key)
+	removeKeyFromIndex(cm.sessionIndex, meta.sessionID, key)
+	removeKeyFromIndex(cm.subjectIndex, meta.subjectID, key)
+	removeKeyFromIndex(cm.tenantIndex, meta.tenantID, key)
+	removeKeyFromIndex(cm.permissionIndex, meta.permissionID, key)
+}
+
+// removeKeyFromIndex removes key from index[id], deleting the map entry when empty.
+func removeKeyFromIndex(index map[string][]string, id, key string) {
+	keys, ok := index[id]
+	if !ok {
+		return
+	}
+	for i, k := range keys {
+		if k == key {
+			last := len(keys) - 1
+			keys[i] = keys[last]
+			index[id] = keys[:last]
+			if len(index[id]) == 0 {
+				delete(index, id)
 			}
+			return
 		}
 	}
 }

--- a/features/rbac/continuous/cache_manager_invalidation_test.go
+++ b/features/rbac/continuous/cache_manager_invalidation_test.go
@@ -11,9 +11,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// makeDecision builds a CachedAuthDecision and stores it directly into only L2
-// (bypassing the normal CacheAuth path so that L1 never sees the entry).
-// This lets tests verify that invalidation scans L2 independently of L1.
+// storeL2Only inserts a cache entry via the normal CacheAuth path (so it is indexed),
+// then evicts the entry from L1 to simulate an entry that has been promoted to L2 only
+// (as if it was evicted from L1 by LRU pressure but has not yet expired in L2).
+// This verifies that index-based invalidation covers both L1 and L2 independently.
 func storeL2Only(t *testing.T, cm *CacheManager, subjectID, tenantID, permissionID string) string {
 	t.Helper()
 	req := &ContinuousAuthRequest{
@@ -25,17 +26,17 @@ func storeL2Only(t *testing.T, cm *CacheManager, subjectID, tenantID, permission
 		},
 		SessionID: "session-" + subjectID,
 	}
-	key := cm.generateCacheKey(req)
-	decision := &CachedAuthDecision{
-		CacheKey:     key,
-		CacheLevel:   CacheLevelL2,
-		ValidUntil:   time.Now().Add(5 * time.Minute),
-		SubjectID:    subjectID,
-		TenantID:     tenantID,
-		PermissionID: permissionID,
-		SessionID:    "session-" + subjectID,
+	resp := &ContinuousAuthResponse{
+		AccessResponse: &common.AccessResponse{Granted: true},
+		ValidUntil:     time.Now().Add(5 * time.Minute),
+		DecisionID:     "dec-" + subjectID,
+		DecisionTime:   time.Now(),
 	}
-	require.NoError(t, cm.l2Cache.Set(key, decision, 5*time.Minute))
+	require.NoError(t, cm.CacheAuth(req, resp))
+	key := cm.generateCacheKey(req)
+
+	// Evict from L1 to simulate an entry that exists only in L2.
+	cm.l1Cache.Delete(key)
 
 	// Confirm L1 does NOT have this entry.
 	_, inL1 := cm.l1Cache.Get(key)

--- a/features/rbac/continuous/cache_manager_test.go
+++ b/features/rbac/continuous/cache_manager_test.go
@@ -1,0 +1,219 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+package continuous
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/cfgis/cfgms/api/proto/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// cacheEntry inserts one entry via the normal CacheAuth path and returns the cache key.
+func cacheEntry(t *testing.T, cm *CacheManager, subjectID, tenantID, permissionID, sessionID, resourceID string) string {
+	t.Helper()
+	req := &ContinuousAuthRequest{
+		AccessRequest: &common.AccessRequest{
+			SubjectId:    subjectID,
+			TenantId:     tenantID,
+			PermissionId: permissionID,
+			ResourceId:   resourceID,
+		},
+		SessionID: sessionID,
+	}
+	resp := &ContinuousAuthResponse{
+		AccessResponse: &common.AccessResponse{Granted: true},
+		ValidUntil:     time.Now().Add(5 * time.Minute),
+		DecisionID:     "dec-" + subjectID,
+		DecisionTime:   time.Now(),
+	}
+	require.NoError(t, cm.CacheAuth(req, resp))
+	return cm.generateCacheKey(req)
+}
+
+// TestInvalidateSubject_IndexBasedLookup verifies that invalidateSubject removes
+// all entries for the target subject using the subject index (O(1) lookup),
+// including entries that exist only in L2 (evicted from L1).
+func TestInvalidateSubject_IndexBasedLookup(t *testing.T) {
+	cm := newTestCacheManager()
+
+	// Insert three entries for the target subject (different permissions/resources).
+	key1 := cacheEntry(t, cm, "user-alpha", "tenant1", "perm-read", "sess-alpha", "res-1")
+	key2 := cacheEntry(t, cm, "user-alpha", "tenant1", "perm-write", "sess-alpha", "res-2")
+	key3 := cacheEntry(t, cm, "user-alpha", "tenant1", "perm-admin", "sess-alpha", "res-3")
+
+	// Evict key2 from L1 to simulate an entry that is L2-only.
+	cm.l1Cache.Delete(key2)
+	_, inL1 := cm.l1Cache.Get(key2)
+	require.False(t, inL1, "key2 must be L2-only for this test to be meaningful")
+
+	// Insert an unrelated entry for a different subject.
+	otherKey := cacheEntry(t, cm, "user-beta", "tenant1", "perm-read", "sess-beta", "res-1")
+
+	require.NoError(t, cm.InvalidateSubject("user-alpha"))
+
+	// All three target entries must be gone from both L1 and L2.
+	for _, key := range []string{key1, key2, key3} {
+		_, inL1 := cm.l1Cache.Get(key)
+		_, inL2 := cm.l2Cache.Get(key)
+		assert.False(t, inL1, "target entry must be removed from L1 after InvalidateSubject")
+		assert.False(t, inL2, "target entry must be removed from L2 after InvalidateSubject")
+	}
+
+	// Unrelated subject entry must survive.
+	_, otherInL1 := cm.l1Cache.Get(otherKey)
+	_, otherInL2 := cm.l2Cache.Get(otherKey)
+	assert.True(t, otherInL1 || otherInL2, "unrelated subject entry must survive InvalidateSubject")
+}
+
+// TestInvalidateTenant_IndexBasedLookup verifies that invalidateTenant removes
+// all entries for the target tenant using the tenant index.
+func TestInvalidateTenant_IndexBasedLookup(t *testing.T) {
+	cm := newTestCacheManager()
+
+	key1 := cacheEntry(t, cm, "user1", "tenant-x", "perm-read", "sess-1", "res-1")
+	key2 := cacheEntry(t, cm, "user2", "tenant-x", "perm-read", "sess-2", "res-1")
+
+	// Evict key1 from L1 to simulate L2-only state.
+	cm.l1Cache.Delete(key1)
+
+	otherKey := cacheEntry(t, cm, "user1", "tenant-y", "perm-read", "sess-1", "res-1")
+
+	require.NoError(t, cm.InvalidateTenant("tenant-x"))
+
+	for _, key := range []string{key1, key2} {
+		_, inL1 := cm.l1Cache.Get(key)
+		_, inL2 := cm.l2Cache.Get(key)
+		assert.False(t, inL1, "target tenant entry must be removed from L1")
+		assert.False(t, inL2, "target tenant entry must be removed from L2")
+	}
+
+	_, otherInL1 := cm.l1Cache.Get(otherKey)
+	_, otherInL2 := cm.l2Cache.Get(otherKey)
+	assert.True(t, otherInL1 || otherInL2, "unrelated tenant entry must survive InvalidateTenant")
+}
+
+// TestInvalidatePermission_IndexBasedLookup verifies that invalidatePermission removes
+// all entries for the target permission using the permission index.
+func TestInvalidatePermission_IndexBasedLookup(t *testing.T) {
+	cm := newTestCacheManager()
+
+	key1 := cacheEntry(t, cm, "user1", "tenant1", "perm-secret", "sess-1", "res-1")
+	key2 := cacheEntry(t, cm, "user2", "tenant1", "perm-secret", "sess-2", "res-1")
+
+	// Evict key1 from L1 to simulate L2-only state.
+	cm.l1Cache.Delete(key1)
+
+	otherKey := cacheEntry(t, cm, "user1", "tenant1", "perm-public", "sess-1", "res-1")
+
+	require.NoError(t, cm.InvalidateCache(&CacheInvalidationRequest{
+		InvalidationType: InvalidationTypePermission,
+		PermissionID:     "perm-secret",
+		Reason:           "permission revoked",
+	}))
+
+	for _, key := range []string{key1, key2} {
+		_, inL1 := cm.l1Cache.Get(key)
+		_, inL2 := cm.l2Cache.Get(key)
+		assert.False(t, inL1, "target permission entry must be removed from L1")
+		assert.False(t, inL2, "target permission entry must be removed from L2")
+	}
+
+	_, otherInL1 := cm.l1Cache.Get(otherKey)
+	_, otherInL2 := cm.l2Cache.Get(otherKey)
+	assert.True(t, otherInL1 || otherInL2, "unrelated permission entry must survive invalidation")
+}
+
+// TestInvalidateSubject_CrossIndexCleanup verifies that after subject invalidation
+// the session index no longer contains the deleted keys, preventing stale index entries.
+func TestInvalidateSubject_CrossIndexCleanup(t *testing.T) {
+	cm := newTestCacheManager()
+
+	cacheEntry(t, cm, "user-cleanup", "tenant1", "perm-read", "session-cleanup", "res-1")
+
+	// Confirm the session index has the key before invalidation.
+	cm.indexMutex.RLock()
+	sessionKeys := cm.sessionIndex["session-cleanup"]
+	cm.indexMutex.RUnlock()
+	require.Len(t, sessionKeys, 1, "session index must have one entry before invalidation")
+
+	require.NoError(t, cm.InvalidateSubject("user-cleanup"))
+
+	// After subject invalidation, the session index must no longer have the key.
+	cm.indexMutex.RLock()
+	sessionKeysAfter := cm.sessionIndex["session-cleanup"]
+	cm.indexMutex.RUnlock()
+	assert.Empty(t, sessionKeysAfter, "session index must be clean after InvalidateSubject")
+}
+
+// makeBenchmarkCache creates a CacheManager populated with totalEntries entries,
+// of which targetEntries belong to targetSubject.
+func makeBenchmarkCache(b *testing.B, totalEntries, targetEntries int, targetSubject string) *CacheManager {
+	b.Helper()
+	cm := NewCacheManager(10*time.Minute, 100)
+	otherCount := totalEntries - targetEntries
+
+	for i := 0; i < otherCount; i++ {
+		req := &ContinuousAuthRequest{
+			AccessRequest: &common.AccessRequest{
+				SubjectId:    fmt.Sprintf("other-subject-%d", i),
+				TenantId:     "tenant1",
+				PermissionId: fmt.Sprintf("perm-%d", i%100),
+				ResourceId:   "res-1",
+			},
+			SessionID: fmt.Sprintf("sess-%d", i),
+		}
+		resp := &ContinuousAuthResponse{
+			AccessResponse: &common.AccessResponse{Granted: true},
+			ValidUntil:     time.Now().Add(10 * time.Minute),
+			DecisionID:     fmt.Sprintf("dec-%d", i),
+			DecisionTime:   time.Now(),
+		}
+		if err := cm.CacheAuth(req, resp); err != nil {
+			b.Fatalf("CacheAuth failed during benchmark setup: %v", err)
+		}
+	}
+
+	for i := 0; i < targetEntries; i++ {
+		req := &ContinuousAuthRequest{
+			AccessRequest: &common.AccessRequest{
+				SubjectId:    targetSubject,
+				TenantId:     "tenant1",
+				PermissionId: fmt.Sprintf("perm-%d", i),
+				ResourceId:   fmt.Sprintf("res-%d", i),
+			},
+			SessionID: fmt.Sprintf("sess-target-%d", i),
+		}
+		resp := &ContinuousAuthResponse{
+			AccessResponse: &common.AccessResponse{Granted: true},
+			ValidUntil:     time.Now().Add(10 * time.Minute),
+			DecisionID:     fmt.Sprintf("dec-target-%d", i),
+			DecisionTime:   time.Now(),
+		}
+		if err := cm.CacheAuth(req, resp); err != nil {
+			b.Fatalf("CacheAuth failed during benchmark setup (target subject): %v", err)
+		}
+	}
+
+	return cm
+}
+
+// BenchmarkInvalidateSubject measures the time to invalidate all cache entries for
+// a single subject in a 100k-entry cache where the target subject has 100 entries.
+// Expected: completes in <1ms per operation.
+func BenchmarkInvalidateSubject(b *testing.B) {
+	const totalEntries = 100_000
+	const targetEntries = 100
+	const targetSubject = "benchmark-target-subject"
+
+	for i := 0; i < b.N; i++ {
+		b.StopTimer()
+		cm := makeBenchmarkCache(b, totalEntries, targetEntries, targetSubject)
+		b.StartTimer()
+
+		_ = cm.invalidateSubject(targetSubject, "benchmark")
+	}
+}

--- a/features/rbac/continuous/cache_manager_test.go
+++ b/features/rbac/continuous/cache_manager_test.go
@@ -153,7 +153,10 @@ func TestInvalidateSubject_CrossIndexCleanup(t *testing.T) {
 // of which targetEntries belong to targetSubject.
 func makeBenchmarkCache(b *testing.B, totalEntries, targetEntries int, targetSubject string) *CacheManager {
 	b.Helper()
-	cm := NewCacheManager(10*time.Minute, 100)
+	// Size L1 to hold all entries so no LRU eviction fires during setup.
+	// pkg/cache evictLRU uses an O(n²) sort; triggering it 90k times on a 10k-entry
+	// L1 would make setup take hours. The benchmark measures invalidateSubject, not setup.
+	cm := newCacheManagerSized(10*time.Minute, 100, totalEntries+1000, totalEntries+1000)
 	otherCount := totalEntries - targetEntries
 
 	for i := 0; i < otherCount; i++ {

--- a/features/rbac/escalation_prevention.go
+++ b/features/rbac/escalation_prevention.go
@@ -14,7 +14,8 @@ import (
 
 // EscalationPreventionManager provides comprehensive privilege escalation attack prevention
 type EscalationPreventionManager struct {
-	rbacManager RBACManager
+	rbacManager   RBACManager
+	storeAccessor RBACStoreAccessor
 
 	// Concurrent modification protection
 	operationMutex sync.RWMutex
@@ -36,27 +37,28 @@ type EscalationPreventionManager struct {
 
 // OperationRecord tracks RBAC operations for audit and analysis
 type OperationRecord struct {
-	ID           string                 `json:"id"`
-	Type         OperationType          `json:"type"`
-	SubjectID    string                 `json:"subject_id,omitempty"`
-	RoleID       string                 `json:"role_id,omitempty"`
-	ParentRoleID string                 `json:"parent_role_id,omitempty"`
-	TenantID     string                 `json:"tenant_id"`
-	Timestamp    time.Time              `json:"timestamp"`
-	Success      bool                   `json:"success"`
-	Error        string                 `json:"error,omitempty"`
-	Context      map[string]interface{} `json:"context,omitempty"`
+	ID           string                  `json:"id"`
+	Type         EscalationOperationType `json:"type"`
+	SubjectID    string                  `json:"subject_id,omitempty"`
+	RoleID       string                  `json:"role_id,omitempty"`
+	ParentRoleID string                  `json:"parent_role_id,omitempty"`
+	TenantID     string                  `json:"tenant_id"`
+	Timestamp    time.Time               `json:"timestamp"`
+	Success      bool                    `json:"success"`
+	Error        string                  `json:"error,omitempty"`
+	Context      map[string]interface{}  `json:"context,omitempty"`
 }
 
-// OperationType defines types of RBAC operations that can be tracked
-type OperationType string
+// EscalationOperationType defines types of RBAC operations tracked by escalation prevention.
+// This is distinct from continuous.OperationType which classifies API/resource/data risk levels.
+type EscalationOperationType string
 
 const (
-	OpTypeRoleAssignment   OperationType = "role_assignment"
-	OpTypeRoleRevocation   OperationType = "role_revocation"
-	OpTypeRoleParentSet    OperationType = "role_parent_set"
-	OpTypeRoleParentRemove OperationType = "role_parent_remove"
-	OpTypePermissionCheck  OperationType = "permission_check"
+	EscalationOpTypeRoleAssignment   EscalationOperationType = "role_assignment"
+	EscalationOpTypeRoleRevocation   EscalationOperationType = "role_revocation"
+	EscalationOpTypeRoleParentSet    EscalationOperationType = "role_parent_set"
+	EscalationOpTypeRoleParentRemove EscalationOperationType = "role_parent_remove"
+	EscalationOpTypePermissionCheck  EscalationOperationType = "permission_check"
 )
 
 // EscalationAlert represents a detected privilege escalation attempt
@@ -95,10 +97,13 @@ const (
 	SeverityCritical AlertSeverity = "critical"
 )
 
-// NewEscalationPreventionManager creates a new privilege escalation prevention manager
-func NewEscalationPreventionManager(rbacManager RBACManager) *EscalationPreventionManager {
+// NewEscalationPreventionManager creates a new privilege escalation prevention manager.
+// storeAccessor provides direct access to the underlying RoleStore without going through
+// the full RBACManager dispatch (which would cause infinite recursion via SetRoleParent).
+func NewEscalationPreventionManager(rbacManager RBACManager, storeAccessor RBACStoreAccessor) *EscalationPreventionManager {
 	return &EscalationPreventionManager{
 		rbacManager:            rbacManager,
+		storeAccessor:          storeAccessor,
 		operationLog:           make([]OperationRecord, 0),
 		recentOperations:       make(map[string][]time.Time),
 		escalationAlerts:       make([]EscalationAlert, 0),
@@ -116,7 +121,7 @@ func (epm *EscalationPreventionManager) ValidateAndSetRoleParent(ctx context.Con
 	// Record operation start
 	operation := OperationRecord{
 		ID:           operationID,
-		Type:         OpTypeRoleParentSet,
+		Type:         EscalationOpTypeRoleParentSet,
 		RoleID:       roleID,
 		ParentRoleID: parentRoleID,
 		SubjectID:    subjectID,
@@ -175,12 +180,9 @@ func (epm *EscalationPreventionManager) ValidateAndSetRoleParent(ctx context.Con
 	}
 
 	// Perform the actual role parent assignment directly through the underlying store
-	// to avoid circular calls back to the Manager's SetRoleParent method
-	manager, ok := epm.rbacManager.(*Manager)
-	if !ok {
-		return fmt.Errorf("escalation prevention manager requires Manager implementation")
-	}
-	err := manager.GetStore().SetRoleParent(ctx, roleID, parentRoleID, inheritanceType)
+	// to avoid circular calls back to the Manager's SetRoleParent method.
+	// Using storeAccessor (RBACStoreAccessor) instead of a type assertion to *Manager.
+	err := epm.storeAccessor.GetStore().SetRoleParent(ctx, roleID, parentRoleID, inheritanceType)
 
 	// Record operation result
 	operation.Success = (err == nil)
@@ -205,7 +207,7 @@ func (epm *EscalationPreventionManager) ValidateAndAssignRole(ctx context.Contex
 	// Record operation start
 	operation := OperationRecord{
 		ID:        operationID,
-		Type:      OpTypeRoleAssignment,
+		Type:      EscalationOpTypeRoleAssignment,
 		SubjectID: assignment.SubjectId,
 		RoleID:    assignment.RoleId,
 		TenantID:  assignment.TenantId,
@@ -433,7 +435,7 @@ func (epm *EscalationPreventionManager) countRecentChainModifications(roleID str
 	defer epm.operationMutex.RUnlock()
 
 	for _, operation := range epm.operationLog {
-		if operation.Type == OpTypeRoleParentSet &&
+		if operation.Type == EscalationOpTypeRoleParentSet &&
 			(operation.RoleID == roleID || operation.ParentRoleID == roleID) &&
 			operation.Timestamp.After(cutoff) {
 			count++
@@ -451,7 +453,7 @@ func (epm *EscalationPreventionManager) countRecentRoleAssignments(subjectID str
 	defer epm.operationMutex.RUnlock()
 
 	for _, operation := range epm.operationLog {
-		if operation.Type == OpTypeRoleAssignment &&
+		if operation.Type == EscalationOpTypeRoleAssignment &&
 			operation.SubjectID == subjectID &&
 			operation.Timestamp.After(cutoff) &&
 			operation.Success {
@@ -497,7 +499,7 @@ func (epm *EscalationPreventionManager) countRecentHighPrivilegeAssignments(subj
 	defer epm.operationMutex.RUnlock()
 
 	for _, operation := range epm.operationLog {
-		if operation.Type == OpTypeRoleAssignment &&
+		if operation.Type == EscalationOpTypeRoleAssignment &&
 			operation.SubjectID == subjectID &&
 			operation.Timestamp.After(cutoff) &&
 			operation.Success {
@@ -606,7 +608,7 @@ func (epm *EscalationPreventionManager) getPreviousSubjectRoles(subjectID, tenan
 		operation := epm.operationLog[i]
 		if operation.SubjectID == subjectID &&
 			operation.TenantID == tenantID &&
-			operation.Type == OpTypeRoleAssignment &&
+			operation.Type == EscalationOpTypeRoleAssignment &&
 			operation.Success {
 			// This is a simplified implementation
 			// In production, would track actual role states

--- a/features/rbac/escalation_prevention_test.go
+++ b/features/rbac/escalation_prevention_test.go
@@ -1,0 +1,175 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+package rbac
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cfgis/cfgms/api/proto/common"
+	"github.com/cfgis/cfgms/pkg/storage/interfaces"
+
+	// Import storage providers for testing
+	_ "github.com/cfgis/cfgms/pkg/storage/providers/flatfile"
+	_ "github.com/cfgis/cfgms/pkg/storage/providers/sqlite"
+)
+
+// TestEscalationOperationType_Constants verifies that EscalationOperationType constants
+// have the expected string values after the rename from OperationType.
+func TestEscalationOperationType_Constants(t *testing.T) {
+	assert.Equal(t, EscalationOperationType("role_assignment"), EscalationOpTypeRoleAssignment)
+	assert.Equal(t, EscalationOperationType("role_revocation"), EscalationOpTypeRoleRevocation)
+	assert.Equal(t, EscalationOperationType("role_parent_set"), EscalationOpTypeRoleParentSet)
+	assert.Equal(t, EscalationOperationType("role_parent_remove"), EscalationOpTypeRoleParentRemove)
+	assert.Equal(t, EscalationOperationType("permission_check"), EscalationOpTypePermissionCheck)
+}
+
+// TestEscalationOperationType_DistinctType verifies EscalationOperationType is its own type.
+func TestEscalationOperationType_DistinctType(t *testing.T) {
+	et := EscalationOpTypeRoleAssignment
+	assert.Equal(t, "role_assignment", string(et))
+}
+
+// TestNewEscalationPreventionManager_AcceptsStoreAccessor verifies that
+// NewEscalationPreventionManager accepts a separate RBACStoreAccessor argument
+// and that *Manager satisfies both RBACManager and RBACStoreAccessor.
+func TestNewEscalationPreventionManager_AcceptsStoreAccessor(t *testing.T) {
+	tmpDir := t.TempDir()
+	storageManager, err := interfaces.CreateOSSStorageManager(tmpDir+"/flatfile", tmpDir+"/cfgms.db")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = storageManager.Close() })
+
+	manager := NewManagerWithStorage(
+		storageManager.GetAuditStore(),
+		storageManager.GetClientTenantStore(),
+		storageManager.GetRBACStore(),
+	)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	t.Cleanup(func() {
+		_ = manager.Close(ctx)
+	})
+
+	// *Manager satisfies both RBACManager and RBACStoreAccessor; construction must not panic.
+	epm := NewEscalationPreventionManager(manager, manager)
+	require.NotNil(t, epm)
+
+	// Verify the manager's GetStore accessor satisfies the interface.
+	var _ RBACStoreAccessor = manager
+}
+
+// TestValidateAndSetRoleParent_NoTypeAssertion verifies that ValidateAndSetRoleParent
+// works correctly when called through the Manager (which routes through
+// escalationPreventionMgr). This confirms the storeAccessor path works end-to-end
+// without a type assertion to *Manager.
+func TestValidateAndSetRoleParent_NoTypeAssertion(t *testing.T) {
+	tmpDir := t.TempDir()
+	storageManager, err := interfaces.CreateOSSStorageManager(tmpDir+"/flatfile", tmpDir+"/cfgms.db")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = storageManager.Close() })
+
+	manager := NewManagerWithStorage(
+		storageManager.GetAuditStore(),
+		storageManager.GetClientTenantStore(),
+		storageManager.GetRBACStore(),
+	)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	t.Cleanup(func() {
+		_ = manager.Close(ctx)
+	})
+
+	require.NoError(t, manager.Initialize(ctx))
+
+	// Create two roles so we can establish a parent-child relationship.
+	parentRole := &common.Role{
+		Id:          "test-parent-role",
+		Name:        "Test Parent Role",
+		TenantId:    "tenant-1",
+		Description: "Parent role for hierarchy test",
+	}
+	childRole := &common.Role{
+		Id:          "test-child-role",
+		Name:        "Test Child Role",
+		TenantId:    "tenant-1",
+		Description: "Child role for hierarchy test",
+	}
+
+	ctxWithJustification := WithSensitiveOperationJustification(ctx, "test: creating roles for hierarchy test")
+	require.NoError(t, manager.CreateRole(ctxWithJustification, parentRole))
+	require.NoError(t, manager.CreateRole(ctxWithJustification, childRole))
+
+	// SetRoleParent routes through Manager.SetRoleParent → escalationPreventionMgr.ValidateAndSetRoleParent
+	// → storeAccessor.GetStore().SetRoleParent (no type assertion to *Manager).
+	err = manager.SetRoleParent(ctx, childRole.Id, parentRole.Id, common.RoleInheritanceType_ROLE_INHERITANCE_ADDITIVE)
+	require.NoError(t, err)
+
+	// Verify the parent was set.
+	parent, err := manager.GetParentRole(ctx, childRole.Id)
+	require.NoError(t, err)
+	assert.Equal(t, parentRole.Id, parent.Id)
+}
+
+// TestOperationLog_UsesEscalationOperationType verifies that the operation log
+// records operations using EscalationOperationType values.
+func TestOperationLog_UsesEscalationOperationType(t *testing.T) {
+	tmpDir := t.TempDir()
+	storageManager, err := interfaces.CreateOSSStorageManager(tmpDir+"/flatfile", tmpDir+"/cfgms.db")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = storageManager.Close() })
+
+	manager := NewManagerWithStorage(
+		storageManager.GetAuditStore(),
+		storageManager.GetClientTenantStore(),
+		storageManager.GetRBACStore(),
+	)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	t.Cleanup(func() {
+		_ = manager.Close(ctx)
+	})
+
+	require.NoError(t, manager.Initialize(ctx))
+
+	// Create a simple role and a subject, then assign the role to generate a log entry.
+	ctxWithJustification := WithSensitiveOperationJustification(ctx, "test: creating roles and assigning for log verification")
+	testRole := &common.Role{
+		Id:       "test-role-log",
+		Name:     "Test Role Log",
+		TenantId: "tenant-log",
+	}
+	require.NoError(t, manager.CreateRole(ctxWithJustification, testRole))
+
+	subjectID := "test-subject-log"
+	subject := &common.Subject{
+		Id:       subjectID,
+		Type:     common.SubjectType_SUBJECT_TYPE_USER,
+		TenantId: "tenant-log",
+		IsActive: true,
+	}
+	require.NoError(t, manager.CreateSubject(ctx, subject))
+
+	assignment := &common.RoleAssignment{
+		SubjectId: subjectID,
+		RoleId:    testRole.Id,
+		TenantId:  "tenant-log",
+	}
+	require.NoError(t, manager.AssignRole(ctxWithJustification, assignment))
+
+	// The operation log must contain at least one entry with EscalationOpTypeRoleAssignment.
+	log := manager.GetOperationLog()
+	require.NotEmpty(t, log, "operation log must not be empty after role assignment")
+
+	var found bool
+	for _, entry := range log {
+		if entry.Type == EscalationOpTypeRoleAssignment {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found, "operation log must contain an EscalationOpTypeRoleAssignment entry")
+}

--- a/features/rbac/interfaces.go
+++ b/features/rbac/interfaces.go
@@ -131,6 +131,13 @@ type PolicyEngine interface {
 	GetPolicies(ctx context.Context, tenantID, resourceType string) ([]memory.Policy, error)
 }
 
+// RBACStoreAccessor is a narrow interface used by EscalationPreventionManager to reach the
+// underlying RoleStore directly without going through the full RBACManager dispatch, which
+// would cause infinite recursion via SetRoleParent.
+type RBACStoreAccessor interface {
+	GetStore() *memory.Store
+}
+
 // RBACManager provides a high-level interface for RBAC operations
 type RBACManager interface {
 	PermissionStore

--- a/features/rbac/manager.go
+++ b/features/rbac/manager.go
@@ -35,7 +35,6 @@ type Manager struct {
 	// RevokeRole and DeleteRolesByTenant. When nil, those operations skip invalidation.
 	cacheManager *continuous.CacheManager
 
-	engine                  *AuthEngine
 	advancedEngine          *AdvancedAuthEngine
 	hierarchyEngine         *HierarchyEngine
 	delegationManager       *DelegationManager
@@ -77,7 +76,6 @@ func NewManagerWithStorage(auditStore business.AuditStore, clientTenantStore bus
 	// This store exists only for the lifetime of this manager instance
 	// All persistent data flows through global storage interfaces (auditStore, clientTenantStore)
 	ephemeralStore := memory.NewStore()
-	engine := NewAuthEngine(ephemeralStore, ephemeralStore, ephemeralStore, ephemeralStore)
 	hierarchyEngine := NewHierarchyEngine(ephemeralStore, ephemeralStore)
 
 	// Create audit manager for RBAC operations
@@ -85,10 +83,6 @@ func NewManagerWithStorage(auditStore business.AuditStore, clientTenantStore bus
 	if auditErr != nil {
 		panic(fmt.Sprintf("NewManagerWithStorage: failed to create audit manager: %v", auditErr))
 	}
-
-	// Wire the hierarchy engine into the base auth engine so GetEffectivePermissions
-	// traverses role inheritance chains.
-	engine.SetHierarchyEngine(hierarchyEngine)
 
 	// Create manager instance with pluggable storage
 	manager := &Manager{
@@ -98,15 +92,14 @@ func NewManagerWithStorage(auditStore business.AuditStore, clientTenantStore bus
 		rbacStore:           rbacStore, // Write-through persistent RBAC storage
 		usePluggableStorage: true,
 		auditManager:        auditManager,
-		engine:              engine,
 		hierarchyEngine:     hierarchyEngine,
 	}
 
 	// Initialize advanced components
 	advancedEngine := NewAdvancedAuthEngine(ephemeralStore, ephemeralStore, ephemeralStore, ephemeralStore)
-	delegationManager := NewDelegationManager(manager)                 // Pass manager for RBAC operations
-	templateManager := NewTemplateManager(manager)                     // Pass manager for template operations
-	escalationPreventionMgr := NewEscalationPreventionManager(manager) // Pass manager for privilege escalation protection
+	delegationManager := NewDelegationManager(manager)                          // Pass manager for RBAC operations
+	templateManager := NewTemplateManager(manager)                              // Pass manager for template operations
+	escalationPreventionMgr := NewEscalationPreventionManager(manager, manager) // manager satisfies both RBACManager and RBACStoreAccessor
 
 	// Set circular references
 	advancedEngine.SetRBACManager(manager)

--- a/features/rbac/manager_test.go
+++ b/features/rbac/manager_test.go
@@ -883,11 +883,10 @@ func TestManager_CheckPermission_DbError_RecordsAuditEvent(t *testing.T) {
 	}
 
 	// Replace the base engine inside the advanced engine with one that uses the
-	// error-injecting store. Both manager.engine and manager.advancedEngine.baseEngine
-	// are accessible from within the same package.
+	// error-injecting store. manager.advancedEngine.baseEngine is the actual
+	// path used by Manager.CheckPermission.
 	errorEngine := NewAuthEngine(manager.store, errorStore, manager.store, manager.store)
 	errorEngine.SetHierarchyEngine(manager.hierarchyEngine)
-	manager.engine = errorEngine
 	manager.advancedEngine.baseEngine = errorEngine
 
 	request := &common.AccessRequest{


### PR DESCRIPTION
## Summary

- **Down-cast fix**: `ValidateAndSetRoleParent` replaced `epm.rbacManager.(*Manager)` type assertion with a new `RBACStoreAccessor` mini-interface that exposes `GetStore() *memory.Store`. `EscalationPreventionManager` now holds a `storeAccessor` field; `*Manager` satisfies both `RBACManager` and `RBACStoreAccessor` without additional methods.
- **Dead field removal**: `Manager.engine *AuthEngine` was constructed but never read (all CheckPermission calls route through `advancedEngine`). Removed field, local variable, and struct-literal assignment. `AdvancedAuthEngine.baseEngine` is live and untouched.
- **Enum disambiguation**: Renamed `OperationType` → `EscalationOperationType` in `escalation_prevention.go` to eliminate ambiguity with `continuous.OperationType` (different purpose: API/resource/data risk level). All constants renamed `EscalationOpType*`.
- **O(1) cache invalidation**: Added `subjectIndex`, `tenantIndex`, `permissionIndex` forward maps and `keyMeta` reverse map to `CacheManager`. `CacheAuth` populates all indexes. `invalidateSubject/Tenant/Permission` use index lookup instead of linear cache scan. `invalidateSession` updated symmetrically. `removeKeyFromAllIndexesLocked` provides O(1) cross-index cleanup.

## Test plan

- [ ] `go test -race ./features/rbac/...` — all packages pass
- [ ] `golangci-lint run ./features/rbac/...` — zero issues
- [ ] `make build` — all binaries compile
- [ ] `BenchmarkInvalidateSubject` in `cache_manager_test.go` — 100k-entry cache, 100 target entries
- [ ] `TestValidateAndSetRoleParent_NoTypeAssertion` — end-to-end verification via storeAccessor path
- [ ] `TestInvalidateSubject_IndexBasedLookup` / `TestInvalidateTenant_IndexBasedLookup` / `TestInvalidatePermission_IndexBasedLookup` — O(1) invalidation with L2-only entries covered
- [ ] `TestInvalidateSubject_CrossIndexCleanup` — session index clean after subject invalidation
- [ ] `TestEscalationOperationType_Constants` — renamed constants have correct values

## Specialist Review Results

- **QA Test Runner**: PASS — all tests pass, lint clean, build passes
- **QA Code Reviewer**: PASS (after fixes) — resolved lint issues (gofmt, redundant type, unused method) and added proper error handling in benchmark setup
- **Security Engineer**: PASS — no blocking issues; gosec/staticcheck/go vet clean; architecture check clean; no hardcoded secrets, no SQL injection, no central provider violations, tenant isolation maintained

Fixes #977

🤖 Generated with [Claude Code](https://claude.com/claude-code)