### PR TITLE
test: consolidate RBAC provider blank imports into providers_test.go files (Issue #1207)

### DIFF
--- a/features/rbac/advanced_permissions_test.go
+++ b/features/rbac/advanced_permissions_test.go
@@ -13,10 +13,6 @@ import (
 	"github.com/cfgis/cfgms/api/proto/common"
 	"github.com/cfgis/cfgms/pkg/storage/interfaces"
 	business "github.com/cfgis/cfgms/pkg/storage/interfaces/business"
-
-	// Import storage providers for testing
-	_ "github.com/cfgis/cfgms/pkg/storage/providers/flatfile"
-	_ "github.com/cfgis/cfgms/pkg/storage/providers/sqlite"
 )
 
 func TestAdvancedPermissionManagement(t *testing.T) {

--- a/features/rbac/audit_integration_test.go
+++ b/features/rbac/audit_integration_test.go
@@ -7,16 +7,12 @@ import (
 	"testing"
 	"time"
 
-	"github.com/cfgis/cfgms/api/proto/common"
-	"github.com/cfgis/cfgms/pkg/storage/interfaces"
-
-	// Import storage providers to register them
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/cfgis/cfgms/api/proto/common"
+	"github.com/cfgis/cfgms/pkg/storage/interfaces"
 	business "github.com/cfgis/cfgms/pkg/storage/interfaces/business"
-	_ "github.com/cfgis/cfgms/pkg/storage/providers/flatfile"
-	_ "github.com/cfgis/cfgms/pkg/storage/providers/sqlite"
 )
 
 // TestRBACManager_AuditIntegration tests that RBAC operations generate proper audit events

--- a/features/rbac/delegation_test.go
+++ b/features/rbac/delegation_test.go
@@ -14,9 +14,6 @@ import (
 
 	"github.com/cfgis/cfgms/api/proto/common"
 	"github.com/cfgis/cfgms/pkg/storage/interfaces"
-
-	_ "github.com/cfgis/cfgms/pkg/storage/providers/flatfile"
-	_ "github.com/cfgis/cfgms/pkg/storage/providers/sqlite"
 )
 
 // newTestDelegationSetup constructs a DelegationManager backed by real storage.

--- a/features/rbac/escalation_prevention_test.go
+++ b/features/rbac/escalation_prevention_test.go
@@ -12,10 +12,6 @@ import (
 
 	"github.com/cfgis/cfgms/api/proto/common"
 	"github.com/cfgis/cfgms/pkg/storage/interfaces"
-
-	// Import storage providers for testing
-	_ "github.com/cfgis/cfgms/pkg/storage/providers/flatfile"
-	_ "github.com/cfgis/cfgms/pkg/storage/providers/sqlite"
 )
 
 // TestEscalationOperationType_Constants verifies that EscalationOperationType constants

--- a/features/rbac/jit/access_manager_test.go
+++ b/features/rbac/jit/access_manager_test.go
@@ -16,11 +16,6 @@ import (
 	"github.com/cfgis/cfgms/pkg/audit"
 	"github.com/cfgis/cfgms/pkg/storage/interfaces"
 	business "github.com/cfgis/cfgms/pkg/storage/interfaces/business"
-
-	// Import storage providers to register them
-	_ "github.com/cfgis/cfgms/pkg/storage/providers/database"
-	_ "github.com/cfgis/cfgms/pkg/storage/providers/flatfile"
-	_ "github.com/cfgis/cfgms/pkg/storage/providers/sqlite"
 )
 
 func TestNewJITAccessManager(t *testing.T) {

--- a/features/rbac/jit/providers_test.go
+++ b/features/rbac/jit/providers_test.go
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+package jit
+
+// Provider registration for tests in this package.
+// JIT tests use interfaces.CreateOSSStorageManager which requires
+// these providers to be registered. These blank imports trigger the
+// providers' init() registration.
+// Cannot use pkg/testing helpers due to import cycle (pkg/testing
+// imports features/rbac). See epic #731.
+import (
+	_ "github.com/cfgis/cfgms/pkg/storage/providers/database"
+	_ "github.com/cfgis/cfgms/pkg/storage/providers/flatfile"
+	_ "github.com/cfgis/cfgms/pkg/storage/providers/sqlite"
+)

--- a/features/rbac/manager_hierarchy_test.go
+++ b/features/rbac/manager_hierarchy_test.go
@@ -12,10 +12,6 @@ import (
 
 	"github.com/cfgis/cfgms/api/proto/common"
 	"github.com/cfgis/cfgms/pkg/storage/interfaces"
-
-	// Import storage providers for testing
-	_ "github.com/cfgis/cfgms/pkg/storage/providers/flatfile"
-	_ "github.com/cfgis/cfgms/pkg/storage/providers/sqlite"
 )
 
 func TestManager_CreateRoleWithParent(t *testing.T) {

--- a/features/rbac/manager_storage_test.go
+++ b/features/rbac/manager_storage_test.go
@@ -7,16 +7,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/cfgis/cfgms/api/proto/common"
-	"github.com/cfgis/cfgms/pkg/storage/interfaces"
-
-	// Import storage providers to register them
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	_ "github.com/cfgis/cfgms/pkg/storage/providers/database"
-	_ "github.com/cfgis/cfgms/pkg/storage/providers/flatfile"
-	_ "github.com/cfgis/cfgms/pkg/storage/providers/sqlite"
+	"github.com/cfgis/cfgms/api/proto/common"
+	"github.com/cfgis/cfgms/pkg/storage/interfaces"
 )
 
 // TestNewManagerWithStorage tests the new constructor that accepts storage interfaces

--- a/features/rbac/manager_test.go
+++ b/features/rbac/manager_test.go
@@ -14,10 +14,6 @@ import (
 	"github.com/cfgis/cfgms/api/proto/common"
 	"github.com/cfgis/cfgms/features/rbac/continuous"
 	"github.com/cfgis/cfgms/pkg/storage/interfaces"
-
-	// Import storage providers for testing
-	_ "github.com/cfgis/cfgms/pkg/storage/providers/flatfile"
-	_ "github.com/cfgis/cfgms/pkg/storage/providers/sqlite"
 )
 
 func TestManager_Initialize(t *testing.T) {

--- a/features/rbac/providers_test.go
+++ b/features/rbac/providers_test.go
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+package rbac
+
+// Provider registration for tests in this package.
+// RBAC tests use interfaces.CreateOSSStorageManager which requires
+// these providers to be registered. These blank imports trigger the
+// providers' init() registration.
+// Cannot use pkg/testing helpers due to import cycle (pkg/testing
+// imports features/rbac). See epic #731.
+import (
+	_ "github.com/cfgis/cfgms/pkg/storage/providers/database"
+	_ "github.com/cfgis/cfgms/pkg/storage/providers/flatfile"
+	_ "github.com/cfgis/cfgms/pkg/storage/providers/sqlite"
+)

--- a/features/rbac/sensitive_operations_test.go
+++ b/features/rbac/sensitive_operations_test.go
@@ -14,9 +14,6 @@ import (
 	"github.com/cfgis/cfgms/api/proto/common"
 	"github.com/cfgis/cfgms/pkg/storage/interfaces"
 	business "github.com/cfgis/cfgms/pkg/storage/interfaces/business"
-
-	_ "github.com/cfgis/cfgms/pkg/storage/providers/flatfile"
-	_ "github.com/cfgis/cfgms/pkg/storage/providers/sqlite"
 )
 
 // TestValidateSensitiveOperation tests validation of sensitive operations

--- a/features/rbac/templates_test.go
+++ b/features/rbac/templates_test.go
@@ -12,10 +12,6 @@ import (
 
 	"github.com/cfgis/cfgms/api/proto/common"
 	"github.com/cfgis/cfgms/pkg/storage/interfaces"
-
-	// Import storage providers for testing
-	_ "github.com/cfgis/cfgms/pkg/storage/providers/flatfile"
-	_ "github.com/cfgis/cfgms/pkg/storage/providers/sqlite"
 )
 
 func setupTemplateTestManager(t *testing.T) (*Manager, context.Context) {

--- a/features/rbac/zerotrust/policy_engine_test.go
+++ b/features/rbac/zerotrust/policy_engine_test.go
@@ -17,10 +17,6 @@ import (
 	"github.com/cfgis/cfgms/pkg/audit"
 	"github.com/cfgis/cfgms/pkg/storage/interfaces"
 	business "github.com/cfgis/cfgms/pkg/storage/interfaces/business"
-
-	// storage providers for in-test audit manager setup
-	_ "github.com/cfgis/cfgms/pkg/storage/providers/flatfile"
-	_ "github.com/cfgis/cfgms/pkg/storage/providers/sqlite"
 )
 
 func TestNewZeroTrustPolicyEngine(t *testing.T) {

--- a/features/rbac/zerotrust/providers_test.go
+++ b/features/rbac/zerotrust/providers_test.go
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+package zerotrust
+
+// Provider registration for tests in this package.
+// Zero trust tests use interfaces.CreateOSSStorageManager which requires
+// these providers to be registered. These blank imports trigger the
+// providers' init() registration.
+// Cannot use pkg/testing helpers due to import cycle (pkg/testing
+// imports features/rbac). See epic #731.
+import (
+	_ "github.com/cfgis/cfgms/pkg/storage/providers/flatfile"
+	_ "github.com/cfgis/cfgms/pkg/storage/providers/sqlite"
+)


### PR DESCRIPTION
## Summary

- Created 3 new `providers_test.go` files (one per sub-package) that consolidate all `pkg/storage/providers/*` blank imports from 11 RBAC test files
- Removed direct provider blank imports from all 11 existing test files; `interfaces.CreateOSSStorageManager` calls are unchanged
- Added explanatory comments in each `providers_test.go` documenting the import-cycle constraint that prevents using `pkg/testing` helpers

Fixes #1207

## Context

`pkg/testing` imports `features/rbac`, so any RBAC test file importing `pkg/testing` creates the cycle `features/rbac → pkg/testing → features/rbac`. The providers_test.go pattern is the correct consolidation approach for internal packages.

## Files Changed

**New files:**
- `features/rbac/providers_test.go` — database + flatfile + sqlite
- `features/rbac/jit/providers_test.go` — database + flatfile + sqlite
- `features/rbac/zerotrust/providers_test.go` — flatfile + sqlite

**Modified (blank provider imports removed):**
- `features/rbac/manager_test.go`
- `features/rbac/advanced_permissions_test.go`
- `features/rbac/audit_integration_test.go`
- `features/rbac/delegation_test.go`
- `features/rbac/escalation_prevention_test.go`
- `features/rbac/manager_hierarchy_test.go`
- `features/rbac/manager_storage_test.go`
- `features/rbac/sensitive_operations_test.go`
- `features/rbac/templates_test.go`
- `features/rbac/jit/access_manager_test.go`
- `features/rbac/zerotrust/policy_engine_test.go`

## Specialist Review Results

| Reviewer | Result | Notes |
|----------|--------|-------|
| QA Test Runner | **PASS** | All ~100 packages pass; 0 lint issues; all cross-platform builds pass |
| QA Code Reviewer | **PASS** | Pre-existing mocks in jit/zerotrust are out of scope for this story; no new mocks or t.Skip introduced |
| Security Engineer | **PASS** | security-precommit, check-architecture, security-scan all PASS; 0 blocking issues |

## Test Plan

- [x] `go test ./features/rbac/... ./features/rbac/jit/... ./features/rbac/zerotrust/...` — all pass
- [x] `golangci-lint run ./features/rbac/...` — 0 issues
- [x] `make test-agent-complete` — PASS (all gates)
- [x] Zero `pkg/storage/providers/*` imports remain in the 11 original test files
- [x] Zero `pkg/testing` imports in any of the 11 files
- [x] All `interfaces.CreateOSSStorageManager` calls preserved unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)