### PR TITLE
refresh-pins: fix story-template section name + discover tool usage locations (Issue #1437)

### DIFF
--- a/.claude/skills/refresh-pins/assets/story-template.md
+++ b/.claude/skills/refresh-pins/assets/story-template.md
@@ -6,7 +6,7 @@ Bump `{{NAME}}` from `{{FROM}}` to `{{TO}}`.
 
 {{JUSTIFICATION}}
 
-## Files to update ({{LOCATION_COUNT}} occurrences — lockstep required)
+## Files In Scope ({{LOCATION_COUNT}} occurrences — lockstep required)
 
 {{LOCATION_LIST}}
 

--- a/.claude/skills/refresh-pins/references/inventory-schema.md
+++ b/.claude/skills/refresh-pins/references/inventory-schema.md
@@ -22,7 +22,7 @@
 ## `kind` values
 
 - **`lockstep`** — the pin appears in multiple files that must all move together. The dev agent's story must update every entry in `locations[]` in a single PR. The acceptance verification AC must grep for the old version (expect 0) and new version (expect `len(locations)`).
-- **`tool`** — pin is enumerated in `dependency-pin-check.yml` and may appear in additional usage locations (Dockerfile installs, Makefile targets). The single `locations[]` entry points at the check_version declaration; the bump story discovers the actual usage locations by grepping for the version string.
+- **`tool`** — pin is enumerated in `dependency-pin-check.yml` and appears in additional usage locations (Dockerfile installs, workflow install steps, shell scripts). The `locations[]` array contains the `check_version` declaration as its first entry, followed by every additional install/usage site discovered by grepping the in-scope paths (`.github/workflows/`, `.devcontainer/Dockerfile`, `Makefile`, `cmd/*/Dockerfile`, `scripts/*.sh`) for the literal version string. All entries must move together in a single bump PR — the dispatcher uses this array to compute file-overlap conflicts.
 
 ## `release_source` values
 
@@ -46,5 +46,6 @@ Common mappings (extend as needed):
 ## Notes on the discover script's output
 
 - The script does NOT verify lockstep consistency — if `go.mod` is at 1.25.10 but one workflow is still on 1.25.9, both versions appear in the same `go-toolchain` pin's `locations[]`. The CONSUMER (Claude in Phase 3) is expected to detect this and surface it as a lockstep-drift finding. This is the bug class that bit us on 2026-05-12 with PR #1433.
+- For `kind: tool` pins, `locations[]` includes the `check_version` declaration in `dependency-pin-check.yml` plus every additional install/usage site found by grepping for the literal version string across `.github/workflows/` (excluding `dependency-pin-check.yml`), `.devcontainer/Dockerfile`, `Makefile`, `cmd/*/Dockerfile`, and `scripts/*.sh`. A dispatched dev agent must update all listed locations to avoid lockstep drift.
 - The order of `locations[]` is deterministic (alphabetical by file path), which makes diffs of the inventory readable.
 - The script is read-only; no side effects.

--- a/.claude/skills/refresh-pins/scripts/discover-pins.py
+++ b/.claude/skills/refresh-pins/scripts/discover-pins.py
@@ -112,11 +112,47 @@ def discover_go_toolchain(root: Path) -> dict:
     }
 
 
