### PR TITLE
pipeline-security: migrate 4 agent specs to project-queue.sh get-item (Issue #1479)

### DIFF
--- a/.claude/agents/acceptance-checker.md
+++ b/.claude/agents/acceptance-checker.md
@@ -21,7 +21,8 @@ You are spawned by `/story-complete` with:
 
 - Working directory: the agent's clone of the repo, on the story branch
 - Story number: derivable from the branch (`feature/story-<N>-*`) or via `git config --get branch.$(git branch --show-current).description` if set
-- Story body: fetch via `gh issue view <STORY_NUM> --repo cfg-is/cfgms --json title,body`
+- Project item ID: passed as `--project-item <ITEM_ID>` at invocation (retained alongside `STORY_NUM` which is used for reference only)
+- Story body: fetch via `./scripts/project-queue.sh get-item <ITEM_ID>` — returns JSON with `.body` (story body, ACs), `.title`, `.issue_num`
 - Changed files: `git diff --name-only develop...HEAD`
 
 You do NOT have a PR number — the PR doesn't exist yet. That's the whole point of running here.
@@ -29,12 +30,16 @@ You do NOT have a PR number — the PR doesn't exist yet. That's the whole point
 ## Phase 1: Fetch story and identify changes
 
 ```bash
-# Determine story number from current branch
+# Determine story number from current branch (retained for reference)
 BRANCH=$(git branch --show-current)
 STORY_NUM=$(echo "$BRANCH" | sed -nE 's|^feature/story-([0-9]+)-.*|\1|p')
 
-# Fetch story body
-gh issue view "$STORY_NUM" --repo cfg-is/cfgms --json title,body
+# Project item ID is passed via --project-item flag at invocation
+# ITEM_ID=<value from --project-item argument>
+
+# Fetch story body from the private project (avoids public issue injection surface)
+./scripts/project-queue.sh get-item "$ITEM_ID"
+# Returns JSON with .body (story body, ACs), .title, .issue_num
 
 # Identify changed files on this branch
 git diff --name-only develop...HEAD
@@ -89,7 +94,7 @@ For each reference recorded in Phase 2:
 If a banned-phrase match is preceded by `// Deferred: tracked in #NNN`, verify the tracking issue is valid:
 
 ```bash
-gh issue view <NNN> --repo cfg-is/cfgms --json state,labels --jq '{state, labels: [.labels[].name]}'
+gh api "repos/cfg-is/cfgms/issues/<NNN>" --jq '{state, labels: [.labels[].name]}'
 ```
 
 Requirements:

--- a/.claude/agents/acceptance-reviewer.md
+++ b/.claude/agents/acceptance-reviewer.md
@@ -22,7 +22,10 @@ You are NOT the same as `/story-complete` QA. The distinction:
 
 ## Input
 
-You receive a PR number and story issue number as `$ARGUMENTS` (format: `pr:<PR_NUM> story:<STORY_NUM>`).
+You receive a PR number, story issue number, and project item ID as `$ARGUMENTS`
+(format: `pr:<PR_NUM> story:<STORY_NUM> --project-item <ITEM_ID>`).
+
+The story issue number is retained for PR linking and assignee operations. `ITEM_ID` is used for body reads and status updates.
 
 ## Phase 0: Draft-PR Short-Circuit (BLOCKING)
 
@@ -43,7 +46,10 @@ If `isDraft == true`:
   Draft PRs are typically WIP from a truncated agent session (token reauth, token limit). The PO will dispatch `fix-pr` to resume the work; the resumed agent will mark this PR ready for review when finished. No findings to report at this stage.
   ```
 
-- Remove the `pipeline:reviewing` label from the PR (so the failsafe doesn't think the review is still in flight).
+- Update the project item status so the failsafe doesn't think the review is still in flight:
+  ```bash
+  ./scripts/project-queue.sh update-field <ITEM_ID> status "In Progress"
+  ```
 - Exit cleanly with verdict `SKIPPED_DRAFT`. Do NOT enqueue, label `pipeline:fix`, or label `pipeline:blocked` — those are wrong actions for a session-truncated WIP.
 
 A draft PR with body starting `Agent session failed with exit code` or title starting `WIP:` and ending `(agent failed)` is the canonical session-truncation case — same handling.
@@ -60,11 +66,10 @@ gh pr diff <PR_NUM> --repo cfg-is/cfgms
 # CI status
 gh pr checks <PR_NUM> --repo cfg-is/cfgms
 
-# Story acceptance criteria
-gh issue view <STORY_NUM> --repo cfg-is/cfgms --json number,title,body
-
-# Check if this is a re-review (fix cycle)
-gh issue view <STORY_NUM> --repo cfg-is/cfgms --json labels --jq '[.labels[].name] | if index("pipeline:fix") then "FIX_CYCLE" else "FIRST_REVIEW" end'
+# Story body and review cycle status from the private project
+./scripts/project-queue.sh get-item <ITEM_ID>
+# Returns .body (acceptance criteria text) and .status
+# .status == "Fix" means FIX_CYCLE; any other status means FIRST_REVIEW
 ```
 
 Also read `CLAUDE.md` for architecture rules and testing standards.
@@ -199,17 +204,17 @@ PASS requires BOTH: the Findings table is empty AND every Code-Reference Verific
 
 If `po-act.sh enqueue` exits non-zero (`ENQUEUE_FAILED`), do NOT proceed to cleanup. Surface the failure: post a one-line comment on the PR noting the enqueue gate refused, and leave the dev agent's container/worktree intact so the next cron cycle's reconciliation step can pick it up. Common causes the script's retry can't recover from: required reviewer not yet assigned, CODEOWNERS gate, or a CI check newly going red between PASS verdict and enqueue call.
 
-If the story had `pipeline:fix`, remove it:
+Mark the story as done in the project queue:
 ```bash
-./scripts/pipeline-helper.sh label-remove <STORY_NUM> "pipeline:fix"
+./scripts/project-queue.sh update-field <ITEM_ID> status Done
 ```
 
 ### Any Findings — First Review
 
-Apply fix label and post findings:
+Update project item status and post findings:
 
 ```bash
-./scripts/pipeline-helper.sh label-add <STORY_NUM> "pipeline:fix"
+./scripts/project-queue.sh update-field <ITEM_ID> status Fix
 ```
 
 ### Any Findings — Second Review (Fix Cycle)
@@ -217,7 +222,7 @@ Apply fix label and post findings:
 Escalate to founder and clean up the agent container (the dev agent is done regardless):
 
 ```bash
-./scripts/pipeline-helper.sh label-swap <STORY_NUM> "pipeline:fix" "pipeline:blocked"
+./scripts/project-queue.sh update-field <ITEM_ID> status Blocked
 gh issue edit <STORY_NUM> --repo cfg-is/cfgms --add-assignee "jrdnr"
 
 # Clean up — agent is done, founder takes over
@@ -275,7 +280,7 @@ If there are zero findings, the Findings table should say "None" and the Accepta
 - Never skip acceptance criteria verification — every checkbox must be checked against the diff AND the Code-Reference Verification table
 - **Any FAIL row in Code-Reference Verification forces `## Acceptance Review — FAIL`.** The reviewer CANNOT issue PASS while any reference is failing or unverified. "New functions added + tests pass" is NOT sufficient when the AC names a specific symbol that must change.
 - **Diff-blindness rule**: when an AC names existing code that must change, verify the post-change state by fetching the file from the PR's HEAD ref. Searching only `gh pr diff` will miss unchanged stubs (they're absent from the diff by definition).
