### PR TITLE
workflow: enforce MaxAttempts retry loop in executeStepsWithRetry (Issue #1084)

### DIFF
--- a/features/workflow/engine.go
+++ b/features/workflow/engine.go
@@ -10,6 +10,8 @@ import (
 	"sync/atomic"
 	"time"
 
+	"gopkg.in/yaml.v3"
+
 	"github.com/cfgis/cfgms/features/modules"
 	"github.com/cfgis/cfgms/features/steward/factory"
 	"github.com/cfgis/cfgms/pkg/logging"
@@ -30,15 +32,15 @@ type TransformStepExecutor interface {
 
 // Engine implements the WorkflowEngine interface
 type Engine struct {
-	moduleFactory    *factory.ModuleFactory
-	logger           *logging.ModuleLogger
-	executions       map[string]*WorkflowExecution
-	mutex            sync.RWMutex
-	httpClient       *HTTPClient
-	providerRegistry *ProviderRegistry
-	errorHandler     ErrorHandler
-	syncManager      *SyncManager
-	debugEngine      *DebugEngineImpl
+	moduleFactory     *factory.ModuleFactory
+	logger            *logging.ModuleLogger
+	executions        map[string]*WorkflowExecution
+	mutex             sync.RWMutex
+	httpClient        *HTTPClient
+	providerRegistry  *ProviderRegistry
+	errorHandler      ErrorHandler
+	syncManager       *SyncManager
+	debugEngine       *DebugEngineImpl
 	transformExecutor TransformStepExecutor
 }
 
@@ -65,13 +67,13 @@ func NewEngine(moduleFactory *factory.ModuleFactory, logger logging.Logger, tran
 	providerRegistry := NewProviderRegistry(logger) // Keep legacy for now
 
 	engine := &Engine{
-		moduleFactory:    moduleFactory,
-		logger:           workflowLogger,
-		executions:       make(map[string]*WorkflowExecution),
-		httpClient:       httpClient,
-		providerRegistry: providerRegistry,
-		errorHandler:     NewDefaultErrorHandler(),
-		syncManager:      NewSyncManager(),
+		moduleFactory:     moduleFactory,
+		logger:            workflowLogger,
+		executions:        make(map[string]*WorkflowExecution),
+		httpClient:        httpClient,
+		providerRegistry:  providerRegistry,
+		errorHandler:      NewDefaultErrorHandler(),
+		syncManager:       NewSyncManager(),
 		transformExecutor: transformExecutor,
 	}
 
@@ -255,24 +257,50 @@ func (e *Engine) executeStepsWithRetry(ctx context.Context, steps []Step, execut
 							"decision", decision.Message)
 						continue
 					case ErrorActionRetry:
-						// Implement retry with backoff
-						if decision.RetryDelay > 0 {
-							e.logger.Info("Retrying step after delay",
+						// enableRetry=false in try/catch blocks — retry loop must not activate
+						retryConfig := retryConfigForStep(step)
+						if retryConfig == nil || retryConfig.MaxAttempts <= 1 {
+							return workflowErr
+						}
+						var lastRetryErr error = workflowErr
+						for attempt := 1; e.errorHandler.ShouldRetry(workflowErr, attempt, retryConfig); attempt++ {
+							delay := e.errorHandler.CalculateRetryDelay(attempt-1, retryConfig)
+							if delay > 0 {
+								e.logger.Info("Retrying step after delay",
+									"step", step.Name,
+									"delay", delay,
+									"attempt", attempt)
+								select {
+								case <-ctx.Done():
+									return ctx.Err()
+								case <-time.After(delay):
+								}
+							}
+							e.logger.Info("Retrying failed step",
 								"step", step.Name,
-								"delay", decision.RetryDelay,
-								"decision", decision.Message)
-							select {
-							case <-ctx.Done():
-								return ctx.Err()
-							case <-time.After(decision.RetryDelay):
+								"attempt", attempt)
+							lastRetryErr = e.executeStep(ctx, step, execution)
+							if result, exists := execution.GetStepResult(step.Name); exists {
+								result.RetryCount = attempt
+								execution.SetStepResult(step.Name, result)
+							}
+							if lastRetryErr == nil {
+								break
+							}
+							if wfErr, ok := lastRetryErr.(*WorkflowError); ok {
+								workflowErr = wfErr
+							} else {
+								workflowErr = NewWorkflowError(
+									ErrorCodeStepExecution,
+									lastRetryErr.Error(),
+									step.Name,
+									step.Type,
+									lastRetryErr,
+								).WithVariableState(execution.Variables)
 							}
 						}
-						// Retry the step (this would need more sophisticated retry tracking)
-						e.logger.Info("Retrying failed step",
-							"step", step.Name,
-							"decision", decision.Message)
-						if retryErr := e.executeStep(ctx, step, execution); retryErr != nil {
-							return workflowErr // Return original error if retry fails
+						if lastRetryErr != nil {
+							return workflowErr
 						}
 					case ErrorActionContinueWith:
 						targetName := decision.ContinueWith
@@ -818,13 +846,11 @@ func (g *genericConfigState) AsMap() map[string]interface{} {
 }
 
 func (g *genericConfigState) ToYAML() ([]byte, error) {
-	// This would use yaml.Marshal in a real implementation
-	return []byte("workflow yaml"), nil
+	return yaml.Marshal(g.data)
 }
 
 func (g *genericConfigState) FromYAML(data []byte) error {
-	// This would use yaml.Unmarshal in a real implementation
-	return nil
+	return yaml.Unmarshal(data, &g.data)
 }
 
 func (g *genericConfigState) Validate() error {
@@ -1205,4 +1231,24 @@ type fanOutResult struct {
 	Value      interface{}
 	StepResult interface{}
 	Error      error
+}
+
+// retryConfigForStep returns the RetryConfig for a step from its type-specific config,
+// or nil if the step type carries no retry config (e.g. StepTypeTask, StepTypeSequential).
+func retryConfigForStep(step Step) *RetryConfig {
+	switch step.Type {
+	case StepTypeHTTP:
+		if step.HTTP != nil {
+			return step.HTTP.Retry
+		}
+	case StepTypeAPI:
+		if step.API != nil {
+			return step.API.Retry
+		}
+	case StepTypeWebhook:
+		if step.Webhook != nil {
+			return step.Webhook.Retry
+		}
+	}
+	return nil
 }

--- a/features/workflow/engine_test.go
+++ b/features/workflow/engine_test.go
@@ -5,6 +5,9 @@ package workflow
 import (
 	"context"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -88,7 +91,7 @@ func TestEngine_ExecuteWorkflow_Simple(t *testing.T) {
 	// Check final status
 	finalExecution, err := engine.GetExecution(execution.ID)
 	require.NoError(t, err)
-	assert.Contains(t, []ExecutionStatus{StatusCompleted, StatusFailed}, finalExecution.GetStatus())
+	assert.Equal(t, StatusCompleted, finalExecution.GetStatus())
 }
 
 func TestEngine_ExecuteWorkflow_Parallel(t *testing.T) {
@@ -142,7 +145,7 @@ func TestEngine_ExecuteWorkflow_Parallel(t *testing.T) {
 
 	finalExecution, err := engine.GetExecution(execution.ID)
 	require.NoError(t, err)
-	assert.Contains(t, []ExecutionStatus{StatusCompleted, StatusFailed}, finalExecution.GetStatus())
+	assert.Equal(t, StatusCompleted, finalExecution.GetStatus())
 }
 
 func TestEngine_CancelExecution(t *testing.T) {
@@ -330,6 +333,7 @@ func (e *testTransformExecutor) ExecuteTransformStep(_ context.Context, _ Step, 
 }
 
 // testErrorHandler is a test implementation of ErrorHandler that always returns a fixed decision.
+// ShouldRetry always returns false — use testRetryDecisionHandler when ShouldRetry must return true.
 type testErrorHandler struct {
 	decision ErrorHandlingDecision
 }
@@ -343,6 +347,28 @@ func (h *testErrorHandler) ShouldRetry(_ *WorkflowError, _ int, _ *RetryConfig) 
 }
 
 func (h *testErrorHandler) CalculateRetryDelay(_ int, _ *RetryConfig) time.Duration {
+	return 0
+}
+
+// testRetryDecisionHandler returns a fixed HandleError decision and implements ShouldRetry
+// using real retry-count logic so tests can detect whether the retry loop was entered.
+type testRetryDecisionHandler struct {
+	decision    ErrorHandlingDecision
+	maxAttempts int
+}
+
+func (h *testRetryDecisionHandler) HandleError(_ context.Context, _ *WorkflowError, _ *WorkflowExecution) ErrorHandlingDecision {
+	return h.decision
+}
+
+func (h *testRetryDecisionHandler) ShouldRetry(err *WorkflowError, retryCount int, config *RetryConfig) bool {
+	if config != nil {
+		return retryCount < config.MaxAttempts && err.Recoverable
+	}
+	return retryCount < h.maxAttempts && err.Recoverable
+}
+
+func (h *testRetryDecisionHandler) CalculateRetryDelay(_ int, _ *RetryConfig) time.Duration {
 	return 0
 }
 
@@ -500,4 +526,146 @@ func TestFallbackStepExecution(t *testing.T) {
 
 	results := final.GetStepResults()
 	assert.Contains(t, results, "fallback-step")
+}
+
+// TestRetryMaxAttempts verifies that executeStepsWithRetry loops up to
+// retryConfigForStep(step).MaxAttempts on ErrorActionRetry and writes the
+// attempt count to StepResult.RetryCount.
+//
+// The server fails the first two executeHTTPStep calls completely (all MaxAttempts
+// HTTP-client-level retries return 500), then succeeds on the third call.
+// With MaxAttempts=3: initial + 2 retries = 3 total invocations, RetryCount=2.
+func TestRetryMaxAttempts(t *testing.T) {
+	const maxAttempts = 3
+	// Each failed executeHTTPStep call exhausts all maxAttempts HTTP-client retries.
+	// failedCalls=2 means the server must return 500 for (maxAttempts*2) requests,
+	// then 200 from request (maxAttempts*2 + 1) onward.
+	const failedCalls = 2
+	var requestCount int32
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := int(atomic.AddInt32(&requestCount, 1))
+		if n <= maxAttempts*failedCalls {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		if _, err := w.Write([]byte(`{}`)); err != nil {
+			t.Logf("write error: %v", err)
+		}
+	}))
+	defer server.Close()
+
+	factory := createTestFactory()
+	logger := pkgtesting.NewMockLogger(true)
+	engine := NewEngine(factory, logger, nil)
+	// Use zero delays so the test runs instantly.
+	engine.errorHandler = &DefaultErrorHandler{
+		MaxRetries:        maxAttempts,
+		BaseDelay:         0,
+		MaxDelay:          0,
+		BackoffMultiplier: 1.0,
+	}
+
+	wf := Workflow{
+		Name: "retry-max-attempts-test",
+		Steps: []Step{
+			{
+				Name: "http-retry-step",
+				Type: StepTypeHTTP,
+				HTTP: &HTTPConfig{
+					URL:    server.URL,
+					Method: "GET",
+					Retry: &RetryConfig{
+						MaxAttempts:       maxAttempts,
+						InitialDelay:      0,
+						MaxDelay:          0,
+						BackoffMultiplier: 1.0,
+					},
+				},
+			},
+		},
+	}
+
+	ctx := context.Background()
+	execution, err := engine.ExecuteWorkflow(ctx, wf, nil)
+	require.NoError(t, err)
+
+	waitForWorkflowCompletion(t, execution, 5*time.Second)
+
+	final, err := engine.GetExecution(execution.ID)
+	require.NoError(t, err)
+	assert.Equal(t, StatusCompleted, final.GetStatus(), "workflow should complete successfully after retries")
+
+	stepResults := final.GetStepResults()
+	result, exists := stepResults["http-retry-step"]
+	require.True(t, exists, "step result must exist")
+	assert.Equal(t, 2, result.RetryCount, "RetryCount should be 2 (failed twice, succeeded on third attempt)")
+}
+
+// TestRetryNilConfig verifies that when retryConfigForStep returns nil (step type
+// has no Retry field), a step failure returns the error immediately without retrying.
+//
+// The error handler's ShouldRetry returns true (would allow retries if the nil guard
+// were absent), so RetryCount == 0 proves the nil guard fired and prevented the loop.
+func TestRetryNilConfig(t *testing.T) {
+	factory := createTestFactory()
+	logger := pkgtesting.NewMockLogger(true)
+	exec := &testTransformExecutor{
+		result: StepResult{Status: StatusFailed},
+		err:    fmt.Errorf("step error"),
+	}
+	engine := NewEngine(factory, logger, exec)
+	// ShouldRetry returns true (up to 5 attempts) — without the nil guard this handler
+	// would cause the loop to run, resulting in RetryCount > 0.
+	engine.errorHandler = &testRetryDecisionHandler{
+		decision:    ErrorHandlingDecision{Action: ErrorActionRetry},
+		maxAttempts: 5,
+	}
+
+	wf := Workflow{
+		Name: "nil-retry-config-test",
+		Steps: []Step{
+			// StepTypeTransform has no Retry field → retryConfigForStep returns nil.
+			{Name: "transform-step", Type: StepTypeTransform},
+		},
+	}
+
+	ctx := context.Background()
+	execution, err := engine.ExecuteWorkflow(ctx, wf, nil)
+	require.NoError(t, err)
+
+	waitForWorkflowCompletion(t, execution, 2*time.Second)
+
+	final, err := engine.GetExecution(execution.ID)
+	require.NoError(t, err)
+	assert.Equal(t, StatusFailed, final.GetStatus(), "workflow must fail when step has no retry config")
+
+	stepResults := final.GetStepResults()
+	result, exists := stepResults["transform-step"]
+	require.True(t, exists, "step result must exist")
+	assert.Equal(t, 0, result.RetryCount, "nil retryConfig must prevent the retry loop (RetryCount must be 0)")
+}
+
+// TestGenericConfigStateYAMLRoundTrip verifies that genericConfigState.ToYAML
+// produces valid YAML from the data map, and FromYAML restores the original values.
+func TestGenericConfigStateYAMLRoundTrip(t *testing.T) {
+	g := &genericConfigState{
+		data: map[string]interface{}{
+			"env":   "prod",
+			"count": 3,
+		},
+	}
+
+	yamlData, err := g.ToYAML()
+	require.NoError(t, err)
+	require.NotNil(t, yamlData)
+	assert.NotEqual(t, []byte("workflow yaml"), yamlData, "ToYAML must not return the stub value")
+
+	g2 := &genericConfigState{}
+	err = g2.FromYAML(yamlData)
+	require.NoError(t, err)
+
+	assert.Equal(t, "prod", g2.data["env"])
+	assert.EqualValues(t, 3, g2.data["count"])
 }


### PR DESCRIPTION
## Summary

- Replaces single-attempt `ErrorActionRetry` branch with a proper retry loop bounded by `errorHandler.ShouldRetry(workflowErr, attempt, retryConfig)` and `MaxAttempts` from the step's typed config
- Adds `retryConfigForStep` helper that reads `*RetryConfig` from `step.HTTP.Retry`, `step.API.Retry`, or `step.Webhook.Retry` (returns nil for all other types)
- Fixes `genericConfigState.ToYAML`/`FromYAML` stubs: now uses `yaml.Marshal(g.data)` and `yaml.Unmarshal(data, &g.data)` via `gopkg.in/yaml.v3`
- Writes `StepResult.RetryCount` per attempt via `GetStepResult`/`SetStepResult`
- `enableRetry=false` invariant (try/catch context) preserved unchanged with comment

## Test plan

- [x] `TestRetryMaxAttempts` — HTTP step with `MaxAttempts=3`, fails twice then succeeds; asserts `RetryCount==2`, `StatusCompleted`
- [x] `TestRetryNilConfig` — transform step (no Retry field); handler's `ShouldRetry` returns `true`, nil guard fires; asserts `RetryCount==0`, `StatusFailed`
- [x] `TestGenericConfigStateYAMLRoundTrip` — marshals `{"env":"prod","count":3}`, unmarshals, asserts both fields equal
- [x] Pre-existing `assert.Contains(StatusCompleted|StatusFailed)` patterns tightened to `assert.Equal(StatusCompleted)`
- [x] Full `make test-agent-complete` passes (all unit tests, lint=0 issues, arch check, cross-platform builds)

## Specialist Review Results

- **QA Test Runner**: PASS — unit tests, golangci-lint (0 issues), license headers, arch check, cross-platform compilation all green; Trivy DB download blocked by container network (environmental, not code)
- **QA Code Reviewer**: PASS — no mocks, no t.Skip(), no hacky workarounds, error path tested, retry guard falsifiable
- **Security Engineer**: PASS — no hardcoded secrets, no central provider violations, no TLS misuse, no SQL injection; gosec/staticcheck findings all pre-existing on develop

Fixes #1084

🤖 Generated with [Claude Code](https://claude.com/claude-code)