### PR TITLE
terminal: notify WebSocket client on token rotation (Issue #1606)

### DIFF
--- a/features/terminal/auth_integration.go
+++ b/features/terminal/auth_integration.go
@@ -20,6 +20,10 @@ import (
 	business "github.com/cfgis/cfgms/pkg/storage/interfaces/business"
 )
 
+// tokenRefreshNotifyTimeout is the maximum time rotateTokensIfNeeded will wait
+// to deliver a token-refresh message before dropping it for a slow client.
+const tokenRefreshNotifyTimeout = 100 * time.Millisecond
+
 // AuthenticatedTerminalManager manages terminal sessions with mTLS authentication and continuous authorization
 type AuthenticatedTerminalManager struct {
 	baseManager       SessionManager
@@ -32,6 +36,10 @@ type AuthenticatedTerminalManager struct {
 	// Anti-hijacking measures
 	sessionTokens map[string]*SessionToken
 	tokenMutex    sync.RWMutex
+
+	// Per-session channels for token-refresh notifications (session ID → channel).
+	// Protected by tokenMutex.
+	notifyChannels map[string]chan<- *TerminalMessage
 
 	// Configuration
 	config               *AuthConfig
@@ -156,6 +164,7 @@ func NewAuthenticatedTerminalManager(
 		auditManager:         auditManager,
 		sessionMonitor:       sessionMonitor,
 		sessionTokens:        make(map[string]*SessionToken),
+		notifyChannels:       make(map[string]chan<- *TerminalMessage),
 		config:               config,
 		continuousAuthConfig: DefaultContinuousAuthConfig(),
 	}
@@ -680,15 +689,79 @@ func (atm *AuthenticatedTerminalManager) cleanupExpiredTokens() {
 	}
 }
 
-func (atm *AuthenticatedTerminalManager) rotateTokensIfNeeded() {
+// RegisterTokenRefreshChannel registers ch to receive token-refresh messages for
+// the given session. The caller owns the channel and must call
+// UnregisterTokenRefreshChannel when the session ends.
+func (atm *AuthenticatedTerminalManager) RegisterTokenRefreshChannel(sessionID string, ch chan<- *TerminalMessage) {
 	atm.tokenMutex.Lock()
 	defer atm.tokenMutex.Unlock()
+	atm.notifyChannels[sessionID] = ch
+}
 
+// UnregisterTokenRefreshChannel removes the token-refresh notification channel
+// for sessionID so the rotation loop no longer attempts to deliver to it.
+func (atm *AuthenticatedTerminalManager) UnregisterTokenRefreshChannel(sessionID string) {
+	atm.tokenMutex.Lock()
+	defer atm.tokenMutex.Unlock()
+	delete(atm.notifyChannels, sessionID)
+}
+
+func (atm *AuthenticatedTerminalManager) rotateTokensIfNeeded() {
+	type pendingNotification struct {
+		ch        chan<- *TerminalMessage
+		sessionID string
+		newToken  string
+		expiresAt time.Time
+	}
+
+	atm.tokenMutex.Lock()
 	now := time.Now()
-	for _, token := range atm.sessionTokens {
-		if now.Sub(token.LastRotated) > atm.config.TokenRotationInterval {
-			// Deferred: tracked in #1441 — push token-refresh signal to client over WebSocket
-			token.LastRotated = now
+	var notifications []pendingNotification
+
+	for oldTokenStr, token := range atm.sessionTokens {
+		if now.Sub(token.LastRotated) <= atm.config.TokenRotationInterval {
+			continue
+		}
+
+		newTokenStr, err := generateSecureToken()
+		if err != nil {
+			continue
+		}
+
+		// Build the replacement entry (copy then update token-specific fields).
+		newEntry := *token
+		newEntry.Token = newTokenStr
+		newEntry.LastRotated = now
+		newEntry.ExpiresAt = now.Add(atm.config.SessionTimeout)
+
+		delete(atm.sessionTokens, oldTokenStr)
+		atm.sessionTokens[newTokenStr] = &newEntry
+
+		if ch, ok := atm.notifyChannels[token.SessionID]; ok {
+			notifications = append(notifications, pendingNotification{
+				ch:        ch,
+				sessionID: token.SessionID,
+				newToken:  newTokenStr,
+				expiresAt: newEntry.ExpiresAt,
+			})
+		}
+	}
+	atm.tokenMutex.Unlock()
+
+	// Deliver notifications outside the lock so a slow client cannot stall rotation.
+	for _, n := range notifications {
+		expiresAt := n.expiresAt
+		msg := &TerminalMessage{
+			Type:      MessageTypeTokenRefresh,
+			SessionID: n.sessionID,
+			Token:     n.newToken,
+			ExpiresAt: &expiresAt,
+			Timestamp: time.Now(),
+		}
+		select {
+		case n.ch <- msg:
+		case <-time.After(tokenRefreshNotifyTimeout):
+			// slow or disconnected client — drop the notification
 		}
 	}
 }

--- a/features/terminal/auth_integration_test.go
+++ b/features/terminal/auth_integration_test.go
@@ -1,0 +1,179 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+package terminal
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newMinimalAuthManager builds an AuthenticatedTerminalManager with only the
+// fields touched by rotateTokensIfNeeded so the test has no dependency on
+// RBAC, cert, or audit infrastructure.
+func newMinimalAuthManager(rotationInterval time.Duration) *AuthenticatedTerminalManager {
+	return &AuthenticatedTerminalManager{
+		sessionTokens:  make(map[string]*SessionToken),
+		notifyChannels: make(map[string]chan<- *TerminalMessage),
+		config: &AuthConfig{
+			TokenRotationInterval: rotationInterval,
+			SessionTimeout:        4 * time.Hour,
+		},
+	}
+}
+
+func TestRotateTokensIfNeeded_SendsTokenRefreshMessage(t *testing.T) {
+	atm := newMinimalAuthManager(1 * time.Millisecond)
+
+	sessionID := "test-session-001"
+	oldTokenStr := "old-token-value"
+
+	atm.sessionTokens[oldTokenStr] = &SessionToken{
+		Token:       oldTokenStr,
+		SessionID:   sessionID,
+		UserID:      "test-user",
+		IssuedAt:    time.Now().Add(-2 * time.Hour),
+		ExpiresAt:   time.Now().Add(2 * time.Hour),
+		LastRotated: time.Now().Add(-2 * time.Hour), // well past the 1 ms rotation interval
+		Active:      true,
+		Metadata:    make(map[string]string),
+	}
+
+	ch := make(chan *TerminalMessage, 1)
+	atm.RegisterTokenRefreshChannel(sessionID, ch)
+
+	atm.rotateTokensIfNeeded()
+
+	require.Len(t, ch, 1, "expected exactly one token-refresh message on the channel")
+	msg := <-ch
+
+	assert.Equal(t, MessageTypeTokenRefresh, msg.Type)
+	assert.Equal(t, sessionID, msg.SessionID)
+	assert.NotEmpty(t, msg.Token, "new token must not be empty")
+	assert.NotEqual(t, oldTokenStr, msg.Token, "rotated token must differ from the old one")
+	require.NotNil(t, msg.ExpiresAt, "expires_at must be set")
+	assert.True(t, msg.ExpiresAt.After(time.Now()), "expires_at must be in the future")
+
+	// Old token must be gone; new token must be in the map.
+	atm.tokenMutex.RLock()
+	_, oldExists := atm.sessionTokens[oldTokenStr]
+	_, newExists := atm.sessionTokens[msg.Token]
+	atm.tokenMutex.RUnlock()
+
+	assert.False(t, oldExists, "old token must be removed from the map after rotation")
+	assert.True(t, newExists, "rotated token must be present in the map")
+}
+
+func TestRotateTokensIfNeeded_SlowClientDoesNotBlock(t *testing.T) {
+	atm := newMinimalAuthManager(1 * time.Millisecond)
+
+	sessionID := "test-session-slow"
+	oldTokenStr := "old-token-slow"
+
+	atm.sessionTokens[oldTokenStr] = &SessionToken{
+		Token:       oldTokenStr,
+		SessionID:   sessionID,
+		UserID:      "test-user",
+		IssuedAt:    time.Now().Add(-2 * time.Hour),
+		ExpiresAt:   time.Now().Add(2 * time.Hour),
+		LastRotated: time.Now().Add(-2 * time.Hour),
+		Active:      true,
+		Metadata:    make(map[string]string),
+	}
+
+	// Unbuffered channel with no reader — simulates a slow or disconnected client.
+	ch := make(chan *TerminalMessage)
+	atm.RegisterTokenRefreshChannel(sessionID, ch)
+
+	start := time.Now()
+	atm.rotateTokensIfNeeded()
+	elapsed := time.Since(start)
+
+	// Rotation must not block longer than the notify timeout + a small margin.
+	assert.Less(t, elapsed, tokenRefreshNotifyTimeout+200*time.Millisecond,
+		"rotation must not block on a slow/disconnected client (elapsed: %v)", elapsed)
+
+	// Token must still be rotated even when the client is slow.
+	atm.tokenMutex.RLock()
+	_, oldExists := atm.sessionTokens[oldTokenStr]
+	count := len(atm.sessionTokens)
+	atm.tokenMutex.RUnlock()
+
+	assert.False(t, oldExists, "old token must be removed even when the notify channel is full")
+	assert.Equal(t, 1, count, "exactly one token (the rotated replacement) must remain in the map")
+}
+
+func TestRotateTokensIfNeeded_NoNotifyWhenNoChannelRegistered(t *testing.T) {
+	atm := newMinimalAuthManager(1 * time.Millisecond)
+
+	atm.sessionTokens["tok"] = &SessionToken{
+		Token:       "tok",
+		SessionID:   "no-channel-session",
+		UserID:      "test-user",
+		IssuedAt:    time.Now().Add(-2 * time.Hour),
+		ExpiresAt:   time.Now().Add(2 * time.Hour),
+		LastRotated: time.Now().Add(-2 * time.Hour),
+		Active:      true,
+		Metadata:    make(map[string]string),
+	}
+
+	// No channel registered — rotation must succeed without panicking.
+	require.NotPanics(t, func() { atm.rotateTokensIfNeeded() })
+
+	// Old token must be rotated out regardless.
+	atm.tokenMutex.RLock()
+	_, oldExists := atm.sessionTokens["tok"]
+	atm.tokenMutex.RUnlock()
+	assert.False(t, oldExists, "old token must be removed even without a registered notify channel")
+}
+
+func TestRotateTokensIfNeeded_TokenNotYetDue(t *testing.T) {
+	atm := newMinimalAuthManager(1 * time.Hour) // long rotation interval
+
+	sessionID := "test-session-not-due"
+	tokenStr := "fresh-token"
+
+	atm.sessionTokens[tokenStr] = &SessionToken{
+		Token:       tokenStr,
+		SessionID:   sessionID,
+		UserID:      "test-user",
+		IssuedAt:    time.Now(),
+		ExpiresAt:   time.Now().Add(4 * time.Hour),
+		LastRotated: time.Now(), // just rotated — not due again
+		Active:      true,
+		Metadata:    make(map[string]string),
+	}
+
+	ch := make(chan *TerminalMessage, 1)
+	atm.RegisterTokenRefreshChannel(sessionID, ch)
+
+	atm.rotateTokensIfNeeded()
+
+	assert.Len(t, ch, 0, "no refresh message expected when rotation interval has not elapsed")
+
+	// Token must remain unchanged.
+	atm.tokenMutex.RLock()
+	_, exists := atm.sessionTokens[tokenStr]
+	atm.tokenMutex.RUnlock()
+	assert.True(t, exists, "token must remain in the map when rotation is not yet due")
+}
+
+func TestRegisterUnregisterTokenRefreshChannel(t *testing.T) {
+	atm := newMinimalAuthManager(time.Hour)
+	sessionID := "reg-test-session"
+	ch := make(chan *TerminalMessage, 1)
+
+	atm.RegisterTokenRefreshChannel(sessionID, ch)
+	atm.tokenMutex.RLock()
+	_, registered := atm.notifyChannels[sessionID]
+	atm.tokenMutex.RUnlock()
+	assert.True(t, registered, "channel must be present after RegisterTokenRefreshChannel")
+
+	atm.UnregisterTokenRefreshChannel(sessionID)
+	atm.tokenMutex.RLock()
+	_, registered = atm.notifyChannels[sessionID]
+	atm.tokenMutex.RUnlock()
+	assert.False(t, registered, "channel must be absent after UnregisterTokenRefreshChannel")
+}

--- a/features/terminal/types.go
+++ b/features/terminal/types.go
@@ -15,10 +15,11 @@ import (
 type MessageType string
 
 const (
-	MessageTypeData   MessageType = "data"
-	MessageTypeResize MessageType = "resize"
-	MessageTypeClose  MessageType = "close"
-	MessageTypeError  MessageType = "error"
+	MessageTypeData         MessageType = "data"
+	MessageTypeResize       MessageType = "resize"
+	MessageTypeClose        MessageType = "close"
+	MessageTypeError        MessageType = "error"
+	MessageTypeTokenRefresh MessageType = "token-refresh"
 )
 
 // DataDirection represents the direction of terminal data flow
@@ -35,6 +36,8 @@ type TerminalMessage struct {
 	SessionID string      `json:"session_id,omitempty"`
 	Data      []byte      `json:"data,omitempty"`
 	Error     string      `json:"error,omitempty"`
+	Token     string      `json:"token,omitempty"`
+	ExpiresAt *time.Time  `json:"expires_at,omitempty"`
 	Timestamp time.Time   `json:"timestamp,omitempty"`
 }
 


### PR DESCRIPTION
## Summary

- `rotateTokensIfNeeded` now generates a new cryptographically secure token (via `crypto/rand`) on each rotation and swaps the old entry in `sessionTokens` for the new one, immediately invalidating the old token
- After releasing the token mutex, sends a `token-refresh` `TerminalMessage` over a per-session notification channel registered via `RegisterTokenRefreshChannel`; send is non-blocking with a 100 ms timeout so slow/disconnected clients cannot stall the rotation loop
- Added `MessageTypeTokenRefresh = "token-refresh"` to the `MessageType` enum and `Token`/`ExpiresAt` fields to `TerminalMessage` for clean JSON serialisation

## Files changed

- `features/terminal/types.go` — `MessageTypeTokenRefresh` constant; `Token` and `ExpiresAt` fields on `TerminalMessage`
- `features/terminal/auth_integration.go` — `tokenRefreshNotifyTimeout` const; `notifyChannels` map on struct; `RegisterTokenRefreshChannel`/`UnregisterTokenRefreshChannel` methods; reworked `rotateTokensIfNeeded`
- `features/terminal/auth_integration_test.go` — new file; 5 tests covering happy-path notification, slow-client non-blocking, no-channel-registered, not-yet-due, and register/unregister lifecycle

## Specialist review results

- **QA Test Runner: PASS** — `make test-agent-complete` passed all gates (unit, integration, cross-platform builds, lint, license, architecture compliance, security scan)
- **QA Code Reviewer: PASS** — no mocks, no skips, no empty assertions; blocking issue (missing rotation assertions in slow-client test) found and fixed before commit
- **Security Engineer: PASS** — `make security-precommit`, `make check-architecture`, `make security-scan` all passed; no hardcoded secrets, no SQL, no central provider violations, no token values logged; tenant isolation preserved (new token entry copies full `SessionToken` struct including `Metadata["tenant_id"]`)

Fixes #1606