### PR TITLE
rbac/jit: implement multi-stage approval workflow progression (Issue #1380)

### DIFF
--- a/features/rbac/jit/access_manager.go
+++ b/features/rbac/jit/access_manager.go
@@ -17,6 +17,12 @@ import (
 	business "github.com/cfgis/cfgms/pkg/storage/interfaces/business"
 )
 
+// WorkflowProvider selects an approval workflow for a JIT access request.
+// When set on JITAccessManager via SetWorkflowProvider, it replaces the built-in
+// single-stage default with tenant-specific, risk-based, or environment-specific
+// workflow policies without forking the core manager.
+type WorkflowProvider func(ctx context.Context, request *JITAccessRequest) (*ApprovalWorkflow, error)
+
 // JITAccessManager manages Just-In-Time access requests and grants
 type JITAccessManager struct {
 	rbacManager         rbac.RBACManager
@@ -25,6 +31,7 @@ type JITAccessManager struct {
 	approvalWorkflows   map[string]*ApprovalWorkflow
 	auditManager        *audit.Manager
 	notificationService NotificationService
+	workflowProvider    WorkflowProvider
 	mutex               sync.RWMutex
 }
 
@@ -44,6 +51,15 @@ func NewJITAccessManager(rbacManager rbac.RBACManager, notificationService Notif
 // It is a no-op when m is nil.
 func (jam *JITAccessManager) SetAuditManager(m *audit.Manager) {
 	jam.auditManager = m
+}
+
+// SetWorkflowProvider replaces the built-in workflow determination logic with a custom
+// provider. The provider is called once per request creation and must return a non-nil
+// workflow; nil causes request creation to fail.
+func (jam *JITAccessManager) SetWorkflowProvider(provider WorkflowProvider) {
+	jam.mutex.Lock()
+	defer jam.mutex.Unlock()
+	jam.workflowProvider = provider
 }
 
 // recordJITAccessRequest emits a jit_access request audit event. No-op when auditManager is nil.
@@ -187,11 +203,71 @@ func (jam *JITAccessManager) RequestAccess(ctx context.Context, req *JITAccessRe
 	return request, nil
 }
 
-// ApproveRequest approves a JIT access request
+// ApproveRequest approves a JIT access request.
+// For multi-stage workflows it records the stage approval and only creates the
+// grant when the final stage is satisfied. Single-stage workflows grant access
+// immediately (existing behaviour).
 func (jam *JITAccessManager) ApproveRequest(ctx context.Context, requestID, approverID, reason string) (*JITAccessGrant, error) {
 	jam.mutex.Lock()
 	defer jam.mutex.Unlock()
 
+	request, exists := jam.requests[requestID]
+	if !exists {
+		return nil, fmt.Errorf("request %s not found", requestID)
+	}
+
+	if request.Status != JITAccessRequestStatusPending {
+		return nil, fmt.Errorf("request %s is not in pending status", requestID)
+	}
+
+	// Multi-stage path: WorkflowState is only set for workflows with >1 stage.
+	if request.WorkflowState != nil {
+		workflow, exists := jam.approvalWorkflows[requestID]
+		if !exists || workflow == nil {
+			return nil, fmt.Errorf("approval workflow not found for request %s", requestID)
+		}
+
+		// Stage membership check must come before the RBAC permission check so callers
+		// can distinguish the two rejection reasons.
+		if err := jam.validateStageApprover(request, approverID); err != nil {
+			return nil, err
+		}
+
+		stageIdx := request.WorkflowState.CurrentStage
+		stage := workflow.Approvers[stageIdx]
+
+		// Idempotency: silently ignore a duplicate approval from the same approver
+		// in the same stage — no state change, no audit event.
+		if _, already := request.WorkflowState.StageApprovals[stageIdx][approverID]; already {
+			return nil, nil
+		}
+
+		// RBAC check: approver must hold the jit_access.approve permission.
+		if err := jam.validateApprover(ctx, request, approverID); err != nil {
+			return nil, fmt.Errorf("approver validation failed: %w", err)
+		}
+
+		// Record approval in the per-stage set.
+		request.WorkflowState.StageApprovals[stageIdx][approverID] = struct{}{}
+
+		// Emit stage_approved audit event for every new (non-duplicate) approval,
+		// including intermediate stages.
+		jam.recordStageApproval(ctx, request, stage.ID, approverID)
+
+		// Advance when the stage's MinApprovals threshold is met.
+		if len(request.WorkflowState.StageApprovals[stageIdx]) >= stage.MinApprovals {
+			nextIdx := stageIdx + 1
+			if nextIdx >= len(workflow.Approvers) {
+				// Final stage complete — delegate to internal approveRequest for grant creation.
+				return jam.approveRequest(ctx, requestID, approverID, reason)
+			}
+			jam.advanceWorkflowStage(ctx, request, workflow)
+		}
+
+		return nil, nil
+	}
+
+	// Single-stage path: original immediate-grant behaviour.
 	return jam.approveRequest(ctx, requestID, approverID, reason)
 }
 
@@ -497,7 +573,27 @@ func (jam *JITAccessManager) checkCurrentAccess(ctx context.Context, subjectID s
 }
 
 func (jam *JITAccessManager) determineApprovalWorkflow(ctx context.Context, request *JITAccessRequest) (*ApprovalWorkflow, error) {
-	// Default workflow - single approver
+	var (
+		workflow *ApprovalWorkflow
+		err      error
+	)
+
+	if jam.workflowProvider != nil {
+		workflow, err = jam.workflowProvider(ctx, request)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		workflow = jam.defaultApprovalWorkflow(request)
+	}
+
+	// Store the resolved workflow keyed by request ID so multi-stage approval can look it up.
+	jam.approvalWorkflows[request.ID] = workflow
+
+	return workflow, nil
+}
+
+func (jam *JITAccessManager) defaultApprovalWorkflow(request *JITAccessRequest) *ApprovalWorkflow {
 	workflow := &ApprovalWorkflow{
 		ID:   "default-approval",
 		Name: "Default Approval Workflow",
@@ -513,17 +609,15 @@ func (jam *JITAccessManager) determineApprovalWorkflow(ctx context.Context, requ
 		},
 	}
 
-	// Emergency access gets expedited workflow
 	if request.EmergencyAccess {
-		workflow.Approvers[0].TimeoutHours = 0.5 // 30 minutes
+		workflow.Approvers[0].TimeoutHours = 0.5
 	}
 
-	// High-privilege requests require multiple approvers
 	if jam.isHighPrivilegeRequest(request) {
 		workflow.Approvers[0].MinApprovals = 2
 	}
 
-	return workflow, nil
+	return workflow
 }
 
 func (jam *JITAccessManager) shouldAutoApprove(ctx context.Context, request *JITAccessRequest) bool {
@@ -651,13 +745,70 @@ func (jam *JITAccessManager) checkExtensionPermission(ctx context.Context, reque
 }
 
 func (jam *JITAccessManager) startApprovalWorkflow(ctx context.Context, request *JITAccessRequest, workflow *ApprovalWorkflow) error {
-	// Implementation would integrate with workflow engine
-	// For now, simulate by notifying first stage approvers
+	if len(workflow.Approvers) > 1 {
+		// Multi-stage: initialise WorkflowState so ApproveRequest uses the staged path.
+		stageApprovals := make(map[int]map[string]struct{}, len(workflow.Approvers))
+		for i := range workflow.Approvers {
+			stageApprovals[i] = make(map[string]struct{})
+		}
+		request.WorkflowState = &WorkflowState{
+			CurrentStage:   0,
+			StageApprovals: stageApprovals,
+		}
+	}
+
 	if len(workflow.Approvers) > 0 {
-		firstStage := workflow.Approvers[0]
-		return jam.sendApprovalNotifications(ctx, request, firstStage.Approvers)
+		return jam.sendApprovalNotifications(ctx, request, workflow.Approvers[0].Approvers)
 	}
 	return nil
+}
+
+// validateStageApprover checks that approverID is listed in the current pending stage's
+// Approvers slice. It must be called only from the public ApproveRequest path; internal
+// approveRequest (used by auto-approval with approverID="system") is exempt.
+// Returns a distinct error from the RBAC jit_access.approve permission check so callers
+// can tell the two failure modes apart.
+func (jam *JITAccessManager) validateStageApprover(request *JITAccessRequest, approverID string) error {
+	if request.WorkflowState == nil {
+		return nil
+	}
+	workflow, exists := jam.approvalWorkflows[request.ID]
+	if !exists {
+		return nil
+	}
+	stageIdx := request.WorkflowState.CurrentStage
+	if stageIdx >= len(workflow.Approvers) {
+		return nil
+	}
+	stage := workflow.Approvers[stageIdx]
+	for _, a := range stage.Approvers {
+		if a == approverID {
+			return nil
+		}
+	}
+	return fmt.Errorf("approver %s is not a member of stage %s", approverID, stage.ID)
+}
+
+// recordStageApproval emits a stage_approved audit event. No-op when auditManager is nil.
+func (jam *JITAccessManager) recordStageApproval(ctx context.Context, request *JITAccessRequest, stageID, approverID string) {
+	if jam.auditManager == nil {
+		return
+	}
+	if err := jam.auditManager.RecordEvent(ctx, audit.AuthorizationEvent(
+		request.TenantID, request.RequesterID, "jit_access", request.ID, "stage_approved",
+		business.AuditResultSuccess,
+	).Detail("stage_id", stageID).Detail("approver_id", approverID)); err != nil {
+		slog.Warn("failed to record jit stage approval audit event", "error", err)
+	}
+}
+
+// advanceWorkflowStage increments the current stage index and notifies the next stage's approvers.
+func (jam *JITAccessManager) advanceWorkflowStage(ctx context.Context, request *JITAccessRequest, workflow *ApprovalWorkflow) {
+	request.WorkflowState.CurrentStage++
+	nextIdx := request.WorkflowState.CurrentStage
+	if nextIdx < len(workflow.Approvers) {
+		_ = jam.sendApprovalNotifications(ctx, request, workflow.Approvers[nextIdx].Approvers)
+	}
 }
 
 func (jam *JITAccessManager) activateAccess(ctx context.Context, grant *JITAccessGrant) error {

--- a/features/rbac/jit/access_manager_test.go
+++ b/features/rbac/jit/access_manager_test.go
@@ -823,6 +823,363 @@ func TestJITAuditManager_NilSafe(t *testing.T) {
 	assert.NotNil(t, request)
 }
 
+// makeMultiStageWorkflow builds a 2-stage sequential workflow for multi-stage tests.
+// Stage approvers are explicit user IDs (ApprovalStageTypeUser).
+func makeMultiStageWorkflow(s1Approvers []string, s1Min int, s2Approvers []string, s2Min int) *jit.ApprovalWorkflow {
+	return &jit.ApprovalWorkflow{
+		ID:   "two-stage",
+		Name: "Two Stage Workflow",
+		Type: jit.ApprovalTypeSequential,
+		Approvers: []jit.ApprovalStage{
+			{
+				ID:           "stage-1",
+				Type:         jit.ApprovalStageTypeUser,
+				Approvers:    s1Approvers,
+				MinApprovals: s1Min,
+				TimeoutHours: 2,
+			},
+			{
+				ID:           "stage-2",
+				Type:         jit.ApprovalStageTypeUser,
+				Approvers:    s2Approvers,
+				MinApprovals: s2Min,
+				TimeoutHours: 2,
+			},
+		},
+	}
+}
+
+func TestJITAccessManager_MultiStageApproval_AdvancesStages(t *testing.T) {
+	rbacManager := newTestRBACManager(t)
+	jam := jit.NewJITAccessManager(rbacManager, jit.NewSimpleNotificationService())
+
+	grantPermission(t, rbacManager, "approver1", "jit_access.approve", "tenant1")
+	grantPermission(t, rbacManager, "approver2", "jit_access.approve", "tenant1")
+
+	workflow := makeMultiStageWorkflow([]string{"approver1"}, 1, []string{"approver2"}, 1)
+	jam.SetWorkflowProvider(func(_ context.Context, _ *jit.JITAccessRequest) (*jit.ApprovalWorkflow, error) {
+		return workflow, nil
+	})
+
+	ctx := context.Background()
+	request, err := jam.RequestAccess(ctx, &jit.JITAccessRequestSpec{
+		RequesterID:   "user1",
+		TenantID:      "tenant1",
+		Permissions:   []string{"admin"},
+		Duration:      2 * time.Hour,
+		Justification: "multi-stage advance test",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, jit.JITAccessRequestStatusPending, request.Status)
+	require.NotNil(t, request.WorkflowState, "WorkflowState must be initialised for multi-stage workflows")
+	assert.Equal(t, 0, request.WorkflowState.CurrentStage)
+
+	// Stage 1 approval — must not produce a grant; stage index advances to 1.
+	grant, err := jam.ApproveRequest(ctx, request.ID, "approver1", "stage 1 ok")
+	require.NoError(t, err)
+	assert.Nil(t, grant)
+
+	afterStage1, err := jam.GetRequest(ctx, request.ID)
+	require.NoError(t, err)
+	assert.Equal(t, jit.JITAccessRequestStatusPending, afterStage1.Status)
+	assert.Equal(t, 1, afterStage1.WorkflowState.CurrentStage)
+
+	// Stage 2 approval — final stage, grant must be created.
+	grant2, err := jam.ApproveRequest(ctx, request.ID, "approver2", "stage 2 ok")
+	require.NoError(t, err)
+	require.NotNil(t, grant2)
+
+	final, err := jam.GetRequest(ctx, request.ID)
+	require.NoError(t, err)
+	assert.Equal(t, jit.JITAccessRequestStatusApproved, final.Status)
+	assert.Equal(t, grant2.ID, final.GrantedAccess.ID)
+}
+
+func TestJITAccessManager_MultiStageApproval_RequiresBothStages(t *testing.T) {
+	rbacManager := newTestRBACManager(t)
+	jam := jit.NewJITAccessManager(rbacManager, jit.NewSimpleNotificationService())
+
+	grantPermission(t, rbacManager, "approver1", "jit_access.approve", "tenant1")
+
+	workflow := makeMultiStageWorkflow([]string{"approver1"}, 1, []string{"approver1"}, 1)
+	jam.SetWorkflowProvider(func(_ context.Context, _ *jit.JITAccessRequest) (*jit.ApprovalWorkflow, error) {
+		return workflow, nil
+	})
+
+	ctx := context.Background()
+	request, err := jam.RequestAccess(ctx, &jit.JITAccessRequestSpec{
+		RequesterID:   "user1",
+		TenantID:      "tenant1",
+		Permissions:   []string{"admin"},
+		Duration:      2 * time.Hour,
+		Justification: "requires-both-stages test",
+	})
+	require.NoError(t, err)
+
+	// Only stage 1 approved — request must remain pending with no grant.
+	grant, err := jam.ApproveRequest(ctx, request.ID, "approver1", "stage 1")
+	require.NoError(t, err)
+	assert.Nil(t, grant, "no grant should be created until all stages complete")
+
+	afterStage1, err := jam.GetRequest(ctx, request.ID)
+	require.NoError(t, err)
+	assert.Equal(t, jit.JITAccessRequestStatusPending, afterStage1.Status)
+	assert.Nil(t, afterStage1.GrantedAccess)
+
+	// Stage 2 approval completes the workflow and creates the grant.
+	grant2, err := jam.ApproveRequest(ctx, request.ID, "approver1", "stage 2")
+	require.NoError(t, err)
+	require.NotNil(t, grant2)
+
+	afterStage2, err := jam.GetRequest(ctx, request.ID)
+	require.NoError(t, err)
+	assert.Equal(t, jit.JITAccessRequestStatusApproved, afterStage2.Status)
+	assert.NotNil(t, afterStage2.GrantedAccess)
+}
+
+func TestJITAccessManager_MultiStageApproval_DuplicateApproverIgnored(t *testing.T) {
+	rbacManager := newTestRBACManager(t)
+	jam := jit.NewJITAccessManager(rbacManager, jit.NewSimpleNotificationService())
+
+	grantPermission(t, rbacManager, "approver1", "jit_access.approve", "tenant1")
+	grantPermission(t, rbacManager, "approver1b", "jit_access.approve", "tenant1")
+
+	// Stage 1 requires 2 distinct approvals so a duplicate call cannot accidentally advance the stage.
+	workflow := makeMultiStageWorkflow([]string{"approver1", "approver1b"}, 2, []string{"approver2"}, 1)
+	jam.SetWorkflowProvider(func(_ context.Context, _ *jit.JITAccessRequest) (*jit.ApprovalWorkflow, error) {
+		return workflow, nil
+	})
+
+	ctx := context.Background()
+	request, err := jam.RequestAccess(ctx, &jit.JITAccessRequestSpec{
+		RequesterID:   "user1",
+		TenantID:      "tenant1",
+		Permissions:   []string{"admin"},
+		Duration:      2 * time.Hour,
+		Justification: "duplicate approver test",
+	})
+	require.NoError(t, err)
+
+	// First approval.
+	grant, err := jam.ApproveRequest(ctx, request.ID, "approver1", "first")
+	require.NoError(t, err)
+	assert.Nil(t, grant)
+
+	afterFirst, err := jam.GetRequest(ctx, request.ID)
+	require.NoError(t, err)
+	assert.Equal(t, 1, len(afterFirst.WorkflowState.StageApprovals[0]))
+	assert.Equal(t, 0, afterFirst.WorkflowState.CurrentStage)
+
+	// Duplicate call — must be silently ignored: no error, no state change.
+	grant2, err := jam.ApproveRequest(ctx, request.ID, "approver1", "duplicate")
+	require.NoError(t, err)
+	assert.Nil(t, grant2)
+
+	afterDup, err := jam.GetRequest(ctx, request.ID)
+	require.NoError(t, err)
+	assert.Equal(t, 1, len(afterDup.WorkflowState.StageApprovals[0]), "set size must not grow on duplicate")
+	assert.Equal(t, 0, afterDup.WorkflowState.CurrentStage, "stage must not advance on duplicate")
+	assert.Equal(t, jit.JITAccessRequestStatusPending, afterDup.Status)
+
+	// Second unique approver completes stage 1 — verifies the idempotency check did not
+	// consume the stage advancement slot.
+	grant3, err := jam.ApproveRequest(ctx, request.ID, "approver1b", "second unique")
+	require.NoError(t, err)
+	assert.Nil(t, grant3)
+
+	afterAdvance, err := jam.GetRequest(ctx, request.ID)
+	require.NoError(t, err)
+	assert.Equal(t, 1, afterAdvance.WorkflowState.CurrentStage, "stage must advance after MinApprovals met")
+	assert.Equal(t, 2, len(afterAdvance.WorkflowState.StageApprovals[0]))
+}
+
+func TestJITAccessManager_MultiStageApproval_MinApprovalsEnforced(t *testing.T) {
+	rbacManager := newTestRBACManager(t)
+	jam := jit.NewJITAccessManager(rbacManager, jit.NewSimpleNotificationService())
+
+	grantPermission(t, rbacManager, "approver1a", "jit_access.approve", "tenant1")
+	grantPermission(t, rbacManager, "approver1b", "jit_access.approve", "tenant1")
+	grantPermission(t, rbacManager, "approver2", "jit_access.approve", "tenant1")
+
+	// Stage 1 requires 2 distinct approvals before advancing.
+	workflow := makeMultiStageWorkflow([]string{"approver1a", "approver1b"}, 2, []string{"approver2"}, 1)
+	jam.SetWorkflowProvider(func(_ context.Context, _ *jit.JITAccessRequest) (*jit.ApprovalWorkflow, error) {
+		return workflow, nil
+	})
+
+	ctx := context.Background()
+	request, err := jam.RequestAccess(ctx, &jit.JITAccessRequestSpec{
+		RequesterID:   "user1",
+		TenantID:      "tenant1",
+		Permissions:   []string{"admin"},
+		Duration:      2 * time.Hour,
+		Justification: "min-approvals test",
+	})
+	require.NoError(t, err)
+
+	// First stage-1 approval — not yet at MinApprovals=2, stage must not advance.
+	grant, err := jam.ApproveRequest(ctx, request.ID, "approver1a", "first of two")
+	require.NoError(t, err)
+	assert.Nil(t, grant)
+
+	afterFirst, err := jam.GetRequest(ctx, request.ID)
+	require.NoError(t, err)
+	assert.Equal(t, 0, afterFirst.WorkflowState.CurrentStage, "stage must not advance before MinApprovals met")
+	assert.Equal(t, jit.JITAccessRequestStatusPending, afterFirst.Status)
+
+	// Second stage-1 approval — meets MinApprovals=2, stage advances to 1.
+	grant2, err := jam.ApproveRequest(ctx, request.ID, "approver1b", "second of two")
+	require.NoError(t, err)
+	assert.Nil(t, grant2, "no grant until final stage completes")
+
+	afterSecond, err := jam.GetRequest(ctx, request.ID)
+	require.NoError(t, err)
+	assert.Equal(t, 1, afterSecond.WorkflowState.CurrentStage, "stage must advance after MinApprovals met")
+
+	// Final stage-2 approval creates the grant.
+	grant3, err := jam.ApproveRequest(ctx, request.ID, "approver2", "final approval")
+	require.NoError(t, err)
+	require.NotNil(t, grant3)
+
+	final, err := jam.GetRequest(ctx, request.ID)
+	require.NoError(t, err)
+	assert.Equal(t, jit.JITAccessRequestStatusApproved, final.Status)
+}
+
+func TestJITAccessManager_MultiStageApproval_NonMemberRejected(t *testing.T) {
+	rbacManager := newTestRBACManager(t)
+	jam := jit.NewJITAccessManager(rbacManager, jit.NewSimpleNotificationService())
+
+	// Intruder has the RBAC permission so the rejection comes from stage membership, not RBAC.
+	grantPermission(t, rbacManager, "intruder", "jit_access.approve", "tenant1")
+
+	workflow := makeMultiStageWorkflow([]string{"approver1"}, 1, []string{"approver2"}, 1)
+	jam.SetWorkflowProvider(func(_ context.Context, _ *jit.JITAccessRequest) (*jit.ApprovalWorkflow, error) {
+		return workflow, nil
+	})
+
+	ctx := context.Background()
+	request, err := jam.RequestAccess(ctx, &jit.JITAccessRequestSpec{
+		RequesterID:   "user1",
+		TenantID:      "tenant1",
+		Permissions:   []string{"admin"},
+		Duration:      2 * time.Hour,
+		Justification: "non-member rejection test",
+	})
+	require.NoError(t, err)
+
+	grant, err := jam.ApproveRequest(ctx, request.ID, "intruder", "trying to approve stage 1")
+
+	require.Error(t, err)
+	assert.Nil(t, grant)
+	// Error must be the stage-membership error, not the RBAC permission error.
+	assert.Contains(t, err.Error(), "not a member of stage")
+	assert.NotContains(t, err.Error(), "does not have permission to approve")
+
+	// Request must still be pending.
+	updated, err := jam.GetRequest(ctx, request.ID)
+	require.NoError(t, err)
+	assert.Equal(t, jit.JITAccessRequestStatusPending, updated.Status)
+}
+
+func TestJITAccessManager_MultiStageApproval_StageAuditEmitted(t *testing.T) {
+	tmpDir := t.TempDir()
+	storageManager, err := interfaces.CreateOSSStorageManager(tmpDir+"/flatfile", tmpDir+"/cfgms.db")
+	require.NoError(t, err)
+
+	auditMgr, err := audit.NewManager(storageManager.GetAuditStore(), "jit-stage-audit-test")
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		assert.NoError(t, auditMgr.Stop(ctx))
+		assert.NoError(t, storageManager.Close())
+	})
+
+	rbacManager := newTestRBACManager(t)
+	grantPermission(t, rbacManager, "approver1", "jit_access.approve", "tenant1")
+
+	jam := jit.NewJITAccessManager(rbacManager, jit.NewSimpleNotificationService())
+	jam.SetAuditManager(auditMgr)
+
+	// Two-stage workflow; approver1 is listed in both stages.
+	workflow := makeMultiStageWorkflow([]string{"approver1"}, 1, []string{"approver1"}, 1)
+	jam.SetWorkflowProvider(func(_ context.Context, _ *jit.JITAccessRequest) (*jit.ApprovalWorkflow, error) {
+		return workflow, nil
+	})
+
+	ctx := context.Background()
+	request, err := jam.RequestAccess(ctx, &jit.JITAccessRequestSpec{
+		RequesterID:   "user1",
+		TenantID:      "tenant1",
+		Permissions:   []string{"admin"},
+		Duration:      2 * time.Hour,
+		Justification: "stage audit test",
+	})
+	require.NoError(t, err)
+
+	// Approve stage 1 (intermediate — not the final stage).
+	grant, err := jam.ApproveRequest(ctx, request.ID, "approver1", "stage 1")
+	require.NoError(t, err)
+	assert.Nil(t, grant)
+
+	flushCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+	require.NoError(t, auditMgr.Flush(flushCtx))
+
+	entries, err := auditMgr.QueryEntries(ctx, &business.AuditFilter{TenantID: "tenant1"})
+	require.NoError(t, err)
+
+	var stageEntry *business.AuditEntry
+	for _, e := range entries {
+		e := e
+		if e.Action == "stage_approved" {
+			stageEntry = e
+			break
+		}
+	}
+	require.NotNil(t, stageEntry, "expected a stage_approved audit event")
+	assert.Equal(t, "tenant1", stageEntry.TenantID)
+	assert.Equal(t, "jit_access", stageEntry.ResourceType)
+
+	stageID, ok := stageEntry.Details["stage_id"].(string)
+	require.True(t, ok, "stage_id detail must be a string")
+	assert.Equal(t, "stage-1", stageID)
+
+	approverID, ok := stageEntry.Details["approver_id"].(string)
+	require.True(t, ok, "approver_id detail must be a string")
+	assert.Equal(t, "approver1", approverID)
+}
+
+func TestJITAccessManager_AutoApproval_BypassesStageCheck(t *testing.T) {
+	rbacManager := newTestRBACManager(t)
+	jam := jit.NewJITAccessManager(rbacManager, jit.NewSimpleNotificationService())
+
+	// "system" (used by auto-approval) must have the RBAC permission but is intentionally
+	// absent from both stage approvers lists to verify the bypass.
+	grantPermission(t, rbacManager, "system", "jit_access.approve", "tenant1")
+
+	workflow := makeMultiStageWorkflow([]string{"approver1"}, 1, []string{"approver2"}, 1)
+	jam.SetWorkflowProvider(func(_ context.Context, _ *jit.JITAccessRequest) (*jit.ApprovalWorkflow, error) {
+		return workflow, nil
+	})
+
+	ctx := context.Background()
+	request, err := jam.RequestAccess(ctx, &jit.JITAccessRequestSpec{
+		RequesterID:   "user1",
+		TenantID:      "tenant1",
+		Permissions:   []string{"read"},
+		Duration:      time.Hour,
+		Justification: "auto-approve stage bypass test",
+		AutoApprove:   true,
+	})
+
+	require.NoError(t, err, "auto-approval must succeed even when approverID='system' is not in any stage's approvers list")
+	assert.Equal(t, jit.JITAccessRequestStatusApproved, request.Status)
+	assert.NotNil(t, request.GrantedAccess)
+}
+
 func newTestRBACManager(t *testing.T) *rbac.Manager {
 	t.Helper()
 	tmpDir := t.TempDir()

--- a/features/rbac/jit/types.go
+++ b/features/rbac/jit/types.go
@@ -24,6 +24,13 @@ type JITAccessRequestSpec struct {
 	RequesterMetadata map[string]string `json:"requester_metadata,omitempty"`
 }
 
+// WorkflowState tracks multi-stage approval progression embedded on JITAccessRequest.
+// It is initialised by startApprovalWorkflow for workflows with more than one stage.
+type WorkflowState struct {
+	CurrentStage   int                         `json:"current_stage"`
+	StageApprovals map[int]map[string]struct{} `json:"-"` // not serialised; persistence is a separate story
+}
+
 // JITAccessRequest represents a JIT access request
 type JITAccessRequest struct {
 	ID                string            `json:"id"`
@@ -51,6 +58,9 @@ type JITAccessRequest struct {
 	ReviewedBy       string                 `json:"reviewed_by,omitempty"`
 	ReviewedAt       *time.Time             `json:"reviewed_at,omitempty"`
 	DenialReason     string                 `json:"denial_reason,omitempty"`
+
+	// Multi-stage workflow tracking
+	WorkflowState *WorkflowState `json:"workflow_state,omitempty"`
 
 	// Timestamps
 	CreatedAt  time.Time `json:"created_at"`


### PR DESCRIPTION
## Summary

- Replace the stub `startApprovalWorkflow` with real multi-stage workflow progression tracking the current stage index and a per-stage set of approver IDs (`map[int]map[string]struct{}`) embedded as `WorkflowState` on `JITAccessRequest`
- `ApproveRequest` now records stage approvals, enforces `MinApprovals` per stage, advances through stages notifying next-stage approvers, and creates the grant only when the final stage is satisfied
- `validateStageApprover` checks stage membership before the RBAC permission check, returning a distinct error so callers can distinguish the two rejection modes; auto-approval (`approverID="system"`) is explicitly exempt via the internal `approveRequest` path
- Duplicate approvals from the same approver in the same stage are silently ignored with no state change and no duplicate audit event
- Each new stage approval emits a `stage_approved` audit event with `stage_id` and `approver_id` detail fields via the existing `recordJITAccess*` pattern
- Added `WorkflowProvider` function type so operators can supply tenant-specific or risk-based workflow selection policies without modifying the core manager; nil guard added in the multi-stage path

## Tests

Seven new tests covering all acceptance criteria:

| Test | Validates |
|------|-----------|
| `TestJITAccessManager_MultiStageApproval_AdvancesStages` | Stage index increments after stage 1, grant created on stage 2 |
| `TestJITAccessManager_MultiStageApproval_RequiresBothStages` | Request stays pending with nil grant until final stage |
| `TestJITAccessManager_MultiStageApproval_DuplicateApproverIgnored` | Second call from same approver: nil, nil, no state change, stage eventually advances on next unique approver |
| `TestJITAccessManager_MultiStageApproval_MinApprovalsEnforced` | Stage with MinApprovals=2 does not advance on first approval |
| `TestJITAccessManager_MultiStageApproval_NonMemberRejected` | Non-member with RBAC permission gets "not a member of stage" error, not RBAC error |
| `TestJITAccessManager_MultiStageApproval_StageAuditEmitted` | `stage_approved` audit event contains `stage_id` and `approver_id` details |
| `TestJITAccessManager_AutoApproval_BypassesStageCheck` | `AutoApprove=true` creates grant even when `"system"` is not in any stage's approvers |

All 25 existing tests in `access_manager_test.go` pass without modification.

## Specialist Review Results

- **QA Test Runner**: PASS — all unit tests, integration tests, cross-platform builds, linting
- **QA Code Reviewer**: PASS — no mocks, no t.Skip(), nil guard verified, dead code removed, duplicate-approver test covers full stage-advancement path
- **Security Engineer**: PASS — no hardcoded secrets, no injection vulnerabilities, no central provider violations, architecture check clean

Fixes #1380