### PR TITLE
test: isolate provider blank imports into providers_test.go (Issue #1205)

### DIFF
--- a/pkg/audit/manager_test.go
+++ b/pkg/audit/manager_test.go
@@ -19,11 +19,6 @@ import (
 	secretsInterfaces "github.com/cfgis/cfgms/pkg/secrets/interfaces"
 	"github.com/cfgis/cfgms/pkg/storage/interfaces"
 	"github.com/cfgis/cfgms/pkg/storage/interfaces/business"
-
-	// Import storage providers to register them
-	_ "github.com/cfgis/cfgms/pkg/storage/providers/database"
-	_ "github.com/cfgis/cfgms/pkg/storage/providers/flatfile"
-	_ "github.com/cfgis/cfgms/pkg/storage/providers/sqlite"
 )
 
 // testSecretStore is a minimal in-memory implementation of secretsInterfaces.SecretStore

--- a/pkg/audit/providers_test.go
+++ b/pkg/audit/providers_test.go
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+package audit
+
+// Provider registration for tests in this package.
+// The audit manager tests use interfaces.CreateOSSStorageManager which
+// requires database, flatfile, and sqlite providers to be registered.
+// These blank imports trigger the providers' init() registration.
+// Isolated to this file so manager_test.go does not directly import
+// concrete provider packages (per epic #731).
+import (
+	_ "github.com/cfgis/cfgms/pkg/storage/providers/database"
+	_ "github.com/cfgis/cfgms/pkg/storage/providers/flatfile"
+	_ "github.com/cfgis/cfgms/pkg/storage/providers/sqlite"
+)

--- a/pkg/registration/adapter_test.go
+++ b/pkg/registration/adapter_test.go
@@ -14,7 +14,7 @@ import (
 
 	"github.com/cfgis/cfgms/pkg/storage/interfaces"
 	business "github.com/cfgis/cfgms/pkg/storage/interfaces/business"
-	_ "github.com/cfgis/cfgms/pkg/storage/providers/sqlite"
+	_ "github.com/cfgis/cfgms/pkg/testing"
 )
 
 func TestStorageAdapter_WithSQLiteStore(t *testing.T) {


### PR DESCRIPTION
## Summary

- Remove direct `pkg/storage/providers/*` blank imports from `pkg/audit/manager_test.go` and `pkg/registration/adapter_test.go` (epic #731 violations)
- Create `pkg/audit/providers_test.go` (new file) containing only the three blank provider imports isolated from test logic — same `package audit`, still test-only via `_test.go` suffix
- Replace `_ "github.com/cfgis/cfgms/pkg/storage/providers/sqlite"` in `pkg/registration/adapter_test.go` with `_ "github.com/cfgis/cfgms/pkg/testing"`, which transitively registers the required providers

Fixes #1205

## Approach

**Path B (PO-approved):** Keep `pkg/audit/manager_test.go` as `package audit` (internal). Isolate the blank provider imports into a dedicated `pkg/audit/providers_test.go` file (also `package audit`, test-only via suffix). This satisfies the architectural rule — production binaries never link these provider packages — without converting the test package or adding export shims.

## Test plan

- [x] `go test ./pkg/audit/... ./pkg/registration/...` passes — all tests green, zero new `t.Skip`
- [x] `make test-agent-complete` passes — 128 packages, all passing
- [x] Cross-platform builds verified (linux/amd64, linux/arm64, darwin/amd64, darwin/arm64, windows/amd64)
- [x] `make check-architecture` — no central provider violations
- [x] `make security-scan` — Trivy, Nancy, gosec, staticcheck all pass

## Specialist Review Results

**QA Test Runner: PASS**
- All 128 packages pass, zero failures
- Cross-platform builds verified

**QA Code Reviewer: PASS**
- 0 blocking issues, 0 warnings
- No mocks, no `t.Skip`, no empty assertions introduced

**Security Engineer: PASS**
- 0 blocking issues, 0 warnings
- check-architecture: PASS, security-scan: PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)