### PR TITLE
features/rbac/ports: extract RBACManager/JITManager/RiskManager interfaces; resolve JITManager naming conflict (Issue #1277)

### DIFF
--- a/features/rbac/continuous/authorization_engine.go
+++ b/features/rbac/continuous/authorization_engine.go
@@ -9,26 +9,13 @@ import (
 	"time"
 
 	"github.com/cfgis/cfgms/api/proto/common"
+	"github.com/cfgis/cfgms/features/rbac/ports"
 )
 
-// RBACManager interface defines the RBAC operations needed by continuous authorization
-type RBACManager interface {
-	CheckPermission(ctx context.Context, request *common.AccessRequest) (*common.AccessResponse, error)
-	GetEffectivePermissions(ctx context.Context, subjectID, tenantID string) ([]*common.Permission, error)
-	GetSubjectPermissions(ctx context.Context, subjectID, tenantID string) ([]*common.Permission, error)
-	Initialize(ctx context.Context) error
-}
-
-// JITManager interface defines JIT operations needed by continuous authorization
-type JITManager interface {
-	CheckJITAccess(ctx context.Context, request *common.AccessRequest) (*common.AccessResponse, error)
-	// Add JIT methods as needed
-}
-
-// RiskManager interface defines risk operations needed by continuous authorization
-type RiskManager interface {
+// ContinuousRiskManager is session-compliance oriented and intentionally distinct from ports.RiskManager.
+// It surfaces enhanced risk checks (EnhancedRiskAccessCheck) rather than the canonical AssessRisk method.
+type ContinuousRiskManager interface {
 	EnhancedRiskAccessCheck(ctx context.Context, request *common.AccessRequest) (*RiskAccessResult, error)
-	// Add risk methods as needed
 }
 
 // RiskAccessResult represents result from risk assessment
@@ -154,9 +141,9 @@ type RiskFactor struct {
 // with dynamic permission updates and immediate revocation capabilities
 type ContinuousAuthorizationEngine struct {
 	// Core dependencies
-	rbacManager    RBACManager
-	jitManager     JITManager
-	riskManager    RiskManager
+	rbacManager    ports.RBACManager
+	jitManager     ports.JITManager
+	riskManager    ContinuousRiskManager
 	tenantSecurity TenantSecurityMiddleware
 
 	// Core components
@@ -332,9 +319,9 @@ const (
 
 // NewContinuousAuthorizationEngine creates a new continuous authorization engine
 func NewContinuousAuthorizationEngine(
-	rbacManager RBACManager,
-	jitManager JITManager,
-	riskManager RiskManager,
+	rbacManager ports.RBACManager,
+	jitManager ports.JITManager,
+	riskManager ContinuousRiskManager,
 	tenantSecurity TenantSecurityMiddleware,
 	config *ContinuousAuthConfig,
 ) *ContinuousAuthorizationEngine {
@@ -560,7 +547,7 @@ func (cae *ContinuousAuthorizationEngine) performAuthorizationCheck(ctx context.
 	// If RBAC denies, check JIT access
 	if !rbacResponse.Granted {
 		if cae.jitManager != nil {
-			jitResponse, err := cae.jitManager.CheckJITAccess(ctx, accessRequest)
+			jitResponse, err := cae.jitManager.ValidateJITAccess(ctx, accessRequest)
 			if err == nil && jitResponse != nil && jitResponse.Granted {
 				rbacResponse = jitResponse
 			}

--- a/features/rbac/continuous/authorization_engine_test.go
+++ b/features/rbac/continuous/authorization_engine_test.go
@@ -57,18 +57,18 @@ func (m *MockRBACManager) Initialize(ctx context.Context) error {
 	return m.initializeError
 }
 
-// MockJITManager implements JITManager interface for testing
+// MockJITManager implements ports.JITManager interface for testing
 type MockJITManager struct {
-	checkJITAccessResponse *common.AccessResponse
-	checkJITAccessError    error
+	validateJITAccessResponse *common.AccessResponse
+	validateJITAccessError    error
 }
 
-func (m *MockJITManager) CheckJITAccess(ctx context.Context, request *common.AccessRequest) (*common.AccessResponse, error) {
-	if m.checkJITAccessError != nil {
-		return nil, m.checkJITAccessError
+func (m *MockJITManager) ValidateJITAccess(ctx context.Context, request *common.AccessRequest) (*common.AccessResponse, error) {
+	if m.validateJITAccessError != nil {
+		return nil, m.validateJITAccessError
 	}
-	if m.checkJITAccessResponse != nil {
-		return m.checkJITAccessResponse, nil
+	if m.validateJITAccessResponse != nil {
+		return m.validateJITAccessResponse, nil
 	}
 
 	// Default no JIT access
@@ -200,11 +200,10 @@ func TestContinuousAuthorizationEngine_Start_Success(t *testing.T) {
 	ctx := context.Background()
 
 	err := engine.Start(ctx)
-
 	require.NoError(t, err)
+	assert.True(t, engine.running)
 
-	// Verify that monitoring loops are started (we can't easily test this without exposing internal state)
-	// The important thing is that Start doesn't return an error
+	t.Cleanup(func() { _ = engine.Stop() })
 }
 
 func TestContinuousAuthorizationEngine_Start_InitializationError(t *testing.T) {
@@ -304,7 +303,7 @@ func TestContinuousAuthorizationEngine_AuthorizeAction_WithJITAccess(t *testing.
 	}
 
 	engine.jitManager = &MockJITManager{
-		checkJITAccessResponse: &common.AccessResponse{
+		validateJITAccessResponse: &common.AccessResponse{
 			Granted:            true,
 			Reason:             "JIT access active",
 			AppliedPermissions: []string{"admin"},

--- a/features/rbac/continuous/context_monitor.go
+++ b/features/rbac/continuous/context_monitor.go
@@ -12,7 +12,7 @@ import (
 // ContextMonitor provides continuous monitoring of authorization context and compliance
 type ContextMonitor struct {
 	// Core dependencies
-	riskManager RiskManager
+	riskManager ContinuousRiskManager
 
 	// Context tracking
 	contextStore map[string]*AuthorizationContext // sessionID -> context
@@ -345,7 +345,7 @@ type ContextMonitorStats struct {
 }
 
 // NewContextMonitor creates a new context monitor
-func NewContextMonitor(riskManager RiskManager, checkInterval time.Duration) *ContextMonitor {
+func NewContextMonitor(riskManager ContinuousRiskManager, checkInterval time.Duration) *ContextMonitor {
 	return &ContextMonitor{
 		riskManager:     riskManager,
 		contextStore:    make(map[string]*AuthorizationContext),

--- a/features/rbac/ports/interfaces.go
+++ b/features/rbac/ports/interfaces.go
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+package ports
+
+import (
+	"context"
+
+	"github.com/cfgis/cfgms/api/proto/common"
+)
+
+// RBACManager is the canonical minimal interface shared across zerotrust, continuous, and risk subpackages.
+// It is a leaf package — it imports only context and api/proto/common — so subpackages can import it without cycles.
+type RBACManager interface {
+	CheckPermission(ctx context.Context, request *common.AccessRequest) (*common.AccessResponse, error)
+	GetEffectivePermissions(ctx context.Context, subjectID, tenantID string) ([]*common.Permission, error)
+	GetSubjectPermissions(ctx context.Context, subjectID, tenantID string) ([]*common.Permission, error)
+	Initialize(ctx context.Context) error
+}
+
+// JITManager is the canonical minimal interface for just-in-time access validation.
+// ValidateJITAccess is the canonical method name (resolves the zerotrust/continuous naming conflict).
+type JITManager interface {
+	ValidateJITAccess(ctx context.Context, request *common.AccessRequest) (*common.AccessResponse, error)
+}
+
+// RiskManager is the canonical minimal interface for risk-based access assessment.
+type RiskManager interface {
+	AssessRisk(ctx context.Context, request *common.AccessRequest) (*common.AccessResponse, error)
+}

--- a/features/rbac/ports/interfaces_test.go
+++ b/features/rbac/ports/interfaces_test.go
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+package ports_test
+
+import (
+	"github.com/cfgis/cfgms/features/rbac"
+	"github.com/cfgis/cfgms/features/rbac/ports"
+)
+
+// Compile-time assertion: rbac.Manager must satisfy ports.RBACManager.
+var _ ports.RBACManager = (*rbac.Manager)(nil)

--- a/features/rbac/risk/integration.go
+++ b/features/rbac/risk/integration.go
@@ -10,6 +10,7 @@ import (
 	"github.com/cfgis/cfgms/api/proto/common"
 	"github.com/cfgis/cfgms/features/rbac"
 	"github.com/cfgis/cfgms/features/rbac/jit"
+	"github.com/cfgis/cfgms/features/rbac/ports"
 	"github.com/cfgis/cfgms/features/rbac/zerotrust"
 	"github.com/cfgis/cfgms/features/tenant/security"
 )
@@ -37,17 +38,12 @@ type RiskBasedAccessIntegration struct {
 	zeroTrustEngine   *zerotrust.ZeroTrustPolicyEngine
 	zeroTrustEnabled  bool
 	zeroTrustRiskMode ZeroTrustRiskMode
-	baseRiskManager   RiskManager // Base risk manager for compatibility
+	baseRiskManager   ports.RiskManager // Base risk manager for compatibility
 	config            *RiskIntegrationConfig
 
 	// Continuous authorization integration
 	continuousRiskMonitor *ContinuousRiskMonitor
 	sessionRiskTracker    *SessionRiskTracker
-}
-
-// RiskManager interface for base risk assessment
-type RiskManager interface {
-	AssessRisk(ctx context.Context, request *common.AccessRequest) (*common.AccessResponse, error)
 }
 
 // RiskIntegrationConfig configuration for risk-based access integration

--- a/features/rbac/zerotrust/policy_engine.go
+++ b/features/rbac/zerotrust/policy_engine.go
@@ -12,23 +12,10 @@ import (
 	"time"
 
 	"github.com/cfgis/cfgms/api/proto/common"
+	"github.com/cfgis/cfgms/features/rbac/ports"
 	"github.com/cfgis/cfgms/pkg/audit"
 	business "github.com/cfgis/cfgms/pkg/storage/interfaces/business"
 )
-
-// External system interfaces (to avoid circular imports)
-type RBACManager interface {
-	CheckPermission(ctx context.Context, request *common.AccessRequest) (*common.AccessResponse, error)
-	GetEffectivePermissions(ctx context.Context, subjectID, tenantID string) ([]*common.Permission, error)
-}
-
-type JITManager interface {
-	ValidateJITAccess(ctx context.Context, request *common.AccessRequest) (*common.AccessResponse, error)
-}
-
-type RiskManager interface {
-	AssessRisk(ctx context.Context, request *common.AccessRequest) (*common.AccessResponse, error)
-}
 
 type ContinuousAuthManager interface {
 	ValidateContinuousAuth(ctx context.Context, request *common.AccessRequest) (*common.AccessResponse, error)
@@ -41,9 +28,9 @@ type TenantSecurityManager interface {
 // ZeroTrustPolicyEngine provides unified zero-trust policy enforcement across all authorization systems
 type ZeroTrustPolicyEngine struct {
 	// Core authorization system integrations
-	rbacManager          RBACManager
-	jitManager           JITManager
-	riskManager          RiskManager
+	rbacManager          ports.RBACManager
+	jitManager           ports.JITManager
+	riskManager          ports.RiskManager
 	continuousAuthEngine ContinuousAuthManager
 	tenantSecurityEngine TenantSecurityManager
 
@@ -329,9 +316,9 @@ func NewZeroTrustPolicyEngine(config *ZeroTrustConfig) *ZeroTrustPolicyEngine {
 
 // SetIntegrations configures the authorization system integrations
 func (z *ZeroTrustPolicyEngine) SetIntegrations(
-	rbacManager RBACManager,
-	jitManager JITManager,
-	riskManager RiskManager,
+	rbacManager ports.RBACManager,
+	jitManager ports.JITManager,
+	riskManager ports.RiskManager,
 	continuousAuthEngine ContinuousAuthManager,
 	tenantSecurityEngine TenantSecurityManager,
 ) {

--- a/features/rbac/zerotrust/policy_engine_test.go
+++ b/features/rbac/zerotrust/policy_engine_test.go
@@ -913,6 +913,20 @@ func (m *mockRBACManagerWithError) GetEffectivePermissions(ctx context.Context, 
 	return []*common.Permission{{Id: "test-permission", Name: "Test Permission"}}, nil
 }
 
+func (m *mockRBACManagerWithError) GetSubjectPermissions(ctx context.Context, subjectID, tenantID string) ([]*common.Permission, error) {
+	if m.shouldError {
+		return nil, errors.New("RBAC system unavailable")
+	}
+	return []*common.Permission{{Id: "test-permission", Name: "Test Permission"}}, nil
+}
+
+func (m *mockRBACManagerWithError) Initialize(ctx context.Context) error {
+	if m.shouldError {
+		return errors.New("RBAC system unavailable")
+	}
+	return nil
+}
+
 func (m *mockRBACManagerWithError) SetError(shouldError bool) {
 	m.shouldError = shouldError
 }
@@ -979,6 +993,19 @@ func (m *mockRBACManager) GetEffectivePermissions(ctx context.Context, subjectID
 			Name: "Test Permission",
 		},
 	}, nil
+}
+
+func (m *mockRBACManager) GetSubjectPermissions(ctx context.Context, subjectID, tenantID string) ([]*common.Permission, error) {
+	return []*common.Permission{
+		{
+			Id:   "test-permission",
+			Name: "Test Permission",
+		},
+	}, nil
+}
+
+func (m *mockRBACManager) Initialize(ctx context.Context) error {
+	return nil
 }
 
 type mockJITManager struct{}


### PR DESCRIPTION
## Summary

- Creates `features/rbac/ports/interfaces.go` as the canonical leaf package for the three shared interfaces (`RBACManager` with 4 methods, `JITManager` with `ValidateJITAccess`, `RiskManager` with `AssessRisk`) — imports only `context` and `api/proto/common`, no cycles possible
- Removes six local duplicate interface declarations across `zerotrust/`, `continuous/`, and `risk/`, replacing with `ports.*` types
- Resolves the `JITManager` naming conflict: `continuous` used `CheckJITAccess`, `zerotrust` used `ValidateJITAccess` — `ValidateJITAccess` is now canonical; call site in `authorization_engine.go` updated to match
- Renames `continuous.RiskManager` → `ContinuousRiskManager` (session-compliance oriented, distinct from `ports.RiskManager` which exposes `AssessRisk`) with explanatory comment
- Adds compile-time assertion `var _ ports.RBACManager = (*rbac.Manager)(nil)` in `ports/interfaces_test.go`

Fixes #1277

## Acceptance Criteria Verified

1. ✅ `features/rbac/ports/interfaces.go` exists with `RBACManager` (4 methods), `JITManager` (`ValidateJITAccess`), `RiskManager` (`AssessRisk`)
2. ✅ `zerotrust/policy_engine.go` — no local `type RBACManager`, `type JITManager`, `type RiskManager`
3. ✅ `continuous/authorization_engine.go` — no local `RBACManager`/`JITManager`; risk interface renamed to `ContinuousRiskManager` with comment
4. ✅ `continuous/context_monitor.go` — uses `ContinuousRiskManager`
5. ✅ `risk/integration.go` — no local `RiskManager`; `baseRiskManager` typed to `ports.RiskManager`
6. ✅ `ports/interfaces_test.go` compile-time assertion compiles; all 97 test packages pass

## Specialist Review Results

**QA Test Runner: PASS**
- 97 packages, all passing
- `features/rbac/ports`, `zerotrust`, `continuous`, `risk` all green
- Trivy DB download skipped (no outbound network in agent sandbox; passes in CI)

**Security Engineer: PASS**
- security-precommit: PASS (no secrets)
- check-architecture: PASS (no central provider violations)
- security-scan (gosec, staticcheck): PASS
- No hardcoded secrets, SQL injection, TLS issues, or tenant isolation regressions
- Tenant scoping (`tenantID` parameters) preserved in all interface signatures

**QA Code Reviewer: findings are pre-existing technical debt**
The reviewer identified mock patterns in `continuous/` and `zerotrust/` test files. These existed before this story — this story only renamed `CheckJITAccess→ValidateJITAccess` and added two stub methods to existing mocks to satisfy the expanded interface. The reviewer also flagged `jit/` package issues which the story explicitly excludes from scope. One legitimate in-scope finding was fixed: goroutine leak in `TestContinuousAuthorizationEngine_Start_Success` (added `t.Cleanup` + `engine.running` assertion). Pre-existing mock patterns are tracked as technical debt for Epic #738 follow-on stories.

## Test Plan

- [x] `go test ./features/rbac/...` — all 9 packages pass
- [x] `go build ./features/rbac/ports/...` — no import cycles
- [x] Compile-time assertion `var _ ports.RBACManager = (*rbac.Manager)(nil)` compiles
- [x] Race detection: `go test -race ./features/rbac/continuous/...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)