### PR TITLE
refresh-pins: add Agent Skill for pin freshness research + story creation

### DIFF
--- a/.claude/skills/refresh-pins/SKILL.md
+++ b/.claude/skills/refresh-pins/SKILL.md
@@ -1,0 +1,156 @@
+---
+name: refresh-pins
+description: Research all pinned dependencies and the Go toolchain version against
+  their upstream latest releases, apply a 3-day cooldown plus CVE-driven override
+  policy, and create stories for pins that should be bumped. Use after the weekly
+  `dependency-pins` GitHub issue lands, when Trivy or the docker-security gate
+  flags a CVE in a currently-pinned version, or when the founder asks about pin
+  freshness. Loads the full decision rationale and cooldown policy from
+  references/ lazily — do not pre-load them. Outputs a single Markdown summary
+  and one GitHub story per pin that should be bumped.
+context: fork
+agent: general-purpose
+allowed-tools: Bash, Read, Write, WebFetch
+---
+
+# Refresh-Pins Skill
+
+You research the state of every pinned dependency in the repo, apply the cooldown + CVE policy, and create dispatchable stories for the ones that need bumping. You produce one Markdown summary back to the founder, no chatter.
+
+## Inputs
+
+`$ARGUMENTS` is one of:
+
+- empty — sweep every pin
+- `<pin-name>` — focused single-pin run (e.g. `go-toolchain`, `trivy`, `gosec`)
+- `--urgent <pin-name>` — CVE-driven; skip the cooldown gate, log the override
+
+## Phase 1: Discover
+
+Run the discovery script to build the pin inventory:
+
+```bash
+./.claude/skills/refresh-pins/scripts/discover-pins.py
+```
+
+Output is JSON conforming to `references/inventory-schema.md` (load that file lazily if you need to interpret a field). Each pin entry has: `name`, `kind` (`lockstep` | `tool`), `current` version, `release_source` (URL or `gh:<org>/<repo>`), and `locations[]` of every file:line where the pin appears.
+
+If `$ARGUMENTS` names a specific pin, filter the inventory to that pin only. Halt with a clear error if the named pin isn't in the inventory.
+
+## Phase 2: Research
+
+For each pin (run in parallel where independent — separate Bash calls in one assistant turn):
+
+1. **Latest stable version + published_at**
+   - `gh:<owner>/<repo>` release source: `gh api repos/<owner>/<repo>/releases/latest --jq '{tag_name, published_at}'`
+   - `https://go.dev/dl/?mode=json` source: `curl -fsSL 'https://go.dev/dl/?mode=json' | jq '[.[] | select(.stable)][0] | {version, files: [.files[] | select(.kind=="source")][0].sha256}'`
+2. **CVEs against the current pinned version** — `gh api graphql` GHSA query:
+   ```graphql
+   query($ecosystem: SecurityAdvisoryEcosystem!, $package: String!) {
+     securityVulnerabilities(ecosystem: $ecosystem, package: $package, first: 20) {
+       nodes {
+         severity
+         advisory { ghsaId summary }
+         vulnerableVersionRange
+         firstPatchedVersion { identifier }
+       }
+     }
+   }
+   ```
+   For Go stdlib use ecosystem `GO`, package `stdlib`. For tools that don't resolve cleanly through GHSA, fall back to a `WebFetch` of their release notes for the latest version and look for "CVE" mentions.
+3. **CI-driven signal** — check whether the current pin is actively blocking CI:
+   ```bash
+   gh run list --repo cfg-is/cfgms --workflow docker-security.yml --status failure --limit 5 \
+     --json databaseId,headSha --jq '.[].databaseId' | head -3 | while read run_id; do
+       gh api "repos/cfg-is/cfgms/actions/runs/$run_id/artifacts" --jq '.artifacts[] | select(.name | contains("trivy")) | .archive_download_url'
+   done
+   ```
+   Then for each artifact URL, download, unzip, and grep the SARIF for `"Installed Version": "<current_pin>"`. A match means the gate is currently failing on this exact pin → flag for cooldown override.
+
+## Phase 3: Justify (apply the decision matrix)
+
+Load `references/decision-matrix.md` and `references/cooldown-policy.md` only now (lazy).
+
+Apply the matrix per pin. The summary table:
+
+| Has active CVE blocking CI? | Cooldown elapsed? | Decision |
+|---|---|---|
+| Yes | (override) | **BUMP NOW** + audit log entry |
+| Yes | Yes | **BUMP** |
+| No | Yes | **BUMP** |
+| No | No | **HOLD** until cooldown elapses |
+| No newer release | — | **OK** |
+
+For each pin, record a 1-paragraph justification block citing: current/latest versions, release date, days since release, the cooldown threshold applied, any CVE IDs found, and any CI-blocking signal observed.
+
+If `$ARGUMENTS` started with `--urgent`, force BUMP NOW for the named pin regardless of cooldown — but still write the override line to the audit log.
+
+## Phase 4: Create stories
+
+For each pin with verdict BUMP or BUMP NOW:
+
+1. Read `assets/story-template.md` (lazy load)
+2. Substitute placeholders:
+   - `{{NAME}}` — pin name (e.g. `go-toolchain`)
+   - `{{FROM}}` — current version
+   - `{{TO}}` — latest version
+   - `{{JUSTIFICATION}}` — paragraph from Phase 3
+   - `{{LOCATION_COUNT}}` — number of file:line entries
+   - `{{LOCATION_LIST}}` — bullet list of every `file:line` to touch
+   - `{{FROM_PATTERN}}` / `{{TO_PATTERN}}` — regex-escaped version strings for grep verification
+   - `{{SCOPE_PATHS}}` — comma-separated paths to grep within (derived from `locations`)
+   - `{{COOLDOWN_BLOCK}}` — "Cooldown elapsed (N days since release)" OR "Cooldown OVERRIDE: CVE-X blocking <gate>"
+3. Write the instantiated body to `/tmp/refresh-pins-<slug>.md`
+4. Create the story:
+   ```bash
+   gh issue create --repo cfg-is/cfgms \
+     --title "deps: bump <name> <from> → <to> (<short-reason>)" \
+     --label "pipeline:story,agent:ready,dependencies" \
+     --body-file /tmp/refresh-pins-<slug>.md
+   ```
+5. Capture the returned URL/number for the report
+
+If a story for the same pin+version already exists (search by title with `gh issue list --search "deps: bump <name> <from> → <to>"`), update it in place via `gh issue comment` rather than duplicating.
+
+## Phase 5: Cooldown override audit (if any BUMP NOW)
+
+For each BUMP NOW verdict, append one line to `.claude/scratch/pin-overrides.log`:
+
+```
+<ISO-8601 UTC>  <pin-name>  <from>→<to>  <CVE-or-reason>  story:#<NNNN>
+```
+
+Create the file if it doesn't exist. Append only — never rewrite.
+
+## Phase 6: Report to the founder
+
+Single Markdown summary, sections in this order (omit empty sections):
+
+```markdown
+## Pin Refresh — <local time, e.g. 11:51 EDT>
+
+### Bumping immediately (CVE-driven, cooldown override)
+- <name> <from>→<to> — <CVE-ID> blocking <gate>; story #NNNN
+
+### Bumping (cooldown elapsed)
+- <name> <from>→<to> — released <N> days ago; story #NNNN
+
+### Holding (within cooldown window)
+- <name> <from>→<to> — released <N> days ago; waiting until <YYYY-MM-DD>
+
+### Up to date
+- <count> pins up to date (collapsed; expand on request)
+
+### Stories created
+- #NNNN — deps: bump <name>
+- ...
+```
+
+## Rules
+
+- **Lazy-load references**: do not read `references/decision-matrix.md`, `references/cooldown-policy.md`, or `references/inventory-schema.md` until Phase 2/3 needs them. They are not in your context until you Read them.
+- **One story per logical pin**, not per file. `go-toolchain` is one story that touches all 13 file:line locations in lockstep.
+- **No code edits**: this skill creates stories, it does not edit go.mod / workflows / Dockerfiles directly. Dispatched dev agents apply the bumps under the regular pipeline.
+- **CI-blocking pins skip cooldown**: a vulnerability that's actively failing required CI is its own justification — don't wait the 3 days.
+- **Audit every override**: every BUMP NOW that overrides cooldown gets a line in the audit log. No exceptions.
+- **Idempotent**: re-running the skill produces the same stories (or comments on existing ones if they already exist). No duplicates.

