### PR TITLE
feat: route factory log.Printf and multitenant slog.Warn through pkg/logging (Issue #1161)

### DIFF
--- a/features/controller/api/handlers_workflows_test.go
+++ b/features/controller/api/handlers_workflows_test.go
@@ -44,7 +44,7 @@ func newTestWorkflowHandler(t *testing.T) (*WorkflowHandler, cfgconfig.ConfigSto
 	errorConfig := stewardconfig.ErrorHandlingConfig{
 		ModuleLoadFailure: stewardconfig.ActionContinue,
 	}
-	moduleFactory := factory.New(registry, errorConfig)
+	moduleFactory := factory.New(registry, errorConfig, logging.NewNoopLogger())
 	logger := logging.NewNoopLogger()
 	engine := workflow.NewEngine(moduleFactory, logger, nil)
 
@@ -519,7 +519,7 @@ func TestWorkflowHandler_SpecialCharsInName_HandledSafely(t *testing.T) {
 
 	registry := make(discovery.ModuleRegistry)
 	errCfg := stewardconfig.ErrorHandlingConfig{ModuleLoadFailure: stewardconfig.ActionContinue}
-	engine := workflow.NewEngine(factory.New(registry, errCfg), capLogger, nil)
+	engine := workflow.NewEngine(factory.New(registry, errCfg, logging.NewNoopLogger()), capLogger, nil)
 	h := NewWorkflowHandler(engine, configStore, nil, capLogger)
 	router := newWorkflowRouter(h)
 

--- a/features/controller/api/registration_hook_test.go
+++ b/features/controller/api/registration_hook_test.go
@@ -44,7 +44,7 @@ func newTestApprovalHook(t *testing.T) (*WorkflowApprovalHook, cfgconfig.ConfigS
 	errorConfig := stewardconfig.ErrorHandlingConfig{
 		ModuleLoadFailure: stewardconfig.ActionContinue,
 	}
-	moduleFactory := factory.New(registry, errorConfig)
+	moduleFactory := factory.New(registry, errorConfig, logging.NewNoopLogger())
 	logger := logging.NewNoopLogger()
 	engine := workflow.NewEngine(moduleFactory, logger, nil)
 

--- a/features/controller/server/server.go
+++ b/features/controller/server/server.go
@@ -710,6 +710,7 @@ func initializeWorkflowHandler(storageManager *interfaces.StorageManager, logger
 	moduleFactory := stewardfactory.New(
 		discovery.ModuleRegistry{},
 		stewardconfig.ErrorHandlingConfig{},
+		logger,
 	)
 
 	workflowEngine := workflow.NewEngine(moduleFactory, logger, nil)

--- a/features/saas/microsoft_multitenant.go
+++ b/features/saas/microsoft_multitenant.go
@@ -21,6 +21,8 @@ import (
 	"net/url"
 	"strings"
 	"time"
+
+	"github.com/cfgis/cfgms/pkg/logging"
 )
 
 // MicrosoftMultiTenantProvider implements multi-tenant Microsoft Graph operations
@@ -59,7 +61,7 @@ func NewMicrosoftMultiTenantProvider(credStore CredentialStore, httpClient *http
 	}
 	// Wire self as the TenantDiscoverer so DiscoverTenantsFromMicrosoft is the
 	// production implementation used by MultiTenantManager.discoverTenants.
-	p.multiTenantManager = NewMultiTenantManager(credStore, NewInMemoryConsentStore(), httpClient, p)
+	p.multiTenantManager = NewMultiTenantManager(credStore, NewInMemoryConsentStore(), httpClient, p, logging.NewNoopLogger())
 	return p
 }
 

--- a/features/saas/multitenant.go
+++ b/features/saas/multitenant.go
@@ -32,7 +32,6 @@ package saas
 import (
 	"context"
 	"fmt"
-	"log/slog"
 	"net/http"
 	"net/url"
 	"strings"
@@ -49,6 +48,7 @@ type MultiTenantManager struct {
 	httpClient       *http.Client
 	oauth2Client     OAuth2Client
 	tenantDiscoverer TenantDiscoverer
+	logger           logging.Logger
 
 	// Cache of tenant discovery results to avoid repeated API calls
 	tenantCache map[string]*TenantDiscoveryResult
@@ -61,13 +61,17 @@ type MultiTenantManager struct {
 // pre-production use until a durable implementation is available.
 // discoverer performs the actual tenant discovery API call after consent is
 // granted; MicrosoftMultiTenantProvider satisfies this interface in production.
-func NewMultiTenantManager(credStore CredentialStore, consentStore ConsentStore, httpClient *http.Client, discoverer TenantDiscoverer) *MultiTenantManager {
+func NewMultiTenantManager(credStore CredentialStore, consentStore ConsentStore, httpClient *http.Client, discoverer TenantDiscoverer, logger logging.Logger) *MultiTenantManager {
+	if logger == nil {
+		logger = logging.NewNoopLogger()
+	}
 	return &MultiTenantManager{
 		credStore:        credStore,
 		consentStore:     consentStore,
 		httpClient:       httpClient,
 		oauth2Client:     NewOAuth2Client(httpClient, nil),
 		tenantDiscoverer: discoverer,
+		logger:           logger,
 		tenantCache:      make(map[string]*TenantDiscoveryResult),
 		cacheExpiry:      15 * time.Minute,
 	}
@@ -294,7 +298,7 @@ func (mtm *MultiTenantManager) GetTenantToken(ctx context.Context, provider, ten
 	// compatibility with client-credentials flows that return opaque tokens.
 	tid, jwtErr := extractJWTTenantID(tokenSet.AccessToken)
 	if jwtErr != nil {
-		slog.Warn("GetTenantToken: tid extraction failed, proceeding with opaque token (fail-open)",
+		mtm.logger.Warn("GetTenantToken: tid extraction failed, proceeding with opaque token (fail-open)",
 			"provider", logging.SanitizeLogValue(provider),
 			"tenant_id", logging.SanitizeLogValue(tenantID),
 			"reason", logging.SanitizeLogValue(jwtErr.Error()))

--- a/features/saas/multitenant_test.go
+++ b/features/saas/multitenant_test.go
@@ -12,6 +12,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cfgis/cfgms/pkg/logging"
+	pkgtesting "github.com/cfgis/cfgms/pkg/testing"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -91,7 +93,7 @@ func TestMultiTenantManager_StartAdminConsent(t *testing.T) {
 			credStore := newTestCredentialStore(t)
 			consentStore := NewInMemoryConsentStore()
 			httpClient := NewGraphHTTPClient(100, 1000)
-			mtm := NewMultiTenantManager(credStore, consentStore, httpClient, newStubTenantDiscoverer())
+			mtm := NewMultiTenantManager(credStore, consentStore, httpClient, newStubTenantDiscoverer(), logging.NewNoopLogger())
 
 			ctx := context.Background()
 			url, err := mtm.StartAdminConsent(ctx, "microsoft", tt.config)
@@ -169,7 +171,7 @@ func TestMultiTenantManager_CompleteAdminConsent(t *testing.T) {
 			consentStore := NewInMemoryConsentStore()
 			// Use the real DefaultOAuth2Client so ExchangeCode hits the httptest server.
 			// Wire a stub discoverer so discoverTenants returns stubTenants without HTTP calls.
-			mtm := NewMultiTenantManager(credStore, consentStore, NewGraphHTTPClient(100, 1000), newStubTenantDiscoverer(stubTenants...))
+			mtm := NewMultiTenantManager(credStore, consentStore, NewGraphHTTPClient(100, 1000), newStubTenantDiscoverer(stubTenants...), logging.NewNoopLogger())
 
 			ctx := context.Background()
 			provider := "microsoft"
@@ -269,7 +271,7 @@ func TestMultiTenantManager_DiscoverTenantsErrors(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			credStore := newTestCredentialStore(t)
 			consentStore := NewInMemoryConsentStore()
-			mtm := NewMultiTenantManager(credStore, consentStore, NewGraphHTTPClient(100, 1000), tt.discoverer)
+			mtm := NewMultiTenantManager(credStore, consentStore, NewGraphHTTPClient(100, 1000), tt.discoverer, logging.NewNoopLogger())
 
 			require.NoError(t, consentStore.StoreConsent("microsoft", &ConsentStatus{
 				Provider:    "microsoft",
@@ -399,7 +401,7 @@ func TestMultiTenantManager_GetTenantToken(t *testing.T) {
 	credStore := newTestCredentialStore(t)
 	consentStore := NewInMemoryConsentStore()
 	httpClient := NewGraphHTTPClient(100, 1000)
-	mtm := NewMultiTenantManager(credStore, consentStore, httpClient, newStubTenantDiscoverer())
+	mtm := NewMultiTenantManager(credStore, consentStore, httpClient, newStubTenantDiscoverer(), logging.NewNoopLogger())
 
 	ctx := context.Background()
 	provider := "microsoft"
@@ -437,7 +439,7 @@ func TestMultiTenantManager_GetTenantToken_NoAccess(t *testing.T) {
 	credStore := newTestCredentialStore(t)
 	consentStore := NewInMemoryConsentStore()
 	httpClient := NewGraphHTTPClient(100, 1000)
-	mtm := NewMultiTenantManager(credStore, consentStore, httpClient, newStubTenantDiscoverer())
+	mtm := NewMultiTenantManager(credStore, consentStore, httpClient, newStubTenantDiscoverer(), logging.NewNoopLogger())
 
 	ctx := context.Background()
 	provider := "microsoft"
@@ -470,7 +472,7 @@ func TestMultiTenantManager_GetTenantToken_NoAccess(t *testing.T) {
 func TestMultiTenantManager_GetTenantToken_TIDMismatch(t *testing.T) {
 	credStore := newTestCredentialStore(t)
 	consentStore := NewInMemoryConsentStore()
-	mtm := NewMultiTenantManager(credStore, consentStore, NewGraphHTTPClient(100, 1000), newStubTenantDiscoverer())
+	mtm := NewMultiTenantManager(credStore, consentStore, NewGraphHTTPClient(100, 1000), newStubTenantDiscoverer(), logging.NewNoopLogger())
 
 	ctx := context.Background()
 	provider := "microsoft"
@@ -502,7 +504,7 @@ func TestMultiTenantManager_GetTenantToken_TIDMismatch(t *testing.T) {
 func TestMultiTenantManager_GetTenantToken_OpaqueToken(t *testing.T) {
 	credStore := newTestCredentialStore(t)
 	consentStore := NewInMemoryConsentStore()
-	mtm := NewMultiTenantManager(credStore, consentStore, NewGraphHTTPClient(100, 1000), newStubTenantDiscoverer())
+	mtm := NewMultiTenantManager(credStore, consentStore, NewGraphHTTPClient(100, 1000), newStubTenantDiscoverer(), logging.NewNoopLogger())
 
 	ctx := context.Background()
 	provider := "microsoft"
@@ -533,7 +535,7 @@ func TestMultiTenantManager_GetTenantToken_OpaqueToken(t *testing.T) {
 func TestMultiTenantManager_GetTenantToken_ExpiredToken_RefreshNotImplemented(t *testing.T) {
 	credStore := newTestCredentialStore(t)
 	consentStore := NewInMemoryConsentStore()
-	mtm := NewMultiTenantManager(credStore, consentStore, NewGraphHTTPClient(100, 1000), newStubTenantDiscoverer())
+	mtm := NewMultiTenantManager(credStore, consentStore, NewGraphHTTPClient(100, 1000), newStubTenantDiscoverer(), logging.NewNoopLogger())
 
 	ctx := context.Background()
 	provider := "microsoft"
@@ -565,7 +567,7 @@ func TestMultiTenantManager_ListAccessibleTenants(t *testing.T) {
 	credStore := newTestCredentialStore(t)
 	consentStore := NewInMemoryConsentStore()
 	httpClient := NewGraphHTTPClient(100, 1000)
-	mtm := NewMultiTenantManager(credStore, consentStore, httpClient, newStubTenantDiscoverer())
+	mtm := NewMultiTenantManager(credStore, consentStore, httpClient, newStubTenantDiscoverer(), logging.NewNoopLogger())
 
 	ctx := context.Background()
 	provider := "microsoft"
@@ -604,7 +606,7 @@ func TestMultiTenantManager_RevokeConsent(t *testing.T) {
 	credStore := newTestCredentialStore(t)
 	consentStore := NewInMemoryConsentStore()
 	httpClient := NewGraphHTTPClient(100, 1000)
-	mtm := NewMultiTenantManager(credStore, consentStore, httpClient, newStubTenantDiscoverer())
+	mtm := NewMultiTenantManager(credStore, consentStore, httpClient, newStubTenantDiscoverer(), logging.NewNoopLogger())
 
 	ctx := context.Background()
 	provider := "microsoft"
@@ -787,7 +789,7 @@ func TestMultiTenantManager_TenantCacheConcurrency(t *testing.T) {
 	// Stub returns one deterministic tenant so RefreshTenantDiscovery writes a
 	// non-empty AccessibleTenants slice to the consent store on each call.
 	stub := newStubTenantDiscoverer(TenantInfo{TenantID: "stub-concurrent-tenant", HasAccess: true})
-	mtm := NewMultiTenantManager(credStore, consentStore, httpClient, stub)
+	mtm := NewMultiTenantManager(credStore, consentStore, httpClient, stub, logging.NewNoopLogger())
 
 	ctx := context.Background()
 	provider := "microsoft"
@@ -909,7 +911,7 @@ func BenchmarkMultiTenantManager_GetTenantToken(b *testing.B) {
 	credStore := newBenchCredentialStore(b)
 	consentStore := NewInMemoryConsentStore()
 	httpClient := NewGraphHTTPClient(100, 1000)
-	mtm := NewMultiTenantManager(credStore, consentStore, httpClient, newStubTenantDiscoverer())
+	mtm := NewMultiTenantManager(credStore, consentStore, httpClient, newStubTenantDiscoverer(), logging.NewNoopLogger())
 
 	ctx := context.Background()
 	provider := "microsoft"
@@ -995,4 +997,41 @@ func BenchmarkMicrosoftMultiTenantProvider_CreateInTenant(b *testing.B) {
 			b.Fatal(err)
 		}
 	}
+}
+
+// TestMultiTenantManager_GetTenantToken_logsOnTIDFailure verifies that when
+// extractJWTTenantID fails (opaque / non-JWT token), the manager logs a warn
+// through its injected logger rather than through slog.Default().
+func TestMultiTenantManager_GetTenantToken_logsOnTIDFailure(t *testing.T) {
+	credStore := newTestCredentialStore(t)
+	consentStore := NewInMemoryConsentStore()
+	mock := pkgtesting.NewMockLogger(true)
+	mtm := NewMultiTenantManager(credStore, consentStore, NewGraphHTTPClient(100, 1000), newStubTenantDiscoverer(), mock)
+
+	ctx := context.Background()
+	provider := "microsoft"
+	tenantID := "any-tenant"
+
+	require.NoError(t, consentStore.StoreConsent(provider, &ConsentStatus{
+		Provider:        provider,
+		HasAdminConsent: true,
+		AccessibleTenants: []TenantInfo{
+			{TenantID: tenantID, HasAccess: true},
+		},
+	}))
+
+	// Store an opaque (non-JWT) token; extractJWTTenantID will fail, triggering the warn.
+	tenantKey := mtm.getTenantKey(provider, tenantID)
+	require.NoError(t, credStore.StoreTokenSet(tenantKey, &TokenSet{
+		AccessToken: "opaque-not-a-jwt",
+		TokenType:   "Bearer",
+		ExpiresAt:   time.Now().Add(1 * time.Hour),
+	}))
+
+	token, err := mtm.GetTenantToken(ctx, provider, tenantID)
+	require.NoError(t, err, "fail-open: opaque token must succeed")
+	require.NotNil(t, token)
+
+	warnLogs := mock.GetLogs("warn")
+	assert.NotEmpty(t, warnLogs, "expected at least one warn log for opaque-token tid-extraction failure")
 }

--- a/features/steward/execution/execution_test.go
+++ b/features/steward/execution/execution_test.go
@@ -21,7 +21,7 @@ import (
 func newTestExecutor(t *testing.T, errorConfig config.ErrorHandlingConfig) *Executor {
 	t.Helper()
 	registry := discovery.ModuleRegistry{}
-	moduleFactory := factory.New(registry, errorConfig)
+	moduleFactory := factory.New(registry, errorConfig, logging.NewNoopLogger())
 	comparator := stewardtesting.NewStateComparator()
 	logger := logging.NewLogger("info")
 	executor, err := NewExecutor(&ExecutorConfig{
@@ -37,7 +37,7 @@ func newTestExecutor(t *testing.T, errorConfig config.ErrorHandlingConfig) *Exec
 func TestNewExecutorWithComponents(t *testing.T) {
 	registry := discovery.ModuleRegistry{}
 	errorConfig := config.ErrorHandlingConfig{}
-	moduleFactory := factory.New(registry, errorConfig)
+	moduleFactory := factory.New(registry, errorConfig, logging.NewNoopLogger())
 	comparator := stewardtesting.NewStateComparator()
 	logger := logging.NewLogger("info")
 

--- a/features/steward/execution/executor.go
+++ b/features/steward/execution/executor.go
@@ -73,7 +73,7 @@ func NewExecutor(cfg *ExecutorConfig) (*Executor, error) {
 			ConfigurationError: config.ActionFail,
 		}
 		// Empty registry — all 7 built-in modules are loaded on demand by the factory
-		f = factory.New(discovery.ModuleRegistry{}, defaultErrCfg)
+		f = factory.New(discovery.ModuleRegistry{}, defaultErrCfg, cfg.Logger)
 		errCfg = defaultErrCfg
 	}
 	if comp == nil {

--- a/features/steward/factory/factory.go
+++ b/features/steward/factory/factory.go
@@ -34,7 +34,6 @@ package factory
 
 import (
 	"fmt"
-	"log"
 	"time"
 
 	"github.com/cfgis/cfgms/features/modules"
@@ -69,6 +68,9 @@ type ModuleFactory struct {
 	// stewardID identifies the steward this factory belongs to
 	stewardID string
 
+	// logger is the factory's own operational logger
+	logger logging.Logger
+
 	// loggerProvider creates loggers for module injection
 	loggerProvider modules.LoggerProvider
 
@@ -83,12 +85,16 @@ type ModuleFactory struct {
 //
 // The factory will use the registry to locate modules when loading and apply
 // the error configuration to determine how to handle loading failures.
-func New(registry discovery.ModuleRegistry, errorConfig config.ErrorHandlingConfig) *ModuleFactory {
+func New(registry discovery.ModuleRegistry, errorConfig config.ErrorHandlingConfig, logger logging.Logger) *ModuleFactory {
+	if logger == nil {
+		logger = logging.NewNoopLogger()
+	}
 	return &ModuleFactory{
 		registry:        registry,
 		instances:       make(map[string]modules.Module),
 		config:          errorConfig,
 		stewardID:       "unknown", // Will be set by steward during initialization
+		logger:          logger,
 		injectionStatus: make(map[string]modules.LoggerInjectionStatus),
 	}
 }
@@ -96,12 +102,16 @@ func New(registry discovery.ModuleRegistry, errorConfig config.ErrorHandlingConf
 // NewWithStewardID creates a new ModuleFactory with a specific steward ID and logging capability.
 //
 // This constructor enables centralized logging from the moment of factory creation.
-func NewWithStewardID(registry discovery.ModuleRegistry, errorConfig config.ErrorHandlingConfig, stewardID string) *ModuleFactory {
+func NewWithStewardID(registry discovery.ModuleRegistry, errorConfig config.ErrorHandlingConfig, stewardID string, logger logging.Logger) *ModuleFactory {
+	if logger == nil {
+		logger = logging.NewNoopLogger()
+	}
 	factory := &ModuleFactory{
 		registry:        registry,
 		instances:       make(map[string]modules.Module),
 		config:          errorConfig,
 		stewardID:       stewardID,
+		logger:          logger,
 		injectionStatus: make(map[string]modules.LoggerInjectionStatus),
 	}
 
@@ -253,7 +263,7 @@ func (f *ModuleFactory) attemptSecretStoreInjection(instance modules.Module, mod
 
 	if err := injectable.SetSecretStore(f.secretStore); err != nil {
 		// Log but don't fail - module can operate without secrets
-		log.Printf("Warning: failed to inject secret store into module %s: %v", moduleName, err)
+		f.logger.Warn("failed to inject secret store into module", "module", moduleName, "error", err)
 	}
 }
 

--- a/features/steward/factory/factory_test.go
+++ b/features/steward/factory/factory_test.go
@@ -3,13 +3,20 @@
 package factory
 
 import (
+	"context"
+	"errors"
 	"testing"
 
+	"github.com/cfgis/cfgms/features/modules"
 	"github.com/cfgis/cfgms/features/modules/file"
 	"github.com/cfgis/cfgms/features/steward/config"
 	"github.com/cfgis/cfgms/features/steward/discovery"
+	"github.com/cfgis/cfgms/pkg/logging"
+	secretsif "github.com/cfgis/cfgms/pkg/secrets/interfaces"
+	pkgtesting "github.com/cfgis/cfgms/pkg/testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestNew(t *testing.T) {
@@ -25,7 +32,7 @@ func TestNew(t *testing.T) {
 		ModuleLoadFailure: config.ActionFail,
 	}
 
-	factory := New(registry, errorConfig)
+	factory := New(registry, errorConfig, logging.NewNoopLogger())
 
 	assert.NotNil(t, factory)
 	assert.Equal(t, registry, factory.registry)
@@ -121,7 +128,7 @@ func TestCreateModuleInstance(t *testing.T) {
 				ModuleLoadFailure: tt.errorAction,
 			}
 
-			factory := New(tt.registry, errorConfig)
+			factory := New(tt.registry, errorConfig, logging.NewNoopLogger())
 
 			module, err := factory.CreateModuleInstance(tt.moduleName)
 
@@ -143,7 +150,7 @@ func TestCreateModuleInstance(t *testing.T) {
 func TestGetLoadedModules(t *testing.T) {
 	registry := discovery.ModuleRegistry{}
 	errorConfig := config.ErrorHandlingConfig{}
-	factory := New(registry, errorConfig)
+	factory := New(registry, errorConfig, logging.NewNoopLogger())
 
 	// Initially empty
 	loaded := factory.GetLoadedModules()
@@ -164,7 +171,7 @@ func TestGetLoadedModules(t *testing.T) {
 func TestUnloadModule(t *testing.T) {
 	registry := discovery.ModuleRegistry{}
 	errorConfig := config.ErrorHandlingConfig{}
-	factory := New(registry, errorConfig)
+	factory := New(registry, errorConfig, logging.NewNoopLogger())
 
 	// Load a real module
 	_, err := factory.LoadModule("file")
@@ -178,7 +185,7 @@ func TestUnloadModule(t *testing.T) {
 func TestUnloadAllModules(t *testing.T) {
 	registry := discovery.ModuleRegistry{}
 	errorConfig := config.ErrorHandlingConfig{}
-	factory := New(registry, errorConfig)
+	factory := New(registry, errorConfig, logging.NewNoopLogger())
 
 	// Load multiple real built-in modules
 	for _, name := range []string{"file", "directory", "script"} {
@@ -203,7 +210,7 @@ func TestGetModuleInfo(t *testing.T) {
 	}
 
 	errorConfig := config.ErrorHandlingConfig{}
-	factory := New(registry, errorConfig)
+	factory := New(registry, errorConfig, logging.NewNoopLogger())
 
 	// Test existing module
 	info, exists := factory.GetModuleInfo("test-module")
@@ -216,10 +223,80 @@ func TestGetModuleInfo(t *testing.T) {
 }
 
 func TestAllSevenBuiltinModulesLoad(t *testing.T) {
-	factory := New(discovery.ModuleRegistry{}, config.ErrorHandlingConfig{ModuleLoadFailure: config.ActionFail})
+	factory := New(discovery.ModuleRegistry{}, config.ErrorHandlingConfig{ModuleLoadFailure: config.ActionFail}, logging.NewNoopLogger())
 	for _, name := range []string{"acme", "directory", "file", "firewall", "package", "patch", "script"} {
 		mod, err := factory.LoadModule(name)
 		assert.NoError(t, err, "built-in module %q must load without error", name)
 		assert.NotNil(t, mod, "built-in module %q must not be nil", name)
 	}
+}
+
+// stubFailingSecretStoreModule implements modules.Module and modules.SecretStoreInjectable.
+// SetSecretStore always returns an error to exercise the warning-log path in attemptSecretStoreInjection.
+type stubFailingSecretStoreModule struct{}
+
+func (s *stubFailingSecretStoreModule) Get(_ context.Context, _ string) (modules.ConfigState, error) {
+	return nil, nil
+}
+
+func (s *stubFailingSecretStoreModule) Set(_ context.Context, _ string, _ modules.ConfigState) error {
+	return nil
+}
+
+func (s *stubFailingSecretStoreModule) SetSecretStore(_ secretsif.SecretStore) error {
+	return errors.New("injection always fails")
+}
+
+func (s *stubFailingSecretStoreModule) GetSecretStore() (secretsif.SecretStore, bool) {
+	return nil, false
+}
+
+// stubSecretStore is a no-op SecretStore that satisfies the interface so the
+// factory's nil-guard does not short-circuit before reaching SetSecretStore.
+type stubSecretStore struct{}
+
+func (s *stubSecretStore) StoreSecret(_ context.Context, _ *secretsif.SecretRequest) error {
+	return nil
+}
+func (s *stubSecretStore) GetSecret(_ context.Context, _ string) (*secretsif.Secret, error) {
+	return nil, nil
+}
+func (s *stubSecretStore) DeleteSecret(_ context.Context, _ string) error { return nil }
+func (s *stubSecretStore) ListSecrets(_ context.Context, _ *secretsif.SecretFilter) ([]*secretsif.SecretMetadata, error) {
+	return nil, nil
+}
+func (s *stubSecretStore) GetSecrets(_ context.Context, _ []string) (map[string]*secretsif.Secret, error) {
+	return nil, nil
+}
+func (s *stubSecretStore) StoreSecrets(_ context.Context, _ map[string]*secretsif.SecretRequest) error {
+	return nil
+}
+func (s *stubSecretStore) GetSecretVersion(_ context.Context, _ string, _ int) (*secretsif.Secret, error) {
+	return nil, nil
+}
+func (s *stubSecretStore) ListSecretVersions(_ context.Context, _ string) ([]*secretsif.SecretVersion, error) {
+	return nil, nil
+}
+func (s *stubSecretStore) GetSecretMetadata(_ context.Context, _ string) (*secretsif.SecretMetadata, error) {
+	return nil, nil
+}
+func (s *stubSecretStore) UpdateSecretMetadata(_ context.Context, _ string, _ map[string]string) error {
+	return nil
+}
+func (s *stubSecretStore) RotateSecret(_ context.Context, _ string, _ string) error { return nil }
+func (s *stubSecretStore) ExpireSecret(_ context.Context, _ string) error           { return nil }
+func (s *stubSecretStore) HealthCheck(_ context.Context) error                      { return nil }
+func (s *stubSecretStore) Close() error                                             { return nil }
+
+func TestModuleFactory_injectSecretStore_logsWarning(t *testing.T) {
+	mock := pkgtesting.NewMockLogger(true)
+	f := New(discovery.ModuleRegistry{}, config.ErrorHandlingConfig{}, mock)
+	f.secretStore = &stubSecretStore{}
+
+	mod := &stubFailingSecretStoreModule{}
+	f.attemptSecretStoreInjection(mod, "test-module")
+
+	warnLogs := mock.GetLogs("warn")
+	require.Len(t, warnLogs, 1)
+	assert.Equal(t, "failed to inject secret store into module", warnLogs[0].Message)
 }

--- a/features/steward/steward.go
+++ b/features/steward/steward.go
@@ -123,7 +123,7 @@ func NewStandalone(configPath string, logger logging.Logger) (*Steward, error) {
 	if stewardID == "" {
 		stewardID = "steward-standalone" // Default ID for standalone mode
 	}
-	moduleFactory := factory.NewWithStewardID(registry, cfg.Steward.ErrorHandling, stewardID)
+	moduleFactory := factory.NewWithStewardID(registry, cfg.Steward.ErrorHandling, stewardID, logger)
 
 	// Initialize steward secret store if provider is available
 	var secretStore secretsif.SecretStore

--- a/features/workflow/engine_test.go
+++ b/features/workflow/engine_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cfgis/cfgms/features/steward/config"
 	"github.com/cfgis/cfgms/features/steward/discovery"
 	"github.com/cfgis/cfgms/features/steward/factory"
+	"github.com/cfgis/cfgms/pkg/logging"
 	pkgtesting "github.com/cfgis/cfgms/pkg/testing"
 )
 
@@ -37,7 +38,7 @@ func createTestFactory() *factory.ModuleFactory {
 		ModuleLoadFailure: config.ActionContinue,
 	}
 
-	return factory.New(registry, errorConfig)
+	return factory.New(registry, errorConfig, logging.NewNoopLogger())
 }
 
 func TestEngine_ExecuteWorkflow_Simple(t *testing.T) {

--- a/features/workflow/trigger/controller_factory_test.go
+++ b/features/workflow/trigger/controller_factory_test.go
@@ -73,7 +73,7 @@ func newRealWorkflowTrigger(tb testing.TB) WorkflowTrigger {
 
 	registry := make(discovery.ModuleRegistry)
 	errCfg := stewardconfig.ErrorHandlingConfig{ModuleLoadFailure: stewardconfig.ActionContinue}
-	eng := workflow.NewEngine(factory.New(registry, errCfg), logging.NewNoopLogger(), nil)
+	eng := workflow.NewEngine(factory.New(registry, errCfg, logging.NewNoopLogger()), logging.NewNoopLogger(), nil)
 
 	return &workflowEngineAdapter{
 		engine:      eng,

--- a/pkg/logging/central_logging_validation_test.go
+++ b/pkg/logging/central_logging_validation_test.go
@@ -111,7 +111,7 @@ func testModuleFactoryLoggerInjection(t *testing.T) {
 	errorConfig := config.ErrorHandlingConfig{
 		ModuleLoadFailure: config.ActionFail,
 	}
-	moduleFactory := factory.NewWithStewardID(registry, errorConfig, stewardID)
+	moduleFactory := factory.NewWithStewardID(registry, errorConfig, stewardID, logging.NewNoopLogger())
 
 	// Test each module type
 	testCases := []struct {
@@ -336,7 +336,7 @@ func testCentralLoggingControllerVisibility(t *testing.T) {
 
 	// Create factories for each steward
 	for _, stewardID := range stewardIDs {
-		moduleFactory := factory.NewWithStewardID(registry, errorConfig, stewardID)
+		moduleFactory := factory.NewWithStewardID(registry, errorConfig, stewardID, logging.NewNoopLogger())
 		factoryMap[stewardID] = moduleFactory
 	}
 


### PR DESCRIPTION
## Summary

- Routes the single `log.Printf` in `features/steward/factory/factory.go` through an injected `logging.Logger`, removing the `"log"` stdlib import
- Routes the single `slog.Warn` in `features/saas/multitenant.go` through an injected `logging.Logger`, removing the `"log/slog"` stdlib import
- Completes the `features/` sweep of Epic #726 (adopt pkg/logging consistently)

Fixes #1161

## Changes

**Core implementation:**
- `ModuleFactory` struct gains `logger logging.Logger` field; `New()` and `NewWithStewardID()` accept `logger` as final parameter with `logging.NewNoopLogger()` nil-guard
- `MultiTenantManager` struct gains `logger logging.Logger` field; `NewMultiTenantManager()` accepts `logger` as final parameter with nil-guard
- `logging.SanitizeLogValue()` wrappers preserved verbatim at the `slog.Warn` replacement site

**Call sites updated (3 production + 1 internal production):**
- `features/controller/server/server.go:710` — passes existing `logger`
- `features/steward/steward.go:126` — passes existing `logger`
- `features/steward/execution/executor.go:76` — passes `cfg.Logger`
- `features/saas/microsoft_multitenant.go:62` — passes `logging.NewNoopLogger()`

**Test files updated (8 files):** All callers of updated constructors pass `logging.NewNoopLogger()`

**New tests:**
- `TestModuleFactory_injectSecretStore_logsWarning` — constructs with `pkgtesting.NewMockLogger(true)`, triggers injection failure path, asserts `mock.GetLogs("warn")[0].Message == "failed to inject secret store into module"`
- `TestMultiTenantManager_GetTenantToken_logsOnTIDFailure` — constructs with mock logger, triggers opaque-token tid-extraction failure, asserts warn is emitted via injected logger (not `slog.Default()`)

## Specialist Review Results

| Reviewer | Result | Notes |
|----------|--------|-------|
| QA Test Runner | **PASS** | All packages pass, cross-platform builds verified |
| QA Code Reviewer | **PASS** | 0 blocking issues; 2 non-blocking warnings (message-assertion style, noop logger in MicrosoftMultiTenantProvider) |
| Security Engineer | **PASS** | 0 blocking issues; `SanitizeLogValue` preservation verified; all scans green |

## Test Plan

- [x] `go test ./features/steward/factory/...` — passes
- [x] `go test ./features/saas/...` — passes
- [x] `go test ./pkg/logging/...` — passes
- [x] `make test-agent-complete` — all gates pass (unit, lint, cross-platform compilation)