### PR TITLE
ci: update actions/setup-go SHA pins from v4 to v5 (Issue #1450)

### DIFF
--- a/.github/workflows/production-gates.yml
+++ b/.github/workflows/production-gates.yml
@@ -44,10 +44,10 @@ jobs:
       uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
     
     - name: Set up Go
-      uses: actions/setup-go@7b8cf10d4e4a01d4992d18a89f4d7dc5a3e6d6f4 # v4
+      uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
       with:
         go-version: '1.25.10'
-    
+
     - name: Install Security Tools
       run: |
         echo "🔧 Installing Security Tools for Production Gate"
@@ -276,7 +276,7 @@ jobs:
     - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
     - name: Set up Go
-      uses: actions/setup-go@7b8cf10d4e4a01d4992d18a89f4d7dc5a3e6d6f4 # v4
+      uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
       with:
         go-version: '1.25.10'
 
@@ -410,7 +410,7 @@ jobs:
     - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
     - name: Set up Go
-      uses: actions/setup-go@7b8cf10d4e4a01d4992d18a89f4d7dc5a3e6d6f4 # v4
+      uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
       with:
         go-version: '1.25.10'
 
@@ -495,13 +495,13 @@ jobs:
     - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
     
     - name: Set up Go
-      uses: actions/setup-go@7b8cf10d4e4a01d4992d18a89f4d7dc5a3e6d6f4 # v4
+      uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
       with:
         go-version: '1.25.10'
-    
+
     - name: Install dependencies
       run: go mod download
-    
+
     - name: Run Steward Cross-Platform Tests
       shell: bash
       run: |
@@ -546,13 +546,13 @@ jobs:
     - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
     
     - name: Set up Go
-      uses: actions/setup-go@7b8cf10d4e4a01d4992d18a89f4d7dc5a3e6d6f4 # v4
+      uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
       with:
         go-version: '1.25.10'
-    
+
     - name: Install dependencies
       run: go mod download
-    
+
     - name: Run Full E2E Test Suite
       run: |
         echo "🎯 COMPREHENSIVE E2E TESTING"
@@ -753,13 +753,13 @@ jobs:
     - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
     
     - name: Set up Go
-      uses: actions/setup-go@7b8cf10d4e4a01d4992d18a89f4d7dc5a3e6d6f4 # v4
+      uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
       with:
         go-version: '1.25.10'
-    
+
     - name: Install dependencies
       run: go mod download
-    
+
     - name: Run Cross-Feature Integration Scenarios
       run: |
         echo "🔗 CROSS-FEATURE INTEGRATION TESTING (Story #85)"

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -100,7 +100,7 @@ jobs:
       uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
     
     - name: Set up Go
-      uses: actions/setup-go@7b8cf10d4e4a01d4992d18a89f4d7dc5a3e6d6f4 # v4
+      uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
       with:
         go-version: ${{ env.GO_VERSION }}
     
@@ -142,7 +142,7 @@ jobs:
       uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
     
     - name: Set up Go
-      uses: actions/setup-go@7b8cf10d4e4a01d4992d18a89f4d7dc5a3e6d6f4 # v4
+      uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
       with:
         go-version: ${{ env.GO_VERSION }}
     
@@ -217,7 +217,7 @@ jobs:
       uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
     
     - name: Set up Go
-      uses: actions/setup-go@7b8cf10d4e4a01d4992d18a89f4d7dc5a3e6d6f4 # v4
+      uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
       with:
         go-version: ${{ env.GO_VERSION }}
     
@@ -265,7 +265,7 @@ jobs:
       uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
     - name: Set up Go
-      uses: actions/setup-go@7b8cf10d4e4a01d4992d18a89f4d7dc5a3e6d6f4 # v4
+      uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
       with:
         go-version: ${{ env.GO_VERSION }}
     

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -41,7 +41,7 @@ jobs:
     - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
     
     - name: Set up Go
-      uses: actions/setup-go@7b8cf10d4e4a01d4992d18a89f4d7dc5a3e6d6f4 # v4
+      uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
       with:
         go-version: ${{ env.GO_VERSION }}
     
@@ -82,7 +82,7 @@ jobs:
     - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
     
     - name: Set up Go
-      uses: actions/setup-go@7b8cf10d4e4a01d4992d18a89f4d7dc5a3e6d6f4 # v4
+      uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
       with:
         go-version: ${{ env.GO_VERSION }}
     
@@ -133,7 +133,7 @@ jobs:
     - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
     
     - name: Set up Go
-      uses: actions/setup-go@7b8cf10d4e4a01d4992d18a89f4d7dc5a3e6d6f4 # v4
+      uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
       with:
         go-version: ${{ env.GO_VERSION }}
     
@@ -188,7 +188,7 @@ jobs:
     - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
     
     - name: Set up Go
-      uses: actions/setup-go@7b8cf10d4e4a01d4992d18a89f4d7dc5a3e6d6f4 # v4
+      uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
       with:
         go-version: ${{ env.GO_VERSION }}
     
@@ -244,7 +244,7 @@ jobs:
     - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
     
     - name: Set up Go
-      uses: actions/setup-go@7b8cf10d4e4a01d4992d18a89f4d7dc5a3e6d6f4 # v4
+      uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
       with:
         go-version: ${{ env.GO_VERSION }}
     


### PR DESCRIPTION
## Summary

- Rotates `actions/setup-go` from the v4 SHA (`7b8cf10d…`) to the v5 SHA (`40f1582b…`) in three workflows: `test-suite.yml` (5 occurrences), `security-scan.yml` (4 occurrences), `production-gates.yml` (6 active occurrences)
- Brings these three files into alignment with the rest of the repo (`release.yml`, `cross-platform-build.yml`, `codeql-analysis.yml`, etc.) which already use the v5 SHA
- Three commented-out blocks in `production-gates.yml` (lines 236, 356, 381) are intentionally left on the old SHA per story spec — updating a commented SHA without activating the block creates misleading maintenance debt

Fixes #1450

## Specialist Review Results

| Reviewer | Result | Notes |
|---|---|---|
| QA Test Runner | **PASS** | `make test-agent-complete` — all in-container gates pass (unit, integration, cross-platform build) |
| QA Code Reviewer | **PASS** | Change is purely mechanical; old SHA absent from all active lines; commented lines preserved |
| Security Engineer | **PASS** | New SHA verified as legitimate v5 (same pin in 5 other workflows); no secrets, no architecture violations |

## Test plan

- [x] `grep -n "7b8cf10d4e4a01d4992d18a89f4d7dc5a3e6d6f4" .github/workflows/test-suite.yml` — no output
- [x] `grep -n "7b8cf10d4e4a01d4992d18a89f4d7dc5a3e6d6f4" .github/workflows/security-scan.yml | grep -v "^[0-9]*:[[:space:]]*#"` — no output
- [x] `grep -n "7b8cf10d4e4a01d4992d18a89f4d7dc5a3e6d6f4" .github/workflows/production-gates.yml | grep -v "^[0-9]*:[[:space:]]*#"` — no output
- [x] Commented lines 236, 356, 381 in `production-gates.yml` still contain old SHA (expected and correct)
- [x] New SHA count: 5 in `test-suite.yml`, 4 in `security-scan.yml`, 6 in `production-gates.yml`
- [x] Only the three specified files modified (`git diff --name-only`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)