### PR TITLE
tech-debt: narrow epic #721 canonical scan + close epic (Issue #1445)

### DIFF
--- a/features/config/rollback/notifier.go
+++ b/features/config/rollback/notifier.go
@@ -49,7 +49,7 @@ func (n *DefaultRollbackNotifier) NotifyRollbackProgress(ctx context.Context, op
 		"current_action", logging.SanitizeLogValue(operation.Progress.CurrentAction),
 	)
 
-	// Milestone throttling not implemented; all progress events are logged.
+	// Deferred: tracked in #1441 — milestone throttling; all progress events are logged
 
 	return nil
 }

--- a/pkg/logging/telemetry_bridge.go
+++ b/pkg/logging/telemetry_bridge.go
@@ -48,7 +48,7 @@ func (t *TelemetryBridge) GetTraceInfoFromContext(ctx context.Context) (string, 
 	return spanCtx.TraceID().String(), spanCtx.SpanID().String()
 }
 
-// Initialize sets up the telemetry bridge to replace placeholder functions.
+// Initialize activates the telemetry bridge for correlation ID and trace extraction.
 // This should be called during application initialization after telemetry setup.
 // It is safe to call concurrently and from multiple goroutines.
 func (t *TelemetryBridge) Initialize() {

--- a/pkg/storage/providers/flatfile/plugin.go
+++ b/pkg/storage/providers/flatfile/plugin.go
@@ -46,8 +46,8 @@ import (
 	cfgconfig "github.com/cfgis/cfgms/pkg/storage/interfaces/config"
 )
 
-// ErrNotSupported is returned by store factory methods that are not implemented
-// by the flat-file provider. These stores belong to the business-data tier.
+// ErrNotSupported is returned by store factory methods not supported by the flat-file provider.
+// These stores belong to the business-data tier.
 var ErrNotSupported = errors.New("flatfile: operation not supported by flat-file provider")
 
 // ErrImmutable is returned when attempting to mutate immutable data, such as

--- a/pkg/storage/providers/sqlite/plugin.go
+++ b/pkg/storage/providers/sqlite/plugin.go
@@ -229,7 +229,7 @@ func (p *SQLiteProvider) CreateSessionStore(config map[string]interface{}) (busi
 	return &SQLiteSessionStore{db: db}, nil
 }
 
-// CreateConfigStore is not implemented by the SQLite provider.
+// CreateConfigStore is not supported by the SQLite provider.
 // Config data uses the flat-file provider (OSS) or PostgreSQL (commercial).
 func (p *SQLiteProvider) CreateConfigStore(config map[string]interface{}) (cfgconfig.ConfigStore, error) {
 	return nil, business.ErrNotSupported


### PR DESCRIPTION
## Summary

Closes epic #721 by auditing all 42 hits from the original broad stub-marker pattern, narrowing the canonical scan to target genuine stubs only, and handling the one real stub found.

- **4 comment rewording changes** — no logic changes
- **Epic #721 body updated** with the narrowed canonical scan pattern and rationale
- **Narrowed scan: 0 hits** (well under the 30-item success criterion)

Fixes #1445
Closes #721

---

## Full Classification Audit (42 original hits)

### FALSE POSITIVE — legitimate domain term (33 hits)

All `placeholder` variable/identifier hits in parameter substitution, template substitution, and SQL query building:

| File | Lines | Reason |
|------|-------|--------|
| `features/modules/script/parameter_injection.go` | 52,53,70,71,77,95,107,117,135,151,161 | `placeholder` is a local variable for `$KEY` → `value` substitution; also doc comments for the same function |
| `features/saas/workflow.go` | 443,444,461,462,474,475 | `placeholder := "${" + key + "}"` — template variable substitution |
| `features/workflow/engine_conditions.go` | 148,154,156 | `${variable}` placeholder substitution; local var name |
| `features/workflow/transform/builtin/string_transforms.go` | 498,541,543 | `{variable}` template substitution; description string |
| `features/workflow/template.go` | 427,433 | `placeholder := match[0]` — regex match capture for substitution |
| `pkg/storage/providers/database/rbac_queries.go` | 99,103,107,113 | SQL parameter placeholders `$1, $2, …` in a dynamic IN clause |
| `pkg/audit/manager.go` | 42 | "redactedValue is the placeholder used in place of sensitive values" — redaction token doc |
| `pkg/cert/admin_marker.go` | 13 | "99999 is a placeholder PEN" — design note for unregistered Private Enterprise Number |
| `pkg/config/validator.go` | 93 | "conventional placeholder for token-based auth" — doc comment for `Username: "git"` |

### FALSE POSITIVE — "would be" in positive prose (3 hits)

| File | Line | Text |
|------|------|------|
| `features/config/diff/impact.go` | 304 | `// assessRollbackComplexity assesses how difficult it would be to rollback a change` — function docstring |
| `features/config/diff/types.go` | 120 | `// RollbackComplexity indicates how difficult rollback would be` — field comment |
| `features/config/rollback/validator.go` | 274 | `return fmt.Errorf("module %s depends on %s which would be incompatible after rollback", …)` — error message |

### ALREADY DEFERRED — pre-existing Deferred annotation (1 hit)

| File | Line | Annotation |
|------|------|-----------|
| `features/modules/network_activedirectory/module.go` | 503 | `// Deferred: tracked in #1443 — introduce a DirectoryComputer type; represented as user for now` |

### DESIGN STATEMENT — build-tag gated error sentinel (1 hit)

| File | Line | Verdict |
|------|------|---------|
| `features/workflow/providers.go` | 40 | `ErrProviderNotImplemented = errors.New("provider not implemented: build with -tags experimental to enable")` — intentional sentinel for a build-tag-gated feature; the error message is the contract |

### REAL STUB → Deferred-annotated (1 hit, this PR)

| File | Line | Action |
|------|------|--------|
| `features/config/rollback/notifier.go` | 52 | Was: `// Milestone throttling not implemented; all progress events are logged.` → Now: `// Deferred: tracked in #1441 — milestone throttling; all progress events are logged` |

### DESIGN STATEMENT → reworded (3 hits, this PR)

| File | Line | Change |
|------|------|--------|
| `pkg/logging/telemetry_bridge.go` | 51 | "replace placeholder functions" → "activates the telemetry bridge for correlation ID and trace extraction" — fully implemented function, old wording implied a stub |
| `pkg/storage/providers/flatfile/plugin.go` | 49 | "not implemented by the flat-file provider" → "not supported by the flat-file provider" — architectural boundary, not a missing implementation |
| `pkg/storage/providers/sqlite/plugin.go` | 232 | "not implemented by the SQLite provider" → "not supported by the SQLite provider" — same |

---

## Verification

### Narrowed canonical scan (new pattern, target < 30)
```bash
grep -rEn "(// For now|placeholder implementation|would\s+implement|// not yet implemented|In a (real|full) implementation|tracked internally)" \
  --include="*.go" features/ pkg/ commercial/ \
  | grep -v "_test.go" \
  | grep -vE "// Deferred: tracked in #[0-9]+" \
  | wc -l
```
**Result: 0** ✅

### Original broad scan (OK to remain > 30)
```bash
grep -rEn "(for now|placeholder|would\s+(implement|be|need)|not\s+(yet\s+)?implemented)" \
  --include="*.go" features/ pkg/ commercial/ \
  | grep -v "_test.go" \
  | wc -l
```
**Result: 38** (down from 42; all remaining hits are false positives per the audit above)

---

## Specialist Review Results

- **QA test runner**: PASS — `make test-agent-complete` all unit + integration tests pass
- **QA code reviewer**: PASS — no mocks, no skips, no logic changes; pre-existing `notifier_test.go` mock logger noted as pre-existing (not introduced by this story)
- **Security engineer**: PASS — `go vet` + `make check-architecture` clean; zero code paths modified