### PR TITLE
feat(cfg): implement cfg steward list subcommand (Issue #1543)

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -553,7 +553,7 @@ make build-steward
 
 # 3. Use CLI to manage fleet
 make build-cli
-# [GAP: cfg steward list not implemented — see issue #1543]
+cfg steward list --url=http://localhost:9080
 # [GAP: cfg config apply not implemented — see issue #1543]
 # Fleet management via REST API: GET http://localhost:9080/api/v1/stewards
 ```

--- a/cmd/cfg/cmd/root.go
+++ b/cmd/cfg/cmd/root.go
@@ -52,6 +52,7 @@ func init() {
 	rootCmd.AddCommand(controllerCmd)
 	rootCmd.AddCommand(traceCmd)
 	rootCmd.AddCommand(storageCmd)
+	rootCmd.AddCommand(stewardCmd)
 	rootCmd.AddCommand(workflowCmd)
 }
 

--- a/cmd/cfg/cmd/steward.go
+++ b/cmd/cfg/cmd/steward.go
@@ -1,0 +1,162 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+// Package cmd implements the CLI commands for cfg
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"text/tabwriter"
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	stewardURL         string
+	stewardAPIKey      string
+	stewardTLSCACert   string
+	stewardTLSInsecure bool
+)
+
+// stewardCmd is the parent command for steward subcommands.
+var stewardCmd = &cobra.Command{
+	Use:   "steward",
+	Short: "Manage registered stewards",
+	Long:  `Commands for inspecting and managing stewards registered with the controller.`,
+}
+
+// stewardListCmd lists all stewards registered with the controller.
+var stewardListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List registered stewards",
+	Long: `Display all stewards registered with the controller.
+
+Prints a tabular list of steward IDs, tenants, statuses, and last-seen times.
+
+Examples:
+  # List stewards using admin bundle (mTLS auto-discovery)
+  cfg steward list
+
+  # List stewards with explicit URL
+  cfg steward list --url=https://controller.example.com
+
+  # List stewards with API key authentication
+  cfg steward list --url=https://controller.example.com --api-key=your-key`,
+	RunE: runStewardList,
+}
+
+func init() {
+	stewardListCmd.Flags().StringVar(&stewardURL, "url", "", "Controller API URL")
+	stewardListCmd.Flags().StringVar(&stewardAPIKey, "api-key", "", "API key for authentication")
+	stewardListCmd.Flags().StringVar(&stewardTLSCACert, "tls-ca-cert", "", "Path to CA certificate for TLS verification (env: CFGMS_TLS_CA_CERT)")
+	stewardListCmd.Flags().BoolVar(&stewardTLSInsecure, "tls-insecure", false, "Skip TLS verification (development only, env: CFGMS_TLS_INSECURE)")
+
+	stewardCmd.AddCommand(stewardListCmd)
+}
+
+// getStewardClient creates an API client using bundle auth (mTLS) when available,
+// falling back to API key auth when no bundle is found or discovery is opted out.
+func getStewardClient() (*APIClient, error) {
+	apiURL := strings.TrimSuffix(stewardURL, "/")
+	if apiURL == "" {
+		apiURL = os.Getenv("CFGMS_API_URL")
+	}
+
+	client, err := resolveBundleClient(apiURL)
+	if err != nil {
+		return nil, fmt.Errorf("bundle lookup failed: %w", err)
+	}
+	if client != nil {
+		return client, nil
+	}
+
+	apiKey := stewardAPIKey
+	if apiKey == "" {
+		apiKey = os.Getenv("CFGMS_API_KEY")
+	}
+
+	tlsInsecure := stewardTLSInsecure
+	if !tlsInsecure && os.Getenv("CFGMS_TLS_INSECURE") == "true" {
+		tlsInsecure = true
+	}
+
+	tlsCACertPath := stewardTLSCACert
+	if tlsCACertPath == "" {
+		tlsCACertPath = os.Getenv("CFGMS_TLS_CA_CERT")
+	}
+
+	return newClientFromFlags(apiURL, apiKey, tlsCACertPath, tlsInsecure)
+}
+
+// stewardEntry is a local representation of a steward from the API response.
+type stewardEntry struct {
+	ID       string    `json:"id"`
+	Status   string    `json:"status"`
+	LastSeen time.Time `json:"last_seen"`
+	Version  string    `json:"version"`
+	DNA      *struct {
+		Hostname string `json:"hostname"`
+	} `json:"dna,omitempty"`
+}
+
+func runStewardList(cmd *cobra.Command, args []string) error {
+	client, err := getStewardClient()
+	if err != nil {
+		return fmt.Errorf("failed to create API client: %w", err)
+	}
+
+	resp, err := client.Get(context.Background(), "/api/v1/stewards")
+	if err != nil {
+		return fmt.Errorf("failed to fetch stewards: %w", err)
+	}
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			fmt.Printf("Failed to close response body: %v\n", err)
+		}
+	}()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("API request failed: %s - %s", resp.Status, string(body))
+	}
+
+	var apiResp struct {
+		Data []stewardEntry `json:"data"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&apiResp); err != nil {
+		return fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	if len(apiResp.Data) == 0 {
+		fmt.Println("No stewards registered.")
+		return nil
+	}
+
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	if _, err := fmt.Fprintln(w, "ID\tSTATUS\tVERSION\tLAST SEEN\tHOSTNAME"); err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintln(w, "--\t------\t-------\t---------\t--------"); err != nil {
+		return err
+	}
+	for _, s := range apiResp.Data {
+		hostname := ""
+		if s.DNA != nil {
+			hostname = s.DNA.Hostname
+		}
+		lastSeen := ""
+		if !s.LastSeen.IsZero() {
+			lastSeen = s.LastSeen.Format("2006-01-02 15:04:05")
+		}
+		if _, err := fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n", s.ID, s.Status, s.Version, lastSeen, hostname); err != nil {
+			return err
+		}
+	}
+	return w.Flush()
+}

--- a/cmd/cfg/cmd/steward_test.go
+++ b/cmd/cfg/cmd/steward_test.go
@@ -1,0 +1,140 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+package cmd
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStewardList_CallsGetStewardsEndpoint(t *testing.T) {
+	now := time.Now().UTC()
+	stewards := []map[string]interface{}{
+		{"id": "steward-abc", "status": "connected", "last_seen": now.Format(time.RFC3339)},
+		{"id": "steward-xyz", "status": "offline", "last_seen": now.Add(-5 * time.Minute).Format(time.RFC3339)},
+	}
+
+	var requestPath string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestPath = r.URL.Path
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"data":      stewards,
+			"timestamp": now,
+		})
+	}))
+	defer server.Close()
+
+	origURL := stewardURL
+	origInsecure := stewardTLSInsecure
+	t.Cleanup(func() {
+		stewardURL = origURL
+		stewardTLSInsecure = origInsecure
+	})
+
+	stewardURL = server.URL
+	stewardTLSInsecure = true
+
+	output := captureStdout(t, func() {
+		err := runStewardList(stewardListCmd, []string{})
+		require.NoError(t, err)
+	})
+
+	assert.Equal(t, "/api/v1/stewards", requestPath)
+	assert.Contains(t, output, "steward-abc")
+	assert.Contains(t, output, "steward-xyz")
+}
+
+func TestStewardList_NonOKStatusReturnsError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusUnauthorized)
+		_ = json.NewEncoder(w).Encode(map[string]string{"error": "unauthorized"})
+	}))
+	defer server.Close()
+
+	origURL := stewardURL
+	origInsecure := stewardTLSInsecure
+	t.Cleanup(func() {
+		stewardURL = origURL
+		stewardTLSInsecure = origInsecure
+	})
+
+	stewardURL = server.URL
+	stewardTLSInsecure = true
+
+	err := runStewardList(stewardListCmd, []string{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "401")
+}
+
+func TestStewardList_EmptyList(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"data":      []interface{}{},
+			"timestamp": time.Now().UTC(),
+		})
+	}))
+	defer server.Close()
+
+	origURL := stewardURL
+	origInsecure := stewardTLSInsecure
+	t.Cleanup(func() {
+		stewardURL = origURL
+		stewardTLSInsecure = origInsecure
+	})
+
+	stewardURL = server.URL
+	stewardTLSInsecure = true
+
+	output := captureStdout(t, func() {
+		err := runStewardList(stewardListCmd, []string{})
+		require.NoError(t, err)
+	})
+
+	assert.Contains(t, output, "No stewards registered")
+}
+
+func TestStewardList_FlagsRegistered(t *testing.T) {
+	assert.NotNil(t, stewardListCmd.Flags().Lookup("url"), "--url flag must be registered")
+	assert.NotNil(t, stewardListCmd.Flags().Lookup("api-key"), "--api-key flag must be registered")
+	assert.NotNil(t, stewardListCmd.Flags().Lookup("tls-ca-cert"), "--tls-ca-cert flag must be registered")
+	assert.NotNil(t, stewardListCmd.Flags().Lookup("tls-insecure"), "--tls-insecure flag must be registered")
+}
+
+func TestStewardCmd_RegisteredOnRoot(t *testing.T) {
+	var found bool
+	for _, cmd := range rootCmd.Commands() {
+		if cmd.Name() == "steward" {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found, "steward command must be registered on rootCmd")
+}
+
+func TestStewardList_UsesBundleClientPattern(t *testing.T) {
+	// Verify resolveBundleClient is used by confirming --no-bundle flag is inherited
+	// from rootCmd's persistent flags (the same flag resolveBundleClient reads).
+	f := rootCmd.PersistentFlags().Lookup("no-bundle")
+	assert.NotNil(t, f, "--no-bundle persistent flag must exist on rootCmd for bundle resolution")
+
+	// Confirm steward list is a sub-command of stewardCmd (not directly on root)
+	var found bool
+	for _, cmd := range stewardCmd.Commands() {
+		if cmd.Name() == "list" {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found, "list must be registered as subcommand of stewardCmd")
+}


### PR DESCRIPTION
## Summary

- Adds `cfg steward list` CLI subcommand that calls `GET /api/v1/stewards` on the controller and prints registered stewards in a tabular format (ID, Status, Version, Last Seen, Hostname)
- Uses `resolveBundleClient()` admin bundle auto-discovery chain (mTLS-first, API-key fallback), consistent with all other `cfg` subcommands (`controller`, `trace`, `workflow`, `storage`)
- Registers `stewardCmd` on the root command; removes the DEVELOPMENT.md GAP marker at line 556

Fixes #1543

## Files Changed

- `cmd/cfg/cmd/steward.go` — new file; `cfg steward list` implementation
- `cmd/cfg/cmd/steward_test.go` — new file; 6 tests including `TestStewardList_CallsGetStewardsEndpoint`
- `cmd/cfg/cmd/root.go` — registers `stewardCmd`
- `DEVELOPMENT.md` — removes GAP marker, replaces with working example command

## Specialist Review Results

### QA Test Runner: PASS
- All quality validation gates passed (130+ packages, lint, license headers, architecture compliance, security scan, integration tests, cross-platform builds)
- Initial run failed on 3 errcheck lint violations (fmt.Fprintln/fmt.Fprintf return values); fixed and re-run confirmed PASS

### QA Code Reviewer: PASS
- No mocks, no skipped tests, no empty assertions, no hacky workarounds
- Error path testing present (`TestStewardList_NonOKStatusReturnsError` covers HTTP 401)
- 1 warning (non-blocking): `TestStewardList_UsesBundleClientPattern` uses a proxy assertion rather than calling through the full auth chain; consistent with the project-wide pattern in `workflow_test.go`

### Security Engineer: PASS
- No hardcoded secrets, no SQL injection surface, no information disclosure
- TLS defaults to secure (system CA pool, `--tls-insecure` defaults false)
- No central provider violations; all TLS config routed through `pkg/cert` via existing `APIClient`/`newClientFromFlags`
- Automated scans: security-precommit PASS, check-architecture PASS, security-scan PASS

## Test Plan

- [ ] `cfg steward list --help` shows `--url`, `--api-key`, `--bundle`, `--no-bundle` flags
- [ ] `cfg steward list --url=<controller>` prints tabular steward list
- [ ] `cfg steward list --url=<bad-url>` returns error with HTTP status
- [ ] `make test-agent-complete` passes (validated by QA test runner)