### PR TITLE
ha: wire Raft application commands via proposeC/confChangeC (Issue #1293)

### DIFF
--- a/commercial/ha/manager.go
+++ b/commercial/ha/manager.go
@@ -601,6 +601,51 @@ func (m *Manager) startClusterMode() error {
 			return fmt.Errorf("failed to start Raft consensus: %w", err)
 		}
 		m.logger.Info("DEBUG: Raft consensus started successfully")
+
+		// Replicate local node metadata through the Raft log once a leader exists.
+		// Proposals sent before leader election are dropped, so we wait for
+		// leaderElectedC (closed by the Raft loop on first leader detection)
+		// before calling ProposeNodeUpdate. The goroutine is bounded by m.ctx.
+		rc := m.raftConsensus
+		nodeInfo := m.nodeInfo
+		go func() {
+			select {
+			case <-rc.leaderElectedC:
+				if err := rc.ProposeNodeUpdate(nodeInfo); err != nil {
+					m.logger.Warn("Failed to propose initial node update", "error", err)
+				}
+			case <-m.ctx.Done():
+				return
+			}
+		}()
+
+		// Propose add-node ConfChanges for each peer known at startup.
+		// These are non-critical (initial membership is bootstrapped via StartNode);
+		// failures are logged but do not block cluster startup.
+		localNodeID := hashStringToUint64(m.nodeInfo.ID)
+		if nodes := m.cfg.Cluster.Discovery.Config["nodes"]; nodes != nil {
+			if nodeList, ok := nodes.([]interface{}); ok {
+				for _, n := range nodeList {
+					nodeMap, ok := n.(map[string]interface{})
+					if !ok {
+						continue
+					}
+					id, ok := nodeMap["id"].(string)
+					if !ok {
+						continue
+					}
+					peerID := hashStringToUint64(id)
+					if peerID == localNodeID {
+						continue
+					}
+					addr, _ := nodeMap["address"].(string)
+					peerInfo := &NodeInfo{ID: id, Address: addr}
+					if err := m.raftConsensus.ProposeAddNode(peerID, peerInfo); err != nil {
+						m.logger.Warn("Failed to propose add-node for peer", "peer_id", peerID, "error", err)
+					}
+				}
+			}
+		}
 	}
 
 	if m.failover != nil {

--- a/commercial/ha/manager_test.go
+++ b/commercial/ha/manager_test.go
@@ -219,7 +219,7 @@ func TestManager_ClusterMode(t *testing.T) {
 	// Manager.Stop() also stops raftConsensus (idempotent via stopOnce).
 	// Cleanup is a safety net for early-return paths.
 	t.Cleanup(func() {
-		_ = manager.raftConsensus.Stop()
+		assert.NoError(t, manager.raftConsensus.Stop())
 	})
 
 	// Test deployment mode
@@ -236,10 +236,17 @@ func TestManager_ClusterMode(t *testing.T) {
 	err = manager.Start(ctx)
 	require.NoError(t, err)
 
-	// Get cluster nodes — should include at least the local node
-	nodes, err := manager.GetClusterNodes()
-	require.NoError(t, err)
-	assert.NotEmpty(t, nodes)
+	// ProposeNodeUpdate is called during Start(). Because the construction-time seed
+	// was removed, GetClusterNodes() returns the local node only after that proposal
+	// is committed and applied via the Raft log. If ProposeNodeUpdate is never called,
+	// this Eventually will time out and fail, proving the wiring is correct.
+	var nodes []*NodeInfo
+	require.Eventually(t, func() bool {
+		var getErr error
+		nodes, getErr = manager.GetClusterNodes()
+		return getErr == nil && len(nodes) > 0
+	}, 10*time.Second, 25*time.Millisecond,
+		"local node must appear in GetClusterNodes via the Raft apply path after ProposeNodeUpdate")
 
 	// IsLeader() must delegate to raftConsensus (not a cached local field)
 	raftAnswer := manager.raftConsensus.IsLeader()
@@ -469,10 +476,11 @@ func TestDeploymentModeProgression(t *testing.T) {
 		// Should support cluster operations
 		assert.Equal(t, ClusterMode, manager.GetDeploymentMode())
 
-		// Should have cluster nodes
-		nodes, err := manager.GetClusterNodes()
-		require.NoError(t, err)
-		assert.NotEmpty(t, nodes)
+		// Wait for ProposeNodeUpdate (sent during Start) to be applied via the Raft log.
+		require.Eventually(t, func() bool {
+			nodes, getErr := manager.GetClusterNodes()
+			return getErr == nil && len(nodes) > 0
+		}, 10*time.Second, 25*time.Millisecond, "local node must appear in GetClusterNodes via Raft apply path")
 
 		err = manager.Stop(ctx)
 		assert.NoError(t, err)

--- a/commercial/ha/raft_consensus.go
+++ b/commercial/ha/raft_consensus.go
@@ -23,6 +23,7 @@ import (
 type RaftConsensus struct {
 	mu       sync.RWMutex
 	stopOnce sync.Once
+	wg       sync.WaitGroup // tracks the runRaft goroutine; Stop() waits on it
 
 	// Raft core
 	node    raft.Node
@@ -40,9 +41,13 @@ type RaftConsensus struct {
 	// Channels for coordination
 	proposeC    chan []byte
 	confChangeC chan raftpb.ConfChange
-	commitC     chan *commit
 	errorC      chan error
 	stopC       chan struct{}
+
+	// leaderElectedC is closed once the first leader is known; callers that need
+	// to propose (which requires a leader) can select on this channel.
+	leaderElectedC chan struct{}
+	leaderOnce     sync.Once
 
 	// Transport
 	transport *raftTransport
@@ -60,13 +65,6 @@ type ClusterState struct {
 	Leader       uint64
 	Nodes        map[uint64]*NodeInfo
 	LastModified time.Time
-}
-
-// commit represents a committed log entry
-type commit struct {
-	data  [][]byte //nolint:unused // Reserved for future use
-	index uint64   //nolint:unused // Reserved for future use
-	term  uint64   //nolint:unused // Reserved for future use
 }
 
 // RaftCommand represents commands sent through Raft
@@ -105,18 +103,15 @@ func NewRaftConsensus(ctx context.Context, nodeID uint64, nodeInfo *NodeInfo, pe
 		clusterState: &ClusterState{
 			Nodes: make(map[uint64]*NodeInfo),
 		},
-		proposeC:    make(chan []byte),
-		confChangeC: make(chan raftpb.ConfChange),
-		commitC:     make(chan *commit, 128),
-		errorC:      make(chan error),
-		stopC:       make(chan struct{}),
-		logger:      logger,
+		proposeC:       make(chan []byte, 16),
+		confChangeC:    make(chan raftpb.ConfChange, 16),
+		errorC:         make(chan error),
+		stopC:          make(chan struct{}),
+		leaderElectedC: make(chan struct{}),
+		logger:         logger,
 	}
 
 	rc.ctx, rc.cancel = context.WithCancel(ctx)
-
-	// Initialize cluster state with local node
-	rc.clusterState.Nodes[nodeID] = nodeInfo
 
 	// Start Raft node
 	if len(peers) > 0 {
@@ -137,6 +132,7 @@ func NewRaftConsensus(ctx context.Context, nodeID uint64, nodeInfo *NodeInfo, pe
 	// CRITICAL: Start the Raft processing loop IMMEDIATELY
 	// The Ready channel must be consumed or Raft will block
 	logger.Debug("RAFT: Starting Raft processing loop immediately", "node_id", nodeID)
+	rc.wg.Add(1)
 	go rc.runRaft()
 
 	return rc, nil
@@ -175,6 +171,8 @@ func (rc *RaftConsensus) Start() error {
 }
 
 // Stop gracefully stops the Raft consensus engine. Safe to call multiple times.
+// Blocks until the runRaft goroutine has exited so callers can safely inspect
+// internal channels (e.g. proposeC) once Stop returns.
 func (rc *RaftConsensus) Stop() error {
 	rc.stopOnce.Do(func() {
 		rc.logger.Info("RAFT: Stopping Raft consensus engine", "node_id", rc.nodeID)
@@ -188,11 +186,14 @@ func (rc *RaftConsensus) Stop() error {
 		}
 		rc.node.Stop()
 	})
+	rc.wg.Wait() // all callers block until runRaft has exited
 	return nil
 }
 
 // runRaft is the main Raft processing loop
 func (rc *RaftConsensus) runRaft() {
+	defer rc.wg.Done()
+
 	ticker := time.NewTicker(100 * time.Millisecond)
 	defer ticker.Stop()
 
@@ -466,6 +467,7 @@ func (rc *RaftConsensus) updateLeadership(ss *raft.SoftState) {
 
 	if ss.Lead != raft.None {
 		rc.clusterState.Leader = ss.Lead
+		rc.leaderOnce.Do(func() { close(rc.leaderElectedC) })
 	}
 }
 
@@ -515,6 +517,63 @@ func (rc *RaftConsensus) GetClusterNodes() []*NodeInfo {
 	}
 
 	return nodes
+}
+
+// ProposeNodeUpdate replicates updated NodeInfo for this node through the Raft log.
+// It is non-blocking: if proposeC is at capacity it returns an error immediately.
+func (rc *RaftConsensus) ProposeNodeUpdate(nodeInfo *NodeInfo) error {
+	cmd := RaftCommand{
+		Type: "node_update",
+		Data: NodeUpdateCommand{
+			NodeID:   rc.nodeID,
+			NodeInfo: nodeInfo,
+		},
+	}
+	data, err := json.Marshal(cmd)
+	if err != nil {
+		return fmt.Errorf("failed to marshal node update command: %w", err)
+	}
+	select {
+	case rc.proposeC <- data:
+		return nil
+	default:
+		return fmt.Errorf("propose channel full, cannot enqueue node update")
+	}
+}
+
+// ProposeAddNode proposes a ConfChangeAddNode for the given node.
+// It is non-blocking: if confChangeC is at capacity it returns an error immediately.
+func (rc *RaftConsensus) ProposeAddNode(nodeID uint64, nodeInfo *NodeInfo) error {
+	contextData, err := json.Marshal(nodeInfo)
+	if err != nil {
+		return fmt.Errorf("failed to marshal node info for add-node conf change: %w", err)
+	}
+	cc := raftpb.ConfChange{
+		Type:    raftpb.ConfChangeAddNode,
+		NodeID:  nodeID,
+		Context: contextData,
+	}
+	select {
+	case rc.confChangeC <- cc:
+		return nil
+	default:
+		return fmt.Errorf("conf change channel full, cannot enqueue add-node for %d", nodeID)
+	}
+}
+
+// ProposeRemoveNode proposes a ConfChangeRemoveNode for the given node.
+// It is non-blocking: if confChangeC is at capacity it returns an error immediately.
+func (rc *RaftConsensus) ProposeRemoveNode(nodeID uint64) error {
+	cc := raftpb.ConfChange{
+		Type:   raftpb.ConfChangeRemoveNode,
+		NodeID: nodeID,
+	}
+	select {
+	case rc.confChangeC <- cc:
+		return nil
+	default:
+		return fmt.Errorf("conf change channel full, cannot enqueue remove-node for %d", nodeID)
+	}
 }
 
 // Process receives and processes Raft messages from peers

--- a/commercial/ha/raft_consensus_test.go
+++ b/commercial/ha/raft_consensus_test.go
@@ -11,6 +11,10 @@ import (
 	"testing"
 	"time"
 
+	"go.etcd.io/raft/v3"
+	"go.etcd.io/raft/v3/raftpb"
+
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	pkgtesting "github.com/cfgis/cfgms/pkg/testing"
@@ -54,4 +58,185 @@ func TestRaftConsensus_propose_logsError(t *testing.T) {
 		}
 		return false
 	}, 2*time.Second, 10*time.Millisecond, "expected 'Failed to propose to Raft' error log")
+}
+
+// TestRaftConsensus_ProposeNodeUpdate_AppliedViaRaft verifies that ProposeNodeUpdate
+// encodes the command and sends it through proposeC, and that after the Raft loop
+// processes the entry, GetClusterNodes returns the updated NodeInfo.
+func TestRaftConsensus_ProposeNodeUpdate_AppliedViaRaft(t *testing.T) {
+	mock := pkgtesting.NewMockLogger(true)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	nodeInfo := &NodeInfo{
+		ID:      "test-node",
+		Address: "127.0.0.1:1111",
+		State:   NodeStateHealthy,
+		Role:    NodeRoleFollower,
+	}
+
+	// Single-peer list so StartNode bootstraps a new single-node cluster.
+	peers := []raft.Peer{{ID: 1}}
+	rc, err := NewRaftConsensus(ctx, 1, nodeInfo, peers, mock)
+	require.NoError(t, err)
+	defer rc.Stop() //nolint:errcheck // Stop always returns nil; error is non-actionable in cleanup
+
+	// Wait for the node to win the election and become leader before proposing.
+	require.Eventually(t, func() bool {
+		return rc.IsLeader()
+	}, 10*time.Second, 50*time.Millisecond, "single-node cluster must elect itself leader")
+
+	// Propose an update with a distinctive address to verify the value came
+	// through the apply path (not any construction-time initialisation).
+	updatedInfo := &NodeInfo{
+		ID:      "test-node",
+		Address: "127.0.0.1:9999",
+		State:   NodeStateHealthy,
+		Role:    NodeRoleLeader,
+	}
+
+	err = rc.ProposeNodeUpdate(updatedInfo)
+	require.NoError(t, err)
+
+	// Wait for the Raft loop to commit and apply the entry.
+	require.Eventually(t, func() bool {
+		for _, n := range rc.GetClusterNodes() {
+			if n.Address == "127.0.0.1:9999" {
+				return true
+			}
+		}
+		return false
+	}, 5*time.Second, 25*time.Millisecond, "ProposeNodeUpdate must be committed and applied via the Raft log")
+}
+
+// TestRaftConsensus_ProposeAddNode_SubmitsToChannel verifies ProposeAddNode does not
+// block the caller and enqueues a ConfChange of type ConfChangeAddNode to confChangeC.
+func TestRaftConsensus_ProposeAddNode_SubmitsToChannel(t *testing.T) {
+	mock := pkgtesting.NewMockLogger(true)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	nodeInfo := &NodeInfo{ID: "node-1", Address: "127.0.0.1:2000"}
+	rc, err := NewRaftConsensus(ctx, 1, nodeInfo, nil, mock)
+	require.NoError(t, err)
+	// Stop before the deferred Stop — stopOnce makes this safe; both return nil.
+	rc.Stop() //nolint:errcheck // Stop always returns nil; error is non-actionable in cleanup
+	defer rc.Stop() //nolint:errcheck // Stop always returns nil; error is non-actionable in cleanup
+
+	// Raft loop has fully exited (Stop blocks on wg.Wait), so confChangeC won't be drained.
+	peerInfo := &NodeInfo{ID: "node-2", Address: "127.0.0.1:2001"}
+	err = rc.ProposeAddNode(2, peerInfo)
+	require.NoError(t, err, "ProposeAddNode must not return an error when channel has capacity")
+
+	// Drain the channel to confirm the correct ConfChange was enqueued.
+	select {
+	case cc := <-rc.confChangeC:
+		assert.Equal(t, raftpb.ConfChangeAddNode, cc.Type)
+		assert.Equal(t, uint64(2), cc.NodeID)
+	default:
+		t.Fatal("confChangeC should contain the enqueued ConfChange")
+	}
+}
+
+// TestRaftConsensus_ProposeRemoveNode_SubmitsToChannel verifies ProposeRemoveNode does
+// not block and enqueues a ConfChange of type ConfChangeRemoveNode to confChangeC.
+func TestRaftConsensus_ProposeRemoveNode_SubmitsToChannel(t *testing.T) {
+	mock := pkgtesting.NewMockLogger(true)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	nodeInfo := &NodeInfo{ID: "node-1", Address: "127.0.0.1:3000"}
+	rc, err := NewRaftConsensus(ctx, 1, nodeInfo, nil, mock)
+	require.NoError(t, err)
+	rc.Stop() //nolint:errcheck // Stop always returns nil; error is non-actionable in cleanup
+	defer rc.Stop() //nolint:errcheck // Stop always returns nil; error is non-actionable in cleanup
+
+	err = rc.ProposeRemoveNode(2)
+	require.NoError(t, err, "ProposeRemoveNode must not return an error when channel has capacity")
+
+	select {
+	case cc := <-rc.confChangeC:
+		assert.Equal(t, raftpb.ConfChangeRemoveNode, cc.Type)
+		assert.Equal(t, uint64(2), cc.NodeID)
+	default:
+		t.Fatal("confChangeC should contain the enqueued ConfChange")
+	}
+}
+
+// TestRaftConsensus_ProposeNodeUpdate_ChannelFull_ReturnsError verifies that
+// ProposeNodeUpdate returns a non-nil error rather than blocking when proposeC is full.
+func TestRaftConsensus_ProposeNodeUpdate_ChannelFull_ReturnsError(t *testing.T) {
+	mock := pkgtesting.NewMockLogger(true)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	nodeInfo := &NodeInfo{ID: "node-fill", Address: "127.0.0.1:4000"}
+	rc, err := NewRaftConsensus(ctx, 1, nodeInfo, nil, mock)
+	require.NoError(t, err)
+
+	// Stop blocks until runRaft exits, guaranteeing proposeC won't be drained.
+	rc.Stop() //nolint:errcheck // Stop always returns nil; error is non-actionable in cleanup
+
+	const bufSize = 16
+	for i := 0; i < bufSize; i++ {
+		rc.proposeC <- []byte("fill")
+	}
+
+	// With proposeC at capacity, ProposeNodeUpdate must return an error immediately.
+	err = rc.ProposeNodeUpdate(nodeInfo)
+	require.Error(t, err, "ProposeNodeUpdate must return an error when proposeC is full")
+}
+
+// TestRaftConsensus_ProposeAddNode_ChannelFull_ReturnsError verifies that
+// ProposeAddNode returns a non-nil error rather than blocking when confChangeC is full.
+func TestRaftConsensus_ProposeAddNode_ChannelFull_ReturnsError(t *testing.T) {
+	mock := pkgtesting.NewMockLogger(true)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	nodeInfo := &NodeInfo{ID: "node-add-fill", Address: "127.0.0.1:5000"}
+	rc, err := NewRaftConsensus(ctx, 1, nodeInfo, nil, mock)
+	require.NoError(t, err)
+
+	// Stop blocks until runRaft exits, guaranteeing confChangeC won't be drained.
+	rc.Stop() //nolint:errcheck // Stop always returns nil; error is non-actionable in cleanup
+
+	const bufSize = 16
+	for i := 0; i < bufSize; i++ {
+		rc.confChangeC <- raftpb.ConfChange{Type: raftpb.ConfChangeAddNode, NodeID: uint64(i + 10)}
+	}
+
+	// With confChangeC at capacity, ProposeAddNode must return an error immediately.
+	err = rc.ProposeAddNode(99, &NodeInfo{ID: "overflow", Address: "127.0.0.1:6000"})
+	require.Error(t, err, "ProposeAddNode must return an error when confChangeC is full")
+}
+
+// TestRaftConsensus_ProposeRemoveNode_ChannelFull_ReturnsError verifies that
+// ProposeRemoveNode returns a non-nil error rather than blocking when confChangeC is full.
+func TestRaftConsensus_ProposeRemoveNode_ChannelFull_ReturnsError(t *testing.T) {
+	mock := pkgtesting.NewMockLogger(true)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	nodeInfo := &NodeInfo{ID: "node-rem-fill", Address: "127.0.0.1:7000"}
+	rc, err := NewRaftConsensus(ctx, 1, nodeInfo, nil, mock)
+	require.NoError(t, err)
+
+	// Stop blocks until runRaft exits, guaranteeing confChangeC won't be drained.
+	rc.Stop() //nolint:errcheck // Stop always returns nil; error is non-actionable in cleanup
+
+	const bufSize = 16
+	for i := 0; i < bufSize; i++ {
+		rc.confChangeC <- raftpb.ConfChange{Type: raftpb.ConfChangeRemoveNode, NodeID: uint64(i + 10)}
+	}
+
+	// With confChangeC at capacity, ProposeRemoveNode must return an error immediately.
+	err = rc.ProposeRemoveNode(99)
+	require.Error(t, err, "ProposeRemoveNode must return an error when confChangeC is full")
 }


### PR DESCRIPTION
## Summary

- Exports `ProposeNodeUpdate`, `ProposeAddNode`, `ProposeRemoveNode` on `RaftConsensus` — all non-blocking (buffered channels, `default:` branch returns error if full)
- Deletes dead scaffolding: `commitC chan *commit` field and `commit` struct (confirmed unused by `//nolint:unused` tags)
- Adds `leaderElectedC chan struct{}` (closed on first leader detection) so `startClusterMode` can defer `ProposeNodeUpdate` until Raft is ready to commit — prevents silent proposal drops during election window
- Adds `sync.WaitGroup` to `Stop()` so it blocks until `runRaft` goroutine exits, making channel inspection after Stop() deterministic
- Removes the construction-time seed `clusterState.Nodes[nodeID] = nodeInfo`; cluster state is now populated exclusively via the Raft apply path

Fixes #1293

## Specialist Review Results

| Reviewer | Round 1 | Round 2 |
|----------|---------|---------|
| QA Test Runner | FAIL (race in channel-full test) | **PASS** |
| QA Code Reviewer | FAIL (missing justifications, missing error tests) | **PASS** |
| Security Engineer | **PASS** | — |

Round-1 fixes: added WaitGroup to Stop(), added `//nolint` justification comments, added ProposeAddNode/ProposeRemoveNode channel-full error tests, fixed `_ = Stop()` in TestManager_ClusterMode cleanup.

Pre-existing issues noted but out of scope for this story (tracked separately):
- `t.Skip()` in `TestManager_HealthChecks` (Issue #1299)
- `time.Sleep()` synchronization in `TestManager_SingleServerMode`
- `context.Background()` in `NewRaftConsensus` call in `manager.go`
- `_ = Stop()` in cleanup blocks for tests not modified by this story

## Test Plan

- [x] `TestRaftConsensus_ProposeNodeUpdate_AppliedViaRaft` — single-node Raft, leader election, apply path verified
- [x] `TestRaftConsensus_ProposeAddNode_SubmitsToChannel` — channel content verified
- [x] `TestRaftConsensus_ProposeRemoveNode_SubmitsToChannel` — channel content verified
- [x] `TestRaftConsensus_Propose*_ChannelFull_ReturnsError` (×3) — all non-blocking contracts verified
- [x] `TestManager_ClusterMode` — `GetClusterNodes` returns local node via apply path (require.Eventually)
- [x] All 101 packages pass with `-race`, including `commercial/ha` (12s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)