### PR TITLE
tech-debt: wire output channel in terminal websocket ping loop (Issue #1443-B-1)

### DIFF
--- a/features/terminal/session.go
+++ b/features/terminal/session.go
@@ -56,6 +56,8 @@ func NewSession(req *SessionRequest, logger logging.Logger) (*Session, error) {
 		LastActivity: now,
 		Environment:  req.Env,
 		closed:       false,
+		outputCh:     make(chan []byte, 64),
+		logger:       logger,
 	}
 
 	// Initialize shell executor
@@ -132,6 +134,14 @@ func (s *Session) HandleOutput(ctx context.Context, data []byte) error {
 			// Log error but don't fail the operation
 			_ = err // Explicitly ignore recording errors for resilience
 		}
+	}
+
+	// Relay to WebSocket client. Non-blocking: drop and warn when the consumer is slow.
+	select {
+	case s.outputCh <- data:
+	default:
+		s.logger.Warn("Terminal output dropped; WebSocket client is not consuming output fast enough",
+			"session_id", logging.RedactedID(s.ID))
 	}
 
 	return nil
@@ -336,4 +346,13 @@ func (s *Session) GetErrorChannel() <-chan error {
 		return nil
 	}
 	return s.executor.ErrorChannel()
+}
+
+// OutputChan returns the session-level relay channel that carries steward output
+// destined for the WebSocket client. Writers use HandleOutput; readers are
+// WebSocket write loops. The channel is buffered; messages are dropped (with a
+// warning log) when the buffer is full so a slow consumer never stalls the
+// steward output path.
+func (s *Session) OutputChan() <-chan []byte {
+	return s.outputCh
 }

--- a/features/terminal/session.go
+++ b/features/terminal/session.go
@@ -353,6 +353,11 @@ func (s *Session) GetErrorChannel() <-chan error {
 // WebSocket write loops. The channel is buffered; messages are dropped (with a
 // warning log) when the buffer is full so a slow consumer never stalls the
 // steward output path.
+//
+// The channel is intentionally never closed: HandleOutput may be invoked from
+// handleShellOutput after Close, so closing would risk a send-on-closed panic.
+// Readers must detect session termination via context cancellation, not a
+// channel-close signal.
 func (s *Session) OutputChan() <-chan []byte {
 	return s.outputCh
 }

--- a/features/terminal/types.go
+++ b/features/terminal/types.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/cfgis/cfgms/features/terminal/shell"
+	"github.com/cfgis/cfgms/pkg/logging"
 )
 
 // MessageType represents the type of WebSocket message
@@ -66,6 +67,8 @@ type Session struct {
 	closed       bool
 	recorder     Recorder
 	executor     shell.Executor
+	outputCh     chan []byte // buffered relay channel: steward → WebSocket client
+	logger       logging.Logger
 	mu           sync.RWMutex // Mutex for thread-safe access to session fields
 }
 

--- a/features/terminal/websocket.go
+++ b/features/terminal/websocket.go
@@ -266,6 +266,19 @@ func (h *DefaultWebSocketHandler) writeMessages(ctx context.Context, conn *webso
 			return
 		case <-done:
 			return
+		case data := <-session.OutputChan():
+			if err := conn.SetWriteDeadline(time.Now().Add(10 * time.Second)); err != nil {
+				_ = err // Explicitly ignore deadline errors for resilience
+			}
+			msg := &TerminalMessage{
+				Type:      MessageTypeData,
+				Data:      data,
+				Timestamp: time.Now(),
+			}
+			if err := conn.WriteJSON(msg); err != nil {
+				h.logger.Warn("Failed to send terminal output", "session_id", logging.RedactedID(session.ID), "error", err)
+				return
+			}
 		case <-ticker.C:
 			if err := conn.SetWriteDeadline(time.Now().Add(10 * time.Second)); err != nil {
 				// Log error but continue
@@ -275,7 +288,6 @@ func (h *DefaultWebSocketHandler) writeMessages(ctx context.Context, conn *webso
 				h.logger.Warn("Failed to send ping", "session_id", logging.RedactedID(session.ID), "error", err)
 				return
 			}
-			// Deferred: tracked in #1443 — stream steward output channel to the WebSocket client
 		}
 	}
 }

--- a/features/terminal/websocket_test.go
+++ b/features/terminal/websocket_test.go
@@ -636,6 +636,120 @@ func (l *failListener) setAllFailWrites(v bool) {
 	}
 }
 
