### PR TITLE
m365-auth: replace tokenCache and delegatedTokenCache with pkg/cache (Issue #1201)

### DIFF
--- a/features/modules/m365/auth/oauth2_provider.go
+++ b/features/modules/m365/auth/oauth2_provider.go
@@ -9,9 +9,9 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
-	"sync"
 	"time"
 
+	"github.com/cfgis/cfgms/pkg/cache"
 	"github.com/cfgis/cfgms/pkg/logging"
 )
 
@@ -24,23 +24,15 @@ type OAuth2Provider struct {
 	credentialStore CredentialStore
 
 	// Token cache to avoid unnecessary requests (for application tokens)
-	tokenCache map[string]*cachedToken
-	cacheMutex sync.RWMutex
+	tokenCache *cache.Cache
 
 	// Delegated token cache for user-specific tokens
-	delegatedTokenCache map[string]*cachedToken
-	delegatedCacheMutex sync.RWMutex
+	delegatedTokenCache *cache.Cache
 
 	// Default configuration for new tenants
 	defaultConfig *OAuth2Config
 
 	logger logging.Logger
-}
-
-// cachedToken represents a cached access token with expiration tracking
-type cachedToken struct {
-	token     *AccessToken
-	expiresAt time.Time
 }
 
 // NewOAuth2Provider creates a new OAuth2Provider instance
@@ -52,11 +44,19 @@ func NewOAuth2Provider(credentialStore CredentialStore, defaultConfig *OAuth2Con
 		httpClient: &http.Client{
 			Timeout: 30 * time.Second,
 		},
-		credentialStore:     credentialStore,
-		tokenCache:          make(map[string]*cachedToken),
-		delegatedTokenCache: make(map[string]*cachedToken),
-		defaultConfig:       defaultConfig,
-		logger:              logger,
+		credentialStore: credentialStore,
+		tokenCache: cache.NewCache(cache.CacheConfig{
+			Name:            "m365-token",
+			DefaultTTL:      55 * time.Minute,
+			CleanupInterval: 1 * time.Minute,
+		}),
+		delegatedTokenCache: cache.NewCache(cache.CacheConfig{
+			Name:            "m365-delegated-token",
+			DefaultTTL:      55 * time.Minute,
+			CleanupInterval: 1 * time.Minute,
+		}),
+		defaultConfig: defaultConfig,
+		logger:        logger,
 	}
 }
 
