### PR TITLE
m365-auth: route fmt.Printf through pkg/logging in oauth2, interactive, callback (Issue #1160)

### DIFF
--- a/features/modules/m365/auth/callback_handler.go
+++ b/features/modules/m365/auth/callback_handler.go
@@ -10,6 +10,8 @@ import (
 	"net/http"
 	"sync"
 	"time"
+
+	"github.com/cfgis/cfgms/pkg/logging"
 )
 
 // CallbackHandler manages OAuth2 callback processing and flow state
@@ -21,6 +23,9 @@ type CallbackHandler struct {
 	// HTTP server for handling callbacks
 	server     *http.Server
 	serverPort string
+	listener   net.Listener
+
+	logger logging.Logger
 }
 
 // NewCallbackHandler creates a new callback handler
@@ -28,7 +33,16 @@ func NewCallbackHandler() *CallbackHandler {
 	return &CallbackHandler{
 		flowStates: make(map[string]*AuthFlowState),
 		serverPort: "8080", // Default port
+		logger:     logging.NewNoopLogger(),
 	}
+}
+
+// WithLogger sets the logger for the callback handler and returns h for chaining.
+func (h *CallbackHandler) WithLogger(logger logging.Logger) *CallbackHandler {
+	if logger != nil {
+		h.logger = logger
+	}
+	return h
 }
 
 // StartCallbackServer starts the HTTP server to handle OAuth2 callbacks
@@ -50,6 +64,7 @@ func (h *CallbackHandler) StartCallbackServer(ctx context.Context, port string) 
 
 	// Update serverPort with actual port (important when using "0")
 	h.serverPort = fmt.Sprintf("%d", listener.Addr().(*net.TCPAddr).Port)
+	h.listener = listener
 
 	h.server = &http.Server{
 		Handler:      mux,
@@ -59,7 +74,7 @@ func (h *CallbackHandler) StartCallbackServer(ctx context.Context, port string) 
 
 	go func() {
 		if err := h.server.Serve(listener); err != nil && err != http.ErrServerClosed {
-			fmt.Printf("Callback server error: %v\n", err)
+			h.logger.Error("callback server error", "error", err)
 		}
 	}()
 
@@ -170,8 +185,7 @@ func (h *CallbackHandler) handleCallback(w http.ResponseWriter, r *http.Request)
 	if r.Header.Get("Accept") == "application/json" {
 		w.Header().Set("Content-Type", "application/json")
 		if err := json.NewEncoder(w).Encode(response); err != nil {
-			// Log error - we could add a logger field to CallbackHandler in the future
-			_ = err // Acknowledge error
+			h.logger.Error("failed to encode callback response", "error", err)
 			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		}
 		return
@@ -181,8 +195,7 @@ func (h *CallbackHandler) handleCallback(w http.ResponseWriter, r *http.Request)
 	html := h.generateCallbackHTML(response)
 	w.Header().Set("Content-Type", "text/html")
 	if _, err := w.Write([]byte(html)); err != nil {
-		// Log error - we could add a logger field to CallbackHandler in the future
-		_ = err // Acknowledge error
+		h.logger.Error("failed to write callback html", "error", err)
 	}
 }
 
@@ -203,8 +216,7 @@ func (h *CallbackHandler) handleStatus(w http.ResponseWriter, r *http.Request) {
 			"success": result.Success,
 			"state":   result.State,
 		}); err != nil {
-			// Log error - we could add a logger field to CallbackHandler in the future
-			_ = err // Acknowledge error
+			h.logger.Error("failed to encode status response", "error", err)
 			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		}
 	} else {
@@ -212,8 +224,7 @@ func (h *CallbackHandler) handleStatus(w http.ResponseWriter, r *http.Request) {
 			"ready": false,
 			"state": state,
 		}); err != nil {
-			// Log error - we could add a logger field to CallbackHandler in the future
-			_ = err // Acknowledge error
+			h.logger.Error("failed to encode status response", "error", err)
 			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		}
 	}
@@ -226,8 +237,7 @@ func (h *CallbackHandler) handleHealth(w http.ResponseWriter, r *http.Request) {
 		"timestamp": time.Now().Format(time.RFC3339),
 		"version":   "1.0.0",
 	}); err != nil {
-		// Could add logging here if needed
-		_ = err
+		h.logger.Error("failed to encode health response", "error", err)
 	}
 }
 

