### PR TITLE
commercial/ha: collapse 4 single-impl interfaces and eliminate sessionSync downcast (Epic #733)

### DIFF
--- a/commercial/ha/failover.go
+++ b/commercial/ha/failover.go
@@ -16,7 +16,6 @@ import (
 	"github.com/cfgis/cfgms/pkg/logging"
 )
 
-// failoverManager implements FailoverManager interface
 type failoverManager struct {
 	mu      sync.RWMutex
 	cfg     *FailoverConfig
@@ -34,7 +33,7 @@ type failoverManager struct {
 }
 
 // NewFailoverManager creates a new failover manager
-func NewFailoverManager(cfg *FailoverConfig, logger logging.Logger, manager *Manager) (FailoverManager, error) {
+func NewFailoverManager(cfg *FailoverConfig, logger logging.Logger, manager *Manager) (*failoverManager, error) {
 	if cfg == nil {
 		cfg = &FailoverConfig{
 			Enabled:             true,

--- a/commercial/ha/interfaces.go
+++ b/commercial/ha/interfaces.go
@@ -143,40 +143,10 @@ type HealthStatus struct {
 	Details   map[string]string    `json:"details,omitempty"`
 }
 
-// SessionSynchronizer handles session state synchronization across cluster nodes
-type SessionSynchronizer interface {
-	// SyncSessionState synchronizes session state to other cluster nodes
-	SyncSessionState(ctx context.Context, sessionID string, state interface{}) error
-
-	// GetSessionState retrieves session state from the cluster
-	GetSessionState(ctx context.Context, sessionID string) (interface{}, error)
-
-	// RemoveSessionState removes session state from the cluster
-	RemoveSessionState(ctx context.Context, sessionID string) error
-
-	// Subscribe to session state changes
-	Subscribe(ctx context.Context, handler SessionStateHandler) error
-}
-
 // SessionStateHandler handles session state change notifications
 type SessionStateHandler interface {
 	OnSessionStateChanged(sessionID string, state interface{}) error
 	OnSessionRemoved(sessionID string) error
-}
-
-// LoadBalancer handles request distribution across cluster nodes
-type LoadBalancer interface {
-	// GetNextNode returns the next node for load balancing
-	GetNextNode() (*NodeInfo, error)
-
-	// UpdateNodeHealth updates the health status of a node
-	UpdateNodeHealth(nodeID string, health *HealthStatus) error
-
-	// RemoveNode removes a node from load balancing
-	RemoveNode(nodeID string) error
-
-	// GetLoadBalancingStrategy returns the current strategy
-	GetLoadBalancingStrategy() LoadBalancingStrategy
 }
 
 // LoadBalancingStrategy represents different load balancing strategies
@@ -204,24 +174,6 @@ func (s LoadBalancingStrategy) String() string {
 	}
 }
 
-// FailoverManager handles automatic failover operations
-type FailoverManager interface {
-	// Start begins failover monitoring
-	Start(ctx context.Context) error
-
-	// Stop stops failover monitoring
-	Stop(ctx context.Context) error
-
-	// RegisterFailoverHandler registers a handler for failover events
-	RegisterFailoverHandler(handler FailoverHandler)
-
-	// TriggerFailover manually triggers a failover
-	TriggerFailover(ctx context.Context, reason string) error
-
-	// GetFailoverHistory returns recent failover events
-	GetFailoverHistory() ([]*FailoverEvent, error)
-}
-
 // FailoverHandler handles failover events
 type FailoverHandler interface {
 	OnFailoverStarted(event *FailoverEvent) error
@@ -240,21 +192,6 @@ type FailoverEvent struct {
 	SessionsMigrated int                    `json:"sessions_migrated"`
 	Status           string                 `json:"status"`
 	Details          map[string]interface{} `json:"details,omitempty"`
-}
-
-// SplitBrainDetector detects and prevents split-brain scenarios
-type SplitBrainDetector interface {
-	// Start begins split-brain detection
-	Start(ctx context.Context) error
-
-	// Stop stops split-brain detection
-	Stop(ctx context.Context) error
-
-	// CheckSplitBrain checks for split-brain conditions
-	CheckSplitBrain(ctx context.Context) (*SplitBrainStatus, error)
-
-	// RegisterSplitBrainHandler registers a handler for split-brain events
-	RegisterSplitBrainHandler(handler SplitBrainHandler)
 }
 
 // SplitBrainHandler handles split-brain detection events

--- a/commercial/ha/load_balancer.go
+++ b/commercial/ha/load_balancer.go
@@ -16,7 +16,6 @@ import (
 	"github.com/cfgis/cfgms/pkg/logging"
 )
 
-// loadBalancer implements LoadBalancer interface
 type loadBalancer struct {
 	mu       sync.RWMutex
 	cfg      *LoadBalancingConfig
@@ -42,7 +41,7 @@ type nodeStats struct {
 }
 
 // NewLoadBalancer creates a new load balancer
-func NewLoadBalancer(cfg *LoadBalancingConfig, logger logging.Logger) (LoadBalancer, error) {
+func NewLoadBalancer(cfg *LoadBalancingConfig, logger logging.Logger) (*loadBalancer, error) {
 	if cfg == nil {
 		cfg = &LoadBalancingConfig{
 			Strategy: HealthBasedStrategy,

--- a/commercial/ha/manager.go
+++ b/commercial/ha/manager.go
@@ -33,10 +33,10 @@ type Manager struct {
 	healthChecker *HealthChecker
 	raftConsensus *RaftConsensus // NEW: Raft-based consensus (replaces discovery + custom election)
 	discovery     Discovery      // DEPRECATED: Will be removed
-	loadBalancer  LoadBalancer
-	failover      FailoverManager
-	splitBrain    SplitBrainDetector
-	sessionSync   SessionSynchronizer
+	loadBalancer  *loadBalancer
+	failover      *failoverManager
+	splitBrain    *splitBrainDetector
+	sessionSync   *sessionSynchronizer
 
 	// State management
 	storageManager *interfaces.StorageManager
@@ -250,7 +250,7 @@ func (m *Manager) Stop(ctx context.Context) error {
 	}
 
 	if m.sessionSync != nil {
-		if err := m.sessionSync.(*sessionSynchronizer).Stop(ctx); err != nil {
+		if err := m.sessionSync.Stop(ctx); err != nil {
 			stopErrors = append(stopErrors, fmt.Errorf("session sync stop: %w", err))
 		}
 	}

--- a/commercial/ha/manager_test.go
+++ b/commercial/ha/manager_test.go
@@ -21,6 +21,41 @@ import (
 	"github.com/cfgis/cfgms/pkg/testing/storage"
 )
 
+// TestManager_ConcreteCollaboratorTypes verifies that Manager stores concrete types
+// for the 4 collaborators that had single-impl interfaces eliminated (Issue #1234).
+// Before the fix these fields were interface types; the sessionSync field required
+// a type-assertion downcast to call Stop(). Now all four are concrete pointer types.
+func TestManager_ConcreteCollaboratorTypes(t *testing.T) {
+	storageManager, err := storage.CreateTestStorageManager()
+	require.NoError(t, err)
+
+	cfg := DefaultConfig()
+	cfg.Mode = ClusterMode
+	cfg.Node.ID = "test-node-concrete-types"
+
+	mock := pkgtesting.NewMockLogger(true)
+	manager, err := NewManager(cfg, mock, storageManager)
+	require.NoError(t, err)
+	require.NotNil(t, manager)
+
+	t.Cleanup(func() {
+		if manager.raftConsensus != nil {
+			_ = manager.raftConsensus.Stop()
+		}
+	})
+
+	// All four collaborators must be non-nil concrete pointers after cluster-mode init.
+	require.NotNil(t, manager.sessionSync, "sessionSync must be initialized in cluster mode")
+	require.NotNil(t, manager.loadBalancer, "loadBalancer must be initialized in cluster mode")
+	require.NotNil(t, manager.failover, "failover must be initialized in cluster mode")
+	require.NotNil(t, manager.splitBrain, "splitBrain must be initialized in cluster mode")
+
+	// Stop() must be callable directly on the concrete *sessionSynchronizer field
+	// without any type-assertion downcast — the primary smell this issue removes.
+	ctx := context.Background()
+	assert.NoError(t, manager.sessionSync.Stop(ctx))
+}
+
 func TestManager_initRaft_logsInitStart(t *testing.T) {
 	mock := pkgtesting.NewMockLogger(true)
 

--- a/commercial/ha/manager_test.go
+++ b/commercial/ha/manager_test.go
@@ -33,14 +33,14 @@ func TestManager_ConcreteCollaboratorTypes(t *testing.T) {
 	cfg.Mode = ClusterMode
 	cfg.Node.ID = "test-node-concrete-types"
 
-	mock := pkgtesting.NewMockLogger(true)
-	manager, err := NewManager(cfg, mock, storageManager)
+	logger := logging.GetLogger()
+	manager, err := NewManager(cfg, logger, storageManager)
 	require.NoError(t, err)
 	require.NotNil(t, manager)
 
 	t.Cleanup(func() {
 		if manager.raftConsensus != nil {
-			_ = manager.raftConsensus.Stop()
+			assert.NoError(t, manager.raftConsensus.Stop())
 		}
 	})
 

--- a/commercial/ha/session_sync.go
+++ b/commercial/ha/session_sync.go
@@ -25,7 +25,6 @@ type runtimeStateStore interface {
 	DeleteRuntimeState(ctx context.Context, key string) error
 }
 
-// sessionSynchronizer implements SessionSynchronizer interface
 type sessionSynchronizer struct {
 	mu         sync.RWMutex
 	cfg        *SessionSyncConfig
@@ -60,7 +59,7 @@ type sessionState struct {
 }
 
 // NewSessionSynchronizer creates a new session synchronizer
-func NewSessionSynchronizer(cfg *SessionSyncConfig, logger logging.Logger, storage *interfaces.StorageManager, manager *Manager) (SessionSynchronizer, error) {
+func NewSessionSynchronizer(cfg *SessionSyncConfig, logger logging.Logger, storage *interfaces.StorageManager, manager *Manager) (*sessionSynchronizer, error) {
 	if cfg == nil {
 		cfg = &SessionSyncConfig{
 			Enabled:      true,

--- a/commercial/ha/split_brain.go
+++ b/commercial/ha/split_brain.go
@@ -15,7 +15,6 @@ import (
 	"github.com/cfgis/cfgms/pkg/logging"
 )
 
-// splitBrainDetector implements SplitBrainDetector interface
 type splitBrainDetector struct {
 	mu      sync.RWMutex
 	cfg     *SplitBrainConfig
@@ -42,7 +41,7 @@ type partitionInfo struct {
 }
 
 // NewSplitBrainDetector creates a new split-brain detector
-func NewSplitBrainDetector(cfg *SplitBrainConfig, logger logging.Logger, manager *Manager) (SplitBrainDetector, error) {
+func NewSplitBrainDetector(cfg *SplitBrainConfig, logger logging.Logger, manager *Manager) (*splitBrainDetector, error) {
 	if cfg == nil {
 		cfg = &SplitBrainConfig{
 			Enabled:            true,


### PR DESCRIPTION
Agent session failed with exit code 1. Review container logs for details.