### PR TITLE
controller/api: accept mTLS admin client cert auth on REST API (Issue #1415)

### DIFF
--- a/features/controller/api/handlers_apikeys.go
+++ b/features/controller/api/handlers_apikeys.go
@@ -67,6 +67,15 @@ func (s *Server) handleCreateAPIKey(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// C1: Validate permissions against the known allow-list. "*" and unknown IDs are rejected.
+	for _, p := range createReq.Permissions {
+		if !isKnownPermission(p) {
+			s.writeErrorResponse(w, http.StatusBadRequest,
+				"Unknown or reserved permission ID: "+p, "INVALID_PERMISSION")
+			return
+		}
+	}
+
 	// Set default tenant if not specified
 	tenantID := createReq.TenantID
 	if tenantID == "" {

--- a/features/controller/api/handlers_apikeys_test.go
+++ b/features/controller/api/handlers_apikeys_test.go
@@ -3,6 +3,7 @@
 package api
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"net/http"
@@ -151,4 +152,57 @@ func TestHandleListAPIKeys_RouterPath_FiltersByAuthenticatedTenant(t *testing.T)
 		assert.NotEqual(t, "tenant-b-key-id", keyMap["id"],
 			"tenant-b key must not be visible through the router to tenant-a")
 	}
+}
+
+// callHandleCreateAPIKey posts body to handleCreateAPIKey with the given context tenant.
+func callHandleCreateAPIKey(server *Server, body []byte, contextTenantID string) *httptest.ResponseRecorder {
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/api-keys", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	if contextTenantID != "" {
+		req = req.WithContext(context.WithValue(req.Context(), ctxkeys.TenantID, contextTenantID))
+	}
+	rec := httptest.NewRecorder()
+	server.handleCreateAPIKey(rec, req)
+	return rec
+}
+
+// TestHandleCreateAPIKey_RejectsWildcard verifies that POST /api/v1/api-keys with
+// permissions: ["*"] returns 400 INVALID_PERMISSION and does not persist the key (C1).
+func TestHandleCreateAPIKey_RejectsWildcard(t *testing.T) {
+	server := setupTestServer(t)
+
+	body := []byte(`{"name":"test-key","permissions":["*"]}`)
+	rec := callHandleCreateAPIKey(server, body, "default")
+
+	assert.Equal(t, http.StatusBadRequest, rec.Code, "wildcard permission must be rejected")
+	assert.Contains(t, rec.Body.String(), "INVALID_PERMISSION")
+
+	// Secret store must be unchanged — key was not persisted.
+	server.mu.RLock()
+	defer server.mu.RUnlock()
+	for _, key := range server.apiKeys {
+		assert.NotEqual(t, "test-key", key.Name, "key with wildcard permission must not be stored")
+	}
+}
+
+// TestHandleCreateAPIKey_RejectsUnknownPermission verifies that an unrecognized permission
+// ID is rejected with 400 INVALID_PERMISSION (C1).
+func TestHandleCreateAPIKey_RejectsUnknownPermission(t *testing.T) {
+	server := setupTestServer(t)
+
+	body := []byte(`{"name":"test-key","permissions":["does-not-exist:action"]}`)
+	rec := callHandleCreateAPIKey(server, body, "default")
+
+	assert.Equal(t, http.StatusBadRequest, rec.Code, "unknown permission must be rejected")
+	assert.Contains(t, rec.Body.String(), "INVALID_PERMISSION")
+}
+
+// TestHandleCreateAPIKey_AcceptsKnownPermissions verifies that valid permission IDs are accepted.
+func TestHandleCreateAPIKey_AcceptsKnownPermissions(t *testing.T) {
+	server := setupTestServer(t)
+
+	body := []byte(`{"name":"valid-key","permissions":["steward:read","api-key:list"]}`)
+	rec := callHandleCreateAPIKey(server, body, "default")
+
+	assert.Equal(t, http.StatusCreated, rec.Code, "known permissions must be accepted")
 }

--- a/features/controller/api/middleware.go
+++ b/features/controller/api/middleware.go
@@ -4,6 +4,8 @@ package api
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -15,6 +17,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/gorilla/mux"
 
+	"github.com/cfgis/cfgms/pkg/cert"
 	"github.com/cfgis/cfgms/pkg/ctxkeys"
 	"github.com/cfgis/cfgms/pkg/logging"
 )
@@ -27,7 +30,23 @@ const (
 	apiKeyContextKey       contextKey = "api_key"
 	userIDContextKey       contextKey = "user_id"
 	authDecisionContextKey contextKey = "auth_decision"
+	principalContextKey    contextKey = "principal"
 )
+
+// Principal represents an authenticated entity — either an mTLS admin cert or an API key.
+// Admin principals (IsAdmin == true) are set exclusively by the cert-auth path after
+// admin-extension verification. API-key principals are converted from APIKey structs.
+type Principal struct {
+	ID          string
+	Name        string
+	IsAdmin     bool
+	Permissions []string
+	TenantID    string
+	// Cert-auth fields — non-empty only when IsAdmin == true (H3)
+	CertSerial      string
+	CertFingerprint string
+	CertNotAfter    time.Time
+}
 
 // loggingMiddleware logs HTTP requests
 func (s *Server) loggingMiddleware(next http.Handler) http.Handler {
@@ -115,8 +134,42 @@ func (s *Server) contentTypeMiddleware(next http.Handler) http.Handler {
 	})
 }
 
-// authenticationMiddleware validates API keys for protected endpoints
-// M-AUTH-1: Load API keys from secret store on-demand if not in cache
+// extractAdminPrincipal inspects r.TLS.PeerCertificates[0] for the CFGMS admin extension.
+// Returns a non-nil *Principal when the cert carries the admin marker. Chain verification
+// is done at the TLS layer (VerifyClientCertIfGiven + ClientCAs); this function only checks
+// the extension. Returns nil when no cert is presented or the cert lacks the admin marker.
+func extractAdminPrincipal(r *http.Request) *Principal {
+	if r.TLS == nil || len(r.TLS.PeerCertificates) == 0 {
+		return nil
+	}
+	peerCert := r.TLS.PeerCertificates[0]
+	if !cert.HasAdminMarker(peerCert) {
+		return nil
+	}
+	fpSum := sha256.Sum256(peerCert.Raw)
+	return &Principal{
+		ID:              peerCert.Subject.CommonName,
+		Name:            "mtls-admin:" + peerCert.Subject.CommonName,
+		IsAdmin:         true,
+		TenantID:        "default",
+		CertSerial:      peerCert.SerialNumber.String(),
+		CertFingerprint: hex.EncodeToString(fpSum[:]),
+		CertNotAfter:    peerCert.NotAfter,
+	}
+}
+
+// hasHeaderCredentials reports whether the request carries an API key or Bearer token header.
+func hasHeaderCredentials(r *http.Request) bool {
+	if r.Header.Get("X-API-Key") != "" {
+		return true
+	}
+	return strings.HasPrefix(r.Header.Get("Authorization"), "Bearer ")
+}
+
+// authenticationMiddleware validates incoming requests via mTLS admin cert or API key.
+// States: (a) admin-marked cert only → admin principal; (b) admin-marked cert + header → 400;
+// (c) cert without admin marker → fall through to API-key auth; (d) no cert → API-key auth.
+// M-AUTH-1: Load API keys from secret store on-demand if not in cache.
 func (s *Server) authenticationMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// Test endpoints require explicit opt-in via CFGMS_ENABLE_TEST_ENDPOINTS=true.
@@ -137,29 +190,48 @@ func (s *Server) authenticationMiddleware(next http.Handler) http.Handler {
 			}
 		}
 
