### PR TITLE
deps: bump trufflehog v3.94.2 → v3.95.2

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -58,7 +58,7 @@ RUN GOPATH=$(go env GOPATH) \
     && chmod +x "$GOPATH/bin/nancy"
 
 # truffleHog (optional, best-effort secret scanning — pinned version, not @main)
-RUN curl -sSfL https://raw.githubusercontent.com/trufflesecurity/trufflehog/v3.94.2/scripts/install.sh | sh -s -- -b /usr/local/bin v3.94.2 || true
+RUN curl -sSfL https://raw.githubusercontent.com/trufflesecurity/trufflehog/v3.95.2/scripts/install.sh | sh -s -- -b /usr/local/bin v3.95.2 || true
 
 # Claude Code
 RUN npm install -g @anthropic-ai/claude-code

--- a/.github/workflows/dependency-pin-check.yml
+++ b/.github/workflows/dependency-pin-check.yml
@@ -57,7 +57,7 @@ jobs:
         check_version "staticcheck" "dominikh/go-tools"                       "2026.1"
         check_version "gitleaks"    "zricethezav/gitleaks"                    "v8.30.1"
         check_version "nancy"       "sonatype-nexus-community/nancy"          "v1.2.0"
-        check_version "trufflehog"  "trufflesecurity/trufflehog"              "v3.94.2"
+        check_version "trufflehog"  "trufflesecurity/trufflehog"              "v3.95.2"
         check_version "trivy"       "aquasecurity/trivy"                      "v0.69.3"
         check_version "go-licenses" "google/go-licenses"                      "v2.0.1"
         check_version "golangci-lint" "golangci/golangci-lint"                "v2.11.4"


### PR DESCRIPTION
## Summary

Bumps the pinned trufflehog version from `v3.94.2` to `v3.95.2`. v3.95.2 is a stability-fix release that reverts a parser-panic regression introduced in v3.95.0 (INS-397 on non-numeric patch versions). 12 days of upstream soak time, no community concerns reported, no breaking changes.

Tracking issue: #820 (auto-generated outdated-pin report).

## Changes
- `.devcontainer/Dockerfile` line 61: install URL and install.sh argument both updated to v3.95.2
- `.github/workflows/dependency-pin-check.yml` line 60: expected version updated to v3.95.2

## Out of scope
- Trivy bump (separate PR — needs hardening ACs from adversarial review)
- All other tool pins
- cfg-agent base image rebuild — needs to happen out-of-band post-merge so autonomous agents pick up the new binary

## Test plan
- [x] `make test` (46/46 passed locally; pre-push hook re-ran)
- [x] grep verified: only v3.95.2 remains in `.devcontainer/`, `.github/workflows/`, and `Makefile`
- [ ] CI required checks: unit-tests, integration-tests, Build Gate, security-deployment-gate