### PR TITLE
ci: fix CodeQL cache restore tar conflict (Issue #1584)

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -68,16 +68,7 @@ jobs:
       uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
       with:
         go-version: ${{ env.GO_VERSION }}
-
-    - name: Cache Go modules
-      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
-      with:
-        path: |
-          ~/go/pkg/mod
-          ~/.cache/go-build
-        key: ${{ runner.os }}-go-codeql-${{ hashFiles('**/go.sum') }}
-        restore-keys: |
-          ${{ runner.os }}-go-codeql-
+        cache: true  # explicit default — module cache handled here, no separate actions/cache step needed
 
     # Cache the CodeQL database between runs (Issue #1581). Keyed on a digest
     # of all Go sources + go.sum so a real code change invalidates the cache


### PR DESCRIPTION
## Summary

- Removes the redundant `Cache Go modules` step from `codeql-analysis.yml` that conflicted with `actions/setup-go@v6`'s built-in `cache: true` default
- The duplicate cache step caused thousands of `Cannot open: File exists` tar errors and wasted a 387MB download on every warm-cache CodeQL run
- Adds explicit `cache: true` to the `Set up Go` step for self-documenting intent

## Root Cause

`actions/setup-go@v6` defaults to `cache: true` and pre-populates `~/go/pkg/mod` before the explicit `actions/cache` step ran. The cache action swallowed the tar exit-2 as a warning and reported success, masking the failure. Every warm run wasted a 387MB download and forced `go mod download` to re-fetch all modules from origin.

First observed in job 76840807167 (PR #1580, 2026-05-19).

## Files Changed

- `.github/workflows/codeql-analysis.yml` — remove `Cache Go modules` step (10 lines deleted), add `cache: true` to `Set up Go` step (1 line added)

## Specialist Review Results

| Reviewer | Result |
|----------|--------|
| QA Test Runner (`make test-agent-complete`) | **PASS** — 0 failures, all in-container gates passed |
| QA Code Reviewer | **PASS** — no test quality issues, YAML-only change |
| Security Engineer | **PASS** — all scans clean, no blocking issues |

Fixes #1584