### PR TITLE
transport: add active_sessions and connection_state to Heartbeat proto + steward pipeline (Issue #1324)

### DIFF
--- a/api/proto/transport/control.pb.go
+++ b/api/proto/transport/control.pb.go
@@ -569,16 +569,18 @@ func (x *Event) GetSeverity() Severity {
 
 // Heartbeat is sent from steward to controller via ControlChannel.
 type Heartbeat struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	StewardId     string                 `protobuf:"bytes,1,opt,name=steward_id,json=stewardId,proto3" json:"steward_id,omitempty"`
-	TenantId      string                 `protobuf:"bytes,2,opt,name=tenant_id,json=tenantId,proto3" json:"tenant_id,omitempty"`
-	Status        StewardStatus          `protobuf:"varint,3,opt,name=status,proto3,enum=cfgms.transport.StewardStatus" json:"status,omitempty"`
-	Timestamp     *timestamppb.Timestamp `protobuf:"bytes,4,opt,name=timestamp,proto3" json:"timestamp,omitempty"`
-	Metrics       map[string]string      `protobuf:"bytes,5,rep,name=metrics,proto3" json:"metrics,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
-	Version       string                 `protobuf:"bytes,6,opt,name=version,proto3" json:"version,omitempty"`
-	DnaHash       string                 `protobuf:"bytes,7,opt,name=dna_hash,json=dnaHash,proto3" json:"dna_hash,omitempty"` // for hash-based sync detection
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	state           protoimpl.MessageState `protogen:"open.v1"`
+	StewardId       string                 `protobuf:"bytes,1,opt,name=steward_id,json=stewardId,proto3" json:"steward_id,omitempty"`
+	TenantId        string                 `protobuf:"bytes,2,opt,name=tenant_id,json=tenantId,proto3" json:"tenant_id,omitempty"`
+	Status          StewardStatus          `protobuf:"varint,3,opt,name=status,proto3,enum=cfgms.transport.StewardStatus" json:"status,omitempty"`
+	Timestamp       *timestamppb.Timestamp `protobuf:"bytes,4,opt,name=timestamp,proto3" json:"timestamp,omitempty"`
+	Metrics         map[string]string      `protobuf:"bytes,5,rep,name=metrics,proto3" json:"metrics,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	Version         string                 `protobuf:"bytes,6,opt,name=version,proto3" json:"version,omitempty"`
+	DnaHash         string                 `protobuf:"bytes,7,opt,name=dna_hash,json=dnaHash,proto3" json:"dna_hash,omitempty"`
+	ActiveSessions  int32                  `protobuf:"varint,8,opt,name=active_sessions,json=activeSessions,proto3" json:"active_sessions,omitempty"`
+	ConnectionState string                 `protobuf:"bytes,9,opt,name=connection_state,json=connectionState,proto3" json:"connection_state,omitempty"`
+	unknownFields   protoimpl.UnknownFields
+	sizeCache       protoimpl.SizeCache
 }
 
 func (x *Heartbeat) Reset() {
@@ -656,6 +658,20 @@ func (x *Heartbeat) GetVersion() string {
 func (x *Heartbeat) GetDnaHash() string {
 	if x != nil {
 		return x.DnaHash
+	}
+	return ""
+}
+
+func (x *Heartbeat) GetActiveSessions() int32 {
+	if x != nil {
+		return x.ActiveSessions
+	}
+	return 0
+}
+
+func (x *Heartbeat) GetConnectionState() string {
+	if x != nil {
+		return x.ConnectionState
 	}
 	return ""
 }
@@ -748,91 +764,72 @@ func (x *Response) GetDetails() map[string]string {
 var File_transport_control_proto protoreflect.FileDescriptor
 
 const file_transport_control_proto_rawDesc = "" +
-	"\n" +
-	"\x17transport/control.proto\x12\x0fcfgms.transport\x1a\x1fgoogle/protobuf/timestamp.proto\"\xf6\x01\n" +
-	"\x0eControlMessage\x124\n" +
-	"\acommand\x18\x01 \x01(\v2\x18.cfgms.transport.CommandH\x00R\acommand\x12.\n" +
-	"\x05event\x18\x02 \x01(\v2\x16.cfgms.transport.EventH\x00R\x05event\x12:\n" +
-	"\theartbeat\x18\x03 \x01(\v2\x1a.cfgms.transport.HeartbeatH\x00R\theartbeat\x127\n" +
-	"\bresponse\x18\x04 \x01(\v2\x19.cfgms.transport.ResponseH\x00R\bresponseB\t\n" +
-	"\apayload\"\xd6\x02\n" +
-	"\aCommand\x12\x0e\n" +
-	"\x02id\x18\x01 \x01(\tR\x02id\x120\n" +
-	"\x04type\x18\x02 \x01(\x0e2\x1c.cfgms.transport.CommandTypeR\x04type\x12\x1d\n" +
-	"\n" +
-	"steward_id\x18\x03 \x01(\tR\tstewardId\x12\x1b\n" +
-	"\ttenant_id\x18\x04 \x01(\tR\btenantId\x128\n" +
-	"\ttimestamp\x18\x05 \x01(\v2\x1a.google.protobuf.TimestampR\ttimestamp\x12<\n" +
-	"\x06params\x18\x06 \x03(\v2$.cfgms.transport.Command.ParamsEntryR\x06params\x12\x1a\n" +
-	"\bpriority\x18\a \x01(\x05R\bpriority\x1a9\n" +
-	"\vParamsEntry\x12\x10\n" +
-	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
-	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\x8e\x03\n" +
-	"\x05Event\x12\x0e\n" +
-	"\x02id\x18\x01 \x01(\tR\x02id\x12.\n" +
-	"\x04type\x18\x02 \x01(\x0e2\x1a.cfgms.transport.EventTypeR\x04type\x12\x1d\n" +
-	"\n" +
-	"steward_id\x18\x03 \x01(\tR\tstewardId\x12\x1b\n" +
-	"\ttenant_id\x18\x04 \x01(\tR\btenantId\x128\n" +
-	"\ttimestamp\x18\x05 \x01(\v2\x1a.google.protobuf.TimestampR\ttimestamp\x12\x1d\n" +
-	"\n" +
-	"command_id\x18\x06 \x01(\tR\tcommandId\x12=\n" +
-	"\adetails\x18\a \x03(\v2#.cfgms.transport.Event.DetailsEntryR\adetails\x125\n" +
-	"\bseverity\x18\b \x01(\x0e2\x19.cfgms.transport.SeverityR\bseverity\x1a:\n" +
-	"\fDetailsEntry\x12\x10\n" +
-	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
-	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\xed\x02\n" +
-	"\tHeartbeat\x12\x1d\n" +
-	"\n" +
-	"steward_id\x18\x01 \x01(\tR\tstewardId\x12\x1b\n" +
-	"\ttenant_id\x18\x02 \x01(\tR\btenantId\x126\n" +
-	"\x06status\x18\x03 \x01(\x0e2\x1e.cfgms.transport.StewardStatusR\x06status\x128\n" +
-	"\ttimestamp\x18\x04 \x01(\v2\x1a.google.protobuf.TimestampR\ttimestamp\x12A\n" +
-	"\ametrics\x18\x05 \x03(\v2'.cfgms.transport.Heartbeat.MetricsEntryR\ametrics\x12\x18\n" +
-	"\aversion\x18\x06 \x01(\tR\aversion\x12\x19\n" +
-	"\bdna_hash\x18\a \x01(\tR\adnaHash\x1a:\n" +
-	"\fMetricsEntry\x12\x10\n" +
-	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
-	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\xb4\x02\n" +
-	"\bResponse\x12\x1d\n" +
-	"\n" +
-	"command_id\x18\x01 \x01(\tR\tcommandId\x12\x1d\n" +
-	"\n" +
-	"steward_id\x18\x02 \x01(\tR\tstewardId\x12\x18\n" +
-	"\asuccess\x18\x03 \x01(\bR\asuccess\x12\x18\n" +
-	"\amessage\x18\x04 \x01(\tR\amessage\x128\n" +
-	"\ttimestamp\x18\x05 \x01(\v2\x1a.google.protobuf.TimestampR\ttimestamp\x12@\n" +
-	"\adetails\x18\x06 \x03(\v2&.cfgms.transport.Response.DetailsEntryR\adetails\x1a:\n" +
-	"\fDetailsEntry\x12\x10\n" +
-	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
-	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01*\xe4\x01\n" +
-	"\vCommandType\x12\x1c\n" +
-	"\x18COMMAND_TYPE_UNSPECIFIED\x10\x00\x12\x1c\n" +
-	"\x18COMMAND_TYPE_SYNC_CONFIG\x10\x01\x12\x19\n" +
-	"\x15COMMAND_TYPE_SYNC_DNA\x10\x02\x12\"\n" +
-	"\x1eCOMMAND_TYPE_CONNECT_DATAPLANE\x10\x03\x12\x1d\n" +
-	"\x19COMMAND_TYPE_EXECUTE_TASK\x10\x04\x12\x19\n" +
-	"\x15COMMAND_TYPE_SHUTDOWN\x10\x05\x12 \n" +
-	"\x1cCOMMAND_TYPE_VALIDATE_CONFIG\x10\x06*\xb2\x01\n" +
-	"\tEventType\x12\x1a\n" +
-	"\x16EVENT_TYPE_UNSPECIFIED\x10\x00\x12\x1d\n" +
-	"\x19EVENT_TYPE_CONFIG_APPLIED\x10\x01\x12\x19\n" +
-	"\x15EVENT_TYPE_DNA_SYNCED\x10\x02\x12\x1d\n" +
-	"\x19EVENT_TYPE_TASK_COMPLETED\x10\x03\x12\x1a\n" +
-	"\x16EVENT_TYPE_TASK_FAILED\x10\x04\x12\x14\n" +
-	"\x10EVENT_TYPE_ERROR\x10\x05*x\n" +
-	"\bSeverity\x12\x18\n" +
-	"\x14SEVERITY_UNSPECIFIED\x10\x00\x12\x11\n" +
-	"\rSEVERITY_INFO\x10\x01\x12\x14\n" +
-	"\x10SEVERITY_WARNING\x10\x02\x12\x12\n" +
-	"\x0eSEVERITY_ERROR\x10\x03\x12\x15\n" +
-	"\x11SEVERITY_CRITICAL\x10\x04*\xa3\x01\n" +
-	"\rStewardStatus\x12\x1e\n" +
-	"\x1aSTEWARD_STATUS_UNSPECIFIED\x10\x00\x12\x1a\n" +
-	"\x16STEWARD_STATUS_HEALTHY\x10\x01\x12\x1b\n" +
-	"\x17STEWARD_STATUS_DEGRADED\x10\x02\x12\x18\n" +
-	"\x14STEWARD_STATUS_ERROR\x10\x03\x12\x1f\n" +
-	"\x1bSTEWARD_STATUS_DISCONNECTED\x10\x04B,Z*github.com/cfgis/cfgms/api/proto/transportb\x06proto3"
+	"\n\x17transport/control.proto\x12\x0fcfgms.transport\x1a\x1fg" +
+	"oogle/protobuf/timestamp.proto\"\xf6\x01\n\x0eControlMessage\x12" +
+	"4\n\x07command\x18\x01 \x01(\x0b2\x18.cfgms.transport.Command" +
+	"H\x00R\x07command\x12.\n\x05event\x18\x02 \x01(\x0b2\x16.cfgm" +
+	"s.transport.EventH\x00R\x05event\x12:\n\theartbeat\x18\x03 \x01" +
+	"(\x0b2\x1a.cfgms.transport.HeartbeatH\x00R\theartbeat\x127\n\x08" +
+	"response\x18\x04 \x01(\x0b2\x19.cfgms.transport.ResponseH\x00" +
+	"R\x08responseB\t\n\x07payload\"\xd6\x02\n\x07Command\x12\x0e\n" +
+	"\x02id\x18\x01 \x01(\tR\x02id\x120\n\x04type\x18\x02 \x01(\x0e" +
+	"2\x1c.cfgms.transport.CommandTypeR\x04type\x12\x1d\n\nsteward" +
+	"_id\x18\x03 \x01(\tR\tstewardId\x12\x1b\n\ttenant_id\x18\x04 " +
+	"\x01(\tR\x08tenantId\x128\n\ttimestamp\x18\x05 \x01(\x0b2\x1a" +
+	".google.protobuf.TimestampR\ttimestamp\x12<\n\x06params\x18\x06" +
+	" \x03(\x0b2$.cfgms.transport.Command.ParamsEntryR\x06params\x12" +
+	"\x1a\n\x08priority\x18\x07 \x01(\x05R\x08priority\x1a9\n\x0bP" +
+	"aramsEntry\x12\x10\n\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\x8e\x03\n\x05" +
+	"Event\x12\x0e\n\x02id\x18\x01 \x01(\tR\x02id\x12.\n\x04type\x18" +
+	"\x02 \x01(\x0e2\x1a.cfgms.transport.EventTypeR\x04type\x12\x1d" +
+	"\n\nsteward_id\x18\x03 \x01(\tR\tstewardId\x12\x1b\n\ttenant_" +
+	"id\x18\x04 \x01(\tR\x08tenantId\x128\n\ttimestamp\x18\x05 \x01" +
+	"(\x0b2\x1a.google.protobuf.TimestampR\ttimestamp\x12\x1d\n\nc" +
+	"ommand_id\x18\x06 \x01(\tR\tcommandId\x12=\n\x07details\x18\x07" +
+	" \x03(\x0b2#.cfgms.transport.Event.DetailsEntryR\x07details\x12" +
+	"5\n\x08severity\x18\x08 \x01(\x0e2\x19.cfgms.transport.Severi" +
+	"tyR\x08severity\x1a:\n\x0cDetailsEntry\x12\x10\n\x03key\x18\x01" +
+	" \x01(\tR\x03key\x12\x14\n\x05value\x18\x02 \x01(\tR\x05value" +
+	":\x028\x01\"\xc1\x03\n\tHeartbeat\x12\x1d\n\nsteward_id\x18\x01" +
+	" \x01(\tR\tstewardId\x12\x1b\n\ttenant_id\x18\x02 \x01(\tR\x08" +
+	"tenantId\x126\n\x06status\x18\x03 \x01(\x0e2\x1e.cfgms.transp" +
+	"ort.StewardStatusR\x06status\x128\n\ttimestamp\x18\x04 \x01(\x0b" +
+	"2\x1a.google.protobuf.TimestampR\ttimestamp\x12A\n\x07metrics" +
+	"\x18\x05 \x03(\x0b2'.cfgms.transport.Heartbeat.MetricsEntryR\x07" +
+	"metrics\x12\x18\n\x07version\x18\x06 \x01(\tR\x07version\x12\x19" +
+	"\n\x08dna_hash\x18\x07 \x01(\tR\x07dnaHash\x12'\n\x0factive_s" +
+	"essions\x18\x08 \x01(\x05R\x0eactiveSessions\x12)\n\x10connec" +
+	"tion_state\x18\t \x01(\tR\x0fconnectionState\x1a:\n\x0cMetric" +
+	"sEntry\x12\x10\n\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n\x05" +
+	"value\x18\x02 \x01(\tR\x05value:\x028\x01\"\xb4\x02\n\x08Resp" +
+	"onse\x12\x1d\n\ncommand_id\x18\x01 \x01(\tR\tcommandId\x12\x1d" +
+	"\n\nsteward_id\x18\x02 \x01(\tR\tstewardId\x12\x18\n\x07succe" +
+	"ss\x18\x03 \x01(\x08R\x07success\x12\x18\n\x07message\x18\x04" +
+	" \x01(\tR\x07message\x128\n\ttimestamp\x18\x05 \x01(\x0b2\x1a" +
+	".google.protobuf.TimestampR\ttimestamp\x12@\n\x07details\x18\x06" +
+	" \x03(\x0b2&.cfgms.transport.Response.DetailsEntryR\x07detail" +
+	"s\x1a:\n\x0cDetailsEntry\x12\x10\n\x03key\x18\x01 \x01(\tR\x03" +
+	"key\x12\x14\n\x05value\x18\x02 \x01(\tR\x05value:\x028\x01*\xe4" +
+	"\x01\n\x0bCommandType\x12\x1c\n\x18COMMAND_TYPE_UNSPECIFIED\x10" +
+	"\x00\x12\x1c\n\x18COMMAND_TYPE_SYNC_CONFIG\x10\x01\x12\x19\n\x15" +
+	"COMMAND_TYPE_SYNC_DNA\x10\x02\x12\"\n\x1eCOMMAND_TYPE_CONNECT" +
+	"_DATAPLANE\x10\x03\x12\x1d\n\x19COMMAND_TYPE_EXECUTE_TASK\x10" +
+	"\x04\x12\x19\n\x15COMMAND_TYPE_SHUTDOWN\x10\x05\x12 \n\x1cCOM" +
+	"MAND_TYPE_VALIDATE_CONFIG\x10\x06*\xb2\x01\n\tEventType\x12\x1a" +
+	"\n\x16EVENT_TYPE_UNSPECIFIED\x10\x00\x12\x1d\n\x19EVENT_TYPE_" +
+	"CONFIG_APPLIED\x10\x01\x12\x19\n\x15EVENT_TYPE_DNA_SYNCED\x10" +
+	"\x02\x12\x1d\n\x19EVENT_TYPE_TASK_COMPLETED\x10\x03\x12\x1a\n" +
+	"\x16EVENT_TYPE_TASK_FAILED\x10\x04\x12\x14\n\x10EVENT_TYPE_ER" +
+	"ROR\x10\x05*x\n\x08Severity\x12\x18\n\x14SEVERITY_UNSPECIFIED" +
+	"\x10\x00\x12\x11\n\x0dSEVERITY_INFO\x10\x01\x12\x14\n\x10SEVE" +
+	"RITY_WARNING\x10\x02\x12\x12\n\x0eSEVERITY_ERROR\x10\x03\x12\x15" +
+	"\n\x11SEVERITY_CRITICAL\x10\x04*\xa3\x01\n\x0dStewardStatus\x12" +
+	"\x1e\n\x1aSTEWARD_STATUS_UNSPECIFIED\x10\x00\x12\x1a\n\x16STE" +
+	"WARD_STATUS_HEALTHY\x10\x01\x12\x1b\n\x17STEWARD_STATUS_DEGRA" +
+	"DED\x10\x02\x12\x18\n\x14STEWARD_STATUS_ERROR\x10\x03\x12\x1f" +
+	"\n\x1bSTEWARD_STATUS_DISCONNECTED\x10\x04B,Z*github.com/cfgis" +
+	"/cfgms/api/proto/transportb\x06proto3"
 
 var (
 	file_transport_control_proto_rawDescOnce sync.Once

--- a/api/proto/transport/control.proto
+++ b/api/proto/transport/control.proto
@@ -89,6 +89,8 @@ message Heartbeat {
   map<string, string> metrics = 5;
   string version = 6;
   string dna_hash = 7;      // for hash-based sync detection
+  int32 active_sessions = 8;    // number of active control-channel streams (1 when connected, 0 otherwise)
+  string connection_state = 9;  // steward connection state ("connected", "disconnected", "connecting", "reconnecting")
 }
 
 // Response is sent from steward to controller for command acknowledgment.

--- a/features/controller/api/types.go
+++ b/features/controller/api/types.go
@@ -30,13 +30,13 @@ type APIError struct {
 
 // StewardInfo represents steward information for API responses
 type StewardInfo struct {
-	ID              string            `json:"id"`
-	Status          string            `json:"status"`
-	LastSeen        time.Time         `json:"last_seen"`
-	Version         string            `json:"version"`
-	ConnectedAt     time.Time         `json:"connected_at"`
-	Metrics         map[string]string `json:"metrics,omitempty"`
-	DNA             *DNAInfo          `json:"dna,omitempty"`
+	ID          string            `json:"id"`
+	Status      string            `json:"status"`
+	LastSeen    time.Time         `json:"last_seen"`
+	Version     string            `json:"version"`
+	ConnectedAt time.Time         `json:"connected_at"`
+	Metrics     map[string]string `json:"metrics,omitempty"`
+	DNA         *DNAInfo          `json:"dna,omitempty"`
 	// ActiveSessions is 1 when the steward has an active ControlChannel stream,
 	// 0 otherwise. Each steward holds at most one stream at a time, so this is
 	// a binary sentinel, not a real connection count.

--- a/features/controller/heartbeat/service.go
+++ b/features/controller/heartbeat/service.go
@@ -33,6 +33,14 @@ type StewardStatus struct {
 	// Empty when the steward has not yet sent a DNA hash (older steward versions).
 	DNAHash string
 
+	// ActiveSessions is the number of active control-channel streams reported by the steward.
+	// Value is 1 when connected, 0 otherwise.
+	ActiveSessions int
+
+	// ConnectionState is the steward's self-reported connection state string.
+	// Values: "connected", "disconnected", "connecting", "reconnecting".
+	ConnectionState string
+
 	// expectedDNAHash is the hash the controller expects the steward to have,
 	// set after a successful full DNA sync.  Compared against DNAHash on each
 	// heartbeat to detect missed deltas.
@@ -191,6 +199,9 @@ func (s *Service) handleHeartbeatFromProvider(ctx context.Context, hb *controlpl
 		}
 		status.Metrics = metrics
 	}
+
+	status.ActiveSessions = int(hb.ActiveSessions)
+	status.ConnectionState = hb.ConnectionState
 
 	status.MissedBeats = 0
 	status.Healthy = true

--- a/features/controller/heartbeat/service_dna_test.go
+++ b/features/controller/heartbeat/service_dna_test.go
@@ -217,6 +217,28 @@ func TestHeartbeatService_GetAllStatusesDNAHash(t *testing.T) {
 	assert.Equal(t, "h3", all["s3"].DNAHash)
 }
 
+func TestHeartbeatService_ActiveSessionsAndConnectionState(t *testing.T) {
+	svc, cp := newTestService(t)
+	ctx := context.Background()
+
+	hb := &controlplaneTypes.Heartbeat{
+		StewardID:       "steward-ac",
+		TenantID:        "tenant-ac",
+		Status:          controlplaneTypes.StatusHealthy,
+		Timestamp:       time.Now(),
+		ActiveSessions:  1,
+		ConnectionState: "connected",
+	}
+	require.NoError(t, cp.sendHeartbeat(ctx, hb))
+
+	status, ok := svc.GetStatus("steward-ac")
+	require.True(t, ok, "steward must be registered after heartbeat")
+	assert.Equal(t, 1, status.ActiveSessions,
+		"StewardStatus.ActiveSessions must equal the heartbeat active_sessions value")
+	assert.Equal(t, "connected", status.ConnectionState,
+		"StewardStatus.ConnectionState must equal the heartbeat connection_state value")
+}
+
 func TestSetExpectedDNAHash_UnknownSteward(t *testing.T) {
 	svc, _ := newTestService(t)
 

--- a/features/steward/client/client_transport.go
+++ b/features/steward/client/client_transport.go
@@ -694,13 +694,22 @@ func (c *TransportClient) SendHeartbeat(ctx context.Context, status string, metr
 	currentDNAHash := c.currentDNAHash
 	c.dnaMu.RUnlock()
 
+	activeSessions := int32(0)
+	connectionState := "disconnected"
+	if cp.IsConnected() {
+		activeSessions = 1
+		connectionState = "connected"
+	}
+
 	heartbeat := &cpTypes.Heartbeat{
-		StewardID: stewardID,
-		TenantID:  tenantID,
-		Status:    cpTypes.HeartbeatStatus(status),
-		Timestamp: time.Now(),
-		Metrics:   metricsMap,
-		DNAHash:   currentDNAHash,
+		StewardID:       stewardID,
+		TenantID:        tenantID,
+		Status:          cpTypes.HeartbeatStatus(status),
+		Timestamp:       time.Now(),
+		Metrics:         metricsMap,
+		DNAHash:         currentDNAHash,
+		ActiveSessions:  activeSessions,
+		ConnectionState: connectionState,
 	}
 
 	if err := cp.SendHeartbeat(ctx, heartbeat); err != nil {

--- a/pkg/controlplane/providers/grpc/convert.go
+++ b/pkg/controlplane/providers/grpc/convert.go
@@ -242,11 +242,14 @@ func heartbeatToProto(hb *types.Heartbeat) *transportpb.Heartbeat {
 		return nil
 	}
 	pb := &transportpb.Heartbeat{
-		StewardId: hb.StewardID,
-		TenantId:  hb.TenantID,
-		Status:    heartbeatStatusToProto[hb.Status],
-		Timestamp: timestamppb.New(hb.Timestamp),
-		Version:   hb.Version,
+		StewardId:       hb.StewardID,
+		TenantId:        hb.TenantID,
+		Status:          heartbeatStatusToProto[hb.Status],
+		Timestamp:       timestamppb.New(hb.Timestamp),
+		Version:         hb.Version,
+		DnaHash:         hb.DNAHash,
+		ActiveSessions:  hb.ActiveSessions,
+		ConnectionState: hb.ConnectionState,
 	}
 	if len(hb.Metrics) > 0 {
 		pb.Metrics = interfaceMapToStringMap(hb.Metrics)
@@ -259,11 +262,14 @@ func heartbeatFromProto(pb *transportpb.Heartbeat) *types.Heartbeat {
 		return nil
 	}
 	hb := &types.Heartbeat{
-		StewardID: pb.GetStewardId(),
-		TenantID:  pb.GetTenantId(),
-		Status:    protoToHeartbeatStatus[pb.GetStatus()],
-		Timestamp: protoTimestampToTime(pb.GetTimestamp()),
-		Version:   pb.GetVersion(),
+		StewardID:       pb.GetStewardId(),
+		TenantID:        pb.GetTenantId(),
+		Status:          protoToHeartbeatStatus[pb.GetStatus()],
+		Timestamp:       protoTimestampToTime(pb.GetTimestamp()),
+		Version:         pb.GetVersion(),
+		DNAHash:         pb.GetDnaHash(),
+		ActiveSessions:  pb.GetActiveSessions(),
+		ConnectionState: pb.GetConnectionState(),
 	}
 	if len(pb.GetMetrics()) > 0 {
 		hb.Metrics = stringMapToInterfaceMap(pb.GetMetrics())

--- a/pkg/controlplane/providers/grpc/convert_test.go
+++ b/pkg/controlplane/providers/grpc/convert_test.go
@@ -211,6 +211,17 @@ func TestHeartbeatRoundTrip(t *testing.T) {
 				Timestamp: now,
 			},
 		},
+		{
+			name: "with active_sessions and connection_state",
+			hb: &types.Heartbeat{
+				StewardID:       "steward-3",
+				Status:          types.StatusHealthy,
+				Timestamp:       now,
+				Version:         "3.0.0",
+				ActiveSessions:  1,
+				ConnectionState: "connected",
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -226,6 +237,8 @@ func TestHeartbeatRoundTrip(t *testing.T) {
 			assert.Equal(t, tt.hb.Status, result.Status)
 			assert.Equal(t, tt.hb.Timestamp.UTC(), result.Timestamp.UTC())
 			assert.Equal(t, tt.hb.Version, result.Version)
+			assert.Equal(t, tt.hb.ActiveSessions, result.ActiveSessions)
+			assert.Equal(t, tt.hb.ConnectionState, result.ConnectionState)
 
 			if tt.hb.Metrics != nil {
 				require.NotNil(t, result.Metrics)

--- a/pkg/controlplane/types/messages.go
+++ b/pkg/controlplane/types/messages.go
@@ -157,6 +157,14 @@ type Heartbeat struct {
 	// sends a CommandSyncDNA to request a full sync over the data plane.
 	// Empty for older stewards that do not support hash-based sync.
 	DNAHash string `json:"dna_hash,omitempty"`
+
+	// ActiveSessions is the number of active control-channel streams the steward holds.
+	// Value is 1 when connected, 0 otherwise.
+	ActiveSessions int32 `json:"active_sessions,omitempty"`
+
+	// ConnectionState is the steward's current connection state string.
+	// Values: "connected", "disconnected", "connecting", "reconnecting".
+	ConnectionState string `json:"connection_state,omitempty"`
 }
 
 // Response represents a command response/acknowledgment.


### PR DESCRIPTION
## Summary

- Adds `int32 active_sessions = 8` and `string connection_state = 9` to the `Heartbeat` proto message (field numbers unoccupied in the existing schema)
- Propagates both fields through the full steward→controller pipeline: proto wire → controlplane types → gRPC convert layer → heartbeat service → `StewardStatus`
- Steward reports `active_sessions=1` + `connection_state="connected"` when its controlplane provider `IsConnected()`, otherwise `0` / `"disconnected"`
- Controller heartbeat service stores both values on `StewardStatus` for monitoring and the HA `getStewardStatus` call chain (parent epic #1255)

Fixes #1324

## Files Changed

| File | Change |
|------|--------|
| `api/proto/transport/control.proto` | Added fields 8 and 9 to `Heartbeat` message |
| `api/proto/transport/control.pb.go` | Updated rawDesc binary + struct fields + getters |
| `pkg/controlplane/types/messages.go` | Added `ActiveSessions int32` + `ConnectionState string` to `Heartbeat` |
| `pkg/controlplane/providers/grpc/convert.go` | Updated `heartbeatToProto`/`heartbeatFromProto`; also added previously missing `DnaHash` mapping |
| `pkg/controlplane/providers/grpc/convert_test.go` | Added round-trip test case for new fields |
| `features/controller/heartbeat/service.go` | Added `ActiveSessions int` + `ConnectionState string` to `StewardStatus`; populate in handler |
| `features/steward/client/client_transport.go` | `SendHeartbeat` now populates both new fields |
| `features/controller/heartbeat/service_dna_test.go` | Added `TestHeartbeatService_ActiveSessionsAndConnectionState` |
| `features/controller/api/types.go` | gofmt alignment fix for `StewardInfo` (pre-existing issue from #1323) |

## Specialist Review Results

**QA Test Runner**: PASS — all unit tests, integration tests, lint, build gates, and architecture checks pass. Applied a gofmt fix to `api/types.go` (pre-existing formatting regression from #1323).

**QA Code Reviewer**: PASS — no mocks, no `t.Skip()`, no empty assertions. `testControlPlane` is a compiler-verified in-process implementation. `TestHeartbeatService_ActiveSessionsAndConnectionState` directly validates the acceptance criterion. One non-blocking warning: steward-side `SendHeartbeat` field population lacks a unit test in `client_transport_test.go` (controller-side round-trip is fully covered).

**Security Engineer**: PASS — no new attack surface. `ConnectionState` values are hardcoded literals (`"connected"`/`"disconnected"`), not user-controlled strings. Field is not logged unsanitized. `make check-architecture` clean. All pre-existing gosec findings are unrelated to this story.

## Test Plan

- [x] `TestHeartbeatService_ActiveSessionsAndConnectionState` — sends heartbeat with `active_sessions=1, connection_state="connected"`, verifies `StewardStatus` stores both values
- [x] `TestHeartbeatRoundTrip/with_active_sessions_and_connection_state` — verifies fields survive `heartbeatToProto`→`heartbeatFromProto` round-trip
- [x] All existing heartbeat and gRPC controlplane tests pass unchanged
- [x] `make test-agent-complete` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)