### PR TITLE
diff/approval: implement webhook delivery for approval notifications (Issue #1624)

### DIFF
--- a/features/config/diff/approval.go
+++ b/features/config/diff/approval.go
@@ -4,14 +4,105 @@
 package diff
 
 import (
+	"bytes"
 	"context"
 	"crypto/rand"
+	"encoding/json"
 	"fmt"
+	"io"
+	"net/http"
+	"net/url"
 	"time"
 
 	"github.com/cfgis/cfgms/pkg/ctxkeys"
 	"github.com/cfgis/cfgms/pkg/logging"
 )
+
+// ApprovalWebhookConfig holds configuration for the webhook delivery channel.
+type ApprovalWebhookConfig struct {
+	// RetryBase is the initial delay before the first retry. Subsequent delays
+	// double with each attempt. Defaults to 1 second when zero.
+	RetryBase time.Duration
+}
+
+// approvalWebhookSender delivers approval notifications via HTTP POST with retry.
+type approvalWebhookSender struct {
+	webhookURL string
+	logger     logging.Logger
+	retryBase  time.Duration
+	httpClient *http.Client
+}
+
+// sendWebhook marshals payload to JSON and POSTs it to the configured URL,
+// retrying up to 3 times with exponential backoff on 5xx responses or network
+// errors. Only http and https schemes are accepted to prevent SSRF. Only the
+// host is logged so that secrets embedded in webhook URL paths are never written
+// to log sinks.
+func (s *approvalWebhookSender) sendWebhook(ctx context.Context, payload interface{}) error {
+	u, err := url.Parse(s.webhookURL)
+	if err != nil || u.Host == "" || (u.Scheme != "http" && u.Scheme != "https") {
+		return fmt.Errorf("invalid webhook URL: must use http or https scheme")
+	}
+
+	data, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("marshal webhook payload: %w", err)
+	}
+
+	safeHost := logging.SanitizeLogValue(u.Host)
+
+	var lastErr error
+	for attempt := 0; attempt < 3; attempt++ {
+		if attempt > 0 {
+			delay := time.Duration(1<<uint(attempt-1)) * s.retryBase
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-time.After(delay):
+			}
+		}
+
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, s.webhookURL, bytes.NewReader(data))
+		if err != nil {
+			return fmt.Errorf("create webhook request: %w", err)
+		}
+		req.Header.Set("Content-Type", "application/json")
+
+		resp, err := s.httpClient.Do(req)
+		if err != nil {
+			lastErr = fmt.Errorf("webhook POST attempt %d: %w", attempt+1, err)
+			s.logger.Warn("webhook delivery attempt failed",
+				"attempt", attempt+1,
+				"host", safeHost,
+				"error", logging.SanitizeLogValue(lastErr.Error()),
+			)
+			continue
+		}
+		_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 1<<20))
+		if err := resp.Body.Close(); err != nil {
+			s.logger.Warn("failed to close webhook response body", "error", err)
+		}
+
+		if resp.StatusCode >= 500 {
+			lastErr = fmt.Errorf("webhook server error on attempt %d: status %d", attempt+1, resp.StatusCode)
+			s.logger.Warn("webhook delivery attempt failed",
+				"attempt", attempt+1,
+				"host", safeHost,
+				"status", resp.StatusCode,
+			)
+			continue
+		}
+
+		s.logger.Debug("webhook notification sent", "host", safeHost)
+		return nil
+	}
+
+	s.logger.Error("webhook delivery permanently failed",
+		"host", safeHost,
+		"error", logging.SanitizeLogValue(lastErr.Error()),
+	)
+	return lastErr
+}
 
 // DefaultApprovalIntegration implements the ApprovalIntegration interface
 // with basic approval workflow functionality
@@ -25,7 +116,8 @@ type DefaultApprovalIntegration struct {
 	// defaultExpiry is the default expiration time for approval requests
 	defaultExpiry time.Duration
 
-	logger logging.Logger
+	logger  logging.Logger
+	webhook *approvalWebhookSender // nil when no webhook is configured
 }
 
 // NewDefaultApprovalIntegration creates a new DefaultApprovalIntegration
