### PR TITLE
workflow: fix template YAML serialization stubs (Issue #1083)

### DIFF
--- a/features/siem/stream_processor_test.go
+++ b/features/siem/stream_processor_test.go
@@ -163,11 +163,11 @@ func TestSanitizedFields(t *testing.T) {
 
 	fields := map[string]interface{}{
 		"newline_injection": "before\nINJECTED_LINE", // CWE-117 log forgery via newline
-		"ansi_escape":       "\x1b[31mRED\x1b[0m",   // ANSI color escape sequences
+		"ansi_escape":       "\x1b[31mRED\x1b[0m",    // ANSI color escape sequences
 		"cr_injection":      "before\roverwritten",   // CWE-117 via carriage return
-		"long_value":        string(longValue),        // must be truncated
+		"long_value":        string(longValue),       // must be truncated
 		"safe_value":        "10.0.0.1",              // safe passthrough
-		"numeric":           42,                       // numeric converted to string
+		"numeric":           42,                      // numeric converted to string
 	}
 
 	result := sanitizedFields(fields)

--- a/features/workflow/template.go
+++ b/features/workflow/template.go
@@ -8,6 +8,8 @@ import (
 	"regexp"
 	"strings"
 	"time"
+
+	"gopkg.in/yaml.v3"
 )
 
 // WorkflowTemplate represents a reusable workflow template
@@ -277,16 +279,16 @@ func (te *TemplateEngine) MergeWithDefaults(template *WorkflowTemplate, paramete
 
 // ProcessTemplateSubstitutions processes template variable substitutions
 func (te *TemplateEngine) ProcessTemplateSubstitutions(workflow Workflow, parameters map[string]interface{}) (Workflow, error) {
-	// Convert workflow to string for processing
-	workflowStr := te.workflowToString(workflow)
+	workflowStr, err := te.workflowToString(workflow)
+	if err != nil {
+		return workflow, fmt.Errorf("serializing workflow for template substitution: %w", err)
+	}
 
-	// Process substitutions
 	processedStr, err := te.processSubstitutions(workflowStr, parameters)
 	if err != nil {
 		return workflow, err
 	}
 
-	// Convert back to workflow
 	processedWorkflow, err := te.stringToWorkflow(processedStr)
 	if err != nil {
 		return workflow, err
@@ -437,17 +439,20 @@ func (te *TemplateEngine) processSubstitutions(content string, parameters map[st
 	return result, nil
 }
 
-// workflowToString and stringToWorkflow would need proper YAML marshaling/unmarshaling
-// This is a simplified implementation for demonstration
-func (te *TemplateEngine) workflowToString(workflow Workflow) string {
-	// In a real implementation, this would use yaml.Marshal
-	return fmt.Sprintf("workflow: %+v", workflow)
+func (te *TemplateEngine) workflowToString(workflow Workflow) (string, error) {
+	data, err := yaml.Marshal(workflow)
+	if err != nil {
+		return "", err
+	}
+	return string(data), nil
 }
 
 func (te *TemplateEngine) stringToWorkflow(content string) (Workflow, error) {
-	// In a real implementation, this would use yaml.Unmarshal
-	// For now, return the original workflow
-	return Workflow{}, nil
+	var w Workflow
+	if err := yaml.Unmarshal([]byte(content), &w); err != nil {
+		return Workflow{}, err
+	}
+	return w, nil
 }
 
 // Utility functions

--- a/features/workflow/template_test.go
+++ b/features/workflow/template_test.go
@@ -528,6 +528,98 @@ func TestTemplateEngine_ProcessSubstitutions(t *testing.T) {
 	}
 }
 
+func TestWorkflowToStringMarshalsValidYAML(t *testing.T) {
+	engine := NewTemplateEngine()
+
+	workflow := Workflow{
+		Name:        "test-workflow",
+		Description: "A test workflow",
+		Steps: []Step{
+			{
+				Name:   "step-one",
+				Type:   StepTypeTask,
+				Module: "test-module",
+				Config: map[string]interface{}{
+					"key": "value",
+				},
+			},
+		},
+	}
+
+	yamlStr, err := engine.workflowToString(workflow)
+	require.NoError(t, err)
+	assert.NotEmpty(t, yamlStr)
+	assert.Contains(t, yamlStr, "test-workflow")
+	assert.Contains(t, yamlStr, "A test workflow")
+	assert.Contains(t, yamlStr, "step-one")
+}
+
+func TestStringToWorkflowRoundTrip(t *testing.T) {
+	engine := NewTemplateEngine()
+
+	original := Workflow{
+		Name:        "round-trip-workflow",
+		Description: "Round-trip test",
+		Steps: []Step{
+			{
+				Name:   "first-step",
+				Type:   StepTypeTask,
+				Module: "test-module",
+				Config: map[string]interface{}{
+					"param": "value",
+				},
+			},
+		},
+		Variables: map[string]interface{}{
+			"env": "production",
+		},
+	}
+
+	yamlStr, err := engine.workflowToString(original)
+	require.NoError(t, err)
+
+	restored, err := engine.stringToWorkflow(yamlStr)
+	require.NoError(t, err)
+
+	assert.Equal(t, original.Name, restored.Name)
+	assert.Equal(t, original.Description, restored.Description)
+	require.Len(t, restored.Steps, 1)
+	assert.Equal(t, original.Steps[0].Name, restored.Steps[0].Name)
+	assert.Equal(t, original.Variables["env"], restored.Variables["env"])
+
+	t.Run("invalid YAML propagates error", func(t *testing.T) {
+		_, err := engine.stringToWorkflow(":\tinvalid: yaml: [\x00")
+		assert.Error(t, err)
+	})
+}
+
+func TestProcessTemplateSubstitutionsEndToEnd(t *testing.T) {
+	engine := NewTemplateEngine()
+
+	workflow := Workflow{
+		Name:        "${workflow_name}",
+		Description: "Template workflow",
+		Steps: []Step{
+			{
+				Name:   "deploy-step",
+				Type:   StepTypeTask,
+				Module: "deploy-module",
+				Config: map[string]interface{}{
+					"target": "production",
+				},
+			},
+		},
+	}
+
+	parameters := map[string]interface{}{
+		"workflow_name": "test-wf",
+	}
+
+	result, err := engine.ProcessTemplateSubstitutions(workflow, parameters)
+	require.NoError(t, err)
+	assert.Equal(t, "test-wf", result.Name)
+}
+
 func TestWorkflowTemplate_CreationAndUpdate(t *testing.T) {
 	template := &WorkflowTemplate{
 		ID:          "test-template",


### PR DESCRIPTION
## Summary

- Replaces `workflowToString` placeholder (`fmt.Sprintf("workflow: %+v")`) with `gopkg.in/yaml.v3` `yaml.Marshal`, returning `(string, error)`
- Replaces `stringToWorkflow` stub (always returned empty `Workflow{}`) with `yaml.Unmarshal`, propagating parse errors
- `ProcessTemplateSubstitutions` now propagates marshal failure wrapped as `"serializing workflow for template substitution: %w"`
- Fixes pre-existing `gofmt` alignment issue in `features/siem/stream_processor_test.go` that was blocking lint

## Tests added

- `TestWorkflowToStringMarshalsValidYAML` — asserts `yaml.Marshal` produces YAML containing known Name/Description/Steps
- `TestStringToWorkflowRoundTrip` — round-trips Name, Description, Steps[0].Name, Variables; includes invalid-YAML error path subtest
- `TestProcessTemplateSubstitutionsEndToEnd` — substitutes `${workflow_name}` → `"test-wf"` and asserts `result.Name == "test-wf"`

## Specialist review results

| Agent | Result |
|-------|--------|
| QA Test Runner | **PASS** — all unit tests, builds, lint, script tests passed; Trivy blocked by sandbox network (expected, re-runs in CI) |
| QA Code Reviewer | **PASS** — no blocking issues; 2 warnings (unreachable error branch note, pre-existing `InstantiateTemplate` test gap) |
| Security Engineer | **PASS** — no blocking issues; pre-commit scan, architecture check, gosec, staticcheck all pass; Trivy sandbox network failure (expected) |

Fixes #1083

🤖 Generated with [Claude Code](https://claude.com/claude-code)