### PR TITLE
ci: bump GitHub Actions pins to Node.js 24-compatible releases (Issue #1583)

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -62,15 +62,15 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
     - name: Set up Go
-      uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
       with:
         go-version: ${{ env.GO_VERSION }}
 
     - name: Cache Go modules
-      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
       with:
         path: |
           ~/go/pkg/mod
@@ -85,7 +85,7 @@ jobs:
     # or a non-Go change in the same series get a fast restore + analyze.
     # Cache scope: the CodeQL action stores its DB under runner.temp by default.
     - name: Cache CodeQL database
-      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
       with:
         path: ${{ runner.temp }}/codeql_databases
         key: ${{ runner.os }}-codeql-db-${{ matrix.language }}-${{ hashFiles('**/*.go', '**/go.sum') }}
@@ -97,7 +97,7 @@ jobs:
 
     # Initialize CodeQL tools for scanning
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@480db559a14342288b67e54bd959dd52dc3ee68f # v3
+      uses: github/codeql-action/init@9e0d7b8d25671d64c341c19c0152d693099fb5ba # v4
       with:
         languages: ${{ matrix.language }}
         # Pull queries (security-extended) AND data-extension packs from a
@@ -111,7 +111,7 @@ jobs:
         dependency-caching: true
         db-location: ${{ runner.temp }}/codeql_databases
         # Enable automatic language detection
-        setup-python-dependencies: false
+
 
     # Build the Go code for CodeQL to analyze
     # CodeQL needs to trace the build to understand code flow
@@ -124,7 +124,7 @@ jobs:
 
     # Perform CodeQL Analysis
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@480db559a14342288b67e54bd959dd52dc3ee68f # v3
+      uses: github/codeql-action/analyze@9e0d7b8d25671d64c341c19c0152d693099fb5ba # v4
       with:
         category: "/language:${{ matrix.language }}"
         # Upload results to GitHub Security tab (SARIF format)
@@ -136,7 +136,7 @@ jobs:
         # fail-on: high
 
     - name: Upload CodeQL Results
-      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+      uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
       if: always()
       with:
         name: codeql-results-${{ matrix.language }}

--- a/.github/workflows/docker-security.yml
+++ b/.github/workflows/docker-security.yml
@@ -93,7 +93,7 @@ jobs:
         skip-setup-trivy: true
 
     - name: Upload Trivy results to GitHub Security tab
-      uses: github/codeql-action/upload-sarif@480db559a14342288b67e54bd959dd52dc3ee68f # v3
+      uses: github/codeql-action/upload-sarif@9e0d7b8d25671d64c341c19c0152d693099fb5ba # v4
       if: always()
       with:
         sarif_file: 'trivy-controller-results.sarif'
@@ -180,7 +180,7 @@ jobs:
         skip-setup-trivy: true
 
     - name: Upload Trivy results to GitHub Security tab
-      uses: github/codeql-action/upload-sarif@480db559a14342288b67e54bd959dd52dc3ee68f # v3
+      uses: github/codeql-action/upload-sarif@9e0d7b8d25671d64c341c19c0152d693099fb5ba # v4
       if: always()
       with:
         sarif_file: 'trivy-steward-results.sarif'

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -79,7 +79,7 @@ jobs:
         fi
     
     - name: Upload Trivy SARIF
-      uses: github/codeql-action/upload-sarif@480db559a14342288b67e54bd959dd52dc3ee68f # v3
+      uses: github/codeql-action/upload-sarif@9e0d7b8d25671d64c341c19c0152d693099fb5ba # v4
       if: always() && hashFiles('sarif-results/trivy.sarif') != ''
       with:
         sarif_file: sarif-results/trivy.sarif
@@ -200,7 +200,7 @@ jobs:
     # configuration, and results are still available via workflow artifacts.
     #
     # - name: Upload gosec SARIF
-    #   uses: github/codeql-action/upload-sarif@480db559a14342288b67e54bd959dd52dc3ee68f # v3
+    #   uses: github/codeql-action/upload-sarif@9e0d7b8d25671d64c341c19c0152d693099fb5ba # v4
     #   if: always() && hashFiles('sarif-results/gosec.sarif') != ''
     #   with:
     #     sarif_file: sarif-results/gosec.sarif


### PR DESCRIPTION
## Summary

- Bumps `actions/checkout` v4→v5, `actions/setup-go` v5→v6, `actions/cache` v4→v5, `actions/upload-artifact` v4→v6, and `github/codeql-action` v3→v4 in `codeql-analysis.yml`
- Bumps `github/codeql-action/upload-sarif` v3→v4 in `security-scan.yml` and `docker-security.yml`
- Removes deprecated `setup-python-dependencies: false` input (no-op since codeql-action v2.16)

## Why

GitHub has announced Node.js 20 deprecation on Actions runners: forced to Node 24 on **June 2 2026**, removed entirely **September 16 2026**. All bumped actions now use `node24`. CodeQL Action v3 is also deprecated December 2026; bumping to v4 eliminates both warnings in one pass since v4 ships with Node.js 24 support.

`upload-artifact` v5 was still on node20 at implementation time — v6 is the first upload-artifact major with node24 support, satisfying the AC requirement for "Node.js 24-compatible release".

## SHA pins resolved

| Action | Old | New |
|--------|-----|-----|
| `actions/checkout` | `34e11487` v4 | `93cb6efe` v5 |
| `actions/setup-go` | `40f1582b` v5 | `4a360112` v6 |
| `actions/cache` | `0057852b` v4 | `27d5ce7f` v5 |
| `actions/upload-artifact` | `ea165f8d` v4 | `b7c566a7` v6 |
| `github/codeql-action` | `480db559` v3 | `9e0d7b8d` v4 |

All SHAs verified via `action.yml` `runs.using: 'node24'` check before pinning.

## Specialist Review Results

- **QA Test Runner**: PASS — 124/124 script tests, all Go unit/integration/production-critical tests pass, cross-platform builds clean
- **QA Code Reviewer**: PASS — all SHA pins match expected values, out-of-scope pins untouched, `setup-python-dependencies` correctly removed
- **Security Engineer**: PASS — no blocking issues; all new pins are 40-char hex SHAs (not moving tags); no supply-chain regressions; gosec/Trivy/Nancy/staticcheck all clean

## Test plan

- [ ] `codeql-analysis` workflow runs green on this PR
- [ ] `security-deployment-gate` (security-scan.yml) runs green
- [ ] Inspect CodeQL job log via `gh run view --log` — confirm absence of "Node.js 20 actions are deprecated", "CodeQL Action v3 will be deprecated", and "setup-python-dependencies input is deprecated" warnings
- [ ] `docker-security` workflow runs green (triggered on Dockerfile/go.mod changes; can be verified via `workflow_dispatch`)

Fixes #1583