### PR TITLE
m365/gdap: extract gdap/types leaf package; delete saas-side copies (Issue #1273)

### DIFF
--- a/features/modules/m365/gdap/gdap_provider.go
+++ b/features/modules/m365/gdap/gdap_provider.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/cfgis/cfgms/features/modules/m365/auth"
+	gdaptypes "github.com/cfgis/cfgms/features/modules/m365/gdap/types"
 	"github.com/cfgis/cfgms/features/saas"
 )
 
@@ -116,34 +117,20 @@ type GDAPConfig struct {
 	RequireActiveRelationship bool `json:"require_active_relationship"`
 }
 
-// GDAPRelationship represents a GDAP relationship with a customer tenant
-type GDAPRelationship struct {
-	RelationshipID   string                 `json:"relationship_id"`
-	CustomerTenantID string                 `json:"customer_tenant_id"`
-	CustomerName     string                 `json:"customer_name"`
-	Status           GDAPRelationshipStatus `json:"status"`
-	Roles            []GDAPRole             `json:"roles"`
-	ExpiresAt        time.Time              `json:"expires_at"`
-	CreatedAt        time.Time              `json:"created_at"`
-	LastModified     time.Time              `json:"last_modified"`
-}
-
-// GDAPRelationshipStatus represents the status of a GDAP relationship
-type GDAPRelationshipStatus string
-
-const (
-	GDAPStatusPending    GDAPRelationshipStatus = "pending"
-	GDAPStatusActive     GDAPRelationshipStatus = "active"
-	GDAPStatusExpired    GDAPRelationshipStatus = "expired"
-	GDAPStatusTerminated GDAPRelationshipStatus = "terminated"
+// Type aliases re-export the canonical types from gdaptypes so existing
+// code in this package compiles without modification.
+type (
+	GDAPRelationship       = gdaptypes.GDAPRelationship
+	GDAPRelationshipStatus = gdaptypes.GDAPRelationshipStatus
+	GDAPRole               = gdaptypes.GDAPRole
 )
 
-// GDAPRole represents a role assignment within a GDAP relationship
-type GDAPRole struct {
-	RoleDefinitionID string `json:"role_definition_id"`
-	RoleName         string `json:"role_name"`
-	RoleDescription  string `json:"role_description"`
-}
+const (
+	GDAPStatusPending    = gdaptypes.GDAPStatusPending
+	GDAPStatusActive     = gdaptypes.GDAPStatusActive
+	GDAPStatusExpired    = gdaptypes.GDAPStatusExpired
+	GDAPStatusTerminated = gdaptypes.GDAPStatusTerminated
+)
 
 // DiscoverGDAPCustomers discovers customer tenants accessible via GDAP
 func (p *GDAPProvider) DiscoverGDAPCustomers(ctx context.Context) ([]GDAPRelationship, error) {

--- a/features/modules/m365/gdap/types/types.go
+++ b/features/modules/m365/gdap/types/types.go
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+// Package gdaptypes defines the canonical types for GDAP (Granular Delegated
+// Admin Privileges) operations shared between the saas and gdap packages.
+// It imports only standard library packages to avoid import cycles.
+package gdaptypes
+
+import (
+	"context"
+	"time"
+)
+
+// GDAPRelationshipStatus represents the status of a GDAP relationship.
+type GDAPRelationshipStatus string
+
+const (
+	GDAPStatusPending    GDAPRelationshipStatus = "pending"
+	GDAPStatusActive     GDAPRelationshipStatus = "active"
+	GDAPStatusExpired    GDAPRelationshipStatus = "expired"
+	GDAPStatusTerminated GDAPRelationshipStatus = "terminated"
+)
+
+// GDAPRole represents a role assignment within a GDAP relationship.
+type GDAPRole struct {
+	RoleDefinitionID string `json:"role_definition_id"`
+	RoleName         string `json:"role_name"`
+	RoleDescription  string `json:"role_description"`
+}
+
+// GDAPRelationship represents a GDAP relationship with a customer tenant.
+type GDAPRelationship struct {
+	RelationshipID   string                 `json:"relationship_id"`
+	CustomerTenantID string                 `json:"customer_tenant_id"`
+	CustomerName     string                 `json:"customer_name"`
+	Status           GDAPRelationshipStatus `json:"status"`
+	Roles            []GDAPRole             `json:"roles"`
+	ExpiresAt        time.Time              `json:"expires_at"`
+	CreatedAt        time.Time              `json:"created_at"`
+	LastModified     time.Time              `json:"last_modified"`
+}
+
+// GDAPProvider defines the interface for GDAP relationship discovery and validation.
+type GDAPProvider interface {
+	DiscoverGDAPCustomers(ctx context.Context) ([]GDAPRelationship, error)
+	ValidateGDAPAccess(ctx context.Context, customerTenantID string, requiredRoles []string) (*GDAPRelationship, error)
+}

--- a/features/modules/m365/gdap/types/types_test.go
+++ b/features/modules/m365/gdap/types/types_test.go
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+package gdaptypes_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	gdaptypes "github.com/cfgis/cfgms/features/modules/m365/gdap/types"
+)
+
+// compile-time assertion: mockProvider implements GDAPProvider
+type mockProvider struct{}
+
+func (m *mockProvider) DiscoverGDAPCustomers(_ context.Context) ([]gdaptypes.GDAPRelationship, error) {
+	return nil, nil
+}
+
+func (m *mockProvider) ValidateGDAPAccess(_ context.Context, _ string, _ []string) (*gdaptypes.GDAPRelationship, error) {
+	return nil, nil
+}
+
+var _ gdaptypes.GDAPProvider = (*mockProvider)(nil)
+
+func TestGDAPRelationshipFields(t *testing.T) {
+	expires := time.Now().Add(30 * 24 * time.Hour)
+	created := time.Now().Add(-7 * 24 * time.Hour)
+
+	rel := gdaptypes.GDAPRelationship{
+		RelationshipID:   "rel-abc",
+		CustomerTenantID: "tenant-xyz",
+		CustomerName:     "Contoso Ltd",
+		Status:           gdaptypes.GDAPStatusActive,
+		Roles: []gdaptypes.GDAPRole{
+			{RoleDefinitionID: "62e90394-69f5-4237-9190-012177145e10", RoleName: "Global Administrator"},
+		},
+		ExpiresAt:    expires,
+		CreatedAt:    created,
+		LastModified: created,
+	}
+
+	assert.Equal(t, "rel-abc", rel.RelationshipID)
+	assert.Equal(t, "tenant-xyz", rel.CustomerTenantID)
+	assert.Equal(t, "Contoso Ltd", rel.CustomerName)
+	assert.Equal(t, gdaptypes.GDAPStatusActive, rel.Status)
+	assert.Len(t, rel.Roles, 1)
+	assert.Equal(t, "Global Administrator", rel.Roles[0].RoleName)
+	assert.Equal(t, expires, rel.ExpiresAt)
+}
+
+func TestGDAPRelationshipStatusConstants(t *testing.T) {
+	assert.Equal(t, gdaptypes.GDAPRelationshipStatus("pending"), gdaptypes.GDAPStatusPending)
+	assert.Equal(t, gdaptypes.GDAPRelationshipStatus("active"), gdaptypes.GDAPStatusActive)
+	assert.Equal(t, gdaptypes.GDAPRelationshipStatus("expired"), gdaptypes.GDAPStatusExpired)
+	assert.Equal(t, gdaptypes.GDAPRelationshipStatus("terminated"), gdaptypes.GDAPStatusTerminated)
+}
+
+func TestGDAPRoleFields(t *testing.T) {
+	role := gdaptypes.GDAPRole{
+		RoleDefinitionID: "role-def-id",
+		RoleName:         "User Administrator",
+		RoleDescription:  "Manages users and groups",
+	}
+
+	assert.Equal(t, "role-def-id", role.RoleDefinitionID)
+	assert.Equal(t, "User Administrator", role.RoleName)
+	assert.Equal(t, "Manages users and groups", role.RoleDescription)
+}

--- a/features/saas/m365_tenant_manager.go
+++ b/features/saas/m365_tenant_manager.go
@@ -14,30 +14,16 @@ import (
 	"time"
 
 	"github.com/cfgis/cfgms/features/modules/m365/auth"
+	gdaptypes "github.com/cfgis/cfgms/features/modules/m365/gdap/types"
 	"github.com/cfgis/cfgms/features/tenant"
 )
-
-// GDAPProvider defines the interface for GDAP operations (avoids import cycle)
-type GDAPProvider interface {
-	DiscoverGDAPCustomers(ctx context.Context) ([]GDAPRelationship, error)
-	ValidateGDAPAccess(ctx context.Context, customerTenantID string, requiredRoles []string) (*GDAPRelationship, error)
-}
-
-// GDAPRelationship represents a GDAP relationship (copied to avoid import cycle)
-type GDAPRelationship struct {
-	RelationshipID   string
-	CustomerTenantID string
-	CustomerName     string
-	Status           string // "active", "pending", "expired", "terminated"
-	ExpiresAt        time.Time
-}
 
 // M365TenantManager integrates M365 multi-tenant capabilities with CFGMS tenant management
 type M365TenantManager struct {
 	cfgmsTenantManager *tenant.Manager
 	m365Provider       *MicrosoftMultiTenantProvider
 	adminConsentFlow   *auth.AdminConsentFlow
-	gdapProvider       GDAPProvider
+	gdapProvider       gdaptypes.GDAPProvider
 	httpClient         *http.Client
 	m365IDIndex        map[string]string // maps m365TenantID → cfgmsTenantID; nil means unpopulated
 	indexMu            sync.Mutex
@@ -48,7 +34,7 @@ func NewM365TenantManager(
 	cfgmsTenantManager *tenant.Manager,
 	m365Provider *MicrosoftMultiTenantProvider,
 	adminConsentFlow *auth.AdminConsentFlow,
-	gdapProvider GDAPProvider,
+	gdapProvider gdaptypes.GDAPProvider,
 ) *M365TenantManager {
 	return &M365TenantManager{
 		cfgmsTenantManager: cfgmsTenantManager,
@@ -79,7 +65,7 @@ func (m *M365TenantManager) DiscoverAndSyncTenants(ctx context.Context, discover
 			tenants = append(tenants, TenantInfo{
 				TenantID:    rel.CustomerTenantID,
 				DisplayName: rel.CustomerName,
-				HasAccess:   rel.Status == "active",
+				HasAccess:   rel.Status == gdaptypes.GDAPStatusActive,
 			})
 		}
 	default:
@@ -515,7 +501,7 @@ func (m *M365TenantManager) checkGDAPRelationship(ctx context.Context, m365Tenan
 		}
 	}
 
-	if relationship.Status != "active" {
+	if relationship.Status != gdaptypes.GDAPStatusActive {
 		return HealthCheckResult{
 			Name:    "gdap_relationship",
 			Status:  tenant.HealthStatusDegraded,

--- a/features/saas/m365_tenant_manager_test.go
+++ b/features/saas/m365_tenant_manager_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/cfgis/cfgms/features/modules/m365/auth"
+	gdaptypes "github.com/cfgis/cfgms/features/modules/m365/gdap/types"
 	"github.com/cfgis/cfgms/features/tenant"
 )
 
@@ -122,7 +123,7 @@ func setupTestManager(t *testing.T) (*M365TenantManager, *mockTenantStore, conte
 	var adminConsentFlow *auth.AdminConsentFlow
 
 	// Create GDAP provider (can be nil for basic tests)
-	var gdapProvider GDAPProvider
+	var gdapProvider gdaptypes.GDAPProvider
 
 	// Create M365 tenant manager
 	manager := NewM365TenantManager(
@@ -609,14 +610,14 @@ func TestM365TenantManager_GetTenantByM365ID_ListTenantsError(t *testing.T) {
 
 // mockGDAPProvider is a test-local GDAP implementation for benchmark setup.
 type mockGDAPProvider struct {
-	relationships []GDAPRelationship
+	relationships []gdaptypes.GDAPRelationship
 }
 
-func (m *mockGDAPProvider) DiscoverGDAPCustomers(_ context.Context) ([]GDAPRelationship, error) {
+func (m *mockGDAPProvider) DiscoverGDAPCustomers(_ context.Context) ([]gdaptypes.GDAPRelationship, error) {
 	return m.relationships, nil
 }
 
-func (m *mockGDAPProvider) ValidateGDAPAccess(_ context.Context, customerTenantID string, _ []string) (*GDAPRelationship, error) {
+func (m *mockGDAPProvider) ValidateGDAPAccess(_ context.Context, customerTenantID string, _ []string) (*gdaptypes.GDAPRelationship, error) {
 	for i := range m.relationships {
 		if m.relationships[i].CustomerTenantID == customerTenantID {
 			return &m.relationships[i], nil
@@ -629,13 +630,13 @@ func BenchmarkM365TenantManager_DiscoverAndSyncTenants(b *testing.B) {
 	ctx := context.Background()
 	const n = 100
 
-	relationships := make([]GDAPRelationship, n)
+	relationships := make([]gdaptypes.GDAPRelationship, n)
 	for i := range n {
-		relationships[i] = GDAPRelationship{
+		relationships[i] = gdaptypes.GDAPRelationship{
 			RelationshipID:   fmt.Sprintf("rel-%d", i),
 			CustomerTenantID: fmt.Sprintf("m365-bench-%d", i),
 			CustomerName:     fmt.Sprintf("Bench Tenant %d", i),
-			Status:           "active",
+			Status:           gdaptypes.GDAPStatusActive,
 			ExpiresAt:        time.Now().Add(365 * 24 * time.Hour),
 		}
 	}


### PR DESCRIPTION
## Summary

- Introduces `features/modules/m365/gdap/types` — a stdlib-only leaf package with canonical `GDAPRelationship`, `GDAPRelationshipStatus` constants, `GDAPRole`, and `GDAPProvider` interface
- Removes the duplicate local `GDAPProvider` interface and `GDAPRelationship` struct from `features/saas/m365_tenant_manager.go` (previously marked "copied to avoid import cycle")
- Migrates `features/saas` and `features/modules/m365/gdap` to import from `gdaptypes`; upgrades bare `"active"` string comparisons to the typed constant `gdaptypes.GDAPStatusActive`

Fixes #1273

## Why

`features/saas` held a copy of `GDAPRelationship` and `GDAPProvider` solely to break an import cycle. The saas copy used `Status string` while the canonical gdap copy used `GDAPRelationshipStatus` — a latent divergence. The `gdaptypes` leaf package resolves the cycle structurally: it imports only stdlib, so both `saas` and `gdap` can safely import it.

## Files changed

| File | Change |
|------|--------|
| `features/modules/m365/gdap/types/types.go` | NEW — canonical types, stdlib only |
| `features/modules/m365/gdap/types/types_test.go` | NEW — compile-time assertion + field/constant exercises |
| `features/modules/m365/gdap/gdap_provider.go` | Type aliases + const re-exports pointing to gdaptypes |
| `features/saas/m365_tenant_manager.go` | Delete local declarations; import gdaptypes; typed status comparisons |
| `features/saas/m365_tenant_manager_test.go` | Import + type reference updates only |

## Specialist Review Results

| Reviewer | Result | Notes |
|----------|--------|-------|
| Security Engineer | **PASS** | No secrets, no violations, architecture check clean |
| QA Code Reviewer | **PASS** | No blocking issues introduced by this PR |
| QA Test Runner | **PASS** (code quality) | All unit tests, lint, license, cross-platform builds, architecture checks pass; Trivy DB download blocked by container DNS isolation (infrastructure constraint, not code defect) |

## Test plan

- [ ] `go test ./features/modules/m365/gdap/types/...` — new package tests pass
- [ ] `go test ./features/modules/m365/gdap/...` — existing gdap tests unaffected
- [ ] `go test ./features/saas/...` — saas tests unaffected
- [ ] `make check-architecture` — no central provider violations
- [ ] CI required checks: unit-tests, integration-tests, Build Gate, security-deployment-gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)