### PR TITLE
refactor: delete dead cache fields from saas/multitenant and integration/access_control (Issue #1202)

### DIFF
--- a/features/integration/access_control.go
+++ b/features/integration/access_control.go
@@ -88,9 +88,6 @@ const (
 // PerformanceConfig defines performance-related configuration
 type PerformanceConfig struct {
 	MaxProcessingTime        time.Duration `json:"max_processing_time"`
-	EnableCaching            bool          `json:"enable_caching"`
-	CacheTimeout             time.Duration `json:"cache_timeout"`
-	EnableParallelEval       bool          `json:"enable_parallel_eval"`
 	RiskAssessmentTimeout    time.Duration `json:"risk_assessment_timeout"`
 	ContinuousAuthTimeout    time.Duration `json:"continuous_auth_timeout"`
 	MaxContinuousAuthLatency time.Duration `json:"max_continuous_auth_latency"`
@@ -217,9 +214,6 @@ func NewEnhancedAccessControlManager(
 		enableZeroTrustPolicies: false,                       // Default to disabled
 		performanceConfig: &PerformanceConfig{
 			MaxProcessingTime:        5 * time.Second,
-			EnableCaching:            true,
-			CacheTimeout:             10 * time.Minute,
-			EnableParallelEval:       false,
 			RiskAssessmentTimeout:    2 * time.Second,
 			ContinuousAuthTimeout:    500 * time.Millisecond,
 			MaxContinuousAuthLatency: 10 * time.Millisecond,

--- a/features/saas/multitenant.go
+++ b/features/saas/multitenant.go
@@ -35,7 +35,6 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/cfgis/cfgms/pkg/logging"
@@ -50,9 +49,6 @@ type MultiTenantManager struct {
 	tenantDiscoverer TenantDiscoverer
 	logger           logging.Logger
 
-	// Cache of tenant discovery results to avoid repeated API calls
-	tenantCache map[string]*TenantDiscoveryResult
-	cacheMu     sync.RWMutex
 	cacheExpiry time.Duration
 }
 
@@ -72,7 +68,6 @@ func NewMultiTenantManager(credStore CredentialStore, consentStore ConsentStore,
 		oauth2Client:     NewOAuth2Client(httpClient, nil),
 		tenantDiscoverer: discoverer,
 		logger:           logger,
-		tenantCache:      make(map[string]*TenantDiscoveryResult),
 		cacheExpiry:      15 * time.Minute,
 	}
 }
@@ -257,11 +252,6 @@ func (mtm *MultiTenantManager) CompleteAdminConsent(ctx context.Context, provide
 		return fmt.Errorf("failed to update consent status: %w", err)
 	}
 
-	// Cache the discovery result
-	mtm.cacheMu.Lock()
-	mtm.tenantCache[provider] = discoveryResult
-	mtm.cacheMu.Unlock()
-
 	return nil
 }
 
@@ -372,11 +362,6 @@ func (mtm *MultiTenantManager) RefreshTenantDiscovery(ctx context.Context, provi
 		return fmt.Errorf("failed to update consent status: %w", err)
 	}
 
-	// Update cache
-	mtm.cacheMu.Lock()
-	mtm.tenantCache[provider] = discoveryResult
-	mtm.cacheMu.Unlock()
-
 	return nil
 }
 
@@ -402,11 +387,6 @@ func (mtm *MultiTenantManager) RevokeConsent(ctx context.Context, provider strin
 	if err := mtm.consentStore.DeleteConsent(provider); err != nil {
 		return fmt.Errorf("failed to delete consent status: %w", err)
 	}
-
-	// Clear cache
-	mtm.cacheMu.Lock()
-	delete(mtm.tenantCache, provider)
-	mtm.cacheMu.Unlock()
 
 	return nil
 }

--- a/features/saas/multitenant_test.go
+++ b/features/saas/multitenant_test.go
@@ -777,11 +777,9 @@ func TestMicrosoftMultiTenantProvider_CreateInTenant(t *testing.T) {
 	}
 }
 
-// TestMultiTenantManager_TenantCacheConcurrency verifies that concurrent writes
-// to tenantCache (from RefreshTenantDiscovery triggered directly and via
-// ListAccessibleTenants) do not cause data races under go test -race.
-// tenantCache has no direct read paths in the current code, so this test exercises
-// write-write safety. The RWMutex is chosen to be forward-compatible with future reads.
+// TestMultiTenantManager_TenantCacheConcurrency verifies that concurrent calls to
+// RefreshTenantDiscovery (triggered directly and via ListAccessibleTenants) do not
+// cause data races or errors under go test -race.
 func TestMultiTenantManager_TenantCacheConcurrency(t *testing.T) {
 	credStore := newTestCredentialStore(t)
 	consentStore := NewInMemoryConsentStore()
@@ -805,7 +803,7 @@ func TestMultiTenantManager_TenantCacheConcurrency(t *testing.T) {
 	require.NoError(t, err)
 
 	// Set LastTenantDiscovery in the past so ListAccessibleTenants triggers a
-	// RefreshTenantDiscovery call, maximising concurrent write contention on tenantCache.
+	// RefreshTenantDiscovery call, maximising concurrent write contention on the consentStore.
 	err = consentStore.StoreConsent(provider, &ConsentStatus{
 		Provider:            provider,
 		HasAdminConsent:     true,


### PR DESCRIPTION
## Summary

- Removes `tenantCache map[string]*TenantDiscoveryResult` and `cacheMu sync.RWMutex` from `MultiTenantManager` in `features/saas/multitenant.go` — fields were written on every discovery/revoke but never read; `consentStore` is the durable authoritative source
- Removes `EnableCaching bool`, `CacheTimeout time.Duration`, and `EnableParallelEval bool` from `PerformanceConfig` in `features/integration/access_control.go` — all three set but never read anywhere in the codebase
- Updates `TestMultiTenantManager_TenantCacheConcurrency` comment to accurately describe what is under concurrent contention after the deletion

Fixes #1202

Part of Epic #729 — adopt pkg/cache / remove in-package mini-caches.

## Specialist Review Results

| Reviewer | Result |
|---|---|
| QA Test Runner (`make test-agent-complete`) | ✅ PASS — all packages, cross-platform builds, integration tests |
| QA Code Reviewer | ✅ PASS — 0 blocking issues, 0 warnings |
| Security Engineer | ✅ PASS — 0 blocking issues; scans clean (precommit, architecture, full scan) |

## Test plan

- [x] `go test ./features/saas/... ./features/integration/... -race -count=1` passes
- [x] `grep -rn "tenantCache\|cacheMu" features/saas/` — no results
- [x] `grep -rn "\.EnableCaching\|\.CacheTimeout\|\.EnableParallelEval" features/integration/` — no results
- [x] `make test-agent-complete` — all gates pass
- [x] Cross-platform compilation verified (linux/amd64, linux/arm64, darwin/amd64, darwin/arm64, windows/amd64)

🤖 Generated with [Claude Code](https://claude.com/claude-code)