### PR TITLE
fix: unstick develop — breach-detector test + script literal-param resolution

### DIFF
--- a/features/modules/script/executor.go
+++ b/features/modules/script/executor.go
@@ -69,7 +69,7 @@ func (e *Executor) Execute(ctx context.Context) (*ExecutionResult, error) {
 	//   literal       → strings.ToUpper(param.Name) on all platforms — no secret
 	//                   prefix because the value is not a credential
 	var secretEnvEntries []string
-	if e.secretStore != nil && len(e.secretBindings) > 0 {
+	if len(e.secretBindings) > 0 {
 		resolved, err := ResolveSecretBindings(ctx, e.secretStore, e.secretBindings)
 		if err != nil {
 			return nil, fmt.Errorf("secret injection blocked: %w", err)

--- a/features/modules/script/param_binding.go
+++ b/features/modules/script/param_binding.go
@@ -56,6 +56,9 @@ func ResolveSecretBindings(ctx context.Context, store interfaces.SecretStore, bi
 			if binding.Key == "" {
 				return nil, fmt.Errorf("param %q: key is required for from: secret-store", binding.Name)
 			}
+			if store == nil {
+				return nil, fmt.Errorf("param %q: secret-store binding requires a non-nil secret store", binding.Name)
+			}
 			secret, err := store.GetSecret(ctx, binding.Key)
 			if err != nil {
 				return nil, fmt.Errorf("secret resolution failed for param %q (key %q): %w", binding.Name, binding.Key, err)

--- a/features/tenant/security/breach_detector_test.go
+++ b/features/tenant/security/breach_detector_test.go
@@ -253,8 +253,13 @@ func TestBreachDetector_TimePatternDetection(t *testing.T) {
 
 	tenantID := "550e8400-e29b-41d4-a716-446655440000"
 
-	// Establish baseline during business hours (9 AM - 5 PM)
-	baseDate := time.Now().Add(-24 * time.Hour)
+	// Establish baseline during business hours (9 AM - 5 PM).
+	// Use absolute clock hours via time.Date so updateActiveHours converges to 9-17.
+	// time.Now().Add(N*time.Hour) was wrong here: it adds N hours to the current
+	// clock time (yesterday-at-now-hour + N), not "yesterday at hour N" — when the
+	// test ran at 14:35 the baseline populated hours 23,0-7 instead of 9-17 and the
+	// 2 AM "out-of-hours" event below fell inside the detected active range.
+	yesterday := time.Now().Add(-24 * time.Hour)
 	for hour := 9; hour <= 17; hour++ {
 		for i := 0; i < 5; i++ {
 			event := &security.AccessEvent{
@@ -264,7 +269,7 @@ func TestBreachDetector_TimePatternDetection(t *testing.T) {
 				Resource:  "/api/v1/configs",
 				SourceIP:  "192.168.1.100",
 				UserAgent: "Business-Client/1.0",
-				Timestamp: baseDate.Add(time.Duration(hour) * time.Hour).Add(time.Duration(i*10) * time.Minute),
+				Timestamp: time.Date(yesterday.Year(), yesterday.Month(), yesterday.Day(), hour, i*10, 0, 0, yesterday.Location()),
 				Success:   true,
 			}
 			err := bd.RecordAccess(ctx, event)


### PR DESCRIPTION
## Summary

Two unrelated tests are failing on `origin/develop`, blocking the merge queue. This PR fixes both so the seven PRs currently sitting in the queue (#1270, #1267, #1249, #1230, #1290, #1297, #1287) can drain.

Both bugs were diagnosed during a local pull of PR #1282, which was repeatedly kicked back from the merge queue with `Native Build` red. The `Native Build` failures were **not** caused by #1282 — every CI failure traces to one of these two pre-existing tests.

## Bugs and fixes

### 1. `script: resolve literal param bindings without a secret store`

`features/modules/script/executor.go:72` gated **all** param resolution on `e.secretStore != nil`. An executor created with `NewExecutorWithSecrets(config, nil, bindings)` would never inject literal-binding values into the child env even though literal bindings don't require a secret store. The script ran with no `APIURL` env var → `TestExecutorWithSecrets_LiteralParamUsesPlainName` failed with `"" does not contain "https://example.com"`.

- Drop the `secretStore != nil` gate (literal bindings stand on their own).
- Add a defensive nil-store guard inside `ResolveSecretBindings` so a `from: secret-store` binding with no store fails cleanly instead of panicking on `store.GetSecret`.

### 2. `test(tenant/security): use absolute clock hours in TimePatternDetection baseline`

`TestBreachDetector_TimePatternDetection` seeded its 9-17 baseline with `baseDate.Add(N*time.Hour)` where `baseDate = time.Now() - 24h`. That adds N hours to the current clock time (yesterday-at-now-hour + N), not "yesterday at hour N". When the test ran at 14:35 UTC the baseline actually populated clock hours `23, 0-7`; `updateActiveHours` converged to `{Start:0, End:8}`; the 2 AM "out-of-hours" event below fell *inside* the detected active range; assertion `riskScoreAfter > riskScoreBefore` failed with both at 0.15.

Use `time.Date(year, month, day, hour, ...)` so the baseline timestamps land on literal hours 9-17, `updateActiveHours` converges to a 9-17 window, and the 2 AM event correctly registers as out-of-hours (firing `SuspiciousTimeAccess` and bumping the risk score).

The test was made external by issue #1225 / PR #1252 which exposed the pre-existing bug in test setup logic.

## Verification

```
go test -count=1 -run TestBreachDetector_TimePatternDetection ./features/tenant/security/  → PASS
go test -count=1 -run TestExecutorWithSecrets_LiteralParamUsesPlainName ./features/modules/script/  → PASS
go test -count=1 ./features/tenant/security/  → ok (10.6s)
go test -count=1 ./features/modules/script/  → ok (3.4s)
make check-architecture  → ✅ no violations
go build ./...  → ok
```

Wider `go test ./features/... ./pkg/... ./cmd/... ./commercial/... ./api/...` is green except for M365 integration tests gated on `M365_CLIENT_ID`/`M365_CLIENT_SECRET`/`M365_TENANT_ID` (pre-existing, also not run in CI's unit-tests job).

## Test plan

- [ ] `Native Build (ubuntu-latest)` passes
- [ ] `Native Build (macos-latest)` passes
- [ ] `Native Build (windows-latest)` passes
- [ ] `unit-tests` passes
- [ ] `Build Gate` passes
- [ ] Once merged: re-enqueue any of the 7 stuck PRs that fall out of the queue automatically; manual `gh pr merge --squash` for any that don't

🤖 Generated with [Claude Code](https://claude.com/claude-code)