### PR TITLE
workflow: gate simulated providers behind experimental build tag (Issue #1087)

### DIFF
--- a/features/workflow/engine.go
+++ b/features/workflow/engine.go
@@ -30,15 +30,15 @@ type TransformStepExecutor interface {
 
 // Engine implements the WorkflowEngine interface
 type Engine struct {
-	moduleFactory    *factory.ModuleFactory
-	logger           *logging.ModuleLogger
-	executions       map[string]*WorkflowExecution
-	mutex            sync.RWMutex
-	httpClient       *HTTPClient
-	providerRegistry *ProviderRegistry
-	errorHandler     ErrorHandler
-	syncManager      *SyncManager
-	debugEngine      *DebugEngineImpl
+	moduleFactory     *factory.ModuleFactory
+	logger            *logging.ModuleLogger
+	executions        map[string]*WorkflowExecution
+	mutex             sync.RWMutex
+	httpClient        *HTTPClient
+	providerRegistry  *ProviderRegistry
+	errorHandler      ErrorHandler
+	syncManager       *SyncManager
+	debugEngine       *DebugEngineImpl
 	transformExecutor TransformStepExecutor
 }
 
@@ -65,13 +65,13 @@ func NewEngine(moduleFactory *factory.ModuleFactory, logger logging.Logger, tran
 	providerRegistry := NewProviderRegistry(logger) // Keep legacy for now
 
 	engine := &Engine{
-		moduleFactory:    moduleFactory,
-		logger:           workflowLogger,
-		executions:       make(map[string]*WorkflowExecution),
-		httpClient:       httpClient,
-		providerRegistry: providerRegistry,
-		errorHandler:     NewDefaultErrorHandler(),
-		syncManager:      NewSyncManager(),
+		moduleFactory:     moduleFactory,
+		logger:            workflowLogger,
+		executions:        make(map[string]*WorkflowExecution),
+		httpClient:        httpClient,
+		providerRegistry:  providerRegistry,
+		errorHandler:      NewDefaultErrorHandler(),
+		syncManager:       NewSyncManager(),
 		transformExecutor: transformExecutor,
 	}
 

--- a/features/workflow/providers.go
+++ b/features/workflow/providers.go
@@ -28,11 +28,20 @@ package workflow
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 
 	"github.com/cfgis/cfgms/pkg/logging"
 )
+
+// ErrProviderNotImplemented is returned by stub provider implementations in default builds.
+// Use -tags experimental to enable simulated provider behaviour.
+var ErrProviderNotImplemented = errors.New("provider not implemented: build with -tags experimental to enable")
+
+// providerOverrides maps provider names to override implementations.
+// Populated by init() in providers_experimental.go before any ProviderRegistry is created.
+var providerOverrides = map[string]APIProvider{}
 
 // ProviderRegistry manages external API providers and their operations
 type ProviderRegistry struct {
@@ -192,26 +201,22 @@ func (r *ProviderRegistry) ExecuteOperation(ctx context.Context, config *APIConf
 	return response, nil
 }
 
-// registerBuiltinProviders registers the built-in API providers
+// registerBuiltinProviders registers the built-in API providers.
+// Entries in providerOverrides (set by providers_experimental.go init()) replace defaults.
 func (r *ProviderRegistry) registerBuiltinProviders() {
-	// Register Microsoft provider
-	if err := r.RegisterProvider("microsoft", &MicrosoftProvider{}); err != nil {
-		r.logger.Error("Failed to register Microsoft provider", "error", err)
+	defaults := map[string]APIProvider{
+		"microsoft":   &MicrosoftProvider{},
+		"google":      &GoogleProvider{},
+		"salesforce":  &SalesforceProvider{},
+		"connectwise": &ConnectWiseProvider{},
 	}
-
-	// Register Google provider
-	if err := r.RegisterProvider("google", &GoogleProvider{}); err != nil {
-		r.logger.Error("Failed to register Google provider", "error", err)
+	for name, p := range providerOverrides {
+		defaults[name] = p
 	}
-
-	// Register Salesforce provider
-	if err := r.RegisterProvider("salesforce", &SalesforceProvider{}); err != nil {
-		r.logger.Error("Failed to register Salesforce provider", "error", err)
-	}
-
-	// Register ConnectWise provider
-	if err := r.RegisterProvider("connectwise", &ConnectWiseProvider{}); err != nil {
-		r.logger.Error("Failed to register ConnectWise provider", "error", err)
+	for name, p := range defaults {
+		if err := r.RegisterProvider(name, p); err != nil {
+			r.logger.Error("Failed to register provider", "provider", name, "error", err)
+		}
 	}
 }
 
@@ -260,18 +265,8 @@ func (p *MicrosoftProvider) ValidateConfig(config *APIConfig) error {
 	return fmt.Errorf("unsupported service: %s", config.Service)
 }
 
-func (p *MicrosoftProvider) ExecuteOperation(ctx context.Context, config *APIConfig) (*APIResponse, error) {
-	// This is a simplified implementation
-	// In a real system, this would make actual Microsoft Graph API calls
-	return &APIResponse{
-		Success:    true,
-		Data:       map[string]interface{}{"message": "Microsoft operation simulated"},
-		StatusCode: 200,
-		Metadata: map[string]interface{}{
-			"provider": "microsoft",
-			"service":  config.Service,
-		},
-	}, nil
+func (p *MicrosoftProvider) ExecuteOperation(_ context.Context, _ *APIConfig) (*APIResponse, error) {
+	return nil, ErrProviderNotImplemented
 }
 
 func (p *MicrosoftProvider) RefreshToken(ctx context.Context, config *APIConfig) error {
@@ -320,16 +315,8 @@ func (p *GoogleProvider) ValidateConfig(config *APIConfig) error {
 	return fmt.Errorf("unsupported service: %s", config.Service)
 }
 
-func (p *GoogleProvider) ExecuteOperation(ctx context.Context, config *APIConfig) (*APIResponse, error) {
-	return &APIResponse{
-		Success:    true,
-		Data:       map[string]interface{}{"message": "Google operation simulated"},
-		StatusCode: 200,
-		Metadata: map[string]interface{}{
-			"provider": "google",
-			"service":  config.Service,
-		},
-	}, nil
+func (p *GoogleProvider) ExecuteOperation(_ context.Context, _ *APIConfig) (*APIResponse, error) {
+	return nil, ErrProviderNotImplemented
 }
 
 func (p *GoogleProvider) RefreshToken(ctx context.Context, config *APIConfig) error {
@@ -378,16 +365,8 @@ func (p *SalesforceProvider) ValidateConfig(config *APIConfig) error {
 	return fmt.Errorf("unsupported service: %s", config.Service)
 }
 
-func (p *SalesforceProvider) ExecuteOperation(ctx context.Context, config *APIConfig) (*APIResponse, error) {
-	return &APIResponse{
-		Success:    true,
-		Data:       map[string]interface{}{"message": "Salesforce operation simulated"},
-		StatusCode: 200,
-		Metadata: map[string]interface{}{
-			"provider": "salesforce",
-			"service":  config.Service,
-		},
-	}, nil
+func (p *SalesforceProvider) ExecuteOperation(_ context.Context, _ *APIConfig) (*APIResponse, error) {
+	return nil, ErrProviderNotImplemented
 }
 
 func (p *SalesforceProvider) RefreshToken(ctx context.Context, config *APIConfig) error {
@@ -438,16 +417,8 @@ func (p *ConnectWiseProvider) ValidateConfig(config *APIConfig) error {
 	return fmt.Errorf("unsupported service: %s", config.Service)
 }
 
-func (p *ConnectWiseProvider) ExecuteOperation(ctx context.Context, config *APIConfig) (*APIResponse, error) {
-	return &APIResponse{
-		Success:    true,
-		Data:       map[string]interface{}{"message": "ConnectWise operation simulated"},
-		StatusCode: 200,
-		Metadata: map[string]interface{}{
-			"provider": "connectwise",
-			"service":  config.Service,
-		},
-	}, nil
+func (p *ConnectWiseProvider) ExecuteOperation(_ context.Context, _ *APIConfig) (*APIResponse, error) {
+	return nil, ErrProviderNotImplemented
 }
 
 func (p *ConnectWiseProvider) RefreshToken(ctx context.Context, config *APIConfig) error {

--- a/features/workflow/providers_default_test.go
+++ b/features/workflow/providers_default_test.go
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+
+//go:build !experimental
+
+package workflow
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	pkgtesting "github.com/cfgis/cfgms/pkg/testing"
+)
+
+// TestDefaultBuildProvidersReturnErrNotImplemented verifies that all four builtin providers
+// return ErrProviderNotImplemented in the default (non-experimental) build.
+func TestDefaultBuildProvidersReturnErrNotImplemented(t *testing.T) {
+	cases := []struct {
+		provider string
+		service  string
+	}{
+		{"microsoft", "users"},
+		{"google", "admin"},
+		{"salesforce", "sobjects"},
+		{"connectwise", "manage"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.provider, func(t *testing.T) {
+			logger := pkgtesting.NewMockLogger(true)
+			registry := NewProviderRegistry(logger)
+
+			config := &APIConfig{
+				Provider:  tc.provider,
+				Service:   tc.service,
+				Operation: "list",
+			}
+
+			_, err := registry.ExecuteOperation(context.Background(), config)
+			require.Error(t, err)
+			assert.True(t, errors.Is(err, ErrProviderNotImplemented),
+				"expected ErrProviderNotImplemented for provider %q, got: %v", tc.provider, err)
+		})
+	}
+}

--- a/features/workflow/providers_experimental.go
+++ b/features/workflow/providers_experimental.go
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+
+//go:build experimental
+
+package workflow
+
+import "context"
+
+// experimentalMicrosoftProvider wraps MicrosoftProvider with a simulated ExecuteOperation.
+type experimentalMicrosoftProvider struct {
+	MicrosoftProvider
+}
+
+func (p *experimentalMicrosoftProvider) ExecuteOperation(_ context.Context, config *APIConfig) (*APIResponse, error) {
+	return &APIResponse{
+		Success:    true,
+		Data:       map[string]interface{}{"message": "Microsoft operation simulated"},
+		StatusCode: 200,
+		Metadata: map[string]interface{}{
+			"provider": "microsoft",
+			"service":  config.Service,
+		},
+	}, nil
+}
+
+// experimentalGoogleProvider wraps GoogleProvider with a simulated ExecuteOperation.
+type experimentalGoogleProvider struct {
+	GoogleProvider
+}
+
+func (p *experimentalGoogleProvider) ExecuteOperation(_ context.Context, config *APIConfig) (*APIResponse, error) {
+	return &APIResponse{
+		Success:    true,
+		Data:       map[string]interface{}{"message": "Google operation simulated"},
+		StatusCode: 200,
+		Metadata: map[string]interface{}{
+			"provider": "google",
+			"service":  config.Service,
+		},
+	}, nil
+}
+
+// experimentalSalesforceProvider wraps SalesforceProvider with a simulated ExecuteOperation.
+type experimentalSalesforceProvider struct {
+	SalesforceProvider
+}
+
+func (p *experimentalSalesforceProvider) ExecuteOperation(_ context.Context, config *APIConfig) (*APIResponse, error) {
+	return &APIResponse{
+		Success:    true,
+		Data:       map[string]interface{}{"message": "Salesforce operation simulated"},
+		StatusCode: 200,
+		Metadata: map[string]interface{}{
+			"provider": "salesforce",
+			"service":  config.Service,
+		},
+	}, nil
+}
+
+// experimentalConnectWiseProvider wraps ConnectWiseProvider with a simulated ExecuteOperation.
+type experimentalConnectWiseProvider struct {
+	ConnectWiseProvider
+}
+
+func (p *experimentalConnectWiseProvider) ExecuteOperation(_ context.Context, config *APIConfig) (*APIResponse, error) {
+	return &APIResponse{
+		Success:    true,
+		Data:       map[string]interface{}{"message": "ConnectWise operation simulated"},
+		StatusCode: 200,
+		Metadata: map[string]interface{}{
+			"provider": "connectwise",
+			"service":  config.Service,
+		},
+	}, nil
+}
+
+// init overrides the default stub registrations with simulated implementations.
+// Runs before any NewProviderRegistry call so registerBuiltinProviders picks up the overrides.
+func init() {
+	providerOverrides["microsoft"] = &experimentalMicrosoftProvider{}
+	providerOverrides["google"] = &experimentalGoogleProvider{}
+	providerOverrides["salesforce"] = &experimentalSalesforceProvider{}
+	providerOverrides["connectwise"] = &experimentalConnectWiseProvider{}
+}

--- a/features/workflow/providers_experimental_test.go
+++ b/features/workflow/providers_experimental_test.go
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+
+//go:build experimental
+
+package workflow
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	pkgtesting "github.com/cfgis/cfgms/pkg/testing"
+)
+
+// TestExperimentalBuildProvidersReturnSimulatedSuccess verifies that in the experimental build
+// all four builtin providers return a successful simulated response.
+func TestExperimentalBuildProvidersReturnSimulatedSuccess(t *testing.T) {
+	cases := []struct {
+		provider string
+		service  string
+	}{
+		{"microsoft", "users"},
+		{"google", "admin"},
+		{"salesforce", "sobjects"},
+		{"connectwise", "manage"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.provider, func(t *testing.T) {
+			logger := pkgtesting.NewMockLogger(true)
+			registry := NewProviderRegistry(logger)
+
+			config := &APIConfig{
+				Provider:  tc.provider,
+				Service:   tc.service,
+				Operation: "list",
+			}
+
+			response, err := registry.ExecuteOperation(context.Background(), config)
+			require.NoError(t, err)
+			assert.True(t, response.Success, "expected Success=true for provider %q", tc.provider)
+			assert.Equal(t, 200, response.StatusCode)
+			assert.NotNil(t, response.Data)
+		})
+	}
+}

--- a/features/workflow/providers_test.go
+++ b/features/workflow/providers_test.go
@@ -4,6 +4,7 @@ package workflow
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -72,10 +73,15 @@ func TestProviderRegistry_ExecuteOperation(t *testing.T) {
 	logger := pkgtesting.NewMockLogger(true)
 	registry := NewProviderRegistry(logger)
 
-	// Test executing operation with Microsoft provider
+	// Use a mock provider so the test is build-tag-neutral; the builtin provider
+	// gate is verified by TestDefaultBuildProvidersReturnErrNotImplemented.
+	mockProvider := &MockProvider{name: "test-exec"}
+	err := registry.RegisterProvider("test-exec", mockProvider)
+	require.NoError(t, err)
+
 	config := &APIConfig{
-		Provider:  "microsoft",
-		Service:   "users",
+		Provider:  "test-exec",
+		Service:   "test",
 		Operation: "list",
 		Parameters: map[string]interface{}{
 			"top": 10,
@@ -87,8 +93,6 @@ func TestProviderRegistry_ExecuteOperation(t *testing.T) {
 	require.NoError(t, err)
 	assert.True(t, response.Success)
 	assert.Equal(t, 200, response.StatusCode)
-	assert.Contains(t, response.Metadata, "provider")
-	assert.Equal(t, "microsoft", response.Metadata["provider"])
 }
 
 func TestProviderRegistry_ExecuteOperation_InvalidProvider(t *testing.T) {
@@ -216,10 +220,16 @@ func TestConnectWiseProvider(t *testing.T) {
 }
 
 func TestEngine_ExecuteAPIStep_WithProviderRegistry(t *testing.T) {
-	// Create engine with provider registry
+	// Create engine and register a succeeding mock provider to test engine plumbing.
+	// The builtin providers return ErrProviderNotImplemented in default builds;
+	// this test exercises the engine's variable-storage path, not the provider stubs.
 	moduleFactory := createTestFactory()
 	logger := pkgtesting.NewMockLogger(true)
 	engine := NewEngine(moduleFactory, logger, nil)
+
+	const providerName = "test-api-provider"
+	err := engine.providerRegistry.RegisterProvider(providerName, &MockProvider{name: providerName})
+	require.NoError(t, err)
 
 	workflow := Workflow{
 		Name: "api-provider-test",
@@ -228,8 +238,8 @@ func TestEngine_ExecuteAPIStep_WithProviderRegistry(t *testing.T) {
 				Name: "test-api-call",
 				Type: StepTypeAPI,
 				API: &APIConfig{
-					Provider:  "microsoft",
-					Service:   "users",
+					Provider:  providerName,
+					Service:   "test",
 					Operation: "list",
 					Parameters: map[string]interface{}{
 						"top": 10,
@@ -254,7 +264,53 @@ func TestEngine_ExecuteAPIStep_WithProviderRegistry(t *testing.T) {
 	assert.True(t, finalExecution.Variables["test-api-call_api_success"].(bool))
 	assert.Equal(t, 200, finalExecution.Variables["test-api-call_api_status"])
 	assert.NotNil(t, finalExecution.Variables["test-api-call_api_response"])
-	assert.NotNil(t, finalExecution.Variables["test-api-call_api_metadata"])
+}
+
+// TestProviderNoPayloadLogging verifies that config.Parameters and config.Auth credential
+// values never appear in log output at any level in either build.
+func TestProviderNoPayloadLogging(t *testing.T) {
+	logger := pkgtesting.NewMockLogger(true)
+	registry := NewProviderRegistry(logger)
+
+	// Register a succeeding mock so the completion-log path is exercised.
+	const providerName = "test-log-provider"
+	err := registry.RegisterProvider(providerName, &MockProvider{name: providerName})
+	require.NoError(t, err)
+
+	const sensitiveParam = "super-secret-param-value-7f3x"
+	const sensitiveCredential = "super-secret-bearer-token-9z2q"
+
+	config := &APIConfig{
+		Provider:  providerName,
+		Service:   "test",
+		Operation: "test",
+		Parameters: map[string]interface{}{
+			"secret_key": sensitiveParam,
+		},
+		Auth: &AuthConfig{
+			Type:        AuthTypeBearer,
+			BearerToken: sensitiveCredential,
+		},
+	}
+
+	_, execErr := registry.ExecuteOperation(context.Background(), config)
+	require.NoError(t, execErr)
+
+	for _, level := range []string{"debug", "info", "warn", "error", "fatal"} {
+		for _, entry := range logger.GetLogs(level) {
+			assert.NotContains(t, entry.Message, sensitiveParam,
+				"level=%s message contains sensitive parameter value", level)
+			assert.NotContains(t, entry.Message, sensitiveCredential,
+				"level=%s message contains sensitive credential value", level)
+			for _, kv := range entry.Data {
+				s := fmt.Sprintf("%v", kv)
+				assert.NotContains(t, s, sensitiveParam,
+					"level=%s log data contains sensitive parameter value", level)
+				assert.NotContains(t, s, sensitiveCredential,
+					"level=%s log data contains sensitive credential value", level)
+			}
+		}
+	}
 }
 
 // MockProvider is a test implementation of APIProvider


### PR DESCRIPTION
## Summary

- Adds `ErrProviderNotImplemented` sentinel in `providers.go` (no build tag) so callers can `errors.Is()` it in both builds
- All four builtin provider `ExecuteOperation` methods return the sentinel in default builds; simulated logic moved to `providers_experimental.go` (`//go:build experimental`) behind unexported wrapper types registered via `init()`
- Adds `TestDefaultBuildProvidersReturnErrNotImplemented` (`//go:build !experimental`), `TestExperimentalBuildProvidersReturnSimulatedSuccess` (`//go:build experimental`), and `TestProviderNoPayloadLogging` (build-neutral, asserts no credentials or parameters leak into logs at any level)

## Test plan

- [ ] `go test ./features/workflow/...` (default build) — all pass
- [ ] `go test -tags experimental ./features/workflow/...` — all pass
- [ ] `go vet ./features/workflow/...` — clean
- [ ] `go vet -tags experimental ./features/workflow/...` — clean
- [ ] `make check-architecture` — no central provider violations
- [ ] `make test-agent-complete` — all gates pass (Trivy skipped: network unavailable in agent container, runs in CI)

## Specialist review results

| Reviewer | Result | Notes |
|---|---|---|
| QA Test Runner | **PASS** | All gates pass; Trivy network-only failure (container isolation, not a finding) |
| QA Code Reviewer | **PASS** | 0 blocking issues; 2 non-blocking warnings (no experimental error-path test, vacuous warn-log assertion) |
| Security Engineer | **PASS** | 0 blocking; 0 warnings; verified no credential/param logging in either build; `providerOverrides` mutation safety confirmed |

Fixes #1087

🤖 Generated with [Claude Code](https://claude.com/claude-code)