### PR TITLE
deps: bump trufflehog v3.95.2 → v3.95.3 (Issue #1463)

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -69,7 +69,7 @@ RUN GOPATH=$(go env GOPATH) \
     && chmod +x "$GOPATH/bin/nancy"
 
 # truffleHog (optional, best-effort secret scanning — pinned version, not @main)
-RUN curl -sSfL https://raw.githubusercontent.com/trufflesecurity/trufflehog/v3.95.2/scripts/install.sh | sh -s -- -b /usr/local/bin v3.95.2 || true
+RUN curl -sSfL https://raw.githubusercontent.com/trufflesecurity/trufflehog/v3.95.3/scripts/install.sh | sh -s -- -b /usr/local/bin v3.95.3 || true
 
 # Claude Code
 RUN npm install -g @anthropic-ai/claude-code

--- a/.github/workflows/dependency-pin-check.yml
+++ b/.github/workflows/dependency-pin-check.yml
@@ -99,7 +99,7 @@ jobs:
         check_version "staticcheck" "dominikh/go-tools"                       "2026.1"
         check_version "gitleaks"    "zricethezav/gitleaks"                    "v8.30.1"
         check_version "nancy"       "sonatype-nexus-community/nancy"          "v1.2.0"
-        check_version "trufflehog"  "trufflesecurity/trufflehog"              "v3.95.2"
+        check_version "trufflehog"  "trufflesecurity/trufflehog"              "v3.95.3"
         check_version "trivy"       "aquasecurity/trivy"                      "v0.70.0"
         check_version "go-licenses" "google/go-licenses"                      "v2.0.1"
         check_version "golangci-lint" "golangci/golangci-lint"                "v2.12.2"


### PR DESCRIPTION
## Summary

Routine patch refresh bumping trufflehog from v3.95.2 to v3.95.3. Cooldown elapsed (4 days since the 2026-05-11 release; threshold is 3 days). No CVE applies — the only GHSA advisory for trufflehog (GHSA-3r74-v83p-f4f4) was patched in 3.81.9, well below the current pin.

## Changes

- `.github/workflows/dependency-pin-check.yml:102` — `check_version` assertion updated from `v3.95.2` to `v3.95.3`
- `.devcontainer/Dockerfile:72` — install URL ref and install argument both updated from `v3.95.2` to `v3.95.3` (two occurrences on one line, both updated)

## Acceptance Criteria Verification

- Old version absent: `grep -rE "v3\.95\.2" .github/workflows/ .devcontainer/Dockerfile` → 0 matches ✅
- New version present: `grep -oE "v3\.95\.3" .github/workflows/ .devcontainer/Dockerfile` → 3 occurrences ✅
- `make test` passes ✅

## Specialist Review Results

| Reviewer | Result | Notes |
|----------|--------|-------|
| QA Test Runner | **PASS** | 100+ packages, 62 script tests, cross-platform build (5 platforms) |
| QA Code Reviewer | **PASS** | Lockstep confirmed, 0 stale refs to v3.95.2 anywhere in repo |
| Security Engineer | **PASS** | gitleaks + truffleHog clean, architecture checks pass, upstream tag v3.95.3 verified |

Fixes #1463