### PR TITLE
docs: audit docs/modules/*.md against module implementations (Issue #1511)

### DIFF
--- a/docs/modules/directory.md
+++ b/docs/modules/directory.md
@@ -4,6 +4,21 @@
 
 The Directory Module manages filesystem directories on CFGMS-managed endpoints. It creates and configures directories while enforcing a security boundary through the required `allowed_base_path` field. Every OS call is routed through `pkg/security.ValidateAndCleanPath` to prevent path traversal attacks.
 
+## Implementation References
+
+- Schema: [`features/modules/directory/module.yaml`](../../features/modules/directory/module.yaml)
+- Implementation: [`features/modules/directory/module.go`](../../features/modules/directory/module.go)
+
+## Platform Support
+
+| Platform | State management | Unix permissions | Ownership (`owner`/`group`) | Windows ACL |
+|----------|-----------------|------------------|-----------------------------|-------------|
+| Linux    | ✓ | ✓ (mode bits) | ✓ (`uid`/`gid` via `os.Chown`) | — |
+| macOS    | ✓ | ✓ (mode bits) | ✓ (`uid`/`gid` via `os.Chown`) | — |
+| Windows  | ✓ | — (returns error if set; use `windows_acl`) | — | ✓ (NTFS DACL) |
+
+> **Note:** `Set()` always creates or ensures the directory. Directory deletion is not implemented — `Set()` does not read the `state` field and will not delete a directory even if `state: absent` is passed.
+
 ## Table of Contents
 
 - [Quick Start](#quick-start)
@@ -55,6 +70,10 @@ Before any `os.Stat`, `os.MkdirAll`, `os.Mkdir`, `os.Chmod`, or `os.Chown` call,
 3. Returns an error if the resolved path escapes the boundary.
 
 This prevents `path` values containing `../` sequences (or equivalent) from reaching the OS.
+
+### `mode` alias
+
+The implementation also accepts `mode` as an alias for `permissions` (parsed as an octal string such as `"0755"`, or as an integer). The `permissions` field name is preferred in operator-facing YAML.
 
 ### Symlink limitation
 

--- a/docs/modules/file.md
+++ b/docs/modules/file.md
@@ -4,6 +4,19 @@
 
 The file module manages file content, permissions, and ownership on managed endpoints. It enforces path-traversal protection via a required `allowed_base_path` field.
 
+## Implementation References
+
+- Schema: [`features/modules/file/module.yaml`](../../features/modules/file/module.yaml)
+- Implementation: [`features/modules/file/implementation.go`](../../features/modules/file/implementation.go)
+
+## Platform Support
+
+| Platform | State management | Unix permissions | Ownership (`owner`/`group`) | Windows ACL |
+|----------|-----------------|------------------|-----------------------------|-------------|
+| Linux    | ✓ | ✓ (mode bits) | ✓ (`uid`/`gid` via `os.Chown`) | — |
+| macOS    | ✓ | ✓ (mode bits) | ✓ (`uid`/`gid` via `os.Chown`) | — |
+| Windows  | ✓ | — (returns error if set; use `windows_acl`) | Limited (user lookup only; `os.Chown` not called) | ✓ (NTFS DACL) |
+
 ## Configuration
 
 | Field | Type | Required | Description |
@@ -23,6 +36,20 @@ The file module manages file content, permissions, and ownership on managed endp
 If the field is absent or not an absolute path, the module returns `ErrAllowedBasePathRequired` and performs no filesystem operations.
 
 **Note:** `allowed_base_path` uses `filepath.Clean` + `filepath.Abs` internally. Symlink escapes outside the base path are **not** blocked.
+
+### Initialization via `Configure()`
+
+`fileModule` implements the `modules.Configurable` interface. The execution engine calls `Configure(desiredState)` before the `Get→Compare→Set→Verify` cycle begins. `Configure()` extracts `allowed_base_path` from the desired config and stores it in `configuredBasePath`, allowing `Get()` to validate resource paths before any `Set()` has run.
+
+If `Configure()` is never called (or returns an error), `configuredBasePath` is empty and `Get()` returns `ErrAllowedBasePathRequired`. The engine surfaces this as a module configuration failure and does not proceed to `Set()`.
+
+### `path` in YAML examples
+
+In the CFGMS module system, the file path is the **resource identifier** — it is passed to `Get()` and `Set()` as the `resourceID` parameter. The `path` field shown in YAML examples below is read by the CFGMS framework and used as the resource identifier; it is not stored inside the module's `FileConfig` struct. The `FileConfig` type does not have a `path` field.
+
+### `mode` alias
+
+The implementation also accepts `mode` as an alias for `permissions` (parsed as an octal string such as `"0644"`, or as an integer). The `permissions` field name is preferred in operator-facing YAML.
 
 ### Example: Ensure a configuration file exists with permissions and owner
 

--- a/docs/modules/firewall.md
+++ b/docs/modules/firewall.md
@@ -7,10 +7,30 @@ module instance represents a single named rule — `action`, `direction`, `proto
 and address constraints — that the steward applies to the operating-system firewall.
 
 **Platform Support:** This module is **Linux only**. The implementation ships two
-executors: `executor_linux.go` (iptables/nftables) and `executor_stub.go` for all
-other platforms. On Windows and macOS the stub executor accepts all calls silently
-without applying any rules. Use platform targeting in your CFGMS configuration to
-restrict firewall modules to Linux steward endpoints.
+executors: `executor_linux.go` (iptables, via `exec.Command("iptables", ...)`) and
+`executor_stub.go` for all other platforms. On Windows and macOS the stub executor
+returns `modules.ErrUnsupportedPlatform` — all calls fail immediately. Use platform
+targeting in your CFGMS configuration to restrict firewall modules to Linux steward
+endpoints.
+
+> **Note:** `module.yaml` lists `darwin` and `windows` under `platforms:`, but the
+> stub executor actively rejects all operations on those platforms at runtime.
+> nftables is **not** currently supported; the Linux executor uses iptables only.
+
+## Implementation References
+
+- Schema: [`features/modules/firewall/module.yaml`](../../features/modules/firewall/module.yaml)
+- Implementation: [`features/modules/firewall/module.go`](../../features/modules/firewall/module.go)
+- Linux executor: [`features/modules/firewall/executor_linux.go`](../../features/modules/firewall/executor_linux.go)
+- Non-Linux stub: [`features/modules/firewall/executor_stub.go`](../../features/modules/firewall/executor_stub.go)
+
+## Platform Support
+
+| Platform | `applyRule` | `deleteRule` | `ruleExists` | Backend |
+|----------|------------|--------------|--------------|---------|
+| Linux    | ✓ | ✓ | ✓ | iptables |
+| macOS    | ✗ (`ErrUnsupportedPlatform`) | ✗ | ✗ | — |
+| Windows  | ✗ (`ErrUnsupportedPlatform`) | ✗ | ✗ | — |
 
 ## Configuration
 
@@ -26,7 +46,7 @@ restrict firewall modules to Linux steward endpoints.
 | `port` | int | Conditional | Single port number (0–65535). Required when `protocol` is set and `service` is not. |
 | `ports` | []int | Conditional | List of port numbers. Use instead of `port` to match multiple ports in one rule. |
 | `description` | string | No | Human-readable description of the rule. Max 256 characters. |
-| `enabled` | bool | No | Whether the rule is active. Default: `true`. |
+| `enabled` | bool | No | Whether the rule is active. Default: `false` (Go zero value; omit this field or set `enabled: true` to activate). |
 | `state` | string | No | `present` (default) creates or updates the rule; `absent` deletes it. |
 
 ### Validation Rules
@@ -61,7 +81,7 @@ modules:
       enabled: true
 ```
 
-**Expected Outcome:** An iptables/nftables rule is inserted that accepts inbound TCP
+**Expected Outcome:** An iptables rule is inserted that accepts inbound TCP
 traffic on port 443 originating from `10.10.0.0/16`. Traffic from sources outside that
 CIDR is not matched by this rule and falls through to the next rule in the chain.
 Subsequent convergence cycles are idempotent — the rule is not duplicated if it already

--- a/docs/modules/script-module.md
+++ b/docs/modules/script-module.md
@@ -2,7 +2,22 @@
 
 ## Overview
 
-The Script Module provides cross-platform script execution capabilities for CFGMS, supporting Windows (PowerShell, CMD) and Unix-like systems (Bash, Zsh, Python). It implements the standard CFGMS module interface with comprehensive audit logging and security features.
+The Script Module provides cross-platform script execution capabilities for CFGMS, supporting Windows (PowerShell, CMD) and Unix-like systems (Bash, Zsh, sh, Python). It implements the standard CFGMS module interface with comprehensive audit logging and security features.
+
+## Implementation References
+
+- Schema: [`features/modules/script/module.yaml`](../../features/modules/script/module.yaml)
+- Implementation: [`features/modules/script/module.go`](../../features/modules/script/module.go)
+- Configuration type: [`features/modules/script/config.go`](../../features/modules/script/config.go)
+- Execution monitor: [`features/modules/script/execution_monitor.go`](../../features/modules/script/execution_monitor.go)
+
+## Platform Support
+
+| Platform | Supported shells |
+|----------|-----------------|
+| Linux    | `bash`, `zsh`, `sh`, `python`, `python3` |
+| macOS    | `bash`, `zsh`, `sh`, `python`, `python3` |
+| Windows  | `powershell`, `cmd`, `python`, `python3` |
 
 ## Table of Contents
 
@@ -11,7 +26,6 @@ The Script Module provides cross-platform script execution capabilities for CFGM
 - [Security Features](#security-features)
 - [Execution Environment](#execution-environment)
 - [Audit and Monitoring](#audit-and-monitoring)
-- [API Integration](#api-integration)
 - [Examples](#examples)
 
 ## Basic Usage
@@ -32,13 +46,6 @@ script:
   signing_policy: none
 ```
 
-### Supported Shells
-
-| Platform | Supported Shells |
-|----------|------------------|
-| Linux/macOS | `bash`, `zsh`, `python` |
-| Windows | `powershell`, `cmd` |
-
 ## Configuration Options
 
 ### Core Configuration
@@ -46,12 +53,21 @@ script:
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
 | `content` | string | Yes | The script content to execute |
-| `shell` | string | Yes | Shell/interpreter to use |
-| `timeout` | duration | No | Maximum execution time (default: 30s) |
+| `shell` | string | Yes | Shell/interpreter to use (see [Platform Support](#platform-support)) |
+| `timeout` | duration | No | Maximum execution time. Default: **5 minutes** (`5m`). |
 | `description` | string | No | Human-readable description |
-| `working_dir` | string | No | Working directory for execution |
-| `environment` | map | No | Environment variables |
-| `signing_policy` | string | No | Script signing requirement |
+| `working_dir` | string | No | Working directory for execution (defaults to system temp) |
+| `environment` | map | No | Environment variables injected into the script process |
+| `signing_policy` | string | No | Script signing requirement: `none` (default), `optional`, `required` |
+| `execution_context` | string | No | User context for execution: `system` (default) or `logged_in_user` |
+| `metadata` | map | No | Arbitrary key-value metadata stored with the execution record |
+
+#### `execution_context`
+
+Controls the user account under which the script runs:
+
+- `system` (default): runs as SYSTEM on Windows or as the steward process user (typically root) on Linux/macOS. No credential switching.
+- `logged_in_user`: runs as the currently logged-in console user. If no interactive user is logged in, execution returns `ErrNoUserLoggedIn` so the caller can queue the request for retry rather than failing permanently.
 
 ### Security Configuration
 
@@ -86,14 +102,22 @@ script:
 
 ### Signing Policies
 
-1. **None** (`none`): No signature validation
-2. **Optional** (`optional`): Validate signature if present
-3. **Required** (`required`): Signature must be present and valid
+1. **None** (`none`): No signature validation (default when `signing_policy` is omitted)
+2. **Optional** (`optional`): Validate signature if present; execute without validation if absent
+3. **Required** (`required`): Signature must be present and cryptographically valid
 
 ### Supported Algorithms
 
-- RSA with SHA-256 (`RSA-SHA256`)
-- ECDSA with SHA-256 (`ECDSA-SHA256`)
+| Value | Description |
+|-------|-------------|
+| `RSA-SHA256` | RSA with SHA-256 digest |
+| `RSA-SHA512` | RSA with SHA-512 digest |
+| `ECDSA-SHA256` | ECDSA with SHA-256 digest |
+| `ECDSA-SHA384` | ECDSA with SHA-384 digest |
+
+Algorithm matching is case-insensitive (`RSA-SHA256` and `rsa-sha256` are equivalent).
+
+For PowerShell scripts on Windows, Authenticode verification is used instead of detached signature verification.
 
 ### Example with Signature
 
@@ -119,8 +143,8 @@ script:
 
 - **Timeout Handling**: Graceful termination with SIGTERM, followed by SIGKILL
 - **Resource Isolation**: Each script runs in its own process
-- **Working Directory**: Configurable working directory (defaults to system temp)
-- **Environment**: Clean environment with configurable variables
+- **Working Directory**: Configurable via `working_dir`; defaults to system temp
+- **Environment**: Clean environment with configurable variables via `environment`
 
 ### Output Capture
 
@@ -129,6 +153,8 @@ script:
 - **Exit Code**: Process exit code for success/failure determination
 
 ## Audit and Monitoring
+
+The script module maintains an in-process `AuditLogger` (capped at 1000 records per steward by default) and an `ExecutionMonitor` for cross-device execution tracking. These are internal components accessible via the `Module` struct's `GetExecutionHistory`, `QueryExecutions`, and `GetExecutionMetrics` methods — they are not exposed as REST endpoints.
 
 ### Execution Records
 
@@ -169,41 +195,6 @@ Aggregated metrics include:
 - **Average Duration**: Mean execution time
 - **Shell Usage**: Distribution of shell usage
 - **Failure Analysis**: Common failure patterns
-
-## API Integration
-
-### REST API Endpoints
-
-The script module integrates with CFGMS REST API:
-
-```bash
-# List script executions
-GET /api/v1/stewards/{id}/scripts/executions?since=2025-07-28T00:00:00Z
-
-# Get specific execution
-GET /api/v1/stewards/{id}/scripts/executions/{execution_id}
-
-# Get performance metrics
-GET /api/v1/stewards/{id}/scripts/metrics?since=2025-07-27T00:00:00Z
-
-# Get current script status
-GET /api/v1/stewards/{id}/scripts/status
-
-# Retry failed execution
-POST /api/v1/stewards/{id}/scripts/executions/{execution_id}/retry
-```
-
-### Query Parameters
-
-| Parameter | Description | Example |
-|-----------|-------------|---------|
-| `since` | Filter executions since timestamp | `2025-07-28T00:00:00Z` |
-| `until` | Filter executions until timestamp | `2025-07-28T23:59:59Z` |
-| `status` | Filter by execution status | `completed`, `failed`, `running` |
-| `resource_id` | Filter by script resource | `backup-script` |
-| `user_id` | Filter by executing user | `admin` |
-| `limit` | Limit number of results | `50` |
-| `offset` | Pagination offset | `100` |
 
 ## Examples
 
@@ -440,15 +431,13 @@ modules:
 
 ### 3. Performance
 
-- **Appropriate Timeouts**: Set realistic timeouts based on expected execution time
+- **Appropriate Timeouts**: Set realistic timeouts based on expected execution time. The default is 5 minutes; set an explicit `timeout:` for scripts that should complete faster.
 - **Resource Management**: Monitor CPU and memory usage for long-running scripts
-- **Parallel Execution**: Use parallel execution for independent operations
 - **Caching**: Cache expensive operations when possible
 
 ### 4. Monitoring
 
 - **Comprehensive Logging**: Use structured logging for better searchability
-- **Metrics Collection**: Track execution metrics for performance optimization
 - **Alert Configuration**: Set up alerts for script failures and performance issues
 - **Regular Audits**: Review script execution patterns and audit logs
 
@@ -457,7 +446,7 @@ modules:
 ### Common Issues
 
 1. **Timeout Errors**
-   - Increase timeout value
+   - Increase timeout value (default is 5 minutes — adjust downward to fail fast or upward for long operations)
    - Optimize script performance
    - Break long operations into smaller chunks
 
@@ -469,6 +458,7 @@ modules:
 3. **Shell Not Available**
    - Verify shell is installed on target system
    - Check shell path and availability
+   - See [Platform Support](#platform-support) for supported shells per platform
    - Use cross-platform compatible commands
 
 4. **Environment Variable Issues**
@@ -492,62 +482,12 @@ script:
 
 ## Integration with CFGMS
 
-### Module Registration
-
-The script module is automatically registered with the CFGMS module system:
-
-```go
-// Automatic registration in module factory
-func init() {
-    modules.RegisterModule("script", script.New)
-}
-```
-
 ### Steward Integration
 
 Scripts are executed through the steward's module system:
 
 1. Configuration received from controller
-2. Script module validates configuration
+2. Script module validates configuration (including shell availability and signature if required)
 3. Executor prepares execution environment
-4. Script runs with monitoring and timeout
-5. Results and audit data sent to controller
-
-### Workflow Integration
-
-Scripts can be integrated into CFGMS workflows:
-
-```yaml
-workflow:
-  name: "System Maintenance"
-  steps:
-    - name: "pre_checks"
-      type: task
-      module: script
-      config:
-        content: "systemctl status critical-service"
-        shell: bash
-    
-    - name: "maintenance"
-      type: task
-      module: script
-      config:
-        content: "apt update && apt upgrade -y"
-        shell: bash
-        timeout: 600s
-    
-    - name: "post_checks"
-      type: task
-      module: script
-      config:
-        content: "systemctl status critical-service"
-        shell: bash
-```
-
-## Future Enhancements
-
-- **Container Execution**: Support for containerized script execution
-- **Resource Limits**: CPU and memory limits for script execution
-- **Script Library**: Shared script repository with versioning
-- **Advanced Monitoring**: Real-time execution monitoring and metrics
-- **Interactive Scripts**: Support for scripts requiring user input
+4. Script runs with timeout enforcement
+5. Results and audit data stored in the in-process audit logger


### PR DESCRIPTION
## Summary

Audited all four `docs/modules/` files against their Go implementations in `features/modules/{file,directory,firewall,script}/`. Fixes inaccurate claims and adds mandatory cross-references + platform matrices.

- **file.md**: Added implementation references, platform matrix, Configure() interface note, path-as-resourceID clarification, `mode` alias note
- **directory.md**: Added implementation references, platform matrix, Set()-ignores-state warning, `mode` alias note
- **firewall.md**: Fixed iptables-only (was "iptables/nftables"), fixed stub returns ErrUnsupportedPlatform (was "accepts silently"), fixed `enabled` default false (was true), added references + matrix
- **script-module.md**: Fixed shell support table (added sh/python3/python), fixed timeout default (30s → 5 minutes), added `execution_context` + `metadata` fields, fixed signing algorithms (added rsa-sha512/ecdsa-sha384), removed unimplemented REST API endpoints section, added references + matrix

Fixes #1511

## Specialist Review Results

| Reviewer | Result |
|----------|--------|
| qa-test-runner | **PASS** — all tests pass, no Go code changed |
| qa-code-reviewer | **PASS** — one blocking issue (residual "iptables/nftables" in example prose) found and fixed before merge |
| security-engineer | **PASS** — no secrets, no unsafe content, 0 blocking issues |

## Code Gaps Surfaced (follow-up issues to be filed)

The audit surfaced three code gaps not in scope to fix here (code wins, docs updated to match):

1. `directory`: `Set()` ignores the `state` field — passes `state: absent` still creates the directory
2. `firewall`: `module.yaml` lists darwin+windows but runtime stub errors on those platforms
3. `firewall`: `validate()` allows both `protocol` and `service` simultaneously (docs say exactly one)