--- a/.claude/skills/refresh-pins/assets/story-template.md
+++ b/.claude/skills/refresh-pins/assets/story-template.md
@@ -1,0 +1,49 @@
+## Summary
+
+Bump `{{NAME}}` from `{{FROM}}` to `{{TO}}`.
+
+## Why now
+
+{{JUSTIFICATION}}
+
+## Files to update ({{LOCATION_COUNT}} occurrences — lockstep required)
+
+{{LOCATION_LIST}}
+
+## Acceptance Criteria
+
+1. Every location listed above is updated from `{{FROM}}` to `{{TO}}`. No file left at the old version.
+2. **Verification — old version absent**: `grep -rE "{{FROM_PATTERN}}" {{SCOPE_PATHS}}` returns **0 matches**.
+3. **Verification — new version present**: `grep -rE "{{TO_PATTERN}}" {{SCOPE_PATHS}}` returns **{{LOCATION_COUNT}} matches**.
+4. `make test` passes locally before the PR is opened.
+5. CI required checks all pass (unit-tests, integration-tests, Build Gate, security-deployment-gate).
+6. If this pin appears in any Docker image (FROM golang:..., FROM ...), the rebuilt image's Trivy scan reports the new version, not the old. The acceptance reviewer must verify by fetching the latest docker-security workflow run for this PR and grepping the Trivy SARIF for `"Installed Version"` lines.
+
+## Cooldown decision
+
+{{COOLDOWN_BLOCK}}
+
+## Out of Scope
+
+- Bumping unrelated pins in the same PR (one story per logical pin)
+- Refactoring code that uses the bumped dependency (only the version string changes)
+- Adding new tests for behavior that already has coverage
+
+## Dependencies
+
+None
+
+## Implementation Notes
+
+- This is a mechanical change. Edit every location in the list, run `make test`, commit, open PR targeting `develop`.
+- If `make test` fails on the new version, that's a real regression — STOP, do not paper over it. Open a `pipeline:blocked` issue describing the failure and assign to the founder. Do NOT add `t.Skip()` or otherwise mask the failure.
+- For Docker `FROM` lines: the tag format is `<image>:<version>-<base>`. Preserve the `-alpine3.23` (or whatever) suffix exactly — only the version segment changes.
+- For Go toolchain bumps specifically: `go.mod` uses `toolchain go1.X.Y` (no leading `v`); workflows use `GO_VERSION: '1.X.Y'` and `go-version: '1.X.Y'`; Dockerfiles use `FROM golang:1.X.Y-alpine...`. Same numeric value, three different surrounding syntaxes — all must move together.
+
+## Required Tests
+
+`make test` must pass. No new tests required for a version bump (unless `make test` exposes a real regression that requires test updates).
+
+## Notes
+
+This story was created by the `refresh-pins` skill on {{DATE_UTC}}. See `.claude/skills/refresh-pins/SKILL.md` for the skill's flow and `.claude/skills/refresh-pins/references/cooldown-policy.md` for the cooldown policy this story applied.

