### PR TITLE
controller: rename BasicStorageStats to UnimplementedStorageStats with sentinel values (Issue #1100)

### DIFF
--- a/features/controller/server/health_adapters.go
+++ b/features/controller/server/health_adapters.go
@@ -83,30 +83,36 @@ func (a *GRPCTransportStatsAdapter) GetAvgLatency() time.Duration {
 	return stats.AvgLatency
 }
 
-// BasicStorageStats implements health.StorageProviderStats with the provider
-// name and zero metrics. Real latency instrumentation is a follow-up.
-type BasicStorageStats struct {
+// UnimplementedStorageStats implements health.StorageProviderStats with sentinel
+// values (-1) that are distinguishable from real zero measurements. Implemented()
+// returns false so callers can skip or annotate these metrics accordingly.
+type UnimplementedStorageStats struct {
 	providerName string
 }
 
-// NewBasicStorageStats creates a BasicStorageStats for the given provider.
-func NewBasicStorageStats(providerName string) *BasicStorageStats {
-	return &BasicStorageStats{providerName: providerName}
+// NewUnimplementedStorageStats creates an UnimplementedStorageStats for the given provider.
+func NewUnimplementedStorageStats(providerName string) *UnimplementedStorageStats {
+	return &UnimplementedStorageStats{providerName: providerName}
+}
+
+// Implemented returns false — storage metrics are not yet instrumented.
+func (s *UnimplementedStorageStats) Implemented() bool {
+	return false
 }
 
 // GetProviderName returns the storage provider name.
-func (s *BasicStorageStats) GetProviderName() string {
+func (s *UnimplementedStorageStats) GetProviderName() string {
 	return s.providerName
 }
 
-// GetPoolUtilization returns 0 (not instrumented yet).
-func (s *BasicStorageStats) GetPoolUtilization() float64 {
-	return 0
+// GetPoolUtilization returns -1.0 (sentinel: not instrumented).
+func (s *UnimplementedStorageStats) GetPoolUtilization() float64 {
+	return -1.0
 }
 
-// GetQueryMetrics returns zeros (not instrumented yet).
-func (s *BasicStorageStats) GetQueryMetrics() (avgLatencyMs, p95LatencyMs float64, totalQueries, slowQueries, queryErrors int64) {
-	return 0, 0, 0, 0, 0
+// GetQueryMetrics returns -1 for all values (sentinel: not instrumented).
+func (s *UnimplementedStorageStats) GetQueryMetrics() (avgLatencyMs, p95LatencyMs float64, totalQueries, slowQueries, queryErrors int64) {
+	return -1, -1, -1, -1, -1
 }
 
 // NoOpApplicationQueueStats implements health.ApplicationQueueStats returning

--- a/features/controller/server/health_adapters_test.go
+++ b/features/controller/server/health_adapters_test.go
@@ -102,18 +102,19 @@ func TestGRPCTransportStatsAdapter_NoReconnectAttemptsKey(t *testing.T) {
 	assert.Equal(t, int64(0), adapter.GetReconnectionAttempts())
 }
 
-func TestBasicStorageStats_ReturnsProviderName(t *testing.T) {
-	stats := NewBasicStorageStats("git")
+func TestUnimplementedStorageStats_ReportsUnimplemented(t *testing.T) {
+	stats := NewUnimplementedStorageStats("git")
 
 	require.Equal(t, "git", stats.GetProviderName())
-	assert.Equal(t, float64(0), stats.GetPoolUtilization())
+	assert.False(t, stats.Implemented())
+	assert.Equal(t, -1.0, stats.GetPoolUtilization())
 
 	avg, p95, total, slow, errors := stats.GetQueryMetrics()
-	assert.Equal(t, float64(0), avg)
-	assert.Equal(t, float64(0), p95)
-	assert.Equal(t, int64(0), total)
-	assert.Equal(t, int64(0), slow)
-	assert.Equal(t, int64(0), errors)
+	assert.Equal(t, -1.0, avg)
+	assert.Equal(t, -1.0, p95)
+	assert.Equal(t, int64(-1), total)
+	assert.Equal(t, int64(-1), slow)
+	assert.Equal(t, int64(-1), errors)
 }
 
 func TestNoOpApplicationQueueStats_ReturnsZeros(t *testing.T) {

--- a/features/controller/server/server.go
+++ b/features/controller/server/server.go
@@ -489,7 +489,7 @@ func New(cfg *config.Config, logger logging.Logger) (*Server, error) {
 		}
 
 		// Storage stats — provider name only, latency instrumentation is follow-up
-		storageStats := NewBasicStorageStats(cfg.Storage.Provider)
+		storageStats := NewUnimplementedStorageStats(cfg.Storage.Provider)
 		storageCollector := health.NewDefaultStorageCollector(storageStats)
 
 		// Application stats — uses no-op queue stats; workflow engine health


### PR DESCRIPTION
## Summary

- Renamed `BasicStorageStats` → `UnimplementedStorageStats` and `NewBasicStorageStats` → `NewUnimplementedStorageStats` in `health_adapters.go`
- Added `Implemented() bool` method returning `false` (machine-detectable "not wired up" state)
- Changed `GetPoolUtilization()` to return `-1.0` sentinel (was `0`, indistinguishable from a real zero measurement)
- Changed `GetQueryMetrics()` to return `-1,-1,-1,-1,-1` sentinels (was all zeros)
- Updated call site in `server.go`
- Replaced `TestBasicStorageStats_ReturnsProviderName` with `TestUnimplementedStorageStats_ReportsUnimplemented` asserting all sentinel values and `Implemented() == false`

Closes #1100

## Specialist Review Results

| Reviewer | Result |
|----------|--------|
| QA Test Runner | **PASS** — 79 packages, 0 failures; race detection enabled |
| QA Code Reviewer | **PASS** — 0 blocking issues |
| Security Engineer | **PASS** — 0 blocking issues; gosec 0 issues on changed package; architecture check clean |

## Test plan

- [x] `go test ./features/controller/server/...` passes locally
- [x] `TestUnimplementedStorageStats_ReportsUnimplemented` asserts `Implemented() == false`, `GetPoolUtilization() == -1.0`, all `GetQueryMetrics()` values == `-1`
- [x] `make test-agent-complete` passed (79 packages, 0 failures)
- [x] Architecture check passed (no central provider violations)

🤖 Generated with [Claude Code](https://claude.com/claude-code)