### PR TITLE
controlplane/grpc: replace package globals with per-test injection (Issue #1245)

### DIFF
--- a/pkg/controlplane/providers/grpc/provider.go
+++ b/pkg/controlplane/providers/grpc/provider.go
@@ -44,6 +44,25 @@ const (
 	ModeClient Mode = "client"
 )
 
+// option is an unexported functional option for New.
+type option func(*Provider)
+
+// withBackoff injects a custom backoff configuration into the provider.
+// Intended for testing only; production code uses the defaults.
+func withBackoff(b *backoff) option {
+	return func(p *Provider) {
+		p.backoffOverride = b
+	}
+}
+
+// withQUICConfig injects a custom QUIC configuration into the provider.
+// Intended for testing only; production code uses the defaults.
+func withQUICConfig(cfg *quicgo.Config) option {
+	return func(p *Provider) {
+		p.quicConfigOverride = cfg
+	}
+}
+
 // Provider implements the ControlPlaneProvider interface using gRPC-over-QUIC.
 type Provider struct {
 	mu sync.RWMutex
@@ -76,6 +95,10 @@ type Provider struct {
 	tenantID        string
 	logger          logging.Logger
 	startTime       time.Time
+
+	// Per-instance overrides injected via constructor options (test-only)
+	backoffOverride    *backoff
+	quicConfigOverride *quicgo.Config
 
 	// Subscription handlers (client mode)
 	commandHandler interfaces.CommandHandler
@@ -113,14 +136,18 @@ type eventSubscription struct {
 }
 
 // New creates a new gRPC control plane provider.
-func New(mode Mode) *Provider {
-	return &Provider{
+func New(mode Mode, opts ...option) *Provider {
+	p := &Provider{
 		name:              "grpc",
 		mode:              mode,
 		eventHandlers:     []eventSubscription{},
 		heartbeatHandlers: []interfaces.HeartbeatHandler{},
 		logger:            logging.NewNoopLogger(),
 	}
+	for _, opt := range opts {
+		opt(p)
+	}
+	return p
 }
 
 func (p *Provider) Name() string { return p.name }
@@ -254,8 +281,8 @@ func (p *Provider) Start(ctx context.Context) error {
 
 // quicConfig returns a *quicgo.Config with any user overrides, or nil for defaults.
 func (p *Provider) quicConfig() *quicgo.Config {
-	if testQUICConfig != nil {
-		return testQUICConfig
+	if p.quicConfigOverride != nil {
+		return p.quicConfigOverride
 	}
 	if p.keepalivePeriod == 0 && p.idleTimeout == 0 {
 		return nil // use QUIC transport defaults
@@ -418,27 +445,16 @@ func (p *Provider) clientReceiveLoop() {
 	}
 }
 
-// testBackoffOverride allows tests to use shorter backoff intervals.
-// Only set from test code via the unexported field.
-var testBackoffOverride *backoff
-
-// testQUICConfig allows tests to override the QUIC configuration.
-// Setting a short MaxIdleTimeout and KeepAlivePeriod ensures that
-// server failures are detected quickly on loaded CI machines even
-// when CONNECTION_CLOSE frames are delayed by goroutine scheduling.
-// Only set from test code via the unexported field.
-var testQUICConfig *quicgo.Config
-
 // reconnectLoop attempts to re-establish the ControlChannel with exponential backoff.
 // It runs until either a connection is established or the provider context is cancelled.
 func (p *Provider) reconnectLoop() {
 	bo := defaultBackoff()
-	if testBackoffOverride != nil {
+	if p.backoffOverride != nil {
 		bo = &backoff{
-			initial:    testBackoffOverride.initial,
-			max:        testBackoffOverride.max,
-			multiplier: testBackoffOverride.multiplier,
-			jitter:     testBackoffOverride.jitter,
+			initial:    p.backoffOverride.initial,
+			max:        p.backoffOverride.max,
+			multiplier: p.backoffOverride.multiplier,
+			jitter:     p.backoffOverride.jitter,
 		}
 	}
 

--- a/pkg/controlplane/providers/grpc/provider_test.go
+++ b/pkg/controlplane/providers/grpc/provider_test.go
@@ -11,6 +11,7 @@ import (
 	pkgtesting "github.com/cfgis/cfgms/pkg/testing"
 	quictransport "github.com/cfgis/cfgms/pkg/transport/quic"
 	"github.com/cfgis/cfgms/pkg/transport/registry"
+	quicgo "github.com/quic-go/quic-go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
@@ -54,7 +55,10 @@ func TestControlPlaneProvider_reconnectLoop_logsWarning(t *testing.T) {
 	serverAddr := server.ListenAddr()
 	mockLog := pkgtesting.NewMockLogger(true)
 
-	client := New(ModeClient)
+	client := New(ModeClient,
+		withBackoff(&backoff{initial: 50 * time.Millisecond, max: 200 * time.Millisecond, multiplier: 2.0, jitter: 0.1}),
+		withQUICConfig(&quicgo.Config{MaxIdleTimeout: 3 * time.Second, KeepAlivePeriod: 200 * time.Millisecond}),
+	)
 	require.NoError(t, client.Initialize(context.Background(), map[string]interface{}{
 		"mode":       "client",
 		"addr":       serverAddr,

--- a/pkg/controlplane/providers/grpc/reconnect_test.go
+++ b/pkg/controlplane/providers/grpc/reconnect_test.go
@@ -5,7 +5,7 @@ package grpc
 
 import (
 	"context"
-	"os"
+	"crypto/tls"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -42,23 +42,32 @@ func restartServerAndRepoint(t *testing.T, client *Provider, tc *testCA, reg reg
 	return server
 }
 
-func TestMain(m *testing.M) {
-	// Use fast backoff for all reconnection tests to avoid timeouts with race detector.
-	testBackoffOverride = &backoff{
-		initial:    50 * time.Millisecond,
-		max:        200 * time.Millisecond,
-		multiplier: 2.0,
-		jitter:     0.1,
-	}
-	// Use short QUIC timeouts so server failures are detected quickly on loaded
-	// CI machines even when CONNECTION_CLOSE frames are delayed by goroutine
-	// scheduling under the race detector. KeepAlivePeriod keeps established
-	// connections alive; MaxIdleTimeout bounds worst-case failure detection.
-	testQUICConfig = &quicgo.Config{
-		MaxIdleTimeout:  3 * time.Second,
-		KeepAlivePeriod: 200 * time.Millisecond,
-	}
-	os.Exit(m.Run())
+// newTestClient creates a ModeClient Provider pre-configured with fast backoff
+// and short QUIC timeouts for reconnection tests. Fast backoff avoids timeouts
+// under the race detector; short QUIC timeouts ensure server failures are
+// detected quickly on loaded CI machines even when CONNECTION_CLOSE frames are
+// delayed by goroutine scheduling.
+func newTestClient(t *testing.T, addr string, tlsConfig *tls.Config, stewardID string) *Provider {
+	t.Helper()
+	p := New(ModeClient,
+		withBackoff(&backoff{
+			initial:    50 * time.Millisecond,
+			max:        200 * time.Millisecond,
+			multiplier: 2.0,
+			jitter:     0.1,
+		}),
+		withQUICConfig(&quicgo.Config{
+			MaxIdleTimeout:  3 * time.Second,
+			KeepAlivePeriod: 200 * time.Millisecond,
+		}),
+	)
+	require.NoError(t, p.Initialize(context.Background(), map[string]interface{}{
+		"mode":       "client",
+		"addr":       addr,
+		"tls_config": tlsConfig,
+		"steward_id": stewardID,
+	}))
+	return p
 }
 
 func TestReconnectAfterServerRestart(t *testing.T) {
@@ -80,13 +89,7 @@ func TestReconnectAfterServerRestart(t *testing.T) {
 	// Set up command handler before connecting — handler survives reconnection
 	received := make(chan *types.SignedCommand, 1)
 
-	client := New(ModeClient)
-	require.NoError(t, client.Initialize(context.Background(), map[string]interface{}{
-		"mode":       "client",
-		"addr":       listenAddr,
-		"tls_config": tc.clientTLSConfig(t, "steward-reconnect"),
-		"steward_id": "steward-reconnect",
-	}))
+	client := newTestClient(t, listenAddr, tc.clientTLSConfig(t, "steward-reconnect"), "steward-reconnect")
 	require.NoError(t, client.SubscribeCommands(context.Background(), "steward-reconnect", func(ctx context.Context, sc *types.SignedCommand) error {
 		received <- sc
 		return nil
@@ -153,13 +156,7 @@ func TestStopDuringReconnection(t *testing.T) {
 	require.NoError(t, server.Start(context.Background()))
 	listenAddr := server.ListenAddr()
 
-	client := New(ModeClient)
-	require.NoError(t, client.Initialize(context.Background(), map[string]interface{}{
-		"mode":       "client",
-		"addr":       listenAddr,
-		"tls_config": tc.clientTLSConfig(t, "steward-stop-reconnect"),
-		"steward_id": "steward-stop-reconnect",
-	}))
+	client := newTestClient(t, listenAddr, tc.clientTLSConfig(t, "steward-stop-reconnect"), "steward-stop-reconnect")
 	require.NoError(t, client.Start(context.Background()))
 
 	// Wait for connection
@@ -209,13 +206,7 @@ func TestSendsDuringDisconnectionReturnErrors(t *testing.T) {
 	require.NoError(t, server.Start(context.Background()))
 	listenAddr := server.ListenAddr()
 
-	client := New(ModeClient)
-	require.NoError(t, client.Initialize(context.Background(), map[string]interface{}{
-		"mode":       "client",
-		"addr":       listenAddr,
-		"tls_config": tc.clientTLSConfig(t, "steward-send-err"),
-		"steward_id": "steward-send-err",
-	}))
+	client := newTestClient(t, listenAddr, tc.clientTLSConfig(t, "steward-send-err"), "steward-send-err")
 	require.NoError(t, client.Start(context.Background()))
 	t.Cleanup(func() { _ = client.Stop(context.Background()) })
 
@@ -273,7 +264,10 @@ func TestOnStateChangeCallback(t *testing.T) {
 	require.NoError(t, server.Start(context.Background()))
 	listenAddr := server.ListenAddr()
 
-	client := New(ModeClient)
+	client := New(ModeClient,
+		withBackoff(&backoff{initial: 50 * time.Millisecond, max: 200 * time.Millisecond, multiplier: 2.0, jitter: 0.1}),
+		withQUICConfig(&quicgo.Config{MaxIdleTimeout: 3 * time.Second, KeepAlivePeriod: 200 * time.Millisecond}),
+	)
 	require.NoError(t, client.Initialize(context.Background(), map[string]interface{}{
 		"mode":       "client",
 		"addr":       listenAddr,
@@ -322,13 +316,7 @@ func TestReconnectStatsTracking(t *testing.T) {
 	require.NoError(t, server.Start(context.Background()))
 	listenAddr := server.ListenAddr()
 
-	client := New(ModeClient)
-	require.NoError(t, client.Initialize(context.Background(), map[string]interface{}{
-		"mode":       "client",
-		"addr":       listenAddr,
-		"tls_config": tc.clientTLSConfig(t, "steward-stats-reconnect"),
-		"steward_id": "steward-stats-reconnect",
-	}))
+	client := newTestClient(t, listenAddr, tc.clientTLSConfig(t, "steward-stats-reconnect"), "steward-stats-reconnect")
 	require.NoError(t, client.Start(context.Background()))
 	t.Cleanup(func() { _ = client.Stop(context.Background()) })
 
@@ -375,9 +363,6 @@ func TestRapidDisconnectReconnectCycles(t *testing.T) {
 
 	var serverCount atomic.Int32
 
-	client := New(ModeClient)
-	var listenAddr string
-
 	// Start initial server
 	reg := registry.NewRegistry()
 	server := New(ModeServer)
@@ -388,14 +373,9 @@ func TestRapidDisconnectReconnectCycles(t *testing.T) {
 		"registry":   reg,
 	}))
 	require.NoError(t, server.Start(context.Background()))
-	listenAddr = server.ListenAddr()
+	listenAddr := server.ListenAddr()
 
-	require.NoError(t, client.Initialize(context.Background(), map[string]interface{}{
-		"mode":       "client",
-		"addr":       listenAddr,
-		"tls_config": tc.clientTLSConfig(t, "steward-rapid"),
-		"steward_id": "steward-rapid",
-	}))
+	client := newTestClient(t, listenAddr, tc.clientTLSConfig(t, "steward-rapid"), "steward-rapid")
 	require.NoError(t, client.Start(context.Background()))
 	t.Cleanup(func() { _ = client.Stop(context.Background()) })
 


### PR DESCRIPTION
## Summary

- Removes `testBackoffOverride` and `testQUICConfig` package-level mutable globals from `pkg/controlplane/providers/grpc/provider.go`
- Adds unexported `option` type with `withBackoff`/`withQUICConfig` constructors following the existing functional options pattern (see `pkg/gitsync`)
- Updates `New()` to `New(mode Mode, opts ...option)` — all callers without options are unaffected
- Replaces `TestMain` in `reconnect_test.go` with `newTestClient` helper that injects options per-test

## Test plan

- [x] All reconnect tests pass with `-race`: `go test -race ./pkg/controlplane/providers/grpc/...`
- [x] No package-level `testBackoffOverride` or `testQUICConfig` variables remain
- [x] `New()` accepts unexported functional options; exported API is unchanged
- [x] `TestMain` removed from `reconnect_test.go`; `newTestClient` helper added
- [x] `TestControlPlaneProvider_reconnectLoop_logsWarning` updated to inject config (relied on removed global)
- [x] QA code review: PASS — no mocks, no t.Skip, no workarounds
- [x] Security review: PASS — net security improvement (eliminates mutable global state); gosec, staticcheck, architecture checks all pass; Trivy blocked by sandbox DNS (will run in CI)

Fixes #1245

🤖 Generated with [Claude Code](https://claude.com/claude-code)