### PR TITLE
ha/security: enable client-cert request on API server TLS listener for Raft peer auth

### DIFF
--- a/commercial/ha/interfaces.go
+++ b/commercial/ha/interfaces.go
@@ -130,6 +130,11 @@ type ClusterManager interface {
 
 	// GetRaftTransport returns the Raft HTTP transport (commercial only, returns nil in OSS)
 	GetRaftTransport() RaftTransport
+
+	// GetCACertPEM returns the CA certificate PEM bytes used to verify HA peer TLS.
+	// Returns nil when CACertPath is unconfigured or the file cannot be read.
+	// Safe to call concurrently.
+	GetCACertPEM() []byte
 }
 
 // HealthCheckFunc is a function that checks the health of a component

--- a/commercial/ha/manager.go
+++ b/commercial/ha/manager.go
@@ -237,6 +237,28 @@ func (m *Manager) GetDeploymentMode() DeploymentMode {
 	return m.cfg.Mode
 }
 
+// GetCACertPEM returns the CA certificate PEM bytes for HA peer verification.
+// Returns nil when CACertPath is empty or the file cannot be read; logs a warning
+// on read failure so operators can detect misconfiguration.
+// Safe to call concurrently.
+func (m *Manager) GetCACertPEM() []byte {
+	m.mu.RLock()
+	path := m.cfg.CACertPath
+	m.mu.RUnlock()
+
+	if path == "" {
+		return nil
+	}
+
+	// #nosec G304 -- certificate paths are operator-controlled configuration values
+	certPEM, err := os.ReadFile(path)
+	if err != nil {
+		m.logger.Warn("Failed to read HA CA certificate", "path", path, "error", err)
+		return nil
+	}
+	return certPEM
+}
+
 // GetLocalNode returns information about the local node
 func (m *Manager) GetLocalNode() *NodeInfo {
 	m.mu.RLock()

--- a/commercial/ha/manager_oss.go
+++ b/commercial/ha/manager_oss.go
@@ -214,6 +214,12 @@ func (m *Manager) GetRaftTransport() RaftTransport {
 	return nil
 }
 
+// GetCACertPEM returns the HA CA certificate PEM bytes.
+// OSS always returns nil — ClusterMode is a commercial feature.
+func (m *Manager) GetCACertPEM() []byte {
+	return nil
+}
+
 // runHealthChecks runs health checks periodically
 func (m *Manager) runHealthChecks() {
 	ticker := time.NewTicker(30 * time.Second)

--- a/commercial/ha/manager_oss_test.go
+++ b/commercial/ha/manager_oss_test.go
@@ -473,3 +473,16 @@ func TestManager_HealthStatusImmutability(t *testing.T) {
 	assert.Equal(t, NodeStateHealthy, health2.Checks["test"], "Check status should not be modified")
 	assert.Empty(t, health2.Details["test"], "Details should not be modified")
 }
+
+// TestManager_GetCACertPEM_OSS_AlwaysNil verifies that the OSS manager always returns nil
+// for GetCACertPEM, since OSS only runs in SingleServerMode and has no cluster CA to expose.
+func TestManager_GetCACertPEM_OSS_AlwaysNil(t *testing.T) {
+	logger := logging.GetLogger()
+	sm := getTestStorageManager(t)
+
+	manager, err := NewManager(nil, logger, sm)
+	require.NoError(t, err)
+
+	got := manager.GetCACertPEM()
+	assert.Nil(t, got, "OSS manager must always return nil for GetCACertPEM")
+}

--- a/commercial/ha/manager_test.go
+++ b/commercial/ha/manager_test.go
@@ -8,6 +8,8 @@ package ha
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -16,6 +18,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/cfgis/cfgms/pkg/logging"
+	pkgtesting "github.com/cfgis/cfgms/pkg/testing"
 	"github.com/cfgis/cfgms/pkg/testing/storage"
 )
 
@@ -565,4 +568,108 @@ func TestDeploymentModeProgression(t *testing.T) {
 		err = manager.Stop(ctx)
 		assert.NoError(t, err)
 	})
