### PR TITLE
test(logging,storage): convert env-var-gated integration tests to build tags (Issue #1244)

### DIFF
--- a/pkg/logging/providers/timescale/plugin_test.go
+++ b/pkg/logging/providers/timescale/plugin_test.go
@@ -1,3 +1,5 @@
+//go:build integration
+
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2026 Jordan Ritz
 package timescale
@@ -20,10 +22,6 @@ import (
 
 // TestTimescaleProvider_BasicFunctionality tests basic provider operations
 func TestTimescaleProvider_BasicFunctionality(t *testing.T) {
-	if !isTimescaleTestEnabled() {
-		t.Skip("TimescaleDB tests disabled - set CFGMS_TEST_TIMESCALEDB=1 to enable")
-	}
-
 	// Test availability check before initialization
 	provider := &TimescaleProvider{}
 	available, err := provider.Available()
@@ -57,10 +55,6 @@ func TestTimescaleProvider_BasicFunctionality(t *testing.T) {
 
 // TestTimescaleProvider_WriteAndQuery tests writing and querying log entries
 func TestTimescaleProvider_WriteAndQuery(t *testing.T) {
-	if !isTimescaleTestEnabled() {
-		t.Skip("TimescaleDB tests disabled - set CFGMS_TEST_TIMESCALEDB=1 to enable")
-	}
-
 	provider, _ := createTestProviderWithCleanup(t, "writequery")
 
 	ctx := context.Background()
@@ -180,10 +174,6 @@ func TestTimescaleProvider_WriteAndQuery(t *testing.T) {
 
 // TestTimescaleProvider_LevelFiltering tests log level filtering
 func TestTimescaleProvider_LevelFiltering(t *testing.T) {
-	if !isTimescaleTestEnabled() {
-		t.Skip("TimescaleDB tests disabled - set CFGMS_TEST_TIMESCALEDB=1 to enable")
-	}
-
 	provider, _ := createTestProviderWithCleanup(t, "level")
 
 	ctx := context.Background()
@@ -249,10 +239,6 @@ func TestTimescaleProvider_LevelFiltering(t *testing.T) {
 
 // TestTimescaleProvider_HighVolume tests high-volume logging performance
 func TestTimescaleProvider_HighVolume(t *testing.T) {
-	if !isTimescaleTestEnabled() {
-		t.Skip("TimescaleDB tests disabled - set CFGMS_TEST_TIMESCALEDB=1 to enable")
-	}
-
 	provider, config := createTestProviderWithCleanup(t, "highvolume")
 	config["batch_size"] = 1000
 
@@ -329,10 +315,6 @@ func TestTimescaleProvider_HighVolume(t *testing.T) {
 
 // TestTimescaleProvider_Stats tests statistics functionality
 func TestTimescaleProvider_Stats(t *testing.T) {
-	if !isTimescaleTestEnabled() {
-		t.Skip("TimescaleDB tests disabled - set CFGMS_TEST_TIMESCALEDB=1 to enable")
-	}
-
 	provider, _ := createTestProviderWithCleanup(t, "stats")
 
 	ctx := context.Background()
@@ -374,10 +356,6 @@ func TestTimescaleProvider_Stats(t *testing.T) {
 
 // TestTimescaleProvider_ProviderRegistration tests provider registration
 func TestTimescaleProvider_ProviderRegistration(t *testing.T) {
-	if !isTimescaleTestEnabled() {
-		t.Skip("TimescaleDB tests disabled - set CFGMS_TEST_TIMESCALEDB=1 to enable")
-	}
-
 	// Test that the provider is registered
 	provider, err := interfaces.CreateLoggingProviderFromConfig("timescale", getTestTimescaleConfig())
 	assert.NoError(t, err)
@@ -389,11 +367,6 @@ func TestTimescaleProvider_ProviderRegistration(t *testing.T) {
 }
 
 // Helper functions
-
-// isTimescaleTestEnabled checks if TimescaleDB tests should run
-func isTimescaleTestEnabled() bool {
-	return os.Getenv("CFGMS_TEST_TIMESCALEDB") == "1"
-}
 
 // getTestTimescaleConfig returns test configuration for TimescaleDB with unique table names
 func getTestTimescaleConfig() map[string]interface{} {

--- a/pkg/logging/subscribers/syslog/subscriber_integration_test.go
+++ b/pkg/logging/subscribers/syslog/subscriber_integration_test.go
@@ -1,0 +1,54 @@
+//go:build !windows && integration
+
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+package syslog
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cfgis/cfgms/pkg/logging/interfaces"
+)
+
+func TestSyslogSubscriber_HandleLogEntry(t *testing.T) {
+	subscriber := NewSyslogSubscriber()
+
+	config := map[string]interface{}{
+		"network":         "", // Local syslog
+		"facility":        "daemon",
+		"tag":             "cfgms-test",
+		"structured_data": true,
+	}
+
+	err := subscriber.Initialize(config)
+	require.NoError(t, err)
+	defer func() { _ = subscriber.Close() }()
+
+	// Create test log entry
+	entry := interfaces.LogEntry{
+		Timestamp:   time.Now(),
+		Level:       "INFO",
+		Message:     "Test syslog subscriber",
+		ServiceName: "cfgms-controller",
+		Component:   "test-component",
+		TenantID:    "test-tenant",
+		SessionID:   "test-session",
+		Fields: map[string]interface{}{
+			"test_field": "test_value",
+		},
+	}
+
+	// Populate RFC5424 fields
+	interfaces.PopulateRFC5424Fields(&entry, "test-host", "cfgms-test", "12345", interfaces.FacilityDaemon)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	err = subscriber.HandleLogEntry(ctx, entry)
+	assert.NoError(t, err)
+}

--- a/pkg/logging/subscribers/syslog/subscriber_test.go
+++ b/pkg/logging/subscribers/syslog/subscriber_test.go
@@ -168,49 +168,6 @@ func TestSyslogSubscriber_Available_NetworkSyslog(t *testing.T) {
 	}
 }
 
-func TestSyslogSubscriber_HandleLogEntry(t *testing.T) {
-	// Skip this test if not running in an environment with syslog
-	if os.Getenv("CFGMS_TEST_SYSLOG") != "1" {
-		t.Skip("Syslog tests disabled - set CFGMS_TEST_SYSLOG=1 to enable")
-	}
-
-	subscriber := NewSyslogSubscriber()
-
-	config := map[string]interface{}{
-		"network":         "", // Local syslog
-		"facility":        "daemon",
-		"tag":             "cfgms-test",
-		"structured_data": true,
-	}
-
-	err := subscriber.Initialize(config)
-	require.NoError(t, err)
-	defer func() { _ = subscriber.Close() }()
-
-	// Create test log entry
-	entry := interfaces.LogEntry{
-		Timestamp:   time.Now(),
-		Level:       "INFO",
-		Message:     "Test syslog subscriber",
-		ServiceName: "cfgms-controller",
-		Component:   "test-component",
-		TenantID:    "test-tenant",
-		SessionID:   "test-session",
-		Fields: map[string]interface{}{
-			"test_field": "test_value",
-		},
-	}
-
-	// Populate RFC5424 fields
-	interfaces.PopulateRFC5424Fields(&entry, "test-host", "cfgms-test", "12345", interfaces.FacilityDaemon)
-
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
-
-	err = subscriber.HandleLogEntry(ctx, entry)
-	assert.NoError(t, err)
-}
-
 func TestSyslogSubscriber_HandleLogEntry_NotInitialized(t *testing.T) {
 	subscriber := NewSyslogSubscriber()
 

--- a/pkg/storage/providers/database/plugin_integration_test.go
+++ b/pkg/storage/providers/database/plugin_integration_test.go
@@ -1,0 +1,46 @@
+//go:build integration
+
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+// Package database provides integration tests for PostgreSQL storage provider
+package database
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cfgis/cfgms/pkg/storage/interfaces"
+)
+
+func TestDatabaseProvider_Integration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping database integration tests in short mode")
+	}
+
+	db := setupTestDatabase(t)
+	defer func() { _ = db.Close() }()
+
+	// Test provider registration
+	providerNames := interfaces.GetRegisteredProviderNames()
+	assert.Contains(t, providerNames, "database")
+
+	// Test getting the provider
+	provider, err := interfaces.GetStorageProvider("database")
+	require.NoError(t, err)
+	assert.NotNil(t, provider)
+
+	// Test creating storage manager (database provider uses single-backend mode)
+	storageManager, err := interfaces.CreateAllStoresFromConfig("database", getTestConfig()) //nolint:staticcheck // deprecated helper retained for integration coverage; no replacement in scope for this story
+	require.NoError(t, err)
+	require.NotNil(t, storageManager)
+
+	assert.Equal(t, "database", storageManager.GetProviderName())
+	assert.NotNil(t, storageManager.GetClientTenantStore())
+	assert.NotNil(t, storageManager.GetConfigStore())
+	assert.NotNil(t, storageManager.GetAuditStore())
+
+	capabilities := storageManager.GetCapabilities()
+	assert.True(t, capabilities.SupportsTransactions)
+}

--- a/pkg/storage/providers/database/plugin_test.go
+++ b/pkg/storage/providers/database/plugin_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/cfgis/cfgms/pkg/storage/interfaces"
 	business "github.com/cfgis/cfgms/pkg/storage/interfaces/business"
 	"github.com/cfgis/cfgms/pkg/testutil"
 )
@@ -407,42 +406,6 @@ func TestDatabaseClientTenantStore_AdminConsent(t *testing.T) {
 
 	_, err = store.GetAdminConsentRequest("test-state-789")
 	assert.Error(t, err)
-}
-
-func TestDatabaseProvider_Integration(t *testing.T) {
-	if testing.Short() {
-		t.Skip("Skipping database integration tests in short mode")
-	}
-
-	// Skip if DATABASE_URL is not set (CI/CD environments)
-	if os.Getenv("DATABASE_URL") == "" {
-		t.Skip("DATABASE_URL not set, skipping integration test")
-	}
-
-	db := setupTestDatabase(t)
-	defer func() { _ = db.Close() }()
-
-	// Test provider registration
-	providerNames := interfaces.GetRegisteredProviderNames()
-	assert.Contains(t, providerNames, "database")
-
-	// Test getting the provider
-	provider, err := interfaces.GetStorageProvider("database")
-	require.NoError(t, err)
-	assert.NotNil(t, provider)
-
-	// Test creating storage manager (database provider uses single-backend mode)
-	storageManager, err := interfaces.CreateAllStoresFromConfig("database", getTestConfig()) //nolint:staticcheck
-	require.NoError(t, err)
-	require.NotNil(t, storageManager)
-
-	assert.Equal(t, "database", storageManager.GetProviderName())
-	assert.NotNil(t, storageManager.GetClientTenantStore())
-	assert.NotNil(t, storageManager.GetConfigStore())
-	assert.NotNil(t, storageManager.GetAuditStore())
-
-	capabilities := storageManager.GetCapabilities()
-	assert.True(t, capabilities.SupportsTransactions)
 }
 
 func TestDatabaseProvider_ErrorHandling(t *testing.T) {


### PR DESCRIPTION
## Summary

- `pkg/logging/providers/timescale/plugin_test.go`: added `//go:build integration`; removed `isTimescaleTestEnabled()` helper and all 6 env-var `t.Skip` guards — file excluded from non-integration builds entirely
- `pkg/logging/subscribers/syslog/subscriber_integration_test.go`: new file (`//go:build !windows && integration`) with `TestSyslogSubscriber_HandleLogEntry` moved from `subscriber_test.go`, env-var check removed
- `pkg/storage/providers/database/plugin_integration_test.go`: new file (`//go:build integration`) with `TestDatabaseProvider_Integration` moved from `plugin_test.go`, `DATABASE_URL` env-var check removed; `testing.Short()` guard preserved

Fixes #1244

## Motivation

Three test packages used runtime env-var guards (`CFGMS_TEST_TIMESCALEDB`, `CFGMS_TEST_SYSLOG`, `DATABASE_URL`) to skip tests requiring live infrastructure. This produces silent skip noise in plain `go test` runs. After this change, these tests are gated by `//go:build integration` — they don't compile into the default binary at all, so no skips appear.

## Acceptance criteria verified

- [x] `go test ./pkg/logging/providers/timescale/... ./pkg/logging/subscribers/syslog/... ./pkg/storage/providers/database/...` (no tag) — zero skips/failures for formerly-gated tests
- [x] `go test -list . -tags=integration` — lists all formerly-gated test functions (confirmed they compile)
- [x] `make test-agent-complete` — PASS

## Specialist review results

**QA Test Runner: PASS**
- All packages compile and test clean
- Cross-platform builds verified (linux/amd64, linux/arm64, darwin/amd64, darwin/arm64, windows/amd64)
- 0 failures, 0 blocking issues
- Sentinel `/tmp/agent-validation-passed` written

**Security Engineer: PASS**
- `make security-precommit`: PASS
- `make check-architecture`: PASS
- `make security-scan`: PASS (Trivy, Nancy, gosec, staticcheck all green)
- No hardcoded secrets, SQL injection, central provider violations, or insecure defaults introduced

**QA Code Reviewer: 1 actionable issue fixed**
- Added justification comment to `//nolint:staticcheck` directive in new integration test file
- 3 other flagged items are pre-existing issues explicitly excluded by story spec:
  - `subscriber_test.go:156` skip — story spec: "Do not touch — runtime availability gate, not env-var gate"
  - `plugin_test.go` database connectivity skips — story spec: "Do not touch testing.Short() skips — legitimate Go idioms"