### PR TITLE
rollback: wire real CPU/disk metrics into checkSystemHealth (Issue #1601)

### DIFF
--- a/features/config/rollback/validator.go
+++ b/features/config/rollback/validator.go
@@ -11,6 +11,8 @@ import (
 	"github.com/cfgis/cfgms/api/proto/common"
 	"github.com/cfgis/cfgms/features/rbac"
 	"github.com/cfgis/cfgms/pkg/ctxkeys"
+	"github.com/shirou/gopsutil/v3/cpu"
+	"github.com/shirou/gopsutil/v3/disk"
 )
 
 // DefaultRollbackValidator implements the RollbackValidator interface
@@ -133,7 +135,7 @@ func (v *DefaultRollbackValidator) ValidateRollback(ctx context.Context, request
 	}
 
 	// Check system health
-	healthIssues := v.checkSystemHealth(ctx, request.TargetType, request.TargetID)
+	healthIssues, cpuUsage, diskUsage := v.checkSystemHealth(ctx, request.TargetType, request.TargetID)
 	if len(healthIssues) > 0 {
 		results.Warnings = append(results.Warnings, healthIssues...)
 	}
@@ -141,6 +143,8 @@ func (v *DefaultRollbackValidator) ValidateRollback(ctx context.Context, request
 	// Add validation metadata
 	results.Metadata["validation_time"] = time.Now()
 	results.Metadata["validator_version"] = "1.0.0"
+	results.Metadata["cpu_usage_percent"] = cpuUsage
+	results.Metadata["disk_usage_percent"] = diskUsage
 
 	return results, nil
 }
@@ -411,35 +415,44 @@ func (v *DefaultRollbackValidator) validatePermissions(ctx context.Context, requ
 	return nil
 }
 
-func (v *DefaultRollbackValidator) checkSystemHealth(ctx context.Context, targetType TargetType, targetID string) []ValidationIssue {
-	issues := []ValidationIssue{}
+func (v *DefaultRollbackValidator) checkSystemHealth(_ context.Context, _ TargetType, _ string) ([]ValidationIssue, float64, float64) {
+	cpuPercents, err := cpu.Percent(500*time.Millisecond, false)
+	var cpuUsage float64
+	if err == nil && len(cpuPercents) > 0 {
+		cpuUsage = cpuPercents[0]
+	}
 
-	// Deferred: tracked in #1440 — query real CPU/disk metrics from steward DNA hardware attributes
+	var diskUsage float64
+	if stat, err := disk.Usage("/"); err == nil {
+		diskUsage = stat.UsedPercent
+	}
 
-	// Check CPU usage
-	cpuUsage := 75 // Simulated
-	if cpuUsage > 80 {
+	return EvaluateSystemHealthMetrics(cpuUsage, diskUsage), cpuUsage, diskUsage
+}
+
+// EvaluateSystemHealthMetrics applies health thresholds to CPU and disk usage values and
+// returns any validation issues. Exported so tests can exercise threshold logic directly
+// without requiring a live OS probe.
+func EvaluateSystemHealthMetrics(cpuPercent, diskPercent float64) []ValidationIssue {
+	var issues []ValidationIssue
+	if cpuPercent > 90 {
 		issues = append(issues, ValidationIssue{
 			Type:       "system_health",
 			Severity:   "warning",
-			Message:    fmt.Sprintf("High CPU usage detected: %d%%", cpuUsage),
+			Message:    fmt.Sprintf("High CPU usage detected: %.1f%%", cpuPercent),
 			Resolvable: true,
 			Resolution: "Wait for CPU usage to decrease or proceed with caution",
 		})
 	}
-
-	// Check available disk space
-	diskFree := 15 // Simulated percentage
-	if diskFree < 20 {
+	if diskPercent > 95 {
 		issues = append(issues, ValidationIssue{
 			Type:       "system_health",
 			Severity:   "warning",
-			Message:    fmt.Sprintf("Low disk space: %d%% free", diskFree),
+			Message:    fmt.Sprintf("High disk usage detected: %.1f%% used", diskPercent),
 			Resolvable: true,
 			Resolution: "Free up disk space before proceeding",
 		})
 	}
-
 	return issues
 }
 

--- a/features/config/rollback/validator_test.go
+++ b/features/config/rollback/validator_test.go
@@ -12,8 +12,8 @@ import (
 	"github.com/cfgis/cfgms/api/proto/common"
 	"github.com/cfgis/cfgms/features/config/rollback"
 	"github.com/cfgis/cfgms/features/rbac"
-	pkgtesting "github.com/cfgis/cfgms/pkg/testing"
 	"github.com/cfgis/cfgms/pkg/ctxkeys"
+	pkgtesting "github.com/cfgis/cfgms/pkg/testing"
 )
 
 // ctxWithCaller injects the UserIDKey and TenantID context values that validatePermissions reads.
@@ -214,6 +214,78 @@ func TestValidatePermissions_MSPRollback_Granted(t *testing.T) {
 			"caller with rollback.msp must not receive a permission error")
 	}
 	assert.True(t, result.Passed)
+}
+
+// TestCheckSystemHealth_ReturnsRealMetrics verifies that ValidateRollback populates
+// cpu_usage_percent and disk_usage_percent in Metadata from real OS probes (not hardcoded).
+func TestCheckSystemHealth_ReturnsRealMetrics(t *testing.T) {
+	validator := rollback.NewRollbackValidator(&noopModuleRegistry{}, nil, nil)
+
+	request := rollback.RollbackRequest{
+		TargetType:   rollback.TargetTypeDevice,
+		TargetID:     "device-1",
+		RollbackType: rollback.RollbackTypeFull,
+		RollbackTo:   "v1.0",
+	}
+
+	result, err := validator.ValidateRollback(context.Background(), request, nil)
+	require.NoError(t, err)
+
+	cpuVal, ok := result.Metadata["cpu_usage_percent"]
+	require.True(t, ok, "cpu_usage_percent must be present in Metadata")
+	cpuPct, ok := cpuVal.(float64)
+	require.True(t, ok, "cpu_usage_percent must be float64")
+	assert.GreaterOrEqual(t, cpuPct, 0.0, "CPU percent must be >= 0")
+	assert.LessOrEqual(t, cpuPct, 100.0, "CPU percent must be <= 100")
+
+	diskVal, ok := result.Metadata["disk_usage_percent"]
+	require.True(t, ok, "disk_usage_percent must be present in Metadata")
+	diskPct, ok := diskVal.(float64)
+	require.True(t, ok, "disk_usage_percent must be float64")
+	assert.Greater(t, diskPct, 0.0, "disk percent must be > 0 (container has data on disk)")
+	assert.LessOrEqual(t, diskPct, 100.0, "disk percent must be <= 100")
+}
+
+// TestEvaluateSystemHealthMetrics_HighCPU verifies that CPU usage above 90% produces a warning.
+func TestEvaluateSystemHealthMetrics_HighCPU(t *testing.T) {
+	issues := rollback.EvaluateSystemHealthMetrics(91.5, 50.0)
+	require.Len(t, issues, 1)
+	assert.Equal(t, "system_health", issues[0].Type)
+	assert.Equal(t, "warning", issues[0].Severity)
+	assert.Contains(t, issues[0].Message, "CPU")
+}
+
+// TestEvaluateSystemHealthMetrics_HighDisk verifies that disk usage above 95% produces a warning.
+func TestEvaluateSystemHealthMetrics_HighDisk(t *testing.T) {
+	issues := rollback.EvaluateSystemHealthMetrics(50.0, 96.0)
+	require.Len(t, issues, 1)
+	assert.Equal(t, "system_health", issues[0].Type)
+	assert.Equal(t, "warning", issues[0].Severity)
+	assert.Contains(t, issues[0].Message, "disk")
+}
+
+// TestEvaluateSystemHealthMetrics_Healthy verifies that normal CPU and disk usage produces no issues.
+func TestEvaluateSystemHealthMetrics_Healthy(t *testing.T) {
+	issues := rollback.EvaluateSystemHealthMetrics(50.0, 60.0)
+	assert.Empty(t, issues)
+}
+
+// TestEvaluateSystemHealthMetrics_BothUnhealthy verifies that CPU and disk thresholds can both trigger.
+func TestEvaluateSystemHealthMetrics_BothUnhealthy(t *testing.T) {
+	issues := rollback.EvaluateSystemHealthMetrics(95.0, 97.0)
+	require.Len(t, issues, 2)
+	assert.Equal(t, "system_health", issues[0].Type)
+	assert.Equal(t, "system_health", issues[1].Type)
+}
+
+// TestEvaluateSystemHealthMetrics_AtThreshold verifies behavior exactly at the threshold boundaries.
+func TestEvaluateSystemHealthMetrics_AtThreshold(t *testing.T) {
+	// Exactly at threshold — not unhealthy (>90, not >=90)
+	assert.Empty(t, rollback.EvaluateSystemHealthMetrics(90.0, 95.0))
+	// One tick above CPU threshold
+	assert.Len(t, rollback.EvaluateSystemHealthMetrics(90.1, 50.0), 1)
+	// One tick above disk threshold
+	assert.Len(t, rollback.EvaluateSystemHealthMetrics(50.0, 95.1), 1)
 }
 
 // TestValidatePermissions_StandardRollback_NoCheck verifies that a standard (non-emergency,


### PR DESCRIPTION
## Summary

- Replace hardcoded CPU/disk values in `checkSystemHealth()` with real `gopsutil/v3` OS probes (`cpu.Percent(500ms)` and `disk.Usage("/")`)
- Add exported `EvaluateSystemHealthMetrics(cpuPercent, diskPercent float64)` for testable threshold logic (CPU >90% or disk >95% used → warning)
- Store `cpu_usage_percent` and `disk_usage_percent` in `ValidationResults.Metadata` so callers can inspect the live values
- Add 6 tests covering real probe execution, threshold boundaries (above/at/below), both-unhealthy, and healthy states

Fixes #1601

## Specialist Review Results

**QA Test Runner: PASS**
- All quality validation gates passed (`make test-agent-complete`)
- 6 new story tests all pass with `-race` on linux/amd64
- Cross-platform compilation: linux/amd64, linux/arm64, darwin/amd64, darwin/arm64, windows/amd64 — all PASS

**QA Code Reviewer: PASS**
- 0 blocking issues
- Warnings (non-blocking): 500ms CPU sample interval adds latency to `TestCheckSystemHealth_ReturnsRealMetrics`; disk >0 assertion assumes container has data on `/`

**Security Engineer: PASS**
- `security-precommit`: PASS
- `check-architecture`: PASS — no central provider violations
- `security-scan`: PASS — "DEPLOYMENT APPROVED"
- No hardcoded secrets, SQL injection, information disclosure, or insecure defaults

## Test plan

- [ ] `go test ./features/config/rollback/... -race` — all pass
- [ ] `TestCheckSystemHealth_ReturnsRealMetrics` — `cpu_usage_percent` and `disk_usage_percent` in Metadata are float64 values in [0,100] with disk >0
- [ ] `TestEvaluateSystemHealthMetrics_*` — threshold logic: high CPU, high disk, healthy, both unhealthy, boundary cases
- [ ] `make test-agent-complete` — full suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)