### PR TITLE
test: pkg/config — switch to pkg/testing top-level, drop provider blank imports (Issue #1206)

### DIFF
--- a/pkg/config/inheritance_test.go
+++ b/pkg/config/inheritance_test.go
@@ -13,9 +13,7 @@ import (
 	stewardconfig "github.com/cfgis/cfgms/features/steward/config"
 	business "github.com/cfgis/cfgms/pkg/storage/interfaces/business"
 	cfgconfig "github.com/cfgis/cfgms/pkg/storage/interfaces/config"
-	_ "github.com/cfgis/cfgms/pkg/storage/providers/flatfile"
-	_ "github.com/cfgis/cfgms/pkg/storage/providers/sqlite"
-	teststorage "github.com/cfgis/cfgms/pkg/testing/storage"
+	pkgtesting "github.com/cfgis/cfgms/pkg/testing"
 )
 
 // seedThreeLevelTenants creates root → msp → client tenant hierarchy in the store.
@@ -42,9 +40,7 @@ func marshalStewardConfig(t *testing.T, cfg stewardconfig.StewardConfig) []byte 
 }
 
 func TestGetTenantPath_Returns3LevelAncestorChain(t *testing.T) {
-	sm, err := teststorage.CreateTestStorageManager()
-	require.NoError(t, err)
-	t.Cleanup(func() { _ = sm.Close() })
+	sm := pkgtesting.SetupTestStorage(t)
 
 	ctx := context.Background()
 	seedThreeLevelTenants(t, ctx, sm)
@@ -57,21 +53,17 @@ func TestGetTenantPath_Returns3LevelAncestorChain(t *testing.T) {
 }
 
 func TestGetTenantPath_ErrorOnUnknownTenant(t *testing.T) {
-	sm, err := teststorage.CreateTestStorageManager()
-	require.NoError(t, err)
-	t.Cleanup(func() { _ = sm.Close() })
+	sm := pkgtesting.SetupTestStorage(t)
 
 	ctx := context.Background()
 	ir := NewInheritanceResolverWithStorageManager(sm)
 
-	_, err = ir.getTenantPath(ctx, "nonexistent")
+	_, err := ir.getTenantPath(ctx, "nonexistent")
 	assert.Error(t, err)
 }
 
 func TestResolveConfiguration_3LevelHierarchy(t *testing.T) {
-	sm, err := teststorage.CreateTestStorageManager()
-	require.NoError(t, err)
-	t.Cleanup(func() { _ = sm.Close() })
+	sm := pkgtesting.SetupTestStorage(t)
 
 	ctx := context.Background()
 	seedThreeLevelTenants(t, ctx, sm)
@@ -120,23 +112,19 @@ func TestResolveConfiguration_3LevelHierarchy(t *testing.T) {
 }
 
 func TestResolveConfiguration_ErrorOnUnknownTenant(t *testing.T) {
-	sm, err := teststorage.CreateTestStorageManager()
-	require.NoError(t, err)
-	t.Cleanup(func() { _ = sm.Close() })
+	sm := pkgtesting.SetupTestStorage(t)
 
 	ctx := context.Background()
 	ir := NewInheritanceResolverWithStorageManager(sm)
 
 	// Tenant "ghost" does not exist in the store — ResolveConfiguration must propagate the error.
-	_, err = ir.ResolveConfiguration(ctx, "ghost", "steward-1")
+	_, err := ir.ResolveConfiguration(ctx, "ghost", "steward-1")
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to resolve tenant hierarchy")
 }
 
 func TestResolveConfiguration_LaterLevelOverridesEarlier(t *testing.T) {
-	sm, err := teststorage.CreateTestStorageManager()
-	require.NoError(t, err)
-	t.Cleanup(func() { _ = sm.Close() })
+	sm := pkgtesting.SetupTestStorage(t)
 
 	ctx := context.Background()
 	seedThreeLevelTenants(t, ctx, sm)

--- a/pkg/config/manager_test.go
+++ b/pkg/config/manager_test.go
@@ -11,26 +11,20 @@ import (
 	"github.com/stretchr/testify/require"
 
 	stewardconfig "github.com/cfgis/cfgms/features/steward/config"
-	_ "github.com/cfgis/cfgms/pkg/storage/providers/flatfile"
-	_ "github.com/cfgis/cfgms/pkg/storage/providers/sqlite"
-	pkgtesting "github.com/cfgis/cfgms/pkg/testing/storage"
+	pkgtesting "github.com/cfgis/cfgms/pkg/testing"
 )
 
 // newTestManager creates a Manager backed by a real OSS storage stack for testing.
 func newTestManager(t *testing.T) *Manager {
 	t.Helper()
-	sm, err := pkgtesting.CreateTestStorageManager()
-	require.NoError(t, err)
-	t.Cleanup(func() { _ = sm.Close() })
+	sm := pkgtesting.SetupTestStorage(t)
 	return NewManagerWithStorageManager(sm)
 }
 
 // newTestValidationManager creates a ValidationManager backed by a real OSS storage stack.
 func newTestValidationManager(t *testing.T) *ValidationManager {
 	t.Helper()
-	sm, err := pkgtesting.CreateTestStorageManager()
-	require.NoError(t, err)
-	t.Cleanup(func() { _ = sm.Close() })
+	sm := pkgtesting.SetupTestStorage(t)
 	return NewValidationManager(sm.GetConfigStore())
 }
 


### PR DESCRIPTION
## Summary

- Remove direct `pkg/storage/providers/flatfile` and `pkg/storage/providers/sqlite` blank imports from `pkg/config/manager_test.go` and `pkg/config/inheritance_test.go`
- Switch both files from `pkg/testing/storage` sub-package to `pkg/testing` top-level, whose `storage_helper.go` already blank-imports both providers — so per-file registration is no longer needed
- Replace all `CreateTestStorageManager()` calls with `pkgtesting.SetupTestStorage(t)`, which returns `*interfaces.StorageManager` directly and registers `t.Cleanup` for safe Windows-friendly teardown

Fixes #1206

## Test plan

- [x] `go test ./pkg/config/...` — PASS (11s)
- [x] `make test-agent-complete` — all packages PASS, 0 linting issues, cross-platform builds PASS, security scans PASS
- [x] `make check-architecture` — PASS, no central provider violations
- [x] `make security-precommit` — PASS, no secrets detected

## Specialist Review Results

**QA Test Runner: PASS**
- All packages passing; pkg/config runs cleanly with the updated imports
- golangci-lint: 0 issues; license headers valid; no secrets found
- Cross-platform: linux/amd64, linux/arm64, darwin/amd64, darwin/arm64, windows/amd64 all compile

**QA Code Review: PASS**
- No mocks, no skipped tests, no empty assertions, no swallowed errors introduced
- SetupTestStorage properly registers t.Cleanup; all 17 test functions retain meaningful assertions covering happy paths and error conditions
- 3 pre-existing warnings noted (mock_logger.go, fixtures.go MkdirTemp pattern, fixtures_test.go no-assert subtest) — all out of scope for this story

**Security Review: PASS**
- security-precommit: PASS
- check-architecture: PASS (architectural improvement — provider registration now flows exclusively through pkg/testing helper)
- security-scan: PASS (Trivy, Nancy, gosec, staticcheck all green in blocking mode)
- No hardcoded secrets, SQL injection, information disclosure, TLS issues, or tenant isolation concerns

🤖 Generated with [Claude Code](https://claude.com/claude-code)