### PR TITLE
steward: read registration CA cert from platform-standard path (Issue #1685)

### DIFF
--- a/cmd/steward/main.go
+++ b/cmd/steward/main.go
@@ -449,13 +449,56 @@ func logLevelFromEnv() string {
 }
 
 // buildHTTPConfig constructs an HTTPConfig from environment variables and the provided arguments.
-// CFGMS_HTTP_CA_CERT_PATH, when set, is used to verify the controller's TLS certificate during registration.
 func buildHTTPConfig(controllerURL string, timeout time.Duration, logger logging.Logger) *registration.HTTPConfig {
 	return &registration.HTTPConfig{
 		ControllerURL: controllerURL,
 		Timeout:       timeout,
-		CACertPath:    os.Getenv("CFGMS_HTTP_CA_CERT_PATH"),
+		CACertPath:    resolveRegistrationCACertPath(logger),
 		Logger:        logger,
+	}
+}
+
+// resolveRegistrationCACertPath returns the first CA cert path that exists on disk,
+// checking in priority order: env var override, platform-standard installer path,
+// then empty string (system trust store). See doResolveRegistrationCACertPath for logic.
+func resolveRegistrationCACertPath(logger logging.Logger) string {
+	return doResolveRegistrationCACertPath(logger, defaultPlatformCACertPath())
+}
+
+// doResolveRegistrationCACertPath is the testable core of resolveRegistrationCACertPath.
+// platformPath is injected so tests can exercise all priority levels without root access.
+func doResolveRegistrationCACertPath(logger logging.Logger, platformPath string) string {
+	// Priority 1: explicit env var override.
+	if envPath := os.Getenv("CFGMS_HTTP_CA_CERT_PATH"); envPath != "" {
+		if _, err := os.Stat(envPath); err == nil {
+			return envPath
+		}
+		logger.Warn("CFGMS_HTTP_CA_CERT_PATH set but file not found, falling through", "path", envPath)
+	}
+
+	// Priority 2: platform-standard path written by the installer.
+	if _, err := os.Stat(platformPath); err == nil {
+		logger.Info("Using platform-standard CA cert path", "path", platformPath)
+		return platformPath
+	}
+
+	// Priority 3: no cert found; caller uses system trust store.
+	logger.Info("No CA cert found; using system trust store")
+	return ""
+}
+
+// defaultPlatformCACertPath returns the OS-specific path where the installer writes
+// the controller CA cert, mirroring the path convention used by the install package.
+func defaultPlatformCACertPath() string {
+	switch runtime.GOOS {
+	case "windows":
+		programData := os.Getenv("ProgramData")
+		if programData == "" {
+			programData = `C:\ProgramData`
+		}
+		return filepath.Join(programData, "cfgms", "controller-ca.crt")
+	default: // linux and darwin
+		return "/etc/cfgms/controller-ca.crt"
 	}
 }
 

--- a/cmd/steward/main_test.go
+++ b/cmd/steward/main_test.go
@@ -6,6 +6,8 @@ package main
 import (
 	"context"
 	"io"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -100,14 +102,61 @@ func TestBuildHTTPConfig(t *testing.T) {
 		cfg := buildHTTPConfig("https://controller.example.com", 30*time.Second, logger)
 		require.NotNil(t, cfg)
 		assert.Equal(t, "https://controller.example.com", cfg.ControllerURL)
+		// CACertPath is "" when no env var is set and platform-standard cert does not exist.
+		// In test environments the platform cert is absent, so this holds.
 		assert.Equal(t, "", cfg.CACertPath)
 	})
 
-	t.Run("CFGMS_HTTP_CA_CERT_PATH is forwarded to HTTPConfig.CACertPath", func(t *testing.T) {
-		t.Setenv("CFGMS_HTTP_CA_CERT_PATH", "/etc/cfgms/ca.crt")
+	t.Run("CFGMS_HTTP_CA_CERT_PATH with existing file is forwarded to HTTPConfig.CACertPath", func(t *testing.T) {
+		dir := t.TempDir()
+		certFile := filepath.Join(dir, "ca.crt")
+		require.NoError(t, os.WriteFile(certFile, []byte("fake-cert"), 0600))
+		t.Setenv("CFGMS_HTTP_CA_CERT_PATH", certFile)
 		cfg := buildHTTPConfig("https://controller.example.com", 30*time.Second, logger)
 		require.NotNil(t, cfg)
-		assert.Equal(t, "/etc/cfgms/ca.crt", cfg.CACertPath)
+		assert.Equal(t, certFile, cfg.CACertPath)
+	})
+}
+
+func TestResolveRegistrationCACertPath(t *testing.T) {
+	logger := logging.NewLogger("debug")
+
+	t.Run("priority 1: env var set and file exists", func(t *testing.T) {
+		dir := t.TempDir()
+		certFile := filepath.Join(dir, "ca.crt")
+		require.NoError(t, os.WriteFile(certFile, []byte("fake-cert"), 0600))
+		t.Setenv("CFGMS_HTTP_CA_CERT_PATH", certFile)
+
+		result := doResolveRegistrationCACertPath(logger, filepath.Join(dir, "platform-ca.crt"))
+		assert.Equal(t, certFile, result)
+	})
+
+	t.Run("priority 1 fallthrough: env var set but file missing; platform path used", func(t *testing.T) {
+		dir := t.TempDir()
+		platformCert := filepath.Join(dir, "platform-ca.crt")
+		require.NoError(t, os.WriteFile(platformCert, []byte("fake-cert"), 0600))
+		t.Setenv("CFGMS_HTTP_CA_CERT_PATH", filepath.Join(dir, "nonexistent.crt"))
+
+		result := doResolveRegistrationCACertPath(logger, platformCert)
+		assert.Equal(t, platformCert, result)
+	})
+
+	t.Run("priority 2: platform-standard path exists when env var is empty", func(t *testing.T) {
+		dir := t.TempDir()
+		platformCert := filepath.Join(dir, "controller-ca.crt")
+		require.NoError(t, os.WriteFile(platformCert, []byte("fake-cert"), 0600))
+		t.Setenv("CFGMS_HTTP_CA_CERT_PATH", "")
+
+		result := doResolveRegistrationCACertPath(logger, platformCert)
+		assert.Equal(t, platformCert, result)
+	})
+
+	t.Run("priority 3: neither env var nor platform path exists returns empty string", func(t *testing.T) {
+		dir := t.TempDir()
+		t.Setenv("CFGMS_HTTP_CA_CERT_PATH", "")
+
+		result := doResolveRegistrationCACertPath(logger, filepath.Join(dir, "nonexistent.crt"))
+		assert.Equal(t, "", result)
 	})
 }
 


### PR DESCRIPTION
## Summary

- Adds `resolveRegistrationCACertPath(logger)` that probes sources in priority order: `CFGMS_HTTP_CA_CERT_PATH` env var (with file-existence check), platform-standard installer path (`/etc/cfgms/controller-ca.crt` on Linux/Darwin, `%ProgramData%\cfgms\controller-ca.crt` on Windows), then empty string (system trust store)
- `buildHTTPConfig` now delegates to `resolveRegistrationCACertPath` instead of reading the env var directly, so stewards installed via the install package can find their CA cert without manual configuration
- `CFGMS_HTTP_CA_CERT_PATH` remains as a higher-priority override for backward compatibility

Fixes #1685

## Test plan

- [ ] `TestResolveRegistrationCACertPath` — 4 subtests covering all priority levels (env var + existing file, env var + missing file, platform path only, neither)
- [ ] `TestBuildHTTPConfig` — updated to use real temp cert file; integration path through `buildHTTPConfig` verified
- [ ] `go test ./cmd/steward/...` passes locally

## Specialist Review Results

### QA Test Runner
All `cmd/steward` tests pass. Lint failures reported are pre-existing in `develop` (in `cmd/cfg/cmd/script.go`, `features/controller/api/handlers_scripts.go`, etc.) — none in the files changed by this story. `gofmt` and `go vet` are clean on `cmd/steward/main.go` and `cmd/steward/main_test.go`.

### QA Code Reviewer: PASS
No blocking issues. Two warnings (non-blocking):
- `TestBuildHTTPConfig/"empty env var"` subtest has an environment-dependent assertion (passes when platform cert absent, which is true in CI/dev)
- `defaultPlatformCACertPath()` Windows branch is untestable in Linux CI

### Security Engineer: PASS
- No hardcoded secrets, no sensitive data logged (file path only), no central provider violations, no insecure defaults
- Fallback to empty string → system trust store (TLS verification still occurs; `InsecureSkipVerify` never set)
- `make security-precommit`, `make check-architecture`, `make security-scan` all passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)