### PR TITLE
configrouting: pluggable ConfigSourceRouter with atomic SnapshotSources for cascade (Issue #1393)

### DIFF
--- a/features/controller/service/config_service_v2.go
+++ b/features/controller/service/config_service_v2.go
@@ -14,6 +14,7 @@ import (
 	"github.com/cfgis/cfgms/features/config/rollback"
 	stewardconfig "github.com/cfgis/cfgms/features/steward/config"
 	"github.com/cfgis/cfgms/pkg/config"
+	controllerrouter "github.com/cfgis/cfgms/pkg/configrouting/providers/controller"
 	"github.com/cfgis/cfgms/pkg/logging"
 	"github.com/cfgis/cfgms/pkg/storage/interfaces"
 	cfgconfig "github.com/cfgis/cfgms/pkg/storage/interfaces/config"
@@ -31,12 +32,19 @@ type ConfigurationServiceV2 struct {
 	storageManager      *interfaces.StorageManager
 }
 
-// NewConfigurationServiceV2 creates a new Epic 6 compliant Configuration service
+// NewConfigurationServiceV2 creates a new Epic 6 compliant Configuration service.
+// A ConfigSourceRouter wrapping the storage manager's config and tenant stores is
+// constructed here and injected into the InheritanceResolver so that SnapshotSources
+// is called once per cascade (atomic source resolution, per story #1393).
 func NewConfigurationServiceV2(logger logging.Logger, storageManager *interfaces.StorageManager, controllerSvc *ControllerService) *ConfigurationServiceV2 {
+	router := controllerrouter.NewControllerRouter(
+		storageManager.GetConfigStore(),
+		storageManager.GetTenantStore(),
+	)
 	return &ConfigurationServiceV2{
 		logger:              logger,
 		configManager:       config.NewManagerWithStorageManager(storageManager),
-		inheritanceResolver: config.NewInheritanceResolverWithStorageManager(storageManager),
+		inheritanceResolver: config.NewInheritanceResolver(router, storageManager.GetClientTenantStore(), storageManager.GetTenantStore()),
 		validationManager:   config.NewValidationManager(storageManager.GetConfigStore()),
 		controllerSvc:       controllerSvc,
 		storageManager:      storageManager,

--- a/features/tenant/manager.go
+++ b/features/tenant/manager.go
@@ -13,10 +13,17 @@ import (
 	business "github.com/cfgis/cfgms/pkg/storage/interfaces/business"
 )
 
+// cacheInvalidator is the minimal interface required by Manager to invalidate cached
+// config source resolutions after a tenant update. Implemented by ConfigSourceRouter.
+type cacheInvalidator interface {
+	InvalidateTenantCache(tenantID string)
+}
+
 // Manager handles tenant operations and integrates with RBAC
 type Manager struct {
 	store       Store
 	rbacManager *rbac.Manager
+	router      cacheInvalidator // optional; invalidates config source cache on UpdateTenant
 }
 
 // NewManager creates a new tenant manager
@@ -25,6 +32,14 @@ func NewManager(store Store, rbacManager *rbac.Manager) *Manager {
 		store:       store,
 		rbacManager: rbacManager,
 	}
+}
+
+// WithConfigRouter wires a ConfigSourceRouter into the manager so that
+// UpdateTenant can invalidate the per-tenant config source cache immediately
+// after a successful store update.
+func (m *Manager) WithConfigRouter(r cacheInvalidator) *Manager {
+	m.router = r
+	return m
 }
 
 // CreateTenant creates a new tenant with validation and RBAC setup
@@ -94,6 +109,11 @@ func (m *Manager) UpdateTenant(ctx context.Context, tenantID string, req *Tenant
 	// Update in storage
 	if err := m.store.UpdateTenant(ctx, existing); err != nil {
 		return nil, fmt.Errorf("failed to update tenant: %w", err)
+	}
+
+	// Invalidate the config source cache so the next resolution reflects the new metadata.
+	if m.router != nil {
+		m.router.InvalidateTenantCache(tenantID)
 	}
 
 	return existing, nil

--- a/features/tenant/manager_test.go
+++ b/features/tenant/manager_test.go
@@ -337,3 +337,47 @@ func TestDeleteTenant_CascadesRBACCleanup_PartialFailureContinues(t *testing.T) 
 	// DeleteTenant must return nil despite individual cascade errors
 	require.NoError(t, manager.DeleteTenant(ctx, tenant.ID))
 }
+
+// recordingInvalidator records every tenant ID passed to InvalidateTenantCache.
+type recordingInvalidator struct {
+	calls []string
+}
+
+func (r *recordingInvalidator) InvalidateTenantCache(id string) {
+	r.calls = append(r.calls, id)
+}
+
+func TestManager_UpdateTenant_InvalidatesConfigCache(t *testing.T) {
+	manager := newTestTenantManager(t)
+	ctx := context.Background()
+
+	tenant, err := manager.CreateTenant(ctx, &TenantRequest{Name: "Cache-Invalidation-Test"})
+	require.NoError(t, err)
+
+	inv := &recordingInvalidator{}
+	manager.WithConfigRouter(inv)
+
+	updateReq := &TenantRequest{
+		Name: tenant.Name,
+		Metadata: map[string]string{
+			"config_source_type": "controller",
+		},
+	}
+	_, err = manager.UpdateTenant(ctx, tenant.ID, updateReq)
+	require.NoError(t, err)
+
+	require.Len(t, inv.calls, 1, "InvalidateTenantCache must be called exactly once after UpdateTenant")
+	assert.Equal(t, tenant.ID, inv.calls[0], "InvalidateTenantCache must receive the updated tenant ID")
+}
+
+func TestManager_UpdateTenant_NoRouterWired_NoError(t *testing.T) {
+	// Manager with no router wired must not panic on UpdateTenant.
+	manager := newTestTenantManager(t)
+	ctx := context.Background()
+
+	tenant, err := manager.CreateTenant(ctx, &TenantRequest{Name: "No-Router-Tenant"})
+	require.NoError(t, err)
+
+	_, err = manager.UpdateTenant(ctx, tenant.ID, &TenantRequest{Name: tenant.Name})
+	require.NoError(t, err, "UpdateTenant without a wired router must succeed")
+}

--- a/pkg/config/inheritance.go
+++ b/pkg/config/inheritance.go
@@ -16,15 +16,44 @@ import (
 	cfgconfig "github.com/cfgis/cfgms/pkg/storage/interfaces/config"
 )
 
+// configSourceRouter is the minimal interface that InheritanceResolver requires from
+// a ConfigSourceRouter. Defined here (not in pkg/configrouting/interfaces) to avoid
+// a circular import: pkg/configrouting/interfaces imports pkg/config for ConfigSourceInfo,
+// so pkg/config cannot import pkg/configrouting/interfaces in return.
+// The concrete *controllerRouter in pkg/configrouting/providers/controller satisfies this
+// interface by duck-typing; no explicit declaration is needed there.
+type configSourceRouter interface {
+	cfgconfig.ConfigStore
+	// SnapshotSources resolves the config source for every tenant in tenantPath atomically.
+	SnapshotSources(ctx context.Context, tenantPath []string) (map[string]*ConfigSourceInfo, error)
+}
+
+// cfgStoreAsRouter wraps a plain ConfigStore to satisfy configSourceRouter.
+// SnapshotSources always returns ConfigSourceTypeController for backward compatibility
+// (used by NewInheritanceResolverWithStorageManager which has no router available).
+type cfgStoreAsRouter struct {
+	cfgconfig.ConfigStore
+}
+
+func (s *cfgStoreAsRouter) SnapshotSources(_ context.Context, tenantPath []string) (map[string]*ConfigSourceInfo, error) {
+	m := make(map[string]*ConfigSourceInfo, len(tenantPath))
+	for _, tid := range tenantPath {
+		m[tid] = &ConfigSourceInfo{Type: ConfigSourceTypeController}
+	}
+	return m, nil
+}
+
 // InheritanceResolver handles configuration inheritance across tenant hierarchy
 type InheritanceResolver struct {
-	configStore       cfgconfig.ConfigStore
+	configStore       configSourceRouter
 	clientTenantStore business.ClientTenantStore
 	tenantStore       business.TenantStore
 }
 
-// NewInheritanceResolver creates a new inheritance resolver
-func NewInheritanceResolver(configStore cfgconfig.ConfigStore, clientTenantStore business.ClientTenantStore, tenantStore business.TenantStore) *InheritanceResolver {
+// NewInheritanceResolver creates an InheritanceResolver backed by a ConfigSourceRouter.
+// Pass a *controllerRouter (or any configSourceRouter implementation) so that
+// SnapshotSources is called once per cascade for atomic source resolution.
+func NewInheritanceResolver(configStore configSourceRouter, clientTenantStore business.ClientTenantStore, tenantStore business.TenantStore) *InheritanceResolver {
 	return &InheritanceResolver{
 		configStore:       configStore,
 		clientTenantStore: clientTenantStore,
@@ -32,10 +61,13 @@ func NewInheritanceResolver(configStore cfgconfig.ConfigStore, clientTenantStore
 	}
 }
 
-// NewInheritanceResolverWithStorageManager creates an inheritance resolver from storage manager
+// NewInheritanceResolverWithStorageManager creates an inheritance resolver from a storage
+// manager. The underlying ConfigStore is wrapped in a cfgStoreAsRouter adapter that always
+// returns ConfigSourceTypeController from SnapshotSources (backward-compatible default).
+// Prefer NewInheritanceResolver with a real ConfigSourceRouter for production deployments.
 func NewInheritanceResolverWithStorageManager(storageManager *interfaces.StorageManager) *InheritanceResolver {
 	return &InheritanceResolver{
-		configStore:       storageManager.GetConfigStore(),
+		configStore:       &cfgStoreAsRouter{ConfigStore: storageManager.GetConfigStore()},
 		clientTenantStore: storageManager.GetClientTenantStore(),
 		tenantStore:       storageManager.GetTenantStore(),
 	}
@@ -70,12 +102,21 @@ const (
 	LevelDevice InheritanceLevel = 3 // Device-specific configurations
 )
 
-// ResolveConfiguration resolves configuration with full tenant hierarchy inheritance
+// ResolveConfiguration resolves configuration with full tenant hierarchy inheritance.
+// SnapshotSources is called once before the cascade loop so that every level in the
+// hierarchy uses the same generation of source routing decisions — preventing a
+// mid-cascade source redirect from causing partial data from two different stores.
 func (ir *InheritanceResolver) ResolveConfiguration(ctx context.Context, tenantID, stewardID string) (*EffectiveConfiguration, error) {
 	// Get tenant hierarchy path
 	tenantPath, err := ir.getTenantPath(ctx, tenantID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to resolve tenant hierarchy: %w", err)
+	}
+
+	// Snapshot all config sources atomically before entering the cascade loop.
+	sourcesSnapshot, err := ir.configStore.SnapshotSources(ctx, tenantPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to snapshot config sources: %w", err)
 	}
 
 	// Initialize effective configuration
@@ -87,9 +128,10 @@ func (ir *InheritanceResolver) ResolveConfiguration(ctx context.Context, tenantI
 		GeneratedAt: time.Now(),
 	}
 
-	// Apply configurations from MSP level down to device level
+	// Apply configurations from MSP level down to device level using the pre-snapshotted sources.
 	for level, currentTenantID := range tenantPath {
-		if err := ir.applyConfigurationLevel(ctx, effective, currentTenantID, stewardID, level); err != nil {
+		source := sourcesSnapshot[currentTenantID]
+		if err := ir.applyConfigurationLevel(ctx, effective, currentTenantID, stewardID, level, source); err != nil {
 			return nil, fmt.Errorf("failed to apply configuration at level %d (tenant %s): %w", level, currentTenantID, err)
 		}
 	}
@@ -107,8 +149,13 @@ func (ir *InheritanceResolver) getTenantPath(ctx context.Context, tenantID strin
 	return ir.tenantStore.GetTenantPath(ctx, tenantID)
 }
 
-// applyConfigurationLevel applies configuration from a specific hierarchy level
-func (ir *InheritanceResolver) applyConfigurationLevel(ctx context.Context, effective *EffectiveConfiguration, tenantID, stewardID string, level int) error {
+// applyConfigurationLevel applies configuration from a specific hierarchy level.
+// source is the pre-snapshotted ConfigSourceInfo for this tenant, resolved once by
+// ResolveConfiguration before the cascade loop. In Phase 1 the router always returns
+// ConfigSourceTypeController so the configStore.GetConfig call below routes there;
+// Phase 2 (Story C) will use source.Type to dispatch to a git store.
+func (ir *InheritanceResolver) applyConfigurationLevel(ctx context.Context, effective *EffectiveConfiguration, tenantID, stewardID string, level int, source *ConfigSourceInfo) error {
+	_ = source // Phase 1: routing handled internally by configStore (always controller)
 	// Try to get configuration at this level
 	var configNamespace string
 	var configName string
@@ -146,7 +193,7 @@ func (ir *InheritanceResolver) applyConfigurationLevel(ctx context.Context, effe
 	}
 
 	// Create inheritance source tracking
-	source := &InheritanceSource{
+	inheritSrc := &InheritanceSource{
 		Level:      level,
 		TenantID:   tenantID,
 		ConfigName: configName,
@@ -156,7 +203,7 @@ func (ir *InheritanceResolver) applyConfigurationLevel(ctx context.Context, effe
 	}
 
 	// Apply configuration using declarative merging (named resources replace entirely)
-	ir.applyConfigurationWithSource(effective, &levelConfig, source)
+	ir.applyConfigurationWithSource(effective, &levelConfig, inheritSrc)
 
 	return nil
 }

--- a/pkg/configrouting/interfaces/contract_test.go
+++ b/pkg/configrouting/interfaces/contract_test.go
@@ -1,0 +1,276 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+// Package interfaces_test contains contract tests for the ConfigSourceRouter interface.
+//
+// # Usage by provider implementors
+//
+// To validate a new ConfigSourceRouter implementation, call RunRouterContractTests
+// from the provider's test package:
+//
+//	func TestMyRouter_ContractSuite(t *testing.T) {
+//		interfaces.RunRouterContractTests(t, myRouterFactory)
+//	}
+//
+// where myRouterFactory returns a fully initialised ConfigSourceRouter and a cleanup
+// function (to release resources).
+package interfaces_test
+
+import (
+	"context"
+	"testing"
+
+	pkgconfig "github.com/cfgis/cfgms/pkg/config"
+	routerinterfaces "github.com/cfgis/cfgms/pkg/configrouting/interfaces"
+	cfgconfig "github.com/cfgis/cfgms/pkg/storage/interfaces/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// RouterFactory creates a ConfigSourceRouter and returns it together with a cleanup
+// function that releases all associated resources.
+//
+// The returned router must be backed by a tenant hierarchy with at least three
+// levels: root → msp → client (IDs exactly as shown). The root tenant must have
+// no config_source_type metadata (so GetEffectiveConfigSource defaults to controller).
+type RouterFactory func(t *testing.T) (router routerinterfaces.ConfigSourceRouter, cleanup func())
+
+// RunRouterContractTests runs the full ConfigSourceRouter contract test suite.
+// Each contract is a separate subtest for granular reporting.
+func RunRouterContractTests(t *testing.T, factory RouterFactory) {
+	t.Helper()
+
+	t.Run("GetEffectiveConfigSource_DefaultsToController", func(t *testing.T) {
+		testGetEffectiveConfigSource_DefaultsToController(t, factory)
+	})
+	t.Run("GetEffectiveConfigSource_CachesResult", func(t *testing.T) {
+		testGetEffectiveConfigSource_CachesResult(t, factory)
+	})
+	t.Run("SnapshotSources_ReturnsAllLevels", func(t *testing.T) {
+		testSnapshotSources_ReturnsAllLevels(t, factory)
+	})
+	t.Run("SnapshotSources_ReturnsDeepCopies", func(t *testing.T) {
+		testSnapshotSources_ReturnsDeepCopies(t, factory)
+	})
+	t.Run("InvalidateTenantCache_ForcesRefresh", func(t *testing.T) {
+		testInvalidateTenantCache_ForcesRefresh(t, factory)
+	})
+	t.Run("StoreConfig_Roundtrip", func(t *testing.T) {
+		testStoreConfig_Roundtrip(t, factory)
+	})
+	t.Run("GetConfig_NotFound", func(t *testing.T) {
+		testGetConfig_NotFound(t, factory)
+	})
+	t.Run("ListConfigs_EmptyTenantIDAllowed", func(t *testing.T) {
+		testListConfigs_EmptyTenantIDAllowed(t, factory)
+	})
+	t.Run("DeleteConfig_Roundtrip", func(t *testing.T) {
+		testDeleteConfig_Roundtrip(t, factory)
+	})
+	t.Run("StoreConfigBatch_Roundtrip", func(t *testing.T) {
+		testStoreConfigBatch_Roundtrip(t, factory)
+	})
+	t.Run("GetConfigHistory_AfterStore", func(t *testing.T) {
+		testGetConfigHistory_AfterStore(t, factory)
+	})
+	t.Run("SnapshotSources_EmptyPath", func(t *testing.T) {
+		testSnapshotSources_EmptyPath(t, factory)
+	})
+}
+
+func testGetEffectiveConfigSource_DefaultsToController(t *testing.T, factory RouterFactory) {
+	t.Helper()
+	router, cleanup := factory(t)
+	defer cleanup()
+
+	info, err := router.GetEffectiveConfigSource(context.Background(), "root")
+	require.NoError(t, err)
+	assert.Equal(t, pkgconfig.ConfigSourceTypeController, info.Type)
+}
+
+func testGetEffectiveConfigSource_CachesResult(t *testing.T, factory RouterFactory) {
+	t.Helper()
+	router, cleanup := factory(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	info1, err := router.GetEffectiveConfigSource(ctx, "root")
+	require.NoError(t, err)
+
+	info2, err := router.GetEffectiveConfigSource(ctx, "root")
+	require.NoError(t, err)
+
+	assert.Equal(t, info1.Type, info2.Type, "repeated calls must return consistent results")
+}
+
+func testSnapshotSources_ReturnsAllLevels(t *testing.T, factory RouterFactory) {
+	t.Helper()
+	router, cleanup := factory(t)
+	defer cleanup()
+
+	path := []string{"root", "msp", "client"}
+	snapshot, err := router.SnapshotSources(context.Background(), path)
+	require.NoError(t, err)
+	require.Len(t, snapshot, 3)
+
+	for _, tid := range path {
+		info, ok := snapshot[tid]
+		require.True(t, ok, "snapshot must include entry for %q", tid)
+		assert.NotNil(t, info)
+	}
+}
+
+func testSnapshotSources_ReturnsDeepCopies(t *testing.T, factory RouterFactory) {
+	t.Helper()
+	router, cleanup := factory(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	snapshot, err := router.SnapshotSources(ctx, []string{"root"})
+	require.NoError(t, err)
+
+	// Mutate snapshot entry; subsequent GetEffectiveConfigSource must not see mutation.
+	entry := snapshot["root"]
+	entry.Branch = "mutated-branch"
+
+	info, err := router.GetEffectiveConfigSource(ctx, "root")
+	require.NoError(t, err)
+	assert.NotEqual(t, "mutated-branch", info.Branch, "mutation of snapshot must not affect cache")
+}
+
+func testInvalidateTenantCache_ForcesRefresh(t *testing.T, factory RouterFactory) {
+	t.Helper()
+	router, cleanup := factory(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	// Prime the cache.
+	_, err := router.GetEffectiveConfigSource(ctx, "client")
+	require.NoError(t, err)
+
+	// Invalidate should not panic or error.
+	router.InvalidateTenantCache("client")
+
+	// Subsequent resolution should still work after invalidation.
+	info, err := router.GetEffectiveConfigSource(ctx, "client")
+	require.NoError(t, err)
+	assert.NotNil(t, info)
+}
+
+func testStoreConfig_Roundtrip(t *testing.T, factory RouterFactory) {
+	t.Helper()
+	router, cleanup := factory(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	key := &cfgconfig.ConfigKey{TenantID: "client", Namespace: "test-contract", Name: "entry1"}
+	entry := &cfgconfig.ConfigEntry{
+		Key:    key,
+		Data:   []byte("contract: test"),
+		Format: cfgconfig.ConfigFormatYAML,
+	}
+
+	require.NoError(t, router.StoreConfig(ctx, entry))
+
+	got, err := router.GetConfig(ctx, key)
+	require.NoError(t, err)
+	assert.Equal(t, entry.Data, got.Data)
+}
+
+func testGetConfig_NotFound(t *testing.T, factory RouterFactory) {
+	t.Helper()
+	router, cleanup := factory(t)
+	defer cleanup()
+
+	key := &cfgconfig.ConfigKey{TenantID: "client", Namespace: "test-contract", Name: "does-not-exist"}
+	_, err := router.GetConfig(context.Background(), key)
+	assert.Error(t, err, "GetConfig must return an error for missing keys")
+}
+
+func testListConfigs_EmptyTenantIDAllowed(t *testing.T, factory RouterFactory) {
+	t.Helper()
+	router, cleanup := factory(t)
+	defer cleanup()
+
+	// ListConfigs with an empty TenantID filter must not return a cross-tenant error.
+	filter := &cfgconfig.ConfigFilter{TenantID: ""}
+	_, err := router.ListConfigs(context.Background(), filter)
+	assert.NoError(t, err, "empty TenantID filter must be accepted (backward compat)")
+}
+
+func testDeleteConfig_Roundtrip(t *testing.T, factory RouterFactory) {
+	t.Helper()
+	router, cleanup := factory(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	key := &cfgconfig.ConfigKey{TenantID: "client", Namespace: "test-contract", Name: "to-delete"}
+	entry := &cfgconfig.ConfigEntry{
+		Key:    key,
+		Data:   []byte("delete: me"),
+		Format: cfgconfig.ConfigFormatYAML,
+	}
+
+	require.NoError(t, router.StoreConfig(ctx, entry))
+	require.NoError(t, router.DeleteConfig(ctx, key))
+
+	_, err := router.GetConfig(ctx, key)
+	assert.Error(t, err, "GetConfig must error after deletion")
+}
+
+func testStoreConfigBatch_Roundtrip(t *testing.T, factory RouterFactory) {
+	t.Helper()
+	router, cleanup := factory(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	entries := []*cfgconfig.ConfigEntry{
+		{
+			Key:    &cfgconfig.ConfigKey{TenantID: "client", Namespace: "batch", Name: "a"},
+			Data:   []byte("a: 1"),
+			Format: cfgconfig.ConfigFormatYAML,
+		},
+		{
+			Key:    &cfgconfig.ConfigKey{TenantID: "client", Namespace: "batch", Name: "b"},
+			Data:   []byte("b: 2"),
+			Format: cfgconfig.ConfigFormatYAML,
+		},
+	}
+
+	require.NoError(t, router.StoreConfigBatch(ctx, entries))
+
+	for _, e := range entries {
+		got, err := router.GetConfig(ctx, e.Key)
+		require.NoError(t, err)
+		assert.Equal(t, e.Data, got.Data)
+	}
+}
+
+func testGetConfigHistory_AfterStore(t *testing.T, factory RouterFactory) {
+	t.Helper()
+	router, cleanup := factory(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	key := &cfgconfig.ConfigKey{TenantID: "client", Namespace: "history", Name: "versioned"}
+	entry := &cfgconfig.ConfigEntry{
+		Key:    key,
+		Data:   []byte("version: 1"),
+		Format: cfgconfig.ConfigFormatYAML,
+	}
+
+	require.NoError(t, router.StoreConfig(ctx, entry))
+
+	history, err := router.GetConfigHistory(ctx, key, 10)
+	require.NoError(t, err)
+	assert.NotEmpty(t, history, "history must not be empty after StoreConfig")
+}
+
+func testSnapshotSources_EmptyPath(t *testing.T, factory RouterFactory) {
+	t.Helper()
+	router, cleanup := factory(t)
+	defer cleanup()
+
+	snapshot, err := router.SnapshotSources(context.Background(), []string{})
+	require.NoError(t, err)
+	assert.Empty(t, snapshot, "empty path must return empty map")
+}

--- a/pkg/configrouting/interfaces/providers_test.go
+++ b/pkg/configrouting/interfaces/providers_test.go
@@ -1,0 +1,139 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+// Package interfaces_test — provider factory for contract tests.
+// Kept in a file named providers_test.go so that the check-providers.sh
+// architecture script allows the direct flatfile import (*/providers_test.go exception).
+package interfaces_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	routerinterfaces "github.com/cfgis/cfgms/pkg/configrouting/interfaces"
+	controllerrouter "github.com/cfgis/cfgms/pkg/configrouting/providers/controller"
+	business "github.com/cfgis/cfgms/pkg/storage/interfaces/business"
+	flatfile "github.com/cfgis/cfgms/pkg/storage/providers/flatfile"
+)
+
+// contractTenantStore is the in-memory tenant store used by the contract test factory.
+// It provides a fixed 3-level hierarchy: root → msp → client.
+type contractTenantStore struct {
+	tenants map[string]*business.TenantData
+}
+
+func newContractTenantStore() *contractTenantStore {
+	ts := &contractTenantStore{tenants: make(map[string]*business.TenantData)}
+	for _, td := range []*business.TenantData{
+		{ID: "root", Name: "Root", Status: business.TenantStatusActive},
+		{ID: "msp", Name: "MSP", ParentID: "root", Status: business.TenantStatusActive},
+		{ID: "client", Name: "Client", ParentID: "msp", Status: business.TenantStatusActive},
+	} {
+		ts.tenants[td.ID] = td
+	}
+	return ts
+}
+
+func (s *contractTenantStore) Initialize(_ context.Context) error { return nil }
+func (s *contractTenantStore) Close() error                       { return nil }
+func (s *contractTenantStore) CreateTenant(_ context.Context, t *business.TenantData) error {
+	s.tenants[t.ID] = t
+	return nil
+}
+func (s *contractTenantStore) GetTenant(_ context.Context, id string) (*business.TenantData, error) {
+	t, ok := s.tenants[id]
+	if !ok {
+		return nil, fmt.Errorf("tenant not found: %s", id)
+	}
+	return t, nil
+}
+func (s *contractTenantStore) UpdateTenant(_ context.Context, t *business.TenantData) error {
+	s.tenants[t.ID] = t
+	return nil
+}
+func (s *contractTenantStore) DeleteTenant(_ context.Context, id string) error {
+	delete(s.tenants, id)
+	return nil
+}
+func (s *contractTenantStore) ListTenants(_ context.Context, _ *business.TenantFilter) ([]*business.TenantData, error) {
+	out := make([]*business.TenantData, 0, len(s.tenants))
+	for _, t := range s.tenants {
+		out = append(out, t)
+	}
+	return out, nil
+}
+func (s *contractTenantStore) GetTenantHierarchy(_ context.Context, id string) (*business.TenantHierarchy, error) {
+	path, _ := s.GetTenantPath(context.Background(), id)
+	return &business.TenantHierarchy{TenantID: id, Path: path, Depth: len(path) - 1}, nil
+}
+func (s *contractTenantStore) GetChildTenants(_ context.Context, parentID string) ([]*business.TenantData, error) {
+	var children []*business.TenantData
+	for _, t := range s.tenants {
+		if t.ParentID == parentID {
+			children = append(children, t)
+		}
+	}
+	return children, nil
+}
+func (s *contractTenantStore) GetTenantPath(_ context.Context, tenantID string) ([]string, error) {
+	var path []string
+	cur := tenantID
+	seen := make(map[string]bool)
+	for {
+		if seen[cur] {
+			return nil, fmt.Errorf("cycle detected for %q", tenantID)
+		}
+		seen[cur] = true
+		path = append([]string{cur}, path...)
+		t, ok := s.tenants[cur]
+		if !ok {
+			return nil, fmt.Errorf("tenant not found: %s", cur)
+		}
+		if t.ParentID == "" {
+			break
+		}
+		cur = t.ParentID
+	}
+	return path, nil
+}
+func (s *contractTenantStore) IsTenantAncestor(_ context.Context, ancestorID, descendantID string) (bool, error) {
+	cur := descendantID
+	seen := make(map[string]bool)
+	for {
+		if seen[cur] {
+			return false, nil
+		}
+		seen[cur] = true
+		t, ok := s.tenants[cur]
+		if !ok {
+			return false, nil
+		}
+		if t.ParentID == ancestorID {
+			return true, nil
+		}
+		if t.ParentID == "" {
+			return false, nil
+		}
+		cur = t.ParentID
+	}
+}
+
+// controllerRouterFactory creates a ControllerRouter backed by a FlatFileConfigStore
+// and an in-memory tenant store with the required 3-level hierarchy (root → msp → client).
+func controllerRouterFactory(t *testing.T) (routerinterfaces.ConfigSourceRouter, func()) {
+	t.Helper()
+	flatfileRoot := t.TempDir()
+	cs, err := flatfile.NewFlatFileConfigStore(flatfileRoot)
+	if err != nil {
+		t.Fatalf("failed to create flatfile store: %v", err)
+	}
+	ts := newContractTenantStore()
+	router := controllerrouter.NewControllerRouter(cs, ts)
+	return router, func() {}
+}
+
+// TestControllerRouter_ContractSuite runs all ConfigSourceRouter contract tests against
+// the Phase 1 controller provider implementation.
+func TestControllerRouter_ContractSuite(t *testing.T) {
+	RunRouterContractTests(t, controllerRouterFactory)
+}

--- a/pkg/configrouting/interfaces/providers_test.go
+++ b/pkg/configrouting/interfaces/providers_test.go
@@ -2,134 +2,52 @@
 // Copyright 2026 Jordan Ritz
 // Package interfaces_test — provider factory for contract tests.
 // Kept in a file named providers_test.go so that the check-providers.sh
-// architecture script allows the direct flatfile import (*/providers_test.go exception).
+// architecture script allows the direct flatfile/sqlite import (*/providers_test.go exception).
 package interfaces_test
 
 import (
 	"context"
-	"fmt"
+	"path/filepath"
 	"testing"
 
 	routerinterfaces "github.com/cfgis/cfgms/pkg/configrouting/interfaces"
 	controllerrouter "github.com/cfgis/cfgms/pkg/configrouting/providers/controller"
 	business "github.com/cfgis/cfgms/pkg/storage/interfaces/business"
 	flatfile "github.com/cfgis/cfgms/pkg/storage/providers/flatfile"
+	"github.com/cfgis/cfgms/pkg/storage/providers/sqlite"
 )
 
-// contractTenantStore is the in-memory tenant store used by the contract test factory.
-// It provides a fixed 3-level hierarchy: root → msp → client.
-type contractTenantStore struct {
-	tenants map[string]*business.TenantData
-}
-
-func newContractTenantStore() *contractTenantStore {
-	ts := &contractTenantStore{tenants: make(map[string]*business.TenantData)}
-	for _, td := range []*business.TenantData{
-		{ID: "root", Name: "Root", Status: business.TenantStatusActive},
-		{ID: "msp", Name: "MSP", ParentID: "root", Status: business.TenantStatusActive},
-		{ID: "client", Name: "Client", ParentID: "msp", Status: business.TenantStatusActive},
-	} {
-		ts.tenants[td.ID] = td
-	}
-	return ts
-}
-
-func (s *contractTenantStore) Initialize(_ context.Context) error { return nil }
-func (s *contractTenantStore) Close() error                       { return nil }
-func (s *contractTenantStore) CreateTenant(_ context.Context, t *business.TenantData) error {
-	s.tenants[t.ID] = t
-	return nil
-}
-func (s *contractTenantStore) GetTenant(_ context.Context, id string) (*business.TenantData, error) {
-	t, ok := s.tenants[id]
-	if !ok {
-		return nil, fmt.Errorf("tenant not found: %s", id)
-	}
-	return t, nil
-}
-func (s *contractTenantStore) UpdateTenant(_ context.Context, t *business.TenantData) error {
-	s.tenants[t.ID] = t
-	return nil
-}
-func (s *contractTenantStore) DeleteTenant(_ context.Context, id string) error {
-	delete(s.tenants, id)
-	return nil
-}
-func (s *contractTenantStore) ListTenants(_ context.Context, _ *business.TenantFilter) ([]*business.TenantData, error) {
-	out := make([]*business.TenantData, 0, len(s.tenants))
-	for _, t := range s.tenants {
-		out = append(out, t)
-	}
-	return out, nil
-}
-func (s *contractTenantStore) GetTenantHierarchy(_ context.Context, id string) (*business.TenantHierarchy, error) {
-	path, _ := s.GetTenantPath(context.Background(), id)
-	return &business.TenantHierarchy{TenantID: id, Path: path, Depth: len(path) - 1}, nil
-}
-func (s *contractTenantStore) GetChildTenants(_ context.Context, parentID string) ([]*business.TenantData, error) {
-	var children []*business.TenantData
-	for _, t := range s.tenants {
-		if t.ParentID == parentID {
-			children = append(children, t)
-		}
-	}
-	return children, nil
-}
-func (s *contractTenantStore) GetTenantPath(_ context.Context, tenantID string) ([]string, error) {
-	var path []string
-	cur := tenantID
-	seen := make(map[string]bool)
-	for {
-		if seen[cur] {
-			return nil, fmt.Errorf("cycle detected for %q", tenantID)
-		}
-		seen[cur] = true
-		path = append([]string{cur}, path...)
-		t, ok := s.tenants[cur]
-		if !ok {
-			return nil, fmt.Errorf("tenant not found: %s", cur)
-		}
-		if t.ParentID == "" {
-			break
-		}
-		cur = t.ParentID
-	}
-	return path, nil
-}
-func (s *contractTenantStore) IsTenantAncestor(_ context.Context, ancestorID, descendantID string) (bool, error) {
-	cur := descendantID
-	seen := make(map[string]bool)
-	for {
-		if seen[cur] {
-			return false, nil
-		}
-		seen[cur] = true
-		t, ok := s.tenants[cur]
-		if !ok {
-			return false, nil
-		}
-		if t.ParentID == ancestorID {
-			return true, nil
-		}
-		if t.ParentID == "" {
-			return false, nil
-		}
-		cur = t.ParentID
-	}
-}
-
 // controllerRouterFactory creates a ControllerRouter backed by a FlatFileConfigStore
-// and an in-memory tenant store with the required 3-level hierarchy (root → msp → client).
+// and a real SQLite TenantStore with the required 3-level hierarchy (root → msp → client).
 func controllerRouterFactory(t *testing.T) (routerinterfaces.ConfigSourceRouter, func()) {
 	t.Helper()
+
 	flatfileRoot := t.TempDir()
 	cs, err := flatfile.NewFlatFileConfigStore(flatfileRoot)
 	if err != nil {
 		t.Fatalf("failed to create flatfile store: %v", err)
 	}
-	ts := newContractTenantStore()
+
+	dir := t.TempDir()
+	p := sqlite.NewSQLiteProvider(dir)
+	ts, err := p.CreateTenantStore(map[string]interface{}{"path": filepath.Join(dir, "tenants.db")})
+	if err != nil {
+		t.Fatalf("failed to create sqlite tenant store: %v", err)
+	}
+
+	ctx := context.Background()
+	for _, td := range []*business.TenantData{
+		{ID: "root", Name: "Root", Status: business.TenantStatusActive},
+		{ID: "msp", Name: "MSP", ParentID: "root", Status: business.TenantStatusActive},
+		{ID: "client", Name: "Client", ParentID: "msp", Status: business.TenantStatusActive},
+	} {
+		if err := ts.CreateTenant(ctx, td); err != nil {
+			t.Fatalf("failed to create tenant %s: %v", td.ID, err)
+		}
+	}
+
 	router := controllerrouter.NewControllerRouter(cs, ts)
-	return router, func() {}
+	return router, func() { _ = ts.Close() }
 }
 
 // TestControllerRouter_ContractSuite runs all ConfigSourceRouter contract tests against

--- a/pkg/configrouting/interfaces/router.go
+++ b/pkg/configrouting/interfaces/router.go
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+// Package interfaces defines the ConfigSourceRouter contract for per-tenant config source routing.
+package interfaces
+
+import (
+	"context"
+
+	pkgconfig "github.com/cfgis/cfgms/pkg/config"
+	cfgconfig "github.com/cfgis/cfgms/pkg/storage/interfaces/config"
+)
+
+// ConfigSourceRouter wraps cfgconfig.ConfigStore and adds per-tenant config source routing.
+// Implementations resolve which backing store (controller, git, etc.) to use for each
+// tenant based on mount-point metadata, caching resolution decisions with a 1-minute TTL.
+//
+// Phase 1 routes every tenant to the controller's own store.
+// Phase 2 (Story C) extends storeForSource to dispatch git sources without changing this interface.
+type ConfigSourceRouter interface {
+	cfgconfig.ConfigStore
+
+	// GetEffectiveConfigSource returns the resolved config source for tenantID.
+	// Walks TenantStore.GetTenantPath leaf-to-root and returns the first ancestor
+	// (inclusive) with config_source_type in metadata. Falls back to
+	// ConfigSourceTypeController when no metadata is present.
+	GetEffectiveConfigSource(ctx context.Context, tenantID string) (*pkgconfig.ConfigSourceInfo, error)
+
+	// SnapshotSources resolves the config source for every tenant in tenantPath in a
+	// single atomic pass, acquiring the cache read-lock before iterating.
+	// The returned map contains deep copies — callers must not retain references to cached values.
+	// InheritanceResolver calls this once before the cascade loop to prevent
+	// mid-cascade source redirects.
+	SnapshotSources(ctx context.Context, tenantPath []string) (map[string]*pkgconfig.ConfigSourceInfo, error)
+
+	// InvalidateTenantCache immediately evicts the cached source resolution for tenantID.
+	// Called by tenant.Manager.UpdateTenant after a successful store update.
+	InvalidateTenantCache(tenantID string)
+}

--- a/pkg/configrouting/providers/controller/router.go
+++ b/pkg/configrouting/providers/controller/router.go
@@ -1,0 +1,261 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+// Package controller provides the Phase 1 ConfigSourceRouter implementation that routes
+// all tenant config reads to the controller's own store.
+//
+// Phase 2 (Story C) extends storeForSource to dispatch git sources without modifying
+// this router's interface or the cache/snapshot machinery defined here.
+package controller
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/cfgis/cfgms/pkg/cache"
+	pkgconfig "github.com/cfgis/cfgms/pkg/config"
+	routerinterfaces "github.com/cfgis/cfgms/pkg/configrouting/interfaces"
+	"github.com/cfgis/cfgms/pkg/ctxkeys"
+	"github.com/cfgis/cfgms/pkg/logging"
+	business "github.com/cfgis/cfgms/pkg/storage/interfaces/business"
+	cfgconfig "github.com/cfgis/cfgms/pkg/storage/interfaces/config"
+)
+
+const sourceCacheTTL = time.Minute
+
+// controllerRouter implements ConfigSourceRouter routing all reads to controllerStore.
+type controllerRouter struct {
+	controllerStore cfgconfig.ConfigStore
+	tenantStore     business.TenantStore
+	sourceCache     *cache.Cache
+	// snapshotMu serialises InvalidateTenantCache against SnapshotSources so that
+	// a snapshot never straddles a cache flush — every entry in the snapshot is
+	// resolved from the same generation of the cache.
+	snapshotMu sync.RWMutex
+}
+
+// NewControllerRouter creates a ConfigSourceRouter that delegates all reads and writes
+// to controllerStore. tenantStore is used to resolve the tenant hierarchy for source
+// resolution and cross-tenant access checks.
+func NewControllerRouter(controllerStore cfgconfig.ConfigStore, tenantStore business.TenantStore) routerinterfaces.ConfigSourceRouter {
+	return &controllerRouter{
+		controllerStore: controllerStore,
+		tenantStore:     tenantStore,
+		sourceCache: cache.NewCache(cache.CacheConfig{
+			Name:            "configrouting-source",
+			MaxRuntimeItems: 10000,
+			DefaultTTL:      sourceCacheTTL,
+			CleanupInterval: 5 * time.Minute,
+			EvictionPolicy:  cache.EvictionLRU,
+		}),
+	}
+}
+
+// GetEffectiveConfigSource resolves the config source for tenantID, walking the tenant
+// path leaf-to-root and returning the first ancestor (inclusive) that has
+// config_source_type in its metadata. Results are cached for sourceCacheTTL.
+func (r *controllerRouter) GetEffectiveConfigSource(ctx context.Context, tenantID string) (*pkgconfig.ConfigSourceInfo, error) {
+	if cached, ok := r.sourceCache.Get(tenantID); ok {
+		info := cached.(pkgconfig.ConfigSourceInfo)
+		return &info, nil
+	}
+
+	path, err := r.tenantStore.GetTenantPath(ctx, tenantID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get tenant path for %q: %w", tenantID, err)
+	}
+
+	// Walk leaf-to-root: GetTenantPath returns root→leaf, so iterate in reverse.
+	for i := len(path) - 1; i >= 0; i-- {
+		tid := path[i]
+		tenant, err := r.tenantStore.GetTenant(ctx, tid)
+		if err != nil {
+			continue // skip tenants that can't be loaded
+		}
+		if _, hasType := tenant.Metadata[pkgconfig.MetaKeyConfigSourceType]; hasType {
+			info, err := pkgconfig.ParseConfigSource(tenant.Metadata)
+			if err != nil {
+				return nil, fmt.Errorf("invalid config source metadata for tenant %q: %w", tid, err)
+			}
+			if info.Type == pkgconfig.ConfigSourceTypeGit {
+				slog.Debug("config source router: git source resolved",
+					"tenant_id", logging.SanitizeLogValue(tenantID),
+					"resolved_from", logging.SanitizeLogValue(tid),
+					"url", logging.SanitizeLogValue(info.URL),
+				)
+			}
+			_ = r.sourceCache.Set(tenantID, *info, sourceCacheTTL)
+			return info, nil
+		}
+	}
+
+	// No metadata found anywhere in the hierarchy — default to controller.
+	info := &pkgconfig.ConfigSourceInfo{Type: pkgconfig.ConfigSourceTypeController}
+	_ = r.sourceCache.Set(tenantID, *info, sourceCacheTTL)
+	return info, nil
+}
+
+// SnapshotSources resolves config sources for every tenant in tenantPath in a single
+// atomic pass. Holds snapshotMu.RLock() throughout so that InvalidateTenantCache
+// cannot flush the cache mid-iteration, keeping the snapshot internally consistent.
+// Each returned *ConfigSourceInfo is a deep copy; callers must not retain references.
+func (r *controllerRouter) SnapshotSources(ctx context.Context, tenantPath []string) (map[string]*pkgconfig.ConfigSourceInfo, error) {
+	r.snapshotMu.RLock()
+	defer r.snapshotMu.RUnlock()
+
+	result := make(map[string]*pkgconfig.ConfigSourceInfo, len(tenantPath))
+	for _, tenantID := range tenantPath {
+		info, err := r.GetEffectiveConfigSource(ctx, tenantID)
+		if err != nil {
+			return nil, fmt.Errorf("snapshot: failed to resolve source for tenant %q: %w", tenantID, err)
+		}
+		copied := *info // deep copy — ConfigSourceInfo contains no pointer fields that need cloning
+		result[tenantID] = &copied
+	}
+	return result, nil
+}
+
+// InvalidateTenantCache evicts the cached source resolution for tenantID. Acquires
+// snapshotMu.Lock() so that in-flight snapshots complete before the entry is removed.
+func (r *controllerRouter) InvalidateTenantCache(tenantID string) {
+	r.snapshotMu.Lock()
+	defer r.snapshotMu.Unlock()
+	r.sourceCache.Delete(tenantID)
+}
+
+// storeForSource returns the ConfigStore to use for the given source.
+// Phase 1: always returns controllerStore.
+// Phase 2 (Story C): check info.Type == ConfigSourceTypeGit and return GitConfigStore.
+func (r *controllerRouter) storeForSource(_ *pkgconfig.ConfigSourceInfo) cfgconfig.ConfigStore {
+	return r.controllerStore
+}
+
+// checkCrossTenant returns an error if the context tenant cannot access tenantID's config.
+// Rules (skip check when either side is unset/default for backward compatibility):
+//   - same tenant → allowed
+//   - tenantID is an ancestor of the context tenant → allowed (cascade reads ancestors)
+//   - otherwise → cross-tenant denied
+func (r *controllerRouter) checkCrossTenant(ctx context.Context, tenantID string) error {
+	if tenantID == "" {
+		return nil // empty TenantID is handled as "route to controllerStore" elsewhere
+	}
+	ctxTenant, ok := ctx.Value(ctxkeys.TenantID).(string)
+	if !ok || ctxTenant == "" || ctxTenant == "default" {
+		return nil // no authenticated context tenant — backward-compat passthrough
+	}
+	if ctxTenant == tenantID {
+		return nil
+	}
+	// Allow reads of ancestor tenants (InheritanceResolver walking up the hierarchy).
+	isAncestor, err := r.tenantStore.IsTenantAncestor(ctx, tenantID, ctxTenant)
+	if err != nil {
+		return fmt.Errorf("cross-tenant check for tenant %q: %w", tenantID, err)
+	}
+	if !isAncestor {
+		return fmt.Errorf("cross-tenant access denied: caller %q cannot access tenant %q",
+			ctxTenant, tenantID)
+	}
+	return nil
+}
+
+// routeRead resolves the store for key.TenantID and delegates the actual call to
+// the provided fn. Empty TenantID bypasses resolution and goes to controllerStore.
+func (r *controllerRouter) routeRead(ctx context.Context, tenantID string, fn func(cfgconfig.ConfigStore) error) error {
+	if tenantID == "" {
+		return fn(r.controllerStore)
+	}
+	if err := r.checkCrossTenant(ctx, tenantID); err != nil {
+		return err
+	}
+	info, err := r.GetEffectiveConfigSource(ctx, tenantID)
+	if err != nil {
+		return err
+	}
+	return fn(r.storeForSource(info))
+}
+
+// --- ConfigStore read methods ---
+
+func (r *controllerRouter) GetConfig(ctx context.Context, key *cfgconfig.ConfigKey) (*cfgconfig.ConfigEntry, error) {
+	var result *cfgconfig.ConfigEntry
+	err := r.routeRead(ctx, key.TenantID, func(s cfgconfig.ConfigStore) error {
+		var e error
+		result, e = s.GetConfig(ctx, key)
+		return e
+	})
+	return result, err
+}
+
+func (r *controllerRouter) ListConfigs(ctx context.Context, filter *cfgconfig.ConfigFilter) ([]*cfgconfig.ConfigEntry, error) {
+	tenantID := ""
+	if filter != nil {
+		tenantID = filter.TenantID
+	}
+	var result []*cfgconfig.ConfigEntry
+	err := r.routeRead(ctx, tenantID, func(s cfgconfig.ConfigStore) error {
+		var e error
+		result, e = s.ListConfigs(ctx, filter)
+		return e
+	})
+	return result, err
+}
+
+func (r *controllerRouter) GetConfigHistory(ctx context.Context, key *cfgconfig.ConfigKey, limit int) ([]*cfgconfig.ConfigEntry, error) {
+	var result []*cfgconfig.ConfigEntry
+	err := r.routeRead(ctx, key.TenantID, func(s cfgconfig.ConfigStore) error {
+		var e error
+		result, e = s.GetConfigHistory(ctx, key, limit)
+		return e
+	})
+	return result, err
+}
+
+func (r *controllerRouter) GetConfigVersion(ctx context.Context, key *cfgconfig.ConfigKey, version int64) (*cfgconfig.ConfigEntry, error) {
+	var result *cfgconfig.ConfigEntry
+	err := r.routeRead(ctx, key.TenantID, func(s cfgconfig.ConfigStore) error {
+		var e error
+		result, e = s.GetConfigVersion(ctx, key, version)
+		return e
+	})
+	return result, err
+}
+
+func (r *controllerRouter) ResolveConfigWithInheritance(ctx context.Context, key *cfgconfig.ConfigKey) (*cfgconfig.ConfigEntry, error) {
+	var result *cfgconfig.ConfigEntry
+	err := r.routeRead(ctx, key.TenantID, func(s cfgconfig.ConfigStore) error {
+		var e error
+		result, e = s.ResolveConfigWithInheritance(ctx, key)
+		return e
+	})
+	return result, err
+}
+
+// --- ConfigStore write methods — always route to controllerStore ---
+// External git sources are read-only; all writes go to the controller store regardless
+// of the declared source type.
+
+func (r *controllerRouter) StoreConfig(ctx context.Context, config *cfgconfig.ConfigEntry) error {
+	return r.controllerStore.StoreConfig(ctx, config)
+}
+
+func (r *controllerRouter) DeleteConfig(ctx context.Context, key *cfgconfig.ConfigKey) error {
+	return r.controllerStore.DeleteConfig(ctx, key)
+}
+
+func (r *controllerRouter) StoreConfigBatch(ctx context.Context, configs []*cfgconfig.ConfigEntry) error {
+	return r.controllerStore.StoreConfigBatch(ctx, configs)
+}
+
+func (r *controllerRouter) DeleteConfigBatch(ctx context.Context, keys []*cfgconfig.ConfigKey) error {
+	return r.controllerStore.DeleteConfigBatch(ctx, keys)
+}
+
+func (r *controllerRouter) ValidateConfig(ctx context.Context, config *cfgconfig.ConfigEntry) error {
+	return r.controllerStore.ValidateConfig(ctx, config)
+}
+
+func (r *controllerRouter) GetConfigStats(ctx context.Context) (*cfgconfig.ConfigStats, error) {
+	return r.controllerStore.GetConfigStats(ctx)
+}

--- a/pkg/configrouting/providers/controller/router_test.go
+++ b/pkg/configrouting/providers/controller/router_test.go
@@ -1,0 +1,510 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+package controller
+
+import (
+	"context"
+	"fmt"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/cfgis/cfgms/pkg/cache"
+	pkgconfig "github.com/cfgis/cfgms/pkg/config"
+	"github.com/cfgis/cfgms/pkg/ctxkeys"
+	business "github.com/cfgis/cfgms/pkg/storage/interfaces/business"
+	cfgconfig "github.com/cfgis/cfgms/pkg/storage/interfaces/config"
+	flatfile "github.com/cfgis/cfgms/pkg/storage/providers/flatfile"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- test-double TenantStore ---
+
+// simpleTenantStore is a test-double TenantStore backed by an in-memory map.
+// Not a mock — uses real logic to walk the parent chain.
+type simpleTenantStore struct {
+	tenants map[string]*business.TenantData
+}
+
+func newSimpleTenantStore() *simpleTenantStore {
+	return &simpleTenantStore{tenants: make(map[string]*business.TenantData)}
+}
+
+func (s *simpleTenantStore) add(id, parentID string, metadata map[string]string) {
+	s.tenants[id] = &business.TenantData{
+		ID:       id,
+		Name:     id,
+		ParentID: parentID,
+		Metadata: metadata,
+		Status:   business.TenantStatusActive,
+	}
+}
+
+func (s *simpleTenantStore) Initialize(_ context.Context) error { return nil }
+func (s *simpleTenantStore) Close() error                       { return nil }
+
+func (s *simpleTenantStore) CreateTenant(_ context.Context, t *business.TenantData) error {
+	s.tenants[t.ID] = t
+	return nil
+}
+func (s *simpleTenantStore) GetTenant(_ context.Context, id string) (*business.TenantData, error) {
+	t, ok := s.tenants[id]
+	if !ok {
+		return nil, fmt.Errorf("tenant not found: %s", id)
+	}
+	return t, nil
+}
+func (s *simpleTenantStore) UpdateTenant(_ context.Context, t *business.TenantData) error {
+	s.tenants[t.ID] = t
+	return nil
+}
+func (s *simpleTenantStore) DeleteTenant(_ context.Context, id string) error {
+	delete(s.tenants, id)
+	return nil
+}
+func (s *simpleTenantStore) ListTenants(_ context.Context, _ *business.TenantFilter) ([]*business.TenantData, error) {
+	out := make([]*business.TenantData, 0, len(s.tenants))
+	for _, t := range s.tenants {
+		out = append(out, t)
+	}
+	return out, nil
+}
+func (s *simpleTenantStore) GetTenantHierarchy(_ context.Context, id string) (*business.TenantHierarchy, error) {
+	path, err := s.GetTenantPath(context.Background(), id)
+	if err != nil {
+		return nil, err
+	}
+	return &business.TenantHierarchy{TenantID: id, Path: path, Depth: len(path) - 1}, nil
+}
+func (s *simpleTenantStore) GetChildTenants(_ context.Context, parentID string) ([]*business.TenantData, error) {
+	var children []*business.TenantData
+	for _, t := range s.tenants {
+		if t.ParentID == parentID {
+			children = append(children, t)
+		}
+	}
+	return children, nil
+}
+
+// GetTenantPath returns the path from root to tenantID by walking parent links.
+func (s *simpleTenantStore) GetTenantPath(_ context.Context, tenantID string) ([]string, error) {
+	var path []string
+	cur := tenantID
+	seen := make(map[string]bool)
+	for {
+		if seen[cur] {
+			return nil, fmt.Errorf("cycle detected in tenant hierarchy for %q", tenantID)
+		}
+		seen[cur] = true
+		path = append([]string{cur}, path...)
+		t, ok := s.tenants[cur]
+		if !ok {
+			return nil, fmt.Errorf("tenant not found: %s", cur)
+		}
+		if t.ParentID == "" {
+			break
+		}
+		cur = t.ParentID
+	}
+	return path, nil
+}
+
+// IsTenantAncestor returns true if ancestorID is a (transitive) ancestor of descendantID.
+func (s *simpleTenantStore) IsTenantAncestor(_ context.Context, ancestorID, descendantID string) (bool, error) {
+	cur := descendantID
+	seen := make(map[string]bool)
+	for {
+		if seen[cur] {
+			return false, nil
+		}
+		seen[cur] = true
+		t, ok := s.tenants[cur]
+		if !ok {
+			return false, nil
+		}
+		if t.ParentID == ancestorID {
+			return true, nil
+		}
+		if t.ParentID == "" {
+			return false, nil
+		}
+		cur = t.ParentID
+	}
+}
+
+// --- test-double ConfigStore ---
+
+// recordingConfigStore is a test-double ConfigStore that counts how many times
+// it is called. Used to verify the cross-tenant check blocks store access.
+type recordingConfigStore struct {
+	callCount int64
+}
+
+func (r *recordingConfigStore) record()      { atomic.AddInt64(&r.callCount, 1) }
+func (r *recordingConfigStore) calls() int64 { return atomic.LoadInt64(&r.callCount) }
+
+func (r *recordingConfigStore) StoreConfig(_ context.Context, _ *cfgconfig.ConfigEntry) error {
+	r.record()
+	return nil
+}
+func (r *recordingConfigStore) GetConfig(_ context.Context, _ *cfgconfig.ConfigKey) (*cfgconfig.ConfigEntry, error) {
+	r.record()
+	return nil, cfgconfig.ErrConfigNotFound
+}
+func (r *recordingConfigStore) DeleteConfig(_ context.Context, _ *cfgconfig.ConfigKey) error {
+	r.record()
+	return nil
+}
+func (r *recordingConfigStore) ListConfigs(_ context.Context, _ *cfgconfig.ConfigFilter) ([]*cfgconfig.ConfigEntry, error) {
+	r.record()
+	return nil, nil
+}
+func (r *recordingConfigStore) GetConfigHistory(_ context.Context, _ *cfgconfig.ConfigKey, _ int) ([]*cfgconfig.ConfigEntry, error) {
+	r.record()
+	return nil, nil
+}
+func (r *recordingConfigStore) GetConfigVersion(_ context.Context, _ *cfgconfig.ConfigKey, _ int64) (*cfgconfig.ConfigEntry, error) {
+	r.record()
+	return nil, cfgconfig.ErrConfigNotFound
+}
+func (r *recordingConfigStore) StoreConfigBatch(_ context.Context, _ []*cfgconfig.ConfigEntry) error {
+	r.record()
+	return nil
+}
+func (r *recordingConfigStore) DeleteConfigBatch(_ context.Context, _ []*cfgconfig.ConfigKey) error {
+	r.record()
+	return nil
+}
+func (r *recordingConfigStore) ResolveConfigWithInheritance(_ context.Context, _ *cfgconfig.ConfigKey) (*cfgconfig.ConfigEntry, error) {
+	r.record()
+	return nil, cfgconfig.ErrConfigNotFound
+}
+func (r *recordingConfigStore) ValidateConfig(_ context.Context, _ *cfgconfig.ConfigEntry) error {
+	r.record()
+	return nil
+}
+func (r *recordingConfigStore) GetConfigStats(_ context.Context) (*cfgconfig.ConfigStats, error) {
+	r.record()
+	return nil, nil
+}
+
+// --- helpers ---
+
+// ctxWithTenant returns a context carrying the given tenant ID.
+func ctxWithTenant(tenantID string) context.Context {
+	return context.WithValue(context.Background(), ctxkeys.TenantID, tenantID)
+}
+
+// --- unit tests ---
+
+func TestGetEffectiveConfigSource_DefaultController(t *testing.T) {
+	ts := newSimpleTenantStore()
+	ts.add("root", "", nil)
+
+	router := NewControllerRouter(&recordingConfigStore{}, ts).(*controllerRouter)
+	info, err := router.GetEffectiveConfigSource(context.Background(), "root")
+	require.NoError(t, err)
+	assert.Equal(t, pkgconfig.ConfigSourceTypeController, info.Type)
+}
+
+func TestGetEffectiveConfigSource_InheritsParent(t *testing.T) {
+	ts := newSimpleTenantStore()
+	ts.add("root", "", map[string]string{
+		pkgconfig.MetaKeyConfigSourceType: string(pkgconfig.ConfigSourceTypeController),
+	})
+	ts.add("child", "root", nil) // child has no metadata — inherits root
+
+	router := NewControllerRouter(&recordingConfigStore{}, ts).(*controllerRouter)
+	info, err := router.GetEffectiveConfigSource(context.Background(), "child")
+	require.NoError(t, err)
+	assert.Equal(t, pkgconfig.ConfigSourceTypeController, info.Type)
+}
+
+func TestGetEffectiveConfigSource_ChildOverridesParent(t *testing.T) {
+	ts := newSimpleTenantStore()
+	ts.add("root", "", map[string]string{
+		pkgconfig.MetaKeyConfigSourceType: string(pkgconfig.ConfigSourceTypeController),
+	})
+	// child has its own metadata — should be returned first (leaf-to-root walk)
+	ts.add("child", "root", map[string]string{
+		pkgconfig.MetaKeyConfigSourceType: string(pkgconfig.ConfigSourceTypeController),
+	})
+
+	router := NewControllerRouter(&recordingConfigStore{}, ts).(*controllerRouter)
+	// The child-level entry is resolved first because we walk leaf-to-root.
+	info, err := router.GetEffectiveConfigSource(context.Background(), "child")
+	require.NoError(t, err)
+	assert.Equal(t, pkgconfig.ConfigSourceTypeController, info.Type)
+}
+
+func TestGetEffectiveConfigSource_EmptyTenantIDRoutesToController(t *testing.T) {
+	cs := &recordingConfigStore{}
+	ts := newSimpleTenantStore()
+	router := NewControllerRouter(cs, ts)
+
+	// GetConfig with empty TenantID must route to controllerStore without a cross-tenant error.
+	key := &cfgconfig.ConfigKey{TenantID: "", Namespace: "ns", Name: "cfg"}
+	_, err := router.GetConfig(context.Background(), key)
+	// ErrConfigNotFound is expected (recordingConfigStore returns it) — not a routing error.
+	assert.ErrorIs(t, err, cfgconfig.ErrConfigNotFound)
+	assert.Equal(t, int64(1), cs.calls(), "store must be called for empty TenantID")
+}
+
+func TestConfigSourceRouter_CrossTenantRejected(t *testing.T) {
+	cs := &recordingConfigStore{}
+	ts := newSimpleTenantStore()
+	ts.add("tenant-a", "", nil)
+	ts.add("tenant-b", "", nil) // no relationship with tenant-a
+
+	router := NewControllerRouter(cs, ts)
+	ctx := ctxWithTenant("tenant-a")
+
+	key := &cfgconfig.ConfigKey{TenantID: "tenant-b", Namespace: "ns", Name: "cfg"}
+	_, err := router.GetConfig(ctx, key)
+	require.Error(t, err, "cross-tenant access must be rejected")
+	assert.Contains(t, err.Error(), "cross-tenant access denied")
+	assert.Equal(t, int64(0), cs.calls(), "underlying store must never be called on cross-tenant rejection")
+}
+
+func TestConfigSourceRouter_CacheInvalidatedOnTenantUpdate(t *testing.T) {
+	ts := newSimpleTenantStore()
+	ts.add("root", "", nil)
+
+	r := NewControllerRouter(&recordingConfigStore{}, ts).(*controllerRouter)
+	ctx := context.Background()
+
+	// Prime the cache.
+	info1, err := r.GetEffectiveConfigSource(ctx, "root")
+	require.NoError(t, err)
+	assert.Equal(t, pkgconfig.ConfigSourceTypeController, info1.Type)
+	assert.Equal(t, 1, r.sourceCache.Size(), "cache should hold one entry")
+
+	// Invalidate — simulates what tenant.Manager does after UpdateTenant.
+	r.InvalidateTenantCache("root")
+	assert.Equal(t, 0, r.sourceCache.Size(), "cache entry must be evicted")
+
+	// Mutate the tenant metadata to confirm fresh resolution occurs.
+	ts.tenants["root"].Metadata = map[string]string{
+		pkgconfig.MetaKeyConfigSourceType: string(pkgconfig.ConfigSourceTypeController),
+	}
+	info2, err := r.GetEffectiveConfigSource(ctx, "root")
+	require.NoError(t, err)
+	assert.Equal(t, pkgconfig.ConfigSourceTypeController, info2.Type)
+	assert.Equal(t, 1, r.sourceCache.Size(), "cache should be repopulated after re-resolution")
+}
+
+func TestSnapshotSources_AtomicResolution(t *testing.T) {
+	ts := newSimpleTenantStore()
+	ts.add("root", "", map[string]string{
+		pkgconfig.MetaKeyConfigSourceType: string(pkgconfig.ConfigSourceTypeController),
+	})
+	ts.add("msp", "root", nil)
+	ts.add("client", "msp", nil)
+
+	router := NewControllerRouter(&recordingConfigStore{}, ts)
+	ctx := context.Background()
+
+	tenantPath := []string{"root", "msp", "client"}
+	snapshot, err := router.SnapshotSources(ctx, tenantPath)
+	require.NoError(t, err)
+	require.Len(t, snapshot, 3, "snapshot must contain an entry for every path element")
+
+	for _, tid := range tenantPath {
+		info, ok := snapshot[tid]
+		require.True(t, ok, "snapshot missing entry for %q", tid)
+		assert.Equal(t, pkgconfig.ConfigSourceTypeController, info.Type)
+	}
+}
+
+func TestSnapshotSources_DeepCopyNoSharedRefs(t *testing.T) {
+	ts := newSimpleTenantStore()
+	ts.add("root", "", nil)
+
+	router := NewControllerRouter(&recordingConfigStore{}, ts)
+	ctx := context.Background()
+
+	snapshot, err := router.SnapshotSources(ctx, []string{"root"})
+	require.NoError(t, err)
+
+	// Mutate the snapshot entry; the cache must not reflect the mutation.
+	snapshotEntry := snapshot["root"]
+	snapshotEntry.Branch = "mutated"
+
+	// Fetch again — cached value should be unchanged.
+	info, err := router.GetEffectiveConfigSource(ctx, "root")
+	require.NoError(t, err)
+	assert.NotEqual(t, "mutated", info.Branch, "cached value must not share memory with snapshot copy")
+}
+
+func TestWriteMethodsAlwaysUseControllerStore(t *testing.T) {
+	cs := &recordingConfigStore{}
+	ts := newSimpleTenantStore()
+
+	router := NewControllerRouter(cs, ts)
+	ctx := context.Background()
+
+	entry := &cfgconfig.ConfigEntry{
+		Key:  &cfgconfig.ConfigKey{TenantID: "t", Namespace: "ns", Name: "cfg"},
+		Data: []byte("data"),
+	}
+	require.NoError(t, router.StoreConfig(ctx, entry))
+	require.NoError(t, router.DeleteConfig(ctx, entry.Key))
+	require.NoError(t, router.StoreConfigBatch(ctx, []*cfgconfig.ConfigEntry{entry}))
+	require.NoError(t, router.DeleteConfigBatch(ctx, []*cfgconfig.ConfigKey{entry.Key}))
+
+	assert.Equal(t, int64(4), cs.calls(), "all four write calls must reach the controller store")
+}
+
+func TestGetEffectiveConfigSource_Cached(t *testing.T) {
+	pathCallCount := 0
+	ts := &callCountingTenantStore{
+		inner:     newSimpleTenantStore(),
+		pathCalls: &pathCallCount,
+	}
+	ts.inner.add("root", "", nil)
+
+	router := NewControllerRouter(&recordingConfigStore{}, ts).(*controllerRouter)
+	ctx := context.Background()
+
+	// First call must hit the tenant store.
+	_, err := router.GetEffectiveConfigSource(ctx, "root")
+	require.NoError(t, err)
+	assert.Equal(t, 1, pathCallCount)
+
+	// Second call must be served from cache without re-hitting the store.
+	_, err = router.GetEffectiveConfigSource(ctx, "root")
+	require.NoError(t, err)
+	assert.Equal(t, 1, pathCallCount, "cache must prevent a second GetTenantPath call")
+}
+
+// callCountingTenantStore wraps simpleTenantStore and counts GetTenantPath calls.
+type callCountingTenantStore struct {
+	inner     *simpleTenantStore
+	pathCalls *int
+}
+
+func (s *callCountingTenantStore) Initialize(_ context.Context) error { return nil }
+func (s *callCountingTenantStore) Close() error                       { return nil }
+func (s *callCountingTenantStore) CreateTenant(ctx context.Context, t *business.TenantData) error {
+	return s.inner.CreateTenant(ctx, t)
+}
+func (s *callCountingTenantStore) GetTenant(ctx context.Context, id string) (*business.TenantData, error) {
+	return s.inner.GetTenant(ctx, id)
+}
+func (s *callCountingTenantStore) UpdateTenant(ctx context.Context, t *business.TenantData) error {
+	return s.inner.UpdateTenant(ctx, t)
+}
+func (s *callCountingTenantStore) DeleteTenant(ctx context.Context, id string) error {
+	return s.inner.DeleteTenant(ctx, id)
+}
+func (s *callCountingTenantStore) ListTenants(ctx context.Context, f *business.TenantFilter) ([]*business.TenantData, error) {
+	return s.inner.ListTenants(ctx, f)
+}
+func (s *callCountingTenantStore) GetTenantHierarchy(ctx context.Context, id string) (*business.TenantHierarchy, error) {
+	return s.inner.GetTenantHierarchy(ctx, id)
+}
+func (s *callCountingTenantStore) GetChildTenants(ctx context.Context, id string) ([]*business.TenantData, error) {
+	return s.inner.GetChildTenants(ctx, id)
+}
+func (s *callCountingTenantStore) GetTenantPath(ctx context.Context, id string) ([]string, error) {
+	*s.pathCalls++
+	return s.inner.GetTenantPath(ctx, id)
+}
+func (s *callCountingTenantStore) IsTenantAncestor(ctx context.Context, a, d string) (bool, error) {
+	return s.inner.IsTenantAncestor(ctx, a, d)
+}
+
+// --- integration test: real FlatFileConfigStore + simpleTenantStore across 3-level hierarchy ---
+
+func TestIntegration_RouterWith3LevelHierarchy(t *testing.T) {
+	ts := newSimpleTenantStore()
+	ts.add("root", "", map[string]string{
+		pkgconfig.MetaKeyConfigSourceType: string(pkgconfig.ConfigSourceTypeController),
+	})
+	ts.add("msp", "root", nil)
+	ts.add("client", "msp", nil)
+
+	flatfileRoot := t.TempDir()
+	cs, err := flatfile.NewFlatFileConfigStore(flatfileRoot)
+	require.NoError(t, err)
+
+	router := NewControllerRouter(cs, ts)
+	ctx := context.Background()
+
+	// Write via the write path (always controllerStore).
+	entry := &cfgconfig.ConfigEntry{
+		Key:    &cfgconfig.ConfigKey{TenantID: "client", Namespace: "policies", Name: "baseline"},
+		Data:   []byte("steward: {}"),
+		Format: cfgconfig.ConfigFormatYAML,
+	}
+	require.NoError(t, router.StoreConfig(ctx, entry))
+
+	// Read back via the read path (routes through source resolution).
+	got, err := router.GetConfig(ctx, entry.Key)
+	require.NoError(t, err)
+	assert.Equal(t, entry.Data, got.Data)
+
+	// SnapshotSources must resolve all three levels.
+	path := []string{"root", "msp", "client"}
+	snapshot, err := router.SnapshotSources(ctx, path)
+	require.NoError(t, err)
+	for _, tid := range path {
+		info, ok := snapshot[tid]
+		require.True(t, ok, "snapshot missing entry for %q", tid)
+		assert.Equal(t, pkgconfig.ConfigSourceTypeController, info.Type, "all tenants route to controller in Phase 1")
+	}
+
+	// InvalidateTenantCache must not break subsequent reads.
+	router.InvalidateTenantCache("client")
+	info, err := router.GetEffectiveConfigSource(ctx, "client")
+	require.NoError(t, err)
+	assert.Equal(t, pkgconfig.ConfigSourceTypeController, info.Type)
+}
+
+func TestIntegration_CrossTenantRejectedRealFlatfileStore(t *testing.T) {
+	ts := newSimpleTenantStore()
+	ts.add("org-a", "", nil)
+	ts.add("org-b", "", nil) // completely separate root — no relationship
+
+	flatfileRoot := t.TempDir()
+	cs, err := flatfile.NewFlatFileConfigStore(flatfileRoot)
+	require.NoError(t, err)
+
+	router := NewControllerRouter(cs, ts)
+	ctx := ctxWithTenant("org-a")
+
+	key := &cfgconfig.ConfigKey{TenantID: "org-b", Namespace: "ns", Name: "cfg"}
+	_, err = router.GetConfig(ctx, key)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cross-tenant access denied")
+}
+
+// fakeClock is a Clock implementation for testing cache TTL without real sleep.
+type fakeClock struct{ now time.Time }
+
+func (f *fakeClock) Now() time.Time { return f.now }
+
+func TestCacheTTL_ExpiredEntryNotReturned(t *testing.T) {
+	start := time.Now()
+	clk := &fakeClock{now: start}
+	shortTTL := 50 * time.Millisecond
+
+	c := cache.NewCache(cache.CacheConfig{
+		Name:            "test-ttl",
+		MaxRuntimeItems: 100,
+		DefaultTTL:      shortTTL,
+		EvictionPolicy:  cache.EvictionLRU,
+		Clock:           clk,
+	})
+
+	// Inject a value directly with the short TTL so we don't fight the router's
+	// hard-coded sourceCacheTTL constant in GetEffectiveConfigSource.
+	require.NoError(t, c.Set("root", pkgconfig.ConfigSourceInfo{Type: pkgconfig.ConfigSourceTypeController}, shortTTL))
+	assert.Equal(t, 1, c.Size())
+
+	// Advance the fake clock past the TTL — no real sleep needed.
+	clk.now = start.Add(100 * time.Millisecond)
+	_, ok := c.Get("root")
+	assert.False(t, ok, "cache must not return an expired entry")
+}

--- a/pkg/configrouting/providers/controller/router_test.go
+++ b/pkg/configrouting/providers/controller/router_test.go
@@ -9,12 +9,15 @@ import (
 	"testing"
 	"time"
 
+	"path/filepath"
+
 	"github.com/cfgis/cfgms/pkg/cache"
 	pkgconfig "github.com/cfgis/cfgms/pkg/config"
 	"github.com/cfgis/cfgms/pkg/ctxkeys"
 	business "github.com/cfgis/cfgms/pkg/storage/interfaces/business"
 	cfgconfig "github.com/cfgis/cfgms/pkg/storage/interfaces/config"
 	flatfile "github.com/cfgis/cfgms/pkg/storage/providers/flatfile"
+	"github.com/cfgis/cfgms/pkg/storage/providers/sqlite"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -415,15 +418,34 @@ func (s *callCountingTenantStore) IsTenantAncestor(ctx context.Context, a, d str
 	return s.inner.IsTenantAncestor(ctx, a, d)
 }
 
-// --- integration test: real FlatFileConfigStore + simpleTenantStore across 3-level hierarchy ---
+// newSQLiteTSForIntegration creates a real SQLite-backed TenantStore populated with the given tenants.
+// Used by integration tests to validate the router against the production SQLite component.
+func newSQLiteTSForIntegration(t *testing.T, tenants []*business.TenantData) business.TenantStore {
+	t.Helper()
+	dir := t.TempDir()
+	p := sqlite.NewSQLiteProvider(dir)
+	store, err := p.CreateTenantStore(map[string]interface{}{"path": filepath.Join(dir, "tenants.db")})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = store.Close() })
+	for _, td := range tenants {
+		require.NoError(t, store.CreateTenant(context.Background(), td))
+	}
+	return store
+}
+
+// --- integration test: real FlatFileConfigStore + SQLite TenantStore across 3-level hierarchy ---
 
 func TestIntegration_RouterWith3LevelHierarchy(t *testing.T) {
-	ts := newSimpleTenantStore()
-	ts.add("root", "", map[string]string{
-		pkgconfig.MetaKeyConfigSourceType: string(pkgconfig.ConfigSourceTypeController),
+	ts := newSQLiteTSForIntegration(t, []*business.TenantData{
+		{
+			ID: "root", Name: "root", Status: business.TenantStatusActive,
+			Metadata: map[string]string{
+				pkgconfig.MetaKeyConfigSourceType: string(pkgconfig.ConfigSourceTypeController),
+			},
+		},
+		{ID: "msp", Name: "msp", ParentID: "root", Status: business.TenantStatusActive},
+		{ID: "client", Name: "client", ParentID: "msp", Status: business.TenantStatusActive},
 	})
-	ts.add("msp", "root", nil)
-	ts.add("client", "msp", nil)
 
 	flatfileRoot := t.TempDir()
 	cs, err := flatfile.NewFlatFileConfigStore(flatfileRoot)
@@ -463,9 +485,10 @@ func TestIntegration_RouterWith3LevelHierarchy(t *testing.T) {
 }
 
 func TestIntegration_CrossTenantRejectedRealFlatfileStore(t *testing.T) {
-	ts := newSimpleTenantStore()
-	ts.add("org-a", "", nil)
-	ts.add("org-b", "", nil) // completely separate root — no relationship
+	ts := newSQLiteTSForIntegration(t, []*business.TenantData{
+		{ID: "org-a", Name: "org-a", Status: business.TenantStatusActive},
+		{ID: "org-b", Name: "org-b", Status: business.TenantStatusActive}, // completely separate root — no relationship
+	})
 
 	flatfileRoot := t.TempDir()
 	cs, err := flatfile.NewFlatFileConfigStore(flatfileRoot)

--- a/scripts/check-providers.sh
+++ b/scripts/check-providers.sh
@@ -26,6 +26,7 @@ get_files() {
 is_allowed() {
     local file="$1"
     [[ "$file" == pkg/storage/providers/* ]] && return 0
+    [[ "$file" == pkg/configrouting/providers/* ]] && return 0
     [[ "$file" == pkg/testing/* ]] && return 0
     [[ "$file" == test/* ]] && return 0
     [[ "$file" == cmd/controller/main.go ]] && return 0
@@ -64,6 +65,7 @@ else
     echo ""
     echo "Direct pkg/storage/providers/* imports are only allowed in:"
     echo "  pkg/storage/providers/                                      (provider-internal)"
+    echo "  pkg/configrouting/providers/                                (provider-internal)"
     echo "  pkg/testing/                                                (test registration helpers)"
     echo "  test/                                                       (integration and e2e tests)"
     echo "  cmd/controller/main.go                                      (registry bootstrap)"


### PR DESCRIPTION
## Summary

- Introduces `pkg/configrouting/` as a pluggable central provider for config source routing, with a `ConfigSourceRouter` interface that embeds `ConfigStore` and adds `GetEffectiveConfigSource`, `SnapshotSources`, and `InvalidateTenantCache`
- Phase 1 `ControllerRouter` routes all tenant reads/writes to the controller's own store with a 1-min LRU cache and `snapshotMu` RWMutex for atomic cascade snapshots; cross-tenant access denied unless caller is same-tenant or key-tenant is an ancestor
- `InheritanceResolver` now calls `SnapshotSources` once before the cascade loop (atomic source resolution), eliminating the race where a mid-cascade cache flush could produce an internally inconsistent snapshot

## Test plan

- [x] `go test ./pkg/configrouting/...` — 13 contract subtests + 13 unit tests + 2 integration tests pass
- [x] `go test ./features/tenant/...` — `TestManager_UpdateTenant_InvalidatesConfigCache` verifies `InvalidateTenantCache` is called after `UpdateTenant`
- [x] `bash scripts/check-providers.sh` — no violations; `pkg/configrouting/providers/*` added to allowlist
- [x] `golangci-lint run` — 0 issues
- [x] `make test-agent-complete` — all Go tests pass; Trivy network-unavailable in sandbox (infrastructure, not code)

Fixes #1393

🤖 Generated with [Claude Code](https://claude.com/claude-code)