### PR TITLE
docs: audit docs/deployment/ non-walkthrough files against current code (Issue #1512)

### DIFF
--- a/docs/deployment/controller-cluster/walkthrough.md
+++ b/docs/deployment/controller-cluster/walkthrough.md
@@ -6,7 +6,11 @@ Deploy a geo-redundant CFGMS controller cluster for high availability and region
 
 ## Status
 
-This deployment mode is planned. The walkthrough will be added when controller clustering is implemented.
+This deployment mode is planned. Documentation will be added when controller clustering is implemented.
+
+**Tracking**: [Issue #1517](https://github.com/cfg-is/cfgms/issues/1517) — steward multi-controller/failover support (one binary = one controller URL is the current constraint).
+
+For current cluster formation and steward HA test patterns, see `test/integration/ha/` in the repository.
 
 ## What this will cover
 

--- a/docs/deployment/platform-support.md
+++ b/docs/deployment/platform-support.md
@@ -13,7 +13,7 @@ The CFGMS Steward is designed for broad cross-platform deployment to managed end
 | **Linux** | AMD64 (x86_64) | ✅ Fully Supported | Primary development platform |
 | **Linux** | ARM64 (aarch64) | ✅ Fully Supported | Raspberry Pi, AWS Graviton, etc. |
 | **Windows** | AMD64 (x86_64) | ✅ Fully Supported | Windows 10, 11, Server 2019+ |
-| **Windows** | ARM64 | ✅ Fully Supported | Surface Pro X, Windows on ARM |
+| **macOS** | AMD64 (x86_64) | ✅ Fully Supported | Intel Macs |
 | **macOS** | ARM64 (M series) | ✅ Fully Supported | Apple Silicon Macs |
 
 ### Controller Support
@@ -101,16 +101,11 @@ The CFGMS Controller is designed for infrastructure deployment:
 CFGMS supports native cross-compilation for all target platforms:
 
 ```bash
-# Steward builds for all supported platforms
-make build-steward-linux-amd64    # Linux x86_64
-make build-steward-linux-arm64    # Linux ARM64
-make build-steward-windows-amd64  # Windows x86_64
-make build-steward-windows-arm64  # Windows ARM64
-make build-steward-darwin-arm64   # macOS Apple Silicon
+# Build all binaries for all supported platforms (outputs to bin/<os>-<arch>/)
+make build-cross-platform
 
-# Controller builds
-make build-controller-linux-amd64   # Linux x86_64 (primary)
-make build-controller-windows-amd64 # Windows x86_64 (development)
+# Validate cross-platform compilation without saving binaries (CI-friendly)
+make build-cross-validate
 ```
 
 ### GitHub Actions CI/CD
@@ -139,9 +134,11 @@ make build
 ### Cross-Platform Steward Builds
 
 ```bash
-# Build for a specific platform
+# Build steward for a specific platform
+make build-steward-cross GOOS=linux GOARCH=amd64
 make build-steward-cross GOOS=linux GOARCH=arm64
 make build-steward-cross GOOS=windows GOARCH=amd64
+make build-steward-cross GOOS=darwin GOARCH=amd64
 make build-steward-cross GOOS=darwin GOARCH=arm64
 ```
 
@@ -270,4 +267,4 @@ Each platform logs to appropriate system locations:
 
 ### Community Contributions
 
-Platform support contributions are welcome. See [CONTRIBUTING.md](../CONTRIBUTING.md) for guidelines on adding new platform support.
+Platform support contributions are welcome. Open a GitHub issue describing the target platform before starting work.

--- a/docs/deployment/single-controller/walkthrough.md
+++ b/docs/deployment/single-controller/walkthrough.md
@@ -89,6 +89,16 @@ Open `/etc/cfgms/controller.cfg` in your editor and verify the following variabl
 
 The REST API listens on port 9080 by default. To change it, set `CFGMS_HTTP_LISTEN_ADDR` in the systemd unit's `Environment=` directive.
 
+> **Storage**: If `controller.cfg` contains `storage.provider: "git"`, replace the entire `storage:` block with the OSS composite backend before running `--init`. The `git` provider has been removed and the controller will refuse to start with it configured:
+>
+> ```yaml
+> storage:
+>   flatfile_root: "/var/lib/cfgms/storage"
+>   sqlite_path: "/var/lib/cfgms/cfgms.db"
+> ```
+>
+> See issue [#1547](https://github.com/cfg-is/cfgms/issues/1547) to track the canonical config update.
+
 ### Install the systemd service
 
 Copy [cfgms-controller.service](cfgms-controller.service) to `/etc/systemd/system/`:
@@ -109,16 +119,17 @@ sudo cfgms-controller --init --config /etc/cfgms/controller.cfg
 You should see:
 
 ```
-Initializing storage backend... provider=flatfile
-Storage backend initialized
-Creating Certificate Authority... ca_path=/var/lib/cfgms/certs/ca
-Certificate Authority created
-Admin bundle issued path=/etc/cfgms/admin.bundle.yaml serial=<serial>
-Controller initialized successfully
-  CA fingerprint: SHA256:xxxx...
+Controller initialization complete:
+  CA Fingerprint:    SHA256:xxxx...
+  Storage Provider:  flatfile
+  Initialized At:    2026-05-19T00:00:00Z
+
+The controller is now ready to start with: cfgms-controller --config <path>
 ```
 
-Save the CA fingerprint — stewards verify it during registration.
+Save the CA fingerprint — stewards verify it during registration. Detailed initialization
+logs (CA creation, storage setup, RBAC, bundle issuance) are written to
+`/var/log/cfgms/cfgms.log`.
 
 ### Admin credential bundle
 
@@ -147,7 +158,7 @@ controller is initialized (CA fingerprint: <fp>) but admin bundle is missing at 
 To regenerate the bundle, run: cfgms-controller bootstrap-admin --regenerate
 ```
 
-Run `cfgms-controller bootstrap-admin --regenerate` to re-issue the admin bundle without reinitializing the CA or storage. (This command is implemented in Story D.)
+Run `cfgms-controller bootstrap-admin --regenerate` to re-issue the admin bundle without reinitializing the CA or storage.
 
 ### Start the controller
 


### PR DESCRIPTION
## Summary

Applies the standard audit methodology (✅/⚠️/❌/🔧) to three docs/deployment/ files, per issue #1512.

- **platform-support.md**: removed wrong Windows ARM64 claim (not in CI/Makefile PLATFORMS), added missing macOS AMD64, replaced nonexistent make targets with actual ones, removed broken CONTRIBUTING.md link
- **single-controller/walkthrough.md**: removed stale dev note, fixed initialization output to match actual binary stdout, added warning about deprecated `git` storage provider in canonical controller.cfg
- **controller-cluster/walkthrough.md**: refined placeholder with issue #1517 reference and pointer to `test/integration/ha/`

## Audit findings for audit-only files

Findings for `docs/deployment/README.md` (audit-only per file-overlap rule) were posted as a comment on issue #1512. No path-reference issues found — all links are correct post-#1508 merge. One critical finding: `docs/deployment/controller.cfg` (owned by #1508) still has `storage.provider: "git"` which the controller rejects at startup. Filed follow-up issue **#1547** (parented to epic #1501, status: Draft) to fix the canonical config.

## Specialist review results

- **QA Test Runner**: PASS — all quality gates passed, 5 cross-platform builds verified
- **QA Code Reviewer**: PASS — all Makefile targets verified to exist, init output verified against `cmd/controller/main.go:121-125`, no stale references remain (one WARNING about incomplete init output block — fixed before commit)
- **Security Engineer**: PASS — no hardcoded secrets, no insecure defaults; YAML snippet verified against `features/controller/config/config.go:235,240`; OpenBao production guard claim verified against `pkg/secrets/providers/openbao/provider.go:120-137`

Fixes #1512