### PR TITLE
test: adopt pkgtesting.SetupTestStorage helpers across 17 test files (Issue #1209)

### DIFF
--- a/cmd/controller/main_test.go
+++ b/cmd/controller/main_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/cfgis/cfgms/features/controller/config"
 	secretsif "github.com/cfgis/cfgms/pkg/secrets/interfaces"
 	_ "github.com/cfgis/cfgms/pkg/secrets/providers/sops"
-	_ "github.com/cfgis/cfgms/pkg/storage/providers/flatfile"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/commercial/ha/manager_test.go
+++ b/commercial/ha/manager_test.go
@@ -17,8 +17,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/cfgis/cfgms/pkg/logging"
-	_ "github.com/cfgis/cfgms/pkg/storage/providers/flatfile"
-	_ "github.com/cfgis/cfgms/pkg/storage/providers/sqlite" // Register git provider
 	pkgtesting "github.com/cfgis/cfgms/pkg/testing"
 	"github.com/cfgis/cfgms/pkg/testing/storage"
 )

--- a/features/config/rollback/storage_store_test.go
+++ b/features/config/rollback/storage_store_test.go
@@ -13,9 +13,7 @@ import (
 
 	"github.com/cfgis/cfgms/features/config/rollback"
 	"github.com/cfgis/cfgms/pkg/storage/interfaces"
-	_ "github.com/cfgis/cfgms/pkg/storage/providers/database" // Register database provider
-	_ "github.com/cfgis/cfgms/pkg/storage/providers/flatfile"
-	_ "github.com/cfgis/cfgms/pkg/storage/providers/sqlite" // Register sqlite provider
+	_ "github.com/cfgis/cfgms/pkg/testing"
 	teststorage "github.com/cfgis/cfgms/pkg/testing/storage"
 )
 

--- a/features/controller/api/handlers_registration_test.go
+++ b/features/controller/api/handlers_registration_test.go
@@ -26,8 +26,7 @@ import (
 	"github.com/cfgis/cfgms/pkg/registration"
 	"github.com/cfgis/cfgms/pkg/storage/interfaces"
 	business "github.com/cfgis/cfgms/pkg/storage/interfaces/business"
-	_ "github.com/cfgis/cfgms/pkg/storage/providers/flatfile"
-	_ "github.com/cfgis/cfgms/pkg/storage/providers/sqlite"
+	pkgtesting "github.com/cfgis/cfgms/pkg/testing"
 )
 
 // newTestRegistrationStore creates a real SQLite-backed registration.Store for handler tests.
@@ -75,11 +74,8 @@ func newHandleRegisterServer(t *testing.T, tokenStore registration.Store, certMg
 	} else {
 		logger = logging.NewNoopLogger()
 	}
-	tempDir := t.TempDir()
 
