### PR TITLE
cert/bundle, controller/init: admin bundle issuance during --init (Issue #1416)

### DIFF
--- a/docs/deployment/single-controller/walkthrough.md
+++ b/docs/deployment/single-controller/walkthrough.md
@@ -100,7 +100,7 @@ sudo systemctl daemon-reload
 
 ### Initialize the controller
 
-This is a one-time operation that creates the CA, server certificates, and storage backend:
+This is a one-time operation that creates the CA, server certificates, storage backend, and admin credential bundle:
 
 ```bash
 sudo cfgms-controller --init --config /etc/cfgms/controller.cfg
@@ -109,15 +109,45 @@ sudo cfgms-controller --init --config /etc/cfgms/controller.cfg
 You should see:
 
 ```
-Initializing storage backend... provider=git
+Initializing storage backend... provider=flatfile
 Storage backend initialized
 Creating Certificate Authority... ca_path=/var/lib/cfgms/certs/ca
 Certificate Authority created
+Admin bundle issued path=/etc/cfgms/admin.bundle.yaml serial=<serial>
 Controller initialized successfully
   CA fingerprint: SHA256:xxxx...
 ```
 
 Save the CA fingerprint — stewards verify it during registration.
+
+### Admin credential bundle
+
+`--init` writes an admin credential bundle to `/etc/cfgms/admin.bundle.yaml` (mode `0600`, owned by the `cfgms` daemon user). The bundle contains:
+
+- The admin mTLS client certificate and private key
+- The CA certificate for server verification
+- The controller URL
+- The cert serial number and fingerprint (for revocation lookup)
+
+**Protect this file.** It grants full admin access to the controller REST API. Treat it like a root SSH key.
+
+| Platform | Default path |
+|----------|-------------|
+| Linux    | `/etc/cfgms/admin.bundle.yaml` |
+| Windows  | `%ProgramData%\cfgms\admin.bundle.yaml` |
+
+An idempotency marker is written alongside the bundle at `/etc/cfgms/.admin-bundle-issued`. If `--init` is re-run and the bundle file already exists, issuance is skipped and the existing bundle is preserved.
+
+### Bundle recovery
+
+If the bundle file is accidentally deleted after a successful `--init`, the controller detects this on the next `--init` run and refuses to start:
+
+```
+controller is initialized (CA fingerprint: <fp>) but admin bundle is missing at /etc/cfgms/admin.bundle.yaml.
+To regenerate the bundle, run: cfgms-controller bootstrap-admin --regenerate
+```
+
+Run `cfgms-controller bootstrap-admin --regenerate` to re-issue the admin bundle without reinitializing the CA or storage. (This command is implemented in Story D.)
 
 ### Start the controller
 

--- a/features/controller/config/config.go
+++ b/features/controller/config/config.go
@@ -94,6 +94,11 @@ type Config struct {
 
 	// Transport is the unified, protocol-agnostic transport configuration.
 	Transport *TransportConfig `yaml:"transport"`
+
+	// AdminBundlePath is the path where --init writes the admin credential bundle.
+	// Default: /etc/cfgms/admin.bundle.yaml (Linux) or %ProgramData%\cfgms\admin.bundle.yaml (Windows).
+	// Mode 0600, daemon-user-owned. Contains the admin mTLS cert, key, CA, and controller URL.
+	AdminBundlePath string `yaml:"admin_bundle_path,omitempty"`
 }
 
 // CertificateConfig contains certificate management settings

--- a/features/controller/initialization/bundle_marker.go
+++ b/features/controller/initialization/bundle_marker.go
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+package initialization
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+const bundleMarkerFileName = ".admin-bundle-issued"
+
+// BundleMarker records that the admin bundle has been issued.
+// Written atomically after bundle.Write succeeds.
+type BundleMarker struct {
+	Serial      string
+	Fingerprint string
+	IssuedAt    time.Time
+	BundlePath  string
+}
+
+// defaultAdminBundlePath returns the platform default for the admin bundle file.
+func defaultAdminBundlePath() string {
+	if runtime.GOOS == "windows" {
+		programData := os.Getenv("ProgramData")
+		if programData == "" {
+			programData = `C:\ProgramData`
+		}
+		return filepath.Join(programData, "cfgms", "admin.bundle.yaml")
+	}
+	return "/etc/cfgms/admin.bundle.yaml"
+}
+
+// bundleMarkerPath returns the path for the bundle issuance marker,
+// derived from the bundle file path (same directory, hidden file).
+func bundleMarkerPath(bundlePath string) string {
+	return filepath.Join(filepath.Dir(bundlePath), bundleMarkerFileName)
+}
+
+// isBundleMarkerPresent checks whether the admin bundle issuance marker exists.
+func isBundleMarkerPresent(bundlePath string) bool {
+	_, err := os.Stat(bundleMarkerPath(bundlePath))
+	return err == nil
+}
+
+// readBundleMarker reads and parses the bundle issuance marker file.
+func readBundleMarker(bundlePath string) (*BundleMarker, error) {
+	markerPath := bundleMarkerPath(bundlePath)
+	// #nosec G304 -- controlled path derived from operator-configured bundle path
+	data, err := os.ReadFile(markerPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read bundle marker: %w", err)
+	}
+
+	marker := &BundleMarker{}
+	scanner := bufio.NewScanner(strings.NewReader(string(data)))
+	for scanner.Scan() {
+		line := scanner.Text()
+		parts := strings.SplitN(line, "=", 2)
+		if len(parts) != 2 {
+			continue
+		}
+		key, value := strings.TrimSpace(parts[0]), strings.TrimSpace(parts[1])
+		switch key {
+		case "serial":
+			marker.Serial = value
+		case "fingerprint":
+			marker.Fingerprint = value
+		case "issued_at":
+			t, parseErr := time.Parse(time.RFC3339, value)
+			if parseErr == nil {
+				marker.IssuedAt = t
+			}
+		case "bundle_path":
+			marker.BundlePath = value
+		}
+	}
+	return marker, scanner.Err()
+}
+
+// writeBundleMarker atomically writes the bundle issuance marker file.
+// The marker is written AFTER bundle.Write succeeds, so its presence implies
+// the bundle was successfully created at BundlePath.
+func writeBundleMarker(bundlePath string, marker *BundleMarker) error {
+	markerPath := bundleMarkerPath(bundlePath)
+
+	content := fmt.Sprintf("serial=%s\nfingerprint=%s\nissued_at=%s\nbundle_path=%s\n",
+		marker.Serial,
+		marker.Fingerprint,
+		marker.IssuedAt.UTC().Format(time.RFC3339),
+		marker.BundlePath,
+	)
+
+	tmpPath := markerPath + ".tmp"
+	if err := os.WriteFile(tmpPath, []byte(content), 0600); err != nil {
+		return fmt.Errorf("failed to write bundle marker temp file: %w", err)
+	}
+
+	if err := os.Rename(tmpPath, markerPath); err != nil {
+		_ = os.Remove(tmpPath)
+		return fmt.Errorf("failed to finalize bundle marker: %w", err)
+	}
+
+	return nil
+}

--- a/features/controller/initialization/bundle_marker_test.go
+++ b/features/controller/initialization/bundle_marker_test.go
@@ -1,0 +1,129 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+package initialization
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBundleMarkerPath(t *testing.T) {
+	cases := []struct {
+		bundlePath string
+		wantSuffix string
+	}{
+		{"/etc/cfgms/admin.bundle.yaml", ".admin-bundle-issued"},
+		{"/tmp/test/admin.bundle.yaml", ".admin-bundle-issued"},
+	}
+	for _, tc := range cases {
+		got := bundleMarkerPath(tc.bundlePath)
+		assert.Equal(t, filepath.Join(filepath.Dir(tc.bundlePath), tc.wantSuffix), got)
+	}
+}
+
+func TestIsBundleMarkerPresent_False(t *testing.T) {
+	dir := t.TempDir()
+	bundlePath := filepath.Join(dir, "admin.bundle.yaml")
+	assert.False(t, isBundleMarkerPresent(bundlePath))
+}
+
+func TestIsBundleMarkerPresent_True(t *testing.T) {
+	dir := t.TempDir()
+	bundlePath := filepath.Join(dir, "admin.bundle.yaml")
+	markerPath := bundleMarkerPath(bundlePath)
+	require.NoError(t, os.WriteFile(markerPath, []byte("serial=test\n"), 0600))
+	assert.True(t, isBundleMarkerPresent(bundlePath))
+}
+
+func TestBundleMarker_RoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	bundlePath := filepath.Join(dir, "admin.bundle.yaml")
+
+	now := time.Now().UTC().Truncate(time.Second)
+	original := &BundleMarker{
+		Serial:      "123456789012345678901234567890",
+		Fingerprint: "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+		IssuedAt:    now,
+		BundlePath:  bundlePath,
+	}
+
+	require.NoError(t, writeBundleMarker(bundlePath, original))
+	got, err := readBundleMarker(bundlePath)
+	require.NoError(t, err)
+
+	assert.Equal(t, original.Serial, got.Serial)
+	assert.Equal(t, original.Fingerprint, got.Fingerprint)
+	assert.Equal(t, original.BundlePath, got.BundlePath)
+	assert.Equal(t, now, got.IssuedAt)
+}
+
+func TestBundleMarker_MalformedLines_Skipped(t *testing.T) {
+	dir := t.TempDir()
+	bundlePath := filepath.Join(dir, "admin.bundle.yaml")
+	markerPath := bundleMarkerPath(bundlePath)
+
+	// Lines without '=' are silently skipped
+	content := "not-a-key-value-line\nserial=abc123\n=no-key\n"
+	require.NoError(t, os.WriteFile(markerPath, []byte(content), 0600))
+
+	got, err := readBundleMarker(bundlePath)
+	require.NoError(t, err)
+	assert.Equal(t, "abc123", got.Serial)
+}
+
+func TestBundleMarker_BadTimestamp_ZeroTime(t *testing.T) {
+	dir := t.TempDir()
+	bundlePath := filepath.Join(dir, "admin.bundle.yaml")
+	markerPath := bundleMarkerPath(bundlePath)
+
+	content := "serial=abc\nfingerprint=def\nissued_at=not-a-timestamp\nbundle_path=/tmp/x\n"
+	require.NoError(t, os.WriteFile(markerPath, []byte(content), 0600))
+
+	got, err := readBundleMarker(bundlePath)
+	require.NoError(t, err)
+	assert.True(t, got.IssuedAt.IsZero(), "unparseable timestamp must result in zero time")
+}
+
+func TestBundleMarker_MissingFile_Error(t *testing.T) {
+	dir := t.TempDir()
+	bundlePath := filepath.Join(dir, "admin.bundle.yaml")
+	_, err := readBundleMarker(bundlePath)
+	assert.Error(t, err)
+}
+
+func TestWriteBundleMarker_FileMode(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("file mode bits not enforced on Windows")
+	}
+
+	dir := t.TempDir()
+	bundlePath := filepath.Join(dir, "admin.bundle.yaml")
+	marker := &BundleMarker{
+		Serial:      "test",
+		Fingerprint: "fp",
+		IssuedAt:    time.Now().UTC(),
+		BundlePath:  bundlePath,
+	}
+	require.NoError(t, writeBundleMarker(bundlePath, marker))
+
+	info, err := os.Stat(bundleMarkerPath(bundlePath))
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0600), info.Mode().Perm(), "bundle marker must be mode 0600")
+}
+
+func TestDefaultAdminBundlePath(t *testing.T) {
+	got := defaultAdminBundlePath()
+	assert.NotEmpty(t, got)
+	if runtime.GOOS == "windows" {
+		assert.Contains(t, got, "cfgms")
+		assert.Contains(t, got, "admin.bundle.yaml")
+	} else {
+		assert.Equal(t, "/etc/cfgms/admin.bundle.yaml", got)
+	}
+}

--- a/features/controller/initialization/initialization.go
+++ b/features/controller/initialization/initialization.go
@@ -98,6 +98,11 @@ func Run(cfg *config.Config, logger logging.Logger) (*Result, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize OSS composite storage: %w", err)
 	}
+	defer func() {
+		if cErr := storageManager.Close(); cErr != nil {
+			logger.Error("Failed to close storage manager during initialization", "error", cErr)
+		}
+	}()
 	logger.Info("OSS composite storage backend initialized")
 
 	// Step 2: Create CA and certificates

--- a/features/controller/initialization/initialization.go
+++ b/features/controller/initialization/initialization.go
@@ -13,12 +13,16 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"os/user"
 	"path/filepath"
+	"runtime"
+	"strconv"
 	"time"
 
 	"github.com/cfgis/cfgms/features/controller/config"
 	"github.com/cfgis/cfgms/features/rbac"
 	"github.com/cfgis/cfgms/pkg/cert"
+	"github.com/cfgis/cfgms/pkg/cert/bundle"
 	"github.com/cfgis/cfgms/pkg/logging"
 	"github.com/cfgis/cfgms/pkg/storage/interfaces"
 	_ "github.com/cfgis/cfgms/pkg/storage/providers/flatfile" // register flatfile provider for OSS composite manager
@@ -51,12 +55,25 @@ func Run(cfg *config.Config, logger logging.Logger) (*Result, error) {
 		return nil, fmt.Errorf("certificate CA path is required for initialization (certificate.ca_path)")
 	}
 
+	bundlePath := cfg.AdminBundlePath
+	if bundlePath == "" {
+		bundlePath = defaultAdminBundlePath()
+	}
+
 	// Idempotent guard: refuse if already initialized
 	if IsInitialized(caPath) {
 		existing, err := ReadInitMarker(caPath)
 		if err != nil {
 			return nil, fmt.Errorf("controller is already initialized but marker is unreadable: %w", err)
 		}
+
+		// Check if bundle was issued but bundle file is now missing (external deletion).
+		if isBundleMarkerPresent(bundlePath) && !fileExists(bundlePath) {
+			return nil, fmt.Errorf("controller is initialized (CA fingerprint: %s) but admin bundle is missing at %s.\n"+
+				"To regenerate the bundle, run: cfgms-controller bootstrap-admin --regenerate",
+				existing.CAFingerprint, bundlePath)
+		}
+
 		return nil, fmt.Errorf("controller is already initialized (initialized at %s with CA fingerprint %s). "+
 			"To re-initialize, remove the CA directory at %s and run --init again",
 			existing.InitializedAt.Format(time.RFC3339), existing.CAFingerprint, caPath)
@@ -216,6 +233,16 @@ func Run(cfg *config.Config, logger logging.Logger) (*Result, error) {
 		return nil, fmt.Errorf("failed to write initialization marker: %w", err)
 	}
 
+	// Step 6: Issue admin credential bundle
+	logger.Info("Checking admin bundle...", "path", bundlePath)
+	if fileExists(bundlePath) {
+		logger.Info("Admin bundle already exists, skipping issuance", "path", bundlePath)
+	} else {
+		if err := issueAdminBundle(bundlePath, cfg, certManager, logger); err != nil {
+			return nil, err
+		}
+	}
+
 	logger.Info("Initialization complete",
 		"ca_fingerprint", caInfo.Fingerprint,
 		"storage_provider", cfg.Storage.Provider,
@@ -226,6 +253,94 @@ func Run(cfg *config.Config, logger logging.Logger) (*Result, error) {
 		StorageProvider: cfg.Storage.Provider,
 		InitializedAt:   marker.InitializedAt,
 	}, nil
+}
+
+// issueAdminBundle generates an admin client certificate with the CFGMS admin marker,
+// writes the bundle file, and writes the idempotency marker.
+func issueAdminBundle(bundlePath string, cfg *config.Config, certManager *cert.Manager, logger logging.Logger) error {
+	// Issue an admin client cert with the CFGMS admin X.509 extension.
+	// Subject: CN=cfgms-admin, O=CFGMS (no OU — the extension OID is the identity marker).
+	// Validity: 365 days hard cap (Story D enforces renewal).
+	adminCert, err := certManager.GenerateClientCertificate(&cert.ClientCertConfig{
+		CommonName:       "cfgms-admin",
+		Organization:     "CFGMS",
+		ValidityDays:     365,
+		TemplateModifier: cert.SetAdminMarker,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to issue admin certificate: %w", err)
+	}
+
+	caPEM, err := certManager.GetCACertificate()
+	if err != nil {
+		return fmt.Errorf("failed to get CA certificate PEM: %w", err)
+	}
+
+	controllerURL := cfg.ExternalURL
+
+	b := &bundle.Bundle{
+		CertPEM:         string(adminCert.CertificatePEM),
+		KeyPEM:          string(adminCert.PrivateKeyPEM),
+		CAPEM:           string(caPEM),
+		ControllerURL:   controllerURL,
+		AuditSubject:    "admin:cfgms-admin",
+		CertSerial:      adminCert.SerialNumber,
+		CertFingerprint: adminCert.Fingerprint,
+	}
+
+	if err := bundle.Write(bundlePath, b); err != nil {
+		return fmt.Errorf("failed to write admin bundle: %w", err)
+	}
+
+	// Write the idempotency marker AFTER bundle.Write succeeds.
+	// Marker presence implies the bundle was successfully written at BundlePath.
+	bundleMarker := &BundleMarker{
+		Serial:      adminCert.SerialNumber,
+		Fingerprint: adminCert.Fingerprint,
+		IssuedAt:    time.Now().UTC(),
+		BundlePath:  bundlePath,
+	}
+	if err := writeBundleMarker(bundlePath, bundleMarker); err != nil {
+		return fmt.Errorf("failed to write bundle issuance marker: %w", err)
+	}
+
+	chownBundleFiles(bundlePath, logger)
+
+	logger.Info("Admin bundle issued",
+		"path", bundlePath,
+		"serial", adminCert.SerialNumber)
+	return nil
+}
+
+// chownBundleFiles transfers ownership of the bundle and marker files to the
+// cfgms daemon user on Linux when running as root. No-op on Windows.
+func chownBundleFiles(bundlePath string, logger logging.Logger) {
+	if runtime.GOOS == "windows" {
+		return
+	}
+	if os.Getuid() != 0 {
+		return
+	}
+	u, err := user.Lookup("cfgms")
+	if err != nil {
+		logger.Warn("cfgms user not found, skipping chown on bundle files", "error", err.Error())
+		return
+	}
+	uid, uidErr := strconv.Atoi(u.Uid)
+	if uidErr != nil {
+		logger.Warn("Invalid UID for cfgms user, skipping chown", "uid", u.Uid, "error", uidErr.Error())
+		return
+	}
+	gid, gidErr := strconv.Atoi(u.Gid)
+	if gidErr != nil {
+		logger.Warn("Invalid GID for cfgms user, skipping chown", "gid", u.Gid, "error", gidErr.Error())
+		return
+	}
+	for _, path := range []string{bundlePath, bundleMarkerPath(bundlePath)} {
+		if chownErr := os.Chown(path, uid, gid); chownErr != nil {
+			logger.Warn("Failed to chown bundle file", "path", path, "error", chownErr.Error())
+		}
+	}
 }
 
 // CAFilesExist checks whether the CA certificate and key files exist at the given path.

--- a/features/controller/initialization/initialization_test.go
+++ b/features/controller/initialization/initialization_test.go
@@ -3,22 +3,24 @@
 package initialization
 
 import (
+	"crypto/x509"
+	"encoding/pem"
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/cfgis/cfgms/features/controller/config"
 	"github.com/cfgis/cfgms/pkg/cert"
+	"github.com/cfgis/cfgms/pkg/cert/bundle"
 	"github.com/cfgis/cfgms/pkg/logging"
 )
 
 func TestIsInitialized(t *testing.T) {
-	tempDir, err := os.MkdirTemp("", "init_marker_test")
-	require.NoError(t, err)
-	defer func() { _ = os.RemoveAll(tempDir) }()
+	tempDir := t.TempDir()
 
 	// Not initialized yet
 	assert.False(t, IsInitialized(tempDir))
@@ -30,7 +32,7 @@ func TestIsInitialized(t *testing.T) {
 		StorageProvider:   "git",
 		CAFingerprint:     "test-fingerprint",
 	}
-	err = WriteInitMarker(tempDir, marker)
+	err := WriteInitMarker(tempDir, marker)
 	require.NoError(t, err)
 
 	// Now initialized
@@ -38,9 +40,7 @@ func TestIsInitialized(t *testing.T) {
 }
 
 func TestReadWriteInitMarker(t *testing.T) {
-	tempDir, err := os.MkdirTemp("", "init_marker_rw_test")
-	require.NoError(t, err)
-	defer func() { _ = os.RemoveAll(tempDir) }()
+	tempDir := t.TempDir()
 
 	original := &InitMarker{
 		Version:           1,
@@ -50,7 +50,7 @@ func TestReadWriteInitMarker(t *testing.T) {
 	}
 
 	// Write
-	err = WriteInitMarker(tempDir, original)
+	err := WriteInitMarker(tempDir, original)
 	require.NoError(t, err)
 
 	// Read back
@@ -64,21 +64,17 @@ func TestReadWriteInitMarker(t *testing.T) {
 }
 
 func TestReadInitMarker_NotFound(t *testing.T) {
-	tempDir, err := os.MkdirTemp("", "init_marker_notfound_test")
-	require.NoError(t, err)
-	defer func() { _ = os.RemoveAll(tempDir) }()
+	tempDir := t.TempDir()
 
-	_, err = ReadInitMarker(tempDir)
+	_, err := ReadInitMarker(tempDir)
 	assert.Error(t, err)
 }
 
 func TestCreateLegacyMarker(t *testing.T) {
-	tempDir, err := os.MkdirTemp("", "init_legacy_test")
-	require.NoError(t, err)
-	defer func() { _ = os.RemoveAll(tempDir) }()
+	tempDir := t.TempDir()
 
 	// Create a CA so the fingerprint can be read
-	_, err = cert.NewManager(&cert.ManagerConfig{
+	_, err := cert.NewManager(&cert.ManagerConfig{
 		StoragePath: tempDir,
 		CAConfig: &cert.CAConfig{
 			Organization: "Legacy Test",
@@ -105,12 +101,10 @@ func TestCreateLegacyMarker(t *testing.T) {
 }
 
 func TestCreateLegacyMarker_NoCA(t *testing.T) {
-	tempDir, err := os.MkdirTemp("", "init_legacy_noca_test")
-	require.NoError(t, err)
-	defer func() { _ = os.RemoveAll(tempDir) }()
+	tempDir := t.TempDir()
 
 	// Create legacy marker without CA files — should still succeed with fallback fingerprint
-	err = CreateLegacyMarker(tempDir)
+	err := CreateLegacyMarker(tempDir)
 	require.NoError(t, err)
 
 	marker, err := ReadInitMarker(tempDir)
@@ -119,9 +113,7 @@ func TestCreateLegacyMarker_NoCA(t *testing.T) {
 }
 
 func TestCAFilesExist(t *testing.T) {
-	tempDir, err := os.MkdirTemp("", "ca_files_test")
-	require.NoError(t, err)
-	defer func() { _ = os.RemoveAll(tempDir) }()
+	tempDir := t.TempDir()
 
 	// No files
 	assert.False(t, CAFilesExist(tempDir))
@@ -164,16 +156,16 @@ func TestRollbackTracker_Empty(t *testing.T) {
 }
 
 func TestRun_FullInitialization(t *testing.T) {
-	tempDir, err := os.MkdirTemp("", "init_full_test")
-	require.NoError(t, err)
-	defer func() { _ = os.RemoveAll(tempDir) }()
-
+	tempDir := t.TempDir()
 	caDir := filepath.Join(tempDir, "ca")
+	bundlePath := filepath.Join(tempDir, "admin.bundle.yaml")
 	logger := logging.NewNoopLogger()
 
 	cfg := &config.Config{
-		ListenAddr: "127.0.0.1:0",
-		CertPath:   caDir,
+		ListenAddr:      "127.0.0.1:0",
+		ExternalURL:     "https://controller.test:9080",
+		CertPath:        caDir,
+		AdminBundlePath: bundlePath,
 		Certificate: &config.CertificateConfig{
 			EnableCertManagement:   true,
 			CAPath:                 caDir,
@@ -213,16 +205,16 @@ func TestRun_FullInitialization(t *testing.T) {
 }
 
 func TestRun_AlreadyInitialized(t *testing.T) {
-	tempDir, err := os.MkdirTemp("", "init_already_test")
-	require.NoError(t, err)
-	defer func() { _ = os.RemoveAll(tempDir) }()
-
+	tempDir := t.TempDir()
 	caDir := filepath.Join(tempDir, "ca")
+	bundlePath := filepath.Join(tempDir, "admin.bundle.yaml")
 	logger := logging.NewNoopLogger()
 
 	cfg := &config.Config{
-		ListenAddr: "127.0.0.1:0",
-		CertPath:   caDir,
+		ListenAddr:      "127.0.0.1:0",
+		ExternalURL:     "https://controller.test:9080",
+		CertPath:        caDir,
+		AdminBundlePath: bundlePath,
 		Certificate: &config.CertificateConfig{
 			EnableCertManagement: true,
 			CAPath:               caDir,
@@ -239,7 +231,7 @@ func TestRun_AlreadyInitialized(t *testing.T) {
 	}
 
 	// First init should succeed
-	_, err = Run(cfg, logger)
+	_, err := Run(cfg, logger)
 	require.NoError(t, err)
 
 	// Second init should fail with "already initialized"
@@ -265,4 +257,145 @@ func TestRun_CertManagementDisabled(t *testing.T) {
 	_, err := Run(cfg, logger)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "certificate management must be enabled")
+}
+
+// --- Story B: Required tests ---
+
+// TestInit_ProducesAdminBundle verifies that Run writes an admin bundle with a valid
+// admin-marked certificate, 365-day validity, and the correct subject.
+func TestInit_ProducesAdminBundle(t *testing.T) {
+	tempDir := t.TempDir()
+	caDir := filepath.Join(tempDir, "ca")
+	bundlePath := filepath.Join(tempDir, "admin.bundle.yaml")
+	logger := logging.NewNoopLogger()
+
+	cfg := makeTestConfig(t, tempDir, caDir, bundlePath)
+
+	_, err := Run(cfg, logger)
+	require.NoError(t, err)
+
+	// Bundle file must exist
+	require.FileExists(t, bundlePath)
+
+	b, err := bundle.Read(bundlePath)
+	require.NoError(t, err)
+
+	// Parse the cert from the bundle
+	block, _ := pem.Decode([]byte(b.CertPEM))
+	require.NotNil(t, block, "bundle CertPEM must be valid PEM")
+	x509cert, err := x509.ParseCertificate(block.Bytes)
+	require.NoError(t, err)
+
+	// Must carry the admin marker
+	assert.True(t, cert.HasAdminMarker(x509cert), "admin cert must carry the CFGMS admin marker OID")
+
+	// Validity must be ~365 days (allow 1-day tolerance for test execution time)
+	validity := x509cert.NotAfter.Sub(x509cert.NotBefore)
+	assert.InDelta(t, 365*24*time.Hour, validity, float64(24*time.Hour),
+		"admin cert validity must be 365 days")
+
+	// Subject: CN=cfgms-admin, O=CFGMS
+	assert.Equal(t, "cfgms-admin", x509cert.Subject.CommonName)
+	require.Len(t, x509cert.Subject.Organization, 1)
+	assert.Equal(t, "CFGMS", x509cert.Subject.Organization[0])
+	assert.Empty(t, x509cert.Subject.OrganizationalUnit, "OU must not be set")
+}
+
+// TestInit_BundleSerialMatchesMarker verifies that the idempotency marker's serial= line
+// matches the serial in the bundle file.
+func TestInit_BundleSerialMatchesMarker(t *testing.T) {
+	tempDir := t.TempDir()
+	caDir := filepath.Join(tempDir, "ca")
+	bundlePath := filepath.Join(tempDir, "admin.bundle.yaml")
+	logger := logging.NewNoopLogger()
+
+	cfg := makeTestConfig(t, tempDir, caDir, bundlePath)
+
+	_, err := Run(cfg, logger)
+	require.NoError(t, err)
+
+	b, err := bundle.Read(bundlePath)
+	require.NoError(t, err)
+
+	markerFile, err := readBundleMarker(bundlePath)
+	require.NoError(t, err)
+
+	assert.Equal(t, b.CertSerial, markerFile.Serial,
+		"bundle marker serial= must match bundle CertSerial")
+}
+
+// TestInit_Idempotent_BundleNotOverwritten verifies that if the bundle file already
+// exists when Run is called, it is left untouched.
+func TestInit_Idempotent_BundleNotOverwritten(t *testing.T) {
+	tempDir := t.TempDir()
+	caDir := filepath.Join(tempDir, "ca")
+	bundlePath := filepath.Join(tempDir, "admin.bundle.yaml")
+	logger := logging.NewNoopLogger()
+
+	// Pre-write a sentinel bundle file before initialization
+	sentinel := "sentinel-content-do-not-overwrite"
+	require.NoError(t, os.WriteFile(bundlePath, []byte(sentinel), 0600))
+
+	cfg := makeTestConfig(t, tempDir, caDir, bundlePath)
+
+	_, err := Run(cfg, logger)
+	require.NoError(t, err)
+
+	// The sentinel content must be unchanged
+	got, err := os.ReadFile(bundlePath)
+	require.NoError(t, err)
+	assert.Equal(t, sentinel, string(got), "Run must not overwrite a pre-existing bundle file")
+}
+
+// TestInit_MarkerPresent_BundleMissing_Errors verifies that when the bundle issuance
+// marker is present but the bundle file has been externally deleted, Run returns
+// the operator recovery error pointing at bootstrap-admin --regenerate.
+func TestInit_MarkerPresent_BundleMissing_Errors(t *testing.T) {
+	tempDir := t.TempDir()
+	caDir := filepath.Join(tempDir, "ca")
+	bundlePath := filepath.Join(tempDir, "admin.bundle.yaml")
+	logger := logging.NewNoopLogger()
+
+	cfg := makeTestConfig(t, tempDir, caDir, bundlePath)
+
+	// First run succeeds: writes init marker, bundle, and bundle issuance marker.
+	_, err := Run(cfg, logger)
+	require.NoError(t, err)
+	require.FileExists(t, bundlePath)
+
+	// Simulate external deletion of the bundle file.
+	require.NoError(t, os.Remove(bundlePath))
+
+	// Second run must return the recovery error.
+	_, err = Run(cfg, logger)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "admin bundle is missing at")
+	assert.Contains(t, err.Error(), "bootstrap-admin --regenerate")
+}
+
+// makeTestConfig builds a minimal valid Config for initialization tests using temp dirs.
+func makeTestConfig(t *testing.T, tempDir, caDir, bundlePath string) *config.Config {
+	t.Helper()
+	return &config.Config{
+		ListenAddr:      "127.0.0.1:0",
+		ExternalURL:     "https://controller.test:9080",
+		CertPath:        caDir,
+		AdminBundlePath: bundlePath,
+		Certificate: &config.CertificateConfig{
+			EnableCertManagement: true,
+			CAPath:               caDir,
+			RenewalThresholdDays: 7,
+			Server: &config.ServerCertificateConfig{
+				CommonName:   "test-controller",
+				DNSNames:     []string{"localhost"},
+				IPAddresses:  []string{"127.0.0.1"},
+				Organization: "Test Org",
+			},
+		},
+		Storage: &config.StorageConfig{
+			Provider:     "flatfile",
+			FlatfileRoot: filepath.Join(tempDir, "flatfile"),
+			SQLitePath:   filepath.Join(tempDir, "cfgms.db"),
+		},
+	}
 }

--- a/features/steward/registration/client_http_test.go
+++ b/features/steward/registration/client_http_test.go
@@ -3,6 +3,7 @@
 package registration
 
 import (
+	"encoding/json"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -13,6 +14,31 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// TestRegistrationResponse_JSONFieldNames is a regression guard that ensures
+// the wire format of RegistrationResponse has not changed. The JSON field names
+// client_cert, client_key, and ca_cert are consumed by stewards in production;
+// any rename would silently break existing deployments.
+func TestRegistrationResponse_JSONFieldNames(t *testing.T) {
+	resp := RegistrationResponse{
+		ClientCert: "cert-pem",
+		ClientKey:  "key-pem",
+		CACert:     "ca-pem",
+	}
+
+	data, err := json.Marshal(resp)
+	require.NoError(t, err)
+
+	var raw map[string]interface{}
+	require.NoError(t, json.Unmarshal(data, &raw))
+
+	assert.Contains(t, raw, "client_cert", "wire field client_cert must not be renamed")
+	assert.Contains(t, raw, "client_key", "wire field client_key must not be renamed")
+	assert.Contains(t, raw, "ca_cert", "wire field ca_cert must not be renamed")
+	assert.Equal(t, "cert-pem", raw["client_cert"])
+	assert.Equal(t, "key-pem", raw["client_key"])
+	assert.Equal(t, "ca-pem", raw["ca_cert"])
+}
 
 func TestNewHTTPClientAlwaysVerifiesTLS(t *testing.T) {
 	logger := logging.NewLogger("debug")

--- a/pkg/cert/bundle/bundle.go
+++ b/pkg/cert/bundle/bundle.go
@@ -12,6 +12,7 @@ package bundle
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 
 	"gopkg.in/yaml.v3"
 )
@@ -28,8 +29,13 @@ type Bundle struct {
 }
 
 // Write serializes b to YAML and atomically writes it to path with mode 0600.
+// The parent directory is created with mode 0700 if it does not exist.
 // The caller is responsible for chown on Linux if daemon-user ownership is required.
 func Write(path string, b *Bundle) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
+		return fmt.Errorf("failed to create bundle directory: %w", err)
+	}
+
 	data, err := yaml.Marshal(b)
 	if err != nil {
 		return fmt.Errorf("failed to marshal bundle: %w", err)

--- a/pkg/cert/bundle/bundle.go
+++ b/pkg/cert/bundle/bundle.go
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+
+// Package bundle provides read/write support for the CFGMS admin credential bundle.
+//
+// The bundle file (admin.bundle.yaml, mode 0600) contains everything the cfg CLI
+// needs to authenticate as a CFGMS admin: the mTLS client certificate and key,
+// the CA certificate for server verification, the controller URL, an audit subject,
+// and identifiers for revocation lookup.
+package bundle
+
+import (
+	"fmt"
+	"os"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Bundle holds the contents of an admin credential bundle file.
+type Bundle struct {
+	CertPEM         string `yaml:"cert_pem"`
+	KeyPEM          string `yaml:"key_pem"`
+	CAPEM           string `yaml:"ca_pem"`
+	ControllerURL   string `yaml:"controller_url"`
+	AuditSubject    string `yaml:"audit_subject"`
+	CertSerial      string `yaml:"cert_serial"`
+	CertFingerprint string `yaml:"cert_fingerprint"`
+}
+
+// Write serializes b to YAML and atomically writes it to path with mode 0600.
+// The caller is responsible for chown on Linux if daemon-user ownership is required.
+func Write(path string, b *Bundle) error {
+	data, err := yaml.Marshal(b)
+	if err != nil {
+		return fmt.Errorf("failed to marshal bundle: %w", err)
+	}
+
+	tmpPath := path + ".tmp"
+	if err := os.WriteFile(tmpPath, data, 0600); err != nil {
+		return fmt.Errorf("failed to write bundle temp file: %w", err)
+	}
+
+	if err := os.Rename(tmpPath, path); err != nil {
+		_ = os.Remove(tmpPath)
+		return fmt.Errorf("failed to finalize bundle file: %w", err)
+	}
+
+	return nil
+}
+
+// Read parses the YAML bundle at path and returns the Bundle.
+func Read(path string) (*Bundle, error) {
+	// #nosec G304 -- caller-controlled path; bundle files live under /etc/cfgms (root-owned)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read bundle: %w", err)
+	}
+
+	var b Bundle
+	if err := yaml.Unmarshal(data, &b); err != nil {
+		return nil, fmt.Errorf("failed to parse bundle: %w", err)
+	}
+
+	return &b, nil
+}

--- a/pkg/cert/bundle/bundle_test.go
+++ b/pkg/cert/bundle/bundle_test.go
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+package bundle
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBundle_RoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "admin.bundle.yaml")
+
+	original := &Bundle{
+		CertPEM:         "-----BEGIN CERTIFICATE-----\nMIItest\n-----END CERTIFICATE-----\n",
+		KeyPEM:          "-----BEGIN RSA PRIVATE KEY-----\nkeydata\n-----END RSA PRIVATE KEY-----\n",
+		CAPEM:           "-----BEGIN CERTIFICATE-----\ncadata\n-----END CERTIFICATE-----\n",
+		ControllerURL:   "https://controller.example.com:9080",
+		AuditSubject:    "admin:cfgms-admin",
+		CertSerial:      "12345678901234567890",
+		CertFingerprint: "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+	}
+
+	require.NoError(t, Write(path, original))
+
+	got, err := Read(path)
+	require.NoError(t, err)
+
+	assert.Equal(t, original.CertPEM, got.CertPEM)
+	assert.Equal(t, original.KeyPEM, got.KeyPEM)
+	assert.Equal(t, original.CAPEM, got.CAPEM)
+	assert.Equal(t, original.ControllerURL, got.ControllerURL)
+	assert.Equal(t, original.AuditSubject, got.AuditSubject)
+	assert.Equal(t, original.CertSerial, got.CertSerial)
+	assert.Equal(t, original.CertFingerprint, got.CertFingerprint)
+}
+
+func TestBundle_FileMode(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("file mode bits not enforced on Windows")
+	}
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "admin.bundle.yaml")
+
+	require.NoError(t, Write(path, &Bundle{AuditSubject: "admin:cfgms-admin"}))
+
+	info, err := os.Stat(path)
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0600), info.Mode().Perm(), "bundle file must be mode 0600")
+}
+
+func TestBundle_Read_MissingFile(t *testing.T) {
+	_, err := Read(filepath.Join(t.TempDir(), "nonexistent.yaml"))
+	assert.Error(t, err)
+}
+
+func TestBundle_Read_MalformedYAML(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "bad.yaml")
+	require.NoError(t, os.WriteFile(path, []byte("not: valid: yaml: [\n"), 0600))
+
+	_, err := Read(path)
+	assert.Error(t, err)
+}

--- a/pkg/cert/bundle/bundle_test.go
+++ b/pkg/cert/bundle/bundle_test.go
@@ -55,6 +55,32 @@ func TestBundle_FileMode(t *testing.T) {
 	assert.Equal(t, os.FileMode(0600), info.Mode().Perm(), "bundle file must be mode 0600")
 }
 
+func TestBundle_Write_CreatesParentDirectory(t *testing.T) {
+	// Verify Write creates intermediate directories that do not yet exist.
+	// This is the regression test for the CI failure where /etc/cfgms/ was absent.
+	path := filepath.Join(t.TempDir(), "nested", "subdir", "admin.bundle.yaml")
+
+	require.NoError(t, Write(path, &Bundle{AuditSubject: "admin:cfgms-admin"}))
+
+	_, err := os.Stat(path)
+	require.NoError(t, err, "bundle file must exist after Write to nested path")
+}
+
+func TestBundle_Write_InvalidDirectory_Error(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("os.MkdirAll path-as-file behavior differs on Windows")
+	}
+	// Create a regular file and then try to use it as a directory component.
+	// MkdirAll fails with ENOTDIR, which Write must surface.
+	dir := t.TempDir()
+	blockingFile := filepath.Join(dir, "notadir")
+	require.NoError(t, os.WriteFile(blockingFile, []byte("x"), 0600))
+
+	path := filepath.Join(blockingFile, "admin.bundle.yaml")
+	err := Write(path, &Bundle{AuditSubject: "admin:cfgms-admin"})
+	assert.Error(t, err, "Write must return error when parent directory cannot be created")
+}
+
 func TestBundle_Read_MissingFile(t *testing.T) {
 	_, err := Read(filepath.Join(t.TempDir(), "nonexistent.yaml"))
 	assert.Error(t, err)

--- a/pkg/cert/ca.go
+++ b/pkg/cert/ca.go
@@ -343,17 +343,25 @@ func (ca *CA) GenerateClientCertificate(config *ClientCertConfig) (*Certificate,
 	}
 
 	// Create client certificate template
+	subject := pkix.Name{
+		Organization: []string{config.Organization},
+		CommonName:   config.CommonName,
+	}
+	if config.OrganizationalUnit != "" {
+		subject.OrganizationalUnit = []string{config.OrganizationalUnit}
+	}
+
 	template := &x509.Certificate{
 		SerialNumber: serialNumber,
-		Subject: pkix.Name{
-			Organization:       []string{config.Organization},
-			OrganizationalUnit: []string{config.OrganizationalUnit},
-			CommonName:         config.CommonName,
-		},
-		NotBefore:   time.Now(),
-		NotAfter:    time.Now().Add(time.Duration(config.ValidityDays) * 24 * time.Hour),
-		KeyUsage:    x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
-		ExtKeyUsage: []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+		Subject:      subject,
+		NotBefore:    time.Now(),
+		NotAfter:     time.Now().Add(time.Duration(config.ValidityDays) * 24 * time.Hour),
+		KeyUsage:     x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+	}
+
+	if config.TemplateModifier != nil {
+		config.TemplateModifier(template)
 	}
 
 	// Create the client certificate

--- a/pkg/cert/types.go
+++ b/pkg/cert/types.go
@@ -41,6 +41,7 @@
 package cert
 
 import (
+	"crypto/x509"
 	"time"
 )
 
@@ -168,6 +169,10 @@ type ClientCertConfig struct {
 
 	// Client identifier for tracking
 	ClientID string
+
+	// TemplateModifier is an optional function applied to the certificate template
+	// before signing. Pass SetAdminMarker (from the cert package) to issue admin certificates.
+	TemplateModifier func(*x509.Certificate)
 }
 
 // Certificate represents a generated certificate with its metadata

--- a/test/integration/configs/controller-test.cfg
+++ b/test/integration/configs/controller-test.cfg
@@ -7,6 +7,9 @@
 # Certificate storage path (cert manager stores CA at cert_path/ca/, certs at cert_path/{serial}/)
 cert_path: "./test/integration/transport/certs"
 
+# Admin bundle path for --init (avoids writing to /etc/cfgms in non-root CI environments)
+admin_bundle_path: "./test/integration/transport/certs/admin.bundle.yaml"
+
 # Certificate management with auto-generation
 certificate:
   enable_cert_management: true

--- a/test/integration/testutil/test_helper.go
+++ b/test/integration/testutil/test_helper.go
@@ -131,10 +131,11 @@ func createTestEnv(t *testing.T, tempDir string, logger *testpkg.MockLogger, ctx
 	require.NoError(t, err)
 
 	controllerCfg := &config.Config{
-		ListenAddr: "127.0.0.1:0",   // Use random port
-		CertPath:   certStoragePath, // Legacy cert path for backward compatibility
-		DataDir:    filepath.Join(tempDir, "controller-data"),
-		LogLevel:   "debug",
+		ListenAddr:      "127.0.0.1:0",   // Use random port
+		CertPath:        certStoragePath, // Legacy cert path for backward compatibility
+		DataDir:         filepath.Join(tempDir, "controller-data"),
+		LogLevel:        "debug",
+		AdminBundlePath: filepath.Join(tempDir, "admin.bundle.yaml"),
 		Storage: &config.StorageConfig{
 			Provider:     "flatfile",
 			FlatfileRoot: filepath.Join(tempDir, "storage-flatfile"),


### PR DESCRIPTION
## Summary

- Adds `pkg/cert/bundle` package with `Bundle` struct (YAML), atomic `Write` (mode 0600), and `Read` functions
- Extends `--init` to issue an admin client certificate (CN=cfgms-admin, O=CFGMS, 365-day validity) carrying the CFGMS admin marker OID and write it as a YAML bundle file
- Writes an idempotency marker (`.admin-bundle-issued`) after the bundle succeeds; re-runs skip issuance when bundle already exists
- Extends the already-initialized guard: marker present + bundle file missing → operator recovery error pointing at `bootstrap-admin --regenerate`
- Adds `TemplateModifier func(*x509.Certificate)` hook to `ClientCertConfig` so `--init` can inject the admin marker before signing without violating the architecture allow-list
- Fixes OU-set-when-empty bug in `GenerateClientCertificate` (was creating `[""]` instead of omitting the field)
- Adds `AdminBundlePath` to controller `Config`; integration test helper routes bundle writes to `t.TempDir()`
- Adds JSON regression guard for `RegistrationResponse` wire format
- Updates deployment walkthrough with bundle path table, ownership, and recovery procedure

## Test plan

- [x] `TestInit_ProducesAdminBundle` — bundle exists, cert carries admin marker OID, 365-day validity, correct subject
- [x] `TestInit_BundleSerialMatchesMarker` — marker `serial=` matches `CertSerial` in bundle
- [x] `TestInit_Idempotent_BundleNotOverwritten` — pre-existing bundle file is left untouched
- [x] `TestInit_MarkerPresent_BundleMissing_Errors` — recovery error returned when bundle externally deleted
- [x] `TestBundle_RoundTrip`, `TestBundle_FileMode`, `TestBundle_Read_MissingFile`, `TestBundle_Read_MalformedYAML`
- [x] 9 bundle marker tests (path derivation, round-trip, malformed input, bad timestamp, missing file, file mode, default path)
- [x] `TestRegistrationResponse_JSONFieldNames` — JSON wire format regression guard
- [x] `make test` — 62/62 tests pass (pkg/cert, pkg/cert/bundle, initialization, steward/registration, integration)
- [x] QA Test Runner: PASS
- [x] QA Code Reviewer: PASS (0 blocking issues)

Fixes #1416

🤖 Generated with [Claude Code](https://claude.ai/claude-code)