### PR TITLE
pipeline: route review-FAIL PRs by verdict, not CI-green heuristic

### DIFF
--- a/.claude/scripts/po-cycle-preflight.py
+++ b/.claude/scripts/po-cycle-preflight.py
@@ -380,6 +380,39 @@ def is_trusted_review_comment(comment):
     return _ACCEPTANCE_REVIEW_SENTINEL in body or _ACCEPTANCE_REVIEW_HEADING in body
 
 
+# Matches the verdict heading `## Acceptance Review — PASS|FAIL` emitted by the
+# acceptance-reviewer agent. The dash may be em-dash, en-dash, or hyphen.
+_REVIEW_VERDICT_RE = re.compile(r"acceptance review\s*[—–-]\s*(pass|fail)", re.IGNORECASE)
+
+
+def review_verdict(comment):
+    """Return 'pass', 'fail', or None for a single review comment."""
+    m = _REVIEW_VERDICT_RE.search(comment.get("body") or "")
+    return m.group(1).lower() if m else None
+
+
+def latest_review_verdict(comments):
+    """Verdict of the most recent trusted acceptance-review comment.
+
+    GitHub returns issue comments oldest-first, so the last trusted comment
+    with a parseable verdict is the latest review. Returns 'pass', 'fail',
+    or None (no review comment, or none with a parseable verdict).
+
+    Distinguishing the verdict matters: a `Fix` status (or the mere presence
+    of a review comment) does not say whether the review passed. A FAIL review
+    with green CI must NOT be treated as merge-ready — green CI proves the code
+    compiles, not that the reviewer's acceptance-criteria findings were
+    addressed. Only a passing re-review resolves a FAIL.
+    """
+    verdict = None
+    for c in comments:
+        if is_trusted_review_comment(c):
+            v = review_verdict(c)
+            if v is not None:
+                verdict = v
+    return verdict
+
+
 def _pq_script_path():
     """Return the project-queue.sh path, honoring CFGMS_TEST_PROJECT_QUEUE override."""
     override = os.environ.get("CFGMS_TEST_PROJECT_QUEUE")
@@ -869,7 +902,10 @@ def compute_review_recommendations(pr_summaries, queued_pr_numbers, active_fix_p
     - skip: in-flight (in queue, auto-merge armed, OR has active fix-agent
               container — fix-agent and rebase-pr.sh would race on the same
               branch); leave alone.
-    - spawn_acceptance_reviewer: needs first-time review (CI green, no comment).
+    - spawn_acceptance_reviewer: needs review — either a first review (CI green,
+              no review comment) or a re-review (latest review verdict was FAIL,
+              the fix landed, CI is green again). A FAIL is never enqueued; it
+              must pass a re-review first.
     - defer: CI still pending.
     - investigate: CI red and not stale-base; needs diagnose + dispatch-fix.
 
@@ -939,9 +975,39 @@ def compute_review_recommendations(pr_summaries, queued_pr_numbers, active_fix_p
             })
             continue
 
+        verdict = pr.get("latest_review_verdict")
+
+        # Review FAILED. Green CI proves only that the code compiles, NOT that
+        # the reviewer's acceptance-criteria findings were addressed — never
+        # enqueue a FAIL. (fix-agent-in-flight is already handled above.)
+        if pr["has_acceptance_review_comment"] and verdict == "fail":
+            if overall == "green":
+                recs.append({
+                    "pr": pr["pr"],
+                    "story": pr["story_number"],
+                    "action": "spawn_acceptance_reviewer",
+                    "reason": "acceptance review FAILED, fix landed (CI green) — re-review required before this PR can merge",
+                })
+            elif overall == "pending":
+                pending = pr["ci_summary"]["pending_checks"][:3]
+                recs.append({
+                    "pr": pr["pr"],
+                    "story": pr["story_number"],
+                    "action": "defer",
+                    "reason": f"acceptance review FAILED; fix in progress, CI pending: {', '.join(pending)}",
+                })
+            else:
+                recs.append({
+                    "pr": pr["pr"],
+                    "story": pr["story_number"],
+                    "action": "skip",
+                    "reason": "acceptance review FAILED and CI red — fix cycle owns this (see fix_recommendations / dispatch-fix)",
+                })
+            continue
+
         if pr["has_acceptance_review_comment"]:
