### PR TITLE
docs(cert,config/git): add pkg/cache exemption comments to disk-synchronised indexes (Issue #1203)

### DIFF
--- a/features/config/git/manager.go
+++ b/features/config/git/manager.go
@@ -16,11 +16,12 @@ import (
 
 // DefaultGitManager implements the GitManager interface
 type DefaultGitManager struct {
-	provider     GitProvider
-	store        RepositoryStore
-	syncManager  SyncManager
-	hookManager  HookManager
-	sopsManager  *SOPSManager
+	provider    GitProvider
+	store       RepositoryStore
+	syncManager SyncManager
+	hookManager HookManager
+	sopsManager *SOPSManager
+	// Authoritative in-memory state: RepositoryStore (git filesystem) has no metadata persistence layer. These maps are the only record of registered repositories and their local paths. Not a cache — pkg/cache migration would make repository registration non-durable across restarts.
 	repositories map[string]*Repository
 	localCache   map[string]string // repoID -> local path
 	mu           sync.RWMutex

--- a/features/config/git/module_repository.go
+++ b/features/config/git/module_repository.go
@@ -16,8 +16,9 @@ import (
 
 // ModuleRepositoryManager manages script and module repositories
 type ModuleRepositoryManager struct {
-	gitManager   GitManager
-	store        RepositoryStore
+	gitManager GitManager
+	store      RepositoryStore
+	// Authoritative in-memory state: RepositoryStore (git filesystem) has no metadata persistence layer. These maps are the only record of registered repositories and their local paths. Not a cache — pkg/cache migration would make repository registration non-durable across restarts.
 	moduleCache  map[string]*CustomModule // module_id -> module
 	repoCache    map[string]*Repository   // repo_id -> repository
 	mu           sync.RWMutex

--- a/pkg/cert/storage.go
+++ b/pkg/cert/storage.go
@@ -17,7 +17,8 @@ import (
 type FileStore struct {
 	mu       sync.RWMutex
 	basePath string
-	certs    map[string]*CertificateInfo // indexed by serial number
+	// Disk-synchronised index: authoritative in-memory snapshot of PEM files on disk. Populated by loadCertificates on init and kept consistent on every StoreCertificate/DeleteCertificate call. Not a cache — migrating to pkg/cache would lose the write-through-to-disk invariant.
+	certs map[string]*CertificateInfo // indexed by serial number
 }
 
 // NewFileStore creates a new filesystem-based certificate store


### PR DESCRIPTION
## Summary

- Adds exemption doc comments to three map+mutex constructs in `pkg/cert/storage.go`, `features/config/git/manager.go`, and `features/config/git/module_repository.go` that were flagged as pkg/cache migration candidates under Epic #729
- Each comment explains WHY the map is an authoritative in-memory index backed by filesystem state, not a cache — so future reviewers can verify the exemption remains valid
- No functional code changed in any of the three files

Fixes #1203

## Changes

| File | Field(s) | Exemption rationale |
|------|----------|---------------------|
| `pkg/cert/storage.go` | `FileStore.certs` | Disk-synchronised index of PEM files; write-through invariant would break with pkg/cache |
| `features/config/git/manager.go` | `DefaultGitManager.repositories`, `.localCache` | Only durable record of registered repos; TTL eviction would make registration non-durable |
| `features/config/git/module_repository.go` | `ModuleRepositoryManager.moduleCache`, `.repoCache` | Same rationale as DefaultGitManager above |

## Specialist Review Results

**QA Test Runner: PASS**
- All quality validation gates passed (`make test-agent-complete`)
- Found and fixed a gofmt field-alignment issue introduced by the comment block insertion
- Unit tests, cross-platform builds (linux/amd64, linux/arm64, darwin/amd64, darwin/arm64, windows/amd64), shell script validation all PASS

**QA Code Reviewer: PASS**
- 0 blocking issues, 0 warnings
- Pure comment additions — no executable code, no mocks, no t.Skip(), no empty assertions

**Security Engineer: PASS**
- security-precommit: PASS (no secrets in changed files)
- check-architecture: PASS (no central provider violations)
- security-scan: PASS (gosec, Trivy, Nancy, staticcheck all clean)
- No functional code changes — zero new security surface