### PR TITLE
ha: route 112 commercial/ha log.Printf calls through pkg/logging (Issue #1155)

### DIFF
--- a/commercial/ha/discovery.go
+++ b/commercial/ha/discovery.go
@@ -10,7 +10,6 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
-	"log"
 	"net/http"
 	"os"
 	"strings"
@@ -70,7 +69,7 @@ func newStaticDiscovery(cfg *DiscoveryConfig, logger logging.Logger, manager *Ma
 
 // Start begins the discovery process
 func (d *staticDiscovery) Start(ctx context.Context) error {
-	log.Printf("DISCOVERY_START: Entering staticDiscovery.Start()")
+	d.logger.Debug("DISCOVERY_START: Entering staticDiscovery.Start()")
 	d.mu.Lock()
 
 	if d.started {
@@ -78,38 +77,38 @@ func (d *staticDiscovery) Start(ctx context.Context) error {
 		return fmt.Errorf("discovery is already started")
 	}
 
-	log.Printf("DISCOVERY_START: About to set up context and mark as started")
+	d.logger.Debug("DISCOVERY_START: About to set up context and mark as started")
 	// TEMP FIX: Use Background context to prevent immediate cancellation
 	// TODO: Investigate why parent context is getting cancelled
 	d.ctx, d.cancel = context.WithCancel(context.Background())
 	d.started = true
 
 	// Register local node - avoid deadlock by accessing nodeInfo directly
-	log.Printf("DISCOVERY_START: About to get local node info directly")
+	d.logger.Debug("DISCOVERY_START: About to get local node info directly")
 	// Access nodeInfo directly to avoid GetLocalNode() deadlock during startup
 	nodeInfo := *d.manager.nodeInfo // Create a copy
 	nodeInfo.LastSeen = time.Now()
-	log.Printf("DISCOVERY_START: Got local node info, adding to nodes map, node_id=%s", nodeInfo.ID)
+	d.logger.Debug("DISCOVERY_START: Got local node info, adding to nodes map", "node_id", nodeInfo.ID)
 	d.nodes[nodeInfo.ID] = &nodeInfo
 
 	d.mu.Unlock() // Release lock before calling loadStaticNodes which needs to acquire it
 
 	// Load static nodes from configuration
-	log.Printf("DISCOVERY_START: About to load static nodes from configuration")
+	d.logger.Debug("DISCOVERY_START: About to load static nodes from configuration")
 	if err := d.loadStaticNodes(); err != nil {
-		log.Printf("DISCOVERY_START: Failed to load static nodes: %v", err)
+		d.logger.Error("DISCOVERY_START: Failed to load static nodes", "error", err)
 	}
-	log.Printf("DISCOVERY_START: Static nodes loaded successfully, total_nodes=%d", len(d.nodes))
+	d.logger.Debug("DISCOVERY_START: Static nodes loaded successfully", "total_nodes", len(d.nodes))
 
 	// Start periodic discovery if interval is configured
-	log.Printf("DISCOVERY_START: About to start periodic discovery, interval=%v", d.cfg.Interval)
+	d.logger.Debug("DISCOVERY_START: About to start periodic discovery", "interval", d.cfg.Interval)
 	if d.cfg.Interval > 0 {
 		go d.periodicDiscovery()
 	}
 
-	log.Printf("DISCOVERY_START: Static discovery started, interval=%v, node_timeout=%v", d.cfg.Interval, d.cfg.NodeTimeout)
+	d.logger.Info("Static discovery started", "interval", d.cfg.Interval, "node_timeout", d.cfg.NodeTimeout)
 
-	log.Printf("DISCOVERY_START: Exiting staticDiscovery.Start() successfully")
+	d.logger.Debug("DISCOVERY_START: Exiting staticDiscovery.Start() successfully")
 	return nil
 }
 
@@ -192,8 +191,8 @@ func (d *staticDiscovery) UnregisterNode(nodeID string) error {
 
 // loadStaticNodes loads static node configuration
 func (d *staticDiscovery) loadStaticNodes() error {
-	log.Printf("LOAD_STATIC: Entering loadStaticNodes()")
-	log.Printf("LOAD_STATIC: Discovery config contents: %+v, len=%d", d.cfg.Config, len(d.cfg.Config))
+	d.logger.Debug("LOAD_STATIC: Entering loadStaticNodes()")
+	d.logger.Debug("LOAD_STATIC: Discovery config contents", "config", d.cfg.Config, "len", len(d.cfg.Config))
 
 	// Check for static nodes in configuration
 	// Handle both []interface{} and []map[string]interface{} types
@@ -210,26 +209,26 @@ func (d *staticDiscovery) loadStaticNodes() error {
 	}
 
 	if len(staticNodes) > 0 {
-		log.Printf("LOAD_STATIC: Found static nodes in configuration, count=%d", len(staticNodes))
+		d.logger.Debug("LOAD_STATIC: Found static nodes in configuration", "count", len(staticNodes))
 		for i, nodeMap := range staticNodes {
-			log.Printf("LOAD_STATIC: Processing static node, index=%d, data=%+v", i, nodeMap)
+			d.logger.Debug("LOAD_STATIC: Processing static node", "index", i, "data", nodeMap)
 			node, err := d.parseNodeFromConfig(nodeMap)
 			if err != nil {
-				log.Printf("LOAD_STATIC: Failed to parse static node: %v, data=%+v", err, nodeMap)
+				d.logger.Warn("LOAD_STATIC: Failed to parse static node", "error", err, "data", nodeMap)
 				continue
 			}
 
-			log.Printf("LOAD_STATIC: About to register static node, node_id=%s", node.ID)
+			d.logger.Debug("LOAD_STATIC: About to register static node", "node_id", node.ID)
 			if err := d.RegisterNode(node); err != nil {
-				log.Printf("LOAD_STATIC: Failed to register static node: %v, node_id=%s", err, node.ID)
+				d.logger.Warn("LOAD_STATIC: Failed to register static node", "error", err, "node_id", node.ID)
 			}
-			log.Printf("LOAD_STATIC: Static node registered successfully, node_id=%s", node.ID)
+			d.logger.Debug("LOAD_STATIC: Static node registered successfully", "node_id", node.ID)
 		}
 	} else {
-		log.Printf("LOAD_STATIC: No static nodes found in configuration")
+		d.logger.Debug("LOAD_STATIC: No static nodes found in configuration")
 	}
 
-	log.Printf("LOAD_STATIC: Exiting loadStaticNodes() successfully")
+	d.logger.Debug("LOAD_STATIC: Exiting loadStaticNodes() successfully")
 	return nil
 }
 
@@ -271,17 +270,17 @@ func (d *staticDiscovery) parseNodeFromConfig(nodeMap map[string]interface{}) (*
 
 // periodicDiscovery runs periodic discovery
 func (d *staticDiscovery) periodicDiscovery() {
-	log.Printf("PERIODIC_DISCOVERY: Goroutine started, interval=%v", d.cfg.Interval)
+	d.logger.Debug("PERIODIC_DISCOVERY: Goroutine started", "interval", d.cfg.Interval)
 	ticker := time.NewTicker(d.cfg.Interval)
 	defer ticker.Stop()
 
 	for {
 		select {
 		case <-d.ctx.Done():
-			log.Printf("PERIODIC_DISCOVERY: Context cancelled, exiting")
+			d.logger.Debug("PERIODIC_DISCOVERY: Context cancelled, exiting")
 			return
 		case <-ticker.C:
-			log.Printf("PERIODIC_DISCOVERY: Ticker fired, calling performDiscovery()")
+			d.logger.Debug("PERIODIC_DISCOVERY: Ticker fired, calling performDiscovery()")
 			d.performDiscovery()
 		}
 	}
@@ -310,7 +309,7 @@ func (d *staticDiscovery) checkNodeHealth(node *NodeInfo) bool {
 		tlsConfig, err = cert.CreateBasicTLSConfig(nil, nil, tls.VersionTLS12)
 	}
 	if err != nil {
-		log.Printf("DISCOVERY: Failed to create TLS config for health check: %v", err)
+		d.logger.Error("DISCOVERY: Failed to create TLS config for health check", "error", err)
 		return false
 	}
 
@@ -327,21 +326,21 @@ func (d *staticDiscovery) checkNodeHealth(node *NodeInfo) bool {
 		// TLS handshake errors mean the server IS responding — it just requires proper certs.
 		// This is a connectivity check, not a data exchange, so this is correct behavior.
 		if strings.Contains(err.Error(), "tls:") || strings.Contains(err.Error(), "certificate") {
-			log.Printf("HEALTH_CHECK: Node up (TLS handshake), node_id=%s, address=%s", node.ID, node.Address)
+			d.logger.Debug("HEALTH_CHECK: Node up (TLS handshake)", "node_id", node.ID, "address", node.Address)
 			return true // Server is up, just needs mTLS
 		}
-		log.Printf("HEALTH_CHECK: Node unreachable, node_id=%s, address=%s, error=%v", node.ID, node.Address, err)
+		d.logger.Warn("HEALTH_CHECK: Node unreachable", "node_id", node.ID, "address", node.Address, "error", err)
 		return false
 	}
 	defer func() {
 		if err := resp.Body.Close(); err != nil {
-			log.Printf("HEALTH_CHECK: Failed to close response body, node_id=%s, error=%v", node.ID, err)
+			d.logger.Error("HEALTH_CHECK: Failed to close response body", "node_id", node.ID, "error", err)
 		}
 	}()
 
 	isHealthy := resp.StatusCode == 200 || resp.StatusCode == 404 || resp.StatusCode == 401 // Any response means server is up
-	log.Printf("HEALTH_CHECK: Node checked, node_id=%s, address=%s, status=%d, healthy=%v",
-		node.ID, node.Address, resp.StatusCode, isHealthy)
+	d.logger.Debug("HEALTH_CHECK: Node checked",
+		"node_id", node.ID, "address", node.Address, "status", resp.StatusCode, "healthy", isHealthy)
 	return isHealthy
 }
 
@@ -373,18 +372,18 @@ func (d *staticDiscovery) performDiscovery() {
 
 		// Check if node has timed out
 		if node.LastSeen.Before(timeoutThreshold) {
-			log.Printf("DISCOVERY_CYCLE: Node timed out, node_id=%s, last_seen=%v, timeout_threshold=%v",
-				nodeID, node.LastSeen, timeoutThreshold)
+			d.logger.Warn("DISCOVERY_CYCLE: Node timed out",
+				"node_id", nodeID, "last_seen", node.LastSeen, "timeout_threshold", timeoutThreshold)
 
 			// If the timed-out node is the leader, trigger election
 			if currentLeader != nil && nodeID == currentLeader.ID {
-				log.Printf("DISCOVERY_CYCLE: Leader has timed out, triggering election, leader_id=%s", nodeID)
+				d.logger.Warn("DISCOVERY_CYCLE: Leader has timed out, triggering election", "leader_id", nodeID)
 				go d.manager.triggerLeaderElection("leader timeout detected")
 			}
 		}
 	}
 
-	log.Printf("DISCOVERY_CYCLE: Discovery cycle completed, total_nodes=%d", len(d.nodes))
+	d.logger.Debug("DISCOVERY_CYCLE: Discovery cycle completed", "total_nodes", len(d.nodes))
 }
 
 // geographicDiscovery implements Discovery with geographic awareness

--- a/commercial/ha/discovery_test.go
+++ b/commercial/ha/discovery_test.go
@@ -1,0 +1,44 @@
+//go:build commercial
+
+// SPDX-License-Identifier: Elastic-2.0
+// Copyright 2026 Jordan Ritz
+// +build commercial
+
+package ha
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	pkgtesting "github.com/cfgis/cfgms/pkg/testing"
+)
+
+func TestDiscovery_Stop_logsStop(t *testing.T) {
+	mock := pkgtesting.NewMockLogger(true)
+
+	cfg := &DiscoveryConfig{
+		Method:      "static",
+		Config:      make(map[string]interface{}),
+		NodeTimeout: 30 * time.Second,
+	}
+
+	d, err := newStaticDiscovery(cfg, mock, nil)
+	require.NoError(t, err)
+
+	// Mark as started so Stop() proceeds past the early-return guard.
+	d.mu.Lock()
+	d.started = true
+	d.mu.Unlock()
+
+	ctx := context.Background()
+	err = d.Stop(ctx)
+	require.NoError(t, err)
+
+	infoLogs := mock.GetLogs("info")
+	require.NotEmpty(t, infoLogs, "expected info logs from Stop()")
+	assert.Equal(t, "Static discovery stopped", infoLogs[0].Message)
+}

--- a/commercial/ha/manager.go
+++ b/commercial/ha/manager.go
@@ -11,7 +11,6 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"fmt"
-	"log"
 	"os"
 	"sync"
 	"time"
@@ -481,20 +480,20 @@ func (m *Manager) initializeRaftConsensus() error {
 	// Use a simple hash of the node ID string
 	nodeID := hashStringToUint64(m.nodeInfo.ID)
 
-	log.Printf("RAFT_INIT: Starting Raft consensus initialization, node_id_string=%s, node_id_uint64=%d, node_address=%s",
-		m.nodeInfo.ID, nodeID, m.nodeInfo.Address)
+	m.logger.Debug("RAFT_INIT: Starting Raft consensus initialization",
+		"node_id_string", m.nodeInfo.ID, "node_id_uint64", nodeID, "node_address", m.nodeInfo.Address)
 
 	// Build peer list from cluster configuration
 	peers := make([]raft.Peer, 0)
 
 	// Parse cluster nodes from config
-	log.Printf("RAFT_INIT: Parsing cluster nodes from config, config_nil=%t", m.cfg.Cluster.Discovery.Config == nil)
+	m.logger.Debug("RAFT_INIT: Parsing cluster nodes from config", "config_nil", m.cfg.Cluster.Discovery.Config == nil)
 
 	if clusterNodes := m.cfg.Cluster.Discovery.Config["nodes"]; clusterNodes != nil {
-		log.Printf("RAFT_INIT: Found cluster nodes in config, type=%T", clusterNodes)
+		m.logger.Debug("RAFT_INIT: Found cluster nodes in config", "type", fmt.Sprintf("%T", clusterNodes))
 		// Try both []interface{} and []map[string]interface{} type assertions
 		if nodes, ok := clusterNodes.([]interface{}); ok {
-			log.Printf("RAFT_INIT: Cluster nodes is []interface{}, count=%d", len(nodes))
+			m.logger.Debug("RAFT_INIT: Cluster nodes is []interface{}", "count", len(nodes))
 			for i, n := range nodes {
 				if nodeMap, ok := n.(map[string]interface{}); ok {
 					if id, ok := nodeMap["id"].(string); ok {
@@ -503,12 +502,12 @@ func (m *Manager) initializeRaftConsensus() error {
 							ID:      peerID,
 							Context: []byte(id), // Store original string ID
 						})
-						log.Printf("RAFT_INIT: Added peer to list, index=%d, peer_id_string=%s, peer_id_uint64=%d", i, id, peerID)
+						m.logger.Debug("RAFT_INIT: Added peer to list", "index", i, "peer_id_string", id, "peer_id_uint64", peerID)
 					}
 				}
 			}
 		} else if nodes, ok := clusterNodes.([]map[string]interface{}); ok {
-			log.Printf("RAFT_INIT: Cluster nodes is []map[string]interface{}, count=%d", len(nodes))
+			m.logger.Debug("RAFT_INIT: Cluster nodes is []map[string]interface{}", "count", len(nodes))
 			for i, nodeMap := range nodes {
 				if id, ok := nodeMap["id"].(string); ok {
 					peerID := hashStringToUint64(id)
@@ -516,14 +515,14 @@ func (m *Manager) initializeRaftConsensus() error {
 						ID:      peerID,
 						Context: []byte(id), // Store original string ID
 					})
-					log.Printf("RAFT_INIT: Added peer to list, index=%d, peer_id_string=%s, peer_id_uint64=%d", i, id, peerID)
+					m.logger.Debug("RAFT_INIT: Added peer to list", "index", i, "peer_id_string", id, "peer_id_uint64", peerID)
 				}
 			}
 		} else {
-			log.Printf("RAFT_INIT: Cluster nodes has unexpected type: %T", clusterNodes)
+			m.logger.Debug("RAFT_INIT: Cluster nodes has unexpected type", "type", fmt.Sprintf("%T", clusterNodes))
 		}
 	} else {
-		log.Printf("RAFT_INIT: No cluster nodes found in config")
+		m.logger.Debug("RAFT_INIT: No cluster nodes found in config")
 	}
 
 	// Create Raft consensus
@@ -539,21 +538,21 @@ func (m *Manager) initializeRaftConsensus() error {
 		var readErr error
 		caCertPEM, readErr = os.ReadFile(m.cfg.CACertPath)
 		if readErr != nil {
-			log.Printf("RAFT_INIT: WARNING: Failed to read CA cert from %s: %v", m.cfg.CACertPath, readErr)
+			m.logger.Warn("RAFT_INIT: Failed to read CA cert", "path", m.cfg.CACertPath, "error", readErr)
 		}
 	}
 
 	// Create and attach transport
-	transport := newRaftTransport(nodeID, m.nodeInfo.Address, m.raftConsensus, caCertPEM)
+	transport := newRaftTransport(nodeID, m.nodeInfo.Address, m.raftConsensus, caCertPEM, m.logger)
 	m.raftConsensus.transport = transport
 
 	// Add peer addresses to transport
-	log.Printf("RAFT_INIT: Configuring peer addresses for transport")
+	m.logger.Debug("RAFT_INIT: Configuring peer addresses for transport")
 	peerCount := 0
 	if clusterNodes := m.cfg.Cluster.Discovery.Config["nodes"]; clusterNodes != nil {
 		// Try both []interface{} and []map[string]interface{} type assertions
 		if nodes, ok := clusterNodes.([]interface{}); ok {
-			log.Printf("RAFT_INIT: Processing peer addresses ([]interface{}), total_nodes=%d", len(nodes))
+			m.logger.Debug("RAFT_INIT: Processing peer addresses ([]interface{})", "total_nodes", len(nodes))
 			for i, n := range nodes {
 				if nodeMap, ok := n.(map[string]interface{}); ok {
 					if id, ok := nodeMap["id"].(string); ok {
@@ -562,19 +561,19 @@ func (m *Manager) initializeRaftConsensus() error {
 							if peerID != nodeID { // Don't add self
 								transport.AddPeer(peerID, addr)
 								peerCount++
-								log.Printf("RAFT_INIT: Added peer address to transport, index=%d, peer_id_string=%s, peer_id_uint64=%d, address=%s",
-									i, id, peerID, addr)
+								m.logger.Debug("RAFT_INIT: Added peer address to transport",
+									"index", i, "peer_id_string", id, "peer_id_uint64", peerID, "address", addr)
 							} else {
-								log.Printf("RAFT_INIT: Skipped self in peer list, node_id=%s", id)
+								m.logger.Debug("RAFT_INIT: Skipped self in peer list", "node_id", id)
 							}
 						} else {
-							log.Printf("RAFT_INIT: Node missing address, index=%d, node_id=%s", i, id)
+							m.logger.Debug("RAFT_INIT: Node missing address", "index", i, "node_id", id)
 						}
 					}
 				}
 			}
 		} else if nodes, ok := clusterNodes.([]map[string]interface{}); ok {
-			log.Printf("RAFT_INIT: Processing peer addresses ([]map), total_nodes=%d", len(nodes))
+			m.logger.Debug("RAFT_INIT: Processing peer addresses ([]map)", "total_nodes", len(nodes))
 			for i, nodeMap := range nodes {
 				if id, ok := nodeMap["id"].(string); ok {
 					if addr, ok := nodeMap["address"].(string); ok {
@@ -582,21 +581,21 @@ func (m *Manager) initializeRaftConsensus() error {
 						if peerID != nodeID { // Don't add self
 							transport.AddPeer(peerID, addr)
 							peerCount++
-							log.Printf("RAFT_INIT: Added peer address to transport, index=%d, peer_id_string=%s, peer_id_uint64=%d, address=%s",
-								i, id, peerID, addr)
+							m.logger.Debug("RAFT_INIT: Added peer address to transport",
+								"index", i, "peer_id_string", id, "peer_id_uint64", peerID, "address", addr)
 						} else {
-							log.Printf("RAFT_INIT: Skipped self in peer list, node_id=%s", id)
+							m.logger.Debug("RAFT_INIT: Skipped self in peer list", "node_id", id)
 						}
 					} else {
-						log.Printf("RAFT_INIT: Node missing address, index=%d, node_id=%s", i, id)
+						m.logger.Debug("RAFT_INIT: Node missing address", "index", i, "node_id", id)
 					}
 				}
 			}
 		}
 	}
 
-	log.Printf("RAFT_INIT: Raft consensus initialized, node_id=%d, total_peers=%d, configured_peer_addresses=%d",
-		nodeID, len(peers), peerCount)
+	m.logger.Debug("RAFT_INIT: Raft consensus initialized",
+		"node_id", nodeID, "total_peers", len(peers), "configured_peer_addresses", peerCount)
 
 	return nil
 }

--- a/commercial/ha/manager_test.go
+++ b/commercial/ha/manager_test.go
@@ -8,6 +8,7 @@ package ha
 
 import (
 	"context"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -18,8 +19,42 @@ import (
 	"github.com/cfgis/cfgms/pkg/logging"
 	_ "github.com/cfgis/cfgms/pkg/storage/providers/flatfile"
 	_ "github.com/cfgis/cfgms/pkg/storage/providers/sqlite" // Register git provider
+	pkgtesting "github.com/cfgis/cfgms/pkg/testing"
 	"github.com/cfgis/cfgms/pkg/testing/storage"
 )
+
+func TestManager_initRaft_logsInitStart(t *testing.T) {
+	mock := pkgtesting.NewMockLogger(true)
+
+	storageManager, err := storage.CreateTestStorageManager()
+	require.NoError(t, err)
+
+	cfg := DefaultConfig()
+	cfg.Mode = ClusterMode
+	cfg.Node.ID = "test-node-init-raft"
+
+	manager, err := NewManager(cfg, mock, storageManager)
+	require.NoError(t, err)
+	require.NotNil(t, manager)
+
+	t.Cleanup(func() {
+		if manager.raftConsensus != nil {
+			assert.NoError(t, manager.raftConsensus.Stop())
+		}
+	})
+
+	debugLogs := mock.GetLogs("debug")
+	require.NotEmpty(t, debugLogs, "expected debug logs from raft initialization")
+
+	found := false
+	for _, entry := range debugLogs {
+		if strings.Contains(entry.Message, "RAFT_INIT") {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found, "expected a debug log containing RAFT_INIT, got logs: %v", debugLogs)
+}
 
 func TestManager_SingleServerMode(t *testing.T) {
 	// Create test logger

--- a/commercial/ha/raft_consensus.go
+++ b/commercial/ha/raft_consensus.go
@@ -10,7 +10,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"log"
 	"sync"
 	"time"
 
@@ -122,21 +121,21 @@ func NewRaftConsensus(ctx context.Context, nodeID uint64, nodeInfo *NodeInfo, pe
 	if len(peers) > 0 {
 		// Starting a new cluster
 		rc.node = raft.StartNode(config, peers)
-		log.Printf("RAFT: Started new Raft node, node_id=%d, peers=%v", nodeID, peers)
+		logger.Info("RAFT: Started new Raft node", "node_id", nodeID, "peers", peers)
 
 		// Log Raft status immediately after start
 		status := rc.node.Status()
-		log.Printf("RAFT: Initial status after StartNode, node_id=%d, term=%d, lead=%d, raft_state=%s",
-			nodeID, status.Term, status.Lead, status.RaftState)
+		logger.Debug("RAFT: Initial status after StartNode",
+			"node_id", nodeID, "term", status.Term, "lead", status.Lead, "raft_state", status.RaftState)
 	} else {
 		// Joining existing cluster (will be added via ConfChange)
 		rc.node = raft.RestartNode(config)
-		log.Printf("RAFT: Restarted Raft node, node_id=%d", nodeID)
+		logger.Info("RAFT: Restarted Raft node", "node_id", nodeID)
 	}
 
 	// CRITICAL: Start the Raft processing loop IMMEDIATELY
 	// The Ready channel must be consumed or Raft will block
-	log.Printf("RAFT: Starting Raft processing loop immediately, node_id=%d", nodeID)
+	logger.Debug("RAFT: Starting Raft processing loop immediately", "node_id", nodeID)
 	go rc.runRaft()
 
 	return rc, nil
@@ -144,7 +143,7 @@ func NewRaftConsensus(ctx context.Context, nodeID uint64, nodeInfo *NodeInfo, pe
 
 // Start begins the Raft consensus engine
 func (rc *RaftConsensus) Start() error {
-	log.Printf("RAFT: Starting Raft consensus engine, node_id=%d", rc.nodeID)
+	rc.logger.Info("RAFT: Starting Raft consensus engine", "node_id", rc.nodeID)
 
 	// Note: runRaft() goroutine is already started in NewRaftConsensus()
 	// to ensure Ready channel is consumed immediately
@@ -165,7 +164,7 @@ func (rc *RaftConsensus) Start() error {
 
 // Stop gracefully stops the Raft consensus engine
 func (rc *RaftConsensus) Stop() error {
-	log.Printf("RAFT: Stopping Raft consensus engine, node_id=%d", rc.nodeID)
+	rc.logger.Info("RAFT: Stopping Raft consensus engine", "node_id", rc.nodeID)
 
 	close(rc.stopC)
 	rc.cancel()
@@ -184,7 +183,7 @@ func (rc *RaftConsensus) runRaft() {
 	ticker := time.NewTicker(100 * time.Millisecond)
 	defer ticker.Stop()
 
-	log.Printf("RAFT: Main Raft loop started, node_id=%d, ticker=%p", rc.nodeID, ticker)
+	rc.logger.Debug("RAFT: Main Raft loop started", "node_id", rc.nodeID)
 	tickCount := 0
 	loopCount := 0
 
@@ -195,45 +194,45 @@ func (rc *RaftConsensus) runRaft() {
 	for {
 		loopCount++
 		if loopCount%100 == 0 {
-			log.Printf("RAFT: Loop iteration %d, node_id=%d", loopCount, rc.nodeID)
+			rc.logger.Debug("RAFT: Loop iteration", "count", loopCount, "node_id", rc.nodeID)
 		}
 
 		select {
 		case <-ticker.C:
 			tickCount++
-			log.Printf("RAFT: Tick %d START, node_id=%d", tickCount, rc.nodeID)
+			rc.logger.Debug("RAFT: Tick START", "tick", tickCount, "node_id", rc.nodeID)
 			rc.node.Tick()
-			log.Printf("RAFT: Tick %d COMPLETE, node_id=%d", tickCount, rc.nodeID)
+			rc.logger.Debug("RAFT: Tick COMPLETE", "tick", tickCount, "node_id", rc.nodeID)
 
 		case <-debugTicker.C:
 			// Periodic health check
 
 		case rd := <-rc.node.Ready():
 			// Process Ready updates from Raft
-			log.Printf("RAFT: Processing Ready, node_id=%d, has_entries=%d, has_messages=%d, has_snapshot=%t",
-				rc.nodeID, len(rd.Entries), len(rd.Messages), !raft.IsEmptySnap(rd.Snapshot))
+			rc.logger.Debug("RAFT: Processing Ready",
+				"node_id", rc.nodeID, "entries", len(rd.Entries), "messages", len(rd.Messages), "has_snapshot", !raft.IsEmptySnap(rd.Snapshot))
 			rc.processReady(rd)
 
 		case prop := <-rc.proposeC:
 			// Propose new entry to Raft log
-			log.Printf("RAFT: Received proposal, node_id=%d", rc.nodeID)
+			rc.logger.Debug("RAFT: Received proposal", "node_id", rc.nodeID)
 			if err := rc.node.Propose(rc.ctx, prop); err != nil {
 				rc.logger.Error("Failed to propose to Raft", "error", err)
 			}
 
 		case cc := <-rc.confChangeC:
 			// Propose configuration change
-			log.Printf("RAFT: Received conf change, node_id=%d", rc.nodeID)
+			rc.logger.Debug("RAFT: Received conf change", "node_id", rc.nodeID)
 			if err := rc.node.ProposeConfChange(rc.ctx, cc); err != nil {
 				rc.logger.Error("Failed to propose conf change", "error", err)
 			}
 
 		case <-rc.stopC:
-			log.Printf("RAFT: Raft loop stopping, node_id=%d", rc.nodeID)
+			rc.logger.Debug("RAFT: Raft loop stopping", "node_id", rc.nodeID)
 			return
 
 		case <-rc.ctx.Done():
-			log.Printf("RAFT: Raft loop context cancelled, node_id=%d", rc.nodeID)
+			rc.logger.Debug("RAFT: Raft loop context cancelled", "node_id", rc.nodeID)
 			return
 		}
 	}
@@ -241,57 +240,57 @@ func (rc *RaftConsensus) runRaft() {
 
 // processReady handles Ready struct from Raft
 func (rc *RaftConsensus) processReady(rd raft.Ready) {
-	log.Printf("RAFT: processReady START, node_id=%d", rc.nodeID)
+	rc.logger.Debug("RAFT: processReady START", "node_id", rc.nodeID)
 
 	// Save to storage before sending messages
 	if !raft.IsEmptySnap(rd.Snapshot) {
-		log.Printf("RAFT: Applying snapshot, node_id=%d", rc.nodeID)
+		rc.logger.Debug("RAFT: Applying snapshot", "node_id", rc.nodeID)
 		if err := rc.storage.ApplySnapshot(rd.Snapshot); err != nil {
-			log.Printf("RAFT: Failed to apply snapshot, node_id=%d, error=%v", rc.nodeID, err)
+			rc.logger.Error("RAFT: Failed to apply snapshot", "node_id", rc.nodeID, "error", err)
 		}
 		rc.publishSnapshot(rd.Snapshot)
 	}
 
 	if len(rd.Entries) > 0 {
-		log.Printf("RAFT: Appending %d entries to storage, node_id=%d", len(rd.Entries), rc.nodeID)
+		rc.logger.Debug("RAFT: Appending entries to storage", "count", len(rd.Entries), "node_id", rc.nodeID)
 		if err := rc.storage.Append(rd.Entries); err != nil {
-			log.Printf("RAFT: Failed to append entries, node_id=%d, error=%v", rc.nodeID, err)
+			rc.logger.Error("RAFT: Failed to append entries", "node_id", rc.nodeID, "error", err)
 		}
 	}
 
 	if !raft.IsEmptyHardState(rd.HardState) {
 		hardState := rd.HardState
-		log.Printf("RAFT: Setting HardState, node_id=%d, term=%d, vote=%d, commit=%d",
-			rc.nodeID, hardState.Term, hardState.Vote, hardState.Commit)
+		rc.logger.Debug("RAFT: Setting HardState",
+			"node_id", rc.nodeID, "term", hardState.Term, "vote", hardState.Vote, "commit", hardState.Commit)
 		if err := rc.storage.SetHardState(hardState); err != nil {
-			log.Printf("RAFT: Failed to set hard state, node_id=%d, error=%v", rc.nodeID, err)
+			rc.logger.Error("RAFT: Failed to set hard state", "node_id", rc.nodeID, "error", err)
 		}
 	}
 
 	// Send messages to peers
 	if rc.transport != nil && len(rd.Messages) > 0 {
-		log.Printf("RAFT: Sending %d messages to peers, node_id=%d", len(rd.Messages), rc.nodeID)
+		rc.logger.Debug("RAFT: Sending messages to peers", "count", len(rd.Messages), "node_id", rc.nodeID)
 		rc.transport.Send(rd.Messages)
 	}
 
 	// Apply committed entries to state machine
 	if len(rd.CommittedEntries) > 0 {
-		log.Printf("RAFT: Applying %d committed entries, node_id=%d", len(rd.CommittedEntries), rc.nodeID)
+		rc.logger.Debug("RAFT: Applying committed entries", "count", len(rd.CommittedEntries), "node_id", rc.nodeID)
 		rc.publishEntries(rc.entriesToApply(rd.CommittedEntries))
 	}
 
 	// Update leadership
 	if rd.SoftState != nil {
 		softState := rd.SoftState
-		log.Printf("RAFT: Updating leadership, node_id=%d, lead=%d, raft_state=%s",
-			rc.nodeID, softState.Lead, softState.RaftState)
+		rc.logger.Debug("RAFT: Updating leadership",
+			"node_id", rc.nodeID, "lead", softState.Lead, "raft_state", softState.RaftState)
 		rc.updateLeadership(softState)
 	}
 
 	// Advance the Raft state machine
-	log.Printf("RAFT: Calling Advance(), node_id=%d", rc.nodeID)
+	rc.logger.Debug("RAFT: Calling Advance()", "node_id", rc.nodeID)
 	rc.node.Advance()
-	log.Printf("RAFT: processReady COMPLETE, node_id=%d", rc.nodeID)
+	rc.logger.Debug("RAFT: processReady COMPLETE", "node_id", rc.nodeID)
 }
 
 // entriesToApply filters out entries that have already been applied
@@ -307,12 +306,12 @@ func (rc *RaftConsensus) entriesToApply(entries []raftpb.Entry) []raftpb.Entry {
 	firstIdx := entries[0].Index
 	lastIdx := entries[len(entries)-1].Index
 
-	log.Printf("RAFT: entriesToApply check, node_id=%d, firstIdx=%d, lastIdx=%d, appliedIndex=%d",
-		rc.nodeID, firstIdx, lastIdx, rc.appliedIndex)
+	rc.logger.Debug("RAFT: entriesToApply check",
+		"node_id", rc.nodeID, "firstIdx", firstIdx, "lastIdx", lastIdx, "appliedIndex", rc.appliedIndex)
 
 	// If we've already applied all these entries, skip them
 	if lastIdx <= rc.appliedIndex {
-		log.Printf("RAFT: All entries already applied, node_id=%d", rc.nodeID)
+		rc.logger.Debug("RAFT: All entries already applied", "node_id", rc.nodeID)
 		return nil
 	}
 
@@ -321,7 +320,7 @@ func (rc *RaftConsensus) entriesToApply(entries []raftpb.Entry) []raftpb.Entry {
 	if firstIdx <= rc.appliedIndex {
 		// Some entries at the beginning have already been applied
 		offset = rc.appliedIndex + 1 - firstIdx
-		log.Printf("RAFT: Skipping %d already-applied entries, node_id=%d", offset, rc.nodeID)
+		rc.logger.Debug("RAFT: Skipping already-applied entries", "count", offset, "node_id", rc.nodeID)
 	}
 
 	if offset >= uint64(len(entries)) {
@@ -344,13 +343,13 @@ func (rc *RaftConsensus) publishEntries(entries []raftpb.Entry) {
 
 			// Apply command to state machine
 			if err := rc.applyCommand(entry.Data); err != nil {
-				log.Printf("RAFT: Failed to apply command: %v", err)
+				rc.logger.Error("RAFT: Failed to apply command", "error", err)
 			}
 
 		case raftpb.EntryConfChange:
 			var cc raftpb.ConfChange
 			if err := cc.Unmarshal(entry.Data); err != nil {
-				log.Printf("RAFT: Failed to unmarshal conf change: %v", err)
+				rc.logger.Error("RAFT: Failed to unmarshal conf change", "error", err)
 				continue
 			}
 
@@ -358,9 +357,9 @@ func (rc *RaftConsensus) publishEntries(entries []raftpb.Entry) {
 
 			switch cc.Type {
 			case raftpb.ConfChangeAddNode:
-				log.Printf("RAFT: Added node to cluster, node_id=%d", cc.NodeID)
+				rc.logger.Info("RAFT: Added node to cluster", "node_id", cc.NodeID)
 			case raftpb.ConfChangeRemoveNode:
-				log.Printf("RAFT: Removed node from cluster, node_id=%d", cc.NodeID)
+				rc.logger.Info("RAFT: Removed node from cluster", "node_id", cc.NodeID)
 				rc.clusterState.mu.Lock()
 				delete(rc.clusterState.Nodes, cc.NodeID)
 				rc.clusterState.mu.Unlock()
@@ -371,7 +370,7 @@ func (rc *RaftConsensus) publishEntries(entries []raftpb.Entry) {
 		rc.mu.Lock()
 		if entry.Index > rc.appliedIndex {
 			rc.appliedIndex = entry.Index
-			log.Printf("RAFT: Updated appliedIndex=%d, node_id=%d", rc.appliedIndex, rc.nodeID)
+			rc.logger.Debug("RAFT: Updated appliedIndex", "applied_index", rc.appliedIndex, "node_id", rc.nodeID)
 		}
 		rc.mu.Unlock()
 	}
@@ -409,7 +408,7 @@ func (rc *RaftConsensus) applyNodeUpdate(data interface{}) error {
 	rc.clusterState.LastModified = time.Now()
 	rc.clusterState.mu.Unlock()
 
-	log.Printf("RAFT: Applied node update, node_id=%d, node_info=%+v", update.NodeID, update.NodeInfo)
+	rc.logger.Debug("RAFT: Applied node update", "node_id", update.NodeID, "node_info", update.NodeInfo)
 
 	return nil
 }
@@ -420,11 +419,11 @@ func (rc *RaftConsensus) publishSnapshot(snapshot raftpb.Snapshot) {
 		return
 	}
 
-	log.Printf("RAFT: Publishing snapshot at index %d", snapshot.Metadata.Index)
+	rc.logger.Debug("RAFT: Publishing snapshot", "index", snapshot.Metadata.Index)
 
 	var state ClusterState
 	if err := json.Unmarshal(snapshot.Data, &state); err != nil {
-		log.Printf("RAFT: Failed to unmarshal snapshot: %v", err)
+		rc.logger.Error("RAFT: Failed to unmarshal snapshot", "error", err)
 		return
 	}
 
@@ -442,10 +441,10 @@ func (rc *RaftConsensus) updateLeadership(ss *raft.SoftState) {
 	isLeader := ss.Lead == rc.nodeID && ss.RaftState == raft.StateLeader
 
 	if !wasLeader && isLeader {
-		log.Printf("RAFT: Node became LEADER, node_id=%d, term=%d", rc.nodeID, rc.node.Status().Term)
+		rc.logger.Info("RAFT: Node became LEADER", "node_id", rc.nodeID, "term", rc.node.Status().Term)
 		rc.clusterState.Leader = rc.nodeID
 	} else if wasLeader && !isLeader {
-		log.Printf("RAFT: Node lost LEADER status, node_id=%d, new_leader=%d", rc.nodeID, ss.Lead)
+		rc.logger.Info("RAFT: Node lost LEADER status", "node_id", rc.nodeID, "new_leader", ss.Lead)
 		rc.clusterState.Leader = ss.Lead
 	}
 

--- a/commercial/ha/raft_consensus_test.go
+++ b/commercial/ha/raft_consensus_test.go
@@ -1,0 +1,57 @@
+//go:build commercial
+
+// SPDX-License-Identifier: Elastic-2.0
+// Copyright 2026 Jordan Ritz
+// +build commercial
+
+package ha
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	pkgtesting "github.com/cfgis/cfgms/pkg/testing"
+)
+
+func TestRaftConsensus_propose_logsError(t *testing.T) {
+	mock := pkgtesting.NewMockLogger(true)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	nodeInfo := &NodeInfo{
+		ID:    "test-node",
+		State: NodeStateHealthy,
+		Role:  NodeRoleFollower,
+	}
+
+	rc, err := NewRaftConsensus(ctx, 1, nodeInfo, nil, mock)
+	require.NoError(t, err)
+
+	// Stop the underlying raft node so that Propose returns ErrStopped.
+	// The runRaft goroutine continues running (stopC and ctx not closed),
+	// so it will read from proposeC, call Propose, get ErrStopped, and log.
+	rc.node.Stop()
+
+	// Send a proposal in a goroutine; the runRaft loop will try to Propose
+	// on the stopped node, receive ErrStopped, and log the error.
+	go func() {
+		select {
+		case rc.proposeC <- []byte("trigger error"):
+		case <-time.After(2 * time.Second):
+		}
+	}()
+
+	// Poll until the error log appears — no fixed sleep, race-detector safe.
+	require.Eventually(t, func() bool {
+		for _, entry := range mock.GetLogs("error") {
+			if entry.Message == "Failed to propose to Raft" {
+				return true
+			}
+		}
+		return false
+	}, 2*time.Second, 10*time.Millisecond, "expected 'Failed to propose to Raft' error log")
+}

--- a/commercial/ha/raft_transport.go
+++ b/commercial/ha/raft_transport.go
@@ -13,7 +13,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"log"
 	"net/http"
 	"sync"
 	"time"
@@ -21,6 +20,7 @@ import (
 	"go.etcd.io/raft/v3/raftpb"
 
 	"github.com/cfgis/cfgms/pkg/cert"
+	"github.com/cfgis/cfgms/pkg/logging"
 )
 
 // raftTransport handles network communication between Raft nodes
@@ -45,10 +45,12 @@ type raftTransport struct {
 	ctx    context.Context
 	cancel context.CancelFunc
 	stopC  chan struct{}
+
+	logger logging.Logger
 }
 
 // newRaftTransport creates a new Raft transport
-func newRaftTransport(nodeID uint64, address string, consensus *RaftConsensus, caCertPEM []byte) *raftTransport {
+func newRaftTransport(nodeID uint64, address string, consensus *RaftConsensus, caCertPEM []byte, logger logging.Logger) *raftTransport {
 	var tlsConfig *tls.Config
 	var err error
 
@@ -56,14 +58,14 @@ func newRaftTransport(nodeID uint64, address string, consensus *RaftConsensus, c
 		// Proper TLS validation with CA certificate
 		tlsConfig, err = cert.CreateClientTLSConfig(nil, nil, caCertPEM, "", tls.VersionTLS12)
 		if err != nil {
-			log.Printf("RAFT_TRANSPORT: Failed to create TLS config with CA cert, using basic TLS: %v", err)
+			logger.Error("RAFT_TRANSPORT: Failed to create TLS config with CA cert, using basic TLS", "error", err)
 			tlsConfig, _ = cert.CreateBasicTLSConfig(nil, nil, tls.VersionTLS12)
 		}
 	} else {
 		// No CA cert available — use basic TLS without InsecureSkipVerify.
 		// Connections to peers will fail TLS validation (correct: don't run HA without proper certs).
-		log.Printf("RAFT_TRANSPORT: WARNING: No CA certificate configured for HA transport. " +
-			"Set CFGMS_HA_CA_CERT_PATH for proper TLS validation between cluster nodes.")
+		logger.Warn("RAFT_TRANSPORT: No CA certificate configured for HA transport",
+			"hint", "Set CFGMS_HA_CA_CERT_PATH for proper TLS validation between cluster nodes")
 		tlsConfig, _ = cert.CreateBasicTLSConfig(nil, nil, tls.VersionTLS12)
 	}
 
@@ -83,14 +85,15 @@ func newRaftTransport(nodeID uint64, address string, consensus *RaftConsensus, c
 			Timeout:   3 * time.Second,
 			Transport: transport,
 		},
-		stopC: make(chan struct{}),
+		stopC:  make(chan struct{}),
+		logger: logger,
 	}
 }
 
 // Start begins the transport layer
 func (t *raftTransport) Start(ctx context.Context) error {
 	t.ctx, t.cancel = context.WithCancel(ctx)
-	log.Printf("RAFT_TRANSPORT: Started transport, node_id=%d, address=%s", t.nodeID, t.address)
+	t.logger.Info("RAFT_TRANSPORT: Started transport", "node_id", t.nodeID, "address", t.address)
 	return nil
 }
 
@@ -100,7 +103,7 @@ func (t *raftTransport) Stop() {
 		t.cancel()
 	}
 	close(t.stopC)
-	log.Printf("RAFT_TRANSPORT: Stopped transport, node_id=%d", t.nodeID)
+	t.logger.Info("RAFT_TRANSPORT: Stopped transport", "node_id", t.nodeID)
 }
 
 // AddPeer adds a peer node address
@@ -108,7 +111,7 @@ func (t *raftTransport) AddPeer(nodeID uint64, address string) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 	t.peers[nodeID] = address
-	log.Printf("RAFT_TRANSPORT: Added peer, node_id=%d, address=%s", nodeID, address)
+	t.logger.Debug("RAFT_TRANSPORT: Added peer", "node_id", nodeID, "address", address)
 }
 
 // RemovePeer removes a peer node
@@ -116,7 +119,7 @@ func (t *raftTransport) RemovePeer(nodeID uint64) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 	delete(t.peers, nodeID)
-	log.Printf("RAFT_TRANSPORT: Removed peer, node_id=%d", nodeID)
+	t.logger.Debug("RAFT_TRANSPORT: Removed peer", "node_id", nodeID)
 }
 
 // Send sends messages to peer nodes
@@ -138,14 +141,14 @@ func (t *raftTransport) sendMessage(msg raftpb.Message) {
 	t.mu.RUnlock()
 
 	if !ok {
-		log.Printf("RAFT_TRANSPORT: No address for peer, peer_id=%d", msg.To)
+		t.logger.Warn("RAFT_TRANSPORT: No address for peer", "peer_id", msg.To)
 		return
 	}
 
 	// Serialize message
 	data, err := msg.Marshal()
 	if err != nil {
-		log.Printf("RAFT_TRANSPORT: Failed to marshal message: %v", err)
+		t.logger.Error("RAFT_TRANSPORT: Failed to marshal message", "error", err)
 		return
 	}
 
@@ -159,7 +162,7 @@ func (t *raftTransport) sendMessage(msg raftpb.Message) {
 	// Send HTTP POST
 	req, err := http.NewRequestWithContext(t.ctx, "POST", url, bytes.NewReader(data))
 	if err != nil {
-		log.Printf("RAFT_TRANSPORT: Failed to create request: %v", err)
+		t.logger.Error("RAFT_TRANSPORT: Failed to create request", "error", err)
 		return
 	}
 
@@ -168,59 +171,59 @@ func (t *raftTransport) sendMessage(msg raftpb.Message) {
 
 	resp, err := t.client.Do(req)
 	if err != nil {
-		log.Printf("RAFT_TRANSPORT: Failed to send message to peer %d at %s: %v", msg.To, peerAddr, err)
+		t.logger.Error("RAFT_TRANSPORT: Failed to send message to peer", "peer_id", msg.To, "address", peerAddr, "error", err)
 		return
 	}
 	defer func() {
 		if err := resp.Body.Close(); err != nil {
-			log.Printf("RAFT_TRANSPORT: Failed to close response body for peer %d: %v", msg.To, err)
+			t.logger.Error("RAFT_TRANSPORT: Failed to close response body", "peer_id", msg.To, "error", err)
 		}
 	}()
 
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
-		log.Printf("RAFT_TRANSPORT: Peer %d returned error %d: %s", msg.To, resp.StatusCode, string(body))
+		t.logger.Warn("RAFT_TRANSPORT: Peer returned error", "peer_id", msg.To, "status", resp.StatusCode, "body", string(body))
 	}
 }
 
 // HandleMessage processes incoming Raft messages (HTTP handler)
 func (t *raftTransport) HandleMessage(w http.ResponseWriter, r *http.Request) {
-	log.Printf("RAFT_TRANSPORT: Received message HTTP request, node_id=%d, remote_addr=%s", t.nodeID, r.RemoteAddr)
+	t.logger.Debug("RAFT_TRANSPORT: Received message HTTP request", "node_id", t.nodeID, "remote_addr", r.RemoteAddr)
 
 	// Read message body
 	data, err := io.ReadAll(r.Body)
 	if err != nil {
-		log.Printf("RAFT_TRANSPORT: Failed to read message body: %v", err)
+		t.logger.Error("RAFT_TRANSPORT: Failed to read message body", "error", err)
 		http.Error(w, "Failed to read message", http.StatusBadRequest)
 		return
 	}
 	defer func() {
 		if err := r.Body.Close(); err != nil {
-			log.Printf("RAFT_TRANSPORT: Failed to close request body: %v", err)
+			t.logger.Error("RAFT_TRANSPORT: Failed to close request body", "error", err)
 		}
 	}()
 
-	log.Printf("RAFT_TRANSPORT: Read %d bytes from request body", len(data))
+	t.logger.Debug("RAFT_TRANSPORT: Read bytes from request body", "bytes", len(data))
 
 	// Deserialize message
 	var msg raftpb.Message
 	if err := msg.Unmarshal(data); err != nil {
-		log.Printf("RAFT_TRANSPORT: Failed to unmarshal message: %v", err)
+		t.logger.Error("RAFT_TRANSPORT: Failed to unmarshal message", "error", err)
 		http.Error(w, "Failed to unmarshal message", http.StatusBadRequest)
 		return
 	}
 
-	log.Printf("RAFT_TRANSPORT: Received Raft message, node_id=%d, from=%d, to=%d, type=%s",
-		t.nodeID, msg.From, msg.To, msg.Type)
+	t.logger.Debug("RAFT_TRANSPORT: Received Raft message",
+		"node_id", t.nodeID, "from", msg.From, "to", msg.To, "type", msg.Type)
 
 	// Process message through Raft
 	if err := t.consensus.Process(r.Context(), msg); err != nil {
-		log.Printf("RAFT_TRANSPORT: Failed to process message from peer %d: %v", msg.From, err)
+		t.logger.Error("RAFT_TRANSPORT: Failed to process message from peer", "peer_id", msg.From, "error", err)
 		http.Error(w, "Failed to process message", http.StatusInternalServerError)
 		return
 	}
 
-	log.Printf("RAFT_TRANSPORT: Successfully processed message from peer %d", msg.From)
+	t.logger.Debug("RAFT_TRANSPORT: Successfully processed message from peer", "peer_id", msg.From)
 	w.WriteHeader(http.StatusOK)
 }
 
@@ -245,6 +248,6 @@ func (t *raftTransport) HandleStatus(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", "application/json")
 	if err := json.NewEncoder(w).Encode(status); err != nil {
-		log.Printf("RAFT_TRANSPORT: Failed to encode status response: %v", err)
+		t.logger.Error("RAFT_TRANSPORT: Failed to encode status response", "error", err)
 	}
 }

--- a/commercial/ha/raft_transport_test.go
+++ b/commercial/ha/raft_transport_test.go
@@ -1,0 +1,33 @@
+//go:build commercial
+
+// SPDX-License-Identifier: Elastic-2.0
+// Copyright 2026 Jordan Ritz
+// +build commercial
+
+package ha
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	pkgtesting "github.com/cfgis/cfgms/pkg/testing"
+)
+
+func TestRaftTransport_Start_logsStartup(t *testing.T) {
+	mock := pkgtesting.NewMockLogger(true)
+
+	transport := newRaftTransport(1, "localhost:8080", nil, nil, mock)
+
+	ctx := context.Background()
+	err := transport.Start(ctx)
+	require.NoError(t, err)
+
+	infoLogs := mock.GetLogs("info")
+	require.NotEmpty(t, infoLogs, "expected at least one info log after Start()")
+	assert.True(t, strings.Contains(infoLogs[0].Message, "RAFT_TRANSPORT"),
+		"startup log should contain RAFT_TRANSPORT, got: %s", infoLogs[0].Message)
+}


### PR DESCRIPTION
## Summary

- Replace all 112 `log.Printf` call sites in `commercial/ha` with the `pkg/logging.Logger` already present on each struct, eliminating the `"log"` import from all four files
- Add `logger logging.Logger` field to `raftTransport` struct and propagate it from the manager via updated `newRaftTransport` signature
- Add 4 required acceptance tests using `pkgtesting.NewMockLogger`

## Acceptance Criteria Verification

- [x] `grep -rn '"log"' commercial/ha/` returns zero results
- [x] `grep -rn 'log\.Printf' commercial/ha/` returns zero results
- [x] `newRaftTransport` signature updated to accept `logger logging.Logger` as final parameter
- [x] `TestManager_initRaft_logsInitStart` — asserts debug log contains `"RAFT_INIT"`
- [x] `TestRaftConsensus_propose_logsError` — asserts error log `"Failed to propose to Raft"` (uses `require.Eventually`, race-detector safe)
- [x] `TestRaftTransport_Start_logsStartup` — asserts info log contains `"RAFT_TRANSPORT"`
- [x] `TestDiscovery_Stop_logsStop` — asserts `"Static discovery stopped"` info log

## Specialist Review Results

**QA Test Runner: PASS**
- All packages passing; commercial/ha: PASS
- Cross-platform compilation: 5 targets verified
- All 4 required tests confirmed running
- `/tmp/agent-validation-passed` written

**QA Code Reviewer: PASS** (after one fix iteration)
- Fixed: `time.Sleep` in `TestRaftConsensus_propose_logsError` replaced with `require.Eventually`
- Fixed: `_ = raftConsensus.Stop()` → `assert.NoError(t, raftConsensus.Stop())` in cleanup
- Fixed: Added specific message assertion to `TestRaftTransport_Start_logsStartup`
- 0 blocking issues, 0 warnings on changed code

**Security Engineer: PASS**
- security-precommit: PASS
- check-architecture: PASS (no central provider violations)
- security-scan: PASS (Trivy, Nancy, gosec, staticcheck all green)
- 0 blocking issues

## Notes

Pre-existing issues in `manager_test.go` (skipped tests for known deadlock, `time.Sleep` synchronization) and `discovery.go` (`context.Background()` TEMP FIX) are out of scope for this logging-replacement story and were present on `develop` before this branch. They are documented for follow-up.

Fixes #1155