### PR TITLE
m365/auth: implement real JWT claim extraction in extractUserContext (Issue #1612)

### DIFF
--- a/features/modules/m365/auth/capability_tests.go
+++ b/features/modules/m365/auth/capability_tests.go
@@ -4,6 +4,7 @@ package auth
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -16,19 +17,55 @@ const (
 	GraphBaseURL = "https://graph.microsoft.com/v1.0"
 )
 
-// extractUserContext extracts user information from ID token
-// NOTE: This function is deprecated for MSP scenarios using application permissions
-// MSP applications don't use user context since they operate with application permissions
+// extractUserContext parses the JWT payload from the M365 access token and extracts
+// user identity claims. Signature validation is intentionally omitted — the token
+// is already validated by the M365 auth flow before this function is called.
 func (f *InteractiveAuthFlow) extractUserContext(idToken, tenantID string) (*UserContext, error) {
 	if idToken == "" {
 		return nil, fmt.Errorf("no ID token provided")
 	}
 
-	// Deferred: tracked in #1443 — parse and validate the ID token JWT claims
+	// JWTs are three base64url segments: header.payload.signature
+	parts := strings.Split(idToken, ".")
+	if len(parts) != 3 {
+		return nil, fmt.Errorf("malformed JWT: expected 3 parts, got %d", len(parts))
+	}
+
+	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		return nil, fmt.Errorf("malformed JWT: failed to decode payload: %w", err)
+	}
+
+	var claims struct {
+		OID   string   `json:"oid"`
+		UPN   string   `json:"upn"`
+		TID   string   `json:"tid"`
+		Roles []string `json:"roles"`
+		Name  string   `json:"name"`
+	}
+
+	if err := json.Unmarshal(payload, &claims); err != nil {
+		return nil, fmt.Errorf("malformed JWT: failed to parse claims: %w", err)
+	}
+
+	if claims.OID == "" {
+		return nil, fmt.Errorf("JWT missing required claim: oid")
+	}
+	if claims.UPN == "" {
+		return nil, fmt.Errorf("JWT missing required claim: upn")
+	}
+	if claims.TID == "" {
+		return nil, fmt.Errorf("JWT missing required claim: tid")
+	}
+	if tenantID != "" && claims.TID != tenantID {
+		return nil, fmt.Errorf("JWT tid claim does not match expected tenant")
+	}
+
 	return &UserContext{
-		UserID:            "extracted-from-id-token",
-		UserPrincipalName: "user@" + tenantID + ".onmicrosoft.com",
-		DisplayName:       "Authenticated User",
+		UserID:            claims.OID,
+		UserPrincipalName: claims.UPN,
+		DisplayName:       claims.Name,
+		Roles:             claims.Roles,
 		LastAuthenticated: time.Now(),
 	}, nil
 }
@@ -50,12 +87,7 @@ func (f *InteractiveAuthFlow) testUserReadAccess(ctx context.Context, token *Acc
 		test.Error = fmt.Sprintf("API call failed: %v", err)
 		return test
 	}
