### PR TITLE
rbac(jit): replace hardcoded escalation recipients with configurable approver registry (Issue #1604)

### DIFF
--- a/features/rbac/jit/approver_registry.go
+++ b/features/rbac/jit/approver_registry.go
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+package jit
+
+import "context"
+
+// EscalationTypeDefault is the key used by SendEscalationNotification when querying the registry.
+// Operators configure recipients for this key to control who receives escalation alerts.
+const EscalationTypeDefault = "escalation"
+
+// ApproverRegistry resolves the set of recipients for a given escalation type.
+// Implementations can be backed by controller config, a database, or any other
+// operator-controlled source so that escalation targets are configurable without
+// code modification.
+type ApproverRegistry interface {
+	GetApprovers(ctx context.Context, escalationType string) ([]string, error)
+}
+
+// StaticApproverRegistry is an ApproverRegistry backed by a static map of
+// escalation type → recipient slice. It is the default implementation for
+// controller-config-driven deployments.
+//
+// The empty-string key "" acts as a fallback for escalation types not
+// explicitly mapped.
+type StaticApproverRegistry struct {
+	approvers map[string][]string
+}
+
+// NewStaticApproverRegistry creates a StaticApproverRegistry from the provided map.
+// Use an empty-string key "" as a catch-all for types not explicitly listed.
+func NewStaticApproverRegistry(approvers map[string][]string) *StaticApproverRegistry {
+	return &StaticApproverRegistry{approvers: approvers}
+}
+
+// GetApprovers returns the recipient list for escalationType, falling back to
+// the "" key if the type is not explicitly mapped. Returns nil (no error) when
+// neither the type nor the fallback is present.
+func (r *StaticApproverRegistry) GetApprovers(_ context.Context, escalationType string) ([]string, error) {
+	if recipients, ok := r.approvers[escalationType]; ok {
+		return recipients, nil
+	}
+	if fallback, ok := r.approvers[""]; ok {
+		return fallback, nil
+	}
+	return nil, nil
+}

--- a/features/rbac/jit/notification.go
+++ b/features/rbac/jit/notification.go
@@ -5,6 +5,7 @@ package jit
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"time"
 )
 
@@ -12,12 +13,23 @@ import (
 type SimpleNotificationService struct {
 	// Deferred: tracked in #1441 — integrate with email, Slack, and other delivery channels
 	notifications []NotificationRecord
+	registry      ApproverRegistry
 }
 
-// NewSimpleNotificationService creates a new simple notification service
+// NewSimpleNotificationService creates a new simple notification service without a registry.
+// SendEscalationNotification will log a warning and record the notification with no recipients.
 func NewSimpleNotificationService() *SimpleNotificationService {
 	return &SimpleNotificationService{
 		notifications: make([]NotificationRecord, 0),
+	}
+}
+
+// NewSimpleNotificationServiceWithRegistry creates a notification service that resolves
+// escalation recipients from the provided ApproverRegistry.
+func NewSimpleNotificationServiceWithRegistry(registry ApproverRegistry) *SimpleNotificationService {
+	return &SimpleNotificationService{
+		notifications: make([]NotificationRecord, 0),
+		registry:      registry,
 	}
 }
 
@@ -233,7 +245,9 @@ func (sns *SimpleNotificationService) SendRevocationNotification(ctx context.Con
 	})
 }
 
