### PR TITLE
config: wire real user identity into getCurrentUser (Issue #1602)

### DIFF
--- a/features/config/diff/approval.go
+++ b/features/config/diff/approval.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/cfgis/cfgms/pkg/ctxkeys"
 	"github.com/cfgis/cfgms/pkg/logging"
 )
 
@@ -42,6 +43,11 @@ func NewDefaultApprovalIntegration(logger logging.Logger) *DefaultApprovalIntegr
 
 // CreateApprovalRequest creates an approval request for changes
 func (ai *DefaultApprovalIntegration) CreateApprovalRequest(ctx context.Context, result *ComparisonResult, assessment *RiskAssessment) (*ApprovalRequest, error) {
+	requester, err := ai.getCurrentUser(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("cannot create approval request: %w", err)
+	}
+
 	// Generate unique request ID
 	requestID, err := generateRequestID()
 	if err != nil {
@@ -58,7 +64,7 @@ func (ai *DefaultApprovalIntegration) CreateApprovalRequest(ctx context.Context,
 		Description:       ai.generateDescription(result, assessment),
 		Changes:           result,
 		RiskAssessment:    assessment,
-		Requester:         ai.getCurrentUser(ctx),
+		Requester:         requester,
 		RequiredApprovers: requiredApprovers,
 		Status: ApprovalStatus{
 			Status:           "pending",
@@ -296,9 +302,12 @@ func (ai *DefaultApprovalIntegration) generateDescription(result *ComparisonResu
 }
 
 // getCurrentUser gets the current user from context
-func (ai *DefaultApprovalIntegration) getCurrentUser(ctx context.Context) string {
-	// Deferred: tracked in #1440 — extract authenticated user identity from context
-	return "system"
+func (ai *DefaultApprovalIntegration) getCurrentUser(ctx context.Context) (string, error) {
+	userID, ok := ctx.Value(ctxkeys.UserIDKey).(string)
+	if !ok || userID == "" {
+		return "", fmt.Errorf("unauthenticated: no user identity in context")
+	}
+	return userID, nil
 }
 
 // determineRequiredApprovers determines who needs to approve based on risk assessment

--- a/features/config/diff/approval_test.go
+++ b/features/config/diff/approval_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/cfgis/cfgms/pkg/ctxkeys"
 	pkgtesting "github.com/cfgis/cfgms/pkg/testing"
 )
 
@@ -16,7 +17,7 @@ func TestNewDefaultApprovalIntegration_nilLogger_usesNoop(t *testing.T) {
 	ai := NewDefaultApprovalIntegration(nil)
 	require.NotNil(t, ai)
 	// Verify no panic on usage
-	ctx := context.Background()
+	ctx := context.WithValue(context.Background(), ctxkeys.UserIDKey, "test-user")
 	result := &ComparisonResult{
 		FromRef: ConfigurationReference{Commit: "abc12345"},
 		ToRef:   ConfigurationReference{Commit: "def67890"},
@@ -35,7 +36,7 @@ func TestDefaultApprovalIntegration_logsApproverCount(t *testing.T) {
 	ai := NewDefaultApprovalIntegration(mock)
 	require.NotNil(t, ai)
 
-	ctx := context.Background()
+	ctx := context.WithValue(context.Background(), ctxkeys.UserIDKey, "test-user")
 	result := &ComparisonResult{
 		FromRef: ConfigurationReference{Commit: "abc12345"},
 		ToRef:   ConfigurationReference{Commit: "def67890"},
@@ -86,7 +87,7 @@ func TestDefaultApprovalIntegration_logsOnNotifyUpdate(t *testing.T) {
 	mock := pkgtesting.NewMockLogger(true)
 	ai := NewDefaultApprovalIntegration(mock)
 
-	ctx := context.Background()
+	ctx := context.WithValue(context.Background(), ctxkeys.UserIDKey, "test-user")
 	result := &ComparisonResult{
 		FromRef: ConfigurationReference{Commit: "abc12345"},
 		ToRef:   ConfigurationReference{Commit: "def67890"},
@@ -110,7 +111,7 @@ func TestDefaultApprovalIntegration_logsOnNotifyCancellation(t *testing.T) {
 	mock := pkgtesting.NewMockLogger(true)
 	ai := NewDefaultApprovalIntegration(mock)
 
-	ctx := context.Background()
+	ctx := context.WithValue(context.Background(), ctxkeys.UserIDKey, "test-user")
 	result := &ComparisonResult{
 		FromRef: ConfigurationReference{Commit: "abc12345"},
 		ToRef:   ConfigurationReference{Commit: "def67890"},
@@ -128,4 +129,39 @@ func TestDefaultApprovalIntegration_logsOnNotifyCancellation(t *testing.T) {
 	infoLogs := mock.GetLogs("info")
 	require.NotEmpty(t, infoLogs)
 	assert.Equal(t, "notifying approvers of cancellation", infoLogs[0].Message)
+}
+
+func TestDefaultApprovalIntegration_CreateApprovalRequest_RequesterFromContext(t *testing.T) {
+	ai := NewDefaultApprovalIntegration(nil)
+	ctx := context.WithValue(context.Background(), ctxkeys.UserIDKey, "alice@example.com")
+
+	result := &ComparisonResult{
+		FromRef: ConfigurationReference{Commit: "abc12345"},
+		ToRef:   ConfigurationReference{Commit: "def67890"},
+		Summary: DiffSummary{TotalChanges: 1},
+	}
+	assessment := &RiskAssessment{OverallRisk: ImpactLevelLow}
+
+	req, err := ai.CreateApprovalRequest(ctx, result, assessment)
+
+	require.NoError(t, err)
+	require.NotNil(t, req)
+	assert.Equal(t, "alice@example.com", req.Requester)
+}
+
+func TestDefaultApprovalIntegration_CreateApprovalRequest_ErrorWithoutUserInContext(t *testing.T) {
+	ai := NewDefaultApprovalIntegration(nil)
+	ctx := context.Background() // No user ID in context
+
+	result := &ComparisonResult{
+		FromRef: ConfigurationReference{Commit: "abc12345"},
+		ToRef:   ConfigurationReference{Commit: "def67890"},
+		Summary: DiffSummary{TotalChanges: 1},
+	}
+	assessment := &RiskAssessment{OverallRisk: ImpactLevelLow}
+
+	_, err := ai.CreateApprovalRequest(ctx, result, assessment)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unauthenticated")
 }

--- a/features/config/rollback/manager.go
+++ b/features/config/rollback/manager.go
@@ -11,6 +11,7 @@ import (
 	"github.com/google/uuid"
 
 	"github.com/cfgis/cfgms/features/config/git"
+	"github.com/cfgis/cfgms/pkg/ctxkeys"
 )
 
 // DefaultRollbackManager implements the RollbackManager interface
@@ -156,6 +157,11 @@ func (m *DefaultRollbackManager) PreviewRollback(ctx context.Context, request Ro
 
 // ExecuteRollback performs the rollback operation
 func (m *DefaultRollbackManager) ExecuteRollback(ctx context.Context, request RollbackRequest) (*RollbackOperation, error) {
+	userID, err := m.getCurrentUser(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("cannot execute rollback: %w", err)
+	}
+
 	// Check for existing rollback in progress
 	if err := m.checkNoRollbackInProgress(ctx, request.TargetType, request.TargetID); err != nil {
 		return nil, err
@@ -191,7 +197,7 @@ func (m *DefaultRollbackManager) ExecuteRollback(ctx context.Context, request Ro
 		ID:          uuid.New().String(),
 		Request:     request,
 		Status:      RollbackStatusPending,
-		InitiatedBy: m.getCurrentUser(ctx),
+		InitiatedBy: userID,
 		InitiatedAt: time.Now(),
 		Progress: RollbackProgress{
 			Stage:      "initializing",
@@ -238,6 +244,11 @@ func (m *DefaultRollbackManager) GetRollbackStatus(ctx context.Context, rollback
 
 // CancelRollback cancels an in-progress rollback
 func (m *DefaultRollbackManager) CancelRollback(ctx context.Context, rollbackID string, reason string) error {
+	userID, err := m.getCurrentUser(ctx)
+	if err != nil {
+		return fmt.Errorf("cannot cancel rollback: %w", err)
+	}
+
 	operation, err := m.store.GetOperation(ctx, rollbackID)
 	if err != nil {
 		return err
@@ -264,7 +275,7 @@ func (m *DefaultRollbackManager) CancelRollback(ctx context.Context, rollbackID 
 
 	// Add audit entry
 	m.addAuditEntry(ctx, operation, "rollback_cancelled", reason, map[string]interface{}{
-		"cancelled_by": m.getCurrentUser(ctx),
+		"cancelled_by": userID,
 	})
 
 	// Update operation
@@ -682,16 +693,24 @@ func (m *DefaultRollbackManager) verifyApproval(ctx context.Context, approvalID 
 	return nil
 }
 
-func (m *DefaultRollbackManager) getCurrentUser(ctx context.Context) string {
-	// Deferred: tracked in #1440 — extract authenticated user identity from context
-	return "system"
+func (m *DefaultRollbackManager) getCurrentUser(ctx context.Context) (string, error) {
+	userID, ok := ctx.Value(ctxkeys.UserIDKey).(string)
+	if !ok || userID == "" {
+		return "", fmt.Errorf("unauthenticated: no user identity in context")
+	}
+	return userID, nil
 }
 
 func (m *DefaultRollbackManager) addAuditEntry(ctx context.Context, operation *RollbackOperation, eventType, action string, details map[string]interface{}) {
+	actor, err := m.getCurrentUser(ctx)
+	if err != nil {
+		// Async operations run with context.Background(); use the authenticated initiator recorded at operation start.
+		actor = operation.InitiatedBy
+	}
 	entry := AuditEntry{
 		Timestamp: time.Now(),
 		EventType: eventType,
-		Actor:     m.getCurrentUser(ctx),
+		Actor:     actor,
 		Action:    action,
 		Details:   details,
 		Result:    "success",

--- a/features/config/rollback/manager_test.go
+++ b/features/config/rollback/manager_test.go
@@ -9,9 +9,11 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 
 	"github.com/cfgis/cfgms/features/config/git"
 	"github.com/cfgis/cfgms/features/config/rollback"
+	"github.com/cfgis/cfgms/pkg/ctxkeys"
 )
 
 // Mock implementations
@@ -337,7 +339,7 @@ func TestRollbackManager_PreviewRollback(t *testing.T) {
 }
 
 func TestRollbackManager_ExecuteRollback_RequiresApproval(t *testing.T) {
-	ctx := context.Background()
+	ctx := context.WithValue(context.Background(), ctxkeys.UserIDKey, "test-user")
 
 	// Setup mocks
 	gitManager := new(MockGitManager)
@@ -501,4 +503,62 @@ func (m *MockConfigParser) GetRequiredFields(schema string) []string {
 		return nil
 	}
 	return args.Get(0).([]string)
+}
+
+func TestRollbackManager_ExecuteRollback_ErrorWithoutUserInContext(t *testing.T) {
+	// CancelRollback and ExecuteRollback both call getCurrentUser first;
+	// use a context with no user ID to assert the auth guard is in place.
+	ctx := context.Background()
+
+	store := rollback.NewInMemoryRollbackStore()
+	manager := rollback.NewRollbackManager(nil, nil, store, nil)
+
+	request := rollback.RollbackRequest{
+		TargetType:   rollback.TargetTypeDevice,
+		TargetID:     "123",
+		RollbackType: rollback.RollbackTypeFull,
+		RollbackTo:   "abc123",
+		Reason:       "test",
+	}
+
+	_, err := manager.ExecuteRollback(ctx, request)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unauthenticated")
+}
+
+func TestRollbackManager_CancelRollback_UserIDFromContext(t *testing.T) {
+	// Seeds an operation directly in the store, then cancels it with a known user in context.
+	// Verifies that getCurrentUser reads the user ID from context and records it in the audit trail.
+	ctx := context.WithValue(context.Background(), ctxkeys.UserIDKey, "cancel-actor")
+
+	store := rollback.NewInMemoryRollbackStore()
+	manager := rollback.NewRollbackManager(nil, nil, store, nil)
+
+	op := &rollback.RollbackOperation{
+		ID:          "op-ctx-test",
+		Status:      rollback.RollbackStatusPending,
+		InitiatedBy: "original-user",
+		AuditTrail:  []rollback.AuditEntry{},
+	}
+	require.NoError(t, store.SaveOperation(ctx, op))
+
+	require.NoError(t, manager.CancelRollback(ctx, "op-ctx-test", "context test"))
+
+	updated, err := store.GetOperation(ctx, "op-ctx-test")
+	require.NoError(t, err)
+	require.NotEmpty(t, updated.AuditTrail)
+	assert.Equal(t, "cancel-actor", updated.AuditTrail[len(updated.AuditTrail)-1].Actor)
+}
+
+func TestRollbackManager_CancelRollback_ErrorWithoutUserInContext(t *testing.T) {
+	ctx := context.Background() // No user ID in context
+
+	store := rollback.NewInMemoryRollbackStore()
+	manager := rollback.NewRollbackManager(nil, nil, store, nil)
+
+	err := manager.CancelRollback(ctx, "any-op-id", "reason")
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unauthenticated")
 }


### PR DESCRIPTION
## Summary

Replaces the hardcoded `return "system"` in `rollback/manager.go` and `diff/approval.go` `getCurrentUser()` with real context extraction using `ctxkeys.UserIDKey`. Both functions now fail closed — returning an unauthenticated error — when no user identity is present in context, instead of silently attributing operations to a phantom "system" actor.

## Problem Context

`getCurrentUser()` in both files returned the string literal `"system"` unconditionally. This meant every rollback `InitiatedBy`, cancel audit entry, and approval request `Requester` field recorded `"system"` regardless of which authenticated user performed the action. Auth failures were invisible: a missing user in context produced the same behaviour as a properly authenticated one.

## Changes

- `getCurrentUser()` in both files now reads `ctxkeys.UserIDKey` from context and returns `(string, error)` — error if the key is absent or empty
- `ExecuteRollback` and `CancelRollback` check user identity at function entry before touching git/store operations
- `addAuditEntry` uses `operation.InitiatedBy` as the actor when called from the async goroutine (`context.Background()` carries no user; the initiator was captured from an authenticated context at `ExecuteRollback` entry)
- `CreateApprovalRequest` propagates the auth error to the caller

## Testing

New mock-free tests using real `InMemoryRollbackStore` and `DefaultApprovalIntegration`:
- `TestRollbackManager_CancelRollback_UserIDFromContext` — seeds a Pending operation, cancels with user in context, asserts `AuditTrail[last].Actor == user from context`
- `TestRollbackManager_CancelRollback_ErrorWithoutUserInContext` — verifies unauthenticated error
- `TestRollbackManager_ExecuteRollback_ErrorWithoutUserInContext` — verifies unauthenticated error at function entry
- `TestDefaultApprovalIntegration_CreateApprovalRequest_RequesterFromContext` — asserts `req.Requester` matches user in context
- `TestDefaultApprovalIntegration_CreateApprovalRequest_ErrorWithoutUserInContext` — verifies error propagation

All existing tests updated to supply a user ID in context where required.

## Specialist Review Results

- **QA Test Runner**: PASS — all packages pass with race detection; 5 cross-platform builds verified
- **QA Code Reviewer**: PASS — 0 blocking issues; all new tests mock-free with meaningful assertions and error path coverage
- **Security Engineer**: PASS — 0 blocking issues; automated scans (gosec, Trivy, Nancy, staticcheck, architecture) all pass

## Follow-up Required

The controller HTTP middleware (`features/controller/api/middleware.go`) writes the authenticated user under a local `userIDContextKey`, not `ctxkeys.UserIDKey`. Until that middleware is migrated, these auth guards will reject real HTTP requests (fail-closed, not fail-open). A follow-up story to align the middleware is tracked separately.

Fixes #1602