### PR TITLE
controller/api: wire HA workflow execution test helpers to existing API (Issue #1372)

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -166,6 +166,8 @@ services:
       CFGMS_HA_ELECTION_TIMEOUT: "5s"
       CFGMS_HA_HEARTBEAT_INTERVAL: "2s"
       CFGMS_API_KEY: "${API_KEY_EAST}"
+      CFGMS_SEED_TEST_API_KEYS: "1"
+      CFGMS_API_KEY_EAST: "test-api-key-east"
     depends_on:
       timescaledb-test:
         condition: service_healthy
@@ -223,6 +225,8 @@ services:
       CFGMS_HA_ELECTION_TIMEOUT: "5s"
       CFGMS_HA_HEARTBEAT_INTERVAL: "2s"
       CFGMS_API_KEY: "${API_KEY_CENTRAL}"
+      CFGMS_SEED_TEST_API_KEYS: "1"
+      CFGMS_API_KEY_CENTRAL: "test-api-key-central"
     depends_on:
       timescaledb-test:
         condition: service_healthy
@@ -280,6 +284,8 @@ services:
       CFGMS_HA_ELECTION_TIMEOUT: "5s"
       CFGMS_HA_HEARTBEAT_INTERVAL: "2s"
       CFGMS_API_KEY: "${API_KEY_WEST}"
+      CFGMS_SEED_TEST_API_KEYS: "1"
+      CFGMS_API_KEY_WEST: "test-api-key-west"
     depends_on:
       timescaledb-test:
         condition: service_healthy

--- a/features/controller/api/server.go
+++ b/features/controller/api/server.go
@@ -188,6 +188,20 @@ func New(
 		logger.Warn("Failed to load API keys from store", "error", err)
 	}
 
+	// Seed test API keys only when explicitly requested via environment variable.
+	// Never runs in production — must be set deliberately in test environments.
+	if os.Getenv("CFGMS_SEED_TEST_API_KEYS") == "1" {
+		for _, envVar := range []string{"CFGMS_API_KEY_EAST", "CFGMS_API_KEY_CENTRAL", "CFGMS_API_KEY_WEST"} {
+			if keyVal := os.Getenv(envVar); keyVal != "" {
+				server.apiKeys[keyVal] = &APIKey{ //nolint:gosec // test-only seeding, env-gated
+					Key:         keyVal,
+					Permissions: []string{"steward:read", "steward:auth-refresh", "workflow:execute", "workflow:read"},
+					TenantID:    "default",
+				}
+			}
+		}
+	}
+
 	// M-AUTH-1: Do NOT generate default API keys (security anti-pattern)
 	// API keys must be explicitly created by administrators
 

--- a/test/integration/ha/authentication_workflow_test.go
+++ b/test/integration/ha/authentication_workflow_test.go
@@ -7,14 +7,26 @@
 package ha
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
+	"net"
+	"net/http"
+	neturl "net/url"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+)
+
+// workflowExecToName maps execution IDs to workflow names for status lookup.
+var (
+	workflowExecToName   = make(map[string]string)
+	workflowExecToNameMu sync.RWMutex
 )
 
 // AuthenticationState represents the authentication state of a steward
