### PR TITLE
steward: remove InstallPath() interface method and clean up cmd/steward residuals (Issue #1079)

### DIFF
--- a/cmd/steward/main.go
+++ b/cmd/steward/main.go
@@ -152,13 +152,9 @@ func runSteward(ctx context.Context, regToken, configPath string) error {
 
 	// gRPC transport registration flow.
 	if regToken != "" {
-		tokenPrefix := regToken
-		if len(regToken) > 15 {
-			tokenPrefix = regToken[:15] + "..."
-		}
 		logger.Info("Using registration token for auto-registration (gRPC transport mode)",
 			"operation", "registration_init",
-			"token_prefix", tokenPrefix)
+			"token_prefix", logging.RedactedID(regToken))
 
 		transportCl, err := registerAndConnect(ctx, regToken, logger)
 		if err != nil {
@@ -300,10 +296,6 @@ func buildStatusCommand() *cobra.Command {
 
 // runInstall performs the install operation for the current platform.
 func runInstall(regToken string) error {
-	if regToken == "" {
-		return fmt.Errorf("--regtoken is required for install")
-	}
-
 	exe, err := os.Executable()
 	if err != nil {
 		return fmt.Errorf("failed to determine executable path: %w", err)

--- a/cmd/steward/main_test.go
+++ b/cmd/steward/main_test.go
@@ -53,12 +53,6 @@ func TestBuildRootCommandNoModeFlag(t *testing.T) {
 	assert.Nil(t, cmd.Flags().Lookup("mode"), "mode flag must not be registered")
 }
 
-func TestRunInstallRequiresToken(t *testing.T) {
-	err := runInstall("")
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "--regtoken is required")
-}
-
 func TestRunInstallRequiresElevation(t *testing.T) {
 	if isElevated() {
 		t.Skip("test requires non-elevated process — running as root")

--- a/cmd/steward/service/manager.go
+++ b/cmd/steward/service/manager.go
@@ -45,10 +45,6 @@ type Manager interface {
 	// IsElevated returns true if the current process has the privileges
 	// required to install or uninstall the service.
 	IsElevated() bool
-
-	// InstallPath returns the platform-standard path the binary will be
-	// copied to during Install.
-	InstallPath() string
 }
 
 // New returns the platform-specific Manager for the current OS.

--- a/cmd/steward/service/manager_darwin.go
+++ b/cmd/steward/service/manager_darwin.go
@@ -26,8 +26,6 @@ type darwinManager struct {
 	binaryPath string
 }
 
-func (m *darwinManager) InstallPath() string { return darwinInstallPath }
-
 func (m *darwinManager) IsElevated() bool {
 	return os.Getuid() == 0
 }

--- a/cmd/steward/service/manager_darwin_test.go
+++ b/cmd/steward/service/manager_darwin_test.go
@@ -16,7 +16,9 @@ import (
 
 func TestDarwinManagerInstallPath(t *testing.T) {
 	m := New("/usr/local/bin/cfgms-steward")
-	assert.Equal(t, darwinInstallPath, m.InstallPath())
+	status, err := m.Status()
+	require.NoError(t, err)
+	assert.Equal(t, darwinInstallPath, status.InstallPath)
 }
 
 func TestDarwinManagerIsElevated(t *testing.T) {

--- a/cmd/steward/service/manager_linux.go
+++ b/cmd/steward/service/manager_linux.go
@@ -26,8 +26,6 @@ type linuxManager struct {
 	binaryPath string
 }
 
-func (m *linuxManager) InstallPath() string { return linuxInstallPath }
-
 func (m *linuxManager) IsElevated() bool {
 	return os.Getuid() == 0
 }

--- a/cmd/steward/service/manager_linux_test.go
+++ b/cmd/steward/service/manager_linux_test.go
@@ -17,7 +17,9 @@ import (
 
 func TestLinuxManagerInstallPath(t *testing.T) {
 	m := New("/usr/bin/cfgms-steward")
-	assert.Equal(t, linuxInstallPath, m.InstallPath())
+	status, err := m.Status()
+	require.NoError(t, err)
+	assert.Equal(t, linuxInstallPath, status.InstallPath)
 }
 
 func TestLinuxManagerIsElevated(t *testing.T) {

--- a/cmd/steward/service/manager_stub.go
+++ b/cmd/steward/service/manager_stub.go
@@ -16,8 +16,6 @@ func newManager(binaryPath string) Manager {
 
 type stubManager struct{}
 
-func (m *stubManager) InstallPath() string { return "" }
-
 func (m *stubManager) IsElevated() bool { return false }
 
 func (m *stubManager) Install(token string) error {

--- a/cmd/steward/service/manager_windows.go
+++ b/cmd/steward/service/manager_windows.go
@@ -30,8 +30,6 @@ type windowsManager struct {
 	binaryPath string
 }
 
-func (m *windowsManager) InstallPath() string { return windowsInstallPath }
-
 // IsElevated returns true if the current process has Administrator privileges.
 // It checks by attempting to open the service control manager, which requires
 // Administrator — the canonical check without additional packages.

--- a/cmd/steward/service/manager_windows_test.go
+++ b/cmd/steward/service/manager_windows_test.go
@@ -14,7 +14,9 @@ import (
 
 func TestWindowsManagerInstallPath(t *testing.T) {
 	m := New("cfgms-steward.exe")
-	assert.Equal(t, windowsInstallPath, m.InstallPath())
+	status, err := m.Status()
+	require.NoError(t, err)
+	assert.Equal(t, windowsInstallPath, status.InstallPath)
 }
 
 func TestWindowsManagerStatusNotInstalled(t *testing.T) {


### PR DESCRIPTION
## Summary

- Removes `Manager.InstallPath() string` from the `service.Manager` interface and all four platform implementations; rewrites three platform test functions to use `m.Status().InstallPath` (matching the production read pattern already used by `runStatus`).
- Replaces the 15-char manual token-prefix truncation block in `main.go` with `logging.RedactedID(regToken)` — reduces logged prefix to 8 chars, adds control-character sanitization, and uses the existing `pkg/logging` central provider correctly.
- Removes the unreachable `if regToken == ""` guard in `runInstall`; cobra's `MarkFlagRequired("regtoken")` already enforces non-empty on the install subcommand path. Deletes `TestRunInstallRequiresToken` which tested the now-removed dead-code check.

This closes out the three remaining low-severity findings from epic #757.

Fixes #1079

## Specialist Review Results

**QA Test Runner: PASS**
- All packages passing (100+ packages, 0 failures)
- Linting, license headers, secret scan, architecture compliance: all clean
- Cross-platform compilation: verified

**QA Code Reviewer: PASS**
- 0 blocking issues
- 1 warning: pre-existing coverage gap in `TestWindowsManagerStatusNotInstalled` (missing `Installed`/`Running` false-assertions) — not introduced by this story

**Security Engineer: PASS**
- 0 blocking issues
- `logging.RedactedID` replacement confirmed as net security improvement (shorter prefix, log-injection protection, dev opt-in for unredacted values)
- `security-precommit` (gitleaks + truffleHog): PASS
- `check-architecture`: PASS
- `gosec` / `staticcheck`: PASS
- Trivy: infra failure (no network access to mirror.gcr.io in sandbox) — will run in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)