### PR TITLE
fleet/storage: fix OptimizedDNACompressor round-trip and wire factory (Issue #1607)

### DIFF
--- a/features/controller/fleet/storage/compression.go
+++ b/features/controller/fleet/storage/compression.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/timestamppb"
 
 	commonpb "github.com/cfgis/cfgms/api/proto/common"
 )
@@ -46,6 +47,8 @@ func NewCompressor(algorithm string, level int) (Compressor, error) {
 		return NewZstdCompressor(level)
 	case "lz4":
 		return NewLZ4Compressor()
+	case "dna-optimized":
+		return NewOptimizedDNACompressor("gzip", level)
 	default:
 		return nil, fmt.Errorf("unsupported compression algorithm: %s", algorithm)
 	}
@@ -386,50 +389,146 @@ func NewOptimizedDNACompressor(algorithm string, level int) (*OptimizedDNACompre
 
 // OptimizedDNAData represents DNA data optimized for compression
 type OptimizedDNAData struct {
-	ID              string `json:"id"`
-	AttributeKeys   []int  `json:"attribute_keys"`   // Indices into attribute dictionary
-	AttributeValues []int  `json:"attribute_values"` // Indices into value dictionary
-	LastUpdated     int64  `json:"last_updated"`     // Unix timestamp
-	ConfigHash      string `json:"config_hash"`
-	LastSyncTime    int64  `json:"last_sync_time"` // Unix timestamp
-	AttributeCount  int32  `json:"attribute_count"`
-	SyncFingerprint string `json:"sync_fingerprint"`
+	ID                string `json:"id"`
+	AttributeKeys     []int  `json:"attribute_keys"`   // Indices into attribute dictionary
+	AttributeValues   []int  `json:"attribute_values"` // Indices into value dictionary
+	LastUpdated       int64  `json:"last_updated"`     // Unix timestamp seconds
+	LastUpdatedNanos  int32  `json:"last_updated_nanos,omitempty"`
+	ConfigHash        string `json:"config_hash"`
+	LastSyncTime      int64  `json:"last_sync_time"` // Unix timestamp seconds
+	LastSyncTimeNanos int32  `json:"last_sync_time_nanos,omitempty"`
+	AttributeCount    int32  `json:"attribute_count"`
+	SyncFingerprint   string `json:"sync_fingerprint"`
+}
+
+// serializedOptimizedPayload is the on-wire format produced by OptimizedDNACompressor.
+// It embeds the reverse dictionaries so each payload is self-contained.
+type serializedOptimizedPayload struct {
+	Data          *OptimizedDNAData `json:"d"`
+	AttributeDict []string          `json:"ak"` // index → attribute key string
+	ValueDict     []string          `json:"vk"` // index → value string
 }
 
 // Compress compresses DNA data using dictionary-based optimization
 func (c *OptimizedDNACompressor) Compress(dna *commonpb.DNA) ([]byte, int64, error) {
 	start := time.Now()
 
-	// Build dictionaries and convert to optimized format
 	optimized := c.optimizeDNA(dna)
 
-	// Serialize optimized data
-	optimizedData, err := json.Marshal(optimized)
-	if err != nil {
-		return nil, 0, fmt.Errorf("failed to marshal optimized DNA: %w", err)
+	// Build reverse dictionaries to embed in the payload so Decompress is self-contained.
+	c.dictMutex.RLock()
+	attrDict := make([]string, len(c.attributeDict))
+	for k, idx := range c.attributeDict {
+		attrDict[idx] = k
+	}
+	valDict := make([]string, len(c.valueDict))
+	for k, idx := range c.valueDict {
+		valDict[idx] = k
+	}
+	c.dictMutex.RUnlock()
+
+	payload := &serializedOptimizedPayload{
+		Data:          optimized,
+		AttributeDict: attrDict,
+		ValueDict:     valDict,
 	}
 
-	originalSize := int64(len(optimizedData))
-
-	// Compress using base compressor
-	compressed, _, err := c.baseCompressor.Compress(dna)
+	payloadData, err := json.Marshal(payload)
 	if err != nil {
-		return nil, originalSize, err
+		return nil, 0, fmt.Errorf("failed to marshal optimized DNA payload: %w", err)
 	}
 
-	compressedSize := int64(len(compressed))
+	originalSize := int64(len(payloadData))
+
+	var buf bytes.Buffer
+	gzipWriter, err := gzip.NewWriterLevel(&buf, gzip.DefaultCompression)
+	if err != nil {
+		return nil, originalSize, fmt.Errorf("failed to create gzip writer: %w", err)
+	}
+
+	if _, err := gzipWriter.Write(payloadData); err != nil {
+		_ = gzipWriter.Close()
+		return nil, originalSize, fmt.Errorf("failed to compress optimized DNA payload: %w", err)
+	}
+
+	if err := gzipWriter.Close(); err != nil {
+		return nil, originalSize, fmt.Errorf("failed to finalize gzip compression: %w", err)
+	}
+
+	compressedData := buf.Bytes()
+	compressedSize := int64(len(compressedData))
 	compressionTime := time.Since(start)
 
-	// Update statistics
 	c.updateStats(originalSize, compressedSize, compressionTime)
 
-	return compressed, originalSize, nil
+	return compressedData, originalSize, nil
 }
 
-// Decompress decompresses optimized DNA data
+// Decompress decompresses optimized DNA data, reversing the dictionary optimization.
 func (c *OptimizedDNACompressor) Decompress(data []byte) (*commonpb.DNA, error) {
-	// Deferred: tracked in #1443 — reverse DNA field-level optimization on decompress
-	return c.baseCompressor.Decompress(data)
+	reader, err := gzip.NewReader(bytes.NewReader(data))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create gzip reader: %w", err)
+	}
+	defer func() { _ = reader.Close() }()
+
+	var raw bytes.Buffer
+	if _, err := raw.ReadFrom(reader); err != nil {
+		return nil, fmt.Errorf("failed to decompress optimized DNA payload: %w", err)
+	}
+
+	var payload serializedOptimizedPayload
+	if err := json.Unmarshal(raw.Bytes(), &payload); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal optimized DNA payload: %w", err)
+	}
+
+	optimized := payload.Data
+	if optimized == nil {
+		return nil, fmt.Errorf("missing DNA data in optimized payload")
+	}
+
+	dna := &commonpb.DNA{
+		Id:              optimized.ID,
+		ConfigHash:      optimized.ConfigHash,
+		AttributeCount:  optimized.AttributeCount,
+		SyncFingerprint: optimized.SyncFingerprint,
+	}
+
+	if optimized.LastUpdated != 0 || optimized.LastUpdatedNanos != 0 {
+		dna.LastUpdated = &timestamppb.Timestamp{
+			Seconds: optimized.LastUpdated,
+			Nanos:   optimized.LastUpdatedNanos,
+		}
+	}
+
+	if optimized.LastSyncTime != 0 || optimized.LastSyncTimeNanos != 0 {
+		dna.LastSyncTime = &timestamppb.Timestamp{
+			Seconds: optimized.LastSyncTime,
+			Nanos:   optimized.LastSyncTimeNanos,
+		}
+	}
+
+	// Reverse the dictionary optimization to reconstruct the attributes map.
+	if len(optimized.AttributeKeys) > 0 {
+		if len(optimized.AttributeKeys) != len(optimized.AttributeValues) {
+			return nil, fmt.Errorf("attribute keys/values length mismatch: %d keys, %d values",
+				len(optimized.AttributeKeys), len(optimized.AttributeValues))
+		}
+
+		dna.Attributes = make(map[string]string, len(optimized.AttributeKeys))
+		for i, keyIdx := range optimized.AttributeKeys {
+			if keyIdx < 0 || keyIdx >= len(payload.AttributeDict) {
+				return nil, fmt.Errorf("attribute key index %d out of range (dict size %d)", keyIdx, len(payload.AttributeDict))
+			}
+			valueIdx := optimized.AttributeValues[i]
+			if valueIdx < 0 || valueIdx >= len(payload.ValueDict) {
+				return nil, fmt.Errorf("attribute value index %d out of range (dict size %d)", valueIdx, len(payload.ValueDict))
+			}
+			dna.Attributes[payload.AttributeDict[keyIdx]] = payload.ValueDict[valueIdx]
+		}
+	}
+
+	return dna, nil
 }
 
 // GetCompressionRatio returns the current average compression ratio
