### PR TITLE
ha: replicate session registry state via session_update Raft command (Issue #1326)

### DIFF
--- a/commercial/ha/manager.go
+++ b/commercial/ha/manager.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/cfgis/cfgms/pkg/logging"
 	"github.com/cfgis/cfgms/pkg/storage/interfaces"
+	"github.com/cfgis/cfgms/pkg/transport/registry"
 	"github.com/cfgis/cfgms/pkg/version"
 )
 
@@ -42,6 +43,9 @@ type Manager struct {
 	startTime      time.Time
 	ctx            context.Context
 	cancel         context.CancelFunc
+
+	// Session registry for steward connect/disconnect replication
+	registry registry.Registry
 
 	// Cluster state
 	clusterNodes map[string]*NodeInfo
@@ -169,6 +173,25 @@ func (m *Manager) Start(ctx context.Context) error {
 		}
 	case SingleServerMode:
 		m.logger.Info("Running in single server mode - no additional HA components needed")
+	}
+
+	// Register session hooks so steward connect/disconnect events are replicated
+	// through the Raft log when running in cluster mode.
+	if m.raftConsensus != nil && m.registry != nil {
+		rc := m.raftConsensus
+		nodeID := m.nodeInfo.ID
+		m.registry.OnConnect(func(stewardID string) {
+			if err := rc.ProposeSessionUpdate(stewardID, nodeID, true); err != nil {
+				m.logger.Warn("Failed to propose session connect",
+					"steward_id", logging.SanitizeLogValue(stewardID), "error", err)
+			}
+		})
+		m.registry.OnDisconnect(func(stewardID string) {
+			if err := rc.ProposeSessionUpdate(stewardID, nodeID, false); err != nil {
+				m.logger.Warn("Failed to propose session disconnect",
+					"steward_id", logging.SanitizeLogValue(stewardID), "error", err)
+			}
+		})
 	}
 
 	m.isStarted = true
@@ -374,6 +397,15 @@ func (m *Manager) GetRaftTransport() RaftTransport {
 	rc.mu.RLock()
 	defer rc.mu.RUnlock()
 	return rc.transport
+}
+
+// SetRegistry wires the active-steward connection registry so that connect and
+// disconnect events are replicated through the Raft log (Issue #1326).
+// Call this after NewManager returns but before Start is called.
+func (m *Manager) SetRegistry(r registry.Registry) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.registry = r
 }
 
 // initializeComponents initializes HA components based on deployment mode

--- a/commercial/ha/manager_test.go
+++ b/commercial/ha/manager_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cfgis/cfgms/pkg/logging"
 	pkgtesting "github.com/cfgis/cfgms/pkg/testing"
 	"github.com/cfgis/cfgms/pkg/testing/storage"
+	"github.com/cfgis/cfgms/pkg/transport/registry"
 )
 
 // TestManager_ConcreteCollaboratorTypes verifies that Manager stores concrete types
@@ -679,4 +680,149 @@ func TestManager_GetCACertPEM_Concurrent(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		<-done
 	}