-- The fix cycle gets exactly one attempt. First failure = `pipeline:fix`. Second failure = `pipeline:blocked`. No third attempt.
+- The fix cycle gets exactly one attempt. First failure = `status Fix`. Second failure = `status Blocked`. No third attempt.
 - Merge enqueue uses `--squash` — merge queue handles the rest (rebase + re-validation + actual merge)
 - Clean up agent container/worktree on auto-merge — the agent infrastructure is no longer needed
 - If the PR targets `main` instead of `develop`, this is a BLOCKING workflow violation. Report it and do not merge.

--- a/.claude/agents/ba.md
+++ b/.claude/agents/ba.md
@@ -13,10 +13,19 @@ You are the Business Analyst for CFGMS. You receive a `pipeline:epic` issue and 
 
 ## Input
 
-You receive an epic issue number as `$ARGUMENTS`. Start by reading the epic:
+You receive an epic issue number and project item ID as `$ARGUMENTS` in the form:
+`<ISSUE_NUM> --project-item <ITEM_ID>`
+
+Parse the arguments and read the epic body from the private project:
 
 ```bash
-gh issue view $ARGUMENTS --repo cfg-is/cfgms --json number,title,body,labels
+# Parse arguments — ISSUE_NUM retained for sub-issue linking and PR references
+ISSUE_NUM=$(echo "$ARGUMENTS" | awk '{print $1}')
+ITEM_ID=$(echo "$ARGUMENTS" | sed -n 's/.*--project-item[[:space:]]\+\([^[:space:]]\+\).*/\1/p')
+
+# Read epic body from the private project (avoids public issue injection surface)
+./scripts/project-queue.sh get-item "$ITEM_ID"
+# Returns JSON with .body (epic goal, success criteria, non-goals, constraints), .title, .issue_num, .status
 ```
 
 ## Pre-Checks
