### PR TITLE
pipeline: agents block existing item on escalation, not create tracking issue

### DIFF
--- a/.claude/agents/ba.md
+++ b/.claude/agents/ba.md
@@ -221,26 +221,12 @@ rm /tmp/story-body.md
 
 If you encounter ambiguity that prevents correct decomposition:
 
-1. Create a tracking issue and mark it Blocked:
+1. Block the **epic itself** with an explanation — do NOT create a parallel tracking issue. The epic's Blocked status + explanatory comment IS the escalation; the founder unblocks the epic when ready.
    ```bash
-   cat > /tmp/blocked-body.md <<'BLOCK_EOF'
-   ## Blocked Story
-   #<NUM> — <story title>
-   ## Issue
-   <What specifically prevents decomposition>
-   ## Recommendation
-   <What the founder should do>
-   BLOCK_EOF
-
-   # Create issue then set Blocked status via po-act.sh
-   gh issue create --repo cfg-is/cfgms --label "high-priority" \
-     --title "BLOCKED: BA decomposition on epic #<NUM>" \
-     --body-file /tmp/blocked-body.md
-   rm /tmp/blocked-body.md
-   # Then: ./.claude/scripts/po-act.sh block <NEW_ISSUE_NUM> "BA blocked: <specific question>"
+   ./.claude/scripts/po-act.sh block <EPIC_NUM> "BA decomposition blocked: <specific question / ambiguity>. Affected scope: <which part of the epic this prevents decomposing>. Recommendation: <what the founder should clarify or decide>."
    ```
 2. Continue decomposing stories you CAN write. Partial decomposition is acceptable.
-3. Report back what was created and what is blocked.
+3. Report back what was created and which aspect of the epic was blocked.
 
 ## Completion
 

--- a/.claude/agents/po.md
+++ b/.claude/agents/po.md
@@ -473,7 +473,7 @@ The conversation follows this protocol:
 4. **If revisions needed** — PO relays Tech Lead feedback to BA: `SendMessage(to: "ba", message: <feedback>)`. BA revises and re-proposes. PO relays to Tech Lead for re-review. Only unresolved stories iterate — approved stories are locked.
 5. **PO product decisions** — if BA and Tech Lead disagree on scope, priority, or approach, PO makes the product call and sends the decision to both: `SendMessage(to: "*", message: "PO DECISION: ...")`
 
-**Maximum 3 revision rounds.** A round = BA revises + Tech Lead re-reviews. After 3 rounds, any remaining REVISION NEEDED stories are resolved by PO decision: either accept with a PO note, or drop and document in a Blocked tracking issue (use `po-act.sh block`).
+**Maximum 3 revision rounds.** A round = BA revises + Tech Lead re-reviews. After 3 rounds, any remaining REVISION NEEDED stories are resolved by PO decision: either accept with a PO note, or drop and document the convergence failure by blocking the epic (use `po-act.sh block <EPIC_NUM> "<reason>"`). Do NOT create a parallel tracking issue — the epic's Blocked status + comment IS the escalation.
 
 **7f. Create stories in the project queue (after consensus):**
 
@@ -557,26 +557,26 @@ TeamDelete()
 ```
 
 **7i. Fallback — convergence failure:**
-If the PO drops any stories (couldn't converge after 3 rounds), create a tracking issue and add it to the project queue as Blocked:
+If the PO drops any stories (couldn't converge after 3 rounds), block the **epic itself** with the convergence summary — do NOT create a parallel tracking issue. The epic's Blocked status + explanatory comment IS the escalation; the founder unblocks the epic when ready.
+
+Build the comment body (stories-agreed + stories-disputed summary) and pass it to `po-act.sh block` via stdin:
 ```bash
-cat > /tmp/blocked-body.md <<'BLOCK_EOF'
+cat > /tmp/convergence-failure-<EPIC_NUM>.md <<'BLOCK_EOF'
 ## Planning Team: Could Not Converge
 
-Epic: #<NUM> — <title>
+Epic: #<EPIC_NUM> — <title>
 
-## Stories Agreed
-- #NNN — <title> (created, Ready status in project queue)
+## Stories Agreed (created at Ready status)
+- #NNN — <title>
 
