### PR TITLE
ci: add merge_group trigger to zizmor workflow (Issue #1473)

### DIFF
--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -3,6 +3,7 @@ name: zizmor
 on:
   pull_request:
     branches: [ main, develop ]
+  merge_group:
   workflow_dispatch:
 
 permissions: {}

--- a/pkg/configrouting/providers/git/git_store_test.go
+++ b/pkg/configrouting/providers/git/git_store_test.go
@@ -477,7 +477,7 @@ func assertNoCredentialInStruct(t *testing.T, v interface{}, credential, path st
 		return
 	}
 	val := reflect.ValueOf(v)
-	if val.Kind() == reflect.Ptr {
+	if val.Kind() == reflect.Pointer {
 		if val.IsNil() {
 			return
 		}


### PR DESCRIPTION
## Summary

- Adds `merge_group:` to the `on:` block in `.github/workflows/zizmor.yml` so the workflow fires on merge-queue candidate commits (`gh-readonly-queue/*` branches)
- Fixes pre-existing govet lint error in `pkg/configrouting/providers/git/git_store_test.go`: replaces deprecated `reflect.Ptr` alias with `reflect.Pointer`

## Problem

The `zizmor` workflow only triggered on `pull_request` and `workflow_dispatch`. GitHub's merge queue fires a `merge_group` event on a synthetic candidate commit — `zizmor` never ran on these commits, yet `zizmor` is a required status check on `develop`. Result: every PR that entered the merge queue waited indefinitely for a check-run that never appeared, eventually timing out at 60 minutes.

PR #1472 was the first to hit this trap: enqueued 2026-05-15 22:07 UTC, stuck `AWAITING_CHECKS` for 38+ minutes.

## Change

```yaml
on:
  pull_request:
    branches: [ main, develop ]
  merge_group:
  workflow_dispatch:
```

One line. `merge_group:` with no sub-filters fires for every merge-queue candidate — the correct behavior.

Fixes #1473

## Specialist Review Results

| Reviewer | Result |
|----------|--------|
| QA Test Runner (`make test-agent-complete`) | PASS — 128 packages, 523 attack simulations, cross-platform compilation all green |
| QA Code Reviewer | PASS — 0 blocking issues, 0 warnings |
| Security Engineer | PASS — 0 blocking issues; `merge_group` trigger does not expose secrets (runs on internal `gh-readonly-queue/*` branches, not forks; bounded by job-level `permissions: contents: read, security-events: write`) |

## Test Plan

- [ ] Verify `zizmor` check-run appears on the merge candidate commit when this PR is enqueued
- [ ] Confirm PR #1472 (or next re-enqueued PR) no longer gets stuck in `AWAITING_CHECKS` waiting for `zizmor`