--- a/features/modules/m365/auth/callback_handler_test.go
+++ b/features/modules/m365/auth/callback_handler_test.go
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+package auth
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	pkgtesting "github.com/cfgis/cfgms/pkg/testing"
+)
+
+// TestCallbackHandler_WithLogger_routesError verifies that server errors in the
+// callback server goroutine are routed through the injected logger.
+func TestCallbackHandler_WithLogger_routesError(t *testing.T) {
+	mockLog := pkgtesting.NewMockLogger(false)
+
+	handler := NewCallbackHandler()
+	handler.WithLogger(mockLog)
+
+	ctx := context.Background()
+	err := handler.StartCallbackServer(ctx, "0")
+	require.NoError(t, err)
+
+	// Forcefully close the underlying listener (not via Shutdown) so that
+	// server.Serve returns a non-ErrServerClosed error, triggering the log path.
+	require.NotNil(t, handler.listener)
+	require.NoError(t, handler.listener.Close())
+
+	// Give the goroutine time to react and log the error.
+	deadline := time.Now().Add(2 * time.Second)
+	var errLogs []pkgtesting.LogEntry
+	for time.Now().Before(deadline) {
+		errLogs = mockLog.GetLogs("error")
+		if len(errLogs) > 0 {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	require.NotEmpty(t, errLogs, "expected error log when listener is closed externally")
+	assert.Equal(t, "callback server error", errLogs[0].Message)
+}
+
+// TestCallbackHandler_WithLogger_chainsReturn verifies that WithLogger returns
+// the handler itself for chaining.
+func TestCallbackHandler_WithLogger_chainsReturn(t *testing.T) {
+	h := NewCallbackHandler()
+	mockLog := pkgtesting.NewMockLogger(false)
+	returned := h.WithLogger(mockLog)
+	assert.Same(t, h, returned, "WithLogger must return the receiver for chaining")
+}
+
+// TestCallbackHandler_WithLogger_nilIsIgnored verifies that passing nil to
+// WithLogger does not replace the existing logger.
+func TestCallbackHandler_WithLogger_nilIsIgnored(t *testing.T) {
+	h := NewCallbackHandler()
+	original := h.logger
+	h.WithLogger(nil)
+	assert.Equal(t, original, h.logger, "nil logger should not replace the existing logger")
+}
+
+// TestCallbackHandler_defaultLogger_isNoopLogger verifies that a freshly
+// constructed CallbackHandler has a non-nil logger.
+func TestCallbackHandler_defaultLogger_isNoopLogger(t *testing.T) {
+	h := NewCallbackHandler()
+	assert.NotNil(t, h.logger, "default logger must be non-nil")
+}

--- a/features/modules/m365/auth/delegated_integration_test.go
+++ b/features/modules/m365/auth/delegated_integration_test.go
@@ -11,6 +11,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/cfgis/cfgms/pkg/logging"
 )
 
 // TestDelegatedPermissionsIntegration tests the complete delegated permissions workflow
@@ -45,7 +47,7 @@ func TestDelegatedPermissionsIntegration(t *testing.T) {
 		},
 	}
 
