### PR TITLE
deps: update gosec v2.25.0→v2.26.1 and golangci-lint v2.11.4→v2.12.1 (Issue #1309)

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -38,12 +38,12 @@ RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
 
 # Go-based security and quality tools
 # Versions MUST match .github/workflows/dependency-pin-check.yml
-RUN go install github.com/securego/gosec/v2/cmd/gosec@v2.25.0 \
+RUN go install github.com/securego/gosec/v2/cmd/gosec@v2.26.1 \
     && go install honnef.co/go/tools/cmd/staticcheck@2026.1 \
     && go install github.com/zricethezav/gitleaks/v8@v8.30.1 \
     && go install github.com/google/go-licenses/v2@v2.0.1 \
     && curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh \
-       | sh -s -- -b "$(go env GOPATH)/bin" v2.11.4
+       | sh -s -- -b "$(go env GOPATH)/bin" v2.12.1
 
 # Trivy — v0.69.4-v0.69.6 are compromised (CVE-2026-33634); v0.70.0 is the
 # post-incident clean release. We download the project's release archive and

--- a/.github/workflows/dependency-pin-check.yml
+++ b/.github/workflows/dependency-pin-check.yml
@@ -94,14 +94,14 @@ jobs:
         }
 
         echo "Checking pinned tool versions..."
-        check_version "gosec"       "securego/gosec"                          "v2.25.0"
+        check_version "gosec"       "securego/gosec"                          "v2.26.1"
         check_version "staticcheck" "dominikh/go-tools"                       "2026.1"
         check_version "gitleaks"    "zricethezav/gitleaks"                    "v8.30.1"
         check_version "nancy"       "sonatype-nexus-community/nancy"          "v1.2.0"
         check_version "trufflehog"  "trufflesecurity/trufflehog"              "v3.95.2"
         check_version "trivy"       "aquasecurity/trivy"                      "v0.70.0"
         check_version "go-licenses" "google/go-licenses"                      "v2.0.1"
-        check_version "golangci-lint" "golangci/golangci-lint"                "v2.11.4"
+        check_version "golangci-lint" "golangci/golangci-lint"                "v2.12.1"
 
         if [ -z "$outdated" ] && [ -z "$warnings" ]; then
           echo ""

--- a/.github/workflows/production-gates.yml
+++ b/.github/workflows/production-gates.yml
@@ -61,7 +61,7 @@ jobs:
 
         # Install other security tools
         make install-nancy
-        go install github.com/securego/gosec/v2/cmd/gosec@v2.25.0
+        go install github.com/securego/gosec/v2/cmd/gosec@v2.26.1
         go install honnef.co/go/tools/cmd/staticcheck@2026.1
         
         echo "✅ Security tools installed"

--- a/.github/workflows/release-automation.yml
+++ b/.github/workflows/release-automation.yml
@@ -211,11 +211,11 @@ jobs:
 
           # Install security scanning tools
           make install-nancy
-          go install github.com/securego/gosec/v2/cmd/gosec@v2.25.0
+          go install github.com/securego/gosec/v2/cmd/gosec@v2.26.1
           go install honnef.co/go/tools/cmd/staticcheck@2026.1
 
           # Install linting tools
-          curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin latest
+          curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh | sh -s -- -b $(go env GOPATH)/bin v2.12.1
 
           echo "✅ All tools installed"
 

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -158,7 +158,7 @@ jobs:
     #   continue-on-error: true
     
     - name: Install gosec
-      run: go install github.com/securego/gosec/v2/cmd/gosec@v2.25.0
+      run: go install github.com/securego/gosec/v2/cmd/gosec@v2.26.1
     
     - name: Run gosec Scan
       id: scan
@@ -307,7 +307,7 @@ jobs:
         sudo .github/scripts/install-trivy.sh 'v0.70.0' '8b4376d5d6befe5c24d503f10ff136d9e0c49f9127a4279fd110b727929a5aa9'
 
         # Install gosec and staticcheck
-        go install github.com/securego/gosec/v2/cmd/gosec@v2.25.0
+        go install github.com/securego/gosec/v2/cmd/gosec@v2.26.1
         go install honnef.co/go/tools/cmd/staticcheck@2026.1
     
     - name: Generate Remediation Report on Failure

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,8 +8,8 @@
 
 repos:
   # Go security pattern analysis with gosec
-  - repo: https://github.com/securecodewarrior/gosec
-    rev: v2.22.0
+  - repo: https://github.com/securego/gosec
+    rev: v2.26.1
     hooks:
       - id: gosec
         name: gosec security scan
