### PR TITLE
ctxkeys: add canonical CorrelationIDKey, migrate pkg/logging + pkg/telemetry (Issue #1132)

### DIFF
--- a/pkg/ctxkeys/ctxkeys.go
+++ b/pkg/ctxkeys/ctxkeys.go
@@ -14,3 +14,12 @@ const (
 	// config handlers, service methods, and terminal session managers to enforce tenant isolation.
 	TenantID ContextKey = "tenant_id"
 )
+
+// correlationIDKeyType is unexported so no external package can construct a value of this type,
+// preventing key aliasing across package boundaries (the standard Go "opaque key" idiom).
+type correlationIDKeyType struct{}
+
+// CorrelationIDKey is the single canonical context key for correlation IDs.
+// Both pkg/logging and pkg/telemetry store and read correlation IDs under this key,
+// so that logging.WithCorrelation and telemetry.GetCorrelationID share the same slot.
+var CorrelationIDKey = correlationIDKeyType{}

--- a/pkg/ctxkeys/ctxkeys_test.go
+++ b/pkg/ctxkeys/ctxkeys_test.go
@@ -33,3 +33,26 @@ func TestContextKeyCollision(t *testing.T) {
 	assert.False(t, ok, "typed key must not match plain string key")
 	assert.Empty(t, got)
 }
+
+func TestCorrelationIDKeyRoundtrip(t *testing.T) {
+	ctx := context.WithValue(context.Background(), ctxkeys.CorrelationIDKey, "test-correlation-123")
+	got, ok := ctx.Value(ctxkeys.CorrelationIDKey).(string)
+	assert.True(t, ok)
+	assert.Equal(t, "test-correlation-123", got)
+}
+
+func TestCorrelationIDKeyMissing(t *testing.T) {
+	ctx := context.Background()
+	got, ok := ctx.Value(ctxkeys.CorrelationIDKey).(string)
+	assert.False(t, ok)
+	assert.Empty(t, got)
+}
+
+func TestCorrelationIDKeyCollision(t *testing.T) {
+	// A plain string key must not collide with the struct-typed CorrelationIDKey.
+	//nolint:staticcheck // SA1029: intentionally using a plain string to verify typed key does not collide
+	ctx := context.WithValue(context.Background(), "correlation_id", "plain-string-value")
+	got, ok := ctx.Value(ctxkeys.CorrelationIDKey).(string)
+	assert.False(t, ok, "struct-typed key must not match plain string key")
+	assert.Empty(t, got)
+}

--- a/pkg/logging/context_keys.go
+++ b/pkg/logging/context_keys.go
@@ -13,6 +13,3 @@ type sessionIDKey struct{}
 
 // operationKey is the context key for operations
 type operationKey struct{}
-
-// correlationIDKey is the context key for correlation IDs
-type correlationIDKey struct{}

--- a/pkg/logging/injection.go
+++ b/pkg/logging/injection.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/cfgis/cfgms/pkg/ctxkeys"
 	"github.com/cfgis/cfgms/pkg/logging/interfaces"
 )
 
