### PR TITLE
docs: enrich operating-model docs with save=deploy, trust model, registration credentials (Epic #1500)

### DIFF
--- a/docs/architecture/controller-operating-model.md
+++ b/docs/architecture/controller-operating-model.md
@@ -149,11 +149,13 @@ The controller is the authoring and distribution point for steward cfgs. It does
 Author → Validate → Store → Distribute → Monitor Compliance
 ```
 
-1. **Author** — Cfgs are created or updated via REST API, workflow output, or direct storage edit
-2. **Validate** — Controller validates cfg syntax, module references, and tenant scoping before accepting
-3. **Store** — Cfg is persisted in durable, version-controlled storage. Every change is a new version with full audit trail
-4. **Distribute** — Controller pushes the cfg to the target steward(s) over the QUIC data plane. Cfgs are signed with the controller's signing certificate so stewards can verify authenticity
-5. **Monitor** — Controller receives convergence results from stewards and tracks per-device compliance status
+1. **Author** — Cfgs are created or updated via the `cfg` CLI (`cfg config upload`), the commercial web UI, a GitOps webhook, or workflow output. All sources write through the same ConfigStore — there is no separate "fast path".
+2. **Validate** — Controller validates cfg syntax, module references, and tenant scoping before accepting. Validation is part of the write path; an invalid cfg never lands in storage.
+3. **Store** — Cfg is persisted in durable, version-controlled ConfigStore. Every change is a new version with full audit trail.
+4. **Distribute** — A successful ConfigStore write triggers automatic distribution. A storage-watch trigger fires after a ~500ms debounce window (absorbing burst saves) and publishes fanout jobs to the controller's durable job queue. Fanout sends `CommandSyncConfig` to all stewards whose targeting matches; the job survives controller restarts and HA failover replay. Cfgs are signed with the controller's signing certificate so stewards can verify authenticity. Fanout is bounded by controller capacity (CPU, outbound bandwidth) to prevent thundering-herd saturation.
+5. **Monitor** — Controller receives convergence results from stewards and tracks per-device compliance status. Operators view propagation via `cfg config deployments <id>`.
+
+**Save = Deploy:** there is no separate "push" verb. Save IS deploy. See [system operating model — Save = Deploy](operating-model.md#save--deploy) for the cross-component view.
 
 ### Cfg Targeting
 
@@ -161,8 +163,12 @@ The controller decides which steward gets which cfg based on:
 
 - **Direct assignment** — a cfg explicitly targets a steward by ID
 - **Group membership** — a cfg targets a group; all stewards in that group receive it
+- **Tag-based targeting** — stewards can carry arbitrary tags (e.g., `ring=canary`, `role=web-server`, `region=us-east`); a cfg targets stewards by tag expression
+- **DNA-attribute matching** — a cfg can target stewards whose DNA attributes match a predicate (e.g., `os=linux`, `cpu_arch=arm64`)
 - **Tenant hierarchy** — cfgs inherit through the recursive tenant hierarchy (e.g., MSP → Client → Group → Device). Child tenants can override parent settings at any depth
 - **Effective cfg** — the controller resolves inheritance and produces the effective cfg for each steward, merging all applicable layers
+
+**Deployment rings (convention):** operators commonly tag stewards with ring identifiers (`ring=canary`, `ring=prod-early`, `ring=prod-broad`) and author phased rollouts as separate cfgs or staged target lists. v1 is convention; auto-progressive ring machinery (with bake time + health gating) is a future enhancement.
 
 ### Config Signing
 
@@ -212,7 +218,7 @@ The controller can send commands to stewards over the gRPC control plane service
 
 | Command | Purpose |
 |---------|---------|
-| `sync_config` | Tell steward to fetch its latest cfg now (optimization — steward also checks on schedule) |
+| `sync_config` | Tell steward to fetch its latest cfg now (optimization — steward also checks on schedule). Save=deploy automatically issues this command for affected stewards after a ConfigStore write. |
 | `sync_dna` | Request fresh DNA collection and upload |
 | `execute_script` | Run an ad-hoc script (outside the cfg) |
 
@@ -403,13 +409,32 @@ The workflow engine must support the following capabilities to fulfill its role 
 
 ### Steward Registration
 
-The controller is the certificate authority and identity provider for stewards:
+The controller is the certificate authority and identity provider for stewards. Two credential flavors support different deployment workflows:
 
-1. Admin creates a **registration token** via REST API (scoped to tenant/group, with expiry)
-2. Steward presents token during registration
-3. Controller validates token, generates steward ID, issues mTLS client certificate
-4. Controller distributes CA cert, signing cert, and connection details
-5. Steward is now a trusted member of the fleet
+**Short-lived / single-use registration tokens**
+- Generated via REST API or `cfg token create --expires=<duration> --single-use`
+- Scoped to tenant/group, with expiry
+- Consumed on use (single-use enforces one-time pairing; expiry enforces time bounds)
+- Suitable for: manual onboarding, small fleets, time-bounded provisioning
+
+**Long-lived tenant/group registration codes**
+- Durable random opaque strings stored as a join field on the tenant/group record
+- On registration, the controller looks up the code and assigns the steward to the matching tenant/group
+- Suitable for: RMM/GPO mass deployment where the same code is baked into deployment scripts and used by many devices
+- Renaming a tenant/group does not break previously issued codes (the code is independent of the human-readable name)
+
+**Registration flow:**
+
+1. Admin creates a token or code on the controller (scoped to tenant/group, with optional expiry for tokens).
+2. Steward presents the token/code during registration via the compile-time controller URL.
+3. Controller validates the credential — single-use: consume; long-lived code: look up matching record.
+4. Controller runs the registration approval workflow via `RegistrationApprovalHook`:
+   - **`auto-approve`** (development default): accepts immediately
+   - **`manual-review`** (production): pauses pending operator action via `cfg registration approve <id>` / `cfg registration deny <id> [--reason ...]`
+   - Custom workflows can implement arbitrary policy (e.g., approve `tenant=lab` registrations, manual-review everything else)
+5. On approval, controller generates the steward ID and issues an mTLS client certificate scoped to the steward's tenant/group identity.
+6. Controller distributes the CA cert, signing cert, and connection details.
+7. Steward is now a trusted member of the fleet and stores its cert for subsequent startups.
 
 ### RBAC
 
@@ -429,8 +454,27 @@ If a cache invalidation call fails transiently (e.g., transient error), the oper
 
 ### API Authentication
 
-- **API keys** — stored encrypted, used for programmatic access
-- **Registration tokens** — scoped, expirable tokens for steward bootstrap only
+Three authentication mechanisms, used for different purposes.
+
+**Admin mTLS bundle (primary operator path)**
+- Single-file YAML containing admin cert + key + CA inline
+- Generated on `--init` and written to a platform-default path:
+  - Linux/macOS: `/etc/cfgms/admin.bundle.yaml`
+  - Windows: `%ProgramData%\cfgms\admin.bundle.yaml`
+- The `cfg` CLI auto-discovers via: `--bundle <path>` flag → `CFGMS_ADMIN_BUNDLE` env → `~/.config/cfgms/admin.bundle.yaml` → system path
+- `cfgms-controller bootstrap-admin` manages bundles:
+  - Issue named bundles per operator (`bootstrap-admin --name <op> --output <path>`)
+  - Regenerate the system bundle (`bootstrap-admin --regenerate`)
+  - List issued bundles (`bootstrap-admin --list`)
+  - Revoke by serial (`bootstrap-admin --revoke <serial>`)
+
+**API keys (programmatic access)**
+- Stored encrypted, used for service-to-service integration and scripted automation
+- Scoped to specific permissions via RBAC
+
+**Registration tokens (steward bootstrap only)**
+- Scoped, expirable tokens for the steward registration flow described in [Steward Registration](#steward-registration)
+- Not usable for general API authentication after bootstrap
 
 ## Multi-Tenancy
 

--- a/docs/architecture/operating-model.md
+++ b/docs/architecture/operating-model.md
@@ -41,6 +41,53 @@ A cfg is a YAML file (`hostname.cfg`) that declares the desired state of a devic
 
 The cfg is the single source of truth for a steward. Whether it came from a local file or was pushed by a controller, the steward treats it the same way.
 
+## Core Primitives
+
+CFGMS is built from a small set of powerful primitives. New features compose existing primitives rather than introducing parallel mechanisms.
+
+- **Config management** — the cfg + steward convergence loop is the substrate for all device state management.
+- **Workflow engine** — handles cloud/SaaS desired-state, orchestration, and event-driven automation. Registration approval, drift response policies, and third-party integrations all express through workflows.
+- **Durable job queue (controller-side)** — fanout, retries, deferred operations, and HA failover replay all use the same queue. Survives controller restarts and leader failover.
+- **DNA** — deterministic, hashable representation of managed-object state. Underlies sync, drift detection, and compliance reporting.
+- **Central providers** (storage, logging, secrets, directory, transport) — pluggable interfaces. New backends extend an existing provider rather than introducing a parallel system.
+
+If a feature can use an existing primitive, that's the path. Building a parallel mechanism requires justification.
+
+## Save = Deploy
+
+Any source that writes a cfg to the controller's ConfigStore (CLI, web UI, GitOps webhook, workflow output) triggers automatic distribution to matched stewards. There is no separate "push" action — save IS deploy.
+
+```
+ ┌───────────────┐   write   ┌─────────────┐  storage-watch  ┌──────────┐
+ │ Author        │ ─────────▶│ ConfigStore │ ──────────────▶│  Fanout  │
+ │ (CLI/UI/Hook) │           │ (durable)   │ debounce ~500ms │ (queue)  │
+ └───────────────┘           └─────────────┘                 └─────┬────┘
+                                                                   ▼
+                                                            ┌──────────────┐
+                                                            │  Stewards    │
+                                                            │  (converge   │
+                                                            │   on next hb)│
+                                                            └──────────────┘
+```
+
+- **Single write path.** All sources write to ConfigStore via the same path.
+- **Debounce.** Storage-watch waits ~500ms (configurable) before triggering fanout. Absorbs burst edits invisibly.
+- **Durable queue.** Fanout uses the controller's durable job queue — the same primitive used for retries, deferred operations, and HA failover replay.
+- **Idempotency carries load.** A steward already at the target DNA hash treats a sync command as a no-op.
+- **Resource-bounded fanout.** Fanout is bounded by controller capacity (CPU, outbound bandwidth) to prevent thundering-herd saturation.
+
+Stewards' own heartbeat-driven loops also notice config divergence via DNA hash mismatch — the fanout command is an optimization on top of that steady-state loop, not a dependency for correctness.
+
+## Safety Primitives
+
+Safety against bad configs comes from operator-controllable primitives:
+
+- **Targeting precision** — a cfg explicitly lists which stewards / groups / tenant paths / DNA-attributes it applies to. A bad change is bounded by what it was authored to target.
+- **Deployment rings (convention)** — steward tags (`ring=canary`, `ring=prod-early`, `ring=prod-broad`) let operators author phased rollouts as separate configs or staged target lists. v1 is convention; auto-progressive ring machinery is a future enhancement.
+- **Deployment visibility** — `cfg config deployments <id>` shows applied / pending / failed / halted counts and per-steward status.
+- **E-stop (planned)** — `cfg config halt <id>` cancels remaining queued sends for a config.
+- **Rollback (planned CLI; underlying infrastructure exists)** — restore a previous cfg version via `features/controller/api/rollback_handler.go`.
+
 ## Component Roles
 
 ### Steward
@@ -53,6 +100,15 @@ The steward is a daemon that maintains a device in the state described by its cf
 2. **Maintain** — Re-check compliance on the schedule defined in the cfg. In `apply` mode, correct any drift. In `monitor` mode, report drift. Respond to module-defined event hooks (e.g., file change triggers re-check of that resource)
 3. **Know itself** — Collect DNA (hardware, software, network, security attributes). Monitor its own health and performance
 4. **Report** — Always log locally. When connected to a controller, also report events, status, and DNA upstream. When disconnected, queue reports locally and resync on reconnect
+
+**Apply mode vs Monitor mode (configurable per steward):**
+
+- **`apply` mode** (default for managed devices): the steward actively converges the device to match its cfg. When drift is detected, the steward attempts local convergence and reports the outcome as a single combined message containing `{drift_detected, drift_setting, convergence_result, final_state}` — one message per drift event.
+- **`monitor` mode**: the steward detects drift but does not act. Emits a non-compliance event upstream; operator action (or a separate `apply` workflow) decides whether to correct.
+
+Mode is set in steward configuration. A single steward operates in one mode at a time across all its managed resources. Per-resource override is not in scope for v1.
+
+Controller-side logging captures both the drift event and convergence result regardless of mode — flapping detection can be added later without wire-protocol changes.
 
 These four behaviors are the same regardless of deployment mode. The only difference between standalone and controller-connected is **where the cfg comes from** and **where reports go**.
 
@@ -115,6 +171,28 @@ Controller                              Steward
 Both planes use the unified **gRPC-over-QUIC** transport (port 4433, mTLS). All controller-steward communication flows over a single multiplexed QUIC connection with distinct gRPC services for control and data operations.
 
 The controller can tell a steward to sync its cfg immediately (e.g., after an admin pushes a change). But the steward also re-checks on its own schedule. The command is an optimization, not a dependency.
+
+### Trust Model
+
+mTLS for all controller↔steward traffic, with three layers of identity.
+
+**Controller identity is anchored at build time.**
+The steward binary is built with the controller's URL compiled in (`-ldflags="-X main.ControllerURL=..."`). Scope: per controller (or controller cluster), not per tenant. One steward binary serves all tenants the controller manages.
+
+**Steward identity is established at registration.**
+Two credential flavors:
+
+- **Short-lived / single-use registration tokens** — manual onboarding, small fleets, time-bounded provisioning. Generated on the controller, handed to the steward as a string. Consumed at registration; expiry enforces time bounds.
+- **Long-lived tenant/group registration codes** — RMM/GPO mass deployment. Same string-on-the-wire pattern, baked into deployment scripts and reused by many devices. Encodes tenant/group target.
+
+Both flow through the controller's registration approval workflow. Built-in: `auto-approve` (development default) and `manual-review` (production). Custom workflows implement arbitrary policy via the workflow engine.
+
+**Admin identity is a single-file mTLS bundle.**
+On `--init`, the controller writes the bundle to a known path:
+- Linux/macOS: `/etc/cfgms/admin.bundle.yaml`
+- Windows: `%ProgramData%\cfgms\admin.bundle.yaml`
+
+YAML containing cert + key + CA inline. The `cfg` CLI auto-discovers via: `--bundle <path>` → `CFGMS_ADMIN_BUNDLE` env → `~/.config/cfgms/admin.bundle.yaml` → system path. `cfgms-controller bootstrap-admin` issues named bundles per operator, regenerates the system bundle, lists issued bundles, and revokes by serial.
 
 ### Outpost (Future)
 
@@ -187,6 +265,18 @@ controller ← admin authors workflows
 ```
 
 This is the same controller — it just has no stewards registered. The workflow engine operates independently of steward management.
+
+## UX Surfaces
+
+Operators interact with CFGMS through layered UX surfaces.
+
+**`cfg` CLI — first-class community UI.** The canonical interaction surface for the open-source distribution. Every documented operator action works through the CLI. The CLI wraps REST endpoints so operators don't need to script against REST for documented workflows.
+
+**Web UI — commercial layer (planned before v1).** A separate UX layer in the commercial distribution. Targets operators who prefer graphical workflows or shared-team views. Some power-user flows may remain CLI-only.
+
+**REST API — underlying contract.** The wire format the CLI and web UI both use. Stable, versioned, and documented at `docs/api/rest-api.md`. Available to operators and integrators for scripting and third-party tools.
+
+**Workflow engine — automation surface.** For SaaS/cloud operations that don't require a steward (M365, identity providers, ticketing systems), the workflow engine is the primary expression mechanism. See [controller operating model](controller-operating-model.md#workflow-engine).
 
 ## Monitoring Export Credentials
 

--- a/docs/architecture/steward-operating-model.md
+++ b/docs/architecture/steward-operating-model.md
@@ -101,6 +101,17 @@ Failed resources are reported individually — a failure on one resource does no
 
 Every convergence run must be safe to repeat. Modules implement Get/Set such that applying a cfg that is already converged results in zero changes. This is fundamental — the scheduled re-check depends on it.
 
+### Drift Modes
+
+The cfg's `mode` field selects how the steward responds to drift detected during convergence or scheduled re-checks:
+
+- **`apply` mode** (default for managed devices): the steward attempts local convergence and reports the outcome as a single combined message containing `{drift_detected, drift_setting, convergence_result, final_state}` — one message per drift event. The controller sees the drift and its resolution together.
+- **`monitor` mode**: the steward detects drift but does not act. Emits a non-compliance event upstream; operator action (or a separate `apply` workflow) decides whether to correct.
+
+Mode is set at the steward level (`steward.mode` in the cfg) — a single steward operates in one mode at a time across all its managed resources. Per-resource override is not in scope for v1.
+
+Controller-side logging captures both the drift event and convergence result regardless of mode, enabling flapping detection (a future enhancement) without wire-protocol changes.
+
 ## Modules
 
 Modules are the code packages that manage resources. Each resource block in the cfg references a module by name and provides module-specific configuration.
@@ -123,13 +134,16 @@ Compare and Verify are performed by the execution engine (not the module) — it
 
 ### Event Hooks
 
-Modules can optionally implement the `Monitor` interface to watch for real-time changes to their managed resources. The monitor provides a `Changes()` channel that emits `ChangeEvent` values (created, modified, deleted, permissions changed).
+Modules **should, when possible, implement the `Monitor` interface** to watch for real-time changes to their managed resources. The monitor provides a `Changes()` channel that emits `ChangeEvent` values (created, modified, deleted, permissions changed). When a change event fires, it triggers a convergence check for that specific resource rather than waiting for the next scheduled run — near-real-time drift correction for critical resources.
 
-For example:
-- The `file` module watches for filesystem changes to managed files
-- The `service` module monitors service state changes
+Some resources don't have a feasible event-source (no OS-level watcher, no vendor API hook); those modules fall back to the scheduled re-check interval (`steward.converge_interval`). Event-driven Monitor support is preferred and should be added where the underlying platform permits it.
 
-When a change event fires, it triggers a convergence check for that specific resource rather than waiting for the next scheduled run. This provides near-real-time drift correction for critical resources.
+Current adoption (as of v0.9.x):
+
+- **Implemented**: `activedirectory` module
+- **Polling-only (no Monitor yet)**: `file`, `directory`, `script`, `firewall`, `package`, `patch`
+
+Adding `Monitor` support to additional modules is an ongoing enhancement, prioritized by user impact (security-sensitive resources benefit most from event-driven detection).
 
 ## Self-Awareness
 
@@ -263,7 +277,14 @@ These behaviors require an active controller connection and are not available in
 
 ### Cfg Delivery
 
-The controller pushes cfg updates to the steward over the gRPC data plane service. Cfgs are signed by the controller's signing certificate — the steward verifies the signature before applying, ensuring cfgs cannot be tampered with in transit or injected by a rogue source. The steward stores the verified cfg locally and triggers a convergence run. If the connection is later lost, the steward continues using the last-received cfg.
+The steward receives new cfgs via two paths, both arriving over the gRPC data plane service:
+
+- **Controller-initiated sync** — after a save-IS-deploy ConfigStore write on the controller, the controller fans out a `CommandSyncConfig` to the steward, prompting it to fetch the new cfg immediately.
+- **Heartbeat-driven discovery** — every heartbeat carries the steward's current cfg version. If the controller's view diverges (newer cfg available), the next heartbeat response triggers the same sync path.
+
+Either path lands the same outcome: the steward fetches the new cfg, verifies the controller's signature, stores it locally, and triggers a convergence run. Cfgs are signed by the controller's signing certificate — the steward verifies the signature before applying, ensuring cfgs cannot be tampered with in transit or injected by a rogue source.
+
+If the controller connection is later lost, the steward continues using the last-received cfg.
 
 ### Ad-Hoc Script Execution
 
@@ -286,15 +307,41 @@ The steward participates in multi-node operations coordinated by the controller 
 
 How a steward joins a controller.
 
-1. Administrator creates a **registration token** on the controller (via REST API)
-2. Steward is started with `--regtoken <token>`
-3. Steward contacts controller, submits token
-4. Controller validates token, provisions steward identity, issues mTLS certificates
-5. Steward stores certificates locally and establishes a gRPC-over-QUIC transport connection
-6. Steward checks for a cfg from the controller
-7. Normal operation begins
+### Controller Anchor (Build Time)
 
-The `--regtoken` flag must be supplied each time the steward starts — there is no stored-certificate resume path in the current implementation. Every invocation re-registers via HTTP and receives fresh mTLS certificates from the controller.
+The steward binary is built with the controller's URL compiled in at link time (`-ldflags="-X main.ControllerURL=..."`). A given steward binary will only ever talk to its compile-time controller. Scope: per controller (or controller cluster), not per tenant — one steward binary serves all tenants the controller manages.
+
+A steward binary today connects to exactly one controller URL. Multi-controller deployments — where a steward might fail over between geographically distributed controllers (e.g., `east.cfg.ms`, `west.cfg.ms`) — are not yet supported. [GAP: multi-controller / subdomain-matching binary support — see issue #1517]
+
+### Registration Credentials
+
+Two credential flavors, both flow through the same registration API:
+
+1. **Short-lived / single-use registration tokens** — generated on the controller via `cfg token create --expires=<duration> --single-use`. Suitable for manual onboarding, small fleets, or time-bounded provisioning windows. The token is consumed on use; expiry enforces time bounds.
+2. **Long-lived tenant/group registration codes** — durable, non-single-use random opaque strings stored as a join field on the controller's tenant/group record. Suitable for RMM/GPO mass deployment where the same code is baked into a deployment script and reused by many devices. On registration the controller looks up the code in its records and assigns the steward to the matching tenant/group; the code itself carries no meaning, so renames of the tenant/group don't break previously issued codes.
+
+The administrator chooses which flavor fits the deployment workflow. Both arrive at the steward as a plain string passed via `--regtoken <token>` (or `cfgms-steward install --regtoken <token>` for the OS-service install).
+
+### Registration Flow
+
+1. Administrator creates a registration token or code on the controller.
+2. Steward is started with `--regtoken <token>`.
+3. Steward contacts its compile-time controller URL (HTTPS), submits the token.
+4. Controller validates the token (single-use: consume; long-lived code: look up the matching tenant/group record), applies the registration approval workflow (`auto-approve` or `manual-review`), and on approval issues mTLS certificates scoped to the steward's tenant/group identity.
+5. Steward stores its issued cert + node ID locally and establishes a gRPC-over-QUIC transport connection.
+6. Steward checks for a cfg from the controller.
+7. Normal operation begins.
+
+On subsequent startups the steward reuses its stored mTLS cert — no re-registration required unless the cert expires or is revoked. Cert renewal is automatic via the certificate manager.
+
+### Approval Workflow
+
+Registration approval runs through the controller's workflow engine via the `RegistrationApprovalHook`. Built-in workflows:
+
+- **`auto-approve`** (development default): accepts any valid token immediately.
+- **`manual-review`** (production): pauses the registration workflow pending operator action via `cfg registration approve <id>` or `cfg registration deny <id>`.
+
+Operators can also write custom workflows that implement arbitrary policy (e.g., auto-approve `tenant=lab` registrations, manual-review everything else).
 
 ### Bootstrap TLS Trust
 


### PR DESCRIPTION
## Summary

Pre-Wave-1 enrichment for Epic #1500 — adds founder-confirmed design decisions to the three operating-model docs so the docs become the unambiguous source of truth before the doc-audit stories begin dispatching.

### Why this lands before Wave 1

During planning, a review of the existing operating-model docs revealed several design decisions captured only in memory + the methodology comment on #1500, not in the docs themselves: save=deploy specifics, apply/monitor single-message reporting, the two registration credential flavors, the admin mTLS bundle workflow, the CLI-as-community-UI principle, and others. Without enrichment first, agents auditing the docs against code would have no clear authority for "this should be in the doc but isn't" cases.

This PR closes that gap directly so Wave 1 audits run against complete, authoritative ground truth.

### What changed

**`docs/architecture/operating-model.md` (+90 lines)** — 5 new sections + 1 subsection expansion:
- `## Core Primitives` — config management, workflow engine, durable job queue, DNA, central providers. Establishes the "compose existing primitives" preference.
- `## Save = Deploy` — single write path through ConfigStore, debounce, durable queue fanout, resource-bounded (not safety-throttled). Includes ASCII flow diagram.
- `## Safety Primitives` — targeting, deployment rings (convention), visibility, e-stop (planned), rollback (planned CLI).
- `### Trust Model` (within Component Roles) — three identity layers: compile-time controller URL, two registration credential flavors, admin mTLS bundle with auto-discovery chain.
- `## UX Surfaces` — CLI as first-class community UI, web UI as commercial layer planned before v1, REST as underlying contract, workflow engine for SaaS automation.
- Expands Apply/Monitor one-liners in the Steward role into a proper subsection documenting the single-message auto-correct reporting flow.

**`docs/architecture/steward-operating-model.md` (+61 lines net)**:
- `### Drift Modes` (new subsection under Convergence Loop) — formalizes apply vs monitor mode.
- `### Event Hooks` rewrite — Monitor is preferred-when-possible (not merely optional); current adoption list (AD implemented; file/directory/script/firewall/package/patch use polling).
- `## Registration` restructured into four subsections:
  - Controller Anchor (Build Time) — compile-time URL trust + multi-controller gap [GAP: see #1517]
  - Registration Credentials — short-lived/single-use tokens AND long-lived tenant/group join codes (random opaque strings, looked up at registration — rename-safe)
  - Registration Flow — corrected to reflect cert-resume on subsequent startups
  - Approval Workflow — auto-approve / manual-review + custom workflow option with `cfg registration approve/deny` CLI
- Expands Cfg Delivery to document both delivery paths (controller-initiated CommandSyncConfig fanout + heartbeat-driven discovery).

**`docs/architecture/controller-operating-model.md` (+59 lines net)**:
- Expands Cfg Lifecycle with save=deploy mechanics (storage-watch + debounce + durable queue + resource-bounded fanout, link to system-level Save=Deploy).
- Expands Cfg Targeting with tag-based targeting, DNA-attribute matching, and deployment rings as convention.
- Updates Commands table so `sync_config` notes save=deploy issues it automatically.
- Rewrites Steward Registration to cover both credential flavors + the full approval-workflow surface.
- Rewrites API Authentication to document the admin mTLS bundle as primary operator path (YAML format, platform defaults, `cfg` auto-discovery chain, `cfgms-controller bootstrap-admin` operations).

### New gap issue filed alongside

- #1517 — steward: multi-controller / failover binary support. Referenced as `[GAP: see #1517]` in the steward doc's Controller Anchor subsection.

## Test plan

- [x] All three modified docs render as valid markdown (visual inspection of structure + section outline)
- [x] No fictional CLI commands introduced — every command reference verified during drafting against `cmd/cfg/cmd/` and `cmd/controller/main.go`
- [x] No fictional REST endpoints introduced
- [x] Cross-links between the three docs use the existing relative-path convention
- [x] `git grep "CFGMS_HTTP_CA_CERT_PATH"` and similar config-name references remain consistent with current code
- [x] ASCII diagram in Save=Deploy section renders correctly in code-block context

Doc-only PR — no code changes, no test execution required. CI doc-only stub jobs should complete in <2 minutes per CLAUDE.md.

## Relationship to #1500

This PR does NOT close #1500. The epic remains open for the 12 sub-stories (#1504-#1516) that audit and enhance the rest of the doc tree. Wave-1 audit stories now have an unambiguous source-of-truth target.

🤖 Generated with [Claude Code](https://claude.com/claude-code)