-## Stories Disputed
+## Stories Disputed (dropped after 3 revision rounds)
 - "<story title>": BA proposed: <summary>. Tech Lead objected: <objection>. PO recommendation: <what the founder should decide>.
 BLOCK_EOF
 
-gh issue create --repo cfg-is/cfgms --label "high-priority" \
-  --title "BLOCKED: planning convergence failure on epic #<NUM>" \
-  --body-file /tmp/blocked-body.md
-rm /tmp/blocked-body.md
+./.claude/scripts/po-act.sh block <EPIC_NUM> - < /tmp/convergence-failure-<EPIC_NUM>.md
+rm /tmp/convergence-failure-<EPIC_NUM>.md
 ```
-Then set the new issue to Blocked status via `po-act.sh block <ISSUE_NUM> "Planning team: convergence failure on epic #<NUM>"`.
+`po-act.sh block <ISSUE> -` reads the reason from stdin so multi-line summaries don't need command-line argument escaping. The block subcommand idempotently adds the epic to the project queue (if not present) and sets status to Blocked.
 
 **Step 8 — Forward edge:**
 If active milestone >80% complete and next milestone has no epics, create a `high-priority` tracking issue requesting intent capture and add it to the project queue as Blocked.

--- a/.claude/agents/tech-lead.md
+++ b/.claude/agents/tech-lead.md
@@ -41,7 +41,7 @@ For each story, run all 7 checks. A story must pass ALL checks to be promoted.
   ```
   If multiple PRs match, list all candidates with their state and let the dev agent pick the merged one.
 - If a dependency is missing, add it to the story body
-- If a circular dependency exists, create a Blocked tracking issue
+- If a circular dependency exists, set the offending story to Blocked (see "Failing a Story" section) and describe the cycle in the comment — do NOT create a parallel tracking issue
 
 **File overlap check (required when reviewing multiple stories in the same epic):**
 
@@ -78,7 +78,7 @@ For each story, run all 7 checks. A story must pass ALL checks to be promoted.
 - **AC ceiling**: more than 6 acceptance criteria (excluding `make test-complete`) means the story is too broad — block and recommend a split
 - **Module ceiling**: files in scope spanning more than 2 packages means the story is too broad — block and recommend a split by package or capability
 - **Out of Scope section required**: every story must have a `## Out of Scope` section. Block any story missing it. Issue #957 shipped a WIP because the agent refactored `examples/` which was implicitly out of scope but never explicitly excluded
-- Create a Blocked tracking issue recommending a split, with specific suggested boundaries
+- For story-too-broad cases (AC or module ceiling exceeded), set the existing story to Blocked (see "Failing a Story" section) and put the suggested split boundaries in the comment — do NOT create a parallel tracking issue
 
 ### 4. Constraint Flagging
 


### PR DESCRIPTION
## Summary

Changes agent escalation behavior across `tech-lead.md`, `ba.md`, `po.md`: when a Tech Lead / BA / Planning Team hits a Blocked condition, set the **existing item** (story or epic) to Blocked with an explanatory comment. Do NOT create a parallel `BLOCKED: …` tracking issue. The Blocked status + comment IS the escalation.

Founder directive 2026-05-19. Today's AD Monitor decision (#1520 + #1551 = 2 issues for 1 problem) was the surfacing case.

## What changed

| File | Change |
|------|--------|
| `tech-lead.md:44` | circular dep → block existing story (not create tracking issue) |
| `tech-lead.md:81` | story too broad → block existing story, put split suggestion in comment |
| `ba.md` Ambiguity Handling | BA escalation → `po-act.sh block <EPIC_NUM>` directly on epic |
| `po.md` §7i convergence failure | Planning Team failure → block epic via `po-act.sh block <EPIC> -` (stdin for multi-line) |
| `po.md` 3-revision-rounds wording | "Blocked tracking issue" → "block the epic" with no-parallel-issue note |

## Unchanged
- `po.md` Step 8 Forward edge — that scenario has no existing item to block (requests intent capture for a future milestone), so the tracking issue IS the first item there.
- `po-act.sh block` itself — already does the right thing (idempotent add-to-project + set Blocked + post comment).

## Test plan
- [x] `make test` (pre-push hook) — green
- [x] `bash -n` not applicable (markdown only)

Fixes #1562

🤖 Generated with [Claude Code](https://claude.com/claude-code)