@@ -304,7 +305,7 @@ func WithSession(ctx context.Context, sessionID string) context.Context {
 
 // WithCorrelation adds correlation ID to context for downstream logging
 func WithCorrelation(ctx context.Context, correlationID string) context.Context {
-	return context.WithValue(ctx, correlationIDKey{}, correlationID)
+	return context.WithValue(ctx, ctxkeys.CorrelationIDKey, correlationID)
 }
 
 // WithOperation adds operation context for structured logging

--- a/pkg/logging/telemetry_bridge.go
+++ b/pkg/logging/telemetry_bridge.go
@@ -10,6 +10,7 @@ package logging
 import (
 	"context"
 
+	"github.com/cfgis/cfgms/pkg/ctxkeys"
 	"go.opentelemetry.io/otel/trace"
 )
 
@@ -18,37 +19,16 @@ import (
 // from context without directly importing the telemetry package.
 type TelemetryBridge struct{}
 
-// GetCorrelationIDFromContext extracts correlation ID using the telemetry package's key structure.
-// This is the actual implementation that replaces the placeholder in extractCorrelationID.
+// GetCorrelationIDFromContext extracts correlation ID using the canonical ctxkeys.CorrelationIDKey.
 func (t *TelemetryBridge) GetCorrelationIDFromContext(ctx context.Context) string {
-	// Try to get correlation ID using the telemetry package's CorrelationIDKey{}
-	// We need to match the exact type from the telemetry package
-
-	// Create the key type that matches telemetry.CorrelationIDKey{}
-	type correlationIDKey struct{}
-	if value := ctx.Value(correlationIDKey{}); value != nil {
-		if correlationID, ok := value.(string); ok {
-			return correlationID
-		}
+	if correlationID, ok := ctx.Value(ctxkeys.CorrelationIDKey).(string); ok {
+		return correlationID
 	}
 
-	// Fallback: Try to extract from span context if available
+	// Fallback: extract from OTel span context if available
 	span := trace.SpanFromContext(ctx)
 	if span.SpanContext().IsValid() {
-		// Use trace ID as correlation ID if no explicit ID is set
 		return span.SpanContext().TraceID().String()
-	}
-
-	// Additional fallback keys for compatibility
-	for _, key := range []interface{}{
-		"correlation_id",
-		"cfgms_correlation_id",
-	} {
-		if value := ctx.Value(key); value != nil {
-			if correlationID, ok := value.(string); ok {
-				return correlationID
-			}
-		}
 	}
 
 	return ""
@@ -84,8 +64,11 @@ func UpdatedExtractCorrelationID(ctx context.Context) string {
 		return globalTelemetryBridge.GetCorrelationIDFromContext(ctx)
 	}
 
-	// Fallback to the original implementation
-	return extractCorrelationIDFallback(ctx)
+	// Direct read from the canonical key — no bridge required.
+	if correlationID, ok := ctx.Value(ctxkeys.CorrelationIDKey).(string); ok {
+		return correlationID
+	}
+	return ""
 }
 
 // UpdatedExtractTraceInfo is the enhanced trace info extractor.
@@ -96,20 +79,4 @@ func UpdatedExtractTraceInfo(ctx context.Context) (string, string) {
 
 	// Fallback: no trace information available
 	return "", ""
-}
-
-// extractCorrelationIDFallback provides basic correlation ID extraction without telemetry integration.
-func extractCorrelationIDFallback(ctx context.Context) string {
-	// Basic implementation that works without telemetry package
-	type correlationKey struct{}
-	if correlationID, ok := ctx.Value(correlationKey{}).(string); ok {
-		return correlationID
-	}
-
-	// Try string key as well
-	if correlationID, ok := ctx.Value("correlation_id").(string); ok {
-		return correlationID
-	}
-
-	return ""
 }

--- a/pkg/telemetry/context.go
+++ b/pkg/telemetry/context.go
@@ -9,14 +9,11 @@ import (
 	"strings"
 	"time"
 
+	"github.com/cfgis/cfgms/pkg/ctxkeys"
 	"github.com/google/uuid"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
 )
-
-// CorrelationIDKey is the context key for correlation IDs.
-// This enables correlation tracking across distributed operations.
-type CorrelationIDKey struct{}
 
 // GetCorrelationID extracts the correlation ID from the context.
 // If no correlation ID is present, it returns an empty string.
@@ -31,7 +28,7 @@ type CorrelationIDKey struct{}
 //	    logger.InfoCtx(ctx, "Processing request", "correlation_id", correlationID)
 //	}
 func GetCorrelationID(ctx context.Context) string {
-	if correlationID, ok := ctx.Value(CorrelationIDKey{}).(string); ok {
+	if correlationID, ok := ctx.Value(ctxkeys.CorrelationIDKey).(string); ok {
 		return correlationID
 	}
 
@@ -53,7 +50,7 @@ func GetCorrelationID(ctx context.Context) string {
 //	correlationID := "req-" + uuid.New().String()
 //	ctx = telemetry.WithCorrelationID(ctx, correlationID)
 func WithCorrelationID(ctx context.Context, correlationID string) context.Context {
-	ctx = context.WithValue(ctx, CorrelationIDKey{}, correlationID)
+	ctx = context.WithValue(ctx, ctxkeys.CorrelationIDKey, correlationID)
 
 	// Also add to active span if present
 	span := trace.SpanFromContext(ctx)
@@ -85,7 +82,7 @@ func ensureCorrelationID(ctx context.Context, span trace.Span) context.Context {
 	correlationID := GenerateCorrelationID()
 
 	// Add to context
-	ctx = context.WithValue(ctx, CorrelationIDKey{}, correlationID)
+	ctx = context.WithValue(ctx, ctxkeys.CorrelationIDKey, correlationID)
 
 	// Add to span attributes
 	if span.SpanContext().IsValid() {

--- a/pkg/telemetry/context_test.go
+++ b/pkg/telemetry/context_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/cfgis/cfgms/pkg/logging"
 	"github.com/cfgis/cfgms/pkg/telemetry"
 )
 
@@ -249,6 +250,16 @@ func BenchmarkGetCorrelationID(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		_ = telemetry.GetCorrelationID(ctx)
 	}
+}
+
+// TestCrossPackageCorrelationIDRoundtrip verifies that logging.WithCorrelation and
+// telemetry.GetCorrelationID share the same context slot via ctxkeys.CorrelationIDKey.
+func TestCrossPackageCorrelationIDRoundtrip(t *testing.T) {
+	ctx := context.Background()
+	ctx = logging.WithCorrelation(ctx, "cross-pkg-test-id")
+
+	got := telemetry.GetCorrelationID(ctx)
+	assert.Equal(t, "cross-pkg-test-id", got, "telemetry.GetCorrelationID must read value set by logging.WithCorrelation")
 }
 
 func TestCorrelationIDUniqueness(t *testing.T) {


### PR DESCRIPTION
## Summary

- Adds `ctxkeys.CorrelationIDKey` (opaque struct-typed var, unexported type) as the single canonical context key for correlation IDs
- Migrates `pkg/logging` and `pkg/telemetry` to read/write from the same context slot via `ctxkeys.CorrelationIDKey`
- Deletes three locally-declared duplicate struct types and the string-key fallback loop that was always a miss

## Problem Fixed

`logging.WithCorrelation(ctx, id)` and `telemetry.GetCorrelationID(ctx)` each used their own distinct struct type as a context key. Because Go context lookup uses type identity, values stored by one were invisible to the other. The bridge in `telemetry_bridge.go` attempted a workaround by re-declaring an identical struct, but two separately-declared structs with the same name are still different types — the lookup always missed.

## Files Changed

| File | Change |
|------|--------|
| `pkg/ctxkeys/ctxkeys.go` | Added `correlationIDKeyType` + `CorrelationIDKey` |
| `pkg/ctxkeys/ctxkeys_test.go` | Round-trip, missing, and collision tests |
| `pkg/logging/context_keys.go` | Deleted `correlationIDKey struct{}` |
| `pkg/logging/injection.go` | `WithCorrelation` uses `ctxkeys.CorrelationIDKey` |
| `pkg/logging/telemetry_bridge.go` | Canonical key, deleted fallback loop + `extractCorrelationIDFallback` |
| `pkg/telemetry/context.go` | Deleted `CorrelationIDKey struct{}`, uses `ctxkeys.CorrelationIDKey` |
| `pkg/telemetry/context_test.go` | `TestCrossPackageCorrelationIDRoundtrip` cross-package bridge test |

## Specialist Review Results

- **QA Test Runner**: PASS — all 90+ packages pass, cross-platform builds verified, gofmt clean
- **QA Code Reviewer**: PASS — 0 blocking issues, 0 warnings; real components, full assertions, no mocks
- **Security Engineer**: PASS — 0 blocking issues; architecture check passes, no new deps, the change is a security improvement (removes string-key collision-prone fallback)

## Test Plan

- [ ] `pkg/ctxkeys`: `TestCorrelationIDKeyRoundtrip`, `TestCorrelationIDKeyMissing`, `TestCorrelationIDKeyCollision` all pass
- [ ] `pkg/telemetry`: `TestCrossPackageCorrelationIDRoundtrip` confirms `logging.WithCorrelation → telemetry.GetCorrelationID` round-trip
- [ ] `make test-agent-complete` passes

Fixes #1132

🤖 Generated with [Claude Code](https://claude.com/claude-code)