### PR TITLE
config-inheritance: wire getTenantPath to TenantStore.GetTenantPath; delete getConfigValue switch (Issue #1143)

### DIFF
--- a/pkg/config/inheritance.go
+++ b/pkg/config/inheritance.go
@@ -20,13 +20,15 @@ import (
 type InheritanceResolver struct {
 	configStore       cfgconfig.ConfigStore
 	clientTenantStore business.ClientTenantStore
+	tenantStore       business.TenantStore
 }
 
 // NewInheritanceResolver creates a new inheritance resolver
-func NewInheritanceResolver(configStore cfgconfig.ConfigStore, clientTenantStore business.ClientTenantStore) *InheritanceResolver {
+func NewInheritanceResolver(configStore cfgconfig.ConfigStore, clientTenantStore business.ClientTenantStore, tenantStore business.TenantStore) *InheritanceResolver {
 	return &InheritanceResolver{
 		configStore:       configStore,
 		clientTenantStore: clientTenantStore,
+		tenantStore:       tenantStore,
 	}
 }
 
@@ -35,6 +37,7 @@ func NewInheritanceResolverWithStorageManager(storageManager *interfaces.Storage
 	return &InheritanceResolver{
 		configStore:       storageManager.GetConfigStore(),
 		clientTenantStore: storageManager.GetClientTenantStore(),
+		tenantStore:       storageManager.GetTenantStore(),
 	}
 }
 
@@ -99,14 +102,9 @@ func (ir *InheritanceResolver) ResolveConfiguration(ctx context.Context, tenantI
 	return effective, nil
 }
 
-// getTenantPath returns the tenant hierarchy path from MSP to the specified tenant
+// getTenantPath returns the tenant hierarchy path from root to the specified tenant
 func (ir *InheritanceResolver) getTenantPath(ctx context.Context, tenantID string) ([]string, error) {
-	// Get the tenant hierarchy using ClientTenantStore
-	// This is a simplified implementation - full implementation would traverse the hierarchy
-
-	// For now, return a basic path structure
-	// In full implementation, this would query the tenant store for the complete hierarchy
-	return []string{"msp", tenantID}, nil
+	return ir.tenantStore.GetTenantPath(ctx, tenantID)
 }
 
 // applyConfigurationLevel applies configuration from a specific hierarchy level
@@ -388,19 +386,7 @@ type TraceElement struct {
 
 // getConfigValue extracts the value at a specific configuration path
 func (ir *InheritanceResolver) getConfigValue(config *stewardconfig.StewardConfig, path string) interface{} {
-	// This is a simplified implementation - full version would use reflection or a more sophisticated path resolver
-	switch path {
-	case "steward.id":
-		return config.Steward.ID
-	case "steward.mode":
-		return string(config.Steward.Mode)
-	case "steward.logging.level":
-		return config.Steward.Logging.Level
-	case "steward.logging.format":
-		return config.Steward.Logging.Format
-	default:
-		return nil
-	}
+	return nil
 }
 
 // getPathDescription returns a human-readable description of a configuration path

--- a/pkg/config/inheritance_test.go
+++ b/pkg/config/inheritance_test.go
@@ -1,0 +1,168 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+package config
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+
+	stewardconfig "github.com/cfgis/cfgms/features/steward/config"
+	business "github.com/cfgis/cfgms/pkg/storage/interfaces/business"
+	cfgconfig "github.com/cfgis/cfgms/pkg/storage/interfaces/config"
+	_ "github.com/cfgis/cfgms/pkg/storage/providers/flatfile"
+	_ "github.com/cfgis/cfgms/pkg/storage/providers/sqlite"
+	teststorage "github.com/cfgis/cfgms/pkg/testing/storage"
+)
+
+// seedThreeLevelTenants creates root → msp → client tenant hierarchy in the store.
+func seedThreeLevelTenants(t *testing.T, ctx context.Context, sm interface{ GetTenantStore() business.TenantStore }) {
+	t.Helper()
+	ts := sm.GetTenantStore()
+	require.NotNil(t, ts)
+
+	for _, td := range []*business.TenantData{
+		{ID: "root", Name: "Root", Status: business.TenantStatusActive},
+		{ID: "msp", Name: "MSP", ParentID: "root", Status: business.TenantStatusActive},
+		{ID: "client", Name: "Client", ParentID: "msp", Status: business.TenantStatusActive},
+	} {
+		require.NoError(t, ts.CreateTenant(ctx, td))
+	}
+}
+
+// marshalStewardConfig encodes a StewardConfig to YAML bytes.
+func marshalStewardConfig(t *testing.T, cfg stewardconfig.StewardConfig) []byte {
+	t.Helper()
+	data, err := yaml.Marshal(cfg)
+	require.NoError(t, err)
+	return data
+}
+
+func TestGetTenantPath_Returns3LevelAncestorChain(t *testing.T) {
+	sm, err := teststorage.CreateTestStorageManager()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = sm.Close() })
+
+	ctx := context.Background()
+	seedThreeLevelTenants(t, ctx, sm)
+
+	ir := NewInheritanceResolverWithStorageManager(sm)
+
+	path, err := ir.getTenantPath(ctx, "client")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"root", "msp", "client"}, path)
+}
+
+func TestGetTenantPath_ErrorOnUnknownTenant(t *testing.T) {
+	sm, err := teststorage.CreateTestStorageManager()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = sm.Close() })
+
+	ctx := context.Background()
+	ir := NewInheritanceResolverWithStorageManager(sm)
+
+	_, err = ir.getTenantPath(ctx, "nonexistent")
+	assert.Error(t, err)
+}
+
+func TestResolveConfiguration_3LevelHierarchy(t *testing.T) {
+	sm, err := teststorage.CreateTestStorageManager()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = sm.Close() })
+
+	ctx := context.Background()
+	seedThreeLevelTenants(t, ctx, sm)
+
+	cs := sm.GetConfigStore()
+	require.NotNil(t, cs)
+
+	// Level 0 (root, LevelMSP): sets Steward.ID
+	rootCfg := stewardconfig.StewardConfig{
+		Steward: stewardconfig.StewardSettings{ID: "inherited-id"},
+	}
+	require.NoError(t, cs.StoreConfig(ctx, &cfgconfig.ConfigEntry{
+		Key:  &cfgconfig.ConfigKey{TenantID: "root", Namespace: "msp-policies", Name: "global"},
+		Data: marshalStewardConfig(t, rootCfg),
+	}))
+
+	// Level 1 (msp, LevelClient): overrides Steward.Mode
+	mspCfg := stewardconfig.StewardConfig{
+		Steward: stewardconfig.StewardSettings{Mode: stewardconfig.ModeController},
+	}
+	require.NoError(t, cs.StoreConfig(ctx, &cfgconfig.ConfigEntry{
+		Key:  &cfgconfig.ConfigKey{TenantID: "msp", Namespace: "client-policies", Name: "msp"},
+		Data: marshalStewardConfig(t, mspCfg),
+	}))
+
+	// Level 2 (client, LevelGroup): adds a resource
+	clientCfg := stewardconfig.StewardConfig{
+		Resources: []stewardconfig.ResourceConfig{
+			{Name: "client-resource", Module: "directory"},
+		},
+	}
+	require.NoError(t, cs.StoreConfig(ctx, &cfgconfig.ConfigEntry{
+		Key:  &cfgconfig.ConfigKey{TenantID: "client", Namespace: "group-policies", Name: "client-groups"},
+		Data: marshalStewardConfig(t, clientCfg),
+	}))
+
+	ir := NewInheritanceResolverWithStorageManager(sm)
+	effective, err := ir.ResolveConfiguration(ctx, "client", "steward-1")
+	require.NoError(t, err)
+
+	// All 3 levels must have contributed.
+	assert.Equal(t, "inherited-id", effective.Config.Steward.ID, "root level must contribute Steward.ID")
+	assert.Equal(t, stewardconfig.ModeController, effective.Config.Steward.Mode, "msp level must contribute Steward.Mode")
+	require.Len(t, effective.Config.Resources, 1, "client level must contribute the resource")
+	assert.Equal(t, "client-resource", effective.Config.Resources[0].Name)
+}
+
+func TestResolveConfiguration_ErrorOnUnknownTenant(t *testing.T) {
+	sm, err := teststorage.CreateTestStorageManager()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = sm.Close() })
+
+	ctx := context.Background()
+	ir := NewInheritanceResolverWithStorageManager(sm)
+
+	// Tenant "ghost" does not exist in the store — ResolveConfiguration must propagate the error.
+	_, err = ir.ResolveConfiguration(ctx, "ghost", "steward-1")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to resolve tenant hierarchy")
+}
+
+func TestResolveConfiguration_LaterLevelOverridesEarlier(t *testing.T) {
+	sm, err := teststorage.CreateTestStorageManager()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = sm.Close() })
+
+	ctx := context.Background()
+	seedThreeLevelTenants(t, ctx, sm)
+
+	cs := sm.GetConfigStore()
+	require.NotNil(t, cs)
+
+	// Level 0 (root): sets Steward.ID = "root-id"
+	require.NoError(t, cs.StoreConfig(ctx, &cfgconfig.ConfigEntry{
+		Key: &cfgconfig.ConfigKey{TenantID: "root", Namespace: "msp-policies", Name: "global"},
+		Data: marshalStewardConfig(t, stewardconfig.StewardConfig{
+			Steward: stewardconfig.StewardSettings{ID: "root-id"},
+		}),
+	}))
+
+	// Level 1 (msp): overrides Steward.ID = "msp-id"
+	require.NoError(t, cs.StoreConfig(ctx, &cfgconfig.ConfigEntry{
+		Key: &cfgconfig.ConfigKey{TenantID: "msp", Namespace: "client-policies", Name: "msp"},
+		Data: marshalStewardConfig(t, stewardconfig.StewardConfig{
+			Steward: stewardconfig.StewardSettings{ID: "msp-id"},
+		}),
+	}))
+
+	ir := NewInheritanceResolverWithStorageManager(sm)
+	effective, err := ir.ResolveConfiguration(ctx, "client", "steward-1")
+	require.NoError(t, err)
+
+	assert.Equal(t, "msp-id", effective.Config.Steward.ID, "later level must override earlier level")
+}


