### PR TITLE
terminal: implement real baseline metrics from session audit store (Issue #1609)

### DIFF
--- a/features/terminal/monitor.go
+++ b/features/terminal/monitor.go
@@ -4,11 +4,109 @@ package terminal
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
 	"strings"
 	"sync"
 	"time"
 )
+
+// SessionAuditStore provides access to historical session data for baseline metric derivation.
+type SessionAuditStore interface {
+	// GetRecentSessions returns the most recent limit closed sessions for userID, ordered
+	// newest-first. A limit of 0 or less returns all matching records.
+	GetRecentSessions(ctx context.Context, userID string, limit int) ([]SessionAuditRecord, error)
+}
+
+// SessionAuditRecord captures the per-session fields needed to compute baseline metrics.
+type SessionAuditRecord struct {
+	UserID     string
+	StartedAt  time.Time
+	EndedAt    *time.Time
+	EventCount int64
+}
+
+// SessionMonitorOption is a functional option for NewSessionMonitor.
+type SessionMonitorOption func(*SessionMonitor)
+
+// WithAuditStore wires an audit store into the monitor so that getBaselineMetrics
+// can derive per-user baselines from real historical session data.
+func WithAuditStore(store SessionAuditStore) SessionMonitorOption {
+	return func(sm *SessionMonitor) {
+		sm.auditStore = store
+	}
+}
+
+// RecordingMetaAuditStore implements SessionAuditStore by reading the .rec.meta
+// JSON files written by DefaultSessionRecorder.
+type RecordingMetaAuditStore struct {
+	storagePath string
+}
+
+// NewRecordingMetaAuditStore returns a RecordingMetaAuditStore backed by storagePath.
+func NewRecordingMetaAuditStore(storagePath string) *RecordingMetaAuditStore {
+	return &RecordingMetaAuditStore{storagePath: storagePath}
+}
+
+// GetRecentSessions scans the recording directory for .rec.meta files belonging to
+// userID, sorts them newest-first, and trims to limit.
+func (s *RecordingMetaAuditStore) GetRecentSessions(ctx context.Context, userID string, limit int) ([]SessionAuditRecord, error) {
+	entries, err := os.ReadDir(s.storagePath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to read recording directory: %w", err)
+	}
+
+	var records []SessionAuditRecord
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".rec.meta") {
+			continue
+		}
+
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		default:
+		}
+
+		metaPath := filepath.Join(s.storagePath, entry.Name())
+		data, readErr := os.ReadFile(metaPath) // #nosec G304 — path derived from os.ReadDir, not user input
+		if readErr != nil {
+			continue
+		}
+
+		var meta recordingMeta
+		if jsonErr := json.Unmarshal(data, &meta); jsonErr != nil {
+			continue
+		}
+
+		if meta.UserID != userID {
+			continue
+		}
+
+		records = append(records, SessionAuditRecord{
+			UserID:     meta.UserID,
+			StartedAt:  meta.StartedAt,
+			EndedAt:    meta.EndedAt,
+			EventCount: meta.EventCount,
+		})
+	}
+
+	sort.Slice(records, func(i, j int) bool {
+		return records[i].StartedAt.After(records[j].StartedAt)
+	})
+
+	if limit > 0 && len(records) > limit {
+		records = records[:limit]
+	}
+
+	return records, nil
+}
 
 // SessionMonitor provides real-time monitoring and control of terminal sessions
 type SessionMonitor struct {
@@ -21,6 +119,9 @@ type SessionMonitor struct {
 
 	// Monitoring configuration
 	config *MonitorConfig
+
+	// Audit store for historical baseline derivation
+	auditStore SessionAuditStore
 
 	// Control channels
 	stopChannel chan struct{}
@@ -163,13 +264,15 @@ type MonitorConfig struct {
 	AlertOnAnomalousPatterns   bool `json:"alert_on_anomalous_patterns"`
 }
 
-// NewSessionMonitor creates a new session monitor with the given configuration
-func NewSessionMonitor(validator *SecurityValidator, config *MonitorConfig) *SessionMonitor {
+// NewSessionMonitor creates a new session monitor with the given configuration.
+// Optional SessionMonitorOption values (e.g. WithAuditStore) may be supplied to
+// extend behaviour without changing the core signature.
+func NewSessionMonitor(validator *SecurityValidator, config *MonitorConfig, opts ...SessionMonitorOption) *SessionMonitor {
 	if config == nil {
 		config = DefaultMonitorConfig()
 	}
 
-	return &SessionMonitor{
+	sm := &SessionMonitor{
 		sessions:          make(map[string]*MonitoredSession),
 		securityValidator: validator,
 		auditChannel:      make(chan *CommandAuditEvent, 1000),
@@ -178,6 +281,12 @@ func NewSessionMonitor(validator *SecurityValidator, config *MonitorConfig) *Ses
 		stopChannel:       make(chan struct{}),
 		terminated:        make(chan struct{}),
 	}
+
+	for _, opt := range opts {
+		opt(sm)
+	}
+
+	return sm
 }
 
 // Start begins monitoring sessions
@@ -209,7 +318,7 @@ func (sm *SessionMonitor) AddSession(session *Session, securityContext *SessionS
 		sessionID: session.ID,
 		startTime: time.Now(),
 		anomalyDetector: &AnomalyDetector{
-			baselineMetrics: sm.getBaselineMetrics(securityContext.UserID),
+			baselineMetrics: sm.getBaselineMetrics(context.Background(), securityContext.UserID),
 			anomalyRules:    sm.getAnomalyRules(),
 		},
 	}
@@ -562,13 +671,86 @@ func (sm *SessionMonitor) isPrivilegedCommand(command string) bool {
 	return false
 }
 
-func (sm *SessionMonitor) getBaselineMetrics(userID string) BaselineMetrics {
-	// Deferred: tracked in #1443 — load per-user baseline from historical session data
+func (sm *SessionMonitor) getBaselineMetrics(ctx context.Context, userID string) BaselineMetrics {
+	if sm.auditStore == nil {
+		return conservativeBaselineDefaults()
+	}
+
+	records, err := sm.auditStore.GetRecentSessions(ctx, userID, 20)
+	if err != nil || len(records) == 0 {
+		return conservativeBaselineDefaults()
+	}
+
+	return deriveBaselineFromRecords(records)
+}
+
+// conservativeBaselineDefaults returns low-activity bounds used when no historical
+// session data is available. Conservative means tighter thresholds so that anomaly
+// detection fires earlier rather than later.
+func conservativeBaselineDefaults() BaselineMetrics {
 	return BaselineMetrics{
-		AvgCommandRate:     10.0, // 10 commands per minute
-		AvgSessionDuration: 30 * time.Minute,
-		CommonCommands:     map[string]int{"ls": 50, "cd": 30, "cat": 20},
-		TypicalHours:       []int{9, 10, 11, 14, 15, 16},
+		AvgCommandRate:     1.0,
+		AvgSessionDuration: 15 * time.Minute,
+		CommonCommands:     map[string]int{},
+		TypicalHours:       []int{9, 10, 11, 12, 13, 14, 15, 16, 17},
+	}
+}
+
+// deriveBaselineFromRecords computes baseline metrics from completed historical sessions.
+// Sessions without an EndedAt timestamp are excluded from rate and duration calculations.
+// If no sessions have both a start and end time, conservative defaults are returned.
+func deriveBaselineFromRecords(records []SessionAuditRecord) BaselineMetrics {
+	var completedCount int
+	var totalDuration time.Duration
+	var totalEventRate float64
+	hourCounts := make(map[int]int, 24)
+
+	for _, r := range records {
+		hourCounts[r.StartedAt.Hour()]++
+
+		if r.EndedAt == nil || !r.EndedAt.After(r.StartedAt) {
+			continue
+		}
+
+		dur := r.EndedAt.Sub(r.StartedAt)
+		totalDuration += dur
+		completedCount++
+
+		mins := dur.Minutes()
+		if mins > 0 {
+			totalEventRate += float64(r.EventCount) / mins
+		}
+	}
+
+	if completedCount == 0 {
+		return conservativeBaselineDefaults()
+	}
+
+	avgDuration := totalDuration / time.Duration(completedCount)
+	avgRate := totalEventRate / float64(completedCount)
+
+	// Hours seen in more than 20% of all sampled sessions are considered typical.
+	// Strictly greater-than ensures a session at exactly the 20% boundary is not
+	// counted as established behaviour.
+	threshold := len(records) / 5
+	if threshold < 1 {
+		threshold = 1
+	}
+	var typicalHours []int
+	for h := 0; h < 24; h++ {
+		if hourCounts[h] > threshold {
+			typicalHours = append(typicalHours, h)
+		}
+	}
+	if len(typicalHours) == 0 {
+		typicalHours = []int{9, 10, 11, 12, 13, 14, 15, 16, 17}
+	}
+
+	return BaselineMetrics{
+		AvgCommandRate:     avgRate,
+		AvgSessionDuration: avgDuration,
+		CommonCommands:     map[string]int{},
+		TypicalHours:       typicalHours,
 	}
 }
 

--- a/features/terminal/monitor_test.go
+++ b/features/terminal/monitor_test.go
@@ -1,0 +1,259 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+package terminal
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// testAuditStore is an in-memory SessionAuditStore for use in tests.
+type testAuditStore struct {
+	records map[string][]SessionAuditRecord
+	err     error
+}
+
+func (s *testAuditStore) GetRecentSessions(_ context.Context, userID string, limit int) ([]SessionAuditRecord, error) {
+	if s.err != nil {
+		return nil, s.err
+	}
+	records := s.records[userID]
+	if limit > 0 && len(records) > limit {
+		records = records[:limit]
+	}
+	return records, nil
+}
+
+// writeMeta writes a recordingMeta as a JSON .rec.meta file in dir.
+func writeMeta(t *testing.T, dir, sessionID string, meta recordingMeta) {
+	t.Helper()
+	data, err := json.Marshal(meta)
+	require.NoError(t, err)
+	path := filepath.Join(dir, sessionID+".rec.meta")
+	require.NoError(t, os.WriteFile(path, data, 0600))
+}
+
+func TestGetBaselineMetrics_NoAuditStore(t *testing.T) {
+	sm := &SessionMonitor{}
+	baseline := sm.getBaselineMetrics(context.Background(), "user123")
+
+	// Must return conservative defaults, not the old hardcoded "healthy" values
+	assert.Equal(t, 1.0, baseline.AvgCommandRate, "conservative rate should be 1.0, not the old hardcode of 10.0")
+	assert.Equal(t, 15*time.Minute, baseline.AvgSessionDuration, "conservative duration should be short, not 30min hardcode")
+	assert.Empty(t, baseline.CommonCommands, "no commands should be pre-assumed as common")
+	assert.Equal(t, []int{9, 10, 11, 12, 13, 14, 15, 16, 17}, baseline.TypicalHours)
+}
+
+func TestGetBaselineMetrics_EmptyStore(t *testing.T) {
+	store := &testAuditStore{records: map[string][]SessionAuditRecord{}}
+	sm := &SessionMonitor{auditStore: store}
+	baseline := sm.getBaselineMetrics(context.Background(), "user123")
+
+	assert.Equal(t, 1.0, baseline.AvgCommandRate, "empty store should produce conservative defaults")
+	assert.Equal(t, 15*time.Minute, baseline.AvgSessionDuration)
+	assert.Empty(t, baseline.CommonCommands)
+}
+
+func TestGetBaselineMetrics_StoreError(t *testing.T) {
+	store := &testAuditStore{err: errors.New("store unavailable")}
+	sm := &SessionMonitor{auditStore: store}
+	baseline := sm.getBaselineMetrics(context.Background(), "user123")
+
+	assert.Equal(t, 1.0, baseline.AvgCommandRate, "store error should fall back to conservative defaults")
+	assert.Equal(t, 15*time.Minute, baseline.AvgSessionDuration)
+}
+
+func TestGetBaselineMetrics_WithHistoricalData(t *testing.T) {
+	// 4 completed sessions, each 1 hour long with 120 events → 2.0 events/min
+	var sessions []SessionAuditRecord
+	for i := 0; i < 4; i++ {
+		start := time.Date(2026, 1, 15-i, 10, 0, 0, 0, time.UTC)
+		end := start.Add(time.Hour)
+		sessions = append(sessions, SessionAuditRecord{
+			UserID:     "user123",
+			StartedAt:  start,
+			EndedAt:    &end,
+			EventCount: 120,
+		})
+	}
+	store := &testAuditStore{records: map[string][]SessionAuditRecord{"user123": sessions}}
+	sm := &SessionMonitor{auditStore: store}
+
+	baseline := sm.getBaselineMetrics(context.Background(), "user123")
+
+	assert.InDelta(t, 2.0, baseline.AvgCommandRate, 0.001, "rate should be 120 events / 60 min = 2.0")
+	assert.Equal(t, time.Hour, baseline.AvgSessionDuration, "avg duration should reflect actual session length")
+	assert.Empty(t, baseline.CommonCommands, "command distribution is not derivable from session metadata")
+}
+
+func TestGetBaselineMetrics_TypicalHoursFromData(t *testing.T) {
+	// 8 sessions at hour 14, 2 sessions at hour 3
+	// With 10 records, threshold = 10/5 = 2; hour 14 qualifies (8>=2), hour 3 does not (2<2)
+	var sessions []SessionAuditRecord
+	for i := 0; i < 8; i++ {
+		start := time.Date(2026, 1, 1+i, 14, 0, 0, 0, time.UTC)
+		end := start.Add(30 * time.Minute)
+		sessions = append(sessions, SessionAuditRecord{
+			UserID:     "user123",
+			StartedAt:  start,
+			EndedAt:    &end,
+			EventCount: 30,
+		})
+	}
+	for i := 0; i < 2; i++ {
+		start := time.Date(2026, 1, 20+i, 3, 0, 0, 0, time.UTC)
+		end := start.Add(30 * time.Minute)
+		sessions = append(sessions, SessionAuditRecord{
+			UserID:     "user123",
+			StartedAt:  start,
+			EndedAt:    &end,
+			EventCount: 30,
+		})
+	}
+	store := &testAuditStore{records: map[string][]SessionAuditRecord{"user123": sessions}}
+	sm := &SessionMonitor{auditStore: store}
+
+	baseline := sm.getBaselineMetrics(context.Background(), "user123")
+
+	assert.Contains(t, baseline.TypicalHours, 14, "hour 14 should be typical (seen in 80% of sessions)")
+	assert.NotContains(t, baseline.TypicalHours, 3, "hour 3 should not be typical (seen in exactly 20% of sessions, threshold requires strictly more than 20%)")
+}
+
+func TestGetBaselineMetrics_SkipsOpenSessions(t *testing.T) {
+	// Mix of one completed session (2 hours, 120 events) and one open session (no EndedAt)
+	start := time.Date(2026, 1, 1, 10, 0, 0, 0, time.UTC)
+	end := start.Add(2 * time.Hour)
+	sessions := []SessionAuditRecord{
+		{UserID: "user123", StartedAt: start, EndedAt: &end, EventCount: 120},
+		{UserID: "user123", StartedAt: start, EndedAt: nil, EventCount: 0},
+	}
+	store := &testAuditStore{records: map[string][]SessionAuditRecord{"user123": sessions}}
+	sm := &SessionMonitor{auditStore: store}
+
+	baseline := sm.getBaselineMetrics(context.Background(), "user123")
+
+	assert.Equal(t, 2*time.Hour, baseline.AvgSessionDuration, "open sessions must not skew duration calculation")
+	assert.InDelta(t, 1.0, baseline.AvgCommandRate, 0.001, "120 events / 120 min = 1.0")
+}
+
+func TestGetBaselineMetrics_AllOpenSessionsFallsBack(t *testing.T) {
+	// All sessions are still open — no EndedAt → fall back to conservative defaults
+	start := time.Date(2026, 1, 1, 10, 0, 0, 0, time.UTC)
+	sessions := []SessionAuditRecord{
+		{UserID: "user123", StartedAt: start, EndedAt: nil, EventCount: 50},
+		{UserID: "user123", StartedAt: start, EndedAt: nil, EventCount: 80},
+	}
+	store := &testAuditStore{records: map[string][]SessionAuditRecord{"user123": sessions}}
+	sm := &SessionMonitor{auditStore: store}
+
+	baseline := sm.getBaselineMetrics(context.Background(), "user123")
+
+	assert.Equal(t, 1.0, baseline.AvgCommandRate, "all-open sessions should fall back to conservative defaults")
+	assert.Equal(t, 15*time.Minute, baseline.AvgSessionDuration)
+}
+
+func TestRecordingMetaAuditStore_GetRecentSessions(t *testing.T) {
+	dir := t.TempDir()
+	store := NewRecordingMetaAuditStore(dir)
+
+	base := time.Date(2026, 1, 1, 10, 0, 0, 0, time.UTC)
+	end := base.Add(30 * time.Minute)
+
+	// 2 sessions for user123, 1 for user456
+	writeMeta(t, dir, "sess-1", recordingMeta{SessionID: "sess-1", UserID: "user123", StartedAt: base, EndedAt: &end, EventCount: 30})
+	writeMeta(t, dir, "sess-2", recordingMeta{SessionID: "sess-2", UserID: "user123", StartedAt: base.Add(-24 * time.Hour), EndedAt: &end, EventCount: 20})
+	writeMeta(t, dir, "sess-3", recordingMeta{SessionID: "sess-3", UserID: "user456", StartedAt: base, EndedAt: &end, EventCount: 15})
+
+	records, err := store.GetRecentSessions(context.Background(), "user123", 10)
+	require.NoError(t, err)
+	require.Len(t, records, 2, "only user123 sessions should be returned")
+	assert.Equal(t, "user123", records[0].UserID)
+	assert.Equal(t, "user123", records[1].UserID)
+	assert.True(t, records[0].StartedAt.After(records[1].StartedAt), "results must be ordered most-recent-first")
+}
+
+func TestRecordingMetaAuditStore_RespectsLimit(t *testing.T) {
+	dir := t.TempDir()
+	store := NewRecordingMetaAuditStore(dir)
+
+	base := time.Date(2026, 1, 1, 10, 0, 0, 0, time.UTC)
+	end := base.Add(time.Hour)
+	for i := 0; i < 5; i++ {
+		writeMeta(t, dir, fmt.Sprintf("sess-%d", i), recordingMeta{
+			SessionID:  fmt.Sprintf("sess-%d", i),
+			UserID:     "user123",
+			StartedAt:  base.Add(time.Duration(-i) * 24 * time.Hour),
+			EndedAt:    &end,
+			EventCount: 10,
+		})
+	}
+
+	records, err := store.GetRecentSessions(context.Background(), "user123", 3)
+	require.NoError(t, err)
+	assert.Len(t, records, 3, "limit parameter must be respected")
+}
+
+func TestRecordingMetaAuditStore_NonexistentDirectory(t *testing.T) {
+	store := NewRecordingMetaAuditStore("/nonexistent/path/that/does/not/exist")
+	records, err := store.GetRecentSessions(context.Background(), "user123", 10)
+	assert.NoError(t, err, "nonexistent directory should return empty result, not error")
+	assert.Empty(t, records)
+}
+
+func TestRecordingMetaAuditStore_IgnoresMalformedMeta(t *testing.T) {
+	dir := t.TempDir()
+	store := NewRecordingMetaAuditStore(dir)
+
+	// Write one valid and one malformed meta file
+	base := time.Date(2026, 1, 1, 10, 0, 0, 0, time.UTC)
+	end := base.Add(time.Hour)
+	writeMeta(t, dir, "good-sess", recordingMeta{SessionID: "good-sess", UserID: "user123", StartedAt: base, EndedAt: &end, EventCount: 60})
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "bad-sess.rec.meta"), []byte("not json"), 0600))
+
+	records, err := store.GetRecentSessions(context.Background(), "user123", 10)
+	require.NoError(t, err, "malformed meta files should be skipped silently")
+	assert.Len(t, records, 1, "only the valid meta file should be returned")
+}
+
+func TestAddSession_UsesAuditStoreForBaseline(t *testing.T) {
+	// Verify that AddSession completes without error when an audit store is wired in
+	start := time.Date(2026, 1, 1, 9, 0, 0, 0, time.UTC)
+	end := start.Add(2 * time.Hour)
+	records := []SessionAuditRecord{
+		{UserID: "user123", StartedAt: start, EndedAt: &end, EventCount: 120},
+	}
+	store := &testAuditStore{records: map[string][]SessionAuditRecord{"user123": records}}
+
+	validator := NewSecurityValidator(nil)
+	config := DefaultMonitorConfig()
+	config.AutoTerminateOnCritical = false
+	sm := NewSessionMonitor(validator, config, WithAuditStore(store))
+
+	session := &Session{
+		ID:        "test-audit-baseline",
+		UserID:    "user123",
+		StewardID: "steward-x",
+		CreatedAt: time.Now(),
+	}
+	secCtx := &SessionSecurityContext{
+		SessionID: session.ID,
+		UserID:    session.UserID,
+		StewardID: session.StewardID,
+		TenantID:  "tenant1",
+	}
+
+	require.NoError(t, sm.AddSession(session, secCtx))
+
+	info, err := sm.GetSessionInfo(session.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "test-audit-baseline", info.Session.ID)
+}


### PR DESCRIPTION
## Summary

- Replaces hardcoded baseline values in `getBaselineMetrics()` with a real lookup from the session audit store
- Defines `SessionAuditStore` interface and `RecordingMetaAuditStore` concrete implementation backed by `.rec.meta` files
- Conservative defaults (1.0 cmd/min, 15-min sessions, business hours) used when no historical data exists — tighter thresholds so anomaly detection fails secure

## Changes

**`features/terminal/monitor.go`**
- Added `SessionAuditStore` interface, `SessionAuditRecord` struct, `SessionMonitorOption` type, `WithAuditStore` option function
- Added `RecordingMetaAuditStore` that reads `.rec.meta` JSON files written by `DefaultSessionRecorder` — filters by `userID`, sorts newest-first, respects `limit`
- Added `conservativeBaselineDefaults()` and `deriveBaselineFromRecords()` helpers
- Updated `getBaselineMetrics` to query the store and derive real metrics from completed sessions; falls back to conservative defaults on any error or missing data
- Updated `NewSessionMonitor` to accept variadic `SessionMonitorOption` (no signature break for existing callers)

**`features/terminal/monitor_test.go`** (new)
- 11 test cases covering: no audit store, empty store, store error, real data (rate/duration), typical-hour threshold, open-session exclusion, all-open fallback, file-based store (filtering, limit, missing dir, malformed meta)

Fixes #1609

## Specialist Review Results

**QA Test Runner: PASS** — All quality gates passed; `features/terminal` tests ran in ~5s, cross-platform builds verified, linting clean.

**QA Code Reviewer: PASS** — No blocking issues. `testAuditStore` is a real in-memory interface implementation (not a mock). All error paths tested. No `t.Skip()` or empty assertions.

**Security Engineer: PASS** — No blocking issues. `// #nosec G304` annotation is justified (path derived from `os.ReadDir`, not user input). Conservative defaults are a security improvement. Automated scans (security-precommit, check-architecture, security-scan) all PASS.