### PR TITLE
m365(auth): replace in-memory flow state with durable encrypted store (Issue #1611)

### DIFF
--- a/features/modules/m365/auth/interactive_flow.go
+++ b/features/modules/m365/auth/interactive_flow.go
@@ -8,12 +8,18 @@ import (
 	"crypto/sha256"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
 	"strings"
 	"time"
+
+	secretsif "github.com/cfgis/cfgms/pkg/secrets/interfaces"
 )
+
+// ErrFlowStateExpired is returned when the retrieved auth flow state has passed its TTL.
+var ErrFlowStateExpired = errors.New("m365 auth flow state expired")
 
 // InteractiveAuthFlow manages the OAuth2 authorization code flow with PKCE
 type InteractiveAuthFlow struct {
@@ -21,6 +27,10 @@ type InteractiveAuthFlow struct {
 	config          *OAuth2Config
 	httpClient      *http.Client
 	callbackHandler *CallbackHandler
+
+	// flowStore, when set, persists flow state to a durable encrypted store instead of memory.
+	flowStore    secretsif.SecretStore
+	flowStateTTL time.Duration
 }
 
 // AuthFlowState represents the state of an ongoing authorization flow
@@ -61,6 +71,26 @@ func NewInteractiveAuthFlow(provider *OAuth2Provider, config *OAuth2Config) *Int
 		httpClient:      &http.Client{Timeout: 30 * time.Second},
 		callbackHandler: NewCallbackHandler(),
 	}
+}
+
+// NewInteractiveAuthFlowWithStore creates an interactive auth flow manager that persists
+// flow state to a durable encrypted store instead of memory. Flow state survives restarts
+// and expires after flowStateTTL (default 10 minutes).
+func NewInteractiveAuthFlowWithStore(provider *OAuth2Provider, config *OAuth2Config, store secretsif.SecretStore) *InteractiveAuthFlow {
+	return &InteractiveAuthFlow{
+		provider:        provider,
+		config:          config,
+		httpClient:      &http.Client{Timeout: 30 * time.Second},
+		callbackHandler: NewCallbackHandler(),
+		flowStore:       store,
+		flowStateTTL:    10 * time.Minute,
+	}
+}
+
+// flowStateKey returns the secret store key for an M365 auth flow state entry.
+// The key includes the flow ID (state parameter) to namespace entries per flow.
+func flowStateKey(state string) string {
+	return "m365/flow-state/" + sanitizeSegment(state)
 }
 
 // StartAuthFlow initiates the OAuth2 authorization code flow
@@ -396,12 +426,58 @@ func (f *InteractiveAuthFlow) storeTokens(tenantID string, accessToken *AccessTo
 // State management
 
 func (f *InteractiveAuthFlow) storeFlowState(state string, flowState *AuthFlowState) error {
-	// Deferred: tracked in #1443 — persist flow state in a secure temporary store
+	if f.flowStore != nil {
+		data, err := json.Marshal(flowState)
+		if err != nil {
+			return fmt.Errorf("marshal flow state: %w", err)
+		}
+		return f.flowStore.StoreSecret(context.Background(), &secretsif.SecretRequest{
+			Key:       flowStateKey(state),
+			Value:     string(data),
+			TenantID:  "m365",
+			CreatedBy: "m365-auth",
+			TTL:       f.flowStateTTL,
+			Metadata: map[string]string{
+				"tenant_id": flowState.TenantID,
+				"flow_id":   state,
+			},
+			Description: fmt.Sprintf("M365 OAuth flow state for tenant %s", flowState.TenantID),
+		})
+	}
 	return f.callbackHandler.StoreFlowState(state, flowState)
 }
 
 func (f *InteractiveAuthFlow) getFlowState(state string) (*AuthFlowState, error) {
+	if f.flowStore != nil {
+		return f.loadFlowStateFromStore(state)
+	}
 	return f.callbackHandler.GetFlowState(state)
+}
+
+// loadFlowStateFromStore retrieves flow state from the durable encrypted store,
+// returning ErrFlowStateExpired when the state has passed its TTL.
+func (f *InteractiveAuthFlow) loadFlowStateFromStore(state string) (*AuthFlowState, error) {
+	secret, err := f.flowStore.GetSecret(context.Background(), flowStateKey(state))
+	if err != nil {
+		if errors.Is(err, secretsif.ErrSecretNotFound) {
+			return nil, fmt.Errorf("auth flow state not found: %w", err)
+		}
+		if strings.Contains(err.Error(), "expired") {
+			return nil, ErrFlowStateExpired
+		}
+		return nil, fmt.Errorf("auth flow state retrieval failed: %w", err)
+	}
+
+	var flowState AuthFlowState
+	if err := json.Unmarshal([]byte(secret.Value), &flowState); err != nil {
+		return nil, fmt.Errorf("unmarshal auth flow state: %w", err)
+	}
+
+	if time.Now().After(flowState.ExpiresAt) {
+		return nil, ErrFlowStateExpired
+	}
+
+	return &flowState, nil
 }
 
 func (f *InteractiveAuthFlow) validateFlowState(flowState *AuthFlowState) error {
@@ -417,6 +493,10 @@ func (f *InteractiveAuthFlow) validateFlowState(flowState *AuthFlowState) error 
 }
 
 func (f *InteractiveAuthFlow) cleanupFlowState(state string) {
+	if f.flowStore != nil {
+		_ = f.flowStore.DeleteSecret(context.Background(), flowStateKey(state))
+		return
+	}
 	f.callbackHandler.CleanupFlowState(state)
 }
 

--- a/features/modules/m365/auth/interactive_flow_test.go
+++ b/features/modules/m365/auth/interactive_flow_test.go
@@ -17,6 +17,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	secretsif "github.com/cfgis/cfgms/pkg/secrets/interfaces"
+	stewardprovider "github.com/cfgis/cfgms/pkg/secrets/providers/steward"
+
 	"github.com/cfgis/cfgms/pkg/logging"
 )
 