@@ -46,7 +46,7 @@ repos:
                 staticcheck "$@"
               fi
             else
-              echo "⚠️  staticcheck not installed - skipping (run: go install honnef.co/go/tools/cmd/staticcheck@latest)"
+              echo "⚠️  staticcheck not installed - skipping (run: go install honnef.co/go/tools/cmd/staticcheck@2026.1)"
               exit 0
             fi
         stages: [commit]

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -41,8 +41,7 @@ This guide provides instructions for setting up a local CFGMS development enviro
 - **Docker** - For integration tests and local deployment
 - **golangci-lint** - Code linting
   ```bash
-  # Install using go install
-  go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
+  curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh | sh -s -- -b $(go env GOPATH)/bin v2.12.1
   ```
 
 - **entr** - For watch mode during development
@@ -61,7 +60,7 @@ This guide provides instructions for setting up a local CFGMS development enviro
 
 - **gosec** - Security scanning
   ```bash
-  go install github.com/securego/gosec/v2/cmd/gosec@latest
+  go install github.com/securego/gosec/v2/cmd/gosec@v2.26.1
   ```
 
 ### System Requirements

--- a/Makefile
+++ b/Makefile
@@ -885,7 +885,7 @@ security-gosec:
 		echo "❌ Error: gosec is not installed"; \
 		echo ""; \
 		echo "Install gosec using Go:"; \
-		echo "  go install github.com/securego/gosec/v2/cmd/gosec@v2.25.0"; \
+		echo "  go install github.com/securego/gosec/v2/cmd/gosec@v2.26.1"; \
 		echo ""; \
 		echo "For more info: https://github.com/securego/gosec"; \
 		exit 1; \

--- a/docs/development/security-setup.md
+++ b/docs/development/security-setup.md
@@ -17,7 +17,7 @@ CFGMS uses a multi-layered security scanning approach with four primary tools:
 # 1. Install security tools
 ./.github/scripts/install-trivy.sh v0.70.0 \
     8b4376d5d6befe5c24d503f10ff136d9e0c49f9127a4279fd110b727929a5aa9
-go install github.com/securego/gosec/v2/cmd/gosec@v2.25.0
+go install github.com/securego/gosec/v2/cmd/gosec@v2.26.1
 go install honnef.co/go/tools/cmd/staticcheck@2026.1
 make install-nancy     # Auto-install Nancy for your platform
 
@@ -136,7 +136,7 @@ gosec analyzes Go source code for security problems and anti-patterns.
 
 ```bash
 # Go installation (all platforms) - RECOMMENDED
-go install github.com/securego/gosec/v2/cmd/gosec@v2.25.0
+go install github.com/securego/gosec/v2/cmd/gosec@v2.26.1
 
 # Verify installation
 gosec --version
@@ -422,7 +422,7 @@ Current tool versions (as of v0.3.1):
 
 - **Trivy**: v0.70.0 (pinned — v0.69.4-v0.69.6 compromised per CVE-2026-33634; v0.70.0 is the post-incident clean rebuild with new GPG key. Install via `./.github/scripts/install-trivy.sh`. NEVER use @latest, NEVER use `go install`.)
 - **Nancy**: v1.2.0
-- **gosec**: v2.25.0 (pinned — avoid @latest)
+- **gosec**: v2.26.1 (pinned — avoid @latest)
 - **staticcheck**: 2026.1 (pinned — avoid @latest)
 
 ## Contributing to Security Setup
@@ -560,7 +560,7 @@ pre-commit install --install-hooks
 ```bash
 # Install missing Go tools
 go install honnef.co/go/tools/cmd/staticcheck@2026.1
-go install github.com/securego/gosec/v2/cmd/gosec@v2.25.0
+go install github.com/securego/gosec/v2/cmd/gosec@v2.26.1
 
 # Verify PATH
 which staticcheck gosec

--- a/docs/development/security-troubleshooting.md
+++ b/docs/development/security-troubleshooting.md
@@ -416,12 +416,12 @@ make security-remediation-report 2>&1 | tee remediation-debug.log
 # Check current versions
 trivy --version      # Should be latest stable
 nancy --version      # Should be v1.0.51+
-gosec -version       # Should be v2.18+
+gosec -version       # Should be v2.26.1+
 staticcheck -version # Should be 2023.1+
 
 # Update to compatible versions
