### PR TITLE
ctxkeys: migrate 4 hardcoded ctx.Value string keys to typed pkg/ctxkeys (Issue #1218)

### DIFF
--- a/features/modules/script/audit.go
+++ b/features/modules/script/audit.go
@@ -8,6 +8,8 @@ import (
 	"fmt"
 	"sync"
 	"time"
+
+	"github.com/cfgis/cfgms/pkg/ctxkeys"
 )
 
 // AuditLogger handles comprehensive audit logging for script executions
@@ -117,13 +119,13 @@ func (al *AuditLogger) LogExecution(ctx context.Context, record *AuditRecord) er
 	}
 
 	// Extract context information
-	if correlationID, ok := ctx.Value("correlation_id").(string); ok {
+	if correlationID, ok := ctx.Value(ctxkeys.CorrelationIDKey).(string); ok {
 		record.CorrelationID = correlationID
 	}
-	if userID, ok := ctx.Value("user_id").(string); ok {
+	if userID, ok := ctx.Value(ctxkeys.UserIDKey).(string); ok {
 		record.UserID = userID
 	}
-	if tenantID, ok := ctx.Value("tenant_id").(string); ok {
+	if tenantID, ok := ctx.Value(ctxkeys.TenantID).(string); ok {
 		record.TenantID = tenantID
 	}
 

--- a/features/modules/script/audit_test.go
+++ b/features/modules/script/audit_test.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"testing"
 	"time"
+
+	"github.com/cfgis/cfgms/pkg/ctxkeys"
 )
 
 func TestAuditLogger_LogExecution(t *testing.T) {
@@ -347,6 +349,90 @@ func TestCreateAuditRecord_WithError(t *testing.T) {
 	if record.ErrorMessage != testError.Error() {
 		t.Errorf("Expected error message %s, got %s", testError.Error(), record.ErrorMessage)
 	}
+}
+
+func TestAuditLogger_LogExecution_ContextExtraction(t *testing.T) {
+	t.Run("typed keys populate record fields", func(t *testing.T) {
+		logger := NewAuditLogger(10)
+		ctx := context.Background()
+		ctx = context.WithValue(ctx, ctxkeys.CorrelationIDKey, "corr-abc")
+		ctx = context.WithValue(ctx, ctxkeys.UserIDKey, "user-xyz")
+		ctx = context.WithValue(ctx, ctxkeys.TenantID, "tenant-123")
+
+		record := &AuditRecord{
+			StewardID:     "s1",
+			ResourceID:    "r1",
+			ExecutionTime: time.Now(),
+			Status:        StatusCompleted,
+		}
+		if err := logger.LogExecution(ctx, record); err != nil {
+			t.Fatalf("LogExecution returned error: %v", err)
+		}
+
+		if record.CorrelationID != "corr-abc" {
+			t.Errorf("CorrelationID: got %q, want %q", record.CorrelationID, "corr-abc")
+		}
+		if record.UserID != "user-xyz" {
+			t.Errorf("UserID: got %q, want %q", record.UserID, "user-xyz")
+		}
+		if record.TenantID != "tenant-123" {
+			t.Errorf("TenantID: got %q, want %q", record.TenantID, "tenant-123")
+		}
+	})
+
+	t.Run("missing typed keys leave fields empty", func(t *testing.T) {
+		logger := NewAuditLogger(10)
+
+		record := &AuditRecord{
+			StewardID:     "s2",
+			ResourceID:    "r2",
+			ExecutionTime: time.Now(),
+			Status:        StatusCompleted,
+		}
+		if err := logger.LogExecution(context.Background(), record); err != nil {
+			t.Fatalf("LogExecution returned error: %v", err)
+		}
+
+		if record.CorrelationID != "" {
+			t.Errorf("CorrelationID should be empty, got %q", record.CorrelationID)
+		}
+		if record.UserID != "" {
+			t.Errorf("UserID should be empty, got %q", record.UserID)
+		}
+		if record.TenantID != "" {
+			t.Errorf("TenantID should be empty, got %q", record.TenantID)
+		}
+	})
+
+	t.Run("plain string keys do not populate record fields", func(t *testing.T) {
+		logger := NewAuditLogger(10)
+		//nolint:staticcheck // SA1029: intentionally using plain strings to verify typed keys are required
+		ctx := context.WithValue(context.Background(), "correlation_id", "plain-corr")
+		//nolint:staticcheck // SA1029: intentionally using plain strings to verify typed keys are required
+		ctx = context.WithValue(ctx, "user_id", "plain-user")
+		//nolint:staticcheck // SA1029: intentionally using plain strings to verify typed keys are required
+		ctx = context.WithValue(ctx, "tenant_id", "plain-tenant")
+
+		record := &AuditRecord{
+			StewardID:     "s3",
+			ResourceID:    "r3",
+			ExecutionTime: time.Now(),
+			Status:        StatusCompleted,
+		}
+		if err := logger.LogExecution(ctx, record); err != nil {
+			t.Fatalf("LogExecution returned error: %v", err)
+		}
+
+		if record.CorrelationID != "" {
+			t.Errorf("plain string key must not set CorrelationID, got %q", record.CorrelationID)
+		}
+		if record.UserID != "" {
+			t.Errorf("plain string key must not set UserID, got %q", record.UserID)
+		}
+		if record.TenantID != "" {
+			t.Errorf("plain string key must not set TenantID, got %q", record.TenantID)
+		}
+	})
 }
 
 func TestAuditLogger_Pagination(t *testing.T) {

--- a/pkg/ctxkeys/ctxkeys.go
+++ b/pkg/ctxkeys/ctxkeys.go
@@ -4,16 +4,13 @@
 // defined here to avoid cross-feature imports.
 package ctxkeys
 
-// ContextKey is the type for shared context keys. Using a named type
-// prevents accidental collisions with keys from other packages.
-type ContextKey string
+// tenantIDKeyType is unexported to prevent external construction and key aliasing.
+type tenantIDKeyType struct{}
 
-const (
-	// TenantID is the context key for the authenticated tenant ID.
-	// Set by the auth middleware after validating an API key and read by
-	// config handlers, service methods, and terminal session managers to enforce tenant isolation.
-	TenantID ContextKey = "tenant_id"
-)
+// TenantID is the canonical context key for the authenticated tenant ID.
+// Set by the auth middleware after validating an API key and read by
+// config handlers, service methods, and terminal session managers to enforce tenant isolation.
+var TenantID = tenantIDKeyType{}
 
 // correlationIDKeyType is unexported so no external package can construct a value of this type,
 // preventing key aliasing across package boundaries (the standard Go "opaque key" idiom).
@@ -23,3 +20,9 @@ type correlationIDKeyType struct{}
 // Both pkg/logging and pkg/telemetry store and read correlation IDs under this key,
 // so that logging.WithCorrelation and telemetry.GetCorrelationID share the same slot.
 var CorrelationIDKey = correlationIDKeyType{}
+
+// userIDKeyType is unexported to prevent external construction and key aliasing.
+type userIDKeyType struct{}
+
+// UserIDKey is the canonical context key for the authenticated user ID.
+var UserIDKey = userIDKeyType{}

--- a/pkg/ctxkeys/ctxkeys_test.go
+++ b/pkg/ctxkeys/ctxkeys_test.go
@@ -26,11 +26,11 @@ func TestTenantIDMissing(t *testing.T) {
 }
 
 func TestContextKeyCollision(t *testing.T) {
-	// A plain string key must not collide with the typed ContextKey.
+	// A plain string key must not collide with the struct-typed TenantID key.
 	//nolint:staticcheck // SA1029: intentionally using a plain string to verify typed key does not collide
 	ctx := context.WithValue(context.Background(), "tenant_id", "plain-string-value")
 	got, ok := ctx.Value(ctxkeys.TenantID).(string)
-	assert.False(t, ok, "typed key must not match plain string key")
+	assert.False(t, ok, "struct-typed key must not match plain string key")
 	assert.Empty(t, got)
 }
 
@@ -53,6 +53,29 @@ func TestCorrelationIDKeyCollision(t *testing.T) {
 	//nolint:staticcheck // SA1029: intentionally using a plain string to verify typed key does not collide
 	ctx := context.WithValue(context.Background(), "correlation_id", "plain-string-value")
 	got, ok := ctx.Value(ctxkeys.CorrelationIDKey).(string)
+	assert.False(t, ok, "struct-typed key must not match plain string key")
+	assert.Empty(t, got)
+}
+
+func TestUserIDKeyRoundtrip(t *testing.T) {
+	ctx := context.WithValue(context.Background(), ctxkeys.UserIDKey, "user-abc-123")
+	got, ok := ctx.Value(ctxkeys.UserIDKey).(string)
+	assert.True(t, ok)
+	assert.Equal(t, "user-abc-123", got)
+}
+
+func TestUserIDKeyMissing(t *testing.T) {
+	ctx := context.Background()
+	got, ok := ctx.Value(ctxkeys.UserIDKey).(string)
+	assert.False(t, ok)
+	assert.Empty(t, got)
+}
+
+func TestUserIDKeyCollision(t *testing.T) {
+	// A plain string key must not collide with the struct-typed UserIDKey.
+	//nolint:staticcheck // SA1029: intentionally using a plain string to verify typed key does not collide
+	ctx := context.WithValue(context.Background(), "user_id", "plain-string-value")
+	got, ok := ctx.Value(ctxkeys.UserIDKey).(string)
 	assert.False(t, ok, "struct-typed key must not match plain string key")
 	assert.Empty(t, got)
 }

--- a/pkg/storage/providers/database/rbac_store.go
+++ b/pkg/storage/providers/database/rbac_store.go
@@ -11,6 +11,8 @@ import (
 	"time"
 
 	_ "github.com/lib/pq" // PostgreSQL driver
+
+	"github.com/cfgis/cfgms/pkg/ctxkeys"
 )
 
 // ErrCrossTenantAccessDenied is returned when attempting to access a resource from a different tenant
@@ -115,7 +117,7 @@ func (s *DatabaseRBACStore) validateTenantAccess(ctx context.Context, resourceTe
 	}
 
 	// Extract authenticated tenant ID from context
-	authTenantIDValue := ctx.Value("tenant_id")
+	authTenantIDValue := ctx.Value(ctxkeys.TenantID)
 	if authTenantIDValue == nil {
 		// If no tenant_id in context, allow operation (backwards compatibility)
 		// This supports operations from internal system components


### PR DESCRIPTION
## Summary

- Migrated all remaining hardcoded `ctx.Value("tenant_id"|"user_id"|"correlation_id")` string lookups in production code to typed keys from `pkg/ctxkeys`, eliminating the key-aliasing / context-spoofing risk
- Migrated `TenantID` from named-string `ContextKey` type to opaque `tenantIDKeyType{}` struct (matching the existing `CorrelationIDKey` pattern) — external packages can no longer construct a colliding key
- Added `UserIDKey` with opaque `userIDKeyType{}` struct
- Added regression-guard tests in `pkg/ctxkeys/ctxkeys_test.go` (UserIDKey roundtrip, missing, collision) and `features/modules/script/audit_test.go` (context extraction: typed keys populate fields, missing keys leave fields empty, plain strings are rejected)

Fixes #1218

## Files Changed

| File | Change |
|------|--------|
| `pkg/ctxkeys/ctxkeys.go` | TenantID → opaque struct; add UserIDKey opaque struct |
| `pkg/ctxkeys/ctxkeys_test.go` | 3 new tests for UserIDKey; update TenantID collision test comment |
| `pkg/storage/providers/database/rbac_store.go:121` | `ctx.Value("tenant_id")` → `ctx.Value(ctxkeys.TenantID)` |
| `features/modules/script/audit.go:122-128` | 3 hardcoded strings → ctxkeys typed keys |
| `features/modules/script/audit_test.go` | TestAuditLogger_LogExecution_ContextExtraction (3 subtests) |

## Out of Scope (per issue)

- `features/controller/api/server_test.go:1188` — intentional regression test verifying plain string does NOT match typed key (unchanged)
- `features/reports/advanced.go:218-224` — documented dead-read fallbacks, separate cleanup story

## Specialist Review Results

**QA Test Runner: PASS**
- All 85+ packages passing, including pkg/ctxkeys, pkg/storage/providers/database, features/modules/script
- Cross-platform builds: linux/amd64, linux/arm64, darwin/amd64, darwin/arm64, windows/amd64 all pass
- Integration tests (certificate, controller, transport, logging): all pass

**QA Code Reviewer: PASS** (after fix iteration)
- Initial review found: (1) missing LogExecution context-extraction test coverage, (2) TenantID using named-string instead of opaque struct — both resolved
- Re-review confirmed: 0 blocking issues, 0 warnings

**Security Engineer: PASS**
- `make security-precommit`: PASS
- `make check-architecture`: PASS (no central provider violations)
- `make security-scan`: PASS (Trivy, Nancy, gosec, staticcheck all green)
- Manual review: changes are a net security improvement — eliminates plain-string ctx-key spoofing on tenant isolation and audit provenance paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)