### PR TITLE
workflow/trigger: implement JSON schema validation and Basic auth (Issue #713)

### DIFF
--- a/features/workflow/trigger/webhook.go
+++ b/features/workflow/trigger/webhook.go
@@ -8,6 +8,7 @@ import (
 	"crypto/rand"
 	"crypto/sha256"
 	"crypto/subtle"
+	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
@@ -29,6 +30,9 @@ import (
 
 // errBearerAuthRateLimited is returned when the bearer token auth failure rate limit is exceeded.
 var errBearerAuthRateLimited = errors.New("bearer auth rate limit exceeded")
+
+// errBasicAuthUnauthorized is returned when Basic auth credentials are missing or invalid.
+var errBasicAuthUnauthorized = errors.New("basic auth unauthorized")
 
 // HTTPWebhookHandler implements the WebhookHandler interface using HTTP endpoints
 type HTTPWebhookHandler struct {
@@ -485,6 +489,13 @@ func (wh *HTTPWebhookHandler) handleWebhookRequest(w http.ResponseWriter, r *htt
 			http.Error(w, "Rate limit exceeded", http.StatusTooManyRequests)
 			return
 		}
+		if errors.Is(err, errBasicAuthUnauthorized) {
+			logger.WarnCtx(ctx, "Webhook basic auth failed",
+				"trigger_id", triggerID,
+				"remote_addr", r.RemoteAddr)
+			http.Error(w, "Unauthorized", http.StatusUnauthorized)
+			return
+		}
 		logger.ErrorCtx(ctx, "Failed to process webhook",
 			"trigger_id", triggerID,
 			"error", err.Error())
@@ -526,11 +537,8 @@ func (wh *HTTPWebhookHandler) validatePayload(webhook *WebhookConfig, payload []
 
 	// Validate JSON structure if JSON schema is provided
 	if validation.JSONSchema != "" {
-		// TODO: Implement JSON schema validation
-		// For now, just check if it's valid JSON
-		var jsonData interface{}
-		if err := json.Unmarshal(payload, &jsonData); err != nil {
-			return fmt.Errorf("invalid JSON payload: %w", err)
+		if err := validateJSONSchema(payload, validation.JSONSchema); err != nil {
+			return err
 		}
 	}
 
@@ -703,10 +711,39 @@ func (wh *HTTPWebhookHandler) validateBasicAuth(auth *WebhookAuth, headers map[s
 		return fmt.Errorf("basic auth configuration is required")
 	}
 
-	// TODO: Implement Basic auth validation
-	// This would require base64 decoding the Authorization header
-	// and comparing username/password
-	return fmt.Errorf("basic auth validation not yet implemented")
+	authHeader, exists := headers["Authorization"]
+	if !exists {
+		return errBasicAuthUnauthorized
+	}
+
+	const prefix = "Basic "
+	if !strings.HasPrefix(authHeader, prefix) {
+		return errBasicAuthUnauthorized
+	}
+
+	decoded, err := base64.StdEncoding.DecodeString(authHeader[len(prefix):])
+	if err != nil {
+		return errBasicAuthUnauthorized
+	}
+
+	// Split on the first colon only — passwords may contain colons (RFC 7617).
+	colonIdx := strings.IndexByte(string(decoded), ':')
+	if colonIdx < 0 {
+		return errBasicAuthUnauthorized
+	}
+
+	username := string(decoded[:colonIdx])
+	password := string(decoded[colonIdx+1:])
+
+	usernameMatch := subtle.ConstantTimeCompare([]byte(username), []byte(auth.BasicAuth.Username))
+	passwordMatch := subtle.ConstantTimeCompare([]byte(password), []byte(auth.BasicAuth.Password))
+
+	// AND the results to prevent short-circuit timing differences.
+	if usernameMatch&passwordMatch != 1 {
+		return errBasicAuthUnauthorized
+	}
+
+	return nil
 }
 
 // blockedWebhookHeaders is the set of header names (lowercased) that must never appear
@@ -724,6 +761,115 @@ func sanitizeHeaders(headers map[string]string) map[string]string {
 		}
 	}
 	return out
+}
+
+// validateJSONSchema validates a JSON payload against a JSON schema using basic structural
+// validation (type, required, properties). Supports a subset of JSON Schema draft-07.
+func validateJSONSchema(payload []byte, schema string) error {
+	var payloadDoc interface{}
+	if err := json.Unmarshal(payload, &payloadDoc); err != nil {
+		return fmt.Errorf("invalid JSON payload: %w", err)
+	}
+
+	var schemaDoc map[string]interface{}
+	if err := json.Unmarshal([]byte(schema), &schemaDoc); err != nil {
+		return fmt.Errorf("invalid JSON schema: %w", err)
+	}
+
+	if err := applySchemaRules(payloadDoc, schemaDoc); err != nil {
+		return fmt.Errorf("payload does not match JSON schema: %w", err)
+	}
+	return nil
+}
+
+// applySchemaRules recursively applies JSON schema rules (type, required, properties).
+func applySchemaRules(value interface{}, schema map[string]interface{}) error {
+	if schemaType, ok := schema["type"]; ok {
+		typeName, ok := schemaType.(string)
+		if !ok {
+			return fmt.Errorf("schema 'type' must be a string")
+		}
+		if err := checkJSONType(value, typeName); err != nil {
+			return err
+		}
+	}
+
+	obj, isObj := value.(map[string]interface{})
+
+	if required, ok := schema["required"]; ok {
+		requiredFields, ok := required.([]interface{})
+		if !ok {
+			return fmt.Errorf("schema 'required' must be an array")
+		}
+		if !isObj {
+			return fmt.Errorf("payload must be an object to validate required fields")
+		}
+		for _, f := range requiredFields {
+			field, _ := f.(string)
+			if _, exists := obj[field]; !exists {
+				return fmt.Errorf("required field %q is missing", field)
+			}
+		}
+	}
+
+	if properties, ok := schema["properties"]; ok && isObj {
+		propsMap, ok := properties.(map[string]interface{})
+		if !ok {
+			return fmt.Errorf("schema 'properties' must be an object")
+		}
+		for fieldName, fieldSchema := range propsMap {
+			if fieldValue, exists := obj[fieldName]; exists {
+				fieldSchemaMap, ok := fieldSchema.(map[string]interface{})
+				if !ok {
+					continue
+				}
+				if err := applySchemaRules(fieldValue, fieldSchemaMap); err != nil {
+					return fmt.Errorf("field %q: %w", fieldName, err)
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
+// checkJSONType verifies that a JSON value matches the declared schema type.
+func checkJSONType(value interface{}, schemaType string) error {
+	switch schemaType {
+	case "object":
+		if _, ok := value.(map[string]interface{}); !ok {
+			return fmt.Errorf("expected type object, got %T", value)
+		}
+	case "array":
+		if _, ok := value.([]interface{}); !ok {
+			return fmt.Errorf("expected type array, got %T", value)
+		}
+	case "string":
+		if _, ok := value.(string); !ok {
+			return fmt.Errorf("expected type string, got %T", value)
+		}
+	case "number":
+		if _, ok := value.(float64); !ok {
+			return fmt.Errorf("expected type number, got %T", value)
+		}
+	case "integer":
+		f, ok := value.(float64)
+		if !ok {
+			return fmt.Errorf("expected type integer, got %T", value)
+		}
+		if f != float64(int64(f)) {
+			return fmt.Errorf("expected integer value, got %v", f)
+		}
+	case "boolean":
+		if _, ok := value.(bool); !ok {
+			return fmt.Errorf("expected type boolean, got %T", value)
+		}
+	case "null":
+		if value != nil {
+			return fmt.Errorf("expected null, got %T", value)
+		}
+	}
+	return nil
 }
 
 // mapPayloadToVariables maps webhook payload to workflow variables

--- a/features/workflow/trigger/webhook.go
+++ b/features/workflow/trigger/webhook.go
@@ -34,6 +34,9 @@ var errBearerAuthRateLimited = errors.New("bearer auth rate limit exceeded")
 // errBasicAuthUnauthorized is returned when Basic auth credentials are missing or invalid.
 var errBasicAuthUnauthorized = errors.New("basic auth unauthorized")
 
+// errPayloadValidationFailed is returned when a webhook payload fails schema or structural validation.
+var errPayloadValidationFailed = errors.New("payload validation failed")
+
 // HTTPWebhookHandler implements the WebhookHandler interface using HTTP endpoints
 type HTTPWebhookHandler struct {
 	logger              *logging.ModuleLogger
@@ -257,7 +260,7 @@ func (wh *HTTPWebhookHandler) HandleWebhook(ctx context.Context, triggerID strin
 			"trigger_id", triggerID,
 			"error", err.Error())
 
-		return execution, err
+		return execution, fmt.Errorf("%w: %v", errPayloadValidationFailed, err)
 	}
 
 	// Authenticate request
@@ -494,6 +497,13 @@ func (wh *HTTPWebhookHandler) handleWebhookRequest(w http.ResponseWriter, r *htt
 				"trigger_id", triggerID,
 				"remote_addr", r.RemoteAddr)
 			http.Error(w, "Unauthorized", http.StatusUnauthorized)
+			return
+		}
+		if errors.Is(err, errPayloadValidationFailed) {
+			logger.WarnCtx(ctx, "Webhook payload validation failed",
+				"trigger_id", triggerID,
+				"remote_addr", r.RemoteAddr)
+			http.Error(w, "Bad Request", http.StatusBadRequest)
 			return
 		}
 		logger.ErrorCtx(ctx, "Failed to process webhook",

--- a/features/workflow/trigger/webhook_test.go
+++ b/features/workflow/trigger/webhook_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"crypto/hmac"
 	"crypto/sha256"
+	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
@@ -1008,6 +1009,275 @@ func TestHandleWebhookNoAuthHeadersInWorkflowVariables(t *testing.T) {
 
 	// Safe headers must still be present.
 	assert.Contains(t, combined, "safe-value", "non-auth headers must still be present")
+}
+
+// TestWebhookPayloadSchemaValidation covers valid payload, invalid payload, and no-schema cases.
+func TestWebhookPayloadSchemaValidation(t *testing.T) {
+	handler := &HTTPWebhookHandler{}
+
+	tests := []struct {
+		name          string
+		webhook       *WebhookConfig
+		payload       []byte
+		expectError   bool
+		errorContains string
+	}{
+		{
+			name: "no schema configured accepts any payload",
+			webhook: &WebhookConfig{
+				PayloadValidation: &PayloadValidation{
+					JSONSchema: "",
+				},
+			},
+			payload:     []byte(`{"anything": "accepted"}`),
+			expectError: false,
+		},
+		{
+			name: "valid payload matching schema",
+			webhook: &WebhookConfig{
+				PayloadValidation: &PayloadValidation{
+					JSONSchema: `{"type": "object", "required": ["id", "name"], "properties": {"id": {"type": "string"}, "name": {"type": "string"}}}`,
+				},
+			},
+			payload:     []byte(`{"id": "123", "name": "test", "extra": "ignored"}`),
+			expectError: false,
+		},
+		{
+			name: "payload missing required field rejected with schema error",
+			webhook: &WebhookConfig{
+				PayloadValidation: &PayloadValidation{
+					JSONSchema: `{"type": "object", "required": ["id", "name"]}`,
+				},
+			},
+			payload:       []byte(`{"id": "123"}`),
+			expectError:   true,
+			errorContains: "payload does not match JSON schema",
+		},
+		{
+			name: "payload wrong root type rejected",
+			webhook: &WebhookConfig{
+				PayloadValidation: &PayloadValidation{
+					JSONSchema: `{"type": "object"}`,
+				},
+			},
+			payload:       []byte(`["not", "an", "object"]`),
+			expectError:   true,
+			errorContains: "payload does not match JSON schema",
+		},
+		{
+			name: "property type mismatch rejected",
+			webhook: &WebhookConfig{
+				PayloadValidation: &PayloadValidation{
+					JSONSchema: `{"type": "object", "properties": {"count": {"type": "integer"}}}`,
+				},
+			},
+			payload:       []byte(`{"count": "not-a-number"}`),
+			expectError:   true,
+			errorContains: "payload does not match JSON schema",
+		},
+		{
+			name: "invalid JSON schema config returns error",
+			webhook: &WebhookConfig{
+				PayloadValidation: &PayloadValidation{
+					JSONSchema: `{invalid json`,
+				},
+			},
+			payload:       []byte(`{"id": "123"}`),
+			expectError:   true,
+			errorContains: "invalid JSON schema",
+		},
+		{
+			name: "no validation config accepts payload",
+			webhook: &WebhookConfig{
+				PayloadValidation: nil,
+			},
+			payload:     []byte(`{"anything": "accepted"}`),
+			expectError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := handler.validatePayload(tt.webhook, tt.payload)
+			if tt.expectError {
+				require.Error(t, err)
+				if tt.errorContains != "" {
+					assert.Contains(t, err.Error(), tt.errorContains)
+				}
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+// TestWebhookBasicAuth covers correct credentials, wrong password, and missing header cases.
+func TestWebhookBasicAuth(t *testing.T) {
+	handler := &HTTPWebhookHandler{}
+
+	auth := &WebhookAuth{
+		BasicAuth: &BasicAuth{
+			Username: "admin",
+			Password: "s3cr3t!",
+		},
+	}
+
+	basicHeader := func(username, password string) string {
+		return "Basic " + base64.StdEncoding.EncodeToString([]byte(username+":"+password))
+	}
+
+	tests := []struct {
+		name        string
+		headers     map[string]string
+		expectError bool
+		errorIs     error
+	}{
+		{
+			name:        "correct credentials accepted",
+			headers:     map[string]string{"Authorization": basicHeader("admin", "s3cr3t!")},
+			expectError: false,
+		},
+		{
+			name:        "wrong password rejected",
+			headers:     map[string]string{"Authorization": basicHeader("admin", "wrong")},
+			expectError: true,
+			errorIs:     errBasicAuthUnauthorized,
+		},
+		{
+			name:        "wrong username rejected",
+			headers:     map[string]string{"Authorization": basicHeader("other", "s3cr3t!")},
+			expectError: true,
+			errorIs:     errBasicAuthUnauthorized,
+		},
+		{
+			name:        "missing Authorization header rejected",
+			headers:     map[string]string{},
+			expectError: true,
+			errorIs:     errBasicAuthUnauthorized,
+		},
+		{
+			name:        "malformed base64 rejected",
+			headers:     map[string]string{"Authorization": "Basic not-valid-base64!!!"},
+			expectError: true,
+			errorIs:     errBasicAuthUnauthorized,
+		},
+		{
+			name:        "non-Basic scheme rejected",
+			headers:     map[string]string{"Authorization": "Bearer some-token"},
+			expectError: true,
+			errorIs:     errBasicAuthUnauthorized,
+		},
+		{
+			name:        "password mismatch confirms split on first colon only",
+			headers:     map[string]string{"Authorization": basicHeader("admin", "s3cr3t!:extra")},
+			expectError: true, // "s3cr3t!:extra" != "s3cr3t!" — correct first-colon split, wrong password
+			errorIs:     errBasicAuthUnauthorized,
+		},
+	}
+
+	// Nil BasicAuth config tested separately since it requires a different auth struct.
+	t.Run("nil BasicAuth config returns configuration error", func(t *testing.T) {
+		err := handler.validateBasicAuth(&WebhookAuth{BasicAuth: nil}, map[string]string{
+			"Authorization": basicHeader("admin", "s3cr3t!"),
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "basic auth configuration is required")
+	})
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := handler.validateBasicAuth(auth, tt.headers)
+			if tt.expectError {
+				require.Error(t, err)
+				if tt.errorIs != nil {
+					assert.ErrorIs(t, err, tt.errorIs)
+				}
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+// TestWebhookBasicAuthHTTP verifies that the HTTP handler returns 401 for missing or wrong
+// Basic auth credentials and 202 for correct credentials.
+func TestWebhookBasicAuthHTTP(t *testing.T) {
+	mockTriggerManager := &MockTriggerManager{}
+	mockWorkflowTrigger := &MockWorkflowTrigger{}
+	handler := NewHTTPWebhookHandler(mockTriggerManager, mockWorkflowTrigger, "localhost", 0)
+
+	trigger := &Trigger{
+		ID:           "webhook-basic",
+		Type:         TriggerTypeWebhook,
+		WorkflowName: "test-workflow",
+		Webhook: &WebhookConfig{
+			Path:    "/webhook/basic-auth-test",
+			Method:  []string{"POST"},
+			Enabled: true,
+			Authentication: &WebhookAuth{
+				Type: WebhookAuthBasic,
+				BasicAuth: &BasicAuth{
+					Username: "user",
+					Password: "pass",
+				},
+			},
+		},
+	}
+
+	ctx := context.Background()
+	err := handler.RegisterWebhook(ctx, trigger)
+	require.NoError(t, err)
+
+	mockWorkflowTrigger.On("TriggerWorkflow", mock.Anything, mock.Anything, mock.Anything).Return(
+		&workflow.WorkflowExecution{
+			ID:           "exec-basic",
+			WorkflowName: "test-workflow",
+			Status:       workflow.StatusRunning,
+			StartTime:    time.Now(),
+		}, nil)
+
+	basicHeader := func(username, password string) string {
+		return "Basic " + base64.StdEncoding.EncodeToString([]byte(username+":"+password))
+	}
+
+	tests := []struct {
+		name           string
+		authHeader     string
+		expectedStatus int
+	}{
+		{
+			name:           "missing Authorization header returns 401",
+			authHeader:     "",
+			expectedStatus: http.StatusUnauthorized,
+		},
+		{
+			name:           "wrong password returns 401",
+			authHeader:     basicHeader("user", "wrong"),
+			expectedStatus: http.StatusUnauthorized,
+		},
+		{
+			name:           "correct credentials returns 202",
+			authHeader:     basicHeader("user", "pass"),
+			expectedStatus: http.StatusAccepted,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req, err := http.NewRequest("POST", "/webhook/basic-auth-test",
+				strings.NewReader(`{"event": "test"}`))
+			require.NoError(t, err)
+			req.Header.Set("Content-Type", "application/json")
+			if tt.authHeader != "" {
+				req.Header.Set("Authorization", tt.authHeader)
+			}
+
+			rr := httptest.NewRecorder()
+			handler.router.ServeHTTP(rr, req)
+
+			assert.Equal(t, tt.expectedStatus, rr.Code)
+		})
+	}
 }
 
 // Helper function to generate HMAC signature for tests

--- a/features/workflow/trigger/webhook_test.go
+++ b/features/workflow/trigger/webhook_test.go
@@ -1280,6 +1280,76 @@ func TestWebhookBasicAuthHTTP(t *testing.T) {
 	}
 }
 
+// TestWebhookPayloadSchemaValidationHTTP verifies that the HTTP handler returns 400 for
+// payloads that fail JSON schema validation and 202 for valid payloads.
+func TestWebhookPayloadSchemaValidationHTTP(t *testing.T) {
+	mockTriggerManager := &MockTriggerManager{}
+	mockWorkflowTrigger := &MockWorkflowTrigger{}
+	handler := NewHTTPWebhookHandler(mockTriggerManager, mockWorkflowTrigger, "localhost", 0)
+
+	trigger := &Trigger{
+		ID:           "webhook-schema",
+		Type:         TriggerTypeWebhook,
+		WorkflowName: "test-workflow",
+		Webhook: &WebhookConfig{
+			Path:    "/webhook/schema-test",
+			Method:  []string{"POST"},
+			Enabled: true,
+			PayloadValidation: &PayloadValidation{
+				JSONSchema: `{"type": "object", "required": ["id"], "properties": {"id": {"type": "string"}}}`,
+			},
+		},
+	}
+
+	ctx := context.Background()
+	err := handler.RegisterWebhook(ctx, trigger)
+	require.NoError(t, err)
+
+	mockWorkflowTrigger.On("TriggerWorkflow", mock.Anything, mock.Anything, mock.Anything).Return(
+		&workflow.WorkflowExecution{
+			ID:           "exec-schema",
+			WorkflowName: "test-workflow",
+			Status:       workflow.StatusRunning,
+			StartTime:    time.Now(),
+		}, nil)
+
+	tests := []struct {
+		name           string
+		payload        string
+		expectedStatus int
+	}{
+		{
+			name:           "schema-invalid payload returns 400",
+			payload:        `{"name": "missing-id-field"}`,
+			expectedStatus: http.StatusBadRequest,
+		},
+		{
+			name:           "wrong root type returns 400",
+			payload:        `["not", "an", "object"]`,
+			expectedStatus: http.StatusBadRequest,
+		},
+		{
+			name:           "valid payload returns 202",
+			payload:        `{"id": "abc123"}`,
+			expectedStatus: http.StatusAccepted,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req, err := http.NewRequest("POST", "/webhook/schema-test",
+				strings.NewReader(tt.payload))
+			require.NoError(t, err)
+			req.Header.Set("Content-Type", "application/json")
+
+			rr := httptest.NewRecorder()
+			handler.router.ServeHTTP(rr, req)
+
+			assert.Equal(t, tt.expectedStatus, rr.Code)
+		})
+	}
+}
+
 // Helper function to generate HMAC signature for tests
 func generateHMACSignature(secret string, payload []byte) string {
 	mac := hmac.New(sha256.New, []byte(secret))


### PR DESCRIPTION
## Summary

- Replaces two TODO stubs in `features/workflow/trigger/webhook.go` with real security-complete implementations
- **JSON schema validation**: stdlib-only validator (type, required, properties) that rejects non-conforming payloads with HTTP 400
- **Basic auth**: constant-time credential comparison via `crypto/subtle.ConstantTimeCompare`, with RFC 7617-correct first-colon split; all failure paths return the same sentinel error to prevent credential enumeration
- **HTTP 401**: `handleWebhookRequest` now maps `errBasicAuthUnauthorized` to 401 Unauthorized (previously all auth failures returned 500)

Fixes #713

## Test plan

- [ ] `TestWebhookPayloadSchemaValidation` — 7 subtests: no-schema pass-through, valid payload, missing required field, wrong root type, property type mismatch, invalid schema config
- [ ] `TestWebhookBasicAuth` — 8 subtests: correct credentials, wrong password, wrong username, missing header, malformed base64, wrong scheme, nil config, first-colon-only split
- [ ] `TestWebhookBasicAuthHTTP` — 3 subtests: HTTP 401 for missing header, HTTP 401 for wrong password, HTTP 202 for correct credentials
- [ ] All existing webhook tests continue to pass

## Specialist Review Results

**QA Test Runner**: PASS — all packages pass, 0 test failures, lint clean, architecture compliant

**QA Code Reviewer**: PASS — 0 blocking issues; 3 non-blocking warnings (misleading test case name fixed before commit, nil-config error path test added)

**Security Engineer**: PASS — `subtle.ConstantTimeCompare` with bitwise AND verified at line 738-742; no information disclosure; no hardcoded secrets; no central provider violations; architecture scan clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)