### PR TITLE
controller/push: fan-out CommandSyncConfig to active stewards on config push (Issue #1319)

### DIFF
--- a/features/controller/api/handlers_certificates_test.go
+++ b/features/controller/api/handlers_certificates_test.go
@@ -63,6 +63,7 @@ func setupCertTestServer(t *testing.T) (*Server, *cert.Manager) {
 		cfg, logger, controllerService, configService,
 		nil, rbacService, certMgr, tenantManager, rbacManager,
 		nil, nil, nil, "", nil, auditMgr,
+		nil, // No command publisher for basic tests
 	)
 	require.NoError(t, err)
 	t.Cleanup(func() {

--- a/features/controller/api/handlers_push.go
+++ b/features/controller/api/handlers_push.go
@@ -3,6 +3,7 @@
 package api
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -23,8 +24,8 @@ type leaderStatus interface {
 // handleConfigPush implements POST /api/v1/config/push.
 //
 // Validates the StewardConfiguration body, rejects non-leader nodes with 503,
-// records an audit event, and returns 202 Accepted with a push ID. Fan-out to
-// stewards is handled in a subsequent story and is deliberately out of scope.
+// records an audit event, triggers a fire-and-forget fan-out to all active
+// stewards via commandPublisher, and returns 202 Accepted immediately.
 func (s *Server) handleConfigPush(w http.ResponseWriter, r *http.Request) {
 	// Reject followers immediately — only the leader accepts config pushes.
 	if checker := s.pushLeaderStatus; checker != nil && !checker.IsLeader() {
@@ -54,6 +55,27 @@ func (s *Server) handleConfigPush(w http.ResponseWriter, r *http.Request) {
 	queuedAt := time.Now().UTC()
 
 	s.emitConfigPushAudit(r, cfg.TenantID, cfg.ConfigID, pushID)
+
+	// Fan-out CommandSyncConfig to every active steward. Fire-and-forget: the
+	// goroutine uses context.Background so it is not cancelled when the HTTP
+	// response is written. 202 is returned to the caller immediately.
+	if s.commandPublisher != nil {
+		stewards := s.controllerService.GetAllStewards()
+		cfgSnapshot := cfg
+		go func() {
+			result := push.Fanout(context.Background(), &cfgSnapshot, stewards, s.commandPublisher, s.logger)
+			s.logger.Info("Config push fan-out complete",
+				"push_id", pushID,
+				"succeeded", len(result.Succeeded),
+				"failed", len(result.Failed))
+			for stewardID, err := range result.Failed {
+				s.logger.Error("Config push fan-out delivery failed",
+					"push_id", pushID,
+					"steward_id", logging.SanitizeLogValue(stewardID),
+					"error", err)
+			}
+		}()
+	}
 
 	s.respondJSON(w, http.StatusAccepted, ConfigPushResponse{
 		PushID:   pushID,

--- a/features/controller/api/handlers_push_test.go
+++ b/features/controller/api/handlers_push_test.go
@@ -6,20 +6,27 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	common "github.com/cfgis/cfgms/api/proto/common"
+	ctrlproto "github.com/cfgis/cfgms/api/proto/controller"
+	"github.com/cfgis/cfgms/features/controller/commands"
 	"github.com/cfgis/cfgms/features/controller/config"
 	"github.com/cfgis/cfgms/features/controller/push"
 	"github.com/cfgis/cfgms/features/controller/service"
 	"github.com/cfgis/cfgms/features/rbac"
 	"github.com/cfgis/cfgms/features/tenant"
 	"github.com/cfgis/cfgms/pkg/audit"
+	controlplaneInterfaces "github.com/cfgis/cfgms/pkg/controlplane/interfaces"
+	controlplaneTypes "github.com/cfgis/cfgms/pkg/controlplane/types"
 	"github.com/cfgis/cfgms/pkg/logging"
 	business "github.com/cfgis/cfgms/pkg/storage/interfaces/business"
 	pkgtesting "github.com/cfgis/cfgms/pkg/testing"
@@ -87,6 +94,7 @@ func setupPushServer(t *testing.T) (*Server, *audit.Manager) {
 		nil, tenantManager, rbacManager,
 		nil, nil, nil, "", nil,
 		auditMgr,
+		nil, // No command publisher: fanout is out of scope for push handler unit tests
 	)
 	require.NoError(t, err)
 	t.Cleanup(func() {
@@ -251,4 +259,151 @@ func TestHandleConfigPush_AuditEventEmitted(t *testing.T) {
 	require.Len(t, entries, 1, "expected exactly one config.push.initiated audit entry")
 	assert.Equal(t, payload.TenantID, entries[0].TenantID)
 	assert.Equal(t, "config.push.initiated", entries[0].Action)
+}
+
+// syncedControlPlane is a real ControlPlaneProvider for handler-level fanout tests.
+// It records steward IDs from SendCommand calls and signals a WaitGroup so tests
+// can synchronize with the fire-and-forget goroutine.
+type syncedControlPlane struct {
+	mu       sync.Mutex
+	received []string
+	wg       sync.WaitGroup
+}
+
+func (c *syncedControlPlane) ReceivedIDs() []string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	out := make([]string, len(c.received))
+	copy(out, c.received)
+	return out
+}
+
+func (c *syncedControlPlane) Name() string      { return "synced-recording" }
+func (c *syncedControlPlane) IsConnected() bool { return true }
+
+func (c *syncedControlPlane) Initialize(_ context.Context, _ map[string]interface{}) error {
+	return nil
+}
+func (c *syncedControlPlane) Start(_ context.Context) error { return nil }
+func (c *syncedControlPlane) Stop(_ context.Context) error  { return nil }
+
+func (c *syncedControlPlane) SendCommand(_ context.Context, cmd *controlplaneTypes.SignedCommand) error {
+	defer c.wg.Done()
+	c.mu.Lock()
+	c.received = append(c.received, cmd.Command.StewardID)
+	c.mu.Unlock()
+	return nil
+}
+
+func (c *syncedControlPlane) FanOutCommand(_ context.Context, _ *controlplaneTypes.SignedCommand, _ []string) (*controlplaneTypes.FanOutResult, error) {
+	return nil, fmt.Errorf("FanOutCommand must not be called; route via SendCommand through TriggerConfigSync")
+}
+
+func (c *syncedControlPlane) SubscribeCommands(_ context.Context, _ string, _ controlplaneInterfaces.CommandHandler) error {
+	return nil
+}
+
+func (c *syncedControlPlane) PublishEvent(_ context.Context, _ *controlplaneTypes.Event) error {
+	return nil
+}
+
+func (c *syncedControlPlane) SubscribeEvents(_ context.Context, _ *controlplaneTypes.EventFilter, _ controlplaneInterfaces.EventHandler) error {
+	return nil
+}
+
+func (c *syncedControlPlane) SendHeartbeat(_ context.Context, _ *controlplaneTypes.Heartbeat) error {
+	return nil
+}
+
+func (c *syncedControlPlane) SubscribeHeartbeats(_ context.Context, _ controlplaneInterfaces.HeartbeatHandler) error {
+	return nil
+}
+
+func (c *syncedControlPlane) GetStats(_ context.Context) (*controlplaneTypes.ControlPlaneStats, error) {
+	return &controlplaneTypes.ControlPlaneStats{}, nil
+}
+
+// registerActiveSteward registers a steward and immediately transitions it to
+// "active" status via a heartbeat, matching the real steward lifecycle.
+// Returns the controller-assigned steward ID (not the DNA ID).
+func registerActiveSteward(t *testing.T, svc *service.ControllerService, dnaID string) string {
+	t.Helper()
+	ctx := context.Background()
+	resp, err := svc.AcceptRegistration(ctx, &ctrlproto.RegisterRequest{
+		Version:    "1.0.0",
+		InitialDna: &common.DNA{Id: dnaID},
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, resp.StewardId, "AcceptRegistration must return a generated steward ID")
+	_, err = svc.ProcessHeartbeat(ctx, &ctrlproto.HeartbeatRequest{
+		StewardId: resp.StewardId,
+		Status:    "active",
+	})
+	require.NoError(t, err)
+	return resp.StewardId
+}
+
+// makeSyncedPublisher creates a real commands.Publisher backed by the synced control plane.
+func makeSyncedPublisher(t *testing.T, cp *syncedControlPlane) *commands.Publisher {
+	t.Helper()
+	pub, err := commands.New(&commands.Config{
+		ControlPlane: cp,
+		Signer:       nil,
+		Logger:       logging.NewNoopLogger(),
+	})
+	require.NoError(t, err)
+	return pub
+}
+
+// TestHandleConfigPush_FanoutNoActiveStewards verifies that when commandPublisher is
+// wired but no active stewards exist, the handler still returns 202 and no SendCommand
+// calls are dispatched.
+func TestHandleConfigPush_FanoutNoActiveStewards(t *testing.T) {
+	server := setupTestServer(t)
+	server.pushLeaderStatus = nil // leader
+
+	cp := &syncedControlPlane{}
+	server.commandPublisher = makeSyncedPublisher(t, cp)
+
+	body := marshalPayload(t, validPushPayload())
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/config/push", body)
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+
+	server.handleConfigPush(rec, req)
+
+	require.Equal(t, http.StatusAccepted, rec.Code)
+	// No active stewards → Fanout skips all → no SendCommand calls.
+	// cp.received is never written by the goroutine, so this read is race-free.
+	assert.Empty(t, cp.ReceivedIDs())
+}
+
+// TestHandleConfigPush_FanoutToActiveStewards verifies that when commandPublisher is
+// wired and an active steward exists, the fire-and-forget goroutine dispatches
+// TriggerConfigSync (via SendCommand) to that steward.
+func TestHandleConfigPush_FanoutToActiveStewards(t *testing.T) {
+	server := setupTestServer(t)
+	server.pushLeaderStatus = nil // leader
+
+	cp := &syncedControlPlane{}
+	server.commandPublisher = makeSyncedPublisher(t, cp)
+
+	stewardID := registerActiveSteward(t, server.controllerService, "fanout-dna-1")
+
+	// Expect exactly one TriggerConfigSync call (one active steward).
+	cp.wg.Add(1)
+
+	body := marshalPayload(t, validPushPayload())
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/config/push", body)
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+
+	server.handleConfigPush(rec, req)
+
+	require.Equal(t, http.StatusAccepted, rec.Code)
+
+	// Wait for the fire-and-forget goroutine to deliver to the active steward.
+	cp.wg.Wait()
+
+	assert.ElementsMatch(t, []string{stewardID}, cp.ReceivedIDs())
 }

--- a/features/controller/api/handlers_registration_test.go
+++ b/features/controller/api/handlers_registration_test.go
@@ -108,6 +108,7 @@ func newHandleRegisterServer(t *testing.T, tokenStore registration.Store, certMg
 		"",
 		nil,
 		auditMgr,
+		nil, // No command publisher for basic tests
 	)
 	require.NoError(t, err)
 	t.Cleanup(func() {

--- a/features/controller/api/handlers_registration_tokens_test.go
+++ b/features/controller/api/handlers_registration_tokens_test.go
@@ -100,6 +100,7 @@ func setupTestServerWithTokenStore(t *testing.T) (*Server, registration.Store) {
 		"",       // No signer cert serial for basic tests
 		nil,      // No health collector for basic tests
 		auditMgr, // Issue #775: registration audit events
+		nil,      // No command publisher for basic tests
 	)
 	require.NoError(t, err)
 	t.Cleanup(func() {

--- a/features/controller/api/server.go
+++ b/features/controller/api/server.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/cfgis/cfgms/commercial/ha"
 	"github.com/cfgis/cfgms/features/config/rollback"
+	"github.com/cfgis/cfgms/features/controller/commands"
 	"github.com/cfgis/cfgms/features/controller/config"
 	"github.com/cfgis/cfgms/features/controller/fleet"
 	"github.com/cfgis/cfgms/features/controller/health"
@@ -71,6 +72,7 @@ type Server struct {
 	scriptAuditLogger       *script.AuditLogger            // Issue #708: in-memory execution metrics
 	scriptMonitor           *script.ExecutionMonitor       // Issue #708: active execution tracking
 	pushLeaderStatus        leaderStatus                   // Issue #1318: leader check for config push (nil = leader)
+	commandPublisher        *commands.Publisher            // Issue #1319: fan-out config push to active stewards
 	registry                registry.Registry              // Issue #1323: active steward connection registry
 	stopCleanup             chan struct{}                  // signals startAPIKeyCleanup to exit
 	cleanupDone             chan struct{}                  // closed when cleanup goroutine exits
@@ -118,6 +120,7 @@ func New(
 	signerCertSerial string, // Story #378: Serial of cert used for config signing
 	healthCollector *health.Collector, // Story #417: CFGMS health monitoring
 	auditManager *audit.Manager, // Issue #775: registration audit events
+	commandPublisher *commands.Publisher, // Issue #1319: fan-out config push to active stewards
 ) (*Server, error) {
 	if cfg == nil {
 		return nil, fmt.Errorf("config cannot be nil")
@@ -148,6 +151,7 @@ func New(
 		secretStore:             secretStore,              // M-AUTH-1: Central secrets provider
 		approvalHook:            &DefaultApprovalHook{},   // Issue #422: accept-all default
 		auditManager:            auditManager,             // Issue #775: registration audit events
+		commandPublisher:        commandPublisher,         // Issue #1319: fan-out config push to active stewards
 		stopCleanup:             make(chan struct{}),
 		cleanupDone:             make(chan struct{}),
 	}

--- a/features/controller/api/server_test.go
+++ b/features/controller/api/server_test.go
@@ -84,6 +84,7 @@ func setupTestServer(t *testing.T) *Server {
 		"",       // No signer cert serial for basic tests
 		nil,      // No health collector for basic tests
 		auditMgr, // Issue #775: registration audit events
+		nil,      // No command publisher for basic tests
 	)
 	require.NoError(t, err)
 	t.Cleanup(func() {
@@ -871,6 +872,7 @@ func setupTestServerWithLogger(t *testing.T, logger logging.Logger) *Server {
 		cfg, logger, controllerService, configService,
 		nil, rbacService, nil, tenantManager, rbacManager,
 		nil, nil, nil, "", nil, auditMgr,
+		nil, // No command publisher for basic tests
 	)
 	require.NoError(t, err)
 	t.Cleanup(func() {

--- a/features/controller/api/types.go
+++ b/features/controller/api/types.go
@@ -30,13 +30,13 @@ type APIError struct {
 
 // StewardInfo represents steward information for API responses
 type StewardInfo struct {
-	ID              string            `json:"id"`
-	Status          string            `json:"status"`
-	LastSeen        time.Time         `json:"last_seen"`
-	Version         string            `json:"version"`
-	ConnectedAt     time.Time         `json:"connected_at"`
-	Metrics         map[string]string `json:"metrics,omitempty"`
-	DNA             *DNAInfo          `json:"dna,omitempty"`
+	ID          string            `json:"id"`
+	Status      string            `json:"status"`
+	LastSeen    time.Time         `json:"last_seen"`
+	Version     string            `json:"version"`
+	ConnectedAt time.Time         `json:"connected_at"`
+	Metrics     map[string]string `json:"metrics,omitempty"`
+	DNA         *DNAInfo          `json:"dna,omitempty"`
 	// ActiveSessions is 1 when the steward has an active ControlChannel stream,
 	// 0 otherwise. Each steward holds at most one stream at a time, so this is
 	// a binary sentinel, not a real connection count.

--- a/features/controller/push/fanout.go
+++ b/features/controller/push/fanout.go
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+package push
+
+import (
+	"context"
+
+	"github.com/cfgis/cfgms/features/controller/commands"
+	"github.com/cfgis/cfgms/features/controller/service"
+	"github.com/cfgis/cfgms/pkg/logging"
+)
+
+// FanoutResult captures per-steward delivery outcomes from Fanout.
+type FanoutResult struct {
+	Succeeded []string
+	Failed    map[string]error
+}
+
+// Fanout sends a CommandSyncConfig to every active steward via the command publisher.
+// Stewards with Status != "active" are skipped. A failure for one steward does not
+// block delivery to others.
+func Fanout(
+	ctx context.Context,
+	cfg *StewardConfiguration,
+	stewards []*service.StewardInfo,
+	publisher *commands.Publisher,
+	logger logging.Logger,
+) FanoutResult {
+	result := FanoutResult{
+		Succeeded: []string{},
+		Failed:    make(map[string]error),
+	}
+
+	for _, steward := range stewards {
+		if steward.Status != "active" {
+			continue
+		}
+
+		_, err := publisher.TriggerConfigSync(ctx, steward.ID)
+		if err != nil {
+			logger.Error("Failed to trigger config sync for steward",
+				"steward_id", logging.SanitizeLogValue(steward.ID),
+				"error", err)
+			result.Failed[steward.ID] = err
+		} else {
+			logger.Info("Triggered config sync for steward",
+				"steward_id", logging.SanitizeLogValue(steward.ID))
+			result.Succeeded = append(result.Succeeded, steward.ID)
+		}
+	}
+
+	return result
+}

--- a/features/controller/push/fanout_test.go
+++ b/features/controller/push/fanout_test.go
@@ -1,0 +1,190 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+package push_test
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cfgis/cfgms/features/controller/commands"
+	"github.com/cfgis/cfgms/features/controller/push"
+	"github.com/cfgis/cfgms/features/controller/service"
+	controlplaneInterfaces "github.com/cfgis/cfgms/pkg/controlplane/interfaces"
+	controlplaneTypes "github.com/cfgis/cfgms/pkg/controlplane/types"
+	"github.com/cfgis/cfgms/pkg/logging"
+)
+
+// recordingControlPlane is a real ControlPlaneProvider implementation that records
+// steward IDs from SendCommand calls and can be configured to fail for specific IDs.
+type recordingControlPlane struct {
+	mu       sync.Mutex
+	received []string
+	failFor  map[string]error
+}
+
+func newRecordingControlPlane(failFor map[string]error) *recordingControlPlane {
+	if failFor == nil {
+		failFor = make(map[string]error)
+	}
+	return &recordingControlPlane{failFor: failFor}
+}
+
+// ReceivedIDs returns a copy of the steward IDs that received a SendCommand call.
+func (r *recordingControlPlane) ReceivedIDs() []string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make([]string, len(r.received))
+	copy(out, r.received)
+	return out
+}
+
+func (r *recordingControlPlane) Name() string      { return "recording" }
+func (r *recordingControlPlane) IsConnected() bool { return true }
+
+func (r *recordingControlPlane) Initialize(_ context.Context, _ map[string]interface{}) error {
+	return nil
+}
+func (r *recordingControlPlane) Start(_ context.Context) error { return nil }
+func (r *recordingControlPlane) Stop(_ context.Context) error  { return nil }
+
+func (r *recordingControlPlane) SendCommand(_ context.Context, cmd *controlplaneTypes.SignedCommand) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	id := cmd.Command.StewardID
+	if err, fail := r.failFor[id]; fail {
+		return err
+	}
+	r.received = append(r.received, id)
+	return nil
+}
+
+func (r *recordingControlPlane) FanOutCommand(_ context.Context, _ *controlplaneTypes.SignedCommand, _ []string) (*controlplaneTypes.FanOutResult, error) {
+	return nil, fmt.Errorf("FanOutCommand must not be called; route via SendCommand through TriggerConfigSync")
+}
+
+func (r *recordingControlPlane) SubscribeCommands(_ context.Context, _ string, _ controlplaneInterfaces.CommandHandler) error {
+	return nil
+}
+
+func (r *recordingControlPlane) PublishEvent(_ context.Context, _ *controlplaneTypes.Event) error {
+	return nil
+}
+
+func (r *recordingControlPlane) SubscribeEvents(_ context.Context, _ *controlplaneTypes.EventFilter, _ controlplaneInterfaces.EventHandler) error {
+	return nil
+}
+
+func (r *recordingControlPlane) SendHeartbeat(_ context.Context, _ *controlplaneTypes.Heartbeat) error {
+	return nil
+}
+
+func (r *recordingControlPlane) SubscribeHeartbeats(_ context.Context, _ controlplaneInterfaces.HeartbeatHandler) error {
+	return nil
+}
+
+func (r *recordingControlPlane) GetStats(_ context.Context) (*controlplaneTypes.ControlPlaneStats, error) {
+	return &controlplaneTypes.ControlPlaneStats{}, nil
+}
+
+// makePublisher creates a real commands.Publisher backed by the recording control plane.
+func makePublisher(t *testing.T, cp *recordingControlPlane) *commands.Publisher {
+	t.Helper()
+	pub, err := commands.New(&commands.Config{
+		ControlPlane: cp,
+		Signer:       nil, // unsigned for tests
+		Logger:       logging.NewNoopLogger(),
+	})
+	require.NoError(t, err)
+	return pub
+}
+
+func activeSteward(id string) *service.StewardInfo {
+	return &service.StewardInfo{ID: id, Status: "active", TenantID: "tenant-test"}
+}
+
+func stewardWithStatus(id, status string) *service.StewardInfo {
+	return &service.StewardInfo{ID: id, Status: status, TenantID: "tenant-test"}
+}
+
+func validFanoutCfg() *push.StewardConfiguration {
+	return &push.StewardConfiguration{
+		ConfigID: "cfg-001",
+		Version:  "1.0.0",
+		TenantID: "tenant-test",
+	}
+}
+
+// TestFanout_EmptyList verifies that an empty steward list yields a zero-result.
+func TestFanout_EmptyList(t *testing.T) {
+	cp := newRecordingControlPlane(nil)
+	pub := makePublisher(t, cp)
+
+	result := push.Fanout(context.Background(), validFanoutCfg(), nil, pub, logging.NewNoopLogger())
+
+	assert.Empty(t, result.Succeeded)
+	assert.Empty(t, result.Failed)
+	assert.Empty(t, cp.ReceivedIDs())
+}
+
+// TestFanout_ActiveStewards asserts that two active stewards each receive
+// TriggerConfigSync and both appear in FanoutResult.Succeeded.
+func TestFanout_ActiveStewards(t *testing.T) {
+	cp := newRecordingControlPlane(nil)
+	pub := makePublisher(t, cp)
+
+	stewards := []*service.StewardInfo{
+		activeSteward("steward-a"),
+		activeSteward("steward-b"),
+	}
+
+	result := push.Fanout(context.Background(), validFanoutCfg(), stewards, pub, logging.NewNoopLogger())
+
+	assert.Empty(t, result.Failed)
+	assert.ElementsMatch(t, []string{"steward-a", "steward-b"}, result.Succeeded)
+	assert.ElementsMatch(t, []string{"steward-a", "steward-b"}, cp.ReceivedIDs())
+}
+
+// TestFanout_SkipsNonActive asserts that stewards with status "registered" and
+// "lost" are not sent a TriggerConfigSync command.
+func TestFanout_SkipsNonActive(t *testing.T) {
+	cp := newRecordingControlPlane(nil)
+	pub := makePublisher(t, cp)
+
+	stewards := []*service.StewardInfo{
+		stewardWithStatus("steward-r", "registered"),
+		stewardWithStatus("steward-l", "lost"),
+	}
+
+	result := push.Fanout(context.Background(), validFanoutCfg(), stewards, pub, logging.NewNoopLogger())
+
+	assert.Empty(t, result.Succeeded)
+	assert.Empty(t, result.Failed)
+	assert.Empty(t, cp.ReceivedIDs(), "non-active stewards must not receive a SendCommand call")
+}
+
+// TestFanout_PartialFailure asserts that a TriggerConfigSync failure for one
+// steward is captured in FanoutResult.Failed while the other steward succeeds.
+func TestFanout_PartialFailure(t *testing.T) {
+	sendErr := fmt.Errorf("transport: connection refused")
+	cp := newRecordingControlPlane(map[string]error{
+		"steward-fail": sendErr,
+	})
+	pub := makePublisher(t, cp)
+
+	stewards := []*service.StewardInfo{
+		activeSteward("steward-ok"),
+		activeSteward("steward-fail"),
+	}
+
+	result := push.Fanout(context.Background(), validFanoutCfg(), stewards, pub, logging.NewNoopLogger())
+
+	assert.ElementsMatch(t, []string{"steward-ok"}, result.Succeeded)
+	require.Contains(t, result.Failed, "steward-fail")
+	assert.ErrorContains(t, result.Failed["steward-fail"], "connection refused")
+	assert.ElementsMatch(t, []string{"steward-ok"}, cp.ReceivedIDs())
+}

--- a/features/controller/server/server.go
+++ b/features/controller/server/server.go
@@ -523,6 +523,7 @@ func New(cfg *config.Config, logger logging.Logger) (*Server, error) {
 		signerCertSerial, // Story #378: signer cert serial for registration
 		healthCollector,  // Story #417: CFGMS health monitoring
 		auditManager,     // Issue #775: registration audit events
+		commandPublisher, // Issue #1319: fan-out config push to active stewards
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize HTTP API server: %w", err)


### PR DESCRIPTION
## Summary

- Adds `push.Fanout` in `features/controller/push/fanout.go` which iterates all stewards returned by `GetAllStewards()`, skips any not in "active" status, and calls `Publisher.TriggerConfigSync` per active steward, collecting per-steward success/failure into a `FanoutResult`
- Wires `Fanout` into `handleConfigPush` as a fire-and-forget goroutine (`context.Background`) so the 202 response is never delayed by fan-out delivery; partial failures are logged without blocking the caller
- Adds `commandPublisher *commands.Publisher` field and `New()` parameter to `features/controller/api/server.go`; `features/controller/server/server.go` passes the publisher into `api.New`

## Test plan

- [x] `push.TestFanout_EmptyList` — zero stewards → zero SendCommand calls, empty result
- [x] `push.TestFanout_ActiveStewards` — two active stewards → both receive TriggerConfigSync, both in Succeeded
- [x] `push.TestFanout_SkipsNonActive` — "registered"/"lost" stewards → no SendCommand calls
- [x] `push.TestFanout_PartialFailure` — one steward fails → appears in Failed, other succeeds
- [x] `api.TestHandleConfigPush_FanoutNoActiveStewards` — commandPublisher wired, no active stewards → 202, no SendCommand
- [x] `api.TestHandleConfigPush_FanoutToActiveStewards` — commandPublisher wired, one active steward → 202, WaitGroup sync confirms SendCommand delivered to correct steward ID
- [x] All pre-existing handler tests (Leader, NonLeader, MissingFields, InvalidJSON, RouteRegistered, AuditEventEmitted) continue to pass
- [x] `make test-agent-complete` passes (all packages, lint, license headers, architecture check, cross-platform compilation)

Fixes #1319

🤖 Generated with [Claude Code](https://claude.com/claude-code)