### PR TITLE
rollback: implement real webhook delivery in WebhookNotifier (Issue #1603)

### DIFF
--- a/features/config/rollback/notifier.go
+++ b/features/config/rollback/notifier.go
@@ -3,18 +3,25 @@
 package rollback
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"time"
 
 	"github.com/cfgis/cfgms/pkg/logging"
 )
 
 // DefaultRollbackNotifier provides a default implementation of RollbackNotifier
 type DefaultRollbackNotifier struct {
-	// Deferred: tracked in #1441 — add email, webhook, and message queue clients
-	logger logging.Logger
+	logger          logging.Logger
+	webhookNotifier *WebhookNotifier
 }
 
-// NewDefaultRollbackNotifier creates a new default notifier
+// NewDefaultRollbackNotifier creates a new default notifier without webhook delivery.
 func NewDefaultRollbackNotifier(logger logging.Logger) RollbackNotifier {
 	if logger == nil {
 		logger = logging.NewNoopLogger()
@@ -22,6 +29,24 @@ func NewDefaultRollbackNotifier(logger logging.Logger) RollbackNotifier {
 
 	return &DefaultRollbackNotifier{
 		logger: logger,
+	}
+}
+
+// NewDefaultRollbackNotifierWithWebhook creates a notifier that logs all events and
+// delivers them via webhook when the operation completes.
+func NewDefaultRollbackNotifierWithWebhook(webhookURL string, logger logging.Logger) RollbackNotifier {
+	if logger == nil {
+		logger = logging.NewNoopLogger()
+	}
+	wn := &WebhookNotifier{
+		webhookURL: webhookURL,
+		logger:     logger,
+		retryBase:  time.Second,
+		httpClient: &http.Client{Timeout: 10 * time.Second},
+	}
+	return &DefaultRollbackNotifier{
+		logger:          logger,
+		webhookNotifier: wn,
 	}
 }
 
@@ -35,7 +60,9 @@ func (n *DefaultRollbackNotifier) NotifyRollbackStarted(ctx context.Context, ope
 		"initiated_by", logging.SanitizeLogValue(operation.InitiatedBy),
 	)
 
-	// Deferred: tracked in #1441 — deliver via email, webhooks, and message queues
+	if n.webhookNotifier != nil {
+		return n.webhookNotifier.NotifyRollbackStarted(ctx, operation)
+	}
 
 	return nil
 }
@@ -49,7 +76,9 @@ func (n *DefaultRollbackNotifier) NotifyRollbackProgress(ctx context.Context, op
 		"current_action", logging.SanitizeLogValue(operation.Progress.CurrentAction),
 	)
 
-	// Deferred: tracked in #1441 — milestone throttling; all progress events are logged
+	if n.webhookNotifier != nil {
+		return n.webhookNotifier.NotifyRollbackProgress(ctx, operation)
+	}
 
 	return nil
 }
@@ -69,7 +98,9 @@ func (n *DefaultRollbackNotifier) NotifyRollbackCompleted(ctx context.Context, o
 		"devices_affected", operation.Result.DevicesAffected,
 	)
 
-	// Deferred: tracked in #1441 — deliver completion reports via external channels
+	if n.webhookNotifier != nil {
+		return n.webhookNotifier.NotifyRollbackCompleted(ctx, operation)
+	}
 
 	return nil
 }
@@ -97,26 +128,50 @@ func (n *DefaultRollbackNotifier) NotifyRollbackFailed(ctx context.Context, oper
 		}
 	}
 
-	// Deferred: tracked in #1441 — send alerts, page on-call, create incident tickets
+	if n.webhookNotifier != nil {
+		return n.webhookNotifier.NotifyRollbackFailed(ctx, operation, err)
+	}
 
 	return nil
