### PR TITLE
controller/api: add ActiveSessions and ConnectionState to StewardInfo (Issue #1323)

### DIFF
--- a/features/controller/api/handlers_stewards.go
+++ b/features/controller/api/handlers_stewards.go
@@ -172,12 +172,26 @@ func (s *Server) handleGetSteward(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	activeSessions := 0
+	connectionState := "disconnected"
+	s.mu.RLock()
+	reg := s.registry
+	s.mu.RUnlock()
+	if reg != nil {
+		if _, ok := reg.Get(stewardID); ok {
+			activeSessions = 1
+			connectionState = "connected"
+		}
+	}
+
 	apiStewardInfo := StewardInfo{
-		ID:       stewardInfo.ID,
-		Status:   stewardInfo.Status,
-		LastSeen: stewardInfo.LastHeartbeat,
-		Version:  stewardInfo.Version,
-		Metrics:  stewardInfo.Metrics,
+		ID:              stewardInfo.ID,
+		Status:          stewardInfo.Status,
+		LastSeen:        stewardInfo.LastHeartbeat,
+		Version:         stewardInfo.Version,
+		Metrics:         stewardInfo.Metrics,
+		ActiveSessions:  activeSessions,
+		ConnectionState: connectionState,
 	}
 
 	// Include DNA information if available

--- a/features/controller/api/handlers_stewards_test.go
+++ b/features/controller/api/handlers_stewards_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -18,6 +19,7 @@ import (
 	controller "github.com/cfgis/cfgms/api/proto/controller"
 	"github.com/cfgis/cfgms/features/controller/fleet"
 	"github.com/cfgis/cfgms/pkg/ctxkeys"
+	"github.com/cfgis/cfgms/pkg/transport/registry"
 )
 
 // ---- buildFleetFilter unit tests (no server required) ----
@@ -356,6 +358,110 @@ func TestHandleListStewards_HTTPRegistration_NoDuplicates(t *testing.T) {
 	require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
 	assert.Len(t, resp.Data, 1, "duplicate steward ID should produce exactly one entry")
 	assert.Equal(t, "quarantined", resp.Data[0].Status)
+}
+
+// noopSender is a minimal transport stub that satisfies registry.MessageSender
+// so that registry.Register's nil-Sender guard passes in tests. It is not a
+// mock of a CFGMS business component — MessageSender is a low-level transport
+// interface whose production implementation is a gRPC stream that cannot be
+// instantiated in unit tests without a live gRPC server. Tests here validate
+// registry lookup behavior, not message delivery.
+type noopSender struct{}
+
+func (n *noopSender) SendMsg(_ interface{}) error { return nil }
+
+// TestHandleGetSteward_ConnectedSteward verifies that active_sessions == 1 and
+// connection_state == "connected" when the steward has an entry in the registry.
+func TestHandleGetSteward_ConnectedSteward(t *testing.T) {
+	server := setupTestServer(t)
+	apiKey := NewTestKey(t, server, []string{"steward:read"})
+
+	// Register the steward in the controller service so GetStewardInfo can find it.
+	stewardID := registerTestSteward(t, server.controllerService, map[string]string{
+		"hostname": "connected-host", "os": "linux",
+	})
+
+	// Wire a real InMemoryRegistry with the steward registered.
+	reg := registry.NewRegistry()
+	require.NoError(t, reg.Register(&registry.StewardConnection{
+		StewardID:   stewardID,
+		Sender:      &noopSender{},
+		ConnectedAt: time.Now(),
+	}))
+	server.SetRegistry(reg)
+
+	req := httptest.NewRequest("GET", "/api/v1/stewards/"+stewardID, nil)
+	req.Header.Set("X-API-Key", apiKey)
+	rec := httptest.NewRecorder()
+	server.router.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	var resp struct {
+		Data StewardInfo `json:"data"`
+	}
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
+	assert.Equal(t, stewardID, resp.Data.ID)
+	assert.NotEmpty(t, resp.Data.Status)
+	assert.Equal(t, 1, resp.Data.ActiveSessions)
+	assert.Equal(t, "connected", resp.Data.ConnectionState)
+}
+
+// TestHandleGetSteward_DisconnectedSteward verifies that active_sessions == 0 and
+// connection_state == "disconnected" when the steward is not in the registry.
+func TestHandleGetSteward_DisconnectedSteward(t *testing.T) {
+	server := setupTestServer(t)
+	apiKey := NewTestKey(t, server, []string{"steward:read"})
+
+	// Register the steward in the controller service but not in the connection registry.
+	stewardID := registerTestSteward(t, server.controllerService, map[string]string{
+		"hostname": "disconnected-host", "os": "linux",
+	})
+
+	// Wire a real InMemoryRegistry with no entry for this steward.
+	reg := registry.NewRegistry()
+	server.SetRegistry(reg)
+
+	req := httptest.NewRequest("GET", "/api/v1/stewards/"+stewardID, nil)
+	req.Header.Set("X-API-Key", apiKey)
+	rec := httptest.NewRecorder()
+	server.router.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	var resp struct {
+		Data StewardInfo `json:"data"`
+	}
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
+	assert.Equal(t, stewardID, resp.Data.ID)
+	assert.NotEmpty(t, resp.Data.Status)
+	assert.Equal(t, 0, resp.Data.ActiveSessions)
+	assert.Equal(t, "disconnected", resp.Data.ConnectionState)
+}
+
+// TestHandleGetSteward_NilRegistry verifies that active_sessions == 0 and
+// connection_state == "disconnected" when no registry is wired (OSS single-node).
+func TestHandleGetSteward_NilRegistry(t *testing.T) {
+	server := setupTestServer(t)
+	apiKey := NewTestKey(t, server, []string{"steward:read"})
+
+	stewardID := registerTestSteward(t, server.controllerService, map[string]string{
+		"hostname": "no-registry-host", "os": "linux",
+	})
+	// registry is nil by default in setupTestServer — no SetRegistry call.
+
+	req := httptest.NewRequest("GET", "/api/v1/stewards/"+stewardID, nil)
+	req.Header.Set("X-API-Key", apiKey)
+	rec := httptest.NewRecorder()
+	server.router.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	var resp struct {
+		Data StewardInfo `json:"data"`
+	}
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
+	assert.Equal(t, stewardID, resp.Data.ID)
+	assert.NotEmpty(t, resp.Data.Status)
+	assert.Equal(t, 0, resp.Data.ActiveSessions)
+	assert.Equal(t, "disconnected", resp.Data.ConnectionState)
 }
 
 // TestServer_ConfigStatusRouteDeregistered verifies that GET /api/v1/stewards/{id}/config/status

--- a/features/controller/api/server.go
+++ b/features/controller/api/server.go
@@ -34,6 +34,7 @@ import (
 	"github.com/cfgis/cfgms/pkg/registration"
 	secretsif "github.com/cfgis/cfgms/pkg/secrets/interfaces"
 	_ "github.com/cfgis/cfgms/pkg/secrets/providers/sops" // Auto-register SOPS provider
+	"github.com/cfgis/cfgms/pkg/transport/registry"
 )
 
 // Server represents the REST API server component of the controller
@@ -70,6 +71,7 @@ type Server struct {
 	scriptAuditLogger       *script.AuditLogger            // Issue #708: in-memory execution metrics
 	scriptMonitor           *script.ExecutionMonitor       // Issue #708: active execution tracking
 	pushLeaderStatus        leaderStatus                   // Issue #1318: leader check for config push (nil = leader)
+	registry                registry.Registry              // Issue #1323: active steward connection registry
 	stopCleanup             chan struct{}                  // signals startAPIKeyCleanup to exit
 	cleanupDone             chan struct{}                  // closed when cleanup goroutine exits
 	closeOnce               sync.Once                      // idempotent Close
@@ -551,6 +553,15 @@ func (s *Server) SetScriptModule(tracker script.ExecutionTracker, auditLogger *s
 	s.scriptTracker = tracker
 	s.scriptAuditLogger = auditLogger
 	s.scriptMonitor = monitor
+}
+
+// SetRegistry wires the active-steward connection registry so that
+// GET /api/v1/stewards/{id} can report connection_state and active_sessions
+// (Issue #1323). Call this after New() returns but before Start() is called.
+func (s *Server) SetRegistry(r registry.Registry) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.registry = r
 }
 
 // SetGitSyncWebhookHandler registers the git-sync push-event webhook handler.

--- a/features/controller/api/types.go
+++ b/features/controller/api/types.go
@@ -30,13 +30,18 @@ type APIError struct {
 
 // StewardInfo represents steward information for API responses
 type StewardInfo struct {
-	ID          string            `json:"id"`
-	Status      string            `json:"status"`
-	LastSeen    time.Time         `json:"last_seen"`
-	Version     string            `json:"version"`
-	ConnectedAt time.Time         `json:"connected_at"`
-	Metrics     map[string]string `json:"metrics,omitempty"`
-	DNA         *DNAInfo          `json:"dna,omitempty"`
+	ID              string            `json:"id"`
+	Status          string            `json:"status"`
+	LastSeen        time.Time         `json:"last_seen"`
+	Version         string            `json:"version"`
+	ConnectedAt     time.Time         `json:"connected_at"`
+	Metrics         map[string]string `json:"metrics,omitempty"`
+	DNA             *DNAInfo          `json:"dna,omitempty"`
+	// ActiveSessions is 1 when the steward has an active ControlChannel stream,
+	// 0 otherwise. Each steward holds at most one stream at a time, so this is
+	// a binary sentinel, not a real connection count.
+	ActiveSessions  int    `json:"active_sessions"`
+	ConnectionState string `json:"connection_state"` // "connected" or "disconnected"
 }
 
 // DNAInfo represents DNA information for API responses


### PR DESCRIPTION
## Summary

- Adds `active_sessions` (int, binary sentinel: 1=connected, 0=not) and `connection_state` (string: "connected"/"disconnected") to the `GET /api/v1/stewards/{id}` JSON response
- Wires a `registry.Registry` into the API server via a new `SetRegistry` setter so `handleGetSteward` can look up live connection state
- Nil-registry guard ensures OSS single-node deployments that do not wire the registry default safely to disconnected

## Test plan

- [ ] `TestHandleGetSteward_ConnectedSteward` — real `InMemoryRegistry` with steward registered → `active_sessions=1`, `connection_state="connected"`, correct `id` and `status`
- [ ] `TestHandleGetSteward_DisconnectedSteward` — registry wired but no entry for steward → `active_sessions=0`, `connection_state="disconnected"`
- [ ] `TestHandleGetSteward_NilRegistry` — no registry wired (OSS default) → `active_sessions=0`, `connection_state="disconnected"`
- [ ] Full package test suite: all 247 tests in `features/controller/api` pass

## Specialist review results

| Reviewer | Result |
|----------|--------|
| QA test runner | PASS — all functional gates green; Trivy DNS failure is sandbox network constraint, not a code issue |
| QA code reviewer | PASS (after one fix round: added binary-sentinel doc comment, noopSender rationale comment, and full response-shape assertions in tests) |
| Security engineer | PASS — 0 blocking issues, correct lock ordering, no information disclosure, no central provider violations |

Fixes #1323

🤖 Generated with [Claude Code](https://claude.com/claude-code)