### PR TITLE
workflow/debug: implement replay, rollback, and condition evaluation (Issue #712)

### DIFF
--- a/features/workflow/debug_engine.go
+++ b/features/workflow/debug_engine.go
@@ -3,8 +3,12 @@
 package workflow
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
+	"io"
+	"net/http"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -389,56 +393,107 @@ func (de *DebugEngineImpl) GetAPICallHistory(sessionID string) ([]APICallInfo, e
 	return history, nil
 }
 
-// ReplayAPICall replays a previous API call
+// ReplayAPICall replays a previous API call by re-issuing the original HTTP request
+// and returning the actual response received from the server.
 func (de *DebugEngineImpl) ReplayAPICall(sessionID string, callID string) (*APICallInfo, error) {
 	session, err := de.GetDebugSession(sessionID)
 	if err != nil {
 		return nil, err
 	}
 
+	// Copy the call info under the read lock so we don't hold it during the HTTP call.
 	session.mutex.RLock()
-	defer session.mutex.RUnlock()
-
-	// Find the API call to replay
-	var originalCall *APICallInfo
+	var original APICallInfo
+	found := false
 	for _, call := range session.APICallLog {
 		if call.ID == callID {
-			originalCall = &call
+			original = call
+			found = true
 			break
 		}
 	}
+	session.mutex.RUnlock()
 
-	if originalCall == nil {
+	if !found {
 		return nil, fmt.Errorf("API call not found: %s", callID)
 	}
-
-	if !originalCall.CanReplay {
+	if !original.CanReplay {
 		return nil, fmt.Errorf("API call cannot be replayed: %s", callID)
 	}
 
-	// TODO: Implement actual API call replay logic
-	// This would involve re-executing the HTTP request with the same parameters
-	// For now, return a placeholder response
+	// Prepare the request body.
+	var bodyReader io.Reader
+	if original.RequestBody != nil {
+		bodyBytes, err := json.Marshal(original.RequestBody)
+		if err != nil {
+			return nil, fmt.Errorf("failed to marshal request body: %w", err)
+		}
+		bodyReader = bytes.NewReader(bodyBytes)
+	}
+
+	req, err := http.NewRequestWithContext(session.Context, original.Method, original.URL, bodyReader)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create replay request: %w", err)
+	}
+	for k, v := range original.RequestHeaders {
+		req.Header.Set(k, v)
+	}
+
+	startTime := time.Now()
+	client := &http.Client{Timeout: 30 * time.Second}
+	resp, doErr := client.Do(req)
+	duration := time.Since(startTime)
 
 	replayCall := &APICallInfo{
-		ID:              generateAPICallID(),
-		StepName:        originalCall.StepName + "_replay",
-		Timestamp:       time.Now(),
-		Method:          originalCall.Method,
-		URL:             originalCall.URL,
-		RequestHeaders:  originalCall.RequestHeaders,
-		RequestBody:     originalCall.RequestBody,
-		ResponseStatus:  200, // Placeholder
-		ResponseHeaders: map[string]string{"X-Replay": "true"},
-		ResponseBody:    map[string]interface{}{"replayed": true},
-		Duration:        100 * time.Millisecond,
-		CanReplay:       true,
+		ID:             generateAPICallID(),
+		StepName:       original.StepName + "_replay",
+		Timestamp:      time.Now(),
+		Method:         original.Method,
+		URL:            original.URL,
+		RequestHeaders: original.RequestHeaders,
+		RequestBody:    original.RequestBody,
+		Duration:       duration,
+		CanReplay:      true,
+	}
+
+	if doErr != nil {
+		replayCall.Error = doErr.Error()
+		de.logger.Warn("Replay HTTP request failed",
+			"session_id", sessionID,
+			"call_id", callID,
+			"error", doErr)
+		return replayCall, nil
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	body, readErr := io.ReadAll(resp.Body)
+	if readErr != nil {
+		replayCall.ResponseStatus = resp.StatusCode
+		replayCall.Error = fmt.Sprintf("failed to read response body: %s", readErr)
+		return replayCall, nil
+	}
+	replayCall.ResponseStatus = resp.StatusCode
+
+	responseHeaders := make(map[string]string, len(resp.Header))
+	for k, v := range resp.Header {
+		if len(v) > 0 {
+			responseHeaders[k] = v[0]
+		}
+	}
+	replayCall.ResponseHeaders = responseHeaders
+
+	var jsonBody interface{}
+	if json.Unmarshal(body, &jsonBody) == nil {
+		replayCall.ResponseBody = jsonBody
+	} else {
+		replayCall.ResponseBody = string(body)
 	}
 
 	de.logger.Info("Replayed API call",
 		"session_id", sessionID,
 		"original_call_id", callID,
-		"replay_call_id", replayCall.ID)
+		"replay_call_id", replayCall.ID,
+		"status", replayCall.ResponseStatus)
 
 	return replayCall, nil
 }
@@ -460,25 +515,52 @@ func (de *DebugEngineImpl) GetStepHistory(sessionID string) ([]DebugStepInfo, er
 	return history, nil
 }
 
-// RollbackToStep rolls back execution to a previous step (for safe testing)
+// RollbackToStep rolls back execution to a previous step by truncating the step
+// history and restoring variables to the snapshot recorded before that step ran.
 func (de *DebugEngineImpl) RollbackToStep(sessionID string, stepName string) error {
-	_, err := de.GetDebugSession(sessionID)
+	session, err := de.GetDebugSession(sessionID)
 	if err != nil {
 		return err
 	}
 
-	// TODO: Implement rollback functionality
-	// This would involve:
-	// 1. Finding the target step in the step history
-	// 2. Restoring variable state from that point
-	// 3. Resetting execution position
-	// 4. Clearing subsequent step results
+	// Truncate step history and reset execution position under the session lock.
+	// Do NOT hold session.mutex while acquiring VariableInspector.mutex — other
+	// methods (InspectVariables, UpdateVariable) take only VariableInspector.mutex,
+	// so nesting them would create an inconsistent lock ordering.
+	session.mutex.Lock()
+	targetIdx := -1
+	for i, step := range session.StepHistory {
+		if step.StepName == stepName {
+			targetIdx = i
+			break
+		}
+	}
+	if targetIdx < 0 {
+		session.mutex.Unlock()
+		return fmt.Errorf("step not found in history: %s", stepName)
+	}
+	targetStep := session.StepHistory[targetIdx]
+	session.StepHistory = session.StepHistory[:targetIdx]
+	session.CurrentStep = stepName
+	session.mutex.Unlock()
 
-	de.logger.Warn("Rollback functionality not yet implemented",
+	// Restore variable state under the variable inspector lock (taken separately).
+	if targetStep.VariablesBefore != nil {
+		restoredVars := make(map[string]interface{}, len(targetStep.VariablesBefore))
+		for k, v := range targetStep.VariablesBefore {
+			restoredVars[k] = v
+		}
+		session.VariableInspector.mutex.Lock()
+		session.VariableInspector.CurrentVariables = restoredVars
+		session.VariableInspector.mutex.Unlock()
+	}
+
+	de.logger.Info("Rolled back to step",
 		"session_id", sessionID,
-		"target_step", stepName)
+		"target_step", stepName,
+		"history_length", len(session.StepHistory))
 
-	return fmt.Errorf("rollback functionality not yet implemented")
+	return nil
 }
 
 // checkBreakpoint checks if execution should pause at a breakpoint
@@ -492,11 +574,12 @@ func (de *DebugEngineImpl) checkBreakpoint(session *DebugSession, stepName strin
 			continue
 		}
 
-		// Check condition if present
+		// Check condition if present; skip this breakpoint when the condition is false.
 		if breakpoint.Condition != nil {
-			// TODO: Implement condition evaluation
-			// For now, assume conditions pass
-			_ = breakpoint.Condition // Acknowledge the condition for linting
+			conditionMet, err := de.workflowEngine.evaluateCondition(breakpoint.Condition, variables)
+			if err != nil || !conditionMet {
+				continue
+			}
 		}
 
 		// Update breakpoint hit information

--- a/features/workflow/debug_test.go
+++ b/features/workflow/debug_test.go
@@ -4,14 +4,16 @@ package workflow
 
 import (
 	"context"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/cfgis/cfgms/features/steward/factory"
 	"github.com/cfgis/cfgms/pkg/logging"
+	pkgtesting "github.com/cfgis/cfgms/pkg/testing"
 )
 
 func TestDebugEngine_StartDebugSession(t *testing.T) {
@@ -210,6 +212,12 @@ func TestDebugEngine_APICallHistory(t *testing.T) {
 	engine, _ := createTestEngineWithDebug(t)
 	debugEngine := engine.GetDebugEngine()
 
+	// Start a local test server so replay makes a real but controlled HTTP call.
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
 	// Create workflow and execution
 	workflow := createTestWorkflow()
 	ctx := context.Background()
@@ -224,14 +232,14 @@ func TestDebugEngine_APICallHistory(t *testing.T) {
 	session, err := debugEngine.StartDebugSession(ctx, execution.ID, settings)
 	require.NoError(t, err)
 
-	// Simulate API call recording
+	// Simulate API call recording — use the local server URL so replay works
 	session.mutex.Lock()
 	apiCall := APICallInfo{
 		ID:              "test_call_1",
 		StepName:        "http_step",
 		Timestamp:       time.Now(),
 		Method:          "GET",
-		URL:             "https://api.example.com/test",
+		URL:             ts.URL + "/test",
 		RequestHeaders:  map[string]string{"Authorization": "Bearer token"},
 		ResponseStatus:  200,
 		ResponseHeaders: map[string]string{"Content-Type": "application/json"},
@@ -250,12 +258,13 @@ func TestDebugEngine_APICallHistory(t *testing.T) {
 	assert.Equal(t, "GET", history[0].Method)
 	assert.True(t, history[0].CanReplay)
 
-	// Test API call replay
+	// Test API call replay — real HTTP round-trip to the test server
 	replayCall, err := debugEngine.ReplayAPICall(session.ID, "test_call_1")
 	require.NoError(t, err)
 	assert.NotNil(t, replayCall)
 	assert.Contains(t, replayCall.StepName, "replay")
 	assert.Equal(t, "GET", replayCall.Method)
+	assert.Equal(t, http.StatusOK, replayCall.ResponseStatus)
 }
 
 func TestDebugEngine_StepHistory(t *testing.T) {
@@ -342,7 +351,7 @@ func TestWorkflowEngine_PauseResumeExecution(t *testing.T) {
 	assert.Contains(t, err.Error(), "execution not found")
 
 	// Test pausing already paused execution
-	_ = engine.PauseExecution(execution.ID)
+	require.NoError(t, engine.PauseExecution(execution.ID))
 	err = engine.PauseExecution(execution.ID)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "cannot pause execution in status")
@@ -463,26 +472,169 @@ func TestDebugEngine_SecurityAndTenantIsolation(t *testing.T) {
 	assert.Contains(t, session.VariableInspector.ModifiedVariables, "sensitive_data")
 }
 
+// TestReplayAPICall_MakesRealRequest verifies that ReplayAPICall issues an actual
+// HTTP round-trip and returns the response received from the server.
+func TestReplayAPICall_MakesRealRequest(t *testing.T) {
+	requestReceived := false
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestReceived = true
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "test-value", r.Header.Get("X-Test-Header"))
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"status":"replayed"}`))
+	}))
+	defer ts.Close()
+
+	engine, _ := createTestEngineWithDebug(t)
+	debugEngine := engine.GetDebugEngine()
+
+	workflow := createTestWorkflow()
+	ctx := context.Background()
+	execution, err := engine.ExecuteWorkflow(ctx, workflow, map[string]interface{}{})
+	require.NoError(t, err)
+
+	settings := DebugSettings{MaxHistorySize: 100}
+	session, err := debugEngine.StartDebugSession(ctx, execution.ID, settings)
+	require.NoError(t, err)
+
+	session.mutex.Lock()
+	session.APICallLog = append(session.APICallLog, APICallInfo{
+		ID:             "call_replay_test",
+		StepName:       "http_step",
+		Timestamp:      time.Now(),
+		Method:         http.MethodGet,
+		URL:            ts.URL + "/replay",
+		RequestHeaders: map[string]string{"X-Test-Header": "test-value"},
+		CanReplay:      true,
+	})
+	session.mutex.Unlock()
+
+	replayCall, err := debugEngine.ReplayAPICall(session.ID, "call_replay_test")
+	require.NoError(t, err)
+	require.NotNil(t, replayCall)
+
+	assert.True(t, requestReceived, "test server must have received the replayed request")
+	assert.Equal(t, http.StatusOK, replayCall.ResponseStatus)
+	assert.Contains(t, replayCall.StepName, "replay")
+	assert.Equal(t, http.MethodGet, replayCall.Method)
+	assert.Equal(t, ts.URL+"/replay", replayCall.URL)
+	assert.NotNil(t, replayCall.ResponseBody)
+}
+
+// TestRollbackToStep_RestoresState verifies that RollbackToStep truncates the step
+// history and restores variables to the snapshot recorded before the target step ran.
+func TestRollbackToStep_RestoresState(t *testing.T) {
+	engine, _ := createTestEngineWithDebug(t)
+	debugEngine := engine.GetDebugEngine()
+
+	workflow := createTestWorkflow()
+	ctx := context.Background()
+	execution, err := engine.ExecuteWorkflow(ctx, workflow, map[string]interface{}{"x": "initial"})
+	require.NoError(t, err)
+
+	settings := DebugSettings{MaxHistorySize: 100}
+	session, err := debugEngine.StartDebugSession(ctx, execution.ID, settings)
+	require.NoError(t, err)
+
+	// Populate step history with variable snapshots
+	session.mutex.Lock()
+	session.StepHistory = []DebugStepInfo{
+		{
+			StepName:        "step1",
+			StepType:        StepTypeDelay,
+			Timestamp:       time.Now(),
+			Status:          StatusCompleted,
+			VariablesBefore: map[string]interface{}{"x": "initial"},
+			VariablesAfter:  map[string]interface{}{"x": "after_step1"},
+		},
+		{
+			StepName:        "step2",
+			StepType:        StepTypeDelay,
+			Timestamp:       time.Now(),
+			Status:          StatusCompleted,
+			VariablesBefore: map[string]interface{}{"x": "after_step1"},
+			VariablesAfter:  map[string]interface{}{"x": "after_step2"},
+		},
+		{
+			StepName:        "step3",
+			StepType:        StepTypeDelay,
+			Timestamp:       time.Now(),
+			Status:          StatusCompleted,
+			VariablesBefore: map[string]interface{}{"x": "after_step2"},
+			VariablesAfter:  map[string]interface{}{"x": "after_step3"},
+		},
+	}
+	session.mutex.Unlock()
+
+	err = debugEngine.RollbackToStep(session.ID, "step2")
+	require.NoError(t, err)
+
+	// History must be truncated: only step1 remains
+	history, err := debugEngine.GetStepHistory(session.ID)
+	require.NoError(t, err)
+	assert.Len(t, history, 1)
+	assert.Equal(t, "step1", history[0].StepName)
+
+	// Variables must reflect the state before step2 ran
+	variables, err := debugEngine.InspectVariables(session.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "after_step1", variables["x"])
+
+	// CurrentStep must point to the rollback target
+	retrievedSession, err := debugEngine.GetDebugSession(session.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "step2", retrievedSession.CurrentStep)
+
+	// Rollback to a non-existent step returns an error
+	err = debugEngine.RollbackToStep(session.ID, "nonexistent_step")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "nonexistent_step")
+}
+
+// TestBreakpointCondition_RespectedOnHit verifies that a conditional breakpoint only
+// pauses execution when Engine.evaluateCondition returns true for the given variables.
+func TestBreakpointCondition_RespectedOnHit(t *testing.T) {
+	engine, _ := createTestEngineWithDebug(t)
+
+	workflow := createTestWorkflow()
+	ctx := context.Background()
+	execution, err := engine.ExecuteWorkflow(ctx, workflow, map[string]interface{}{})
+	require.NoError(t, err)
+
+	settings := DebugSettings{MaxHistorySize: 100}
+	// Use the concrete DebugEngineImpl so we can call the internal checkBreakpoint method.
+	debugImpl := engine.debugEngine
+	session, err := debugImpl.StartDebugSession(ctx, execution.ID, settings)
+	require.NoError(t, err)
+
+	// Conditional breakpoint: pause only when env == "prod"
+	condition := &Condition{
+		Type:     ConditionTypeVariable,
+		Variable: "env",
+		Operator: OperatorEqual,
+		Value:    "prod",
+	}
+	_, err = debugImpl.SetBreakpoint(session.ID, "step1", condition)
+	require.NoError(t, err)
+
+	// Condition is false (env == "dev") — breakpoint must not fire
+	bp, hit := debugImpl.checkBreakpoint(session, "step1", map[string]interface{}{"env": "dev"})
+	assert.Nil(t, bp, "breakpoint must not trigger when condition is false")
+	assert.False(t, hit)
+
+	// Condition is true (env == "prod") — breakpoint must fire
+	bp, hit = debugImpl.checkBreakpoint(session, "step1", map[string]interface{}{"env": "prod"})
+	assert.NotNil(t, bp, "breakpoint must trigger when condition is true")
+	assert.True(t, hit)
+}
+
 // Helper functions for testing
 
-// mockLogger implements a simple test logger
-type mockLogger struct{}
-
-func (l *mockLogger) Debug(msg string, fields ...interface{})                         {}
-func (l *mockLogger) Info(msg string, fields ...interface{})                          {}
-func (l *mockLogger) Warn(msg string, fields ...interface{})                          {}
-func (l *mockLogger) Error(msg string, fields ...interface{})                         {}
-func (l *mockLogger) Fatal(msg string, fields ...interface{})                         {}
-func (l *mockLogger) DebugCtx(ctx context.Context, msg string, fields ...interface{}) {}
-func (l *mockLogger) InfoCtx(ctx context.Context, msg string, fields ...interface{})  {}
-func (l *mockLogger) WarnCtx(ctx context.Context, msg string, fields ...interface{})  {}
-func (l *mockLogger) ErrorCtx(ctx context.Context, msg string, fields ...interface{}) {}
-func (l *mockLogger) FatalCtx(ctx context.Context, msg string, fields ...interface{}) {}
-
 func createTestEngineWithDebug(t *testing.T) (*Engine, logging.Logger) {
-	logger := &mockLogger{}
-	moduleFactory := &factory.ModuleFactory{} // Mock factory for testing
-	engine := NewEngine(moduleFactory, logger, nil)
+	t.Helper()
+	logger := pkgtesting.NewMockLogger(true)
+	engine := NewEngine(createTestFactory(), logger, nil)
 	return engine, logger
 }
 


### PR DESCRIPTION
## Summary

- **ReplayAPICall**: Re-issues the original HTTP request (method, URL, headers, body) via a real `net/http` client and returns the actual response status, headers, and body. Releases the session read lock before making the network call to avoid holding it during I/O; I/O errors are stored in `APICallInfo.Error`.
- **RollbackToStep**: Truncates `session.StepHistory` to exclude the target step and everything after it, restores `VariableInspector.CurrentVariables` from `VariablesBefore` snapshot of that step, and resets `session.CurrentStep`. `session.mutex` and `VariableInspector.mutex` are taken sequentially (never nested) to avoid lock-ordering deadlocks.
- **Breakpoint condition evaluation**: Delegates to `Engine.evaluateCondition(breakpoint.Condition, variables)` — breakpoints whose condition evaluates to false (or errors) are skipped; only true-condition breakpoints pause execution.

Also fixes pre-existing test-quality issues in `debug_test.go` flagged by QA code review:
- Replaced hand-rolled `mockLogger` with `pkgtesting.NewMockLogger(true)` (real CFGMS component)
- Replaced `&factory.ModuleFactory{}` zero-value with `createTestFactory()` (real factory constructor)
- Added `assert.Equal(http.StatusOK, replayCall.ResponseStatus)` in `TestDebugEngine_APICallHistory`
- Changed `_ = PauseExecution` setup call to `require.NoError`

Fixes #712

## Test plan

- [ ] `TestReplayAPICall_MakesRealRequest` — httptest.Server verifies real HTTP round-trip, response status 200, response body parsed
- [ ] `TestRollbackToStep_RestoresState` — asserts history is truncated to 1 entry, variables restored to `after_step1`, CurrentStep set to `step2`; also asserts nonexistent-step returns error
- [ ] `TestBreakpointCondition_RespectedOnHit` — asserts conditional breakpoint returns `(nil, false)` when env=dev, `(bp, true)` when env=prod
- [ ] `make test-agent-complete` passes: 80+ packages, all platforms (linux/amd64, linux/arm64, darwin/amd64, darwin/arm64, windows/amd64), golangci-lint clean, architecture checks pass

## Specialist Review Results

| Specialist | Result | Notes |
|---|---|---|
| QA Test Runner | **PASS** | All 80+ packages, 5 platforms, zero failures |
| QA Code Reviewer | **PASS** (re-run after fixes) | 0 blocking issues; 2 missing error-path test warnings (non-blocking) |
| Security Engineer | **PASS** | 0 blocking issues; 5 low/medium warnings around SSRF hardening on the debug-only replay path (non-blocking; follow-up recommended before API endpoint exposure) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)