### PR TITLE
pipeline-security: route story creation through project drafts + decommission dead label code (Issue #1495)

### DIFF
--- a/.claude/agents/ba.md
+++ b/.claude/agents/ba.md
@@ -210,9 +210,9 @@ cat > /tmp/story-body.md <<'STORY_EOF'
 ...full story body...
 STORY_EOF
 
-# Create the story issue AND link as sub-issue (helper does both)
+# Create the story as a project draft item (not a GitHub issue)
 ./scripts/pipeline-helper.sh create-story <EPIC_NUM> "<scope>: <title>" /tmp/story-body.md
-# Output: CREATED:<NUM>:<URL> then LINKED:<NUM>:epic-<EPIC_NUM>
+# Output: CREATED_DRAFT:<item_id>
 
 rm /tmp/story-body.md
 ```

--- a/.claude/agents/po.md
+++ b/.claude/agents/po.md
@@ -100,7 +100,7 @@ Display sections in this order. **Omit any section with zero items.**
 
 **Section 1: NEEDS ATTENTION** — project items with `Blocked` status. Flag items older than 7 days as stale.
 
-**Section 2: MERGE DECISIONS** — PRs with `pipeline:review` label. Show QA verdict summary and CI status.
+**Section 2: MERGE DECISIONS** — Open PRs where `has_acceptance_review_comment: false` and CI is not failing (read from `review_recommendations` in the preflight output). Show QA verdict summary and CI status.
 
 **Section 3: ACTIVE MILESTONE** — current roadmap milestone, open item count, blockers.
 
@@ -430,8 +430,10 @@ Both gates are computed by the preflight script (`dispatch_recommendations` with
 
 For each story the preflight recommends dispatching:
 ```bash
-./.claude/scripts/po-act.sh dispatch <NUM>
+./.claude/scripts/po-act.sh dispatch <ITEM_ID>
 ```
+
+where `<ITEM_ID>` comes from `dispatch_recommendations[*].item_id` in the preflight output. Note: the `dispatch` subcommand handles both issue_nums (all-digits, legacy path) and item_ids (non-numeric) transparently — Story B wired this.
 
 **This step is intentionally last in priority order.** If the 5-container cap is exhausted by Steps 3-5 (rebase, review, fix-cycle), defer dispatch to the next cycle. Existing in-flight PRs unblock the merge queue, which is more valuable than starting more dev work that would just queue behind them.
 
@@ -473,25 +475,24 @@ The conversation follows this protocol:
 
 **Maximum 3 revision rounds.** A round = BA revises + Tech Lead re-reviews. After 3 rounds, any remaining REVISION NEEDED stories are resolved by PO decision: either accept with a PO note, or drop and document in a Blocked tracking issue (use `po-act.sh block`).
 
-**7f. Create stories on GitHub (after consensus):**
+**7f. Create stories in the project queue (after consensus):**
 
 Story bodies must conform to the parser spec in **Reference: Story Body Conventions** below — in particular the `## Dependencies` and `## Files In Scope` rules. Stories that fail those rules are flagged with `parse_warnings` and skipped by the dispatcher. Both classes of bug (prose-only Dependencies, parent-epic-as-dep) have surfaced repeatedly during decompositions; produce parser-compliant bodies on first try rather than relying on a Tech Lead fix-up step.
 
-Once all stories are APPROVED (or PO-decided), create them on GitHub. For each story:
+Once all stories are APPROVED (or PO-decided), create them in the project queue. For each story:
 ```bash
 cat > /tmp/story-body.md <<'STORY_EOF'
 <full story body from final agreed proposal>
 STORY_EOF
 
 ./scripts/pipeline-helper.sh create-story <EPIC_NUM> "<scope>: <title>" /tmp/story-body.md
+# Returns: CREATED_DRAFT:<item_id>
 rm /tmp/story-body.md
 ```
 
-Then immediately add each story to the project queue at Ready status (skipping Draft — the Tech Lead already validated them during the planning conversation):
+Then immediately mark each story as Ready (skipping Draft — the Tech Lead already validated them during the planning conversation):
 ```bash
-PROJECT_QUEUE="./scripts/project-queue.sh"
-item_id=$(bash "$PROJECT_QUEUE" add-issue <STORY_NUM> | python3 -c "import json,sys; print(json.load(sys.stdin)['item_id'])")
-bash "$PROJECT_QUEUE" update-field "$item_id" status "Ready"
+bash ./scripts/project-queue.sh update-field <item_id> status "Ready"
 ```
 
 **7g. Post summary on epic:**

--- a/.claude/scripts/po-cycle-preflight.py
+++ b/.claude/scripts/po-cycle-preflight.py
@@ -994,7 +994,7 @@ def main():
     )
 
     # Phase 2: parallel fetch of story bodies relevant to conflict detection.
