### PR TITLE
docs: audit docs/architecture/ non-triad sub-docs against current code (Issue #1507)

### DIFF
--- a/docs/architecture/communication-layer-migration.md
+++ b/docs/architecture/communication-layer-migration.md
@@ -52,7 +52,7 @@ The unified transport is configured via the `transport` block in `controller.cfg
 transport:
   listen_addr: "0.0.0.0:4433"   # Single port for all controller-steward traffic
   use_cert_manager: true          # Use controller's cert manager for TLS (recommended)
-  max_connections: 10000          # Maximum concurrent steward connections
+  max_connections: 50000          # Maximum concurrent steward connections
   keepalive_period: 30s           # How often keepalive probes are sent
   idle_timeout: 5m                # Connection idle timeout
 ```
@@ -63,7 +63,7 @@ transport:
 |----------|-------------|---------|
 | `CFGMS_TRANSPORT_LISTEN_ADDR` | Transport listen address | `0.0.0.0:4433` |
 | `CFGMS_TRANSPORT_USE_CERT_MANAGER` | Use cert manager for TLS | `true` |
-| `CFGMS_TRANSPORT_MAX_CONNECTIONS` | Maximum concurrent connections | `10000` |
+| `CFGMS_TRANSPORT_MAX_CONNECTIONS` | Maximum concurrent connections | `50000` |
 | `CFGMS_TRANSPORT_KEEPALIVE_PERIOD` | Keepalive probe interval | `30s` |
 | `CFGMS_TRANSPORT_IDLE_TIMEOUT` | Connection idle timeout | `5m` |
 

--- a/docs/architecture/ha-commercial-split.md
+++ b/docs/architecture/ha-commercial-split.md
@@ -37,6 +37,8 @@ All HA code is located in `commercial/ha/` with Go build tags controlling which 
   - Basic health checking
   - No clustering functionality
   - Compiles by default (without build tags)
+- `config_oss.go` - OSS-only configuration stubs
+- `manager_oss_test.go` - Tests for OSS stub behaviour
 
 **Commercial Only** (`//go:build commercial`):
 
@@ -45,13 +47,11 @@ All HA code is located in `commercial/ha/` with Go build tags controlling which 
 - `health.go` - Health checking implementation
 - `raft_consensus.go` - Raft-based consensus
 - `raft_transport.go` - Raft HTTP transport
-- `discovery.go` - Node discovery
 - `failover.go` - Automatic failover
-- `load_balancer.go` - Load balancing
-- `session_sync.go` - Session synchronization
 - `split_brain.go` - Split-brain detection
+- `types.go` - HA-specific type definitions
 - `manager_test.go` - HA manager tests
-- All implementation files requiring clustering
+- `raft_consensus_test.go`, `raft_transport_test.go`, `failover_test.go`, `split_brain_test.go` - Tests
 
 **Commercial HA Integration Tests** (`//go:build commercial`):
 

--- a/docs/architecture/modules/README.md
+++ b/docs/architecture/modules/README.md
@@ -32,9 +32,12 @@ modules/
 ## Available Modules
 
 - `directory` - Directory creation and permissions
-- `file` - File content and attributes  
+- `file` - File content and attributes
 - `firewall` - Firewall rules and policies
 - `package` - Software package management
+- `acme` - ACME/Let's Encrypt certificate management
+- `activedirectory` - Active Directory integration
+- `m365/*` - Microsoft 365 modules (auth, conditional access, Entra groups/users/apps/admin units, Intune policy, GDAP)
 
 ## Documentation
 

--- a/docs/architecture/modules/interface.md
+++ b/docs/architecture/modules/interface.md
@@ -6,9 +6,8 @@ This document defines the standard interface that all CFGMS modules must impleme
 
 The module interface provides a consistent way for CFGMS to interact with modules, ensuring that all modules behave in a predictable and reliable manner. The interface is designed to be simple yet powerful, allowing modules to be developed independently and integrated seamlessly into the CFGMS workflow.
 
-For information about module lifecycle management, see [Module Lifecycle](lifecycle.md).
-For information about module security requirements, see [Module Security Requirements](security.md).
-For information about module testing requirements, see [Module Testing Requirements](testing.md).
+For module system overview and available modules, see [Module System](README.md).
+For steward configuration and error handling, see [Steward Configuration](../steward-configuration.md).
 
 ## Core Interface
 
@@ -255,6 +254,16 @@ func compareConfigurations(current, desired ConfigState) bool {
 - **Flexibility**: Comparison algorithms can be improved system-wide
 - **Safety**: Drift detection prevents unnecessary Set operations
 
+## Optional Configurable Interface
+
+Modules that require initialization from operator config before `Get()` can safely read the current resource state may implement `Configurable`. The execution engine calls `Configure(desiredState)` before `Get()` when the module implements this interface, allowing security boundaries to be established without modifying any files.
+
+```go
+type Configurable interface {
+    Configure(config ConfigState) error
+}
+```
+
 ## Optional Monitor Interface
 
 While not part of the core Module interface, modules may optionally implement monitoring capabilities for real-time configuration drift detection:
@@ -263,20 +272,20 @@ While not part of the core Module interface, modules may optionally implement mo
 // Monitor interface for modules that support real-time monitoring
 type Monitor interface {
     // Monitor watches for changes to a resource and triggers events
-    Monitor(ctx context.Context, resourceID string, configData string) error
-    
+    Monitor(ctx context.Context, resourceID string, config ConfigState) error
+
     // Changes returns a channel for receiving change notifications
     Changes() <-chan ChangeEvent
-    
+
     // Close stops monitoring and releases resources
     Close() error
 }
 
 type ChangeEvent struct {
     ResourceID string
-    Timestamp  time.Time
+    Timestamp  int64      // Unix timestamp (nanoseconds)
     ChangeType ChangeType
-    Details    string // YAML describing the change
+    Details    ConfigState
 }
 
 type ChangeType int
@@ -426,11 +435,8 @@ Modules should use the provided context for cancellation and timeout:
 
 ## Related Documentation
 
-- [Module Lifecycle](lifecycle.md): How modules are loaded, initialized, and managed
-- [Module Core Principles](core-principles.md): Fundamental principles that guide module design
-- [Module Security Requirements](security.md): Security considerations for module implementation
-- [Module Testing Requirements](testing.md): Testing standards and requirements for modules
-- [Standalone Steward Architecture](standalone-steward.md): Complete architecture for standalone operation
+- [Module System Overview](README.md): Available modules and module structure
+- [Steward Configuration](../steward-configuration.md): Configuration file format and error handling settings
 
 ## Version Information
 

--- a/docs/architecture/plugin-architecture.md
+++ b/docs/architecture/plugin-architecture.md
@@ -20,26 +20,31 @@ Based on CFGMS's documented "Pluggable Infrastructure Design Paradigm":
 
 ## Directory Structure
 
+Storage interfaces are organized into five sub-packages (the five-type taxonomy from ADR-003):
+
 ```
 pkg/
-├── storage/                   # Global storage system
-│   ├── interfaces/           # Storage contracts (used by all modules)
-│   │   ├── client_tenant.go # MSP client tenant storage interface
-│   │   ├── config.go        # Configuration storage interface
-│   │   └── audit.go         # Audit log storage interface
-│   └── providers/           # Storage implementations (controller selects one)
-│       ├── memory/
-│       │   ├── plugin.go    # Plugin registration
-│       │   ├── client_tenant.go
-│       │   ├── config.go
-│       │   └── audit.go
-│       ├── file/
-│       ├── database/
-│       └── git/
+├── storage/
+│   ├── interfaces/           # Storage contracts (used by all features)
+│   │   ├── business/         # Business data: TenantStore, ClientTenantStore,
+│   │   │                     #   StewardStore, CommandStore, AuditStore,
+│   │   │                     #   RBACStore, SessionStore, RegistrationTokenStore,
+│   │   │                     #   TriggerStore, PushStore, DNAHistoryStore
+│   │   ├── config/           # ConfigStore — human-editable configs
+│   │   ├── blob/             # BlobStore — installer binaries, script bodies
+│   │   ├── secrets/          # SecretStore — credentials, API keys
+│   │   └── timeseries/       # MetricsStore, LogStore — append-only metrics
+│   └── providers/            # Storage implementations (one per type)
+│       ├── sqlite/           # Business data OSS default
+│       ├── flatfile/         # Config + audit OSS default
+│       ├── database/         # PostgreSQL (commercial/SaaS)
+│       └── blobstore/
+│           ├── filesystem/   # Blob storage OSS default
+│           └── s3/           # Blob storage commercial/SaaS
 features/
-├── controller/              # Controller configures global storage
-├── modules/m365/auth/       # Uses pkg/storage/interfaces only
-└── modules/firewall/        # Uses pkg/storage/interfaces only
+├── controller/               # Controller wires storage providers
+├── modules/m365/auth/        # Uses pkg/storage/interfaces only
+└── modules/firewall/         # Uses pkg/storage/interfaces only
 ```
 
 ## Implementation Pattern
@@ -110,7 +115,7 @@ func (p *DatabaseProvider) CreateAuditStore(config map[string]interface{}) (inte
 }
 
 func (p *DatabaseProvider) Description() string {
-    return "In-memory storage for development and testing"
+    return "PostgreSQL-backed storage for production and commercial deployments"
 }
 
 // Salt-style auto-registration
@@ -143,63 +148,37 @@ func NewAdminConsentFlow(clientStore interfaces.ClientTenantStore) *AdminConsent
 
 ### Step 4: Controller-Level Storage Configuration
 
+Storage is configured per data type (five-type composition). See [Storage Architecture](storage-architecture.md) for the full reference.
+
 ```yaml
-# cfgms.yaml - Controller configuration
+# cfgms.yaml - Controller configuration (OSS example)
 controller:
   storage:
-    provider: memory  # Single choice for ALL storage needs
+    business:
+      provider: sqlite
+      config:
+        path: /var/lib/cfgms/business.db
     config:
-      # Provider-specific config
-      database_url: postgresql://...  # for database provider
-      file_path: /var/lib/cfgms       # for file provider  
-      git_repository: https://...     # for git provider
+      provider: flatfile
+      config:
+        root: /var/lib/cfgms/configs
+    secrets:
+      provider: sops
+      config:
+        root: /var/lib/cfgms/secrets
+    timeseries:
+      provider: filelog
+      config:
+        root: /var/lib/cfgms/timeseries
+    blobs:
+      provider: filesystem
+      config:
+        root: /var/lib/cfgms/blobs
 ```
 
-```go
-// features/controller/storage.go
-type StorageManager struct {
-    provider          interfaces.StorageProvider
-    clientTenantStore interfaces.ClientTenantStore
-    configStore       interfaces.ConfigStore
-    auditStore        interfaces.AuditStore
-}
+The actual `StorageManager` in `pkg/storage/interfaces` composes providers for each data type. Features receive the specific store interface they need — they never import providers directly.
 
-func NewStorageManager(providerName string, config map[string]interface{}) (*StorageManager, error) {
-    // Get the configured provider
-    provider, err := interfaces.GetStorageProvider(providerName)
-    if err != nil {
-        return nil, fmt.Errorf("storage provider '%s' not available: %v", providerName, err)
-    }
-    
-    // Create ALL storage interfaces from the same provider
-    clientStore, err := provider.CreateClientTenantStore(config)
-    if err != nil {
-        return nil, err
-    }
-    
-    configStore, err := provider.CreateConfigStore(config)
-    if err != nil {
-        return nil, err
-    }
-    
-    auditStore, err := provider.CreateAuditStore(config)
-    if err != nil {
-        return nil, err
-    }
-    
-    return &StorageManager{
-        provider:          provider,
-        clientTenantStore: clientStore,
-        configStore:       configStore,
-        auditStore:        auditStore,
-    }, nil
-}
-
-// Modules get injected with the specific interface they need
-func (sm *StorageManager) GetClientTenantStore() interfaces.ClientTenantStore {
-    return sm.clientTenantStore
-}
-```
+See `pkg/storage/interfaces/provider.go` for the `StorageManager` and `CreateOSSStorageManager` wiring.
 
 ## Plugin Discovery and Management
 
@@ -210,25 +189,31 @@ cfg plugins list storage
 ```
 
 ```
-Available Storage Plugins:
-  ✅ memory      - In-memory storage (development/testing)
-  ✅ file        - Local file storage (simple deployments)
-  ❌ database    - PostgreSQL storage (requires: postgresql client)
-  ❌ git         - Git-based storage (requires: git, mozilla-sops)
+Available Storage Plugins (business data):
+  ✅ sqlite      - SQLite storage (OSS default)
+  ✅ database    - PostgreSQL storage (requires: postgresql client)
+
+Available Storage Plugins (config storage):
+  ✅ flatfile    - Flat-file storage (OSS default)
+  ✅ database    - PostgreSQL storage (commercial/SaaS)
+
+Available Storage Plugins (blob storage):
+  ✅ filesystem  - Local filesystem (OSS default)
+  ✅ s3          - S3-compatible object storage
 ```
 
 ### Runtime Plugin Information
 
 ```go
-// Get all available plugins
-available := interfaces.GetAvailableStoragePlugins()
+// Get all registered storage providers
+available := interfaces.GetRegisteredProviders()
 
-// Check specific plugin
-plugin, err := interfaces.GetStoragePlugin("database")
+// Check specific provider by name
+provider, err := interfaces.GetStorageProvider("sqlite")
 if err != nil {
-    log.Printf("Database plugin unavailable: %v", err)
-    // Fall back to file storage
-    plugin, _ = interfaces.GetStoragePlugin("file")
+    log.Printf("SQLite provider unavailable: %v", err)
+    // Fall back to database provider
+    provider, _ = interfaces.GetStorageProvider("database")
 }
 ```
 
@@ -255,15 +240,19 @@ func TestStoragePluginCompliance(t *testing.T) {
 
 ### Business Logic Testing
 
+Business logic tests use real CFGMS provider implementations (e.g. SQLite for business data, flat-file for config storage) — never in-memory substitutes or mocks. The pluggable interface makes it trivial to inject the appropriate real provider in tests:
+
 ```go
 // features/modules/m365/auth/admin_consent_test.go
 func TestAdminConsentFlow(t *testing.T) {
-    // Use any available storage plugin
-    plugin, _ := interfaces.GetStoragePlugin("memory")
-    store, _ := plugin.Create(nil)
-    
-    flow := NewAdminConsentFlow(store)
-    // Test business logic without caring about storage implementation
+    // Use a real storage provider (sqlite) — no mocks or in-memory substitutes
+    provider, err := interfaces.GetStorageProvider("sqlite")
+    require.NoError(t, err)
+    bundle, err := provider.OpenBusinessStores(t.TempDir() + "/test.db")
+    require.NoError(t, err)
+
+    flow := NewAdminConsentFlow(bundle.ClientTenant)
+    // Test business logic with a real provider; isolation via t.TempDir()
 }
 ```
 
@@ -327,26 +316,30 @@ func CreateStorageFromConfig(backendType string, config map[string]interface{}) 
 
 ## Architecture Summary
 
-### Key Concept: Global Storage Decision
+### Key Concept: Five-Type Storage Composition
 
-- **Controller** chooses ONE storage provider for the entire system
-- **All modules** use the same storage backend automatically  
-- **Users** configure storage once at the controller level
-- **No per-module storage decisions** - everything is consistent
+Per [ADR-003](decisions/003-storage-data-taxonomy.md), storage is split into five independent data types. Each type is configured with its own provider — there is no single global storage backend.
+
+- **Business data** (tenants, RBAC, sessions, commands, audit): `sqlite` (OSS), `database`/PostgreSQL (commercial)
+- **Config storage** (templates, policies, firewall rules): `flatfile` (OSS), `database`/PostgreSQL (commercial)
+- **Secrets** (credentials, certificates): `sops` (OSS), key vault (commercial)
+- **Timeseries** (metrics, logs): local files (OSS), ClickHouse/Timescale (commercial)
+- **Blobs** (installers, script bodies): `filesystem` (OSS), `s3` (commercial)
 
 ### Configuration Flow
 
 ```
-cfgms.yaml (controller.storage.provider: "database")
+cfgms.yaml (controller.storage.* with per-type providers)
     ↓
-Controller creates DatabaseProvider 
-    ↓  
-All storage interfaces use database:
-  ├── ClientTenantStore → PostgreSQL tables
-  ├── ConfigStore → PostgreSQL tables  
-  └── AuditStore → PostgreSQL tables
+Controller creates one provider per data type:
+  ├── business.provider: sqlite  → SQLite tables for tenants, RBAC, etc.
+  ├── config.provider: flatfile  → Flat files for human-editable configs
+  ├── secrets.provider: sops     → SOPS-encrypted files
+  ├── timeseries.provider: filelog → Append-only log files
+  └── blobs.provider: filesystem → Local filesystem blobs
     ↓
-Modules get injected with interfaces (don't know it's PostgreSQL)
+Modules get injected with the specific interface they need
+(don't know which backend serves it)
 ```
 
 ## Benefits
@@ -363,12 +356,15 @@ Modules get injected with interfaces (don't know it's PostgreSQL)
 
 Current implementations following this pattern:
 
-- **Storage Backends**: DNA storage (interfaces.go + backends.go)
-- **Compression**: GZIP, ZSTD, LZ4 compressors
-- **Git Providers**: GitHub, GitLab, Bitbucket integration
+- **Business data**: `pkg/storage/providers/sqlite` (TenantStore, ClientTenantStore, AuditStore, RBACStore, SessionStore, CommandStore, StewardStore, RegistrationTokenStore, TriggerStore, PushStore)
+- **Config storage**: `pkg/storage/providers/flatfile` (ConfigStore, AuditStore, StewardStore)
+- **Blob storage**: `pkg/storage/providers/blobstore/filesystem` and `blobstore/s3`
+- **PostgreSQL**: `pkg/storage/providers/database` (business + config stores for commercial)
+- **Git sync**: `pkg/gitsync` — optional read-only import from external git repos into ConfigStore
+- **Control/data plane**: `pkg/controlplane/providers/grpc`, `pkg/dataplane/providers/grpc`
+- **Secrets**: `pkg/secrets` (SOPS-based for OSS)
+- **Logging**: `pkg/logging` (file, timescale)
 
-Future implementations:
-
-- **MSP Client Storage**: Memory, File, Git, Database backends
+Future:
 - **KMS Providers**: Vault, AWS KMS, Azure Key Vault
-- **Database Providers**: PostgreSQL, MySQL, SQLite adapters
+- **Timeseries backends**: ClickHouse, InfluxDB, Timescale

--- a/docs/architecture/rollback-design.md
+++ b/docs/architecture/rollback-design.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-This document outlines the design for implementing configuration rollback capabilities in CFGMS. The rollback system integrates with the Git backend to provide reliable, auditable, and safe configuration rollback functionality.
+This document outlines the design for implementing configuration rollback capabilities in CFGMS. The rollback system integrates with the durable storage layer (`ConfigStore`, `CommandStore`, `AuditStore`) to provide reliable, auditable, and safe configuration rollback functionality. Note: the git storage backend was removed in Issue #664; rollback points are version IDs in the config store, not git commit SHAs.
 
 ## Goals
 
@@ -10,7 +10,7 @@ This document outlines the design for implementing configuration rollback capabi
 2. **Audit Trail**: Maintain complete audit trail of all rollback operations
 3. **Safety Checks**: Implement validation to prevent dangerous rollbacks
 4. **Multi-Level Support**: Support rollback at device, group, client, and MSP levels
-5. **Integration**: Seamless integration with Git backend and existing module system
+5. **Integration**: Seamless integration with config storage and existing module system
 
 ## Architecture
 
@@ -20,7 +20,7 @@ This document outlines the design for implementing configuration rollback capabi
 
 Central component that orchestrates rollback operations:
 
-- Interfaces with Git backend to retrieve historical configurations
+- Interfaces with `ConfigStore` to retrieve historical configuration versions
 - Validates rollback safety and dependencies
 - Coordinates with Steward for configuration deployment
 - Maintains rollback audit logs
@@ -128,11 +128,11 @@ graph TD
 
 ### Integration Points
 
-1. **Git Backend Integration**
-   - Retrieve historical configurations
-   - Create rollback commits
-   - Maintain version history
-   - Support branch-based rollbacks
+1. **Storage Integration**
+   - Rollback points are persisted in `CommandStore` and `AuditStore` (durable business-data stores)
+   - Historical configurations are retrieved from `ConfigStore`
+   - The git storage backend was removed in Issue #664; rollback history is now durable storage-backed, not git-commit-based
+   - See [Storage Architecture](storage-architecture.md) for the current five-type storage model
 
 2. **Module System Integration**
    - Module-aware rollback
@@ -163,7 +163,7 @@ Response:
 {
   "rollback_points": [
     {
-      "commit_sha": "abc123",
+      "version_id": "abc123",
       "timestamp": "2024-07-29T10:00:00Z",
       "author": "john.doe",
       "message": "Update firewall rules",
@@ -194,8 +194,8 @@ Response:
     "changes": [
       {
         "path": "firewall.yaml",
-        "current_version": "def456",
-        "rollback_version": "abc123",
+        "current_version_id": "def456",
+        "rollback_version_id": "abc123",
         "diff": "...",
         "risk": "low"
       }
@@ -272,8 +272,8 @@ CREATE TABLE rollback_operations (
     target_type VARCHAR(50) NOT NULL,
     target_id VARCHAR(255) NOT NULL,
     rollback_type VARCHAR(50) NOT NULL,
-    from_commit VARCHAR(40) NOT NULL,
-    to_commit VARCHAR(40) NOT NULL,
+    from_version VARCHAR(255) NOT NULL,
+    to_version VARCHAR(255) NOT NULL,
     initiated_by VARCHAR(255) NOT NULL,
     initiated_at TIMESTAMP NOT NULL,
     completed_at TIMESTAMP,
@@ -351,7 +351,7 @@ CREATE TABLE rollback_validations (
 ### Performance Considerations
 
 1. **Efficient History Retrieval**
-   - Indexed Git operations
+   - Indexed queries against `ConfigStore` and `CommandStore`
    - Caching of recent configurations
    - Pagination of rollback points
    - Optimized diff generation
@@ -377,7 +377,7 @@ CREATE TABLE rollback_validations (
    - Database operations
 
 2. **Integration Tests**
-   - Git backend integration
+   - Config storage integration (ConfigStore, CommandStore, AuditStore)
    - Module system interaction
    - Steward communication
    - End-to-end workflows
@@ -399,7 +399,7 @@ CREATE TABLE rollback_validations (
 ### Phase 1: Core Rollback (Week 1)
 
 - Implement RollbackManager
-- Basic Git integration
+- ConfigStore integration for version history retrieval
 - Simple rollback operations
 - Unit tests
 

--- a/docs/architecture/steward-configuration.md
+++ b/docs/architecture/steward-configuration.md
@@ -10,37 +10,39 @@ The Steward searches for configuration files in the following priority order:
 
 1. **Command-line specified**: `--config /path/to/hostname.cfg`
 2. **Environment variable**: `CFGMS_CONFIG=/path/to/hostname.cfg`
-3. **Default locations**:
-   - `./<hostname>.cfg` (current directory)
-   - `/etc/cfgms/<hostname>.cfg` (Linux/macOS)
-   - `C:\ProgramData\cfgms\<hostname>.cfg` (Windows)
+3. **Default locations** (searched in order per platform):
+   - `./<hostname>.cfg` (current working directory — all platforms)
+   - Linux: `/etc/cfgms/<hostname>.cfg`, `/usr/local/etc/cfgms/<hostname>.cfg`, `~/.config/cfgms/<hostname>.cfg`, `~/.cfgms/<hostname>.cfg`
+   - macOS: `/Library/Application Support/cfgms/<hostname>.cfg`, `/usr/local/etc/cfgms/<hostname>.cfg`, `~/Library/Application Support/cfgms/<hostname>.cfg`, `~/.cfgms/<hostname>.cfg`
+   - Windows: `%PROGRAMDATA%\cfgms\<hostname>.cfg`, `%USERPROFILE%\.cfgms\<hostname>.cfg`
 
 ## Configuration Format
 
 ```yaml
 # hostname.cfg - Steward standalone configuration
 steward:
-  name: "hostname-steward"
-  log_level: "info"
-  
-  # Module discovery paths (searched in order)
+  id: "hostname-steward"
+  mode: "standalone"               # "standalone" or "controller"
+
+  # Logging settings
+  logging:
+    level: "info"                  # "debug", "info", "warn", or "error"
+    format: "text"                 # "text" or "json"
+
+  # Module discovery paths (searched in order, in addition to built-in paths)
   module_paths:
     - "./modules"
     - "/opt/cfgms/modules"          # Linux/macOS
     - "C:\\Program Files\\cfgms\\modules"  # Windows
-  
+
+  # How often the steward re-converges against the cfg (default: 30m)
+  converge_interval: "30m"
+
   # Error handling behavior
   error_handling:
-    module_load_failure: "continue"        # "continue" or "fail"
-    config_validation_failure: "fail"      # "fail" or "continue"
-    runtime_error_behavior: "continue"     # "continue" or "fail"
-  
-  # Execution settings
-  execution:
-    mode: "apply"                    # "apply", "check", or "drift"
-    timeout: "300s"                  # Default operation timeout
-    retry_attempts: 3                # Number of retry attempts for transient errors
-    retry_delay: "5s"               # Delay between retry attempts
+    module_load_failure: "continue"   # "continue", "warn", or "fail"
+    resource_failure: "warn"          # "continue", "warn", or "fail"
+    configuration_error: "fail"       # "continue", "warn", or "fail"
 
 # Resource configurations
 resources:
@@ -114,34 +116,36 @@ resources:
 
 **Basic Settings:**
 
-- `name`: Unique identifier for this Steward instance
-- `log_level`: Logging verbosity (`debug`, `info`, `warn`, `error`)
+- `id`: Unique identifier for this Steward instance (defaults to the system hostname)
+- `mode`: Operation mode — `standalone` (local config files) or `controller` (connected to controller)
+
+**Logging:**
+
+- `logging.level`: Logging verbosity (`debug`, `info`, `warn`, `error`); default `info`
+- `logging.format`: Log output format (`text` or `json`); default `text`
 
 **Module Discovery:**
 
-- `module_paths`: List of directories to search for modules (searched in order)
+- `module_paths`: Additional directories to search for modules beyond built-in locations
+
+**Convergence:**
+
+- `converge_interval`: How often the steward re-converges against the config (e.g. `30m`, `5m`, `1h`); default `30m`
 
 **Error Handling:**
 
 - `module_load_failure`: How to handle module loading failures
   - `continue`: Skip failed modules, continue with available ones (default)
+  - `warn`: Log a warning and continue
   - `fail`: Stop execution if any module fails to load
-- `config_validation_failure`: How to handle configuration validation errors
+- `resource_failure`: How to handle errors during resource execution
+  - `continue`: Continue with remaining resources after errors
+  - `warn`: Log a warning and continue (default)
+  - `fail`: Stop execution on any resource error
+- `configuration_error`: How to handle configuration validation errors
   - `fail`: Stop execution on validation errors (default)
+  - `warn`: Log a warning and continue
   - `continue`: Skip invalid configurations, process valid ones
-- `runtime_error_behavior`: How to handle runtime errors during execution
-  - `continue`: Continue with remaining modules after errors (default)
-  - `fail`: Stop execution on any runtime error
-
-**Execution Settings:**
-
-- `mode`: Execution mode
-  - `apply`: Execute Set operations to achieve desired state (default)
-  - `check`: Execute Get operations and compare (dry-run)
-  - `drift`: Execute Get operations to detect configuration drift
-- `timeout`: Default timeout for module operations
-- `retry_attempts`: Number of retry attempts for transient errors
-- `retry_delay`: Delay between retry attempts
 
 ### Resources Section
 
@@ -159,17 +163,24 @@ The `resources` section contains an array of resource configurations. Each resou
 
 ## Platform-Specific Considerations
 
-### Linux/macOS
+### Linux
 
-- Configuration files stored in `/etc/cfgms/`
-- Modules installed in `/opt/cfgms/modules/`
+- System config path: `/etc/cfgms/<hostname>.cfg`
+- Module paths: `/opt/cfgms/modules/`
+- Use forward slashes in paths
+- Owner/group settings supported for file and directory modules
+
+### macOS
+
+- System config path: `/Library/Application Support/cfgms/<hostname>.cfg`
+- Module paths: `/opt/cfgms/modules/` or custom `module_paths`
 - Use forward slashes in paths
 - Owner/group settings supported for file and directory modules
 
 ### Windows
 
-- Configuration files stored in `C:\ProgramData\cfgms\`
-- Modules installed in `C:\Program Files\cfgms\modules\`
+- System config path: `C:\ProgramData\cfgms\<hostname>.cfg`
+- Module paths: `C:\Program Files\cfgms\modules\`
 - Use double backslashes in paths: `"C:\\path\\to\\file"`
 - Limited owner/group support (owner only)
 
@@ -188,7 +199,7 @@ The Steward validates configuration files on startup:
 
 ```yaml
 steward:
-  name: "web-server-01"
+  id: "web-server-01"
 
 resources:
   - name: "web-dir"
@@ -202,16 +213,16 @@ resources:
 
 ```yaml
 steward:
-  name: "dev-machine"
-  log_level: "debug"
+  id: "dev-machine"
+  logging:
+    level: "debug"
   module_paths:
     - "./local-modules"
     - "./modules"
+  converge_interval: "5m"
   error_handling:
     module_load_failure: "fail"
-    config_validation_failure: "fail"
-  execution:
-    mode: "check"  # Dry-run mode for development
+    configuration_error: "fail"
 
 resources:
   - name: "dev-tools"
@@ -225,6 +236,5 @@ resources:
 
 ## Related Documentation
 
-- [Standalone Steward Architecture](modules/standalone-steward.md): Complete architecture overview
 - [Module Interface](modules/interface.md): Module interface and ConfigState details
-- [Module Development](modules/development.md): Guide for developing new modules
+- [Module System](modules/README.md): Available modules overview

--- a/docs/architecture/storage-architecture.md
+++ b/docs/architecture/storage-architecture.md
@@ -280,7 +280,7 @@ Blobs are large, immutable artifacts: installer binaries, script bodies, report 
 
 ### Interface
 
-`pkg/storage/interfaces/blob_store.go` defines the `BlobStore` interface and associated types:
+`pkg/storage/interfaces/blob/blob_store.go` defines the `BlobStore` interface and associated types:
 
 ```go
 // BlobKey uniquely identifies a blob within CFGMS.

--- a/docs/architecture/template-engine-design.md
+++ b/docs/architecture/template-engine-design.md
@@ -34,7 +34,7 @@ This document outlines the design for the CFGMS configuration template engine. T
 
 ### Data Flow
 
-1. **Template Definition** → Stored in Git (MSP global or client repo)
+1. **Template Definition** → Stored in `ConfigStore` (optionally synced from external git via `pkg/gitsync`)
 2. **Value Resolution** → Merge inheritance + DNA + external data
 3. **Template Execution** → Render with security sandbox
 4. **Validation** → Check output before deployment
@@ -418,12 +418,12 @@ test_cases:
 
 ## Integration Points
 
-### With Git Backend (Story #74)
+### With Config Storage
 
-- Templates stored in Git repositories
-- Version control for template evolution
-- Template discovery and loading
-- Cross-repository template references
+- Templates stored in `ConfigStore` (flat-file for OSS, PostgreSQL for commercial)
+- Git is available as an *optional sync source* for admin-designated config scopes via `pkg/gitsync` (see [Storage Architecture](storage-architecture.md))
+- Template discovery and loading via the config store API
+- The git storage backend was removed in Issue #664; the older "Story #74 git backend" reference is superseded
 
 ### With Rollback (Story #75)
 


### PR DESCRIPTION
## Summary

Audited all 12 `docs/architecture/` sub-docs in scope for Issue #1507 against current code, applying the standard Epic #1500 methodology.

- 3 files left unchanged (already accurate): `git-backend-design.md` (DEPRECATED notice correct), `hybrid-storage-solution.md` (redirect stub), `workflow-debug-system.md` (matches `features/workflow/` implementation)
- 9 files corrected (see below)

Fixes #1507

## Findings by File

### communication-layer-migration.md
- **max_connections default**: `10000` → `50000` (matches `features/controller/config/config.go` `DefaultConfig()` and env vars table)

### steward-configuration.md (multiple schema errors)
- `name:` → `id:` (YAML tag on `StewardSettings.ID`)
- `log_level: "info"` → `logging: { level, format }` struct
- `config_validation_failure` → `configuration_error` (actual field name)
- `runtime_error_behavior` → `resource_failure` (actual field name; also adds `warn` as valid value)
- Removed non-existent `execution:` block (mode/timeout/retry don't exist in config struct; actual `mode` is `standalone`/`controller`)
- Added `converge_interval` field (present in code, missing from doc)
- Corrected macOS search paths (code uses `/Library/Application Support/cfgms/`, not `/etc/cfgms/`)
- Removed dangling cross-references to non-existent files

### modules/interface.md (Monitor interface mismatches)
- `Monitor(ctx, resourceID, configData string)` → `Monitor(ctx, resourceID string, config ConfigState)` (matches `module.go:48`)
- `ChangeEvent.Timestamp: time.Time` → `int64` (matches `module.go:60`)
- `ChangeEvent.Details: string` → `ConfigState` (matches `module.go:62`)
- Added `Configurable` interface (exists in `module.go:41-43`, was absent from doc)
- Removed dangling cross-references (lifecycle.md, security.md, testing.md don't exist)

### storage-architecture.md
- Blob interface path: `pkg/storage/interfaces/blob_store.go` → `pkg/storage/interfaces/blob/blob_store.go`

### ha-commercial-split.md
- Removed non-existent files: `discovery.go`, `load_balancer.go`, `session_sync.go`
- Added actually-existing files: `types.go`, `config_oss.go`, `manager_oss_test.go`, test files

### plugin-architecture.md (multiple structural errors — pre-ADR-003)
- Directory structure updated to five-type taxonomy (`business/`, `config/`, `blob/`, `secrets/`, `timeseries/`)
- Provider names: `memory`→`sqlite`, `file`→`flatfile`, `git` removed (Issue #664)
- Architecture summary: "one provider for all" is superseded by five-type composition
- Config example updated to per-type provider config
- Testing example: in-memory plugin prescription replaced with real `sqlite` provider + `require.NoError`
- `DatabaseProvider.Description()` corrected (said "in-memory storage" for a DB provider)

### modules/README.md
- Added missing modules: `acme`, `activedirectory`, `m365/*` (previously listed only 4 of ~10 modules)

### rollback-design.md (git backend references throughout)
- Removed git backend from overview, goals, integration points, performance section, testing strategy, Phase 1
- `commit_sha` → `version_id` in API examples (rollback points are config-store version IDs, not git SHAs)
- `from_commit`/`to_commit` → `from_version`/`to_version` in schema

### template-engine-design.md
- "Stored in Git repositories" → stored in `ConfigStore`; git available as optional sync source via `pkg/gitsync`

## Specialist Review Results

| Reviewer | Result |
|----------|--------|
| qa-test-runner | ✅ PASS — all unit/integration/compilation gates pass; docs-only diff, no regressions |
| qa-code-reviewer | ✅ PASS — all blocking issues from initial review resolved (mock pattern removed, git contradictions removed, dangling references fixed) |
| security-engineer | ✅ PASS — no hardcoded secrets, no insecure patterns, no central provider violations |

🤖 Generated with [Claude Code](https://claude.com/claude-code)