@@ -36,8 +128,39 @@ func NewDefaultApprovalIntegration(logger logging.Logger) *DefaultApprovalIntegr
 	return &DefaultApprovalIntegration{
 		requests:      make(map[string]*ApprovalRequest),
 		approvers:     initializeDefaultApprovers(),
-		defaultExpiry: 24 * time.Hour, // 24 hours default
+		defaultExpiry: 24 * time.Hour,
 		logger:        logger,
+	}
+}
+
+// NewDefaultApprovalIntegrationWithWebhook creates an integration that delivers
+// approval notifications to webhookURL in addition to logging.
+func NewDefaultApprovalIntegrationWithWebhook(webhookURL string, logger logging.Logger) *DefaultApprovalIntegration {
+	return NewDefaultApprovalIntegrationWithWebhookConfig(webhookURL, logger, ApprovalWebhookConfig{})
+}
+
+// NewDefaultApprovalIntegrationWithWebhookConfig is the same as
+// NewDefaultApprovalIntegrationWithWebhook but accepts caller-supplied config.
+// Intended for tests where a shorter RetryBase speeds up retry-behavior tests.
+func NewDefaultApprovalIntegrationWithWebhookConfig(webhookURL string, logger logging.Logger, cfg ApprovalWebhookConfig) *DefaultApprovalIntegration {
+	if logger == nil {
+		logger = logging.NewNoopLogger()
+	}
+	retryBase := cfg.RetryBase
+	if retryBase <= 0 {
+		retryBase = time.Second
+	}
+	return &DefaultApprovalIntegration{
+		requests:      make(map[string]*ApprovalRequest),
+		approvers:     initializeDefaultApprovers(),
+		defaultExpiry: 24 * time.Hour,
+		logger:        logger,
+		webhook: &approvalWebhookSender{
+			webhookURL: webhookURL,
+			logger:     logger,
+			retryBase:  retryBase,
+			httpClient: &http.Client{Timeout: 10 * time.Second},
+		},
 	}
 }
 
@@ -196,10 +319,8 @@ func (ai *DefaultApprovalIntegration) AddApproval(ctx context.Context, requestID
 
 	request.Status.Approvals = append(request.Status.Approvals, approval)
 
-	// Remove from pending approvers if approved
-	if decision == "approved" {
-		request.Status.PendingApprovers = ai.removePendingApprover(request.Status.PendingApprovers, approver)
-	}
+	// Remove from pending once any decision is recorded (approved or rejected).
+	request.Status.PendingApprovers = ai.removePendingApprover(request.Status.PendingApprovers, approver)
 
 	// Update status
 	request.Status.UpdatedAt = time.Now()
@@ -210,6 +331,13 @@ func (ai *DefaultApprovalIntegration) AddApproval(ctx context.Context, requestID
 			request.Status.Status = "approved"
 		} else {
 			request.Status.Status = "rejected"
+		}
+
+		if err := ai.notifyApprovalDecision(ctx, request); err != nil {
+			ai.logger.Warn("failed to notify approvers of decision",
+				"request_id", logging.SanitizeLogValue(requestID),
+				"error", err,
+			)
 		}
 	}
 
@@ -389,30 +517,72 @@ func (ai *DefaultApprovalIntegration) allApproved(request *ApprovalRequest) bool
 	return true
 }
 
-// notifyApprovers sends notifications to required approvers
+// notifyApprovers sends notifications to required approvers when a request is created.
 func (ai *DefaultApprovalIntegration) notifyApprovers(ctx context.Context, request *ApprovalRequest) error {
-	// Deferred: tracked in #1441 — deliver via email, Slack, and webhook channels
 	ai.logger.Info("notifying approvers",
 		"request_id", logging.SanitizeLogValue(request.ID),
 		"approver_count", len(request.RequiredApprovers),
 	)
-	return nil
+	if ai.webhook == nil {
+		return nil
+	}
+	return ai.webhook.sendWebhook(ctx, map[string]interface{}{
+		"event":          "approval.requested",
+		"diff_id":        request.ID,
+		"initiator":      request.Requester,
+		"approvers":      request.RequiredApprovers,
+		"approver_count": len(request.RequiredApprovers),
+		"timestamp":      time.Now(),
+	})
 }
 
