### PR TITLE
ad-module: delete plaintext Password field, resolve via pkg/secrets (Issue #1114)

### DIFF
--- a/features/modules/network_activedirectory/auth.go
+++ b/features/modules/network_activedirectory/auth.go
@@ -11,20 +11,39 @@ import (
 	"github.com/jcmturner/gokrb5/v8/client"
 	"github.com/jcmturner/gokrb5/v8/config"
 	"github.com/jcmturner/gokrb5/v8/credentials"
+
+	secretsinterfaces "github.com/cfgis/cfgms/pkg/secrets/interfaces"
 )
 
 // AuthenticationManager handles different authentication methods for Active Directory
 type AuthenticationManager struct {
-	config     *ADModuleConfig
-	krb5Config *config.Config
-	krb5Client *client.Client
+	config      *ADModuleConfig
+	secretStore secretsinterfaces.SecretStore
+	krb5Config  *config.Config
+	krb5Client  *client.Client
 }
 
 // NewAuthenticationManager creates a new authentication manager
-func NewAuthenticationManager(config *ADModuleConfig) *AuthenticationManager {
+func NewAuthenticationManager(config *ADModuleConfig, secretStore secretsinterfaces.SecretStore) *AuthenticationManager {
 	return &AuthenticationManager{
-		config: config,
+		config:      config,
+		secretStore: secretStore,
 	}
+}
+
+// resolvePassword retrieves the service account password from the secret store.
+func (a *AuthenticationManager) resolvePassword(ctx context.Context) (string, error) {
+	if a.secretStore == nil {
+		return "", fmt.Errorf("ADModuleConfig: no SecretStore configured")
+	}
+	if a.config.PasswordSecretKey == "" {
+		return "", fmt.Errorf("ADModuleConfig.PasswordSecretKey is required for auth_method %q; store the password in pkg/secrets and set password_secret_key", a.config.AuthMethod)
+	}
+	secret, err := a.secretStore.GetSecret(ctx, a.config.PasswordSecretKey)
+	if err != nil {
+		return "", fmt.Errorf("failed to retrieve password from secret store (key=%q): %w", a.config.PasswordSecretKey, err)
+	}
+	return secret.Value, nil
 }
 
 // Authenticate authenticates to Active Directory using the configured method
@@ -43,8 +62,13 @@ func (a *AuthenticationManager) Authenticate(ctx context.Context, conn *ldap.Con
 
 // authenticateSimple performs simple bind authentication
 func (a *AuthenticationManager) authenticateSimple(ctx context.Context, conn *ldap.Conn) error {
-	if a.config.Username == "" || a.config.Password == "" {
+	if a.config.Username == "" {
 		return fmt.Errorf("username and password required for simple authentication")
+	}
+
+	password, err := a.resolvePassword(ctx)
+	if err != nil {
+		return fmt.Errorf("simple authentication failed: %w", err)
 	}
 
 	// Convert username to proper format
@@ -63,8 +87,7 @@ func (a *AuthenticationManager) authenticateSimple(ctx context.Context, conn *ld
 	}
 
 	// Perform bind
-	err := conn.Bind(userDN, a.config.Password)
-	if err != nil {
+	if err := conn.Bind(userDN, password); err != nil {
 		return fmt.Errorf("simple bind failed for user %s: %w", userDN, err)
 	}
 
@@ -73,8 +96,13 @@ func (a *AuthenticationManager) authenticateSimple(ctx context.Context, conn *ld
 
 // authenticateKerberos performs Kerberos authentication
 func (a *AuthenticationManager) authenticateKerberos(ctx context.Context, conn *ldap.Conn) error {
-	if a.config.Username == "" || a.config.Password == "" {
+	if a.config.Username == "" {
 		return fmt.Errorf("username and password required for Kerberos authentication")
+	}
+
+	password, err := a.resolvePassword(ctx)
+	if err != nil {
+		return fmt.Errorf("kerberos authentication failed: %w", err)
 	}
 
 	// Initialize Kerberos configuration
@@ -84,14 +112,13 @@ func (a *AuthenticationManager) authenticateKerberos(ctx context.Context, conn *
 
 	// Create Kerberos credentials
 	creds := credentials.New(a.config.Username, strings.ToUpper(a.config.Domain))
-	creds.WithPassword(a.config.Password)
+	creds.WithPassword(password)
 
 	// Create Kerberos client
 	krb5Client := client.NewWithPassword(creds.UserName(), strings.ToUpper(a.config.Domain), creds.Password(), a.krb5Config)
 
 	// Login to get TGT
-	err := krb5Client.Login()
-	if err != nil {
+	if err := krb5Client.Login(); err != nil {
 		return fmt.Errorf("kerberos login failed: %w", err)
 	}
 
@@ -103,8 +130,7 @@ func (a *AuthenticationManager) authenticateKerberos(ctx context.Context, conn *
 	// In a production implementation, this would use SASL GSSAPI
 
 	userPrincipal := fmt.Sprintf("%s@%s", a.config.Username, strings.ToUpper(a.config.Domain))
-	err = conn.Bind(userPrincipal, a.config.Password)
-	if err != nil {
+	if err := conn.Bind(userPrincipal, password); err != nil {
 		return fmt.Errorf("kerberos-authenticated bind failed: %w", err)
 	}
 
@@ -221,31 +247,4 @@ func (a *AuthenticationManager) GetAuthenticationStatus() map[string]interface{}
 	}
 
 	return status
-}
-
-// SecureCredentialStorage provides secure storage for authentication credentials
-type SecureCredentialStorage struct {
-	// In a production implementation, this would integrate with:
-	// - Windows Credential Manager on Windows
-	// - Linux keyring on Linux
-	// - External secret management systems (Vault, etc.)
-}
-
-// StoreCredentials securely stores authentication credentials
-func (s *SecureCredentialStorage) StoreCredentials(domain, username, password string) error {
-	// This would implement secure credential storage
-	// For now, return a placeholder
-	return fmt.Errorf("secure credential storage not yet implemented - use configuration files with proper permissions")
-}
-
-// RetrieveCredentials securely retrieves authentication credentials
-func (s *SecureCredentialStorage) RetrieveCredentials(domain, username string) (string, error) {
-	// This would implement secure credential retrieval
-	return "", fmt.Errorf("secure credential retrieval not yet implemented")
-}
-
-// RotateCredentials handles automatic credential rotation
-func (s *SecureCredentialStorage) RotateCredentials(domain, username string) error {
-	// This would implement automatic password rotation
-	return fmt.Errorf("credential rotation not yet implemented")
 }

--- a/features/modules/network_activedirectory/auth_test.go
+++ b/features/modules/network_activedirectory/auth_test.go
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+package network_activedirectory
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	secretsinterfaces "github.com/cfgis/cfgms/pkg/secrets/interfaces"
+	"github.com/cfgis/cfgms/pkg/secrets/providers/steward"
+)
+
+func newTestSecretStore(t *testing.T) secretsinterfaces.SecretStore {
+	t.Helper()
+	if _, err := os.Stat("/etc/machine-id"); os.IsNotExist(err) {
+		t.Skip("skipping: /etc/machine-id not available (required for platform key derivation on Linux)")
+	}
+	tmpDir := t.TempDir()
+	provider := &steward.StewardProvider{}
+	store, err := provider.CreateSecretStore(map[string]interface{}{
+		"secrets_dir": tmpDir,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = store.Close() })
+	return store
+}
+
+func TestResolvePassword_Success(t *testing.T) {
+	store := newTestSecretStore(t)
+	ctx := context.Background()
+
+	err := store.StoreSecret(ctx, &secretsinterfaces.SecretRequest{
+		Key:       "ad/test.example.com/svc_password",
+		Value:     "super-secret-password",
+		CreatedBy: "test",
+		TenantID:  "test",
+	})
+	require.NoError(t, err)
+
+	config := &ADModuleConfig{
+		Domain:            "test.example.com",
+		AuthMethod:        "simple",
+		PasswordSecretKey: "ad/test.example.com/svc_password",
+	}
+	authManager := NewAuthenticationManager(config, store)
+
+	password, err := authManager.resolvePassword(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, "super-secret-password", password)
+}
+
+func TestResolvePassword_MissingKey(t *testing.T) {
+	store := newTestSecretStore(t)
+	ctx := context.Background()
+
+	config := &ADModuleConfig{
+		Domain:     "test.example.com",
+		AuthMethod: "simple",
+		// PasswordSecretKey intentionally empty
+	}
+	authManager := NewAuthenticationManager(config, store)
+
+	_, err := authManager.resolvePassword(ctx)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "PasswordSecretKey is required")
+}
+
+func TestResolvePassword_KeyNotFound(t *testing.T) {
+	store := newTestSecretStore(t)
+	ctx := context.Background()
+
+	// Key is set but the secret has not been stored
+	config := &ADModuleConfig{
+		Domain:            "test.example.com",
+		AuthMethod:        "simple",
+		PasswordSecretKey: "ad/test.example.com/nonexistent",
+	}
+	authManager := NewAuthenticationManager(config, store)
+
+	_, err := authManager.resolvePassword(ctx)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to retrieve password from secret store")
+}
+
+func TestResolvePassword_NilStore(t *testing.T) {
+	ctx := context.Background()
+
+	config := &ADModuleConfig{
+		Domain:            "test.example.com",
+		AuthMethod:        "simple",
+		PasswordSecretKey: "ad/test.example.com/svc_password",
+	}
+	authManager := NewAuthenticationManager(config, nil)
+
+	_, err := authManager.resolvePassword(ctx)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no SecretStore configured")
+}

--- a/features/modules/network_activedirectory/integration_test.go
+++ b/features/modules/network_activedirectory/integration_test.go
@@ -34,25 +34,25 @@ func TestADModuleIntegration(t *testing.T) {
 
 	// Test configuration for basic domain
 	basicConfig := &ADModuleConfig{
-		Domain:         "test.local",
-		AuthMethod:     "simple",
-		Username:       "testuser",
-		Password:       "testpass",
-		OperationType:  "read",
-		ObjectTypes:    []string{"user", "group", "organizational_unit"},
-		UseTLS:         false,
-		Port:           389,
-		PageSize:       100,
-		MaxConnections: 5,
-		RequestTimeout: 30 * time.Second,
+		Domain:            "test.local",
+		AuthMethod:        "simple",
+		Username:          "testuser",
+		PasswordSecretKey: "ad/test.local/svc_password",
+		OperationType:     "read",
+		ObjectTypes:       []string{"user", "group", "organizational_unit"},
+		UseTLS:            false,
+		Port:              389,
+		PageSize:          100,
+		MaxConnections:    5,
+		RequestTimeout:    30 * time.Second,
 	}
 
 	t.Run("Basic Domain Operations", func(t *testing.T) {
 		t.Run("Set Configuration", func(t *testing.T) {
 			err := module.Set(ctx, "config", basicConfig)
 			if err != nil {
-				t.Logf("Note: Actual AD server required for real connection test. Mock error: %v", err)
-				// Continue with mock tests
+				t.Logf("Note: Actual AD server required for real connection test. Connection error: %v", err)
+				// Continue with remaining subtests; they assert "not connected" for any AD operations
 			}
 		})
 
@@ -570,19 +570,20 @@ func TestADModuleRealWorldScenarios(t *testing.T) {
 
 		t.Run("Credential Security", func(t *testing.T) {
 			configWithCreds := &ADModuleConfig{
-				Domain:        "test.local",
-				AuthMethod:    "simple",
-				Username:      "serviceaccount",
-				Password:      "supersecret",
-				OperationType: "read",
-				ObjectTypes:   []string{"user"},
+				Domain:            "test.local",
+				AuthMethod:        "simple",
+				Username:          "serviceaccount",
+				PasswordSecretKey: "ad/test.local/svc_password",
+				OperationType:     "read",
+				ObjectTypes:       []string{"user"},
 			}
 
-			// Test that YAML serialization hides passwords
+			// Test that YAML serialization contains the secret key reference but no plaintext password
 			yamlData, err := configWithCreds.ToYAML()
 			require.NoError(t, err)
-			assert.Contains(t, string(yamlData), "[REDACTED]")
-			assert.NotContains(t, string(yamlData), "supersecret")
+			yamlStr := string(yamlData)
+			assert.Contains(t, yamlStr, "password_secret_key")
+			assert.NotContains(t, yamlStr, "password:")
 		})
 	})
 }
@@ -690,12 +691,12 @@ func TestADModuleFailureScenarios(t *testing.T) {
 	t.Run("Authentication Failure Scenarios", func(t *testing.T) {
 		// Test behavior with invalid credentials
 		invalidAuthConfig := &ADModuleConfig{
-			Domain:        "test.local",
-			AuthMethod:    "simple",
-			Username:      "invalid_user",
-			Password:      "wrong_password",
-			OperationType: "read",
-			ObjectTypes:   []string{"user"},
+			Domain:            "test.local",
+			AuthMethod:        "simple",
+			Username:          "invalid_user",
+			PasswordSecretKey: "ad/test.local/invalid_password",
+			OperationType:     "read",
+			ObjectTypes:       []string{"user"},
 		}
 
 		err := module.Set(ctx, "config", invalidAuthConfig)

--- a/features/modules/network_activedirectory/module.go
+++ b/features/modules/network_activedirectory/module.go
@@ -15,11 +15,13 @@ import (
 	"github.com/cfgis/cfgms/features/modules"
 	"github.com/cfgis/cfgms/pkg/directory/interfaces"
 	"github.com/cfgis/cfgms/pkg/logging"
+	secretsinterfaces "github.com/cfgis/cfgms/pkg/secrets/interfaces"
 )
 
 // activeDirectoryModule implements the Module interface for Active Directory management
 type activeDirectoryModule struct {
-	logger logging.Logger
+	logger      logging.Logger
+	secretStore secretsinterfaces.SecretStore
 
 	// Connection management
 	conn    *ldap.Conn
@@ -37,6 +39,11 @@ type activeDirectoryModule struct {
 		lastRequest  time.Time
 		connectedAt  time.Time
 	}
+}
+
+// SetSecretStore injects a secret store for password resolution.
+func (m *activeDirectoryModule) SetSecretStore(store secretsinterfaces.SecretStore) {
+	m.secretStore = store
 }
 
 // New creates a new instance of the Active Directory module
@@ -127,8 +134,8 @@ func (m *activeDirectoryModule) Set(ctx context.Context, resourceID string, conf
 	if username, ok := configMap["username"].(string); ok {
 		adConfig.Username = username
 	}
-	if password, ok := configMap["password"].(string); ok {
-		adConfig.Password = password
+	if passwordSecretKey, ok := configMap["password_secret_key"].(string); ok {
+		adConfig.PasswordSecretKey = passwordSecretKey
 	}
 	if searchBase, ok := configMap["search_base"].(string); ok {
 		adConfig.SearchBase = searchBase
@@ -187,7 +194,7 @@ func (m *activeDirectoryModule) Set(ctx context.Context, resourceID string, conf
 	m.config = adConfig
 
 	// Initialize authentication manager
-	m.authManager = NewAuthenticationManager(adConfig)
+	m.authManager = NewAuthenticationManager(adConfig, m.secretStore)
 
 	// Establish new connection
 	if err := m.connect(ctx); err != nil {

--- a/features/modules/network_activedirectory/module_test.go
+++ b/features/modules/network_activedirectory/module_test.go
@@ -16,12 +16,12 @@ import (
 func TestADModuleConfig(t *testing.T) {
 	t.Run("valid configuration", func(t *testing.T) {
 		config := &ADModuleConfig{
-			Domain:        "example.com",
-			AuthMethod:    "simple",
-			OperationType: "read",
-			ObjectTypes:   []string{"user", "group"},
-			Username:      "service-account",
-			Password:      "password123",
+			Domain:            "example.com",
+			AuthMethod:        "simple",
+			OperationType:     "read",
+			ObjectTypes:       []string{"user", "group"},
+			Username:          "service-account",
+			PasswordSecretKey: "ad/example.com/svc_password",
 		}
 
 		err := config.Validate()
@@ -90,21 +90,21 @@ func TestADModuleConfig(t *testing.T) {
 
 	t.Run("YAML serialization", func(t *testing.T) {
 		config := &ADModuleConfig{
-			Domain:        "example.com",
-			AuthMethod:    "simple",
-			OperationType: "read",
-			ObjectTypes:   []string{"user", "group"},
-			Username:      "service-account",
-			Password:      "secret123",
+			Domain:            "example.com",
+			AuthMethod:        "simple",
+			OperationType:     "read",
+			ObjectTypes:       []string{"user", "group"},
+			Username:          "service-account",
+			PasswordSecretKey: "ad/example.com/svc_password",
 		}
 
-		// Test ToYAML (should redact password)
+		// Test ToYAML — password_secret_key is serialized; no plaintext password exists
 		yamlData, err := config.ToYAML()
 		require.NoError(t, err)
 		yamlStr := string(yamlData)
 		assert.Contains(t, yamlStr, "domain: example.com")
-		assert.Contains(t, yamlStr, "[REDACTED]")
-		assert.NotContains(t, yamlStr, "secret123")
+		assert.Contains(t, yamlStr, "password_secret_key: ad/example.com/svc_password")
+		assert.NotContains(t, yamlStr, "password:")
 
 		// Test FromYAML
 		newConfig := &ADModuleConfig{}
@@ -112,6 +112,7 @@ func TestADModuleConfig(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, "example.com", newConfig.Domain)
 		assert.Equal(t, "simple", newConfig.AuthMethod)
+		assert.Equal(t, "ad/example.com/svc_password", newConfig.PasswordSecretKey)
 	})
 }
 

--- a/features/modules/network_activedirectory/types.go
+++ b/features/modules/network_activedirectory/types.go
@@ -26,9 +26,9 @@ type ADModuleConfig struct {
 	CrossDomainAuth bool     `yaml:"cross_domain_auth"`           // Enable cross-domain authentication
 
 	// Authentication
-	AuthMethod string `yaml:"auth_method"`        // "kerberos", "ntlm", "simple"
-	Username   string `yaml:"username,omitempty"` // Service account username
-	Password   string `yaml:"password,omitempty"` // Service account password
+	AuthMethod        string `yaml:"auth_method"`                   // "kerberos", "ntlm", "simple"
+	Username          string `yaml:"username,omitempty"`            // Service account username
+	PasswordSecretKey string `yaml:"password_secret_key,omitempty"` // pkg/secrets key for the service account password
 
 	// Search configuration
 	SearchBase string `yaml:"search_base,omitempty"` // Base DN for searches
@@ -65,6 +65,9 @@ func (c *ADModuleConfig) AsMap() map[string]interface{} {
 	if c.Username != "" {
 		result["username"] = c.Username
 	}
+	if c.PasswordSecretKey != "" {
+		result["password_secret_key"] = c.PasswordSecretKey
+	}
 	if c.SearchBase != "" {
 		result["search_base"] = c.SearchBase
 	}
@@ -95,10 +98,7 @@ func (c *ADModuleConfig) AsMap() map[string]interface{} {
 
 // ToYAML serializes the configuration to YAML
 func (c *ADModuleConfig) ToYAML() ([]byte, error) {
-	// Create a copy without sensitive fields for serialization
-	safe := *c
-	safe.Password = "[REDACTED]"
-	return yaml.Marshal(safe)
+	return yaml.Marshal(c)
 }
 
 // FromYAML deserializes YAML data into the configuration


### PR DESCRIPTION
## Summary

- Removes `Password string` from `ADModuleConfig` — no more plaintext passwords in YAML configs or the live call path
- Adds `PasswordSecretKey string` (yaml: `password_secret_key`) that holds the `pkg/secrets` key name; password is resolved at auth time via `secretStore.GetSecret`
- Deletes `SecureCredentialStorage` struct and its three methods — zero callers (grep-confirmed dead code)
- Injects `secretsinterfaces.SecretStore` into `activeDirectoryModule` via `SetSecretStore()`, wired through `NewAuthenticationManager()`

## Test plan

- [x] `TestResolvePassword_Success` — real steward store, pre-stored secret, verifies password retrieval
- [x] `TestResolvePassword_MissingKey` — empty `PasswordSecretKey` returns actionable error message
- [x] `TestResolvePassword_KeyNotFound` — valid key not in store returns wrapped `GetSecret` error
- [x] `TestResolvePassword_NilStore` — nil store returns clear `"no SecretStore configured"` error
- [x] Existing module_test.go and integration_test.go updated to use `PasswordSecretKey`
- [x] `go test ./features/modules/network_activedirectory/...` passes

## Specialist Review Results

| Agent | Result |
|-------|--------|
| qa-test-runner | PASS — all code quality, lint, test, build gates passed; Trivy blocked by sandbox DNS (environmental) |
| qa-code-reviewer | PASS — real store used in tests, all 4 error paths covered, no mocks |
| security-engineer | PASS — no plaintext password remains, resolvePassword does not log secret value, architecture compliance verified, SecureCredentialStorage fully deleted |

## Migration Note

Pre-production clean break. YAML configs with `password:` continue to parse silently (Go YAML ignores unknown fields) but the value is no longer used. Operators must:
1. Pre-store the password: `secretStore.StoreSecret(ctx, &SecretRequest{Key: "ad/<domain>/svc_password", Value: "<password>", ...})`
2. Set `password_secret_key: "ad/<domain>/svc_password"` in their AD module config

Part of Epic #728 — adopt pkg/secrets / remove custom credential encryption.

🤖 Generated with [Claude Code](https://claude.com/claude-code)