### PR TITLE
fix: firewall validate() rejects protocol+service set simultaneously (Issue #1541)

### DIFF
--- a/features/modules/firewall/module.go
+++ b/features/modules/firewall/module.go
@@ -139,7 +139,10 @@ func (c *firewallConfig) validate() error {
 		return ErrInvalidAction
 	}
 
-	// Validate protocol or service
+	// Validate protocol or service — exactly one must be set, not both
+	if c.Service != "" && c.Protocol != "" {
+		return ErrInvalidProtocol
+	}
 	if c.Service == "" {
 		if c.Protocol == "" {
 			return ErrInvalidProtocol

--- a/features/modules/firewall/module_test.go
+++ b/features/modules/firewall/module_test.go
@@ -502,6 +502,27 @@ enabled: true
 	}
 }
 
+// TestFirewallConfig_Validate_BothProtocolAndService verifies that validate()
+// rejects a config where both protocol and service are non-empty, since exactly
+// one selector must be provided.
+func TestFirewallConfig_Validate_BothProtocolAndService(t *testing.T) {
+	cfg := &firewallConfig{
+		Name:        "ambiguous-rule",
+		Action:      "allow",
+		Direction:   "input",
+		Protocol:    "tcp",
+		Service:     "https",
+		Port:        443,
+		Source:      "0.0.0.0/0",
+		Destination: "10.0.0.0/24",
+	}
+
+	err := cfg.validate()
+	if !errors.Is(err, ErrInvalidProtocol) {
+		t.Errorf("validate() with both protocol and service set: got %v, want ErrInvalidProtocol", err)
+	}
+}
+
 // TestSet_AbsentState_NotFound returns ErrRuleNotFound when deleting a
 // rule that was never installed.
 func TestSet_AbsentState_NotFound(t *testing.T) {


### PR DESCRIPTION
## Summary

- `validate()` in `features/modules/firewall/module.go` now rejects configurations where both `protocol` and `service` are non-empty, enforcing the "exactly one must be provided" invariant documented in #1511
- Added guard `if c.Service != "" && c.Protocol != "" { return ErrInvalidProtocol }` before the existing protocol-or-service block
- Added `TestFirewallConfig_Validate_BothProtocolAndService` that directly calls `validate()` with both fields set and asserts `errors.Is(err, ErrInvalidProtocol)`

Fixes #1541

## Specialist Review Results

**QA Test Runner: PASS**
- All packages pass with race detection, including the new `TestFirewallConfig_Validate_BothProtocolAndService`
- Cross-platform compilation verified (linux/amd64, linux/arm64, darwin/amd64, darwin/arm64, windows/amd64)
- Linting, license headers, architecture compliance, security scan: all clean

**QA Code Reviewer: PASS**
- 0 blocking issues
- 2 non-blocking warnings: (1) `ErrInvalidProtocol` message wording is slightly misleading for the both-set case (story explicitly requires reuse of this sentinel — out of scope to change here); (2) the new guard could also be covered by a table-driven row in `TestFirewallModule` (not required by AC)

**Security Engineer: PASS**
- 0 blocking issues, 0 warnings on changed files
- `security-precommit`, `check-architecture`, `security-scan`: all PASS
- Change is security-positive: closes a configuration-ambiguity footgun

## Test plan

- [ ] `go test ./features/modules/firewall/...` — all tests pass
- [ ] `TestFirewallConfig_Validate_BothProtocolAndService` asserts `errors.Is(err, ErrInvalidProtocol)` for `{protocol: "tcp", service: "https"}`
- [ ] Existing valid-case tests (`Service-based rule`, `Basic allow rule`) unmodified and still pass
- [ ] `make test-agent-complete` passes all gates

🤖 Generated with [Claude Code](https://claude.com/claude-code)