+}
+
+// noopSender is a minimal registry.MessageSender for tests that only need a non-nil sender.
+type noopSender struct{}
+
+func (noopSender) SendMsg(_ interface{}) error { return nil }
+
+// TestManager_SessionHooks verifies that after Manager.Start() with a real
+// registry.InMemoryRegistry, firing an OnConnect event via registry.Register
+// propagates through the Raft log so raftConsensus.clusterState.Sessions reflects the
+// connected steward (no mocks — real Raft apply path).
+func TestManager_SessionHooks(t *testing.T) {
+	storageManager, err := storage.CreateTestStorageManager()
+	require.NoError(t, err)
+
+	const nodeID = "session-hooks-node"
+	cfg := DefaultConfig()
+	cfg.Mode = ClusterMode
+	cfg.Node.ID = nodeID
+	cfg.Cluster.HeartbeatInterval = 100 * time.Millisecond
+	cfg.Cluster.ElectionTimeout = 1 * time.Second
+	cfg.Cluster.ExpectedSize = 1
+	cfg.Cluster.MinQuorum = 1
+	cfg.Cluster.Discovery.Config = map[string]interface{}{
+		"nodes": []interface{}{
+			map[string]interface{}{
+				"id":      nodeID,
+				"address": "127.0.0.1:0",
+			},
+		},
+	}
+
+	logger := logging.GetLogger()
+	manager, err := NewManager(cfg, logger, storageManager)
+	require.NoError(t, err)
+	require.NotNil(t, manager.raftConsensus)
+
+	t.Cleanup(func() {
+		assert.NoError(t, manager.raftConsensus.Stop())
+	})
+
+	reg := registry.NewRegistry()
+	manager.SetRegistry(reg)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	require.NoError(t, manager.Start(ctx))
+	t.Cleanup(func() {
+		assert.NoError(t, manager.Stop(ctx))
+	})
+
+	// Wait for Raft to elect a leader before firing the connect event.
+	require.Eventually(t, func() bool {
+		return manager.raftConsensus.IsLeader()
+	}, 10*time.Second, 50*time.Millisecond, "single-node cluster must elect itself leader")
+
+	// Fire an OnConnect event by registering a steward connection.
+	conn := &registry.StewardConnection{
+		StewardID: "steward-test",
+		Sender:    noopSender{},
+	}
+	require.NoError(t, reg.Register(conn))
+
+	// The hook fires in a goroutine; wait for the Raft apply path to complete.
+	require.Eventually(t, func() bool {
+		manager.raftConsensus.clusterState.mu.RLock()
+		cmd, ok := manager.raftConsensus.clusterState.Sessions["steward-test"]
+		manager.raftConsensus.clusterState.mu.RUnlock()
+		return ok && cmd.Connected
+	}, 5*time.Second, 25*time.Millisecond,
+		"OnConnect hook must propagate through Raft log so clusterState.Sessions[steward-test].Connected == true")
+}
+
+// TestManager_SessionDisconnectHook verifies that the OnDisconnect hook wired in
+// Manager.Start() propagates through the Raft log and removes the session entry from
+// clusterState.Sessions (real Raft apply path — no mocks).
+func TestManager_SessionDisconnectHook(t *testing.T) {
+	storageManager, err := storage.CreateTestStorageManager()
+	require.NoError(t, err)
+
+	const nodeID = "session-disconnect-hooks-node"
+	cfg := DefaultConfig()
+	cfg.Mode = ClusterMode
+	cfg.Node.ID = nodeID
+	cfg.Cluster.HeartbeatInterval = 100 * time.Millisecond
+	cfg.Cluster.ElectionTimeout = 1 * time.Second
+	cfg.Cluster.ExpectedSize = 1
+	cfg.Cluster.MinQuorum = 1
+	cfg.Cluster.Discovery.Config = map[string]interface{}{
+		"nodes": []interface{}{
+			map[string]interface{}{
+				"id":      nodeID,
+				"address": "127.0.0.1:0",
+			},
+		},
+	}
+
+	logger := logging.GetLogger()
+	manager, err := NewManager(cfg, logger, storageManager)
+	require.NoError(t, err)
+	require.NotNil(t, manager.raftConsensus)
+
+	t.Cleanup(func() {
+		assert.NoError(t, manager.raftConsensus.Stop())
+	})
+
+	reg := registry.NewRegistry()
+	manager.SetRegistry(reg)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	require.NoError(t, manager.Start(ctx))
+	t.Cleanup(func() {
+		assert.NoError(t, manager.Stop(ctx))
+	})
+
+	require.Eventually(t, func() bool {
+		return manager.raftConsensus.IsLeader()
+	}, 10*time.Second, 50*time.Millisecond, "single-node cluster must elect itself leader")
+
+	// Connect first so there is an entry to disconnect.
+	conn := &registry.StewardConnection{
+		StewardID: "steward-disconnect",
+		Sender:    noopSender{},
+	}
+	require.NoError(t, reg.Register(conn))
+	require.Eventually(t, func() bool {
+		manager.raftConsensus.clusterState.mu.RLock()
+		_, ok := manager.raftConsensus.clusterState.Sessions["steward-disconnect"]
+		manager.raftConsensus.clusterState.mu.RUnlock()
+		return ok
+	}, 5*time.Second, 25*time.Millisecond, "connect must be applied before disconnect is triggered")
+
+	// Trigger the OnDisconnect hook via registry.Unregister.
+	reg.Unregister("steward-disconnect")
+
+	require.Eventually(t, func() bool {
+		manager.raftConsensus.clusterState.mu.RLock()
+		_, ok := manager.raftConsensus.clusterState.Sessions["steward-disconnect"]
+		manager.raftConsensus.clusterState.mu.RUnlock()
+		return !ok
+	}, 5*time.Second, 25*time.Millisecond,
+		"OnDisconnect hook must propagate through Raft log and delete clusterState.Sessions[steward-disconnect]")
 }

