### PR TITLE
docs/modules: add named-map examples to file, directory, script, firewall docs (Issue #255)

### DIFF
--- a/docs/modules/directory.md
+++ b/docs/modules/directory.md
@@ -115,6 +115,46 @@ modules:
       recursive: true
 ```
 
+### Example: Create a log directory with ownership
+
+**Use Case:** Ensure a service's log directory exists on every managed Linux endpoint, owned by the service account so the process can write logs without elevated privileges.
+
+**Configuration:**
+
+```yaml
+modules:
+  app_log_dir:
+    type: directory
+    config:
+      allowed_base_path: /var/log/myapp
+      path: /var/log/myapp
+      state: present
+      permissions: 0750
+      owner: myapp
+      group: myapp
+      recursive: true
+```
+
+**Expected Outcome:** `/var/log/myapp` is created if it does not exist, with mode `0750` and ownership `myapp:myapp`. Parent directories are created automatically because `recursive: true` is set. Subsequent runs are idempotent — the directory is not re-created if it already matches the desired state.
+
+### Example: Ensure a directory is absent
+
+**Use Case:** Remove a legacy working directory that should no longer exist after a service migration.
+
+**Configuration:**
+
+```yaml
+modules:
+  remove_legacy_workdir:
+    type: directory
+    config:
+      allowed_base_path: /var/myapp
+      path: /var/myapp/legacy_cache
+      state: absent
+```
+
+**Expected Outcome:** The module records the desired state as `absent`. On the next convergence cycle, if `/var/myapp/legacy_cache` is detected by `Get()`, the engine omits `Set()` (directory deletion is not implemented by `Set()`); the operator should combine this with a script module to perform the removal. The `allowed_base_path` boundary still applies — no path outside `/var/myapp` can be evaluated.
+
 ## Migration Guide
 
 ### Breaking change in CFGMS Story #876

--- a/docs/modules/file.md
+++ b/docs/modules/file.md
@@ -23,29 +23,87 @@ If the field is absent or not an absolute path, the module returns `ErrAllowedBa
 
 **Note:** `allowed_base_path` uses `filepath.Clean` + `filepath.Abs` internally. Symlink escapes outside the base path are **not** blocked.
 
-### Example
+### Example: Ensure a configuration file exists with permissions and owner
+
+**Use Case:** Deploy a systemd unit file to a managed path with explicit permissions and ownership.
+
+**Configuration:**
 
 ```yaml
-file:
-  state: present
-  content: |
-    [Unit]
-    Description=My Service
-  permissions: 0644
-  allowed_base_path: /var/cfgms/managed
+modules:
+  my_service_unit:
+    type: file
+    config:
+      allowed_base_path: /etc/systemd/system
+      path: /etc/systemd/system/my-service.service
+      state: present
+      content: |
+        [Unit]
+        Description=My Service
+      permissions: 0644
+      owner: root
+      group: root
 ```
+
+**Expected Outcome:** `/etc/systemd/system/my-service.service` is created or updated with the specified content and mode `0644`, owned by `root:root`. The `allowed_base_path` constraint prevents any path outside `/etc/systemd/system` from being targeted.
+
+### Example: Ensure a file is absent
+
+**Use Case:** Remove a legacy configuration file that should no longer exist on managed endpoints.
+
+**Configuration:**
+
+```yaml
+modules:
+  remove_legacy_conf:
+    type: file
+    config:
+      allowed_base_path: /etc/myapp
+      path: /etc/myapp/legacy.conf
+      state: absent
+```
+
+**Expected Outcome:** `/etc/myapp/legacy.conf` is deleted if it exists. If the file is already absent the module reports no change. No filesystem operation is attempted outside `/etc/myapp`.
+
+### Example: Manage a file within a constrained base path
+
+**Use Case:** Write an application configuration file while keeping the security boundary as narrow as possible — only the application's own config directory, not the entire `/etc` tree.
+
+**Configuration:**
+
+```yaml
+modules:
+  app_config:
+    type: file
+    config:
+      allowed_base_path: /etc/myapp
+      path: /etc/myapp/settings.yaml
+      state: present
+      content: |
+        log_level: info
+        listen_addr: 0.0.0.0:8080
+      permissions: 0640
+      owner: myapp
+      group: myapp
+```
+
+**Expected Outcome:** `/etc/myapp/settings.yaml` is written with the provided content, mode `0640`, owned by `myapp:myapp`. Any attempt to resolve `path` to a location outside `/etc/myapp` (for example via `../` sequences) is rejected before any OS call is made.
 
 ## Migration
 
 Existing configurations that omit `allowed_base_path` will fail validation after this change. Add the field pointing to the directory that contains the managed files:
 
+Before:
+
 ```yaml
-# Before
 file:
   state: present
   content: "hello"
+```
 
-# After
+After:
+
+```yaml
 file:
   state: present
   content: "hello"

--- a/docs/modules/firewall.md
+++ b/docs/modules/firewall.md
@@ -1,0 +1,99 @@
+# Firewall Module
+
+## Overview
+
+The Firewall module manages host-based firewall rules on CFGMS-managed endpoints. Each
+module instance represents a single named rule — `action`, `direction`, `protocol`/`service`,
+and address constraints — that the steward applies to the operating-system firewall.
+
+**Platform Support:** This module is **Linux only**. The implementation ships two
+executors: `executor_linux.go` (iptables/nftables) and `executor_stub.go` for all
+other platforms. On Windows and macOS the stub executor accepts all calls silently
+without applying any rules. Use platform targeting in your CFGMS configuration to
+restrict firewall modules to Linux steward endpoints.
+
+## Configuration
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `name` | string | **Yes** | Unique rule identifier. Alphanumeric, `_`, and `-` only; max 64 characters. |
+| `action` | string | **Yes** | `allow` or `deny` |
+| `direction` | string | **Yes** | `input`, `output`, or `forward` |
+| `source` | string | **Yes** | Source IP address or CIDR (e.g. `10.0.0.0/8`, `192.168.1.5`) |
+| `destination` | string | **Yes** | Destination IP address or CIDR |
+| `protocol` | string | Conditional | `tcp`, `udp`, or `icmp`. Required when `service` is not set. |
+| `service` | string | Conditional | Named service (e.g. `https`). Alternative to `protocol` + `port`. |
+| `port` | int | Conditional | Single port number (0–65535). Required when `protocol` is set and `service` is not. |
+| `ports` | []int | Conditional | List of port numbers. Use instead of `port` to match multiple ports in one rule. |
+| `description` | string | No | Human-readable description of the rule. Max 256 characters. |
+| `enabled` | bool | No | Whether the rule is active. Default: `true`. |
+| `state` | string | No | `present` (default) creates or updates the rule; `absent` deletes it. |
+
+### Validation Rules
+
+- `name`, `action`, `direction`, `source`, and `destination` are always required.
+- Exactly one of `protocol` or `service` must be provided — not both, not neither.
+- When `protocol` is set (and `service` is not set), at least one of `port` or `ports` must be provided.
+- `source` and `destination` must be valid IP addresses or CIDR notation.
+
+## Examples
+
+### Example: Allow inbound HTTPS from a specific source
+
+**Use Case:** Permit TCP port 443 traffic arriving from a corporate network CIDR while
+leaving the default policy unchanged for all other sources.
+
+**Configuration:**
+
+```yaml
+modules:
+  allow_corporate_https:
+    type: firewall
+    config:
+      name: allow-corporate-https
+      action: allow
+      direction: input
+      protocol: tcp
+      port: 443
+      source: 10.10.0.0/16
+      destination: 0.0.0.0/0
+      description: Allow inbound HTTPS from corporate network
+      enabled: true
+```
+
+**Expected Outcome:** An iptables/nftables rule is inserted that accepts inbound TCP
+traffic on port 443 originating from `10.10.0.0/16`. Traffic from sources outside that
+CIDR is not matched by this rule and falls through to the next rule in the chain.
+Subsequent convergence cycles are idempotent — the rule is not duplicated if it already
+matches the desired state.
+
+### Example: Block outbound traffic on a port range
+
+**Use Case:** Prevent endpoints from initiating outbound connections on commonly abused
+plaintext and alternate HTTP ports, reducing the attack surface for data exfiltration.
+
+**Configuration:**
+
+```yaml
+modules:
+  block_outbound_http_variants:
+    type: firewall
+    config:
+      name: block-outbound-http-variants
+      action: deny
+      direction: output
+      protocol: tcp
+      ports:
+        - 80
+        - 8080
+        - 8443
+      source: 0.0.0.0/0
+      destination: 0.0.0.0/0
+      description: Block outbound connections on plaintext and alternate HTTP ports
+      enabled: true
+```
+
+**Expected Outcome:** Outbound TCP connections on ports 80, 8080, and 8443 are dropped
+before they leave the host. Steward-managed services cannot initiate cleartext HTTP or
+alternate HTTPS connections to external destinations. The rule covers all source and
+destination addresses (`0.0.0.0/0`) so it applies regardless of the endpoint's own IP.

--- a/docs/modules/script-module.md
+++ b/docs/modules/script-module.md
@@ -361,6 +361,67 @@ modules:
       signing_policy: optional
 ```
 
+### Example: Simple idempotent health-check script (no signing)
+
+**Use Case:** Run a lightweight health check on every convergence cycle to verify that a critical service is running. No code-signing required because the script performs read-only checks and the risk profile is low.
+
+**Configuration:**
+
+```yaml
+modules:
+  service_health_check:
+    type: script
+    config:
+      content: |
+        #!/bin/bash
+        set -e
+        SERVICE=my-service
+        if systemctl is-active --quiet "$SERVICE"; then
+          echo "$SERVICE is running"
+        else
+          echo "$SERVICE is NOT running" >&2
+          exit 1
+        fi
+      shell: bash
+      timeout: 10s
+      description: Verify that my-service is active
+      signing_policy: none
+```
+
+**Expected Outcome:** The script exits 0 when `my-service` is active. If the service is stopped the script exits 1 and the steward records an execution failure in the audit log. Because the script is idempotent (read-only), re-running it on every cycle is safe and produces no side-effects.
+
+### Example: Production deployment with script signing
+
+**Use Case:** Restart a service after a deployment. The script is signed with an RSA key so the steward rejects any unsigned or tampered version before execution.
+
+**Configuration:**
+
+```yaml
+modules:
+  deploy_restart:
+    type: script
+    config:
+      content: |
+        #!/bin/bash
+        set -e
+        systemctl restart my-service
+        systemctl is-active --quiet my-service
+        echo "my-service restarted successfully"
+      shell: bash
+      timeout: 30s
+      description: Restart my-service after deployment
+      signing_policy: required
+      signature:
+        algorithm: RSA-SHA256
+        signature: "MEQCIBxQ7..."
+        public_key: |
+          -----BEGIN PUBLIC KEY-----
+          MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA...
+          -----END PUBLIC KEY-----
+```
+
+**Expected Outcome:** The steward validates the RSA-SHA256 signature against the script content before executing. If the signature is missing or invalid the script is rejected with a signing error and no `systemctl` call is made. A valid signature triggers the restart and returns exit 0; the result is recorded in the audit log.
+
 ## Best Practices
 
 ### 1. Script Design


### PR DESCRIPTION
## Summary

- Added 3 `### Example: <title>` sections to `docs/modules/file.md` (reformatted existing flat example + 2 new ones)
- Added 2 `### Example: <title>` sections to `docs/modules/directory.md`
- Added 2 `### Example: <title>` sections to `docs/modules/script-module.md`
- Created `docs/modules/firewall.md` with overview, config fields table, Linux-only platform note, and 2 example sections

All examples use the named-map wrapper form directly copy-pasteable into real multi-module configs. All 28 YAML blocks validated. No Go code changed.

Fixes #255

## Specialist Review Results

**QA Test Runner — PASS**
All unit tests, script tests, linting, license headers, secret scan, and architecture checks passed. Trivy was network-blocked (container DNS) — not a code defect; no Go dependencies changed.

**QA Code Reviewer — PASS**
All 7 acceptance criteria verified. All four files contain 2+ `### Example: <title>` sections with Use Case / Configuration / Expected Outcome in named-map form. Every `file` module example includes `allowed_base_path`. No code changes.

**Security Engineer — PASS**
0 blocking issues. gosec, staticcheck, gitleaks, truffleHog, and architecture checks all clean. One low-severity cosmetic note (example app config uses `0.0.0.0:8080` as illustrative file content — not a CFGMS listener recommendation). Trivy network-blocked as above.

## Test plan

- [ ] Verify YAML blocks parse cleanly: `python3 -c "import yaml; [yaml.safe_load(b) for b in open('docs/modules/<FILE>.md').read().split('\`\`\`yaml')[1::2]]"` for FILE in {file,directory,script-module,firewall}
- [ ] Confirm all four files contain 2+ `### Example: <title>` headings
- [ ] Confirm all named-map examples include `type:` and `config:` sub-keys under a named resource key

🤖 Generated with [Claude Code](https://claude.com/claude-code)