### PR TITLE
telemetry: delete shadow OTel trace/span symbols (Issue #1134)

### DIFF
--- a/pkg/telemetry/context.go
+++ b/pkg/telemetry/context.go
@@ -4,10 +4,6 @@ package telemetry
 
 import (
 	"context"
-	"crypto/rand"
-	"fmt"
-	"strings"
-	"time"
 
 	"github.com/cfgis/cfgms/pkg/ctxkeys"
 	"github.com/google/uuid"
@@ -165,76 +161,6 @@ func InjectPropagationContext(ctx context.Context, propCtx *PropagationContext) 
 	// primarily handles correlation ID injection for logging purposes.
 
 	return ctx
-}
-
-// TraceIDKey is the context key for trace IDs.
-type TraceIDKey struct{}
-
-// SpanIDKey is the context key for span IDs.
-type SpanIDKey struct{}
-
-// GenerateTraceID creates a new 32-character hex trace ID.
-func GenerateTraceID() string {
-	// Generate 16 random bytes and convert to 32-char hex string
-	bytes := make([]byte, 16)
-	_, err := rand.Read(bytes)
-	if err != nil {
-		// Fallback to UUID without dashes
-		return strings.ReplaceAll(uuid.New().String(), "-", "")
-	}
-	return fmt.Sprintf("%032x", bytes)
-}
-
-// GenerateSpanID creates a new 16-character hex span ID.
-func GenerateSpanID() string {
-	// Generate 8 random bytes and convert to 16-char hex string
-	bytes := make([]byte, 8)
-	_, err := rand.Read(bytes)
-	if err != nil {
-		// Fallback to timestamp-based ID
-		return fmt.Sprintf("%016x", time.Now().UnixNano())
-	}
-	return fmt.Sprintf("%016x", bytes)
-}
-
-// GetTraceID extracts the trace ID from the context.
-func GetTraceID(ctx context.Context) string {
-	if traceID, ok := ctx.Value(TraceIDKey{}).(string); ok {
-		return traceID
-	}
-
-	// Try to extract from span context if available
-	span := trace.SpanFromContext(ctx)
-	if span.SpanContext().IsValid() {
-		return span.SpanContext().TraceID().String()
-	}
-
-	return ""
-}
-
-// WithTraceID adds a trace ID to the context.
-func WithTraceID(ctx context.Context, traceID string) context.Context {
-	return context.WithValue(ctx, TraceIDKey{}, traceID)
-}
-
-// GetSpanID extracts the span ID from the context.
-func GetSpanID(ctx context.Context) string {
-	if spanID, ok := ctx.Value(SpanIDKey{}).(string); ok {
-		return spanID
-	}
-
-	// Try to extract from span context if available
-	span := trace.SpanFromContext(ctx)
-	if span.SpanContext().IsValid() {
-		return span.SpanContext().SpanID().String()
-	}
-
-	return ""
-}
-
-// WithSpanID adds a span ID to the context.
-func WithSpanID(ctx context.Context, spanID string) context.Context {
-	return context.WithValue(ctx, SpanIDKey{}, spanID)
 }
 
 // EnsureCorrelationID ensures that a correlation ID is present in the context.

--- a/pkg/telemetry/context_test.go
+++ b/pkg/telemetry/context_test.go
@@ -66,106 +66,6 @@ func TestCorrelationID(t *testing.T) {
 	})
 }
 
