### PR TITLE
pipeline: gate agent dispatch on creds + fix review-comment match (Item #BX5ezzgtQqQA)

### DIFF
--- a/.claude/agents/acceptance-reviewer.md
+++ b/.claude/agents/acceptance-reviewer.md
@@ -237,6 +237,7 @@ Post this comment on the PR regardless of verdict:
 
 ```bash
 cat > /tmp/review-<PR_NUM>.md <<'REVIEW_EOF'
+<!-- cfgms-acceptance-review -->
 ## Acceptance Review — [PASS/FAIL]
 
 ### Acceptance Criteria

--- a/.claude/scripts/agent-dispatch.sh
+++ b/.claude/scripts/agent-dispatch.sh
@@ -87,6 +87,30 @@ refresh_creds_from_host() {
     || echo "WARN: Failed to refresh credentials from host"
 }
 
+# Gate on credential validity before launching any agent container.
+# Threshold: 30 minutes (raised from 15; a 401 was observed at 27 min remaining).
+# Sets CFGMS_TEST_CREDS_STATUS to inject a synthetic result in hermetic tests.
+# Exits 10 with DISPATCH_DEFERRED:creds_low:<result> if creds are insufficient.
+gate_credentials_for_launch() {
+  local creds_status
+  if [[ -n "${CFGMS_TEST_CREDS_STATUS:-}" ]]; then
+    creds_status="$CFGMS_TEST_CREDS_STATUS"
+  else
+    creds_status=$(bash "$0" check-creds 2>/dev/null)
+  fi
+  case "$creds_status" in
+    CREDS_OK:*) ;;
+    CREDS_LOW:*|CREDS_EXPIRED:*|CREDS_MISSING:*|CREDS_ERROR:*)
+      echo "DISPATCH_DEFERRED:creds_low:${creds_status}"
+      exit 10
+      ;;
+    *)
+      echo "DISPATCH_DEFERRED:creds_low:check_creds_unknown:${creds_status}"
+      exit 10
+      ;;
+  esac
+}
+
 usage() {
   cat <<'EOF'
 Usage: agent-dispatch.sh <command> [args...]
@@ -339,9 +363,9 @@ case "$cmd" in
   launch)
     [[ $# -eq 1 ]] || { echo "launch requires exactly one issue number"; exit 1; }
     num="$1"
+    gate_credentials_for_launch
     clone_path="${WORKTREE_BASE}/story-${num}"
     real_path=$(realpath "$clone_path")
-    refresh_creds_from_host
     gh_token=$(gh auth token)
     if container_id=$(docker run -d \
       --name "cfg-agent-${num}" \
@@ -375,8 +399,8 @@ case "$cmd" in
     clone_dir="$1"; shift
     entrypoint_args=("$@")
 
+    gate_credentials_for_launch
     real_path=$(realpath "$clone_dir")
-    refresh_creds_from_host
     gh_token=$(gh auth token)
 
     # Derive mode and metadata labels from entrypoint args
@@ -697,7 +721,7 @@ now = time.time()
 remaining_min = int((exp_s - now) / 60)
 if remaining_min < 0:
     print(f'CREDS_EXPIRED:{remaining_min}')
-elif remaining_min < 15:
+elif remaining_min < 30:
     print(f'CREDS_LOW:{remaining_min}')
 else:
     print(f'CREDS_OK:{remaining_min}')
@@ -854,6 +878,8 @@ else:
       echo "ERROR: PR number must be numeric, got '${pr_num}'"
       exit 1
     fi
+
+    gate_credentials_for_launch
 
     # Validate PR + auto-detect story number.
     pr_meta=$(gh pr view "$pr_num" --repo cfg-is/cfgms \
@@ -1032,7 +1058,6 @@ PROMPT_EOF
     fi
 
     real_path=$(realpath "$clone_dir")
-    refresh_creds_from_host
     gh_token=$(gh auth token)
 
     # Determine story label: 0 for item-branch PRs (no linked issue).

--- a/.claude/scripts/po-cycle-preflight.py
+++ b/.claude/scripts/po-cycle-preflight.py
@@ -358,12 +358,26 @@ def gh_graphql_pr_states(numbers):
     return out
 
 
+_ACCEPTANCE_REVIEW_SENTINEL = "<!-- cfgms-acceptance-review -->"
+_ACCEPTANCE_REVIEW_HEADING = "## acceptance review"
+
+
 def is_trusted_review_comment(comment):
-    """Return True only for cfg-agent acceptance-review comments; rejects forgery attempts."""
-    return (
-        comment.get("author", {}).get("login") == "cfg-agent"
-        and "acceptance review" in (comment.get("body") or "").lower()
-    )
+    """Return True for genuine acceptance-review comments.
+
+    Matches by machine sentinel or structural heading:
+    1. Machine sentinel <!-- cfgms-acceptance-review --> — emitted by the
+       acceptance-reviewer agent in every comment (added in item #BX5ezzgtQqQA).
+    2. Structural heading '## Acceptance Review' — backward-compatible with
+       existing comments that predate the sentinel (e.g. PR #1589 authored by
+       jrdnr via the host gh token before the sentinel was introduced).
+
+    Author-login matching was removed because review comments are posted via
+    the host gh token (identity: jrdnr), not a dedicated cfg-agent bot account.
+    Forgery resistance is an accepted tradeoff documented in item #BX5ezzgtQqQA.
+    """
+    body = (comment.get("body") or "").lower()
+    return _ACCEPTANCE_REVIEW_SENTINEL in body or _ACCEPTANCE_REVIEW_HEADING in body
 
 
 def _pq_script_path():

--- a/scripts/test-scripts.sh
+++ b/scripts/test-scripts.sh
@@ -1891,6 +1891,7 @@ DOCKEREOF
         PATH="${tmp_dir}:${PATH}" \
         CFGMS_TEST_REPO_ROOT="$fake_repo" \
         CFGMS_TEST_WORKTREE_BASE="$worktree_dir" \
+        CFGMS_TEST_CREDS_STATUS="CREDS_OK:60" \
         bash "$dispatch_script" review-pr 77 2>&1
     ) || exit_code=$?
 
@@ -2071,6 +2072,183 @@ FAILPQEOF
     fi
 }
 
+test_dispatch_creds_gate() {
+    log_test "Testing agent-dispatch.sh: launch/review-pr gate on CREDS_LOW/EXPIRED, emit DISPATCH_DEFERRED..."
+
+    local dispatch_script
+    dispatch_script="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/../.claude/scripts/agent-dispatch.sh"
+
+    if [[ ! -f "$dispatch_script" ]]; then
+        log_fail "dispatch_creds_gate: script not found at $dispatch_script"
+        return
+    fi
+
+    # CREDS_LOW causes launch to exit non-zero with DISPATCH_DEFERRED token
+    local output exit_code=0
+    output=$(CFGMS_TEST_CREDS_STATUS="CREDS_LOW:5" bash "$dispatch_script" launch 99 2>&1) || exit_code=$?
+    if [[ $exit_code -ne 0 ]]; then
+        log_pass "dispatch_creds_gate launch CREDS_LOW: exits non-zero"
+    else
+        log_fail "dispatch_creds_gate launch CREDS_LOW: expected non-zero exit, got 0: ${output}"
+    fi
+    if echo "$output" | grep -q "DISPATCH_DEFERRED:creds_low:CREDS_LOW:5"; then
+        log_pass "dispatch_creds_gate launch CREDS_LOW: emits DISPATCH_DEFERRED:creds_low:CREDS_LOW:5"
+    else
+        log_fail "dispatch_creds_gate launch CREDS_LOW: expected DISPATCH_DEFERRED:creds_low:CREDS_LOW:5 in output: ${output}"
+    fi
+
+    # CREDS_EXPIRED causes launch to exit non-zero with DISPATCH_DEFERRED token
+    exit_code=0
+    output=$(CFGMS_TEST_CREDS_STATUS="CREDS_EXPIRED:-3" bash "$dispatch_script" launch 99 2>&1) || exit_code=$?
+    if [[ $exit_code -ne 0 ]]; then
+        log_pass "dispatch_creds_gate launch CREDS_EXPIRED: exits non-zero"
+    else
+        log_fail "dispatch_creds_gate launch CREDS_EXPIRED: expected non-zero exit, got 0: ${output}"
+    fi
+    if echo "$output" | grep -q "DISPATCH_DEFERRED:creds_low:CREDS_EXPIRED:-3"; then
+        log_pass "dispatch_creds_gate launch CREDS_EXPIRED: emits DISPATCH_DEFERRED:creds_low:CREDS_EXPIRED:-3"
+    else
+        log_fail "dispatch_creds_gate launch CREDS_EXPIRED: expected DISPATCH_DEFERRED:creds_low:CREDS_EXPIRED:-3 in output: ${output}"
+    fi
+
+    # CREDS_LOW causes review-pr to exit non-zero with DISPATCH_DEFERRED token
+    exit_code=0
+    output=$(CFGMS_TEST_CREDS_STATUS="CREDS_LOW:2" bash "$dispatch_script" review-pr 1589 2>&1) || exit_code=$?
+    if [[ $exit_code -ne 0 ]]; then
+        log_pass "dispatch_creds_gate review-pr CREDS_LOW: exits non-zero"
+    else
+        log_fail "dispatch_creds_gate review-pr CREDS_LOW: expected non-zero exit, got 0: ${output}"
+    fi
+    if echo "$output" | grep -q "DISPATCH_DEFERRED:creds_low:CREDS_LOW:2"; then
+        log_pass "dispatch_creds_gate review-pr CREDS_LOW: emits DISPATCH_DEFERRED:creds_low:CREDS_LOW:2"
+    else
+        log_fail "dispatch_creds_gate review-pr CREDS_LOW: expected DISPATCH_DEFERRED:creds_low:CREDS_LOW:2 in output: ${output}"
+    fi
+
+    # CREDS_LOW causes launch-generic to exit non-zero with DISPATCH_DEFERRED token
+    exit_code=0
+    output=$(CFGMS_TEST_CREDS_STATUS="CREDS_LOW:8" bash "$dispatch_script" launch-generic "cfg-agent-test" "/tmp/nonexistent" 2>&1) || exit_code=$?
+    if [[ $exit_code -ne 0 ]]; then
+        log_pass "dispatch_creds_gate launch-generic CREDS_LOW: exits non-zero"
+    else
+        log_fail "dispatch_creds_gate launch-generic CREDS_LOW: expected non-zero exit, got 0: ${output}"
+    fi
+    if echo "$output" | grep -q "DISPATCH_DEFERRED:creds_low:CREDS_LOW:8"; then
+        log_pass "dispatch_creds_gate launch-generic CREDS_LOW: emits DISPATCH_DEFERRED:creds_low:CREDS_LOW:8"
+    else
+        log_fail "dispatch_creds_gate launch-generic CREDS_LOW: expected DISPATCH_DEFERRED:creds_low:CREDS_LOW:8 in output: ${output}"
+    fi
+}
+
+test_preflight_acceptance_review_comment_match() {
+    log_test "Testing po-cycle-preflight.py: is_trusted_review_comment matches sentinel and heading, not just author..."
+
+    local preflight_script
+    preflight_script="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/../.claude/scripts/po-cycle-preflight.py"
+
+    if [[ ! -f "$preflight_script" ]]; then
+        log_fail "po-cycle-preflight.py: not found at $preflight_script"
+        return
+    fi
+
+    local tmp_py
+    tmp_py=$(mktemp --suffix=.py)
+    trap 'rm -f "$tmp_py"' RETURN
+
+    cat > "$tmp_py" << 'PYEOF'
+import sys, importlib.util, os
+
+script_path = os.environ["PREFLIGHT_SCRIPT"]
+spec = importlib.util.spec_from_file_location("preflight", script_path)
+mod = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(mod)
+
+# Part A: sentinel in body matches regardless of author (forward-compat path)
+sentinel_comment = {
+    "author": {"login": "jrdnr"},
+    "body": "<!-- cfgms-acceptance-review -->\n## Acceptance Review — PASS\n\nAll checks passing.",
+}
+result = mod.is_trusted_review_comment(sentinel_comment)
+if result:
+    print("PASS_A: sentinel match accepted (author=jrdnr, sentinel present)")
+else:
+    print("FAIL_A: sentinel comment rejected — expected True")
+    sys.exit(1)
+
+# Part B: ## Acceptance Review heading from jrdnr matches (backward compat, PR #1589 scenario)
+heading_comment = {
+    "author": {"login": "jrdnr"},
+    "body": "## Acceptance Review — FAIL\n\n### Findings\n| 1 | High | ... |",
+}
+result = mod.is_trusted_review_comment(heading_comment)
+if result:
+    print("PASS_B: heading match accepted (author=jrdnr, ## Acceptance Review heading present)")
+else:
+    print("FAIL_B: heading-only comment rejected — expected True for backward compat")
+    sys.exit(1)
+
+# Part C: plain body with 'acceptance review' but no ## heading or sentinel is rejected
+plain_comment = {
+    "author": {"login": "anyone"},
+    "body": "acceptance review: LGTM",
+}
+result = mod.is_trusted_review_comment(plain_comment)
+if not result:
+    print("PASS_C: plain 'acceptance review' body (no ## heading, no sentinel) correctly rejected")
+else:
+    print("FAIL_C: plain comment accepted as trusted — expected False")
+    sys.exit(1)
+
+# Part D: compute_review_recommendations does NOT recommend spawn_acceptance_reviewer
+# for a PR whose comment matches the heading (PR #1589 regression test)
+pr_summary = {
+    "pr": 1589,
+    "story_number": 1570,
+    "has_acceptance_review_comment": True,  # already set by preflight using new logic
+    "wip_session_failed": False,
+    "merge_state_status": "MERGEABLE",
+    "mergeable": "MERGEABLE",
+    "auto_merge_enabled": False,
+    "ci_summary": {
+        "overall": "green",
+        "pass": 4, "pending": 0, "fail": 0, "skipped": 0,
+        "pending_checks": [], "failed_checks": [],
+    },
+}
+recs = mod.compute_review_recommendations([pr_summary], set(), set())
+if not recs:
+    print("FAIL_D: compute_review_recommendations returned empty list")
+    sys.exit(1)
+action = recs[0].get("action", "")
+if action != "spawn_acceptance_reviewer":
+    print(f"PASS_D: PR #1589 with existing review comment gets action={action!r} (not spawn_acceptance_reviewer)")
+else:
+    print("FAIL_D: PR #1589 recommended spawn_acceptance_reviewer despite existing review comment")
+    sys.exit(1)
+PYEOF
+
+    local exit_code=0
+    local output
+    output=$(PREFLIGHT_SCRIPT="$preflight_script" python3 "$tmp_py" 2>&1) || exit_code=$?
+
+    while IFS= read -r line; do
+        case "$line" in
+            PASS_A:*) log_pass "preflight review match: ${line#PASS_A: }" ;;
+            PASS_B:*) log_pass "preflight review match: ${line#PASS_B: }" ;;
+            PASS_C:*) log_pass "preflight review match: ${line#PASS_C: }" ;;
+            PASS_D:*) log_pass "preflight review match: ${line#PASS_D: }" ;;
+            FAIL_A:*) log_fail "preflight review match: ${line#FAIL_A: }" ;;
+            FAIL_B:*) log_fail "preflight review match: ${line#FAIL_B: }" ;;
+            FAIL_C:*) log_fail "preflight review match: ${line#FAIL_C: }" ;;
+            FAIL_D:*) log_fail "preflight review match: ${line#FAIL_D: }" ;;
+        esac
+    done <<< "$output"
+
+    if [[ $exit_code -ne 0 ]] && ! grep -q "^FAIL" <<< "$output"; then
+        log_fail "preflight acceptance review comment match: Python test crashed (exit $exit_code): $output"
+    fi
+}
+
 # Main execution
 echo "🔍 Script Validation Test Suite"
 echo "================================"
@@ -2130,6 +2308,10 @@ echo ""
 test_preflight_forged_acceptance_review
 echo ""
 test_preflight_gh_call_budget
+echo ""
+test_dispatch_creds_gate
+echo ""
+test_preflight_acceptance_review_comment_match
 echo ""
 test_trust_boundary
 echo ""


### PR DESCRIPTION
## Summary

- **Bug 1 (creds gate)**: `launch`, `launch-generic`, and `review-pr` dispatch paths called `refresh_creds_from_host` unconditionally but never checked credential validity. Added `gate_credentials_for_launch()` that calls `check-creds` (which refreshes first) and exits 10 with `DISPATCH_DEFERRED:creds_low:<result>` if creds are low/expired/missing. Raised threshold from 15→30 minutes (401 observed at 27 min remaining). Containers `cfg-agent-1570` and `cfg-agent-review-pr-1589` both burned 2026-05-19 due to this gap.
- **Bug 2 (review-comment match)**: `is_trusted_review_comment` required `author.login == "cfg-agent"` but no such bot account exists — review comments post as `jrdnr` via the host gh token. Replaced with body-content matching: HTML sentinel `<!-- cfgms-acceptance-review -->` (added to reviewer template) and `## Acceptance Review` heading (backward-compat for PR #1589 and all prior comments). Phantom `spawn_acceptance_reviewer` recommendations on already-reviewed PRs are now resolved.

## Test plan

- [ ] `test_dispatch_creds_gate`: 8 assertions — `CREDS_LOW`/`CREDS_EXPIRED` on `launch`, `launch-generic`, `review-pr` all exit non-zero with `DISPATCH_DEFERRED:creds_low:…`
- [ ] `test_preflight_acceptance_review_comment_match`: 4 assertions — sentinel match, `## Acceptance Review` heading backward-compat (PR #1589 scenario), plain text rejection, `compute_review_recommendations` non-regression
- [ ] Updated `test_review_pr_item_branch` to pass `CFGMS_TEST_CREDS_STATUS=CREDS_OK:60` so it still exercises the item-branch scan path rather than early-exiting on the creds gate
- [ ] Full script test suite: 136 passed, 0 failed (was 120 pass before this story)

## Specialist Review Results

- **QA Test Runner**: PASS — 136/136 script tests, all Go packages pass with race detection, cross-platform compilation verified (5 platforms)
- **QA Code Reviewer**: PASS — 0 blocking issues; 4 non-blocking warnings (missing CREDS_OK happy-path direct assertion, coverage gaps on CREDS_MISSING/ERROR branches, test early-exit cascade fragility, stale test description label)
- **Security Engineer**: PASS — 0 blocking issues; 2 LOW warnings (forgery-resistance tradeoff documented in item body, CFGMS_TEST_CREDS_STATUS scoping verified safe); all automated scans (security-precommit, check-architecture, security-scan) PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)


Fixes #1593
