### PR TITLE
deps: bump trivy v0.69.3 → v0.70.0 with checksum + denylist guards

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -45,11 +45,22 @@ RUN go install github.com/securego/gosec/v2/cmd/gosec@v2.25.0 \
     && curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh \
        | sh -s -- -b "$(go env GOPATH)/bin" v2.11.4
 
-# Trivy — pinned to v0.69.3 via install.sh because v0.69.4+ are compromised
-# (CVE-2026-33634). The apt repo no longer ships v0.69.3, so we use the
-# official install script against the still-available GitHub release.
-RUN curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh \
-    | sh -s -- -b /usr/local/bin v0.69.3
+# Trivy — v0.69.4-v0.69.6 are compromised (CVE-2026-33634); v0.70.0 is the
+# post-incident clean release. We download the project's release archive and
+# verify its SHA-256 against a pinned value before extraction, rather than
+# piping the trivy main branch's install.sh through `sh` (whose contents are
+# fetched at install time and can be tampered with). See
+# docs/runbooks/trivy-rollback.md for rollback procedure.
+RUN set -eu; \
+    TRIVY_VERSION='v0.70.0'; \
+    TRIVY_SHA256='8b4376d5d6befe5c24d503f10ff136d9e0c49f9127a4279fd110b727929a5aa9'; \
+    ARCHIVE="trivy_${TRIVY_VERSION#v}_Linux-64bit.tar.gz"; \
+    curl -sSfL -o "/tmp/${ARCHIVE}" \
+      "https://github.com/aquasecurity/trivy/releases/download/${TRIVY_VERSION}/${ARCHIVE}"; \
+    printf '%s  /tmp/%s\n' "${TRIVY_SHA256}" "${ARCHIVE}" | sha256sum -c -; \
+    tar -xzf "/tmp/${ARCHIVE}" -C /tmp trivy; \
+    install -m 0755 /tmp/trivy /usr/local/bin/trivy; \
+    rm -f "/tmp/${ARCHIVE}" /tmp/trivy
 
 # Nancy (Go dependency scanner)
 RUN GOPATH=$(go env GOPATH) \

--- a/.github/scripts/install-trivy.sh
+++ b/.github/scripts/install-trivy.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# Verified Trivy install: downloads the project's release archive, verifies the
+# SHA-256 against a caller-pinned value, and refuses known-compromised
+# versions per the GHSA-69fq-xp46-6x23 advisory (CVE-2026-33634).
+#
+# Usage: install-trivy.sh <version> <sha256> [dest_dir]
+#   version    Trivy version tag (e.g. "v0.70.0")
+#   sha256     Expected SHA-256 of trivy_<v>_Linux-64bit.tar.gz from the
+#              upstream release's checksums.txt — pinned in caller's env.
+#   dest_dir   Install directory (default: /usr/local/bin)
+#
+# Why this exists rather than `curl install.sh | sh`:
+#   The trivy main branch's contrib/install.sh has been tampered with during
+#   the supply-chain compromise window. This script verifies the release
+#   artifact's SHA-256 against a value pinned in our own repo before extraction.
+#
+# Defense in depth:
+#   1. Compromised-version denylist (refuses v0.69.4 / v0.69.5 / v0.69.6).
+#   2. SHA-256 verification against a value pinned by the caller (not fetched
+#      at runtime — runtime fetch defeats the purpose if the supply chain is
+#      mid-compromise).
+#   3. Re-runnable: if any of the above fails, no binary is installed and the
+#      script exits non-zero.
+#
+# Sigstore-bundle (cosign) verification of the .sigstore.json artifact is a
+# planned follow-up — requires installing cosign on the runner first. Until
+# then, SHA-256 + denylist is the bound.
+
+set -euo pipefail
+
+VERSION="${1:?usage: install-trivy.sh <version> <sha256> [dest_dir]}"
+SHA256="${2:?usage: install-trivy.sh <version> <sha256> [dest_dir]}"
+DEST_DIR="${3:-/usr/local/bin}"
+
+# Compromised-version denylist (CVE-2026-33634).
+case "$VERSION" in
+  v0.69.4|v0.69.4-*|v0.69.5|v0.69.5-*|v0.69.6|v0.69.6-*)
+    echo "ERROR: $VERSION is a known-compromised release (CVE-2026-33634)." >&2
+    echo "Refusing to install. See docs/runbooks/trivy-rollback.md." >&2
+    exit 2
+    ;;
+esac
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+ARCHIVE="trivy_${VERSION#v}_Linux-64bit.tar.gz"
+URL="https://github.com/aquasecurity/trivy/releases/download/${VERSION}/${ARCHIVE}"
+
+echo "Downloading $URL"
+curl -sSfL -o "$WORK/$ARCHIVE" "$URL"
+
+echo "Verifying SHA-256 against pinned value"
+printf '%s  %s\n' "$SHA256" "$WORK/$ARCHIVE" | sha256sum -c -
+
+echo "Extracting trivy binary"
+tar -xzf "$WORK/$ARCHIVE" -C "$WORK" trivy
+install -m 0755 "$WORK/trivy" "$DEST_DIR/trivy"
+
+echo "Installed: $("$DEST_DIR/trivy" --version | head -1)"

