### PR TITLE
deps: bump golangci-lint v2.12.1 → v2.12.2 (Issue #1436)

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -43,7 +43,7 @@ RUN go install github.com/securego/gosec/v2/cmd/gosec@v2.26.1 \
     && go install github.com/zricethezav/gitleaks/v8@v8.30.1 \
     && go install github.com/google/go-licenses/v2@v2.0.1 \
     && curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh \
-       | sh -s -- -b "$(go env GOPATH)/bin" v2.12.1
+       | sh -s -- -b "$(go env GOPATH)/bin" v2.12.2
 
 # Trivy — v0.69.4-v0.69.6 are compromised (CVE-2026-33634); v0.70.0 is the
 # post-incident clean release. We download the project's release archive and

--- a/.github/workflows/dependency-pin-check.yml
+++ b/.github/workflows/dependency-pin-check.yml
@@ -101,7 +101,7 @@ jobs:
         check_version "trufflehog"  "trufflesecurity/trufflehog"              "v3.95.2"
         check_version "trivy"       "aquasecurity/trivy"                      "v0.70.0"
         check_version "go-licenses" "google/go-licenses"                      "v2.0.1"
-        check_version "golangci-lint" "golangci/golangci-lint"                "v2.12.1"
+        check_version "golangci-lint" "golangci/golangci-lint"                "v2.12.2"
 
         if [ -z "$outdated" ] && [ -z "$warnings" ]; then
           echo ""

--- a/.github/workflows/release-automation.yml
+++ b/.github/workflows/release-automation.yml
@@ -215,7 +215,7 @@ jobs:
           go install honnef.co/go/tools/cmd/staticcheck@2026.1
 
           # Install linting tools
-          curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh | sh -s -- -b $(go env GOPATH)/bin v2.12.1
+          curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh | sh -s -- -b $(go env GOPATH)/bin v2.12.2
 
           echo "✅ All tools installed"
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -41,7 +41,7 @@ This guide provides instructions for setting up a local CFGMS development enviro
 - **Docker** - For integration tests and local deployment
 - **golangci-lint** - Code linting
   ```bash
-  curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh | sh -s -- -b $(go env GOPATH)/bin v2.12.1
+  curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh | sh -s -- -b $(go env GOPATH)/bin v2.12.2
   ```
 
 - **entr** - For watch mode during development


### PR DESCRIPTION
## Summary

Routine cooldown-elapsed pin refresh. golangci-lint v2.12.2 was published 2026-05-06 (6 days before this PR), past the 3-day default cooldown. No CVEs against golangci/golangci-lint for this release. The changelog is limited to five dependency bumps and a gomodguard config fix — no behaviour changes that affect CFGMS lint findings.

Fixes #1436

## Files Changed

All four locations that pin the version updated in lockstep:

| File | Change |
|------|--------|
| `.github/workflows/dependency-pin-check.yml` | `v2.12.1` → `v2.12.2` (source of truth) |
| `.github/workflows/release-automation.yml` | `v2.12.1` → `v2.12.2` |
| `.devcontainer/Dockerfile` | `v2.12.1` → `v2.12.2` |
| `DEVELOPMENT.md` | `v2.12.1` → `v2.12.2` (contributor install snippet) |

## Acceptance Criteria Verification

- AC1: All files updated ✅
- AC2: `grep -rEn "golangci-lint.*v2\.12\.1|v2\.12\.1.*golangci-lint" .github/workflows/ .devcontainer/` → 0 matches ✅
- AC3: `grep -rEn "v2\.12\.2" .github/workflows/dependency-pin-check.yml .github/workflows/release-automation.yml .devcontainer/Dockerfile` → 3 matches ✅
- AC4: `make test` passes ✅

## Specialist Review Results

| Reviewer | Result | Notes |
|----------|--------|-------|
| QA test runner | **PASS** | All packages passing, marker written to `/tmp/agent-validation-passed` |
| QA code reviewer | **PASS** | No blocking issues; stale DEVELOPMENT.md ref also fixed in this PR |
| Security engineer | **PASS** | No CVEs, security scans clean, no central provider violations |

## Test Plan

- [ ] CI unit-tests pass
- [ ] CI integration-tests pass
- [ ] CI Build Gate passes (cross-platform compilation)
- [ ] CI security-deployment-gate passes
- [ ] `dependency-pin-check` workflow runs green (self-check validates the new pin)