### PR TITLE
saas: replace plaintext colon-joined credentials with SecretStoreCredentialStore (Issue #1112)

### DIFF
--- a/features/saas/README.md
+++ b/features/saas/README.md
@@ -315,4 +315,4 @@ The SaaS Steward is designed to be:
 - **Secure**: Industry-standard OAuth2 implementation
 - **Extensible**: Plugin architecture for new providers
 - **Observable**: Comprehensive logging and monitoring
-- **Testable**: Real components (InMemoryConsentStore, MockCredentialStore) for unit testing
+- **Testable**: Real components (InMemoryConsentStore, SecretStoreCredentialStore) for unit testing

--- a/features/saas/auth.go
+++ b/features/saas/auth.go
@@ -20,6 +20,7 @@ package saas
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -190,9 +191,20 @@ func (ua *UniversalAuthenticator) authenticateAPIKey(ctx context.Context, provid
 		return fmt.Errorf("invalid API key config: %w", err)
 	}
 
-	// Store the API key configuration
-	configData := fmt.Sprintf("%s:%s:%s", apiKeyConfig.Key, apiKeyConfig.Header, apiKeyConfig.QueryParam)
-	return ua.credStore.StoreClientSecret(provider, configData)
+	// Store the API key configuration as JSON
+	data, err := json.Marshal(struct {
+		Key        string `json:"key"`
+		Header     string `json:"header"`
+		QueryParam string `json:"query_param"`
+	}{
+		Key:        apiKeyConfig.Key,
+		Header:     apiKeyConfig.Header,
+		QueryParam: apiKeyConfig.QueryParam,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to marshal API key config: %w", err)
+	}
+	return ua.credStore.StoreClientSecret(provider, string(data))
 }
 
 func (ua *UniversalAuthenticator) getAPIKeyHeaders(provider string) (map[string]string, error) {
@@ -201,18 +213,19 @@ func (ua *UniversalAuthenticator) getAPIKeyHeaders(provider string) (map[string]
 		return nil, fmt.Errorf("failed to get API key config: %w", err)
 	}
 
-	parts := strings.Split(configData, ":")
-	if len(parts) < 3 {
-		return nil, fmt.Errorf("invalid API key config format")
+	var apiKey struct {
+		Key        string `json:"key"`
+		Header     string `json:"header"`
+		QueryParam string `json:"query_param"`
+	}
+	if err := json.Unmarshal([]byte(configData), &apiKey); err != nil {
+		return nil, fmt.Errorf("invalid API key config: %w", err)
 	}
 
-	key, header := parts[0], parts[1]
-	if header != "" {
-		return map[string]string{header: key}, nil
+	if apiKey.Header != "" {
+		return map[string]string{apiKey.Header: apiKey.Key}, nil
 	}
-
-	// Default to X-API-Key header
-	return map[string]string{"X-API-Key": key}, nil
+	return map[string]string{"X-API-Key": apiKey.Key}, nil
 }
 
 // Basic Authentication Implementation
@@ -223,9 +236,18 @@ func (ua *UniversalAuthenticator) authenticateBasicAuth(ctx context.Context, pro
 		return fmt.Errorf("invalid basic auth config: %w", err)
 	}
 
-	// Store username:password
-	configData := fmt.Sprintf("%s:%s", basicConfig.Username, basicConfig.Password)
-	return ua.credStore.StoreClientSecret(provider, configData)
+	// Store username and password as JSON
+	data, err := json.Marshal(struct {
+		Username string `json:"username"`
+		Password string `json:"password"`
+	}{
+		Username: basicConfig.Username,
+		Password: basicConfig.Password,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to marshal basic auth config: %w", err)
+	}
+	return ua.credStore.StoreClientSecret(provider, string(data))
 }
 
 func (ua *UniversalAuthenticator) getBasicAuthHeaders(provider string) (map[string]string, error) {
@@ -234,8 +256,17 @@ func (ua *UniversalAuthenticator) getBasicAuthHeaders(provider string) (map[stri
 		return nil, fmt.Errorf("failed to get basic auth config: %w", err)
 	}
 
+	var basicAuth struct {
+		Username string `json:"username"`
+		Password string `json:"password"`
+	}
+	if err := json.Unmarshal([]byte(configData), &basicAuth); err != nil {
+		return nil, fmt.Errorf("invalid basic auth config: %w", err)
+	}
+
+	encoded := base64.StdEncoding.EncodeToString([]byte(basicAuth.Username + ":" + basicAuth.Password))
 	return map[string]string{
-		"Authorization": "Basic " + configData, // Should be base64 encoded
+		"Authorization": "Basic " + encoded,
 	}, nil
 }
 

--- a/features/saas/m365_tenant_manager_test.go
+++ b/features/saas/m365_tenant_manager_test.go
@@ -112,7 +112,7 @@ func setupTestManager(t *testing.T) (*M365TenantManager, *mockTenantStore, conte
 	cfgmsTenantManager := tenant.NewManager(mockStore, nil)
 
 	// Create credential store
-	mockCredStore := NewMockCredentialStore()
+	mockCredStore := newTestCredentialStore(t)
 
 	// Create M365 provider
 	httpClient := NewGraphHTTPClient(100, 1000)
@@ -532,7 +532,7 @@ func setupTestManagerWithCountingStore(t *testing.T) (*M365TenantManager, *count
 	ctx := context.Background()
 	counting := &countingTenantStore{mockTenantStore: newMockTenantStore()}
 	cfgmsTenantManager := tenant.NewManager(counting, nil)
-	m365Provider := NewMicrosoftMultiTenantProvider(NewMockCredentialStore(), NewGraphHTTPClient(100, 1000))
+	m365Provider := NewMicrosoftMultiTenantProvider(newTestCredentialStore(t), NewGraphHTTPClient(100, 1000))
 	manager := NewM365TenantManager(cfgmsTenantManager, m365Provider, nil, nil)
 	return manager, counting, ctx
 }
@@ -592,7 +592,7 @@ func TestM365TenantManager_GetTenantByM365ID_ListTenantsError(t *testing.T) {
 		listErr:         fmt.Errorf("storage unavailable"),
 	}
 	cfgmsTenantManager := tenant.NewManager(failing, nil)
-	m365Provider := NewMicrosoftMultiTenantProvider(NewMockCredentialStore(), NewGraphHTTPClient(100, 1000))
+	m365Provider := NewMicrosoftMultiTenantProvider(newTestCredentialStore(t), NewGraphHTTPClient(100, 1000))
 	manager := NewM365TenantManager(cfgmsTenantManager, m365Provider, nil, nil)
 
 	// ListTenants fails → getTenantByM365ID must propagate the error.
@@ -645,7 +645,7 @@ func BenchmarkM365TenantManager_DiscoverAndSyncTenants(b *testing.B) {
 
 		mockStore := newMockTenantStore()
 		cfgmsTenantManager := tenant.NewManager(mockStore, nil)
-		m365Provider := NewMicrosoftMultiTenantProvider(NewMockCredentialStore(), NewGraphHTTPClient(100, 1000))
+		m365Provider := NewMicrosoftMultiTenantProvider(newBenchCredentialStore(b), NewGraphHTTPClient(100, 1000))
 		gdap := &mockGDAPProvider{relationships: relationships}
 		manager := NewM365TenantManager(cfgmsTenantManager, m365Provider, nil, gdap)
 

--- a/features/saas/multitenant_test.go
+++ b/features/saas/multitenant_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"sync"
@@ -41,55 +40,6 @@ func (s *stubTenantDiscoverer) DiscoverTenants(_ context.Context, _ *TokenSet) (
 // newStubTenantDiscoverer returns a stub that returns the given tenants on every call.
 func newStubTenantDiscoverer(tenants ...TenantInfo) *stubTenantDiscoverer {
 	return &stubTenantDiscoverer{tenants: tenants}
-}
-
-// Mock implementations for testing
-
-// MockCredentialStore implements CredentialStore for testing token and client-secret
-// operations. It must NOT be used for consent state — use InMemoryConsentStore instead.
-type MockCredentialStore struct {
-	tokens  map[string]*TokenSet
-	secrets map[string]string
-}
-
-func NewMockCredentialStore() *MockCredentialStore {
-	return &MockCredentialStore{
-		tokens:  make(map[string]*TokenSet),
-		secrets: make(map[string]string),
-	}
-}
-
-func (m *MockCredentialStore) StoreTokenSet(provider string, tokens *TokenSet) error {
-	m.tokens[provider] = tokens
-	return nil
-}
-
-func (m *MockCredentialStore) GetTokenSet(provider string) (*TokenSet, error) {
-	if tokens, exists := m.tokens[provider]; exists {
-		return tokens, nil
-	}
-	return nil, fmt.Errorf("token set not found for provider: %s", provider)
-}
-
-func (m *MockCredentialStore) DeleteTokenSet(provider string) error {
-	delete(m.tokens, provider)
-	return nil
-}
-
-func (m *MockCredentialStore) StoreClientSecret(provider, clientSecret string) error {
-	m.secrets[provider] = clientSecret
-	return nil
-}
-
-func (m *MockCredentialStore) GetClientSecret(provider string) (string, error) {
-	if secret, exists := m.secrets[provider]; exists {
-		return secret, nil
-	}
-	return "", fmt.Errorf("client secret not found for provider: %s", provider)
-}
-
-func (m *MockCredentialStore) IsAvailable() bool {
-	return true
 }
 
 // Test MultiTenantManager
@@ -138,7 +88,7 @@ func TestMultiTenantManager_StartAdminConsent(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			credStore := NewMockCredentialStore()
+			credStore := newTestCredentialStore(t)
 			consentStore := NewInMemoryConsentStore()
 			httpClient := NewGraphHTTPClient(100, 1000)
 			mtm := NewMultiTenantManager(credStore, consentStore, httpClient, newStubTenantDiscoverer())
@@ -215,7 +165,7 @@ func TestMultiTenantManager_CompleteAdminConsent(t *testing.T) {
 			}))
 			defer tokenServer.Close()
 
-			credStore := NewMockCredentialStore()
+			credStore := newTestCredentialStore(t)
 			consentStore := NewInMemoryConsentStore()
 			// Use the real DefaultOAuth2Client so ExchangeCode hits the httptest server.
 			// Wire a stub discoverer so discoverTenants returns stubTenants without HTTP calls.
@@ -317,7 +267,7 @@ func TestMultiTenantManager_DiscoverTenantsErrors(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			credStore := NewMockCredentialStore()
+			credStore := newTestCredentialStore(t)
 			consentStore := NewInMemoryConsentStore()
 			mtm := NewMultiTenantManager(credStore, consentStore, NewGraphHTTPClient(100, 1000), tt.discoverer)
 
@@ -446,7 +396,7 @@ func TestDefaultOAuth2Client_ExchangeCode(t *testing.T) {
 }
 
 func TestMultiTenantManager_GetTenantToken(t *testing.T) {
-	credStore := NewMockCredentialStore()
+	credStore := newTestCredentialStore(t)
 	consentStore := NewInMemoryConsentStore()
 	httpClient := NewGraphHTTPClient(100, 1000)
 	mtm := NewMultiTenantManager(credStore, consentStore, httpClient, newStubTenantDiscoverer())
@@ -484,7 +434,7 @@ func TestMultiTenantManager_GetTenantToken(t *testing.T) {
 }
 
 func TestMultiTenantManager_GetTenantToken_NoAccess(t *testing.T) {
-	credStore := NewMockCredentialStore()
+	credStore := newTestCredentialStore(t)
 	consentStore := NewInMemoryConsentStore()
 	httpClient := NewGraphHTTPClient(100, 1000)
 	mtm := NewMultiTenantManager(credStore, consentStore, httpClient, newStubTenantDiscoverer())
@@ -518,7 +468,7 @@ func TestMultiTenantManager_GetTenantToken_NoAccess(t *testing.T) {
 }
 
 func TestMultiTenantManager_GetTenantToken_TIDMismatch(t *testing.T) {
-	credStore := NewMockCredentialStore()
+	credStore := newTestCredentialStore(t)
 	consentStore := NewInMemoryConsentStore()
 	mtm := NewMultiTenantManager(credStore, consentStore, NewGraphHTTPClient(100, 1000), newStubTenantDiscoverer())
 
@@ -550,7 +500,7 @@ func TestMultiTenantManager_GetTenantToken_TIDMismatch(t *testing.T) {
 }
 
 func TestMultiTenantManager_GetTenantToken_OpaqueToken(t *testing.T) {
-	credStore := NewMockCredentialStore()
+	credStore := newTestCredentialStore(t)
 	consentStore := NewInMemoryConsentStore()
 	mtm := NewMultiTenantManager(credStore, consentStore, NewGraphHTTPClient(100, 1000), newStubTenantDiscoverer())
 
@@ -581,7 +531,7 @@ func TestMultiTenantManager_GetTenantToken_OpaqueToken(t *testing.T) {
 }
 
 func TestMultiTenantManager_GetTenantToken_ExpiredToken_RefreshNotImplemented(t *testing.T) {
-	credStore := NewMockCredentialStore()
+	credStore := newTestCredentialStore(t)
 	consentStore := NewInMemoryConsentStore()
 	mtm := NewMultiTenantManager(credStore, consentStore, NewGraphHTTPClient(100, 1000), newStubTenantDiscoverer())
 
@@ -612,7 +562,7 @@ func TestMultiTenantManager_GetTenantToken_ExpiredToken_RefreshNotImplemented(t 
 }
 
 func TestMultiTenantManager_ListAccessibleTenants(t *testing.T) {
-	credStore := NewMockCredentialStore()
+	credStore := newTestCredentialStore(t)
 	consentStore := NewInMemoryConsentStore()
 	httpClient := NewGraphHTTPClient(100, 1000)
 	mtm := NewMultiTenantManager(credStore, consentStore, httpClient, newStubTenantDiscoverer())
@@ -651,7 +601,7 @@ func TestMultiTenantManager_ListAccessibleTenants(t *testing.T) {
 }
 
 func TestMultiTenantManager_RevokeConsent(t *testing.T) {
-	credStore := NewMockCredentialStore()
+	credStore := newTestCredentialStore(t)
 	consentStore := NewInMemoryConsentStore()
 	httpClient := NewGraphHTTPClient(100, 1000)
 	mtm := NewMultiTenantManager(credStore, consentStore, httpClient, newStubTenantDiscoverer())
@@ -709,7 +659,7 @@ func TestMultiTenantManager_RevokeConsent(t *testing.T) {
 // Test MicrosoftMultiTenantProvider
 
 func TestMicrosoftMultiTenantProvider_Creation(t *testing.T) {
-	credStore := NewMockCredentialStore()
+	credStore := newTestCredentialStore(t)
 	httpClient := NewGraphHTTPClient(100, 1000)
 
 	provider := NewMicrosoftMultiTenantProvider(credStore, httpClient)
@@ -720,7 +670,7 @@ func TestMicrosoftMultiTenantProvider_Creation(t *testing.T) {
 }
 
 func TestMicrosoftMultiTenantProvider_StartAdminConsent(t *testing.T) {
-	credStore := NewMockCredentialStore()
+	credStore := newTestCredentialStore(t)
 	httpClient := NewGraphHTTPClient(100, 1000)
 	provider := NewMicrosoftMultiTenantProvider(credStore, httpClient)
 
@@ -778,7 +728,7 @@ func TestMicrosoftMultiTenantProvider_CreateInTenant(t *testing.T) {
 			}))
 			defer server.Close()
 
-			credStore := NewMockCredentialStore()
+			credStore := newTestCredentialStore(t)
 			provider := NewMicrosoftMultiTenantProvider(credStore, server.Client())
 			provider.baseURL = server.URL
 
@@ -828,7 +778,7 @@ func TestMicrosoftMultiTenantProvider_CreateInTenant(t *testing.T) {
 // Test TenantOnboardingWorkflow
 
 func TestTenantOnboardingWorkflow_StartTenantOnboarding(t *testing.T) {
-	credStore := NewMockCredentialStore()
+	credStore := newTestCredentialStore(t)
 	httpClient := NewGraphHTTPClient(100, 1000)
 	provider := NewMicrosoftMultiTenantProvider(credStore, httpClient)
 	providerCfg := &MicrosoftMultiTenantConfig{
@@ -871,7 +821,7 @@ func TestTenantOnboardingWorkflow_StartTenantOnboarding(t *testing.T) {
 }
 
 func TestTenantOnboardingWorkflow_StartAdminConsentFlow_UsesProviderConfig(t *testing.T) {
-	credStore := NewMockCredentialStore()
+	credStore := newTestCredentialStore(t)
 	httpClient := NewGraphHTTPClient(100, 1000)
 	provider := NewMicrosoftMultiTenantProvider(credStore, httpClient)
 
@@ -915,7 +865,7 @@ func TestTenantOnboardingWorkflow_StartAdminConsentFlow_UsesProviderConfig(t *te
 }
 
 func TestTenantOnboardingWorkflow_StartAdminConsentFlow_NilConfig(t *testing.T) {
-	credStore := NewMockCredentialStore()
+	credStore := newTestCredentialStore(t)
 	httpClient := NewGraphHTTPClient(100, 1000)
 	provider := NewMicrosoftMultiTenantProvider(credStore, httpClient)
 	workflow := NewTenantOnboardingWorkflow(provider, nil)
@@ -1033,7 +983,7 @@ func TestTenantOnboardingWorkflow_ValidateRequest(t *testing.T) {
 // tenantCache has no direct read paths in the current code, so this test exercises
 // write-write safety. The RWMutex is chosen to be forward-compatible with future reads.
 func TestMultiTenantManager_TenantCacheConcurrency(t *testing.T) {
-	credStore := NewMockCredentialStore()
+	credStore := newTestCredentialStore(t)
 	consentStore := NewInMemoryConsentStore()
 	httpClient := NewGraphHTTPClient(100, 1000)
 	// Stub returns one deterministic tenant so RefreshTenantDiscovery writes a
@@ -1103,7 +1053,7 @@ func TestMultiTenantManager_TenantCacheConcurrency(t *testing.T) {
 // non-tenant-aware CRUD methods return ErrNoTenantSelected with a nil result.
 // Callers that need to act on a specific tenant must use the *InTenant variants.
 func TestMicrosoftMultiTenantProvider_TenantlessCRUD(t *testing.T) {
-	credStore := NewMockCredentialStore()
+	credStore := newTestCredentialStore(t)
 	httpClient := NewGraphHTTPClient(100, 1000)
 	provider := NewMicrosoftMultiTenantProvider(credStore, httpClient)
 	ctx := context.Background()
@@ -1158,7 +1108,7 @@ func TestMicrosoftMultiTenantProvider_TenantlessCRUD(t *testing.T) {
 // Benchmarks
 
 func BenchmarkMultiTenantManager_GetTenantToken(b *testing.B) {
-	credStore := NewMockCredentialStore()
+	credStore := newBenchCredentialStore(b)
 	consentStore := NewInMemoryConsentStore()
 	httpClient := NewGraphHTTPClient(100, 1000)
 	mtm := NewMultiTenantManager(credStore, consentStore, httpClient, newStubTenantDiscoverer())
@@ -1203,7 +1153,7 @@ func BenchmarkMultiTenantManager_GetTenantToken(b *testing.B) {
 }
 
 func BenchmarkMicrosoftMultiTenantProvider_CreateInTenant(b *testing.B) {
-	credStore := NewMockCredentialStore()
+	credStore := newBenchCredentialStore(b)
 	httpClient := NewGraphHTTPClient(100, 1000)
 	provider := NewMicrosoftMultiTenantProvider(credStore, httpClient)
 

--- a/features/saas/secret_store_credential_store.go
+++ b/features/saas/secret_store_credential_store.go
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+package saas
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	secretsif "github.com/cfgis/cfgms/pkg/secrets/interfaces"
+)
+
+// SecretStoreCredentialStore implements CredentialStore backed by a secretsif.SecretStore.
+// All SecretRequests set TenantID="saas" (fixed) so sops and other multi-tenant backends
+// always receive a non-empty TenantID.
+type SecretStoreCredentialStore struct {
+	secretStore secretsif.SecretStore
+}
+
+// NewSecretStoreCredentialStore returns a CredentialStore backed by the given SecretStore.
+func NewSecretStoreCredentialStore(secretStore secretsif.SecretStore) *SecretStoreCredentialStore {
+	return &SecretStoreCredentialStore{secretStore: secretStore}
+}
+
+// StoreClientSecret stores a client secret for the given provider.
+func (s *SecretStoreCredentialStore) StoreClientSecret(provider, clientSecret string) error {
+	return s.secretStore.StoreSecret(context.Background(), &secretsif.SecretRequest{
+		Key:      "saas/" + provider + "/client_secret",
+		Value:    clientSecret,
+		TenantID: "saas",
+	})
+}
+
+// GetClientSecret retrieves a client secret for the given provider.
+func (s *SecretStoreCredentialStore) GetClientSecret(provider string) (string, error) {
+	secret, err := s.secretStore.GetSecret(context.Background(), "saas/"+provider+"/client_secret")
+	if err != nil {
+		return "", fmt.Errorf("client secret not found for provider %s: %w", provider, err)
+	}
+	return secret.Value, nil
+}
+
+// StoreTokenSet JSON-marshals tokens and stores them for the given provider.
+func (s *SecretStoreCredentialStore) StoreTokenSet(provider string, tokens *TokenSet) error {
+	data, err := json.Marshal(tokens)
+	if err != nil {
+		return fmt.Errorf("failed to marshal token set for provider %s: %w", provider, err)
+	}
+	return s.secretStore.StoreSecret(context.Background(), &secretsif.SecretRequest{
+		Key:      "saas/" + provider + "/token_set",
+		Value:    string(data),
+		TenantID: "saas",
+	})
+}
+
+// GetTokenSet retrieves and unmarshals the token set for the given provider.
+func (s *SecretStoreCredentialStore) GetTokenSet(provider string) (*TokenSet, error) {
+	secret, err := s.secretStore.GetSecret(context.Background(), "saas/"+provider+"/token_set")
+	if err != nil {
+		return nil, fmt.Errorf("token set not found for provider %s: %w", provider, err)
+	}
+	var tokenSet TokenSet
+	if err := json.Unmarshal([]byte(secret.Value), &tokenSet); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal token set for provider %s: %w", provider, err)
+	}
+	return &tokenSet, nil
+}
+
+// DeleteTokenSet removes the token set for the given provider.
+func (s *SecretStoreCredentialStore) DeleteTokenSet(provider string) error {
+	return s.secretStore.DeleteSecret(context.Background(), "saas/"+provider+"/token_set")
+}
+
+// IsAvailable checks if the underlying secret store is healthy.
+func (s *SecretStoreCredentialStore) IsAvailable() bool {
+	return s.secretStore.HealthCheck(context.Background()) == nil
+}

--- a/features/saas/secret_store_credential_store_test.go
+++ b/features/saas/secret_store_credential_store_test.go
@@ -1,0 +1,153 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+package saas
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	stewardprovider "github.com/cfgis/cfgms/pkg/secrets/providers/steward"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newTestCredentialStore creates a SecretStoreCredentialStore backed by a real steward
+// store in a temporary directory. Tests are skipped when /etc/machine-id is absent
+// (required for OS-native key derivation on Linux).
+func newTestCredentialStore(t *testing.T) CredentialStore {
+	t.Helper()
+	if _, err := os.Stat("/etc/machine-id"); os.IsNotExist(err) {
+		t.Skip("skipping: /etc/machine-id not available (required for platform key derivation on Linux)")
+	}
+
+	tmpDir := t.TempDir()
+	provider := &stewardprovider.StewardProvider{}
+	store, err := provider.CreateSecretStore(map[string]interface{}{
+		"secrets_dir": tmpDir,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		if err := store.Close(); err != nil {
+			t.Errorf("failed to close secret store: %v", err)
+		}
+	})
+
+	return NewSecretStoreCredentialStore(store)
+}
+
+// newBenchCredentialStore creates a SecretStoreCredentialStore backed by a real steward
+// store for use in benchmarks.
+func newBenchCredentialStore(b *testing.B) CredentialStore {
+	b.Helper()
+	if _, err := os.Stat("/etc/machine-id"); os.IsNotExist(err) {
+		b.Skip("skipping: /etc/machine-id not available (required for platform key derivation on Linux)")
+	}
+
+	tmpDir := b.TempDir()
+	provider := &stewardprovider.StewardProvider{}
+	store, err := provider.CreateSecretStore(map[string]interface{}{
+		"secrets_dir": tmpDir,
+	})
+	if err != nil {
+		b.Fatalf("failed to create secret store: %v", err)
+	}
+	b.Cleanup(func() {
+		if err := store.Close(); err != nil {
+			b.Errorf("failed to close secret store: %v", err)
+		}
+	})
+
+	return NewSecretStoreCredentialStore(store)
+}
+
+func TestSecretStoreCredentialStore_StoreAndGetClientSecret(t *testing.T) {
+	cs := newTestCredentialStore(t)
+
+	err := cs.StoreClientSecret("test-provider", "super-secret-value")
+	require.NoError(t, err)
+
+	got, err := cs.GetClientSecret("test-provider")
+	require.NoError(t, err)
+	assert.Equal(t, "super-secret-value", got)
+}
+
+func TestSecretStoreCredentialStore_StoreAndGetTokenSet(t *testing.T) {
+	cs := newTestCredentialStore(t)
+
+	tokens := &TokenSet{
+		AccessToken:  "access-token-abc",
+		RefreshToken: "refresh-token-xyz",
+		TokenType:    "Bearer",
+		ExpiresAt:    time.Now().Add(1 * time.Hour).Truncate(time.Second),
+		Scopes:       []string{"read", "write"},
+	}
+
+	err := cs.StoreTokenSet("test-provider", tokens)
+	require.NoError(t, err)
+
+	got, err := cs.GetTokenSet("test-provider")
+	require.NoError(t, err)
+	require.NotNil(t, got)
+
+	assert.Equal(t, tokens.AccessToken, got.AccessToken)
+	assert.Equal(t, tokens.RefreshToken, got.RefreshToken)
+	assert.Equal(t, tokens.TokenType, got.TokenType)
+	assert.Equal(t, tokens.Scopes, got.Scopes)
+	assert.Equal(t, tokens.ExpiresAt.Unix(), got.ExpiresAt.Unix())
+}
+
+func TestSecretStoreCredentialStore_DeleteTokenSet(t *testing.T) {
+	cs := newTestCredentialStore(t)
+
+	tokens := &TokenSet{
+		AccessToken: "access-token",
+		TokenType:   "Bearer",
+	}
+
+	require.NoError(t, cs.StoreTokenSet("del-provider", tokens))
+
+	got, err := cs.GetTokenSet("del-provider")
+	require.NoError(t, err)
+	require.NotNil(t, got)
+
+	require.NoError(t, cs.DeleteTokenSet("del-provider"))
+
+	_, err = cs.GetTokenSet("del-provider")
+	require.Error(t, err)
+}
+
+func TestSecretStoreCredentialStore_GetClientSecret_NotFound(t *testing.T) {
+	cs := newTestCredentialStore(t)
+
+	_, err := cs.GetClientSecret("nonexistent-provider")
+	require.Error(t, err)
+}
+
+func TestSecretStoreCredentialStore_GetTokenSet_NotFound(t *testing.T) {
+	cs := newTestCredentialStore(t)
+
+	_, err := cs.GetTokenSet("nonexistent-provider")
+	require.Error(t, err)
+}
+
+func TestSecretStoreCredentialStore_IsAvailable(t *testing.T) {
+	cs := newTestCredentialStore(t)
+
+	assert.True(t, cs.IsAvailable())
+}
+
+func TestSecretStoreCredentialStore_IsolatedPerProvider(t *testing.T) {
+	cs := newTestCredentialStore(t)
+
+	require.NoError(t, cs.StoreClientSecret("provider-a", "secret-a"))
+	require.NoError(t, cs.StoreClientSecret("provider-b", "secret-b"))
+
+	gotA, err := cs.GetClientSecret("provider-a")
+	require.NoError(t, err)
+	assert.Equal(t, "secret-a", gotA)
+
+	gotB, err := cs.GetClientSecret("provider-b")
+	require.NoError(t, err)
+	assert.Equal(t, "secret-b", gotB)
+}


### PR DESCRIPTION
## Summary

- Replace colon-joined API key config and `username:password` basic auth encoding in `auth.go` with structured JSON, eliminating ambiguity when values contain colons and making the stored format self-describing.
- Add `SecretStoreCredentialStore` that implements `CredentialStore` via `pkg/secrets/interfaces.SecretStore`, so all SaaS credentials are now encrypted at rest by the OS-native steward backend. Every `SecretRequest` sets `TenantID="saas"` (required by the sops backend).
- Delete `MockCredentialStore` from `multitenant_test.go` and replace all 22 call sites across `multitenant_test.go` and `m365_tenant_manager_test.go` with a real steward-backed `SecretStoreCredentialStore`. Tests skip on systems without `/etc/machine-id` (same pattern as the steward provider's own tests).
- Fix latent bug: `getBasicAuthHeaders` now correctly base64-encodes `username:password` per RFC 7617 (prior code emitted an unencoded `"Basic username:password"` header).
- Update `README.md` to replace the stale `MockCredentialStore` reference with `SecretStoreCredentialStore`.

## Test plan

- [x] `TestSecretStoreCredentialStore_StoreAndGetClientSecret` — round-trip client secret
- [x] `TestSecretStoreCredentialStore_StoreAndGetTokenSet` — round-trip TokenSet with all fields
- [x] `TestSecretStoreCredentialStore_DeleteTokenSet` — delete removes secret from store
- [x] `TestSecretStoreCredentialStore_GetClientSecret_NotFound` — missing key returns error
- [x] `TestSecretStoreCredentialStore_GetTokenSet_NotFound` — missing key returns error
- [x] `TestSecretStoreCredentialStore_IsAvailable` — delegates to HealthCheck
- [x] `TestSecretStoreCredentialStore_IsolatedPerProvider` — different providers do not share secrets
- [x] All pre-existing tests in `multitenant_test.go` and `m365_tenant_manager_test.go` pass or skip with infrastructure-appropriate justification
- [x] `make test-agent-complete` — all packages pass, cross-platform builds verified

## Specialist Review Results

- **QA Test Runner**: PASS — 100 packages, all passing; cross-platform builds verified
- **QA Code Reviewer**: PASS — no mocks, no unjustified skips, no empty assertions
- **Security Engineer**: PASS — no blocking issues; gosec warnings are intentional (JSON value encrypted at rest by SecretStore before persistence); `check-architecture` and `security-precommit` pass clean

Fixes #1112

🤖 Generated with [Claude Code](https://claude.com/claude-code)