### PR TITLE
workflow: implement data-flow pipeline threading in executeComponentsPipeline (Issue #1471)

### DIFF
--- a/features/workflow/engine_composition.go
+++ b/features/workflow/engine_composition.go
@@ -503,11 +503,45 @@ func (e *Engine) executeComponentsDependency(ctx context.Context, config *Compos
 	return e.executeTopological(ctx, config, execution, stepName, adjList, inDegree)
 }
 
-// executeComponentsPipeline executes components as a data processing pipeline
+// executeComponentsPipeline executes components sequentially in declaration order,
+// threading each component's output into the next via DataFlow mappings.
 func (e *Engine) executeComponentsPipeline(ctx context.Context, config *CompositeConfig, execution *WorkflowExecution, stepName string) error {
-	// Deferred: tracked in #1442 — implement data-flow pipeline composition with inter-component streaming
-	e.logger.Warn("Pipeline composition not fully implemented, falling back to sequential")
-	return e.executeComponentsSequential(ctx, config, execution, stepName)
+	if len(config.Components) == 0 {
+		return nil
+	}
+
+	for i, component := range config.Components {
+		e.logger.Info("Executing pipeline component", "component", component.Name, "index", i)
+
+		err := e.executeComponent(ctx, component, execution, stepName)
+		if err != nil {
+			return e.handleComponentFailure(err, component, config.FailurePolicy)
+		}
+
+		e.applyDataFlowMappings(config.DataFlow, component.Name, execution)
+	}
+	return nil
+}
+
+// applyDataFlowMappings copies variables from the completed component's outputs into
+// the execution context so the next pipeline component can pick them up as inputs.
+// Missing source variables are logged as warnings and skipped (non-fatal).
+func (e *Engine) applyDataFlowMappings(dataFlow []DataFlowMapping, fromComponent string, execution *WorkflowExecution) {
+	for _, mapping := range dataFlow {
+		if mapping.FromComponent != fromComponent {
+			continue
+		}
+		value, exists := execution.GetVariable(mapping.FromVariable)
+		if !exists {
+			e.logger.Warn("DataFlow mapping source variable not found",
+				"from_component", mapping.FromComponent,
+				"from_variable", mapping.FromVariable,
+				"to_component", mapping.ToComponent,
+				"to_variable", mapping.ToVariable)
+			continue
+		}
+		execution.SetVariable(mapping.ToVariable, value)
+	}
 }
 
 // executeComponentsConditional executes components based on conditions

--- a/features/workflow/engine_composition_test.go
+++ b/features/workflow/engine_composition_test.go
@@ -262,3 +262,187 @@ func TestExecuteComponentsDependency_UnknownDependency(t *testing.T) {
 	assert.Equal(t, StatusFailed, execution.GetStatus())
 	assert.Contains(t, execution.GetError(), "unknown")
 }
+
+// TestExecuteComponentsPipeline_OutputThreaded verifies that DataFlow mappings seed
+// a completed component's output variable into the execution context before the next
+// component runs. The test asserts that the threaded variable carries the exact value
+// set by component 1 — a bare no-error assertion would pass with the old sequential stub.
+func TestExecuteComponentsPipeline_OutputThreaded(t *testing.T) {
+	engine := NewEngine(createTestFactory(), logging.NewNoopLogger(), nil)
+
+	// comp1 exposes output_val; OutputMappings propagate it to comp1_result in parent execution.
+	engine.RegisterWorkflow(Workflow{
+		Name:      "pipe-comp1",
+		Variables: map[string]interface{}{"output_val": "pipeline_value"},
+		Steps: []Step{{
+			Name:  "step1",
+			Type:  StepTypeDelay,
+			Delay: &DelayConfig{Duration: 1 * time.Millisecond},
+		}},
+	})
+	// comp2 is a minimal delay; its role is to be the DataFlow target.
+	engine.RegisterWorkflow(Workflow{
+		Name:  "pipe-comp2",
+		Steps: []Step{{
+			Name:  "step2",
+			Type:  StepTypeDelay,
+			Delay: &DelayConfig{Duration: 1 * time.Millisecond},
+		}},
+	})
+
+	workflow := Workflow{
+		Name: "pipeline-threaded-test",
+		Steps: []Step{{
+			Name: "compose",
+			Type: StepTypeComposite,
+			Composite: &CompositeConfig{
+				Strategy:      CompositionStrategyPipeline,
+				FailurePolicy: CompositeFailurePolicyFail,
+				Components: []WorkflowComponent{
+					{
+						Name:           "comp1",
+						WorkflowName:   "pipe-comp1",
+						OutputMappings: map[string]string{"output_val": "comp1_result"},
+					},
+					{
+						Name:         "comp2",
+						WorkflowName: "pipe-comp2",
+					},
+				},
+				DataFlow: []DataFlowMapping{
+					{
+						FromComponent: "comp1",
+						FromVariable:  "comp1_result",
+						ToComponent:   "comp2",
+						ToVariable:    "threaded_input",
+					},
+				},
+			},
+		}},
+	}
+
+	ctx := context.Background()
+	execution, err := engine.ExecuteWorkflow(ctx, workflow, nil)
+	require.NoError(t, err)
+	require.NotNil(t, execution)
+
+	waitForWorkflowCompletion(t, execution, 5*time.Second)
+
+	assert.Equal(t, StatusCompleted, execution.GetStatus())
+
+	val, ok := execution.GetVariable("threaded_input")
+	require.True(t, ok, "threaded_input must be set by DataFlow mapping after comp1 completes")
+	assert.Equal(t, "pipeline_value", val)
+}
+
+// TestExecuteComponentsPipeline_EmptyPipeline verifies that a pipeline with zero
+// components returns nil immediately without error.
+func TestExecuteComponentsPipeline_EmptyPipeline(t *testing.T) {
+	engine := NewEngine(createTestFactory(), logging.NewNoopLogger(), nil)
+
+	execution := &WorkflowExecution{
+		ID:           "test-empty-pipeline",
+		WorkflowName: "test",
+		Status:       StatusRunning,
+		Variables:    make(map[string]interface{}),
+	}
+
+	config := &CompositeConfig{
+		Strategy:      CompositionStrategyPipeline,
+		FailurePolicy: CompositeFailurePolicyFail,
+		Components:    []WorkflowComponent{},
+	}
+
+	err := engine.executeComponentsPipeline(context.Background(), config, execution, "test-step")
+	require.NoError(t, err)
+}
+
+// TestExecuteComponentsPipeline_MissingDataFlowVariable verifies that a DataFlow
+// mapping referencing a non-existent FromVariable logs a warning but does not fail;
+// the pipeline completes successfully.
+func TestExecuteComponentsPipeline_MissingDataFlowVariable(t *testing.T) {
+	engine := NewEngine(createTestFactory(), logging.NewNoopLogger(), nil)
+
+	engine.RegisterWorkflow(Workflow{
+		Name:  "pipe-missing-src",
+		Steps: []Step{{
+			Name:  "step",
+			Type:  StepTypeDelay,
+			Delay: &DelayConfig{Duration: 1 * time.Millisecond},
+		}},
+	})
+
+	workflow := Workflow{
+		Name: "pipeline-missing-var-test",
+		Steps: []Step{{
+			Name: "compose",
+			Type: StepTypeComposite,
+			Composite: &CompositeConfig{
+				Strategy:      CompositionStrategyPipeline,
+				FailurePolicy: CompositeFailurePolicyFail,
+				Components: []WorkflowComponent{
+					{
+						Name:         "src",
+						WorkflowName: "pipe-missing-src",
+					},
+				},
+				DataFlow: []DataFlowMapping{
+					{
+						FromComponent: "src",
+						FromVariable:  "does_not_exist",
+						ToComponent:   "nowhere",
+						ToVariable:    "target",
+					},
+				},
+			},
+		}},
+	}
+
+	ctx := context.Background()
+	execution, err := engine.ExecuteWorkflow(ctx, workflow, nil)
+	require.NoError(t, err)
+	require.NotNil(t, execution)
+
+	waitForWorkflowCompletion(t, execution, 5*time.Second)
+
+	assert.Equal(t, StatusCompleted, execution.GetStatus())
+
+	_, ok := execution.GetVariable("target")
+	assert.False(t, ok, "target must not be set when FromVariable is missing")
+}
+
+// TestExecuteComponentsPipeline_ComponentFailure verifies that when a pipeline
+// component fails, handleComponentFailure propagates the error and the workflow
+// reaches StatusFailed — exercising the failure-propagation branch on line 518.
+func TestExecuteComponentsPipeline_ComponentFailure(t *testing.T) {
+	engine := NewEngine(createTestFactory(), logging.NewNoopLogger(), nil)
+
+	// "unregistered-wf" is intentionally not registered so executeComponent fails.
+	workflow := Workflow{
+		Name: "pipeline-failure-test",
+		Steps: []Step{{
+			Name: "compose",
+			Type: StepTypeComposite,
+			Composite: &CompositeConfig{
+				Strategy:      CompositionStrategyPipeline,
+				FailurePolicy: CompositeFailurePolicyFail,
+				Components: []WorkflowComponent{
+					{
+						Name:         "bad-comp",
+						WorkflowName: "unregistered-wf",
+					},
+				},
+			},
+		}},
+	}
+
+	ctx := context.Background()
+	execution, err := engine.ExecuteWorkflow(ctx, workflow, nil)
+	require.NoError(t, err)
+	require.NotNil(t, execution)
+
+	waitForWorkflowCompletion(t, execution, 5*time.Second)
+
+	assert.Equal(t, StatusFailed, execution.GetStatus())
+	assert.NotEmpty(t, execution.GetError(), "error message must be set when pipeline component fails")
+}


### PR DESCRIPTION
## Summary

- Replaces the `executeComponentsPipeline` stub (which fell back to sequential with a `Warn` log) with a real sequential pipeline that applies `DataFlow` mappings between components
- Adds `applyDataFlowMappings` helper: copies `FromVariable` → `ToVariable` in the execution context after each component completes; missing source variables log a warning and are skipped (non-fatal)
- Empty pipeline (0 components) returns nil immediately

## What Changed

**`features/workflow/engine_composition.go`**
- `executeComponentsPipeline`: iterates `config.Components` in declaration order, calls `executeComponent`, then `applyDataFlowMappings` before the next component runs; removes the `Warn` fallback
- `applyDataFlowMappings` (new unexported helper): DataFlow-driven variable threading between components

**`features/workflow/engine_composition_test.go`** (appended to file created by #1470)
- `TestExecuteComponentsPipeline_OutputThreaded`: asserts `execution.GetVariable` returns the exact value threaded from component 1 via DataFlow — a meaningful assertion that would fail with the old stub
- `TestExecuteComponentsPipeline_EmptyPipeline`: zero components returns nil
- `TestExecuteComponentsPipeline_MissingDataFlowVariable`: missing `FromVariable` logs warning, workflow completes
- `TestExecuteComponentsPipeline_ComponentFailure`: unregistered workflow triggers load failure; asserts `StatusFailed` (exercises `handleComponentFailure` branch)

## Specialist Review Results

| Reviewer | Result |
|----------|--------|
| QA Test Runner (`make test-agent-complete`) | **PASS** — all pipeline tests pass; pre-existing unrelated flaky perf test in `rbac/authdefense` not introduced by this story |
| QA Code Reviewer | **PASS** — blocking issue (missing error path test) resolved with `TestExecuteComponentsPipeline_ComponentFailure`; no mocks, no skips, meaningful assertions |
| Security Engineer | **PASS** — all scans clean (gitleaks, truffleHog, gosec, staticcheck, Trivy, Nancy, check-architecture); no blocking issues |

Fixes #1471