### PR TITLE
po: handle WIP draft PRs from session truncation autonomously

### DIFF
--- a/.claude/agents/acceptance-reviewer.md
+++ b/.claude/agents/acceptance-reviewer.md
@@ -24,6 +24,30 @@ You are NOT the same as `/story-complete` QA. The distinction:
 
 You receive a PR number and story issue number as `$ARGUMENTS` (format: `pr:<PR_NUM> story:<STORY_NUM>`).
 
+## Phase 0: Draft-PR Short-Circuit (BLOCKING)
+
+Before any review work, check if the PR is a draft:
+
+```bash
+gh pr view <PR_NUM> --repo cfg-is/cfgms --json isDraft,body,title --jq '{isDraft, title, body_first_line: (.body | split("\n")[0])}'
+```
+
+If `isDraft == true`:
+
+- Do **NOT** run Phase 1–4. Do **NOT** check CI, acceptance criteria, or merge state.
+- Post a single comment on the PR using this exact body:
+
+  ```
+  Acceptance Reviewer — skipping draft PR.
+
+  Draft PRs are typically WIP from a truncated agent session (token reauth, token limit). The PO will dispatch `fix-pr` to resume the work; the resumed agent will mark this PR ready for review when finished. No findings to report at this stage.
+  ```
+
+- Remove the `pipeline:reviewing` label from the PR (so the failsafe doesn't think the review is still in flight).
+- Exit cleanly with verdict `SKIPPED_DRAFT`. Do NOT enqueue, label `pipeline:fix`, or label `pipeline:blocked` — those are wrong actions for a session-truncated WIP.
+
+A draft PR with body starting `Agent session failed with exit code` or title starting `WIP:` and ending `(agent failed)` is the canonical session-truncation case — same handling.
+
 ## Phase 1: Gather Context
 
 Run these in parallel:

--- a/.claude/agents/po.md
+++ b/.claude/agents/po.md
@@ -362,6 +362,25 @@ permission mode. The acceptance reviewer now runs in a dedicated headless
 container with skip-permissions inside, and the host PO dispatches it
 non-blocking and moves on.
 
+**Pre-step — Resume session-truncated WIP drafts.** Before any review work,
+process every `review_recommendations` entry with `action: "resume_failed_session"`.
+These are draft PRs pushed by `.devcontainer/entrypoint.sh` after an agent
+session hit a non-recoverable failure (token reauth, token-limit truncation,
+network drop). They should NOT be reviewed in their current state — the
+partial work is committed but incomplete.
+
+For each such entry:
+
+```bash
+./.claude/scripts/po-act.sh dispatch-fix <PR_NUM>
+```
+
+The fix-pr agent picks up the existing branch, completes the remaining work,
+and the entrypoint marks the PR ready for review when the agent exits 0. The
+next cron cycle will see the now-ready PR and route it through normal
+review (Step 5). This is "finishing a story", not "fixing a story" — fresh
+agent, fresh budget. No retry counter is incremented at the cron level.
+
 **Find PRs that need review.** A PR is review-eligible when:
 - branch is `feature/story-*`
 - state is OPEN

--- a/.claude/scripts/po-cycle-preflight.py
+++ b/.claude/scripts/po-cycle-preflight.py
@@ -130,7 +130,7 @@ def gh_pr_list_story_prs():
         "--repo", REPO,
         "--search", "head:feature/story-",
         "--state", "open",
-        "--json", "number,title,headRefName,labels,comments,statusCheckRollup,mergeStateStatus,mergeable,autoMergeRequest",
+        "--json", "number,title,body,isDraft,headRefName,labels,comments,statusCheckRollup,mergeStateStatus,mergeable,autoMergeRequest",
         "--limit", "50",
     )
 
