### PR TITLE
test: remove mockCredentialStore from TestGDAPConfig (Issue #1260)

### DIFF
--- a/features/modules/m365/gdap/gdap_provider_test.go
+++ b/features/modules/m365/gdap/gdap_provider_test.go
@@ -8,94 +8,15 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
-
-	"github.com/cfgis/cfgms/features/modules/m365/auth"
 )
 
-// mockCredentialStore implements auth.CredentialStore for testing
-type mockCredentialStore struct {
-	tokens map[string]*auth.AccessToken
-}
-
-func newMockCredentialStore() *mockCredentialStore {
-	return &mockCredentialStore{
-		tokens: make(map[string]*auth.AccessToken),
-	}
-}
-
-func (m *mockCredentialStore) StoreToken(tenantID string, token *auth.AccessToken) error {
-	m.tokens[tenantID] = token
-	return nil
-}
-
-func (m *mockCredentialStore) GetToken(tenantID string) (*auth.AccessToken, error) {
-	if token, exists := m.tokens[tenantID]; exists {
-		return token, nil
-	}
-	return nil, auth.ErrTokenNotFound
-}
-
-func (m *mockCredentialStore) DeleteToken(tenantID string) error {
-	delete(m.tokens, tenantID)
-	return nil
-}
-
-func (m *mockCredentialStore) StoreDelegatedToken(tenantID, userID string, token *auth.AccessToken) error {
-	key := tenantID + ":" + userID
-	m.tokens[key] = token
-	return nil
-}
-
-func (m *mockCredentialStore) GetDelegatedToken(tenantID, userID string) (*auth.AccessToken, error) {
-	key := tenantID + ":" + userID
-	if token, exists := m.tokens[key]; exists {
-		return token, nil
-	}
-	return nil, auth.ErrTokenNotFound
-}
-
-func (m *mockCredentialStore) DeleteDelegatedToken(tenantID, userID string) error {
-	key := tenantID + ":" + userID
-	delete(m.tokens, key)
-	return nil
-}
-
-func (m *mockCredentialStore) StoreUserContext(tenantID, userID string, userContext *auth.UserContext) error {
-	return nil // Not used in this test
-}
-
-func (m *mockCredentialStore) GetUserContext(tenantID, userID string) (*auth.UserContext, error) {
-	return nil, auth.ErrTokenNotFound // Not used in this test
-}
-
-func (m *mockCredentialStore) DeleteUserContext(tenantID, userID string) error {
-	return nil // Not used in this test
-}
-
-// Add missing GetConfig method for full auth.CredentialStore compatibility
-func (m *mockCredentialStore) GetConfig(tenantID string) (*auth.OAuth2Config, error) {
-	return nil, auth.ErrTokenNotFound
-}
-
-func (m *mockCredentialStore) StoreConfig(tenantID string, config *auth.OAuth2Config) error {
-	return nil
-}
-
-func (m *mockCredentialStore) DeleteConfig(tenantID string) error {
-	return nil
-}
-
-// IsAvailable checks if the credential store is available
-func (m *mockCredentialStore) IsAvailable() bool {
-	return true
-}
-
 func TestGDAPConfig(t *testing.T) {
-	credStore := newMockCredentialStore()
-	httpClient := &http.Client{}
+	httpClient := &http.Client{Timeout: 30 * time.Second}
 	partnerTenantID := "partner-tenant-123"
 
-	provider := NewGDAPProvider(credStore, httpClient, partnerTenantID)
+	// ValidateGDAPConfig only inspects GDAPConfig fields; it never reads the
+	// credential store, so nil is safe here.
+	provider := NewGDAPProvider(nil, httpClient, partnerTenantID)
 
 	t.Run("ValidateGDAPConfigSuccess", func(t *testing.T) {
 		config := &GDAPConfig{

--- a/features/modules/m365/gdap/gdap_simple_test.go
+++ b/features/modules/m365/gdap/gdap_simple_test.go
@@ -194,9 +194,10 @@ func TestGDAPRoleRequirements(t *testing.T) {
 	})
 
 	t.Run("UnknownResourceDefault", func(t *testing.T) {
-		// Test that unknown resources default to Global Administrator
-		defaultRoles := []string{"Global Administrator"}
-		assert.Equal(t, defaultRoles, []string{"Global Administrator"})
+		// Verify the production method returns ["Global Administrator"] for unmapped resources.
+		provider := NewGDAPProvider(nil, &http.Client{}, "partner-tenant")
+		roles := provider.GetGDAPRoleRequirements("unknown_resource", "read")
+		assert.Equal(t, []string{"Global Administrator"}, roles)
 	})
 }
 


### PR DESCRIPTION
## Summary

- Deleted `mockCredentialStore` struct, `newMockCredentialStore` constructor, and all 13 methods from `features/modules/m365/gdap/gdap_provider_test.go`. `ValidateGDAPConfig` only inspects `*GDAPConfig` fields and never reads the credential store, so `nil` is passed to `NewGDAPProvider` — no real or fake store is needed.
- Removed the now-unused `auth` import from `gdap_provider_test.go`.
- Fixed `TestGDAPRoleRequirements/UnknownResourceDefault` in `gdap_simple_test.go`: the subtest previously compared a local slice literal against itself (tautology that could never fail regardless of production behaviour). Rewritten to call `provider.GetGDAPRoleRequirements("unknown_resource", "read")` and assert the result.

Fixes #1260

## Acceptance Criteria Verification

- `grep -n "mockCredentialStore\|newMockCredentialStore" features/modules/m365/gdap/gdap_provider_test.go` → zero matches ✓
- `TestGDAPConfig` constructs provider with `nil` credential store — no `auth.CredentialStore` implementation in scope ✓
- All three subtests present and unchanged: `ValidateGDAPConfigSuccess`, `ValidateGDAPConfigMissingClientID`, `ValidateGDAPConfigMissingPartnerScope` ✓
- `go test -count=1 ./features/modules/m365/gdap/...` passes with zero skips (one pre-existing platform skip in `TestGDAPProviderCreation` requires `/etc/machine-id`) ✓
- `make check-architecture` passes ✓

## Specialist Review Results

| Reviewer | Result |
|----------|--------|
| QA Test Runner | **PASS** — all unit tests, linting, license headers, architecture checks passing |
| QA Code Reviewer | **PASS** — zero blocking issues; warnings are pre-existing tautological struct-field round-trip tests not introduced by this story |
| Security Engineer | **PASS** — no hardcoded secrets, no central provider violations, no security issues |

## Test Plan

- [x] `go test -run TestGDAPConfig ./features/modules/m365/gdap/... -count=1 -v` — all 3 subtests PASS
- [x] `go test -count=1 ./features/modules/m365/gdap/...` — full package suite PASS
- [x] `make check-architecture` — no violations
- [x] `make test-agent-complete` — all gates PASS (Trivy inconclusive due to sandbox DNS, not a code finding)

🤖 Generated with [Claude Code](https://claude.com/claude-code)