### PR TITLE
controller/directory: implement real CompareDirectories and GetProviderStatistics (Issue #714)

### DIFF
--- a/features/controller/directory/service.go
+++ b/features/controller/directory/service.go
@@ -5,9 +5,13 @@ package directory
 import (
 	"context"
 	"fmt"
+	"strconv"
+	"strings"
 	"sync"
 	"time"
 
+	"github.com/cfgis/cfgms/pkg/directory/dna"
+	"github.com/cfgis/cfgms/pkg/directory/interfaces"
 	"github.com/cfgis/cfgms/pkg/directory/types"
 	"github.com/cfgis/cfgms/pkg/logging"
 )
@@ -28,6 +32,19 @@ type DirectoryService struct {
 
 	// Module integration (will be set by controller)
 	moduleRegistry ModuleRegistry
+
+	// Per-provider operational metrics
+	metricsMu sync.RWMutex
+	metrics   map[string]*providerMetrics
+}
+
+// providerMetrics tracks per-provider operational counters.
+type providerMetrics struct {
+	mu           sync.Mutex
+	requestCount int64
+	errorCount   int64
+	totalLatency time.Duration
+	callCount    int64
 }
 
 // ModuleRegistry defines how the directory service integrates with CFGMS modules
@@ -47,6 +64,7 @@ func NewDirectoryService(logger logging.Logger) *DirectoryService {
 	return &DirectoryService{
 		providers: make(map[string]Provider),
 		logger:    logger,
+		metrics:   make(map[string]*providerMetrics),
 	}
 }
 
@@ -75,6 +93,11 @@ func (s *DirectoryService) RegisterProvider(provider Provider) error {
 		s.defaultProvider = name
 		s.logger.Info("Set default directory provider", "name", name)
 	}
+
+	// Initialize metrics tracker for this provider
+	s.metricsMu.Lock()
+	s.metrics[name] = &providerMetrics{}
+	s.metricsMu.Unlock()
 
 	return nil
 }
@@ -152,7 +175,9 @@ func (s *DirectoryService) GetUser(ctx context.Context, providerName, userID str
 		return nil, err
 	}
 
+	start := time.Now()
 	user, err := provider.GetUser(ctx, userID)
+	s.recordProviderOp(provider.Name(), time.Since(start), err)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get user from provider '%s': %w", provider.Name(), err)
 	}
@@ -235,7 +260,9 @@ func (s *DirectoryService) SearchUsers(ctx context.Context, providerName string,
 		return nil, err
 	}
 
+	start := time.Now()
 	users, err := provider.SearchUsers(ctx, query)
+	s.recordProviderOp(provider.Name(), time.Since(start), err)
 	if err != nil {
 		return nil, fmt.Errorf("failed to search users in provider '%s': %w", provider.Name(), err)
 	}
@@ -259,7 +286,9 @@ func (s *DirectoryService) GetGroup(ctx context.Context, providerName, groupID s
 		return nil, err
 	}
 
+	start := time.Now()
 	group, err := provider.GetGroup(ctx, groupID)
+	s.recordProviderOp(provider.Name(), time.Since(start), err)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get group from provider '%s': %w", provider.Name(), err)
 	}
@@ -342,7 +371,9 @@ func (s *DirectoryService) SearchGroups(ctx context.Context, providerName string
 		return nil, err
 	}
 
+	start := time.Now()
 	groups, err := provider.SearchGroups(ctx, query)
+	s.recordProviderOp(provider.Name(), time.Since(start), err)
 	if err != nil {
 		return nil, fmt.Errorf("failed to search groups in provider '%s': %w", provider.Name(), err)
 	}
@@ -635,19 +666,67 @@ func (s *DirectoryService) SyncGroup(ctx context.Context, sourceProvider, target
 	return nil
 }
 
