### PR TITLE
pipeline-security: preflight item_id dispatch + po-act backward-compat + Done-on-merge (Issue #1493)

### DIFF
--- a/.claude/scripts/agent-dispatch.sh
+++ b/.claude/scripts/agent-dispatch.sh
@@ -95,6 +95,7 @@ Commands:
   check-conflicts <NUM> [NUM...]            Check for existing containers/clones (issue mode)
   check-conflicts --branch <NAME>           Check for existing containers/clones (branch mode)
   check-conflicts --pr <NUM>                Check for existing containers/clones (PR-fix mode)
+  create-clone-item <ITEM_ID>               Clone repo and create feature/item-<LAST12>-agent branch
   create-clone    <NUM> [--keep-remote] [--allow-duplicate-pr]
                                             Clone repo and create feature branch (issue mode)
                                             If remote branch feature/story-<NUM>-agent already exists,
@@ -240,6 +241,26 @@ case "$cmd" in
     git checkout -b "$branch_name"
     trap - ERR
     echo "CLONE_OK:${num}:$(git branch --show-current)"
+    ;;
+
+  create-clone-item)
+    [[ $# -eq 1 ]] || { echo "create-clone-item requires exactly one item_id"; exit 1; }
+    item_id="$1"
+    # Derive LAST12: last 12 alphanumeric chars of item_id (strip non-[a-zA-Z0-9])
+    LAST12=$(echo "$item_id" | tr -cd 'a-zA-Z0-9' | rev | cut -c1-12 | rev)
+    [[ -n "$LAST12" ]] || { echo "ERROR: item_id '${item_id}' has no alphanumeric chars — cannot derive LAST12"; exit 1; }
+    branch_name="feature/item-${LAST12}-agent"
+    dest="${WORKTREE_BASE}/item-${LAST12}"
+    github_url=$(git -C "$REPO_ROOT" remote get-url origin)
+
+    trap "rm -rf '$dest'" ERR
+    git clone --local --branch develop "$REPO_ROOT" "$dest"
+    cd "$dest"
+    git remote set-url origin "$github_url"
+    sync_to_remote_develop
+    git checkout -b "$branch_name"
+    trap - ERR
+    echo "CLONE_OK:item-${LAST12}:$(git branch --show-current)"
     ;;
 
   create-clone-branch)

--- a/.claude/scripts/po-act.sh
+++ b/.claude/scripts/po-act.sh
@@ -45,26 +45,42 @@ shift || true
 
 case "$cmd" in
   dispatch)
-    story="${1:?story number required}"
-    "$DISPATCH" check-conflicts "$story" >/dev/null
-    "$DISPATCH" create-clone "$story" | tail -1
-
-    # Fetch item_id BEFORE launch so CFGMS_PROJECT_ITEM_ID can be passed to the
-    # container. The entrypoint refuses to run without this var — hard fail here
-    # if the story is not in the project queue at Ready status.
+    arg="${1:?story number or item_id required}"
     PROJECT_QUEUE="$(cd "$(dirname "$0")/../.." && pwd)/scripts/project-queue.sh"
-    item_id=$(bash "$PROJECT_QUEUE" list-by-status Ready 2>/dev/null \
-      | jq -r --argjson num "$story" '.[] | select(.issue_num == $num) | .item_id' \
-      2>/dev/null || true)
-    if [ -z "${item_id:-}" ]; then
-      echo "ERROR: story #${story} not found in project queue with Ready status" >&2
-      exit 1
+
+    if [[ "$arg" =~ ^[0-9]+$ ]]; then
+      # Issue number path: existing create-clone flow
+      story="$arg"
+      "$DISPATCH" check-conflicts "$story" >/dev/null
+      "$DISPATCH" create-clone "$story" | tail -1
+
+      # Fetch item_id BEFORE launch so CFGMS_PROJECT_ITEM_ID can be passed to the
+      # container. The entrypoint refuses to run without this var.
+      item_id=$(bash "$PROJECT_QUEUE" list-by-status Ready 2>/dev/null \
+        | jq -r --argjson num "$story" '.[] | select(.issue_num == $num) | .item_id' \
+        2>/dev/null || true)
+      if [ -z "${item_id:-}" ]; then
+        echo "ERROR: story #${story} not found in project queue with Ready status" >&2
+        exit 1
+      fi
+
+      clone_path="${WORKTREE_BASE}/story-${story}"
+      container_name="cfg-agent-${story}"
+      first_arg="${story}"
+    else
+      # Item ID path (non-numeric, e.g., PVTI_-prefixed pure draft items)
+      item_id="$arg"
+      LAST12=$(echo "$item_id" | tr -cd 'a-zA-Z0-9' | rev | cut -c1-12 | rev)
+      "$DISPATCH" create-clone-item "$item_id" | tail -1
+
+      clone_path="${WORKTREE_BASE}/item-${LAST12}"
+      container_name="cfg-agent-item-${LAST12}"
+      first_arg="${item_id}"
     fi
 
     # Launch with CFGMS_PROJECT_ITEM_ID so entrypoint sources content from Projects V2.
     # Inlined from agent-dispatch.sh launch to pass the extra env var without editing
