### PR TITLE
test: refactor gitsync and trigger tests to use storage interfaces (Issue #1210)

### DIFF
--- a/features/workflow/trigger/controller_factory_test.go
+++ b/features/workflow/trigger/controller_factory_test.go
@@ -17,8 +17,7 @@ import (
 	"github.com/cfgis/cfgms/pkg/logging"
 	storageif "github.com/cfgis/cfgms/pkg/storage/interfaces"
 	cfgconfig "github.com/cfgis/cfgms/pkg/storage/interfaces/config"
-	"github.com/cfgis/cfgms/pkg/storage/providers/flatfile"
-	_ "github.com/cfgis/cfgms/pkg/storage/providers/sqlite"
+	pkgtesting "github.com/cfgis/cfgms/pkg/testing"
 )
 
 // workflowEngineAdapter implements WorkflowTrigger using a real *workflow.Engine and a real
@@ -84,7 +83,9 @@ func newRealWorkflowTrigger(tb testing.TB) WorkflowTrigger {
 // TestNewControllerTriggerManager_ReturnsWiredManager verifies that the factory creates a
 // manager with all three components (scheduler, webhookHandler, siemIntegration) non-nil.
 func TestNewControllerTriggerManager_ReturnsWiredManager(t *testing.T) {
-	storage := &flatfile.FlatFileProvider{}
+	pkgtesting.SetupTestStorage(t)
+	storage, err := storageif.GetStorageProvider("flatfile")
+	require.NoError(t, err)
 	wt := newRealWorkflowTrigger(t)
 
 	manager := NewControllerTriggerManager(storage, wt)
@@ -100,7 +101,9 @@ func TestNewControllerTriggerManager_ReturnsWiredManager(t *testing.T) {
 // TestNewControllerTriggerManager_ComponentsReferenceManager verifies that the two-phase
 // circular-dependency resolution wires each component back to the parent manager.
 func TestNewControllerTriggerManager_ComponentsReferenceManager(t *testing.T) {
-	storage := &flatfile.FlatFileProvider{}
+	pkgtesting.SetupTestStorage(t)
+	storage, err := storageif.GetStorageProvider("flatfile")
+	require.NoError(t, err)
 	wt := newRealWorkflowTrigger(t)
 
 	manager := NewControllerTriggerManager(storage, wt)
@@ -122,7 +125,9 @@ func TestNewControllerTriggerManager_ComponentsReferenceManager(t *testing.T) {
 // TestNewControllerTriggerManager_StartStopLifecycle verifies that the manager created by
 // the factory starts and stops cleanly using the real component implementations.
 func TestNewControllerTriggerManager_StartStopLifecycle(t *testing.T) {
-	storage := &flatfile.FlatFileProvider{}
+	pkgtesting.SetupTestStorage(t)
+	storage, err := storageif.GetStorageProvider("flatfile")
+	require.NoError(t, err)
 	wt := newRealWorkflowTrigger(t)
 
 	manager := NewControllerTriggerManager(storage, wt)
@@ -130,7 +135,7 @@ func TestNewControllerTriggerManager_StartStopLifecycle(t *testing.T) {
 
 	ctx := context.Background()
 
-	err := manager.Start(ctx)
+	err = manager.Start(ctx)
 	assert.NoError(t, err, "Start must succeed with real components")
 	assert.True(t, manager.running, "manager must be running after Start")
 

--- a/pkg/gitsync/syncer_test.go
+++ b/pkg/gitsync/syncer_test.go
@@ -19,7 +19,7 @@ import (
 	secretsif "github.com/cfgis/cfgms/pkg/secrets/interfaces"
 	stewardprovider "github.com/cfgis/cfgms/pkg/secrets/providers/steward"
 	cfgconfig "github.com/cfgis/cfgms/pkg/storage/interfaces/config"
-	"github.com/cfgis/cfgms/pkg/storage/providers/flatfile"
+	pkgtesting "github.com/cfgis/cfgms/pkg/testing"
 )
 
 // requireGit skips the test if the git binary is not found in PATH.
@@ -99,13 +99,12 @@ func newTestRepo(t *testing.T, initialFiles map[string]string) (bareDir, workDir
 	return bare, work, push
 }
 
-// newTestSyncer creates a Syncer wired to a FlatFileConfigStore for testing.
-func newTestSyncer(t *testing.T, opts ...gitsync.Option) (*gitsync.Syncer, *flatfile.FlatFileConfigStore, *gitsync.BindingStore) {
+// newTestSyncer creates a Syncer wired to a real ConfigStore for testing.
+func newTestSyncer(t *testing.T, opts ...gitsync.Option) (*gitsync.Syncer, cfgconfig.ConfigStore, *gitsync.BindingStore) {
 	t.Helper()
 	root := t.TempDir()
 
-	store, err := flatfile.NewFlatFileConfigStore(filepath.Join(root, "configs"))
-	require.NoError(t, err)
+	store := pkgtesting.SetupTestStorage(t).GetConfigStore()
 
 	bindings, err := gitsync.NewBindingStore(root)
 	require.NoError(t, err)

--- a/pkg/gitsync/webhook_test.go
+++ b/pkg/gitsync/webhook_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/cfgis/cfgms/pkg/logging"
 	secretsif "github.com/cfgis/cfgms/pkg/secrets/interfaces"
 	cfgconfig "github.com/cfgis/cfgms/pkg/storage/interfaces/config"
-	"github.com/cfgis/cfgms/pkg/storage/providers/flatfile"
+	pkgtesting "github.com/cfgis/cfgms/pkg/testing"
 )
 
 // buildPushPayload returns a JSON push-event payload for the given origin URL
@@ -56,14 +56,13 @@ type webhookTestSetup struct {
 	bindings *gitsync.BindingStore
 }
 
-// newWebhookSetup creates a WebhookHandler backed by a real FlatFileConfigStore
+// newWebhookSetup creates a WebhookHandler backed by a real ConfigStore
 // and a BindingStore pre-populated with the given bindings.
 func newWebhookSetup(t *testing.T, bs []gitsync.ScopeBinding) *webhookTestSetup {
 	t.Helper()
 	root := t.TempDir()
 
-	store, err := flatfile.NewFlatFileConfigStore(filepath.Join(root, "configs"))
-	require.NoError(t, err)
+	store := pkgtesting.SetupTestStorage(t).GetConfigStore()
 
 	bindings, err := gitsync.NewBindingStore(root)
 	require.NoError(t, err)
@@ -388,8 +387,7 @@ func TestWebhookWaitForPendingSyncsDrainsBeforeDeadline(t *testing.T) {
 
 	// Build components directly so the store is accessible for result verification.
 	root := t.TempDir()
-	store, err := flatfile.NewFlatFileConfigStore(filepath.Join(root, "configs"))
-	require.NoError(t, err)
+	store := pkgtesting.SetupTestStorage(t).GetConfigStore()
 
 	bindings, err := gitsync.NewBindingStore(root)
 	require.NoError(t, err)
@@ -465,8 +463,7 @@ func TestResolveWebhookSecret_SecretScheme(t *testing.T) {
 		}))
 
 		root := t.TempDir()
-		configStore, err := flatfile.NewFlatFileConfigStore(filepath.Join(root, "configs"))
-		require.NoError(t, err)
+		configStore := pkgtesting.SetupTestStorage(t).GetConfigStore()
 
 		bindings, err := gitsync.NewBindingStore(root)
 		require.NoError(t, err)
@@ -505,8 +502,7 @@ func TestResolveWebhookSecret_SecretScheme(t *testing.T) {
 
 	t.Run("returns HTTP 500 when SecretStore is not configured", func(t *testing.T) {
 		root := t.TempDir()
-		configStore, err := flatfile.NewFlatFileConfigStore(filepath.Join(root, "configs"))
-		require.NoError(t, err)
+		configStore := pkgtesting.SetupTestStorage(t).GetConfigStore()
 
 		bindings, err := gitsync.NewBindingStore(root)
 		require.NoError(t, err)
@@ -542,8 +538,7 @@ func TestResolveWebhookSecret_SecretScheme(t *testing.T) {
 		// Do NOT store the key — GetSecret will return ErrSecretNotFound.
 
 		root := t.TempDir()
-		configStore, err := flatfile.NewFlatFileConfigStore(filepath.Join(root, "configs"))
-		require.NoError(t, err)
+		configStore := pkgtesting.SetupTestStorage(t).GetConfigStore()
 
 		bindings, err := gitsync.NewBindingStore(root)
 		require.NoError(t, err)


### PR DESCRIPTION
## Summary

- Removes all direct `pkg/storage/providers/flatfile` imports from `pkg/gitsync/syncer_test.go`, `pkg/gitsync/webhook_test.go`, and `features/workflow/trigger/controller_factory_test.go`
- `newTestSyncer` and `newWebhookSetup` helpers now use `pkgtesting.SetupTestStorage(t).GetConfigStore()` and return the `cfgconfig.ConfigStore` interface instead of `*flatfile.FlatFileConfigStore`
- `controller_factory_test.go` replaces `&flatfile.FlatFileProvider{}` with `storageif.GetStorageProvider("flatfile")` after provider registration via `pkgtesting.SetupTestStorage(t)`; the blank `_ ".../providers/sqlite"` import is dropped since `pkg/testing` handles both registrations

Fixes #1210

## Test plan

- [x] `go test ./pkg/gitsync/... ./features/workflow/trigger/...` — all pass
- [x] `make test-agent-complete` — all quality gates pass
- [x] Zero new `t.Skip()` calls introduced
- [x] Zero direct `pkg/storage/providers/` imports remain in the three changed files

## Specialist Review Results

**qa-test-runner: PASS** — 130+ packages tested, zero failures; cross-platform builds verified; gitsync (16.4s) and trigger (9.6s) packages confirmed passing

**qa-code-reviewer: PASS** — no blocking issues; 0 mocks, legitimate infrastructure skips only, all error paths covered

**security-engineer: PASS** — security-precommit PASS, check-architecture PASS, security-scan PASS; refactor strictly improves architectural compliance

🤖 Generated with [Claude Code](https://claude.com/claude-code)