### PR TITLE
jit/notification: implement webhook delivery for escalation notifications (Issue #1623)

### DIFF
--- a/features/rbac/jit/notification.go
+++ b/features/rbac/jit/notification.go
@@ -3,10 +3,17 @@
 package jit
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
+	"io"
 	"log/slog"
+	"net/http"
+	"net/url"
 	"time"
+
+	"github.com/cfgis/cfgms/pkg/logging"
 )
 
 // SimpleNotificationService provides a basic implementation of NotificationService
@@ -401,6 +408,195 @@ type NotificationStats struct {
 	TypeBreakdown    map[NotificationType]int    `json:"type_breakdown"`
 	ChannelBreakdown map[NotificationChannel]int `json:"channel_breakdown"`
 	GeneratedAt      time.Time                   `json:"generated_at"`
+}
+
+// EscalationWebhookPayload is the JSON body delivered when a JIT escalation notification
+// is sent via webhook. All required fields from the acceptance criteria are included.
+type EscalationWebhookPayload struct {
+	Event                string    `json:"event"`
+	EscalationID         string    `json:"escalation_id"`
+	RequestID            string    `json:"request_id"`
+	RequestingUser       string    `json:"requesting_user"`
+	RequestedPermissions []string  `json:"requested_permissions"`
+	Approvers            []string  `json:"approvers"`
+	EscalationLevel      int       `json:"escalation_level"`
+	Timestamp            time.Time `json:"timestamp"`
+}
+
+// WebhookNotificationConfig holds optional overrides for WebhookNotificationService.
+// Intended for tests that need a shorter RetryBase or a custom HTTP client.
+type WebhookNotificationConfig struct {
+	RetryBase  time.Duration
+	HTTPClient *http.Client
+}
+
+// WebhookNotificationService delivers JIT escalation notifications via HTTP POST webhook
+// and records them in memory after successful delivery. All non-escalation notification
+// methods are provided by the embedded SimpleNotificationService.
+type WebhookNotificationService struct {
+	*SimpleNotificationService
+	webhookURL string
+	retryBase  time.Duration
+	httpClient *http.Client
+}
+
+// compile-time check: WebhookNotificationService must satisfy NotificationService.
+var _ NotificationService = (*WebhookNotificationService)(nil)
+
+// NewWebhookNotificationService creates a production WebhookNotificationService using
+// standard retry defaults (1-second base, 10-second per-request timeout).
+func NewWebhookNotificationService(webhookURL string, registry ApproverRegistry) *WebhookNotificationService {
+	return NewWebhookNotificationServiceWithConfig(webhookURL, registry, WebhookNotificationConfig{})
+}
+
+// NewWebhookNotificationServiceWithConfig creates a WebhookNotificationService with
+// caller-supplied configuration. Intended for tests where shorter retry delays are needed.
+func NewWebhookNotificationServiceWithConfig(webhookURL string, registry ApproverRegistry, cfg WebhookNotificationConfig) *WebhookNotificationService {
+	retryBase := cfg.RetryBase
+	if retryBase <= 0 {
+		retryBase = time.Second
+	}
+	httpClient := cfg.HTTPClient
+	if httpClient == nil {
+		httpClient = &http.Client{Timeout: 10 * time.Second}
+	}
+	return &WebhookNotificationService{
+		SimpleNotificationService: NewSimpleNotificationServiceWithRegistry(registry),
+		webhookURL:                webhookURL,
+		retryBase:                 retryBase,
+		httpClient:                httpClient,
+	}
+}
+
+// SendEscalationNotification delivers an escalation notification via HTTP POST and records
+// it in the in-memory store on success. Delivery is retried up to 3 times with exponential
+// backoff on 5xx responses or network errors. Returns an error if all attempts fail;
+// no memory record is written on permanent delivery failure.
+func (w *WebhookNotificationService) SendEscalationNotification(ctx context.Context, request *JITAccessRequest, escalationLevel int) error {
+	approvers := []string{}
+	if w.registry != nil {
+		resolved, err := w.registry.GetApprovers(ctx, EscalationTypeDefault)
+		if err != nil {
+			return fmt.Errorf("approver registry lookup failed: %w", err)
+		}
+		if resolved != nil {
+			approvers = resolved
+		}
+	}
+
+	if len(approvers) == 0 {
+		slog.Warn("no escalation recipients configured; webhook will deliver with empty approver list",
+			"request_id", request.ID,
+			"tenant_id", request.TenantID,
+			"escalation_level", escalationLevel,
+		)
+	}
+
+	escalationID := fmt.Sprintf("esc-%s-l%d-%d", request.ID, escalationLevel, time.Now().UnixNano())
+	payload := EscalationWebhookPayload{
+		Event:                "jit.escalation",
+		EscalationID:         escalationID,
+		RequestID:            request.ID,
+		RequestingUser:       request.RequesterID,
+		RequestedPermissions: request.Permissions,
+		Approvers:            approvers,
+		EscalationLevel:      escalationLevel,
+		Timestamp:            time.Now(),
+	}
+
+	if err := w.sendWebhook(ctx, payload); err != nil {
+		return err
+	}
+
+	subject := fmt.Sprintf("[ESCALATION LEVEL %d] JIT Access Approval Required", escalationLevel)
+	message := fmt.Sprintf(
+		"JIT access request %s has been escalated to level %d due to lack of approval. Original request from %s for %v permissions.",
+		request.ID, escalationLevel, request.RequesterID, request.Permissions,
+	)
+	return w.sendNotification(ctx, NotificationTypeEscalation, approvers, subject, message, map[string]interface{}{
+		"request_id":         request.ID,
+		"tenant_id":          request.TenantID,
+		"escalation_level":   escalationLevel,
+		"original_requester": request.RequesterID,
+		"emergency_access":   request.EmergencyAccess,
+		"escalation_id":      escalationID,
+	})
+}
+
+// sendWebhook marshals payload to JSON and POSTs it to the configured URL, retrying up
+// to 3 times with exponential backoff on 5xx responses or network errors. Only http and
+// https schemes are accepted to prevent SSRF via exotic schemes. Only the host is logged
+// so that secrets embedded in URL paths are not written to log sinks.
+func (w *WebhookNotificationService) sendWebhook(ctx context.Context, payload interface{}) error {
+	u, err := url.Parse(w.webhookURL)
+	if err != nil || u.Host == "" || (u.Scheme != "http" && u.Scheme != "https") {
+		return fmt.Errorf("invalid webhook URL: must use http or https scheme")
+	}
+
+	data, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("marshal webhook payload: %w", err)
+	}
+
+	safeHost := logging.SanitizeLogValue(u.Host)
+
+	var lastErr error
+	for attempt := 0; attempt < 3; attempt++ {
+		if attempt > 0 {
+			delay := time.Duration(1<<uint(attempt-1)) * w.retryBase
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-time.After(delay):
+			}
+		}
+
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, w.webhookURL, bytes.NewReader(data))
+		if err != nil {
+			return fmt.Errorf("create webhook request: %w", err)
+		}
+		req.Header.Set("Content-Type", "application/json")
+
+		resp, err := w.httpClient.Do(req)
+		if err != nil {
+			lastErr = fmt.Errorf("webhook POST attempt %d: %w", attempt+1, err)
+			slog.Warn("webhook delivery attempt failed",
+				"attempt", attempt+1,
+				"host", safeHost,
+				"error", logging.SanitizeLogValue(lastErr.Error()),
+			)
+			continue
+		}
+		_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 1<<20))
+		if err := resp.Body.Close(); err != nil {
+			slog.Warn("failed to close webhook response body", "error", err)
+		}
+
+		if resp.StatusCode >= 500 {
+			lastErr = fmt.Errorf("webhook server error on attempt %d: status %d", attempt+1, resp.StatusCode)
+			slog.Warn("webhook delivery attempt failed",
+				"attempt", attempt+1,
+				"host", safeHost,
+				"status", resp.StatusCode,
+			)
+			continue
+		}
+
+		// Non-2xx below 500 (e.g. 401/403/404) indicates a permanent misconfiguration —
+		// the server received the request but rejected it. Do not retry.
+		if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+			return fmt.Errorf("webhook rejected escalation notification: status %d", resp.StatusCode)
+		}
+
+		slog.Debug("webhook escalation notification sent", "host", safeHost)
+		return nil
+	}
+
+	slog.Error("webhook escalation delivery permanently failed",
+		"host", safeHost,
+		"error", logging.SanitizeLogValue(lastErr.Error()),
+	)
+	return lastErr
 }
 
 // GetNotificationStats generates notification statistics