-    # that file (avoids a file conflict with the parallel Story 7 branch).
-    clone_path="${WORKTREE_BASE}/story-${story}"
+    # that file.
     real_path=$(realpath "$clone_path")
     # Refresh credentials from host session (mirrors refresh_creds_from_host in agent-dispatch.sh).
     host_creds="$HOME/.claude/.credentials.json"
@@ -77,9 +93,9 @@ case "$cmd" in
     fi
     gh_token=$(gh auth token)
     if container_id=$(docker run -d \
-      --name "cfg-agent-${story}" \
+      --name "$container_name" \
       --label "cfg-agent=true" \
-      --label "issue=${story}" \
+      --label "issue=${story:-}" \
       --label "mode=issue" \
       --memory=4g \
       --cpus=4 \
@@ -92,17 +108,17 @@ case "$cmd" in
       -e "CFGMS_PROJECT_ITEM_ID=${item_id}" \
       --cap-add NET_ADMIN \
       cfg-agent:latest \
-      "${story}" 2>&1); then
-      echo "LAUNCHED:${story}:${container_id}"
+      "${first_arg}" 2>&1); then
+      echo "LAUNCHED:${first_arg}:${container_id}"
     else
-      echo "LAUNCH_FAILED:${story}:${container_id}"
+      echo "LAUNCH_FAILED:${first_arg}:${container_id}"
       rm -rf "$clone_path"
       echo "CLEANED:clone:${clone_path}"
       exit 1
     fi
 
     bash "$PROJECT_QUEUE" update-field "$item_id" status "In Progress" >/dev/null 2>&1 || true
-    echo "DISPATCHED:$story"
+    echo "DISPATCHED:${first_arg}"
     ;;
 
   dispatch-fix)
@@ -130,7 +146,7 @@ case "$cmd" in
     story="${2:-}"
     # If a story is provided, ensure the PR body contains a GitHub auto-close
     # keyword for that issue. Dev agents miss this ~85% of the time, leaving
-    # orphan agent:success issues after the PR merges. Patching here is cheap
+    # orphan issues that stay open after the PR merges. Patching here is cheap
     # (a body edit doesn't trigger CI) and runs at the last gate before the
     # merge queue, so it's the right choke point.
     if [ -n "$story" ]; then

--- a/.claude/scripts/po-cycle-preflight.py
+++ b/.claude/scripts/po-cycle-preflight.py
@@ -46,7 +46,7 @@ BARE_PATH_RE = re.compile(
     r"(?:^|[\s(\[])"
     r"([a-zA-Z0-9_./-]+/[a-zA-Z0-9_./-]+\.(?:go|md|proto|sh|yaml|yml|json|toml|ts|tsx))"
 )
-BRANCH_STORY_RE = re.compile(r"feature/story-(\d+)")
+BRANCH_STORY_RE = re.compile(r"feature/(?:story-(\d+)|item-([a-zA-Z0-9]+)-agent)")
 
 
 def cache_dir():
@@ -118,7 +118,7 @@ def gh_pr_list_story_prs():
     return gh(
         "pr", "list",
         "--repo", REPO,
-        "--search", "head:feature/story-",
+        "--search", "head:feature/",
         "--state", "open",
         "--json", "number,title,body,isDraft,headRefName,labels,comments,statusCheckRollup,mergeStateStatus,mergeable,autoMergeRequest",
         "--limit", "50",
@@ -172,11 +172,23 @@ def is_trusted_review_comment(comment):
     )
 
 
+def _pq_script_path():
+    """Return the project-queue.sh path, honoring CFGMS_TEST_PROJECT_QUEUE override."""
+    override = os.environ.get("CFGMS_TEST_PROJECT_QUEUE")
+    if override:
+        return override
+    return str(Path(__file__).resolve().parent.parent.parent / "scripts" / "project-queue.sh")
+
+
 def project_queue_list_by_status(status):
-    """Call project-queue.sh list-by-status; return [{number, title}] matching gh_issue_list format."""
-    script = Path(__file__).resolve().parent.parent.parent / "scripts" / "project-queue.sh"
+    """Call project-queue.sh list-by-status; return [{number, title, item_id}].
+
+    Pure draft items (issue_num == None) are included with number: null.
+    Honors CFGMS_TEST_PROJECT_QUEUE env var for hermetic tests.
+    """
+    script = _pq_script_path()
     result = subprocess.run(
-        ["bash", str(script), "list-by-status", status],
+        ["bash", script, "list-by-status", status],
         capture_output=True, text=True, check=False, timeout=60,
     )
     if result.returncode != 0:
