### PR TITLE
ci: bump windows build timeout to 30m, drop redundant module cache

### DIFF
--- a/.github/workflows/cross-platform-build.yml
+++ b/.github/workflows/cross-platform-build.yml
@@ -69,7 +69,7 @@ jobs:
           - os: windows-latest
             platform: Windows
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 20
+    timeout-minutes: 30
     steps:
     - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
@@ -77,14 +77,6 @@ jobs:
       uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
       with:
         go-version: ${{ env.GO_VERSION }}
-
-    - name: Cache Go modules
-      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
-      with:
-        path: ~/go/pkg/mod
-        key: ${{ runner.os }}-go-modules-${{ hashFiles('**/go.sum') }}
-        restore-keys: |
-          ${{ runner.os }}-go-modules-
 
     - name: Download dependencies
       run: go mod download


### PR DESCRIPTION
## Summary

- Windows ` Native Build` job has been creeping toward the 20m cap for months (~8m in Dec 2025 → ~12m today). PR #1305 blew through it when `Post Set up Go` cleanup stalled for 7+ minutes, cancelling the job and failing the Build Gate.
- Remove the redundant manual `actions/cache` for `~/go/pkg/mod` — `actions/setup-go@v5` already manages the module cache by default (`cache: true`). The two were stepping on each other during cleanup, which is what triggered the stall.
- Bump `timeout-minutes: 20 → 30` on `native-builds` to restore headroom. The cap was set when Windows ran in ~5m; nominal duration has nearly tripled since.

Scoped to `native-builds` only — `cross-compile-check` and `integration-tests` run on Linux and haven't shown the hang.

## Investigation

| Run | Conclusion | Windows duration | `Post Set up Go` |
|-----|-----------|------------------|------------------|
| 2025-12-19 (early) | success | ~3-8m | normal |
| 2026-03-02 | success | 11:05 | normal |
| 2026-05-06 PR #1308 | success | 11:42 | 28s |
| **2026-05-06 PR #1305** | **cancelled @ 20m** | **20:07** | **7:15 (stalled)** |

## Test plan

- [ ] Cross-Platform Build Validation passes on this PR
- [ ] Windows `Native Build` completes well under the new 30m cap
- [ ] No regression on Linux/macOS native builds

🤖 Generated with [Claude Code](https://claude.com/claude-code)