### PR TITLE
monitoring/export: implement real OTLP HealthCheck HTTP probe (Issue #1365)

### DIFF
--- a/features/monitoring/export/otlp.go
+++ b/features/monitoring/export/otlp.go
@@ -231,7 +231,9 @@ func (oe *OTLPExporter) Export(ctx context.Context, data ExportData) error {
 	return nil
 }
 
-// HealthCheck verifies connectivity to the OTLP endpoint.
+// HealthCheck probes the OTLP endpoint by POSTing a minimal empty
+// ExportTraceServiceRequest to /v1/traces. 2xx and 4xx responses indicate
+// the collector is reachable; 5xx responses and connection errors do not.
 func (oe *OTLPExporter) HealthCheck(ctx context.Context) ExporterHealth {
 	health := ExporterHealth{
 		Name:            oe.Name(),
@@ -240,14 +242,54 @@ func (oe *OTLPExporter) HealthCheck(ctx context.Context) ExporterHealth {
 		LastExport:      oe.lastExport,
 	}
 
-	if oe.connected {
-		health.Status = "healthy"
-		health.Message = "OTLP endpoint reachable"
-	} else {
+	probeCtx, cancel := context.WithTimeout(ctx, oe.config.Timeout)
+	defer cancel()
+
+	probePayload, err := proto.Marshal(&tracecollectorpb.ExportTraceServiceRequest{})
+	if err != nil {
 		health.Status = "unhealthy"
-		health.Message = "OTLP endpoint not reachable"
+		health.Message = fmt.Sprintf("failed to marshal probe payload: %v", err)
+		oe.connected = false
+		return health
 	}
 
+	httpReq, err := http.NewRequestWithContext(probeCtx, http.MethodPost,
+		oe.config.Endpoint+"/v1/traces", bytes.NewReader(probePayload))
+	if err != nil {
+		health.Status = "unhealthy"
+		health.Message = fmt.Sprintf("failed to create probe request: %v", err)
+		oe.connected = false
+		return health
+	}
+	httpReq.Header.Set("Content-Type", "application/x-protobuf")
+	for k, v := range oe.config.Headers {
+		httpReq.Header.Set(k, v)
+	}
+
+	client := &http.Client{Timeout: oe.config.Timeout}
+	start := time.Now()
+	resp, err := client.Do(httpReq)
+	health.ResponseTime = time.Since(start)
+
+	if err != nil {
+		health.Status = "unhealthy"
+		health.Message = fmt.Sprintf("OTLP endpoint not reachable: %v", err)
+		oe.connected = false
+		return health
+	}
+	defer func() { _ = resp.Body.Close() }()
+	_, _ = io.Copy(io.Discard, resp.Body)
+
+	if resp.StatusCode >= 500 {
+		health.Status = "unhealthy"
+		health.Message = fmt.Sprintf("OTLP endpoint returned %d", resp.StatusCode)
+		oe.connected = false
+		return health
+	}
+
+	health.Status = "healthy"
+	health.Message = "OTLP endpoint reachable"
+	oe.connected = true
 	return health
 }
 

--- a/features/monitoring/export/otlp_test.go
+++ b/features/monitoring/export/otlp_test.go
@@ -577,6 +577,87 @@ func TestOTLPExporter_SecretNotFound(t *testing.T) {
 	assert.True(t, cl.contains(missingKey), "key name must appear in warning log for debuggability")
 }
 
+// TestOTLPExporter_HealthCheck_Healthy verifies that a 200 response causes HealthCheck
+// to return status == "healthy" and sets oe.connected = true.
+func TestOTLPExporter_HealthCheck_Healthy(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/v1/traces", r.URL.Path)
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "application/x-protobuf", r.Header.Get("Content-Type"))
+		_, _ = io.Copy(io.Discard, r.Body)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	oe := newTestOTLPExporter(srv.URL)
+	health := oe.HealthCheck(context.Background())
+
+	assert.Equal(t, "healthy", health.Status)
+	assert.Equal(t, "otlp", health.Name)
+	assert.NotEmpty(t, health.Message)
+	assert.True(t, oe.connected)
+	assert.Positive(t, health.ResponseTime)
+}
+
+// TestOTLPExporter_HealthCheck_Unhealthy_5xx verifies that a 500 response causes
+// HealthCheck to return status == "unhealthy" and sets oe.connected = false.
+func TestOTLPExporter_HealthCheck_Unhealthy_5xx(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.Copy(io.Discard, r.Body)
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	oe := newTestOTLPExporter(srv.URL)
+	health := oe.HealthCheck(context.Background())
+
+	assert.Equal(t, "unhealthy", health.Status)
+	assert.NotEmpty(t, health.Message)
+	assert.False(t, oe.connected)
+}
+
+// TestOTLPExporter_HealthCheck_Unhealthy_Timeout verifies that a server that never
+// responds causes HealthCheck to return status == "unhealthy" within the configured timeout.
+func TestOTLPExporter_HealthCheck_Unhealthy_Timeout(t *testing.T) {
+	done := make(chan struct{})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-done
+	}))
+	defer func() {
+		close(done)
+		srv.Close()
+	}()
+
+	oe := newTestOTLPExporter(srv.URL)
+	oe.config.Timeout = 150 * time.Millisecond
+
+	start := time.Now()
+	health := oe.HealthCheck(context.Background())
+	elapsed := time.Since(start)
+
+	assert.Equal(t, "unhealthy", health.Status)
+	assert.NotEmpty(t, health.Message)
+	assert.Less(t, elapsed, 700*time.Millisecond)
+	assert.False(t, oe.connected)
+}
+
+// TestOTLPExporter_HealthCheck_4xx_Reachable verifies that 4xx responses are treated
+// as reachable — the collector responded, which proves connectivity.
+func TestOTLPExporter_HealthCheck_4xx_Reachable(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.Copy(io.Discard, r.Body)
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	oe := newTestOTLPExporter(srv.URL)
+	health := oe.HealthCheck(context.Background())
+
+	assert.Equal(t, "healthy", health.Status)
+	assert.NotEmpty(t, health.Message)
+	assert.True(t, oe.connected)
+}
+
 // TestOTLPExporter_Export_Integration tests the full Export routing for all three
 // signal types, verifying each is sent to the correct /v1/{signal} endpoint.
 func TestOTLPExporter_Export_Integration(t *testing.T) {


### PR DESCRIPTION
## Summary

- Replaces the `OTLPExporter.HealthCheck` placeholder (which only read the `oe.connected` boolean, never updated it) with a real HTTP probe to the configured OTLP endpoint
- Probe POSTs a minimal empty `ExportTraceServiceRequest` to `/v1/traces` with the same headers as normal export; treats 2xx/4xx as reachable, 5xx/errors as unhealthy
- Honours caller context and `oe.config.Timeout`; populates `health.ResponseTime`; updates `oe.connected` so subsequent `Export` reads accurate state

## Test plan

- [ ] `TestOTLPExporter_HealthCheck_Healthy` — httptest 200 → `"healthy"`, `connected = true`, `ResponseTime > 0`
- [ ] `TestOTLPExporter_HealthCheck_Unhealthy_5xx` — httptest 500 → `"unhealthy"`, `connected = false`
- [ ] `TestOTLPExporter_HealthCheck_Unhealthy_Timeout` — blocking server + 150ms timeout → `"unhealthy"` within 700ms
- [ ] `TestOTLPExporter_HealthCheck_4xx_Reachable` — httptest 404 → `"healthy"`, `connected = true`
- [ ] `go test ./features/monitoring/export/... -race` passes (all 47 tests)
- [ ] `make test-agent-complete` passes

## Specialist review results

**QA Test Runner: PASS** — all 100 packages pass, cross-platform builds verified, lint clean

**QA Code Reviewer: PASS** — no blocking issues in diff scope; 3 low-severity warnings addressed (ResponseTime assertion added, Message assertion added to 4xx test, timeout bound tightened to 700ms)

**Security Engineer: PASS** — no hardcoded secrets, no central provider violations, no insecure defaults; 2 low/informational warnings (pre-existing patterns not introduced by this story)

Fixes #1365

🤖 Generated with [Claude Code](https://claude.com/claude-code)