### PR TITLE
storage: add durable IP-trust store with tenant-scoped CIDR entries (Issue #1691)

### DIFF
--- a/features/workflow/trigger/integration_test.go
+++ b/features/workflow/trigger/integration_test.go
@@ -163,6 +163,10 @@ func (t *TestStorageProvider) CreatePendingRegistrationStore(_ map[string]interf
 	return nil, business.ErrNotSupported
 }
 
+func (t *TestStorageProvider) CreateIPTrustStore(_ map[string]interface{}) (business.IPTrustStore, error) {
+	return nil, business.ErrNotSupported
+}
+
 func (t *TestStorageProvider) GetCapabilities() interfaces.ProviderCapabilities {
 	return interfaces.ProviderCapabilities{
 		MaxBatchSize:          100,

--- a/features/workflow/trigger/manager_test.go
+++ b/features/workflow/trigger/manager_test.go
@@ -132,6 +132,10 @@ func (m *MockStorageProvider) CreatePendingRegistrationStore(_ map[string]interf
 	return nil, business.ErrNotSupported
 }
 
+func (m *MockStorageProvider) CreateIPTrustStore(_ map[string]interface{}) (business.IPTrustStore, error) {
+	return nil, business.ErrNotSupported
+}
+
 func (m *MockStorageProvider) GetCapabilities() interfaces.ProviderCapabilities {
 	args := m.Called()
 	return args.Get(0).(interfaces.ProviderCapabilities)

--- a/pkg/storage/interfaces/business/ip_trust_store.go
+++ b/pkg/storage/interfaces/business/ip_trust_store.go
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+// Package business defines business-data storage contracts for CFGMS
+package business
+
+import (
+	"context"
+	"errors"
+	"time"
+)
+
+// ErrIPTrustEntryNotFound is returned when an IP trust entry does not exist.
+var ErrIPTrustEntryNotFound = errors.New("ip trust entry not found")
+
+// IPTrustStore defines storage contract for tenant-scoped IP trust ranges.
+// Each tenant maintains an independent set of trusted CIDRs; /32 entries
+// represent single-host trust and broader CIDRs represent subnet trust.
+type IPTrustStore interface {
+	// AddTrustedRange records a trusted CIDR for a tenant. The CIDR is
+	// normalised (network address, not host address) before storage, so
+	// "192.168.1.1/24" and "192.168.1.0/24" produce the same entry.
+	// If the CIDR was previously revoked it is re-activated.
+	AddTrustedRange(ctx context.Context, tenantID, cidr string, preSeeded bool) error
+
+	// IsTrusted returns true iff the given IP falls within at least one
+	// non-revoked trusted CIDR for the tenant. Containment is evaluated in
+	// Go (not SQL) via net.ParseCIDR + ipNet.Contains.
+	IsTrusted(ctx context.Context, tenantID, ip string) (bool, error)
+
+	// ListTrustedRanges returns all trust entries for the tenant, including
+	// revoked ones (callers inspect the Revoked field).
+	ListTrustedRanges(ctx context.Context, tenantID string) ([]*IPTrustEntry, error)
+
+	// RevokeTrustedRange marks the entry for (tenantID, cidr) as revoked.
+	// Subsequent IsTrusted calls for IPs in that range return false.
+	// Returns ErrIPTrustEntryNotFound if no non-revoked entry exists.
+	RevokeTrustedRange(ctx context.Context, tenantID, cidr string) error
+
+	// RecordHealthySteward records a successful liveness event for the given
+	// IP. It upserts last_activity and last_activity_ip on the CIDR entry
+	// that contains the IP. No-op if no matching non-revoked entry exists.
+	RecordHealthySteward(ctx context.Context, tenantID, ip string, at time.Time) error
+
+	// GetLastActivity returns last-seen activity for the CIDR entry that
+	// contains the given IP. Returns nil, nil when no matching entry or no
+	// activity has been recorded yet.
+	GetLastActivity(ctx context.Context, tenantID, ip string) (*IPTrustActivity, error)
+}
+
+// IPTrustEntry represents a trusted IP range in persistent storage.
+type IPTrustEntry struct {
+	ID           string
+	TenantID     string
+	CIDR         string
+	PreSeeded    bool
+	TrustedSince time.Time
+	LastActivity time.Time // zero value means no activity recorded
+	Revoked      bool
+	RevokedAt    *time.Time
+}
+
+// IPTrustActivity holds last-seen information for a specific IP address.
+type IPTrustActivity struct {
+	TenantID string
+	IP       string
+	LastSeen time.Time
+}

--- a/pkg/storage/interfaces/business/ip_trust_store_test.go
+++ b/pkg/storage/interfaces/business/ip_trust_store_test.go
@@ -1,0 +1,378 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+package business_test
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cfgis/cfgms/pkg/storage/interfaces/business"
+)
+
+// inMemIPTrustStore is a minimal in-memory IPTrustStore used only for
+// contract testing. It is NOT intended for production use.
+type inMemIPTrustStore struct {
+	mu      sync.RWMutex
+	entries []*business.IPTrustEntry
+	seq     int
+}
+
+// normalizeCIDR returns the network address form of cidr, e.g. "192.168.1.0/24".
+func normalizeCIDR(cidr string) (string, error) {
+	_, ipNet, err := net.ParseCIDR(cidr)
+	if err != nil {
+		return "", fmt.Errorf("invalid CIDR %q: %w", cidr, err)
+	}
+	return ipNet.String(), nil
+}
+
+func (s *inMemIPTrustStore) AddTrustedRange(_ context.Context, tenantID, cidr string, preSeeded bool) error {
+	normalized, err := normalizeCIDR(cidr)
+	if err != nil {
+		return err
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	// Upsert: re-activate if previously revoked, otherwise insert new.
+	for _, e := range s.entries {
+		if e.TenantID == tenantID && e.CIDR == normalized {
+			e.PreSeeded = preSeeded
+			e.TrustedSince = time.Now()
+			e.Revoked = false
+			e.RevokedAt = nil
+			return nil
+		}
+	}
+	s.seq++
+	s.entries = append(s.entries, &business.IPTrustEntry{
+		ID:           fmt.Sprintf("entry-%d", s.seq),
+		TenantID:     tenantID,
+		CIDR:         normalized,
+		PreSeeded:    preSeeded,
+		TrustedSince: time.Now(),
+	})
+	return nil
+}
+
+func (s *inMemIPTrustStore) IsTrusted(_ context.Context, tenantID, ip string) (bool, error) {
+	parsedIP := net.ParseIP(ip)
+	if parsedIP == nil {
+		return false, fmt.Errorf("invalid IP address: %s", ip)
+	}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	for _, e := range s.entries {
+		if e.TenantID != tenantID || e.Revoked {
+			continue
+		}
+		_, ipNet, err := net.ParseCIDR(e.CIDR)
+		if err != nil {
+			continue
+		}
+		if ipNet.Contains(parsedIP) {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func (s *inMemIPTrustStore) ListTrustedRanges(_ context.Context, tenantID string) ([]*business.IPTrustEntry, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	var out []*business.IPTrustEntry
+	for _, e := range s.entries {
+		if e.TenantID == tenantID {
+			cp := *e
+			out = append(out, &cp)
+		}
+	}
+	return out, nil
+}
+
+func (s *inMemIPTrustStore) RevokeTrustedRange(_ context.Context, tenantID, cidr string) error {
+	normalized, err := normalizeCIDR(cidr)
+	if err != nil {
+		return err
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, e := range s.entries {
+		if e.TenantID == tenantID && e.CIDR == normalized && !e.Revoked {
+			now := time.Now()
+			e.Revoked = true
+			e.RevokedAt = &now
+			return nil
+		}
+	}
+	return business.ErrIPTrustEntryNotFound
+}
+
+func (s *inMemIPTrustStore) RecordHealthySteward(_ context.Context, tenantID, ip string, at time.Time) error {
+	parsedIP := net.ParseIP(ip)
+	if parsedIP == nil {
+		return fmt.Errorf("invalid IP address: %s", ip)
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, e := range s.entries {
+		if e.TenantID != tenantID || e.Revoked {
+			continue
+		}
+		_, ipNet, err := net.ParseCIDR(e.CIDR)
+		if err != nil {
+			continue
+		}
+		if ipNet.Contains(parsedIP) {
+			e.LastActivity = at
+			return nil
+		}
+	}
+	return nil // no-op if no matching entry
+}
+
+func (s *inMemIPTrustStore) GetLastActivity(_ context.Context, tenantID, ip string) (*business.IPTrustActivity, error) {
+	parsedIP := net.ParseIP(ip)
+	if parsedIP == nil {
+		return nil, fmt.Errorf("invalid IP address: %s", ip)
+	}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	for _, e := range s.entries {
+		if e.TenantID != tenantID || e.Revoked {
+			continue
+		}
+		_, ipNet, err := net.ParseCIDR(e.CIDR)
+		if err != nil {
+			continue
+		}
+		if ipNet.Contains(parsedIP) {
+			if e.LastActivity.IsZero() {
+				return nil, nil
+			}
+			return &business.IPTrustActivity{
+				TenantID: tenantID,
+				IP:       ip,
+				LastSeen: e.LastActivity,
+			}, nil
+		}
+	}
+	return nil, nil
+}
+
+// Compile-time assertion: inMemIPTrustStore satisfies the interface.
+var _ business.IPTrustStore = (*inMemIPTrustStore)(nil)
+
+// --- Contract tests ---
+
+func newInMemStore() business.IPTrustStore {
+	return &inMemIPTrustStore{}
+}
+
+func TestIPTrustStore_AddAndIsTrusted(t *testing.T) {
+	store := newInMemStore()
+	ctx := context.Background()
+
+	require.NoError(t, store.AddTrustedRange(ctx, "tenant-1", "10.0.0.0/8", false))
+
+	trusted, err := store.IsTrusted(ctx, "tenant-1", "10.1.2.3")
+	require.NoError(t, err)
+	assert.True(t, trusted, "IP within /8 must be trusted")
+
+	notTrusted, err := store.IsTrusted(ctx, "tenant-1", "192.168.1.1")
+	require.NoError(t, err)
+	assert.False(t, notTrusted, "IP outside range must not be trusted")
+}
+
+func TestIPTrustStore_TenantIsolation(t *testing.T) {
+	store := newInMemStore()
+	ctx := context.Background()
+
+	require.NoError(t, store.AddTrustedRange(ctx, "tenant-A", "10.0.0.0/8", false))
+
+	trusted, err := store.IsTrusted(ctx, "tenant-B", "10.1.2.3")
+	require.NoError(t, err)
+	assert.False(t, trusted, "tenant-B must not see tenant-A ranges")
+}
+
+func TestIPTrustStore_PreSeeded(t *testing.T) {
+	store := newInMemStore()
+	ctx := context.Background()
+
+	// Pre-seeded entry trusts without requiring any liveness event.
+	require.NoError(t, store.AddTrustedRange(ctx, "tenant-1", "172.16.0.0/12", true))
+
+	trusted, err := store.IsTrusted(ctx, "tenant-1", "172.20.1.1")
+	require.NoError(t, err)
+	assert.True(t, trusted, "pre-seeded CIDR must be trusted without liveness event")
+}
+
+func TestIPTrustStore_RevokeClearsAccess(t *testing.T) {
+	store := newInMemStore()
+	ctx := context.Background()
+
+	require.NoError(t, store.AddTrustedRange(ctx, "tenant-1", "192.168.0.0/16", false))
+
+	trusted, err := store.IsTrusted(ctx, "tenant-1", "192.168.5.5")
+	require.NoError(t, err)
+	require.True(t, trusted, "expected trusted before revoke")
+
+	require.NoError(t, store.RevokeTrustedRange(ctx, "tenant-1", "192.168.0.0/16"))
+
+	trusted, err = store.IsTrusted(ctx, "tenant-1", "192.168.5.5")
+	require.NoError(t, err)
+	assert.False(t, trusted, "expected untrusted after revoke")
+}
+
+func TestIPTrustStore_RevokeNotFound(t *testing.T) {
+	store := newInMemStore()
+	ctx := context.Background()
+
+	err := store.RevokeTrustedRange(ctx, "tenant-1", "10.0.0.0/8")
+	assert.ErrorIs(t, err, business.ErrIPTrustEntryNotFound)
+}
+
+func TestIPTrustStore_CIDRNormalization(t *testing.T) {
+	store := newInMemStore()
+	ctx := context.Background()
+
+	// Host address form normalises to network address.
+	require.NoError(t, store.AddTrustedRange(ctx, "tenant-1", "192.168.1.5/24", false))
+
+	entries, err := store.ListTrustedRanges(ctx, "tenant-1")
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+	assert.Equal(t, "192.168.1.0/24", entries[0].CIDR, "CIDR must be stored in normalised form")
+
+	// Re-adding via host address must not create a duplicate.
+	require.NoError(t, store.AddTrustedRange(ctx, "tenant-1", "192.168.1.99/24", false))
+	entries, err = store.ListTrustedRanges(ctx, "tenant-1")
+	require.NoError(t, err)
+	assert.Len(t, entries, 1, "normalised duplicates must not create a second entry")
+}
+
+func TestIPTrustStore_ListTrustedRanges(t *testing.T) {
+	store := newInMemStore()
+	ctx := context.Background()
+
+	require.NoError(t, store.AddTrustedRange(ctx, "tenant-1", "10.0.0.0/8", false))
+	require.NoError(t, store.AddTrustedRange(ctx, "tenant-1", "192.168.0.0/16", true))
+	require.NoError(t, store.AddTrustedRange(ctx, "tenant-2", "172.16.0.0/12", false))
+
+	entries, err := store.ListTrustedRanges(ctx, "tenant-1")
+	require.NoError(t, err)
+	assert.Len(t, entries, 2)
+
+	entries, err = store.ListTrustedRanges(ctx, "tenant-2")
+	require.NoError(t, err)
+	assert.Len(t, entries, 1)
+}
+
+func TestIPTrustStore_ListIncludesRevoked(t *testing.T) {
+	store := newInMemStore()
+	ctx := context.Background()
+
+	require.NoError(t, store.AddTrustedRange(ctx, "tenant-1", "10.0.0.0/8", false))
+	require.NoError(t, store.RevokeTrustedRange(ctx, "tenant-1", "10.0.0.0/8"))
+
+	entries, err := store.ListTrustedRanges(ctx, "tenant-1")
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+	assert.True(t, entries[0].Revoked, "revoked entry must be included in list")
+	assert.NotNil(t, entries[0].RevokedAt)
+}
+
+func TestIPTrustStore_RecordHealthySteward(t *testing.T) {
+	store := newInMemStore()
+	ctx := context.Background()
+
+	require.NoError(t, store.AddTrustedRange(ctx, "tenant-1", "10.0.0.0/8", false))
+
+	now := time.Now().UTC().Truncate(time.Second)
+	require.NoError(t, store.RecordHealthySteward(ctx, "tenant-1", "10.1.2.3", now))
+
+	activity, err := store.GetLastActivity(ctx, "tenant-1", "10.1.2.3")
+	require.NoError(t, err)
+	require.NotNil(t, activity)
+	assert.Equal(t, "tenant-1", activity.TenantID)
+	assert.Equal(t, "10.1.2.3", activity.IP)
+	assert.Equal(t, now, activity.LastSeen)
+}
+
+func TestIPTrustStore_RecordHealthySteward_NoMatch_IsNoop(t *testing.T) {
+	store := newInMemStore()
+	ctx := context.Background()
+
+	// No entry exists; RecordHealthySteward must be a no-op.
+	err := store.RecordHealthySteward(ctx, "tenant-1", "10.0.0.1", time.Now())
+	assert.NoError(t, err)
+}
+
+func TestIPTrustStore_GetLastActivity_NoActivity(t *testing.T) {
+	store := newInMemStore()
+	ctx := context.Background()
+
+	require.NoError(t, store.AddTrustedRange(ctx, "tenant-1", "10.0.0.0/8", false))
+
+	activity, err := store.GetLastActivity(ctx, "tenant-1", "10.0.0.1")
+	require.NoError(t, err)
+	assert.Nil(t, activity, "no activity recorded yet")
+}
+
+func TestIPTrustStore_GetLastActivity_NotInRange(t *testing.T) {
+	store := newInMemStore()
+	ctx := context.Background()
+
+	require.NoError(t, store.AddTrustedRange(ctx, "tenant-1", "10.0.0.0/8", false))
+	require.NoError(t, store.RecordHealthySteward(ctx, "tenant-1", "10.0.0.1", time.Now()))
+
+	activity, err := store.GetLastActivity(ctx, "tenant-1", "192.168.1.1")
+	require.NoError(t, err)
+	assert.Nil(t, activity, "IP outside range has no activity")
+}
+
+func TestIPTrustStore_IPTrustEntryStructFields(t *testing.T) {
+	now := time.Now()
+	revokedAt := now.Add(time.Hour)
+	entry := business.IPTrustEntry{
+		ID:           "entry-001",
+		TenantID:     "tenant-1",
+		CIDR:         "10.0.0.0/8",
+		PreSeeded:    true,
+		TrustedSince: now,
+		LastActivity: now,
+		Revoked:      true,
+		RevokedAt:    &revokedAt,
+	}
+	assert.Equal(t, "entry-001", entry.ID)
+	assert.Equal(t, "tenant-1", entry.TenantID)
+	assert.Equal(t, "10.0.0.0/8", entry.CIDR)
+	assert.True(t, entry.PreSeeded)
+	assert.Equal(t, now, entry.TrustedSince)
+	assert.Equal(t, now, entry.LastActivity)
+	assert.True(t, entry.Revoked)
+	assert.Equal(t, revokedAt, *entry.RevokedAt)
+}
+
+func TestIPTrustStore_IPTrustActivityStructFields(t *testing.T) {
+	now := time.Now()
+	activity := business.IPTrustActivity{
+		TenantID: "tenant-1",
+		IP:       "10.0.0.1",
+		LastSeen: now,
+	}
+	assert.Equal(t, "tenant-1", activity.TenantID)
+	assert.Equal(t, "10.0.0.1", activity.IP)
+	assert.Equal(t, now, activity.LastSeen)
+}
+
+func TestErrIPTrustEntryNotFound(t *testing.T) {
+	assert.NotNil(t, business.ErrIPTrustEntryNotFound)
+	assert.Equal(t, "ip trust entry not found", business.ErrIPTrustEntryNotFound.Error())
+}

--- a/pkg/storage/interfaces/hybrid_manager.go
+++ b/pkg/storage/interfaces/hybrid_manager.go
@@ -4,6 +4,7 @@
 package interfaces
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/cfgis/cfgms/pkg/storage/interfaces/business"
@@ -73,6 +74,14 @@ func NewHybridStorageManager(config HybridStorageConfig) (*HybridStorageManager,
 	}
 	manager.auditStore = auditStore
 
+	// IP trust storage is database-tier only; operational providers that do not
+	// implement it (e.g. sqlite) leave the accessor nil rather than failing.
+	ipTrustStore, err := opProvider.CreateIPTrustStore(config.Operational.Config)
+	if err != nil && !errors.Is(err, business.ErrNotSupported) {
+		return nil, fmt.Errorf("failed to create IP trust store: %w", err)
+	}
+	manager.ipTrustStore = ipTrustStore
+
 	// Create configuration store (GitOps workflow)
 	configStore, err := cfgProvider.CreateConfigStore(config.Configuration.Config)
 	if err != nil {
@@ -98,7 +107,8 @@ func (h *HybridStorageManager) GetConfigStore() cfgconfig.ConfigStore {
 	return h.configStore
 }
 
-// GetIPTrustStore returns the IP trust storage interface (operational backend).
+// GetIPTrustStore returns the IP trust storage interface (operational backend,
+// nil if the operational provider does not support IP trust storage).
 func (h *HybridStorageManager) GetIPTrustStore() business.IPTrustStore {
 	return h.ipTrustStore
 }

--- a/pkg/storage/interfaces/hybrid_manager.go
+++ b/pkg/storage/interfaces/hybrid_manager.go
@@ -33,6 +33,7 @@ type HybridStorageManager struct {
 	clientTenantStore business.ClientTenantStore
 	auditStore        business.AuditStore
 	configStore       cfgconfig.ConfigStore
+	ipTrustStore      business.IPTrustStore
 
 	config HybridStorageConfig
 }
@@ -95,6 +96,11 @@ func (h *HybridStorageManager) GetAuditStore() business.AuditStore {
 // GetConfigStore returns the configuration storage interface (configuration backend).
 func (h *HybridStorageManager) GetConfigStore() cfgconfig.ConfigStore {
 	return h.configStore
+}
+
+// GetIPTrustStore returns the IP trust storage interface (operational backend).
+func (h *HybridStorageManager) GetIPTrustStore() business.IPTrustStore {
+	return h.ipTrustStore
 }
 
 // GetOperationalProvider returns the operational storage provider.

--- a/pkg/storage/interfaces/hybrid_manager_test.go
+++ b/pkg/storage/interfaces/hybrid_manager_test.go
@@ -122,6 +122,9 @@ func TestHybridStorageManager_Creation(t *testing.T) {
 	require.NotNil(t, ctStore)
 	assert.NotNil(t, manager.GetAuditStore())
 	assert.NotNil(t, manager.GetConfigStore())
+	// GetIPTrustStore must be wired in the constructor when the operational
+	// provider supports IP trust storage (Issue #1691, PR #1711 finding #1).
+	assert.NotNil(t, manager.GetIPTrustStore())
 
 	// Round-trip: store a client tenant and verify retrieval returns the same value.
 	wantTenant := &business.ClientTenant{ID: "hybrid-rt-1", TenantName: "Hybrid Round Trip"}
@@ -382,7 +385,7 @@ func (p *mockProvider) CreatePendingRegistrationStore(_ map[string]interface{}) 
 }
 
 func (p *mockProvider) CreateIPTrustStore(_ map[string]interface{}) (business.IPTrustStore, error) {
-	return nil, business.ErrNotSupported
+	return &mockIPTrustStore{}, nil
 }
 
 func (p *mockProvider) GetCapabilities() ProviderCapabilities {
@@ -698,3 +701,30 @@ func (s *mockRegistrationTokenStore) ConsumeToken(_ context.Context, _, _ string
 }
 func (s *mockRegistrationTokenStore) Initialize(_ context.Context) error { return nil }
 func (s *mockRegistrationTokenStore) Close() error                       { return nil }
+
+// mockIPTrustStore implements business.IPTrustStore for testing HybridStorageManager wiring.
+type mockIPTrustStore struct{}
+
+func (s *mockIPTrustStore) AddTrustedRange(_ context.Context, _, _ string, _ bool) error {
+	return nil
+}
+
+func (s *mockIPTrustStore) IsTrusted(_ context.Context, _, _ string) (bool, error) {
+	return false, nil
+}
+
+func (s *mockIPTrustStore) ListTrustedRanges(_ context.Context, _ string) ([]*business.IPTrustEntry, error) {
+	return nil, nil
+}
+
+func (s *mockIPTrustStore) RevokeTrustedRange(_ context.Context, _, _ string) error {
+	return nil
+}
+
+func (s *mockIPTrustStore) RecordHealthySteward(_ context.Context, _, _ string, _ time.Time) error {
+	return nil
+}
+
+func (s *mockIPTrustStore) GetLastActivity(_ context.Context, _, _ string) (*business.IPTrustActivity, error) {
+	return nil, nil
+}

--- a/pkg/storage/interfaces/hybrid_manager_test.go
+++ b/pkg/storage/interfaces/hybrid_manager_test.go
@@ -381,6 +381,10 @@ func (p *mockProvider) CreatePendingRegistrationStore(_ map[string]interface{}) 
 	return nil, business.ErrNotSupported
 }
 
+func (p *mockProvider) CreateIPTrustStore(_ map[string]interface{}) (business.IPTrustStore, error) {
+	return nil, business.ErrNotSupported
+}
+
 func (p *mockProvider) GetCapabilities() ProviderCapabilities {
 	return ProviderCapabilities{
 		SupportsTransactions:   true,

--- a/pkg/storage/interfaces/provider.go
+++ b/pkg/storage/interfaces/provider.go
@@ -47,6 +47,7 @@ type BusinessStoreBundle struct {
 	Trigger             business.TriggerStore
 	Push                business.PushStore
 	PendingRegistration business.PendingRegistrationStore
+	IPTrust             business.IPTrustStore
 }
 
 // BusinessStoreOpener is an optional StorageProvider extension. A provider that
@@ -78,6 +79,7 @@ type StorageProvider interface {
 	CreateTriggerStore(config map[string]interface{}) (business.TriggerStore, error)
 	CreatePushStore(config map[string]interface{}) (business.PushStore, error)
 	CreatePendingRegistrationStore(config map[string]interface{}) (business.PendingRegistrationStore, error)
+	CreateIPTrustStore(config map[string]interface{}) (business.IPTrustStore, error)
 
 	// Provider capabilities and metadata
 	GetCapabilities() ProviderCapabilities

--- a/pkg/storage/interfaces/provider_test.go
+++ b/pkg/storage/interfaces/provider_test.go
@@ -168,6 +168,10 @@ func (m *MockStorageProvider) CreatePendingRegistrationStore(_ map[string]interf
 	return nil, business.ErrNotSupported
 }
 
+func (m *MockStorageProvider) CreateIPTrustStore(_ map[string]interface{}) (business.IPTrustStore, error) {
+	return nil, business.ErrNotSupported
+}
+
 // Mock implementations of store interfaces
 type MockClientTenantStore struct {
 	tenants map[string]*business.ClientTenant
@@ -1065,6 +1069,10 @@ func (m *MockOSSProvider) CreatePendingRegistrationStore(_ map[string]interface{
 	return nil, business.ErrNotSupported
 }
 
+func (m *MockOSSProvider) CreateIPTrustStore(_ map[string]interface{}) (business.IPTrustStore, error) {
+	return nil, business.ErrNotSupported
+}
+
 // MockOSSProviderWithError is an interface stub that returns an error from a designated Create* method.
 // It is used to test that CreateOSSStorageManager propagates store-creation errors correctly.
 // Real providers cannot be used here because pkg/storage/providers/* imports this package
@@ -1160,6 +1168,10 @@ func (m *MockOSSProviderWithError) CreatePendingRegistrationStore(_ map[string]i
 	if err := m.mayFail("CreatePendingRegistrationStore"); err != nil {
 		return nil, err
 	}
+	return nil, business.ErrNotSupported
+}
+
+func (m *MockOSSProviderWithError) CreateIPTrustStore(_ map[string]interface{}) (business.IPTrustStore, error) {
 	return nil, business.ErrNotSupported
 }
 

--- a/pkg/storage/providers/database/ip_trust_store.go
+++ b/pkg/storage/providers/database/ip_trust_store.go
@@ -1,0 +1,345 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+package database
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"net"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+	_ "github.com/lib/pq" // PostgreSQL driver
+
+	business "github.com/cfgis/cfgms/pkg/storage/interfaces/business"
+)
+
+// Compile-time assertion.
+var _ business.IPTrustStore = (*DatabaseIPTrustStore)(nil)
+
+// DatabaseIPTrustStore implements IPTrustStore using PostgreSQL.
+type DatabaseIPTrustStore struct {
+	db      *sql.DB
+	mu      sync.RWMutex
+	schemas DatabaseSchemas
+}
+
+// NewDatabaseIPTrustStore opens a PostgreSQL-backed IPTrustStore at dsn.
+func NewDatabaseIPTrustStore(dsn string, config map[string]interface{}) (*DatabaseIPTrustStore, error) {
+	db, err := sql.Open("postgres", dsn)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open database connection: %w", err)
+	}
+
+	maxOpenConns := getIntFromConfig(config, "max_open_connections", 25)
+	maxIdleConns := getIntFromConfig(config, "max_idle_connections", 5)
+	connMaxLifetime := time.Duration(getIntFromConfig(config, "connection_max_lifetime_minutes", 30)) * time.Minute
+	db.SetMaxOpenConns(maxOpenConns)
+	db.SetMaxIdleConns(maxIdleConns)
+	db.SetConnMaxLifetime(connMaxLifetime)
+
+	if err := db.Ping(); err != nil {
+		_ = db.Close()
+		return nil, fmt.Errorf("failed to ping database: %w", err)
+	}
+
+	store := &DatabaseIPTrustStore{db: db, schemas: NewDatabaseSchemas()}
+	if err := store.initSchema(); err != nil {
+		_ = db.Close()
+		return nil, fmt.Errorf("failed to initialise ip trust schema: %w", err)
+	}
+	return store, nil
+}
+
+func (s *DatabaseIPTrustStore) initSchema() error {
+	ctx := context.Background()
+	const lockID = 16923847 // unique advisory lock ID for this schema
+
+	if _, err := s.db.ExecContext(ctx, "SELECT pg_advisory_lock($1)", lockID); err != nil {
+		return fmt.Errorf("failed to acquire ip trust schema lock: %w", err)
+	}
+	defer func() {
+		_, _ = s.db.ExecContext(ctx, "SELECT pg_advisory_unlock($1)", lockID)
+	}()
+
+	return s.schemas.CreateIPTrustRangesTable(ctx, s.db)
+}
+
+// Close closes the underlying database connection.
+func (s *DatabaseIPTrustStore) Close() error {
+	return s.db.Close()
+}
+
+// normalizeCIDR returns the network-address form of cidr (e.g. "192.168.1.0/24").
+func normalizeCIDR(cidr string) (string, error) {
+	_, ipNet, err := net.ParseCIDR(cidr)
+	if err != nil {
+		return "", fmt.Errorf("invalid CIDR %q: %w", cidr, err)
+	}
+	return ipNet.String(), nil
+}
+
+// AddTrustedRange implements IPTrustStore.AddTrustedRange.
+// CIDR is normalised before storage. A previously revoked entry is re-activated.
+func (s *DatabaseIPTrustStore) AddTrustedRange(ctx context.Context, tenantID, cidr string, preSeeded bool) error {
+	normalized, err := normalizeCIDR(cidr)
+	if err != nil {
+		return err
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	id := uuid.New().String()
+	now := time.Now().UTC()
+
+	_, err = s.db.ExecContext(ctx, `
+		INSERT INTO cfgms_ip_trust_ranges
+			(id, tenant_id, cidr, pre_seeded, trusted_since)
+		VALUES ($1, $2, $3, $4, $5)
+		ON CONFLICT (tenant_id, cidr) DO UPDATE SET
+			pre_seeded    = EXCLUDED.pre_seeded,
+			trusted_since = EXCLUDED.trusted_since,
+			revoked       = FALSE,
+			revoked_at    = NULL`,
+		id, tenantID, normalized, preSeeded, now,
+	)
+	if err != nil {
+		return fmt.Errorf("failed to add trusted range: %w", err)
+	}
+	return nil
+}
+
+// IsTrusted implements IPTrustStore.IsTrusted.
+// Containment is evaluated in Go — not SQL — via net.ParseCIDR + ipNet.Contains.
+func (s *DatabaseIPTrustStore) IsTrusted(ctx context.Context, tenantID, ip string) (bool, error) {
+	parsedIP := net.ParseIP(ip)
+	if parsedIP == nil {
+		return false, fmt.Errorf("invalid IP address: %s", ip)
+	}
+
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT cidr FROM cfgms_ip_trust_ranges
+		WHERE tenant_id = $1 AND revoked = FALSE`,
+		tenantID,
+	)
+	if err != nil {
+		return false, fmt.Errorf("failed to query trusted ranges: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	for rows.Next() {
+		var cidrStr string
+		if err := rows.Scan(&cidrStr); err != nil {
+			return false, fmt.Errorf("failed to scan CIDR: %w", err)
+		}
+		_, ipNet, err := net.ParseCIDR(cidrStr)
+		if err != nil {
+			continue // skip malformed stored entries
+		}
+		if ipNet.Contains(parsedIP) {
+			return true, nil
+		}
+	}
+	return false, rows.Err()
+}
+
+// ListTrustedRanges implements IPTrustStore.ListTrustedRanges.
+// Returns all entries for the tenant (including revoked), ordered by trusted_since.
+func (s *DatabaseIPTrustStore) ListTrustedRanges(ctx context.Context, tenantID string) ([]*business.IPTrustEntry, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT id, tenant_id, cidr, pre_seeded, trusted_since,
+		       last_activity, last_activity_ip, revoked, revoked_at
+		FROM cfgms_ip_trust_ranges
+		WHERE tenant_id = $1
+		ORDER BY trusted_since ASC`,
+		tenantID,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list trusted ranges: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var entries []*business.IPTrustEntry
+	for rows.Next() {
+		e, err := scanIPTrustEntry(rows)
+		if err != nil {
+			return nil, err
+		}
+		entries = append(entries, e)
+	}
+	return entries, rows.Err()
+}
+
+// RevokeTrustedRange implements IPTrustStore.RevokeTrustedRange.
+func (s *DatabaseIPTrustStore) RevokeTrustedRange(ctx context.Context, tenantID, cidr string) error {
+	normalized, err := normalizeCIDR(cidr)
+	if err != nil {
+		return err
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	now := time.Now().UTC()
+	res, err := s.db.ExecContext(ctx, `
+		UPDATE cfgms_ip_trust_ranges
+		SET revoked = TRUE, revoked_at = $1
+		WHERE tenant_id = $2 AND cidr = $3 AND revoked = FALSE`,
+		now, tenantID, normalized,
+	)
+	if err != nil {
+		return fmt.Errorf("failed to revoke trusted range: %w", err)
+	}
+	n, _ := res.RowsAffected()
+	if n == 0 {
+		return business.ErrIPTrustEntryNotFound
+	}
+	return nil
+}
+
+// RecordHealthySteward implements IPTrustStore.RecordHealthySteward.
+// Finds the CIDR entry containing ip and upserts last_activity / last_activity_ip.
+// No-op if no matching non-revoked entry exists.
+func (s *DatabaseIPTrustStore) RecordHealthySteward(ctx context.Context, tenantID, ip string, at time.Time) error {
+	parsedIP := net.ParseIP(ip)
+	if parsedIP == nil {
+		return fmt.Errorf("invalid IP address: %s", ip)
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	// Fetch all non-revoked CIDRs for containment check in Go.
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT id, cidr FROM cfgms_ip_trust_ranges
+		WHERE tenant_id = $1 AND revoked = FALSE`,
+		tenantID,
+	)
+	if err != nil {
+		return fmt.Errorf("failed to query ranges for activity update: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var matchID string
+	for rows.Next() {
+		var id, cidrStr string
+		if err := rows.Scan(&id, &cidrStr); err != nil {
+			return fmt.Errorf("failed to scan range row: %w", err)
+		}
+		_, ipNet, err := net.ParseCIDR(cidrStr)
+		if err != nil {
+			continue
+		}
+		if ipNet.Contains(parsedIP) {
+			matchID = id
+			break
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("error iterating ranges: %w", err)
+	}
+	if matchID == "" {
+		return nil // no matching entry — no-op per spec
+	}
+
+	_, err = s.db.ExecContext(ctx, `
+		UPDATE cfgms_ip_trust_ranges
+		SET last_activity = $1, last_activity_ip = $2
+		WHERE id = $3`,
+		at.UTC(), ip, matchID,
+	)
+	if err != nil {
+		return fmt.Errorf("failed to record healthy steward: %w", err)
+	}
+	return nil
+}
+
+// GetLastActivity implements IPTrustStore.GetLastActivity.
+// Returns nil, nil when no matching entry or no activity has been recorded.
+func (s *DatabaseIPTrustStore) GetLastActivity(ctx context.Context, tenantID, ip string) (*business.IPTrustActivity, error) {
+	parsedIP := net.ParseIP(ip)
+	if parsedIP == nil {
+		return nil, fmt.Errorf("invalid IP address: %s", ip)
+	}
+
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT cidr, last_activity FROM cfgms_ip_trust_ranges
+		WHERE tenant_id = $1 AND revoked = FALSE`,
+		tenantID,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query ranges for activity: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	for rows.Next() {
+		var cidrStr string
+		var lastActivity sql.NullTime
+		if err := rows.Scan(&cidrStr, &lastActivity); err != nil {
+			return nil, fmt.Errorf("failed to scan activity row: %w", err)
+		}
+		_, ipNet, err := net.ParseCIDR(cidrStr)
+		if err != nil {
+			continue
+		}
+		if ipNet.Contains(parsedIP) {
+			if !lastActivity.Valid {
+				return nil, nil
+			}
+			return &business.IPTrustActivity{
+				TenantID: tenantID,
+				IP:       ip,
+				LastSeen: lastActivity.Time,
+			}, nil
+		}
+	}
+	return nil, rows.Err()
+}
+
+// rowScanner abstracts *sql.Rows so scanIPTrustEntry can be shared.
+type rowScanner interface {
+	Scan(dest ...interface{}) error
+}
+
+// scanIPTrustEntry scans one row from cfgms_ip_trust_ranges into an IPTrustEntry.
+func scanIPTrustEntry(row rowScanner) (*business.IPTrustEntry, error) {
+	var (
+		e            business.IPTrustEntry
+		lastActivity sql.NullTime
+		lastActIP    sql.NullString
+		revokedAt    sql.NullTime
+	)
+	if err := row.Scan(
+		&e.ID,
+		&e.TenantID,
+		&e.CIDR,
+		&e.PreSeeded,
+		&e.TrustedSince,
+		&lastActivity,
+		&lastActIP,
+		&e.Revoked,
+		&revokedAt,
+	); err != nil {
+		return nil, fmt.Errorf("failed to scan ip trust entry: %w", err)
+	}
+	if lastActivity.Valid {
+		e.LastActivity = lastActivity.Time
+	}
+	if revokedAt.Valid {
+		t := revokedAt.Time
+		e.RevokedAt = &t
+	}
+	return &e, nil
+}

--- a/pkg/storage/providers/database/ip_trust_store_test.go
+++ b/pkg/storage/providers/database/ip_trust_store_test.go
@@ -1,0 +1,216 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+package database
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	business "github.com/cfgis/cfgms/pkg/storage/interfaces/business"
+)
+
+func newTestIPTrustStore(t *testing.T) *DatabaseIPTrustStore {
+	t.Helper()
+	db := setupTestDatabase(t)
+	t.Cleanup(func() { _ = db.Close() })
+	schemas := NewDatabaseSchemas()
+	ctx := context.Background()
+	require.NoError(t, schemas.CreateIPTrustRangesTable(ctx, db))
+	return &DatabaseIPTrustStore{db: db, schemas: schemas}
+}
+
+func TestIPTrustStore_AddAndQuery(t *testing.T) {
+	store := newTestIPTrustStore(t)
+	ctx := context.Background()
+
+	require.NoError(t, store.AddTrustedRange(ctx, "tenant-1", "10.0.0.0/8", false))
+
+	trusted, err := store.IsTrusted(ctx, "tenant-1", "10.1.2.3")
+	require.NoError(t, err)
+	assert.True(t, trusted)
+
+	notTrusted, err := store.IsTrusted(ctx, "tenant-1", "192.168.1.1")
+	require.NoError(t, err)
+	assert.False(t, notTrusted)
+}
+
+func TestIPTrustStore_TenantIsolation(t *testing.T) {
+	store := newTestIPTrustStore(t)
+	ctx := context.Background()
+
+	require.NoError(t, store.AddTrustedRange(ctx, "tenant-A", "10.0.0.0/8", false))
+
+	trusted, err := store.IsTrusted(ctx, "tenant-B", "10.1.2.3")
+	require.NoError(t, err)
+	assert.False(t, trusted, "tenant-B must not see tenant-A ranges")
+}
+
+func TestIPTrustStore_CIDRContainment(t *testing.T) {
+	store := newTestIPTrustStore(t)
+	ctx := context.Background()
+
+	// Add a /24 range and a single /32.
+	require.NoError(t, store.AddTrustedRange(ctx, "tenant-1", "192.168.1.0/24", false))
+	require.NoError(t, store.AddTrustedRange(ctx, "tenant-1", "10.0.0.5/32", false))
+
+	tests := []struct {
+		ip      string
+		want    bool
+		comment string
+	}{
+		{"192.168.1.1", true, "/24 containment — first host"},
+		{"192.168.1.254", true, "/24 containment — last host"},
+		{"192.168.2.1", false, "out-of-range — different subnet"},
+		{"10.0.0.5", true, "/32 exact match"},
+		{"10.0.0.6", false, "/32 — adjacent IP not in range"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.comment, func(t *testing.T) {
+			got, err := store.IsTrusted(ctx, "tenant-1", tc.ip)
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, got, tc.comment)
+		})
+	}
+}
+
+func TestIPTrustStore_PreSeeded_RoundTrip(t *testing.T) {
+	store := newTestIPTrustStore(t)
+	ctx := context.Background()
+
+	require.NoError(t, store.AddTrustedRange(ctx, "tenant-1", "172.16.0.0/12", true))
+
+	entries, err := store.ListTrustedRanges(ctx, "tenant-1")
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+	assert.True(t, entries[0].PreSeeded, "pre_seeded flag must round-trip")
+	assert.Equal(t, "172.16.0.0/12", entries[0].CIDR)
+
+	// pre-seeded entry must be trusted without any liveness event.
+	trusted, err := store.IsTrusted(ctx, "tenant-1", "172.20.1.1")
+	require.NoError(t, err)
+	assert.True(t, trusted)
+}
+
+func TestIPTrustStore_RevokeClearsAccess(t *testing.T) {
+	store := newTestIPTrustStore(t)
+	ctx := context.Background()
+
+	require.NoError(t, store.AddTrustedRange(ctx, "tenant-1", "10.0.0.0/8", false))
+
+	trusted, err := store.IsTrusted(ctx, "tenant-1", "10.1.2.3")
+	require.NoError(t, err)
+	require.True(t, trusted, "expected trusted before revoke")
+
+	require.NoError(t, store.RevokeTrustedRange(ctx, "tenant-1", "10.0.0.0/8"))
+
+	trusted, err = store.IsTrusted(ctx, "tenant-1", "10.1.2.3")
+	require.NoError(t, err)
+	assert.False(t, trusted, "expected untrusted after revoke")
+}
+
+func TestIPTrustStore_RevokeNotFound(t *testing.T) {
+	store := newTestIPTrustStore(t)
+	ctx := context.Background()
+
+	err := store.RevokeTrustedRange(ctx, "tenant-1", "10.0.0.0/8")
+	require.ErrorIs(t, err, business.ErrIPTrustEntryNotFound)
+}
+
+func TestIPTrustStore_RecordHealthySteward_Upsert(t *testing.T) {
+	store := newTestIPTrustStore(t)
+	ctx := context.Background()
+
+	require.NoError(t, store.AddTrustedRange(ctx, "tenant-1", "10.0.0.0/8", false))
+
+	t1 := time.Now().UTC().Truncate(time.Millisecond)
+	require.NoError(t, store.RecordHealthySteward(ctx, "tenant-1", "10.0.0.1", t1))
+
+	activity, err := store.GetLastActivity(ctx, "tenant-1", "10.0.0.1")
+	require.NoError(t, err)
+	require.NotNil(t, activity)
+	assert.Equal(t, "tenant-1", activity.TenantID)
+	assert.Equal(t, "10.0.0.1", activity.IP)
+	assert.WithinDuration(t, t1, activity.LastSeen, time.Millisecond)
+
+	// Second call updates the timestamp.
+	t2 := t1.Add(time.Minute)
+	require.NoError(t, store.RecordHealthySteward(ctx, "tenant-1", "10.0.0.1", t2))
+
+	activity, err = store.GetLastActivity(ctx, "tenant-1", "10.0.0.1")
+	require.NoError(t, err)
+	require.NotNil(t, activity)
+	assert.WithinDuration(t, t2, activity.LastSeen, time.Millisecond)
+}
+
+func TestIPTrustStore_RecordHealthySteward_NoMatch(t *testing.T) {
+	store := newTestIPTrustStore(t)
+	ctx := context.Background()
+
+	// No entry exists; must be a no-op (no error).
+	err := store.RecordHealthySteward(ctx, "tenant-1", "10.0.0.1", time.Now())
+	assert.NoError(t, err)
+}
+
+func TestIPTrustStore_GetLastActivity_NoActivity(t *testing.T) {
+	store := newTestIPTrustStore(t)
+	ctx := context.Background()
+
+	require.NoError(t, store.AddTrustedRange(ctx, "tenant-1", "10.0.0.0/8", false))
+
+	activity, err := store.GetLastActivity(ctx, "tenant-1", "10.0.0.1")
+	require.NoError(t, err)
+	assert.Nil(t, activity, "no activity recorded yet")
+}
+
+func TestIPTrustStore_CIDRNormalization(t *testing.T) {
+	store := newTestIPTrustStore(t)
+	ctx := context.Background()
+
+	// Host-address form must be normalised.
+	require.NoError(t, store.AddTrustedRange(ctx, "tenant-1", "192.168.1.99/24", false))
+
+	entries, err := store.ListTrustedRanges(ctx, "tenant-1")
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+	assert.Equal(t, "192.168.1.0/24", entries[0].CIDR)
+
+	// Re-adding via another host address in the same /24 must not create a second row.
+	require.NoError(t, store.AddTrustedRange(ctx, "tenant-1", "192.168.1.5/24", false))
+	entries, err = store.ListTrustedRanges(ctx, "tenant-1")
+	require.NoError(t, err)
+	assert.Len(t, entries, 1, "normalised duplicate must not create a second entry")
+}
+
+func TestIPTrustStore_ListIncludesRevoked(t *testing.T) {
+	store := newTestIPTrustStore(t)
+	ctx := context.Background()
+
+	require.NoError(t, store.AddTrustedRange(ctx, "tenant-1", "10.0.0.0/8", false))
+	require.NoError(t, store.RevokeTrustedRange(ctx, "tenant-1", "10.0.0.0/8"))
+
+	entries, err := store.ListTrustedRanges(ctx, "tenant-1")
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+	assert.True(t, entries[0].Revoked)
+	assert.NotNil(t, entries[0].RevokedAt)
+}
+
+func TestIPTrustStore_ReactivateRevokedRange(t *testing.T) {
+	store := newTestIPTrustStore(t)
+	ctx := context.Background()
+
+	require.NoError(t, store.AddTrustedRange(ctx, "tenant-1", "10.0.0.0/8", false))
+	require.NoError(t, store.RevokeTrustedRange(ctx, "tenant-1", "10.0.0.0/8"))
+
+	// Re-adding after revoke should reactivate.
+	require.NoError(t, store.AddTrustedRange(ctx, "tenant-1", "10.0.0.0/8", true))
+
+	trusted, err := store.IsTrusted(ctx, "tenant-1", "10.1.2.3")
+	require.NoError(t, err)
+	assert.True(t, trusted, "re-added CIDR must be trusted again")
+}

--- a/pkg/storage/providers/database/plugin.go
+++ b/pkg/storage/providers/database/plugin.go
@@ -177,6 +177,19 @@ func (p *DatabaseProvider) CreatePendingRegistrationStore(config map[string]inte
 	return nil, business.ErrNotSupported
 }
 
+// CreateIPTrustStore creates a PostgreSQL-backed IPTrustStore.
+func (p *DatabaseProvider) CreateIPTrustStore(config map[string]interface{}) (business.IPTrustStore, error) {
+	dsn, err := p.getDSN(config)
+	if err != nil {
+		return nil, fmt.Errorf("invalid database configuration: %w", err)
+	}
+	store, err := NewDatabaseIPTrustStore(dsn, config)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create database ip trust store: %w", err)
+	}
+	return store, nil
+}
+
 func (p *DatabaseProvider) CreateRegistrationTokenStore(config map[string]interface{}) (business.RegistrationTokenStore, error) {
 	// Get database connection string from config
 	dsn, err := p.getDSN(config)

--- a/pkg/storage/providers/database/plugin_test.go
+++ b/pkg/storage/providers/database/plugin_test.go
@@ -273,6 +273,7 @@ func TestDatabaseSchemas_CreateTables(t *testing.T) {
 		"config_history",
 		"audit_entries",
 		"storage_health",
+		"cfgms_ip_trust_ranges",
 	}
 
 	for _, table := range tables {

--- a/pkg/storage/providers/database/schemas.go
+++ b/pkg/storage/providers/database/schemas.go
@@ -628,6 +628,41 @@ func (s DatabaseSchemas) CreateRegistrationTokensTable(ctx context.Context, db *
 	return nil
 }
 
+// CreateIPTrustRangesTable creates the cfgms_ip_trust_ranges table for tenant-scoped IP trust.
+func (s DatabaseSchemas) CreateIPTrustRangesTable(ctx context.Context, db *sql.DB) error {
+	createTableQuery := `
+		CREATE TABLE IF NOT EXISTS cfgms_ip_trust_ranges (
+			id              TEXT PRIMARY KEY,
+			tenant_id       TEXT NOT NULL,
+			cidr            TEXT NOT NULL,
+			pre_seeded      BOOLEAN NOT NULL DEFAULT FALSE,
+			trusted_since   TIMESTAMP WITH TIME ZONE NOT NULL,
+			last_activity   TIMESTAMP WITH TIME ZONE,
+			last_activity_ip TEXT,
+			revoked         BOOLEAN NOT NULL DEFAULT FALSE,
+			revoked_at      TIMESTAMP WITH TIME ZONE,
+			UNIQUE(tenant_id, cidr)
+		);
+	`
+
+	if _, err := db.ExecContext(ctx, createTableQuery); err != nil {
+		return fmt.Errorf("failed to create cfgms_ip_trust_ranges table: %w", err)
+	}
+
+	indexes := []string{
+		"CREATE INDEX IF NOT EXISTS idx_ip_trust_tenant_revoked ON cfgms_ip_trust_ranges(tenant_id, revoked);",
+		"CREATE INDEX IF NOT EXISTS idx_ip_trust_tenant_cidr    ON cfgms_ip_trust_ranges(tenant_id, cidr);",
+	}
+
+	for _, indexQuery := range indexes {
+		if _, err := db.ExecContext(ctx, indexQuery); err != nil {
+			return fmt.Errorf("failed to create cfgms_ip_trust_ranges index: %w", err)
+		}
+	}
+
+	return nil
+}
+
 // CreateAllTables creates all necessary database tables and indexes
 func (s DatabaseSchemas) CreateAllTables(ctx context.Context, db *sql.DB) error {
 	// Create tables in dependency order

--- a/pkg/storage/providers/database/schemas.go
+++ b/pkg/storage/providers/database/schemas.go
@@ -698,6 +698,10 @@ func (s DatabaseSchemas) CreateAllTables(ctx context.Context, db *sql.DB) error 
 		return err
 	}
 
+	if err := s.CreateIPTrustRangesTable(ctx, db); err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -713,6 +717,7 @@ func (s DatabaseSchemas) DropAllTables(ctx context.Context, db *sql.DB) error {
 		"DROP TABLE IF EXISTS admin_consent_requests;",
 		"DROP TABLE IF EXISTS client_tenants;",
 		"DROP TABLE IF EXISTS cfgms_registration_tokens;",
+		"DROP TABLE IF EXISTS cfgms_ip_trust_ranges;",
 		"DROP TABLE IF EXISTS rbac_role_assignments;", // Has foreign keys to subjects and roles
 		"DROP TABLE IF EXISTS rbac_subjects;",
 		"DROP TABLE IF EXISTS rbac_roles;", // Has self-reference foreign key

--- a/pkg/storage/providers/flatfile/plugin.go
+++ b/pkg/storage/providers/flatfile/plugin.go
@@ -220,6 +220,12 @@ func (p *FlatFileProvider) CreatePendingRegistrationStore(config map[string]inte
 	return nil, ErrNotSupported
 }
 
+// CreateIPTrustStore returns ErrNotSupported.
+// IP trust storage belongs in the business-data tier (Issue #1691).
+func (p *FlatFileProvider) CreateIPTrustStore(_ map[string]interface{}) (business.IPTrustStore, error) {
+	return nil, ErrNotSupported
+}
+
 // init auto-registers the flat-file provider so that a blank import is sufficient.
 func init() {
 	interfaces.RegisterStorageProvider(&FlatFileProvider{})

--- a/pkg/storage/providers/sqlite/plugin.go
+++ b/pkg/storage/providers/sqlite/plugin.go
@@ -280,6 +280,12 @@ func (p *SQLiteProvider) CreatePendingRegistrationStore(config map[string]interf
 	return &SQLitePendingRegistrationStore{db: db}, nil
 }
 
+// CreateIPTrustStore is not yet supported by the SQLite provider.
+// IP trust storage is implemented by the database (PostgreSQL) provider (Issue #1691).
+func (p *SQLiteProvider) CreateIPTrustStore(_ map[string]interface{}) (business.IPTrustStore, error) {
+	return nil, business.ErrNotSupported
+}
+
 // OpenBusinessStores implements interfaces.BusinessStoreOpener.
 // It opens the SQLite database at path exactly once, runs schema initialisation,
 // and returns all seven business stores sharing the same *sql.DB connection pool.


### PR DESCRIPTION
## Summary

- Introduces `IPTrustStore` interface and PostgreSQL implementation for recording tenant-scoped trusted IP ranges (/32 or CIDR)
- Wires the store into `StorageProvider`, `BusinessStoreBundle`, and `HybridStorageManager` infrastructure
- SQLite and flatfile providers return `ErrNotSupported` — IP trust is database-tier only in this story

## What changed

**New interface** (`pkg/storage/interfaces/business/ip_trust_store.go`):
- `AddTrustedRange`, `IsTrusted`, `ListTrustedRanges`, `RevokeTrustedRange`, `RecordHealthySteward`, `GetLastActivity`
- `IPTrustEntry` and `IPTrustActivity` structs; `ErrIPTrustEntryNotFound` sentinel
- CIDR normalization via `net.ParseCIDR` round-trip (stores network address, prevents duplicates)

**PostgreSQL implementation** (`pkg/storage/providers/database/ip_trust_store.go`):
- IP containment checked in Go (`ipNet.Contains`), not SQL — avoids DB-level CIDR type dependency
- UPSERT (`ON CONFLICT (tenant_id, cidr) DO UPDATE`) reactivates revoked entries
- Advisory lock `16923847` for schema initialization
- `cfgms_ip_trust_ranges` table with `UNIQUE(tenant_id, cidr)` + two covering indexes

**Contract tests** (15 tests, in-memory test double, `package business_test`):
Tenant isolation, CIDR normalization, revoke-clears-access, pre-seeded round-trip, activity tracking

**Integration tests** (PostgreSQL, skip when unavailable):
All acceptance criteria paths including `TestIPTrustStore_CIDRContainment` (/32, /24 containment, out-of-range) and `TestIPTrustStore_RevokeClearsAccess`

## Specialist review results

- **QA code reviewer**: PASS (after strengthening `RevokeNotFound` assertion from `assert.Error` to `require.ErrorIs` against sentinel)
- **QA test runner**: PASS (after adding `CreateIPTrustStore` stubs to trigger package test mocks)
- **Security engineer**: PASS

## Pre-existing lint failures

`make lint` fails on three files unrelated to this story:
- `features/modules/script/versioning.go` — gofmt (pre-existing)
- `features/controller/api/server.go` — gofmt (pre-existing)
- `features/controller/api/handlers_scripts.go` — unused function (pre-existing)

Confirmed pre-existing via `git stash` + `make lint` showing identical failures on the base branch.

Fixes #1691