### PR TITLE
rbac/jit: add isWorkflowComplete helper and wire into ApproveRequest (Issue #1428)

### DIFF
--- a/features/rbac/jit/access_manager.go
+++ b/features/rbac/jit/access_manager.go
@@ -488,8 +488,7 @@ func (jam *JITAccessManager) ApproveRequest(ctx context.Context, requestID, appr
 
 		// Advance when the stage's MinApprovals threshold is met.
 		if len(request.WorkflowState.StageApprovals[stageIdx]) >= stage.MinApprovals {
-			nextIdx := stageIdx + 1
-			if nextIdx >= len(workflow.Approvers) {
+			if jam.isWorkflowComplete(request, workflow) {
 				// Final stage complete — delegate to internal approveRequest for grant creation.
 				return jam.approveRequest(ctx, requestID, approverID, reason)
 			}
@@ -1062,6 +1061,15 @@ func (jam *JITAccessManager) advanceWorkflowStage(ctx context.Context, request *
 	if nextIdx < len(workflow.Approvers) {
 		_ = jam.sendApprovalNotifications(ctx, request, workflow.Approvers[nextIdx].Approvers)
 	}
+}
+
+// isWorkflowComplete reports whether the current stage is the final stage of the workflow.
+// Called before stage advancement: returns true when stageIdx+1 equals the total stage count.
+func (jam *JITAccessManager) isWorkflowComplete(request *JITAccessRequest, workflow *ApprovalWorkflow) bool {
+	if request.WorkflowState == nil {
+		return false
+	}
+	return request.WorkflowState.CurrentStage+1 >= len(workflow.Approvers)
 }
 
 // activateAccess sets the grant active and persists it to the SessionStore.


### PR DESCRIPTION
## Summary

- Adds the `isWorkflowComplete` named helper that Issue #1428's spec required but PR #1390 omitted — the helper returns `true` when `CurrentStage+1 >= len(workflow.Approvers)`, with a defensive nil-guard on `WorkflowState`
- Replaces the inline `nextIdx` check in `ApproveRequest` with the named helper, making the final-stage detection explicit
- All multi-stage approval logic (WorkflowState initialization, per-stage set tracking, MinApprovals advancement, stage audit events, non-member rejection, duplicate idempotency, auto-approval bypass) was already correctly implemented by the preceding commit in PR #1390 and is verified passing here

Fixes #1428

## AC Verification

| AC | Status |
|----|--------|
| 1. startApprovalWorkflow initializes WorkflowState | ✅ |
| 2. ApproveRequest records approver, advances on MinApprovals, stays pending | ✅ |
| 3. Single-stage no regression | ✅ |
| 4. Non-member rejection distinct from RBAC error | ✅ |
| 5. Duplicate approver silently ignored | ✅ |
| 6. Stage advancement notifies next-stage approvers | ✅ |
| 7. stage_approved audit event with stage_id + approver_id | ✅ |
| 8. validateStageApprover only in public ApproveRequest path | ✅ |
| 9. All existing tests pass without modification | ✅ |
| 10. Banned stub phrases absent (grep returns 0 matches) | ✅ |

## Specialist Review Results

**QA Test Runner: PASS**
- All packages pass including `features/rbac/jit` (race detection enabled)
- Cross-platform compilation: linux/amd64, linux/arm64, darwin/amd64, darwin/arm64, windows/amd64 all pass
- Integration tests pass

**QA Code Reviewer: PASS** (3 non-blocking warnings)
- All 7 required multi-stage tests verified present
- No mocks, no t.Skip(), no empty assertions, no error swallowing

**Security Engineer: PASS**
- security-precommit: PASS
- check-architecture: PASS (no central provider violations)
- security-scan: PASS (Trivy, Nancy, gosec, staticcheck all green)
- Pure behavior-preserving refactor; RBAC and stage-membership gates untouched

## Test Plan

- [ ] All 7 multi-stage approval tests pass: `go test ./features/rbac/jit/... -race`
- [ ] Banned phrase grep: `grep -n "simulate by notifying first stage approvers" features/rbac/jit/access_manager.go` → 0 matches
- [ ] Banned phrase grep: `grep -n "Implementation would integrate with workflow engine" features/rbac/jit/access_manager.go` → 0 matches
- [ ] CI required checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)