### PR TITLE
config: wire real TenantStore lookup into validateTenantContext (Issue #1618)

### DIFF
--- a/features/config/rollback/validator_test.go
+++ b/features/config/rollback/validator_test.go
@@ -12,8 +12,8 @@ import (
 	"github.com/cfgis/cfgms/api/proto/common"
 	"github.com/cfgis/cfgms/features/config/rollback"
 	"github.com/cfgis/cfgms/features/rbac"
-	pkgtesting "github.com/cfgis/cfgms/pkg/testing"
 	"github.com/cfgis/cfgms/pkg/ctxkeys"
+	pkgtesting "github.com/cfgis/cfgms/pkg/testing"
 )
 
 // ctxWithCaller injects the UserIDKey and TenantID context values that validatePermissions reads.

--- a/features/controller/service/config_service_v2.go
+++ b/features/controller/service/config_service_v2.go
@@ -53,7 +53,7 @@ func NewConfigurationServiceV2(logger logging.Logger, storageManager *interfaces
 		logger:              logger,
 		configManager:       config.NewManagerWithStorageManager(storageManager),
 		inheritanceResolver: config.NewInheritanceResolver(router, storageManager.GetClientTenantStore(), storageManager.GetTenantStore()),
-		validationManager:   config.NewValidationManager(storageManager.GetConfigStore()),
+		validationManager:   config.NewValidationManager(storageManager.GetConfigStore(), storageManager.GetTenantStore()),
 		controllerSvc:       controllerSvc,
 		storageManager:      storageManager,
 	}

--- a/pkg/config/manager_test.go
+++ b/pkg/config/manager_test.go
@@ -25,7 +25,7 @@ func newTestManager(t *testing.T) *Manager {
 func newTestValidationManager(t *testing.T) *ValidationManager {
 	t.Helper()
 	sm := pkgtesting.SetupTestStorage(t)
-	return NewValidationManager(sm.GetConfigStore())
+	return NewValidationManager(sm.GetConfigStore(), sm.GetTenantStore())
 }
 
 func TestManagerStoreAndGetConfiguration(t *testing.T) {

--- a/pkg/config/validation.go
+++ b/pkg/config/validation.go
@@ -11,18 +11,21 @@ import (
 	"gopkg.in/yaml.v3"
 
 	stewardconfig "github.com/cfgis/cfgms/features/steward/config"
+	"github.com/cfgis/cfgms/pkg/storage/interfaces/business"
 	cfgconfig "github.com/cfgis/cfgms/pkg/storage/interfaces/config"
 )
 
 // ValidationManager handles configuration validation before storage
 type ValidationManager struct {
 	configStore cfgconfig.ConfigStore
+	tenantStore business.TenantStore
 }
 
 // NewValidationManager creates a new validation manager
-func NewValidationManager(configStore cfgconfig.ConfigStore) *ValidationManager {
+func NewValidationManager(configStore cfgconfig.ConfigStore, tenantStore business.TenantStore) *ValidationManager {
 	return &ValidationManager{
 		configStore: configStore,
+		tenantStore: tenantStore,
 	}
 }
 
@@ -88,7 +91,19 @@ func (vm *ValidationManager) ValidateConfiguration(ctx context.Context, tenantID
 	}
 
 	// Validate tenant context
-	result.TenantChecks = vm.validateTenantContext(ctx, tenantID, stewardID, config)
+	tenantChecks, tenantErr := vm.validateTenantContext(ctx, tenantID, stewardID, config)
+	if tenantErr != nil {
+		result.Valid = false
+		result.Errors = append(result.Errors, ValidationError{
+			Field:   "tenant_id",
+			Message: fmt.Sprintf("Tenant lookup failed: %v", tenantErr),
+			Code:    "TENANT_LOOKUP_ERROR",
+			Level:   "error",
+		})
+		result.TenantChecks = &TenantValidationResult{TenantID: tenantID}
+	} else {
+		result.TenantChecks = tenantChecks
+	}
 
 	// Validate module dependencies
 	result.DependencyChecks = vm.validateDependencies(ctx, config)
@@ -132,18 +147,31 @@ func (vm *ValidationManager) ValidateConfiguration(ctx context.Context, tenantID
 	return result
 }
 
-// validateTenantContext validates tenant-related aspects of the configuration
-func (vm *ValidationManager) validateTenantContext(ctx context.Context, tenantID, stewardID string, config *stewardconfig.StewardConfig) *TenantValidationResult {
+// validateTenantContext validates tenant-related aspects of the configuration.
+// Returns (result, nil) when the tenant exists or is simply absent from the store.
+// Returns (nil, err) only on a real store error (not a not-found condition).
+func (vm *ValidationManager) validateTenantContext(ctx context.Context, tenantID, stewardID string, config *stewardconfig.StewardConfig) (*TenantValidationResult, error) {
 	result := &TenantValidationResult{
-		TenantExists:      true,
+		TenantExists:      false,
 		TenantID:          tenantID,
 		InheritanceValid:  true,
 		ConflictsDetected: 0,
 	}
 
-	// Deferred: tracked in #1443 — query ClientTenantStore, validate inheritance chain, check conflicts
+	if tenantID == "" {
+		return result, nil
+	}
 
-	return result
+	_, err := vm.tenantStore.GetTenant(ctx, tenantID)
+	if err != nil {
+		if strings.Contains(err.Error(), "not found") {
+			return result, nil
+		}
+		return nil, fmt.Errorf("tenant store lookup failed: %w", err)
+	}
+
+	result.TenantExists = true
+	return result, nil
 }
 
 // validateDependencies validates module dependencies and availability

--- a/pkg/config/validation_test.go
+++ b/pkg/config/validation_test.go
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+package config
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	stewardconfig "github.com/cfgis/cfgms/features/steward/config"
+	"github.com/cfgis/cfgms/pkg/storage/interfaces/business"
+	pkgtesting "github.com/cfgis/cfgms/pkg/testing"
+)
+
+// minimalValidConfig returns a StewardConfig that passes basic validation.
+func minimalValidConfig() *stewardconfig.StewardConfig {
+	return &stewardconfig.StewardConfig{
+		Steward: stewardconfig.StewardSettings{
+			ID:   "steward-1",
+			Mode: stewardconfig.ModeStandalone,
+			Logging: stewardconfig.LoggingConfig{
+				Level: "info",
+			},
+		},
+	}
+}
+
+func TestValidateTenantContext_TenantExists(t *testing.T) {
+	sm := pkgtesting.SetupTestStorage(t)
+	ctx := context.Background()
+
+	require.NoError(t, sm.GetTenantStore().CreateTenant(ctx, &business.TenantData{
+		ID:     "acme-corp",
+		Name:   "Acme Corp",
+		Status: business.TenantStatusActive,
+	}))
+
+	vm := NewValidationManager(sm.GetConfigStore(), sm.GetTenantStore())
+	result := vm.ValidateConfiguration(ctx, "acme-corp", "steward-1", minimalValidConfig())
+
+	require.NotNil(t, result.TenantChecks)
+	assert.True(t, result.TenantChecks.TenantExists)
+	assert.Equal(t, "acme-corp", result.TenantChecks.TenantID)
+}
+
+func TestValidateTenantContext_TenantNotFound(t *testing.T) {
+	sm := pkgtesting.SetupTestStorage(t)
+	vm := NewValidationManager(sm.GetConfigStore(), sm.GetTenantStore())
+	ctx := context.Background()
+
+	result := vm.ValidateConfiguration(ctx, "nonexistent-tenant", "steward-1", minimalValidConfig())
+
+	require.NotNil(t, result.TenantChecks)
+	assert.False(t, result.TenantChecks.TenantExists)
+	for _, e := range result.Errors {
+		assert.NotEqual(t, "TENANT_LOOKUP_ERROR", e.Code, "not-found must not produce a TENANT_LOOKUP_ERROR")
+	}
+}
+
+func TestValidateTenantContext_EmptyTenantID(t *testing.T) {
+	sm := pkgtesting.SetupTestStorage(t)
+	vm := NewValidationManager(sm.GetConfigStore(), sm.GetTenantStore())
+	ctx := context.Background()
+
+	result := vm.ValidateConfiguration(ctx, "", "steward-1", minimalValidConfig())
+
+	require.NotNil(t, result.TenantChecks)
+	assert.False(t, result.TenantChecks.TenantExists)
+	for _, e := range result.Errors {
+		assert.NotEqual(t, "TENANT_LOOKUP_ERROR", e.Code, "empty tenantID must not trigger a store lookup error")
+	}
+}
+
+func TestValidateTenantContext_StoreError(t *testing.T) {
+	sm := pkgtesting.SetupTestStorage(t)
+	vm := NewValidationManager(sm.GetConfigStore(), sm.GetTenantStore())
+
+	// Force a real store error by closing the underlying database.
+	_ = sm.Close()
+
+	result := vm.ValidateConfiguration(context.Background(), "some-tenant", "steward-1", minimalValidConfig())
+
+	assert.False(t, result.Valid)
+	codes := make([]string, 0, len(result.Errors))
+	for _, e := range result.Errors {
+		codes = append(codes, e.Code)
+	}
+	assert.Contains(t, codes, "TENANT_LOOKUP_ERROR")
+}

--- a/pkg/controlplane/providers/grpc/provider_register_identity_test.go
+++ b/pkg/controlplane/providers/grpc/provider_register_identity_test.go
@@ -90,7 +90,7 @@ func (s *inMemoryTokenStore) ConsumeToken(_ context.Context, tokenStr, stewardID
 }
 
 func (s *inMemoryTokenStore) Initialize(_ context.Context) error { return nil }
-func (s *inMemoryTokenStore) Close() error                        { return nil }
+func (s *inMemoryTokenStore) Close() error                       { return nil }
 
 // compile-time assertion
 var _ business.RegistrationTokenStore = (*inMemoryTokenStore)(nil)


### PR DESCRIPTION
## Summary

- Replaces the hardcoded `TenantExists: true` stub in `validateTenantContext()` with a real `TenantStore.GetTenant()` lookup
- A missing tenant returns `TenantExists: false` (not an error); a store failure sets `result.Valid = false` with code `TENANT_LOOKUP_ERROR`
- Adds `tenantStore business.TenantStore` to `ValidationManager` via constructor injection; updates the one call site in `config_service_v2.go`
- Adds `pkg/config/validation_test.go` with 4 tests covering: tenant exists, tenant not found, empty tenantID, and store error

Fixes #1618

## Specialist Review Results

| Reviewer | Result | Notes |
|----------|--------|-------|
| QA Test Runner | **PASS** | All tests pass; pre-existing gofmt issues from prior stories fixed |
| QA Code Reviewer | **PASS** | No blocking issues; added empty-tenantID test per reviewer suggestion |
| Security Engineer | **PASS** | No blocking issues; `strings.Contains("not found")` fragility and raw error in message are non-blocking warnings |

## Test Plan

- [ ] `go test ./pkg/config/... -v -run TestValidateTenantContext` — 4 tests pass
- [ ] `make test-agent-complete` — all gates pass
- [ ] New test `TestValidateTenantContext_TenantExists` creates a real tenant and verifies `TenantExists: true`
- [ ] New test `TestValidateTenantContext_TenantNotFound` verifies absent tenant returns `TenantExists: false` with no error
- [ ] New test `TestValidateTenantContext_EmptyTenantID` verifies empty tenant skips store lookup cleanly
- [ ] New test `TestValidateTenantContext_StoreError` closes the DB and verifies `TENANT_LOOKUP_ERROR` is emitted

🤖 Generated with [Claude Code](https://claude.com/claude-code)