### PR TITLE
tech-debt: fix staticcheck ST1003 naming violations (Issue #720)

### DIFF
--- a/features/controller/fleet/storage/indexer.go
+++ b/features/controller/fleet/storage/indexer.go
@@ -153,24 +153,24 @@ func (i *MemoryIndexer) QueryRecords(ctx context.Context, deviceID string, optio
 	totalCount := int64(len(filteredRecords))
 
 	// Apply pagination
-	start_idx := 0
-	end_idx := len(filteredRecords)
+	startIdx := 0
+	endIdx := len(filteredRecords)
 
 	if options.Offset > 0 {
-		start_idx = options.Offset
-		if start_idx >= len(filteredRecords) {
+		startIdx = options.Offset
+		if startIdx >= len(filteredRecords) {
 			return []*RecordRef{}, totalCount, nil
 		}
 	}
 
 	if options.Limit > 0 {
-		end_idx = start_idx + options.Limit
-		if end_idx > len(filteredRecords) {
-			end_idx = len(filteredRecords)
+		endIdx = startIdx + options.Limit
+		if endIdx > len(filteredRecords) {
+			endIdx = len(filteredRecords)
 		}
 	}
 
-	result := filteredRecords[start_idx:end_idx]
+	result := filteredRecords[startIdx:endIdx]
 
 	i.logger.Debug("DNA records queried",
 		"device_id", logging.SanitizeLogValue(deviceID),
@@ -431,24 +431,24 @@ func (i *MemoryIndexer) QueryByAttribute(ctx context.Context, attribute, value s
 	}
 
 	// Apply pagination
-	start_idx := 0
-	end_idx := len(filteredRefs)
+	startIdx := 0
+	endIdx := len(filteredRefs)
 
 	if options.Offset > 0 {
-		start_idx = options.Offset
-		if start_idx >= len(filteredRefs) {
+		startIdx = options.Offset
+		if startIdx >= len(filteredRefs) {
 			return []*RecordRef{}, nil
 		}
 	}
 
 	if options.Limit > 0 {
-		end_idx = start_idx + options.Limit
-		if end_idx > len(filteredRefs) {
-			end_idx = len(filteredRefs)
+		endIdx = startIdx + options.Limit
+		if endIdx > len(filteredRefs) {
+			endIdx = len(filteredRefs)
 		}
 	}
 
-	return filteredRefs[start_idx:end_idx], nil
+	return filteredRefs[startIdx:endIdx], nil
 }
 
 // GetDeviceTimeline returns a timeline of changes for a device
@@ -478,24 +478,24 @@ func (i *MemoryIndexer) GetDeviceTimeline(ctx context.Context, deviceID string, 
 	}
 
 	// Apply pagination
-	start_idx := 0
-	end_idx := len(filteredRefs)
+	startIdx := 0
+	endIdx := len(filteredRefs)
 
 	if options.Offset > 0 {
-		start_idx = options.Offset
-		if start_idx >= len(filteredRefs) {
+		startIdx = options.Offset
+		if startIdx >= len(filteredRefs) {
 			return []*RecordRef{}, nil
 		}
 	}
 
 	if options.Limit > 0 {
-		end_idx = start_idx + options.Limit
-		if end_idx > len(filteredRefs) {
-			end_idx = len(filteredRefs)
+		endIdx = startIdx + options.Limit
+		if endIdx > len(filteredRefs) {
+			endIdx = len(filteredRefs)
 		}
 	}
 
-	return filteredRefs[start_idx:end_idx], nil
+	return filteredRefs[startIdx:endIdx], nil
 }
 
 // GetTimeRangeStats returns statistics for a specific time range

--- a/features/controller/fleet/storage/interfaces.go
+++ b/features/controller/fleet/storage/interfaces.go
@@ -354,7 +354,7 @@ type PerformanceReport struct {
 	DecompressionTime time.Duration `json:"decompression_time"` // Average decompression time
 	ThroughputWrites  float64       `json:"throughput_writes"`  // Writes per second
 	ThroughputReads   float64       `json:"throughput_reads"`   // Reads per second
-	CpuUsage          float64       `json:"cpu_usage"`          // CPU usage percentage
+	CPUUsage          float64       `json:"cpu_usage"`          // CPU usage percentage
 	MemoryUsage       int64         `json:"memory_usage"`       // Memory usage in bytes
 	DiskIOPS          float64       `json:"disk_iops"`          // Disk I/O operations per second
 }

--- a/features/controller/server/server.go
+++ b/features/controller/server/server.go
@@ -61,8 +61,8 @@ import (
 	quictransport "github.com/cfgis/cfgms/pkg/transport/quic"
 )
 
-// BUILD_VERSION_CHECK is a compile-time constant to verify code version in Docker
-const BUILD_VERSION_CHECK = "story-362-config-signing-enabled"
+// buildVersionCheck is a compile-time constant to verify code version in Docker
+const buildVersionCheck = "story-362-config-signing-enabled"
 
 // Server represents the controller server component (gRPC-over-QUIC based)
 type Server struct {
@@ -793,7 +793,7 @@ func (s *Server) Start() error {
 	}
 
 	// Start shared gRPC-over-QUIC transport and wire composite handler (Story #515)
-	s.logger.Info("Controller build version", "version", BUILD_VERSION_CHECK)
+	s.logger.Info("Controller build version", "version", buildVersionCheck)
 	if s.controlPlane != nil {
 		// Build TLS config for the QUIC listener
 		grpcTLSConfig, err := buildGRPCControlPlaneTLSConfig(s.cfg, s.certManager, s.logger)

--- a/features/modules/m365/entra_application/integration_test.go
+++ b/features/modules/m365/entra_application/integration_test.go
@@ -108,7 +108,7 @@ func TestEntraApplication_Integration_BasicOperations(t *testing.T) {
 		},
 		RequiredResourceAccess: []ResourceAccess{
 			{
-				ResourceAppId: "00000003-0000-0000-c000-000000000000", // Microsoft Graph
+				ResourceAppID: "00000003-0000-0000-c000-000000000000", // Microsoft Graph
 				ResourceAccess: []PermissionScope{
 					{ID: "e1fe6dd8-ba31-4d61-89e7-88639da4683d", Type: "Scope"}, // User.Read
 				},
@@ -267,10 +267,10 @@ func TestEntraApplication_Integration_ComplexConfiguration(t *testing.T) {
 			Mobile:  []string{"https://cfgms-complex-app.example.com/mobile"},
 			Desktop: []string{"https://cfgms-complex-app.example.com/desktop"},
 		},
-		LogoutUrl: "https://cfgms-complex-app.example.com/logout",
+		LogoutURL: "https://cfgms-complex-app.example.com/logout",
 		RequiredResourceAccess: []ResourceAccess{
 			{
-				ResourceAppId: "00000003-0000-0000-c000-000000000000", // Microsoft Graph
+				ResourceAppID: "00000003-0000-0000-c000-000000000000", // Microsoft Graph
 				ResourceAccess: []PermissionScope{
 					{ID: "e1fe6dd8-ba31-4d61-89e7-88639da4683d", Type: "Scope"}, // User.Read
 					{ID: "06da0dbc-49e2-44d2-8312-53746cb0532c", Type: "Scope"}, // Mail.Read
@@ -308,7 +308,7 @@ func TestEntraApplication_Integration_ComplexConfiguration(t *testing.T) {
 			},
 		},
 		OptionalClaims: &OptionalClaims{
-			IdToken: []OptionalClaim{
+			IDToken: []OptionalClaim{
 				{
 					Name:      "email",
 					Essential: true,
@@ -518,7 +518,7 @@ func TestEntraApplication_Integration_FullCRUD(t *testing.T) {
 		},
 		RequiredResourceAccess: []ResourceAccess{
 			{
-				ResourceAppId: "00000003-0000-0000-c000-000000000000", // Microsoft Graph
+				ResourceAppID: "00000003-0000-0000-c000-000000000000", // Microsoft Graph
 				ResourceAccess: []PermissionScope{
 					{ID: "e1fe6dd8-ba31-4d61-89e7-88639da4683d", Type: "Scope"}, // User.Read
 				},
@@ -603,7 +603,7 @@ func TestEntraApplication_Integration_FullCRUD(t *testing.T) {
 		},
 		RequiredResourceAccess: []ResourceAccess{
 			{
-				ResourceAppId: "00000003-0000-0000-c000-000000000000", // Microsoft Graph
+				ResourceAppID: "00000003-0000-0000-c000-000000000000", // Microsoft Graph
 				ResourceAccess: []PermissionScope{
 					{ID: "e1fe6dd8-ba31-4d61-89e7-88639da4683d", Type: "Scope"}, // User.Read
 					{ID: "06da0dbc-49e2-44d2-8312-53746cb0532c", Type: "Scope"}, // Mail.Read (ADD)

--- a/features/modules/m365/entra_application/module.go
+++ b/features/modules/m365/entra_application/module.go
@@ -39,7 +39,7 @@ type EntraApplicationConfig struct {
 	// Application URLs
 	IdentifierUris []string      `yaml:"identifier_uris,omitempty"`
 	RedirectUris   *RedirectUris `yaml:"redirect_uris,omitempty"`
-	LogoutUrl      string        `yaml:"logout_url,omitempty"`
+	LogoutURL      string        `yaml:"logout_url,omitempty"`
 
 	// API permissions and scopes
 	RequiredResourceAccess []ResourceAccess `yaml:"required_resource_access,omitempty"`
@@ -84,7 +84,7 @@ type RedirectUris struct {
 
 // ResourceAccess represents required permissions to a resource (API)
 type ResourceAccess struct {
-	ResourceAppId  string            `yaml:"resource_app_id"`
+	ResourceAppID  string            `yaml:"resource_app_id"`
 	ResourceAccess []PermissionScope `yaml:"resource_access"`
 }
 
@@ -130,12 +130,12 @@ type KeyCredential struct {
 	Type        string `yaml:"type"`          // "AsymmetricX509Cert", "X509CertAndPassword"
 	Usage       string `yaml:"usage"`         // "Sign", "Verify"
 	Key         string `yaml:"key,omitempty"` // Base64-encoded certificate
-	KeyId       string `yaml:"key_id,omitempty"`
+	KeyID       string `yaml:"key_id,omitempty"`
 }
 
 // OptionalClaims represents optional claims configuration
 type OptionalClaims struct {
-	IdToken     []OptionalClaim `yaml:"id_token,omitempty"`
+	IDToken     []OptionalClaim `yaml:"id_token,omitempty"`
 	AccessToken []OptionalClaim `yaml:"access_token,omitempty"`
 	Saml2Token  []OptionalClaim `yaml:"saml2_token,omitempty"`
 }
@@ -182,8 +182,8 @@ func (c *EntraApplicationConfig) AsMap() map[string]interface{} {
 	if c.RedirectUris != nil {
 		result["redirect_uris"] = c.RedirectUris
 	}
-	if c.LogoutUrl != "" {
-		result["logout_url"] = c.LogoutUrl
+	if c.LogoutURL != "" {
+		result["logout_url"] = c.LogoutURL
 	}
 	if len(c.RequiredResourceAccess) > 0 {
 		result["required_resource_access"] = c.RequiredResourceAccess

--- a/features/modules/m365/entra_application/module_test.go
+++ b/features/modules/m365/entra_application/module_test.go
@@ -420,10 +420,10 @@ func TestEntraApplicationConfig_AsMap(t *testing.T) {
 		RedirectUris: &RedirectUris{
 			Web: []string{"https://example.com/callback"},
 		},
-		LogoutUrl: "https://example.com/logout",
+		LogoutURL: "https://example.com/logout",
 		RequiredResourceAccess: []ResourceAccess{
 			{
-				ResourceAppId: "00000003-0000-0000-c000-000000000000",
+				ResourceAppID: "00000003-0000-0000-c000-000000000000",
 				ResourceAccess: []PermissionScope{
 					{ID: "e1fe6dd8-ba31-4d61-89e7-88639da4683d", Type: "Scope"},
 				},
@@ -462,7 +462,7 @@ func TestEntraApplicationConfig_AsMap(t *testing.T) {
 			},
 		},
 		OptionalClaims: &OptionalClaims{
-			IdToken: []OptionalClaim{
+			IDToken: []OptionalClaim{
 				{Name: "email", Essential: true},
 			},
 		},
@@ -537,7 +537,7 @@ func TestEntraApplicationConfig_GetManagedFields(t *testing.T) {
 					Web: []string{"https://example.com/callback"},
 				},
 				RequiredResourceAccess: []ResourceAccess{
-					{ResourceAppId: "test-app-id"},
+					{ResourceAppID: "test-app-id"},
 				},
 				OAuth2Permissions: []OAuth2Scope{
 					{Value: "read"},
@@ -795,7 +795,7 @@ func TestComplexStructureSerialization(t *testing.T) {
 		SignInAudience: "AzureADMultipleOrgs",
 		TenantID:       "tenant-123",
 		OptionalClaims: &OptionalClaims{
-			IdToken: []OptionalClaim{
+			IDToken: []OptionalClaim{
 				{
 					Name:      "email",
 					Essential: true,
@@ -813,7 +813,7 @@ func TestComplexStructureSerialization(t *testing.T) {
 		},
 		RequiredResourceAccess: []ResourceAccess{
 			{
-				ResourceAppId: "00000003-0000-0000-c000-000000000000", // Microsoft Graph
+				ResourceAppID: "00000003-0000-0000-c000-000000000000", // Microsoft Graph
 				ResourceAccess: []PermissionScope{
 					{ID: "e1fe6dd8-ba31-4d61-89e7-88639da4683d", Type: "Scope"}, // User.Read
 					{ID: "405a51b5-8d8d-430b-9842-8be4b0e9f324", Type: "Role"},  // User.Read.All
@@ -834,13 +834,13 @@ func TestComplexStructureSerialization(t *testing.T) {
 	assert.Equal(t, config.DisplayName, deserializedConfig.DisplayName)
 	assert.Equal(t, config.SignInAudience, deserializedConfig.SignInAudience)
 	assert.NotNil(t, deserializedConfig.OptionalClaims)
-	assert.Len(t, deserializedConfig.OptionalClaims.IdToken, 1)
-	assert.Equal(t, "email", deserializedConfig.OptionalClaims.IdToken[0].Name)
-	assert.True(t, deserializedConfig.OptionalClaims.IdToken[0].Essential)
-	assert.Len(t, deserializedConfig.OptionalClaims.IdToken[0].AdditionalProperties, 1)
+	assert.Len(t, deserializedConfig.OptionalClaims.IDToken, 1)
+	assert.Equal(t, "email", deserializedConfig.OptionalClaims.IDToken[0].Name)
+	assert.True(t, deserializedConfig.OptionalClaims.IDToken[0].Essential)
+	assert.Len(t, deserializedConfig.OptionalClaims.IDToken[0].AdditionalProperties, 1)
 
 	assert.Len(t, deserializedConfig.RequiredResourceAccess, 1)
-	assert.Equal(t, "00000003-0000-0000-c000-000000000000", deserializedConfig.RequiredResourceAccess[0].ResourceAppId)
+	assert.Equal(t, "00000003-0000-0000-c000-000000000000", deserializedConfig.RequiredResourceAccess[0].ResourceAppID)
 	assert.Len(t, deserializedConfig.RequiredResourceAccess[0].ResourceAccess, 2)
 }
 

--- a/features/modules/m365/graph/client.go
+++ b/features/modules/m365/graph/client.go
@@ -382,7 +382,7 @@ type Application struct {
 // ApplicationWeb represents web settings for an application
 type ApplicationWeb struct {
 	RedirectUris []string `json:"redirectUris"`
-	LogoutUrl    string   `json:"logoutUrl,omitempty"`
+	LogoutURL    string   `json:"logoutUrl,omitempty"`
 }
 
 // ApplicationSpa represents SPA settings for an application
@@ -392,7 +392,7 @@ type ApplicationSpa struct {
 
 // ApplicationResourceAccess represents required resource access
 type ApplicationResourceAccess struct {
-	ResourceAppId  string                       `json:"resourceAppId"`
+	ResourceAppID  string                       `json:"resourceAppId"`
 	ResourceAccess []ApplicationPermissionScope `json:"resourceAccess"`
 }
 
@@ -446,7 +446,7 @@ type ApplicationPasswordCredential struct {
 
 // ApplicationOptionalClaims represents optional claims configuration
 type ApplicationOptionalClaims struct {
-	IdToken     []ApplicationOptionalClaim `json:"idToken"`
+	IDToken     []ApplicationOptionalClaim `json:"idToken"`
 	AccessToken []ApplicationOptionalClaim `json:"accessToken"`
 	Saml2Token  []ApplicationOptionalClaim `json:"saml2Token"`
 }

--- a/features/modules/m365/graph/http_client.go
+++ b/features/modules/m365/graph/http_client.go
@@ -162,7 +162,7 @@ func (c *HTTPClient) GetUserLicenses(ctx context.Context, token *auth.AccessToke
 		Value []struct {
 			SkuID        string `json:"skuId"`
 			ServicePlans []struct {
-				ServicePlanId      string `json:"servicePlanId"`
+				ServicePlanID      string `json:"servicePlanId"`
 				ProvisioningStatus string `json:"provisioningStatus"`
 			} `json:"servicePlans"`
 		} `json:"value"`
@@ -181,7 +181,7 @@ func (c *HTTPClient) GetUserLicenses(ctx context.Context, token *auth.AccessToke
 		// Collect disabled service plans
 		for _, plan := range license.ServicePlans {
 			if plan.ProvisioningStatus == "Disabled" {
-				assignment.DisabledPlans = append(assignment.DisabledPlans, plan.ServicePlanId)
+				assignment.DisabledPlans = append(assignment.DisabledPlans, plan.ServicePlanID)
 			}
 		}
 


### PR DESCRIPTION
## Summary

- Renames snake_case local variables (`start_idx`/`end_idx` → `startIdx`/`endIdx`) in `indexer.go` across 3 pagination blocks
- Renames `CpuUsage` → `CPUUsage` in `interfaces.go` (Go initialisms)
- Renames `BUILD_VERSION_CHECK` → `buildVersionCheck` in `server.go` (unexported constant, single file scope)
- Renames exported fields with incorrect abbreviation casing in `features/modules/m365/`: `LogoutUrl→LogoutURL`, `ResourceAppId→ResourceAppID`, `KeyId→KeyID`, `IdToken→IDToken`, `ServicePlanId→ServicePlanID`
- All JSON/YAML wire format tags are **unchanged** — Go-identifier-only renaming, no API contract impact
- Updated test files to reference renamed fields

Fixes #720

## Verification

`staticcheck ./features/controller/fleet/storage/... ./features/controller/server/... ./features/modules/m365/...` reports **zero ST1003 findings** (excluding underscore package names which are explicitly out of scope per the issue — separate epic).

## Specialist Review Results

| Specialist | Result | Notes |
|---|---|---|
| QA Test Runner | **PASS** | All quality gates pass; cross-platform builds clean; no regressions |
| Security Engineer | **PASS** | Zero blocking issues; wire format verified preserved; no secrets introduced |
| QA Code Reviewer | FAIL (pre-existing) | Flagged pre-existing `testify/mock` usage and `t.Skip()` bypass in `m365/entra_application/` tests — not introduced by this story; fixing requires real M365 credentials and is out of scope for a naming refactor |

The QA code reviewer's findings are pre-existing violations in files we only touched to update field name references. They predate story #720 and require a dedicated test-quality story to address properly.

## Test Plan

- [x] `go build ./features/controller/fleet/storage/... ./features/controller/server/... ./features/modules/m365/...` — clean
- [x] `staticcheck` — zero ST1003 findings in scope
- [x] `go test ./features/controller/fleet/storage/...` — PASS
- [x] `go test ./features/controller/server/...` — PASS
- [x] `make test-agent-complete` — all gates pass (Trivy DB download unavailable in sandbox, CI will validate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)