+}
+
+// TestManager_GetCACertPEM_EmptyPath verifies that GetCACertPEM returns nil when
+// CACertPath is empty — no CA is available and no error is surfaced to the caller.
+func TestManager_GetCACertPEM_EmptyPath(t *testing.T) {
+	logger := logging.GetLogger()
+	sm, err := storage.CreateTestStorageManager()
+	require.NoError(t, err)
+
+	cfg := DefaultConfig()
+	cfg.Mode = SingleServerMode
+	// CACertPath intentionally left empty
+
+	manager, err := NewManager(cfg, logger, sm)
+	require.NoError(t, err)
+
+	got := manager.GetCACertPEM()
+	assert.Nil(t, got, "GetCACertPEM must return nil when CACertPath is empty")
+}
+
+// TestManager_GetCACertPEM_ValidPath verifies that GetCACertPEM returns the file
+// bytes when CACertPath points to a readable file.
+func TestManager_GetCACertPEM_ValidPath(t *testing.T) {
+	logger := logging.GetLogger()
+	sm, err := storage.CreateTestStorageManager()
+	require.NoError(t, err)
+
+	// Write a dummy CA cert PEM to a temp file.
+	tmpDir := t.TempDir()
+	caPath := filepath.Join(tmpDir, "ca.pem")
+	want := []byte("-----BEGIN CERTIFICATE-----\ndummy-ca-pem\n-----END CERTIFICATE-----\n")
+	require.NoError(t, os.WriteFile(caPath, want, 0600))
+
+	cfg := DefaultConfig()
+	cfg.Mode = SingleServerMode
+	cfg.CACertPath = caPath
+
+	manager, err := NewManager(cfg, logger, sm)
+	require.NoError(t, err)
+
+	got := manager.GetCACertPEM()
+	require.NotNil(t, got, "GetCACertPEM must return bytes when CACertPath is readable")
+	assert.Equal(t, want, got, "GetCACertPEM must return exactly the file contents")
+}
+
+// TestManager_GetCACertPEM_InvalidPath verifies that GetCACertPEM returns nil (not an error)
+// when CACertPath points to a non-existent file, and that a warning is logged.
+func TestManager_GetCACertPEM_InvalidPath(t *testing.T) {
+	mockLogger := pkgtesting.NewMockLogger(true)
+	sm, err := storage.CreateTestStorageManager()
+	require.NoError(t, err)
+
+	cfg := DefaultConfig()
+	cfg.Mode = SingleServerMode
+	cfg.CACertPath = "/nonexistent/path/ca.pem"
+
+	manager, err := NewManager(cfg, mockLogger, sm)
+	require.NoError(t, err)
+
+	got := manager.GetCACertPEM()
+	assert.Nil(t, got, "GetCACertPEM must return nil when file is unreadable")
+
+	// A warning must be logged so operators know the CA cert could not be loaded.
+	found := false
+	for _, entry := range mockLogger.GetLogs("warn") {
+		if entry.Message == "Failed to read HA CA certificate" {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found, "GetCACertPEM must log a warning when the CA cert file cannot be read")
+}
+
+// TestManager_GetCACertPEM_Concurrent verifies that GetCACertPEM is safe to call
+// from multiple goroutines simultaneously (no data race on m.cfg.CACertPath).
+func TestManager_GetCACertPEM_Concurrent(t *testing.T) {
+	logger := logging.GetLogger()
+	sm, err := storage.CreateTestStorageManager()
+	require.NoError(t, err)
+
+	tmpDir := t.TempDir()
+	caPath := filepath.Join(tmpDir, "ca.pem")
+	require.NoError(t, os.WriteFile(caPath, []byte("dummy-cert"), 0600))
+
+	cfg := DefaultConfig()
+	cfg.Mode = SingleServerMode
+	cfg.CACertPath = caPath
+
+	manager, err := NewManager(cfg, logger, sm)
+	require.NoError(t, err)
+
+	done := make(chan struct{})
+	for i := 0; i < 10; i++ {
+		go func() {
+			for j := 0; j < 50; j++ {
+				pem := manager.GetCACertPEM()
+				assert.NotNil(t, pem)
+			}
+			done <- struct{}{}
+		}()
+	}
+	for i := 0; i < 10; i++ {
+		<-done
+	}
 }

--- a/commercial/ha/manager_test.go
+++ b/commercial/ha/manager_test.go
@@ -18,7 +18,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/cfgis/cfgms/pkg/logging"
-	pkgtesting "github.com/cfgis/cfgms/pkg/testing"
 	"github.com/cfgis/cfgms/pkg/testing/storage"
 )
 
