### PR TITLE
config: delete validateStewardSettings duplicate + unreachable branch; replace MockConfigStore (Issue #1141)

### DIFF
--- a/pkg/config/manager_test.go
+++ b/pkg/config/manager_test.go
@@ -6,209 +6,45 @@ import (
 	"context"
 	"fmt"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	stewardconfig "github.com/cfgis/cfgms/features/steward/config"
-	cfgconfig "github.com/cfgis/cfgms/pkg/storage/interfaces/config"
+	_ "github.com/cfgis/cfgms/pkg/storage/providers/flatfile"
+	_ "github.com/cfgis/cfgms/pkg/storage/providers/sqlite"
+	pkgtesting "github.com/cfgis/cfgms/pkg/testing/storage"
 )
 
-// MockConfigStore implements cfgconfig.ConfigStore for testing
-type MockConfigStore struct {
-	configs map[string]*cfgconfig.ConfigEntry
-	history map[string][]*cfgconfig.ConfigEntry
+// newTestManager creates a Manager backed by a real OSS storage stack for testing.
+func newTestManager(t *testing.T) *Manager {
+	t.Helper()
+	sm, err := pkgtesting.CreateTestStorageManager()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = sm.Close() })
+	return NewManagerWithStorageManager(sm)
 }
 
-func NewMockConfigStore() *MockConfigStore {
-	return &MockConfigStore{
-		configs: make(map[string]*cfgconfig.ConfigEntry),
-		history: make(map[string][]*cfgconfig.ConfigEntry),
-	}
+// newTestValidationManager creates a ValidationManager backed by a real OSS storage stack.
+func newTestValidationManager(t *testing.T) *ValidationManager {
+	t.Helper()
+	sm, err := pkgtesting.CreateTestStorageManager()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = sm.Close() })
+	return NewValidationManager(sm.GetConfigStore())
 }
