### PR TITLE
pipeline: raise autonomous-container cap 5 → 7

### DIFF
--- a/.claude/agents/po.md
+++ b/.claude/agents/po.md
@@ -273,7 +273,7 @@ The preflight handles all label queries, PR CI summaries, merge queue state, cod
 
 Each step sets project status `Blocked` on unrecoverable failure and continues to the next.
 
-**Priority order (cap-constrained):** in-flight work is processed before new work. The 5-container cap is shared across all autonomous activity (dev agents, fix-pr, review containers), so when slots are scarce the cycle finishes existing PRs first — they unblock the merge queue, which is more valuable than starting more dev work that would just queue behind them. The numbered steps below reflect this priority: Step 3 (rebase) → Step 4 (review) → Step 5 (fix-cycle) → Step 6 (dispatch new dev). If the cap is exhausted by Steps 3-5, defer Step 6 to the next cycle.
+**Priority order (cap-constrained):** in-flight work is processed before new work. The 7-container cap is shared across all autonomous activity (dev agents, fix-pr, review containers), so when slots are scarce the cycle finishes existing PRs first — they unblock the merge queue, which is more valuable than starting more dev work that would just queue behind them. The numbered steps below reflect this priority: Step 3 (rebase) → Step 4 (review) → Step 5 (fix-cycle) → Step 6 (dispatch new dev). If the cap is exhausted by Steps 3-5, defer Step 6 to the next cycle.
 
 **Step 1 — Unblock check:**
 Find recently merged PRs. Check if any `Draft` stories had `## Dependencies` referencing the merged story. If satisfied, they're eligible for Tech Lead review.
@@ -435,7 +435,7 @@ For each story the preflight recommends dispatching:
 
 where `<ITEM_ID>` comes from `dispatch_recommendations[*].item_id` in the preflight output. Note: the `dispatch` subcommand handles both issue_nums (all-digits, legacy path) and item_ids (non-numeric) transparently — Story B wired this.
 
-**This step is intentionally last in priority order.** If the 5-container cap is exhausted by Steps 3-5 (rebase, review, fix-cycle), defer dispatch to the next cycle. Existing in-flight PRs unblock the merge queue, which is more valuable than starting more dev work that would just queue behind them.
+**This step is intentionally last in priority order.** If the 7-container cap is exhausted by Steps 3-5 (rebase, review, fix-cycle), defer dispatch to the next cycle. Existing in-flight PRs unblock the merge queue, which is more valuable than starting more dev work that would just queue behind them.
 
 **Step 7 — Planning Team (BA + Tech Lead collaboration):**
 Find `epic` issues with no sub-issues (`subIssuesSummary` total = 0). For each epic, orchestrate a collaborative planning session where BA and Tech Lead work together to produce stories that are ready on the first try.

--- a/.claude/commands/po.md
+++ b/.claude/commands/po.md
@@ -33,7 +33,7 @@ If `$ARGUMENTS` starts with any of `cron`, `cycle`, `decompose`, or `plan`, do *
 **How:**
 1. Read `.claude/agents/po.md` to load the PO's behavioral rules and the relevant section.
 2. Execute the section directly in the main session in priority order — preflight, unblock check, agent cleanup, Tech Lead pass, rebase (§4.1 Step 3), Acceptance Reviewer (§4.1 Step 4), fix cycle (§4.1 Step 5), dispatch (§4.1 Step 6), Planning Team (§4.1 Step 7 — see routing table above), forward edge, session log.
-3. Honor the 5-container cap from `feedback_max_running_agents.md` — the cap is on docker containers (`./.claude/scripts/agent-dispatch.sh list-running` count) shared across all autonomous activity (dev, fix-pr, review). When slots are scarce, finish in-flight work first (Steps 3-5) and defer new dev dispatch (Step 6) to the next cycle.
+3. Honor the 7-container cap from `feedback_max_running_agents.md` — the cap is on docker containers (`./.claude/scripts/agent-dispatch.sh list-running` count) shared across all autonomous activity (dev, fix-pr, review). When slots are scarce, finish in-flight work first (Steps 3-5) and defer new dev dispatch (Step 6) to the next cycle.
 4. Spawn nested subagents via the Agent tool with `mode: auto`. Spawn the Planning Team via `TeamCreate` + Agent calls with `team_name` (per `.claude/agents/po.md` §4.1 Step 7c).
 5. Report the summary back to the founder using the same format the PO subagent uses.
 


### PR DESCRIPTION
## Summary

Bump documented cap on concurrent autonomous docker agent containers from **5 → 7** per founder directive 2026-05-18.

- 3 docs/template references updated (cap is convention-enforced — no code constant)
- Memory `feedback_max_running_agents.md` updated in-session (off-repo)

## Why now

The 5-cap was set 2026-05-01 with disk + token budget constraints in mind. Today's docker cleanup recovered ~198 GB (90% → 67% root filesystem usage), removing the disk-pressure rationale. Memory is still healthy (30 GiB total, ~22 GiB free at idle) so 7 autonomous + 1 live-develop = 8 total stays within budget.

## Files

- `.claude/commands/po.md` — Path A "How" step 3
- `.claude/agents/po.md` — Step 4.1 priority-order intro
- `.claude/agents/po.md` — Step 6 deferral rationale

## Test plan
- [x] `grep -nE "5-container cap|7-container cap" .claude/commands/po.md .claude/agents/po.md` — all 3 spots show "7-container cap"
- [x] `grep -rnE "\b5\b" .claude/scripts/` — no code constants reference the old cap (verified earlier)
- [x] `make test` (pre-push hook) — green

Fixes #1545

🤖 Generated with [Claude Code](https://claude.com/claude-code)