--- a/.github/workflows/dependency-pin-check.yml
+++ b/.github/workflows/dependency-pin-check.yml
@@ -14,11 +14,52 @@ on:
   schedule:
     - cron: '0 9 * * 3'  # Wednesday 09:00 UTC
   workflow_dispatch:
+  pull_request:
+    paths:
+      - '.devcontainer/Dockerfile'
+      - '.github/workflows/**'
+      - '.github/scripts/install-trivy.sh'
+      - 'Makefile'
 
 jobs:
+  # Hard-fail any PR (or schedule run) that reintroduces a compromised Trivy
+  # version (v0.69.4 / v0.69.5 / v0.69.6) into the build. CVE-2026-33634.
+  # Runs first so a bad pin can't sneak in even if a newer freshness check
+  # later relabels something.
+  denylist-check:
+    name: Compromised Version Denylist
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    permissions:
+      contents: read
+    steps:
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+    - name: Scan for known-compromised trivy versions
+      run: |
+        # Match v0.69.4 / v0.69.5 / v0.69.6 (plus pre-release suffixes like
+        # -rc1) ONLY when they appear in a pin-usage context: quoted string
+        # value, env-var assignment (`=`), or Go module ref (`@`). This
+        # avoids false positives on documentation prose that mentions the
+        # compromised versions to warn against them.
+        if grep -rEn $'(\'|"|=|@)v0\\.69\\.[456]([.-][[:alnum:]_.-]*)?' \
+              --include='Dockerfile' --include='*.yml' --include='*.yaml' \
+              --include='Makefile' --include='*.sh' \
+              .devcontainer/ .github/ Makefile 2>/dev/null; then
+          echo "" >&2
+          echo "ERROR: a known-compromised Trivy version (v0.69.4 - v0.69.6) was found in a pin-usage context." >&2
+          echo "These releases are part of the CVE-2026-33634 supply-chain compromise." >&2
+          echo "Use v0.70.0 (post-incident clean release) or v0.69.3 (pre-incident)." >&2
+          echo "See docs/runbooks/trivy-rollback.md for context." >&2
+          exit 1
+        fi
+        echo "No compromised trivy versions detected in any pin-usage context."
+
   check-tool-versions:
     name: Check Pinned Tool Versions
     runs-on: ubuntu-latest
+    # Only run the freshness check on schedule/manual triggers — on PR we don't
+    # want to open new GitHub issues; the denylist-check above is the gate.
+    if: github.event_name != 'pull_request'
     timeout-minutes: 5
     permissions:
       contents: read
@@ -58,7 +99,7 @@ jobs:
         check_version "gitleaks"    "zricethezav/gitleaks"                    "v8.30.1"
         check_version "nancy"       "sonatype-nexus-community/nancy"          "v1.2.0"
         check_version "trufflehog"  "trufflesecurity/trufflehog"              "v3.95.2"