--- a/.claude/skills/refresh-pins/references/cooldown-policy.md
+++ b/.claude/skills/refresh-pins/references/cooldown-policy.md
@@ -1,0 +1,89 @@
+# Pin Cooldown Policy
+
+Why we wait, how long, and when we override.
+
+## The 3-day default
+
+Default cooldown: **3 days** from upstream release `published_at` before bumping a pin.
+
+### Why we wait at all
+
+Three classes of incident the cooldown defends against:
+
+1. **Supply-chain compromise** — malicious or compromised release that the upstream maintainer or registry yanks within hours-to-days. CVE-2026-33634 (compromised Trivy v0.69.4-6, ref `docs/runbooks/trivy-rollback.md`) is the canonical example. The maintainer yanked the bad versions within 48 hours. A 3-day window catches the obvious cases without making us laggards.
+2. **Regression in the release** — the release builds and ships but introduces a behavior regression that surfaces over 24-72 hours of community use. Bumping immediately means we run into the regression too.
+3. **Build/install issues** — the release artifact has a missing file, wrong checksum, or broken installer. Caught quickly by the broader community.
+
+### Why 3 days specifically
+
+| Threshold | Pro | Con |
+|---|---|---|
+| 0 days (immediate) | Always on the latest | Full exposure to supply-chain attacks |
+| 3 days (default) | Catches supply-chain yanks (48-72h typical) | Brief lag on patches |
+| 7 days | More conservative | Real lag during active CVE waves |
+| 14 days | Maximum caution | Months behind on routine updates |
+
+The CFGMS posture is **3 days routine, override on CI-blocking CVE**. Aligned with the founder's stated policy ("3-5 days from release unless upgrade faster is warranted to fix a current vulnerability").
+
+## Per-pin overrides
+
+The default is 3 days for every pin discovered. Per-pin overrides live in a small JSON file alongside this doc:
+
+`.claude/skills/refresh-pins/references/cooldown-overrides.json` (optional — absent file means "all pins use the default")
+
+Example:
+
+```json
+{
+  "go-toolchain": {"cooldown_days": 5, "reason": "stdlib bumps touch the entire build; extra caution"},
+  "gosec":        {"cooldown_days": 2, "reason": "low blast radius; faster refresh OK"}
+}
+```
+
+Claude reads this in Phase 3 and applies the per-pin value when present.
+
+## Override conditions (skip the cooldown)
+
+The cooldown is overridden when ANY of these are true:
+
+1. **Active CVE blocking required CI** — see `decision-matrix.md` for the precise definition. This is the common case.
+2. **`--urgent` flag** at invocation time — founder asserts urgency from external knowledge (Trivy DB lag, supply-chain announcement, etc.).
+3. **Cooldown override file exists with `force: true`** — emergency mode, set by the founder for a specific pin. Documented in the audit log immediately. Removed after the bump lands.
+
+When the cooldown is overridden, **the audit log entry is mandatory**.
+
+## The audit log
+
+Location: `.claude/scratch/pin-overrides.log`
+
+Format (one line per override, append-only):
+
+```
+<ISO-8601 UTC>  <pin-name>  <from>→<to>  <reason>  story:#<NNNN>
+```
+
+Examples:
+
+```
+2026-05-12T15:30:14Z  go-toolchain  1.25.9→1.25.10  CVE-2026-33811 (+4 more) blocking security-deployment-gate  story:#1444
+2026-05-15T08:12:00Z  trivy         v0.70.0→v0.71.0  --urgent (founder: yanked-version-announcement)            story:#1450
+```
+
+Rationale (why an append-only log):
+
+- **Auditability**: every bump-without-cooldown leaves a record of why
+- **Pattern detection**: if the same pin gets overridden repeatedly, the cooldown for that pin may need tuning
+- **Forensics**: when a future incident traces back to a too-fast bump, the log shows the decision and its rationale
+- **Append-only**: rewriting history defeats the audit purpose. Use a new line to correct a prior entry.
+
+Claude appends via `printf '...' >> .claude/scratch/pin-overrides.log` — never rewrites.
+
+## When NOT to override
+
+Even with these signals, do NOT skip cooldown when:
+
+- The CVE severity is `MEDIUM` or `LOW` (only HIGH/CRITICAL justifies the override)
+- The CVE is in a code path the project doesn't exercise (mark as `accept-risk` in a tracking issue rather than racing to bump)
+- The release was published less than 6 hours ago — `published_at < 6 hours` is too fresh even with a CVE; wait the minimum 6h for any obvious supply-chain yank to surface
+
+The 6-hour minimum is hard-coded; it's not configurable per pin. A release that's been out less than 6 hours is too fresh to trust, full stop.

