### PR TITLE
api: fix trigger route double-prefix /triggers/triggers → /triggers (Issue #1535)

### DIFF
--- a/features/controller/api/handlers_workflows_test.go
+++ b/features/controller/api/handlers_workflows_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cfgis/cfgms/features/steward/discovery"
 	"github.com/cfgis/cfgms/features/steward/factory"
 	"github.com/cfgis/cfgms/features/workflow"
+	"github.com/cfgis/cfgms/features/workflow/trigger"
 	"github.com/cfgis/cfgms/pkg/ctxkeys"
 	"github.com/cfgis/cfgms/pkg/logging"
 	cfgconfig "github.com/cfgis/cfgms/pkg/storage/interfaces/config"
@@ -438,6 +439,50 @@ func TestWorkflowHandler_RegisterTriggerRoutes_NilManager_NoRegistration(t *test
 	assert.NotPanics(t, func() {
 		h.RegisterTriggerRoutes(sub)
 	})
+}
+
+// TestTriggerRouteRegistration verifies that all 10 documented trigger paths are
+// registered (non-404 from mux) when the workflow handler is wired with a real trigger
+// manager. This guards against the double-prefix bug where /triggers/triggers/... was
+// registered instead of /triggers/...
+//
+// Route-registration is verified via router.Match rather than a live ServeHTTP call
+// because several routes correctly return HTTP 404 for non-existent resource IDs — that
+// is handler-level 404, not mux-level 404.  router.Match returns false only when no
+// route matches, which is the exact condition the double-prefix bug would trigger.
+func TestTriggerRouteRegistration(t *testing.T) {
+	logger := logging.NewNoopLogger()
+	mgr := trigger.NewControllerTriggerManager(nil, nil)
+	h := NewWorkflowHandler(nil, nil, mgr, logger)
+
+	router := mux.NewRouter()
+	sub := router.PathPrefix("/triggers").Subrouter()
+	h.RegisterTriggerRoutes(sub)
+
+	paths := []struct {
+		method string
+		path   string
+	}{
+		{"GET", "/triggers/health"},
+		{"POST", "/triggers"},
+		{"GET", "/triggers"},
+		{"GET", "/triggers/test-id"},
+		{"PUT", "/triggers/test-id"},
+		{"DELETE", "/triggers/test-id"},
+		{"POST", "/triggers/test-id/enable"},
+		{"POST", "/triggers/test-id/disable"},
+		{"POST", "/triggers/test-id/execute"},
+		{"GET", "/triggers/test-id/executions"},
+	}
+
+	for _, tc := range paths {
+		t.Run(tc.method+" "+tc.path, func(t *testing.T) {
+			req := httptest.NewRequest(tc.method, tc.path, nil)
+			var match mux.RouteMatch
+			assert.True(t, router.Match(req, &match),
+				"route %s %s must be registered (no match — likely double-prefix bug)", tc.method, tc.path)
+		})
+	}
 }
 
 // --- log injection safety ----------------------------------------------------

--- a/features/workflow/trigger/api.go
+++ b/features/workflow/trigger/api.go
@@ -32,25 +32,27 @@ func NewAPIHandler(triggerManager TriggerManager) *APIHandler {
 	}
 }
 
-// RegisterRoutes registers all trigger API routes with the router
+// RegisterRoutes registers all trigger API routes with the router.
+// Expects router to be a subrouter already scoped to the /triggers prefix
+// (e.g. api.PathPrefix("/triggers").Subrouter()), so all paths here are relative.
 func (api *APIHandler) RegisterRoutes(router *mux.Router) {
 	// Health check (must be before {id} routes to avoid conflicts)
-	router.HandleFunc("/triggers/health", api.handleHealthCheck).Methods("GET")
+	router.HandleFunc("/health", api.handleHealthCheck).Methods("GET")
 
 	// Trigger management endpoints
-	router.HandleFunc("/triggers", api.handleCreateTrigger).Methods("POST")
-	router.HandleFunc("/triggers", api.handleListTriggers).Methods("GET")
-	router.HandleFunc("/triggers/{id}", api.handleGetTrigger).Methods("GET")
-	router.HandleFunc("/triggers/{id}", api.handleUpdateTrigger).Methods("PUT")
-	router.HandleFunc("/triggers/{id}", api.handleDeleteTrigger).Methods("DELETE")
+	router.HandleFunc("", api.handleCreateTrigger).Methods("POST")
+	router.HandleFunc("", api.handleListTriggers).Methods("GET")
+	router.HandleFunc("/{id}", api.handleGetTrigger).Methods("GET")
+	router.HandleFunc("/{id}", api.handleUpdateTrigger).Methods("PUT")
+	router.HandleFunc("/{id}", api.handleDeleteTrigger).Methods("DELETE")
 
 	// Trigger control endpoints
-	router.HandleFunc("/triggers/{id}/enable", api.handleEnableTrigger).Methods("POST")
-	router.HandleFunc("/triggers/{id}/disable", api.handleDisableTrigger).Methods("POST")
-	router.HandleFunc("/triggers/{id}/execute", api.handleExecuteTrigger).Methods("POST")
+	router.HandleFunc("/{id}/enable", api.handleEnableTrigger).Methods("POST")
+	router.HandleFunc("/{id}/disable", api.handleDisableTrigger).Methods("POST")
+	router.HandleFunc("/{id}/execute", api.handleExecuteTrigger).Methods("POST")
 
 	// Trigger execution history
-	router.HandleFunc("/triggers/{id}/executions", api.handleGetTriggerExecutions).Methods("GET")
+	router.HandleFunc("/{id}/executions", api.handleGetTriggerExecutions).Methods("GET")
 }
 
 // handleCreateTrigger creates a new trigger

