### PR TITLE
logging: delete root-level LogEntry, canonicalize on interfaces.LogEntry (Issue #1271)

### DIFF
--- a/pkg/logging/logger.go
+++ b/pkg/logging/logger.go
@@ -87,19 +87,6 @@ func DefaultConfig(serviceName, component string) *Config {
 	}
 }
 
-// LogEntry represents a structured log entry for JSON output.
-type LogEntry struct {
-	Timestamp     time.Time              `json:"timestamp"`
-	Level         string                 `json:"level"`
-	Message       string                 `json:"message"`
-	ServiceName   string                 `json:"service_name,omitempty"`
-	Component     string                 `json:"component,omitempty"`
-	CorrelationID string                 `json:"correlation_id,omitempty"`
-	TraceID       string                 `json:"trace_id,omitempty"`
-	SpanID        string                 `json:"span_id,omitempty"`
-	Fields        map[string]interface{} `json:"fields,omitempty"`
-}
-
 // DefaultLogger is an enhanced implementation of Logger with correlation support
 // It can use either the legacy stdout logging or the new provider system
 type DefaultLogger struct {
@@ -229,7 +216,7 @@ func (l *DefaultLogger) logEntry(ctx context.Context, level Level, levelStr, msg
 
 // logJSON outputs structured JSON logs with correlation support.
 func (l *DefaultLogger) logJSON(ctx context.Context, level, msg string, keysAndValues ...interface{}) {
-	entry := LogEntry{
+	entry := interfaces.LogEntry{
 		Timestamp:   time.Now().UTC(),
 		Level:       level,
 		Message:     SanitizeLogValue(msg),

--- a/pkg/logging/logger_test.go
+++ b/pkg/logging/logger_test.go
@@ -1,0 +1,118 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+package logging
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"log"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/cfgis/cfgms/pkg/logging/interfaces"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestLogEntryStructRemovedFromLogger confirms that the shadow LogEntry struct has been
+// deleted from logger.go and only interfaces.LogEntry is used.
+func TestLogEntryStructRemovedFromLogger(t *testing.T) {
+	data, err := os.ReadFile("logger.go")
+	require.NoError(t, err, "logger.go must be readable")
+	assert.NotContains(t, string(data), "type LogEntry struct",
+		"logger.go must not define its own LogEntry struct; use interfaces.LogEntry instead")
+}
+
+// TestLogJSONUsesInterfacesLogEntry is a compile-time assertion: if logJSON were still
+// constructing the local LogEntry the file would not compile after the struct is deleted.
+// This test verifies the JSON output produced by logJSON contains the expected fields.
+func TestLogJSONUsesInterfacesLogEntry(t *testing.T) {
+	var buf bytes.Buffer
+	l := &DefaultLogger{
+		config: &Config{
+			Level:             DebugLevel,
+			Format:            JSONFormat,
+			ServiceName:       "test-service",
+			Component:         "test-component",
+			EnableCorrelation: false,
+		},
+		log:               log.New(&buf, "", 0),
+		useProviderSystem: false,
+	}
+
+	l.logJSON(context.Background(), "INFO", "hello world")
+
+	output := strings.TrimSpace(buf.String())
+	require.NotEmpty(t, output)
+
+	var entry interfaces.LogEntry
+	err := json.Unmarshal([]byte(output), &entry)
+	require.NoError(t, err, "logJSON output must be valid JSON deserializable into interfaces.LogEntry")
+
+	assert.Equal(t, "INFO", entry.Level)
+	assert.Equal(t, "hello world", entry.Message)
+	assert.Equal(t, "test-service", entry.ServiceName)
+	assert.Equal(t, "test-component", entry.Component)
+	assert.False(t, entry.Timestamp.IsZero(), "Timestamp must be populated")
+}
+
+// TestLogJSONWithCorrelation verifies correlation/trace fields are injected via interfaces.LogEntry.
+func TestLogJSONWithCorrelation(t *testing.T) {
+	var buf bytes.Buffer
+	l := &DefaultLogger{
+		config: &Config{
+			Level:             DebugLevel,
+			Format:            JSONFormat,
+			ServiceName:       "svc",
+			Component:         "comp",
+			EnableCorrelation: true,
+		},
+		log:               log.New(&buf, "", 0),
+		useProviderSystem: false,
+	}
+
+	ctx := context.Background()
+	l.logJSON(ctx, "WARN", "something happened", "key", "value")
+
+	output := strings.TrimSpace(buf.String())
+	require.NotEmpty(t, output)
+
+	var entry interfaces.LogEntry
+	err := json.Unmarshal([]byte(output), &entry)
+	require.NoError(t, err)
+
+	assert.Equal(t, "WARN", entry.Level)
+	assert.Equal(t, "something happened", entry.Message)
+	assert.NotNil(t, entry.Fields)
+	assert.Equal(t, "value", entry.Fields["key"])
+}
+
+// TestLogJSONTimestampIsUTC verifies the timestamp in the JSON output is UTC.
+func TestLogJSONTimestampIsUTC(t *testing.T) {
+	var buf bytes.Buffer
+	l := &DefaultLogger{
+		config: &Config{
+			Level:  DebugLevel,
+			Format: JSONFormat,
+		},
+		log:               log.New(&buf, "", 0),
+		useProviderSystem: false,
+	}
+
+	before := time.Now().UTC().Add(-time.Second)
+	l.logJSON(context.Background(), "DEBUG", "tick")
+	after := time.Now().UTC().Add(time.Second)
+
+	output := strings.TrimSpace(buf.String())
+	require.NotEmpty(t, output)
+
+	var entry interfaces.LogEntry
+	require.NoError(t, json.Unmarshal([]byte(output), &entry))
+
+	assert.True(t, entry.Timestamp.After(before), "timestamp should be after test start")
+	assert.True(t, entry.Timestamp.Before(after), "timestamp should be before test end")
+	assert.Equal(t, "UTC", entry.Timestamp.Location().String())
+}


### PR DESCRIPTION
## Summary

- Deleted the shadow `type LogEntry struct` from `pkg/logging/logger.go` (was lines 90–101); it duplicated the canonical type at `pkg/logging/interfaces/provider.go:50` with a 9-field subset, creating silent drift risk
- Updated `logJSON()` to construct `interfaces.LogEntry{}` instead of the local `LogEntry{}`; `pkg/logging` already imported `pkg/logging/interfaces` so no new imports needed
- Added `pkg/logging/logger_test.go` with four tests covering the structural invariant (grep-based assertion), JSON output correctness, field population, and UTC timestamp

Fixes #1271

## Test plan

- [ ] `TestLogEntryStructRemovedFromLogger` — reads `logger.go` and asserts `type LogEntry struct` is absent
- [ ] `TestLogJSONUsesInterfacesLogEntry` — exercises `logJSON()` end-to-end, deserializes JSON into `interfaces.LogEntry`
- [ ] `TestLogJSONWithCorrelation` — verifies key-value fields appear in `Fields` map
- [ ] `TestLogJSONTimestampIsUTC` — verifies UTC timestamp within test time window
- [ ] Full `pkg/logging/...` suite passes (46+ tests)

## Specialist review results

| Reviewer | Result | Notes |
|----------|--------|-------|
| QA Test Runner | **PASS** | All 100 packages pass under `-race`; 4 new tests pass |
| QA Code Reviewer | **PASS** | No mocks, no `t.Skip()`, no hacky workarounds; all assertions load-bearing |
| Security Engineer | **PASS** | gosec 0 issues; CWE-117 sink sanitization preserved; no central provider violations |

🤖 Generated with [Claude Code](https://claude.com/claude-code)