### PR TITLE
rbac: decouple RBACService proto converters from features/rbac/memory import (Issue #1099)

### DIFF
--- a/features/controller/service/rbac_service.go
+++ b/features/controller/service/rbac_service.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/cfgis/cfgms/api/proto/controller"
 	"github.com/cfgis/cfgms/features/rbac"
-	"github.com/cfgis/cfgms/features/rbac/memory"
 )
 
 // injectJustification extracts a sensitive-operation justification from gRPC incoming
@@ -458,7 +457,7 @@ func (s *RBACService) ValidateRoleHierarchy(ctx context.Context, req *controller
 
 // Helper methods for type conversion
 
-func (s *RBACService) convertToProtoHierarchy(hierarchy *memory.RoleHierarchy) *controller.RoleHierarchy {
+func (s *RBACService) convertToProtoHierarchy(hierarchy *rbac.RoleHierarchy) *controller.RoleHierarchy {
 	if hierarchy == nil {
 		return nil
 	}
@@ -484,7 +483,7 @@ func (s *RBACService) convertToProtoHierarchy(hierarchy *memory.RoleHierarchy) *
 	return protoHierarchy
 }
 
-func (s *RBACService) convertToProtoEffectivePermissions(effectivePerms *memory.EffectivePermissions) *controller.EffectivePermissions {
+func (s *RBACService) convertToProtoEffectivePermissions(effectivePerms *rbac.EffectivePermissions) *controller.EffectivePermissions {
 	if effectivePerms == nil {
 		return nil
 	}

--- a/features/controller/service/rbac_service_test.go
+++ b/features/controller/service/rbac_service_test.go
@@ -20,6 +20,76 @@ import (
 	_ "github.com/cfgis/cfgms/pkg/storage/providers/sqlite"
 )
 
+func TestRBACService_ConvertToProtoHierarchy_Roundtrip(t *testing.T) {
+	s := &RBACService{}
+
+	parent := &rbac.RoleHierarchy{
+		Role:  &common.Role{Id: "parent-role", Name: "Parent Role"},
+		Depth: 1,
+	}
+	// Real store assigns Depth: -1 to descendants; converter bounds-checks and clamps it to 0.
+	child := &rbac.RoleHierarchy{
+		Role:  &common.Role{Id: "child-role", Name: "Child Role"},
+		Depth: -1,
+	}
+	hierarchy := &rbac.RoleHierarchy{
+		Role:     &common.Role{Id: "root-role", Name: "Root Role"},
+		Parent:   parent,
+		Children: []*rbac.RoleHierarchy{child},
+		Depth:    0,
+	}
+
+	proto := s.convertToProtoHierarchy(hierarchy)
+
+	require.NotNil(t, proto)
+	assert.Equal(t, "root-role", proto.Role.Id)
+	assert.Equal(t, int32(0), proto.Depth)
+	require.NotNil(t, proto.Parent)
+	assert.Equal(t, "parent-role", proto.Parent.Role.Id)
+	assert.Equal(t, int32(1), proto.Parent.Depth)
+	require.Len(t, proto.Children, 1)
+	assert.Equal(t, "child-role", proto.Children[0].Role.Id)
+	assert.Equal(t, int32(0), proto.Children[0].Depth) // -1 clamped to 0
+}
+
+func TestRBACService_ConvertToProtoHierarchy_Nil(t *testing.T) {
+	s := &RBACService{}
+	assert.Nil(t, s.convertToProtoHierarchy(nil))
+}
+
+func TestRBACService_ConvertToProtoEffectivePermissions(t *testing.T) {
+	s := &RBACService{}
+
+	computedAt := time.Unix(1234567890, 0)
+	directPerm := &common.Permission{Id: "perm.read", Name: "Read"}
+	inheritedPerm := &common.Permission{Id: "perm.write", Name: "Write"}
+
+	effectivePerms := &rbac.EffectivePermissions{
+		RoleID:            "role-123",
+		DirectPermissions: []*common.Permission{directPerm},
+		InheritedPermissions: map[string][]*common.Permission{
+			"parent-role": {inheritedPerm},
+		},
+		ComputedAt: computedAt,
+	}
+
+	proto := s.convertToProtoEffectivePermissions(effectivePerms)
+
+	require.NotNil(t, proto)
+	assert.Equal(t, "role-123", proto.RoleId)
+	require.Len(t, proto.DirectPermissions, 1)
+	assert.Equal(t, "perm.read", proto.DirectPermissions[0].Id)
+	require.Contains(t, proto.InheritedPermissions, "parent-role")
+	require.Len(t, proto.InheritedPermissions["parent-role"].Permissions, 1)
+	assert.Equal(t, "perm.write", proto.InheritedPermissions["parent-role"].Permissions[0].Id)
+	assert.Equal(t, computedAt.Unix(), proto.ComputedAt)
+}
+
+func TestRBACService_ConvertToProtoEffectivePermissions_Nil(t *testing.T) {
+	s := &RBACService{}
+	assert.Nil(t, s.convertToProtoEffectivePermissions(nil))
+}
+
 func TestRBACService_Integration(t *testing.T) {
 	// Setup RBAC manager and service with git storage
 	tmpDir := t.TempDir()

--- a/features/rbac/types.go
+++ b/features/rbac/types.go
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+package rbac
+
+import "github.com/cfgis/cfgms/features/rbac/memory"
+
+// RoleHierarchy exposes the memory-layer type at the rbac package boundary so
+// callers outside this feature do not need to import features/rbac/memory directly.
+type RoleHierarchy = memory.RoleHierarchy
+
+// EffectivePermissions exposes the memory-layer type at the rbac package boundary
+// for the same reason.
+type EffectivePermissions = memory.EffectivePermissions

--- a/features/workflow/engine.go
+++ b/features/workflow/engine.go
@@ -30,15 +30,15 @@ type TransformStepExecutor interface {
 
 // Engine implements the WorkflowEngine interface
 type Engine struct {
-	moduleFactory    *factory.ModuleFactory
-	logger           *logging.ModuleLogger
-	executions       map[string]*WorkflowExecution
-	mutex            sync.RWMutex
-	httpClient       *HTTPClient
-	providerRegistry *ProviderRegistry
-	errorHandler     ErrorHandler
-	syncManager      *SyncManager
-	debugEngine      *DebugEngineImpl
+	moduleFactory     *factory.ModuleFactory
+	logger            *logging.ModuleLogger
+	executions        map[string]*WorkflowExecution
+	mutex             sync.RWMutex
+	httpClient        *HTTPClient
+	providerRegistry  *ProviderRegistry
+	errorHandler      ErrorHandler
+	syncManager       *SyncManager
+	debugEngine       *DebugEngineImpl
 	transformExecutor TransformStepExecutor
 }
 
@@ -65,13 +65,13 @@ func NewEngine(moduleFactory *factory.ModuleFactory, logger logging.Logger, tran
 	providerRegistry := NewProviderRegistry(logger) // Keep legacy for now
 
 	engine := &Engine{
-		moduleFactory:    moduleFactory,
-		logger:           workflowLogger,
-		executions:       make(map[string]*WorkflowExecution),
-		httpClient:       httpClient,
-		providerRegistry: providerRegistry,
-		errorHandler:     NewDefaultErrorHandler(),
-		syncManager:      NewSyncManager(),
+		moduleFactory:     moduleFactory,
+		logger:            workflowLogger,
+		executions:        make(map[string]*WorkflowExecution),
+		httpClient:        httpClient,
+		providerRegistry:  providerRegistry,
+		errorHandler:      NewDefaultErrorHandler(),
+		syncManager:       NewSyncManager(),
 		transformExecutor: transformExecutor,
 	}
 


### PR DESCRIPTION
## Summary

- Created `features/rbac/types.go` with type aliases `RoleHierarchy = memory.RoleHierarchy` and `EffectivePermissions = memory.EffectivePermissions` at the `rbac` package boundary
- Removed the direct `features/rbac/memory` import from `features/controller/service/rbac_service.go`; updated `convertToProtoHierarchy` and `convertToProtoEffectivePermissions` parameter types to use `*rbac.RoleHierarchy` and `*rbac.EffectivePermissions`
- Added 4 unit tests covering both converters (roundtrip, nil-input guards, effective permissions field mappings)
- Fixed a pre-existing `gofmt` struct-alignment violation in `features/workflow/engine.go` that was blocking the lint gate

Fixes #1099

## Specialist Review Results

| Agent | Result |
|-------|--------|
| qa-test-runner | **PASS** — all 4 new unit tests + 5 integration subtests pass; lint clean; architecture compliant |
| qa-code-reviewer | **PASS** — no mocks, no t.Skip(), nil guards verified, Depth:-1 clamp path exercised, effective permissions fully covered |
| security-engineer | **PASS** — no new findings; import cycle verified absent; gosec/staticcheck clean on changed files |

## Test plan

- [ ] `grep '"github.com/cfgis/cfgms/features/rbac/memory"' features/controller/service/rbac_service.go` returns no matches
- [ ] `features/rbac/types.go` exists with aliases for `RoleHierarchy` and `EffectivePermissions`
- [ ] `TestRBACService_ConvertToProtoHierarchy_Roundtrip` passes
- [ ] `TestRBACService_ConvertToProtoHierarchy_Nil` passes
- [ ] `TestRBACService_ConvertToProtoEffectivePermissions` passes
- [ ] `TestRBACService_ConvertToProtoEffectivePermissions_Nil` passes
- [ ] All CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)