### PR TITLE
configrouting/git: HTTPS read-only GitConfigStore wrapping LocalRepositoryStore (Issue #1394)

### DIFF
--- a/pkg/configrouting/providers/controller/router.go
+++ b/pkg/configrouting/providers/controller/router.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2026 Jordan Ritz
-// Package controller provides the Phase 1 ConfigSourceRouter implementation that routes
-// all tenant config reads to the controller's own store.
+// Package controller provides the ConfigSourceRouter implementation that routes tenant
+// config reads to the appropriate backing store — controller store or git store.
 //
 // Phase 2 (Story C) extends storeForSource to dispatch git sources without modifying
 // this router's interface or the cache/snapshot machinery defined here.
@@ -9,6 +9,7 @@ package controller
 
 import (
 	"context"
+	"crypto/sha256"
 	"fmt"
 	"log/slog"
 	"sync"
@@ -17,15 +18,17 @@ import (
 	"github.com/cfgis/cfgms/pkg/cache"
 	pkgconfig "github.com/cfgis/cfgms/pkg/config"
 	routerinterfaces "github.com/cfgis/cfgms/pkg/configrouting/interfaces"
+	gitprovider "github.com/cfgis/cfgms/pkg/configrouting/providers/git"
 	"github.com/cfgis/cfgms/pkg/ctxkeys"
 	"github.com/cfgis/cfgms/pkg/logging"
+	secretsiface "github.com/cfgis/cfgms/pkg/secrets/interfaces"
 	business "github.com/cfgis/cfgms/pkg/storage/interfaces/business"
 	cfgconfig "github.com/cfgis/cfgms/pkg/storage/interfaces/config"
 )
 
 const sourceCacheTTL = time.Minute
 
-// controllerRouter implements ConfigSourceRouter routing all reads to controllerStore.
+// controllerRouter implements ConfigSourceRouter routing reads to the appropriate store.
 type controllerRouter struct {
 	controllerStore cfgconfig.ConfigStore
 	tenantStore     business.TenantStore
@@ -34,6 +37,13 @@ type controllerRouter struct {
 	// a snapshot never straddles a cache flush — every entry in the snapshot is
 	// resolved from the same generation of the cache.
 	snapshotMu sync.RWMutex
+
+	// git source fields (nil when not configured — controller-only mode)
+	secretStore   secretsiface.SecretStore
+	gitWorkDir    string
+	logger        logging.Logger
+	gitStoreMu    sync.Mutex
+	gitStoreCache map[string]*gitprovider.GitConfigStore // key: tenantID+":"+sha256(url)
 }
 
 // NewControllerRouter creates a ConfigSourceRouter that delegates all reads and writes
@@ -50,6 +60,33 @@ func NewControllerRouter(controllerStore cfgconfig.ConfigStore, tenantStore busi
 			CleanupInterval: 5 * time.Minute,
 			EvictionPolicy:  cache.EvictionLRU,
 		}),
+	}
+}
+
+// NewControllerRouterWithGit creates a ConfigSourceRouter that supports both controller
+// and external HTTPS git config sources. secretStore is used to fetch git credentials at
+// transport time. gitWorkDir is the base directory for cloned repositories.
+func NewControllerRouterWithGit(
+	controllerStore cfgconfig.ConfigStore,
+	tenantStore business.TenantStore,
+	secretStore secretsiface.SecretStore,
+	gitWorkDir string,
+	logger logging.Logger,
+) routerinterfaces.ConfigSourceRouter {
+	return &controllerRouter{
+		controllerStore: controllerStore,
+		tenantStore:     tenantStore,
+		sourceCache: cache.NewCache(cache.CacheConfig{
+			Name:            "configrouting-source",
+			MaxRuntimeItems: 10000,
+			DefaultTTL:      sourceCacheTTL,
+			CleanupInterval: 5 * time.Minute,
+			EvictionPolicy:  cache.EvictionLRU,
+		}),
+		secretStore:   secretStore,
+		gitWorkDir:    gitWorkDir,
+		logger:        logger,
+		gitStoreCache: make(map[string]*gitprovider.GitConfigStore),
 	}
 }
 
@@ -125,11 +162,41 @@ func (r *controllerRouter) InvalidateTenantCache(tenantID string) {
 	r.sourceCache.Delete(tenantID)
 }
 
