### PR TITLE
test: replace pkg/cert IsValid tautologies with ValidateCertificate calls (Issue #1173)

### DIFF
--- a/pkg/cert/ca_test.go
+++ b/pkg/cert/ca_test.go
@@ -132,8 +132,11 @@ func TestCA_GenerateServerCertificate(t *testing.T) {
 	assert.NotEmpty(t, cert.SerialNumber)
 	assert.NotEmpty(t, cert.CertificatePEM)
 	assert.NotEmpty(t, cert.PrivateKeyPEM)
-	assert.True(t, cert.IsValid)
 	assert.NotEmpty(t, cert.Fingerprint)
+
+	serverResult, err := ca.ValidateCertificate(cert.CertificatePEM)
+	require.NoError(t, err)
+	assert.True(t, serverResult.IsValid)
 
 	// Parse and verify the generated certificate
 	x509Cert, err := ParseCertificateFromPEM(cert.CertificatePEM)
@@ -194,8 +197,11 @@ func TestCA_GenerateClientCertificate(t *testing.T) {
 	assert.NotEmpty(t, cert.SerialNumber)
 	assert.NotEmpty(t, cert.CertificatePEM)
 	assert.NotEmpty(t, cert.PrivateKeyPEM)
-	assert.True(t, cert.IsValid)
 	assert.NotEmpty(t, cert.Fingerprint)
+
+	clientResult, err := ca.ValidateCertificate(cert.CertificatePEM)
+	require.NoError(t, err)
+	assert.True(t, clientResult.IsValid)
 
 	// Parse and verify the generated certificate
 	x509Cert, err := ParseCertificateFromPEM(cert.CertificatePEM)
@@ -332,7 +338,6 @@ func TestCA_GetCAInfo(t *testing.T) {
 	assert.Equal(t, "Test CA Root CA", info.CommonName)
 	assert.NotEmpty(t, info.SerialNumber)
 	assert.NotEmpty(t, info.Fingerprint)
-	assert.True(t, info.IsValid)
 	assert.Greater(t, info.DaysUntilExpiration, 0)
 	assert.Equal(t, info.CommonName, info.Issuer) // Self-signed
 }

--- a/pkg/cert/manager_test.go
+++ b/pkg/cert/manager_test.go
@@ -131,7 +131,10 @@ func TestManager_GenerateServerCertificate(t *testing.T) {
 	assert.NotEmpty(t, cert.SerialNumber)
 	assert.NotEmpty(t, cert.CertificatePEM)
 	assert.NotEmpty(t, cert.PrivateKeyPEM)
-	assert.True(t, cert.IsValid)
+
+	serverResult, err := manager.ValidateCertificate(cert.CertificatePEM)
+	require.NoError(t, err)
+	assert.True(t, serverResult.IsValid)
 
 	// Verify certificate is stored
 	storedCert, err := manager.GetCertificate(cert.SerialNumber)
@@ -178,7 +181,10 @@ func TestManager_GenerateClientCertificate(t *testing.T) {
 	assert.NotEmpty(t, cert.SerialNumber)
 	assert.NotEmpty(t, cert.CertificatePEM)
 	assert.NotEmpty(t, cert.PrivateKeyPEM)
-	assert.True(t, cert.IsValid)
+
+	clientResult, err := manager.ValidateCertificate(cert.CertificatePEM)
+	require.NoError(t, err)
+	assert.True(t, clientResult.IsValid)
 
 	// Verify certificate is stored
 	storedCert, err := manager.GetCertificate(cert.SerialNumber)

--- a/pkg/cert/signing_test.go
+++ b/pkg/cert/signing_test.go
@@ -31,8 +31,11 @@ func TestGenerateSigningCertificate_Properties(t *testing.T) {
 	assert.NotEmpty(t, cert.SerialNumber)
 	assert.NotEmpty(t, cert.CertificatePEM)
 	assert.NotEmpty(t, cert.PrivateKeyPEM)
-	assert.True(t, cert.IsValid)
 	assert.NotEmpty(t, cert.Fingerprint)
+
+	result, err := ca.ValidateCertificate(cert.CertificatePEM)
+	require.NoError(t, err)
+	assert.True(t, result.IsValid)
 
 	// Parse and verify x509 properties
 	x509Cert, err := ParseCertificateFromPEM(cert.CertificatePEM)
@@ -151,17 +154,6 @@ func TestGenerateInternalServerCertificate(t *testing.T) {
 	require.NoError(t, err)
 	err = x509Cert.CheckSignatureFrom(caCert)
 	assert.NoError(t, err)
-}
-
-// TestCertificateTypeEnumStability ensures explicit type values never change
-// (prevents metadata.json corruption from iota reordering)
-func TestCertificateTypeEnumStability(t *testing.T) {
-	assert.Equal(t, CertificateType(0), CertificateTypeCA, "CA must be 0")
-	assert.Equal(t, CertificateType(1), CertificateTypeServer, "Server must be 1")
-	assert.Equal(t, CertificateType(2), CertificateTypeClient, "Client must be 2")
-	assert.Equal(t, CertificateType(3), CertificateTypePublicAPI, "PublicAPI must be 3")
-	assert.Equal(t, CertificateType(4), CertificateTypeInternalServer, "InternalServer must be 4")
-	assert.Equal(t, CertificateType(5), CertificateTypeConfigSigning, "ConfigSigning must be 5")
 }
 
 // TestCertificateTypeString verifies String() for all types


### PR DESCRIPTION
## Summary

- Deletes `TestCertificateTypeEnumStability` (integer-literal equality guaranteed by explicit constant values — no protection against anything)
- Replaces five `assert.True(t, cert.IsValid)` tautologies with real `ValidateCertificate()` API calls that perform CA-chain verification in `signing_test.go`, `ca_test.go`, and `manager_test.go`
- Removes redundant `assert.True(t, info.IsValid)` in `TestCA_GetCAInfo` — the immediately following `assert.Greater(t, info.DaysUntilExpiration, 0)` already proves the same property more explicitly

Fixes #1173

## Specialist Review Results

| Specialist | Result |
|-----------|--------|
| QA Test Runner (`make test-agent-complete`) | **PASS** — all pkg/cert tests pass, cross-platform builds pass, security scans pass, lint clean |
| QA Code Reviewer | Raised two findings: (1) `info.IsValid` deletion — directly addressed by acceptance criteria which explicitly requires the deletion (DaysUntilExpiration covers it); (2) `time.Sleep` in TestManager_CertificateRenewal — pre-existing code in an untouched function, out of scope |
| Security Engineer | **PASS** — no secrets, no central provider violations, gosec/staticcheck/go vet clean (7 pre-existing gosec findings unrelated to this story) |

## Test Plan

- [x] `grep -n "TestCertificateTypeEnumStability" pkg/cert/signing_test.go` returns zero matches
- [x] All five tautological `assert.True(t, cert.IsValid)` replaced with `ValidateCertificate()` calls
- [x] `TestCA_GetCAInfo` no longer asserts `info.IsValid`; `DaysUntilExpiration > 0` remains
- [x] `go test ./pkg/cert/...` passes (7.759s, all tests green)
- [x] Cross-platform compilation passes (linux/amd64, linux/arm64, darwin/amd64, darwin/arm64, windows/amd64)

🤖 Generated with [Claude Code](https://claude.com/claude-code)