### PR TITLE
test: adopt pkg/testing helpers in tenant and controller tests (Issue #1208)

### DIFF
--- a/features/controller/service/config_service_storage_test.go
+++ b/features/controller/service/config_service_storage_test.go
@@ -13,25 +13,16 @@ import (
 
 	stewardconfig "github.com/cfgis/cfgms/features/steward/config"
 	"github.com/cfgis/cfgms/pkg/logging"
-	"github.com/cfgis/cfgms/pkg/storage/interfaces"
-
-	// Import git storage provider for testing
 	cfgconfig "github.com/cfgis/cfgms/pkg/storage/interfaces/config"
-	_ "github.com/cfgis/cfgms/pkg/storage/providers/flatfile"
-	_ "github.com/cfgis/cfgms/pkg/storage/providers/sqlite"
+	pkgtesting "github.com/cfgis/cfgms/pkg/testing"
 )
 
 // createTestConfigStore creates a real git-backed ConfigStore for testing.
 // This follows the same pattern as createTestServiceV2 in config_service_test.go.
 func createTestConfigStore(t *testing.T) cfgconfig.ConfigStore {
 	t.Helper()
-
-	tmpDir := t.TempDir()
-	storageManager, err := interfaces.CreateOSSStorageManager(tmpDir+"/flatfile", tmpDir+"/cfgms.db")
-	require.NoError(t, err)
-	t.Cleanup(func() { _ = storageManager.Close() })
-
-	return storageManager.GetConfigStore()
+	sm := pkgtesting.SetupTestStorage(t)
+	return sm.GetConfigStore()
 }
 
 // TestConfigurationStorageMigration tests the Epic 6 compliant storage migration

--- a/features/controller/service/config_service_test.go
+++ b/features/controller/service/config_service_test.go
@@ -15,11 +15,7 @@ import (
 	controller "github.com/cfgis/cfgms/api/proto/controller"
 	stewardconfig "github.com/cfgis/cfgms/features/steward/config"
 	"github.com/cfgis/cfgms/pkg/logging"
-	"github.com/cfgis/cfgms/pkg/storage/interfaces"
-
-	// Import storage provider for testing
-	_ "github.com/cfgis/cfgms/pkg/storage/providers/flatfile"
-	_ "github.com/cfgis/cfgms/pkg/storage/providers/sqlite"
+	pkgtesting "github.com/cfgis/cfgms/pkg/testing"
 )
 
 func createTestStewardConfig(stewardID string) *stewardconfig.StewardConfig {
@@ -67,13 +63,8 @@ func createTestStewardConfig(stewardID string) *stewardconfig.StewardConfig {
 // createTestServiceV2 creates a ConfigurationServiceV2 backed by a real git StorageManager
 func createTestServiceV2(t *testing.T) *ConfigurationServiceV2 {
 	t.Helper()
-
 	logger := logging.NewNoopLogger()
-	tmpDir := t.TempDir()
-	storageManager, err := interfaces.CreateOSSStorageManager(tmpDir+"/flatfile", tmpDir+"/cfgms.db")
-	require.NoError(t, err)
-	t.Cleanup(func() { _ = storageManager.Close() })
-
+	storageManager := pkgtesting.SetupTestStorage(t)
 	return NewConfigurationServiceV2(logger, storageManager, nil)
 }
 

--- a/features/controller/transport/config_handler_test.go
+++ b/features/controller/transport/config_handler_test.go
@@ -26,11 +26,7 @@ import (
 	cfgcert "github.com/cfgis/cfgms/pkg/cert"
 	dataplaneTypes "github.com/cfgis/cfgms/pkg/dataplane/types"
 	"github.com/cfgis/cfgms/pkg/logging"
-	"github.com/cfgis/cfgms/pkg/storage/interfaces"
-
-	// Register storage providers required by CreateOSSStorageManager.
-	_ "github.com/cfgis/cfgms/pkg/storage/providers/flatfile"
-	_ "github.com/cfgis/cfgms/pkg/storage/providers/sqlite"
+	pkgtesting "github.com/cfgis/cfgms/pkg/testing"
 )
 
 // ---------------------------------------------------------------------------
@@ -98,13 +94,7 @@ func peerContextWithCA(t *testing.T, ca *cfgcert.CA, cn string) context.Context 
 // storage rooted in a temporary directory that is cleaned up after the test.
 func createTestService(t *testing.T) *service.ConfigurationServiceV2 {
 	t.Helper()
-	tmpDir := t.TempDir()
-	storageManager, err := interfaces.CreateOSSStorageManager(
-		tmpDir+"/flatfile",
-		tmpDir+"/cfgms.db",
-	)
-	require.NoError(t, err)
-	t.Cleanup(func() { _ = storageManager.Close() })
+	storageManager := pkgtesting.SetupTestStorage(t)
 	return service.NewConfigurationServiceV2(logging.NewNoopLogger(), storageManager, nil)
 }
 

--- a/features/tenant/manager.go
+++ b/features/tenant/manager.go
@@ -37,6 +37,7 @@ func (m *Manager) CreateTenant(ctx context.Context, req *TenantRequest) (*Tenant
 	tenantID := m.generateTenantID(req.Name)
 
 	// Create tenant object
+	now := time.Now()
 	tenant := &Tenant{
 		ID:          tenantID,
 		Name:        req.Name,
@@ -44,6 +45,8 @@ func (m *Manager) CreateTenant(ctx context.Context, req *TenantRequest) (*Tenant
 		ParentID:    req.ParentID,
 		Metadata:    req.Metadata,
 		Status:      TenantStatusActive,
+		CreatedAt:   now,
+		UpdatedAt:   now,
 	}
 
 	// Create the tenant in storage

--- a/features/tenant/manager_test.go
+++ b/features/tenant/manager_test.go
@@ -14,7 +14,6 @@ import (
 	cfgmstesting "github.com/cfgis/cfgms/pkg/testing"
 )
 
-// mockStore implements Store interface for testing
 // newTestTenantManager creates a Manager backed by real SQLite+flatfile storage.
 func newTestTenantManager(t *testing.T) *Manager {
 	t.Helper()

--- a/features/tenant/manager_test.go
+++ b/features/tenant/manager_test.go
@@ -4,276 +4,28 @@ package tenant
 
 import (
 	"context"
-	"fmt"
-	"sync"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/cfgis/cfgms/api/proto/common"
 	"github.com/cfgis/cfgms/features/rbac"
-	"github.com/cfgis/cfgms/pkg/storage/interfaces"
 	cfgmstesting "github.com/cfgis/cfgms/pkg/testing"
-
-	// Import storage providers for testing
-	_ "github.com/cfgis/cfgms/pkg/storage/providers/flatfile"
-	_ "github.com/cfgis/cfgms/pkg/storage/providers/sqlite"
 )
 
-// setupTestRBACManager creates an RBAC manager with git storage for tenant testing
-func setupTestRBACManager(t *testing.T) *rbac.Manager {
-	tmpDir := t.TempDir()
-	storageManager, err := interfaces.CreateOSSStorageManager(tmpDir+"/flatfile", tmpDir+"/cfgms.db")
-	require.NoError(t, err)
-	t.Cleanup(func() { _ = storageManager.Close() })
-
-	manager := rbac.NewManagerWithStorage(
-		storageManager.GetAuditStore(),
-		storageManager.GetClientTenantStore(),
-		storageManager.GetRBACStore(),
-	)
-
-	err = manager.Initialize(context.Background())
-	require.NoError(t, err)
-
-	t.Cleanup(func() {
-		flushCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-		defer cancel()
-		_ = manager.FlushAudit(flushCtx)
-	})
-
-	return manager
-}
-
 // mockStore implements Store interface for testing
-type mockStore struct {
-	mu        sync.RWMutex
-	tenants   map[string]*Tenant
-	hierarchy map[string]*TenantHierarchy
-}
-
-func newMockStore() *mockStore {
-	store := &mockStore{
-		tenants:   make(map[string]*Tenant),
-		hierarchy: make(map[string]*TenantHierarchy),
-	}
-
-	// Initialize with default tenant
-	defaultTenant := &Tenant{
-		ID:          "default",
-		Name:        "Default Tenant",
-		Description: "Default system tenant",
-		Status:      TenantStatusActive,
-		CreatedAt:   time.Now(),
-		UpdatedAt:   time.Now(),
-	}
-
-	store.tenants["default"] = defaultTenant
-	store.hierarchy["default"] = &TenantHierarchy{
-		TenantID: "default",
-		Path:     []string{"default"},
-		Depth:    0,
-		Children: []string{},
-	}
-
-	return store
-}
-
-func (s *mockStore) CreateTenant(ctx context.Context, t *Tenant) error {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
-	if _, exists := s.tenants[t.ID]; exists {
-		return ErrTenantExists
-	}
-
-	var parentHierarchy *TenantHierarchy
-	if t.ParentID != "" {
-		parent, exists := s.tenants[t.ParentID]
-		if !exists {
-			return ErrInvalidParent
-		}
-		if parent.Status != TenantStatusActive {
-			return fmt.Errorf("parent tenant is not active")
-		}
-		parentHierarchy = s.hierarchy[t.ParentID]
-	}
-
-	now := time.Now()
-	t.CreatedAt = now
-	t.UpdatedAt = now
-
-	s.tenants[t.ID] = t
-
-	hierarchy := &TenantHierarchy{
-		TenantID: t.ID,
-		Children: []string{},
-	}
-
-	if parentHierarchy != nil {
-		hierarchy.Path = append(parentHierarchy.Path, t.ID)
-		hierarchy.Depth = parentHierarchy.Depth + 1
-		parentHierarchy.Children = append(parentHierarchy.Children, t.ID)
-	} else {
-		hierarchy.Path = []string{t.ID}
-		hierarchy.Depth = 0
-	}
-
-	s.hierarchy[t.ID] = hierarchy
-	return nil
-}
-
-func (s *mockStore) GetTenant(ctx context.Context, tenantID string) (*Tenant, error) {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-
-	t, exists := s.tenants[tenantID]
-	if !exists {
-		return nil, ErrTenantNotFound
-	}
-
-	result := *t
-	return &result, nil
-}
-
-func (s *mockStore) UpdateTenant(ctx context.Context, t *Tenant) error {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
-	existing, exists := s.tenants[t.ID]
-	if !exists {
-		return ErrTenantNotFound
-	}
-
-	t.CreatedAt = existing.CreatedAt
-	t.UpdatedAt = time.Now()
-	s.tenants[t.ID] = t
-	return nil
-}
-
-func (s *mockStore) DeleteTenant(ctx context.Context, tenantID string) error {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
-	t, exists := s.tenants[tenantID]
-	if !exists {
-		return ErrTenantNotFound
-	}
-
-	hierarchy := s.hierarchy[tenantID]
-	if len(hierarchy.Children) > 0 {
-		return ErrTenantHasChildren
-	}
-
-	if tenantID == "default" {
-		return fmt.Errorf("cannot delete default tenant")
-	}
-
-	t.Status = TenantStatusInactive
-	t.UpdatedAt = time.Now()
-	return nil
-}
-
-func (s *mockStore) ListTenants(ctx context.Context, filter *TenantFilter) ([]*Tenant, error) {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-
-	var result []*Tenant
-	for _, t := range s.tenants {
-		if filter != nil {
-			if filter.ParentID != "" && t.ParentID != filter.ParentID {
-				continue
-			}
-			if filter.Status != "" && t.Status != filter.Status {
-				continue
-			}
-		}
-
-		tenantCopy := *t
-		result = append(result, &tenantCopy)
-	}
-
-	return result, nil
-}
-
-func (s *mockStore) GetTenantHierarchy(ctx context.Context, tenantID string) (*TenantHierarchy, error) {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-
-	hierarchy, exists := s.hierarchy[tenantID]
-	if !exists {
-		return nil, ErrTenantNotFound
-	}
-
-	result := *hierarchy
-	result.Children = make([]string, len(hierarchy.Children))
-	copy(result.Children, hierarchy.Children)
-	result.Path = make([]string, len(hierarchy.Path))
-	copy(result.Path, hierarchy.Path)
-
-	return &result, nil
-}
-
-func (s *mockStore) GetChildTenants(ctx context.Context, parentID string) ([]*Tenant, error) {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-
-	hierarchy, exists := s.hierarchy[parentID]
-	if !exists {
-		return nil, ErrTenantNotFound
-	}
-
-	var children []*Tenant
-	for _, childID := range hierarchy.Children {
-		if child, exists := s.tenants[childID]; exists {
-			childCopy := *child
-			children = append(children, &childCopy)
-		}
-	}
-
-	return children, nil
-}
-
-func (s *mockStore) GetTenantPath(ctx context.Context, tenantID string) ([]string, error) {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-
-	hierarchy, exists := s.hierarchy[tenantID]
-	if !exists {
-		return nil, ErrTenantNotFound
-	}
-
-	path := make([]string, len(hierarchy.Path))
-	copy(path, hierarchy.Path)
-	return path, nil
-}
-
-func (s *mockStore) IsTenantAncestor(ctx context.Context, ancestorID, descendantID string) (bool, error) {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-
-	descendantHierarchy, exists := s.hierarchy[descendantID]
-	if !exists {
-		return false, ErrTenantNotFound
-	}
-
-	for _, pathTenantID := range descendantHierarchy.Path {
-		if pathTenantID == ancestorID {
-			return true, nil
-		}
-	}
-
-	return false, nil
+// newTestTenantManager creates a Manager backed by real SQLite+flatfile storage.
+func newTestTenantManager(t *testing.T) *Manager {
+	t.Helper()
+	storageManager := cfgmstesting.SetupTestStorage(t)
+	tenantStore := NewStorageAdapter(storageManager.GetTenantStore())
+	rbacManager := cfgmstesting.SetupTestRBACManager(t)
+	return NewManager(tenantStore, rbacManager)
 }
 
 func TestManager_CreateTenant(t *testing.T) {
-	// Setup
-	tenantStore := newMockStore()
-	rbacManager := setupTestRBACManager(t)
-
-	manager := NewManager(tenantStore, rbacManager)
+	manager := newTestTenantManager(t)
 	ctx := context.Background()
 
 	// Test creating a new tenant
@@ -303,11 +55,7 @@ func TestManager_CreateTenant(t *testing.T) {
 }
 
 func TestManager_CreateTenant_WithParent(t *testing.T) {
-	// Setup
-	tenantStore := newMockStore()
-	rbacManager := setupTestRBACManager(t)
-
-	manager := NewManager(tenantStore, rbacManager)
+	manager := newTestTenantManager(t)
 	ctx := context.Background()
 
 	// Create parent tenant
@@ -341,11 +89,7 @@ func TestManager_CreateTenant_WithParent(t *testing.T) {
 }
 
 func TestManager_CreateTenant_Validation(t *testing.T) {
-	// Setup
-	tenantStore := newMockStore()
-	rbacManager := setupTestRBACManager(t)
-
-	manager := NewManager(tenantStore, rbacManager)
+	manager := newTestTenantManager(t)
 	ctx := context.Background()
 
 	// Test validation errors
@@ -380,11 +124,7 @@ func TestManager_CreateTenant_Validation(t *testing.T) {
 }
 
 func TestManager_ListTenants(t *testing.T) {
-	// Setup
-	tenantStore := newMockStore()
-	rbacManager := setupTestRBACManager(t)
-
-	manager := NewManager(tenantStore, rbacManager)
+	manager := newTestTenantManager(t)
 	ctx := context.Background()
 
 	// Create test tenants
@@ -394,10 +134,10 @@ func TestManager_ListTenants(t *testing.T) {
 	tenant2, err := manager.CreateTenant(ctx, &TenantRequest{Name: "Tenant2", ParentID: tenant1.ID})
 	require.NoError(t, err)
 
-	// List all tenants
+	// List all tenants (real storage starts empty — only tenant1 and tenant2 present)
 	tenants, err := manager.ListTenants(ctx, nil)
 	require.NoError(t, err)
-	assert.GreaterOrEqual(t, len(tenants), 3) // default + tenant1 + tenant2
+	assert.GreaterOrEqual(t, len(tenants), 2)
 
 	// List tenants with filter
 	filter := &TenantFilter{ParentID: tenant1.ID}
@@ -408,11 +148,7 @@ func TestManager_ListTenants(t *testing.T) {
 }
 
 func TestManager_UpdateTenant(t *testing.T) {
-	// Setup
-	tenantStore := newMockStore()
-	rbacManager := setupTestRBACManager(t)
-
-	manager := NewManager(tenantStore, rbacManager)
+	manager := newTestTenantManager(t)
 	ctx := context.Background()
 
 	// Create tenant
@@ -437,17 +173,13 @@ func TestManager_UpdateTenant(t *testing.T) {
 	assert.Equal(t, "Updated-Name", updated.Name)
 	assert.Equal(t, "Updated Description", updated.Description)
 	assert.Equal(t, "true", updated.Metadata["updated"])
-	assert.Equal(t, tenant.CreatedAt, updated.CreatedAt)
+	assert.True(t, tenant.CreatedAt.Equal(updated.CreatedAt), "CreatedAt should not change after update")
 	// UpdatedAt should be at or after the original (may be equal on fast systems)
 	assert.False(t, updated.UpdatedAt.Before(tenant.UpdatedAt))
 }
 
 func TestManager_DeleteTenant(t *testing.T) {
-	// Setup
-	tenantStore := newMockStore()
-	rbacManager := setupTestRBACManager(t)
-
-	manager := NewManager(tenantStore, rbacManager)
+	manager := newTestTenantManager(t)
 	ctx := context.Background()
 
 	// Create tenant
@@ -458,18 +190,13 @@ func TestManager_DeleteTenant(t *testing.T) {
 	err = manager.DeleteTenant(ctx, tenant.ID)
 	require.NoError(t, err)
 
-	// Verify tenant is soft deleted
-	deleted, err := manager.GetTenant(ctx, tenant.ID)
-	require.NoError(t, err)
-	assert.Equal(t, TenantStatusInactive, deleted.Status)
+	// Verify tenant was removed (real storage hard-deletes)
+	_, err = manager.GetTenant(ctx, tenant.ID)
+	require.Error(t, err)
 }
 
 func TestManager_DeleteTenant_WithChildren(t *testing.T) {
-	// Setup
-	tenantStore := newMockStore()
-	rbacManager := setupTestRBACManager(t)
-
-	manager := NewManager(tenantStore, rbacManager)
+	manager := newTestTenantManager(t)
 	ctx := context.Background()
 
 	// Create parent and child tenants
@@ -486,11 +213,7 @@ func TestManager_DeleteTenant_WithChildren(t *testing.T) {
 }
 
 func TestManager_IsTenantAncestor(t *testing.T) {
-	// Setup
-	tenantStore := newMockStore()
-	rbacManager := setupTestRBACManager(t)
-
-	manager := NewManager(tenantStore, rbacManager)
+	manager := newTestTenantManager(t)
 	ctx := context.Background()
 
 	// Create hierarchy: grandparent -> parent -> child

--- a/features/tenant/security/audit_test.go
+++ b/features/tenant/security/audit_test.go
@@ -15,15 +15,11 @@ import (
 	"github.com/cfgis/cfgms/pkg/audit"
 	"github.com/cfgis/cfgms/pkg/storage/interfaces"
 	business "github.com/cfgis/cfgms/pkg/storage/interfaces/business"
-
-	// Register storage providers
-	_ "github.com/cfgis/cfgms/pkg/storage/providers/flatfile"
-	_ "github.com/cfgis/cfgms/pkg/storage/providers/sqlite"
+	pkgtesting "github.com/cfgis/cfgms/pkg/testing"
 )
 
 // newTestAuditManager creates a real audit.Manager backed by OSS storage for tests.
-// Registers cleanup via tb.Cleanup. Accepts testing.TB so it works in both
-// *testing.T and *testing.B contexts.
+// Accepts testing.TB so it works in both *testing.T and *testing.B contexts.
 func newTestAuditManager(tb testing.TB) *audit.Manager {
 	tb.Helper()
 	tmpDir := tb.TempDir()
@@ -72,11 +68,7 @@ func newTenantSecurityAuditLoggerWithCap(tb testing.TB, cap int) *TenantSecurity
 func TestTenantSecurityAuditLogger_ForwardsToAuditManager(t *testing.T) {
 	ctx := context.Background()
 
-	tmpDir := t.TempDir()
-	sm, err := interfaces.CreateOSSStorageManager(tmpDir+"/flatfile", tmpDir+"/cfgms.db")
-	require.NoError(t, err)
-	t.Cleanup(func() { _ = sm.Close() })
-
+	sm := pkgtesting.SetupTestStorage(t)
 	auditMgr, err := audit.NewManager(sm.GetAuditStore(), "tenant-security-test")
 	require.NoError(t, err)
 	t.Cleanup(func() {
@@ -214,11 +206,7 @@ func TestTenantSecurityAuditLogger_CapEviction(t *testing.T) {
 	ctx := context.Background()
 	const writeCount = 1100
 
-	tmpDir := t.TempDir()
-	sm, err := interfaces.CreateOSSStorageManager(tmpDir+"/flatfile", tmpDir+"/cfgms.db")
-	require.NoError(t, err)
-	t.Cleanup(func() { _ = sm.Close() })
-
+	sm := pkgtesting.SetupTestStorage(t)
 	auditMgr, err := audit.NewManager(sm.GetAuditStore(), "tenant-security-cap-test")
 	require.NoError(t, err)
 	t.Cleanup(func() {

--- a/features/tenant/security/enhanced_multi_tenant_security_test.go
+++ b/features/tenant/security/enhanced_multi_tenant_security_test.go
@@ -12,21 +12,14 @@ import (
 
 	"github.com/cfgis/cfgms/features/tenant"
 	"github.com/cfgis/cfgms/pkg/audit"
-	"github.com/cfgis/cfgms/pkg/storage/interfaces"
-
-	// Import storage providers for testing
-	_ "github.com/cfgis/cfgms/pkg/storage/providers/flatfile"
-	_ "github.com/cfgis/cfgms/pkg/storage/providers/sqlite"
+	pkgtesting "github.com/cfgis/cfgms/pkg/testing"
 )
 
 func TestEnhancedMultiTenantSecurity(t *testing.T) {
 	ctx := context.Background()
 
 	// Setup test infrastructure with durable storage (git-backed)
-	tmpDir := t.TempDir()
-	storageManager, err := interfaces.CreateOSSStorageManager(tmpDir+"/flatfile", tmpDir+"/cfgms.db")
-	require.NoError(t, err)
-	t.Cleanup(func() { _ = storageManager.Close() })
+	storageManager := pkgtesting.SetupTestStorage(t)
 
 	tenantStore := tenant.NewStorageAdapter(storageManager.GetTenantStore())
 	tenantManager := tenant.NewManager(tenantStore, nil)

--- a/features/tenant/security/integration_cross_tenant_isolation_test.go
+++ b/features/tenant/security/integration_cross_tenant_isolation_test.go
@@ -17,11 +17,7 @@ import (
 	"github.com/cfgis/cfgms/features/rbac"
 	"github.com/cfgis/cfgms/features/tenant"
 	"github.com/cfgis/cfgms/pkg/audit"
-	"github.com/cfgis/cfgms/pkg/storage/interfaces"
-
-	// Import storage providers for testing
-	_ "github.com/cfgis/cfgms/pkg/storage/providers/flatfile"
-	_ "github.com/cfgis/cfgms/pkg/storage/providers/sqlite"
+	pkgtesting "github.com/cfgis/cfgms/pkg/testing"
 )
 
 // TestCrossTenantPermissionIsolationIntegration tests tenant isolation using real RBAC components
@@ -32,17 +28,14 @@ func TestCrossTenantPermissionIsolationIntegration(t *testing.T) {
 	ctx = rbac.WithSensitiveOperationJustification(ctx, "test: cross-tenant isolation integration")
 
 	// Setup REAL RBAC and tenant infrastructure with git storage
-	tmpDir := t.TempDir()
-	storageManager, err := interfaces.CreateOSSStorageManager(tmpDir+"/flatfile", tmpDir+"/cfgms.db")
-	require.NoError(t, err)
-	t.Cleanup(func() { _ = storageManager.Close() })
+	storageManager := pkgtesting.SetupTestStorage(t)
 
 	rbacManager := rbac.NewManagerWithStorage(
 		storageManager.GetAuditStore(),
 		storageManager.GetClientTenantStore(),
 		storageManager.GetRBACStore(),
 	)
-	err = rbacManager.Initialize(ctx)
+	err := rbacManager.Initialize(ctx)
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		// 30s allows the rbac drain goroutine to finish on slow Windows CI
@@ -237,13 +230,9 @@ func TestCrossTenantPermissionIsolationIntegration(t *testing.T) {
 			err = rbacManager.CreateRoleWithParent(ctx, childRole, "parent-admin-role",
 				common.RoleInheritanceType_ROLE_INHERITANCE_ADDITIVE)
 
-			// Current RBAC system doesn't enforce cross-tenant role restrictions yet
-			// This test documents the current behavior for future enhancement
-			if err != nil {
-				t.Logf("✅ Cross-tenant role inheritance blocked: %v", err)
-			} else {
-				t.Logf("ℹ️  Cross-tenant role inheritance allowed - RBAC system needs cross-tenant validation enhancement")
-			}
+			// M-TENANT-2: cross-tenant role inheritance is blocked by the RBAC system.
+			require.Error(t, err, "cross-tenant role inheritance must be blocked")
+			assert.Contains(t, err.Error(), "cross-tenant role inheritance not allowed")
 		})
 
 		t.Run("SameTenantRoleInheritanceAllowed", func(t *testing.T) {
@@ -437,8 +426,6 @@ func TestCrossTenantPermissionIsolationIntegration(t *testing.T) {
 						}
 					}
 
-					// Small delay to vary timing
-					time.Sleep(time.Millisecond * time.Duration((id%5)+1))
 				}
 			}(userID)
 		}

--- a/features/tenant/security/secret_manager_test.go
+++ b/features/tenant/security/secret_manager_test.go
@@ -15,10 +15,8 @@ import (
 	"github.com/cfgis/cfgms/pkg/audit"
 	secretsif "github.com/cfgis/cfgms/pkg/secrets/interfaces"
 	"github.com/cfgis/cfgms/pkg/secrets/providers/steward"
-	"github.com/cfgis/cfgms/pkg/storage/interfaces"
 	business "github.com/cfgis/cfgms/pkg/storage/interfaces/business"
-	_ "github.com/cfgis/cfgms/pkg/storage/providers/flatfile"
-	_ "github.com/cfgis/cfgms/pkg/storage/providers/sqlite"
+	pkgtesting "github.com/cfgis/cfgms/pkg/testing"
 )
 
 // newTestSecretStore creates a steward-backed SecretStore for tests.
@@ -874,12 +872,8 @@ func TestTenantSecretManager_GenerateSecretID(t *testing.T) {
 func TestTenantSecretManager_AuditIntegration(t *testing.T) {
 	secretStore := newTestSecretStore(t)
 
-	tmpDir := t.TempDir()
-	storageManager, err := interfaces.CreateOSSStorageManager(tmpDir+"/flatfile", tmpDir+"/cfgms.db")
-	require.NoError(t, err)
-	t.Cleanup(func() { _ = storageManager.Close() })
-
-	auditMgr, err := audit.NewManager(storageManager.GetAuditStore(), "tenant_secret_manager")
+	sm := pkgtesting.SetupTestStorage(t)
+	auditMgr, err := audit.NewManager(sm.GetAuditStore(), "tenant_secret_manager")
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)


### PR DESCRIPTION
## Summary

- Replace `interfaces.CreateOSSStorageManager` + blank `pkg/storage/providers/*` imports with `pkgtesting.SetupTestStorage(t)` / `SetupTestRBACManager(t)` in 8 test files across `features/tenant`, `features/tenant/security`, and `features/controller/{service,transport}`
- Remove ~270 lines of `mockStore` scaffolding from `manager_test.go`; all tenant manager tests now run against real SQLite+flatfile storage
- Fix `Manager.CreateTenant` to set `CreatedAt`/`UpdatedAt` timestamps on the returned `*Tenant` (previously zero; exposed by removing the mock)
- Fix `TestManager_UpdateTenant` to use `time.Time.Equal()` for timestamp comparison (DB round-trip normalises timezone/monotonic; semantic equality is correct)
- Fix `CrossTenantRoleInheritanceBlocked` subtest to assert `require.Error` (RBAC enforces M-TENANT-2 blocking with error "cross-tenant role inheritance not allowed")

## Scope-deviation acknowledgement: `features/tenant/manager.go`

Story #1208 lists "Production code" as out-of-scope. This PR modifies one production file (`features/tenant/manager.go:37-48`) by 4 lines to set `CreatedAt`/`UpdatedAt` in `CreateTenant`. This is an in-scope-by-necessity contract-bug fix, not a refactor:

- `Tenant.CreatedAt` / `UpdatedAt` are declared fields on the type but `CreateTenant` was returning a struct with zero-value timestamps.
- `convertTenantToStorage` allocates a copy `business.TenantData`; the SQLite store mutates the copy's timestamps, so the original `*Tenant` returned to callers retained zero values.
- The deleted `mockStore.CreateTenant` previously masked this by mutating the input pointer directly.
- Without the fix, real-storage tests cannot satisfy AC #4 (`go test ... passes`) — assertions on the returned tenant's timestamps see zero values.
- Server-side `time.Now()`, no input-trust path, no injection vector.

Out-of-scope-prohibition was intended to prevent unrelated refactors, not block correctness fixes exposed by removing the mock. Documenting here for traceability.

## Status: pipeline:fix — second-cycle close-out

Adversarial review (tech-lead + security-engineer) verified PR branch state at `94cb16e`:

- 7 of 8 in-scope files: clean
- 1 remaining violation: `features/tenant/security/audit_test.go::newTestAuditManager` (line 26) — inline `interfaces.CreateOSSStorageManager` + `t.TempDir`
- 0 new gosec findings
- `make check-architecture` PASS (separately tracked: epic #731 AC #2 — wire `scripts/check-providers.sh` into the target — needs a follow-up story; not in #1208 scope)
- Security verdict: CONDITIONAL APPROVE pending the one fix below

## Required close-out (single-pass mechanical fix)

Edit `features/tenant/security/audit_test.go`:

1. Delete line 16 import: `"github.com/cfgis/cfgms/pkg/storage/interfaces"`
2. Replace the body of `newTestAuditManager` (lines 23-44) with:
   ```go
   func newTestAuditManager(t *testing.T) *audit.Manager {
       t.Helper()
       return pkgtesting.SetupTestAuditManager(t)
   }
   ```
   (helper exists at `pkg/testing/storage_helper.go:82-95`)
3. Narrow `newTestAuditLogger` signature: `(tb testing.TB)` → `(t *testing.T)`; rename `tb` → `t` in body. (No `*testing.B` callers — verified.)
4. Narrow `newTenantSecurityAuditLoggerWithCap` signature: `(tb testing.TB, cap int)` → `(t *testing.T, cap int)`; rename `tb` → `t` in body.

Verify:
- `go build ./features/tenant/security/...`
- `go test ./features/tenant/security/...`
- `grep 'pkg/storage/providers\|interfaces.CreateOSSStorageManager' features/tenant/security/audit_test.go` returns nothing

Note: `pkgtesting.SetupTestAuditManager` uses a 5-second `Stop()` timeout vs the inline helper's 30s. Stop is best-effort cleanup — won't fail tests. If Windows CI flakes on the cap-eviction path, follow-up patches `pkgtesting.SetupTestAuditManager`'s timeout in `pkg/testing/storage_helper.go`.

## Test plan

- [x] `go test ./features/tenant/... ./features/tenant/security/... ./features/controller/service/... ./features/controller/transport/...` — all pass
- [x] `make test-agent-complete` — all pre-commit, fast, and production-critical checks pass; cross-platform compilation clean
- [ ] Post-fix re-run of the above

Fixes #1208

🤖 Generated with [Claude Code](https://claude.com/claude-code)
