### PR TITLE
ha: wire ClusterConfig timing fields into raft.Config; fix hashStringToUint64 collision risk (Issue #1294)

### DIFF
--- a/commercial/ha/manager.go
+++ b/commercial/ha/manager.go
@@ -11,6 +11,7 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"fmt"
+	"hash/fnv"
 	"os"
 	"sync"
 	"time"
@@ -464,6 +465,10 @@ func (m *Manager) initializeRaftConsensus() error {
 	// Parse cluster nodes from config
 	m.logger.Debug("RAFT_INIT: Parsing cluster nodes from config", "config_nil", m.cfg.Cluster.Discovery.Config == nil)
 
+	// seenHashes guards against node ID hash collisions before they can silently alias
+	// two distinct nodes to the same Raft peer ID.
+	seenHashes := make(map[uint64]string) // hash → original string ID
+
 	if clusterNodes := m.cfg.Cluster.Discovery.Config["nodes"]; clusterNodes != nil {
 		m.logger.Debug("RAFT_INIT: Found cluster nodes in config", "type", fmt.Sprintf("%T", clusterNodes))
 		// Try both []interface{} and []map[string]interface{} type assertions
@@ -473,6 +478,10 @@ func (m *Manager) initializeRaftConsensus() error {
 				if nodeMap, ok := n.(map[string]interface{}); ok {
 					if id, ok := nodeMap["id"].(string); ok {
 						peerID := hashStringToUint64(id)
+						if existing, dup := seenHashes[peerID]; dup {
+							return fmt.Errorf("node ID hash collision: %q and %q both hash to %d", existing, id, peerID)
+						}
+						seenHashes[peerID] = id
 						peers = append(peers, raft.Peer{
 							ID:      peerID,
 							Context: []byte(id), // Store original string ID
@@ -486,6 +495,10 @@ func (m *Manager) initializeRaftConsensus() error {
 			for i, nodeMap := range nodes {
 				if id, ok := nodeMap["id"].(string); ok {
 					peerID := hashStringToUint64(id)
+					if existing, dup := seenHashes[peerID]; dup {
+						return fmt.Errorf("node ID hash collision: %q and %q both hash to %d", existing, id, peerID)
+					}
+					seenHashes[peerID] = id
 					peers = append(peers, raft.Peer{
 						ID:      peerID,
 						Context: []byte(id), // Store original string ID
@@ -502,7 +515,7 @@ func (m *Manager) initializeRaftConsensus() error {
 
 	// Create Raft consensus
 	var err error
-	m.raftConsensus, err = NewRaftConsensus(context.Background(), nodeID, m.nodeInfo, peers, m.logger)
+	m.raftConsensus, err = NewRaftConsensus(context.Background(), nodeID, m.nodeInfo, peers, &m.cfg.Cluster, m.logger)
 	if err != nil {
 		return fmt.Errorf("failed to create Raft consensus: %w", err)
 	}
@@ -575,13 +588,13 @@ func (m *Manager) initializeRaftConsensus() error {
 	return nil
 }
 
-// hashStringToUint64 converts a string to a deterministic uint64
+// hashStringToUint64 converts a string to a deterministic uint64 using FNV-1a 64-bit.
+// FNV-1a has negligible collision probability for the node-count range (3–50 nodes)
+// and avoids the aliasing risk of the old polynomial (31-based) hash.
 func hashStringToUint64(s string) uint64 {
-	var hash uint64
-	for i := 0; i < len(s); i++ {
-		hash = hash*31 + uint64(s[i])
-	}
-	return hash
+	h := fnv.New64a()
+	h.Write([]byte(s))
+	return h.Sum64()
 }
 
 // initializeBlueGreenComponents initializes components for blue-green mode.

--- a/commercial/ha/manager_test.go
+++ b/commercial/ha/manager_test.go
@@ -193,10 +193,13 @@ func TestManager_ClusterMode(t *testing.T) {
 	// Create HA config for cluster mode.
 	// Configure self as the only peer so Raft calls StartNode (new cluster) rather
 	// than RestartNode (join existing), allowing the node to become leader.
+	// Use fast timing so elections complete well within the 10-second Eventually window.
 	const nodeID = "test-node-cluster-mode"
 	cfg := DefaultConfig()
 	cfg.Mode = ClusterMode
 	cfg.Node.ID = nodeID
+	cfg.Cluster.HeartbeatInterval = 100 * time.Millisecond
+	cfg.Cluster.ElectionTimeout = 1 * time.Second
 	cfg.Cluster.ExpectedSize = 1
 	cfg.Cluster.MinQuorum = 1
 	cfg.Cluster.Discovery.Config = map[string]interface{}{
@@ -269,6 +272,8 @@ func TestManager_IsLeader_UsesRaftConsensus(t *testing.T) {
 	cfg := DefaultConfig()
 	cfg.Mode = ClusterMode
 	cfg.Node.ID = nodeID
+	cfg.Cluster.HeartbeatInterval = 100 * time.Millisecond
+	cfg.Cluster.ElectionTimeout = 1 * time.Second
 	// Configure self as peer so Raft initializes a new cluster via StartNode.
 	cfg.Cluster.Discovery.Config = map[string]interface{}{
 		"nodes": []interface{}{
@@ -397,6 +402,43 @@ func TestConfig_LoadFromEnvironment_InvalidQuorum(t *testing.T) {
 	assert.Contains(t, err.Error(), "quorum")
 }
 
+// TestHashStringToUint64_DistinguishesKnownPolynomialColliders verifies that the
+// fnv-based hash distinguishes "Aa" and "BB", which are known colliders under the
+// old polynomial hash (both produce 2112: 65*31+97 == 66*31+66).
+func TestHashStringToUint64_DistinguishesKnownPolynomialColliders(t *testing.T) {
+	h1 := hashStringToUint64("Aa")
+	h2 := hashStringToUint64("BB")
+	assert.NotEqual(t, h1, h2,
+		"fnv hash must distinguish strings that collide under the old polynomial hash")
+}
+
+// TestManager_InitRaftConsensus_DuplicateNodeIDReturnsError verifies that
+// initializeRaftConsensus returns a non-nil error when two configured peer nodes
+// produce the same uint64 hash — surfacing misconfiguration before any silent aliasing.
+func TestManager_InitRaftConsensus_DuplicateNodeIDReturnsError(t *testing.T) {
+	storageManager, err := storage.CreateTestStorageManager()
+	require.NoError(t, err)
+
+	cfg := DefaultConfig()
+	cfg.Mode = ClusterMode
+	cfg.Node.ID = "collision-self-node"
+	cfg.Cluster.ExpectedSize = 1
+	cfg.Cluster.MinQuorum = 1
+	// Two peers with identical ID strings: same string → same hash → collision detected.
+	cfg.Cluster.Discovery.Config = map[string]interface{}{
+		"nodes": []interface{}{
+			map[string]interface{}{"id": "duplicate-peer-id", "address": "127.0.0.1:9001"},
+			map[string]interface{}{"id": "duplicate-peer-id", "address": "127.0.0.1:9002"},
+		},
+	}
+
+	logger := logging.GetLogger()
+	_, err = NewManager(cfg, logger, storageManager)
+	require.Error(t, err, "NewManager must return an error when two peer IDs produce the same hash")
+	assert.Contains(t, err.Error(), "collision",
+		"error message must mention collision so operators understand the misconfiguration")
+}
+
 func TestDeploymentModeProgression(t *testing.T) {
 	// This test verifies the progressive deployment model works correctly
 	logger := logging.GetLogger()
@@ -450,6 +492,9 @@ func TestDeploymentModeProgression(t *testing.T) {
 		cfg := DefaultConfig()
 		cfg.Mode = ClusterMode
 		cfg.Node.ID = nodeID
+		// Fast timing so elections complete well within the 10-second Eventually window.
+		cfg.Cluster.HeartbeatInterval = 100 * time.Millisecond
+		cfg.Cluster.ElectionTimeout = 1 * time.Second
 		cfg.Cluster.ExpectedSize = 1
 		cfg.Cluster.MinQuorum = 1
 		cfg.Cluster.Discovery.Config = map[string]interface{}{

--- a/commercial/ha/raft_consensus.go
+++ b/commercial/ha/raft_consensus.go
@@ -26,9 +26,10 @@ type RaftConsensus struct {
 	wg       sync.WaitGroup // tracks the runRaft goroutine; Stop() waits on it
 
 	// Raft core
-	node    raft.Node
-	storage *raft.MemoryStorage
-	config  *raft.Config
+	node         raft.Node
+	storage      *raft.MemoryStorage
+	config       *raft.Config
+	tickInterval time.Duration // derived from ClusterConfig.HeartbeatInterval
 
 	// Node identity
 	nodeID   uint64
@@ -79,14 +80,36 @@ type NodeUpdateCommand struct {
 	NodeInfo *NodeInfo `json:"node_info"`
 }
 
-// NewRaftConsensus creates a new Raft consensus instance
-func NewRaftConsensus(ctx context.Context, nodeID uint64, nodeInfo *NodeInfo, peers []raft.Peer, logger logging.Logger) (*RaftConsensus, error) {
+// NewRaftConsensus creates a new Raft consensus instance. clusterCfg provides the
+// timing source: tickInterval = HeartbeatInterval, HeartbeatTick = 1, and
+// ElectionTick = ElectionTimeout / HeartbeatInterval. ElectionTick must be >= 5.
+func NewRaftConsensus(ctx context.Context, nodeID uint64, nodeInfo *NodeInfo, peers []raft.Peer, clusterCfg *ClusterConfig, logger logging.Logger) (*RaftConsensus, error) {
+	if clusterCfg == nil {
+		return nil, fmt.Errorf("clusterCfg must not be nil")
+	}
+	if clusterCfg.HeartbeatInterval <= 0 {
+		return nil, fmt.Errorf("ClusterConfig.HeartbeatInterval must be positive, got %v", clusterCfg.HeartbeatInterval)
+	}
+	if clusterCfg.ElectionTimeout <= 0 {
+		return nil, fmt.Errorf("ClusterConfig.ElectionTimeout must be positive, got %v", clusterCfg.ElectionTimeout)
+	}
+
+	tickInterval := clusterCfg.HeartbeatInterval
+	heartbeatTick := 1
+	electionTick := int(clusterCfg.ElectionTimeout / clusterCfg.HeartbeatInterval)
+	if electionTick < 5*heartbeatTick {
+		return nil, fmt.Errorf(
+			"ElectionTimeout (%v) must be at least 5× HeartbeatInterval (%v): got ElectionTick=%d, need ≥%d",
+			clusterCfg.ElectionTimeout, clusterCfg.HeartbeatInterval, electionTick, 5*heartbeatTick,
+		)
+	}
+
 	storage := raft.NewMemoryStorage()
 
 	config := &raft.Config{
 		ID:              nodeID,
-		ElectionTick:    10, // 1 second (with 100ms tick)
-		HeartbeatTick:   1,  // 100ms heartbeat
+		ElectionTick:    electionTick,
+		HeartbeatTick:   heartbeatTick,
 		Storage:         storage,
 		MaxSizePerMsg:   4096,
 		MaxInflightMsgs: 256,
@@ -96,10 +119,11 @@ func NewRaftConsensus(ctx context.Context, nodeID uint64, nodeInfo *NodeInfo, pe
 	}
 
 	rc := &RaftConsensus{
-		nodeID:   nodeID,
-		nodeInfo: nodeInfo,
-		storage:  storage,
-		config:   config,
+		nodeID:       nodeID,
+		nodeInfo:     nodeInfo,
+		storage:      storage,
+		config:       config,
+		tickInterval: tickInterval,
 		clusterState: &ClusterState{
 			Nodes: make(map[uint64]*NodeInfo),
 		},
@@ -194,7 +218,7 @@ func (rc *RaftConsensus) Stop() error {
 func (rc *RaftConsensus) runRaft() {
 	defer rc.wg.Done()
 
-	ticker := time.NewTicker(100 * time.Millisecond)
+	ticker := time.NewTicker(rc.tickInterval)
 	defer ticker.Stop()
 
 	rc.logger.Debug("RAFT: Main Raft loop started", "node_id", rc.nodeID)

--- a/commercial/ha/raft_consensus_test.go
+++ b/commercial/ha/raft_consensus_test.go
@@ -17,10 +17,93 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/cfgis/cfgms/pkg/logging"
 	pkgtesting "github.com/cfgis/cfgms/pkg/testing"
 )
 
+// newTestClusterCfg returns a minimal ClusterConfig that mirrors the old hardcoded
+// Raft defaults (100ms tick, 10 election ticks, 1 heartbeat tick) for tests that
+// do not exercise timing-specific behaviour.
+func newTestClusterCfg() *ClusterConfig {
+	return &ClusterConfig{
+		HeartbeatInterval: 100 * time.Millisecond,
+		ElectionTimeout:   1 * time.Second,
+	}
+}
+
+// TestRaftConsensus_TimingDerivedFromClusterConfig verifies that HeartbeatTick,
+// ElectionTick, and the internal ticker interval are all derived from ClusterConfig
+// rather than hardcoded constants. With HeartbeatInterval=500ms / ElectionTimeout=5s
+// the expected values are: tickInterval=500ms, HeartbeatTick=1, ElectionTick=10.
+func TestRaftConsensus_TimingDerivedFromClusterConfig(t *testing.T) {
+	clusterCfg := &ClusterConfig{
+		HeartbeatInterval: 500 * time.Millisecond,
+		ElectionTimeout:   5 * time.Second,
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	nodeInfo := &NodeInfo{ID: "timing-node", State: NodeStateHealthy, Role: NodeRoleFollower}
+	rc, err := NewRaftConsensus(ctx, 1, nodeInfo, nil, clusterCfg, logging.GetLogger())
+	require.NoError(t, err)
+	defer rc.Stop() //nolint:errcheck // Stop always returns nil; error is non-actionable in cleanup
+
+	assert.Equal(t, 500*time.Millisecond, rc.tickInterval, "tickInterval must equal HeartbeatInterval")
+	assert.Equal(t, 1, rc.config.HeartbeatTick, "HeartbeatTick must be 1 (Raft recommendation)")
+	assert.Equal(t, 10, rc.config.ElectionTick, "ElectionTick must equal ElectionTimeout/HeartbeatInterval")
+}
+
+// TestRaftConsensus_NewRaftConsensus_NilClusterCfgReturnsError verifies that a nil
+// ClusterConfig is rejected at construction time with a descriptive error.
+func TestRaftConsensus_NewRaftConsensus_NilClusterCfgReturnsError(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	nodeInfo := &NodeInfo{ID: "err-node", State: NodeStateHealthy, Role: NodeRoleFollower}
+	_, err := NewRaftConsensus(ctx, 1, nodeInfo, nil, nil, logging.GetLogger())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "clusterCfg")
+}
+
+// TestRaftConsensus_NewRaftConsensus_ZeroHeartbeatIntervalReturnsError verifies that
+// a non-positive HeartbeatInterval is rejected at construction time.
+func TestRaftConsensus_NewRaftConsensus_ZeroHeartbeatIntervalReturnsError(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	nodeInfo := &NodeInfo{ID: "err-node", State: NodeStateHealthy, Role: NodeRoleFollower}
+	cfg := &ClusterConfig{HeartbeatInterval: 0, ElectionTimeout: 1 * time.Second}
+	_, err := NewRaftConsensus(ctx, 1, nodeInfo, nil, cfg, logging.GetLogger())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "HeartbeatInterval")
+}
+
+// TestRaftConsensus_NewRaftConsensus_ZeroElectionTimeoutReturnsError verifies that
+// a non-positive ElectionTimeout is rejected at construction time.
+func TestRaftConsensus_NewRaftConsensus_ZeroElectionTimeoutReturnsError(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	nodeInfo := &NodeInfo{ID: "err-node", State: NodeStateHealthy, Role: NodeRoleFollower}
+	cfg := &ClusterConfig{HeartbeatInterval: 100 * time.Millisecond, ElectionTimeout: 0}
+	_, err := NewRaftConsensus(ctx, 1, nodeInfo, nil, cfg, logging.GetLogger())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "ElectionTimeout")
+}
+
+// TestRaftConsensus_NewRaftConsensus_ElectionTickTooSmallReturnsError verifies that
+// an ElectionTimeout less than 5× HeartbeatInterval is rejected (Raft safety requirement).
+func TestRaftConsensus_NewRaftConsensus_ElectionTickTooSmallReturnsError(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	nodeInfo := &NodeInfo{ID: "err-node", State: NodeStateHealthy, Role: NodeRoleFollower}
+	// ElectionTimeout / HeartbeatInterval = 2, which is < 5×HeartbeatTick (= 5).
+	cfg := &ClusterConfig{HeartbeatInterval: 500 * time.Millisecond, ElectionTimeout: 1 * time.Second}
+	_, err := NewRaftConsensus(ctx, 1, nodeInfo, nil, cfg, logging.GetLogger())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "ElectionTimeout")
+}
+
 func TestRaftConsensus_propose_logsError(t *testing.T) {
+	// pkgtesting.MockLogger is used here because this test asserts on captured log output.
 	mock := pkgtesting.NewMockLogger(true)
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -32,7 +115,7 @@ func TestRaftConsensus_propose_logsError(t *testing.T) {
 		Role:  NodeRoleFollower,
 	}
 
-	rc, err := NewRaftConsensus(ctx, 1, nodeInfo, nil, mock)
+	rc, err := NewRaftConsensus(ctx, 1, nodeInfo, nil, newTestClusterCfg(), mock)
 	require.NoError(t, err)
 
 	// Stop the underlying raft node so that Propose returns ErrStopped.
@@ -64,8 +147,6 @@ func TestRaftConsensus_propose_logsError(t *testing.T) {
 // encodes the command and sends it through proposeC, and that after the Raft loop
 // processes the entry, GetClusterNodes returns the updated NodeInfo.
 func TestRaftConsensus_ProposeNodeUpdate_AppliedViaRaft(t *testing.T) {
-	mock := pkgtesting.NewMockLogger(true)
-
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 	defer cancel()
 
@@ -78,7 +159,7 @@ func TestRaftConsensus_ProposeNodeUpdate_AppliedViaRaft(t *testing.T) {
 
 	// Single-peer list so StartNode bootstraps a new single-node cluster.
 	peers := []raft.Peer{{ID: 1}}
-	rc, err := NewRaftConsensus(ctx, 1, nodeInfo, peers, mock)
+	rc, err := NewRaftConsensus(ctx, 1, nodeInfo, peers, newTestClusterCfg(), logging.GetLogger())
 	require.NoError(t, err)
 	defer rc.Stop() //nolint:errcheck // Stop always returns nil; error is non-actionable in cleanup
 
@@ -113,13 +194,11 @@ func TestRaftConsensus_ProposeNodeUpdate_AppliedViaRaft(t *testing.T) {
 // TestRaftConsensus_ProposeAddNode_SubmitsToChannel verifies ProposeAddNode does not
 // block the caller and enqueues a ConfChange of type ConfChangeAddNode to confChangeC.
 func TestRaftConsensus_ProposeAddNode_SubmitsToChannel(t *testing.T) {
-	mock := pkgtesting.NewMockLogger(true)
-
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
 	nodeInfo := &NodeInfo{ID: "node-1", Address: "127.0.0.1:2000"}
-	rc, err := NewRaftConsensus(ctx, 1, nodeInfo, nil, mock)
+	rc, err := NewRaftConsensus(ctx, 1, nodeInfo, nil, newTestClusterCfg(), logging.GetLogger())
 	require.NoError(t, err)
 	// Stop before the deferred Stop — stopOnce makes this safe; both return nil.
 	rc.Stop() //nolint:errcheck // Stop always returns nil; error is non-actionable in cleanup
@@ -143,13 +222,11 @@ func TestRaftConsensus_ProposeAddNode_SubmitsToChannel(t *testing.T) {
 // TestRaftConsensus_ProposeRemoveNode_SubmitsToChannel verifies ProposeRemoveNode does
 // not block and enqueues a ConfChange of type ConfChangeRemoveNode to confChangeC.
 func TestRaftConsensus_ProposeRemoveNode_SubmitsToChannel(t *testing.T) {
-	mock := pkgtesting.NewMockLogger(true)
-
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
 	nodeInfo := &NodeInfo{ID: "node-1", Address: "127.0.0.1:3000"}
-	rc, err := NewRaftConsensus(ctx, 1, nodeInfo, nil, mock)
+	rc, err := NewRaftConsensus(ctx, 1, nodeInfo, nil, newTestClusterCfg(), logging.GetLogger())
 	require.NoError(t, err)
 	rc.Stop() //nolint:errcheck // Stop always returns nil; error is non-actionable in cleanup
 	defer rc.Stop() //nolint:errcheck // Stop always returns nil; error is non-actionable in cleanup
@@ -169,13 +246,11 @@ func TestRaftConsensus_ProposeRemoveNode_SubmitsToChannel(t *testing.T) {
 // TestRaftConsensus_ProposeNodeUpdate_ChannelFull_ReturnsError verifies that
 // ProposeNodeUpdate returns a non-nil error rather than blocking when proposeC is full.
 func TestRaftConsensus_ProposeNodeUpdate_ChannelFull_ReturnsError(t *testing.T) {
-	mock := pkgtesting.NewMockLogger(true)
-
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
 	nodeInfo := &NodeInfo{ID: "node-fill", Address: "127.0.0.1:4000"}
-	rc, err := NewRaftConsensus(ctx, 1, nodeInfo, nil, mock)
+	rc, err := NewRaftConsensus(ctx, 1, nodeInfo, nil, newTestClusterCfg(), logging.GetLogger())
 	require.NoError(t, err)
 
 	// Stop blocks until runRaft exits, guaranteeing proposeC won't be drained.
@@ -194,13 +269,11 @@ func TestRaftConsensus_ProposeNodeUpdate_ChannelFull_ReturnsError(t *testing.T) 
 // TestRaftConsensus_ProposeAddNode_ChannelFull_ReturnsError verifies that
 // ProposeAddNode returns a non-nil error rather than blocking when confChangeC is full.
 func TestRaftConsensus_ProposeAddNode_ChannelFull_ReturnsError(t *testing.T) {
-	mock := pkgtesting.NewMockLogger(true)
-
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
 	nodeInfo := &NodeInfo{ID: "node-add-fill", Address: "127.0.0.1:5000"}
-	rc, err := NewRaftConsensus(ctx, 1, nodeInfo, nil, mock)
+	rc, err := NewRaftConsensus(ctx, 1, nodeInfo, nil, newTestClusterCfg(), logging.GetLogger())
 	require.NoError(t, err)
 
 	// Stop blocks until runRaft exits, guaranteeing confChangeC won't be drained.
@@ -219,13 +292,11 @@ func TestRaftConsensus_ProposeAddNode_ChannelFull_ReturnsError(t *testing.T) {
 // TestRaftConsensus_ProposeRemoveNode_ChannelFull_ReturnsError verifies that
 // ProposeRemoveNode returns a non-nil error rather than blocking when confChangeC is full.
 func TestRaftConsensus_ProposeRemoveNode_ChannelFull_ReturnsError(t *testing.T) {
-	mock := pkgtesting.NewMockLogger(true)
-
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
 	nodeInfo := &NodeInfo{ID: "node-rem-fill", Address: "127.0.0.1:7000"}
-	rc, err := NewRaftConsensus(ctx, 1, nodeInfo, nil, mock)
+	rc, err := NewRaftConsensus(ctx, 1, nodeInfo, nil, newTestClusterCfg(), logging.GetLogger())
 	require.NoError(t, err)
 
 	// Stop blocks until runRaft exits, guaranteeing confChangeC won't be drained.


### PR DESCRIPTION
## Summary

- **Timing wiring**: `raft.Config.ElectionTick` and `HeartbeatTick` are now derived from `ClusterConfig.ElectionTimeout` / `HeartbeatInterval` instead of hardcoded constants. `tickInterval = HeartbeatInterval` (so `HeartbeatTick = 1`) and `ElectionTick = ElectionTimeout / HeartbeatInterval`. The hardcoded 100ms ticker constant is gone.
- **Collision-resistant hash**: `hashStringToUint64` now uses `fnv.New64a` (standard library) instead of a polynomial hash that had known collision pairs (e.g., `"Aa"` and `"BB"` both mapped to 2112 under the old hash).
- **Collision detection guard**: `initializeRaftConsensus` returns a descriptive error if two configured node IDs produce the same uint64 hash, surfacing misconfiguration at startup rather than silently aliasing two nodes to the same Raft peer ID.

Fixes #1294

## Changed Files

| File | Change |
|------|--------|
| `commercial/ha/raft_consensus.go` | Add `tickInterval` field; update `NewRaftConsensus` to accept `*ClusterConfig`; compute ticks; use `rc.tickInterval` in `runRaft` |
| `commercial/ha/manager.go` | Replace polynomial hash with `fnv.New64a`; add `seenHashes` collision detection; pass `&m.cfg.Cluster` to `NewRaftConsensus` |
| `commercial/ha/raft_consensus_test.go` | Add timing + 4 validation error-path tests; update all call sites to pass `*ClusterConfig`; replace `MockLogger` with `logging.GetLogger()` where log assertions are not needed |
| `commercial/ha/manager_test.go` | Add hash collision and duplicate-ID tests; add fast timing to cluster-mode tests that require elections |

## Specialist Review Results

- **QA Test Runner**: PASS — all 31 tests pass (1 pre-existing skip: `TestManager_HealthChecks` tracking issue #1299); trivy skipped due to sandbox network restriction, not a code defect
- **QA Code Reviewer**: PASS (second pass after fixes) — MockLogger confined to `TestRaftConsensus_propose_logsError` where log assertions are needed; all 4 error-path tests present; nolint directives carry justification comments
- **Security Engineer**: PASS — no hardcoded secrets, no central provider violations, collision error message discloses only infrastructure IDs (not secrets/PII), `hash/fnv` is stdlib only

## Test Plan

- [ ] `TestRaftConsensus_TimingDerivedFromClusterConfig`: 500ms/5s config → `tickInterval=500ms`, `HeartbeatTick=1`, `ElectionTick=10`
- [ ] `TestRaftConsensus_NewRaftConsensus_NilClusterCfgReturnsError`
- [ ] `TestRaftConsensus_NewRaftConsensus_ZeroHeartbeatIntervalReturnsError`
- [ ] `TestRaftConsensus_NewRaftConsensus_ZeroElectionTimeoutReturnsError`
- [ ] `TestRaftConsensus_NewRaftConsensus_ElectionTickTooSmallReturnsError`
- [ ] `TestHashStringToUint64_DistinguishesKnownPolynomialColliders`: `"Aa"` and `"BB"` no longer collide
- [ ] `TestManager_InitRaftConsensus_DuplicateNodeIDReturnsError`: duplicate peer IDs return error
- [ ] All pre-existing tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)