@@ -140,8 +152,6 @@ func TestWorkflowExecutionResilience(t *testing.T) {
 
 	helper := NewDockerComposeHelper()
 
-	t.Skip("Skipping: workflow execution API not yet implemented (requires controller workflow management)")
-
 	t.Log("Starting full HA cluster for workflow resilience testing...")
 	require.NoError(t, helper.StartCluster(ctx))
 	defer func() {
@@ -231,6 +241,7 @@ func testCertificateValidityDuringFailover(t *testing.T, ctx context.Context, he
 		}
 	}
 
+	require.NotEmpty(t, leaderService, "must identify a leader before triggering failover")
 	t.Logf("Triggering failover by stopping %s...", leaderService)
 	require.NoError(t, helper.RestartService(ctx, leaderService))
 
@@ -268,48 +279,10 @@ func testCertificateValidityDuringFailover(t *testing.T, ctx context.Context, he
 	t.Log("✓ Certificate validity maintained during failover")
 }
 
-func testTokenRefreshDuringFailover(t *testing.T, ctx context.Context, helper *DockerComposeHelper, controllers []string, stewards []string) {
-	t.Skip("Skipping: token refresh API not yet implemented (requires steward token management endpoint)")
-	t.Log("Testing token refresh during controller failover...")
-
-	// Simulate token refresh scenario
-	for _, steward := range stewards {
-		require.NoError(t, simulateTokenRefresh(steward))
-	}
-
-	// Trigger failover during token refresh
-	var leaderService string
-	for i, url := range controllers {
-		instance, err := getControllerState(url)
-		if err == nil && instance.IsLeader {
-			services := []string{"controller-east", "controller-central", "controller-west"}
-			leaderService = services[i]
-			break
-		}
-	}
-
-	t.Logf("Triggering failover during token refresh...")
-	require.NoError(t, helper.RestartService(ctx, leaderService))
-
-	// Verify token validity is maintained
-	require.Eventually(t, func() bool {
-		validTokens := 0
-
-		for _, steward := range stewards {
-			state, err := getAuthenticationState(ctx, helper, steward)
-			if err != nil {
-				continue
-			}
-
-			if state.TokenValid && state.Authenticated {
-				validTokens++
-			}
-		}
-
-		return validTokens == len(stewards)
-	}, 60*time.Second, 3*time.Second, "Token validity not maintained during failover")
-
-	t.Log("✓ Token refresh resilience verified during failover")
+func testTokenRefreshDuringFailover(t *testing.T, _ context.Context, _ *DockerComposeHelper, _ []string, _ []string) {
+	// Infrastructure skip: requires a steward token management endpoint (POST /api/v1/stewards/{id}/tokens)
+	// that does not yet exist. Remove this skip when the endpoint is implemented.
+	t.Skip("requires steward token management endpoint (not yet implemented)")
 }
 
 func testReconnectionAuthenticationFlow(t *testing.T, ctx context.Context, helper *DockerComposeHelper, controllers []string, stewards []string) {
@@ -382,6 +355,7 @@ func testLongRunningWorkflowWithFailover(t *testing.T, ctx context.Context, help
 			break
 		}
 	}
+	require.NotEmpty(t, leaderService, "must identify a leader before triggering failover")
 
 	t.Logf("Triggering failover during long-running workflow...")
 	require.NoError(t, helper.RestartService(ctx, leaderService))
@@ -389,16 +363,13 @@ func testLongRunningWorkflowWithFailover(t *testing.T, ctx context.Context, help
 	// Wait for failover and workflow recovery
 	time.Sleep(30 * time.Second)
 
-	// Verify workflow resilience
+	// Verify workflow resilience — status must be queryable; specific outcome is implementation-defined.
 	finalStatus, err := getWorkflowStatus(workflow.ExecutionID)
 	if err != nil {
-		t.Logf("Workflow status unavailable after failover (expected in current implementation): %v", err)
+		t.Logf("Workflow status unavailable after failover: %v", err)
 	} else {
 		t.Logf("Workflow status after failover: %s", finalStatus.Status)
-		// In a real implementation, workflow should either:
-		// 1. Continue running if state was preserved
-		// 2. Be marked for retry if state was lost
-		// 3. Be properly resumed from last checkpoint
+		assert.NotEmpty(t, finalStatus.Status, "post-failover workflow status must be a non-empty string")
 	}
 
 	t.Log("✓ Long-running workflow failover behavior verified")
@@ -429,13 +400,14 @@ func testMultipleWorkflowsWithFailover(t *testing.T, ctx context.Context, helper
 		}
 	}
 
+	require.NotEmpty(t, leaderService, "must identify a leader before triggering failover")
 	t.Logf("Triggering failover with multiple active workflows...")
 	require.NoError(t, helper.RestartService(ctx, leaderService))
 
 	// Wait for recovery
 	time.Sleep(30 * time.Second)
 
-	// Check workflow states
+	// Check workflow states — each execution must have a queryable, non-empty status.
 	runningWorkflows := 0
 	for i, workflow := range workflows {
 		status, err := getWorkflowStatus(workflow.ExecutionID)
@@ -443,6 +415,7 @@ func testMultipleWorkflowsWithFailover(t *testing.T, ctx context.Context, helper
 			t.Logf("Workflow %d status unavailable: %v", i, err)
 		} else {
 			t.Logf("Workflow %d status: %s", i, status.Status)
+			assert.NotEmpty(t, status.Status, "workflow %d should have a non-empty status after failover", i)
 			if status.Status == "running" || status.Status == "completed" {
 				runningWorkflows++
 			}
@@ -463,11 +436,11 @@ func testWorkflowStateRecoveryAfterFailover(t *testing.T, ctx context.Context, h
 	// Wait for partial execution
 	time.Sleep(8 * time.Second)
 
-	// Get pre-failover state
+	// Get pre-failover state — execution must be queryable before the leader is stopped.
 	preFailoverStatus, err := getWorkflowStatus(workflow.ExecutionID)
-	if err == nil {
-		t.Logf("Pre-failover workflow state: %s", preFailoverStatus.Status)
-	}
+	require.NoError(t, err, "pre-failover status must be queryable")
+	t.Logf("Pre-failover workflow state: %s", preFailoverStatus.Status)
+	assert.NotEmpty(t, preFailoverStatus.Status, "pre-failover status must be non-empty")
 
 	// Trigger failover
 	var leaderService string
@@ -479,6 +452,7 @@ func testWorkflowStateRecoveryAfterFailover(t *testing.T, ctx context.Context, h
 			break
 		}
 	}
+	require.NotEmpty(t, leaderService, "must identify a leader before triggering failover")
 
 	t.Logf("Triggering failover for state recovery test...")
 	require.NoError(t, helper.RestartService(ctx, leaderService))
@@ -486,17 +460,13 @@ func testWorkflowStateRecoveryAfterFailover(t *testing.T, ctx context.Context, h
 	// Wait for recovery
 	time.Sleep(30 * time.Second)
 
-	// Check state recovery
+	// Check state recovery — status must be a non-empty string if queryable.
 	postFailoverStatus, err := getWorkflowStatus(workflow.ExecutionID)
 	if err != nil {
-		t.Logf("Post-failover state unavailable (expected in current implementation): %v", err)
+		t.Logf("Post-failover state unavailable: %v", err)
 	} else {
 		t.Logf("Post-failover workflow state: %s", postFailoverStatus.Status)
-
-		// In a real implementation, we would verify:
-		// 1. Workflow state was properly recovered
-		// 2. Completed steps are not re-executed
-		// 3. Workflow can continue from last checkpoint
+		assert.NotEmpty(t, postFailoverStatus.Status, "post-failover status must be non-empty")
 	}
 
 	t.Log("✓ Workflow state recovery behavior verified")
@@ -534,11 +504,6 @@ func getAuthenticationState(ctx context.Context, helper *DockerComposeHelper, st
 		AuthenticationMethod: "mTLS",
 		ConnectionCount:      connectionCount,
 	}, nil
-}
-
-func simulateTokenRefresh(stewardName string) error {
-	// Token refresh requires steward token management API (not yet implemented)
-	return fmt.Errorf("token refresh not implemented: no API available for steward %s", stewardName)
 }
 
 func createLongRunningWorkflow(workflowID string, stewardID string) *WorkflowExecution {
@@ -598,12 +563,174 @@ func createMultiStepWorkflow(workflowID string, stewardID string) *WorkflowExecu
 	}
 }
 
+// controllerURLs is the ordered list of HA controller HTTP endpoints.
+var controllerURLs = []string{
+	"https://localhost:9080",
+	"https://localhost:9081",
+	"https://localhost:9082",
+}
+
+// firstReachableController returns the first controller URL that accepts TCP connections.
+func firstReachableController() (string, error) {
+	for _, url := range controllerURLs {
+		u, err := neturl.Parse(url)
+		if err != nil {
+			continue
+		}
+		conn, err := net.DialTimeout("tcp", u.Host, 2*time.Second)
+		if err == nil {
+			_ = conn.Close()
+			return url, nil
+		}
+	}
+	return "", fmt.Errorf("no reachable controller found among %v", controllerURLs)
+}
+
 func startWorkflowExecution(workflow *WorkflowExecution) error {
-	// Workflow execution requires controller workflow API (not yet implemented)
-	return fmt.Errorf("workflow execution not implemented: no API available for workflow %s", workflow.WorkflowID)
+	controllerURL, err := firstReachableController()
+	if err != nil {
+		return err
+	}
+
+	client := buildTLSClient(containerNameForURL(controllerURL))
+	apiKey := getAPIKeyForURL(controllerURL)
+
+	// Build the step list from the WorkflowExecution steps.
+	steps := make([]map[string]interface{}, 0, len(workflow.Steps))
+	for _, step := range workflow.Steps {
+		steps = append(steps, map[string]interface{}{
+			"name": step.Name,
+			"type": "task",
+		})
+	}
+
+	// POST /api/v1/workflows — create the workflow definition.
+	createBody, err := json.Marshal(map[string]interface{}{
+		"name":  workflow.WorkflowID,
+		"steps": steps,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to marshal workflow create request: %w", err)
+	}
+
+	createReq, err := http.NewRequest(http.MethodPost, controllerURL+"/api/v1/workflows", bytes.NewReader(createBody))
+	if err != nil {
+		return fmt.Errorf("failed to build workflow create request: %w", err)
+	}
+	createReq.Header.Set("Content-Type", "application/json")
+	createReq.Header.Set("X-API-Key", apiKey)
+
+	createResp, err := client.Do(createReq)
+	if err != nil {
+		return fmt.Errorf("workflow create request failed: %w", err)
+	}
+	defer func() { _ = createResp.Body.Close() }()
+	if createResp.StatusCode != http.StatusCreated {
+		return fmt.Errorf("workflow create returned HTTP %d", createResp.StatusCode)
+	}
+
+	// POST /api/v1/workflows/{id}/execute — trigger execution.
+	execReq, err := http.NewRequest(
+		http.MethodPost,
+		fmt.Sprintf("%s/api/v1/workflows/%s/execute", controllerURL, workflow.WorkflowID),
+		strings.NewReader("{}"),
+	)
+	if err != nil {
+		return fmt.Errorf("failed to build execute request: %w", err)
+	}
+	execReq.Header.Set("Content-Type", "application/json")
+	execReq.Header.Set("X-API-Key", apiKey)
+
+	execResp, err := client.Do(execReq)
+	if err != nil {
+		return fmt.Errorf("workflow execute request failed: %w", err)
+	}
+	defer func() { _ = execResp.Body.Close() }()
+	if execResp.StatusCode != http.StatusAccepted {
+		return fmt.Errorf("workflow execute returned HTTP %d", execResp.StatusCode)
+	}
+
+	var execResult map[string]interface{}
+	if err := json.NewDecoder(execResp.Body).Decode(&execResult); err != nil {
+		return fmt.Errorf("failed to parse execute response: %w", err)
+	}
+
+	executionID, ok := execResult["execution_id"].(string)
+	if !ok || executionID == "" {
+		return fmt.Errorf("execute response missing execution_id")
+	}
+
+	workflow.ExecutionID = executionID
+
+	workflowExecToNameMu.Lock()
+	workflowExecToName[executionID] = workflow.WorkflowID
+	workflowExecToNameMu.Unlock()
+
+	return nil
 }
 
 func getWorkflowStatus(executionID string) (*WorkflowExecution, error) {
-	// Workflow status requires controller workflow API (not yet implemented)
-	return nil, fmt.Errorf("workflow status not implemented: no API available for execution %s", executionID)
+	controllerURL, err := firstReachableController()
+	if err != nil {
+		return nil, err
+	}
+
+	workflowExecToNameMu.RLock()
+	workflowName := workflowExecToName[executionID]
+	workflowExecToNameMu.RUnlock()
+
+	if workflowName == "" {
+		return nil, fmt.Errorf("no workflow name found for execution %s", executionID)
+	}
+
+	client := buildTLSClient(containerNameForURL(controllerURL))
+	apiKey := getAPIKeyForURL(controllerURL)
+
+	req, err := http.NewRequest(
+		http.MethodGet,
+		fmt.Sprintf("%s/api/v1/workflows/%s/executions", controllerURL, workflowName),
+		nil,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to build status request: %w", err)
+	}
+	req.Header.Set("X-API-Key", apiKey)
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("workflow status request failed: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("workflow status returned HTTP %d", resp.StatusCode)
+	}
+
+	var statusResp map[string]interface{}
+	if err := json.NewDecoder(resp.Body).Decode(&statusResp); err != nil {
+		return nil, fmt.Errorf("failed to parse status response: %w", err)
+	}
+
+	executions, ok := statusResp["executions"].([]interface{})
+	if !ok {
+		return nil, fmt.Errorf("status response missing executions array")
+	}
+
+	for _, raw := range executions {
+		entry, ok := raw.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		id, _ := entry["id"].(string)
+		if id != executionID {
+			continue
+		}
+		status, _ := entry["status"].(string)
+		return &WorkflowExecution{
+			ExecutionID: executionID,
+			WorkflowID:  workflowName,
+			Status:      status,
+		}, nil
+	}
+
+	return nil, fmt.Errorf("execution %s not found in workflow %s executions", executionID, workflowName)
 }


### PR DESCRIPTION
## Summary

- Removes `t.Skip` from `TestWorkflowExecutionResilience` and implements `startWorkflowExecution` / `getWorkflowStatus` as real HTTP calls against the controller's existing workflow API endpoints
- Adds `CFGMS_SEED_TEST_API_KEYS=1` gate in `features/controller/api/server.go` that pre-loads per-node API keys into the in-memory key map at startup (matches the `CFGMS_SEED_TEST_TOKENS` pattern)
- Wires the gate in `docker-compose.test.yml` for `controller-east`, `controller-central`, and `controller-west`

Fixes #1372

## Implementation Notes

**API key seeding** (`server.go`): After `loadAPIKeysFromStore()`, reads `CFGMS_API_KEY_EAST/CENTRAL/WEST` env vars and inserts each non-empty value as `*APIKey{Permissions: []string{"steward:read", "steward:auth-refresh", "workflow:execute", "workflow:read"}, TenantID: "default"}`. Memory-only, no secret store write, `//nolint:gosec` with justification comment matching the existing token-seeding block.

**`startWorkflowExecution`**: TCP-dials the three controller URLs to find a reachable node, builds a TLS client via `buildTLSClient(containerNameForURL(url))`, calls `POST /api/v1/workflows` to create the definition, then `POST .../execute` to trigger it. Stores `execution_id` on `workflow.ExecutionID` and records the workflow name in a package-level `sync.RWMutex`-protected map for reverse-lookup.

**`getWorkflowStatus`**: Looks up the workflow name from the map, calls `GET /api/v1/workflows/{name}/executions`, and finds the matching entry by `id` field.

**Assertion improvements** (activated by removing the skip): Added `require.NotEmpty(t, leaderService)` guards before all four `RestartService` calls; added `assert.NotEmpty` on post-failover status in all three workflow resilience subtests; cleaned up `testTokenRefreshDuringFailover` to remove unreachable dead code (legitimate infrastructure skip — steward token management endpoint not yet implemented).

## Test Plan

- [x] `go build -tags commercial ./test/integration/ha/...` — compiles clean
- [x] `go build ./features/controller/api/...` — compiles clean
- [x] `go test ./features/controller/api/...` — all tests pass
- [x] `make test-agent-complete` — all quality gates pass (unit, lint, license, architecture, cross-platform)
- [x] QA code reviewer: PASS (all blocking issues resolved)
- [x] Security engineer: PASS (no security issues, scans pass)
- [x] QA test runner: PASS

## Specialist Review Results

**QA Test Runner**: PASS — 96 packages, 0 failures, all cross-platform builds clean

**QA Code Reviewer**: PASS — 0 blocking issues, 0 warnings

**Security Engineer**: PASS — 0 blocking issues, 0 warnings; `gosec` 0 issues, `check-architecture` clean, `security-precommit` clean (gitleaks/truffleHog); hardcoded test key strings allow-listed in `.gitleaks.toml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)