### PR TITLE
ci: isolate release caches, drop broad restore-keys, pin golangci-lint (Issue #1449)

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -78,7 +78,6 @@ jobs:
         key: ${{ runner.os }}-go-codeql-${{ hashFiles('**/go.sum') }}
         restore-keys: |
           ${{ runner.os }}-go-codeql-
-          ${{ runner.os }}-go-
 
     - name: Download dependencies
       run: go mod download

--- a/.github/workflows/license-check.yml
+++ b/.github/workflows/license-check.yml
@@ -49,7 +49,6 @@ jobs:
         key: ${{ runner.os }}-go-licenses-${{ hashFiles('**/go.sum') }}
         restore-keys: |
           ${{ runner.os }}-go-licenses-
-          ${{ runner.os }}-go-
 
     - name: Install go-licenses tool
       run: go install github.com/google/go-licenses/v2@v2.0.1

--- a/.github/workflows/release-automation.yml
+++ b/.github/workflows/release-automation.yml
@@ -181,13 +181,11 @@ jobs:
         with:
           go-version: ${{ env.GO_VERSION }}
 
-      - name: Cache Go modules
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+      - name: Restore Go module cache
+        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
+          key: release-${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
 
       - name: Install dependencies
         run: go mod download
@@ -215,7 +213,7 @@ jobs:
           go install honnef.co/go/tools/cmd/staticcheck@2026.1
 
           # Install linting tools
-          curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh | sh -s -- -b $(go env GOPATH)/bin v2.12.2
+          go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2
 
           echo "✅ All tools installed"
 
@@ -252,6 +250,13 @@ jobs:
         run: |
           echo "📝 Running linting..."
           make lint
+
+      - name: Save Go module cache
+        if: success()
+        uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: ~/go/pkg/mod
+          key: release-${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
 
       - name: Test Summary
         if: always()

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -119,13 +119,11 @@ jobs:
       with:
         go-version: ${{ env.GO_VERSION }}
 
-    - name: Cache Go modules
-      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+    - name: Restore Go module cache
+      uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
       with:
         path: ~/go/pkg/mod
-        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-        restore-keys: |
-          ${{ runner.os }}-go-
+        key: release-${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
 
     - name: Build binaries
       env:
@@ -182,6 +180,13 @@ jobs:
           "cfgms-steward-$VERSION-$OS-$ARCH$EXT" \
           "cfgms-cli-$VERSION-$OS-$ARCH$EXT" \
           "checksums-$OS-$ARCH.txt"
+
+    - name: Save Go module cache
+      if: success()
+      uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+      with:
+        path: ~/go/pkg/mod
+        key: release-${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
 
   # Generate SBOM (Software Bill of Materials)
   generate-sbom:


### PR DESCRIPTION
## Summary

- **AF-4/AF-5**: Split `actions/cache` into `actions/cache/restore` + `actions/cache/save` (`if: success()`) in `release.yml` and `release-automation.yml`, with a `release-` prefixed key and no `restore-keys` fallback — prevents PR-branch cache entries from being served to release jobs
- **AF-3**: Removed the broad `${{ runner.os }}-go-` restore-keys fallback from `license-check.yml` and `codeql-analysis.yml`
- **AF-6**: Replaced `curl | sh` golangci-lint install (mutable HEAD URL, no integrity check) with `go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2` in `release-automation.yml`

Fixes #1449

## Files Changed

- `.github/workflows/release.yml` — split-cache pattern with `release-` prefix, no `restore-keys`
- `.github/workflows/release-automation.yml` — split-cache pattern + pinned `go install` for golangci-lint
- `.github/workflows/license-check.yml` — removed `${{ runner.os }}-go-` restore-keys line
- `.github/workflows/codeql-analysis.yml` — removed `${{ runner.os }}-go-` restore-keys line

## Specialist Review Results

**QA Test Runner**: PASS — 128 packages tested, all passing; cross-platform builds (5 platforms) verified; YAML syntax valid on all four files; `/tmp/agent-validation-passed` written

**QA Code Reviewer**: PASS — all 9 acceptance criteria verified against current file contents; no blocking issues; no warnings

**Security Engineer**: PASS — automated scans (`gosec`, `staticcheck`, `Nancy`, `Trivy`) all pass; all four story-specific security guarantees verified: cache isolation confirmed, no `restore-keys` in release workflows, no `raw.githubusercontent.com` in any workflow, all `actions/cache/restore`/`save` pinned to `0057852bfaa89a56745cba8c7296529d2fc39830`

## Test Plan

- [x] `make test-agent-complete` passes (validated by QA test runner agent)
- [x] YAML syntax validated on all four modified files
- [x] Grep confirms `restore-keys` absent from both release workflows
- [x] Grep confirms `raw.githubusercontent.com/golangci/golangci-lint` absent from entire repo
- [x] Grep confirms `go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2` present
- [x] Grep confirms all cache/restore and cache/save references use SHA `0057852bfaa89a56745cba8c7296529d2fc39830`

🤖 Generated with [Claude Code](https://claude.com/claude-code)