@@ -594,6 +597,134 @@ func TestRealM365InteractiveIntegration(t *testing.T) {
 
 	// Note: Real callback testing would require manual interaction
 	// or browser automation (which is beyond scope of this test)
+}
+
+// newTestFlowStateStore creates a steward-backed SecretStore in a temp directory.
+// Skips the test if /etc/machine-id is absent (required for platform key derivation on Linux).
+func newTestFlowStateStore(tb testing.TB, dir string) secretsif.SecretStore {
+	tb.Helper()
+	if _, err := os.Stat("/etc/machine-id"); os.IsNotExist(err) {
+		tb.Skip("skipping: /etc/machine-id not available (required for platform key derivation on Linux)")
+	}
+	provider := &stewardprovider.StewardProvider{}
+	store, err := provider.CreateSecretStore(map[string]interface{}{
+		"secrets_dir": dir,
+	})
+	if err != nil {
+		tb.Fatalf("create steward store: %v", err)
+	}
+	tb.Cleanup(func() { _ = store.Close() })
+	return store
+}
+
+// TestFlowStateDurableStorage verifies that M365 auth flow state survives a simulated
+// controller restart. Instance 1 writes state; a new instance backed by the same store
+// dir reads it back successfully.
+func TestFlowStateDurableStorage(t *testing.T) {
+	secretsDir := t.TempDir()
+
+	config := &OAuth2Config{
+		ClientID:    "test-durable-client",
+		TenantID:    "test-durable-tenant",
+		RedirectURI: "http://localhost:8080/auth/callback",
+	}
+
+	credStore := newTestCredentialStore(t)
+	oauthProvider := NewOAuth2Provider(credStore, config, logging.NewNoopLogger())
+
+	// Instance 1 — before simulated restart
+	store1 := newTestFlowStateStore(t, secretsDir)
+	flow1 := NewInteractiveAuthFlowWithStore(oauthProvider, config, store1)
+
+	ctx := context.Background()
+	flowState, _, err := flow1.StartAuthFlow(ctx, config.TenantID, []string{"User.Read"})
+	require.NoError(t, err)
+	capturedState := flowState.State
+
+	// Flush to disk before opening a second instance
+	require.NoError(t, store1.Close())
+
+	// Instance 2 — after simulated restart, same secrets directory
+	provider2 := &stewardprovider.StewardProvider{}
+	store2, err := provider2.CreateSecretStore(map[string]interface{}{
+		"secrets_dir": secretsDir,
+	})
+	require.NoError(t, err)
+	defer func() { _ = store2.Close() }()
+
+	flow2 := NewInteractiveAuthFlowWithStore(oauthProvider, config, store2)
+
+	retrieved, err := flow2.getFlowState(capturedState)
+	require.NoError(t, err)
+	require.NotNil(t, retrieved, "flow state must survive simulated restart")
+
+	assert.Equal(t, flowState.TenantID, retrieved.TenantID)
+	assert.Equal(t, flowState.CodeVerifier, retrieved.CodeVerifier)
+	assert.Equal(t, flowState.CodeChallenge, retrieved.CodeChallenge)
+	assert.Equal(t, flowState.Nonce, retrieved.Nonce)
+}
+
+// TestFlowStateExpiredReturnsDistinctError verifies that reading a flow state whose
+// ExpiresAt is in the past returns ErrFlowStateExpired — not stale or zero state.
+func TestFlowStateExpiredReturnsDistinctError(t *testing.T) {
+	store := newTestFlowStateStore(t, t.TempDir())
+
+	config := &OAuth2Config{
+		ClientID: "test-expiry-client",
+		TenantID: "test-expiry-tenant",
+	}
+	credStore := newTestCredentialStore(t)
+	oauthProvider := NewOAuth2Provider(credStore, config, logging.NewNoopLogger())
+	flow := NewInteractiveAuthFlowWithStore(oauthProvider, config, store)
+
+	// Write an already-expired flow state directly — no store-level TTL so the
+	// store returns the value, and expiry is caught by the embedded ExpiresAt check.
+	stateID := "test-expired-state-id"
+	expiredState := &AuthFlowState{
+		TenantID:        "test-expiry-tenant",
+		State:           stateID,
+		CodeVerifier:    "test-verifier",
+		CodeChallenge:   "test-challenge",
+		Nonce:           "test-nonce",
+		RequestedScopes: []string{"User.Read"},
+		CreatedAt:       time.Now().Add(-20 * time.Minute),
+		ExpiresAt:       time.Now().Add(-10 * time.Minute), // already expired
+		RedirectURI:     "http://localhost:8080/auth/callback",
+	}
+	data, err := json.Marshal(expiredState)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	err = store.StoreSecret(ctx, &secretsif.SecretRequest{
+		Key:       flowStateKey(stateID),
+		Value:     string(data),
+		TenantID:  "m365",
+		CreatedBy: "test",
+		// No TTL — store does not expire it; expiry is enforced by our code.
+	})
+	require.NoError(t, err)
+
+	_, err = flow.getFlowState(stateID)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrFlowStateExpired, "expired flow state must return ErrFlowStateExpired")
+}
+
+// TestFlowStateMissingReturnsError verifies that reading a non-existent flow state
+// returns an error and not nil/zero state.
+func TestFlowStateMissingReturnsError(t *testing.T) {
+	store := newTestFlowStateStore(t, t.TempDir())
+
+	config := &OAuth2Config{
+		ClientID: "test-missing-client",
+		TenantID: "test-missing-tenant",
+	}
+	credStore := newTestCredentialStore(t)
+	oauthProvider := NewOAuth2Provider(credStore, config, logging.NewNoopLogger())
+	flow := NewInteractiveAuthFlowWithStore(oauthProvider, config, store)
+
+	result, err := flow.getFlowState("nonexistent-flow-state-id")
+	assert.Nil(t, result, "result must be nil for missing flow state")
+	assert.Error(t, err, "missing flow state must return an error")
 }
 
 // Helper type for mocking HTTP transport


