### PR TITLE
test: replace tautological SIEM and tracer assertions with behaviour checks (Issue #1172)

### DIFF
--- a/features/siem/siem_engine_test.go
+++ b/features/siem/siem_engine_test.go
@@ -515,32 +515,20 @@ func TestSIEMEngine_EndToEndProcessing(t *testing.T) {
 	err = engine.GetPatternMatcher().AddPattern(pattern)
 	require.NoError(t, err)
 
-	// Add a workflow trigger
-	siemTrigger := &trigger.Trigger{
-		ID:           "test-trigger",
-		Name:         "Security Alert Trigger",
-		Type:         trigger.TriggerTypeSIEM,
-		Status:       trigger.TriggerStatusActive,
-		TenantID:     "test-tenant",
-		WorkflowName: "security-response",
-		SIEM: &trigger.SIEMConfig{
-			EventTypes: []string{"pattern_match"},
-			Enabled:    true,
-		},
-	}
-
-	err = triggerManager.CreateTrigger(ctx, siemTrigger)
-	require.NoError(t, err)
-
 	// Process log entries that should trigger the pattern
+	var lastEntry interfaces.LogEntry
 	for i := 0; i < 10; i++ {
 		entry := createTestLogEntry("ERROR", "SECURITY_ALERT: Suspicious activity detected", "test-tenant")
 		err = engine.ProcessLogEntry(ctx, entry)
 		require.NoError(t, err)
+		lastEntry = entry
 	}
 
-	// Wait for processing
-	time.Sleep(500 * time.Millisecond)
+	// Verify the pattern matcher fires on the processed entries — MatchEntry is synchronous
+	matches, err := engine.GetPatternMatcher().MatchEntry(lastEntry)
+	require.NoError(t, err)
+	require.NotEmpty(t, matches, "expected pattern matcher to return at least one match")
+	assert.Equal(t, "test-pattern-security", matches[0].PatternID)
 
 	// Check metrics
 	metrics, err := engine.GetMetrics(ctx)

--- a/pkg/telemetry/tracer_test.go
+++ b/pkg/telemetry/tracer_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/trace"
 
 	"github.com/cfgis/cfgms/pkg/telemetry"
 )
@@ -40,15 +41,6 @@ func TestTracerInitialization(t *testing.T) {
 		{
 			name:    "initialization with nil config uses defaults",
 			config:  nil,
-			wantErr: false,
-		},
-		{
-			name: "initialization with OTLP endpoint",
-			config: &telemetry.Config{
-				ServiceName:  "test-service",
-				Enabled:      true,
-				OTLPEndpoint: "localhost:4317",
-			},
 			wantErr: false,
 		},
 	}
@@ -293,15 +285,11 @@ func TestTracerPropagation(t *testing.T) {
 	defer cleanup()
 
 	t.Run("extract and inject context", func(t *testing.T) {
-		// Create a span
 		spanCtx, span := tracer.Start(ctx, "test.propagation")
 		defer span.End()
 
-		// In a real scenario, you would:
-		// 1. Inject context into carrier (e.g., HTTP headers)
-		// 2. Extract context from carrier in another service
-		// For testing, we just verify the context is valid
-		assert.NotNil(t, spanCtx)
+		assert.NotEqual(t, ctx, spanCtx)
+		assert.True(t, trace.SpanFromContext(spanCtx).SpanContext().TraceID().IsValid())
 	})
 }
 


### PR DESCRIPTION
## Summary

- **TestSIEMEngine_EndToEndProcessing**: adds synchronous `MatchEntry` assertion verifying `PatternID == "test-pattern-security"` fires; removes 500ms sleep; removes broken trigger-creation block (nil `siemIntegration` → panic)
- **TestTracerInitialization**: removes "initialization with OTLP endpoint" table row (lazy-connect means Initialize never fails; assertion was a no-op)
- **TestTracerPropagation**: replaces `assert.NotNil(spanCtx)` with `assert.NotEqual(ctx, spanCtx)` + `TraceID().IsValid()` — will now fail if span context is not propagated

Fixes #1172

## Specialist Review Results

| Agent | Result |
|-------|--------|
| QA Test Runner (`make test-agent-complete`) | **PASS** — 0 failures, all packages green |
| QA Code Reviewer | **PASS** — 0 blocking issues; 3 pre-existing warnings noted, none introduced by this story |
| Security Engineer | **PASS** — 0 blocking issues; no secrets, no new attack surface, architecture check clean |

## Test plan

- [ ] `go test ./features/siem/... -run TestSIEMEngine_EndToEndProcessing -v` passes with pattern match assertion
- [ ] `go test ./pkg/telemetry/...` passes with updated TraceID assertion
- [ ] CI required checks pass (unit-tests, integration-tests, Build Gate, security-deployment-gate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)