### PR TITLE
test: features/rbac — _test packages + real rbac.Manager replaces MockRBACManager (Issue #1224)

### DIFF
--- a/features/rbac/continuous/authorization_engine_test.go
+++ b/features/rbac/continuous/authorization_engine_test.go
@@ -1,11 +1,10 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2026 Jordan Ritz
-package continuous
+package continuous_test
 
 import (
 	"context"
 	"fmt"
-	"sync"
 	"testing"
 	"time"
 
@@ -13,6 +12,8 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/cfgis/cfgms/api/proto/common"
+	"github.com/cfgis/cfgms/features/rbac/continuous"
+	"github.com/cfgis/cfgms/features/rbac/ports"
 )
 
 // Mock implementations for testing
@@ -80,11 +81,11 @@ func (m *MockJITManager) ValidateJITAccess(ctx context.Context, request *common.
 
 // MockRiskManager implements RiskManager interface for testing
 type MockRiskManager struct {
-	enhancedRiskResponse *RiskAccessResult
+	enhancedRiskResponse *continuous.RiskAccessResult
 	enhancedRiskError    error
 }
 
-func (m *MockRiskManager) EnhancedRiskAccessCheck(ctx context.Context, request *common.AccessRequest) (*RiskAccessResult, error) {
+func (m *MockRiskManager) EnhancedRiskAccessCheck(ctx context.Context, request *common.AccessRequest) (*continuous.RiskAccessResult, error) {
 	if m.enhancedRiskError != nil {
 		return nil, m.enhancedRiskError
 	}
@@ -93,7 +94,7 @@ func (m *MockRiskManager) EnhancedRiskAccessCheck(ctx context.Context, request *
 	}
 
 	// Default low risk response
-	return &RiskAccessResult{
+	return &continuous.RiskAccessResult{
 		StandardResponse: &common.AccessResponse{
 			Granted:            true,
 			Reason:             "Low risk assessment",
@@ -105,11 +106,11 @@ func (m *MockRiskManager) EnhancedRiskAccessCheck(ctx context.Context, request *
 // MockTenantSecurityPolicyEngine for testing
 type MockTenantSecurityPolicyEngine struct{}
 
-func (m *MockTenantSecurityPolicyEngine) EvaluateSecurityPolicy(ctx context.Context, request *SecurityEvaluationRequest) (*SecurityPolicyResult, error) {
-	return &SecurityPolicyResult{
+func (m *MockTenantSecurityPolicyEngine) EvaluateSecurityPolicy(ctx context.Context, request *continuous.SecurityEvaluationRequest) (*continuous.SecurityPolicyResult, error) {
+	return &continuous.SecurityPolicyResult{
 		ComplianceStatus:   true,
 		RecommendedActions: []string{},
-		Violations:         []PolicyViolation{},
+		Violations:         []continuous.PolicyViolation{},
 		AppliedRules:       []string{"default-rule"},
 		Allowed:            true,
 	}, nil
@@ -117,10 +118,10 @@ func (m *MockTenantSecurityPolicyEngine) EvaluateSecurityPolicy(ctx context.Cont
 
 // MockTenantSecurityMiddleware implements TenantSecurityMiddleware for testing
 type MockTenantSecurityMiddleware struct {
-	policyEngine TenantSecurityPolicyEngine
+	policyEngine continuous.TenantSecurityPolicyEngine
 }
 
-func (m *MockTenantSecurityMiddleware) GetPolicyEngine() TenantSecurityPolicyEngine {
+func (m *MockTenantSecurityMiddleware) GetPolicyEngine() continuous.TenantSecurityPolicyEngine {
 	if m.policyEngine != nil {
 		return m.policyEngine
 	}
@@ -129,8 +130,8 @@ func (m *MockTenantSecurityMiddleware) GetPolicyEngine() TenantSecurityPolicyEng
 
 // Test helper functions
 
-func createTestContinuousAuthEngine() *ContinuousAuthorizationEngine {
-	config := &ContinuousAuthConfig{
+func defaultTestConfig() *continuous.ContinuousAuthConfig {
+	return &continuous.ContinuousAuthConfig{
 		MaxAuthLatencyMs:       10,
 		PermissionCacheTTL:     5 * time.Minute,
 		SessionUpdateInterval:  60 * time.Second,
@@ -140,25 +141,37 @@ func createTestContinuousAuthEngine() *ContinuousAuthorizationEngine {
 		RiskCheckInterval:      30 * time.Second,
 		EnableAutoTermination:  false,
 	}
-
-	return &ContinuousAuthorizationEngine{
-		rbacManager:     &MockRBACManager{},
-		jitManager:      &MockJITManager{},
-		riskManager:     &MockRiskManager{},
-		tenantSecurity:  &MockTenantSecurityMiddleware{},
-		sessionRegistry: NewSessionRegistry(),
-		permissionCache: NewCacheManager(config.PermissionCacheTTL, config.MaxAuthLatencyMs),
-		eventBus:        NewPermissionEventBus(100),                           // buffer size
-		contextMonitor:  NewContextMonitor(nil, config.SessionUpdateInterval), // nil risk manager for test
-		policyEnforcer:  NewPolicyEnforcer(nil, false),                        // nil tenant security, no auto termination
-		config:          config,
-		stats:           &AuthorizationStats{mutex: sync.RWMutex{}}, // Initialize stats for tests
-		stopChannel:     make(chan struct{}),                        // Initialize stop channel
-	}
 }
 
-func createTestContinuousAuthRequest(subjectID, resourceID, permissionID, tenantID, sessionID string) *ContinuousAuthRequest {
-	return &ContinuousAuthRequest{
+// newTestContinuousEngine creates a ContinuousAuthorizationEngine via the public constructor.
+// Nil arguments default to the standard mock implementations.
+func newTestContinuousEngine(
+	rbacMgr ports.RBACManager,
+	jitMgr ports.JITManager,
+	riskMgr continuous.ContinuousRiskManager,
+	ts continuous.TenantSecurityMiddleware,
+) *continuous.ContinuousAuthorizationEngine {
+	if rbacMgr == nil {
+		rbacMgr = &MockRBACManager{}
+	}
+	if jitMgr == nil {
+		jitMgr = &MockJITManager{}
+	}
+	if riskMgr == nil {
+		riskMgr = &MockRiskManager{}
+	}
+	if ts == nil {
+		ts = &MockTenantSecurityMiddleware{}
+	}
+	return continuous.NewContinuousAuthorizationEngine(rbacMgr, jitMgr, riskMgr, ts, defaultTestConfig())
+}
+
+func createTestContinuousAuthEngine() *continuous.ContinuousAuthorizationEngine {
+	return newTestContinuousEngine(nil, nil, nil, nil)
+}
+
+func createTestContinuousAuthRequest(subjectID, resourceID, permissionID, tenantID, sessionID string) *continuous.ContinuousAuthRequest {
+	return &continuous.ContinuousAuthRequest{
 		AccessRequest: &common.AccessRequest{
 			SubjectId:    subjectID,
 			ResourceId:   resourceID,
@@ -169,7 +182,7 @@ func createTestContinuousAuthRequest(subjectID, resourceID, permissionID, tenant
 			},
 		},
 		SessionID:     sessionID,
-		OperationType: OperationTypeStandard,
+		OperationType: continuous.OperationTypeStandard,
 		ResourceContext: map[string]string{
 			"resource_type": "database",
 			"sensitivity":   "high",
@@ -181,18 +194,15 @@ func createTestContinuousAuthRequest(subjectID, resourceID, permissionID, tenant
 
 func TestNewContinuousAuthorizationEngine(t *testing.T) {
 	engine := createTestContinuousAuthEngine()
+	ctx := context.Background()
 
-	assert.NotNil(t, engine)
-	assert.NotNil(t, engine.rbacManager)
-	assert.NotNil(t, engine.jitManager)
-	assert.NotNil(t, engine.riskManager)
-	assert.NotNil(t, engine.tenantSecurity)
-	assert.NotNil(t, engine.sessionRegistry)
-	assert.NotNil(t, engine.permissionCache)
-	assert.NotNil(t, engine.eventBus)
-	assert.NotNil(t, engine.contextMonitor)
-	assert.NotNil(t, engine.policyEnforcer)
-	assert.NotNil(t, engine.config)
+	// Prove all 9 internal dependencies were correctly wired:
+	// Start() initialises each component and returns an error if any are nil or fail.
+	err := engine.Start(ctx)
+	require.NoError(t, err)
+
+	err = engine.Stop()
+	require.NoError(t, err)
 }
 
 func TestContinuousAuthorizationEngine_Start_Success(t *testing.T) {
@@ -201,16 +211,15 @@ func TestContinuousAuthorizationEngine_Start_Success(t *testing.T) {
 
 	err := engine.Start(ctx)
 	require.NoError(t, err)
-	assert.True(t, engine.running)
 
 	t.Cleanup(func() { _ = engine.Stop() })
 }
 
 func TestContinuousAuthorizationEngine_Start_InitializationError(t *testing.T) {
-	engine := createTestContinuousAuthEngine()
-	engine.rbacManager = &MockRBACManager{
-		initializeError: fmt.Errorf("initialization failed"),
-	}
+	engine := newTestContinuousEngine(
+		&MockRBACManager{initializeError: fmt.Errorf("initialization failed")},
+		nil, nil, nil,
+	)
 	ctx := context.Background()
 
 	err := engine.Start(ctx)
@@ -233,21 +242,19 @@ func TestContinuousAuthorizationEngine_Stop_Success(t *testing.T) {
 }
 
 func TestContinuousAuthorizationEngine_AuthorizeAction_Success(t *testing.T) {
-	engine := createTestContinuousAuthEngine()
-	ctx := context.Background()
-
-	// Register session first
-	err := engine.RegisterSession(ctx, "session1", "user1", "tenant1", nil)
-	require.NoError(t, err)
-
-	// Setup successful RBAC response
-	engine.rbacManager = &MockRBACManager{
+	rbacMgr := &MockRBACManager{
 		checkPermissionResponse: &common.AccessResponse{
 			Granted:            true,
 			Reason:             "Access granted by RBAC",
 			AppliedPermissions: []string{"read"},
 		},
 	}
+	engine := newTestContinuousEngine(rbacMgr, nil, nil, nil)
+	ctx := context.Background()
+
+	// Register session first
+	err := engine.RegisterSession(ctx, "session1", "user1", "tenant1", nil)
+	require.NoError(t, err)
 
 	request := createTestContinuousAuthRequest("user1", "resource1", "read", "tenant1", "session1")
 
@@ -260,20 +267,18 @@ func TestContinuousAuthorizationEngine_AuthorizeAction_Success(t *testing.T) {
 }
 
 func TestContinuousAuthorizationEngine_AuthorizeAction_RBACDenied(t *testing.T) {
-	engine := createTestContinuousAuthEngine()
-	ctx := context.Background()
-
-	// Register session first
-	err := engine.RegisterSession(ctx, "session1", "user1", "tenant1", nil)
-	require.NoError(t, err)
-
-	// Setup RBAC denial
-	engine.rbacManager = &MockRBACManager{
+	rbacMgr := &MockRBACManager{
 		checkPermissionResponse: &common.AccessResponse{
 			Granted: false,
 			Reason:  "Access denied by RBAC",
 		},
 	}
+	engine := newTestContinuousEngine(rbacMgr, nil, nil, nil)
+	ctx := context.Background()
+
+	// Register session first
+	err := engine.RegisterSession(ctx, "session1", "user1", "tenant1", nil)
+	require.NoError(t, err)
 
 	request := createTestContinuousAuthRequest("user1", "resource1", "admin", "tenant1", "session1")
 
@@ -287,39 +292,36 @@ func TestContinuousAuthorizationEngine_AuthorizeAction_RBACDenied(t *testing.T) 
 }
 
 func TestContinuousAuthorizationEngine_AuthorizeAction_WithJITAccess(t *testing.T) {
-	engine := createTestContinuousAuthEngine()
-	ctx := context.Background()
-
-	// Register session first
-	err := engine.RegisterSession(ctx, "session1", "user1", "tenant1", nil)
-	require.NoError(t, err)
-
-	// Setup RBAC denial but JIT access granted
-	engine.rbacManager = &MockRBACManager{
-		checkPermissionResponse: &common.AccessResponse{
-			Granted: false,
-			Reason:  "No standard permission",
+	engine := newTestContinuousEngine(
+		&MockRBACManager{
+			checkPermissionResponse: &common.AccessResponse{
+				Granted: false,
+				Reason:  "No standard permission",
+			},
 		},
-	}
-
-	engine.jitManager = &MockJITManager{
-		validateJITAccessResponse: &common.AccessResponse{
-			Granted:            true,
-			Reason:             "JIT access active",
-			AppliedPermissions: []string{"admin"},
-		},
-	}
-
-	// Setup risk manager to preserve JIT access decision
-	engine.riskManager = &MockRiskManager{
-		enhancedRiskResponse: &RiskAccessResult{
-			StandardResponse: &common.AccessResponse{
+		&MockJITManager{
+			validateJITAccessResponse: &common.AccessResponse{
 				Granted:            true,
 				Reason:             "JIT access active",
 				AppliedPermissions: []string{"admin"},
 			},
 		},
-	}
+		&MockRiskManager{
+			enhancedRiskResponse: &continuous.RiskAccessResult{
+				StandardResponse: &common.AccessResponse{
+					Granted:            true,
+					Reason:             "JIT access active",
+					AppliedPermissions: []string{"admin"},
+				},
+			},
+		},
+		nil,
+	)
+	ctx := context.Background()
+
+	// Register session first
+	err := engine.RegisterSession(ctx, "session1", "user1", "tenant1", nil)
+	require.NoError(t, err)
 
 	request := createTestContinuousAuthRequest("user1", "resource1", "admin", "tenant1", "session1")
 
@@ -332,30 +334,30 @@ func TestContinuousAuthorizationEngine_AuthorizeAction_WithJITAccess(t *testing.
 }
 
 func TestContinuousAuthorizationEngine_AuthorizeAction_RiskBasedDenial(t *testing.T) {
-	engine := createTestContinuousAuthEngine()
+	engine := newTestContinuousEngine(
+		&MockRBACManager{
+			checkPermissionResponse: &common.AccessResponse{
+				Granted:            true,
+				Reason:             "RBAC permission granted",
+				AppliedPermissions: []string{"read"},
+			},
+		},
+		nil,
+		&MockRiskManager{
+			enhancedRiskResponse: &continuous.RiskAccessResult{
+				StandardResponse: &common.AccessResponse{
+					Granted: false,
+					Reason:  "High risk detected - access denied",
+				},
+			},
+		},
+		nil,
+	)
 	ctx := context.Background()
 
 	// Register session first
 	err := engine.RegisterSession(ctx, "session1", "user1", "tenant1", nil)
 	require.NoError(t, err)
-
-	// Setup RBAC success but high risk denial
-	engine.rbacManager = &MockRBACManager{
-		checkPermissionResponse: &common.AccessResponse{
-			Granted:            true,
-			Reason:             "RBAC permission granted",
-			AppliedPermissions: []string{"read"},
-		},
-	}
-
-	engine.riskManager = &MockRiskManager{
-		enhancedRiskResponse: &RiskAccessResult{
-			StandardResponse: &common.AccessResponse{
-				Granted: false,
-				Reason:  "High risk detected - access denied",
-			},
-		},
-	}
 
 	request := createTestContinuousAuthRequest("user1", "resource1", "read", "tenant1", "session1")
 
@@ -373,7 +375,7 @@ func TestContinuousAuthorizationEngine_AuthorizeAction_ValidationErrors(t *testi
 
 	tests := []struct {
 		name    string
-		request *ContinuousAuthRequest
+		request *continuous.ContinuousAuthRequest
 		wantErr bool
 	}{
 		{
@@ -383,14 +385,14 @@ func TestContinuousAuthorizationEngine_AuthorizeAction_ValidationErrors(t *testi
 		},
 		{
 			name: "missing access request",
-			request: &ContinuousAuthRequest{
+			request: &continuous.ContinuousAuthRequest{
 				SessionID: "session1",
 			},
 			wantErr: true,
 		},
 		{
 			name: "missing subject ID",
-			request: &ContinuousAuthRequest{
+			request: &continuous.ContinuousAuthRequest{
 				AccessRequest: &common.AccessRequest{
 					ResourceId:   "resource1",
 					PermissionId: "read",
@@ -402,7 +404,7 @@ func TestContinuousAuthorizationEngine_AuthorizeAction_ValidationErrors(t *testi
 		},
 		{
 			name: "missing session ID",
-			request: &ContinuousAuthRequest{
+			request: &continuous.ContinuousAuthRequest{
 				AccessRequest: &common.AccessRequest{
 					SubjectId:    "user1",
 					ResourceId:   "resource1",
@@ -504,17 +506,15 @@ func TestContinuousAuthorizationEngine_GetAuthorizationStats(t *testing.T) {
 }
 
 func TestContinuousAuthorizationEngine_AuthorizeAction_SystemIntegrationFailure(t *testing.T) {
-	engine := createTestContinuousAuthEngine()
+	engine := newTestContinuousEngine(
+		&MockRBACManager{checkPermissionError: fmt.Errorf("RBAC system unavailable")},
+		nil, nil, nil,
+	)
 	ctx := context.Background()
 
 	// Register session first
 	err := engine.RegisterSession(ctx, "session1", "user1", "tenant1", nil)
 	require.NoError(t, err)
-
-	// Setup RBAC system failure
-	engine.rbacManager = &MockRBACManager{
-		checkPermissionError: fmt.Errorf("RBAC system unavailable"),
-	}
 
 	request := createTestContinuousAuthRequest("user1", "resource1", "read", "tenant1", "session1")
 
@@ -532,12 +532,12 @@ func TestContinuousAuthorizationEngine_AuthorizeAction_SecurityEdgeCases(t *test
 
 	tests := []struct {
 		name        string
-		request     *ContinuousAuthRequest
+		request     *continuous.ContinuousAuthRequest
 		expectError bool
 	}{
 		{
 			name: "malformed session ID",
-			request: &ContinuousAuthRequest{
+			request: &continuous.ContinuousAuthRequest{
 				AccessRequest: &common.AccessRequest{
 					SubjectId:    "user1",
 					ResourceId:   "resource1",
@@ -550,7 +550,7 @@ func TestContinuousAuthorizationEngine_AuthorizeAction_SecurityEdgeCases(t *test
 		},
 		{
 			name: "injection attempt in subject ID",
-			request: &ContinuousAuthRequest{
+			request: &continuous.ContinuousAuthRequest{
 				AccessRequest: &common.AccessRequest{
 					SubjectId:    "user1'; DROP TABLE users; --",
 					ResourceId:   "resource1",
@@ -563,7 +563,7 @@ func TestContinuousAuthorizationEngine_AuthorizeAction_SecurityEdgeCases(t *test
 		},
 		{
 			name: "cross-tenant access attempt",
-			request: &ContinuousAuthRequest{
+			request: &continuous.ContinuousAuthRequest{
 				AccessRequest: &common.AccessRequest{
 					SubjectId:    "user1",
 					ResourceId:   "tenant2/sensitive-resource",
@@ -597,7 +597,7 @@ func TestContinuousAuthorizationEngine_AuthorizeAction_ConcurrentRequests(t *tes
 	ctx := context.Background()
 
 	const numConcurrent = 10
-	results := make(chan *ContinuousAuthResponse, numConcurrent)
+	results := make(chan *continuous.ContinuousAuthResponse, numConcurrent)
 	errors := make(chan error, numConcurrent)
 
 	// Run multiple concurrent authorization requests

--- a/features/rbac/continuous/authorization_engine_test.go
+++ b/features/rbac/continuous/authorization_engine_test.go
@@ -5,6 +5,7 @@ package continuous_test
 import (
 	"context"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -12,13 +13,18 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/cfgis/cfgms/api/proto/common"
+	"github.com/cfgis/cfgms/features/rbac"
 	"github.com/cfgis/cfgms/features/rbac/continuous"
 	"github.com/cfgis/cfgms/features/rbac/ports"
+	"github.com/cfgis/cfgms/pkg/storage/interfaces"
 )
 
 // Mock implementations for testing
-
-// MockRBACManager implements RBACManager interface for testing
+//
+// MockRBACManager is retained only for the two tests that need to simulate RBAC-layer
+// errors (Start_InitializationError, SystemIntegrationFailure) — scenarios that cannot
+// be triggered through a real rbac.Manager.  All other tests use newTestRBACManager(t)
+// which returns a real rbac.Manager backed by an in-process SQLite store.
 type MockRBACManager struct {
 	checkPermissionResponse   *common.AccessResponse
 	checkPermissionError      error
@@ -37,7 +43,6 @@ func (m *MockRBACManager) CheckPermission(ctx context.Context, request *common.A
 		return m.checkPermissionResponse, nil
 	}
 
-	// Default response
 	return &common.AccessResponse{
 		Granted:            true,
 		Reason:             "RBAC check passed",
@@ -58,7 +63,19 @@ func (m *MockRBACManager) Initialize(ctx context.Context) error {
 	return m.initializeError
 }
 
-// MockJITManager implements ports.JITManager interface for testing
+// The three test doubles below remain because no real CFGMS type satisfies their
+// respective interfaces.  This is documented architectural debt in the continuous
+// package — resolving it requires redesigning these production interfaces in a
+// dedicated story.
+//
+//   - ports.JITManager.ValidateJITAccess has a different signature than
+//     jit.JITAccessManager.CheckJITAccess.
+//   - continuous.ContinuousRiskManager.EnhancedRiskAccessCheck returns a local
+//     wrapper type that no real risk package type satisfies.
+//   - continuous.TenantSecurityMiddleware.GetPolicyEngine() has no real CFGMS
+//     implementation.
+
+// MockJITManager implements ports.JITManager for testing.
 type MockJITManager struct {
 	validateJITAccessResponse *common.AccessResponse
 	validateJITAccessError    error
@@ -72,14 +89,13 @@ func (m *MockJITManager) ValidateJITAccess(ctx context.Context, request *common.
 		return m.validateJITAccessResponse, nil
 	}
 
-	// Default no JIT access
 	return &common.AccessResponse{
 		Granted: false,
 		Reason:  "No active JIT access",
 	}, nil
 }
 
-// MockRiskManager implements RiskManager interface for testing
+// MockRiskManager implements continuous.ContinuousRiskManager for testing.
 type MockRiskManager struct {
 	enhancedRiskResponse *continuous.RiskAccessResult
 	enhancedRiskError    error
@@ -93,7 +109,6 @@ func (m *MockRiskManager) EnhancedRiskAccessCheck(ctx context.Context, request *
 		return m.enhancedRiskResponse, nil
 	}
 
-	// Default low risk response
 	return &continuous.RiskAccessResult{
 		StandardResponse: &common.AccessResponse{
 			Granted:            true,
@@ -103,7 +118,7 @@ func (m *MockRiskManager) EnhancedRiskAccessCheck(ctx context.Context, request *
 	}, nil
 }
 
-// MockTenantSecurityPolicyEngine for testing
+// MockTenantSecurityPolicyEngine for testing.
 type MockTenantSecurityPolicyEngine struct{}
 
 func (m *MockTenantSecurityPolicyEngine) EvaluateSecurityPolicy(ctx context.Context, request *continuous.SecurityEvaluationRequest) (*continuous.SecurityPolicyResult, error) {
@@ -116,7 +131,7 @@ func (m *MockTenantSecurityPolicyEngine) EvaluateSecurityPolicy(ctx context.Cont
 	}, nil
 }
 
-// MockTenantSecurityMiddleware implements TenantSecurityMiddleware for testing
+// MockTenantSecurityMiddleware implements continuous.TenantSecurityMiddleware for testing.
 type MockTenantSecurityMiddleware struct {
 	policyEngine continuous.TenantSecurityPolicyEngine
 }
@@ -129,6 +144,75 @@ func (m *MockTenantSecurityMiddleware) GetPolicyEngine() continuous.TenantSecuri
 }
 
 // Test helper functions
+
+// newTestRBACManager returns a real rbac.Manager backed by an in-process OSS store
+// rooted in t.TempDir().  Cleanup is registered automatically.
+func newTestRBACManager(t *testing.T) *rbac.Manager {
+	t.Helper()
+	tmpDir := t.TempDir()
+	sm, err := interfaces.CreateOSSStorageManager(tmpDir+"/flatfile", tmpDir+"/cfgms.db")
+	require.NoError(t, err)
+	t.Cleanup(func() { assert.NoError(t, sm.Close()) })
+
+	mgr := rbac.NewManagerWithStorage(sm.GetAuditStore(), sm.GetClientTenantStore(), sm.GetRBACStore())
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		assert.NoError(t, mgr.Close(ctx))
+	})
+
+	ctx := rbac.WithSensitiveOperationJustification(context.Background(), "test rbac manager initialization")
+	require.NoError(t, mgr.Initialize(ctx))
+	return mgr
+}
+
+// grantPermission creates a permission + role + subject + assignment in mgr.
+func grantPermission(t *testing.T, mgr *rbac.Manager, subjectID, permissionID, tenantID string) {
+	t.Helper()
+	ctx := rbac.WithSensitiveOperationJustification(context.Background(), "test setup: grant permission")
+
+	perm := &common.Permission{
+		Id:           permissionID,
+		Name:         permissionID,
+		ResourceType: "test",
+		Actions:      []string{"execute"},
+	}
+	if err := mgr.CreatePermission(ctx, perm); err != nil && !strings.Contains(err.Error(), "already exists") {
+		require.NoError(t, err)
+	}
+
+	roleID := subjectID + "-" + permissionID + "-" + tenantID
+	role := &common.Role{
+		Id:            roleID,
+		Name:          roleID,
+		PermissionIds: []string{permissionID},
+		TenantId:      tenantID,
+	}
+	if err := mgr.CreateRole(ctx, role); err != nil {
+		if strings.Contains(err.Error(), "already exists") {
+			return
+		}
+		require.NoError(t, err)
+	}
+
+	subject := &common.Subject{
+		Id:          subjectID,
+		Type:        common.SubjectType_SUBJECT_TYPE_USER,
+		DisplayName: subjectID,
+		TenantId:    tenantID,
+		IsActive:    true,
+	}
+	if err := mgr.CreateSubject(ctx, subject); err != nil && !strings.Contains(err.Error(), "already exists") {
+		require.NoError(t, err)
+	}
+
+	assignment := &common.RoleAssignment{
+		SubjectId: subjectID,
+		RoleId:    roleID,
+		TenantId:  tenantID,
+	}
+	require.NoError(t, mgr.AssignRole(ctx, assignment))
+}
 
 func defaultTestConfig() *continuous.ContinuousAuthConfig {
 	return &continuous.ContinuousAuthConfig{
@@ -143,16 +227,20 @@ func defaultTestConfig() *continuous.ContinuousAuthConfig {
 	}
 }
 
-// newTestContinuousEngine creates a ContinuousAuthorizationEngine via the public constructor.
-// Nil arguments default to the standard mock implementations.
+// newTestContinuousEngine creates a ContinuousAuthorizationEngine via the public
+// constructor.  A nil rbacMgr uses a real rbac.Manager; nil jitMgr, riskMgr, and ts
+// use test doubles (no real CFGMS implementation satisfies those interfaces — see
+// comment above the mock type definitions).
 func newTestContinuousEngine(
+	t *testing.T,
 	rbacMgr ports.RBACManager,
 	jitMgr ports.JITManager,
 	riskMgr continuous.ContinuousRiskManager,
 	ts continuous.TenantSecurityMiddleware,
 ) *continuous.ContinuousAuthorizationEngine {
+	t.Helper()
 	if rbacMgr == nil {
-		rbacMgr = &MockRBACManager{}
+		rbacMgr = newTestRBACManager(t)
 	}
 	if jitMgr == nil {
 		jitMgr = &MockJITManager{}
@@ -166,8 +254,9 @@ func newTestContinuousEngine(
 	return continuous.NewContinuousAuthorizationEngine(rbacMgr, jitMgr, riskMgr, ts, defaultTestConfig())
 }
 
-func createTestContinuousAuthEngine() *continuous.ContinuousAuthorizationEngine {
-	return newTestContinuousEngine(nil, nil, nil, nil)
+func createTestContinuousAuthEngine(t *testing.T) *continuous.ContinuousAuthorizationEngine {
+	t.Helper()
+	return newTestContinuousEngine(t, nil, nil, nil, nil)
 }
 
 func createTestContinuousAuthRequest(subjectID, resourceID, permissionID, tenantID, sessionID string) *continuous.ContinuousAuthRequest {
@@ -193,7 +282,7 @@ func createTestContinuousAuthRequest(subjectID, resourceID, permissionID, tenant
 // Test functions
 
 func TestNewContinuousAuthorizationEngine(t *testing.T) {
-	engine := createTestContinuousAuthEngine()
+	engine := createTestContinuousAuthEngine(t)
 	ctx := context.Background()
 
 	// Prove all 9 internal dependencies were correctly wired:
@@ -206,17 +295,18 @@ func TestNewContinuousAuthorizationEngine(t *testing.T) {
 }
 
 func TestContinuousAuthorizationEngine_Start_Success(t *testing.T) {
-	engine := createTestContinuousAuthEngine()
+	engine := createTestContinuousAuthEngine(t)
 	ctx := context.Background()
 
 	err := engine.Start(ctx)
 	require.NoError(t, err)
 
-	t.Cleanup(func() { _ = engine.Stop() })
+	t.Cleanup(func() { assert.NoError(t, engine.Stop()) })
 }
 
 func TestContinuousAuthorizationEngine_Start_InitializationError(t *testing.T) {
 	engine := newTestContinuousEngine(
+		t,
 		&MockRBACManager{initializeError: fmt.Errorf("initialization failed")},
 		nil, nil, nil,
 	)
@@ -229,30 +319,22 @@ func TestContinuousAuthorizationEngine_Start_InitializationError(t *testing.T) {
 }
 
 func TestContinuousAuthorizationEngine_Stop_Success(t *testing.T) {
-	engine := createTestContinuousAuthEngine()
+	engine := createTestContinuousAuthEngine(t)
 	ctx := context.Background()
 
-	// Start the engine first
 	err := engine.Start(ctx)
 	require.NoError(t, err)
 
-	// Now stop it
 	err = engine.Stop()
 	require.NoError(t, err)
 }
 
 func TestContinuousAuthorizationEngine_AuthorizeAction_Success(t *testing.T) {
-	rbacMgr := &MockRBACManager{
-		checkPermissionResponse: &common.AccessResponse{
-			Granted:            true,
-			Reason:             "Access granted by RBAC",
-			AppliedPermissions: []string{"read"},
-		},
-	}
-	engine := newTestContinuousEngine(rbacMgr, nil, nil, nil)
+	rbacMgr := newTestRBACManager(t)
+	grantPermission(t, rbacMgr, "user1", "read", "tenant1")
+	engine := newTestContinuousEngine(t, rbacMgr, nil, nil, nil)
 	ctx := context.Background()
 
-	// Register session first
 	err := engine.RegisterSession(ctx, "session1", "user1", "tenant1", nil)
 	require.NoError(t, err)
 
@@ -267,16 +349,10 @@ func TestContinuousAuthorizationEngine_AuthorizeAction_Success(t *testing.T) {
 }
 
 func TestContinuousAuthorizationEngine_AuthorizeAction_RBACDenied(t *testing.T) {
-	rbacMgr := &MockRBACManager{
-		checkPermissionResponse: &common.AccessResponse{
-			Granted: false,
-			Reason:  "Access denied by RBAC",
-		},
-	}
-	engine := newTestContinuousEngine(rbacMgr, nil, nil, nil)
+	// Real manager with no permissions granted — RBAC denies by default.
+	engine := createTestContinuousAuthEngine(t)
 	ctx := context.Background()
 
-	// Register session first
 	err := engine.RegisterSession(ctx, "session1", "user1", "tenant1", nil)
 	require.NoError(t, err)
 
@@ -288,17 +364,14 @@ func TestContinuousAuthorizationEngine_AuthorizeAction_RBACDenied(t *testing.T) 
 	assert.NotNil(t, response)
 	assert.False(t, response.AccessResponse.Granted)
 	assert.NotEmpty(t, response.DecisionID)
-	assert.Contains(t, response.AccessResponse.Reason, "Access denied by RBAC")
+	assert.NotEmpty(t, response.AccessResponse.Reason)
 }
 
 func TestContinuousAuthorizationEngine_AuthorizeAction_WithJITAccess(t *testing.T) {
+	// Real manager with no permissions — RBAC denies, JIT grants.
 	engine := newTestContinuousEngine(
-		&MockRBACManager{
-			checkPermissionResponse: &common.AccessResponse{
-				Granted: false,
-				Reason:  "No standard permission",
-			},
-		},
+		t,
+		nil, // real rbac.Manager, no permissions → RBAC denies
 		&MockJITManager{
 			validateJITAccessResponse: &common.AccessResponse{
 				Granted:            true,
@@ -319,7 +392,6 @@ func TestContinuousAuthorizationEngine_AuthorizeAction_WithJITAccess(t *testing.
 	)
 	ctx := context.Background()
 
-	// Register session first
 	err := engine.RegisterSession(ctx, "session1", "user1", "tenant1", nil)
 	require.NoError(t, err)
 
@@ -334,14 +406,11 @@ func TestContinuousAuthorizationEngine_AuthorizeAction_WithJITAccess(t *testing.
 }
 
 func TestContinuousAuthorizationEngine_AuthorizeAction_RiskBasedDenial(t *testing.T) {
+	rbacMgr := newTestRBACManager(t)
+	grantPermission(t, rbacMgr, "user1", "read", "tenant1")
 	engine := newTestContinuousEngine(
-		&MockRBACManager{
-			checkPermissionResponse: &common.AccessResponse{
-				Granted:            true,
-				Reason:             "RBAC permission granted",
-				AppliedPermissions: []string{"read"},
-			},
-		},
+		t,
+		rbacMgr,
 		nil,
 		&MockRiskManager{
 			enhancedRiskResponse: &continuous.RiskAccessResult{
@@ -355,7 +424,6 @@ func TestContinuousAuthorizationEngine_AuthorizeAction_RiskBasedDenial(t *testin
 	)
 	ctx := context.Background()
 
-	// Register session first
 	err := engine.RegisterSession(ctx, "session1", "user1", "tenant1", nil)
 	require.NoError(t, err)
 
@@ -370,7 +438,7 @@ func TestContinuousAuthorizationEngine_AuthorizeAction_RiskBasedDenial(t *testin
 }
 
 func TestContinuousAuthorizationEngine_AuthorizeAction_ValidationErrors(t *testing.T) {
-	engine := createTestContinuousAuthEngine()
+	engine := createTestContinuousAuthEngine(t)
 	ctx := context.Background()
 
 	tests := []struct {
@@ -432,7 +500,7 @@ func TestContinuousAuthorizationEngine_AuthorizeAction_ValidationErrors(t *testi
 }
 
 func TestContinuousAuthorizationEngine_RegisterSession_Success(t *testing.T) {
-	engine := createTestContinuousAuthEngine()
+	engine := createTestContinuousAuthEngine(t)
 	ctx := context.Background()
 
 	metadata := map[string]string{
@@ -445,7 +513,6 @@ func TestContinuousAuthorizationEngine_RegisterSession_Success(t *testing.T) {
 
 	require.NoError(t, err)
 
-	// Verify session is registered by checking status
 	status, err := engine.GetSessionStatus(ctx, "session1")
 	require.NoError(t, err)
 	assert.NotNil(t, status)
@@ -454,25 +521,22 @@ func TestContinuousAuthorizationEngine_RegisterSession_Success(t *testing.T) {
 }
 
 func TestContinuousAuthorizationEngine_UnregisterSession_Success(t *testing.T) {
-	engine := createTestContinuousAuthEngine()
+	engine := createTestContinuousAuthEngine(t)
 	ctx := context.Background()
 
-	// First register a session
 	err := engine.RegisterSession(ctx, "session1", "user1", "tenant1", nil)
 	require.NoError(t, err)
 
-	// Then unregister it
 	err = engine.UnregisterSession(ctx, "session1")
 	require.NoError(t, err)
 
-	// Verify session is no longer found
 	status, err := engine.GetSessionStatus(ctx, "session1")
 	assert.Error(t, err)
 	assert.Nil(t, status)
 }
 
 func TestContinuousAuthorizationEngine_RevokePermissions_Success(t *testing.T) {
-	engine := createTestContinuousAuthEngine()
+	engine := createTestContinuousAuthEngine(t)
 	ctx := context.Background()
 
 	permissions := []string{"read", "write"}
@@ -483,7 +547,7 @@ func TestContinuousAuthorizationEngine_RevokePermissions_Success(t *testing.T) {
 }
 
 func TestContinuousAuthorizationEngine_GetSessionStatus_SessionNotFound(t *testing.T) {
-	engine := createTestContinuousAuthEngine()
+	engine := createTestContinuousAuthEngine(t)
 	ctx := context.Background()
 
 	status, err := engine.GetSessionStatus(ctx, "nonexistent-session")
@@ -494,7 +558,7 @@ func TestContinuousAuthorizationEngine_GetSessionStatus_SessionNotFound(t *testi
 }
 
 func TestContinuousAuthorizationEngine_GetAuthorizationStats(t *testing.T) {
-	engine := createTestContinuousAuthEngine()
+	engine := createTestContinuousAuthEngine(t)
 
 	stats := engine.GetAuthorizationStats()
 
@@ -507,12 +571,12 @@ func TestContinuousAuthorizationEngine_GetAuthorizationStats(t *testing.T) {
 
 func TestContinuousAuthorizationEngine_AuthorizeAction_SystemIntegrationFailure(t *testing.T) {
 	engine := newTestContinuousEngine(
+		t,
 		&MockRBACManager{checkPermissionError: fmt.Errorf("RBAC system unavailable")},
 		nil, nil, nil,
 	)
 	ctx := context.Background()
 
-	// Register session first
 	err := engine.RegisterSession(ctx, "session1", "user1", "tenant1", nil)
 	require.NoError(t, err)
 
@@ -527,80 +591,92 @@ func TestContinuousAuthorizationEngine_AuthorizeAction_SystemIntegrationFailure(
 }
 
 func TestContinuousAuthorizationEngine_AuthorizeAction_SecurityEdgeCases(t *testing.T) {
-	engine := createTestContinuousAuthEngine()
+	// Each subtest gets its own engine so sessions don't conflict between cases.
+	// Sessions are registered with the exact IDs from the request so the engine
+	// exercises RBAC rather than short-circuiting at "session not found".
+	// No permissions are granted, so RBAC denies all requests — this proves the
+	// engine handles unusual/malicious inputs without panicking and correctly
+	// propagates the denial.
 	ctx := context.Background()
 
 	tests := []struct {
-		name        string
-		request     *continuous.ContinuousAuthRequest
-		expectError bool
+		name       string
+		sessionID  string
+		subjectID  string
+		resourceID string
+		permID     string
+		tenantID   string
 	}{
 		{
-			name: "malformed session ID",
-			request: &continuous.ContinuousAuthRequest{
-				AccessRequest: &common.AccessRequest{
-					SubjectId:    "user1",
-					ResourceId:   "resource1",
-					PermissionId: "read",
-					TenantId:     "tenant1",
-				},
-				SessionID: "../../../etc/passwd",
-			},
-			expectError: false, // Should handle gracefully, not error
+			name:       "malformed session ID",
+			sessionID:  "../../../etc/passwd",
+			subjectID:  "user1",
+			resourceID: "resource1",
+			permID:     "read",
+			tenantID:   "tenant1",
 		},
 		{
-			name: "injection attempt in subject ID",
-			request: &continuous.ContinuousAuthRequest{
-				AccessRequest: &common.AccessRequest{
-					SubjectId:    "user1'; DROP TABLE users; --",
-					ResourceId:   "resource1",
-					PermissionId: "read",
-					TenantId:     "tenant1",
-				},
-				SessionID: "session1",
-			},
-			expectError: false,
+			name:       "injection attempt in subject ID",
+			sessionID:  "session-injection",
+			subjectID:  "user1'; DROP TABLE users; --",
+			resourceID: "resource1",
+			permID:     "read",
+			tenantID:   "tenant1",
 		},
 		{
-			name: "cross-tenant access attempt",
-			request: &continuous.ContinuousAuthRequest{
-				AccessRequest: &common.AccessRequest{
-					SubjectId:    "user1",
-					ResourceId:   "tenant2/sensitive-resource",
-					PermissionId: "admin",
-					TenantId:     "tenant1",
-				},
-				SessionID: "session1",
-			},
-			expectError: false,
+			name:       "cross-tenant access attempt",
+			sessionID:  "session-crosstenant",
+			subjectID:  "user1",
+			resourceID: "tenant2/sensitive-resource",
+			permID:     "admin",
+			tenantID:   "tenant1",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			response, err := engine.AuthorizeAction(ctx, tt.request)
+			engine := createTestContinuousAuthEngine(t)
 
-			if tt.expectError {
-				assert.Error(t, err)
-			} else {
-				assert.NoError(t, err)
-				assert.NotNil(t, response)
-				// Security edge cases should be denied, not cause errors
-				assert.False(t, response.AccessResponse.Granted)
+			err := engine.RegisterSession(ctx, tt.sessionID, tt.subjectID, tt.tenantID, nil)
+			require.NoError(t, err, "registering a session must succeed regardless of ID content")
+
+			request := &continuous.ContinuousAuthRequest{
+				AccessRequest: &common.AccessRequest{
+					SubjectId:    tt.subjectID,
+					ResourceId:   tt.resourceID,
+					PermissionId: tt.permID,
+					TenantId:     tt.tenantID,
+				},
+				SessionID: tt.sessionID,
 			}
+
+			response, err := engine.AuthorizeAction(ctx, request)
+
+			// Engine must handle unusual inputs gracefully: no panic, no error.
+			require.NoError(t, err)
+			assert.NotNil(t, response)
+			// No permissions are granted in the test RBAC store.
+			assert.False(t, response.AccessResponse.Granted)
 		})
 	}
 }
 
 func TestContinuousAuthorizationEngine_AuthorizeAction_ConcurrentRequests(t *testing.T) {
-	engine := createTestContinuousAuthEngine()
+	engine := createTestContinuousAuthEngine(t)
 	ctx := context.Background()
 
 	const numConcurrent = 10
+
+	// Pre-register all sessions so AuthorizeAction exercises the full RBAC pipeline
+	// rather than short-circuiting at session validation.
+	for i := 0; i < numConcurrent; i++ {
+		err := engine.RegisterSession(ctx, fmt.Sprintf("session%d", i), fmt.Sprintf("user%d", i), "tenant1", nil)
+		require.NoError(t, err)
+	}
+
 	results := make(chan *continuous.ContinuousAuthResponse, numConcurrent)
 	errors := make(chan error, numConcurrent)
 
-	// Run multiple concurrent authorization requests
 	for i := 0; i < numConcurrent; i++ {
 		go func(requestNum int) {
 			request := createTestContinuousAuthRequest(
@@ -620,7 +696,6 @@ func TestContinuousAuthorizationEngine_AuthorizeAction_ConcurrentRequests(t *tes
 		}(i)
 	}
 
-	// Collect results
 	successCount := 0
 	errorCount := 0
 
@@ -643,12 +718,14 @@ func TestContinuousAuthorizationEngine_AuthorizeAction_ConcurrentRequests(t *tes
 }
 
 func TestContinuousAuthorizationEngine_AuthorizeAction_PerformanceTesting(t *testing.T) {
-	engine := createTestContinuousAuthEngine()
+	engine := createTestContinuousAuthEngine(t)
 	ctx := context.Background()
+
+	err := engine.RegisterSession(ctx, "session1", "user1", "tenant1", nil)
+	require.NoError(t, err)
 
 	request := createTestContinuousAuthRequest("user1", "resource1", "read", "tenant1", "session1")
 
-	// Measure authorization time for performance validation
 	startTime := time.Now()
 
 	response, err := engine.AuthorizeAction(ctx, request)
@@ -658,7 +735,6 @@ func TestContinuousAuthorizationEngine_AuthorizeAction_PerformanceTesting(t *tes
 	require.NoError(t, err)
 	assert.NotNil(t, response)
 
-	// Should complete within reasonable time (adjust threshold as needed)
 	assert.Less(t, elapsedTime, 100*time.Millisecond,
 		"Authorization should complete quickly for performance")
 }

--- a/features/rbac/continuous/providers_test.go
+++ b/features/rbac/continuous/providers_test.go
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+package continuous
+
+// Provider registration for tests in this package.
+// Tests use interfaces.CreateOSSStorageManager which requires
+// these providers to be registered. These blank imports trigger the
+// providers' init() registration.
+// Cannot use pkg/testing helpers due to import cycle (pkg/testing
+// imports features/rbac). See epic #731.
+import (
+	_ "github.com/cfgis/cfgms/pkg/storage/providers/database"
+	_ "github.com/cfgis/cfgms/pkg/storage/providers/flatfile"
+	_ "github.com/cfgis/cfgms/pkg/storage/providers/sqlite"
+)

--- a/features/rbac/jit/access_manager_test.go
+++ b/features/rbac/jit/access_manager_test.go
@@ -1,9 +1,10 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2026 Jordan Ritz
-package jit
+package jit_test
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 
@@ -12,6 +13,7 @@ import (
 
 	"github.com/cfgis/cfgms/api/proto/common"
 	"github.com/cfgis/cfgms/features/rbac"
+	"github.com/cfgis/cfgms/features/rbac/jit"
 	"github.com/cfgis/cfgms/features/rbac/zerotrust"
 	"github.com/cfgis/cfgms/pkg/audit"
 	"github.com/cfgis/cfgms/pkg/storage/interfaces"
@@ -19,97 +21,99 @@ import (
 )
 
 func TestNewJITAccessManager(t *testing.T) {
-	rbacManager := &MockRBACManager{}
-	notificationService := &MockNotificationService{}
+	rbacManager := newTestRBACManager(t)
+	notificationService := jit.NewSimpleNotificationService()
 
-	jam := NewJITAccessManager(rbacManager, notificationService)
+	jam := jit.NewJITAccessManager(rbacManager, notificationService)
 
 	assert.NotNil(t, jam)
-	assert.Equal(t, rbacManager, jam.rbacManager)
-	assert.Equal(t, notificationService, jam.notificationService)
-	assert.NotNil(t, jam.requests)
-	assert.NotNil(t, jam.activeGrants)
-	assert.NotNil(t, jam.approvalWorkflows)
-	assert.Nil(t, jam.auditManager)
-	assert.False(t, jam.zeroTrustEnabled)
-	assert.Equal(t, ZeroTrustJITModeDisabled, jam.zeroTrustMode)
-	assert.Nil(t, jam.zeroTrustEngine)
+	assert.Equal(t, jit.ZeroTrustJITModeDisabled, jam.GetZeroTrustMode())
+
+	// Smoke test: constructor wires all dependencies — RequestAccess processes the request.
+	// Use admin (high-privilege) to prevent time-sensitive auto-approval from triggering.
+	ctx := context.Background()
+	smokeReq, err := jam.RequestAccess(ctx, &jit.JITAccessRequestSpec{
+		RequesterID:   "smoke-user",
+		TenantID:      "smoke-tenant",
+		Permissions:   []string{"admin"},
+		Duration:      time.Hour,
+		Justification: "constructor smoke test",
+	})
+	require.NoError(t, err)
+	assert.NotNil(t, smokeReq)
 }
 
 func TestJITAccessManager_EnableZeroTrustPolicies(t *testing.T) {
 	tests := []struct {
-		name            string
-		engine          *zerotrust.ZeroTrustPolicyEngine
-		mode            ZeroTrustJITMode
-		expectedEnabled bool
+		name     string
+		engine   *zerotrust.ZeroTrustPolicyEngine
+		mode     jit.ZeroTrustJITMode
+		wantMode jit.ZeroTrustJITMode
 	}{
 		{
-			name:            "Enable with valid engine and mode",
-			engine:          createMockZeroTrustEngine(),
-			mode:            ZeroTrustJITModeComprehensive,
-			expectedEnabled: true,
+			name:     "Enable with valid engine and mode",
+			engine:   createMockZeroTrustEngine(),
+			mode:     jit.ZeroTrustJITModeComprehensive,
+			wantMode: jit.ZeroTrustJITModeComprehensive,
 		},
 		{
-			name:            "Disable with disabled mode",
-			engine:          createMockZeroTrustEngine(),
-			mode:            ZeroTrustJITModeDisabled,
-			expectedEnabled: false,
+			name:     "Disable with disabled mode",
+			engine:   createMockZeroTrustEngine(),
+			mode:     jit.ZeroTrustJITModeDisabled,
+			wantMode: jit.ZeroTrustJITModeDisabled,
 		},
 		{
-			name:            "Disable with nil engine",
-			engine:          nil,
-			mode:            ZeroTrustJITModeComprehensive,
-			expectedEnabled: false,
+			name:     "Nil engine stores mode but keeps disabled effective state",
+			engine:   nil,
+			mode:     jit.ZeroTrustJITModeComprehensive,
+			wantMode: jit.ZeroTrustJITModeComprehensive,
 		},
 		{
-			name:            "Enable request validation mode",
-			engine:          createMockZeroTrustEngine(),
-			mode:            ZeroTrustJITModeRequestValidation,
-			expectedEnabled: true,
+			name:     "Enable request validation mode",
+			engine:   createMockZeroTrustEngine(),
+			mode:     jit.ZeroTrustJITModeRequestValidation,
+			wantMode: jit.ZeroTrustJITModeRequestValidation,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			jam := NewJITAccessManager(&MockRBACManager{}, &MockNotificationService{})
+			jam := jit.NewJITAccessManager(newTestRBACManager(t), jit.NewSimpleNotificationService())
 
 			jam.EnableZeroTrustPolicies(tt.engine, tt.mode)
 
-			assert.Equal(t, tt.expectedEnabled, jam.zeroTrustEnabled)
-			assert.Equal(t, tt.mode, jam.zeroTrustMode)
-			assert.Equal(t, tt.engine, jam.zeroTrustEngine)
+			assert.Equal(t, tt.wantMode, jam.GetZeroTrustMode())
 		})
 	}
 }
 
 func TestJITAccessManager_SetZeroTrustMode(t *testing.T) {
-	jam := NewJITAccessManager(&MockRBACManager{}, &MockNotificationService{})
+	jam := jit.NewJITAccessManager(newTestRBACManager(t), jit.NewSimpleNotificationService())
 	engine := createMockZeroTrustEngine()
 
 	// First enable with an engine
-	jam.EnableZeroTrustPolicies(engine, ZeroTrustJITModeComprehensive)
-	assert.True(t, jam.zeroTrustEnabled)
+	jam.EnableZeroTrustPolicies(engine, jit.ZeroTrustJITModeComprehensive)
+	assert.NotEqual(t, jit.ZeroTrustJITModeDisabled, jam.GetZeroTrustMode())
 
 	// Change mode to disabled
-	jam.SetZeroTrustMode(ZeroTrustJITModeDisabled)
-	assert.False(t, jam.zeroTrustEnabled)
-	assert.Equal(t, ZeroTrustJITModeDisabled, jam.GetZeroTrustMode())
+	jam.SetZeroTrustMode(jit.ZeroTrustJITModeDisabled)
+	assert.Equal(t, jit.ZeroTrustJITModeDisabled, jam.GetZeroTrustMode())
 
 	// Change mode back to enabled
-	jam.SetZeroTrustMode(ZeroTrustJITModeApprovalGating)
-	assert.True(t, jam.zeroTrustEnabled)
-	assert.Equal(t, ZeroTrustJITModeApprovalGating, jam.GetZeroTrustMode())
+	jam.SetZeroTrustMode(jit.ZeroTrustJITModeApprovalGating)
+	assert.NotEqual(t, jit.ZeroTrustJITModeDisabled, jam.GetZeroTrustMode())
+	assert.Equal(t, jit.ZeroTrustJITModeApprovalGating, jam.GetZeroTrustMode())
 }
 
 func TestJITAccessManager_RequestAccess_Success(t *testing.T) {
 	tests := []struct {
 		name        string
-		requestSpec *JITAccessRequestSpec
-		setupMocks  func(*MockRBACManager, *MockNotificationService)
+		requestSpec *jit.JITAccessRequestSpec
+		setupPerms  func(*testing.T, *rbac.Manager)
 	}{
 		{
 			name: "Valid access request with immediate approval",
-			requestSpec: &JITAccessRequestSpec{
+			requestSpec: &jit.JITAccessRequestSpec{
 				RequesterID:     "user1",
 				TenantID:        "tenant1",
 				Permissions:     []string{"read"},
@@ -117,57 +121,47 @@ func TestJITAccessManager_RequestAccess_Success(t *testing.T) {
 				Justification:   "Need access for troubleshooting",
 				AutoApprove:     true,
 				EmergencyAccess: false,
-				Priority:        AccessPriorityMedium,
+				Priority:        jit.AccessPriorityMedium,
 			},
-			setupMocks: func(rbac *MockRBACManager, notif *MockNotificationService) {
-				// Current access check - should return false (user doesn't have access)
-				rbac.SetCheckPermissionResponse("user1", "read", "tenant1", false, "No access")
-				// System approval check - should return true (system can auto-approve)
-				rbac.SetCheckPermissionResponse("system", "jit_access.approve", "tenant1", true, "System approved")
+			setupPerms: func(t *testing.T, rbacMgr *rbac.Manager) {
+				grantPermission(t, rbacMgr, "system", "jit_access.approve", "tenant1")
 			},
 		},
 		{
 			name: "Valid access request with workflow approval",
-			requestSpec: &JITAccessRequestSpec{
+			requestSpec: &jit.JITAccessRequestSpec{
 				RequesterID:   "user2",
 				TenantID:      "tenant1",
 				Permissions:   []string{"write", "delete"},
 				Duration:      2 * time.Hour,
 				Justification: "Urgent production fix required",
 				AutoApprove:   false,
-				Priority:      AccessPriorityHigh,
+				Priority:      jit.AccessPriorityHigh,
 			},
-			setupMocks: func(rbac *MockRBACManager, notif *MockNotificationService) {
-				// Current access check - should return false
-				rbac.SetCheckPermissionResponse("user2", "write", "tenant1", false, "No access")
-				rbac.SetCheckPermissionResponse("user2", "delete", "tenant1", false, "No access")
-			},
+			setupPerms: nil,
 		},
 		{
 			name: "Emergency access request",
-			requestSpec: &JITAccessRequestSpec{
+			requestSpec: &jit.JITAccessRequestSpec{
 				RequesterID:     "user3",
 				TenantID:        "tenant1",
 				Permissions:     []string{"admin"},
 				Duration:        30 * time.Minute,
 				Justification:   "Critical system failure - emergency access required",
 				EmergencyAccess: true,
-				Priority:        AccessPriorityEmergency,
+				Priority:        jit.AccessPriorityEmergency,
 			},
-			setupMocks: func(rbac *MockRBACManager, notif *MockNotificationService) {
-				rbac.SetCheckPermissionResponse("user3", "admin", "tenant1", false, "No access")
-			},
+			setupPerms: nil,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			rbacManager := &MockRBACManager{}
-			notificationService := &MockNotificationService{}
-			jam := NewJITAccessManager(rbacManager, notificationService)
+			rbacManager := newTestRBACManager(t)
+			jam := jit.NewJITAccessManager(rbacManager, jit.NewSimpleNotificationService())
 
-			if tt.setupMocks != nil {
-				tt.setupMocks(rbacManager, notificationService)
+			if tt.setupPerms != nil {
+				tt.setupPerms(t, rbacManager)
 			}
 
 			ctx := context.Background()
@@ -189,10 +183,10 @@ func TestJITAccessManager_RequestAccess_Success(t *testing.T) {
 
 			// If auto-approve is enabled, should have granted access
 			if tt.requestSpec.AutoApprove {
-				assert.Equal(t, JITAccessRequestStatusApproved, request.Status)
+				assert.Equal(t, jit.JITAccessRequestStatusApproved, request.Status)
 				assert.NotNil(t, request.GrantedAccess)
 			} else {
-				assert.Equal(t, JITAccessRequestStatusPending, request.Status)
+				assert.Equal(t, jit.JITAccessRequestStatusPending, request.Status)
 			}
 		})
 	}
@@ -201,12 +195,12 @@ func TestJITAccessManager_RequestAccess_Success(t *testing.T) {
 func TestJITAccessManager_RequestAccess_ValidationErrors(t *testing.T) {
 	tests := []struct {
 		name        string
-		requestSpec *JITAccessRequestSpec
+		requestSpec *jit.JITAccessRequestSpec
 		expectedErr string
 	}{
 		{
 			name: "Missing requester ID",
-			requestSpec: &JITAccessRequestSpec{
+			requestSpec: &jit.JITAccessRequestSpec{
 				TenantID:      "tenant1",
 				Permissions:   []string{"read"},
 				Duration:      time.Hour,
@@ -216,7 +210,7 @@ func TestJITAccessManager_RequestAccess_ValidationErrors(t *testing.T) {
 		},
 		{
 			name: "Missing tenant ID",
-			requestSpec: &JITAccessRequestSpec{
+			requestSpec: &jit.JITAccessRequestSpec{
 				RequesterID:   "user1",
 				Permissions:   []string{"read"},
 				Duration:      time.Hour,
@@ -226,7 +220,7 @@ func TestJITAccessManager_RequestAccess_ValidationErrors(t *testing.T) {
 		},
 		{
 			name: "Missing permissions and roles",
-			requestSpec: &JITAccessRequestSpec{
+			requestSpec: &jit.JITAccessRequestSpec{
 				RequesterID:   "user1",
 				TenantID:      "tenant1",
 				Duration:      time.Hour,
@@ -236,7 +230,7 @@ func TestJITAccessManager_RequestAccess_ValidationErrors(t *testing.T) {
 		},
 		{
 			name: "Invalid duration (zero)",
-			requestSpec: &JITAccessRequestSpec{
+			requestSpec: &jit.JITAccessRequestSpec{
 				RequesterID:   "user1",
 				TenantID:      "tenant1",
 				Permissions:   []string{"read"},
@@ -247,7 +241,7 @@ func TestJITAccessManager_RequestAccess_ValidationErrors(t *testing.T) {
 		},
 		{
 			name: "Duration exceeds maximum",
-			requestSpec: &JITAccessRequestSpec{
+			requestSpec: &jit.JITAccessRequestSpec{
 				RequesterID:   "user1",
 				TenantID:      "tenant1",
 				Permissions:   []string{"read"},
@@ -258,7 +252,7 @@ func TestJITAccessManager_RequestAccess_ValidationErrors(t *testing.T) {
 		},
 		{
 			name: "Missing justification",
-			requestSpec: &JITAccessRequestSpec{
+			requestSpec: &jit.JITAccessRequestSpec{
 				RequesterID: "user1",
 				TenantID:    "tenant1",
 				Permissions: []string{"read"},
@@ -270,7 +264,7 @@ func TestJITAccessManager_RequestAccess_ValidationErrors(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			jam := NewJITAccessManager(&MockRBACManager{}, &MockNotificationService{})
+			jam := jit.NewJITAccessManager(newTestRBACManager(t), jit.NewSimpleNotificationService())
 
 			ctx := context.Background()
 			request, err := jam.RequestAccess(ctx, tt.requestSpec)
@@ -283,13 +277,13 @@ func TestJITAccessManager_RequestAccess_ValidationErrors(t *testing.T) {
 }
 
 func TestJITAccessManager_RequestAccess_AlreadyHasAccess(t *testing.T) {
-	rbacManager := &MockRBACManager{}
-	jam := NewJITAccessManager(rbacManager, &MockNotificationService{})
+	rbacManager := newTestRBACManager(t)
+	jam := jit.NewJITAccessManager(rbacManager, jit.NewSimpleNotificationService())
 
-	// Setup mock to return that user already has access
-	rbacManager.SetCheckPermissionResponse("user1", "read", "tenant1", true, "Already has access")
+	// User already has the requested permission
+	grantPermission(t, rbacManager, "user1", "read", "tenant1")
 
-	requestSpec := &JITAccessRequestSpec{
+	requestSpec := &jit.JITAccessRequestSpec{
 		RequesterID:   "user1",
 		TenantID:      "tenant1",
 		Permissions:   []string{"read"},
@@ -306,15 +300,14 @@ func TestJITAccessManager_RequestAccess_AlreadyHasAccess(t *testing.T) {
 }
 
 func TestJITAccessManager_ApproveRequest(t *testing.T) {
-	rbacManager := &MockRBACManager{}
-	jam := NewJITAccessManager(rbacManager, &MockNotificationService{})
+	rbacManager := newTestRBACManager(t)
+	jam := jit.NewJITAccessManager(rbacManager, jit.NewSimpleNotificationService())
 
-	// Create a pending request
-	rbacManager.SetCheckPermissionResponse("user1", "admin", "tenant1", false, "No access")
-	rbacManager.SetCheckPermissionResponse("approver1", "jit_access.approve", "tenant1", true, "Can approve")
-	rbacManager.SetCheckPermissionResponse("system", "jit_access.approve", "tenant1", true, "System can approve")
+	// Grant approval permissions to approver and system
+	grantPermission(t, rbacManager, "approver1", "jit_access.approve", "tenant1")
+	grantPermission(t, rbacManager, "system", "jit_access.approve", "tenant1")
 
-	requestSpec := &JITAccessRequestSpec{
+	requestSpec := &jit.JITAccessRequestSpec{
 		RequesterID:   "user1",
 		TenantID:      "tenant1",
 		Permissions:   []string{"admin"}, // High privilege to prevent auto-approval
@@ -326,7 +319,7 @@ func TestJITAccessManager_ApproveRequest(t *testing.T) {
 	ctx := context.Background()
 	request, err := jam.RequestAccess(ctx, requestSpec)
 	require.NoError(t, err)
-	assert.Equal(t, JITAccessRequestStatusPending, request.Status)
+	assert.Equal(t, jit.JITAccessRequestStatusPending, request.Status)
 
 	// Now approve the request
 	grant, err := jam.ApproveRequest(ctx, request.ID, "approver1", "Approved for testing")
@@ -336,14 +329,14 @@ func TestJITAccessManager_ApproveRequest(t *testing.T) {
 	assert.Equal(t, request.ID, grant.RequestID)
 	assert.Equal(t, "approver1", grant.ApprovedBy)
 	assert.Equal(t, "Approved for testing", grant.ApprovalReason)
-	assert.Equal(t, JITAccessGrantStatusActive, grant.Status)
+	assert.Equal(t, jit.JITAccessGrantStatusActive, grant.Status)
 	assert.NotZero(t, grant.GrantedAt)
 	assert.Equal(t, request.ExpiresAt, grant.ExpiresAt)
 
 	// Check request was updated
 	updatedRequest, err := jam.GetRequest(ctx, request.ID)
 	require.NoError(t, err)
-	assert.Equal(t, JITAccessRequestStatusApproved, updatedRequest.Status)
+	assert.Equal(t, jit.JITAccessRequestStatusApproved, updatedRequest.Status)
 	assert.Equal(t, "approver1", updatedRequest.ApprovedBy)
 	assert.NotNil(t, updatedRequest.ApprovedAt)
 	assert.Equal(t, grant, updatedRequest.GrantedAccess)
@@ -352,14 +345,14 @@ func TestJITAccessManager_ApproveRequest(t *testing.T) {
 func TestJITAccessManager_ApproveRequest_Errors(t *testing.T) {
 	tests := []struct {
 		name          string
-		setupRequest  func(*JITAccessManager, context.Context) *JITAccessRequest
+		setupRequest  func(*testing.T, *jit.JITAccessManager, *rbac.Manager, context.Context) *jit.JITAccessRequest
 		approverID    string
-		setupApprover func(*MockRBACManager, string, string)
+		setupApprover func(*testing.T, *rbac.Manager, string, string)
 		expectedErr   string
 	}{
 		{
 			name: "Request not found",
-			setupRequest: func(jam *JITAccessManager, ctx context.Context) *JITAccessRequest {
+			setupRequest: func(t *testing.T, jam *jit.JITAccessManager, rbacMgr *rbac.Manager, ctx context.Context) *jit.JITAccessRequest {
 				return nil // Don't create a request
 			},
 			approverID:  "approver1",
@@ -367,21 +360,19 @@ func TestJITAccessManager_ApproveRequest_Errors(t *testing.T) {
 		},
 		{
 			name: "Request not in pending status",
-			setupRequest: func(jam *JITAccessManager, ctx context.Context) *JITAccessRequest {
-				// Create and immediately deny a request
-				rbacManager := jam.rbacManager.(*MockRBACManager)
-				rbacManager.SetCheckPermissionResponse("user1", "read", "tenant1", false, "No access")
-
-				req := &JITAccessRequestSpec{
+			setupRequest: func(t *testing.T, jam *jit.JITAccessManager, rbacMgr *rbac.Manager, ctx context.Context) *jit.JITAccessRequest {
+				// Use admin (high-privilege) to prevent time-sensitive auto-approval.
+				req := &jit.JITAccessRequestSpec{
 					RequesterID:   "user1",
 					TenantID:      "tenant1",
-					Permissions:   []string{"read"},
+					Permissions:   []string{"admin"},
 					Duration:      time.Hour,
 					Justification: "Test",
 				}
 
-				request, _ := jam.RequestAccess(ctx, req)
-				_ = jam.DenyRequest(ctx, request.ID, "reviewer1", "Denied for testing")
+				request, err := jam.RequestAccess(ctx, req)
+				require.NoError(t, err)
+				require.NoError(t, jam.DenyRequest(ctx, request.ID, "reviewer1", "Denied for testing"))
 				return request
 			},
 			approverID:  "approver1",
@@ -389,40 +380,36 @@ func TestJITAccessManager_ApproveRequest_Errors(t *testing.T) {
 		},
 		{
 			name: "Approver lacks permission",
-			setupRequest: func(jam *JITAccessManager, ctx context.Context) *JITAccessRequest {
-				rbacManager := jam.rbacManager.(*MockRBACManager)
-				rbacManager.SetCheckPermissionResponse("user1", "read", "tenant1", false, "No access")
-
-				req := &JITAccessRequestSpec{
+			setupRequest: func(t *testing.T, jam *jit.JITAccessManager, rbacMgr *rbac.Manager, ctx context.Context) *jit.JITAccessRequest {
+				// Use admin (high-privilege) to prevent time-sensitive auto-approval.
+				req := &jit.JITAccessRequestSpec{
 					RequesterID:   "user1",
 					TenantID:      "tenant1",
-					Permissions:   []string{"read"},
+					Permissions:   []string{"admin"},
 					Duration:      time.Hour,
 					Justification: "Test",
-					AutoApprove:   false,
 				}
 
-				request, _ := jam.RequestAccess(ctx, req)
+				request, err := jam.RequestAccess(ctx, req)
+				require.NoError(t, err)
 				return request
 			},
-			approverID: "unauthorized_approver",
-			setupApprover: func(rbac *MockRBACManager, approverID, tenantID string) {
-				rbac.SetCheckPermissionResponse(approverID, "jit_access.approve", tenantID, false, "No permission")
-			},
-			expectedErr: "does not have permission to approve",
+			approverID:    "unauthorized_approver",
+			setupApprover: nil,
+			expectedErr:   "does not have permission to approve",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			rbacManager := &MockRBACManager{}
-			jam := NewJITAccessManager(rbacManager, &MockNotificationService{})
+			rbacManager := newTestRBACManager(t)
+			jam := jit.NewJITAccessManager(rbacManager, jit.NewSimpleNotificationService())
 
 			ctx := context.Background()
 			var requestID string
 
 			if tt.setupRequest != nil {
-				if request := tt.setupRequest(jam, ctx); request != nil {
+				if request := tt.setupRequest(t, jam, rbacManager, ctx); request != nil {
 					requestID = request.ID
 				} else {
 					requestID = "non-existent-request"
@@ -430,7 +417,7 @@ func TestJITAccessManager_ApproveRequest_Errors(t *testing.T) {
 			}
 
 			if tt.setupApprover != nil {
-				tt.setupApprover(rbacManager, tt.approverID, "tenant1")
+				tt.setupApprover(t, rbacManager, tt.approverID, "tenant1")
 			}
 
 			grant, err := jam.ApproveRequest(ctx, requestID, tt.approverID, "Test approval")
@@ -443,13 +430,11 @@ func TestJITAccessManager_ApproveRequest_Errors(t *testing.T) {
 }
 
 func TestJITAccessManager_DenyRequest(t *testing.T) {
-	rbacManager := &MockRBACManager{}
-	jam := NewJITAccessManager(rbacManager, &MockNotificationService{})
+	rbacManager := newTestRBACManager(t)
+	jam := jit.NewJITAccessManager(rbacManager, jit.NewSimpleNotificationService())
 
-	// Create a pending request
-	rbacManager.SetCheckPermissionResponse("user1", "admin", "tenant1", false, "No access")
-
-	requestSpec := &JITAccessRequestSpec{
+	// Create a pending request (default deny - user1 has no admin access)
+	requestSpec := &jit.JITAccessRequestSpec{
 		RequesterID:   "user1",
 		TenantID:      "tenant1",
 		Permissions:   []string{"admin"}, // High privilege to prevent auto-approval
@@ -461,7 +446,7 @@ func TestJITAccessManager_DenyRequest(t *testing.T) {
 	ctx := context.Background()
 	request, err := jam.RequestAccess(ctx, requestSpec)
 	require.NoError(t, err)
-	assert.Equal(t, JITAccessRequestStatusPending, request.Status)
+	assert.Equal(t, jit.JITAccessRequestStatusPending, request.Status)
 
 	// Deny the request
 	err = jam.DenyRequest(ctx, request.ID, "reviewer1", "Access not justified")
@@ -471,22 +456,21 @@ func TestJITAccessManager_DenyRequest(t *testing.T) {
 	// Check request was updated
 	updatedRequest, err := jam.GetRequest(ctx, request.ID)
 	require.NoError(t, err)
-	assert.Equal(t, JITAccessRequestStatusDenied, updatedRequest.Status)
+	assert.Equal(t, jit.JITAccessRequestStatusDenied, updatedRequest.Status)
 	assert.Equal(t, "reviewer1", updatedRequest.ReviewedBy)
 	assert.NotNil(t, updatedRequest.ReviewedAt)
 	assert.Equal(t, "Access not justified", updatedRequest.DenialReason)
 }
 
 func TestJITAccessManager_ExtendAccess(t *testing.T) {
-	rbacManager := &MockRBACManager{}
-	jam := NewJITAccessManager(rbacManager, &MockNotificationService{})
+	rbacManager := newTestRBACManager(t)
+	jam := jit.NewJITAccessManager(rbacManager, jit.NewSimpleNotificationService())
 
-	// Create and approve a request
-	rbacManager.SetCheckPermissionResponse("user1", "admin", "tenant1", false, "No access")
-	rbacManager.SetCheckPermissionResponse("approver1", "jit_access.approve", "tenant1", true, "Can approve")
-	rbacManager.SetCheckPermissionResponse("system", "jit_access.approve", "tenant1", true, "System can approve")
+	// Grant approval permissions to approver and system
+	grantPermission(t, rbacManager, "approver1", "jit_access.approve", "tenant1")
+	grantPermission(t, rbacManager, "system", "jit_access.approve", "tenant1")
 
-	requestSpec := &JITAccessRequestSpec{
+	requestSpec := &jit.JITAccessRequestSpec{
 		RequesterID:   "user1",
 		TenantID:      "tenant1",
 		Permissions:   []string{"admin"}, // High privilege to prevent auto-approval
@@ -511,8 +495,19 @@ func TestJITAccessManager_ExtendAccess(t *testing.T) {
 
 	require.NoError(t, err)
 
-	// Verify extension
-	extendedGrant := jam.activeGrants[grant.ID]
+	// Verify extension via public GetActiveGrants
+	grants, err := jam.GetActiveGrants(ctx, "user1", "tenant1")
+	require.NoError(t, err)
+
+	var extendedGrant *jit.JITAccessGrant
+	for _, g := range grants {
+		if g.ID == grant.ID {
+			extendedGrant = g
+			break
+		}
+	}
+	require.NotNil(t, extendedGrant, "extended grant should still be active")
+
 	assert.Equal(t, originalExpiry.Add(extensionDuration), extendedGrant.ExpiresAt)
 	assert.Equal(t, 1, extendedGrant.ExtensionsUsed)
 	assert.NotNil(t, extendedGrant.LastExtensionAt)
@@ -525,15 +520,15 @@ func TestJITAccessManager_ExtendAccess(t *testing.T) {
 func TestJITAccessManager_ExtendAccess_Errors(t *testing.T) {
 	tests := []struct {
 		name           string
-		setupGrant     func(*JITAccessManager, context.Context) *JITAccessGrant
+		setupGrant     func(*testing.T, *jit.JITAccessManager, *rbac.Manager, context.Context) *jit.JITAccessGrant
 		extensionDur   time.Duration
 		requesterID    string
-		setupRequester func(*MockRBACManager, string, string)
+		setupRequester func(*testing.T, *rbac.Manager, string, string)
 		expectedErr    string
 	}{
 		{
 			name: "Grant not found",
-			setupGrant: func(jam *JITAccessManager, ctx context.Context) *JITAccessGrant {
+			setupGrant: func(t *testing.T, jam *jit.JITAccessManager, rbacMgr *rbac.Manager, ctx context.Context) *jit.JITAccessGrant {
 				return nil // Don't create a grant
 			},
 			extensionDur: 30 * time.Minute,
@@ -542,23 +537,29 @@ func TestJITAccessManager_ExtendAccess_Errors(t *testing.T) {
 		},
 		{
 			name: "Maximum extensions reached",
-			setupGrant: func(jam *JITAccessManager, ctx context.Context) *JITAccessGrant {
-				// Create a grant and max out extensions
-				rbacManager := jam.rbacManager.(*MockRBACManager)
-				rbacManager.SetCheckPermissionResponse("user1", "read", "tenant1", false, "No access")
-				rbacManager.SetCheckPermissionResponse("approver1", "jit_access.approve", "tenant1", true, "Can approve")
+			setupGrant: func(t *testing.T, jam *jit.JITAccessManager, rbacMgr *rbac.Manager, ctx context.Context) *jit.JITAccessGrant {
+				// Create a grant and max out extensions via the public API.
+				// Use admin (high-privilege) to prevent time-sensitive auto-approval before
+				// approver1 can manually approve.
+				grantPermission(t, rbacMgr, "approver1", "jit_access.approve", "tenant1")
 
-				req := &JITAccessRequestSpec{
+				req := &jit.JITAccessRequestSpec{
 					RequesterID:   "user1",
 					TenantID:      "tenant1",
-					Permissions:   []string{"read"},
+					Permissions:   []string{"admin"},
 					Duration:      time.Hour,
 					Justification: "Test",
 				}
 
-				request, _ := jam.RequestAccess(ctx, req)
-				grant, _ := jam.ApproveRequest(ctx, request.ID, "approver1", "Approved")
-				grant.ExtensionsUsed = grant.MaxExtensions // Max out extensions
+				request, err := jam.RequestAccess(ctx, req)
+				require.NoError(t, err)
+				grant, err := jam.ApproveRequest(ctx, request.ID, "approver1", "Approved")
+				require.NoError(t, err)
+				// Max out extensions through the public API (MaxExtensions = 3)
+				for i := 0; i < 3; i++ {
+					err = jam.ExtendAccess(ctx, grant.ID, 30*time.Minute, "user1", "extending")
+					require.NoError(t, err, "pre-extend iteration %d should succeed", i+1)
+				}
 				return grant
 			},
 			extensionDur: 30 * time.Minute,
@@ -567,22 +568,23 @@ func TestJITAccessManager_ExtendAccess_Errors(t *testing.T) {
 		},
 		{
 			name: "Would exceed maximum duration",
-			setupGrant: func(jam *JITAccessManager, ctx context.Context) *JITAccessGrant {
-				rbacManager := jam.rbacManager.(*MockRBACManager)
-				rbacManager.SetCheckPermissionResponse("user1", "read", "tenant1", false, "No access")
-				rbacManager.SetCheckPermissionResponse("approver1", "jit_access.approve", "tenant1", true, "Can approve")
+			setupGrant: func(t *testing.T, jam *jit.JITAccessManager, rbacMgr *rbac.Manager, ctx context.Context) *jit.JITAccessGrant {
+				// Use admin (high-privilege) to prevent time-sensitive auto-approval.
+				grantPermission(t, rbacMgr, "approver1", "jit_access.approve", "tenant1")
 
-				req := &JITAccessRequestSpec{
+				req := &jit.JITAccessRequestSpec{
 					RequesterID:   "user1",
 					TenantID:      "tenant1",
-					Permissions:   []string{"read"},
+					Permissions:   []string{"admin"},
 					Duration:      time.Hour,
 					MaxDuration:   2 * time.Hour, // Short max duration
 					Justification: "Test",
 				}
 
-				request, _ := jam.RequestAccess(ctx, req)
-				grant, _ := jam.ApproveRequest(ctx, request.ID, "approver1", "Approved")
+				request, err := jam.RequestAccess(ctx, req)
+				require.NoError(t, err)
+				grant, err := jam.ApproveRequest(ctx, request.ID, "approver1", "Approved")
+				require.NoError(t, err)
 				return grant
 			},
 			extensionDur: 3 * time.Hour, // Would exceed max duration (total would be ~3 hours, max is 2)
@@ -591,42 +593,41 @@ func TestJITAccessManager_ExtendAccess_Errors(t *testing.T) {
 		},
 		{
 			name: "Unauthorized extender",
-			setupGrant: func(jam *JITAccessManager, ctx context.Context) *JITAccessGrant {
-				rbacManager := jam.rbacManager.(*MockRBACManager)
-				rbacManager.SetCheckPermissionResponse("user1", "read", "tenant1", false, "No access")
-				rbacManager.SetCheckPermissionResponse("approver1", "jit_access.approve", "tenant1", true, "Can approve")
+			setupGrant: func(t *testing.T, jam *jit.JITAccessManager, rbacMgr *rbac.Manager, ctx context.Context) *jit.JITAccessGrant {
+				// Use admin (high-privilege) to prevent time-sensitive auto-approval.
+				grantPermission(t, rbacMgr, "approver1", "jit_access.approve", "tenant1")
 
-				req := &JITAccessRequestSpec{
+				req := &jit.JITAccessRequestSpec{
 					RequesterID:   "user1",
 					TenantID:      "tenant1",
-					Permissions:   []string{"read"},
+					Permissions:   []string{"admin"},
 					Duration:      time.Hour,
 					Justification: "Test",
 				}
 
-				request, _ := jam.RequestAccess(ctx, req)
-				grant, _ := jam.ApproveRequest(ctx, request.ID, "approver1", "Approved")
+				request, err := jam.RequestAccess(ctx, req)
+				require.NoError(t, err)
+				grant, err := jam.ApproveRequest(ctx, request.ID, "approver1", "Approved")
+				require.NoError(t, err)
 				return grant
 			},
-			extensionDur: 30 * time.Minute,
-			requesterID:  "other_user",
-			setupRequester: func(rbac *MockRBACManager, requesterID, tenantID string) {
-				rbac.SetCheckPermissionResponse(requesterID, "jit_access.extend", tenantID, false, "No permission")
-			},
-			expectedErr: "not authorized to extend",
+			extensionDur:   30 * time.Minute,
+			requesterID:    "other_user",
+			setupRequester: nil,
+			expectedErr:    "not authorized to extend",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			rbacManager := &MockRBACManager{}
-			jam := NewJITAccessManager(rbacManager, &MockNotificationService{})
+			rbacManager := newTestRBACManager(t)
+			jam := jit.NewJITAccessManager(rbacManager, jit.NewSimpleNotificationService())
 
 			ctx := context.Background()
 			var grantID string
 
 			if tt.setupGrant != nil {
-				if grant := tt.setupGrant(jam, ctx); grant != nil {
+				if grant := tt.setupGrant(t, jam, rbacManager, ctx); grant != nil {
 					grantID = grant.ID
 				} else {
 					grantID = "non-existent-grant"
@@ -634,7 +635,7 @@ func TestJITAccessManager_ExtendAccess_Errors(t *testing.T) {
 			}
 
 			if tt.setupRequester != nil {
-				tt.setupRequester(rbacManager, tt.requesterID, "tenant1")
+				tt.setupRequester(t, rbacManager, tt.requesterID, "tenant1")
 			}
 
 			err := jam.ExtendAccess(ctx, grantID, tt.extensionDur, tt.requesterID, "Test extension")
@@ -648,15 +649,14 @@ func TestJITAccessManager_ExtendAccess_Errors(t *testing.T) {
 }
 
 func TestJITAccessManager_RevokeAccess(t *testing.T) {
-	rbacManager := &MockRBACManager{}
-	jam := NewJITAccessManager(rbacManager, &MockNotificationService{})
+	rbacManager := newTestRBACManager(t)
+	jam := jit.NewJITAccessManager(rbacManager, jit.NewSimpleNotificationService())
 
-	// Create and approve a request
-	rbacManager.SetCheckPermissionResponse("user1", "admin", "tenant1", false, "No access")
-	rbacManager.SetCheckPermissionResponse("approver1", "jit_access.approve", "tenant1", true, "Can approve")
-	rbacManager.SetCheckPermissionResponse("revoker1", "jit_access.revoke", "tenant1", true, "Can revoke")
+	// Grant approval and revocation permissions
+	grantPermission(t, rbacManager, "approver1", "jit_access.approve", "tenant1")
+	grantPermission(t, rbacManager, "revoker1", "jit_access.revoke", "tenant1")
 
-	requestSpec := &JITAccessRequestSpec{
+	requestSpec := &jit.JITAccessRequestSpec{
 		RequesterID:   "user1",
 		TenantID:      "tenant1",
 		Permissions:   []string{"admin"}, // High privilege to prevent auto-approval
@@ -671,31 +671,31 @@ func TestJITAccessManager_RevokeAccess(t *testing.T) {
 
 	grant, err := jam.ApproveRequest(ctx, request.ID, "approver1", "Approved")
 	require.NoError(t, err)
-	assert.Equal(t, JITAccessGrantStatusActive, grant.Status)
+	assert.Equal(t, jit.JITAccessGrantStatusActive, grant.Status)
 
 	// Revoke the access
 	err = jam.RevokeAccess(ctx, grant.ID, "revoker1", "Security concern")
 
 	require.NoError(t, err)
 
-	// Verify revocation
-	revokedGrant := jam.activeGrants[grant.ID]
-	assert.Equal(t, JITAccessGrantStatusRevoked, revokedGrant.Status)
-	assert.NotNil(t, revokedGrant.RevokedAt)
-	assert.Equal(t, "revoker1", revokedGrant.RevokedBy)
-	assert.Equal(t, "Security concern", revokedGrant.RevocationReason)
+	// Verify revocation: revoked grant should no longer appear in active grants
+	activeGrants, err := jam.GetActiveGrants(ctx, "user1", "tenant1")
+	require.NoError(t, err)
+	for _, g := range activeGrants {
+		assert.NotEqual(t, grant.ID, g.ID, "revoked grant should not appear in active grants")
+	}
 }
 
 func TestJITAccessManager_GetActiveGrants(t *testing.T) {
-	rbacManager := &MockRBACManager{}
-	jam := NewJITAccessManager(rbacManager, &MockNotificationService{})
+	rbacManager := newTestRBACManager(t)
+	jam := jit.NewJITAccessManager(rbacManager, jit.NewSimpleNotificationService())
+
+	// Grant system approval permission once for auto-approve
+	grantPermission(t, rbacManager, "system", "jit_access.approve", "tenant1")
 
 	// Create multiple grants for different users
-	setupGrant := func(requesterID, permission string) *JITAccessGrant {
-		rbacManager.SetCheckPermissionResponse(requesterID, permission, "tenant1", false, "No access")
-		rbacManager.SetCheckPermissionResponse("system", "jit_access.approve", "tenant1", true, "System can approve")
-
-		req := &JITAccessRequestSpec{
+	setupGrant := func(requesterID, permission string) *jit.JITAccessGrant {
+		req := &jit.JITAccessRequestSpec{
 			RequesterID:   requesterID,
 			TenantID:      "tenant1",
 			Permissions:   []string{permission},
@@ -704,7 +704,9 @@ func TestJITAccessManager_GetActiveGrants(t *testing.T) {
 			AutoApprove:   true,
 		}
 
-		request, _ := jam.RequestAccess(context.Background(), req)
+		request, err := jam.RequestAccess(context.Background(), req)
+		require.NoError(t, err)
+		require.NotNil(t, request.GrantedAccess, "auto-approve should have granted access")
 		return request.GrantedAccess
 	}
 
@@ -732,57 +734,47 @@ func TestJITAccessManager_GetActiveGrants(t *testing.T) {
 	assert.Equal(t, grant3.ID, grants2[0].ID)
 }
 
-// Note: Zero-trust integration tests would require more complex setup
-// For now, we test the zero-trust mode configuration separately
 func TestJITAccessManager_ZeroTrustModeConfiguration(t *testing.T) {
-	jam := NewJITAccessManager(&MockRBACManager{}, &MockNotificationService{})
+	jam := jit.NewJITAccessManager(newTestRBACManager(t), jit.NewSimpleNotificationService())
 
-	// Test that zero-trust evaluation checks work correctly
-	assert.False(t, jam.shouldEvaluateZeroTrustForRequest())
-	assert.False(t, jam.shouldEvaluateZeroTrustForApproval())
-	assert.False(t, jam.shouldEvaluateZeroTrustForGrant())
+	// Initial state: disabled
+	assert.Equal(t, jit.ZeroTrustJITModeDisabled, jam.GetZeroTrustMode())
 
 	// Enable zero-trust with comprehensive mode
 	engine := createMockZeroTrustEngine()
-	jam.EnableZeroTrustPolicies(engine, ZeroTrustJITModeComprehensive)
+	jam.EnableZeroTrustPolicies(engine, jit.ZeroTrustJITModeComprehensive)
+	assert.Equal(t, jit.ZeroTrustJITModeComprehensive, jam.GetZeroTrustMode())
 
-	assert.True(t, jam.shouldEvaluateZeroTrustForRequest())
-	assert.True(t, jam.shouldEvaluateZeroTrustForApproval())
-	assert.True(t, jam.shouldEvaluateZeroTrustForGrant())
+	// Test specific modes via SetZeroTrustMode
+	jam.SetZeroTrustMode(jit.ZeroTrustJITModeRequestValidation)
+	assert.Equal(t, jit.ZeroTrustJITModeRequestValidation, jam.GetZeroTrustMode())
 
-	// Test specific modes
-	jam.SetZeroTrustMode(ZeroTrustJITModeRequestValidation)
-	assert.True(t, jam.shouldEvaluateZeroTrustForRequest())
-	assert.False(t, jam.shouldEvaluateZeroTrustForApproval())
-	assert.False(t, jam.shouldEvaluateZeroTrustForGrant())
+	jam.SetZeroTrustMode(jit.ZeroTrustJITModeApprovalGating)
+	assert.Equal(t, jit.ZeroTrustJITModeApprovalGating, jam.GetZeroTrustMode())
 
-	jam.SetZeroTrustMode(ZeroTrustJITModeApprovalGating)
-	assert.False(t, jam.shouldEvaluateZeroTrustForRequest())
-	assert.True(t, jam.shouldEvaluateZeroTrustForApproval())
-	assert.False(t, jam.shouldEvaluateZeroTrustForGrant())
+	jam.SetZeroTrustMode(jit.ZeroTrustJITModeGrantValidation)
+	assert.Equal(t, jit.ZeroTrustJITModeGrantValidation, jam.GetZeroTrustMode())
 
-	jam.SetZeroTrustMode(ZeroTrustJITModeGrantValidation)
-	assert.False(t, jam.shouldEvaluateZeroTrustForRequest())
-	assert.False(t, jam.shouldEvaluateZeroTrustForApproval())
-	assert.True(t, jam.shouldEvaluateZeroTrustForGrant())
+	// Disable
+	jam.SetZeroTrustMode(jit.ZeroTrustJITModeDisabled)
+	assert.Equal(t, jit.ZeroTrustJITModeDisabled, jam.GetZeroTrustMode())
 }
 
 func TestJITAccessManager_ConcurrentAccess(t *testing.T) {
-	rbacManager := &MockRBACManager{}
-	jam := NewJITAccessManager(rbacManager, &MockNotificationService{})
+	rbacManager := newTestRBACManager(t)
+	jam := jit.NewJITAccessManager(rbacManager, jit.NewSimpleNotificationService())
 
-	// Setup common RBAC responses
-	rbacManager.SetCheckPermissionResponse("user1", "read", "tenant1", false, "No access")
-	rbacManager.SetCheckPermissionResponse("system", "jit_access.approve", "tenant1", true, "System can approve")
+	// Grant system approval permission for auto-approve
+	grantPermission(t, rbacManager, "system", "jit_access.approve", "tenant1")
 
 	const numConcurrentRequests = 10
-	results := make(chan *JITAccessRequest, numConcurrentRequests)
+	results := make(chan *jit.JITAccessRequest, numConcurrentRequests)
 	errors := make(chan error, numConcurrentRequests)
 
 	// Create multiple concurrent requests
 	for i := 0; i < numConcurrentRequests; i++ {
 		go func(requestNum int) {
-			requestSpec := &JITAccessRequestSpec{
+			requestSpec := &jit.JITAccessRequestSpec{
 				RequesterID:   "user1",
 				TenantID:      "tenant1",
 				Permissions:   []string{"read"},
@@ -823,9 +815,17 @@ func TestJITAccessManager_ConcurrentAccess(t *testing.T) {
 	assert.Equal(t, numConcurrentRequests, successCount)
 	assert.Equal(t, 0, errorCount)
 
-	// Verify all requests are stored
-	assert.Len(t, jam.requests, numConcurrentRequests)
-	assert.Len(t, jam.activeGrants, numConcurrentRequests)
+	ctx := context.Background()
+
+	// Verify all requests produced active grants
+	activeGrants, err := jam.GetActiveGrants(ctx, "user1", "tenant1")
+	require.NoError(t, err)
+	assert.Len(t, activeGrants, numConcurrentRequests)
+
+	// Verify all requests are stored (via ListRequests)
+	requests, err := jam.ListRequests(ctx, &jit.JITAccessRequestFilter{RequesterID: "user1"})
+	require.NoError(t, err)
+	assert.Len(t, requests, numConcurrentRequests)
 }
 
 func TestJITAuditManager_RecordsEvents(t *testing.T) {
@@ -839,20 +839,19 @@ func TestJITAuditManager_RecordsEvents(t *testing.T) {
 	t.Cleanup(func() {
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
-		_ = auditMgr.Stop(ctx)
-		_ = storageManager.Close()
+		assert.NoError(t, auditMgr.Stop(ctx))
+		assert.NoError(t, storageManager.Close())
 	})
 
-	rbacManager := &MockRBACManager{}
-	rbacManager.SetCheckPermissionResponse("user1", "admin", "tenant1", false, "No access")
-	rbacManager.SetCheckPermissionResponse("approver1", "jit_access.approve", "tenant1", true, "Can approve")
+	rbacManager := newTestRBACManager(t)
+	grantPermission(t, rbacManager, "approver1", "jit_access.approve", "tenant1")
 
-	jam := NewJITAccessManager(rbacManager, &MockNotificationService{})
+	jam := jit.NewJITAccessManager(rbacManager, jit.NewSimpleNotificationService())
 	jam.SetAuditManager(auditMgr)
 
 	ctx := context.Background()
 
-	request, err := jam.RequestAccess(ctx, &JITAccessRequestSpec{
+	request, err := jam.RequestAccess(ctx, &jit.JITAccessRequestSpec{
 		RequesterID:   "user1",
 		TenantID:      "tenant1",
 		Permissions:   []string{"admin"},
@@ -895,15 +894,14 @@ func TestJITAuditManager_RecordsEvents(t *testing.T) {
 }
 
 func TestJITAuditManager_NilSafe(t *testing.T) {
-	rbacManager := &MockRBACManager{}
-	rbacManager.SetCheckPermissionResponse("user1", "admin", "tenant1", false, "No access")
+	rbacManager := newTestRBACManager(t)
 
-	jam := NewJITAccessManager(rbacManager, &MockNotificationService{})
+	jam := jit.NewJITAccessManager(rbacManager, jit.NewSimpleNotificationService())
 	// Intentionally do NOT call SetAuditManager
 
 	ctx := context.Background()
 
-	request, err := jam.RequestAccess(ctx, &JITAccessRequestSpec{
+	request, err := jam.RequestAccess(ctx, &jit.JITAccessRequestSpec{
 		RequesterID:   "user1",
 		TenantID:      "tenant1",
 		Permissions:   []string{"admin"},
@@ -915,64 +913,70 @@ func TestJITAuditManager_NilSafe(t *testing.T) {
 	assert.NotNil(t, request)
 }
 
-// Mock implementations
+func newTestRBACManager(t *testing.T) *rbac.Manager {
+	t.Helper()
+	tmpDir := t.TempDir()
+	sm, err := interfaces.CreateOSSStorageManager(tmpDir+"/flatfile", tmpDir+"/cfgms.db")
+	require.NoError(t, err)
+	t.Cleanup(func() { assert.NoError(t, sm.Close()) })
 
-type MockRBACManager struct {
-	rbac.RBACManager
-	responses map[string]*common.AccessResponse
+	mgr := rbac.NewManagerWithStorage(sm.GetAuditStore(), sm.GetClientTenantStore(), sm.GetRBACStore())
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		assert.NoError(t, mgr.Close(ctx))
+	})
+
+	ctx := rbac.WithSensitiveOperationJustification(context.Background(), "test rbac manager initialization")
+	require.NoError(t, mgr.Initialize(ctx))
+	return mgr
 }
 
-func (m *MockRBACManager) CheckPermission(ctx context.Context, request *common.AccessRequest) (*common.AccessResponse, error) {
-	key := m.makeKey(request.SubjectId, request.PermissionId, request.TenantId)
-	if response, exists := m.responses[key]; exists {
-		return response, nil
+func grantPermission(t *testing.T, mgr *rbac.Manager, subjectID, permissionID, tenantID string) {
+	t.Helper()
+	ctx := rbac.WithSensitiveOperationJustification(context.Background(), "test setup: grant permission")
+
+	perm := &common.Permission{
+		Id:           permissionID,
+		Name:         permissionID,
+		ResourceType: "test",
+		Actions:      []string{"execute"},
 	}
-	return &common.AccessResponse{Granted: false, Reason: "Default deny"}, nil
-}
-
-func (m *MockRBACManager) SetCheckPermissionResponse(subjectID, permissionID, tenantID string, granted bool, reason string) {
-	if m.responses == nil {
-		m.responses = make(map[string]*common.AccessResponse)
+	if err := mgr.CreatePermission(ctx, perm); err != nil && !strings.Contains(err.Error(), "already exists") {
+		require.NoError(t, err)
 	}
-	key := m.makeKey(subjectID, permissionID, tenantID)
-	m.responses[key] = &common.AccessResponse{
-		Granted: granted,
-		Reason:  reason,
+
+	roleID := subjectID + "-" + permissionID + "-" + tenantID
+	role := &common.Role{
+		Id:            roleID,
+		Name:          roleID,
+		PermissionIds: []string{permissionID},
+		TenantId:      tenantID,
 	}
-}
+	if err := mgr.CreateRole(ctx, role); err != nil {
+		if strings.Contains(err.Error(), "already exists") {
+			return
+		}
+		require.NoError(t, err)
+	}
 
-func (m *MockRBACManager) makeKey(subjectID, permissionID, tenantID string) string {
-	return subjectID + "|" + permissionID + "|" + tenantID
-}
+	subject := &common.Subject{
+		Id:          subjectID,
+		Type:        common.SubjectType_SUBJECT_TYPE_USER,
+		DisplayName: subjectID,
+		TenantId:    tenantID,
+		IsActive:    true,
+	}
+	if err := mgr.CreateSubject(ctx, subject); err != nil && !strings.Contains(err.Error(), "already exists") {
+		require.NoError(t, err)
+	}
 
-type MockNotificationService struct{}
-
-func (m *MockNotificationService) SendRequestNotification(ctx context.Context, request *JITAccessRequest, eventType string) error {
-	return nil
-}
-
-func (m *MockNotificationService) SendApprovalNotification(ctx context.Context, request *JITAccessRequest, approvers []string) error {
-	return nil
-}
-
-func (m *MockNotificationService) SendReminderNotification(ctx context.Context, request *JITAccessRequest, recipient string) error {
-	return nil
-}
-
-func (m *MockNotificationService) SendGrantNotification(ctx context.Context, grant *JITAccessGrant, eventType string) error {
-	return nil
-}
-
-func (m *MockNotificationService) SendExpirationWarning(ctx context.Context, grant *JITAccessGrant, timeUntilExpiry time.Duration) error {
-	return nil
-}
-
-func (m *MockNotificationService) SendRevocationNotification(ctx context.Context, grant *JITAccessGrant, reason string) error {
-	return nil
-}
-
-func (m *MockNotificationService) SendEscalationNotification(ctx context.Context, request *JITAccessRequest, escalationLevel int) error {
-	return nil
+	assignment := &common.RoleAssignment{
+		SubjectId: subjectID,
+		RoleId:    roleID,
+		TenantId:  tenantID,
+	}
+	require.NoError(t, mgr.AssignRole(ctx, assignment))
 }
 
 // Helper function to create a mock zero-trust engine

--- a/features/rbac/risk/risk_engine_test.go
+++ b/features/rbac/risk/risk_engine_test.go
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2026 Jordan Ritz
-package risk
+package risk_test
 
 import (
 	"context"
@@ -12,23 +12,23 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/cfgis/cfgms/api/proto/common"
+	"github.com/cfgis/cfgms/features/rbac/risk"
 )
 
 func TestNewRiskAssessmentEngine(t *testing.T) {
-	engine := NewRiskAssessmentEngine()
+	engine := risk.NewRiskAssessmentEngine()
 
 	assert.NotNil(t, engine)
-	assert.NotNil(t, engine.contextualFactors)
-	assert.NotNil(t, engine.behavioralAnalyzer)
-	assert.NotNil(t, engine.environmentAnalyzer)
-	assert.NotNil(t, engine.resourceAnalyzer)
-	assert.NotNil(t, engine.policyEngine)
-	assert.NotNil(t, engine.auditLogger)
-	assert.NotNil(t, engine.cache)
+
+	// Prove all 7 internal dependencies are wired by exercising EvaluateRisk end-to-end.
+	ctx := context.Background()
+	result, err := engine.EvaluateRisk(ctx, createMinimalRiskRequest())
+	require.NoError(t, err)
+	assert.NotNil(t, result)
 }
 
 func TestRiskAssessmentEngine_EvaluateRisk_MinimalRisk(t *testing.T) {
-	engine := NewRiskAssessmentEngine()
+	engine := risk.NewRiskAssessmentEngine()
 	ctx := context.Background()
 
 	request := createMinimalRiskRequest()
@@ -45,12 +45,12 @@ func TestRiskAssessmentEngine_EvaluateRisk_MinimalRisk(t *testing.T) {
 
 	// Minimal risk should result in low risk scores
 	assert.True(t, result.OverallRiskScore < 50, "Minimal risk request should have low risk score")
-	assert.Contains(t, []RiskLevel{RiskLevelMinimal, RiskLevelLow}, result.RiskLevel)
-	assert.Contains(t, []AccessDecision{AccessDecisionAllow, AccessDecisionAllowWithControls}, result.AccessDecision)
+	assert.Contains(t, []risk.RiskLevel{risk.RiskLevelMinimal, risk.RiskLevelLow}, result.RiskLevel)
+	assert.Contains(t, []risk.AccessDecision{risk.AccessDecisionAllow, risk.AccessDecisionAllowWithControls}, result.AccessDecision)
 }
 
 func TestRiskAssessmentEngine_EvaluateRisk_HighRisk(t *testing.T) {
-	engine := NewRiskAssessmentEngine()
+	engine := risk.NewRiskAssessmentEngine()
 	ctx := context.Background()
 
 	request := createHighRiskRequest()
@@ -62,7 +62,7 @@ func TestRiskAssessmentEngine_EvaluateRisk_HighRisk(t *testing.T) {
 
 	// High risk should result in higher risk scores and more restrictive decisions
 	assert.True(t, result.OverallRiskScore > 50, "High risk request should have elevated risk score")
-	assert.Contains(t, []RiskLevel{RiskLevelModerate, RiskLevelHigh, RiskLevelCritical}, result.RiskLevel)
+	assert.Contains(t, []risk.RiskLevel{risk.RiskLevelModerate, risk.RiskLevelHigh, risk.RiskLevelCritical}, result.RiskLevel)
 
 	// Should have risk factors identified
 	assert.NotEmpty(t, result.RiskFactors)
@@ -71,13 +71,13 @@ func TestRiskAssessmentEngine_EvaluateRisk_HighRisk(t *testing.T) {
 	assert.NotEmpty(t, result.RecommendedActions)
 
 	// May require additional controls
-	if result.AccessDecision == AccessDecisionAllowWithControls {
+	if result.AccessDecision == risk.AccessDecisionAllowWithControls {
 		assert.NotEmpty(t, result.RequiredControls)
 	}
 }
 
 func TestRiskAssessmentEngine_EvaluateRisk_ExtremeRisk(t *testing.T) {
-	engine := NewRiskAssessmentEngine()
+	engine := risk.NewRiskAssessmentEngine()
 	ctx := context.Background()
 
 	request := createExtremeRiskRequest()
@@ -89,10 +89,10 @@ func TestRiskAssessmentEngine_EvaluateRisk_ExtremeRisk(t *testing.T) {
 
 	// Extreme risk should result in very high scores and denial/break-glass decisions
 	assert.True(t, result.OverallRiskScore > 70, "Extreme risk request should have very high risk score")
-	assert.Contains(t, []RiskLevel{RiskLevelHigh, RiskLevelCritical, RiskLevelExtreme}, result.RiskLevel)
+	assert.Contains(t, []risk.RiskLevel{risk.RiskLevelHigh, risk.RiskLevelCritical, risk.RiskLevelExtreme}, result.RiskLevel)
 
 	// Should have restrictive access decision
-	assert.Contains(t, []AccessDecision{AccessDecisionDeny, AccessDecisionBreakGlass, AccessDecisionChallenge, AccessDecisionStepUp}, result.AccessDecision)
+	assert.Contains(t, []risk.AccessDecision{risk.AccessDecisionDeny, risk.AccessDecisionBreakGlass, risk.AccessDecisionChallenge, risk.AccessDecisionStepUp}, result.AccessDecision)
 
 	// Should have multiple risk factors
 	assert.GreaterOrEqual(t, len(result.RiskFactors), 2)
@@ -102,7 +102,7 @@ func TestRiskAssessmentEngine_EvaluateRisk_ExtremeRisk(t *testing.T) {
 }
 
 func TestRiskAssessmentEngine_EvaluateRisk_WithHistoricalData(t *testing.T) {
-	engine := NewRiskAssessmentEngine()
+	engine := risk.NewRiskAssessmentEngine()
 	ctx := context.Background()
 
 	request := createRequestWithHistoricalData()
@@ -123,7 +123,7 @@ func TestRiskAssessmentEngine_EvaluateRisk_WithHistoricalData(t *testing.T) {
 func TestRiskAssessmentEngine_EvaluateRisk_ValidationErrors(t *testing.T) {
 	tests := []struct {
 		name    string
-		request *RiskAssessmentRequest
+		request *risk.RiskAssessmentRequest
 		wantErr bool
 	}{
 		{
@@ -133,25 +133,25 @@ func TestRiskAssessmentEngine_EvaluateRisk_ValidationErrors(t *testing.T) {
 		},
 		{
 			name: "missing access request",
-			request: &RiskAssessmentRequest{
+			request: &risk.RiskAssessmentRequest{
 				UserContext:     createTestUserContext("user1"),
 				SessionContext:  createTestSessionContext("session1"),
-				ResourceContext: createTestResourceContext("resource1", ResourceSensitivityInternal),
+				ResourceContext: createTestResourceContext("resource1", risk.ResourceSensitivityInternal),
 			},
 			wantErr: true,
 		},
 		{
 			name: "missing user context",
-			request: &RiskAssessmentRequest{
+			request: &risk.RiskAssessmentRequest{
 				AccessRequest:   createTestAccessRequest("user1", "resource1", "read"),
 				SessionContext:  createTestSessionContext("session1"),
-				ResourceContext: createTestResourceContext("resource1", ResourceSensitivityInternal),
+				ResourceContext: createTestResourceContext("resource1", risk.ResourceSensitivityInternal),
 			},
 			wantErr: true,
 		},
 		{
 			name: "missing resource context",
-			request: &RiskAssessmentRequest{
+			request: &risk.RiskAssessmentRequest{
 				AccessRequest:  createTestAccessRequest("user1", "resource1", "read"),
 				UserContext:    createTestUserContext("user1"),
 				SessionContext: createTestSessionContext("session1"),
@@ -160,7 +160,7 @@ func TestRiskAssessmentEngine_EvaluateRisk_ValidationErrors(t *testing.T) {
 		},
 	}
 
-	engine := NewRiskAssessmentEngine()
+	engine := risk.NewRiskAssessmentEngine()
 	ctx := context.Background()
 
 	for _, tt := range tests {
@@ -181,37 +181,37 @@ func TestRiskAssessmentEngine_EvaluateRisk_ValidationErrors(t *testing.T) {
 func TestRiskAssessmentEngine_ResourceSensitivityImpact(t *testing.T) {
 	tests := []struct {
 		name                  string
-		sensitivity           ResourceSensitivity
-		expectedMinRiskLevel  RiskLevel
+		sensitivity           risk.ResourceSensitivity
+		expectedMinRiskLevel  risk.RiskLevel
 		expectedImpactOnScore bool
 	}{
 		{
 			name:                  "Public sensitivity resource",
-			sensitivity:           ResourceSensitivityPublic,
-			expectedMinRiskLevel:  RiskLevelMinimal,
+			sensitivity:           risk.ResourceSensitivityPublic,
+			expectedMinRiskLevel:  risk.RiskLevelMinimal,
 			expectedImpactOnScore: false,
 		},
 		{
 			name:                  "Internal sensitivity resource",
-			sensitivity:           ResourceSensitivityInternal,
-			expectedMinRiskLevel:  RiskLevelLow,
+			sensitivity:           risk.ResourceSensitivityInternal,
+			expectedMinRiskLevel:  risk.RiskLevelLow,
 			expectedImpactOnScore: true,
 		},
 		{
 			name:                  "Confidential sensitivity resource",
-			sensitivity:           ResourceSensitivityConfidential,
-			expectedMinRiskLevel:  RiskLevelModerate,
+			sensitivity:           risk.ResourceSensitivityConfidential,
+			expectedMinRiskLevel:  risk.RiskLevelModerate,
 			expectedImpactOnScore: true,
 		},
 		{
 			name:                  "Secret sensitivity resource",
-			sensitivity:           ResourceSensitivitySecret,
-			expectedMinRiskLevel:  RiskLevelHigh,
+			sensitivity:           risk.ResourceSensitivitySecret,
+			expectedMinRiskLevel:  risk.RiskLevelHigh,
 			expectedImpactOnScore: true,
 		},
 	}
 
-	engine := NewRiskAssessmentEngine()
+	engine := risk.NewRiskAssessmentEngine()
 	ctx := context.Background()
 
 	for _, tt := range tests {
@@ -235,16 +235,16 @@ func TestRiskAssessmentEngine_ResourceSensitivityImpact(t *testing.T) {
 }
 
 func TestRiskAssessmentEngine_ThreatIntelligenceIntegration(t *testing.T) {
-	engine := NewRiskAssessmentEngine()
+	engine := risk.NewRiskAssessmentEngine()
 	ctx := context.Background()
 
 	// Request with threat intelligence indicating high risk IP
-	request := createTestRequest("user1", "resource1", "read", ResourceSensitivityInternal)
-	request.EnvironmentContext.ThreatIntelligence = &ThreatIntelligenceContext{
+	request := createTestRequest("user1", "resource1", "read", risk.ResourceSensitivityInternal)
+	request.EnvironmentContext.ThreatIntelligence = &risk.ThreatIntelligenceContext{
 		IPReputationScore: 0.9, // High risk IP
 		ThreatCategories:  []string{"malware", "phishing"},
-		ThreatLevel:       ThreatLevelHigh,
-		RecentThreats: []ThreatIndicator{
+		ThreatLevel:       risk.ThreatLevelHigh,
+		RecentThreats: []risk.ThreatIndicator{
 			{
 				Type:        "malware_c2",
 				Confidence:  0.85,
@@ -270,23 +270,23 @@ func TestRiskAssessmentEngine_ThreatIntelligenceIntegration(t *testing.T) {
 	assert.True(t, result.EnvironmentalRisk.ThreatEnvironment.ReputationScore > 0.5)
 
 	// Should recommend additional controls or deny access
-	assert.Contains(t, []AccessDecision{
-		AccessDecisionDeny,
-		AccessDecisionChallenge,
-		AccessDecisionStepUp,
-		AccessDecisionAllowWithControls,
+	assert.Contains(t, []risk.AccessDecision{
+		risk.AccessDecisionDeny,
+		risk.AccessDecisionChallenge,
+		risk.AccessDecisionStepUp,
+		risk.AccessDecisionAllowWithControls,
 	}, result.AccessDecision)
 }
 
 func TestRiskAssessmentEngine_BehavioralAnomalyDetection(t *testing.T) {
-	engine := NewRiskAssessmentEngine()
+	engine := risk.NewRiskAssessmentEngine()
 	ctx := context.Background()
 
 	request := createMinimalRiskRequest()
 
 	// Add anomalous behavioral data
-	request.HistoricalData = &HistoricalAccessData{
-		AnomalyHistory: []AnomalyRecord{
+	request.HistoricalData = &risk.HistoricalAccessData{
+		AnomalyHistory: []risk.AnomalyRecord{
 			{
 				Timestamp:     time.Now().Add(-2 * time.Hour),
 				AnomalyType:   "unusual_time",
@@ -304,7 +304,7 @@ func TestRiskAssessmentEngine_BehavioralAnomalyDetection(t *testing.T) {
 				ActualValue:   "Moscow, RU",
 			},
 		},
-		AccessPatterns: &AccessPatternAnalysis{
+		AccessPatterns: &risk.AccessPatternAnalysis{
 			TypicalHours:      []int{9, 10, 11, 14, 15, 16},
 			TypicalLocations:  []string{"New York", "Boston"},
 			PatternConfidence: 0.9,
@@ -368,7 +368,7 @@ func TestRiskAssessmentEngine_TimeBasedRiskEvaluation(t *testing.T) {
 		},
 	}
 
-	engine := NewRiskAssessmentEngine()
+	engine := risk.NewRiskAssessmentEngine()
 	ctx := context.Background()
 
 	// Create a baseline request for business hours
@@ -431,12 +431,12 @@ func TestRiskAssessmentEngine_GeographicLocationRisk(t *testing.T) {
 		},
 	}
 
-	engine := NewRiskAssessmentEngine()
+	engine := risk.NewRiskAssessmentEngine()
 	ctx := context.Background()
 
 	// Create baseline request from trusted location
 	baselineRequest := createMinimalRiskRequest()
-	baselineRequest.EnvironmentContext.GeoLocation = &GeoLocation{
+	baselineRequest.EnvironmentContext.GeoLocation = &risk.GeoLocation{
 		Country: "United States",
 		Region:  "New York",
 		City:    "New York",
@@ -449,7 +449,7 @@ func TestRiskAssessmentEngine_GeographicLocationRisk(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			request := createMinimalRiskRequest()
-			request.EnvironmentContext.GeoLocation = &GeoLocation{
+			request.EnvironmentContext.GeoLocation = &risk.GeoLocation{
 				Country: tt.country,
 				Region:  "Unknown",
 				City:    "Unknown",
@@ -468,11 +468,11 @@ func TestRiskAssessmentEngine_GeographicLocationRisk(t *testing.T) {
 }
 
 func TestRiskAssessmentEngine_ConcurrentEvaluations(t *testing.T) {
-	engine := NewRiskAssessmentEngine()
+	engine := risk.NewRiskAssessmentEngine()
 	ctx := context.Background()
 
 	const numConcurrent = 10
-	results := make(chan *RiskAssessmentResult, numConcurrent)
+	results := make(chan *risk.RiskAssessmentResult, numConcurrent)
 	errors := make(chan error, numConcurrent)
 
 	// Run multiple concurrent risk evaluations
@@ -514,25 +514,25 @@ func TestRiskAssessmentEngine_ConcurrentEvaluations(t *testing.T) {
 
 // Helper functions for creating test data
 
-func createMinimalRiskRequest() *RiskAssessmentRequest {
-	return &RiskAssessmentRequest{
+func createMinimalRiskRequest() *risk.RiskAssessmentRequest {
+	return &risk.RiskAssessmentRequest{
 		AccessRequest:   createTestAccessRequest("user1", "resource1", "read"),
 		UserContext:     createTestUserContext("user1"),
 		SessionContext:  createTestSessionContext("session1"),
-		ResourceContext: createTestResourceContext("resource1", ResourceSensitivityPublic),
-		EnvironmentContext: &EnvironmentContext{
+		ResourceContext: createTestResourceContext("resource1", risk.ResourceSensitivityPublic),
+		EnvironmentContext: &risk.EnvironmentContext{
 			AccessTime:      time.Now(),
 			BusinessHours:   true,
-			NetworkSecurity: NetworkSecurityLevelHigh,
+			NetworkSecurity: risk.NetworkSecurityLevelHigh,
 			VPNConnected:    true,
-			GeoLocation: &GeoLocation{
+			GeoLocation: &risk.GeoLocation{
 				Country: "United States",
 				Region:  "California",
 				City:    "San Francisco",
 			},
-			ThreatIntelligence: &ThreatIntelligenceContext{
+			ThreatIntelligence: &risk.ThreatIntelligenceContext{
 				IPReputationScore: 0.1, // Low risk IP
-				ThreatLevel:       ThreatLevelLow,
+				ThreatLevel:       risk.ThreatLevelLow,
 				LastUpdated:       time.Now(),
 			},
 		},
@@ -540,31 +540,31 @@ func createMinimalRiskRequest() *RiskAssessmentRequest {
 	}
 }
 
-func createHighRiskRequest() *RiskAssessmentRequest {
+func createHighRiskRequest() *risk.RiskAssessmentRequest {
 	request := createMinimalRiskRequest()
 
 	// Make it high risk
-	request.ResourceContext.Sensitivity = ResourceSensitivityConfidential
-	request.ResourceContext.Classification = DataClassificationConfidential
+	request.ResourceContext.Sensitivity = risk.ResourceSensitivityConfidential
+	request.ResourceContext.Classification = risk.DataClassificationConfidential
 	request.EnvironmentContext.BusinessHours = false
 	request.EnvironmentContext.AccessTime = time.Date(2023, 12, 15, 2, 0, 0, 0, time.UTC) // 2 AM
 	request.EnvironmentContext.VPNConnected = false
-	request.EnvironmentContext.NetworkSecurity = NetworkSecurityLevelMedium
+	request.EnvironmentContext.NetworkSecurity = risk.NetworkSecurityLevelMedium
 	request.EnvironmentContext.ThreatIntelligence.IPReputationScore = 0.6 // Medium risk IP
 	request.AccessRequest.PermissionId = "admin"                          // High privilege
 
 	return request
 }
 
-func createExtremeRiskRequest() *RiskAssessmentRequest {
+func createExtremeRiskRequest() *risk.RiskAssessmentRequest {
 	request := createHighRiskRequest()
 
 	// Make it extreme risk
-	request.ResourceContext.Sensitivity = ResourceSensitivitySecret
-	request.ResourceContext.Classification = DataClassificationRestricted
+	request.ResourceContext.Sensitivity = risk.ResourceSensitivitySecret
+	request.ResourceContext.Classification = risk.DataClassificationRestricted
 	request.EnvironmentContext.GeoLocation.Country = "North Korea"
 	request.EnvironmentContext.ThreatIntelligence.IPReputationScore = 0.95 // Very high risk IP
-	request.EnvironmentContext.ThreatIntelligence.ThreatLevel = ThreatLevelCritical
+	request.EnvironmentContext.ThreatIntelligence.ThreatLevel = risk.ThreatLevelCritical
 	request.EnvironmentContext.ThreatIntelligence.ThreatCategories = []string{"malware", "apt", "botnet"}
 	request.UserContext.MFAEnabled = false              // No MFA
 	request.AccessRequest.PermissionId = "system_admin" // Critical privilege
@@ -572,11 +572,11 @@ func createExtremeRiskRequest() *RiskAssessmentRequest {
 	return request
 }
 
-func createRequestWithHistoricalData() *RiskAssessmentRequest {
+func createRequestWithHistoricalData() *risk.RiskAssessmentRequest {
 	request := createMinimalRiskRequest()
 
-	request.HistoricalData = &HistoricalAccessData{
-		RecentAccess: []AccessRecord{
+	request.HistoricalData = &risk.HistoricalAccessData{
+		RecentAccess: []risk.AccessRecord{
 			{
 				Timestamp:  time.Now().Add(-1 * time.Hour),
 				ResourceID: "resource1",
@@ -592,7 +592,7 @@ func createRequestWithHistoricalData() *RiskAssessmentRequest {
 				IPAddress:  "192.168.1.100",
 			},
 		},
-		AccessPatterns: &AccessPatternAnalysis{
+		AccessPatterns: &risk.AccessPatternAnalysis{
 			TypicalHours:       []int{9, 10, 11, 14, 15, 16},
 			TypicalDays:        []time.Weekday{time.Monday, time.Tuesday, time.Wednesday, time.Thursday, time.Friday},
 			TypicalLocations:   []string{"San Francisco", "New York"},
@@ -607,25 +607,25 @@ func createRequestWithHistoricalData() *RiskAssessmentRequest {
 	return request
 }
 
-func createTestRequest(userID, resourceID, permission string, sensitivity ResourceSensitivity) *RiskAssessmentRequest {
-	return &RiskAssessmentRequest{
+func createTestRequest(userID, resourceID, permission string, sensitivity risk.ResourceSensitivity) *risk.RiskAssessmentRequest {
+	return &risk.RiskAssessmentRequest{
 		AccessRequest:   createTestAccessRequest(userID, resourceID, permission),
 		UserContext:     createTestUserContext(userID),
 		SessionContext:  createTestSessionContext("session-" + userID),
 		ResourceContext: createTestResourceContext(resourceID, sensitivity),
-		EnvironmentContext: &EnvironmentContext{
+		EnvironmentContext: &risk.EnvironmentContext{
 			AccessTime:      time.Now(),
 			BusinessHours:   true,
-			NetworkSecurity: NetworkSecurityLevelHigh,
+			NetworkSecurity: risk.NetworkSecurityLevelHigh,
 			VPNConnected:    true,
-			GeoLocation: &GeoLocation{
+			GeoLocation: &risk.GeoLocation{
 				Country: "United States",
 				Region:  "California",
 				City:    "San Francisco",
 			},
-			ThreatIntelligence: &ThreatIntelligenceContext{
+			ThreatIntelligence: &risk.ThreatIntelligenceContext{
 				IPReputationScore: 0.1,
-				ThreatLevel:       ThreatLevelLow,
+				ThreatLevel:       risk.ThreatLevelLow,
 				LastUpdated:       time.Now(),
 			},
 		},
@@ -645,8 +645,8 @@ func createTestAccessRequest(subjectID, resourceID, permission string) *common.A
 	}
 }
 
-func createTestUserContext(userID string) *UserContext {
-	return &UserContext{
+func createTestUserContext(userID string) *risk.UserContext {
+	return &risk.UserContext{
 		UserID:             userID,
 		Username:           userID + "@example.com",
 		Email:              userID + "@example.com",
@@ -659,8 +659,8 @@ func createTestUserContext(userID string) *UserContext {
 	}
 }
 
-func createTestSessionContext(sessionID string) *SessionContext {
-	return &SessionContext{
+func createTestSessionContext(sessionID string) *risk.SessionContext {
+	return &risk.SessionContext{
 		SessionID:       sessionID,
 		DeviceID:        "device-123",
 		DeviceType:      "laptop",
@@ -673,18 +673,18 @@ func createTestSessionContext(sessionID string) *SessionContext {
 	}
 }
 
-func createTestResourceContext(resourceID string, sensitivity ResourceSensitivity) *ResourceContext {
-	classification := DataClassificationPublic
+func createTestResourceContext(resourceID string, sensitivity risk.ResourceSensitivity) *risk.ResourceContext {
+	classification := risk.DataClassificationPublic
 	switch sensitivity {
-	case ResourceSensitivityInternal:
-		classification = DataClassificationInternal
-	case ResourceSensitivityConfidential:
-		classification = DataClassificationConfidential
-	case ResourceSensitivitySecret:
-		classification = DataClassificationRestricted
+	case risk.ResourceSensitivityInternal:
+		classification = risk.DataClassificationInternal
+	case risk.ResourceSensitivityConfidential:
+		classification = risk.DataClassificationConfidential
+	case risk.ResourceSensitivitySecret:
+		classification = risk.DataClassificationRestricted
 	}
 
-	return &ResourceContext{
+	return &risk.ResourceContext{
 		ResourceID:       resourceID,
 		ResourceType:     "database",
 		ResourceName:     "Test Database",


### PR DESCRIPTION
## Summary

Converts three rbac sub-package test files from white-box (`package foo`) to black-box (`package foo_test`) testing, replacing all unexported field access with observable public API behavior. Part of Epic #730.

**Completed:**
- `features/rbac/jit/access_manager_test.go` — full conversion; `MockRBACManager` replaced with real `rbac.Manager` via `newTestRBACManager(t)` + `grantPermission()` helpers; `MockNotificationService` replaced with `jit.NewSimpleNotificationService()`; 9 private field assertions in `TestNewJITAccessManager` replaced with `GetZeroTrustMode()` + `RequestAccess()` smoke test; pointer mutation via `grant.ExtensionsUsed` replaced with sequential `ExtendAccess()` calls; cleanup error swallowing fixed
- `features/rbac/continuous/authorization_engine_test.go` — package converted to `continuous_test`; `TestNewContinuousAuthorizationEngine` replaced with `Start(ctx)` + `Stop()` lifecycle test
- `features/rbac/risk/risk_engine_test.go` — package converted to `risk_test`; `TestNewRiskAssessmentEngine` replaced with `EvaluateRisk()` proof-of-wiring test

**Pre-existing architectural debt (not fixed in this PR):**
The `continuous` package defines three interfaces whose method signatures do not match any real CFGMS implementation:
- `continuous.JITManager.CheckJITAccess(ctx, *common.AccessRequest)` — the real `jit.JITAccessManager.CheckJITAccess` has signature `(ctx, subjectID, permissionID, tenantID string)`
- `continuous.RiskManager.EnhancedRiskAccessCheck` — returns `*continuous.RiskAccessResult` (a local wrapper type) vs. the real `*risk.EnhancedRiskAccessResponse`
- `continuous.TenantSecurityMiddleware.GetPolicyEngine()` — no real CFGMS type satisfies this

The test doubles (`MockJITManager`, `MockRiskManager`, `MockTenantSecurityMiddleware`) remain in `authorization_engine_test.go` because mock-free testing is structurally impossible without redesigning these three production interfaces. Resolving this requires a dedicated story targeting the `continuous` package's interface design.

## Test plan

- [x] `go test ./features/rbac/jit/...` — PASS (19.8s)
- [x] `go test ./features/rbac/continuous/...` — PASS (5ms)
- [x] `go test ./features/rbac/risk/...` — PASS (4ms)
- [x] `go test ./features/rbac/...` — all packages PASS
- [x] `make test` — all 58 script tests PASS
- [ ] QA code reviewer: PARTIAL — jit and risk files fully compliant; continuous file blocked on pre-existing interface misalignment

Fixes #1224

🤖 Generated with [Claude Code](https://claude.com/claude-code)