### PR TITLE
bootstrap: wire TelemetryBridge.Initialize() at 3 entry points + remove dead controller tracer field (Issue #1135)

### DIFF
--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -103,6 +103,7 @@ func runController(configPath string, initMode bool) error {
 	if err := logging.InitializeGlobalLogging(loggingConfig); err != nil {
 		return fmt.Errorf("failed to initialize global logging: %w", err)
 	}
+	(&logging.TelemetryBridge{}).Initialize()
 
 	logging.InitializeGlobalLoggerFactory("controller", "main")
 	logger := logging.ForComponent("controller")
@@ -302,6 +303,7 @@ func runInstall(configPath string) error {
 		if err := logging.InitializeGlobalLogging(loggingConfig); err != nil {
 			return fmt.Errorf("failed to initialize logging: %w", err)
 		}
+		(&logging.TelemetryBridge{}).Initialize()
 		logging.InitializeGlobalLoggerFactory("controller", "install")
 		logger := logging.ForComponent("controller")
 

--- a/cmd/steward/main.go
+++ b/cmd/steward/main.go
@@ -146,6 +146,7 @@ func runSteward(ctx context.Context, regToken, configPath string) error {
 	if err := logging.InitializeGlobalLogging(loggingConfig); err != nil {
 		return fmt.Errorf("failed to initialize global logging: %w", err)
 	}
+	(&logging.TelemetryBridge{}).Initialize()
 
 	logging.InitializeGlobalLoggerFactory("steward", "main")
 	logger := logging.ForComponent("steward")

--- a/features/controller/api/handlers_registration_test.go
+++ b/features/controller/api/handlers_registration_test.go
@@ -107,7 +107,7 @@ func newHandleRegisterServer(t *testing.T, tokenStore registration.Store, certMg
 	server, err := New(
 		cfg, logger, controllerService, configService, nil, rbacService,
 		certMgr, tenantManager, rbacManager,
-		nil, nil, nil, nil,
+		nil, nil, nil,
 		tokenStore,
 		"",
 		nil,

--- a/features/controller/api/handlers_registration_tokens_test.go
+++ b/features/controller/api/handlers_registration_tokens_test.go
@@ -102,7 +102,6 @@ func setupTestServerWithTokenStore(t *testing.T) (*Server, registration.Store) {
 		rbacManager,
 		nil, // No system monitor for basic tests
 		nil, // No platform monitor for basic tests
-		nil, // No tracer for basic tests
 		nil, // No HA manager for basic tests
 		tokenStore,
 		"",       // No signer cert serial for basic tests

--- a/features/controller/api/server.go
+++ b/features/controller/api/server.go
@@ -34,7 +34,6 @@ import (
 	"github.com/cfgis/cfgms/pkg/registration"
 	secretsif "github.com/cfgis/cfgms/pkg/secrets/interfaces"
 	_ "github.com/cfgis/cfgms/pkg/secrets/providers/sops" // Auto-register SOPS provider
-	"github.com/cfgis/cfgms/pkg/telemetry"
 )
 
 // Server represents the REST API server component of the controller
@@ -54,7 +53,6 @@ type Server struct {
 	systemMonitor           *monitoring.SystemMonitor
 	platformMonitor         pkgmonitoring.PlatformMonitor
 	healthCollector         *health.Collector
-	tracer                  *telemetry.Tracer
 	haManager               *ha.Manager
 	apiKeys                 map[string]*APIKey             // In-memory cache for fast lookup
 	secretStore             secretsif.SecretStore          // M-AUTH-1: Central secrets provider for API keys
@@ -111,7 +109,6 @@ func New(
 	rbacManager *rbac.Manager,
 	systemMonitor *monitoring.SystemMonitor,
 	platformMonitor pkgmonitoring.PlatformMonitor,
-	tracer *telemetry.Tracer,
 	haManager *ha.Manager,
 	registrationTokenStore registration.Store,
 	signerCertSerial string, // Story #378: Serial of cert used for config signing
@@ -141,7 +138,6 @@ func New(
 		systemMonitor:           systemMonitor,
 		platformMonitor:         platformMonitor,
 		healthCollector:         healthCollector,
-		tracer:                  tracer,
 		haManager:               haManager,
 		registrationTokenStore:  registrationTokenStore,
 		signerCertSerial:        signerCertSerial,         // Story #378: For registration handler

--- a/features/controller/api/server_test.go
+++ b/features/controller/api/server_test.go
@@ -87,7 +87,6 @@ func setupTestServer(t *testing.T) *Server {
 		rbacManager,
 		nil,      // No system monitor for basic tests
 		nil,      // No platform monitor for basic tests
-		nil,      // No tracer for basic tests
 		nil,      // No HA manager for basic tests
 		nil,      // No registration token store for basic tests
 		"",       // No signer cert serial for basic tests
@@ -882,7 +881,7 @@ func setupTestServerWithLogger(t *testing.T, logger logging.Logger) *Server {
 	server, err := New(
 		cfg, logger, controllerService, configService,
 		nil, rbacService, nil, tenantManager, rbacManager,
-		nil, nil, nil, nil, nil, "", nil, auditMgr,
+		nil, nil, nil, nil, "", nil, auditMgr,
 	)
 	require.NoError(t, err)
 	t.Cleanup(func() {

--- a/features/controller/server/server.go
+++ b/features/controller/server/server.go
@@ -520,7 +520,6 @@ func New(cfg *config.Config, logger logging.Logger) (*Server, error) {
 		rbacManager,
 		nil, // systemMonitor
 		nil, // platformMonitor
-		nil, // tracer
 		haManager,
 		regStore,         // registrationTokenStore
 		signerCertSerial, // Story #378: signer cert serial for registration

--- a/pkg/logging/telemetry_bridge.go
+++ b/pkg/logging/telemetry_bridge.go
@@ -9,6 +9,7 @@ package logging
 
 import (
 	"context"
+	"sync/atomic"
 
 	"github.com/cfgis/cfgms/pkg/ctxkeys"
 	"go.opentelemetry.io/otel/trace"
@@ -49,19 +50,19 @@ func (t *TelemetryBridge) GetTraceInfoFromContext(ctx context.Context) (string, 
 
 // Initialize sets up the telemetry bridge to replace placeholder functions.
 // This should be called during application initialization after telemetry setup.
+// It is safe to call concurrently and from multiple goroutines.
 func (t *TelemetryBridge) Initialize() {
-	// Replace the placeholder functions with actual implementations
-	// This is done to avoid circular dependencies while maintaining functionality
-	globalTelemetryBridge = t
+	globalTelemetryBridge.Store(t)
 }
 
-// Global bridge instance for function replacement
-var globalTelemetryBridge *TelemetryBridge
+// globalTelemetryBridge is the atomic bridge instance. Atomic access ensures
+// Initialize() and the extractor functions are race-free when called concurrently.
+var globalTelemetryBridge atomic.Pointer[TelemetryBridge]
 
 // UpdatedExtractCorrelationID is the enhanced correlation ID extractor.
 func UpdatedExtractCorrelationID(ctx context.Context) string {
-	if globalTelemetryBridge != nil {
-		return globalTelemetryBridge.GetCorrelationIDFromContext(ctx)
+	if b := globalTelemetryBridge.Load(); b != nil {
+		return b.GetCorrelationIDFromContext(ctx)
 	}
 
 	// Direct read from the canonical key — no bridge required.
@@ -73,8 +74,8 @@ func UpdatedExtractCorrelationID(ctx context.Context) string {
 
 // UpdatedExtractTraceInfo is the enhanced trace info extractor.
 func UpdatedExtractTraceInfo(ctx context.Context) (string, string) {
-	if globalTelemetryBridge != nil {
-		return globalTelemetryBridge.GetTraceInfoFromContext(ctx)
+	if b := globalTelemetryBridge.Load(); b != nil {
+		return b.GetTraceInfoFromContext(ctx)
 	}
 
 	// Fallback: no trace information available

--- a/pkg/logging/telemetry_bridge_test.go
+++ b/pkg/logging/telemetry_bridge_test.go
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+package logging
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTelemetryBridgeInitialize_EndToEnd(t *testing.T) {
+	// Save and restore global state so tests don't pollute each other.
+	prev := globalTelemetryBridge.Load()
+	t.Cleanup(func() { globalTelemetryBridge.Store(prev) })
+	globalTelemetryBridge.Store(nil)
+
+	// Bridge is not yet wired — UpdatedExtractCorrelationID falls back to
+	// direct key read and must still find the value.
+	ctx := WithCorrelation(context.Background(), "e2e-id")
+	assert.Equal(t, "e2e-id", UpdatedExtractCorrelationID(ctx), "direct key read before bridge init")
+
+	// Wire the bridge.
+	(&TelemetryBridge{}).Initialize()
+	assert.NotNil(t, globalTelemetryBridge.Load(), "bridge must be set after Initialize")
+
+	// After Initialize the bridge code path is exercised and must return the same value.
+	assert.Equal(t, "e2e-id", UpdatedExtractCorrelationID(ctx), "bridge code path after Initialize")
+}
+
+func TestTelemetryBridgeInitialize_Idempotent(t *testing.T) {
+	prev := globalTelemetryBridge.Load()
+	t.Cleanup(func() { globalTelemetryBridge.Store(prev) })
+	globalTelemetryBridge.Store(nil)
+
+	ctx := WithCorrelation(context.Background(), "id-idem")
+
+	(&TelemetryBridge{}).Initialize()
+	result1 := UpdatedExtractCorrelationID(ctx)
+
+	(&TelemetryBridge{}).Initialize()
+	result2 := UpdatedExtractCorrelationID(ctx)
+
+	assert.NotNil(t, globalTelemetryBridge.Load(), "bridge non-nil after repeated Initialize calls")
+	assert.Equal(t, result1, result2, "successive Initialize calls produce identical observable behavior")
+	assert.Equal(t, "id-idem", result2, "correlation ID correct after second Initialize")
+}
+
+func TestTelemetryBridgeInitialize_EmptyContext(t *testing.T) {
+	prev := globalTelemetryBridge.Load()
+	t.Cleanup(func() { globalTelemetryBridge.Store(prev) })
+	globalTelemetryBridge.Store(nil)
+
+	// Verify fallback (no bridge) returns empty for a context with no correlation ID.
+	assert.Equal(t, "", UpdatedExtractCorrelationID(context.Background()), "no bridge, no value → empty")
+
+	(&TelemetryBridge{}).Initialize()
+
+	// After wiring, context with no correlation ID still returns empty.
+	assert.Equal(t, "", UpdatedExtractCorrelationID(context.Background()), "bridge wired, no value → empty")
+}


### PR DESCRIPTION
## Summary

- Calls `(&logging.TelemetryBridge{}).Initialize()` after `logging.InitializeGlobalLogging()` in all three entry points: `cmd/controller/main.go` (`runController` + `runInstall`) and `cmd/steward/main.go` (`runSteward`), making the correlation-ID bridge live from first request
- Removes the dead `tracer *telemetry.Tracer` field, its `New()` parameter, struct literal assignment, and the now-orphaned `pkg/telemetry` import from `features/controller/api/server.go`; removes the stale `nil` tracer argument from `features/controller/server/server.go` and from all three `api.New()` test call sites
- Changes `globalTelemetryBridge` from a bare pointer to `atomic.Pointer[TelemetryBridge]` so `Initialize()` and the extractor functions are race-free under concurrent server startup
- Adds `pkg/logging/telemetry_bridge_test.go` with three tests: end-to-end bridge wiring (`"e2e-id"` round-trip), idempotency (two successive `Initialize()` calls produce identical behavior), and empty-context baseline

## Specialist Review Results

- **QA Test Runner**: PASS — 80+ packages, all cross-platform builds, integration tests, race detection, lint, secret scan, architecture compliance, security scan all green
- **QA Code Reviewer**: PASS — no mocks, no t.Skip(), no empty assertions, race fix verified via atomic.Pointer, all call sites updated
- **Security Engineer**: PASS — security-precommit, check-architecture, security-scan all green; no hardcoded secrets, no central provider violations, no insecure defaults

Fixes #1135