@@ -506,6 +506,11 @@ def compute_review_recommendations(pr_summaries, queued_pr_numbers, active_fix_p
     """Decide what to do with each open story PR.
 
     Action vocabulary:
+    - resume_failed_session: WIP draft PR pushed by entrypoint.sh after a
+              session truncation (token reauth, token limit). Dispatch
+              fix-pr to resume the work; the resumed agent marks the PR
+              ready on success. Takes top priority — these PRs should not
+              be reviewed, rebased, or enqueued in their current state.
     - rebase: PR's branch needs `rebase-pr.sh` to clear conflicts or stale base
               before any other action makes sense. Always takes precedence
               when mergeStateStatus is DIRTY (conflicts) or BEHIND (base advanced).
@@ -541,6 +546,20 @@ def compute_review_recommendations(pr_summaries, queued_pr_numbers, active_fix_p
                 "story": pr["story_number"],
                 "action": "skip",
                 "reason": "fix-agent in flight (cfg-agent-pr-fix-<PR> running) — wait for it to exit before rebase or re-dispatch",
+            })
+            continue
+
+        # PRIORITY 0.5: WIP draft PR from a truncated agent session.
+        # The acceptance reviewer would falsely recommend enqueue (because
+        # CI is green on the partial work); the merge queue would refuse.
+        # Dispatch fix-pr to resume the work — the resumed agent marks the
+        # PR ready on success and the next cycle picks it up normally.
+        if pr.get("wip_session_failed"):
+            recs.append({
+                "pr": pr["pr"],
+                "story": pr["story_number"],
+                "action": "resume_failed_session",
+                "reason": "WIP draft PR from session truncation (token reauth/limit) — run `./.claude/scripts/po-act.sh dispatch-fix <PR>` to resume; the fix-pr agent will mark the PR ready when it finishes",
             })
             continue
 
@@ -828,13 +847,25 @@ def main():
             "acceptance review" in (c.get("body") or "").lower()
             for c in comments
         )
+        body = pr.get("body") or ""
+        title = pr.get("title", "")
+        is_draft = bool(pr.get("isDraft"))
+        # Detect WIP draft PRs created by .devcontainer/entrypoint.sh on agent
+        # session failure (token reauth, token-limit truncation, etc.). The
+        # entrypoint pushes draft PRs with the literal markers below.
+        wip_session_failed = is_draft and (
+            body.startswith("Agent session failed with exit code")
+            or title.startswith("WIP:") and title.endswith("(agent failed)")
+        )
         pr_summaries.append({
             "pr": pr["number"],
-            "title": pr.get("title", ""),
+            "title": title,
             "head_ref": head,
             "story_number": story_number,
             "comment_count": len(comments),
             "has_acceptance_review_comment": has_review_comment,
+            "is_draft": is_draft,
+            "wip_session_failed": wip_session_failed,
             "merge_state_status": pr.get("mergeStateStatus"),
             "mergeable": pr.get("mergeable"),
             "auto_merge_enabled": pr.get("autoMergeRequest") is not None,

--- a/.devcontainer/entrypoint.sh
+++ b/.devcontainer/entrypoint.sh
@@ -597,6 +597,17 @@ fi
 
 if [ "$EXIT_CODE" -eq 0 ]; then
     echo "Agent completed successfully. PR: ${PR_URL}"
+
+    # If we just finished a fix-pr resume of a session-truncated draft, mark
+    # the PR ready for review so the cron's acceptance-reviewer picks it up
+    # next cycle. Idempotent: gh pr ready on an already-ready PR is a no-op.
+    if [[ "$MODE" == "fix-pr" ]] && [[ -n "$PR_URL" ]]; then
+        is_draft=$(gh pr view "$PR_URL" --json isDraft -q '.isDraft' 2>/dev/null || echo "false")
+        if [[ "$is_draft" == "true" ]]; then
+            echo "Resumed PR was a draft; marking ready"
+            gh pr ready "$PR_URL" 2>/dev/null || true
+        fi
+    fi
 else
     echo "Agent failed with exit code ${EXIT_CODE}"
 

--- a/.devcontainer/entrypoint.sh
+++ b/.devcontainer/entrypoint.sh
@@ -600,11 +600,22 @@ if [ "$EXIT_CODE" -eq 0 ]; then
 
     # If we just finished a fix-pr resume of a session-truncated draft, mark
     # the PR ready for review so the cron's acceptance-reviewer picks it up
-    # next cycle. Idempotent: gh pr ready on an already-ready PR is a no-op.
+    # next cycle. Also rewrite the leftover "WIP: <branch> (agent failed)"
+    # title — otherwise it lands on develop verbatim as the squash-merge
+    # commit subject. Both calls are idempotent.
     if [[ "$MODE" == "fix-pr" ]] && [[ -n "$PR_URL" ]]; then
         is_draft=$(gh pr view "$PR_URL" --json isDraft -q '.isDraft' 2>/dev/null || echo "false")
         if [[ "$is_draft" == "true" ]]; then
-            echo "Resumed PR was a draft; marking ready"
+            echo "Resumed PR was a draft; marking ready and cleaning title"
+            # Derive a clean title from the linked story issue when possible.
+            new_title=""
+            if [[ "$CURRENT_BRANCH" =~ feature/story-([0-9]+) ]]; then
+                story_num="${BASH_REMATCH[1]}"
+                new_title=$(gh issue view "$story_num" --json title -q '.title' 2>/dev/null || echo "")
+            fi
+            if [[ -n "$new_title" ]]; then
+                gh pr edit "$PR_URL" --title "$new_title" 2>/dev/null || true
+            fi
             gh pr ready "$PR_URL" 2>/dev/null || true
         fi
     fi


### PR DESCRIPTION
## Summary

Closes a real-world gap in the cron pipeline: when a dev agent's Claude session is truncated (token reauth, token-limit hit), `.devcontainer/entrypoint.sh` pushes a draft PR with body `Agent session failed with exit code N`. Before this PR, the cron would:

1. Route the draft PR to the acceptance reviewer
2. Reviewer would see green CI on the partial work and recommend `enqueue_merge`
3. Merge queue would refuse the draft
4. PO would escalate to `pipeline:blocked` — wrongly treating a partial-work signal as a fundamental failure

After this PR the cron auto-detects these and dispatches `fix-pr` to resume the work; the resumed agent marks the PR ready for review when it finishes, and the next cycle routes it through normal review.

PR #1066 (story #1047) was the live case that surfaced this — it's already been resumed manually as the validation case.

## Changes
- `.claude/scripts/po-cycle-preflight.py` — detect WIP draft PRs by entrypoint markers; emit new `resume_failed_session` action at top priority
- `.claude/agents/acceptance-reviewer.md` — short-circuit on `isDraft=true`, post clear comment, clear `pipeline:reviewing`
- `.claude/agents/po.md` — add pre-step in §4.1 Step 5 to dispatch fix-pr for `resume_failed_session` PRs
- `.devcontainer/entrypoint.sh` — when fix-pr mode exits 0 and the PR is still a draft, `gh pr ready` it

Resuming a session-truncated PR counts as finishing the story (fresh agent, fresh internal 3-iteration budget), not fixing — no cron-level retry counter touched.

## Test plan
- [x] `make test` (46/46 passed locally; pre-push hook re-ran)
- [x] Manually ran preflight against current state — PR #1066 correctly routed to `resume_failed_session`
- [ ] CI required checks: unit-tests, integration-tests, Build Gate, security-deployment-gate