### PR TITLE
controller: deregister handleGetConfigStatus and delete StreamConfigurationUpdates + dead types (Issue #1101)

### DIFF
--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -245,33 +245,6 @@ paths:
         '401':
           $ref: '#/components/responses/Unauthorized'
 
-  /stewards/{stewardId}/config/status:
-    get:
-      summary: Get configuration status
-      description: Returns the status of configuration deployment on a steward
-      operationId: getConfigStatus
-      tags:
-        - Configuration
-      parameters:
-        - $ref: '#/components/parameters/stewardId'
-      responses:
-        '200':
-          description: Configuration status
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  data:
-                    $ref: '#/components/schemas/ConfigStatusInfo'
-                  timestamp:
-                    type: string
-                    format: date-time
-        '401':
-          $ref: '#/components/responses/Unauthorized'
-        '404':
-          $ref: '#/components/responses/NotFound'
-
   /certificates:
     get:
       summary: List certificates
@@ -775,24 +748,6 @@ components:
                 type: string
               message:
                 type: string
-
-    ConfigStatusInfo:
-      type: object
-      properties:
-        steward_id:
-          type: string
-        config_version:
-          type: string
-        last_applied:
-          type: string
-          format: date-time
-        status:
-          type: string
-          enum: [pending, applied, failed, unknown]
-        errors:
-          type: array
-          items:
-            type: string
 
     CertificateInfo:
       type: object

--- a/features/controller/api/handlers_stewards.go
+++ b/features/controller/api/handlers_stewards.go
@@ -436,31 +436,6 @@ func (s *Server) handleValidateConfig(w http.ResponseWriter, r *http.Request) {
 	s.writeSuccessResponse(w, result)
 }
 
-// handleGetConfigStatus handles GET /api/v1/stewards/{id}/config/status
-func (s *Server) handleGetConfigStatus(w http.ResponseWriter, r *http.Request) {
-	vars := mux.Vars(r)
-	stewardID := vars["id"]
-
-	if stewardID == "" {
-		s.writeErrorResponse(w, http.StatusBadRequest, "Steward ID is required", "MISSING_STEWARD_ID")
-		return
-	}
-
-	// Get configuration status from the service
-	// For now, we'll return a placeholder since we need to implement this in the service layer
-	// TODO: Implement configuration status tracking in the service layer
-
-	status := ConfigStatusInfo{
-		StewardID:     stewardID,
-		ConfigVersion: "unknown",
-		Status:        "unknown",
-		Modules:       []ModuleStatus{},
-		UpdatedAt:     getCurrentTimestamp(),
-	}
-
-	s.writeSuccessResponse(w, status)
-}
-
 // handleGetEffectiveConfig handles GET /api/v1/stewards/{id}/config/effective
 func (s *Server) handleGetEffectiveConfig(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)

--- a/features/controller/api/handlers_stewards_test.go
+++ b/features/controller/api/handlers_stewards_test.go
@@ -357,3 +357,19 @@ func TestHandleListStewards_HTTPRegistration_NoDuplicates(t *testing.T) {
 	assert.Len(t, resp.Data, 1, "duplicate steward ID should produce exactly one entry")
 	assert.Equal(t, "quarantined", resp.Data[0].Status)
 }
+
+// TestServer_ConfigStatusRouteDeregistered verifies that GET /api/v1/stewards/{id}/config/status
+// is no longer registered and returns 404 or 405, never 200 with hardcoded "unknown" data.
+func TestServer_ConfigStatusRouteDeregistered(t *testing.T) {
+	server := setupTestServer(t)
+	apiKey := NewTestKey(t, server, []string{"steward:read-config"})
+
+	req := httptest.NewRequest("GET", "/api/v1/stewards/any-steward-id/config/status", nil)
+	req.Header.Set("X-API-Key", apiKey)
+	rec := httptest.NewRecorder()
+	server.router.ServeHTTP(rec, req)
+
+	assert.NotEqual(t, http.StatusOK, rec.Code, "config/status route must not return 200 after deregistration")
+	assert.True(t, rec.Code == http.StatusNotFound || rec.Code == http.StatusMethodNotAllowed,
+		"expected 404 or 405, got %d", rec.Code)
+}

--- a/features/controller/api/server.go
+++ b/features/controller/api/server.go
@@ -248,7 +248,6 @@ func (s *Server) setupRouter() {
 	stewards.Handle("/{id}/config", s.requirePermission("steward", "read-config")(http.HandlerFunc(s.handleGetStewardConfig))).Methods("GET")
 	stewards.Handle("/{id}/config", s.requirePermission("steward", "write-config")(http.HandlerFunc(s.handleUpdateStewardConfig))).Methods("PUT")
 	stewards.Handle("/{id}/config/validate", s.requirePermission("steward", "validate-config")(http.HandlerFunc(s.handleValidateConfig))).Methods("POST")
-	stewards.Handle("/{id}/config/status", s.requirePermission("steward", "read-config")(http.HandlerFunc(s.handleGetConfigStatus))).Methods("GET")
 	stewards.Handle("/{id}/config/effective", s.requirePermission("steward", "read-config")(http.HandlerFunc(s.handleGetEffectiveConfig))).Methods("GET")
 
 	// QUIC connection management endpoints

--- a/features/controller/api/types.go
+++ b/features/controller/api/types.go
@@ -78,23 +78,6 @@ type ValidationError struct {
 	Suggestion string `json:"suggestion,omitempty"`
 }
 
-// ConfigStatusInfo represents configuration status
-type ConfigStatusInfo struct {
-	StewardID     string         `json:"steward_id"`
-	ConfigVersion string         `json:"config_version"`
-	Status        string         `json:"status"`
-	Modules       []ModuleStatus `json:"modules"`
-	UpdatedAt     time.Time      `json:"updated_at"`
-}
-
-// ModuleStatus represents the status of a module
-type ModuleStatus struct {
-	Name      string    `json:"name"`
-	Status    string    `json:"status"`
-	Message   string    `json:"message"`
-	Timestamp time.Time `json:"timestamp"`
-}
-
 // CertificateInfo represents certificate information
 type CertificateInfo struct {
 	SerialNumber        string    `json:"serial_number"`
@@ -252,16 +235,6 @@ func ValidationErrorFromProto(err *controller.ValidationError) ValidationError {
 		Level:      level,
 		Code:       err.Code,
 		Suggestion: err.Suggestion,
-	}
-}
-
-// ModuleStatusFromProto converts a protobuf ModuleStatus to ModuleStatus
-func ModuleStatusFromProto(status *controller.ModuleStatus) ModuleStatus {
-	return ModuleStatus{
-		Name:      status.Name,
-		Status:    status.Status.Message,
-		Message:   status.Message,
-		Timestamp: status.Timestamp.AsTime(),
 	}
 }
 

--- a/features/controller/service/config_service_v2.go
+++ b/features/controller/service/config_service_v2.go
@@ -325,13 +325,6 @@ func (s *ConfigurationServiceV2) ValidateConfig(ctx context.Context, req *contro
 	}, nil
 }
 
-// StreamConfigurationUpdates streams configuration updates to stewards
-// NOTE: Disabled - use control plane events for real-time updates.
-// This would need to be enhanced with storage-based change notifications
-func (s *ConfigurationServiceV2) StreamConfigurationUpdates(req *controller.ConfigStreamRequest, stream interface{}) error {
-	return fmt.Errorf("streaming not supported: use control plane events for real-time configuration updates")
-}
-
 // Helper methods
 
 // filterConfigByModules filters configuration to include only requested modules


### PR DESCRIPTION
## Summary

- Removes `GET /api/v1/stewards/{id}/config/status` route and its handler (`handleGetConfigStatus`), which returned a hardcoded `"unknown"` status with no real data behind it
- Deletes `ConfigStatusInfo`, `ModuleStatus`, and `ModuleStatusFromProto` types from `api/types.go` — no callers remain after handler removal
- Deletes `StreamConfigurationUpdates` from `ConfigurationServiceV2` — the method always errored; `ConfigurationServiceV2` is never registered as a gRPC server (no `RegisterConfigurationServiceServer` call sites), so no interface satisfaction is required
- Removes stale `/stewards/{stewardId}/config/status` endpoint block and `ConfigStatusInfo` schema from `docs/api/openapi.yaml` to keep the documented API surface in sync

## Test plan

- [x] `TestServer_ConfigStatusRouteDeregistered`: new smoke test confirms `GET /api/v1/stewards/any-steward-id/config/status` returns 404 or 405 (never 200) after deregistration
- [x] `grep -rn "ModuleStatusFromProto|ConfigStatusInfo|ModuleStatus" /workspace/features/controller` returns zero matches
- [x] `go build ./features/controller/...` — clean
- [x] `go test ./features/controller/...` — all packages pass

## Specialist review results

| Reviewer | Result |
|----------|--------|
| QA Test Runner (`make test-agent-complete`) | **PASS** — all packages, lint, cross-platform builds, architecture check |
| QA Code Reviewer | **PASS** — no mocks, no skips, proper assertions, 0 blocking issues |
| Security Engineer | **PASS** — 0 blocking issues; gosec/staticcheck/architecture/secret scan all clean |

Fixes #1101

🤖 Generated with [Claude Code](https://claude.com/claude-code)