### PR TITLE
steward: remove broken Monitor() stub from network_activedirectory (Issue #1520)

### DIFF
--- a/docs/architecture/steward-operating-model.md
+++ b/docs/architecture/steward-operating-model.md
@@ -146,7 +146,7 @@ Some resources don't have a feasible event-source (no OS-level watcher, no vendo
 
 Current adoption (as of v0.9.x):
 
-- **Implemented**: none [GAP: `network_activedirectory` module has a `Monitor()` method stub but it does not satisfy the `modules.Monitor` interface (wrong return type, always returns an error, missing `Changes()` and correctly-signed `Close()` methods, `GetCapabilities()` reports `supports_monitor: false`). See issue #1520]
+- **Implemented**: none
 - **Polling-only (no Monitor yet)**: `activedirectory`, `file`, `directory`, `script`, `firewall`, `package`, `patch`
 
 Adding `Monitor` support to additional modules is an ongoing enhancement, prioritized by user impact (security-sensitive resources benefit most from event-driven detection).

--- a/features/modules/network_activedirectory/module.go
+++ b/features/modules/network_activedirectory/module.go
@@ -764,12 +764,6 @@ func (m *activeDirectoryModule) Close(ctx context.Context) error {
 	return nil
 }
 
-// Monitor implements optional real-time monitoring for AD changes
-func (m *activeDirectoryModule) Monitor(ctx context.Context, resourceID string, config modules.ConfigState) (<-chan modules.ConfigState, error) {
-	// Design decision: real-time AD monitoring requires an LDAP change notification channel; the LDAP client does not expose one yet.
-	return nil, fmt.Errorf("real-time AD monitoring requires an LDAP change notification channel; the LDAP client does not expose one")
-}
-
 // GetCapabilities returns the capabilities of this module
 func (m *activeDirectoryModule) GetCapabilities() map[string]interface{} {
 	return map[string]interface{}{


### PR DESCRIPTION
## Summary

- Removes the `Monitor()` stub from `activeDirectoryModule` in `features/modules/network_activedirectory/module.go` — the method returned a wrong signature, always errored, and never satisfied `modules.Monitor`
- Drops the now-resolved GAP annotation from `docs/architecture/steward-operating-model.md:149`
- No new code added; pure dead-code deletion

## Background

The stub (`Monitor()` at lines 767–771) had the wrong return type (`<-chan modules.ConfigState, error` instead of `error`), always returned an error, and was missing `Changes()` and a correctly-signed `Close()`. `GetCapabilities()` already reported `supports_monitor: false`, so the method was unreachable dead code. Founder decision #1551 (2026-05-19): remove the stub rather than implement real LDAP change notifications. AD module stays polling-only; revisit Monitor if the requirement emerges.

## Specialist Review Results

| Reviewer | Result |
|----------|--------|
| qa-test-runner | **PASS** — all packages passing, cross-platform builds verified |
| qa-code-reviewer | **PASS** — no blocking issues, no orphaned test references |
| security-engineer | **PASS** — security-precommit, check-architecture, security-scan all green |

Fixes #1520

🤖 Generated with [Claude Code](https://claude.com/claude-code)