-// SendEscalationNotification sends escalation notifications
+// SendEscalationNotification sends escalation notifications.
+// Recipients are resolved from the ApproverRegistry; if none are configured a warning is
+// logged and the notification is still recorded so the event is not silently dropped.
 func (sns *SimpleNotificationService) SendEscalationNotification(ctx context.Context, request *JITAccessRequest, escalationLevel int) error {
 	subject := fmt.Sprintf("[ESCALATION LEVEL %d] JIT Access Approval Required", escalationLevel)
 	message := fmt.Sprintf(
@@ -244,8 +258,22 @@ func (sns *SimpleNotificationService) SendEscalationNotification(ctx context.Con
 		request.Permissions,
 	)
 
-	// Deferred: tracked in #1441 — resolve escalation recipients from configurable approver registry
-	recipients := []string{"security-admin", "compliance-officer"}
+	var recipients []string
+	if sns.registry != nil {
+		resolved, err := sns.registry.GetApprovers(ctx, EscalationTypeDefault)
+		if err != nil {
+			return fmt.Errorf("approver registry lookup failed: %w", err)
+		}
+		recipients = resolved
+	}
+
+	if len(recipients) == 0 {
+		slog.Warn("no escalation recipients configured; notification recorded with empty recipient list",
+			"request_id", request.ID,
+			"tenant_id", request.TenantID,
+			"escalation_level", escalationLevel,
+		)
+	}
 
 	return sns.sendNotification(ctx, NotificationTypeEscalation, recipients, subject, message, map[string]interface{}{
 		"request_id":         request.ID,

--- a/features/rbac/jit/notification_test.go
+++ b/features/rbac/jit/notification_test.go
@@ -1,0 +1,185 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+package jit_test
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cfgis/cfgms/features/rbac/jit"
+)
+
+func TestStaticApproverRegistry_GetApprovers(t *testing.T) {
+	t.Run("returns recipients for known escalation type", func(t *testing.T) {
+		registry := jit.NewStaticApproverRegistry(map[string][]string{
+			"escalation": {"admin@example.com", "security@example.com"},
+		})
+		recipients, err := registry.GetApprovers(context.Background(), "escalation")
+		require.NoError(t, err)
+		assert.Equal(t, []string{"admin@example.com", "security@example.com"}, recipients)
+	})
+
+	t.Run("falls back to default key for unmapped type", func(t *testing.T) {
+		registry := jit.NewStaticApproverRegistry(map[string][]string{
+			"": {"fallback@example.com"},
+		})
+		recipients, err := registry.GetApprovers(context.Background(), "some-other-type")
+		require.NoError(t, err)
+		assert.Equal(t, []string{"fallback@example.com"}, recipients)
+	})
+
+	t.Run("returns nil for unknown type with no fallback", func(t *testing.T) {
+		registry := jit.NewStaticApproverRegistry(map[string][]string{})
+		recipients, err := registry.GetApprovers(context.Background(), "escalation")
+		require.NoError(t, err)
+		assert.Nil(t, recipients)
+	})
+
+	t.Run("explicit type takes precedence over fallback", func(t *testing.T) {
+		registry := jit.NewStaticApproverRegistry(map[string][]string{
+			"escalation": {"specific@example.com"},
+			"":           {"fallback@example.com"},
+		})
+		recipients, err := registry.GetApprovers(context.Background(), "escalation")
+		require.NoError(t, err)
+		assert.Equal(t, []string{"specific@example.com"}, recipients)
+	})
+}
+
+func TestSendEscalationNotification_UsesRegistry(t *testing.T) {
+	registry := jit.NewStaticApproverRegistry(map[string][]string{
+		jit.EscalationTypeDefault: {"admin@example.com", "security@example.com"},
+	})
+	svc := jit.NewSimpleNotificationServiceWithRegistry(registry)
+
+	req := &jit.JITAccessRequest{
+		ID:          "req-1",
+		RequesterID: "user1",
+		TenantID:    "tenant1",
+		Permissions: []string{"admin"},
+	}
+
+	err := svc.SendEscalationNotification(context.Background(), req, 1)
+	require.NoError(t, err)
+
+	history, err := svc.GetNotificationHistory(context.Background(), nil)
+	require.NoError(t, err)
+	require.Len(t, history, 1)
+	assert.Equal(t, []string{"admin@example.com", "security@example.com"}, history[0].Recipients)
+}
+
+func TestSendEscalationNotification_HardcodedRecipientsNotUsed(t *testing.T) {
+	// Verify old hardcoded values are not present — registry is the sole source of recipients.
+	registry := jit.NewStaticApproverRegistry(map[string][]string{
+		jit.EscalationTypeDefault: {"custom-admin@example.com"},
+	})
+	svc := jit.NewSimpleNotificationServiceWithRegistry(registry)
+
+	req := &jit.JITAccessRequest{
+		ID:          "req-1",
+		RequesterID: "user1",
+		TenantID:    "tenant1",
+		Permissions: []string{"admin"},
+	}
+
+	err := svc.SendEscalationNotification(context.Background(), req, 2)
+	require.NoError(t, err)
+
+	history, err := svc.GetNotificationHistory(context.Background(), nil)
+	require.NoError(t, err)
+	require.Len(t, history, 1)
+
+	for _, r := range history[0].Recipients {
+		assert.NotEqual(t, "security-admin", r, "hardcoded recipient must not appear")
+		assert.NotEqual(t, "compliance-officer", r, "hardcoded recipient must not appear")
+	}
+	assert.Equal(t, []string{"custom-admin@example.com"}, history[0].Recipients)
+}
+
+func TestSendEscalationNotification_EmptyRegistryWarnsAndDoesNotDrop(t *testing.T) {
+	var logBuf bytes.Buffer
+	original := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&logBuf, nil)))
+	defer slog.SetDefault(original)
+
+	registry := jit.NewStaticApproverRegistry(map[string][]string{})
+	svc := jit.NewSimpleNotificationServiceWithRegistry(registry)
+
+	req := &jit.JITAccessRequest{
+		ID:          "req-empty",
+		RequesterID: "user1",
+		TenantID:    "tenant1",
+		Permissions: []string{"admin"},
+	}
+
+	err := svc.SendEscalationNotification(context.Background(), req, 1)
+	require.NoError(t, err, "empty registry must not drop the escalation")
+
+	logOutput := logBuf.String()
+	assert.True(t, strings.Contains(logOutput, "WARN") || strings.Contains(logOutput, "warn"),
+		"expected warning log when registry returns empty, got: %q", logOutput)
+
+	history, err := svc.GetNotificationHistory(context.Background(), nil)
+	require.NoError(t, err)
+	assert.Len(t, history, 1, "escalation must be recorded even with empty recipient list")
+}
+
+func TestSendEscalationNotification_RegistryChangeAffectsRecipients(t *testing.T) {
+	// Changing the registry config changes the recipients without code modification (AC #2).
+	registryV1 := jit.NewStaticApproverRegistry(map[string][]string{
+		jit.EscalationTypeDefault: {"v1-admin@example.com"},
+	})
+	svcV1 := jit.NewSimpleNotificationServiceWithRegistry(registryV1)
+
+	registryV2 := jit.NewStaticApproverRegistry(map[string][]string{
+		jit.EscalationTypeDefault: {"v2-admin@example.com", "v2-security@example.com"},
+	})
+	svcV2 := jit.NewSimpleNotificationServiceWithRegistry(registryV2)
+
+	req := &jit.JITAccessRequest{
+		ID:          "req-1",
+		RequesterID: "user1",
+		TenantID:    "tenant1",
+		Permissions: []string{"admin"},
+	}
+
+	ctx := context.Background()
+	require.NoError(t, svcV1.SendEscalationNotification(ctx, req, 1))
+	require.NoError(t, svcV2.SendEscalationNotification(ctx, req, 1))
+
+	histV1, err := svcV1.GetNotificationHistory(ctx, nil)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"v1-admin@example.com"}, histV1[0].Recipients)
+
+	histV2, err := svcV2.GetNotificationHistory(ctx, nil)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"v2-admin@example.com", "v2-security@example.com"}, histV2[0].Recipients)
+}
+
+func TestSendEscalationNotification_RegistryError(t *testing.T) {
+	svc := jit.NewSimpleNotificationServiceWithRegistry(&errorRegistry{})
+
+	req := &jit.JITAccessRequest{
+		ID:          "req-1",
+		RequesterID: "user1",
+		TenantID:    "tenant1",
+		Permissions: []string{"admin"},
+	}
+
+	err := svc.SendEscalationNotification(context.Background(), req, 1)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "approver registry lookup failed")
+}
+
+// errorRegistry is a test-only ApproverRegistry that always returns an error.
+type errorRegistry struct{}
+
+func (e *errorRegistry) GetApprovers(_ context.Context, _ string) ([]string, error) {
+	return nil, assert.AnError
+}