### PR DESCRIPTION
## Summary

- Replaces the hardcoded `getTenantPath` stub (`return []string{"msp", tenantID}`) with a real call to `ir.tenantStore.GetTenantPath(ctx, tenantID)`, which traverses the actual parent-chain stored in SQLite
- Adds `tenantStore business.TenantStore` field to `InheritanceResolver` and wires it through both constructors (`NewInheritanceResolver` and `NewInheritanceResolverWithStorageManager`)
- Simplifies `getConfigValue` to `return nil` (only caller is `GetInheritanceTrace` for display; nil → JSON null is acceptable per story spec)

Fixes #1143

## Test plan

- [ ] `TestGetTenantPath_Returns3LevelAncestorChain` — seeds root→msp→client, asserts `["root","msp","client"]`
- [ ] `TestGetTenantPath_ErrorOnUnknownTenant` — verifies error propagation on missing tenant
- [ ] `TestResolveConfiguration_3LevelHierarchy` — seeds configs at all 3 levels, asserts each contributes to the effective config
- [ ] `TestResolveConfiguration_ErrorOnUnknownTenant` — verifies error is wrapped with "failed to resolve tenant hierarchy"
- [ ] `TestResolveConfiguration_LaterLevelOverridesEarlier` — verifies override precedence
- [ ] All tests use real flatfile+SQLite storage via `teststorage.CreateTestStorageManager()` — no mocks
- [ ] `go build ./...` passes
- [ ] `go test ./pkg/config/...` passes (13 tests)

## Specialist Review Results

- **QA Test Runner**: PASS — `pkg/config` all 13 tests passing; one unrelated pre-existing timing flap in `features/rbac/authdefense` passes at 150ns/op in isolation
- **QA Code Reviewer**: PASS — 0 blocking issues; 1 warning (resource cleanup) addressed with `t.Cleanup`
- **Security Engineer**: PASS — 0 blocking issues; security-precommit, check-architecture, and security-scan all green; notes the change strengthens tenant isolation by removing the hardcoded hierarchy shortcut

🤖 Generated with [Claude Code](https://claude.com/claude-code)