### PR TITLE
build: wire check-providers.sh into make check-architecture (Issue #1289)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -493,6 +493,9 @@ check-architecture:
 		echo ""; \
 		exit 1; \
 	fi
+	@echo ""
+	@echo "📦 Checking storage provider import violations..."
+	@bash ./scripts/check-providers.sh
 	@echo "   Safe to commit - no secrets detected in staged files"
 
 # License Header Verification

--- a/features/tenant/security/breach_detector_test.go
+++ b/features/tenant/security/breach_detector_test.go
@@ -15,21 +15,27 @@ import (
 	"github.com/cfgis/cfgms/features/tenant/security"
 	"github.com/cfgis/cfgms/pkg/audit"
 	"github.com/cfgis/cfgms/pkg/storage/interfaces"
-	_ "github.com/cfgis/cfgms/pkg/storage/providers/flatfile"
-	_ "github.com/cfgis/cfgms/pkg/storage/providers/sqlite"
+	pkgtesting "github.com/cfgis/cfgms/pkg/testing"
 )
 
 // newTestAuditManager creates a real audit.Manager backed by OSS storage for tests.
 // Accepts testing.TB so it works in both *testing.T and *testing.B contexts.
 func newTestAuditManager(tb testing.TB) *audit.Manager {
 	tb.Helper()
+	if t, ok := tb.(*testing.T); ok {
+		return pkgtesting.SetupTestAuditManager(t)
+	}
+	// *testing.B path: construct directly; providers are registered via pkgtesting import.
 	tmpDir := tb.TempDir()
 	sm, err := interfaces.CreateOSSStorageManager(tmpDir+"/flatfile", tmpDir+"/cfgms.db")
-	require.NoError(tb, err)
+	if err != nil {
+		tb.Fatalf("CreateOSSStorageManager: %v", err)
+	}
 	tb.Cleanup(func() { _ = sm.Close() })
-
 	mgr, err := audit.NewManager(sm.GetAuditStore(), "tenant-security-test")
-	require.NoError(tb, err)
+	if err != nil {
+		tb.Fatalf("audit.NewManager: %v", err)
+	}
 	tb.Cleanup(func() {
 		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 		defer cancel()

--- a/scripts/check-providers.sh
+++ b/scripts/check-providers.sh
@@ -32,6 +32,7 @@ is_allowed() {
     [[ "$file" == cmd/cfg/cmd/storage.go ]] && return 0
     [[ "$file" == features/controller/initialization/initialization.go ]] && return 0
     [[ "$file" == features/controller/server/server.go ]] && return 0
+    [[ "$file" == */providers_test.go ]] && return 0
     return 1
 }
 
@@ -69,5 +70,6 @@ else
     echo "  cmd/cfg/cmd/storage.go                                      (CLI registry bootstrap)"
     echo "  features/controller/initialization/initialization.go        (registry bootstrap)"
     echo "  features/controller/server/server.go                        (registry bootstrap)"
+    echo "  */providers_test.go                                         (per-package test provider registration)"
     exit 1
 fi

--- a/scripts/test-scripts.sh
+++ b/scripts/test-scripts.sh
@@ -478,6 +478,8 @@ GOEOF
         "cmd/cfg/cmd/storage.go"
         "features/controller/initialization/initialization.go"
         "features/controller/server/server.go"
+        "features/rbac/continuous/providers_test.go"
+        "pkg/audit/providers_test.go"
     )
     local allowed_file
     for allowed_file in "${allowed_paths[@]}"; do


### PR DESCRIPTION
## Summary

- **Epic #731 AC #2**: `make check-architecture` now invokes `scripts/check-providers.sh` and propagates its exit code — provider bypass violations fail the build.
- Extended `check-providers.sh` allowlist with `*/providers_test.go` (consolidated per-package test provider registration; established by stories #1205/#1207).
- Migrated `features/tenant/security/breach_detector_test.go` to `pkgtesting.SetupTestAuditManager(t)`, eliminating the 2 blank provider imports missed by #1208.
- Added 2 test cases to `scripts/test-scripts.sh` covering the new allowlist pattern.

Fixes #1289

## Acceptance Criteria Verification

| AC | Status | Evidence |
|----|--------|---------|
| `check-providers.sh` exits non-zero when violations exist | ✅ | Injection test: added `_ ".../providers/git"` to `features/monitoring/collectors.go`; `make check-architecture` exited 2. Reverted; exited 0. |
| `check-providers.sh` allowlist includes `*/providers_test.go` | ✅ | `is_allowed()` entry added; 9 AC-4 test cases in `test-scripts.sh` all pass |
| `make check-architecture` invokes `check-providers.sh` and propagates exit code | ✅ | Makefile `check-architecture` target extended; verified in injection test |
| On post-#1208 develop HEAD, `make check-architecture` exits 0 | ✅ | Runs clean on this branch |
| New provider blank import outside allowlist → `make check-architecture` exits non-zero | ✅ | Confirmed via injection test |
| `breach_detector_test.go` migrated to `pkgtesting.SetupTestStorage(t)` | ✅ | Uses `pkgtesting.SetupTestAuditManager(t)` for `*testing.T`; `*testing.B` path uses direct construction with providers registered via pkgtesting import |
| Injection verification documented | ✅ | See above |
| `make test-complete` passes | ✅ | 53/53 script tests, all Go tests pass; Trivy skipped (network isolation in container) |

## Specialist Review Results

**QA Test Runner**: PASS — all unit tests pass, 53/53 script tests pass, `check-architecture` clean. Trivy network-isolation failure is a known container limitation, not a code issue.

**QA Code Reviewer**: PASS — no mocks, no `t.Skip()`, no hardcoded secrets, no provider violations. Two non-blocking warnings noted (pre-existing cosmetic label and benchmark error discard — both out of story scope).

**Security Engineer**: PASS — `*/providers_test.go` glob is safe: requires a directory prefix, cannot match production code, matches only `_test.go` files excluded from binaries. No security issues in migration or Makefile wiring.

## Files Changed

- `scripts/check-providers.sh` — `*/providers_test.go` to `is_allowed()`, help text updated
- `Makefile` — `check-architecture` target extended to call `check-providers.sh`
- `features/tenant/security/breach_detector_test.go` — blank imports removed, `pkgtesting` migration
- `scripts/test-scripts.sh` — 2 new allowlist test cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)