-	storageManager, err := interfaces.CreateOSSStorageManager(tempDir+"/flatfile", tempDir+"/cfgms.db")
-	require.NoError(t, err)
-	t.Cleanup(func() { _ = storageManager.Close() })
+	storageManager := pkgtesting.SetupTestStorage(t)
 
 	rbacManager := rbac.NewManagerWithStorage(
 		storageManager.GetAuditStore(),

--- a/features/controller/api/handlers_registration_tokens_test.go
+++ b/features/controller/api/handlers_registration_tokens_test.go
@@ -22,8 +22,7 @@ import (
 	"github.com/cfgis/cfgms/pkg/logging"
 	"github.com/cfgis/cfgms/pkg/registration"
 	"github.com/cfgis/cfgms/pkg/storage/interfaces"
-	_ "github.com/cfgis/cfgms/pkg/storage/providers/flatfile"
-	_ "github.com/cfgis/cfgms/pkg/storage/providers/sqlite"
+	pkgtesting "github.com/cfgis/cfgms/pkg/testing"
 )
 
 // setupTestServerWithTokenStore creates a test server with a real registration token store
@@ -40,20 +39,15 @@ func setupTestServerWithTokenStore(t *testing.T) (*Server, registration.Store) {
 	// Create test logger
 	logger := logging.NewNoopLogger()
 
-	// Create temporary directory for storage
-	tempDir := t.TempDir()
-
 	// Initialize RBAC system with OSS composite storage
-	storageManager, err := interfaces.CreateOSSStorageManager(tempDir+"/flatfile", tempDir+"/cfgms.db")
-	require.NoError(t, err)
-	t.Cleanup(func() { _ = storageManager.Close() })
+	storageManager := pkgtesting.SetupTestStorage(t)
 
 	rbacManager := rbac.NewManagerWithStorage(
 		storageManager.GetAuditStore(),
 		storageManager.GetClientTenantStore(),
 		storageManager.GetRBACStore(),
 	)
-	err = rbacManager.Initialize(context.Background())
+	err := rbacManager.Initialize(context.Background())
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		closeCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)

--- a/features/controller/api/handlers_workflows_test.go
+++ b/features/controller/api/handlers_workflows_test.go
@@ -22,22 +22,15 @@ import (
 	"github.com/cfgis/cfgms/features/workflow"
 	"github.com/cfgis/cfgms/pkg/ctxkeys"
 	"github.com/cfgis/cfgms/pkg/logging"
-	"github.com/cfgis/cfgms/pkg/storage/interfaces"
-
-	// Auto-register git storage provider
 	cfgconfig "github.com/cfgis/cfgms/pkg/storage/interfaces/config"
-	_ "github.com/cfgis/cfgms/pkg/storage/providers/flatfile"
-	_ "github.com/cfgis/cfgms/pkg/storage/providers/sqlite"
+	pkgtesting "github.com/cfgis/cfgms/pkg/testing"
 )
 
 // newTestWorkflowHandler creates a WorkflowHandler backed by real git storage and a real engine.
 func newTestWorkflowHandler(t *testing.T) (*WorkflowHandler, cfgconfig.ConfigStore) {
 	t.Helper()
 
-	tmpDir := t.TempDir()
-	storageManager, err := interfaces.CreateOSSStorageManager(tmpDir+"/flatfile", tmpDir+"/cfgms.db")
-	require.NoError(t, err)
-	t.Cleanup(func() { _ = storageManager.Close() })
+	storageManager := pkgtesting.SetupTestStorage(t)
 	configStore := storageManager.GetConfigStore()
 
 	registry := make(discovery.ModuleRegistry)

--- a/features/controller/api/registration_hook_test.go
+++ b/features/controller/api/registration_hook_test.go
@@ -21,23 +21,16 @@ import (
 	"github.com/cfgis/cfgms/features/workflow"
 	"github.com/cfgis/cfgms/pkg/logging"
 	"github.com/cfgis/cfgms/pkg/registration"
-	"github.com/cfgis/cfgms/pkg/storage/interfaces"
 	business "github.com/cfgis/cfgms/pkg/storage/interfaces/business"
-
-	// Auto-register git storage provider
 	cfgconfig "github.com/cfgis/cfgms/pkg/storage/interfaces/config"
-	_ "github.com/cfgis/cfgms/pkg/storage/providers/flatfile"
-	_ "github.com/cfgis/cfgms/pkg/storage/providers/sqlite"
+	pkgtesting "github.com/cfgis/cfgms/pkg/testing"
 )
 
 // newTestApprovalHook builds a WorkflowApprovalHook backed by real git storage and workflow engine.
 func newTestApprovalHook(t *testing.T) (*WorkflowApprovalHook, cfgconfig.ConfigStore) {
 	t.Helper()
 
-	tmpDir := t.TempDir()
-	storageManager, err := interfaces.CreateOSSStorageManager(tmpDir+"/flatfile", tmpDir+"/cfgms.db")
-	require.NoError(t, err)
-	t.Cleanup(func() { _ = storageManager.Close() })
+	storageManager := pkgtesting.SetupTestStorage(t)
 	configStore := storageManager.GetConfigStore()
 
 	registry := make(discovery.ModuleRegistry)

--- a/features/controller/api/server_test.go
+++ b/features/controller/api/server_test.go
@@ -22,11 +22,7 @@ import (
 	"github.com/cfgis/cfgms/pkg/audit"
 	"github.com/cfgis/cfgms/pkg/ctxkeys"
 	"github.com/cfgis/cfgms/pkg/logging"
-	"github.com/cfgis/cfgms/pkg/storage/interfaces"
-
-	// Import storage providers for testing
-	_ "github.com/cfgis/cfgms/pkg/storage/providers/flatfile"
-	_ "github.com/cfgis/cfgms/pkg/storage/providers/sqlite"
+	pkgtesting "github.com/cfgis/cfgms/pkg/testing"
 )
 
 func setupTestServer(t *testing.T) *Server {
@@ -42,17 +38,14 @@ func setupTestServer(t *testing.T) *Server {
 	logger := logging.NewNoopLogger()
 
 	// Initialize RBAC system with git storage
-	tmpDir := t.TempDir()
-	storageManager, err := interfaces.CreateOSSStorageManager(tmpDir+"/flatfile", tmpDir+"/cfgms.db")
-	require.NoError(t, err)
-	t.Cleanup(func() { _ = storageManager.Close() })
+	storageManager := pkgtesting.SetupTestStorage(t)
 
 	rbacManager := rbac.NewManagerWithStorage(
 		storageManager.GetAuditStore(),
 		storageManager.GetClientTenantStore(),
 		storageManager.GetRBACStore(),
 	)
-	err = rbacManager.Initialize(context.Background())
+	err := rbacManager.Initialize(context.Background())
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		closeCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
@@ -849,17 +842,14 @@ func setupTestServerWithLogger(t *testing.T, logger logging.Logger) *Server {
 	cfg := config.DefaultConfig()
 	cfg.Certificate.EnableCertManagement = false
 
-	tmpDir := t.TempDir()
-	storageManager, err := interfaces.CreateOSSStorageManager(tmpDir+"/flatfile", tmpDir+"/cfgms.db")
-	require.NoError(t, err)
-	t.Cleanup(func() { _ = storageManager.Close() })
+	storageManager := pkgtesting.SetupTestStorage(t)
 
 	rbacManager := rbac.NewManagerWithStorage(
 		storageManager.GetAuditStore(),
 		storageManager.GetClientTenantStore(),
 		storageManager.GetRBACStore(),
 	)
-	err = rbacManager.Initialize(context.Background())
+	err := rbacManager.Initialize(context.Background())
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		closeCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)

--- a/features/controller/fleet/health_tracker_test.go
+++ b/features/controller/fleet/health_tracker_test.go
@@ -11,16 +11,15 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/cfgis/cfgms/pkg/logging"
+	storageif "github.com/cfgis/cfgms/pkg/storage/interfaces"
 	business "github.com/cfgis/cfgms/pkg/storage/interfaces/business"
-	"github.com/cfgis/cfgms/pkg/storage/providers/flatfile"
+	pkgtesting "github.com/cfgis/cfgms/pkg/testing"
 )
 
-// newTestTracker creates a HealthTracker backed by a real flat-file StewardStore.
+// newTestTracker creates a HealthTracker backed by a real OSS composite StewardStore.
 func newTestTracker(t *testing.T) *HealthTracker {
 	t.Helper()
-	store, err := flatfile.NewFlatFileStewardStore(t.TempDir())
-	require.NoError(t, err)
-	t.Cleanup(func() { _ = store.Close() })
+	store := pkgtesting.SetupTestStorage(t).GetStewardStore()
 	logger := logging.NewLogger("debug")
 	return NewHealthTracker(store, logger)
 }
@@ -149,8 +148,9 @@ func TestHealthTracker_EphemeralMetricsNotPersisted(t *testing.T) {
 	root := t.TempDir()
 	ctx := context.Background()
 
-	store1, err := flatfile.NewFlatFileStewardStore(root)
+	sm1, err := storageif.CreateOSSStorageManager(root, root+"/cfgms.db")
 	require.NoError(t, err)
+	store1 := sm1.GetStewardStore()
 	logger := logging.NewLogger("debug")
 
 	tracker1 := NewHealthTracker(store1, logger)
@@ -162,11 +162,12 @@ func TestHealthTracker_EphemeralMetricsNotPersisted(t *testing.T) {
 	require.NotNil(t, metrics1)
 	assert.Equal(t, 1, metrics1.TaskCount)
 	assert.Equal(t, 1, metrics1.ConfigErrors)
-	_ = store1.Close()
+	_ = sm1.Close()
 
-	store2, err := flatfile.NewFlatFileStewardStore(root)
+	sm2, err := storageif.CreateOSSStorageManager(root, root+"/cfgms.db")
 	require.NoError(t, err)
-	defer func() { _ = store2.Close() }()
+	defer func() { _ = sm2.Close() }()
+	store2 := sm2.GetStewardStore()
 
 	tracker2 := NewHealthTracker(store2, logger)
 

--- a/features/controller/initialization/initialization_test.go
+++ b/features/controller/initialization/initialization_test.go
@@ -13,10 +13,6 @@ import (
 	"github.com/cfgis/cfgms/features/controller/config"
 	"github.com/cfgis/cfgms/pkg/cert"
 	"github.com/cfgis/cfgms/pkg/logging"
-
-	// Register storage providers for init tests
-	_ "github.com/cfgis/cfgms/pkg/storage/providers/flatfile"
-	_ "github.com/cfgis/cfgms/pkg/storage/providers/sqlite"
 )
 
 func TestIsInitialized(t *testing.T) {

--- a/features/controller/server/server_security_test.go
+++ b/features/controller/server/server_security_test.go
@@ -18,12 +18,6 @@ import (
 	"github.com/cfgis/cfgms/pkg/logging"
 	"github.com/cfgis/cfgms/pkg/storage/interfaces"
 	"github.com/cfgis/cfgms/pkg/testutil"
-
-	// Import storage providers for Epic 6 compliance testing
-	// Note: memory provider is NOT imported as it's not a global provider
-	_ "github.com/cfgis/cfgms/pkg/storage/providers/database"
-	_ "github.com/cfgis/cfgms/pkg/storage/providers/flatfile"
-	_ "github.com/cfgis/cfgms/pkg/storage/providers/sqlite"
 )
 
 // Security-focused tests for the controller server
@@ -330,7 +324,7 @@ func TestServer_StorageProviderValidation(t *testing.T) {
 		t.Logf("Currently registered storage providers: %v", providerNames)
 
 		// These are the providers we expect to exist based on our architecture
-		expectedProviders := []string{"flatfile", "sqlite", "database"}
+		expectedProviders := []string{"flatfile", "sqlite"}
 
 		for _, expected := range expectedProviders {
 			found := false

--- a/features/controller/server/server_test.go
+++ b/features/controller/server/server_test.go
@@ -11,9 +11,6 @@ import (
 
 	"github.com/cfgis/cfgms/features/controller/config"
 	"github.com/cfgis/cfgms/pkg/logging"
-
-	_ "github.com/cfgis/cfgms/pkg/storage/providers/flatfile"
-	_ "github.com/cfgis/cfgms/pkg/storage/providers/sqlite"
 )
 
 // hardcodedTestTokens lists the token strings that must never appear in a

--- a/features/controller/service/rbac_service_test.go
+++ b/features/controller/service/rbac_service_test.go
@@ -13,11 +13,7 @@ import (
 	"github.com/cfgis/cfgms/api/proto/common"
 	"github.com/cfgis/cfgms/api/proto/controller"
 	"github.com/cfgis/cfgms/features/rbac"
-	"github.com/cfgis/cfgms/pkg/storage/interfaces"
-
-	// Import storage providers for testing
-	_ "github.com/cfgis/cfgms/pkg/storage/providers/flatfile"
-	_ "github.com/cfgis/cfgms/pkg/storage/providers/sqlite"
+	pkgtesting "github.com/cfgis/cfgms/pkg/testing"
 )
 
 func TestRBACService_ConvertToProtoHierarchy_Roundtrip(t *testing.T) {
@@ -91,11 +87,8 @@ func TestRBACService_ConvertToProtoEffectivePermissions_Nil(t *testing.T) {
 }
 
 func TestRBACService_Integration(t *testing.T) {
-	// Setup RBAC manager and service with git storage
-	tmpDir := t.TempDir()
-	storageManager, err := interfaces.CreateOSSStorageManager(tmpDir+"/flatfile", tmpDir+"/cfgms.db")
-	require.NoError(t, err)
-	t.Cleanup(func() { _ = storageManager.Close() })
+	// Setup RBAC manager and service with OSS composite storage
+	storageManager := pkgtesting.SetupTestStorage(t)
 
 	rbacManager := rbac.NewManagerWithStorage(
 		storageManager.GetAuditStore(),
@@ -106,7 +99,7 @@ func TestRBACService_Integration(t *testing.T) {
 	// M-AUTH-2: inject justification so sensitive RBAC operations pass the gate
 	ctx = rbac.WithSensitiveOperationJustification(ctx, "test: RBAC service integration")
 
-	err = rbacManager.Initialize(ctx)
+	err := rbacManager.Initialize(ctx)
 	require.NoError(t, err)
 
 	t.Cleanup(func() {

--- a/features/modules/m365/auth/msp_e2e_test.go
+++ b/features/modules/m365/auth/msp_e2e_test.go
@@ -13,10 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	business "github.com/cfgis/cfgms/pkg/storage/interfaces/business"
-
-	// Import git plugin to register it with global storage
-	_ "github.com/cfgis/cfgms/pkg/storage/providers/flatfile"
-	_ "github.com/cfgis/cfgms/pkg/storage/providers/sqlite"
+	_ "github.com/cfgis/cfgms/pkg/testing"
 )
 
 // TestMSPEndToEndClientOnboarding simulates a complete real-world MSP client onboarding scenario

--- a/features/modules/m365/auth/msp_simple_integration_test.go
+++ b/features/modules/m365/auth/msp_simple_integration_test.go
@@ -14,9 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	business "github.com/cfgis/cfgms/pkg/storage/interfaces/business"
-
-	_ "github.com/cfgis/cfgms/pkg/storage/providers/flatfile"
-	_ "github.com/cfgis/cfgms/pkg/storage/providers/sqlite"
+	_ "github.com/cfgis/cfgms/pkg/testing"
 )
 
 // TestMSPCompleteFlow tests the complete MSP flow using the new global storage architecture

--- a/features/reports/advanced_test.go
+++ b/features/reports/advanced_test.go
@@ -14,15 +14,10 @@ import (
 	"github.com/cfgis/cfgms/features/steward/dna/drift"
 	"github.com/cfgis/cfgms/pkg/audit"
 	"github.com/cfgis/cfgms/pkg/logging"
+	pkgtesting "github.com/cfgis/cfgms/pkg/testing"
 
-	// Import storage providers to register them
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
-	storageif "github.com/cfgis/cfgms/pkg/storage/interfaces"
-	_ "github.com/cfgis/cfgms/pkg/storage/providers/database"
-	_ "github.com/cfgis/cfgms/pkg/storage/providers/flatfile"
-	_ "github.com/cfgis/cfgms/pkg/storage/providers/sqlite"
 )
 
 // TestAdvancedServiceWithConfig tests service creation with custom configuration
@@ -58,11 +53,8 @@ func TestAdvancedServiceWithConfig(t *testing.T) {
 	driftDetector, err := drift.NewDetector(drift.DefaultDetectorConfig(), logger)
 	require.NoError(t, err)
 
-	// Create audit components using git storage for testing
-	tmpDir := t.TempDir()
-	globalStorageManager, err := storageif.CreateOSSStorageManager(tmpDir+"/flatfile", tmpDir+"/cfgms.db")
-	require.NoError(t, err)
-	t.Cleanup(func() { _ = globalStorageManager.Close() })
+	// Create audit components using OSS storage for testing
+	globalStorageManager := pkgtesting.SetupTestStorage(t)
 
 	auditStore := globalStorageManager.GetAuditStore()
 	auditManager, err := audit.NewManager(auditStore, "test-reports")
@@ -590,11 +582,8 @@ func createTestAdvancedService(t *testing.T) *AdvancedService {
 	driftDetector, err := drift.NewDetector(drift.DefaultDetectorConfig(), logger)
 	require.NoError(t, err, "Failed to create drift detector")
 
-	// Create audit components using git storage for testing
-	tmpDir := t.TempDir()
-	globalStorageManager, err := storageif.CreateOSSStorageManager(tmpDir+"/flatfile", tmpDir+"/cfgms.db")
-	require.NoError(t, err, "Failed to create global storage manager")
-	t.Cleanup(func() { _ = globalStorageManager.Close() })
+	// Create audit components using OSS storage for testing
+	globalStorageManager := pkgtesting.SetupTestStorage(t)
 
 	auditStore := globalStorageManager.GetAuditStore()
 	auditManager, err := audit.NewManager(auditStore, "test-reports")

--- a/features/siem/stream_processor_test.go
+++ b/features/siem/stream_processor_test.go
@@ -12,31 +12,14 @@ import (
 
 	"github.com/cfgis/cfgms/pkg/audit"
 	"github.com/cfgis/cfgms/pkg/logging/interfaces"
-	storageInterfaces "github.com/cfgis/cfgms/pkg/storage/interfaces"
 	"github.com/cfgis/cfgms/pkg/storage/interfaces/business"
-
-	// Register OSS storage providers
-	_ "github.com/cfgis/cfgms/pkg/storage/providers/database"
-	_ "github.com/cfgis/cfgms/pkg/storage/providers/flatfile"
-	_ "github.com/cfgis/cfgms/pkg/storage/providers/sqlite"
+	pkgtesting "github.com/cfgis/cfgms/pkg/testing"
 )
 
 // newTestAuditManager creates a real audit.Manager backed by OSS storage in a temp dir.
 func newTestAuditManager(t *testing.T) *audit.Manager {
 	t.Helper()
-	tmpDir := t.TempDir()
-	storageManager, err := storageInterfaces.CreateOSSStorageManager(tmpDir+"/flatfile", tmpDir+"/cfgms.db")
-	require.NoError(t, err)
-	t.Cleanup(func() { _ = storageManager.Close() })
-
-	mgr, err := audit.NewManager(storageManager.GetAuditStore(), "siem")
-	require.NoError(t, err)
-	t.Cleanup(func() {
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-		defer cancel()
-		_ = mgr.Stop(ctx)
-	})
-	return mgr
+	return pkgtesting.SetupTestAuditManager(t)
 }
 
 // TestStreamProcessor_SecurityEventAuditEmission verifies that a pattern match


### PR DESCRIPTION
## Summary

- Replaces direct `pkg/storage/providers/{flatfile,sqlite,database}` blank imports in 17 test files with `pkgtesting.SetupTestStorage(t)` / `SetupTestAuditManager(t)` helpers from `pkg/testing`
- Dead blank imports already covered by production binaries (`server.go`, `main.go`) are removed outright with no replacement
- `features/controller/server/server_security_test.go`: removes the `database` provider blank import and updates `FutureProofProviderList` to expect `["flatfile", "sqlite"]` (OSS composite only)
- `features/controller/fleet/health_tracker_test.go` (`TestHealthTracker_EphemeralMetricsNotPersisted`): retains `storageif.CreateOSSStorageManager` because the test requires two managers on the same root directory — `SetupTestStorage` always creates a fresh temp dir

## Files Changed (17 test files)

`cmd/controller/main_test.go`, `commercial/ha/manager_test.go`, `features/config/rollback/storage_store_test.go`, `features/controller/api/handlers_registration_test.go`, `features/controller/api/handlers_registration_tokens_test.go`, `features/controller/api/handlers_workflows_test.go`, `features/controller/api/registration_hook_test.go`, `features/controller/api/server_test.go`, `features/controller/fleet/health_tracker_test.go`, `features/controller/initialization/initialization_test.go`, `features/controller/server/server_security_test.go`, `features/controller/server/server_test.go`, `features/controller/service/rbac_service_test.go`, `features/modules/m365/auth/msp_e2e_test.go`, `features/modules/m365/auth/msp_simple_integration_test.go`, `features/reports/advanced_test.go`, `features/siem/stream_processor_test.go`

## Test plan

- [x] `go vet` passes for all 17 modified packages
- [x] `go test ./features/controller/...` — all tests pass
- [x] `go test ./features/modules/m365/auth/... ./features/config/rollback/... ./features/siem/... ./features/reports/... ./cmd/controller/...` — all tests pass
- [x] `make test-commit` passes (unit tests + lint + security + architecture)
- [x] `make check-architecture` — no central provider violations
- [x] QA code review: 0 blocking issues
- [x] Security review: 0 blocking issues, all automated scans passed

Fixes #1209

🤖 Generated with [Claude Code](https://claude.com/claude-code)