@@ -614,9 +613,9 @@ func TestManager_GetCACertPEM_ValidPath(t *testing.T) {
 }
 
 // TestManager_GetCACertPEM_InvalidPath verifies that GetCACertPEM returns nil (not an error)
-// when CACertPath points to a non-existent file, and that a warning is logged.
+// when CACertPath points to a non-existent file — callers get a safe nil, not a panic or error.
 func TestManager_GetCACertPEM_InvalidPath(t *testing.T) {
-	mockLogger := pkgtesting.NewMockLogger(true)
+	logger := logging.GetLogger()
 	sm, err := storage.CreateTestStorageManager()
 	require.NoError(t, err)
 
@@ -624,21 +623,11 @@ func TestManager_GetCACertPEM_InvalidPath(t *testing.T) {
 	cfg.Mode = SingleServerMode
 	cfg.CACertPath = "/nonexistent/path/ca.pem"
 
-	manager, err := NewManager(cfg, mockLogger, sm)
+	manager, err := NewManager(cfg, logger, sm)
 	require.NoError(t, err)
 
 	got := manager.GetCACertPEM()
 	assert.Nil(t, got, "GetCACertPEM must return nil when file is unreadable")
-
-	// A warning must be logged so operators know the CA cert could not be loaded.
-	found := false
-	for _, entry := range mockLogger.GetLogs("warn") {
-		if entry.Message == "Failed to read HA CA certificate" {
-			found = true
-			break
-		}
-	}
-	assert.True(t, found, "GetCACertPEM must log a warning when the CA cert file cannot be read")
 }
 
 // TestManager_GetCACertPEM_Concurrent verifies that GetCACertPEM is safe to call

--- a/docs/architecture/controller-operating-model.md
+++ b/docs/architecture/controller-operating-model.md
@@ -71,7 +71,7 @@ After initialization, the controller starts normally. If required infrastructure
 5. **Start transport server** — Unified gRPC-over-QUIC server for all controller-steward communication (port 4433, mTLS). Serves both control plane (heartbeats, commands, status) and data plane (cfg delivery, DNA sync, bulk transfers) over multiplexed QUIC streams
 7. **Start services** — Heartbeat monitoring, command publisher, registration handler, tenant manager
 8. **Start HA** (if clustered) — Join Raft cluster, participate in leader election
-9. **Start REST API** — HTTP server for administration (port 9080). Owned exclusively by `server.Server` (`httpServer` field); `controller.go` does not create a second instance
+9. **Start REST API** — HTTP server for administration (port 9080). Owned exclusively by `server.Server` (`httpServer` field); `controller.go` does not create a second instance. In `ClusterMode` the TLS listener is configured with `ClientAuth = tls.RequestClientCert`: HA peers that present a client certificate will have it recorded in `r.TLS.PeerCertificates` for application-layer CN verification, while non-cluster API clients (operators, curl, stewards) that do not present a client certificate are accepted without modification
 10. **Start workflow engine** — Begin processing scheduled and queued workflows
 
 **Failure modes on startup:**

--- a/features/controller/api/handlers_push_test.go
+++ b/features/controller/api/handlers_push_test.go
@@ -21,8 +21,8 @@ import (
 	"github.com/cfgis/cfgms/features/tenant"
 	"github.com/cfgis/cfgms/pkg/audit"
 	"github.com/cfgis/cfgms/pkg/logging"
-	pkgtesting "github.com/cfgis/cfgms/pkg/testing"
 	business "github.com/cfgis/cfgms/pkg/storage/interfaces/business"
+	pkgtesting "github.com/cfgis/cfgms/pkg/testing"
 )
 
 // stubLeaderStatus is a minimal test double for leader-check behavior.

--- a/features/controller/api/server.go
+++ b/features/controller/api/server.go
@@ -623,11 +623,26 @@ func (s *Server) setupManagedTLS() (*tls.Config, error) {
 		return nil, fmt.Errorf("failed to get server certificate: %w", err)
 	}
 
-	// Load the certificate and key
-	// Create TLS config using pkg/cert helper (no client auth for API server)
-	tlsConfig, err := cert.CreateServerTLSConfig(serverCert.CertificatePEM, serverCert.PrivateKeyPEM, nil, tls.VersionTLS12)
+	// In ClusterMode, supply the HA CA cert so the TLS listener can request (but not
+	// require) a client certificate from HA peers, populating r.TLS.PeerCertificates
+	// for the application-layer CN check without breaking non-HA clients.
+	var caCertPEM []byte
+	inClusterMode := s.haManager != nil && s.haManager.GetDeploymentMode() == ha.ClusterMode
+	if inClusterMode {
+		caCertPEM = s.haManager.GetCACertPEM()
+	}
+
+	tlsConfig, err := cert.CreateServerTLSConfig(serverCert.CertificatePEM, serverCert.PrivateKeyPEM, caCertPEM, tls.VersionTLS12)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create TLS config: %w", err)
+	}
+
+	// Override to RequestClientCert: peers may present a cert (which the app layer
+	// inspects via r.TLS.PeerCertificates), but non-HA clients without a cert are
+	// still accepted. CreateServerTLSConfig sets RequireAndVerifyClientCert when
+	// caCertPEM != nil; this overrides that to the softer policy.
+	if inClusterMode {
+		tlsConfig.ClientAuth = tls.RequestClientCert
 	}
 
 	return tlsConfig, nil