--- a/commercial/ha/raft_consensus.go
+++ b/commercial/ha/raft_consensus.go
@@ -65,6 +65,7 @@ type ClusterState struct {
 	mu           sync.RWMutex
 	Leader       uint64
 	Nodes        map[uint64]*NodeInfo
+	Sessions     map[string]SessionUpdateCommand
 	LastModified time.Time
 }
 
@@ -78,6 +79,14 @@ type RaftCommand struct {
 type NodeUpdateCommand struct {
 	NodeID   uint64    `json:"node_id"`
 	NodeInfo *NodeInfo `json:"node_info"`
+}
+
+// SessionUpdateCommand is sent when a steward connects or disconnects
+type SessionUpdateCommand struct {
+	StewardID string    `json:"steward_id"`
+	NodeID    string    `json:"node_id"`
+	Connected bool      `json:"connected"`
+	Timestamp time.Time `json:"timestamp"`
 }
 
 // NewRaftConsensus creates a new Raft consensus instance. clusterCfg provides the
@@ -125,7 +134,8 @@ func NewRaftConsensus(ctx context.Context, nodeID uint64, nodeInfo *NodeInfo, pe
 		config:       config,
 		tickInterval: tickInterval,
 		clusterState: &ClusterState{
-			Nodes: make(map[uint64]*NodeInfo),
+			Nodes:    make(map[uint64]*NodeInfo),
+			Sessions: make(map[string]SessionUpdateCommand),
 		},
 		proposeC:       make(chan []byte, 16),
 		confChangeC:    make(chan raftpb.ConfChange, 16),
@@ -406,6 +416,8 @@ func (rc *RaftConsensus) applyCommand(data []byte) error {
 	switch cmd.Type {
 	case "node_update":
 		return rc.applyNodeUpdate(cmd.Data)
+	case "session_update":
+		return rc.applySessionUpdate(cmd.Data)
 	default:
 		return fmt.Errorf("unknown command type: %s", cmd.Type)
 	}
@@ -431,6 +443,59 @@ func (rc *RaftConsensus) applyNodeUpdate(data interface{}) error {
 	rc.logger.Debug("Applied node update", "node_id", update.NodeID, "node_info", update.NodeInfo)
 
 	return nil
+}
+
+// applySessionUpdate updates session state in the cluster state machine
+func (rc *RaftConsensus) applySessionUpdate(data interface{}) error {
+	dataBytes, err := json.Marshal(data)
+	if err != nil {
+		return err
+	}
+
+	var update SessionUpdateCommand
+	if err := json.Unmarshal(dataBytes, &update); err != nil {
+		return err
+	}
+
+	rc.clusterState.mu.Lock()
+	if update.Connected {
+		rc.clusterState.Sessions[update.StewardID] = update
+	} else {
+		delete(rc.clusterState.Sessions, update.StewardID)
+	}
+	rc.clusterState.LastModified = time.Now()
+	rc.clusterState.mu.Unlock()
+
+	rc.logger.Debug("Applied session update",
+		"steward_id", logging.SanitizeLogValue(update.StewardID),
+		"node_id", logging.SanitizeLogValue(update.NodeID),
+		"connected", update.Connected)
+
+	return nil
+}
+
+// ProposeSessionUpdate replicates a steward connect/disconnect event through the Raft log.
+// It is non-blocking: if proposeC is at capacity it returns an error immediately.
+func (rc *RaftConsensus) ProposeSessionUpdate(stewardID, nodeID string, connected bool) error {
+	cmd := RaftCommand{
+		Type: "session_update",
+		Data: SessionUpdateCommand{
+			StewardID: stewardID,
+			NodeID:    nodeID,
+			Connected: connected,
+			Timestamp: time.Now(),
+		},
+	}
+	data, err := json.Marshal(cmd)
+	if err != nil {
+		return fmt.Errorf("failed to marshal session update command: %w", err)
+	}
+	select {
+	case rc.proposeC <- data:
+		return nil
+	default:
+		return fmt.Errorf("propose channel full, cannot enqueue session update")
+	}
 }
 
 // publishSnapshot applies a snapshot to the state machine

--- a/commercial/ha/raft_consensus_test.go
+++ b/commercial/ha/raft_consensus_test.go
@@ -311,3 +311,102 @@ func TestRaftConsensus_ProposeRemoveNode_ChannelFull_ReturnsError(t *testing.T) 
 	err = rc.ProposeRemoveNode(99)
 	require.Error(t, err, "ProposeRemoveNode must return an error when confChangeC is full")
 }
+
+// TestRaftConsensus_ProposeSessionUpdate_AppliedViaRaft verifies that
+// ProposeSessionUpdate(connected=true) commits through the Raft log and
+// clusterState.Sessions["steward-1"].Connected becomes true via applySessionUpdate.
+func TestRaftConsensus_ProposeSessionUpdate_AppliedViaRaft(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	nodeInfo := &NodeInfo{
+		ID:      "session-test-node",
+		Address: "127.0.0.1:8111",
+		State:   NodeStateHealthy,
+		Role:    NodeRoleFollower,
+	}
+
+	peers := []raft.Peer{{ID: 1}}
+	rc, err := NewRaftConsensus(ctx, 1, nodeInfo, peers, newTestClusterCfg(), logging.GetLogger())
+	require.NoError(t, err)
+	defer rc.Stop() //nolint:errcheck // Stop always returns nil; error is non-actionable in cleanup
+
+	require.Eventually(t, func() bool {
+		return rc.IsLeader()
+	}, 10*time.Second, 50*time.Millisecond, "single-node cluster must elect itself leader")
+
+	err = rc.ProposeSessionUpdate("steward-1", "node-1", true)
+	require.NoError(t, err)
+
+	require.Eventually(t, func() bool {
+		rc.clusterState.mu.RLock()
+		cmd, ok := rc.clusterState.Sessions["steward-1"]
+		rc.clusterState.mu.RUnlock()
+		return ok && cmd.Connected
+	}, 5*time.Second, 25*time.Millisecond, "session connect must be committed and applied via the Raft log")
+
+	// Verify all fields are preserved through the apply path.
+	rc.clusterState.mu.RLock()
+	cmd := rc.clusterState.Sessions["steward-1"]
+	rc.clusterState.mu.RUnlock()
+	assert.Equal(t, "steward-1", cmd.StewardID)
+	assert.Equal(t, "node-1", cmd.NodeID)
+	assert.True(t, cmd.Connected)
+	assert.False(t, cmd.Timestamp.IsZero(), "Timestamp must be set")
+}
+
+// TestRaftConsensus_ProposeSessionUpdate_Disconnect_DeletesEntry verifies that
+// ProposeSessionUpdate(connected=false) removes the entry from ClusterState.Sessions
+// after the entry is committed via the Raft log.
+func TestRaftConsensus_ProposeSessionUpdate_Disconnect_DeletesEntry(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	nodeInfo := &NodeInfo{ID: "session-disconnect-node", Address: "127.0.0.1:8222", State: NodeStateHealthy, Role: NodeRoleFollower}
+	peers := []raft.Peer{{ID: 1}}
+	rc, err := NewRaftConsensus(ctx, 1, nodeInfo, peers, newTestClusterCfg(), logging.GetLogger())
+	require.NoError(t, err)
+	defer rc.Stop() //nolint:errcheck // Stop always returns nil; error is non-actionable in cleanup
+
+	require.Eventually(t, func() bool {
+		return rc.IsLeader()
+	}, 10*time.Second, 50*time.Millisecond, "single-node cluster must elect itself leader")
+
+	// First connect, then disconnect.
+	require.NoError(t, rc.ProposeSessionUpdate("steward-2", "node-1", true))
+	require.Eventually(t, func() bool {
+		rc.clusterState.mu.RLock()
+		_, ok := rc.clusterState.Sessions["steward-2"]
+		rc.clusterState.mu.RUnlock()
+		return ok
+	}, 5*time.Second, 25*time.Millisecond, "connect must be applied before disconnect is proposed")
+
+	require.NoError(t, rc.ProposeSessionUpdate("steward-2", "node-1", false))
+	require.Eventually(t, func() bool {
+		rc.clusterState.mu.RLock()
+		_, ok := rc.clusterState.Sessions["steward-2"]
+		rc.clusterState.mu.RUnlock()
+		return !ok
+	}, 5*time.Second, 25*time.Millisecond, "session disconnect must delete the entry via the Raft log")
+}
+
+// TestRaftConsensus_ProposeSessionUpdate_ChannelFull_ReturnsError verifies that
+// ProposeSessionUpdate returns a non-nil error rather than blocking when proposeC is full.
+func TestRaftConsensus_ProposeSessionUpdate_ChannelFull_ReturnsError(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	nodeInfo := &NodeInfo{ID: "session-full-node", Address: "127.0.0.1:8333"}
+	rc, err := NewRaftConsensus(ctx, 1, nodeInfo, nil, newTestClusterCfg(), logging.GetLogger())
+	require.NoError(t, err)
+
+	rc.Stop() //nolint:errcheck // Stop always returns nil; error is non-actionable in cleanup
+
+	const bufSize = 16
+	for i := 0; i < bufSize; i++ {
+		rc.proposeC <- []byte("fill")
+	}
+
+	err = rc.ProposeSessionUpdate("steward-x", "node-1", true)
+	require.Error(t, err, "ProposeSessionUpdate must return an error when proposeC is full")
+}

--- a/features/controller/api/types.go
+++ b/features/controller/api/types.go
@@ -30,13 +30,13 @@ type APIError struct {
 
 // StewardInfo represents steward information for API responses
 type StewardInfo struct {
-	ID              string            `json:"id"`
-	Status          string            `json:"status"`
-	LastSeen        time.Time         `json:"last_seen"`
-	Version         string            `json:"version"`
-	ConnectedAt     time.Time         `json:"connected_at"`
-	Metrics         map[string]string `json:"metrics,omitempty"`
-	DNA             *DNAInfo          `json:"dna,omitempty"`
+	ID          string            `json:"id"`
+	Status      string            `json:"status"`
+	LastSeen    time.Time         `json:"last_seen"`
+	Version     string            `json:"version"`
+	ConnectedAt time.Time         `json:"connected_at"`
+	Metrics     map[string]string `json:"metrics,omitempty"`
+	DNA         *DNAInfo          `json:"dna,omitempty"`
 	// ActiveSessions is 1 when the steward has an active ControlChannel stream,
 	// 0 otherwise. Each steward holds at most one stream at a time, so this is
 	// a binary sentinel, not a real connection count.


### PR DESCRIPTION
## Summary

- Adds `SessionUpdateCommand` struct and `ClusterState.Sessions` map to `raft_consensus.go` so every Raft node holds a consistent view of active steward sessions
- `ProposeSessionUpdate(stewardID, nodeID, connected)` is non-blocking (select/default on buffered `proposeC`); `applySessionUpdate` upserts on connect, deletes on disconnect
- `Manager.SetRegistry` / `Start()` hooks wire the `registry.OnConnect`/`OnDisconnect` event bus to `ProposeSessionUpdate` so connect/disconnect events flow through the Raft log automatically

Fixes #1326

## Specialist Review Results

| Agent | Result |
|-------|--------|
| QA Test Runner | **PASS** — all unit tests, integration tests, cross-platform builds, lint pass; Trivy offline (container network constraint, not a code issue) |
| QA Code Reviewer | **PASS** — initial finding (missing OnDisconnect Manager test) fixed; `TestManager_SessionDisconnectHook` added |
| Security Engineer | **PASS** — no blocking issues; all log fields use `logging.SanitizeLogValue`; no central-provider violations; `check-architecture` clean |

## Test plan

- [ ] `TestRaftConsensus_ProposeSessionUpdate_AppliedViaRaft` — connect event committed and applied via Raft log
- [ ] `TestRaftConsensus_ProposeSessionUpdate_Disconnect_DeletesEntry` — disconnect removes the entry
- [ ] `TestRaftConsensus_ProposeSessionUpdate_ChannelFull_ReturnsError` — non-blocking contract
- [ ] `TestManager_SessionHooks` — real registry + cluster-mode Manager, OnConnect propagates via Raft
- [ ] `TestManager_SessionDisconnectHook` — OnDisconnect propagates via Raft and deletes entry
- [ ] `make test-agent-complete` passes (verified by QA test runner agent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)