@@ -188,10 +200,90 @@ def project_queue_list_by_status(status):
         return []
     items = json.loads(result.stdout)
     return [
-        {"number": item["issue_num"], "title": item.get("title", "")}
+        {
+            "number": item.get("issue_num"),
+            "title": item.get("title", ""),
+            "item_id": item.get("item_id", ""),
+        }
         for item in items
-        if item.get("issue_num") is not None
     ]
+
+
+def auto_close_merged_items(degraded_reasons=None):
+    """Scan In Progress items and mark Done if their linked PR has been merged.
+
+    Non-fatal: all subprocess failures are caught and appended to degraded_reasons.
+    Returns the count of items closed.
+    """
+    if degraded_reasons is None:
+        degraded_reasons = []
+    count = 0
+    script = _pq_script_path()
+
+    result = subprocess.run(
+        ["bash", script, "list-by-status", "In Progress"],
+        capture_output=True, text=True, check=False, timeout=60,
+    )
+    if result.returncode != 0:
+        degraded_reasons.append(
+            f"auto_close_merged_items: list-by-status failed: {result.stderr.strip()[:200]}"
+        )
+        return count
+
+    if not result.stdout.strip():
+        return count
+
+    try:
+        items = json.loads(result.stdout)
+    except json.JSONDecodeError:
+        degraded_reasons.append("auto_close_merged_items: list-by-status returned invalid JSON")
+        return count
+
+    for item in items:
+        item_id = item.get("item_id")
+        if not item_id:
+            continue
+        try:
+            get_result = subprocess.run(
+                ["bash", script, "get-item", item_id],
+                capture_output=True, text=True, check=False, timeout=60,
+            )
+            if get_result.returncode != 0:
+                degraded_reasons.append(
+                    f"auto_close_merged_items: get-item {item_id} failed: {get_result.stderr.strip()[:100]}"
+                )
+                continue
+            item_data = json.loads(get_result.stdout)
+            pr_num = (item_data.get("fields") or {}).get("PR")
+            if not pr_num:
+                continue
+            pr_result = subprocess.run(
+                ["gh", "pr", "view", str(pr_num), "--json", "state", "--jq", ".state"],
+                capture_output=True, text=True, check=False, timeout=60,
+            )
+            if pr_result.returncode != 0:
+                degraded_reasons.append(
+                    f"auto_close_merged_items: gh pr view {pr_num} failed: {pr_result.stderr.strip()[:100]}"
+                )
+                continue
+            state = pr_result.stdout.strip().strip('"')
+            if state != "MERGED":
+                continue
+            update_result = subprocess.run(
+                ["bash", script, "update-field", item_id, "status", "Done"],
+                capture_output=True, text=True, check=False, timeout=60,
+            )
+            if update_result.returncode != 0:
+                degraded_reasons.append(
+                    f"auto_close_merged_items: update-field {item_id} status Done failed: {update_result.stderr.strip()[:100]}"
+                )
+                continue
+            count += 1
+        except Exception as e:
+            degraded_reasons.append(f"auto_close_merged_items: error processing {item_id}: {e}")
+            continue
+
+    return count
 
 
 def running_containers():
@@ -360,7 +452,7 @@ def parse_story(issue):
     so the LLM can override if parsing missed something.
     """
     body = issue.get("body") or ""
-    number = issue["number"]
+    number = issue.get("number")  # may be None for pure draft items
     warnings = []
 
     deps_raw = extract_section(body, "Dependencies")
@@ -373,7 +465,7 @@ def parse_story(issue):
         pass
     else:
         deps_parsed = sorted(
-            {int(n) for n in ISSUE_NUM_RE.findall(deps_raw) if int(n) != number}
+            {int(n) for n in ISSUE_NUM_RE.findall(deps_raw) if number is None or int(n) != number}
         )
         if not deps_parsed:
             warnings.append("'## Dependencies' section had content but no #NNN references found")
@@ -388,7 +480,7 @@ def parse_story(issue):
         if not files_parsed:
             warnings.append("'## Files In Scope' section had content but no file paths detected")
 
-    all_nums = sorted({int(n) for n in ISSUE_NUM_RE.findall(body) if int(n) != number})
+    all_nums = sorted({int(n) for n in ISSUE_NUM_RE.findall(body) if number is None or int(n) != number})
     all_paths = sorted(set(BACKTICK_PATH_RE.findall(body)) | set(BARE_PATH_RE.findall(body)))
 
     return {
@@ -449,7 +541,7 @@ def ci_summary(checks):
 def compute_dispatch_recommendations(ready_stories, active_stories, dep_states):
     """Greedy conflict-free selection.
 
