### PR TITLE
test(controlplane/grpc): adopt public APIs in test files (Issue #1229)

### DIFF
--- a/pkg/controlplane/providers/grpc/export_test.go
+++ b/pkg/controlplane/providers/grpc/export_test.go
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+
+package grpc
+
+// GetState exposes the private getState method for test-only connection state inspection.
+var GetState = (*Provider).getState
+
+// SetAddrUnderSendMu atomically updates the provider's dial address under sendMu,
+// preserving the invariant that the reconnect loop reads addr under sendMu.
+var SetAddrUnderSendMu = func(p *Provider, addr string) {
+	p.sendMu.Lock()
+	p.addr = addr
+	p.sendMu.Unlock()
+}

--- a/pkg/controlplane/providers/grpc/external_server_test.go
+++ b/pkg/controlplane/providers/grpc/external_server_test.go
@@ -22,8 +22,12 @@ func TestExternalServer_InitializeWithGRPCServer(t *testing.T) {
 		"grpc_server": grpcServer,
 	})
 	require.NoError(t, err)
-	assert.False(t, p.ownGRPCServer, "should not own the gRPC server")
-	assert.Same(t, grpcServer, p.grpcServer, "should store the provided gRPC server")
+	require.NoError(t, p.Start(context.Background()))
+	defer func() { _ = p.Stop(context.Background()) }()
+	// External server path: no QUIC listener is created
+	assert.Equal(t, "", p.ListenAddr(), "should not create a QUIC listener when external gRPC server provided")
+	// External server path: a handler is registered with the provided gRPC server
+	assert.NotNil(t, p.ServerHandler(), "should register handler with the external gRPC server")
 }
 
 func TestExternalServer_StartCreatesServerImpl(t *testing.T) {
@@ -40,8 +44,8 @@ func TestExternalServer_StartCreatesServerImpl(t *testing.T) {
 	require.NoError(t, err)
 	defer func() { _ = p.Stop(context.Background()) }()
 
-	assert.Nil(t, p.listener, "should not create a QUIC listener")
-	assert.NotNil(t, p.serverImpl, "should create serverImpl for handler delegation")
+	assert.Equal(t, "", p.ListenAddr(), "should not create a QUIC listener")
+	assert.NotNil(t, p.ServerHandler(), "should create serverImpl for handler delegation")
 }
 
 func TestExternalServer_ServerHandlerReturnsHandler(t *testing.T) {
@@ -132,13 +136,10 @@ func TestOwnedServer_StillWorks(t *testing.T) {
 		"tls_config": serverTLS,
 	})
 	require.NoError(t, err)
-	assert.True(t, p.ownGRPCServer, "should own the gRPC server when using addr")
-
 	err = p.Start(context.Background())
 	require.NoError(t, err)
-	defer forceStopServer(p)
+	defer p.ForceStop()
 
-	assert.NotNil(t, p.listener, "should create a QUIC listener")
-	assert.NotNil(t, p.grpcServer, "should create a gRPC server")
-	assert.True(t, p.IsConnected())
+	assert.NotEqual(t, "", p.ListenAddr(), "should create a QUIC listener when using addr")
+	assert.True(t, p.IsConnected(), "should be connected after Start with owned gRPC server")
 }

