### PR TITLE
steward: implement apply/monitor mode drift toggle (Issue #1519)

### DIFF
--- a/docs/architecture/steward-operating-model.md
+++ b/docs/architecture/steward-operating-model.md
@@ -15,7 +15,7 @@ The steward is a daemon that maintains a device in the state described by its cf
 
 1. **Load cfg** — Find and parse the `hostname.cfg` file (local file, or last-known cfg from controller)
 2. **Discover modules** — Scan module paths and register available modules. Modules referenced in the cfg are loaded on-demand during convergence (not validated at startup)
-3. **Initial convergence** — Evaluate every resource in the cfg immediately (apply or monitor, depending on mode) [GAP: apply/monitor toggle not yet wired — see issue #1519; current code always applies changes]
+3. **Initial convergence** — Evaluate every resource in the cfg immediately (apply or monitor, depending on `drift_mode` received from the controller)
 4. **Start convergence schedule** — Begin the compliance re-check loop at the interval defined by `converge_interval` in the cfg (default: 30 minutes). DNA is collected as part of each convergence run (not a separate startup step)
 5. **Connect to controller** (if configured) — Establish a gRPC-over-QUIC transport connection. Check for cfg updates
 
@@ -76,7 +76,7 @@ Get → Compare → Set → Verify
 
 1. **Get**: Call `module.Get()` to read current state from the system
 2. **Compare**: Engine compares current state against desired state from the cfg (using `StateComparator`)
-3. **Set**: If drifted and in `apply` mode, call `module.Set()` to converge [GAP: apply/monitor toggle not yet wired — see issue #1519; current code always calls Set when drift is detected]
+3. **Set**: If drifted and in `apply` mode, call `module.Set()` to converge. In `monitor` mode, emit `drift.detected.monitor` event upstream and skip Set/Verify.
 4. **Verify**: Call `module.Get()` again to confirm the change took effect
 
 **In `apply` mode:**
@@ -85,9 +85,7 @@ Get → Compare → Set → Verify
 
 **In `monitor` mode:**
 - If current matches desired: report compliant
-- If drifted: report drift (skip Set and Verify, no changes made)
-
-[GAP: apply/monitor toggle not implemented — `steward.mode` in the cfg currently controls connectivity mode (standalone/controller), not drift behavior. The execution engine always calls Set() when drift is detected regardless of mode. See issue #1519]
+- If drifted: emit `drift.detected.monitor` upstream event; skip Set and Verify; report `StatusNonCompliant`
 
 ### Error Handling
 
@@ -107,16 +105,18 @@ Every convergence run must be safe to repeat. Modules implement Get/Set such tha
 
 ### Drift Modes
 
-The cfg's `mode` field selects how the steward responds to drift detected during convergence or scheduled re-checks:
+The `drift_mode` field in the controller-delivered cfg selects how the steward responds to drift detected during convergence or scheduled re-checks:
 
-- **`apply` mode** (default for managed devices): the steward attempts local convergence and reports the outcome as a single combined message containing `{drift_detected, drift_setting, convergence_result, final_state}` — one message per drift event. The controller sees the drift and its resolution together.
-- **`monitor` mode**: the steward detects drift but does not act. Emits a non-compliance event upstream; operator action (or a separate `apply` workflow) decides whether to correct.
+- **`apply` mode** (default — matches current behavior when `drift_mode` is absent): the steward attempts local convergence and reports the outcome. The controller sees the drift and its resolution together.
+- **`monitor` mode**: the steward detects drift but does not act. Emits a `drift.detected.monitor` event upstream with `ResourceResult.Status = StatusNonCompliant`; operator action (or a separate `apply` workflow) decides whether to correct.
 
-Mode is set at the steward level (`steward.mode` in the cfg) — a single steward operates in one mode at a time across all its managed resources. Per-resource override is not in scope for v1.
+`drift_mode` is set exclusively from the controller-delivered cfg — a separate field from `steward.mode` (which controls connectivity: `standalone` or `controller`). A single steward operates in one drift mode at a time across all its managed resources. Per-resource override is not in scope for v1.
+
+**Security invariant**: `drift_mode` is sourced from the authenticated controller-delivered cfg only. The local-file loading path (`loadFromPath` in `features/steward/config/config.go`) clears the field after parsing so a tampered `hostname.cfg` cannot flip a controller-connected steward into monitor mode.
+
+**Distinguishable event type**: in monitor mode the executor sets `StateDiff.EventType = "drift.detected.monitor"` before invoking the `DriftEventHandler`. This lets the controller distinguish monitor-mode stewards (which simply haven't drifted) from apply-mode stewards via fleet-wide telemetry. Handler ordering is preserved: `DriftEventHandler` always fires before any mode-specific branch.
 
 Controller-side logging captures both the drift event and convergence result regardless of mode, enabling flapping detection (a future enhancement) without wire-protocol changes.
-
-[GAP: apply/monitor toggle not implemented — the `steward.mode` cfg field currently accepts `standalone` or `controller` (connectivity mode), not `apply` or `monitor`. A separate `drift_mode` field (or renamed `mode` field) needs to be added. The execution engine always applies changes when drift is detected regardless of any mode setting. See issue #1519]
 
 ## Modules
 
@@ -370,6 +370,7 @@ The convergence loop behaviour is controlled by fields in the cfg:
 | Field | Default | Description |
 |-------|---------|-------------|
 | `steward.converge_interval` | `30m` | How often the steward re-converges against the cfg. Accepts any Go duration string: `"5m"`, `"30m"`, `"1h"`, etc. |
+| `steward.drift_mode` | `apply` | How the steward handles detected drift. `apply`: correct drift with `Set()` + `Verify()`. `monitor`: emit `drift.detected.monitor` event, skip `Set()` and `Verify()`. **Controller-delivered only** — local file value is ignored. |
 
 Industry reference intervals: CFEngine 5 min, DSC 15 min, Chef/Puppet 30 min.
 
@@ -380,7 +381,7 @@ The steward binary is the same in every deployment. The table below shows which 
 | Behavior | Standalone | Controller-Connected |
 |----------|------------|---------------------|
 | Load and parse cfg | Local file | Pushed by controller, stored locally |
-| Convergence loop (apply/monitor) [GAP: toggle not wired, see #1519] | Yes | Yes |
+| Convergence loop (apply/monitor) | Yes | Yes |
 | Scheduled re-check (`converge_interval`) | Yes | Yes (default 30m until cfg received) |
 | Event hooks | Yes | Yes |
 | DNA collection | Yes | Yes |

--- a/features/steward/client/client_transport.go
+++ b/features/steward/client/client_transport.go
@@ -507,6 +507,11 @@ func (c *TransportClient) setupCommandHandler(ctx context.Context, stewardID str
 		c.convergeInterval = newInterval
 		c.mu.Unlock()
 
+		// Thread drift mode from the controller-delivered cfg into the executor.
+		// This is the only authorised source of DriftMode — local steward.cfg
+		// cannot set it (the local-file loading path clears the field).
+		executor.SetDriftMode(goConfig.Steward.DriftMode)
+
 		// Marshal to YAML for executor
 		configYAML, err := yaml.Marshal(goConfig)
 		if err != nil {

--- a/features/steward/config/config.go
+++ b/features/steward/config/config.go
@@ -170,6 +170,12 @@ type StewardSettings struct {
 	// in bytes. Commands whose Params serialise to more than this limit are rejected
 	// before dispatch. Defaults to 65536 (64 KiB) when zero.
 	SignedCommandMaxParamsBytes int `yaml:"signed_command_max_params_bytes,omitempty"`
+
+	// DriftMode controls how the steward responds to detected configuration drift.
+	// Must be sourced exclusively from the controller-delivered cfg — the local-file
+	// loading path (loadFromPath) clears this field after parsing so that editing
+	// hostname.cfg cannot flip a controller-connected steward into monitor mode.
+	DriftMode DriftMode `yaml:"drift_mode,omitempty"`
 }
 
 // SecretsConfig defines configuration for steward-side secret storage.
@@ -271,6 +277,21 @@ const (
 	ModeController OperationMode = "controller"
 )
 
+// DriftMode defines how the steward responds to detected configuration drift.
+// Set exclusively from controller-delivered cfg bytes — never from local steward.cfg —
+// so a tampered local file cannot bypass the authenticated delivery channel.
+type DriftMode string
+
+const (
+	// DriftModeApply corrects detected drift by calling module.Set() and Verify().
+	// This is the default behavior when drift_mode is absent.
+	DriftModeApply DriftMode = "apply"
+
+	// DriftModeMonitor emits a non-compliance event upstream but does not call
+	// module.Set() or module.Verify(). Drift is observed, not corrected.
+	DriftModeMonitor DriftMode = "monitor"
+)
+
 // LoggingConfig defines logging output settings.
 type LoggingConfig struct {
 	// Level sets the logging verbosity (debug, info, warn, error)
@@ -368,6 +389,11 @@ func loadFromPath(configPath string) (StewardConfig, error) {
 	if err := yaml.Unmarshal([]byte(expandedData), &config); err != nil {
 		return config, fmt.Errorf("failed to parse configuration: %w", err)
 	}
+
+	// Security invariant: DriftMode must come from controller-delivered cfg only.
+	// Clear any local-file value so a tampered hostname.cfg cannot flip a
+	// controller-connected steward into monitor mode.
+	config.Steward.DriftMode = ""
 
 	// Apply defaults
 	applyDefaults(&config)

--- a/features/steward/config/config_test.go
+++ b/features/steward/config/config_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
 )
 
 func TestLoadConfiguration(t *testing.T) {
@@ -913,4 +914,69 @@ resources:
 	_, err := LoadConfiguration(configFile)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "trusted_keys")
+}
+
+// TestDriftModeFromControllerCfgBytes asserts that DriftMode is correctly parsed
+// from controller-delivered cfg bytes (YAML), and that absence of drift_mode
+// results in an empty field (treated as DriftModeApply by the executor).
+func TestDriftModeFromControllerCfgBytes(t *testing.T) {
+	// Simulate controller-delivered YAML bytes containing drift_mode: monitor.
+	yamlMonitor := []byte(`
+steward:
+  id: test-steward
+  drift_mode: monitor
+resources: []
+`)
+	var cfgMonitor StewardConfig
+	require.NoError(t, yaml.Unmarshal(yamlMonitor, &cfgMonitor))
+	assert.Equal(t, DriftModeMonitor, cfgMonitor.Steward.DriftMode,
+		"drift_mode: monitor must parse to DriftModeMonitor")
+
+	// Simulate controller-delivered YAML bytes with drift_mode: apply.
+	yamlApply := []byte(`
+steward:
+  id: test-steward
+  drift_mode: apply
+resources: []
+`)
+	var cfgApply StewardConfig
+	require.NoError(t, yaml.Unmarshal(yamlApply, &cfgApply))
+	assert.Equal(t, DriftModeApply, cfgApply.Steward.DriftMode,
+		"drift_mode: apply must parse to DriftModeApply")
+
+	// Absence of drift_mode field defaults to empty (executor treats empty as apply).
+	yamlNoMode := []byte(`
+steward:
+  id: test-steward
+resources: []
+`)
+	var cfgNoMode StewardConfig
+	require.NoError(t, yaml.Unmarshal(yamlNoMode, &cfgNoMode))
+	assert.Empty(t, cfgNoMode.Steward.DriftMode,
+		"missing drift_mode must be empty (executor default: apply)")
+}
+
+// TestDriftMode_LocalFileCannotSetIt asserts the security invariant:
+// LoadConfiguration clears DriftMode so a tampered local file cannot flip
+// a controller-connected steward into monitor mode.
+func TestDriftMode_LocalFileCannotSetIt(t *testing.T) {
+	tempDir := t.TempDir()
+	configFile := filepath.Join(tempDir, "test.cfg")
+
+	configData := `steward:
+  id: test-steward
+  drift_mode: monitor
+
+resources:
+  - name: test-resource
+    module: test-module
+    config:
+      key: value
+`
+	require.NoError(t, os.WriteFile(configFile, []byte(configData), 0644))
+
+	cfg, err := LoadConfiguration(configFile)
+	require.NoError(t, err, "config with drift_mode must load without error")
+	assert.Empty(t, cfg.Steward.DriftMode,
+		"DriftMode must be cleared after loading from local file (security invariant)")
 }

--- a/features/steward/execution/execution.go
+++ b/features/steward/execution/execution.go
@@ -51,14 +51,15 @@ type DriftEventHandler func(resourceName string, moduleName string, diff *stewar
 
 // ExecutionReport contains the results of configuration execution
 type ExecutionReport struct {
-	StartTime       time.Time
-	EndTime         time.Time
-	TotalResources  int
-	SuccessfulCount int
-	FailedCount     int
-	SkippedCount    int
-	ResourceResults []ResourceResult
-	Errors          []string
+	StartTime         time.Time
+	EndTime           time.Time
+	TotalResources    int
+	SuccessfulCount   int
+	FailedCount       int
+	SkippedCount      int
+	NonCompliantCount int
+	ResourceResults   []ResourceResult
+	Errors            []string
 }
 
 // ResourceResult contains the result of executing a single resource
@@ -81,6 +82,9 @@ const (
 	StatusFailed
 	StatusSkipped
 	StatusNoChange
+	// StatusNonCompliant indicates drift was detected in monitor mode.
+	// module.Set() and module.Verify() were NOT called; the drift is reported but not corrected.
+	StatusNonCompliant
 )
 
 // genericConfigState is a simple map-backed ConfigState implementation used

--- a/features/steward/execution/executor.go
+++ b/features/steward/execution/executor.go
@@ -41,6 +41,11 @@ type ExecutorConfig struct {
 	// ErrorHandling controls resource failure behaviour. Zero value applies when
 	// Factory is provided by the caller; defaults are used otherwise.
 	ErrorHandling config.ErrorHandlingConfig
+
+	// DriftMode controls how the executor responds to detected drift.
+	// Defaults to DriftModeApply (current behavior) when not set.
+	// Thread from controller-delivered cfg via SetDriftMode; never from local files.
+	DriftMode config.DriftMode
 }
 
 // Executor applies configurations using the unified Get→Compare→Set→Verify workflow.
@@ -53,6 +58,7 @@ type Executor struct {
 	tenantID     string
 	logger       logging.Logger
 	driftHandler DriftEventHandler
+	driftMode    config.DriftMode
 }
 
 // NewExecutor creates an Executor. When cfg.Factory is nil, an empty registry and
@@ -86,6 +92,7 @@ func NewExecutor(cfg *ExecutorConfig) (*Executor, error) {
 		config:     errCfg,
 		tenantID:   cfg.TenantID,
 		logger:     cfg.Logger,
+		driftMode:  cfg.DriftMode,
 	}, nil
 }
 
@@ -93,6 +100,13 @@ func NewExecutor(cfg *ExecutorConfig) (*Executor, error) {
 // drift on a managed resource, before Set corrects it. Pass nil to remove a handler.
 func (e *Executor) SetDriftEventHandler(handler DriftEventHandler) {
 	e.driftHandler = handler
+}
+
+// SetDriftMode updates the executor's drift mode. Call this when the
+// controller delivers a new cfg with an updated drift_mode field.
+// An empty string is treated as DriftModeApply (default behavior).
+func (e *Executor) SetDriftMode(mode config.DriftMode) {
+	e.driftMode = mode
 }
 
 // ExecuteConfiguration executes the complete configuration for all resources.
@@ -124,6 +138,8 @@ func (e *Executor) ExecuteConfiguration(ctx context.Context, cfg config.StewardC
 				report.FailedCount++
 			case StatusSkipped:
 				report.SkippedCount++
+			case StatusNonCompliant:
+				report.NonCompliantCount++
 			}
 		}
 	}
@@ -135,6 +151,7 @@ func (e *Executor) ExecuteConfiguration(ctx context.Context, cfg config.StewardC
 		"successful", report.SuccessfulCount,
 		"failed", report.FailedCount,
 		"skipped", report.SkippedCount,
+		"non_compliant", report.NonCompliantCount,
 		"duration", report.EndTime.Sub(report.StartTime))
 
 	return report
@@ -230,9 +247,28 @@ func (e *Executor) ExecuteResource(ctx context.Context, resource config.Resource
 		"resource", resource.Name,
 		"changes_required", len(stateDiff.ChangedFields))
 
-	// Emit drift event before Set corrects the drift.
+	// Tag the event type for upstream telemetry before invoking the handler.
+	// "drift.detected.monitor" lets the controller distinguish monitor-mode stewards
+	// from apply-mode stewards that simply have not drifted.
+	if e.driftMode == config.DriftModeMonitor {
+		stateDiff.EventType = "drift.detected.monitor"
+	} else {
+		stateDiff.EventType = "drift.detected"
+	}
+
+	// Emit drift event. Handler fires in both modes — ordering is always preserved.
 	if e.driftHandler != nil {
 		e.driftHandler(resource.Name, resource.Module, &stateDiff)
+	}
+
+	// In monitor mode, report non-compliance without correcting the drift.
+	if e.driftMode == config.DriftModeMonitor {
+		result.Status = StatusNonCompliant
+		result.ExecutionTime = time.Since(startTime)
+		e.logger.Info("Monitor mode: drift detected, skipping Set",
+			"resource", resource.Name,
+			"event_type", stateDiff.EventType)
+		return result
 	}
 
 	if err := module.Set(ctx, resourceID, desiredState); err != nil {
@@ -367,6 +403,7 @@ func (e *Executor) ApplyConfiguration(ctx context.Context, configData []byte, ve
 	report.ExecutionTimeMs = execReport.EndTime.Sub(execReport.StartTime).Milliseconds()
 
 	hasErrors := false
+	hasNonCompliant := false
 
 	// Group per-resource results into per-module statuses
 	for _, result := range execReport.ResourceResults {
@@ -384,6 +421,7 @@ func (e *Executor) ApplyConfiguration(ctx context.Context, configData []byte, ve
 
 		successCount, _ := moduleStatus.Details["success_count"].(int)
 		errorCount, _ := moduleStatus.Details["error_count"].(int)
+		nonCompliantCount, _ := moduleStatus.Details["non_compliant_count"].(int)
 		totalCount, _ := moduleStatus.Details["total_count"].(int)
 		totalCount++
 
@@ -400,14 +438,24 @@ func (e *Executor) ApplyConfiguration(ctx context.Context, configData []byte, ve
 			}
 		case StatusSkipped:
 			// Skipped resources are counted but don't set ERROR status
+		case StatusNonCompliant:
+			// Drift detected in monitor mode — not corrected, not an execution error.
+			nonCompliantCount++
+			hasNonCompliant = true
+			if moduleStatus.Status == "OK" {
+				moduleStatus.Status = "NON_COMPLIANT"
+			}
 		}
 
 		moduleStatus.Details["success_count"] = successCount
 		moduleStatus.Details["error_count"] = errorCount
+		moduleStatus.Details["non_compliant_count"] = nonCompliantCount
 		moduleStatus.Details["total_count"] = totalCount
 
 		if errorCount > 0 {
 			moduleStatus.Message = fmt.Sprintf("Applied %d/%d resources (%d errors)", successCount, totalCount, errorCount)
+		} else if nonCompliantCount > 0 {
+			moduleStatus.Message = fmt.Sprintf("Monitored %d resources (%d non-compliant)", totalCount, nonCompliantCount)
 		} else {
 			moduleStatus.Message = fmt.Sprintf("Applied %d resources", totalCount)
 		}
@@ -422,6 +470,9 @@ func (e *Executor) ApplyConfiguration(ctx context.Context, configData []byte, ve
 	if hasErrors {
 		report.Status = "ERROR"
 		report.Message = "Configuration applied with errors"
+	} else if hasNonCompliant {
+		report.Status = "NON_COMPLIANT"
+		report.Message = "Configuration monitored: drift detected but not corrected"
 	}
 
 	report.ExecutionTimeMs = time.Since(startTime).Milliseconds()

--- a/features/steward/execution/executor_test.go
+++ b/features/steward/execution/executor_test.go
@@ -9,12 +9,15 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"sync/atomic"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	stewardconfig "github.com/cfgis/cfgms/features/steward/config"
 	"github.com/cfgis/cfgms/features/steward/execution"
+	stewardtesting "github.com/cfgis/cfgms/features/steward/testing"
 	"github.com/cfgis/cfgms/pkg/logging"
 )
 
@@ -255,6 +258,166 @@ func TestExecutor_GetCompareSetVerify_Workflow(t *testing.T) {
 	report2, err := executor.ApplyConfiguration(ctx, []byte(configJSON), "v1.0")
 	require.NoError(t, err)
 	assert.Equal(t, "OK", report2.Status)
+}
+
+// TestExecuteResource_ApplyMode_CallsSet asserts that module.Set() is called when
+// drift is detected in apply mode, preserving existing behavior bit-for-bit.
+func TestExecuteResource_ApplyMode_CallsSet(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix file permissions not applicable on Windows; no Windows equivalent for this test")
+	}
+	tempDir := t.TempDir()
+	filePath := filepath.Join(tempDir, "apply_test.txt")
+	require.NoError(t, os.WriteFile(filePath, []byte("initial content\n"), 0644))
+
+	logger := logging.ForModule("executor_test")
+	executor, err := execution.NewExecutor(&execution.ExecutorConfig{
+		Logger:    logger,
+		DriftMode: stewardconfig.DriftModeApply,
+	})
+	require.NoError(t, err)
+
+	var handlerFired int32
+	executor.SetDriftEventHandler(func(rn, mn string, diff *stewardtesting.StateDiff) {
+		atomic.AddInt32(&handlerFired, 1)
+		assert.Equal(t, "drift.detected", diff.EventType, "apply mode must emit drift.detected event type")
+	})
+
+	resource := stewardconfig.ResourceConfig{
+		Name:   "apply-test-file",
+		Module: "file",
+		Config: map[string]interface{}{
+			"path":              filepath.ToSlash(filePath),
+			"content":           "desired content\n",
+			"permissions":       420, // 0644 octal
+			"allowed_base_path": filepath.ToSlash(tempDir),
+		},
+	}
+
+	ctx := context.Background()
+	result := executor.ExecuteResource(ctx, resource)
+
+	assert.Equal(t, execution.StatusSuccess, result.Status, "apply mode must correct drift and return StatusSuccess")
+	assert.True(t, result.DriftDetected, "drift must be detected")
+	assert.True(t, result.ChangesApplied, "Set() must be called in apply mode")
+	assert.Equal(t, int32(1), atomic.LoadInt32(&handlerFired), "DriftEventHandler must fire once")
+
+	// Verify Set() actually ran — file must contain desired content.
+	got, err := os.ReadFile(filePath)
+	require.NoError(t, err)
+	assert.Equal(t, "desired content\n", string(got), "file content must be updated by Set()")
+}
+
+// TestExecuteResource_MonitorMode_SkipsSet asserts that in monitor mode:
+//   - module.Set() and module.Verify() are NOT called
+//   - ResourceResult.Status is StatusNonCompliant
+//   - DriftEventHandler fires before the early return (ordering preserved)
+//   - The emitted event type is "drift.detected.monitor"
+func TestExecuteResource_MonitorMode_SkipsSet(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix file permissions not applicable on Windows; no Windows equivalent for this test")
+	}
+	tempDir := t.TempDir()
+	filePath := filepath.Join(tempDir, "monitor_test.txt")
+	initialContent := "initial content\n"
+	require.NoError(t, os.WriteFile(filePath, []byte(initialContent), 0644))
+
+	logger := logging.ForModule("executor_test")
+	executor, err := execution.NewExecutor(&execution.ExecutorConfig{
+		Logger:    logger,
+		DriftMode: stewardconfig.DriftModeMonitor,
+	})
+	require.NoError(t, err)
+
+	var handlerFired int32
+	var capturedEventType string
+	executor.SetDriftEventHandler(func(rn, mn string, diff *stewardtesting.StateDiff) {
+		atomic.AddInt32(&handlerFired, 1)
+		capturedEventType = diff.EventType
+	})
+
+	resource := stewardconfig.ResourceConfig{
+		Name:   "monitor-test-file",
+		Module: "file",
+		Config: map[string]interface{}{
+			"path":              filepath.ToSlash(filePath),
+			"content":           "desired content\n",
+			"permissions":       420, // 0644 octal
+			"allowed_base_path": filepath.ToSlash(tempDir),
+		},
+	}
+
+	ctx := context.Background()
+	result := executor.ExecuteResource(ctx, resource)
+
+	assert.Equal(t, execution.StatusNonCompliant, result.Status, "monitor mode must return StatusNonCompliant")
+	assert.True(t, result.DriftDetected, "drift must be detected")
+	assert.False(t, result.ChangesApplied, "Set() must NOT be called in monitor mode")
+	assert.Equal(t, int32(1), atomic.LoadInt32(&handlerFired), "DriftEventHandler must fire before the early return")
+	assert.Equal(t, "drift.detected.monitor", capturedEventType, "monitor mode must emit drift.detected.monitor event type")
+
+	// Verify Set() was NOT called — file must still contain initial content.
+	got, err := os.ReadFile(filePath)
+	require.NoError(t, err)
+	assert.Equal(t, initialContent, string(got), "file content must be unchanged in monitor mode (Set() skipped)")
+}
+
+// TestApplyConfiguration_MonitorMode verifies that when the executor is configured
+// with DriftModeMonitor and a config with drifted resources is applied:
+//   - The overall report status is "NON_COMPLIANT"
+//   - Drifted resources have StatusNonCompliant
+//   - The file on disk is NOT modified (Set() was not called)
+//   - ExecutorDriftMode confirms the mode was threaded from ExecutorConfig
+func TestApplyConfiguration_MonitorMode(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix file permissions not applicable on Windows; no Windows equivalent for this test")
+	}
+	tempDir := t.TempDir()
+	filePath := filepath.Join(tempDir, "monitor_apply_test.txt")
+	initialContent := "initial content\n"
+	require.NoError(t, os.WriteFile(filePath, []byte(initialContent), 0644))
+
+	logger := logging.ForModule("executor_test")
+	executor, err := execution.NewExecutor(&execution.ExecutorConfig{
+		Logger:    logger,
+		DriftMode: stewardconfig.DriftModeMonitor,
+	})
+	require.NoError(t, err)
+
+	// ExecutorDriftMode confirms the mode was threaded from ExecutorConfig.
+	assert.Equal(t, stewardconfig.DriftModeMonitor, execution.ExecutorDriftMode(executor),
+		"DriftMode must be threaded from ExecutorConfig into Executor")
+
+	configJSON := `{
+  "steward": {"id": "test-steward", "mode": "controller"},
+  "resources": [
+    {
+      "name": "monitor-apply-file",
+      "module": "file",
+      "config": ` + testFileConfig(filePath, "desired content\\n") + `
+    }
+  ]
+}`
+
+	ctx := context.Background()
+	report, err := executor.ApplyConfiguration(ctx, []byte(configJSON), "v-monitor-1")
+	require.NoError(t, err)
+	require.NotNil(t, report)
+
+	assert.Equal(t, "NON_COMPLIANT", report.Status,
+		"monitor mode with drifted resources must produce NON_COMPLIANT report status")
+
+	fileStatus, ok := report.Modules["file"]
+	assert.True(t, ok, "file module must be present in report")
+	assert.Equal(t, "NON_COMPLIANT", fileStatus.Status, "file module status must be NON_COMPLIANT")
+
+	nonCompliantCount, _ := fileStatus.Details["non_compliant_count"].(int)
+	assert.Equal(t, 1, nonCompliantCount, "non_compliant_count must be 1")
+
+	// Verify Set() was NOT called — file must still contain initial content.
+	got, readErr := os.ReadFile(filePath)
+	require.NoError(t, readErr)
+	assert.Equal(t, initialContent, string(got), "file must be unchanged in monitor mode")
 }
 
 func TestExecutor_ApplyConfiguration_PermissionsRejectedOnWindows(t *testing.T) {

--- a/features/steward/execution/export_test.go
+++ b/features/steward/execution/export_test.go
@@ -3,6 +3,7 @@
 package execution
 
 import (
+	"github.com/cfgis/cfgms/features/steward/config"
 	"github.com/cfgis/cfgms/features/steward/factory"
 	stewardtesting "github.com/cfgis/cfgms/features/steward/testing"
 )
@@ -15,3 +16,6 @@ var ExecutorComparator = func(e *Executor) *stewardtesting.StateComparator { ret
 
 // HandleResourceError exposes the unexported handleResourceError method for package execution_test files.
 var HandleResourceError = (*Executor).handleResourceError
+
+// ExecutorDriftMode exposes the driftMode field of Executor for package execution_test inspection.
+var ExecutorDriftMode = func(e *Executor) config.DriftMode { return e.driftMode }

--- a/features/steward/testing/comparison.go
+++ b/features/steward/testing/comparison.go
@@ -62,6 +62,11 @@ type StateDiff struct {
 
 	// RemovedFields contains fields present in current but not in desired
 	RemovedFields map[string]interface{}
+
+	// EventType classifies the drift event for upstream telemetry.
+	// "drift.detected" in apply mode; "drift.detected.monitor" in monitor mode.
+	// Set by the executor before invoking DriftEventHandler.
+	EventType string
 }
 
 // FieldDiff represents a difference in a specific configuration field.

--- a/features/steward/testing/comparison_test.go
+++ b/features/steward/testing/comparison_test.go
@@ -6,45 +6,34 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
+	"gopkg.in/yaml.v3"
 )
 
-// mockConfigState implements ConfigState interface for testing
-type mockConfigState struct {
-	mock.Mock
+// testConfigState is a real implementation of modules.ConfigState used in tests.
+// No mocks — state is held in a plain map, matching the genericConfigState pattern.
+type testConfigState struct {
 	data          map[string]interface{}
 	managedFields []string
 }
 
-func (m *mockConfigState) AsMap() map[string]interface{} {
-	args := m.Called()
-	if args.Get(0) != nil {
-		return args.Get(0).(map[string]interface{})
-	}
-	return m.data
+func (s *testConfigState) AsMap() map[string]interface{} {
+	return s.data
 }
 
-func (m *mockConfigState) GetManagedFields() []string {
-	args := m.Called()
-	if args.Get(0) != nil {
-		return args.Get(0).([]string)
-	}
-	return m.managedFields
+func (s *testConfigState) GetManagedFields() []string {
+	return s.managedFields
 }
 
-func (m *mockConfigState) ToYAML() ([]byte, error) {
-	args := m.Called()
-	return args.Get(0).([]byte), args.Error(1)
+func (s *testConfigState) ToYAML() ([]byte, error) {
+	return yaml.Marshal(s.data)
 }
 
-func (m *mockConfigState) FromYAML(data []byte) error {
-	args := m.Called(data)
-	return args.Error(0)
+func (s *testConfigState) FromYAML(data []byte) error {
+	return yaml.Unmarshal(data, &s.data)
 }
 
-func (m *mockConfigState) Validate() error {
-	args := m.Called()
-	return args.Error(0)
+func (s *testConfigState) Validate() error {
+	return nil
 }
 
 func TestNewStateComparator(t *testing.T) {
@@ -55,27 +44,15 @@ func TestNewStateComparator(t *testing.T) {
 func TestCompareStates_NoDrift(t *testing.T) {
 	comparator := NewStateComparator()
 
-	// Create mock states with identical managed fields
-	currentData := map[string]interface{}{
-		"field1": "value1",
-		"field2": 42,
-		"field3": true,
-	}
-
-	desiredData := map[string]interface{}{
-		"field1": "value1",
-		"field2": 42,
-		"field3": true,
-	}
-
 	managedFields := []string{"field1", "field2", "field3"}
+	sharedData := map[string]interface{}{
+		"field1": "value1",
+		"field2": 42,
+		"field3": true,
+	}
 
-	current := &mockConfigState{data: currentData, managedFields: managedFields}
-	desired := &mockConfigState{data: desiredData, managedFields: managedFields}
-
-	current.On("AsMap").Return(currentData)
-	desired.On("AsMap").Return(desiredData)
-	desired.On("GetManagedFields").Return(managedFields)
+	current := &testConfigState{data: sharedData, managedFields: managedFields}
+	desired := &testConfigState{data: sharedData, managedFields: managedFields}
 
 	driftDetected, diff := comparator.CompareStates(current, desired)
 
@@ -84,129 +61,102 @@ func TestCompareStates_NoDrift(t *testing.T) {
 	assert.Len(t, diff.ChangedFields, 0)
 	assert.Len(t, diff.AddedFields, 0)
 	assert.Len(t, diff.RemovedFields, 0)
-
-	current.AssertExpectations(t)
-	desired.AssertExpectations(t)
 }
 
 func TestCompareStates_DriftDetected(t *testing.T) {
 	comparator := NewStateComparator()
 
-	// Create mock states with different values
-	currentData := map[string]interface{}{
-		"field1": "old_value",
-		"field2": 42,
-		"field3": true,
-	}
-
-	desiredData := map[string]interface{}{
-		"field1": "new_value", // Changed
-		"field2": 42,          // Same
-		"field4": "added",     // Added
-		// field3 removed (not in desired)
-	}
-
 	managedFields := []string{"field1", "field2", "field3", "field4"}
 
-	current := &mockConfigState{data: currentData, managedFields: managedFields}
-	desired := &mockConfigState{data: desiredData, managedFields: managedFields}
-
-	current.On("AsMap").Return(currentData)
-	desired.On("AsMap").Return(desiredData)
-	desired.On("GetManagedFields").Return(managedFields)
+	current := &testConfigState{
+		data: map[string]interface{}{
+			"field1": "old_value",
+			"field2": 42,
+			"field3": true,
+		},
+		managedFields: managedFields,
+	}
+	desired := &testConfigState{
+		data: map[string]interface{}{
+			"field1": "new_value", // Changed
+			"field2": 42,          // Same
+			"field4": "added",     // Added
+			// field3 removed (not in desired)
+		},
+		managedFields: managedFields,
+	}
 
 	driftDetected, diff := comparator.CompareStates(current, desired)
 
 	assert.True(t, driftDetected)
 	assert.False(t, diff.IsEmpty())
 
-	// Check changed fields
 	assert.Len(t, diff.ChangedFields, 1)
 	assert.Contains(t, diff.ChangedFields, "field1")
 	assert.Equal(t, "old_value", diff.ChangedFields["field1"].Current)
 	assert.Equal(t, "new_value", diff.ChangedFields["field1"].Desired)
 
-	// Check added fields
 	assert.Len(t, diff.AddedFields, 1)
 	assert.Contains(t, diff.AddedFields, "field4")
 	assert.Equal(t, "added", diff.AddedFields["field4"])
 
-	// Check removed fields
 	assert.Len(t, diff.RemovedFields, 1)
 	assert.Contains(t, diff.RemovedFields, "field3")
 	assert.Equal(t, true, diff.RemovedFields["field3"])
-
-	current.AssertExpectations(t)
-	desired.AssertExpectations(t)
 }
 
 func TestCompareStates_OnlyManagedFields(t *testing.T) {
 	comparator := NewStateComparator()
 
-	// Current has more fields, but only managed fields should be compared
-	currentData := map[string]interface{}{
-		"managed1":   "value1",
-		"managed2":   "value2",
-		"unmanaged1": "should_be_ignored",
-		"unmanaged2": "also_ignored",
+	managedFields := []string{"managed1", "managed2"}
+
+	current := &testConfigState{
+		data: map[string]interface{}{
+			"managed1":   "value1",
+			"managed2":   "value2",
+			"unmanaged1": "should_be_ignored",
+			"unmanaged2": "also_ignored",
+		},
+		managedFields: managedFields,
 	}
-
-	desiredData := map[string]interface{}{
-		"managed1": "value1",
-		"managed2": "changed_value", // This should be detected
+	desired := &testConfigState{
+		data: map[string]interface{}{
+			"managed1": "value1",
+			"managed2": "changed_value",
+		},
+		managedFields: managedFields,
 	}
-
-	managedFields := []string{"managed1", "managed2"} // Only these should be compared
-
-	current := &mockConfigState{data: currentData, managedFields: managedFields}
-	desired := &mockConfigState{data: desiredData, managedFields: managedFields}
-
-	current.On("AsMap").Return(currentData)
-	desired.On("AsMap").Return(desiredData)
-	desired.On("GetManagedFields").Return(managedFields)
 
 	driftDetected, diff := comparator.CompareStates(current, desired)
 
 	assert.True(t, driftDetected)
-
-	// Only managed2 should show as changed
 	assert.Len(t, diff.ChangedFields, 1)
 	assert.Contains(t, diff.ChangedFields, "managed2")
 	assert.Equal(t, "value2", diff.ChangedFields["managed2"].Current)
 	assert.Equal(t, "changed_value", diff.ChangedFields["managed2"].Desired)
-
-	// Unmanaged fields should not appear in diff
 	assert.NotContains(t, diff.ChangedFields, "unmanaged1")
 	assert.NotContains(t, diff.ChangedFields, "unmanaged2")
-
-	current.AssertExpectations(t)
-	desired.AssertExpectations(t)
 }
 
 func TestGetManagedFieldValues(t *testing.T) {
 	comparator := NewStateComparator()
 
-	stateData := map[string]interface{}{
-		"field1": "value1",
-		"field2": 42,
-		"field3": true,
-		"field4": "not_managed",
+	state := &testConfigState{
+		data: map[string]interface{}{
+			"field1": "value1",
+			"field2": 42,
+			"field3": true,
+			"field4": "not_managed",
+		},
 	}
 
-	state := &mockConfigState{data: stateData}
-	state.On("AsMap").Return(stateData)
-
-	managedFields := []string{"field1", "field2", "field3"}
-
-	result := comparator.GetManagedFieldValues(state, managedFields)
+	result := comparator.GetManagedFieldValues(state, []string{"field1", "field2", "field3"})
 
 	assert.Len(t, result, 3)
 	assert.Equal(t, "value1", result["field1"])
 	assert.Equal(t, 42, result["field2"])
 	assert.Equal(t, true, result["field3"])
-	assert.NotContains(t, result, "field4") // Should not include unmanaged field
-
-	state.AssertExpectations(t)
+	assert.NotContains(t, result, "field4")
 }
 
 func TestValuesEqual(t *testing.T) {
@@ -218,66 +168,16 @@ func TestValuesEqual(t *testing.T) {
 		desired  interface{}
 		expected bool
 	}{
-		{
-			name:     "identical strings",
-			current:  "value",
-			desired:  "value",
-			expected: true,
-		},
-		{
-			name:     "different strings",
-			current:  "old",
-			desired:  "new",
-			expected: false,
-		},
-		{
-			name:     "identical numbers",
-			current:  42,
-			desired:  42,
-			expected: true,
-		},
-		{
-			name:     "different numbers",
-			current:  42,
-			desired:  43,
-			expected: false,
-		},
-		{
-			name:     "both nil",
-			current:  nil,
-			desired:  nil,
-			expected: true,
-		},
-		{
-			name:     "one nil",
-			current:  nil,
-			desired:  "value",
-			expected: false,
-		},
-		{
-			name:     "identical slices",
-			current:  []string{"a", "b", "c"},
-			desired:  []string{"a", "b", "c"},
-			expected: true,
-		},
-		{
-			name:     "different slices",
-			current:  []string{"a", "b", "c"},
-			desired:  []string{"a", "b", "d"},
-			expected: false,
-		},
-		{
-			name:     "identical maps",
-			current:  map[string]int{"a": 1, "b": 2},
-			desired:  map[string]int{"a": 1, "b": 2},
-			expected: true,
-		},
-		{
-			name:     "different maps",
-			current:  map[string]int{"a": 1, "b": 2},
-			desired:  map[string]int{"a": 1, "b": 3},
-			expected: false,
-		},
+		{"identical strings", "value", "value", true},
+		{"different strings", "old", "new", false},
+		{"identical numbers", 42, 42, true},
+		{"different numbers", 42, 43, false},
+		{"both nil", nil, nil, true},
+		{"one nil", nil, "value", false},
+		{"identical slices", []string{"a", "b", "c"}, []string{"a", "b", "c"}, true},
+		{"different slices", []string{"a", "b", "c"}, []string{"a", "b", "d"}, false},
+		{"identical maps", map[string]int{"a": 1, "b": 2}, map[string]int{"a": 1, "b": 2}, true},
+		{"different maps", map[string]int{"a": 1, "b": 2}, map[string]int{"a": 1, "b": 3}, false},
 	}
 
 	for _, tt := range tests {
@@ -297,24 +197,9 @@ func TestGetDiffType(t *testing.T) {
 		desired  interface{}
 		expected DiffType
 	}{
-		{
-			name:     "same type different value",
-			current:  "old",
-			desired:  "new",
-			expected: DiffTypeChanged,
-		},
-		{
-			name:     "different types",
-			current:  "42",
-			desired:  42,
-			expected: DiffTypeTypeChanged,
-		},
-		{
-			name:     "same type same value",
-			current:  42,
-			desired:  42,
-			expected: DiffTypeChanged, // Still marked as changed since this is called when values differ
-		},
+		{"same type different value", "old", "new", DiffTypeChanged},
+		{"different types", "42", 42, DiffTypeTypeChanged},
+		{"same type same value", 42, 42, DiffTypeChanged},
 	}
 
 	for _, tt := range tests {
@@ -326,7 +211,6 @@ func TestGetDiffType(t *testing.T) {
 }
 
 func TestStateDiff_Methods(t *testing.T) {
-	// Test empty diff
 	emptyDiff := StateDiff{
 		ChangedFields: map[string]FieldDiff{},
 		AddedFields:   map[string]interface{}{},
@@ -339,7 +223,6 @@ func TestStateDiff_Methods(t *testing.T) {
 	assert.Len(t, emptyDiff.GetAddedFieldNames(), 0)
 	assert.Len(t, emptyDiff.GetRemovedFieldNames(), 0)
 
-	// Test diff with changes
 	diff := StateDiff{
 		ChangedFields: map[string]FieldDiff{
 			"field1": {Current: "old", Desired: "new", Type: DiffTypeChanged},
@@ -374,4 +257,23 @@ func TestStateDiff_Methods(t *testing.T) {
 	assert.Contains(t, detailedDiff, "Changed: field2: 42 -> 43")
 	assert.Contains(t, detailedDiff, "Added: field3: added_value")
 	assert.Contains(t, detailedDiff, "Removed: field4: removed_value")
+}
+
+// TestStateDiff_EventType asserts that the EventType field propagates correctly
+// through the StateDiff struct and is available to DriftEventHandler receivers.
+func TestStateDiff_EventType(t *testing.T) {
+	diff := StateDiff{
+		ChangedFields: map[string]FieldDiff{},
+		AddedFields:   map[string]interface{}{},
+		RemovedFields: map[string]interface{}{},
+	}
+
+	assert.Empty(t, diff.EventType, "EventType defaults to empty")
+
+	diff.EventType = "drift.detected"
+	assert.Equal(t, "drift.detected", diff.EventType)
+
+	diff.EventType = "drift.detected.monitor"
+	assert.Equal(t, "drift.detected.monitor", diff.EventType,
+		"drift.detected.monitor must be storable for monitor-mode telemetry")
 }


### PR DESCRIPTION
## Summary

- Adds `DriftMode` (apply/monitor) to the steward execution engine, sourced exclusively from the controller-delivered cfg. A tampered `hostname.cfg` cannot flip a controller-connected steward into monitor mode — `loadFromPath` clears the field after parsing.
- In monitor mode, `ExecuteResource` emits `drift.detected.monitor` via `DriftEventHandler` then returns `StatusNonCompliant` without calling `module.Set()` or `module.Verify()`.
- `ApplyConfiguration` surfaces a `NON_COMPLIANT` report status (distinct from `OK`/`ERROR`) and per-module `non_compliant_count` for controller telemetry.

## Acceptance Criteria verification

- [x] `DriftMode` type + `DriftModeApply`/`DriftModeMonitor` constants in `features/steward/config/config.go`
- [x] `StewardSettings.DriftMode` populated only from controller-delivered cfg bytes; `loadFromPath` clears it
- [x] `TestExecuteResource_ApplyMode_CallsSet` — Set() called in apply mode, file updated
- [x] `TestExecuteResource_MonitorMode_SkipsSet` — Set()/Verify() skipped, `StatusNonCompliant`, handler fires, event type `drift.detected.monitor`
- [x] `TestDriftModeFromControllerCfgBytes` + `TestDriftMode_LocalFileCannotSetIt` in config_test.go
- [x] `TestApplyConfiguration_MonitorMode` — full `ApplyConfiguration` path, `NON_COMPLIANT` status
- [x] `drift.detected.monitor` event type verifiable in `TestExecuteResource_MonitorMode_SkipsSet`
- [x] `docs/architecture/steward-operating-model.md` GAP markers removed; Drift Modes section updated

## Specialist Review Results

**QA Test Runner**: PASS — all 130+ packages, cross-platform (linux/amd64, linux/arm64, darwin/amd64, darwin/arm64, windows/amd64), lint clean, security scans clean.

**QA Code Reviewer**: PASS (second pass) — blocking issues from round 1 resolved: pre-existing mock in `comparison_test.go` replaced with real `testConfigState`; `TestApplyConfiguration_MonitorMode` added; `ExecutorDriftMode` used in tests.

**Security Engineer**: PASS — security invariant correctly implemented and tested; no hardcoded secrets; no information disclosure; no central provider violations; gosec/staticcheck/Trivy/Nancy clean.

Fixes #1519