### PR TITLE
controller/push: promote StewardConfiguration to canonical production type (Issue #1315)

### DIFF
--- a/features/controller/push/types.go
+++ b/features/controller/push/types.go
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+package push
+
+import "time"
+
+// StewardConfiguration is the canonical type for a configuration push payload
+// delivered to a steward. Shared by the push handler, fan-out logic, and
+// persistence layer so that no duplicate definitions are needed in test code.
+type StewardConfiguration struct {
+	ConfigID  string                 `json:"config_id"`
+	Version   string                 `json:"version"`
+	TenantID  string                 `json:"tenant_id"`
+	Policies  map[string]interface{} `json:"policies"`
+	Modules   []string               `json:"modules"`
+	AppliedAt time.Time              `json:"applied_at"`
+	Source    string                 `json:"source"`
+}

--- a/features/controller/push/types_test.go
+++ b/features/controller/push/types_test.go
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+package push_test
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/cfgis/cfgms/features/controller/push"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStewardConfigurationJSONRoundTrip(t *testing.T) {
+	appliedAt := time.Date(2026, 1, 15, 10, 30, 0, 0, time.UTC)
+	original := push.StewardConfiguration{
+		ConfigID: "cfg-001",
+		Version:  "1.2.3",
+		TenantID: "tenant-abc",
+		Policies: map[string]interface{}{
+			"security": map[string]interface{}{
+				"enabled": true,
+				"level":   "high",
+			},
+		},
+		Modules:   []string{"file", "directory", "script"},
+		AppliedAt: appliedAt,
+		Source:    "controller-east",
+	}
+
+	data, err := json.Marshal(original)
+	require.NoError(t, err)
+
+	var result push.StewardConfiguration
+	require.NoError(t, json.Unmarshal(data, &result))
+
+	assert.Equal(t, original.ConfigID, result.ConfigID)
+	assert.Equal(t, original.Version, result.Version)
+	assert.Equal(t, original.TenantID, result.TenantID)
+	assert.Equal(t, original.Modules, result.Modules)
+	assert.True(t, original.AppliedAt.Equal(result.AppliedAt))
+	assert.Equal(t, original.Source, result.Source)
+	// Verify full Policies map round-trips, not just a single nested key.
+	require.NotNil(t, result.Policies)
+	security, ok := result.Policies["security"].(map[string]interface{})
+	require.True(t, ok, "policies.security must be a map")
+	assert.Equal(t, true, security["enabled"])
+	assert.Equal(t, "high", security["level"])
+}
+
+func TestStewardConfigurationZeroValue(t *testing.T) {
+	var cfg push.StewardConfiguration
+
+	data, err := json.Marshal(cfg)
+	require.NoError(t, err)
+
+	var result push.StewardConfiguration
+	require.NoError(t, json.Unmarshal(data, &result))
+
+	assert.Empty(t, result.ConfigID)
+	assert.Empty(t, result.Version)
+	assert.Empty(t, result.TenantID)
+	assert.Nil(t, result.Policies)
+	assert.Nil(t, result.Modules)
+	assert.True(t, result.AppliedAt.IsZero())
+	assert.Empty(t, result.Source)
+}

--- a/test/integration/ha/configuration_continuity_test.go
+++ b/test/integration/ha/configuration_continuity_test.go
@@ -15,6 +15,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cfgis/cfgms/features/controller/push"
 	"github.com/stretchr/testify/require"
 )
 
