### PR TITLE
pipeline-security: close entrypoint injection surface (Issue #1480)

### DIFF
--- a/.claude/scripts/po-act.sh
+++ b/.claude/scripts/po-act.sh
@@ -47,16 +47,62 @@ case "$cmd" in
     story="${1:?story number required}"
     "$DISPATCH" check-conflicts "$story" >/dev/null
     "$DISPATCH" create-clone "$story" | tail -1
-    "$DISPATCH" launch "$story" | tail -1
+
+    # Fetch item_id BEFORE launch so CFGMS_PROJECT_ITEM_ID can be passed to the
+    # container. The entrypoint refuses to run without this var — hard fail here
+    # if the story is not in the project queue at Ready status.
     PROJECT_QUEUE="$(cd "$(dirname "$0")/../.." && pwd)/scripts/project-queue.sh"
     item_id=$(bash "$PROJECT_QUEUE" list-by-status Ready 2>/dev/null \
       | jq -r --argjson num "$story" '.[] | select(.issue_num == $num) | .item_id' \
       2>/dev/null || true)
+    if [ -z "${item_id:-}" ]; then
+      echo "ERROR: story #${story} not found in project queue with Ready status" >&2
+      exit 1
+    fi
+
+    # Launch with CFGMS_PROJECT_ITEM_ID so entrypoint sources content from Projects V2.
+    # Inlined from agent-dispatch.sh launch to pass the extra env var without editing
+    # that file (avoids a file conflict with the parallel Story 7 branch).
+    clone_path="${WORKTREE_BASE}/story-${story}"
+    real_path=$(realpath "$clone_path")
+    # Refresh credentials from host session (mirrors refresh_creds_from_host in agent-dispatch.sh).
+    host_creds="$HOME/.claude/.credentials.json"
+    if [ -f "$host_creds" ]; then
+      docker run --rm --entrypoint bash \
+        -v claude-creds:/persist \
+        -v "${host_creds}:/host-creds.json:ro" \
+        cfg-agent:latest \
+        -c "cp /host-creds.json /persist/.credentials.json" 2>/dev/null || true
+    fi
+    gh_token=$(gh auth token)
+    if container_id=$(docker run -d \
+      --name "cfg-agent-${story}" \
+      --label "cfg-agent=true" \
+      --label "issue=${story}" \
+      --label "mode=issue" \
+      --memory=4g \
+      --cpus=4 \
+      --stop-timeout=3600 \
+      -v "${real_path}:/workspace" \
+      -v "claude-creds:/persist" \
+      -v "cfgms-go-build-cache:/home/agent/.cache/go-build" \
+      -v "cfgms-go-mod-cache:/home/agent/go/pkg/mod" \
+      -e "GH_TOKEN=${gh_token}" \
+      -e "CFGMS_PROJECT_ITEM_ID=${item_id}" \
+      --cap-add NET_ADMIN \
+      cfg-agent:latest \
+      "${story}" 2>&1); then
+      echo "LAUNCHED:${story}:${container_id}"
+    else
+      echo "LAUNCH_FAILED:${story}:${container_id}"
+      rm -rf "$clone_path"
+      echo "CLEANED:clone:${clone_path}"
+      exit 1
+    fi
+
     gh issue edit "$story" --repo "$REPO" \
       --remove-label "agent:ready" --add-label "agent:in-progress" >/dev/null
-    if [ -n "${item_id:-}" ]; then
-      bash "$PROJECT_QUEUE" update-field "$item_id" status "In Progress" >/dev/null 2>&1 || true
-    fi
+    bash "$PROJECT_QUEUE" update-field "$item_id" status "In Progress" >/dev/null 2>&1 || true
     echo "DISPATCHED:$story"
     ;;
 

--- a/.devcontainer/entrypoint.sh
+++ b/.devcontainer/entrypoint.sh
@@ -7,6 +7,9 @@ set -euo pipefail
 # shellcheck source=./agent-context.sh
 source "$(dirname "${BASH_SOURCE[0]}")/agent-context.sh"
 
+# Path to the Projects V2 queue helper (configurable for testing).
+PROJECT_QUEUE="${CFGMS_TEST_PROJECT_QUEUE:-$(dirname "${BASH_SOURCE[0]}")/../scripts/project-queue.sh}"
+
 # --- Argument parsing ---
 MODE="issue"
 ISSUE_NUM=""
@@ -173,24 +176,21 @@ SCOPE_CONSTRAINTS_SECTION='## Scope Constraints
 # --- Phase 1: Compose prompt based on mode ---
 
 compose_issue_prompt() {
-    echo "Fetching issue #${ISSUE_NUM}..."
-    ISSUE_JSON=$(gh_api_with_retry "fetch issue #${ISSUE_NUM}" gh issue view "$ISSUE_NUM" --json title,body,labels,comments) || {
-        echo "ERROR: Cannot proceed without issue context"
+    echo "Fetching project item ${CFGMS_PROJECT_ITEM_ID}..."
+    local item_json
+    item_json=$(bash "$PROJECT_QUEUE" get-item "$CFGMS_PROJECT_ITEM_ID") || {
+        echo "ERROR: Cannot fetch project item ${CFGMS_PROJECT_ITEM_ID}"
         exit 1
     }
 
-    TITLE=$(echo "$ISSUE_JSON" | jq -r '.title')
-    BODY=$(echo "$ISSUE_JSON" | jq -r '.body')
-    local issue_comments_json
-    issue_comments_json=$(echo "$ISSUE_JSON" | jq -c '.comments // []')
+    TITLE=$(echo "$item_json" | jq -r '.title')
+    BODY=$(echo "$item_json" | jq -r '.body')
 
     # Build prompt in a temp file to avoid shell metacharacter corruption.
     # Issue bodies often contain backticks, $ field numbers, etc.
     PROMPT_FILE=$(mktemp)
     printf 'You are implementing GitHub issue #%s: %s\n\n' "$ISSUE_NUM" "$TITLE" > "$PROMPT_FILE"
     printf '%s\n\n' "$BODY" >> "$PROMPT_FILE"
-    ac_render_issue_comments "$issue_comments_json" >> "$PROMPT_FILE"
-    printf '\n' >> "$PROMPT_FILE"
     cat >> "$PROMPT_FILE" <<PROMPT_EOF
 ## Instructions
 
@@ -254,27 +254,23 @@ compose_branch_prompt() {
         echo "Auto-detected issue #${ISSUE_NUM} from branch name"
     fi
 
-    # Fetch issue context if available
-    local issue_comments_md=""
+    # Fetch issue context from Projects V2 — never from gh issue view.
     if [[ -n "$ISSUE_NUM" ]]; then
-        echo "Fetching issue #${ISSUE_NUM} for context..."
-        ISSUE_JSON=$(gh_api_with_retry "fetch issue #${ISSUE_NUM}" gh issue view "$ISSUE_NUM" --json title,body,labels,comments) || {
-            echo "ERROR: Cannot proceed without issue context"
+        echo "Fetching project item ${CFGMS_PROJECT_ITEM_ID} for context..."
+        local item_json
+        item_json=$(bash "$PROJECT_QUEUE" get-item "$CFGMS_PROJECT_ITEM_ID") || {
+            echo "ERROR: Cannot fetch project item ${CFGMS_PROJECT_ITEM_ID}"
             exit 1
         }
-        if echo "$ISSUE_JSON" | jq -e '.title' >/dev/null 2>&1; then
-            TITLE=$(echo "$ISSUE_JSON" | jq -r '.title')
-            BODY=$(echo "$ISSUE_JSON" | jq -r '.body')
-            issue_context="## Issue Context
+        local item_title item_body
+        item_title=$(echo "$item_json" | jq -r '.title')
+        item_body=$(echo "$item_json" | jq -r '.body')
+        issue_context="## Issue Context
 
-GitHub issue #${ISSUE_NUM}: ${TITLE}
+GitHub issue #${ISSUE_NUM}: ${item_title}
 
-${BODY}
+${item_body}
 "
-            local _comments_json
-            _comments_json=$(echo "$ISSUE_JSON" | jq -c '.comments // []')
-            issue_comments_md=$(ac_render_issue_comments "$_comments_json")
-        fi
     fi
 
     # Detect if a PR already exists for this branch
@@ -297,9 +293,6 @@ ${BODY}
     printf 'You are working on existing branch `%s`.\n\n' "$BRANCH" > "$PROMPT_FILE"
     if [[ -n "$issue_context" ]]; then
         printf '%s\n' "$issue_context" >> "$PROMPT_FILE"
-    fi
-    if [[ -n "$issue_comments_md" ]]; then
-        printf '%s\n\n' "$issue_comments_md" >> "$PROMPT_FILE"
     fi
     cat >> "$PROMPT_FILE" <<PROMPT_EOF
 ## Instructions
@@ -484,6 +477,13 @@ If specialists report issues that cannot be fixed after 3 iterations:
 PROMPT_EOF
     printf '%s\n' "$SCOPE_CONSTRAINTS_SECTION" >> "$PROMPT_FILE"
 }
+
+# Hard refusal: issue and branch modes must source content from Projects V2.
+# fix-pr reads PR review comments gated by repo write access — a separate surface.
+if [[ "$MODE" != "fix-pr" ]] && [[ -z "${CFGMS_PROJECT_ITEM_ID:-}" ]]; then
+    echo "ERROR: CFGMS_PROJECT_ITEM_ID must be set — no fallback to gh issue view" >&2
+    exit 1
+fi
 
 # Compose prompt based on mode
 case "$MODE" in

--- a/.devcontainer/entrypoint_test.sh
+++ b/.devcontainer/entrypoint_test.sh
@@ -405,6 +405,147 @@ test_13_review_level_comments_render() {
 }
 
 # ============================================================================
+# Entrypoint subprocess test helpers
+#
+# These helpers set up a self-contained temp directory with stubs for all
+# external dependencies, then invoke entrypoint.sh as a subprocess in
+# --dry-run mode so the prompt-assembly path can be tested without Docker,
+# Claude credentials, or a live GitHub token.
+# ============================================================================
+
+SENTINEL_INJECTION="NON_MEMBER_COMMENT_SENTINEL_XYZZY"
+SENTINEL_PROJECT_BODY="PROJECT_ITEM_BODY_SENTINEL_ABCDE"
+
+setup_entrypoint_stubs() {
+    TEST_ENTRY_DIR=$(mktemp -d)
+    export TEST_ENTRY_DIR
+
+    # Fake home: credentials file with far-future expiry (>>300s remaining)
+    # so the OAuth refresh code path is never triggered.
+    mkdir -p "$TEST_ENTRY_DIR/home/.claude"
+    printf '{"claudeAiOauth":{"expiresAt":9999999999000}}\n' \
+        > "$TEST_ENTRY_DIR/home/.claude/.credentials.json"
+
+    # setup-env.sh stub (no-op) — entrypoint calls this bare-name so PATH must include it.
+    cat > "$TEST_ENTRY_DIR/setup-env.sh" <<'STUB'
+#!/usr/bin/env bash
+exit 0
+STUB
+    chmod +x "$TEST_ENTRY_DIR/setup-env.sh"
+
+    # project-queue.sh stub — returns a clean project item (no comments field).
+    cat > "$TEST_ENTRY_DIR/project-queue.sh" <<STUB
+#!/usr/bin/env bash
+printf '{"item_id":"pv2-test-item","title":"Test Story","body":"${SENTINEL_PROJECT_BODY}","issue_num":9999,"status":"Ready","fields":{}}\n'
+STUB
+    chmod +x "$TEST_ENTRY_DIR/project-queue.sh"
+
+    # gh stub — returns injected comments when called for "issue view".
+    # This is the payload that would appear if the entrypoint still called
+    # gh issue view instead of project-queue.sh get-item.
+    cat > "$TEST_ENTRY_DIR/gh" <<STUB
+#!/usr/bin/env bash
+case "\$*" in
+    *"issue view"*)
+        printf '{"title":"Test","body":"Issue body","labels":[],"comments":[{"author":{"login":"non-member"},"createdAt":"2026-01-01T00:00:00Z","body":"${SENTINEL_INJECTION}"}]}\n'
+        ;;
+    *"pr list"*)
+        printf '[]\n'
+        ;;
+    *)
+        printf '[]\n'
+        ;;
+esac
+STUB
+    chmod +x "$TEST_ENTRY_DIR/gh"
+
+    ORIG_PATH_ENTRY="$PATH"
+    export PATH="$TEST_ENTRY_DIR:$PATH"
+    export ORIG_PATH_ENTRY
+}
+
+teardown_entrypoint_stubs() {
+    export PATH="$ORIG_PATH_ENTRY"
+    rm -rf "$TEST_ENTRY_DIR"
+    unset TEST_ENTRY_DIR ORIG_PATH_ENTRY
+}
+
+# ============================================================================
+# TEST 14 — dry-run issue mode: injection sentinel absent, project body present
+# (AC1, AC2, AC6 — must fail against develop@HEAD, pass after this story)
+# ============================================================================
+test_14_dry_run_issue_mode_no_injection() {
+    setup_entrypoint_stubs
+
+    local output rc=0
+    output=$(CFGMS_PROJECT_ITEM_ID="pv2-test-item" \
+        CFGMS_TEST_PROJECT_QUEUE="$TEST_ENTRY_DIR/project-queue.sh" \
+        HOME="$TEST_ENTRY_DIR/home" \
+        bash "$SCRIPT_DIR/entrypoint.sh" 9999 --dry-run 2>&1) || rc=$?
+
+    if [[ "$rc" -ne 0 ]]; then
+        _fail "issue --dry-run exited $rc (expected 0)"
+        teardown_entrypoint_stubs
+        return
+    fi
+    assert_not_contains "$output" "$SENTINEL_INJECTION" \
+        "injection sentinel absent from issue-mode prompt"
+    assert_contains "$output" "$SENTINEL_PROJECT_BODY" \
+        "project item body present in issue-mode prompt"
+
+    teardown_entrypoint_stubs
+}
+
+# ============================================================================
+# TEST 15 — dry-run branch mode: injection sentinel absent, project body present
+# (AC1, AC3, AC6 — must fail against develop@HEAD, pass after this story)
+# ============================================================================
+test_15_dry_run_branch_mode_no_injection() {
+    setup_entrypoint_stubs
+
+    local output rc=0
+    output=$(CFGMS_PROJECT_ITEM_ID="pv2-test-item" \
+        CFGMS_TEST_PROJECT_QUEUE="$TEST_ENTRY_DIR/project-queue.sh" \
+        HOME="$TEST_ENTRY_DIR/home" \
+        bash "$SCRIPT_DIR/entrypoint.sh" --branch feature/story-9999-agent --dry-run 2>&1) || rc=$?
+
+    if [[ "$rc" -ne 0 ]]; then
+        _fail "branch --dry-run exited $rc (expected 0)"
+        teardown_entrypoint_stubs
+        return
+    fi
+    assert_not_contains "$output" "$SENTINEL_INJECTION" \
+        "injection sentinel absent from branch-mode prompt"
+    assert_contains "$output" "$SENTINEL_PROJECT_BODY" \
+        "project item body present in branch-mode prompt"
+
+    teardown_entrypoint_stubs
+}
+
+# ============================================================================
+# TEST 16 — hard refusal: CFGMS_PROJECT_ITEM_ID unset → exit non-zero
+# (AC5 — must fail against develop@HEAD, pass after this story)
+# ============================================================================
+test_16_hard_refusal_missing_project_item_id() {
+    setup_entrypoint_stubs
+
+    local output rc=0
+    output=$(HOME="$TEST_ENTRY_DIR/home" \
+        bash "$SCRIPT_DIR/entrypoint.sh" 9999 --dry-run 2>&1) || rc=$?
+
+    if [[ "$rc" -eq 0 ]]; then
+        _fail "entrypoint should exit non-zero when CFGMS_PROJECT_ITEM_ID is unset (got exit 0)"
+        teardown_entrypoint_stubs
+        return
+    fi
+    assert_contains "$output" "CFGMS_PROJECT_ITEM_ID" \
+        "error message names the required env var"
+    echo "    ✓ entrypoint exited $rc (non-zero) with correct message"
+
+    teardown_entrypoint_stubs
+}
+
+# ============================================================================
 # runner
 # ============================================================================
 
@@ -421,6 +562,9 @@ run_test "T10 — linked issue section" test_10_linked_issue_section
 run_test "T11 — empty inputs produce sentinels" test_11_empty_inputs
 run_test "T12 — no-op body shape" test_12_no_op_comment_body_shape
 run_test "T13 — review-level comments render" test_13_review_level_comments_render
+run_test "T14 — dry-run issue mode: no injection, project body present" test_14_dry_run_issue_mode_no_injection
+run_test "T15 — dry-run branch mode: no injection, project body present" test_15_dry_run_branch_mode_no_injection
+run_test "T16 — hard refusal when CFGMS_PROJECT_ITEM_ID unset" test_16_hard_refusal_missing_project_item_id
 
 echo ""
 echo "============================================================"


### PR DESCRIPTION
## Summary

- Removes both `ac_render_issue_comments` call sites from `compose_issue_prompt()` and `compose_branch_prompt()` — public issue comments are no longer rendered into the agent prompt
- Routes story content through `project-queue.sh get-item $CFGMS_PROJECT_ITEM_ID` (Projects V2) for both issue and branch dispatch modes — only project-owner-controlled content is included
- Adds hard refusal: if `CFGMS_PROJECT_ITEM_ID` is unset in issue/branch mode, entrypoint exits non-zero with `"CFGMS_PROJECT_ITEM_ID must be set — no fallback to gh issue view"`
- Updates `po-act.sh dispatch` to fetch `item_id` before container launch and pass `CFGMS_PROJECT_ITEM_ID` via `docker run -e` (agent-dispatch.sh not modified, avoiding file conflict with Story 7)
- Adds `--dry-run` tests T14/T15/T16: sentinel string from non-member comment absent in both issue and branch mode prompts; project item body present; hard refusal fires when var unset

## Specialist Review Results

- **QA Test Runner**: PASS — 16/16 entrypoint tests pass; `make test-agent-complete` all gates green
- **QA Code Reviewer**: PASS — 0 blocking issues; notes: project-queue fetch failure path and po-act.sh LAUNCH_FAILED path lack dedicated tests (consistent with existing codebase)
- **Security Engineer**: PASS — injection surface confirmed closed; hard refusal correctly gated; CFGMS_PROJECT_ITEM_ID passthrough is injection-safe (quoted expansion, no eval, GraphQL node IDs from controller-controlled source)

## Test Plan

- [x] `bash .devcontainer/entrypoint_test.sh` → 16/16 pass (T14/T15/T16 are the new required tests)
- [x] T14: dry-run issue mode — SENTINEL_INJECTION absent, PROJECT_BODY present
- [x] T15: dry-run branch mode — same sentinel/body assertions
- [x] T16: missing CFGMS_PROJECT_ITEM_ID → exit 1 with correct message
- [x] `make test-agent-complete` → all gates pass

Fixes #1480

🤖 Generated with [Claude Code](https://claude.com/claude-code)