### PR TITLE
ci: remove unused pull-requests: write from license-check job (Issue #1452)

### DIFF
--- a/.github/workflows/license-check.yml
+++ b/.github/workflows/license-check.yml
@@ -33,7 +33,6 @@ jobs:
     timeout-minutes: 10
     permissions:
       contents: read
-      pull-requests: write
 
     steps:
     - name: Checkout repository


### PR DESCRIPTION
## Summary

- Removes the unused `pull-requests: write` permission from the `license-check` job in `license-check.yml`
- The job now has only `contents: read`, which is the minimum required for `actions/checkout`
- No step in the job writes PR comments, sets labels, or calls any pull-requests API endpoint — the permission was a copy-paste artefact

Fixes #1452

## Changed Files

- `.github/workflows/license-check.yml` — one line deleted (`pull-requests: write`)

## Specialist Review Results

| Reviewer | Result |
|----------|--------|
| QA Test Runner | **PASS** — all validation gates pass; no regressions |
| QA Code Reviewer | **PASS** — no test quality issues (YAML-only change) |
| Security Engineer | **PASS** — security-precommit, check-architecture, security-scan all pass; change is a strict permission reduction (least-privilege improvement) |