### PR TITLE
dataplane: replace *slog.Logger with logging.Logger in grpc provider (Issue #1163)

### DIFF
--- a/pkg/dataplane/providers/grpc/provider.go
+++ b/pkg/dataplane/providers/grpc/provider.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
-	"log/slog"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -14,6 +13,7 @@ import (
 	transportpb "github.com/cfgis/cfgms/api/proto/transport"
 	"github.com/cfgis/cfgms/pkg/dataplane/interfaces"
 	"github.com/cfgis/cfgms/pkg/dataplane/types"
+	"github.com/cfgis/cfgms/pkg/logging"
 	quictransport "github.com/cfgis/cfgms/pkg/transport/quic"
 	"google.golang.org/grpc"
 )
@@ -77,14 +77,14 @@ type Provider struct {
 	stats Stats
 
 	// Logger
-	logger *slog.Logger
+	logger logging.Logger
 }
 
 // New creates a new gRPC data plane provider with defaults.
 func New() *Provider {
 	return &Provider{
 		sessions: make(map[string]*Session),
-		logger:   slog.Default(),
+		logger:   logging.NewNoopLogger(),
 	}
 }
 
@@ -101,7 +101,7 @@ func (p *Provider) Description() string {
 // Config keys:
 //   - "mode": string ("server" or "client") — required
 //   - "tls_config": *tls.Config — required when creating own server or connection
-//   - "logger": *slog.Logger — optional
+//   - "logger": logging.Logger — optional
 //
 // Server mode additional keys:
 //   - "listen_addr": string — required if "grpc_server" not provided
@@ -121,7 +121,7 @@ func (p *Provider) Initialize(_ context.Context, config map[string]interface{}) 
 	}
 	p.mode = mode
 
-	if logger, ok := config["logger"].(*slog.Logger); ok {
+	if logger, ok := config["logger"].(logging.Logger); ok {
 		p.logger = logger
 	}
 
@@ -206,12 +206,13 @@ func (p *Provider) startServer() error {
 			append([]grpc.ServerOption{grpc.Creds(quictransport.TransportCredentials())}, ServerOptions()...)...,
 		)
 
+		srv := p.grpcServer
 		go func() {
-			if err := p.grpcServer.Serve(ql); err != nil {
+			if err := srv.Serve(ql); err != nil {
 				p.logger.Error("gRPC data plane server stopped", "error", err)
 			}
 		}()
-		p.logger.Info("gRPC data plane server started", "addr", p.listenAddr)
+		p.logger.Info("gRPC data plane server started", "addr", logging.SanitizeLogValue(p.listenAddr))
 	} else {
 		// Shared server: the caller (controller) registers the composite handler.
 		p.logger.Info("gRPC data plane attached to existing gRPC server")
@@ -236,7 +237,7 @@ func (p *Provider) startClient() error {
 	}
 	p.grpcClient = transportpb.NewStewardTransportClient(p.grpcConn)
 	p.started.Store(true)
-	p.logger.Info("gRPC data plane client ready", "steward_id", p.stewardID)
+	p.logger.Info("gRPC data plane client ready", "steward_id", logging.SanitizeLogValue(p.stewardID))
 	return nil
 }
 
@@ -343,7 +344,7 @@ func (p *Provider) Connect(ctx context.Context, serverAddr string) (interfaces.D
 
 	p.logger.Debug("gRPC data plane client session created",
 		"session_id", sessionID,
-		"steward_id", p.stewardID)
+		"steward_id", logging.SanitizeLogValue(p.stewardID))
 	return s, nil
 }
 

--- a/pkg/dataplane/providers/grpc/provider_test.go
+++ b/pkg/dataplane/providers/grpc/provider_test.go
@@ -10,7 +10,10 @@ import (
 	"testing"
 
 	transportpb "github.com/cfgis/cfgms/api/proto/transport"
+	cfgcert "github.com/cfgis/cfgms/pkg/cert"
 	"github.com/cfgis/cfgms/pkg/dataplane/interfaces"
+	pkgtesting "github.com/cfgis/cfgms/pkg/testing"
+	quictransport "github.com/cfgis/cfgms/pkg/transport/quic"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
@@ -18,6 +21,40 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/status"
 )
+
+// newTestServerTLSConfig creates a self-signed TLS config suitable for starting
+// the QUIC listener in tests. Uses cfgcert.NewCA to avoid static test certs.
+func newTestServerTLSConfig(t *testing.T) *tls.Config {
+	t.Helper()
+
+	ca, err := cfgcert.NewCA(&cfgcert.CAConfig{
+		Organization: "CFGMS Test",
+		Country:      "US",
+		ValidityDays: 1,
+		KeySize:      2048,
+	})
+	require.NoError(t, err)
+	require.NoError(t, ca.Initialize(nil))
+
+	caPEM, err := ca.GetCACertificate()
+	require.NoError(t, err)
+
+	serverCert, err := ca.GenerateServerCertificate(&cfgcert.ServerCertConfig{
+		CommonName:   "localhost",
+		DNSNames:     []string{"localhost"},
+		ValidityDays: 1,
+		KeySize:      2048,
+	})
+	require.NoError(t, err)
+
+	serverTLS, err := cfgcert.CreateServerTLSConfig(
+		serverCert.CertificatePEM, serverCert.PrivateKeyPEM,
+		caPEM, tls.VersionTLS13,
+	)
+	require.NoError(t, err)
+	serverTLS.NextProtos = []string{quictransport.ALPNProtocol}
+	return serverTLS
+}
 
 // TestProvider_Registration verifies the provider registers itself as "grpc" via init().
 func TestProvider_Registration(t *testing.T) {
@@ -245,4 +282,92 @@ type dosLimitTestHandler struct {
 func (h *dosLimitTestHandler) SyncDNA(stream grpc.ClientStreamingServer[transportpb.DNAChunk, transportpb.DNASyncResponse]) error {
 	_, err := stream.Recv()
 	return err
+}
+
+// TestDataPlaneProvider_Start_server_logsStarted verifies that Start() in server mode
+// emits an info log with message "gRPC data plane server started".
+func TestDataPlaneProvider_Start_server_logsStarted(t *testing.T) {
+	mock := pkgtesting.NewMockLogger(true)
+	serverTLS := newTestServerTLSConfig(t)
+
+	p := New()
+	err := p.Initialize(context.Background(), map[string]interface{}{
+		"mode":        "server",
+		"listen_addr": "127.0.0.1:0",
+		"tls_config":  serverTLS,
+		"logger":      mock,
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, p.Start(context.Background()))
+	t.Cleanup(func() { assert.NoError(t, p.Stop(context.Background())) })
+
+	infoLogs := mock.GetLogs("info")
+	found := false
+	for _, entry := range infoLogs {
+		if entry.Message == "gRPC data plane server started" {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found, "expected info log 'gRPC data plane server started', got: %v", infoLogs)
+}
+
+// TestDataPlaneProvider_Stop_logsStop verifies that Stop() emits an info log
+// with message "gRPC data plane provider stopped".
+func TestDataPlaneProvider_Stop_logsStop(t *testing.T) {
+	mock := pkgtesting.NewMockLogger(true)
+	serverTLS := newTestServerTLSConfig(t)
+
+	p := New()
+	err := p.Initialize(context.Background(), map[string]interface{}{
+		"mode":        "server",
+		"listen_addr": "127.0.0.1:0",
+		"tls_config":  serverTLS,
+		"logger":      mock,
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, p.Start(context.Background()))
+	require.NoError(t, p.Stop(context.Background()))
+
+	infoLogs := mock.GetLogs("info")
+	found := false
+	for _, entry := range infoLogs {
+		if entry.Message == "gRPC data plane provider stopped" {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found, "expected info log 'gRPC data plane provider stopped', got: %v", infoLogs)
+}
+
+// TestDataPlaneProvider_Initialize_injectsLogger verifies that Initialize() correctly
+// stores the injected logging.Logger and that it is used for subsequent log calls.
+// This exercises the `config["logger"].(logging.Logger)` type assertion path.
+func TestDataPlaneProvider_Initialize_injectsLogger(t *testing.T) {
+	mock := pkgtesting.NewMockLogger(true)
+	p := New()
+	err := p.Initialize(context.Background(), map[string]interface{}{
+		"mode":        "server",
+		"listen_addr": "127.0.0.1:0",
+		"tls_config":  &tls.Config{MinVersion: tls.VersionTLS13}, //nolint:gosec // test config
+		"logger":      mock,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, mock, p.logger, "Initialize must store the injected logging.Logger")
+}
+
+// TestDataPlaneProvider_Initialize_noopLoggerDefault verifies that New() initialises the
+// logger field to a non-nil NoopLogger (not slog.Default()) so that callers who
+// do not inject a logger get silent behaviour rather than a panic or global slog output.
+func TestDataPlaneProvider_Initialize_noopLoggerDefault(t *testing.T) {
+	p := New()
+	assert.NotNil(t, p.logger, "New() must initialise logger to a non-nil NoopLogger")
+	// A NoopLogger absorbs all calls without panicking.
+	assert.NotPanics(t, func() {
+		p.logger.Info("test", "key", "value")
+		p.logger.Error("test error", "key", "value")
+		p.logger.Debug("test debug", "key", "value")
+	})
 }


### PR DESCRIPTION
## Summary

- Replaces `*slog.Logger` field with `logging.Logger` in `pkg/dataplane/providers/grpc/provider.go`, routing all 7 operational log call sites through the `pkg/logging` central provider
- Removes `"log/slog"` import; adds `"github.com/cfgis/cfgms/pkg/logging"`
- Applies `logging.SanitizeLogValue()` to `p.listenAddr` and `p.stewardID` at every log call site
- Fixes a goroutine data race: captures `srv := p.grpcServer` before the goroutine closure so `Stop()` cannot nil the field while `Serve()` runs
- Adds 4 tests in `provider_test.go` covering logger injection, NoopLogger default, server start log, and stop log

Fixes #1163

## Specialist Review Results

**QA Test Runner**: PASS — all unit tests, integration tests, architecture checks, security scans, and cross-platform builds passing

**QA Code Reviewer**: PASS — no blocking issues; confirmed MockLogger use is a test-utility capture buffer (required by AC), cleanup error checked with `assert.NoError`, error-path coverage added via `TestDataPlaneProvider_Initialize_injectsLogger`

**Security Engineer**: PASS — no blocking issues; `logging.SanitizeLogValue` correctly applied to user-controlled fields; goroutine race fix confirmed; no hardcoded secrets, SQL injection, or central provider violations

## Test plan

- [ ] `grep -n '"log/slog"' pkg/dataplane/providers/grpc/provider.go` → zero results
- [ ] `grep -n 'slog\.' pkg/dataplane/providers/grpc/provider.go` → zero results  
- [ ] `go test ./pkg/dataplane/providers/grpc/...` passes including the two required tests
- [ ] `make check-architecture` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)