### PR TITLE
ha: fix analyzePartitions so split-brain detection produces real partition sets (Issue #1300)

### DIFF
--- a/commercial/ha/split_brain.go
+++ b/commercial/ha/split_brain.go
@@ -25,10 +25,11 @@ type splitBrainDetector struct {
 	started bool
 
 	// Split-brain detection state
-	handlers       []SplitBrainHandler
-	lastDetection  time.Time
-	currentStatus  *SplitBrainStatus
-	partitionTrack map[string]*partitionInfo
+	handlers         []SplitBrainHandler
+	lastDetection    time.Time
+	currentStatus    *SplitBrainStatus
+	partitionTrack   map[string]*partitionInfo
+	reachabilityFunc func(fromID, toID string) bool
 }
 
 // partitionInfo tracks information about a network partition
@@ -61,6 +62,9 @@ func NewSplitBrainDetector(cfg *SplitBrainConfig, logger logging.Logger, manager
 			Details:   make(map[string]interface{}),
 		},
 		partitionTrack: make(map[string]*partitionInfo),
+		// Conservative default: treat all node pairs as reachable until a real
+		// probe mechanism is wired in, so detection never false-positives.
+		reachabilityFunc: func(_, _ string) bool { return true },
 	}, nil
 }
 
@@ -141,6 +145,15 @@ func (sbd *splitBrainDetector) RegisterSplitBrainHandler(handler SplitBrainHandl
 	sbd.logger.Debug("Split-brain handler registered")
 }
 
