### PR TITLE
feat(cfg): implement cfg steward status subcommand (Issue #1566)

### DIFF
--- a/cmd/cfg/cmd/steward.go
+++ b/cmd/cfg/cmd/steward.go
@@ -18,10 +18,11 @@ import (
 )
 
 var (
-	stewardURL         string
-	stewardAPIKey      string
-	stewardTLSCACert   string
-	stewardTLSInsecure bool
+	stewardURL              string
+	stewardAPIKey           string
+	stewardTLSCACert        string
+	stewardTLSInsecure      bool
+	stewardStatusJSONOutput bool
 )
 
 // stewardCmd is the parent command for steward subcommands.
@@ -57,7 +58,14 @@ func init() {
 	stewardListCmd.Flags().StringVar(&stewardTLSCACert, "tls-ca-cert", "", "Path to CA certificate for TLS verification (env: CFGMS_TLS_CA_CERT)")
 	stewardListCmd.Flags().BoolVar(&stewardTLSInsecure, "tls-insecure", false, "Skip TLS verification (development only, env: CFGMS_TLS_INSECURE)")
 
+	stewardStatusCmd.Flags().StringVar(&stewardURL, "url", "", "Controller API URL")
+	stewardStatusCmd.Flags().StringVar(&stewardAPIKey, "api-key", "", "API key for authentication")
+	stewardStatusCmd.Flags().StringVar(&stewardTLSCACert, "tls-ca-cert", "", "Path to CA certificate for TLS verification (env: CFGMS_TLS_CA_CERT)")
+	stewardStatusCmd.Flags().BoolVar(&stewardTLSInsecure, "tls-insecure", false, "Skip TLS verification (development only, env: CFGMS_TLS_INSECURE)")
+	stewardStatusCmd.Flags().BoolVar(&stewardStatusJSONOutput, "json", false, "Emit JSON output instead of human-readable text")
+
 	stewardCmd.AddCommand(stewardListCmd)
+	stewardCmd.AddCommand(stewardStatusCmd)
 }
 
 // getStewardClient creates an API client using bundle auth (mTLS) when available,
@@ -103,6 +111,116 @@ type stewardEntry struct {
 	DNA      *struct {
 		Hostname string `json:"hostname"`
 	} `json:"dna,omitempty"`
+}
+
+// stewardStatusCmd shows detailed status for a single steward.
+var stewardStatusCmd = &cobra.Command{
+	Use:   "status <id>",
+	Short: "Show detailed status for a steward",
+	Long: `Display full details for a single steward registered with the controller.
+
+Prints labelled fields including id, status, last_seen, version, hostname, OS,
+connection state, and other available metadata.
+
+Examples:
+  # Show status using admin bundle (mTLS auto-discovery)
+  cfg steward status <steward-id>
+
+  # Show status with explicit URL
+  cfg steward status <steward-id> --url=https://controller.example.com
+
+  # Show status as JSON
+  cfg steward status <steward-id> --json`,
+	Args: cobra.ExactArgs(1),
+	RunE: runStewardStatus,
+}
+
+// stewardStatusInfo is a local representation of a steward detail from the API response.
+type stewardStatusInfo struct {
+	ID              string            `json:"id"`
+	Status          string            `json:"status"`
+	LastSeen        time.Time         `json:"last_seen"`
+	Version         string            `json:"version"`
+	ConnectionState string            `json:"connection_state"`
+	ActiveSessions  int               `json:"active_sessions"`
+	TenantID        string            `json:"tenant_id,omitempty"`
+	Group           string            `json:"group,omitempty"`
+	Metrics         map[string]string `json:"metrics,omitempty"`
+	DNA             *struct {
+		Hostname     string `json:"hostname"`
+		OS           string `json:"os"`
+		Architecture string `json:"architecture"`
+	} `json:"dna,omitempty"`
+}
+
+func runStewardStatus(cmd *cobra.Command, args []string) error {
+	stewardID := args[0]
+
+	client, err := getStewardClient()
+	if err != nil {
+		return fmt.Errorf("failed to create API client: %w", err)
+	}
+
+	resp, err := client.Get(context.Background(), "/api/v1/stewards/"+stewardID)
+	if err != nil {
+		return fmt.Errorf("failed to fetch steward: %w", err)
+	}
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			fmt.Fprintf(os.Stderr, "failed to close response body: %v\n", err)
+		}
+	}()
+
+	if resp.StatusCode == http.StatusNotFound {
+		return fmt.Errorf("steward %s not found", stewardID)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("API request failed: %s - %s", resp.Status, string(body))
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("failed to read response: %w", err)
+	}
+
+	if stewardStatusJSONOutput {
+		_, err := os.Stdout.Write(body)
+		return err
+	}
+
+	var apiResp struct {
+		Data stewardStatusInfo `json:"data"`
+	}
+	if err := json.Unmarshal(body, &apiResp); err != nil {
+		return fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	s := apiResp.Data
+	fmt.Printf("ID:               %s\n", s.ID)
+	fmt.Printf("Status:           %s\n", s.Status)
+	fmt.Printf("Connection:       %s\n", s.ConnectionState)
+	lastSeen := ""
+	if !s.LastSeen.IsZero() {
+		lastSeen = s.LastSeen.Format("2006-01-02 15:04:05")
+	}
+	fmt.Printf("Last Seen:        %s\n", lastSeen)
+	fmt.Printf("Version:          %s\n", s.Version)
+	if s.DNA != nil {
+		fmt.Printf("Hostname:         %s\n", s.DNA.Hostname)
+		fmt.Printf("OS:               %s\n", s.DNA.OS)
+		if s.DNA.Architecture != "" {
+			fmt.Printf("Architecture:     %s\n", s.DNA.Architecture)
+		}
+	}
+	if s.TenantID != "" {
+		fmt.Printf("Tenant ID:        %s\n", s.TenantID)
+	}
+	if s.Group != "" {
+		fmt.Printf("Group:            %s\n", s.Group)
+	}
+	return nil
 }
 
 func runStewardList(cmd *cobra.Command, args []string) error {

--- a/cmd/cfg/cmd/steward_test.go
+++ b/cmd/cfg/cmd/steward_test.go
@@ -122,6 +122,146 @@ func TestStewardCmd_RegisteredOnRoot(t *testing.T) {
 	assert.True(t, found, "steward command must be registered on rootCmd")
 }
 
+func TestStewardStatusCommand(t *testing.T) {
+	t.Run("happy path prints labelled fields", func(t *testing.T) {
+		now := time.Now().UTC()
+		var requestPath string
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			requestPath = r.URL.Path
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"data": map[string]interface{}{
+					"id":               "steward-abc123",
+					"status":           "connected",
+					"connection_state": "connected",
+					"last_seen":        now.Format(time.RFC3339),
+					"version":          "1.0.0",
+					"tenant_id":        "default",
+					"group":            "production",
+					"dna": map[string]interface{}{
+						"hostname":     "steward-vm-1",
+						"os":           "linux",
+						"architecture": "amd64",
+					},
+				},
+				"timestamp": now,
+			})
+		}))
+		defer server.Close()
+
+		origURL := stewardURL
+		origInsecure := stewardTLSInsecure
+		t.Cleanup(func() {
+			stewardURL = origURL
+			stewardTLSInsecure = origInsecure
+		})
+		stewardURL = server.URL
+		stewardTLSInsecure = true
+
+		output := captureStdout(t, func() {
+			err := runStewardStatus(stewardStatusCmd, []string{"steward-abc123"})
+			require.NoError(t, err)
+		})
+
+		assert.Equal(t, "/api/v1/stewards/steward-abc123", requestPath)
+		assert.Contains(t, output, "steward-abc123")
+		assert.Contains(t, output, "connected")
+		assert.Contains(t, output, "1.0.0")
+		assert.Contains(t, output, "steward-vm-1")
+		assert.Contains(t, output, "linux")
+		assert.Contains(t, output, "default")
+		assert.Contains(t, output, "production")
+	})
+
+	t.Run("missing id argument returns cobra arg error", func(t *testing.T) {
+		err := stewardStatusCmd.Args(stewardStatusCmd, []string{})
+		require.Error(t, err)
+	})
+
+	t.Run("unknown id 404 returns not found error", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusNotFound)
+			_ = json.NewEncoder(w).Encode(map[string]string{"error": "steward not found"})
+		}))
+		defer server.Close()
+
+		origURL := stewardURL
+		origInsecure := stewardTLSInsecure
+		t.Cleanup(func() {
+			stewardURL = origURL
+			stewardTLSInsecure = origInsecure
+		})
+		stewardURL = server.URL
+		stewardTLSInsecure = true
+
+		err := runStewardStatus(stewardStatusCmd, []string{"nonexistent-steward-id"})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+		assert.Contains(t, err.Error(), "nonexistent-steward-id")
+	})
+
+	t.Run("non-ok non-404 status returns error", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusInternalServerError)
+			_ = json.NewEncoder(w).Encode(map[string]string{"error": "internal error"})
+		}))
+		defer server.Close()
+
+		origURL := stewardURL
+		origInsecure := stewardTLSInsecure
+		t.Cleanup(func() {
+			stewardURL = origURL
+			stewardTLSInsecure = origInsecure
+		})
+		stewardURL = server.URL
+		stewardTLSInsecure = true
+
+		err := runStewardStatus(stewardStatusCmd, []string{"steward-abc123"})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "500")
+	})
+
+	t.Run("json flag emits raw JSON response", func(t *testing.T) {
+		now := time.Now().UTC()
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"data": map[string]interface{}{
+					"id":     "steward-abc123",
+					"status": "connected",
+				},
+				"timestamp": now,
+			})
+		}))
+		defer server.Close()
+
+		origURL := stewardURL
+		origInsecure := stewardTLSInsecure
+		origJSON := stewardStatusJSONOutput
+		t.Cleanup(func() {
+			stewardURL = origURL
+			stewardTLSInsecure = origInsecure
+			stewardStatusJSONOutput = origJSON
+		})
+		stewardURL = server.URL
+		stewardTLSInsecure = true
+		stewardStatusJSONOutput = true
+
+		output := captureStdout(t, func() {
+			err := runStewardStatus(stewardStatusCmd, []string{"steward-abc123"})
+			require.NoError(t, err)
+		})
+
+		var parsed map[string]interface{}
+		require.NoError(t, json.Unmarshal([]byte(output), &parsed), "output must be valid JSON")
+		assert.Contains(t, output, "steward-abc123")
+	})
+}
+
 func TestStewardList_UsesBundleClientPattern(t *testing.T) {
 	// Verify resolveBundleClient is used by confirming --no-bundle flag is inherited
 	// from rootCmd's persistent flags (the same flag resolveBundleClient reads).

--- a/docs/deployment/fleet/walkthrough.md
+++ b/docs/deployment/fleet/walkthrough.md
@@ -328,68 +328,74 @@ Configuration executor initialized  tenant_id=default
 
 ## Phase 5 — Verify Fleet
 
-> **[GAP: `cfg steward list` and `cfg steward status` not yet implemented — see Epic #1501]**
-> These CLI verbs will wrap the REST API endpoints below. Until Epic #1501 lands, use
-> the `curl` fallback.
-
-### REST API fallback — list all stewards
-
-Extract your admin bundle's certs once for use with curl:
+### List registered stewards
 
 ```bash
-# Run on your workstation where admin.bundle.yaml is present
-python3 - <<'EOF'
-import os, yaml
-b = yaml.safe_load(open(os.path.expanduser('~/.config/cfgms/admin.bundle.yaml')))
-open('/tmp/admin.crt','w').write(b['cert_pem'])
-open('/tmp/admin.key','w').write(b['key_pem'])
-open('/tmp/admin-ca.crt','w').write(b['ca_pem'])
-EOF
-chmod 600 /tmp/admin.key
+cfg steward list
 ```
 
-List all registered stewards:
+Expected output (two stewards registered, both `connected`):
+
+```
+ID              STATUS     VERSION  LAST SEEN             HOSTNAME
+--              ------     -------  ---------             --------
+steward-abc123  connected  1.0.0    2026-05-19 00:00:30   steward-1
+steward-def456  connected  1.0.0    2026-05-19 00:00:31   steward-2
+```
+
+Note the `ID` values for each steward — you'll need them in Phase 6.
+
+### Inspect a specific steward
 
 ```bash
-curl \
-  --cacert /tmp/admin-ca.crt \
-  --cert /tmp/admin.crt \
-  --key /tmp/admin.key \
-  https://<CONTROLLER_IP>:9080/api/v1/stewards
+cfg steward status <STEWARD_ID>
 ```
 
-Expected response (two stewards registered, both `connected`):
+Expected output:
 
-```json
-{
-  "data": [
-    {
-      "id": "steward-abc123",
-      "status": "connected",
-      "last_seen": "2026-05-19T00:00:30Z",
-      "dna": { "hostname": "steward-1", "os": "linux" }
-    },
-    {
-      "id": "steward-def456",
-      "status": "connected",
-      "last_seen": "2026-05-19T00:00:31Z",
-      "dna": { "hostname": "steward-2", "os": "linux" }
-    }
-  ]
-}
+```
+ID:               steward-abc123
+Status:           connected
+Connection:       connected
+Last Seen:        2026-05-19 00:00:30
+Version:          1.0.0
+Hostname:         steward-1
+OS:               linux
+Architecture:     amd64
 ```
 
-Note the `id` values for each steward — you'll need them in Phase 6.
-
-Get details for a specific steward:
+Use `--json` to get the full machine-readable response:
 
 ```bash
-curl \
-  --cacert /tmp/admin-ca.crt \
-  --cert /tmp/admin.crt \
-  --key /tmp/admin.key \
-  https://<CONTROLLER_IP>:9080/api/v1/stewards/<STEWARD_ID>
+cfg steward status <STEWARD_ID> --json
 ```
+
+> **Alternative — REST API via curl**
+> If you prefer direct API access or need to script around the controller, the REST
+> endpoints are also available. First extract your admin bundle's certs:
+>
+> ```bash
+> python3 - <<'EOF'
+> import os, yaml
+> b = yaml.safe_load(open(os.path.expanduser('~/.config/cfgms/admin.bundle.yaml')))
+> open('/tmp/admin.crt','w').write(b['cert_pem'])
+> open('/tmp/admin.key','w').write(b['key_pem'])
+> open('/tmp/admin-ca.crt','w').write(b['ca_pem'])
+> EOF
+> chmod 600 /tmp/admin.key
+> ```
+>
+> List all stewards:
+> ```bash
+> curl --cacert /tmp/admin-ca.crt --cert /tmp/admin.crt --key /tmp/admin.key \
+>   https://<CONTROLLER_IP>:9080/api/v1/stewards
+> ```
+>
+> Get a specific steward:
+> ```bash
+> curl --cacert /tmp/admin-ca.crt --cert /tmp/admin.crt --key /tmp/admin.key \
+>   https://<CONTROLLER_IP>:9080/api/v1/stewards/<STEWARD_ID>
+> ```
 
 ### Controller-side visibility
 
@@ -514,14 +520,10 @@ cat /etc/myapp/config.yaml
 > This command will show applied/pending/failed counts and per-steward status.
 > Until #1526 lands, observe convergence via steward logs (above) and the REST API.
 
-Poll steward status via REST API to confirm `last_seen` advances with each heartbeat:
+Poll steward status to confirm `last_seen` advances with each heartbeat:
 
 ```bash
-curl \
-  --cacert /tmp/admin-ca.crt \
-  --cert /tmp/admin.crt \
-  --key /tmp/admin.key \
-  https://<CONTROLLER_IP>:9080/api/v1/stewards/<STEWARD_1_ID>
+cfg steward status <STEWARD_1_ID>
 ```
 
 A `last_seen` timestamp that advances every 30 minutes (the default convergence interval)
@@ -712,8 +714,6 @@ The table below collects all `[GAP: ...]` markers from this walkthrough for easy
 
 | Gap | Issue | Phase affected |
 |-----|-------|----------------|
-| `cfg steward list` not implemented | [Epic #1501](https://github.com/cfg-is/cfgms/issues/1501) | Phase 5 |
-| `cfg steward status` not implemented | [Epic #1501](https://github.com/cfg-is/cfgms/issues/1501) | Phase 5 |
 | `cfg config upload` not implemented | [Epic #1501](https://github.com/cfg-is/cfgms/issues/1501) | Phase 6 |
 | `cfg config deployments <id>` not implemented | [#1526](https://github.com/cfg-is/cfgms/issues/1526) | Phase 7 |
 | save=deploy auto-distribution not wired | [#1525](https://github.com/cfg-is/cfgms/issues/1525) | Phase 6 |


### PR DESCRIPTION
## Summary

- Adds `cfg steward status <id>` which calls `GET /api/v1/stewards/{id}` via mTLS bundle auto-discovery and prints labelled detail output (id, status, connection, last_seen, version, hostname, OS, architecture, tenant_id, group)
- `--json` flag emits the raw API response; missing/unknown `<id>` produces clear errors (cobra arg validation / "not found" + exit 1)
- Updates `docs/deployment/fleet/walkthrough.md` Phase 5: removes the GAP notice, promotes `cfg steward list` + `cfg steward status` as primary commands, demotes curl to an "Alternative" callout, removes both resolved rows from the Known Gaps table

Fixes #1566

## Specialist Review Results

- **QA Test Runner**: PASS — all 130+ packages, 5 new `TestStewardStatusCommand` sub-tests, linting, architecture compliance, cross-platform builds all green
- **QA Code Reviewer**: PASS — no mocks, no `t.Skip()`, all error paths covered (happy path, missing arg, 404, 500, `--json`)
- **Security Engineer**: PASS — no hardcoded secrets, no central provider violations, TLS delegated to `getStewardClient()`/`pkg/cert`, no injection risk (baseURL is fixed via mTLS bundle), all scans clean

## Test plan

- [ ] `go test ./cmd/cfg/cmd/... -run TestStewardStatus` — all 5 sub-tests pass
- [ ] `cfg steward status <id>` on a live controller prints labelled fields
- [ ] `cfg steward status nonexistent` returns exit 1 with "not found" on stderr
- [ ] `cfg steward status <id> --json` prints valid JSON
- [ ] Phase 5 of `docs/deployment/fleet/walkthrough.md` no longer contains the GAP notice

🤖 Generated with [Claude Code](https://claude.com/claude-code)