### PR TITLE
ci: switch dependency-pin-check to GraphQL latestRelease (Issue #1464)

### DIFF
--- a/.github/workflows/dependency-pin-check.yml
+++ b/.github/workflows/dependency-pin-check.yml
@@ -75,17 +75,19 @@ jobs:
 
         check_version() {
           local name="$1" repo="$2" pinned="$3"
-          latest=$(gh api "repos/${repo}/releases/latest" --jq '.tag_name' 2>/dev/null) || latest=""
-          # Fallback to tags API if releases API fails (e.g. org IP allowlists)
+          local owner="${repo%/*}" repo_name="${repo#*/}"
+
+          latest=$(gh api graphql \
+            -f query='query($owner:String!,$name:String!){repository(owner:$owner,name:$name){latestRelease{tagName}}}' \
+            -f owner="$owner" -f name="$repo_name" \
+            --jq '.data.repository.latestRelease.tagName')
+
           if [ -z "$latest" ] || [ "$latest" = "null" ]; then
-            echo "  WARN: releases API failed for ${repo}, trying tags API..."
-            latest=$(gh api "repos/${repo}/tags" --jq '.[0].name' 2>/dev/null) || latest=""
-          fi
-          if [ -z "$latest" ] || [ "$latest" = "null" ]; then
-            echo "  WARN: Could not fetch latest version for ${repo} via releases or tags API"
-            warnings="${warnings}- **${name}**: could not fetch latest version from \`${repo}\` (both releases and tags API failed)\n"
+            echo "  WARN: GraphQL latestRelease returned empty/null for ${repo}"
+            warnings="${warnings}- **${name}**: \`latestRelease\` returned empty/null from \`${repo}\` (GraphQL)\n"
             return
           fi
+
           if [ "$pinned" != "$latest" ]; then
             echo "  OUTDATED: ${name} pinned=${pinned} latest=${latest}"
             outdated="${outdated}- **${name}**: pinned \`${pinned}\`, latest \`${latest}\` ([releases](https://github.com/${repo}/releases))\n"


### PR DESCRIPTION
## Summary

- Replaces REST `/releases/latest` (~76 KB response) in `check_version()` with a GraphQL `latestRelease{tagName}` query (~100 B), eliminating the secondary rate-limit risk that caused silent failures for `aquasecurity/trivy` in issues #678, #820, #1447
- Removes `2>/dev/null` suppression — real HTTP errors (403, 429, 503) now surface in the workflow log with their actual status code
- Removes the tags-API fallback; `latestRelease` is the canonical latest-non-prerelease indicator

Fixes #1464

## Files Changed

- `.github/workflows/dependency-pin-check.yml` — `check_version()` helper only; all eight call sites, Go toolchain check, lockstep validator, and denylist job are unchanged

## Specialist Review Results

**QA Test Runner: PASS**
- All 130+ packages, shell script tests (62/62), lint, license headers, secret scanning, architecture compliance, security scans passed
- Cross-platform compilation verified (linux/amd64, linux/arm64, darwin/amd64, darwin/arm64, windows/amd64)

**QA Code Reviewer: PASS**
- No blocking issues
- Warning: `latestRelease` returns null for repos with no GitHub Releases (tags-only repos like `dominikh/go-tools`); this is intentional — the null path emits a named warning that is now distinguishable from a rate-limit failure, unlike the old `2>/dev/null` behavior

**Security Engineer: PASS**
- GraphQL injection: safe — query is single-quoted with variables passed via separate `-f` flags; repo slugs are hardcoded literals
- Permissions: unchanged (`contents: read`, `issues: write`)
- Automated scans: security-precommit PASS, check-architecture PASS, security-scan PASS

## Verification Post-Merge

Trigger the workflow via `workflow_dispatch` on develop. Expected output for trivy:
```
  OK: trivy v0.70.0
```
(or `OUTDATED:` if upstream has a new release). Any failure now shows the real HTTP status from GitHub's GraphQL endpoint instead of a silent warning.