### PR TITLE
test(fleet): add fleet e2e walkthrough validation suite (Issue #1571)

### DIFF
--- a/test/e2e/fleet/configs/fleet-config.yaml
+++ b/test/e2e/fleet/configs/fleet-config.yaml
@@ -1,0 +1,36 @@
+# Fleet E2E test configuration.
+# Used by TestConfigUploadAndConvergence, TestPerModuleConvergence, and TestDriftAutoCorrection.
+# Covers file, directory, and script modules on the /test-workspace tmpfs mount.
+# Drift mode defaults to apply — required for TestDriftAutoCorrection.
+
+steward:
+  id: ""
+  mode: controller
+
+resources:
+  - name: managed-file
+    module: file
+    config:
+      path: /test-workspace/managed-file
+      state: present
+      content: "fleet-managed-content\n"
+      mode: "0644"
+      allowed_base_path: /test-workspace
+
+  - name: managed-dir
+    module: directory
+    config:
+      path: /test-workspace/managed-dir
+      state: present
+      mode: "0755"
+      allowed_base_path: /test-workspace
+
+  - name: script-runner
+    module: script
+    config:
+      shell: sh
+      signing_policy: none
+      content: |
+        #!/bin/sh
+        echo "fleet-script-executed" > /test-workspace/script-output.txt
+      timeout: 30s

--- a/test/e2e/fleet/configs/fleet-config.yaml
+++ b/test/e2e/fleet/configs/fleet-config.yaml
@@ -6,6 +6,12 @@
 steward:
   id: ""
   mode: controller
+  # Short convergence interval so TestDriftAutoCorrection observes a correction
+  # within its 90s window (default is 30m).
+  converge_interval: "10s"
+  # Apply mode auto-corrects detected drift via module.Set()/Verify().
+  # Required for TestDriftAutoCorrection's drift_setting assertion.
+  drift_mode: apply
 
 resources:
   - name: managed-file

--- a/test/e2e/fleet/drift_test.go
+++ b/test/e2e/fleet/drift_test.go
@@ -16,7 +16,10 @@ import (
 //  2. Wait until managed-file is present (config applied).
 //  3. Corrupt managed-file via docker exec.
 //  4. Wait up to 90 seconds for the steward to detect and correct the drift.
-//  5. Verify the file content is restored to "fleet-managed-content\n".
+//  5. Verify the file content is restored to "fleet-managed-content\n" (final_state).
+//  6. Assert the steward's convergence report records the drift event
+//     (drift_detected), apply mode (drift_setting), and the correction
+//     (convergence_result).
 func TestDriftAutoCorrection(t *testing.T) {
 	if os.Getenv("CFGMS_FLEET_TEST") != "1" {
 		t.Skip("Fleet E2E tests require CFGMS_FLEET_TEST=1 (run via: make test-e2e-fleet)")
@@ -39,6 +42,16 @@ func TestDriftAutoCorrection(t *testing.T) {
 	if !suite.waitForManagedFile(t, container, 60*time.Second) {
 		t.Fatalf("managed-file did not appear within 60s after config upload")
 	}
+
+	// Snapshot how many drift-detected entries the steward log already has for
+	// managed-file (the initial config apply logs one). The post-correction count
+	// must exceed this baseline, proving the *injected* drift was detected — not
+	// just the initial resource creation.
+	baselineLog, err := suite.readStewardLog(t, container)
+	if err != nil {
+		t.Fatalf("read steward log baseline: %v", err)
+	}
+	driftBaseline := countLogLinesWith(baselineLog, "drift detected", "managed-file")
 
 	// Inject drift by overwriting the file with unexpected content.
 	if _, err := suite.dockerExec(t, container, "sh", "-c",
@@ -72,4 +85,65 @@ func TestDriftAutoCorrection(t *testing.T) {
 		finalContent, _ := suite.dockerExec(t, container, "cat", "/test-workspace/managed-file")
 		t.Errorf("Drift not corrected within 90s; file content: %q", finalContent)
 	}
+
+	// Assert the steward's own convergence report records the drift cycle.
+	// The steward exposes no HTTP status endpoint, so its structured log file
+	// is the authoritative upstream report — the same convergence outcome is
+	// published to the controller as an EventConfigApplied event.
+	logContent, err := suite.readStewardLog(t, container)
+	if err != nil {
+		t.Fatalf("read steward log for drift report: %v", err)
+	}
+	assertDriftReport(t, logContent, driftBaseline)
+}
+
+// assertDriftReport verifies the steward convergence log records the facts
+// AC8 requires for a drift cycle:
+//   - drift_detected: a NEW drift event (beyond driftBaseline) was logged for
+//     the managed-file resource — i.e. the injected drift, not the initial apply.
+//   - drift_setting: apply mode is in effect (no monitor-mode skip was logged).
+//   - convergence_result: the drift was corrected by re-applying the resource.
+//
+// final_state is asserted separately above via the restored file content.
+func assertDriftReport(t *testing.T, log string, driftBaseline int) {
+	t.Helper()
+
+	// drift_detected — the Compare step logged a drift event for managed-file
+	// after the injection (count must exceed the pre-injection baseline).
+	driftCount := countLogLinesWith(log, "drift detected", "managed-file")
+	if driftCount <= driftBaseline {
+		t.Errorf("drift report: no new drift-detected entry for managed-file (count %d, baseline %d)",
+			driftCount, driftBaseline)
+	}
+
+	// drift_setting — apply mode auto-corrects; it must NOT log the monitor-mode
+	// skip. Its presence would mean the steward was running drift_setting=monitor.
+	if strings.Contains(strings.ToLower(log), "monitor mode: drift detected, skipping set") {
+		t.Errorf("drift report: steward logged a monitor-mode skip; expected drift_setting=apply")
+	}
+
+	// convergence_result — the drifted resource was successfully re-applied.
+	if countLogLinesWith(log, "applied successfully", "managed-file") == 0 {
+		t.Errorf("drift report: no successful re-apply entry for managed-file in steward log")
+	}
+}
+
+// countLogLinesWith returns the number of log lines that contain every
+// case-insensitive substring in substrs.
+func countLogLinesWith(log string, substrs ...string) int {
+	count := 0
+	for _, line := range strings.Split(log, "\n") {
+		lower := strings.ToLower(line)
+		matched := true
+		for _, sub := range substrs {
+			if !strings.Contains(lower, strings.ToLower(sub)) {
+				matched = false
+				break
+			}
+		}
+		if matched {
+			count++
+		}
+	}
+	return count
 }

--- a/test/e2e/fleet/drift_test.go
+++ b/test/e2e/fleet/drift_test.go
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+package fleet
+
+import (
+	"os"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestDriftAutoCorrection verifies that apply mode (the fleet default) auto-corrects drift.
+//
+// Flow:
+//  1. Set up the suite and upload fleet-config.yaml to fleet-steward-1.
+//  2. Wait until managed-file is present (config applied).
+//  3. Corrupt managed-file via docker exec.
+//  4. Wait up to 90 seconds for the steward to detect and correct the drift.
+//  5. Verify the file content is restored to "fleet-managed-content\n".
+func TestDriftAutoCorrection(t *testing.T) {
+	if os.Getenv("CFGMS_FLEET_TEST") != "1" {
+		t.Skip("Fleet E2E tests require CFGMS_FLEET_TEST=1 (run via: make test-e2e-fleet)")
+	}
+
+	suite := setupFleetSuite(t)
+	container := "fleet-steward-1"
+	stewardID := suite.stewardIDs[container]
+
+	if !suite.waitForConvergence(t, stewardID, 60*time.Second) {
+		t.Fatalf("steward %s not connected before drift test", stewardID)
+	}
+
+	// Upload config so the managed-file resource is declared.
+	if err := suite.uploadConfig(t, stewardID, "configs/fleet-config.yaml"); err != nil {
+		t.Fatalf("upload config before drift test: %v", err)
+	}
+
+	// Wait for the file to appear (steward applies the config).
+	if !suite.waitForManagedFile(t, container, 60*time.Second) {
+		t.Fatalf("managed-file did not appear within 60s after config upload")
+	}
+
+	// Inject drift by overwriting the file with unexpected content.
+	if _, err := suite.dockerExec(t, container, "sh", "-c",
+		`echo "drift-injected-content" > /test-workspace/managed-file`); err != nil {
+		t.Fatalf("inject drift: %v", err)
+	}
+	t.Log("Drift injected: managed-file overwritten with unexpected content")
+
+	// Confirm the write was visible (fail fast if docker exec itself errored).
+	got, err := suite.dockerExec(t, container, "cat", "/test-workspace/managed-file")
+	if err != nil {
+		t.Fatalf("verify drift injection: %v", err)
+	}
+	// The apply-mode convergence loop may correct drift quickly; log what we observe.
+	t.Logf("File content immediately after drift injection: %q", strings.TrimSpace(got))
+
+	// Wait for apply-mode convergence loop to detect and correct the drift.
+	corrected := false
+	deadline := time.Now().Add(90 * time.Second)
+	for time.Now().Before(deadline) {
+		content, err := suite.dockerExec(t, container, "cat", "/test-workspace/managed-file")
+		if err == nil && content == "fleet-managed-content\n" {
+			corrected = true
+			t.Log("Drift corrected: managed-file restored to expected content")
+			break
+		}
+		time.Sleep(2 * time.Second)
+	}
+
+	if !corrected {
+		finalContent, _ := suite.dockerExec(t, container, "cat", "/test-workspace/managed-file")
+		t.Errorf("Drift not corrected within 90s; file content: %q", finalContent)
+	}
+}

--- a/test/e2e/fleet/framework_test.go
+++ b/test/e2e/fleet/framework_test.go
@@ -3,7 +3,6 @@
 package fleet
 
 import (
-	"bytes"
 	"context"
 	"crypto/tls"
 	"crypto/x509"
@@ -13,6 +12,7 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -31,8 +31,18 @@ var validFleetContainers = map[string]bool{
 type FleetTestSuite struct {
 	controllerURL string
 	httpClient    *http.Client      // mTLS client (admin bundle) for authenticated endpoints
-	noAuthClient  *http.Client      // CA-only client for unauthenticated test endpoints
 	stewardIDs    map[string]string // container name → steward ID
+	tmpDir        string            // scratch dir for the admin bundle and patched config files
+	bundlePath    string            // admin bundle file on disk, passed to `cfg --bundle`
+}
+
+// cfgBinary returns the path to the cfg CLI binary. CFG_BINARY is exported by
+// make test-e2e-fleet; it falls back to "cfg" on PATH for ad-hoc local runs.
+func cfgBinary() string {
+	if b := os.Getenv("CFG_BINARY"); b != "" {
+		return b
+	}
+	return "cfg"
 }
 
 // adminBundle mirrors the YAML structure of /etc/cfgms/admin.bundle.yaml.
@@ -63,6 +73,7 @@ func setupFleetSuite(t *testing.T) *FleetTestSuite {
 	s := &FleetTestSuite{
 		controllerURL: "https://localhost:8090",
 		stewardIDs:    make(map[string]string),
+		tmpDir:        t.TempDir(),
 	}
 
 	for _, name := range []string{"fleet-controller", "fleet-steward-1", "fleet-steward-2"} {
@@ -106,6 +117,14 @@ func (s *FleetTestSuite) rebuildClients(t *testing.T) error {
 			bundle.CertPEM != "", bundle.KeyPEM != "", bundle.CAPEM != "")
 	}
 
+	// Persist the bundle to disk so the `cfg` CLI can authenticate via --bundle.
+	// The controller regenerates the bundle on every init, so this is rewritten
+	// after each controller restart.
+	s.bundlePath = filepath.Join(s.tmpDir, "admin.bundle.yaml")
+	if err := os.WriteFile(s.bundlePath, []byte(bundleYAML), 0o600); err != nil {
+		return fmt.Errorf("write admin bundle file: %w", err)
+	}
+
 	clientCert, err := tls.X509KeyPair([]byte(bundle.CertPEM), []byte(bundle.KeyPEM))
 	if err != nil {
 		return fmt.Errorf("load admin cert/key pair: %w", err)
@@ -123,16 +142,6 @@ func (s *FleetTestSuite) rebuildClients(t *testing.T) error {
 				Certificates: []tls.Certificate{clientCert},
 				RootCAs:      caPool,
 				MinVersion:   tls.VersionTLS13,
-			},
-		},
-	}
-
-	s.noAuthClient = &http.Client{
-		Timeout: 15 * time.Second,
-		Transport: &http.Transport{
-			TLSClientConfig: &tls.Config{
-				RootCAs:    caPool,
-				MinVersion: tls.VersionTLS13,
 			},
 		},
 	}
@@ -250,11 +259,16 @@ func (s *FleetTestSuite) getStewardConnectionState(t *testing.T, stewardID strin
 	return apiResp.Data.ConnectionState, nil
 }
 
-// uploadConfig reads configPath, patches the steward ID, and sends to the test endpoint.
-// The test endpoint (PUT /api/v1/test/stewards/{id}/config) bypasses authentication
-// when CFGMS_ENABLE_TEST_ENDPOINTS=true, which is set in the fleet docker-compose profile.
+// uploadConfig uploads configPath to a steward using the `cfg config upload` CLI —
+// the same user-facing command an operator runs. The config's steward.id is patched
+// to stewardID in a temp copy first, and the admin bundle extracted from
+// fleet-controller authenticates the mTLS request.
 func (s *FleetTestSuite) uploadConfig(t *testing.T, stewardID, configPath string) error {
 	t.Helper()
+
+	if s.bundlePath == "" {
+		return fmt.Errorf("admin bundle path not set; call rebuildClients first")
+	}
 
 	rawYAML, err := os.ReadFile(configPath)
 	if err != nil {
@@ -265,35 +279,35 @@ func (s *FleetTestSuite) uploadConfig(t *testing.T, stewardID, configPath string
 	if err := yaml.Unmarshal(rawYAML, &cfg); err != nil {
 		return fmt.Errorf("parse config YAML: %w", err)
 	}
-
 	if section, ok := cfg["steward"].(map[string]interface{}); ok {
 		section["id"] = stewardID
 	}
-
-	body, err := json.Marshal(cfg)
+	patched, err := yaml.Marshal(cfg)
 	if err != nil {
-		return fmt.Errorf("marshal config to JSON: %w", err)
+		return fmt.Errorf("marshal patched config: %w", err)
 	}
 
-	url := fmt.Sprintf("%s/api/v1/test/stewards/%s/config", s.controllerURL, stewardID)
-	req, err := http.NewRequestWithContext(context.Background(), http.MethodPut, url, bytes.NewReader(body))
+	tmpConfig := filepath.Join(s.tmpDir, "upload-"+stewardID+".yaml")
+	if err := os.WriteFile(tmpConfig, patched, 0o600); err != nil {
+		return fmt.Errorf("write temp config: %w", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	// #nosec G204 - cfgBinary() and all args are test-controlled, not user input.
+	cmd := exec.CommandContext(ctx, cfgBinary(),
+		"config", "upload", tmpConfig,
+		"--steward", stewardID,
+		"--bundle", s.bundlePath,
+		"--url", s.controllerURL)
+	out, err := cmd.CombinedOutput()
 	if err != nil {
-		return err
-	}
-	req.Header.Set("Content-Type", "application/json")
-
-	resp, err := s.noAuthClient.Do(req)
-	if err != nil {
-		return fmt.Errorf("PUT test config: %w", err)
-	}
-	defer func() { _ = resp.Body.Close() }()
-
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		respBody, _ := io.ReadAll(resp.Body)
-		return fmt.Errorf("config upload returned %d: %s", resp.StatusCode, strings.TrimSpace(string(respBody)))
+		return fmt.Errorf("cfg config upload for %s: %w (output: %s)",
+			stewardID, err, strings.TrimSpace(string(out)))
 	}
 
-	t.Logf("Config uploaded for steward %s", stewardID)
+	t.Logf("Config uploaded for steward %s via cfg config upload: %s",
+		stewardID, strings.TrimSpace(string(out)))
 	return nil
 }
 
@@ -312,6 +326,47 @@ func (s *FleetTestSuite) containerRestart(t *testing.T, container string, health
 	if !s.waitForContainerHealthy(t, container, healthTimeout) {
 		t.Fatalf("container %s did not reach healthy after restart", container)
 	}
+}
+
+// containerStop stops a fleet container (its writable layer — including the
+// stored steward cert — survives; only the /test-workspace tmpfs is cleared).
+func (s *FleetTestSuite) containerStop(t *testing.T, container string) {
+	t.Helper()
+	if err := validateFleetContainer(container); err != nil {
+		t.Fatalf("containerStop: %v", err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	if out, err := exec.CommandContext(ctx, "docker", "stop", container).CombinedOutput(); err != nil {
+		t.Fatalf("docker stop %s: %v (output: %s)", container, err, strings.TrimSpace(string(out)))
+	}
+	t.Logf("Stopped %s", container)
+}
+
+// containerStart starts a previously stopped fleet container and waits for healthy.
+func (s *FleetTestSuite) containerStart(t *testing.T, container string, healthTimeout time.Duration) {
+	t.Helper()
+	if err := validateFleetContainer(container); err != nil {
+		t.Fatalf("containerStart: %v", err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	if out, err := exec.CommandContext(ctx, "docker", "start", container).CombinedOutput(); err != nil {
+		t.Fatalf("docker start %s: %v (output: %s)", container, err, strings.TrimSpace(string(out)))
+	}
+	t.Logf("Started %s; waiting for healthy...", container)
+	if !s.waitForContainerHealthy(t, container, healthTimeout) {
+		t.Fatalf("container %s did not reach healthy after start", container)
+	}
+}
+
+// readStewardLog returns the contents of the most recent steward log file.
+// The steward exposes no HTTP status endpoint; its structured log is the
+// authoritative local record of convergence and drift events.
+func (s *FleetTestSuite) readStewardLog(t *testing.T, container string) (string, error) {
+	t.Helper()
+	return s.dockerExec(t, container, "sh", "-c",
+		`ls -t /tmp/cfgms/cfgms-*.log 2>/dev/null | head -1 | xargs cat 2>/dev/null`)
 }
 
 // TestFleetWalkthrough is the single ordered entry point for all fleet walkthrough scenarios.

--- a/test/e2e/fleet/framework_test.go
+++ b/test/e2e/fleet/framework_test.go
@@ -1,0 +1,330 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+package fleet
+
+import (
+	"bytes"
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+
+	"gopkg.in/yaml.v3"
+)
+
+// validFleetContainers is the allowlist of permitted container names.
+var validFleetContainers = map[string]bool{
+	"fleet-controller": true,
+	"fleet-steward-1":  true,
+	"fleet-steward-2":  true,
+}
+
+// FleetTestSuite holds shared state for the fleet walkthrough test sequence.
+type FleetTestSuite struct {
+	controllerURL string
+	httpClient    *http.Client      // mTLS client (admin bundle) for authenticated endpoints
+	noAuthClient  *http.Client      // CA-only client for unauthenticated test endpoints
+	stewardIDs    map[string]string // container name → steward ID
+}
+
+// adminBundle mirrors the YAML structure of /etc/cfgms/admin.bundle.yaml.
+type adminBundle struct {
+	CertPEM       string `yaml:"cert_pem"`
+	KeyPEM        string `yaml:"key_pem"`
+	CAPEM         string `yaml:"ca_pem"`
+	ControllerURL string `yaml:"controller_url"`
+}
+
+// stewardAPIResponse is the data envelope from GET /api/v1/stewards/{id}.
+type stewardAPIResponse struct {
+	Data struct {
+		ID              string `json:"id"`
+		ConnectionState string `json:"connection_state"`
+	} `json:"data"`
+}
+
+// setupFleetSuite initialises the fleet test suite.
+// Immediately skips if CFGMS_FLEET_TEST=1 is not set.
+func setupFleetSuite(t *testing.T) *FleetTestSuite {
+	t.Helper()
+
+	if os.Getenv("CFGMS_FLEET_TEST") != "1" {
+		t.Skip("Fleet E2E tests require CFGMS_FLEET_TEST=1 (run via: make test-e2e-fleet)")
+	}
+
+	s := &FleetTestSuite{
+		controllerURL: "https://localhost:8090",
+		stewardIDs:    make(map[string]string),
+	}
+
+	for _, name := range []string{"fleet-controller", "fleet-steward-1", "fleet-steward-2"} {
+		if !s.waitForContainerHealthy(t, name, 90*time.Second) {
+			t.Fatalf("container %s did not reach healthy state within 90s", name)
+		}
+	}
+
+	if err := s.rebuildClients(t); err != nil {
+		t.Fatalf("failed to build HTTP clients: %v", err)
+	}
+
+	for _, name := range []string{"fleet-steward-1", "fleet-steward-2"} {
+		id, err := s.getStewardIDFromLogs(t, name)
+		if err != nil {
+			t.Fatalf("failed to get steward ID from %s: %v", name, err)
+		}
+		s.stewardIDs[name] = id
+		t.Logf("Fleet suite: %s → steward ID %s", name, id)
+	}
+
+	return s
+}
+
+// rebuildClients re-extracts the admin bundle from fleet-controller and rebuilds both clients.
+// Call this after a controller restart (the admin bundle changes on every init).
+func (s *FleetTestSuite) rebuildClients(t *testing.T) error {
+	t.Helper()
+
+	bundleYAML, err := s.dockerExec(t, "fleet-controller", "cat", "/etc/cfgms/admin.bundle.yaml")
+	if err != nil {
+		return fmt.Errorf("read admin bundle: %w", err)
+	}
+
+	var bundle adminBundle
+	if err := yaml.Unmarshal([]byte(bundleYAML), &bundle); err != nil {
+		return fmt.Errorf("parse admin bundle: %w", err)
+	}
+	if bundle.CertPEM == "" || bundle.KeyPEM == "" || bundle.CAPEM == "" {
+		return fmt.Errorf("admin bundle incomplete (cert=%v key=%v ca=%v)",
+			bundle.CertPEM != "", bundle.KeyPEM != "", bundle.CAPEM != "")
+	}
+
+	clientCert, err := tls.X509KeyPair([]byte(bundle.CertPEM), []byte(bundle.KeyPEM))
+	if err != nil {
+		return fmt.Errorf("load admin cert/key pair: %w", err)
+	}
+
+	caPool := x509.NewCertPool()
+	if !caPool.AppendCertsFromPEM([]byte(bundle.CAPEM)) {
+		return fmt.Errorf("parse CA cert from admin bundle")
+	}
+
+	s.httpClient = &http.Client{
+		Timeout: 30 * time.Second,
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{
+				Certificates: []tls.Certificate{clientCert},
+				RootCAs:      caPool,
+				MinVersion:   tls.VersionTLS13,
+			},
+		},
+	}
+
+	s.noAuthClient = &http.Client{
+		Timeout: 15 * time.Second,
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{
+				RootCAs:    caPool,
+				MinVersion: tls.VersionTLS13,
+			},
+		},
+	}
+
+	return nil
+}
+
+// validateFleetContainer returns an error if name is not in the fleet allowlist.
+func validateFleetContainer(name string) error {
+	if !validFleetContainers[name] {
+		return fmt.Errorf("container %q not in fleet allowlist", name)
+	}
+	return nil
+}
+
+// dockerExec runs args in a named container and returns stdout output.
+func (s *FleetTestSuite) dockerExec(t *testing.T, container string, args ...string) (string, error) {
+	t.Helper()
+	if err := validateFleetContainer(container); err != nil {
+		return "", err
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	cmdArgs := append([]string{"exec", container}, args...)
+	out, err := exec.CommandContext(ctx, "docker", cmdArgs...).CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("docker exec %s %v: %w (output: %s)", container, args, err, strings.TrimSpace(string(out)))
+	}
+	return string(out), nil
+}
+
+// getStewardIDFromLogs extracts the steward ID from /tmp/cfgms log files in the container.
+// Uses the same grep pattern as test/integration/transport/module_helpers.go.
+func (s *FleetTestSuite) getStewardIDFromLogs(t *testing.T, container string) (string, error) {
+	t.Helper()
+	if err := validateFleetContainer(container); err != nil {
+		return "", err
+	}
+
+	for attempt := 1; attempt <= 30; attempt++ {
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		cmd := exec.CommandContext(ctx, "docker", "exec", container, "sh", "-c",
+			`ls -t /tmp/cfgms/cfgms-*.log 2>/dev/null | head -1 | xargs cat 2>/dev/null | grep -o '"steward_id":"[^"]*"' | tail -1 | cut -d'"' -f4`)
+		out, err := cmd.CombinedOutput()
+		cancel()
+		if id := strings.TrimSpace(string(out)); err == nil && id != "" {
+			return id, nil
+		}
+		if attempt%5 == 0 {
+			t.Logf("Waiting for steward ID in %s logs (attempt %d/30)...", container, attempt)
+		}
+		time.Sleep(1 * time.Second)
+	}
+	return "", fmt.Errorf("steward ID not found in %s logs after 30 attempts", container)
+}
+
+// waitForContainerHealthy polls docker ps until the container reports healthy or timeout expires.
+func (s *FleetTestSuite) waitForContainerHealthy(t *testing.T, container string, timeout time.Duration) bool {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		out, err := exec.CommandContext(ctx, "docker", "ps",
+			"--filter", "name="+container,
+			"--filter", "health=healthy",
+			"--format", "{{.Names}}").CombinedOutput()
+		cancel()
+		if err == nil && strings.Contains(string(out), container) {
+			t.Logf("Container %s is healthy", container)
+			return true
+		}
+		time.Sleep(2 * time.Second)
+	}
+	t.Logf("Container %s did not reach healthy within %v", container, timeout)
+	return false
+}
+
+// waitForConvergence polls GET /api/v1/stewards/{id} until connection_state == "connected".
+func (s *FleetTestSuite) waitForConvergence(t *testing.T, stewardID string, timeout time.Duration) bool {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		state, err := s.getStewardConnectionState(t, stewardID)
+		if err == nil && state == "connected" {
+			t.Logf("Steward %s: connection_state=connected", stewardID)
+			return true
+		}
+		time.Sleep(2 * time.Second)
+	}
+	t.Logf("Steward %s did not reach connected state within %v", stewardID, timeout)
+	return false
+}
+
+// getStewardConnectionState returns connection_state from GET /api/v1/stewards/{id}.
+func (s *FleetTestSuite) getStewardConnectionState(t *testing.T, stewardID string) (string, error) {
+	t.Helper()
+	url := fmt.Sprintf("%s/api/v1/stewards/%s", s.controllerURL, stewardID)
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, url, nil)
+	if err != nil {
+		return "", err
+	}
+	resp, err := s.httpClient.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return "", fmt.Errorf("GET %s: status %d: %s", url, resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+	var apiResp stewardAPIResponse
+	if err := json.NewDecoder(resp.Body).Decode(&apiResp); err != nil {
+		return "", fmt.Errorf("decode steward response: %w", err)
+	}
+	return apiResp.Data.ConnectionState, nil
+}
+
+// uploadConfig reads configPath, patches the steward ID, and sends to the test endpoint.
+// The test endpoint (PUT /api/v1/test/stewards/{id}/config) bypasses authentication
+// when CFGMS_ENABLE_TEST_ENDPOINTS=true, which is set in the fleet docker-compose profile.
+func (s *FleetTestSuite) uploadConfig(t *testing.T, stewardID, configPath string) error {
+	t.Helper()
+
+	rawYAML, err := os.ReadFile(configPath)
+	if err != nil {
+		return fmt.Errorf("read %s: %w", configPath, err)
+	}
+
+	var cfg map[string]interface{}
+	if err := yaml.Unmarshal(rawYAML, &cfg); err != nil {
+		return fmt.Errorf("parse config YAML: %w", err)
+	}
+
+	if section, ok := cfg["steward"].(map[string]interface{}); ok {
+		section["id"] = stewardID
+	}
+
+	body, err := json.Marshal(cfg)
+	if err != nil {
+		return fmt.Errorf("marshal config to JSON: %w", err)
+	}
+
+	url := fmt.Sprintf("%s/api/v1/test/stewards/%s/config", s.controllerURL, stewardID)
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodPut, url, bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := s.noAuthClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("PUT test config: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		respBody, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("config upload returned %d: %s", resp.StatusCode, strings.TrimSpace(string(respBody)))
+	}
+
+	t.Logf("Config uploaded for steward %s", stewardID)
+	return nil
+}
+
+// containerRestart restarts a fleet container and waits for it to reach healthy.
+func (s *FleetTestSuite) containerRestart(t *testing.T, container string, healthTimeout time.Duration) {
+	t.Helper()
+	if err := validateFleetContainer(container); err != nil {
+		t.Fatalf("containerRestart: %v", err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	if out, err := exec.CommandContext(ctx, "docker", "restart", container).CombinedOutput(); err != nil {
+		t.Fatalf("docker restart %s: %v (output: %s)", container, err, strings.TrimSpace(string(out)))
+	}
+	t.Logf("Restarted %s; waiting for healthy...", container)
+	if !s.waitForContainerHealthy(t, container, healthTimeout) {
+		t.Fatalf("container %s did not reach healthy after restart", container)
+	}
+}
+
+// TestFleetWalkthrough is the single ordered entry point for all fleet walkthrough scenarios.
+// Scenarios execute in definition order via t.Run so each is individually identified in output.
+func TestFleetWalkthrough(t *testing.T) {
+	suite := setupFleetSuite(t)
+	cfg := "configs/fleet-config.yaml"
+
+	t.Run("VanillaState", func(t *testing.T) { suite.testVanillaState(t) })
+	t.Run("ConfigUploadAndConvergence", func(t *testing.T) { suite.testConfigUploadAndConvergence(t, cfg) })
+	t.Run("IdempotentReUpload", func(t *testing.T) { suite.testIdempotentReUpload(t, cfg) })
+	t.Run("PerModuleConvergence", func(t *testing.T) { suite.testPerModuleConvergence(t) })
+	t.Run("ControllerRestart", func(t *testing.T) { suite.testControllerRestart(t, cfg) })
+	t.Run("StewardRestart", func(t *testing.T) { suite.testStewardRestart(t, cfg) })
+	t.Run("DeferredConfig", func(t *testing.T) { suite.testDeferredConfig(t, cfg) })
+}

--- a/test/e2e/fleet/walkthrough_test.go
+++ b/test/e2e/fleet/walkthrough_test.go
@@ -9,8 +9,10 @@ import (
 	"time"
 )
 
-// testVanillaState verifies both stewards are connected before any config is applied.
-// The /test-workspace tmpfs is empty at container start, so managed resources should not exist.
+// testVanillaState verifies both stewards are connected before any config is applied
+// and asserts that no managed resources exist yet — the /test-workspace tmpfs is
+// empty at container start, so managed-file, managed-dir, and script-output.txt
+// must all be absent until a config is uploaded.
 func (s *FleetTestSuite) testVanillaState(t *testing.T) {
 	t.Helper()
 
@@ -19,8 +21,25 @@ func (s *FleetTestSuite) testVanillaState(t *testing.T) {
 		if !s.waitForConvergence(t, stewardID, 30*time.Second) {
 			t.Errorf("steward %s (%s) not connected in vanilla state", container, stewardID)
 		}
+		s.assertNoManagedResources(t, container)
 	}
-	t.Log("VanillaState: both stewards connected, baseline established")
+	t.Log("VanillaState: both stewards connected with no managed resources")
+}
+
+// assertNoManagedResources fails if any managed resource path exists in the container.
+func (s *FleetTestSuite) assertNoManagedResources(t *testing.T, container string) {
+	t.Helper()
+	for _, path := range []string{
+		"/test-workspace/managed-file",
+		"/test-workspace/managed-dir",
+		"/test-workspace/script-output.txt",
+	} {
+		// `test -e` exits non-zero (dockerExec returns an error) when the path
+		// is absent — which is the expected vanilla state.
+		if _, err := s.dockerExec(t, container, "test", "-e", path); err == nil {
+			t.Errorf("%s: %s exists before config upload — expected vanilla state with no managed resources", container, path)
+		}
+	}
 }
 
 // testConfigUploadAndConvergence uploads fleet-config.yaml to both stewards and verifies
@@ -78,14 +97,18 @@ func (s *FleetTestSuite) testIdempotentReUpload(t *testing.T, configPath string)
 	t.Log("IdempotentReUpload: resources unchanged after second upload")
 }
 
-// testPerModuleConvergence verifies each module type individually on fleet-steward-1.
+// testPerModuleConvergence verifies each module type individually on both stewards.
 func (s *FleetTestSuite) testPerModuleConvergence(t *testing.T) {
 	t.Helper()
 
-	container := "fleet-steward-1"
-	t.Run("FileModule", func(t *testing.T) { s.verifyManagedFile(t, container) })
-	t.Run("DirectoryModule", func(t *testing.T) { s.verifyManagedDir(t, container) })
-	t.Run("ScriptModule", func(t *testing.T) { s.verifyScriptOutput(t, container) })
+	for _, container := range []string{"fleet-steward-1", "fleet-steward-2"} {
+		container := container
+		t.Run(container, func(t *testing.T) {
+			t.Run("FileModule", func(t *testing.T) { s.verifyManagedFile(t, container) })
+			t.Run("DirectoryModule", func(t *testing.T) { s.verifyManagedDir(t, container) })
+			t.Run("ScriptModule", func(t *testing.T) { s.verifyScriptOutput(t, container) })
+		})
+	}
 }
 
 // testControllerRestart restarts fleet-controller, waits for stewards to reconnect,
@@ -131,15 +154,19 @@ func (s *FleetTestSuite) testStewardRestart(t *testing.T, configPath string) {
 
 	s.containerRestart(t, container, 60*time.Second)
 
-	// The steward may re-register with a new ID after restart.
+	// AC6: the steward must reuse its stored cert and reconnect with the SAME ID.
+	// A docker restart preserves the container's writable layer (where the cert
+	// lives), so re-registration with a new ID indicates the stored-cert reuse
+	// path is broken.
 	newID, err := s.getStewardIDFromLogs(t, container)
 	if err != nil {
 		t.Fatalf("steward ID not found after %s restart: %v", container, err)
 	}
-	s.stewardIDs[container] = newID
 	if newID != oldID {
-		t.Logf("Steward re-registered: %s → %s", oldID, newID)
+		t.Errorf("steward %s re-registered after restart: %s → %s; expected stored-cert reuse (no re-registration)",
+			container, oldID, newID)
 	}
+	s.stewardIDs[container] = newID
 
 	if err := s.uploadConfig(t, newID, configPath); err != nil {
 		t.Fatalf("upload config to %s after restart: %v", container, err)
@@ -158,27 +185,55 @@ func (s *FleetTestSuite) testStewardRestart(t *testing.T, configPath string) {
 	t.Logf("StewardRestart: %s reconnected and converged (steward ID: %s)", container, newID)
 }
 
-// testDeferredConfig uploads a config for fleet-steward-2 and verifies the controller
-// stores it and the steward applies it — confirming config delivery works end-to-end
-// for a steward that may have just become available.
+// testDeferredConfig stops fleet-steward-2, uploads a config while it is offline,
+// then restarts it and verifies the controller-stored config is delivered and
+// applied on reconnect. The config upload cannot reach the steward live — it must
+// be deferred by the controller until the steward comes back online.
 func (s *FleetTestSuite) testDeferredConfig(t *testing.T, configPath string) {
 	t.Helper()
 
 	container := "fleet-steward-2"
 	stewardID := s.stewardIDs[container]
 
+	// Take steward-2 offline before uploading so the config cannot be delivered live.
+	s.containerStop(t, container)
+
+	// Upload while steward-2 is offline — the controller must store the config and
+	// hold it for delivery when the steward reconnects.
 	if err := s.uploadConfig(t, stewardID, configPath); err != nil {
-		t.Fatalf("deferred config upload to %s: %v", container, err)
+		// Restart before failing so later scenarios are not left with a dead container.
+		s.containerStart(t, container, 90*time.Second)
+		t.Fatalf("deferred config upload to %s while offline: %v", container, err)
+	}
+	t.Logf("DeferredConfig: config uploaded for %s while it was offline", container)
+
+	// Bring steward-2 back online. Its /test-workspace tmpfs is recreated empty,
+	// so any managed resources that appear are proof the deferred config was applied.
+	s.containerStart(t, container, 90*time.Second)
+
+	// The stored cert survives docker stop/start, so the ID must be unchanged.
+	newID, err := s.getStewardIDFromLogs(t, container)
+	if err != nil {
+		t.Fatalf("steward ID not found after %s restart: %v", container, err)
+	}
+	if newID != stewardID {
+		t.Errorf("steward %s re-registered after restart: %s → %s; expected stored-cert reuse",
+			container, stewardID, newID)
+	}
+	s.stewardIDs[container] = newID
+
+	if !s.waitForConvergence(t, newID, 90*time.Second) {
+		t.Fatalf("steward %s (%s) did not reconnect after coming back online", container, newID)
 	}
 
-	if !s.waitForConvergence(t, stewardID, 60*time.Second) {
-		t.Errorf("steward %s (%s) did not converge after deferred config", container, stewardID)
-		return
+	// The deferred config must now be applied even though it was uploaded offline.
+	if !s.waitForManagedFile(t, container, 60*time.Second) {
+		t.Errorf("%s: deferred config not applied — managed-file absent after restart", container)
+	} else {
+		s.verifyManagedFile(t, container)
 	}
-
-	s.verifyManagedFile(t, container)
 	s.verifyManagedDir(t, container)
-	t.Logf("DeferredConfig: %s applied config (steward ID: %s)", container, stewardID)
+	t.Logf("DeferredConfig: %s applied config uploaded while offline (steward ID: %s)", container, newID)
 }
 
 // --- shared resource verification helpers ---

--- a/test/e2e/fleet/walkthrough_test.go
+++ b/test/e2e/fleet/walkthrough_test.go
@@ -1,0 +1,256 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+package fleet
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+)
+
+// testVanillaState verifies both stewards are connected before any config is applied.
+// The /test-workspace tmpfs is empty at container start, so managed resources should not exist.
+func (s *FleetTestSuite) testVanillaState(t *testing.T) {
+	t.Helper()
+
+	for _, container := range []string{"fleet-steward-1", "fleet-steward-2"} {
+		stewardID := s.stewardIDs[container]
+		if !s.waitForConvergence(t, stewardID, 30*time.Second) {
+			t.Errorf("steward %s (%s) not connected in vanilla state", container, stewardID)
+		}
+	}
+	t.Log("VanillaState: both stewards connected, baseline established")
+}
+
+// testConfigUploadAndConvergence uploads fleet-config.yaml to both stewards and verifies
+// all three module resources (file, directory, script) are applied within 60 seconds.
+func (s *FleetTestSuite) testConfigUploadAndConvergence(t *testing.T, configPath string) {
+	t.Helper()
+
+	for _, container := range []string{"fleet-steward-1", "fleet-steward-2"} {
+		stewardID := s.stewardIDs[container]
+		if err := s.uploadConfig(t, stewardID, configPath); err != nil {
+			t.Fatalf("upload config to %s: %v", container, err)
+		}
+	}
+
+	for _, container := range []string{"fleet-steward-1", "fleet-steward-2"} {
+		stewardID := s.stewardIDs[container]
+
+		if !s.waitForConvergence(t, stewardID, 60*time.Second) {
+			t.Errorf("steward %s (%s) did not converge after config upload", container, stewardID)
+			continue
+		}
+
+		// Poll until all resources appear (controller→steward push may take a few seconds).
+		if !s.waitForManagedFile(t, container, 60*time.Second) {
+			t.Errorf("%s: managed-file did not appear within 60s", container)
+		} else {
+			s.verifyManagedFile(t, container)
+		}
+
+		s.verifyManagedDir(t, container)
+		s.verifyScriptOutput(t, container)
+	}
+}
+
+// testIdempotentReUpload re-uploads the same config and verifies resources remain correct.
+func (s *FleetTestSuite) testIdempotentReUpload(t *testing.T, configPath string) {
+	t.Helper()
+
+	for _, container := range []string{"fleet-steward-1", "fleet-steward-2"} {
+		stewardID := s.stewardIDs[container]
+		if err := s.uploadConfig(t, stewardID, configPath); err != nil {
+			t.Fatalf("re-upload config to %s: %v", container, err)
+		}
+	}
+
+	for _, container := range []string{"fleet-steward-1", "fleet-steward-2"} {
+		stewardID := s.stewardIDs[container]
+		if !s.waitForConvergence(t, stewardID, 30*time.Second) {
+			t.Errorf("steward %s (%s) disconnected after idempotent re-upload", container, stewardID)
+			continue
+		}
+		s.verifyManagedFile(t, container)
+		s.verifyManagedDir(t, container)
+	}
+	t.Log("IdempotentReUpload: resources unchanged after second upload")
+}
+
+// testPerModuleConvergence verifies each module type individually on fleet-steward-1.
+func (s *FleetTestSuite) testPerModuleConvergence(t *testing.T) {
+	t.Helper()
+
+	container := "fleet-steward-1"
+	t.Run("FileModule", func(t *testing.T) { s.verifyManagedFile(t, container) })
+	t.Run("DirectoryModule", func(t *testing.T) { s.verifyManagedDir(t, container) })
+	t.Run("ScriptModule", func(t *testing.T) { s.verifyScriptOutput(t, container) })
+}
+
+// testControllerRestart restarts fleet-controller, waits for stewards to reconnect,
+// re-uploads configs (controller loses in-memory state on restart), and verifies convergence.
+func (s *FleetTestSuite) testControllerRestart(t *testing.T, configPath string) {
+	t.Helper()
+
+	s.containerRestart(t, "fleet-controller", 60*time.Second)
+
+	// Rebuild HTTP clients — the admin bundle is regenerated on every controller init.
+	if err := s.rebuildClients(t); err != nil {
+		t.Fatalf("rebuild clients after controller restart: %v", err)
+	}
+
+	// Re-upload configs; the controller does not persist config across restarts
+	// (fleet-controller has no data volume in docker-compose.test.yml).
+	for _, container := range []string{"fleet-steward-1", "fleet-steward-2"} {
+		stewardID := s.stewardIDs[container]
+		if err := s.uploadConfig(t, stewardID, configPath); err != nil {
+			t.Fatalf("re-upload config to %s after controller restart: %v", container, err)
+		}
+	}
+
+	for _, container := range []string{"fleet-steward-1", "fleet-steward-2"} {
+		stewardID := s.stewardIDs[container]
+		if !s.waitForConvergence(t, stewardID, 90*time.Second) {
+			t.Errorf("steward %s (%s) did not reconnect after controller restart", container, stewardID)
+			continue
+		}
+		s.verifyManagedFile(t, container)
+		s.verifyManagedDir(t, container)
+	}
+	t.Log("ControllerRestart: both stewards reconnected and converged")
+}
+
+// testStewardRestart restarts fleet-steward-1, discovers its (possibly new) steward ID,
+// re-uploads config, and verifies the apply-mode steward re-applies resources on reconnect.
+func (s *FleetTestSuite) testStewardRestart(t *testing.T, configPath string) {
+	t.Helper()
+
+	container := "fleet-steward-1"
+	oldID := s.stewardIDs[container]
+
+	s.containerRestart(t, container, 60*time.Second)
+
+	// The steward may re-register with a new ID after restart.
+	newID, err := s.getStewardIDFromLogs(t, container)
+	if err != nil {
+		t.Fatalf("steward ID not found after %s restart: %v", container, err)
+	}
+	s.stewardIDs[container] = newID
+	if newID != oldID {
+		t.Logf("Steward re-registered: %s → %s", oldID, newID)
+	}
+
+	if err := s.uploadConfig(t, newID, configPath); err != nil {
+		t.Fatalf("upload config to %s after restart: %v", container, err)
+	}
+
+	if !s.waitForConvergence(t, newID, 90*time.Second) {
+		t.Fatalf("steward %s (%s) did not reconnect after restart", container, newID)
+	}
+
+	if !s.waitForManagedFile(t, container, 60*time.Second) {
+		t.Errorf("%s: managed-file did not appear after restart", container)
+	} else {
+		s.verifyManagedFile(t, container)
+	}
+	s.verifyManagedDir(t, container)
+	t.Logf("StewardRestart: %s reconnected and converged (steward ID: %s)", container, newID)
+}
+
+// testDeferredConfig uploads a config for fleet-steward-2 and verifies the controller
+// stores it and the steward applies it — confirming config delivery works end-to-end
+// for a steward that may have just become available.
+func (s *FleetTestSuite) testDeferredConfig(t *testing.T, configPath string) {
+	t.Helper()
+
+	container := "fleet-steward-2"
+	stewardID := s.stewardIDs[container]
+
+	if err := s.uploadConfig(t, stewardID, configPath); err != nil {
+		t.Fatalf("deferred config upload to %s: %v", container, err)
+	}
+
+	if !s.waitForConvergence(t, stewardID, 60*time.Second) {
+		t.Errorf("steward %s (%s) did not converge after deferred config", container, stewardID)
+		return
+	}
+
+	s.verifyManagedFile(t, container)
+	s.verifyManagedDir(t, container)
+	t.Logf("DeferredConfig: %s applied config (steward ID: %s)", container, stewardID)
+}
+
+// --- shared resource verification helpers ---
+
+// waitForManagedFile polls until /test-workspace/managed-file exists or timeout expires.
+func (s *FleetTestSuite) waitForManagedFile(t *testing.T, container string, timeout time.Duration) bool {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if _, err := s.dockerExec(t, container, "test", "-f", "/test-workspace/managed-file"); err == nil {
+			return true
+		}
+		time.Sleep(2 * time.Second)
+	}
+	return false
+}
+
+// verifyManagedFile checks /test-workspace/managed-file content and permissions.
+func (s *FleetTestSuite) verifyManagedFile(t *testing.T, container string) {
+	t.Helper()
+
+	content, err := s.dockerExec(t, container, "cat", "/test-workspace/managed-file")
+	if err != nil {
+		t.Errorf("%s: managed-file not readable: %v", container, err)
+		return
+	}
+	if content != "fleet-managed-content\n" {
+		t.Errorf("%s: managed-file content = %q, want %q", container, content, "fleet-managed-content\n")
+	}
+
+	perms, err := s.dockerExec(t, container, "stat", "-c", "%a", "/test-workspace/managed-file")
+	if err != nil {
+		t.Errorf("%s: stat managed-file: %v", container, err)
+		return
+	}
+	if got := strings.TrimSpace(perms); got != "644" {
+		t.Errorf("%s: managed-file perms = %s, want 644", container, got)
+	}
+	t.Logf("%s: managed-file verified (content: %d bytes, perms: %s)", container, len(content), strings.TrimSpace(perms))
+}
+
+// verifyManagedDir checks /test-workspace/managed-dir existence and permissions.
+func (s *FleetTestSuite) verifyManagedDir(t *testing.T, container string) {
+	t.Helper()
+
+	if _, err := s.dockerExec(t, container, "test", "-d", "/test-workspace/managed-dir"); err != nil {
+		t.Errorf("%s: managed-dir does not exist: %v", container, err)
+		return
+	}
+
+	perms, err := s.dockerExec(t, container, "stat", "-c", "%a", "/test-workspace/managed-dir")
+	if err != nil {
+		t.Errorf("%s: stat managed-dir: %v", container, err)
+		return
+	}
+	if got := strings.TrimSpace(perms); got != "755" {
+		t.Errorf("%s: managed-dir perms = %s, want 755", container, got)
+	}
+	t.Logf("%s: managed-dir verified (perms: %s)", container, strings.TrimSpace(perms))
+}
+
+// verifyScriptOutput checks that the script module wrote /test-workspace/script-output.txt.
+func (s *FleetTestSuite) verifyScriptOutput(t *testing.T, container string) {
+	t.Helper()
+
+	content, err := s.dockerExec(t, container, "cat", "/test-workspace/script-output.txt")
+	if err != nil {
+		t.Errorf("%s: script-output.txt not found: %v", container, err)
+		return
+	}
+	if !strings.Contains(content, "fleet-script-executed") {
+		t.Errorf("%s: script-output.txt = %q, want to contain %q", container, content, "fleet-script-executed")
+	}
+	t.Logf("%s: script-output.txt verified: %s", container, fmt.Sprintf("%q", strings.TrimSpace(content)))
+}


### PR DESCRIPTION
## Summary

- Adds `test/e2e/fleet/framework_test.go` — `FleetTestSuite` struct, `setupFleetSuite`, mTLS client built from runtime-extracted admin bundle, docker exec helpers with container allowlist, convergence poller, config upload via test endpoint
- Adds `test/e2e/fleet/walkthrough_test.go` — 7 ordered scenarios under a single `TestFleetWalkthrough` entry point: VanillaState, ConfigUploadAndConvergence, IdempotentReUpload, PerModuleConvergence, ControllerRestart, StewardRestart, DeferredConfig
- Adds `test/e2e/fleet/drift_test.go` — `TestDriftAutoCorrection` validates apply-mode drift correction for the file module
- Adds `test/e2e/fleet/configs/fleet-config.yaml` — fleet test config covering file, directory, and script modules on `/test-workspace` tmpfs

Tests skip unless `CFGMS_FLEET_TEST=1` is set; all existing CI checks pass unmodified.

## Test plan

- [x] `go build ./test/e2e/fleet/...` — compiles cleanly
- [x] `go vet ./test/e2e/fleet/...` — no issues
- [x] `go test -short ./test/e2e/fleet/...` — passes (fleet tests skip as expected)
- [x] `make test` — 124/124 script tests pass, all unit tests pass
- [x] `gosec ./test/e2e/fleet/...` — 0 issues
- [x] `staticcheck ./test/e2e/fleet/...` — 0 issues
- [x] QA code review: 3 blocking issues found and fixed (exec.CommandContext timeout, drift error assertion, non-asserting log block removed)
- [x] QA test runner: all 5 gates passed

Fixes #1571

🤖 Generated with [Claude Code](https://claude.com/claude-code)