### PR TITLE
script: two-tier metadata + cfg script admin command (Issue #1670)

### DIFF
--- a/api/proto/controller/config.pb.go
+++ b/api/proto/controller/config.pb.go
@@ -873,7 +873,7 @@ type ScriptSigningConfig struct {
 	TrustedKeys []*TrustedKeyRef `protobuf:"bytes,3,rep,name=trusted_keys,json=trustedKeys,proto3" json:"trusted_keys,omitempty"`
 	// allow_public_ca, when true alongside trusted_keys_and_public mode, also accepts public CAs.
 	AllowPublicCa bool `protobuf:"varint,4,opt,name=allow_public_ca,json=allowPublicCa,proto3" json:"allow_public_ca,omitempty"`
-	// script_repo_url is the MSP-level Git repository URL for the tenant's script store.
+	// Deprecated: reserved in proto (field 5). Keep for binary-descriptor compatibility until protoc regeneration.
 	ScriptRepoUrl string `protobuf:"bytes,5,opt,name=script_repo_url,json=scriptRepoUrl,proto3" json:"script_repo_url,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -937,6 +937,7 @@ func (x *ScriptSigningConfig) GetAllowPublicCa() bool {
 	return false
 }
 
+// Deprecated: GetScriptRepoUrl is reserved; use ScriptPrivilegeMetadata in the controller API instead.
 func (x *ScriptSigningConfig) GetScriptRepoUrl() string {
 	if x != nil {
 		return x.ScriptRepoUrl

--- a/api/proto/controller/config.proto
+++ b/api/proto/controller/config.proto
@@ -121,8 +121,8 @@ message ScriptSigningConfig {
   // allow_public_ca, when true alongside trusted_keys_and_public mode, also accepts public CAs.
   bool allow_public_ca = 4;
 
-  // script_repo_url is the MSP-level Git repository URL for the tenant's script store.
-  string script_repo_url = 5;
+  reserved 5;
+  reserved "script_repo_url";
 }
 
 // TrustedKeyRef identifies a trusted signing key or certificate.

--- a/cmd/cfg/cmd/script.go
+++ b/cmd/cfg/cmd/script.go
@@ -3,6 +3,8 @@
 package cmd
 
 import (
+	"bytes"
+	"context"
 	"crypto"
 	"crypto/ecdsa"
 	"crypto/rand"
@@ -10,12 +12,17 @@ import (
 	"crypto/sha256"
 	"crypto/sha512"
 	"crypto/x509"
+	"encoding/json"
 	"encoding/pem"
 	"errors"
 	"fmt"
+	"io"
+	"net/http"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
+	"text/tabwriter"
 
 	"github.com/spf13/cobra"
 )
@@ -59,10 +66,228 @@ Exit codes:
   1  signature invalid, not found, or signing failed`,
 }
 
+var (
+	scriptLibURL         string
+	scriptLibAPIKey      string
+	scriptLibTLSCACert   string
+	scriptLibTLSInsecure bool
+)
+
+// scriptPrivilegeScopes holds the --scope flag values for set-privilege.
+var scriptPrivilegeScopes []string
+
+// scriptPrivilegeBindings holds the --param-binding flag values for set-privilege.
+var scriptPrivilegeBindings []string
+
+// scriptListCmd outputs script IDs and names from the controller's script library.
+var scriptListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List scripts in the controller's library",
+	Long: `Display scripts from the git-backed script library on the controller.
+
+Examples:
+  cfg script list --url=https://controller.example.com --api-key=mykey`,
+	RunE: runScriptList,
+}
+
+// scriptShowCmd displays a single script by ID.
+var scriptShowCmd = &cobra.Command{
+	Use:   "show <id>",
+	Short: "Show a script from the library",
+	Long: `Display metadata and content for a specific script from the controller's library.
+
+Examples:
+  cfg script show backup-all --url=https://controller.example.com --api-key=mykey`,
+	Args: cobra.ExactArgs(1),
+	RunE: runScriptShow,
+}
+
+// scriptSetPrivilegeCmd sets controller-side privilege metadata for a script.
+var scriptSetPrivilegeCmd = &cobra.Command{
+	Use:   "set-privilege <id>",
+	Short: "Set privilege metadata for a script",
+	Long: `Configure controller-side privilege constraints for a library script.
+
+  --scope       Required API scope for consumers of this script (repeatable).
+  --param-binding  Parameter→DNA-key binding in the form key=dna.path (repeatable).
+
+Caller must hold every scope they grant and must have steward:read-dna to bind DNA paths.
+
+Examples:
+  cfg script set-privilege backup-all --scope steward:execute-scripts \
+    --url=https://controller.example.com --api-key=mykey`,
+	Args: cobra.ExactArgs(1),
+	RunE: runScriptSetPrivilege,
+}
+
 func init() {
+	// Library subcommand flags
+	for _, cmd := range []*cobra.Command{scriptListCmd, scriptShowCmd, scriptSetPrivilegeCmd} {
+		cmd.Flags().StringVar(&scriptLibURL, "url", "", "Controller API URL")
+		cmd.Flags().StringVar(&scriptLibAPIKey, "api-key", "", "API key for authentication")
+		cmd.Flags().StringVar(&scriptLibTLSCACert, "tls-ca-cert", "", "Path to CA certificate (env: CFGMS_TLS_CA_CERT)")
+		cmd.Flags().BoolVar(&scriptLibTLSInsecure, "tls-insecure", false, "Skip TLS verification (env: CFGMS_TLS_INSECURE)")
+	}
+	scriptSetPrivilegeCmd.Flags().StringArrayVar(&scriptPrivilegeScopes, "scope", nil, "Required API scope (repeatable)")
+	scriptSetPrivilegeCmd.Flags().StringArrayVar(&scriptPrivilegeBindings, "param-binding", nil, "Parameter→DNA binding key=path (repeatable)")
+
+	scriptCmd.AddCommand(scriptListCmd)
+	scriptCmd.AddCommand(scriptShowCmd)
+	scriptCmd.AddCommand(scriptSetPrivilegeCmd)
 	scriptCmd.AddCommand(scriptSignCmd)
 	scriptCmd.AddCommand(scriptVerifyCmd)
 	rootCmd.AddCommand(scriptCmd)
+}
+
+// getScriptLibClient creates an API client for the script library commands.
+func getScriptLibClient() (*APIClient, error) {
+	apiURL := strings.TrimSuffix(scriptLibURL, "/")
+	if apiURL == "" {
+		apiURL = os.Getenv("CFGMS_API_URL")
+	}
+
+	client, err := resolveBundleClient(apiURL)
+	if err != nil {
+		return nil, fmt.Errorf("bundle lookup failed: %w", err)
+	}
+	if client != nil {
+		return client, nil
+	}
+
+	apiKey := scriptLibAPIKey
+	if apiKey == "" {
+		apiKey = os.Getenv("CFGMS_API_KEY")
+	}
+
+	tlsInsecure := scriptLibTLSInsecure
+	if !tlsInsecure && os.Getenv("CFGMS_TLS_INSECURE") == "true" {
+		tlsInsecure = true
+	}
+
+	tlsCACertPath := scriptLibTLSCACert
+	if tlsCACertPath == "" {
+		tlsCACertPath = os.Getenv("CFGMS_TLS_CA_CERT")
+	}
+
+	return newClientFromFlags(apiURL, apiKey, tlsCACertPath, tlsInsecure)
+}
+
+func runScriptList(cmd *cobra.Command, _ []string) error {
+	client, err := getScriptLibClient()
+	if err != nil {
+		return fmt.Errorf("failed to create API client: %w", err)
+	}
+
+	resp, err := client.Get(context.Background(), "/api/v1/scripts")
+	if err != nil {
+		return fmt.Errorf("failed to fetch scripts: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("API request failed: %s - %s", resp.Status, string(body))
+	}
+
+	var apiResp struct {
+		Data []struct {
+			ID   string `json:"id"`
+			Name string `json:"name"`
+		} `json:"data"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&apiResp); err != nil {
+		return fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	if len(apiResp.Data) == 0 {
+		fmt.Fprintln(cmd.OutOrStdout(), "No scripts found.")
+		return nil
+	}
+
+	w := tabwriter.NewWriter(cmd.OutOrStdout(), 0, 0, 2, ' ', 0)
+	_, _ = fmt.Fprintln(w, "ID\tNAME")
+	_, _ = fmt.Fprintln(w, "--\t----")
+	for _, s := range apiResp.Data {
+		_, _ = fmt.Fprintf(w, "%s\t%s\n", s.ID, s.Name)
+	}
+	return w.Flush()
+}
+
+func runScriptShow(cmd *cobra.Command, args []string) error {
+	id := url.PathEscape(args[0])
+
+	client, err := getScriptLibClient()
+	if err != nil {
+		return fmt.Errorf("failed to create API client: %w", err)
+	}
+
+	resp, err := client.Get(context.Background(), "/api/v1/scripts/"+id)
+	if err != nil {
+		return fmt.Errorf("failed to fetch script: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("API request failed: %s - %s", resp.Status, string(body))
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("failed to read response: %w", err)
+	}
+
+	// Pretty-print the JSON response.
+	var pretty bytes.Buffer
+	if err := json.Indent(&pretty, body, "", "  "); err != nil {
+		// Fall back to raw output if the response is not JSON.
+		fmt.Fprintln(cmd.OutOrStdout(), string(body))
+		return nil
+	}
+	fmt.Fprintln(cmd.OutOrStdout(), pretty.String())
+	return nil
+}
+
+func runScriptSetPrivilege(_ *cobra.Command, args []string) error {
+	id := url.PathEscape(args[0])
+
+	// Parse --param-binding flags (format: key=dna.path)
+	paramBindings := make(map[string]string)
+	for _, b := range scriptPrivilegeBindings {
+		parts := strings.SplitN(b, "=", 2)
+		if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+			return fmt.Errorf("invalid --param-binding %q: expected key=dna.path", b)
+		}
+		paramBindings[parts[0]] = parts[1]
+	}
+
+	reqBody := map[string]interface{}{
+		"required_api_scope":      scriptPrivilegeScopes,
+		"param_platform_bindings": paramBindings,
+	}
+	reqJSON, err := json.Marshal(reqBody)
+	if err != nil {
+		return fmt.Errorf("failed to encode request: %w", err)
+	}
+
+	client, err := getScriptLibClient()
+	if err != nil {
+		return fmt.Errorf("failed to create API client: %w", err)
+	}
+
+	resp, err := client.doRequest(context.Background(), http.MethodPut, "/api/v1/scripts/"+id+"/privilege", bytes.NewReader(reqJSON))
+	if err != nil {
+		return fmt.Errorf("failed to set privilege: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("API request failed: %s - %s", resp.Status, string(body))
+	}
+
+	fmt.Printf("Privilege metadata updated for script %s\n", args[0])
+	return nil
 }
 
 // ---------------------------------------------------------------------------

--- a/cmd/cfg/cmd/script_test.go
+++ b/cmd/cfg/cmd/script_test.go
@@ -8,6 +8,10 @@ import (
 	"crypto/elliptic"
 	"crypto/rand"
 	"crypto/rsa"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"crypto/sha256"
 	"crypto/sha512"
 	"crypto/x509"
@@ -658,4 +662,163 @@ func TestEscapePSPath_EmptyString(t *testing.T) {
 	if got != "" {
 		t.Errorf("escapePSPath(%q) = %q, want empty", "", got)
 	}
+}
+
+// ---------------------------------------------------------------------------
+// Script library command tests (Issue #1670)
+// ---------------------------------------------------------------------------
+
+// TestScriptList_OutputsScriptIDsInTabularForm is a REQUIRED acceptance test.
+// It verifies that `cfg script list` outputs script IDs from the git repository in tabular form.
+func TestScriptList_OutputsScriptIDsInTabularForm(t *testing.T) {
+	scripts := []map[string]interface{}{
+		{"id": "backup-all", "name": "Backup All"},
+		{"id": "health-check", "name": "Health Check"},
+	}
+
+	var requestPath string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestPath = r.URL.Path
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{"data": scripts})
+	}))
+	defer server.Close()
+
+	origURL := scriptLibURL
+	origInsecure := scriptLibTLSInsecure
+	t.Cleanup(func() {
+		scriptLibURL = origURL
+		scriptLibTLSInsecure = origInsecure
+	})
+	scriptLibURL = server.URL
+	scriptLibTLSInsecure = true
+
+	output := captureStdout(t, func() {
+		err := runScriptList(scriptListCmd, []string{})
+		if err != nil {
+			t.Fatalf("runScriptList: %v", err)
+		}
+	})
+
+	if requestPath != "/api/v1/scripts" {
+		t.Errorf("expected request to /api/v1/scripts, got %s", requestPath)
+	}
+	if !containsStr(output, "backup-all") {
+		t.Errorf("expected output to contain 'backup-all', got:\n%s", output)
+	}
+	if !containsStr(output, "health-check") {
+		t.Errorf("expected output to contain 'health-check', got:\n%s", output)
+	}
+	// Verify tabular header is present.
+	if !containsStr(output, "ID") || !containsStr(output, "NAME") {
+		t.Errorf("expected tabular header in output, got:\n%s", output)
+	}
+}
+
+// TestScriptList_EmptyReturnsMessage verifies that an empty script list prints a user-friendly message.
+func TestScriptList_EmptyReturnsMessage(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{"data": []interface{}{}})
+	}))
+	defer server.Close()
+
+	origURL := scriptLibURL
+	origInsecure := scriptLibTLSInsecure
+	t.Cleanup(func() {
+		scriptLibURL = origURL
+		scriptLibTLSInsecure = origInsecure
+	})
+	scriptLibURL = server.URL
+	scriptLibTLSInsecure = true
+
+	output := captureStdout(t, func() {
+		err := runScriptList(scriptListCmd, []string{})
+		if err != nil {
+			t.Fatalf("runScriptList: %v", err)
+		}
+	})
+
+	if !containsStr(output, "No scripts found") {
+		t.Errorf("expected 'No scripts found' message, got:\n%s", output)
+	}
+}
+
+// TestScriptList_ServerErrorReturnsError verifies that a non-OK response propagates as an error.
+func TestScriptList_ServerErrorReturnsError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_ = json.NewEncoder(w).Encode(map[string]string{"error": "unauthorized"})
+	}))
+	defer server.Close()
+
+	origURL := scriptLibURL
+	origInsecure := scriptLibTLSInsecure
+	t.Cleanup(func() {
+		scriptLibURL = origURL
+		scriptLibTLSInsecure = origInsecure
+	})
+	scriptLibURL = server.URL
+	scriptLibTLSInsecure = true
+
+	err := runScriptList(scriptListCmd, []string{})
+	if err == nil {
+		t.Error("expected error for non-OK response, got nil")
+	}
+}
+
+// TestScriptShow_PrintsScriptDetails verifies that runScriptShow prints the script JSON.
+func TestScriptShow_PrintsScriptDetails(t *testing.T) {
+	var capturedPath string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedPath = r.URL.Path
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"data": map[string]interface{}{
+				"metadata": map[string]interface{}{"id": "backup-all", "name": "Backup All"},
+				"content":  "#!/bin/bash\necho backup\n",
+			},
+		})
+	}))
+	defer server.Close()
+
+	origURL := scriptLibURL
+	origInsecure := scriptLibTLSInsecure
+	t.Cleanup(func() {
+		scriptLibURL = origURL
+		scriptLibTLSInsecure = origInsecure
+	})
+	scriptLibURL = server.URL
+	scriptLibTLSInsecure = true
+
+	output := captureStdout(t, func() {
+		err := runScriptShow(scriptShowCmd, []string{"backup-all"})
+		if err != nil {
+			t.Fatalf("runScriptShow: %v", err)
+		}
+	})
+
+	if capturedPath != "/api/v1/scripts/backup-all" {
+		t.Errorf("expected path /api/v1/scripts/backup-all, got %s", capturedPath)
+	}
+	if !containsStr(output, "backup-all") {
+		t.Errorf("expected output to contain script ID, got:\n%s", output)
+	}
+}
+
+// TestScriptSetPrivilege_InvalidParamBinding verifies that malformed --param-binding returns an error.
+func TestScriptSetPrivilege_InvalidParamBinding(t *testing.T) {
+	origBindings := scriptPrivilegeBindings
+	t.Cleanup(func() { scriptPrivilegeBindings = origBindings })
+	scriptPrivilegeBindings = []string{"bad-format"}
+
+	err := runScriptSetPrivilege(scriptSetPrivilegeCmd, []string{"some-script"})
+	if err == nil {
+		t.Error("expected error for invalid --param-binding, got nil")
+	}
+}
+
+// containsStr is a helper that checks whether substr appears in s.
+func containsStr(s, substr string) bool {
+	return strings.Contains(s, substr)
 }

--- a/features/controller/api/handlers_scripts.go
+++ b/features/controller/api/handlers_scripts.go
@@ -125,7 +125,7 @@ func (s *Server) handleGetScriptLibraryItem(w http.ResponseWriter, r *http.Reque
 
 	vs, err := s.scriptRepo.Get(id, "")
 	if err != nil {
-		s.logger.Warn("Script not found", "id", sanitizedID, "error", err)
+		s.logger.Warn("Script not found", "id", sanitizedID, "error", logging.SanitizeLogValue(err.Error()))
 		s.writeErrorResponse(w, http.StatusNotFound, "Script not found", "NOT_FOUND")
 		return
 	}

--- a/features/controller/api/handlers_scripts.go
+++ b/features/controller/api/handlers_scripts.go
@@ -3,6 +3,10 @@
 package api
 
 import (
+	"context"
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
 	"net/http"
 	"strconv"
 	"time"
@@ -10,8 +14,202 @@ import (
 	"github.com/gorilla/mux"
 
 	"github.com/cfgis/cfgms/features/modules/script"
+	"github.com/cfgis/cfgms/pkg/ctxkeys"
+	cfgconfig "github.com/cfgis/cfgms/pkg/storage/interfaces/config"
 	"github.com/cfgis/cfgms/pkg/logging"
 )
+
+// ScriptPrivilegeMetadata holds controller-side privilege configuration for a library script.
+// It is stored per-tenant and never included in VersionedScript (steward-visible).
+type ScriptPrivilegeMetadata struct {
+	ScriptID              string            `json:"script_id"`
+	RequiredAPIScope      []string          `json:"required_api_scope,omitempty"`
+	ParamPlatformBindings map[string]string `json:"param_platform_bindings,omitempty"`
+	SetByUserID           string            `json:"set_by_user_id"`
+	SetAt                 time.Time         `json:"set_at"`
+}
+
+// SetPrivilegeRequest is the body of PUT /api/v1/scripts/{id}/privilege.
+type SetPrivilegeRequest struct {
+	RequiredAPIScope      []string          `json:"required_api_scope,omitempty"`
+	ParamPlatformBindings map[string]string `json:"param_platform_bindings,omitempty"`
+}
+
+// storePrivilegeMetadata writes privilege metadata to the config store under the tenant namespace.
+func (s *Server) storePrivilegeMetadata(ctx context.Context, tenantID, scriptID string, meta *ScriptPrivilegeMetadata) error {
+	if s.privilegeStore == nil {
+		return fmt.Errorf("privilege store not configured")
+	}
+
+	data, err := json.Marshal(meta)
+	if err != nil {
+		return fmt.Errorf("failed to marshal privilege metadata: %w", err)
+	}
+
+	checksum := fmt.Sprintf("%x", sha256.Sum256(data))
+	entry := &cfgconfig.ConfigEntry{
+		Key: &cfgconfig.ConfigKey{
+			TenantID:  tenantID,
+			Namespace: "script-privilege",
+			Name:      scriptID,
+		},
+		Data:      data,
+		Format:    cfgconfig.ConfigFormatJSON,
+		Checksum:  checksum,
+		UpdatedAt: meta.SetAt,
+		UpdatedBy: meta.SetByUserID,
+		Source:    "script-admin",
+	}
+
+	return s.privilegeStore.StoreConfig(ctx, entry)
+}
+
+// loadPrivilegeMetadata reads privilege metadata from the config store.
+func (s *Server) loadPrivilegeMetadata(ctx context.Context, tenantID, scriptID string) (*ScriptPrivilegeMetadata, error) {
+	if s.privilegeStore == nil {
+		return nil, fmt.Errorf("privilege store not configured")
+	}
+
+	key := &cfgconfig.ConfigKey{
+		TenantID:  tenantID,
+		Namespace: "script-privilege",
+		Name:      scriptID,
+	}
+
+	entry, err := s.privilegeStore.GetConfig(ctx, key)
+	if err != nil {
+		return nil, fmt.Errorf("privilege metadata not found: %w", err)
+	}
+
+	var meta ScriptPrivilegeMetadata
+	if err := json.Unmarshal(entry.Data, &meta); err != nil {
+		return nil, fmt.Errorf("failed to parse privilege metadata: %w", err)
+	}
+
+	return &meta, nil
+}
+
+// handleListScripts handles GET /api/v1/scripts.
+func (s *Server) handleListScripts(w http.ResponseWriter, r *http.Request) {
+	if s.scriptRepo == nil {
+		s.writeErrorResponse(w, http.StatusServiceUnavailable, "Script library not available", "SERVICE_UNAVAILABLE")
+		return
+	}
+
+	scripts, err := s.scriptRepo.List(nil)
+	if err != nil {
+		s.logger.Error("Failed to list scripts", "error", err)
+		s.writeErrorResponse(w, http.StatusInternalServerError, "Failed to list scripts", "INTERNAL_ERROR")
+		return
+	}
+
+	s.writeSuccessResponse(w, scripts)
+}
+
+// handleGetScriptLibraryItem handles GET /api/v1/scripts/{id}.
+func (s *Server) handleGetScriptLibraryItem(w http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+	id := vars["id"]
+
+	if id == "" {
+		s.writeErrorResponse(w, http.StatusBadRequest, "Script ID is required", "MISSING_SCRIPT_ID")
+		return
+	}
+
+	if s.scriptRepo == nil {
+		s.writeErrorResponse(w, http.StatusServiceUnavailable, "Script library not available", "SERVICE_UNAVAILABLE")
+		return
+	}
+
+	sanitizedID := logging.SanitizeLogValue(id)
+
+	vs, err := s.scriptRepo.Get(id, "")
+	if err != nil {
+		s.logger.Warn("Script not found", "id", sanitizedID, "error", err)
+		s.writeErrorResponse(w, http.StatusNotFound, "Script not found", "NOT_FOUND")
+		return
+	}
+
+	s.logger.Info("Retrieved script", "id", sanitizedID)
+	s.writeSuccessResponse(w, vs)
+}
+
+// handlePutScriptPrivilege handles PUT /api/v1/scripts/{id}/privilege.
+// The PermissionScriptAdmin gate is enforced by requirePermission middleware.
+// Additionally, the caller must hold every scope listed in RequiredAPIScope,
+// and must have steward:read-dna for any ParamPlatformBindings entry.
+func (s *Server) handlePutScriptPrivilege(w http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+	id := vars["id"]
+
+	if id == "" {
+		s.writeErrorResponse(w, http.StatusBadRequest, "Script ID is required", "MISSING_SCRIPT_ID")
+		return
+	}
+
+	tenantID, _ := r.Context().Value(ctxkeys.TenantID).(string)
+
+	principal, ok := r.Context().Value(principalContextKey).(*Principal)
+	if !ok || principal == nil {
+		s.writeErrorResponse(w, http.StatusUnauthorized, "Authentication required", "AUTHENTICATION_REQUIRED")
+		return
+	}
+
+	if s.privilegeStore == nil {
+		s.writeErrorResponse(w, http.StatusServiceUnavailable, "Privilege store not available", "SERVICE_UNAVAILABLE")
+		return
+	}
+
+	var req SetPrivilegeRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		s.writeErrorResponse(w, http.StatusBadRequest, "Invalid request body", "INVALID_REQUEST")
+		return
+	}
+
+	// Held-scope ceiling: caller must personally hold every scope they are granting.
+	for _, scope := range req.RequiredAPIScope {
+		if !s.hasPermission(principal, scope) {
+			s.logger.Warn("Scope ceiling violation: caller lacks scope being granted",
+				"caller", logging.SanitizeLogValue(principal.ID),
+				"scope", logging.SanitizeLogValue(scope),
+			)
+			s.writeErrorResponse(w, http.StatusForbidden,
+				fmt.Sprintf("cannot grant scope %q: caller does not hold it", scope),
+				"INSUFFICIENT_PERMISSIONS")
+			return
+		}
+	}
+
+	// DNA path check: any param-platform binding requires steward:read-dna.
+	if len(req.ParamPlatformBindings) > 0 && !s.hasPermission(principal, "steward:read-dna") {
+		s.logger.Warn("DNA path binding requires steward:read-dna",
+			"caller", logging.SanitizeLogValue(principal.ID),
+		)
+		s.writeErrorResponse(w, http.StatusForbidden,
+			"cannot bind parameters to DNA key paths without steward:read-dna permission",
+			"INSUFFICIENT_PERMISSIONS")
+		return
+	}
+
+	sanitizedID := logging.SanitizeLogValue(id)
+
+	meta := &ScriptPrivilegeMetadata{
+		ScriptID:              id,
+		RequiredAPIScope:      req.RequiredAPIScope,
+		ParamPlatformBindings: req.ParamPlatformBindings,
+		SetByUserID:           principal.ID,
+		SetAt:                 time.Now().UTC(),
+	}
+
+	if err := s.storePrivilegeMetadata(r.Context(), tenantID, id, meta); err != nil {
+		s.logger.Error("Failed to store privilege metadata", "id", sanitizedID, "error", err)
+		s.writeErrorResponse(w, http.StatusInternalServerError, "Failed to store privilege metadata", "INTERNAL_ERROR")
+		return
+	}
+
+	s.logger.Info("Script privilege metadata updated", "id", sanitizedID, "tenant_id", logging.SanitizeLogValue(tenantID))
+	s.writeSuccessResponse(w, meta)
+}
 
 // ScriptExecutionInfo represents script execution information for API responses
 type ScriptExecutionInfo struct {

--- a/features/controller/api/handlers_scripts_test.go
+++ b/features/controller/api/handlers_scripts_test.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -15,6 +16,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/cfgis/cfgms/features/modules/script"
+	pkgtesting "github.com/cfgis/cfgms/pkg/testing"
 )
 
 // newTestScriptTracker opens an in-memory SQLite database and returns a ready
@@ -353,4 +355,248 @@ func TestHandlePostScriptRetry_NotImplemented(t *testing.T) {
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &errResp))
 	require.NotNil(t, errResp.Error)
 	assert.Equal(t, "NOT_IMPLEMENTED", errResp.Error.Code)
+}
+
+// ---------------------------------------------------------------------------
+// Script library handler tests (Issue #1670)
+// ---------------------------------------------------------------------------
+
+// setupScriptLibraryServer creates a test server with a real script repository and privilege store.
+func setupScriptLibraryServer(t *testing.T) (*Server, *script.GitScriptRepository) {
+	t.Helper()
+	server := setupTestServer(t)
+
+	sm := pkgtesting.SetupTestStorage(t)
+	repo, err := script.NewGitScriptRepository(sm.GetConfigStore(), "test-tenant", false)
+	require.NoError(t, err)
+
+	server.SetScriptRepository(repo)
+	server.SetPrivilegeStore(sm.GetConfigStore())
+
+	return server, repo
+}
+
+// seedLibraryScript inserts a script into the repository.
+func seedLibraryScript(t *testing.T, repo *script.GitScriptRepository, id, name string) {
+	t.Helper()
+	vs := &script.VersionedScript{
+		Metadata: &script.ScriptMetadata{
+			ID:       id,
+			Name:     name,
+			Version:  &script.Version{Major: 1, Minor: 0, Patch: 0},
+			Shell:    script.ShellBash,
+			Platform: []string{"linux"},
+		},
+		Content: "#!/bin/bash\necho " + name + "\n",
+	}
+	require.NoError(t, repo.Create(vs))
+}
+
+// TestHandleListScripts_ReturnsSeededScripts verifies GET /api/v1/scripts returns scripts from the repo.
+func TestHandleListScripts_ReturnsSeededScripts(t *testing.T) {
+	server, repo := setupScriptLibraryServer(t)
+	apiKey := NewTestKey(t, server, []string{"script:admin"})
+
+	seedLibraryScript(t, repo, "backup-all", "Backup All")
+	seedLibraryScript(t, repo, "health-check", "Health Check")
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/scripts", nil)
+	req.Header.Set("X-API-Key", apiKey)
+	rec := httptest.NewRecorder()
+	server.router.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var resp APIResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+
+	items, ok := resp.Data.([]interface{})
+	require.True(t, ok, "expected array in data")
+	assert.Len(t, items, 2)
+
+	ids := make([]string, 0, len(items))
+	for _, item := range items {
+		m, ok := item.(map[string]interface{})
+		require.True(t, ok)
+		ids = append(ids, m["id"].(string))
+	}
+	assert.Contains(t, ids, "backup-all")
+	assert.Contains(t, ids, "health-check")
+}
+
+// TestHandleListScripts_ServiceUnavailable verifies 503 when no repo is wired.
+func TestHandleListScripts_ServiceUnavailable(t *testing.T) {
+	server := setupTestServer(t)
+	apiKey := NewTestKey(t, server, []string{"script:admin"})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/scripts", nil)
+	req.Header.Set("X-API-Key", apiKey)
+	rec := httptest.NewRecorder()
+	server.router.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusServiceUnavailable, rec.Code)
+}
+
+// TestHandleGetScriptLibraryItem_Found verifies GET /api/v1/scripts/{id} returns a real script.
+func TestHandleGetScriptLibraryItem_Found(t *testing.T) {
+	server, repo := setupScriptLibraryServer(t)
+	apiKey := NewTestKey(t, server, []string{"script:admin"})
+
+	seedLibraryScript(t, repo, "deploy-agent", "Deploy Agent")
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/scripts/deploy-agent", nil)
+	req.Header.Set("X-API-Key", apiKey)
+	rec := httptest.NewRecorder()
+	server.router.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var resp APIResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	m, ok := resp.Data.(map[string]interface{})
+	require.True(t, ok)
+	meta, ok := m["metadata"].(map[string]interface{})
+	require.True(t, ok)
+	assert.Equal(t, "deploy-agent", meta["id"])
+}
+
+// TestHandleGetScriptLibraryItem_NotFound verifies 404 for an unknown script ID.
+func TestHandleGetScriptLibraryItem_NotFound(t *testing.T) {
+	server, _ := setupScriptLibraryServer(t)
+	apiKey := NewTestKey(t, server, []string{"script:admin"})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/scripts/does-not-exist", nil)
+	req.Header.Set("X-API-Key", apiKey)
+	rec := httptest.NewRecorder()
+	server.router.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+}
+
+// TestHandlePutScriptPrivilege_ScopeNotHeldByCallerReturns403 is a REQUIRED acceptance test.
+// Even when the caller has PermissionScriptAdmin, granting a scope they don't hold must return 403.
+func TestHandlePutScriptPrivilege_ScopeNotHeldByCallerReturns403(t *testing.T) {
+	server, repo := setupScriptLibraryServer(t)
+	// Caller has script:admin but NOT config:push.
+	apiKey := NewTestKey(t, server, []string{"script:admin"})
+
+	seedLibraryScript(t, repo, "priv-test", "Priv Test")
+
+	body := `{"required_api_scope": ["config:push"]}`
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/scripts/priv-test/privilege", strings.NewReader(body))
+	req.Header.Set("X-API-Key", apiKey)
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	server.router.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusForbidden, rec.Code, "must return 403 when granting scope caller does not hold")
+}
+
+// TestHandlePutScriptPrivilege_DNAPathWithoutReadDNAReturns403 is a REQUIRED acceptance test.
+// A ParamPlatformBindings entry pointing to a DNA key path without steward:read-dna returns 403.
+func TestHandlePutScriptPrivilege_DNAPathWithoutReadDNAReturns403(t *testing.T) {
+	server, repo := setupScriptLibraryServer(t)
+	// Caller has script:admin but NOT steward:read-dna.
+	apiKey := NewTestKey(t, server, []string{"script:admin"})
+
+	seedLibraryScript(t, repo, "dna-priv-test", "DNA Priv Test")
+
+	body := `{"param_platform_bindings": {"os_version": "OS.Version"}}`
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/scripts/dna-priv-test/privilege", strings.NewReader(body))
+	req.Header.Set("X-API-Key", apiKey)
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	server.router.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusForbidden, rec.Code, "must return 403 when binding DNA paths without steward:read-dna")
+}
+
+// TestHandlePutScriptPrivilege_AllowedWhenCallerHoldsScopes verifies successful privilege update.
+func TestHandlePutScriptPrivilege_AllowedWhenCallerHoldsScopes(t *testing.T) {
+	server, repo := setupScriptLibraryServer(t)
+	// Caller has script:admin AND steward:read-scripts.
+	apiKey := NewTestKey(t, server, []string{"script:admin", "steward:read-scripts"})
+
+	seedLibraryScript(t, repo, "ok-priv", "OK Priv")
+
+	body := `{"required_api_scope": ["steward:read-scripts"]}`
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/scripts/ok-priv/privilege", strings.NewReader(body))
+	req.Header.Set("X-API-Key", apiKey)
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	server.router.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var resp APIResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	m, ok := resp.Data.(map[string]interface{})
+	require.True(t, ok)
+	assert.Equal(t, "ok-priv", m["script_id"])
+}
+
+// TestHandlePutScriptPrivilege_DNAPathAllowedWithReadDNA verifies DNA binding when caller has steward:read-dna.
+func TestHandlePutScriptPrivilege_DNAPathAllowedWithReadDNA(t *testing.T) {
+	server, repo := setupScriptLibraryServer(t)
+	apiKey := NewTestKey(t, server, []string{"script:admin", "steward:read-dna"})
+
+	seedLibraryScript(t, repo, "dna-ok", "DNA OK")
+
+	body := `{"param_platform_bindings": {"os_version": "OS.Version"}}`
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/scripts/dna-ok/privilege", strings.NewReader(body))
+	req.Header.Set("X-API-Key", apiKey)
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	server.router.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+}
+
+// TestHandlePutScriptPrivilege_TenantIsolation verifies that privilege metadata is tenant-scoped.
+func TestHandlePutScriptPrivilege_TenantIsolation(t *testing.T) {
+	server, repo := setupScriptLibraryServer(t)
+	// Create keys for different tenants.
+	keyTenantA := NewEphemeralTestKey(t, server, []string{"script:admin"}, "tenant-a", 5*time.Minute)
+	keyTenantB := NewEphemeralTestKey(t, server, []string{"script:admin"}, "tenant-b", 5*time.Minute)
+
+	seedLibraryScript(t, repo, "shared-id", "Shared Script")
+
+	// Tenant A sets privilege (no required scopes so no scope ceiling issue).
+	body := `{}`
+	reqA := httptest.NewRequest(http.MethodPut, "/api/v1/scripts/shared-id/privilege", strings.NewReader(body))
+	reqA.Header.Set("X-API-Key", keyTenantA)
+	reqA.Header.Set("Content-Type", "application/json")
+	recA := httptest.NewRecorder()
+	server.router.ServeHTTP(recA, reqA)
+	require.Equal(t, http.StatusOK, recA.Code)
+
+	// Tenant B sets privilege with different data.
+	bodyB := `{"required_api_scope": []}`
+	reqB := httptest.NewRequest(http.MethodPut, "/api/v1/scripts/shared-id/privilege", strings.NewReader(bodyB))
+	reqB.Header.Set("X-API-Key", keyTenantB)
+	reqB.Header.Set("Content-Type", "application/json")
+	recB := httptest.NewRecorder()
+	server.router.ServeHTTP(recB, reqB)
+	require.Equal(t, http.StatusOK, recB.Code)
+}
+
+// TestHandlePutScriptPrivilege_ServiceUnavailable verifies 503 when privilege store is not wired.
+func TestHandlePutScriptPrivilege_ServiceUnavailable(t *testing.T) {
+	server := setupTestServer(t)
+	// Wire repo but not privilege store.
+	sm := pkgtesting.SetupTestStorage(t)
+	repo, err := script.NewGitScriptRepository(sm.GetConfigStore(), "test-tenant", false)
+	require.NoError(t, err)
+	server.SetScriptRepository(repo)
+
+	apiKey := NewTestKey(t, server, []string{"script:admin"})
+
+	body := `{}`
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/scripts/any-id/privilege", strings.NewReader(body))
+	req.Header.Set("X-API-Key", apiKey)
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	server.router.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusServiceUnavailable, rec.Code)
 }

--- a/features/controller/api/permissions.go
+++ b/features/controller/api/permissions.go
@@ -65,6 +65,8 @@ var knownPermissions = map[string]bool{
 	"compliance:read-summary": true,
 	// Tenant management
 	"tenant:manage": true,
+	// Script library administration (Issue #1670)
+	"script:admin": true,
 }
 
 // isKnownPermission reports whether p is a recognized permission ID.

--- a/features/controller/api/server.go
+++ b/features/controller/api/server.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cfgis/cfgms/features/controller/push"
 	"github.com/cfgis/cfgms/features/controller/service"
 	"github.com/cfgis/cfgms/features/modules/script"
+	cfgconfig "github.com/cfgis/cfgms/pkg/storage/interfaces/config"
 	"github.com/cfgis/cfgms/features/monitoring"
 	"github.com/cfgis/cfgms/features/rbac"
 	"github.com/cfgis/cfgms/features/rbac/authdefense"
@@ -73,6 +74,8 @@ type Server struct {
 	scriptTracker           script.ExecutionTracker        // Issue #708: durable execution audit records
 	scriptAuditLogger       *script.AuditLogger            // Issue #708: in-memory execution metrics
 	scriptMonitor           *script.ExecutionMonitor       // Issue #708: active execution tracking
+	scriptRepo              script.ScriptRepository        // Issue #1670: git-backed script library
+	privilegeStore          cfgconfig.ConfigStore          // Issue #1670: controller-side script privilege metadata
 	pushLeaderStatus        leaderStatus                   // Issue #1318: leader check for config push (nil = leader)
 	commandPublisher        *commands.Publisher            // Issue #1319: fan-out config push to active stewards
 	pushStore               business.PushStore             // Issue #1320: durable push-state persistence for HA failover
@@ -323,6 +326,12 @@ func (s *Server) setupRouter() {
 	stewards.Handle("/{id}/scripts/executions/{execution_id}/retry", s.requirePermission("steward", "execute-scripts")(http.HandlerFunc(s.handlePostScriptRetry))).Methods("POST")
 	stewards.Handle("/{id}/scripts/metrics", s.requirePermission("steward", "read-scripts")(http.HandlerFunc(s.handleGetScriptMetrics))).Methods("GET")
 	stewards.Handle("/{id}/scripts/status", s.requirePermission("steward", "read-scripts")(http.HandlerFunc(s.handleGetScriptStatus))).Methods("GET")
+
+	// Script library endpoints (Issue #1670)
+	scripts := api.PathPrefix("/scripts").Subrouter()
+	scripts.Handle("", s.requirePermission("script", "admin")(http.HandlerFunc(s.handleListScripts))).Methods("GET")
+	scripts.Handle("/{id}", s.requirePermission("script", "admin")(http.HandlerFunc(s.handleGetScriptLibraryItem))).Methods("GET")
+	scripts.Handle("/{id}/privilege", s.requirePermission("script", "admin")(http.HandlerFunc(s.handlePutScriptPrivilege))).Methods("PUT")
 
 	// Configuration list endpoint (Issue #1570)
 	api.Handle("/configs", s.requirePermission("config", "list")(http.HandlerFunc(s.handleListConfigs))).Methods("GET")
@@ -635,6 +644,24 @@ func (s *Server) SetScriptModule(tracker script.ExecutionTracker, auditLogger *s
 	s.scriptTracker = tracker
 	s.scriptAuditLogger = auditLogger
 	s.scriptMonitor = monitor
+}
+
+// SetScriptRepository wires the git-backed script library so that
+// GET /api/v1/scripts returns real script metadata (Issue #1670).
+// Call this after New() returns but before Start() is called.
+func (s *Server) SetScriptRepository(r script.ScriptRepository) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.scriptRepo = r
+}
+
+// SetPrivilegeStore wires the config store used to persist controller-side
+// script privilege metadata (Issue #1670).
+// Call this after New() returns but before Start() is called.
+func (s *Server) SetPrivilegeStore(cs cfgconfig.ConfigStore) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.privilegeStore = cs
 }
 
 // SetRegistry wires the active-steward connection registry so that

--- a/features/modules/script/repository_git.go
+++ b/features/modules/script/repository_git.go
@@ -11,7 +11,6 @@ import (
 
 	"gopkg.in/yaml.v3"
 
-	"github.com/cfgis/cfgms/pkg/storage/interfaces"
 	cfgconfig "github.com/cfgis/cfgms/pkg/storage/interfaces/config"
 )
 
@@ -24,11 +23,9 @@ type GitScriptRepository struct {
 }
 
 // NewGitScriptRepository creates a new git-based script repository
-func NewGitScriptRepository(storage interfaces.StorageProvider, tenantID string, global bool) (*GitScriptRepository, error) {
-	// Create ConfigStore from provider
-	configStore, err := storage.CreateConfigStore(nil)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create config store: %w", err)
+func NewGitScriptRepository(configStore cfgconfig.ConfigStore, tenantID string, global bool) (*GitScriptRepository, error) {
+	if configStore == nil {
+		return nil, fmt.Errorf("configStore is required")
 	}
 
 	namespace := "scripts"
@@ -96,6 +93,11 @@ func (r *GitScriptRepository) Get(id string, version string) (*VersionedScript, 
 	expectedHash := r.calculateHash(script.Content)
 	if script.Hash != expectedHash {
 		return nil, fmt.Errorf("script integrity check failed: hash mismatch")
+	}
+
+	// Apply system default timeout for scripts stored with Timeout == 0.
+	if script.Metadata != nil && script.Metadata.Timeout == 0 {
+		script.Metadata.Timeout = 15 * time.Minute
 	}
 
 	return &script, nil

--- a/features/modules/script/versioning.go
+++ b/features/modules/script/versioning.go
@@ -114,6 +114,8 @@ type ScriptMetadata struct {
 	Parameters  []ScriptParameter `json:"parameters,omitempty" yaml:"parameters,omitempty"` // Script parameters
 	CreatedAt   time.Time         `json:"created_at" yaml:"created_at"`                     // Creation timestamp
 	UpdatedAt   time.Time         `json:"updated_at" yaml:"updated_at"`                     // Last update timestamp
+	Idempotent  bool              `json:"idempotent,omitempty" yaml:"idempotent,omitempty"` // Whether the script is idempotent (safe to run multiple times)
+	Timeout     time.Duration     `json:"timeout,omitempty" yaml:"timeout,omitempty"`       // Maximum execution time; zero means use system default (15 min)
 }
 
 // ScriptParameter defines a parameter that can be passed to the script
@@ -129,9 +131,10 @@ type ScriptParameter struct {
 
 // VersionedScript represents a complete versioned script
 type VersionedScript struct {
-	Metadata *ScriptMetadata `json:"metadata" yaml:"metadata"` // Script metadata
-	Content  string          `json:"content" yaml:"content"`   // Script content
-	Hash     string          `json:"hash" yaml:"hash"`         // Content hash for integrity
+	Metadata  *ScriptMetadata  `json:"metadata" yaml:"metadata"`                   // Script metadata
+	Content   string           `json:"content" yaml:"content"`                     // Script content
+	Hash      string           `json:"hash" yaml:"hash"`                           // Content hash for integrity
+	Signature *ScriptSignature `json:"signature,omitempty" yaml:"signature,omitempty"` // Detached signature (optional)
 }
 
 // ScriptRepository defines the interface for script storage and versioning

--- a/features/modules/script/versioning_test.go
+++ b/features/modules/script/versioning_test.go
@@ -8,6 +8,9 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+
+	pkgtesting "github.com/cfgis/cfgms/pkg/testing"
 )
 
 func TestParseVersion(t *testing.T) {
@@ -244,4 +247,120 @@ func TestScriptMetadataClone(t *testing.T) {
 	// Ensure deep copy (modifying clone doesn't affect original)
 	clone.Tags[0] = "modified"
 	assert.NotEqual(t, original.Tags[0], clone.Tags[0])
+}
+
+// TestVersionedScriptYAMLRoundTrip_NewFields verifies that Signature, Idempotent, and Timeout
+// round-trip through YAML marshalling both when present and when absent.
+func TestVersionedScriptYAMLRoundTrip_NewFields(t *testing.T) {
+	t.Run("fields present", func(t *testing.T) {
+		original := &VersionedScript{
+			Metadata: &ScriptMetadata{
+				ID:         "test-script",
+				Name:       "Test Script",
+				Version:    &Version{Major: 1, Minor: 0, Patch: 0},
+				Shell:      ShellBash,
+				Platform:   []string{"linux"},
+				Idempotent: true,
+				Timeout:    30 * time.Minute,
+			},
+			Content: "#!/bin/bash\necho hello\n",
+			Hash:    "abc123",
+			Signature: &ScriptSignature{
+				Algorithm:  "rsa-sha256",
+				Signature:  "base64sig==",
+				PublicKey:  "base64pub==",
+				Thumbprint: "fingerprint",
+			},
+		}
+
+		data, err := yaml.Marshal(original)
+		require.NoError(t, err)
+
+		var restored VersionedScript
+		require.NoError(t, yaml.Unmarshal(data, &restored))
+
+		require.NotNil(t, restored.Metadata)
+		assert.True(t, restored.Metadata.Idempotent)
+		assert.Equal(t, 30*time.Minute, restored.Metadata.Timeout)
+		require.NotNil(t, restored.Signature)
+		assert.Equal(t, "rsa-sha256", restored.Signature.Algorithm)
+		assert.Equal(t, "base64sig==", restored.Signature.Signature)
+		assert.Equal(t, "fingerprint", restored.Signature.Thumbprint)
+	})
+
+	t.Run("fields absent", func(t *testing.T) {
+		original := &VersionedScript{
+			Metadata: &ScriptMetadata{
+				ID:       "min-script",
+				Name:     "Minimal Script",
+				Version:  &Version{Major: 1, Minor: 0, Patch: 0},
+				Shell:    ShellBash,
+				Platform: []string{"linux"},
+			},
+			Content: "#!/bin/bash\necho hi\n",
+			Hash:    "def456",
+		}
+
+		data, err := yaml.Marshal(original)
+		require.NoError(t, err)
+
+		var restored VersionedScript
+		require.NoError(t, yaml.Unmarshal(data, &restored))
+
+		require.NotNil(t, restored.Metadata)
+		assert.False(t, restored.Metadata.Idempotent)
+		assert.Equal(t, time.Duration(0), restored.Metadata.Timeout)
+		assert.Nil(t, restored.Signature)
+	})
+}
+
+// TestGitScriptRepository_TimeoutDefault verifies that Get returns Timeout = 15 * time.Minute
+// for a script stored with Timeout == 0.
+func TestGitScriptRepository_TimeoutDefault(t *testing.T) {
+	sm := pkgtesting.SetupTestStorage(t)
+	repo, err := NewGitScriptRepository(sm.GetConfigStore(), "test-tenant", false)
+	require.NoError(t, err)
+
+	script := &VersionedScript{
+		Metadata: &ScriptMetadata{
+			ID:       "timeout-test",
+			Name:     "Timeout Test",
+			Version:  &Version{Major: 1, Minor: 0, Patch: 0},
+			Shell:    ShellBash,
+			Platform: []string{"linux"},
+			// Timeout intentionally zero — Get must apply the 15-min default.
+		},
+		Content: "#!/bin/bash\ndate\n",
+	}
+	require.NoError(t, repo.Create(script))
+
+	got, err := repo.Get("timeout-test", "")
+	require.NoError(t, err)
+	require.NotNil(t, got.Metadata)
+	assert.Equal(t, 15*time.Minute, got.Metadata.Timeout, "Get must return 15-min default for zero Timeout")
+}
+
+// TestGitScriptRepository_TimeoutPreserved verifies that a non-zero Timeout is not overwritten.
+func TestGitScriptRepository_TimeoutPreserved(t *testing.T) {
+	sm := pkgtesting.SetupTestStorage(t)
+	repo, err := NewGitScriptRepository(sm.GetConfigStore(), "test-tenant-2", false)
+	require.NoError(t, err)
+
+	script := &VersionedScript{
+		Metadata: &ScriptMetadata{
+			ID:       "timeout-preserved",
+			Name:     "Timeout Preserved",
+			Version:  &Version{Major: 1, Minor: 0, Patch: 0},
+			Shell:    ShellBash,
+			Platform: []string{"linux"},
+			Timeout:  5 * time.Minute,
+		},
+		Content: "#!/bin/bash\ndate\n",
+	}
+	require.NoError(t, repo.Create(script))
+
+	got, err := repo.Get("timeout-preserved", "")
+	require.NoError(t, err)
+	require.NotNil(t, got.Metadata)
+	assert.Equal(t, 5*time.Minute, got.Metadata.Timeout, "explicitly set Timeout must not be overwritten")
 }

--- a/features/steward/config/config.go
+++ b/features/steward/config/config.go
@@ -55,6 +55,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"runtime"
+	"strings"
 	"time"
 
 	"gopkg.in/yaml.v3"
@@ -245,10 +246,6 @@ type ScriptSigningConfig struct {
 	// AllowPublicCA, when true alongside trusted_keys_and_public mode, also accepts
 	// signatures from public certificate authorities.
 	AllowPublicCA bool `yaml:"allow_public_ca,omitempty"`
-
-	// ScriptRepoURL is the MSP-level Git repository URL for the tenant's script store.
-	// Tenant-scoped; child tenants may override this to point to their own repo.
-	ScriptRepoURL string `yaml:"script_repo_url,omitempty"`
 }
 
 // ResourceConfig defines a single resource to be managed by the steward.
@@ -386,7 +383,9 @@ func loadFromPath(configPath string) (StewardConfig, error) {
 	// This supports ${VAR} and ${VAR:-default} syntax for explicit env var references
 	expandedData := expandEnvWithDefaults(content)
 
-	if err := yaml.Unmarshal([]byte(expandedData), &config); err != nil {
+	dec := yaml.NewDecoder(strings.NewReader(expandedData))
+	dec.KnownFields(true)
+	if err := dec.Decode(&config); err != nil {
 		return config, fmt.Errorf("failed to parse configuration: %w", err)
 	}
 
@@ -598,11 +597,6 @@ func MergeScriptSigningConfig(parent, child ScriptSigningConfig) (ScriptSigningC
 	// AllowPublicCA: child inherits parent value if not set (bool — treat parent true as inherited)
 	if !result.AllowPublicCA && parent.AllowPublicCA {
 		result.AllowPublicCA = parent.AllowPublicCA
-	}
-
-	// ScriptRepoURL: child overrides parent; inherit if child has none
-	if result.ScriptRepoURL == "" {
-		result.ScriptRepoURL = parent.ScriptRepoURL
 	}
 
 	return result, nil

--- a/features/steward/config/config.go
+++ b/features/steward/config/config.go
@@ -50,7 +50,9 @@
 package config
 
 import (
+	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -386,7 +388,12 @@ func loadFromPath(configPath string) (StewardConfig, error) {
 	dec := yaml.NewDecoder(strings.NewReader(expandedData))
 	dec.KnownFields(true)
 	if err := dec.Decode(&config); err != nil {
-		return config, fmt.Errorf("failed to parse configuration: %w", err)
+		// An empty (or whitespace-only) configuration file yields io.EOF from the
+		// streaming decoder. Treat it as an empty config: defaults are applied below
+		// and ID falls back to the hostname.
+		if !errors.Is(err, io.EOF) {
+			return config, fmt.Errorf("failed to parse configuration: %w", err)
+		}
 	}
 
 	// Security invariant: DriftMode must come from controller-delivered cfg only.

--- a/features/steward/config/config_test.go
+++ b/features/steward/config/config_test.go
@@ -879,6 +879,22 @@ resources:
 	require.Error(t, err, "config with removed script_repo_url field must fail to load")
 }
 
+// TestLoadConfiguration_EmptyFileAppliesDefaults verifies that a completely empty
+// configuration file loads without error and falls through to default application.
+// The streaming YAML decoder returns io.EOF on an empty document; loadFromPath must
+// treat that as an empty config rather than a parse failure.
+func TestLoadConfiguration_EmptyFileAppliesDefaults(t *testing.T) {
+	tempDir := t.TempDir()
+	configFile := filepath.Join(tempDir, "empty.cfg")
+	require.NoError(t, os.WriteFile(configFile, []byte(""), 0644))
+
+	cfg, err := LoadConfiguration(configFile)
+	require.NoError(t, err, "empty config file must load without error")
+
+	assert.Equal(t, ModeStandalone, cfg.Steward.Mode, "empty config defaults to standalone mode")
+	assert.NotEmpty(t, cfg.Steward.ID, "empty config defaults ID to hostname")
+}
+
 func TestScriptSigningConfigValidationInLoadConfiguration(t *testing.T) {
 	tempDir := t.TempDir()
 	configFile := filepath.Join(tempDir, "test.cfg")

--- a/features/steward/config/config_test.go
+++ b/features/steward/config/config_test.go
@@ -681,14 +681,6 @@ func TestValidateScriptSigningConfig(t *testing.T) {
 			wantErr: true,
 			errMsg:  "thumbprint or public_key_ref",
 		},
-		{
-			name: "script_repo_url is optional and does not affect validation",
-			cfg: ScriptSigningConfig{
-				Policy:        ScriptSigningPolicyNone,
-				ScriptRepoURL: "https://git.example.com/msp/scripts.git",
-			},
-			wantErr: false,
-		},
 	}
 
 	for _, tt := range tests {
@@ -708,14 +700,13 @@ func TestValidateScriptSigningConfig(t *testing.T) {
 
 func TestMergeScriptSigningConfig(t *testing.T) {
 	tests := []struct {
-		name        string
-		parent      ScriptSigningConfig
-		child       ScriptSigningConfig
-		wantErr     bool
-		errMsg      string
-		wantPolicy  ScriptSigningPolicy
-		wantMode    ScriptTrustMode
-		wantRepoURL string
+		name       string
+		parent     ScriptSigningConfig
+		child      ScriptSigningConfig
+		wantErr    bool
+		errMsg     string
+		wantPolicy ScriptSigningPolicy
+		wantMode   ScriptTrustMode
 	}{
 		{
 			name:       "empty parent and child returns empty",
@@ -797,28 +788,6 @@ func TestMergeScriptSigningConfig(t *testing.T) {
 			errMsg:  "loosen",
 		},
 		{
-			name: "child overrides script_repo_url",
-			parent: ScriptSigningConfig{
-				Policy:        ScriptSigningPolicyNone,
-				ScriptRepoURL: "https://parent.example.com/scripts.git",
-			},
-			child: ScriptSigningConfig{
-				ScriptRepoURL: "https://child.example.com/scripts.git",
-			},
-			wantPolicy:  ScriptSigningPolicyNone,
-			wantRepoURL: "https://child.example.com/scripts.git",
-		},
-		{
-			name: "child inherits parent script_repo_url when not set",
-			parent: ScriptSigningConfig{
-				Policy:        ScriptSigningPolicyNone,
-				ScriptRepoURL: "https://parent.example.com/scripts.git",
-			},
-			child:       ScriptSigningConfig{},
-			wantPolicy:  ScriptSigningPolicyNone,
-			wantRepoURL: "https://parent.example.com/scripts.git",
-		},
-		{
 			name: "child overrides trusted keys",
 			parent: ScriptSigningConfig{
 				Policy:    ScriptSigningPolicyRequired,
@@ -852,9 +821,6 @@ func TestMergeScriptSigningConfig(t *testing.T) {
 			if tt.wantMode != "" {
 				assert.Equal(t, tt.wantMode, result.TrustMode)
 			}
-			if tt.wantRepoURL != "" {
-				assert.Equal(t, tt.wantRepoURL, result.ScriptRepoURL)
-			}
 		})
 	}
 }
@@ -871,7 +837,6 @@ func TestScriptSigningConfigInConfigFile(t *testing.T) {
     trusted_keys:
       - name: corp-cert
         thumbprint: abc123def456
-    script_repo_url: https://git.example.com/msp/scripts.git
 
 resources:
   - name: test-resource
@@ -888,7 +853,30 @@ resources:
 	assert.Len(t, cfg.Steward.ScriptSigning.TrustedKeys, 1)
 	assert.Equal(t, "corp-cert", cfg.Steward.ScriptSigning.TrustedKeys[0].Name)
 	assert.Equal(t, "abc123def456", cfg.Steward.ScriptSigning.TrustedKeys[0].Thumbprint)
-	assert.Equal(t, "https://git.example.com/msp/scripts.git", cfg.Steward.ScriptSigning.ScriptRepoURL)
+}
+
+// TestLoadConfiguration_ScriptRepoURLIsRejected verifies that a config file containing
+// the removed script_repo_url field is rejected with a clear error (clean break).
+func TestLoadConfiguration_ScriptRepoURLIsRejected(t *testing.T) {
+	tempDir := t.TempDir()
+	configFile := filepath.Join(tempDir, "test.cfg")
+
+	configData := `steward:
+  id: test-steward
+  script_signing:
+    policy: none
+    script_repo_url: https://git.example.com/msp/scripts.git
+
+resources:
+  - name: test-resource
+    module: test-module
+    config:
+      key: value
+`
+	require.NoError(t, os.WriteFile(configFile, []byte(configData), 0644))
+
+	_, err := LoadConfiguration(configFile)
+	require.Error(t, err, "config with removed script_repo_url field must fail to load")
 }
 
 func TestScriptSigningConfigValidationInLoadConfiguration(t *testing.T) {

--- a/features/steward/config/proto_converter.go
+++ b/features/steward/config/proto_converter.go
@@ -58,7 +58,6 @@ func ToProto(config *StewardConfig) (*controller.StewardConfig, error) {
 		Policy:        string(ss.Policy),
 		TrustMode:     string(ss.TrustMode),
 		AllowPublicCa: ss.AllowPublicCA,
-		ScriptRepoUrl: ss.ScriptRepoURL,
 	}
 	for _, key := range ss.TrustedKeys {
 		protoSS.TrustedKeys = append(protoSS.TrustedKeys, &controller.TrustedKeyRef{
@@ -145,7 +144,6 @@ func FromProto(proto *controller.StewardConfig) (*StewardConfig, error) {
 			Policy:        ScriptSigningPolicy(ps.Policy),
 			TrustMode:     ScriptTrustMode(ps.TrustMode),
 			AllowPublicCA: ps.AllowPublicCa,
-			ScriptRepoURL: ps.ScriptRepoUrl,
 		}
 		for _, key := range ps.TrustedKeys {
 			sc.TrustedKeys = append(sc.TrustedKeys, TrustedKeyRef{

--- a/features/steward/config/proto_converter_test.go
+++ b/features/steward/config/proto_converter_test.go
@@ -124,10 +124,8 @@ func TestToProtoFromProto_ScriptSigning(t *testing.T) {
 			ID:   "signing-steward",
 			Mode: ModeStandalone,
 			ScriptSigning: ScriptSigningConfig{
-				Policy:        ScriptSigningPolicyRequired,
-				TrustMode:     TrustModeTrustedKeys,
-				AllowPublicCA: false,
-				ScriptRepoURL: "https://git.example.com/scripts",
+				Policy:    ScriptSigningPolicyRequired,
+				TrustMode: TrustModeTrustedKeys,
 				TrustedKeys: []TrustedKeyRef{
 					{
 						Name:         "ops-key",
@@ -156,7 +154,6 @@ func TestToProtoFromProto_ScriptSigning(t *testing.T) {
 	ss := restored.Steward.ScriptSigning
 	assert.Equal(t, ScriptSigningPolicyRequired, ss.Policy)
 	assert.Equal(t, TrustModeTrustedKeys, ss.TrustMode)
-	assert.Equal(t, "https://git.example.com/scripts", ss.ScriptRepoURL)
 	require.Len(t, ss.TrustedKeys, 1)
 	assert.Equal(t, "ops-key", ss.TrustedKeys[0].Name)
 	assert.Equal(t, "AA:BB:CC:DD", ss.TrustedKeys[0].Thumbprint)
@@ -179,7 +176,6 @@ func TestToProtoFromProto_AllThreeNewFields(t *testing.T) {
 				Policy:        ScriptSigningPolicyOptional,
 				TrustMode:     TrustModeAnyValid,
 				AllowPublicCA: true,
-				ScriptRepoURL: "https://git.example.com/repo",
 			},
 			Logging:       LoggingConfig{Level: "debug", Format: "json"},
 			ErrorHandling: ErrorHandlingConfig{ModuleLoadFailure: ActionContinue, ResourceFailure: ActionWarn, ConfigurationError: ActionFail},
@@ -207,7 +203,6 @@ func TestToProtoFromProto_AllThreeNewFields(t *testing.T) {
 	assert.Equal(t, ScriptSigningPolicyOptional, restored.Steward.ScriptSigning.Policy)
 	assert.Equal(t, TrustModeAnyValid, restored.Steward.ScriptSigning.TrustMode)
 	assert.True(t, restored.Steward.ScriptSigning.AllowPublicCA)
-	assert.Equal(t, "https://git.example.com/repo", restored.Steward.ScriptSigning.ScriptRepoURL)
 }
 
 // TestToProto_NilConfig verifies that ToProto returns an error on nil input.


### PR DESCRIPTION
## Summary

- Adds two-tier script metadata: `Idempotent`, `Timeout` (with 15-min default applied in `Get()`), and `Signature` fields to `VersionedScript`/`ScriptMetadata`
- Adds controller-side `ScriptPrivilegeMetadata` (tenant-scoped, stored via ConfigStore) with HTTP handlers for list, show, and privilege update
- Adds `script:admin` RBAC permission; all three library routes are gated behind it
- Enforces held-scope ceiling (caller cannot grant scope they don't hold) and `steward:read-dna` requirement for DNA path bindings in `PUT /api/v1/scripts/{id}/privilege`
- Adds `cfg script list`, `cfg script show`, `cfg script set-privilege` CLI subcommands
- Removes `ScriptRepoURL` from steward `ScriptSigningConfig` (clean break); adds `KnownFields(true)` YAML strict-decode so existing configs with `script_repo_url` fail loudly
- Reserves proto field 5 in `config.proto`; `ScriptRepoUrl` retained in `config.pb.go` for binary descriptor compatibility until protoc regeneration

## Acceptance criteria met

- `TestHandlePutScriptPrivilege_ScopeNotHeldByCallerReturns403` ✓
- `TestHandlePutScriptPrivilege_DNAPathWithoutReadDNAReturns403` ✓
- `TestHandleListScripts_ReturnsSeededScripts` ✓
- `TestScriptList_OutputsScriptIDsInTabularForm` ✓
- `TestScriptSetPrivilege_InvalidParamBinding` ✓
- `TestLoadConfiguration_ScriptRepoURLIsRejected` ✓

## Test plan

- [ ] `go test ./features/steward/config/... ./features/modules/script/... ./features/controller/api/... ./cmd/cfg/cmd/...` — all pass
- [ ] `go build ./...` — clean compilation
- [ ] `make security-scan` — PASS (Trivy, Nancy, gosec, staticcheck)
- [ ] `make check-architecture` — PASS (no central provider violations)
- [ ] Parallel review: qa-test-runner PASS, qa-code-reviewer PASS, security-engineer PASS

Fixes #1670

🤖 Generated with [Claude Code](https://claude.com/claude-code)