### PR TITLE
rollback: wire real RBAC checks into validatePermissions (Issue #1600)

### DIFF
--- a/features/config/rollback/manager_test.go
+++ b/features/config/rollback/manager_test.go
@@ -386,10 +386,8 @@ func TestRollbackManager_ExecuteRollback_RequiresApproval(t *testing.T) {
 func TestRollbackValidator_ValidateRollback(t *testing.T) {
 	ctx := context.Background()
 
-	// Create validator with mocks
-	moduleRegistry := new(MockModuleRegistry)
-	configParser := new(MockConfigParser)
-	validator := rollback.NewRollbackValidator(moduleRegistry, configParser)
+	// Use no-op implementations for interfaces not exercised by these test cases.
+	validator := rollback.NewRollbackValidator(&noopModuleRegistry{}, &noopConfigParser{}, nil)
 
 	// Test cases
 	tests := []struct {
@@ -454,51 +452,34 @@ func TestRollbackValidator_ValidateRollback(t *testing.T) {
 	}
 }
 
-// Mock module registry for validator tests
-type MockModuleRegistry struct {
-	mock.Mock
+// noopModuleRegistry satisfies rollback.ModuleRegistry for tests that don't exercise
+// module-compatibility paths.
+type noopModuleRegistry struct{}
+
+func (r *noopModuleRegistry) GetModuleVersion(_ context.Context, _ string) (string, error) {
+	return "1.0.0", nil
 }
 
-func (m *MockModuleRegistry) GetModuleVersion(ctx context.Context, moduleName string) (string, error) {
-	args := m.Called(ctx, moduleName)
-	return args.String(0), args.Error(1)
+func (r *noopModuleRegistry) GetModuleDependencies(_ context.Context, _ string) ([]string, error) {
+	return nil, nil
 }
 
-func (m *MockModuleRegistry) GetModuleDependencies(ctx context.Context, moduleName string) ([]string, error) {
-	args := m.Called(ctx, moduleName)
-	if args.Get(0) == nil {
-		return nil, args.Error(1)
-	}
-	return args.Get(0).([]string), args.Error(1)
+func (r *noopModuleRegistry) IsModuleCompatible(_ context.Context, _, _ string) (bool, error) {
+	return true, nil
 }
 
-func (m *MockModuleRegistry) IsModuleCompatible(ctx context.Context, moduleName, version string) (bool, error) {
-	args := m.Called(ctx, moduleName, version)
-	return args.Bool(0), args.Error(1)
+// noopConfigParser satisfies rollback.ConfigurationParser for tests that don't exercise
+// configuration-parsing paths.
+type noopConfigParser struct{}
+
+func (p *noopConfigParser) ParseConfiguration(_ []byte, _ string) (map[string]interface{}, error) {
+	return map[string]interface{}{}, nil
 }
 
-// Mock config parser for validator tests
-type MockConfigParser struct {
-	mock.Mock
+func (p *noopConfigParser) ValidateSchema(_ map[string]interface{}, _ string) error {
+	return nil
 }
 
-func (m *MockConfigParser) ParseConfiguration(content []byte, format string) (map[string]interface{}, error) {
-	args := m.Called(content, format)
-	if args.Get(0) == nil {
-		return nil, args.Error(1)
-	}
-	return args.Get(0).(map[string]interface{}), args.Error(1)
-}
-
-func (m *MockConfigParser) ValidateSchema(config map[string]interface{}, schema string) error {
-	args := m.Called(config, schema)
-	return args.Error(0)
-}
-
-func (m *MockConfigParser) GetRequiredFields(schema string) []string {
-	args := m.Called(schema)
-	if args.Get(0) == nil {
-		return nil
-	}
-	return args.Get(0).([]string)
+func (p *noopConfigParser) GetRequiredFields(_ string) []string {
+	return nil
 }

--- a/features/config/rollback/validator.go
+++ b/features/config/rollback/validator.go
@@ -7,13 +7,17 @@ import (
 	"fmt"
 	"strings"
 	"time"
+
+	"github.com/cfgis/cfgms/api/proto/common"
+	"github.com/cfgis/cfgms/features/rbac"
+	"github.com/cfgis/cfgms/pkg/ctxkeys"
 )
 
 // DefaultRollbackValidator implements the RollbackValidator interface
 type DefaultRollbackValidator struct {
-	// Dependencies for validation
 	moduleRegistry ModuleRegistry
 	configParser   ConfigurationParser
+	rbacManager    rbac.RBACManager
 }
 
 // ModuleRegistry provides module information for validation
@@ -30,11 +34,13 @@ type ConfigurationParser interface {
 	GetRequiredFields(schema string) []string
 }
 
-// NewRollbackValidator creates a new rollback validator
-func NewRollbackValidator(moduleRegistry ModuleRegistry, configParser ConfigurationParser) RollbackValidator {
+// NewRollbackValidator creates a new rollback validator. Pass nil for rbacManager to disable
+// permission checks (useful for no-op or test contexts that only exercise other validations).
+func NewRollbackValidator(moduleRegistry ModuleRegistry, configParser ConfigurationParser, rbacManager rbac.RBACManager) RollbackValidator {
 	return &DefaultRollbackValidator{
 		moduleRegistry: moduleRegistry,
 		configParser:   configParser,
+		rbacManager:    rbacManager,
 	}
 }
 
@@ -367,7 +373,41 @@ func (v *DefaultRollbackValidator) checkBreakingChanges(ctx context.Context, cha
 }
 
 func (v *DefaultRollbackValidator) validatePermissions(ctx context.Context, request RollbackRequest) error {
-	// Deferred: tracked in #1440 — wire real RBAC checks for emergency and MSP-level rollback permissions
+	if v.rbacManager == nil {
+		return nil
+	}
+
+	userID, _ := ctx.Value(ctxkeys.UserIDKey).(string)
+	tenantID, _ := ctx.Value(ctxkeys.TenantID).(string)
+
+	if request.Emergency || request.RollbackType == RollbackTypeEmergency {
+		resp, err := v.rbacManager.CheckPermission(ctx, &common.AccessRequest{
+			SubjectId:    userID,
+			PermissionId: "rollback.emergency",
+			TenantId:     tenantID,
+		})
+		if err != nil {
+			return fmt.Errorf("permission check failed: %w", err)
+		}
+		if !resp.Granted {
+			return fmt.Errorf("caller does not have permission to perform emergency rollbacks")
+		}
+	}
+
+	if request.TargetType == TargetTypeMSP {
+		resp, err := v.rbacManager.CheckPermission(ctx, &common.AccessRequest{
+			SubjectId:    userID,
+			PermissionId: "rollback.msp",
+			TenantId:     tenantID,
+		})
+		if err != nil {
+			return fmt.Errorf("permission check failed: %w", err)
+		}
+		if !resp.Granted {
+			return fmt.Errorf("caller does not have permission to perform MSP-level rollbacks")
+		}
+	}
+
 	return nil
 }
 

--- a/features/config/rollback/validator_test.go
+++ b/features/config/rollback/validator_test.go
@@ -1,0 +1,253 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+package rollback_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cfgis/cfgms/api/proto/common"
+	"github.com/cfgis/cfgms/features/config/rollback"
+	"github.com/cfgis/cfgms/features/rbac"
+	pkgtesting "github.com/cfgis/cfgms/pkg/testing"
+	"github.com/cfgis/cfgms/pkg/ctxkeys"
+)
+
+// ctxWithCaller injects the UserIDKey and TenantID context values that validatePermissions reads.
+func ctxWithCaller(userID, tenantID string) context.Context {
+	ctx := context.WithValue(context.Background(), ctxkeys.UserIDKey, userID)
+	return context.WithValue(ctx, ctxkeys.TenantID, tenantID)
+}
+
+// adminCtx returns a background context with a sensitive-operation justification, required by
+// RBAC manager methods that modify roles or assignments (M-AUTH-2).
+func adminCtx() context.Context {
+	return rbac.WithSensitiveOperationJustification(context.Background(), "test: validator_test setup")
+}
+
+// TestValidatePermissions_EmergencyRollback_Denied verifies that a caller without the
+// rollback.emergency permission is denied when requesting an emergency rollback.
+func TestValidatePermissions_EmergencyRollback_Denied(t *testing.T) {
+	rbacManager := pkgtesting.SetupTestRBACManager(t)
+	ctx := context.Background()
+
+	// Create a subject with no rollback-related permissions (no role assigned).
+	subject := &common.Subject{
+		Id:          "user-no-emergency-perm",
+		Type:        common.SubjectType_SUBJECT_TYPE_USER,
+		DisplayName: "Unprivileged User",
+		TenantId:    "test-tenant",
+		IsActive:    true,
+	}
+	require.NoError(t, rbacManager.CreateSubject(ctx, subject))
+
+	validator := rollback.NewRollbackValidator(&noopModuleRegistry{}, nil, rbacManager)
+
+	callerCtx := ctxWithCaller("user-no-emergency-perm", "test-tenant")
+	request := rollback.RollbackRequest{
+		TargetType:   rollback.TargetTypeDevice,
+		TargetID:     "device-1",
+		RollbackType: rollback.RollbackTypeEmergency,
+		Emergency:    true,
+		Reason:       "Critical production failure",
+		RollbackTo:   "v1.0",
+	}
+
+	result, err := validator.ValidateRollback(callerCtx, request, nil)
+	require.NoError(t, err)
+	assert.False(t, result.Passed)
+
+	found := false
+	for _, e := range result.Errors {
+		if e.Type == "permission_validation" {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found, "expected permission_validation error for caller without rollback.emergency")
+}
+
+// TestValidatePermissions_EmergencyRollback_Granted verifies that a caller holding a role
+// with rollback.emergency passes the permission check and the rollback proceeds.
+func TestValidatePermissions_EmergencyRollback_Granted(t *testing.T) {
+	rbacManager := pkgtesting.SetupTestRBACManager(t)
+	setupCtx := adminCtx()
+
+	// Create the permission (already loaded by Initialize; just verify it exists).
+	_, err := rbacManager.GetPermission(setupCtx, "rollback.emergency")
+	require.NoError(t, err, "rollback.emergency permission must exist after Initialize")
+
+	// Create a role that grants emergency rollback access.
+	role := &common.Role{
+		Id:            "emergency-operator",
+		Name:          "Emergency Operator",
+		TenantId:      "test-tenant",
+		PermissionIds: []string{"rollback.emergency"},
+	}
+	require.NoError(t, rbacManager.CreateRole(setupCtx, role))
+
+	// Create the subject and assign the role.
+	subject := &common.Subject{
+		Id:          "user-with-emergency-perm",
+		Type:        common.SubjectType_SUBJECT_TYPE_USER,
+		DisplayName: "Emergency Operator User",
+		TenantId:    "test-tenant",
+		IsActive:    true,
+	}
+	require.NoError(t, rbacManager.CreateSubject(setupCtx, subject))
+	require.NoError(t, rbacManager.AssignRole(setupCtx, &common.RoleAssignment{
+		SubjectId: "user-with-emergency-perm",
+		RoleId:    "emergency-operator",
+		TenantId:  "test-tenant",
+	}))
+
+	validator := rollback.NewRollbackValidator(&noopModuleRegistry{}, nil, rbacManager)
+
+	callerCtx := ctxWithCaller("user-with-emergency-perm", "test-tenant")
+	request := rollback.RollbackRequest{
+		TargetType:   rollback.TargetTypeDevice,
+		TargetID:     "device-1",
+		RollbackType: rollback.RollbackTypeEmergency,
+		Emergency:    true,
+		Reason:       "Critical production failure",
+		RollbackTo:   "v1.0",
+	}
+
+	result, err := validator.ValidateRollback(callerCtx, request, nil)
+	require.NoError(t, err)
+
+	for _, e := range result.Errors {
+		assert.NotEqual(t, "permission_validation", e.Type,
+			"caller with rollback.emergency must not receive a permission error")
+	}
+	assert.True(t, result.Passed)
+}
+
+// TestValidatePermissions_MSPRollback_Denied verifies that a caller without rollback.msp
+// is denied when the rollback targets MSP scope.
+func TestValidatePermissions_MSPRollback_Denied(t *testing.T) {
+	rbacManager := pkgtesting.SetupTestRBACManager(t)
+	ctx := context.Background()
+
+	subject := &common.Subject{
+		Id:          "user-no-msp-perm",
+		Type:        common.SubjectType_SUBJECT_TYPE_USER,
+		DisplayName: "Non-MSP User",
+		TenantId:    "test-tenant",
+		IsActive:    true,
+	}
+	require.NoError(t, rbacManager.CreateSubject(ctx, subject))
+
+	validator := rollback.NewRollbackValidator(&noopModuleRegistry{}, nil, rbacManager)
+
+	callerCtx := ctxWithCaller("user-no-msp-perm", "test-tenant")
+	request := rollback.RollbackRequest{
+		TargetType:   rollback.TargetTypeMSP,
+		TargetID:     "msp-org-1",
+		RollbackType: rollback.RollbackTypeFull,
+		RollbackTo:   "v1.0",
+	}
+
+	result, err := validator.ValidateRollback(callerCtx, request, nil)
+	require.NoError(t, err)
+	assert.False(t, result.Passed)
+
+	found := false
+	for _, e := range result.Errors {
+		if e.Type == "permission_validation" {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found, "expected permission_validation error for caller without rollback.msp")
+}
+
+// TestValidatePermissions_MSPRollback_Granted verifies that a caller holding rollback.msp
+// passes the permission check for MSP-scope rollbacks.
+func TestValidatePermissions_MSPRollback_Granted(t *testing.T) {
+	rbacManager := pkgtesting.SetupTestRBACManager(t)
+	setupCtx := adminCtx()
+
+	_, err := rbacManager.GetPermission(setupCtx, "rollback.msp")
+	require.NoError(t, err, "rollback.msp permission must exist after Initialize")
+
+	role := &common.Role{
+		Id:            "msp-operator",
+		Name:          "MSP Operator",
+		TenantId:      "test-tenant",
+		PermissionIds: []string{"rollback.msp"},
+	}
+	require.NoError(t, rbacManager.CreateRole(setupCtx, role))
+
+	subject := &common.Subject{
+		Id:          "user-with-msp-perm",
+		Type:        common.SubjectType_SUBJECT_TYPE_USER,
+		DisplayName: "MSP Operator User",
+		TenantId:    "test-tenant",
+		IsActive:    true,
+	}
+	require.NoError(t, rbacManager.CreateSubject(setupCtx, subject))
+	require.NoError(t, rbacManager.AssignRole(setupCtx, &common.RoleAssignment{
+		SubjectId: "user-with-msp-perm",
+		RoleId:    "msp-operator",
+		TenantId:  "test-tenant",
+	}))
+
+	validator := rollback.NewRollbackValidator(&noopModuleRegistry{}, nil, rbacManager)
+
+	callerCtx := ctxWithCaller("user-with-msp-perm", "test-tenant")
+	request := rollback.RollbackRequest{
+		TargetType:   rollback.TargetTypeMSP,
+		TargetID:     "msp-org-1",
+		RollbackType: rollback.RollbackTypeFull,
+		RollbackTo:   "v1.0",
+	}
+
+	result, err := validator.ValidateRollback(callerCtx, request, nil)
+	require.NoError(t, err)
+
+	for _, e := range result.Errors {
+		assert.NotEqual(t, "permission_validation", e.Type,
+			"caller with rollback.msp must not receive a permission error")
+	}
+	assert.True(t, result.Passed)
+}
+
+// TestValidatePermissions_StandardRollback_NoCheck verifies that a standard (non-emergency,
+// non-MSP) rollback does not require any rollback-specific permission.
+func TestValidatePermissions_StandardRollback_NoCheck(t *testing.T) {
+	rbacManager := pkgtesting.SetupTestRBACManager(t)
+	ctx := context.Background()
+
+	// Subject with no rollback permissions at all.
+	subject := &common.Subject{
+		Id:          "user-standard-only",
+		Type:        common.SubjectType_SUBJECT_TYPE_USER,
+		DisplayName: "Standard User",
+		TenantId:    "test-tenant",
+		IsActive:    true,
+	}
+	require.NoError(t, rbacManager.CreateSubject(ctx, subject))
+
+	validator := rollback.NewRollbackValidator(&noopModuleRegistry{}, nil, rbacManager)
+
+	callerCtx := ctxWithCaller("user-standard-only", "test-tenant")
+	request := rollback.RollbackRequest{
+		TargetType:   rollback.TargetTypeDevice,
+		TargetID:     "device-1",
+		RollbackType: rollback.RollbackTypeFull,
+		RollbackTo:   "v1.0",
+	}
+
+	result, err := validator.ValidateRollback(callerCtx, request, nil)
+	require.NoError(t, err)
+
+	for _, e := range result.Errors {
+		assert.NotEqual(t, "permission_validation", e.Type,
+			"standard rollback must not trigger permission check")
+	}
+	assert.True(t, result.Passed)
+}

--- a/features/controller/server/server.go
+++ b/features/controller/server/server.go
@@ -573,7 +573,7 @@ func New(cfg *config.Config, logger logging.Logger) (*Server, error) {
 	}
 
 	// Story #416: Wire rollback manager into API server
-	rollbackManager := initializeRollbackManager(storageManager, logger)
+	rollbackManager := initializeRollbackManager(storageManager, logger, rbacManager)
 	httpServer.SetRollbackManager(rollbackManager)
 	configService.SetRollbackManager(rollbackManager)
 	logger.Info("Rollback manager wired to HTTP API server and gRPC config service")
@@ -722,12 +722,12 @@ func (r *noOpModuleRegistry) IsModuleCompatible(_ context.Context, _, _ string) 
 }
 
 // initializeRollbackManager creates and wires the rollback manager.
-func initializeRollbackManager(storageManager *interfaces.StorageManager, logger logging.Logger) rollback.RollbackManager {
+func initializeRollbackManager(storageManager *interfaces.StorageManager, logger logging.Logger, rbacManager rbac.RBACManager) rollback.RollbackManager {
 	// Use durable storage for rollback operations
 	rollbackStore := rollback.NewStorageRollbackStore(storageManager.GetConfigStore())
 
 	// Create validator with no-op module registry (full module registry requires separate story)
-	rollbackValidator := rollback.NewRollbackValidator(&noOpModuleRegistry{}, nil)
+	rollbackValidator := rollback.NewRollbackValidator(&noOpModuleRegistry{}, nil, rbacManager)
 
 	// Create notifier using standard logger
 	rollbackNotifier := rollback.NewDefaultRollbackNotifier(logger)

--- a/features/rbac/defaults.go
+++ b/features/rbac/defaults.go
@@ -221,6 +221,22 @@ var DefaultPermissions = []*common.Permission{
 		ResourceType: "system",
 		Actions:      []string{"emergency.access"},
 	},
+
+	// Rollback Permissions
+	{
+		Id:           "rollback.emergency",
+		Name:         "Emergency Rollback",
+		Description:  "Perform emergency configuration rollback without the normal approval flow",
+		ResourceType: "rollback",
+		Actions:      []string{"emergency"},
+	},
+	{
+		Id:           "rollback.msp",
+		Name:         "MSP-Level Rollback",
+		Description:  "Perform configuration rollback at MSP scope",
+		ResourceType: "rollback",
+		Actions:      []string{"rollback"},
+	},
 }
 
 // Default system roles that combine permissions logically


### PR DESCRIPTION
## Summary

- Replaces the `validatePermissions` stub in `DefaultRollbackValidator` with real `RBACManager.CheckPermission` calls
- Adds `rollback.emergency` and `rollback.msp` to `DefaultPermissions` (dot-notation, consistent with all existing permissions)
- Emergency and `RollbackTypeEmergency` requests gate on `rollback.emergency`; `TargetTypeMSP` requests gate on `rollback.msp`
- Five new tests use a real `rbac.Manager` backed by OSS composite storage (no mocks): denied/granted for both permission types plus standard no-check path
- Replaces `MockModuleRegistry`/`MockConfigParser` (testify/mock) in `manager_test.go` with plain no-op structs
- Wires the real RBAC manager into `initializeRollbackManager` in `server.go`

Fixes #1600

## Specialist Review Results

| Specialist | Result |
|---|---|
| QA Test Runner | ✅ PASS — all 5 new tests pass; full `make test-agent-complete` passes |
| QA Code Reviewer | ✅ PASS — no mocks in validator_test.go, both denied and granted paths covered, pre-existing manager orchestration mocks acknowledged as out-of-scope tech debt |
| Security Engineer | ✅ PASS — permission IDs use dot notation (wildcard-evasion gap closed), fail-closed behavior verified, no information disclosure, check-architecture clean |

## Test plan

- [ ] `go test ./features/config/rollback/... -v` — all 5 new permission tests pass
- [ ] `go test ./features/rbac/... -v` — RBAC defaults tests still pass
- [ ] `go build ./features/controller/server/...` — server compiles with new rbacManager wiring
- [ ] `make test-agent-complete` — full suite passes (validated by QA test runner)