+}
+
+// WebhookConfig holds configuration for a WebhookNotifier.
+type WebhookConfig struct {
+	// RetryBase is the initial delay before the first retry. Subsequent delays
+	// double with each attempt. Defaults to 1 second when zero.
+	RetryBase time.Duration
 }
 
 // WebhookNotifier sends notifications via webhooks
 type WebhookNotifier struct {
 	webhookURL string
 	logger     logging.Logger
+	retryBase  time.Duration
+	httpClient *http.Client
 }
 
-// NewWebhookNotifier creates a new webhook notifier
+// NewWebhookNotifier creates a new webhook notifier with production defaults
+// (1-second exponential backoff, 10-second per-request timeout).
 func NewWebhookNotifier(webhookURL string, logger logging.Logger) RollbackNotifier {
+	return NewWebhookNotifierWithConfig(webhookURL, logger, WebhookConfig{})
+}
+
+// NewWebhookNotifierWithConfig creates a webhook notifier with caller-supplied
+// configuration. Intended for use in tests where a shorter RetryBase speeds
+// up the retry-behavior tests without changing production behavior.
+func NewWebhookNotifierWithConfig(webhookURL string, logger logging.Logger, cfg WebhookConfig) RollbackNotifier {
 	if logger == nil {
 		logger = logging.NewNoopLogger()
 	}
-
+	retryBase := cfg.RetryBase
+	if retryBase <= 0 {
+		retryBase = time.Second
+	}
 	return &WebhookNotifier{
 		webhookURL: webhookURL,
 		logger:     logger,
+		retryBase:  retryBase,
+		httpClient: &http.Client{Timeout: 10 * time.Second},
 	}
 }
 
@@ -161,21 +216,97 @@ func (w *WebhookNotifier) NotifyRollbackCompleted(ctx context.Context, operation
 
 // NotifyRollbackFailed sends webhook notification for failure
 func (w *WebhookNotifier) NotifyRollbackFailed(ctx context.Context, operation *RollbackOperation, err error) error {
+	errMsg := ""
+	if err != nil {
+		errMsg = err.Error()
+	}
 	payload := map[string]interface{}{
 		"event":     "rollback.failed",
 		"operation": operation,
-		"error":     err.Error(),
+		"error":     errMsg,
 		"result":    operation.Result,
 	}
 
 	return w.sendWebhook(ctx, payload)
 }
 
+// sendWebhook marshals payload to JSON and POSTs it to the configured URL,
+// retrying up to 3 times with exponential backoff on 5xx responses or network
+// errors. On permanent failure the error is logged and returned.
+//
+// URL scheme is validated before any network I/O — only http and https are
+// accepted to prevent SSRF via exotic schemes. Only the host is logged so that
+// secrets embedded in webhook URL paths (e.g. Slack signed URLs) are never
+// written to log sinks.
 func (w *WebhookNotifier) sendWebhook(ctx context.Context, payload interface{}) error {
-	// Deferred: tracked in #1441 — implement HTTP POST with retry and rate-limit handling
+	// Validate URL scheme before any network I/O to prevent SSRF via exotic schemes.
+	u, err := url.Parse(w.webhookURL)
+	if err != nil || u.Host == "" || (u.Scheme != "http" && u.Scheme != "https") {
+		return fmt.Errorf("invalid webhook URL: must use http or https scheme")
+	}
 
-	w.logger.Debug("webhook notification sent", "payload", payload)
-	return nil
+	data, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("marshal webhook payload: %w", err)
+	}
+
+	// Log only the host, not the full URL, to avoid leaking webhook secrets
+	// that may be embedded in the URL path (e.g. Slack, PagerDuty signed URLs).
+	safeHost := logging.SanitizeLogValue(u.Host)
+
+	var lastErr error
+	for attempt := 0; attempt < 3; attempt++ {
+		if attempt > 0 {
+			delay := time.Duration(1<<uint(attempt-1)) * w.retryBase
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-time.After(delay):
+			}
+		}
+
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, w.webhookURL, bytes.NewReader(data))
+		if err != nil {
+			// Malformed URL after scheme check — no point retrying.
+			return fmt.Errorf("create webhook request: %w", err)
+		}
+		req.Header.Set("Content-Type", "application/json")
+
+		resp, err := w.httpClient.Do(req)
+		if err != nil {
+			lastErr = fmt.Errorf("webhook POST attempt %d: %w", attempt+1, err)
+			w.logger.Warn("webhook delivery attempt failed",
+				"attempt", attempt+1,
+				"host", safeHost,
+				"error", logging.SanitizeLogValue(lastErr.Error()),
+			)
+			continue
+		}
+		// Drain with a cap to enable connection reuse and bound memory on large responses.
+		_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 1<<20))
+		if err := resp.Body.Close(); err != nil {
+			w.logger.Warn("failed to close webhook response body", "error", err)
+		}
+
+		if resp.StatusCode >= 500 {
+			lastErr = fmt.Errorf("webhook server error on attempt %d: status %d", attempt+1, resp.StatusCode)
+			w.logger.Warn("webhook delivery attempt failed",
+				"attempt", attempt+1,
+				"host", safeHost,
+				"status", resp.StatusCode,
+			)
+			continue
+		}
+
+		w.logger.Debug("webhook notification sent", "host", safeHost)
+		return nil
+	}
+
+	w.logger.Error("webhook delivery permanently failed",
+		"host", safeHost,
+		"error", logging.SanitizeLogValue(lastErr.Error()),
+	)
+	return lastErr
 }
 
 // CompositeNotifier combines multiple notifiers

