### PR TITLE
pipeline: preflight rebase rec for BLOCKED+auto-merge PRs (workflow drift)

### DIFF
--- a/.claude/scripts/po-cycle-preflight.py
+++ b/.claude/scripts/po-cycle-preflight.py
@@ -754,6 +754,29 @@ def compute_review_recommendations(pr_summaries, queued_pr_numbers, active_fix_p
                     "action": "enqueue_merge",
                     "reason": "reviewed + CI green + mergeable but not in merge queue — run `gh pr merge <N> --squash`",
                 })
+            elif (
+                ms == "BLOCKED"
+                and pr.get("auto_merge_enabled")
+                and pr.get("mergeable") == "MERGEABLE"
+                and not in_queue
+                and overall != "red"
+            ):
+                # Workflow-drift case: review passed + auto-merge armed, but
+                # mergeStateStatus is BLOCKED and CI isn't actually red. This
+                # signals missing required-check status (the PR's CI ran with a
+                # check set that diverged from develop's current required set —
+                # e.g., a new required check landed on develop after the PR
+                # branched and didn't retroactively trigger on this branch).
+                # Surfaced 2026-05-19 on #1537/#1538 (two audit PRs that sat in
+                # BLOCKED for hours with only one required check reported).
+                # A rebase triggers fresh CI with the current check set; once
+                # those report, auto-merge completes automatically.
+                recs.append({
+                    "pr": pr["pr"],
+                    "story": pr["story_number"],
+                    "action": "rebase",
+                    "reason": "reviewed + auto-merge armed but mergeStateStatus=BLOCKED with CI not red — likely missing required-check status (workflow drift between PR branch and current develop required set). Preemptive rebase via `./.claude/scripts/rebase-pr.sh <PR>` triggers fresh CI with the current check set; auto-merge completes when checks report green.",
+                })
             else:
                 reason = "acceptance review comment already present"
                 if in_queue:


### PR DESCRIPTION
## Summary

Adds preflight recommendation `action: "rebase"` for PRs stuck in `mergeStateStatus=BLOCKED` with auto-merge armed + a prior PASS review + CI not red. This is the "workflow drift" failure mode where a PR's required-check set diverges from develop's current required set.

## Why now

Surfaced 2026-05-19 on #1537 (story #1510) and #1538 (story #1511) — two audit PRs sat for hours in BLOCKED + auto-merge armed. Each had only ONE required check reported (the `No pipeline/agent label references` gate from #1482), but develop's branch protection required several more that never triggered on the stale branches. Manual rebase tripped fresh CI with the current workflow set; auto-merge then completed. The cron should catch this pattern automatically.

## What changed

Single file: `.claude/scripts/po-cycle-preflight.py` — new `elif` branch in `compute_review_recommendations` that fires when the workflow-drift signature is detected. Uses the existing `rebase` action (same mechanism as `DIRTY` / `BEHIND` cases) so no cron logic changes needed.

## Existing behavior preserved

- DIRTY → rebase (unchanged)
- BEHIND + auto-merge → rebase (unchanged)
- CI red → rebase_then_investigate (unchanged)
- has_review + CI green + not in queue + no auto-merge → enqueue_merge (unchanged)
- CI green + no review → spawn_acceptance_reviewer (unchanged)
- CI pending → defer (unchanged)
- Catch-all skip → unchanged for cases that don't match the new condition

## Test plan
- [x] `python3 -c "import ast; ast.parse(open('.claude/scripts/po-cycle-preflight.py').read())"` — syntax OK
- [x] `./.claude/scripts/po-act.sh preflight` runs cleanly
- [x] `make test` (pre-push hook) — green

Fixes #1557

🤖 Generated with [Claude Code](https://claude.com/claude-code)