### PR TITLE
terminal: fix WindowsExecutor channel-close race

### DIFF
--- a/features/terminal/shell/windows.go
+++ b/features/terminal/shell/windows.go
@@ -10,12 +10,12 @@ import (
 	"os/exec"
 	"sync"
 	"syscall"
-	"time"
 )
 
 // WindowsExecutor implements shell execution for Windows systems
 type WindowsExecutor struct {
 	mu       sync.RWMutex
+	wg       sync.WaitGroup
 	config   *Config
 	cmd      *exec.Cmd
 	stdin    io.WriteCloser
@@ -126,6 +126,9 @@ func (e *WindowsExecutor) Start(ctx context.Context, config *Config) error {
 
 	e.running = true
 
+	// Track writer goroutines so Close can wait for them before closing channels
+	e.wg.Add(3)
+
 	// Start output readers
 	go e.readOutput(e.stdout, false) // stdout
 	go e.readOutput(e.stderr, true)  // stderr
@@ -216,11 +219,11 @@ func (e *WindowsExecutor) Close(ctx context.Context) error {
 		_ = stderr.Close()
 	}
 
-	// Give goroutines a moment to see the context cancellation
-	// before closing channels
-	time.Sleep(10 * time.Millisecond)
+	// Wait for writer goroutines to exit before closing channels.
+	// Without this barrier, a writer can race with close() and the race
+	// detector flags chansend-on-closed-channel.
+	e.wg.Wait()
 
-	// Close channels - safe now that goroutines should have exited
 	close(e.outputCh)
 	close(e.errorCh)
 
@@ -246,6 +249,7 @@ func (e *WindowsExecutor) IsRunning() bool {
 
 // readOutput reads output from stdout or stderr and sends it to the output channel
 func (e *WindowsExecutor) readOutput(reader io.ReadCloser, isStderr bool) {
+	defer e.wg.Done()
 	defer func() {
 		if isStderr {
 			return // Don't mark as not running for stderr reader
@@ -294,6 +298,8 @@ func (e *WindowsExecutor) readOutput(reader io.ReadCloser, isStderr bool) {
 
 // monitorProcess monitors the shell process and handles its exit
 func (e *WindowsExecutor) monitorProcess() {
+	defer e.wg.Done()
+
 	if e.cmd == nil {
 		return
 	}


### PR DESCRIPTION
## Summary

`WindowsExecutor.Close()` closed `outputCh`/`errorCh` after a 10ms `time.Sleep` — a hopeful pause, not a synchronization primitive. On Windows, the `readOutput` and `monitorProcess` goroutines could still be mid-chansend when the close happened, and the race detector flagged chansend-on-closed-channel.

This PR replaces the sleep with a `sync.WaitGroup` so `Close()` waits for all three writer goroutines (stdout reader, stderr reader, process monitor) to exit before closing the channels.

## Why now

`TestSessionDataHandling` started failing on `Native Build (windows-latest)` across two unrelated PRs (#1110 — controller cleanup, #1119 — workflow refactor). Their diffs altered test scheduling enough to lose the 10ms race. Both fix-cycle agents would have spent compute trying to debug failures that aren't caused by their PRs. Pre-existing latent bug, surfaced under contention.

## Failure signature (from CI)

```
WARNING: DATA RACE
Write at 0x00c0004656d0 by goroutine 235:
  runtime.closechan()
  features/terminal/shell.(*WindowsExecutor).Close()
      windows.go:225
Previous read at 0x00c0004656d0 by goroutine 237:
  runtime.chansend()
  features/terminal/shell.(*WindowsExecutor).readOutput()
      windows.go:268
```

## Test plan

- [x] `make test` — 46/46 passed
- [x] `go test -race ./features/terminal/... -timeout 120s` — all green locally (the race only manifests on Windows where `WindowsExecutor` is actually used, but the WaitGroup change is portable Go)
- [ ] Windows CI confirms `TestSessionDataHandling` now passes under `-race`

🤖 Generated with [Claude Code](https://claude.com/claude-code)