@@ -508,113 +508,84 @@ func (p *OAuth2Provider) getOAuth2Config(tenantID string) (*OAuth2Config, error)
 
 // getCachedToken retrieves a token from the cache
 func (p *OAuth2Provider) getCachedToken(tenantID string) *AccessToken {
-	p.cacheMutex.RLock()
-	defer p.cacheMutex.RUnlock()
-
-	cached, exists := p.tokenCache[tenantID]
-	if !exists {
+	value, found := p.tokenCache.Get(tenantID)
+	if !found {
 		return nil
 	}
-
-	// Check if cached token is still valid (with 5-minute buffer)
-	if time.Now().Add(5 * time.Minute).After(cached.expiresAt) {
+	token, ok := value.(*AccessToken)
+	if !ok {
 		return nil
 	}
-
-	return cached.token
+	return token
 }
 
-// setCachedToken stores a token in the cache
+// setCachedToken stores a token in the cache with a TTL that fires 5 minutes before the token expires
 func (p *OAuth2Provider) setCachedToken(tenantID string, token *AccessToken) {
-	p.cacheMutex.Lock()
-	defer p.cacheMutex.Unlock()
-
-	p.tokenCache[tenantID] = &cachedToken{
-		token:     token,
-		expiresAt: token.ExpiresAt,
+	ttl := time.Until(token.ExpiresAt) - 5*time.Minute
+	if ttl <= 0 {
+		p.logger.Debug("skipping token cache: TTL too short", "tenant_id", logging.SanitizeLogValue(tenantID))
+		return
 	}
+	_ = p.tokenCache.Set(tenantID, token, ttl)
 }
 
 // getDelegatedCachedToken retrieves a delegated token from the cache
 func (p *OAuth2Provider) getDelegatedCachedToken(cacheKey string) *AccessToken {
-	p.delegatedCacheMutex.RLock()
-	defer p.delegatedCacheMutex.RUnlock()
-
-	cached, exists := p.delegatedTokenCache[cacheKey]
-	if !exists {
+	value, found := p.delegatedTokenCache.Get(cacheKey)
+	if !found {
 		return nil
 	}
-
-	// Check if cached token is still valid (with 5-minute buffer)
-	if time.Now().Add(5 * time.Minute).After(cached.expiresAt) {
+	token, ok := value.(*AccessToken)
+	if !ok {
 		return nil
 	}
-
-	return cached.token
+	return token
 }
 
-// setDelegatedCachedToken stores a delegated token in the cache
+// setDelegatedCachedToken stores a delegated token in the cache with a TTL that fires 5 minutes before the token expires
 func (p *OAuth2Provider) setDelegatedCachedToken(cacheKey string, token *AccessToken) {
-	p.delegatedCacheMutex.Lock()
-	defer p.delegatedCacheMutex.Unlock()
-
-	p.delegatedTokenCache[cacheKey] = &cachedToken{
-		token:     token,
-		expiresAt: token.ExpiresAt,
+	ttl := time.Until(token.ExpiresAt) - 5*time.Minute
+	if ttl <= 0 {
+		p.logger.Debug("skipping delegated token cache: TTL too short", "cache_key", logging.SanitizeLogValue(cacheKey))
+		return
 	}
+	_ = p.delegatedTokenCache.Set(cacheKey, token, ttl)
 }
 
 // ClearCache clears the token cache for all tenants
 func (p *OAuth2Provider) ClearCache() {
-	p.cacheMutex.Lock()
-	defer p.cacheMutex.Unlock()
-
-	p.tokenCache = make(map[string]*cachedToken)
+	p.tokenCache.Clear()
 }
 
 // ClearDelegatedCache clears the delegated token cache for all users
 func (p *OAuth2Provider) ClearDelegatedCache() {
-	p.delegatedCacheMutex.Lock()
-	defer p.delegatedCacheMutex.Unlock()
-
-	p.delegatedTokenCache = make(map[string]*cachedToken)
+	p.delegatedTokenCache.Clear()
 }
 
 // ClearCacheForTenant clears the token cache for a specific tenant
 func (p *OAuth2Provider) ClearCacheForTenant(tenantID string) {
-	p.cacheMutex.Lock()
-	defer p.cacheMutex.Unlock()
-
-	delete(p.tokenCache, tenantID)
+	p.tokenCache.Delete(tenantID)
 }
 
 // ClearDelegatedCacheForUser clears the delegated token cache for a specific user
 func (p *OAuth2Provider) ClearDelegatedCacheForUser(tenantID, userID string) {
-	p.delegatedCacheMutex.Lock()
-	defer p.delegatedCacheMutex.Unlock()
-
-	cacheKey := fmt.Sprintf("%s:%s", tenantID, userID)
-	delete(p.delegatedTokenCache, cacheKey)
+	p.delegatedTokenCache.Delete(fmt.Sprintf("%s:%s", tenantID, userID))
 }
 
 // ClearDelegatedCacheForTenant clears all delegated tokens for a specific tenant
 func (p *OAuth2Provider) ClearDelegatedCacheForTenant(tenantID string) {
-	p.delegatedCacheMutex.Lock()
-	defer p.delegatedCacheMutex.Unlock()
-
-	// Find and remove all cache entries for this tenant
-	keysToDelete := make([]string, 0)
 	tenantPrefix := tenantID + ":"
-
-	for cacheKey := range p.delegatedTokenCache {
-		if strings.HasPrefix(cacheKey, tenantPrefix) {
-			keysToDelete = append(keysToDelete, cacheKey)
+	for _, key := range p.delegatedTokenCache.Keys() {
+		if strings.HasPrefix(key, tenantPrefix) {
+			p.delegatedTokenCache.Delete(key)
 		}
 	}
+}
 
-	for _, key := range keysToDelete {
-		delete(p.delegatedTokenCache, key)
-	}
+// Close stops the background cleanup routines for both token caches
+func (p *OAuth2Provider) Close() {
+	p.tokenCache.Close()
+	p.delegatedTokenCache.Close()
 }
 
 // SetHTTPClient allows customization of the HTTP client

--- a/features/modules/m365/auth/oauth2_provider.go
+++ b/features/modules/m365/auth/oauth2_provider.go
@@ -519,11 +519,13 @@ func (p *OAuth2Provider) getCachedToken(tenantID string) *AccessToken {
 	return token
 }
 
-// setCachedToken stores a token in the cache with a TTL that fires 5 minutes before the token expires
+// setCachedToken stores a token in the cache with a TTL that fires 5 minutes before the token expires.
+// If the token is already within the buffer window (TTL ≤ 0) any existing entry is evicted.
 func (p *OAuth2Provider) setCachedToken(tenantID string, token *AccessToken) {
 	ttl := time.Until(token.ExpiresAt) - 5*time.Minute
 	if ttl <= 0 {
 		p.logger.Debug("skipping token cache: TTL too short", "tenant_id", logging.SanitizeLogValue(tenantID))
+		p.tokenCache.Delete(tenantID)
 		return
 	}
 	_ = p.tokenCache.Set(tenantID, token, ttl)
@@ -542,11 +544,13 @@ func (p *OAuth2Provider) getDelegatedCachedToken(cacheKey string) *AccessToken {
 	return token
 }
 
-// setDelegatedCachedToken stores a delegated token in the cache with a TTL that fires 5 minutes before the token expires
+// setDelegatedCachedToken stores a delegated token in the cache with a TTL that fires 5 minutes before the token expires.
+// If the token is already within the buffer window (TTL ≤ 0) any existing entry is evicted.
 func (p *OAuth2Provider) setDelegatedCachedToken(cacheKey string, token *AccessToken) {
 	ttl := time.Until(token.ExpiresAt) - 5*time.Minute
 	if ttl <= 0 {
 		p.logger.Debug("skipping delegated token cache: TTL too short", "cache_key", logging.SanitizeLogValue(cacheKey))
+		p.delegatedTokenCache.Delete(cacheKey)
 		return
 	}
 	_ = p.delegatedTokenCache.Set(cacheKey, token, ttl)

--- a/features/modules/m365/auth/oauth2_provider_test.go
+++ b/features/modules/m365/auth/oauth2_provider_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/cfgis/cfgms/pkg/cache"
 	pkgtesting "github.com/cfgis/cfgms/pkg/testing"
 )
 
@@ -127,7 +128,9 @@ func TestOAuth2Provider_exchangeCode_tokenStoreFailure_logsWarning(t *testing.T)
 			"expires_in":   3600,
 		}
 		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(resp)
+		if err := json.NewEncoder(w).Encode(resp); err != nil {
+			http.Error(w, "encode failed", http.StatusInternalServerError)
+		}
 	}))
 	defer mockServer.Close()
 
@@ -156,6 +159,159 @@ func TestOAuth2Provider_exchangeCode_tokenStoreFailure_logsWarning(t *testing.T)
 	assert.Equal(t, "failed to store token", warnLogs[0].Message)
 }
 
+// testClock is a fake clock for controlling cache time in tests.
+type testClock struct {
+	now time.Time
+}
+
+func (c *testClock) Now() time.Time { return c.now }
+
+// TestOAuth2Provider_TokenCacheExpiry verifies that tokens are absent from the
+// cache after the configured TTL elapses, using a fake clock to avoid real waits.
+func TestOAuth2Provider_TokenCacheExpiry(t *testing.T) {
+	startTime := time.Now()
+	clk := &testClock{now: startTime}
+
+	credStore := &failingCredentialStore{}
+	provider := NewOAuth2Provider(credStore, nil, nil)
+	defer provider.Close()
+
+	// Replace production caches with fake-clock caches (no background cleanup).
+	provider.tokenCache.Close()
+	provider.tokenCache = cache.NewCache(cache.CacheConfig{
+		Name:            "m365-token-test",
+		DefaultTTL:      55 * time.Minute,
+		CleanupInterval: 0,
+		Clock:           clk,
+	})
+	provider.delegatedTokenCache.Close()
+	provider.delegatedTokenCache = cache.NewCache(cache.CacheConfig{
+		Name:            "m365-delegated-token-test",
+		DefaultTTL:      55 * time.Minute,
+		CleanupInterval: 0,
+		Clock:           clk,
+	})
+
+	// Token expires 60 minutes from startTime; cache TTL = 60min - 5min = 55min.
+	token := &AccessToken{
+		Token:     "test-access-token",
+		TokenType: "Bearer",
+		ExpiresAt: startTime.Add(60 * time.Minute),
+	}
+	provider.setCachedToken("tenant1", token)
+
+	// At T0 the token must be present.
+	clk.now = startTime
+	got := provider.getCachedToken("tenant1")
+	require.NotNil(t, got, "token must be cached at T0")
+	assert.Equal(t, "test-access-token", got.Token)
+
+	// At T0+54min the token must still be present (within the 55-min window).
+	clk.now = startTime.Add(54 * time.Minute)
+	got = provider.getCachedToken("tenant1")
+	assert.NotNil(t, got, "token must still be cached at T0+54min")
+
+	// At T0+56min the TTL has elapsed; the cache must return nothing.
+	clk.now = startTime.Add(56 * time.Minute)
+	got = provider.getCachedToken("tenant1")
+	assert.Nil(t, got, "token must be absent from cache at T0+56min (TTL=55min)")
+}
+
+// TestOAuth2Provider_DelegatedTokenCacheExpiry mirrors TestOAuth2Provider_TokenCacheExpiry
+// for the delegated token cache.
+func TestOAuth2Provider_DelegatedTokenCacheExpiry(t *testing.T) {
+	startTime := time.Now()
+	clk := &testClock{now: startTime}
+
+	provider := NewOAuth2Provider(&failingCredentialStore{}, nil, nil)
+	defer provider.Close()
+
+	provider.tokenCache.Close()
+	provider.tokenCache = cache.NewCache(cache.CacheConfig{
+		Name:            "m365-token-test",
+		DefaultTTL:      55 * time.Minute,
+		CleanupInterval: 0,
+		Clock:           clk,
+	})
+	provider.delegatedTokenCache.Close()
+	provider.delegatedTokenCache = cache.NewCache(cache.CacheConfig{
+		Name:            "m365-delegated-token-test",
+		DefaultTTL:      55 * time.Minute,
+		CleanupInterval: 0,
+		Clock:           clk,
+	})
+
+	token := &AccessToken{
+		Token:     "delegated-token",
+		TokenType: "Bearer",
+		ExpiresAt: startTime.Add(60 * time.Minute),
+	}
+	cacheKey := "tenant1:user1"
+	provider.setDelegatedCachedToken(cacheKey, token)
+
+	clk.now = startTime
+	got := provider.getDelegatedCachedToken(cacheKey)
+	require.NotNil(t, got, "delegated token must be cached at T0")
+	assert.Equal(t, "delegated-token", got.Token)
+
+	clk.now = startTime.Add(56 * time.Minute)
+	got = provider.getDelegatedCachedToken(cacheKey)
+	assert.Nil(t, got, "delegated token must be absent after TTL elapses")
+}
+
+// TestOAuth2Provider_setCachedToken_skipsTTLTooShort verifies that tokens
+// already within the 5-minute buffer window are not stored in the cache.
+func TestOAuth2Provider_setCachedToken_skipsTTLTooShort(t *testing.T) {
+	provider := NewOAuth2Provider(&failingCredentialStore{}, nil, nil)
+	defer provider.Close()
+
+	// Token expires in 3 minutes — within the 5-minute buffer, TTL would be negative.
+	token := &AccessToken{
+		Token:     "almost-expired-token",
+		TokenType: "Bearer",
+		ExpiresAt: time.Now().Add(3 * time.Minute),
+	}
+	provider.setCachedToken("tenant1", token)
+	assert.Nil(t, provider.getCachedToken("tenant1"), "token near expiry must not be cached")
+}
+
+// TestOAuth2Provider_ClearMethods verifies all five Clear* methods delegate
+// correctly to pkg/cache without panicking.
+func TestOAuth2Provider_ClearMethods(t *testing.T) {
+	provider := NewOAuth2Provider(&failingCredentialStore{}, nil, nil)
+	defer provider.Close()
+
+	token := &AccessToken{Token: "tok", ExpiresAt: time.Now().Add(60 * time.Minute)}
+	provider.setCachedToken("t1", token)
+	provider.setCachedToken("t2", token)
+	provider.setDelegatedCachedToken("t1:u1", token)
+	provider.setDelegatedCachedToken("t1:u2", token)
+	provider.setDelegatedCachedToken("t2:u1", token)
+
+	// ClearCacheForTenant removes only the targeted tenant.
+	provider.ClearCacheForTenant("t1")
+	assert.Nil(t, provider.getCachedToken("t1"))
+	assert.NotNil(t, provider.getCachedToken("t2"))
+
+	// ClearDelegatedCacheForUser removes only the targeted user.
+	provider.ClearDelegatedCacheForUser("t1", "u1")
+	assert.Nil(t, provider.getDelegatedCachedToken("t1:u1"))
+	assert.NotNil(t, provider.getDelegatedCachedToken("t1:u2"))
+
+	// ClearDelegatedCacheForTenant removes all users for the tenant.
+	provider.ClearDelegatedCacheForTenant("t1")
+	assert.Nil(t, provider.getDelegatedCachedToken("t1:u2"))
+	assert.NotNil(t, provider.getDelegatedCachedToken("t2:u1"))
+
+	// ClearCache wipes all application tokens.
+	provider.ClearCache()
+	assert.Nil(t, provider.getCachedToken("t2"))
+
+	// ClearDelegatedCache wipes all delegated tokens.
+	provider.ClearDelegatedCache()
+	assert.Nil(t, provider.getDelegatedCachedToken("t2:u1"))
+}
+
 // TestOAuth2Provider_refreshDelegated_storeFailure_logsWarning verifies that
 // RefreshDelegatedToken logs warnings when delegated token and user context
 // storage fail.
@@ -168,7 +324,9 @@ func TestOAuth2Provider_refreshDelegated_storeFailure_logsWarning(t *testing.T) 
 			"refresh_token": "new-refresh",
 		}
 		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(resp)
+		if err := json.NewEncoder(w).Encode(resp); err != nil {
+			http.Error(w, "encode failed", http.StatusInternalServerError)
+		}
 	}))
 	defer mockServer.Close()
 