@@ -223,7 +224,7 @@ func testMultipleConfigurationPushesWithFailover(t *testing.T, ctx context.Conte
 	t.Log("Testing multiple configuration pushes with controller failover...")
 
 	// Create multiple test configurations
-	configs := []StewardConfiguration{
+	configs := []push.StewardConfiguration{
 		createTestConfiguration("multi-config-1", "security"),
 		createTestConfiguration("multi-config-2", "monitoring"),
 		createTestConfiguration("multi-config-3", "backup"),
@@ -247,7 +248,7 @@ func testMultipleConfigurationPushesWithFailover(t *testing.T, ctx context.Conte
 	pushResults := make(chan error, len(configs))
 
 	for i, config := range configs {
-		go func(configIndex int, cfg StewardConfiguration) {
+		go func(configIndex int, cfg push.StewardConfiguration) {
 			// Stagger the pushes slightly
 			time.Sleep(time.Duration(configIndex) * 2 * time.Second)
 			err := pushConfigurationToStewards(leaderURL, cfg)
@@ -352,7 +353,7 @@ func testConfigurationRollbackDuringFailover(t *testing.T, ctx context.Context, 
 // Helper functions
 
 // createLargeTestConfiguration creates a large configuration for testing
-func createLargeTestConfiguration(configID string) StewardConfiguration {
+func createLargeTestConfiguration(configID string) push.StewardConfiguration {
 	// Create a configuration with many policies to simulate slow push
 	policies := make(map[string]interface{})
 
@@ -372,7 +373,7 @@ func createLargeTestConfiguration(configID string) StewardConfiguration {
 		}
 	}
 
-	return StewardConfiguration{
+	return push.StewardConfiguration{
 		ConfigID: configID,
 		Version:  "1.0.0",
 		TenantID: "test-tenant",
@@ -382,8 +383,8 @@ func createLargeTestConfiguration(configID string) StewardConfiguration {
 }
 
 // createTestConfiguration creates a test configuration
-func createTestConfiguration(configID string, category string) StewardConfiguration {
-	return StewardConfiguration{
+func createTestConfiguration(configID string, category string) push.StewardConfiguration {
+	return push.StewardConfiguration{
 		ConfigID: configID,
 		Version:  "1.0.0",
 		TenantID: "test-tenant",
@@ -398,7 +399,7 @@ func createTestConfiguration(configID string, category string) StewardConfigurat
 }
 
 // pushLargeConfiguration pushes a large configuration to the controller
-func pushLargeConfiguration(controllerURL string, config StewardConfiguration) error {
+func pushLargeConfiguration(controllerURL string, config push.StewardConfiguration) error {
 	// Call the controller's large config push API and return actual errors
 	client := &http.Client{Timeout: 30 * time.Second}
 

--- a/test/integration/ha/steward_ha_test.go
+++ b/test/integration/ha/steward_ha_test.go
@@ -15,6 +15,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cfgis/cfgms/features/controller/push"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -29,17 +30,6 @@ type StewardStatus struct {
 	LastHeartbeat     time.Time `json:"last_heartbeat"`
 	ConfigurationHash string    `json:"configuration_hash"` // Hash of current configuration
 	ActiveSessions    int       `json:"active_sessions"`    // Number of active gRPC streams
-}
-
-// StewardConfiguration represents a configuration push to steward
-type StewardConfiguration struct {
-	ConfigID  string                 `json:"config_id"`
-	Version   string                 `json:"version"`
-	TenantID  string                 `json:"tenant_id"`
-	Policies  map[string]interface{} `json:"policies"`
-	Modules   []string               `json:"modules"`
-	AppliedAt time.Time              `json:"applied_at"`
-	Source    string                 `json:"source"` // Which controller applied it
 }
 
 // TestStewardControllerHA tests steward High Availability with real controller cluster
@@ -232,7 +222,7 @@ func testConfigurationContinuity(t *testing.T, ctx context.Context, helper *Dock
 	t.Log("Testing configuration push continuity during failover...")
 
 	// Push a test configuration to all stewards
-	testConfig := StewardConfiguration{
+	testConfig := push.StewardConfiguration{
 		ConfigID: "test-config-continuity",
 		Version:  "1.0.0",
 		TenantID: "test-tenant",
@@ -506,7 +496,7 @@ func getStewardStatus(ctx context.Context, helper *DockerComposeHelper, stewardN
 }
 
 // pushConfigurationToStewards pushes configuration to stewards via controller
-func pushConfigurationToStewards(controllerURL string, config StewardConfiguration) error {
+func pushConfigurationToStewards(controllerURL string, config push.StewardConfiguration) error {
 	// Call the controller's config push API and return actual errors
 	client := &http.Client{Timeout: 10 * time.Second}
 


### PR DESCRIPTION
## Summary

- Creates `features/controller/push/types.go` with the canonical `StewardConfiguration` struct (7 fields, JSON tags matching the test-local definition it replaces)
- Adds `features/controller/push/types_test.go` with `TestStewardConfigurationJSONRoundTrip` (full round-trip including Policies map) and `TestStewardConfigurationZeroValue`
- Removes the duplicate local `StewardConfiguration` struct from `test/integration/ha/steward_ha_test.go`
- Updates both `test/integration/ha/steward_ha_test.go` and `test/integration/ha/configuration_continuity_test.go` to import `features/controller/push` and reference `push.StewardConfiguration`

Fixes #1315

## Specialist Review Results

| Agent | Result |
|-------|--------|
| qa-test-runner | PASS — 97 packages, 0 failures; commercial HA build passes |
| qa-code-reviewer | PASS — no blocking issues in-scope; pre-existing t.Skip() in HA helpers confirmed out of scope per story constraints |
| security-engineer | PASS — no hardcoded secrets, no central provider violations, no insecure patterns introduced |

## Test Plan

- [ ] `go test ./features/controller/push/...` — both unit tests pass
- [ ] `go build -tags commercial ./test/integration/ha/...` — integration test package compiles cleanly
- [ ] `make test-agent-complete` — full suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)