### PR TITLE
ha/security: authenticate /raft/message via mTLS peer CN verification (Issue #1298)

### DIFF
--- a/commercial/ha/manager.go
+++ b/commercial/ha/manager.go
@@ -500,8 +500,30 @@ func (m *Manager) initializeRaftConsensus() error {
 		}
 	}
 
+	// Collect allowed peer CNs for mTLS verification on /raft/message.
+	// The local node's own CN is included first so single-node loopback messages
+	// are accepted without requiring a second allowlist entry.
+	allowedCNs := []string{m.nodeInfo.ID}
+	if clusterNodes := m.cfg.Cluster.Discovery.Config["nodes"]; clusterNodes != nil {
+		if nodes, ok := clusterNodes.([]interface{}); ok {
+			for _, n := range nodes {
+				if nodeMap, ok := n.(map[string]interface{}); ok {
+					if id, ok := nodeMap["id"].(string); ok && id != m.nodeInfo.ID {
+						allowedCNs = append(allowedCNs, id)
+					}
+				}
+			}
+		} else if nodes, ok := clusterNodes.([]map[string]interface{}); ok {
+			for _, nodeMap := range nodes {
+				if id, ok := nodeMap["id"].(string); ok && id != m.nodeInfo.ID {
+					allowedCNs = append(allowedCNs, id)
+				}
+			}
+		}
+	}
+
 	// Create and attach transport
-	transport := newRaftTransport(nodeID, m.nodeInfo.Address, m.raftConsensus, caCertPEM, m.logger)
+	transport := newRaftTransport(nodeID, m.nodeInfo.Address, m.raftConsensus, caCertPEM, allowedCNs, m.logger)
 	m.raftConsensus.SetTransport(transport)
 
 	// Add peer addresses to transport

