### PR TITLE
rbac-zerotrust: replace ComplianceCache with pkg/cache (Issue #1198)

### DIFF
--- a/features/rbac/zerotrust/compliance_engine.go
+++ b/features/rbac/zerotrust/compliance_engine.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"sync"
 	"time"
+
+	"github.com/cfgis/cfgms/pkg/cache"
 )
 
 // ComplianceFrameworkEngine provides compliance validation against major frameworks
@@ -16,7 +18,7 @@ type ComplianceFrameworkEngine struct {
 	validators map[ComplianceFramework]ComplianceValidator
 
 	// Compliance cache for performance
-	complianceCache *ComplianceCache
+	complianceCache *cache.Cache
 
 	// Configuration
 	enabledFrameworks []ComplianceFramework
@@ -113,24 +115,6 @@ type ComplianceValidator interface {
 	GetSupportedControls() []string
 }
 
-// ComplianceCache provides high-performance caching for compliance validation results
-type ComplianceCache struct {
-	entries map[string]*ComplianceCacheEntry
-	mutex   sync.RWMutex
-	maxSize int
-	ttl     time.Duration
-}
-
-// ComplianceCacheEntry represents a cached compliance validation result
-type ComplianceCacheEntry struct {
-	Key          string                      `json:"key"`
-	Result       *ComplianceValidationResult `json:"result"`
-	CreatedAt    time.Time                   `json:"created_at"`
-	ExpiresAt    time.Time                   `json:"expires_at"`
-	AccessCount  int64                       `json:"access_count"`
-	LastAccessed time.Time                   `json:"last_accessed"`
-}
-
 // ComplianceStats tracks compliance engine statistics
 type ComplianceStats struct {
 	TotalValidations       int64                         `json:"total_validations"`
@@ -165,9 +149,15 @@ const (
 // NewComplianceFrameworkEngine creates a new compliance framework engine
 func NewComplianceFrameworkEngine(enabledFrameworks []ComplianceFramework) *ComplianceFrameworkEngine {
 	engine := &ComplianceFrameworkEngine{
-		frameworks:        make(map[ComplianceFramework]*FrameworkTemplate),
-		validators:        make(map[ComplianceFramework]ComplianceValidator),
-		complianceCache:   NewComplianceCache(1000, 10*time.Minute),
+		frameworks: make(map[ComplianceFramework]*FrameworkTemplate),
+		validators: make(map[ComplianceFramework]ComplianceValidator),
+		complianceCache: cache.NewCache(cache.CacheConfig{
+			Name:            "zerotrust-compliance",
+			MaxRuntimeItems: 1000,
+			DefaultTTL:      10 * time.Minute,
+			CleanupInterval: 1 * time.Minute,
+			EvictionPolicy:  cache.EvictionLRU,
+		}),
 		enabledFrameworks: enabledFrameworks,
 		strictMode:        true,
 		cacheEnabled:      true,
@@ -234,11 +224,13 @@ func (c *ComplianceFrameworkEngine) validateFrameworkCompliance(ctx context.Cont
 	// Check cache first
 	if c.cacheEnabled {
 		cacheKey := c.generateComplianceCacheKey(request, framework)
-		if cachedResult := c.complianceCache.Get(cacheKey); cachedResult != nil {
-			c.stats.mutex.Lock()
-			c.stats.CachedValidations++
-			c.stats.mutex.Unlock()
-			return cachedResult, nil
+		if value, found := c.complianceCache.Get(cacheKey); found {
+			if cachedResult, ok := value.(*ComplianceValidationResult); ok {
+				c.stats.mutex.Lock()
+				c.stats.CachedValidations++
+				c.stats.mutex.Unlock()
+				return cachedResult, nil
+			}
 		}
 	}
 
@@ -256,10 +248,10 @@ func (c *ComplianceFrameworkEngine) validateFrameworkCompliance(ctx context.Cont
 
 	result.ProcessingTime = time.Since(startTime)
 
-	// Cache the result
+	// Cache the result — ignore error; a missed cache write is non-critical
 	if c.cacheEnabled {
 		cacheKey := c.generateComplianceCacheKey(request, framework)
-		c.complianceCache.Put(cacheKey, result)
+		_ = c.complianceCache.Set(cacheKey, result, 0)
 	}
 
 	return result, nil
@@ -668,102 +660,7 @@ func NewComplianceStats() *ComplianceStats {
 	}
 }
 
-func NewComplianceCache(maxSize int, ttl time.Duration) *ComplianceCache {
-	cache := &ComplianceCache{
-		entries: make(map[string]*ComplianceCacheEntry),
-		maxSize: maxSize,
-		ttl:     ttl,
-	}
-
-	// Start cleanup goroutine
-	go cache.cleanupLoop()
-
-	return cache
-}
-
-// ComplianceCache methods
-
-func (cc *ComplianceCache) Get(key string) *ComplianceValidationResult {
-	cc.mutex.RLock()
-	defer cc.mutex.RUnlock()
-
-	entry, exists := cc.entries[key]
-	if !exists {
-		return nil
-	}
-
-	// Check if expired
-	if time.Now().After(entry.ExpiresAt) {
-		delete(cc.entries, key)
-		return nil
-	}
-
-	// Update access information
-	entry.AccessCount++
-	entry.LastAccessed = time.Now()
-
-	return entry.Result
-}
-
-func (cc *ComplianceCache) Put(key string, result *ComplianceValidationResult) {
-	cc.mutex.Lock()
-	defer cc.mutex.Unlock()
-
-	// Check if we need to evict entries
-	if len(cc.entries) >= cc.maxSize {
-		cc.evictLRU()
-	}
-
-	now := time.Now()
-	cc.entries[key] = &ComplianceCacheEntry{
-		Key:          key,
-		Result:       result,
-		CreatedAt:    now,
-		ExpiresAt:    now.Add(cc.ttl),
-		AccessCount:  1,
-		LastAccessed: now,
-	}
-}
-
-func (cc *ComplianceCache) evictLRU() {
-	var oldestKey string
-	var oldestTime time.Time
-
-	for key, entry := range cc.entries {
-		if oldestTime.IsZero() || entry.LastAccessed.Before(oldestTime) {
-			oldestKey = key
-			oldestTime = entry.LastAccessed
-		}
-	}
-
-	if oldestKey != "" {
-		delete(cc.entries, oldestKey)
-	}
-}
-
-func (cc *ComplianceCache) cleanupLoop() {
-	ticker := time.NewTicker(1 * time.Minute)
-	defer ticker.Stop()
-
-	for range ticker.C {
-		cc.cleanup()
-	}
-}
-
-func (cc *ComplianceCache) cleanup() {
-	cc.mutex.Lock()
-	defer cc.mutex.Unlock()
-
-	now := time.Now()
-	var expiredKeys []string
-
-	for key, entry := range cc.entries {
-		if now.After(entry.ExpiresAt) {
-			expiredKeys = append(expiredKeys, key)
-		}
-	}
-
-	for _, key := range expiredKeys {
-		delete(cc.entries, key)
-	}
+// Close stops the compliance cache cleanup routine and releases resources.
+func (c *ComplianceFrameworkEngine) Close() {
+	c.complianceCache.Close()
 }

--- a/features/rbac/zerotrust/compliance_engine_test.go
+++ b/features/rbac/zerotrust/compliance_engine_test.go
@@ -1,0 +1,129 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+package zerotrust
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/cfgis/cfgms/api/proto/common"
+	"github.com/cfgis/cfgms/pkg/cache"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type fakeClock struct{ t time.Time }
+
+func (f *fakeClock) Now() time.Time { return f.t }
+
+// TestComplianceCache_HitMissExpiry verifies that a cached compliance result is
+// returned before TTL expires and absent after the clock advances past TTL.
+func TestComplianceCache_HitMissExpiry(t *testing.T) {
+	clk := &fakeClock{t: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)}
+	ttl := 10 * time.Minute
+
+	c := cache.NewCache(cache.CacheConfig{
+		Name:            "zerotrust-compliance",
+		MaxRuntimeItems: 1000,
+		DefaultTTL:      ttl,
+		CleanupInterval: 1 * time.Minute,
+		EvictionPolicy:  cache.EvictionLRU,
+		Clock:           clk,
+	})
+	t.Cleanup(c.Close)
+
+	key := "compliance:SOC2:user1:tenant1:req1"
+	result := &ComplianceValidationResult{
+		Framework:      ComplianceFrameworkSOC2,
+		ComplianceRate: 1.0,
+	}
+
+	require.NoError(t, c.Set(key, result, 0)) // 0 = use DefaultTTL (10 min)
+
+	// Hit: before TTL expires
+	value, found := c.Get(key)
+	require.True(t, found, "should be a cache hit before TTL expires")
+	got, ok := value.(*ComplianceValidationResult)
+	require.True(t, ok, "cached value should be *ComplianceValidationResult")
+	assert.Equal(t, result, got)
+
+	// Advance clock past TTL
+	clk.t = clk.t.Add(ttl + time.Second)
+
+	// Miss: after TTL expires
+	_, found = c.Get(key)
+	assert.False(t, found, "should be a cache miss after TTL expires")
+}
+
+func makeTestRequest(subjectID, tenantID, requestID string) *ZeroTrustAccessRequest {
+	return &ZeroTrustAccessRequest{
+		AccessRequest: &common.AccessRequest{
+			SubjectId: subjectID,
+			TenantId:  tenantID,
+		},
+		RequestID:       requestID,
+		SecurityContext: &SecurityContext{AuthenticationMethod: "certificate"},
+	}
+}
+
+// TestValidateFrameworkCompliance_CacheHitIncrementsStats verifies that a second
+// call with the same key returns the cached result and increments CachedValidations.
+func TestValidateFrameworkCompliance_CacheHitIncrementsStats(t *testing.T) {
+	engine := NewComplianceFrameworkEngine([]ComplianceFramework{ComplianceFrameworkSOC2})
+	t.Cleanup(engine.Close)
+
+	req := makeTestRequest("user1", "tenant1", "req1")
+	ctx := context.Background()
+
+	first, err := engine.validateFrameworkCompliance(ctx, req, ComplianceFrameworkSOC2, nil)
+	require.NoError(t, err)
+	require.NotNil(t, first)
+
+	statsBefore := engine.GetStats()
+
+	second, err := engine.validateFrameworkCompliance(ctx, req, ComplianceFrameworkSOC2, nil)
+	require.NoError(t, err)
+	require.NotNil(t, second)
+
+	statsAfter := engine.GetStats()
+	assert.Equal(t, statsBefore.CachedValidations+1, statsAfter.CachedValidations,
+		"CachedValidations should increment on cache hit")
+	assert.Equal(t, first.ComplianceRate, second.ComplianceRate,
+		"cached result should match original result")
+}
+
+// TestValidateFrameworkCompliance_ValidatorNotFound verifies that an unknown framework
+// causes an error return from validateFrameworkCompliance.
+func TestValidateFrameworkCompliance_ValidatorNotFound(t *testing.T) {
+	engine := NewComplianceFrameworkEngine([]ComplianceFramework{ComplianceFrameworkSOC2})
+	t.Cleanup(engine.Close)
+
+	req := makeTestRequest("user1", "tenant1", "req-unknown")
+	ctx := context.Background()
+
+	// Use a framework that has no registered validator
+	_, err := engine.validateFrameworkCompliance(ctx, req, ComplianceFramework("UNKNOWN"), nil)
+	require.Error(t, err, "should return error when framework validator is not registered")
+	assert.Contains(t, err.Error(), "no validator found for framework")
+}
+
+// TestValidateFrameworkCompliance_CacheDisabled verifies that when cacheEnabled is false,
+// each call re-executes validation and CachedValidations stays at zero.
+func TestValidateFrameworkCompliance_CacheDisabled(t *testing.T) {
+	engine := NewComplianceFrameworkEngine([]ComplianceFramework{ComplianceFrameworkSOC2})
+	t.Cleanup(engine.Close)
+	engine.cacheEnabled = false
+
+	req := makeTestRequest("user1", "tenant1", "req-nocache")
+	ctx := context.Background()
+
+	_, err := engine.validateFrameworkCompliance(ctx, req, ComplianceFrameworkSOC2, nil)
+	require.NoError(t, err)
+	_, err = engine.validateFrameworkCompliance(ctx, req, ComplianceFrameworkSOC2, nil)
+	require.NoError(t, err)
+
+	stats := engine.GetStats()
+	assert.Equal(t, int64(0), stats.CachedValidations,
+		"CachedValidations should remain zero when cache is disabled")
+}


### PR DESCRIPTION
## Summary

- Deletes the hand-rolled `ComplianceCache` (map+mutex+goroutine+manual LRU) and `ComplianceCacheEntry` from `compliance_engine.go` (~100 lines removed)
- Replaces `complianceCache *ComplianceCache` field with `*cache.Cache` from `pkg/cache`, following the same pattern as `PolicyCache` in `cache.go`
- Adds `Close()` method on `ComplianceFrameworkEngine` that delegates to `complianceCache.Close()`
- Adds `compliance_engine_test.go` with clock-driven TTL expiry test and engine-level cache behaviour tests

Fixes #1198

## Test plan

- [x] `TestComplianceCache_HitMissExpiry` — fakeClock-driven: result found before TTL, absent after advance past TTL
- [x] `TestValidateFrameworkCompliance_CacheHitIncrementsStats` — cache hit path increments `CachedValidations`
- [x] `TestValidateFrameworkCompliance_ValidatorNotFound` — error path returns "no validator found for framework"
- [x] `TestValidateFrameworkCompliance_CacheDisabled` — `cacheEnabled=false` keeps `CachedValidations` at zero
- [x] `make test-agent-complete` — all gates PASS (unit, lint, license, architecture, cross-platform compilation, integration)

## Specialist Review Results

| Reviewer | Result |
|----------|--------|
| QA Test Runner | **PASS** — all gates green, marker written |
| QA Code Reviewer | **PASS** — 0 blocking issues, 0 warnings |
| Security Engineer | **PASS** — no secrets, no central provider violations, architecture scan clean |

🤖 Generated with [Claude Code](https://claude.com/claude-code)