### PR TITLE
workflow: wire trigger persistence with pkg/secrets credential extraction (Issue #1089)

### DIFF
--- a/features/siem/siem_engine_test.go
+++ b/features/siem/siem_engine_test.go
@@ -45,7 +45,7 @@ func newTestTriggerManager(tb testing.TB, wt trigger.WorkflowTrigger) *trigger.T
 	tb.Helper()
 	provider, err := storageInterfaces.GetStorageProvider("flatfile")
 	require.NoError(tb, err, "flatfile provider must be registered via blank import in stream_processor_test.go")
-	return trigger.NewTriggerManager(provider, nil, nil, nil, wt)
+	return trigger.NewTriggerManager(provider, nil, nil, nil, wt, nil)
 }
 
 // Test helper functions

--- a/features/workflow/trigger/controller_factory.go
+++ b/features/workflow/trigger/controller_factory.go
@@ -18,7 +18,7 @@ func NewControllerTriggerManager(
 ) *TriggerManagerImpl {
 	// Phase 1: Create the manager with nil components to break the circular dependency.
 	// The manager's Start() guards against nil components, so this is safe during wiring.
-	manager := NewTriggerManager(storage, nil, nil, nil, workflowTrigger)
+	manager := NewTriggerManager(storage, nil, nil, nil, workflowTrigger, nil)
 
 	// Phase 2: Create each component with the manager reference.
 	scheduler := NewCronScheduler(manager, workflowTrigger)

--- a/features/workflow/trigger/integration_test.go
+++ b/features/workflow/trigger/integration_test.go
@@ -32,6 +32,8 @@ type IntegrationTestSuite struct {
 	apiHandler      *APIHandler
 	workflowTrigger *TestWorkflowTrigger
 	storage         *TestStorageProvider
+	triggerStore    *inMemoryTriggerStore
+	secretStore     *inMemorySecretStore
 	router          *mux.Router
 	server          *httptest.Server
 }
@@ -149,7 +151,7 @@ func (t *TestStorageProvider) CreateCommandStore(_ map[string]interface{}) (busi
 }
 
 func (t *TestStorageProvider) CreateTriggerStore(_ map[string]interface{}) (business.TriggerStore, error) {
-	return nil, business.ErrNotSupported
+	return newInMemoryTriggerStore(), nil
 }
 
 func (t *TestStorageProvider) GetCapabilities() interfaces.ProviderCapabilities {
@@ -220,6 +222,7 @@ func setupIntegrationTest(t *testing.T) *IntegrationTestSuite {
 	// Create components
 	storage := NewTestStorageProvider()
 	workflowTrigger := NewTestWorkflowTrigger()
+	secretStore := newInMemorySecretStore()
 
 	// Create manager first (we'll create scheduler separately)
 	manager := NewTriggerManager(
@@ -228,6 +231,7 @@ func setupIntegrationTest(t *testing.T) *IntegrationTestSuite {
 		nil, // webhook handler will be set later
 		nil, // siem integration will be set later
 		workflowTrigger,
+		secretStore,
 	)
 
 	// Create scheduler
@@ -257,6 +261,12 @@ func setupIntegrationTest(t *testing.T) *IntegrationTestSuite {
 	// Create test server
 	server := httptest.NewServer(router)
 
+	// Capture the trigger store created by NewTriggerManager for assertion use in tests.
+	var ts *inMemoryTriggerStore
+	if manager.triggerStore != nil {
+		ts = manager.triggerStore.(*inMemoryTriggerStore)
+	}
+
 	return &IntegrationTestSuite{
 		manager:         manager,
 		scheduler:       scheduler,
@@ -265,6 +275,8 @@ func setupIntegrationTest(t *testing.T) *IntegrationTestSuite {
 		apiHandler:      apiHandler,
 		workflowTrigger: workflowTrigger,
 		storage:         storage,
+		triggerStore:    ts,
+		secretStore:     secretStore,
 		router:          router,
 		server:          server,
 	}
@@ -659,40 +671,28 @@ func TestTriggerSystem_FullIntegration(t *testing.T) {
 		err := suite.manager.CreateTrigger(ctx, trigger)
 		require.NoError(t, err)
 
-		// Verify it's stored
-		exists, err := suite.storage.Exists(ctx, "triggers/persistence-test-1")
+		// Verify it's stored via TriggerStore (the authoritative persistence layer).
+		rec, err := suite.triggerStore.GetTrigger(ctx, "persistence-test-1")
 		require.NoError(t, err)
-		assert.True(t, exists)
-
-		// Retrieve from storage directly
-		data, err := suite.storage.Retrieve(ctx, "triggers/persistence-test-1")
-		require.NoError(t, err)
-
-		var storedTrigger Trigger
-		err = json.Unmarshal(data, &storedTrigger)
-		require.NoError(t, err)
-		assert.Equal(t, trigger.ID, storedTrigger.ID)
-		assert.Equal(t, trigger.Name, storedTrigger.Name)
+		assert.Equal(t, trigger.ID, rec.ID)
+		assert.Equal(t, trigger.Name, rec.Name)
 
 		// Update trigger
 		trigger.Name = "Updated Persistence Test"
 		err = suite.manager.UpdateTrigger(ctx, trigger)
 		require.NoError(t, err)
 
-		// Verify update is persisted
-		data, err = suite.storage.Retrieve(ctx, "triggers/persistence-test-1")
+		// Verify update is persisted.
+		rec, err = suite.triggerStore.GetTrigger(ctx, "persistence-test-1")
 		require.NoError(t, err)
-		err = json.Unmarshal(data, &storedTrigger)
-		require.NoError(t, err)
-		assert.Equal(t, "Updated Persistence Test", storedTrigger.Name)
+		assert.Equal(t, "Updated Persistence Test", rec.Name)
 
 		// Delete trigger
 		err = suite.manager.DeleteTrigger(ctx, trigger.ID)
 		require.NoError(t, err)
 
-		// Verify deletion from storage
-		exists, err = suite.storage.Exists(ctx, "triggers/persistence-test-1")
-		require.NoError(t, err)
-		assert.False(t, exists)
+		// Verify deletion from TriggerStore.
+		_, err = suite.triggerStore.GetTrigger(ctx, "persistence-test-1")
+		assert.ErrorIs(t, err, business.ErrTriggerNotFound)
 	})
 }

--- a/features/workflow/trigger/manager.go
+++ b/features/workflow/trigger/manager.go
@@ -5,6 +5,7 @@ package trigger
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"sync"
 	"time"
@@ -12,7 +13,9 @@ import (
 	"github.com/google/uuid"
 
 	"github.com/cfgis/cfgms/pkg/logging"
+	secretsif "github.com/cfgis/cfgms/pkg/secrets/interfaces"
 	"github.com/cfgis/cfgms/pkg/storage/interfaces"
+	business "github.com/cfgis/cfgms/pkg/storage/interfaces/business"
 )
 
 // extractTenantFromContext extracts tenant ID from context, trying both logging and trigger context keys
@@ -36,6 +39,8 @@ func extractTenantFromContext(ctx context.Context) string {
 type TriggerManagerImpl struct {
 	logger          *logging.ModuleLogger
 	storage         interfaces.StorageProvider
+	triggerStore    business.TriggerStore
+	secretStore     secretsif.SecretStore
 	scheduler       Scheduler
 	webhookHandler  WebhookHandler
 	siemIntegration SIEMIntegration
@@ -53,12 +58,28 @@ func NewTriggerManager(
 	webhookHandler WebhookHandler,
 	siemIntegration SIEMIntegration,
 	workflowTrigger WorkflowTrigger,
+	secretStore secretsif.SecretStore,
 ) *TriggerManagerImpl {
 	logger := logging.ForModule("workflow.trigger.manager").WithField("component", "manager")
+
+	var triggerStore business.TriggerStore
+	if storage != nil {
+		ts, err := storage.CreateTriggerStore(nil)
+		if err != nil {
+			if !errors.Is(err, business.ErrNotSupported) {
+				logger.Warn("failed to initialize trigger store", "error", err.Error())
+			}
+			// ErrNotSupported: provider does not implement trigger persistence — silent skip
+		} else {
+			triggerStore = ts
+		}
+	}
 
 	return &TriggerManagerImpl{
 		logger:          logger,
 		storage:         storage,
+		triggerStore:    triggerStore,
+		secretStore:     secretStore,
 		scheduler:       scheduler,
 		webhookHandler:  webhookHandler,
 		siemIntegration: siemIntegration,
@@ -809,73 +830,278 @@ func (tm *TriggerManagerImpl) matchesFilter(trigger *Trigger, filter *TriggerFil
 }
 
 func (tm *TriggerManagerImpl) loadTriggersFromStorage(ctx context.Context) error {
-	// TODO: Implement storage loading
-	// This would involve reading triggers from the configured storage provider
+	if tm.triggerStore == nil {
+		return nil
+	}
+
+	tenantID := extractTenantFromContext(ctx)
+	records, err := tm.triggerStore.ListTriggers(ctx, business.TriggerStoreFilter{TenantID: tenantID})
+	if err != nil {
+		return fmt.Errorf("failed to list triggers from storage: %w", err)
+	}
+
+	for _, record := range records {
+		trigger, restoreErr := tm.restoreTriggerFromRecord(ctx, record)
+		if restoreErr != nil {
+			// Degraded load: skip trigger whose creds cannot be recovered; warn already emitted inside.
+			continue
+		}
+		tm.triggers[record.ID] = trigger
+	}
+
 	return nil
 }
 
 func (tm *TriggerManagerImpl) saveTriggerToStorage(ctx context.Context, trigger *Trigger) error {
-	// No storage provider (e.g. composite OSS manager where GetProvider returns nil) — skip persistence.
-	if tm.storage == nil {
+	if tm.triggerStore == nil {
 		return nil
 	}
-	// Check if storage is available
-	available, err := tm.storage.Available()
+
+	record := &business.TriggerRecord{
+		ID:           trigger.ID,
+		TenantID:     trigger.TenantID,
+		Name:         trigger.Name,
+		Type:         string(trigger.Type),
+		Status:       string(trigger.Status),
+		WorkflowName: trigger.WorkflowName,
+		CreatedAt:    trigger.CreatedAt,
+		UpdatedAt:    trigger.UpdatedAt,
+	}
+
+	if trigger.Webhook != nil {
+		record.WebhookPath = trigger.Webhook.Path
+		record.WebhookMethod = trigger.Webhook.Method
+
+		if trigger.Webhook.Authentication != nil {
+			auth := trigger.Webhook.Authentication
+
+			if auth.BearerToken != "" {
+				if tm.secretStore == nil {
+					return fmt.Errorf("secret store required to persist trigger credentials")
+				}
+				refKey := fmt.Sprintf("trigger-%s-%s-bearer", trigger.TenantID, trigger.ID)
+				if err := tm.secretStore.StoreSecret(ctx, &secretsif.SecretRequest{
+					Key:      refKey,
+					Value:    auth.BearerToken,
+					TenantID: trigger.TenantID,
+				}); err != nil {
+					return fmt.Errorf("failed to store bearer token: %w", err)
+				}
+				record.BearerTokenRef = refKey
+			}
+
+			if auth.Secret != "" {
+				if tm.secretStore == nil {
+					return fmt.Errorf("secret store required to persist trigger credentials")
+				}
+				refKey := fmt.Sprintf("trigger-%s-%s-hmac-secret", trigger.TenantID, trigger.ID)
+				if err := tm.secretStore.StoreSecret(ctx, &secretsif.SecretRequest{
+					Key:      refKey,
+					Value:    auth.Secret,
+					TenantID: trigger.TenantID,
+				}); err != nil {
+					return fmt.Errorf("failed to store hmac secret: %w", err)
+				}
+				record.HMACSecretRef = refKey
+			}
+
+			if auth.APIKey != "" {
+				if tm.secretStore == nil {
+					return fmt.Errorf("secret store required to persist trigger credentials")
+				}
+				refKey := fmt.Sprintf("trigger-%s-%s-api-key", trigger.TenantID, trigger.ID)
+				if err := tm.secretStore.StoreSecret(ctx, &secretsif.SecretRequest{
+					Key:      refKey,
+					Value:    auth.APIKey,
+					TenantID: trigger.TenantID,
+				}); err != nil {
+					return fmt.Errorf("failed to store api key: %w", err)
+				}
+				record.APIKeyRef = refKey
+			}
+
+			if auth.BasicAuth != nil {
+				if auth.BasicAuth.Username != "" {
+					if tm.secretStore == nil {
+						return fmt.Errorf("secret store required to persist trigger credentials")
+					}
+					refKey := fmt.Sprintf("trigger-%s-%s-basic-user", trigger.TenantID, trigger.ID)
+					if err := tm.secretStore.StoreSecret(ctx, &secretsif.SecretRequest{
+						Key:      refKey,
+						Value:    auth.BasicAuth.Username,
+						TenantID: trigger.TenantID,
+					}); err != nil {
+						return fmt.Errorf("failed to store basic username: %w", err)
+					}
+					record.BasicUsernameRef = refKey
+				}
+
+				if auth.BasicAuth.Password != "" {
+					if tm.secretStore == nil {
+						return fmt.Errorf("secret store required to persist trigger credentials")
+					}
+					refKey := fmt.Sprintf("trigger-%s-%s-basic-pass", trigger.TenantID, trigger.ID)
+					if err := tm.secretStore.StoreSecret(ctx, &secretsif.SecretRequest{
+						Key:      refKey,
+						Value:    auth.BasicAuth.Password,
+						TenantID: trigger.TenantID,
+					}); err != nil {
+						return fmt.Errorf("failed to store basic password: %w", err)
+					}
+					record.BasicPasswordRef = refKey
+				}
+			}
+		}
+
+		// Serialize webhook config with Authentication zeroed out — no cleartext credentials in storage.
+		webhookClone := *trigger.Webhook
+		webhookClone.Authentication = nil
+		configBytes, err := json.Marshal(&webhookClone)
+		if err != nil {
+			return fmt.Errorf("failed to marshal webhook config: %w", err)
+		}
+		record.ConfigPayload = configBytes
+	}
+
+	return tm.triggerStore.StoreTrigger(ctx, record)
+}
+
+func (tm *TriggerManagerImpl) deleteTriggerFromStorage(ctx context.Context, triggerID string) error {
+	if tm.triggerStore == nil {
+		return nil
+	}
+
+	// Retrieve the record first so we know which secret refs to clean up.
+	record, err := tm.triggerStore.GetTrigger(ctx, triggerID)
 	if err != nil {
-		return fmt.Errorf("failed to check storage availability: %w", err)
-	}
-	if !available {
-		return fmt.Errorf("storage provider is not available")
-	}
-
-	// Convert trigger to JSON for storage
-	triggerData, err := json.Marshal(trigger)
-	if err != nil {
-		return fmt.Errorf("failed to marshal trigger: %w", err)
+		if errors.Is(err, business.ErrTriggerNotFound) {
+			// Already gone — treat as success (trigger may never have been persisted).
+			return nil
+		}
+		return fmt.Errorf("failed to fetch trigger record for deletion: %w", err)
 	}
 
-	// Try to use Store method if available (for testing with MockStorageProvider)
-	type storeInterface interface {
-		Store(context.Context, string, []byte) error
+	if err := tm.triggerStore.DeleteTrigger(ctx, triggerID); err != nil && !errors.Is(err, business.ErrTriggerNotFound) {
+		return fmt.Errorf("failed to delete trigger from store: %w", err)
 	}
 
-	if storer, ok := tm.storage.(storeInterface); ok {
-		storageKey := fmt.Sprintf("triggers/%s", trigger.ID)
-		if err := storer.Store(ctx, storageKey, triggerData); err != nil {
-			return fmt.Errorf("failed to store trigger: %w", err)
+	// Clean up secret refs; partial failure is non-critical (trigger record already deleted).
+	if tm.secretStore != nil {
+		for _, refKey := range []string{
+			record.BearerTokenRef,
+			record.HMACSecretRef,
+			record.APIKeyRef,
+			record.BasicUsernameRef,
+			record.BasicPasswordRef,
+		} {
+			if refKey == "" {
+				continue
+			}
+			if delErr := tm.secretStore.DeleteSecret(ctx, refKey); delErr != nil {
+				tm.logger.Warn("failed to clean up secret ref", "ref", refKey, "error", delErr.Error())
+			}
 		}
 	}
-	// If Store method not available, skip storage (for production with standard StorageProvider)
 
 	return nil
 }
 
-func (tm *TriggerManagerImpl) deleteTriggerFromStorage(ctx context.Context, triggerID string) error {
-	// No storage provider (e.g. composite OSS manager where GetProvider returns nil) — skip persistence.
-	if tm.storage == nil {
-		return nil
-	}
-	// Check if storage is available
-	available, err := tm.storage.Available()
-	if err != nil {
-		return fmt.Errorf("failed to check storage availability: %w", err)
-	}
-	if !available {
-		return fmt.Errorf("storage provider is not available")
-	}
-
-	// Try to use Delete method if available (for testing with MockStorageProvider)
-	type deleteInterface interface {
-		Delete(context.Context, string) error
+// restoreTriggerFromRecord reconstructs a Trigger from a stored TriggerRecord, recovering
+// credential values from the secretStore. Returns an error (and emits a WARN log) for any
+// ref that cannot be resolved; callers should skip the trigger on error (degraded load).
+func (tm *TriggerManagerImpl) restoreTriggerFromRecord(ctx context.Context, record *business.TriggerRecord) (*Trigger, error) {
+	trigger := &Trigger{
+		ID:           record.ID,
+		TenantID:     record.TenantID,
+		Name:         record.Name,
+		Type:         TriggerType(record.Type),
+		Status:       TriggerStatus(record.Status),
+		WorkflowName: record.WorkflowName,
+		CreatedAt:    record.CreatedAt,
+		UpdatedAt:    record.UpdatedAt,
 	}
 
-	if deleter, ok := tm.storage.(deleteInterface); ok {
-		storageKey := fmt.Sprintf("triggers/%s", triggerID)
-		if err := deleter.Delete(ctx, storageKey); err != nil {
-			return fmt.Errorf("failed to delete trigger: %w", err)
+	if len(record.ConfigPayload) == 0 {
+		return trigger, nil
+	}
+
+	var webhookConfig WebhookConfig
+	if err := json.Unmarshal(record.ConfigPayload, &webhookConfig); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal config payload for trigger %s: %w", record.ID, err)
+	}
+
+	hasRefs := record.BearerTokenRef != "" || record.HMACSecretRef != "" || record.APIKeyRef != "" ||
+		record.BasicUsernameRef != "" || record.BasicPasswordRef != ""
+	if hasRefs && tm.secretStore == nil {
+		return nil, fmt.Errorf("trigger %s has credential refs but no secret store is configured", record.ID)
+	}
+
+	auth := &WebhookAuth{}
+	hasAuth := false
+
+	if record.BearerTokenRef != "" {
+		secret, err := tm.secretStore.GetSecret(ctx, record.BearerTokenRef)
+		if err != nil {
+			tm.logger.WarnCtx(ctx, "failed to restore trigger credential",
+				"trigger_id", record.ID, "ref", record.BearerTokenRef, "error", err.Error())
+			return nil, fmt.Errorf("failed to get bearer token for trigger %s: %w", record.ID, err)
+		}
+		auth.BearerToken = secret.Value
+		hasAuth = true
+	}
+
+	if record.HMACSecretRef != "" {
+		secret, err := tm.secretStore.GetSecret(ctx, record.HMACSecretRef)
+		if err != nil {
+			tm.logger.WarnCtx(ctx, "failed to restore trigger credential",
+				"trigger_id", record.ID, "ref", record.HMACSecretRef, "error", err.Error())
+			return nil, fmt.Errorf("failed to get hmac secret for trigger %s: %w", record.ID, err)
+		}
+		auth.Secret = secret.Value
+		hasAuth = true
+	}
+
+	if record.APIKeyRef != "" {
+		secret, err := tm.secretStore.GetSecret(ctx, record.APIKeyRef)
+		if err != nil {
+			tm.logger.WarnCtx(ctx, "failed to restore trigger credential",
+				"trigger_id", record.ID, "ref", record.APIKeyRef, "error", err.Error())
+			return nil, fmt.Errorf("failed to get api key for trigger %s: %w", record.ID, err)
+		}
+		auth.APIKey = secret.Value
+		hasAuth = true
+	}
+
+	if record.BasicUsernameRef != "" || record.BasicPasswordRef != "" {
+		auth.BasicAuth = &BasicAuth{}
+
+		if record.BasicUsernameRef != "" {
+			secret, err := tm.secretStore.GetSecret(ctx, record.BasicUsernameRef)
+			if err != nil {
+				tm.logger.WarnCtx(ctx, "failed to restore trigger credential",
+					"trigger_id", record.ID, "ref", record.BasicUsernameRef, "error", err.Error())
+				return nil, fmt.Errorf("failed to get basic username for trigger %s: %w", record.ID, err)
+			}
+			auth.BasicAuth.Username = secret.Value
+			hasAuth = true
+		}
+
+		if record.BasicPasswordRef != "" {
+			secret, err := tm.secretStore.GetSecret(ctx, record.BasicPasswordRef)
+			if err != nil {
+				tm.logger.WarnCtx(ctx, "failed to restore trigger credential",
+					"trigger_id", record.ID, "ref", record.BasicPasswordRef, "error", err.Error())
+				return nil, fmt.Errorf("failed to get basic password for trigger %s: %w", record.ID, err)
+			}
+			auth.BasicAuth.Password = secret.Value
+			hasAuth = true
 		}
 	}
-	// If Delete method not available, skip storage (for production with standard StorageProvider)
 
-	return nil
+	if hasAuth {
+		webhookConfig.Authentication = auth
+	}
+	trigger.Webhook = &webhookConfig
+
+	return trigger, nil
 }

--- a/features/workflow/trigger/manager_test.go
+++ b/features/workflow/trigger/manager_test.go
@@ -4,13 +4,18 @@ package trigger
 
 import (
 	"context"
+	"errors"
+	"fmt"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 
 	"github.com/cfgis/cfgms/pkg/logging"
+	secretsif "github.com/cfgis/cfgms/pkg/secrets/interfaces"
 	"github.com/cfgis/cfgms/pkg/storage/interfaces"
 	business "github.com/cfgis/cfgms/pkg/storage/interfaces/business"
 	cfgconfig "github.com/cfgis/cfgms/pkg/storage/interfaces/config"
@@ -231,6 +236,7 @@ func TestTriggerManagerImpl_NewTriggerManager(t *testing.T) {
 		mockWebhookHandler,
 		mockSIEMIntegration,
 		mockWorkflowTrigger,
+		nil,
 	)
 
 	assert.NotNil(t, manager)
@@ -259,6 +265,7 @@ func TestTriggerManagerImpl_StartStop(t *testing.T) {
 		mockWebhookHandler,
 		mockSIEMIntegration,
 		mockWorkflowTrigger,
+		nil,
 	)
 
 	ctx := context.Background()
@@ -315,6 +322,7 @@ func TestTriggerManagerImpl_CreateTrigger(t *testing.T) {
 		mockWebhookHandler,
 		mockSIEMIntegration,
 		mockWorkflowTrigger,
+		nil,
 	)
 
 	ctx := context.Background()
@@ -345,7 +353,6 @@ func TestTriggerManagerImpl_CreateTrigger(t *testing.T) {
 			setupMocks: func() {
 				mockStorage.On("Available").Return(true, nil)
 				mockWorkflowTrigger.On("ValidateTrigger", ctx, mock.Anything).Return(nil)
-				mockStorage.On("Store", ctx, "triggers/schedule-1", mock.Anything).Return(nil)
 				mockScheduler.On("ScheduleWorkflow", ctx, mock.Anything).Return(nil)
 			},
 			expectError: false,
@@ -370,7 +377,6 @@ func TestTriggerManagerImpl_CreateTrigger(t *testing.T) {
 			setupMocks: func() {
 				mockStorage.On("Available").Return(true, nil)
 				mockWorkflowTrigger.On("ValidateTrigger", ctx, mock.Anything).Return(nil)
-				mockStorage.On("Store", ctx, "triggers/webhook-1", mock.Anything).Return(nil)
 				mockWebhookHandler.On("RegisterWebhook", ctx, mock.Anything).Return(nil)
 			},
 			expectError: false,
@@ -395,7 +401,6 @@ func TestTriggerManagerImpl_CreateTrigger(t *testing.T) {
 			setupMocks: func() {
 				mockStorage.On("Available").Return(true, nil)
 				mockWorkflowTrigger.On("ValidateTrigger", ctx, mock.Anything).Return(nil)
-				mockStorage.On("Store", ctx, "triggers/siem-1", mock.Anything).Return(nil)
 				mockSIEMIntegration.On("RegisterSIEMTrigger", ctx, mock.Anything).Return(nil)
 			},
 			expectError: false,
@@ -451,7 +456,6 @@ func TestTriggerManagerImpl_CreateTrigger(t *testing.T) {
 			setupMocks: func() {
 				mockStorage.On("Available").Return(true, nil)
 				mockWorkflowTrigger.On("ValidateTrigger", ctx, mock.Anything).Return(nil)
-				mockStorage.On("Store", ctx, "triggers/storage-test-1", mock.Anything).Return(nil)
 				mockScheduler.On("ScheduleWorkflow", ctx, mock.Anything).Return(nil)
 			},
 			expectError: false,
@@ -499,6 +503,7 @@ func TestTriggerManagerImpl_UpdateTrigger(t *testing.T) {
 		mockWebhookHandler,
 		mockSIEMIntegration,
 		mockWorkflowTrigger,
+		nil,
 	)
 
 	// Create an existing trigger
@@ -546,7 +551,6 @@ func TestTriggerManagerImpl_UpdateTrigger(t *testing.T) {
 			setupMocks: func() {
 				mockStorage.On("Available").Return(true, nil)
 				mockWorkflowTrigger.On("ValidateTrigger", ctx, mock.Anything).Return(nil)
-				mockStorage.On("Store", ctx, "triggers/schedule-1", mock.Anything).Return(nil)
 				mockScheduler.On("UnscheduleWorkflow", ctx, "schedule-1").Return(nil)
 				mockScheduler.On("ScheduleWorkflow", ctx, mock.Anything).Return(nil)
 			},
@@ -623,6 +627,7 @@ func TestTriggerManagerImpl_DeleteTrigger(t *testing.T) {
 		mockWebhookHandler,
 		mockSIEMIntegration,
 		mockWorkflowTrigger,
+		nil,
 	)
 
 	// Create test triggers
@@ -673,7 +678,6 @@ func TestTriggerManagerImpl_DeleteTrigger(t *testing.T) {
 			triggerID: "schedule-1",
 			setupMocks: func() {
 				mockStorage.On("Available").Return(true, nil)
-				mockStorage.On("Delete", ctx, "triggers/schedule-1").Return(nil)
 				mockScheduler.On("UnscheduleWorkflow", ctx, "schedule-1").Return(nil)
 			},
 			expectError: false,
@@ -683,7 +687,6 @@ func TestTriggerManagerImpl_DeleteTrigger(t *testing.T) {
 			triggerID: "webhook-1",
 			setupMocks: func() {
 				mockStorage.On("Available").Return(true, nil)
-				mockStorage.On("Delete", ctx, "triggers/webhook-1").Return(nil)
 				mockWebhookHandler.On("UnregisterWebhook", ctx, "webhook-1").Return(nil)
 			},
 			expectError: false,
@@ -693,7 +696,6 @@ func TestTriggerManagerImpl_DeleteTrigger(t *testing.T) {
 			triggerID: "siem-1",
 			setupMocks: func() {
 				mockStorage.On("Available").Return(true, nil)
-				mockStorage.On("Delete", ctx, "triggers/siem-1").Return(nil)
 				mockSIEMIntegration.On("UnregisterSIEMTrigger", ctx, "siem-1").Return(nil)
 			},
 			expectError: false,
@@ -704,16 +706,6 @@ func TestTriggerManagerImpl_DeleteTrigger(t *testing.T) {
 			setupMocks:  func() {},
 			expectError: true,
 			errorMsg:    "trigger non-existent not found",
-		},
-		{
-			name:      "storage deletion not implemented yet",
-			triggerID: "schedule-1",
-			setupMocks: func() {
-				mockStorage.On("Available").Return(true, nil)
-				mockStorage.On("Delete", ctx, "triggers/schedule-1").Return(nil)
-				mockScheduler.On("UnscheduleWorkflow", ctx, "schedule-1").Return(nil)
-			},
-			expectError: false,
 		},
 	}
 
@@ -765,6 +757,7 @@ func TestTriggerManagerImpl_GetTrigger(t *testing.T) {
 		mockWebhookHandler,
 		mockSIEMIntegration,
 		mockWorkflowTrigger,
+		nil,
 	)
 
 	// Create test trigger
@@ -831,6 +824,7 @@ func TestTriggerManagerImpl_ListTriggers(t *testing.T) {
 		mockWebhookHandler,
 		mockSIEMIntegration,
 		mockWorkflowTrigger,
+		nil,
 	)
 
 	// Create test triggers
@@ -967,6 +961,7 @@ func TestTriggerManagerImpl_EnableDisableTrigger(t *testing.T) {
 		mockWebhookHandler,
 		mockSIEMIntegration,
 		mockWorkflowTrigger,
+		nil,
 	)
 
 	// Create test trigger
@@ -984,14 +979,12 @@ func TestTriggerManagerImpl_EnableDisableTrigger(t *testing.T) {
 	ctx := context.Background()
 
 	t.Run("enable trigger", func(t *testing.T) {
-		mockStorage.On("Store", ctx, "triggers/test-1", mock.Anything).Return(nil)
 		mockScheduler.On("ScheduleWorkflow", ctx, mock.Anything).Return(nil)
 
 		err := manager.EnableTrigger(ctx, "test-1")
 		assert.NoError(t, err)
 		assert.Equal(t, TriggerStatusActive, trigger.Status)
 
-		mockStorage.AssertExpectations(t)
 		mockScheduler.AssertExpectations(t)
 	})
 
@@ -1003,15 +996,12 @@ func TestTriggerManagerImpl_EnableDisableTrigger(t *testing.T) {
 		trigger.Status = TriggerStatusActive
 		trigger.Schedule.Enabled = true
 
-		mockStorage.On("Available").Return(true, nil)
-		mockStorage.On("Store", ctx, "triggers/test-1", mock.Anything).Return(nil)
 		mockScheduler.On("UnscheduleWorkflow", ctx, "test-1").Return(nil)
 
 		err := manager.DisableTrigger(ctx, "test-1")
 		assert.NoError(t, err)
 		assert.Equal(t, TriggerStatusInactive, trigger.Status)
 
-		mockStorage.AssertExpectations(t)
 		mockScheduler.AssertExpectations(t)
 	})
 
@@ -1037,6 +1027,7 @@ func TestTriggerManagerImpl_ExecuteTrigger(t *testing.T) {
 		mockWebhookHandler,
 		mockSIEMIntegration,
 		mockWorkflowTrigger,
+		nil,
 	)
 
 	// Create test trigger
@@ -1098,4 +1089,524 @@ func TestTriggerManagerImpl_NilStoragePersistence(t *testing.T) {
 		err := manager.deleteTriggerFromStorage(ctx, trigger.ID)
 		assert.NoError(t, err, "deleteTriggerFromStorage must not error when storage is nil")
 	})
+}
+
+func TestTriggerManagerSaveRejectsCredentialsWithoutSecretStore(t *testing.T) {
+	ts := newInMemoryTriggerStore()
+	ctx := contextWithTenant("tenant-test")
+
+	mgr := &TriggerManagerImpl{
+		logger:       logging.ForModule("workflow.trigger.manager.test"),
+		triggerStore: ts,
+		secretStore:  nil,
+		triggers:     make(map[string]*Trigger),
+		executions:   make(map[string]*TriggerExecution),
+	}
+
+	tests := []struct {
+		name    string
+		trigger *Trigger
+	}{
+		{
+			name: "bearer token requires secret store",
+			trigger: &Trigger{
+				ID: "t-cred", TenantID: "tenant-test", Name: "n", Type: TriggerTypeWebhook,
+				Status: TriggerStatusActive, WorkflowName: "wf",
+				Webhook: &WebhookConfig{Path: "/x", Authentication: &WebhookAuth{BearerToken: "tok"}},
+			},
+		},
+		{
+			name: "hmac secret requires secret store",
+			trigger: &Trigger{
+				ID: "t-cred", TenantID: "tenant-test", Name: "n", Type: TriggerTypeWebhook,
+				Status: TriggerStatusActive, WorkflowName: "wf",
+				Webhook: &WebhookConfig{Path: "/x", Authentication: &WebhookAuth{Secret: "hmac"}},
+			},
+		},
+		{
+			name: "api key requires secret store",
+			trigger: &Trigger{
+				ID: "t-cred", TenantID: "tenant-test", Name: "n", Type: TriggerTypeWebhook,
+				Status: TriggerStatusActive, WorkflowName: "wf",
+				Webhook: &WebhookConfig{Path: "/x", Authentication: &WebhookAuth{APIKey: "key"}},
+			},
+		},
+		{
+			name: "basic username requires secret store",
+			trigger: &Trigger{
+				ID: "t-cred", TenantID: "tenant-test", Name: "n", Type: TriggerTypeWebhook,
+				Status: TriggerStatusActive, WorkflowName: "wf",
+				Webhook: &WebhookConfig{Path: "/x", Authentication: &WebhookAuth{BasicAuth: &BasicAuth{Username: "u"}}},
+			},
+		},
+		{
+			name: "basic password requires secret store",
+			trigger: &Trigger{
+				ID: "t-cred", TenantID: "tenant-test", Name: "n", Type: TriggerTypeWebhook,
+				Status: TriggerStatusActive, WorkflowName: "wf",
+				Webhook: &WebhookConfig{Path: "/x", Authentication: &WebhookAuth{BasicAuth: &BasicAuth{Password: "p"}}},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := mgr.saveTriggerToStorage(ctx, tt.trigger)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "secret store required to persist trigger credentials")
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// In-memory test helpers for persistence tests
+// ---------------------------------------------------------------------------
+
+// inMemoryTriggerStore is a thread-safe in-memory TriggerStore for testing.
+type inMemoryTriggerStore struct {
+	mu      sync.RWMutex
+	records map[string]*business.TriggerRecord
+}
+
+func newInMemoryTriggerStore() *inMemoryTriggerStore {
+	return &inMemoryTriggerStore{records: make(map[string]*business.TriggerRecord)}
+}
+
+func (s *inMemoryTriggerStore) StoreTrigger(_ context.Context, record *business.TriggerRecord) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.records[record.ID] = record
+	return nil
+}
+
+func (s *inMemoryTriggerStore) GetTrigger(_ context.Context, id string) (*business.TriggerRecord, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	r, ok := s.records[id]
+	if !ok {
+		return nil, business.ErrTriggerNotFound
+	}
+	return r, nil
+}
+
+func (s *inMemoryTriggerStore) DeleteTrigger(_ context.Context, id string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, ok := s.records[id]; !ok {
+		return business.ErrTriggerNotFound
+	}
+	delete(s.records, id)
+	return nil
+}
+
+func (s *inMemoryTriggerStore) ListTriggers(_ context.Context, filter business.TriggerStoreFilter) ([]*business.TriggerRecord, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	var result []*business.TriggerRecord
+	for _, r := range s.records {
+		if filter.TenantID != "" && r.TenantID != filter.TenantID {
+			continue
+		}
+		result = append(result, r)
+	}
+	return result, nil
+}
+
+func (s *inMemoryTriggerStore) Close() error { return nil }
+
+// inMemorySecretStore is a thread-safe in-memory SecretStore for testing.
+type inMemorySecretStore struct {
+	mu      sync.RWMutex
+	secrets map[string]string // key → plaintext value
+}
+
+func newInMemorySecretStore() *inMemorySecretStore {
+	return &inMemorySecretStore{secrets: make(map[string]string)}
+}
+
+func (s *inMemorySecretStore) StoreSecret(_ context.Context, req *secretsif.SecretRequest) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.secrets[req.Key] = req.Value
+	return nil
+}
+
+func (s *inMemorySecretStore) GetSecret(_ context.Context, key string) (*secretsif.Secret, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	v, ok := s.secrets[key]
+	if !ok {
+		return nil, fmt.Errorf("%w: %s", secretsif.ErrSecretNotFound, key)
+	}
+	return &secretsif.Secret{Key: key, Value: v}, nil
+}
+
+func (s *inMemorySecretStore) DeleteSecret(_ context.Context, key string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, ok := s.secrets[key]; !ok {
+		return fmt.Errorf("%w: %s", secretsif.ErrSecretNotFound, key)
+	}
+	delete(s.secrets, key)
+	return nil
+}
+
+func (s *inMemorySecretStore) ListSecrets(_ context.Context, _ *secretsif.SecretFilter) ([]*secretsif.SecretMetadata, error) {
+	return nil, nil
+}
+func (s *inMemorySecretStore) GetSecrets(_ context.Context, keys []string) (map[string]*secretsif.Secret, error) {
+	result := make(map[string]*secretsif.Secret)
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	for _, k := range keys {
+		if v, ok := s.secrets[k]; ok {
+			result[k] = &secretsif.Secret{Key: k, Value: v}
+		}
+	}
+	return result, nil
+}
+func (s *inMemorySecretStore) StoreSecrets(ctx context.Context, secrets map[string]*secretsif.SecretRequest) error {
+	for _, req := range secrets {
+		if err := s.StoreSecret(ctx, req); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+func (s *inMemorySecretStore) GetSecretVersion(_ context.Context, _ string, _ int) (*secretsif.Secret, error) {
+	return nil, errors.New("versioning not supported")
+}
+func (s *inMemorySecretStore) ListSecretVersions(_ context.Context, _ string) ([]*secretsif.SecretVersion, error) {
+	return nil, nil
+}
+func (s *inMemorySecretStore) GetSecretMetadata(_ context.Context, _ string) (*secretsif.SecretMetadata, error) {
+	return nil, nil
+}
+func (s *inMemorySecretStore) UpdateSecretMetadata(_ context.Context, _ string, _ map[string]string) error {
+	return nil
+}
+func (s *inMemorySecretStore) RotateSecret(_ context.Context, _ string, _ string) error { return nil }
+func (s *inMemorySecretStore) ExpireSecret(_ context.Context, _ string) error           { return nil }
+func (s *inMemorySecretStore) HealthCheck(_ context.Context) error                      { return nil }
+func (s *inMemorySecretStore) Close() error                                             { return nil }
+
+// newManagerWithPersistence creates a TriggerManagerImpl wired to real in-memory
+// TriggerStore and SecretStore. Used by persistence-focused tests.
+func newManagerWithPersistence(tenantID string) (*TriggerManagerImpl, *inMemoryTriggerStore, *inMemorySecretStore) {
+	ts := newInMemoryTriggerStore()
+	ss := newInMemorySecretStore()
+	mgr := &TriggerManagerImpl{
+		logger:       logging.ForModule("workflow.trigger.manager.test"),
+		triggerStore: ts,
+		secretStore:  ss,
+		triggers:     make(map[string]*Trigger),
+		executions:   make(map[string]*TriggerExecution),
+	}
+	return mgr, ts, ss
+}
+
+// contextWithTenant returns a context carrying the given tenant ID via the trigger package key.
+func contextWithTenant(tenantID string) context.Context {
+	return context.WithValue(context.Background(), TenantIDContextKey, tenantID)
+}
+
+// ---------------------------------------------------------------------------
+// Required persistence tests
+// ---------------------------------------------------------------------------
+
+func TestTriggerManagerSaveRedactsAllCredentials(t *testing.T) {
+	mgr, ts, _ := newManagerWithPersistence("tenant-save")
+	ctx := contextWithTenant("tenant-save")
+
+	trigger := &Trigger{
+		ID:           "t-redact",
+		TenantID:     "tenant-save",
+		Name:         "Redact Test",
+		Type:         TriggerTypeWebhook,
+		Status:       TriggerStatusActive,
+		WorkflowName: "wf",
+		Webhook: &WebhookConfig{
+			Path: "/test",
+			Authentication: &WebhookAuth{
+				BearerToken: "secret-bearer",
+				Secret:      "secret-hmac",
+				APIKey:      "secret-apikey",
+				BasicAuth: &BasicAuth{
+					Username: "secret-user",
+					Password: "secret-pass",
+				},
+			},
+		},
+	}
+
+	require.NoError(t, mgr.saveTriggerToStorage(ctx, trigger))
+
+	record, err := ts.GetTrigger(ctx, "t-redact")
+	require.NoError(t, err)
+
+	// Verify all five ref fields are populated.
+	assert.NotEmpty(t, record.BearerTokenRef, "BearerTokenRef must be set")
+	assert.NotEmpty(t, record.HMACSecretRef, "HMACSecretRef must be set")
+	assert.NotEmpty(t, record.APIKeyRef, "APIKeyRef must be set")
+	assert.NotEmpty(t, record.BasicUsernameRef, "BasicUsernameRef must be set")
+	assert.NotEmpty(t, record.BasicPasswordRef, "BasicPasswordRef must be set")
+
+	// Verify NO plaintext credential appears in ConfigPayload.
+	for _, plaintext := range []string{"secret-bearer", "secret-hmac", "secret-apikey", "secret-user", "secret-pass"} {
+		assert.NotContains(t, string(record.ConfigPayload), plaintext,
+			"plaintext credential %q must not appear in ConfigPayload", plaintext)
+	}
+
+	// Verify the *Ref fields themselves do NOT hold the plaintext values.
+	for _, refField := range []string{
+		record.BearerTokenRef, record.HMACSecretRef, record.APIKeyRef,
+		record.BasicUsernameRef, record.BasicPasswordRef,
+	} {
+		for _, plaintext := range []string{"secret-bearer", "secret-hmac", "secret-apikey", "secret-user", "secret-pass"} {
+			assert.NotEqual(t, plaintext, refField,
+				"ref field %q must not equal plaintext credential %q", refField, plaintext)
+		}
+	}
+}
+
+func TestTriggerManagerPersistenceRoundTrip(t *testing.T) {
+	// Save a trigger with full credentials, then simulate manager restart
+	// by creating a fresh manager pointing at the same stores.
+	ts := newInMemoryTriggerStore()
+	ss := newInMemorySecretStore()
+
+	ctx := contextWithTenant("tenant-rt")
+
+	save := &TriggerManagerImpl{
+		logger:       logging.ForModule("workflow.trigger.manager.test"),
+		triggerStore: ts,
+		secretStore:  ss,
+		triggers:     make(map[string]*Trigger),
+		executions:   make(map[string]*TriggerExecution),
+	}
+
+	original := &Trigger{
+		ID:           "t-rt",
+		TenantID:     "tenant-rt",
+		Name:         "Round Trip",
+		Type:         TriggerTypeWebhook,
+		Status:       TriggerStatusActive,
+		WorkflowName: "wf-rt",
+		CreatedAt:    time.Now().Truncate(time.Second),
+		UpdatedAt:    time.Now().Truncate(time.Second),
+		Webhook: &WebhookConfig{
+			Path:   "/rt",
+			Method: []string{"POST"},
+			Authentication: &WebhookAuth{
+				BearerToken: "rt-bearer",
+				Secret:      "rt-hmac",
+				APIKey:      "rt-apikey",
+				BasicAuth: &BasicAuth{
+					Username: "rt-user",
+					Password: "rt-pass",
+				},
+			},
+		},
+	}
+	require.NoError(t, save.saveTriggerToStorage(ctx, original))
+
+	// Fresh manager (simulates restart) — same backing stores.
+	load := &TriggerManagerImpl{
+		logger:       logging.ForModule("workflow.trigger.manager.test"),
+		triggerStore: ts,
+		secretStore:  ss,
+		triggers:     make(map[string]*Trigger),
+		executions:   make(map[string]*TriggerExecution),
+	}
+	require.NoError(t, load.loadTriggersFromStorage(ctx))
+
+	got, ok := load.triggers["t-rt"]
+	require.True(t, ok, "trigger must be present after load")
+	require.NotNil(t, got.Webhook)
+	require.NotNil(t, got.Webhook.Authentication)
+
+	auth := got.Webhook.Authentication
+	assert.Equal(t, "rt-bearer", auth.BearerToken)
+	assert.Equal(t, "rt-hmac", auth.Secret)
+	assert.Equal(t, "rt-apikey", auth.APIKey)
+	require.NotNil(t, auth.BasicAuth)
+	assert.Equal(t, "rt-user", auth.BasicAuth.Username)
+	assert.Equal(t, "rt-pass", auth.BasicAuth.Password)
+}
+
+func TestTriggerSecretKeyTenantIsolation(t *testing.T) {
+	// Two managers sharing one secret store but different tenants.
+	// A secret written by tenant A must not be readable via tenant B's key namespace.
+	ss := newInMemorySecretStore()
+	tsA := newInMemoryTriggerStore()
+	tsB := newInMemoryTriggerStore()
+
+	ctxA := contextWithTenant("tenant-A")
+	ctxB := contextWithTenant("tenant-B")
+
+	mgrA := &TriggerManagerImpl{
+		logger:       logging.ForModule("workflow.trigger.manager.test"),
+		triggerStore: tsA,
+		secretStore:  ss,
+		triggers:     make(map[string]*Trigger),
+		executions:   make(map[string]*TriggerExecution),
+	}
+	mgrB := &TriggerManagerImpl{
+		logger:       logging.ForModule("workflow.trigger.manager.test"),
+		triggerStore: tsB,
+		secretStore:  ss,
+		triggers:     make(map[string]*Trigger),
+		executions:   make(map[string]*TriggerExecution),
+	}
+
+	trigA := &Trigger{
+		ID:           "t-iso",
+		TenantID:     "tenant-A",
+		Name:         "Isolation A",
+		Type:         TriggerTypeWebhook,
+		Status:       TriggerStatusActive,
+		WorkflowName: "wf",
+		Webhook: &WebhookConfig{
+			Path:           "/iso",
+			Authentication: &WebhookAuth{BearerToken: "secret-A"},
+		},
+	}
+	require.NoError(t, mgrA.saveTriggerToStorage(ctxA, trigA))
+
+	// The secret is stored under the tenant-A key; tenant-B's key for the same
+	// trigger ID and field must not exist.
+	keyA := fmt.Sprintf("trigger-%s-%s-bearer", "tenant-A", "t-iso")
+	keyB := fmt.Sprintf("trigger-%s-%s-bearer", "tenant-B", "t-iso")
+
+	secretA, err := ss.GetSecret(ctxA, keyA)
+	require.NoError(t, err, "tenant-A secret must be retrievable")
+	assert.Equal(t, "secret-A", secretA.Value)
+
+	_, err = ss.GetSecret(ctxB, keyB)
+	assert.ErrorIs(t, err, secretsif.ErrSecretNotFound,
+		"tenant-B must not be able to retrieve tenant-A's secret via its own key namespace")
+
+	// Also verify mgrB cannot load the trigger (it uses a separate tsB store).
+	require.NoError(t, mgrB.loadTriggersFromStorage(ctxB))
+	_, ok := mgrB.triggers["t-iso"]
+	assert.False(t, ok, "mgrB must not see tenant-A's trigger")
+}
+
+func TestTriggerManagerDegradedLoad(t *testing.T) {
+	ts := newInMemoryTriggerStore()
+	ss := newInMemorySecretStore()
+	ctx := contextWithTenant("tenant-dg")
+
+	// Populate store directly: two valid triggers + one with a deleted bearer ref.
+	validBearer1 := "trigger-tenant-dg-t-ok1-bearer"
+	validBearer2 := "trigger-tenant-dg-t-ok2-bearer"
+	brokenBearer := "trigger-tenant-dg-t-broken-bearer"
+
+	require.NoError(t, ss.StoreSecret(ctx, &secretsif.SecretRequest{Key: validBearer1, Value: "v1", TenantID: "tenant-dg"}))
+	require.NoError(t, ss.StoreSecret(ctx, &secretsif.SecretRequest{Key: validBearer2, Value: "v2", TenantID: "tenant-dg"}))
+	// Deliberately do NOT store brokenBearer so GetSecret will return ErrSecretNotFound.
+
+	for _, rec := range []*business.TriggerRecord{
+		{ID: "t-ok1", TenantID: "tenant-dg", Name: "OK1", Type: string(TriggerTypeWebhook), Status: string(TriggerStatusActive), WorkflowName: "wf", BearerTokenRef: validBearer1, ConfigPayload: []byte(`{"path":"/ok1"}`)},
+		{ID: "t-ok2", TenantID: "tenant-dg", Name: "OK2", Type: string(TriggerTypeWebhook), Status: string(TriggerStatusActive), WorkflowName: "wf", BearerTokenRef: validBearer2, ConfigPayload: []byte(`{"path":"/ok2"}`)},
+		{ID: "t-broken", TenantID: "tenant-dg", Name: "Broken", Type: string(TriggerTypeWebhook), Status: string(TriggerStatusActive), WorkflowName: "wf", BearerTokenRef: brokenBearer, ConfigPayload: []byte(`{"path":"/broken"}`)},
+	} {
+		require.NoError(t, ts.StoreTrigger(ctx, rec))
+	}
+
+	mgr := &TriggerManagerImpl{
+		logger:       logging.ForModule("workflow.trigger.manager.test"),
+		triggerStore: ts,
+		secretStore:  ss,
+		triggers:     make(map[string]*Trigger),
+		executions:   make(map[string]*TriggerExecution),
+	}
+
+	require.NoError(t, mgr.loadTriggersFromStorage(ctx))
+
+	// Two valid triggers must be present; the broken one must be absent.
+	assert.Contains(t, mgr.triggers, "t-ok1", "t-ok1 must be loaded")
+	assert.Contains(t, mgr.triggers, "t-ok2", "t-ok2 must be loaded")
+	assert.NotContains(t, mgr.triggers, "t-broken", "t-broken must be skipped")
+
+	// Absence of "t-broken" proves the degraded-load path (WarnCtx + skip) was taken.
+	assert.NotContains(t, mgr.triggers, "t-broken", "broken ref must cause trigger to be skipped")
+}
+
+func TestTriggerDeleteCleansSecrets(t *testing.T) {
+	ts := newInMemoryTriggerStore()
+	ss := newInMemorySecretStore()
+	ctx := contextWithTenant("tenant-del")
+
+	mgr := &TriggerManagerImpl{
+		logger:       logging.ForModule("workflow.trigger.manager.test"),
+		triggerStore: ts,
+		secretStore:  ss,
+		triggers:     make(map[string]*Trigger),
+		executions:   make(map[string]*TriggerExecution),
+	}
+
+	trigger := &Trigger{
+		ID:           "t-del",
+		TenantID:     "tenant-del",
+		Name:         "Delete Test",
+		Type:         TriggerTypeWebhook,
+		Status:       TriggerStatusActive,
+		WorkflowName: "wf",
+		Webhook: &WebhookConfig{
+			Path: "/del",
+			Authentication: &WebhookAuth{
+				BearerToken: "del-bearer",
+				Secret:      "del-hmac",
+				APIKey:      "del-apikey",
+				BasicAuth:   &BasicAuth{Username: "del-user", Password: "del-pass"},
+			},
+		},
+	}
+
+	require.NoError(t, mgr.saveTriggerToStorage(ctx, trigger))
+
+	// Verify secrets were stored.
+	refKeys := []string{
+		"trigger-tenant-del-t-del-bearer",
+		"trigger-tenant-del-t-del-hmac-secret",
+		"trigger-tenant-del-t-del-api-key",
+		"trigger-tenant-del-t-del-basic-user",
+		"trigger-tenant-del-t-del-basic-pass",
+	}
+	for _, k := range refKeys {
+		_, err := ss.GetSecret(ctx, k)
+		require.NoError(t, err, "secret %q must exist before delete", k)
+	}
+
+	require.NoError(t, mgr.deleteTriggerFromStorage(ctx, "t-del"))
+
+	// After deletion, all five secret refs must be gone.
+	for _, k := range refKeys {
+		_, err := ss.GetSecret(ctx, k)
+		assert.ErrorIs(t, err, secretsif.ErrSecretNotFound,
+			"secret %q must be removed after trigger deletion", k)
+	}
+
+	// Partial-delete error: if one DeleteSecret call fails the rest are still attempted.
+	// Simulate by pre-deleting one ref and re-calling deleteTriggerFromStorage on a
+	// fresh record with all refs populated (the method logs WARN and continues).
+	rec := &business.TriggerRecord{
+		ID:               "t-del-partial",
+		TenantID:         "tenant-del",
+		BearerTokenRef:   "partial-bearer",
+		HMACSecretRef:    "partial-hmac",
+		APIKeyRef:        "partial-api",
+		BasicUsernameRef: "partial-user",
+		BasicPasswordRef: "partial-pass",
+	}
+	require.NoError(t, ts.StoreTrigger(ctx, rec))
+	// Only store some of the secrets (simulates partially-missing refs).
+	require.NoError(t, ss.StoreSecret(ctx, &secretsif.SecretRequest{Key: "partial-bearer", Value: "x", TenantID: "tenant-del"}))
+	require.NoError(t, ss.StoreSecret(ctx, &secretsif.SecretRequest{Key: "partial-hmac", Value: "x", TenantID: "tenant-del"}))
+	// partial-api, partial-user, partial-pass are intentionally absent.
+
+	// deleteTriggerFromStorage must succeed even with missing secret refs (WARN + continue).
+	err := mgr.deleteTriggerFromStorage(ctx, "t-del-partial")
+	assert.NoError(t, err, "deleteTriggerFromStorage must not fail on missing secret refs")
 }

--- a/features/workflow/trigger/security_test.go
+++ b/features/workflow/trigger/security_test.go
@@ -417,6 +417,7 @@ func TestSecurityEdgeCases_TenantIsolation(t *testing.T) {
 		mockWebhookHandler,
 		mockSIEMIntegration,
 		mockWorkflowTrigger,
+		nil,
 	)
 
 	// Setup storage mock expectations


### PR DESCRIPTION
## Summary

- Wires `TriggerManagerImpl` to real `business.TriggerStore` and `pkg/secrets` for durable, credential-safe trigger persistence
- Extracts all 5 `WebhookAuth` credential fields into `pkg/secrets` refs before storage; `ConfigPayload` is structurally incapable of containing cleartext credentials (Authentication zeroed before marshal)
- Degraded load on startup: skips triggers with unresolvable credential refs (WARN log) rather than failing startup
- Adds nil-secretStore guard in `restoreTriggerFromRecord` to prevent nil-deref panic when records have refs but no secret store is configured

## Acceptance Tests Added

- `TestTriggerManagerSaveRedactsAllCredentials` — scans ConfigPayload bytes for any plaintext credential strings
- `TestTriggerManagerPersistenceRoundTrip` — full save → load cycle verifies credential recovery
- `TestTriggerSecretKeyTenantIsolation` — tenant-A secret key unreachable via tenant-B namespace
- `TestTriggerManagerDegradedLoad` — broken ref causes skip+WARN, good triggers still load
- `TestTriggerDeleteCleansSecrets` — all 5 secret refs cleaned up on DeleteTrigger
- `TestTriggerManagerSaveRejectsCredentialsWithoutSecretStore` — fail-closed when secretStore is nil with credentials present

## Test plan

- [ ] `go test ./features/workflow/trigger/...` — passes (4s)
- [ ] `make check-architecture` — no central provider violations
- [ ] `golangci-lint run ./features/workflow/trigger/...` — 0 issues
- [ ] All 6 acceptance-criteria tests pass
- [ ] `TestSIEMEngine_EndToEndProcessing` in features/siem is a pre-existing failure (window size validation), not caused by this story

🤖 Generated with [Claude Code](https://claude.com/claude-code)