-    Order: ascending story number (stable, predictable).
+    Order: ascending story number (stable, predictable); pure drafts (number=None) last.
     Skip if any dep is not CLOSED.
     Skip if files overlap with an active story (status In Progress or open PR) or a
     story already picked this cycle.
@@ -461,8 +553,9 @@ def compute_dispatch_recommendations(ready_stories, active_stories, dep_states):
     recommendations = []
     picked_file_sets = []
 
-    for s in sorted(ready_stories, key=lambda x: x["number"]):
+    for s in sorted(ready_stories, key=lambda x: (x.get("number") is None, x.get("number") or 0)):
         num = s["number"]
+        item_id = s.get("item_id", "")
         open_deps = [d for d in s["deps_parsed"] if dep_states.get(d) != "CLOSED"]
         if open_deps:
             dep_desc = ", ".join(
@@ -470,6 +563,7 @@ def compute_dispatch_recommendations(ready_stories, active_stories, dep_states):
             )
             recommendations.append({
                 "number": num,
+                "item_id": item_id,
                 "action": "hold",
                 "reason": f"deps not closed: {dep_desc}",
             })
@@ -479,6 +573,7 @@ def compute_dispatch_recommendations(ready_stories, active_stories, dep_states):
         if not my_files:
             recommendations.append({
                 "number": num,
+                "item_id": item_id,
                 "action": "dispatch",
                 "reason": "deps clear; no files parsed from Files In Scope",
                 "caveat": "no_files_parsed_cannot_check_conflicts — LLM should verify manually",
@@ -494,6 +589,7 @@ def compute_dispatch_recommendations(ready_stories, active_stories, dep_states):
             n, shared = active_hit
             recommendations.append({
                 "number": num,
+                "item_id": item_id,
                 "action": "hold",
                 "reason": f"file-conflict with active #{n} (in-progress or open PR) on: {', '.join(sorted(shared))}",
             })
@@ -507,6 +603,7 @@ def compute_dispatch_recommendations(ready_stories, active_stories, dep_states):
             n, shared = picked_hit
             recommendations.append({
                 "number": num,
+                "item_id": item_id,
                 "action": "hold",
                 "reason": f"file-conflict with dispatch-candidate #{n} on: {', '.join(sorted(shared))}",
             })
@@ -514,6 +611,7 @@ def compute_dispatch_recommendations(ready_stories, active_stories, dep_states):
 
         recommendations.append({
             "number": num,
+            "item_id": item_id,
             "action": "dispatch",
             "reason": "deps clear; no file overlap with in-progress or dispatch set",
         })
@@ -847,6 +945,9 @@ def main():
                 "checks": {},
             }
 
+    # Auto-close project items whose linked PRs have been merged (done-on-merge).
+    done_on_merge_count = auto_close_merged_items(degraded_reasons)
+
     out["pipeline_state"] = {
         "drafts": draft_issues,
         "ready": ready_issues,
@@ -858,6 +959,7 @@ def main():
     out["running_containers"] = containers
     out["merge_queue"] = merge_queue
     out["code_health"] = code_health
+    out["done_on_merge_count"] = done_on_merge_count
     if not code_health.get("ok"):
         if code_health.get("skipped"):
             degraded_reasons.append(
@@ -894,12 +996,36 @@ def main():
     # Phase 2: parallel fetch of story bodies relevant to conflict detection.
     # Conflict-detection set = agent:in-progress + stories with open PRs (files in flight
     # until merge). Ready stories are always fetched for gating.
-    ready_nums = [s["number"] for s in ready_issues]
-    in_progress_nums = [s["number"] for s in in_progress_issues]
+    # Issue-linked items use gh_issue_body; pure draft items use project-queue.sh get-item.
+
+    # Separate issue-linked items from pure draft items for each queue bucket.
+    ready_item_id_by_num = {}
+    ready_draft_items = []
+    for item in ready_issues:
+        n = item.get("number")
+        iid = item.get("item_id", "")
+        if n is not None:
+            ready_item_id_by_num[n] = iid
+        elif iid:
+            ready_draft_items.append(item)
+
+    in_progress_item_id_by_num = {}
+    in_progress_draft_items = []
+    for item in in_progress_issues:
+        n = item.get("number")
+        iid = item.get("item_id", "")
+        if n is not None:
+            in_progress_item_id_by_num[n] = iid
+        elif iid:
+            in_progress_draft_items.append(item)
+
+    ready_nums = list(ready_item_id_by_num.keys())
+    in_progress_nums = list(in_progress_item_id_by_num.keys())
+
     pr_story_nums = []
     for pr in prs:
         m = BRANCH_STORY_RE.match(pr.get("headRefName", ""))
-        if m:
+        if m and m.group(1) and m.group(1).isdigit():
             pr_story_nums.append(int(m.group(1)))
     active_story_nums = sorted(set(in_progress_nums + pr_story_nums))
     all_story_nums = sorted(set(ready_nums + active_story_nums))
@@ -915,15 +1041,77 @@ def main():
                 except Exception as e:
                     degraded_reasons.append(f"gh issue view #{n} failed: {e}")
 
-    ready_parsed = [
-        parse_story(story_bodies[n]) for n in ready_nums if n in story_bodies
-    ]
-    in_progress_parsed = [
-        parse_story(story_bodies[n]) for n in in_progress_nums if n in story_bodies
-    ]
-    active_parsed = [
-        parse_story(story_bodies[n]) for n in active_story_nums if n in story_bodies
-    ]
+    # Fetch bodies for pure draft items via project-queue.sh get-item.
+    _pq = _pq_script_path()
+
+    def _fetch_draft_body(item):
+        try:
+            res = subprocess.run(
+                ["bash", _pq, "get-item", item["item_id"]],
+                capture_output=True, text=True, check=False, timeout=60,
+            )
+            if res.returncode != 0:
+                return item["item_id"], None
+            data = json.loads(res.stdout)
+            return item["item_id"], {
+                "number": None,
+                "title": item.get("title", ""),
+                "body": data.get("body", ""),
+                "state": "OPEN",
+                "labels": [],
+            }
+        except Exception:
+            return item["item_id"], None
+
+    draft_bodies = {}
+    all_draft_items = ready_draft_items + in_progress_draft_items
+    if all_draft_items:
+        with ThreadPoolExecutor(max_workers=5) as ex:
+            futures = {ex.submit(_fetch_draft_body, itm): itm for itm in all_draft_items}
+            for fut in as_completed(futures):
+                itm = futures[fut]
+                try:
+                    item_id, body_data = fut.result()
+                    if body_data is not None:
+                        draft_bodies[item_id] = body_data
+                    else:
+                        degraded_reasons.append(f"get-item {itm['item_id']} failed for draft body")
+                except Exception as e:
+                    degraded_reasons.append(f"draft body fetch failed for {itm.get('item_id')}: {e}")
+
+    # Build parsed story lists with item_id attached.
+    ready_parsed = []
+    for n in ready_nums:
+        if n in story_bodies:
+            parsed = parse_story(story_bodies[n])
+            parsed["item_id"] = ready_item_id_by_num.get(n, "")
+            ready_parsed.append(parsed)
+    for item in ready_draft_items:
+        iid = item["item_id"]
+        if iid in draft_bodies:
+            parsed = parse_story(draft_bodies[iid])
+            parsed["item_id"] = iid
+            ready_parsed.append(parsed)
+
+    in_progress_parsed = []
+    for n in in_progress_nums:
+        if n in story_bodies:
+            parsed = parse_story(story_bodies[n])
+            parsed["item_id"] = in_progress_item_id_by_num.get(n, "")
+            in_progress_parsed.append(parsed)
+    for item in in_progress_draft_items:
+        iid = item["item_id"]
+        if iid in draft_bodies:
+            parsed = parse_story(draft_bodies[iid])
+            parsed["item_id"] = iid
+            in_progress_parsed.append(parsed)
+
+    active_parsed = list(in_progress_parsed)
+    for n in pr_story_nums:
+        if n in story_bodies and n not in in_progress_nums:
+            p = parse_story(story_bodies[n])
+            p["item_id"] = ""
+            active_parsed.append(p)
 
     # Phase 3: fetch states for every unique dep referenced across ready stories
     dep_nums = set()
@@ -954,7 +1142,7 @@ def main():
             "files_parsed": s["files_parsed"],
             "parse_warnings": s["parse_warnings"],
             "source": "status:In Progress" + (
-                " + open-pr" if s["number"] in pr_story_nums else ""
+                " + open-pr" if s.get("number") is not None and s["number"] in pr_story_nums else ""
             ),
         }
         for s in in_progress_parsed
@@ -967,7 +1155,7 @@ def main():
             "parse_warnings": s["parse_warnings"],
         }
         for s in active_parsed
-        if s["number"] in pr_story_nums and s["number"] not in in_progress_nums
+        if s.get("number") is not None and s["number"] in pr_story_nums and s["number"] not in in_progress_nums
     ]
 
     # Phase 4: PR summaries