-// CompareDirectories compares two directories and returns differences
+// CompareDirectories compares two directories and returns differences.
+// It fetches all users and groups from each provider, builds DNA snapshots, and uses
+// the drift detector to identify objects that exist only in one provider or differ
+// in their attributes.
 func (s *DirectoryService) CompareDirectories(ctx context.Context, provider1, provider2 string) (*DirectoryComparison, error) {
-	// This is a complex operation that would compare users and groups between providers
-	// Implementation would involve fetching all objects from both providers and comparing
-	// For now, return a placeholder
-	return &DirectoryComparison{
+	p1, err := s.GetProvider(provider1)
+	if err != nil {
+		return nil, fmt.Errorf("provider '%s': %w", provider1, err)
+	}
+	p2, err := s.GetProvider(provider2)
+	if err != nil {
+		return nil, fmt.Errorf("provider '%s': %w", provider2, err)
+	}
+
+	detector := dna.NewDirectoryDriftDetector(s.logger)
+	comparison := &DirectoryComparison{
 		Provider1:      provider1,
 		Provider2:      provider2,
 		ComparisonTime: time.Now(),
-		Summary: DirectoryComparisonSummary{
-			TotalDifferences: 0, // Would be calculated
-		},
-	}, fmt.Errorf("directory comparison not yet implemented")
+	}
+
+	// Compare users: treat provider1 as current, provider2 as baseline
+	p1Users, err := p1.SearchUsers(ctx, &SearchQuery{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to list users from provider '%s': %w", provider1, err)
+	}
+	p2Users, err := p2.SearchUsers(ctx, &SearchQuery{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to list users from provider '%s': %w", provider2, err)
+	}
+
+	userDrifts, err := detector.DetectBulkDrift(ctx, buildUserDNASet(p1Users), buildUserDNASet(p2Users))
+	if err != nil {
+		return nil, fmt.Errorf("user comparison failed: %w", err)
+	}
+
+	// Compare groups
+	p1Groups, err := p1.SearchGroups(ctx, &SearchQuery{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to list groups from provider '%s': %w", provider1, err)
+	}
+	p2Groups, err := p2.SearchGroups(ctx, &SearchQuery{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to list groups from provider '%s': %w", provider2, err)
+	}
+
+	groupDrifts, err := detector.DetectBulkDrift(ctx, buildGroupDNASet(p1Groups), buildGroupDNASet(p2Groups))
+	if err != nil {
+		return nil, fmt.Errorf("group comparison failed: %w", err)
+	}
+
+	comparison.UserDifferences = driftsToObjectDifferences(userDrifts, ObjectTypeUser)
+	comparison.GroupDifferences = driftsToObjectDifferences(groupDrifts, ObjectTypeGroup)
+	comparison.Summary = buildComparisonSummary(userDrifts, groupDrifts)
+
+	s.logger.Info("Directory comparison completed",
+		"provider1", provider1,
+		"provider2", provider2,
+		"total_differences", comparison.Summary.TotalDifferences)
+
+	return comparison, nil
 }
 
 // Health and Statistics
@@ -662,15 +741,47 @@ func (s *DirectoryService) GetProviderHealth(ctx context.Context, providerName s
 	return provider.HealthCheck(ctx)
 }
 
-// GetProviderStatistics gets statistics for a provider
+// GetProviderStatistics gets statistics for a provider.
+// It returns tracked request/error counters accumulated since the provider was registered,
+// combined with a live count of users and groups fetched from the provider.
 func (s *DirectoryService) GetProviderStatistics(ctx context.Context, providerName string) (*ProviderStatistics, error) {
-	// This would be implemented to gather statistics from the provider
-	// For now, return placeholder
+	provider, err := s.getProviderOrDefault(providerName)
+	if err != nil {
+		return nil, err
+	}
+
+	users, err := provider.SearchUsers(ctx, &SearchQuery{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to count users in provider '%s': %w", provider.Name(), err)
+	}
+	groups, err := provider.SearchGroups(ctx, &SearchQuery{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to count groups in provider '%s': %w", provider.Name(), err)
+	}
+
+	s.metricsMu.RLock()
+	m := s.metrics[provider.Name()]
+	s.metricsMu.RUnlock()
+
+	var requestCount, errorCount int64
+	var avgLatency time.Duration
+	if m != nil {
+		m.mu.Lock()
+		requestCount = m.requestCount
+		errorCount = m.errorCount
+		if m.callCount > 0 {
+			avgLatency = m.totalLatency / time.Duration(m.callCount)
+		}
+		m.mu.Unlock()
+	}
+
 	return &ProviderStatistics{
-		RequestCount:   0,
-		ErrorCount:     0,
-		AverageLatency: 0,
-	}, fmt.Errorf("provider statistics not yet implemented")
+		TotalUsers:     int64(len(users)),
+		TotalGroups:    int64(len(groups)),
+		RequestCount:   requestCount,
+		ErrorCount:     errorCount,
+		AverageLatency: avgLatency,
+	}, nil
 }
 
 // Helper methods
@@ -681,4 +792,175 @@ func (s *DirectoryService) getProviderOrDefault(providerName string) (Provider, 
 		return s.GetDefaultProvider()
 	}
 	return s.GetProvider(providerName)
+}
+
+// buildUserDNASet converts a slice of users into DirectoryDNA records keyed by UPN for
+// cross-provider comparison. Only stable, semantic attributes are included so that
+// provider-specific metadata does not create spurious differences.
+func buildUserDNASet(users []*types.DirectoryUser) []*dna.DirectoryDNA {
+	dnaSet := make([]*dna.DirectoryDNA, 0, len(users))
+	for _, u := range users {
+		dnaSet = append(dnaSet, userToComparisonDNA(u))
+	}
+	return dnaSet
+}
+
+func userToComparisonDNA(u *types.DirectoryUser) *dna.DirectoryDNA {
+	key := u.UserPrincipalName
+	if key == "" {
+		key = u.ID
+	}
+	attrs := map[string]string{
+		"display_name":    u.DisplayName,
+		"account_enabled": strconv.FormatBool(u.AccountEnabled),
+	}
+	if u.SAMAccountName != "" {
+		attrs["sam_account_name"] = u.SAMAccountName
+	}
+	if u.EmailAddress != "" {
+		attrs["email_address"] = u.EmailAddress
+	}
+	if u.Department != "" {
+		attrs["department"] = u.Department
+	}
+	if u.JobTitle != "" {
+		attrs["job_title"] = u.JobTitle
+	}
+	if u.Manager != "" {
+		attrs["manager"] = u.Manager
+	}
+	if len(u.Groups) > 0 {
+		attrs["groups"] = strings.Join(u.Groups, ",")
+	}
+	now := time.Now()
+	return &dna.DirectoryDNA{
+		ObjectID:    key,
+		ObjectType:  interfaces.DirectoryObjectTypeUser,
+		ID:          key,
+		Attributes:  attrs,
+		LastUpdated: &now,
+	}
+}
+
+// buildGroupDNASet converts a slice of groups into DirectoryDNA records keyed by Name
+// for cross-provider comparison.
+func buildGroupDNASet(groups []*types.DirectoryGroup) []*dna.DirectoryDNA {
+	dnaSet := make([]*dna.DirectoryDNA, 0, len(groups))
+	for _, g := range groups {
+		dnaSet = append(dnaSet, groupToComparisonDNA(g))
+	}
+	return dnaSet
+}
+
+func groupToComparisonDNA(g *types.DirectoryGroup) *dna.DirectoryDNA {
+	key := g.Name
+	if key == "" {
+		key = g.ID
+	}
+	attrs := map[string]string{
+		"display_name": g.DisplayName,
+		"group_type":   string(g.GroupType),
+		"group_scope":  string(g.GroupScope),
+	}
+	if g.Description != "" {
+		attrs["description"] = g.Description
+	}
+	if len(g.Members) > 0 {
+		attrs["members"] = strings.Join(g.Members, ",")
+	}
+	now := time.Now()
+	return &dna.DirectoryDNA{
+		ObjectID:    key,
+		ObjectType:  interfaces.DirectoryObjectTypeGroup,
+		ID:          key,
+		Attributes:  attrs,
+		LastUpdated: &now,
+	}
+}
+
+// driftsToObjectDifferences maps drift detection results to ObjectDifference entries.
+// Creates/deletes produce a single entry per object; attribute changes produce one entry
+// per changed field so callers can inspect exactly what differed.
+func driftsToObjectDifferences(drifts []*dna.DirectoryDrift, objectType ObjectType) []ObjectDifference {
+	var diffs []ObjectDifference
+	for _, drift := range drifts {
+		switch drift.DriftType {
+		case dna.DirectoryDriftTypeObjectCreation:
+			diffs = append(diffs, ObjectDifference{
+				ObjectType: objectType,
+				ObjectID:   drift.ObjectID,
+				Action:     "create",
+			})
+		case dna.DirectoryDriftTypeObjectDeletion:
+			diffs = append(diffs, ObjectDifference{
+				ObjectType: objectType,
+				ObjectID:   drift.ObjectID,
+				Action:     "delete",
+			})
+		default:
+			for _, change := range drift.Changes {
+				oldVal, _ := change.OldValue.(string)
+				newVal, _ := change.NewValue.(string)
+				diffs = append(diffs, ObjectDifference{
+					ObjectType: objectType,
+					ObjectID:   drift.ObjectID,
+					Action:     "update",
+					Field:      change.Field,
+					OldValue:   oldVal,
+					NewValue:   newVal,
+				})
+			}
+		}
+	}
+	return diffs
+}
+
+// buildComparisonSummary aggregates drift results into per-object counts.
+func buildComparisonSummary(userDrifts, groupDrifts []*dna.DirectoryDrift) DirectoryComparisonSummary {
+	summary := DirectoryComparisonSummary{}
+	for _, drift := range userDrifts {
+		switch drift.DriftType {
+		case dna.DirectoryDriftTypeObjectCreation:
+			summary.UsersToCreate++
+		case dna.DirectoryDriftTypeObjectDeletion:
+			summary.UsersToDelete++
+		default:
+			if len(drift.Changes) > 0 {
+				summary.UsersToUpdate++
+			}
+		}
+	}
+	for _, drift := range groupDrifts {
+		switch drift.DriftType {
+		case dna.DirectoryDriftTypeObjectCreation:
+			summary.GroupsToCreate++
+		case dna.DirectoryDriftTypeObjectDeletion:
+			summary.GroupsToDelete++
+		default:
+			if len(drift.Changes) > 0 {
+				summary.GroupsToUpdate++
+			}
+		}
+	}
+	summary.TotalDifferences = summary.UsersToCreate + summary.UsersToUpdate + summary.UsersToDelete +
+		summary.GroupsToCreate + summary.GroupsToUpdate + summary.GroupsToDelete
+	return summary
+}
+
+// recordProviderOp increments the request/error counters and accumulates latency for a provider.
+func (s *DirectoryService) recordProviderOp(name string, latency time.Duration, err error) {
+	s.metricsMu.RLock()
+	m, ok := s.metrics[name]
+	s.metricsMu.RUnlock()
+	if !ok {
+		return
+	}
+	m.mu.Lock()
+	m.requestCount++
+	m.callCount++
+	m.totalLatency += latency
+	if err != nil {
+		m.errorCount++
+	}
+	m.mu.Unlock()
 }

--- a/features/controller/directory/service_test.go
+++ b/features/controller/directory/service_test.go
@@ -1,0 +1,390 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+package directory
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cfgis/cfgms/pkg/directory/types"
+	"github.com/cfgis/cfgms/pkg/logging"
+)
+
+// testProvider is a real in-memory Provider for use in unit tests.
+// It stores users and groups by ID, and returns them via SearchUsers/SearchGroups.
+// Set failSearch to make SearchUsers/SearchGroups return an error for error-path testing.
+type testProvider struct {
+	mu         sync.RWMutex
+	name       string
+	users      map[string]*types.DirectoryUser
+	groups     map[string]*types.DirectoryGroup
+	failSearch bool
+}
+
+func newTestProvider(name string) *testProvider {
+	return &testProvider{
+		name:   name,
+		users:  make(map[string]*types.DirectoryUser),
+		groups: make(map[string]*types.DirectoryGroup),
+	}
+}
+
+func (p *testProvider) addUser(u *types.DirectoryUser) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.users[u.ID] = u
+}
+
+func (p *testProvider) addGroup(g *types.DirectoryGroup) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.groups[g.ID] = g
+}
+
+// Provider interface implementation
+
+func (p *testProvider) Name() string        { return p.name }
+func (p *testProvider) DisplayName() string { return p.name }
+func (p *testProvider) Description() string { return "test provider" }
+func (p *testProvider) Capabilities() ProviderCapabilities {
+	return ProviderCapabilities{UserManagement: true, GroupManagement: true}
+}
+func (p *testProvider) Connect(_ context.Context, _ ProviderConfig) error { return nil }
+func (p *testProvider) Disconnect(_ context.Context) error                { return nil }
+func (p *testProvider) IsConnected() bool                                 { return true }
+func (p *testProvider) HealthCheck(_ context.Context) (*ProviderHealth, error) {
+	return &ProviderHealth{IsHealthy: true, LastCheck: time.Now()}, nil
+}
+
+func (p *testProvider) GetUser(_ context.Context, userID string) (*types.DirectoryUser, error) {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	u, ok := p.users[userID]
+	if !ok {
+		return nil, fmt.Errorf("user %q not found", userID)
+	}
+	return u, nil
+}
+
+func (p *testProvider) CreateUser(_ context.Context, u *types.DirectoryUser) (*types.DirectoryUser, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.users[u.ID] = u
+	return u, nil
+}
+
+func (p *testProvider) UpdateUser(_ context.Context, userID string, updates *types.DirectoryUser) (*types.DirectoryUser, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.users[userID] = updates
+	return updates, nil
+}
+
+func (p *testProvider) DeleteUser(_ context.Context, userID string) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	delete(p.users, userID)
+	return nil
+}
+
+func (p *testProvider) SearchUsers(_ context.Context, _ *SearchQuery) ([]*types.DirectoryUser, error) {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	if p.failSearch {
+		return nil, fmt.Errorf("simulated search failure")
+	}
+	users := make([]*types.DirectoryUser, 0, len(p.users))
+	for _, u := range p.users {
+		users = append(users, u)
+	}
+	return users, nil
+}
+
+func (p *testProvider) GetGroup(_ context.Context, groupID string) (*types.DirectoryGroup, error) {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	g, ok := p.groups[groupID]
+	if !ok {
+		return nil, fmt.Errorf("group %q not found", groupID)
+	}
+	return g, nil
+}
+
+func (p *testProvider) CreateGroup(_ context.Context, g *types.DirectoryGroup) (*types.DirectoryGroup, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.groups[g.ID] = g
+	return g, nil
+}
+
+func (p *testProvider) UpdateGroup(_ context.Context, groupID string, updates *types.DirectoryGroup) (*types.DirectoryGroup, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.groups[groupID] = updates
+	return updates, nil
+}
+
+func (p *testProvider) DeleteGroup(_ context.Context, groupID string) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	delete(p.groups, groupID)
+	return nil
+}
+
+func (p *testProvider) SearchGroups(_ context.Context, _ *SearchQuery) ([]*types.DirectoryGroup, error) {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	if p.failSearch {
+		return nil, fmt.Errorf("simulated search failure")
+	}
+	groups := make([]*types.DirectoryGroup, 0, len(p.groups))
+	for _, g := range p.groups {
+		groups = append(groups, g)
+	}
+	return groups, nil
+}
+
+func (p *testProvider) AddUserToGroup(_ context.Context, _, _ string) error      { return nil }
+func (p *testProvider) RemoveUserFromGroup(_ context.Context, _, _ string) error { return nil }
+func (p *testProvider) GetUserGroups(_ context.Context, _ string) ([]*types.DirectoryGroup, error) {
+	return nil, nil
+}
+func (p *testProvider) GetGroupMembers(_ context.Context, _ string) ([]*types.DirectoryUser, error) {
+	return nil, nil
+}
+
+func (p *testProvider) SupportsOUs() bool { return false }
+func (p *testProvider) GetOU(_ context.Context, _ string) (*OrganizationalUnit, error) {
+	return nil, fmt.Errorf("OUs not supported")
+}
+func (p *testProvider) CreateOU(_ context.Context, _ *OrganizationalUnit) (*OrganizationalUnit, error) {
+	return nil, fmt.Errorf("OUs not supported")
+}
+func (p *testProvider) UpdateOU(_ context.Context, _ string, _ *OrganizationalUnit) (*OrganizationalUnit, error) {
+	return nil, fmt.Errorf("OUs not supported")
+}
+func (p *testProvider) DeleteOU(_ context.Context, _ string) error {
+	return fmt.Errorf("OUs not supported")
+}
+func (p *testProvider) ListOUs(_ context.Context) ([]*OrganizationalUnit, error) {
+	return nil, fmt.Errorf("OUs not supported")
+}
+
+func (p *testProvider) SupportsAdminUnits() bool { return false }
+func (p *testProvider) GetAdminUnit(_ context.Context, _ string) (*AdministrativeUnit, error) {
+	return nil, fmt.Errorf("admin units not supported")
+}
+func (p *testProvider) CreateAdminUnit(_ context.Context, _ *AdministrativeUnit) (*AdministrativeUnit, error) {
+	return nil, fmt.Errorf("admin units not supported")
+}
+func (p *testProvider) UpdateAdminUnit(_ context.Context, _ string, _ *AdministrativeUnit) (*AdministrativeUnit, error) {
+	return nil, fmt.Errorf("admin units not supported")
+}
+func (p *testProvider) DeleteAdminUnit(_ context.Context, _ string) error {
+	return fmt.Errorf("admin units not supported")
+}
+func (p *testProvider) ListAdminUnits(_ context.Context) ([]*AdministrativeUnit, error) {
+	return nil, fmt.Errorf("admin units not supported")
+}
+
+// newTestService creates a DirectoryService with the given providers registered.
+func newTestService(t *testing.T, providers ...*testProvider) *DirectoryService {
+	t.Helper()
+	svc := NewDirectoryService(logging.NewNoopLogger())
+	for _, p := range providers {
+		require.NoError(t, svc.RegisterProvider(p))
+	}
+	return svc
+}
+
+// TestCompareDirectories_IdenticalProviders_ZeroDiffs asserts that two providers carrying
+// identical users and groups produce TotalDifferences == 0.
+func TestCompareDirectories_IdenticalProviders_ZeroDiffs(t *testing.T) {
+	p1 := newTestProvider("alpha")
+	p2 := newTestProvider("beta")
+
+	user := &types.DirectoryUser{
+		ID:                "u1",
+		UserPrincipalName: "alice@example.com",
+		DisplayName:       "Alice",
+		AccountEnabled:    true,
+	}
+	group := &types.DirectoryGroup{
+		ID:          "g1",
+		Name:        "engineers",
+		DisplayName: "Engineers",
+		GroupType:   types.GroupTypeSecurity,
+		GroupScope:  types.GroupScopeGlobal,
+	}
+
+	p1.addUser(user)
+	p2.addUser(user)
+	p1.addGroup(group)
+	p2.addGroup(group)
+
+	svc := newTestService(t, p1, p2)
+
+	result, err := svc.CompareDirectories(context.Background(), "alpha", "beta")
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, "alpha", result.Provider1)
+	assert.Equal(t, "beta", result.Provider2)
+	assert.Equal(t, 0, result.Summary.TotalDifferences)
+	assert.Empty(t, result.UserDifferences)
+	assert.Empty(t, result.GroupDifferences)
+}
+
+// TestCompareDirectories_DetectsRealDiffs asserts that differences between providers are
+// detected and surfaced with a non-zero TotalDifferences count.
+func TestCompareDirectories_DetectsRealDiffs(t *testing.T) {
+	p1 := newTestProvider("alpha")
+	p2 := newTestProvider("beta")
+
+	// alice exists in both but with a different DisplayName in p2
+	p1.addUser(&types.DirectoryUser{
+		ID:                "u1",
+		UserPrincipalName: "alice@example.com",
+		DisplayName:       "Alice",
+		AccountEnabled:    true,
+	})
+	p2.addUser(&types.DirectoryUser{
+		ID:                "u1",
+		UserPrincipalName: "alice@example.com",
+		DisplayName:       "Alice Smith", // differs
+		AccountEnabled:    true,
+	})
+
+	// bob exists only in p1 — should count as a create relative to p2
+	p1.addUser(&types.DirectoryUser{
+		ID:                "u2",
+		UserPrincipalName: "bob@example.com",
+		DisplayName:       "Bob",
+		AccountEnabled:    true,
+	})
+
+	svc := newTestService(t, p1, p2)
+
+	result, err := svc.CompareDirectories(context.Background(), "alpha", "beta")
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Greater(t, result.Summary.TotalDifferences, 0,
+		"expected at least one difference; got %+v", result.Summary)
+	assert.NotEmpty(t, result.UserDifferences)
+}
+
+// TestCompareDirectories_GroupDiffs asserts that group-level differences are detected.
+func TestCompareDirectories_GroupDiffs(t *testing.T) {
+	p1 := newTestProvider("alpha")
+	p2 := newTestProvider("beta")
+
+	// Same group, different description
+	p1.addGroup(&types.DirectoryGroup{
+		ID:          "g1",
+		Name:        "engineers",
+		DisplayName: "Engineers",
+		Description: "Build things",
+		GroupType:   types.GroupTypeSecurity,
+		GroupScope:  types.GroupScopeGlobal,
+	})
+	p2.addGroup(&types.DirectoryGroup{
+		ID:          "g1",
+		Name:        "engineers",
+		DisplayName: "Engineers",
+		Description: "Ship things", // differs
+		GroupType:   types.GroupTypeSecurity,
+		GroupScope:  types.GroupScopeGlobal,
+	})
+
+	svc := newTestService(t, p1, p2)
+
+	result, err := svc.CompareDirectories(context.Background(), "alpha", "beta")
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Greater(t, result.Summary.TotalDifferences, 0)
+	assert.NotEmpty(t, result.GroupDifferences)
+}
+
+// TestCompareDirectories_UnknownProvider returns an error for a missing provider.
+func TestCompareDirectories_UnknownProvider(t *testing.T) {
+	p1 := newTestProvider("alpha")
+	svc := newTestService(t, p1)
+
+	_, err := svc.CompareDirectories(context.Background(), "alpha", "nonexistent")
+	require.Error(t, err)
+}
+
+// TestGetProviderStatistics_ReturnsRealCounts asserts that user and group counts reflect
+// the actual objects stored in the provider.
+func TestGetProviderStatistics_ReturnsRealCounts(t *testing.T) {
+	p := newTestProvider("alpha")
+	p.addUser(&types.DirectoryUser{
+		ID:                "u1",
+		UserPrincipalName: "alice@example.com",
+		DisplayName:       "Alice",
+		AccountEnabled:    true,
+	})
+	p.addUser(&types.DirectoryUser{
+		ID:                "u2",
+		UserPrincipalName: "bob@example.com",
+		DisplayName:       "Bob",
+		AccountEnabled:    true,
+	})
+	p.addGroup(&types.DirectoryGroup{
+		ID:          "g1",
+		Name:        "engineers",
+		DisplayName: "Engineers",
+		GroupType:   types.GroupTypeSecurity,
+		GroupScope:  types.GroupScopeGlobal,
+	})
+
+	svc := newTestService(t, p)
+
+	stats, err := svc.GetProviderStatistics(context.Background(), "alpha")
+	require.NoError(t, err)
+	require.NotNil(t, stats)
+	assert.Equal(t, int64(2), stats.TotalUsers)
+	assert.Equal(t, int64(1), stats.TotalGroups)
+}
+
+// TestGetProviderStatistics_TracksRequestCount asserts that SearchUsers calls are counted
+// in the provider's request counter.
+func TestGetProviderStatistics_TracksRequestCount(t *testing.T) {
+	p := newTestProvider("alpha")
+	p.addUser(&types.DirectoryUser{
+		ID:                "u1",
+		UserPrincipalName: "alice@example.com",
+		DisplayName:       "Alice",
+		AccountEnabled:    true,
+	})
+
+	svc := newTestService(t, p)
+	ctx := context.Background()
+
+	// Issue two search calls to increment the counter
+	_, err := svc.SearchUsers(ctx, "alpha", &SearchQuery{})
+	require.NoError(t, err)
+	_, err = svc.SearchUsers(ctx, "alpha", &SearchQuery{})
+	require.NoError(t, err)
+
+	stats, err := svc.GetProviderStatistics(ctx, "alpha")
+	require.NoError(t, err)
+	require.NotNil(t, stats)
+	assert.Equal(t, int64(2), stats.RequestCount)
+}
+
+// TestGetProviderStatistics_PropagatesSearchError asserts that a provider search failure
+// is returned as an error rather than silently producing zero counts.
+func TestGetProviderStatistics_PropagatesSearchError(t *testing.T) {
+	p := newTestProvider("alpha")
+	p.failSearch = true
+	svc := newTestService(t, p)
+
+	_, err := svc.GetProviderStatistics(context.Background(), "alpha")
+	require.Error(t, err, "expected error when provider search fails")
+}