-go install github.com/securecodewarrior/gosec/v2/cmd/gosec@latest
-go install honnef.co/go/tools/cmd/staticcheck@latest
+go install github.com/securego/gosec/v2/cmd/gosec@v2.26.1
+go install honnef.co/go/tools/cmd/staticcheck@2026.1
 ```
 
 ## Escalation Procedures
@@ -541,8 +541,8 @@ rm -rf ~/.cache/staticcheck
 
 # Reinstall tools
 make install-nancy
-go install github.com/securecodewarrior/gosec/v2/cmd/gosec@latest
-go install honnef.co/go/tools/cmd/staticcheck@latest
+go install github.com/securego/gosec/v2/cmd/gosec@v2.26.1
+go install honnef.co/go/tools/cmd/staticcheck@2026.1
 
 # Test installations
 trivy --version && nancy --version && gosec -version && staticcheck -version

--- a/docs/development/security-workflow-guide.md
+++ b/docs/development/security-workflow-guide.md
@@ -60,8 +60,8 @@ make install-nancy
 
 # Install individual tools (Ubuntu/Debian)
 sudo apt-get install trivy
-go install github.com/securecodewarrior/gosec/v2/cmd/gosec@latest
-go install honnef.co/go/tools/cmd/staticcheck@latest
+go install github.com/securego/gosec/v2/cmd/gosec@v2.26.1
+go install honnef.co/go/tools/cmd/staticcheck@2026.1
 ```
 
 ### Development Security Commands


### PR DESCRIPTION
## Summary

- Bumps `gosec` from v2.25.0 to v2.26.1 and `golangci-lint` from v2.11.4 to v2.12.1 across all pin sites so the `dependency-pin-check` workflow reports green
- Corrects a supply-chain risk: `.pre-commit-config.yaml` pointed at `securecodewarrior/gosec` (HTTP 404, unclaimed org); changed to canonical `securego/gosec`
- Fixes `@latest` / wrong-module-path install commands found in developer docs and `release-automation.yml` during the sweep

Fixes #1309

## Pin sites updated

| File | Change |
|------|--------|
| `.devcontainer/Dockerfile` | gosec v2.25.0→v2.26.1, golangci-lint v2.11.4→v2.12.1 |
| `.github/workflows/security-scan.yml` | gosec v2.25.0→v2.26.1 (×2) |
| `.github/workflows/dependency-pin-check.yml` | gosec "v2.25.0"→"v2.26.1", golangci-lint "v2.11.4"→"v2.12.1" |
| `.github/workflows/production-gates.yml` | gosec v2.25.0→v2.26.1 |
| `.github/workflows/release-automation.yml` | gosec v2.25.0→v2.26.1; golangci-lint `@latest`→`v2.12.1` |
| `Makefile` | gosec install hint v2.25.0→v2.26.1 |
| `.pre-commit-config.yaml` | repo URL `securecodewarrior/gosec`→`securego/gosec`, rev v2.22.0→v2.26.1, staticcheck echo hint `@latest`→`@2026.1` |
| `docs/development/security-setup.md` | gosec v2.25.0→v2.26.1 (×4 + version table) |
| `docs/development/security-troubleshooting.md` | gosec wrong path + `@latest` fixed (×2), staticcheck `@latest`→`@2026.1` (×2), version comment updated |
| `docs/development/security-workflow-guide.md` | gosec wrong path + `@latest` fixed, staticcheck `@latest`→`@2026.1` |
| `DEVELOPMENT.md` | gosec `@latest`→`@v2.26.1`, golangci-lint `@latest`→install script v2.12.1 |

## Validation

- `make security-gosec` — PASS (exit 0; 237 pre-existing non-blocking findings, no new ones from v2.26.1)
- `make lint` — PASS (0 issues with golangci-lint v2.12.1)
- `make test-agent-complete` — all non-Docker gates PASS; Docker gate blocked by missing daemon in agent container (pre-existing infrastructure constraint, unrelated to this change)

## Specialist Review Results

**QA Test Runner**: PASS — all unit, integration, script, lint, license, and architecture gates pass; Docker gate is an environment constraint pre-existing in this container

**QA Code Reviewer**: PASS — all pin sites verified consistent; no `@latest` or stale versions remain in CI workflows or developer docs; Dockerfile comment contract satisfied

**Security Engineer**: PASS — no compromised Trivy versions; no `@latest` install commands in CI; `securecodewarrior/gosec` supply-chain risk resolved; `make check-architecture` clean; no hardcoded secrets