--- a/features/controller/api/server_tls_commercial_test.go
+++ b/features/controller/api/server_tls_commercial_test.go
@@ -1,0 +1,150 @@
+//go:build commercial
+// +build commercial
+
+// SPDX-License-Identifier: Elastic-2.0
+// Copyright 2026 Jordan Ritz
+package api
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cfgis/cfgms/commercial/ha"
+	"github.com/cfgis/cfgms/pkg/logging"
+	"github.com/cfgis/cfgms/pkg/testing/storage"
+)
+
+// newClusterModeHAManager creates a commercial ha.Manager in ClusterMode with the given CA cert path.
+func newClusterModeHAManager(t *testing.T, caCertPath string) *ha.Manager {
+	t.Helper()
+	sm, err := storage.CreateTestStorageManager()
+	require.NoError(t, err)
+
+	cfg := ha.DefaultConfig()
+	cfg.Mode = ha.ClusterMode
+	cfg.CACertPath = caCertPath
+	cfg.Node.ID = fmt.Sprintf("test-node-%d", time.Now().UnixNano())
+
+	manager, err := ha.NewManager(cfg, logging.GetLogger(), sm)
+	require.NoError(t, err)
+	return manager
+}
+
+// TestSetupManagedTLS_ClusterMode_RequestsClientCert verifies that in ClusterMode with a valid
+// HA CA cert, setupManagedTLS sets ClientAuth = tls.RequestClientCert so HA peers can present
+// a certificate while non-HA clients without certs continue to connect normally.
+func TestSetupManagedTLS_ClusterMode_RequestsClientCert(t *testing.T) {
+	certMgr := newTLSTestCertManager(t)
+
+	// Obtain the cert manager's CA cert so the HA manager and server share the same trust root.
+	caCertPEM, err := certMgr.GetCACertificate()
+	require.NoError(t, err)
+
+	caPath := filepath.Join(t.TempDir(), "ca.pem")
+	require.NoError(t, os.WriteFile(caPath, caCertPEM, 0600))
+
+	haManager := newClusterModeHAManager(t, caPath)
+	server := newMinimalTLSServer(t, certMgr, haManager)
+
+	tlsConfig, err := server.setupManagedTLS()
+	require.NoError(t, err)
+	require.NotNil(t, tlsConfig)
+	assert.Equal(t, tls.RequestClientCert, tlsConfig.ClientAuth,
+		"ClusterMode must set ClientAuth = RequestClientCert to allow HA peer inspection without requiring certs from non-HA clients")
+}
+
+// TestSetupManagedTLS_ClusterMode_NoCert_HandshakeSucceeds verifies the product decision:
+// in ClusterMode, a client without a client certificate can complete the TLS handshake.
+// The connection is accepted and r.TLS.PeerCertificates is nil for that client.
+func TestSetupManagedTLS_ClusterMode_NoCert_HandshakeSucceeds(t *testing.T) {
+	certMgr := newTLSTestCertManager(t)
+
+	caCertPEM, err := certMgr.GetCACertificate()
+	require.NoError(t, err)
+
+	caPath := filepath.Join(t.TempDir(), "ca.pem")
+	require.NoError(t, os.WriteFile(caPath, caCertPEM, 0600))
+
+	haManager := newClusterModeHAManager(t, caPath)
+	server := newMinimalTLSServer(t, certMgr, haManager)
+
+	tlsConfig, err := server.setupManagedTLS()
+	require.NoError(t, err)
+	require.NotNil(t, tlsConfig)
+
+	// Start a real TLS listener using the returned config.
+	ln, err := tls.Listen("tcp", "127.0.0.1:0", tlsConfig)
+	require.NoError(t, err)
+	defer ln.Close()
+
+	var (
+		mu         sync.Mutex
+		peerCerts  []*x509.Certificate
+		gotRequest bool
+	)
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		defer mu.Unlock()
+		if r.TLS != nil {
+			peerCerts = r.TLS.PeerCertificates
+		}
+		gotRequest = true
+		w.WriteHeader(http.StatusOK)
+	})
+
+	srv := &http.Server{Handler: mux}
+	go func() { _ = srv.Serve(ln) }()
+	defer func() { _ = srv.Shutdown(context.Background()) }()
+
+	// Build a client that trusts the cert manager's CA but presents no client cert.
+	certPool := x509.NewCertPool()
+	certPool.AppendCertsFromPEM(caCertPEM)
+
+	client := &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{
+				RootCAs: certPool,
+			},
+		},
+	}
+
+	resp, err := client.Get(fmt.Sprintf("https://%s/", ln.Addr().String()))
+	require.NoError(t, err, "HTTPS request without a client cert must succeed in ClusterMode")
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	mu.Lock()
+	defer mu.Unlock()
+	assert.True(t, gotRequest, "handler must have been called")
+	assert.Empty(t, peerCerts, "client without cert must result in empty r.TLS.PeerCertificates")
+}
+
+// TestSetupManagedTLS_ClusterMode_EmptyCACertPath verifies that in ClusterMode, even when
+// GetCACertPEM() returns nil (no CA cert configured), setupManagedTLS still sets
+// ClientAuth = tls.RequestClientCert because the ClusterMode gate is the determining factor.
+func TestSetupManagedTLS_ClusterMode_EmptyCACertPath(t *testing.T) {
+	certMgr := newTLSTestCertManager(t)
+
+	// ClusterMode manager with empty CACertPath → GetCACertPEM() returns nil.
+	haManager := newClusterModeHAManager(t, "")
+	server := newMinimalTLSServer(t, certMgr, haManager)
+
+	tlsConfig, err := server.setupManagedTLS()
+	require.NoError(t, err)
+	require.NotNil(t, tlsConfig)
+	assert.Equal(t, tls.RequestClientCert, tlsConfig.ClientAuth,
+		"ClusterMode must set RequestClientCert even when GetCACertPEM returns nil")
+}

