### PR TITLE
pipeline-security: dispatch + entrypoint create-clone-item, review-pr item-branch, set-pr call (Issue #1494)

### DIFF
--- a/.claude/scripts/agent-dispatch.sh
+++ b/.claude/scripts/agent-dispatch.sh
@@ -253,6 +253,15 @@ case "$cmd" in
     dest="${WORKTREE_BASE}/item-${LAST12}"
     github_url=$(git -C "$REPO_ROOT" remote get-url origin)
 
+    # Check for stale remote branch before cloning — same logic as create-clone.
+    if git -C "$REPO_ROOT" ls-remote --heads origin "$branch_name" 2>/dev/null | grep -q .; then
+      echo "Cleaning stale remote branch: ${branch_name}"
+      if ! git -C "$REPO_ROOT" push origin --delete "$branch_name" 2>&1; then
+        echo "ERROR: Failed to delete stale remote branch '${branch_name}'. Refusing to dispatch to prevent history corruption."
+        exit 1
+      fi
+    fi
+
     trap "rm -rf '$dest'" ERR
     git clone --local --branch develop "$REPO_ROOT" "$dest"
     cd "$dest"
@@ -698,23 +707,39 @@ else:
     ;;
 
   cleanup-issue)
-    [[ $# -eq 1 ]] || { echo "cleanup-issue requires exactly one issue number"; exit 1; }
+    [[ $# -eq 1 ]] || { echo "cleanup-issue requires exactly one issue number or item_id"; exit 1; }
     num="$1"
-    # Copy result file (best-effort)
-    docker cp "cfg-agent-${num}:/tmp/agent-result.json" "/tmp/agent-result-${num}.json" 2>/dev/null || true
-    # Remove container (works for both running and exited)
-    if docker rm -f "cfg-agent-${num}" >/dev/null 2>&1; then
-      echo "CLEANED:container:cfg-agent-${num}"
+    if [[ "$num" =~ ^[0-9]+$ ]]; then
+      # Issue mode (numeric): existing behavior
+      docker cp "cfg-agent-${num}:/tmp/agent-result.json" "/tmp/agent-result-${num}.json" 2>/dev/null || true
+      if docker rm -f "cfg-agent-${num}" >/dev/null 2>&1; then
+        echo "CLEANED:container:cfg-agent-${num}"
+      else
+        echo "SKIP:container:cfg-agent-${num} not found"
+      fi
+      clone_dir="${WORKTREE_BASE}/story-${num}"
+      if [[ -d "$clone_dir" ]]; then
+        rm -rf "$clone_dir"
+        echo "CLEANED:clone:${clone_dir}"
+      else
+        echo "SKIP:clone:${clone_dir} not found"
+      fi
     else
-      echo "SKIP:container:cfg-agent-${num} not found"
-    fi
-    # Remove clone directory
-    clone_dir="${WORKTREE_BASE}/story-${num}"
-    if [[ -d "$clone_dir" ]]; then
-      rm -rf "$clone_dir"
-      echo "CLEANED:clone:${clone_dir}"
-    else
-      echo "SKIP:clone:${clone_dir} not found"
+      # Item mode (non-numeric item_id): derive LAST12 and clean item resources
+      item_last12=$(echo "$num" | tr -cd 'a-zA-Z0-9' | rev | cut -c1-12 | rev)
+      item_container="cfg-agent-item-${item_last12}"
+      if docker rm -f "$item_container" >/dev/null 2>&1; then
+        echo "CLEANED:container:${item_container}"
+      else
+        echo "SKIP:container:${item_container} not found"
+      fi
+      clone_dir="${WORKTREE_BASE}/item-${item_last12}"
+      if [[ -d "$clone_dir" ]]; then
+        rm -rf "$clone_dir"
+        echo "CLEANED:clone:${clone_dir}"
+      else
+        echo "SKIP:clone:${clone_dir} not found"
+      fi
     fi
     echo "CLEANUP_DONE:${num}"
     ;;
@@ -852,14 +877,21 @@ else:
     fi
     validate_branch "$pr_branch"
 
-    # Auto-detect story number: first try "Fixes #N" in PR body, then branch.
+    # Auto-detect story number or item_id: first try "Fixes #N" in PR body, then branch.
     story_num=$(echo "$pr_body" | grep -oP '(?:Fixes|Closes|Resolves)\s+#\K[0-9]+' | head -1 || true)
-    if [[ -z "$story_num" && "$pr_branch" =~ story-([0-9]+) ]]; then
-      story_num="${BASH_REMATCH[1]}"
-    fi
+    is_item_branch=false
+    item_last12=""
+
     if [[ -z "$story_num" ]]; then
-      echo "REVIEW_REFUSED:${pr_num}:no_story_link"
-      exit 3
+      if [[ "$pr_branch" =~ feature/story-([0-9]+) ]]; then
+        story_num="${BASH_REMATCH[1]}"
+      elif [[ "$pr_branch" =~ feature/item-([a-zA-Z0-9]+) ]]; then
+        is_item_branch=true
+        item_last12="${BASH_REMATCH[1]}"
+      else
+        echo "REVIEW_REFUSED:${pr_num}:no_story_link"
+        exit 3
+      fi
     fi
 
     container_name="cfg-agent-review-pr-${pr_num}"
@@ -871,11 +903,61 @@ else:
       exit 3
     fi
 
-    # Look up project item_id for the story so the reviewer can update status.
     PROJECT_QUEUE="${REPO_ROOT}/scripts/project-queue.sh"
-    item_id=$(bash "$PROJECT_QUEUE" add-issue "$story_num" 2>/dev/null \
-      | python3 -c "import json,sys; print(json.load(sys.stdin).get('item_id',''))" \
-      2>/dev/null || true)
+    item_id=""
+
+    if $is_item_branch; then
+      # Item-branch PR: find item_id via PR-field scan, then item_id-suffix scan.
+      # PR-field scan: iterate In Progress items, check if .fields.PR == pr_num.
+      in_progress_ids=$(bash "$PROJECT_QUEUE" list-by-status "In Progress" 2>/dev/null | \
+        python3 -c "import json,sys; [print(i['item_id']) for i in json.load(sys.stdin)]" \
+        2>/dev/null || true)
+      for candidate_id in $in_progress_ids; do
+        candidate_json=$(bash "$PROJECT_QUEUE" get-item "$candidate_id" 2>/dev/null || echo "")
+        candidate_pr=$(echo "$candidate_json" | python3 -c "
+import json, sys
+try:
+    d = json.load(sys.stdin)
+    print(d.get('fields', {}).get('PR', ''))
+except Exception:
+    print('')
+" 2>/dev/null || echo "")
+        if [[ "$candidate_pr" == "$pr_num" ]]; then
+          item_id="$candidate_id"
+          break
+        fi
+      done
+      # Item_id-suffix scan fallback: check all status buckets for item_id ending with LAST12.
+      if [[ -z "$item_id" ]]; then
+        for scan_status in "Draft" "Ready" "In Progress" "Fix" "Done" "Blocked" "Failed"; do
+          scan_result=$(bash "$PROJECT_QUEUE" list-by-status "$scan_status" 2>/dev/null | \
+            python3 -c "
+import json, sys
+suffix = '${item_last12}'
+items = json.load(sys.stdin)
+for i in items:
+    iid = i.get('item_id', '')
+    alphanumeric = ''.join(c for c in iid if c.isalnum())
+    if alphanumeric[-len(suffix):] == suffix and len(suffix) > 0:
+        print(iid)
+        break
+" 2>/dev/null || true)
+          if [[ -n "$scan_result" ]]; then
+            item_id="$scan_result"
+            break
+          fi
+        done
+      fi
+      if [[ -z "$item_id" ]]; then
+        echo "REVIEW_REFUSED:${pr_num}:no_story_link"
+        exit 3
+      fi
+    else
+      # Story PR: look up project item_id via add-issue.
+      item_id=$(bash "$PROJECT_QUEUE" add-issue "$story_num" 2>/dev/null \
+        | python3 -c "import json,sys; print(json.load(sys.stdin).get('item_id',''))" \
+        2>/dev/null || true)
+    fi
 
     # Stale clone cleanup (previous run crashed before docker rm got the dir).
     rm -rf "$clone_dir" 2>/dev/null || true
@@ -894,7 +976,35 @@ else:
 
     # Write the review prompt into the cloned worktree. The container's
     # review-entrypoint.sh reads it and hands off to claude -p.
-    cat > "${clone_dir}/.acceptance-review-prompt.md" <<PROMPT_EOF
+    if $is_item_branch; then
+      # Item-branch prompt: story:0, cleanup via item_id (no linked issue to close).
+      cat > "${clone_dir}/.acceptance-review-prompt.md" <<PROMPT_EOF
+You are operating as the Acceptance Reviewer agent for CFGMS.
+
+Your assignment: pr:${pr_num} story:0 --project-item ${item_id}
+
+Read \`.claude/agents/acceptance-reviewer.md\` and execute its full Phase 1-5
+workflow against the PR currently checked out in this workspace. Use real \`gh\`
+commands; you are inside a container with a fresh GH_TOKEN and skip-permissions
+mode, so no approval prompts will block you.
+
+When the verdict is determined, post the structured review comment per the
+agent definition. Then take exactly ONE of these closing actions:
+
+- **PASS (zero findings)**:
+  mark item Done with \`./scripts/project-queue.sh update-field ${item_id} status Done\`,
+  then run \`./.claude/scripts/agent-dispatch.sh cleanup-issue ${item_id}\` to
+  release the dev agent's container/worktree.
+- **FAIL on first review**: \`./scripts/project-queue.sh update-field ${item_id} status Fix\`.
+- **FAIL on second review (fix cycle)**:
+  \`./scripts/project-queue.sh update-field ${item_id} status Blocked\`,
+  and run \`./.claude/scripts/agent-dispatch.sh cleanup-issue ${item_id}\`.
+- **WAIT (CI pending)**: post the WAIT verdict comment and exit cleanly. The
+  host PO will re-dispatch when CI completes.
+PROMPT_EOF
+    else
+      # Story-branch prompt: includes issue closing and story cleanup.
+      cat > "${clone_dir}/.acceptance-review-prompt.md" <<PROMPT_EOF
 You are operating as the Acceptance Reviewer agent for CFGMS.
 
 Your assignment: pr:${pr_num} story:${story_num} --project-item ${item_id}
@@ -919,10 +1029,17 @@ agent definition. Then take exactly ONE of these closing actions:
 - **WAIT (CI pending)**: post the WAIT verdict comment and exit cleanly. The
   host PO will re-dispatch when CI completes.
 PROMPT_EOF
+    fi
 
     real_path=$(realpath "$clone_dir")
     refresh_creds_from_host
     gh_token=$(gh auth token)
+
+    # Determine story label: 0 for item-branch PRs (no linked issue).
+    review_story_label="${story_num:-0}"
+    if $is_item_branch; then
+      review_story_label="0"
+    fi
 
     # Launch headless. Mount the review entrypoint at runtime — no image rebuild
     # required when this script changes.
@@ -931,7 +1048,7 @@ PROMPT_EOF
       --label "cfg-agent=true" \
       --label "mode=review" \
       --label "pr=${pr_num}" \
-      --label "story=${story_num}" \
+      --label "story=${review_story_label}" \
       --memory=4g \
       --cpus=4 \
       --stop-timeout=1800 \
@@ -946,7 +1063,7 @@ PROMPT_EOF
       --cap-add NET_ADMIN \
       --entrypoint /usr/local/bin/review-entrypoint.sh \
       cfg-agent:latest 2>&1); then
-      echo "REVIEW_DISPATCHED:${pr_num}:${story_num}:${container_id}"
+      echo "REVIEW_DISPATCHED:${pr_num}:${review_story_label}:${container_id}"
     else
       echo "LAUNCH_FAILED:${container_name}:${container_id}"
       rm -rf "$clone_dir"

--- a/.devcontainer/entrypoint.sh
+++ b/.devcontainer/entrypoint.sh
@@ -13,6 +13,8 @@ PROJECT_QUEUE="${CFGMS_TEST_PROJECT_QUEUE:-$(dirname "${BASH_SOURCE[0]}")/../scr
 # --- Argument parsing ---
 MODE="issue"
 ISSUE_NUM=""
+ITEM_ID_SHORT=""
+ITEM_MODE="false"
 BRANCH=""
 PR_NUM=""
 DRY_RUN=""
@@ -26,9 +28,14 @@ while [[ $# -gt 0 ]]; do
         *)
             if [[ "$1" =~ ^[0-9]+$ ]]; then
                 ISSUE_NUM="$1"; shift
+            elif [[ "$1" =~ ^[a-zA-Z0-9_]+$ ]]; then
+                # Non-numeric positional arg: signals item_id mode.
+                # ITEM_ID_SHORT is derived from CFGMS_PROJECT_ITEM_ID env var.
+                ITEM_MODE="true"; shift
             else
                 echo "ERROR: Unknown argument: $1"
                 echo "Usage: entrypoint.sh <ISSUE_NUM> [--dry-run]"
+                echo "       entrypoint.sh <ITEM_ID> [--dry-run]  (sets item mode)"
                 echo "       entrypoint.sh --branch <BRANCH> [--issue <NUM>] [--dry-run]"
                 echo "       entrypoint.sh --fix-pr <PR_NUM> [--dry-run]"
                 exit 1
@@ -41,8 +48,13 @@ done
 case "$MODE" in
     issue)
         if [[ -z "$ISSUE_NUM" ]]; then
-            echo "ERROR: Issue mode requires an issue number"
-            exit 1
+            if [[ "$ITEM_MODE" == "true" && -n "${CFGMS_PROJECT_ITEM_ID:-}" ]]; then
+                # Item mode: derive ITEM_ID_SHORT from CFGMS_PROJECT_ITEM_ID
+                ITEM_ID_SHORT=$(echo "$CFGMS_PROJECT_ITEM_ID" | tr -cd 'a-zA-Z0-9' | rev | cut -c1-12 | rev)
+            else
+                echo "ERROR: Issue mode requires an issue number"
+                exit 1
+            fi
         fi
         ;;
     branch)
@@ -189,9 +201,12 @@ compose_issue_prompt() {
     # Build prompt in a temp file to avoid shell metacharacter corruption.
     # Issue bodies often contain backticks, $ field numbers, etc.
     PROMPT_FILE=$(mktemp)
-    printf 'You are implementing GitHub issue #%s: %s\n\n' "$ISSUE_NUM" "$TITLE" > "$PROMPT_FILE"
-    printf '%s\n\n' "$BODY" >> "$PROMPT_FILE"
-    cat >> "$PROMPT_FILE" <<PROMPT_EOF
+
+    if [[ -n "$ISSUE_NUM" ]]; then
+        # Issue mode: standard GitHub issue prompt
+        printf 'You are implementing GitHub issue #%s: %s\n\n' "$ISSUE_NUM" "$TITLE" > "$PROMPT_FILE"
+        printf '%s\n\n' "$BODY" >> "$PROMPT_FILE"
+        cat >> "$PROMPT_FILE" <<PROMPT_EOF
 ## Instructions
 
 You are running inside an isolated container with --dangerously-skip-permissions.
@@ -213,10 +228,10 @@ architecture rules, and coding standards. CFGMS_AGENT_MODE=true is set.
 7. Fix any compilation or test errors before proceeding to review phase
 
 PROMPT_EOF
-    # Append shared sections (contain backticks — must not be inside unquoted heredoc)
-    printf '%s\n\n' "$SELF_REVIEW_SECTION" >> "$PROMPT_FILE"
-    printf '%s\n\n' "$ADVERSARIAL_REVIEW_SECTION" >> "$PROMPT_FILE"
-    cat >> "$PROMPT_FILE" <<PROMPT_EOF
+        # Append shared sections (contain backticks — must not be inside unquoted heredoc)
+        printf '%s\n\n' "$SELF_REVIEW_SECTION" >> "$PROMPT_FILE"
+        printf '%s\n\n' "$ADVERSARIAL_REVIEW_SECTION" >> "$PROMPT_FILE"
+        cat >> "$PROMPT_FILE" <<PROMPT_EOF
 ## Phase 5: Commit and PR
 
 After all three specialists report PASS:
@@ -242,16 +257,72 @@ If specialists report issues that cannot be fixed after 3 iterations:
 - Exit non-zero
 
 PROMPT_EOF
+    else
+        # Item mode: project item prompt (no linked GitHub issue to close)
+        printf 'You are implementing project item %s: %s\n\n' "$ITEM_ID_SHORT" "$TITLE" > "$PROMPT_FILE"
+        printf '%s\n\n' "$BODY" >> "$PROMPT_FILE"
+        cat >> "$PROMPT_FILE" <<PROMPT_EOF
+## Instructions
+
+You are running inside an isolated container with --dangerously-skip-permissions.
+Your branch \`feature/item-${ITEM_ID_SHORT}-agent\` is already checked out from \`develop\`.
+Follow the CLAUDE.md file in the repository root — it contains all project conventions,
+architecture rules, and coding standards. CFGMS_AGENT_MODE=true is set.
+
+## Phase 1: Implement
+
+1. Read and understand the full item description including acceptance criteria
+2. Read CLAUDE.md for project conventions (central providers, storage architecture, etc.)
+3. If the item mentions reference files or patterns, read them first
+4. Write tests FIRST for the expected behavior (TDD — tests must fail before implementation)
+5. Implement the change to make the tests pass, following existing patterns
+
+## Phase 2: Validate (quick self-check before specialist review)
+
+6. Run \`go test ./path/to/changed/packages/...\` to verify your tests pass locally
+7. Fix any compilation or test errors before proceeding to review phase
+
+PROMPT_EOF
+        printf '%s\n\n' "$SELF_REVIEW_SECTION" >> "$PROMPT_FILE"
+        printf '%s\n\n' "$ADVERSARIAL_REVIEW_SECTION" >> "$PROMPT_FILE"
+        cat >> "$PROMPT_FILE" <<PROMPT_EOF
+## Phase 5: Commit and PR
+
+After all three specialists report PASS:
+
+8. Run \`go mod tidy\` if dependencies changed
+9. Stage all changes with \`git add <specific files>\` (never git add . or git add -A)
+10. Commit with message: \`<scope>: <description> (Item #${ITEM_ID_SHORT})\`
+    - Follow commit message format in CLAUDE.md (15-25 lines, WHY + WHAT)
+    - Include \`Co-Authored-By: Claude <noreply@anthropic.com>\`
+11. Push branch: \`git push -u origin \$(git branch --show-current)\`
+12. Open PR targeting \`develop\` (NEVER \`main\`):
+    \`gh pr create --base develop --title "<scope>: <title> (Item #${ITEM_ID_SHORT})"\`
+    Include specialist review results (PASS/FAIL summaries) in the PR body.
+
+## Failure Handling
+
+If specialists report issues that cannot be fixed after 3 iterations:
+- Stage all changes and commit with message describing what was attempted
+- Push the branch
+- Open a DRAFT PR with failure details and specialist reports in the description body
+- Exit non-zero
+
+PROMPT_EOF
+    fi
     printf '%s\n' "$SCOPE_CONSTRAINTS_SECTION" >> "$PROMPT_FILE"
 }
 
 compose_branch_prompt() {
     local issue_context=""
 
-    # Auto-detect issue from branch name if not provided
+    # Auto-detect issue or item from branch name if not provided
     if [[ -z "$ISSUE_NUM" ]] && [[ "$BRANCH" =~ story-([0-9]+) ]]; then
         ISSUE_NUM="${BASH_REMATCH[1]}"
         echo "Auto-detected issue #${ISSUE_NUM} from branch name"
+    elif [[ -z "$ISSUE_NUM" ]] && [[ "$BRANCH" =~ item-([a-zA-Z0-9]+) ]]; then
+        ITEM_ID_SHORT="${BASH_REMATCH[1]}"
+        echo "Auto-detected item ${ITEM_ID_SHORT} from branch name"
     fi
 
     # Fetch issue context from Projects V2 — never from gh issue view.
@@ -564,6 +635,16 @@ fi
 # Extract PR URL if one was created
 CURRENT_BRANCH=$(git branch --show-current 2>/dev/null || echo "unknown")
 PR_URL=$(gh pr list --head "$CURRENT_BRANCH" --json url -q '.[0].url' 2>/dev/null || echo "")
+
+# Update project item with the PR number so the pipeline can track it.
+# Non-fatal: a failed set-pr never affects the agent's exit code.
+if [[ -n "${CFGMS_PROJECT_ITEM_ID:-}" ]] && [[ -n "$PR_URL" ]] && [[ "$MODE" != "fix-pr" ]]; then
+    _pr_num=$(echo "$PR_URL" | grep -oE '[0-9]+$' || true)
+    if [[ -n "$_pr_num" ]]; then
+        bash "$PROJECT_QUEUE" set-pr "$CFGMS_PROJECT_ITEM_ID" "$_pr_num" \
+            || echo "WARN: set-pr failed — continuing"
+    fi
+fi
 
 # Write result summary
 cat > /tmp/agent-result.json <<RESULT_EOF

--- a/scripts/test-scripts.sh
+++ b/scripts/test-scripts.sh
@@ -1567,6 +1567,365 @@ PYEOF
     fi
 }
 
+test_agent_dispatch_create_clone_item() {
+    log_test "Testing agent-dispatch.sh create-clone-item: LAST12 derivation and clone creation..."
+
+    local tmp_dir
+    tmp_dir=$(mktemp -d)
+    local remote_dir="${tmp_dir}/remote.git"
+    local host_dir="${tmp_dir}/host"
+    local worktree_dir="${tmp_dir}/worktrees"
+    # item_id from AC: PVTI_lADOtest000000012345
+    # Strip non-alphanumeric → PVTIlADOtest000000012345 (24 chars)
+    # Rightmost 12 → 000000012345
+    local item_id="PVTI_lADOtest000000012345"
+    local expected_last12="000000012345"
+    local expected_branch="feature/item-${expected_last12}-agent"
+    local dispatch_script
+    dispatch_script="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/../.claude/scripts/agent-dispatch.sh"
+
+    git init --bare -b develop "$remote_dir" >/dev/null 2>&1
+    git init -b develop "$host_dir" >/dev/null 2>&1
+    git -C "$host_dir" config user.email "test@test.com"
+    git -C "$host_dir" config user.name "Test"
+    git -C "$host_dir" remote add origin "$remote_dir"
+    git -C "$host_dir" commit --allow-empty -m "initial commit" >/dev/null 2>&1
+    git -C "$host_dir" push origin develop >/dev/null 2>&1
+
+    mkdir -p "$worktree_dir"
+
+    local output exit_code=0
+    output=$(CFGMS_TEST_REPO_ROOT="$host_dir" CFGMS_TEST_WORKTREE_BASE="$worktree_dir" \
+        bash "$dispatch_script" create-clone-item "$item_id" 2>&1) || exit_code=$?
+
+    if [[ $exit_code -eq 0 ]]; then
+        log_pass "agent_dispatch_create_clone_item: exits 0 for item_id ${item_id}"
+    else
+        log_fail "agent_dispatch_create_clone_item: exited ${exit_code}: ${output}"
+        rm -rf "$tmp_dir"
+        return
+    fi
+
+    # Full match: verifies correct LAST12 and branch name, not just prefix
+    if echo "$output" | grep -q "CLONE_OK:item-${expected_last12}:${expected_branch}"; then
+        log_pass "agent_dispatch_create_clone_item: stdout contains full CLONE_OK:item-${expected_last12}:${expected_branch}"
+    else
+        log_fail "agent_dispatch_create_clone_item: expected 'CLONE_OK:item-${expected_last12}:${expected_branch}' in output: ${output}"
+    fi
+
+    local clone_dir="${worktree_dir}/item-${expected_last12}"
+    if [[ -d "$clone_dir" ]]; then
+        log_pass "agent_dispatch_create_clone_item: clone directory created at item-${expected_last12}"
+    else
+        log_fail "agent_dispatch_create_clone_item: clone directory '${clone_dir}' not created"
+    fi
+
+    # Verify checked-out branch matches expected item branch name
+    local actual_branch
+    actual_branch=$(git -C "$clone_dir" branch --show-current 2>/dev/null || echo "(unknown)")
+    if [[ "$actual_branch" == "$expected_branch" ]]; then
+        log_pass "agent_dispatch_create_clone_item: cloned repo is on expected branch ${expected_branch}"
+    else
+        log_fail "agent_dispatch_create_clone_item: expected branch '${expected_branch}', got '${actual_branch}'"
+    fi
+
+    rm -rf "$tmp_dir"
+}
+
+test_cleanup_issue_item_mode() {
+    log_test "Testing agent-dispatch.sh cleanup-issue: non-numeric item_id targets item container/clone..."
+
+    local tmp_dir
+    tmp_dir=$(mktemp -d)
+    local worktree_dir="${tmp_dir}/worktrees"
+    # item_id: PVTI_itemcleanup123 → strip non-alnum → PVTIitemcleanup123 (18) → last 12 = itemcleanup123... wait
+    # PVTIitemcleanup123: P(1)V(2)T(3)I(4)i(5)t(6)e(7)m(8)c(9)l(10)e(11)a(12)n(13)u(14)p(15)1(16)2(17)3(18)
+    # last 12 = cleanup123...
+    # Actually: nup123 is wrong. Let me use a simpler example.
+    # PVTI_testclean99 → PVTItestclean99 (15 chars) → last 12 = testclean99... that's 11...
+    # PVTItestclean99: P(1)V(2)T(3)I(4)t(5)e(6)s(7)t(8)c(9)l(10)e(11)a(12)n(13)9(14)9(15) → last 12: testclean99 (only 11 after index 4)
+    # Let me use PVTI_abcdefghij0123 → PVTIabcdefghij0123 (18 chars) → last 12 = bcdefghij0123...
+    # Wait that's 13. Let me count: PVTIabcdefghij0123: P,V,T,I,a,b,c,d,e,f,g,h,i,j,0,1,2,3 = 18 chars
+    # last 12 = chars 7-18 = efghij0123... that's 12 chars: e,f,g,h,i,j,0,1,2,3 = only 10
+    # OK let me just compute it properly:
+    # Strip non-alnum from PVTI_testcleanXY123 → PVTItestcleanXY123 → 18 chars
+    # Last 12: chars 7-18 = "eanXY123" ... hmm let me just pick a clear item_id
+    # PVTI_item000000000042 → strip non-alnum → PVTIitem000000000042 (20 chars) → last 12 = 000000000042
+    local item_id="PVTI_item000000000042"
+    local expected_last12="000000000042"
+    local dispatch_script
+    dispatch_script="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/../.claude/scripts/agent-dispatch.sh"
+
+    mkdir -p "$worktree_dir"
+    local clone_dir="${worktree_dir}/item-${expected_last12}"
+    # Pre-create the clone directory so cleanup can remove it and we can verify
+
+    mkdir -p "$clone_dir"
+
+    local output exit_code=0
+    output=$(CFGMS_TEST_REPO_ROOT="$(pwd)" CFGMS_TEST_WORKTREE_BASE="$worktree_dir" \
+        bash "$dispatch_script" cleanup-issue "$item_id" 2>&1) || exit_code=$?
+
+    # Container removal will fail (not found is fine — docker not available or container absent)
+    # We check the SKIP or CLEANED message uses the correct item container name
+
+    if echo "$output" | grep -q "cfg-agent-item-${expected_last12}"; then
+        log_pass "cleanup_issue_item_mode: targets correct container name cfg-agent-item-${expected_last12}"
+    else
+        log_fail "cleanup_issue_item_mode: expected container name 'cfg-agent-item-${expected_last12}' in output: ${output}"
+    fi
+
+    if echo "$output" | grep -q "CLEANED:clone:${clone_dir}"; then
+        log_pass "cleanup_issue_item_mode: clone directory ${clone_dir} cleaned"
+    else
+        log_fail "cleanup_issue_item_mode: expected 'CLEANED:clone:${clone_dir}' in output: ${output}"
+    fi
+
+    if [[ ! -d "$clone_dir" ]]; then
+        log_pass "cleanup_issue_item_mode: clone directory removed on disk"
+    else
+        log_fail "cleanup_issue_item_mode: clone directory still exists after cleanup"
+    fi
+
+    if echo "$output" | grep -q "CLEANUP_DONE:${item_id}"; then
+        log_pass "cleanup_issue_item_mode: CLEANUP_DONE reports original item_id"
+    else
+        log_fail "cleanup_issue_item_mode: expected 'CLEANUP_DONE:${item_id}' in output: ${output}"
+    fi
+
+    rm -rf "$tmp_dir"
+}
+
+test_review_pr_item_branch() {
+    log_test "Testing review-pr item-branch: scans project queue and refuses when item_id not found..."
+
+    local tmp_dir
+    tmp_dir=$(mktemp -d)
+    local worktree_dir="${tmp_dir}/worktrees"
+    local pq_calls_file="${tmp_dir}/pq-calls.txt"
+    touch "$pq_calls_file"
+    local dispatch_script
+    dispatch_script="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/../.claude/scripts/agent-dispatch.sh"
+
+    mkdir -p "$worktree_dir"
+
+    # Fake repo root with a scripts/project-queue.sh that records calls and returns empty
+    local fake_repo="${tmp_dir}/repo"
+    mkdir -p "${fake_repo}/scripts"
+    cat > "${fake_repo}/scripts/project-queue.sh" << PQEOF
+#!/usr/bin/env bash
+echo "\$@" >> "${pq_calls_file}"
+printf '[]\n'
+exit 0
+PQEOF
+    chmod +x "${fake_repo}/scripts/project-queue.sh"
+
+    # Mock gh: returns an open item-branch PR
+    cat > "${tmp_dir}/gh" << 'GHEOF'
+#!/usr/bin/env bash
+if [[ "$1" == "pr" && "$2" == "view" ]]; then
+    printf '{"state":"OPEN","headRefName":"feature/item-ABCD12345678-agent","body":"No fixes link","labels":[],"headRepositoryOwner":{"login":"cfg-is"}}\n'
+elif [[ "$1" == "auth" && "$2" == "token" ]]; then
+    echo "fake-token"
+else
+    printf '{}\n'
+fi
+exit 0
+GHEOF
+    chmod +x "${tmp_dir}/gh"
+
+    # Mock docker: returns empty (no existing containers or images)
+    cat > "${tmp_dir}/docker" << 'DOCKEREOF'
+#!/usr/bin/env bash
+exit 0
+DOCKEREOF
+    chmod +x "${tmp_dir}/docker"
+
+    local output exit_code=0
+    output=$(
+        PATH="${tmp_dir}:${PATH}" \
+        CFGMS_TEST_REPO_ROOT="$fake_repo" \
+        CFGMS_TEST_WORKTREE_BASE="$worktree_dir" \
+        bash "$dispatch_script" review-pr 77 2>&1
+    ) || exit_code=$?
+
+    if [[ $exit_code -eq 3 ]]; then
+        log_pass "review_pr_item_branch: exits 3 when no item_id found for item branch"
+    else
+        log_fail "review_pr_item_branch: expected exit 3, got ${exit_code}: ${output}"
+    fi
+
+    if echo "$output" | grep -q "REVIEW_REFUSED:77:no_story_link"; then
+        log_pass "review_pr_item_branch: emits REVIEW_REFUSED:77:no_story_link after scans find nothing"
+    else
+        log_fail "review_pr_item_branch: expected 'REVIEW_REFUSED:77:no_story_link' in: ${output}"
+    fi
+
+    # Verify that the item-branch scan path was actually executed (list-by-status called)
+    if grep -q "list-by-status" "$pq_calls_file" 2>/dev/null; then
+        log_pass "review_pr_item_branch: project-queue list-by-status was called (scan attempted)"
+    else
+        log_fail "review_pr_item_branch: list-by-status not called — item-branch scan path not exercised"
+    fi
+
+    rm -rf "$tmp_dir"
+}
+
+test_entrypoint_set_pr_call() {
+    log_test "Testing entrypoint.sh: set-pr called after PR creation with CFGMS_PROJECT_ITEM_ID..."
+
+    local tmp_dir
+    tmp_dir=$(mktemp -d)
+    trap 'rm -rf "$tmp_dir"' RETURN
+
+    local calls_file="${tmp_dir}/pq-calls.txt"
+    touch "$calls_file"
+
+    # Fake HOME with credentials (far-future expiry so token check passes)
+    local fake_home="${tmp_dir}/home"
+    mkdir -p "${fake_home}/.claude"
+    cat > "${fake_home}/.claude/.credentials.json" << 'CREDEOF'
+{"claudeAiOauth":{"expiresAt":9999999999999,"accessToken":"fake","refreshToken":"fake"}}
+CREDEOF
+    cat > "${fake_home}/.claude.json" << 'CONFIGEOF'
+{"hasCompletedOnboarding":true}
+CONFIGEOF
+
+    # Git repo with correct branch so git branch --show-current returns story branch
+    local git_dir="${tmp_dir}/repo"
+    git init -b develop "$git_dir" >/dev/null 2>&1
+    git -C "$git_dir" config user.email "test@test.com"
+    git -C "$git_dir" config user.name "Test"
+    git -C "$git_dir" commit --allow-empty -m "initial" >/dev/null 2>&1
+    git -C "$git_dir" checkout -b "feature/story-999-agent" >/dev/null 2>&1
+
+    # Mock setup-env.sh — minimal: just git config (no firewall/credentials setup needed)
+    cat > "${tmp_dir}/setup-env.sh" << 'SETUPEOF'
+#!/usr/bin/env bash
+git config --global user.name "test-agent" 2>/dev/null || true
+git config --global user.email "agent@test.com" 2>/dev/null || true
+SETUPEOF
+    chmod +x "${tmp_dir}/setup-env.sh"
+
+    # Mock claude: creates validation marker and exits 0
+    cat > "${tmp_dir}/claude" << 'CLAUDEOF'
+#!/usr/bin/env bash
+touch /tmp/agent-validation-passed
+exit 0
+CLAUDEOF
+    chmod +x "${tmp_dir}/claude"
+
+    # Mock gh: returns PR URL for pr list, {} for everything else
+    cat > "${tmp_dir}/gh" << 'GHEOF'
+#!/usr/bin/env bash
+if [[ "$1" == "pr" && "$2" == "list" ]]; then
+    echo "https://github.com/cfg-is/cfgms/pull/42"
+else
+    echo "{}"
+fi
+exit 0
+GHEOF
+    chmod +x "${tmp_dir}/gh"
+
+    # Mock project-queue.sh: records all calls, responds to get-item and set-pr
+    local pq_recorder="${tmp_dir}/pq-recorder.sh"
+    cat > "$pq_recorder" << PQEOF
+#!/usr/bin/env bash
+echo "\$@" >> "${calls_file}"
+subcmd="\${1:-}"
+case "\$subcmd" in
+    get-item)
+        printf '{"item_id":"PVTI_testitem","title":"Test Story 999","body":"Test body content.","status":"In Progress","fields":{}}\n'
+        ;;
+    set-pr)
+        printf '{"updated":true}\n'
+        ;;
+    *)
+        printf '[]\n'
+        ;;
+esac
+exit 0
+PQEOF
+    chmod +x "$pq_recorder"
+
+    local entrypoint_script
+    entrypoint_script="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/.devcontainer/entrypoint.sh"
+
+    if [[ ! -f "$entrypoint_script" ]]; then
+        log_fail "entrypoint_set_pr_call: entrypoint.sh not found at ${entrypoint_script}"
+        return
+    fi
+
+    # Run entrypoint.sh from the temp git repo (so git branch --show-current works)
+    rm -f /tmp/agent-validation-passed
+    local output exit_code=0
+    output=$(
+        cd "$git_dir"
+        PATH="${tmp_dir}:${PATH}" \
+        HOME="${fake_home}" \
+        CFGMS_PROJECT_ITEM_ID="PVTI_testitem" \
+        CFGMS_TEST_PROJECT_QUEUE="$pq_recorder" \
+        bash "$entrypoint_script" 999 2>&1
+    ) || exit_code=$?
+
+    if [[ $exit_code -eq 0 ]]; then
+        log_pass "entrypoint_set_pr_call: entrypoint exits 0 with valid mocks"
+    else
+        log_fail "entrypoint_set_pr_call: entrypoint exited ${exit_code}: ${output}"
+        return
+    fi
+
+    if grep -q "set-pr PVTI_testitem 42" "$calls_file" 2>/dev/null; then
+        log_pass "entrypoint_set_pr_call: set-pr called with correct item_id and PR number (42)"
+    else
+        log_fail "entrypoint_set_pr_call: set-pr not called correctly (calls: $(cat "$calls_file" 2>/dev/null))"
+    fi
+
+    # Non-fatal assertion: set-pr failure must not cause entrypoint to fail
+    local fail_pq="${tmp_dir}/fail-pq.sh"
+    cat > "$fail_pq" << FAILPQEOF
+#!/usr/bin/env bash
+subcmd="\${1:-}"
+case "\$subcmd" in
+    get-item)
+        printf '{"item_id":"PVTI_testitem","title":"Test Story 999","body":"Test body.","status":"In Progress","fields":{}}\n'
+        ;;
+    set-pr)
+        echo "simulated set-pr failure" >&2
+        exit 1
+        ;;
+    *)
+        printf '[]\n'
+        ;;
+esac
+FAILPQEOF
+    chmod +x "$fail_pq"
+
+    rm -f /tmp/agent-validation-passed
+    local fail_exit=0
+    local fail_output
+    fail_output=$(
+        cd "$git_dir"
+        PATH="${tmp_dir}:${PATH}" \
+        HOME="${fake_home}" \
+        CFGMS_PROJECT_ITEM_ID="PVTI_testitem" \
+        CFGMS_TEST_PROJECT_QUEUE="$fail_pq" \
+        bash "$entrypoint_script" 999 2>&1
+    ) || fail_exit=$?
+
+    if [[ $fail_exit -eq 0 ]]; then
+        log_pass "entrypoint_set_pr_call: entrypoint exits 0 even when set-pr fails (non-fatal)"
+    else
+        log_fail "entrypoint_set_pr_call: entrypoint should exit 0 when set-pr fails, got ${fail_exit}"
+    fi
+
+    if echo "$fail_output" | grep -q "WARN"; then
+        log_pass "entrypoint_set_pr_call: entrypoint emits WARN when set-pr fails"
+    else
+        log_fail "entrypoint_set_pr_call: should emit WARN when set-pr fails (output: ${fail_output})"
+    fi
+}
+
 # Main execution
 echo "🔍 Script Validation Test Suite"
 echo "================================"
@@ -1610,6 +1969,14 @@ echo ""
 test_project_queue_set_pr
 echo ""
 test_create_clone_item
+echo ""
+test_agent_dispatch_create_clone_item
+echo ""
+test_cleanup_issue_item_mode
+echo ""
+test_review_pr_item_branch
+echo ""
+test_entrypoint_set_pr_call
 echo ""
 test_preflight_item_dispatch
 echo ""


### PR DESCRIPTION
## Summary

- `create-clone-item` in `agent-dispatch.sh` now deletes stale remote branches before cloning (same guard as `create-clone`)
- `review-pr` handles `feature/item-<LAST12>-agent` branches: PR-field scan then item_id-suffix scan; item-branch prompt uses `story:0` and item-mode cleanup
- `cleanup-issue` accepts non-numeric item_id: derives LAST12, removes `cfg-agent-item-<LAST12>` container and `item-<LAST12>` clone
- `entrypoint.sh` handles non-numeric `$1` as item mode: derives `ITEM_ID_SHORT` from `CFGMS_PROJECT_ITEM_ID`, adjusts prompt (branch name, commit suffix, no Fixes/Issue links)
- `entrypoint.sh` Phase 3: calls `set-pr CFGMS_PROJECT_ITEM_ID <pr_num>` after PR creation; non-fatal, skipped in fix-pr mode
- 4 new tests: `test_agent_dispatch_create_clone_item`, `test_cleanup_issue_item_mode`, `test_review_pr_item_branch`, `test_entrypoint_set_pr_call`

## Specialist Review Results

- **QA Test Runner**: PASS — 121 script tests, all Go packages, linting, security scans, cross-platform builds
- **QA Code Reviewer**: PASS — initial blocking issues (weak assertions, missing coverage for new paths) resolved in fix iteration
- **Security Engineer**: PASS — all security scans green; LAST12 derivation uses `tr -cd 'a-zA-Z0-9'` sanitizer preventing injection

## Test plan

- [ ] `bash scripts/test-scripts.sh` → 121 passed, 0 failed
- [ ] `make test-agent-complete` → all checks pass
- [ ] CI: unit-tests, integration-tests, Build Gate, security-deployment-gate

Fixes #1494