### PR TITLE
controller/api: migrate auth middleware to ctxkeys.UserIDKey (Issue #1635)

### DIFF
--- a/features/controller/api/handlers_config_source.go
+++ b/features/controller/api/handlers_config_source.go
@@ -10,6 +10,7 @@ import (
 	"github.com/gorilla/mux"
 
 	cfgpkg "github.com/cfgis/cfgms/pkg/config"
+	"github.com/cfgis/cfgms/pkg/ctxkeys"
 	"github.com/cfgis/cfgms/pkg/logging"
 	secretsiface "github.com/cfgis/cfgms/pkg/secrets/interfaces"
 )
@@ -73,7 +74,7 @@ func (s *Server) handleConfigSourceTest(w http.ResponseWriter, r *http.Request) 
 	s.mu.RUnlock()
 
 	// Actor is extracted from the authenticated context only — never from request body.
-	actor, _ := r.Context().Value(userIDContextKey).(string)
+	actor, _ := r.Context().Value(ctxkeys.UserIDKey).(string)
 	if actor == "" {
 		actor = "unknown"
 	}

--- a/features/controller/api/middleware.go
+++ b/features/controller/api/middleware.go
@@ -28,7 +28,6 @@ type contextKey string
 const (
 	// Context keys
 	apiKeyContextKey       contextKey = "api_key"
-	userIDContextKey       contextKey = "user_id"
 	authDecisionContextKey contextKey = "auth_decision"
 	principalContextKey    contextKey = "principal"
 )
@@ -208,7 +207,7 @@ func (s *Server) authenticationMiddleware(next http.Handler) http.Handler {
 			}
 			// Cert-auth success: set principal context and proceed.
 			ctx := context.WithValue(r.Context(), principalContextKey, adminPrincipal)
-			ctx = context.WithValue(ctx, userIDContextKey, logging.SanitizeLogValue(adminPrincipal.ID))
+			ctx = context.WithValue(ctx, ctxkeys.UserIDKey, logging.SanitizeLogValue(adminPrincipal.ID))
 			ctx = context.WithValue(ctx, ctxkeys.TenantID, adminPrincipal.TenantID)
 			next.ServeHTTP(w, r.WithContext(ctx))
 			return
@@ -265,7 +264,7 @@ func (s *Server) authenticationMiddleware(next http.Handler) http.Handler {
 		// Add key info and principal to request context
 		ctx := context.WithValue(r.Context(), apiKeyContextKey, keyInfo)
 		ctx = context.WithValue(ctx, principalContextKey, principal)
-		ctx = context.WithValue(ctx, userIDContextKey, keyInfo.ID)
+		ctx = context.WithValue(ctx, ctxkeys.UserIDKey, keyInfo.ID)
 		ctx = context.WithValue(ctx, ctxkeys.TenantID, keyInfo.TenantID)
 
 		next.ServeHTTP(w, r.WithContext(ctx))
@@ -384,7 +383,7 @@ func (s *Server) requirePermission(resourceType, action string) func(http.Handle
 				return
 			}
 
-			userID, _ := r.Context().Value(userIDContextKey).(string)
+			userID, _ := r.Context().Value(ctxkeys.UserIDKey).(string)
 			tenantID, _ := r.Context().Value(ctxkeys.TenantID).(string)
 
 			// Build resource identifier from URL path variables

--- a/features/controller/api/middleware_test.go
+++ b/features/controller/api/middleware_test.go
@@ -752,3 +752,50 @@ func TestExtractAdminPrincipal_NilCertManager_AllowsUnrevoked(t *testing.T) {
 	require.NotNil(t, principal, "admin cert must be accepted when certManager is nil (no revocation checking)")
 	assert.True(t, principal.IsAdmin)
 }
+
+// TestAuthMiddleware_SetsUserIDKey_APIKey verifies that the API-key auth path writes
+// the authenticated user ID under ctxkeys.UserIDKey so downstream readers in
+// features/config/rollback and features/config/diff/approval can find it.
+func TestAuthMiddleware_SetsUserIDKey_APIKey(t *testing.T) {
+	server := setupTestServer(t)
+	apiKeyStr := NewTestKey(t, server, []string{"steward:read"})
+
+	var capturedUserID string
+	handler := server.authenticationMiddleware(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			capturedUserID, _ = r.Context().Value(ctxkeys.UserIDKey).(string)
+			w.WriteHeader(http.StatusOK)
+		}),
+	)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/stewards", nil)
+	req.Header.Set("X-API-Key", apiKeyStr)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	assert.NotEmpty(t, capturedUserID, "ctxkeys.UserIDKey must be set after API-key auth")
+}
+
+// TestAuthMiddleware_SetsUserIDKey_CertAuth verifies that the mTLS admin-cert auth
+// path writes the authenticated user ID under ctxkeys.UserIDKey.
+func TestAuthMiddleware_SetsUserIDKey_CertAuth(t *testing.T) {
+	server := setupTestServer(t)
+	adminCert := makeSelfSignedAdminCert(t)
+
+	var capturedUserID string
+	handler := server.authenticationMiddleware(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			capturedUserID, _ = r.Context().Value(ctxkeys.UserIDKey).(string)
+			w.WriteHeader(http.StatusOK)
+		}),
+	)
+
+	req := requestWithTLSCert(http.MethodGet, "/api/v1/stewards", adminCert)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	assert.NotEmpty(t, capturedUserID, "ctxkeys.UserIDKey must be set after mTLS cert auth")
+	assert.Equal(t, "test-admin", capturedUserID, "UserIDKey must equal the cert CN (sanitized)")
+}