-    # Conflict-detection set = agent:in-progress + stories with open PRs (files in flight
+    # Conflict-detection set = In Progress items + stories with open PRs (files in flight
     # until merge). Ready stories are always fetched for gating.
     # Issue-linked items use gh_issue_body; pure draft items use project-queue.sh get-item.
 

--- a/.github/workflows/label-decommission-gate.yml
+++ b/.github/workflows/label-decommission-gate.yml
@@ -22,6 +22,7 @@ jobs:
           #     prefixed with *, since those are documentation prose
           #   - The docs/ directory entirely (historical records are fine)
           #   - This workflow file itself (the pattern strings above are in a comment)
+          #   - scripts/test-scripts.sh (references patterns to test for their absence)
           matches=$(grep -rn \
             -E "pipeline:(draft|ready|fix|reviewing|epic|story|blocked)|agent:(ready|in-progress|failed|success)" \
             .claude/ scripts/ .devcontainer/ \
@@ -32,6 +33,7 @@ jobs:
             | grep -v "^docs/" \
             | grep -v "label-decommission-gate.yml" \
             | grep -v "scripts/migrate-queue-to-project.sh" \
+            | grep -v "scripts/test-scripts.sh" \
             || true)
 
           if [ -n "$matches" ]; then

--- a/scripts/migrate-queue-to-project.sh
+++ b/scripts/migrate-queue-to-project.sh
@@ -3,8 +3,8 @@
 # to GitHub Projects V2 substrate.
 #
 # Context: Story #1482 (pipeline-security: in-flight migration + decommission
-# pipeline/agent labels). This script was intended to migrate open
-# pipeline:draft and agent:ready issues to project items before label deletion.
+# pipeline/agent label system). This script was intended to migrate open
+# labeled issues to project items before label deletion.
 # Labels were already removed from the repo before this story ran, so at
 # execution time no labeled issues remain and this script is a verification
 # no-op.
@@ -22,27 +22,35 @@ echo ""
 
 # Step 1: Confirm pipeline/agent labels no longer exist
 echo "--- Step 1: Verify labels are absent ---"
-if gh label list --repo "$REPO" 2>/dev/null | grep -E "pipeline:|agent:" | grep -v "^$"; then
+if gh label list --repo "$REPO" 2>/dev/null | grep -E "^(pipeline|agent):" | grep -v "^$"; then
   echo "ERROR: pipeline:* or agent:* labels still exist. Delete them before running."
   echo "Run: gh label delete '<name>' --repo $REPO --yes"
   exit 1
 fi
 echo "OK: No pipeline:* or agent:* labels found."
 
-# Step 2: Verify no open issues carry the old labels
+# Step 2: Verify no open issues carry any remaining pipeline/agent labels
 echo ""
 echo "--- Step 2: Verify no labeled issues remain ---"
 
-# Since labels are deleted, these queries should return empty arrays
-for label in "pipeline:draft" "pipeline:ready" "pipeline:fix" "pipeline:reviewing" \
-             "pipeline:epic" "pipeline:story" "pipeline:blocked" \
-             "agent:ready" "agent:in-progress" "agent:failed" "agent:success"; do
+# Query for any surviving pipeline:/agent: labels dynamically so no label
+# names are hard-coded here (labels are decommissioned and no longer exist).
+# --jq '[.[].name]' wraps into a JSON array so json.load() parses it correctly.
+while IFS= read -r label; do
   count=$(gh issue list --repo "$REPO" --label "$label" --state open \
     --json number --jq 'length' 2>/dev/null || echo "0")
   if [ "${count}" != "0" ]; then
     echo "WARNING: $count open issue(s) still carry label '$label'"
   fi
