### PR TITLE
ha: replace tautological env-var echo test with constraint-validation test (Issue #1170)

### DIFF
--- a/commercial/ha/manager_test.go
+++ b/commercial/ha/manager_test.go
@@ -301,24 +301,22 @@ func TestManager_ConfigValidation(t *testing.T) {
 	assert.Contains(t, err.Error(), "min quorum must be between 1 and expected size")
 }
 
-func TestConfig_LoadFromEnvironment(t *testing.T) {
-	cfg := DefaultConfig()
-
-	// Set environment variables
-	t.Setenv("CFGMS_HA_MODE", "cluster")
-	t.Setenv("CFGMS_NODE_ID", "test-node-123")
-	t.Setenv("CFGMS_HA_NODE_NAME", "test-controller")
-	t.Setenv("CFGMS_HA_CLUSTER_SIZE", "5")
-	t.Setenv("CFGMS_HA_MIN_QUORUM", "3")
-
-	err := cfg.LoadFromEnvironment()
+func TestConfig_LoadFromEnvironment_InvalidQuorum(t *testing.T) {
+	logger := logging.GetLogger()
+	storageManager, err := storage.CreateTestStorageManager()
 	require.NoError(t, err)
 
-	assert.Equal(t, ClusterMode, cfg.Mode)
-	assert.Equal(t, "test-node-123", cfg.Node.ID)
-	assert.Equal(t, "test-controller", cfg.Node.Name)
-	assert.Equal(t, 5, cfg.Cluster.ExpectedSize)
-	assert.Equal(t, 3, cfg.Cluster.MinQuorum)
+	t.Setenv("CFGMS_HA_MODE", "cluster")
+	t.Setenv("CFGMS_NODE_ID", "test-node")
+	t.Setenv("CFGMS_HA_CLUSTER_SIZE", "3")
+	t.Setenv("CFGMS_HA_MIN_QUORUM", "5")
+
+	cfg := DefaultConfig()
+	require.NoError(t, cfg.LoadFromEnvironment())
+
+	_, err = NewManager(cfg, logger, storageManager)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "quorum")
 }
 
 func TestDeploymentModeProgression(t *testing.T) {


### PR DESCRIPTION
## Summary

- Deleted `TestConfig_LoadFromEnvironment` from `commercial/ha/manager_test.go` — it only asserted env vars round-tripped into config fields (no validation, no behaviour)
- Added `TestConfig_LoadFromEnvironment_InvalidQuorum`: sets `CFGMS_HA_MODE=cluster`, `CFGMS_NODE_ID=test-node`, `CFGMS_HA_CLUSTER_SIZE=3`, `CFGMS_HA_MIN_QUORUM=5` via `t.Setenv`, calls `cfg.LoadFromEnvironment()` then `NewManager()`, and asserts the returned error contains `"quorum"` — exercising the real constraint enforced by `Validate()` inside `NewManager`

Fixes #1170

## Specialist Review Results

**QA Test Runner: PASS**
- All quality validation gates passed
- `TestConfig_LoadFromEnvironment_InvalidQuorum` in `commercial/ha` package: PASS
- Cross-platform compilation (linux/amd64, linux/arm64, darwin, windows): PASS
- golangci-lint, license headers, staticcheck: PASS

**QA Code Reviewer: PASS (for story-scoped changes)**
- New test uses real components, meaningful assertions, tests a real error path
- Blocking issues reported are all pre-existing in the file and explicitly out of scope per the story definition ("Out of Scope: All other tests in commercial/ha/manager_test.go")

**Security Engineer: PASS**
- No hardcoded secrets, no SQL injection, no information disclosure
- No central provider violations
- `security-precommit`, `check-architecture`, `security-scan` all PASS

## Test plan

- [ ] `go test -tags commercial -run TestConfig_LoadFromEnvironment_InvalidQuorum ./commercial/ha/...` → PASS
- [ ] `grep -n "^func TestConfig_LoadFromEnvironment\b" commercial/ha/manager_test.go` → zero matches
- [ ] `make test-agent-complete` → PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)