### PR TITLE
ci: add curl-redirect fallback to dependency-pin-check

### DIFF
--- a/.github/workflows/dependency-pin-check.yml
+++ b/.github/workflows/dependency-pin-check.yml
@@ -76,15 +76,30 @@ jobs:
         check_version() {
           local name="$1" repo="$2" pinned="$3"
           local owner="${repo%/*}" repo_name="${repo#*/}"
+          local latest
 
+          # GraphQL first (preferred — official API, lightweight). On failure,
+          # stderr is preserved in the workflow log for diagnostics, then we
+          # fall through. `|| latest=""` prevents `set -e` from killing the job
+          # when one tool fails (so the other seven still get checked).
           latest=$(gh api graphql \
             -f query='query($owner:String!,$name:String!){repository(owner:$owner,name:$name){latestRelease{tagName}}}' \
             -f owner="$owner" -f name="$repo_name" \
-            --jq '.data.repository.latestRelease.tagName')
+            --jq '.data.repository.latestRelease.tagName') || latest=""
 
           if [ -z "$latest" ] || [ "$latest" = "null" ]; then
-            echo "  WARN: GraphQL latestRelease returned empty/null for ${repo}"
-            warnings="${warnings}- **${name}**: \`latestRelease\` returned empty/null from \`${repo}\` (GraphQL)\n"
+            # Fallback: HTTP HEAD against the public release-redirect URL.
+            # Bypasses org IP allowlists (e.g. aquasecurity blocks GitHub
+            # Actions runner IPs from authenticated API access) since this is
+            # an unauthenticated public web request, not an api.github.com call.
+            echo "  INFO: ${repo} GraphQL returned empty/null or failed — trying redirect parse"
+            latest=$(curl -sI "https://github.com/${repo}/releases/latest" \
+                     | sed -n 's|^location: .*/tag/||Ip' | tr -d '\r\n')
+          fi
+
+          if [ -z "$latest" ]; then
+            echo "  WARN: Both GraphQL and redirect-parse failed for ${repo}"
+            warnings="${warnings}- **${name}**: could not fetch latest version from \`${repo}\` (GraphQL + redirect parse both failed)\n"
             return
           fi
 


### PR DESCRIPTION
## Summary

When GraphQL `latestRelease` returns empty/null or the `gh api` call fails, fall back to HTTP HEAD against `github.com/<repo>/releases/latest` and parse the tag from the `Location:` header.

## Why

The 2026-05-15 manual run of the GraphQL pin-check (PR #1465 just merged) revealed the **real** root cause of the recurring "could not fetch latest version from aquasecurity/trivy" warning that appeared in #678, #820, and #1447:

```
gh: Although you appear to have the correct authorization credentials,
the `aquasecurity` organization has an IP allow list enabled,
and your IP address is not permitted to access this resource.
```

It was never a rate limit or response-size issue. The aquasecurity org gates authenticated `api.github.com` access by IP, and GitHub Actions runner IPs aren't on the allowlist. The redirect endpoint at `github.com/<owner>/<repo>/releases/latest` is unauthenticated public web (not API), so allowlist policies don't apply.

A second related fix: adding `|| latest=""` on the GraphQL call so a single tool's failure doesn't kill the whole job under `set -e` — when the GraphQL call exited non-zero on trivy in the manual smoke test, `set -e` killed the script before `go-licenses` and `golangci-lint` could be checked.

## Local validation

```
$ curl -sI https://github.com/aquasecurity/trivy/releases/latest | grep -i location
location: https://github.com/aquasecurity/trivy/releases/tag/v0.70.0

$ curl -sI https://github.com/dominikh/go-tools/releases/latest | grep -i location
location: https://github.com/dominikh/go-tools/releases/tag/2026.1
```

Parser handles both `vX.Y.Z` and `YYYY.N` formats.

## Test plan

- [x] Local smoke-test of redirect parse against trivy and staticcheck
- [ ] CI smoke-test: after merge, manually trigger `dependency-pin-check.yml` via `workflow_dispatch` on develop. Expected output: all 8 tools report OK, with an `INFO: aquasecurity/trivy GraphQL returned empty/null or failed — trying redirect parse` line preceding the trivy OK.