-            # Review done. Flag as stuck if CI green + mergeable but not in queue
-            # and not already auto-merge-enabled (the two "enqueued" signals).
+            # Review passed (or verdict unparseable). Flag as stuck if CI green
+            # + mergeable but not in queue and not already auto-merge-enabled.
             if (
                 overall == "green"
                 and pr.get("mergeable") == "MERGEABLE"
@@ -1038,9 +1104,12 @@ def compute_fix_recommendations(fix_stories, pr_summaries, active_fix_pr_nums=No
 
     Action vocabulary:
     - dispatch_fix: open PR exists with CI red or pending — dispatch fix-pr now.
-    - clear_stale_status: open PR exists with CI green — fix already succeeded;
-                  set status back to Ready and the next cycle will route to
-                  acceptance-review normally.
+    - clear_stale_status: open PR exists with CI green and the Fix was NOT a
+                  review FAIL — the CI-driven fix succeeded; set status back to
+                  Ready and the next cycle routes to acceptance-review normally.
+                  A Fix from a review FAIL never clears on green CI alone — it
+                  routes to a re-review instead (skip here; the review
+                  recommender emits spawn_acceptance_reviewer).
     - skip: fix-agent already in flight, OR PR already in merge queue.
     - no_open_pr: story has Fix status but no open PR — stale status;
                   PO should investigate (likely a PR was closed/merged without
@@ -1088,14 +1157,38 @@ def compute_fix_recommendations(fix_stories, pr_summaries, active_fix_pr_nums=No
             continue
         overall = (pr.get("ci_summary") or {}).get("overall")
         ms = (pr.get("merge_state_status") or "").upper()
-        # clear_stale_status only when CI green AND no merge-state blockers.
-        # DIRTY (conflicts) and BLOCKED still need fix-pr even with green CI.
+        verdict = pr.get("latest_review_verdict")
+        # A Fix that originated from an acceptance-review FAIL is NOT resolved
+        # by green CI — only a passing re-review resolves it. Never
+        # clear_stale_status for those: green CI means the fix code landed,
+        # so the next step is the re-review (compute_review_recommendations
+        # emits spawn_acceptance_reviewer for review-FAIL + green CI), not a
+        # status clear or an enqueue.
+        if verdict == "fail":
+            if overall == "green" and ms not in ("DIRTY", "BLOCKED"):
+                recs.append({
+                    "story": story_num,
+                    "pr": pr_num,
+                    "action": "skip",
+                    "reason": "review FAIL fix landed (CI green) — re-review pending (review_recommendations emits spawn_acceptance_reviewer); do NOT clear status or enqueue",
+                })
+            else:
+                recs.append({
+                    "story": story_num,
+                    "pr": pr_num,
+                    "action": "dispatch_fix",
+                    "reason": f"review FAIL not yet resolved (CI={overall}, mergeStateStatus={ms or 'UNKNOWN'}) — run `./.claude/scripts/po-act.sh dispatch-fix <PR>`",
+                })
+            continue
+        # CI-driven Fix (no review FAIL): green CI genuinely means the fix
+        # succeeded. clear_stale_status only when CI green AND no merge-state
+        # blockers. DIRTY (conflicts) and BLOCKED still need fix-pr.
         if overall == "green" and ms not in ("DIRTY", "BLOCKED"):
             recs.append({
                 "story": story_num,
                 "pr": pr_num,
                 "action": "clear_stale_status",
-                "reason": "Fix status but CI green and no merge-state blockers — fix already succeeded; update status via `./scripts/project-queue.sh update-field <ITEM_ID> status Ready`",
+                "reason": "Fix status but CI green, no review FAIL, no merge-state blockers — fix already succeeded; update status via `./scripts/project-queue.sh update-field <ITEM_ID> status Ready`",
             })
             continue
         recs.append({
@@ -1438,6 +1531,7 @@ def main():
             story_number = None
         comments = pr.get("comments") or []
         has_review_comment = any(is_trusted_review_comment(c) for c in comments)
+        review_verdict_val = latest_review_verdict(comments)
         body = pr.get("body") or ""
         title = pr.get("title", "")
         is_draft = bool(pr.get("isDraft"))
@@ -1455,6 +1549,7 @@ def main():
             "story_number": story_number,
             "comment_count": len(comments),
             "has_acceptance_review_comment": has_review_comment,
+            "latest_review_verdict": review_verdict_val,
             "is_draft": is_draft,
             "wip_session_failed": wip_session_failed,
             "merge_state_status": pr.get("mergeStateStatus"),

--- a/scripts/test-scripts.sh
+++ b/scripts/test-scripts.sh
@@ -2249,6 +2249,117 @@ PYEOF
     fi
 }
 
+test_preflight_review_verdict_routing() {
+    log_test "Testing po-cycle-preflight.py: review-FAIL PRs route to re-review, never enqueue/clear-stale (Issue #1657)..."
+
+    local preflight_script
+    preflight_script="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/../.claude/scripts/po-cycle-preflight.py"
+
+    if [[ ! -f "$preflight_script" ]]; then
+        log_fail "po-cycle-preflight.py: not found at $preflight_script"
+        return
+    fi
+
+    local tmp_py
+    tmp_py=$(mktemp --suffix=.py)
+    trap 'rm -f "$tmp_py"' RETURN
+
+    cat > "$tmp_py" << 'PYEOF'
+import sys, importlib.util, os
+
+script_path = os.environ["PREFLIGHT_SCRIPT"]
+spec = importlib.util.spec_from_file_location("preflight", script_path)
+mod = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(mod)
+
+fail_c = {"body": "<!-- cfgms-acceptance-review -->\n## Acceptance Review — FAIL\n"}
+pass_c = {"body": "<!-- cfgms-acceptance-review -->\n## Acceptance Review — PASS\n"}
+
+# Part A: latest_review_verdict extracts fail/pass/None
+if (mod.latest_review_verdict([fail_c]) == "fail"
+        and mod.latest_review_verdict([pass_c]) == "pass"
+        and mod.latest_review_verdict([]) is None):
+    print("PASS_A: latest_review_verdict extracts fail/pass/None")
+else:
+    print("FAIL_A: latest_review_verdict extraction wrong")
+    sys.exit(1)
+
+# Part A2: most recent verdict wins (FAIL then PASS -> pass)
+if mod.latest_review_verdict([fail_c, pass_c]) == "pass":
+    print("PASS_A2: latest_review_verdict takes the most recent verdict")
+else:
+    print("FAIL_A2: latest_review_verdict did not take the latest")
+    sys.exit(1)
+
+pr_fail_green = {
+    "pr": 2001, "story_number": 3001,
+    "has_acceptance_review_comment": True,
+    "latest_review_verdict": "fail",
+    "wip_session_failed": False,
+    "merge_state_status": "MERGEABLE", "mergeable": "MERGEABLE",
+    "auto_merge_enabled": False,
+    "ci_summary": {"overall": "green", "pass": 4, "pending": 0, "fail": 0,
+                   "skipped": 0, "pending_checks": [], "failed_checks": []},
+}
+
+# Part B: review FAIL + CI green -> re-review, NOT enqueue_merge
+recs = mod.compute_review_recommendations([pr_fail_green], set(), set())
+action = recs[0].get("action") if recs else None
+if action == "spawn_acceptance_reviewer":
+    print("PASS_B: review FAIL + CI green -> spawn_acceptance_reviewer (re-review)")
+else:
+    print(f"FAIL_B: review FAIL + CI green got action={action!r}, expected spawn_acceptance_reviewer")
+    sys.exit(1)
+
+# Part C: review PASS + CI green + mergeable -> enqueue_merge (unchanged)
+pr_pass_green = dict(pr_fail_green, pr=2002, latest_review_verdict="pass")
+recs = mod.compute_review_recommendations([pr_pass_green], set(), set())
+action = recs[0].get("action") if recs else None
+if action == "enqueue_merge":
+    print("PASS_C: review PASS + CI green -> enqueue_merge")
+else:
+    print(f"FAIL_C: review PASS + CI green got action={action!r}, expected enqueue_merge")
+    sys.exit(1)
+
+# Part D: Fix story whose PR FAILED review + CI green must NOT clear_stale_status
+fix_story = {"number": 3001, "title": "t", "item_id": "X"}
+recs = mod.compute_fix_recommendations([fix_story], [pr_fail_green], set(), set())
+action = recs[0].get("action") if recs else None
+if action and action != "clear_stale_status":
+    print(f"PASS_D: review-FAIL Fix story + CI green -> action={action!r} (not clear_stale_status)")
+else:
+    print(f"FAIL_D: review-FAIL Fix story got action={action!r}, must not be clear_stale_status")
+    sys.exit(1)
+
+# Part E: CI-driven Fix (no review FAIL) + CI green still clears stale status
+pr_noreview_green = dict(pr_fail_green, pr=2003, story_number=3002,
+                         has_acceptance_review_comment=False, latest_review_verdict=None)
+fix_story2 = {"number": 3002, "title": "t", "item_id": "Y"}
+recs = mod.compute_fix_recommendations([fix_story2], [pr_noreview_green], set(), set())
+action = recs[0].get("action") if recs else None
+if action == "clear_stale_status":
+    print("PASS_E: CI-driven Fix (no review FAIL) + CI green -> clear_stale_status retained")
+else:
+    print(f"FAIL_E: CI-driven Fix got action={action!r}, expected clear_stale_status")
+    sys.exit(1)
+PYEOF
+
+    local exit_code=0
+    local output
+    output=$(PREFLIGHT_SCRIPT="$preflight_script" python3 "$tmp_py" 2>&1) || exit_code=$?
+
+    while IFS= read -r line; do
+        case "$line" in
+            PASS_*) log_pass "preflight verdict routing: ${line#*: }" ;;
+            FAIL_*) log_fail "preflight verdict routing: ${line#*: }" ;;
+        esac
+    done <<< "$output"
+
+    if [[ $exit_code -ne 0 ]] && ! grep -q "^FAIL" <<< "$output"; then
+        log_fail "preflight review verdict routing: Python test crashed (exit $exit_code): $output"
+    fi
+}
+
 # Main execution
 echo "🔍 Script Validation Test Suite"
 echo "================================"
@@ -2312,6 +2423,8 @@ echo ""
 test_dispatch_creds_gate
 echo ""
 test_preflight_acceptance_review_comment_match
+echo ""
+test_preflight_review_verdict_routing
 echo ""
 test_trust_boundary
 echo ""


### PR DESCRIPTION
## Summary

- `po-cycle-preflight.py` now parses the acceptance-review **verdict** (PASS/FAIL) from the latest trusted sentinel comment into each PR summary as `latest_review_verdict`.
- `compute_review_recommendations` and `compute_fix_recommendations` route by verdict: a **review FAIL + green CI** now yields `spawn_acceptance_reviewer` (re-review), never `enqueue_merge` / `clear_stale_status`.
- `clear_stale_status` is retained only for CI-driven Fixes (no review FAIL).

## Why

Both functions decided merge-readiness from the `has_acceptance_review_comment` **boolean** + CI status — never the verdict. A FAIL review whose fix landed (green CI) was routed to `enqueue_merge`. Green CI proves the code compiles, not that the reviewer's acceptance-criteria findings were addressed — only a passing re-review does. In an unattended cron this merges a PR with unaddressed findings. Misfired 4+ times on 2026-05-20 (stories #1571, #1604, #1599, #1617), each caught only by a manual verdict check.

## Test plan

- [x] `make test` passes — 142 script tests (was 136)
- [x] New `test_preflight_review_verdict_routing`: verdict extraction (fail/pass/None, latest-wins), review FAIL+green → re-review, review PASS+green → enqueue, review-FAIL Fix story → not clear_stale, CI-driven Fix → clear_stale retained

Fixes #1657

🤖 Generated with [Claude Code](https://claude.com/claude-code)