### PR TITLE
feat(cfg): implement cfg config upload subcommand (Issue #1567)

### DIFF
--- a/cmd/cfg/cmd/api_client.go
+++ b/cmd/cfg/cmd/api_client.go
@@ -226,6 +226,11 @@ func (c *APIClient) Get(ctx context.Context, path string) (*http.Response, error
 
 // doRequest performs an HTTP request with authentication
 func (c *APIClient) doRequest(ctx context.Context, method, path string, body io.Reader) (*http.Response, error) {
+	return c.doRequestWithContentType(ctx, method, path, body, "application/json")
+}
+
+// doRequestWithContentType performs an HTTP request with the specified Content-Type.
+func (c *APIClient) doRequestWithContentType(ctx context.Context, method, path string, body io.Reader, contentType string) (*http.Response, error) {
 	url := c.baseURL + path
 
 	req, err := http.NewRequestWithContext(ctx, method, url, body)
@@ -233,7 +238,7 @@ func (c *APIClient) doRequest(ctx context.Context, method, path string, body io.
 		return nil, fmt.Errorf("failed to create request: %w", err)
 	}
 
-	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Content-Type", contentType)
 	req.Header.Set("Accept", "application/json")
 	if c.apiKey != "" {
 		req.Header.Set("Authorization", "Bearer "+c.apiKey)

--- a/cmd/cfg/cmd/config.go
+++ b/cmd/cfg/cmd/config.go
@@ -1,0 +1,168 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+// Package cmd implements the CLI commands for cfg
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	configUploadStewardID   string
+	configUploadJSONOutput  bool
+	configUploadURL         string
+	configUploadAPIKey      string
+	configUploadTLSCACert   string
+	configUploadTLSInsecure bool
+)
+
+var configCmd = &cobra.Command{
+	Use:   "config",
+	Short: "Manage steward configurations",
+	Long:  `Commands for uploading and managing steward configurations.`,
+}
+
+var configUploadCmd = &cobra.Command{
+	Use:   "upload <file>",
+	Short: "Upload a YAML config to a steward",
+	Long: `Upload a YAML configuration file to a registered steward.
+
+Reads the file from disk and issues PUT /api/v1/stewards/{id}/config
+with Content-Type: application/yaml. Auth uses the admin bundle
+(mTLS auto-discovery) by default.
+
+Examples:
+  # Upload a fleet config to a steward
+  cfg config upload fleet-config.yaml --steward steward-abc123
+
+  # Upload with JSON response output
+  cfg config upload fleet-config.yaml --steward steward-abc123 --json
+
+  # Upload using explicit controller URL
+  cfg config upload fleet-config.yaml --steward steward-abc123 --url=https://ctrl.example.com:9080`,
+	Args: cobra.ExactArgs(1),
+	RunE: runConfigUpload,
+}
+
+func init() {
+	configUploadCmd.Flags().StringVar(&configUploadStewardID, "steward", "", "Steward ID to upload the config to (required)")
+	configUploadCmd.Flags().BoolVar(&configUploadJSONOutput, "json", false, "Emit raw API response JSON instead of human-readable text")
+	configUploadCmd.Flags().StringVar(&configUploadURL, "url", "", "Controller API URL (env: CFGMS_API_URL)")
+	configUploadCmd.Flags().StringVar(&configUploadAPIKey, "api-key", "", "API key for authentication (env: CFGMS_API_KEY)")
+	configUploadCmd.Flags().StringVar(&configUploadTLSCACert, "tls-ca-cert", "", "Path to CA certificate for TLS verification (env: CFGMS_TLS_CA_CERT)")
+	configUploadCmd.Flags().BoolVar(&configUploadTLSInsecure, "tls-insecure", false, "Skip TLS verification (development only)")
+
+	_ = configUploadCmd.MarkFlagRequired("steward")
+
+	configCmd.AddCommand(configUploadCmd)
+}
+
+func getConfigClient() (*APIClient, error) {
+	apiURL := configUploadURL
+	if apiURL == "" {
+		apiURL = os.Getenv("CFGMS_API_URL")
+	}
+
+	client, err := resolveBundleClient(apiURL)
+	if err != nil {
+		return nil, fmt.Errorf("bundle lookup failed: %w", err)
+	}
+	if client != nil {
+		return client, nil
+	}
+
+	apiKey := configUploadAPIKey
+	if apiKey == "" {
+		apiKey = os.Getenv("CFGMS_API_KEY")
+	}
+
+	tlsInsecure := configUploadTLSInsecure
+	if !tlsInsecure && os.Getenv("CFGMS_TLS_INSECURE") == "true" {
+		tlsInsecure = true
+	}
+
+	tlsCACertPath := configUploadTLSCACert
+	if tlsCACertPath == "" {
+		tlsCACertPath = os.Getenv("CFGMS_TLS_CA_CERT")
+	}
+
+	return newClientFromFlags(apiURL, apiKey, tlsCACertPath, tlsInsecure)
+}
+
+func runConfigUpload(cmd *cobra.Command, args []string) error {
+	filePath := args[0]
+
+	// Defense-in-depth: cobra MarkFlagRequired also enforces this
+	if configUploadStewardID == "" {
+		return fmt.Errorf("--steward flag is required")
+	}
+
+	// Validate file exists and is non-empty before any HTTP call
+	info, err := os.Stat(filePath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return fmt.Errorf("file not found: %s", filePath)
+		}
+		return fmt.Errorf("cannot access file %s: %w", filePath, err)
+	}
+	if info.Size() == 0 {
+		return fmt.Errorf("file is empty: %s", filePath)
+	}
+
+	// #nosec G304 - file path provided by user via CLI argument
+	data, err := os.ReadFile(filePath)
+	if err != nil {
+		return fmt.Errorf("failed to read file %s: %w", filePath, err)
+	}
+
+	client, err := getConfigClient()
+	if err != nil {
+		return fmt.Errorf("failed to create API client: %w", err)
+	}
+
+	path := "/api/v1/stewards/" + configUploadStewardID + "/config"
+	resp, err := client.doRequestWithContentType(context.Background(), "PUT", path, bytes.NewReader(data), "application/yaml")
+	if err != nil {
+		return fmt.Errorf("failed to upload config: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return client.parseError(resp)
+	}
+
+	bodyBytes, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("failed to read response: %w", err)
+	}
+
+	if configUploadJSONOutput {
+		_, err := os.Stdout.Write(bodyBytes)
+		return err
+	}
+
+	var apiResp struct {
+		Data struct {
+			StewardID string `json:"steward_id"`
+			Status    string `json:"status"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(bodyBytes, &apiResp); err != nil {
+		return fmt.Errorf("failed to decode response: %w", err)
+	}
+
+	status := apiResp.Data.Status
+	if status == "" {
+		status = "stored"
+	}
+
+	fmt.Printf("Configuration stored for steward %s (status: %s)\n", configUploadStewardID, status)
+	return nil
+}

--- a/cmd/cfg/cmd/config_test.go
+++ b/cmd/cfg/cmd/config_test.go
@@ -1,0 +1,246 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+// Package cmd implements the CLI commands for cfg
+package cmd
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConfigUploadCommand(t *testing.T) {
+	t.Run("happy path sends PUT with yaml content type", func(t *testing.T) {
+		var (
+			capturedMethod      string
+			capturedPath        string
+			capturedContentType string
+			capturedBody        string
+		)
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			capturedMethod = r.Method
+			capturedPath = r.URL.Path
+			capturedContentType = r.Header.Get("Content-Type")
+
+			bodyBytes, err := io.ReadAll(r.Body)
+			require.NoError(t, err)
+			capturedBody = string(bodyBytes)
+
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"data": map[string]string{
+					"steward_id": "test-steward",
+					"tenant_id":  "default",
+					"status":     "stored",
+					"message":    "Configuration stored successfully",
+				},
+				"timestamp": "2026-05-19T00:00:00Z",
+			})
+		}))
+		defer server.Close()
+
+		yamlContent := "resources:\n  - type: file\n    name: test\n"
+		tmpFile := filepath.Join(t.TempDir(), "fleet-config.yaml")
+		require.NoError(t, os.WriteFile(tmpFile, []byte(yamlContent), 0600))
+
+		origURL := configUploadURL
+		origInsecure := configUploadTLSInsecure
+		origStewardID := configUploadStewardID
+		origJSON := configUploadJSONOutput
+		t.Cleanup(func() {
+			configUploadURL = origURL
+			configUploadTLSInsecure = origInsecure
+			configUploadStewardID = origStewardID
+			configUploadJSONOutput = origJSON
+		})
+
+		configUploadURL = server.URL
+		configUploadTLSInsecure = true
+		configUploadStewardID = "test-steward"
+		configUploadJSONOutput = false
+
+		output := captureStdout(t, func() {
+			err := runConfigUpload(configUploadCmd, []string{tmpFile})
+			require.NoError(t, err)
+		})
+
+		assert.Equal(t, "PUT", capturedMethod)
+		assert.Equal(t, "/api/v1/stewards/test-steward/config", capturedPath)
+		assert.Equal(t, "application/yaml", capturedContentType)
+		assert.Equal(t, yamlContent, capturedBody)
+		assert.Contains(t, output, "Configuration stored for steward test-steward (status: stored)")
+	})
+
+	t.Run("file not found returns error before HTTP call", func(t *testing.T) {
+		httpCallCount := 0
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			httpCallCount++
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer server.Close()
+
+		origURL := configUploadURL
+		origStewardID := configUploadStewardID
+		t.Cleanup(func() {
+			configUploadURL = origURL
+			configUploadStewardID = origStewardID
+		})
+
+		configUploadURL = server.URL
+		configUploadStewardID = "test-steward"
+
+		err := runConfigUpload(configUploadCmd, []string{"/nonexistent/path/config.yaml"})
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "file not found")
+		assert.Equal(t, 0, httpCallCount, "no HTTP call should be made when file not found")
+	})
+
+	t.Run("empty file returns error before HTTP call", func(t *testing.T) {
+		httpCallCount := 0
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			httpCallCount++
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer server.Close()
+
+		tmpFile := filepath.Join(t.TempDir(), "empty-config.yaml")
+		require.NoError(t, os.WriteFile(tmpFile, []byte{}, 0600))
+
+		origURL := configUploadURL
+		origStewardID := configUploadStewardID
+		t.Cleanup(func() {
+			configUploadURL = origURL
+			configUploadStewardID = origStewardID
+		})
+
+		configUploadURL = server.URL
+		configUploadStewardID = "test-steward"
+
+		err := runConfigUpload(configUploadCmd, []string{tmpFile})
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "file is empty")
+		assert.Equal(t, 0, httpCallCount, "no HTTP call should be made when file is empty")
+	})
+
+	t.Run("missing steward flag returns error before HTTP call", func(t *testing.T) {
+		httpCallCount := 0
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			httpCallCount++
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer server.Close()
+
+		yamlContent := "resources: []\n"
+		tmpFile := filepath.Join(t.TempDir(), "fleet-config.yaml")
+		require.NoError(t, os.WriteFile(tmpFile, []byte(yamlContent), 0600))
+
+		origURL := configUploadURL
+		origStewardID := configUploadStewardID
+		t.Cleanup(func() {
+			configUploadURL = origURL
+			configUploadStewardID = origStewardID
+		})
+
+		configUploadURL = server.URL
+		configUploadStewardID = ""
+
+		err := runConfigUpload(configUploadCmd, []string{tmpFile})
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "--steward")
+		assert.Equal(t, 0, httpCallCount, "no HTTP call should be made when steward ID is missing")
+	})
+
+	t.Run("HTTP 4xx error propagated", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusNotFound)
+			_ = json.NewEncoder(w).Encode(map[string]string{
+				"error": "steward not found",
+			})
+		}))
+		defer server.Close()
+
+		yamlContent := "resources: []\n"
+		tmpFile := filepath.Join(t.TempDir(), "fleet-config.yaml")
+		require.NoError(t, os.WriteFile(tmpFile, []byte(yamlContent), 0600))
+
+		origURL := configUploadURL
+		origInsecure := configUploadTLSInsecure
+		origStewardID := configUploadStewardID
+		t.Cleanup(func() {
+			configUploadURL = origURL
+			configUploadTLSInsecure = origInsecure
+			configUploadStewardID = origStewardID
+		})
+
+		configUploadURL = server.URL
+		configUploadTLSInsecure = true
+		configUploadStewardID = "nonexistent-steward"
+
+		err := runConfigUpload(configUploadCmd, []string{tmpFile})
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "steward not found")
+	})
+
+	t.Run("json flag emits raw API response JSON", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"data": map[string]string{
+					"steward_id": "test-steward",
+					"tenant_id":  "default",
+					"status":     "stored",
+					"message":    "Configuration stored successfully",
+				},
+				"timestamp": "2026-05-19T00:00:00Z",
+			})
+		}))
+		defer server.Close()
+
+		yamlContent := "resources: []\n"
+		tmpFile := filepath.Join(t.TempDir(), "fleet-config.yaml")
+		require.NoError(t, os.WriteFile(tmpFile, []byte(yamlContent), 0600))
+
+		origURL := configUploadURL
+		origInsecure := configUploadTLSInsecure
+		origStewardID := configUploadStewardID
+		origJSON := configUploadJSONOutput
+		t.Cleanup(func() {
+			configUploadURL = origURL
+			configUploadTLSInsecure = origInsecure
+			configUploadStewardID = origStewardID
+			configUploadJSONOutput = origJSON
+		})
+
+		configUploadURL = server.URL
+		configUploadTLSInsecure = true
+		configUploadStewardID = "test-steward"
+		configUploadJSONOutput = true
+
+		output := captureStdout(t, func() {
+			err := runConfigUpload(configUploadCmd, []string{tmpFile})
+			require.NoError(t, err)
+		})
+
+		assert.True(t, strings.Contains(output, "steward_id"), "JSON output should contain steward_id")
+		assert.True(t, strings.Contains(output, "stored"), "JSON output should contain stored status")
+		// Verify output is valid JSON
+		var parsed interface{}
+		require.NoError(t, json.Unmarshal([]byte(strings.TrimSpace(output)), &parsed), "output should be valid JSON")
+	})
+}

--- a/cmd/cfg/cmd/root.go
+++ b/cmd/cfg/cmd/root.go
@@ -54,6 +54,7 @@ func init() {
 	rootCmd.AddCommand(storageCmd)
 	rootCmd.AddCommand(stewardCmd)
 	rootCmd.AddCommand(workflowCmd)
+	rootCmd.AddCommand(configCmd)
 }
 
 // versionCmd represents the version command

--- a/docs/deployment/fleet/walkthrough.md
+++ b/docs/deployment/fleet/walkthrough.md
@@ -411,39 +411,39 @@ Look for `Connected Stewards: 2` in the Transport section.
 
 ## Phase 6 — Upload a Fleet Config
 
-> **[GAP: `cfg config upload` not yet implemented — see Epic #1501]**
-> This CLI verb will wrap the `PUT /api/v1/stewards/{id}/config` REST endpoint below.
-> Until Epic #1501 lands, use the `curl` fallback.
-
 An example fleet config is in [`example-fleet-config.yaml`](example-fleet-config.yaml).
 It demonstrates a simple file and directory deployment. Edit it to match your environment
 before uploading.
 
-### REST API fallback — upload config to a steward
-
 Upload the config to each registered steward using the steward IDs from Phase 5:
 
 ```bash
-# Upload to steward-1 (Content-Type: application/yaml triggers YAML parsing in the handler)
-curl \
-  --cacert /tmp/admin-ca.crt \
-  --cert /tmp/admin.crt \
-  --key /tmp/admin.key \
-  -X PUT \
-  -H "Content-Type: application/yaml" \
-  -d @example-fleet-config.yaml \
-  https://<CONTROLLER_IP>:9080/api/v1/stewards/<STEWARD_1_ID>/config
+# Upload to steward-1
+cfg config upload example-fleet-config.yaml --steward <STEWARD_1_ID>
 
 # Upload to steward-2
-curl \
-  --cacert /tmp/admin-ca.crt \
-  --cert /tmp/admin.crt \
-  --key /tmp/admin.key \
-  -X PUT \
-  -H "Content-Type: application/yaml" \
-  -d @example-fleet-config.yaml \
-  https://<CONTROLLER_IP>:9080/api/v1/stewards/<STEWARD_2_ID>/config
+cfg config upload example-fleet-config.yaml --steward <STEWARD_2_ID>
 ```
+
+Expected output:
+
+```
+Configuration stored for steward <STEWARD_1_ID> (status: stored)
+```
+
+> **Alternative (curl)**: If you prefer the REST API directly, you can upload using
+> `PUT /api/v1/stewards/{id}/config` with `Content-Type: application/yaml`:
+>
+> ```bash
+> curl \
+>   --cacert /tmp/admin-ca.crt \
+>   --cert /tmp/admin.crt \
+>   --key /tmp/admin.key \
+>   -X PUT \
+>   -H "Content-Type: application/yaml" \
+>   -d @example-fleet-config.yaml \
+>   https://<CONTROLLER_IP>:9080/api/v1/stewards/<STEWARD_1_ID>/config
+> ```
 
 ### Trigger distribution
 
@@ -714,7 +714,6 @@ The table below collects all `[GAP: ...]` markers from this walkthrough for easy
 
 | Gap | Issue | Phase affected |
 |-----|-------|----------------|
-| `cfg config upload` not implemented | [Epic #1501](https://github.com/cfg-is/cfgms/issues/1501) | Phase 6 |
 | `cfg config deployments <id>` not implemented | [#1526](https://github.com/cfg-is/cfgms/issues/1526) | Phase 7 |
 | save=deploy auto-distribution not wired | [#1525](https://github.com/cfg-is/cfgms/issues/1525) | Phase 6 |
 | apply/monitor mode toggle not implemented | [#1524](https://github.com/cfg-is/cfgms/issues/1524) | Phase 8 |


### PR DESCRIPTION
## Summary

- Adds `cfg config upload <file> --steward <id>` to the `cfg` CLI, closing the Phase 6 GAP in the fleet walkthrough
- Validates file exists and is non-empty before any HTTP call; issues `PUT /api/v1/stewards/{id}/config` with `Content-Type: application/yaml`
- Auth via admin bundle mTLS auto-discovery (same pattern as all other cfg subcommands)
- `--json` flag emits raw API response JSON; default output: `Configuration stored for steward <id> (status: stored)`

Fixes #1567

## Changes

| File | Change |
|------|--------|
| `cmd/cfg/cmd/config.go` | New — `configCmd` + `configUploadCmd` + `runConfigUpload` |
| `cmd/cfg/cmd/config_test.go` | New — `TestConfigUploadCommand` (6 subtests) |
| `cmd/cfg/cmd/api_client.go` | Added `doRequestWithContentType`; `doRequest` delegates to it |
| `cmd/cfg/cmd/root.go` | Wired `configCmd` into `rootCmd.AddCommand` |
| `docs/deployment/fleet/walkthrough.md` | Removed Phase 6 GAP block; added CLI invocation; curl demoted to alternative; Known Gaps table updated |

## Test plan

- [ ] `cfg config upload fleet-config.yaml --steward <id>` reads file and issues PUT with `Content-Type: application/yaml`
- [ ] Missing `--steward` flag returns error before any HTTP call
- [ ] Non-existent file returns error before any HTTP call
- [ ] Empty file returns error before any HTTP call
- [ ] HTTP 4xx from server is propagated as error
- [ ] `--json` flag emits raw API response JSON

## Specialist Review Results

**QA Test Runner**: PASS — all quality validation gates passed; 6 new subtests all green; cross-platform builds verified (linux/amd64, linux/arm64, darwin/amd64, darwin/arm64, windows/amd64)

**QA Code Reviewer**: PASS (after fix) — fixed two blocking issues: (1) replaced `r.Body.Read(buf)` with `io.ReadAll` in happy-path test handler; (2) added empty-file subtest for the `info.Size() == 0` guard. One non-blocking warning about `doRequestWithContentType` having only indirect test coverage — acceptable given full behavior is exercised through `TestConfigUploadCommand`.

**Security Engineer**: PASS — no blocking issues; automated scans (security-precommit, check-architecture, security-scan) all green. One low-severity warning: steward ID concatenated into URL path without regex validation (pre-existing pattern across all cfg subcommands; non-blocking).

🤖 Generated with [Claude Code](https://claude.com/claude-code)