--- a/features/controller/api/validation_middleware.go
+++ b/features/controller/api/validation_middleware.go
@@ -67,7 +67,7 @@ func (s *Server) buildSecurityContext(r *http.Request) *security.SecurityContext
 	}
 
 	// Extract user and tenant info from context if available
-	if userID, ok := r.Context().Value(userIDContextKey).(string); ok {
+	if userID, ok := r.Context().Value(ctxkeys.UserIDKey).(string); ok {
 		ctx.UserID = userID
 	}
 	if tenantID, ok := r.Context().Value(ctxkeys.TenantID).(string); ok {

--- a/features/saas/auth_test.go
+++ b/features/saas/auth_test.go
@@ -55,7 +55,7 @@ func (s *inMemoryCredentialStore) GetToken(tenantID string) (*auth.AccessToken, 
 	return t, nil
 }
 
-func (s *inMemoryCredentialStore) DeleteToken(_ string) error                              { return nil }
+func (s *inMemoryCredentialStore) DeleteToken(_ string) error { return nil }
 func (s *inMemoryCredentialStore) StoreDelegatedToken(_, _ string, _ *auth.AccessToken) error {
 	return nil
 }
@@ -69,7 +69,7 @@ func (s *inMemoryCredentialStore) StoreUserContext(_, _ string, _ *auth.UserCont
 func (s *inMemoryCredentialStore) GetUserContext(_, _ string) (*auth.UserContext, error) {
 	return nil, fmt.Errorf("not implemented")
 }
-func (s *inMemoryCredentialStore) DeleteUserContext(_, _ string) error { return nil }
+func (s *inMemoryCredentialStore) DeleteUserContext(_, _ string) error              { return nil }
 func (s *inMemoryCredentialStore) StoreConfig(_ string, _ *auth.OAuth2Config) error { return nil }
 func (s *inMemoryCredentialStore) GetConfig(_ string) (*auth.OAuth2Config, error) {
 	return nil, fmt.Errorf("not implemented")

--- a/pkg/directory/providers/network_activedirectory/provider_test.go
+++ b/pkg/directory/providers/network_activedirectory/provider_test.go
@@ -539,11 +539,11 @@ func TestNewFromRegistry_WithRegistry_ReturnsConfiguredProvider(t *testing.T) {
 
 	client := NewMockStewardClient()
 	client.AddSteward(StewardInfo{
-		ID:       "steward-dc01",
-		Hostname: "dc01.example.com",
-		Platform: "windows",
-		Modules:  []string{"activedirectory"},
-		Tags:     map[string]string{"ad_domain": "example.com"},
+		ID:        "steward-dc01",
+		Hostname:  "dc01.example.com",
+		Platform:  "windows",
+		Modules:   []string{"activedirectory"},
+		Tags:      map[string]string{"ad_domain": "example.com"},
 		IsHealthy: true,
 	})
 


### PR DESCRIPTION
## Summary

- Removes the package-local `userIDContextKey contextKey = "user_id"` constant from `features/controller/api/middleware.go`
- Writes the authenticated user ID under `ctxkeys.UserIDKey` in both auth paths (cert-auth and API-key)
- Updates all three readers in the `api` package (`requirePermission`, `handleConfigSourceTest`, `buildSecurityContext`) to use `ctxkeys.UserIDKey`
- Adds two middleware tests to pin the correct key is set after each auth path
- Fixes pre-existing gofmt violations in two unrelated test files

## Problem

`middleware.go` wrote the authenticated user ID under a package-local `contextKey("user_id")` string key. Readers in `features/config/rollback` and `features/config/diff/approval` (introduced in #1602) read `ctxkeys.UserIDKey` — a distinct unexported struct-typed key. Because Go context key identity is type-based, `ctx.Value()` never matched, causing every authenticated HTTP request to those paths to be rejected with an "unauthenticated" error.

## Test plan

- [ ] `TestAuthMiddleware_SetsUserIDKey_APIKey` — API-key auth path sets `ctxkeys.UserIDKey`
- [ ] `TestAuthMiddleware_SetsUserIDKey_CertAuth` — mTLS cert auth path sets `ctxkeys.UserIDKey`
- [ ] All pre-existing middleware and controller API tests continue to pass
- [ ] `make test-agent-complete` passes

## Specialist Review Results

- **QA Test Runner**: PASS (after fixing 2 pre-existing gofmt violations unrelated to this story)
- **QA Code Reviewer**: PASS — no mocks, no t.Skip, real CFGMS components, error paths covered
- **Security Engineer**: PASS — no secrets, no injection surfaces, input sanitization preserved, check-architecture clean

Fixes #1635

🤖 Generated with [Claude Code](https://claude.com/claude-code)