-        check_version "trivy"       "aquasecurity/trivy"                      "v0.69.3"
+        check_version "trivy"       "aquasecurity/trivy"                      "v0.70.0"
         check_version "go-licenses" "google/go-licenses"                      "v2.0.1"
         check_version "golangci-lint" "golangci/golangci-lint"                "v2.11.4"
 

--- a/.github/workflows/docker-security.yml
+++ b/.github/workflows/docker-security.yml
@@ -32,7 +32,7 @@ env:
   GO_VERSION: '1.25.9'
   REGISTRY: ghcr.io
   IMAGE_PREFIX: cfg-is/cfgms
-  TRIVY_VERSION: 'v0.69.3'
+  TRIVY_VERSION: 'v0.70.0'
 
 jobs:
   # Scan Controller Docker Image

--- a/.github/workflows/production-gates.yml
+++ b/.github/workflows/production-gates.yml
@@ -53,10 +53,11 @@ jobs:
         echo "🔧 Installing Security Tools for Production Gate"
         echo "=============================================="
         
-        # Install Trivy — v0.69.4+ are compromised (CVE-2026-33634); apt repo
-        # no longer ships v0.69.3. Install from the official install.sh against
-        # the still-available GitHub release.
-        curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sudo sh -s -- -b /usr/local/bin v0.69.3
+        # Install Trivy — v0.69.4-v0.69.6 are compromised (CVE-2026-33634);
+        # v0.70.0 is the post-incident clean release. The install helper
+        # verifies the archive SHA-256 against the pinned value before
+        # extraction. See docs/runbooks/trivy-rollback.md for rollback.
+        sudo .github/scripts/install-trivy.sh 'v0.70.0' '8b4376d5d6befe5c24d503f10ff136d9e0c49f9127a4279fd110b727929a5aa9'
 
         # Install other security tools
         make install-nancy

--- a/.github/workflows/release-automation.yml
+++ b/.github/workflows/release-automation.yml
@@ -203,10 +203,11 @@ jobs:
           echo "🔧 Installing development and security tools..."
           echo "=============================================="
 
-          # Install Trivy — v0.69.4+ are compromised (CVE-2026-33634); apt
-          # repo no longer ships v0.69.3. Install from the official install.sh
-          # against the still-available GitHub release.
-          curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sudo sh -s -- -b /usr/local/bin v0.69.3
+          # Install Trivy — v0.69.4-v0.69.6 are compromised (CVE-2026-33634);
+          # v0.70.0 is the post-incident clean release. The install helper
+          # verifies the archive SHA-256 against the pinned value before
+          # extraction. See docs/runbooks/trivy-rollback.md for rollback.
+          sudo .github/scripts/install-trivy.sh 'v0.70.0' '8b4376d5d6befe5c24d503f10ff136d9e0c49f9127a4279fd110b727929a5aa9'
 
           # Install security scanning tools
           make install-nancy

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -45,11 +45,14 @@ jobs:
       uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
     
     - name: Install Trivy
-      run: |
-        # Trivy v0.69.4+ are compromised (CVE-2026-33634); apt repo no longer
-        # ships v0.69.3. Install from the official install.sh against the
-        # still-available GitHub release.
-        curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sudo sh -s -- -b /usr/local/bin v0.69.3
+      env:
+        # Trivy v0.69.4-v0.69.6 are compromised (CVE-2026-33634); v0.70.0 is
+        # the post-incident clean release. The install helper verifies the
+        # archive SHA-256 against this pinned value before extraction. See
+        # docs/runbooks/trivy-rollback.md for rollback procedure.
+        TRIVY_VERSION: 'v0.70.0'
+        TRIVY_SHA256: '8b4376d5d6befe5c24d503f10ff136d9e0c49f9127a4279fd110b727929a5aa9'
+      run: sudo .github/scripts/install-trivy.sh "$TRIVY_VERSION" "$TRIVY_SHA256"
 
     - name: Run Trivy Scan
       id: scan
@@ -297,10 +300,11 @@ jobs:
         # Only install tools if we need to generate remediation report
         make install-nancy
         
