### PR TITLE
fix: firewall module.yaml platforms corrected to linux-only (Issue #1540)

### DIFF
--- a/features/modules/firewall/module.yaml
+++ b/features/modules/firewall/module.yaml
@@ -10,8 +10,6 @@ author: CFGMS Team
 license: MIT
 platforms:
   - linux
-  - darwin
-  - windows
 dependencies:
   - name: yaml
     version: v3


### PR DESCRIPTION
## Summary

- Removed `darwin` and `windows` from `platforms:` in `features/modules/firewall/module.yaml`
- `linux` is now the only declared supported platform, matching the runtime behaviour of `executor_stub.go` (build tag `!linux`) which returns `ErrUnsupportedPlatform` on non-Linux systems
- Metadata-only change; no Go source files modified

Fixes #1540

## Why

`module.yaml` claimed darwin and windows support while the stub executor unconditionally returns `ErrUnsupportedPlatform` on those platforms. Operators or tooling reading the manifest would incorrectly believe the firewall module is functional on macOS and Windows.

## Test plan

- [x] Existing firewall package tests pass (`go test ./features/modules/firewall/...`)
- [x] `make test-agent-complete` — 249 packages passing, linting clean, cross-platform builds verified
- [x] No Go source files changed; YAML-only correction

## Specialist Review Results

| Reviewer | Result |
|---|---|
| QA Test Runner | PASS — 249 packages, all passing; cross-platform builds verified |
| QA Code Reviewer | PASS — 0 blocking issues, 0 warnings |
| Security Engineer | PASS — security-precommit, check-architecture, security-scan all PASS |

🤖 Generated with [Claude Code](https://claude.com/claude-code)