### PR TITLE
ctxkeys: migrate remaining string literals in getUserIDFromContext (Issue #1266)

### DIFF
--- a/features/reports/advanced.go
+++ b/features/reports/advanced.go
@@ -214,13 +214,11 @@ func NewAdvancedServiceWithConfig(
 
 // getUserIDFromContext extracts user ID from context for RBAC validation
 func (s *AdvancedService) getUserIDFromContext(ctx context.Context) string {
-	// dead read: no set-site uses this plain string key; tracked for cleanup separately
-	if userID, ok := ctx.Value("user_id").(string); ok && userID != "" {
+	if userID, ok := ctx.Value(ctxkeys.UserIDKey).(string); ok && userID != "" {
 		return userID
 	}
 
-	// dead read: no set-site uses this plain string key; tracked for cleanup separately
-	if claims, ok := ctx.Value("auth_claims").(map[string]interface{}); ok {
+	if claims, ok := ctx.Value(ctxkeys.AuthClaimsKey).(map[string]interface{}); ok {
 		if sub, ok := claims["sub"].(string); ok {
 			return sub
 		}

--- a/features/reports/advanced_test.go
+++ b/features/reports/advanced_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/cfgis/cfgms/features/reports/interfaces"
 	"github.com/cfgis/cfgms/features/steward/dna/drift"
 	"github.com/cfgis/cfgms/pkg/audit"
+	"github.com/cfgis/cfgms/pkg/ctxkeys"
 	"github.com/cfgis/cfgms/pkg/logging"
 	pkgtesting "github.com/cfgis/cfgms/pkg/testing"
 
@@ -412,6 +413,28 @@ func TestConvenienceMethods(t *testing.T) {
 	)
 	assert.NoError(t, err)
 	assert.NotNil(t, dashboardData)
+}
+
+// TestGetUserIDFromContext verifies getUserIDFromContext reads user identity via typed ctxkeys,
+// not plain string literals.
+func TestGetUserIDFromContext(t *testing.T) {
+	service := createTestAdvancedService(t)
+
+	// UserIDKey (typed) takes priority over other fallbacks.
+	ctxWithUserID := context.WithValue(context.Background(), ctxkeys.UserIDKey, "user-abc-123")
+	assert.Equal(t, "user-abc-123", service.getUserIDFromContext(ctxWithUserID))
+
+	// AuthClaimsKey (typed) is the second fallback; sub field extracted.
+	claims := map[string]interface{}{"sub": "claims-user-456", "role": "admin"}
+	ctxWithClaims := context.WithValue(context.Background(), ctxkeys.AuthClaimsKey, claims)
+	assert.Equal(t, "claims-user-456", service.getUserIDFromContext(ctxWithClaims))
+
+	// TenantID fallback when neither UserIDKey nor AuthClaimsKey is present.
+	ctxWithTenant := context.WithValue(context.Background(), ctxkeys.TenantID, "tenant-xyz")
+	assert.Equal(t, "system-user-tenant-xyz", service.getUserIDFromContext(ctxWithTenant))
+
+	// Default when no context values are set.
+	assert.Equal(t, "system-user", service.getUserIDFromContext(context.Background()))
 }
 
 // TestServiceClose tests service cleanup

--- a/pkg/ctxkeys/ctxkeys.go
+++ b/pkg/ctxkeys/ctxkeys.go
@@ -26,3 +26,9 @@ type userIDKeyType struct{}
 
 // UserIDKey is the canonical context key for the authenticated user ID.
 var UserIDKey = userIDKeyType{}
+
+// authClaimsKeyType is unexported to prevent external construction and key aliasing.
+type authClaimsKeyType struct{}
+
+// AuthClaimsKey is the canonical context key for authentication claims (e.g., JWT claims map).
+var AuthClaimsKey = authClaimsKeyType{}

--- a/pkg/ctxkeys/ctxkeys_test.go
+++ b/pkg/ctxkeys/ctxkeys_test.go
@@ -79,3 +79,27 @@ func TestUserIDKeyCollision(t *testing.T) {
 	assert.False(t, ok, "struct-typed key must not match plain string key")
 	assert.Empty(t, got)
 }
+
+func TestAuthClaimsKeyRoundtrip(t *testing.T) {
+	claims := map[string]interface{}{"sub": "user-123", "role": "admin"}
+	ctx := context.WithValue(context.Background(), ctxkeys.AuthClaimsKey, claims)
+	got, ok := ctx.Value(ctxkeys.AuthClaimsKey).(map[string]interface{})
+	assert.True(t, ok)
+	assert.Equal(t, claims, got)
+}
+
+func TestAuthClaimsKeyMissing(t *testing.T) {
+	ctx := context.Background()
+	got, ok := ctx.Value(ctxkeys.AuthClaimsKey).(map[string]interface{})
+	assert.False(t, ok)
+	assert.Nil(t, got)
+}
+
+func TestAuthClaimsKeyCollision(t *testing.T) {
+	// A plain string key must not collide with the struct-typed AuthClaimsKey.
+	//nolint:staticcheck // SA1029: intentionally using a plain string to verify typed key does not collide
+	ctx := context.WithValue(context.Background(), "auth_claims", map[string]interface{}{"sub": "bad"})
+	got, ok := ctx.Value(ctxkeys.AuthClaimsKey).(map[string]interface{})
+	assert.False(t, ok, "struct-typed key must not match plain string key")
+	assert.Nil(t, got)
+}


### PR DESCRIPTION
## Summary

Epic #734 follow-up closing the two `ctx.Value` string literals in `features/reports/advanced.go` that were missed when sub-issue #1218 was resolved via PR #1236.

- Add `AuthClaimsKey` typed context key to `pkg/ctxkeys/ctxkeys.go` using the same opaque-struct idiom as `TenantID`, `CorrelationIDKey`, and `UserIDKey`
- Replace `ctx.Value("user_id")` → `ctx.Value(ctxkeys.UserIDKey)` and `ctx.Value("auth_claims")` → `ctx.Value(ctxkeys.AuthClaimsKey)` in `getUserIDFromContext`
- Add `TestGetUserIDFromContext` exercising all four code paths with typed keys; add three `AuthClaimsKey` tests to `ctxkeys_test.go`

Fixes #1266

## Acceptance Criteria Status

- [x] `features/reports/advanced.go:218` reads `user_id` via `ctxkeys.UserIDKey`
- [x] `features/reports/advanced.go:223` reads `auth_claims` via `ctxkeys.AuthClaimsKey`
- [x] `grep -nE 'ctx\.Value\("(user_id|auth_claims|tenant_id|correlation_id)"\)' features/reports/advanced.go` → zero results
- [x] Existing tests in `features/reports/` continue to pass
- [x] `make test-agent-complete` passes

## Specialist Review Results

| Reviewer | Result | Notes |
|---|---|---|
| qa-test-runner | **PASS** | All tests pass; Trivy DB download blocked by container network (infra issue, not code) |
| qa-code-reviewer | **PASS** | 0 blocking issues, 0 warnings; all four `getUserIDFromContext` paths covered |
| security-engineer | **PASS** | 0 blocking issues; noted this closes two context-key-aliasing footguns |

## Files Changed

- `pkg/ctxkeys/ctxkeys.go` — add `AuthClaimsKey`
- `pkg/ctxkeys/ctxkeys_test.go` — 3 new tests for `AuthClaimsKey`
- `features/reports/advanced.go` — replace 2 string literals with typed keys
- `features/reports/advanced_test.go` — add `TestGetUserIDFromContext`