### PR TITLE
cert/admin: bootstrap-admin command and revocation primitive (Issue #1418)

### DIFF
--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cfgis/cfgms/features/controller/config"
 	"github.com/cfgis/cfgms/features/controller/initialization"
 	"github.com/cfgis/cfgms/features/controller/server"
+	certpkg "github.com/cfgis/cfgms/pkg/cert"
 	"github.com/cfgis/cfgms/pkg/logging"
 	secretsif "github.com/cfgis/cfgms/pkg/secrets/interfaces"
 	"github.com/cfgis/cfgms/pkg/version"
@@ -71,6 +72,7 @@ Entry paths:
 		buildInstallCommand(),
 		buildUninstallCommand(),
 		buildStatusCommand(),
+		buildBootstrapAdminCommand(),
 	)
 
 	return root
@@ -411,6 +413,174 @@ func resolveInstallCAPath(cfg *config.Config, configPath string) (string, error)
 		return "", fmt.Errorf("certificate configuration is required for initialization; set certificate.ca_path in %s", configPath)
 	}
 	return cfg.Certificate.CAPath, nil
+}
+
+// buildBootstrapAdminCommand builds the `cfgms-controller bootstrap-admin` subcommand.
+// Exactly one of --name, --regenerate, --revoke, or --list must be specified.
+func buildBootstrapAdminCommand() *cobra.Command {
+	var (
+		configPath string
+		name       string
+		outputPath string
+		regenerate bool
+		revoke     string
+		list       bool
+	)
+
+	cmd := &cobra.Command{
+		Use:   "bootstrap-admin",
+		Short: "Issue, regenerate, or revoke admin credential bundles",
+		Long: `bootstrap-admin manages admin mTLS credential bundles for the CFGMS controller.
+
+Each bundle contains the admin client certificate, key, CA certificate, and controller
+URL. The holder of a bundle can authenticate to the controller REST API as a full admin.
+
+Operations:
+  --name <name> --output <path>   Issue a new bundle for a named operator or system.
+                                  Name must be alphanumeric+hyphens, max 64 chars.
+  --regenerate                    Regenerate the system admin bundle at the configured
+                                  path. Requires interactive confirmation (type 'yes').
+                                  After regenerating, revoke the old bundle serial:
+                                    cfgms-controller bootstrap-admin --revoke <old-serial>
+  --revoke <serial>               Revoke a previously-issued bundle by serial number.
+                                  The serial is printed at issuance time and stored in
+                                  the bundle file (cert_serial field).
+  --list                          List all issued and revoked admin certs.
+
+Bundles are written with mode 0600. Treat them like root SSH keys.`,
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runBootstrapAdmin(configPath, name, outputPath, regenerate, revoke, list)
+		},
+	}
+
+	cmd.Flags().StringVar(&configPath, "config", "", "Path to configuration file (default: search /etc/cfgms/controller.cfg)")
+	cmd.Flags().StringVar(&name, "name", "", "Operator or system name for the new bundle (alphanumeric+hyphens, max 64)")
+	cmd.Flags().StringVar(&outputPath, "output", "", "Output path for the bundle file (required with --name)")
+	cmd.Flags().BoolVar(&regenerate, "regenerate", false, "Regenerate the system admin bundle (requires confirmation)")
+	cmd.Flags().StringVar(&revoke, "revoke", "", "Revoke a bundle by serial number")
+	cmd.Flags().BoolVar(&list, "list", false, "List all issued and revoked admin certs")
+
+	return cmd
+}
+
+// runBootstrapAdmin executes the bootstrap-admin operation.
+func runBootstrapAdmin(configPath, name, outputPath string, regenerate bool, revoke string, list bool) error {
+	// Exactly one operation must be specified.
+	active := 0
+	if name != "" {
+		active++
+	}
+	if regenerate {
+		active++
+	}
+	if revoke != "" {
+		active++
+	}
+	if list {
+		active++
+	}
+	if active == 0 {
+		return fmt.Errorf("one of --name, --regenerate, --revoke, or --list is required")
+	}
+	if active > 1 {
+		return fmt.Errorf("only one of --name, --regenerate, --revoke, or --list may be specified at a time")
+	}
+	if name != "" && outputPath == "" {
+		return fmt.Errorf("--output is required with --name")
+	}
+
+	cfg, err := config.LoadWithPath(configPath)
+	if err != nil {
+		return fmt.Errorf("failed to load configuration: %w", err)
+	}
+
+	logger := logging.NewNoopLogger()
+
+	switch {
+	case name != "":
+		if err := initialization.IssueAdminBundle(cfg, logger, name, outputPath); err != nil {
+			return err
+		}
+		fmt.Printf("Admin bundle issued: %s\n", outputPath)
+		return nil
+
+	case regenerate:
+		return initialization.RunRegenerate(cfg, logger, os.Stdin, os.Stdout)
+
+	case revoke != "":
+		if err := initialization.RevokeAdminBundle(cfg, logger, revoke); err != nil {
+			return err
+		}
+		fmt.Printf("Bundle revoked: serial=%s\n", revoke)
+		return nil
+
+	case list:
+		return runBootstrapAdminList(cfg)
+	}
+
+	return nil
+}
+
+// runBootstrapAdminList prints all issued admin certs and their revocation status.
+func runBootstrapAdminList(cfg *config.Config) error {
+	certPath := cfg.CertPath
+	if certPath == "" && cfg.Certificate != nil {
+		certPath = cfg.Certificate.CAPath
+	}
+	if certPath == "" {
+		return fmt.Errorf("certificate path not configured (cert_path or certificate.ca_path required)")
+	}
+
+	certManager, err := certpkg.NewManager(&certpkg.ManagerConfig{
+		StoragePath:    certPath,
+		LoadExistingCA: true,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to load cert manager: %w", err)
+	}
+
+	certs, err := certManager.GetCertificatesByType(certpkg.CertificateTypeClient)
+	if err != nil {
+		return fmt.Errorf("failed to list certificates: %w", err)
+	}
+
+	revoked, err := certManager.ListRevoked()
+	if err != nil {
+		return fmt.Errorf("failed to list revoked serials: %w", err)
+	}
+
+	revokedSet := make(map[string]bool, len(revoked))
+	for _, e := range revoked {
+		revokedSet[e.Serial] = true
+	}
+
+	fmt.Printf("%-20s  %-30s  %-12s  %s\n", "SERIAL (last 12)", "COMMON NAME", "STATUS", "EXPIRES")
+	fmt.Printf("%s\n", strings.Repeat("-", 80))
+	for _, c := range certs {
+		status := "active"
+		if revokedSet[c.SerialNumber] {
+			status = "REVOKED"
+		}
+		short := c.SerialNumber
+		if len(short) > 12 {
+			short = "..." + short[len(short)-12:]
+		}
+		fmt.Printf("%-20s  %-30s  %-12s  %s\n",
+			short,
+			truncate(c.CommonName, 30),
+			status,
+			c.ExpiresAt.Format("2006-01-02"),
+		)
+	}
+	return nil
+}
+
+func truncate(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n-3] + "..."
 }
 
 // buildLoggingConfig constructs a complete LoggingConfig for the given component.