@@ -975,7 +1163,10 @@ def main():
     for pr in prs:
         head = pr.get("headRefName", "")
         m = BRANCH_STORY_RE.match(head)
-        story_number = int(m.group(1)) if m else None
+        if m and m.group(1) and m.group(1).isdigit():
+            story_number = int(m.group(1))
+        else:
+            story_number = None
         comments = pr.get("comments") or []
         has_review_comment = any(is_trusted_review_comment(c) for c in comments)
         body = pr.get("body") or ""
@@ -1070,6 +1261,7 @@ def write_output(out, mode):
             ],
         },
         "dispatch_blocked": not code_health.get("ok", False) and not code_health.get("skipped", False),
+        "done_on_merge_count": out.get("done_on_merge_count", 0),
         "counts": {
             "ready": len(out.get("ready_stories", [])),
             "in_progress": len(out.get("in_progress_stories", [])),

--- a/scripts/test-scripts.sh
+++ b/scripts/test-scripts.sh
@@ -1236,6 +1236,259 @@ test_trust_boundary() {
     fi
 }
 
+test_preflight_item_dispatch() {
+    log_test "Testing po-cycle-preflight.py: project_queue_list_by_status includes pure draft items via CFGMS_TEST_PROJECT_QUEUE..."
+
+    local preflight_script
+    preflight_script="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/../.claude/scripts/po-cycle-preflight.py"
+
+    if [[ ! -f "$preflight_script" ]]; then
+        log_fail "po-cycle-preflight.py: not found at $preflight_script"
+        return
+    fi
+
+    local tmp_dir
+    tmp_dir=$(mktemp -d)
+    trap 'rm -rf "$tmp_dir"' RETURN
+
+    # Mock project-queue.sh: responds to list-by-status Ready with a pure draft item,
+    # all other subcommands return empty array.
+    local mock_pq="${tmp_dir}/project-queue.sh"
+    cat > "$mock_pq" << 'MOCKEOF'
+#!/usr/bin/env bash
+subcmd="${1:-}"
+status="${2:-}"
+if [[ "$subcmd" == "list-by-status" && "$status" == "Ready" ]]; then
+    printf '[{"item_id":"PVTI_test123456789012","issue_num":null,"title":"pure draft"}]\n'
+else
+    printf '[]\n'
+fi
+exit 0
+MOCKEOF
+    chmod +x "$mock_pq"
+
+    local tmp_py
+    tmp_py=$(mktemp --suffix=.py)
+    # Use importlib.util to load the hyphen-named file (matching existing test pattern).
+    cat > "$tmp_py" << PYEOF
+import sys, os, importlib.util
+os.environ['CFGMS_TEST_PROJECT_QUEUE'] = '${mock_pq}'
+spec = importlib.util.spec_from_file_location('preflight', '${preflight_script}')
+mod = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(mod)
+r = mod.project_queue_list_by_status('Ready')
+assert any(i.get('item_id') == 'PVTI_test123456789012' and i.get('number') is None for i in r), f'FAIL: {r}'
+print('PASS')
+PYEOF
+
+    local output exit_code=0
+    output=$(python3 "$tmp_py" 2>&1) || exit_code=$?
+    rm -f "$tmp_py"
+
+    if [[ $exit_code -eq 0 ]] && echo "$output" | grep -q "^PASS"; then
+        log_pass "preflight item dispatch: pure draft item_id preserved, number=null, included in results"
+    else
+        log_fail "preflight item dispatch: assertion failed (exit $exit_code): $output"
+    fi
+}
+
+test_done_on_merge() {
+    log_test "Testing po-cycle-preflight.py: auto_close_merged_items marks Done when PR is MERGED..."
+
+    local preflight_script
+    preflight_script="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/../.claude/scripts/po-cycle-preflight.py"
+
+    if [[ ! -f "$preflight_script" ]]; then
+        log_fail "po-cycle-preflight.py: not found at $preflight_script"
+        return
+    fi
+
+    local tmp_dir
+    tmp_dir=$(mktemp -d)
+    trap 'rm -rf "$tmp_dir"' RETURN
+
+    local calls_file="${tmp_dir}/calls.txt"
+    touch "$calls_file"
+
+    # Mock project-queue.sh:
+    # - list-by-status "In Progress" → item with PR field
+    # - get-item PVTI_dmtest → item with PR=1234
+    # - update-field → records call and succeeds
+    local mock_pq="${tmp_dir}/project-queue.sh"
+    cat > "$mock_pq" << MOCKEOF
+#!/usr/bin/env bash
+subcmd="\${1:-}"
+case "\$subcmd" in
+  list-by-status)
+    printf '[{"item_id":"PVTI_dmtest","issue_num":null,"title":"t","status":"In Progress"}]\n'
+    ;;
+  get-item)
+    printf '{"item_id":"PVTI_dmtest","fields":{"PR":"1234"},"status":"In Progress","title":"t","body":""}\n'
+    ;;
+  update-field)
+    echo "\$@" >> "${calls_file}"
+    printf '{"updated":true}\n'
+    ;;
+  *)
+    printf '[]\n'
+    ;;
+esac
+exit 0
+MOCKEOF
+    chmod +x "$mock_pq"
+
+    # Mock gh that returns MERGED for pr view 1234
+    local mock_gh="${tmp_dir}/gh"
+    cat > "$mock_gh" << 'MOCKEOF'
+#!/usr/bin/env bash
+if [[ "$1" == "pr" && "$2" == "view" && "$3" == "1234" ]]; then
+    printf '"MERGED"\n'
+else
+    printf '{}\n'
+fi
+exit 0
+MOCKEOF
+    chmod +x "$mock_gh"
+
+    # Use a temp Python script (importlib.util pattern matching existing tests).
+    local tmp_py
+    tmp_py=$(mktemp --suffix=.py)
+    cat > "$tmp_py" << PYEOF
+import sys, os, importlib.util
+os.environ['CFGMS_TEST_PROJECT_QUEUE'] = '${mock_pq}'
+os.environ['PATH'] = '${tmp_dir}:' + os.environ.get('PATH', '')
+spec = importlib.util.spec_from_file_location('preflight', '${preflight_script}')
+mod = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(mod)
+count = mod.auto_close_merged_items()
+assert count == 1, f'Expected count=1 (one item closed), got count={count}'
+print(f'COUNT:{count}')
+PYEOF
+
+    local output exit_code=0
+    output=$(python3 "$tmp_py" 2>&1) || exit_code=$?
+    rm -f "$tmp_py"
+
+    if [[ $exit_code -eq 0 ]] && echo "$output" | grep -q "^COUNT:1"; then
+        log_pass "done_on_merge: auto_close_merged_items exits 0 and returned count=1"
+    else
+        log_fail "done_on_merge: expected exit 0 and COUNT:1 (exit=$exit_code): $output"
+    fi
+
+    if grep -q "update-field PVTI_dmtest status Done" "$calls_file" 2>/dev/null; then
+        log_pass "done_on_merge: update-field PVTI_dmtest status Done was called"
+    else
+        log_fail "done_on_merge: update-field call not recorded (calls: $(cat "$calls_file" 2>/dev/null))"
+    fi
+
+    # Test that a failing update-field is still non-fatal
+    local fail_pq="${tmp_dir}/fail-project-queue.sh"
+    cat > "$fail_pq" << MOCKEOF2
+#!/usr/bin/env bash
+subcmd="\${1:-}"
+case "\$subcmd" in
+  list-by-status)
+    printf '[{"item_id":"PVTI_dmtest","issue_num":null,"title":"t","status":"In Progress"}]\n'
+    ;;
+  get-item)
+    printf '{"item_id":"PVTI_dmtest","fields":{"PR":"1234"},"status":"In Progress","title":"t","body":""}\n'
+    ;;
+  update-field)
+    echo "simulated failure" >&2
+    exit 1
+    ;;
+  *)
+    printf '[]\n'
+    ;;
+esac
+exit 0
+MOCKEOF2
+    chmod +x "$fail_pq"
+
+    local tmp_py2
+    tmp_py2=$(mktemp --suffix=.py)
+    cat > "$tmp_py2" << PYEOF2
+import sys, os, importlib.util
+os.environ['CFGMS_TEST_PROJECT_QUEUE'] = '${fail_pq}'
+os.environ['PATH'] = '${tmp_dir}:' + os.environ.get('PATH', '')
+spec = importlib.util.spec_from_file_location('preflight', '${preflight_script}')
+mod = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(mod)
+mod.auto_close_merged_items()
+PYEOF2
+
+    local fail_exit=0
+    python3 "$tmp_py2" 2>/dev/null || fail_exit=$?
+    rm -f "$tmp_py2"
+
+    if [[ $fail_exit -eq 0 ]]; then
+        log_pass "done_on_merge: failing update-field does not cause auto_close_merged_items to exit non-zero"
+    else
+        log_fail "done_on_merge: auto_close_merged_items should be non-fatal even when update-field fails (exit $fail_exit)"
+    fi
+}
+
+test_create_clone_item() {
+    log_test "Testing create-clone-item: branch and worktree created from item_id LAST12..."
+
+    local tmp_dir
+    tmp_dir=$(mktemp -d)
+    local remote_dir="${tmp_dir}/remote.git"
+    local host_dir="${tmp_dir}/host"
+    local worktree_dir="${tmp_dir}/worktrees"
+    local item_id="PVTI_abc123456789012"
+    # LAST12 = last 12 alphanumeric chars of item_id: "PVTIabc123456789012" → last 12 = "123456789012"
+    local expected_last12="123456789012"
+    local expected_branch="feature/item-${expected_last12}-agent"
+    local dispatch_script
+    dispatch_script="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/../.claude/scripts/agent-dispatch.sh"
+
+    git init --bare -b develop "$remote_dir" >/dev/null 2>&1
+    git init -b develop "$host_dir" >/dev/null 2>&1
+    git -C "$host_dir" config user.email "test@test.com"
+    git -C "$host_dir" config user.name "Test"
+    git -C "$host_dir" remote add origin "$remote_dir"
+    git -C "$host_dir" commit --allow-empty -m "initial commit" >/dev/null 2>&1
+    git -C "$host_dir" push origin develop >/dev/null 2>&1
+
+    mkdir -p "$worktree_dir"
+
+    local output exit_code=0
+    output=$(CFGMS_TEST_REPO_ROOT="$host_dir" CFGMS_TEST_WORKTREE_BASE="$worktree_dir" \
+        bash "$dispatch_script" create-clone-item "$item_id" 2>&1) || exit_code=$?
+
+    if [[ $exit_code -eq 0 ]]; then
+        log_pass "create-clone-item: exits 0 for valid item_id"
+    else
+        log_fail "create-clone-item: exited $exit_code: $output"
+        rm -rf "$tmp_dir"
+        return
+    fi
+
+    if echo "$output" | grep -q "CLONE_OK:item-${expected_last12}:${expected_branch}"; then
+        log_pass "create-clone-item: output contains CLONE_OK:item-<LAST12>:<branch>"
+    else
+        log_fail "create-clone-item: expected 'CLONE_OK:item-${expected_last12}:${expected_branch}' not found in: $output"
+    fi
+
+    local clone_dir="${worktree_dir}/item-${expected_last12}"
+    if [[ -d "$clone_dir" ]]; then
+        log_pass "create-clone-item: clone directory created at item-<LAST12>"
+    else
+        log_fail "create-clone-item: clone directory '${clone_dir}' not created"
+    fi
+
+    if git -C "$clone_dir" branch --show-current 2>/dev/null | grep -q "^${expected_branch}$"; then
+        log_pass "create-clone-item: cloned repo is on branch feature/item-<LAST12>-agent"
+    else
+        local actual_branch
+        actual_branch=$(git -C "$clone_dir" branch --show-current 2>/dev/null || echo "(unknown)")
+        log_fail "create-clone-item: expected branch '${expected_branch}', got '${actual_branch}'"
+    fi
+
+    rm -rf "$tmp_dir"
+}
+
 test_preflight_forged_acceptance_review() {
     log_test "Testing po-cycle-preflight.py: forged acceptance review comment rejected (author-gate)..."
 
@@ -1355,6 +1608,12 @@ echo ""
 test_project_queue_integration
 echo ""
 test_project_queue_set_pr
+echo ""
+test_create_clone_item
+echo ""
+test_preflight_item_dispatch
+echo ""
+test_done_on_merge
 echo ""
 test_preflight_forged_acceptance_review
 echo ""


### PR DESCRIPTION
## Summary

- **Preflight item_id dispatch**: `po-cycle-preflight.py` now surfaces pure-draft project items (no linked GitHub issue) in dispatch recommendations. `item_id` is included on all recommendation dicts; `BRANCH_STORY_RE` extended to match `feature/item-<LAST12>-agent` branches so In Progress detection works for item branches.
- **po-act.sh backward-compat**: `dispatch` subcommand accepts both numeric issue numbers (existing path, unchanged) and non-numeric item_ids. Item_id path derives LAST12, calls `agent-dispatch.sh create-clone-item`, passes `CFGMS_PROJECT_ITEM_ID` to the container.
- **Done-on-merge**: `auto_close_merged_items()` scans In Progress items, checks if their linked PR is merged via `gh pr view`, and marks them Done via `project-queue.sh update-field`. Non-fatal: failures are appended to `degraded_reasons`, loop continues.

## Specialist Review Results

- **QA Test Runner**: PASS — 106/106 tests passed, 0 failed
- **QA Code Reviewer**: PASS — no blocking issues (count assertion + create-clone-item test coverage confirmed)
- **Security Engineer**: PASS — 3 LOW informational findings only (empty LAST12 guard added per recommendation)

## Test plan

- [ ] `bash scripts/test-scripts.sh` — all 106 tests pass
- [ ] `test_create_clone_item`: creates local git remote, verifies `CLONE_OK:item-123456789012:feature/item-123456789012-agent`, clone dir exists, branch correct
- [ ] `test_preflight_item_dispatch`: mock project queue returns pure-draft item with `issue_num=null`; assert `number is None` and `item_id == 'PVTI_test123456789012'`
- [ ] `test_done_on_merge`: mock gh returns MERGED; assert `count == 1`, `update-field` called with `Done`, non-fatal on failing update-field

Fixes #1493

🤖 Generated with [Claude Code](https://claude.com/claude-code)