-        # Install Trivy — v0.69.4+ are compromised (CVE-2026-33634); apt repo
-        # no longer ships v0.69.3. Install from the official install.sh against
-        # the still-available GitHub release.
-        curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sudo sh -s -- -b /usr/local/bin v0.69.3
+        # Install Trivy — v0.69.4-v0.69.6 are compromised (CVE-2026-33634);
+        # v0.70.0 is the post-incident clean release. The install helper
+        # verifies the archive SHA-256 against the pinned value before
+        # extraction. See docs/runbooks/trivy-rollback.md for rollback.
+        sudo .github/scripts/install-trivy.sh 'v0.70.0' '8b4376d5d6befe5c24d503f10ff136d9e0c49f9127a4279fd110b727929a5aa9'
 
         # Install gosec and staticcheck
         go install github.com/securego/gosec/v2/cmd/gosec@v2.25.0

--- a/Makefile
+++ b/Makefile
@@ -801,13 +801,13 @@ security-trivy:
 	@if ! command -v trivy >/dev/null 2>&1; then \
 		echo "❌ Error: trivy is not installed"; \
 		echo ""; \
-		echo "Install trivy v0.69.3 (NEVER use @latest — CVE-2026-33634):"; \
-		echo "  go install github.com/aquasecurity/trivy/cmd/trivy@v0.69.3"; \
+		echo "Install trivy v0.70.0 — NEVER use v0.69.4-v0.69.6 (CVE-2026-33634)"; \
+		echo "and NEVER use @latest:"; \
+		echo "  ./.github/scripts/install-trivy.sh v0.70.0 \\"; \
+		echo "    8b4376d5d6befe5c24d503f10ff136d9e0c49f9127a4279fd110b727929a5aa9"; \
 		echo ""; \
-		echo "Alternative installation methods:"; \
-		echo "  # Binary download:"; \
-		echo "  curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin v0.69.3"; \
-		echo "  # Official documentation: https://aquasecurity.github.io/trivy/latest/getting-started/installation/"; \
+		echo "Official documentation: https://aquasecurity.github.io/trivy/latest/getting-started/installation/"; \
+		echo "Rollback procedure: docs/runbooks/trivy-rollback.md"; \
 		exit 1; \
 	fi
 	@echo "Running trivy filesystem scan..."