--- a/features/workflow/trigger/api_test.go
+++ b/features/workflow/trigger/api_test.go
@@ -17,6 +17,15 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// newTestTriggerRouter wires handler onto a /triggers-prefixed subrouter, matching
+// how server.go registers it: api.PathPrefix("/triggers").Subrouter().
+func newTestTriggerRouter(handler *APIHandler) *mux.Router {
+	router := mux.NewRouter()
+	sub := router.PathPrefix("/triggers").Subrouter()
+	handler.RegisterRoutes(sub)
+	return router
+}
+
 func TestAPIHandler_NewAPIHandler(t *testing.T) {
 	mockTriggerManager := &MockTriggerManager{}
 
@@ -30,9 +39,7 @@ func TestAPIHandler_NewAPIHandler(t *testing.T) {
 func TestAPIHandler_RegisterRoutes(t *testing.T) {
 	mockTriggerManager := &MockTriggerManager{}
 	handler := NewAPIHandler(mockTriggerManager)
-	router := mux.NewRouter()
-
-	handler.RegisterRoutes(router)
+	router := newTestTriggerRouter(handler)
 
 	// Test that routes are registered by attempting to match them
 	tests := []struct {
@@ -64,8 +71,7 @@ func TestAPIHandler_RegisterRoutes(t *testing.T) {
 func TestAPIHandler_HandleCreateTrigger(t *testing.T) {
 	mockTriggerManager := &MockTriggerManager{}
 	handler := NewAPIHandler(mockTriggerManager)
-	router := mux.NewRouter()
-	handler.RegisterRoutes(router)
+	router := newTestTriggerRouter(handler)
 
 	tests := []struct {
 		name           string
@@ -227,8 +233,7 @@ func TestAPIHandler_HandleListTriggers(t *testing.T) {
 			// Create fresh mock for each test
 			mockTriggerManager := &MockTriggerManager{}
 			handler := NewAPIHandler(mockTriggerManager)
-			router := mux.NewRouter()
-			handler.RegisterRoutes(router)
+			router := newTestTriggerRouter(handler)
 
 			tt.setupMocks(mockTriggerManager)
 
@@ -258,8 +263,7 @@ func TestAPIHandler_HandleListTriggers(t *testing.T) {
 func TestAPIHandler_HandleGetTrigger(t *testing.T) {
 	mockTriggerManager := &MockTriggerManager{}
 	handler := NewAPIHandler(mockTriggerManager)
-	router := mux.NewRouter()
-	handler.RegisterRoutes(router)
+	router := newTestTriggerRouter(handler)
 
 	testTrigger := &Trigger{
 		ID:           "test-1",
@@ -336,8 +340,7 @@ func TestAPIHandler_HandleGetTrigger(t *testing.T) {
 func TestAPIHandler_HandleUpdateTrigger(t *testing.T) {
 	mockTriggerManager := &MockTriggerManager{}
 	handler := NewAPIHandler(mockTriggerManager)
-	router := mux.NewRouter()
-	handler.RegisterRoutes(router)
+	router := newTestTriggerRouter(handler)
 
 	updatedTrigger := Trigger{
 		ID:           "test-1",
@@ -419,8 +422,7 @@ func TestAPIHandler_HandleUpdateTrigger(t *testing.T) {
 func TestAPIHandler_HandleDeleteTrigger(t *testing.T) {
 	mockTriggerManager := &MockTriggerManager{}
 	handler := NewAPIHandler(mockTriggerManager)
-	router := mux.NewRouter()
-	handler.RegisterRoutes(router)
+	router := newTestTriggerRouter(handler)
 
 	tests := []struct {
 		name           string
@@ -484,8 +486,7 @@ func TestAPIHandler_HandleDeleteTrigger(t *testing.T) {
 func TestAPIHandler_HandleEnableDisableTrigger(t *testing.T) {
 	mockTriggerManager := &MockTriggerManager{}
 	handler := NewAPIHandler(mockTriggerManager)
-	router := mux.NewRouter()
-	handler.RegisterRoutes(router)
+	router := newTestTriggerRouter(handler)
 
 	tests := []struct {
 		name                  string
@@ -571,8 +572,7 @@ func TestAPIHandler_HandleEnableDisableTrigger(t *testing.T) {
 func TestAPIHandler_HandleExecuteTrigger(t *testing.T) {
 	mockTriggerManager := &MockTriggerManager{}
 	handler := NewAPIHandler(mockTriggerManager)
-	router := mux.NewRouter()
-	handler.RegisterRoutes(router)
+	router := newTestTriggerRouter(handler)
 
 	executionResult := &TriggerExecution{
 		ID:                  "exec-123",
@@ -674,8 +674,7 @@ func TestAPIHandler_HandleExecuteTrigger(t *testing.T) {
 func TestAPIHandler_HandleGetTriggerExecutions(t *testing.T) {
 	mockTriggerManager := &MockTriggerManager{}
 	handler := NewAPIHandler(mockTriggerManager)
-	router := mux.NewRouter()
-	handler.RegisterRoutes(router)
+	router := newTestTriggerRouter(handler)
 
 	executions := []*TriggerExecution{
 		{
@@ -774,8 +773,7 @@ func TestAPIHandler_HandleGetTriggerExecutions(t *testing.T) {
 func TestAPIHandler_HandleHealthCheck(t *testing.T) {
 	mockTriggerManager := &MockTriggerManager{}
 	handler := NewAPIHandler(mockTriggerManager)
-	router := mux.NewRouter()
-	handler.RegisterRoutes(router)
+	router := newTestTriggerRouter(handler)
 
 	req, err := http.NewRequest("GET", "/triggers/health", nil)
 	require.NoError(t, err)

--- a/features/workflow/trigger/integration_test.go
+++ b/features/workflow/trigger/integration_test.go
@@ -258,10 +258,11 @@ func setupIntegrationTest(t *testing.T) *IntegrationTestSuite {
 	// Create API handler
 	apiHandler := NewAPIHandler(manager)
 
-	// Set up router
+	// Set up router — subrouter mirrors server.go: api.PathPrefix("/triggers").Subrouter()
 	router := mux.NewRouter()
 	router.Use(TriggerAPIMiddleware)
-	apiHandler.RegisterRoutes(router)
+	sub := router.PathPrefix("/triggers").Subrouter()
+	apiHandler.RegisterRoutes(sub)
 
 	// Create test server
 	server := httptest.NewServer(router)

--- a/features/workflow/trigger/security_test.go
+++ b/features/workflow/trigger/security_test.go
@@ -519,7 +519,8 @@ func TestSecurityEdgeCases_APIEndpointSecurity(t *testing.T) {
 	mockTriggerManager := &MockTriggerManager{}
 	handler := NewAPIHandler(mockTriggerManager)
 	router := mux.NewRouter()
-	handler.RegisterRoutes(router)
+	sub := router.PathPrefix("/triggers").Subrouter()
+	handler.RegisterRoutes(sub)
 
 	tests := []struct {
 		name           string


### PR DESCRIPTION
## Summary

Fixes the trigger REST API route double-prefix bug discovered during the REST API audit (Issue #1510). All trigger endpoints were unreachable at their documented paths (`/api/v1/triggers/...`) because route registration was concatenating the subrouter prefix with the handler's own `/triggers` prefix, producing `/api/v1/triggers/triggers/...`.

- **`features/workflow/trigger/api.go`**: Changed `RegisterRoutes()` from absolute paths (`/triggers/health`, `/triggers/{id}`, etc.) to relative paths (`/health`, `""`, `/{id}`, etc.) — matching the pattern already used by `RegisterWorkflowRoutes()`. The comment on `RegisterRoutes` documents the expected subrouter contract.
- **`features/controller/api/handlers_workflows_test.go`**: Added `TestTriggerRouteRegistration` using a real `trigger.NewControllerTriggerManager` that verifies all 10 documented trigger paths are matched by `router.Match()` (not just no-panic). Route-matching is tested via `router.Match` rather than `ServeHTTP` because several paths correctly return handler-level 404 for non-existent resources, which would be indistinguishable from a routing miss.
- **Test files updated**: `api_test.go`, `integration_test.go`, `security_test.go` — all now register routes on a `/triggers`-prefixed subrouter matching production wiring. Existing test paths (`/triggers/...`) are preserved.
- **`server.go` lines 390-391 unchanged** as specified in the issue.

Fixes #1535

## Specialist Review Results

- **QA Test Runner**: PASS — `make test-agent-complete` passed (all ~80+ packages)
- **QA Code Reviewer**: PASS — no blocking issues, no warnings
- **Security Engineer**: PASS — all scans green (security-precommit, check-architecture, security-scan)

## Test plan

- [ ] `TestTriggerRouteRegistration` passes — all 10 trigger paths matched by router
- [ ] `TestAPIHandler_RegisterRoutes` passes — existing trigger API unit tests pass with subrouter wiring
- [ ] `TestTriggerSystem_FullIntegration/API_Integration_-_CRUD_Operations` passes
- [ ] `TestSecurityEdgeCases_APIEndpointSecurity` passes
- [ ] `TestWorkflowHandler_RegisterTriggerRoutes_NilManager_NoRegistration` passes (no regression)
- [ ] All workflow CRUD routes at `/api/v1/workflows/*` unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)