-// notifyApproversOfUpdate notifies approvers of request updates
+// notifyApproversOfUpdate notifies approvers when the underlying changes are updated.
 func (ai *DefaultApprovalIntegration) notifyApproversOfUpdate(ctx context.Context, request *ApprovalRequest) error {
 	ai.logger.Info("notifying approvers of update",
 		"request_id", logging.SanitizeLogValue(request.ID),
 	)
-	return nil
+	if ai.webhook == nil {
+		return nil
+	}
+	return ai.webhook.sendWebhook(ctx, map[string]interface{}{
+		"event":     "approval.updated",
+		"diff_id":   request.ID,
+		"initiator": request.Requester,
+		"approvers": request.RequiredApprovers,
+		"timestamp": time.Now(),
+	})
 }
 
-// notifyApproversOfCancellation notifies approvers of request cancellation
+// notifyApproversOfCancellation notifies approvers when a request is cancelled.
 func (ai *DefaultApprovalIntegration) notifyApproversOfCancellation(ctx context.Context, request *ApprovalRequest) error {
 	ai.logger.Info("notifying approvers of cancellation",
 		"request_id", logging.SanitizeLogValue(request.ID),
 	)
-	return nil
+	if ai.webhook == nil {
+		return nil
+	}
+	return ai.webhook.sendWebhook(ctx, map[string]interface{}{
+		"event":     "approval.cancelled",
+		"diff_id":   request.ID,
+		"initiator": request.Requester,
+		"approvers": request.RequiredApprovers,
+		"timestamp": time.Now(),
+	})
+}
+
+// notifyApprovalDecision fires an "approval.approved" or "approval.rejected" webhook
+// once all required approvers have responded.
+func (ai *DefaultApprovalIntegration) notifyApprovalDecision(ctx context.Context, request *ApprovalRequest) error {
+	if ai.webhook == nil {
+		return nil
+	}
+	return ai.webhook.sendWebhook(ctx, map[string]interface{}{
+		"event":     "approval." + request.Status.Status,
+		"diff_id":   request.ID,
+		"initiator": request.Requester,
+		"approvers": request.RequiredApprovers,
+		"timestamp": time.Now(),
+	})
 }
 
 // initializeDefaultApprovers initializes the default approvers by type

