### PR TITLE
controller: route TimescaleDB credentials through pkg/secrets, export api.NewSecretStore (Issue #1118)

### DIFF
--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -3,6 +3,8 @@
 package main
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/signal"
@@ -11,10 +13,12 @@ import (
 	"time"
 
 	"github.com/cfgis/cfgms/cmd/controller/service"
+	controllerapi "github.com/cfgis/cfgms/features/controller/api"
 	"github.com/cfgis/cfgms/features/controller/config"
 	"github.com/cfgis/cfgms/features/controller/initialization"
 	"github.com/cfgis/cfgms/features/controller/server"
 	"github.com/cfgis/cfgms/pkg/logging"
+	secretsif "github.com/cfgis/cfgms/pkg/secrets/interfaces"
 	"github.com/cfgis/cfgms/pkg/version"
 	"github.com/spf13/cobra"
 
@@ -86,7 +90,12 @@ func runController(configPath string, initMode bool) error {
 			"then update your configuration to use 'flatfile' or 'database'")
 	}
 
-	loggingConfig, err := buildLoggingConfig(cfg, "main")
+	secretStore, err := controllerapi.NewSecretStore(cfg)
+	if err != nil {
+		return fmt.Errorf("failed to initialize secret store: %w", err)
+	}
+
+	loggingConfig, err := buildLoggingConfig(cfg, secretStore, "main")
 	if err != nil {
 		return err
 	}
@@ -274,6 +283,11 @@ func runInstall(configPath string) error {
 		return fmt.Errorf("failed to load configuration from %s: %w", configPath, err)
 	}
 
+	secretStore, err := controllerapi.NewSecretStore(cfg)
+	if err != nil {
+		return fmt.Errorf("failed to initialize secret store: %w", err)
+	}
+
 	caPath, err := resolveInstallCAPath(cfg, configPath)
 	if err != nil {
 		return err
@@ -281,7 +295,7 @@ func runInstall(configPath string) error {
 
 	if !initialization.IsInitialized(caPath) {
 		fmt.Println("Controller not yet initialized — running --init...")
-		loggingConfig, err := buildLoggingConfig(cfg, "install")
+		loggingConfig, err := buildLoggingConfig(cfg, secretStore, "install")
 		if err != nil {
 			return fmt.Errorf("failed to initialize logging: %w", err)
 		}
@@ -400,8 +414,8 @@ func resolveInstallCAPath(cfg *config.Config, configPath string) (string, error)
 // buildLoggingConfig constructs a complete LoggingConfig for the given component.
 // All fields are set identically regardless of call site so runController and
 // runInstall share the same logging shape.
-func buildLoggingConfig(cfg *config.Config, component string) (*logging.LoggingConfig, error) {
-	logProviderConfig, err := getLogProviderConfig(cfg)
+func buildLoggingConfig(cfg *config.Config, store secretsif.SecretStore, component string) (*logging.LoggingConfig, error) {
+	logProviderConfig, err := getLogProviderConfig(cfg, store)
 	if err != nil {
 		return nil, fmt.Errorf("failed to build log provider config: %w", err)
 	}
@@ -430,7 +444,10 @@ func getLogProvider(cfg *config.Config) string {
 }
 
 // getLogProviderConfig creates provider-specific configuration.
-func getLogProviderConfig(cfg *config.Config) (map[string]interface{}, error) {
+// For the timescale provider all 6 connection fields are read exclusively from
+// the SecretStore under the "controller/logging/timescale/<field>" keys.
+// A missing secret is a hard startup error — there is no env var fallback.
+func getLogProviderConfig(cfg *config.Config, store secretsif.SecretStore) (map[string]interface{}, error) {
 	if cfg.Logging != nil && cfg.Logging.Config != nil && len(cfg.Logging.Config) > 0 {
 		return cfg.Logging.Config, nil
 	}
@@ -439,40 +456,29 @@ func getLogProviderConfig(cfg *config.Config) (map[string]interface{}, error) {
 
 	switch provider {
 	case "timescale":
-		password := os.Getenv("CFGMS_TIMESCALE_PASSWORD")
-		if password == "" {
-			return nil, fmt.Errorf("CFGMS_TIMESCALE_PASSWORD environment variable is required when " +
-				"using timescale logging provider; configure logging.config.password in the config " +
-				"file or set CFGMS_TIMESCALE_PASSWORD (see QUICK_START.md for examples)")
+		if store == nil {
+			return nil, fmt.Errorf("controller logging: SecretStore is required for TimescaleDB credentials")
 		}
-		host := os.Getenv("CFGMS_TIMESCALE_HOST")
-		if host == "" {
-			host = "localhost"
+		ctx := context.Background()
+		// field → leaf key under "controller/" tenant
+		// key format: controller/logging-timescale-<field>
+		// (SOPS store requires tenant/leaf where leaf must not contain '/')
+		fields := []string{"password", "host", "port", "database", "username", "ssl_mode"}
+		result := make(map[string]interface{}, len(fields))
+		for _, field := range fields {
+			leaf := "logging-timescale-" + strings.ReplaceAll(field, "_", "-")
+			key := "controller/" + leaf
+			secret, err := store.GetSecret(ctx, key)
+			if err != nil {
+				if errors.Is(err, secretsif.ErrSecretNotFound) {
+					return nil, fmt.Errorf("timescale %s: secret '%s' not found in store; "+
+						"pre-store via the secrets CLI before starting the controller", field, key)
+				}
+				return nil, fmt.Errorf("timescale %s: failed to retrieve secret '%s': %w", field, key, err)
+			}
+			result[field] = secret.Value
 		}
-		port := os.Getenv("CFGMS_TIMESCALE_PORT")
-		if port == "" {
-			port = "5432"
-		}
-		database := os.Getenv("CFGMS_TIMESCALE_DATABASE")
-		if database == "" {
-			database = "cfgms"
-		}
-		username := os.Getenv("CFGMS_TIMESCALE_USER")
-		if username == "" {
-			username = "cfgms"
-		}
-		sslMode := os.Getenv("CFGMS_TIMESCALE_SSLMODE")
-		if sslMode == "" {
-			sslMode = "require"
-		}
-		return map[string]interface{}{
-			"host":     host,
-			"port":     port,
-			"database": database,
-			"username": username,
-			"password": password,
-			"ssl_mode": sslMode,
-		}, nil
+		return result, nil
 
 	default:
 		return map[string]interface{}{

--- a/cmd/controller/main_test.go
+++ b/cmd/controller/main_test.go
@@ -4,6 +4,7 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io"
 	"os"
@@ -13,6 +14,9 @@ import (
 
 	"github.com/cfgis/cfgms/cmd/controller/service"
 	"github.com/cfgis/cfgms/features/controller/config"
+	secretsif "github.com/cfgis/cfgms/pkg/secrets/interfaces"
+	_ "github.com/cfgis/cfgms/pkg/secrets/providers/sops"
+	_ "github.com/cfgis/cfgms/pkg/storage/providers/flatfile"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -130,36 +134,75 @@ func TestRunControllerNoDebugOutput(t *testing.T) {
 		"runController must not write [DEBUG] output to stdout")
 }
 
-// TestGetLogProviderConfigTimescaleMissingPassword verifies that getLogProviderConfig
-// returns a non-nil error when the timescale provider is configured but
-// CFGMS_TIMESCALE_PASSWORD is not set.
-func TestGetLogProviderConfigTimescaleMissingPassword(t *testing.T) {
-	t.Setenv("CFGMS_TIMESCALE_PASSWORD", "")
-	cfg := &config.Config{
-		Logging: &config.LoggingConfig{
-			Provider: "timescale",
-		},
-	}
-	result, err := getLogProviderConfig(cfg)
-	require.Error(t, err, "expected error when CFGMS_TIMESCALE_PASSWORD is unset")
-	assert.Nil(t, result)
-	assert.Contains(t, err.Error(), "CFGMS_TIMESCALE_PASSWORD")
-}
+// TestGetLogProviderConfig_SecretsResolution verifies that getLogProviderConfig
+// loads all 6 TimescaleDB fields from a real SOPS-backed SecretStore in t.TempDir().
+// Keys follow the controller/logging-timescale-<field> convention required by the
+// SOPS store (tenant/leaf where the leaf must not contain '/').
+func TestGetLogProviderConfig_SecretsResolution(t *testing.T) {
+	store := newTestSecretStore(t)
+	ctx := context.Background()
 
-// TestGetLogProviderConfigTimescaleWithPassword verifies that getLogProviderConfig
-// returns a nil error and a map containing the "password" key when
-// CFGMS_TIMESCALE_PASSWORD is set.
-func TestGetLogProviderConfigTimescaleWithPassword(t *testing.T) {
-	t.Setenv("CFGMS_TIMESCALE_PASSWORD", "secret123")
-	cfg := &config.Config{
-		Logging: &config.LoggingConfig{
-			Provider: "timescale",
-		},
+	// Store each field under its production key: controller/logging-timescale-<field>
+	// ssl_mode uses a hyphen: logging-timescale-ssl-mode
+	fieldSecrets := map[string]string{
+		"logging-timescale-password": "s3cr3t",
+		"logging-timescale-host":     "timescale.example.com",
+		"logging-timescale-port":     "5432",
+		"logging-timescale-database": "cfgms_logs",
+		"logging-timescale-username": "cfgms_user",
+		"logging-timescale-ssl-mode": "require",
 	}
-	result, err := getLogProviderConfig(cfg)
+	for leaf, value := range fieldSecrets {
+		err := store.StoreSecret(ctx, &secretsif.SecretRequest{
+			Key:       leaf,
+			TenantID:  "controller",
+			Value:     value,
+			CreatedBy: "test",
+		})
+		require.NoError(t, err, "pre-populating secret %q", leaf)
+	}
+
+	cfg := &config.Config{
+		Logging: &config.LoggingConfig{Provider: "timescale"},
+	}
+	result, err := getLogProviderConfig(cfg, store)
 	require.NoError(t, err)
 	require.NotNil(t, result)
-	assert.Equal(t, "secret123", result["password"])
+	assert.Equal(t, "s3cr3t", result["password"])
+	assert.Equal(t, "timescale.example.com", result["host"])
+	assert.Equal(t, "5432", result["port"])
+	assert.Equal(t, "cfgms_logs", result["database"])
+	assert.Equal(t, "cfgms_user", result["username"])
+	assert.Equal(t, "require", result["ssl_mode"])
+}
+
+// TestGetLogProviderConfig_FailsWithoutPassword verifies that getLogProviderConfig
+// returns a clear startup error naming the missing secret key when the password
+// secret is absent from the store.
+func TestGetLogProviderConfig_FailsWithoutPassword(t *testing.T) {
+	store := newTestSecretStore(t) // empty store — no secrets pre-populated
+
+	cfg := &config.Config{
+		Logging: &config.LoggingConfig{Provider: "timescale"},
+	}
+	_, err := getLogProviderConfig(cfg, store)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "controller/logging-timescale-password")
+	assert.Contains(t, err.Error(), "not found")
+}
+
+// newTestSecretStore creates a real SOPS-backed SecretStore rooted in t.TempDir().
+func newTestSecretStore(t *testing.T) secretsif.SecretStore {
+	t.Helper()
+	dir := t.TempDir()
+	store, err := secretsif.CreateSecretStoreFromConfig("sops", map[string]interface{}{
+		"storage_provider": "flatfile",
+		"storage_config":   map[string]interface{}{"root": dir},
+		"cache_enabled":    false,
+	})
+	require.NoError(t, err, "creating test secret store")
+	t.Cleanup(func() { _ = store.Close() })
+	return store
 }
 
 // TestBuildLoggingConfigFieldsComplete asserts that buildLoggingConfig populates
@@ -168,7 +211,7 @@ func TestBuildLoggingConfigFieldsComplete(t *testing.T) {
 	cfg := &config.Config{
 		LogLevel: "debug",
 	}
-	lc, err := buildLoggingConfig(cfg, "test")
+	lc, err := buildLoggingConfig(cfg, nil, "test")
 	require.NoError(t, err)
 	require.NotNil(t, lc)
 
@@ -190,10 +233,10 @@ func TestRunInstallLoggingConfigMatchesRunController(t *testing.T) {
 		LogLevel: "info",
 	}
 
-	mainCfg, err := buildLoggingConfig(cfg, "main")
+	mainCfg, err := buildLoggingConfig(cfg, nil, "main")
 	require.NoError(t, err)
 
-	installCfg, err := buildLoggingConfig(cfg, "install")
+	installCfg, err := buildLoggingConfig(cfg, nil, "install")
 	require.NoError(t, err)
 
 	assert.Equal(t, mainCfg.Level, installCfg.Level)

--- a/features/controller/api/server.go
+++ b/features/controller/api/server.go
@@ -123,7 +123,7 @@ func New(
 	}
 
 	// M-AUTH-1: Initialize central secrets provider for API key storage
-	secretStore, err := initializeSecretStore(cfg, logger)
+	secretStore, err := NewSecretStore(cfg)
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize secret store: %w", err)
 	}
@@ -832,9 +832,11 @@ func (s *Server) configureCORS() {
 	}
 }
 
-// M-AUTH-1: Initialize central secrets provider for API key storage
-// Replaces the incorrect file-based APIKeyStore implementation
-func initializeSecretStore(cfg *config.Config, logger logging.Logger) (secretsif.SecretStore, error) {
+// NewSecretStore initializes and returns the central secrets provider for the controller.
+// It is exported so that cmd/controller/main.go can initialize the store before logging
+// is configured, while server.New continues to call it internally unchanged.
+func NewSecretStore(cfg *config.Config) (secretsif.SecretStore, error) {
+	logger := logging.ForComponent("controller")
 	// Determine secrets storage path
 	secretsPath := os.Getenv("CFGMS_SECRETS_REPO_PATH")
 	if secretsPath == "" {


### PR DESCRIPTION
## Summary

- Exported `api.NewSecretStore(cfg *config.Config) (secretsif.SecretStore, error)` from `features/controller/api/` so `cmd/controller/main.go` can initialize the SecretStore before logging is configured.
- Removed all `os.Getenv("CFGMS_TIMESCALE_*")` reads from `getLogProviderConfig`; the 6 TimescaleDB fields (`password`, `host`, `port`, `database`, `username`, `ssl_mode`) are now read exclusively from the SecretStore under keys `controller/logging-timescale-<field>`.
- A missing secret produces a hard startup error naming the exact key and directing the operator to pre-store it via the secrets CLI.

## What changed

**`features/controller/api/server.go`**
- Renamed `initializeSecretStore(cfg, logger)` → `NewSecretStore(cfg)` (exported; logger created internally). `server.New` signature unchanged.

**`cmd/controller/main.go`**
- Both `runController` and `runInstall` call `api.NewSecretStore(cfg)` before `buildLoggingConfig`; failure aborts startup.
- `buildLoggingConfig` and `getLogProviderConfig` accept `secretsif.SecretStore`.
- `getLogProviderConfig` timescale branch: `store.GetSecret` for each field; `ErrSecretNotFound` → fatal error; no env var fallback.

**`cmd/controller/main_test.go`**
- Added `TestGetLogProviderConfig_SecretsResolution` (real SOPS store, all 6 fields).
- Added `TestGetLogProviderConfig_FailsWithoutPassword` (missing secret → clear error).
- Removed obsolete env-var-based timescale tests.

## Acceptance criteria status

- [x] `api.NewSecretStore(cfg *config.Config) (secretsif.SecretStore, error)` exported
- [x] `server.New` calls `api.NewSecretStore` internally; signature unchanged
- [x] `cmd/controller/main.go` calls `api.NewSecretStore(cfg)` before `buildLoggingConfig`; failure aborts
- [x] `getLogProviderConfig(cfg, store secretsif.SecretStore)` signature
- [x] `store.GetSecret` called for all 6 fields; `ErrSecretNotFound` returns fatal error
- [x] No `os.Getenv("CFGMS_TIMESCALE_*")` in `getLogProviderConfig` (grep confirms)
- [x] `TestGetLogProviderConfig_SecretsResolution` — real SOPS store, all 6 fields verified
- [x] `TestGetLogProviderConfig_FailsWithoutPassword` — missing password → clear error

## Specialist review results

- **QA Test Runner**: PASS — 109 packages, golangci-lint clean, architecture check clean, security scans pass
- **QA Code Reviewer**: PASS — no mocks, all error paths covered, key format consistent between prod and test
- **Security Engineer**: PASS — no credential leaks, env vars fully removed, central provider compliance confirmed

Fixes #1118