### PR TITLE
storage: define PushStore interface and SQLite implementation (Issue #1317)

### DIFF
--- a/features/workflow/trigger/integration_test.go
+++ b/features/workflow/trigger/integration_test.go
@@ -155,6 +155,10 @@ func (t *TestStorageProvider) CreateTriggerStore(_ map[string]interface{}) (busi
 	return newInMemoryTriggerStore(), nil
 }
 
+func (t *TestStorageProvider) CreatePushStore(_ map[string]interface{}) (business.PushStore, error) {
+	return nil, business.ErrNotSupported
+}
+
 func (t *TestStorageProvider) GetCapabilities() interfaces.ProviderCapabilities {
 	return interfaces.ProviderCapabilities{
 		MaxBatchSize:          100,

--- a/features/workflow/trigger/manager_test.go
+++ b/features/workflow/trigger/manager_test.go
@@ -124,6 +124,10 @@ func (m *MockStorageProvider) CreateTriggerStore(_ map[string]interface{}) (busi
 	return nil, business.ErrNotSupported
 }
 
+func (m *MockStorageProvider) CreatePushStore(_ map[string]interface{}) (business.PushStore, error) {
+	return nil, business.ErrNotSupported
+}
+
 func (m *MockStorageProvider) GetCapabilities() interfaces.ProviderCapabilities {
 	args := m.Called()
 	return args.Get(0).(interfaces.ProviderCapabilities)

--- a/pkg/storage/interfaces/business/push_store.go
+++ b/pkg/storage/interfaces/business/push_store.go
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+// Package business defines the PushStore interface for durable push-state persistence.
+package business
+
+import (
+	"context"
+	"errors"
+	"time"
+)
+
+// ErrPushNotFound is returned when a push record does not exist.
+var ErrPushNotFound = errors.New("push record not found")
+
+// PushStatus represents the lifecycle state of a configuration push operation.
+type PushStatus string
+
+const (
+	// PushStatusPending indicates the push has been created but not yet started.
+	PushStatusPending PushStatus = "pending"
+
+	// PushStatusInProgress indicates the push is actively being distributed.
+	PushStatusInProgress PushStatus = "in_progress"
+
+	// PushStatusCompleted indicates the push completed successfully.
+	PushStatusCompleted PushStatus = "completed"
+
+	// PushStatusFailed indicates the push encountered a terminal error.
+	PushStatusFailed PushStatus = "failed"
+)
+
+// PushRecord holds the durable state for a single configuration push operation.
+// Data stores the full StewardConfiguration as a JSON blob so the push can be
+// replayed by a new leader without referencing the push package.
+type PushRecord struct {
+	// ID is the unique push operation identifier.
+	ID string
+
+	// ConfigID is the identifier of the configuration being pushed.
+	ConfigID string
+
+	// TenantID is the tenant that owns this push.
+	TenantID string
+
+	// Version is the configuration version being pushed.
+	Version string
+
+	// Status is the current lifecycle state of the push.
+	Status PushStatus
+
+	// InitiatedBy identifies the user or system that initiated the push.
+	InitiatedBy string
+
+	// Data is the full StewardConfiguration JSON blob for replay.
+	Data []byte
+
+	// CreatedAt is the time the push record was created.
+	CreatedAt time.Time
+
+	// UpdatedAt is the time the push record was last modified.
+	UpdatedAt time.Time
+}
+
+// PushStore defines the storage interface for durable push-state persistence.
+//
+// A new leader uses this interface to resume pending and in-progress pushes
+// after a failover, replaying the stored StewardConfiguration blob rather than
+// reconstructing the push from the feature layer.
+type PushStore interface {
+	// CreatePush inserts a new push record with status PushStatusPending.
+	CreatePush(ctx context.Context, record *PushRecord) error
+
+	// UpdatePushStatus updates the status and updated_at of the given push record.
+	// Returns ErrPushNotFound if no record exists for the ID.
+	UpdatePushStatus(ctx context.Context, id string, status PushStatus) error
+
+	// GetPendingPushes returns all records with status pending or in_progress.
+	// A new leader calls this to resume both states after failover.
+	GetPendingPushes(ctx context.Context) ([]*PushRecord, error)
+
+	// GetPush retrieves the push record for the given ID.
+	// Returns ErrPushNotFound if no record exists.
+	GetPush(ctx context.Context, id string) (*PushRecord, error)
+}

--- a/pkg/storage/interfaces/hybrid_manager_test.go
+++ b/pkg/storage/interfaces/hybrid_manager_test.go
@@ -373,6 +373,10 @@ func (p *mockProvider) CreateTriggerStore(_ map[string]interface{}) (business.Tr
 	return nil, business.ErrNotSupported
 }
 
+func (p *mockProvider) CreatePushStore(_ map[string]interface{}) (business.PushStore, error) {
+	return nil, business.ErrNotSupported
+}
+
 func (p *mockProvider) GetCapabilities() ProviderCapabilities {
 	return ProviderCapabilities{
 		SupportsTransactions:   true,

--- a/pkg/storage/interfaces/provider.go
+++ b/pkg/storage/interfaces/provider.go
@@ -45,6 +45,7 @@ type BusinessStoreBundle struct {
 	Session           business.SessionStore
 	Command           business.CommandStore
 	Trigger           business.TriggerStore
+	Push              business.PushStore
 }
 
 // BusinessStoreOpener is an optional StorageProvider extension. A provider that
@@ -74,6 +75,7 @@ type StorageProvider interface {
 	CreateStewardStore(config map[string]interface{}) (business.StewardStore, error)
 	CreateCommandStore(config map[string]interface{}) (business.CommandStore, error)
 	CreateTriggerStore(config map[string]interface{}) (business.TriggerStore, error)
+	CreatePushStore(config map[string]interface{}) (business.PushStore, error)
 
 	// Provider capabilities and metadata
 	GetCapabilities() ProviderCapabilities
@@ -477,6 +479,11 @@ func CreateAllStoresFromConfig(providerName string, config map[string]interface{
 		return nil, fmt.Errorf("failed to create trigger store: %w", err)
 	}
 
+	pushStore, err := provider.CreatePushStore(config)
+	if err != nil && !errors.Is(err, business.ErrNotSupported) {
+		return nil, fmt.Errorf("failed to create push store: %w", err)
+	}
+
 	return &StorageManager{
 		providerName:           providerName,
 		provider:               provider,
@@ -490,6 +497,7 @@ func CreateAllStoresFromConfig(providerName string, config map[string]interface{
 		stewardStore:           stewardStore,
 		commandStore:           commandStore,
 		triggerStore:           triggerStore,
+		pushStore:              pushStore,
 	}, nil
 }
 
@@ -507,6 +515,7 @@ type StorageManager struct {
 	stewardStore           business.StewardStore
 	commandStore           business.CommandStore
 	triggerStore           business.TriggerStore
+	pushStore              business.PushStore
 }
 
 // GetProviderName returns the name of the storage provider.
@@ -569,6 +578,11 @@ func (sm *StorageManager) GetTriggerStore() business.TriggerStore {
 	return sm.triggerStore
 }
 
+// GetPushStore returns the push-state storage interface (nil if not supported by provider).
+func (sm *StorageManager) GetPushStore() business.PushStore {
+	return sm.pushStore
+}
+
 // GetCapabilities returns the provider's capabilities.
 // Returns a zero-value ProviderCapabilities when the manager has no backing provider
 // (e.g. a composite manager created with NewStorageManagerFromStores).
@@ -610,6 +624,7 @@ func (sm *StorageManager) Close() error {
 		sm.stewardStore,
 		sm.commandStore,
 		sm.triggerStore,
+		sm.pushStore,
 	}
 	var firstErr error
 	for _, s := range slots {
@@ -681,6 +696,7 @@ func NewStorageManagerFromStores(
 	stewardStore business.StewardStore,
 	commandStore business.CommandStore,
 	triggerStore business.TriggerStore,
+	pushStore business.PushStore,
 ) *StorageManager {
 	return &StorageManager{
 		providerName:           "composite",
@@ -695,6 +711,7 @@ func NewStorageManagerFromStores(
 		stewardStore:           stewardStore,
 		commandStore:           commandStore,
 		triggerStore:           triggerStore,
+		pushStore:              pushStore,
 	}
 }
 
@@ -749,7 +766,7 @@ func CreateOSSStorageManager(flatfileRoot, sqliteConnStr string) (*StorageManage
 			configStore, auditStore,
 			bundle.RBAC, bundle.Tenant, bundle.ClientTenant,
 			bundle.RegistrationToken, bundle.Session,
-			stewardStore, bundle.Command, bundle.Trigger,
+			stewardStore, bundle.Command, bundle.Trigger, bundle.Push,
 		), nil
 	}
 
@@ -781,10 +798,14 @@ func CreateOSSStorageManager(flatfileRoot, sqliteConnStr string) (*StorageManage
 	if err != nil && !errors.Is(err, business.ErrNotSupported) {
 		return nil, fmt.Errorf("failed to create trigger store (sqlite): %w", err)
 	}
+	pushStore, err := sqProvider.CreatePushStore(sqliteCfg)
+	if err != nil && !errors.Is(err, business.ErrNotSupported) {
+		return nil, fmt.Errorf("failed to create push store (sqlite): %w", err)
+	}
 
 	return NewStorageManagerFromStores(
 		configStore, auditStore, rbacStore,
 		tenantStore, clientTenantStore, registrationTokenStore,
-		sessionStore, stewardStore, commandStore, triggerStore,
+		sessionStore, stewardStore, commandStore, triggerStore, pushStore,
 	), nil
 }

--- a/pkg/storage/interfaces/provider_test.go
+++ b/pkg/storage/interfaces/provider_test.go
@@ -160,6 +160,10 @@ func (m *MockStorageProvider) CreateTriggerStore(_ map[string]interface{}) (busi
 	return nil, business.ErrNotSupported
 }
 
+func (m *MockStorageProvider) CreatePushStore(_ map[string]interface{}) (business.PushStore, error) {
+	return nil, business.ErrNotSupported
+}
+
 // Mock implementations of store interfaces
 type MockClientTenantStore struct {
 	tenants map[string]*business.ClientTenant
@@ -488,6 +492,22 @@ func (m *MockCommandStore) PurgeExpiredRecords(_ context.Context, _ time.Time) (
 func (m *MockCommandStore) HealthCheck(_ context.Context) error { return nil }
 func (m *MockCommandStore) Close() error                        { return nil }
 
+// MockPushStore implements business.PushStore for testing
+type MockPushStore struct{}
+
+func (m *MockPushStore) CreatePush(_ context.Context, _ *business.PushRecord) error {
+	return nil
+}
+func (m *MockPushStore) UpdatePushStatus(_ context.Context, _ string, _ business.PushStatus) error {
+	return nil
+}
+func (m *MockPushStore) GetPendingPushes(_ context.Context) ([]*business.PushRecord, error) {
+	return nil, nil
+}
+func (m *MockPushStore) GetPush(_ context.Context, _ string) (*business.PushRecord, error) {
+	return nil, nil
+}
+
 // Test provider registration
 func TestRegisterStorageProvider(t *testing.T) {
 	// Clear registry for test
@@ -786,7 +806,7 @@ func TestNewStorageManagerFromStores(t *testing.T) {
 		sm := NewStorageManagerFromStores(
 			&MockConfigStore{}, &MockAuditStore{}, &MockRBACStore{},
 			&MockTenantStore{}, newMockClientTenantStore(), &MockRegistrationTokenStore{},
-			nil, nil, nil, nil,
+			nil, nil, nil, nil, nil,
 		)
 
 		if sm.GetProviderName() != "composite" {
@@ -798,7 +818,7 @@ func TestNewStorageManagerFromStores(t *testing.T) {
 	})
 
 	t.Run("GetCapabilities returns zero value without panic", func(t *testing.T) {
-		sm := NewStorageManagerFromStores(nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+		sm := NewStorageManagerFromStores(nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 		caps := sm.GetCapabilities()
 		// Zero value - no field should be set
 		if caps.SupportsTransactions || caps.SupportsVersioning || caps.MaxBatchSize != 0 {
@@ -807,14 +827,14 @@ func TestNewStorageManagerFromStores(t *testing.T) {
 	})
 
 	t.Run("GetVersion returns composite without panic", func(t *testing.T) {
-		sm := NewStorageManagerFromStores(nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+		sm := NewStorageManagerFromStores(nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 		if sm.GetVersion() != "composite" {
 			t.Errorf("expected version %q, got %q", "composite", sm.GetVersion())
 		}
 	})
 
 	t.Run("GetProvider returns nil without panic", func(t *testing.T) {
-		sm := NewStorageManagerFromStores(nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+		sm := NewStorageManagerFromStores(nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 		if sm.GetProvider() != nil {
 			t.Errorf("expected nil from GetProvider on composite manager")
 		}
@@ -827,11 +847,12 @@ func TestNewStorageManagerFromStores(t *testing.T) {
 		tenantStore := &MockTenantStore{}
 		clientTenantStore := newMockClientTenantStore()
 		registrationTokenStore := &MockRegistrationTokenStore{}
+		pushStore := &MockPushStore{}
 
 		sm := NewStorageManagerFromStores(
 			configStore, auditStore, rbacStore,
 			tenantStore, clientTenantStore, registrationTokenStore,
-			nil, nil, nil, nil,
+			nil, nil, nil, nil, pushStore,
 		)
 
 		if sm.GetConfigStore() != configStore {
@@ -864,10 +885,13 @@ func TestNewStorageManagerFromStores(t *testing.T) {
 		if sm.GetTriggerStore() != nil {
 			t.Errorf("TriggerStore should be nil")
 		}
+		if sm.GetPushStore() != pushStore {
+			t.Errorf("PushStore mismatch")
+		}
 	})
 
 	t.Run("nil values allowed for all stores", func(t *testing.T) {
-		sm := NewStorageManagerFromStores(nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+		sm := NewStorageManagerFromStores(nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 		// Should not panic
 		if sm.GetConfigStore() != nil {
 			t.Errorf("expected nil ConfigStore")
@@ -1026,6 +1050,9 @@ func (m *MockOSSProvider) CreateCommandStore(_ map[string]interface{}) (business
 func (m *MockOSSProvider) CreateTriggerStore(_ map[string]interface{}) (business.TriggerStore, error) {
 	return nil, business.ErrNotSupported
 }
+func (m *MockOSSProvider) CreatePushStore(_ map[string]interface{}) (business.PushStore, error) {
+	return nil, business.ErrNotSupported
+}
 
 // MockOSSProviderWithError is an interface stub that returns an error from a designated Create* method.
 // It is used to test that CreateOSSStorageManager propagates store-creation errors correctly.
@@ -1111,6 +1138,12 @@ func (m *MockOSSProviderWithError) CreateTriggerStore(_ map[string]interface{}) 
 	}
 	return nil, business.ErrNotSupported
 }
+func (m *MockOSSProviderWithError) CreatePushStore(_ map[string]interface{}) (business.PushStore, error) {
+	if err := m.mayFail("CreatePushStore"); err != nil {
+		return nil, err
+	}
+	return nil, business.ErrNotSupported
+}
 
 func TestCreateOSSStorageManager_StoreCreationErrors(t *testing.T) {
 	// Save and clear registry
@@ -1145,6 +1178,7 @@ func TestCreateOSSStorageManager_StoreCreationErrors(t *testing.T) {
 		"CreateRegistrationTokenStore",
 		"CreateSessionStore",
 		"CreateCommandStore",
+		"CreatePushStore",
 	}
 
 	for _, failMethod := range flatfileFailures {

--- a/pkg/storage/providers/database/plugin.go
+++ b/pkg/storage/providers/database/plugin.go
@@ -166,6 +166,12 @@ func (p *DatabaseProvider) CreateTriggerStore(config map[string]interface{}) (bu
 	return nil, business.ErrNotSupported
 }
 
+// CreatePushStore is not supported by the database provider.
+// Push-state persistence belongs in the business-data tier (SQLite for OSS).
+func (p *DatabaseProvider) CreatePushStore(config map[string]interface{}) (business.PushStore, error) {
+	return nil, business.ErrNotSupported
+}
+
 func (p *DatabaseProvider) CreateRegistrationTokenStore(config map[string]interface{}) (business.RegistrationTokenStore, error) {
 	// Get database connection string from config
 	dsn, err := p.getDSN(config)

--- a/pkg/storage/providers/flatfile/plugin.go
+++ b/pkg/storage/providers/flatfile/plugin.go
@@ -208,6 +208,12 @@ func (p *FlatFileProvider) CreateTriggerStore(config map[string]interface{}) (bu
 	return nil, ErrNotSupported
 }
 
+// CreatePushStore returns ErrNotSupported.
+// Push-state persistence belongs in the business-data tier (SQLite).
+func (p *FlatFileProvider) CreatePushStore(config map[string]interface{}) (business.PushStore, error) {
+	return nil, ErrNotSupported
+}
+
 // init auto-registers the flat-file provider so that a blank import is sufficient.
 func init() {
 	interfaces.RegisterStorageProvider(&FlatFileProvider{})

--- a/pkg/storage/providers/sqlite/plugin.go
+++ b/pkg/storage/providers/sqlite/plugin.go
@@ -262,6 +262,15 @@ func (p *SQLiteProvider) CreateTriggerStore(config map[string]interface{}) (busi
 	return &SQLiteTriggerStore{db: db}, nil
 }
 
+// CreatePushStore returns a SQLite-backed PushStore for durable push-state persistence.
+func (p *SQLiteProvider) CreatePushStore(config map[string]interface{}) (business.PushStore, error) {
+	db, err := openAndInit(getPath(config))
+	if err != nil {
+		return nil, err
+	}
+	return &SQLitePushStore{db: db}, nil
+}
+
 // OpenBusinessStores implements interfaces.BusinessStoreOpener.
 // It opens the SQLite database at path exactly once, runs schema initialisation,
 // and returns all seven business stores sharing the same *sql.DB connection pool.
@@ -282,6 +291,7 @@ func (p *SQLiteProvider) OpenBusinessStores(path string) (*interfaces.BusinessSt
 		Session:           &SQLiteSessionStore{db: db},
 		Command:           &SQLiteCommandStore{db: db},
 		Trigger:           &SQLiteTriggerStore{db: db},
+		Push:              &SQLitePushStore{db: db},
 	}, nil
 }
 

--- a/pkg/storage/providers/sqlite/push_store.go
+++ b/pkg/storage/providers/sqlite/push_store.go
@@ -1,0 +1,165 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+// Package sqlite implements PushStore using SQLite for durable push-state persistence.
+package sqlite
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"strings"
+
+	business "github.com/cfgis/cfgms/pkg/storage/interfaces/business"
+)
+
+// SQLitePushStore implements business.PushStore using a SQLite database.
+// Records are stored in the push_records table. A new leader queries this
+// table to resume pending and in-progress pushes after failover.
+type SQLitePushStore struct {
+	db *sql.DB
+}
+
+// Initialize is a no-op; schema is applied in openAndInit.
+func (s *SQLitePushStore) Initialize(_ context.Context) error { return nil }
+
+// Close closes the database connection.
+func (s *SQLitePushStore) Close() error {
+	if s.db != nil {
+		return s.db.Close()
+	}
+	return nil
+}
+
+// CreatePush inserts a new push record. Returns an error if a record with the
+// same ID already exists.
+func (s *SQLitePushStore) CreatePush(ctx context.Context, record *business.PushRecord) error {
+	if record == nil {
+		return fmt.Errorf("sqlite: push record cannot be nil")
+	}
+	if record.ID == "" {
+		return fmt.Errorf("sqlite: push record ID cannot be empty")
+	}
+
+	now := nowUTC()
+	status := record.Status
+	if status == "" {
+		status = business.PushStatusPending
+	}
+	createdAt := record.CreatedAt
+	if createdAt.IsZero() {
+		createdAt = now
+	}
+
+	_, err := s.db.ExecContext(ctx, `
+		INSERT INTO push_records
+			(id, config_id, tenant_id, version, status, initiated_by, data, created_at, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		record.ID,
+		record.ConfigID,
+		record.TenantID,
+		record.Version,
+		string(status),
+		record.InitiatedBy,
+		record.Data,
+		formatTime(createdAt),
+		formatTime(now),
+	)
+	if err != nil {
+		if strings.Contains(err.Error(), "UNIQUE constraint failed") {
+			return fmt.Errorf("sqlite: push record %s already exists", record.ID)
+		}
+		return fmt.Errorf("sqlite: failed to create push record %s: %w", record.ID, err)
+	}
+	return nil
+}
+
+// UpdatePushStatus updates the status and updated_at of the given push record.
+// Returns ErrPushNotFound if no record exists for the ID.
+func (s *SQLitePushStore) UpdatePushStatus(ctx context.Context, id string, status business.PushStatus) error {
+	res, err := s.db.ExecContext(ctx, `
+		UPDATE push_records SET status = ?, updated_at = ? WHERE id = ?`,
+		string(status), formatTime(nowUTC()), id,
+	)
+	if err != nil {
+		return fmt.Errorf("sqlite: failed to update push status for %s: %w", id, err)
+	}
+	n, _ := res.RowsAffected()
+	if n == 0 {
+		return business.ErrPushNotFound
+	}
+	return nil
+}
+
+// GetPendingPushes returns all records with status pending or in_progress.
+// Both states are returned so a new leader can resume all unfinished work.
+func (s *SQLitePushStore) GetPendingPushes(ctx context.Context) ([]*business.PushRecord, error) {
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT id, config_id, tenant_id, version, status, initiated_by, data, created_at, updated_at
+		FROM push_records
+		WHERE status IN ('pending', 'in_progress')
+		ORDER BY created_at ASC`,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("sqlite: failed to get pending push records: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	return scanPushRows(rows)
+}
+
+// GetPush retrieves the push record for the given ID.
+// Returns ErrPushNotFound if no record exists.
+func (s *SQLitePushStore) GetPush(ctx context.Context, id string) (*business.PushRecord, error) {
+	row := s.db.QueryRowContext(ctx, `
+		SELECT id, config_id, tenant_id, version, status, initiated_by, data, created_at, updated_at
+		FROM push_records WHERE id = ?`, id)
+	return scanPushRow(row)
+}
+
+// ---- helpers ----------------------------------------------------------------
+
+// scanPushRow scans a *sql.Row into a PushRecord.
+func scanPushRow(row *sql.Row) (*business.PushRecord, error) {
+	r := &business.PushRecord{}
+	var statusStr, createdStr, updatedStr string
+	err := row.Scan(
+		&r.ID, &r.ConfigID, &r.TenantID, &r.Version,
+		&statusStr, &r.InitiatedBy, &r.Data,
+		&createdStr, &updatedStr,
+	)
+	if err == sql.ErrNoRows {
+		return nil, business.ErrPushNotFound
+	}
+	if err != nil {
+		return nil, fmt.Errorf("sqlite: failed to scan push record: %w", err)
+	}
+	return populatePush(r, statusStr, createdStr, updatedStr), nil
+}
+
+// scanPushRows scans *sql.Rows into a slice of PushRecords.
+func scanPushRows(rows *sql.Rows) ([]*business.PushRecord, error) {
+	var records []*business.PushRecord
+	for rows.Next() {
+		r := &business.PushRecord{}
+		var statusStr, createdStr, updatedStr string
+		if err := rows.Scan(
+			&r.ID, &r.ConfigID, &r.TenantID, &r.Version,
+			&statusStr, &r.InitiatedBy, &r.Data,
+			&createdStr, &updatedStr,
+		); err != nil {
+			return nil, fmt.Errorf("sqlite: failed to scan push record row: %w", err)
+		}
+		records = append(records, populatePush(r, statusStr, createdStr, updatedStr))
+	}
+	return records, rows.Err()
+}
+
+// populatePush fills in the time and status fields from their string representations.
+func populatePush(r *business.PushRecord, statusStr, createdStr, updatedStr string) *business.PushRecord {
+	r.Status = business.PushStatus(statusStr)
+	r.CreatedAt = parseTime(createdStr)
+	r.UpdatedAt = parseTime(updatedStr)
+	return r
+}
+
+// Compile-time assertion
+var _ business.PushStore = (*SQLitePushStore)(nil)

--- a/pkg/storage/providers/sqlite/push_store_test.go
+++ b/pkg/storage/providers/sqlite/push_store_test.go
@@ -1,0 +1,177 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+package sqlite
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	business "github.com/cfgis/cfgms/pkg/storage/interfaces/business"
+)
+
+// newTestPushStore creates an in-memory SQLite PushStore for tests.
+func newTestPushStore(t *testing.T) *SQLitePushStore {
+	t.Helper()
+	db, err := openAndInit(":memory:")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+	return &SQLitePushStore{db: db}
+}
+
+// testPushRecord returns a PushRecord with sensible defaults.
+func testPushRecord(id string) *business.PushRecord {
+	return &business.PushRecord{
+		ID:          id,
+		ConfigID:    "cfg-" + id,
+		TenantID:    "tenant-1",
+		Version:     "v1.0.0",
+		Status:      business.PushStatusPending,
+		InitiatedBy: "user@example.com",
+		Data:        []byte(`{"steward_id":"` + id + `"}`),
+	}
+}
+
+func TestPushStore_CreateAndRetrieve(t *testing.T) {
+	store := newTestPushStore(t)
+	ctx := context.Background()
+
+	rec := testPushRecord("push-001")
+	require.NoError(t, store.CreatePush(ctx, rec))
+
+	got, err := store.GetPush(ctx, "push-001")
+	require.NoError(t, err)
+
+	assert.Equal(t, "push-001", got.ID)
+	assert.Equal(t, "cfg-push-001", got.ConfigID)
+	assert.Equal(t, "tenant-1", got.TenantID)
+	assert.Equal(t, "v1.0.0", got.Version)
+	assert.Equal(t, business.PushStatusPending, got.Status)
+	assert.Equal(t, "user@example.com", got.InitiatedBy)
+	assert.Equal(t, rec.Data, got.Data)
+	assert.False(t, got.CreatedAt.IsZero(), "CreatedAt should be set")
+	assert.False(t, got.UpdatedAt.IsZero(), "UpdatedAt should be set")
+}
+
+func TestPushStore_GetPendingPushes(t *testing.T) {
+	store := newTestPushStore(t)
+	ctx := context.Background()
+
+	pending := testPushRecord("push-pending")
+	pending.Status = business.PushStatusPending
+	require.NoError(t, store.CreatePush(ctx, pending))
+
+	inProgress := testPushRecord("push-inprogress")
+	inProgress.Status = business.PushStatusInProgress
+	require.NoError(t, store.CreatePush(ctx, inProgress))
+
+	completed := testPushRecord("push-completed")
+	completed.Status = business.PushStatusCompleted
+	require.NoError(t, store.CreatePush(ctx, completed))
+
+	results, err := store.GetPendingPushes(ctx)
+	require.NoError(t, err)
+	require.Len(t, results, 2, "only pending and in_progress records should be returned")
+
+	ids := make(map[string]bool)
+	for _, r := range results {
+		ids[r.ID] = true
+	}
+	assert.True(t, ids["push-pending"], "pending record should be included")
+	assert.True(t, ids["push-inprogress"], "in_progress record should be included")
+	assert.False(t, ids["push-completed"], "completed record should not be included")
+}
+
+func TestPushStore_GetPendingPushes_FailedExcluded(t *testing.T) {
+	store := newTestPushStore(t)
+	ctx := context.Background()
+
+	failed := testPushRecord("push-failed")
+	failed.Status = business.PushStatusFailed
+	require.NoError(t, store.CreatePush(ctx, failed))
+
+	results, err := store.GetPendingPushes(ctx)
+	require.NoError(t, err)
+	assert.Empty(t, results, "failed records should not be returned")
+}
+
+func TestPushStore_GetPendingPushes_Empty(t *testing.T) {
+	store := newTestPushStore(t)
+	results, err := store.GetPendingPushes(context.Background())
+	require.NoError(t, err)
+	assert.Empty(t, results)
+}
+
+func TestPushStore_GetPush_NotFound(t *testing.T) {
+	store := newTestPushStore(t)
+	_, err := store.GetPush(context.Background(), "does-not-exist")
+	assert.ErrorIs(t, err, business.ErrPushNotFound)
+}
+
+func TestPushStore_UpdatePushStatus(t *testing.T) {
+	store := newTestPushStore(t)
+	ctx := context.Background()
+
+	require.NoError(t, store.CreatePush(ctx, testPushRecord("push-upd")))
+	require.NoError(t, store.UpdatePushStatus(ctx, "push-upd", business.PushStatusInProgress))
+
+	got, err := store.GetPush(ctx, "push-upd")
+	require.NoError(t, err)
+	assert.Equal(t, business.PushStatusInProgress, got.Status)
+	assert.False(t, got.UpdatedAt.IsZero())
+}
+
+func TestPushStore_UpdatePushStatus_NotFound(t *testing.T) {
+	store := newTestPushStore(t)
+	err := store.UpdatePushStatus(context.Background(), "ghost", business.PushStatusFailed)
+	assert.ErrorIs(t, err, business.ErrPushNotFound)
+}
+
+func TestPushStore_CreatePush_NilRecord(t *testing.T) {
+	store := newTestPushStore(t)
+	err := store.CreatePush(context.Background(), nil)
+	assert.Error(t, err)
+}
+
+func TestPushStore_CreatePush_EmptyID(t *testing.T) {
+	store := newTestPushStore(t)
+	err := store.CreatePush(context.Background(), &business.PushRecord{})
+	assert.Error(t, err)
+}
+
+func TestPushStore_RestartPersistence(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "push.db")
+	ctx := context.Background()
+
+	db1, err := openAndInit(dbPath)
+	require.NoError(t, err)
+	store1 := &SQLitePushStore{db: db1}
+
+	require.NoError(t, store1.CreatePush(ctx, testPushRecord("push-persist")))
+	require.NoError(t, store1.UpdatePushStatus(ctx, "push-persist", business.PushStatusInProgress))
+	require.NoError(t, store1.Close())
+
+	db2, err := openAndInit(dbPath)
+	require.NoError(t, err)
+	store2 := &SQLitePushStore{db: db2}
+	defer func() { _ = store2.Close() }()
+
+	got, err := store2.GetPush(ctx, "push-persist")
+	require.NoError(t, err)
+	assert.Equal(t, "push-persist", got.ID)
+	assert.Equal(t, business.PushStatusInProgress, got.Status)
+
+	pending, err := store2.GetPendingPushes(ctx)
+	require.NoError(t, err)
+	assert.Len(t, pending, 1)
+	assert.Equal(t, "push-persist", pending[0].ID)
+}
+
+func TestPushStore_Initialize(t *testing.T) {
+	store := newTestPushStore(t)
+	assert.NoError(t, store.Initialize(context.Background()))
+	assert.NoError(t, store.Initialize(context.Background()))
+}

--- a/pkg/storage/providers/sqlite/schema.go
+++ b/pkg/storage/providers/sqlite/schema.go
@@ -337,6 +337,23 @@ func initializeSchema(ctx context.Context, db *sql.DB) error {
 		`CREATE INDEX IF NOT EXISTS idx_triggers_type      ON triggers(type)`,
 		`CREATE INDEX IF NOT EXISTS idx_triggers_status    ON triggers(status)`,
 
+		// Push records — durable configuration push state (Issue #1317)
+		// Stores pending and in-progress push operations so a new leader can resume
+		// after failover. The data column holds the full StewardConfiguration JSON blob.
+		`CREATE TABLE IF NOT EXISTS push_records (
+			id           TEXT PRIMARY KEY,
+			config_id    TEXT NOT NULL,
+			tenant_id    TEXT NOT NULL,
+			version      TEXT NOT NULL,
+			status       TEXT NOT NULL,
+			initiated_by TEXT NOT NULL,
+			data         BLOB NOT NULL,
+			created_at   TEXT NOT NULL,
+			updated_at   TEXT NOT NULL
+		)`,
+		`CREATE INDEX IF NOT EXISTS idx_push_records_status    ON push_records(status)`,
+		`CREATE INDEX IF NOT EXISTS idx_push_records_tenant_id ON push_records(tenant_id)`,
+
 		// Durable sessions (Persistent=true only)
 		`CREATE TABLE IF NOT EXISTS sessions (
 			session_id       TEXT PRIMARY KEY,


### PR DESCRIPTION
## Summary

- Defines `PushStore` interface (`pkg/storage/interfaces/business/push_store.go`) with `PushStatus` type, `PushRecord` struct, and four methods: `CreatePush`, `UpdatePushStatus`, `GetPendingPushes`, `GetPush`
- Adds `push_records` table DDL to SQLite schema and a fully-wired `SQLitePushStore` implementation that stores the `StewardConfiguration` JSON blob for leader-failover replay
- Wires `PushStore` into `StorageManager`, `BusinessStoreBundle`, all providers, and all call sites of `NewStorageManagerFromStores`

Fixes #1317

## Specialist Review Results

**QA Test Runner: PASS** — All code tests pass (unit, integration, cross-platform builds, lint, license headers, architecture checks). Trivy skipped due to container network restrictions (no outbound access to mirror.gcr.io); will run cleanly in CI.

**QA Code Reviewer: PASS** — No blocking issues. `TestPushStore_CreateAndRetrieve` asserts all nine fields; `TestPushStore_GetPendingPushes` verifies pending + in_progress returned, completed/failed excluded; `GetPushStore()` roundtrip tested in `TestNewStorageManagerFromStores`; `CreatePushStore` error injection present in `TestCreateOSSStorageManager_StoreCreationErrors`.

**Security Engineer: PASS** — No blocking issues. All SQL uses `?` parameterized placeholders; no hardcoded secrets; no central provider violations; `tenant_id` stored and indexed per record; `check-architecture` clean.

## Test plan

- [ ] `make test-agent-complete` passes in CI (all required checks)
- [ ] `TestPushStore_CreateAndRetrieve` — all fields round-trip through SQLite
- [ ] `TestPushStore_GetPendingPushes` — only pending/in_progress returned; completed/failed excluded
- [ ] `TestPushStore_RestartPersistence` — records survive store restart using t.TempDir()
- [ ] `TestCreateOSSStorageManager_StoreCreationErrors/sqlite_CreatePushStore_returns_error` — error propagation verified
- [ ] `TestNewStorageManagerFromStores/all_store_parameters_accepted_and_retrievable` — GetPushStore() roundtrip asserted

🤖 Generated with [Claude Code](https://claude.com/claude-code)