--- a/features/rbac/jit/notification_test.go
+++ b/features/rbac/jit/notification_test.go
@@ -5,9 +5,15 @@ package jit_test
 import (
 	"bytes"
 	"context"
+	"encoding/json"
+	"errors"
+	"io"
 	"log/slog"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -181,5 +187,284 @@ func TestSendEscalationNotification_RegistryError(t *testing.T) {
 type errorRegistry struct{}
 
 func (e *errorRegistry) GetApprovers(_ context.Context, _ string) ([]string, error) {
-	return nil, assert.AnError
+	return nil, errors.New("registry unavailable")
+}
+
+// --- WebhookNotificationService tests ---
+
+func TestWebhookNotificationService_SendEscalationNotification_DeliversPayload(t *testing.T) {
+	var received []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		received = body
+		assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	registry := jit.NewStaticApproverRegistry(map[string][]string{
+		jit.EscalationTypeDefault: {"admin@example.com", "security@example.com"},
+	})
+	svc := jit.NewWebhookNotificationServiceWithConfig(server.URL, registry, jit.WebhookNotificationConfig{
+		RetryBase: time.Millisecond,
+	})
+
+	req := &jit.JITAccessRequest{
+		ID:          "req-webhook-1",
+		RequesterID: "user1",
+		TenantID:    "tenant1",
+		Permissions: []string{"admin", "sudo"},
+	}
+
+	err := svc.SendEscalationNotification(context.Background(), req, 2)
+	require.NoError(t, err)
+	require.NotEmpty(t, received)
+
+	var payload map[string]interface{}
+	require.NoError(t, json.Unmarshal(received, &payload))
+
+	assert.Equal(t, "jit.escalation", payload["event"])
+	assert.NotEmpty(t, payload["escalation_id"])
+	assert.Equal(t, "req-webhook-1", payload["request_id"])
+	assert.Equal(t, "user1", payload["requesting_user"])
+	assert.NotEmpty(t, payload["timestamp"])
+	assert.InDelta(t, float64(2), payload["escalation_level"], 0)
+
+	approvers, ok := payload["approvers"].([]interface{})
+	require.True(t, ok)
+	assert.ElementsMatch(t, []interface{}{"admin@example.com", "security@example.com"}, approvers)
+
+	perms, ok := payload["requested_permissions"].([]interface{})
+	require.True(t, ok)
+	assert.ElementsMatch(t, []interface{}{"admin", "sudo"}, perms)
+}
+
+func TestWebhookNotificationService_SendEscalationNotification_StoresInMemoryAfterSuccess(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	registry := jit.NewStaticApproverRegistry(map[string][]string{
+		jit.EscalationTypeDefault: {"admin@example.com"},
+	})
+	svc := jit.NewWebhookNotificationServiceWithConfig(server.URL, registry, jit.WebhookNotificationConfig{
+		RetryBase: time.Millisecond,
+	})
+
+	req := &jit.JITAccessRequest{
+		ID:          "req-mem-1",
+		RequesterID: "user1",
+		TenantID:    "tenant1",
+		Permissions: []string{"admin"},
+	}
+
+	err := svc.SendEscalationNotification(context.Background(), req, 1)
+	require.NoError(t, err)
+
+	history, err := svc.GetNotificationHistory(context.Background(), nil)
+	require.NoError(t, err)
+	require.Len(t, history, 1)
+	assert.Equal(t, jit.NotificationTypeEscalation, history[0].Type)
+	assert.Equal(t, []string{"admin@example.com"}, history[0].Recipients)
+}
+
+func TestWebhookNotificationService_SendEscalationNotification_RetriesOnServerError(t *testing.T) {
+	attemptCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attemptCount++
+		if attemptCount < 3 {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	registry := jit.NewStaticApproverRegistry(map[string][]string{
+		jit.EscalationTypeDefault: {"admin@example.com"},
+	})
+	svc := jit.NewWebhookNotificationServiceWithConfig(server.URL, registry, jit.WebhookNotificationConfig{
+		RetryBase: time.Millisecond,
+	})
+
+	req := &jit.JITAccessRequest{
+		ID:          "req-retry-1",
+		RequesterID: "user1",
+		TenantID:    "tenant1",
+		Permissions: []string{"admin"},
+	}
+
+	err := svc.SendEscalationNotification(context.Background(), req, 1)
+	require.NoError(t, err)
+	assert.Equal(t, 3, attemptCount, "expected 3 attempts before success")
+}
+
+func TestWebhookNotificationService_SendEscalationNotification_FailsAfterMaxRetries(t *testing.T) {
+	attemptCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attemptCount++
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	registry := jit.NewStaticApproverRegistry(map[string][]string{
+		jit.EscalationTypeDefault: {"admin@example.com"},
+	})
+	svc := jit.NewWebhookNotificationServiceWithConfig(server.URL, registry, jit.WebhookNotificationConfig{
+		RetryBase: time.Millisecond,
+	})
+
+	req := &jit.JITAccessRequest{
+		ID:          "req-fail-1",
+		RequesterID: "user1",
+		TenantID:    "tenant1",
+		Permissions: []string{"admin"},
+	}
+
+	err := svc.SendEscalationNotification(context.Background(), req, 1)
+	require.Error(t, err)
+	assert.Equal(t, 3, attemptCount, "expected exactly 3 attempts before permanent failure")
+
+	// Must NOT record in memory when delivery fails
+	history, histErr := svc.GetNotificationHistory(context.Background(), nil)
+	require.NoError(t, histErr)
+	assert.Empty(t, history, "failed delivery must not leave a phantom record in memory")
+}
+
+func TestWebhookNotificationService_SendEscalationNotification_InvalidWebhookURL(t *testing.T) {
+	registry := jit.NewStaticApproverRegistry(map[string][]string{
+		jit.EscalationTypeDefault: {"admin@example.com"},
+	})
+
+	for _, badURL := range []string{"file:///etc/passwd", "ftp://host/path", "not-a-url"} {
+		svc := jit.NewWebhookNotificationServiceWithConfig(badURL, registry, jit.WebhookNotificationConfig{
+			RetryBase: time.Millisecond,
+		})
+		req := &jit.JITAccessRequest{
+			ID:          "req-ssrf-1",
+			RequesterID: "user1",
+			TenantID:    "tenant1",
+			Permissions: []string{"admin"},
+		}
+		err := svc.SendEscalationNotification(context.Background(), req, 1)
+		require.Error(t, err, "expected error for URL: %s", badURL)
+		assert.Contains(t, err.Error(), "invalid webhook URL", "URL: %s", badURL)
+	}
+}
+
+func TestWebhookNotificationService_SendEscalationNotification_ContextCancellationDuringRetry(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Always return 503 to force retries
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer server.Close()
+
+	registry := jit.NewStaticApproverRegistry(map[string][]string{
+		jit.EscalationTypeDefault: {"admin@example.com"},
+	})
+	// retryBase of 2s ensures context expires during backoff sleep (100ms context timeout)
+	svc := jit.NewWebhookNotificationServiceWithConfig(server.URL, registry, jit.WebhookNotificationConfig{
+		RetryBase: 2 * time.Second,
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	req := &jit.JITAccessRequest{
+		ID:          "req-ctx-1",
+		RequesterID: "user1",
+		TenantID:    "tenant1",
+		Permissions: []string{"admin"},
+	}
+
+	err := svc.SendEscalationNotification(ctx, req, 1)
+	require.Error(t, err, "expected error when context is cancelled")
+}
+
+func TestWebhookNotificationService_SendEscalationNotification_RegistryError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	svc := jit.NewWebhookNotificationServiceWithConfig(server.URL, &errorRegistry{}, jit.WebhookNotificationConfig{
+		RetryBase: time.Millisecond,
+	})
+
+	req := &jit.JITAccessRequest{
+		ID:          "req-reg-err-1",
+		RequesterID: "user1",
+		TenantID:    "tenant1",
+		Permissions: []string{"admin"},
+	}
+
+	err := svc.SendEscalationNotification(context.Background(), req, 1)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "approver registry lookup failed")
+}
+
+func TestWebhookNotificationService_SendEscalationNotification_ClientErrorIsNotRetried(t *testing.T) {
+	// 4xx responses indicate permanent misconfiguration (rejected payload) — must return
+	// an error immediately without retry so the caller knows the escalation was not delivered.
+	attemptCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attemptCount++
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer server.Close()
+
+	registry := jit.NewStaticApproverRegistry(map[string][]string{
+		jit.EscalationTypeDefault: {"admin@example.com"},
+	})
+	svc := jit.NewWebhookNotificationServiceWithConfig(server.URL, registry, jit.WebhookNotificationConfig{
+		RetryBase: time.Millisecond,
+	})
+
+	req := &jit.JITAccessRequest{
+		ID:          "req-4xx-1",
+		RequesterID: "user1",
+		TenantID:    "tenant1",
+		Permissions: []string{"admin"},
+	}
+
+	err := svc.SendEscalationNotification(context.Background(), req, 1)
+	require.Error(t, err, "4xx response must return an error")
+	assert.Contains(t, err.Error(), "webhook rejected")
+	assert.Equal(t, 1, attemptCount, "4xx must not be retried")
+}
+
+func TestWebhookNotificationService_SendEscalationNotification_EmptyApproversDelivers(t *testing.T) {
+	var received []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		received = body
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	// Registry with no recipients for the default escalation type
+	registry := jit.NewStaticApproverRegistry(map[string][]string{})
+	svc := jit.NewWebhookNotificationServiceWithConfig(server.URL, registry, jit.WebhookNotificationConfig{
+		RetryBase: time.Millisecond,
+	})
+
+	req := &jit.JITAccessRequest{
+		ID:          "req-empty-2",
+		RequesterID: "user1",
+		TenantID:    "tenant1",
+		Permissions: []string{"admin"},
+	}
+
+	err := svc.SendEscalationNotification(context.Background(), req, 1)
+	require.NoError(t, err, "empty approver list must not block delivery")
+
+	var payload map[string]interface{}
+	require.NoError(t, json.Unmarshal(received, &payload))
+
+	approvers, ok := payload["approvers"].([]interface{})
+	require.True(t, ok, "approvers field must be an array even when empty")
+	assert.Empty(t, approvers)
 }


### PR DESCRIPTION
## Summary

- Implements `WebhookNotificationService` in `features/rbac/jit/notification.go` — the production delivery channel for JIT escalation notifications via HTTP POST webhook
- Payload carries all AC-required fields: `escalation_id`, `request_id`, `requesting_user`, `requested_permissions`, `approvers`, `escalation_level`, `timestamp`
- Retry policy matches #1603 rollback notifier: 3 attempts, exponential backoff, retries on 5xx/network errors, 4xx treated as permanent failure (no retry)
- `SimpleNotificationService` is retained unchanged for unit tests

Fixes #1623

## What changed

**`features/rbac/jit/notification.go`**
- `EscalationWebhookPayload` — typed JSON body with all required fields
- `WebhookNotificationConfig` — optional overrides (RetryBase, HTTPClient) for test injection
- `WebhookNotificationService` — embeds `*SimpleNotificationService`; overrides `SendEscalationNotification` with real webhook delivery + in-memory record on success
- `sendWebhook` — 3-attempt exponential backoff; SSRF prevention (http/https only); logs host only (not full URL) to protect path secrets; 4xx returns error without retry
- Compile-time interface guard: `var _ NotificationService = (*WebhookNotificationService)(nil)`

**`features/rbac/jit/notification_test.go`**
- 9 new tests using real `httptest.Server` (no mocks)
- Covers: payload delivery, memory store, 5xx retry, max-retry failure, invalid URL (SSRF), context cancellation, registry error, 4xx no-retry, empty approvers
- `errorRegistry` sentinel changed to `errors.New("registry unavailable")`

## Specialist Review Results

| Reviewer | Result | Notes |
|----------|--------|-------|
| QA test runner | **PASS** | All packages, lint, arch checks, security scans, cross-platform builds |
| QA code reviewer | **PASS** | After adding 4xx test and fixing errorRegistry sentinel |
| Security engineer | **PASS** | No blocking issues; SSRF protection, log sanitization, response body caps confirmed |

## Test plan

- [ ] `go test ./features/rbac/jit/...` — all 15 notification tests pass
- [ ] `make test-agent-complete` — full validation suite passes
- [ ] Verify webhook payload via `TestWebhookNotificationService_SendEscalationNotification_DeliversPayload`
- [ ] Verify retry behavior via `TestWebhookNotificationService_SendEscalationNotification_RetriesOnServerError`

🤖 Generated with [Claude Code](https://claude.com/claude-code)