### PR TITLE
pkg/directory: alias interfaces.DirectoryUser/Group to types canonical (Issue #1272)

### DIFF
--- a/pkg/directory/interfaces/alias_test.go
+++ b/pkg/directory/interfaces/alias_test.go
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+package interfaces_test
+
+import (
+	"testing"
+
+	"github.com/cfgis/cfgms/pkg/directory/interfaces"
+	"github.com/cfgis/cfgms/pkg/directory/types"
+)
+
+// Compile-time assertions: all four aliased types are identical to their types package counterparts.
+var _ types.DirectoryUser = interfaces.DirectoryUser{}
+var _ types.DirectoryGroup = interfaces.DirectoryGroup{}
+var _ types.GroupType = interfaces.GroupType("")
+var _ types.GroupScope = interfaces.GroupScope("")
+
+func TestTypeAliasIdentity(t *testing.T) {
+	u := interfaces.DirectoryUser{Source: "test-source"}
+	canonical := u
+	if canonical.Source != "test-source" {
+		t.Fatal("DirectoryUser alias identity failed: field value not preserved")
+	}
+
+	g := interfaces.DirectoryGroup{Source: "test-source"}
+	canonicalGroup := g
+	if canonicalGroup.Source != "test-source" {
+		t.Fatal("DirectoryGroup alias identity failed: field value not preserved")
+	}
+
+	// Verify GroupType constants round-trip correctly across the alias boundary.
+	if interfaces.GroupTypeSecurity != types.GroupTypeSecurity {
+		t.Fatalf("GroupTypeSecurity mismatch: %q vs %q", interfaces.GroupTypeSecurity, types.GroupTypeSecurity)
+	}
+	if interfaces.GroupTypeDistribution != types.GroupTypeDistribution {
+		t.Fatalf("GroupTypeDistribution mismatch: %q vs %q", interfaces.GroupTypeDistribution, types.GroupTypeDistribution)
+	}
+	if interfaces.GroupTypeMicrosoft365 != types.GroupTypeMicrosoft365 {
+		t.Fatalf("GroupTypeMicrosoft365 mismatch: %q vs %q", interfaces.GroupTypeMicrosoft365, types.GroupTypeMicrosoft365)
+	}
+
+	// Verify GroupScope constants round-trip correctly.
+	if interfaces.GroupScopeDomainLocal != types.GroupScopeDomainLocal {
+		t.Fatalf("GroupScopeDomainLocal mismatch: %q vs %q", interfaces.GroupScopeDomainLocal, types.GroupScopeDomainLocal)
+	}
+	if interfaces.GroupScopeGlobal != types.GroupScopeGlobal {
+		t.Fatalf("GroupScopeGlobal mismatch: %q vs %q", interfaces.GroupScopeGlobal, types.GroupScopeGlobal)
+	}
+	if interfaces.GroupScopeUniversal != types.GroupScopeUniversal {
+		t.Fatalf("GroupScopeUniversal mismatch: %q vs %q", interfaces.GroupScopeUniversal, types.GroupScopeUniversal)
+	}
+}

--- a/pkg/directory/interfaces/provider.go
+++ b/pkg/directory/interfaces/provider.go
@@ -31,6 +31,8 @@ import (
 	"fmt"
 	"sync"
 	"time"
+
+	"github.com/cfgis/cfgms/pkg/directory/types"
 )
 
 // DirectoryProvider defines the unified interface for all directory service providers.
@@ -143,70 +145,11 @@ type ProviderCapabilities struct {
 	RateLimitInfo *RateLimitInfo `json:"rate_limit_info,omitempty"`
 }
 
-// DirectoryUser represents a normalized user object across all directory providers
-type DirectoryUser struct {
-	// Core Identity
-	ID                string `json:"id"`                         // Unique identifier in source directory
-	UserPrincipalName string `json:"user_principal_name"`        // UPN (user@domain.com)
-	SAMAccountName    string `json:"sam_account_name,omitempty"` // For AD compatibility
-	DisplayName       string `json:"display_name"`               // Full display name
+// DirectoryUser is an alias for types.DirectoryUser — types is the canonical definition.
+type DirectoryUser = types.DirectoryUser
 
-	// Authentication
-	AccountEnabled bool       `json:"account_enabled"`           // Is account enabled
-	PasswordExpiry *time.Time `json:"password_expiry,omitempty"` // When password expires
-	LastLogon      *time.Time `json:"last_logon,omitempty"`      // Last successful logon
-
-	// Contact Information
-	EmailAddress string `json:"email_address,omitempty"` // Primary email
-	PhoneNumber  string `json:"phone_number,omitempty"`  // Primary phone
-	MobilePhone  string `json:"mobile_phone,omitempty"`  // Mobile phone
-
-	// Organizational Information
-	Department     string `json:"department,omitempty"`      // Department name
-	JobTitle       string `json:"job_title,omitempty"`       // Job title
-	Manager        string `json:"manager,omitempty"`         // Manager's ID
-	OfficeLocation string `json:"office_location,omitempty"` // Office location
-	Company        string `json:"company,omitempty"`         // Company name
-
-	// Directory Structure
-	DistinguishedName string   `json:"distinguished_name,omitempty"` // Full DN (for AD)
-	OU                string   `json:"ou,omitempty"`                 // Parent OU
-	Groups            []string `json:"groups,omitempty"`             // Group memberships
-
-	// Provider-Specific Attributes
-	ProviderAttributes map[string]interface{} `json:"provider_attributes,omitempty"`
-
-	// Metadata
-	Created  *time.Time `json:"created,omitempty"`  // When created
-	Modified *time.Time `json:"modified,omitempty"` // When last modified
-	Source   string     `json:"source"`             // Source provider name
-}
-
-// DirectoryGroup represents a normalized group object across all directory providers
-type DirectoryGroup struct {
-	// Core Identity
-	ID          string `json:"id"`                    // Unique identifier
-	Name        string `json:"name"`                  // Group name
-	DisplayName string `json:"display_name"`          // Display name
-	Description string `json:"description,omitempty"` // Group description
-
-	// Group Properties
-	GroupType  GroupType  `json:"group_type"`            // Security vs Distribution
-	GroupScope GroupScope `json:"group_scope,omitempty"` // Domain, Global, Universal
-
-	// Directory Structure
-	DistinguishedName string   `json:"distinguished_name,omitempty"` // Full DN (for AD)
-	OU                string   `json:"ou,omitempty"`                 // Parent OU
-	Members           []string `json:"members,omitempty"`            // Member user IDs
-
-	// Provider-Specific Attributes
-	ProviderAttributes map[string]interface{} `json:"provider_attributes,omitempty"`
-
-	// Metadata
-	Created  *time.Time `json:"created,omitempty"`  // When created
-	Modified *time.Time `json:"modified,omitempty"` // When last modified
-	Source   string     `json:"source"`             // Source provider name
-}
+// DirectoryGroup is an alias for types.DirectoryGroup — types is the canonical definition.
+type DirectoryGroup = types.DirectoryGroup
 
 // OrganizationalUnit represents a normalized OU object (primarily for AD compatibility)
 type OrganizationalUnit struct {
@@ -240,16 +183,17 @@ const (
 	DirectoryObjectTypeOU    DirectoryObjectType = "organizational_unit"
 )
 
-// GroupType represents the type of group
-type GroupType string
+// GroupType is an alias for types.GroupType — types is the canonical definition.
+type GroupType = types.GroupType
 
 const (
 	GroupTypeSecurity     GroupType = "security"
 	GroupTypeDistribution GroupType = "distribution"
+	GroupTypeMicrosoft365 GroupType = "microsoft365"
 )
 
-// GroupScope represents the scope of a group (AD concept)
-type GroupScope string
+// GroupScope is an alias for types.GroupScope — types is the canonical definition.
+type GroupScope = types.GroupScope
 
 const (
 	GroupScopeDomainLocal GroupScope = "domain_local"


### PR DESCRIPTION
## Summary

- Replaces duplicate `DirectoryUser` and `DirectoryGroup` struct definitions in `pkg/directory/interfaces/provider.go` with type aliases pointing to the canonical definitions in `pkg/directory/types`
- Aliases `GroupType` and `GroupScope` to `types.GroupType`/`types.GroupScope` so all existing constant references (`GroupTypeSecurity`, etc.) remain valid without any call-site changes
- Adds `GroupTypeMicrosoft365` constant to the interfaces package to maintain a complete surface matching the canonical types definition
- Adds `pkg/directory/interfaces/alias_test.go` with compile-time assertions (`var _ types.X = interfaces.X{}`) and runtime constant round-trip checks for all aliased types

Fixes #1272

## Specialist Review Results

| Agent | Result |
|-------|--------|
| QA Test Runner | **PASS** — 80+ packages, 0 failures, race detection clean, lint 0 issues |
| QA Code Reviewer | **PASS** — blocking issues (missing `GroupTypeMicrosoft365`, incomplete alias tests) identified and resolved before commit |
| Security Engineer | **PASS** — no secrets, no TLS issues, no central provider violations, architecture check clean |

## Test plan

- [x] `go test ./pkg/directory/... -race` — all 4 packages pass
- [x] Compile-time alias identity verified for `DirectoryUser`, `DirectoryGroup`, `GroupType`, `GroupScope`
- [x] Runtime constant round-trip assertions for all 6 `GroupType`/`GroupScope` values
- [x] All pre-existing tests in `pkg/directory/` pass without modification

🤖 Generated with [Claude Code](https://claude.com/claude-code)