+// SetReachabilityFunc injects a custom node-reachability probe for testing or
+// future live-probe implementations. The production default always returns true
+// (conservative: no false partition reports until a real probe is wired in).
+func (sbd *splitBrainDetector) SetReachabilityFunc(f func(fromID, toID string) bool) {
+	sbd.mu.Lock()
+	defer sbd.mu.Unlock()
+	sbd.reachabilityFunc = f
+}
+
 // periodicDetection performs periodic split-brain detection
 func (sbd *splitBrainDetector) periodicDetection() {
 	ticker := time.NewTicker(sbd.cfg.DetectionInterval)
@@ -214,7 +227,7 @@ func (sbd *splitBrainDetector) performSplitBrainCheck() *SplitBrainStatus {
 
 	// Count leaders and analyze partitions
 	leaderCount := 0
-	partitions := sbd.analyzePartitions(nodes)
+	partitions := sbd.analyzePartitions(nodes, sbd.reachabilityFunc)
 
 	for _, node := range nodes {
 		if node.Role == NodeRoleLeader {
@@ -254,35 +267,72 @@ func (sbd *splitBrainDetector) performSplitBrainCheck() *SplitBrainStatus {
 	return status
 }
 
-// analyzePartitions analyzes the cluster for potential network partitions
-func (sbd *splitBrainDetector) analyzePartitions(nodes []*NodeInfo) []*partitionInfo {
-	// Simple partition detection based on node connectivity
-	// In a production implementation, this would use more sophisticated
-	// network connectivity analysis
+// analyzePartitions groups nodes into connected components using BFS over the
+// reachability graph. Nodes that can mutually reach each other belong to the
+// same partition. The reachable function is injected so tests can simulate
+// network splits without actual network access.
+//
+// This method must NOT acquire sbd.mu — callers pass already-fetched NodeInfo
+// slices and a reachability function with no new lock dependencies.
+func (sbd *splitBrainDetector) analyzePartitions(nodes []*NodeInfo, reachable func(fromID, toID string) bool) []*partitionInfo {
+	if len(nodes) == 0 {
+		return nil
+	}
 
-	partitions := make([]*partitionInfo, 0)
-	processed := make(map[string]bool)
+	// component[nodeID] = component index (-1 = unvisited)
+	component := make(map[string]int, len(nodes))
+	for _, n := range nodes {
+		component[n.ID] = -1
+	}
 
-	for _, node := range nodes {
-		if processed[node.ID] {
+	numComponents := 0
+	for _, seed := range nodes {
+		if component[seed.ID] >= 0 {
 			continue
 		}
 
-		partition := &partitionInfo{
-			ID:        fmt.Sprintf("partition-%s", node.ID[:8]),
-			Nodes:     []string{node.ID},
+		compIdx := numComponents
+		numComponents++
+
+		queue := []string{seed.ID}
+		component[seed.ID] = compIdx
+
+		for len(queue) > 0 {
+			cur := queue[0]
+			queue = queue[1:]
+			for _, other := range nodes {
+				if component[other.ID] >= 0 {
+					continue
+				}
+				if reachable(cur, other.ID) {
+					component[other.ID] = compIdx
+					queue = append(queue, other.ID)
+				}
+			}
+		}
+	}
+
+	// Build a partitionInfo per component
+	partitions := make([]*partitionInfo, numComponents)
+	for i := range partitions {
+		partitions[i] = &partitionInfo{
 			FirstSeen: time.Now(),
 			LastSeen:  time.Now(),
 		}
+	}
 
+	for _, node := range nodes {
+		p := partitions[component[node.ID]]
+		p.Nodes = append(p.Nodes, node.ID)
 		if node.Role == NodeRoleLeader {
-			partition.LeaderClaims = 1
+			p.LeaderClaims++
 		}
+	}
 
-		// For now, each node is in its own partition
-		// This is a simplified implementation
-		processed[node.ID] = true
-		partitions = append(partitions, partition)
+	for _, p := range partitions {
+		if len(p.Nodes) > 0 {
+			p.ID = fmt.Sprintf("partition-%s", p.Nodes[0])
+		}
 	}
 
 	return partitions

--- a/commercial/ha/split_brain_test.go
+++ b/commercial/ha/split_brain_test.go
@@ -9,6 +9,7 @@ package ha
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -36,7 +37,7 @@ func TestSplitBrainDetector_ResolutionStrategies_DeferToRaft(t *testing.T) {
 
 	t.Cleanup(func() {
 		if manager.raftConsensus != nil {
-			_ = manager.raftConsensus.Stop()
+			assert.NoError(t, manager.raftConsensus.Stop())
 		}
 	})
 
@@ -48,21 +49,20 @@ func TestSplitBrainDetector_ResolutionStrategies_DeferToRaft(t *testing.T) {
 		Details:  make(map[string]interface{}),
 	}
 
-	// quorum-based: should return "raft_will_step_down" or "maintaining_quorum"
-	// (not "stepped_down_no_quorum" — that old sentinel required demoteFromLeader)
+	// quorum-based: returns "raft_will_step_down" (below quorum) or "maintaining_quorum"
 	result := sbd.applyQuorumBasedResolution(status)
-	assert.NotEqual(t, "stepped_down_no_quorum", result,
-		"quorum-based resolution must not call demoteFromLeader; got %q", result)
+	assert.Contains(t, []string{"raft_will_step_down", "maintaining_quorum"}, result,
+		"quorum-based resolution must return a Raft-deferred sentinel; got %q", result)
 
-	// oldest-leader: should return "raft_manages_step_down" or "not_leader"
+	// oldest-leader: returns "raft_manages_step_down" or "not_leader"
 	result = sbd.applyOldestLeaderResolution(status)
-	assert.NotEqual(t, "stepped_down_not_oldest", result,
-		"oldest-leader resolution must not call demoteFromLeader; got %q", result)
+	assert.Contains(t, []string{"raft_manages_step_down", "not_leader"}, result,
+		"oldest-leader resolution must return a Raft-deferred sentinel; got %q", result)
 
-	// step-down: should return "raft_manages_step_down" or "not_leader"
+	// step-down: returns "raft_manages_step_down" or "not_leader"
 	result = sbd.applyStepDownResolution(status)
-	assert.NotEqual(t, "stepped_down_split_brain", result,
-		"step-down resolution must not call demoteFromLeader; got %q", result)
+	assert.Contains(t, []string{"raft_manages_step_down", "not_leader"}, result,
+		"step-down resolution must return a Raft-deferred sentinel; got %q", result)
 }
 
 // TestSplitBrainDetector_CheckSplitBrain_NonCluster verifies that split-brain
@@ -87,4 +87,125 @@ func TestSplitBrainDetector_CheckSplitBrain_NonCluster(t *testing.T) {
 	assert.NotNil(t, status)
 	// Single server mode must not report a split-brain condition.
 	assert.False(t, status.Detected, "split-brain must not be detected in single-server mode")
+}
+
+// TestAnalyzePartitions_Empty verifies that an empty node list returns nil
+// (no partitions to group).
+func TestAnalyzePartitions_Empty(t *testing.T) {
+	var sbd splitBrainDetector
+	partitions := sbd.analyzePartitions(nil, func(_, _ string) bool { return true })
+	assert.Nil(t, partitions, "empty node list must return nil partitions")
+}
+
+// TestAnalyzePartitions_FullyConnected verifies that a 3-node cluster where
+// every pair of nodes can reach each other yields a single partition.
+func TestAnalyzePartitions_FullyConnected(t *testing.T) {
+	nodes := []*NodeInfo{
+		{ID: "node-alpha", Role: NodeRoleFollower},
+		{ID: "node-beta", Role: NodeRoleFollower},
+		{ID: "node-gamma", Role: NodeRoleLeader},
+	}
+
+	reachable := func(_, _ string) bool { return true }
+
+	var sbd splitBrainDetector
+	partitions := sbd.analyzePartitions(nodes, reachable)
+
+	require.Len(t, partitions, 1, "fully-connected cluster must produce exactly 1 partition")
+	assert.Len(t, partitions[0].Nodes, 3, "the single partition must contain all 3 nodes")
+	assert.Equal(t, 1, partitions[0].LeaderClaims, "leader count must be 1")
+}
+
+// TestAnalyzePartitions_Split_2Plus1 verifies that a 3-node cluster whose
+// reachability graph has two connected components yields exactly 2 partitions
+// with the correct node distribution.
+func TestAnalyzePartitions_Split_2Plus1(t *testing.T) {
+	const (
+		nodeA = "node-alpha"
+		nodeB = "node-beta"
+		nodeC = "node-gamma" // isolated node claiming leadership
+	)
+
+	nodes := []*NodeInfo{
+		{ID: nodeA, Role: NodeRoleFollower},
+		{ID: nodeB, Role: NodeRoleFollower},
+		{ID: nodeC, Role: NodeRoleLeader},
+	}
+
+	// alpha ↔ beta are connected; gamma is unreachable from both
+	reachable := func(from, to string) bool {
+		return (from == nodeA && to == nodeB) || (from == nodeB && to == nodeA)
+	}
+
+	var sbd splitBrainDetector
+	partitions := sbd.analyzePartitions(nodes, reachable)
+
+	require.Len(t, partitions, 2, "split 2+1 must produce exactly 2 partitions")
+
+	sizes := make([]int, len(partitions))
+	leaderClaims := make([]int, len(partitions))
+	for i, p := range partitions {
+		sizes[i] = len(p.Nodes)
+		leaderClaims[i] = p.LeaderClaims
+	}
+	assert.ElementsMatch(t, []int{2, 1}, sizes, "partition sizes must be 2 and 1")
+	assert.ElementsMatch(t, []int{0, 1}, leaderClaims, "leader claims must be 0 and 1 across partitions")
+}
+
+// TestPerformSplitBrainCheck_PartitionDetected verifies that performSplitBrainCheck
+// sets Detected=true when a network-isolated partition contains a leader claim
+// and meets the MinQuorum threshold.
+func TestPerformSplitBrainCheck_PartitionDetected(t *testing.T) {
+	const (
+		nodeA = "node-alpha"
+		nodeB = "node-beta"
+		nodeC = "node-gamma" // isolated; claims leadership
+	)
+
+	// Minimal Manager constructed directly so raftConsensus is nil and
+	// GetClusterNodes falls back to clusterNodes map — no Raft bootstrap needed.
+	manager := &Manager{
+		cfg: &Config{
+			Mode: ClusterMode,
+			Cluster: ClusterConfig{
+				MinQuorum: 1, // any partition with a leader triggers detection
+			},
+		},
+		clusterNodes: map[string]*NodeInfo{
+			nodeA: {ID: nodeA, Role: NodeRoleFollower},
+			nodeB: {ID: nodeB, Role: NodeRoleFollower},
+			nodeC: {ID: nodeC, Role: NodeRoleLeader},
+		},
+		logger: logging.GetLogger(),
+	}
+
+	// alpha ↔ beta are connected; gamma is unreachable from both
+	reachable := func(from, to string) bool {
+		return (from == nodeA && to == nodeB) || (from == nodeB && to == nodeA)
+	}
+
+	sbd := &splitBrainDetector{
+		cfg: &SplitBrainConfig{
+			Enabled:           true,
+			DetectionInterval: 15 * time.Second,
+		},
+		logger:  logging.GetLogger(),
+		manager: manager,
+		currentStatus: &SplitBrainStatus{
+			Detected:  false,
+			Timestamp: time.Now(),
+			Details:   make(map[string]interface{}),
+		},
+		partitionTrack:   make(map[string]*partitionInfo),
+		reachabilityFunc: reachable,
+	}
+
+	status := sbd.performSplitBrainCheck()
+
+	require.NotNil(t, status)
+	assert.True(t, status.Detected,
+		"split-brain must be detected when an isolated partition holds a leader claim")
+	assert.Len(t, status.PartitionIDs, 2, "status must report 2 partition IDs")
+	assert.Equal(t, "partition_with_quorum", status.Details["condition"],
+		"detection condition must be partition_with_quorum")
 }


### PR DESCRIPTION
## Summary

- Replaces the "one node per partition" placeholder in `analyzePartitions` with BFS-based connected-component grouping; `len(partitions) > 1` now fires only when genuine network isolation exists
- Adds injectable `reachabilityFunc` field (production default: always returns `true` = conservative, no false positives) and `SetReachabilityFunc` for test injection
- Fixes pre-existing `TestSplitBrainDetector_ResolutionStrategies_DeferToRaft` to use positive assertions (`assert.Contains` against valid sentinel set) instead of weak negative assertions against stale strings
- Adds four tests covering empty input, fully-connected cluster, 2+1 split, and end-to-end `performSplitBrainCheck` detection

Fixes #1300

## Test plan

- [ ] `TestAnalyzePartitions_Empty` — nil input → nil output
- [ ] `TestAnalyzePartitions_FullyConnected` — 3 nodes all reachable → 1 partition
- [ ] `TestAnalyzePartitions_Split_2Plus1` — 3 nodes split 2+1 → 2 partitions with correct LeaderClaims
- [ ] `TestPerformSplitBrainCheck_PartitionDetected` — isolated leader triggers `Detected=true`
- [ ] `make test-agent-complete` — all gates green (cross-platform builds, race detection, lint, license headers, architecture compliance)

## Specialist Review Results

**QA Test Runner: PASS**
- All quality validation gates passed
- Unit tests: all packages, race detection clean
- Commercial HA tests (`-tags commercial`): all 16 tests passing (1 pre-existing skip for health-checker sync issue unrelated to this story)
- Cross-platform compilation: linux/amd64, linux/arm64, darwin/amd64, darwin/arm64, windows/amd64 — all PASS
- Trivy: infrastructure DNS failure in sandbox (not a code issue; security-engineer confirmed same)

**QA Code Reviewer: PASS** (after fixing blocking issue)
- Fixed: `TestSplitBrainDetector_ResolutionStrategies_DeferToRaft` upgraded from negative assertions to positive `assert.Contains` calls
- Fixed: `_ = manager.raftConsensus.Stop()` → `assert.NoError(t, manager.raftConsensus.Stop())`
- Added: `TestAnalyzePartitions_Empty` covers the nil-input edge case

**Security Engineer: PASS**
- No hardcoded secrets, no SQL injection, no information disclosure
- No central provider violations, no TLS issues
- Concurrency: `reachabilityFunc` field guarded by `sbd.mu` on all access paths — no data race
- `make security-precommit`: PASS, `make check-architecture`: PASS, `make security-scan` (gosec/staticcheck): PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)