### PR TITLE
steward: add cobra enforcement test for install --regtoken (Issue #1136)

### DIFF
--- a/cmd/steward/main_test.go
+++ b/cmd/steward/main_test.go
@@ -5,6 +5,7 @@ package main
 
 import (
 	"context"
+	"io"
 	"testing"
 	"time"
 
@@ -51,6 +52,20 @@ func TestBuildRootCommandFlags(t *testing.T) {
 func TestBuildRootCommandNoModeFlag(t *testing.T) {
 	cmd := buildRootCommand()
 	assert.Nil(t, cmd.Flags().Lookup("mode"), "mode flag must not be registered")
+}
+
+func TestInstallCommandEnforcesRequiredRegtoken(t *testing.T) {
+	// Verify cobra's MarkFlagRequired("regtoken") rejects the install subcommand
+	// when --regtoken is absent. This is the cobra-level guard that supersedes
+	// any manual empty-token check in runInstall — runInstall is never reached
+	// without a non-empty token value.
+	root := buildRootCommand()
+	root.SetOut(io.Discard)
+	root.SetErr(io.Discard)
+	root.SetArgs([]string{"install"})
+	err := root.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "regtoken")
 }
 
 func TestRunInstallRequiresElevation(t *testing.T) {


### PR DESCRIPTION
## Summary

Story #1136 closes the three remaining acceptance items on epic #757 (cmd/steward endpoint attack surface). All three items were already implemented by commit 5d208ef6 (PR #1080 for issue #1079):

1. **`Manager.InstallPath() string` removed** from the interface and all platform implementations — `Status().InstallPath` is the canonical accessor; tests already use this pattern.
2. **`logging.RedactedID(regToken)` in use** — `cmd/steward/main.go:157` uses the canonical redaction helper; no manual `regToken[:N]+"..."` slicing remains.
3. **Redundant empty-token check removed** from `runInstall` — cobra's `MarkFlagRequired("regtoken")` enforces the requirement before `runInstall` is ever called.

This PR adds one test that locks in item 3 — `TestInstallCommandEnforcesRequiredRegtoken` — so a future refactor can't accidentally remove the `MarkFlagRequired` call without a test catching it.

## Changes

- `cmd/steward/main_test.go`: add `TestInstallCommandEnforcesRequiredRegtoken` and `io` import

## Specialist Review Results

| Reviewer | Result | Notes |
|----------|--------|-------|
| QA Test Runner | **PASS** | All packages pass with race detection; cross-platform builds verified; Trivy skipped (no network in sandbox — infra-only, not a code issue) |
| QA Code Reviewer | **PASS** | No mocks, no abusive `t.Skip()`, two meaningful assertions, no production code added without tests |
| Security Engineer | **PASS** | No secrets, no central provider violations, no `InsecureSkipVerify`, scans clean |

## Test plan

- [x] `TestInstallCommandEnforcesRequiredRegtoken` passes
- [x] All existing steward tests continue to pass
- [x] Cross-platform compilation verified (linux/amd64, linux/arm64, darwin/amd64, darwin/arm64, windows/amd64)

🤖 Generated with [Claude Code](https://claude.com/claude-code)