### PR TITLE
test(workflow,script): implement TestErrorHandlingIntegration and TestEphemeralKeyCleanup (Issue #1247)

### DIFF
--- a/features/modules/script/ephemeral_keys.go
+++ b/features/modules/script/ephemeral_keys.go
@@ -63,13 +63,18 @@ type EphemeralKeyManager struct {
 
 // NewEphemeralKeyManager creates a new ephemeral key manager
 func NewEphemeralKeyManager() *EphemeralKeyManager {
+	return newEphemeralKeyManagerWithInterval(1 * time.Minute)
+}
+
+// newEphemeralKeyManagerWithInterval creates an EphemeralKeyManager with a custom cleanup interval.
+// Use in tests to avoid waiting for the 1-minute default before verifying cleanup behaviour.
+func newEphemeralKeyManagerWithInterval(cleanupInterval time.Duration) *EphemeralKeyManager {
 	manager := &EphemeralKeyManager{
 		keys:            make(map[string]*EphemeralAPIKey),
-		cleanupInterval: 1 * time.Minute,
+		cleanupInterval: cleanupInterval,
 		stopCleanup:     make(chan struct{}),
 	}
 
-	// Start cleanup goroutine
 	go manager.cleanupExpiredKeys()
 
 	return manager

--- a/features/modules/script/ephemeral_keys_test.go
+++ b/features/modules/script/ephemeral_keys_test.go
@@ -171,8 +171,7 @@ func TestEphemeralKeyRevocation(t *testing.T) {
 }
 
 func TestEphemeralKeyCleanup(t *testing.T) {
-	t.Skip("Skipping due to race condition with cleanupInterval - cleanup is tested in other ways")
-	manager := NewEphemeralKeyManager()
+	manager := newEphemeralKeyManagerWithInterval(10 * time.Millisecond)
 	defer manager.Stop()
 
 	// Generate expired keys
@@ -189,10 +188,20 @@ func TestEphemeralKeyCleanup(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	// Wait for keys to expire and cleanup to run
-	time.Sleep(300 * time.Millisecond)
+	// All 5 keys should be present before expiry.
+	require.Equal(t, 5, manager.GetKeyCount())
 
-	// All keys should be cleaned up
+	// Poll until the background cleanup goroutine removes all expired keys,
+	// or until the deadline is reached. Using a poll loop instead of a fixed
+	// sleep avoids flakiness under load while honouring the race detector.
+	deadline := time.Now().Add(1 * time.Second)
+	for time.Now().Before(deadline) {
+		if manager.GetKeyCount() == 0 {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
 	assert.Equal(t, 0, manager.GetKeyCount())
 }
 

--- a/features/workflow/error_handling_test.go
+++ b/features/workflow/error_handling_test.go
@@ -5,12 +5,15 @@ package workflow
 import (
 	"context"
 	"errors"
+	"fmt"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/cfgis/cfgms/pkg/logging"
 )
 
 func TestWorkflowError(t *testing.T) {
@@ -296,12 +299,37 @@ func TestDefaultErrorHandler(t *testing.T) {
 }
 
 func TestErrorHandlingIntegration(t *testing.T) {
-	t.Skip("Skipping integration test - requires module factory setup")
-
 	t.Run("Workflow handles step errors appropriately", func(t *testing.T) {
-		// Test is skipped - would require proper module factory setup
-		// This test would create a workflow with a failing step and verify
-		// that error handling works correctly throughout the execution chain
+		factory := createTestFactory()
+		logger := logging.NewNoopLogger()
+
+		stepErr := fmt.Errorf("step execution failed: injected error")
+		exec := &testTransformExecutor{
+			result: StepResult{Status: StatusFailed},
+			err:    stepErr,
+		}
+		engine := NewEngine(factory, logger, exec)
+		engine.errorHandler = &testErrorHandler{
+			decision: ErrorHandlingDecision{Action: ErrorActionStop},
+		}
+
+		wf := Workflow{
+			Name: "error-handling-integration-test",
+			Steps: []Step{
+				{Name: "failing-step", Type: StepTypeTransform},
+			},
+		}
+
+		ctx := context.Background()
+		execution, err := engine.ExecuteWorkflow(ctx, wf, nil)
+		require.NoError(t, err)
+
+		waitForWorkflowCompletion(t, execution, 2*time.Second)
+
+		final, err := engine.GetExecution(execution.ID)
+		require.NoError(t, err)
+		assert.Equal(t, StatusFailed, final.GetStatus())
+		assert.NotEmpty(t, final.GetError())
 	})
 }
 


### PR DESCRIPTION
## Summary

- Implement `TestErrorHandlingIntegration` in `features/workflow/error_handling_test.go` using `createTestFactory()`, a real injected error, and assertions on `StatusFailed` + non-empty error message.
- Implement `TestEphemeralKeyCleanup` in `features/modules/script/ephemeral_keys_test.go` by adding `newEphemeralKeyManagerWithInterval(10ms)` in `ephemeral_keys.go` and replacing the fixed sleep with a deadline-polling loop.
- Removes both `t.Skip` calls; all tests pass with `-race`.

## Changes

**`features/modules/script/ephemeral_keys.go`** — Adds unexported `newEphemeralKeyManagerWithInterval(cleanupInterval time.Duration)` constructor. `NewEphemeralKeyManager()` delegates to it; production default (1 minute) unchanged. No public API change.

**`features/modules/script/ephemeral_keys_test.go`** — Removes `t.Skip` from `TestEphemeralKeyCleanup`. Uses `newEphemeralKeyManagerWithInterval(10ms)` so the background cleanup goroutine fires within the test window. Adds pre-condition `require.Equal(t, 5, ...)` and a deadline polling loop (10ms poll, 1s deadline) replacing the fixed 300ms sleep.

**`features/workflow/error_handling_test.go`** — Removes `t.Skip` stub from `TestErrorHandlingIntegration`. Uses `createTestFactory()`, `testTransformExecutor` (injected error), `testErrorHandler{ErrorActionStop}`, and `logging.NewNoopLogger()` (real component). Asserts `StatusFailed` and non-empty error string.

## Test Plan

- [x] `go test -race ./features/workflow/...` — PASS
- [x] `go test -race ./features/modules/script/... -run TestEphemeralKey` — PASS
- [x] `make test-agent-complete` — PASS (QA test runner)

## Specialist Review Results

- **QA Test Runner**: PASS — all quality validation gates passed
- **QA Code Reviewer**: PASS — no blocking issues (mock logger replaced with `logging.NewNoopLogger()`, sleep replaced with polling loop)
- **Security Engineer**: PASS — no security issues, automated scans (security-precommit, check-architecture, security-scan) all passed

Fixes #1247