--- a/.claude/skills/refresh-pins/references/decision-matrix.md
+++ b/.claude/skills/refresh-pins/references/decision-matrix.md
@@ -1,0 +1,94 @@
+# Pin Bump Decision Matrix
+
+The full bump-or-hold rationale that backs the summary table in SKILL.md. Loaded by Claude in Phase 3.
+
+## The matrix
+
+| # | Has active CVE blocking required CI? | Cooldown elapsed? | Newer release exists? | Verdict | Notes |
+|---|---|---|---|---|---|
+| 1 | Yes | (any) | Yes | **BUMP NOW** | Cooldown overridden — vulnerability is its own justification. Write audit-log entry. |
+| 2 | No  | Yes | Yes | **BUMP** | Routine refresh. No urgency. |
+| 3 | No  | No  | Yes | **HOLD** | Within cooldown window. Report the unlock date in the founder summary. |
+| 4 | No  | (n/a) | No  | **OK** | Up to date. |
+| 5 | Yes | (n/a) | No  | **INVESTIGATE** | We're pinned at a vulnerable version with no fix available. Escalate. |
+
+## What counts as "active CVE blocking required CI"
+
+Concrete evidence — not just "this version has a CVE in some advisory database." All three of:
+
+1. The CVE affects the `current` version (vulnerable version range includes it).
+2. The CVE has severity `HIGH` or `CRITICAL` (medium/low don't override cooldown).
+3. The CVE is detected by a required CI check — `security-deployment-gate`, `unit-tests`, `integration-tests`, or `Build Gate` — that is currently failing or has failed in the last 5 runs.
+
+Evidence for criterion 3 is the Trivy SARIF artifact downloaded in Phase 2's CI-driven-signal step. If the SARIF lists `Installed Version: <current>` for a HIGH/CRITICAL CVE, criterion 3 is met.
+
+If a CVE is in the advisory database but no CI check has surfaced it, this is **BUMP** (eligible normally) not **BUMP NOW** — wait for the cooldown.
+
+## What counts as "cooldown elapsed"
+
+`now - published_at >= cooldown_days` where `cooldown_days` is the per-pin cooldown threshold from `cooldown-policy.md`.
+
+Default cooldown is **3 days**. Per-pin overrides allowed for higher-risk pins (the Go toolchain itself, anything in the security gate's hot path).
+
+Cooldown is measured from the release's `published_at` timestamp returned by the upstream API, NOT from when we noticed.
+
+## Worked examples
+
+### Example 1 — the 2026-05-12 incident (Verdict: BUMP NOW)
+
+- Pin: `go-toolchain`, current `1.25.9`
+- Latest: `1.25.10`, published 2026-05-09 (3 days ago)
+- CVEs in 1.25.9: CVE-2026-33811, 33814, 39820, 39836, 42499 — all HIGH severity, ecosystem GO, package stdlib
+- CI signal: docker-security gate failing on PR #1426 since 2026-05-11; Trivy SARIF lists `Installed Version: v1.25.9` for all five CVEs
+- Cooldown: 3 days elapsed; would have qualified for BUMP anyway, but **CI-driven override applies regardless**
+
+Verdict: **BUMP NOW**. Audit log:
+
+```
+2026-05-12T15:30:00Z  go-toolchain  1.25.9→1.25.10  CVE-2026-33811 (+4) blocking security-deployment-gate  story:#NNNN
+```
+
+### Example 2 — newly-released minor bump, no urgency (Verdict: HOLD)
+
+- Pin: `trivy`, current `v0.70.0`
+- Latest: `v0.71.0`, published 2 days ago
+- CVEs in v0.70.0: none in GHSA
+- CI signal: none — docker-security gate is green on the latest develop runs
+- Cooldown: NOT elapsed (2 < 3 days)
+
+Verdict: **HOLD**. Founder summary line: `trivy v0.70.0→v0.71.0 — released 2 days ago; waiting until <date>`
+
+### Example 3 — newer release, past cooldown, no CVE (Verdict: BUMP)
+
+- Pin: `gosec`, current `v2.26.1`
+- Latest: `v2.27.0`, published 9 days ago
+- CVEs in v2.26.1: none
+- CI signal: none
+- Cooldown: elapsed (9 > 3 days)
+
+Verdict: **BUMP**. Story body explains: routine refresh, past cooldown, no urgency. Cooldown block is `Cooldown elapsed (9 days since release; threshold 3 days)`.
+
+### Example 4 — pinned-at-vulnerable, no fix available (Verdict: INVESTIGATE)
+
+- Pin: `somepkg`, current `v1.2.3` (latest)
+- CVEs in v1.2.3: CVE-2026-XXXXX, HIGH
+- CI signal: yes (Trivy is flagging it)
+- No newer release exists
+
+Verdict: **INVESTIGATE**. Don't create a bump story (there's nowhere to bump to). Create a `pipeline:blocked` issue describing the pin, the CVE, and the lack of upstream fix — assign to founder. The skill should print this case explicitly in the report so the founder can escalate to the upstream or accept the risk.
+
+## Multiple CVEs in one pin
+
+Aggregate by maximum severity. If a pin has both LOW and HIGH CVEs, treat it as HIGH.
+
+In the audit log, list the highest-severity CVE ID followed by `(+N more)` rather than listing all of them.
+
+## When to use the `--urgent` flag
+
+`--urgent <pin-name>` forces BUMP NOW for that pin even when no CVE is in evidence. Use only when:
+
+- Trivy / external scanner has flagged a CVE we know about but the GHSA query hasn't picked it up yet
+- A supply-chain incident is reported on the pinned version
+- The founder explicitly invokes it after their own threat-assessment
+
+Every `--urgent` use generates an audit log line with reason field set to whatever the founder passed after the flag (or "founder-override" if no reason given).

--- a/.claude/skills/refresh-pins/references/inventory-schema.md
+++ b/.claude/skills/refresh-pins/references/inventory-schema.md
@@ -1,0 +1,50 @@
+# Pin Inventory JSON Schema
+
+`scripts/discover-pins.py` emits a JSON array to stdout. Each element is a pin object.
+
+## Pin object
+
+```jsonc
+{
+  "name": "go-toolchain",       // string — stable identifier for this pin (used in story titles, override audit log)
+  "kind": "lockstep",           // "lockstep" | "tool"
+  "current": "1.25.10",         // string — version string as it appears in the source (no leading "v" for Go)
+  "release_source": "https://go.dev/dl/?mode=json",  // URL or "gh:<owner>/<repo>"
+  "ecosystem": "GO",            // GHSA SecurityAdvisoryEcosystem enum, or null if not GHSA-queryable
+  "package": "stdlib",          // package name for GHSA query, or null
+  "locations": [                // every file:line where this version string appears
+    {"file": "go.mod", "line": 5, "match": "toolchain go1.25.10"},
+    {"file": ".github/workflows/cross-platform-build.yml", "line": 19, "match": "GO_VERSION: '1.25.10'"}
+  ]
+}
+```
+
+## `kind` values
+
+- **`lockstep`** — the pin appears in multiple files that must all move together. The dev agent's story must update every entry in `locations[]` in a single PR. The acceptance verification AC must grep for the old version (expect 0) and new version (expect `len(locations)`).
+- **`tool`** — pin is enumerated in `dependency-pin-check.yml` and may appear in additional usage locations (Dockerfile installs, Makefile targets). The single `locations[]` entry points at the check_version declaration; the bump story discovers the actual usage locations by grepping for the version string.
+
+## `release_source` values
+
+- `https://go.dev/dl/?mode=json` — Go release index. Returns array of versions; `[.[] | select(.stable)][0]` is the latest stable.
+- `gh:<owner>/<repo>` — fetch via `gh api repos/<owner>/<repo>/releases/latest` for `tag_name` and `published_at`.
+
+## `ecosystem` and `package`
+
+Used for GHSA vulnerability queries against the `current` pinned version. Set to `null` when the tool doesn't have a clean GHSA mapping — fall back to release-notes WebFetch.
+
+Common mappings (extend as needed):
+
+| Tool | ecosystem | package |
+|---|---|---|
+| Go stdlib | `GO` | `stdlib` |
+| gosec | `GO` | `github.com/securego/gosec` |
+| staticcheck | `GO` | `honnef.co/go/tools` |
+| trivy | (none in GHSA) | (use release notes) |
+| nancy | (none in GHSA) | (use release notes) |
+
+## Notes on the discover script's output
+
+- The script does NOT verify lockstep consistency — if `go.mod` is at 1.25.10 but one workflow is still on 1.25.9, both versions appear in the same `go-toolchain` pin's `locations[]`. The CONSUMER (Claude in Phase 3) is expected to detect this and surface it as a lockstep-drift finding. This is the bug class that bit us on 2026-05-12 with PR #1433.
+- The order of `locations[]` is deterministic (alphabetical by file path), which makes diffs of the inventory readable.
+- The script is read-only; no side effects.

--- a/.claude/skills/refresh-pins/scripts/discover-pins.py
+++ b/.claude/skills/refresh-pins/scripts/discover-pins.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+"""Discover all pinned dependencies across the CFGMS repo.
+
+Emits a JSON inventory to stdout following the schema documented in
+references/inventory-schema.md. Each pin entry includes every file:line
+location where the version string appears, so consumers can verify
+lockstep bumps.
+
+Discovery sources:
+- go.mod              — Go toolchain directive
+- .github/workflows/  — GO_VERSION env vars, go-version: in setup-go uses
+- cmd/*/Dockerfile    — FROM golang:X-alpine tags
+- .devcontainer/Dockerfile — same
+- .github/workflows/dependency-pin-check.yml — the existing tool pin list
+  (check_version <name> <repo> <version> calls)
+
+Run from repo root or any subdir — uses `git rev-parse --show-toplevel`
+to anchor.
+"""
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+
+def repo_root() -> Path:
+    result = subprocess.run(
+        ["git", "rev-parse", "--show-toplevel"],
+        capture_output=True, text=True, check=True,
+    )
+    return Path(result.stdout.strip())
+
+
+def grep_files(pattern: re.Pattern, files: list[Path], root: Path) -> list[dict]:
+    """Return location dicts for every matching line."""
+    locations = []
+    for f in files:
+        if not f.exists() or not f.is_file():
+            continue
+        try:
+            for i, line in enumerate(f.read_text().splitlines(), 1):
+                if pattern.search(line):
+                    locations.append({
+                        "file": str(f.relative_to(root)),
+                        "line": i,
+                        "match": line.strip(),
+                    })
+        except UnicodeDecodeError:
+            continue
+    return locations
+
+
+def discover_go_toolchain(root: Path) -> dict:
+    """Go toolchain pin — lockstep across go.mod, workflows, Dockerfiles."""
+    locations = []
+
+    # go.mod toolchain directive
+    go_mod = root / "go.mod"
+    current = None
+    for i, line in enumerate(go_mod.read_text().splitlines(), 1):
+        m = re.match(r"^toolchain go(\S+)", line)
+        if m:
+            current = m.group(1)
+            locations.append({
+                "file": "go.mod",
+                "line": i,
+                "match": line.strip(),
+            })
+            break
+    if current is None:
+        # Fall back to the `go X.Y.Z` directive if no explicit toolchain
+        for i, line in enumerate(go_mod.read_text().splitlines(), 1):
+            m = re.match(r"^go (\S+)", line)
+            if m:
+                current = m.group(1)
+                locations.append({
+                    "file": "go.mod",
+                    "line": i,
+                    "match": line.strip(),
+                })
+                break
+
+    # Workflow GO_VERSION and go-version: pins
+    workflows = sorted((root / ".github/workflows").glob("*.yml"))
+    locations.extend(grep_files(
+        re.compile(r"(GO_VERSION|go-version):\s*['\"]?\d+\.\d+(\.\d+)?['\"]?"),
+        workflows, root,
+    ))
+
+    # Dockerfile FROM golang: pins (active uncommented lines only)
+    dockerfiles = list((root / "cmd").glob("*/Dockerfile")) + \
+                  list((root / "cmd").glob("*/Dockerfile.*"))
+    devcontainer_df = root / ".devcontainer" / "Dockerfile"
+    if devcontainer_df.exists():
+        dockerfiles.append(devcontainer_df)
+    locations.extend(grep_files(
+        re.compile(r"^\s*FROM\s+golang:\d+\.\d+(\.\d+)?"),
+        dockerfiles, root,
+    ))
+
+    return {
+        "name": "go-toolchain",
+        "kind": "lockstep",
+        "current": current or "unknown",
+        "release_source": "https://go.dev/dl/?mode=json",
+        "ecosystem": "GO",
+        "package": "stdlib",
+        "locations": locations,
+    }
+
+
+def discover_tool_pins(root: Path) -> list[dict]:
+    """Tool pins listed in .github/workflows/dependency-pin-check.yml.
+
+    Parses lines of the form:
+      check_version "<name>" "<repo>" "<version>"
+    """
+    pins = []
+    pin_file = root / ".github/workflows/dependency-pin-check.yml"
+    if not pin_file.exists():
+        return pins
+
+    pattern = re.compile(
+        r'^\s*check_version\s+"([^"]+)"\s+"([^"]+)"\s+"([^"]+)"'
+    )
+
+    for i, line in enumerate(pin_file.read_text().splitlines(), 1):
+        m = pattern.match(line)
+        if not m:
+            continue
+        name, repo, version = m.group(1), m.group(2), m.group(3)
+        pins.append({
+            "name": name,
+            "kind": "tool",
+            "current": version,
+            "release_source": f"gh:{repo}",
+            "ecosystem": None,  # GHSA query needs case-by-case mapping for tools
+            "package": None,
+            "locations": [{
+                "file": ".github/workflows/dependency-pin-check.yml",
+                "line": i,
+                "match": line.strip(),
+            }],
+        })
+    return pins
+
+
+def main() -> int:
+    root = repo_root()
+    inventory = [discover_go_toolchain(root)]
+    inventory.extend(discover_tool_pins(root))
+    json.dump(inventory, sys.stdout, indent=2)
+    sys.stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/dependency-pin-check.yml
+++ b/.github/workflows/dependency-pin-check.yml
@@ -65,6 +65,7 @@ jobs:
       contents: read
       issues: write
     steps:
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
     - name: Check for outdated pinned tools
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -102,6 +103,51 @@ jobs:
         check_version "trivy"       "aquasecurity/trivy"                      "v0.70.0"
         check_version "go-licenses" "google/go-licenses"                      "v2.0.1"
         check_version "golangci-lint" "golangci/golangci-lint"                "v2.12.1"
+
+        # Go toolchain freshness check. Go's release index doesn't fit the
+        # GitHub Releases pattern of check_version above, so it gets its own
+        # handler. The toolchain version is pinned in go.mod and in workflow
+        # GO_VERSION env vars; the freshness check uses go.mod as the source
+        # of truth, and lockstep-check below catches drift across files.
+        echo "Checking Go toolchain version..."
+        go_pinned=$(grep -E "^toolchain go" go.mod | sed 's/^toolchain go//')
+        go_latest=$(curl -fsSL "https://go.dev/dl/?mode=json" 2>/dev/null \
+                    | jq -r '[.[] | select(.stable)][0].version' 2>/dev/null \
+                    | sed 's/^go//')
+        if [ -z "$go_latest" ] || [ "$go_latest" = "null" ]; then
+          echo "  WARN: Could not fetch latest Go version from go.dev/dl"
+          warnings="${warnings}- **Go toolchain**: could not fetch latest from go.dev/dl?mode=json\n"
+        elif [ "$go_pinned" != "$go_latest" ]; then
+          echo "  OUTDATED: Go toolchain pinned=${go_pinned} latest=${go_latest}"
+          outdated="${outdated}- **Go toolchain**: pinned \`${go_pinned}\`, latest \`${go_latest}\` ([release notes](https://go.dev/doc/devel/release))\n"
+        else
+          echo "  OK: Go toolchain ${go_pinned}"
+        fi
+
+        # Lockstep validator. The Go toolchain version is pinned in MULTIPLE
+        # places (go.mod, workflow GO_VERSION/go-version, cmd/*/Dockerfile FROM
+        # golang:X-alpine, .devcontainer/Dockerfile). All must move together.
+        # This check caught the 2026-05-12 drift where go.mod was bumped to
+        # 1.25.10 but the Dockerfile FROM lines were still at 1.25.9, causing
+        # Trivy to keep reporting stdlib CVEs on PRs against develop.
+        echo "Checking Go toolchain lockstep across all pin locations..."
+        lockstep_versions=$(
+          {
+            grep -hoE "^toolchain go[0-9.]+" go.mod | sed 's/^toolchain go//'
+            grep -hoE "(GO_VERSION|go-version):[[:space:]]*['\"]?[0-9]+\.[0-9]+\.[0-9]+['\"]?" .github/workflows/*.yml \
+              | grep -oE "[0-9]+\.[0-9]+\.[0-9]+"
+            grep -hoE "^FROM golang:[0-9]+\.[0-9]+\.[0-9]+" cmd/*/Dockerfile .devcontainer/Dockerfile 2>/dev/null \
+              | grep -oE "[0-9]+\.[0-9]+\.[0-9]+"
+          } | sort -u
+        )
+        lockstep_count=$(printf '%s\n' "$lockstep_versions" | grep -c .)
+        if [ "$lockstep_count" -gt 1 ]; then
+          echo "  ERROR: Go toolchain pin drift — multiple versions in use:"
+          printf '%s\n' "$lockstep_versions" | sed 's/^/    /'
+          outdated="${outdated}- **Go toolchain (lockstep drift)**: multiple versions present in repo — \`$(printf '%s, ' $lockstep_versions | sed 's/, $//')\`. Bump all locations to the same version (run \`./.claude/skills/refresh-pins/scripts/discover-pins.py\` to see every file:line).\n"
+        else
+          echo "  OK: Go toolchain lockstep version=${lockstep_versions}"
+        fi
 
         if [ -z "$outdated" ] && [ -z "$warnings" ]; then
           echo ""


### PR DESCRIPTION
## Summary

Adds a new Anthropic Agent Skill at `.claude/skills/refresh-pins/` that researches all pinned dependencies (Go toolchain, 8 security tools) against their upstream latest releases, applies a 3-day cooldown + CVE-driven override policy, and creates dispatchable stories for pins that should be bumped. Also extends the existing weekly `dependency-pin-check` workflow with a Go toolchain freshness check and a lockstep validator that would have caught the 2026-05-12 drift between `go.mod` and Dockerfile `FROM` lines.

Skill is already discoverable in the harness's available-skills list — `refresh-pins` appears alongside `po`, `dispatch`, etc.

## Skill structure

Standard Anthropic Agent Skills format:

```
.claude/skills/refresh-pins/
├── SKILL.md                          # 150 lines, always loaded — orchestration
├── scripts/
│   └── discover-pins.py              # grep-based pin inventory → JSON (22 lockstep locations for go-toolchain on develop today)
├── references/                       # lazy-loaded — Claude reads only when Phase 2/3 needs them
│   ├── inventory-schema.md           # JSON shape discover-pins emits
│   ├── decision-matrix.md            # bump/hold rules + 4 worked examples (today's incident is example #1)
│   └── cooldown-policy.md            # why 3 days, override conditions, audit log spec
└── assets/
    └── story-template.md             # per-pin story body with {{PLACEHOLDER}} substitution
```

## Skill flow

1. **Discover** — `discover-pins.py` emits a JSON inventory of every pin. Today's run on develop returns 9 pins with 22 lockstep locations for go-toolchain.
2. **Research** — for each pin: latest version + `published_at` from upstream (gh releases / go.dev/dl), CVEs via GHSA query, CI-driven signal from recent Trivy SARIF artifacts.
3. **Justify** — apply decision matrix; record per-pin verdict (BUMP NOW / BUMP / HOLD / OK / INVESTIGATE) with paragraph rationale.
4. **Create stories** — one per logical pin (`go-toolchain` = 1 story touching 22 files in lockstep, not 22 stories). Substitutes the template, writes to `/tmp/`, `gh issue create --label "pipeline:story,agent:ready,dependencies"`.
5. **Audit log** — every BUMP NOW that overrides cooldown appends one line to `.claude/scratch/pin-overrides.log`.
6. **Report** — single Markdown summary back to the founder.

## Companion workflow extension

`.github/workflows/dependency-pin-check.yml` gains two new checks:

1. **Go toolchain freshness** — fetches latest stable from `https://go.dev/dl/?mode=json` and compares to `go.mod` `toolchain` directive. This pin was previously uncovered by the workflow — nothing told us 1.25.9 was outdated until Trivy crashed on docker-security gate.
2. **Lockstep validator** — verifies `go.mod` toolchain == all workflow `GO_VERSION`/`go-version` values == all Dockerfile `FROM golang:` tags. PR #1433's initial commit bumped go.mod + workflows but missed the Dockerfile FROM lines, causing Trivy to keep reporting stdlib v1.25.9 even after go.mod was at 1.25.10. This check fails the workflow immediately when drift exists.

## Test plan

- [x] `discover-pins.py` smoke-tested on develop — returns 9 pins, 22 locations for go-toolchain (matches manual count)
- [x] Lockstep grep tested manually on develop — returns single version `1.25.9` (clean)
- [x] `make test` passes locally
- [ ] CI: required checks pass on this PR
- [ ] After merge: invoke `/refresh-pins` to validate end-to-end. Should report `go-toolchain` as BUMP NOW (1.25.9 has CVEs blocking docker-security) and create the bump story — or if PR #1433 has already landed by then, report `go-toolchain` as up-to-date.

## Out of scope

- The skill does NOT edit go.mod / workflows / Dockerfiles directly. It creates stories that dispatched dev agents then execute under the normal pipeline.
- GHSA → tool name mapping is partial in this iteration. Tools without clean GHSA mapping (trivy, nancy, trufflehog) fall back to WebFetch of release notes. Can expand the mapping in a follow-up.
- Per-pin cooldown overrides via JSON config file are documented but not yet implemented — defaults to 3 days for all pins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)