### PR TITLE
test: add pkg/version Short() tests and pkg/maintenance window-limitation tests (Issue #1174)

### DIFF
--- a/pkg/maintenance/window_test.go
+++ b/pkg/maintenance/window_test.go
@@ -239,6 +239,54 @@ func TestManager_CanReboot_InWindow(t *testing.T) {
 	assert.True(t, canReboot, "Should allow reboot when inside maintenance window")
 }
 
+func TestManager_CanReboot_DeferWithMaxDeferDays(t *testing.T) {
+	// MaxDeferDays=7 is set but currently not evaluated by CanReboot — this test documents the known limitation.
+	policy := maintenance.Policy{
+		Enabled:       true,
+		DefaultAction: "defer",
+		Windows: []maintenance.Window{
+			{
+				MaxDeferDays: 7,
+				Schedule:     "test_schedule",
+				Duration:     time.Hour,
+			},
+		},
+	}
+	manager := maintenance.NewManager(policy, nil)
+
+	ctx := context.Background()
+	canReboot, err := manager.CanReboot(ctx, "device-1")
+
+	require.NoError(t, err)
+	assert.False(t, canReboot, "Should defer reboot; MaxDeferDays field is not evaluated by CanReboot")
+}
+
+func TestDefaultParser_Daily2AM_IgnoresDuration(t *testing.T) {
+	// defaultParser.IsInSchedule hardcodes "hour >= 2 && hour < 4" and never reads Window.Duration.
+	// We prove Duration is ignored by showing two managers with different Duration values always
+	// return identical results — regardless of what time CI runs this test.
+	ctx := context.Background()
+
+	managerShort := maintenance.NewManager(maintenance.Policy{
+		Enabled: true,
+		Windows: []maintenance.Window{{Schedule: "daily_2am", Duration: 30 * time.Minute}},
+	}, nil)
+
+	managerLong := maintenance.NewManager(maintenance.Policy{
+		Enabled: true,
+		Windows: []maintenance.Window{{Schedule: "daily_2am", Duration: 4 * time.Hour}},
+	}, nil)
+
+	shortResult, err := managerShort.IsInWindow(ctx, "device-1")
+	require.NoError(t, err)
+
+	longResult, err := managerLong.IsInWindow(ctx, "device-1")
+	require.NoError(t, err)
+
+	// Duration has no effect: both managers return the same result at any clock time.
+	assert.Equal(t, shortResult, longResult, "Duration field has no effect on defaultParser IsInWindow")
+}
+
 // mockScheduleParser is a mock implementation of ScheduleParser for testing
 type mockScheduleParser struct {
 	isInSchedule bool

--- a/pkg/version/version_test.go
+++ b/pkg/version/version_test.go
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+package version
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestShort_PrependV(t *testing.T) {
+	orig := Version
+	t.Cleanup(func() { Version = orig })
+	Version = "0.5.0-dev"
+
+	assert.Equal(t, "v0.5.0-dev", Short())
+}
+
+func TestShort_NoPrependWhenVPresent(t *testing.T) {
+	orig := Version
+	t.Cleanup(func() { Version = orig })
+	Version = "v1.0.0"
+
+	assert.Equal(t, "v1.0.0", Short())
+}
+
+func TestShortWithoutPrefix_StripsV(t *testing.T) {
+	orig := Version
+	t.Cleanup(func() { Version = orig })
+	Version = "v1.0.0"
+
+	assert.Equal(t, "1.0.0", ShortWithoutPrefix())
+}
+
+func TestShortWithoutPrefix_NoPrefix(t *testing.T) {
+	orig := Version
+	t.Cleanup(func() { Version = orig })
+	Version = "1.0.0"
+
+	assert.Equal(t, "1.0.0", ShortWithoutPrefix())
+}


### PR DESCRIPTION
## Summary

- Add `pkg/version/version_test.go` (new) with 4 tests covering `Short()` and `ShortWithoutPrefix()` behavior
- Add `TestManager_CanReboot_DeferWithMaxDeferDays` to `pkg/maintenance/window_test.go` documenting that `MaxDeferDays` on `Window` is not currently evaluated by `CanReboot`
- Add `TestDefaultParser_Daily2AM_IgnoresDuration` to `pkg/maintenance/window_test.go` documenting that `defaultParser` hardcodes its schedule window and ignores `Window.Duration`

Fixes #1174

## Test plan

- [ ] `pkg/version`: TestShort_PrependV, TestShort_NoPrependWhenVPresent, TestShortWithoutPrefix_StripsV, TestShortWithoutPrefix_NoPrefix — all pass with `-race`
- [ ] `pkg/maintenance`: TestManager_CanReboot_DeferWithMaxDeferDays, TestDefaultParser_Daily2AM_IgnoresDuration — all pass with `-race`
- [ ] `make test-agent-complete` — all packages pass

## Specialist Review Results

**QA Test Runner: PASS** — All quality validation gates passed; both new packages verified passing with race detection.

**QA Code Reviewer: PASS** — 0 blocking issues, 0 warnings. Version tests capture original value before mutation; maintenance Duration test is deterministic (compares two managers, no clock dependency).

**Security Engineer: PASS** — 0 blocking issues, 0 warnings. Test-only changes; no secrets, SQL, TLS, or central provider violations. All automated scans (security-precommit, check-architecture, security-scan) passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)