-done
+done < <(gh label list --repo "$REPO" --json name --jq '[.[].name]' 2>/dev/null \
+  | python3 -c "
+import sys, json
+labels = json.load(sys.stdin)
+for l in labels:
+    if l.startswith('pipeline:') or l.startswith('agent:'):
+        print(l)
+" || true)
+
 echo "OK: No open issues with pipeline/agent labels."
 
 # Step 3: Verify project queue has items migrated

--- a/scripts/pipeline-helper.sh
+++ b/scripts/pipeline-helper.sh
@@ -15,7 +15,7 @@ usage() {
 Pipeline Helper — wraps gh CLI for subagent permission compatibility
 
 Story lifecycle:
-  create-story <epic_num> <title> <body_file>   Create story issue with story label and link to epic
+  create-story <epic_num> <title> <body_file>   Create story as a project draft item (not a GitHub issue)
   edit-body <issue_num> <body_file>              Replace issue body from file
   append-section <issue_num> <section> <file>    Append content after ## <section> heading
 
@@ -54,24 +54,13 @@ case "$cmd" in
       exit 1
     fi
 
-    # Create the story issue
-    story_url=$(gh issue create --repo "$REPO" \
-      --title "$title" \
-      --label "story" \
-      --body-file "$body_file")
+    PROJECT_QUEUE="$(cd "$(dirname "$0")/.." && pwd)/scripts/project-queue.sh"
 
-    story_num=$(echo "$story_url" | grep -oP '\d+$')
-    echo "CREATED:${story_num}:${story_url}"
-
-    # Link as sub-issue of epic
-    epic_id=$(gh issue view "$epic_num" --repo "$REPO" --json id -q .id)
-    child_id=$(gh issue view "$story_num" --repo "$REPO" --json id -q .id)
-    gh api graphql \
-      -f query='mutation($parentId: ID!, $childId: ID!) { addSubIssue(input: {issueId: $parentId, subIssueId: $childId}) { issue { number } subIssue { number } } }' \
-      -f parentId="$epic_id" \
-      -f childId="$child_id" > /dev/null
-
-    echo "LINKED:${story_num}:epic-${epic_num}"
+    # Create a project draft item (private; not a public GitHub issue).
+    # epic_num is passed as story_num — a traceability hint; 0 is acceptable too.
+    draft_json=$(bash "$PROJECT_QUEUE" create-draft "$epic_num" "$title" "$body_file")
+    item_id=$(echo "$draft_json" | python3 -c "import json,sys; print(json.load(sys.stdin)['item_id'])")
+    echo "CREATED_DRAFT:${item_id}"
     ;;
 
   edit-body)

--- a/scripts/test-scripts.sh
+++ b/scripts/test-scripts.sh
@@ -1236,6 +1236,48 @@ test_trust_boundary() {
     fi
 }
 
+test_no_pipeline_label_refs() {
+    log_test "Testing: no pipeline:* or agent:* label references in .claude/ or scripts/..."
+
+    local root
+    root="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/.."
+
+    # Falsifiability check: inject a prohibited label into a temp file and verify
+    # the grep pattern fires, so a broken grep doesn't silently always pass.
+    local tmp_dir
+    tmp_dir=$(mktemp -d)
+    trap 'rm -rf "$tmp_dir"' RETURN
+    printf '# prohibited: pipeline:story label reference\n' > "$tmp_dir/probe.sh"
+    local probe_matches
+    probe_matches=$(grep -rn \
+        "pipeline:story\|pipeline:draft\|pipeline:review\|pipeline:ready\|agent:ready\|agent:success\|agent:in-progress\|agent:failed" \
+        "$tmp_dir/" \
+        2>/dev/null) || true
+    if [[ -n "$probe_matches" ]]; then
+        log_pass "no_pipeline_label_refs: grep pattern correctly detects violations (falsifiability)"
+    else
+        log_fail "no_pipeline_label_refs: grep pattern failed to detect injected violation — grep is broken"
+        return
+    fi
+
+    # Real check: assert zero matches in the actual codebase directories.
+    local matches
+    matches=$(grep -rn \
+        "pipeline:story\|pipeline:draft\|pipeline:review\|pipeline:ready\|agent:ready\|agent:success\|agent:in-progress\|agent:failed" \
+        "${root}/.claude/" "${root}/scripts/" \
+        --exclude="test-scripts.sh" \
+        2>/dev/null) || true
+
+    if [[ -z "$matches" ]]; then
+        log_pass "no_pipeline_label_refs: zero prohibited label references in .claude/ and scripts/"
+    else
+        log_fail "no_pipeline_label_refs: found prohibited label references (remove them):"
+        while IFS= read -r line; do
+            echo "    $line"
+        done <<< "$matches"
+    fi
+}
+
 test_preflight_item_dispatch() {
     log_test "Testing po-cycle-preflight.py: project_queue_list_by_status includes pure draft items via CFGMS_TEST_PROJECT_QUEUE..."
 
@@ -1985,6 +2027,8 @@ echo ""
 test_preflight_forged_acceptance_review
 echo ""
 test_trust_boundary
+echo ""
+test_no_pipeline_label_refs
 echo ""
 echo ""
 echo "📊 Test Summary"


### PR DESCRIPTION
## Summary

- `scripts/pipeline-helper.sh` `create-story` now delegates to `project-queue.sh create-draft` instead of `gh issue create --label pipeline:story`. Outputs `CREATED_DRAFT:<item_id>`. Command signature unchanged so call sites do not break.
- `PROJECT_QUEUE` defined relative to script location per AC requirement.
- `.claude/agents/ba.md` updated: output comment changed to `CREATED_DRAFT:<item_id>`; prose updated to say "project draft item, not a GitHub issue".
- `.claude/agents/po.md` Step 7f: heading changed to "Create stories in the project queue"; two-step `add-issue + update-field` replaced with `update-field` after `create-story` returns `CREATED_DRAFT:<item_id>`.
- `.claude/agents/po.md` §4.1 Step 6: dispatch call updated to `po-act.sh dispatch <ITEM_ID>` with backward-compatibility note.
- `.claude/agents/po.md` §1.1 Section 2: `pipeline:review` label reference removed; replaced with `has_acceptance_review_comment: false` / CI-based description.
- `scripts/migrate-queue-to-project.sh`: label name literals removed; replaced with dynamic `[.[].name]` jq query (correct JSON array for python3 parsing).
- `.claude/scripts/po-cycle-preflight.py`: comment updated from `agent:in-progress` to `In Progress items`.
- `scripts/test-scripts.sh`: `test_no_pipeline_label_refs` added with falsifiability check + real grep asserting zero matches.

After this story: creating a story produces a private project item, not a public GitHub issue.

Fixes #1495

## Specialist Review Results

- **QA Test Runner**: PASS — 123 tests passed, 0 failed. `test_no_pipeline_label_refs` passes with falsifiability check.
- **QA Code Reviewer**: PASS (after fixes) — initial review found 2 blocking issues (json.load() bug in migrate script, missing falsifiability test); both fixed before merge.
- **Security Engineer**: PASS — no hardcoded secrets, no injection vectors, no central provider violations. `security-precommit`, `check-architecture`, `security-scan` all passed (DEPLOYMENT APPROVED).

## Test plan

- [x] `bash scripts/test-scripts.sh` — 123 tests, 0 failed
- [x] `grep -rn "pipeline:story\|pipeline:draft\|pipeline:review\|pipeline:ready\|agent:ready\|agent:success\|agent:in-progress\|agent:failed" .claude/ scripts/ --exclude=test-scripts.sh` — zero matches
- [x] `make test-agent-complete` — all gates passed
- [x] Cross-platform compilation: linux/amd64, linux/arm64, darwin/amd64, darwin/arm64, windows/amd64 ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)