### PR TITLE
docs: audit steward-operating-model.md against current code (Issue #1505)

### DIFF
--- a/docs/architecture/steward-operating-model.md
+++ b/docs/architecture/steward-operating-model.md
@@ -14,11 +14,10 @@ The steward is a daemon that maintains a device in the state described by its cf
 ### Startup
 
 1. **Load cfg** — Find and parse the `hostname.cfg` file (local file, or last-known cfg from controller)
-2. **Discover modules** — Scan module paths, load available modules, validate that all modules referenced in the cfg are available
-3. **Initial convergence** — Evaluate every resource in the cfg immediately (apply or monitor, depending on mode)
-4. **Start convergence schedule** — Begin the compliance re-check loop at the interval defined by `converge_interval` in the cfg (default: 30 minutes)
-5. **Collect DNA** — Gather device identity and attributes (hardware, software, network, security)
-6. **Connect to controller** (if configured) — Establish a gRPC-over-QUIC transport connection. Check for cfg updates
+2. **Discover modules** — Scan module paths and register available modules. Modules referenced in the cfg are loaded on-demand during convergence (not validated at startup)
+3. **Initial convergence** — Evaluate every resource in the cfg immediately (apply or monitor, depending on mode) [GAP: apply/monitor toggle not yet wired — see issue #1519; current code always applies changes]
+4. **Start convergence schedule** — Begin the compliance re-check loop at the interval defined by `converge_interval` in the cfg (default: 30 minutes). DNA is collected as part of each convergence run (not a separate startup step)
+5. **Connect to controller** (if configured) — Establish a gRPC-over-QUIC transport connection. Check for cfg updates
 
 ### Normal Operation
 
@@ -77,7 +76,7 @@ Get → Compare → Set → Verify
 
 1. **Get**: Call `module.Get()` to read current state from the system
 2. **Compare**: Engine compares current state against desired state from the cfg (using `StateComparator`)
-3. **Set**: If drifted and in `apply` mode, call `module.Set()` to converge
+3. **Set**: If drifted and in `apply` mode, call `module.Set()` to converge [GAP: apply/monitor toggle not yet wired — see issue #1519; current code always calls Set when drift is detected]
 4. **Verify**: Call `module.Get()` again to confirm the change took effect
 
 **In `apply` mode:**
@@ -88,12 +87,17 @@ Get → Compare → Set → Verify
 - If current matches desired: report compliant
 - If drifted: report drift (skip Set and Verify, no changes made)
 
+[GAP: apply/monitor toggle not implemented — `steward.mode` in the cfg currently controls connectivity mode (standalone/controller), not drift behavior. The execution engine always calls Set() when drift is detected regardless of mode. See issue #1519]
+
 ### Error Handling
 
-Controlled by the cfg's `error_handling` settings:
+Controlled by the cfg's `error_handling` settings (three independent fields: `module_load_failure`, `resource_failure`, `configuration_error`):
 
-- **continue** (default): Log the error, skip the failed resource, process remaining resources
-- **fail**: Stop execution on the first error
+- **continue**: Log the error, skip the failed resource, process remaining resources
+- **warn** (default for `resource_failure`): Log a warning, skip the failed resource, continue with remaining resources
+- **fail** (default for `configuration_error`): Stop execution on the first error
+
+The default for `resource_failure` is `warn` (not `continue`). `module_load_failure` defaults to `continue`; `configuration_error` defaults to `fail`.
 
 Failed resources are reported individually — a failure on one resource does not mask the status of others.
 
@@ -111,6 +115,8 @@ The cfg's `mode` field selects how the steward responds to drift detected during
 Mode is set at the steward level (`steward.mode` in the cfg) — a single steward operates in one mode at a time across all its managed resources. Per-resource override is not in scope for v1.
 
 Controller-side logging captures both the drift event and convergence result regardless of mode, enabling flapping detection (a future enhancement) without wire-protocol changes.
+
+[GAP: apply/monitor toggle not implemented — the `steward.mode` cfg field currently accepts `standalone` or `controller` (connectivity mode), not `apply` or `monitor`. A separate `drift_mode` field (or renamed `mode` field) needs to be added. The execution engine always applies changes when drift is detected regardless of any mode setting. See issue #1519]
 
 ## Modules
 
@@ -140,8 +146,8 @@ Some resources don't have a feasible event-source (no OS-level watcher, no vendo
 
 Current adoption (as of v0.9.x):
 
-- **Implemented**: `activedirectory` module
-- **Polling-only (no Monitor yet)**: `file`, `directory`, `script`, `firewall`, `package`, `patch`
+- **Implemented**: none [GAP: `network_activedirectory` module has a `Monitor()` method stub but it does not satisfy the `modules.Monitor` interface (wrong return type, always returns an error, missing `Changes()` and correctly-signed `Close()` methods, `GetCapabilities()` reports `supports_monitor: false`). See issue #1520]
+- **Polling-only (no Monitor yet)**: `activedirectory`, `file`, `directory`, `script`, `firewall`, `package`, `patch`
 
 Adding `Monitor` support to additional modules is an ongoing enhancement, prioritized by user impact (security-sensitive resources benefit most from event-driven detection).
 
@@ -328,11 +334,11 @@ The administrator chooses which flavor fits the deployment workflow. Both arrive
 2. Steward is started with `--regtoken <token>`.
 3. Steward contacts its compile-time controller URL (HTTPS), submits the token.
 4. Controller validates the token (single-use: consume; long-lived code: look up the matching tenant/group record), applies the registration approval workflow (`auto-approve` or `manual-review`), and on approval issues mTLS certificates scoped to the steward's tenant/group identity.
-5. Steward stores its issued cert + node ID locally and establishes a gRPC-over-QUIC transport connection.
+5. Steward imports the issued cert into its local `cert.Manager` (stored under the platform cert dir) for use in TLS handshakes, records the node ID, and establishes a gRPC-over-QUIC transport connection.
 6. Steward checks for a cfg from the controller.
 7. Normal operation begins.
 
-On subsequent startups the steward reuses its stored mTLS cert — no re-registration required unless the cert expires or is revoked. Cert renewal is automatic via the certificate manager.
+On every subsequent startup the steward re-registers via the same HTTP REST endpoint — HTTP registration is called on every invocation and there is no stored-certificate resume path that skips it. The cert stored by `cert.Manager` is used for TLS handshakes within the session but does not replace the HTTP registration call.
 
 ### Approval Workflow
 
@@ -374,7 +380,7 @@ The steward binary is the same in every deployment. The table below shows which 
 | Behavior | Standalone | Controller-Connected |
 |----------|------------|---------------------|
 | Load and parse cfg | Local file | Pushed by controller, stored locally |
-| Convergence loop (apply/monitor) | Yes | Yes |
+| Convergence loop (apply/monitor) [GAP: toggle not wired, see #1519] | Yes | Yes |
 | Scheduled re-check (`converge_interval`) | Yes | Yes (default 30m until cfg received) |
 | Event hooks | Yes | Yes |
 | DNA collection | Yes | Yes |


### PR DESCRIPTION
## Summary

Audits `docs/architecture/steward-operating-model.md` against the steward binary's actual behavior. Every substantive claim in the 396-line document was verified against `features/steward/steward.go`, `cmd/steward/main.go`, the execution engine, DNA package, client transport, offline queue, registration client, and the module interface.

Fixes #1505

## Changes

### 1. Startup sequence corrected
- **Step 2**: modules are loaded on-demand during convergence (`ExecuteResource()` → `factory.CreateModuleInstance()`), not validated at startup.
- **Step 5 (DNA) removed**: DNA collection happens inside `runConvergence()` → `detectUnmanagedDNADrift()` — not a separate startup phase.

### 2. Apply/monitor mode — GAP #1519 markers added
- `StewardSettings.Mode` accepts `"standalone"`/`"controller"` (connectivity mode), not `"apply"`/`"monitor"`. No drift-behavior mode field exists.
- The execution engine (`executor.go`) always calls `module.Set()` when drift is detected — no mode guard present.
- GAP markers placed in 5 locations. Issue #1519 filed.

### 3. Error handling — `warn` action added, defaults corrected
- `warn` is the third action type (doc previously listed only `continue` and `fail`).
- Default for `resource_failure` is `warn`, not `continue` (verified in `applyDefaults()`).

### 4. Monitor interface for activedirectory — GAP #1520 marker added
- `network_activedirectory.Monitor()` has wrong return type, always returns an error, and `GetCapabilities()` reports `supports_monitor: false`.
- Changed "Implemented: activedirectory" → "Implemented: none". Moved activedirectory to polling-only list. Issue #1520 filed.

### 5. Registration flow — "subsequent startups reuse cert" claim removed
- `registerAndConnect()` always calls `httpClient.Register()` on every startup — there is no stored-cert resume path.
- This contradicted the accurate Entry Paths table statement ("Registration is called on every invocation"). The contradiction is resolved.

## Verified accurate (no changes needed)
- DNA hash in every heartbeat (`DNAHash` field in `cpTypes.Heartbeat`) ✓
- `GetConvergeInterval()` with 30m default ✓
- Offline queue (AES-256-GCM, ordered, 1000 cap, 24h TTL) ✓
- `CFGMS_HTTP_CA_CERT_PATH` bootstrap TLS trust ✓
- File-only logging, `CFGMS_LOG_LEVEL` / `CFGMS_LOG_DIR` ✓
- Controller URL compiled in via `-ldflags` ✓
- 4 entry paths with `--regtoken` precedence ✓
- `sync_config` as optimization-only trigger ✓
- GAP #1517 (multi-controller) already present ✓

## Specialist Review Results

| Specialist | Result |
|------------|--------|
| QA Code Reviewer | **PASS** — documentation-only change, no Go code modified, GAP markers properly formatted with issue numbers |
| Security Engineer | **PASS** — security-precommit, check-architecture, security-scan all pass |
| QA Test Runner | **PASS** (one pre-existing flaky test in `features/monitoring` unrelated to this change; passes consistently in isolation) |

## Gap Issues Filed
- [#1519](https://github.com/cfg-is/cfgms/issues/1519) — implement apply/monitor drift behavior toggle
- [#1520](https://github.com/cfg-is/cfgms/issues/1520) — network_activedirectory Monitor interface implementation