+		// H2: mTLS-presented identity always wins.
+		if adminPrincipal := extractAdminPrincipal(r); adminPrincipal != nil {
+			// H2/L5: Conflicting credentials — cert AND header present → reject.
+			if hasHeaderCredentials(r) {
+				s.writeErrorResponse(w, http.StatusBadRequest,
+					"Conflicting credentials: mTLS admin cert and API key header cannot both be present",
+					"CONFLICTING_CREDENTIALS")
+				return
+			}
+			// Cert-auth success: set principal context and proceed.
+			ctx := context.WithValue(r.Context(), principalContextKey, adminPrincipal)
+			ctx = context.WithValue(ctx, userIDContextKey, logging.SanitizeLogValue(adminPrincipal.ID))
+			ctx = context.WithValue(ctx, ctxkeys.TenantID, adminPrincipal.TenantID)
+			next.ServeHTTP(w, r.WithContext(ctx))
+			return
+		}
+
+		// State (c)/(d): no admin cert presented — use API-key path.
+
 		// Extract API key from header
-		apiKey := r.Header.Get("X-API-Key")
-		if apiKey == "" {
+		apiKeyStr := r.Header.Get("X-API-Key")
+		if apiKeyStr == "" {
 			// Also check Authorization header for Bearer token
 			authHeader := r.Header.Get("Authorization")
 			if strings.HasPrefix(authHeader, "Bearer ") {
-				apiKey = strings.TrimPrefix(authHeader, "Bearer ")
+				apiKeyStr = strings.TrimPrefix(authHeader, "Bearer ")
 			}
 		}
 
-		if apiKey == "" {
+		if apiKeyStr == "" {
 			s.writeErrorResponse(w, http.StatusUnauthorized, "API key required", "MISSING_API_KEY")
 			return
 		}
 
 		// Check memory cache first
 		s.mu.RLock()
-		keyInfo, exists := s.apiKeys[apiKey]
+		keyInfo, exists := s.apiKeys[apiKeyStr]
 		s.mu.RUnlock()
 
 		// M-AUTH-1: If not in cache, try to load from secret store
 		if !exists {
-			loadedKey, err := s.loadAPIKeyFromStore(r.Context(), apiKey)
+			loadedKey, err := s.loadAPIKeyFromStore(r.Context(), apiKeyStr)
 			if err != nil {
 				s.logger.Debug("Failed to load API key from store", "error", err)
 				s.writeErrorResponse(w, http.StatusUnauthorized, "Invalid API key", "INVALID_API_KEY")
@@ -174,8 +246,18 @@ func (s *Server) authenticationMiddleware(next http.Handler) http.Handler {
 			return
 		}
 
-		// Add key info to request context
+		// Convert API key to Principal for uniform authorization handling.
+		principal := &Principal{
+			ID:          keyInfo.ID,
+			Name:        keyInfo.Name,
+			IsAdmin:     false,
+			Permissions: keyInfo.Permissions,
+			TenantID:    keyInfo.TenantID,
+		}
+
+		// Add key info and principal to request context
 		ctx := context.WithValue(r.Context(), apiKeyContextKey, keyInfo)
+		ctx = context.WithValue(ctx, principalContextKey, principal)
 		ctx = context.WithValue(ctx, userIDContextKey, keyInfo.ID)
 		ctx = context.WithValue(ctx, ctxkeys.TenantID, keyInfo.TenantID)
 
@@ -276,7 +358,8 @@ type AuthorizationDecision struct {
 	ConditionalVars map[string]interface{} `json:"conditional_vars,omitempty"`
 }
 
-// requirePermission creates middleware that enforces specific permission requirements
+// requirePermission creates middleware that enforces specific permission requirements.
+// Admin principals (IsAdmin == true) short-circuit to ALLOW for any permission.
 func (s *Server) requirePermission(resourceType, action string) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -287,8 +370,8 @@ func (s *Server) requirePermission(resourceType, action string) func(http.Handle
 				return
 			}
 
-			// Get authentication context
-			apiKey, ok := r.Context().Value(apiKeyContextKey).(*APIKey)
+			// Get authenticated principal from context (set by authenticationMiddleware).
+			principal, ok := r.Context().Value(principalContextKey).(*Principal)
 			if !ok {
 				s.writeErrorResponse(w, http.StatusUnauthorized, "Authentication required", "AUTHENTICATION_REQUIRED")
 				return
@@ -300,16 +383,15 @@ func (s *Server) requirePermission(resourceType, action string) func(http.Handle
 			// Build resource identifier from URL path variables
 			resource := s.buildResourceIdentifier(r, resourceType)
 
-			// Check API key permissions first (simple permission check)
 			permissionID := s.buildPermissionID(resourceType, action)
-			if !s.hasAPIKeyPermission(apiKey, permissionID) {
+			if !s.hasPermission(principal, permissionID) {
 				decision := &AuthorizationDecision{
 					Granted:      false,
 					PermissionID: permissionID,
 					Resource:     resource,
 					Action:       action,
 					Decision:     "DENY",
-					Reason:       "API key lacks required permission: " + permissionID,
+					Reason:       "Principal lacks required permission: " + permissionID,
 					CheckedAt:    time.Now(),
 					SubjectID:    userID,
 					TenantID:     tenantID,
@@ -320,14 +402,18 @@ func (s *Server) requirePermission(resourceType, action string) func(http.Handle
 				return
 			}
 
-			// API key has correct permissions - grant access and skip RBAC check
+			// Principal has required permission — grant access.
+			reason := "API key has required permission: " + permissionID
+			if principal.IsAdmin {
+				reason = "Admin principal granted full access"
+			}
 			decision := &AuthorizationDecision{
 				Granted:      true,
 				PermissionID: permissionID,
 				Resource:     resource,
 				Action:       action,
 				Decision:     "ALLOW",
-				Reason:       "API key has required permission: " + permissionID,
+				Reason:       reason,
 				CheckedAt:    time.Now(),
 				SubjectID:    userID,
 				TenantID:     tenantID,
@@ -336,8 +422,9 @@ func (s *Server) requirePermission(resourceType, action string) func(http.Handle
 			// Add decision to context
 			ctx := context.WithValue(r.Context(), authDecisionContextKey, decision)
 
-			s.logger.Debug("Access granted via API key permission",
+			s.logger.Debug("Access granted",
 				"subject_id", userID,
+				"is_admin", principal.IsAdmin,
 				"permission_id", permissionID,
 				"resource", resource,
 			)
@@ -411,7 +498,7 @@ func (s *Server) writeAuthorizationError(w http.ResponseWriter, message, code st
 	_ = json.NewEncoder(w).Encode(errorResponse)
 }
 
-// auditAuthorizationDecision logs authorization decisions for security auditing
+// auditAuthorizationDecision logs authorization decisions for security auditing (H3).
 func (s *Server) auditAuthorizationDecision(r *http.Request, decision *AuthorizationDecision) {
 	auditFields := map[string]interface{}{
 		"event_type":     "api_authorization",
@@ -431,6 +518,17 @@ func (s *Server) auditAuthorizationDecision(r *http.Request, decision *Authoriza
 		"user_agent":     logging.SanitizeLogValue(r.Header.Get("User-Agent")),
 		"request_id":     logging.SanitizeLogValue(s.getRequestID(r)),
 		"severity":       s.getAuditSeverity(decision),
+	}
+
+	// H3: Include auth method and cert details in audit log.
+	principal, _ := r.Context().Value(principalContextKey).(*Principal)
+	if principal != nil && principal.IsAdmin {
+		auditFields["auth_method"] = "cert"
+		auditFields["cert_serial"] = logging.SanitizeLogValue(principal.CertSerial)
+		auditFields["cert_fingerprint"] = logging.SanitizeLogValue(principal.CertFingerprint)
+		auditFields["cert_not_after"] = principal.CertNotAfter.UTC().Format(time.RFC3339)
+	} else {
+		auditFields["auth_method"] = "api_key"
 	}
 
 	if decision.ConditionalVars != nil {
@@ -493,36 +591,20 @@ func (s *Server) getAuditSeverity(decision *AuthorizationDecision) string {
 	return "LOW" // Regular authorized operations
 }
 
-// hasAPIKeyPermission checks if an API key has a specific permission
-func (s *Server) hasAPIKeyPermission(apiKey *APIKey, permissionID string) bool {
-	if apiKey == nil || apiKey.Permissions == nil {
-		s.logger.Debug("API key permission check failed - nil key or permissions",
-			"key_id", func() string {
-				if apiKey != nil {
-					return apiKey.ID
-				}
-				return "nil"
-			}())
+// hasPermission checks whether principal has permissionID.
+// Admin principals (IsAdmin == true) short-circuit to true regardless of permissionID.
+// C1: "*" is treated as a literal permission name — it will not match any real permissionID.
+func (s *Server) hasPermission(principal *Principal, permissionID string) bool {
+	if principal == nil {
 		return false
 	}
-
-	s.logger.Debug("Checking API key permission",
-		"key_id", apiKey.ID,
-		"required_permission", permissionID,
-		"available_permissions", apiKey.Permissions)
-
-	for _, permission := range apiKey.Permissions {
-		if permission == permissionID {
-			s.logger.Debug("API key permission granted",
-				"key_id", apiKey.ID,
-				"permission", permissionID)
+	if principal.IsAdmin {
+		return true
+	}
+	for _, p := range principal.Permissions {
+		if p == permissionID {
 			return true
 		}
 	}
-
-	s.logger.Debug("API key permission denied",
-		"key_id", apiKey.ID,
-		"required_permission", permissionID,
-		"available_permissions", apiKey.Permissions)
 	return false
 }

--- a/features/controller/api/middleware_test.go
+++ b/features/controller/api/middleware_test.go
@@ -4,8 +4,15 @@ package api
 
 import (
 	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
 	"fmt"
+	"math/big"
 	"net/http"
+	"net/http/httptest"
 	"strings"
 	"sync"
 	"testing"
@@ -14,6 +21,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/cfgis/cfgms/pkg/cert"
+	"github.com/cfgis/cfgms/pkg/ctxkeys"
 	"github.com/cfgis/cfgms/pkg/logging"
 )
 
@@ -375,4 +384,243 @@ func TestAuditAuthorizationDecision_SanitizesNestedConditionalVars(t *testing.T)
 	mMap, ok := cvMap["m"].(map[string]interface{})
 	require.True(t, ok, "conditional_vars[m] must be a nested map")
 	assert.Equal(t, "v_x", mMap["deep"], "null byte in nested map value must be replaced")
+}
+
+// --- mTLS auth middleware tests (Story #1415) ---
+
+// makeSelfSignedAdminCert creates a self-signed cert with the CFGMS admin marker.
+// The TLS chain verification is bypassed in middleware unit tests (done at TLS layer in prod).
+func makeSelfSignedAdminCert(t *testing.T) *x509.Certificate {
+	t.Helper()
+	return makeAdminTestCert(t, true)
+}
+
+// makeSelfSignedCert creates a self-signed cert WITHOUT the admin marker.
+func makeSelfSignedCert(t *testing.T) *x509.Certificate {
+	t.Helper()
+	return makeAdminTestCert(t, false)
+}
+
+func makeAdminTestCert(t *testing.T, withMarker bool) *x509.Certificate {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	template := &x509.Certificate{
+		SerialNumber: big.NewInt(1234),
+		Subject:      pkix.Name{CommonName: "test-admin"},
+		NotBefore:    time.Now(),
+		NotAfter:     time.Now().Add(24 * time.Hour),
+		KeyUsage:     x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+	}
+	if withMarker {
+		cert.SetAdminMarker(template)
+	}
+
+	// Self-signed for unit test purposes; chain verification is done at TLS layer in prod.
+	certDER, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+	require.NoError(t, err)
+	parsed, err := x509.ParseCertificate(certDER)
+	require.NoError(t, err)
+	return parsed
+}
+
+// requestWithTLSCert returns an httptest.Request with r.TLS set to present peerCert.
+func requestWithTLSCert(method, path string, peerCert *x509.Certificate) *http.Request {
+	req := httptest.NewRequest(method, path, nil)
+	req.TLS = &tls.ConnectionState{
+		PeerCertificates: []*x509.Certificate{peerCert},
+	}
+	return req
+}
+
+// wrapWithAuth wraps handler with authenticationMiddleware then requirePermission.
+func wrapWithAuth(s *Server, resourceType, action string, inner http.HandlerFunc) http.Handler {
+	return s.authenticationMiddleware(
+		s.requirePermission(resourceType, action)(inner),
+	)
+}
+
+// TestMTLSAuth_AdminMarker_Granted verifies that a request presenting a cert with the
+// CFGMS admin extension is authenticated as an admin principal and passes requirePermission.
+func TestMTLSAuth_AdminMarker_Granted(t *testing.T) {
+	server := setupTestServer(t)
+	adminCert := makeSelfSignedAdminCert(t)
+
+	var capturedPrincipal *Principal
+	handler := wrapWithAuth(server, "steward", "read",
+		func(w http.ResponseWriter, r *http.Request) {
+			capturedPrincipal, _ = r.Context().Value(principalContextKey).(*Principal)
+			w.WriteHeader(http.StatusOK)
+		})
+
+	req := requestWithTLSCert(http.MethodGet, "/api/v1/stewards/test", adminCert)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code, "admin cert must be granted access")
+	require.NotNil(t, capturedPrincipal)
+	assert.True(t, capturedPrincipal.IsAdmin, "principal from admin cert must have IsAdmin == true")
+	assert.NotEmpty(t, capturedPrincipal.CertSerial)
+	assert.NotEmpty(t, capturedPrincipal.CertFingerprint)
+	assert.False(t, capturedPrincipal.CertNotAfter.IsZero())
+}
+
+// TestMTLSAuth_NoMarker_FallsThrough verifies that when a cert without the admin marker
+// is presented alongside a valid API key, the API-key auth path handles the request normally.
+func TestMTLSAuth_NoMarker_FallsThrough(t *testing.T) {
+	server := setupTestServer(t)
+	apiKeyStr := NewTestKey(t, server, []string{"steward:read"})
+
+	regularCert := makeSelfSignedCert(t)
+
+	var capturedPrincipal *Principal
+	handler := wrapWithAuth(server, "steward", "read",
+		func(w http.ResponseWriter, r *http.Request) {
+			capturedPrincipal, _ = r.Context().Value(principalContextKey).(*Principal)
+			w.WriteHeader(http.StatusOK)
+		})
+
+	req := requestWithTLSCert(http.MethodGet, "/api/v1/stewards/test", regularCert)
+	req.Header.Set("X-API-Key", apiKeyStr)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code, "cert without marker + valid API key must succeed via API-key path")
+	require.NotNil(t, capturedPrincipal)
+	assert.False(t, capturedPrincipal.IsAdmin, "principal from API-key path must not be admin")
+}
+
+// TestMTLSAuth_ConflictingCredentials_Rejected verifies that presenting an admin cert AND
+// an API-key header together returns 400 CONFLICTING_CREDENTIALS (H2/L5).
+func TestMTLSAuth_ConflictingCredentials_Rejected(t *testing.T) {
+	server := setupTestServer(t)
+	adminCert := makeSelfSignedAdminCert(t)
+	apiKeyStr := NewTestKey(t, server, []string{"steward:read"})
+
+	handler := server.authenticationMiddleware(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := requestWithTLSCert(http.MethodGet, "/api/v1/stewards/test", adminCert)
+	req.Header.Set("X-API-Key", apiKeyStr)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusBadRequest, rec.Code, "admin cert + API key header must return 400")
+	assert.Contains(t, rec.Body.String(), "CONFLICTING_CREDENTIALS")
+}
+
+// TestMTLSAuth_ConflictingCredentials_BearerToken verifies that admin cert + Bearer token
+// also returns 400 CONFLICTING_CREDENTIALS.
+func TestMTLSAuth_ConflictingCredentials_BearerToken(t *testing.T) {
+	server := setupTestServer(t)
+	adminCert := makeSelfSignedAdminCert(t)
+	apiKeyStr := NewTestKey(t, server, []string{"steward:read"})
+
+	handler := server.authenticationMiddleware(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := requestWithTLSCert(http.MethodGet, "/api/v1/stewards/test", adminCert)
+	req.Header.Set("Authorization", "Bearer "+apiKeyStr)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusBadRequest, rec.Code, "admin cert + Bearer token must return 400")
+	assert.Contains(t, rec.Body.String(), "CONFLICTING_CREDENTIALS")
+}
+
+// TestMTLSAuth_NoCert_FallsBackToAPIKey verifies that when no cert is presented,
+// the middleware falls back to API-key auth unchanged.
+func TestMTLSAuth_NoCert_FallsBackToAPIKey(t *testing.T) {
+	server := setupTestServer(t)
+	apiKeyStr := NewTestKey(t, server, []string{"steward:read"})
+
+	var capturedPrincipal *Principal
+	handler := wrapWithAuth(server, "steward", "read",
+		func(w http.ResponseWriter, r *http.Request) {
+			capturedPrincipal, _ = r.Context().Value(principalContextKey).(*Principal)
+			w.WriteHeader(http.StatusOK)
+		})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/stewards/test", nil)
+	req.Header.Set("X-API-Key", apiKeyStr)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code, "no cert + valid API key must succeed")
+	require.NotNil(t, capturedPrincipal)
+	assert.False(t, capturedPrincipal.IsAdmin)
+}
+
+// TestHasPermission_AdminPrincipal verifies that hasPermission returns true for any
+// permissionID when the principal has IsAdmin == true.
+func TestHasPermission_AdminPrincipal(t *testing.T) {
+	server := setupTestServer(t)
+	admin := &Principal{IsAdmin: true}
+
+	assert.True(t, server.hasPermission(admin, "steward:read"))
+	assert.True(t, server.hasPermission(admin, "rbac:delete-role"))
+	assert.True(t, server.hasPermission(admin, "some-future:permission"))
+}
+
+// TestHasPermission_WildcardStringRejected verifies that an API-key principal with
+// Permissions: []string{"*"} does not short-circuit — "*" is treated as a literal
+// permission name (C1: no wildcard in permission strings).
+func TestHasPermission_WildcardStringRejected(t *testing.T) {
+	server := setupTestServer(t)
+	wildcardPrincipal := &Principal{
+		IsAdmin:     false,
+		Permissions: []string{"*"},
+	}
+
+	// "*" must not match any real permissionID
+	assert.False(t, server.hasPermission(wildcardPrincipal, "steward:read"),
+		"wildcard string must not grant steward:read")
+	assert.False(t, server.hasPermission(wildcardPrincipal, "rbac:admin"),
+		"wildcard string must not grant rbac:admin")
+}
+
+// TestMTLSAuth_AuditFields_CertAuth verifies that audit log entries from cert-auth
+// requests carry auth_method=cert and cert detail fields (H3).
+func TestMTLSAuth_AuditFields_CertAuth(t *testing.T) {
+	capLog := &auditCapturingLogger{}
+	server := setupTestServerWithLogger(t, capLog)
+	adminCert := makeSelfSignedAdminCert(t)
+
+	handler := wrapWithAuth(server, "steward", "read",
+		func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusOK) })
+
+	req := requestWithTLSCert(http.MethodGet, "/api/v1/stewards/test", adminCert)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, "cert", capLog.kvValue("auth_method"), "cert-auth must log auth_method=cert")
+	assert.NotNil(t, capLog.kvValue("cert_serial"), "must log cert_serial")
+	assert.NotNil(t, capLog.kvValue("cert_fingerprint"), "must log cert_fingerprint")
+	assert.NotNil(t, capLog.kvValue("cert_not_after"), "must log cert_not_after")
+}
+
+// TestMTLSAuth_AuditFields_APIKeyAuth verifies that audit log entries from API-key
+// auth requests carry auth_method=api_key (H3).
+func TestMTLSAuth_AuditFields_APIKeyAuth(t *testing.T) {
+	capLog := &auditCapturingLogger{}
+	server := setupTestServerWithLogger(t, capLog)
+	apiKeyStr := NewTestKey(t, server, []string{"steward:read"})
+
+	handler := wrapWithAuth(server, "steward", "read",
+		func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusOK) })
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/stewards/test", nil)
+	req.Header.Set("X-API-Key", apiKeyStr)
+	// Inject tenant context so requirePermission finds it.
+	req = req.WithContext(context.WithValue(req.Context(), ctxkeys.TenantID, "test-tenant"))
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, "api_key", capLog.kvValue("auth_method"), "API-key auth must log auth_method=api_key")
 }

--- a/features/controller/api/permissions.go
+++ b/features/controller/api/permissions.go
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+package api
+
+// knownPermissions is the allow-list of valid permission IDs for handleCreateAPIKey.
+// Each entry corresponds to a permission checked by requirePermission in server.go.
+// C1: "*" (wildcard) is intentionally absent — it is never a valid permission ID.
+var knownPermissions = map[string]bool{
+	// Steward management
+	"steward:list":            true,
+	"steward:read":            true,
+	"steward:read-dna":        true,
+	"steward:auth-refresh":    true,
+	"steward:read-config":     true,
+	"steward:write-config":    true,
+	"steward:validate-config": true,
+	"steward:read-scripts":    true,
+	"steward:execute-scripts": true,
+	"steward:read-compliance": true,
+	// Config push
+	"config:push": true,
+	// Certificate management
+	"certificate:list":      true,
+	"certificate:provision": true,
+	// RBAC
+	"rbac:list-permissions": true,
+	"rbac:read-permission":  true,
+	"rbac:list-roles":       true,
+	"rbac:create-role":      true,
+	"rbac:read-role":        true,
+	"rbac:update-role":      true,
+	"rbac:delete-role":      true,
+	// API key management
+	"api-key:list":   true,
+	"api-key:create": true,
+	"api-key:read":   true,
+	"api-key:delete": true,
+	// Registration token management
+	"registration:list-tokens":  true,
+	"registration:create-token": true,
+	"registration:read-token":   true,
+	"registration:delete-token": true,
+	"registration:revoke-token": true,
+	// Monitoring
+	"monitoring:read-health":            true,
+	"monitoring:read-metrics":           true,
+	"monitoring:read-config":            true,
+	"monitoring:read-anomalies":         true,
+	"monitoring:read-component-health":  true,
+	"monitoring:read-component-metrics": true,
+	// HA management
+	"ha:read-status":  true,
+	"ha:read-cluster": true,
+	"ha:read-leader":  true,
+	"ha:read-nodes":   true,
+	// Compliance
+	"compliance:read-summary": true,
+	// Tenant management
+	"tenant:manage": true,
+}
+
+// isKnownPermission reports whether p is a recognized permission ID.
+// "*" and all other unlisted strings return false.
+func isKnownPermission(p string) bool {
+	return knownPermissions[p]
+}

--- a/features/controller/api/server.go
+++ b/features/controller/api/server.go
@@ -649,7 +649,7 @@ func (s *Server) setupTLS() (*tls.Config, error) {
 	return s.setupLegacyTLS()
 }
 
-// setupManagedTLS configures TLS using managed certificates
+// setupManagedTLS configures TLS using managed certificates.
 func (s *Server) setupManagedTLS() (*tls.Config, error) {
 	// Story #377: In separated mode with external source, load from disk
 	if s.cfg.Certificate != nil && s.cfg.Certificate.IsSeparatedArchitecture() {
@@ -666,26 +666,31 @@ func (s *Server) setupManagedTLS() (*tls.Config, error) {
 		return nil, fmt.Errorf("failed to get server certificate: %w", err)
 	}
 
-	// In ClusterMode, supply the HA CA cert so the TLS listener can request (but not
-	// require) a client certificate from HA peers, populating r.TLS.PeerCertificates
-	// for the application-layer CN check without breaking non-HA clients.
-	var caCertPEM []byte
-	inClusterMode := s.haManager != nil && s.haManager.GetDeploymentMode() == ha.ClusterMode
-	if inClusterMode {
-		caCertPEM = s.haManager.GetCACertPEM()
+	// Populate ClientCAs with the controller CA so that presented admin certs
+	// are chain-verified at the TLS handshake layer (Story #1415).
+	controllerCACertPEM, err := s.certManager.GetCACertificate()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get controller CA certificate: %w", err)
 	}
 
-	tlsConfig, err := cert.CreateServerTLSConfig(serverCert.CertificatePEM, serverCert.PrivateKeyPEM, caCertPEM, tls.VersionTLS12)
+	tlsConfig, err := cert.CreateServerTLSConfig(serverCert.CertificatePEM, serverCert.PrivateKeyPEM, controllerCACertPEM, tls.VersionTLS12)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create TLS config: %w", err)
 	}
 
-	// Override to RequestClientCert: peers may present a cert (which the app layer
-	// inspects via r.TLS.PeerCertificates), but non-HA clients without a cert are
-	// still accepted. CreateServerTLSConfig sets RequireAndVerifyClientCert when
-	// caCertPEM != nil; this overrides that to the softer policy.
+	// Use VerifyClientCertIfGiven (not RequireAndVerifyClientCert): when a client
+	// presents a cert the TLS stack verifies it against ClientCAs; clients without
+	// a cert fall through to API-key auth in the application layer. This implements
+	// mTLS admin auth alongside the existing API-key path (H2).
+	tlsConfig.ClientAuth = tls.VerifyClientCertIfGiven
+
+	// Cluster mode (HA): merge the HA peer CA into ClientCAs so that both admin
+	// certs (controller CA) and HA peer certs (HA CA) pass TLS chain verification.
+	inClusterMode := s.haManager != nil && s.haManager.GetDeploymentMode() == ha.ClusterMode
 	if inClusterMode {
-		tlsConfig.ClientAuth = tls.RequestClientCert
+		if haCACertPEM := s.haManager.GetCACertPEM(); len(haCACertPEM) > 0 {
+			tlsConfig.ClientCAs.AppendCertsFromPEM(haCACertPEM)
+		}
 	}
 
 	return tlsConfig, nil

--- a/features/controller/api/server_test.go
+++ b/features/controller/api/server_test.go
@@ -263,7 +263,7 @@ func TestAPIKeyManagement(t *testing.T) {
 	// Test creating a new API key
 	createReq := APIKeyCreateRequest{
 		Name:        "Test Key",
-		Permissions: []string{"stewards:read"},
+		Permissions: []string{"steward:read"},
 		TenantID:    "test-tenant",
 	}
 
@@ -735,7 +735,7 @@ func TestEphemeralAPIKeys(t *testing.T) {
 	})
 
 	t.Run("JIT key convenience function", func(t *testing.T) {
-		permissions := []string{"stewards:execute-scripts"}
+		permissions := []string{"steward:read"}
 
 		// Use convenience function for 1-hour JIT key
 		jitKey := NewJITTestKey(t, server, permissions)
@@ -751,6 +751,15 @@ func TestEphemeralAPIKeys(t *testing.T) {
 		// Should expire in approximately 1 hour (within 10 seconds tolerance for CI)
 		expectedExpiry := time.Now().Add(1 * time.Hour)
 		assert.WithinDuration(t, expectedExpiry, *keyInfo.ExpiresAt, 10*time.Second)
+
+		// Verify the JIT key actually grants access to an authorized endpoint
+		req := httptest.NewRequest("GET", "/api/v1/stewards/test-steward-id", nil)
+		req.Header.Set("X-API-Key", jitKey)
+		rec := httptest.NewRecorder()
+		server.router.ServeHTTP(rec, req)
+		// 404 means auth passed and the endpoint was reached (no steward with that ID exists)
+		assert.NotEqual(t, http.StatusUnauthorized, rec.Code, "JIT key must authenticate the request")
+		assert.NotEqual(t, http.StatusForbidden, rec.Code, "JIT key must have steward:read permission")
 	})
 
 	t.Run("automatic cleanup removes expired keys", func(t *testing.T) {

--- a/features/controller/api/server_tls_commercial_test.go
+++ b/features/controller/api/server_tls_commercial_test.go
@@ -7,9 +7,14 @@ package api
 
 import (
 	"context"
+	"crypto/rand"
+	"crypto/rsa"
 	"crypto/tls"
 	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
 	"fmt"
+	"math/big"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -21,6 +26,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/cfgis/cfgms/commercial/ha"
+	"github.com/cfgis/cfgms/pkg/cert"
 	"github.com/cfgis/cfgms/pkg/logging"
 	"github.com/cfgis/cfgms/pkg/testing/storage"
 )
@@ -41,10 +47,11 @@ func newClusterModeHAManager(t *testing.T, caCertPath string) *ha.Manager {
 	return manager
 }
 
-// TestSetupManagedTLS_ClusterMode_RequestsClientCert verifies that in ClusterMode with a valid
-// HA CA cert, setupManagedTLS sets ClientAuth = tls.RequestClientCert so HA peers can present
-// a certificate while non-HA clients without certs continue to connect normally.
-func TestSetupManagedTLS_ClusterMode_RequestsClientCert(t *testing.T) {
+// TestSetupManagedTLS_ClusterMode_VerifyClientCertIfGiven verifies that in ClusterMode with a
+// valid HA CA cert, setupManagedTLS sets ClientAuth = tls.VerifyClientCertIfGiven. Presented
+// certs are chain-verified against both the controller CA and the HA CA; clients without
+// certs continue to connect normally (falling through to API-key auth).
+func TestSetupManagedTLS_ClusterMode_VerifyClientCertIfGiven(t *testing.T) {
 	certMgr := newTLSTestCertManager(t)
 
 	// Obtain the cert manager's CA cert so the HA manager and server share the same trust root.
@@ -60,13 +67,15 @@ func TestSetupManagedTLS_ClusterMode_RequestsClientCert(t *testing.T) {
 	tlsConfig, err := server.setupManagedTLS()
 	require.NoError(t, err)
 	require.NotNil(t, tlsConfig)
-	assert.Equal(t, tls.RequestClientCert, tlsConfig.ClientAuth,
-		"ClusterMode must set ClientAuth = RequestClientCert to allow HA peer inspection without requiring certs from non-HA clients")
+	assert.Equal(t, tls.VerifyClientCertIfGiven, tlsConfig.ClientAuth,
+		"ClusterMode must set ClientAuth = VerifyClientCertIfGiven: presented certs are chain-verified "+
+			"against both controller CA and HA CA; missing cert falls through to API-key auth")
 }
 
 // TestSetupManagedTLS_ClusterMode_NoCert_HandshakeSucceeds verifies the product decision:
 // in ClusterMode, a client without a client certificate can complete the TLS handshake.
 // The connection is accepted and r.TLS.PeerCertificates is nil for that client.
+// This remains true under VerifyClientCertIfGiven (no cert = no verification attempt).
 func TestSetupManagedTLS_ClusterMode_NoCert_HandshakeSucceeds(t *testing.T) {
 	certMgr := newTLSTestCertManager(t)
 
@@ -122,7 +131,7 @@ func TestSetupManagedTLS_ClusterMode_NoCert_HandshakeSucceeds(t *testing.T) {
 	}
 
 	resp, err := client.Get(fmt.Sprintf("https://%s/", ln.Addr().String()))
-	require.NoError(t, err, "HTTPS request without a client cert must succeed in ClusterMode")
+	require.NoError(t, err, "HTTPS request without a client cert must succeed under VerifyClientCertIfGiven")
 	defer resp.Body.Close()
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 
@@ -133,8 +142,9 @@ func TestSetupManagedTLS_ClusterMode_NoCert_HandshakeSucceeds(t *testing.T) {
 }
 
 // TestSetupManagedTLS_ClusterMode_EmptyCACertPath verifies that in ClusterMode, even when
-// GetCACertPEM() returns nil (no CA cert configured), setupManagedTLS still sets
-// ClientAuth = tls.RequestClientCert because the ClusterMode gate is the determining factor.
+// GetCACertPEM() returns nil (no HA CA cert configured), setupManagedTLS still sets
+// ClientAuth = tls.VerifyClientCertIfGiven because certManager is the determining factor.
+// ClientCAs will contain only the controller CA cert.
 func TestSetupManagedTLS_ClusterMode_EmptyCACertPath(t *testing.T) {
 	certMgr := newTLSTestCertManager(t)
 
@@ -145,6 +155,145 @@ func TestSetupManagedTLS_ClusterMode_EmptyCACertPath(t *testing.T) {
 	tlsConfig, err := server.setupManagedTLS()
 	require.NoError(t, err)
 	require.NotNil(t, tlsConfig)
-	assert.Equal(t, tls.RequestClientCert, tlsConfig.ClientAuth,
-		"ClusterMode must set RequestClientCert even when GetCACertPEM returns nil")
+	assert.Equal(t, tls.VerifyClientCertIfGiven, tlsConfig.ClientAuth,
+		"ClusterMode must set VerifyClientCertIfGiven even when GetCACertPEM returns nil (controller CA still in ClientCAs)")
+}
+
+// TestSetupManagedTLS_ClusterMode_AdminCertAndHAPeerCertBothVerify verifies that in cluster
+// mode, setupManagedTLS merges both the controller CA and the HA peer CA into ClientCAs,
+// so a cert signed by either CA succeeds TLS handshake. The admin marker (application-layer
+// concern) is validated separately in middleware tests.
+func TestSetupManagedTLS_ClusterMode_AdminCertAndHAPeerCertBothVerify(t *testing.T) {
+	// Controller CA: from the cert manager.
+	certMgr := newTLSTestCertManager(t)
+	controllerCACertPEM, err := certMgr.GetCACertificate()
+	require.NoError(t, err)
+
+	// HA CA: a separate CA created for this test so the two CAs are distinct.
+	haCACert, haCAKey, haCACertPEM := makeCommercialTestCA(t)
+
+	haCAPath := filepath.Join(t.TempDir(), "ha-ca.pem")
+	require.NoError(t, os.WriteFile(haCAPath, haCACertPEM, 0600))
+
+	haManager := newClusterModeHAManager(t, haCAPath)
+	server := newMinimalTLSServer(t, certMgr, haManager)
+
+	tlsConfig, err := server.setupManagedTLS()
+	require.NoError(t, err)
+	require.NotNil(t, tlsConfig)
+	assert.Equal(t, tls.VerifyClientCertIfGiven, tlsConfig.ClientAuth)
+
+	// Start a real TLS listener.
+	ln, err := tls.Listen("tcp", "127.0.0.1:0", tlsConfig)
+	require.NoError(t, err)
+	defer ln.Close()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	srv := &http.Server{Handler: mux}
+	go func() { _ = srv.Serve(ln) }()
+	defer func() { _ = srv.Shutdown(context.Background()) }()
+
+	// Combined trust root pool for clients verifying the server cert.
+	serverTrustPool := x509.NewCertPool()
+	serverTrustPool.AppendCertsFromPEM(controllerCACertPEM)
+
+	addr := fmt.Sprintf("https://%s/", ln.Addr().String())
+
+	// Case 1: client cert signed by controller CA (represents an admin cert).
+	adminClientCert := makeCommercialTestClientCert(t, certMgr)
+	doTLSHandshake(t, addr, adminClientCert, serverTrustPool,
+		"admin cert (controller-CA-signed) must complete TLS handshake")
+
+	// Case 2: client cert signed by HA CA (represents an HA peer cert).
+	haPeerClientCert := makeCommercialTestClientCertFromCA(t, haCACert, haCAKey)
+	doTLSHandshake(t, addr, haPeerClientCert, serverTrustPool,
+		"HA peer cert (HA-CA-signed) must complete TLS handshake when HA CA is in ClientCAs")
+}
+
+// --- helpers for the cluster-mode HA+admin cert test ---
+
+// makeCommercialTestCA creates an in-memory CA (cert, key, PEM) for test use.
+func makeCommercialTestCA(t *testing.T) (*x509.Certificate, *rsa.PrivateKey, []byte) {
+	t.Helper()
+	caKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	template := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "Test HA CA"},
+		NotBefore:             time.Now(),
+		NotAfter:              time.Now().Add(365 * 24 * time.Hour),
+		IsCA:                  true,
+		BasicConstraintsValid: true,
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
+	}
+	caDER, err := x509.CreateCertificate(rand.Reader, template, template, &caKey.PublicKey, caKey)
+	require.NoError(t, err)
+	caCert, err := x509.ParseCertificate(caDER)
+	require.NoError(t, err)
+	caPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: caDER})
+	return caCert, caKey, caPEM
+}
+
+// makeCommercialTestClientCert creates a client cert signed by certMgr's CA.
+// Uses certMgr.GenerateClientCertificate so the cert is signed by the controller CA.
+func makeCommercialTestClientCert(t *testing.T, certMgr *cert.Manager) tls.Certificate {
+	t.Helper()
+	clientCert, err := certMgr.GenerateClientCertificate(&cert.ClientCertConfig{
+		CommonName:   "test-admin-client",
+		ValidityDays: 1,
+	})
+	require.NoError(t, err)
+
+	tlsCert, err := tls.X509KeyPair(clientCert.CertificatePEM, clientCert.PrivateKeyPEM)
+	require.NoError(t, err)
+	return tlsCert
+}
+
+// makeCommercialTestClientCertFromCA creates a client cert signed by an arbitrary CA.
+func makeCommercialTestClientCertFromCA(t *testing.T, caCert *x509.Certificate, caKey *rsa.PrivateKey) tls.Certificate {
+	t.Helper()
+	leafKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	template := &x509.Certificate{
+		SerialNumber: big.NewInt(2),
+		Subject:      pkix.Name{CommonName: "ha-peer"},
+		NotBefore:    time.Now(),
+		NotAfter:     time.Now().Add(24 * time.Hour),
+		KeyUsage:     x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+	}
+	certDER, err := x509.CreateCertificate(rand.Reader, template, caCert, &leafKey.PublicKey, caKey)
+	require.NoError(t, err)
+
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER})
+	keyPEM := pem.EncodeToMemory(&pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: x509.MarshalPKCS1PrivateKey(leafKey),
+	})
+
+	tlsCert, err := tls.X509KeyPair(certPEM, keyPEM)
+	require.NoError(t, err)
+	return tlsCert
+}
+
+// doTLSHandshake connects to addr with the given client cert, trusting serverTrustPool.
+func doTLSHandshake(t *testing.T, addr string, clientCert tls.Certificate, serverTrustPool *x509.CertPool, msg string) {
+	t.Helper()
+	client := &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{
+				Certificates: []tls.Certificate{clientCert},
+				RootCAs:      serverTrustPool,
+			},
+		},
+	}
+	resp, err := client.Get(addr)
+	require.NoError(t, err, msg)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusOK, resp.StatusCode, msg)
 }

--- a/features/controller/api/server_tls_test.go
+++ b/features/controller/api/server_tls_test.go
@@ -42,26 +42,29 @@ func newMinimalTLSServer(t *testing.T, certMgr *cert.Manager, haManager *ha.Mana
 	}
 }
 
-// TestSetupManagedTLS_NilHAManager_NoClientAuth verifies that when haManager is nil,
-// setupManagedTLS returns a tls.Config with no client auth — non-HA API consumers
-// must not be required or requested to present client certificates.
-func TestSetupManagedTLS_NilHAManager_NoClientAuth(t *testing.T) {
+// TestSetupManagedTLS_RequestsClientCertWhenCertManagerSet verifies that when certManager
+// is non-nil (regardless of HA mode), setupManagedTLS sets ClientAuth = VerifyClientCertIfGiven
+// and populates ClientCAs from the controller CA. This enables mTLS admin cert auth while
+// allowing clients without certs to fall through to API-key auth.
+func TestSetupManagedTLS_RequestsClientCertWhenCertManagerSet(t *testing.T) {
 	certMgr := newTLSTestCertManager(t)
 	server := newMinimalTLSServer(t, certMgr, nil)
 
 	tlsConfig, err := server.setupManagedTLS()
 	require.NoError(t, err)
 	require.NotNil(t, tlsConfig)
-	assert.Equal(t, tls.NoClientCert, tlsConfig.ClientAuth,
-		"nil haManager must not request or require client certificates")
+	assert.Equal(t, tls.VerifyClientCertIfGiven, tlsConfig.ClientAuth,
+		"certManager != nil must set ClientAuth = VerifyClientCertIfGiven: "+
+			"presented certs are chain-verified; missing cert falls through to API-key auth")
+	assert.NotNil(t, tlsConfig.ClientCAs,
+		"ClientCAs must be populated from the controller CA when certManager is set")
 }
 
-// TestSetupManagedTLS_SingleServerMode_NoClientAuth verifies that when haManager is
-// non-nil but configured in SingleServerMode, setupManagedTLS returns a tls.Config
-// with no client auth. This exercises the GetDeploymentMode() != ClusterMode branch
-// (distinct from the nil haManager short-circuit path), ensuring a bug in the mode
-// comparison cannot hide behind the nil check.
-func TestSetupManagedTLS_SingleServerMode_NoClientAuth(t *testing.T) {
+// TestSetupManagedTLS_SingleServerMode_VerifyClientCertIfGiven verifies that when haManager
+// is non-nil but configured in SingleServerMode, setupManagedTLS still sets
+// ClientAuth = VerifyClientCertIfGiven because cert management (not HA mode) is the
+// determining factor. This exercises the GetDeploymentMode() != ClusterMode branch.
+func TestSetupManagedTLS_SingleServerMode_VerifyClientCertIfGiven(t *testing.T) {
 	certMgr := newTLSTestCertManager(t)
 
 	haManager, err := ha.NewManager(ha.DefaultConfig(), logging.NewNoopLogger(), nil)
@@ -72,6 +75,8 @@ func TestSetupManagedTLS_SingleServerMode_NoClientAuth(t *testing.T) {
 	tlsConfig, err := server.setupManagedTLS()
 	require.NoError(t, err)
 	require.NotNil(t, tlsConfig)
-	assert.Equal(t, tls.NoClientCert, tlsConfig.ClientAuth,
-		"SingleServerMode manager must not request or require client certificates")
+	assert.Equal(t, tls.VerifyClientCertIfGiven, tlsConfig.ClientAuth,
+		"SingleServerMode manager must set VerifyClientCertIfGiven (certManager drives the policy)")
+	assert.NotNil(t, tlsConfig.ClientCAs,
+		"ClientCAs must be populated from the controller CA")
 }

--- a/pkg/cert/admin_marker.go
+++ b/pkg/cert/admin_marker.go
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+package cert
+
+import (
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/asn1"
+)
+
+// AdminMarkerOID is the CFGMS-private OID used to mark admin client certificates.
+// Arc: 1.3.6.1.4.1.99999.1.1
+// NOTE: 99999 is a placeholder PEN. Once CFGMS registers a Private Enterprise Number
+// with IANA, replace 99999 with the assigned PEN in all issued certificate templates.
+// The OID byte sequence is the security boundary — certs already issued with this OID
+// require a coordinated rotation when the PEN changes.
+// Follow-up P3 issue: register CFGMS PEN with IANA.
+var AdminMarkerOID = asn1.ObjectIdentifier{1, 3, 6, 1, 4, 1, 99999, 1, 1}
+
+// SetAdminMarker stamps template with the CFGMS admin extension (OID 1.3.6.1.4.1.99999.1.1).
+// A cert bearing this extension, signed by the controller CA, authenticates its holder
+// as a CFGMS admin principal with full API authorization.
+//
+// IMPORTANT — restricted callers (enforced by TestSetAdminMarker_Architecture in architecture_test.go).
+// Do not call from any production path outside the allow-list without PO approval:
+//   - features/controller/initialization/initialization.go (Story B)
+//   - features/controller/initialization/admin_bundle.go  (Story D)
+func SetAdminMarker(template *x509.Certificate) {
+	// ASN.1 DER encoding of boolean TRUE: 0x01 (BOOLEAN) 0x01 (length) 0xFF (TRUE)
+	template.ExtraExtensions = append(template.ExtraExtensions, pkix.Extension{
+		Id:       AdminMarkerOID,
+		Critical: false,
+		Value:    []byte{0x01, 0x01, 0xff},
+	})
+}
+
+// HasAdminMarker reports whether cert carries the CFGMS admin extension.
+// Chain verification is the caller's responsibility — in production this is handled
+// at the TLS handshake layer via tls.VerifyClientCertIfGiven + ClientCAs.
+func HasAdminMarker(cert *x509.Certificate) bool {
+	for _, ext := range cert.Extensions {
+		if ext.Id.Equal(AdminMarkerOID) {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/cert/admin_marker_test.go
+++ b/pkg/cert/admin_marker_test.go
@@ -1,0 +1,144 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+package cert
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/asn1"
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSetAdminMarker_AddsExtension(t *testing.T) {
+	template := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "test"},
+		NotBefore:    time.Now(),
+		NotAfter:     time.Now().Add(24 * time.Hour),
+	}
+
+	SetAdminMarker(template)
+
+	found := false
+	for _, ext := range template.ExtraExtensions {
+		if ext.Id.Equal(AdminMarkerOID) {
+			found = true
+			assert.False(t, ext.Critical, "admin marker must not be critical")
+			assert.Equal(t, []byte{0x01, 0x01, 0xff}, ext.Value, "admin marker value must be ASN.1 DER boolean TRUE")
+			break
+		}
+	}
+	assert.True(t, found, "SetAdminMarker must add the admin marker OID extension")
+}
+
+func TestSetAdminMarker_PreservesExistingExtensions(t *testing.T) {
+	otherOID := asn1.ObjectIdentifier{1, 2, 3, 4}
+	template := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "test"},
+		NotBefore:    time.Now(),
+		NotAfter:     time.Now().Add(24 * time.Hour),
+		ExtraExtensions: []pkix.Extension{
+			{Id: otherOID, Value: []byte{0x00}},
+		},
+	}
+
+	SetAdminMarker(template)
+
+	assert.Len(t, template.ExtraExtensions, 2, "must preserve existing extension")
+	assert.True(t, template.ExtraExtensions[0].Id.Equal(otherOID), "existing extension must remain first")
+}
+
+func TestHasAdminMarker_TrueForMarkedCert(t *testing.T) {
+	cert := makeSignedCert(t, true)
+	assert.True(t, HasAdminMarker(cert), "HasAdminMarker must return true for a cert with admin marker")
+}
+
+func TestHasAdminMarker_FalseForUnmarkedCert(t *testing.T) {
+	cert := makeSignedCert(t, false)
+	assert.False(t, HasAdminMarker(cert), "HasAdminMarker must return false for a cert without admin marker")
+}
+
+func TestHasAdminMarker_FalseForWrongOID(t *testing.T) {
+	wrongOID := asn1.ObjectIdentifier{1, 3, 6, 1, 4, 1, 99999, 1, 2} // sibling OID
+	caKey, caCert := makeTestCA(t)
+
+	leafKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	template := &x509.Certificate{
+		SerialNumber: big.NewInt(3),
+		Subject:      pkix.Name{CommonName: "wrong-oid"},
+		NotBefore:    time.Now(),
+		NotAfter:     time.Now().Add(24 * time.Hour),
+		KeyUsage:     x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+		ExtraExtensions: []pkix.Extension{
+			{Id: wrongOID, Value: []byte{0x01, 0x01, 0xff}},
+		},
+	}
+
+	certDER, err := x509.CreateCertificate(rand.Reader, template, caCert, &leafKey.PublicKey, caKey)
+	require.NoError(t, err)
+	leafCert, err := x509.ParseCertificate(certDER)
+	require.NoError(t, err)
+
+	assert.False(t, HasAdminMarker(leafCert), "HasAdminMarker must return false for cert with wrong OID")
+}
+
+// makeTestCA generates an in-memory CA key and self-signed certificate for tests.
+func makeTestCA(t *testing.T) (caKey *rsa.PrivateKey, caCert *x509.Certificate) {
+	t.Helper()
+	var err error
+	caKey, err = rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	template := &x509.Certificate{
+		SerialNumber:          big.NewInt(100),
+		Subject:               pkix.Name{CommonName: "Test CA"},
+		NotBefore:             time.Now(),
+		NotAfter:              time.Now().Add(365 * 24 * time.Hour),
+		IsCA:                  true,
+		BasicConstraintsValid: true,
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
+	}
+	caDER, err := x509.CreateCertificate(rand.Reader, template, template, &caKey.PublicKey, caKey)
+	require.NoError(t, err)
+	caCert, err = x509.ParseCertificate(caDER)
+	require.NoError(t, err)
+	return
+}
+
+// makeSignedCert creates a CA-signed leaf cert optionally carrying the admin marker.
+func makeSignedCert(t *testing.T, withMarker bool) *x509.Certificate {
+	t.Helper()
+	caKey, caCert := makeTestCA(t)
+
+	leafKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	template := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "test-leaf"},
+		NotBefore:    time.Now(),
+		NotAfter:     time.Now().Add(24 * time.Hour),
+		KeyUsage:     x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+	}
+	if withMarker {
+		SetAdminMarker(template)
+	}
+
+	certDER, err := x509.CreateCertificate(rand.Reader, template, caCert, &leafKey.PublicKey, caKey)
+	require.NoError(t, err)
+	leafCert, err := x509.ParseCertificate(certDER)
+	require.NoError(t, err)
+	return leafCert
+}

--- a/pkg/cert/architecture_test.go
+++ b/pkg/cert/architecture_test.go
@@ -3,7 +3,11 @@
 package cert
 
 import (
+	"bytes"
+	"io/fs"
 	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -232,4 +236,65 @@ func setupTestManager(t *testing.T) *Manager {
 	require.NoError(t, err)
 
 	return manager
+}
+
+// TestSetAdminMarker_Architecture enforces the restricted-caller rule for SetAdminMarker.
+// Any production file outside the allow-list that calls cert.SetAdminMarker fails this test.
+// Test files (_test.go) are excluded — they are test infrastructure, not production code paths.
+func TestSetAdminMarker_Architecture(t *testing.T) {
+	allowList := map[string]bool{
+		// Story B: admin cert issuance during controller initialization
+		"features/controller/initialization/initialization.go": true,
+		// Story D: admin bundle packaging
+		"features/controller/initialization/admin_bundle.go": true,
+	}
+
+	repoRoot := findRepoRoot(t)
+
+	var violations []string
+	err := filepath.WalkDir(repoRoot, func(path string, d fs.DirEntry, err error) error {
+		if err != nil || d.IsDir() {
+			return err
+		}
+		if !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+		content, err := os.ReadFile(path) // #nosec G304 -- repo scan reads controlled source files
+		if err != nil {
+			return nil
+		}
+		if bytes.Contains(content, []byte("cert.SetAdminMarker")) {
+			rel, relErr := filepath.Rel(repoRoot, path)
+			if relErr != nil {
+				rel = path
+			}
+			rel = filepath.ToSlash(rel)
+			if !allowList[rel] {
+				violations = append(violations, rel)
+			}
+		}
+		return nil
+	})
+	require.NoError(t, err)
+
+	assert.Empty(t, violations,
+		"unauthorized production callers of cert.SetAdminMarker; "+
+			"add to allow-list or move to an allowed file: %v", violations)
+}
+
+// findRepoRoot walks up from the working directory to find the repository root (go.mod presence).
+func findRepoRoot(t *testing.T) string {
+	t.Helper()
+	dir, err := os.Getwd()
+	require.NoError(t, err)
+	for {
+		if _, statErr := os.Stat(filepath.Join(dir, "go.mod")); statErr == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Fatal("could not find repo root (go.mod not found)")
+		}
+		dir = parent
+	}
 }


### PR DESCRIPTION
## Summary

- Implements mTLS admin certificate authentication as a second auth path alongside the existing API-key path on the controller REST API (`:9080`)
- Admin certs are identified by a CFGMS-private X.509 extension OID (1.3.6.1.4.1.99999.1.1), not OU=admin — prevents footgun via caller-controlled subject fields
- `setupManagedTLS` now uses `tls.VerifyClientCertIfGiven` with `ClientCAs` populated from the controller CA (+ HA CA in cluster mode), so chain-verified certs reach the middleware while uncerted clients fall through to API-key auth unchanged

## Security constraints

| Constraint | Implementation |
|-----------|---------------|
| C1 — no wildcard permissions | `handleCreateAPIKey` validates against a typed allow-list; `hasPermission` treats `*` as a literal (never matches) |
| H1 — OID extension (not OU) | `pkg/cert/admin_marker.go` defines the OID; architecture test enforces restricted callers |
| H2 — cert identity wins | Admin cert + header credentials → 400 CONFLICTING_CREDENTIALS; cert without marker falls through to API-key auth |
| H3 — audit fields | `auth_method=cert\|api_key`, `cert_serial`, `cert_fingerprint`, `cert_not_after` on all audit entries |

## Specialist review results

**QA Test Runner: PASS** — 127 packages, all tests passing; cross-platform builds pass (linux/amd64, arm64, darwin, windows); lint clean.

**QA Code Reviewer: PASS** — All 10 acceptance criteria tests verified present. Blocking issue found (first pass: "stewards:execute-scripts" typo + missing endpoint validation in server_test.go) was fixed before final PASS.

**Security Engineer: PASS** — 0 blocking issues; gosec/staticcheck/Trivy all pass; C1/H1/H2/H3/audit/TLS minimum all verified.

## Acceptance criteria met

- [x] `pkg/cert/admin_marker.go` defines OID, `SetAdminMarker`, `HasAdminMarker`
- [x] `TestSetupManagedTLS_RequestsClientCertWhenCertManagerSet` — `VerifyClientCertIfGiven` + `ClientCAs != nil`
- [x] `TestSetupManagedTLS_ClusterMode_AdminCertAndHAPeerCertBothVerify` — both CAs in pool, both cert types complete handshake
- [x] Existing `server_tls_test.go` / `server_tls_commercial_test.go` tests updated to assert `VerifyClientCertIfGiven`
- [x] `TestMTLSAuth_AdminMarker_Granted` — admin cert → `IsAdmin == true`
- [x] `TestMTLSAuth_NoMarker_FallsThrough` — cert without marker + valid API key → API-key auth
- [x] `TestMTLSAuth_ConflictingCredentials_Rejected` — admin cert + API key header → 400
- [x] `TestMTLSAuth_NoCert_FallsBackToAPIKey` — no cert + valid API key → API-key path
- [x] `TestHasPermission_AdminPrincipal` — `IsAdmin == true` → `hasPermission` always true
- [x] `TestHasPermission_WildcardStringRejected` — `*` string never grants anything
- [x] `TestHandleCreateAPIKey_RejectsWildcard` — `permissions: ["*"]` → 400
- [x] `TestHandleCreateAPIKey_RejectsUnknownPermission` — unknown ID → 400
- [x] `TestSetAdminMarker_Architecture` — unauthorized callers fail the test
- [x] Audit entries carry `auth_method`, cert fields (cert-auth) or `auth_method=api_key` (key-auth)
- [x] `make test-complete` passes

Fixes #1415

🤖 Generated with [Claude Code](https://claude.com/claude-code)