### PR TITLE
controller/push: wire push persistence into handler and leader-resume (Issue #1320)

### DIFF
--- a/features/controller/api/handlers_certificates_test.go
+++ b/features/controller/api/handlers_certificates_test.go
@@ -64,6 +64,7 @@ func setupCertTestServer(t *testing.T) (*Server, *cert.Manager) {
 		nil, rbacService, certMgr, tenantManager, rbacManager,
 		nil, nil, nil, "", nil, auditMgr,
 		nil, // No command publisher for basic tests
+		nil, // No push store for basic tests
 	)
 	require.NoError(t, err)
 	t.Cleanup(func() {

--- a/features/controller/api/handlers_push.go
+++ b/features/controller/api/handlers_push.go
@@ -56,6 +56,29 @@ func (s *Server) handleConfigPush(w http.ResponseWriter, r *http.Request) {
 
 	s.emitConfigPushAudit(r, cfg.TenantID, cfg.ConfigID, pushID)
 
+	// Durably record the push intent before fan-out begins so that an HA leader
+	// failover can replay any push that was interrupted mid-delivery.
+	if s.pushStore != nil {
+		pushData, marshalErr := json.Marshal(&cfg)
+		if marshalErr == nil {
+			record := &business.PushRecord{
+				ID:        pushID,
+				ConfigID:  cfg.ConfigID,
+				TenantID:  cfg.TenantID,
+				Version:   cfg.Version,
+				Status:    business.PushStatusInProgress,
+				Data:      pushData,
+				CreatedAt: queuedAt,
+				UpdatedAt: queuedAt,
+			}
+			if err := s.pushStore.CreatePush(r.Context(), record); err != nil {
+				s.logger.Warn("Failed to persist push record", "error", err, "push_id", pushID)
+			}
+		} else {
+			s.logger.Warn("Failed to marshal push payload for persistence", "error", marshalErr, "push_id", pushID)
+		}
+	}
+
 	// Fan-out CommandSyncConfig to every active steward. Fire-and-forget: the
 	// goroutine uses context.Background so it is not cancelled when the HTTP
 	// response is written. 202 is returned to the caller immediately.
@@ -73,6 +96,15 @@ func (s *Server) handleConfigPush(w http.ResponseWriter, r *http.Request) {
 					"push_id", pushID,
 					"steward_id", logging.SanitizeLogValue(stewardID),
 					"error", err)
+			}
+			if s.pushStore != nil {
+				finalStatus := business.PushStatusCompleted
+				if len(result.Failed) > 0 && len(result.Succeeded) == 0 {
+					finalStatus = business.PushStatusFailed
+				}
+				if updateErr := s.pushStore.UpdatePushStatus(context.Background(), pushID, finalStatus); updateErr != nil {
+					s.logger.Warn("Failed to update push record status", "error", updateErr, "push_id", pushID)
+				}
 			}
 		}()
 	}

--- a/features/controller/api/handlers_push_test.go
+++ b/features/controller/api/handlers_push_test.go
@@ -95,6 +95,7 @@ func setupPushServer(t *testing.T) (*Server, *audit.Manager) {
 		nil, nil, nil, "", nil,
 		auditMgr,
 		nil, // No command publisher: fanout is out of scope for push handler unit tests
+		nil, // No push store for audit-only push tests
 	)
 	require.NoError(t, err)
 	t.Cleanup(func() {
@@ -406,4 +407,251 @@ func TestHandleConfigPush_FanoutToActiveStewards(t *testing.T) {
 	cp.wg.Wait()
 
 	assert.ElementsMatch(t, []string{stewardID}, cp.ReceivedIDs())
+}
+
+// TestHandleConfigPush_PersistenceRecord verifies that a successful push request
+// creates a PushRecord with status in_progress in the push store before fan-out
+// begins. No commandPublisher is wired so the goroutine never runs and the record
+// stays in_progress — confirming durable capture regardless of delivery state.
+func TestHandleConfigPush_PersistenceRecord(t *testing.T) {
+	t.Setenv("CFGMS_SECRETS_REPO_PATH", t.TempDir())
+
+	cfg := config.DefaultConfig()
+	cfg.Certificate.EnableCertManagement = false
+	logger := logging.NewNoopLogger()
+
+	storageManager := pkgtesting.SetupTestStorage(t)
+
+	rbacManager := rbac.NewManagerWithStorage(
+		storageManager.GetAuditStore(),
+		storageManager.GetClientTenantStore(),
+		storageManager.GetRBACStore(),
+	)
+	require.NoError(t, rbacManager.Initialize(context.Background()))
+	t.Cleanup(func() {
+		closeCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_ = rbacManager.Close(closeCtx)
+	})
+
+	tenantStore := tenant.NewStorageAdapter(storageManager.GetTenantStore())
+	tenantManager := tenant.NewManager(tenantStore, rbacManager)
+
+	controllerService := service.NewControllerService(logger)
+	configService := service.NewConfigurationServiceV2(logger, storageManager, controllerService)
+	rbacService := service.NewRBACService(rbacManager)
+
+	auditMgr, err := audit.NewManager(storageManager.GetAuditStore(), "controller")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = auditMgr.Stop(context.Background()) })
+
+	pushStore := storageManager.GetPushStore()
+	require.NotNil(t, pushStore, "push store must be available from test storage")
+
+	server, err := New(
+		cfg, logger, controllerService, configService, nil, rbacService,
+		nil, tenantManager, rbacManager,
+		nil, nil, nil, "", nil,
+		auditMgr,
+		nil,       // No command publisher: goroutine never runs, record stays in_progress
+		pushStore, // Wire real push store
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		closeCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_ = server.Close(closeCtx)
+	})
+
+	server.pushLeaderStatus = nil // leader
+
+	payload := validPushPayload()
+	body := marshalPayload(t, payload)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/config/push", body)
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+
+	server.handleConfigPush(rec, req)
+
+	require.Equal(t, http.StatusAccepted, rec.Code)
+
+	// The push record must be durably written before the handler returns 202.
+	// No commandPublisher means the goroutine never runs, so the record
+	// remains in_progress — exactly what GetPendingPushes returns.
+	ctx := context.Background()
+	pending, err := pushStore.GetPendingPushes(ctx)
+	require.NoError(t, err)
+	require.Len(t, pending, 1, "expected exactly one in_progress push record")
+
+	record := pending[0]
+	assert.Equal(t, business.PushStatusInProgress, record.Status)
+	assert.Equal(t, payload.ConfigID, record.ConfigID)
+	assert.Equal(t, payload.TenantID, record.TenantID)
+	assert.Equal(t, payload.Version, record.Version)
+	assert.NotEmpty(t, record.ID)
+	assert.NotEmpty(t, record.Data, "push record must have marshalled payload for replay")
+}
+
+// failingControlPlane is a ControlPlaneProvider whose SendCommand always returns an error,
+// enabling tests that verify the PushStatusFailed branch in the fan-out goroutine.
+type failingControlPlane struct {
+	syncedControlPlane
+	sendErr error
+}
+
+func (c *failingControlPlane) SendCommand(_ context.Context, _ *controlplaneTypes.SignedCommand) error {
+	defer c.wg.Done()
+	return c.sendErr
+}
+
+// makePushServerWithStore creates a test server wired with both a command publisher
+// and a real push store so that the fan-out goroutine's UpdatePushStatus paths can be exercised.
+func makePushServerWithStore(t *testing.T, cp controlplaneInterfaces.ControlPlaneProvider) (*Server, business.PushStore) {
+	t.Helper()
+	t.Setenv("CFGMS_SECRETS_REPO_PATH", t.TempDir())
+
+	cfg := config.DefaultConfig()
+	cfg.Certificate.EnableCertManagement = false
+	logger := logging.NewNoopLogger()
+
+	storageManager := pkgtesting.SetupTestStorage(t)
+
+	rbacManager := rbac.NewManagerWithStorage(
+		storageManager.GetAuditStore(),
+		storageManager.GetClientTenantStore(),
+		storageManager.GetRBACStore(),
+	)
+	require.NoError(t, rbacManager.Initialize(context.Background()))
+	t.Cleanup(func() {
+		closeCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_ = rbacManager.Close(closeCtx)
+	})
+
+	tenantStore := tenant.NewStorageAdapter(storageManager.GetTenantStore())
+	tenantManager := tenant.NewManager(tenantStore, rbacManager)
+
+	controllerService := service.NewControllerService(logger)
+	configService := service.NewConfigurationServiceV2(logger, storageManager, controllerService)
+	rbacService := service.NewRBACService(rbacManager)
+
+	auditMgr, err := audit.NewManager(storageManager.GetAuditStore(), "controller")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = auditMgr.Stop(context.Background()) })
+
+	pushStore := storageManager.GetPushStore()
+	require.NotNil(t, pushStore)
+
+	pub, err := commands.New(&commands.Config{ControlPlane: cp, Signer: nil, Logger: logger})
+	require.NoError(t, err)
+
+	server, err := New(
+		cfg, logger, controllerService, configService, nil, rbacService,
+		nil, tenantManager, rbacManager,
+		nil, nil, nil, "", nil,
+		auditMgr,
+		pub,       // real command publisher
+		pushStore, // real push store
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		closeCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_ = server.Close(closeCtx)
+	})
+	return server, pushStore
+}
+
+// TestHandleConfigPush_PersistenceStatusCompleted verifies that when the fan-out goroutine
+// succeeds for all active stewards, the push record status is updated to completed.
+func TestHandleConfigPush_PersistenceStatusCompleted(t *testing.T) {
+	cp := &syncedControlPlane{}
+	server, pushStore := makePushServerWithStore(t, cp)
+	server.pushLeaderStatus = nil // leader
+
+	stewardID := registerActiveSteward(t, server.controllerService, "persist-complete-dna-1")
+	cp.wg.Add(1)
+
+	body := marshalPayload(t, validPushPayload())
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/config/push", body)
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+
+	server.handleConfigPush(rec, req)
+	require.Equal(t, http.StatusAccepted, rec.Code)
+
+	// Wait for the fire-and-forget goroutine to finish delivery and update status.
+	cp.wg.Wait()
+
+	// Allow the goroutine's UpdatePushStatus call to complete.
+	assert.ElementsMatch(t, []string{stewardID}, cp.ReceivedIDs())
+
+	// Status must be completed since delivery succeeded.
+	ctx := context.Background()
+	pending, err := pushStore.GetPendingPushes(ctx)
+	require.NoError(t, err)
+	assert.Empty(t, pending, "no in_progress records should remain after successful delivery")
+
+	// Retrieve the record by checking for completed status (GetPendingPushes skips completed).
+	var resp ConfigPushResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.NotEmpty(t, resp.PushID)
+
+	// Poll briefly for the status update to land (goroutine runs concurrently with wg.Wait).
+	var updated *business.PushRecord
+	for i := 0; i < 20; i++ {
+		updated, err = pushStore.GetPush(ctx, resp.PushID)
+		if err == nil && updated.Status == business.PushStatusCompleted {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	require.NoError(t, err)
+	assert.Equal(t, business.PushStatusCompleted, updated.Status,
+		"push record must be marked completed after successful fan-out delivery")
+}
+
+// TestHandleConfigPush_PersistenceStatusFailed verifies that when the fan-out goroutine
+// fails for all targeted stewards, the push record status is updated to failed.
+func TestHandleConfigPush_PersistenceStatusFailed(t *testing.T) {
+	cp := &failingControlPlane{
+		syncedControlPlane: syncedControlPlane{},
+		sendErr:            fmt.Errorf("simulated delivery failure"),
+	}
+	server, pushStore := makePushServerWithStore(t, cp)
+	server.pushLeaderStatus = nil // leader
+
+	// Register an active steward so the fanout targets it and fails.
+	registerActiveSteward(t, server.controllerService, "persist-fail-dna-1")
+	cp.wg.Add(1)
+
+	body := marshalPayload(t, validPushPayload())
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/config/push", body)
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+
+	server.handleConfigPush(rec, req)
+	require.Equal(t, http.StatusAccepted, rec.Code)
+
+	// Wait for the goroutine to attempt delivery and update the status.
+	cp.wg.Wait()
+
+	var resp ConfigPushResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.NotEmpty(t, resp.PushID)
+
+	// Poll briefly for the status update to land.
+	ctx := context.Background()
+	var updated *business.PushRecord
+	var err error
+	for i := 0; i < 20; i++ {
+		updated, err = pushStore.GetPush(ctx, resp.PushID)
+		if err == nil && updated.Status == business.PushStatusFailed {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	require.NoError(t, err)
+	assert.Equal(t, business.PushStatusFailed, updated.Status,
+		"push record must be marked failed when all targeted stewards fail delivery")
 }

--- a/features/controller/api/handlers_registration_test.go
+++ b/features/controller/api/handlers_registration_test.go
@@ -109,6 +109,7 @@ func newHandleRegisterServer(t *testing.T, tokenStore registration.Store, certMg
 		nil,
 		auditMgr,
 		nil, // No command publisher for basic tests
+		nil, // No push store for basic tests
 	)
 	require.NoError(t, err)
 	t.Cleanup(func() {

--- a/features/controller/api/handlers_registration_tokens_test.go
+++ b/features/controller/api/handlers_registration_tokens_test.go
@@ -101,6 +101,7 @@ func setupTestServerWithTokenStore(t *testing.T) (*Server, registration.Store) {
 		nil,      // No health collector for basic tests
 		auditMgr, // Issue #775: registration audit events
 		nil,      // No command publisher for basic tests
+		nil,      // No push store for basic tests
 	)
 	require.NoError(t, err)
 	t.Cleanup(func() {

--- a/features/controller/api/server.go
+++ b/features/controller/api/server.go
@@ -35,6 +35,7 @@ import (
 	"github.com/cfgis/cfgms/pkg/registration"
 	secretsif "github.com/cfgis/cfgms/pkg/secrets/interfaces"
 	_ "github.com/cfgis/cfgms/pkg/secrets/providers/sops" // Auto-register SOPS provider
+	business "github.com/cfgis/cfgms/pkg/storage/interfaces/business"
 	"github.com/cfgis/cfgms/pkg/transport/registry"
 )
 
@@ -73,6 +74,7 @@ type Server struct {
 	scriptMonitor           *script.ExecutionMonitor       // Issue #708: active execution tracking
 	pushLeaderStatus        leaderStatus                   // Issue #1318: leader check for config push (nil = leader)
 	commandPublisher        *commands.Publisher            // Issue #1319: fan-out config push to active stewards
+	pushStore               business.PushStore             // Issue #1320: durable push-state persistence for HA failover
 	registry                registry.Registry              // Issue #1323: active steward connection registry
 	stopCleanup             chan struct{}                  // signals startAPIKeyCleanup to exit
 	cleanupDone             chan struct{}                  // closed when cleanup goroutine exits
@@ -121,6 +123,7 @@ func New(
 	healthCollector *health.Collector, // Story #417: CFGMS health monitoring
 	auditManager *audit.Manager, // Issue #775: registration audit events
 	commandPublisher *commands.Publisher, // Issue #1319: fan-out config push to active stewards
+	pushStore business.PushStore, // Issue #1320: durable push-state persistence for HA failover
 ) (*Server, error) {
 	if cfg == nil {
 		return nil, fmt.Errorf("config cannot be nil")
@@ -152,6 +155,7 @@ func New(
 		approvalHook:            &DefaultApprovalHook{},   // Issue #422: accept-all default
 		auditManager:            auditManager,             // Issue #775: registration audit events
 		commandPublisher:        commandPublisher,         // Issue #1319: fan-out config push to active stewards
+		pushStore:               pushStore,                // Issue #1320: durable push-state persistence for HA failover
 		stopCleanup:             make(chan struct{}),
 		cleanupDone:             make(chan struct{}),
 	}

--- a/features/controller/api/server_test.go
+++ b/features/controller/api/server_test.go
@@ -85,6 +85,7 @@ func setupTestServer(t *testing.T) *Server {
 		nil,      // No health collector for basic tests
 		auditMgr, // Issue #775: registration audit events
 		nil,      // No command publisher for basic tests
+		nil,      // No push store for basic tests
 	)
 	require.NoError(t, err)
 	t.Cleanup(func() {
@@ -873,6 +874,7 @@ func setupTestServerWithLogger(t *testing.T, logger logging.Logger) *Server {
 		nil, rbacService, nil, tenantManager, rbacManager,
 		nil, nil, nil, "", nil, auditMgr,
 		nil, // No command publisher for basic tests
+		nil, // No push store for basic tests
 	)
 	require.NoError(t, err)
 	t.Cleanup(func() {

--- a/features/controller/server/push_resume_test.go
+++ b/features/controller/server/push_resume_test.go
@@ -1,0 +1,376 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	common "github.com/cfgis/cfgms/api/proto/common"
+	ctrlproto "github.com/cfgis/cfgms/api/proto/controller"
+	"github.com/cfgis/cfgms/features/controller/commands"
+	"github.com/cfgis/cfgms/features/controller/config"
+	"github.com/cfgis/cfgms/features/controller/push"
+	controlplaneInterfaces "github.com/cfgis/cfgms/pkg/controlplane/interfaces"
+	controlplaneTypes "github.com/cfgis/cfgms/pkg/controlplane/types"
+	"github.com/cfgis/cfgms/pkg/logging"
+	business "github.com/cfgis/cfgms/pkg/storage/interfaces/business"
+)
+
+// recordingControlPlane is a minimal ControlPlaneProvider for server-level tests.
+// It records steward IDs from SendCommand calls and signals a WaitGroup so tests
+// can synchronize with the fan-out goroutine.
+type recordingControlPlane struct {
+	mu       sync.Mutex
+	received []string
+	wg       sync.WaitGroup
+}
+
+// errorControlPlane is a ControlPlaneProvider whose SendCommand always returns an error,
+// enabling tests for the PushStatusFailed branch in resumePendingPushes.
+type errorControlPlane struct {
+	recordingControlPlane
+	sendErr error
+}
+
+func (c *recordingControlPlane) ReceivedIDs() []string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	out := make([]string, len(c.received))
+	copy(out, c.received)
+	return out
+}
+
+func (c *recordingControlPlane) Name() string      { return "recording" }
+func (c *recordingControlPlane) IsConnected() bool { return true }
+
+func (c *recordingControlPlane) Initialize(_ context.Context, _ map[string]interface{}) error {
+	return nil
+}
+func (c *recordingControlPlane) Start(_ context.Context) error { return nil }
+func (c *recordingControlPlane) Stop(_ context.Context) error  { return nil }
+
+func (c *recordingControlPlane) SendCommand(_ context.Context, cmd *controlplaneTypes.SignedCommand) error {
+	defer c.wg.Done()
+	c.mu.Lock()
+	c.received = append(c.received, cmd.Command.StewardID)
+	c.mu.Unlock()
+	return nil
+}
+
+func (c *errorControlPlane) SendCommand(_ context.Context, _ *controlplaneTypes.SignedCommand) error {
+	defer c.wg.Done()
+	return c.sendErr
+}
+
+func (c *recordingControlPlane) FanOutCommand(_ context.Context, _ *controlplaneTypes.SignedCommand, _ []string) (*controlplaneTypes.FanOutResult, error) {
+	return nil, fmt.Errorf("FanOutCommand must not be called in resume tests")
+}
+
+func (c *recordingControlPlane) SubscribeCommands(_ context.Context, _ string, _ controlplaneInterfaces.CommandHandler) error {
+	return nil
+}
+
+func (c *recordingControlPlane) PublishEvent(_ context.Context, _ *controlplaneTypes.Event) error {
+	return nil
+}
+
+func (c *recordingControlPlane) SubscribeEvents(_ context.Context, _ *controlplaneTypes.EventFilter, _ controlplaneInterfaces.EventHandler) error {
+	return nil
+}
+
+func (c *recordingControlPlane) SendHeartbeat(_ context.Context, _ *controlplaneTypes.Heartbeat) error {
+	return nil
+}
+
+func (c *recordingControlPlane) SubscribeHeartbeats(_ context.Context, _ controlplaneInterfaces.HeartbeatHandler) error {
+	return nil
+}
+
+func (c *recordingControlPlane) GetStats(_ context.Context) (*controlplaneTypes.ControlPlaneStats, error) {
+	return &controlplaneTypes.ControlPlaneStats{}, nil
+}
+
+// makeRecordingPublisher creates a real commands.Publisher backed by the recording control plane.
+func makeRecordingPublisher(t *testing.T, cp *recordingControlPlane) *commands.Publisher {
+	t.Helper()
+	pub, err := commands.New(&commands.Config{
+		ControlPlane: cp,
+		Signer:       nil,
+		Logger:       logging.NewNoopLogger(),
+	})
+	require.NoError(t, err)
+	require.NoError(t, pub.Start(context.Background()))
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+		defer cancel()
+		_ = pub.Stop(ctx)
+	})
+	return pub
+}
+
+// registerResumeSteward registers a steward and transitions it to "active" status.
+// Returns the controller-assigned steward ID.
+func registerResumeSteward(t *testing.T, srv *Server, dnaID string) string {
+	t.Helper()
+	ctx := context.Background()
+	resp, err := srv.controllerService.AcceptRegistration(ctx, &ctrlproto.RegisterRequest{
+		Version:    "1.0.0",
+		InitialDna: &common.DNA{Id: dnaID},
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, resp.StewardId)
+	_, err = srv.controllerService.ProcessHeartbeat(ctx, &ctrlproto.HeartbeatRequest{
+		StewardId: resp.StewardId,
+		Status:    "active",
+	})
+	require.NoError(t, err)
+	return resp.StewardId
+}
+
+// TestLeaderResumePendingPushes asserts that on startup as leader,
+// GetPendingPushes() results trigger TriggerConfigSync for each affected
+// steward and that the push record status is updated to completed.
+func TestLeaderResumePendingPushes(t *testing.T) {
+	t.Setenv("CFGMS_SECRETS_REPO_PATH", t.TempDir())
+
+	tempDir := t.TempDir()
+	cfg := &config.Config{
+		ListenAddr: "127.0.0.1:0",
+		Certificate: &config.CertificateConfig{
+			EnableCertManagement: false,
+		},
+		Storage: &config.StorageConfig{
+			Provider:     "flatfile",
+			FlatfileRoot: tempDir + "/flatfile",
+			SQLitePath:   tempDir + "/cfgms.db",
+		},
+	}
+
+	srv, err := New(cfg, logging.NewNoopLogger())
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = srv.Stop() })
+
+	// Wire a recording control plane and publisher. New() creates no commandPublisher
+	// in OSS mode (no Transport config), so we inject one directly.
+	rcp := &recordingControlPlane{}
+	srv.commandPublisher = makeRecordingPublisher(t, rcp)
+
+	// Register one active steward so resumePendingPushes has a delivery target.
+	ctx := context.Background()
+	stewardID := registerResumeSteward(t, srv, "resume-dna-1")
+
+	// Create an in-progress push record as if a previous leader was interrupted.
+	pushStore := srv.storageManager.GetPushStore()
+	require.NotNil(t, pushStore, "push store must be available via storage manager")
+
+	cfg2 := push.StewardConfiguration{
+		ConfigID: "cfg-resume-001",
+		Version:  "2.0.0",
+		TenantID: "tenant-resume",
+	}
+	data, marshalErr := json.Marshal(&cfg2)
+	require.NoError(t, marshalErr)
+
+	pushID := "push-resume-test-1"
+	require.NoError(t, pushStore.CreatePush(ctx, &business.PushRecord{
+		ID:        pushID,
+		ConfigID:  cfg2.ConfigID,
+		TenantID:  cfg2.TenantID,
+		Version:   cfg2.Version,
+		Status:    business.PushStatusInProgress,
+		Data:      data,
+		CreatedAt: time.Now(),
+		UpdatedAt: time.Now(),
+	}))
+
+	// resumePendingPushes delivers to every active steward — expect one SendCommand.
+	rcp.wg.Add(1)
+
+	srv.resumePendingPushes(ctx)
+
+	// Wait for the synchronous fan-out (resumePendingPushes calls push.Fanout directly).
+	rcp.wg.Wait()
+
+	// Verify TriggerConfigSync was dispatched to the active steward.
+	assert.ElementsMatch(t, []string{stewardID}, rcp.ReceivedIDs(),
+		"resumePendingPushes must trigger TriggerConfigSync for each active steward")
+
+	// Verify the push record was updated to completed after successful delivery.
+	updated, err := pushStore.GetPush(ctx, pushID)
+	require.NoError(t, err)
+	assert.Equal(t, business.PushStatusCompleted, updated.Status,
+		"push record must be marked completed after successful resume delivery")
+}
+
+// TestLeaderResumePendingPushes_NoPendingPushes verifies that resumePendingPushes
+// is a no-op when no in_progress records exist in the push store.
+func TestLeaderResumePendingPushes_NoPendingPushes(t *testing.T) {
+	t.Setenv("CFGMS_SECRETS_REPO_PATH", t.TempDir())
+
+	tempDir := t.TempDir()
+	cfg := &config.Config{
+		ListenAddr: "127.0.0.1:0",
+		Certificate: &config.CertificateConfig{
+			EnableCertManagement: false,
+		},
+		Storage: &config.StorageConfig{
+			Provider:     "flatfile",
+			FlatfileRoot: tempDir + "/flatfile",
+			SQLitePath:   tempDir + "/cfgms.db",
+		},
+	}
+
+	srv, err := New(cfg, logging.NewNoopLogger())
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = srv.Stop() })
+
+	rcp := &recordingControlPlane{}
+	srv.commandPublisher = makeRecordingPublisher(t, rcp)
+
+	// No push records inserted — resumePendingPushes should be a no-op.
+	srv.resumePendingPushes(context.Background())
+
+	// No SendCommand calls should have been made.
+	assert.Empty(t, rcp.ReceivedIDs(), "no SendCommand calls expected when push store is empty")
+}
+
+// TestLeaderResumePendingPushes_BadDataMarkedFailed verifies that a push record
+// with an undecodable Data blob is marked PushStatusFailed and processing continues.
+func TestLeaderResumePendingPushes_BadDataMarkedFailed(t *testing.T) {
+	t.Setenv("CFGMS_SECRETS_REPO_PATH", t.TempDir())
+
+	tempDir := t.TempDir()
+	cfg := &config.Config{
+		ListenAddr: "127.0.0.1:0",
+		Certificate: &config.CertificateConfig{
+			EnableCertManagement: false,
+		},
+		Storage: &config.StorageConfig{
+			Provider:     "flatfile",
+			FlatfileRoot: tempDir + "/flatfile",
+			SQLitePath:   tempDir + "/cfgms.db",
+		},
+	}
+
+	srv, err := New(cfg, logging.NewNoopLogger())
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = srv.Stop() })
+
+	rcp := &recordingControlPlane{}
+	srv.commandPublisher = makeRecordingPublisher(t, rcp)
+
+	ctx := context.Background()
+	pushStore := srv.storageManager.GetPushStore()
+	require.NotNil(t, pushStore)
+
+	pushID := "push-bad-data"
+	require.NoError(t, pushStore.CreatePush(ctx, &business.PushRecord{
+		ID:        pushID,
+		ConfigID:  "cfg-bad",
+		TenantID:  "tenant-bad",
+		Version:   "1.0.0",
+		Status:    business.PushStatusInProgress,
+		Data:      []byte("{not valid json"),
+		CreatedAt: time.Now(),
+		UpdatedAt: time.Now(),
+	}))
+
+	srv.resumePendingPushes(ctx)
+
+	// Record with invalid data must be marked failed.
+	updated, err := pushStore.GetPush(ctx, pushID)
+	require.NoError(t, err)
+	assert.Equal(t, business.PushStatusFailed, updated.Status,
+		"push record with invalid data must be marked failed")
+
+	// No SendCommand calls should have been made.
+	assert.Empty(t, rcp.ReceivedIDs())
+}
+
+// TestLeaderResumePendingPushes_DeliveryFailureMarkedFailed verifies that when
+// all stewards fail delivery during resume, the push record is marked PushStatusFailed.
+func TestLeaderResumePendingPushes_DeliveryFailureMarkedFailed(t *testing.T) {
+	t.Setenv("CFGMS_SECRETS_REPO_PATH", t.TempDir())
+
+	tempDir := t.TempDir()
+	cfg := &config.Config{
+		ListenAddr: "127.0.0.1:0",
+		Certificate: &config.CertificateConfig{
+			EnableCertManagement: false,
+		},
+		Storage: &config.StorageConfig{
+			Provider:     "flatfile",
+			FlatfileRoot: tempDir + "/flatfile",
+			SQLitePath:   tempDir + "/cfgms.db",
+		},
+	}
+
+	srv, err := New(cfg, logging.NewNoopLogger())
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = srv.Stop() })
+
+	ecp := &errorControlPlane{
+		sendErr: fmt.Errorf("simulated network failure"),
+	}
+	pub, err := commands.New(&commands.Config{
+		ControlPlane: ecp,
+		Logger:       logging.NewNoopLogger(),
+	})
+	require.NoError(t, err)
+	require.NoError(t, pub.Start(context.Background()))
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+		defer cancel()
+		_ = pub.Stop(ctx)
+	})
+	srv.commandPublisher = pub
+
+	// Register an active steward so the fanout targets it and fails.
+	ctx := context.Background()
+	registerResumeSteward(t, srv, "resume-fail-dna-1")
+
+	pushStore := srv.storageManager.GetPushStore()
+	require.NotNil(t, pushStore)
+
+	cfg2 := push.StewardConfiguration{
+		ConfigID: "cfg-fail-001",
+		Version:  "1.0.0",
+		TenantID: "tenant-fail",
+	}
+	data, marshalErr := json.Marshal(&cfg2)
+	require.NoError(t, marshalErr)
+
+	pushID := "push-fail-test-1"
+	require.NoError(t, pushStore.CreatePush(ctx, &business.PushRecord{
+		ID:        pushID,
+		ConfigID:  cfg2.ConfigID,
+		TenantID:  cfg2.TenantID,
+		Version:   cfg2.Version,
+		Status:    business.PushStatusInProgress,
+		Data:      data,
+		CreatedAt: time.Now(),
+		UpdatedAt: time.Now(),
+	}))
+
+	// Expect one failed SendCommand attempt for the active steward.
+	ecp.wg.Add(1)
+
+	srv.resumePendingPushes(ctx)
+
+	// Wait for the synchronous fan-out (resumePendingPushes calls push.Fanout directly).
+	ecp.wg.Wait()
+
+	// All deliveries failed — push record must be marked failed.
+	updated, err := pushStore.GetPush(ctx, pushID)
+	require.NoError(t, err)
+	assert.Equal(t, business.PushStatusFailed, updated.Status,
+		"push record must be marked failed when all stewards fail delivery during resume")
+}

--- a/features/controller/server/server.go
+++ b/features/controller/server/server.go
@@ -5,6 +5,7 @@ package server
 import (
 	"context"
 	"crypto/tls"
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -28,6 +29,7 @@ import (
 	"github.com/cfgis/cfgms/features/controller/health"
 	"github.com/cfgis/cfgms/features/controller/heartbeat"
 	"github.com/cfgis/cfgms/features/controller/initialization"
+	"github.com/cfgis/cfgms/features/controller/push"
 	"github.com/cfgis/cfgms/features/controller/service"
 	controllerTransport "github.com/cfgis/cfgms/features/controller/transport"
 	"github.com/cfgis/cfgms/features/rbac"
@@ -55,6 +57,7 @@ import (
 	"github.com/cfgis/cfgms/pkg/logging"
 	pkgRegistration "github.com/cfgis/cfgms/pkg/registration"
 	"github.com/cfgis/cfgms/pkg/storage/interfaces"
+	business "github.com/cfgis/cfgms/pkg/storage/interfaces/business"
 	cfgconfig "github.com/cfgis/cfgms/pkg/storage/interfaces/config"
 	_ "github.com/cfgis/cfgms/pkg/storage/providers/flatfile" // register flatfile provider for OSS composite manager
 	_ "github.com/cfgis/cfgms/pkg/storage/providers/sqlite"   // register sqlite provider for OSS composite manager
@@ -519,11 +522,12 @@ func New(cfg *config.Config, logger logging.Logger) (*Server, error) {
 		rbacManager,
 		nil, // systemMonitor
 		haManager,
-		regStore,         // registrationTokenStore
-		signerCertSerial, // Story #378: signer cert serial for registration
-		healthCollector,  // Story #417: CFGMS health monitoring
-		auditManager,     // Issue #775: registration audit events
-		commandPublisher, // Issue #1319: fan-out config push to active stewards
+		regStore,                      // registrationTokenStore
+		signerCertSerial,              // Story #378: signer cert serial for registration
+		healthCollector,               // Story #417: CFGMS health monitoring
+		auditManager,                  // Issue #775: registration audit events
+		commandPublisher,              // Issue #1319: fan-out config push to active stewards
+		storageManager.GetPushStore(), // Issue #1320: durable push-state for HA failover
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize HTTP API server: %w", err)
@@ -931,6 +935,13 @@ func (s *Server) Start() error {
 		"ha_mode", s.haManager.GetDeploymentMode().String(),
 		"is_leader", s.haManager.IsLeader())
 
+	// Issue #1320: On startup, if this node is the leader, replay any push
+	// operations that were interrupted before a previous leader could complete
+	// delivery. Nil haManager means OSS single-node mode, which is always leader.
+	if (s.haManager == nil || s.haManager.IsLeader()) && s.commandPublisher != nil {
+		go s.resumePendingPushes(context.Background())
+	}
+
 	// Record system startup audit event
 	if s.auditManager != nil {
 		ctx := context.Background()
@@ -1082,6 +1093,55 @@ func (s *Server) Stop() error {
 	}
 
 	return nil
+}
+
+// resumePendingPushes is called on leader startup to re-deliver any push
+// operations that were recorded as in_progress before the previous leader
+// stopped. It unmarshals the stored StewardConfiguration blob and calls
+// push.Fanout for each pending record, updating the final status on completion.
+func (s *Server) resumePendingPushes(ctx context.Context) {
+	if s.storageManager == nil || s.commandPublisher == nil {
+		return
+	}
+	pushStore := s.storageManager.GetPushStore()
+	if pushStore == nil {
+		return
+	}
+	records, err := pushStore.GetPendingPushes(ctx)
+	if err != nil {
+		s.logger.Error("Failed to load pending pushes for leader resume", "error", err)
+		return
+	}
+	if len(records) == 0 {
+		return
+	}
+	s.logger.Info("Resuming pending push operations after leader election", "count", len(records))
+	for _, record := range records {
+		var cfg push.StewardConfiguration
+		if err := json.Unmarshal(record.Data, &cfg); err != nil {
+			s.logger.Error("Failed to unmarshal push data for resume; marking failed",
+				"push_id", record.ID, "error", err)
+			if updateErr := pushStore.UpdatePushStatus(ctx, record.ID, business.PushStatusFailed); updateErr != nil {
+				s.logger.Warn("Failed to mark push as failed after unmarshal error",
+					"push_id", record.ID, "error", updateErr)
+			}
+			continue
+		}
+		stewards := s.controllerService.GetAllStewards()
+		result := push.Fanout(ctx, &cfg, stewards, s.commandPublisher, s.logger)
+		s.logger.Info("Resumed push fan-out complete",
+			"push_id", record.ID,
+			"succeeded", len(result.Succeeded),
+			"failed", len(result.Failed))
+		finalStatus := business.PushStatusCompleted
+		if len(result.Failed) > 0 && len(result.Succeeded) == 0 {
+			finalStatus = business.PushStatusFailed
+		}
+		if updateErr := pushStore.UpdatePushStatus(ctx, record.ID, finalStatus); updateErr != nil {
+			s.logger.Warn("Failed to update push record status after resume",
+				"push_id", record.ID, "error", updateErr)
+		}
+	}
 }
 
 // GetConfigurationService returns the configuration service instance


### PR DESCRIPTION
## Summary

- Wires `PushStore` durability into `POST /api/v1/config/push`: every accepted push is recorded as `in_progress` before fan-out begins, and the goroutine updates the status to `completed` or `failed` after delivery
- Implements `resumePendingPushes` on `server.Server`: on leader startup, reads `GetPendingPushes()`, unmarshals the stored `StewardConfiguration` blob, and calls `push.Fanout` with `commandPublisher` for each interrupted record
- Calls `resumePendingPushes` in `Start()` when node is leader (nil `haManager` = OSS single-node = always leader, matching convention from #1318)

Fixes #1320

## Acceptance Criteria

- [x] `features/controller/api/server.go` has `pushStore business.PushStore` field; `New()` accepts it
- [x] `POST /api/v1/config/push` creates a `PushRecord` with `status: in_progress` before fan-out starts
- [x] After fan-out completes, the `PushRecord` is updated to `completed` or `failed`
- [x] At `Start()`, if `haManager.IsLeader()`, `GetPendingPushes()` is called and any `in_progress` records are re-run via `Fanout`
- [x] `TestHandleConfigPush_PersistenceRecord` — in_progress record exists after push request
- [x] `TestLeaderResumePendingPushes` — TriggerConfigSync dispatched and record marked completed
- [x] Tests added for all behavior changes including error paths
- [x] `make test-agent-complete` passes

## Test Plan

- [ ] `TestHandleConfigPush_PersistenceRecord` — nil commandPublisher; record stays in_progress
- [ ] `TestHandleConfigPush_PersistenceStatusCompleted` — real delivery; record transitions to completed
- [ ] `TestHandleConfigPush_PersistenceStatusFailed` — failing control plane; record transitions to failed
- [ ] `TestLeaderResumePendingPushes` — active steward + pending record; TriggerConfigSync called, record completed
- [ ] `TestLeaderResumePendingPushes_NoPendingPushes` — empty store; no-op
- [ ] `TestLeaderResumePendingPushes_BadDataMarkedFailed` — invalid JSON blob; record marked failed
- [ ] `TestLeaderResumePendingPushes_DeliveryFailureMarkedFailed` — error control plane; record marked failed

## Specialist Review Results

**QA Test Runner**: PASS — all unit tests, lint, architecture checks, and cross-platform builds passed; `make test-agent-complete` succeeded; marker written to `/tmp/agent-validation-passed`

**QA Code Reviewer**: PASS — no blocking issues; two non-blocking warnings (bounded polling loop after goroutine delivery, and a redundant `wg.Wait()` after synchronous call — both acceptable)

**Security Engineer**: PASS — no blocking issues; check-architecture passed with no violations; all user-controlled fields properly sanitized with `logging.SanitizeLogValue()`; no direct storage provider imports in feature code; context usage correct (`r.Context()` for synchronous handler calls, `context.Background()` for fire-and-forget goroutines)

🤖 Generated with [Claude Code](https://claude.com/claude-code)