--- a/features/config/rollback/notifier_test.go
+++ b/features/config/rollback/notifier_test.go
@@ -4,7 +4,12 @@ package rollback_test
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync"
 	"testing"
 	"time"
 
@@ -140,9 +145,14 @@ func TestDefaultRollbackNotifier_logsFailedAsError(t *testing.T) {
 }
 
 func TestNewWebhookNotifier_nilLogger_usesNoop(t *testing.T) {
-	notifier := rollback.NewWebhookNotifier("https://example.com/webhook", nil)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	notifier := rollback.NewWebhookNotifier(server.URL, nil)
 	require.NotNil(t, notifier)
-	// Verify no panic
+
 	ctx := context.Background()
 	op := &rollback.RollbackOperation{
 		ID:          "test-op-5",
@@ -155,8 +165,13 @@ func TestNewWebhookNotifier_nilLogger_usesNoop(t *testing.T) {
 }
 
 func TestNewWebhookNotifier_logsDebugOnSend(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
 	mock := pkgtesting.NewMockLogger(true)
-	notifier := rollback.NewWebhookNotifier("https://example.com/webhook", mock)
+	notifier := rollback.NewWebhookNotifier(server.URL, mock)
 	require.NotNil(t, notifier)
 
 	ctx := context.Background()
@@ -171,4 +186,305 @@ func TestNewWebhookNotifier_logsDebugOnSend(t *testing.T) {
 	debugLogs := mock.GetLogs("debug")
 	require.NotEmpty(t, debugLogs)
 	assert.Equal(t, "webhook notification sent", debugLogs[0].Message)
+}
+
+func TestWebhookNotifier_POSTsJSONPayload(t *testing.T) {
+	var mu sync.Mutex
+	var receivedBody []byte
+	var receivedContentType string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		defer mu.Unlock()
+		body, _ := io.ReadAll(r.Body)
+		receivedBody = body
+		receivedContentType = r.Header.Get("Content-Type")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	mock := pkgtesting.NewMockLogger(true)
+	notifier := rollback.NewWebhookNotifier(server.URL, mock)
+
+	ctx := context.Background()
+	op := &rollback.RollbackOperation{
+		ID:          "test-payload",
+		InitiatedAt: time.Now(),
+		Request:     rollback.RollbackRequest{RollbackType: rollback.RollbackTypeFull},
+	}
+
+	err := notifier.NotifyRollbackStarted(ctx, op)
+	require.NoError(t, err)
+
+	mu.Lock()
+	body := receivedBody
+	ct := receivedContentType
+	mu.Unlock()
+
+	assert.Equal(t, "application/json", ct)
+	require.NotEmpty(t, body)
+
+	var decoded map[string]interface{}
+	require.NoError(t, json.Unmarshal(body, &decoded))
+	assert.Equal(t, "rollback.started", decoded["event"])
+	assert.NotNil(t, decoded["operation"])
+}
+
+func TestWebhookNotifier_retriesOn5xx(t *testing.T) {
+	var mu sync.Mutex
+	attempts := 0
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		defer mu.Unlock()
+		attempts++
+		if attempts < 3 {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	mock := pkgtesting.NewMockLogger(true)
+	cfg := rollback.WebhookConfig{RetryBase: 10 * time.Millisecond}
+	notifier := rollback.NewWebhookNotifierWithConfig(server.URL, mock, cfg)
+
+	ctx := context.Background()
+	op := &rollback.RollbackOperation{
+		ID:          "test-retry-5xx",
+		InitiatedAt: time.Now(),
+		Request:     rollback.RollbackRequest{},
+	}
+
+	err := notifier.NotifyRollbackStarted(ctx, op)
+	require.NoError(t, err)
+
+	mu.Lock()
+	total := attempts
+	mu.Unlock()
+	assert.Equal(t, 3, total)
+
+	warnLogs := mock.GetLogs("warn")
+	assert.Len(t, warnLogs, 2)
+}
+
+func TestWebhookNotifier_permanentFailureAfter3Retries(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer server.Close()
+
+	mock := pkgtesting.NewMockLogger(true)
+	cfg := rollback.WebhookConfig{RetryBase: 10 * time.Millisecond}
+	notifier := rollback.NewWebhookNotifierWithConfig(server.URL, mock, cfg)
+
+	ctx := context.Background()
+	op := &rollback.RollbackOperation{
+		ID:          "test-perm-fail",
+		InitiatedAt: time.Now(),
+		Request:     rollback.RollbackRequest{},
+	}
+
+	err := notifier.NotifyRollbackStarted(ctx, op)
+	require.Error(t, err)
+
+	warnLogs := mock.GetLogs("warn")
+	assert.Len(t, warnLogs, 3)
+
+	errorLogs := mock.GetLogs("error")
+	require.NotEmpty(t, errorLogs)
+	assert.Equal(t, "webhook delivery permanently failed", errorLogs[0].Message)
+}
+
+func TestWebhookNotifier_retriesOnNetworkError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	serverURL := server.URL
+	server.Close()
+
+	mock := pkgtesting.NewMockLogger(true)
+	cfg := rollback.WebhookConfig{RetryBase: 10 * time.Millisecond}
+	notifier := rollback.NewWebhookNotifierWithConfig(serverURL, mock, cfg)
+
+	ctx := context.Background()
+	op := &rollback.RollbackOperation{
+		ID:          "test-network-err",
+		InitiatedAt: time.Now(),
+		Request:     rollback.RollbackRequest{},
+	}
+
+	err := notifier.NotifyRollbackStarted(ctx, op)
+	require.Error(t, err)
+
+	warnLogs := mock.GetLogs("warn")
+	assert.Len(t, warnLogs, 3)
+
+	errorLogs := mock.GetLogs("error")
+	require.NotEmpty(t, errorLogs)
+	assert.Equal(t, "webhook delivery permanently failed", errorLogs[0].Message)
+}
+
+func TestWebhookNotifier_contextCanceledDuringRetry(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer server.Close()
+
+	mock := pkgtesting.NewMockLogger(true)
+	// Use a long retry base so the context cancel fires during backoff
+	cfg := rollback.WebhookConfig{RetryBase: 5 * time.Second}
+	notifier := rollback.NewWebhookNotifierWithConfig(server.URL, mock, cfg)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	op := &rollback.RollbackOperation{
+		ID:          "test-ctx-cancel",
+		InitiatedAt: time.Now(),
+		Request:     rollback.RollbackRequest{},
+	}
+
+	err := notifier.NotifyRollbackStarted(ctx, op)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, context.DeadlineExceeded)
+}
+
+func TestWebhookNotifier_rejectsNonHTTPScheme(t *testing.T) {
+	mock := pkgtesting.NewMockLogger(true)
+	for _, badURL := range []string{
+		"ftp://example.com/hook",
+		"file:///etc/passwd",
+		"javascript:alert(1)",
+		"://bad",
+	} {
+		notifier := rollback.NewWebhookNotifier(badURL, mock)
+		ctx := context.Background()
+		op := &rollback.RollbackOperation{
+			ID:          "test-bad-scheme",
+			InitiatedAt: time.Now(),
+			Request:     rollback.RollbackRequest{},
+		}
+		err := notifier.NotifyRollbackStarted(ctx, op)
+		require.Error(t, err, "URL %q should be rejected", badURL)
+		assert.Contains(t, err.Error(), "invalid webhook URL")
+	}
+}
+
+func TestDefaultRollbackNotifier_delegatesToWebhookWhenURLConfigured(t *testing.T) {
+	var mu sync.Mutex
+	var receivedBody []byte
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		defer mu.Unlock()
+		body, _ := io.ReadAll(r.Body)
+		receivedBody = body
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	mock := pkgtesting.NewMockLogger(true)
+	notifier := rollback.NewDefaultRollbackNotifierWithWebhook(server.URL, mock)
+
+	ctx := context.Background()
+	op := &rollback.RollbackOperation{
+		ID:          "test-delegate",
+		InitiatedBy: "admin",
+		InitiatedAt: time.Now(),
+		Request: rollback.RollbackRequest{
+			TargetType:   rollback.TargetTypeClient,
+			TargetID:     "client-1",
+			RollbackType: rollback.RollbackTypeFull,
+		},
+	}
+
+	err := notifier.NotifyRollbackStarted(ctx, op)
+	require.NoError(t, err)
+
+	mu.Lock()
+	body := receivedBody
+	mu.Unlock()
+
+	require.NotEmpty(t, body, "DefaultRollbackNotifier with webhook URL must deliver via HTTP POST")
+
+	var decoded map[string]interface{}
+	require.NoError(t, json.Unmarshal(body, &decoded))
+	assert.Equal(t, "rollback.started", decoded["event"])
+
+	// Must also log the event
+	infoLogs := mock.GetLogs("info")
+	require.NotEmpty(t, infoLogs)
+	assert.Equal(t, "rollback started", infoLogs[0].Message)
+}
+
+func TestDefaultRollbackNotifier_noWebhookWhenURLNotConfigured(t *testing.T) {
+	mock := pkgtesting.NewMockLogger(true)
+	notifier := rollback.NewDefaultRollbackNotifier(mock)
+
+	ctx := context.Background()
+	op := &rollback.RollbackOperation{
+		ID:          "test-no-webhook",
+		InitiatedAt: time.Now(),
+		Request:     rollback.RollbackRequest{RollbackType: rollback.RollbackTypeFull},
+	}
+
+	err := notifier.NotifyRollbackStarted(ctx, op)
+	require.NoError(t, err)
+
+	infoLogs := mock.GetLogs("info")
+	require.NotEmpty(t, infoLogs)
+	assert.Equal(t, "rollback started", infoLogs[0].Message)
+}
+
+func TestWebhookNotifier_allFourLifecycleEventsDeliver(t *testing.T) {
+	var mu sync.Mutex
+	var events []string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var decoded map[string]interface{}
+		if err := json.Unmarshal(body, &decoded); err == nil {
+			if ev, ok := decoded["event"].(string); ok {
+				mu.Lock()
+				events = append(events, ev)
+				mu.Unlock()
+			}
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	mock := pkgtesting.NewMockLogger(true)
+	notifier := rollback.NewWebhookNotifier(server.URL, mock)
+
+	ctx := context.Background()
+	completedAt := time.Now()
+	op := &rollback.RollbackOperation{
+		ID:          "test-lifecycle",
+		InitiatedAt: time.Now().Add(-2 * time.Second),
+		CompletedAt: &completedAt,
+		Request:     rollback.RollbackRequest{RollbackType: rollback.RollbackTypeFull},
+		Progress:    rollback.RollbackProgress{Percentage: 25},
+		Result: &rollback.RollbackResult{
+			Success: true,
+		},
+	}
+
+	require.NoError(t, notifier.NotifyRollbackStarted(ctx, op))
+	require.NoError(t, notifier.NotifyRollbackProgress(ctx, op))
+	require.NoError(t, notifier.NotifyRollbackCompleted(ctx, op))
+	require.NoError(t, notifier.NotifyRollbackFailed(ctx, op, errors.New("test failure")))
+
+	mu.Lock()
+	captured := make([]string, len(events))
+	copy(captured, events)
+	mu.Unlock()
+
+	// Progress fires only at 25% milestones; 25 % 25 == 0 so it fires
+	assert.Contains(t, captured, "rollback.started")
+	assert.Contains(t, captured, "rollback.progress")
+	assert.Contains(t, captured, "rollback.completed")
+	assert.Contains(t, captured, "rollback.failed")
 }


### PR DESCRIPTION
## Summary

- `WebhookNotifier.sendWebhook` now sends a real HTTP POST with JSON payload, retries up to 3× with exponential backoff on 5xx or network error, validates URL scheme (http/https only) before any network I/O, logs only the URL host (never the full URL) to prevent secret leakage from signed paths.
- `DefaultRollbackNotifier` gains `NewDefaultRollbackNotifierWithWebhook` — logs all events and delegates to `WebhookNotifier` when a URL is configured. Existing `NewDefaultRollbackNotifier` is unchanged.
- `WebhookConfig{RetryBase}` and `NewWebhookNotifierWithConfig` let tests drive retry logic at millisecond scale without changing production defaults (1 second).

Fixes #1603

## Specialist Review Results

**QA Test Runner: PASS** — all packages pass including cross-platform builds; lint clean; no errcheck violations.

**Security Engineer: PASS** — URL scheme validation matches `alerting.go` reference pattern; host-only logging prevents secret leakage; body drain bounds memory; no hardcoded secrets, no central provider violations; automated scans (Trivy, Nancy, gosec, staticcheck) all pass.

**QA Code Reviewer: PASS** — all HTTP calls use real `httptest.Server`; error paths covered (5xx retry, network error retry, context cancel during backoff, permanent failure, invalid URL scheme); all 4 lifecycle events tested; `DefaultRollbackNotifier` delegation verified with and without webhook URL.

## Test plan

- [ ] `go test ./features/config/rollback/...` — all 43 tests pass in ~1s
- [ ] Retry tests (`TestWebhookNotifier_retriesOn5xx`, `TestWebhookNotifier_permanentFailureAfter3Retries`, `TestWebhookNotifier_retriesOnNetworkError`) run with 10ms `RetryBase` — complete in <100ms each
- [ ] `TestWebhookNotifier_contextCanceledDuringRetry` uses 5s `RetryBase` + 50ms context deadline to verify cancel fires during backoff
- [ ] `TestWebhookNotifier_rejectsNonHTTPScheme` covers ftp://, file://, javascript:, malformed URLs
- [ ] `make test-agent-complete` passes (validated by QA Test Runner agent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)