### PR TITLE
directory: inject logging.Logger into DefaultDirectoryConnectionPool (Issue #1157)

### DIFF
--- a/pkg/directory/interfaces/connection.go
+++ b/pkg/directory/interfaces/connection.go
@@ -11,10 +11,11 @@ package interfaces
 import (
 	"context"
 	"fmt"
-	"log"
 	"sync"
 	"sync/atomic"
 	"time"
+
+	"github.com/cfgis/cfgms/pkg/logging"
 )
 
 // DirectoryConnectionPool manages a pool of directory connections with health monitoring
@@ -39,6 +40,7 @@ type DirectoryConnectionPool interface {
 type DefaultDirectoryConnectionPool struct {
 	// Configuration
 	config PoolConfig
+	logger logging.Logger
 
 	// Connection management
 	connections    chan DirectoryConnection
@@ -132,13 +134,17 @@ type PoolHealth struct {
 }
 
 // NewDirectoryConnectionPool creates a new directory connection pool
-func NewDirectoryConnectionPool(config PoolConfig, connectionFunc ConnectionFunc) (*DefaultDirectoryConnectionPool, error) {
+func NewDirectoryConnectionPool(config PoolConfig, connectionFunc ConnectionFunc, logger logging.Logger) (*DefaultDirectoryConnectionPool, error) {
 	if config.MaxConnections <= 0 {
 		return nil, fmt.Errorf("max_connections must be positive")
 	}
 
 	if connectionFunc == nil {
 		return nil, fmt.Errorf("connection function cannot be nil")
+	}
+
+	if logger == nil {
+		logger = logging.NewNoopLogger()
 	}
 
 	// Set defaults
@@ -172,6 +178,7 @@ func NewDirectoryConnectionPool(config PoolConfig, connectionFunc ConnectionFunc
 
 	pool := &DefaultDirectoryConnectionPool{
 		config:         config,
+		logger:         logger,
 		connections:    make(chan DirectoryConnection, config.MaxConnections),
 		activeConns:    make(map[DirectoryConnection]bool),
 		connectionFunc: connectionFunc,
@@ -342,8 +349,7 @@ func (p *DefaultDirectoryConnectionPool) Put(conn DirectoryConnection) error {
 	if atomic.LoadInt32(&p.closed) != 0 {
 		if conn != nil {
 			if err := conn.Close(context.Background()); err != nil {
-				// Log error but don't fail the operation
-				log.Printf("Warning: failed to close connection: %v", err)
+				p.logger.Warn("failed to close connection", "error", err)
 			}
 		}
 		return fmt.Errorf("connection pool is closed")
@@ -365,8 +371,7 @@ func (p *DefaultDirectoryConnectionPool) Put(conn DirectoryConnection) error {
 	if err := p.healthChecker.CheckHealth(ctx, conn); err != nil {
 		// Connection is unhealthy, close it
 		if err := conn.Close(ctx); err != nil {
-			// Log error but don't fail the health check process
-			log.Printf("Warning: failed to close unhealthy connection: %v", err)
+			p.logger.Warn("failed to close unhealthy connection", "error", err)
 		}
 
 		p.updateStatistics(func(stats *PoolStatistics) {
@@ -390,8 +395,7 @@ func (p *DefaultDirectoryConnectionPool) Put(conn DirectoryConnection) error {
 	default:
 		// Pool is full, close connection
 		if err := conn.Close(ctx); err != nil {
-			// Log error but don't fail the pool operation
-			log.Printf("Warning: failed to close excess connection: %v", err)
+			p.logger.Warn("failed to close excess connection", "error", err)
 		}
 
 		p.updateStatistics(func(stats *PoolStatistics) {
@@ -419,9 +423,8 @@ func (p *DefaultDirectoryConnectionPool) Close() error {
 		close(p.connections)
 		for conn := range p.connections {
 			if conn != nil {
-				if err := conn.Close(context.Background()); err != nil {
-					// Log error - could add logging here if needed
-					_ = err
+				if closeErr := conn.Close(context.Background()); closeErr != nil {
+					p.logger.Warn("failed to close connection", "error", closeErr)
 				}
 			}
 		}
@@ -430,9 +433,8 @@ func (p *DefaultDirectoryConnectionPool) Close() error {
 		p.mutex.Lock()
 		for conn := range p.activeConns {
 			if conn != nil {
-				if err := conn.Close(context.Background()); err != nil {
-					// Log error - could add logging here if needed
-					_ = err
+				if closeErr := conn.Close(context.Background()); closeErr != nil {
+					p.logger.Warn("failed to close connection", "error", closeErr)
 				}
 			}
 		}

--- a/pkg/directory/interfaces/connection_test.go
+++ b/pkg/directory/interfaces/connection_test.go
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+package interfaces
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cfgis/cfgms/pkg/logging"
+	pkgtesting "github.com/cfgis/cfgms/pkg/testing"
+)
+
+// failingCloseConnection is a DirectoryConnection whose Close always returns an error.
+type failingCloseConnection struct{}
+
+func (f *failingCloseConnection) Open(_ context.Context, _ ProviderConfig) error { return nil }
+func (f *failingCloseConnection) Close(_ context.Context) error {
+	return fmt.Errorf("close failed")
+}
+func (f *failingCloseConnection) IsHealthy(_ context.Context) bool  { return true }
+func (f *failingCloseConnection) GetConnectionInfo() ConnectionInfo { return ConnectionInfo{} }
+func (f *failingCloseConnection) GetStatistics() ConnectionStatistics {
+	return ConnectionStatistics{}
+}
+func (f *failingCloseConnection) Reset(_ context.Context) error              { return nil }
+func (f *failingCloseConnection) RefreshCredentials(_ context.Context) error { return nil }
+
+func newTestPool(t *testing.T, logger logging.Logger) *DefaultDirectoryConnectionPool {
+	t.Helper()
+	conn := &failingCloseConnection{}
+	config := PoolConfig{
+		MaxConnections:      2,
+		MinConnections:      1,
+		InitialSize:         1,
+		ConnectionTimeout:   time.Second,
+		HealthCheckInterval: time.Hour,
+		HealthCheckTimeout:  time.Second,
+		MaxRetries:          1,
+		RetryDelay:          time.Millisecond,
+	}
+	pool, err := NewDirectoryConnectionPool(config, func(_ context.Context) (DirectoryConnection, error) {
+		return conn, nil
+	}, logger)
+	require.NoError(t, err)
+	return pool
+}
+
+// TestDirectoryConnectionPool_Close_logsWarnings verifies that Close and Put on a closed pool
+// log "failed to close connection" warnings when the connection's Close method returns an error.
+func TestDirectoryConnectionPool_Close_logsWarnings(t *testing.T) {
+	t.Run("Put on closed pool logs warning", func(t *testing.T) {
+		mockLogger := pkgtesting.NewMockLogger(true)
+		pool := newTestPool(t, mockLogger)
+
+		// Drain pool state cleanly for the closed-pool Put path test.
+		require.NoError(t, pool.Close())
+		mockLogger.Reset()
+
+		// Put with a closed pool triggers conn.Close which returns an error.
+		conn := &failingCloseConnection{}
+		err := pool.Put(conn)
+		require.Error(t, err, "Put on a closed pool must return an error")
+
+		logs := mockLogger.GetLogs("warn")
+		require.GreaterOrEqual(t, len(logs), 1, "expected at least one warn log entry")
+		assert.Equal(t, "failed to close connection", logs[0].Message)
+	})
+
+	t.Run("Close logs warnings for connections that fail to close", func(t *testing.T) {
+		mockLogger := pkgtesting.NewMockLogger(true)
+		pool := newTestPool(t, mockLogger)
+
+		// Close triggers conn.Close on every idle connection; failingCloseConnection returns an error.
+		require.NoError(t, pool.Close())
+
+		logs := mockLogger.GetLogs("warn")
+		require.GreaterOrEqual(t, len(logs), 1, "expected at least one warn log entry from Close")
+		assert.Equal(t, "failed to close connection", logs[0].Message)
+	})
+}
+
+// TestNewDirectoryConnectionPool_NilLoggerDefaultsToNoop verifies that passing nil for the
+// logger parameter does not panic and the pool operates normally.
+func TestNewDirectoryConnectionPool_NilLoggerDefaultsToNoop(t *testing.T) {
+	config := PoolConfig{
+		MaxConnections:      1,
+		MinConnections:      1,
+		InitialSize:         1,
+		ConnectionTimeout:   time.Second,
+		HealthCheckInterval: time.Hour,
+		HealthCheckTimeout:  time.Second,
+		MaxRetries:          1,
+		RetryDelay:          time.Millisecond,
+	}
+	pool, err := NewDirectoryConnectionPool(config, func(_ context.Context) (DirectoryConnection, error) {
+		return &failingCloseConnection{}, nil
+	}, nil)
+	require.NoError(t, err)
+	require.NotNil(t, pool)
+	require.NoError(t, pool.Close()) // must not panic with nil-guarded noop logger
+}


### PR DESCRIPTION
## Summary

- Add `logger logging.Logger` field to `DefaultDirectoryConnectionPool`; `NewDirectoryConnectionPool` accepts it as a third parameter (nil → `logging.NewNoopLogger()`)
- Replace 3 `log.Printf` call sites in `Put()` with `p.logger.Warn(...)`
- Replace 2 silent `_ = err` discards in `Close()` teardown loops with `p.logger.Warn("failed to close connection", "error", closeErr)` — these were hiding real teardown failures in production
- Remove `"log"` import from `pkg/directory/interfaces/connection.go`
- Add `pkg/directory/interfaces/connection_test.go` with 3 test functions covering the Put-on-closed-pool warning path, the Close() teardown warning path, and nil-logger nil-guard

Fixes #1157

## Specialist Review Results

| Reviewer | Result |
|----------|--------|
| qa-test-runner | **PASS** — all unit, integration, cross-platform, lint, security scans clean |
| qa-code-reviewer | **PASS** (after fix iteration: Close() teardown `_ = err` → `p.logger.Warn`; Put return value asserted in test) |
| security-engineer | **PASS** — no blocking issues; net security posture improved (stdlib log bypassed central sanitization) |

## Test plan

- [ ] `go test ./pkg/directory/interfaces/...` — all tests pass locally
- [ ] `TestDirectoryConnectionPool_Close_logsWarnings/Put_on_closed_pool_logs_warning`
- [ ] `TestDirectoryConnectionPool_Close_logsWarnings/Close_logs_warnings_for_connections_that_fail_to_close`
- [ ] `TestNewDirectoryConnectionPool_NilLoggerDefaultsToNoop`
- [ ] `grep -n '"log"' pkg/directory/interfaces/connection.go` → zero results
- [ ] `grep -n 'log\.Printf' pkg/directory/interfaces/connection.go` → zero results

🤖 Generated with [Claude Code](https://claude.com/claude-code)