-func TestTraceID(t *testing.T) {
-	t.Run("generate trace ID", func(t *testing.T) {
-		id1 := telemetry.GenerateTraceID()
-		id2 := telemetry.GenerateTraceID()
-
-		// Should be unique
-		assert.NotEqual(t, id1, id2)
-
-		// Should be 32 character hex string
-		assert.Len(t, id1, 32)
-		assert.Len(t, id2, 32)
-		assert.Regexp(t, `^[a-f0-9]{32}$`, id1)
-		assert.Regexp(t, `^[a-f0-9]{32}$`, id2)
-	})
-
-	t.Run("trace ID in context", func(t *testing.T) {
-		ctx := context.Background()
-		traceID := telemetry.GenerateTraceID()
-
-		// Add to context
-		ctxWithID := telemetry.WithTraceID(ctx, traceID)
-
-		// Retrieve from context
-		retrievedID := telemetry.GetTraceID(ctxWithID)
-		assert.Equal(t, traceID, retrievedID)
-	})
-
-	t.Run("missing trace ID returns empty", func(t *testing.T) {
-		ctx := context.Background()
-
-		// Should return empty string when not set
-		retrievedID := telemetry.GetTraceID(ctx)
-		assert.Empty(t, retrievedID)
-	})
-}
-
-func TestSpanID(t *testing.T) {
-	t.Run("generate span ID", func(t *testing.T) {
-		id1 := telemetry.GenerateSpanID()
-		id2 := telemetry.GenerateSpanID()
-
-		// Should be unique
-		assert.NotEqual(t, id1, id2)
-
-		// Should be 16 character hex string
-		assert.Len(t, id1, 16)
-		assert.Len(t, id2, 16)
-		assert.Regexp(t, `^[a-f0-9]{16}$`, id1)
-		assert.Regexp(t, `^[a-f0-9]{16}$`, id2)
-	})
-
-	t.Run("span ID in context", func(t *testing.T) {
-		ctx := context.Background()
-		spanID := telemetry.GenerateSpanID()
-
-		// Add to context
-		ctxWithID := telemetry.WithSpanID(ctx, spanID)
-
-		// Retrieve from context
-		retrievedID := telemetry.GetSpanID(ctxWithID)
-		assert.Equal(t, spanID, retrievedID)
-	})
-}
-
-func TestMultipleIDs(t *testing.T) {
-	t.Run("all IDs in same context", func(t *testing.T) {
-		ctx := context.Background()
-
-		correlationID := telemetry.GenerateCorrelationID()
-		traceID := telemetry.GenerateTraceID()
-		spanID := telemetry.GenerateSpanID()
-
-		// Add all IDs to context
-		ctx = telemetry.WithCorrelationID(ctx, correlationID)
-		ctx = telemetry.WithTraceID(ctx, traceID)
-		ctx = telemetry.WithSpanID(ctx, spanID)
-
-		// Retrieve all IDs
-		assert.Equal(t, correlationID, telemetry.GetCorrelationID(ctx))
-		assert.Equal(t, traceID, telemetry.GetTraceID(ctx))
-		assert.Equal(t, spanID, telemetry.GetSpanID(ctx))
-	})
-
-	t.Run("update individual IDs", func(t *testing.T) {
-		ctx := context.Background()
-
-		// Set initial IDs
-		ctx = telemetry.WithCorrelationID(ctx, "initial-correlation")
-		ctx = telemetry.WithTraceID(ctx, "initial-trace")
-
-		// Update correlation ID
-		newCorrelationID := telemetry.GenerateCorrelationID()
-		ctx = telemetry.WithCorrelationID(ctx, newCorrelationID)
-
-		// Original trace ID should be preserved
-		assert.Equal(t, newCorrelationID, telemetry.GetCorrelationID(ctx))
-		assert.Equal(t, "initial-trace", telemetry.GetTraceID(ctx))
-	})
-}
-
 func TestContextPropagation(t *testing.T) {
 	t.Run("propagate through function calls", func(t *testing.T) {
 		ctx := context.Background()
@@ -223,12 +123,6 @@ func TestEnsureCorrelationID(t *testing.T) {
 func BenchmarkGenerateCorrelationID(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		_ = telemetry.GenerateCorrelationID()
-	}
-}
-
-func BenchmarkGenerateTraceID(b *testing.B) {
-	for i := 0; i < b.N; i++ {
-		_ = telemetry.GenerateTraceID()
 	}
 }
 
@@ -292,23 +186,4 @@ func TestIDFormats(t *testing.T) {
 		assert.Len(t, parts[4], 12)
 	})
 
-	t.Run("trace ID format", func(t *testing.T) {
-		id := telemetry.GenerateTraceID()
-
-		// Should be 32 hex characters
-		assert.Len(t, id, 32)
-		for _, char := range id {
-			assert.Contains(t, "0123456789abcdef", string(char))
-		}
-	})
-
-	t.Run("span ID format", func(t *testing.T) {
-		id := telemetry.GenerateSpanID()
-
-		// Should be 16 hex characters
-		assert.Len(t, id, 16)
-		for _, char := range id {
-			assert.Contains(t, "0123456789abcdef", string(char))
-		}
-	})
 }


### PR DESCRIPTION
## Summary

- Deleted 8 dead OTel shadow symbols (`TraceIDKey`, `SpanIDKey`, `GenerateTraceID`, `GenerateSpanID`, `GetTraceID`, `GetSpanID`, `WithTraceID`, `WithSpanID`) from `pkg/telemetry/context.go` — zero callers existed outside the test file
- Removed orphaned imports (`crypto/rand`, `fmt`, `strings`, `time`) that became unused after the deletion
- Deleted all tests and benchmarks for the removed symbols from `pkg/telemetry/context_test.go` in lockstep

Fixes #1134

## Motivation

These symbols duplicated what `trace.SpanFromContext` already provides. Their ID generators had silent fallback paths (UUID-without-dashes and `time.Now().UnixNano()`) when `crypto/rand` failed, producing non-cryptographic/predictable IDs with no caller aware of the degradation. All trace/span ID reads now flow exclusively through the authoritative OTel SDK path.

## What stays untouched

`GetCorrelationID`, `WithCorrelationID`, `GenerateCorrelationID`, `EnsureCorrelationID`, `PropagationContext`, `ExtractPropagationContext`, `InjectPropagationContext` — all correlation-ID helpers are unchanged.

## Specialist Review Results

| Specialist | Result |
|---|---|
| qa-test-runner | **PASS** — all 100+ packages pass including full integration suite and cross-platform builds (linux/amd64, linux/arm64, darwin/amd64, darwin/arm64, windows/amd64) |
| qa-code-reviewer | **PASS** — 0 blocking issues; 1 pre-existing warning (PropagationContext coverage gap, out of scope) |
| security-engineer | **PASS** — 0 blocking issues; gosec/staticcheck/go vet clean; no secrets, no callers left dangling |

## Test Plan

- [x] `go test ./pkg/telemetry/...` passes
- [x] `make build` (cross-platform) passes
- [x] `make test-agent-complete` passes
- [x] Repository-wide grep confirms zero remaining references to deleted symbols

🤖 Generated with [Claude Code](https://claude.com/claude-code)