-
-func (m *MockConfigStore) StoreConfig(ctx context.Context, config *cfgconfig.ConfigEntry) error {
-	key := config.Key.String()
-
-	// Store current version in history
-	if existing, exists := m.configs[key]; exists {
-		if m.history[key] == nil {
-			m.history[key] = []*cfgconfig.ConfigEntry{}
-		}
-		m.history[key] = append(m.history[key], existing)
-	}
-
-	// Set version and timestamps
-	config.Version = int64(len(m.history[key]) + 1)
-	config.UpdatedAt = time.Now()
-	if config.CreatedAt.IsZero() {
-		config.CreatedAt = config.UpdatedAt
-	}
-
-	// Store new version
-	m.configs[key] = config
-	return nil
-}
-
-func (m *MockConfigStore) GetConfig(ctx context.Context, key *cfgconfig.ConfigKey) (*cfgconfig.ConfigEntry, error) {
-	keyStr := key.String()
-	config, exists := m.configs[keyStr]
-	if !exists {
-		return nil, &cfgconfig.ConfigValidationError{
-			Field:   "key",
-			Message: "configuration not found",
-			Code:    "CONFIG_NOT_FOUND",
-		}
-	}
-
-	// Return a copy
-	configCopy := *config
-	return &configCopy, nil
-}
-
-func (m *MockConfigStore) DeleteConfig(ctx context.Context, key *cfgconfig.ConfigKey) error {
-	keyStr := key.String()
-	delete(m.configs, keyStr)
-	delete(m.history, keyStr)
-	return nil
-}
-
-func (m *MockConfigStore) ListConfigs(ctx context.Context, filter *cfgconfig.ConfigFilter) ([]*cfgconfig.ConfigEntry, error) {
-	var results []*cfgconfig.ConfigEntry
-
-	for _, config := range m.configs {
-		// Apply filtering
-		if filter.TenantID != "" && config.Key.TenantID != filter.TenantID {
-			continue
-		}
-		if filter.Namespace != "" && config.Key.Namespace != filter.Namespace {
-			continue
-		}
-
-		// Return a copy
-		configCopy := *config
-		results = append(results, &configCopy)
-	}
-
-	return results, nil
-}
-
-func (m *MockConfigStore) GetConfigHistory(ctx context.Context, key *cfgconfig.ConfigKey, limit int) ([]*cfgconfig.ConfigEntry, error) {
-	keyStr := key.String()
-	history, exists := m.history[keyStr]
-	if !exists {
-		return []*cfgconfig.ConfigEntry{}, nil
-	}
-
-	// Return most recent versions first
-	var results []*cfgconfig.ConfigEntry
-	start := len(history) - limit
-	if start < 0 {
-		start = 0
-	}
-
-	for i := len(history) - 1; i >= start; i-- {
-		configCopy := *history[i]
-		results = append(results, &configCopy)
-	}
-
-	return results, nil
-}
-
-func (m *MockConfigStore) GetConfigVersion(ctx context.Context, key *cfgconfig.ConfigKey, version int64) (*cfgconfig.ConfigEntry, error) {
-	keyStr := key.String()
-	history, exists := m.history[keyStr]
-	if !exists {
-		return nil, &cfgconfig.ConfigValidationError{
-			Field:   "version",
-			Message: "configuration history not found",
-			Code:    "HISTORY_NOT_FOUND",
-		}
-	}
-
-	// Find version in history
-	for _, entry := range history {
-		if entry.Version == version {
-			configCopy := *entry
-			return &configCopy, nil
-		}
-	}
-
-	return nil, &cfgconfig.ConfigValidationError{
-		Field:   "version",
-		Message: "version not found",
-		Code:    "VERSION_NOT_FOUND",
-	}
-}
-
-func (m *MockConfigStore) StoreConfigBatch(ctx context.Context, configs []*cfgconfig.ConfigEntry) error {
-	for _, config := range configs {
-		if err := m.StoreConfig(ctx, config); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-func (m *MockConfigStore) DeleteConfigBatch(ctx context.Context, keys []*cfgconfig.ConfigKey) error {
-	for _, key := range keys {
-		if err := m.DeleteConfig(ctx, key); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-func (m *MockConfigStore) ResolveConfigWithInheritance(ctx context.Context, key *cfgconfig.ConfigKey) (*cfgconfig.ConfigEntry, error) {
-	// Simplified inheritance - just return the direct config
-	return m.GetConfig(ctx, key)
-}
-
-func (m *MockConfigStore) ValidateConfig(ctx context.Context, config *cfgconfig.ConfigEntry) error {
-	if config.Key == nil {
-		return &cfgconfig.ConfigValidationError{
-			Field:   "key",
-			Message: "key is required",
-			Code:    "KEY_REQUIRED",
-		}
-	}
-	return nil
-}
-
-func (m *MockConfigStore) GetConfigStats(ctx context.Context) (*cfgconfig.ConfigStats, error) {
-	totalConfigs := int64(len(m.configs))
-	totalSize := int64(0)
-
-	for _, config := range m.configs {
-		totalSize += int64(len(config.Data))
-	}
-
-	var averageSize int64
-	if totalConfigs > 0 {
-		averageSize = totalSize / totalConfigs
-	}
-
-	return &cfgconfig.ConfigStats{
-		TotalConfigs: totalConfigs,
-		TotalSize:    totalSize,
-		AverageSize:  averageSize,
-		LastUpdated:  time.Now(),
-	}, nil
-}
-
-// Test Cases
 
 func TestManagerStoreAndGetConfiguration(t *testing.T) {
-	mockStore := NewMockConfigStore()
-	manager := NewManager(mockStore)
+	manager := newTestManager(t)
 	ctx := context.Background()
 
-	// Create test configuration
 	testConfig := &stewardconfig.StewardConfig{
 		Steward: stewardconfig.StewardSettings{
 			ID:   "test-steward",
 			Mode: stewardconfig.ModeStandalone,
+			Logging: stewardconfig.LoggingConfig{
+				Level: "info",
+			},
 		},
 		Resources: []stewardconfig.ResourceConfig{
 			{
@@ -221,15 +57,12 @@ func TestManagerStoreAndGetConfiguration(t *testing.T) {
 		},
 	}
 
-	// Store configuration
 	err := manager.StoreConfiguration(ctx, "test-tenant", "test-steward", testConfig)
 	require.NoError(t, err)
 
-	// Retrieve configuration
 	retrievedConfig, err := manager.GetConfiguration(ctx, "test-tenant", "test-steward")
 	require.NoError(t, err)
 
-	// Verify configuration
 	assert.Equal(t, testConfig.Steward.ID, retrievedConfig.Steward.ID)
 	assert.Equal(t, testConfig.Steward.Mode, retrievedConfig.Steward.Mode)
 	assert.Len(t, retrievedConfig.Resources, 1)
@@ -238,27 +71,26 @@ func TestManagerStoreAndGetConfiguration(t *testing.T) {
 }
 
 func TestManagerGetConfigurationNotFound(t *testing.T) {
-	mockStore := NewMockConfigStore()
-	manager := NewManager(mockStore)
+	manager := newTestManager(t)
 	ctx := context.Background()
 
-	// Try to get non-existent configuration
 	_, err := manager.GetConfiguration(ctx, "test-tenant", "non-existent")
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "configuration not found")
 }
 
 func TestManagerConfigurationHistory(t *testing.T) {
-	mockStore := NewMockConfigStore()
-	manager := NewManager(mockStore)
+	manager := newTestManager(t)
 	ctx := context.Background()
 
-	// Create and store multiple versions
 	for i := 1; i <= 3; i++ {
 		testConfig := &stewardconfig.StewardConfig{
 			Steward: stewardconfig.StewardSettings{
 				ID:   "test-steward",
 				Mode: stewardconfig.ModeStandalone,
+				Logging: stewardconfig.LoggingConfig{
+					Level: "info",
+				},
 			},
 			Resources: []stewardconfig.ResourceConfig{
 				{
@@ -275,25 +107,23 @@ func TestManagerConfigurationHistory(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	// Get configuration history
 	history, err := manager.GetConfigurationHistory(ctx, "test-tenant", "test-steward", 5)
 	require.NoError(t, err)
-	assert.Len(t, history, 2) // First version goes to history, current version not in history
-
-	// Verify versions are in descending order
-	assert.True(t, history[0].Version > history[1].Version)
+	// Flatfile store returns only the current version; no historical snapshots are retained.
+	assert.Len(t, history, 1)
 }
 
 func TestManagerGetConfigurationVersion(t *testing.T) {
-	mockStore := NewMockConfigStore()
-	manager := NewManager(mockStore)
+	manager := newTestManager(t)
 	ctx := context.Background()
 
-	// Store initial version
 	testConfig1 := &stewardconfig.StewardConfig{
 		Steward: stewardconfig.StewardSettings{
 			ID:   "test-steward",
 			Mode: stewardconfig.ModeStandalone,
+			Logging: stewardconfig.LoggingConfig{
+				Level: "info",
+			},
 		},
 		Resources: []stewardconfig.ResourceConfig{
 			{
@@ -309,11 +139,19 @@ func TestManagerGetConfigurationVersion(t *testing.T) {
 	err := manager.StoreConfiguration(ctx, "test-tenant", "test-steward", testConfig1)
 	require.NoError(t, err)
 
-	// Store second version
+	// Flatfile store assigns version 1 on first write; retrieval by current version succeeds.
+	versionConfig, err := manager.GetConfigurationVersion(ctx, "test-tenant", "test-steward", 1)
+	require.NoError(t, err)
+	pathValue := versionConfig.Resources[0].Config["path"]
+	assert.Equal(t, "/opt/test1", pathValue)
+
 	testConfig2 := &stewardconfig.StewardConfig{
 		Steward: stewardconfig.StewardSettings{
 			ID:   "test-steward",
 			Mode: stewardconfig.ModeStandalone,
+			Logging: stewardconfig.LoggingConfig{
+				Level: "info",
+			},
 		},
 		Resources: []stewardconfig.ResourceConfig{
 			{
@@ -329,26 +167,29 @@ func TestManagerGetConfigurationVersion(t *testing.T) {
 	err = manager.StoreConfiguration(ctx, "test-tenant", "test-steward", testConfig2)
 	require.NoError(t, err)
 
-	// Get version 1
-	versionConfig, err := manager.GetConfigurationVersion(ctx, "test-tenant", "test-steward", 1)
+	// After second write version becomes 2; that is the only version available.
+	versionConfig, err = manager.GetConfigurationVersion(ctx, "test-tenant", "test-steward", 2)
 	require.NoError(t, err)
+	pathValue = versionConfig.Resources[0].Config["path"]
+	assert.Equal(t, "/opt/test2", pathValue)
 
-	// Verify it's the first version
-	pathValue := versionConfig.Resources[0].Config["path"]
-	assert.Equal(t, "/opt/test1", pathValue)
+	// Version 1 is no longer available once version 2 is the current head.
+	_, err = manager.GetConfigurationVersion(ctx, "test-tenant", "test-steward", 1)
+	assert.Error(t, err)
 }
 
 func TestManagerListConfigurations(t *testing.T) {
-	mockStore := NewMockConfigStore()
-	manager := NewManager(mockStore)
+	manager := newTestManager(t)
 	ctx := context.Background()
 
-	// Store configurations for different stewards
 	for i := 1; i <= 3; i++ {
 		testConfig := &stewardconfig.StewardConfig{
 			Steward: stewardconfig.StewardSettings{
 				ID:   fmt.Sprintf("steward-%d", i),
 				Mode: stewardconfig.ModeStandalone,
+				Logging: stewardconfig.LoggingConfig{
+					Level: "info",
+				},
 			},
 		}
 
@@ -356,12 +197,10 @@ func TestManagerListConfigurations(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	// List configurations
 	summaries, err := manager.ListConfigurations(ctx, "test-tenant")
 	require.NoError(t, err)
 	assert.Len(t, summaries, 3)
 
-	// Verify summary data
 	for _, summary := range summaries {
 		assert.Equal(t, "test-tenant", summary.TenantID)
 		assert.NotEmpty(t, summary.StewardID)
@@ -371,11 +210,9 @@ func TestManagerListConfigurations(t *testing.T) {
 }
 
 func TestManagerBatchStoreConfigurations(t *testing.T) {
-	mockStore := NewMockConfigStore()
-	manager := NewManager(mockStore)
+	manager := newTestManager(t)
 	ctx := context.Background()
 
-	// Create batch configurations
 	var batchConfigs []*BatchConfigurationEntry
 
 	for i := 1; i <= 3; i++ {
@@ -383,6 +220,9 @@ func TestManagerBatchStoreConfigurations(t *testing.T) {
 			Steward: stewardconfig.StewardSettings{
 				ID:   fmt.Sprintf("steward-%d", i),
 				Mode: stewardconfig.ModeStandalone,
+				Logging: stewardconfig.LoggingConfig{
+					Level: "info",
+				},
 			},
 		}
 
@@ -393,11 +233,9 @@ func TestManagerBatchStoreConfigurations(t *testing.T) {
 		})
 	}
 
-	// Store batch
 	err := manager.BatchStoreConfigurations(ctx, batchConfigs)
 	require.NoError(t, err)
 
-	// Verify all configurations were stored
 	for i := 1; i <= 3; i++ {
 		config, err := manager.GetConfiguration(ctx, "test-tenant", fmt.Sprintf("steward-%d", i))
 		require.NoError(t, err)
@@ -406,11 +244,9 @@ func TestManagerBatchStoreConfigurations(t *testing.T) {
 }
 
 func TestManagerValidateConfiguration(t *testing.T) {
-	mockStore := NewMockConfigStore()
-	manager := NewManager(mockStore)
+	manager := newTestManager(t)
 	ctx := context.Background()
 
-	// Test valid configuration
 	validConfig := &stewardconfig.StewardConfig{
 		Steward: stewardconfig.StewardSettings{
 			ID:   "test-steward",
@@ -434,10 +270,10 @@ func TestManagerValidateConfiguration(t *testing.T) {
 	err := manager.ValidateConfiguration(ctx, validConfig)
 	assert.NoError(t, err)
 
-	// Test invalid configuration (empty steward ID)
+	// Empty steward ID is rejected by stewardconfig.ValidateConfiguration.
 	invalidConfig := &stewardconfig.StewardConfig{
 		Steward: stewardconfig.StewardSettings{
-			ID:   "", // Invalid: empty ID
+			ID:   "",
 			Mode: stewardconfig.ModeStandalone,
 		},
 	}
@@ -447,45 +283,44 @@ func TestManagerValidateConfiguration(t *testing.T) {
 }
 
 func TestManagerDeleteConfiguration(t *testing.T) {
-	mockStore := NewMockConfigStore()
-	manager := NewManager(mockStore)
+	manager := newTestManager(t)
 	ctx := context.Background()
 
-	// Store configuration
 	testConfig := &stewardconfig.StewardConfig{
 		Steward: stewardconfig.StewardSettings{
 			ID:   "test-steward",
 			Mode: stewardconfig.ModeStandalone,
+			Logging: stewardconfig.LoggingConfig{
+				Level: "info",
+			},
 		},
 	}
 
 	err := manager.StoreConfiguration(ctx, "test-tenant", "test-steward", testConfig)
 	require.NoError(t, err)
 
-	// Verify it exists
 	_, err = manager.GetConfiguration(ctx, "test-tenant", "test-steward")
 	assert.NoError(t, err)
 
-	// Delete configuration
 	err = manager.DeleteConfiguration(ctx, "test-tenant", "test-steward")
 	assert.NoError(t, err)
 
-	// Verify it's deleted
 	_, err = manager.GetConfiguration(ctx, "test-tenant", "test-steward")
 	assert.Error(t, err)
 }
 
 func TestManagerGetConfigurationStats(t *testing.T) {
-	mockStore := NewMockConfigStore()
-	manager := NewManager(mockStore)
+	manager := newTestManager(t)
 	ctx := context.Background()
 
-	// Store a few configurations
 	for i := 1; i <= 2; i++ {
 		testConfig := &stewardconfig.StewardConfig{
 			Steward: stewardconfig.StewardSettings{
 				ID:   fmt.Sprintf("steward-%d", i),
 				Mode: stewardconfig.ModeStandalone,
+				Logging: stewardconfig.LoggingConfig{
+					Level: "info",
+				},
 			},
 		}
 
@@ -493,7 +328,6 @@ func TestManagerGetConfigurationStats(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	// Get stats
 	stats, err := manager.GetConfigurationStats(ctx)
 	require.NoError(t, err)
 
@@ -501,4 +335,81 @@ func TestManagerGetConfigurationStats(t *testing.T) {
 	assert.Greater(t, stats.TotalSize, int64(0))
 	assert.Greater(t, stats.AverageSize, int64(0))
 	assert.NotZero(t, stats.LastUpdated)
+}
+
+// ValidationManager tests verify that ValidateConfiguration still rejects
+// invalid configs after the removal of the duplicate validateStewardSettings.
+
+func TestValidationManagerRejectsInvalidLogLevel(t *testing.T) {
+	vm := newTestValidationManager(t)
+	ctx := context.Background()
+
+	config := &stewardconfig.StewardConfig{
+		Steward: stewardconfig.StewardSettings{
+			ID:   "test-steward",
+			Mode: stewardconfig.ModeStandalone,
+			Logging: stewardconfig.LoggingConfig{
+				Level: "verbose", // not a valid level
+			},
+		},
+	}
+
+	result := vm.ValidateConfiguration(ctx, "test-tenant", "test-steward", config)
+	assert.False(t, result.Valid)
+	require.NotEmpty(t, result.Errors)
+	assert.Equal(t, "BASIC_VALIDATION_FAILED", result.Errors[0].Code)
+}
+
+func TestValidationManagerRejectsInvalidMode(t *testing.T) {
+	vm := newTestValidationManager(t)
+	ctx := context.Background()
+
+	config := &stewardconfig.StewardConfig{
+		Steward: stewardconfig.StewardSettings{
+			ID:   "test-steward",
+			Mode: "unknown-mode", // not a valid mode
+			Logging: stewardconfig.LoggingConfig{
+				Level: "info",
+			},
+		},
+	}
+
+	result := vm.ValidateConfiguration(ctx, "test-tenant", "test-steward", config)
+	assert.False(t, result.Valid)
+	require.NotEmpty(t, result.Errors)
+	assert.Equal(t, "BASIC_VALIDATION_FAILED", result.Errors[0].Code)
+}
+
+func TestValidationManagerRejectsDuplicateResourceNames(t *testing.T) {
+	vm := newTestValidationManager(t)
+	ctx := context.Background()
+
+	config := &stewardconfig.StewardConfig{
+		Steward: stewardconfig.StewardSettings{
+			ID:   "test-steward",
+			Mode: stewardconfig.ModeStandalone,
+			Logging: stewardconfig.LoggingConfig{
+				Level: "info",
+			},
+		},
+		Modules: map[string]string{
+			"file": "file",
+		},
+		Resources: []stewardconfig.ResourceConfig{
+			{Name: "dup", Module: "file", Config: map[string]interface{}{"path": "/tmp/a"}},
+			{Name: "dup", Module: "file", Config: map[string]interface{}{"path": "/tmp/b"}},
+		},
+	}
+
+	result := vm.ValidateConfiguration(ctx, "test-tenant", "test-steward", config)
+	assert.False(t, result.Valid)
+
+	// Verify validateResources in pkg/config specifically catches the duplicate
+	// (stewardconfig.ValidateConfiguration also catches it, but we want to confirm
+	// the local validateResources path is exercised and emits DUPLICATE_RESOURCE_NAME).
+	codes := make([]string, 0, len(result.Errors))
+	for _, e := range result.Errors {
+		codes = append(codes, e.Code)
+	}
+	assert.Contains(t, codes, "DUPLICATE_RESOURCE_NAME")
 }

--- a/pkg/config/validation.go
+++ b/pkg/config/validation.go
@@ -89,16 +89,6 @@ func (vm *ValidationManager) ValidateConfiguration(ctx context.Context, tenantID
 
 	// Validate tenant context
 	result.TenantChecks = vm.validateTenantContext(ctx, tenantID, stewardID, config)
-	if !result.TenantChecks.TenantExists {
-		result.Valid = false
-		result.Errors = append(result.Errors, ValidationError{
-			Field:      "tenant_id",
-			Message:    fmt.Sprintf("Tenant '%s' does not exist", tenantID),
-			Code:       "TENANT_NOT_FOUND",
-			Level:      "error",
-			Suggestion: "Ensure the tenant exists before storing configuration",
-		})
-	}
 
 	// Validate module dependencies
 	result.DependencyChecks = vm.validateDependencies(ctx, config)
@@ -138,9 +128,6 @@ func (vm *ValidationManager) ValidateConfiguration(ctx context.Context, tenantID
 
 	// Validate resource configurations
 	vm.validateResources(result, config)
-
-	// Validate steward settings
-	vm.validateStewardSettings(result, config)
 
 	return result
 }
@@ -280,80 +267,6 @@ func (vm *ValidationManager) validateResources(result *ValidationResult, config 
 	}
 }
 
-// validateStewardSettings validates steward-specific settings
-func (vm *ValidationManager) validateStewardSettings(result *ValidationResult, config *stewardconfig.StewardConfig) {
-	// Validate steward ID
-	if config.Steward.ID == "" {
-		result.Warnings = append(result.Warnings, ValidationError{
-			Field:      "steward.id",
-			Message:    "Steward ID is empty - will use hostname as default",
-			Code:       "EMPTY_STEWARD_ID",
-			Level:      "warning",
-			Suggestion: "Consider setting an explicit steward ID for better identification",
-		})
-	}
-
-	// Validate operation mode
-	validModes := []stewardconfig.OperationMode{stewardconfig.ModeStandalone, stewardconfig.ModeController}
-	modeValid := false
-	for _, validMode := range validModes {
-		if config.Steward.Mode == validMode {
-			modeValid = true
-			break
-		}
-	}
-
-	if !modeValid && config.Steward.Mode != "" {
-		result.Valid = false
-		result.Errors = append(result.Errors, ValidationError{
-			Field:      "steward.mode",
-			Message:    fmt.Sprintf("Invalid operation mode: %s", config.Steward.Mode),
-			Code:       "INVALID_OPERATION_MODE",
-			Level:      "error",
-			Suggestion: "Use 'standalone' or 'controller' as operation mode",
-		})
-	}
-
-	// Validate logging configuration
-	validLogLevels := []string{"debug", "info", "warn", "error"}
-	if config.Steward.Logging.Level != "" {
-		levelValid := false
-		for _, validLevel := range validLogLevels {
-			if config.Steward.Logging.Level == validLevel {
-				levelValid = true
-				break
-			}
-		}
-
-		if !levelValid {
-			result.Valid = false
-			result.Errors = append(result.Errors, ValidationError{
-				Field:      "steward.logging.level",
-				Message:    fmt.Sprintf("Invalid log level: %s", config.Steward.Logging.Level),
-				Code:       "INVALID_LOG_LEVEL",
-				Level:      "error",
-				Suggestion: "Use debug, info, warn, or error as log level",
-			})
-		}
-	}
-
-	// Validate error handling settings
-	validActions := []stewardconfig.ErrorAction{stewardconfig.ActionContinue, stewardconfig.ActionFail, stewardconfig.ActionWarn}
-
-	if config.Steward.ErrorHandling.ModuleLoadFailure != "" {
-		if !isValidErrorAction(config.Steward.ErrorHandling.ModuleLoadFailure, validActions) {
-			result.Valid = false
-			result.Errors = append(result.Errors, ValidationError{
-				Field:      "steward.error_handling.module_load_failure",
-				Message:    fmt.Sprintf("Invalid error action: %s", config.Steward.ErrorHandling.ModuleLoadFailure),
-				Code:       "INVALID_ERROR_ACTION",
-				Level:      "error",
-				Suggestion: "Use continue, fail, or warn as error action",
-			})
-		}
-	}
-}
-
 // isValidResourceName checks if a resource name follows the required format
 func isValidResourceName(name string) bool {
 	if name == "" {
@@ -370,16 +283,6 @@ func isValidResourceName(name string) bool {
 	}
 
 	return true
-}
-
-// isValidErrorAction checks if an error action is valid
-func isValidErrorAction(action stewardconfig.ErrorAction, validActions []stewardconfig.ErrorAction) bool {
-	for _, validAction := range validActions {
-		if action == validAction {
-			return true
-		}
-	}
-	return false
 }
 
 // ValidateConfigurationEntry validates a configuration entry for storage


### PR DESCRIPTION
## Summary

- Deleted `validateStewardSettings` (~70 lines) from `ValidationManager.ValidateConfiguration` — `stewardconfig.ValidateConfiguration` (called 4 lines earlier) already covers mode, log-level, and error-action checks making this a pure duplicate
- Removed the unreachable `!result.TenantChecks.TenantExists` error-append block — `validateTenantContext` is a stub unconditionally returning `TenantExists: true`; the stub itself is preserved for a future story to wire real tenant validation
- Removed `isValidErrorAction` helper (only caller was the deleted method)
- Replaced hand-rolled `MockConfigStore` (~200 lines) in `manager_test.go` with the real OSS storage stack (flatfile + SQLite) via `pkgtesting.CreateTestStorageManager`
- Updated `TestManagerConfigurationHistory` and `TestManagerGetConfigurationVersion` to match flatfile single-snapshot semantics
- Added `TestValidationManagerRejectsInvalidLogLevel`, `TestValidationManagerRejectsInvalidMode`, `TestValidationManagerRejectsDuplicateResourceNames` — the last asserts `DUPLICATE_RESOURCE_NAME` is present to verify the `validateResources` path is exercised

Fixes #1141

## Adversarial Team Review Results

| Specialist | Result | Notes |
|---|---|---|
| QA Test Runner | **PASS** | All 12 pkg/config tests pass; full suite clean across all platforms |
| QA Code Reviewer | **PASS** | No blocking issues; 1 warning addressed (strengthened duplicate-name assertion) |
| Security Engineer | **PASS** | No blocking issues; all scans (gosec, Trivy, Nancy, staticcheck, architecture) green |

## Test Plan

- [x] `go test ./pkg/config/...` — 12 tests pass including 3 new ValidationManager tests
- [x] `make test-agent-complete` — full suite passes (unit, integration, cross-platform builds)
- [x] `make check-architecture` — no central provider violations
- [x] `make security-scan` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)