### PR TITLE
config: route fmt.Printf and log.Printf through pkg/logging across features/config (Issue #1158)

### DIFF
--- a/features/config/diff/approval.go
+++ b/features/config/diff/approval.go
@@ -8,6 +8,8 @@ import (
 	"crypto/rand"
 	"fmt"
 	"time"
+
+	"github.com/cfgis/cfgms/pkg/logging"
 )
 
 // DefaultApprovalIntegration implements the ApprovalIntegration interface
@@ -21,14 +23,20 @@ type DefaultApprovalIntegration struct {
 
 	// defaultExpiry is the default expiration time for approval requests
 	defaultExpiry time.Duration
+
+	logger logging.Logger
 }
 
 // NewDefaultApprovalIntegration creates a new DefaultApprovalIntegration
-func NewDefaultApprovalIntegration() *DefaultApprovalIntegration {
+func NewDefaultApprovalIntegration(logger logging.Logger) *DefaultApprovalIntegration {
+	if logger == nil {
+		logger = logging.NewNoopLogger()
+	}
 	return &DefaultApprovalIntegration{
 		requests:      make(map[string]*ApprovalRequest),
 		approvers:     initializeDefaultApprovers(),
 		defaultExpiry: 24 * time.Hour, // 24 hours default
+		logger:        logger,
 	}
 }
 
@@ -68,9 +76,10 @@ func (ai *DefaultApprovalIntegration) CreateApprovalRequest(ctx context.Context,
 
 	// Send notifications to approvers
 	if err := ai.notifyApprovers(ctx, request); err != nil {
-		// Log warning but don't fail the request creation
-		// In a real implementation, this would use proper logging
-		fmt.Printf("Warning: Failed to notify approvers: %v\n", err)
+		ai.logger.Warn("failed to notify approvers",
+			"request_id", logging.SanitizeLogValue(request.ID),
+			"error", err,
+		)
 	}
 
 	return request, nil
@@ -95,7 +104,10 @@ func (ai *DefaultApprovalIntegration) UpdateApprovalRequest(ctx context.Context,
 
 	// Notify approvers of the update
 	if err := ai.notifyApproversOfUpdate(ctx, request); err != nil {
-		fmt.Printf("Warning: Failed to notify approvers of update: %v\n", err)
+		ai.logger.Warn("failed to notify approvers of update",
+			"request_id", logging.SanitizeLogValue(requestID),
+			"error", err,
+		)
 	}
 
 	return nil
@@ -135,7 +147,10 @@ func (ai *DefaultApprovalIntegration) CancelApprovalRequest(ctx context.Context,
 
 	// Notify approvers of cancellation
 	if err := ai.notifyApproversOfCancellation(ctx, request); err != nil {
-		fmt.Printf("Warning: Failed to notify approvers of cancellation: %v\n", err)
+		ai.logger.Warn("failed to notify approvers of cancellation",
+			"request_id", logging.SanitizeLogValue(requestID),
+			"error", err,
+		)
 	}
 
 	return nil
@@ -368,20 +383,26 @@ func (ai *DefaultApprovalIntegration) allApproved(request *ApprovalRequest) bool
 // notifyApprovers sends notifications to required approvers
 func (ai *DefaultApprovalIntegration) notifyApprovers(ctx context.Context, request *ApprovalRequest) error {
 	// In a real implementation, this would send emails, Slack messages, etc.
-	fmt.Printf("Notifying approvers %v for request %s: %s\n",
-		request.RequiredApprovers, request.ID, request.Title)
+	ai.logger.Info("notifying approvers",
+		"request_id", logging.SanitizeLogValue(request.ID),
+		"approver_count", len(request.RequiredApprovers),
+	)
 	return nil
 }
 
 // notifyApproversOfUpdate notifies approvers of request updates
 func (ai *DefaultApprovalIntegration) notifyApproversOfUpdate(ctx context.Context, request *ApprovalRequest) error {
-	fmt.Printf("Notifying approvers of update for request %s\n", request.ID)
+	ai.logger.Info("notifying approvers of update",
+		"request_id", logging.SanitizeLogValue(request.ID),
+	)
 	return nil
 }
 
 // notifyApproversOfCancellation notifies approvers of request cancellation
 func (ai *DefaultApprovalIntegration) notifyApproversOfCancellation(ctx context.Context, request *ApprovalRequest) error {
-	fmt.Printf("Notifying approvers of cancellation for request %s\n", request.ID)
+	ai.logger.Info("notifying approvers of cancellation",
+		"request_id", logging.SanitizeLogValue(request.ID),
+	)
 	return nil
 }
 

--- a/features/config/diff/approval_test.go
+++ b/features/config/diff/approval_test.go
@@ -1,0 +1,131 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+package diff
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	pkgtesting "github.com/cfgis/cfgms/pkg/testing"
+)
+
+func TestNewDefaultApprovalIntegration_nilLogger_usesNoop(t *testing.T) {
+	ai := NewDefaultApprovalIntegration(nil)
+	require.NotNil(t, ai)
+	// Verify no panic on usage
+	ctx := context.Background()
+	result := &ComparisonResult{
+		FromRef: ConfigurationReference{Commit: "abc12345"},
+		ToRef:   ConfigurationReference{Commit: "def67890"},
+		Summary: DiffSummary{TotalChanges: 1},
+	}
+	assessment := &RiskAssessment{
+		OverallRisk: ImpactLevelLow,
+	}
+	req, err := ai.CreateApprovalRequest(ctx, result, assessment)
+	assert.NoError(t, err)
+	assert.NotNil(t, req)
+}
+
+func TestDefaultApprovalIntegration_logsApproverCount(t *testing.T) {
+	mock := pkgtesting.NewMockLogger(true)
+	ai := NewDefaultApprovalIntegration(mock)
+	require.NotNil(t, ai)
+
+	ctx := context.Background()
+	result := &ComparisonResult{
+		FromRef: ConfigurationReference{Commit: "abc12345"},
+		ToRef:   ConfigurationReference{Commit: "def67890"},
+		Summary: DiffSummary{TotalChanges: 2},
+	}
+	// Use high risk to trigger approvers being added
+	assessment := &RiskAssessment{
+		OverallRisk: ImpactLevelHigh,
+	}
+
+	req, err := ai.CreateApprovalRequest(ctx, result, assessment)
+	assert.NoError(t, err)
+	assert.NotNil(t, req)
+
+	infoLogs := mock.GetLogs("info")
+	require.NotEmpty(t, infoLogs, "expected at least one info log entry")
+
+	// Find the "notifying approvers" entry and verify it has approver_count (integer) not identities
+	var found bool
+	for _, entry := range infoLogs {
+		if entry.Message == "notifying approvers" {
+			found = true
+			data := entry.Data
+			var hasApproverCount bool
+			for i := 0; i+1 < len(data); i += 2 {
+				key, ok := data[i].(string)
+				if !ok {
+					continue
+				}
+				if key == "approver_count" {
+					_, isInt := data[i+1].(int)
+					assert.True(t, isInt, "approver_count must be an integer, got %T", data[i+1])
+					hasApproverCount = true
+				}
+				// Ensure no approver identity strings are logged
+				if key == "approvers" {
+					t.Errorf("approver identities (PII) must not be logged, found key %q", key)
+				}
+			}
+			assert.True(t, hasApproverCount, "approver_count key not found in log entry data")
+			break
+		}
+	}
+	assert.True(t, found, "expected 'notifying approvers' log entry not found")
+}
+
+func TestDefaultApprovalIntegration_logsOnNotifyUpdate(t *testing.T) {
+	mock := pkgtesting.NewMockLogger(true)
+	ai := NewDefaultApprovalIntegration(mock)
+
+	ctx := context.Background()
+	result := &ComparisonResult{
+		FromRef: ConfigurationReference{Commit: "abc12345"},
+		ToRef:   ConfigurationReference{Commit: "def67890"},
+		Summary: DiffSummary{TotalChanges: 1},
+	}
+	assessment := &RiskAssessment{OverallRisk: ImpactLevelLow}
+
+	req, err := ai.CreateApprovalRequest(ctx, result, assessment)
+	require.NoError(t, err)
+
+	mock.Reset()
+	err = ai.UpdateApprovalRequest(ctx, req.ID, result)
+	assert.NoError(t, err)
+
+	infoLogs := mock.GetLogs("info")
+	require.NotEmpty(t, infoLogs)
+	assert.Equal(t, "notifying approvers of update", infoLogs[0].Message)
+}
+
+func TestDefaultApprovalIntegration_logsOnNotifyCancellation(t *testing.T) {
+	mock := pkgtesting.NewMockLogger(true)
+	ai := NewDefaultApprovalIntegration(mock)
+
+	ctx := context.Background()
+	result := &ComparisonResult{
+		FromRef: ConfigurationReference{Commit: "abc12345"},
+		ToRef:   ConfigurationReference{Commit: "def67890"},
+		Summary: DiffSummary{TotalChanges: 1},
+	}
+	assessment := &RiskAssessment{OverallRisk: ImpactLevelLow}
+
+	req, err := ai.CreateApprovalRequest(ctx, result, assessment)
+	require.NoError(t, err)
+
+	mock.Reset()
+	err = ai.CancelApprovalRequest(ctx, req.ID)
+	assert.NoError(t, err)
+
+	infoLogs := mock.GetLogs("info")
+	require.NotEmpty(t, infoLogs)
+	assert.Equal(t, "notifying approvers of cancellation", infoLogs[0].Message)
+}

--- a/features/config/git/access_control.go
+++ b/features/config/git/access_control.go
@@ -10,6 +10,8 @@ import (
 	"regexp"
 	"strings"
 	"time"
+
+	"github.com/cfgis/cfgms/pkg/logging"
 )
 
 // AccessControlManager handles repository access control and drift detection
@@ -18,9 +20,9 @@ type AccessControlManager struct {
 }
 
 // NewAccessControlManager creates a new access control manager
-func NewAccessControlManager() *AccessControlManager {
+func NewAccessControlManager(logger logging.Logger) *AccessControlManager {
 	return &AccessControlManager{
-		driftDetector: NewDriftDetector(),
+		driftDetector: NewDriftDetector(logger),
 	}
 }
 
@@ -123,12 +125,17 @@ func (acm *AccessControlManager) checkDriftProtection(ctx context.Context, repo 
 // DriftDetector detects configuration drift in repositories
 type DriftDetector struct {
 	baselineHashes map[string]string // path -> expected hash
+	logger         logging.Logger
 }
 
 // NewDriftDetector creates a new drift detector
-func NewDriftDetector() *DriftDetector {
+func NewDriftDetector(logger logging.Logger) *DriftDetector {
+	if logger == nil {
+		logger = logging.NewNoopLogger()
+	}
 	return &DriftDetector{
 		baselineHashes: make(map[string]string),
+		logger:         logger,
 	}
 }
 
@@ -162,9 +169,10 @@ func (dd *DriftDetector) DetectDrift(ctx context.Context, repo *Repository, path
 
 // RevertDrift reverts configuration drift
 func (dd *DriftDetector) RevertDrift(ctx context.Context, repo *Repository, drift *DriftDetection) error {
-	// This would implement the actual revert logic
-	// For now, just log the action
-	fmt.Printf("Reverting drift in %s at path %s\n", repo.Name, drift.Path)
+	dd.logger.Info("reverting drift",
+		"repo", logging.SanitizeLogValue(repo.Name),
+		"path", logging.SanitizeLogValue(drift.Path),
+	)
 	return nil
 }
 
@@ -176,12 +184,17 @@ func (dd *DriftDetector) EstablishBaseline(ctx context.Context, repo *Repository
 // GitModeManager manages Git-as-source-of-truth functionality
 type GitModeManager struct {
 	accessControl *AccessControlManager
+	logger        logging.Logger
 }
 
 // NewGitModeManager creates a new Git mode manager
-func NewGitModeManager() *GitModeManager {
+func NewGitModeManager(logger logging.Logger) *GitModeManager {
+	if logger == nil {
+		logger = logging.NewNoopLogger()
+	}
 	return &GitModeManager{
-		accessControl: NewAccessControlManager(),
+		accessControl: NewAccessControlManager(logger),
+		logger:        logger,
 	}
 }
 
@@ -216,8 +229,7 @@ func (gmm *GitModeManager) ProcessGitWebhook(ctx context.Context, repo *Reposito
 	case "pull_request":
 		return gmm.processPullRequestEvent(ctx, repo, webhookData)
 	default:
-		// Log but don't error on unknown actions
-		fmt.Printf("Unknown webhook action: %s\n", action)
+		gmm.logger.Warn("unknown webhook action", "action", logging.SanitizeLogValue(action))
 	}
 
 	return nil
@@ -228,7 +240,7 @@ func (gmm *GitModeManager) processPushEvent(ctx context.Context, repo *Repositor
 	// Extract changed files and trigger configuration reload
 	// This would integrate with the controller to reload configurations
 
-	fmt.Printf("Processing push event for repository %s\n", repo.Name)
+	gmm.logger.Info("processing push event", "repo", logging.SanitizeLogValue(repo.Name))
 
 	// Validate that push is to a protected branch
 	ref, ok := data["ref"].(string)
@@ -279,7 +291,7 @@ func (gmm *GitModeManager) validatePullRequest(ctx context.Context, repo *Reposi
 	// This would validate that PR changes comply with policies
 	// For now, just log the validation
 
-	fmt.Printf("Validating pull request for repository %s\n", repo.Name)
+	gmm.logger.Info("validating pull request", "repo", logging.SanitizeLogValue(repo.Name))
 
 	// Validation stub - would check that changes don't modify read-only paths,
 	// validate configuration syntax, check against policies, and run security scans

--- a/features/config/git/access_control_test.go
+++ b/features/config/git/access_control_test.go
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 CFGMS Contributors
+package git
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	pkgtesting "github.com/cfgis/cfgms/pkg/testing"
+)
+
+func TestNewDriftDetector_nilLogger_usesNoop(t *testing.T) {
+	dd := NewDriftDetector(nil)
+	require.NotNil(t, dd)
+	// Verify it doesn't panic when used
+	ctx := context.Background()
+	repo := &Repository{Name: "test-repo"}
+	drift := &DriftDetection{Path: "config.yaml"}
+	err := dd.RevertDrift(ctx, repo, drift)
+	assert.NoError(t, err)
+}
+
+func TestNewDriftDetector_injectsLogger(t *testing.T) {
+	mock := pkgtesting.NewMockLogger(true)
+	dd := NewDriftDetector(mock)
+	require.NotNil(t, dd)
+
+	ctx := context.Background()
+	repo := &Repository{Name: "test-repo"}
+	drift := &DriftDetection{Path: "config.yaml"}
+	err := dd.RevertDrift(ctx, repo, drift)
+	assert.NoError(t, err)
+
+	logs := mock.GetLogs("info")
+	require.Len(t, logs, 1)
+	assert.Equal(t, "reverting drift", logs[0].Message)
+}
+
+func TestNewGitModeManager_nilLogger_usesNoop(t *testing.T) {
+	gmm := NewGitModeManager(nil)
+	require.NotNil(t, gmm)
+
+	// Verify no panic on usage
+	ctx := context.Background()
+	repo := &Repository{
+		Name: "test-repo",
+		AccessControl: &RepositoryAccessControl{
+			Mode: AccessModeReadOnly,
+			ProtectedBranches: []BranchProtection{
+				{Pattern: "main"},
+			},
+		},
+	}
+	err := gmm.ValidateReadOnlyMode(ctx, repo)
+	assert.NoError(t, err)
+}
+
+func TestNewGitModeManager_logsUnknownWebhookAction(t *testing.T) {
+	mock := pkgtesting.NewMockLogger(true)
+	gmm := NewGitModeManager(mock)
+	require.NotNil(t, gmm)
+
+	repo := &Repository{
+		Name: "test-repo",
+		AccessControl: &RepositoryAccessControl{
+			Mode: AccessModeReadOnly,
+		},
+	}
+
+	webhookData := map[string]interface{}{
+		"action": "unknown_action",
+	}
+	err := gmm.ProcessGitWebhook(context.Background(), repo, webhookData)
+	assert.NoError(t, err)
+
+	warns := mock.GetLogs("warn")
+	require.NotEmpty(t, warns)
+	assert.Equal(t, "unknown webhook action", warns[0].Message)
+}
+
+func TestNewAccessControlManager_propagatesLogger(t *testing.T) {
+	mock := pkgtesting.NewMockLogger(true)
+	acm := NewAccessControlManager(mock)
+	require.NotNil(t, acm)
+	require.NotNil(t, acm.driftDetector)
+}

--- a/features/config/git/manager.go
+++ b/features/config/git/manager.go
@@ -10,6 +10,8 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+
+	"github.com/cfgis/cfgms/pkg/logging"
 )
 
 // DefaultGitManager implements the GitManager interface
@@ -24,6 +26,7 @@ type DefaultGitManager struct {
 	mu           sync.RWMutex
 	cacheDir     string
 	config       GitManagerConfig
+	logger       logging.Logger
 }
 
 // GitManagerConfig contains configuration for the Git manager
@@ -48,7 +51,10 @@ type GitManagerConfig struct {
 }
 
 // NewGitManager creates a new Git manager
-func NewGitManager(provider GitProvider, store RepositoryStore, config GitManagerConfig) *DefaultGitManager {
+func NewGitManager(provider GitProvider, store RepositoryStore, config GitManagerConfig, logger logging.Logger) *DefaultGitManager {
+	if logger == nil {
+		logger = logging.NewNoopLogger()
+	}
 	if config.DefaultBranch == "" {
 		config.DefaultBranch = "main"
 	}
@@ -66,6 +72,7 @@ func NewGitManager(provider GitProvider, store RepositoryStore, config GitManage
 		localCache:   make(map[string]string),
 		cacheDir:     config.CacheDir,
 		config:       config,
+		logger:       logger,
 	}
 
 	// Initialize SOPS manager
@@ -121,8 +128,10 @@ func (m *DefaultGitManager) CreateRepository(ctx context.Context, config Reposit
 	// Generate SOPS configuration if enabled
 	if repo.SOPSConfig != nil && repo.SOPSConfig.Enabled {
 		if err := m.sopsManager.GenerateSOPSConfig(repo.SOPSConfig, localPath); err != nil {
-			// Log warning but don't fail repository creation
-			fmt.Printf("warning: failed to generate .sops.yaml: %v\n", err)
+			m.logger.Warn("failed to generate .sops.yaml",
+				"repo", logging.SanitizeLogValue(repo.Name),
+				"error", err,
+			)
 		}
 	}
 
@@ -339,8 +348,10 @@ func (m *DefaultGitManager) SaveConfiguration(ctx context.Context, ref Configura
 
 	// Store commit metadata
 	if err := m.storeCommitMetadata(ctx, ref.RepositoryID, sha, config); err != nil {
-		// Log error but don't fail the operation
-		fmt.Printf("warning: failed to store commit metadata: %v\n", err)
+		m.logger.Warn("failed to store commit metadata",
+			"repo", logging.SanitizeLogValue(ref.RepositoryID),
+			"error", err,
+		)
 	}
 
 	return nil
@@ -643,8 +654,7 @@ func (m *DefaultGitManager) ensureRepository(ctx context.Context, repoID string)
 	if exists {
 		// Pull latest changes
 		if err := m.store.Pull(ctx, localPath); err != nil {
-			// Log error but continue - we can work with cached version
-			fmt.Printf("warning: failed to pull latest changes: %v\n", err)
+			m.logger.Warn("failed to pull latest changes, using cached version", "error", err)
 		}
 		return localPath, nil
 	}
@@ -722,13 +732,16 @@ func (m *DefaultGitManager) backgroundSync() {
 			Type: RepositoryTypeClient,
 		})
 		if err != nil {
-			fmt.Printf("error listing repositories for sync: %v\n", err)
+			m.logger.Error("error listing repositories for sync", "error", err)
 			continue
 		}
 
 		for _, repo := range repos {
 			if err := m.SyncTemplates(context.Background(), repo.ID); err != nil {
-				fmt.Printf("error syncing templates for %s: %v\n", repo.ID, err)
+				m.logger.Error("error syncing templates",
+					"repo", logging.SanitizeLogValue(repo.ID),
+					"error", err,
+				)
 			}
 		}
 	}

--- a/features/config/git/manager_test.go
+++ b/features/config/git/manager_test.go
@@ -155,7 +155,7 @@ func TestGitManager_CreateRepository(t *testing.T) {
 		EnableHooks:   false, // Disable hooks for simple test
 	}
 
-	manager := NewGitManager(mockProvider, mockStore, config)
+	manager := NewGitManager(mockProvider, mockStore, config, nil)
 
 	// Test repository configuration
 	repoConfig := RepositoryConfig{
@@ -215,7 +215,7 @@ func TestGitManager_SaveConfiguration(t *testing.T) {
 		EnableHooks:   false,
 	}
 
-	manager := NewGitManager(mockProvider, mockStore, config)
+	manager := NewGitManager(mockProvider, mockStore, config, nil)
 
 	// Add a test repository to the manager
 	testRepo := &Repository{
@@ -266,7 +266,7 @@ func TestGitManager_GetConfiguration(t *testing.T) {
 		DefaultBranch: "main",
 	}
 
-	manager := NewGitManager(mockProvider, mockStore, config)
+	manager := NewGitManager(mockProvider, mockStore, config, nil)
 
 	// Add a test repository to the manager
 	testRepo := &Repository{
@@ -326,7 +326,7 @@ func TestGitManager_ListRepositories(t *testing.T) {
 		CacheDir: "/tmp/test-cache",
 	}
 
-	manager := NewGitManager(mockProvider, mockStore, config)
+	manager := NewGitManager(mockProvider, mockStore, config, nil)
 
 	// Add test repositories
 	repo1 := &Repository{
@@ -377,7 +377,7 @@ func TestGitManager_CreateBranch(t *testing.T) {
 		CacheDir: "/tmp/test-cache",
 	}
 
-	manager := NewGitManager(mockProvider, mockStore, config)
+	manager := NewGitManager(mockProvider, mockStore, config, nil)
 
 	// Add test repository
 	testRepo := &Repository{
@@ -406,7 +406,7 @@ func TestGitManager_GenerateRepositoryName(t *testing.T) {
 	mockStore := &MockRepositoryStore{}
 
 	config := GitManagerConfig{}
-	manager := NewGitManager(mockProvider, mockStore, config)
+	manager := NewGitManager(mockProvider, mockStore, config, nil)
 
 	tests := []struct {
 		name     string

--- a/features/config/git/module_repository.go
+++ b/features/config/git/module_repository.go
@@ -10,6 +10,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/cfgis/cfgms/pkg/logging"
 )
 
 // ModuleRepositoryManager manages script and module repositories
@@ -20,16 +22,21 @@ type ModuleRepositoryManager struct {
 	repoCache    map[string]*Repository   // repo_id -> repository
 	mu           sync.RWMutex
 	secValidator *ModuleSecurityValidator
+	logger       logging.Logger
 }
 
 // NewModuleRepositoryManager creates a new module repository manager
-func NewModuleRepositoryManager(gitManager GitManager, store RepositoryStore) *ModuleRepositoryManager {
+func NewModuleRepositoryManager(gitManager GitManager, store RepositoryStore, logger logging.Logger) *ModuleRepositoryManager {
+	if logger == nil {
+		logger = logging.NewNoopLogger()
+	}
 	return &ModuleRepositoryManager{
 		gitManager:   gitManager,
 		store:        store,
 		moduleCache:  make(map[string]*CustomModule),
 		repoCache:    make(map[string]*Repository),
 		secValidator: NewModuleSecurityValidator(),
+		logger:       logger,
 	}
 }
 
@@ -130,13 +137,19 @@ func (mrm *ModuleRepositoryManager) LoadModulesFromRepository(ctx context.Contex
 	for _, spec := range moduleSpecs {
 		module, err := mrm.loadModule(ctx, repo, localPath, spec)
 		if err != nil {
-			fmt.Printf("Warning: failed to load module %s: %v\n", spec, err)
+			mrm.logger.Warn("failed to load module",
+				"spec", logging.SanitizeLogValue(spec),
+				"error", err,
+			)
 			continue
 		}
 
 		// Validate security
 		if err := mrm.secValidator.ValidateModule(ctx, module); err != nil {
-			fmt.Printf("Warning: module %s failed security validation: %v\n", module.Name, err)
+			mrm.logger.Warn("module failed security validation",
+				"module", logging.SanitizeLogValue(module.Name),
+				"error", err,
+			)
 			module.SecurityStatus.Status = SecurityStatusRejected
 			module.SecurityStatus.Issues = []SecurityIssue{{
 				Type:        "security_validation",

--- a/features/config/git/providers/github.go
+++ b/features/config/git/providers/github.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	cfgit "github.com/cfgis/cfgms/features/config/git"
+	"github.com/cfgis/cfgms/pkg/logging"
 )
 
 // GitHubProvider implements the GitProvider interface for GitHub
@@ -22,16 +23,21 @@ type GitHubProvider struct {
 	token     string
 	owner     string
 	userAgent string
+	logger    logging.Logger
 }
 
 // NewGitHubProvider creates a new GitHub provider
-func NewGitHubProvider(token, owner string) *GitHubProvider {
+func NewGitHubProvider(token, owner string, logger logging.Logger) *GitHubProvider {
+	if logger == nil {
+		logger = logging.NewNoopLogger()
+	}
 	return &GitHubProvider{
 		client:    &http.Client{Timeout: 30 * time.Second},
 		baseURL:   "https://api.github.com",
 		token:     token,
 		owner:     owner,
 		userAgent: "CFGMS-GitBackend/1.0",
+		logger:    logger,
 	}
 }
 
@@ -79,8 +85,10 @@ func (p *GitHubProvider) CreateRepository(ctx context.Context, config cfgit.Repo
 
 	// Set up branch protection for important branches
 	if err := p.setupInitialBranchProtection(ctx, repo); err != nil {
-		// Log but don't fail - this is not critical
-		fmt.Printf("warning: failed to set up branch protection: %v\n", err)
+		p.logger.Warn("failed to set up branch protection",
+			"repo", logging.SanitizeLogValue(repo.Name),
+			"error", err,
+		)
 	}
 
 	return repo, nil

--- a/features/config/rollback/notifier.go
+++ b/features/config/rollback/notifier.go
@@ -4,19 +4,20 @@ package rollback
 
 import (
 	"context"
-	"log"
+
+	"github.com/cfgis/cfgms/pkg/logging"
 )
 
 // DefaultRollbackNotifier provides a default implementation of RollbackNotifier
 type DefaultRollbackNotifier struct {
 	// In a real implementation, this would have email, webhook, or message queue clients
-	logger *log.Logger
+	logger logging.Logger
 }
 
 // NewDefaultRollbackNotifier creates a new default notifier
-func NewDefaultRollbackNotifier(logger *log.Logger) RollbackNotifier {
+func NewDefaultRollbackNotifier(logger logging.Logger) RollbackNotifier {
 	if logger == nil {
-		logger = log.Default()
+		logger = logging.NewNoopLogger()
 	}
 
 	return &DefaultRollbackNotifier{
@@ -26,12 +27,12 @@ func NewDefaultRollbackNotifier(logger *log.Logger) RollbackNotifier {
 
 // NotifyRollbackStarted sends a notification when rollback starts
 func (n *DefaultRollbackNotifier) NotifyRollbackStarted(ctx context.Context, operation *RollbackOperation) error {
-	n.logger.Printf("ROLLBACK STARTED: ID=%s, Target=%s/%s, Type=%s, User=%s",
-		operation.ID,
-		operation.Request.TargetType,
-		operation.Request.TargetID,
-		operation.Request.RollbackType,
-		operation.InitiatedBy,
+	n.logger.Info("rollback started",
+		"id", logging.SanitizeLogValue(operation.ID),
+		"target_type", logging.SanitizeLogValue(string(operation.Request.TargetType)),
+		"target_id", logging.SanitizeLogValue(operation.Request.TargetID),
+		"rollback_type", logging.SanitizeLogValue(string(operation.Request.RollbackType)),
+		"initiated_by", logging.SanitizeLogValue(operation.InitiatedBy),
 	)
 
 	// In a real implementation, this would:
@@ -45,11 +46,11 @@ func (n *DefaultRollbackNotifier) NotifyRollbackStarted(ctx context.Context, ope
 
 // NotifyRollbackProgress sends progress updates
 func (n *DefaultRollbackNotifier) NotifyRollbackProgress(ctx context.Context, operation *RollbackOperation) error {
-	n.logger.Printf("ROLLBACK PROGRESS: ID=%s, Stage=%s, Progress=%d%%, Action=%s",
-		operation.ID,
-		operation.Progress.Stage,
-		operation.Progress.Percentage,
-		operation.Progress.CurrentAction,
+	n.logger.Info("rollback progress",
+		"id", logging.SanitizeLogValue(operation.ID),
+		"stage", logging.SanitizeLogValue(operation.Progress.Stage),
+		"percentage", operation.Progress.Percentage,
+		"current_action", logging.SanitizeLogValue(operation.Progress.CurrentAction),
 	)
 
 	// In a real implementation, this would send progress updates
@@ -65,12 +66,12 @@ func (n *DefaultRollbackNotifier) NotifyRollbackCompleted(ctx context.Context, o
 		duration = operation.CompletedAt.Sub(operation.InitiatedAt).String()
 	}
 
-	n.logger.Printf("ROLLBACK COMPLETED: ID=%s, Success=%v, Duration=%s, Configs=%d, Devices=%d",
-		operation.ID,
-		operation.Result.Success,
-		duration,
-		operation.Result.ConfigurationsRolledBack,
-		operation.Result.DevicesAffected,
+	n.logger.Info("rollback completed",
+		"id", logging.SanitizeLogValue(operation.ID),
+		"success", operation.Result.Success,
+		"duration", duration,
+		"configs_rolled_back", operation.Result.ConfigurationsRolledBack,
+		"devices_affected", operation.Result.DevicesAffected,
 	)
 
 	// In a real implementation, this would send detailed completion reports
@@ -80,17 +81,17 @@ func (n *DefaultRollbackNotifier) NotifyRollbackCompleted(ctx context.Context, o
 
 // NotifyRollbackFailed sends failure notification
 func (n *DefaultRollbackNotifier) NotifyRollbackFailed(ctx context.Context, operation *RollbackOperation, err error) error {
-	n.logger.Printf("ROLLBACK FAILED: ID=%s, Error=%v",
-		operation.ID,
-		err,
+	n.logger.Error("rollback failed",
+		"id", logging.SanitizeLogValue(operation.ID),
+		"error", err,
 	)
 
 	if operation.Result != nil && len(operation.Result.Failures) > 0 {
 		for _, failure := range operation.Result.Failures {
-			n.logger.Printf("  - Component: %s, Error: %s, Recoverable: %v",
-				failure.Component,
-				failure.Error,
-				failure.Recoverable,
+			n.logger.Error("rollback failure detail",
+				"component", logging.SanitizeLogValue(failure.Component),
+				"error", logging.SanitizeLogValue(failure.Error),
+				"recoverable", failure.Recoverable,
 			)
 		}
 	}
@@ -106,13 +107,13 @@ func (n *DefaultRollbackNotifier) NotifyRollbackFailed(ctx context.Context, oper
 // WebhookNotifier sends notifications via webhooks
 type WebhookNotifier struct {
 	webhookURL string
-	logger     *log.Logger
+	logger     logging.Logger
 }
 
 // NewWebhookNotifier creates a new webhook notifier
-func NewWebhookNotifier(webhookURL string, logger *log.Logger) RollbackNotifier {
+func NewWebhookNotifier(webhookURL string, logger logging.Logger) RollbackNotifier {
 	if logger == nil {
-		logger = log.Default()
+		logger = logging.NewNoopLogger()
 	}
 
 	return &WebhookNotifier{
@@ -179,7 +180,7 @@ func (w *WebhookNotifier) sendWebhook(ctx context.Context, payload interface{}) 
 	// - Handle retries and failures
 	// - Respect rate limits
 
-	w.logger.Printf("Webhook notification: %+v", payload)
+	w.logger.Debug("webhook notification sent", "payload", payload)
 	return nil
 }
 

--- a/features/config/rollback/notifier_test.go
+++ b/features/config/rollback/notifier_test.go
@@ -1,0 +1,174 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+package rollback_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cfgis/cfgms/features/config/rollback"
+	pkgtesting "github.com/cfgis/cfgms/pkg/testing"
+)
+
+func TestNewDefaultRollbackNotifier_nilLogger_usesNoop(t *testing.T) {
+	notifier := rollback.NewDefaultRollbackNotifier(nil)
+	require.NotNil(t, notifier)
+	// Verify it doesn't panic when used
+	ctx := context.Background()
+	op := &rollback.RollbackOperation{
+		ID:          "test-op-1",
+		InitiatedBy: "test-user",
+		InitiatedAt: time.Now(),
+		Request: rollback.RollbackRequest{
+			TargetType:   rollback.TargetTypeClient,
+			TargetID:     "client-1",
+			RollbackType: rollback.RollbackTypeFull,
+		},
+		Progress: rollback.RollbackProgress{
+			Stage:         "executing",
+			Percentage:    50,
+			CurrentAction: "rolling back",
+		},
+	}
+	err := notifier.NotifyRollbackStarted(ctx, op)
+	assert.NoError(t, err)
+}
+
+func TestNewDefaultRollbackNotifier_injectsLogger(t *testing.T) {
+	mock := pkgtesting.NewMockLogger(true)
+	notifier := rollback.NewDefaultRollbackNotifier(mock)
+	require.NotNil(t, notifier)
+
+	ctx := context.Background()
+	op := &rollback.RollbackOperation{
+		ID:          "test-op-1",
+		InitiatedBy: "test-user",
+		InitiatedAt: time.Now(),
+		Request: rollback.RollbackRequest{
+			TargetType:   rollback.TargetTypeClient,
+			TargetID:     "client-1",
+			RollbackType: rollback.RollbackTypeFull,
+		},
+		Progress: rollback.RollbackProgress{
+			Stage:         "executing",
+			Percentage:    50,
+			CurrentAction: "rolling back",
+		},
+		Result: &rollback.RollbackResult{},
+	}
+
+	err := notifier.NotifyRollbackStarted(ctx, op)
+	assert.NoError(t, err)
+	infoLogs := mock.GetLogs("info")
+	require.NotEmpty(t, infoLogs)
+	assert.Equal(t, "rollback started", infoLogs[0].Message)
+}
+
+func TestDefaultRollbackNotifier_logsProgress(t *testing.T) {
+	mock := pkgtesting.NewMockLogger(true)
+	notifier := rollback.NewDefaultRollbackNotifier(mock)
+
+	ctx := context.Background()
+	op := &rollback.RollbackOperation{
+		ID:          "test-op-2",
+		InitiatedAt: time.Now(),
+		Request:     rollback.RollbackRequest{RollbackType: rollback.RollbackTypePartial},
+		Progress: rollback.RollbackProgress{
+			Stage:         "executing",
+			Percentage:    75,
+			CurrentAction: "processing",
+		},
+	}
+
+	err := notifier.NotifyRollbackProgress(ctx, op)
+	assert.NoError(t, err)
+
+	infoLogs := mock.GetLogs("info")
+	require.NotEmpty(t, infoLogs)
+	assert.Equal(t, "rollback progress", infoLogs[0].Message)
+}
+
+func TestDefaultRollbackNotifier_logsCompleted(t *testing.T) {
+	mock := pkgtesting.NewMockLogger(true)
+	notifier := rollback.NewDefaultRollbackNotifier(mock)
+
+	ctx := context.Background()
+	completedAt := time.Now()
+	op := &rollback.RollbackOperation{
+		ID:          "test-op-3",
+		InitiatedAt: time.Now().Add(-5 * time.Second),
+		CompletedAt: &completedAt,
+		Request:     rollback.RollbackRequest{RollbackType: rollback.RollbackTypeFull},
+		Result: &rollback.RollbackResult{
+			Success:                  true,
+			ConfigurationsRolledBack: 3,
+			DevicesAffected:          10,
+		},
+	}
+
+	err := notifier.NotifyRollbackCompleted(ctx, op)
+	assert.NoError(t, err)
+
+	infoLogs := mock.GetLogs("info")
+	require.NotEmpty(t, infoLogs)
+	assert.Equal(t, "rollback completed", infoLogs[0].Message)
+}
+
+func TestDefaultRollbackNotifier_logsFailedAsError(t *testing.T) {
+	mock := pkgtesting.NewMockLogger(true)
+	notifier := rollback.NewDefaultRollbackNotifier(mock)
+
+	ctx := context.Background()
+	op := &rollback.RollbackOperation{
+		ID:          "test-op-4",
+		InitiatedAt: time.Now(),
+		Request:     rollback.RollbackRequest{RollbackType: rollback.RollbackTypeFull},
+		Result:      &rollback.RollbackResult{},
+	}
+
+	err := notifier.NotifyRollbackFailed(ctx, op, errors.New("simulated failure"))
+	assert.NoError(t, err)
+
+	errorLogs := mock.GetLogs("error")
+	require.NotEmpty(t, errorLogs)
+	assert.Equal(t, "rollback failed", errorLogs[0].Message)
+}
+
+func TestNewWebhookNotifier_nilLogger_usesNoop(t *testing.T) {
+	notifier := rollback.NewWebhookNotifier("https://example.com/webhook", nil)
+	require.NotNil(t, notifier)
+	// Verify no panic
+	ctx := context.Background()
+	op := &rollback.RollbackOperation{
+		ID:          "test-op-5",
+		InitiatedAt: time.Now(),
+		Request:     rollback.RollbackRequest{},
+		Progress:    rollback.RollbackProgress{Percentage: 0},
+	}
+	err := notifier.NotifyRollbackStarted(ctx, op)
+	assert.NoError(t, err)
+}
+
+func TestNewWebhookNotifier_logsDebugOnSend(t *testing.T) {
+	mock := pkgtesting.NewMockLogger(true)
+	notifier := rollback.NewWebhookNotifier("https://example.com/webhook", mock)
+	require.NotNil(t, notifier)
+
+	ctx := context.Background()
+	op := &rollback.RollbackOperation{
+		ID:          "test-op-6",
+		InitiatedAt: time.Now(),
+		Request:     rollback.RollbackRequest{},
+	}
+	err := notifier.NotifyRollbackStarted(ctx, op)
+	assert.NoError(t, err)
+
+	debugLogs := mock.GetLogs("debug")
+	require.NotEmpty(t, debugLogs)
+	assert.Equal(t, "webhook notification sent", debugLogs[0].Message)
+}

--- a/features/controller/server/server.go
+++ b/features/controller/server/server.go
@@ -654,7 +654,7 @@ func initializeRollbackManager(storageManager *interfaces.StorageManager, logger
 	rollbackValidator := rollback.NewRollbackValidator(&noOpModuleRegistry{}, nil)
 
 	// Create notifier using standard logger
-	rollbackNotifier := rollback.NewDefaultRollbackNotifier(nil)
+	rollbackNotifier := rollback.NewDefaultRollbackNotifier(logger)
 
 	// Create local git store for commit history access
 	localGitStore := gitStorage.NewLocalRepositoryStore("", "")
@@ -663,7 +663,7 @@ func initializeRollbackManager(storageManager *interfaces.StorageManager, logger
 	gitManager := configgit.NewGitManager(nil, localGitStore, configgit.GitManagerConfig{
 		DefaultBranch: "main",
 		AutoSync:      false,
-	})
+	}, logger)
 
 	manager := rollback.NewRollbackManager(gitManager, rollbackValidator, rollbackStore, rollbackNotifier)
 	logger.Info("Rollback manager initialized")


### PR DESCRIPTION
## Summary

- Replace all `fmt.Printf` and `*log.Logger` usage in `features/config` with injected `logging.Logger` instances from `pkg/logging`
- Each affected struct (`DriftDetector`, `GitModeManager`, `GitHubProvider`, `DefaultGitManager`, `ModuleRepositoryManager`, `DefaultApprovalIntegration`, `DefaultRollbackNotifier`, `WebhookNotifier`) gains a `logger logging.Logger` field with nil-guard in its constructor
- Approval notifier logs `approver_count` (integer) instead of approver identity strings, protecting PII
- Controller server wires the real logger at both new call sites so production log output is not silently discarded

Fixes #1158

## Files Changed

| File | Change |
|------|--------|
| `features/config/git/access_control.go` | Add logger to `DriftDetector` + `GitModeManager`; propagate through constructor chain; replace 4 `fmt.Printf` calls |
| `features/config/git/providers/github.go` | Add logger to `GitHubProvider`; update constructor signature; replace 1 `fmt.Printf` |
| `features/config/git/manager.go` | Add logger to `DefaultGitManager`; update constructor; replace 5 `fmt.Printf` calls |
| `features/config/git/module_repository.go` | Add logger to `ModuleRepositoryManager`; update constructor; replace 2 `fmt.Printf` calls |
| `features/config/diff/approval.go` | Add logger to `DefaultApprovalIntegration`; update constructor; replace 6 `fmt.Printf` calls; PII-safe approver_count logging |
| `features/config/rollback/notifier.go` | Replace `*log.Logger` with `logging.Logger`; remove `"log"` import; map log levels correctly |
| `features/controller/server/server.go` | Pass real server logger (not noop) to both new call sites in `initializeRollbackManager` |
| `features/config/git/manager_test.go` | Update 6 `NewGitManager` calls to pass nil logger |
| `features/config/git/access_control_test.go` | NEW: nil-guard tests + logger propagation + log assertion tests |
| `features/config/diff/approval_test.go` | NEW: nil-guard test + `TestDefaultApprovalIntegration_logsApproverCount` |
| `features/config/rollback/notifier_test.go` | NEW: nil-guard tests + level-specific log assertion tests |

## Specialist Review Results

| Reviewer | Result |
|----------|--------|
| QA Test Runner | **PASS** — 133+ packages, all green; cross-platform builds verified; linting clean |
| QA Code Reviewer | **PASS** — 0 blocking issues (1 iteration: fixed server.go to use real logger instead of noop) |
| Security Engineer | **PASS** — 0 blocking issues; PII protection confirmed; all sanitization verified; automated scans clean |

## Test Plan

- [x] `TestNewDriftDetector_nilLogger_usesNoop` — nil-guard doesn't panic
- [x] `TestNewDriftDetector_injectsLogger` — log output captured and verified
- [x] `TestNewGitModeManager_nilLogger_usesNoop` — nil-guard doesn't panic
- [x] `TestNewGitModeManager_logsUnknownWebhookAction` — warn log emitted
- [x] `TestDefaultApprovalIntegration_logsApproverCount` — integer count logged, no approver identities
- [x] `TestNewDefaultRollbackNotifier_nilLogger_usesNoop` — nil-guard doesn't panic
- [x] `TestDefaultRollbackNotifier_logsFailedAsError` — FAILED maps to Error level
- [x] `TestNewWebhookNotifier_logsDebugOnSend` — webhook sends log at Debug level
- [x] All pre-existing tests pass with updated constructor signatures

🤖 Generated with [Claude Code](https://claude.com/claude-code)