--- a/features/config/diff/approval_webhook_test.go
+++ b/features/config/diff/approval_webhook_test.go
@@ -1,0 +1,271 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+package diff
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cfgis/cfgms/pkg/ctxkeys"
+)
+
+func newWebhookTestServer(t *testing.T) (*httptest.Server, func() []map[string]interface{}) {
+	t.Helper()
+	var mu sync.Mutex
+	var payloads []map[string]interface{}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var p map[string]interface{}
+		if err := json.Unmarshal(body, &p); err == nil {
+			mu.Lock()
+			payloads = append(payloads, p)
+			mu.Unlock()
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+
+	return srv, func() []map[string]interface{} {
+		mu.Lock()
+		defer mu.Unlock()
+		cp := make([]map[string]interface{}, len(payloads))
+		copy(cp, payloads)
+		return cp
+	}
+}
+
+func baseApprovalFixtures() (*ComparisonResult, *RiskAssessment) {
+	result := &ComparisonResult{
+		FromRef: ConfigurationReference{Commit: "abc12345"},
+		ToRef:   ConfigurationReference{Commit: "def67890"},
+		Summary: DiffSummary{TotalChanges: 1},
+	}
+	// Use RequiredApprovals so we control exactly who must approve.
+	assessment := &RiskAssessment{
+		OverallRisk: ImpactLevelLow,
+		RequiredApprovals: []ApprovalRequirement{
+			{Type: "test", Required: true, Approvers: []string{"approver-1"}},
+		},
+	}
+	return result, assessment
+}
+
+func TestDefaultApprovalIntegration_webhookDeliversApprovalRequested(t *testing.T) {
+	srv, payloads := newWebhookTestServer(t)
+
+	ai := NewDefaultApprovalIntegrationWithWebhookConfig(srv.URL, nil, ApprovalWebhookConfig{RetryBase: time.Millisecond})
+	ctx := context.WithValue(context.Background(), ctxkeys.UserIDKey, "alice@example.com")
+	result, assessment := baseApprovalFixtures()
+
+	_, err := ai.CreateApprovalRequest(ctx, result, assessment)
+	require.NoError(t, err)
+
+	got := payloads()
+	require.Len(t, got, 1)
+	assert.Equal(t, "approval.requested", got[0]["event"])
+	assert.Equal(t, "alice@example.com", got[0]["initiator"])
+	assert.NotEmpty(t, got[0]["diff_id"])
+	assert.NotEmpty(t, got[0]["timestamp"])
+}
+
+func TestDefaultApprovalIntegration_webhookDeliversApprovalUpdated(t *testing.T) {
+	srv, payloads := newWebhookTestServer(t)
+
+	ai := NewDefaultApprovalIntegrationWithWebhookConfig(srv.URL, nil, ApprovalWebhookConfig{RetryBase: time.Millisecond})
+	ctx := context.WithValue(context.Background(), ctxkeys.UserIDKey, "alice@example.com")
+	result, assessment := baseApprovalFixtures()
+
+	req, err := ai.CreateApprovalRequest(ctx, result, assessment)
+	require.NoError(t, err)
+
+	// Clear the first payload (approval.requested) by noting the count.
+	before := len(payloads())
+
+	err = ai.UpdateApprovalRequest(ctx, req.ID, result)
+	require.NoError(t, err)
+
+	got := payloads()
+	require.Greater(t, len(got), before, "expected a new webhook payload for update")
+	last := got[len(got)-1]
+	assert.Equal(t, "approval.updated", last["event"])
+	assert.Equal(t, req.ID, last["diff_id"])
+}
+
+func TestDefaultApprovalIntegration_webhookDeliversApprovalCancelled(t *testing.T) {
+	srv, payloads := newWebhookTestServer(t)
+
+	ai := NewDefaultApprovalIntegrationWithWebhookConfig(srv.URL, nil, ApprovalWebhookConfig{RetryBase: time.Millisecond})
+	ctx := context.WithValue(context.Background(), ctxkeys.UserIDKey, "alice@example.com")
+	result, assessment := baseApprovalFixtures()
+
+	req, err := ai.CreateApprovalRequest(ctx, result, assessment)
+	require.NoError(t, err)
+
+	before := len(payloads())
+
+	err = ai.CancelApprovalRequest(ctx, req.ID)
+	require.NoError(t, err)
+
+	got := payloads()
+	require.Greater(t, len(got), before)
+	last := got[len(got)-1]
+	assert.Equal(t, "approval.cancelled", last["event"])
+	assert.Equal(t, req.ID, last["diff_id"])
+}
+
+func TestDefaultApprovalIntegration_webhookDeliversApprovalApproved(t *testing.T) {
+	srv, payloads := newWebhookTestServer(t)
+
+	ai := NewDefaultApprovalIntegrationWithWebhookConfig(srv.URL, nil, ApprovalWebhookConfig{RetryBase: time.Millisecond})
+	ctx := context.WithValue(context.Background(), ctxkeys.UserIDKey, "alice@example.com")
+	result, assessment := baseApprovalFixtures()
+
+	req, err := ai.CreateApprovalRequest(ctx, result, assessment)
+	require.NoError(t, err)
+
+	before := len(payloads())
+
+	err = ai.AddApproval(ctx, req.ID, "approver-1", "approved", "looks good")
+	require.NoError(t, err)
+
+	got := payloads()
+	require.Greater(t, len(got), before)
+	last := got[len(got)-1]
+	assert.Equal(t, "approval.approved", last["event"])
+	assert.Equal(t, req.ID, last["diff_id"])
+
+	// Verify the request status changed.
+	status, err := ai.GetApprovalStatus(ctx, req.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "approved", status.Status)
+}
+
+func TestDefaultApprovalIntegration_webhookDeliversApprovalRejected(t *testing.T) {
+	srv, payloads := newWebhookTestServer(t)
+
+	ai := NewDefaultApprovalIntegrationWithWebhookConfig(srv.URL, nil, ApprovalWebhookConfig{RetryBase: time.Millisecond})
+	ctx := context.WithValue(context.Background(), ctxkeys.UserIDKey, "alice@example.com")
+	result, assessment := baseApprovalFixtures()
+
+	req, err := ai.CreateApprovalRequest(ctx, result, assessment)
+	require.NoError(t, err)
+
+	before := len(payloads())
+
+	err = ai.AddApproval(ctx, req.ID, "approver-1", "rejected", "not ready")
+	require.NoError(t, err)
+
+	got := payloads()
+	require.Greater(t, len(got), before)
+	last := got[len(got)-1]
+	assert.Equal(t, "approval.rejected", last["event"])
+	assert.Equal(t, req.ID, last["diff_id"])
+
+	status, err := ai.GetApprovalStatus(ctx, req.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "rejected", status.Status)
+}
+
+func TestDefaultApprovalIntegration_webhookRetriesOn5xx(t *testing.T) {
+	var callCount atomic.Int32
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		cur := callCount.Add(1)
+		if cur < 3 {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+
+	ai := NewDefaultApprovalIntegrationWithWebhookConfig(srv.URL, nil, ApprovalWebhookConfig{RetryBase: time.Millisecond})
+	ctx := context.WithValue(context.Background(), ctxkeys.UserIDKey, "alice@example.com")
+	result, assessment := baseApprovalFixtures()
+
+	_, err := ai.CreateApprovalRequest(ctx, result, assessment)
+	require.NoError(t, err)
+	assert.Equal(t, int32(3), callCount.Load(), "expected 3 attempts (2 failures + 1 success)")
+}
+
+func TestDefaultApprovalIntegration_webhookPermanentFailureLogged(t *testing.T) {
+	// Server always returns 503.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	t.Cleanup(srv.Close)
+
+	ai := NewDefaultApprovalIntegrationWithWebhookConfig(srv.URL, nil, ApprovalWebhookConfig{RetryBase: time.Millisecond})
+	ctx := context.WithValue(context.Background(), ctxkeys.UserIDKey, "alice@example.com")
+	result, assessment := baseApprovalFixtures()
+
+	// CreateApprovalRequest logs the webhook error and continues — it must not fail the whole operation.
+	req, err := ai.CreateApprovalRequest(ctx, result, assessment)
+	require.NoError(t, err, "permanent webhook failure must not propagate to caller")
+	assert.NotNil(t, req)
+}
+
+func TestDefaultApprovalIntegration_webhookInvalidSchemeRejected(t *testing.T) {
+	// file:// and ftp:// schemes must be rejected before any network I/O (SSRF prevention).
+	for _, badURL := range []string{"file:///etc/passwd", "ftp://internal/path", "javascript://evil"} {
+		ai := NewDefaultApprovalIntegrationWithWebhookConfig(badURL, nil, ApprovalWebhookConfig{RetryBase: time.Millisecond})
+		ctx := context.WithValue(context.Background(), ctxkeys.UserIDKey, "alice@example.com")
+		result, assessment := baseApprovalFixtures()
+
+		// Should not panic; webhook error is logged but CreateApprovalRequest succeeds.
+		req, err := ai.CreateApprovalRequest(ctx, result, assessment)
+		require.NoError(t, err, "invalid scheme must not propagate to caller (url=%s)", badURL)
+		assert.NotNil(t, req)
+	}
+}
+
+func TestDefaultApprovalIntegration_noWebhook_operationsSucceed(t *testing.T) {
+	// Without a webhook configured, all operations complete without error.
+	ai := NewDefaultApprovalIntegration(nil)
+	ctx := context.WithValue(context.Background(), ctxkeys.UserIDKey, "alice@example.com")
+	result, assessment := baseApprovalFixtures()
+
+	req, err := ai.CreateApprovalRequest(ctx, result, assessment)
+	require.NoError(t, err)
+
+	err = ai.UpdateApprovalRequest(ctx, req.ID, result)
+	require.NoError(t, err)
+
+	err = ai.AddApproval(ctx, req.ID, "approver-1", "approved", "")
+	require.NoError(t, err)
+
+	status, err := ai.GetApprovalStatus(ctx, req.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "approved", status.Status)
+}
+
+func TestDefaultApprovalIntegration_webhookPayloadContainsRequiredFields(t *testing.T) {
+	srv, payloads := newWebhookTestServer(t)
+
+	ai := NewDefaultApprovalIntegrationWithWebhookConfig(srv.URL, nil, ApprovalWebhookConfig{RetryBase: time.Millisecond})
+	ctx := context.WithValue(context.Background(), ctxkeys.UserIDKey, "bob@example.com")
+	result, assessment := baseApprovalFixtures()
+
+	req, err := ai.CreateApprovalRequest(ctx, result, assessment)
+	require.NoError(t, err)
+
+	got := payloads()
+	require.Len(t, got, 1)
+	p := got[0]
+
+	assert.Equal(t, "approval.requested", p["event"], "event field")
+	assert.Equal(t, req.ID, p["diff_id"], "diff_id field")
+	assert.Equal(t, "bob@example.com", p["initiator"], "initiator field")
+	assert.NotNil(t, p["timestamp"], "timestamp field")
+}

--- a/features/config/rollback/validator_test.go
+++ b/features/config/rollback/validator_test.go
@@ -12,8 +12,8 @@ import (
 	"github.com/cfgis/cfgms/api/proto/common"
 	"github.com/cfgis/cfgms/features/config/rollback"
 	"github.com/cfgis/cfgms/features/rbac"
-	pkgtesting "github.com/cfgis/cfgms/pkg/testing"
 	"github.com/cfgis/cfgms/pkg/ctxkeys"
+	pkgtesting "github.com/cfgis/cfgms/pkg/testing"
 )
 
 // ctxWithCaller injects the UserIDKey and TenantID context values that validatePermissions reads.

--- a/features/modules/m365/directory_provider_test.go
+++ b/features/modules/m365/directory_provider_test.go
@@ -69,8 +69,8 @@ func TestEntraIDDirectoryProvider_Connect(t *testing.T) {
 		expectConnect bool
 	}{
 		{
-			name:   "successful connection",
-			config: validConnectConfig(),
+			name:         "successful connection",
+			config:       validConnectConfig(),
 			authProvider: &stubAuthProvider{},
 			graphClient: &stubGraphClient{
 				getUserFn: func(_ context.Context, _ *auth.AccessToken, _ string) (*graph.User, error) {

--- a/pkg/controlplane/providers/grpc/provider_register_identity_test.go
+++ b/pkg/controlplane/providers/grpc/provider_register_identity_test.go
@@ -90,7 +90,7 @@ func (s *inMemoryTokenStore) ConsumeToken(_ context.Context, tokenStr, stewardID
 }
 
 func (s *inMemoryTokenStore) Initialize(_ context.Context) error { return nil }
-func (s *inMemoryTokenStore) Close() error                        { return nil }
+func (s *inMemoryTokenStore) Close() error                       { return nil }
 
 // compile-time assertion
 var _ business.RegistrationTokenStore = (*inMemoryTokenStore)(nil)


### PR DESCRIPTION
## Summary

- Replaces log-only stubs in `notifyApprovers`, `notifyApproversOfUpdate`, and `notifyApproversOfCancellation` with real HTTP webhook delivery
- Adds `notifyApprovalDecision` to fire `approval.approved` / `approval.rejected` events when all required approvers respond
- Fixes a pre-existing bug in `AddApproval` where a rejection decision never removed the approver from `PendingApprovers`, making the "rejected" status unreachable

## Changes

**`features/config/diff/approval.go`**
- `approvalWebhookSender` — HTTP POST helper with 3-attempt exponential backoff, URL scheme validation (SSRF prevention), host-only logging
- `ApprovalWebhookConfig` — test-friendly `RetryBase` field
- `NewDefaultApprovalIntegrationWithWebhook` / `WithWebhookConfig` — constructors for webhook-enabled integration
- All four event types: `approval.requested`, `approval.updated`, `approval.cancelled`, `approval.approved` / `approval.rejected`

**`features/config/diff/approval_webhook_test.go`** (new)
- Real `httptest.Server`-based tests for all four event types
- 5xx retry test (3 attempts), permanent failure non-propagation, SSRF prevention (invalid schemes)
- Race-safe with `sync/atomic.Int32` for handler call counting

**Three pre-existing gofmt violations** fixed (lint gate was blocking):
- `features/config/rollback/validator_test.go`
- `features/modules/m365/directory_provider_test.go`
- `pkg/controlplane/providers/grpc/provider_register_identity_test.go`

## Acceptance Criteria Verification

1. ✅ `notifyApprovers` sends HTTP POST to configured webhook URL on approval request
2. ✅ Approval, rejection, and cancellation events also trigger webhook delivery
3. ✅ Delivery failures are logged and retried (3 attempts, exponential backoff — same policy as #1603)
4. ✅ `make test-agent-complete` passes

## Specialist Review Results

- **QA Test Runner**: PASS — all 100+ packages pass with race detection, lint clean, cross-platform builds verified
- **QA Code Reviewer**: PASS — no mocks, no skips, no empty assertions, `atomic.Int32` race-safe
- **Security Engineer**: PASS — no blocking issues; SSRF prevention via scheme validation, host-only logging, architecture checks pass

Fixes #1624