### PR TITLE
siem: apply defaults before validation in NewSIEMEngine (Issue #1045)

### DIFF
--- a/features/siem/siem_engine.go
+++ b/features/siem/siem_engine.go
@@ -108,11 +108,6 @@ func NewSIEMEngine(config ProcessingConfig, triggerManager trigger.TriggerManage
 
 	logger := logging.ForModule("siem.engine").WithField("component", "engine")
 
-	// Validate configuration
-	if err := validateProcessingConfig(config); err != nil {
-		return nil, fmt.Errorf("invalid processing configuration: %w", err)
-	}
-
 	// Set performance-optimized defaults
 	if config.BufferSize == 0 {
 		config.BufferSize = 100000 // Large buffer for high throughput
@@ -128,6 +123,11 @@ func NewSIEMEngine(config ProcessingConfig, triggerManager trigger.TriggerManage
 	}
 	if config.TargetThroughput == 0 {
 		config.TargetThroughput = 12000 // Target above 10k for safety margin
+	}
+
+	// Validate configuration after defaults are applied
+	if err := validateProcessingConfig(config); err != nil {
+		return nil, fmt.Errorf("invalid processing configuration: %w", err)
 	}
 
 	// Create core components

--- a/features/siem/siem_engine_test.go
+++ b/features/siem/siem_engine_test.go
@@ -155,6 +155,29 @@ func createTestConfig() ProcessingConfig {
 
 // Unit Tests
 
+func TestSIEMEngine_ZeroConfigConstruction(t *testing.T) {
+	triggerManager := NewMockTriggerManager()
+	workflowTrigger := NewMockWorkflowTrigger()
+
+	engine, err := NewSIEMEngine(ProcessingConfig{}, triggerManager, workflowTrigger)
+	require.NoError(t, err)
+	require.NotNil(t, engine)
+	assert.NotNil(t, engine.streamProcessor)
+	assert.NotNil(t, engine.patternMatcher)
+	assert.NotNil(t, engine.eventCorrelator)
+	assert.NotNil(t, engine.ruleManager)
+}
+
+func TestSIEMEngine_InvalidConfigRejected(t *testing.T) {
+	triggerManager := NewMockTriggerManager()
+	workflowTrigger := NewMockWorkflowTrigger()
+
+	// Explicit sub-threshold values are not zero, so no default is applied; validation must reject them.
+	_, err := NewSIEMEngine(ProcessingConfig{BufferSize: 1, BatchSize: 200, WorkerCount: 4, TargetThroughput: 12000}, triggerManager, workflowTrigger)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "buffer size must be at least 1000")
+}
+
 func TestSIEMEngine_Creation(t *testing.T) {
 	triggerManager := NewMockTriggerManager()
 	workflowTrigger := NewMockWorkflowTrigger()


### PR DESCRIPTION
## Summary

- Move `validateProcessingConfig` call to after the zero-value defaults block in `NewSIEMEngine` — defaults are now applied before validation, matching `NewStreamProcessor`'s pattern
- `NewSIEMEngine(ProcessingConfig{}, ...)` now succeeds and returns a non-nil engine instead of failing with "buffer size must be at least 1000"
- Add `TestSIEMEngine_ZeroConfigConstruction` (happy path) and `TestSIEMEngine_InvalidConfigRejected` (error path) tests

Fixes #1045
Parent epic: #752

## Test plan

- [x] `TestSIEMEngine_ZeroConfigConstruction` — zero-value config gets defaults and succeeds
- [x] `TestSIEMEngine_InvalidConfigRejected` — explicit sub-threshold values still rejected
- [x] `TestSIEMEngine_Creation` — existing full-config test still passes
- [x] `go test ./features/siem/...` — all 21 tests pass

## Specialist Review Results

**QA Test Runner: PASS**
- All quality validation gates passed
- `features/siem` package: PASS (all tests)
- Architecture/central provider compliance: PASS
- Cross-platform builds: PASS
- Trivy DB download blocked by sandbox network (environmental, not a code defect — no dependency changes)

**QA Code Review: PASS (pre-existing condition noted)**
- No blocking issues introduced by this PR
- `MockTriggerManager`/`MockWorkflowTrigger` are pre-existing test types used by all tests in the file (and the trigger package tests themselves); out of scope for this story's two-line reorder
- Error path coverage added via `TestSIEMEngine_InvalidConfigRejected`

**Security Review: PASS**
- No blocking issues
- No hardcoded secrets, SQL injection, information disclosure, or central provider violations
- Validation error messages are static strings; no sensitive info disclosed
- All automated scans: PASS (Trivy: environmental network failure only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)