--- a/cmd/controller/main_test.go
+++ b/cmd/controller/main_test.go
@@ -39,6 +39,7 @@ func TestBuildRootCommand(t *testing.T) {
 	assert.Contains(t, names, "install")
 	assert.Contains(t, names, "uninstall")
 	assert.Contains(t, names, "status")
+	assert.Contains(t, names, "bootstrap-admin")
 }
 
 func TestBuildRootCommandFlags(t *testing.T) {
@@ -385,4 +386,29 @@ func TestRunControllerSignalPath(t *testing.T) {
 		t.Fatal("runControllerServer did not return after signal")
 	}
 	assert.Len(t, srv.stopCalled, 1, "Stop() must be called exactly once")
+}
+
+func TestRunBootstrapAdmin_RequiresOneOperation(t *testing.T) {
+	err := runBootstrapAdmin("", "", "", false, "", false)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--name, --regenerate, --revoke, or --list is required")
+}
+
+func TestRunBootstrapAdmin_RejectsMultipleOperations(t *testing.T) {
+	err := runBootstrapAdmin("", "alice", "", false, "some-serial", false)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "only one of")
+}
+
+func TestRunBootstrapAdmin_RequiresOutputWithName(t *testing.T) {
+	err := runBootstrapAdmin("", "alice", "", false, "", false)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--output is required with --name")
+}
+
+func TestRunBootstrapAdminList_RequiresCertPath(t *testing.T) {
+	// A config with no cert path must return an error rather than panic.
+	err := runBootstrapAdminList(&config.Config{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "certificate path not configured")
 }

--- a/docs/deployment/single-controller/walkthrough.md
+++ b/docs/deployment/single-controller/walkthrough.md
@@ -268,6 +268,69 @@ sudo cfgms-steward --config /etc/cfgms/controller-steward.cfg 2>&1 | grep -i err
 | Package install fails | No internet or package manager issue | `sudo apt update` and retry |
 | Firewall module fails | `ufw` or `iptables` not available | Install your distro's firewall tooling |
 
+## Adding Operators
+
+After initialization, you can issue additional admin credential bundles for team members
+or automation systems. Each bundle grants full admin access to the controller REST API.
+
+```bash
+sudo cfgms-controller bootstrap-admin \
+  --config /etc/cfgms/controller.cfg \
+  --name alice \
+  --output /etc/cfgms/alice.bundle.yaml
+```
+
+Copy `alice.bundle.yaml` to the operator securely (treat it like a root SSH key). The
+bundle contains the mTLS client certificate and key, the CA certificate, and the
+controller URL.
+
+**Name rules:** Alphanumeric characters and hyphens only, max 64 characters. Names must
+not begin or end with a hyphen. The following names are reserved and will be rejected:
+`system`, `cfgms`, `cfgms-internal`, `cfgms-admin`, and any UUID-format string (reserved
+for steward certificates).
+
+**Validity:** Admin certificates are valid for 365 days. When a bundle expires, issue a
+new one and revoke the old serial.
+
+### Listing bundles
+
+```bash
+cfgms-controller bootstrap-admin --config /etc/cfgms/controller.cfg --list
+```
+
+This shows all issued admin certs with their serial numbers and revocation status.
+
+## Revoking Access
+
+When an operator leaves, a machine is decommissioned, or a bundle is compromised,
+revoke the cert immediately using the serial number printed at issuance time (also
+stored in the bundle file under `cert_serial`).
+
+```bash
+cfgms-controller bootstrap-admin \
+  --config /etc/cfgms/controller.cfg \
+  --revoke <serial>
+```
+
+The revocation takes effect immediately — the serial is added to the persistent
+revoked-serials list and all subsequent authentication attempts with that cert are
+rejected with `CERT_REVOKED`.
+
+**After regenerating the system bundle**, also revoke the old serial:
+
+```bash
+# Step 1: note the old serial from the current bundle
+OLD_SERIAL=$(grep cert_serial /etc/cfgms/admin.bundle.yaml | awk '{print $2}')
+
+# Step 2: regenerate (follow the interactive confirmation)
+sudo cfgms-controller bootstrap-admin --config /etc/cfgms/controller.cfg --regenerate
+
+# Step 3: revoke the old bundle
+sudo cfgms-controller bootstrap-admin \
+  --config /etc/cfgms/controller.cfg \
+  --revoke "$OLD_SERIAL"
+```
+
 ## Next Steps
 
 - **Connect stewards**: Create a registration token and deploy stewards to your endpoints.

--- a/features/controller/api/middleware.go
+++ b/features/controller/api/middleware.go
@@ -135,15 +135,22 @@ func (s *Server) contentTypeMiddleware(next http.Handler) http.Handler {
 }
 
 // extractAdminPrincipal inspects r.TLS.PeerCertificates[0] for the CFGMS admin extension.
-// Returns a non-nil *Principal when the cert carries the admin marker. Chain verification
-// is done at the TLS layer (VerifyClientCertIfGiven + ClientCAs); this function only checks
-// the extension. Returns nil when no cert is presented or the cert lacks the admin marker.
-func extractAdminPrincipal(r *http.Request) *Principal {
+// Returns a non-nil *Principal when the cert carries the admin marker AND is not revoked.
+// Chain verification is done at the TLS layer (VerifyClientCertIfGiven + ClientCAs).
+// Returns nil when no cert is presented, the cert lacks the admin marker, or the cert
+// serial is in the revoked-serials list (Story D: C2 fix).
+func (s *Server) extractAdminPrincipal(r *http.Request) *Principal {
 	if r.TLS == nil || len(r.TLS.PeerCertificates) == 0 {
 		return nil
 	}
 	peerCert := r.TLS.PeerCertificates[0]
 	if !cert.HasAdminMarker(peerCert) {
+		return nil
+	}
+	serial := peerCert.SerialNumber.String()
+	// Story D: C2 fix — check revocation on every cert-auth request.
+	// certManager may be nil in OSS deployments that haven't initialised cert management.
+	if s.certManager != nil && s.certManager.IsRevoked(serial) {
 		return nil
 	}
 	fpSum := sha256.Sum256(peerCert.Raw)
@@ -152,7 +159,7 @@ func extractAdminPrincipal(r *http.Request) *Principal {
 		Name:            "mtls-admin:" + peerCert.Subject.CommonName,
 		IsAdmin:         true,
 		TenantID:        "default",
-		CertSerial:      peerCert.SerialNumber.String(),
+		CertSerial:      serial,
 		CertFingerprint: hex.EncodeToString(fpSum[:]),
 		CertNotAfter:    peerCert.NotAfter,
 	}
@@ -191,7 +198,7 @@ func (s *Server) authenticationMiddleware(next http.Handler) http.Handler {
 		}
 
 		// H2: mTLS-presented identity always wins.
-		if adminPrincipal := extractAdminPrincipal(r); adminPrincipal != nil {
+		if adminPrincipal := s.extractAdminPrincipal(r); adminPrincipal != nil {
 			// H2/L5: Conflicting credentials — cert AND header present → reject.
 			if hasHeaderCredentials(r) {
 				s.writeErrorResponse(w, http.StatusBadRequest,

--- a/features/controller/api/middleware_test.go
+++ b/features/controller/api/middleware_test.go
@@ -9,6 +9,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"crypto/x509/pkix"
+	"encoding/pem"
 	"fmt"
 	"math/big"
 	"net/http"
@@ -21,9 +22,15 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/cfgis/cfgms/features/controller/config"
+	"github.com/cfgis/cfgms/features/controller/service"
+	"github.com/cfgis/cfgms/features/rbac"
+	"github.com/cfgis/cfgms/features/tenant"
+	"github.com/cfgis/cfgms/pkg/audit"
 	"github.com/cfgis/cfgms/pkg/cert"
 	"github.com/cfgis/cfgms/pkg/ctxkeys"
 	"github.com/cfgis/cfgms/pkg/logging"
+	pkgtesting "github.com/cfgis/cfgms/pkg/testing"
 )
 
 // auditCapturingLogger records Info and Warn calls for audit log assertions.
@@ -623,4 +630,125 @@ func TestMTLSAuth_AuditFields_APIKeyAuth(t *testing.T) {
 
 	assert.Equal(t, http.StatusOK, rec.Code)
 	assert.Equal(t, "api_key", capLog.kvValue("auth_method"), "API-key auth must log auth_method=api_key")
+}
+
+// setupTestServerWithCertMgr creates a test server wired with a real cert.Manager
+// so that extractAdminPrincipal can check the revocation list.
+func setupTestServerWithCertMgr(t *testing.T, certManager *cert.Manager) *Server {
+	t.Helper()
+	t.Setenv("CFGMS_SECRETS_REPO_PATH", t.TempDir())
+
+	cfg := config.DefaultConfig()
+	cfg.Certificate.EnableCertManagement = false
+
+	storageManager := pkgtesting.SetupTestStorage(t)
+	rbacManager := rbac.NewManagerWithStorage(
+		storageManager.GetAuditStore(),
+		storageManager.GetClientTenantStore(),
+		storageManager.GetRBACStore(),
+	)
+	require.NoError(t, rbacManager.Initialize(context.Background()))
+	t.Cleanup(func() {
+		closeCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_ = rbacManager.Close(closeCtx)
+	})
+
+	tenantStore := tenant.NewStorageAdapter(storageManager.GetTenantStore())
+	tenantManager := tenant.NewManager(tenantStore, rbacManager)
+	controllerService := service.NewControllerService(logging.NewNoopLogger())
+	configService := service.NewConfigurationServiceV2(logging.NewNoopLogger(), storageManager, controllerService)
+	rbacService := service.NewRBACService(rbacManager)
+
+	auditMgr, err := audit.NewManager(storageManager.GetAuditStore(), "controller")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = auditMgr.Stop(context.Background()) })
+
+	server, err := New(
+		cfg, logging.NewNoopLogger(),
+		controllerService, configService,
+		nil, rbacService, certManager, tenantManager, rbacManager,
+		nil, nil, nil, "", nil, auditMgr, nil, nil,
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		closeCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		if err := server.Close(closeCtx); err != nil {
+			t.Errorf("server.Close: %v", err)
+		}
+	})
+	return server
+}
+
+// issueCertAndBuildRequest issues a cert via certManager (storing it so Revoke can find it),
+// applies the admin marker, and builds a TLS request presenting that cert.
+// Returns the request and the cert serial number for revocation tests.
+func issueCertAndBuildRequest(t *testing.T, method, path string, certManager *cert.Manager) (*http.Request, string) {
+	t.Helper()
+
+	issuedCert, err := certManager.GenerateClientCertificate(&cert.ClientCertConfig{
+		CommonName:       "test-admin-revoke",
+		Organization:     "CFGMS",
+		ValidityDays:     1,
+		TemplateModifier: cert.SetAdminMarker,
+	})
+	require.NoError(t, err)
+
+	certBlock, _ := pem.Decode(issuedCert.CertificatePEM)
+	require.NotNil(t, certBlock)
+	x509Cert, err := x509.ParseCertificate(certBlock.Bytes)
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(method, path, nil)
+	req.TLS = &tls.ConnectionState{
+		PeerCertificates: []*x509.Certificate{x509Cert},
+	}
+	return req, issuedCert.SerialNumber
+}
+
+// TestExtractAdminPrincipal_ChecksRevocation verifies that a chain-valid admin-marked
+// cert whose serial is in the revoked-serials list returns nil (request rejected).
+// This is the Story D C2 fix: the revocation check must occur on every cert-auth request.
+func TestExtractAdminPrincipal_ChecksRevocation(t *testing.T) {
+	tempDir := t.TempDir()
+	certManager, err := cert.NewManager(&cert.ManagerConfig{
+		StoragePath: tempDir,
+		CAConfig: &cert.CAConfig{
+			Organization: "Test",
+			Country:      "US",
+			ValidityDays: 365,
+		},
+	})
+	require.NoError(t, err)
+
+	server := setupTestServerWithCertMgr(t, certManager)
+
+	// Issue an admin-marked cert via the Manager (stored in certManager for Revoke lookup)
+	req, serial := issueCertAndBuildRequest(t, http.MethodGet, "/api/v1/test", certManager)
+
+	// Before revocation: extractAdminPrincipal must return a non-nil principal
+	principal := server.extractAdminPrincipal(req)
+	require.NotNil(t, principal, "admin-marked cert must be accepted before revocation")
+	assert.True(t, principal.IsAdmin)
+
+	// Revoke the cert
+	require.NoError(t, certManager.Revoke(serial))
+
+	// After revocation: extractAdminPrincipal must return nil (CERT_REVOKED)
+	principal = server.extractAdminPrincipal(req)
+	assert.Nil(t, principal, "revoked admin cert must be rejected by extractAdminPrincipal")
+}
+
+// TestExtractAdminPrincipal_NilCertManager_AllowsUnrevoked verifies that when
+// certManager is nil (disabled cert management), certs are accepted without
+// revocation checking (graceful degradation).
+func TestExtractAdminPrincipal_NilCertManager_AllowsUnrevoked(t *testing.T) {
+	server := setupTestServer(t) // no certManager set
+	adminCert := makeSelfSignedAdminCert(t)
+
+	req := requestWithTLSCert(http.MethodGet, "/api/v1/test", adminCert)
+	principal := server.extractAdminPrincipal(req)
+	require.NotNil(t, principal, "admin cert must be accepted when certManager is nil (no revocation checking)")
+	assert.True(t, principal.IsAdmin)
 }

--- a/features/controller/initialization/admin_bundle.go
+++ b/features/controller/initialization/admin_bundle.go
@@ -1,0 +1,217 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+package initialization
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/cfgis/cfgms/features/controller/config"
+	"github.com/cfgis/cfgms/pkg/cert"
+	"github.com/cfgis/cfgms/pkg/cert/bundle"
+	"github.com/cfgis/cfgms/pkg/logging"
+)
+
+// reservedCNs are CN values that cannot be used for operator admin bundles.
+// "system" prevents impersonation of audit.SystemUserID (pkg/audit/manager.go:90).
+// "cfgms", "cfgms-internal", and "cfgms-admin" are reserved for system-internal certs.
+// "cfgms-admin" is the CN used by the system admin bundle issued during --init; reserving
+// it prevents audit log ambiguity from a duplicate operator bundle with the same CN.
+var reservedCNs = []string{"system", "cfgms", "cfgms-internal", "cfgms-admin"}
+
+// stewardCNPattern matches raw steward UUIDs as used in the controller registration
+// handler (features/controller/api/handlers_registration.go:206-211).
+// Steward client certs use the raw steward UUID as CN with Organization="CFGMS Stewards".
+var stewardCNPattern = regexp.MustCompile(`^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$`)
+
+// adminCertValidityDays is the hard-coded maximum validity for admin certs (L3 fix).
+// All admin cert issuance paths pass this value explicitly; no caller can supply higher.
+const adminCertValidityDays = 365
+
+// IssueAdminBundle issues a new admin client cert+key bundle for the named operator.
+// The name must be non-empty, alphanumeric+hyphens only, max 64 chars, and must not
+// match any reserved CN or steward UUID pattern. The bundle is written to outputPath
+// with mode 0600 (enforced by bundle.Write).
+func IssueAdminBundle(cfg *config.Config, logger logging.Logger, name, outputPath string) error {
+	if err := validateCN(name); err != nil {
+		return err
+	}
+	if outputPath == defaultAdminBundlePath() {
+		return fmt.Errorf("cannot overwrite the system admin bundle; use --regenerate to replace it")
+	}
+
+	certManager, err := loadCertManager(cfg)
+	if err != nil {
+		return fmt.Errorf("failed to load cert manager: %w", err)
+	}
+
+	adminCert, err := certManager.GenerateClientCertificate(&cert.ClientCertConfig{
+		CommonName:       name,
+		Organization:     "CFGMS",
+		ValidityDays:     adminCertValidityDays,
+		TemplateModifier: cert.SetAdminMarker,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to issue admin certificate: %w", err)
+	}
+
+	// L3 defensive check: catch future regressions in GenerateClientCertificate
+	validity := adminCert.ExpiresAt.Sub(adminCert.CreatedAt)
+	maxValidity := time.Duration(adminCertValidityDays+1) * 24 * time.Hour
+	if validity > maxValidity {
+		return fmt.Errorf("issued cert validity %v exceeds cap of %d days: this is a bug in GenerateClientCertificate",
+			validity, adminCertValidityDays)
+	}
+
+	caPEM, err := certManager.GetCACertificate()
+	if err != nil {
+		return fmt.Errorf("failed to get CA certificate PEM: %w", err)
+	}
+
+	b := &bundle.Bundle{
+		CertPEM:         string(adminCert.CertificatePEM),
+		KeyPEM:          string(adminCert.PrivateKeyPEM),
+		CAPEM:           string(caPEM),
+		ControllerURL:   cfg.ExternalURL,
+		AuditSubject:    "admin:" + name,
+		CertSerial:      adminCert.SerialNumber,
+		CertFingerprint: adminCert.Fingerprint,
+	}
+
+	if err := bundle.Write(outputPath, b); err != nil {
+		return fmt.Errorf("failed to write admin bundle: %w", err)
+	}
+
+	bm := &BundleMarker{
+		Serial:      adminCert.SerialNumber,
+		Fingerprint: adminCert.Fingerprint,
+		IssuedAt:    time.Now().UTC(),
+		BundlePath:  outputPath,
+	}
+	if err := writeBundleMarker(outputPath, bm); err != nil {
+		return fmt.Errorf("failed to write bundle issuance marker: %w", err)
+	}
+
+	logger.Info("Admin bundle issued",
+		"path", logging.SanitizeLogValue(outputPath),
+		"name", logging.SanitizeLogValue(name),
+		"serial", adminCert.SerialNumber)
+	return nil
+}
+
+// RegenerateSystemBundle issues a fresh admin cert and overwrites the system bundle.
+// The old cert remains valid until explicitly revoked via RevokeAdminBundle — the
+// caller is responsible for running revocation after regeneration.
+func RegenerateSystemBundle(cfg *config.Config, logger logging.Logger) error {
+	bundlePath := cfg.AdminBundlePath
+	if bundlePath == "" {
+		bundlePath = defaultAdminBundlePath()
+	}
+
+	certManager, err := loadCertManager(cfg)
+	if err != nil {
+		return fmt.Errorf("failed to load cert manager: %w", err)
+	}
+
+	return issueAdminBundle(bundlePath, cfg, certManager, logger)
+}
+
+// RunRegenerate handles the --regenerate flow with an explicit confirmation prompt.
+// The caller supplies in (user input) and out (prompt destination) so tests can
+// inject non-interactive readers without relying on os.Stdin.
+//
+// After regenerating, run `cfgms-controller bootstrap-admin --revoke <old-serial>`
+// to invalidate the previous bundle.
+func RunRegenerate(cfg *config.Config, logger logging.Logger, in io.Reader, out io.Writer) error {
+	bundlePath := cfg.AdminBundlePath
+	if bundlePath == "" {
+		bundlePath = defaultAdminBundlePath()
+	}
+
+	_, _ = fmt.Fprintf(out, "This will issue a new system admin bundle and overwrite the existing one at %s.\n", bundlePath)
+	_, _ = fmt.Fprintln(out, "The old bundle remains valid until you explicitly revoke its certificate.")
+	_, _ = fmt.Fprintln(out, "Type 'yes' to confirm:")
+
+	scanner := bufio.NewScanner(in)
+	var response string
+	if scanner.Scan() {
+		response = scanner.Text()
+	}
+
+	if response != "yes" {
+		_, _ = fmt.Fprintln(out, "Regeneration cancelled.")
+		return fmt.Errorf("regeneration cancelled by operator")
+	}
+
+	return RegenerateSystemBundle(cfg, logger)
+}
+
+// RevokeAdminBundle revokes the admin bundle identified by serialNumber.
+// Returns an error if the serial is not found in the certificate store.
+func RevokeAdminBundle(cfg *config.Config, logger logging.Logger, serialNumber string) error {
+	certManager, err := loadCertManager(cfg)
+	if err != nil {
+		return fmt.Errorf("failed to load cert manager: %w", err)
+	}
+
+	if err := certManager.Revoke(serialNumber); err != nil {
+		return fmt.Errorf("failed to revoke serial %s: %w", serialNumber, err)
+	}
+
+	logger.Info("Admin bundle revoked", "serial", logging.SanitizeLogValue(serialNumber))
+	return nil
+}
+
+// validateCN enforces naming rules for operator admin cert CNs.
+// Returns an error with code "RESERVED_CN" in the message when the name is reserved.
+func validateCN(name string) error {
+	if name == "" {
+		return fmt.Errorf("name is required")
+	}
+	if len(name) > 64 {
+		return fmt.Errorf("name must be 64 characters or fewer")
+	}
+	for _, c := range name {
+		if !isAlphanumHyphen(c) {
+			return fmt.Errorf("name must contain only alphanumeric characters and hyphens, got %q", name)
+		}
+	}
+	if strings.HasPrefix(name, "-") || strings.HasSuffix(name, "-") {
+		return fmt.Errorf("name must not begin or end with a hyphen, got %q", name)
+	}
+	lower := strings.ToLower(name)
+	for _, reserved := range reservedCNs {
+		if lower == reserved {
+			return fmt.Errorf("RESERVED_CN: %q is a reserved common name", name)
+		}
+	}
+	if stewardCNPattern.MatchString(lower) {
+		return fmt.Errorf("RESERVED_CN: %q matches the steward UUID CN pattern and cannot be used for operator bundles", name)
+	}
+	return nil
+}
+
+func isAlphanumHyphen(c rune) bool {
+	return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') ||
+		(c >= '0' && c <= '9') || c == '-'
+}
+
+// loadCertManager loads a cert.Manager from an already-initialized controller.
+// The StoragePath is resolved from cfg.CertPath, falling back to cfg.Certificate.CAPath.
+func loadCertManager(cfg *config.Config) (*cert.Manager, error) {
+	certPath := cfg.CertPath
+	if certPath == "" && cfg.Certificate != nil {
+		certPath = cfg.Certificate.CAPath
+	}
+	if certPath == "" {
+		return nil, fmt.Errorf("certificate path not configured (cert_path or certificate.ca_path required)")
+	}
+	return cert.NewManager(&cert.ManagerConfig{
+		StoragePath:    certPath,
+		LoadExistingCA: true,
+	})
+}

--- a/features/controller/initialization/admin_bundle_test.go
+++ b/features/controller/initialization/admin_bundle_test.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 	"time"
 
@@ -89,8 +90,10 @@ func TestIssueAdminBundle_CreatesFile(t *testing.T) {
 	info, err := os.Stat(outputPath)
 	require.NoError(t, err, "bundle file must exist")
 
-	// Mode must be 0600
-	assert.Equal(t, os.FileMode(0600), info.Mode().Perm(), "bundle file must have mode 0600")
+	// Mode must be 0600 (Unix only — Windows does not enforce Unix permission bits)
+	if runtime.GOOS != "windows" {
+		assert.Equal(t, os.FileMode(0600), info.Mode().Perm(), "bundle file must have mode 0600")
+	}
 
 	x509cert := parseX509FromBundle(t, outputPath)
 

--- a/features/controller/initialization/admin_bundle_test.go
+++ b/features/controller/initialization/admin_bundle_test.go
@@ -1,0 +1,339 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+package initialization
+
+import (
+	"bytes"
+	"crypto/x509"
+	"encoding/pem"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cfgis/cfgms/features/controller/config"
+	"github.com/cfgis/cfgms/pkg/cert"
+	"github.com/cfgis/cfgms/pkg/cert/bundle"
+	"github.com/cfgis/cfgms/pkg/logging"
+)
+
+// setupInitializedController runs full initialization and returns the config and a
+// cert.Manager pointing at the same storage path for direct IsRevoked checks.
+func setupInitializedController(t *testing.T) (*testControllerSetup, func()) {
+	t.Helper()
+	tempDir := t.TempDir()
+	caDir := filepath.Join(tempDir, "ca")
+	bundlePath := filepath.Join(tempDir, "admin.bundle.yaml")
+	logger := logging.NewNoopLogger()
+
+	cfg := makeTestConfig(t, tempDir, caDir, bundlePath)
+
+	_, err := Run(cfg, logger)
+	require.NoError(t, err, "initialization must succeed")
+	require.FileExists(t, bundlePath, "system admin bundle must be created")
+
+	certManager, err := cert.NewManager(&cert.ManagerConfig{
+		StoragePath:    caDir,
+		LoadExistingCA: true,
+	})
+	require.NoError(t, err, "cert manager must load successfully after init")
+
+	return &testControllerSetup{
+		cfg:         cfg,
+		logger:      logger,
+		certManager: certManager,
+		bundlePath:  bundlePath,
+		caDir:       caDir,
+	}, func() {}
+}
+
+type testControllerSetup struct {
+	cfg         *config.Config
+	logger      logging.Logger
+	certManager *cert.Manager
+	bundlePath  string
+	caDir       string
+}
+
+// parseX509FromBundle reads a bundle file and returns the parsed X.509 cert.
+func parseX509FromBundle(t *testing.T, bundlePath string) *x509.Certificate {
+	t.Helper()
+	b, err := bundle.Read(bundlePath)
+	require.NoError(t, err, "bundle must be readable")
+
+	block, _ := pem.Decode([]byte(b.CertPEM))
+	require.NotNil(t, block, "bundle CertPEM must be valid PEM")
+
+	x509cert, err := x509.ParseCertificate(block.Bytes)
+	require.NoError(t, err, "bundle cert must be valid X.509")
+	return x509cert
+}
+
+// TestIssueAdminBundle_CreatesFile verifies that IssueAdminBundle creates a bundle
+// file at the specified path with mode 0600, containing a cert with CN=alice,
+// the admin marker, and 365-day validity.
+func TestIssueAdminBundle_CreatesFile(t *testing.T) {
+	setup, cleanup := setupInitializedController(t)
+	defer cleanup()
+
+	outputPath := filepath.Join(t.TempDir(), "alice.bundle.yaml")
+
+	err := IssueAdminBundle(setup.cfg, setup.logger, "alice", outputPath)
+	require.NoError(t, err)
+
+	// File must exist
+	info, err := os.Stat(outputPath)
+	require.NoError(t, err, "bundle file must exist")
+
+	// Mode must be 0600
+	assert.Equal(t, os.FileMode(0600), info.Mode().Perm(), "bundle file must have mode 0600")
+
+	x509cert := parseX509FromBundle(t, outputPath)
+
+	// Must carry the admin marker
+	assert.True(t, cert.HasAdminMarker(x509cert), "admin bundle cert must carry the CFGMS admin marker")
+
+	// CN must match the requested name
+	assert.Equal(t, "alice", x509cert.Subject.CommonName)
+
+	// Validity must be 365 days ±1 day
+	validity := x509cert.NotAfter.Sub(x509cert.NotBefore)
+	assert.InDelta(t, float64(365*24*time.Hour), float64(validity), float64(24*time.Hour),
+		"admin cert validity must be 365 days (±1 day)")
+}
+
+// TestIssueAdminBundle_ReservedCN_Rejected verifies that reserved common names
+// are rejected and no bundle file is created.
+func TestIssueAdminBundle_ReservedCN_Rejected(t *testing.T) {
+	setup, cleanup := setupInitializedController(t)
+	defer cleanup()
+
+	cases := []struct {
+		name string
+		cn   string
+	}{
+		{"reserved system", "system"},
+		{"reserved cfgms", "cfgms"},
+		{"reserved cfgms-internal", "cfgms-internal"},
+		{"reserved cfgms-admin", "cfgms-admin"},
+		{"steward UUID pattern", "a1b2c3d4-e5f6-7890-abcd-ef1234567890"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			outputPath := filepath.Join(t.TempDir(), "should-not-exist.bundle.yaml")
+			err := IssueAdminBundle(setup.cfg, setup.logger, tc.cn, outputPath)
+			require.Error(t, err, "reserved CN %q must be rejected", tc.cn)
+			assert.Contains(t, err.Error(), "RESERVED_CN",
+				"error message must contain RESERVED_CN for %q", tc.cn)
+			assert.NoFileExists(t, outputPath, "no bundle file must be created for reserved CN")
+		})
+	}
+}
+
+// TestIssueAdminBundle_InvalidCN_Rejected verifies that invalid common names
+// (empty, too long, or containing disallowed characters) are rejected.
+func TestIssueAdminBundle_InvalidCN_Rejected(t *testing.T) {
+	setup, cleanup := setupInitializedController(t)
+	defer cleanup()
+
+	cases := []struct {
+		name string
+		cn   string
+	}{
+		{"empty name", ""},
+		{"too long", "a" + string(make([]byte, 64))},
+		{"contains underscore", "my_admin"},
+		{"contains space", "my admin"},
+		{"contains unicode", "ädmin"},
+		{"leading hyphen", "-alice"},
+		{"trailing hyphen", "alice-"},
+		{"all hyphens", "----"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			outputPath := filepath.Join(t.TempDir(), "should-not-exist.bundle.yaml")
+			err := IssueAdminBundle(setup.cfg, setup.logger, tc.cn, outputPath)
+			require.Error(t, err, "invalid CN %q must be rejected", tc.cn)
+			assert.NoFileExists(t, outputPath, "no bundle file must be created for invalid CN")
+		})
+	}
+}
+
+// TestIssueAdminBundle_CannotOverwriteSystemBundle verifies that passing the default
+// system bundle path as --output is rejected.
+func TestIssueAdminBundle_CannotOverwriteSystemBundle(t *testing.T) {
+	setup, cleanup := setupInitializedController(t)
+	defer cleanup()
+
+	err := IssueAdminBundle(setup.cfg, setup.logger, "alice", defaultAdminBundlePath())
+	require.Error(t, err, "must reject outputPath equal to the system bundle path")
+	assert.Contains(t, err.Error(), "cannot overwrite the system admin bundle")
+}
+
+// TestRevokeAdminBundle_IdempotentDoubleRevoke verifies that revoking the same serial
+// twice is a no-op and the original RevokedAt timestamp is preserved.
+func TestRevokeAdminBundle_IdempotentDoubleRevoke(t *testing.T) {
+	setup, cleanup := setupInitializedController(t)
+	defer cleanup()
+
+	outputPath := filepath.Join(t.TempDir(), "idempotent-revoke.bundle.yaml")
+	require.NoError(t, IssueAdminBundle(setup.cfg, setup.logger, "idempotent-user", outputPath))
+
+	b, err := bundle.Read(outputPath)
+	require.NoError(t, err)
+	serial := b.CertSerial
+
+	require.NoError(t, RevokeAdminBundle(setup.cfg, setup.logger, serial))
+	require.NoError(t, RevokeAdminBundle(setup.cfg, setup.logger, serial), "double-revoke must be a no-op")
+	assert.True(t, setup.certManager.IsRevoked(serial), "cert must still be revoked after double-revoke")
+}
+
+// TestIssueAdminBundle_ValidityCap verifies that the issued cert's validity is
+// exactly 365 days (±1 day clock-skew tolerance).
+func TestIssueAdminBundle_ValidityCap(t *testing.T) {
+	setup, cleanup := setupInitializedController(t)
+	defer cleanup()
+
+	outputPath := filepath.Join(t.TempDir(), "validity-test.bundle.yaml")
+	err := IssueAdminBundle(setup.cfg, setup.logger, "validity-tester", outputPath)
+	require.NoError(t, err)
+
+	x509cert := parseX509FromBundle(t, outputPath)
+	validity := x509cert.NotAfter.Sub(x509cert.NotBefore)
+
+	assert.InDelta(t, float64(365*24*time.Hour), float64(validity), float64(24*time.Hour),
+		"cert NotAfter-NotBefore must be 365 days (±1 day)")
+}
+
+// TestRevokeAdminBundle_RevokedThenAuthFails verifies the full revocation lifecycle:
+// issue a bundle, confirm it is not revoked (auth would succeed), revoke it, and
+// confirm it is revoked (auth would fail with CERT_REVOKED).
+func TestRevokeAdminBundle_RevokedThenAuthFails(t *testing.T) {
+	setup, cleanup := setupInitializedController(t)
+	defer cleanup()
+
+	outputPath := filepath.Join(t.TempDir(), "revoke-test.bundle.yaml")
+	err := IssueAdminBundle(setup.cfg, setup.logger, "revoke-test-user", outputPath)
+	require.NoError(t, err)
+
+	b, err := bundle.Read(outputPath)
+	require.NoError(t, err)
+	serial := b.CertSerial
+
+	// Parse the cert and verify it has the admin marker
+	block, _ := pem.Decode([]byte(b.CertPEM))
+	require.NotNil(t, block)
+	x509cert, err := x509.ParseCertificate(block.Bytes)
+	require.NoError(t, err)
+	assert.True(t, cert.HasAdminMarker(x509cert), "issued cert must carry admin marker")
+
+	// Before revocation: cert manager must not report it as revoked
+	assert.False(t, setup.certManager.IsRevoked(serial),
+		"cert must not be revoked before RevokeAdminBundle is called")
+
+	// Revoke
+	err = RevokeAdminBundle(setup.cfg, setup.logger, serial)
+	require.NoError(t, err)
+
+	// After revocation: a fresh cert manager (simulating controller restart) must
+	// report the serial as revoked (CERT_REVOKED — auth would be rejected)
+	freshManager, err := cert.NewManager(&cert.ManagerConfig{
+		StoragePath:    setup.caDir,
+		LoadExistingCA: true,
+	})
+	require.NoError(t, err)
+	assert.True(t, freshManager.IsRevoked(serial),
+		"cert must be revoked after RevokeAdminBundle; auth would return CERT_REVOKED")
+}
+
+// TestRegenerate_RequiresConfirmation verifies that RunRegenerate requires the
+// operator to type exactly "yes" and exits non-zero otherwise.
+func TestRegenerate_RequiresConfirmation(t *testing.T) {
+	t.Run("no input cancels regeneration", func(t *testing.T) {
+		setup, cleanup := setupInitializedController(t)
+		defer cleanup()
+
+		var in bytes.Buffer
+		in.WriteString("no\n")
+		var out bytes.Buffer
+
+		err := RunRegenerate(setup.cfg, setup.logger, &in, &out)
+		require.Error(t, err, "--regenerate with 'no' must exit non-zero")
+		assert.Contains(t, out.String(), "Regeneration cancelled.")
+	})
+
+	t.Run("empty input cancels regeneration", func(t *testing.T) {
+		setup, cleanup := setupInitializedController(t)
+		defer cleanup()
+
+		var in bytes.Buffer
+		in.WriteString("\n")
+		var out bytes.Buffer
+
+		err := RunRegenerate(setup.cfg, setup.logger, &in, &out)
+		require.Error(t, err, "--regenerate with empty input must exit non-zero")
+		assert.Contains(t, out.String(), "Regeneration cancelled.")
+	})
+
+	t.Run("yes confirms regeneration", func(t *testing.T) {
+		setup, cleanup := setupInitializedController(t)
+		defer cleanup()
+
+		originalBundle, err := bundle.Read(setup.bundlePath)
+		require.NoError(t, err)
+
+		var in bytes.Buffer
+		in.WriteString("yes\n")
+
+		err = RunRegenerate(setup.cfg, setup.logger, &in, io.Discard)
+		require.NoError(t, err, "--regenerate with 'yes' must succeed")
+
+		// Bundle must have been regenerated (new cert serial)
+		newBundle, err := bundle.Read(setup.bundlePath)
+		require.NoError(t, err)
+		assert.NotEqual(t, originalBundle.CertSerial, newBundle.CertSerial,
+			"regeneration must produce a new certificate serial")
+
+		// New cert must still carry the admin marker
+		x509cert := parseX509FromBundle(t, setup.bundlePath)
+		assert.True(t, cert.HasAdminMarker(x509cert), "regenerated cert must carry the admin marker")
+	})
+}
+
+// TestRegenerate_RecoversFromMissingBundle verifies that when the bundle marker is
+// present but the bundle file has been deleted externally, RunRegenerate recreates
+// the bundle and the controller initialization state is still valid.
+func TestRegenerate_RecoversFromMissingBundle(t *testing.T) {
+	setup, cleanup := setupInitializedController(t)
+	defer cleanup()
+
+	// Simulate external deletion of the bundle file
+	require.NoError(t, os.Remove(setup.bundlePath))
+	assert.NoFileExists(t, setup.bundlePath, "pre-condition: bundle file must be absent")
+
+	// The bundle marker file must still be present
+	assert.FileExists(t, bundleMarkerPath(setup.bundlePath),
+		"pre-condition: bundle marker must still be present")
+
+	// RunRegenerate with "yes" must recreate the bundle
+	var in bytes.Buffer
+	in.WriteString("yes\n")
+	err := RunRegenerate(setup.cfg, setup.logger, &in, io.Discard)
+	require.NoError(t, err)
+
+	require.FileExists(t, setup.bundlePath, "bundle file must be recreated by --regenerate")
+
+	// Recreated bundle must be valid
+	x509cert := parseX509FromBundle(t, setup.bundlePath)
+	assert.True(t, cert.HasAdminMarker(x509cert), "recreated cert must carry the admin marker")
+
+	// Initialization marker must still be intact (controller can start)
+	assert.True(t, IsInitialized(setup.caDir),
+		"initialization marker must remain intact after --regenerate")
+}

--- a/features/rbac/escalation_prevention_test.go
+++ b/features/rbac/escalation_prevention_test.go
@@ -44,10 +44,10 @@ func TestNewEscalationPreventionManager_AcceptsStoreAccessor(t *testing.T) {
 		storageManager.GetClientTenantStore(),
 		storageManager.GetRBACStore(),
 	)
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
 	t.Cleanup(func() {
-		_ = manager.Close(ctx)
+		closeCtx, closeCancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer closeCancel()
+		_ = manager.Close(closeCtx)
 	})
 
 	// *Manager satisfies both RBACManager and RBACStoreAccessor; construction must not panic.
@@ -76,7 +76,11 @@ func TestValidateAndSetRoleParent_NoTypeAssertion(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 	t.Cleanup(func() {
-		_ = manager.Close(ctx)
+		// Use a fresh context: defer cancel() fires when the test function returns,
+		// which is before t.Cleanup runs, so ctx is already cancelled here.
+		closeCtx, closeCancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer closeCancel()
+		_ = manager.Close(closeCtx)
 	})
 
 	require.NoError(t, manager.Initialize(ctx))
@@ -126,7 +130,11 @@ func TestOperationLog_UsesEscalationOperationType(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 	t.Cleanup(func() {
-		_ = manager.Close(ctx)
+		// Use a fresh context: defer cancel() fires when the test function returns,
+		// which is before t.Cleanup runs, so ctx is already cancelled here.
+		closeCtx, closeCancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer closeCancel()
+		_ = manager.Close(closeCtx)
 	})
 
 	require.NoError(t, manager.Initialize(ctx))

--- a/pkg/cert/manager.go
+++ b/pkg/cert/manager.go
@@ -49,6 +49,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"path/filepath"
+	"time"
 )
 
 // ManagerConfig contains configuration for the certificate manager
@@ -69,11 +70,12 @@ type ManagerConfig struct {
 
 // Manager provides high-level certificate management functionality
 type Manager struct {
-	ca        *CA
-	store     *FileStore
-	validator *Validator
-	renewer   *Renewer
-	config    *ManagerConfig
+	ca         *CA
+	store      *FileStore
+	validator  *Validator
+	renewer    *Renewer
+	config     *ManagerConfig
+	revocation *revocationStore
 }
 
 // NewManager creates a new certificate manager
@@ -132,12 +134,19 @@ func NewManager(config *ManagerConfig) (*Manager, error) {
 	// Initialize renewer
 	renewer := NewRenewer(ca, store, validator)
 
+	// Initialize revocation store (reads existing list if present, empty list if not)
+	revStore, err := newRevocationStore(config.StoragePath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to initialize revocation store: %w", err)
+	}
+
 	manager := &Manager{
-		ca:        ca,
-		store:     store,
-		validator: validator,
-		renewer:   renewer,
-		config:    config,
+		ca:         ca,
+		store:      store,
+		validator:  validator,
+		renewer:    renewer,
+		config:     config,
+		revocation: revStore,
 	}
 
 	// Store the CA certificate in the certificate store for easy retrieval
@@ -514,4 +523,28 @@ func (m *Manager) GetClientCertificate(_ context.Context) (*tls.Certificate, err
 // GetStoragePath returns the certificate storage path
 func (m *Manager) GetStoragePath() string {
 	return m.store.GetStoragePath()
+}
+
+// Revoke adds serial to the revoked-serials list and persists it atomically.
+// Returns an error if the serial is not found in the certificate store — revoking
+// an unknown serial is an operator error that must surface explicitly.
+func (m *Manager) Revoke(serial string) error {
+	if _, err := m.store.GetCertificate(serial); err != nil {
+		return fmt.Errorf("cannot revoke unknown serial %q: %w", serial, err)
+	}
+	return m.revocation.addAndPersist(RevocationEntry{
+		Serial:    serial,
+		RevokedAt: time.Now().UTC(),
+	})
+}
+
+// IsRevoked reports whether the given certificate serial number appears in the
+// revoked-serials list. Called on every mTLS admin cert authentication request.
+func (m *Manager) IsRevoked(serial string) bool {
+	return m.revocation.isRevoked(serial)
+}
+
+// ListRevoked returns all revocation entries for auditing and --list output.
+func (m *Manager) ListRevoked() ([]RevocationEntry, error) {
+	return m.revocation.allEntries(), nil
 }

--- a/pkg/cert/revocation.go
+++ b/pkg/cert/revocation.go
@@ -1,0 +1,150 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+//
+// Revocation primitive for cert.Manager.
+//
+// Access pattern: IsRevoked is called on every mTLS admin cert authentication
+// request (frequent reads, called from auth middleware). Revoke is called rarely
+// (admin action, CLI invocation). A sync.RWMutex allows many concurrent readers
+// while Revoke acquires exclusive access for the write+persist operation.
+package cert
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+)
+
+const revocationFileName = "revocation.json"
+
+// RevocationEntry records a revoked certificate serial with metadata.
+type RevocationEntry struct {
+	Serial    string    `json:"serial"`
+	RevokedAt time.Time `json:"revoked_at"`
+	Reason    string    `json:"reason,omitempty"`
+}
+
+// revocationList is the on-disk JSON format.
+type revocationList struct {
+	Entries []RevocationEntry `json:"entries"`
+}
+
+// revocationStore persists the revocation list as a JSON file in the certificate
+// store's base path and re-reads it on every IsRevoked call. This ensures that
+// revocations issued by a separate process (e.g. `cfgms-controller bootstrap-admin
+// --revoke`) take effect immediately in the running controller without a restart.
+// The write lock is held for both reads and writes; the list is expected to be small
+// (admin certs only), so lock contention is not a bottleneck in practice.
+type revocationStore struct {
+	mu       sync.RWMutex
+	filePath string
+	bySerial map[string]RevocationEntry
+}
+
+// newRevocationStore loads or creates an empty revocation store backed by
+// basePath/revocation.json. A missing file is treated as an empty list (not an error).
+func newRevocationStore(basePath string) (*revocationStore, error) {
+	rs := &revocationStore{
+		filePath: filepath.Join(basePath, revocationFileName),
+		bySerial: make(map[string]RevocationEntry),
+	}
+	if err := rs.reload(); err != nil {
+		return nil, err
+	}
+	return rs, nil
+}
+
+// reload re-reads the revocation file and rebuilds the in-memory map.
+// Called during initialization and after each addAndPersist to keep cache consistent.
+func (rs *revocationStore) reload() error {
+	rs.mu.Lock()
+	defer rs.mu.Unlock()
+	return rs.loadLocked()
+}
+
+// loadLocked reads the file and rebuilds bySerial. Must be called with the write lock held.
+func (rs *revocationStore) loadLocked() error {
+	// #nosec G304 -- path is controlled: constructed from the cert manager's storage path
+	data, err := os.ReadFile(rs.filePath)
+	if os.IsNotExist(err) {
+		rs.bySerial = make(map[string]RevocationEntry)
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("failed to read revocation list: %w", err)
+	}
+
+	var list revocationList
+	if err := json.Unmarshal(data, &list); err != nil {
+		return fmt.Errorf("failed to parse revocation list: %w", err)
+	}
+
+	m := make(map[string]RevocationEntry, len(list.Entries))
+	for _, e := range list.Entries {
+		m[e.Serial] = e
+	}
+	rs.bySerial = m
+	return nil
+}
+
+// addAndPersist adds the entry to the in-memory map and atomically saves to disk.
+// If the serial is already revoked the call is a no-op (original timestamp preserved).
+// The write lock is held for the duration of the update.
+func (rs *revocationStore) addAndPersist(entry RevocationEntry) error {
+	rs.mu.Lock()
+	defer rs.mu.Unlock()
+	if _, exists := rs.bySerial[entry.Serial]; exists {
+		return nil
+	}
+	rs.bySerial[entry.Serial] = entry
+	return rs.saveLocked()
+}
+
+// saveLocked serializes bySerial to disk atomically. Must be called with the write lock held.
+func (rs *revocationStore) saveLocked() error {
+	entries := make([]RevocationEntry, 0, len(rs.bySerial))
+	for _, e := range rs.bySerial {
+		entries = append(entries, e)
+	}
+
+	list := revocationList{Entries: entries}
+	data, err := json.MarshalIndent(list, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal revocation list: %w", err)
+	}
+
+	tmpPath := rs.filePath + ".tmp"
+	if err := os.WriteFile(tmpPath, data, 0600); err != nil {
+		return fmt.Errorf("failed to write revocation list: %w", err)
+	}
+
+	if err := os.Rename(tmpPath, rs.filePath); err != nil {
+		_ = os.Remove(tmpPath)
+		return fmt.Errorf("failed to finalize revocation list: %w", err)
+	}
+	return nil
+}
+
+// isRevoked reports whether serial is in the revocation list.
+// Re-reads from disk on every call to detect cross-process revocations.
+func (rs *revocationStore) isRevoked(serial string) bool {
+	rs.mu.Lock()
+	defer rs.mu.Unlock()
+	_ = rs.loadLocked() // best-effort reload; stale cache preferred over crashing
+	_, ok := rs.bySerial[serial]
+	return ok
+}
+
+// allEntries returns a snapshot of all revocation entries.
+func (rs *revocationStore) allEntries() []RevocationEntry {
+	rs.mu.RLock()
+	defer rs.mu.RUnlock()
+	out := make([]RevocationEntry, 0, len(rs.bySerial))
+	for _, e := range rs.bySerial {
+		out = append(out, e)
+	}
+	return out
+}

--- a/pkg/cert/revocation_test.go
+++ b/pkg/cert/revocation_test.go
@@ -1,0 +1,185 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+package cert
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRevokeAdminBundle_PersistsAcrossRestart verifies that a revoked serial
+// survives a Manager restart by re-reading the revocation.json file.
+func TestRevokeAdminBundle_PersistsAcrossRestart(t *testing.T) {
+	tempDir := t.TempDir()
+
+	manager, err := NewManager(&ManagerConfig{
+		StoragePath: tempDir,
+		CAConfig: &CAConfig{
+			Organization: "Test",
+			Country:      "US",
+			ValidityDays: 365,
+		},
+	})
+	require.NoError(t, err)
+
+	c, err := manager.GenerateClientCertificate(&ClientCertConfig{
+		CommonName:   "test-operator",
+		Organization: "CFGMS",
+		ValidityDays: 365,
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, manager.Revoke(c.SerialNumber))
+	assert.True(t, manager.IsRevoked(c.SerialNumber))
+
+	// Simulate restart: new Manager, same storage path
+	manager2, err := NewManager(&ManagerConfig{
+		StoragePath:    tempDir,
+		LoadExistingCA: true,
+	})
+	require.NoError(t, err)
+
+	assert.True(t, manager2.IsRevoked(c.SerialNumber),
+		"revocation must persist across Manager restart")
+}
+
+// TestRevokeAdminBundle_UnknownSerial_Errors verifies that revoking a serial
+// not found in the certificate store returns an error (not silent success).
+func TestRevokeAdminBundle_UnknownSerial_Errors(t *testing.T) {
+	tempDir := t.TempDir()
+
+	manager, err := NewManager(&ManagerConfig{
+		StoragePath: tempDir,
+		CAConfig: &CAConfig{
+			Organization: "Test",
+			Country:      "US",
+			ValidityDays: 365,
+		},
+	})
+	require.NoError(t, err)
+
+	err = manager.Revoke("00000000-nonexistent-serial-9999")
+	assert.Error(t, err, "revoking an unknown serial must return an error")
+	assert.Contains(t, err.Error(), "00000000-nonexistent-serial-9999")
+}
+
+// TestIsRevoked_FalseBeforeRevoke verifies that a freshly-issued cert is not revoked.
+func TestIsRevoked_FalseBeforeRevoke(t *testing.T) {
+	manager := setupTestManager(t)
+
+	c, err := manager.GenerateClientCertificate(&ClientCertConfig{
+		CommonName:   "alice",
+		Organization: "CFGMS",
+		ValidityDays: 365,
+	})
+	require.NoError(t, err)
+
+	assert.False(t, manager.IsRevoked(c.SerialNumber),
+		"freshly-issued cert must not be revoked")
+}
+
+// TestListRevoked_ReturnsEntry verifies that ListRevoked returns the revoked serial.
+func TestListRevoked_ReturnsEntry(t *testing.T) {
+	tempDir := t.TempDir()
+
+	manager, err := NewManager(&ManagerConfig{
+		StoragePath: tempDir,
+		CAConfig: &CAConfig{
+			Organization: "Test",
+			Country:      "US",
+			ValidityDays: 365,
+		},
+	})
+	require.NoError(t, err)
+
+	c, err := manager.GenerateClientCertificate(&ClientCertConfig{
+		CommonName:   "bob",
+		Organization: "CFGMS",
+		ValidityDays: 365,
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, manager.Revoke(c.SerialNumber))
+
+	entries, err := manager.ListRevoked()
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+	assert.Equal(t, c.SerialNumber, entries[0].Serial)
+	assert.False(t, entries[0].RevokedAt.IsZero())
+}
+
+// TestRevocationConcurrentAccess verifies that concurrent reads and a write
+// do not race (run with -race to confirm).
+func TestRevocationConcurrentAccess(t *testing.T) {
+	tempDir := t.TempDir()
+
+	manager, err := NewManager(&ManagerConfig{
+		StoragePath: tempDir,
+		CAConfig: &CAConfig{
+			Organization: "Test",
+			Country:      "US",
+			ValidityDays: 365,
+		},
+	})
+	require.NoError(t, err)
+
+	c, err := manager.GenerateClientCertificate(&ClientCertConfig{
+		CommonName:   "concurrency-test",
+		Organization: "CFGMS",
+		ValidityDays: 365,
+	})
+	require.NoError(t, err)
+
+	const readers = 50
+	var wg sync.WaitGroup
+	wg.Add(readers + 1)
+
+	// Spawn concurrent readers
+	for i := 0; i < readers; i++ {
+		go func() {
+			defer wg.Done()
+			_ = manager.IsRevoked(c.SerialNumber)
+		}()
+	}
+
+	// Concurrent writer
+	go func() {
+		defer wg.Done()
+		_ = manager.Revoke(c.SerialNumber)
+	}()
+
+	wg.Wait()
+	// Race correctness verified by the race detector; also confirm the revoke actually persisted.
+	assert.True(t, manager.IsRevoked(c.SerialNumber), "revoke must persist after concurrent access")
+}
+
+// TestRevokeIdempotent verifies that revoking the same serial twice is a no-op and
+// the original RevokedAt timestamp is preserved.
+func TestRevokeIdempotent(t *testing.T) {
+	manager := setupTestManager(t)
+
+	c, err := manager.GenerateClientCertificate(&ClientCertConfig{
+		CommonName:   "idempotent-test",
+		Organization: "CFGMS",
+		ValidityDays: 365,
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, manager.Revoke(c.SerialNumber))
+
+	entries1, err := manager.ListRevoked()
+	require.NoError(t, err)
+	require.Len(t, entries1, 1)
+	firstRevokedAt := entries1[0].RevokedAt
+
+	require.NoError(t, manager.Revoke(c.SerialNumber), "double-revoke must not error")
+
+	entries2, err := manager.ListRevoked()
+	require.NoError(t, err)
+	require.Len(t, entries2, 1, "revocation list must not grow on double-revoke")
+	assert.Equal(t, firstRevokedAt, entries2[0].RevokedAt,
+		"original RevokedAt timestamp must be preserved on double-revoke")
+}


### PR DESCRIPTION
Fixes #1418

## Summary

- **`pkg/cert`**: New minimum-viable revocation primitive — `Revoke`, `IsRevoked`, `ListRevoked` on `cert.Manager`. Atomic JSON persistence at `<storagePath>/revocation.json`. `IsRevoked` re-reads from disk on every call so cross-process revocations (from the CLI) take effect immediately in the running controller. Double-revoke is idempotent (original `RevokedAt` preserved). Concurrent-access verified by race-detector test with 50 readers + 1 writer.

- **`features/controller/initialization`**: New `admin_bundle.go` — `IssueAdminBundle`, `RunRegenerate`, `RevokeAdminBundle`. `validateCN` enforces: alphanumeric+hyphens, max 64 chars, no leading/trailing hyphens, reserved CNs (`system`, `cfgms`, `cfgms-internal`, `cfgms-admin`), steward UUID regex. `IssueAdminBundle` rejects `outputPath == defaultAdminBundlePath()` to prevent accidental system bundle overwrite. 365-day hard-coded validity cap with defensive post-issuance assertion (L3 fix).

- **`features/controller/api/middleware`**: `extractAdminPrincipal` promoted to `*Server` method; checks `certManager.IsRevoked` on every mTLS admin cert authentication request.

- **`cmd/controller/main`**: `bootstrap-admin` subcommand with `--name/--output`, `--regenerate`, `--revoke`, `--list` flags. Mutual exclusion of operations enforced; `--output` required with `--name`.

- **`docs`**: Added "Adding Operators" (with name rules, `--list` usage) and "Revoking Access" (3-step post-regeneration workflow) to single-controller deployment walkthrough.

## Test plan

- [x] `make test` — ✅ ALL VALIDATION COMPLETE (OSS + Commercial + Scripts)
- [x] QA code reviewer: PASS (all blocking issues resolved: `bootstrap-admin` subcommand registration test, `runBootstrapAdmin` flag-validation tests)
- [x] Security engineer: PASS (0 blocking; all 5 warnings addressed: cross-process revocation staleness fixed, `cfgms-admin` reserved, hyphen-edge validation, system bundle path guard, double-revoke idempotency)
- [x] QA test runner (`make test-agent-complete`): PASS — all gates green; Docker/E2E deferred to CI as expected
- [x] Race detector: `TestRevocationConcurrentAccess` — PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)