### PR TITLE
pipeline: po-act.sh sync subcommand to keep cron scripts current

### DIFF
--- a/.claude/agents/po.md
+++ b/.claude/agents/po.md
@@ -235,11 +235,22 @@ This runs **locally** with full Docker access for dispatch and fix cycles. The r
 
 ### 4.0 Pre-Flight
 
+First fast-forward the local checkout so the cycle runs current pipeline
+scripts, then run preflight:
+
 ```bash
+./.claude/scripts/po-act.sh sync
 ./.claude/scripts/po-act.sh preflight
 ```
 
-Emits a compact summary (counts, running containers, merge queue, recommendations). Full JSON cached at `~/.cache/cfgms-po/preflight.json` for further `po-act.sh state '.some.jq.filter'` queries.
+`sync` fast-forwards `develop` (it self-skips on a dirty tree or a
+non-`develop` branch, and never creates a merge commit). Run it as its own
+command before `preflight` — never folded into preflight, since the script
+must not rewrite itself mid-run. Outcomes: `SYNC_OK` / `SYNC_SKIP` — proceed
+normally; `SYNC_FAILED` — note it in the cycle report and continue on the
+current scripts.
+
+`preflight` emits a compact summary (counts, running containers, merge queue, recommendations). Full JSON cached at `~/.cache/cfgms-po/preflight.json` for further `po-act.sh state '.some.jq.filter'` queries.
 
 **Code-health gate (check this BEFORE dispatch decisions):**
 

--- a/.claude/scripts/po-act.sh
+++ b/.claude/scripts/po-act.sh
@@ -18,6 +18,7 @@
 #   merge-queue                     Emit current queue state as JSON
 #   block <ISSUE> <reason>          Set project status Blocked, post escalation comment
 #   unblock <ISSUE> <reason> [--as-fix]  Set project status Ready (or Fix), post unblock comment
+#   sync                            Fast-forward local develop checkout (keeps cron scripts current)
 #   preflight                       Run preflight (writes ~/.cache/cfgms-po/preflight.json, prints summary)
 #   state [jq_filter]               Read cached preflight and apply optional jq filter
 
@@ -244,6 +245,31 @@ case "$cmd" in
     gh api graphql \
       -f query='query { repository(owner: "cfg-is", name: "cfgms") { mergeQueue(branch: "develop") { entries(first: 50) { nodes { position state enqueuedAt pullRequest { number title } } } } } }' \
       -q '.data.repository.mergeQueue.entries.nodes'
+    ;;
+
+  sync)
+    # Fast-forward the local develop checkout so the cycle runs current
+    # pipeline scripts. Refuses on a dirty tree or a non-develop branch, and
+    # never creates a merge commit. Must run BEFORE preflight as its own
+    # process — never inside preflight, since the script must not rewrite
+    # itself mid-run.
+    repo_root="$(cd "$(dirname "$0")/../.." && pwd)"
+    branch=$(git -C "$repo_root" rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
+    if [ "$branch" != "develop" ]; then
+      echo "SYNC_SKIP:on branch ${branch:-unknown} (not develop)"
+      exit 0
+    fi
+    if ! git -C "$repo_root" diff --quiet --ignore-submodules HEAD 2>/dev/null; then
+      echo "SYNC_SKIP:working tree dirty — not pulling"
+      exit 0
+    fi
+    if out=$(git -C "$repo_root" pull --ff-only origin develop 2>&1); then
+      echo "$out" | tail -1
+      echo "SYNC_OK"
+    else
+      echo "SYNC_FAILED:$out" >&2
+      exit 1
+    fi
     ;;
 
   preflight)


### PR DESCRIPTION
## Summary

- Adds a `sync` subcommand to `po-act.sh` that fast-forwards the local `develop` checkout (`--ff-only`; self-skips on a dirty tree or non-`develop` branch; never creates a merge commit).
- `agents/po.md` §4.0 now runs `po-act.sh sync` before `preflight`, as its own command so the script never rewrites itself mid-run.

## Why

Cron cycles execute dispatch logic from the local working-tree copy of the pipeline scripts. When `develop` advances but the checkout is not pulled, cycles run stale logic. Issue #1593's credential gate sat merged but undeployed for ~5.5h, so cycles kept dispatching ungated containers that 401'd. `sync` closes that gap automatically each cycle.

## Test plan

- [x] `make test` passes (136 script tests + full validation)
- [x] `po-act.sh sync` on a feature branch returns `SYNC_SKIP` exit 0
- [x] `po-act.sh help` lists the new subcommand

Fixes #1628

🤖 Generated with [Claude Code](https://claude.com/claude-code)