--- a/pkg/controlplane/providers/grpc/integration_test.go
+++ b/pkg/controlplane/providers/grpc/integration_test.go
@@ -46,10 +46,10 @@ func newTestEnv(t *testing.T, stewardID string) *testEnv {
 	// Start server on ephemeral port
 	err = server.Start(context.Background())
 	require.NoError(t, err)
-	t.Cleanup(func() { forceStopServer(server) })
+	t.Cleanup(server.ForceStop)
 
 	// Get the actual listen address
-	listenAddr := server.listener.Addr().String()
+	listenAddr := server.ListenAddr()
 
 	client := New(ModeClient)
 	err = client.Initialize(context.Background(), map[string]interface{}{
@@ -303,9 +303,9 @@ func TestFanOutCommand(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.NoError(t, server.Start(context.Background()))
-	t.Cleanup(func() { forceStopServer(server) })
+	t.Cleanup(server.ForceStop)
 
-	listenAddr := server.listener.Addr().String()
+	listenAddr := server.ListenAddr()
 
 	// Connect two stewards
 	received := make(map[string]chan *types.SignedCommand)
@@ -394,9 +394,9 @@ func TestDisconnectCleansUpRegistry(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.NoError(t, server.Start(context.Background()))
-	t.Cleanup(func() { forceStopServer(server) })
+	t.Cleanup(server.ForceStop)
 
-	listenAddr := server.listener.Addr().String()
+	listenAddr := server.ListenAddr()
 
 	client := New(ModeClient)
 	err = client.Initialize(context.Background(), map[string]interface{}{
@@ -449,9 +449,9 @@ func TestMultipleConcurrentStewards(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.NoError(t, server.Start(context.Background()))
-	t.Cleanup(func() { forceStopServer(server) })
+	t.Cleanup(server.ForceStop)
 
-	listenAddr := server.listener.Addr().String()
+	listenAddr := server.ListenAddr()
 
 	const numStewards = 5
 
@@ -529,9 +529,17 @@ func TestStatsTracking(t *testing.T) {
 
 	// Poll until all stats are populated (async dispatch via goroutines)
 	require.Eventually(t, func() bool {
-		return env.server.eventsReceived.Load() >= 1 &&
-			env.server.heartbeatsReceived.Load() >= 1 &&
-			env.client.commandsReceived.Load() >= 1
+		sStats, err := env.server.GetStats(context.Background())
+		if err != nil {
+			return false
+		}
+		cStats, err := env.client.GetStats(context.Background())
+		if err != nil {
+			return false
+		}
+		return sStats.EventsReceived >= 1 &&
+			sStats.HeartbeatsReceived >= 1 &&
+			cStats.CommandsReceived >= 1
 	}, 5*time.Second, 10*time.Millisecond)
 
 	// Check server stats
@@ -555,9 +563,12 @@ func TestStatsTracking(t *testing.T) {
 func TestModeValidation(t *testing.T) {
 	// Server-only methods fail in client mode
 	client := New(ModeClient)
-	client.stewardID = "test"
-	client.addr = "localhost:50051"
-	client.tlsConfig = &tls.Config{}
+	require.NoError(t, client.Initialize(context.Background(), map[string]interface{}{
+		"mode":       "client",
+		"addr":       "localhost:50051",
+		"tls_config": &tls.Config{MinVersion: tls.VersionTLS13},
+		"steward_id": "test",
+	}))
 
 	err := client.SendCommand(context.Background(), &types.SignedCommand{})
 	assert.Error(t, err)
@@ -574,8 +585,11 @@ func TestModeValidation(t *testing.T) {
 
 	// Client-only methods fail in server mode
 	server := New(ModeServer)
-	server.addr = ":50051"
-	server.tlsConfig = &tls.Config{}
+	require.NoError(t, server.Initialize(context.Background(), map[string]interface{}{
+		"mode":       "server",
+		"addr":       ":50051",
+		"tls_config": &tls.Config{MinVersion: tls.VersionTLS13},
+	}))
 
 	err = server.SubscribeCommands(context.Background(), "x", nil)
 	assert.Error(t, err)

--- a/pkg/controlplane/providers/grpc/provider_controlchannel_identity_test.go
+++ b/pkg/controlplane/providers/grpc/provider_controlchannel_identity_test.go
@@ -38,9 +38,9 @@ func newMultiStewardEnv(t *testing.T) *multiStewardEnv {
 	})
 	require.NoError(t, err)
 	require.NoError(t, server.Start(context.Background()))
-	t.Cleanup(func() { forceStopServer(server) })
+	t.Cleanup(server.ForceStop)
 
-	listenAddr := server.listener.Addr().String()
+	listenAddr := server.ListenAddr()
 
 	clientA := New(ModeClient)
 	err = clientA.Initialize(context.Background(), map[string]interface{}{

--- a/pkg/controlplane/providers/grpc/provider_test.go
+++ b/pkg/controlplane/providers/grpc/provider_test.go
@@ -51,7 +51,7 @@ func TestControlPlaneProvider_reconnectLoop_logsWarning(t *testing.T) {
 	}))
 	require.NoError(t, server.Start(context.Background()))
 
-	serverAddr := server.listener.Addr().String()
+	serverAddr := server.ListenAddr()
 	mockLog := pkgtesting.NewMockLogger(true)
 
 	client := New(ModeClient)
@@ -72,7 +72,7 @@ func TestControlPlaneProvider_reconnectLoop_logsWarning(t *testing.T) {
 	}, 5*time.Second, 10*time.Millisecond, "steward should be registered before server is killed")
 
 	// Kill the server to trigger the reconnect loop on the client side.
-	forceStopServer(server)
+	server.ForceStop()
 
 	// The reconnect loop will fail to reconnect (server is gone) and emit a warn log.
 	require.Eventually(t, func() bool {

--- a/pkg/controlplane/providers/grpc/reconnect_test.go
+++ b/pkg/controlplane/providers/grpc/reconnect_test.go
@@ -33,32 +33,13 @@ func restartServerAndRepoint(t *testing.T, client *Provider, tc *testCA, reg reg
 		"registry":   reg,
 	}))
 	require.NoError(t, server.Start(context.Background()))
-	t.Cleanup(func() { forceStopServer(server) })
+	t.Cleanup(server.ForceStop)
 
 	// Point the client's reconnection loop at the new server address.
-	// Use sendMu because dialAndOpenStream reads addr under sendMu.
-	client.sendMu.Lock()
-	client.addr = server.listener.Addr().String()
-	client.sendMu.Unlock()
+	// SetAddrUnderSendMu holds sendMu because dialAndOpenStream reads addr under sendMu.
+	SetAddrUnderSendMu(client, server.ListenAddr())
 
 	return server
-}
-
-// forceStopServer forcefully kills a gRPC server without waiting for streams to finish.
-// GracefulStop() hangs on long-lived ControlChannel streams; this is needed for
-// reconnection tests that simulate server crashes.
-//
-// gRPC is stopped before the listener so that Stop() can send stream RST frames to
-// clients over the still-open QUIC connections. Closing the listener first tears down
-// the underlying UDP socket, preventing gRPC from notifying clients and causing them
-// to wait for the QUIC idle timeout (~90 s) instead of detecting the failure immediately.
-func forceStopServer(s *Provider) {
-	if s.grpcServer != nil {
-		s.grpcServer.Stop()
-	}
-	if s.listener != nil {
-		_ = s.listener.Close()
-	}
 }
 
 func TestMain(m *testing.M) {
@@ -94,7 +75,7 @@ func TestReconnectAfterServerRestart(t *testing.T) {
 	}))
 	require.NoError(t, server.Start(context.Background()))
 
-	listenAddr := server.listener.Addr().String()
+	listenAddr := server.ListenAddr()
 
 	// Set up command handler before connecting — handler survives reconnection
 	received := make(chan *types.SignedCommand, 1)
@@ -120,11 +101,11 @@ func TestReconnectAfterServerRestart(t *testing.T) {
 	}, 5*time.Second, 10*time.Millisecond)
 	assert.True(t, client.IsConnected())
 
-	forceStopServer(server)
+	server.ForceStop()
 
 	// Client should detect disconnection
 	require.Eventually(t, func() bool {
-		return client.getState() != StateConnected
+		return GetState(client) != StateConnected
 	}, 5*time.Second, 10*time.Millisecond, "client should detect disconnection")
 
 	// Restart server (new port, client addr updated automatically)
@@ -132,7 +113,7 @@ func TestReconnectAfterServerRestart(t *testing.T) {
 
 	// Client should reconnect automatically
 	require.Eventually(t, func() bool {
-		return client.getState() == StateConnected
+		return GetState(client) == StateConnected
 	}, 30*time.Second, 100*time.Millisecond, "client should reconnect")
 
 	// Steward should be back in the registry
@@ -170,7 +151,7 @@ func TestStopDuringReconnection(t *testing.T) {
 		"registry":   reg,
 	}))
 	require.NoError(t, server.Start(context.Background()))
-	listenAddr := server.listener.Addr().String()
+	listenAddr := server.ListenAddr()
 
 	client := New(ModeClient)
 	require.NoError(t, client.Initialize(context.Background(), map[string]interface{}{
@@ -183,17 +164,17 @@ func TestStopDuringReconnection(t *testing.T) {
 
 	// Wait for connection
 	require.Eventually(t, func() bool {
-		return client.getState() == StateConnected
+		return GetState(client) == StateConnected
 	}, 5*time.Second, 10*time.Millisecond)
 
 	// Kill server to trigger reconnection
-	forceStopServer(server)
+	server.ForceStop()
 
 	// Wait for client to enter reconnecting state. Use 15s to accommodate
 	// loaded CI machines where goroutine scheduling under the race detector
 	// can delay QUIC disconnect propagation beyond the default 5s budget.
 	require.Eventually(t, func() bool {
-		s := client.getState()
+		s := GetState(client)
 		return s == StateReconnecting || s == StateDisconnected
 	}, 15*time.Second, 10*time.Millisecond)
 
@@ -211,7 +192,7 @@ func TestStopDuringReconnection(t *testing.T) {
 		t.Fatal("client.Stop() hung during reconnection")
 	}
 
-	assert.Equal(t, StateDisconnected, client.getState())
+	assert.Equal(t, StateDisconnected, GetState(client))
 }
 
 func TestSendsDuringDisconnectionReturnErrors(t *testing.T) {
@@ -226,7 +207,7 @@ func TestSendsDuringDisconnectionReturnErrors(t *testing.T) {
 		"registry":   reg,
 	}))
 	require.NoError(t, server.Start(context.Background()))
-	listenAddr := server.listener.Addr().String()
+	listenAddr := server.ListenAddr()
 
 	client := New(ModeClient)
 	require.NoError(t, client.Initialize(context.Background(), map[string]interface{}{
@@ -239,15 +220,15 @@ func TestSendsDuringDisconnectionReturnErrors(t *testing.T) {
 	t.Cleanup(func() { _ = client.Stop(context.Background()) })
 
 	require.Eventually(t, func() bool {
-		return client.getState() == StateConnected
+		return GetState(client) == StateConnected
 	}, 5*time.Second, 10*time.Millisecond)
 
 	// Kill server
-	forceStopServer(server)
+	server.ForceStop()
 
 	// Wait for disconnection
 	require.Eventually(t, func() bool {
-		return client.getState() != StateConnected
+		return GetState(client) != StateConnected
 	}, 5*time.Second, 10*time.Millisecond)
 
 	// All send methods should return errors (state may be disconnected or reconnecting)
@@ -270,7 +251,9 @@ func TestSendsDuringDisconnectionReturnErrors(t *testing.T) {
 	require.Error(t, err)
 
 	// DeliveryFailures should be incremented
-	assert.True(t, client.deliveryFailures.Load() >= 3)
+	clientStats, err := client.GetStats(context.Background())
+	require.NoError(t, err)
+	assert.GreaterOrEqual(t, clientStats.DeliveryFailures, int64(3))
 }
 
 func TestOnStateChangeCallback(t *testing.T) {
@@ -288,7 +271,7 @@ func TestOnStateChangeCallback(t *testing.T) {
 		"registry":   reg,
 	}))
 	require.NoError(t, server.Start(context.Background()))
-	listenAddr := server.listener.Addr().String()
+	listenAddr := server.ListenAddr()
 
 	client := New(ModeClient)
 	require.NoError(t, client.Initialize(context.Background(), map[string]interface{}{
@@ -337,7 +320,7 @@ func TestReconnectStatsTracking(t *testing.T) {
 		"registry":   reg,
 	}))
 	require.NoError(t, server.Start(context.Background()))
-	listenAddr := server.listener.Addr().String()
+	listenAddr := server.ListenAddr()
 
 	client := New(ModeClient)
 	require.NoError(t, client.Initialize(context.Background(), map[string]interface{}{
@@ -350,15 +333,24 @@ func TestReconnectStatsTracking(t *testing.T) {
 	t.Cleanup(func() { _ = client.Stop(context.Background()) })
 
 	require.Eventually(t, func() bool {
-		return client.getState() == StateConnected
+		return GetState(client) == StateConnected
 	}, 5*time.Second, 10*time.Millisecond)
 
 	// Kill server to trigger reconnection attempts
-	forceStopServer(server)
+	server.ForceStop()
 
 	// Wait for at least one reconnect attempt
 	require.Eventually(t, func() bool {
-		return client.reconnectAttempts.Load() >= 1
+		stats, err := client.GetStats(context.Background())
+		if err != nil {
+			return false
+		}
+		v, ok := stats.ProviderMetrics["reconnect_attempts"]
+		if !ok {
+			return false
+		}
+		attempts, ok := v.(int64)
+		return ok && attempts >= 1
 	}, 10*time.Second, 50*time.Millisecond)
 
 	// Verify stats include reconnect info
@@ -374,7 +366,7 @@ func TestReconnectStatsTracking(t *testing.T) {
 
 	// Wait for reconnection
 	require.Eventually(t, func() bool {
-		return client.getState() == StateConnected
+		return GetState(client) == StateConnected
 	}, 30*time.Second, 100*time.Millisecond)
 }
 
@@ -396,7 +388,7 @@ func TestRapidDisconnectReconnectCycles(t *testing.T) {
 		"registry":   reg,
 	}))
 	require.NoError(t, server.Start(context.Background()))
-	listenAddr = server.listener.Addr().String()
+	listenAddr = server.ListenAddr()
 
 	require.NoError(t, client.Initialize(context.Background(), map[string]interface{}{
 		"mode":       "client",
@@ -408,15 +400,15 @@ func TestRapidDisconnectReconnectCycles(t *testing.T) {
 	t.Cleanup(func() { _ = client.Stop(context.Background()) })
 
 	require.Eventually(t, func() bool {
-		return client.getState() == StateConnected
+		return GetState(client) == StateConnected
 	}, 5*time.Second, 10*time.Millisecond)
 
 	// Rapid kill/restart cycles
 	for i := 0; i < 3; i++ {
-		forceStopServer(server)
+		server.ForceStop()
 
 		require.Eventually(t, func() bool {
-			return client.getState() != StateConnected
+			return GetState(client) != StateConnected
 		}, 5*time.Second, 10*time.Millisecond)
 
 		// Restart server (new port, client addr updated automatically)
@@ -424,7 +416,7 @@ func TestRapidDisconnectReconnectCycles(t *testing.T) {
 		serverCount.Add(1)
 
 		require.Eventually(t, func() bool {
-			return client.getState() == StateConnected
+			return GetState(client) == StateConnected
 		}, 30*time.Second, 100*time.Millisecond, "should reconnect after cycle %d", i)
 	}
 


### PR DESCRIPTION
## Summary

- Replace all `server.listener.Addr().String()` calls (12 sites across 5 test files) with `server.ListenAddr()`
- Delete `forceStopServer()` helper from reconnect_test.go; all callers use `server.ForceStop()` directly
- Add `export_test.go` with exactly 2 bridges: `GetState` (private state inspection, 12 sites) and `SetAddrUnderSendMu` (atomic addr update under sendMu for live-provider reconnect test)
- Replace direct field writes in `TestModeValidation` with `provider.Initialize()` calls
- Replace atomic stat field reads with `server.GetStats(ctx)` throughout
- Replace private field assertions in `external_server_test.go` with behavioral equivalents (`ListenAddr()`, `ServerHandler()`, `IsConnected()`)

Fixes #1229

## Specialist Review Results

- **QA Test Runner**: PASS — all 58 tests in `pkg/controlplane/providers/grpc` pass; cross-platform compilation passes; integration tests pass; security scans pass
- **QA Code Reviewer**: PASS — 0 blocking issues, 0 warnings; exactly 2 bridges in export_test.go; no mocks, no t.Skip(), no private field accesses remaining
- **Security Engineer**: PASS — no secrets, no vulnerabilities, no central provider violations; TLS configs use MinVersion TLS 1.3

## Test plan

- [x] `go test ./pkg/controlplane/providers/grpc/...` passes (50s, 58 tests)
- [x] `go vet ./pkg/controlplane/providers/grpc/...` passes
- [x] `make test-agent-complete` passes (unit, integration, cross-platform build, security scans)
- [x] No new `t.Skip()` calls
- [x] `export_test.go` has exactly 2 bridges

🤖 Generated with [Claude Code](https://claude.com/claude-code)