@@ -471,10 +570,12 @@ func (c *OptimizedDNACompressor) optimizeDNA(dna *commonpb.DNA) *OptimizedDNADat
 
 	if dna.LastUpdated != nil {
 		optimized.LastUpdated = dna.LastUpdated.Seconds
+		optimized.LastUpdatedNanos = dna.LastUpdated.Nanos
 	}
 
 	if dna.LastSyncTime != nil {
 		optimized.LastSyncTime = dna.LastSyncTime.Seconds
+		optimized.LastSyncTimeNanos = dna.LastSyncTime.Nanos
 	}
 
 	// Convert attributes using dictionaries

--- a/features/controller/fleet/storage/compression_test.go
+++ b/features/controller/fleet/storage/compression_test.go
@@ -1,0 +1,227 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+// Package storage provides tests for DNA compression.
+
+package storage
+
+import (
+	"bytes"
+	"compress/gzip"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	commonpb "github.com/cfgis/cfgms/api/proto/common"
+)
+
+// buildRealisticDNA returns a DNA with multiple attributes, nested keys, and non-zero timestamps
+// to catch index-boundary bugs and nanos-loss bugs.
+func buildRealisticDNA() *commonpb.DNA {
+	return &commonpb.DNA{
+		Id:              "device-12345",
+		ConfigHash:      "abc123def456",
+		AttributeCount:  15,
+		SyncFingerprint: "fp-xyz789",
+		LastUpdated:     &timestamppb.Timestamp{Seconds: 1700000000, Nanos: 123456789},
+		LastSyncTime:    &timestamppb.Timestamp{Seconds: 1700000100, Nanos: 987654321},
+		Attributes: map[string]string{
+			"os.name":          "Ubuntu",
+			"os.version":       "22.04",
+			"os.arch":          "amd64",
+			"software.nginx":   "1.24.0",
+			"software.docker":  "24.0.7",
+			"config.hostname":  "web-server-01",
+			"config.domain":    "example.com",
+			"network.ipv4":     "192.168.1.100",
+			"network.ipv6":     "::1",
+			"hardware.cpu":     "AMD EPYC 7543",
+			"hardware.memory":  "64GB",
+			"hardware.disk":    "1TB NVMe",
+			"security.fw":      "active",
+			"security.selinux": "enforcing",
+			"monitoring.agent": "prometheus-2.45",
+		},
+	}
+}
+
+func TestOptimizedDNACompressor_RoundTrip(t *testing.T) {
+	dna := buildRealisticDNA()
+
+	compressor, err := NewOptimizedDNACompressor("gzip", 6)
+	require.NoError(t, err)
+	defer func() { _ = compressor.Close() }()
+
+	compressed, originalSize, err := compressor.Compress(dna)
+	require.NoError(t, err)
+	assert.Positive(t, originalSize)
+	assert.NotEmpty(t, compressed)
+
+	decompressed, err := compressor.Decompress(compressed)
+	require.NoError(t, err)
+	require.NotNil(t, decompressed)
+
+	// Use proto.Equal for a complete semantic comparison including all fields.
+	assert.True(t, proto.Equal(dna, decompressed),
+		"round-trip must return semantically identical DNA\nwant: %v\ngot:  %v", dna, decompressed)
+}
+
+func TestOptimizedDNACompressor_RoundTrip_EmptyAttributes(t *testing.T) {
+	dna := &commonpb.DNA{
+		Id:         "empty-device",
+		ConfigHash: "hash-empty",
+		Attributes: map[string]string{},
+	}
+
+	compressor, err := NewOptimizedDNACompressor("gzip", 6)
+	require.NoError(t, err)
+	defer func() { _ = compressor.Close() }()
+
+	compressed, _, err := compressor.Compress(dna)
+	require.NoError(t, err)
+
+	decompressed, err := compressor.Decompress(compressed)
+	require.NoError(t, err)
+	assert.True(t, proto.Equal(dna, decompressed))
+}
+
+func TestOptimizedDNACompressor_RoundTrip_NilTimestamps(t *testing.T) {
+	dna := &commonpb.DNA{
+		Id:              "no-timestamps",
+		ConfigHash:      "cfg",
+		SyncFingerprint: "fp",
+		AttributeCount:  2,
+		Attributes: map[string]string{
+			"key1": "val1",
+			"key2": "val2",
+		},
+	}
+
+	compressor, err := NewOptimizedDNACompressor("gzip", 6)
+	require.NoError(t, err)
+	defer func() { _ = compressor.Close() }()
+
+	compressed, _, err := compressor.Compress(dna)
+	require.NoError(t, err)
+
+	decompressed, err := compressor.Decompress(compressed)
+	require.NoError(t, err)
+	assert.True(t, proto.Equal(dna, decompressed))
+	assert.Nil(t, decompressed.LastUpdated)
+	assert.Nil(t, decompressed.LastSyncTime)
+}
+
+func TestNewCompressor_DNAOptimized(t *testing.T) {
+	compressor, err := NewCompressor("dna-optimized", 6)
+	require.NoError(t, err)
+	require.NotNil(t, compressor)
+
+	_, ok := compressor.(*OptimizedDNACompressor)
+	assert.True(t, ok, "NewCompressor(\"dna-optimized\") must return *OptimizedDNACompressor")
+
+	defer func() { _ = compressor.Close() }()
+
+	// Verify it is fully functional end-to-end via the factory.
+	dna := buildRealisticDNA()
+	compressed, _, err := compressor.Compress(dna)
+	require.NoError(t, err)
+
+	decompressed, err := compressor.Decompress(compressed)
+	require.NoError(t, err)
+	assert.True(t, proto.Equal(dna, decompressed))
+}
+
+func TestOptimizedDNACompressor_Decompress_CorruptGzip(t *testing.T) {
+	compressor, err := NewOptimizedDNACompressor("gzip", 6)
+	require.NoError(t, err)
+	defer func() { _ = compressor.Close() }()
+
+	_, err = compressor.Decompress([]byte("not valid gzip data"))
+	assert.Error(t, err)
+}
+
+func TestOptimizedDNACompressor_Decompress_ValidGzipBadJSON(t *testing.T) {
+	compressor, err := NewOptimizedDNACompressor("gzip", 6)
+	require.NoError(t, err)
+	defer func() { _ = compressor.Close() }()
+
+	var buf bytes.Buffer
+	w := gzip.NewWriter(&buf)
+	_, _ = w.Write([]byte("{ not valid json !!!"))
+	_ = w.Close()
+
+	_, err = compressor.Decompress(buf.Bytes())
+	assert.Error(t, err)
+}
+
+func TestOptimizedDNACompressor_Decompress_IndexOutOfRange(t *testing.T) {
+	compressor, err := NewOptimizedDNACompressor("gzip", 6)
+	require.NoError(t, err)
+	defer func() { _ = compressor.Close() }()
+
+	// Craft a payload with an attribute key index that exceeds the dict.
+	payload := serializedOptimizedPayload{
+		Data: &OptimizedDNAData{
+			ID:              "bad-device",
+			AttributeKeys:   []int{99}, // out of range
+			AttributeValues: []int{0},
+		},
+		AttributeDict: []string{"only-one-key"},
+		ValueDict:     []string{"only-one-value"},
+	}
+	raw, err := json.Marshal(payload)
+	require.NoError(t, err)
+
+	var buf bytes.Buffer
+	w := gzip.NewWriter(&buf)
+	_, _ = w.Write(raw)
+	_ = w.Close()
+
+	_, err = compressor.Decompress(buf.Bytes())
+	assert.Error(t, err)
+}
+
+func TestOptimizedDNACompressor_Decompress_KeyValueLengthMismatch(t *testing.T) {
+	compressor, err := NewOptimizedDNACompressor("gzip", 6)
+	require.NoError(t, err)
+	defer func() { _ = compressor.Close() }()
+
+	payload := serializedOptimizedPayload{
+		Data: &OptimizedDNAData{
+			ID:              "mismatch-device",
+			AttributeKeys:   []int{0, 1},
+			AttributeValues: []int{0}, // one fewer value than keys
+		},
+		AttributeDict: []string{"key-a", "key-b"},
+		ValueDict:     []string{"val-a"},
+	}
+	raw, err := json.Marshal(payload)
+	require.NoError(t, err)
+
+	var buf bytes.Buffer
+	w := gzip.NewWriter(&buf)
+	_, _ = w.Write(raw)
+	_ = w.Close()
+
+	_, err = compressor.Decompress(buf.Bytes())
+	assert.Error(t, err)
+}
+
+func TestOptimizedDNACompressor_Stats(t *testing.T) {
+	compressor, err := NewOptimizedDNACompressor("gzip", 6)
+	require.NoError(t, err)
+	defer func() { _ = compressor.Close() }()
+
+	dna := buildRealisticDNA()
+	_, _, err = compressor.Compress(dna)
+	require.NoError(t, err)
+
+	stats := compressor.GetStats()
+	assert.Positive(t, stats.TotalOperations)
+	assert.Positive(t, stats.TotalBytesIn)
+	assert.Positive(t, stats.TotalBytesOut)
+	assert.Positive(t, compressor.GetCompressionRatio())
+}