-	provider := NewOAuth2Provider(credStore, config)
+	provider := NewOAuth2Provider(credStore, config, logging.NewNoopLogger())
 	ctx := context.Background()
 
 	t.Run("TestDelegatedAuthConfiguration", func(t *testing.T) {
@@ -235,7 +237,7 @@ func TestDelegatedPermissionsScenarios(t *testing.T) {
 		},
 	}
 
-	provider := NewOAuth2Provider(credStore, config)
+	provider := NewOAuth2Provider(credStore, config, logging.NewNoopLogger())
 	ctx := context.Background()
 
 	t.Run("TestUserManagementWithDelegatedPermissions", func(t *testing.T) {
@@ -324,7 +326,7 @@ func TestTokenRefreshFlow(t *testing.T) {
 		FallbackToAppPermissions: true,
 	}
 
-	provider := NewOAuth2Provider(credStore, config)
+	provider := NewOAuth2Provider(credStore, config, logging.NewNoopLogger())
 	ctx := context.Background()
 
 	t.Run("TestDelegatedTokenRefresh", func(t *testing.T) {
@@ -414,7 +416,7 @@ func BenchmarkDelegatedTokenOperations(b *testing.B) {
 		SupportDelegatedAuth: true,
 	}
 
-	provider := NewOAuth2Provider(credStore, config)
+	provider := NewOAuth2Provider(credStore, config, logging.NewNoopLogger())
 
 	userContext := &UserContext{
 		UserID:            "benchmark-user",

--- a/features/modules/m365/auth/direct_app_access_test.go
+++ b/features/modules/m365/auth/direct_app_access_test.go
@@ -14,6 +14,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/cfgis/cfgms/pkg/logging"
 )
 
 // TestDirectAppAccessConfiguration tests direct app registration configuration
@@ -59,7 +61,7 @@ func TestDirectAppAccessConfiguration(t *testing.T) {
 		},
 	}
 
-	provider := NewOAuth2Provider(credStore, config)
+	provider := NewOAuth2Provider(credStore, config, logging.NewNoopLogger())
 	ctx := context.Background()
 
 	t.Run("TestDirectAppConfigurationStorage", func(t *testing.T) {
@@ -287,7 +289,7 @@ func TestDirectAppAccessTokenFlow(t *testing.T) {
 		Scopes:                   []string{"User.Read.All", "Directory.Read.All"},
 	}
 
-	provider := NewOAuth2Provider(credStore, config)
+	provider := NewOAuth2Provider(credStore, config, logging.NewNoopLogger())
 	ctx := context.Background()
 
 	t.Run("TestApplicationTokenFlow", func(t *testing.T) {
@@ -348,7 +350,7 @@ func TestDirectAppAccessPermissionScenarios(t *testing.T) {
 		},
 	}
 
-	provider := NewOAuth2Provider(credStore, config)
+	provider := NewOAuth2Provider(credStore, config, logging.NewNoopLogger())
 	ctx := context.Background()
 
 	// Define realistic scenarios for different M365 operations
@@ -484,7 +486,7 @@ func TestDirectAppAccessIntegration(t *testing.T) {
 		},
 	}
 
-	provider := NewOAuth2Provider(credStore, config)
+	provider := NewOAuth2Provider(credStore, config, logging.NewNoopLogger())
 	ctx := context.Background()
 
 	t.Run("TestRealApplicationToken", func(t *testing.T) {

--- a/features/modules/m365/auth/integration_validation_test.go
+++ b/features/modules/m365/auth/integration_validation_test.go
@@ -9,6 +9,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/cfgis/cfgms/pkg/logging"
 )
 
 // TestFullDelegatedPermissionsIntegration validates the complete delegated permissions implementation
@@ -25,7 +27,7 @@ func TestFullDelegatedPermissionsIntegration(t *testing.T) {
 			DelegatedScopes:          []string{"User.Read", "Directory.Read.All"},
 		}
 
-		provider := NewOAuth2Provider(credStore, config)
+		provider := NewOAuth2Provider(credStore, config, logging.NewNoopLogger())
 
 		// Verify provider implements enhanced interface
 		assert.NotNil(t, provider)
@@ -124,7 +126,7 @@ func TestFullDelegatedPermissionsIntegration(t *testing.T) {
 			SupportDelegatedAuth: true,
 		}
 
-		provider := NewOAuth2Provider(credStore, config)
+		provider := NewOAuth2Provider(credStore, config, logging.NewNoopLogger())
 
 		userContext := &UserContext{
 			UserID:            "cache-user",
@@ -171,7 +173,7 @@ func TestFullDelegatedPermissionsIntegration(t *testing.T) {
 	t.Run("TestPermissionValidation", func(t *testing.T) {
 		credStore := newTestCredentialStore(t)
 
-		provider := NewOAuth2Provider(credStore, &OAuth2Config{})
+		provider := NewOAuth2Provider(credStore, &OAuth2Config{}, logging.NewNoopLogger())
 
 		// Test application token (should pass all validations)
 		appToken := &AccessToken{
@@ -279,10 +281,10 @@ func TestInteractiveAuthenticatorCreation(t *testing.T) {
 		SupportDelegatedAuth: true,
 	}
 
-	provider := NewOAuth2Provider(credStore, config)
+	provider := NewOAuth2Provider(credStore, config, logging.NewNoopLogger())
 
 	// Should be able to create interactive authenticator
-	interactiveAuth := NewInteractiveAuthenticator(provider, ":8080")
+	interactiveAuth := NewInteractiveAuthenticator(provider, ":8080", logging.NewNoopLogger())
 	assert.NotNil(t, interactiveAuth)
 
 	// Should be able to generate PKCE parameters
@@ -313,7 +315,7 @@ func TestRealWorldCredentialFlow(t *testing.T) {
 		RequiredDelegatedScopes:  []string{"User.Read"},
 	}
 
-	provider := NewOAuth2Provider(credStore, config)
+	provider := NewOAuth2Provider(credStore, config, logging.NewNoopLogger())
 	ctx := context.Background()
 
 	// Test that the flow would work with real credentials
@@ -408,7 +410,7 @@ func BenchmarkDelegatedOperations(b *testing.B) {
 		SupportDelegatedAuth: true,
 	}
 
-	provider := NewOAuth2Provider(credStore, config)
+	provider := NewOAuth2Provider(credStore, config, logging.NewNoopLogger())
 
 	userContext := &UserContext{
 		UserID:            "benchmark-user",

--- a/features/modules/m365/auth/interactive_auth.go
+++ b/features/modules/m365/auth/interactive_auth.go
@@ -11,8 +11,11 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"os"
 	"strings"
 	"time"
+
+	"github.com/cfgis/cfgms/pkg/logging"
 )
 
 // InteractiveAuthenticator provides methods for interactive OAuth2 flows
@@ -20,17 +23,22 @@ type InteractiveAuthenticator struct {
 	provider     *OAuth2Provider
 	callbackAddr string
 	server       *http.Server
+	logger       logging.Logger
 }
 
 // NewInteractiveAuthenticator creates a new interactive authenticator
-func NewInteractiveAuthenticator(provider *OAuth2Provider, callbackAddr string) *InteractiveAuthenticator {
+func NewInteractiveAuthenticator(provider *OAuth2Provider, callbackAddr string, logger logging.Logger) *InteractiveAuthenticator {
 	if callbackAddr == "" {
 		callbackAddr = ":8080"
+	}
+	if logger == nil {
+		logger = logging.NewNoopLogger()
 	}
 
 	return &InteractiveAuthenticator{
 		provider:     provider,
 		callbackAddr: callbackAddr,
+		logger:       logger,
 	}
 }
 
@@ -65,12 +73,12 @@ func (ia *InteractiveAuthenticator) AuthenticateUser(ctx context.Context, tenant
 	defer ia.stopCallbackServer()
 
 	// Open browser or show URL
-	fmt.Printf("\n🔐 Interactive M365 Authentication Required\n")
-	fmt.Printf("==================================================\n")
-	fmt.Printf("Please open the following URL in your browser:\n\n")
-	fmt.Printf("%s\n\n", authURL)
-	fmt.Printf("After authorization, you will be redirected to localhost.\n")
-	fmt.Printf("Waiting for callback...\n\n")
+	_, _ = fmt.Fprintf(os.Stdout, "\n🔐 Interactive M365 Authentication Required\n")
+	_, _ = fmt.Fprintf(os.Stdout, "==================================================\n")
+	_, _ = fmt.Fprintf(os.Stdout, "Please open the following URL in your browser:\n\n")
+	_, _ = fmt.Fprintf(os.Stdout, "%s\n\n", authURL)
+	_, _ = fmt.Fprintf(os.Stdout, "After authorization, you will be redirected to localhost.\n")
+	_, _ = fmt.Fprintf(os.Stdout, "Waiting for callback...\n\n")
 
 	// Wait for callback with timeout
 	select {
@@ -85,7 +93,7 @@ func (ia *InteractiveAuthenticator) AuthenticateUser(ctx context.Context, tenant
 			return nil, nil, fmt.Errorf("failed to get user info: %w", err)
 		}
 
-		fmt.Printf("✅ Authentication successful! Welcome, %s\n", userContext.DisplayName)
+		_, _ = fmt.Fprintf(os.Stdout, "✅ Authentication successful! Welcome, %s\n", userContext.DisplayName)
 		return userContext, result.token, nil
 
 	case <-time.After(5 * time.Minute):
@@ -250,7 +258,7 @@ func (ia *InteractiveAuthenticator) setupCallbackHandler(state, codeVerifier, te
 func (ia *InteractiveAuthenticator) startCallbackServer() error {
 	go func() {
 		if err := ia.server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
-			fmt.Printf("Callback server error: %v\n", err)
+			ia.logger.Warn("callback server error", "error", err)
 		}
 	}()
 
@@ -305,8 +313,7 @@ func (ia *InteractiveAuthenticator) getUserInfo(ctx context.Context, token *Acce
 	req.Header.Set("Accept", "application/json")
 
 	// Make the request
-	client := &http.Client{Timeout: 30 * time.Second}
-	resp, err := client.Do(req)
+	resp, err := ia.provider.httpClient.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get user info: %w", err)
 	}
@@ -341,7 +348,7 @@ func (ia *InteractiveAuthenticator) getUserInfo(ctx context.Context, token *Acce
 	roles, err := ia.getUserRoles(ctx, token)
 	if err != nil {
 		// Log warning but don't fail - roles are nice-to-have
-		fmt.Printf("Warning: Could not retrieve user roles: %v\n", err)
+		ia.logger.Warn("could not retrieve user roles", "error", err)
 		roles = []string{}
 	}
 
@@ -371,8 +378,7 @@ func (ia *InteractiveAuthenticator) getUserRoles(ctx context.Context, token *Acc
 	req.Header.Set("Accept", "application/json")
 
 	// Make the request
-	client := &http.Client{Timeout: 30 * time.Second}
-	resp, err := client.Do(req)
+	resp, err := ia.provider.httpClient.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get user roles: %w", err)
 	}
@@ -449,31 +455,31 @@ func (ia *InteractiveAuthenticator) TestDelegatedPermissions(ctx context.Context
 		"DeviceManagementConfiguration.ReadWrite.All",
 	}
 
-	fmt.Printf("🧪 Testing Delegated Permissions for %s\n", userContext.DisplayName)
-	fmt.Printf("================================================\n")
+	_, _ = fmt.Fprintf(os.Stdout, "🧪 Testing Delegated Permissions for %s\n", userContext.DisplayName)
+	_, _ = fmt.Fprintf(os.Stdout, "================================================\n")
 
 	for _, scope := range scopesToTest {
-		fmt.Printf("Testing %s... ", scope)
+		_, _ = fmt.Fprintf(os.Stdout, "Testing %s... ", scope)
 
 		err := ia.provider.ValidatePermissions(ctx, token, []string{scope})
 		if err != nil {
 			result.TestedScopes[scope] = false
 			result.FailedScopes = append(result.FailedScopes, scope)
 			result.TestResults[scope] = fmt.Sprintf("Failed: %s", err.Error())
-			fmt.Printf("❌ Failed\n")
+			_, _ = fmt.Fprintf(os.Stdout, "❌ Failed\n")
 		} else {
 			result.TestedScopes[scope] = true
 			result.TestResults[scope] = "Success"
-			fmt.Printf("✅ Success\n")
+			_, _ = fmt.Fprintf(os.Stdout, "✅ Success\n")
 		}
 	}
 
-	fmt.Printf("\n📊 Test Summary:\n")
-	fmt.Printf("- Successful scopes: %d\n", len(result.TestedScopes)-len(result.FailedScopes))
-	fmt.Printf("- Failed scopes: %d\n", len(result.FailedScopes))
+	_, _ = fmt.Fprintf(os.Stdout, "\n📊 Test Summary:\n")
+	_, _ = fmt.Fprintf(os.Stdout, "- Successful scopes: %d\n", len(result.TestedScopes)-len(result.FailedScopes))
+	_, _ = fmt.Fprintf(os.Stdout, "- Failed scopes: %d\n", len(result.FailedScopes))
 
 	if len(result.FailedScopes) > 0 {
-		fmt.Printf("- Failed scopes: %s\n", strings.Join(result.FailedScopes, ", "))
+		_, _ = fmt.Fprintf(os.Stdout, "- Failed scopes: %s\n", strings.Join(result.FailedScopes, ", "))
 	}
 
 	return result, nil

--- a/features/modules/m365/auth/interactive_auth_test.go
+++ b/features/modules/m365/auth/interactive_auth_test.go
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+package auth
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cfgis/cfgms/pkg/logging"
+	pkgtesting "github.com/cfgis/cfgms/pkg/testing"
+)
+
+// TestInteractiveAuthenticator_warning_logsToLogger verifies that a failure to
+// retrieve user roles is routed through the injected logger (not written to
+// stdout directly).
+func TestInteractiveAuthenticator_warning_logsToLogger(t *testing.T) {
+	// Mock Graph server: /me succeeds, /me/memberOf returns 500 to force an error
+	mockGraph := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v1.0/me":
+			resp := map[string]interface{}{
+				"id":                "user-id-1",
+				"userPrincipalName": "testuser@example.com",
+				"displayName":       "Test User",
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(resp)
+		default:
+			// All other paths (including /me/memberOf) return 500
+			w.WriteHeader(http.StatusInternalServerError)
+		}
+	}))
+	defer mockGraph.Close()
+
+	mockLog := pkgtesting.NewMockLogger(false)
+
+	credStore := &failingCredentialStore{}
+	config := &OAuth2Config{
+		TenantID:             "test-tenant",
+		UseClientCredentials: true,
+	}
+
+	provider := NewOAuth2Provider(credStore, config, logging.NewNoopLogger())
+	// Override HTTP client so requests hit our mock server instead of graph.microsoft.com
+	provider.SetHTTPClient(&http.Client{
+		Transport: &graphURLRewriteTransport{baseURL: mockGraph.URL},
+	})
+
+	ia := NewInteractiveAuthenticator(provider, ":0", mockLog)
+
+	token := &AccessToken{
+		Token:     "test-token",
+		TokenType: "Bearer",
+		ExpiresAt: time.Now().Add(time.Hour),
+	}
+
+	userCtx, err := ia.getUserInfo(context.Background(), token)
+	require.NoError(t, err, "getUserInfo should succeed even when roles fail")
+	assert.NotNil(t, userCtx)
+
+	warnLogs := mockLog.GetLogs("warn")
+	require.NotEmpty(t, warnLogs, "expected warn log for role retrieval failure")
+	assert.Equal(t, "could not retrieve user roles", warnLogs[0].Message)
+}
+
+// graphURLRewriteTransport rewrites graph.microsoft.com requests to a test server.
+type graphURLRewriteTransport struct {
+	baseURL string
+}
+
+func (t *graphURLRewriteTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	cloned := req.Clone(req.Context())
+	cloned.URL.Scheme = "http"
+	cloned.URL.Host = t.baseURL[len("http://"):]
+	return http.DefaultTransport.RoundTrip(cloned)
+}
+
+// TestInteractiveAuthenticator_nilLogger_usesNoopLogger verifies that a nil logger
+// is replaced with the no-op logger at construction time.
+func TestInteractiveAuthenticator_nilLogger_usesNoopLogger(t *testing.T) {
+	credStore := &failingCredentialStore{}
+	config := &OAuth2Config{TenantID: "t1"}
+	provider := NewOAuth2Provider(credStore, config, logging.NewNoopLogger())
+
+	ia := NewInteractiveAuthenticator(provider, ":0", nil)
+	assert.NotNil(t, ia.logger, "logger must never be nil after construction")
+}

--- a/features/modules/m365/auth/interactive_flow_test.go
+++ b/features/modules/m365/auth/interactive_flow_test.go
@@ -16,6 +16,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/cfgis/cfgms/pkg/logging"
 )
 
 // TestInteractiveAuthFlowSetup tests the setup button experience backend
@@ -44,7 +46,7 @@ func TestInteractiveAuthFlowSetup(t *testing.T) {
 		},
 	}
 
-	provider := NewOAuth2Provider(credStore, config)
+	provider := NewOAuth2Provider(credStore, config, logging.NewNoopLogger())
 	flow := NewInteractiveAuthFlow(provider, config)
 	ctx := context.Background()
 
@@ -420,7 +422,7 @@ func TestCapabilityTesting(t *testing.T) {
 		Scopes:               []string{"https://graph.microsoft.com/.default"}, // Application permissions use .default scope
 	}
 
-	provider := NewOAuth2Provider(credStore, config)
+	provider := NewOAuth2Provider(credStore, config, logging.NewNoopLogger())
 	flow := NewInteractiveAuthFlow(provider, config)
 
 	// Note: GraphBaseURL is a const, so we use HTTP transport override instead
@@ -566,7 +568,7 @@ func TestRealM365InteractiveIntegration(t *testing.T) {
 		},
 	}
 
-	provider := NewOAuth2Provider(credStore, config)
+	provider := NewOAuth2Provider(credStore, config, logging.NewNoopLogger())
 	flow := NewInteractiveAuthFlow(provider, config)
 	ctx := context.Background()
 

--- a/features/modules/m365/auth/oauth2_provider.go
+++ b/features/modules/m365/auth/oauth2_provider.go
@@ -11,6 +11,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/cfgis/cfgms/pkg/logging"
 )
 
 // OAuth2Provider implements the Provider interface using OAuth2 client credentials flow
@@ -31,6 +33,8 @@ type OAuth2Provider struct {
 
 	// Default configuration for new tenants
 	defaultConfig *OAuth2Config
+
+	logger logging.Logger
 }
 
 // cachedToken represents a cached access token with expiration tracking
@@ -40,7 +44,10 @@ type cachedToken struct {
 }
 
 // NewOAuth2Provider creates a new OAuth2Provider instance
-func NewOAuth2Provider(credentialStore CredentialStore, defaultConfig *OAuth2Config) *OAuth2Provider {
+func NewOAuth2Provider(credentialStore CredentialStore, defaultConfig *OAuth2Config, logger logging.Logger) *OAuth2Provider {
+	if logger == nil {
+		logger = logging.NewNoopLogger()
+	}
 	return &OAuth2Provider{
 		httpClient: &http.Client{
 			Timeout: 30 * time.Second,
@@ -49,6 +56,7 @@ func NewOAuth2Provider(credentialStore CredentialStore, defaultConfig *OAuth2Con
 		tokenCache:          make(map[string]*cachedToken),
 		delegatedTokenCache: make(map[string]*cachedToken),
 		defaultConfig:       defaultConfig,
+		logger:              logger,
 	}
 }
 
@@ -93,7 +101,7 @@ func (p *OAuth2Provider) GetAccessToken(ctx context.Context, tenantID string) (*
 	// Store the new token
 	if err := p.credentialStore.StoreToken(tenantID, token); err != nil {
 		// Log warning but don't fail - we can still return the token
-		fmt.Printf("Warning: Failed to store token for tenant %s: %v\n", tenantID, err)
+		p.logger.Warn("failed to store token", "tenant_id", logging.SanitizeLogValue(tenantID), "error", err)
 	}
 
 	// Cache the token
@@ -255,14 +263,18 @@ func (p *OAuth2Provider) RefreshDelegatedToken(ctx context.Context, refreshToken
 	// Store the refreshed token
 	if err := p.credentialStore.StoreDelegatedToken(tenantID, userContext.UserID, token); err != nil {
 		// Log warning but don't fail
-		fmt.Printf("Warning: Failed to store delegated token for user %s in tenant %s: %v\n",
-			userContext.UserID, tenantID, err)
+		p.logger.Warn("failed to store delegated token",
+			"user_id", logging.SanitizeLogValue(userContext.UserID),
+			"tenant_id", logging.SanitizeLogValue(tenantID),
+			"error", err)
 	}
 
 	// Store updated user context
 	if err := p.credentialStore.StoreUserContext(tenantID, userContext.UserID, userContext); err != nil {
-		fmt.Printf("Warning: Failed to store user context for user %s in tenant %s: %v\n",
-			userContext.UserID, tenantID, err)
+		p.logger.Warn("failed to store user context",
+			"user_id", logging.SanitizeLogValue(userContext.UserID),
+			"tenant_id", logging.SanitizeLogValue(tenantID),
+			"error", err)
 	}
 
 	// Cache the token
@@ -690,14 +702,18 @@ func (p *OAuth2Provider) ExchangeCodeForDelegatedToken(ctx context.Context, tena
 
 		// Store as delegated token
 		if err := p.credentialStore.StoreDelegatedToken(tenantID, userContext.UserID, token); err != nil {
-			fmt.Printf("Warning: Failed to store delegated token for user %s in tenant %s: %v\n",
-				userContext.UserID, tenantID, err)
+			p.logger.Warn("failed to store delegated token",
+				"user_id", logging.SanitizeLogValue(userContext.UserID),
+				"tenant_id", logging.SanitizeLogValue(tenantID),
+				"error", err)
 		}
 
 		// Store user context
 		if err := p.credentialStore.StoreUserContext(tenantID, userContext.UserID, userContext); err != nil {
-			fmt.Printf("Warning: Failed to store user context for user %s in tenant %s: %v\n",
-				userContext.UserID, tenantID, err)
+			p.logger.Warn("failed to store user context",
+				"user_id", logging.SanitizeLogValue(userContext.UserID),
+				"tenant_id", logging.SanitizeLogValue(tenantID),
+				"error", err)
 		}
 
 		// Cache as delegated token
@@ -706,7 +722,7 @@ func (p *OAuth2Provider) ExchangeCodeForDelegatedToken(ctx context.Context, tena
 	} else {
 		// Store as application token
 		if err := p.credentialStore.StoreToken(tenantID, token); err != nil {
-			fmt.Printf("Warning: Failed to store token for tenant %s: %v\n", tenantID, err)
+			p.logger.Warn("failed to store token", "tenant_id", logging.SanitizeLogValue(tenantID), "error", err)
 		}
 
 		// Cache the token

--- a/features/modules/m365/auth/oauth2_provider_test.go
+++ b/features/modules/m365/auth/oauth2_provider_test.go
@@ -1,0 +1,200 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+package auth
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	pkgtesting "github.com/cfgis/cfgms/pkg/testing"
+)
+
+// failingCredentialStore is a test implementation of CredentialStore that returns
+// errors on store operations to verify logging of those failures.
+type failingCredentialStore struct {
+	getConfigErr  error
+	storeTokenErr error
+}
+
+func (s *failingCredentialStore) StoreToken(_ string, _ *AccessToken) error {
+	return s.storeTokenErr
+}
+
+func (s *failingCredentialStore) GetToken(_ string) (*AccessToken, error) {
+	return nil, errors.New("no token")
+}
+
+func (s *failingCredentialStore) DeleteToken(_ string) error { return nil }
+
+func (s *failingCredentialStore) StoreDelegatedToken(_, _ string, _ *AccessToken) error {
+	return s.storeTokenErr
+}
+
+func (s *failingCredentialStore) GetDelegatedToken(_, _ string) (*AccessToken, error) {
+	return nil, errors.New("no token")
+}
+
+func (s *failingCredentialStore) DeleteDelegatedToken(_, _ string) error { return nil }
+
+func (s *failingCredentialStore) StoreUserContext(_, _ string, _ *UserContext) error {
+	return s.storeTokenErr
+}
+
+func (s *failingCredentialStore) GetUserContext(_, _ string) (*UserContext, error) {
+	return nil, errors.New("no context")
+}
+
+func (s *failingCredentialStore) DeleteUserContext(_, _ string) error { return nil }
+
+func (s *failingCredentialStore) StoreConfig(_ string, _ *OAuth2Config) error { return nil }
+
+func (s *failingCredentialStore) GetConfig(_ string) (*OAuth2Config, error) {
+	if s.getConfigErr != nil {
+		return nil, s.getConfigErr
+	}
+	return nil, errors.New("no config")
+}
+
+func (s *failingCredentialStore) IsAvailable() bool { return true }
+
+// TestOAuth2Provider_tokenStoreFailure_logsError verifies that token store failures
+// are routed through the injected logger rather than written directly to stdout.
+func TestOAuth2Provider_tokenStoreFailure_logsError(t *testing.T) {
+	// Mock token endpoint that returns a valid token
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := map[string]interface{}{
+			"access_token": "test-access-token",
+			"token_type":   "Bearer",
+			"expires_in":   3600,
+		}
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(resp); err != nil {
+			http.Error(w, "encode failed", http.StatusInternalServerError)
+		}
+	}))
+	defer mockServer.Close()
+
+	mockLog := pkgtesting.NewMockLogger(false)
+	credStore := &failingCredentialStore{
+		storeTokenErr: errors.New("storage unavailable"),
+	}
+	config := &OAuth2Config{
+		ClientID:             "test-client",
+		ClientSecret:         "test-secret",
+		TenantID:             "test-tenant",
+		UseClientCredentials: true,
+		AuthorityURL:         mockServer.URL,
+	}
+
+	provider := NewOAuth2Provider(credStore, config, mockLog)
+	provider.SetHTTPClient(mockServer.Client())
+
+	token, err := provider.GetAccessToken(context.Background(), config.TenantID)
+	require.NoError(t, err)
+	assert.NotNil(t, token)
+
+	warnLogs := mockLog.GetLogs("warn")
+	require.NotEmpty(t, warnLogs, "expected a warn log for token store failure")
+	assert.Equal(t, "failed to store token", warnLogs[0].Message)
+}
+
+// TestOAuth2Provider_nilLogger_usesNoopLogger verifies that passing nil as logger
+// falls back to the no-op logger instead of panicking.
+func TestOAuth2Provider_nilLogger_usesNoopLogger(t *testing.T) {
+	credStore := &failingCredentialStore{storeTokenErr: errors.New("store failed")}
+	config := &OAuth2Config{TenantID: "t1", UseClientCredentials: true}
+
+	provider := NewOAuth2Provider(credStore, config, nil)
+	assert.NotNil(t, provider.logger, "logger must never be nil after construction")
+}
+
+// TestOAuth2Provider_exchangeCode_tokenStoreFailure_logsWarning verifies that
+// ExchangeCodeForDelegatedToken logs a warning when StoreToken fails for an
+// application token (nil userContext path).
+func TestOAuth2Provider_exchangeCode_tokenStoreFailure_logsWarning(t *testing.T) {
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := map[string]interface{}{
+			"access_token": "exchange-token",
+			"token_type":   "Bearer",
+			"expires_in":   3600,
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer mockServer.Close()
+
+	mockLog := pkgtesting.NewMockLogger(false)
+	credStore := &failingCredentialStore{storeTokenErr: errors.New("store failed")}
+	config := &OAuth2Config{
+		ClientID:             "test-client",
+		ClientSecret:         "test-secret",
+		TenantID:             "test-tenant",
+		UseClientCredentials: true,
+		AuthorityURL:         mockServer.URL,
+	}
+
+	provider := NewOAuth2Provider(credStore, config, mockLog)
+	provider.SetHTTPClient(mockServer.Client())
+
+	// nil userContext → application token path → calls StoreToken
+	token, err := provider.ExchangeCodeForDelegatedToken(
+		context.Background(), config.TenantID, "auth-code", "", nil,
+	)
+	require.NoError(t, err)
+	assert.NotNil(t, token)
+
+	warnLogs := mockLog.GetLogs("warn")
+	require.NotEmpty(t, warnLogs, "expected warn log for token store failure")
+	assert.Equal(t, "failed to store token", warnLogs[0].Message)
+}
+
+// TestOAuth2Provider_refreshDelegated_storeFailure_logsWarning verifies that
+// RefreshDelegatedToken logs warnings when delegated token and user context
+// storage fail.
+func TestOAuth2Provider_refreshDelegated_storeFailure_logsWarning(t *testing.T) {
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := map[string]interface{}{
+			"access_token":  "refreshed-token",
+			"token_type":    "Bearer",
+			"expires_in":    3600,
+			"refresh_token": "new-refresh",
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer mockServer.Close()
+
+	mockLog := pkgtesting.NewMockLogger(false)
+	credStore := &failingCredentialStore{storeTokenErr: errors.New("store failed")}
+	config := &OAuth2Config{
+		ClientID:             "test-client",
+		ClientSecret:         "test-secret",
+		TenantID:             "uid-as-tenant",
+		UseClientCredentials: false,
+		AuthorityURL:         mockServer.URL,
+	}
+
+	provider := NewOAuth2Provider(credStore, config, mockLog)
+	provider.SetHTTPClient(mockServer.Client())
+
+	userCtx := &UserContext{
+		UserID:            "uid-as-tenant",
+		UserPrincipalName: "user@example.com",
+		LastAuthenticated: time.Now(),
+	}
+
+	token, err := provider.RefreshDelegatedToken(context.Background(), "refresh-token", userCtx)
+	require.NoError(t, err)
+	assert.NotNil(t, token)
+
+	warnLogs := mockLog.GetLogs("warn")
+	require.GreaterOrEqual(t, len(warnLogs), 1, "expected at least one warn log")
+}

--- a/features/modules/m365/auth/simple_interactive_test.go
+++ b/features/modules/m365/auth/simple_interactive_test.go
@@ -8,6 +8,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/cfgis/cfgms/pkg/logging"
 )
 
 // TestSimpleInteractiveFlow tests basic interactive flow components
@@ -27,7 +29,7 @@ func TestSimpleInteractiveFlow(t *testing.T) {
 		},
 	}
 
-	provider := NewOAuth2Provider(credStore, config)
+	provider := NewOAuth2Provider(credStore, config, logging.NewNoopLogger())
 	flow := NewInteractiveAuthFlow(provider, config)
 	ctx := context.Background()
 

--- a/features/modules/m365/entra_admin_unit/integration_test.go
+++ b/features/modules/m365/entra_admin_unit/integration_test.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/cfgis/cfgms/features/modules/m365/auth"
 	"github.com/cfgis/cfgms/features/modules/m365/graph"
+	"github.com/cfgis/cfgms/pkg/logging"
 	stewardprovider "github.com/cfgis/cfgms/pkg/secrets/providers/steward"
 )
 
@@ -251,7 +252,7 @@ func createRealAuthProvider(t *testing.T) auth.Provider {
 	}
 
 	// Create provider
-	provider := auth.NewOAuth2Provider(credStore, config)
+	provider := auth.NewOAuth2Provider(credStore, config, logging.NewNoopLogger())
 
 	return provider
 }

--- a/features/modules/m365/entra_application/integration_test.go
+++ b/features/modules/m365/entra_application/integration_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/cfgis/cfgms/features/modules/m365/auth"
 	"github.com/cfgis/cfgms/features/modules/m365/graph"
+	"github.com/cfgis/cfgms/pkg/logging"
 	stewardprovider "github.com/cfgis/cfgms/pkg/secrets/providers/steward"
 )
 
@@ -477,7 +478,7 @@ func createRealAuthProvider(t *testing.T) auth.Provider {
 	}
 
 	// Create provider
-	provider := auth.NewOAuth2Provider(credStore, config)
+	provider := auth.NewOAuth2Provider(credStore, config, logging.NewNoopLogger())
 
 	return provider
 }

--- a/features/modules/m365/entra_group/integration_test.go
+++ b/features/modules/m365/entra_group/integration_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/cfgis/cfgms/features/modules/m365/auth"
 	"github.com/cfgis/cfgms/features/modules/m365/graph"
+	"github.com/cfgis/cfgms/pkg/logging"
 	stewardprovider "github.com/cfgis/cfgms/pkg/secrets/providers/steward"
 )
 
@@ -325,7 +326,7 @@ func createRealAuthProvider(t *testing.T) auth.Provider {
 	}
 
 	// Create provider
-	provider := auth.NewOAuth2Provider(credStore, config)
+	provider := auth.NewOAuth2Provider(credStore, config, logging.NewNoopLogger())
 
 	return provider
 }

--- a/features/modules/m365/entra_user/integration_test.go
+++ b/features/modules/m365/entra_user/integration_test.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/cfgis/cfgms/features/modules/m365/auth"
 	"github.com/cfgis/cfgms/features/modules/m365/graph"
+	"github.com/cfgis/cfgms/pkg/logging"
 	stewardprovider "github.com/cfgis/cfgms/pkg/secrets/providers/steward"
 )
 
@@ -333,7 +334,7 @@ func createRealAuthProvider(t *testing.T) auth.Provider {
 	}
 
 	// Create provider
-	provider := auth.NewOAuth2Provider(credStore, config)
+	provider := auth.NewOAuth2Provider(credStore, config, logging.NewNoopLogger())
 
 	return provider
 }


### PR DESCRIPTION
## Summary

- Replace all 6 `fmt.Printf` token-store failure calls in `oauth2_provider.go` with `p.logger.Warn(...)` via injected `logging.Logger`; apply `logging.SanitizeLogValue` to `tenantID` and `userID`
- Replace `fmt.Printf` warning calls in `interactive_auth.go` (server error + user roles) with `ia.logger.Warn(...)`; convert terminal OAuth UX prompts to `_, _ = fmt.Fprintf(os.Stdout, ...)` to preserve interactive UX while satisfying errcheck
- Add `logger logging.Logger` field to `CallbackHandler` (default `logging.NewNoopLogger()`), export `WithLogger` setter (chaining), replace `fmt.Printf` server error with `h.logger.Error(...)`; route pre-existing `_ = err` encoder errors through `h.logger.Error`; `NewCallbackHandler()` signature unchanged; `interactive_flow.go` untouched
- Update all internal and external callers of `NewOAuth2Provider` and `NewInteractiveAuthenticator` to pass `logging.NewNoopLogger()`
- Add three new test files covering logger injection, warn/error routing, and nil-guard behaviour

Fixes #1160

## Test plan

- [ ] `TestOAuth2Provider_tokenStoreFailure_logsError` — construct `OAuth2Provider` with `pkgtesting.NewMockLogger`, trigger token store failure, assert `mock.GetLogs("warn")` has entry with message `"failed to store token"`
- [ ] `TestInteractiveAuthenticator_warning_logsToLogger` — inject mock logger, trigger user-roles failure via 500 from mock graph server, assert `mock.GetLogs("warn")` has `"could not retrieve user roles"`
- [ ] `TestCallbackHandler_WithLogger_routesError` — construct handler, set mock logger, close listener externally (bypasses `ErrServerClosed`), assert `mock.GetLogs("error")` has `"callback server error"`
- [ ] All existing auth package tests continue to pass
- [ ] `make test-agent-complete` passes (all OSS unit tests, integration tests, linting, architecture checks, security scans)

## Specialist review results

**QA Test Runner**: PASS — zero lint issues, all tests green, cross-platform build clean  
**QA Code Reviewer**: PASS — zero blocking issues; all acceptance criteria verified  
**Security Engineer**: PASS — gosec/staticcheck/Trivy/Nancy all clean; `SanitizeLogValue` applied to all user-tainted log values; no new vulnerabilities introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)