### PR TITLE
siem: wire security event emission through pkg/audit (Issue #1046)

### DIFF
--- a/features/siem/siem_engine.go
+++ b/features/siem/siem_engine.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/cfgis/cfgms/features/workflow/trigger"
+	"github.com/cfgis/cfgms/pkg/audit"
 	"github.com/cfgis/cfgms/pkg/logging"
 	"github.com/cfgis/cfgms/pkg/logging/interfaces"
 )
@@ -21,7 +22,8 @@ import (
 // It coordinates all components to achieve 10,000+ log entries per second processing
 // with <100ms latency for real-time security event detection and workflow automation.
 type SIEMEngine struct {
-	logger *logging.ModuleLogger
+	logger       *logging.ModuleLogger
+	auditManager *audit.Manager
 
 	// Core components
 	streamProcessor     StreamProcessor
@@ -104,7 +106,7 @@ type GCController struct {
 
 // NewSIEMEngine creates a new SIEM processing engine with all components
 func NewSIEMEngine(config ProcessingConfig, triggerManager trigger.TriggerManager,
-	workflowTrigger trigger.WorkflowTrigger) (*SIEMEngine, error) {
+	workflowTrigger trigger.WorkflowTrigger, auditManager *audit.Manager) (*SIEMEngine, error) {
 
 	logger := logging.ForModule("siem.engine").WithField("component", "engine")
 
@@ -134,7 +136,7 @@ func NewSIEMEngine(config ProcessingConfig, triggerManager trigger.TriggerManage
 	patternMatcher := NewPatternMatcher()
 	eventCorrelator := NewEventCorrelator(config.CorrelationWindow)
 	ruleManager := NewRuleManager(patternMatcher, eventCorrelator)
-	streamProcessor := NewStreamProcessor(config, patternMatcher, eventCorrelator, ruleManager)
+	streamProcessor := NewStreamProcessor(config, patternMatcher, eventCorrelator, ruleManager, auditManager)
 
 	// Create workflow integration
 	workflowConfig := WorkflowIntegrationConfig{
@@ -161,6 +163,7 @@ func NewSIEMEngine(config ProcessingConfig, triggerManager trigger.TriggerManage
 
 	return &SIEMEngine{
 		logger:              logger,
+		auditManager:        auditManager,
 		streamProcessor:     streamProcessor,
 		patternMatcher:      patternMatcher,
 		eventCorrelator:     eventCorrelator,

--- a/features/siem/siem_engine_test.go
+++ b/features/siem/siem_engine_test.go
@@ -16,108 +16,36 @@ import (
 
 	"github.com/cfgis/cfgms/features/workflow/trigger"
 	"github.com/cfgis/cfgms/pkg/logging/interfaces"
+	storageInterfaces "github.com/cfgis/cfgms/pkg/storage/interfaces"
 )
 
-// MockTriggerManager implements trigger.TriggerManager for testing
-type MockTriggerManager struct {
-	triggers map[string]*trigger.Trigger
-	mutex    sync.RWMutex
-}
+// testWorkflowTrigger is a minimal real implementation of trigger.WorkflowTrigger.
+// WorkflowIntegration stores this reference but the current SIEM processing pipeline
+// does not invoke workflow execution paths — it is held for future wiring.
+type testWorkflowTrigger struct{}
 
-func NewMockTriggerManager() *MockTriggerManager {
-	return &MockTriggerManager{
-		triggers: make(map[string]*trigger.Trigger),
-	}
-}
-
-func (m *MockTriggerManager) CreateTrigger(ctx context.Context, t *trigger.Trigger) error {
-	m.mutex.Lock()
-	defer m.mutex.Unlock()
-	m.triggers[t.ID] = t
-	return nil
-}
-
-func (m *MockTriggerManager) UpdateTrigger(ctx context.Context, t *trigger.Trigger) error {
-	m.mutex.Lock()
-	defer m.mutex.Unlock()
-	m.triggers[t.ID] = t
-	return nil
-}
-
-func (m *MockTriggerManager) DeleteTrigger(ctx context.Context, triggerID string) error {
-	m.mutex.Lock()
-	defer m.mutex.Unlock()
-	delete(m.triggers, triggerID)
-	return nil
-}
-
-func (m *MockTriggerManager) GetTrigger(ctx context.Context, triggerID string) (*trigger.Trigger, error) {
-	m.mutex.RLock()
-	defer m.mutex.RUnlock()
-	if t, exists := m.triggers[triggerID]; exists {
-		return t, nil
-	}
-	return nil, nil
-}
-
-func (m *MockTriggerManager) ListTriggers(ctx context.Context, filter *trigger.TriggerFilter) ([]*trigger.Trigger, error) {
-	m.mutex.RLock()
-	defer m.mutex.RUnlock()
-
-	var result []*trigger.Trigger
-	for _, t := range m.triggers {
-		result = append(result, t)
-	}
-	return result, nil
-}
-
-func (m *MockTriggerManager) EnableTrigger(ctx context.Context, triggerID string) error  { return nil }
-func (m *MockTriggerManager) DisableTrigger(ctx context.Context, triggerID string) error { return nil }
-func (m *MockTriggerManager) ExecuteTrigger(ctx context.Context, triggerID string, data map[string]interface{}) (*trigger.TriggerExecution, error) {
-	return nil, nil
-}
-func (m *MockTriggerManager) GetTriggerExecutions(ctx context.Context, triggerID string, limit int) ([]*trigger.TriggerExecution, error) {
-	return nil, nil
-}
-func (m *MockTriggerManager) Start(ctx context.Context) error { return nil }
-func (m *MockTriggerManager) Stop(ctx context.Context) error  { return nil }
-
-// MockWorkflowTrigger implements trigger.WorkflowTrigger for testing
-type MockWorkflowTrigger struct {
-	triggeredWorkflows []string
-	mutex              sync.RWMutex
-}
-
-func NewMockWorkflowTrigger() *MockWorkflowTrigger {
-	return &MockWorkflowTrigger{
-		triggeredWorkflows: make([]string, 0),
-	}
-}
-
-func (m *MockWorkflowTrigger) TriggerWorkflow(ctx context.Context, t *trigger.Trigger, data map[string]interface{}) (*trigger.WorkflowExecution, error) {
-	m.mutex.Lock()
-	defer m.mutex.Unlock()
-
-	m.triggeredWorkflows = append(m.triggeredWorkflows, t.WorkflowName)
-
+func (t *testWorkflowTrigger) TriggerWorkflow(_ context.Context, trig *trigger.Trigger, _ map[string]interface{}) (*trigger.WorkflowExecution, error) {
 	return &trigger.WorkflowExecution{
-		ID:           "test-exec-" + t.ID,
-		WorkflowName: t.WorkflowName,
+		ID:           "test-exec-" + trig.ID,
+		WorkflowName: trig.WorkflowName,
 		Status:       "running",
 		StartTime:    time.Now(),
 	}, nil
 }
 
-func (m *MockWorkflowTrigger) ValidateTrigger(ctx context.Context, t *trigger.Trigger) error {
+func (t *testWorkflowTrigger) ValidateTrigger(_ context.Context, _ *trigger.Trigger) error {
 	return nil
 }
 
-func (m *MockWorkflowTrigger) GetTriggeredWorkflows() []string {
-	m.mutex.RLock()
-	defer m.mutex.RUnlock()
-	result := make([]string, len(m.triggeredWorkflows))
-	copy(result, m.triggeredWorkflows)
-	return result
+// newTestTriggerManager creates a real trigger.TriggerManagerImpl backed by the registered
+// flatfile StorageProvider. Trigger state is held in-memory; the flatfile provider satisfies
+// the Available() check but does not implement the optional key-value Store method, so
+// triggers are not persisted to disk — suitable for tests that exercise in-memory behaviour.
+func newTestTriggerManager(tb testing.TB, wt trigger.WorkflowTrigger) *trigger.TriggerManagerImpl {
+	tb.Helper()
+	provider, err := storageInterfaces.GetStorageProvider("flatfile")
+	require.NoError(tb, err, "flatfile provider must be registered via blank import in stream_processor_test.go")
+	return trigger.NewTriggerManager(provider, nil, nil, nil, wt)
 }
 
 // Test helper functions
@@ -156,10 +84,11 @@ func createTestConfig() ProcessingConfig {
 // Unit Tests
 
 func TestSIEMEngine_ZeroConfigConstruction(t *testing.T) {
-	triggerManager := NewMockTriggerManager()
-	workflowTrigger := NewMockWorkflowTrigger()
+	wt := &testWorkflowTrigger{}
+	triggerManager := newTestTriggerManager(t, wt)
+	workflowTrigger := wt
 
-	engine, err := NewSIEMEngine(ProcessingConfig{}, triggerManager, workflowTrigger)
+	engine, err := NewSIEMEngine(ProcessingConfig{}, triggerManager, workflowTrigger, nil)
 	require.NoError(t, err)
 	require.NotNil(t, engine)
 	assert.NotNil(t, engine.streamProcessor)
@@ -169,21 +98,23 @@ func TestSIEMEngine_ZeroConfigConstruction(t *testing.T) {
 }
 
 func TestSIEMEngine_InvalidConfigRejected(t *testing.T) {
-	triggerManager := NewMockTriggerManager()
-	workflowTrigger := NewMockWorkflowTrigger()
+	wt := &testWorkflowTrigger{}
+	triggerManager := newTestTriggerManager(t, wt)
+	workflowTrigger := wt
 
 	// Explicit sub-threshold values are not zero, so no default is applied; validation must reject them.
-	_, err := NewSIEMEngine(ProcessingConfig{BufferSize: 1, BatchSize: 200, WorkerCount: 4, TargetThroughput: 12000}, triggerManager, workflowTrigger)
+	_, err := NewSIEMEngine(ProcessingConfig{BufferSize: 1, BatchSize: 200, WorkerCount: 4, TargetThroughput: 12000}, triggerManager, workflowTrigger, nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "buffer size must be at least 1000")
 }
 
 func TestSIEMEngine_Creation(t *testing.T) {
-	triggerManager := NewMockTriggerManager()
-	workflowTrigger := NewMockWorkflowTrigger()
+	wt := &testWorkflowTrigger{}
+	triggerManager := newTestTriggerManager(t, wt)
+	workflowTrigger := wt
 	config := createTestConfig()
 
-	engine, err := NewSIEMEngine(config, triggerManager, workflowTrigger)
+	engine, err := NewSIEMEngine(config, triggerManager, workflowTrigger, nil)
 	require.NoError(t, err)
 	assert.NotNil(t, engine)
 	assert.Equal(t, int32(0), engine.running)
@@ -194,11 +125,12 @@ func TestSIEMEngine_Creation(t *testing.T) {
 }
 
 func TestSIEMEngine_StartStop(t *testing.T) {
-	triggerManager := NewMockTriggerManager()
-	workflowTrigger := NewMockWorkflowTrigger()
+	wt := &testWorkflowTrigger{}
+	triggerManager := newTestTriggerManager(t, wt)
+	workflowTrigger := wt
 	config := createTestConfig()
 
-	engine, err := NewSIEMEngine(config, triggerManager, workflowTrigger)
+	engine, err := NewSIEMEngine(config, triggerManager, workflowTrigger, nil)
 	require.NoError(t, err)
 
 	ctx := context.Background()
@@ -228,11 +160,12 @@ func TestSIEMEngine_StartStop(t *testing.T) {
 // that verifies ProcessLogEntry sends entries directly to StreamProcessor.ProcessEntry.
 // EntriesProcessed is incremented synchronously in ProcessEntry, so no sleep is needed.
 func TestSIEMEngine_ProcessLogEntry_RoutesToStreamProcessor(t *testing.T) {
-	triggerManager := NewMockTriggerManager()
-	workflowTrigger := NewMockWorkflowTrigger()
+	wt := &testWorkflowTrigger{}
+	triggerManager := newTestTriggerManager(t, wt)
+	workflowTrigger := wt
 	config := createTestConfig()
 
-	engine, err := NewSIEMEngine(config, triggerManager, workflowTrigger)
+	engine, err := NewSIEMEngine(config, triggerManager, workflowTrigger, nil)
 	require.NoError(t, err)
 
 	ctx := context.Background()
@@ -260,11 +193,12 @@ func TestSIEMEngine_ProcessLogEntry(t *testing.T) {
 		t.Skip("Skipping SIEM engine test in short mode")
 	}
 
-	triggerManager := NewMockTriggerManager()
-	workflowTrigger := NewMockWorkflowTrigger()
+	wt := &testWorkflowTrigger{}
+	triggerManager := newTestTriggerManager(t, wt)
+	workflowTrigger := wt
 	config := createTestConfig()
 
-	engine, err := NewSIEMEngine(config, triggerManager, workflowTrigger)
+	engine, err := NewSIEMEngine(config, triggerManager, workflowTrigger, nil)
 	require.NoError(t, err)
 
 	ctx := context.Background()
@@ -295,7 +229,7 @@ func TestStreamProcessor_ProcessEntry(t *testing.T) {
 	eventCorrelator := NewEventCorrelator(5 * time.Minute)
 	ruleManager := NewRuleManager(patternMatcher, eventCorrelator)
 
-	sp := NewStreamProcessor(config, patternMatcher, eventCorrelator, ruleManager)
+	sp := NewStreamProcessor(config, patternMatcher, eventCorrelator, ruleManager, nil)
 
 	ctx := context.Background()
 
@@ -329,7 +263,7 @@ func TestStreamProcessor_ProcessEntry_BufferFull(t *testing.T) {
 	eventCorrelator := NewEventCorrelator(5 * time.Minute)
 	ruleManager := NewRuleManager(patternMatcher, eventCorrelator)
 
-	sp := NewStreamProcessor(config, patternMatcher, eventCorrelator, ruleManager)
+	sp := NewStreamProcessor(config, patternMatcher, eventCorrelator, ruleManager, nil)
 
 	// Manually configure a tiny buffer and mark running to isolate the drop-on-full
 	// path without goroutine scheduling races.
@@ -360,11 +294,12 @@ func TestSIEMEngine_NoGoroutineLeak(t *testing.T) {
 	runtime.GC()
 	beforeCount := runtime.NumGoroutine()
 
-	triggerManager := NewMockTriggerManager()
-	workflowTrigger := NewMockWorkflowTrigger()
+	wt := &testWorkflowTrigger{}
+	triggerManager := newTestTriggerManager(t, wt)
+	workflowTrigger := wt
 	config := createTestConfig()
 
-	engine, err := NewSIEMEngine(config, triggerManager, workflowTrigger)
+	engine, err := NewSIEMEngine(config, triggerManager, workflowTrigger, nil)
 	require.NoError(t, err)
 
 	ctx := context.Background()
@@ -474,11 +409,12 @@ func TestEventCorrelator_BasicCorrelation(t *testing.T) {
 // Performance Tests
 
 func BenchmarkSIEMEngine_ThroughputTest(b *testing.B) {
-	triggerManager := NewMockTriggerManager()
-	workflowTrigger := NewMockWorkflowTrigger()
+	wt := &testWorkflowTrigger{}
+	triggerManager := newTestTriggerManager(b, wt)
+	workflowTrigger := wt
 	config := createTestConfig()
 
-	engine, err := NewSIEMEngine(config, triggerManager, workflowTrigger)
+	engine, err := NewSIEMEngine(config, triggerManager, workflowTrigger, nil)
 	require.NoError(b, err)
 
 	ctx := context.Background()
@@ -551,11 +487,12 @@ func TestSIEMEngine_EndToEndProcessing(t *testing.T) {
 		t.Skip("Skipping end-to-end test in short mode")
 	}
 
-	triggerManager := NewMockTriggerManager()
-	workflowTrigger := NewMockWorkflowTrigger()
+	wt := &testWorkflowTrigger{}
+	triggerManager := newTestTriggerManager(t, wt)
+	workflowTrigger := wt
 	config := createTestConfig()
 
-	engine, err := NewSIEMEngine(config, triggerManager, workflowTrigger)
+	engine, err := NewSIEMEngine(config, triggerManager, workflowTrigger, nil)
 	require.NoError(t, err)
 
 	ctx := context.Background()
@@ -620,11 +557,12 @@ func TestSIEMEngine_ThroughputRequirement(t *testing.T) {
 		t.Skip("Skipping throughput test in short mode")
 	}
 
-	triggerManager := NewMockTriggerManager()
-	workflowTrigger := NewMockWorkflowTrigger()
+	wt := &testWorkflowTrigger{}
+	triggerManager := newTestTriggerManager(t, wt)
+	workflowTrigger := wt
 	config := createTestConfig()
 
-	engine, err := NewSIEMEngine(config, triggerManager, workflowTrigger)
+	engine, err := NewSIEMEngine(config, triggerManager, workflowTrigger, nil)
 	require.NoError(t, err)
 
 	ctx := context.Background()
@@ -684,11 +622,12 @@ func TestSIEMEngine_LatencyRequirement(t *testing.T) {
 		t.Skip("Skipping latency test in short mode")
 	}
 
-	triggerManager := NewMockTriggerManager()
-	workflowTrigger := NewMockWorkflowTrigger()
+	wt := &testWorkflowTrigger{}
+	triggerManager := newTestTriggerManager(t, wt)
+	workflowTrigger := wt
 	config := createTestConfig()
 
-	engine, err := NewSIEMEngine(config, triggerManager, workflowTrigger)
+	engine, err := NewSIEMEngine(config, triggerManager, workflowTrigger, nil)
 	require.NoError(t, err)
 
 	ctx := context.Background()
@@ -752,11 +691,12 @@ func TestSIEMEngine_MemoryUsage(t *testing.T) {
 	var memStatsBefore runtime.MemStats
 	runtime.ReadMemStats(&memStatsBefore)
 
-	triggerManager := NewMockTriggerManager()
-	workflowTrigger := NewMockWorkflowTrigger()
+	wt := &testWorkflowTrigger{}
+	triggerManager := newTestTriggerManager(t, wt)
+	workflowTrigger := wt
 	config := createTestConfig()
 
-	engine, err := NewSIEMEngine(config, triggerManager, workflowTrigger)
+	engine, err := NewSIEMEngine(config, triggerManager, workflowTrigger, nil)
 	require.NoError(t, err)
 
 	ctx := context.Background()
@@ -796,11 +736,12 @@ func TestSIEMEngine_StressTest(t *testing.T) {
 		t.Skip("Skipping stress test in short mode")
 	}
 
-	triggerManager := NewMockTriggerManager()
-	workflowTrigger := NewMockWorkflowTrigger()
+	wt := &testWorkflowTrigger{}
+	triggerManager := newTestTriggerManager(t, wt)
+	workflowTrigger := wt
 	config := createTestConfig()
 
-	engine, err := NewSIEMEngine(config, triggerManager, workflowTrigger)
+	engine, err := NewSIEMEngine(config, triggerManager, workflowTrigger, nil)
 	require.NoError(t, err)
 
 	ctx := context.Background()

--- a/features/siem/stream_processor.go
+++ b/features/siem/stream_processor.go
@@ -11,6 +11,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/cfgis/cfgms/pkg/audit"
 	"github.com/cfgis/cfgms/pkg/logging"
 	"github.com/cfgis/cfgms/pkg/logging/interfaces"
 	"github.com/cfgis/cfgms/pkg/storage/interfaces/business"
@@ -20,8 +21,9 @@ import (
 // buffered processing capabilities designed to handle 10,000+ log entries per second
 // with <100ms processing latency.
 type StreamProcessorImpl struct {
-	logger *logging.ModuleLogger
-	config ProcessingConfig
+	logger       *logging.ModuleLogger
+	config       ProcessingConfig
+	auditManager *audit.Manager
 
 	// Processing components
 	patternMatcher  PatternMatcher
@@ -65,6 +67,7 @@ type StreamWorker struct {
 	inputChan       chan *ProcessingBatch
 	logger          *logging.ModuleLogger
 	processingStats *WorkerStats
+	auditManager    *audit.Manager
 }
 
 // WorkerStats tracks individual worker performance
@@ -81,7 +84,7 @@ const streamWorkerQueueSize = 1000
 
 // NewStreamProcessor creates a new high-performance stream processor
 func NewStreamProcessor(config ProcessingConfig, patternMatcher PatternMatcher,
-	eventCorrelator EventCorrelator, ruleManager RuleManager) *StreamProcessorImpl {
+	eventCorrelator EventCorrelator, ruleManager RuleManager, auditManager *audit.Manager) *StreamProcessorImpl {
 
 	logger := logging.ForModule("siem.stream_processor").WithField("component", "processor")
 
@@ -108,6 +111,7 @@ func NewStreamProcessor(config ProcessingConfig, patternMatcher PatternMatcher,
 	return &StreamProcessorImpl{
 		logger:          logger,
 		config:          config,
+		auditManager:    auditManager,
 		patternMatcher:  patternMatcher,
 		eventCorrelator: eventCorrelator,
 		ruleManager:     ruleManager,
@@ -153,6 +157,7 @@ func (sp *StreamProcessorImpl) Start(ctx context.Context) error {
 			inputChan:       make(chan *ProcessingBatch, streamWorkerQueueSize),
 			logger:          logger.WithField("worker_id", i),
 			processingStats: &WorkerStats{},
+			auditManager:    sp.auditManager,
 		}
 	}
 
@@ -543,16 +548,41 @@ func (w *StreamWorker) convertMatchesToEvents(matches []*PatternMatch, tenantID 
 	return events
 }
 
-// processSecurityEvents processes individual security events (stub for workflow integration)
+// processSecurityEvents records each detected security event in the audit log.
 func (w *StreamWorker) processSecurityEvents(ctx context.Context, events []*SecurityEvent) {
-	// TODO: Implement workflow trigger integration
 	for _, event := range events {
 		w.logger.DebugCtx(ctx, "Processing security event",
 			"event_id", event.ID,
 			"event_type", event.EventType,
 			"severity", event.Severity,
 			"tenant_id", event.TenantID)
+
+		if w.auditManager == nil {
+			continue
+		}
+		builder := audit.SecurityEvent(event.TenantID, "siem", event.EventType, event.Description, event.Severity).
+			Detail("rule_id", event.RuleID).
+			Detail("source", logging.SanitizeLogValue(event.Source)).
+			Details(sanitizedFields(event.Fields))
+		if err := w.auditManager.RecordEvent(ctx, builder); err != nil {
+			w.logger.ErrorCtx(ctx, "Failed to record security event in audit log",
+				"event_id", event.ID,
+				"error", err.Error())
+		}
 	}
+}
+
+// sanitizedFields returns a copy of fields with each value sanitized via
+// logging.SanitizeLogValue to prevent user-controlled data from reaching logs or audit records.
+func sanitizedFields(fields map[string]interface{}) map[string]interface{} {
+	if fields == nil {
+		return nil
+	}
+	out := make(map[string]interface{}, len(fields))
+	for k, v := range fields {
+		out[k] = logging.SanitizeLogValue(fmt.Sprintf("%v", v))
+	}
+	return out
 }
 
 // processCorrelatedEvents processes correlated events (stub for workflow integration)

--- a/features/siem/stream_processor_test.go
+++ b/features/siem/stream_processor_test.go
@@ -1,0 +1,205 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+package siem
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cfgis/cfgms/pkg/audit"
+	"github.com/cfgis/cfgms/pkg/logging/interfaces"
+	storageInterfaces "github.com/cfgis/cfgms/pkg/storage/interfaces"
+	"github.com/cfgis/cfgms/pkg/storage/interfaces/business"
+
+	// Register OSS storage providers
+	_ "github.com/cfgis/cfgms/pkg/storage/providers/database"
+	_ "github.com/cfgis/cfgms/pkg/storage/providers/flatfile"
+	_ "github.com/cfgis/cfgms/pkg/storage/providers/sqlite"
+)
+
+// newTestAuditManager creates a real audit.Manager backed by OSS storage in a temp dir.
+func newTestAuditManager(t *testing.T) *audit.Manager {
+	t.Helper()
+	tmpDir := t.TempDir()
+	storageManager, err := storageInterfaces.CreateOSSStorageManager(tmpDir+"/flatfile", tmpDir+"/cfgms.db")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = storageManager.Close() })
+
+	mgr, err := audit.NewManager(storageManager.GetAuditStore(), "siem")
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_ = mgr.Stop(ctx)
+	})
+	return mgr
+}
+
+// TestStreamProcessor_SecurityEventAuditEmission verifies that a pattern match
+// produces an AuditEventSecurityEvent entry with rule_id in the audit store.
+func TestStreamProcessor_SecurityEventAuditEmission(t *testing.T) {
+	auditManager := newTestAuditManager(t)
+
+	config := createTestConfig()
+	patternMatcher := NewPatternMatcher()
+	eventCorrelator := NewEventCorrelator(5 * time.Minute)
+	ruleManager := NewRuleManager(patternMatcher, eventCorrelator)
+	sp := NewStreamProcessor(config, patternMatcher, eventCorrelator, ruleManager, auditManager)
+
+	ctx := context.Background()
+	require.NoError(t, sp.Start(ctx))
+	t.Cleanup(func() { _ = sp.Stop(ctx) })
+
+	ruleID := "audit-test-rule"
+	err := patternMatcher.AddPattern(&DetectionPattern{
+		ID:          ruleID,
+		Name:        "Audit Emission Test Pattern",
+		Pattern:     "AUDIT_EMISSION_TEST",
+		PatternType: PatternTypeContains,
+		Fields:      []string{"message"},
+		Enabled:     true,
+		Priority:    1,
+		CreatedAt:   time.Now(),
+	})
+	require.NoError(t, err)
+
+	entry := interfaces.LogEntry{
+		Timestamp:   time.Now(),
+		Level:       "ERROR",
+		Message:     "AUDIT_EMISSION_TEST detected suspicious activity",
+		ServiceName: "test-service",
+		TenantID:    "audit-test-tenant",
+		Fields:      map[string]interface{}{"host": "10.0.0.1", "count": 3},
+	}
+	require.NoError(t, sp.ProcessEntry(ctx, entry))
+
+	// Poll until the SIEM pipeline and audit drain goroutine have completed.
+	// The SIEM pipeline is fully async (batch collector → distributor → worker → audit queue → drain),
+	// so flush alone is insufficient without first waiting for pattern matching to emit to the queue.
+	var entries []*business.AuditEntry
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		flushCtx, cancel := context.WithTimeout(ctx, 2*time.Second)
+		_ = auditManager.Flush(flushCtx)
+		cancel()
+
+		entries, err = auditManager.QueryEntries(ctx, &business.AuditFilter{
+			TenantID:   "audit-test-tenant",
+			EventTypes: []business.AuditEventType{business.AuditEventSecurityEvent},
+		})
+		require.NoError(t, err)
+		if len(entries) >= 1 {
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+
+	require.GreaterOrEqual(t, len(entries), 1,
+		"expected at least one AuditEventSecurityEvent in the audit store")
+
+	found := false
+	for _, e := range entries {
+		assert.Equal(t, business.AuditEventSecurityEvent, e.EventType)
+		if e.Details != nil {
+			if v, ok := e.Details["rule_id"]; ok && v == ruleID {
+				found = true
+				break
+			}
+		}
+	}
+	assert.True(t, found, "expected an audit entry with rule_id=%q", ruleID)
+}
+
+// TestStreamProcessor_SecurityEventAuditNilManager verifies that nil auditManager
+// is handled gracefully — pattern matches are still processed without panics.
+func TestStreamProcessor_SecurityEventAuditNilManager(t *testing.T) {
+	config := createTestConfig()
+	patternMatcher := NewPatternMatcher()
+	eventCorrelator := NewEventCorrelator(5 * time.Minute)
+	ruleManager := NewRuleManager(patternMatcher, eventCorrelator)
+	sp := NewStreamProcessor(config, patternMatcher, eventCorrelator, ruleManager, nil)
+
+	ctx := context.Background()
+	require.NoError(t, sp.Start(ctx))
+	t.Cleanup(func() { _ = sp.Stop(ctx) })
+
+	require.NoError(t, patternMatcher.AddPattern(&DetectionPattern{
+		ID:          "nil-manager-rule",
+		Pattern:     "NIL_MANAGER_TEST",
+		PatternType: PatternTypeContains,
+		Fields:      []string{"message"},
+		Enabled:     true,
+		CreatedAt:   time.Now(),
+	}))
+
+	entry := interfaces.LogEntry{
+		Timestamp:   time.Now(),
+		Level:       "ERROR",
+		Message:     "NIL_MANAGER_TEST event",
+		ServiceName: "test-service",
+		TenantID:    "test-tenant",
+	}
+	require.NoError(t, sp.ProcessEntry(ctx, entry))
+
+	// Allow processing to complete without panicking
+	time.Sleep(200 * time.Millisecond)
+
+	metrics, err := sp.GetMetrics(ctx)
+	require.NoError(t, err)
+	assert.GreaterOrEqual(t, metrics.EntriesProcessed, int64(1))
+}
+
+// TestSanitizedFields verifies that user-controlled values are sanitized against log injection.
+func TestSanitizedFields(t *testing.T) {
+	// Build a long value that exceeds the 1024-char truncation threshold
+	longValue := make([]byte, 1200)
+	for i := range longValue {
+		longValue[i] = 'a'
+	}
+
+	fields := map[string]interface{}{
+		"newline_injection": "before\nINJECTED_LINE", // CWE-117 log forgery via newline
+		"ansi_escape":       "\x1b[31mRED\x1b[0m",   // ANSI color escape sequences
+		"cr_injection":      "before\roverwritten",   // CWE-117 via carriage return
+		"long_value":        string(longValue),        // must be truncated
+		"safe_value":        "10.0.0.1",              // safe passthrough
+		"numeric":           42,                       // numeric converted to string
+	}
+
+	result := sanitizedFields(fields)
+	require.NotNil(t, result)
+	assert.Len(t, result, len(fields))
+
+	// Newline and carriage return injection must be neutralized
+	assert.NotContains(t, result["newline_injection"], "\n",
+		"newline must be replaced by sanitizer")
+	assert.NotContains(t, result["cr_injection"], "\r",
+		"carriage return must be replaced by sanitizer")
+
+	// ANSI escape (\x1b) must be neutralized
+	assert.NotContains(t, result["ansi_escape"], "\x1b",
+		"ANSI escape must be replaced by sanitizer")
+
+	// Long values must be truncated (SanitizeLogValue caps at 1024 chars)
+	sanitized, ok := result["long_value"].(string)
+	require.True(t, ok)
+	assert.Less(t, len(sanitized), 1200, "long value must be truncated")
+	assert.Contains(t, sanitized, "[truncated]", "truncated marker must be appended")
+
+	// Safe ASCII passes through
+	assert.Equal(t, "10.0.0.1", result["safe_value"])
+
+	// Numeric value converted to string without control chars
+	numStr, ok := result["numeric"].(string)
+	require.True(t, ok)
+	assert.Equal(t, "42", numStr)
+}
+
+// TestSanitizedFields_Nil verifies that nil input returns nil.
+func TestSanitizedFields_Nil(t *testing.T) {
+	assert.Nil(t, sanitizedFields(nil))
+}


### PR DESCRIPTION
## Summary

- Wires `pkg/audit` into the SIEM stream processor so every pattern match produces a durable `AuditEventSecurityEvent` in the audit log
- `NewStreamProcessor` and `NewSIEMEngine` each accept a new `auditManager *audit.Manager` parameter (nil safe — skips recording when nil)
- `processSecurityEvents` replaces its stub with `audit.SecurityEvent(...).Detail("rule_id",...).Detail("source",...).Details(sanitizedFields(...)).RecordEvent(ctx)`
- User-controlled values (`event.Source`, `event.Fields`) sanitized via `logging.SanitizeLogValue` before reaching the audit record (CWE-117 prevention)
- Mock trigger components replaced with real implementations: `trigger.TriggerManagerImpl` (flatfile StorageProvider) + minimal `testWorkflowTrigger` struct

## Acceptance Criteria Status

- [x] `StreamProcessorImpl` has an `auditManager *audit.Manager` field
- [x] `StreamWorker` has an `auditManager *audit.Manager` field, set during `Start`
- [x] `NewStreamProcessor` accepts `auditManager *audit.Manager`
- [x] `NewSIEMEngine` accepts `auditManager *audit.Manager` and passes it to `NewStreamProcessor`
- [x] `processSecurityEvents` calls `auditManager.RecordEvent` for each detected event when `auditManager != nil`
- [x] `event.Fields` values sanitized via `logging.SanitizeLogValue()` before `Details()`
- [x] `event.Source` sanitized via `logging.SanitizeLogValue()` before use as a `Detail` value
- [x] Test: `TestStreamProcessor_SecurityEventAuditEmission` verifies `auditManager.QueryEntries` returns ≥1 entry with `EventType == business.AuditEventSecurityEvent` and `Details["rule_id"]` matching the rule
- [x] Test uses real `audit.NewManager` with `interfaces.CreateOSSStorageManager` — no mocks
- [x] `TestSanitizedFields` tests hostile inputs (newline injection, ANSI escape, >1024-char truncation)

## Specialist Review Results

| Specialist | Result |
|-----------|--------|
| QA Test Runner | **PASS** — all 84 packages pass; Trivy DB unreachable in sandbox (CI gate handles this) |
| QA Code Reviewer | **PASS** — mock trigger components replaced with real implementations; sanitization tests cover hostile inputs |
| Security Engineer | **PASS** — no blocking issues; untrusted `event.Source` and `event.Fields` sanitized before audit recording |

## Test Plan

- [x] `go test ./features/siem/... -short` passes
- [x] `go test ./pkg/audit/... -short` passes (no regressions)
- [x] `go build ./...` compiles cleanly
- [x] `TestStreamProcessor_SecurityEventAuditEmission` exercises full pipeline: ProcessEntry → pattern match → audit record → QueryEntries
- [x] `TestStreamProcessor_SecurityEventAuditNilManager` verifies nil guard prevents panic

🤖 Generated with [Claude Code](https://claude.com/claude-code)