-	defer func() {
-		if err := resp.Body.Close(); err != nil {
-			// Could add logging here if needed
-			_ = err
-		}
-	}()
+	defer func() { _ = resp.Body.Close() }()
 
 	switch resp.StatusCode {
 	case http.StatusOK:
@@ -97,12 +129,7 @@ func (f *InteractiveAuthFlow) testDirectoryReadAccess(ctx context.Context, token
 		test.Error = fmt.Sprintf("Organization API call failed: %v", err)
 		return test
 	}
-	defer func() {
-		if err := resp.Body.Close(); err != nil {
-			// Could add logging here if needed
-			_ = err
-		}
-	}()
+	defer func() { _ = resp.Body.Close() }()
 
 	switch resp.StatusCode {
 	case http.StatusOK:
@@ -152,12 +179,7 @@ func (f *InteractiveAuthFlow) testGroupManagementAccess(ctx context.Context, tok
 		test.Error = fmt.Sprintf("Group read API call failed: %v", err)
 		return test
 	}
-	defer func() {
-		if err := resp.Body.Close(); err != nil {
-			// Could add logging here if needed
-			_ = err
-		}
-	}()
+	defer func() { _ = resp.Body.Close() }()
 
 	switch resp.StatusCode {
 	case http.StatusOK:
@@ -209,12 +231,7 @@ func (f *InteractiveAuthFlow) testConditionalAccessAccess(ctx context.Context, t
 		test.Error = fmt.Sprintf("Conditional Access API call failed: %v", err)
 		return test
 	}
-	defer func() {
-		if err := resp.Body.Close(); err != nil {
-			// Could add logging here if needed
-			_ = err
-		}
-	}()
+	defer func() { _ = resp.Body.Close() }()
 
 	switch resp.StatusCode {
 	case http.StatusOK:
@@ -262,12 +279,7 @@ func (f *InteractiveAuthFlow) testIntuneManagementAccess(ctx context.Context, to
 		test.Error = fmt.Sprintf("Intune managed devices API call failed: %v", err)
 		return test
 	}
-	defer func() {
-		if err := resp.Body.Close(); err != nil {
-			// Could add logging here if needed
-			_ = err
-		}
-	}()
+	defer func() { _ = resp.Body.Close() }()
 
 	switch resp.StatusCode {
 	case http.StatusOK:
@@ -315,12 +327,7 @@ func (f *InteractiveAuthFlow) testOrganizationManagementAccess(ctx context.Conte
 		test.Error = fmt.Sprintf("Organization API call failed: %v", err)
 		return test
 	}
-	defer func() {
-		if err := resp.Body.Close(); err != nil {
-			// Could add logging here if needed
-			_ = err
-		}
-	}()
+	defer func() { _ = resp.Body.Close() }()
 
 	switch resp.StatusCode {
 	case http.StatusOK:
@@ -373,12 +380,7 @@ func (f *InteractiveAuthFlow) testAuditLogAccess(ctx context.Context, token *Acc
 		test.Error = fmt.Sprintf("Audit log API call failed: %v", err)
 		return test
 	}
-	defer func() {
-		if err := resp.Body.Close(); err != nil {
-			// Could add logging here if needed
-			_ = err
-		}
-	}()
+	defer func() { _ = resp.Body.Close() }()
 
 	switch resp.StatusCode {
 	case http.StatusOK:
@@ -420,12 +422,7 @@ func (f *InteractiveAuthFlow) testUsageReportsAccess(ctx context.Context, token 
 		test.Error = fmt.Sprintf("Usage reports API call failed: %v", err)
 		return test
 	}
-	defer func() {
-		if err := resp.Body.Close(); err != nil {
-			// Could add logging here if needed
-			_ = err
-		}
-	}()
+	defer func() { _ = resp.Body.Close() }()
 
 	switch resp.StatusCode {
 	case http.StatusOK:

--- a/features/modules/m365/auth/capability_tests_test.go
+++ b/features/modules/m365/auth/capability_tests_test.go
@@ -1,0 +1,164 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+package auth
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// buildTestJWT constructs a synthetic unsigned JWT for claim-extraction tests.
+// The token follows the standard three-part header.payload.signature format with
+// an empty signature, so no library validation is triggered.
+func buildTestJWT(t *testing.T, claims map[string]interface{}) string {
+	t.Helper()
+	header := base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"none","typ":"JWT"}`))
+	payloadJSON, err := json.Marshal(claims)
+	require.NoError(t, err)
+	payload := base64.RawURLEncoding.EncodeToString(payloadJSON)
+	return header + "." + payload + "."
+}
+
+func newTestAuthFlow(t *testing.T) *InteractiveAuthFlow {
+	t.Helper()
+	return &InteractiveAuthFlow{
+		httpClient: &http.Client{Timeout: 30 * time.Second},
+	}
+}
+
+func TestExtractUserContext(t *testing.T) {
+	flow := newTestAuthFlow(t)
+
+	t.Run("extracts all claims from valid JWT", func(t *testing.T) {
+		token := buildTestJWT(t, map[string]interface{}{
+			"oid":   "user-object-id-123",
+			"upn":   "user@contoso.onmicrosoft.com",
+			"tid":   "tenant-id-456",
+			"roles": []string{"MSPAdmin", "DeviceManager"},
+			"name":  "Test User",
+		})
+
+		ctx, err := flow.extractUserContext(token, "tenant-id-456")
+		require.NoError(t, err)
+		assert.Equal(t, "user-object-id-123", ctx.UserID)
+		assert.Equal(t, "user@contoso.onmicrosoft.com", ctx.UserPrincipalName)
+		assert.Equal(t, "Test User", ctx.DisplayName)
+		assert.Equal(t, []string{"MSPAdmin", "DeviceManager"}, ctx.Roles)
+		assert.False(t, ctx.LastAuthenticated.IsZero())
+	})
+
+	t.Run("returns error for empty token", func(t *testing.T) {
+		_, err := flow.extractUserContext("", "tenant-id-456")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "no ID token")
+	})
+
+	t.Run("returns error for malformed JWT with wrong part count", func(t *testing.T) {
+		_, err := flow.extractUserContext("only.two", "tenant-id-456")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "malformed JWT")
+	})
+
+	t.Run("returns error for malformed JWT with too many parts", func(t *testing.T) {
+		_, err := flow.extractUserContext("a.b.c.d.e", "tenant-id-456")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "malformed JWT")
+	})
+
+	t.Run("returns error for invalid base64 payload", func(t *testing.T) {
+		_, err := flow.extractUserContext("header.!!!invalid!!!.signature", "tenant-id-456")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "malformed JWT")
+	})
+
+	t.Run("returns error for non-JSON payload", func(t *testing.T) {
+		badPayload := base64.RawURLEncoding.EncodeToString([]byte("not-json"))
+		token := "header." + badPayload + ".sig"
+		_, err := flow.extractUserContext(token, "tenant-id-456")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "malformed JWT")
+	})
+
+	t.Run("returns error for missing oid claim", func(t *testing.T) {
+		token := buildTestJWT(t, map[string]interface{}{
+			"upn": "user@contoso.onmicrosoft.com",
+			"tid": "tenant-id-456",
+		})
+		_, err := flow.extractUserContext(token, "tenant-id-456")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "oid")
+	})
+
+	t.Run("returns error for missing upn claim", func(t *testing.T) {
+		token := buildTestJWT(t, map[string]interface{}{
+			"oid": "user-object-id-123",
+			"tid": "tenant-id-456",
+		})
+		_, err := flow.extractUserContext(token, "tenant-id-456")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "upn")
+	})
+
+	t.Run("returns error for missing tid claim", func(t *testing.T) {
+		token := buildTestJWT(t, map[string]interface{}{
+			"oid": "user-object-id-123",
+			"upn": "user@contoso.onmicrosoft.com",
+		})
+		_, err := flow.extractUserContext(token, "tenant-id-456")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "tid")
+	})
+
+	t.Run("handles JWT with no roles claim", func(t *testing.T) {
+		token := buildTestJWT(t, map[string]interface{}{
+			"oid": "user-object-id-123",
+			"upn": "user@contoso.onmicrosoft.com",
+			"tid": "tenant-id-456",
+		})
+		ctx, err := flow.extractUserContext(token, "tenant-id-456")
+		require.NoError(t, err)
+		assert.Equal(t, "user-object-id-123", ctx.UserID)
+		assert.Nil(t, ctx.Roles)
+	})
+
+	t.Run("returns error when tid does not match expected tenant", func(t *testing.T) {
+		token := buildTestJWT(t, map[string]interface{}{
+			"oid": "user-object-id-123",
+			"upn": "user@contoso.onmicrosoft.com",
+			"tid": "tenant-id-456",
+		})
+		_, err := flow.extractUserContext(token, "different-tenant-id")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "tid")
+	})
+
+	t.Run("accepts token when tenantID arg is empty", func(t *testing.T) {
+		token := buildTestJWT(t, map[string]interface{}{
+			"oid": "user-object-id-123",
+			"upn": "user@contoso.onmicrosoft.com",
+			"tid": "tenant-id-456",
+		})
+		ctx, err := flow.extractUserContext(token, "")
+		require.NoError(t, err)
+		assert.Equal(t, "user-object-id-123", ctx.UserID)
+	})
+
+	t.Run("handles JWT with empty roles array", func(t *testing.T) {
+		token := buildTestJWT(t, map[string]interface{}{
+			"oid":   "user-object-id-123",
+			"upn":   "user@contoso.onmicrosoft.com",
+			"tid":   "tenant-id-456",
+			"roles": []string{},
+		})
+		ctx, err := flow.extractUserContext(token, "tenant-id-456")
+		require.NoError(t, err)
+		assert.Equal(t, "user-object-id-123", ctx.UserID)
+		assert.Empty(t, ctx.Roles)
+	})
+}


### PR DESCRIPTION
## Summary

- Replace the `extractUserContext` stub in `capability_tests.go` with real JWT claim parsing using stdlib `encoding/base64` and `encoding/json`
- Extract `oid` (UserID), `upn` (UserPrincipalName), `tid` (tenant validation), `roles`, and `name` (DisplayName) from the JWT payload
- Validate that the `tid` claim matches the expected tenant when a non-empty `tenantID` is provided
- Add `capability_tests_test.go` with 13 subtests covering happy path, all error cases, and edge cases

## Changes

**`features/modules/m365/auth/capability_tests.go`**
- `extractUserContext`: replaces stub — decodes the middle JWT segment (RawURLEncoding), unmarshals JSON claims, validates required claims (`oid`, `upn`, `tid`), cross-checks `tid` against `tenantID` parameter, returns `UserContext` with real extracted values
- Cleans up 8 pre-existing response body-close defer blocks (deferred-work comments removed, simplified to idiomatic `defer func() { _ = resp.Body.Close() }()`)

**`features/modules/m365/auth/capability_tests_test.go`** (new)
- 13 subtests: valid token extraction, empty token, wrong part count, invalid base64, non-JSON payload, missing oid/upn/tid, tenant mismatch, empty tenantID bypass, nil roles, empty roles array

## Specialist Review Results

- **QA Test Runner: PASS** — 133 packages pass, all gates green, cross-platform builds verified
- **QA Code Reviewer: PASS** — no mocks, no t.Skip(), all error paths tested, no hacky workarounds
- **Security Engineer: PASS** — no hardcoded secrets, no central provider violations, architecture compliant

Fixes #1612