### PR DESCRIPTION
## Summary

- `OptimizedDNACompressor.Compress()` now serializes a self-contained JSON payload (optimized DNA data + embedded reverse-dictionaries) and gzip-compresses it, instead of discarding the dictionary optimization and compressing the original DNA proto
- `OptimizedDNACompressor.Decompress()` fully reverses the process: gzip-decompress → JSON unmarshal → dict reverse-lookup → reconstruct `*commonpb.DNA` with bounds-checked index access
- `OptimizedDNAData` gains `LastUpdatedNanos`/`LastSyncTimeNanos` fields to preserve sub-second timestamp precision across round-trips
- `NewCompressor("dna-optimized", level)` now returns `*OptimizedDNACompressor` (was an error)
- New `compression_test.go` with 9 tests: round-trip with 15-attribute realistic DNA, empty attributes, nil timestamps, factory type assertion, and 4 error-path cases (corrupt gzip, bad JSON, key-index OOB, key/value length mismatch)

Fixes #1607

## Specialist Review Results

| Reviewer | Result |
|---|---|
| qa-test-runner (`make test-agent-complete`) | **PASS** — all packages, linting, license headers, arch checks, cross-platform builds, integration suite |
| qa-code-reviewer | **PASS** — no mocks, no skips, no empty assertions, error paths fully covered |
| security-engineer | **PASS** — gosec/staticcheck/Trivy/Nancy/check-architecture all clean; 1 LOW warning (unbounded gzip inflation, pre-existing pattern across the file, not a regression) |

## Test plan

- [x] `go test ./features/controller/fleet/storage/...` — all pass
- [x] `make test-agent-complete` — all quality gates pass
- [x] Round-trip test with 15-attribute DNA verifies byte-for-byte field equality via `proto.Equal`
- [x] Error paths: corrupt gzip, malformed JSON, out-of-range index, key/value length mismatch
- [x] `NewCompressor("dna-optimized", 6)` returns `*OptimizedDNACompressor`

🤖 Generated with [Claude Code](https://claude.com/claude-code)