@@ -196,5 +354,28 @@ func TestOAuth2Provider_refreshDelegated_storeFailure_logsWarning(t *testing.T) 
 	assert.NotNil(t, token)
 
 	warnLogs := mockLog.GetLogs("warn")
-	require.GreaterOrEqual(t, len(warnLogs), 1, "expected at least one warn log")
+	require.GreaterOrEqual(t, len(warnLogs), 2, "expected warn logs for delegated token and user context store failures")
+
+	messages := make([]string, len(warnLogs))
+	for i, l := range warnLogs {
+		messages[i] = l.Message
+	}
+	assert.Contains(t, messages, "failed to store delegated token")
+	assert.Contains(t, messages, "failed to store user context")
+}
+
+// TestOAuth2Provider_GetAccessToken_configError verifies that GetAccessToken returns
+// a CONFIG_ERROR when no OAuth2 configuration can be resolved for the tenant.
+func TestOAuth2Provider_GetAccessToken_configError(t *testing.T) {
+	// getConfigErr causes the credential store to return an error; nil defaultConfig
+	// removes the fallback so getOAuth2Config has no configuration to return.
+	credStore := &failingCredentialStore{getConfigErr: errors.New("config unavailable")}
+	provider := NewOAuth2Provider(credStore, nil, nil)
+	defer provider.Close()
+
+	_, err := provider.GetAccessToken(context.Background(), "unknown-tenant")
+	require.Error(t, err)
+	authErr, ok := err.(*AuthenticationError)
+	require.True(t, ok, "expected *AuthenticationError")
+	assert.Equal(t, "CONFIG_ERROR", authErr.Code)
 }