@@ -29,7 +38,7 @@ Before decomposing, gather context in parallel:
 4. **Relevant source files** — use Grep/Glob to find files related to the epic's scope. Read key files to understand current implementation.
 5. **Existing sub-issues** — check if the epic already has sub-issues:
    ```bash
-   EPIC_ID=$(gh issue view $ARGUMENTS --json id -q .id)
+   EPIC_ID=$(gh api "repos/cfg-is/cfgms/issues/$ISSUE_NUM" --jq .node_id)
    gh api graphql -f query='
      query($id: ID!) {
        node(id: $id) {

--- a/.claude/agents/tech-lead.md
+++ b/.claude/agents/tech-lead.md
@@ -13,10 +13,16 @@ You are the Tech Lead for CFGMS. You receive `pipeline:draft` story issues and v
 
 ## Input
 
-You receive one or more story issue numbers as `$ARGUMENTS` (space-separated). For each story:
+You receive one or more story issue numbers as `$ARGUMENTS`, each paired with its project item ID
+via `--project-item`: `<NUM1> --project-item <ITEM_ID1> <NUM2> --project-item <ITEM_ID2> ...`
+
+The issue number is retained for PR linking and pipeline-helper operations. For each story, read the body
+from the private project:
 
 ```bash
-gh issue view <NUM> --repo cfg-is/cfgms --json number,title,body,labels
+# For each <NUM> / <ITEM_ID> pair parsed from $ARGUMENTS:
+./scripts/project-queue.sh get-item "<ITEM_ID>"
+# Returns JSON with .body (story body, ACs), .title, .issue_num, .status
 ```
 
 Also read `CLAUDE.md` for architecture rules, central providers, and anti-patterns.
@@ -147,8 +153,8 @@ When all 7 checks pass:
 
 1. Update the issue body with any additions (implementation notes, dependency fixes):
    ```bash
-   # Fetch current body, write updated version to temp file
-   gh issue view <NUM> --repo cfg-is/cfgms --json body -q .body > /tmp/story-<NUM>-body.md
+   # Fetch current body from the private project, write updated version to temp file
+   ./scripts/project-queue.sh get-item "<ITEM_ID>" | python3 -c "import json,sys; print(json.load(sys.stdin)['body'])" > /tmp/story-<NUM>-body.md
    # ... edit the file to add implementation notes ...
    ./scripts/pipeline-helper.sh edit-body <NUM> /tmp/story-<NUM>-body.md
    rm /tmp/story-<NUM>-body.md


### PR DESCRIPTION
## Summary

- Migrates story body and AC text reads in all four pipeline agents (ba, tech-lead, acceptance-reviewer, acceptance-checker) from `gh issue view` on the public issue tracker to `./scripts/project-queue.sh get-item <ITEM_ID>` on the private Projects V2 substrate
- Replaces label add/remove/swap verdict operations in acceptance-reviewer with `project-queue.sh update-field <ITEM_ID> status Done/Fix/Blocked`
- Adds `--project-item <ITEM_ID>` flag documentation to all four agent Input sections; issue numbers retained for PR linking and assignee operations throughout

Fixes #1479

## Test Plan

- [x] `grep -n "gh issue view" .claude/agents/ba.md .claude/agents/tech-lead.md .claude/agents/acceptance-reviewer.md .claude/agents/acceptance-checker.md` — exits 1 (zero matches)
- [x] All 131 Go packages pass unit tests with race detection
- [x] 90 script tests pass (including project-queue.sh get-item live integration tests)
- [x] Cross-platform compilation: linux/amd64, linux/arm64, darwin/amd64, darwin/arm64, windows/amd64
- [x] golangci-lint: 0 issues
- [x] License headers validated
- [x] Architecture compliance: no central provider violations
- [x] Security scan (Trivy, Nancy, gosec, staticcheck): PASS

## Specialist Review Results

**QA Test Runner**: PASS — all 131 packages pass, 90 script tests pass, cross-platform builds verified. `project-queue.sh get-item` live integration assertions all pass.

**QA Code Reviewer**: PASS — zero blocking issues. `gh issue view` fully absent from all 4 files. `project-queue.sh update-field` usage consistent with script implementation. Issue numbers retained across all specs.

**Security Engineer**: PASS — security posture *improved* by moving story-body reads off the public-issue injection surface. `project-queue.sh get-item` uses parameterized GraphQL with environment-variable isolation (no shell injection). Argument parsing in ba.md is safe (awk + sed, quoted downstream). Tech-lead Python one-liner pipes to a temp file, not eval. All automated scans PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)