+// TestWebSocketStewardOutputRelay verifies that data injected via session.HandleOutput
+// is forwarded to the connected WebSocket client in real time.
+func TestWebSocketStewardOutputRelay(t *testing.T) {
+	capLogger := &kvCapturingLogger{}
+	config := &Config{
+		SessionTimeout: 30 * time.Minute,
+		MaxSessions:    100,
+		RecordSessions: true,
+	}
+
+	manager, err := NewSessionManager(config, capLogger)
+	require.NoError(t, err)
+
+	handler, err := NewWebSocketHandler(manager, capLogger, nil)
+	require.NoError(t, err)
+
+	server := httptest.NewServer(withTestTenant(http.HandlerFunc(handler.HandleWebSocket)))
+	defer server.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http")
+	headers := http.Header{"Origin": {server.URL}}
+	conn, _, err := websocket.DefaultDialer.Dial(
+		wsURL+"?steward_id=test-steward&user_id=test-user&shell="+getTestShell(),
+		headers,
+	)
+	require.NoError(t, err)
+	defer func() { _ = conn.Close() }()
+
+	waitForActiveSessions(t, manager, 1)
+	sessions := manager.GetActiveSessions()
+	require.Len(t, sessions, 1)
+	session := sessions[0]
+
+	// Inject steward output directly; simulates data arriving from the steward.
+	testOutput := []byte("CFGMS_TEST_OUTPUT_SENTINEL_12345")
+	err = session.HandleOutput(context.Background(), testOutput)
+	require.NoError(t, err)
+
+	// Poll WebSocket messages until the sentinel arrives.
+	deadline := time.Now().Add(2 * time.Second)
+	found := false
+	for time.Now().Before(deadline) && !found {
+		if setErr := conn.SetReadDeadline(time.Now().Add(200 * time.Millisecond)); setErr != nil {
+			t.Logf("Failed to set read deadline: %v", setErr)
+		}
+		var msg TerminalMessage
+		if readErr := conn.ReadJSON(&msg); readErr != nil {
+			continue
+		}
+		if msg.Type == MessageTypeData && string(msg.Data) == string(testOutput) {
+			found = true
+		}
+	}
+	assert.True(t, found, "steward output must be relayed to the WebSocket client")
+}
+
+// TestWebSocketSlowClientDoesNotBlockOutput verifies that HandleOutput returns
+// without blocking even when the output channel buffer is saturated, so a slow
+// WebSocket consumer cannot stall the steward output path.
+func TestWebSocketSlowClientDoesNotBlockOutput(t *testing.T) {
+	capLogger := &kvCapturingLogger{}
+	config := &Config{
+		SessionTimeout: 30 * time.Minute,
+		MaxSessions:    100,
+		RecordSessions: true,
+	}
+
+	manager, err := NewSessionManager(config, capLogger)
+	require.NoError(t, err)
+
+	handler, err := NewWebSocketHandler(manager, capLogger, nil)
+	require.NoError(t, err)
+
+	server := httptest.NewServer(withTestTenant(http.HandlerFunc(handler.HandleWebSocket)))
+	defer server.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http")
+	headers := http.Header{"Origin": {server.URL}}
+	conn, _, err := websocket.DefaultDialer.Dial(
+		wsURL+"?steward_id=test-steward&user_id=test-user&shell="+getTestShell(),
+		headers,
+	)
+	require.NoError(t, err)
+	defer func() { _ = conn.Close() }()
+
+	waitForActiveSessions(t, manager, 1)
+	sessions := manager.GetActiveSessions()
+	require.Len(t, sessions, 1)
+	session := sessions[0]
+
+	// Flood HandleOutput with far more messages than the channel buffer capacity.
+	// A blocking implementation would deadlock here once outputCh is full.
+	// The non-blocking select/default must return for every call regardless of
+	// how fast the WebSocket consumer drains the buffer.
+	ctx := context.Background()
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for i := 0; i < 1000; i++ {
+			if err := session.HandleOutput(ctx, []byte("x")); err != nil {
+				t.Errorf("HandleOutput returned unexpected error: %v", err)
+				return
+			}
+		}
+	}()
+
+	select {
+	case <-done:
+		// All 1000 calls completed — non-blocking behaviour confirmed.
+	case <-time.After(10 * time.Second):
+		t.Fatal("HandleOutput blocked: 1000 iterations did not complete within 10 s; likely blocking on full output channel")
+	}
+}
+
 // TestWebSocketSessionIDRedaction_Established verifies that the Info log
 // "WebSocket terminal session established" passes session_id through RedactedID.
 func TestWebSocketSessionIDRedaction_Established(t *testing.T) {


### PR DESCRIPTION
Fixes #1608

Agent session failed with exit code 1. Review container logs for details.