-// storeForSource returns the ConfigStore to use for the given source.
-// Phase 1: always returns controllerStore.
-// Phase 2 (Story C): check info.Type == ConfigSourceTypeGit and return GitConfigStore.
-func (r *controllerRouter) storeForSource(_ *pkgconfig.ConfigSourceInfo) cfgconfig.ConfigStore {
-	return r.controllerStore
+// storeForSource returns the ConfigStore to use for the given tenantID and source.
+// Returns controllerStore for controller sources or when git dependencies are not wired.
+// Returns a cached GitConfigStore for git sources; constructs one on first access.
+func (r *controllerRouter) storeForSource(ctx context.Context, tenantID string, info *pkgconfig.ConfigSourceInfo) cfgconfig.ConfigStore {
+	if info.Type != pkgconfig.ConfigSourceTypeGit || r.secretStore == nil || r.gitWorkDir == "" {
+		return r.controllerStore
+	}
+
+	urlHash := fmt.Sprintf("%x", sha256.Sum256([]byte(info.URL)))
+	cacheKey := tenantID + ":" + urlHash
+
+	r.gitStoreMu.Lock()
+	defer r.gitStoreMu.Unlock()
+
+	if gs, ok := r.gitStoreCache[cacheKey]; ok {
+		return gs
+	}
+
+	logger := r.logger
+	if logger == nil {
+		logger = logging.NewNoopLogger()
+	}
+
+	gs, err := gitprovider.NewGitConfigStore(ctx, info, tenantID, r.secretStore, r.gitWorkDir, logger)
+	if err != nil {
+		slog.Warn("configrouting: failed to create git store, falling back to controller store",
+			"tenant_id", logging.SanitizeLogValue(tenantID),
+			"url", logging.SanitizeLogValue(info.URL),
+			"error_category", "initialization_failure",
+		)
+		return r.controllerStore
+	}
+
+	r.gitStoreCache[cacheKey] = gs
+	return gs
 }
 
 // checkCrossTenant returns an error if the context tenant cannot access tenantID's config.
@@ -160,8 +227,8 @@ func (r *controllerRouter) checkCrossTenant(ctx context.Context, tenantID string
 	return nil
 }
 
-// routeRead resolves the store for key.TenantID and delegates the actual call to
-// the provided fn. Empty TenantID bypasses resolution and goes to controllerStore.
+// routeRead resolves the store for tenantID and delegates the actual call to fn.
+// Empty TenantID bypasses resolution and goes to controllerStore.
 func (r *controllerRouter) routeRead(ctx context.Context, tenantID string, fn func(cfgconfig.ConfigStore) error) error {
 	if tenantID == "" {
 		return fn(r.controllerStore)
@@ -173,7 +240,7 @@ func (r *controllerRouter) routeRead(ctx context.Context, tenantID string, fn fu
 	if err != nil {
 		return err
 	}
-	return fn(r.storeForSource(info))
+	return fn(r.storeForSource(ctx, tenantID, info))
 }
 
 // --- ConfigStore read methods ---

--- a/pkg/configrouting/providers/controller/router_git_test.go
+++ b/pkg/configrouting/providers/controller/router_git_test.go
@@ -1,0 +1,260 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 CFGMS Contributors
+package controller
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	gogit "github.com/go-git/go-git/v5"
+	gitcfg "github.com/go-git/go-git/v5/config"
+	"github.com/go-git/go-git/v5/plumbing/object"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	pkgconfig "github.com/cfgis/cfgms/pkg/config"
+	"github.com/cfgis/cfgms/pkg/logging"
+	secretsiface "github.com/cfgis/cfgms/pkg/secrets/interfaces"
+	business "github.com/cfgis/cfgms/pkg/storage/interfaces/business"
+	cfgconfig "github.com/cfgis/cfgms/pkg/storage/interfaces/config"
+	flatfile "github.com/cfgis/cfgms/pkg/storage/providers/flatfile"
+)
+
+// gitRouterMemorySecretStore is a real in-memory SecretStore for git router tests.
+// Same pattern as simpleTenantStore: lightweight in-memory implementation with real CRUD.
+type gitRouterMemorySecretStore struct {
+	secrets map[string]string
+}
+
+func newGitRouterSecretStore(pairs map[string]string) *gitRouterMemorySecretStore {
+	if pairs == nil {
+		pairs = make(map[string]string)
+	}
+	return &gitRouterMemorySecretStore{secrets: pairs}
+}
+
+func (s *gitRouterMemorySecretStore) GetSecret(_ context.Context, key string) (*secretsiface.Secret, error) {
+	v, ok := s.secrets[key]
+	if !ok {
+		return nil, secretsiface.ErrSecretNotFound
+	}
+	return &secretsiface.Secret{Key: key, Value: v}, nil
+}
+
+func (s *gitRouterMemorySecretStore) StoreSecret(_ context.Context, req *secretsiface.SecretRequest) error {
+	s.secrets[req.Key] = req.Value
+	return nil
+}
+func (s *gitRouterMemorySecretStore) DeleteSecret(_ context.Context, key string) error {
+	delete(s.secrets, key)
+	return nil
+}
+func (s *gitRouterMemorySecretStore) ListSecrets(_ context.Context, _ *secretsiface.SecretFilter) ([]*secretsiface.SecretMetadata, error) {
+	return nil, nil
+}
+func (s *gitRouterMemorySecretStore) GetSecrets(_ context.Context, _ []string) (map[string]*secretsiface.Secret, error) {
+	return nil, nil
+}
+func (s *gitRouterMemorySecretStore) StoreSecrets(_ context.Context, _ map[string]*secretsiface.SecretRequest) error {
+	return nil
+}
+func (s *gitRouterMemorySecretStore) GetSecretVersion(_ context.Context, _ string, _ int) (*secretsiface.Secret, error) {
+	return nil, secretsiface.ErrSecretNotFound
+}
+func (s *gitRouterMemorySecretStore) ListSecretVersions(_ context.Context, _ string) ([]*secretsiface.SecretVersion, error) {
+	return nil, nil
+}
+func (s *gitRouterMemorySecretStore) GetSecretMetadata(_ context.Context, _ string) (*secretsiface.SecretMetadata, error) {
+	return nil, nil
+}
+func (s *gitRouterMemorySecretStore) UpdateSecretMetadata(_ context.Context, _ string, _ map[string]string) error {
+	return nil
+}
+func (s *gitRouterMemorySecretStore) RotateSecret(_ context.Context, _ string, _ string) error { return nil }
+func (s *gitRouterMemorySecretStore) ExpireSecret(_ context.Context, _ string) error           { return nil }
+func (s *gitRouterMemorySecretStore) HealthCheck(_ context.Context) error                      { return nil }
+func (s *gitRouterMemorySecretStore) Close() error                                             { return nil }
+
+// createBareRepoForRouterTest creates a bare git repo with the given files.
+func createBareRepoForRouterTest(t *testing.T, files map[string][]byte) string {
+	t.Helper()
+
+	bareDir := t.TempDir()
+	workDir := t.TempDir()
+
+	_, err := gogit.PlainInit(bareDir, true)
+	require.NoError(t, err)
+
+	work, err := gogit.PlainInit(workDir, false)
+	require.NoError(t, err)
+
+	wt, err := work.Worktree()
+	require.NoError(t, err)
+
+	for relPath, content := range files {
+		full := filepath.Join(workDir, relPath)
+		require.NoError(t, os.MkdirAll(filepath.Dir(full), 0750))
+		require.NoError(t, os.WriteFile(full, content, 0600))
+		_, err = wt.Add(relPath)
+		require.NoError(t, err)
+	}
+
+	_, err = wt.Commit("initial", &gogit.CommitOptions{
+		Author: &object.Signature{Name: "Test", Email: "test@example.com", When: time.Now()},
+	})
+	require.NoError(t, err)
+
+	_, err = work.CreateRemote(&gitcfg.RemoteConfig{Name: "origin", URLs: []string{bareDir}})
+	require.NoError(t, err)
+	require.NoError(t, work.Push(&gogit.PushOptions{RemoteName: "origin"}))
+
+	return bareDir
+}
+
+// injectGitSource bypasses ParseConfigSource URL validation by injecting the
+// ConfigSourceInfo directly into the router's source cache. This is necessary
+// for local-repo tests because ParseConfigSource enforces HTTPS URLs (correct
+// for production), but unit tests use local filesystem paths as fake remotes.
+func injectGitSource(r *controllerRouter, tenantID string, source pkgconfig.ConfigSourceInfo) {
+	_ = r.sourceCache.Set(tenantID, source, sourceCacheTTL)
+}
+
+// TestNewControllerRouterWithGit_RoutesGitTenantToGitStore verifies that storeForSource
+// dispatches a git-source tenant to GitConfigStore and reads content from the cloned repo.
+// Source info is injected directly into the cache to bypass HTTPS URL validation.
+func TestNewControllerRouterWithGit_RoutesGitTenantToGitStore(t *testing.T) {
+	const configContent = "git_routed: true\n"
+	remoteDir := createBareRepoForRouterTest(t, map[string][]byte{
+		"configs/policies/baseline.yaml": []byte(configContent),
+	})
+
+	ts := newSimpleTenantStore()
+	ts.add("git-tenant", "", nil)
+	ts.add("ctrl-tenant", "", nil)
+
+	flatfileRoot := t.TempDir()
+	controllerStore, err := flatfile.NewFlatFileConfigStore(flatfileRoot)
+	require.NoError(t, err)
+
+	gitWorkDir := t.TempDir()
+	router := NewControllerRouterWithGit(controllerStore, ts, newGitRouterSecretStore(nil), gitWorkDir, logging.NewNoopLogger()).(*controllerRouter)
+
+	// Inject git source directly (bypasses HTTPS validation — local repo only for tests).
+	injectGitSource(router, "git-tenant", pkgconfig.ConfigSourceInfo{
+		Type:    pkgconfig.ConfigSourceTypeGit,
+		URL:     remoteDir,
+		SubPath: "configs",
+	})
+
+	// Read from git-tenant — must be served from the cloned git repo.
+	gitKey := &cfgconfig.ConfigKey{TenantID: "git-tenant", Namespace: "policies", Name: "baseline"}
+	entry, readErr := router.GetConfig(context.Background(), gitKey)
+	require.NoError(t, readErr, "git-tenant read must succeed")
+	assert.Equal(t, configContent, string(entry.Data), "content must come from the git repo")
+
+	// Write to git-tenant — always routes to controller store (git sources are read-only).
+	writeEntry := &cfgconfig.ConfigEntry{
+		Key:    &cfgconfig.ConfigKey{TenantID: "git-tenant", Namespace: "policies", Name: "new"},
+		Data:   []byte("x: 1\n"),
+		Format: cfgconfig.ConfigFormatYAML,
+	}
+	require.NoError(t, router.StoreConfig(context.Background(), writeEntry),
+		"write must route to controller store regardless of source type")
+
+	// ctrl-tenant (no git source) routes to controller store.
+	_, notFoundErr := router.GetConfig(context.Background(), &cfgconfig.ConfigKey{
+		TenantID: "ctrl-tenant", Namespace: "policies", Name: "baseline",
+	})
+	assert.ErrorIs(t, notFoundErr, cfgconfig.ErrConfigNotFound,
+		"ctrl-tenant read must route to controller store which has nothing stored")
+}
+
+// TestNewControllerRouterWithGit_FallsBackOnInitFailure verifies that when GitConfigStore
+// construction fails, storeForSource falls back to the controller store.
+func TestNewControllerRouterWithGit_FallsBackOnInitFailure(t *testing.T) {
+	ts := newSimpleTenantStore()
+	ts.add("git-tenant", "", nil)
+
+	flatfileRoot := t.TempDir()
+	controllerStore, err := flatfile.NewFlatFileConfigStore(flatfileRoot)
+	require.NoError(t, err)
+
+	gitWorkDir := t.TempDir()
+	router := NewControllerRouterWithGit(controllerStore, ts, newGitRouterSecretStore(nil), gitWorkDir, logging.NewNoopLogger()).(*controllerRouter)
+
+	// Store a value in controller store for the git-tenant so we can detect fallback.
+	controllerEntry := &cfgconfig.ConfigEntry{
+		Key:    &cfgconfig.ConfigKey{TenantID: "git-tenant", Namespace: "fallback", Name: "cfg"},
+		Data:   []byte("fallback: true\n"),
+		Format: cfgconfig.ConfigFormatYAML,
+	}
+	require.NoError(t, controllerStore.StoreConfig(context.Background(), controllerEntry))
+
+	// Inject a git source pointing to a non-existent repo to trigger init failure.
+	injectGitSource(router, "git-tenant", pkgconfig.ConfigSourceInfo{
+		Type:    pkgconfig.ConfigSourceTypeGit,
+		URL:     "/nonexistent/repo/path",
+		SubPath: "configs",
+	})
+
+	// storeForSource must fall back to controller store when git init fails.
+	entry, readErr := router.GetConfig(context.Background(), controllerEntry.Key)
+	require.NoError(t, readErr, "fallback to controller store must succeed")
+	assert.Equal(t, controllerEntry.Data, entry.Data, "fallback must return controller store data")
+}
+
+// TestNewControllerRouterWithGit_GitStoreIsCached verifies that two reads for the same
+// (tenant, URL) pair reuse the same GitConfigStore instance — no double-clone.
+func TestNewControllerRouterWithGit_GitStoreIsCached(t *testing.T) {
+	remoteDir := createBareRepoForRouterTest(t, map[string][]byte{
+		"configs/ns/cfg.yaml": []byte("cached: true\n"),
+	})
+
+	ts := newSimpleTenantStore()
+	ts.add("t1", "", nil)
+
+	flatfileRoot := t.TempDir()
+	controllerStore, err := flatfile.NewFlatFileConfigStore(flatfileRoot)
+	require.NoError(t, err)
+
+	router := NewControllerRouterWithGit(controllerStore, ts, newGitRouterSecretStore(nil), t.TempDir(), logging.NewNoopLogger()).(*controllerRouter)
+
+	injectGitSource(router, "t1", pkgconfig.ConfigSourceInfo{
+		Type:    pkgconfig.ConfigSourceTypeGit,
+		URL:     remoteDir,
+		SubPath: "configs",
+	})
+
+	key := &cfgconfig.ConfigKey{TenantID: "t1", Namespace: "ns", Name: "cfg"}
+
+	// Two reads must not fail and must not double-clone.
+	_, err = router.GetConfig(context.Background(), key)
+	require.NoError(t, err)
+	_, err = router.GetConfig(context.Background(), key)
+	require.NoError(t, err)
+
+	// Cache must hold exactly one entry for t1.
+	router.gitStoreMu.Lock()
+	cacheSize := len(router.gitStoreCache)
+	router.gitStoreMu.Unlock()
+	assert.Equal(t, 1, cacheSize, "git store cache must hold exactly one entry per (tenant,url)")
+}
+
+// TestStoreForSource_ControllerTypeReturnsControllerStore verifies that storeForSource
+// returns the controller store for controller-type sources (regression test for Phase 1 behavior).
+func TestStoreForSource_ControllerTypeReturnsControllerStore(t *testing.T) {
+	cs := &recordingConfigStore{}
+	ts := newSimpleTenantStore()
+
+	router := NewControllerRouterWithGit(cs, ts, newGitRouterSecretStore(nil), t.TempDir(), logging.NewNoopLogger()).(*controllerRouter)
+	ctrlSource := &pkgconfig.ConfigSourceInfo{Type: pkgconfig.ConfigSourceTypeController}
+
+	store := router.storeForSource(context.Background(), "any-tenant", ctrlSource)
+	assert.Same(t, cs, store, "controller source must route to controllerStore")
+}
+
+// Compile-time check: business.TenantStore is satisfied by simpleTenantStore.
+var _ business.TenantStore = (*simpleTenantStore)(nil)

--- a/pkg/configrouting/providers/controller/router_git_test.go
+++ b/pkg/configrouting/providers/controller/router_git_test.go
@@ -73,10 +73,12 @@ func (s *gitRouterMemorySecretStore) GetSecretMetadata(_ context.Context, _ stri
 func (s *gitRouterMemorySecretStore) UpdateSecretMetadata(_ context.Context, _ string, _ map[string]string) error {
 	return nil
 }
-func (s *gitRouterMemorySecretStore) RotateSecret(_ context.Context, _ string, _ string) error { return nil }
-func (s *gitRouterMemorySecretStore) ExpireSecret(_ context.Context, _ string) error           { return nil }
-func (s *gitRouterMemorySecretStore) HealthCheck(_ context.Context) error                      { return nil }
-func (s *gitRouterMemorySecretStore) Close() error                                             { return nil }
+func (s *gitRouterMemorySecretStore) RotateSecret(_ context.Context, _ string, _ string) error {
+	return nil
+}
+func (s *gitRouterMemorySecretStore) ExpireSecret(_ context.Context, _ string) error { return nil }
+func (s *gitRouterMemorySecretStore) HealthCheck(_ context.Context) error            { return nil }
+func (s *gitRouterMemorySecretStore) Close() error                                   { return nil }
 
 // createBareRepoForRouterTest creates a bare git repo with the given files.
 func createBareRepoForRouterTest(t *testing.T, files map[string][]byte) string {

--- a/pkg/configrouting/providers/git/git_store.go
+++ b/pkg/configrouting/providers/git/git_store.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path"
 	"path/filepath"
 	"strings"
 	"time"
@@ -427,13 +428,16 @@ func (s *GitConfigStore) DeleteConfigBatch(_ context.Context, _ []*cfgconfig.Con
 
 // keyToRelativePath builds the relative path within the repo for a ConfigKey.
 // Result: <subPath>/<namespace>/<name>.yaml (subPath may be empty)
+// Uses path.Join (always forward slashes) so the result is valid for both git
+// tree operations (go-git always uses forward slashes) and security.ValidateAndCleanPath
+// (filepath.Clean normalises forward slashes on all platforms).
 func (s *GitConfigStore) keyToRelativePath(key *cfgconfig.ConfigKey) (string, error) {
 	parts := []string{}
 	if s.source.SubPath != "" {
 		parts = append(parts, s.source.SubPath)
 	}
 	parts = append(parts, key.Namespace, key.Name+".yaml")
-	return filepath.Join(parts...), nil
+	return path.Join(parts...), nil
 }
 
 // keyToPath builds and validates the absolute filesystem path for a ConfigKey.

--- a/pkg/configrouting/providers/git/git_store.go
+++ b/pkg/configrouting/providers/git/git_store.go
@@ -1,0 +1,496 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 CFGMS Contributors
+// Package git provides a read-only ConfigStore backed by an external HTTPS git repository.
+// Credentials are fetched from pkg/secrets at transport time and never stored in struct fields.
+package git
+
+import (
+	"context"
+	"crypto/sha256"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	gogit "github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing"
+
+	gitstorage "github.com/cfgis/cfgms/features/config/git/storage"
+	pkgconfig "github.com/cfgis/cfgms/pkg/config"
+	"github.com/cfgis/cfgms/pkg/logging"
+	secretsiface "github.com/cfgis/cfgms/pkg/secrets/interfaces"
+	"github.com/cfgis/cfgms/pkg/security"
+	cfgconfig "github.com/cfgis/cfgms/pkg/storage/interfaces/config"
+)
+
+// ErrReadOnlySource is returned by all write methods — external git repos are never written to.
+var ErrReadOnlySource = errors.New("git config store is read-only: external git sources cannot be written to")
+
+// GitConfigStore wraps LocalRepositoryStore to provide a read-only cfgconfig.ConfigStore
+// view of a single external HTTPS git repository for one mount-pointed tenant.
+//
+// Work directory layout: <workDir>/<tenantID>/<sha256(sourceURL)>/
+// The SHA256 hash of the source URL prevents path collisions for multiple repos under the same tenant.
+//
+// Credentials are fetched from secretStore at transport time (clone, pull) and are
+// never stored in any struct field.
+type GitConfigStore struct {
+	source      *pkgconfig.ConfigSourceInfo
+	tenantID    string
+	repoDir     string
+	secretStore secretsiface.SecretStore
+	logger      logging.Logger
+}
+
+// NewGitConfigStore constructs a GitConfigStore, cloning the remote repository into
+// <workDir>/<tenantID>/<sha256(sourceURL)>/ on first construction.
+//
+// workDir must already exist before this function is called.
+// tenantID is validated via security.ValidateAndCleanPath to prevent path traversal attacks.
+// Credentials are fetched at transport time; the credential value is not retained in any field.
+func NewGitConfigStore(
+	ctx context.Context,
+	source *pkgconfig.ConfigSourceInfo,
+	tenantID string,
+	secretStore secretsiface.SecretStore,
+	workDir string,
+	logger logging.Logger,
+) (*GitConfigStore, error) {
+	// Validate tenantID against workDir before constructing any paths.
+	// ValidateAndCleanPath requires workDir to exist; callers must ensure this.
+	if _, err := security.ValidateAndCleanPath(workDir, tenantID); err != nil {
+		return nil, fmt.Errorf("invalid tenantID %q: %w", tenantID, err)
+	}
+
+	urlHash := fmt.Sprintf("%x", sha256.Sum256([]byte(source.URL)))
+	repoDir := filepath.Join(workDir, tenantID, urlHash)
+
+	if err := os.MkdirAll(repoDir, 0750); err != nil {
+		return nil, fmt.Errorf("failed to create repo directory: %w", err)
+	}
+
+	s := &GitConfigStore{
+		source:      source,
+		tenantID:    tenantID,
+		repoDir:     repoDir,
+		secretStore: secretStore,
+		logger:      logger,
+	}
+
+	// Clone only if the repo hasn't been cloned yet.
+	if _, err := os.Stat(filepath.Join(repoDir, ".git")); os.IsNotExist(err) {
+		username, password, credErr := s.fetchCredential(ctx)
+		if credErr != nil {
+			return nil, fmt.Errorf("failed to fetch credential for clone: %w", credErr)
+		}
+		localStore := gitstorage.NewLocalRepositoryStore(username, password)
+		cloneErr := localStore.Clone(ctx, source.URL, repoDir)
+		if cloneErr != nil {
+			stripped := sanitizeCredential(cloneErr, password)
+			password = "" //nolint:ineffassign // zeroize before return
+			return nil, fmt.Errorf("failed to clone %s: %w", logging.SanitizeLogValue(source.URL), stripped)
+		}
+		password = "" //nolint:ineffassign // zeroize after success
+	}
+
+	return s, nil
+}
+
+// SyncWithRemote pulls latest changes from the remote. On success it returns the
+// post-pull HEAD SHA. On failure the store continues serving the previously cloned
+// state (last-known-good); the error is logged with sanitized fields and returned.
+// Error messages never contain credential material.
+func (s *GitConfigStore) SyncWithRemote(ctx context.Context) (string, error) {
+	username, password, err := s.fetchCredential(ctx)
+	if err != nil {
+		category := categorizeError(err)
+		s.logger.Warn("git-store: sync credential fetch failed",
+			"tenant_id", logging.SanitizeLogValue(s.tenantID),
+			"url", logging.SanitizeLogValue(s.source.URL),
+			"error_category", category,
+		)
+		return "", err
+	}
+
+	localStore := gitstorage.NewLocalRepositoryStore(username, password)
+	pullErr := localStore.Pull(ctx, s.repoDir)
+	if pullErr != nil {
+		stripped := sanitizeCredential(pullErr, password)
+		password = "" //nolint:ineffassign // zeroize before warn/return
+		category := categorizeError(stripped)
+		s.logger.Warn("git-store: sync pull failed",
+			"tenant_id", logging.SanitizeLogValue(s.tenantID),
+			"url", logging.SanitizeLogValue(s.source.URL),
+			"error_category", category,
+		)
+		return "", stripped
+	}
+	password = "" //nolint:ineffassign // zeroize after success
+
+	repo, openErr := gogit.PlainOpen(s.repoDir)
+	if openErr != nil {
+		return "", fmt.Errorf("sync: failed to open repo after pull: %w", openErr)
+	}
+	head, headErr := repo.Head()
+	if headErr != nil {
+		return "", fmt.Errorf("sync: failed to get HEAD after pull: %w", headErr)
+	}
+	return head.Hash().String(), nil
+}
+
+// --- cfgconfig.ConfigStore read methods ---
+
+// GetConfig reads the config file at <repoDir>/<subPath>/<namespace>/<name>.yaml.
+func (s *GitConfigStore) GetConfig(_ context.Context, key *cfgconfig.ConfigKey) (*cfgconfig.ConfigEntry, error) {
+	fullPath, err := s.keyToPath(key)
+	if err != nil {
+		return nil, err
+	}
+
+	data, err := os.ReadFile(fullPath) // #nosec G304 — path validated by ValidateAndCleanPath
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, cfgconfig.ErrConfigNotFound
+		}
+		return nil, fmt.Errorf("failed to read config: %w", err)
+	}
+
+	info, _ := os.Stat(fullPath)
+	entry := &cfgconfig.ConfigEntry{
+		Key:    key,
+		Data:   data,
+		Format: cfgconfig.ConfigFormatYAML,
+	}
+	if info != nil {
+		entry.UpdatedAt = info.ModTime()
+		entry.CreatedAt = info.ModTime()
+	}
+	return entry, nil
+}
+
+// ListConfigs enumerates config files under <repoDir>/<subPath>/<filter.Namespace>/.
+func (s *GitConfigStore) ListConfigs(_ context.Context, filter *cfgconfig.ConfigFilter) ([]*cfgconfig.ConfigEntry, error) {
+	base := s.repoDir
+	if s.source.SubPath != "" {
+		var err error
+		base, err = security.ValidateAndCleanPath(s.repoDir, s.source.SubPath)
+		if err != nil {
+			return nil, fmt.Errorf("invalid subPath: %w", err)
+		}
+	}
+
+	namespace := ""
+	if filter != nil {
+		namespace = filter.Namespace
+	}
+
+	searchDir := base
+	if namespace != "" {
+		var err error
+		searchDir, err = security.ValidateAndCleanPath(base, namespace)
+		if err != nil {
+			return nil, fmt.Errorf("invalid namespace: %w", err)
+		}
+	}
+
+	var entries []*cfgconfig.ConfigEntry
+	err := filepath.Walk(searchDir, func(path string, info os.FileInfo, walkErr error) error {
+		if walkErr != nil || info.IsDir() {
+			return walkErr
+		}
+		if !strings.HasSuffix(path, ".yaml") {
+			return nil
+		}
+
+		data, readErr := os.ReadFile(path) // #nosec G304 — Walk restricts to searchDir subtree
+		if readErr != nil {
+			return nil // skip unreadable files
+		}
+
+		rel, relErr := filepath.Rel(base, path)
+		if relErr != nil {
+			return nil
+		}
+		parts := strings.Split(rel, string(filepath.Separator))
+		if len(parts) < 2 {
+			return nil
+		}
+		ns := parts[0]
+		name := strings.TrimSuffix(parts[len(parts)-1], ".yaml")
+
+		tenantID := ""
+		if filter != nil {
+			tenantID = filter.TenantID
+		}
+		entries = append(entries, &cfgconfig.ConfigEntry{
+			Key: &cfgconfig.ConfigKey{
+				TenantID:  tenantID,
+				Namespace: ns,
+				Name:      name,
+			},
+			Data:      data,
+			Format:    cfgconfig.ConfigFormatYAML,
+			UpdatedAt: info.ModTime(),
+			CreatedAt: info.ModTime(),
+		})
+		return nil
+	})
+	if err != nil && !os.IsNotExist(err) {
+		return nil, fmt.Errorf("failed to list configs: %w", err)
+	}
+	return entries, nil
+}
+
+// GetConfigHistory returns commit history for the config file.
+func (s *GitConfigStore) GetConfigHistory(ctx context.Context, key *cfgconfig.ConfigKey, limit int) ([]*cfgconfig.ConfigEntry, error) {
+	relPath, err := s.keyToRelativePath(key)
+	if err != nil {
+		return nil, err
+	}
+
+	localStore := gitstorage.NewLocalRepositoryStore("", "")
+	commits, err := localStore.GetHistory(ctx, s.repoDir, relPath, limit)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get config history: %w", err)
+	}
+
+	entries := make([]*cfgconfig.ConfigEntry, 0, len(commits))
+	for i, c := range commits {
+		entries = append(entries, &cfgconfig.ConfigEntry{
+			Key:       key,
+			Data:      []byte(c.SHA),
+			Format:    cfgconfig.ConfigFormatYAML,
+			Version:   int64(i + 1),
+			UpdatedAt: c.Timestamp,
+			CreatedAt: c.Timestamp,
+			UpdatedBy: c.Author.Name,
+			CreatedBy: c.Author.Name,
+		})
+	}
+	return entries, nil
+}
+
+// GetConfigVersion returns the config file content at a specific commit in history.
+// version is 1-indexed (1 = most recent, 2 = one before that, etc.).
+func (s *GitConfigStore) GetConfigVersion(ctx context.Context, key *cfgconfig.ConfigKey, version int64) (*cfgconfig.ConfigEntry, error) {
+	if version < 1 {
+		return nil, fmt.Errorf("version must be >= 1, got %d", version)
+	}
+
+	relPath, err := s.keyToRelativePath(key)
+	if err != nil {
+		return nil, err
+	}
+
+	localStore := gitstorage.NewLocalRepositoryStore("", "")
+	commits, err := localStore.GetHistory(ctx, s.repoDir, relPath, int(version))
+	if err != nil {
+		return nil, fmt.Errorf("failed to get history for version: %w", err)
+	}
+	if int(version) > len(commits) {
+		return nil, cfgconfig.ErrConfigNotFound
+	}
+
+	targetCommit := commits[version-1]
+	repo, err := gogit.PlainOpen(s.repoDir)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open repo: %w", err)
+	}
+	commitObj, err := repo.CommitObject(plumbing.NewHash(targetCommit.SHA))
+	if err != nil {
+		return nil, fmt.Errorf("failed to get commit object: %w", err)
+	}
+	file, err := commitObj.File(relPath)
+	if err != nil {
+		return nil, fmt.Errorf("file not found at version %d: %w", version, err)
+	}
+	content, err := file.Contents()
+	if err != nil {
+		return nil, fmt.Errorf("failed to read file contents at version %d: %w", version, err)
+	}
+
+	return &cfgconfig.ConfigEntry{
+		Key:       key,
+		Data:      []byte(content),
+		Format:    cfgconfig.ConfigFormatYAML,
+		Version:   version,
+		UpdatedAt: targetCommit.Timestamp,
+		CreatedAt: targetCommit.Timestamp,
+		UpdatedBy: targetCommit.Author.Name,
+		CreatedBy: targetCommit.Author.Name,
+	}, nil
+}
+
+// ResolveConfigWithInheritance delegates to GetConfig — inheritance resolution for
+// external git sources is handled by the router layer, not the store.
+func (s *GitConfigStore) ResolveConfigWithInheritance(ctx context.Context, key *cfgconfig.ConfigKey) (*cfgconfig.ConfigEntry, error) {
+	return s.GetConfig(ctx, key)
+}
+
+// ValidateConfig checks that the entry has a valid YAML format.
+func (s *GitConfigStore) ValidateConfig(_ context.Context, config *cfgconfig.ConfigEntry) error {
+	if config == nil {
+		return fmt.Errorf("config entry is nil")
+	}
+	if config.Format != cfgconfig.ConfigFormatYAML {
+		return cfgconfig.ErrInvalidFormat
+	}
+	return nil
+}
+
+// GetConfigStats computes basic stats by walking the repo directory.
+func (s *GitConfigStore) GetConfigStats(_ context.Context) (*cfgconfig.ConfigStats, error) {
+	stats := &cfgconfig.ConfigStats{
+		ConfigsByTenant:    make(map[string]int64),
+		ConfigsByFormat:    make(map[string]int64),
+		ConfigsByNamespace: make(map[string]int64),
+		LastUpdated:        time.Now(),
+	}
+
+	base := s.repoDir
+	if s.source.SubPath != "" {
+		var err error
+		base, err = security.ValidateAndCleanPath(s.repoDir, s.source.SubPath)
+		if err != nil {
+			return nil, fmt.Errorf("invalid subPath for stats: %w", err)
+		}
+	}
+
+	walkErr := filepath.Walk(base, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info.IsDir() {
+			if info.Name() == ".git" {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(path, ".yaml") {
+			return nil
+		}
+		stats.TotalConfigs++
+		stats.TotalSize += info.Size()
+		stats.ConfigsByFormat[string(cfgconfig.ConfigFormatYAML)]++
+		stats.ConfigsByTenant[s.tenantID]++
+
+		rel, relErr := filepath.Rel(base, path)
+		if relErr == nil {
+			parts := strings.Split(rel, string(filepath.Separator))
+			if len(parts) >= 1 {
+				stats.ConfigsByNamespace[parts[0]]++
+			}
+		}
+
+		modTime := info.ModTime()
+		if stats.OldestConfig == nil || modTime.Before(*stats.OldestConfig) {
+			t := modTime
+			stats.OldestConfig = &t
+		}
+		if stats.NewestConfig == nil || modTime.After(*stats.NewestConfig) {
+			t := modTime
+			stats.NewestConfig = &t
+		}
+		return nil
+	})
+	if walkErr != nil && !os.IsNotExist(walkErr) {
+		return nil, fmt.Errorf("failed to walk config directory: %w", walkErr)
+	}
+
+	if stats.TotalConfigs > 0 {
+		stats.AverageSize = stats.TotalSize / stats.TotalConfigs
+	}
+	return stats, nil
+}
+
+// --- cfgconfig.ConfigStore write methods — always return ErrReadOnlySource ---
+
+func (s *GitConfigStore) StoreConfig(_ context.Context, _ *cfgconfig.ConfigEntry) error {
+	return ErrReadOnlySource
+}
+
+func (s *GitConfigStore) DeleteConfig(_ context.Context, _ *cfgconfig.ConfigKey) error {
+	return ErrReadOnlySource
+}
+
+func (s *GitConfigStore) StoreConfigBatch(_ context.Context, _ []*cfgconfig.ConfigEntry) error {
+	return ErrReadOnlySource
+}
+
+func (s *GitConfigStore) DeleteConfigBatch(_ context.Context, _ []*cfgconfig.ConfigKey) error {
+	return ErrReadOnlySource
+}
+
+// --- path helpers ---
+
+// keyToRelativePath builds the relative path within the repo for a ConfigKey.
+// Result: <subPath>/<namespace>/<name>.yaml (subPath may be empty)
+func (s *GitConfigStore) keyToRelativePath(key *cfgconfig.ConfigKey) (string, error) {
+	parts := []string{}
+	if s.source.SubPath != "" {
+		parts = append(parts, s.source.SubPath)
+	}
+	parts = append(parts, key.Namespace, key.Name+".yaml")
+	return filepath.Join(parts...), nil
+}
+
+// keyToPath builds and validates the absolute filesystem path for a ConfigKey.
+// Uses security.ValidateAndCleanPath to reject traversal attempts.
+func (s *GitConfigStore) keyToPath(key *cfgconfig.ConfigKey) (string, error) {
+	relPath, err := s.keyToRelativePath(key)
+	if err != nil {
+		return "", err
+	}
+	fullPath, err := security.ValidateAndCleanPath(s.repoDir, relPath)
+	if err != nil {
+		return "", fmt.Errorf("invalid config key path: %w", err)
+	}
+	return fullPath, nil
+}
+
+// --- credential and error helpers ---
+
+// fetchCredential retrieves the HTTPS credential from secretStore at transport time.
+// Returns empty strings when no CredentialRef is set. The credential value is never
+// stored in any GitConfigStore field.
+func (s *GitConfigStore) fetchCredential(ctx context.Context) (username, password string, err error) {
+	if s.source.CredentialRef == "" {
+		return "", "", nil
+	}
+	secret, err := s.secretStore.GetSecret(ctx, s.source.CredentialRef)
+	if err != nil {
+		return "", "", fmt.Errorf("failed to get credential %q: %w", s.source.CredentialRef, err)
+	}
+	return "x-access-token", secret.Value, nil
+}
+
+// sanitizeCredential removes occurrences of the credential value from an error's message.
+// This prevents go-git transport errors from leaking credential material.
+func sanitizeCredential(err error, credential string) error {
+	if err == nil || credential == "" {
+		return err
+	}
+	sanitized := strings.ReplaceAll(err.Error(), credential, "[REDACTED]")
+	return errors.New(sanitized)
+}
+
+// categorizeError returns a coarse error category string suitable for structured logging.
+// Raw error text is never included — only a category label to avoid leaking internals.
+func categorizeError(err error) string {
+	if err == nil {
+		return "none"
+	}
+	msg := strings.ToLower(err.Error())
+	switch {
+	case strings.Contains(msg, "auth") || strings.Contains(msg, "credential") || strings.Contains(msg, "unauthorized"):
+		return "authentication_failure"
+	case strings.Contains(msg, "network") || strings.Contains(msg, "connect") || strings.Contains(msg, "dial") || strings.Contains(msg, "timeout"):
+		return "network_failure"
+	case strings.Contains(msg, "not found") || strings.Contains(msg, "no such"):
+		return "not_found"
+	default:
+		return "unknown"
+	}
+}

--- a/pkg/configrouting/providers/git/git_store_test.go
+++ b/pkg/configrouting/providers/git/git_store_test.go
@@ -1,0 +1,671 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 CFGMS Contributors
+package git
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+	"time"
+
+	gogit "github.com/go-git/go-git/v5"
+	gitconfig "github.com/go-git/go-git/v5/config"
+	"github.com/go-git/go-git/v5/plumbing/object"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	pkgconfig "github.com/cfgis/cfgms/pkg/config"
+	"github.com/cfgis/cfgms/pkg/logging"
+	secretsiface "github.com/cfgis/cfgms/pkg/secrets/interfaces"
+	cfgconfig "github.com/cfgis/cfgms/pkg/storage/interfaces/config"
+)
+
+// --- test helpers ---
+
+// memorySecretStore is a real in-memory implementation of secretsiface.SecretStore for tests.
+// There is no test implementation in pkg/secrets/providers (providers require OpenBao or OS keychain),
+// so this follows the same pattern as simpleTenantStore in pkg/configrouting/providers/controller/router_test.go:
+// a lightweight in-memory struct with real CRUD semantics for use in unit tests.
+type memorySecretStore struct {
+	secrets map[string]*secretsiface.Secret
+}
+
+func newMemorySecretStore(pairs map[string]string) *memorySecretStore {
+	s := &memorySecretStore{secrets: make(map[string]*secretsiface.Secret)}
+	for k, v := range pairs {
+		s.secrets[k] = &secretsiface.Secret{Key: k, Value: v}
+	}
+	return s
+}
+
+func (s *memorySecretStore) GetSecret(_ context.Context, key string) (*secretsiface.Secret, error) {
+	v, ok := s.secrets[key]
+	if !ok {
+		return nil, secretsiface.ErrSecretNotFound
+	}
+	return v, nil
+}
+
+func (s *memorySecretStore) StoreSecret(_ context.Context, req *secretsiface.SecretRequest) error {
+	s.secrets[req.Key] = &secretsiface.Secret{Key: req.Key, Value: req.Value}
+	return nil
+}
+
+func (s *memorySecretStore) DeleteSecret(_ context.Context, key string) error {
+	if _, ok := s.secrets[key]; !ok {
+		return secretsiface.ErrSecretNotFound
+	}
+	delete(s.secrets, key)
+	return nil
+}
+
+func (s *memorySecretStore) ListSecrets(_ context.Context, _ *secretsiface.SecretFilter) ([]*secretsiface.SecretMetadata, error) {
+	out := make([]*secretsiface.SecretMetadata, 0, len(s.secrets))
+	for _, sec := range s.secrets {
+		out = append(out, &secretsiface.SecretMetadata{Key: sec.Key})
+	}
+	return out, nil
+}
+
+func (s *memorySecretStore) GetSecrets(_ context.Context, keys []string) (map[string]*secretsiface.Secret, error) {
+	out := make(map[string]*secretsiface.Secret, len(keys))
+	for _, k := range keys {
+		if v, ok := s.secrets[k]; ok {
+			out[k] = v
+		}
+	}
+	return out, nil
+}
+
+func (s *memorySecretStore) StoreSecrets(_ context.Context, secrets map[string]*secretsiface.SecretRequest) error {
+	for k, req := range secrets {
+		s.secrets[k] = &secretsiface.Secret{Key: k, Value: req.Value}
+	}
+	return nil
+}
+
+func (s *memorySecretStore) GetSecretVersion(_ context.Context, _ string, _ int) (*secretsiface.Secret, error) {
+	return nil, secretsiface.ErrSecretNotFound
+}
+func (s *memorySecretStore) ListSecretVersions(_ context.Context, _ string) ([]*secretsiface.SecretVersion, error) {
+	return nil, nil // versioning not supported by this in-memory store
+}
+func (s *memorySecretStore) GetSecretMetadata(_ context.Context, key string) (*secretsiface.SecretMetadata, error) {
+	if v, ok := s.secrets[key]; ok {
+		return &secretsiface.SecretMetadata{Key: v.Key}, nil
+	}
+	return nil, secretsiface.ErrSecretNotFound
+}
+func (s *memorySecretStore) UpdateSecretMetadata(_ context.Context, _ string, _ map[string]string) error {
+	return nil
+}
+func (s *memorySecretStore) RotateSecret(_ context.Context, key string, newValue string) error {
+	if v, ok := s.secrets[key]; ok {
+		v.Value = newValue
+		return nil
+	}
+	return secretsiface.ErrSecretNotFound
+}
+func (s *memorySecretStore) ExpireSecret(_ context.Context, key string) error {
+	delete(s.secrets, key)
+	return nil
+}
+func (s *memorySecretStore) HealthCheck(_ context.Context) error { return nil }
+func (s *memorySecretStore) Close() error                        { return nil }
+
+// createBareRemote sets up a local bare repo with an initial commit containing the
+// provided files. Returns the path to the bare repo (used as the clone URL).
+// All paths are relative to the repo root.
+func createBareRemote(t *testing.T, files map[string][]byte) string {
+	t.Helper()
+
+	bareDir := t.TempDir()
+	workDir := t.TempDir()
+
+	// Init bare repo
+	_, err := gogit.PlainInit(bareDir, true)
+	require.NoError(t, err, "init bare repo")
+
+	// Init working copy
+	work, err := gogit.PlainInit(workDir, false)
+	require.NoError(t, err, "init working copy")
+
+	wt, err := work.Worktree()
+	require.NoError(t, err)
+
+	// Write files into working copy
+	for relPath, content := range files {
+		full := filepath.Join(workDir, relPath)
+		require.NoError(t, os.MkdirAll(filepath.Dir(full), 0750))
+		require.NoError(t, os.WriteFile(full, content, 0600))
+		_, err = wt.Add(relPath)
+		require.NoError(t, err, "git add %s", relPath)
+	}
+
+	// Commit
+	_, err = wt.Commit("initial commit", &gogit.CommitOptions{
+		Author: &object.Signature{
+			Name:  "Test Author",
+			Email: "test@example.com",
+			When:  time.Now(),
+		},
+	})
+	require.NoError(t, err, "initial commit")
+
+	// Add remote and push to bare
+	_, err = work.CreateRemote(&gitconfig.RemoteConfig{
+		Name: "origin",
+		URLs: []string{bareDir},
+	})
+	require.NoError(t, err)
+
+	err = work.Push(&gogit.PushOptions{RemoteName: "origin"})
+	require.NoError(t, err, "push to bare remote")
+
+	return bareDir
+}
+
+// addCommitToRemote adds a new file commit to the bare remote, simulating a remote update.
+func addCommitToRemote(t *testing.T, bareDir string, filePath string, content []byte) {
+	t.Helper()
+
+	workDir := t.TempDir()
+
+	work, err := gogit.PlainClone(workDir, false, &gogit.CloneOptions{URL: bareDir})
+	require.NoError(t, err, "clone remote for update")
+
+	wt, err := work.Worktree()
+	require.NoError(t, err)
+
+	full := filepath.Join(workDir, filePath)
+	require.NoError(t, os.MkdirAll(filepath.Dir(full), 0750))
+	require.NoError(t, os.WriteFile(full, content, 0600))
+	_, err = wt.Add(filePath)
+	require.NoError(t, err)
+
+	_, err = wt.Commit("update "+filePath, &gogit.CommitOptions{
+		Author: &object.Signature{Name: "Updater", Email: "up@example.com", When: time.Now()},
+	})
+	require.NoError(t, err)
+
+	err = work.Push(&gogit.PushOptions{})
+	require.NoError(t, err, "push update to bare remote")
+}
+
+func makeSource(remoteURL, subPath string) *pkgconfig.ConfigSourceInfo {
+	return &pkgconfig.ConfigSourceInfo{
+		Type:    pkgconfig.ConfigSourceTypeGit,
+		URL:     remoteURL,
+		SubPath: subPath,
+	}
+}
+
+// --- tests ---
+
+// TestGitConfigStore_Clone verifies that NewGitConfigStore clones the remote so that
+// a .git directory is present in the work directory after construction.
+func TestGitConfigStore_Clone(t *testing.T) {
+	remoteDir := createBareRemote(t, map[string][]byte{
+		"configs/default/myapp.yaml": []byte("key: value\n"),
+	})
+
+	workDir := t.TempDir()
+	source := makeSource(remoteDir, "configs")
+	ss := newMemorySecretStore(nil)
+
+	store, err := NewGitConfigStore(context.Background(), source, "tenant1", ss, workDir, logging.NewNoopLogger())
+	require.NoError(t, err)
+	require.NotNil(t, store)
+
+	// .git directory must exist in the cloned repo
+	gitDir := filepath.Join(store.repoDir, ".git")
+	info, statErr := os.Stat(gitDir)
+	require.NoError(t, statErr, ".git must exist after clone")
+	assert.True(t, info.IsDir())
+}
+
+// TestGitConfigStore_GetConfig reads a config file that was present in the cloned repo.
+func TestGitConfigStore_GetConfig(t *testing.T) {
+	const configContent = "name: test\nvalue: 42\n"
+	remoteDir := createBareRemote(t, map[string][]byte{
+		"configs/networking/firewall.yaml": []byte(configContent),
+	})
+
+	workDir := t.TempDir()
+	source := makeSource(remoteDir, "configs")
+	ss := newMemorySecretStore(nil)
+
+	store, err := NewGitConfigStore(context.Background(), source, "tenant1", ss, workDir, logging.NewNoopLogger())
+	require.NoError(t, err)
+
+	entry, err := store.GetConfig(context.Background(), &cfgconfig.ConfigKey{
+		TenantID:  "tenant1",
+		Namespace: "networking",
+		Name:      "firewall",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, configContent, string(entry.Data))
+	assert.Equal(t, cfgconfig.ConfigFormatYAML, entry.Format)
+}
+
+// TestGitConfigStore_WriteReturnsReadOnlyError asserts that all mutating methods
+// return ErrReadOnlySource and never attempt to modify the repository.
+func TestGitConfigStore_WriteReturnsReadOnlyError(t *testing.T) {
+	remoteDir := createBareRemote(t, map[string][]byte{
+		"configs/default/init.yaml": []byte("init: true\n"),
+	})
+
+	workDir := t.TempDir()
+	ss := newMemorySecretStore(nil)
+	store, err := NewGitConfigStore(context.Background(), makeSource(remoteDir, "configs"), "tenant1", ss, workDir, logging.NewNoopLogger())
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	key := &cfgconfig.ConfigKey{TenantID: "tenant1", Namespace: "default", Name: "new"}
+	entry := &cfgconfig.ConfigEntry{Key: key, Data: []byte("x: 1\n"), Format: cfgconfig.ConfigFormatYAML}
+
+	assert.ErrorIs(t, store.StoreConfig(ctx, entry), ErrReadOnlySource, "StoreConfig")
+	assert.ErrorIs(t, store.DeleteConfig(ctx, key), ErrReadOnlySource, "DeleteConfig")
+	assert.ErrorIs(t, store.StoreConfigBatch(ctx, []*cfgconfig.ConfigEntry{entry}), ErrReadOnlySource, "StoreConfigBatch")
+	assert.ErrorIs(t, store.DeleteConfigBatch(ctx, []*cfgconfig.ConfigKey{key}), ErrReadOnlySource, "DeleteConfigBatch")
+}
+
+// TestGitConfigStore_SyncWithRemote verifies that SyncWithRemote pulls new commits and
+// returns the updated HEAD SHA.
+func TestGitConfigStore_SyncWithRemote(t *testing.T) {
+	remoteDir := createBareRemote(t, map[string][]byte{
+		"configs/default/app.yaml": []byte("version: 1\n"),
+	})
+
+	workDir := t.TempDir()
+	ss := newMemorySecretStore(nil)
+	store, err := NewGitConfigStore(context.Background(), makeSource(remoteDir, "configs"), "tenant1", ss, workDir, logging.NewNoopLogger())
+	require.NoError(t, err)
+
+	// Get initial HEAD
+	sha1, err := store.SyncWithRemote(context.Background())
+	require.NoError(t, err)
+	assert.Len(t, sha1, 40, "SHA must be 40 hex characters")
+
+	// Push a new commit to the remote
+	addCommitToRemote(t, remoteDir, "configs/default/app.yaml", []byte("version: 2\n"))
+
+	// Sync again — SHA must change
+	sha2, err := store.SyncWithRemote(context.Background())
+	require.NoError(t, err)
+	assert.Len(t, sha2, 40)
+	assert.NotEqual(t, sha1, sha2, "SHA must advance after remote update")
+
+	// Verify new content is visible via GetConfig
+	entry, err := store.GetConfig(context.Background(), &cfgconfig.ConfigKey{
+		TenantID:  "tenant1",
+		Namespace: "default",
+		Name:      "app",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "version: 2\n", string(entry.Data))
+}
+
+// TestGitConfigStore_PullFailureServesLastGood verifies that a pull error does not
+// evict the last-known-good state — the store must continue serving previously cloned data.
+// The remote origin URL is changed in .git/config to a non-existent path to force failure.
+func TestGitConfigStore_PullFailureServesLastGood(t *testing.T) {
+	const initialContent = "stable: true\n"
+	remoteDir := createBareRemote(t, map[string][]byte{
+		"configs/prod/config.yaml": []byte(initialContent),
+	})
+
+	workDir := t.TempDir()
+	ss := newMemorySecretStore(nil)
+	store, err := NewGitConfigStore(context.Background(), makeSource(remoteDir, "configs"), "tenant1", ss, workDir, logging.NewNoopLogger())
+	require.NoError(t, err)
+
+	// Corrupt the origin URL inside .git/config to force a pull failure.
+	// This simulates the remote becoming unreachable after the initial clone.
+	repo, openErr := gogit.PlainOpen(store.repoDir)
+	require.NoError(t, openErr)
+	cfg, cfgErr := repo.Config()
+	require.NoError(t, cfgErr)
+	cfg.Remotes["origin"].URLs = []string{"/nonexistent/broken/remote"}
+	require.NoError(t, repo.SetConfig(cfg))
+
+	_, pullErr := store.SyncWithRemote(context.Background())
+	assert.Error(t, pullErr, "pull to broken remote must fail")
+
+	// The previously cloned data must still be readable (last-known-good preserved)
+	entry, getErr := store.GetConfig(context.Background(), &cfgconfig.ConfigKey{
+		TenantID:  "tenant1",
+		Namespace: "prod",
+		Name:      "config",
+	})
+	require.NoError(t, getErr, "last-known-good state must remain readable after pull failure")
+	assert.Equal(t, initialContent, string(entry.Data))
+}
+
+// TestGitConfigStore_NoCredentialLeakedInError asserts that the credential value does
+// not appear in any error returned by SyncWithRemote. The origin URL in .git/config is
+// corrupted to a non-existent path to force a pull failure; the sanitizeCredential
+// function must strip the token from any resulting error message.
+func TestGitConfigStore_NoCredentialLeakedInError(t *testing.T) {
+	const secretToken = "super-secret-token-12345"
+
+	remoteDir := createBareRemote(t, map[string][]byte{
+		"configs/default/app.yaml": []byte("ok: true\n"),
+	})
+
+	workDir := t.TempDir()
+	source := &pkgconfig.ConfigSourceInfo{
+		Type:          pkgconfig.ConfigSourceTypeGit,
+		URL:           remoteDir,
+		SubPath:       "configs",
+		CredentialRef: "my-git-token",
+	}
+	ss := newMemorySecretStore(map[string]string{"my-git-token": secretToken})
+
+	store, err := NewGitConfigStore(context.Background(), source, "tenant1", ss, workDir, logging.NewNoopLogger())
+	require.NoError(t, err)
+
+	// Corrupt the origin URL in .git/config to a non-existent path.
+	// The pull will fail; our sanitizeCredential must ensure the error message
+	// does not contain the credential value even if go-git embeds it.
+	repo, openErr := gogit.PlainOpen(store.repoDir)
+	require.NoError(t, openErr)
+	gitCfg, cfgErr := repo.Config()
+	require.NoError(t, cfgErr)
+	gitCfg.Remotes["origin"].URLs = []string{"/nonexistent/broken/" + secretToken + "/path"}
+	require.NoError(t, repo.SetConfig(gitCfg))
+
+	_, pullErr := store.SyncWithRemote(context.Background())
+	require.Error(t, pullErr, "SyncWithRemote to a broken origin must return an error")
+	assert.NotContains(t, pullErr.Error(), secretToken,
+		"error message must not contain the credential value")
+}
+
+// TestGitConfigStore_AdversarialTenantID verifies that the constructor rejects tenantID
+// values that attempt directory traversal (e.g. "../../escape").
+func TestGitConfigStore_AdversarialTenantID(t *testing.T) {
+	workDir := t.TempDir()
+	source := makeSource("https://example.invalid/repo.git", "")
+	ss := newMemorySecretStore(nil)
+
+	adversarialInputs := []string{
+		"../../escape",
+		"../sibling",
+		"/absolute/path",
+		"tenant\x00null",
+	}
+
+	for _, badID := range adversarialInputs {
+		_, err := NewGitConfigStore(context.Background(), source, badID, ss, workDir, logging.NewNoopLogger())
+		assert.Error(t, err, "tenantID %q must be rejected", badID)
+	}
+}
+
+// TestGitConfigStore_StructFieldsNoCredential asserts that after construction no
+// exported or unexported struct field of GitConfigStore contains the credential value.
+// This is a structural invariant: credentials are fetched at transport time only.
+func TestGitConfigStore_StructFieldsNoCredential(t *testing.T) {
+	const secretToken = "very-secret-credential-xyz987"
+
+	remoteDir := createBareRemote(t, map[string][]byte{
+		"configs/default/app.yaml": []byte("ok: true\n"),
+	})
+
+	workDir := t.TempDir()
+	source := &pkgconfig.ConfigSourceInfo{
+		Type:          pkgconfig.ConfigSourceTypeGit,
+		URL:           remoteDir,
+		SubPath:       "configs",
+		CredentialRef: "my-cred",
+	}
+	ss := newMemorySecretStore(map[string]string{"my-cred": secretToken})
+
+	store, err := NewGitConfigStore(context.Background(), source, "tenant1", ss, workDir, logging.NewNoopLogger())
+	require.NoError(t, err)
+
+	assertNoCredentialInStruct(t, store, secretToken, "GitConfigStore")
+}
+
+// assertNoCredentialInStruct uses reflection to walk all fields (including nested structs)
+// and fails the test if the credential value is found in any string field.
+func assertNoCredentialInStruct(t *testing.T, v interface{}, credential, path string) {
+	t.Helper()
+	if credential == "" {
+		return
+	}
+	val := reflect.ValueOf(v)
+	if val.Kind() == reflect.Ptr {
+		if val.IsNil() {
+			return
+		}
+		val = val.Elem()
+	}
+	switch val.Kind() {
+	case reflect.Struct:
+		typ := val.Type()
+		for i := 0; i < val.NumField(); i++ {
+			field := val.Field(i)
+			fieldName := fmt.Sprintf("%s.%s", path, typ.Field(i).Name)
+			// Skip unexported fields that contain interfaces (secretStore, logger) —
+			// those are inspected by type, not value, to avoid reflect panics.
+			if !field.CanInterface() {
+				continue
+			}
+			assertNoCredentialInStruct(t, field.Interface(), credential, fieldName)
+		}
+	case reflect.String:
+		assert.NotContains(t, val.String(), credential,
+			"credential found in field %s", path)
+	}
+}
+
+// TestGitConfigStore_ListConfigs verifies that ListConfigs returns entries for all YAML
+// files under the subPath directory.
+func TestGitConfigStore_ListConfigs(t *testing.T) {
+	remoteDir := createBareRemote(t, map[string][]byte{
+		"configs/networking/fw.yaml":    []byte("type: firewall\n"),
+		"configs/networking/dns.yaml":   []byte("type: dns\n"),
+		"configs/monitoring/agent.yaml": []byte("type: agent\n"),
+	})
+
+	workDir := t.TempDir()
+	ss := newMemorySecretStore(nil)
+	store, err := NewGitConfigStore(context.Background(), makeSource(remoteDir, "configs"), "tenant1", ss, workDir, logging.NewNoopLogger())
+	require.NoError(t, err)
+
+	entries, err := store.ListConfigs(context.Background(), &cfgconfig.ConfigFilter{TenantID: "tenant1"})
+	require.NoError(t, err)
+	assert.Len(t, entries, 3, "should find 3 yaml files")
+
+	// Filter by namespace
+	netEntries, err := store.ListConfigs(context.Background(), &cfgconfig.ConfigFilter{
+		TenantID:  "tenant1",
+		Namespace: "networking",
+	})
+	require.NoError(t, err)
+	assert.Len(t, netEntries, 2, "networking namespace should have 2 files")
+}
+
+// TestGitConfigStore_GetConfigNotFound verifies that GetConfig returns ErrConfigNotFound
+// for a file that does not exist in the cloned repo.
+func TestGitConfigStore_GetConfigNotFound(t *testing.T) {
+	remoteDir := createBareRemote(t, map[string][]byte{
+		"configs/default/existing.yaml": []byte("x: 1\n"),
+	})
+
+	workDir := t.TempDir()
+	ss := newMemorySecretStore(nil)
+	store, err := NewGitConfigStore(context.Background(), makeSource(remoteDir, "configs"), "tenant1", ss, workDir, logging.NewNoopLogger())
+	require.NoError(t, err)
+
+	_, err = store.GetConfig(context.Background(), &cfgconfig.ConfigKey{
+		TenantID:  "tenant1",
+		Namespace: "default",
+		Name:      "missing",
+	})
+	assert.ErrorIs(t, err, cfgconfig.ErrConfigNotFound, "missing config must return ErrConfigNotFound")
+}
+
+// TestGitConfigStore_SecondConstructionSkipsClone verifies that constructing a
+// GitConfigStore for an already-cloned directory does not re-clone.
+func TestGitConfigStore_SecondConstructionSkipsClone(t *testing.T) {
+	remoteDir := createBareRemote(t, map[string][]byte{
+		"configs/default/app.yaml": []byte("x: 1\n"),
+	})
+
+	workDir := t.TempDir()
+	ss := newMemorySecretStore(nil)
+	source := makeSource(remoteDir, "configs")
+
+	store1, err := NewGitConfigStore(context.Background(), source, "tenant1", ss, workDir, logging.NewNoopLogger())
+	require.NoError(t, err)
+
+	// Write a local-only file (simulating uncommitted local change) to detect a re-clone
+	sentinel := filepath.Join(store1.repoDir, "sentinel-file.txt")
+	require.NoError(t, os.WriteFile(sentinel, []byte("do-not-delete"), 0600))
+
+	// Second construction must not wipe the cloned directory
+	_, err = NewGitConfigStore(context.Background(), source, "tenant1", ss, workDir, logging.NewNoopLogger())
+	require.NoError(t, err)
+
+	_, statErr := os.Stat(sentinel)
+	assert.NoError(t, statErr, "sentinel file must survive second construction (no re-clone)")
+}
+
+// TestGitConfigStore_GetConfigStats verifies that GetConfigStats reflects the number
+// of YAML files in the repo and correctly partitions by namespace.
+func TestGitConfigStore_GetConfigStats(t *testing.T) {
+	remoteDir := createBareRemote(t, map[string][]byte{
+		"configs/ns1/a.yaml": []byte("a: 1\n"),
+		"configs/ns1/b.yaml": []byte("b: 2\n"),
+		"configs/ns2/c.yaml": []byte("c: 3\n"),
+	})
+
+	workDir := t.TempDir()
+	ss := newMemorySecretStore(nil)
+	store, err := NewGitConfigStore(context.Background(), makeSource(remoteDir, "configs"), "tenant1", ss, workDir, logging.NewNoopLogger())
+	require.NoError(t, err)
+
+	stats, err := store.GetConfigStats(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, int64(3), stats.TotalConfigs)
+	assert.Equal(t, int64(3), stats.ConfigsByFormat[string(cfgconfig.ConfigFormatYAML)])
+	assert.Equal(t, int64(3), stats.ConfigsByTenant["tenant1"])
+	// Verify namespace split — exercises filepath.Rel/parts[0] logic
+	assert.Equal(t, int64(2), stats.ConfigsByNamespace["ns1"], "ns1 should have 2 files")
+	assert.Equal(t, int64(1), stats.ConfigsByNamespace["ns2"], "ns2 should have 1 file")
+}
+
+// TestGitConfigStore_GetConfigHistory verifies that GetConfigHistory returns commit
+// metadata for files that have multiple commits in the repo.
+func TestGitConfigStore_GetConfigHistory(t *testing.T) {
+	remoteDir := createBareRemote(t, map[string][]byte{
+		"configs/app/settings.yaml": []byte("version: 1\n"),
+	})
+	// Add a second commit to the same file
+	addCommitToRemote(t, remoteDir, "configs/app/settings.yaml", []byte("version: 2\n"))
+
+	workDir := t.TempDir()
+	ss := newMemorySecretStore(nil)
+	store, err := NewGitConfigStore(context.Background(), makeSource(remoteDir, "configs"), "tenant1", ss, workDir, logging.NewNoopLogger())
+	require.NoError(t, err)
+
+	// Sync to pick up both commits
+	_, err = store.SyncWithRemote(context.Background())
+	require.NoError(t, err)
+
+	history, err := store.GetConfigHistory(context.Background(), &cfgconfig.ConfigKey{
+		TenantID:  "tenant1",
+		Namespace: "app",
+		Name:      "settings",
+	}, 10)
+	require.NoError(t, err)
+	assert.GreaterOrEqual(t, len(history), 2, "history must contain at least 2 commits")
+
+	// Each entry must have a non-zero timestamp and a SHA embedded in Data
+	for i, entry := range history {
+		assert.NotZero(t, entry.UpdatedAt, "entry[%d] must have a timestamp", i)
+		assert.NotEmpty(t, entry.Data, "entry[%d].Data must contain SHA", i)
+		assert.Equal(t, int64(i+1), entry.Version, "entry[%d] version must be 1-indexed", i)
+	}
+}
+
+// TestGitConfigStore_GetConfigVersion verifies version retrieval by commit index.
+func TestGitConfigStore_GetConfigVersion(t *testing.T) {
+	remoteDir := createBareRemote(t, map[string][]byte{
+		"configs/app/cfg.yaml": []byte("ver: 1\n"),
+	})
+	addCommitToRemote(t, remoteDir, "configs/app/cfg.yaml", []byte("ver: 2\n"))
+
+	workDir := t.TempDir()
+	ss := newMemorySecretStore(nil)
+	store, err := NewGitConfigStore(context.Background(), makeSource(remoteDir, "configs"), "tenant1", ss, workDir, logging.NewNoopLogger())
+	require.NoError(t, err)
+	_, err = store.SyncWithRemote(context.Background())
+	require.NoError(t, err)
+
+	key := &cfgconfig.ConfigKey{TenantID: "tenant1", Namespace: "app", Name: "cfg"}
+
+	// Version 1 = most recent commit (ver: 2)
+	v1, err := store.GetConfigVersion(context.Background(), key, 1)
+	require.NoError(t, err)
+	assert.Equal(t, "ver: 2\n", string(v1.Data), "version 1 should be the most recent commit")
+
+	// Version 2 = previous commit (ver: 1)
+	v2, err := store.GetConfigVersion(context.Background(), key, 2)
+	require.NoError(t, err)
+	assert.Equal(t, "ver: 1\n", string(v2.Data), "version 2 should be the older commit")
+
+	// Out-of-bounds version returns ErrConfigNotFound
+	_, err = store.GetConfigVersion(context.Background(), key, 999)
+	assert.ErrorIs(t, err, cfgconfig.ErrConfigNotFound, "out-of-bounds version must return ErrConfigNotFound")
+
+	// version < 1 returns validation error
+	_, err = store.GetConfigVersion(context.Background(), key, 0)
+	assert.Error(t, err, "version 0 must return an error")
+}
+
+// TestGitConfigStore_ValidateConfig verifies that ValidateConfig accepts YAML entries
+// and rejects other formats.
+func TestGitConfigStore_ValidateConfig(t *testing.T) {
+	remoteDir := createBareRemote(t, map[string][]byte{
+		"configs/default/app.yaml": []byte("x: 1\n"),
+	})
+	workDir := t.TempDir()
+	ss := newMemorySecretStore(nil)
+	store, err := NewGitConfigStore(context.Background(), makeSource(remoteDir, "configs"), "tenant1", ss, workDir, logging.NewNoopLogger())
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	yamlEntry := &cfgconfig.ConfigEntry{Format: cfgconfig.ConfigFormatYAML, Data: []byte("x: 1\n")}
+	assert.NoError(t, store.ValidateConfig(ctx, yamlEntry), "YAML must be valid")
+
+	jsonEntry := &cfgconfig.ConfigEntry{Format: cfgconfig.ConfigFormatJSON, Data: []byte(`{"x":1}`)}
+	assert.ErrorIs(t, store.ValidateConfig(ctx, jsonEntry), cfgconfig.ErrInvalidFormat, "non-YAML must return ErrInvalidFormat")
+
+	assert.Error(t, store.ValidateConfig(ctx, nil), "nil entry must return error")
+}
+
+// TestGitConfigStore_ResolveConfigWithInheritance verifies that ResolveConfigWithInheritance
+// delegates to GetConfig and returns the file content.
+func TestGitConfigStore_ResolveConfigWithInheritance(t *testing.T) {
+	const content = "resolved: true\n"
+	remoteDir := createBareRemote(t, map[string][]byte{
+		"configs/default/policy.yaml": []byte(content),
+	})
+	workDir := t.TempDir()
+	ss := newMemorySecretStore(nil)
+	store, err := NewGitConfigStore(context.Background(), makeSource(remoteDir, "configs"), "tenant1", ss, workDir, logging.NewNoopLogger())
+	require.NoError(t, err)
+
+	entry, err := store.ResolveConfigWithInheritance(context.Background(), &cfgconfig.ConfigKey{
+		TenantID:  "tenant1",
+		Namespace: "default",
+		Name:      "policy",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, content, string(entry.Data))
+}


### PR DESCRIPTION
## Summary

- Implements `GitConfigStore` — a read-only `cfgconfig.ConfigStore` backed by an external HTTPS git repository for a single mount-pointed tenant. Wraps `LocalRepositoryStore` from `features/config/git/storage`. All four write methods return `ErrReadOnlySource`.
- `storeForSource` in the controller router now dispatches `ConfigSourceTypeGit` tenants to a cached `GitConfigStore`, completing Phase 2 of the config source routing epic. `NewControllerRouterWithGit` constructor wires the git dependencies.
- 16 unit tests in the git package (local bare repo fake remotes, no network) + 4 new integration tests for the router.

## Security invariants verified

- Credentials fetched from `pkg/secrets` at transport time only — never stored in struct fields (verified by `TestGitConfigStore_StructFieldsNoCredential` via reflection)
- Error messages strip credential material via `sanitizeCredential` before return (`TestGitConfigStore_NoCredentialLeakedInError`)
- All filesystem paths validated via `pkg/security.ValidateAndCleanPath`; adversarial `tenantID` values rejected at construction (`TestGitConfigStore_AdversarialTenantID`)
- Zero calls to `Push`, `Commit`, `WriteFile`, `DeleteFile`, `CreateBranch`, or `CreateTag` on `LocalRepositoryStore`

## Adversarial review results

| Specialist | Round 1 | Round 2 | Round 3 |
|---|---|---|---|
| QA Test Runner | FAIL (lint: gofmt + nolint format) | PASS | — |
| QA Code Reviewer | FAIL (3 blocking: tautological assertion, walk error swallowed, missing history/version tests) | FAIL (1 blocking: memorySecretStore pattern) | PASS |
| Security Engineer | **PASS** | — | — |

All blocking issues resolved: `fakeSecretStore` replaced with `memorySecretStore` (real in-memory CRUD implementation following `simpleTenantStore` pattern), tautological assertion replaced with `assert.ErrorIs`, `GetConfigStats` walk error propagated, `GetConfigHistory`/`GetConfigVersion` tests added.

## Test plan

- [ ] `go test ./pkg/configrouting/...` — all 3 packages pass
- [ ] `make test-agent-complete` — full suite passes (QA runner confirmed PASS)
- [ ] Verify CI required checks pass after merge queue picks up the PR

Fixes #1394

🤖 Generated with [Claude Code](https://claude.com/claude-code)