### PR TITLE
workflow: fix bearer token timing attack and webhook credential leaks (Issue #1086)

### DIFF
--- a/features/workflow/engine.go
+++ b/features/workflow/engine.go
@@ -30,15 +30,15 @@ type TransformStepExecutor interface {
 
 // Engine implements the WorkflowEngine interface
 type Engine struct {
-	moduleFactory    *factory.ModuleFactory
-	logger           *logging.ModuleLogger
-	executions       map[string]*WorkflowExecution
-	mutex            sync.RWMutex
-	httpClient       *HTTPClient
-	providerRegistry *ProviderRegistry
-	errorHandler     ErrorHandler
-	syncManager      *SyncManager
-	debugEngine      *DebugEngineImpl
+	moduleFactory     *factory.ModuleFactory
+	logger            *logging.ModuleLogger
+	executions        map[string]*WorkflowExecution
+	mutex             sync.RWMutex
+	httpClient        *HTTPClient
+	providerRegistry  *ProviderRegistry
+	errorHandler      ErrorHandler
+	syncManager       *SyncManager
+	debugEngine       *DebugEngineImpl
 	transformExecutor TransformStepExecutor
 }
 
@@ -65,13 +65,13 @@ func NewEngine(moduleFactory *factory.ModuleFactory, logger logging.Logger, tran
 	providerRegistry := NewProviderRegistry(logger) // Keep legacy for now
 
 	engine := &Engine{
-		moduleFactory:    moduleFactory,
-		logger:           workflowLogger,
-		executions:       make(map[string]*WorkflowExecution),
-		httpClient:       httpClient,
-		providerRegistry: providerRegistry,
-		errorHandler:     NewDefaultErrorHandler(),
-		syncManager:      NewSyncManager(),
+		moduleFactory:     moduleFactory,
+		logger:            workflowLogger,
+		executions:        make(map[string]*WorkflowExecution),
+		httpClient:        httpClient,
+		providerRegistry:  providerRegistry,
+		errorHandler:      NewDefaultErrorHandler(),
+		syncManager:       NewSyncManager(),
 		transformExecutor: transformExecutor,
 	}
 

--- a/features/workflow/trigger/security_test.go
+++ b/features/workflow/trigger/security_test.go
@@ -165,7 +165,7 @@ func TestSecurityEdgeCases_WebhookAuthentication(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := handler.authenticateRequest(tt.webhook, tt.payload, tt.headers)
+			err := handler.authenticateRequest(tt.webhook, tt.payload, tt.headers, "test-trigger-id")
 
 			if tt.expectedResult {
 				assert.NoError(t, err, tt.description)

--- a/features/workflow/trigger/webhook.go
+++ b/features/workflow/trigger/webhook.go
@@ -10,6 +10,7 @@ import (
 	"crypto/subtle"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -26,20 +27,24 @@ import (
 	"github.com/cfgis/cfgms/pkg/logging"
 )
 
+// errBearerAuthRateLimited is returned when the bearer token auth failure rate limit is exceeded.
+var errBearerAuthRateLimited = errors.New("bearer auth rate limit exceeded")
+
 // HTTPWebhookHandler implements the WebhookHandler interface using HTTP endpoints
 type HTTPWebhookHandler struct {
-	logger          *logging.ModuleLogger
-	triggerManager  TriggerManager
-	workflowTrigger WorkflowTrigger
-	server          *http.Server
-	router          *mux.Router
-	webhooks        map[string]*Trigger
-	pathToTrigger   map[string]string // Maps webhook paths to trigger IDs
-	rateLimiters    map[string]*rate.Limiter
-	mutex           sync.RWMutex
-	running         bool
-	address         string
-	port            int
+	logger              *logging.ModuleLogger
+	triggerManager      TriggerManager
+	workflowTrigger     WorkflowTrigger
+	server              *http.Server
+	router              *mux.Router
+	webhooks            map[string]*Trigger
+	pathToTrigger       map[string]string // Maps webhook paths to trigger IDs
+	rateLimiters        map[string]*rate.Limiter
+	authFailureLimiters map[string]*rate.Limiter
+	mutex               sync.RWMutex
+	running             bool
+	address             string
+	port                int
 }
 
 // NewHTTPWebhookHandler creates a new HTTP-based webhook handler
@@ -48,15 +53,16 @@ func NewHTTPWebhookHandler(triggerManager TriggerManager, workflowTrigger Workfl
 
 	router := mux.NewRouter()
 	handler := &HTTPWebhookHandler{
-		logger:          logger,
-		triggerManager:  triggerManager,
-		workflowTrigger: workflowTrigger,
-		router:          router,
-		webhooks:        make(map[string]*Trigger),
-		pathToTrigger:   make(map[string]string),
-		rateLimiters:    make(map[string]*rate.Limiter),
-		address:         address,
-		port:            port,
+		logger:              logger,
+		triggerManager:      triggerManager,
+		workflowTrigger:     workflowTrigger,
+		router:              router,
+		webhooks:            make(map[string]*Trigger),
+		pathToTrigger:       make(map[string]string),
+		rateLimiters:        make(map[string]*rate.Limiter),
+		authFailureLimiters: make(map[string]*rate.Limiter),
+		address:             address,
+		port:                port,
 	}
 
 	// Set up webhook routes
@@ -191,6 +197,7 @@ func (wh *HTTPWebhookHandler) UnregisterWebhook(ctx context.Context, triggerID s
 
 	delete(wh.webhooks, triggerID)
 	delete(wh.rateLimiters, triggerID)
+	delete(wh.authFailureLimiters, triggerID)
 
 	// Clean up path mapping
 	delete(wh.pathToTrigger, trigger.Webhook.Path)
@@ -219,7 +226,8 @@ func (wh *HTTPWebhookHandler) HandleWebhook(ctx context.Context, triggerID strin
 		"trigger_id", triggerID,
 		"payload_size", len(payload))
 
-	// Create trigger execution record
+	// Create trigger execution record — store only sanitized headers to prevent
+	// bearer tokens and credentials from leaking into persisted execution records.
 	execution := &TriggerExecution{
 		ID:        generateExecutionID(),
 		TriggerID: triggerID,
@@ -228,7 +236,7 @@ func (wh *HTTPWebhookHandler) HandleWebhook(ctx context.Context, triggerID strin
 		TriggerData: map[string]interface{}{
 			"trigger_type": "webhook",
 			"trigger_id":   triggerID,
-			"headers":      headers,
+			"headers":      sanitizeHeaders(headers),
 			"payload_size": len(payload),
 		},
 	}
@@ -249,7 +257,7 @@ func (wh *HTTPWebhookHandler) HandleWebhook(ctx context.Context, triggerID strin
 	}
 
 	// Authenticate request
-	if err := wh.authenticateRequest(trigger.Webhook, payload, headers); err != nil {
+	if err := wh.authenticateRequest(trigger.Webhook, payload, headers, triggerID); err != nil {
 		execution.Status = TriggerExecutionStatusFailed
 		execution.Error = fmt.Sprintf("authentication failed: %v", err)
 		endTime := time.Now()
@@ -279,11 +287,12 @@ func (wh *HTTPWebhookHandler) HandleWebhook(ctx context.Context, triggerID strin
 		return execution, err
 	}
 
-	// Add trigger data to variables
+	// Add trigger data to variables — sanitize headers to prevent auth credentials
+	// from reaching workflow steps via the webhook_headers variable.
 	triggerData := map[string]interface{}{
 		"trigger_type":    "webhook",
 		"trigger_id":      triggerID,
-		"webhook_headers": headers,
+		"webhook_headers": sanitizeHeaders(headers),
 		"execution_id":    execution.ID,
 	}
 
@@ -469,6 +478,13 @@ func (wh *HTTPWebhookHandler) handleWebhookRequest(w http.ResponseWriter, r *htt
 	// Process webhook
 	execution, err := wh.HandleWebhook(ctx, triggerID, payload, headers)
 	if err != nil {
+		if errors.Is(err, errBearerAuthRateLimited) {
+			logger.WarnCtx(ctx, "Webhook bearer auth rate limit exceeded",
+				"trigger_id", triggerID,
+				"remote_addr", r.RemoteAddr)
+			http.Error(w, "Rate limit exceeded", http.StatusTooManyRequests)
+			return
+		}
 		logger.ErrorCtx(ctx, "Failed to process webhook",
 			"trigger_id", triggerID,
 			"error", err.Error())
@@ -536,7 +552,7 @@ func (wh *HTTPWebhookHandler) validatePayload(webhook *WebhookConfig, payload []
 }
 
 // authenticateRequest authenticates the webhook request
-func (wh *HTTPWebhookHandler) authenticateRequest(webhook *WebhookConfig, payload []byte, headers map[string]string) error {
+func (wh *HTTPWebhookHandler) authenticateRequest(webhook *WebhookConfig, payload []byte, headers map[string]string, triggerID string) error {
 	if webhook.Authentication == nil || webhook.Authentication.Type == WebhookAuthNone {
 		return nil
 	}
@@ -551,7 +567,7 @@ func (wh *HTTPWebhookHandler) authenticateRequest(webhook *WebhookConfig, payloa
 		return wh.validateAPIKey(auth, headers)
 
 	case WebhookAuthBearer:
-		return wh.validateBearerToken(auth, headers)
+		return wh.validateBearerToken(auth, headers, triggerID)
 
 	case WebhookAuthBasic:
 		return wh.validateBasicAuth(auth, headers)
@@ -627,23 +643,58 @@ func (wh *HTTPWebhookHandler) validateAPIKey(auth *WebhookAuth, headers map[stri
 	return nil
 }
 
-// validateBearerToken validates Bearer token
-func (wh *HTTPWebhookHandler) validateBearerToken(auth *WebhookAuth, headers map[string]string) error {
+// getOrCreateAuthFailureLimiter lazily initializes and returns the auth failure limiter for a trigger.
+func (wh *HTTPWebhookHandler) getOrCreateAuthFailureLimiter(triggerID string) *rate.Limiter {
+	if wh.authFailureLimiters == nil {
+		return nil
+	}
+	wh.mutex.RLock()
+	limiter, exists := wh.authFailureLimiters[triggerID]
+	wh.mutex.RUnlock()
+	if exists {
+		return limiter
+	}
+	wh.mutex.Lock()
+	defer wh.mutex.Unlock()
+	if limiter, exists = wh.authFailureLimiters[triggerID]; exists {
+		return limiter
+	}
+	limiter = rate.NewLimiter(rate.Limit(10.0/60.0), 10)
+	wh.authFailureLimiters[triggerID] = limiter
+	return limiter
+}
+
+// validateBearerToken validates Bearer token using constant-time NFC-normalized comparison.
+func (wh *HTTPWebhookHandler) validateBearerToken(auth *WebhookAuth, headers map[string]string, triggerID string) error {
+	// Fail-closed: missing config rejects all requests without leaking config state.
 	if auth.BearerToken == "" {
-		return fmt.Errorf("bearer token is required")
+		return errors.New("invalid Bearer token")
 	}
 
 	authHeader, exists := headers["Authorization"]
 	if !exists {
-		return fmt.Errorf("authorization header not found")
+		return wh.bearerAuthFailure(triggerID)
 	}
 
-	expectedToken := "Bearer " + auth.BearerToken
-	if authHeader != expectedToken {
-		return fmt.Errorf("invalid Bearer token")
+	// NFC-normalize both sides before comparison to prevent Unicode normalization attacks.
+	// Keep "Bearer " prefix on both sides — equal padding is acceptable.
+	normalizedReceived := norm.NFC.String(authHeader)
+	normalizedExpected := norm.NFC.String("Bearer " + auth.BearerToken)
+
+	if subtle.ConstantTimeCompare([]byte(normalizedReceived), []byte(normalizedExpected)) != 1 {
+		return wh.bearerAuthFailure(triggerID)
 	}
 
 	return nil
+}
+
+// bearerAuthFailure records an auth failure and returns errBearerAuthRateLimited if exhausted.
+func (wh *HTTPWebhookHandler) bearerAuthFailure(triggerID string) error {
+	limiter := wh.getOrCreateAuthFailureLimiter(triggerID)
+	if limiter != nil && !limiter.Allow() {
+		return errBearerAuthRateLimited
+	}
+	return errors.New("invalid Bearer token")
 }
 
 // validateBasicAuth validates HTTP Basic authentication
@@ -656,6 +707,23 @@ func (wh *HTTPWebhookHandler) validateBasicAuth(auth *WebhookAuth, headers map[s
 	// This would require base64 decoding the Authorization header
 	// and comparing username/password
 	return fmt.Errorf("basic auth validation not yet implemented")
+}
+
+// blockedWebhookHeaders is the set of header names (lowercased) that must never appear
+// in execution records or workflow variables to prevent credential leaks.
+var blockedWebhookHeaders = map[string]struct{}{
+	"authorization": {}, "cookie": {}, "x-api-key": {}, "x-auth-token": {},
+}
+
+// sanitizeHeaders returns a copy of headers with auth-related entries removed.
+func sanitizeHeaders(headers map[string]string) map[string]string {
+	out := make(map[string]string, len(headers))
+	for k, v := range headers {
+		if _, blocked := blockedWebhookHeaders[strings.ToLower(k)]; !blocked {
+			out[k] = v
+		}
+	}
+	return out
 }
 
 // mapPayloadToVariables maps webhook payload to workflow variables
@@ -690,9 +758,12 @@ func (wh *HTTPWebhookHandler) mapPayloadToVariables(trigger *Trigger, payload []
 		}
 	}
 
-	// Add headers as variables with "header_" prefix
+	// Add headers as variables with "header_" prefix, excluding auth-related headers.
 	for k, v := range headers {
-		variables["header_"+strings.ToLower(k)] = v
+		lk := strings.ToLower(k)
+		if _, blocked := blockedWebhookHeaders[lk]; !blocked {
+			variables["header_"+lk] = v
+		}
 	}
 
 	return variables, nil

--- a/features/workflow/trigger/webhook_test.go
+++ b/features/workflow/trigger/webhook_test.go
@@ -8,8 +8,10 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -309,7 +311,7 @@ func TestHTTPWebhookHandler_AuthenticateRequest(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := handler.authenticateRequest(tt.webhook, tt.payload, tt.headers)
+			err := handler.authenticateRequest(tt.webhook, tt.payload, tt.headers, "test-trigger-id")
 
 			if tt.expectError {
 				assert.Error(t, err)
@@ -809,6 +811,201 @@ func TestHTTPWebhookHandler_RateLimit(t *testing.T) {
 	rr2 := httptest.NewRecorder()
 	handler.router.ServeHTTP(rr2, req2)
 	assert.Equal(t, http.StatusTooManyRequests, rr2.Code)
+}
+
+// TestValidateBearerTokenConstantTimeCompare verifies that validateBearerToken uses
+// subtle.ConstantTimeCompare and NFC normalization. Wall-clock timing is statistically
+// unreliable on shared CI runners at sub-microsecond resolution, so we use a structural
+// source inspection check (same pattern as TestWebhookHandlerUsesHmacEqual in security_test.go).
+func TestValidateBearerTokenConstantTimeCompare(t *testing.T) {
+	source, err := os.ReadFile("webhook.go")
+	require.NoError(t, err, "failed to read webhook.go")
+	assert.True(t, strings.Contains(string(source), "subtle.ConstantTimeCompare("),
+		"webhook.go must use subtle.ConstantTimeCompare() in validateBearerToken to prevent timing attacks")
+	assert.True(t, strings.Contains(string(source), "norm.NFC.String("),
+		"webhook.go must apply NFC normalization before bearer token comparison to prevent Unicode normalization attacks")
+}
+
+// TestValidateBearerTokenFailClosed asserts that an empty BearerToken config rejects all requests.
+func TestValidateBearerTokenFailClosed(t *testing.T) {
+	handler := &HTTPWebhookHandler{}
+	auth := &WebhookAuth{
+		BearerToken: "",
+	}
+
+	headers := map[string]string{
+		"Authorization": "Bearer anything",
+	}
+
+	err := handler.validateBearerToken(auth, headers, "test-trigger")
+	require.Error(t, err)
+	assert.Equal(t, "invalid Bearer token", err.Error())
+	assert.NotContains(t, err.Error(), "anything")
+}
+
+// TestAuthFailureRateLimit asserts that 11 consecutive bearer auth failures for the same
+// trigger ID return HTTP 429 on the 11th attempt.
+func TestAuthFailureRateLimit(t *testing.T) {
+	mockTriggerManager := &MockTriggerManager{}
+	mockWorkflowTrigger := &MockWorkflowTrigger{}
+	handler := NewHTTPWebhookHandler(mockTriggerManager, mockWorkflowTrigger, "localhost", 0)
+
+	trigger := &Trigger{
+		ID:   "rate-limit-trigger",
+		Type: TriggerTypeWebhook,
+		Webhook: &WebhookConfig{
+			Path:    "/webhook/rate-limit-trigger",
+			Method:  []string{"POST"},
+			Enabled: true,
+			Authentication: &WebhookAuth{
+				Type:        WebhookAuthBearer,
+				BearerToken: "correct-token",
+			},
+		},
+	}
+
+	ctx := context.Background()
+	err := handler.RegisterWebhook(ctx, trigger)
+	require.NoError(t, err)
+
+	// First 10 failures should return 500 (auth failed, limiter not yet exhausted)
+	for i := 0; i < 10; i++ {
+		req, _ := http.NewRequest("POST", "/webhook/rate-limit-trigger",
+			strings.NewReader(`{"test": "data"}`))
+		req.Header.Set("Authorization", "Bearer wrong-token")
+		rr := httptest.NewRecorder()
+		handler.router.ServeHTTP(rr, req)
+		assert.Equal(t, http.StatusInternalServerError, rr.Code,
+			fmt.Sprintf("request %d should fail with 500 (auth error)", i+1))
+	}
+
+	// 11th failure should return 429 (rate limit exhausted)
+	req, _ := http.NewRequest("POST", "/webhook/rate-limit-trigger",
+		strings.NewReader(`{"test": "data"}`))
+	req.Header.Set("Authorization", "Bearer wrong-token")
+	rr := httptest.NewRecorder()
+	handler.router.ServeHTTP(rr, req)
+	assert.Equal(t, http.StatusTooManyRequests, rr.Code,
+		"11th consecutive auth failure should return HTTP 429")
+}
+
+// TestMapPayloadToVariablesHeaderSanitization asserts that auth-related headers are stripped
+// from the workflow variable bag to prevent credential leaks into execution records.
+func TestMapPayloadToVariablesHeaderSanitization(t *testing.T) {
+	handler := &HTTPWebhookHandler{}
+
+	trigger := &Trigger{
+		Webhook: &WebhookConfig{},
+	}
+	payload := []byte(`{"event": "test"}`)
+	headers := map[string]string{
+		"Authorization":   "Bearer super-secret-token",
+		"Cookie":          "session=abc123",
+		"X-Api-Key":       "api-key-value",
+		"X-Auth-Token":    "auth-token-value",
+		"Content-Type":    "application/json",
+		"X-Custom-Header": "allowed-value",
+	}
+
+	variables, err := handler.mapPayloadToVariables(trigger, payload, headers)
+	require.NoError(t, err)
+
+	// Blocked headers must not appear in any form
+	for key, val := range variables {
+		assert.NotContains(t, key, "authorization", "authorization header must be stripped from variable bag")
+		assert.NotContains(t, key, "cookie", "cookie header must be stripped from variable bag")
+		assert.NotContains(t, key, "x-api-key", "x-api-key header must be stripped from variable bag")
+		assert.NotContains(t, key, "x-auth-token", "x-auth-token header must be stripped from variable bag")
+		// Token values must not appear in any variable value
+		assert.NotContains(t, fmt.Sprintf("%v", val), "super-secret-token")
+		assert.NotContains(t, fmt.Sprintf("%v", val), "session=abc123")
+		assert.NotContains(t, fmt.Sprintf("%v", val), "api-key-value")
+		assert.NotContains(t, fmt.Sprintf("%v", val), "auth-token-value")
+	}
+
+	// Allowed headers must still be present
+	assert.Equal(t, "application/json", variables["header_content-type"])
+	assert.Equal(t, "allowed-value", variables["header_x-custom-header"])
+}
+
+// TestHandleWebhookNoAuthHeadersInWorkflowVariables asserts that auth-related headers
+// never reach TriggerWorkflow via webhook_headers or any other path in HandleWebhook.
+func TestHandleWebhookNoAuthHeadersInWorkflowVariables(t *testing.T) {
+	mockTriggerManager := &MockTriggerManager{}
+	mockWorkflowTrigger := &MockWorkflowTrigger{}
+	handler := NewHTTPWebhookHandler(mockTriggerManager, mockWorkflowTrigger, "localhost", 0)
+
+	trigger := &Trigger{
+		ID:           "sanitize-e2e",
+		Type:         TriggerTypeWebhook,
+		WorkflowName: "test-workflow",
+		Webhook: &WebhookConfig{
+			Path:    "/webhook/sanitize-e2e",
+			Method:  []string{"POST"},
+			Enabled: true,
+			Authentication: &WebhookAuth{
+				Type:        WebhookAuthBearer,
+				BearerToken: "correct-token",
+			},
+		},
+	}
+
+	ctx := context.Background()
+	err := handler.RegisterWebhook(ctx, trigger)
+	require.NoError(t, err)
+
+	// Use a channel to synchronize with the async goroutine in HandleWebhook.
+	// The channel send happens-before the receive, ensuring capturedVariables is
+	// visible to the test goroutine without a data race.
+	triggerCalled := make(chan struct{}, 1)
+	var capturedVariables map[string]interface{}
+	mockWorkflowTrigger.On("TriggerWorkflow", mock.Anything, mock.Anything, mock.MatchedBy(func(vars map[string]interface{}) bool {
+		capturedVariables = vars
+		select {
+		case triggerCalled <- struct{}{}:
+		default:
+		}
+		return true
+	})).Return(
+		&WorkflowExecution{ID: "exec-sanitize", WorkflowName: "test-workflow", Status: "running", StartTime: time.Now()},
+		nil,
+	)
+
+	headers := map[string]string{
+		"Authorization":   "Bearer correct-token",
+		"Cookie":          "session=secret123",
+		"X-Api-Key":       "api-key-secret",
+		"X-Auth-Token":    "auth-secret",
+		"Content-Type":    "application/json",
+		"X-Custom-Header": "safe-value",
+	}
+
+	payload := []byte(`{"event": "test"}`)
+	_, err = handler.HandleWebhook(ctx, "sanitize-e2e", payload, headers)
+	require.NoError(t, err)
+
+	// Wait for the async goroutine to invoke TriggerWorkflow.
+	select {
+	case <-triggerCalled:
+	case <-time.After(2 * time.Second):
+		t.Fatal("TriggerWorkflow was not called within 2 seconds")
+	}
+
+	require.NotNil(t, capturedVariables, "TriggerWorkflow must have been called with variables")
+
+	// Stringify all variable values and assert no auth credentials appear.
+	combined := fmt.Sprintf("%v", capturedVariables)
+	assert.NotContains(t, combined, "correct-token", "bearer token must not reach workflow variables")
+	assert.NotContains(t, combined, "secret123", "cookie value must not reach workflow variables")
+	assert.NotContains(t, combined, "api-key-secret", "x-api-key value must not reach workflow variables")
+	assert.NotContains(t, combined, "auth-secret", "x-auth-token value must not reach workflow variables")
+
+	// Auth header keys must not appear either.
+	assert.NotContains(t, combined, "authorization", "authorization key must not appear in workflow variables")
+	assert.NotContains(t, combined, "cookie", "cookie key must not appear in workflow variables")
+
+	// Safe headers must still be present.
+	assert.Contains(t, combined, "safe-value", "non-auth headers must still be present")
 }
 
 // Helper function to generate HMAC signature for tests


### PR DESCRIPTION
## Summary

- Replaces string equality in `validateBearerToken` with `subtle.ConstantTimeCompare` on NFC-normalized inputs, preventing timing attacks
- Adds `authFailureLimiters` (separate from throughput `rateLimiters`) per trigger ID; 11 consecutive bearer auth failures within 60s return HTTP 429
- Fixes credential leaks: `sanitizeHeaders()` now strips `authorization`, `cookie`, `x-api-key`, `x-auth-token` at all three injection sites (`TriggerData["headers"]`, `webhook_headers` workflow variable, and `header_*` variable bag)
- Fail-closed: empty `BearerToken` config rejects all requests with a static error string containing no config or header values

## Test plan

- [x] `TestValidateBearerTokenConstantTimeCompare` — structural check that `subtle.ConstantTimeCompare` and `norm.NFC.String` are present in source
- [x] `TestValidateBearerTokenFailClosed` — empty config returns static "invalid Bearer token"
- [x] `TestAuthFailureRateLimit` — 11 consecutive failures → HTTP 429
- [x] `TestMapPayloadToVariablesHeaderSanitization` — unit-level blocklist coverage
- [x] `TestHandleWebhookNoAuthHeadersInWorkflowVariables` — end-to-end via `HandleWebhook`, channel-synchronized to avoid races
- [x] All existing webhook tests pass with race detector (`go test -race`)
- [x] `make lint` clean, `make check-architecture` clean

## Specialist Review Results

- **QA Code Reviewer**: PASS — all blocking issues resolved (flaky timing test replaced with structural source check, `_ = key` removed, pre-existing `MockStorageProvider` correctly scoped out)
- **Security Engineer**: PASS — both credential leak sites confirmed fixed, channel synchronization verified race-free, all scans clean (Trivy excluded due to network isolation in container)

Fixes #1086