+def discover_tool_usage_locations(version: str, root: Path) -> list[dict]:
+    """Grep in-scope paths for additional usage locations of a tool version string.
+
+    Searches for the literal version string across workflow files (excluding the
+    dependency-pin-check.yml declaration file itself), devcontainer Dockerfile,
+    Makefile, cmd Dockerfiles, and shell scripts. Returns location dicts for
+    every match — these are the install/usage pins that must move lockstep with
+    the check_version declaration.
+    """
+    search_files: list[Path] = []
+
+    for f in sorted((root / ".github/workflows").glob("*.yml")):
+        if f.name != "dependency-pin-check.yml":
+            search_files.append(f)
+
+    devcontainer_df = root / ".devcontainer" / "Dockerfile"
+    if devcontainer_df.exists():
+        search_files.append(devcontainer_df)
+
+    makefile = root / "Makefile"
+    if makefile.exists():
+        search_files.append(makefile)
+
+    for f in sorted((root / "cmd").glob("*/Dockerfile")):
+        search_files.append(f)
+
+    for f in sorted((root / "scripts").glob("*.sh")):
+        search_files.append(f)
+
+    return grep_files(re.compile(re.escape(version)), search_files, root)
+
+
 def discover_tool_pins(root: Path) -> list[dict]:
     """Tool pins listed in .github/workflows/dependency-pin-check.yml.
 
     Parses lines of the form:
       check_version "<name>" "<repo>" "<version>"
+
+    For each pin the locations[] array contains the check_version declaration
+    plus every additional install/usage site discovered by grepping the in-scope
+    paths for the literal version string.
     """
     pins = []
     pin_file = root / ".github/workflows/dependency-pin-check.yml"
@@ -132,6 +168,12 @@ def discover_tool_pins(root: Path) -> list[dict]:
         if not m:
             continue
         name, repo, version = m.group(1), m.group(2), m.group(3)
+        locations = [{
+            "file": ".github/workflows/dependency-pin-check.yml",
+            "line": i,
+            "match": line.strip(),
+        }]
+        locations.extend(discover_tool_usage_locations(version, root))
         pins.append({
             "name": name,
             "kind": "tool",
@@ -139,11 +181,7 @@ def discover_tool_pins(root: Path) -> list[dict]:
             "release_source": f"gh:{repo}",
             "ecosystem": None,  # GHSA query needs case-by-case mapping for tools
             "package": None,
-            "locations": [{
-                "file": ".github/workflows/dependency-pin-check.yml",
-                "line": i,
-                "match": line.strip(),
-            }],
+            "locations": locations,
         })
     return pins
 


### PR DESCRIPTION
## Summary

Fixes two bugs in the `refresh-pins` skill discovered when `/refresh-pins` was invoked on 2026-05-12 immediately after PR #1434 merged.

- **Bug 1 (template section name)**: `assets/story-template.md` used `## Files to update` but the dispatcher's preflight parser requires `## Files In Scope`. Every story generated by the skill shipped with `no_files_parsed_cannot_check_conflicts` warnings, disabling file-overlap conflict detection in the pipeline dispatcher.
- **Bug 2 (missing tool usage locations)**: `discover_tool_pins` only recorded the `check_version` declaration for each tool pin. For `golangci-lint`, two install sites (`.github/workflows/release-automation.yml:218` and `.devcontainer/Dockerfile:46`) were missed entirely. Dispatched agents would have bumped only the declaration file, leaving the repo in lockstep drift and failing the pin-check gate added in PR #1434.

## Changes

- `.claude/skills/refresh-pins/assets/story-template.md` — `## Files to update` → `## Files In Scope`
- `.claude/skills/refresh-pins/scripts/discover-pins.py` — added `discover_tool_usage_locations(version, root)` helper; wired into `discover_tool_pins()` so every tool pin's `locations[]` includes the declaration plus all install/usage sites found by grepping in-scope paths
- `.claude/skills/refresh-pins/references/inventory-schema.md` — updated `kind: tool` description and added a bullet in "Notes on the discover script's output"

## Verification

```
$ grep -c "^## Files In Scope" .claude/skills/refresh-pins/assets/story-template.md
1
$ grep -c "^## Files to update" .claude/skills/refresh-pins/assets/story-template.md
0
$ python3 .claude/skills/refresh-pins/scripts/discover-pins.py | jq '.[] | select(.name == "golangci-lint") | .locations | length'
3
```

## Specialist Review Results

- **qa-test-runner**: PASS — `make test-agent-complete` passed; smoke test confirmed golangci-lint has 3 locations
- **qa-code-reviewer**: PASS — no blocking issues; 4 informational warnings (pre-existing patterns, not introduced by this story)
- **security-engineer**: PASS — no security issues; `security-precommit`, `check-architecture`, `security-scan` all green; `re.escape(version)` confirmed safe against regex injection

Fixes #1437