### PR DESCRIPTION
## Summary

- Introduces `ApproverRegistry` interface (`GetApprovers(ctx, escalationType)`) so escalation targets are operator-defined, not hardcoded in source
- `StaticApproverRegistry` backs the interface from a `map[string][]string` — can be populated from controller config without code changes
- `SendEscalationNotification` now resolves recipients via the registry; empty registry logs a warning and still records the notification (no silent drop)

Fixes #1604

## Changed Files

| File | Change |
|------|--------|
| `features/rbac/jit/approver_registry.go` | New — `ApproverRegistry` interface + `StaticApproverRegistry` implementation |
| `features/rbac/jit/notification.go` | Replace hardcoded recipients; add `registry` field + `NewSimpleNotificationServiceWithRegistry` |
| `features/rbac/jit/notification_test.go` | New — 6 tests: registry lookup, hardcoded values absent, empty-registry warn+no-drop, recipient change, error propagation |

## Acceptance Criteria

| # | Criterion | Status |
|---|-----------|--------|
| 1 | `SendEscalationNotification` resolves recipients from `ApproverRegistry` | ✅ |
| 2 | Changing registry config changes recipients without code modification | ✅ |
| 3 | Empty registry causes warning log, not silent drop | ✅ |
| 4 | `make test-complete` passes | ✅ |

## Specialist Review Results

**qa-test-runner: PASS**
- All quality validation gates passed
- `features/rbac/jit`: PASS (run twice — OSS smart-mode + fast comprehensive)
- Cross-platform builds: linux/amd64, linux/arm64, darwin/amd64, darwin/arm64, windows/amd64 all PASS
- Security scan (Trivy, Nancy, gosec, staticcheck): PASS

**qa-code-reviewer: PASS**
- 0 blocking issues
- 3 non-blocking warnings: slog text-format fragility in log assertion, `assert.AnError` in test double (cosmetic), unguarded slice append in `SimpleNotificationService` (pre-existing, not introduced by this story)

**security-engineer: PASS**
- 0 blocking issues
- Hardcoded recipients `["security-admin", "compliance-officer"]` confirmed removed
- 2 non-blocking warnings: tenant-scoped registry lookup (recommended before real delivery is wired in #1441), empty-recipient non-fatal behaviour (documented and tested)
- `make security-precommit`, `make check-architecture`, `make security-scan`: all PASS