--- a/features/modules/m365/auth/oauth2_provider_test.go
+++ b/features/modules/m365/auth/oauth2_provider_test.go
@@ -275,6 +275,56 @@ func TestOAuth2Provider_setCachedToken_skipsTTLTooShort(t *testing.T) {
 	assert.Nil(t, provider.getCachedToken("tenant1"), "token near expiry must not be cached")
 }
 
+// TestOAuth2Provider_setCachedToken_evictsStaleEntry verifies that calling setCachedToken
+// with an expired token evicts any pre-existing valid entry for that key.
+func TestOAuth2Provider_setCachedToken_evictsStaleEntry(t *testing.T) {
+	provider := NewOAuth2Provider(&failingCredentialStore{}, nil, nil)
+	defer provider.Close()
+
+	validToken := &AccessToken{
+		Token:     "valid-token",
+		TokenType: "Bearer",
+		ExpiresAt: time.Now().Add(60 * time.Minute),
+	}
+	provider.setCachedToken("tenant1", validToken)
+	require.NotNil(t, provider.getCachedToken("tenant1"), "valid token must be cached initially")
+
+	expiredToken := &AccessToken{
+		Token:     "expired-token",
+		TokenType: "Bearer",
+		ExpiresAt: time.Now().Add(-time.Hour),
+	}
+	provider.setCachedToken("tenant1", expiredToken)
+
+	assert.Nil(t, provider.getCachedToken("tenant1"), "stale entry must be evicted when setCachedToken is called with an expired token")
+}
+
+// TestOAuth2Provider_setDelegatedCachedToken_evictsStaleEntry verifies that calling
+// setDelegatedCachedToken with an expired token evicts any pre-existing valid entry.
+func TestOAuth2Provider_setDelegatedCachedToken_evictsStaleEntry(t *testing.T) {
+	provider := NewOAuth2Provider(&failingCredentialStore{}, nil, nil)
+	defer provider.Close()
+
+	cacheKey := "tenant1:user1"
+
+	validToken := &AccessToken{
+		Token:     "valid-delegated-token",
+		TokenType: "Bearer",
+		ExpiresAt: time.Now().Add(60 * time.Minute),
+	}
+	provider.setDelegatedCachedToken(cacheKey, validToken)
+	require.NotNil(t, provider.getDelegatedCachedToken(cacheKey), "valid token must be cached initially")
+
+	expiredToken := &AccessToken{
+		Token:     "expired-delegated-token",
+		TokenType: "Bearer",
+		ExpiresAt: time.Now().Add(-time.Hour),
+	}
+	provider.setDelegatedCachedToken(cacheKey, expiredToken)
+
+	assert.Nil(t, provider.getDelegatedCachedToken(cacheKey), "stale entry must be evicted when setDelegatedCachedToken is called with an expired token")
+}
+
 // TestOAuth2Provider_ClearMethods verifies all five Clear* methods delegate
 // correctly to pkg/cache without panicking.
 func TestOAuth2Provider_ClearMethods(t *testing.T) {


### PR DESCRIPTION
## Summary

- Replaces two hand-rolled `map[string]*cachedToken` + `sync.RWMutex` token caches in `features/modules/m365/auth/oauth2_provider.go` with two `pkg/cache.Cache` instances, eliminating manual mutex management and bespoke expiry-buffer logic
- The 5-minute buffer is now encoded as a TTL offset at `Set` time (`ExpiresAt - now - 5min`); tokens within the buffer window are skipped (logged at debug)
- Adds `Close()` to properly stop background cleanup goroutines
- All five `Clear*` methods delegate to `pkg/cache` (`Clear()`, `Delete()`, `Keys()+Delete()`)

## Test plan

- [x] `TestOAuth2Provider_TokenCacheExpiry` — fake Clock verifies token absent after TTL elapses (primary acceptance criterion)
- [x] `TestOAuth2Provider_DelegatedTokenCacheExpiry` — same for delegated cache
- [x] `TestOAuth2Provider_setCachedToken_skipsTTLTooShort` — tokens near expiry are not cached
- [x] `TestOAuth2Provider_ClearMethods` — all five Clear* methods exercised with scope assertions
- [x] `TestOAuth2Provider_GetAccessToken_configError` — CONFIG_ERROR path now covered (uses `getConfigErr`)
- [x] Pre-existing test quality fixes: encode-error propagation in httptest handlers; message-content assertions in refresh delegated warn test

## Specialist Review Results

| Reviewer | Result |
|----------|--------|
| QA Test Runner | **PASS** — all packages pass, cross-platform builds pass |
| QA Code Reviewer | **PASS** — no mocks, no skips, no empty assertions, all blocking issues resolved |
| Security Engineer | **PASS** — no secrets, no central provider violations, all scans clean |

Fixes #1201

🤖 Generated with [Claude Code](https://claude.com/claude-code)