### PR TITLE
audit: replace tautological RecordEvent/RecordBatch tests with readback assertions (Issue #1168)

### DIFF
--- a/pkg/audit/manager_test.go
+++ b/pkg/audit/manager_test.go
@@ -248,7 +248,9 @@ func TestNewManager_ErrorConditions(t *testing.T) {
 	}
 }
 
-// TestManager_RecordEvent tests basic event recording
+// TestManager_RecordEvent verifies that RecordEvent persists the event to the
+// store. It calls flushOrFail to drain the async queue before reading back, so
+// the test fails if RecordEvent silently discards the event.
 func TestManager_RecordEvent(t *testing.T) {
 	manager := newTestManager(t, "test")
 	ctx := context.Background()
@@ -262,11 +264,19 @@ func TestManager_RecordEvent(t *testing.T) {
 		Detail("test_key", "test_value").
 		Severity(business.AuditSeverityMedium)
 
-	err := manager.RecordEvent(ctx, event)
-	assert.NoError(t, err)
+	require.NoError(t, manager.RecordEvent(ctx, event))
+	flushOrFail(t, manager)
+
+	entries, err := manager.QueryEntries(ctx, &business.AuditFilter{TenantID: "test-tenant"})
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+	assert.Equal(t, "test_action", entries[0].Action)
+	assert.Equal(t, "test-tenant", entries[0].TenantID)
 }
 
-// TestManager_RecordBatch tests batch event recording
+// TestManager_RecordBatch verifies that RecordBatch persists all events to the
+// store. It calls flushOrFail to drain the async queue before reading back, so
+// the test fails if RecordBatch silently discards events.
 func TestManager_RecordBatch(t *testing.T) {
 	manager := newTestManager(t, "test")
 	ctx := context.Background()
@@ -288,8 +298,19 @@ func TestManager_RecordBatch(t *testing.T) {
 			Severity(business.AuditSeverityMedium),
 	}
 
-	err := manager.RecordBatch(ctx, events)
-	assert.NoError(t, err)
+	require.NoError(t, manager.RecordBatch(ctx, events))
+	flushOrFail(t, manager)
+
+	entries, err := manager.QueryEntries(ctx, &business.AuditFilter{TenantID: "test-tenant"})
+	require.NoError(t, err)
+	require.Len(t, entries, 2)
+
+	actions := make(map[string]bool, len(entries))
+	for _, e := range entries {
+		actions[e.Action] = true
+	}
+	assert.True(t, actions["login"], "expected entry with Action=login")
+	assert.True(t, actions["config_update"], "expected entry with Action=config_update")
 }
 
 // TestManager_ValidationErrors tests validation error handling


### PR DESCRIPTION
## Summary

- Replace `TestManager_RecordEvent` and `TestManager_RecordBatch` in `pkg/audit/manager_test.go` with store-readback assertions
- Both tests now call `flushOrFail(t, manager)` then `manager.QueryEntries` to verify events actually reached the store
- Tests now fail if `RecordEvent`/`RecordBatch` silently discard events (the tautological gap they had before)

## Changes

**`pkg/audit/manager_test.go`** (only file changed):
- `TestManager_RecordEvent`: after RecordEvent + flushOrFail, asserts 1 entry with `Action=="test_action"` and `TenantID=="test-tenant"`
- `TestManager_RecordBatch`: after RecordBatch + flushOrFail, asserts exactly 2 entries with Actions `"login"` and `"config_update"` (order-independent set check)

No production source files modified. No new dependencies.

## Specialist Review Results

- **QA Test Runner**: PASS — all 31 pkg/audit tests pass, full test suite clean, cross-platform builds verified, marker written to /tmp/agent-validation-passed
- **QA Code Reviewer**: PASS — no blocking issues; 2 pre-existing warnings (not introduced by this change)
- **Security Engineer**: PASS — security-precommit, check-architecture, security-scan all PASS; no new security issues

## Test Plan

- [x] `TestManager_RecordEvent` passes with readback assertion
- [x] `TestManager_RecordBatch` passes with readback assertion
- [x] All other pkg/audit tests unaffected (31 total, all pass)
- [x] `make test-agent-complete` passes

Fixes #1168

🤖 Generated with [Claude Code](https://claude.com/claude-code)