--- a/commercial/ha/raft_transport.go
+++ b/commercial/ha/raft_transport.go
@@ -41,6 +41,10 @@ type raftTransport struct {
 	// Consensus engine
 	consensus *RaftConsensus
 
+	// allowedCNs is the set of TLS peer certificate CNs permitted to send Raft
+	// messages. Includes the local node's CN so single-node loopback works.
+	allowedCNs []string
+
 	// Lifecycle
 	ctx    context.Context
 	cancel context.CancelFunc
@@ -50,7 +54,7 @@ type raftTransport struct {
 }
 
 // newRaftTransport creates a new Raft transport
-func newRaftTransport(nodeID uint64, address string, consensus *RaftConsensus, caCertPEM []byte, logger logging.Logger) *raftTransport {
+func newRaftTransport(nodeID uint64, address string, consensus *RaftConsensus, caCertPEM []byte, allowedCNs []string, logger logging.Logger) *raftTransport {
 	var tlsConfig *tls.Config
 	var err error
 
@@ -76,11 +80,12 @@ func newRaftTransport(nodeID uint64, address string, consensus *RaftConsensus, c
 	}
 
 	return &raftTransport{
-		nodeID:    nodeID,
-		address:   address,
-		peers:     make(map[uint64]string),
-		consensus: consensus,
-		useTLS:    true, // Default to TLS for cluster communication
+		nodeID:     nodeID,
+		address:    address,
+		peers:      make(map[uint64]string),
+		consensus:  consensus,
+		allowedCNs: allowedCNs,
+		useTLS:     true, // Default to TLS for cluster communication
 		client: &http.Client{
 			Timeout:   3 * time.Second,
 			Transport: transport,
@@ -88,6 +93,22 @@ func newRaftTransport(nodeID uint64, address string, consensus *RaftConsensus, c
 		stopC:  make(chan struct{}),
 		logger: logger,
 	}
+}
+
+// verifyPeerCN checks that the TLS peer certificate CN in r matches one of the
+// allowedCNs. It returns an error when r.TLS is nil, when no peer certificate
+// was presented, or when the CN is not in the allowed set.
+func verifyPeerCN(r *http.Request, allowedCNs []string) error {
+	if r.TLS == nil || len(r.TLS.PeerCertificates) == 0 {
+		return fmt.Errorf("mTLS required: no peer certificate presented")
+	}
+	cn := r.TLS.PeerCertificates[0].Subject.CommonName
+	for _, allowed := range allowedCNs {
+		if cn == allowed {
+			return nil
+		}
+	}
+	return fmt.Errorf("peer certificate CN %q is not a known cluster node", cn)
 }
 
 // Start begins the transport layer
@@ -188,6 +209,13 @@ func (t *raftTransport) sendMessage(msg raftpb.Message) {
 
 // HandleMessage processes incoming Raft messages (HTTP handler)
 func (t *raftTransport) HandleMessage(w http.ResponseWriter, r *http.Request) {
+	if err := verifyPeerCN(r, t.allowedCNs); err != nil {
+		t.logger.Warn("RAFT_TRANSPORT: Rejected message from unauthorized peer",
+			"remote_addr", r.RemoteAddr, "error", err)
+		http.Error(w, "Forbidden: peer certificate verification failed", http.StatusForbidden)
+		return
+	}
+
 	t.logger.Debug("RAFT_TRANSPORT: Received message HTTP request", "node_id", t.nodeID, "remote_addr", r.RemoteAddr)
 
 	// Read message body

--- a/commercial/ha/raft_transport_test.go
+++ b/commercial/ha/raft_transport_test.go
@@ -7,20 +7,28 @@
 package ha
 
 import (
+	"bytes"
 	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"net/http/httptest"
 	"strings"
 	"testing"
+
+	"go.etcd.io/raft/v3/raftpb"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/cfgis/cfgms/pkg/logging"
 	pkgtesting "github.com/cfgis/cfgms/pkg/testing"
 )
 
 func TestRaftTransport_Start_logsStartup(t *testing.T) {
 	mock := pkgtesting.NewMockLogger(true)
 
-	transport := newRaftTransport(1, "localhost:8080", nil, nil, mock)
+	transport := newRaftTransport(1, "localhost:8080", nil, nil, nil, mock)
 
 	ctx := context.Background()
 	err := transport.Start(ctx)
@@ -30,4 +38,99 @@ func TestRaftTransport_Start_logsStartup(t *testing.T) {
 	require.NotEmpty(t, infoLogs, "expected at least one info log after Start()")
 	assert.True(t, strings.Contains(infoLogs[0].Message, "RAFT_TRANSPORT"),
 		"startup log should contain RAFT_TRANSPORT, got: %s", infoLogs[0].Message)
+}
+
+// makeFakePeerCert returns a minimal x509.Certificate with the given CN, suitable
+// for populating r.TLS.PeerCertificates in unit tests. No signature validation is
+// performed by verifyPeerCN — only the CN string is inspected.
+func makeFakePeerCert(cn string) *x509.Certificate {
+	return &x509.Certificate{
+		Subject: pkix.Name{CommonName: cn},
+	}
+}
+
+// TestHandleMessage_NilTLS_Returns403 verifies that HandleMessage rejects requests
+// that arrive without a TLS connection state (i.e., plain HTTP).
+func TestHandleMessage_NilTLS_Returns403(t *testing.T) {
+	logger := pkgtesting.NewMockLogger(true)
+	transport := newRaftTransport(1, "localhost:8080", nil, nil, []string{"node-1"}, logger)
+
+	req := httptest.NewRequest("POST", "/raft/message", nil)
+	// r.TLS is nil (plain HTTP, no peer certificate)
+	w := httptest.NewRecorder()
+	transport.HandleMessage(w, req)
+
+	assert.Equal(t, 403, w.Code, "nil r.TLS must be rejected with 403")
+}
+
+// TestHandleMessage_EmptyPeerCertificates_Returns403 verifies that HandleMessage
+// rejects TLS connections where the peer did not present a client certificate
+// (r.TLS is non-nil but PeerCertificates is empty). This is a distinct reachable
+// scenario from nil-TLS: e.g., a non-peer HTTPS client hitting /raft/message.
+func TestHandleMessage_EmptyPeerCertificates_Returns403(t *testing.T) {
+	logger := pkgtesting.NewMockLogger(true)
+	transport := newRaftTransport(1, "localhost:8080", nil, nil, []string{"node-1"}, logger)
+
+	req := httptest.NewRequest("POST", "/raft/message", nil)
+	req.TLS = &tls.ConnectionState{
+		PeerCertificates: nil, // TLS handshake succeeded but no client cert presented
+	}
+	w := httptest.NewRecorder()
+	transport.HandleMessage(w, req)
+
+	assert.Equal(t, 403, w.Code, "empty PeerCertificates must be rejected with 403")
+}
+
+// TestHandleMessage_UnknownCN_Returns403 verifies that HandleMessage rejects requests
+// whose peer certificate CN is not in the configured cluster node allowlist.
+func TestHandleMessage_UnknownCN_Returns403(t *testing.T) {
+	logger := pkgtesting.NewMockLogger(true)
+	transport := newRaftTransport(1, "localhost:8080", nil, nil, []string{"node-1"}, logger)
+
+	req := httptest.NewRequest("POST", "/raft/message", nil)
+	req.TLS = &tls.ConnectionState{
+		PeerCertificates: []*x509.Certificate{makeFakePeerCert("evil-node")},
+	}
+	w := httptest.NewRecorder()
+	transport.HandleMessage(w, req)
+
+	assert.Equal(t, 403, w.Code, "unknown peer CN must be rejected with 403")
+}
+
+// TestHandleMessage_ValidPeerCN_Returns200 verifies that HandleMessage accepts requests
+// whose peer certificate CN matches a known cluster node. A real RaftConsensus is used
+// so that consensus.Process() (node.Step) succeeds and the handler returns 200.
+func TestHandleMessage_ValidPeerCN_Returns200(t *testing.T) {
+	logger := logging.GetLogger()
+	clusterCfg := newTestClusterCfg()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	nodeInfo := &NodeInfo{ID: "node-1", State: NodeStateHealthy, Role: NodeRoleFollower}
+	consensus, err := NewRaftConsensus(ctx, 1, nodeInfo, nil, clusterCfg, logger)
+	require.NoError(t, err)
+	defer func() {
+		if stopErr := consensus.Stop(); stopErr != nil {
+			t.Logf("consensus.Stop: %v", stopErr)
+		}
+	}()
+
+	transport := newRaftTransport(1, "localhost:8080", consensus, nil, []string{"node-1"}, pkgtesting.NewMockLogger(true))
+
+	// Marshal a minimal raftpb.Message (empty message, Type=MsgHup).
+	// node.Step is non-blocking: it enqueues to the raft goroutine and returns nil.
+	var msg raftpb.Message
+	data, err := msg.Marshal()
+	require.NoError(t, err)
+
+	req := httptest.NewRequest("POST", "/raft/message", bytes.NewReader(data))
+	req.TLS = &tls.ConnectionState{
+		PeerCertificates: []*x509.Certificate{makeFakePeerCert("node-1")},
+	}
+	w := httptest.NewRecorder()
+	transport.HandleMessage(w, req)
+
+	assert.Equal(t, 200, w.Code,
+		"valid peer CN must pass CN verification and reach the handler (got %d)", w.Code)
 }

--- a/docs/architecture/controller-operating-model.md
+++ b/docs/architecture/controller-operating-model.md
@@ -554,6 +554,22 @@ Multiple controller instances form a **Raft consensus cluster**. Raft is the sol
 
 Stewards connect to any cluster node. If their node goes down, they reconnect to another.
 
+#### Raft Peer Authentication
+
+The `POST /raft/message` endpoint uses **mTLS peer certificate CN verification** as its sole authentication mechanism. The TLS listener in `ClusterMode` is configured with `ClientAuth = tls.RequestClientCert` (set in `setupManagedTLS`), so HA peers that present a client certificate have it recorded in `r.TLS.PeerCertificates` for application-layer inspection.
+
+`HandleMessage` extracts `r.TLS.PeerCertificates[0].Subject.CommonName` and rejects (HTTP 403) any request where:
+
+- `r.TLS` is nil (plain HTTP, not mTLS)
+- No peer certificate was presented
+- The peer certificate CN does not match any entry in the node's `allowedCNs` list
+
+The `allowedCNs` list is built at startup from the `discovery.config.nodes` peer entries (each node's `id` field) plus the local node's own `id`. This means **operators must provision peer certificates whose CN matches the `node.id` value declared in the cluster node configuration**. There is no automatic peer-cert provisioning in the HA subsystem — certificate management is delegated to `pkg/cert` and is operator-controlled via `CFGMS_HA_CA_CERT_PATH`.
+
+The `GET /api/v1/raft/status` endpoint is protected by RBAC (`ha:read-status` permission) via the standard API authentication middleware — it is not a peer endpoint and must not be accessed without a valid API key.
+
+> **Do not use the `X-Raft-From` header for authentication** — it is set by the sender and is untrusted. Only the TLS peer certificate is authoritative.
+
 ## REST API
 
 The REST API is the admin interface to the controller. All operations are authenticated, authorized via RBAC, and audit-logged.

--- a/features/controller/api/handlers_raft_commercial_test.go
+++ b/features/controller/api/handlers_raft_commercial_test.go
@@ -1,0 +1,40 @@
+//go:build commercial
+// +build commercial
+
+// SPDX-License-Identifier: Elastic-2.0
+// Copyright 2026 Jordan Ritz
+package api
+
+import (
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestRaftStatus_AuthorizedRequest_Returns200 verifies that an authenticated request
+// with the ha:read-status permission returns 200 when a real ClusterMode HA manager
+// is available. A real raftTransport is wired by newClusterModeHAManager so that
+// handleRaftStatus can delegate to transport.HandleStatus.
+func TestRaftStatus_AuthorizedRequest_Returns200(t *testing.T) {
+	haManager := newClusterModeHAManager(t, "")
+
+	// Set up a fully-wired test server and inject the commercial HA manager.
+	// The router and authentication middleware were registered during New(), so
+	// changing haManager here only affects what the handler reads at request time.
+	server := setupTestServer(t)
+	server.mu.Lock()
+	server.haManager = haManager
+	server.mu.Unlock()
+
+	apiKey := NewEphemeralTestKey(t, server, []string{"ha:read-status"}, "test-tenant", 5*time.Minute)
+
+	req := httptest.NewRequest("GET", "/api/v1/raft/status", nil)
+	req.Header.Set("X-API-Key", apiKey)
+	w := httptest.NewRecorder()
+	server.GetRouter().ServeHTTP(w, req)
+
+	assert.Equal(t, 200, w.Code,
+		"authorized request with ha:read-status permission and a running HA manager must return 200")
+}

--- a/features/controller/api/handlers_raft_test.go
+++ b/features/controller/api/handlers_raft_test.go
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+package api
+
+import (
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestRaftStatus_UnauthenticatedRequest_Returns401 verifies that GET /api/v1/raft/status
+// rejects requests that carry no API key with 401 Unauthorized.
+func TestRaftStatus_UnauthenticatedRequest_Returns401(t *testing.T) {
+	server := setupTestServer(t)
+
+	req := httptest.NewRequest("GET", "/api/v1/raft/status", nil)
+	// No X-API-Key or Authorization header
+	w := httptest.NewRecorder()
+	server.GetRouter().ServeHTTP(w, req)
+
+	assert.Equal(t, 401, w.Code,
+		"/api/v1/raft/status must return 401 for unauthenticated requests")
+}
+
+// TestRaftStatus_AuthorizedRequest_PassesAuth verifies that GET /api/v1/raft/status
+// accepts a request carrying an API key with the ha:read-status permission.
+// In OSS builds GetRaftTransport() returns nil, so the handler returns 503; the
+// important property is that the auth layer admits the request (not 401/403).
+func TestRaftStatus_AuthorizedRequest_PassesAuth(t *testing.T) {
+	server := setupTestServer(t)
+
+	apiKey := NewEphemeralTestKey(t, server, []string{"ha:read-status"}, "test-tenant", 5*time.Minute)
+
+	req := httptest.NewRequest("GET", "/api/v1/raft/status", nil)
+	req.Header.Set("X-API-Key", apiKey)
+	w := httptest.NewRecorder()
+	server.GetRouter().ServeHTTP(w, req)
+
+	assert.NotEqual(t, 401, w.Code, "/api/v1/raft/status must not return 401 for an authorized request")
+	assert.NotEqual(t, 403, w.Code, "/api/v1/raft/status must not return 403 for a request with ha:read-status permission")
+	// OSS build: haManager is nil → handler returns 503 (Raft transport not available).
+	// This confirms the request reached the handler rather than being blocked by auth.
+	assert.Equal(t, 503, w.Code, "OSS build with no HA manager: handler must return 503, not an auth error")
+}

--- a/features/controller/api/server.go
+++ b/features/controller/api/server.go
@@ -329,9 +329,10 @@ func (s *Server) setupRouter() {
 	// No route is pre-registered here; the endpoint only exists when a git-sync
 	// handler is explicitly wired in after server creation.
 
-	// Raft consensus endpoints (no auth required - internal cluster communication)
+	// Raft message endpoint: mTLS peer CN verification is enforced inside HandleMessage
 	s.router.HandleFunc("/raft/message", s.handleRaftMessage).Methods("POST")
-	s.router.HandleFunc("/raft/status", s.handleRaftStatus).Methods("GET")
+	// Raft status endpoint: requires HA read-status permission via API authentication
+	api.Handle("/raft/status", s.requirePermission("ha", "read-status")(http.HandlerFunc(s.handleRaftStatus))).Methods("GET")
 
 	// Rollback management endpoints (Story #416)
 	if s.rollbackManager != nil {


### PR DESCRIPTION
## Summary

- `HandleMessage` now rejects all requests that lack a TLS peer certificate or whose CN is not in the configured cluster node allowlist (HTTP 403), closing the unauthenticated Raft message endpoint
- `/raft/status` moved to `/api/v1/raft/status` behind `requirePermission("ha","read-status")` so unauthenticated callers receive 401
- The "no auth required — internal cluster communication" comment removed from `server.go`
- Operator documentation added to `controller-operating-model.md`: peer certs must have CN matching `node.id` in cluster config

## What changed

| File | Change |
|------|--------|
| `commercial/ha/raft_transport.go` | `allowedCNs` field + `verifyPeerCN` helper + 403 guard in `HandleMessage` |
| `commercial/ha/manager.go` | Collect peer node IDs + local node ID as `allowedCNs`; pass to transport |
| `features/controller/api/server.go` | Move `/raft/status` to `api` subrouter at `/api/v1/raft/status` with `requirePermission` |
| `commercial/ha/raft_transport_test.go` | 4 tests: NilTLS→403, EmptyPeerCerts→403, UnknownCN→403, ValidCN→200 |
| `features/controller/api/handlers_raft_test.go` | Unauthenticated→401, authorized→503 (OSS, no transport) |
| `features/controller/api/handlers_raft_commercial_test.go` | Authorized with real ClusterMode HA manager→200 |
| `docs/architecture/controller-operating-model.md` | Raft peer authentication section |

## Specialist Review Results

- **QA Test Runner**: PASS — `commercial/ha` and `features/controller/api` both green
- **QA Code Reviewer**: PASS — blocking issue (missing empty-PeerCertificates test) identified and fixed before commit
- **Security Engineer**: PASS — `verifyPeerCN` correctly fail-closes on nil TLS and empty cert list; 403 message does not disclose CN or allowlist; no `X-Raft-From` used for auth; log statements use only TCP-stack-set remote addr; no new gosec/staticcheck findings

## Test plan

- [ ] `go test -tags commercial ./commercial/ha/...` — all existing + 4 new HandleMessage tests pass
- [ ] `go test -tags commercial ./features/controller/api/...` — all existing + 3 new /raft/status auth tests pass
- [ ] `GET /api/v1/raft/status` without API key → 401
- [ ] `GET /api/v1/raft/status` with `ha:read-status` API key → 200 (ClusterMode with HA manager)
- [ ] `POST /raft/message` without TLS peer cert → 403
- [ ] `POST /raft/message` with peer cert CN matching cluster node → accepted

Fixes #1298

🤖 Generated with [Claude Code](https://claude.com/claude-code)