### PR TITLE
ha: remove debug/scaffold noise from commercial/ha (Issue #1301)

### DIFF
--- a/commercial/ha/config.go
+++ b/commercial/ha/config.go
@@ -12,8 +12,6 @@ import (
 	"strconv"
 	"strings"
 	"time"
-
-	"github.com/cfgis/cfgms/pkg/logging"
 )
 
 // NOTE: All type definitions (Config, NodeConfig, ClusterConfig, etc.) are now in types.go
@@ -28,25 +26,12 @@ func DefaultConfig() *Config {
 			Capabilities: []string{"config", "rbac", "monitoring", "workflow"},
 		},
 		Cluster: ClusterConfig{
-			ExpectedSize:        3,
-			MinQuorum:           2,
-			ElectionTimeout:     10 * time.Second,
-			HeartbeatInterval:   2 * time.Second,
-			LeaderLeaseDuration: 15 * time.Second,
-			CandidateTimeout:    5 * time.Second,
-			ApplyTimeout:        2 * time.Second,
+			ExpectedSize:      3,
+			MinQuorum:         2,
+			ElectionTimeout:   10 * time.Second,
+			HeartbeatInterval: 2 * time.Second,
 			Discovery: &DiscoveryConfig{
-				Method:      "static",
-				Config:      make(map[string]interface{}),
-				Interval:    30 * time.Second,
-				NodeTimeout: 60 * time.Second,
-				Geographic: &GeographicDiscoveryConfig{
-					EnableRegionAffinity:         true,
-					CrossRegionTimeoutMultiplier: 2.0,
-					MaxCrossRegionLatency:        500 * time.Millisecond,
-					LatencyCheckInterval:         60 * time.Second,
-					RegionalWeights:              make(map[string]float64),
-				},
+				Config: make(map[string]interface{}),
 			},
 		},
 		HealthCheck: &HealthCheckConfig{
@@ -82,9 +67,6 @@ func DefaultConfig() *Config {
 
 // LoadFromEnvironment loads HA configuration from environment variables
 func (c *Config) LoadFromEnvironment() error {
-	logger := logging.NewLogger("debug")
-	logger.Info("HA Config Loading - Starting LoadFromEnvironment")
-
 	// Load deployment mode
 	if mode := os.Getenv("CFGMS_HA_MODE"); mode != "" {
 		switch strings.ToLower(mode) {
@@ -154,45 +136,10 @@ func (c *Config) LoadFromEnvironment() error {
 		}
 	}
 
-	if nodeTimeout := os.Getenv("CFGMS_HA_NODE_TIMEOUT"); nodeTimeout != "" {
-		if timeout, err := time.ParseDuration(nodeTimeout); err == nil {
-			c.Cluster.Discovery.NodeTimeout = timeout
-		}
-	}
-
-	if discoveryInterval := os.Getenv("CFGMS_HA_DISCOVERY_INTERVAL"); discoveryInterval != "" {
-		if interval, err := time.ParseDuration(discoveryInterval); err == nil {
-			c.Cluster.Discovery.Interval = interval
-		}
-	}
-
-	if leaderLease := os.Getenv("CFGMS_HA_LEADER_LEASE_DURATION"); leaderLease != "" {
-		if duration, err := time.ParseDuration(leaderLease); err == nil {
-			c.Cluster.LeaderLeaseDuration = duration
-		}
-	}
-
-	if candidateTimeout := os.Getenv("CFGMS_HA_CANDIDATE_TIMEOUT"); candidateTimeout != "" {
-		if timeout, err := time.ParseDuration(candidateTimeout); err == nil {
-			c.Cluster.CandidateTimeout = timeout
-		}
-	}
-
-	if applyTimeout := os.Getenv("CFGMS_HA_APPLY_TIMEOUT"); applyTimeout != "" {
-		if timeout, err := time.ParseDuration(applyTimeout); err == nil {
-			c.Cluster.ApplyTimeout = timeout
-		}
-	}
-
 	if healthInterval := os.Getenv("CFGMS_HA_HEALTH_CHECK_INTERVAL"); healthInterval != "" {
 		if interval, err := time.ParseDuration(healthInterval); err == nil {
 			c.HealthCheck.Interval = interval
 		}
-	}
-
-	// Load discovery configuration
-	if discoveryMethod := os.Getenv("CFGMS_HA_DISCOVERY_METHOD"); discoveryMethod != "" {
-		c.Cluster.Discovery.Method = discoveryMethod
 	}
 
 	// Load cluster nodes for static discovery
@@ -256,13 +203,6 @@ func (c *Config) LoadFromEnvironment() error {
 		}
 	}
 
-	logger.Info("HA Config Loading - Completed LoadFromEnvironment",
-		"node_id", c.Node.ID,
-		"node_region", c.Node.Region,
-		"node_name", c.Node.Name,
-		"mode", c.GetModeString(),
-		"node_id_empty", c.Node.ID == "")
-
 	return nil
 }
 
@@ -290,18 +230,6 @@ func (c *Config) Validate() error {
 
 		if c.Cluster.HeartbeatInterval <= 0 {
 			return fmt.Errorf("heartbeat interval must be positive")
-		}
-
-		if c.Cluster.LeaderLeaseDuration <= 0 {
-			return fmt.Errorf("leader lease duration must be positive")
-		}
-
-		if c.Cluster.CandidateTimeout <= 0 {
-			return fmt.Errorf("candidate timeout must be positive")
-		}
-
-		if c.Cluster.ApplyTimeout <= 0 {
-			return fmt.Errorf("apply timeout must be positive")
 		}
 
 		if c.Cluster.Discovery == nil {

--- a/commercial/ha/failover.go
+++ b/commercial/ha/failover.go
@@ -276,7 +276,7 @@ func (fm *failoverManager) executeFailover(ctx context.Context, reason string, m
 	// Execute failover steps
 	var failoverErr error
 
-	// Step 1: Elect new leader (if in cluster mode)
+	// Elect new leader (if in cluster mode)
 	if fm.manager.cfg.Mode == ClusterMode {
 		if err := fm.electNewLeader(ctx); err != nil {
 			failoverErr = fmt.Errorf("leader election failed: %w", err)
@@ -288,7 +288,7 @@ func (fm *failoverManager) executeFailover(ctx context.Context, reason string, m
 
 	sessionsMigrated := 0
 
-	// Step 3: Update cluster state
+	// Update cluster state after leader election
 	if failoverErr == nil {
 		if err := fm.updateClusterState(ctx); err != nil {
 			fm.logger.Warn("Cluster state update failed", "error", err)
@@ -358,8 +358,6 @@ func (fm *failoverManager) electNewLeader(ctx context.Context) error {
 
 // updateClusterState updates cluster state after failover
 func (fm *failoverManager) updateClusterState(ctx context.Context) error {
-	// Update local node state and propagate to cluster
-	// In a production implementation, this would update distributed state
 	return nil
 }
 

--- a/commercial/ha/manager.go
+++ b/commercial/ha/manager.go
@@ -426,24 +426,24 @@ func (m *Manager) initializeRaftConsensus() error {
 	// Use a simple hash of the node ID string
 	nodeID := hashStringToUint64(m.nodeInfo.ID)
 
-	m.logger.Debug("RAFT_INIT: Starting Raft consensus initialization",
+	m.logger.Debug("Starting Raft consensus initialization",
 		"node_id_string", m.nodeInfo.ID, "node_id_uint64", nodeID, "node_address", m.nodeInfo.Address)
 
 	// Build peer list from cluster configuration
 	peers := make([]raft.Peer, 0)
 
 	// Parse cluster nodes from config
-	m.logger.Debug("RAFT_INIT: Parsing cluster nodes from config", "config_nil", m.cfg.Cluster.Discovery.Config == nil)
+	m.logger.Debug("Parsing cluster nodes from config", "config_nil", m.cfg.Cluster.Discovery.Config == nil)
 
 	// seenHashes guards against node ID hash collisions before they can silently alias
 	// two distinct nodes to the same Raft peer ID.
 	seenHashes := make(map[uint64]string) // hash → original string ID
 
 	if clusterNodes := m.cfg.Cluster.Discovery.Config["nodes"]; clusterNodes != nil {
-		m.logger.Debug("RAFT_INIT: Found cluster nodes in config", "type", fmt.Sprintf("%T", clusterNodes))
+		m.logger.Debug("Found cluster nodes in config", "type", fmt.Sprintf("%T", clusterNodes))
 		// Try both []interface{} and []map[string]interface{} type assertions
 		if nodes, ok := clusterNodes.([]interface{}); ok {
-			m.logger.Debug("RAFT_INIT: Cluster nodes is []interface{}", "count", len(nodes))
+			m.logger.Debug("Cluster nodes is []interface{}", "count", len(nodes))
 			for i, n := range nodes {
 				if nodeMap, ok := n.(map[string]interface{}); ok {
 					if id, ok := nodeMap["id"].(string); ok {
@@ -456,12 +456,12 @@ func (m *Manager) initializeRaftConsensus() error {
 							ID:      peerID,
 							Context: []byte(id), // Store original string ID
 						})
-						m.logger.Debug("RAFT_INIT: Added peer to list", "index", i, "peer_id_string", id, "peer_id_uint64", peerID)
+						m.logger.Debug("Added peer to list", "index", i, "peer_id_string", id, "peer_id_uint64", peerID)
 					}
 				}
 			}
 		} else if nodes, ok := clusterNodes.([]map[string]interface{}); ok {
-			m.logger.Debug("RAFT_INIT: Cluster nodes is []map[string]interface{}", "count", len(nodes))
+			m.logger.Debug("Cluster nodes is []map[string]interface{}", "count", len(nodes))
 			for i, nodeMap := range nodes {
 				if id, ok := nodeMap["id"].(string); ok {
 					peerID := hashStringToUint64(id)
@@ -473,14 +473,14 @@ func (m *Manager) initializeRaftConsensus() error {
 						ID:      peerID,
 						Context: []byte(id), // Store original string ID
 					})
-					m.logger.Debug("RAFT_INIT: Added peer to list", "index", i, "peer_id_string", id, "peer_id_uint64", peerID)
+					m.logger.Debug("Added peer to list", "index", i, "peer_id_string", id, "peer_id_uint64", peerID)
 				}
 			}
 		} else {
-			m.logger.Debug("RAFT_INIT: Cluster nodes has unexpected type", "type", fmt.Sprintf("%T", clusterNodes))
+			m.logger.Debug("Cluster nodes has unexpected type", "type", fmt.Sprintf("%T", clusterNodes))
 		}
 	} else {
-		m.logger.Debug("RAFT_INIT: No cluster nodes found in config")
+		m.logger.Debug("No cluster nodes found in config")
 	}
 
 	// Create Raft consensus
@@ -496,7 +496,7 @@ func (m *Manager) initializeRaftConsensus() error {
 		var readErr error
 		caCertPEM, readErr = os.ReadFile(m.cfg.CACertPath)
 		if readErr != nil {
-			m.logger.Warn("RAFT_INIT: Failed to read CA cert", "path", m.cfg.CACertPath, "error", readErr)
+			m.logger.Warn("Failed to read CA cert", "path", m.cfg.CACertPath, "error", readErr)
 		}
 	}
 
@@ -527,12 +527,12 @@ func (m *Manager) initializeRaftConsensus() error {
 	m.raftConsensus.SetTransport(transport)
 
 	// Add peer addresses to transport
-	m.logger.Debug("RAFT_INIT: Configuring peer addresses for transport")
+	m.logger.Debug("Configuring peer addresses for transport")
 	peerCount := 0
 	if clusterNodes := m.cfg.Cluster.Discovery.Config["nodes"]; clusterNodes != nil {
 		// Try both []interface{} and []map[string]interface{} type assertions
 		if nodes, ok := clusterNodes.([]interface{}); ok {
-			m.logger.Debug("RAFT_INIT: Processing peer addresses ([]interface{})", "total_nodes", len(nodes))
+			m.logger.Debug("Processing peer addresses ([]interface{})", "total_nodes", len(nodes))
 			for i, n := range nodes {
 				if nodeMap, ok := n.(map[string]interface{}); ok {
 					if id, ok := nodeMap["id"].(string); ok {
@@ -541,19 +541,19 @@ func (m *Manager) initializeRaftConsensus() error {
 							if peerID != nodeID { // Don't add self
 								transport.AddPeer(peerID, addr)
 								peerCount++
-								m.logger.Debug("RAFT_INIT: Added peer address to transport",
+								m.logger.Debug("Added peer address to transport",
 									"index", i, "peer_id_string", id, "peer_id_uint64", peerID, "address", addr)
 							} else {
-								m.logger.Debug("RAFT_INIT: Skipped self in peer list", "node_id", id)
+								m.logger.Debug("Skipped self in peer list", "node_id", id)
 							}
 						} else {
-							m.logger.Debug("RAFT_INIT: Node missing address", "index", i, "node_id", id)
+							m.logger.Debug("Node missing address", "index", i, "node_id", id)
 						}
 					}
 				}
 			}
 		} else if nodes, ok := clusterNodes.([]map[string]interface{}); ok {
-			m.logger.Debug("RAFT_INIT: Processing peer addresses ([]map)", "total_nodes", len(nodes))
+			m.logger.Debug("Processing peer addresses ([]map)", "total_nodes", len(nodes))
 			for i, nodeMap := range nodes {
 				if id, ok := nodeMap["id"].(string); ok {
 					if addr, ok := nodeMap["address"].(string); ok {
@@ -561,20 +561,20 @@ func (m *Manager) initializeRaftConsensus() error {
 						if peerID != nodeID { // Don't add self
 							transport.AddPeer(peerID, addr)
 							peerCount++
-							m.logger.Debug("RAFT_INIT: Added peer address to transport",
+							m.logger.Debug("Added peer address to transport",
 								"index", i, "peer_id_string", id, "peer_id_uint64", peerID, "address", addr)
 						} else {
-							m.logger.Debug("RAFT_INIT: Skipped self in peer list", "node_id", id)
+							m.logger.Debug("Skipped self in peer list", "node_id", id)
 						}
 					} else {
-						m.logger.Debug("RAFT_INIT: Node missing address", "index", i, "node_id", id)
+						m.logger.Debug("Node missing address", "index", i, "node_id", id)
 					}
 				}
 			}
 		}
 	}
 
-	m.logger.Debug("RAFT_INIT: Raft consensus initialized",
+	m.logger.Debug("Raft consensus initialized",
 		"node_id", nodeID, "total_peers", len(peers), "configured_peer_addresses", peerCount)
 
 	return nil

--- a/commercial/ha/manager_test.go
+++ b/commercial/ha/manager_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/cfgis/cfgms/pkg/logging"
+	pkgtesting "github.com/cfgis/cfgms/pkg/testing"
 	"github.com/cfgis/cfgms/pkg/testing/storage"
 )
 
@@ -56,8 +57,8 @@ func TestManager_initRaft_logsInitStart(t *testing.T) {
 	cfg.Mode = ClusterMode
 	cfg.Node.ID = "test-node-init-raft"
 
-	logger := logging.GetLogger()
-	manager, err := NewManager(cfg, logger, storageManager)
+	mock := pkgtesting.NewMockLogger(true)
+	manager, err := NewManager(cfg, mock, storageManager)
 	require.NoError(t, err)
 	require.NotNil(t, manager)
 
@@ -73,6 +74,23 @@ func TestManager_initRaft_logsInitStart(t *testing.T) {
 	expectedID := hashStringToUint64(cfg.Node.ID)
 	assert.Equal(t, expectedID, manager.raftConsensus.nodeID,
 		"raftConsensus nodeID must be the fnv hash of the config node ID string")
+
+	// Verify the init log uses structured key-value fields with no "RAFT_INIT:" prefix.
+	debugLogs := mock.GetLogs("debug")
+	var found bool
+	for _, entry := range debugLogs {
+		if entry.Message == "Starting Raft consensus initialization" {
+			for i := 0; i < len(entry.Data)-1; i += 2 {
+				if k, ok := entry.Data[i].(string); ok && k == "node_id_string" {
+					found = true
+					break
+				}
+			}
+		}
+	}
+	assert.True(t, found,
+		"expected a debug log with message 'Starting Raft consensus initialization' and 'node_id_string' key; got debug logs: %v",
+		debugLogs)
 }
 
 func TestManager_SingleServerMode(t *testing.T) {

--- a/commercial/ha/raft_consensus.go
+++ b/commercial/ha/raft_consensus.go
@@ -141,21 +141,21 @@ func NewRaftConsensus(ctx context.Context, nodeID uint64, nodeInfo *NodeInfo, pe
 	if len(peers) > 0 {
 		// Starting a new cluster
 		rc.node = raft.StartNode(config, peers)
-		logger.Info("RAFT: Started new Raft node", "node_id", nodeID, "peers", peers)
+		logger.Info("Started new Raft node", "node_id", nodeID, "peers", peers)
 
 		// Log Raft status immediately after start
 		status := rc.node.Status()
-		logger.Debug("RAFT: Initial status after StartNode",
+		logger.Debug("Initial status after StartNode",
 			"node_id", nodeID, "term", status.Term, "lead", status.Lead, "raft_state", status.RaftState)
 	} else {
 		// Joining existing cluster (will be added via ConfChange)
 		rc.node = raft.RestartNode(config)
-		logger.Info("RAFT: Restarted Raft node", "node_id", nodeID)
+		logger.Info("Restarted Raft node", "node_id", nodeID)
 	}
 
 	// CRITICAL: Start the Raft processing loop IMMEDIATELY
 	// The Ready channel must be consumed or Raft will block
-	logger.Debug("RAFT: Starting Raft processing loop immediately", "node_id", nodeID)
+	logger.Debug("Starting Raft processing loop immediately", "node_id", nodeID)
 	rc.wg.Add(1)
 	go rc.runRaft()
 
@@ -172,7 +172,7 @@ func (rc *RaftConsensus) SetTransport(t *raftTransport) {
 
 // Start begins the Raft consensus engine
 func (rc *RaftConsensus) Start() error {
-	rc.logger.Info("RAFT: Starting Raft consensus engine", "node_id", rc.nodeID)
+	rc.logger.Info("Starting Raft consensus engine", "node_id", rc.nodeID)
 
 	// Note: runRaft() goroutine is already started in NewRaftConsensus()
 	// to ensure Ready channel is consumed immediately
@@ -199,7 +199,7 @@ func (rc *RaftConsensus) Start() error {
 // internal channels (e.g. proposeC) once Stop returns.
 func (rc *RaftConsensus) Stop() error {
 	rc.stopOnce.Do(func() {
-		rc.logger.Info("RAFT: Stopping Raft consensus engine", "node_id", rc.nodeID)
+		rc.logger.Info("Stopping Raft consensus engine", "node_id", rc.nodeID)
 		close(rc.stopC)
 		rc.cancel()
 		rc.mu.RLock()
@@ -221,56 +221,39 @@ func (rc *RaftConsensus) runRaft() {
 	ticker := time.NewTicker(rc.tickInterval)
 	defer ticker.Stop()
 
-	rc.logger.Debug("RAFT: Main Raft loop started", "node_id", rc.nodeID)
-	tickCount := 0
-	loopCount := 0
-
-	// Debug timer to see if select is blocking
-	debugTicker := time.NewTicker(5 * time.Second)
-	defer debugTicker.Stop()
+	rc.logger.Debug("Raft loop started", "node_id", rc.nodeID)
 
 	for {
-		loopCount++
-		if loopCount%100 == 0 {
-			rc.logger.Debug("RAFT: Loop iteration", "count", loopCount, "node_id", rc.nodeID)
-		}
-
 		select {
 		case <-ticker.C:
-			tickCount++
-			rc.logger.Debug("RAFT: Tick START", "tick", tickCount, "node_id", rc.nodeID)
 			rc.node.Tick()
-			rc.logger.Debug("RAFT: Tick COMPLETE", "tick", tickCount, "node_id", rc.nodeID)
-
-		case <-debugTicker.C:
-			// Periodic health check
 
 		case rd := <-rc.node.Ready():
 			// Process Ready updates from Raft
-			rc.logger.Debug("RAFT: Processing Ready",
+			rc.logger.Debug("Processing Ready",
 				"node_id", rc.nodeID, "entries", len(rd.Entries), "messages", len(rd.Messages), "has_snapshot", !raft.IsEmptySnap(rd.Snapshot))
 			rc.processReady(rd)
 
 		case prop := <-rc.proposeC:
 			// Propose new entry to Raft log
-			rc.logger.Debug("RAFT: Received proposal", "node_id", rc.nodeID)
+			rc.logger.Debug("Received proposal", "node_id", rc.nodeID)
 			if err := rc.node.Propose(rc.ctx, prop); err != nil {
 				rc.logger.Error("Failed to propose to Raft", "error", err)
 			}
 
 		case cc := <-rc.confChangeC:
 			// Propose configuration change
-			rc.logger.Debug("RAFT: Received conf change", "node_id", rc.nodeID)
+			rc.logger.Debug("Received conf change", "node_id", rc.nodeID)
 			if err := rc.node.ProposeConfChange(rc.ctx, cc); err != nil {
 				rc.logger.Error("Failed to propose conf change", "error", err)
 			}
 
 		case <-rc.stopC:
-			rc.logger.Debug("RAFT: Raft loop stopping", "node_id", rc.nodeID)
+			rc.logger.Debug("Raft loop stopping", "node_id", rc.nodeID)
 			return
 
 		case <-rc.ctx.Done():
-			rc.logger.Debug("RAFT: Raft loop context cancelled", "node_id", rc.nodeID)
+			rc.logger.Debug("Raft loop context cancelled", "node_id", rc.nodeID)
 			return
 		}
 	}
@@ -278,30 +261,28 @@ func (rc *RaftConsensus) runRaft() {
 
 // processReady handles Ready struct from Raft
 func (rc *RaftConsensus) processReady(rd raft.Ready) {
-	rc.logger.Debug("RAFT: processReady START", "node_id", rc.nodeID)
-
 	// Save to storage before sending messages
 	if !raft.IsEmptySnap(rd.Snapshot) {
-		rc.logger.Debug("RAFT: Applying snapshot", "node_id", rc.nodeID)
+		rc.logger.Debug("Applying snapshot", "node_id", rc.nodeID)
 		if err := rc.storage.ApplySnapshot(rd.Snapshot); err != nil {
-			rc.logger.Error("RAFT: Failed to apply snapshot", "node_id", rc.nodeID, "error", err)
+			rc.logger.Error("Failed to apply snapshot", "node_id", rc.nodeID, "error", err)
 		}
 		rc.publishSnapshot(rd.Snapshot)
 	}
 
 	if len(rd.Entries) > 0 {
-		rc.logger.Debug("RAFT: Appending entries to storage", "count", len(rd.Entries), "node_id", rc.nodeID)
+		rc.logger.Debug("Appending entries to storage", "count", len(rd.Entries), "node_id", rc.nodeID)
 		if err := rc.storage.Append(rd.Entries); err != nil {
-			rc.logger.Error("RAFT: Failed to append entries", "node_id", rc.nodeID, "error", err)
+			rc.logger.Error("Failed to append entries", "node_id", rc.nodeID, "error", err)
 		}
 	}
 
 	if !raft.IsEmptyHardState(rd.HardState) {
 		hardState := rd.HardState
-		rc.logger.Debug("RAFT: Setting HardState",
+		rc.logger.Debug("Setting HardState",
 			"node_id", rc.nodeID, "term", hardState.Term, "vote", hardState.Vote, "commit", hardState.Commit)
 		if err := rc.storage.SetHardState(hardState); err != nil {
-			rc.logger.Error("RAFT: Failed to set hard state", "node_id", rc.nodeID, "error", err)
+			rc.logger.Error("Failed to set hard state", "node_id", rc.nodeID, "error", err)
 		}
 	}
 
@@ -310,28 +291,26 @@ func (rc *RaftConsensus) processReady(rd raft.Ready) {
 	transport := rc.transport
 	rc.mu.RUnlock()
 	if transport != nil && len(rd.Messages) > 0 {
-		rc.logger.Debug("RAFT: Sending messages to peers", "count", len(rd.Messages), "node_id", rc.nodeID)
+		rc.logger.Debug("Sending messages to peers", "count", len(rd.Messages), "node_id", rc.nodeID)
 		transport.Send(rd.Messages)
 	}
 
 	// Apply committed entries to state machine
 	if len(rd.CommittedEntries) > 0 {
-		rc.logger.Debug("RAFT: Applying committed entries", "count", len(rd.CommittedEntries), "node_id", rc.nodeID)
+		rc.logger.Debug("Applying committed entries", "count", len(rd.CommittedEntries), "node_id", rc.nodeID)
 		rc.publishEntries(rc.entriesToApply(rd.CommittedEntries))
 	}
 
 	// Update leadership
 	if rd.SoftState != nil {
 		softState := rd.SoftState
-		rc.logger.Debug("RAFT: Updating leadership",
+		rc.logger.Debug("Updating leadership",
 			"node_id", rc.nodeID, "lead", softState.Lead, "raft_state", softState.RaftState)
 		rc.updateLeadership(softState)
 	}
 
 	// Advance the Raft state machine
-	rc.logger.Debug("RAFT: Calling Advance()", "node_id", rc.nodeID)
 	rc.node.Advance()
-	rc.logger.Debug("RAFT: processReady COMPLETE", "node_id", rc.nodeID)
 }
 
 // entriesToApply filters out entries that have already been applied
@@ -347,12 +326,12 @@ func (rc *RaftConsensus) entriesToApply(entries []raftpb.Entry) []raftpb.Entry {
 	firstIdx := entries[0].Index
 	lastIdx := entries[len(entries)-1].Index
 
-	rc.logger.Debug("RAFT: entriesToApply check",
+	rc.logger.Debug("entriesToApply check",
 		"node_id", rc.nodeID, "firstIdx", firstIdx, "lastIdx", lastIdx, "appliedIndex", rc.appliedIndex)
 
 	// If we've already applied all these entries, skip them
 	if lastIdx <= rc.appliedIndex {
-		rc.logger.Debug("RAFT: All entries already applied", "node_id", rc.nodeID)
+		rc.logger.Debug("All entries already applied", "node_id", rc.nodeID)
 		return nil
 	}
 
@@ -361,7 +340,7 @@ func (rc *RaftConsensus) entriesToApply(entries []raftpb.Entry) []raftpb.Entry {
 	if firstIdx <= rc.appliedIndex {
 		// Some entries at the beginning have already been applied
 		offset = rc.appliedIndex + 1 - firstIdx
-		rc.logger.Debug("RAFT: Skipping already-applied entries", "count", offset, "node_id", rc.nodeID)
+		rc.logger.Debug("Skipping already-applied entries", "count", offset, "node_id", rc.nodeID)
 	}
 
 	if offset >= uint64(len(entries)) {
@@ -384,13 +363,13 @@ func (rc *RaftConsensus) publishEntries(entries []raftpb.Entry) {
 
 			// Apply command to state machine
 			if err := rc.applyCommand(entry.Data); err != nil {
-				rc.logger.Error("RAFT: Failed to apply command", "error", err)
+				rc.logger.Error("Failed to apply command", "error", err)
 			}
 
 		case raftpb.EntryConfChange:
 			var cc raftpb.ConfChange
 			if err := cc.Unmarshal(entry.Data); err != nil {
-				rc.logger.Error("RAFT: Failed to unmarshal conf change", "error", err)
+				rc.logger.Error("Failed to unmarshal conf change", "error", err)
 				continue
 			}
 
@@ -398,9 +377,9 @@ func (rc *RaftConsensus) publishEntries(entries []raftpb.Entry) {
 
 			switch cc.Type {
 			case raftpb.ConfChangeAddNode:
-				rc.logger.Info("RAFT: Added node to cluster", "node_id", cc.NodeID)
+				rc.logger.Info("Added node to cluster", "node_id", cc.NodeID)
 			case raftpb.ConfChangeRemoveNode:
-				rc.logger.Info("RAFT: Removed node from cluster", "node_id", cc.NodeID)
+				rc.logger.Info("Removed node from cluster", "node_id", cc.NodeID)
 				rc.clusterState.mu.Lock()
 				delete(rc.clusterState.Nodes, cc.NodeID)
 				rc.clusterState.mu.Unlock()
@@ -411,7 +390,7 @@ func (rc *RaftConsensus) publishEntries(entries []raftpb.Entry) {
 		rc.mu.Lock()
 		if entry.Index > rc.appliedIndex {
 			rc.appliedIndex = entry.Index
-			rc.logger.Debug("RAFT: Updated appliedIndex", "applied_index", rc.appliedIndex, "node_id", rc.nodeID)
+			rc.logger.Debug("Updated appliedIndex", "applied_index", rc.appliedIndex, "node_id", rc.nodeID)
 		}
 		rc.mu.Unlock()
 	}
@@ -449,7 +428,7 @@ func (rc *RaftConsensus) applyNodeUpdate(data interface{}) error {
 	rc.clusterState.LastModified = time.Now()
 	rc.clusterState.mu.Unlock()
 
-	rc.logger.Debug("RAFT: Applied node update", "node_id", update.NodeID, "node_info", update.NodeInfo)
+	rc.logger.Debug("Applied node update", "node_id", update.NodeID, "node_info", update.NodeInfo)
 
 	return nil
 }
@@ -460,11 +439,11 @@ func (rc *RaftConsensus) publishSnapshot(snapshot raftpb.Snapshot) {
 		return
 	}
 
-	rc.logger.Debug("RAFT: Publishing snapshot", "index", snapshot.Metadata.Index)
+	rc.logger.Debug("Publishing snapshot", "index", snapshot.Metadata.Index)
 
 	var state ClusterState
 	if err := json.Unmarshal(snapshot.Data, &state); err != nil {
-		rc.logger.Error("RAFT: Failed to unmarshal snapshot", "error", err)
+		rc.logger.Error("Failed to unmarshal snapshot", "error", err)
 		return
 	}
 
@@ -482,10 +461,10 @@ func (rc *RaftConsensus) updateLeadership(ss *raft.SoftState) {
 	isLeader := ss.Lead == rc.nodeID && ss.RaftState == raft.StateLeader
 
 	if !wasLeader && isLeader {
-		rc.logger.Info("RAFT: Node became LEADER", "node_id", rc.nodeID, "term", rc.node.Status().Term)
+		rc.logger.Info("Node became LEADER", "node_id", rc.nodeID, "term", rc.node.Status().Term)
 		rc.clusterState.Leader = rc.nodeID
 	} else if wasLeader && !isLeader {
-		rc.logger.Info("RAFT: Node lost LEADER status", "node_id", rc.nodeID, "new_leader", ss.Lead)
+		rc.logger.Info("Node lost LEADER status", "node_id", rc.nodeID, "new_leader", ss.Lead)
 		rc.clusterState.Leader = ss.Lead
 	}
 

--- a/commercial/ha/raft_transport.go
+++ b/commercial/ha/raft_transport.go
@@ -62,13 +62,13 @@ func newRaftTransport(nodeID uint64, address string, consensus *RaftConsensus, c
 		// Proper TLS validation with CA certificate
 		tlsConfig, err = cert.CreateClientTLSConfig(nil, nil, caCertPEM, "", tls.VersionTLS12)
 		if err != nil {
-			logger.Error("RAFT_TRANSPORT: Failed to create TLS config with CA cert, using basic TLS", "error", err)
+			logger.Error("Failed to create TLS config with CA cert, using basic TLS", "error", err)
 			tlsConfig, _ = cert.CreateBasicTLSConfig(nil, nil, tls.VersionTLS12)
 		}
 	} else {
 		// No CA cert available — use basic TLS without InsecureSkipVerify.
 		// Connections to peers will fail TLS validation (correct: don't run HA without proper certs).
-		logger.Warn("RAFT_TRANSPORT: No CA certificate configured for HA transport",
+		logger.Warn("No CA certificate configured for HA transport",
 			"hint", "Set CFGMS_HA_CA_CERT_PATH for proper TLS validation between cluster nodes")
 		tlsConfig, _ = cert.CreateBasicTLSConfig(nil, nil, tls.VersionTLS12)
 	}
@@ -114,7 +114,7 @@ func verifyPeerCN(r *http.Request, allowedCNs []string) error {
 // Start begins the transport layer
 func (t *raftTransport) Start(ctx context.Context) error {
 	t.ctx, t.cancel = context.WithCancel(ctx)
-	t.logger.Info("RAFT_TRANSPORT: Started transport", "node_id", t.nodeID, "address", t.address)
+	t.logger.Info("Started transport", "node_id", t.nodeID, "address", t.address)
 	return nil
 }
 
@@ -124,7 +124,7 @@ func (t *raftTransport) Stop() {
 		t.cancel()
 	}
 	close(t.stopC)
-	t.logger.Info("RAFT_TRANSPORT: Stopped transport", "node_id", t.nodeID)
+	t.logger.Info("Stopped transport", "node_id", t.nodeID)
 }
 
 // AddPeer adds a peer node address
@@ -132,7 +132,7 @@ func (t *raftTransport) AddPeer(nodeID uint64, address string) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 	t.peers[nodeID] = address
-	t.logger.Debug("RAFT_TRANSPORT: Added peer", "node_id", nodeID, "address", address)
+	t.logger.Debug("Added peer", "node_id", nodeID, "address", address)
 }
 
 // RemovePeer removes a peer node
@@ -140,7 +140,7 @@ func (t *raftTransport) RemovePeer(nodeID uint64) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 	delete(t.peers, nodeID)
-	t.logger.Debug("RAFT_TRANSPORT: Removed peer", "node_id", nodeID)
+	t.logger.Debug("Removed peer", "node_id", nodeID)
 }
 
 // Send sends messages to peer nodes
@@ -162,14 +162,14 @@ func (t *raftTransport) sendMessage(msg raftpb.Message) {
 	t.mu.RUnlock()
 
 	if !ok {
-		t.logger.Warn("RAFT_TRANSPORT: No address for peer", "peer_id", msg.To)
+		t.logger.Warn("No address for peer", "peer_id", msg.To)
 		return
 	}
 
 	// Serialize message
 	data, err := msg.Marshal()
 	if err != nil {
-		t.logger.Error("RAFT_TRANSPORT: Failed to marshal message", "error", err)
+		t.logger.Error("Failed to marshal message", "error", err)
 		return
 	}
 
@@ -183,7 +183,7 @@ func (t *raftTransport) sendMessage(msg raftpb.Message) {
 	// Send HTTP POST
 	req, err := http.NewRequestWithContext(t.ctx, "POST", url, bytes.NewReader(data))
 	if err != nil {
-		t.logger.Error("RAFT_TRANSPORT: Failed to create request", "error", err)
+		t.logger.Error("Failed to create request", "error", err)
 		return
 	}
 
@@ -192,66 +192,66 @@ func (t *raftTransport) sendMessage(msg raftpb.Message) {
 
 	resp, err := t.client.Do(req)
 	if err != nil {
-		t.logger.Error("RAFT_TRANSPORT: Failed to send message to peer", "peer_id", msg.To, "address", peerAddr, "error", err)
+		t.logger.Error("Failed to send message to peer", "peer_id", msg.To, "address", peerAddr, "error", err)
 		return
 	}
 	defer func() {
 		if err := resp.Body.Close(); err != nil {
-			t.logger.Error("RAFT_TRANSPORT: Failed to close response body", "peer_id", msg.To, "error", err)
+			t.logger.Error("Failed to close response body", "peer_id", msg.To, "error", err)
 		}
 	}()
 
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
-		t.logger.Warn("RAFT_TRANSPORT: Peer returned error", "peer_id", msg.To, "status", resp.StatusCode, "body", string(body))
+		t.logger.Warn("Peer returned error", "peer_id", msg.To, "status", resp.StatusCode, "body", string(body))
 	}
 }
 
 // HandleMessage processes incoming Raft messages (HTTP handler)
 func (t *raftTransport) HandleMessage(w http.ResponseWriter, r *http.Request) {
 	if err := verifyPeerCN(r, t.allowedCNs); err != nil {
-		t.logger.Warn("RAFT_TRANSPORT: Rejected message from unauthorized peer",
+		t.logger.Warn("Rejected message from unauthorized peer",
 			"remote_addr", r.RemoteAddr, "error", err)
 		http.Error(w, "Forbidden: peer certificate verification failed", http.StatusForbidden)
 		return
 	}
 
-	t.logger.Debug("RAFT_TRANSPORT: Received message HTTP request", "node_id", t.nodeID, "remote_addr", r.RemoteAddr)
+	t.logger.Debug("Received message HTTP request", "node_id", t.nodeID, "remote_addr", r.RemoteAddr)
 
 	// Read message body
 	data, err := io.ReadAll(r.Body)
 	if err != nil {
-		t.logger.Error("RAFT_TRANSPORT: Failed to read message body", "error", err)
+		t.logger.Error("Failed to read message body", "error", err)
 		http.Error(w, "Failed to read message", http.StatusBadRequest)
 		return
 	}
 	defer func() {
 		if err := r.Body.Close(); err != nil {
-			t.logger.Error("RAFT_TRANSPORT: Failed to close request body", "error", err)
+			t.logger.Error("Failed to close request body", "error", err)
 		}
 	}()
 
-	t.logger.Debug("RAFT_TRANSPORT: Read bytes from request body", "bytes", len(data))
+	t.logger.Debug("Read bytes from request body", "bytes", len(data))
 
 	// Deserialize message
 	var msg raftpb.Message
 	if err := msg.Unmarshal(data); err != nil {
-		t.logger.Error("RAFT_TRANSPORT: Failed to unmarshal message", "error", err)
+		t.logger.Error("Failed to unmarshal message", "error", err)
 		http.Error(w, "Failed to unmarshal message", http.StatusBadRequest)
 		return
 	}
 
-	t.logger.Debug("RAFT_TRANSPORT: Received Raft message",
+	t.logger.Debug("Received Raft message",
 		"node_id", t.nodeID, "from", msg.From, "to", msg.To, "type", msg.Type)
 
 	// Process message through Raft
 	if err := t.consensus.Process(r.Context(), msg); err != nil {
-		t.logger.Error("RAFT_TRANSPORT: Failed to process message from peer", "peer_id", msg.From, "error", err)
+		t.logger.Error("Failed to process message from peer", "peer_id", msg.From, "error", err)
 		http.Error(w, "Failed to process message", http.StatusInternalServerError)
 		return
 	}
 
-	t.logger.Debug("RAFT_TRANSPORT: Successfully processed message from peer", "peer_id", msg.From)
+	t.logger.Debug("Successfully processed message from peer", "peer_id", msg.From)
 	w.WriteHeader(http.StatusOK)
 }
 
@@ -276,6 +276,6 @@ func (t *raftTransport) HandleStatus(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", "application/json")
 	if err := json.NewEncoder(w).Encode(status); err != nil {
-		t.logger.Error("RAFT_TRANSPORT: Failed to encode status response", "error", err)
+		t.logger.Error("Failed to encode status response", "error", err)
 	}
 }

--- a/commercial/ha/raft_transport_test.go
+++ b/commercial/ha/raft_transport_test.go
@@ -13,7 +13,6 @@ import (
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"net/http/httptest"
-	"strings"
 	"testing"
 
 	"go.etcd.io/raft/v3/raftpb"
@@ -36,8 +35,14 @@ func TestRaftTransport_Start_logsStartup(t *testing.T) {
 
 	infoLogs := mock.GetLogs("info")
 	require.NotEmpty(t, infoLogs, "expected at least one info log after Start()")
-	assert.True(t, strings.Contains(infoLogs[0].Message, "RAFT_TRANSPORT"),
-		"startup log should contain RAFT_TRANSPORT, got: %s", infoLogs[0].Message)
+	var found bool
+	for _, entry := range infoLogs {
+		if entry.Message == "Started transport" {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found, "expected info log with message 'Started transport'; got: %v", infoLogs)
 }
 
 // makeFakePeerCert returns a minimal x509.Certificate with the given CN, suitable

--- a/commercial/ha/types.go
+++ b/commercial/ha/types.go
@@ -61,32 +61,16 @@ type GeographicCoordinates struct {
 
 // ClusterConfig contains cluster-wide configuration (commercial only)
 type ClusterConfig struct {
-	ExpectedSize        int              `yaml:"expected_size" json:"expected_size"`
-	MinQuorum           int              `yaml:"min_quorum" json:"min_quorum"`
-	ElectionTimeout     time.Duration    `yaml:"election_timeout" json:"election_timeout"`
-	HeartbeatInterval   time.Duration    `yaml:"heartbeat_interval" json:"heartbeat_interval"`
-	LeaderLeaseDuration time.Duration    `yaml:"leader_lease_duration" json:"leader_lease_duration"`
-	CandidateTimeout    time.Duration    `yaml:"candidate_timeout" json:"candidate_timeout"`
-	ApplyTimeout        time.Duration    `yaml:"apply_timeout" json:"apply_timeout"`
-	Discovery           *DiscoveryConfig `yaml:"discovery" json:"discovery"`
+	ExpectedSize      int              `yaml:"expected_size" json:"expected_size"`
+	MinQuorum         int              `yaml:"min_quorum" json:"min_quorum"`
+	ElectionTimeout   time.Duration    `yaml:"election_timeout" json:"election_timeout"`
+	HeartbeatInterval time.Duration    `yaml:"heartbeat_interval" json:"heartbeat_interval"`
+	Discovery         *DiscoveryConfig `yaml:"discovery" json:"discovery"`
 }
 
 // DiscoveryConfig contains node discovery configuration (commercial only)
 type DiscoveryConfig struct {
-	Method      string                     `yaml:"method" json:"method"`
-	Config      map[string]interface{}     `yaml:"config" json:"config"`
-	Interval    time.Duration              `yaml:"interval" json:"interval"`
-	NodeTimeout time.Duration              `yaml:"node_timeout" json:"node_timeout"`
-	Geographic  *GeographicDiscoveryConfig `yaml:"geographic,omitempty" json:"geographic,omitempty"`
-}
-
-// GeographicDiscoveryConfig contains geographic-aware discovery settings (commercial only)
-type GeographicDiscoveryConfig struct {
-	EnableRegionAffinity         bool               `yaml:"enable_region_affinity" json:"enable_region_affinity"`
-	CrossRegionTimeoutMultiplier float64            `yaml:"cross_region_timeout_multiplier" json:"cross_region_timeout_multiplier"`
-	MaxCrossRegionLatency        time.Duration      `yaml:"max_cross_region_latency" json:"max_cross_region_latency"`
-	LatencyCheckInterval         time.Duration      `yaml:"latency_check_interval" json:"latency_check_interval"`
-	RegionalWeights              map[string]float64 `yaml:"regional_weights,omitempty" json:"regional_weights,omitempty"`
+	Config map[string]interface{} `yaml:"config" json:"config"`
 }
 
 // FailoverConfig contains automatic failover configuration (commercial only)


### PR DESCRIPTION
## Summary

- Replace all `RAFT_INIT:`, `RAFT:`, `RAFT_TRANSPORT:` prefix strings in logger calls with plain descriptions and structured key-value fields
- Remove debug scaffolding from `raft_consensus.go`: `debugTicker`, per-tick bracket logs, loop/tick counters
- Delete two `logger.Info()` calls from `LoadFromEnvironment` (local logger created and immediately discarded)
- Remove the misleading "In a production implementation..." comment from `updateClusterState`
- Remove unread config struct fields from `types.go` (verified unreferenced via grep before deletion): `LeaderLeaseDuration`, `CandidateTimeout`, `ApplyTimeout`, `Discovery.{Method,Interval,NodeTimeout,Geographic}`, `GeographicDiscoveryConfig` type; clean up corresponding `DefaultConfig`/`LoadFromEnvironment`/`Validate()` code in `config.go`
- Update `TestManager_initRaft_logsInitStart` to use `MockLogger` and assert the new structured log format; fix `TestRaftTransport_Start_logsStartup` to check the prefix-free message via iteration

Fixes #1301

## Specialist Review Results

**QA Test Runner**: PASS — all code gates pass (unit tests, lint, license check, cross-platform builds, integration tests, architecture check); Trivy unavailable due to container network constraints (CI will run it)

**Security Engineer**: PASS — no security issues; `security-precommit`, `check-architecture`, and `staticcheck` all clean; no secrets, no central provider violations, no TLS regressions; `pkgtesting.MockLogger` confirmed as project-standard test logger

**QA Code Reviewer**: Blocking items found and fixed — removed `debugTicker` and per-tick scaffold logs from `raft_consensus.go`; fixed brittle `infoLogs[0]` index assumption to use iteration; removed step-number comment gap in `failover.go`. Note on MockLogger: pre-existing project-standard pattern already present in 4 tests before this story; story acceptance criteria explicitly require structured log assertions which necessitate it.

## Test plan

- [ ] `go test -tags commercial ./commercial/ha/...` passes
- [ ] `TestManager_initRaft_logsInitStart` asserts debug log with `Message == "Starting Raft consensus initialization"` and `"node_id_string"` key
- [ ] `TestRaftTransport_Start_logsStartup` asserts `"Started transport"` message without prefix
- [ ] No `RAFT_INIT:`, `RAFT:`, `RAFT_TRANSPORT:` strings remain in production log calls
- [ ] Removed fields confirmed unreferenced via grep before deletion

🤖 Generated with [Claude Code](https://claude.com/claude-code)