### PR TITLE
test(ha): add issue references to unimplemented-API skips in steward_ha_test.go (Issue #1246)

### DIFF
--- a/test/integration/ha/steward_ha_test.go
+++ b/test/integration/ha/steward_ha_test.go
@@ -228,7 +228,7 @@ func testStewardControllerFailover(t *testing.T, ctx context.Context, helper *Do
 
 // testConfigurationContinuity tests configuration push continuity during failover
 func testConfigurationContinuity(t *testing.T, ctx context.Context, helper *DockerComposeHelper, controllers []string, stewards []string) {
-	t.Skip("Skipping: configuration push API not yet implemented (requires controller config push endpoint)")
+	t.Skip("Skipping: configuration push API not yet implemented — Issue #1254")
 	t.Log("Testing configuration push continuity during failover...")
 
 	// Push a test configuration to all stewards
@@ -338,7 +338,7 @@ func testConfigurationContinuity(t *testing.T, ctx context.Context, helper *Dock
 
 // testSessionPersistence tests gRPC session persistence during failover
 func testSessionPersistence(t *testing.T, ctx context.Context, helper *DockerComposeHelper, controllers []string, stewards []string) {
-	t.Skip("Skipping: session monitoring API not yet implemented (requires gRPC session management)")
+	t.Skip("Skipping: session monitoring API not yet implemented — Issue #1255")
 	t.Log("Testing gRPC session persistence during failover...")
 
 	// Record initial session counts


### PR DESCRIPTION
## Summary

- Opened tracking issue #1254 for the missing `controller /api/v1/config/push` endpoint
- Opened tracking issue #1255 for the missing `controlplane gRPC session management API`
- Updated `t.Skip` in `testConfigurationContinuity` (line 231) to cite `Issue #1254`
- Updated `t.Skip` in `testSessionPersistence` (line 341) to cite `Issue #1255`

The anonymous skips in `test/integration/ha/steward_ha_test.go` now have traceable issue references, matching the project pattern established at `test/integration/security_state_consistency_test.go:520`.

Fixes #1246

## Test plan

- [x] `go build -tags=commercial ./test/integration/ha/...` — compiles cleanly
- [x] `make test-agent-complete` — all quality gates pass

## Specialist Review Results

- **QA Test Runner**: PASS — all 130+ packages pass, lint clean, cross-platform builds verified
- **QA Code Reviewer**: PASS — both skips confirmed as legitimate infrastructure skips (real unimplemented APIs, not lazy bypasses); no mocks or workarounds introduced
- **Security Engineer**: PASS — security-precommit, check-architecture, and security-scan all pass; no security concerns in the change

🤖 Generated with [Claude Code](https://claude.com/claude-code)