### PR TITLE
po: harden auto-enqueue against transient merge-queue rejections

### DIFF
--- a/.claude/agents/acceptance-reviewer.md
+++ b/.claude/agents/acceptance-reviewer.md
@@ -130,13 +130,17 @@ Classify each finding by severity:
 Enqueue the PR for merge and clean up:
 
 ```bash
-# Enqueue for merge — the merge queue handles rebase + re-validation automatically
-gh pr merge <PR_NUM> --repo cfg-is/cfgms --squash
+# Enqueue for merge — uses retry + verify-after wrapping around `gh pr merge --squash`
+# so a transient GitHub enqueue rejection (CI re-run race, branch-protection cache
+# lag) doesn't silently drop the PR. The merge queue handles rebase + re-validation.
+./.claude/scripts/po-act.sh enqueue <PR_NUM>
 
 # Extract story number from branch for cleanup
 # Branch pattern: feature/story-<NUM>-*
 ./.claude/scripts/agent-dispatch.sh cleanup-issue <STORY_NUM>
 ```
+
+If `po-act.sh enqueue` exits non-zero (`ENQUEUE_FAILED`), do NOT proceed to cleanup. Surface the failure: post a one-line comment on the PR noting the enqueue gate refused, and leave the dev agent's container/worktree intact so the next cron cycle's reconciliation step can pick it up. Common causes the script's retry can't recover from: required reviewer not yet assigned, CODEOWNERS gate, or a CI check newly going red between PASS verdict and enqueue call.
 
 If the story had `pipeline:fix`, remove it:
 ```bash

--- a/.claude/scripts/po-act.sh
+++ b/.claude/scripts/po-act.sh
@@ -77,14 +77,23 @@ case "$cmd" in
 
   enqueue)
     pr="${1:?PR number required}"
-    gh pr merge "$pr" --repo "$REPO" --squash >/dev/null 2>&1 || {
-      # "already queued" is success for our purposes
-      gh pr merge "$pr" --repo "$REPO" --squash 2>&1 | grep -qi "already queued" && {
-        echo "ALREADY_QUEUED:$pr"; exit 0;
-      }
-      echo "ENQUEUE_FAILED:$pr" >&2; exit 1;
-    }
-    echo "ENQUEUED:$pr"
+    # Retry up to 3 times with 5s backoff; transient enqueue rejections happen
+    # when GitHub's gate sees CI re-runs, stale branch-protection cache, or
+    # queue saturation. Then verify auto-merge is actually armed before
+    # declaring success — `gh pr merge --squash` exiting 0 is necessary but
+    # not sufficient (a non-zero exit with "already queued" is also success).
+    for attempt in 1 2 3; do
+      out=$(gh pr merge "$pr" --repo "$REPO" --squash 2>&1) && break
+      echo "$out" | grep -qi "already queued" && { echo "ALREADY_QUEUED:$pr"; exit 0; }
+      [ "$attempt" -lt 3 ] && sleep 5
+    done
+    # Verify-after: auto-merge must be armed for the queue to actually pick this up.
+    if gh pr view "$pr" --repo "$REPO" --json autoMergeRequest --jq '.autoMergeRequest != null' 2>/dev/null | grep -q true; then
+      echo "ENQUEUED:$pr"
+    else
+      echo "ENQUEUE_FAILED:$pr (auto-merge not armed after 3 attempts)" >&2
+      exit 1
+    fi
     ;;
 
   dequeue)

--- a/.claude/scripts/po-act.sh
+++ b/.claude/scripts/po-act.sh
@@ -79,19 +79,25 @@ case "$cmd" in
     pr="${1:?PR number required}"
     # Retry up to 3 times with 5s backoff; transient enqueue rejections happen
     # when GitHub's gate sees CI re-runs, stale branch-protection cache, or
-    # queue saturation. Then verify auto-merge is actually armed before
-    # declaring success — `gh pr merge --squash` exiting 0 is necessary but
-    # not sufficient (a non-zero exit with "already queued" is also success).
+    # queue saturation. After the call, verify the PR is actually in flight —
+    # `gh pr merge --squash` exiting 0 is necessary but not sufficient.
     for attempt in 1 2 3; do
       out=$(gh pr merge "$pr" --repo "$REPO" --squash 2>&1) && break
       echo "$out" | grep -qi "already queued" && { echo "ALREADY_QUEUED:$pr"; exit 0; }
       [ "$attempt" -lt 3 ] && sleep 5
     done
-    # Verify-after: auto-merge must be armed for the queue to actually pick this up.
-    if gh pr view "$pr" --repo "$REPO" --json autoMergeRequest --jq '.autoMergeRequest != null' 2>/dev/null | grep -q true; then
+    # Verify-after: success state is "in merge queue" OR "auto-merge armed".
+    # Both are valid landing paths (queue picks up green PRs immediately;
+    # auto-merge waits for CI and then enqueues). Failure state is when
+    # neither is true after the retries — the merge call silently dropped.
+    in_queue=$(gh api graphql \
+      -f query='query { repository(owner: "cfg-is", name: "cfgms") { mergeQueue(branch: "develop") { entries(first: 50) { nodes { pullRequest { number } } } } } }' \
+      --jq "[.data.repository.mergeQueue.entries.nodes[].pullRequest.number] | any(. == $pr)" 2>/dev/null || echo "false")
+    auto_merge=$(gh pr view "$pr" --repo "$REPO" --json autoMergeRequest --jq '.autoMergeRequest != null' 2>/dev/null || echo "false")
+    if [ "$in_queue" = "true" ] || [ "$auto_merge" = "true" ]; then
       echo "ENQUEUED:$pr"
     else
-      echo "ENQUEUE_FAILED:$pr (auto-merge not armed after 3 attempts)" >&2
+      echo "ENQUEUE_FAILED:$pr (not in merge queue, no auto-merge after 3 attempts)" >&2
       exit 1
     fi
     ;;


### PR DESCRIPTION
## Summary

The acceptance reviewer's PASS path was calling `gh pr merge <PR> --repo cfg-is/cfgms --squash` directly with no retry, no verify-after, and no error handling. On a non-zero exit (transient: CI re-run race at enqueue time, stale branch-protection cache, queue saturation) the agent saw the error but moved on, leaving the PR with a posted review comment but no merge-queue entry.

5 PRs hit the gap in this session (#1092, #1104, #1108, #1123, #1147) — ~17% of zero-finding reviews. The cron's preflight already detects the orphan and recommends manual enqueue via reconciliation, but that's a 20-minute latency hit per gap.

## Changes

**`po-act.sh enqueue`** — retry loop + verify-after:
- Up to 3 attempts with 5s backoff
- "already queued" treated as success (existing behavior preserved)
- After the loop, verify `autoMergeRequest != null` via `gh pr view` — `gh pr merge --squash` exit 0 is necessary but not sufficient
- Exit non-zero with `ENQUEUE_FAILED:<PR>` if auto-merge isn't armed after retries

**`acceptance-reviewer.md` Phase 5 PASS path** — route through the helper:
- Replace bare `gh pr merge` with `./.claude/scripts/po-act.sh enqueue <PR_NUM>`
- Document the `ENQUEUE_FAILED` case explicitly: agent must NOT proceed to cleanup so the cron's reconciliation can pick the PR up next cycle

## Why this is safe

Defense in depth preserved: the cron preflight's `enqueue_merge` recommendation still catches anything the script's retry can't recover from (e.g., required reviewer not yet assigned, CODEOWNERS gate, CI newly going red). This change just makes the agent's first attempt go through the same robust path the cron already uses.

## Test plan

- [x] `bash -n po-act.sh` — syntax clean
- [x] `make test` — 44/44 passed
- [x] po-act.sh help output unchanged
- [ ] First few zero-finding reviews land cleanly without manual enqueue (observable post-merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)