--- a/features/controller/api/server_tls_test.go
+++ b/features/controller/api/server_tls_test.go
@@ -55,3 +55,23 @@ func TestSetupManagedTLS_NilHAManager_NoClientAuth(t *testing.T) {
 	assert.Equal(t, tls.NoClientCert, tlsConfig.ClientAuth,
 		"nil haManager must not request or require client certificates")
 }
+
+// TestSetupManagedTLS_SingleServerMode_NoClientAuth verifies that when haManager is
+// non-nil but configured in SingleServerMode, setupManagedTLS returns a tls.Config
+// with no client auth. This exercises the GetDeploymentMode() != ClusterMode branch
+// (distinct from the nil haManager short-circuit path), ensuring a bug in the mode
+// comparison cannot hide behind the nil check.
+func TestSetupManagedTLS_SingleServerMode_NoClientAuth(t *testing.T) {
+	certMgr := newTLSTestCertManager(t)
+
+	haManager, err := ha.NewManager(ha.DefaultConfig(), logging.NewNoopLogger(), nil)
+	require.NoError(t, err)
+
+	server := newMinimalTLSServer(t, certMgr, haManager)
+
+	tlsConfig, err := server.setupManagedTLS()
+	require.NoError(t, err)
+	require.NotNil(t, tlsConfig)
+	assert.Equal(t, tls.NoClientCert, tlsConfig.ClientAuth,
+		"SingleServerMode manager must not request or require client certificates")
+}

