### PR TITLE
ci: add zizmor PR-scanning workflow (Issue #1454)

### DIFF
--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,29 @@
+name: zizmor
+
+on:
+  pull_request:
+    branches: [ main, develop ]
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  zizmor:
+    name: zizmor
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@b1d7e1fb5de872772f31590499237e7cce841e8e # v0.5.3
+        continue-on-error: true
+        with:
+          upload: always
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/zizmor.yml` to run `zizmorcore/zizmor-action` on every PR targeting `main` or `develop`
- Uploads SARIF findings to the GitHub Security tab without blocking merge (`continue-on-error: true`, `upload: always`)
- Buys triage time before sub-story #3b promotes zizmor to a required check

## Security posture

- Top-level `permissions: {}` (deny-all) with minimal job-level grants: `contents: read` + `security-events: write`
- Checkout uses `persist-credentials: false` per zizmor's own recommendation
- All action references are SHA-pinned immutable commits
- `pull_request` trigger (not `pull_request_target`) — runs without secret access in fork contexts

## Files changed

- `.github/workflows/zizmor.yml` — new file only; no existing workflow, source, CLAUDE.md, or Makefile changes

## Specialist review results

| Reviewer | Result | Notes |
|---|---|---|
| QA Test Runner | PASS | `make test-agent-complete` passed; all 5 cross-platform builds pass; no Go regressions |
| QA Code Reviewer | PASS | All acceptance criteria verified; correct scope (YAML-only, no Go changes) |
| Security Engineer | PASS | SHA pins verified; permissions minimal; no injection sinks; no blocking issues |

## Test plan

- [ ] Verify CI checks pass on this PR
- [ ] After merge, open a test PR and confirm zizmor findings appear in the Security tab
- [ ] Triage any findings before sub-story #3b promotes zizmor to required check

Fixes #1454