--- a/pkg/directory/dna/drift.go
+++ b/pkg/directory/dna/drift.go
@@ -261,6 +261,11 @@ func (d *DefaultDirectoryDriftDetector) DetectBulkDrift(ctx context.Context, cur
 		}
 	}
 
+	// Wait for all concurrent comparisons before appending serially below.
+	// The creation/deletion loops append to allDrifts without holding mutex,
+	// so all goroutines must be done first to avoid a data race.
+	wg.Wait()
+
 	// Detect new objects (objects in current but not in baseline)
 	for objectID, current := range currentMap {
 		if _, exists := baselineMap[objectID]; !exists {
@@ -308,9 +313,6 @@ func (d *DefaultDirectoryDriftDetector) DetectBulkDrift(ctx context.Context, cur
 			allDrifts = append(allDrifts, drift)
 		}
 	}
-
-	// Wait for all comparisons to complete
-	wg.Wait()
 
 	duration := time.Since(startTime)
 


### PR DESCRIPTION
## Summary

- Implements `CompareDirectories` in `features/controller/directory/service.go`: fetches all users and groups from both providers, builds `DirectoryDNA` snapshots keyed by UserPrincipalName/Name, calls `dna.DefaultDirectoryDriftDetector.DetectBulkDrift`, and returns a real `TotalDifferences` count — no longer returns the "directory comparison not yet implemented" error.
- Implements `GetProviderStatistics`: returns live user/group counts from the provider plus per-provider request/error/latency counters accumulated since registration. Errors from count queries are now propagated instead of silently discarded.
- Fixes a pre-existing data race in `pkg/directory/dna/drift.go` where `DetectBulkDrift` appended to `allDrifts` on the main goroutine concurrently with spawned goroutines; `wg.Wait()` is now called before the creation/deletion loops.

Fixes #714

## Specialist Review Results

| Reviewer | Result |
|---|---|
| QA Test Runner | **PASS** — all packages pass with `-race`; cross-platform builds verified |
| QA Code Reviewer | **PASS** — no mock usage, no skipped tests, error paths covered |
| Security Engineer | **PASS** — no hardcoded secrets, no central provider violations, gosec/staticcheck clean |

## Test plan

- [x] `TestCompareDirectories_IdenticalProviders_ZeroDiffs` — identical providers return `TotalDifferences: 0`
- [x] `TestCompareDirectories_DetectsRealDiffs` — user attribute differences and missing users detected
- [x] `TestCompareDirectories_GroupDiffs` — group attribute differences detected
- [x] `TestCompareDirectories_UnknownProvider` — unknown provider returns error
- [x] `TestGetProviderStatistics_ReturnsRealCounts` — returns real user/group counts from provider
- [x] `TestGetProviderStatistics_TracksRequestCount` — request counter increments correctly
- [x] `TestGetProviderStatistics_PropagatesSearchError` — provider search failures are returned as errors
- [x] All existing `pkg/directory/dna` tests pass with race detection after drift.go fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)