### PR TITLE
api: wire script handlers to real ExecutionTracker and AuditLogger (Issue #708)

### DIFF
--- a/features/controller/api/handlers_scripts.go
+++ b/features/controller/api/handlers_scripts.go
@@ -3,7 +3,6 @@
 package api
 
 import (
-	"fmt"
 	"net/http"
 	"strconv"
 	"time"
@@ -11,6 +10,7 @@ import (
 	"github.com/gorilla/mux"
 
 	"github.com/cfgis/cfgms/features/modules/script"
+	"github.com/cfgis/cfgms/pkg/logging"
 )
 
 // ScriptExecutionInfo represents script execution information for API responses
@@ -55,6 +55,34 @@ type ScriptMetricsInfo struct {
 	ShellUsage      map[string]int `json:"shell_usage"`
 }
 
+// executionRecordToInfo maps a durable ExecutionRecord to the API response type.
+func executionRecordToInfo(r *script.ExecutionRecord) ScriptExecutionInfo {
+	info := ScriptExecutionInfo{
+		ID:            r.ExecutionID,
+		StewardID:     r.DeviceID,
+		ResourceID:    r.ScriptRef,
+		ExecutionTime: r.CompletedAt,
+		Duration:      r.DurationMs,
+		Status:        script.ExecutionStatus(r.State),
+		ExitCode:      r.ExitCode,
+		ScriptConfig: ScriptConfigInfo{
+			Shell:         r.Shell,
+			SigningPolicy: "none",
+		},
+		Metrics: script.ExecutionMetrics{
+			EndTime:  r.CompletedAt,
+			Duration: r.DurationMs,
+		},
+	}
+	if r.Stderr != "" {
+		info.ErrorMessage = r.Stderr
+	}
+	if r.DurationMs > 0 {
+		info.Metrics.StartTime = r.CompletedAt.Add(-time.Duration(r.DurationMs) * time.Millisecond)
+	}
+	return info
+}
+
 // handleGetScriptExecutions handles GET /api/v1/stewards/{id}/scripts/executions
 func (s *Server) handleGetScriptExecutions(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
@@ -65,7 +93,14 @@ func (s *Server) handleGetScriptExecutions(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	// Get query parameters
+	if s.scriptTracker == nil {
+		s.writeErrorResponse(w, http.StatusServiceUnavailable, "Script module not available", "SERVICE_UNAVAILABLE")
+		return
+	}
+
+	sanitizedID := logging.SanitizeLogValue(stewardID)
+
+	// Parse query filters
 	query := &script.AuditQuery{
 		StewardID: stewardID,
 	}
@@ -73,76 +108,84 @@ func (s *Server) handleGetScriptExecutions(w http.ResponseWriter, r *http.Reques
 	if resourceID := r.URL.Query().Get("resource_id"); resourceID != "" {
 		query.ResourceID = resourceID
 	}
-
 	if status := r.URL.Query().Get("status"); status != "" {
 		query.Status = script.ExecutionStatus(status)
 	}
-
 	if userID := r.URL.Query().Get("user_id"); userID != "" {
 		query.UserID = userID
 	}
-
 	if tenantID := r.URL.Query().Get("tenant_id"); tenantID != "" {
 		query.TenantID = tenantID
 	}
-
-	// Parse time range
 	if since := r.URL.Query().Get("since"); since != "" {
 		if sinceTime, err := time.Parse(time.RFC3339, since); err == nil {
 			query.StartTime = &sinceTime
 		}
 	}
-
 	if until := r.URL.Query().Get("until"); until != "" {
 		if untilTime, err := time.Parse(time.RFC3339, until); err == nil {
 			query.EndTime = &untilTime
 		}
 	}
 
-	// Parse pagination
+	limit := 100 // default
 	if limitStr := r.URL.Query().Get("limit"); limitStr != "" {
-		if limit, err := strconv.Atoi(limitStr); err == nil && limit > 0 {
-			query.Limit = limit
+		if l, err := strconv.Atoi(limitStr); err == nil && l > 0 {
+			limit = l
 		}
 	}
-
+	offset := 0
 	if offsetStr := r.URL.Query().Get("offset"); offsetStr != "" {
-		if offset, err := strconv.Atoi(offsetStr); err == nil && offset >= 0 {
-			query.Offset = offset
+		if o, err := strconv.Atoi(offsetStr); err == nil && o >= 0 {
+			offset = o
 		}
 	}
 
-	// TODO: Get script module instance for the steward
-	// This would need integration with the steward manager to get the script module
-	// For now, we'll return a placeholder response
-
-	executions := []ScriptExecutionInfo{
-		{
-			ID:            "example-exec-1",
-			StewardID:     stewardID,
-			ResourceID:    "test-script",
-			ExecutionTime: time.Now().Add(-1 * time.Hour),
-			Duration:      5000,
-			Status:        script.StatusCompleted,
-			ExitCode:      0,
-			ScriptConfig: ScriptConfigInfo{
-				Shell:         "bash",
-				Timeout:       30000,
-				SigningPolicy: "none",
-				Description:   "Example script execution",
-				ContentHash:   "sha256:abcd1234",
-				ContentLength: 45,
-			},
-			Metrics: script.ExecutionMetrics{
-				StartTime: time.Now().Add(-1 * time.Hour),
-				EndTime:   time.Now().Add(-1*time.Hour + 5*time.Second),
-				Duration:  5000,
-				ProcessID: 12345,
-			},
-		},
+	// Fetch from durable tracker; request extra to accommodate in-memory offset slicing.
+	fetchLimit := limit + offset
+	records, err := s.scriptTracker.QueryByDevice(r.Context(), stewardID, fetchLimit)
+	if err != nil {
+		s.logger.Error("Failed to query script executions", "steward_id", sanitizedID, "error", err)
+		s.writeErrorResponse(w, http.StatusInternalServerError, "Failed to retrieve executions", "INTERNAL_ERROR")
+		return
 	}
 
-	s.logger.Info("Retrieved script executions", "steward_id", stewardID, "count", len(executions))
+	// Apply in-memory filters for fields the tracker index does not cover.
+	filtered := make([]*script.ExecutionRecord, 0, len(records))
+	for _, rec := range records {
+		if query.ResourceID != "" && rec.ScriptRef != query.ResourceID {
+			continue
+		}
+		if query.Status != "" && script.ExecutionStatus(rec.State) != query.Status {
+			continue
+		}
+		if query.StartTime != nil && rec.CompletedAt.Before(*query.StartTime) {
+			continue
+		}
+		if query.EndTime != nil && rec.CompletedAt.After(*query.EndTime) {
+			continue
+		}
+		filtered = append(filtered, rec)
+	}
+
+	// Apply offset then limit.
+	if offset > 0 {
+		if offset >= len(filtered) {
+			filtered = nil
+		} else {
+			filtered = filtered[offset:]
+		}
+	}
+	if limit > 0 && len(filtered) > limit {
+		filtered = filtered[:limit]
+	}
+
+	executions := make([]ScriptExecutionInfo, len(filtered))
+	for i, rec := range filtered {
+		executions[i] = executionRecordToInfo(rec)
+	}
+
+	s.logger.Info("Retrieved script executions", "steward_id", sanitizedID, "count", len(executions))
 	s.writeSuccessResponse(w, executions)
 }
 
@@ -156,41 +199,36 @@ func (s *Server) handleGetScriptExecution(w http.ResponseWriter, r *http.Request
 		s.writeErrorResponse(w, http.StatusBadRequest, "Steward ID is required", "MISSING_STEWARD_ID")
 		return
 	}
-
 	if executionID == "" {
 		s.writeErrorResponse(w, http.StatusBadRequest, "Execution ID is required", "MISSING_EXECUTION_ID")
 		return
 	}
 
-	// TODO: Get specific execution by ID from script module
-	// For now, return a placeholder response
-
-	execution := ScriptExecutionInfo{
-		ID:            executionID,
-		StewardID:     stewardID,
-		ResourceID:    "test-script",
-		ExecutionTime: time.Now().Add(-1 * time.Hour),
-		Duration:      5000,
-		Status:        script.StatusCompleted,
-		ExitCode:      0,
-		ScriptConfig: ScriptConfigInfo{
-			Shell:         "bash",
-			Timeout:       30000,
-			SigningPolicy: "none",
-			Description:   "Example script execution",
-			ContentHash:   "sha256:abcd1234",
-			ContentLength: 45,
-		},
-		Metrics: script.ExecutionMetrics{
-			StartTime: time.Now().Add(-1 * time.Hour),
-			EndTime:   time.Now().Add(-1*time.Hour + 5*time.Second),
-			Duration:  5000,
-			ProcessID: 12345,
-		},
+	if s.scriptTracker == nil {
+		s.writeErrorResponse(w, http.StatusServiceUnavailable, "Script module not available", "SERVICE_UNAVAILABLE")
+		return
 	}
 
-	s.logger.Info("Retrieved script execution", "steward_id", stewardID, "execution_id", executionID)
-	s.writeSuccessResponse(w, execution)
+	sanitizedStewardID := logging.SanitizeLogValue(stewardID)
+	sanitizedExecutionID := logging.SanitizeLogValue(executionID)
+
+	// 0 = no limit: scan all records for this device to locate the execution.
+	records, err := s.scriptTracker.QueryByDevice(r.Context(), stewardID, 0)
+	if err != nil {
+		s.logger.Error("Failed to query script executions", "steward_id", sanitizedStewardID, "error", err)
+		s.writeErrorResponse(w, http.StatusInternalServerError, "Failed to retrieve execution", "INTERNAL_ERROR")
+		return
+	}
+
+	for _, rec := range records {
+		if rec.ExecutionID == executionID {
+			s.logger.Info("Retrieved script execution", "steward_id", sanitizedStewardID, "execution_id", sanitizedExecutionID)
+			s.writeSuccessResponse(w, executionRecordToInfo(rec))
+			return
+		}
+	}
+
+	s.writeErrorResponse(w, http.StatusNotFound, "Execution not found", "EXECUTION_NOT_FOUND")
 }
 
 // handleGetScriptMetrics handles GET /api/v1/stewards/{id}/scripts/metrics
@@ -203,34 +241,49 @@ func (s *Server) handleGetScriptMetrics(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	// Parse since parameter
-	since := time.Now().Add(-24 * time.Hour) // Default to last 24 hours
+	if s.scriptAuditLogger == nil {
+		s.writeErrorResponse(w, http.StatusServiceUnavailable, "Script module not available", "SERVICE_UNAVAILABLE")
+		return
+	}
+
+	sanitizedID := logging.SanitizeLogValue(stewardID)
+
+	since := time.Now().Add(-24 * time.Hour) // default: last 24 hours
 	if sinceStr := r.URL.Query().Get("since"); sinceStr != "" {
 		if sinceTime, err := time.Parse(time.RFC3339, sinceStr); err == nil {
 			since = sinceTime
 		}
 	}
 
-	// TODO: Get metrics from script module
-	// For now, return placeholder metrics
-
-	metrics := ScriptMetricsInfo{
-		StewardID:       stewardID,
-		Since:           since,
-		Until:           time.Now(),
-		TotalExecutions: 42,
-		SuccessCount:    38,
-		FailureCount:    4,
-		SuccessRate:     90.48,
-		AverageDuration: 3500,
-		ShellUsage: map[string]int{
-			"bash":       25,
-			"powershell": 12,
-			"python":     5,
-		},
+	aggregated, err := s.scriptAuditLogger.GetExecutionMetrics(stewardID, since)
+	if err != nil {
+		s.logger.Error("Failed to get script metrics", "steward_id", sanitizedID, "error", err)
+		s.writeErrorResponse(w, http.StatusInternalServerError, "Failed to retrieve metrics", "INTERNAL_ERROR")
+		return
 	}
 
-	s.logger.Info("Retrieved script metrics", "steward_id", stewardID, "since", since)
+	metrics := ScriptMetricsInfo{
+		StewardID:       aggregated.StewardID,
+		Since:           aggregated.Since,
+		Until:           aggregated.Until,
+		TotalExecutions: aggregated.TotalExecutions,
+		SuccessCount:    aggregated.SuccessCount,
+		FailureCount:    aggregated.FailureCount,
+		SuccessRate:     aggregated.SuccessRate,
+		AverageDuration: aggregated.AverageDuration,
+		ShellUsage:      aggregated.ShellUsage,
+	}
+	if metrics.StewardID == "" {
+		metrics.StewardID = stewardID
+	}
+	if metrics.Since.IsZero() {
+		metrics.Since = since
+	}
+	if metrics.Until.IsZero() {
+		metrics.Until = time.Now()
+	}
+
+	s.logger.Info("Retrieved script metrics", "steward_id", sanitizedID, "since", since)
 	s.writeSuccessResponse(w, metrics)
 }
 
@@ -244,35 +297,60 @@ func (s *Server) handleGetScriptStatus(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// TODO: Get current script execution status from steward
-	// For now, return placeholder status
-
-	status := map[string]interface{}{
-		"steward_id":        stewardID,
-		"script_capability": "enabled",
-		"current_executions": []map[string]interface{}{
-			{
-				"resource_id": "backup-script",
-				"status":      "running",
-				"started_at":  time.Now().Add(-5 * time.Minute),
-				"progress":    75,
-			},
-		},
-		"last_execution": map[string]interface{}{
-			"resource_id":  "health-check",
-			"status":       "completed",
-			"exit_code":    0,
-			"completed_at": time.Now().Add(-10 * time.Minute),
-			"duration_ms":  2340,
-		},
-		"capabilities": map[string]interface{}{
-			"supported_shells": []string{"bash", "sh", "python"},
-			"max_timeout_ms":   300000,
-			"signing_support":  true,
-		},
+	if s.scriptTracker == nil {
+		s.writeErrorResponse(w, http.StatusServiceUnavailable, "Script module not available", "SERVICE_UNAVAILABLE")
+		return
 	}
 
-	s.logger.Info("Retrieved script status", "steward_id", stewardID)
+	sanitizedID := logging.SanitizeLogValue(stewardID)
+
+	// Most-recent completed execution provides the "last execution" summary.
+	recent, err := s.scriptTracker.QueryByDevice(r.Context(), stewardID, 1)
+	if err != nil {
+		s.logger.Error("Failed to get script status", "steward_id", sanitizedID, "error", err)
+		s.writeErrorResponse(w, http.StatusInternalServerError, "Failed to retrieve script status", "INTERNAL_ERROR")
+		return
+	}
+
+	var lastExecution map[string]interface{}
+	if len(recent) > 0 {
+		rec := recent[0]
+		lastExecution = map[string]interface{}{
+			"execution_id": rec.ExecutionID,
+			"resource_id":  rec.ScriptRef,
+			"status":       rec.State,
+			"exit_code":    rec.ExitCode,
+			"completed_at": rec.CompletedAt,
+			"duration_ms":  rec.DurationMs,
+		}
+	}
+
+	// Active executions come from the in-memory monitor (running + pending).
+	activeExecutions := []map[string]interface{}{}
+	if s.scriptMonitor != nil {
+		for _, exec := range s.scriptMonitor.ListExecutions("") {
+			for _, dev := range exec.Devices {
+				if dev.DeviceID == stewardID &&
+					(dev.Status == script.StatusRunning || dev.Status == script.StatusPending) {
+					activeExecutions = append(activeExecutions, map[string]interface{}{
+						"execution_id": exec.ID,
+						"resource_id":  exec.ScriptName,
+						"status":       dev.Status,
+						"started_at":   dev.StartTime,
+					})
+				}
+			}
+		}
+	}
+
+	status := map[string]interface{}{
+		"steward_id":         stewardID,
+		"script_capability":  "enabled",
+		"current_executions": activeExecutions,
+		"last_execution":     lastExecution,
+	}
+
+	s.logger.Info("Retrieved script status", "steward_id", sanitizedID)
 	s.writeSuccessResponse(w, status)
 }
 
@@ -286,26 +364,14 @@ func (s *Server) handlePostScriptRetry(w http.ResponseWriter, r *http.Request) {
 		s.writeErrorResponse(w, http.StatusBadRequest, "Steward ID is required", "MISSING_STEWARD_ID")
 		return
 	}
-
 	if executionID == "" {
 		s.writeErrorResponse(w, http.StatusBadRequest, "Execution ID is required", "MISSING_EXECUTION_ID")
 		return
 	}
 
-	// TODO: Implement retry logic
-	// This would need to:
-	// 1. Get the original execution configuration
-	// 2. Re-execute the script with the same parameters
-	// 3. Return the new execution ID
-
-	result := map[string]interface{}{
-		"original_execution_id": executionID,
-		"new_execution_id":      fmt.Sprintf("%s-retry-1", executionID),
-		"status":                "initiated",
-		"retry_count":           1,
-		"initiated_at":          time.Now(),
-	}
-
-	s.logger.Info("Initiated script retry", "steward_id", stewardID, "execution_id", executionID)
-	s.writeSuccessResponse(w, result)
+	s.logger.Info("Script retry requested but not implemented",
+		"steward_id", logging.SanitizeLogValue(stewardID),
+		"execution_id", logging.SanitizeLogValue(executionID),
+	)
+	s.writeErrorResponse(w, http.StatusNotImplemented, "Script retry is not yet implemented", "NOT_IMPLEMENTED")
 }

--- a/features/controller/api/handlers_scripts_test.go
+++ b/features/controller/api/handlers_scripts_test.go
@@ -1,0 +1,356 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+package api
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cfgis/cfgms/features/modules/script"
+)
+
+// newTestScriptTracker opens an in-memory SQLite database and returns a ready
+// ExecutionTrackingStore. The database is closed automatically via t.Cleanup.
+func newTestScriptTracker(t *testing.T) *script.ExecutionTrackingStore {
+	t.Helper()
+
+	db, err := sql.Open("sqlite", ":memory:")
+	require.NoError(t, err, "open in-memory sqlite")
+	t.Cleanup(func() { _ = db.Close() })
+
+	store := script.NewExecutionTrackingStore(db)
+	require.NoError(t, store.Init(context.Background()), "tracker Init must succeed")
+	return store
+}
+
+// seedExecution writes a completed execution record to the tracker.
+func seedExecution(t *testing.T, tracker *script.ExecutionTrackingStore, executionID, deviceID, scriptRef, state string) {
+	t.Helper()
+	now := time.Now().UTC().Truncate(time.Second)
+	rec := &script.ExecutionRecord{
+		ExecutionID:  executionID,
+		DeviceID:     deviceID,
+		ScriptRef:    scriptRef,
+		Shell:        "bash",
+		ExitCode:     0,
+		State:        state,
+		DurationMs:   1500,
+		QueuedAt:     now.Add(-10 * time.Second),
+		DispatchedAt: now.Add(-5 * time.Second),
+		CompletedAt:  now,
+	}
+	require.NoError(t, tracker.Record(context.Background(), rec))
+}
+
+// setupScriptServer creates a test server with a real script tracker, audit logger,
+// and execution monitor wired in.
+func setupScriptServer(t *testing.T) (*Server, *script.ExecutionTrackingStore) {
+	t.Helper()
+	server := setupTestServer(t)
+	tracker := newTestScriptTracker(t)
+	auditLogger := script.NewAuditLogger(1000)
+	monitor := script.NewExecutionMonitor()
+	server.SetScriptModule(tracker, auditLogger, monitor)
+	return server, tracker
+}
+
+// TestHandleListScriptExecutions_Real verifies that the list handler returns actual
+// records from the tracker, not hardcoded stub data.
+func TestHandleListScriptExecutions_Real(t *testing.T) {
+	server, tracker := setupScriptServer(t)
+	apiKey := NewTestKey(t, server, []string{"steward:read-scripts"})
+
+	seedExecution(t, tracker, "exec-001", "steward-abc", "scripts/backup.sh", "completed")
+	seedExecution(t, tracker, "exec-002", "steward-abc", "scripts/health.sh", "completed")
+	seedExecution(t, tracker, "exec-003", "steward-xyz", "scripts/other.sh", "completed")
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/stewards/steward-abc/scripts/executions", nil)
+	req.Header.Set("X-API-Key", apiKey)
+	rec := httptest.NewRecorder()
+	server.router.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var resp APIResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+
+	items, ok := resp.Data.([]interface{})
+	require.True(t, ok, "expected array in response data")
+	assert.Len(t, items, 2, "should return only the two records for steward-abc")
+
+	// Verify the returned records are the real ones and not the old hardcoded stub.
+	ids := make([]string, 0, len(items))
+	for _, item := range items {
+		m := item.(map[string]interface{})
+		ids = append(ids, m["id"].(string))
+		// Confirm steward_id matches the queried steward.
+		assert.Equal(t, "steward-abc", m["steward_id"].(string))
+		// The old stub always used "example-exec-1" as the ID.
+		assert.NotEqual(t, "example-exec-1", m["id"].(string))
+	}
+	assert.Contains(t, ids, "exec-001")
+	assert.Contains(t, ids, "exec-002")
+}
+
+// TestHandleListScriptExecutions_Pagination verifies limit and offset work correctly.
+func TestHandleListScriptExecutions_Pagination(t *testing.T) {
+	server, tracker := setupScriptServer(t)
+	apiKey := NewTestKey(t, server, []string{"steward:read-scripts"})
+
+	for i := 0; i < 5; i++ {
+		seedExecution(t, tracker, "exec-pag-00"+string(rune('0'+i)), "steward-pag", "scripts/s.sh", "completed")
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/stewards/steward-pag/scripts/executions?limit=2&offset=1", nil)
+	req.Header.Set("X-API-Key", apiKey)
+	rec := httptest.NewRecorder()
+	server.router.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var resp APIResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+
+	items, ok := resp.Data.([]interface{})
+	require.True(t, ok)
+	assert.Len(t, items, 2, "limit=2 should return exactly 2 records after skipping offset=1")
+}
+
+// TestHandleListScriptExecutions_StatusFilter verifies the status query parameter is applied.
+func TestHandleListScriptExecutions_StatusFilter(t *testing.T) {
+	server, tracker := setupScriptServer(t)
+	apiKey := NewTestKey(t, server, []string{"steward:read-scripts"})
+
+	seedExecution(t, tracker, "exec-done", "steward-flt", "scripts/s.sh", "completed")
+	seedExecution(t, tracker, "exec-fail", "steward-flt", "scripts/f.sh", "failed")
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/stewards/steward-flt/scripts/executions?status=failed", nil)
+	req.Header.Set("X-API-Key", apiKey)
+	rec := httptest.NewRecorder()
+	server.router.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var resp APIResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	items, ok := resp.Data.([]interface{})
+	require.True(t, ok)
+	assert.Len(t, items, 1)
+	assert.Equal(t, "exec-fail", items[0].(map[string]interface{})["id"])
+}
+
+// TestHandleListScriptExecutions_ServiceUnavailable verifies 503 when no tracker is wired.
+func TestHandleListScriptExecutions_ServiceUnavailable(t *testing.T) {
+	server := setupTestServer(t)
+	apiKey := NewTestKey(t, server, []string{"steward:read-scripts"})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/stewards/steward-1/scripts/executions", nil)
+	req.Header.Set("X-API-Key", apiKey)
+	rec := httptest.NewRecorder()
+	server.router.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusServiceUnavailable, rec.Code)
+}
+
+// TestHandleGetScriptExecution_Found verifies the single-execution handler returns the
+// correct record when the execution ID exists.
+func TestHandleGetScriptExecution_Found(t *testing.T) {
+	server, tracker := setupScriptServer(t)
+	apiKey := NewTestKey(t, server, []string{"steward:read-scripts"})
+
+	seedExecution(t, tracker, "exec-target", "steward-1", "scripts/deploy.sh", "completed")
+	seedExecution(t, tracker, "exec-other", "steward-1", "scripts/other.sh", "failed")
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/stewards/steward-1/scripts/executions/exec-target", nil)
+	req.Header.Set("X-API-Key", apiKey)
+	rec := httptest.NewRecorder()
+	server.router.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var resp APIResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+
+	item, ok := resp.Data.(map[string]interface{})
+	require.True(t, ok)
+	assert.Equal(t, "exec-target", item["id"])
+	assert.Equal(t, "steward-1", item["steward_id"])
+	assert.Equal(t, "scripts/deploy.sh", item["resource_id"])
+}
+
+// TestHandleGetScriptExecution_NotFound verifies 404 for a non-existent execution ID.
+func TestHandleGetScriptExecution_NotFound(t *testing.T) {
+	server, tracker := setupScriptServer(t)
+	apiKey := NewTestKey(t, server, []string{"steward:read-scripts"})
+
+	seedExecution(t, tracker, "exec-exists", "steward-1", "scripts/s.sh", "completed")
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/stewards/steward-1/scripts/executions/does-not-exist", nil)
+	req.Header.Set("X-API-Key", apiKey)
+	rec := httptest.NewRecorder()
+	server.router.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+}
+
+// TestHandleGetScriptExecution_ServiceUnavailable verifies 503 when no tracker is wired.
+func TestHandleGetScriptExecution_ServiceUnavailable(t *testing.T) {
+	server := setupTestServer(t)
+	apiKey := NewTestKey(t, server, []string{"steward:read-scripts"})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/stewards/steward-1/scripts/executions/exec-1", nil)
+	req.Header.Set("X-API-Key", apiKey)
+	rec := httptest.NewRecorder()
+	server.router.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusServiceUnavailable, rec.Code)
+}
+
+// TestHandleGetScriptMetrics_Real verifies the metrics handler returns aggregated data
+// from the real AuditLogger, not hardcoded stubs.
+func TestHandleGetScriptMetrics_Real(t *testing.T) {
+	server, _ := setupScriptServer(t)
+	apiKey := NewTestKey(t, server, []string{"steward:read-scripts"})
+
+	// Seed audit logger with known records so we can assert non-stub output.
+	cfg := &script.ScriptConfig{
+		Shell:         script.ShellBash,
+		Content:       "echo hello",
+		Timeout:       30 * time.Second,
+		SigningPolicy: script.SigningPolicyNone,
+	}
+	result := &script.ExecutionResult{
+		ExitCode:  0,
+		Stdout:    "hello",
+		Duration:  500 * time.Millisecond,
+		StartTime: time.Now().Add(-1 * time.Second),
+		EndTime:   time.Now(),
+	}
+	rec := script.CreateAuditRecord("steward-metrics", "scripts/test.sh", cfg, result, nil)
+	require.NoError(t, server.scriptAuditLogger.LogExecution(context.Background(), rec))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/stewards/steward-metrics/scripts/metrics", nil)
+	req.Header.Set("X-API-Key", apiKey)
+	rw := httptest.NewRecorder()
+	server.router.ServeHTTP(rw, req)
+
+	require.Equal(t, http.StatusOK, rw.Code)
+
+	var resp APIResponse
+	require.NoError(t, json.Unmarshal(rw.Body.Bytes(), &resp))
+
+	m, ok := resp.Data.(map[string]interface{})
+	require.True(t, ok)
+
+	assert.Equal(t, "steward-metrics", m["steward_id"])
+
+	// Old stub always returned total_executions=42; a real result with 1 record returns 1.
+	totalRaw, ok := m["total_executions"]
+	require.True(t, ok)
+	total := int(totalRaw.(float64))
+	assert.Equal(t, 1, total, "should reflect the single seeded record, not the old stub value of 42")
+}
+
+// TestHandleGetScriptMetrics_ServiceUnavailable verifies 503 when no audit logger is wired.
+func TestHandleGetScriptMetrics_ServiceUnavailable(t *testing.T) {
+	server := setupTestServer(t)
+	apiKey := NewTestKey(t, server, []string{"steward:read-scripts"})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/stewards/steward-1/scripts/metrics", nil)
+	req.Header.Set("X-API-Key", apiKey)
+	rec := httptest.NewRecorder()
+	server.router.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusServiceUnavailable, rec.Code)
+}
+
+// TestHandleGetScriptStatus_Real verifies the status handler uses real tracker data.
+func TestHandleGetScriptStatus_Real(t *testing.T) {
+	server, tracker := setupScriptServer(t)
+	apiKey := NewTestKey(t, server, []string{"steward:read-scripts"})
+
+	seedExecution(t, tracker, "exec-last", "steward-status", "scripts/health.sh", "completed")
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/stewards/steward-status/scripts/status", nil)
+	req.Header.Set("X-API-Key", apiKey)
+	rec := httptest.NewRecorder()
+	server.router.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var resp APIResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+
+	m, ok := resp.Data.(map[string]interface{})
+	require.True(t, ok)
+	assert.Equal(t, "steward-status", m["steward_id"])
+	assert.Equal(t, "enabled", m["script_capability"])
+
+	// last_execution must reflect the real seeded record.
+	lastRaw, ok := m["last_execution"]
+	require.True(t, ok, "last_execution must be present")
+	last, ok := lastRaw.(map[string]interface{})
+	require.True(t, ok)
+	assert.Equal(t, "exec-last", last["execution_id"])
+	assert.Equal(t, "scripts/health.sh", last["resource_id"])
+}
+
+// TestHandleGetScriptStatus_NoRecords verifies the status handler returns nil last_execution
+// when the tracker has no records for the steward.
+func TestHandleGetScriptStatus_NoRecords(t *testing.T) {
+	server, _ := setupScriptServer(t)
+	apiKey := NewTestKey(t, server, []string{"steward:read-scripts"})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/stewards/steward-empty/scripts/status", nil)
+	req.Header.Set("X-API-Key", apiKey)
+	rec := httptest.NewRecorder()
+	server.router.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var resp APIResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+
+	m, ok := resp.Data.(map[string]interface{})
+	require.True(t, ok)
+	assert.Nil(t, m["last_execution"], "last_execution should be nil when no records exist")
+}
+
+// TestHandleGetScriptStatus_ServiceUnavailable verifies 503 when no tracker is wired.
+func TestHandleGetScriptStatus_ServiceUnavailable(t *testing.T) {
+	server := setupTestServer(t)
+	apiKey := NewTestKey(t, server, []string{"steward:read-scripts"})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/stewards/steward-1/scripts/status", nil)
+	req.Header.Set("X-API-Key", apiKey)
+	rec := httptest.NewRecorder()
+	server.router.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusServiceUnavailable, rec.Code)
+}
+
+// TestHandlePostScriptRetry_NotImplemented verifies that the retry handler returns 501.
+func TestHandlePostScriptRetry_NotImplemented(t *testing.T) {
+	server, _ := setupScriptServer(t)
+	apiKey := NewTestKey(t, server, []string{"steward:execute-scripts"})
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/stewards/steward-1/scripts/executions/exec-1/retry", nil)
+	req.Header.Set("X-API-Key", apiKey)
+	rec := httptest.NewRecorder()
+	server.router.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusNotImplemented, rec.Code)
+
+	var errResp ErrorResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &errResp))
+	require.NotNil(t, errResp.Error)
+	assert.Equal(t, "NOT_IMPLEMENTED", errResp.Error.Code)
+}

--- a/features/controller/api/server.go
+++ b/features/controller/api/server.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cfgis/cfgms/features/controller/fleet"
 	"github.com/cfgis/cfgms/features/controller/health"
 	"github.com/cfgis/cfgms/features/controller/service"
+	"github.com/cfgis/cfgms/features/modules/script"
 	"github.com/cfgis/cfgms/features/monitoring"
 	"github.com/cfgis/cfgms/features/rbac"
 	"github.com/cfgis/cfgms/features/rbac/authdefense"
@@ -65,6 +66,9 @@ type Server struct {
 	fleetQuery              fleet.FleetQuery               // Issue #603: Single query path for device filtering
 	gitSyncWebhookHandler   http.Handler                   // Issue #666: git-sync webhook endpoint (optional)
 	auditManager            *audit.Manager                 // Issue #775: registration audit events
+	scriptTracker           script.ExecutionTracker        // Issue #708: durable execution audit records
+	scriptAuditLogger       *script.AuditLogger            // Issue #708: in-memory execution metrics
+	scriptMonitor           *script.ExecutionMonitor       // Issue #708: active execution tracking
 	stopCleanup             chan struct{}                  // signals startAPIKeyCleanup to exit
 	cleanupDone             chan struct{}                  // closed when cleanup goroutine exits
 	closeOnce               sync.Once                      // idempotent Close
@@ -525,6 +529,17 @@ func (s *Server) SetApprovalHook(hook RegistrationApprovalHook) {
 	if hook != nil {
 		s.approvalHook = hook
 	}
+}
+
+// SetScriptModule wires the script module components so the script API handlers
+// return real execution data (Issue #708). Call this after New() returns but
+// before Start() is called.
+func (s *Server) SetScriptModule(tracker script.ExecutionTracker, auditLogger *script.AuditLogger, monitor *script.ExecutionMonitor) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.scriptTracker = tracker
+	s.scriptAuditLogger = auditLogger
+	s.scriptMonitor = monitor
 }
 
 // SetGitSyncWebhookHandler registers the git-sync push-event webhook handler.


### PR DESCRIPTION
## Summary

- Replace five placeholder script API handlers with real implementations backed by `ExecutionTracker` (SQLite) and `AuditLogger` (in-memory)
- Add `Server.SetScriptModule` setter for injecting the tracker, audit logger, and monitor after construction
- Add 12 integration tests using real components (no mocks)

## What changed

| Handler | Before | After |
|---------|--------|-------|
| `handleGetScriptExecutions` | Hardcoded stub record | `ExecutionTracker.QueryByDevice` with in-memory status/resource/time filters and offset slicing |
| `handleGetScriptExecution` | Hardcoded stub record | `QueryByDevice` scan → find by execution ID → 404 if not found |
| `handleGetScriptMetrics` | Hardcoded values (total=42, rate=90.48) | `AuditLogger.GetExecutionMetrics` |
| `handleGetScriptStatus` | Hardcoded capability/progress | Real last-completed from tracker + active executions from monitor |
| `handlePostScriptRetry` | Fake "initiated" response | `501 Not Implemented` (no re-queue path exists in the module yet) |

All path parameters (`stewardID`, `executionID`) are sanitized with `logging.SanitizeLogValue` before logging.

## Test plan

- [x] `TestHandleListScriptExecutions_Real` — asserts real seeded records returned, not old stub IDs
- [x] `TestHandleListScriptExecutions_Pagination` — limit/offset applied correctly
- [x] `TestHandleListScriptExecutions_StatusFilter` — status query param filters results
- [x] Service-unavailable (nil tracker/logger) → 503 for all 4 read handlers
- [x] `TestHandleGetScriptExecution_Found` / `_NotFound` — 200 vs 404
- [x] `TestHandleGetScriptMetrics_Real` — total_executions=1 from seeded record (not old stub value of 42)
- [x] `TestHandleGetScriptStatus_Real` / `_NoRecords` — last_execution populated from tracker
- [x] `TestHandlePostScriptRetry_NotImplemented` — 501 with `NOT_IMPLEMENTED` code

## Specialist review results

**QA Test Runner**: PASS — all 53 script tests + full package suite passing; lint clean; cross-platform builds verified. (Trivy skipped: no network in agent sandbox; will run in CI.)

**QA Code Reviewer**: PASS — no mocks, no t.Skip, no empty assertions, no error swallowing. Warnings only (pagination test could assert specific IDs; cross-steward isolation not explicitly tested).

**Security Engineer**: PASS — no hardcoded secrets, no SQL injection, input sanitized in logs, `check-architecture` clean. Warnings only: unused `user_id`/`tenant_id` query params, silent RFC3339 parse swallowing, stderr passthrough to API response (LOW severity, access-gated by RBAC).

Fixes #708

🤖 Generated with [Claude Code](https://claude.com/claude-code)