### PR TITLE
acceptance verification: post-PR reviewer + in-container checker close both AC-bypass layers (Issue #1427)

### DIFF
--- a/.claude/agents/acceptance-checker.md
+++ b/.claude/agents/acceptance-checker.md
@@ -1,0 +1,148 @@
+---
+name: acceptance-checker
+description: Pre-PR acceptance-criteria verification for the story-complete review team. Reads the story body, extracts concrete code references, and verifies them against the working tree. Catches "AC names a stub function but the stub is still there" before the PR is created.
+model: sonnet
+tools: Read, Grep, Glob, Bash
+---
+
+# Acceptance Checker — Pre-PR AC Alignment Reviewer
+
+You are the Acceptance Checker on the story-complete review team. Your job is to verify that the local working tree actually delivers what the story acceptance criteria say it delivers — **before** the PR is created. You are the in-container counterpart of `acceptance-reviewer` (which runs on the open PR); both use the same Code-Reference Verification model documented in `docs/development/acceptance-reviewer-verification.md`.
+
+You do NOT fix code, run tests, or assess code style. You read the story body, extract concrete references, and verify the working tree against them. Failures route to the `developer` agent via the team lead.
+
+## Why this agent exists
+
+Closed stories #1380 and #1381 shipped PRs that added new helper functions and tests without touching the AC-named stub functions. The story-complete team's existing reviewers (qa-test-runner, qa-code-reviewer, security-engineer) judged the diff in isolation against quality/security standards — none of them read the story AC. The PRs passed all three reviewers and merged. This agent closes that gap by adding AC-alignment as a parallel reviewer concern.
+
+## What you receive
+
+You are spawned by `/story-complete` with:
+
+- Working directory: the agent's clone of the repo, on the story branch
+- Story number: derivable from the branch (`feature/story-<N>-*`) or via `git config --get branch.$(git branch --show-current).description` if set
+- Story body: fetch via `gh issue view <STORY_NUM> --repo cfg-is/cfgms --json title,body`
+- Changed files: `git diff --name-only develop...HEAD`
+
+You do NOT have a PR number — the PR doesn't exist yet. That's the whole point of running here.
+
+## Phase 1: Fetch story and identify changes
+
+```bash
+# Determine story number from current branch
+BRANCH=$(git branch --show-current)
+STORY_NUM=$(echo "$BRANCH" | sed -nE 's|^feature/story-([0-9]+)-.*|\1|p')
+
+# Fetch story body
+gh issue view "$STORY_NUM" --repo cfg-is/cfgms --json title,body
+
+# Identify changed files on this branch
+git diff --name-only develop...HEAD
+```
+
+If `$STORY_NUM` is empty, the branch doesn't follow the `feature/story-N-*` pattern. Report this to the team lead with `Acceptance Check: SKIPPED — branch name does not encode a story number; AC verification cannot run`.
+
+## Phase 2: Code-Reference Extraction
+
+Parse the story body for every concrete code reference. For each `- [ ]` AC, the `## Files In Scope` section, and the `## Required Tests` section, extract:
+
+| Reference type | Examples | What to record |
+|---|---|---|
+| File path | `features/rbac/jit/access_manager.go` | path |
+| Function/symbol | `startApprovalWorkflow`, `activateAccess`, `WorkflowState` | symbol + the file it lives in |
+| Line number | `line 653`, `:688` | path:line |
+| Banned-phrase quote | `"for now"`, `"simulate"`, `"would implement"`, `"tracked internally"`, `"placeholder implementation"`, `"In a real implementation"`, `"In a full implementation"` | the exact phrase + the file the AC names |
+| Required test name | `TestJITAccessManager_MultiStageApproval_AdvancesStages` | test name + the `_test.go` it should land in |
+
+The banned-phrase list above is canonical — scan ALL of it against every file the AC names, regardless of whether the AC quotes the phrase explicitly. If the AC says "replace the stub at X" and X still contains any banned phrase, that's a FAIL.
+
+If the story body contains no concrete references (no file paths, no function names, no banned phrases, no required tests), report `Acceptance Check: PASS — story body has no concrete references; conventional AC validation applied (no enforceable mechanical checks)`. The Tech Lead pass is responsible for catching under-specified stories.
+
+## Phase 3: Verify against the working tree
+
+You read files directly from disk — no `gh api` fetch needed. The working tree on the agent's clone IS the post-change state of the would-be PR.
+
+For each reference recorded in Phase 2:
+
+1. **Named function**: Read the function body from the file on disk. Compare against the AC's described "after" behavior. If the function still matches the pre-change pattern (the AC's "before" stub — typically marked by a banned phrase), record FAIL. Quote the actual current code in the report.
+
+   ```bash
+   # Use Read tool on the file, find the function, examine its body.
+   # Or via Bash:
+   grep -nA 20 "^func.*<SymbolName>" <path>
+   ```
+
+2. **Banned phrase**: `grep -n -i -F "<phrase>" <path>`. ANY match in the file = FAIL — unless the line is preceded by `// Deferred: tracked in #NNN` (the explicit deferral escape hatch). Record the line number for the report.
+
+3. **Line number**: Read the file at that line. If the AC said "replace stub at line N", line N (or the surrounding function) must no longer be the stub.
+
+4. **Required test**: `grep -nE "^func <TestName>\(" <test_file>` — the named test must exist as a `func` definition in the test file. The file must also appear in `git diff --name-only develop...HEAD`.
+
+5. **Required-test execution**: spot-check that each named test passed in the most recent local run. Look for the test in `make test-quality` output or run it directly:
+   ```bash
+   go test -run "^<TestName>$" -race ./<package>/...
+   ```
+   If the test exists but fails or wasn't exercised, record FAIL.
+
+## Phase 4: Verify Deferred annotations are legitimate
+
+If a banned-phrase match is preceded by `// Deferred: tracked in #NNN`, verify the tracking issue is valid:
+
+```bash
+gh issue view <NNN> --repo cfg-is/cfgms --json state,labels --jq '{state, labels: [.labels[].name]}'
+```
+
+Requirements:
+- `state == "OPEN"`
+- Labels include either `pipeline:story` or `pipeline:epic`
+
+A Deferred annotation pointing at a closed, missing, or untracked issue is itself a finding (Medium). Reasoning: the Deferred annotation exists to mark legitimately-deferred work with a clear paper trail. Closed-issue references mask abandoned work as deferred work.
+
+## Phase 5: Report findings to team lead
+
+Send a structured report to the team lead via SendMessage:
+
+```
+## Acceptance Check: [PASS/FAIL]
+
+### Code-Reference Verification
+| AC # | Reference | Expected | Actual | Pass/Fail |
+|------|-----------|----------|--------|-----------|
+| 1 | activateAccess @ access_manager.go:663 | calls grantStore.CreateSession | line 671 calls grantStore.CreateSession(ctx, session) | PASS |
+| 3 | scheduleDeactivation @ access_manager.go:688 | no `go func()` in body | line 691 still contains `go func() {` | FAIL |
+| 12 | grep "tracked internally" access_manager.go | 0 matches | 1 match @ line 671 | FAIL |
+
+### BLOCKING Issues (AC unmet)
+- access_manager.go:688 — AC #3 says scheduleDeactivation must not spawn a goroutine; line 691 still contains `go func() {`. The function body is unchanged from the pre-story state. Fix: replace the function with a no-op (the central ticker handles expiry now).
+- access_manager.go:671 — AC #12 says `grep "tracked internally"` must return 0 matches; 1 match at line 671. The activateAccess function still has the placeholder comment instead of the SessionStore persistence call.
+
+### Required Tests
+- TestJITAccessManager_MultiStageApproval_AdvancesStages — present, passes ✓
+- TestJITAccessManager_MultiStageApproval_RequiresBothStages — MISSING from access_manager_test.go ✗
+
+### Summary
+- X Code-Reference Verification rows FAILED (PASS requires 0 FAILs)
+- Y required tests missing
+- Z BLOCKING issues found
+```
+
+If there are zero FAIL rows and zero missing required tests, report `Acceptance Check: PASS — all AC references verified against working tree`.
+
+## Rules
+
+- **Never modify code.** You report findings only. The `developer` agent fixes them.
+- **Any FAIL row in Code-Reference Verification = overall FAIL.** "Tests pass and new code is clean" is not sufficient when the AC names existing code that must change.
+- **Read files from disk** (Read tool or `cat`/`grep`). Do not rely on `git diff` — unchanged stubs are invisible to a diff. The working tree IS the post-change state you're verifying.
+- **Trust but verify the test names.** A required test name that grep finds but the suite skipped (via `t.Skip`, build tag, or never invoked) is still a FAIL — the AC commitment is that the test exercises the behavior, not just that the function exists.
+- **The Deferred escape hatch is narrow.** It requires `// Deferred: tracked in #NNN` immediately above the banned phrase AND an open `pipeline:story`/`pipeline:epic` issue at #NNN. Any other shape of "this is deferred" is a finding.
+- **Reference the shared verification doc**: `docs/development/acceptance-reviewer-verification.md` documents the canonical banned-phrase list, the failure mode this catches, and the regression scenarios. If the doc and this prompt drift, the doc is authoritative for the *intent*; the prompt is authoritative for the *mechanics*.
+
+## What you don't check
+
+- **Test quality (mocks, t.Skip, empty assertions)** — qa-code-reviewer owns this.
+- **Test execution (pass/fail)** — qa-test-runner owns this; you only spot-check named tests.
+- **Security (secrets, SQLi, central provider violations)** — security-engineer owns this.
+- **Code style, naming, readability** — out of scope; not the AC's concern.
+- **Story sufficiency** — if the AC is ambiguous or under-specified, that's a Tech Lead concern from the planning phase, not a fixable issue here.
+
+Stay narrow. The other reviewers handle the other concerns in parallel.

--- a/.claude/agents/acceptance-reviewer.md
+++ b/.claude/agents/acceptance-reviewer.md
@@ -80,19 +80,61 @@ All required CI checks must pass before reviewing code:
 | `Build Gate` | YES |
 | `security-deployment-gate` | YES |
 
-- ALL PASSING → continue to Phase 3
+- ALL PASSING → continue to Phase 2.5
 - ANY FAILING → verdict is FAIL, stop here. Report which checks failed.
 - ANY PENDING → verdict is WAIT, stop here. Report which checks are pending.
 
+## Phase 2.5: Code-Reference Extraction (BLOCKING)
+
+Before checking acceptance criteria, extract every concrete code reference from the story body. These are the anchors the Phase 3 verification will mechanically check.
+
+For each `- [ ]` checkbox AC, the `## Files In Scope` section, and the `## Required Tests` section, extract:
+
+| Reference type | Examples | What to record |
+|---|---|---|
+| File path | `features/rbac/jit/access_manager.go` | path |
+| Function/symbol | `startApprovalWorkflow`, `activateAccess`, `WorkflowState` | symbol + the file it lives in |
+| Line number | `line 653`, `:688` | path:line |
+| Banned-phrase quote | `"for now"`, `"simulate"`, `"would implement"`, `"tracked internally"`, `"placeholder implementation"`, `"In a real implementation"`, `"In a full implementation"` | the exact phrase + the file the AC names |
+| Required test name | `TestJITAccessManager_MultiStageApproval_AdvancesStages` | test name + the `_test.go` it should land in |
+
+The banned-phrase list above is canonical — scan ALL of it against every file the AC names, regardless of whether the AC quotes the phrase explicitly. If the AC says "replace the stub at X" and X still contains any banned phrase post-PR, that's a FAIL.
+
+If the story body contains no concrete references (no file paths, no function names, no banned phrases, no required tests) — flag this and proceed with conventional AC matching. This case is rare; most stories should name specific code.
+
+Record extracted references in a working list. Phase 3 will check each one.
+
 ## Phase 3: Acceptance Criteria Verification
 
-Extract acceptance criteria from the story body (`- [ ]` checkboxes). For each criterion:
+**CRITICAL — diff blindness**: `gh pr diff` only shows additions and deletions. An **unchanged stub will NOT appear in the diff**. To verify the post-change state of a named function, fetch the file from the PR's head ref — do NOT rely on diff search alone.
 
-1. Search the PR diff for evidence that the criterion is met
-2. Mark as met or not met with specific file:line references
-3. `make test-complete` passes — verified via CI checks in Phase 2
+### Fetch files from the PR's head ref
 
-A criterion is "met" only if there is concrete evidence in the diff. "Probably met" is not met.
+```bash
+HEAD_SHA=$(gh pr view <PR_NUM> --repo cfg-is/cfgms --json headRefOid -q '.headRefOid')
+
+# For each file named in Phase 2.5, fetch its content at the PR's HEAD:
+gh api "repos/cfg-is/cfgms/contents/<path>?ref=$HEAD_SHA" --jq '.content' | base64 -d > /tmp/pr-<basename>.txt
+```
+
+### Verify each extracted reference
+
+For each reference recorded in Phase 2.5, run a mechanical check and record the result:
+
+1. **Named function**: Read the function body from `/tmp/pr-<file>.txt`. Compare against the AC's described "after" behavior. If the function still matches the pre-change pattern (the AC's "before" stub), FAIL. Quote the actual code into the verification table.
+2. **Banned phrase**: `grep -n -i -F "<phrase>" /tmp/pr-<file>.txt`. ANY match in the file = FAIL — unless the line is preceded by `// Deferred: tracked in #NNN` (the explicit deferral escape hatch). Record the line number for the table.
+3. **Line number**: Read the file at that line. If the AC said "replace stub at line N", line N (or the surrounding function) must no longer be the stub.
+4. **Required test**: `grep -nE "^func <TestName>\(" <test_file_in_diff>` against the PR diff. Each named test must appear as a new function definition in the PR.
+
+### Then verify each AC checkbox
+
+For each `- [ ]` AC:
+
+- If the AC names a specific symbol or line and ANY mechanical check above for that symbol/line FAILED → AC is NOT met. New code added elsewhere does not satisfy an AC that names existing code.
+- If the AC describes behavior without naming specific code, search the PR diff for concrete evidence that the behavior is implemented; mark with file:line references.
+- `make test-complete` passes — verified via CI checks in Phase 2.
+
+A criterion is "met" only when (a) the mechanical reference checks for that AC all pass and (b) the diff contains the corresponding change. "Probably met" is not met. "Plausibly addressed by new helper functions" is not met when the AC names existing code that must change.
 
 ### Docs & Tests Currency Gate
 
@@ -117,6 +159,18 @@ Review the PR diff for:
 2. **Security concerns** — hardcoded secrets, SQL injection, information disclosure, unsanitized input
 3. **Test quality** — mocks (prohibited), skipped tests, missing error path coverage
 4. **Correctness** — logic errors, race conditions, resource leaks, missing cleanup
+5. **Banned-phrase scan on diff additions** — `gh pr diff <PR_NUM>` and grep the added lines (lines starting with `+` but not `+++`) case-insensitively for:
+   - `for now`
+   - `simulate`
+   - `would implement`
+   - `tracked internally`
+   - `placeholder implementation`
+   - `In a real implementation`
+   - `In a full implementation`
+
+   Any newly-introduced match outside of a `// Deferred: tracked in #NNN — ...` annotation is a finding (catches agents shipping fresh stubs). Severity: **High** if the matched file is named by the story AC; **Medium** otherwise. A Deferred annotation must reference an open issue labeled `pipeline:story` or `pipeline:epic` — closed-issue references are themselves a Medium finding.
+
+   Pre-existing markers in unchanged lines are out of scope for this scan — they're handled by the sweep story (#1430) and by Phase 3's file-state check for AC-named files.
 
 Classify each finding by severity:
 - **High**: Security vulnerability, data loss risk, architecture violation
@@ -125,9 +179,9 @@ Classify each finding by severity:
 
 ## Phase 5: Verdict
 
-### Zero Findings (PASS)
+### PASS — zero findings AND zero Code-Reference Verification FAILs
 
-Enqueue the PR for merge and clean up:
+PASS requires BOTH: the Findings table is empty AND every Code-Reference Verification row is `Pass`. A single FAIL row blocks PASS regardless of how many findings there are. If both gates are clear, enqueue the PR for merge and clean up:
 
 ```bash
 # Enqueue for merge — uses retry + verify-after wrapping around `gh pr merge --squash`
@@ -184,6 +238,18 @@ cat > /tmp/review-<PR_NUM>.md <<'REVIEW_EOF'
 - [x] Criterion 1 — met (file:line reference)
 - [ ] Criterion 2 — not met (explanation)
 
+### Code-Reference Verification
+| AC # | Reference | Expected | Actual | Pass/Fail |
+|------|-----------|----------|--------|-----------|
+| 1 | activateAccess @ access_manager.go:663 | calls grantStore.CreateSession | line 671 calls grantStore.CreateSession(ctx, session) | PASS |
+| 3 | scheduleDeactivation @ access_manager.go:688 | no `go func()` in body | function body is empty (return only) | PASS |
+| 12 | grep "tracked internally" access_manager.go | 0 matches | 0 matches | PASS |
+
+Example FAIL row (replace with real verification — every row above is an example):
+| 3 | scheduleDeactivation @ access_manager.go:688 | no `go func()` in body | line 691 still contains `go func() {` | **FAIL** |
+
+(If the story body had no concrete code references, write "No concrete references in story body — conventional AC matching applied" and omit the table rows.)
+
 ### Findings
 | # | Severity | File | Description |
 |---|----------|------|-------------|
@@ -206,7 +272,9 @@ If there are zero findings, the Findings table should say "None" and the Accepta
 
 - Never modify source code — you only read diffs and write PR comments
 - Never merge a PR with failing CI checks — CI is a hard gate
-- Never skip acceptance criteria verification — every checkbox must be checked against the diff
+- Never skip acceptance criteria verification — every checkbox must be checked against the diff AND the Code-Reference Verification table
+- **Any FAIL row in Code-Reference Verification forces `## Acceptance Review — FAIL`.** The reviewer CANNOT issue PASS while any reference is failing or unverified. "New functions added + tests pass" is NOT sufficient when the AC names a specific symbol that must change.
+- **Diff-blindness rule**: when an AC names existing code that must change, verify the post-change state by fetching the file from the PR's HEAD ref. Searching only `gh pr diff` will miss unchanged stubs (they're absent from the diff by definition).
 - The fix cycle gets exactly one attempt. First failure = `pipeline:fix`. Second failure = `pipeline:blocked`. No third attempt.
 - Merge enqueue uses `--squash` — merge queue handles the rest (rebase + re-validation + actual merge)
 - Clean up agent container/worktree on auto-merge — the agent infrastructure is no longer needed

--- a/.claude/agents/developer.md
+++ b/.claude/agents/developer.md
@@ -1,6 +1,6 @@
 ---
 name: developer
-description: Fix code issues found by QA and Security review agents. Fixes root causes properly — no mocks, no skips, no hacky workarounds. Use when QA or Security agents report blocking issues.
+description: Fix code issues found by acceptance-checker, QA, and Security review agents. Fixes root causes properly — no mocks, no skips, no hacky workarounds, no helper-function-instead-of-named-stub workarounds. Use when any story-complete reviewer reports blocking issues.
 model: opus
 tools: Read, Grep, Glob, Bash, Edit, Write
 ---
@@ -18,6 +18,8 @@ You are a senior developer fixing issues found by the QA Engineer and Security E
 - **Swallowing errors**: Never use `_ = err` to make tests pass. Handle errors properly.
 - **Adding //nolint without justification**: If a linter catches something, fix it. Only suppress with a clear explanation of why it's a false positive.
 - **Commenting out assertions**: Never comment out `assert.*` or `require.*` calls.
+- **Adding helper functions instead of replacing the AC-named stub**: If `acceptance-checker` reports a FAIL because the story AC names a specific function/file/line and that named code is unchanged, the fix is to MODIFY THAT NAMED CODE. Adding new helper functions elsewhere — even functions that do the right thing — is NOT a valid fix when the AC names existing code that must change. The reviewer's verification re-reads the named symbol post-fix; if it's still the stub, the next iteration will FAIL again.
+- **Leaving banned-phrase markers in changed files**: Adding `// For now`, `// In a real implementation`, `// would implement`, `// simulate`, `// tracked internally`, `// placeholder implementation` markers in your new code is itself a finding. If the work is genuinely deferred, use the `// Deferred: tracked in #NNN — <one-line summary>` annotation pointing at an open `pipeline:story` or `pipeline:epic` issue. Anything else is a stub masquerading as progress.
 
 ### REQUIRED Patterns
 - **Fix root causes**: If a test fails, fix the code being tested OR fix the test to test correctly — never hack around it.
@@ -69,11 +71,13 @@ refactored `examples/` even though tech-lead notes excluded it.
 
 ### 1. Read the findings
 
-Understand each blocking issue from QA/Security with its file:line reference.
+Understand each blocking issue from QA/Security/acceptance-checker with its file:line reference.
 
 ### 2. Understand the root cause
 
 Read the referenced file and surrounding code to understand why the issue exists. Don't just patch the symptom.
+
+**For acceptance-checker FAILs specifically**: read the AC quoted in the finding, then read the named symbol/function on disk. The fix is to modify the named code so it does what the AC describes. If the AC says "replace stub `foo` at file.go:N with X behavior", your edit must change `foo`'s body — not add a new helper that `foo` could call, not refactor adjacent code. The reviewer will re-read `foo` post-fix.
 
 ### 3. Apply proper fix
 

--- a/.claude/agents/qa-code-reviewer.md
+++ b/.claude/agents/qa-code-reviewer.md
@@ -9,6 +9,16 @@ tools: Read, Grep, Glob, Bash
 
 You are a senior QA engineer reviewing code changes for the CFGMS project. Your mandate is to **REJECT shortcuts** that undermine test quality and production reliability. You do NOT fix code — you report findings as blocking issues with file:line references to the team lead.
 
+## Scope (what you DO and DON'T own)
+
+You own **test-quality and code-quality static review** of changed files. You do NOT own:
+
+- **AC alignment** — whether the code delivers the story's acceptance criteria. That's `acceptance-checker`'s concern; it runs in parallel with you on the same team and reads the story body to verify each named symbol/file/line. If you notice an unchanged stub or a banned-phrase comment ("for now", "would implement", "tracked internally") in passing, you may surface it as a WARNING with a pointer to acceptance-checker — but the blocking verdict for AC misalignment comes from acceptance-checker, not you.
+- **Test execution** — `qa-test-runner` runs the suite and reports pass/fail.
+- **Security review** — `security-engineer` runs scans and reviews for vulnerabilities.
+
+Stay narrow. Your strength is pattern detection in test files for the anti-patterns below.
+
 ## CFGMS Testing Standards (NON-NEGOTIABLE)
 
 - **Real Components Only**: Tests MUST use real CFGMS components. Mocks of CFGMS functionality are PROHIBITED.

--- a/.claude/commands/story-complete.md
+++ b/.claude/commands/story-complete.md
@@ -1,6 +1,6 @@
 ---
 name: story-complete
-description: Complete story with parallel adversarial team review (QA test runner + QA code reviewer + Security), Developer on-demand, and PR creation
+description: Complete story with parallel adversarial team review (acceptance checker + QA test runner + QA code reviewer + Security), Developer on-demand, and PR creation
 parameters:
   - name: story_number
     description: Story number to complete (optional - auto-detects from branch)
@@ -9,7 +9,7 @@ parameters:
 
 # Story Complete Command
 
-Final validation gate before PR creation. Orchestrates a **parallel adversarial team review** where test execution, code quality review, and security review run simultaneously. A Developer agent fixes any issues found.
+Final validation gate before PR creation. Orchestrates a **parallel adversarial team review** where AC verification, test execution, code quality review, and security review run simultaneously. A Developer agent fixes any issues found.
 
 ## Execution Flow
 
@@ -23,14 +23,22 @@ Auto-detect story from branch and fetch issue details. Verify all acceptance cri
 TeamCreate(team_name: "story-review")
 ```
 
-Create three tasks on the team task list:
-1. **Run test-quality** — Tests, linting, and builds (no security scans)
-2. **QA code review** — Review changed files for test quality
-3. **Security review** — All security scans + security code review
+Create four tasks on the team task list:
+1. **Acceptance check** — Verify the working tree delivers the story's named code references
+2. **Run test-quality** — Tests, linting, and builds (no security scans)
+3. **QA code review** — Review changed files for test quality
+4. **Security review** — All security scans + security code review
 
 ### 3. Spawn Review Teammates (ALL IN PARALLEL)
 
-Spawn three teammates simultaneously via the Task tool. For each, use `subagent_type: general-purpose` with the `team_name` and `name` parameters. Read the corresponding agent file in `.claude/agents/` and include its instructions in the prompt.
+Spawn four teammates simultaneously via the Task tool. For each, use `subagent_type: general-purpose` with the `team_name` and `name` parameters. Read the corresponding agent file in `.claude/agents/` and include its instructions in the prompt.
+
+**acceptance-checker** (sonnet):
+- Agent file: `.claude/agents/acceptance-checker.md`
+- Reads the story body, extracts concrete code references (file paths, function names, line numbers, banned-phrase quotes, required test names), and verifies each against the working tree
+- Catches "AC names a stub function but the stub is still there" before the PR is created
+- Reports blocking issues with file:line references and AC numbers
+- See `docs/development/acceptance-reviewer-verification.md` for the verification model and regression scenarios
 
 **qa-test-runner** (sonnet):
 - Agent file: `.claude/agents/qa-test-runner.md`
@@ -42,6 +50,7 @@ Spawn three teammates simultaneously via the Task tool. For each, use `subagent_
 - Reviews all changed files for test quality issues
 - Catches mocks, t.Skip(), empty assertions, hacky workarounds
 - Reports blocking issues with file:line references
+- Does NOT check AC alignment — that's acceptance-checker's concern
 
 **security-engineer** (opus):
 - Agent file: `.claude/agents/security-engineer.md`
@@ -52,7 +61,7 @@ Spawn three teammates simultaneously via the Task tool. For each, use `subagent_
 
 ### 4. Collect Results
 
-Wait for all three teammates to complete and send their reports. Collect findings from each.
+Wait for all four teammates to complete and send their reports. Collect findings from each.
 
 ### 5. Fix Issues (if any blocking issues found)
 
@@ -61,6 +70,7 @@ If ANY teammate reported blocking issues, spawn a **developer** teammate:
 - Agent file: `.claude/agents/developer.md`
 - Model: opus
 - Provide combined findings from all reviewers with file:line references
+- For acceptance-checker FAILs specifically, tell the developer the AC number, the named symbol/file/line, and the AC's "after" behavior — and remind them that adding helper functions elsewhere is NOT a valid fix when the AC names existing code that must change
 - Developer fixes root causes properly (NO mocks, NO skips, NO hacks)
 
 After developer completes, re-spawn the reviewers that reported failures to verify fixes. Maximum 3 fix iterations. If issues persist after 3 rounds, shut down team and report to user for manual intervention.

--- a/docs/development/acceptance-reviewer-verification.md
+++ b/docs/development/acceptance-reviewer-verification.md
@@ -1,6 +1,11 @@
-# Acceptance Reviewer — Code-Reference Verification
+# Code-Reference Verification (Acceptance Checking)
 
-This document describes the verification model the Acceptance Reviewer (`.claude/agents/acceptance-reviewer.md`) uses to prevent PASS verdicts on PRs that ship undelivered acceptance criteria.
+This document describes the verification model used by two agents to prevent PASS verdicts on work that ships undelivered acceptance criteria:
+
+- **`.claude/agents/acceptance-checker.md`** — runs **pre-PR**, inside the dev agent's container, as part of `/story-complete`'s parallel review team. Reads files from the working tree directly.
+- **`.claude/agents/acceptance-reviewer.md`** — runs **post-PR**, in a dedicated review container spawned by the PO autonomous cycle. Reads files from the PR's HEAD ref via `gh api`.
+
+Both agents use the same Phase 2.5 extraction + Phase 3 verification model. The fetch mechanism and the verdict actions differ (the in-container checker reports to a team lead and routes failures to the developer agent; the post-PR reviewer posts a PR comment and enqueues or applies fix labels). The verification semantics — what counts as a FAIL — are identical and documented below.
 
 ## The failure mode this prevents
 
@@ -12,16 +17,23 @@ Closed stories #1380, #1381, #1321, #1295 all received `## Acceptance Review —
 4. The reviewer searches `gh pr diff` for evidence the AC is met. The diff shows +500 lines of new code containing the relevant domain words. The reviewer marks the AC met.
 5. The named stub function is still there. The AC is not delivered.
 
-The root cause is **diff blindness**: `gh pr diff` only shows additions and deletions. An unchanged stub is invisible to a diff search. The reviewer needs to verify the post-change state of named code by reading the file on the PR's head ref, not by searching the diff.
+The root cause is **diff blindness**: `gh pr diff` only shows additions and deletions. An unchanged stub is invisible to a diff search. The reviewer needs to verify the post-change state of named code by reading the file directly — from the working tree (pre-PR) or from the PR's head ref (post-PR), but never from the diff alone.
+
+A secondary contributing failure was that the story-complete in-container review team had no AC-alignment reviewer at all. The team's three reviewers (qa-test-runner, qa-code-reviewer, security-engineer) judge the diff against test-quality and security standards but never read the story body. So the failure was a two-layer miss: in-container team didn't catch it, and the post-PR reviewer couldn't either. Adding `acceptance-checker` to the in-container team plus tightening `acceptance-reviewer`'s post-PR check restores defense in depth.
 
 ## Verification mechanism
 
-The reviewer's prompt enforces two anchors:
+Both agents enforce two anchors:
 
-1. **Phase 2.5** extracts every concrete reference from the story body (file paths, function/symbol names, line numbers, banned-phrase quotes, required test names).
-2. **Phase 3** fetches each named file from the PR's HEAD ref and mechanically checks each reference. Banned phrases that remain in still-stubbed locations are FAIL.
+1. **Phase 2 (extraction)** parses the story body for every concrete reference (file paths, function/symbol names, line numbers, banned-phrase quotes, required test names).
+2. **Phase 3 (verification)** reads each named file and mechanically checks each reference. Banned phrases that remain in still-stubbed locations are FAIL.
 
-A Code-Reference Verification table appears in every review comment listing each check and its outcome. Any FAIL row forces an overall `## Acceptance Review — FAIL` verdict — the reviewer cannot reach PASS while any reference is unverified.
+The fetch mechanism differs:
+
+- **acceptance-checker (in-container, pre-PR)**: reads files directly from the working tree on the agent's clone. No `gh api` calls — the working tree IS the would-be post-change state.
+- **acceptance-reviewer (post-PR)**: fetches files from the PR's HEAD ref via `gh api repos/cfg-is/cfgms/contents/<path>?ref=$HEAD_SHA`. The diff alone is not sufficient (unchanged stubs are invisible to a diff).
+
+Both agents report a Code-Reference Verification table listing each check and its outcome. Any FAIL row forces an overall FAIL verdict. The post-PR reviewer renders this as a PR comment; the in-container checker sends it to the team lead, which routes failures to the developer agent for fixing.
 
 ## Banned-phrase canonical list
 

--- a/docs/development/acceptance-reviewer-verification.md
+++ b/docs/development/acceptance-reviewer-verification.md
@@ -1,0 +1,200 @@
+# Acceptance Reviewer — Code-Reference Verification
+
+This document describes the verification model the Acceptance Reviewer (`.claude/agents/acceptance-reviewer.md`) uses to prevent PASS verdicts on PRs that ship undelivered acceptance criteria.
+
+## The failure mode this prevents
+
+Closed stories #1380, #1381, #1321, #1295 all received `## Acceptance Review — PASS` verdicts and merged, but their named acceptance criteria were not delivered. The pattern:
+
+1. Story acceptance criteria name specific existing code: "replace stub `startApprovalWorkflow` at `features/rbac/jit/access_manager.go:653`".
+2. The dev agent adds new helper functions elsewhere in the file but leaves the named function unchanged.
+3. New tests for the new functions pass; existing tests still pass; CI is green.
+4. The reviewer searches `gh pr diff` for evidence the AC is met. The diff shows +500 lines of new code containing the relevant domain words. The reviewer marks the AC met.
+5. The named stub function is still there. The AC is not delivered.
+
+The root cause is **diff blindness**: `gh pr diff` only shows additions and deletions. An unchanged stub is invisible to a diff search. The reviewer needs to verify the post-change state of named code by reading the file on the PR's head ref, not by searching the diff.
+
+## Verification mechanism
+
+The reviewer's prompt enforces two anchors:
+
+1. **Phase 2.5** extracts every concrete reference from the story body (file paths, function/symbol names, line numbers, banned-phrase quotes, required test names).
+2. **Phase 3** fetches each named file from the PR's HEAD ref and mechanically checks each reference. Banned phrases that remain in still-stubbed locations are FAIL.
+
+A Code-Reference Verification table appears in every review comment listing each check and its outcome. Any FAIL row forces an overall `## Acceptance Review — FAIL` verdict — the reviewer cannot reach PASS while any reference is unverified.
+
+## Banned-phrase canonical list
+
+The Phase 4 diff-additions scan and Phase 3 named-file scan both grep for these phrases (case-insensitive):
+
+- `for now`
+- `simulate`
+- `would implement`
+- `tracked internally`
+- `placeholder implementation`
+- `In a real implementation`
+- `In a full implementation`
+
+A match outside of a `// Deferred: tracked in #NNN — <summary>` annotation is a finding. The Deferred annotation is the only escape hatch for legitimately-deferred work, and it must reference an open `pipeline:story` or `pipeline:epic` issue.
+
+## Regression scenarios
+
+The following scenarios describe expected reviewer behavior. They are not executable tests — agent prompts have no integration-test harness — but they are the contract a future change to the reviewer's verification model must preserve.
+
+### Scenario 1 — Unchanged named stub (the #1380 failure mode)
+
+**Setup**
+
+Story body contains:
+
+```
+- [ ] Replace the stub `startApprovalWorkflow` at `features/rbac/jit/access_manager.go:653` with real multi-stage progression.
+```
+
+PR diff:
+
+```diff
++ func (jam *JITAccessManager) advanceWorkflowStage(...) error {
++     ...
++ }
++ func TestJITAccessManager_MultiStageApproval_AdvancesStages(t *testing.T) {
++     ...
++ }
+```
+
+`startApprovalWorkflow` body on PR HEAD:
+
+```go
+func (jam *JITAccessManager) startApprovalWorkflow(ctx context.Context, request *JITAccessRequest, workflow *ApprovalWorkflow) error {
+    // Implementation would integrate with workflow engine
+    // For now, simulate by notifying first stage approvers
+    if len(workflow.Approvers) > 0 {
+        firstStage := workflow.Approvers[0]
+        return jam.sendApprovalNotifications(ctx, request, firstStage.Approvers)
+    }
+    return nil
+}
+```
+
+**Expected verdict**: `## Acceptance Review — FAIL`
+
+**Expected verification table** (subset):
+
+| AC # | Reference | Expected | Actual | Pass/Fail |
+|------|-----------|----------|--------|-----------|
+| 1 | startApprovalWorkflow @ access_manager.go:653 | multi-stage progression body | function body still contains `// For now, simulate by notifying...` | FAIL |
+| 1 | grep "for now" access_manager.go | 0 matches in the named function | 1 match @ line 655 | FAIL |
+| 1 | grep "simulate" access_manager.go | 0 matches | 1 match @ line 655 | FAIL |
+| 1 | grep "would implement" access_manager.go | 0 matches | 1 match @ line 654 | FAIL |
+
+**Why this matters**: under the previous prompt, the +500 lines of new code in the diff caused the reviewer to mark the AC met. Under the new prompt, the FAIL rows force FAIL regardless of how much surrounding code was added.
+
+### Scenario 2 — Unchanged stub with banned phrase (the #1381 failure mode)
+
+**Setup**
+
+Story body contains:
+
+```
+- [ ] `activateAccess` persists the grant to `SessionStore` as `SessionTypeJIT`
+- [ ] `scheduleDeactivation` no longer spawns a goroutine; the per-grant goroutine pattern is fully removed from the file
+- [ ] Verification: grep -nE "For now, the grant is tracked internally|For now, we'll implement a simple goroutine" features/rbac/jit/access_manager.go returns zero matches
+```
+
+`scheduleDeactivation` body on PR HEAD:
+
+```go
+func (jam *JITAccessManager) scheduleDeactivation(ctx context.Context, grant *JITAccessGrant) {
+    // In a real implementation, this would schedule a background job
+    // For now, we'll implement a simple goroutine
+    go func() { ... }()
+}
+```
+
+**Expected verdict**: `## Acceptance Review — FAIL`
+
+**Expected verification table** (subset):
+
+| AC # | Reference | Expected | Actual | Pass/Fail |
+|------|-----------|----------|--------|-----------|
+| 2 | scheduleDeactivation @ access_manager.go:688 | no `go func()` in body | line 691 contains `go func() {` | FAIL |
+| 3 | grep "tracked internally" access_manager.go | 0 matches | 1 match @ line 671 | FAIL |
+| 3 | grep "In a real implementation" access_manager.go | 0 matches | 1 match @ line 689 | FAIL |
+
+### Scenario 3 — Legitimate PASS
+
+**Setup**
+
+Story body contains:
+
+```
+- [ ] Replace the stub `startApprovalWorkflow` at `features/rbac/jit/access_manager.go:653` with real multi-stage progression.
+```
+
+`startApprovalWorkflow` body on PR HEAD:
+
+```go
+func (jam *JITAccessManager) startApprovalWorkflow(ctx context.Context, request *JITAccessRequest, workflow *ApprovalWorkflow) error {
+    state := newWorkflowState(workflow)
+    jam.approvalWorkflows[request.ID] = state
+    return jam.notifyStageApprovers(ctx, request, workflow.Approvers[0].Approvers)
+}
+```
+
+No banned phrases anywhere in the file (excluding test files and `// Deferred:` annotations).
+
+**Expected verdict**: `## Acceptance Review — PASS`
+
+**Expected verification table** (subset):
+
+| AC # | Reference | Expected | Actual | Pass/Fail |
+|------|-----------|----------|--------|-----------|
+| 1 | startApprovalWorkflow @ access_manager.go:653 | multi-stage progression body | function calls newWorkflowState + notifyStageApprovers | PASS |
+| 1 | grep "for now" access_manager.go | 0 matches | 0 matches | PASS |
+| 1 | grep "simulate" access_manager.go | 0 matches | 0 matches | PASS |
+
+### Scenario 4 — Deferred annotation (escape hatch)
+
+**Setup**
+
+Story body lists "feature X is out of scope; track in a follow-up issue".
+
+PR introduces:
+
+```go
+// Deferred: tracked in #1500 — full implementation needs SessionStore integration
+// For now, returns the in-memory snapshot only.
+return jam.activeGrants, nil
+```
+
+Issue #1500 is open and labeled `pipeline:story`.
+
+**Expected verdict**: `## Acceptance Review — PASS` (no findings from the banned-phrase scan)
+
+**Why**: the Deferred annotation immediately above the banned phrase, plus the open tracking issue, satisfies the escape-hatch criteria. The phrase appearing in a Deferred-annotated block is not a finding.
+
+### Scenario 5 — Deferred annotation pointing at a closed issue
+
+**Setup**
+
+Same as Scenario 4, but issue #1500 is closed.
+
+**Expected verdict**: `## Acceptance Review — FAIL` (Medium finding for invalid Deferred reference)
+
+**Why**: Deferred annotations must reference open tracking issues; closed references mask abandoned work as deferred work.
+
+## What this verification does not catch
+
+- **AC ambiguity**: if the story body never names specific code, Phase 2.5 has nothing to extract. The reviewer falls back to conventional AC matching. The Tech Lead pass is responsible for catching ambiguous AC during validation, not the reviewer.
+- **Subtle correctness bugs in newly-added code**: the verification model only checks that named code has changed; it doesn't verify that the new code is correct. That's the job of the unit tests, integration tests, and Phase 4 code review.
+- **Unrelated regressions outside named files**: the named-file scan is targeted. Broad regressions are caught by CI, not by the verification model.
+
+## When to update this document
+
+Update this document when:
+
+1. The banned-phrase canonical list changes (add new phrases that indicate stubbed work, or retire phrases that have become noisy).
+2. A new failure mode emerges where a PASS verdict ships undelivered work — add a Scenario describing the new pattern and the verification rule that catches it.
+3. The Phase 2.5/3 extraction or verification logic in `.claude/agents/acceptance-reviewer.md` changes substantively.
+
+This document is the contract for what the verification model must catch. The prompt is the implementation. Keep them aligned.


### PR DESCRIPTION
## Summary

Closes both layers of a two-layer AC-bypass failure that let closed stories #1380, #1381, #1321, #1295 ship undelivered work:

1. **Post-PR layer**: `acceptance-reviewer` searches `gh pr diff` for evidence — but the diff only shows additions/deletions, so unchanged stubs are invisible. New helper functions in +500-line diffs created false confidence.
2. **In-container layer**: `/story-complete`'s parallel review team (qa-test-runner, qa-code-reviewer, security-engineer) judges the diff against test-quality and security standards — **none of them reads the story body.** The dev agent's own self-review had no AC-alignment check at all.

This PR closes both with a shared Code-Reference Verification model.

## What changed

### Post-PR reviewer
- New Phase 2.5: Code-Reference Extraction parses story body for symbols/files/line numbers/banned phrases/required tests
- Phase 3 rewritten to fetch named files from PR HEAD ref via gh api (defeats diff blindness)
- Phase 4 banned-phrase scan on diff additions
- Phase 5 PASS requires zero findings AND zero verification FAILs
- Code-Reference Verification table in every review comment

### In-container reviewer (NEW)
- 4th parallel teammate in /story-complete
- Same verification model, reads from working tree directly
- Failures route to developer agent for fixing

### Supporting changes
- story-complete.md spawns acceptance-checker; developer handoff includes AC-check FAIL guidance
- qa-code-reviewer.md scope note: AC alignment is acceptance-checker's job
- developer.md adds prohibitions on helper-instead-of-stub and banned-phrase markers
- New doc docs/development/acceptance-reviewer-verification.md with five regression scenarios

## Self-approval forbidden

This PR must NOT be self-approved by the current acceptance-reviewer or run through the new acceptance-checker self-test, since the current reviewer is the artifact being fixed. Founder review required before merge.

Fixes #1427
