### PR TITLE
entra_group: implement group member and owner operations (Issue #1366)

### DIFF
--- a/features/modules/m365/directory_provider_test.go
+++ b/features/modules/m365/directory_provider_test.go
@@ -380,6 +380,30 @@ func (m *MockGraphClient) RemoveAdminUnitScopedRoleMember(ctx context.Context, t
 	return nil
 }
 
+func (m *MockGraphClient) ListGroupMembers(ctx context.Context, token *auth.AccessToken, groupID string) ([]string, error) {
+	return nil, nil
+}
+
+func (m *MockGraphClient) AddGroupMember(ctx context.Context, token *auth.AccessToken, groupID, memberUPN string) error {
+	return nil
+}
+
+func (m *MockGraphClient) RemoveGroupMember(ctx context.Context, token *auth.AccessToken, groupID, memberUPN string) error {
+	return nil
+}
+
+func (m *MockGraphClient) ListGroupOwners(ctx context.Context, token *auth.AccessToken, groupID string) ([]string, error) {
+	return nil, nil
+}
+
+func (m *MockGraphClient) AddGroupOwner(ctx context.Context, token *auth.AccessToken, groupID, ownerUPN string) error {
+	return nil
+}
+
+func (m *MockGraphClient) RemoveGroupOwner(ctx context.Context, token *auth.AccessToken, groupID, ownerUPN string) error {
+	return nil
+}
+
 // Test functions
 
 func TestNewEntraIDDirectoryProvider(t *testing.T) {

--- a/features/modules/m365/entra_application/module_test.go
+++ b/features/modules/m365/entra_application/module_test.go
@@ -270,6 +270,30 @@ func (m *MockGraphClient) RemoveAdminUnitScopedRoleMember(ctx context.Context, t
 	return nil
 }
 
+func (m *MockGraphClient) ListGroupMembers(ctx context.Context, token *auth.AccessToken, groupID string) ([]string, error) {
+	return nil, nil
+}
+
+func (m *MockGraphClient) AddGroupMember(ctx context.Context, token *auth.AccessToken, groupID, memberUPN string) error {
+	return nil
+}
+
+func (m *MockGraphClient) RemoveGroupMember(ctx context.Context, token *auth.AccessToken, groupID, memberUPN string) error {
+	return nil
+}
+
+func (m *MockGraphClient) ListGroupOwners(ctx context.Context, token *auth.AccessToken, groupID string) ([]string, error) {
+	return nil, nil
+}
+
+func (m *MockGraphClient) AddGroupOwner(ctx context.Context, token *auth.AccessToken, groupID, ownerUPN string) error {
+	return nil
+}
+
+func (m *MockGraphClient) RemoveGroupOwner(ctx context.Context, token *auth.AccessToken, groupID, ownerUPN string) error {
+	return nil
+}
+
 func TestNew(t *testing.T) {
 	mockAuth := &MockAuthProvider{}
 	mockGraph := &MockGraphClient{}

--- a/features/modules/m365/entra_group/integration_test.go
+++ b/features/modules/m365/entra_group/integration_test.go
@@ -284,12 +284,148 @@ func TestEntraGroup_Integration_AuthenticationFlow(t *testing.T) {
 	assert.True(t, isValid, "Token should be valid")
 }
 
+// TestEntraGroup_Integration_MemberOwnerSync verifies member and owner sync against the real Graph API.
+func TestEntraGroup_Integration_MemberOwnerSync(t *testing.T) {
+	checkM365Integration(t)
+
+	authProvider := createRealAuthProvider(t)
+	graphClient := createRealGraphClient(t)
+	module := New(authProvider, graphClient).(*entraGroupModule)
+
+	ctx := context.Background()
+	tenantID := os.Getenv("M365_TENANT_ID")
+	timestamp := time.Now().Format("20060102-150405")
+
+	// Create a test group to work with
+	groupName := fmt.Sprintf("cfgmsmemtest%s", timestamp)
+	createConfig := &EntraGroupConfig{
+		DisplayName:     fmt.Sprintf("CFGMS Member Test %s", timestamp),
+		Description:     "Integration test for member/owner sync",
+		MailNickname:    groupName,
+		MailEnabled:     false,
+		SecurityEnabled: true,
+		GroupType:       "Security",
+		Visibility:      "Private",
+		TenantID:        tenantID,
+	}
+
+	resourceID := tenantID + ":" + groupName
+	err := module.Set(ctx, resourceID, createConfig)
+	require.NoError(t, err, "Should be able to create group")
+
+	token, err := authProvider.GetAccessToken(ctx, tenantID)
+	require.NoError(t, err)
+
+	groups, err := graphClient.ListGroups(ctx, token, fmt.Sprintf("displayName eq '%s'", createConfig.DisplayName))
+	require.NoError(t, err)
+	require.NotEmpty(t, groups, "Should find the created group")
+
+	var createdGroup *graph.Group
+	for i := range groups {
+		if groups[i].DisplayName == createConfig.DisplayName {
+			createdGroup = &groups[i]
+			break
+		}
+	}
+	require.NotNil(t, createdGroup)
+
+	t.Cleanup(func() {
+		cleanupToken, tokenErr := authProvider.GetAccessToken(ctx, tenantID)
+		if tokenErr != nil {
+			t.Logf("Failed to get token for cleanup: %v", tokenErr)
+			return
+		}
+		if err := graphClient.DeleteGroup(ctx, cleanupToken, createdGroup.ID); err != nil {
+			t.Logf("Failed to cleanup group %s: %v", createdGroup.ID, err)
+		}
+	})
+
+	groupID := createdGroup.ID
+
+	// Verify initial state: no members, no owners
+	members, err := graphClient.ListGroupMembers(ctx, token, groupID)
+	require.NoError(t, err)
+	assert.Empty(t, members, "New group should have no members")
+
+	owners, err := graphClient.ListGroupOwners(ctx, token, groupID)
+	require.NoError(t, err)
+	assert.Empty(t, owners, "New group should have no owners")
+
+	// Resolve a test user from the tenant to use for member/owner operations.
+	// The test requires M365_TEST_USER_UPN to be set to a valid UPN in the tenant.
+	testUserUPN := os.Getenv("M365_TEST_USER_UPN")
+	if testUserUPN == "" {
+		if os.Getenv("ALLOW_SKIP_INTEGRATION") == "true" {
+			t.Skip("M365 member/owner sync test - M365_TEST_USER_UPN not available (dev mode)")
+		}
+		t.Fatalf("TestEntraGroup_Integration_MemberOwnerSync requires M365_TEST_USER_UPN. Set a valid UPN in .env.local or the environment")
+	}
+
+	// Add member and sync
+	syncConfigMembers := &EntraGroupConfig{
+		DisplayName:       createConfig.DisplayName,
+		MailNickname:      createConfig.MailNickname,
+		MailEnabled:       false,
+		SecurityEnabled:   true,
+		TenantID:          tenantID,
+		Members:           []string{testUserUPN},
+		ManagedFieldsList: []string{"display_name", "mail_enabled", "security_enabled", "members"},
+	}
+	realResourceID := tenantID + ":" + groupID
+	err = module.Set(ctx, realResourceID, syncConfigMembers)
+	require.NoError(t, err, "Should be able to sync members")
+
+	members, err = graphClient.ListGroupMembers(ctx, token, groupID)
+	require.NoError(t, err)
+	assert.Contains(t, members, testUserUPN, "Member should be present after sync")
+
+	// Remove member via sync (empty desired list)
+	syncConfigNoMembers := &EntraGroupConfig{
+		DisplayName:       createConfig.DisplayName,
+		MailNickname:      createConfig.MailNickname,
+		MailEnabled:       false,
+		SecurityEnabled:   true,
+		TenantID:          tenantID,
+		Members:           []string{},
+		ManagedFieldsList: []string{"display_name", "mail_enabled", "security_enabled", "members"},
+	}
+	err = module.Set(ctx, realResourceID, syncConfigNoMembers)
+	require.NoError(t, err, "Should be able to remove members via sync")
+
+	members, err = graphClient.ListGroupMembers(ctx, token, groupID)
+	require.NoError(t, err)
+	assert.NotContains(t, members, testUserUPN, "Member should be removed after sync")
+
+	// Add owner and sync
+	syncConfigOwners := &EntraGroupConfig{
+		DisplayName:       createConfig.DisplayName,
+		MailNickname:      createConfig.MailNickname,
+		MailEnabled:       false,
+		SecurityEnabled:   true,
+		TenantID:          tenantID,
+		Owners:            []string{testUserUPN},
+		ManagedFieldsList: []string{"display_name", "mail_enabled", "security_enabled", "owners"},
+	}
+	err = module.Set(ctx, realResourceID, syncConfigOwners)
+	require.NoError(t, err, "Should be able to sync owners")
+
+	owners, err = graphClient.ListGroupOwners(ctx, token, groupID)
+	require.NoError(t, err)
+	assert.Contains(t, owners, testUserUPN, "Owner should be present after sync")
+
+	t.Log("✅ Member/owner sync integration test passed")
+}
+
 // TestEntraGroup_Integration_FullSuite runs comprehensive integration tests
 func TestEntraGroup_Integration_FullSuite(t *testing.T) {
 	checkM365Integration(t)
 
 	t.Run("FullCRUD", func(t *testing.T) {
 		TestEntraGroup_Integration_FullCRUD(t)
+	})
+
+	t.Run("MemberOwnerSync", func(t *testing.T) {
+		TestEntraGroup_Integration_MemberOwnerSync(t)
 	})
 
 	t.Run("ConfigValidation", func(t *testing.T) {

--- a/features/modules/m365/entra_group/module.go
+++ b/features/modules/m365/entra_group/module.go
@@ -523,33 +523,88 @@ func (m *entraGroupModule) updateGroup(ctx context.Context, token *auth.AccessTo
 // Additional helper methods (placeholders)
 
 func (m *entraGroupModule) getGroupMembers(ctx context.Context, token *auth.AccessToken, groupID string) ([]string, error) {
-	// Placeholder - would use Graph API /groups/{id}/members
-	return []string{}, nil
+	upns, err := m.graphClient.ListGroupMembers(ctx, token, groupID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list group members: %w", err)
+	}
+	return upns, nil
 }
 
 func (m *entraGroupModule) getGroupOwners(ctx context.Context, token *auth.AccessToken, groupID string) ([]string, error) {
-	// Placeholder - would use Graph API /groups/{id}/owners
-	return []string{}, nil
+	upns, err := m.graphClient.ListGroupOwners(ctx, token, groupID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list group owners: %w", err)
+	}
+	return upns, nil
 }
 
-func (m *entraGroupModule) addGroupMember(ctx context.Context, token *auth.AccessToken, groupID, userID string) error {
-	// Placeholder - would use Graph API POST /groups/{id}/members/$ref
-	return nil
+func (m *entraGroupModule) addGroupMember(ctx context.Context, token *auth.AccessToken, groupID, memberUPN string) error {
+	return m.graphClient.AddGroupMember(ctx, token, groupID, memberUPN)
 }
 
-func (m *entraGroupModule) addGroupOwner(ctx context.Context, token *auth.AccessToken, groupID, userID string) error {
-	// Placeholder - would use Graph API POST /groups/{id}/owners/$ref
-	return nil
+func (m *entraGroupModule) addGroupOwner(ctx context.Context, token *auth.AccessToken, groupID, ownerUPN string) error {
+	return m.graphClient.AddGroupOwner(ctx, token, groupID, ownerUPN)
 }
 
 func (m *entraGroupModule) syncGroupMembers(ctx context.Context, token *auth.AccessToken, groupID string, desiredMembers []string) error {
-	// Similar to user license sync logic
+	current, err := m.graphClient.ListGroupMembers(ctx, token, groupID)
+	if err != nil {
+		return fmt.Errorf("failed to list current group members: %w", err)
+	}
+	toAdd, toRemove := diffUPNSets(current, desiredMembers)
+	for _, upn := range toRemove {
+		if err := m.graphClient.RemoveGroupMember(ctx, token, groupID, upn); err != nil {
+			return fmt.Errorf("failed to remove member %s: %w", upn, err)
+		}
+	}
+	for _, upn := range toAdd {
+		if err := m.graphClient.AddGroupMember(ctx, token, groupID, upn); err != nil {
+			return fmt.Errorf("failed to add member %s: %w", upn, err)
+		}
+	}
 	return nil
 }
 
 func (m *entraGroupModule) syncGroupOwners(ctx context.Context, token *auth.AccessToken, groupID string, desiredOwners []string) error {
-	// Similar to user license sync logic
+	current, err := m.graphClient.ListGroupOwners(ctx, token, groupID)
+	if err != nil {
+		return fmt.Errorf("failed to list current group owners: %w", err)
+	}
+	toAdd, toRemove := diffUPNSets(current, desiredOwners)
+	for _, upn := range toRemove {
+		if err := m.graphClient.RemoveGroupOwner(ctx, token, groupID, upn); err != nil {
+			return fmt.Errorf("failed to remove owner %s: %w", upn, err)
+		}
+	}
+	for _, upn := range toAdd {
+		if err := m.graphClient.AddGroupOwner(ctx, token, groupID, upn); err != nil {
+			return fmt.Errorf("failed to add owner %s: %w", upn, err)
+		}
+	}
 	return nil
+}
+
+// diffUPNSets computes the add/remove diff between current and desired UPN sets.
+func diffUPNSets(current, desired []string) (toAdd, toRemove []string) {
+	currentSet := make(map[string]struct{}, len(current))
+	for _, upn := range current {
+		currentSet[upn] = struct{}{}
+	}
+	desiredSet := make(map[string]struct{}, len(desired))
+	for _, upn := range desired {
+		desiredSet[upn] = struct{}{}
+	}
+	for _, upn := range desired {
+		if _, exists := currentSet[upn]; !exists {
+			toAdd = append(toAdd, upn)
+		}
+	}
+	for _, upn := range current {
+		if _, exists := desiredSet[upn]; !exists {
+			toRemove = append(toRemove, upn)
+		}
+	}
+	return toAdd, toRemove
 }
 
 func (m *entraGroupModule) isTeamGroup(ctx context.Context, token *auth.AccessToken, groupID string) bool {

--- a/features/modules/m365/entra_group/module_test.go
+++ b/features/modules/m365/entra_group/module_test.go
@@ -257,6 +257,30 @@ func (m *MockGraphClient) DeleteGroup(ctx context.Context, token *auth.AccessTok
 	return args.Error(0)
 }
 
+func (m *MockGraphClient) ListGroupMembers(ctx context.Context, token *auth.AccessToken, groupID string) ([]string, error) {
+	return nil, nil
+}
+
+func (m *MockGraphClient) AddGroupMember(ctx context.Context, token *auth.AccessToken, groupID, memberUPN string) error {
+	return nil
+}
+
+func (m *MockGraphClient) RemoveGroupMember(ctx context.Context, token *auth.AccessToken, groupID, memberUPN string) error {
+	return nil
+}
+
+func (m *MockGraphClient) ListGroupOwners(ctx context.Context, token *auth.AccessToken, groupID string) ([]string, error) {
+	return nil, nil
+}
+
+func (m *MockGraphClient) AddGroupOwner(ctx context.Context, token *auth.AccessToken, groupID, ownerUPN string) error {
+	return nil
+}
+
+func (m *MockGraphClient) RemoveGroupOwner(ctx context.Context, token *auth.AccessToken, groupID, ownerUPN string) error {
+	return nil
+}
+
 func (m *MockGraphClient) ListAdminUnitUserMembers(ctx context.Context, token *auth.AccessToken, unitID string) ([]string, error) {
 	return nil, nil
 }
@@ -660,4 +684,52 @@ func TestEntraGroupModule_WorkflowDemo(t *testing.T) {
 	// This test is just demonstrating the workflow structure
 	_ = token  // Use the token variable to avoid unused variable warning
 	_ = module // Use the module variable to avoid unused variable warning
+}
+
+func TestDiffUPNSets_AddOnly(t *testing.T) {
+	current := []string{"a@contoso.com"}
+	desired := []string{"a@contoso.com", "b@contoso.com"}
+	toAdd, toRemove := diffUPNSets(current, desired)
+	assert.ElementsMatch(t, []string{"b@contoso.com"}, toAdd)
+	assert.Empty(t, toRemove)
+}
+
+func TestDiffUPNSets_RemoveOnly(t *testing.T) {
+	current := []string{"a@contoso.com", "b@contoso.com"}
+	desired := []string{"a@contoso.com"}
+	toAdd, toRemove := diffUPNSets(current, desired)
+	assert.Empty(t, toAdd)
+	assert.ElementsMatch(t, []string{"b@contoso.com"}, toRemove)
+}
+
+func TestDiffUPNSets_Mixed(t *testing.T) {
+	current := []string{"a@contoso.com", "b@contoso.com"}
+	desired := []string{"b@contoso.com", "c@contoso.com"}
+	toAdd, toRemove := diffUPNSets(current, desired)
+	assert.ElementsMatch(t, []string{"c@contoso.com"}, toAdd)
+	assert.ElementsMatch(t, []string{"a@contoso.com"}, toRemove)
+}
+
+func TestDiffUPNSets_NoOp(t *testing.T) {
+	current := []string{"a@contoso.com", "b@contoso.com"}
+	desired := []string{"a@contoso.com", "b@contoso.com"}
+	toAdd, toRemove := diffUPNSets(current, desired)
+	assert.Empty(t, toAdd)
+	assert.Empty(t, toRemove)
+}
+
+func TestDiffUPNSets_EmptyCurrent(t *testing.T) {
+	current := []string{}
+	desired := []string{"a@contoso.com", "b@contoso.com"}
+	toAdd, toRemove := diffUPNSets(current, desired)
+	assert.ElementsMatch(t, []string{"a@contoso.com", "b@contoso.com"}, toAdd)
+	assert.Empty(t, toRemove)
+}
+
+func TestDiffUPNSets_EmptyDesired(t *testing.T) {
+	current := []string{"a@contoso.com", "b@contoso.com"}
+	desired := []string{}
+	toAdd, toRemove := diffUPNSets(current, desired)
+	assert.Empty(t, toAdd)
+	assert.ElementsMatch(t, []string{"a@contoso.com", "b@contoso.com"}, toRemove)
 }

--- a/features/modules/m365/graph/client.go
+++ b/features/modules/m365/graph/client.go
@@ -63,6 +63,14 @@ type Client interface {
 	UpdateGroup(ctx context.Context, token *auth.AccessToken, groupID string, request *UpdateGroupRequest) error
 	DeleteGroup(ctx context.Context, token *auth.AccessToken, groupID string) error
 
+	// Group member and owner operations
+	ListGroupMembers(ctx context.Context, token *auth.AccessToken, groupID string) ([]string, error)
+	AddGroupMember(ctx context.Context, token *auth.AccessToken, groupID, memberUPN string) error
+	RemoveGroupMember(ctx context.Context, token *auth.AccessToken, groupID, memberUPN string) error
+	ListGroupOwners(ctx context.Context, token *auth.AccessToken, groupID string) ([]string, error)
+	AddGroupOwner(ctx context.Context, token *auth.AccessToken, groupID, ownerUPN string) error
+	RemoveGroupOwner(ctx context.Context, token *auth.AccessToken, groupID, ownerUPN string) error
+
 	// Administrative Unit member operations
 	ListAdminUnitUserMembers(ctx context.Context, token *auth.AccessToken, unitID string) ([]string, error)
 	ListAdminUnitGroupMembers(ctx context.Context, token *auth.AccessToken, unitID string) ([]string, error)

--- a/features/modules/m365/graph/http_client.go
+++ b/features/modules/m365/graph/http_client.go
@@ -794,6 +794,110 @@ func (c *HTTPClient) DeleteGroup(ctx context.Context, token *auth.AccessToken, g
 	return nil
 }
 
+// ListGroupMembers retrieves the UPNs of members belonging to a group
+func (c *HTTPClient) ListGroupMembers(ctx context.Context, token *auth.AccessToken, groupID string) ([]string, error) {
+	endpoint := fmt.Sprintf("/groups/%s/members", groupID)
+	var response struct {
+		Value []struct {
+			ID                string `json:"id"`
+			UserPrincipalName string `json:"userPrincipalName"`
+		} `json:"value"`
+	}
+	if err := c.makeRequest(ctx, token, "GET", endpoint, nil, &response); err != nil {
+		return nil, fmt.Errorf("failed to list members for group %s: %w", groupID, err)
+	}
+	upns := make([]string, 0, len(response.Value))
+	for _, u := range response.Value {
+		if u.UserPrincipalName != "" {
+			upns = append(upns, u.UserPrincipalName)
+		}
+	}
+	return upns, nil
+}
+
+// AddGroupMember adds a user (by UPN) to a group
+func (c *HTTPClient) AddGroupMember(ctx context.Context, token *auth.AccessToken, groupID, memberUPN string) error {
+	user, err := c.GetUser(ctx, token, memberUPN)
+	if err != nil {
+		return fmt.Errorf("failed to resolve UPN %s: %w", memberUPN, err)
+	}
+	endpoint := fmt.Sprintf("/groups/%s/members/$ref", groupID)
+	request := struct {
+		ODataID string `json:"@odata.id"`
+	}{
+		ODataID: fmt.Sprintf("https://graph.microsoft.com/v1.0/directoryObjects/%s", user.ID),
+	}
+	if err := c.makeRequest(ctx, token, "POST", endpoint, request, nil); err != nil {
+		return fmt.Errorf("failed to add member %s to group %s: %w", memberUPN, groupID, err)
+	}
+	return nil
+}
+
+// RemoveGroupMember removes a user (by UPN) from a group
+func (c *HTTPClient) RemoveGroupMember(ctx context.Context, token *auth.AccessToken, groupID, memberUPN string) error {
+	user, err := c.GetUser(ctx, token, memberUPN)
+	if err != nil {
+		return fmt.Errorf("failed to resolve UPN %s: %w", memberUPN, err)
+	}
+	endpoint := fmt.Sprintf("/groups/%s/members/%s/$ref", groupID, user.ID)
+	if err := c.makeRequest(ctx, token, "DELETE", endpoint, nil, nil); err != nil {
+		return fmt.Errorf("failed to remove member %s from group %s: %w", memberUPN, groupID, err)
+	}
+	return nil
+}
+
+// ListGroupOwners retrieves the UPNs of owners of a group
+func (c *HTTPClient) ListGroupOwners(ctx context.Context, token *auth.AccessToken, groupID string) ([]string, error) {
+	endpoint := fmt.Sprintf("/groups/%s/owners", groupID)
+	var response struct {
+		Value []struct {
+			ID                string `json:"id"`
+			UserPrincipalName string `json:"userPrincipalName"`
+		} `json:"value"`
+	}
+	if err := c.makeRequest(ctx, token, "GET", endpoint, nil, &response); err != nil {
+		return nil, fmt.Errorf("failed to list owners for group %s: %w", groupID, err)
+	}
+	upns := make([]string, 0, len(response.Value))
+	for _, u := range response.Value {
+		if u.UserPrincipalName != "" {
+			upns = append(upns, u.UserPrincipalName)
+		}
+	}
+	return upns, nil
+}
+
+// AddGroupOwner adds a user (by UPN) as an owner of a group
+func (c *HTTPClient) AddGroupOwner(ctx context.Context, token *auth.AccessToken, groupID, ownerUPN string) error {
+	user, err := c.GetUser(ctx, token, ownerUPN)
+	if err != nil {
+		return fmt.Errorf("failed to resolve UPN %s: %w", ownerUPN, err)
+	}
+	endpoint := fmt.Sprintf("/groups/%s/owners/$ref", groupID)
+	request := struct {
+		ODataID string `json:"@odata.id"`
+	}{
+		ODataID: fmt.Sprintf("https://graph.microsoft.com/v1.0/directoryObjects/%s", user.ID),
+	}
+	if err := c.makeRequest(ctx, token, "POST", endpoint, request, nil); err != nil {
+		return fmt.Errorf("failed to add owner %s to group %s: %w", ownerUPN, groupID, err)
+	}
+	return nil
+}
+
+// RemoveGroupOwner removes a user (by UPN) from the owners of a group
+func (c *HTTPClient) RemoveGroupOwner(ctx context.Context, token *auth.AccessToken, groupID, ownerUPN string) error {
+	user, err := c.GetUser(ctx, token, ownerUPN)
+	if err != nil {
+		return fmt.Errorf("failed to resolve UPN %s: %w", ownerUPN, err)
+	}
+	endpoint := fmt.Sprintf("/groups/%s/owners/%s/$ref", groupID, user.ID)
+	if err := c.makeRequest(ctx, token, "DELETE", endpoint, nil, nil); err != nil {
+		return fmt.Errorf("failed to remove owner %s from group %s: %w", ownerUPN, groupID, err)
+	}
+	return nil
+}
+
 // ListAdminUnitUserMembers retrieves user members of an administrative unit
 func (c *HTTPClient) ListAdminUnitUserMembers(ctx context.Context, token *auth.AccessToken, unitID string) ([]string, error) {
 	endpoint := fmt.Sprintf("/administrativeUnits/%s/members/microsoft.graph.user", unitID)


### PR DESCRIPTION
## Summary

- Implements `ListGroupMembers`, `AddGroupMember`, `RemoveGroupMember`, `ListGroupOwners`, `AddGroupOwner`, `RemoveGroupOwner` on `graph.Client` interface and `graph.HTTPClient`
- Replaces six no-op stubs in `entra_group/module.go` with real Graph API calls; adds `diffUPNSets` pure function for sync diff logic
- Adds `TestDiffUPNSets_*` unit tests (6 cases) and `TestEntraGroup_Integration_MemberOwnerSync` integration test

## Implementation Notes

- List paths (`GET /groups/{id}/members`, `/owners`) extract `userPrincipalName` from full User objects — no secondary resolution needed
- Add/remove paths resolve UPN → object ID via `GetUser` before `$ref` POST/DELETE, preventing path injection from user-supplied UPNs
- Sync logic removes before adds to respect potential seat limits
- Two pre-existing `MockGraphClient` structs in `directory_provider_test.go` and `entra_application/module_test.go` updated with no-op stubs to compile against the extended interface

## Specialist Review Results

| Reviewer | Result | Notes |
|----------|--------|-------|
| QA Test Runner | **PASS** | All packages pass; Trivy skipped (sandbox DNS unavailable, will run in CI) |
| QA Code Reviewer | **PASS** | Story-specific issues resolved; pre-existing issues noted but out of scope |
| Security Engineer | **PASS** | No blocking issues; UPN→object-ID resolution praised as defense-in-depth |

Fixes #1366