### PR TITLE
ci: scope release.yml GITHUB_TOKEN permissions per-job (Issue #1453)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,16 +27,15 @@ on:
 env:
   GO_VERSION: '1.25.10'
 
-permissions:
-  contents: write
-  packages: write
-  id-token: write
+permissions: {}
 
 jobs:
   # Create GitHub Release
   create-release:
     name: Create Release
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     timeout-minutes: 5
     outputs:
       version: ${{ steps.get_version.outputs.version }}
@@ -100,6 +99,8 @@ jobs:
   build-binaries:
     name: Build ${{ matrix.os }}-${{ matrix.arch }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     timeout-minutes: 30
     needs: create-release
     strategy:
@@ -192,6 +193,8 @@ jobs:
   generate-sbom:
     name: Generate SBOM
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     timeout-minutes: 15
     needs: create-release
     steps:
@@ -269,6 +272,8 @@ jobs:
   back-merge-to-develop:
     name: Back-merge to Develop
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     needs: [create-release, build-binaries]
     if: success()
     steps:
@@ -324,6 +329,7 @@ jobs:
   release-summary:
     name: Release Summary
     runs-on: ubuntu-latest
+    permissions: {}
     needs: [create-release, build-binaries, generate-sbom, back-merge-to-develop]
     if: always()
     steps:


### PR DESCRIPTION
## Summary

- Replace the workflow-level `permissions: { contents: write, packages: write, id-token: write }` block in `release.yml` with `permissions: {}` (deny-by-default)
- Add per-job `permissions:` blocks granting only the minimum scope each job actually requires
- `packages: write` and `id-token: write` were dead grants — no step in the workflow publishes container images or performs OIDC keyless signing at `anchore/sbom-action@v0.20.11`

Fixes #1453

## Per-job permission rationale

| Job | Granted | Reason |
|-----|---------|--------|
| `create-release` | `contents: write` | `gh release create` writes a GitHub Release |
| `build-binaries` | `contents: write` | `gh release upload` uploads binary artifacts |
| `generate-sbom` | `contents: write` | `gh release upload` + `anchore/sbom-action` asset upload |
| `back-merge-to-develop` | `contents: write` | `git push origin develop` + optional branch deletion |
| `release-summary` | `{}` | writes only to `$GITHUB_STEP_SUMMARY`, no GITHUB_TOKEN calls |

## Specialist Review Results

**QA Test Runner**: PASS — all validation gates passed (unit, integration, cross-platform compilation, lint, license, secret scan, architecture check)

**QA Code Reviewer**: PASS — 0 blocking issues. No step bodies, `with:` inputs, `env:` values, or step order were modified. Removed `packages: write` and `id-token: write` confirmed unused by grep across the full file.

**Security Engineer**: PASS — `make security-precommit`, `make check-architecture`, and `make security-scan` all pass. Permissions are correctly minimised; no hardcoded secrets; all action pins are SHA-pinned.

## Test plan

- [ ] Verify `release.yml` workflow-level block is `permissions: {}`
- [ ] Verify each job has the per-job block listed in the table above
- [ ] Verify no step bodies, `with:` inputs, `env:` values, or step order changed
- [ ] CI checks pass on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)