### PR TITLE
pipeline-security: PR project field + project-queue.sh set-pr (Issue #1492)

### DIFF
--- a/.claude/pipeline.yaml
+++ b/.claude/pipeline.yaml
@@ -8,3 +8,4 @@ status_option_Fix: 7db9c63a
 status_option_Failed: ea575c87
 status_option_Blocked: dafc0ad2
 status_option_Done: cd154748
+pr_field_id: PVTF_lADOCrV4cc4BX5ezzhTMjEg

--- a/scripts/project-queue.sh
+++ b/scripts/project-queue.sh
@@ -23,6 +23,7 @@ Subcommands:
   update-field <item_id> <field> <value>          Update a field value
   add-issue <issue_num>                            Add a GitHub issue to the project
   add-pr <pr_num>                                 Add a GitHub PR to the project
+  set-pr <item_id> <pr_num>                       Record PR number against a project item
   delete-item <item_id>                           Remove an item from the project
 EOF
     exit 2
@@ -605,6 +606,62 @@ print(json.dumps({
 PYEOF
 }
 
+cmd_set_pr() {
+    [[ $# -ge 2 ]] || {
+        printf 'Usage: %s set-pr <item_id> <pr_num>\n' "$0" >&2
+        exit 2
+    }
+    local item_id="$1" pr_num="$2"
+    _require_yaml
+
+    local project_id pr_field_id
+    project_id=$(_yaml_get project_id)
+    pr_field_id=$(_yaml_get pr_field_id)
+
+    GQ_PROJECT_ID="$project_id" GQ_ITEM_ID="$item_id" \
+    GQ_FIELD_ID="$pr_field_id" GQ_PR_NUM="$pr_num" python3 - <<'PYEOF'
+import json, os, subprocess, sys
+
+
+def graphql(payload):
+    r = subprocess.run(
+        ['gh', 'api', 'graphql', '--input', '-'],
+        input=json.dumps(payload).encode(),
+        capture_output=True
+    )
+    if r.returncode != 0:
+        print(r.stderr.decode().strip(), file=sys.stderr)
+        sys.exit(1)
+    resp = json.loads(r.stdout)
+    if resp.get('errors'):
+        for e in resp['errors']:
+            print(e.get('message', str(e)), file=sys.stderr)
+        sys.exit(1)
+    return resp['data']
+
+
+project_id = os.environ['GQ_PROJECT_ID']
+item_id = os.environ['GQ_ITEM_ID']
+field_id = os.environ['GQ_FIELD_ID']
+pr_num = os.environ['GQ_PR_NUM']
+
+graphql({
+    'query': (
+        'mutation($p:ID!,$i:ID!,$f:ID!,$v:String!){'
+        'updateProjectV2ItemFieldValue(input:{projectId:$p,itemId:$i,fieldId:$f,'
+        'value:{text:$v}}){projectV2Item{id}}}'
+    ),
+    'variables': {'p': project_id, 'i': item_id, 'f': field_id, 'v': pr_num}
+})
+
+print(json.dumps({
+    'updated': True,
+    'item_id': item_id,
+    'pr': pr_num
+}))
+PYEOF
+}
+
 cmd_delete_item() {
     [[ $# -ge 1 ]] || {
         printf 'Usage: %s delete-item <item_id>\n' "$0" >&2
@@ -667,6 +724,7 @@ case "$subcommand" in
     update-field)   cmd_update_field "$@" ;;
     add-issue)      cmd_add_issue "$@" ;;
     add-pr)         cmd_add_pr "$@" ;;
+    set-pr)         cmd_set_pr "$@" ;;
     delete-item)    cmd_delete_item "$@" ;;
     *)
         printf 'Error: unknown subcommand: %s\n' "$subcommand" >&2

--- a/scripts/refresh-pipeline-fields.sh
+++ b/scripts/refresh-pipeline-fields.sh
@@ -25,6 +25,7 @@ query($login: String!, $number: Int!) {
           ... on ProjectV2Field {
             id
             name
+            dataType
           }
           ... on ProjectV2SingleSelectField {
             id
@@ -80,6 +81,15 @@ lines = [
 for name in required_options:
     key = 'status_option_' + name.replace(' ', '_')
     lines.append(f"{key}: {option_map[name]}")
+
+# Capture all ProjectV2Field nodes (text/number/date fields — identified by dataType key)
+text_field_nodes = sorted(
+    [n for n in nodes if n and n.get('dataType') is not None and 'options' not in n],
+    key=lambda n: n['name']
+)
+for tf in text_field_nodes:
+    key = tf['name'].lower().replace(' ', '_') + '_field_id'
+    lines.append(f"{key}: {tf['id']}")
 
 content = '\n'.join(lines) + '\n'
 with open(out_file, 'w') as f:

--- a/scripts/test-scripts.sh
+++ b/scripts/test-scripts.sh
@@ -782,6 +782,22 @@ test_project_queue_invalid_args() {
     else
         log_fail "project-queue.sh: delete-item with missing args should exit 2, got $exit_code"
     fi
+
+    exit_code=0
+    bash "$script" set-pr 2>/dev/null || exit_code=$?
+    if [[ $exit_code -eq 2 ]]; then
+        log_pass "project-queue.sh: set-pr with no args exits 2"
+    else
+        log_fail "project-queue.sh: set-pr with no args should exit 2, got $exit_code"
+    fi
+
+    exit_code=0
+    bash "$script" set-pr "ITEM_ID_ONLY" 2>/dev/null || exit_code=$?
+    if [[ $exit_code -eq 2 ]]; then
+        log_pass "project-queue.sh: set-pr with one arg exits 2"
+    else
+        log_fail "project-queue.sh: set-pr with one arg should exit 2, got $exit_code"
+    fi
 }
 
 test_project_queue_integration() {
@@ -1098,6 +1114,106 @@ print(d.get('deleted_item_id', ''))
     fi
 }
 
+test_project_queue_set_pr() {
+    log_test "Testing project-queue.sh: set-pr integration against live cfgms-pipeline project..."
+
+    local script
+    script="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/project-queue.sh"
+
+    if [[ ! -f "$script" ]]; then
+        log_skip "project-queue.sh set-pr: Script not found"
+        return
+    fi
+
+    # Skip if gh is not available or not authenticated
+    if ! command -v gh >/dev/null 2>&1; then
+        log_skip "project-queue.sh set-pr integration: gh CLI not available"
+        return
+    fi
+    if ! gh auth status >/dev/null 2>&1; then
+        log_skip "project-queue.sh set-pr integration: gh not authenticated — skipping live tests"
+        return
+    fi
+
+    local tmp_dir
+    tmp_dir=$(mktemp -d)
+
+    local created_item_id=""
+    cleanup_set_pr() {
+        if [[ -n "$created_item_id" ]]; then
+            bash "$script" delete-item "$created_item_id" >/dev/null 2>&1 || true
+        fi
+        rm -rf "$tmp_dir"
+    }
+    trap cleanup_set_pr RETURN
+
+    echo "Integration test body for set-pr test." > "$tmp_dir/body.md"
+
+    # Create a draft item
+    local create_out exit_code=0
+    create_out=$(bash "$script" create-draft 0 "set-pr integration test" "$tmp_dir/body.md" 2>&1) || exit_code=$?
+
+    if [[ $exit_code -ne 0 ]]; then
+        log_fail "project-queue.sh set-pr: create-draft failed (exit $exit_code): $create_out"
+        return
+    fi
+
+    created_item_id=$(echo "$create_out" | python3 -c "import json,sys; print(json.load(sys.stdin)['item_id'])" 2>/dev/null) || {
+        log_fail "project-queue.sh set-pr: create-draft output not valid JSON: $create_out"
+        return
+    }
+
+    if [[ -z "$created_item_id" ]]; then
+        log_fail "project-queue.sh set-pr: create-draft returned empty item_id"
+        return
+    fi
+
+    # Call set-pr with PR number 9999
+    local set_pr_out
+    exit_code=0
+    set_pr_out=$(bash "$script" set-pr "$created_item_id" "9999" 2>&1) || exit_code=$?
+
+    if [[ $exit_code -ne 0 ]]; then
+        log_fail "project-queue.sh set-pr: failed (exit $exit_code): $set_pr_out"
+        return
+    fi
+
+    local set_pr_ok
+    set_pr_ok=$(echo "$set_pr_out" | python3 -c "
+import json,sys
+d=json.load(sys.stdin)
+print('yes' if d.get('updated') == True else 'no')
+" 2>/dev/null) || set_pr_ok="parse-error"
+
+    if [[ "$set_pr_ok" == "yes" ]]; then
+        log_pass "project-queue.sh set-pr: returns updated=true JSON"
+    else
+        log_fail "project-queue.sh set-pr: unexpected output: $set_pr_out"
+    fi
+
+    # Verify via get-item that .fields.PR == "9999"
+    local get_out pr_field
+    exit_code=0
+    get_out=$(bash "$script" get-item "$created_item_id" 2>&1) || exit_code=$?
+
+    if [[ $exit_code -ne 0 ]]; then
+        log_fail "project-queue.sh set-pr: get-item failed (exit $exit_code): $get_out"
+        return
+    fi
+
+    pr_field=$(echo "$get_out" | python3 -c "
+import json,sys
+d=json.load(sys.stdin)
+print(d.get('fields',{}).get('PR',''))
+" 2>/dev/null) || pr_field=""
+
+    if [[ "$pr_field" == "9999" ]]; then
+        log_pass "project-queue.sh set-pr: get-item fields.PR == '9999' (round-trip verified)"
+    else
+        log_fail "project-queue.sh set-pr: get-item fields.PR='$pr_field' (expected '9999')"
+    fi
+}
+
 test_trust_boundary() {
     log_test "Running trust boundary regression suite (test/security/trust_boundary_test.sh)..."
 
@@ -1237,6 +1353,8 @@ echo ""
 test_project_queue_invalid_args
 echo ""
 test_project_queue_integration
+echo ""
+test_project_queue_set_pr
 echo ""
 test_preflight_forged_acceptance_review
 echo ""


### PR DESCRIPTION
## Summary

- Added `set-pr <item_id> <pr_num>` subcommand to `scripts/project-queue.sh` that writes a PR number to the item's `PR` text field using the cached `pr_field_id` from `pipeline.yaml`
- Extended `scripts/refresh-pipeline-fields.sh` to capture all `ProjectV2Field` nodes (text/number/date) and emit `<snake_case>_field_id` entries — making the pattern generalize beyond just `pr_field_id`
- Added `pr_field_id: PVTF_lADOCrV4cc4BX5ezzhTMjEg` to `.claude/pipeline.yaml` (PR text field was pre-created manually on the project by the PO)
- Added `test_project_queue_set_pr` integration test (create-draft → set-pr → get-item round-trip asserting `.fields.PR == "9999"`) and `set-pr` argument validation tests to `scripts/test-scripts.sh`

Fixes #1492

## Specialist Review Results

**QA Test Runner**: PASS — 98/98 script tests passed, all Go unit/integration tests pass, cross-platform compilation clean, secret scan clean, architecture check clean. Integration round-trip (`set-pr` → `get-item`) confirmed live against the GitHub Project.

**QA Code Reviewer**: PASS — skip-if-no-auth guard present, cleanup-on-exit via `trap`, arg validation exits 2 for 0 and 1 args, both cases registered in `test_project_queue_invalid_args`, error paths covered. No mocks, no skips without justification, no hacky workarounds.

**Security Engineer**: PASS — `pr_num` flows via env-var → `os.environ` → JSON GraphQL variable (no interpolation, no `shell=True`), field IDs read from yaml (not CLI), no hardcoded credentials, single-quoted PYEOF heredoc prevents shell expansion. Two low-severity non-blocking suggestions (numeric validation for `pr_num`, YAML key character validation in refresh script) — neither is a security blocker.

## Test Plan

- [ ] `make test-agent-complete` — all passing (verified pre-PR)
- [ ] Integration test `test_project_queue_set_pr` — verified live against cfgms-pipeline project
- [ ] Argument validation: `set-pr` with 0 and 1 args exits 2
- [ ] `_usage()` lists `set-pr <item_id> <pr_num>`
- [ ] `pipeline.yaml` contains `pr_field_id: PVTF_lADOCrV4cc4BX5ezzhTMjEg`
- [ ] Running `refresh-pipeline-fields.sh` is idempotent (regenerates same output)

🤖 Generated with [Claude Code](https://claude.com/claude-code)