### PR TITLE
reports/exporters: implement PDF and Excel export methods (Issue #707)

### DIFF
--- a/features/reports/exporters/exporter.go
+++ b/features/reports/exporters/exporter.go
@@ -3,6 +3,7 @@
 package exporters
 
 import (
+	"archive/zip"
 	"bytes"
 	"context"
 	"encoding/csv"
@@ -28,15 +29,13 @@ type MultiFormatExporter struct {
 type Config struct {
 	HTMLTemplate string `json:"html_template"`
 	PDFEnabled   bool   `json:"pdf_enabled"`
-	PDFCommand   string `json:"pdf_command"` // Command to convert HTML to PDF
 }
 
 // DefaultConfig returns default exporter configuration
 func DefaultConfig() Config {
 	return Config{
 		HTMLTemplate: defaultHTMLTemplate,
-		PDFEnabled:   false, // Disable PDF by default as it requires external tools
-		PDFCommand:   "wkhtmltopdf --page-size A4 --orientation Portrait --margin-top 1in --margin-bottom 1in --margin-left 0.75in --margin-right 0.75in",
+		PDFEnabled:   true,
 	}
 }
 
@@ -80,14 +79,12 @@ func (e *MultiFormatExporter) SupportedFormats() []interfaces.ExportFormat {
 		interfaces.FormatJSON,
 		interfaces.FormatCSV,
 		interfaces.FormatHTML,
+		interfaces.FormatExcel,
 	}
 
 	if e.config.PDFEnabled {
 		formats = append(formats, interfaces.FormatPDF)
 	}
-
-	// Excel export would require additional dependencies
-	// formats = append(formats, interfaces.FormatExcel)
 
 	return formats
 }
@@ -252,26 +249,251 @@ func (e *MultiFormatExporter) exportHTML(report *interfaces.Report) ([]byte, err
 	return buf.Bytes(), nil
 }
 
-// exportPDF exports the report as PDF (requires external tool)
-func (e *MultiFormatExporter) exportPDF(ctx context.Context, report *interfaces.Report) ([]byte, error) {
+// exportPDF generates a minimal valid PDF-1.4 document using pure stdlib byte-stream
+// construction — no external tools or libraries required.
+func (e *MultiFormatExporter) exportPDF(_ context.Context, report *interfaces.Report) ([]byte, error) {
 	if !e.config.PDFEnabled {
-		return nil, fmt.Errorf("PDF export is not enabled")
+		return nil, fmt.Errorf("PDF export is not enabled; set Config.PDFEnabled = true to enable")
 	}
 
-	// This would require implementing HTML-to-PDF conversion
-	// using an external tool like wkhtmltopdf or a Go library
-	// For now, return an error indicating it's not implemented
-	e.logger.Warn("PDF export not fully implemented - would require external tool integration")
-	return nil, fmt.Errorf("PDF export not implemented - requires external PDF generation tool")
+	stream := buildReportPDFContentStream(report)
+
+	var buf bytes.Buffer
+	buf.WriteString("%PDF-1.4\n")
+
+	// Track byte offset of each object (1-indexed; index 0 unused).
+	var offsets [5]int
+
+	offsets[1] = buf.Len()
+	fmt.Fprintf(&buf, "1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n")
+
+	offsets[2] = buf.Len()
+	fmt.Fprintf(&buf, "2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 >>\nendobj\n")
+
+	offsets[3] = buf.Len()
+	fmt.Fprintf(&buf, "3 0 obj\n<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792]"+
+		" /Contents 4 0 R /Resources << /Font << /F1 << /Type /Font /Subtype /Type1"+
+		" /BaseFont /Helvetica >> >> >> >>\nendobj\n")
+
+	offsets[4] = buf.Len()
+	fmt.Fprintf(&buf, "4 0 obj\n<< /Length %d >>\nstream\n%sendstream\nendobj\n",
+		len(stream), stream)
+
+	xrefOffset := buf.Len()
+	fmt.Fprintf(&buf, "xref\n0 5\n")
+	// Each xref entry must be exactly 20 bytes: 10-digit-offset SP 5-digit-gen SP n|f CR LF
+	fmt.Fprintf(&buf, "0000000000 65535 f\r\n")
+	for i := 1; i <= 4; i++ {
+		fmt.Fprintf(&buf, "%010d 00000 n\r\n", offsets[i])
+	}
+	fmt.Fprintf(&buf, "trailer\n<< /Size 5 /Root 1 0 R >>\nstartxref\n%d\n", xrefOffset)
+	buf.WriteString("%%EOF\n")
+
+	return buf.Bytes(), nil
 }
 
-// exportExcel exports the report as Excel file
-func (e *MultiFormatExporter) exportExcel(report *interfaces.Report) ([]byte, error) {
-	// Excel export would require a library like excelize
-	// For now, return an error indicating it's not implemented
-	e.logger.Warn("Excel export not implemented - would require additional dependencies")
-	return nil, fmt.Errorf("excel export not implemented - requires additional dependencies")
+// buildReportPDFContentStream builds a BT…ET text block for a single-page report PDF.
+func buildReportPDFContentStream(report *interfaces.Report) string {
+	body := fmt.Sprintf(
+		"Generated: %s | Type: %s | Devices: %d | Compliance: %.1f%% | Drift: %d | Critical: %d | Trend: %s",
+		report.GeneratedAt.Format(time.RFC3339),
+		string(report.Type),
+		report.Summary.DevicesAnalyzed,
+		report.Summary.ComplianceScore*100,
+		report.Summary.DriftEventsTotal,
+		report.Summary.CriticalIssues,
+		string(report.Summary.TrendDirection),
+	)
+
+	var b strings.Builder
+	b.WriteString("BT\n")
+	fmt.Fprintf(&b, "/F1 14 Tf\n50 730 Td\n(%s) Tj\n", pdfEscapeString(report.Title))
+	fmt.Fprintf(&b, "/F1 10 Tf\n0 -25 Td\n(%s) Tj\n", pdfEscapeString(body))
+	b.WriteString("ET\n")
+	return b.String()
 }
+
+// pdfEscapeString escapes characters that are special inside PDF literal strings.
+func pdfEscapeString(s string) string {
+	var b strings.Builder
+	for _, ch := range s {
+		switch ch {
+		case '\\':
+			b.WriteString("\\\\")
+		case '(':
+			b.WriteString("\\(")
+		case ')':
+			b.WriteString("\\)")
+		case '\n', '\r':
+			b.WriteByte(' ')
+		default:
+			if ch > 126 {
+				b.WriteByte(' ') // Type1 fonts only cover printable ASCII
+			} else {
+				b.WriteRune(ch)
+			}
+		}
+	}
+	return b.String()
+}
+
+// exportExcel generates a minimal valid XLSX file using archive/zip and inline XML.
+// XLSX is the Open XML Spreadsheet format (ISO/IEC 29500); it requires no external dependencies.
+func (e *MultiFormatExporter) exportExcel(report *interfaces.Report) ([]byte, error) {
+	rows := buildExcelRows(report)
+
+	var buf bytes.Buffer
+	zw := zip.NewWriter(&buf)
+
+	entries := []struct {
+		name    string
+		content string
+	}{
+		{"[Content_Types].xml", xlsxContentTypes},
+		{"_rels/.rels", xlsxRootRels},
+		{"xl/workbook.xml", xlsxWorkbook},
+		{"xl/_rels/workbook.xml.rels", xlsxWorkbookRels},
+		{"xl/worksheets/sheet1.xml", buildSheetXML(rows)},
+	}
+	for _, e := range entries {
+		w, err := zw.Create(e.name)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create XLSX entry %s: %w", e.name, err)
+		}
+		if _, err := fmt.Fprint(w, e.content); err != nil {
+			return nil, fmt.Errorf("failed to write XLSX entry %s: %w", e.name, err)
+		}
+	}
+
+	if err := zw.Close(); err != nil {
+		return nil, fmt.Errorf("failed to finalize XLSX: %w", err)
+	}
+	return buf.Bytes(), nil
+}
+
+// buildExcelRows converts a report into a two-column row slice suitable for an XLSX sheet.
+func buildExcelRows(report *interfaces.Report) [][]string {
+	var rows [][]string
+
+	rows = append(rows,
+		[]string{"Report Title", report.Title},
+		[]string{"Report Type", string(report.Type)},
+		[]string{"Generated At", report.GeneratedAt.Format(time.RFC3339)},
+		[]string{"Time Range", fmt.Sprintf("%s to %s",
+			report.TimeRange.Start.Format(time.RFC3339),
+			report.TimeRange.End.Format(time.RFC3339))},
+		[]string{},
+		[]string{"Summary"},
+		[]string{"Devices Analyzed", strconv.Itoa(report.Summary.DevicesAnalyzed)},
+		[]string{"Drift Events Total", strconv.Itoa(report.Summary.DriftEventsTotal)},
+		[]string{"Compliance Score", fmt.Sprintf("%.2f", report.Summary.ComplianceScore)},
+		[]string{"Critical Issues", strconv.Itoa(report.Summary.CriticalIssues)},
+		[]string{"Trend Direction", string(report.Summary.TrendDirection)},
+		[]string{},
+	)
+
+	if len(report.Summary.KeyInsights) > 0 {
+		rows = append(rows, []string{"Key Insights"})
+		for i, insight := range report.Summary.KeyInsights {
+			rows = append(rows, []string{strconv.Itoa(i + 1), insight})
+		}
+		rows = append(rows, []string{})
+	}
+
+	if len(report.Summary.RecommendedActions) > 0 {
+		rows = append(rows, []string{"Recommended Actions"})
+		for i, action := range report.Summary.RecommendedActions {
+			rows = append(rows, []string{strconv.Itoa(i + 1), action})
+		}
+		rows = append(rows, []string{})
+	}
+
+	for _, section := range report.Sections {
+		rows = append(rows, []string{fmt.Sprintf("Section: %s", section.Title)})
+		rows = append(rows, []string{"Content", fmt.Sprintf("%v", section.Content)})
+		rows = append(rows, []string{})
+	}
+
+	return rows
+}
+
+// buildSheetXML produces the xl/worksheets/sheet1.xml content for the given rows.
+func buildSheetXML(rows [][]string) string {
+	var b strings.Builder
+	b.WriteString(`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>`)
+	b.WriteString(`<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">`)
+	b.WriteString(`<sheetData>`)
+	for rowIdx, row := range rows {
+		rowNum := rowIdx + 1
+		fmt.Fprintf(&b, `<row r="%d">`, rowNum)
+		for colIdx, cell := range row {
+			cellRef := fmt.Sprintf("%s%d", xlsxColLetter(colIdx+1), rowNum)
+			fmt.Fprintf(&b, `<c r="%s" t="inlineStr"><is><t>%s</t></is></c>`,
+				cellRef, xmlEscapeString(cell))
+		}
+		b.WriteString(`</row>`)
+	}
+	b.WriteString(`</sheetData>`)
+	b.WriteString(`</worksheet>`)
+	return b.String()
+}
+
+// xlsxColLetter converts a 1-based column index to an Excel column letter (A–Z, AA–AZ, …).
+func xlsxColLetter(col int) string {
+	if col <= 26 {
+		return string(rune('A' + col - 1))
+	}
+	return string(rune('A'+(col-1)/26-1)) + string(rune('A'+(col-1)%26))
+}
+
+// xmlEscapeString escapes the five predefined XML entities.
+func xmlEscapeString(s string) string {
+	var b strings.Builder
+	for _, ch := range s {
+		switch ch {
+		case '&':
+			b.WriteString("&amp;")
+		case '<':
+			b.WriteString("&lt;")
+		case '>':
+			b.WriteString("&gt;")
+		case '"':
+			b.WriteString("&quot;")
+		case '\'':
+			b.WriteString("&apos;")
+		default:
+			b.WriteRune(ch)
+		}
+	}
+	return b.String()
+}
+
+// XLSX static components — these are fixed for any single-sheet workbook.
+const xlsxContentTypes = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>` +
+	`<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">` +
+	`<Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>` +
+	`<Default Extension="xml" ContentType="application/xml"/>` +
+	`<Override PartName="/xl/workbook.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml"/>` +
+	`<Override PartName="/xl/worksheets/sheet1.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml"/>` +
+	`</Types>`
+
+const xlsxRootRels = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>` +
+	`<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">` +
+	`<Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="xl/workbook.xml"/>` +
+	`</Relationships>`
+
+const xlsxWorkbook = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>` +
+	`<workbook xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"` +
+	` xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">` +
+	`<sheets><sheet name="Report" sheetId="1" r:id="rId1"/></sheets>` +
+	`</workbook>`
+
+const xlsxWorkbookRels = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>` +
+	`<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">` +
+	`<Relationship Id="rId1"` +
+	` Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet"` +
+	` Target="worksheets/sheet1.xml"/>` +
+	`</Relationships>`
 
 // writeTableDataToCSV writes table data to CSV writer
 func (e *MultiFormatExporter) writeTableDataToCSV(writer *csv.Writer, data map[string]interface{}) error {

--- a/features/reports/exporters/exporter_test.go
+++ b/features/reports/exporters/exporter_test.go
@@ -1,0 +1,255 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+package exporters
+
+import (
+	"archive/zip"
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/cfgis/cfgms/features/reports/interfaces"
+	"github.com/cfgis/cfgms/pkg/logging"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// nonTrivialReport returns a report with sections, insights, and actions to exercise
+// all branches of the export logic.
+func nonTrivialReport() *interfaces.Report {
+	now := time.Date(2026, 3, 15, 10, 0, 0, 0, time.UTC)
+	return &interfaces.Report{
+		ID:          "test-report-707",
+		Type:        interfaces.ReportTypeCompliance,
+		Title:       "Q1 Compliance Report",
+		Subtitle:    "Quarterly device compliance analysis",
+		GeneratedAt: now,
+		TimeRange: interfaces.TimeRange{
+			Start: now.Add(-30 * 24 * time.Hour),
+			End:   now,
+		},
+		Metadata: interfaces.ReportMetadata{
+			Template:     "compliance-standard",
+			DeviceCount:  150,
+			DataPoints:   4500,
+			GenerationMS: 234,
+		},
+		Summary: interfaces.ReportSummary{
+			DevicesAnalyzed:    150,
+			DriftEventsTotal:   42,
+			ComplianceScore:    0.94,
+			CriticalIssues:     3,
+			TrendDirection:     interfaces.TrendImproving,
+			KeyInsights:        []string{"Device compliance improved 4% vs last quarter", "3 critical issues require immediate attention"},
+			RecommendedActions: []string{"Patch 12 devices with pending OS updates", "Review firewall rules on segment B"},
+		},
+		Sections: []interfaces.ReportSection{
+			{
+				ID:      "sec-1",
+				Title:   "Device Overview",
+				Type:    interfaces.SectionTypeText,
+				Content: "150 devices were analyzed during this period",
+			},
+			{
+				ID:    "sec-2",
+				Title: "Compliance Table",
+				Type:  interfaces.SectionTypeTable,
+				Content: map[string]interface{}{
+					"headers": []interface{}{"Device", "Score", "Status"},
+					"rows": []interface{}{
+						[]interface{}{"device-001", "0.98", "Compliant"},
+						[]interface{}{"device-002", "0.72", "Non-Compliant"},
+					},
+				},
+			},
+			{
+				ID:    "sec-3",
+				Title: "KPI Summary",
+				Type:  interfaces.SectionTypeKPI,
+				Content: map[string]interface{}{
+					"compliance_rate": 0.94,
+					"device_count":    150,
+				},
+			},
+		},
+	}
+}
+
+// TestExporterMethods exercises PDF and Excel export with a non-trivial report payload.
+func TestExporterMethods(t *testing.T) {
+	logger := logging.NewNoopLogger()
+	report := nonTrivialReport()
+	ctx := context.Background()
+
+	t.Run("PDF_produces_valid_document", func(t *testing.T) {
+		exporter := New(logger).WithConfig(Config{
+			HTMLTemplate: defaultHTMLTemplate,
+			PDFEnabled:   true,
+		})
+		data, err := exporter.Export(ctx, report, interfaces.FormatPDF)
+		require.NoError(t, err)
+		require.NotEmpty(t, data)
+
+		require.GreaterOrEqual(t, len(data), 4, "PDF output must be at least 4 bytes")
+		assert.Equal(t, "%PDF", string(data[:4]), "PDF must begin with %%PDF magic bytes")
+		assert.Contains(t, string(data), "%%EOF", "PDF must contain %%EOF trailer marker")
+		assert.Contains(t, string(data), report.Title, "PDF must embed the report title")
+	})
+
+	t.Run("PDF_disabled_returns_error", func(t *testing.T) {
+		exporter := New(logger).WithConfig(Config{
+			HTMLTemplate: defaultHTMLTemplate,
+			PDFEnabled:   false,
+		})
+		_, err := exporter.Export(ctx, report, interfaces.FormatPDF)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not enabled")
+	})
+
+	t.Run("Excel_produces_valid_XLSX", func(t *testing.T) {
+		exporter := New(logger)
+		data, err := exporter.Export(ctx, report, interfaces.FormatExcel)
+		require.NoError(t, err)
+		require.NotEmpty(t, data)
+
+		// XLSX is a ZIP archive; all ZIP files begin with PK magic bytes.
+		require.GreaterOrEqual(t, len(data), 2, "XLSX output must be at least 2 bytes")
+		assert.Equal(t, "PK", string(data[:2]), "XLSX must begin with ZIP magic bytes")
+
+		zr, err := zip.NewReader(bytes.NewReader(data), int64(len(data)))
+		require.NoError(t, err, "XLSX must be a valid ZIP archive")
+
+		names := make(map[string]bool, len(zr.File))
+		for _, f := range zr.File {
+			names[f.Name] = true
+		}
+		assert.True(t, names["[Content_Types].xml"], "XLSX must contain [Content_Types].xml")
+		assert.True(t, names["xl/workbook.xml"], "XLSX must contain xl/workbook.xml")
+		assert.True(t, names["xl/worksheets/sheet1.xml"], "XLSX must contain sheet1.xml")
+	})
+
+	t.Run("Excel_sheet_contains_report_data", func(t *testing.T) {
+		exporter := New(logger)
+		data, err := exporter.Export(ctx, report, interfaces.FormatExcel)
+		require.NoError(t, err)
+
+		zr, err := zip.NewReader(bytes.NewReader(data), int64(len(data)))
+		require.NoError(t, err)
+
+		var sheetContent string
+		for _, f := range zr.File {
+			if f.Name == "xl/worksheets/sheet1.xml" {
+				rc, err := f.Open()
+				require.NoError(t, err)
+				var buf bytes.Buffer
+				_, err = buf.ReadFrom(rc)
+				require.NoError(t, err)
+				require.NoError(t, rc.Close())
+				sheetContent = buf.String()
+				break
+			}
+		}
+		require.NotEmpty(t, sheetContent, "sheet1.xml must be present and non-empty")
+		assert.Contains(t, sheetContent, report.Title, "sheet must contain report title")
+		assert.Contains(t, sheetContent, "Compliance Score", "sheet must contain compliance score label")
+		assert.Contains(t, sheetContent, "Key Insights", "sheet must contain key insights section")
+		assert.Contains(t, sheetContent, "Device Overview", "sheet must contain section title")
+	})
+
+	t.Run("SupportedFormats_includes_Excel", func(t *testing.T) {
+		exporter := New(logger)
+		formats := exporter.SupportedFormats()
+		assert.Contains(t, formats, interfaces.FormatExcel, "Excel must appear in SupportedFormats")
+	})
+
+	t.Run("SupportedFormats_includes_PDF_when_enabled", func(t *testing.T) {
+		exporter := New(logger).WithConfig(Config{PDFEnabled: true})
+		formats := exporter.SupportedFormats()
+		assert.Contains(t, formats, interfaces.FormatPDF, "PDF must appear in SupportedFormats when enabled")
+	})
+
+	t.Run("SupportedFormats_excludes_PDF_when_disabled", func(t *testing.T) {
+		exporter := New(logger).WithConfig(Config{PDFEnabled: false})
+		formats := exporter.SupportedFormats()
+		assert.NotContains(t, formats, interfaces.FormatPDF, "PDF must not appear in SupportedFormats when disabled")
+	})
+
+	t.Run("DefaultConfig_PDF_enabled", func(t *testing.T) {
+		cfg := DefaultConfig()
+		assert.True(t, cfg.PDFEnabled, "PDF must be enabled by default")
+	})
+}
+
+// TestPDFEscapeString verifies that PDF special characters are correctly escaped.
+func TestPDFEscapeString(t *testing.T) {
+	cases := []struct {
+		input string
+		want  string
+	}{
+		{`hello`, `hello`},
+		{`say (hi)`, `say \(hi\)`},
+		{`back\slash`, `back\\slash`},
+		{"new\nline", "new line"},
+		{"carriage\rreturn", "carriage return"},
+	}
+	for _, tc := range cases {
+		got := pdfEscapeString(tc.input)
+		assert.Equal(t, tc.want, got, "pdfEscapeString(%q)", tc.input)
+	}
+}
+
+// TestXMLEscapeString verifies that XML special characters are correctly escaped.
+func TestXMLEscapeString(t *testing.T) {
+	cases := []struct {
+		input string
+		want  string
+	}{
+		{`plain`, `plain`},
+		{`a & b`, `a &amp; b`},
+		{`<tag>`, `&lt;tag&gt;`},
+		{`"quoted"`, `&quot;quoted&quot;`},
+		{`it's`, `it&apos;s`},
+	}
+	for _, tc := range cases {
+		got := xmlEscapeString(tc.input)
+		assert.Equal(t, tc.want, got, "xmlEscapeString(%q)", tc.input)
+	}
+}
+
+// TestXlsxColLetter verifies column letter generation for common indices.
+func TestXlsxColLetter(t *testing.T) {
+	cases := []struct {
+		col  int
+		want string
+	}{
+		{1, "A"},
+		{2, "B"},
+		{26, "Z"},
+		{27, "AA"},
+		{28, "AB"},
+	}
+	for _, tc := range cases {
+		got := xlsxColLetter(tc.col)
+		assert.Equal(t, tc.want, got, "xlsxColLetter(%d)", tc.col)
+	}
+}
+
+// TestBuildExcelRows verifies that the row builder captures all report sections.
+func TestBuildExcelRows(t *testing.T) {
+	report := nonTrivialReport()
+	rows := buildExcelRows(report)
+
+	flat := make([]string, 0)
+	for _, row := range rows {
+		flat = append(flat, strings.Join(row, "|"))
+	}
+	joined := strings.Join(flat, "\n")
+
+	assert.Contains(t, joined, report.Title)
+	assert.Contains(t, joined, "Compliance Score")
+	assert.Contains(t, joined, "Key Insights")
+	assert.Contains(t, joined, "Recommended Actions")
+	assert.Contains(t, joined, "Device Overview")
+}


### PR DESCRIPTION
## Summary

- Implemented `exportPDF` using pure stdlib PDF-1.4 byte-stream construction (same approach as `features/reports/advanced.go` from #706) — no external tools or new dependencies
- Implemented `exportExcel` generating valid XLSX (ISO/IEC 29500) using `archive/zip` + inline XML — no new module dependencies
- Removed the `PDFCommand` field from `Config` (no longer needed) and set `PDFEnabled: true` as the new default
- Excel added to `SupportedFormats` unconditionally; PDF conditioned on `Config.PDFEnabled`
- `xmlEscapeString` and `pdfEscapeString` helpers prevent content-injection through report data

## Test plan

- [x] `TestExporterMethods` — 8 sub-tests: PDF magic bytes + EOF + title, PDF-disabled error, XLSX ZIP structure, XLSX sheet content, SupportedFormats membership, DefaultConfig value
- [x] `TestPDFEscapeString` — table-driven: all PDF special characters
- [x] `TestXMLEscapeString` — table-driven: all XML predefined entities  
- [x] `TestXlsxColLetter` — column letter generation A–Z and AA+
- [x] `TestBuildExcelRows` — non-trivial payload: summary, insights, actions, sections
- [x] `make test-agent-complete` — PASS (all gates clean, lint clean, cross-platform builds clean)
- [x] Architecture check — no central provider violations
- [x] Security review — no blocking issues; escape functions unit-tested against injection

## Specialist Review Results

**QA Test Runner**: PASS — all unit tests, lint, license, architecture, and cross-platform builds pass  
**QA Code Reviewer**: PASS — no mocks, no t.Skip(), error paths tested, no hacky workarounds (one non-blocking warning: pre-existing coverage gap in JSON/CSV/HTML paths, out of scope for this story)  
**Security Engineer**: PASS — no hardcoded secrets, no SQL, XML/PDF injection prevented by escape functions, all log values sanitized, no central provider violations

Fixes #707

🤖 Generated with [Claude Code](https://claude.com/claude-code)