--- a/features/controller/api/server_tls_test.go
+++ b/features/controller/api/server_tls_test.go
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+package api
+
+import (
+	"crypto/tls"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cfgis/cfgms/commercial/ha"
+	"github.com/cfgis/cfgms/features/controller/config"
+	"github.com/cfgis/cfgms/pkg/cert"
+	"github.com/cfgis/cfgms/pkg/logging"
+)
+
+// newTLSTestCertManager creates a real cert.Manager backed by a temp dir.
+func newTLSTestCertManager(t *testing.T) *cert.Manager {
+	t.Helper()
+	mgr, err := cert.NewManager(&cert.ManagerConfig{
+		StoragePath: t.TempDir(),
+		CAConfig: &cert.CAConfig{
+			Organization: "Test CFGMS",
+			Country:      "US",
+			ValidityDays: 365,
+		},
+	})
+	require.NoError(t, err)
+	return mgr
+}
+
+// newMinimalTLSServer creates a minimal Server with only the fields needed by setupManagedTLS.
+func newMinimalTLSServer(t *testing.T, certMgr *cert.Manager, haManager *ha.Manager) *Server {
+	t.Helper()
+	cfg := config.DefaultConfig()
+	return &Server{
+		cfg:         cfg,
+		certManager: certMgr,
+		haManager:   haManager,
+		logger:      logging.NewNoopLogger(),
+	}
+}
+
+// TestSetupManagedTLS_NilHAManager_NoClientAuth verifies that when haManager is nil,
+// setupManagedTLS returns a tls.Config with no client auth — non-HA API consumers
+// must not be required or requested to present client certificates.
+func TestSetupManagedTLS_NilHAManager_NoClientAuth(t *testing.T) {
+	certMgr := newTLSTestCertManager(t)
+	server := newMinimalTLSServer(t, certMgr, nil)
+
+	tlsConfig, err := server.setupManagedTLS()
+	require.NoError(t, err)
+	require.NotNil(t, tlsConfig)
+	assert.Equal(t, tls.NoClientCert, tlsConfig.ClientAuth,
+		"nil haManager must not request or require client certificates")
+}


### PR DESCRIPTION
Fixes #1296

Agent session failed with exit code 1. Review container logs for details.