### PR TITLE
test(fleet): add fleet docker-compose profile + Dockerfile.debian for steward (Issue #1569)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,6 +69,7 @@ certs/
 !docs/examples/**/*.cfg
 !docs/deployment/**/*.cfg
 !examples/**/*.cfg
+!test/**/*.cfg
 *.env
 .env.local
 

--- a/cmd/steward/Dockerfile.debian
+++ b/cmd/steward/Dockerfile.debian
@@ -1,0 +1,51 @@
+# Build stage
+FROM golang:1.26.3-alpine3.23 AS builder
+
+# Install build dependencies
+RUN apk add --no-cache git ca-certificates
+
+# Set working directory
+WORKDIR /src
+
+# Copy go mod files
+COPY go.mod go.sum ./
+
+# Download dependencies
+RUN go mod download
+
+# Copy source code
+COPY . .
+
+# Build steward with compile-time controller URL
+ARG STEWARD_CONTROLLER_URL=https://localhost:9080
+RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo \
+    -ldflags="-s -w -X main.ControllerURL=${STEWARD_CONTROLLER_URL}" \
+    -o steward ./cmd/steward
+
+# Final stage - Debian bookworm-slim for fleet testing
+FROM debian:bookworm-slim
+
+# Install runtime dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    curl \
+    procps \
+    && rm -rf /var/lib/apt/lists/*
+
+# Create non-root user
+RUN groupadd -g 1001 cfgms && \
+    useradd -u 1001 -g cfgms -M -s /usr/sbin/nologin cfgms
+
+# Set working directory
+WORKDIR /app
+
+# Copy binary from builder
+COPY --from=builder /src/steward .
+
+# Change ownership
+RUN chown -R cfgms:cfgms /app
+
+# Switch to non-root user
+USER cfgms
+
+CMD ["./steward"]

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -654,6 +654,107 @@ services:
     profiles:
       - standalone  # NEW profile for Tier 1 testing
 
+  # ============================================================================
+  # FLEET TEST SERVICES
+  # 1 controller + 2 Debian stewards for fleet test framework validation
+  # Start with: docker compose --profile fleet -f docker-compose.test.yml up -d
+  # ============================================================================
+
+  fleet-controller:
+    container_name: fleet-controller
+    build:
+      context: .
+      dockerfile: cmd/controller/Dockerfile
+    ports:
+      - "4437:4433/udp"   # gRPC-over-QUIC transport
+      - "8090:9080"       # HTTP API
+    environment:
+      CFGMS_SEED_TEST_TOKENS: "1"
+      CFGMS_ENABLE_TEST_ENDPOINTS: "true"
+      CFGMS_TRANSPORT_USE_CERT_MANAGER: "true"
+      CFGMS_LOG_LEVEL: "info"
+      CFGMS_LOG_PROVIDER: "file"
+      CFGMS_LOG_DIR: "/tmp/cfgms"
+    user: root
+    command: ["sh", "-c", "mkdir -p /tmp/cfgms /app/data && ./controller --init 2>/dev/null; exec ./controller"]
+    volumes:
+      - fleet_controller_certs:/app/certs
+      - ./test/e2e/fleet/configs/controller.cfg:/app/controller.cfg:ro
+    healthcheck:
+      test: ["CMD", "sh", "-c", "netstat -ln | grep :4433"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 30s
+    networks:
+      - cfgms-fleet
+    profiles:
+      - fleet
+
+  fleet-steward-1:
+    container_name: fleet-steward-1
+    build:
+      context: .
+      dockerfile: cmd/steward/Dockerfile.debian
+      args:
+        STEWARD_CONTROLLER_URL: "https://fleet-controller:9080"
+    environment:
+      CFGMS_REGISTRATION_TOKEN: "dockertest_fleet"
+      CFGMS_HTTP_CA_CERT_PATH: "/app/controller-certs/ca/ca.crt"
+      CFGMS_LOG_LEVEL: "debug"
+      CFGMS_LOG_PROVIDER: "file"
+      CFGMS_LOG_DIR: "/tmp/cfgms"
+    command: ["sh", "-c", "mkdir -p /tmp/cfgms && ./steward --regtoken $$CFGMS_REGISTRATION_TOKEN"]
+    volumes:
+      - fleet_steward1_data:/app/data
+      - fleet_controller_certs:/app/controller-certs:ro
+    tmpfs:
+      - /test-workspace:uid=1001,gid=1001,mode=0755,exec
+    depends_on:
+      fleet-controller:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "sh", "-c", "ps aux | grep steward | grep -v grep"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+    networks:
+      - cfgms-fleet
+    profiles:
+      - fleet
+
+  fleet-steward-2:
+    container_name: fleet-steward-2
+    build:
+      context: .
+      dockerfile: cmd/steward/Dockerfile.debian
+      args:
+        STEWARD_CONTROLLER_URL: "https://fleet-controller:9080"
+    environment:
+      CFGMS_REGISTRATION_TOKEN: "dockertest_fleet"
+      CFGMS_HTTP_CA_CERT_PATH: "/app/controller-certs/ca/ca.crt"
+      CFGMS_LOG_LEVEL: "debug"
+      CFGMS_LOG_PROVIDER: "file"
+      CFGMS_LOG_DIR: "/tmp/cfgms"
+    command: ["sh", "-c", "mkdir -p /tmp/cfgms && ./steward --regtoken $$CFGMS_REGISTRATION_TOKEN"]
+    volumes:
+      - fleet_steward2_data:/app/data
+      - fleet_controller_certs:/app/controller-certs:ro
+    tmpfs:
+      - /test-workspace:uid=1001,gid=1001,mode=0755,exec
+    depends_on:
+      fleet-controller:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "sh", "-c", "ps aux | grep steward | grep -v grep"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+    networks:
+      - cfgms-fleet
+    profiles:
+      - fleet
+
   # OpenBao dev-mode instance for secrets provider integration tests.
   # Uses host port 8201 to avoid collision with any local Vault/OpenBao on 8200.
   # Start with: docker compose --profile openbao -f docker-compose.test.yml up -d openbao-test
@@ -747,6 +848,22 @@ volumes:
       type: tmpfs
       device: tmpfs
       o: size=256m
+  fleet_controller_certs:
+    driver: local
+    # CA must persist across container restarts (no tmpfs)
+    # Stewards hold client certs issued by this CA — cert validity requires persistence
+  fleet_steward1_data:
+    driver: local
+    driver_opts:
+      type: tmpfs
+      device: tmpfs
+      o: size=128m
+  fleet_steward2_data:
+    driver: local
+    driver_opts:
+      type: tmpfs
+      device: tmpfs
+      o: size=128m
 
 networks:
   cfgms-test:
@@ -756,3 +873,6 @@ networks:
       config:
         - subnet: 172.20.0.0/16
     name: cfgms-test  # Explicit network name to avoid name conflicts
+  cfgms-fleet:
+    driver: bridge
+    name: cfgms-fleet  # Isolated network for fleet test services

--- a/features/controller/server/server.go
+++ b/features/controller/server/server.go
@@ -343,6 +343,16 @@ func New(cfg *config.Config, logger logging.Logger) (*Server, error) {
 					SingleUse:     true,
 					Revoked:       false,
 				},
+				{
+					Token:         "dockertest_fleet", //nolint:gosec // test-only seeding, env-gated
+					TenantID:      "test-tenant-fleet",
+					ControllerURL: "fleet-controller:4433",
+					Group:         "test-group",
+					CreatedAt:     now,
+					ExpiresAt:     nil,
+					SingleUse:     false,
+					Revoked:       false,
+				},
 			}
 
 			for _, testToken := range testTokens {

--- a/test/e2e/fleet/configs/controller.cfg
+++ b/test/e2e/fleet/configs/controller.cfg
@@ -1,0 +1,38 @@
+# Fleet test controller configuration
+# Transport: gRPC-over-QUIC on 0.0.0.0:4433
+# Storage: flatfile (no external database required)
+# Token seeding: handled by CFGMS_SEED_TEST_TOKENS=1 env var, not in this file
+
+cert_path: "/app/certs"
+
+certificate:
+  enable_cert_management: true
+  auto_generate: true
+  ca_path: "/app/certs/ca"
+  renewal_threshold_days: 30
+  server_cert_validity_days: 365
+  client_cert_validity_days: 365
+  server:
+    common_name: "fleet-controller"
+    dns_names:
+      - "fleet-controller"
+      - "localhost"
+    ip_addresses:
+      - "127.0.0.1"
+    organization: "CFGMS Fleet Test"
+
+transport:
+  listen_addr: "0.0.0.0:4433"
+  use_cert_manager: true
+
+storage:
+  flatfile_root: "/app/data/flatfile"
+  sqlite_path: "/app/data/cfgms.db"
+
+logging:
+  level: "info"
+  provider: "file"
+  config:
+    directory: "/tmp/cfgms"
+    max_file_size: 10485760
+    max_files: 3

--- a/test/e2e/fleet/configs/steward.cfg
+++ b/test/e2e/fleet/configs/steward.cfg
@@ -1,0 +1,12 @@
+# Fleet test steward configuration
+# Registration: via CFGMS_REGISTRATION_TOKEN env var passed as --regtoken flag
+# Resources: none — fleet configs pushed from controller after registration
+
+steward:
+  id: "fleet-steward"
+  mode: "controller"
+  logging:
+    level: "info"
+    format: "text"
+
+resources: []

--- a/test/e2e/fleet/setup_test.go
+++ b/test/e2e/fleet/setup_test.go
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+package fleet
+
+import (
+	"context"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestFleetComposeStartup verifies that fleet-controller, fleet-steward-1, and fleet-steward-2
+// all reach healthy state within 60 seconds.
+// Requires: docker compose --profile fleet -f docker-compose.test.yml up -d
+func TestFleetComposeStartup(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping fleet compose startup test in short mode — requires Docker fleet infrastructure")
+	}
+
+	containers := []string{"fleet-controller", "fleet-steward-1", "fleet-steward-2"}
+
+	for _, name := range containers {
+		name := name
+		t.Run(name, func(t *testing.T) {
+			deadline := time.Now().Add(60 * time.Second)
+			for time.Now().Before(deadline) {
+				ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+				out, err := exec.CommandContext(ctx, "docker", "ps",
+					"--filter", "name="+name,
+					"--filter", "health=healthy",
+					"--format", "{{.Names}}").CombinedOutput()
+				cancel()
+
+				if err == nil && strings.Contains(string(out), name) {
+					return
+				}
+				time.Sleep(2 * time.Second)
+			}
+			t.Errorf("container %s did not reach healthy state within 60s", name)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `cmd/steward/Dockerfile.debian`: Debian bookworm-slim based steward image (ca-certificates, curl, procps, non-root cfgms user uid 1001) using the same multi-stage build pattern as the Alpine image.
- Adds `--profile fleet` section to `docker-compose.test.yml`: `fleet-controller` (flatfile storage, ports 4437:4433/udp + 8090:9080, named cert volume for CA persistence) and `fleet-steward-1`/`fleet-steward-2` (built from Dockerfile.debian, isolated on `cfgms-fleet` network).
- Adds `dockertest_fleet` token to the `testTokens` slice in `features/controller/server/server.go` inside the `CFGMS_SEED_TEST_TOKENS=1` guard.
- Adds `test/e2e/fleet/configs/controller.cfg` and `steward.cfg` as minimal fleet test configs.
- Adds `test/e2e/fleet/setup_test.go` with `TestFleetComposeStartup` that polls each container for healthy state with an independent 60s deadline per container.
- Adds `.gitignore` exception `!test/**/*.cfg` so fleet test configs are trackable.

## Specialist Review Results

### QA Test Runner: PASS
- All packages pass (`features/controller/server` with fleet token, `test/integration` all production-critical tests)
- golangci-lint: 0 issues, license headers valid, architecture compliance verified
- Cross-platform builds: linux/amd64, linux/arm64, darwin/amd64, darwin/arm64, windows/amd64 all PASS

### QA Code Reviewer: PASS (blocking issue fixed)
- Found: shared `deadline` across sequential subtests would starve later containers of polling time
- Fixed: moved `deadline := time.Now().Add(60 * time.Second)` inside the loop so each container gets its own independent 60s budget

### Security Engineer: PASS
- No hardcoded secrets, no insecure defaults, no central provider violations
- `dockertest_fleet` token is properly env-gated (`CFGMS_SEED_TEST_TOKENS=1`) with `//nolint:gosec` matching established pattern
- Fleet services isolated on `cfgms-fleet` bridge network; `CFGMS_TRANSPORT_USE_CERT_MANAGER=true` used correctly
- Automated scans: security-precommit PASS, check-architecture PASS, security-scan PASS

## Test Plan

- [ ] `docker build -f cmd/steward/Dockerfile.debian .` succeeds
- [ ] `docker exec fleet-steward-1 which apt` and `which curl` both return a path (Debian confirmed)
- [ ] `docker compose --profile fleet -f docker-compose.test.yml up -d` starts all three fleet containers and all pass healthchecks within 60s
- [ ] `go test -v -run TestFleetComposeStartup ./test/e2e/fleet/...` (with fleet compose running) passes

Fixes #1569

🤖 Generated with [Claude Code](https://claude.com/claude-code)