### PR TITLE
m365: implement Graph API OData filter query in SearchUsers (Issue #1613)

### DIFF
--- a/features/modules/m365/directory_provider.go
+++ b/features/modules/m365/directory_provider.go
@@ -300,15 +300,54 @@ func (p *EntraIDDirectoryProvider) DeleteUser(ctx context.Context, userID string
 	return nil
 }
 
-// SearchUsers searches for users in Entra ID
+// SearchUsers searches for users in Entra ID using OData startswith filters on
+// displayName and userPrincipalName. Paging is handled transparently (up to 1000
+// results). An empty query is rejected to prevent accidentally fetching all users.
 func (p *EntraIDDirectoryProvider) SearchUsers(ctx context.Context, query *directory.SearchQuery) ([]*types.DirectoryUser, error) {
 	if !p.connected {
 		return nil, fmt.Errorf("not connected to Entra ID")
 	}
 
-	// Deferred: tracked in #1443 — construct OData filter queries and call Graph API
-	p.logger.Info("SearchUsers called", "query", query.Query, "limit", query.Limit)
-	return []*types.DirectoryUser{}, nil
+	if strings.TrimSpace(query.Query) == "" {
+		return nil, fmt.Errorf("search query must not be empty")
+	}
+
+	token, err := p.getToken(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	// Sanitize single quotes to prevent OData injection.
+	sanitized := strings.ReplaceAll(query.Query, "'", "''")
+	filter := fmt.Sprintf(
+		"startswith(displayName,'%s') or startswith(userPrincipalName,'%s')",
+		sanitized, sanitized,
+	)
+
+	users, err := p.graphClient.ListUsers(ctx, token, filter)
+	if err != nil {
+		return nil, fmt.Errorf("failed to search users in Entra ID: %w", err)
+	}
+
+	result := make([]*types.DirectoryUser, 0, len(users))
+	for i := range users {
+		graphUserType := &types.GraphUser{
+			ID:                users[i].ID,
+			UserPrincipalName: users[i].UserPrincipalName,
+			DisplayName:       users[i].DisplayName,
+			MailNickname:      users[i].MailNickname,
+			AccountEnabled:    users[i].AccountEnabled,
+			Mail:              users[i].Mail,
+			MobilePhone:       users[i].MobilePhone,
+			OfficeLocation:    users[i].OfficeLocation,
+			JobTitle:          users[i].JobTitle,
+			Department:        users[i].Department,
+			CompanyName:       users[i].CompanyName,
+			CreatedDateTime:   users[i].CreatedDateTime,
+		}
+		result = append(result, types.FromGraphUser(graphUserType, p.name))
+	}
+	return result, nil
 }
 
 // Group Operations

--- a/features/modules/m365/directory_provider_test.go
+++ b/features/modules/m365/directory_provider_test.go
@@ -4,12 +4,15 @@ package m365
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
 
 	"github.com/cfgis/cfgms/features/controller/directory"
 	"github.com/cfgis/cfgms/features/modules/m365/auth"
@@ -17,427 +20,10 @@ import (
 	"github.com/cfgis/cfgms/pkg/directory/types"
 )
 
-// Mock implementations for testing
-
-type MockLogger struct {
-	mock.Mock
-}
-
-func (m *MockLogger) Debug(msg string, keysAndValues ...interface{}) {
-	args := []interface{}{msg}
-	args = append(args, keysAndValues...)
-	m.Called(args...)
-}
-
-func (m *MockLogger) Info(msg string, keysAndValues ...interface{}) {
-	args := []interface{}{msg}
-	args = append(args, keysAndValues...)
-	m.Called(args...)
-}
-
-func (m *MockLogger) Warn(msg string, keysAndValues ...interface{}) {
-	args := []interface{}{msg}
-	args = append(args, keysAndValues...)
-	m.Called(args...)
-}
-
-func (m *MockLogger) Error(msg string, keysAndValues ...interface{}) {
-	args := []interface{}{msg}
-	args = append(args, keysAndValues...)
-	m.Called(args...)
-}
-
-func (m *MockLogger) Fatal(msg string, keysAndValues ...interface{}) {
-	args := []interface{}{msg}
-	args = append(args, keysAndValues...)
-	m.Called(args...)
-}
-
-func (m *MockLogger) DebugCtx(ctx context.Context, msg string, keysAndValues ...interface{}) {
-	args := []interface{}{ctx, msg}
-	args = append(args, keysAndValues...)
-	m.Called(args...)
-}
-
-func (m *MockLogger) InfoCtx(ctx context.Context, msg string, keysAndValues ...interface{}) {
-	args := []interface{}{ctx, msg}
-	args = append(args, keysAndValues...)
-	m.Called(args...)
-}
-
-func (m *MockLogger) WarnCtx(ctx context.Context, msg string, keysAndValues ...interface{}) {
-	args := []interface{}{ctx, msg}
-	args = append(args, keysAndValues...)
-	m.Called(args...)
-}
-
-func (m *MockLogger) ErrorCtx(ctx context.Context, msg string, keysAndValues ...interface{}) {
-	args := []interface{}{ctx, msg}
-	args = append(args, keysAndValues...)
-	m.Called(args...)
-}
-
-func (m *MockLogger) FatalCtx(ctx context.Context, msg string, keysAndValues ...interface{}) {
-	args := []interface{}{ctx, msg}
-	args = append(args, keysAndValues...)
-	m.Called(args...)
-}
-
-type MockAuthProvider struct {
-	mock.Mock
-}
-
-func (m *MockAuthProvider) GetAccessToken(ctx context.Context, tenantID string) (*auth.AccessToken, error) {
-	args := m.Called(ctx, tenantID)
-	if args.Get(0) == nil {
-		return nil, args.Error(1)
-	}
-	return args.Get(0).(*auth.AccessToken), args.Error(1)
-}
-
-func (m *MockAuthProvider) GetDelegatedAccessToken(ctx context.Context, tenantID string, userContext *auth.UserContext) (*auth.AccessToken, error) {
-	args := m.Called(ctx, tenantID, userContext)
-	if args.Get(0) == nil {
-		return nil, args.Error(1)
-	}
-	return args.Get(0).(*auth.AccessToken), args.Error(1)
-}
-
-func (m *MockAuthProvider) RefreshToken(ctx context.Context, refreshToken string) (*auth.AccessToken, error) {
-	args := m.Called(ctx, refreshToken)
-	if args.Get(0) == nil {
-		return nil, args.Error(1)
-	}
-	return args.Get(0).(*auth.AccessToken), args.Error(1)
-}
-
-func (m *MockAuthProvider) RefreshDelegatedToken(ctx context.Context, refreshToken string, userContext *auth.UserContext) (*auth.AccessToken, error) {
-	args := m.Called(ctx, refreshToken, userContext)
-	if args.Get(0) == nil {
-		return nil, args.Error(1)
-	}
-	return args.Get(0).(*auth.AccessToken), args.Error(1)
-}
-
-func (m *MockAuthProvider) IsTokenValid(token *auth.AccessToken) bool {
-	args := m.Called(token)
-	return args.Bool(0)
-}
-
-func (m *MockAuthProvider) ValidatePermissions(ctx context.Context, token *auth.AccessToken, requiredScopes []string) error {
-	args := m.Called(ctx, token, requiredScopes)
-	return args.Error(0)
-}
-
-type MockGraphClient struct {
-	mock.Mock
-}
-
-func (m *MockGraphClient) GetUser(ctx context.Context, token *auth.AccessToken, userPrincipalName string) (*graph.User, error) {
-	args := m.Called(ctx, token, userPrincipalName)
-	if args.Get(0) == nil {
-		return nil, args.Error(1)
-	}
-	return args.Get(0).(*graph.User), args.Error(1)
-}
-
-func (m *MockGraphClient) CreateUser(ctx context.Context, token *auth.AccessToken, request *graph.CreateUserRequest) (*graph.User, error) {
-	args := m.Called(ctx, token, request)
-	if args.Get(0) == nil {
-		return nil, args.Error(1)
-	}
-	return args.Get(0).(*graph.User), args.Error(1)
-}
-
-func (m *MockGraphClient) UpdateUser(ctx context.Context, token *auth.AccessToken, userID string, request *graph.UpdateUserRequest) error {
-	args := m.Called(ctx, token, userID, request)
-	return args.Error(0)
-}
-
-func (m *MockGraphClient) DeleteUser(ctx context.Context, token *auth.AccessToken, userID string) error {
-	args := m.Called(ctx, token, userID)
-	return args.Error(0)
-}
-
-func (m *MockGraphClient) GetUserLicenses(ctx context.Context, token *auth.AccessToken, userID string) ([]graph.LicenseAssignment, error) {
-	args := m.Called(ctx, token, userID)
-	return args.Get(0).([]graph.LicenseAssignment), args.Error(1)
-}
-
-func (m *MockGraphClient) AssignLicense(ctx context.Context, token *auth.AccessToken, userID, skuID string, disabledPlans []string) error {
-	args := m.Called(ctx, token, userID, skuID, disabledPlans)
-	return args.Error(0)
-}
-
-func (m *MockGraphClient) RemoveLicense(ctx context.Context, token *auth.AccessToken, userID, skuID string) error {
-	args := m.Called(ctx, token, userID, skuID)
-	return args.Error(0)
-}
-
-func (m *MockGraphClient) GetUserGroups(ctx context.Context, token *auth.AccessToken, userID string) ([]string, error) {
-	args := m.Called(ctx, token, userID)
-	return args.Get(0).([]string), args.Error(1)
-}
-
-func (m *MockGraphClient) AddUserToGroup(ctx context.Context, token *auth.AccessToken, userID, groupName string) error {
-	args := m.Called(ctx, token, userID, groupName)
-	return args.Error(0)
-}
-
-func (m *MockGraphClient) RemoveUserFromGroup(ctx context.Context, token *auth.AccessToken, userID, groupName string) error {
-	args := m.Called(ctx, token, userID, groupName)
-	return args.Error(0)
-}
-
-func (m *MockGraphClient) GetConditionalAccessPolicy(ctx context.Context, token *auth.AccessToken, policyID string) (*graph.ConditionalAccessPolicy, error) {
-	args := m.Called(ctx, token, policyID)
-	if args.Get(0) == nil {
-		return nil, args.Error(1)
-	}
-	return args.Get(0).(*graph.ConditionalAccessPolicy), args.Error(1)
-}
-
-func (m *MockGraphClient) CreateConditionalAccessPolicy(ctx context.Context, token *auth.AccessToken, request *graph.CreateConditionalAccessPolicyRequest) (*graph.ConditionalAccessPolicy, error) {
-	args := m.Called(ctx, token, request)
-	if args.Get(0) == nil {
-		return nil, args.Error(1)
-	}
-	return args.Get(0).(*graph.ConditionalAccessPolicy), args.Error(1)
-}
-
-func (m *MockGraphClient) UpdateConditionalAccessPolicy(ctx context.Context, token *auth.AccessToken, policyID string, request *graph.UpdateConditionalAccessPolicyRequest) error {
-	args := m.Called(ctx, token, policyID, request)
-	return args.Error(0)
-}
-
-func (m *MockGraphClient) DeleteConditionalAccessPolicy(ctx context.Context, token *auth.AccessToken, policyID string) error {
-	args := m.Called(ctx, token, policyID)
-	return args.Error(0)
-}
-
-func (m *MockGraphClient) GetDeviceConfiguration(ctx context.Context, token *auth.AccessToken, configurationID string) (*graph.DeviceConfiguration, error) {
-	args := m.Called(ctx, token, configurationID)
-	if args.Get(0) == nil {
-		return nil, args.Error(1)
-	}
-	return args.Get(0).(*graph.DeviceConfiguration), args.Error(1)
-}
-
-func (m *MockGraphClient) CreateDeviceConfiguration(ctx context.Context, token *auth.AccessToken, request *graph.CreateDeviceConfigurationRequest) (*graph.DeviceConfiguration, error) {
-	args := m.Called(ctx, token, request)
-	if args.Get(0) == nil {
-		return nil, args.Error(1)
-	}
-	return args.Get(0).(*graph.DeviceConfiguration), args.Error(1)
-}
-
-func (m *MockGraphClient) UpdateDeviceConfiguration(ctx context.Context, token *auth.AccessToken, configurationID string, request *graph.UpdateDeviceConfigurationRequest) error {
-	args := m.Called(ctx, token, configurationID, request)
-	return args.Error(0)
-}
-
-func (m *MockGraphClient) DeleteDeviceConfiguration(ctx context.Context, token *auth.AccessToken, configurationID string) error {
-	args := m.Called(ctx, token, configurationID)
-	return args.Error(0)
-}
-
-func (m *MockGraphClient) ListDeviceConfigurationAssignments(ctx context.Context, token *auth.AccessToken, configurationID string) ([]graph.DeviceConfigurationAssignment, error) {
-	return nil, nil
-}
-
-func (m *MockGraphClient) AssignDeviceConfiguration(ctx context.Context, token *auth.AccessToken, configurationID string, assignments []graph.DeviceConfigurationAssignment) error {
-	return nil
-}
-
-// Missing methods for interface compliance
-func (m *MockGraphClient) ListUsers(ctx context.Context, token *auth.AccessToken, filter string) ([]graph.User, error) {
-	args := m.Called(ctx, token, filter)
-	if args.Get(0) == nil {
-		return nil, args.Error(1)
-	}
-	return args.Get(0).([]graph.User), args.Error(1)
-}
-
-func (m *MockGraphClient) GetApplication(ctx context.Context, token *auth.AccessToken, applicationID string) (*graph.Application, error) {
-	args := m.Called(ctx, token, applicationID)
-	if args.Get(0) == nil {
-		return nil, args.Error(1)
-	}
-	return args.Get(0).(*graph.Application), args.Error(1)
-}
-
-func (m *MockGraphClient) ListApplications(ctx context.Context, token *auth.AccessToken, filter string) ([]graph.Application, error) {
-	args := m.Called(ctx, token, filter)
-	if args.Get(0) == nil {
-		return nil, args.Error(1)
-	}
-	return args.Get(0).([]graph.Application), args.Error(1)
-}
-
-func (m *MockGraphClient) CreateApplication(ctx context.Context, token *auth.AccessToken, request *graph.CreateApplicationRequest) (*graph.Application, error) {
-	args := m.Called(ctx, token, request)
-	if args.Get(0) == nil {
-		return nil, args.Error(1)
-	}
-	return args.Get(0).(*graph.Application), args.Error(1)
-}
-
-func (m *MockGraphClient) UpdateApplication(ctx context.Context, token *auth.AccessToken, applicationID string, request *graph.UpdateApplicationRequest) error {
-	args := m.Called(ctx, token, applicationID, request)
-	return args.Error(0)
-}
-
-func (m *MockGraphClient) DeleteApplication(ctx context.Context, token *auth.AccessToken, applicationID string) error {
-	args := m.Called(ctx, token, applicationID)
-	return args.Error(0)
-}
-
-func (m *MockGraphClient) GetAdministrativeUnit(ctx context.Context, token *auth.AccessToken, unitID string) (*graph.AdministrativeUnit, error) {
-	args := m.Called(ctx, token, unitID)
-	if args.Get(0) == nil {
-		return nil, args.Error(1)
-	}
-	return args.Get(0).(*graph.AdministrativeUnit), args.Error(1)
-}
-
-func (m *MockGraphClient) ListAdministrativeUnits(ctx context.Context, token *auth.AccessToken, filter string) ([]graph.AdministrativeUnit, error) {
-	args := m.Called(ctx, token, filter)
-	if args.Get(0) == nil {
-		return nil, args.Error(1)
-	}
-	return args.Get(0).([]graph.AdministrativeUnit), args.Error(1)
-}
-
-func (m *MockGraphClient) CreateAdministrativeUnit(ctx context.Context, token *auth.AccessToken, request *graph.CreateAdministrativeUnitRequest) (*graph.AdministrativeUnit, error) {
-	args := m.Called(ctx, token, request)
-	if args.Get(0) == nil {
-		return nil, args.Error(1)
-	}
-	return args.Get(0).(*graph.AdministrativeUnit), args.Error(1)
-}
-
-func (m *MockGraphClient) UpdateAdministrativeUnit(ctx context.Context, token *auth.AccessToken, unitID string, request *graph.UpdateAdministrativeUnitRequest) error {
-	args := m.Called(ctx, token, unitID, request)
-	return args.Error(0)
-}
-
-func (m *MockGraphClient) DeleteAdministrativeUnit(ctx context.Context, token *auth.AccessToken, unitID string) error {
-	args := m.Called(ctx, token, unitID)
-	return args.Error(0)
-}
-
-func (m *MockGraphClient) GetGroup(ctx context.Context, token *auth.AccessToken, groupID string) (*graph.Group, error) {
-	args := m.Called(ctx, token, groupID)
-	if args.Get(0) == nil {
-		return nil, args.Error(1)
-	}
-	return args.Get(0).(*graph.Group), args.Error(1)
-}
-
-func (m *MockGraphClient) ListGroups(ctx context.Context, token *auth.AccessToken, filter string) ([]graph.Group, error) {
-	args := m.Called(ctx, token, filter)
-	if args.Get(0) == nil {
-		return nil, args.Error(1)
-	}
-	return args.Get(0).([]graph.Group), args.Error(1)
-}
-
-func (m *MockGraphClient) CreateGroup(ctx context.Context, token *auth.AccessToken, request *graph.CreateGroupRequest) (*graph.Group, error) {
-	args := m.Called(ctx, token, request)
-	if args.Get(0) == nil {
-		return nil, args.Error(1)
-	}
-	return args.Get(0).(*graph.Group), args.Error(1)
-}
-
-func (m *MockGraphClient) UpdateGroup(ctx context.Context, token *auth.AccessToken, groupID string, request *graph.UpdateGroupRequest) error {
-	args := m.Called(ctx, token, groupID, request)
-	return args.Error(0)
-}
-
-func (m *MockGraphClient) DeleteGroup(ctx context.Context, token *auth.AccessToken, groupID string) error {
-	args := m.Called(ctx, token, groupID)
-	return args.Error(0)
-}
-
-func (m *MockGraphClient) ListAdminUnitUserMembers(ctx context.Context, token *auth.AccessToken, unitID string) ([]string, error) {
-	return nil, nil
-}
-
-func (m *MockGraphClient) ListAdminUnitGroupMembers(ctx context.Context, token *auth.AccessToken, unitID string) ([]string, error) {
-	return nil, nil
-}
-
-func (m *MockGraphClient) ListAdminUnitScopedRoleMembers(ctx context.Context, token *auth.AccessToken, unitID string) ([]graph.AdminUnitScopedRoleMember, error) {
-	return nil, nil
-}
-
-func (m *MockGraphClient) AddAdminUnitMember(ctx context.Context, token *auth.AccessToken, unitID, memberID string) error {
-	return nil
-}
-
-func (m *MockGraphClient) AddAdminUnitScopedRoleMember(ctx context.Context, token *auth.AccessToken, unitID string, request *graph.AddScopedRoleMemberRequest) (*graph.AdminUnitScopedRoleMember, error) {
-	return nil, nil
-}
-
-func (m *MockGraphClient) RemoveAdminUnitMember(ctx context.Context, token *auth.AccessToken, unitID, memberID string) error {
-	return nil
-}
-
-func (m *MockGraphClient) RemoveAdminUnitScopedRoleMember(ctx context.Context, token *auth.AccessToken, unitID, scopedRoleMemberID string) error {
-	return nil
-}
-
-func (m *MockGraphClient) ListGroupMembers(ctx context.Context, token *auth.AccessToken, groupID string) ([]string, error) {
-	return nil, nil
-}
-
-func (m *MockGraphClient) AddGroupMember(ctx context.Context, token *auth.AccessToken, groupID, memberUPN string) error {
-	return nil
-}
-
-func (m *MockGraphClient) RemoveGroupMember(ctx context.Context, token *auth.AccessToken, groupID, memberUPN string) error {
-	return nil
-}
-
-func (m *MockGraphClient) ListGroupOwners(ctx context.Context, token *auth.AccessToken, groupID string) ([]string, error) {
-	return nil, nil
-}
-
-func (m *MockGraphClient) AddGroupOwner(ctx context.Context, token *auth.AccessToken, groupID, ownerUPN string) error {
-	return nil
-}
-
-func (m *MockGraphClient) RemoveGroupOwner(ctx context.Context, token *auth.AccessToken, groupID, ownerUPN string) error {
-	return nil
-}
-
-func (m *MockGraphClient) GetTeam(ctx context.Context, token *auth.AccessToken, groupID string) (*graph.Team, error) {
-	args := m.Called(ctx, token, groupID)
-	if args.Get(0) == nil {
-		return nil, args.Error(1)
-	}
-	return args.Get(0).(*graph.Team), args.Error(1)
-}
-
-func (m *MockGraphClient) CreateTeam(ctx context.Context, token *auth.AccessToken, groupID string, request *graph.CreateTeamRequest) error {
-	args := m.Called(ctx, token, groupID, request)
-	return args.Error(0)
-}
-
-func (m *MockGraphClient) UpdateTeamSettings(ctx context.Context, token *auth.AccessToken, teamID string, request *graph.UpdateTeamSettingsRequest) error {
-	args := m.Called(ctx, token, teamID, request)
-	return args.Error(0)
-}
-
 // Test functions
 
 func TestNewEntraIDDirectoryProvider(t *testing.T) {
-	mockLogger := &MockLogger{}
-	mockAuth := &MockAuthProvider{}
-	mockGraph := &MockGraphClient{}
-
-	provider := NewEntraIDDirectoryProvider(mockLogger, mockAuth, mockGraph)
+	provider := NewEntraIDDirectoryProvider(&stubLogger{}, &stubAuthProvider{}, &stubGraphClient{})
 
 	assert.NotNil(t, provider)
 	assert.Equal(t, "entraid", provider.Name())
@@ -459,32 +45,37 @@ func TestNewEntraIDDirectoryProvider(t *testing.T) {
 	assert.NotNil(t, capabilities.RateLimit)
 }
 
+// validConnectConfig returns a well-formed provider config for Connect tests.
+func validConnectConfig() directory.ProviderConfig {
+	return directory.ProviderConfig{
+		ProviderName: "entraid",
+		Settings: map[string]interface{}{
+			"tenant_id": "test-tenant-id",
+			"client_id": "test-client-id",
+		},
+		Credentials: map[string]string{
+			"client_secret": "test-client-secret",
+		},
+	}
+}
+
 func TestEntraIDDirectoryProvider_Connect(t *testing.T) {
 	tests := []struct {
 		name          string
 		config        directory.ProviderConfig
-		setupMocks    func(*MockLogger, *MockAuthProvider, *MockGraphClient)
+		authProvider  auth.Provider
+		graphClient   graph.Client
 		expectError   bool
 		expectConnect bool
 	}{
 		{
-			name: "successful connection",
-			config: directory.ProviderConfig{
-				ProviderName: "entraid",
-				Settings: map[string]interface{}{
-					"tenant_id": "test-tenant-id",
-					"client_id": "test-client-id",
+			name:   "successful connection",
+			config: validConnectConfig(),
+			authProvider: &stubAuthProvider{},
+			graphClient: &stubGraphClient{
+				getUserFn: func(_ context.Context, _ *auth.AccessToken, _ string) (*graph.User, error) {
+					return &graph.User{ID: "me"}, nil
 				},
-				Credentials: map[string]string{
-					"client_secret": "test-client-secret",
-				},
-			},
-			setupMocks: func(mockLogger *MockLogger, mockAuth *MockAuthProvider, mockGraph *MockGraphClient) {
-				mockToken := &auth.AccessToken{Token: "test-token"}
-				mockAuth.On("GetAccessToken", mock.Anything, "test-tenant-id").Return(mockToken, nil)
-				mockUser := &graph.User{ID: "me"}
-				mockGraph.On("GetUser", mock.Anything, mockToken, "me").Return(mockUser, nil)
-				mockLogger.On("Info", "Connected to Entra ID", "tenant_id", "test-tenant-id").Return()
 			},
 			expectError:   false,
 			expectConnect: true,
@@ -493,169 +84,105 @@ func TestEntraIDDirectoryProvider_Connect(t *testing.T) {
 			name: "invalid configuration",
 			config: directory.ProviderConfig{
 				ProviderName: "entraid",
-				Settings: map[string]interface{}{
-					"invalid_field": "value",
-				},
+				Settings:     map[string]interface{}{"invalid_field": "value"},
 			},
-			setupMocks: func(mockLogger *MockLogger, mockAuth *MockAuthProvider, mockGraph *MockGraphClient) {
-				// No mocks needed as this should fail config parsing
-			},
+			authProvider:  &stubAuthProvider{},
+			graphClient:   &stubGraphClient{},
 			expectError:   true,
 			expectConnect: false,
 		},
 		{
-			name: "authentication failure",
-			config: directory.ProviderConfig{
-				ProviderName: "entraid",
-				Settings: map[string]interface{}{
-					"tenant_id": "test-tenant-id",
-					"client_id": "test-client-id",
-				},
-				Credentials: map[string]string{
-					"client_secret": "test-client-secret",
+			name:   "authentication failure",
+			config: validConnectConfig(),
+			authProvider: &stubAuthProvider{
+				getAccessTokenFn: func(_ context.Context, _ string) (*auth.AccessToken, error) {
+					return nil, errors.New("auth failed")
 				},
 			},
-			setupMocks: func(mockLogger *MockLogger, mockAuth *MockAuthProvider, mockGraph *MockGraphClient) {
-				mockAuth.On("GetAccessToken", mock.Anything, "test-tenant-id").Return(nil, errors.New("auth failed"))
-			},
+			graphClient:   &stubGraphClient{},
 			expectError:   true,
 			expectConnect: false,
 		},
 		{
-			name: "graph api failure",
-			config: directory.ProviderConfig{
-				ProviderName: "entraid",
-				Settings: map[string]interface{}{
-					"tenant_id": "test-tenant-id",
-					"client_id": "test-client-id",
+			name:         "graph api failure is tolerated with client credentials",
+			config:       validConnectConfig(),
+			authProvider: &stubAuthProvider{},
+			graphClient: &stubGraphClient{
+				getUserFn: func(_ context.Context, _ *auth.AccessToken, _ string) (*graph.User, error) {
+					return nil, errors.New("graph failed")
 				},
-				Credentials: map[string]string{
-					"client_secret": "test-client-secret",
-				},
-			},
-			setupMocks: func(mockLogger *MockLogger, mockAuth *MockAuthProvider, mockGraph *MockGraphClient) {
-				mockToken := &auth.AccessToken{Token: "test-token"}
-				mockAuth.On("GetAccessToken", mock.Anything, "test-tenant-id").Return(mockToken, nil)
-				mockGraph.On("GetUser", mock.Anything, mockToken, "me").Return(nil, errors.New("graph failed"))
-				mockLogger.On("Debug", "Graph API test call completed", "error", errors.New("graph failed")).Return()
-				mockLogger.On("Info", "Connected to Entra ID", "tenant_id", "test-tenant-id").Return()
 			},
 			expectError:   false,
-			expectConnect: true, // Graph API failure is expected with client credentials
+			expectConnect: true,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			mockLogger := &MockLogger{}
-			mockAuth := &MockAuthProvider{}
-			mockGraph := &MockGraphClient{}
-
-			tt.setupMocks(mockLogger, mockAuth, mockGraph)
-
-			provider := NewEntraIDDirectoryProvider(mockLogger, mockAuth, mockGraph)
-
-			ctx := context.Background()
-			err := provider.Connect(ctx, tt.config)
-
+			provider := NewEntraIDDirectoryProvider(&stubLogger{}, tt.authProvider, tt.graphClient)
+			err := provider.Connect(context.Background(), tt.config)
 			if tt.expectError {
 				assert.Error(t, err)
 			} else {
 				assert.NoError(t, err)
 			}
-
 			assert.Equal(t, tt.expectConnect, provider.IsConnected())
-
-			mockAuth.AssertExpectations(t)
-			mockGraph.AssertExpectations(t)
-			mockLogger.AssertExpectations(t)
 		})
 	}
 }
 
 func TestEntraIDDirectoryProvider_Disconnect(t *testing.T) {
-	mockLogger := &MockLogger{}
-	mockAuth := &MockAuthProvider{}
-	mockGraph := &MockGraphClient{}
-
-	mockLogger.On("Info", "Disconnected from Entra ID").Return()
-
-	provider := NewEntraIDDirectoryProvider(mockLogger, mockAuth, mockGraph)
-
-	// Simulate connected state
+	provider := NewEntraIDDirectoryProvider(&stubLogger{}, &stubAuthProvider{}, &stubGraphClient{})
 	provider.connected = true
-
-	ctx := context.Background()
-	err := provider.Disconnect(ctx)
-
+	err := provider.Disconnect(context.Background())
 	assert.NoError(t, err)
 	assert.False(t, provider.IsConnected())
-
-	mockLogger.AssertExpectations(t)
 }
 
 func TestEntraIDDirectoryProvider_HealthCheck(t *testing.T) {
 	tests := []struct {
 		name           string
 		connected      bool
-		setupMocks     func(*MockAuthProvider)
+		authProvider   auth.Provider
 		expectHealthy  bool
-		expectError    bool
 		expectedErrMsg string
 	}{
 		{
 			name:           "not connected",
 			connected:      false,
-			setupMocks:     func(mockAuth *MockAuthProvider) {},
+			authProvider:   &stubAuthProvider{},
 			expectHealthy:  false,
-			expectError:    false,
 			expectedErrMsg: "not connected to Entra ID",
 		},
 		{
-			name:      "connected and healthy",
-			connected: true,
-			setupMocks: func(mockAuth *MockAuthProvider) {
-				mockToken := &auth.AccessToken{Token: "test-token"}
-				mockAuth.On("GetAccessToken", mock.Anything, "test-tenant-id").Return(mockToken, nil)
-			},
+			name:          "connected and healthy",
+			connected:     true,
+			authProvider:  &stubAuthProvider{},
 			expectHealthy: true,
-			expectError:   false,
 		},
 		{
 			name:      "connected but auth failure",
 			connected: true,
-			setupMocks: func(mockAuth *MockAuthProvider) {
-				mockAuth.On("GetAccessToken", mock.Anything, "test-tenant-id").Return(nil, errors.New("token failed"))
+			authProvider: &stubAuthProvider{
+				getAccessTokenFn: func(_ context.Context, _ string) (*auth.AccessToken, error) {
+					return nil, errors.New("token failed")
+				},
 			},
 			expectHealthy:  false,
-			expectError:    false,
 			expectedErrMsg: "token retrieval failed: token failed",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			mockLogger := &MockLogger{}
-			mockAuth := &MockAuthProvider{}
-			mockGraph := &MockGraphClient{}
-
-			tt.setupMocks(mockAuth)
-
-			provider := NewEntraIDDirectoryProvider(mockLogger, mockAuth, mockGraph)
+			provider := NewEntraIDDirectoryProvider(&stubLogger{}, tt.authProvider, &stubGraphClient{})
 			provider.connected = tt.connected
 			if tt.connected {
 				provider.config = &ProviderConfig{TenantID: "test-tenant-id"}
 			}
 
-			ctx := context.Background()
-			health, err := provider.HealthCheck(ctx)
-
-			if tt.expectError {
-				assert.Error(t, err)
-			} else {
-				assert.NoError(t, err)
-			}
-
+			health, err := provider.HealthCheck(context.Background())
+			assert.NoError(t, err)
 			assert.NotNil(t, health)
 			assert.Equal(t, tt.expectHealthy, health.IsHealthy)
 			assert.False(t, health.LastCheck.IsZero())
@@ -665,52 +192,47 @@ func TestEntraIDDirectoryProvider_HealthCheck(t *testing.T) {
 			}
 
 			if tt.expectHealthy {
-				// Windows timer resolution may cause ResponseTime to be 0 for very fast operations
-				// This is acceptable and doesn't indicate a failure
 				if runtime.GOOS != "windows" {
 					assert.NotZero(t, health.ResponseTime)
 				}
 			}
-
-			mockAuth.AssertExpectations(t)
 		})
 	}
 }
 
 func TestEntraIDDirectoryProvider_GetUser(t *testing.T) {
 	tests := []struct {
-		name        string
-		connected   bool
-		userID      string
-		setupMocks  func(*MockAuthProvider, *MockGraphClient)
-		expectError bool
-		expectUser  *types.DirectoryUser
+		name         string
+		connected    bool
+		userID       string
+		authProvider auth.Provider
+		graphClient  graph.Client
+		expectError  bool
+		expectUser   *types.DirectoryUser
 	}{
 		{
-			name:      "not connected",
-			connected: false,
-			userID:    "test-user-id",
-			setupMocks: func(mockAuth *MockAuthProvider, mockGraph *MockGraphClient) {
-				// No mocks needed
-			},
-			expectError: true,
+			name:         "not connected",
+			connected:    false,
+			userID:       "test-user-id",
+			authProvider: &stubAuthProvider{},
+			graphClient:  &stubGraphClient{},
+			expectError:  true,
 		},
 		{
-			name:      "successful get user",
-			connected: true,
-			userID:    "test-user-id",
-			setupMocks: func(mockAuth *MockAuthProvider, mockGraph *MockGraphClient) {
-				mockToken := &auth.AccessToken{Token: "test-token"}
-				mockAuth.On("GetAccessToken", mock.Anything, "test-tenant-id").Return(mockToken, nil)
-
-				mockUser := &graph.User{
-					ID:                "test-user-id",
-					UserPrincipalName: "test@example.com",
-					DisplayName:       "Test User",
-					AccountEnabled:    true,
-					Mail:              "test@example.com",
-				}
-				mockGraph.On("GetUser", mock.Anything, mockToken, "test-user-id").Return(mockUser, nil)
+			name:         "successful get user",
+			connected:    true,
+			userID:       "test-user-id",
+			authProvider: &stubAuthProvider{},
+			graphClient: &stubGraphClient{
+				getUserFn: func(_ context.Context, _ *auth.AccessToken, id string) (*graph.User, error) {
+					return &graph.User{
+						ID:                id,
+						UserPrincipalName: "test@example.com",
+						DisplayName:       "Test User",
+						AccountEnabled:    true,
+						Mail:              "test@example.com",
+					}, nil
+				},
 			},
 			expectError: false,
 			expectUser: &types.DirectoryUser{
@@ -727,19 +249,23 @@ func TestEntraIDDirectoryProvider_GetUser(t *testing.T) {
 			name:      "auth token failure",
 			connected: true,
 			userID:    "test-user-id",
-			setupMocks: func(mockAuth *MockAuthProvider, mockGraph *MockGraphClient) {
-				mockAuth.On("GetAccessToken", mock.Anything, "test-tenant-id").Return(nil, errors.New("auth failed"))
+			authProvider: &stubAuthProvider{
+				getAccessTokenFn: func(_ context.Context, _ string) (*auth.AccessToken, error) {
+					return nil, errors.New("auth failed")
+				},
 			},
+			graphClient: &stubGraphClient{},
 			expectError: true,
 		},
 		{
-			name:      "graph api failure",
-			connected: true,
-			userID:    "test-user-id",
-			setupMocks: func(mockAuth *MockAuthProvider, mockGraph *MockGraphClient) {
-				mockToken := &auth.AccessToken{Token: "test-token"}
-				mockAuth.On("GetAccessToken", mock.Anything, "test-tenant-id").Return(mockToken, nil)
-				mockGraph.On("GetUser", mock.Anything, mockToken, "test-user-id").Return(nil, errors.New("graph failed"))
+			name:         "graph api failure",
+			connected:    true,
+			userID:       "test-user-id",
+			authProvider: &stubAuthProvider{},
+			graphClient: &stubGraphClient{
+				getUserFn: func(_ context.Context, _ *auth.AccessToken, _ string) (*graph.User, error) {
+					return nil, errors.New("graph failed")
+				},
 			},
 			expectError: true,
 		},
@@ -747,20 +273,13 @@ func TestEntraIDDirectoryProvider_GetUser(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			mockLogger := &MockLogger{}
-			mockAuth := &MockAuthProvider{}
-			mockGraph := &MockGraphClient{}
-
-			tt.setupMocks(mockAuth, mockGraph)
-
-			provider := NewEntraIDDirectoryProvider(mockLogger, mockAuth, mockGraph)
+			provider := NewEntraIDDirectoryProvider(&stubLogger{}, tt.authProvider, tt.graphClient)
 			provider.connected = tt.connected
 			if tt.connected {
 				provider.config = &ProviderConfig{TenantID: "test-tenant-id"}
 			}
 
-			ctx := context.Background()
-			user, err := provider.GetUser(ctx, tt.userID)
+			user, err := provider.GetUser(context.Background(), tt.userID)
 
 			if tt.expectError {
 				assert.Error(t, err)
@@ -768,8 +287,6 @@ func TestEntraIDDirectoryProvider_GetUser(t *testing.T) {
 			} else {
 				assert.NoError(t, err)
 				assert.NotNil(t, user)
-
-				// Compare key fields
 				assert.Equal(t, tt.expectUser.ID, user.ID)
 				assert.Equal(t, tt.expectUser.UserPrincipalName, user.UserPrincipalName)
 				assert.Equal(t, tt.expectUser.DisplayName, user.DisplayName)
@@ -778,32 +295,17 @@ func TestEntraIDDirectoryProvider_GetUser(t *testing.T) {
 				assert.Equal(t, tt.expectUser.Mail, user.Mail)
 				assert.Equal(t, tt.expectUser.Source, user.Source)
 			}
-
-			mockAuth.AssertExpectations(t)
-			mockGraph.AssertExpectations(t)
 		})
 	}
 }
 
 func TestEntraIDDirectoryProvider_SupportsOUs(t *testing.T) {
-	mockLogger := &MockLogger{}
-	mockAuth := &MockAuthProvider{}
-	mockGraph := &MockGraphClient{}
-
-	provider := NewEntraIDDirectoryProvider(mockLogger, mockAuth, mockGraph)
-
-	// Entra ID doesn't support OUs
+	provider := NewEntraIDDirectoryProvider(&stubLogger{}, &stubAuthProvider{}, &stubGraphClient{})
 	assert.False(t, provider.SupportsOUs())
 }
 
 func TestEntraIDDirectoryProvider_SupportsAdminUnits(t *testing.T) {
-	mockLogger := &MockLogger{}
-	mockAuth := &MockAuthProvider{}
-	mockGraph := &MockGraphClient{}
-
-	provider := NewEntraIDDirectoryProvider(mockLogger, mockAuth, mockGraph)
-
-	// Entra ID supports Administrative Units
+	provider := NewEntraIDDirectoryProvider(&stubLogger{}, &stubAuthProvider{}, &stubGraphClient{})
 	assert.True(t, provider.SupportsAdminUnits())
 }
 
@@ -827,10 +329,15 @@ func (s *stubLogger) WithContext(_ context.Context) interface{}                {
 func (s *stubLogger) Named(_ string) interface{}                               { return s }
 func (s *stubLogger) Sync() error                                              { return nil }
 
-// stubAuthProvider always returns a fixed token
-type stubAuthProvider struct{}
+// stubAuthProvider returns a fixed token by default; set getAccessTokenFn to override.
+type stubAuthProvider struct {
+	getAccessTokenFn func(ctx context.Context, tenantID string) (*auth.AccessToken, error)
+}
 
-func (s *stubAuthProvider) GetAccessToken(_ context.Context, _ string) (*auth.AccessToken, error) {
+func (s *stubAuthProvider) GetAccessToken(ctx context.Context, tenantID string) (*auth.AccessToken, error) {
+	if s.getAccessTokenFn != nil {
+		return s.getAccessTokenFn(ctx, tenantID)
+	}
 	return &auth.AccessToken{Token: "stub-token"}, nil
 }
 func (s *stubAuthProvider) GetDelegatedAccessToken(_ context.Context, _ string, _ *auth.UserContext) (*auth.AccessToken, error) {
@@ -858,6 +365,7 @@ type stubGraphClient struct {
 	addUserToGroupFn      func(ctx context.Context, token *auth.AccessToken, userID, groupName string) error
 	removeUserFromGroupFn func(ctx context.Context, token *auth.AccessToken, userID, groupName string) error
 	listGroupMembersFn    func(ctx context.Context, token *auth.AccessToken, groupID string) ([]string, error)
+	listUsersFn           func(ctx context.Context, token *auth.AccessToken, filter string) ([]graph.User, error)
 	getUserFn             func(ctx context.Context, token *auth.AccessToken, upn string) (*graph.User, error)
 	getAdminUnitFn        func(ctx context.Context, token *auth.AccessToken, unitID string) (*graph.AdministrativeUnit, error)
 	listAdminUnitsFn      func(ctx context.Context, token *auth.AccessToken, filter string) ([]graph.AdministrativeUnit, error)
@@ -873,7 +381,10 @@ func (s *stubGraphClient) GetUser(ctx context.Context, t *auth.AccessToken, u st
 	}
 	return &graph.User{ID: u, UserPrincipalName: u}, nil
 }
-func (s *stubGraphClient) ListUsers(_ context.Context, _ *auth.AccessToken, _ string) ([]graph.User, error) {
+func (s *stubGraphClient) ListUsers(ctx context.Context, t *auth.AccessToken, filter string) ([]graph.User, error) {
+	if s.listUsersFn != nil {
+		return s.listUsersFn(ctx, t, filter)
+	}
 	return nil, nil
 }
 func (s *stubGraphClient) CreateUser(_ context.Context, _ *auth.AccessToken, _ *graph.CreateUserRequest) (*graph.User, error) {
@@ -1303,6 +814,215 @@ func TestEntraIDDirectoryProvider_ListAdminUnits(t *testing.T) {
 	assert.Len(t, units, 2)
 	assert.Equal(t, "au-1", units[0].ID)
 	assert.Equal(t, "au-2", units[1].ID)
+}
+
+// --- SearchUsers tests ---
+
+func TestEntraIDDirectoryProvider_SearchUsers_NotConnected(t *testing.T) {
+	p := NewEntraIDDirectoryProvider(&stubLogger{}, &stubAuthProvider{}, &stubGraphClient{})
+	_, err := p.SearchUsers(context.Background(), &directory.SearchQuery{Query: "alice"})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "not connected")
+}
+
+func TestEntraIDDirectoryProvider_SearchUsers_EmptyQuery(t *testing.T) {
+	p := newConnectedProvider(&stubGraphClient{})
+	_, err := p.SearchUsers(context.Background(), &directory.SearchQuery{Query: ""})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "empty")
+}
+
+func TestEntraIDDirectoryProvider_SearchUsers_WhitespaceOnlyQuery(t *testing.T) {
+	p := newConnectedProvider(&stubGraphClient{})
+	_, err := p.SearchUsers(context.Background(), &directory.SearchQuery{Query: "   "})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "empty")
+}
+
+func TestEntraIDDirectoryProvider_SearchUsers_AuthTokenFailure(t *testing.T) {
+	p := NewEntraIDDirectoryProvider(&stubLogger{}, &stubAuthProvider{
+		getAccessTokenFn: func(_ context.Context, _ string) (*auth.AccessToken, error) {
+			return nil, errors.New("token expired")
+		},
+	}, &stubGraphClient{})
+	p.connected = true
+	p.config = &ProviderConfig{TenantID: "test-tenant"}
+
+	_, err := p.SearchUsers(context.Background(), &directory.SearchQuery{Query: "alice"})
+	assert.Error(t, err)
+}
+
+func TestEntraIDDirectoryProvider_SearchUsers_GraphError(t *testing.T) {
+	gc := &stubGraphClient{
+		listUsersFn: func(_ context.Context, _ *auth.AccessToken, _ string) ([]graph.User, error) {
+			return nil, errors.New("graph unavailable")
+		},
+	}
+	p := newConnectedProvider(gc)
+	_, err := p.SearchUsers(context.Background(), &directory.SearchQuery{Query: "alice"})
+	assert.Error(t, err)
+}
+
+func TestEntraIDDirectoryProvider_SearchUsers_FilterContainsQuery(t *testing.T) {
+	var capturedFilter string
+	gc := &stubGraphClient{
+		listUsersFn: func(_ context.Context, _ *auth.AccessToken, filter string) ([]graph.User, error) {
+			capturedFilter = filter
+			return []graph.User{{ID: "u1", DisplayName: "Alice", UserPrincipalName: "alice@example.com"}}, nil
+		},
+	}
+	p := newConnectedProvider(gc)
+	users, err := p.SearchUsers(context.Background(), &directory.SearchQuery{Query: "Alice"})
+	assert.NoError(t, err)
+	assert.Len(t, users, 1)
+	assert.Contains(t, capturedFilter, "Alice")
+	assert.Contains(t, capturedFilter, "startswith")
+	assert.Contains(t, capturedFilter, "displayName")
+	assert.Contains(t, capturedFilter, "userPrincipalName")
+}
+
+func TestEntraIDDirectoryProvider_SearchUsers_SanitizesQuotes(t *testing.T) {
+	var capturedFilter string
+	gc := &stubGraphClient{
+		listUsersFn: func(_ context.Context, _ *auth.AccessToken, filter string) ([]graph.User, error) {
+			capturedFilter = filter
+			return nil, nil
+		},
+	}
+	p := newConnectedProvider(gc)
+	_, err := p.SearchUsers(context.Background(), &directory.SearchQuery{Query: "O'Brien"})
+	assert.NoError(t, err)
+	assert.Contains(t, capturedFilter, "O''Brien") // single-quote doubled
+}
+
+func TestEntraIDDirectoryProvider_SearchUsers_MapsResultsToDirectoryUsers(t *testing.T) {
+	gc := &stubGraphClient{
+		listUsersFn: func(_ context.Context, _ *auth.AccessToken, _ string) ([]graph.User, error) {
+			return []graph.User{
+				{ID: "uid-1", DisplayName: "Alice Test", UserPrincipalName: "alice@example.com", Mail: "alice@example.com"},
+				{ID: "uid-2", DisplayName: "Bob Test", UserPrincipalName: "bob@example.com", Mail: "bob@example.com"},
+			}, nil
+		},
+	}
+	p := newConnectedProvider(gc)
+	users, err := p.SearchUsers(context.Background(), &directory.SearchQuery{Query: "Test"})
+	assert.NoError(t, err)
+	assert.Len(t, users, 2)
+	assert.Equal(t, "uid-1", users[0].ID)
+	assert.Equal(t, "Alice Test", users[0].DisplayName)
+	assert.Equal(t, "alice@example.com", users[0].UserPrincipalName)
+	assert.Equal(t, "entraid", users[0].Source)
+}
+
+// writeGraphResponse encodes v as JSON and writes it to w.
+func writeGraphResponse(t *testing.T, w http.ResponseWriter, v interface{}) {
+	t.Helper()
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(v); err != nil {
+		t.Errorf("writeGraphResponse: %v", err)
+	}
+}
+
+func TestEntraIDDirectoryProvider_SearchUsers_MockHTTPServer_SinglePage(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Contains(t, r.Header.Get("Authorization"), "Bearer")
+		filter := r.URL.Query().Get("$filter")
+		assert.Contains(t, filter, "startswith")
+		writeGraphResponse(t, w, map[string]interface{}{
+			"value": []map[string]interface{}{
+				{"id": "u1", "displayName": "John Doe", "userPrincipalName": "john@example.com", "mail": "john@example.com"},
+				{"id": "u2", "displayName": "John Smith", "userPrincipalName": "jsmith@example.com", "mail": "jsmith@example.com"},
+			},
+		})
+	}))
+	defer server.Close()
+
+	gc := graph.NewHTTPClient(graph.WithBaseURL(server.URL))
+	p := newConnectedProvider(gc)
+
+	users, err := p.SearchUsers(context.Background(), &directory.SearchQuery{Query: "John"})
+	assert.NoError(t, err)
+	assert.Len(t, users, 2)
+	assert.Equal(t, "u1", users[0].ID)
+	assert.Equal(t, "John Doe", users[0].DisplayName)
+}
+
+func TestEntraIDDirectoryProvider_SearchUsers_MockHTTPServer_MultiPage(t *testing.T) {
+	var serverURL string
+	callCount := 0
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		if r.URL.Query().Get("$skiptoken") == "" {
+			// First page: includes nextLink
+			writeGraphResponse(t, w, map[string]interface{}{
+				"@odata.nextLink": serverURL + "/users?$skiptoken=page2token&$select=id,displayName,userPrincipalName,mail",
+				"value": []map[string]interface{}{
+					{"id": "u1", "displayName": "Alice A", "userPrincipalName": "alice@example.com"},
+				},
+			})
+		} else {
+			// Second page: no nextLink
+			writeGraphResponse(t, w, map[string]interface{}{
+				"value": []map[string]interface{}{
+					{"id": "u2", "displayName": "Alice B", "userPrincipalName": "aliceb@example.com"},
+				},
+			})
+		}
+	}))
+	defer server.Close()
+	serverURL = server.URL
+
+	gc := graph.NewHTTPClient(graph.WithBaseURL(server.URL))
+	p := newConnectedProvider(gc)
+
+	users, err := p.SearchUsers(context.Background(), &directory.SearchQuery{Query: "Alice"})
+	assert.NoError(t, err)
+	assert.Len(t, users, 2)
+	assert.Equal(t, 2, callCount, "expected exactly 2 HTTP calls (initial page + nextLink page)")
+	assert.Equal(t, "u1", users[0].ID)
+	assert.Equal(t, "u2", users[1].ID)
+}
+
+func TestEntraIDDirectoryProvider_SearchUsers_MockHTTPServer_CapsAt1000(t *testing.T) {
+	var serverURL string
+	pageSize := 200
+	callCount := 0
+
+	// Build a page of users
+	makePage := func(offset int, count int) []map[string]interface{} {
+		users := make([]map[string]interface{}, count)
+		for i := 0; i < count; i++ {
+			n := offset + i
+			users[i] = map[string]interface{}{
+				"id":                fmt.Sprintf("u%d", n),
+				"displayName":       fmt.Sprintf("User %d", n),
+				"userPrincipalName": fmt.Sprintf("user%d@example.com", n),
+			}
+		}
+		return users
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		page := callCount
+		callCount++
+		offset := page * pageSize
+		// Always return a nextLink so we can verify capping behaviour
+		writeGraphResponse(t, w, map[string]interface{}{
+			"@odata.nextLink": serverURL + fmt.Sprintf("/users?$skiptoken=page%d", page+1),
+			"value":           makePage(offset, pageSize),
+		})
+	}))
+	defer server.Close()
+	serverURL = server.URL
+
+	gc := graph.NewHTTPClient(graph.WithBaseURL(server.URL))
+	p := newConnectedProvider(gc)
+
+	users, err := p.SearchUsers(context.Background(), &directory.SearchQuery{Query: "User"})
+	assert.NoError(t, err)
+	// With pageSize=200 and nextLink always present the loop stops exactly at 1000.
+	assert.Equal(t, 1000, len(users), "results must be capped at exactly 1000")
 }
 
 // Configuration validation is covered by the Connect tests above

--- a/features/modules/m365/graph/http_client.go
+++ b/features/modules/m365/graph/http_client.go
@@ -103,9 +103,11 @@ func (c *HTTPClient) GetUser(ctx context.Context, token *auth.AccessToken, userP
 	return &user, nil
 }
 
-// ListUsers retrieves users with optional OData filter
+// ListUsers retrieves users with optional OData filter. It follows @odata.nextLink
+// pages transparently and caps the total at 1000 results.
 func (c *HTTPClient) ListUsers(ctx context.Context, token *auth.AccessToken, filter string) ([]User, error) {
-	// Explicitly select all the fields we need to ensure they're returned
+	const maxResults = 1000
+
 	selectFields := "id,userPrincipalName,displayName,mailNickname,accountEnabled,mail,mobilePhone,officeLocation,jobTitle,department,companyName,createdDateTime"
 
 	var endpoint string
@@ -115,15 +117,36 @@ func (c *HTTPClient) ListUsers(ctx context.Context, token *auth.AccessToken, fil
 		endpoint = fmt.Sprintf("/users?$select=%s", selectFields)
 	}
 
-	var response struct {
-		Value []User `json:"value"`
+	var allUsers []User
+	for {
+		var response struct {
+			Value    []User `json:"value"`
+			NextLink string `json:"@odata.nextLink"`
+		}
+
+		if err := c.makeRequest(ctx, token, "GET", endpoint, nil, &response); err != nil {
+			return nil, fmt.Errorf("failed to list users: %w", err)
+		}
+
+		allUsers = append(allUsers, response.Value...)
+
+		if response.NextLink == "" || len(allUsers) >= maxResults {
+			break
+		}
+
+		// Extract the relative path from the absolute nextLink URL so makeRequest
+		// can prepend its own baseURL (which may differ in tests).
+		if !strings.HasPrefix(response.NextLink, c.baseURL) {
+			break
+		}
+		endpoint = response.NextLink[len(c.baseURL):]
 	}
 
-	if err := c.makeRequest(ctx, token, "GET", endpoint, nil, &response); err != nil {
-		return nil, fmt.Errorf("failed to list users: %w", err)
+	if len(allUsers) > maxResults {
+		allUsers = allUsers[:maxResults]
 	}
 
-	return response.Value, nil
+	return allUsers, nil
 }
 
 // CreateUser creates a new user


### PR DESCRIPTION
## Summary

- `SearchUsers()` now sends a `startswith(displayName,'X') or startswith(userPrincipalName,'X')` OData filter to the Microsoft Graph `/v1.0/users` endpoint instead of returning an empty slice
- `ListUsers` in the Graph HTTP client transparently follows `@odata.nextLink` pages up to a hard cap of 1000 results
- Empty/whitespace queries are rejected to prevent accidentally fetching all tenant users; single quotes are doubled to prevent OData injection

## Changes

**`features/modules/m365/directory_provider.go`**
- Implement `SearchUsers`: validates query, sanitizes OData input, calls `graphClient.ListUsers`, maps results to `DirectoryUser`

**`features/modules/m365/graph/http_client.go`**
- Add transparent pagination to `ListUsers`: captures `@odata.nextLink`, strips configured `baseURL` prefix to get a relative path, loops until no next link or 1000-result cap is reached

**`features/modules/m365/directory_provider_test.go`**
- 11 new `SearchUsers` tests: not-connected, empty query, whitespace query, auth failure, graph error, filter shape verification, quote sanitization, result mapping, mock HTTP server single-page, mock HTTP server multi-page pagination (callCount assertion), exact 1000-result cap
- Remove pre-existing `testify/mock`-backed types (`MockLogger`, `MockAuthProvider`, `MockGraphClient`) and rewrite their four dependent tests using `stubLogger`/`stubAuthProvider`/`stubGraphClient` — DSD remediation for modified file
- Extend `stubAuthProvider` with configurable `getAccessTokenFn` to support auth-failure test cases

## Specialist Review Results

| Reviewer | Result | Notes |
|----------|--------|-------|
| QA Test Runner | **PASS** | All 11 SearchUsers tests pass; `make test-agent-complete` 136/136 |
| QA Code Reviewer | **PASS** (2nd pass) | Blocking issue (mock framework) resolved; 2 non-blocking warnings |
| Security Engineer | **PASS** | OData injection prevention verified; SSRF surface bounded; no hardcoded secrets |

## Test plan

- [x] `go test ./features/modules/m365/ -run TestEntraIDDirectoryProvider_SearchUsers -v` — 11/11 pass
- [x] `go test ./features/modules/m365/ -count=1` — all unit tests pass (integration tests require M365 credentials, pre-existing skip)
- [x] `make test` — 136/136 pass
- [x] AC1: OData filter sent, results returned ✓
- [x] AC2: Multi-page results fetched (mock HTTP server test with nextLink + callCount==2 assertion) ✓
- [x] AC3: Empty query returns error ✓
- [x] AC4: `make test-complete` passes ✓

Fixes #1613

🤖 Generated with [Claude Code](https://claude.com/claude-code)