### PR DESCRIPTION
## Summary

- `storeFlowState()` now writes `AuthFlowState` (PKCE verifier, nonce, scopes) to a durable encrypted store via `pkg/secrets.SecretStore` instead of the in-memory `sync.Map` in `CallbackHandler`
- Flow state survives controller restarts — a new `InteractiveAuthFlow` instance backed by the same store directory can retrieve in-flight OAuth state
- Expired state (past 10-minute TTL) returns `ErrFlowStateExpired` — a distinct, inspectable sentinel error instead of stale/zero state
- `NewInteractiveAuthFlowWithStore` is the new production constructor; `NewInteractiveAuthFlow` keeps its existing in-memory behaviour for backward compatibility

## Implementation Notes

- Secret key: `m365/flow-state/<state>` using `sanitizeSegment()` — same convention as `SecretStoreCredentialStore`
- Two-layer TTL: `SecretRequest.TTL` (store-level, 10 min) + embedded `AuthFlowState.ExpiresAt` (application-level double-check)
- Cleanup after callback uses `DeleteSecret`; errors are intentionally swallowed since TTL guarantees eventual expiry
- Tenant ID and flow ID are stored in `SecretRequest.Metadata` for audit/namespace context
- No new Go module dependencies added

## Test Plan

- `TestFlowStateDurableStorage` — writes state via instance 1, flushes to disk, opens new store on same dir, reads back via instance 2; asserts CodeVerifier/CodeChallenge/Nonce survive restart
- `TestFlowStateExpiredReturnsDistinctError` — stores JSON with past `ExpiresAt` directly via SecretStore, calls `getFlowState`, asserts `errors.Is(err, ErrFlowStateExpired)`
- `TestFlowStateMissingReturnsError` — calls `getFlowState` with unknown state ID, asserts error returned and result is nil
- All tests use real steward provider (no mocks); skip when `/etc/machine-id` absent (same pattern as all steward-backed tests in the package)
- `make test-agent-complete`: PASS — 130+ packages, lint, architecture checks, cross-platform compilation

## Specialist Review Results

- **QA Test Runner**: PASS — all tests pass, 0 lint issues, all architecture checks clean
- **QA Code Reviewer**: PASS — no mocks, no empty assertions, error paths tested, skip justified
- **Security Engineer**: PASS — PKCE/nonce encrypted at rest, no AUTHZ-PROHIBITION violations, no hardcoded secrets, no information disclosure in errors

Fixes #1611

🤖 Generated with [Claude Code](https://claude.com/claude-code)