### PR TITLE
transport: tune steward heartbeat to 20s+jitter and controller offline threshold to 60s (Issue #1692)

### DIFF
--- a/docs/architecture/controller-operating-model.md
+++ b/docs/architecture/controller-operating-model.md
@@ -208,10 +208,19 @@ For each steward, the controller tracks:
 
 The controller monitors steward heartbeats to detect connectivity loss:
 
-- Stewards send heartbeats at a configurable interval
-- If a heartbeat is missed beyond a timeout threshold, the steward is marked disconnected
+- Stewards send heartbeats at a **20 s base interval with ±10 s uniform per-tick jitter** (effective interval always in [20 s, 30 s) — see the [steward operating model heartbeat timing](steward-operating-model.md#heartbeat-timing) for rationale)
+- The controller marks a steward **offline after 60 s of silence** (`StewardOfflineTimeout`, epic #1664) — this is 3 missed heartbeats at the 20 s base, providing tolerance for transient network blips
 - Disconnected stewards continue operating independently — the controller simply loses visibility until the steward reconnects
 - On reconnect, the steward resyncs queued reports and the controller rebuilds its view
+
+**Two distinct timeout thresholds — do not confuse them:**
+
+| Field | Default | Purpose |
+|-------|---------|---------|
+| `StewardOfflineTimeout` | 60 s | Marks a steward offline after extended silence (epic #1664). Used by `checkStaleHeartbeats`. |
+| `HeartbeatTimeout` | 15 s | HA-failover detection threshold (Story #198, <15 s). Scoped exclusively to controller-HA scenarios. |
+
+These fields must remain distinct. `HeartbeatTimeout` is intentionally short for fast HA-failover detection and must not be used for steward-liveness decisions.
 
 ### Commands
 

--- a/docs/architecture/steward-operating-model.md
+++ b/docs/architecture/steward-operating-model.md
@@ -227,13 +227,25 @@ When connected to a controller, the steward also reports upstream:
 
 | Report | Timing | Content |
 |--------|--------|---------|
-| **Heartbeat** | Periodic (configurable interval) | Health status, uptime |
+| **Heartbeat** | Periodic (20 s base ± up to 10 s uniform jitter per tick; effective interval always in [20 s, 30 s)) | Health status, uptime |
 | **Convergence result** | After each convergence run | Per-resource compliance status, changes made, errors |
 | **DNA hash** | With each heartbeat | Hash of current DNA (control plane) |
 | **DNA delta** | As changes detected | Changed attributes only (control plane) |
 | **DNA full sync** | On hash mismatch or initial registration | Complete DNA snapshot (data plane) |
 | **Performance metrics** | Periodic (e.g., hourly), on-demand, or real-time stream | CPU, memory, disk, network, process metrics |
 | **Events** | As they occur | Drift detected, module errors, threshold breaches |
+
+### Heartbeat Timing
+
+Stewards send heartbeats at a base interval of **20 seconds**, with **uniform per-tick jitter in [0, 10 s)**. The effective per-tick interval is always in **[20 s, 30 s)**.
+
+**Why 20 s base with jitter (epic #1664):**
+
+- **NGFW UDP idle timeout survival**: Most Next-Generation Firewalls and NAT devices expire UDP pinholes after 30 s of silence. With a maximum effective interval of 30 s (exclusive), and QUIC keepalives at 20 s, at least one keepalive or heartbeat always fires before the 30 s timeout — keeping the QUIC connection alive through NGFW/NAT devices without requiring shorter (more expensive) keepalives.
+- **Herd prevention**: Jitter prevents 50 k stewards from synchronising their heartbeats, which would create CPU spikes on the controller. Uniform jitter distributes heartbeat load evenly across the 10 s window.
+- **Controller offline threshold**: The controller marks a steward offline after **60 s of silence** (3 missed heartbeats at 20 s base). The 3-miss threshold provides tolerance for transient network blips while detecting genuinely lost stewards within 60–90 s.
+
+The QUIC `KeepAlivePeriod` is set to **20 s** (aligned with the heartbeat base) so the QUIC layer and application layer cooperate — a QUIC PING fires at 20 s regardless of jitter, ensuring the UDP pinhole never reaches 30 s idle even when the heartbeat fires at its maximum interval.
 
 ### Offline Queueing
 

--- a/features/controller/heartbeat/service.go
+++ b/features/controller/heartbeat/service.go
@@ -72,8 +72,12 @@ type Service struct {
 	stewards map[string]*StewardStatus
 
 	// Configuration
-	heartbeatTimeout time.Duration // Time before marking steward as unhealthy
-	checkInterval    time.Duration // How often to check for timeouts
+	// HeartbeatTimeout is the HA-failover detection threshold (Story #198, <15 s).
+	// StewardOfflineTimeout is the steward-liveness threshold (epic #1664, 60 s).
+	// Do not merge these fields.
+	heartbeatTimeout      time.Duration // HA-failover detection (Story #198, 15 s)
+	stewardOfflineTimeout time.Duration // Steward-liveness detection (epic #1664, 60 s)
+	checkInterval         time.Duration // How often to check for timeouts
 
 	// Callbacks
 	onStatusChange      StatusChangeCallback
@@ -91,9 +95,18 @@ type Config struct {
 	// ControlPlane is the control plane provider for heartbeat subscriptions (Story #363)
 	ControlPlane controlplaneInterfaces.ControlPlaneProvider
 
-	// HeartbeatTimeout is how long to wait before marking a steward unhealthy
-	// Default: 15 seconds (Story #198 requirement)
+	// HeartbeatTimeout is the HA-failover detection threshold (Story #198, <15 s).
+	// StewardOfflineTimeout is the steward-liveness threshold (epic #1664, 60 s).
+	// Do not merge these fields.
+
+	// HeartbeatTimeout is the HA-failover detection threshold.
+	// Default: 15 seconds (Story #198 requirement).
 	HeartbeatTimeout time.Duration
+
+	// StewardOfflineTimeout is the steward-liveness detection threshold used by
+	// checkStaleHeartbeats to mark a steward offline after extended silence.
+	// Default: 60 seconds (epic #1664 — 3 missed heartbeats at 20 s interval).
+	StewardOfflineTimeout time.Duration
 
 	// CheckInterval is how often to check for stale heartbeats
 	// Default: 5 seconds
@@ -129,6 +142,11 @@ func New(cfg *Config) (*Service, error) {
 		heartbeatTimeout = 15 * time.Second // Story #198 requirement: <15s failover detection
 	}
 
+	stewardOfflineTimeout := cfg.StewardOfflineTimeout
+	if stewardOfflineTimeout == 0 {
+		stewardOfflineTimeout = 60 * time.Second // epic #1664: 3 missed heartbeats at 20s interval
+	}
+
 	checkInterval := cfg.CheckInterval
 	if checkInterval == 0 {
 		checkInterval = 5 * time.Second
@@ -137,23 +155,25 @@ func New(cfg *Config) (*Service, error) {
 	ctx, cancel := context.WithCancel(context.Background())
 
 	return &Service{
-		controlPlane:        cfg.ControlPlane,
-		stewards:            make(map[string]*StewardStatus),
-		heartbeatTimeout:    heartbeatTimeout,
-		checkInterval:       checkInterval,
-		onStatusChange:      cfg.OnStatusChange,
-		onDNAHashMismatch:   cfg.OnDNAHashMismatch,
-		onHeartbeatReceived: cfg.OnHeartbeatReceived,
-		ctx:                 ctx,
-		cancel:              cancel,
-		logger:              cfg.Logger,
+		controlPlane:          cfg.ControlPlane,
+		stewards:              make(map[string]*StewardStatus),
+		heartbeatTimeout:      heartbeatTimeout,
+		stewardOfflineTimeout: stewardOfflineTimeout,
+		checkInterval:         checkInterval,
+		onStatusChange:        cfg.OnStatusChange,
+		onDNAHashMismatch:     cfg.OnDNAHashMismatch,
+		onHeartbeatReceived:   cfg.OnHeartbeatReceived,
+		ctx:                   ctx,
+		cancel:                cancel,
+		logger:                cfg.Logger,
 	}, nil
 }
 
 // Start begins monitoring heartbeats.
 func (s *Service) Start(ctx context.Context) error {
 	s.logger.Info("Starting heartbeat monitoring service",
-		"timeout", s.heartbeatTimeout,
+		"ha_failover_timeout", s.heartbeatTimeout,
+		"steward_offline_timeout", s.stewardOfflineTimeout,
 		"check_interval", s.checkInterval)
 
 	// Subscribe to heartbeats via control plane provider (Story #363)
@@ -282,7 +302,7 @@ func (s *Service) checkStaleHeartbeats() {
 	for stewardID, status := range s.stewards {
 		if status.Healthy {
 			timeSinceLastBeat := now.Sub(status.LastHeartbeat)
-			if timeSinceLastBeat > s.heartbeatTimeout {
+			if timeSinceLastBeat > s.stewardOfflineTimeout {
 				// Mark as unhealthy
 				status.Healthy = false
 				status.MissedBeats++

--- a/features/controller/heartbeat/service_test.go
+++ b/features/controller/heartbeat/service_test.go
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+// Package heartbeat tests the steward-offline and HA-failover thresholds.
+// Epic #1664: StewardOfflineTimeout (60 s) is distinct from HeartbeatTimeout (15 s HA-failover).
+package heartbeat
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	controlplaneTypes "github.com/cfgis/cfgms/pkg/controlplane/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestHeartbeatService_StewardOfflineThreshold_60s verifies that:
+//  1. StewardOfflineTimeout defaults to 60 s when not configured.
+//  2. A steward is not marked offline at 59 s of silence (under the threshold).
+//  3. A steward is marked offline after 60 s of silence (at/over the threshold).
+//
+// This test distinguishes the steward-liveness path (StewardOfflineTimeout, 60 s)
+// from the HA-failover path (HeartbeatTimeout, 15 s). After epic #1664 the stale-
+// heartbeat checker uses StewardOfflineTimeout, so 15 s of silence must NOT trigger
+// an offline transition.
+func TestHeartbeatService_StewardOfflineThreshold_60s(t *testing.T) {
+	svc, cp := newTestService(t)
+	ctx := context.Background()
+
+	// Default StewardOfflineTimeout must be 60 s (epic #1664).
+	assert.Equal(t, 60*time.Second, svc.stewardOfflineTimeout,
+		"default StewardOfflineTimeout must be 60s (epic #1664)")
+
+	// Register the steward with a heartbeat.
+	require.NoError(t, cp.sendHeartbeat(ctx, &controlplaneTypes.Heartbeat{
+		StewardID: "steward-offline-test",
+		Status:    controlplaneTypes.StatusHealthy,
+		Timestamp: time.Now(),
+	}))
+
+	status, ok := svc.GetStatus("steward-offline-test")
+	require.True(t, ok)
+	assert.True(t, status.Healthy, "steward must start healthy")
+
+	// Simulate 59 s of silence — must NOT trigger offline (under threshold).
+	svc.mu.Lock()
+	svc.stewards["steward-offline-test"].LastHeartbeat = time.Now().Add(-59 * time.Second)
+	svc.stewards["steward-offline-test"].Healthy = true
+	svc.mu.Unlock()
+
+	svc.checkStaleHeartbeats()
+
+	status, ok = svc.GetStatus("steward-offline-test")
+	require.True(t, ok)
+	assert.True(t, status.Healthy,
+		"steward must remain healthy at 59s — StewardOfflineTimeout is 60s, not 15s")
+
+	// Simulate 61 s of silence — must trigger offline (over threshold).
+	svc.mu.Lock()
+	svc.stewards["steward-offline-test"].LastHeartbeat = time.Now().Add(-61 * time.Second)
+	svc.stewards["steward-offline-test"].Healthy = true
+	svc.mu.Unlock()
+
+	svc.checkStaleHeartbeats()
+
+	status, ok = svc.GetStatus("steward-offline-test")
+	require.True(t, ok)
+	assert.False(t, status.Healthy,
+		"steward must be marked offline after 61s of silence (StewardOfflineTimeout=60s)")
+}
+
+// TestHeartbeatService_HAFailoverThreshold_15s verifies that:
+//  1. HeartbeatTimeout defaults to 15 s (Story #198 requirement).
+//  2. StewardOfflineTimeout does not affect HeartbeatTimeout.
+//  3. The two fields are distinct and serve different purposes.
+//
+// HeartbeatTimeout is scoped to controller-HA failover detection (Story #198, <15 s).
+// StewardOfflineTimeout is scoped to steward-liveness detection (epic #1664, 60 s).
+// They must never be merged.
+func TestHeartbeatService_HAFailoverThreshold_15s(t *testing.T) {
+	svc, _ := newTestService(t)
+
+	// HeartbeatTimeout must remain 15 s for HA-failover detection (Story #198).
+	assert.Equal(t, 15*time.Second, svc.heartbeatTimeout,
+		"HeartbeatTimeout (HA-failover) must default to 15s (Story #198)")
+
+	// StewardOfflineTimeout must be 60 s for steward-liveness detection (epic #1664).
+	assert.Equal(t, 60*time.Second, svc.stewardOfflineTimeout,
+		"StewardOfflineTimeout must default to 60s (epic #1664)")
+
+	// The two fields must be distinct — merging them would break one of the two invariants.
+	assert.NotEqual(t, svc.heartbeatTimeout, svc.stewardOfflineTimeout,
+		"HeartbeatTimeout and StewardOfflineTimeout must be distinct values")
+
+	// StewardOfflineTimeout can be overridden without affecting HeartbeatTimeout.
+	customSvc, _ := newTestService(t, func(cfg *Config) {
+		cfg.StewardOfflineTimeout = 120 * time.Second
+	})
+	assert.Equal(t, 15*time.Second, customSvc.heartbeatTimeout,
+		"overriding StewardOfflineTimeout must not change HeartbeatTimeout")
+	assert.Equal(t, 120*time.Second, customSvc.stewardOfflineTimeout,
+		"custom StewardOfflineTimeout must be respected")
+}

--- a/features/steward/client/client_transport.go
+++ b/features/steward/client/client_transport.go
@@ -15,6 +15,7 @@ import (
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
+	"math/rand"
 	"os"
 	"path/filepath"
 	"sort"
@@ -100,6 +101,9 @@ type TransportClient struct {
 	// Heartbeat
 	heartbeatInterval time.Duration
 	heartbeatStop     chan struct{}
+	// rng is the per-instance RNG for per-tick heartbeat jitter (epic #1664).
+	// Only accessed from the startHeartbeat goroutine; no mutex required.
+	rng *rand.Rand
 
 	// offlineQueue persists reports locally when the controller is unreachable.
 	// Issue #419: drained in order after a successful reconnect.
@@ -192,8 +196,11 @@ func NewTransportClient(cfg *TransportConfig) (*TransportClient, error) {
 
 	heartbeatInterval := cfg.HeartbeatInterval
 	if heartbeatInterval == 0 {
-		heartbeatInterval = 30 * time.Second
+		heartbeatInterval = 20 * time.Second // epic #1664: 20s base + [0,10s) jitter
 	}
+
+	// Per-instance RNG for per-tick heartbeat jitter (epic #1664).
+	rng := rand.New(rand.NewSource(time.Now().UnixNano())) //#nosec G404 -- non-crypto jitter
 
 	// Initialize offline queue for durable report persistence (Issue #419).
 	// Pass the SecretStore so the encryption key is persisted across restarts (Issue #920).
@@ -210,6 +217,7 @@ func NewTransportClient(cfg *TransportConfig) (*TransportClient, error) {
 
 	c := &TransportClient{
 		heartbeatInterval:     heartbeatInterval,
+		rng:                   rng,
 		heartbeatStop:         make(chan struct{}),
 		convergenceStop:       make(chan struct{}),
 		convergeInterval:      30 * time.Minute,
@@ -1236,17 +1244,33 @@ func (c *TransportClient) drainOfflineQueue(ctx context.Context) {
 }
 
 // startHeartbeat starts the periodic heartbeat goroutine.
-// After each successful heartbeat, any events queued during a transient
-// offline period are drained so the controller receives them promptly (Issue #419).
+// Each tick fires after base + uniform jitter in [0, 10 s) so the effective
+// interval is always in [20 s, 30 s). Jitter keeps 50k stewards from
+// synchronising their heartbeats and spiking controller CPU (epic #1664).
+// After each successful heartbeat, queued offline events are drained so the
+// controller receives them promptly (Issue #419).
 func (c *TransportClient) startHeartbeat() {
-	ticker := time.NewTicker(c.heartbeatInterval)
-	defer ticker.Stop()
+	const (
+		jitterMax = 10 * time.Second
+	)
+
+	rng := c.rng
+	if rng == nil {
+		rng = rand.New(rand.NewSource(time.Now().UnixNano())) //#nosec G404 -- non-crypto jitter
+	}
+
+	nextInterval := func() time.Duration {
+		return c.heartbeatInterval + time.Duration(rng.Int63n(int64(jitterMax)))
+	}
+
+	timer := time.NewTimer(nextInterval())
+	defer timer.Stop()
 
 	for {
 		select {
 		case <-c.heartbeatStop:
 			return
-		case <-ticker.C:
+		case <-timer.C:
 			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 			if err := c.SendHeartbeat(ctx, "healthy", nil); err != nil {
 				c.logger.Warn("Failed to send heartbeat", "error", err)
@@ -1256,6 +1280,7 @@ func (c *TransportClient) startHeartbeat() {
 				c.drainOfflineQueue(ctx)
 			}
 			cancel()
+			timer.Reset(nextInterval())
 		}
 	}
 }

--- a/features/steward/client/client_transport_test.go
+++ b/features/steward/client/client_transport_test.go
@@ -164,6 +164,37 @@ func TestTransportClient_CertReloadOnHandshake(t *testing.T) {
 		"second handshake must return the newer cert after rotation (re-fetch, not cached)")
 }
 
+// TestTransportClient_HeartbeatJitter_Range verifies that:
+//  1. The default heartbeat interval is 20 s (epic #1664).
+//  2. 100 per-tick jitter-adjusted intervals all fall in [20 s, 30 s).
+//
+// Jitter is uniform in [0, 10 s), so the effective per-tick interval is always
+// between 20 s (no jitter) and just under 30 s (maximum jitter).
+func TestTransportClient_HeartbeatJitter_Range(t *testing.T) {
+	logger := logging.NewLogger("info")
+	c, err := NewTransportClient(&TransportConfig{
+		ControllerURL: "localhost:4433",
+		Logger:        logger,
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, 20*time.Second, c.heartbeatInterval,
+		"default heartbeat interval must be 20s (epic #1664)")
+
+	require.NotNil(t, c.rng, "NewTransportClient must initialise the per-instance RNG")
+
+	base := 20 * time.Second
+	jitterMax := 10 * time.Second
+	for i := 0; i < 100; i++ {
+		jitter := time.Duration(c.rng.Int63n(int64(jitterMax)))
+		interval := base + jitter
+		assert.GreaterOrEqual(t, interval, base,
+			"sample %d: jitter-adjusted interval must be >= 20s", i)
+		assert.Less(t, interval, base+jitterMax,
+			"sample %d: jitter-adjusted interval must be < 30s", i)
+	}
+}
+
 // TestTransportClient_CertNotCached verifies that every call to the
 // GetClientCertificate callback reads from the cert store rather than a cached
 // value — even when the certificate has not changed.

--- a/pkg/transport/quic/listener.go
+++ b/pkg/transport/quic/listener.go
@@ -15,17 +15,18 @@ import (
 
 // defaultQuicConfig returns the default QUIC configuration for the transport adapter.
 //
-// Keepalive tuning rationale (Story #504):
+// Keepalive tuning rationale (epic #1664, Story #504):
 //
-//   - KeepAlivePeriod 25s: Under the 30s worst-case NAT/firewall UDP pinhole timeout.
-//     At 50k stewards this produces ~2,000 PING frames/sec (vs 5,000 at 10s).
-//     Application heartbeats (default 30s) provide additional traffic that keeps
-//     connections alive, so QUIC keepalives are a safety net, not the primary signal.
+//   - KeepAlivePeriod 20s: Aligned with the steward heartbeat base interval (20 s ± 10 s
+//     jitter, epic #1664). The worst-case effective heartbeat interval is 30 s — the QUIC
+//     PING at 20 s ensures at least one keepalive fires before the 30 s NGFW UDP idle
+//     timeout, keeping the UDP pinhole open even when the heartbeat fires near its maximum
+//     jitter. At 50k stewards this produces ~2,500 PING frames/sec.
 //
-//   - MaxIdleTimeout 90s: 3.6× the keepalive period. A connection is torn down only
-//     after ~3 missed keepalives AND no application traffic. This is generous enough
+//   - MaxIdleTimeout 90s: 4.5× the keepalive period. A connection is torn down only
+//     after ~4 missed keepalives AND no application traffic. This is generous enough
 //     to survive transient network blips while still detecting genuinely dead connections
-//     well before the controller's heartbeat timeout (default 15s detection + this).
+//     well before the controller's steward-offline threshold (60 s, epic #1664).
 //
 //   - HandshakeIdleTimeout 30s: quic-go defaults to 5s, which is too aggressive for
 //     macOS CI environments under load (many rapid UDP socket open/close cycles exhaust
@@ -57,7 +58,7 @@ import (
 func defaultQuicConfig() *quicgo.Config {
 	return &quicgo.Config{
 		MaxIdleTimeout:                 90 * time.Second,
-		KeepAlivePeriod:                25 * time.Second,
+		KeepAlivePeriod:                20 * time.Second,
 		HandshakeIdleTimeout:           30 * time.Second,
 		MaxIncomingStreams:             1,
 		MaxIncomingUniStreams:          -1,
@@ -106,7 +107,7 @@ var _ net.Listener = (*Listener)(nil)
 //
 // tlsConfig must have NextProtos set to a value agreed with the client.
 // If quicConfig is nil, sensible defaults (MaxIdleTimeout: 90s,
-// KeepAlivePeriod: 25s, HandshakeIdleTimeout: 30s, MaxIncomingStreams: 1,
+// KeepAlivePeriod: 20s, HandshakeIdleTimeout: 30s, MaxIncomingStreams: 1,
 // and other DoS-resilience fields) are used. See defaultQuicConfig for rationale.
 //
 // Listen enforces QUIC address validation (Retry) on every inbound connection

--- a/pkg/transport/quic/listener_test.go
+++ b/pkg/transport/quic/listener_test.go
@@ -26,8 +26,8 @@ func TestDefaultQuicConfig_TunedValues(t *testing.T) {
 	if cfg.MaxIdleTimeout != 90*time.Second {
 		t.Errorf("MaxIdleTimeout: want 90s, got %s (see Story #504 keepalive rationale)", cfg.MaxIdleTimeout)
 	}
-	if cfg.KeepAlivePeriod != 25*time.Second {
-		t.Errorf("KeepAlivePeriod: want 25s, got %s (see Story #504 keepalive rationale)", cfg.KeepAlivePeriod)
+	if cfg.KeepAlivePeriod != 20*time.Second {
+		t.Errorf("KeepAlivePeriod: want 20s, got %s (see epic #1664 NGFW alignment rationale)", cfg.KeepAlivePeriod)
 	}
 	if cfg.HandshakeIdleTimeout != 30*time.Second {
 		t.Errorf("HandshakeIdleTimeout: want 30s, got %s (quic-go default 5s is too short for macOS CI under load)", cfg.HandshakeIdleTimeout)


### PR DESCRIPTION
## Summary

- Steward default heartbeat changed from 30s fixed ticker → 20s base + [0,10s) uniform per-tick jitter; effective per-tick interval always in [20s, 30s)
- Controller stale-heartbeat checker now uses `StewardOfflineTimeout` (60s, new) instead of `HeartbeatTimeout`; `HeartbeatTimeout` (15s, Story #198 HA-failover) is unchanged
- QUIC `KeepAlivePeriod` tuned 25s → 20s in `defaultQuicConfig()` to align with heartbeat base and survive 30s NGFW UDP idle timeout

## Motivation

Production NGFW devices expire UDP pinholes after 30s of silence. With the old 30s fixed heartbeat and 25s QUIC keepalive, a single jitter event or scheduling delay could push the effective interval past 30s, dropping the QUIC connection. With this change the maximum effective heartbeat interval is 30s-exclusive and the QUIC PING fires at 20s regardless, ensuring at least one keepalive always arrives before expiry.

The old single `heartbeatTimeout` (15s) was sized for HA-failover detection (Story #198) — using it for steward-liveness detection caused spurious offline transitions. The new `StewardOfflineTimeout` (60s = 3 missed 20s beats) is correctly sized for liveness.

## Tests Added

- `TestTransportClient_HeartbeatJitter_Range` — default interval 20s; 100 sampled jitter intervals all in [20s, 30s)
- `TestHeartbeatService_StewardOfflineThreshold_60s` — healthy at 59s silence, offline at 61s; confirms 60s threshold not old 15s
- `TestHeartbeatService_HAFailoverThreshold_15s` — `HeartbeatTimeout` remains 15s regardless of `StewardOfflineTimeout`
- `TestDefaultQuicConfig_TunedValues` — updated `KeepAlivePeriod` assertion to 20s

## Specialist Review Results

| Reviewer | Result |
|----------|--------|
| qa-test-runner | **PASS** — 142/142 script tests, all Go packages pass, gofmt clean, staticcheck clean |
| qa-code-reviewer | **PASS** — no mocks, no t.Skip, error paths covered, jitter sampling validated |
| security-engineer | **PASS** — `math/rand` jitter is non-crypto and correctly annotated; all scans pass |

Fixes #1692