--- a/docs/runbooks/trivy-rollback.md
+++ b/docs/runbooks/trivy-rollback.md
@@ -1,0 +1,63 @@
+# Trivy Rollback Runbook
+
+This runbook covers what to do if the currently-pinned Trivy release (`v0.70.0`) is later flagged as compromised, OR if Trivy itself starts producing untrusted results.
+
+## Context
+
+Trivy was the target of a supply-chain compromise in March 2026 (advisory [GHSA-69fq-xp46-6x23](https://github.com/aquasecurity/trivy/security/advisories/GHSA-69fq-xp46-6x23), CVE-2026-33634). The threat actor "TeamPCP" published malicious releases as `v0.69.4`, `v0.69.5`, and `v0.69.6` and force-pushed compromised tags on `aquasecurity/trivy-action` and `aquasecurity/setup-trivy`. The advisory's safe versions were `v0.69.2` and `v0.69.3` (binary), `v0.35.0` (trivy-action SHA `57a97c7e7821a5776cebc9bb87c984fa69cba8f1`), and `v0.2.6` (setup-trivy SHA `3fb12ec12f41e471780db15c232d5dd185dcb514`).
+
+`v0.70.0` is the project's first post-incident release, published 2026-04-17 with a new GPG key (`B5690EEEBB952194`) for deb/rpm repositories. CFGMS adopts `v0.70.0` based on the project's release announcement and the SHA-256 verification baked into our install path.
+
+## Detection — when to roll back
+
+Roll back if any of these conditions hold:
+
+1. The advisory page is updated to mark `v0.70.0` as compromised or revoked.
+2. A subsequent release publishes its own advisory referencing `v0.70.0` as malicious.
+3. Trivy in CI starts producing anomalous output: unexpected network calls, unusually large binary size, scan results that don't match other scanners, mass-false-positive or mass-false-negative vulnerability data.
+4. The project rotates GPG / sigstore signing keys again without a clear announcement.
+
+Do NOT roll forward to `v0.69.4`, `v0.69.5`, or `v0.69.6` under any circumstances — those releases are confirmed-malicious. Roll BACK to `v0.69.3`.
+
+## Rollback — pin to v0.69.3
+
+`v0.69.3` is the last pre-incident clean release. The APT repository no longer ships it, so installation must use the GitHub release archive directly with checksum verification.
+
+### Verified-install one-liner (use this — never `curl install.sh | sh`)
+
+```bash
+./.github/scripts/install-trivy.sh v0.69.3 \
+  1816b632dfe529869c740c0913e36bd1629cb7688bd5634f4a858c1d57c88b75
+```
+
+This is the same install helper used by `v0.70.0`. It verifies the archive SHA-256 before extraction. The hash above is the upstream-published SHA-256 of `trivy_0.69.3_Linux-64bit.tar.gz` and is hardcoded here so that a runtime fetch of `checksums.txt` (which would defeat the purpose if the supply chain is mid-compromise) is not required.
+
+### Manual procedure (if the install helper itself is suspect)
+
+```bash
+ARCHIVE="trivy_0.69.3_Linux-64bit.tar.gz"
+EXPECTED="1816b632dfe529869c740c0913e36bd1629cb7688bd5634f4a858c1d57c88b75"
+
+curl -sSfL -o "/tmp/${ARCHIVE}" \
+  "https://github.com/aquasecurity/trivy/releases/download/v0.69.3/${ARCHIVE}"
+printf '%s  /tmp/%s\n' "${EXPECTED}" "${ARCHIVE}" | sha256sum -c -
+tar -xzf "/tmp/${ARCHIVE}" -C /tmp trivy
+sudo install -m 0755 /tmp/trivy /usr/local/bin/trivy
+rm "/tmp/${ARCHIVE}" /tmp/trivy
+```
+
+### What to update when rolling back
+
+1. `.devcontainer/Dockerfile` — `TRIVY_VERSION` and `TRIVY_SHA256` in the Trivy install RUN block.
+2. `.github/workflows/security-scan.yml` — both invocations of `install-trivy.sh`.
+3. `.github/workflows/production-gates.yml` — the install invocation.
+4. `.github/workflows/release-automation.yml` — the install invocation.
+5. `.github/workflows/docker-security.yml` — `TRIVY_VERSION` env var (line 35). The SHA-pinned `aquasecurity/trivy-action` and `aquasecurity/setup-trivy` references at lines 53/81/104/140/168/191 must NOT change — those SHAs are the advisory-confirmed safe versions.
+6. `.github/workflows/dependency-pin-check.yml` — `check_version "trivy"` argument and the denylist regex (the v0.69.4–v0.69.6 entries stay; do NOT add v0.70.0 to the denylist on rollback unless the advisory confirms compromise).
+7. `Makefile` — error-handler echo strings in the `security-trivy` target.
+8. This runbook — update the rollback SHA if you're rolling back to a different version.
+
+## Out of scope
+
+- Rolling back the `aquasecurity/trivy-action` or `aquasecurity/setup-trivy` SHA pins. Those are advisory-blessed and should remain pinned at `57a97c7e...` and `3fb12ec1...` respectively until the advisory recommends new SHAs.
+- Replacing Trivy with another scanner. If `v0.69.3` and `v0.70.0` are both compromised, that is a project-wide incident requiring a different decision (Grype, Snyk OSS, etc.) — not a one-line pin change.


### PR DESCRIPTION
## Summary

Bumps Trivy to **v0.70.0** — the project's first post-supply-chain-incident clean release — and replaces the previous `curl install.sh | sh` pattern with a verified-install helper that SHA-256-checks the release archive before extraction.

Tracking issue: #820. Closes draft story #1075 (story body kept the spec; this PR ships it manually with all the security review's hardening ACs incorporated).

## Why now (and the residual risk)

The current pin `v0.69.3` is the advisory's last-known-clean version. v0.69.4 / v0.69.5 / v0.69.6 are confirmed-malicious (CVE-2026-33634). The project published v0.70.0 on 2026-04-17 as a clean rebuild with a new GPG key (`B5690EEEBB952194`) and sigstore-bundle attestations on every release artifact.

The official advisory [GHSA-69fq-xp46-6x23](https://github.com/aquasecurity/trivy/security/advisories/GHSA-69fq-xp46-6x23) has NOT yet been updated to bless v0.70.0 — moving forward is a PO judgment call. We offset that residual risk by adding active defenses below; the bump is safe even if the advisory is never updated.

## Hardening introduced

- **`.github/scripts/install-trivy.sh` (new)** — verified install: downloads the project's release archive, refuses known-compromised versions (v0.69.4–v0.69.6 plus pre-release suffixes), and SHA-256-verifies against a caller-pinned hash before extracting. Replaces the prior `curl … install.sh | sh` pattern at all 5 install sites.
- **`.github/workflows/dependency-pin-check.yml` denylist job (new)** — runs on every `pull_request`, hard-fails if any pin-usage context (`'v0.69.4'`, `=v0.69.4`, `@v0.69.4`, etc.) matches the compromised range. Documentation prose mentioning the versions for warning purposes is not flagged. Freshness check stays on schedule/workflow_dispatch only.
- **`docs/runbooks/trivy-rollback.md` (new)** — detection signals + rollback to v0.69.3 with the v0.69.3 SHA-256 hardcoded so rollback doesn't fetch `checksums.txt` at runtime.
- **Hardcoded SHAs** — v0.70.0 archive (`8b4376d5d6befe5c24d503f10ff136d9e0c49f9127a4279fd110b727929a5aa9`) and v0.69.3 archive (`1816b632dfe529869c740c0913e36bd1629cb7688bd5634f4a858c1d57c88b75`) are pinned in source so a runtime fetch of upstream checksums isn't needed.
- **Makefile error message** rewritten to point at the install helper and the runbook; dropped the deprecated `go install trivy/cmd/trivy@vX.Y.Z` suggestion (unsupported since v0.29.0).

## Files
- `.devcontainer/Dockerfile` — inline verified-install pattern (the helper script isn't COPY'd into image)
- `.github/scripts/install-trivy.sh` — new helper
- `.github/workflows/security-scan.yml` (×2 sites) / `production-gates.yml` / `release-automation.yml` — switched to helper
- `.github/workflows/docker-security.yml` — `TRIVY_VERSION: 'v0.70.0'`. SHA pins on lines 53/81/104/140/168/191 unchanged per advisory.
- `.github/workflows/dependency-pin-check.yml` — denylist job + `pull_request` trigger + bumped freshness pin
- `Makefile` — error-handler messages updated
- `docs/runbooks/trivy-rollback.md` — new runbook

## Out of scope (intentionally)
- Cosign / sigstore-bundle verification of `.sigstore.json` artifacts. Trivy v0.70.0 does ship these; verifying them requires installing `cosign` on the runner first. Planned as a follow-up.
- SHA pins for `aquasecurity/trivy-action` (`57a97c7e…`) and `aquasecurity/setup-trivy` (`3fb12ec1…`) — those are advisory-blessed and stay untouched.
- Trufflehog bump — separate PR (#1077).

## Post-merge action required
The cfg-agent base image must be rebuilt out-of-band so autonomous agents pick up the new trivy binary. CI workflows fetch fresh per run, so they're unaffected.

## Test plan
- [x] `make test` (46/46 passed locally; pre-push hook re-ran)
- [x] `bash -n .github/scripts/install-trivy.sh` (syntax)
- [x] `install-trivy.sh v0.69.4 dummy` exits 2 with denylist error
- [x] `install-trivy.sh v0.69.5-rc1 dummy` exits 2 with denylist error
- [x] denylist regex against current files: zero matches (no pin-usage contexts of compromised versions)
- [ ] CI required checks: unit-tests, integration-tests, Build Gate, security-deployment-gate
- [ ] CI new check: dependency-pin-check / Compromised Version Denylist