### PR TITLE
controller/run: run/job/execution model + ad-hoc run synthesis (Issue #1673)

### DIFF
--- a/features/controller/api/handlers_runs.go
+++ b/features/controller/api/handlers_runs.go
@@ -1,0 +1,335 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+package api
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"net/http"
+
+	"github.com/gorilla/mux"
+
+	"github.com/cfgis/cfgms/features/controller/fleet"
+	controllerrun "github.com/cfgis/cfgms/features/controller/run"
+	scriptmodule "github.com/cfgis/cfgms/features/modules/script"
+	"github.com/cfgis/cfgms/pkg/ctxkeys"
+	"github.com/cfgis/cfgms/pkg/logging"
+)
+
+// postRunScriptRequest is the body of POST /api/v1/runs/script.
+type postRunScriptRequest struct {
+	Target        string            `json:"target"`         // fleet selector string
+	ScriptID      string            `json:"script_id"`      // script identifier in the library
+	ScriptVersion string            `json:"script_version"` // optional; empty = latest
+	Shell         string            `json:"shell"`          // optional shell override
+	Params        map[string]string `json:"params"`         // script parameters
+}
+
+// postRunCommandRequest is the body of POST /api/v1/runs/command.
+// Content is the inline script body, base64-encoded.
+type postRunCommandRequest struct {
+	Target  string            `json:"target"`  // fleet selector string
+	Content string            `json:"content"` // base64-encoded inline script
+	Shell   string            `json:"shell"`   // shell to use (e.g. "bash")
+	Params  map[string]string `json:"params"`  // script parameters
+}
+
+// handlePostRunScript handles POST /api/v1/runs/script.
+// Creates a run record and fans out one QueuedExecution per matched steward.
+func (s *Server) handlePostRunScript(w http.ResponseWriter, r *http.Request) {
+	if s.runManager == nil || s.runExecutionQueue == nil {
+		s.writeErrorResponse(w, http.StatusServiceUnavailable, "Run service not available", "SERVICE_UNAVAILABLE")
+		return
+	}
+
+	tenantID, _ := r.Context().Value(ctxkeys.TenantID).(string)
+	if tenantID == "" {
+		s.writeErrorResponse(w, http.StatusUnauthorized, "Authentication required", "AUTHENTICATION_REQUIRED")
+		return
+	}
+	principal, ok := r.Context().Value(principalContextKey).(*Principal)
+	if !ok || principal == nil {
+		s.writeErrorResponse(w, http.StatusUnauthorized, "Authentication required", "AUTHENTICATION_REQUIRED")
+		return
+	}
+
+	var req postRunScriptRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		s.writeErrorResponse(w, http.StatusBadRequest, "Invalid request body", "INVALID_REQUEST")
+		return
+	}
+	if req.ScriptID == "" {
+		s.writeErrorResponse(w, http.StatusBadRequest, "script_id is required", "MISSING_SCRIPT_ID")
+		return
+	}
+
+	filter, err := parseRunTarget(req.Target)
+	if err != nil {
+		s.writeErrorResponse(w, http.StatusBadRequest, "Invalid target selector: "+err.Error(), "INVALID_TARGET")
+		return
+	}
+
+	if s.fleetQuery == nil {
+		s.writeErrorResponse(w, http.StatusServiceUnavailable, "Fleet query not available", "SERVICE_UNAVAILABLE")
+		return
+	}
+
+	runID, err := controllerrun.SynthesizeScriptRun(
+		r.Context(),
+		s.runManager,
+		s.runExecutionQueue,
+		s.fleetQuery,
+		tenantID,
+		principal.ID,
+		filter,
+		req.ScriptID,
+		req.ScriptVersion,
+		scriptmodule.ShellType(req.Shell),
+		req.Params,
+	)
+	if err != nil {
+		s.logger.Error("Failed to synthesize script run",
+			"script_id", logging.SanitizeLogValue(req.ScriptID),
+			"error", err,
+		)
+		s.writeErrorResponse(w, http.StatusInternalServerError, "Failed to create run", "INTERNAL_ERROR")
+		return
+	}
+
+	s.writeSuccessResponse(w, map[string]string{"run_id": runID})
+}
+
+// handlePostRunCommand handles POST /api/v1/runs/command.
+// Creates a run record for an inline (ad-hoc) script and fans out one
+// QueuedExecution per matched steward.
+func (s *Server) handlePostRunCommand(w http.ResponseWriter, r *http.Request) {
+	if s.runManager == nil || s.runExecutionQueue == nil {
+		s.writeErrorResponse(w, http.StatusServiceUnavailable, "Run service not available", "SERVICE_UNAVAILABLE")
+		return
+	}
+
+	tenantID, _ := r.Context().Value(ctxkeys.TenantID).(string)
+	if tenantID == "" {
+		s.writeErrorResponse(w, http.StatusUnauthorized, "Authentication required", "AUTHENTICATION_REQUIRED")
+		return
+	}
+	principal, ok := r.Context().Value(principalContextKey).(*Principal)
+	if !ok || principal == nil {
+		s.writeErrorResponse(w, http.StatusUnauthorized, "Authentication required", "AUTHENTICATION_REQUIRED")
+		return
+	}
+
+	var req postRunCommandRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		s.writeErrorResponse(w, http.StatusBadRequest, "Invalid request body", "INVALID_REQUEST")
+		return
+	}
+	if req.Content == "" {
+		s.writeErrorResponse(w, http.StatusBadRequest, "content is required", "MISSING_CONTENT")
+		return
+	}
+	if req.Shell == "" {
+		s.writeErrorResponse(w, http.StatusBadRequest, "shell is required", "MISSING_SHELL")
+		return
+	}
+
+	inlineContent, err := base64.StdEncoding.DecodeString(req.Content)
+	if err != nil {
+		s.writeErrorResponse(w, http.StatusBadRequest, "content must be base64-encoded", "INVALID_CONTENT")
+		return
+	}
+
+	filter, err := parseRunTarget(req.Target)
+	if err != nil {
+		s.writeErrorResponse(w, http.StatusBadRequest, "Invalid target selector: "+err.Error(), "INVALID_TARGET")
+		return
+	}
+
+	if s.fleetQuery == nil {
+		s.writeErrorResponse(w, http.StatusServiceUnavailable, "Fleet query not available", "SERVICE_UNAVAILABLE")
+		return
+	}
+
+	runID, err := controllerrun.SynthesizeCommandRun(
+		r.Context(),
+		s.runManager,
+		s.runExecutionQueue,
+		s.fleetQuery,
+		tenantID,
+		principal.ID,
+		filter,
+		string(inlineContent),
+		scriptmodule.ShellType(req.Shell),
+		req.Params,
+	)
+	if err != nil {
+		s.logger.Error("Failed to synthesize command run",
+			"shell", logging.SanitizeLogValue(req.Shell),
+			"error", err,
+		)
+		s.writeErrorResponse(w, http.StatusInternalServerError, "Failed to create run", "INTERNAL_ERROR")
+		return
+	}
+
+	s.writeSuccessResponse(w, map[string]string{"run_id": runID})
+}
+
+// handleGetRun handles GET /api/v1/runs/{run_id}.
+func (s *Server) handleGetRun(w http.ResponseWriter, r *http.Request) {
+	if s.runManager == nil {
+		s.writeErrorResponse(w, http.StatusServiceUnavailable, "Run service not available", "SERVICE_UNAVAILABLE")
+		return
+	}
+
+	tenantID, _ := r.Context().Value(ctxkeys.TenantID).(string)
+	if tenantID == "" {
+		s.writeErrorResponse(w, http.StatusUnauthorized, "Authentication required", "AUTHENTICATION_REQUIRED")
+		return
+	}
+
+	vars := mux.Vars(r)
+	runID := vars["run_id"]
+	if runID == "" {
+		s.writeErrorResponse(w, http.StatusBadRequest, "run_id is required", "MISSING_RUN_ID")
+		return
+	}
+
+	run, err := s.runManager.GetRun(r.Context(), runID)
+	if err != nil {
+		if errors.Is(err, controllerrun.ErrNotFound) {
+			s.writeErrorResponse(w, http.StatusNotFound, "Run not found", "NOT_FOUND")
+			return
+		}
+		s.logger.Error("Failed to get run", "run_id", logging.SanitizeLogValue(runID), "error", err)
+		s.writeErrorResponse(w, http.StatusInternalServerError, "Failed to get run", "INTERNAL_ERROR")
+		return
+	}
+
+	// Tenant isolation: return 404 (not 403) to avoid leaking existence across tenants.
+	if run.TenantID != tenantID {
+		s.writeErrorResponse(w, http.StatusNotFound, "Run not found", "NOT_FOUND")
+		return
+	}
+
+	s.writeSuccessResponse(w, run)
+}
+
+// handleGetRunJobs handles GET /api/v1/runs/{run_id}/jobs.
+func (s *Server) handleGetRunJobs(w http.ResponseWriter, r *http.Request) {
+	if s.runManager == nil {
+		s.writeErrorResponse(w, http.StatusServiceUnavailable, "Run service not available", "SERVICE_UNAVAILABLE")
+		return
+	}
+
+	tenantID, _ := r.Context().Value(ctxkeys.TenantID).(string)
+	if tenantID == "" {
+		s.writeErrorResponse(w, http.StatusUnauthorized, "Authentication required", "AUTHENTICATION_REQUIRED")
+		return
+	}
+
+	vars := mux.Vars(r)
+	runID := vars["run_id"]
+	if runID == "" {
+		s.writeErrorResponse(w, http.StatusBadRequest, "run_id is required", "MISSING_RUN_ID")
+		return
+	}
+
+	// Verify run existence and tenant ownership before returning job details.
+	run, err := s.runManager.GetRun(r.Context(), runID)
+	if err != nil {
+		if errors.Is(err, controllerrun.ErrNotFound) {
+			s.writeErrorResponse(w, http.StatusNotFound, "Run not found", "NOT_FOUND")
+			return
+		}
+		s.logger.Error("Failed to get run", "run_id", logging.SanitizeLogValue(runID), "error", err)
+		s.writeErrorResponse(w, http.StatusInternalServerError, "Failed to list jobs", "INTERNAL_ERROR")
+		return
+	}
+	if run.TenantID != tenantID {
+		s.writeErrorResponse(w, http.StatusNotFound, "Run not found", "NOT_FOUND")
+		return
+	}
+
+	jobs, err := s.runManager.ListRunJobs(r.Context(), runID)
+	if err != nil {
+		s.logger.Error("Failed to list run jobs", "run_id", logging.SanitizeLogValue(runID), "error", err)
+		s.writeErrorResponse(w, http.StatusInternalServerError, "Failed to list jobs", "INTERNAL_ERROR")
+		return
+	}
+
+	if jobs == nil {
+		jobs = []*controllerrun.JobRecord{}
+	}
+	s.writeSuccessResponse(w, jobs)
+}
+
+// handleDeleteRun handles DELETE /api/v1/runs/{run_id}.
+// Returns 200 on success, 404 when not found, 409 when already terminal.
+func (s *Server) handleDeleteRun(w http.ResponseWriter, r *http.Request) {
+	if s.runManager == nil {
+		s.writeErrorResponse(w, http.StatusServiceUnavailable, "Run service not available", "SERVICE_UNAVAILABLE")
+		return
+	}
+
+	tenantID, _ := r.Context().Value(ctxkeys.TenantID).(string)
+	if tenantID == "" {
+		s.writeErrorResponse(w, http.StatusUnauthorized, "Authentication required", "AUTHENTICATION_REQUIRED")
+		return
+	}
+
+	vars := mux.Vars(r)
+	runID := vars["run_id"]
+	if runID == "" {
+		s.writeErrorResponse(w, http.StatusBadRequest, "run_id is required", "MISSING_RUN_ID")
+		return
+	}
+
+	// Verify tenant ownership before cancelling. Returns 404 on mismatch to avoid
+	// leaking cross-tenant run existence (IDOR prevention).
+	run, err := s.runManager.GetRun(r.Context(), runID)
+	if err != nil {
+		if errors.Is(err, controllerrun.ErrNotFound) {
+			s.writeErrorResponse(w, http.StatusNotFound, "Run not found", "NOT_FOUND")
+			return
+		}
+		s.logger.Error("Failed to get run for cancel", "run_id", logging.SanitizeLogValue(runID), "error", err)
+		s.writeErrorResponse(w, http.StatusInternalServerError, "Failed to cancel run", "INTERNAL_ERROR")
+		return
+	}
+	if run.TenantID != tenantID {
+		s.writeErrorResponse(w, http.StatusNotFound, "Run not found", "NOT_FOUND")
+		return
+	}
+
+	if run.Status.IsTerminal() {
+		s.writeErrorResponse(w, http.StatusConflict, "Run is already in a terminal state", "ALREADY_TERMINAL")
+		return
+	}
+
+	err = s.runManager.CancelRun(r.Context(), runID)
+	if err != nil {
+		if errors.Is(err, controllerrun.ErrNotFound) {
+			s.writeErrorResponse(w, http.StatusNotFound, "Run not found", "NOT_FOUND")
+			return
+		}
+		if errors.Is(err, controllerrun.ErrAlreadyTerminal) {
+			s.writeErrorResponse(w, http.StatusConflict, "Run is already in a terminal state", "ALREADY_TERMINAL")
+			return
+		}
+		s.logger.Error("Failed to cancel run", "run_id", logging.SanitizeLogValue(runID), "error", err)
+		s.writeErrorResponse(w, http.StatusInternalServerError, "Failed to cancel run", "INTERNAL_ERROR")
+		return
+	}
+
+	s.writeSuccessResponse(w, map[string]bool{"cancelled": true})
+}
+
+// parseRunTarget converts an optional fleet selector string to a fleet.Filter.
+// An empty target matches all stewards (within the caller's tenant, enforced by synthesis).
+func parseRunTarget(target string) (fleet.Filter, error) {
+	if target == "" || target == "all" {
+		return fleet.Filter{}, nil
+	}
+	return fleet.ParseTargetSelector(target)
+}

--- a/features/controller/api/handlers_runs_test.go
+++ b/features/controller/api/handlers_runs_test.go
@@ -1,0 +1,557 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+package api
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cfgis/cfgms/features/controller/fleet"
+	controllerrun "github.com/cfgis/cfgms/features/controller/run"
+	scriptmodule "github.com/cfgis/cfgms/features/modules/script"
+	_ "modernc.org/sqlite"
+)
+
+// ---- test helpers -----------------------------------------------------------
+
+// staticRunFleetQuery is a real FleetQuery implementation that returns a fixed
+// set of stewards. It is NOT a mock — it satisfies the fleet.FleetQuery interface.
+type staticRunFleetQuery struct {
+	results []fleet.StewardResult
+}
+
+func (q *staticRunFleetQuery) Search(_ context.Context, _ fleet.Filter) ([]fleet.StewardResult, error) {
+	return q.results, nil
+}
+
+func (q *staticRunFleetQuery) Count(_ context.Context, _ fleet.Filter) (int, error) {
+	return len(q.results), nil
+}
+
+// newTestRunManager creates a run.Manager backed by an in-memory SQLite database.
+func newTestRunManager(t *testing.T) *controllerrun.Manager {
+	t.Helper()
+
+	db, err := sql.Open("sqlite", ":memory:")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+
+	store := controllerrun.NewRunStoreSQL(db)
+	require.NoError(t, store.Init(context.Background()))
+
+	return controllerrun.NewManager(store, nil)
+}
+
+// newTestRunQueue creates a real ExecutionQueue backed by an in-memory store.
+func newTestRunQueue() *scriptmodule.ExecutionQueue {
+	monitor := scriptmodule.NewExecutionMonitor()
+	keyManager := scriptmodule.NewEphemeralKeyManager()
+	return scriptmodule.NewExecutionQueue(monitor, keyManager, 0, "", nil, nil, 0)
+}
+
+// setupRunServer creates a test server wired with a run manager, execution queue,
+// and a fleet query returning the given stewards.
+func setupRunServer(t *testing.T, stewards []fleet.StewardResult) (*Server, *controllerrun.Manager, *scriptmodule.ExecutionQueue) {
+	t.Helper()
+	server := setupTestServer(t)
+
+	manager := newTestRunManager(t)
+	queue := newTestRunQueue()
+
+	server.SetRunManager(manager, queue)
+	server.fleetQuery = &staticRunFleetQuery{results: stewards}
+
+	return server, manager, queue
+}
+
+// postRunScript sends POST /api/v1/runs/script with the given request body.
+func postRunScript(t *testing.T, server *Server, apiKey string, body interface{}) *httptest.ResponseRecorder {
+	t.Helper()
+	b, err := json.Marshal(body)
+	require.NoError(t, err)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/runs/script", bytes.NewReader(b))
+	req.Header.Set("X-API-Key", apiKey)
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	server.router.ServeHTTP(rec, req)
+	return rec
+}
+
+// postRunCommand sends POST /api/v1/runs/command with the given request body.
+func postRunCommand(t *testing.T, server *Server, apiKey string, body interface{}) *httptest.ResponseRecorder {
+	t.Helper()
+	b, err := json.Marshal(body)
+	require.NoError(t, err)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/runs/command", bytes.NewReader(b))
+	req.Header.Set("X-API-Key", apiKey)
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	server.router.ServeHTTP(rec, req)
+	return rec
+}
+
+// getRun sends GET /api/v1/runs/{runID}.
+func getRun(t *testing.T, server *Server, apiKey, runID string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/runs/"+runID, nil)
+	req.Header.Set("X-API-Key", apiKey)
+	rec := httptest.NewRecorder()
+	server.router.ServeHTTP(rec, req)
+	return rec
+}
+
+// getRunJobs sends GET /api/v1/runs/{runID}/jobs.
+func getRunJobs(t *testing.T, server *Server, apiKey, runID string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/runs/"+runID+"/jobs", nil)
+	req.Header.Set("X-API-Key", apiKey)
+	rec := httptest.NewRecorder()
+	server.router.ServeHTTP(rec, req)
+	return rec
+}
+
+// deleteRun sends DELETE /api/v1/runs/{runID}.
+func deleteRun(t *testing.T, server *Server, apiKey, runID string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodDelete, "/api/v1/runs/"+runID, nil)
+	req.Header.Set("X-API-Key", apiKey)
+	rec := httptest.NewRecorder()
+	server.router.ServeHTTP(rec, req)
+	return rec
+}
+
+// ---- [REQUIRED TEST] POST /api/v1/runs/script fan-out ----------------------
+
+// TestPostRunScript_TwoStewardFanout verifies that POST /api/v1/runs/script with
+// two matching stewards creates exactly two JobRecords and two QueuedExecutions,
+// each carrying workflow_run_id in metadata. This is the primary AC test.
+func TestPostRunScript_TwoStewardFanout(t *testing.T) {
+	stewards := []fleet.StewardResult{
+		{ID: "steward-001", TenantID: "test-tenant"},
+		{ID: "steward-002", TenantID: "test-tenant"},
+	}
+	server, manager, queue := setupRunServer(t, stewards)
+	apiKey := NewTestKey(t, server, []string{"steward:execute-scripts"})
+
+	rec := postRunScript(t, server, apiKey, map[string]interface{}{
+		"target":    "all",
+		"script_id": "scripts/deploy.sh",
+		"params":    map[string]string{"env": "prod"},
+	})
+	require.Equal(t, http.StatusOK, rec.Code, "expected 200 OK, body: %s", rec.Body.String())
+
+	var resp APIResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	data, ok := resp.Data.(map[string]interface{})
+	require.True(t, ok, "response data must be an object")
+	runID, ok := data["run_id"].(string)
+	require.True(t, ok && runID != "", "response must contain a non-empty run_id")
+
+	// Two JobRecords must exist, one per steward
+	jobs, err := manager.ListRunJobs(context.Background(), runID)
+	require.NoError(t, err)
+	require.Len(t, jobs, 2, "must have two job records — one per matched steward")
+
+	deviceIDs := map[string]bool{}
+	for _, j := range jobs {
+		assert.Equal(t, runID, j.RunID)
+		assert.NotEmpty(t, j.ExecutionID, "each job must have a pre-assigned execution_id")
+		deviceIDs[j.DeviceID] = true
+	}
+	assert.True(t, deviceIDs["steward-001"], "job for steward-001 must exist")
+	assert.True(t, deviceIDs["steward-002"], "job for steward-002 must exist")
+
+	// Two QueuedExecutions must exist, each with workflow_run_id in metadata
+	exec1 := queue.PeekForDevice("steward-001")
+	exec2 := queue.PeekForDevice("steward-002")
+	require.Len(t, exec1, 1, "steward-001 must have one queued execution")
+	require.Len(t, exec2, 1, "steward-002 must have one queued execution")
+
+	for _, e := range []*scriptmodule.QueuedExecution{exec1[0], exec2[0]} {
+		assert.Equal(t, runID, e.Metadata["workflow_run_id"],
+			"queued execution must carry workflow_run_id")
+		assert.NotEmpty(t, e.Metadata["job_id"], "queued execution must carry job_id")
+	}
+}
+
+// ---- [REQUIRED TEST] GET /api/v1/runs/{run_id}/jobs accuracy ---------------
+
+// TestGetRunJobs_ReturnsCorrectDeviceAndExecutionIDs verifies that
+// GET /api/v1/runs/{run_id}/jobs returns each job with the correct device_id and
+// execution_id matching what was stored by the synthesis path.
+func TestGetRunJobs_ReturnsCorrectDeviceAndExecutionIDs(t *testing.T) {
+	stewards := []fleet.StewardResult{
+		{ID: "device-A", TenantID: "test-tenant"},
+		{ID: "device-B", TenantID: "test-tenant"},
+	}
+	server, _, queue := setupRunServer(t, stewards)
+	execKey := NewTestKey(t, server, []string{"steward:execute-scripts"})
+	readKey := NewTestKey(t, server, []string{"steward:read-scripts"})
+
+	// Create the run
+	rec := postRunScript(t, server, execKey, map[string]interface{}{
+		"target":    "all",
+		"script_id": "scripts/check.sh",
+	})
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var createResp APIResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &createResp))
+	runID := createResp.Data.(map[string]interface{})["run_id"].(string)
+
+	// Query the jobs
+	jobsRec := getRunJobs(t, server, readKey, runID)
+	require.Equal(t, http.StatusOK, jobsRec.Code, "body: %s", jobsRec.Body.String())
+
+	var jobsResp APIResponse
+	require.NoError(t, json.Unmarshal(jobsRec.Body.Bytes(), &jobsResp))
+	items, ok := jobsResp.Data.([]interface{})
+	require.True(t, ok, "response data must be an array")
+	require.Len(t, items, 2, "must return one job per matched steward")
+
+	// Cross-check each job's device_id and execution_id against the queue
+	jobsByDevice := map[string]map[string]interface{}{}
+	for _, item := range items {
+		m := item.(map[string]interface{})
+		deviceID, _ := m["device_id"].(string)
+		jobsByDevice[deviceID] = m
+	}
+
+	for _, deviceID := range []string{"device-A", "device-B"} {
+		j, found := jobsByDevice[deviceID]
+		require.True(t, found, "job for %s must exist", deviceID)
+
+		executionID, _ := j["execution_id"].(string)
+		assert.NotEmpty(t, executionID, "execution_id must not be empty for %s", deviceID)
+
+		// The execution_id in the job record must match the one in the queue
+		queued := queue.PeekForDevice(deviceID)
+		require.Len(t, queued, 1, "%s must have one queued execution", deviceID)
+		assert.Equal(t, executionID, queued[0].ExecutionID,
+			"job execution_id must match queued execution for %s", deviceID)
+	}
+}
+
+// ---- [REQUIRED TEST] Permission gates ---------------------------------------
+
+// TestRunEndpoints_PermissionGates verifies that POST/DELETE require
+// steward:execute-scripts and GET requires steward:read-scripts.
+func TestRunEndpoints_PermissionGates(t *testing.T) {
+	stewards := []fleet.StewardResult{{ID: "device-perm", TenantID: "test-tenant"}}
+	server, _, _ := setupRunServer(t, stewards)
+
+	readOnlyKey := NewTestKey(t, server, []string{"steward:read-scripts"})
+	execOnlyKey := NewTestKey(t, server, []string{"steward:execute-scripts"})
+
+	// POST /runs/script requires execute-scripts
+	rec := postRunScript(t, server, readOnlyKey, map[string]interface{}{
+		"target":    "all",
+		"script_id": "scripts/test.sh",
+	})
+	assert.Equal(t, http.StatusForbidden, rec.Code, "POST /runs/script must require execute-scripts")
+
+	// POST /runs/command requires execute-scripts
+	rec = postRunCommand(t, server, readOnlyKey, map[string]interface{}{
+		"target":  "all",
+		"content": base64.StdEncoding.EncodeToString([]byte("echo hi")),
+		"shell":   "bash",
+	})
+	assert.Equal(t, http.StatusForbidden, rec.Code, "POST /runs/command must require execute-scripts")
+
+	// GET /runs/{run_id} requires read-scripts
+	// Create a run first with exec key
+	createRec := postRunScript(t, server, execOnlyKey, map[string]interface{}{
+		"target":    "all",
+		"script_id": "scripts/test.sh",
+	})
+	require.Equal(t, http.StatusOK, createRec.Code)
+	var createResp APIResponse
+	require.NoError(t, json.Unmarshal(createRec.Body.Bytes(), &createResp))
+	runID := createResp.Data.(map[string]interface{})["run_id"].(string)
+
+	rec = getRun(t, server, execOnlyKey, runID)
+	assert.Equal(t, http.StatusForbidden, rec.Code, "GET /runs/{id} must require read-scripts")
+
+	rec = getRunJobs(t, server, execOnlyKey, runID)
+	assert.Equal(t, http.StatusForbidden, rec.Code, "GET /runs/{id}/jobs must require read-scripts")
+
+	// DELETE requires execute-scripts
+	rec = deleteRun(t, server, readOnlyKey, runID)
+	assert.Equal(t, http.StatusForbidden, rec.Code, "DELETE /runs/{id} must require execute-scripts")
+}
+
+// ---- DELETE /api/v1/runs/{run_id} ------------------------------------------
+
+// TestDeleteRun_Success verifies that DELETE on a non-terminal run returns 200
+// and the run is cancelled.
+func TestDeleteRun_Success(t *testing.T) {
+	stewards := []fleet.StewardResult{{ID: "device-del", TenantID: "test-tenant"}}
+	server, _, _ := setupRunServer(t, stewards)
+	execKey := NewTestKey(t, server, []string{"steward:execute-scripts"})
+	readKey := NewTestKey(t, server, []string{"steward:read-scripts"})
+
+	// Create a run
+	createRec := postRunScript(t, server, execKey, map[string]interface{}{
+		"target":    "all",
+		"script_id": "scripts/cleanup.sh",
+	})
+	require.Equal(t, http.StatusOK, createRec.Code)
+	var createResp APIResponse
+	require.NoError(t, json.Unmarshal(createRec.Body.Bytes(), &createResp))
+	runID := createResp.Data.(map[string]interface{})["run_id"].(string)
+
+	// Cancel it
+	delRec := deleteRun(t, server, execKey, runID)
+	require.Equal(t, http.StatusOK, delRec.Code, "DELETE must return 200 for a non-terminal run; body: %s", delRec.Body.String())
+
+	var delResp APIResponse
+	require.NoError(t, json.Unmarshal(delRec.Body.Bytes(), &delResp))
+	data, ok := delResp.Data.(map[string]interface{})
+	require.True(t, ok)
+	assert.Equal(t, true, data["cancelled"], "response must include cancelled: true")
+
+	// Verify the run is durably cancelled via the read endpoint.
+	getResp := getRun(t, server, readKey, runID)
+	require.Equal(t, http.StatusOK, getResp.Code)
+	var runResp APIResponse
+	require.NoError(t, json.Unmarshal(getResp.Body.Bytes(), &runResp))
+	runData, ok := runResp.Data.(map[string]interface{})
+	require.True(t, ok, "GET response data must be an object")
+	assert.Equal(t, "cancelled", runData["status"], "run status must be 'cancelled' after DELETE")
+}
+
+// TestDeleteRun_NotFound verifies that DELETE on an unknown run returns 404.
+func TestDeleteRun_NotFound(t *testing.T) {
+	server, _, _ := setupRunServer(t, nil)
+	apiKey := NewTestKey(t, server, []string{"steward:execute-scripts"})
+
+	rec := deleteRun(t, server, apiKey, "no-such-run-id")
+	assert.Equal(t, http.StatusNotFound, rec.Code, "DELETE on unknown run must return 404")
+
+	var resp ErrorResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	require.NotNil(t, resp.Error)
+	assert.Equal(t, "NOT_FOUND", resp.Error.Code)
+}
+
+// TestDeleteRun_AlreadyTerminal verifies that DELETE on a completed run returns 409.
+func TestDeleteRun_AlreadyTerminal(t *testing.T) {
+	stewards := []fleet.StewardResult{{ID: "device-term", TenantID: "test-tenant"}}
+	server, _, _ := setupRunServer(t, stewards)
+	execKey := NewTestKey(t, server, []string{"steward:execute-scripts"})
+
+	// Create and cancel a run (so it's in a terminal state)
+	createRec := postRunScript(t, server, execKey, map[string]interface{}{
+		"target":    "all",
+		"script_id": "scripts/test.sh",
+	})
+	require.Equal(t, http.StatusOK, createRec.Code)
+	var createResp APIResponse
+	require.NoError(t, json.Unmarshal(createRec.Body.Bytes(), &createResp))
+	runID := createResp.Data.(map[string]interface{})["run_id"].(string)
+
+	// Cancel it once
+	require.Equal(t, http.StatusOK, deleteRun(t, server, execKey, runID).Code)
+
+	// Cancel it again — must return 409
+	rec := deleteRun(t, server, execKey, runID)
+	assert.Equal(t, http.StatusConflict, rec.Code, "DELETE on terminal run must return 409")
+
+	var resp ErrorResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	require.NotNil(t, resp.Error)
+	assert.Equal(t, "ALREADY_TERMINAL", resp.Error.Code)
+}
+
+// ---- GET /api/v1/runs/{run_id} ----------------------------------------------
+
+func TestGetRun_Found(t *testing.T) {
+	stewards := []fleet.StewardResult{{ID: "device-get", TenantID: "test-tenant"}}
+	server, _, _ := setupRunServer(t, stewards)
+	execKey := NewTestKey(t, server, []string{"steward:execute-scripts"})
+	readKey := NewTestKey(t, server, []string{"steward:read-scripts"})
+
+	createRec := postRunScript(t, server, execKey, map[string]interface{}{
+		"target":    "all",
+		"script_id": "scripts/get-test.sh",
+	})
+	require.Equal(t, http.StatusOK, createRec.Code)
+	var createResp APIResponse
+	require.NoError(t, json.Unmarshal(createRec.Body.Bytes(), &createResp))
+	runID := createResp.Data.(map[string]interface{})["run_id"].(string)
+
+	rec := getRun(t, server, readKey, runID)
+	require.Equal(t, http.StatusOK, rec.Code, "body: %s", rec.Body.String())
+
+	var resp APIResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	data, ok := resp.Data.(map[string]interface{})
+	require.True(t, ok)
+	assert.Equal(t, runID, data["run_id"])
+}
+
+func TestGetRun_NotFound(t *testing.T) {
+	server, _, _ := setupRunServer(t, nil)
+	apiKey := NewTestKey(t, server, []string{"steward:read-scripts"})
+
+	rec := getRun(t, server, apiKey, "nonexistent-run")
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+}
+
+// ---- POST /api/v1/runs/command ----------------------------------------------
+
+func TestPostRunScript_MissingScriptID_ReturnsBadRequest(t *testing.T) {
+	server, _, _ := setupRunServer(t, nil)
+	apiKey := NewTestKey(t, server, []string{"steward:execute-scripts"})
+
+	rec := postRunScript(t, server, apiKey, map[string]interface{}{
+		"target": "all",
+		// script_id intentionally omitted
+	})
+	assert.Equal(t, http.StatusBadRequest, rec.Code, "POST /runs/script without script_id must return 400")
+
+	var resp ErrorResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	require.NotNil(t, resp.Error)
+	assert.Equal(t, "MISSING_SCRIPT_ID", resp.Error.Code)
+}
+
+func TestPostRunCommand_TwoStewardFanout(t *testing.T) {
+	stewards := []fleet.StewardResult{
+		{ID: "cmd-dev-1", TenantID: "test-tenant"},
+		{ID: "cmd-dev-2", TenantID: "test-tenant"},
+	}
+	server, manager, queue := setupRunServer(t, stewards)
+	execKey := NewTestKey(t, server, []string{"steward:execute-scripts"})
+
+	content := base64.StdEncoding.EncodeToString([]byte("#!/bin/bash\necho hello"))
+	rec := postRunCommand(t, server, execKey, map[string]interface{}{
+		"target":  "all",
+		"content": content,
+		"shell":   "bash",
+	})
+	require.Equal(t, http.StatusOK, rec.Code, "body: %s", rec.Body.String())
+
+	var resp APIResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	runID := resp.Data.(map[string]interface{})["run_id"].(string)
+	assert.NotEmpty(t, runID)
+
+	jobs, err := manager.ListRunJobs(context.Background(), runID)
+	require.NoError(t, err)
+	require.Len(t, jobs, 2)
+
+	// Inline content must be in queue metadata
+	for _, deviceID := range []string{"cmd-dev-1", "cmd-dev-2"} {
+		queued := queue.PeekForDevice(deviceID)
+		require.Len(t, queued, 1, "%s must have one queued execution", deviceID)
+		assert.Equal(t, "#!/bin/bash\necho hello",
+			queued[0].Metadata["inline_script_content"],
+			"inline content must be in metadata for %s", deviceID)
+	}
+}
+
+func TestPostRunCommand_InvalidBase64_ReturnsBadRequest(t *testing.T) {
+	server, _, _ := setupRunServer(t, nil)
+	apiKey := NewTestKey(t, server, []string{"steward:execute-scripts"})
+
+	rec := postRunCommand(t, server, apiKey, map[string]interface{}{
+		"target":  "all",
+		"content": "not-valid-base64!!!",
+		"shell":   "bash",
+	})
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestPostRunCommand_MissingContent_ReturnsBadRequest(t *testing.T) {
+	server, _, _ := setupRunServer(t, nil)
+	apiKey := NewTestKey(t, server, []string{"steward:execute-scripts"})
+
+	rec := postRunCommand(t, server, apiKey, map[string]interface{}{
+		"target": "all",
+		"shell":  "bash",
+	})
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+// ---- Tenant isolation (IDOR prevention) -------------------------------------
+
+// TestRunEndpoints_TenantIsolation verifies that a principal in one tenant cannot
+// read or cancel runs belonging to another tenant. GET and DELETE must return 404
+// (not 403) to avoid leaking cross-tenant run existence.
+func TestRunEndpoints_TenantIsolation(t *testing.T) {
+	stewards := []fleet.StewardResult{{ID: "device-iso", TenantID: "test-tenant"}}
+	server, _, _ := setupRunServer(t, stewards)
+
+	// Create a run as the default test-tenant (tenantID = "test-tenant")
+	execKey := NewTestKey(t, server, []string{"steward:execute-scripts"})
+	createRec := postRunScript(t, server, execKey, map[string]interface{}{
+		"target":    "all",
+		"script_id": "scripts/iso-test.sh",
+	})
+	require.Equal(t, http.StatusOK, createRec.Code)
+	var createResp APIResponse
+	require.NoError(t, json.Unmarshal(createRec.Body.Bytes(), &createResp))
+	runID := createResp.Data.(map[string]interface{})["run_id"].(string)
+
+	// A second tenant's API key (different tenantID) must not be able to read the run.
+	// NewEphemeralTestKey allows specifying a tenantID.
+	otherReadKey := NewEphemeralTestKey(t, server, []string{"steward:read-scripts"}, "other-tenant", 5*60*1000000000)
+	rec := getRun(t, server, otherReadKey, runID)
+	assert.Equal(t, http.StatusNotFound, rec.Code, "cross-tenant GET must return 404")
+
+	// Cross-tenant jobs listing must also return 404.
+	rec = getRunJobs(t, server, otherReadKey, runID)
+	assert.Equal(t, http.StatusNotFound, rec.Code, "cross-tenant GET jobs must return 404")
+
+	// Cross-tenant DELETE must return 404.
+	otherExecKey := NewEphemeralTestKey(t, server, []string{"steward:execute-scripts"}, "other-tenant", 5*60*1000000000)
+	rec = deleteRun(t, server, otherExecKey, runID)
+	assert.Equal(t, http.StatusNotFound, rec.Code, "cross-tenant DELETE must return 404")
+}
+
+// ---- Service unavailable when manager not wired -----------------------------
+
+func TestRunEndpoints_ServiceUnavailable_WhenManagerNotWired(t *testing.T) {
+	server := setupTestServer(t)
+	apiKey := NewTestKey(t, server, []string{"steward:execute-scripts", "steward:read-scripts"})
+
+	for _, tc := range []struct {
+		method string
+		path   string
+		body   interface{}
+	}{
+		{"POST", "/api/v1/runs/script", map[string]interface{}{"script_id": "s.sh"}},
+		{"POST", "/api/v1/runs/command", map[string]interface{}{"content": "X", "shell": "bash"}},
+		{"GET", "/api/v1/runs/some-id", nil},
+		{"GET", "/api/v1/runs/some-id/jobs", nil},
+		{"DELETE", "/api/v1/runs/some-id", nil},
+	} {
+		t.Run(tc.method+" "+tc.path, func(t *testing.T) {
+			var body *bytes.Reader
+			if tc.body != nil {
+				b, err := json.Marshal(tc.body)
+				require.NoError(t, err)
+				body = bytes.NewReader(b)
+			} else {
+				body = bytes.NewReader(nil)
+			}
+			req := httptest.NewRequest(tc.method, tc.path, body)
+			req.Header.Set("X-API-Key", apiKey)
+			req.Header.Set("Content-Type", "application/json")
+			rec := httptest.NewRecorder()
+			server.router.ServeHTTP(rec, req)
+			assert.Equal(t, http.StatusServiceUnavailable, rec.Code,
+				"%s %s must return 503 when run manager is not wired", tc.method, tc.path)
+		})
+	}
+}

--- a/features/controller/api/server.go
+++ b/features/controller/api/server.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cfgis/cfgms/features/controller/fleet"
 	"github.com/cfgis/cfgms/features/controller/health"
 	"github.com/cfgis/cfgms/features/controller/push"
+	controllerrun "github.com/cfgis/cfgms/features/controller/run"
 	"github.com/cfgis/cfgms/features/controller/service"
 	"github.com/cfgis/cfgms/features/modules/script"
 	"github.com/cfgis/cfgms/features/monitoring"
@@ -84,6 +85,8 @@ type Server struct {
 	configSourceSecretStore secretsif.SecretStore          // Issue #1396: secrets for config source validator
 	configSourceRateLimits  sync.Map                       // Issue #1396: per-tenant rate-limit counters
 	registrationQueue       sync.Map                       // Issue #1568: quarantined stewards awaiting approval
+	runManager              *controllerrun.Manager         // Issue #1673: run/job/execution model
+	runExecutionQueue       *script.ExecutionQueue         // Issue #1673: queue for ad-hoc run synthesis
 	stopCleanup             chan struct{}                  // signals startAPIKeyCleanup to exit
 	cleanupDone             chan struct{}                  // closed when cleanup goroutine exits
 	closeOnce               sync.Once                      // idempotent Close
@@ -418,6 +421,15 @@ func (s *Server) setupRouter() {
 	tenants.Handle("/{id}/config-source/test",
 		s.requirePermission("tenant", "manage")(http.HandlerFunc(s.handleConfigSourceTest))).Methods("POST")
 
+	// Ad-hoc run endpoints (Issue #1673). Always registered — returns 503 when
+	// run manager is not wired (transport-disabled deployments).
+	runs := api.PathPrefix("/runs").Subrouter()
+	runs.Handle("/script", s.requirePermission("steward", "execute-scripts")(http.HandlerFunc(s.handlePostRunScript))).Methods("POST")
+	runs.Handle("/command", s.requirePermission("steward", "execute-scripts")(http.HandlerFunc(s.handlePostRunCommand))).Methods("POST")
+	runs.Handle("/{run_id}", s.requirePermission("steward", "read-scripts")(http.HandlerFunc(s.handleGetRun))).Methods("GET")
+	runs.Handle("/{run_id}/jobs", s.requirePermission("steward", "read-scripts")(http.HandlerFunc(s.handleGetRunJobs))).Methods("GET")
+	runs.Handle("/{run_id}", s.requirePermission("steward", "execute-scripts")(http.HandlerFunc(s.handleDeleteRun))).Methods("DELETE")
+
 	// Git-sync webhook is registered lazily by SetGitSyncWebhookHandler (Issue #666).
 	// No route is pre-registered here; the endpoint only exists when a git-sync
 	// handler is explicitly wired in after server creation.
@@ -694,6 +706,15 @@ func (s *Server) SetGitSyncWebhookHandler(h http.Handler) {
 		s.router.Handle("/api/v1/webhooks/git-push", h).Methods("POST")
 		s.logger.Info("git-sync webhook endpoint registered at /api/v1/webhooks/git-push")
 	}
+}
+
+// SetRunManager wires the run manager and execution queue for ad-hoc run endpoints
+// (Issue #1673). Call this after New() returns but before Start() is called.
+func (s *Server) SetRunManager(m *controllerrun.Manager, queue *script.ExecutionQueue) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.runManager = m
+	s.runExecutionQueue = queue
 }
 
 // getHTTPListenAddr determines the HTTP listen address.

--- a/features/controller/dispatcher/dispatcher.go
+++ b/features/controller/dispatcher/dispatcher.go
@@ -49,6 +49,10 @@ type Dispatcher struct {
 	deviceLocks  sync.Map
 	pollInterval time.Duration
 	logger       logging.Logger
+	// runSink, when set, receives job-completion notifications so the run/job
+	// tracking model can advance run status. Set once via SetRunCompletionSink
+	// before Start; nil when no run manager is wired.
+	runSink RunCompletionSink
 
 	ctx    context.Context
 	cancel context.CancelFunc
@@ -58,6 +62,14 @@ type Dispatcher struct {
 	// to prevent a race between external callbacks and wg.Wait in Stop.
 	mu      sync.Mutex
 	stopped bool
+}
+
+// RunCompletionSink is notified when a dispatched execution reaches a terminal
+// state so the run/job tracking model can advance run status (Issue #1673).
+// It is implemented by *run.Manager. The dispatcher depends on this narrow
+// interface rather than importing the run package directly.
+type RunCompletionSink interface {
+	RecordJobCompletion(ctx context.Context, runID, jobID, executionID string, failed bool) error
 }
 
 // Config holds Dispatcher configuration.
@@ -103,6 +115,13 @@ func New(cfg *Config) (*Dispatcher, error) {
 		ctx:          ctx,
 		cancel:       cancel,
 	}, nil
+}
+
+// SetRunCompletionSink wires the run/job tracking sink that receives a
+// notification when a dispatched execution completes. It must be called before
+// Start so the field is published before the event subscription begins.
+func (d *Dispatcher) SetRunCompletionSink(sink RunCompletionSink) {
+	d.runSink = sink
 }
 
 // Start begins the polling loop and subscribes to EventScriptCompleted events.
@@ -399,6 +418,18 @@ func (d *Dispatcher) handleCompletionEvent(ctx context.Context, event *controlpl
 		}
 	}
 
+	// Capture run-tracking metadata BEFORE AcknowledgeCompletion moves the entry
+	// out of the active queue. The run synthesis layer threads workflow_run_id
+	// and job_id through QueuedExecution.Metadata (Issue #1673).
+	var runID, jobID string
+	for _, qe := range d.queue.PeekForDevice(deviceID) {
+		if qe.ExecutionID == executionID && qe.Metadata != nil {
+			runID, _ = qe.Metadata["workflow_run_id"].(string)
+			jobID, _ = qe.Metadata["job_id"].(string)
+			break
+		}
+	}
+
 	if err := d.queue.AcknowledgeCompletion(executionID, deviceID, state, result); err != nil {
 		d.logger.Error("Failed to acknowledge completion",
 			"device_id", logging.SanitizeLogValue(deviceID),
@@ -410,6 +441,19 @@ func (d *Dispatcher) handleCompletionEvent(ctx context.Context, event *controlpl
 			"device_id", logging.SanitizeLogValue(deviceID),
 			"execution_id", executionID,
 			"state", state)
+
+		// Advance run/job tracking so the run can reach a terminal status once
+		// every job finishes (Issue #1673, AC3). Best-effort: a tracking failure
+		// must not stall the per-device dispatch loop.
+		if d.runSink != nil && runID != "" && jobID != "" {
+			if err := d.runSink.RecordJobCompletion(ctx, runID, jobID, executionID, state == script.QueueStateFailed); err != nil {
+				d.logger.Error("Failed to record job completion in run store",
+					"device_id", logging.SanitizeLogValue(deviceID),
+					"execution_id", logging.SanitizeLogValue(executionID),
+					"run_id", logging.SanitizeLogValue(runID),
+					"error", err)
+			}
+		}
 	}
 
 	// Release the per-device lock so the next queued execution can be dispatched.

--- a/features/controller/dispatcher/dispatcher_test.go
+++ b/features/controller/dispatcher/dispatcher_test.go
@@ -4,6 +4,7 @@ package dispatcher
 
 import (
 	"context"
+	"database/sql"
 	"errors"
 	"fmt"
 	"strings"
@@ -14,10 +15,13 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/cfgis/cfgms/features/controller/run"
 	script "github.com/cfgis/cfgms/features/modules/script"
 	cpinterfaces "github.com/cfgis/cfgms/pkg/controlplane/interfaces"
 	controlplaneTypes "github.com/cfgis/cfgms/pkg/controlplane/types"
 	"github.com/cfgis/cfgms/pkg/logging"
+
+	_ "modernc.org/sqlite"
 )
 
 // ----------------------------------------------------------------------------
@@ -562,6 +566,165 @@ func TestDispatcher_SendCommandErrorReleasesLock(t *testing.T) {
 		return cp.sentCount() >= 1
 	}, 2*time.Second, 10*time.Millisecond,
 		"dispatch should succeed after send error cleared and lock released")
+}
+
+// runTrackedExec builds a QueuedExecution carrying the workflow_run_id / job_id
+// metadata that the run synthesis layer threads through for dispatch tracking.
+func runTrackedExec(executionID, scriptRef, runID, jobID string) *script.QueuedExecution {
+	qe := queuedExec(executionID, scriptRef)
+	qe.Metadata = map[string]interface{}{
+		"workflow_run_id": runID,
+		"job_id":          jobID,
+	}
+	return qe
+}
+
+// TestDispatcher_CompletionAdvancesRunStatus verifies AC3: when every job of a
+// run reports completion, the dispatcher drives the run record to a terminal
+// status via the wired RunCompletionSink.
+func TestDispatcher_CompletionAdvancesRunStatus(t *testing.T) {
+	store := run.NewRunStoreSQL(mustOpenMemDB(t))
+	require.NoError(t, store.Init(context.Background()))
+	manager := run.NewManager(store, nil)
+
+	const runID = "run-disp-1"
+	require.NoError(t, store.CreateRun(&run.RunRecord{
+		RunID:     runID,
+		TenantID:  "tenant-abc",
+		CreatedAt: time.Now().UTC(),
+		Status:    run.RunStatusRunning,
+		JobCount:  2,
+	}))
+	require.NoError(t, store.CreateJob(&run.JobRecord{
+		JobID: "job-1", RunID: runID, DeviceID: "device-1",
+		ExecutionID: "exec-001", Status: run.JobStatusPending, CreatedAt: time.Now().UTC(),
+	}))
+	require.NoError(t, store.CreateJob(&run.JobRecord{
+		JobID: "job-2", RunID: runID, DeviceID: "device-2",
+		ExecutionID: "exec-002", Status: run.JobStatusPending, CreatedAt: time.Now().UTC(),
+	}))
+
+	cp := &testControlPlane{}
+	q := newTestQueue(t, nil)
+	d := newTestDispatcher(t, q, cp)
+	d.SetRunCompletionSink(manager)
+
+	require.NoError(t, d.Start(context.Background()))
+	t.Cleanup(d.Stop)
+
+	require.NoError(t, q.QueueExecution("device-1", runTrackedExec("exec-001", "script-abc", runID, "job-1")))
+	require.NoError(t, q.QueueExecution("device-2", runTrackedExec("exec-002", "script-abc", runID, "job-2")))
+
+	d.OnHeartbeat("device-1")
+	d.OnHeartbeat("device-2")
+	require.Eventually(t, func() bool {
+		return cp.sentCount() >= 2
+	}, 2*time.Second, 10*time.Millisecond, "both executions should be dispatched")
+
+	// First job completes — run must remain running.
+	require.NoError(t, cp.injectCompletion(context.Background(), "device-1", "exec-001", 0))
+	require.Eventually(t, func() bool {
+		r, err := manager.GetRun(context.Background(), runID)
+		return err == nil && r.CompletedJobs == 1
+	}, 2*time.Second, 10*time.Millisecond, "first job completion should be recorded")
+
+	r, err := manager.GetRun(context.Background(), runID)
+	require.NoError(t, err)
+	assert.Equal(t, run.RunStatusRunning, r.Status, "run must stay running while a job is in flight")
+
+	// Second (final) job completes — run must transition to completed.
+	require.NoError(t, cp.injectCompletion(context.Background(), "device-2", "exec-002", 0))
+	require.Eventually(t, func() bool {
+		r, err := manager.GetRun(context.Background(), runID)
+		return err == nil && r.Status == run.RunStatusCompleted
+	}, 2*time.Second, 10*time.Millisecond, "run must reach completed once all jobs are terminal")
+
+	r, err = manager.GetRun(context.Background(), runID)
+	require.NoError(t, err)
+	assert.Equal(t, 2, r.CompletedJobs)
+	assert.Equal(t, 0, r.FailedJobs)
+
+	jobs, err := manager.ListRunJobs(context.Background(), runID)
+	require.NoError(t, err)
+	require.Len(t, jobs, 2)
+	for _, j := range jobs {
+		assert.Equal(t, run.JobStatusCompleted, j.Status, "job %s must be completed", j.JobID)
+	}
+}
+
+// TestDispatcher_CompletionMarksRunFailed verifies that a non-zero exit code
+// from a steward drives the run record to the failed terminal status.
+func TestDispatcher_CompletionMarksRunFailed(t *testing.T) {
+	store := run.NewRunStoreSQL(mustOpenMemDB(t))
+	require.NoError(t, store.Init(context.Background()))
+	manager := run.NewManager(store, nil)
+
+	const runID = "run-disp-2"
+	require.NoError(t, store.CreateRun(&run.RunRecord{
+		RunID: runID, TenantID: "tenant-abc", CreatedAt: time.Now().UTC(),
+		Status: run.RunStatusRunning, JobCount: 1,
+	}))
+	require.NoError(t, store.CreateJob(&run.JobRecord{
+		JobID: "job-fail", RunID: runID, DeviceID: "device-1",
+		ExecutionID: "exec-fail", Status: run.JobStatusPending, CreatedAt: time.Now().UTC(),
+	}))
+
+	cp := &testControlPlane{}
+	q := newTestQueue(t, nil)
+	d := newTestDispatcher(t, q, cp)
+	d.SetRunCompletionSink(manager)
+
+	require.NoError(t, d.Start(context.Background()))
+	t.Cleanup(d.Stop)
+
+	require.NoError(t, q.QueueExecution("device-1", runTrackedExec("exec-fail", "script-abc", runID, "job-fail")))
+	d.OnHeartbeat("device-1")
+	require.Eventually(t, func() bool {
+		return cp.sentCount() >= 1
+	}, 2*time.Second, 10*time.Millisecond)
+
+	// Steward reports a non-zero exit code.
+	require.NoError(t, cp.injectCompletion(context.Background(), "device-1", "exec-fail", 1))
+	require.Eventually(t, func() bool {
+		r, err := manager.GetRun(context.Background(), runID)
+		return err == nil && r.Status == run.RunStatusFailed
+	}, 2*time.Second, 10*time.Millisecond, "run must reach failed when a job fails")
+
+	r, err := manager.GetRun(context.Background(), runID)
+	require.NoError(t, err)
+	assert.Equal(t, 1, r.FailedJobs)
+	assert.Equal(t, 0, r.CompletedJobs)
+}
+
+// TestDispatcher_CompletionWithoutSinkIsSafe verifies that completion handling
+// does not panic or error when no RunCompletionSink is wired.
+func TestDispatcher_CompletionWithoutSinkIsSafe(t *testing.T) {
+	cp := &testControlPlane{}
+	q := newTestQueue(t, nil)
+	d := newTestDispatcher(t, q, cp) // no SetRunCompletionSink
+
+	require.NoError(t, d.Start(context.Background()))
+	t.Cleanup(d.Stop)
+
+	require.NoError(t, q.QueueExecution("device-1", runTrackedExec("exec-001", "script-abc", "run-x", "job-x")))
+	d.OnHeartbeat("device-1")
+	require.Eventually(t, func() bool {
+		return cp.sentCount() >= 1
+	}, 2*time.Second, 10*time.Millisecond)
+
+	require.NoError(t, cp.injectCompletion(context.Background(), "device-1", "exec-001", 0))
+	require.Eventually(t, func() bool {
+		return q.GetQueueDepth("device-1") == 0
+	}, 2*time.Second, 10*time.Millisecond, "completion must be acknowledged even without a run sink")
+}
+
+// mustOpenMemDB opens an in-memory SQLite database closed via t.Cleanup.
+func mustOpenMemDB(t *testing.T) *sql.DB {
+	t.Helper()
+	db, err := sql.Open("sqlite", ":memory:")
+	require.NoError(t, err, "open in-memory sqlite")
+	t.Cleanup(func() { _ = db.Close() })
+	return db
 }
 
 // TestDispatcher_New_ValidationErrors verifies that New rejects nil config fields.

--- a/features/controller/run/run.go
+++ b/features/controller/run/run.go
@@ -370,6 +370,69 @@ func (m *Manager) CancelRun(_ context.Context, runID string) error {
 	return m.store.UpdateRunStatus(runID, RunStatusCancelled)
 }
 
+// RecordJobCompletion records a terminal state for one job and advances the
+// run's status when every job has finished. It is invoked by the dispatcher
+// when a steward reports an execution complete (Issue #1673, AC3).
+//
+// The job is moved to completed or failed. Job states are then aggregated: once
+// every job in the run is terminal the run transitions to completed, or to
+// failed if any job failed. A run that is already terminal (e.g. cancelled) is
+// left untouched so a late completion callback cannot resurrect it.
+func (m *Manager) RecordJobCompletion(_ context.Context, runID, jobID, executionID string, failed bool) error {
+	jobStatus := JobStatusCompleted
+	if failed {
+		jobStatus = JobStatusFailed
+	}
+	if err := m.store.UpdateJobStatus(jobID, jobStatus, executionID); err != nil {
+		return fmt.Errorf("record job completion: update job %s: %w", jobID, err)
+	}
+
+	jobs, err := m.store.ListRunJobs(runID)
+	if err != nil {
+		return fmt.Errorf("record job completion: list jobs for run %s: %w", runID, err)
+	}
+
+	completed, failedCount := 0, 0
+	allTerminal := true
+	for _, j := range jobs {
+		switch j.Status {
+		case JobStatusCompleted:
+			completed++
+		case JobStatusFailed:
+			failedCount++
+		case JobStatusCancelled:
+			// Terminal, but counts toward neither completed nor failed.
+		default:
+			allTerminal = false
+		}
+	}
+
+	if err := m.store.UpdateRunCounts(runID, completed, failedCount); err != nil {
+		return fmt.Errorf("record job completion: update counts for run %s: %w", runID, err)
+	}
+
+	if !allTerminal {
+		return nil
+	}
+
+	run, err := m.store.GetRun(runID)
+	if err != nil {
+		return fmt.Errorf("record job completion: get run %s: %w", runID, err)
+	}
+	if run.Status.IsTerminal() {
+		return nil
+	}
+
+	finalStatus := RunStatusCompleted
+	if failedCount > 0 {
+		finalStatus = RunStatusFailed
+	}
+	if err := m.store.UpdateRunStatus(runID, finalStatus); err != nil {
+		return fmt.Errorf("record job completion: update run status for run %s: %w", runID, err)
+	}
+	return nil
+}
+
 // Close releases resources held by the Manager's store. If the store does not
 // own a closable resource, Close is a no-op.
 func (m *Manager) Close() error {

--- a/features/controller/run/run.go
+++ b/features/controller/run/run.go
@@ -1,0 +1,361 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+package run
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/cfgis/cfgms/features/controller/fleet"
+	scriptmodule "github.com/cfgis/cfgms/features/modules/script"
+	_ "modernc.org/sqlite"
+)
+
+// ErrNotFound is returned when a run or job record does not exist.
+var ErrNotFound = errors.New("run not found")
+
+// ErrAlreadyTerminal is returned when an operation targets a run that has already reached a terminal state.
+var ErrAlreadyTerminal = errors.New("run is already in a terminal state")
+
+// RunStatus represents the lifecycle state of a run.
+type RunStatus string
+
+const (
+	RunStatusPending   RunStatus = "pending"
+	RunStatusRunning   RunStatus = "running"
+	RunStatusCompleted RunStatus = "completed"
+	RunStatusFailed    RunStatus = "failed"
+	RunStatusCancelled RunStatus = "cancelled"
+)
+
+// IsTerminal reports whether the status is a terminal (non-progressing) state.
+func (s RunStatus) IsTerminal() bool {
+	return s == RunStatusCompleted || s == RunStatusFailed || s == RunStatusCancelled
+}
+
+// JobStatus represents the lifecycle state of a single job within a run.
+type JobStatus string
+
+const (
+	JobStatusPending   JobStatus = "pending"
+	JobStatusRunning   JobStatus = "running"
+	JobStatusCompleted JobStatus = "completed"
+	JobStatusFailed    JobStatus = "failed"
+	JobStatusCancelled JobStatus = "cancelled"
+)
+
+// IsTerminal reports whether the job status is a terminal state.
+func (s JobStatus) IsTerminal() bool {
+	return s == JobStatusCompleted || s == JobStatusFailed || s == JobStatusCancelled
+}
+
+// RunRecord is the durable tracking record for a multi-steward script dispatch.
+// One RunRecord fans out to one JobRecord per matched steward.
+type RunRecord struct {
+	RunID         string                 `json:"run_id"`
+	TenantID      string                 `json:"tenant_id"`
+	CreatedBy     string                 `json:"created_by,omitempty"`
+	CreatedAt     time.Time              `json:"created_at"`
+	Status        RunStatus              `json:"status"`
+	Filter        fleet.Filter           `json:"filter,omitempty"`
+	ScriptRef     string                 `json:"script_ref,omitempty"`
+	InlineContent string                 `json:"inline_content,omitempty"`
+	Shell         scriptmodule.ShellType `json:"shell,omitempty"`
+	JobCount      int                    `json:"job_count"`
+	CompletedJobs int                    `json:"completed_jobs"`
+	FailedJobs    int                    `json:"failed_jobs"`
+}
+
+// JobRecord tracks the dispatch state for one steward within a run.
+type JobRecord struct {
+	JobID       string     `json:"job_id"`
+	RunID       string     `json:"run_id"`
+	DeviceID    string     `json:"device_id"`
+	ExecutionID string     `json:"execution_id,omitempty"`
+	Status      JobStatus  `json:"status"`
+	CreatedAt   time.Time  `json:"created_at"`
+	CompletedAt *time.Time `json:"completed_at,omitempty"`
+}
+
+// RunStore is the durable storage interface for run and job records.
+type RunStore interface {
+	CreateRun(*RunRecord) error
+	CreateJob(*JobRecord) error
+	GetRun(runID string) (*RunRecord, error)
+	ListRunJobs(runID string) ([]*JobRecord, error)
+	UpdateJobStatus(jobID string, status JobStatus, executionID string) error
+	UpdateRunStatus(runID string, status RunStatus) error
+	UpdateRunCounts(runID string, completedJobs, failedJobs int) error
+}
+
+// RunStoreSQL is the SQLite-backed implementation of RunStore.
+// Call Init before any other method — it creates tables and indexes idempotently.
+type RunStoreSQL struct {
+	db *sql.DB
+}
+
+// NewRunStoreSQL creates a RunStoreSQL that uses db for persistence.
+// The caller must call Init before any other method.
+func NewRunStoreSQL(db *sql.DB) *RunStoreSQL {
+	return &RunStoreSQL{db: db}
+}
+
+// Init creates the script_runs and script_run_jobs tables and their indexes if
+// they do not already exist. Safe to call multiple times (idempotent).
+func (s *RunStoreSQL) Init(_ context.Context) error {
+	const createRuns = `
+CREATE TABLE IF NOT EXISTS script_runs (
+    run_id         TEXT NOT NULL PRIMARY KEY,
+    tenant_id      TEXT NOT NULL,
+    created_by     TEXT,
+    created_at     DATETIME NOT NULL,
+    status         TEXT NOT NULL,
+    filter_json    TEXT,
+    script_ref     TEXT,
+    inline_content TEXT,
+    shell          TEXT,
+    job_count      INTEGER DEFAULT 0,
+    completed_jobs INTEGER DEFAULT 0,
+    failed_jobs    INTEGER DEFAULT 0
+);`
+	const createJobs = `
+CREATE TABLE IF NOT EXISTS script_run_jobs (
+    job_id        TEXT NOT NULL PRIMARY KEY,
+    run_id        TEXT NOT NULL,
+    device_id     TEXT NOT NULL,
+    execution_id  TEXT,
+    status        TEXT NOT NULL,
+    created_at    DATETIME NOT NULL,
+    completed_at  DATETIME
+);`
+	const createJobsIndex = `
+CREATE INDEX IF NOT EXISTS idx_srj_run_id ON script_run_jobs(run_id);`
+
+	for _, stmt := range []string{createRuns, createJobs, createJobsIndex} {
+		if _, err := s.db.Exec(stmt); err != nil {
+			return fmt.Errorf("run store init: %w", err)
+		}
+	}
+	return nil
+}
+
+// CreateRun persists a new run record. RunID must be unique.
+func (s *RunStoreSQL) CreateRun(r *RunRecord) error {
+	filterJSON, err := json.Marshal(r.Filter)
+	if err != nil {
+		return fmt.Errorf("run store create run: marshal filter: %w", err)
+	}
+	const q = `
+INSERT INTO script_runs
+    (run_id, tenant_id, created_by, created_at, status, filter_json,
+     script_ref, inline_content, shell, job_count, completed_jobs, failed_jobs)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+	_, err = s.db.Exec(q,
+		r.RunID, r.TenantID,
+		nullableStr(r.CreatedBy),
+		r.CreatedAt, string(r.Status), string(filterJSON),
+		nullableStr(r.ScriptRef),
+		nullableStr(r.InlineContent),
+		nullableStr(string(r.Shell)),
+		r.JobCount, r.CompletedJobs, r.FailedJobs,
+	)
+	return err
+}
+
+// CreateJob persists a new job record.
+func (s *RunStoreSQL) CreateJob(j *JobRecord) error {
+	const q = `
+INSERT INTO script_run_jobs
+    (job_id, run_id, device_id, execution_id, status, created_at, completed_at)
+VALUES (?, ?, ?, ?, ?, ?, ?)`
+	var completedAt interface{}
+	if j.CompletedAt != nil {
+		completedAt = *j.CompletedAt
+	}
+	_, err := s.db.Exec(q,
+		j.JobID, j.RunID, j.DeviceID,
+		nullableStr(j.ExecutionID),
+		string(j.Status), j.CreatedAt, completedAt,
+	)
+	return err
+}
+
+// GetRun returns the run record for runID, or ErrNotFound if not found.
+func (s *RunStoreSQL) GetRun(runID string) (*RunRecord, error) {
+	const q = `
+SELECT run_id, tenant_id, created_by, created_at, status, filter_json,
+       script_ref, inline_content, shell, job_count, completed_jobs, failed_jobs
+FROM script_runs
+WHERE run_id = ?`
+
+	row := s.db.QueryRow(q, runID)
+	r := &RunRecord{}
+	var (
+		createdBy     sql.NullString
+		filterJSON    sql.NullString
+		scriptRef     sql.NullString
+		inlineContent sql.NullString
+		shell         sql.NullString
+	)
+	err := row.Scan(
+		&r.RunID, &r.TenantID, &createdBy, &r.CreatedAt,
+		(*string)(&r.Status), &filterJSON,
+		&scriptRef, &inlineContent, &shell,
+		&r.JobCount, &r.CompletedJobs, &r.FailedJobs,
+	)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, ErrNotFound
+		}
+		return nil, fmt.Errorf("run store get run: %w", err)
+	}
+	r.CreatedBy = createdBy.String
+	r.ScriptRef = scriptRef.String
+	r.InlineContent = inlineContent.String
+	r.Shell = scriptmodule.ShellType(shell.String)
+	if filterJSON.Valid && filterJSON.String != "" {
+		_ = json.Unmarshal([]byte(filterJSON.String), &r.Filter)
+	}
+	return r, nil
+}
+
+// ListRunJobs returns all job records for runID ordered by created_at ASC.
+func (s *RunStoreSQL) ListRunJobs(runID string) ([]*JobRecord, error) {
+	const q = `
+SELECT job_id, run_id, device_id, execution_id, status, created_at, completed_at
+FROM script_run_jobs
+WHERE run_id = ?
+ORDER BY created_at ASC`
+
+	rows, err := s.db.Query(q, runID)
+	if err != nil {
+		return nil, fmt.Errorf("run store list jobs: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var jobs []*JobRecord
+	for rows.Next() {
+		j := &JobRecord{}
+		var executionID sql.NullString
+		var completedAt sql.NullTime
+		if err := rows.Scan(
+			&j.JobID, &j.RunID, &j.DeviceID, &executionID,
+			(*string)(&j.Status), &j.CreatedAt, &completedAt,
+		); err != nil {
+			return nil, fmt.Errorf("run store scan job: %w", err)
+		}
+		j.ExecutionID = executionID.String
+		if completedAt.Valid {
+			t := completedAt.Time
+			j.CompletedAt = &t
+		}
+		jobs = append(jobs, j)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("run store list jobs rows: %w", err)
+	}
+	return jobs, nil
+}
+
+// UpdateJobStatus sets the status and optionally the executionID for a job.
+// When status is terminal, completed_at is set to the current UTC time.
+func (s *RunStoreSQL) UpdateJobStatus(jobID string, status JobStatus, executionID string) error {
+	var completedAt interface{}
+	if status.IsTerminal() {
+		completedAt = time.Now().UTC()
+	}
+	// Update execution_id only when a non-empty value is supplied.
+	const q = `
+UPDATE script_run_jobs
+SET status       = ?,
+    execution_id = CASE WHEN ? != '' THEN ? ELSE execution_id END,
+    completed_at = COALESCE(?, completed_at)
+WHERE job_id = ?`
+	_, err := s.db.Exec(q, string(status), executionID, executionID, completedAt, jobID)
+	return err
+}
+
+// UpdateRunStatus updates the top-level status for a run.
+func (s *RunStoreSQL) UpdateRunStatus(runID string, status RunStatus) error {
+	const q = `UPDATE script_runs SET status = ? WHERE run_id = ?`
+	_, err := s.db.Exec(q, string(status), runID)
+	return err
+}
+
+// UpdateRunCounts updates the completed and failed job counts for a run.
+func (s *RunStoreSQL) UpdateRunCounts(runID string, completedJobs, failedJobs int) error {
+	const q = `UPDATE script_runs SET completed_jobs = ?, failed_jobs = ? WHERE run_id = ?`
+	_, err := s.db.Exec(q, completedJobs, failedJobs, runID)
+	return err
+}
+
+func nullableStr(s string) sql.NullString {
+	return sql.NullString{String: s, Valid: s != ""}
+}
+
+// Manager coordinates the lifecycle of run records: retrieval and cancellation.
+// Run creation is performed by the synthesis functions in synthesis.go.
+type Manager struct {
+	store          RunStore
+	executionQueue *scriptmodule.ExecutionQueue
+}
+
+// NewManager creates a Manager backed by store and executionQueue.
+// executionQueue may be nil; CancelRun will then skip queue-level cancellation.
+func NewManager(store RunStore, executionQueue *scriptmodule.ExecutionQueue) *Manager {
+	return &Manager{store: store, executionQueue: executionQueue}
+}
+
+// GetRun returns the run record for runID.
+// Returns ErrNotFound when no run exists with that ID.
+func (m *Manager) GetRun(_ context.Context, runID string) (*RunRecord, error) {
+	return m.store.GetRun(runID)
+}
+
+// ListRunJobs returns all job records for the given run.
+// Returns ErrNotFound when the run does not exist.
+func (m *Manager) ListRunJobs(_ context.Context, runID string) ([]*JobRecord, error) {
+	if _, err := m.store.GetRun(runID); err != nil {
+		return nil, err
+	}
+	return m.store.ListRunJobs(runID)
+}
+
+// CancelRun transitions a non-terminal run and all its non-terminal jobs to
+// cancelled. It also calls CancelExecution on the queue for each job that has
+// a non-empty ExecutionID.
+//
+// Returns ErrNotFound if the run does not exist.
+// Returns ErrAlreadyTerminal if the run is already completed, failed, or cancelled.
+func (m *Manager) CancelRun(_ context.Context, runID string) error {
+	run, err := m.store.GetRun(runID)
+	if err != nil {
+		return err
+	}
+	if run.Status.IsTerminal() {
+		return ErrAlreadyTerminal
+	}
+
+	jobs, err := m.store.ListRunJobs(runID)
+	if err != nil {
+		return fmt.Errorf("cancel run: list jobs: %w", err)
+	}
+
+	for _, job := range jobs {
+		if job.Status.IsTerminal() {
+			continue
+		}
+		if m.executionQueue != nil && job.ExecutionID != "" {
+			_ = m.executionQueue.CancelExecution(job.DeviceID, job.ExecutionID)
+		}
+		if updateErr := m.store.UpdateJobStatus(job.JobID, JobStatusCancelled, ""); updateErr != nil {
+			return fmt.Errorf("cancel run: update job %s: %w", job.JobID, updateErr)
+		}
+	}
+
+	return m.store.UpdateRunStatus(runID, RunStatusCancelled)
+}

--- a/features/controller/run/run.go
+++ b/features/controller/run/run.go
@@ -293,6 +293,16 @@ func (s *RunStoreSQL) UpdateRunCounts(runID string, completedJobs, failedJobs in
 	return err
 }
 
+// Close releases the underlying database connection. After Close, the store
+// must not be used. Safe to call on a store backed by a shared *sql.DB only
+// when that connection is dedicated to the run store.
+func (s *RunStoreSQL) Close() error {
+	if s.db == nil {
+		return nil
+	}
+	return s.db.Close()
+}
+
 func nullableStr(s string) sql.NullString {
 	return sql.NullString{String: s, Valid: s != ""}
 }
@@ -358,4 +368,13 @@ func (m *Manager) CancelRun(_ context.Context, runID string) error {
 	}
 
 	return m.store.UpdateRunStatus(runID, RunStatusCancelled)
+}
+
+// Close releases resources held by the Manager's store. If the store does not
+// own a closable resource, Close is a no-op.
+func (m *Manager) Close() error {
+	if closer, ok := m.store.(interface{ Close() error }); ok {
+		return closer.Close()
+	}
+	return nil
 }

--- a/features/controller/run/run_test.go
+++ b/features/controller/run/run_test.go
@@ -1,0 +1,390 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+package run
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cfgis/cfgms/features/controller/fleet"
+	scriptmodule "github.com/cfgis/cfgms/features/modules/script"
+	_ "modernc.org/sqlite"
+)
+
+// newTestRunStore opens an in-memory SQLite database, initializes the RunStoreSQL
+// schema, and returns the store. The database is closed automatically via t.Cleanup.
+func newTestRunStore(t *testing.T) *RunStoreSQL {
+	t.Helper()
+
+	db, err := sql.Open("sqlite", ":memory:")
+	require.NoError(t, err, "open in-memory sqlite")
+	t.Cleanup(func() { _ = db.Close() })
+
+	store := NewRunStoreSQL(db)
+	require.NoError(t, store.Init(context.Background()), "Init must succeed")
+	return store
+}
+
+// sampleRun returns a populated RunRecord suitable for tests.
+func sampleRun(runID, tenantID string) *RunRecord {
+	return &RunRecord{
+		RunID:     runID,
+		TenantID:  tenantID,
+		CreatedBy: "user-1",
+		CreatedAt: time.Now().UTC().Truncate(time.Second),
+		Status:    RunStatusPending,
+		Filter:    fleet.Filter{TenantID: tenantID, OS: "linux"},
+		ScriptRef: "scripts/deploy.sh",
+		Shell:     scriptmodule.ShellBash,
+		JobCount:  2,
+	}
+}
+
+// sampleJob returns a populated JobRecord suitable for tests.
+func sampleJob(jobID, runID, deviceID string) *JobRecord {
+	return &JobRecord{
+		JobID:     jobID,
+		RunID:     runID,
+		DeviceID:  deviceID,
+		Status:    JobStatusPending,
+		CreatedAt: time.Now().UTC().Truncate(time.Second),
+	}
+}
+
+// ---- RunStoreSQL tests -------------------------------------------------------
+
+func TestRunStoreSQL_Init_Idempotent(t *testing.T) {
+	db, err := sql.Open("sqlite", ":memory:")
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	store := NewRunStoreSQL(db)
+
+	require.NoError(t, store.Init(context.Background()), "first Init must succeed")
+	require.NoError(t, store.Init(context.Background()), "second Init must succeed (idempotent)")
+
+	// Tables must exist
+	var count int
+	require.NoError(t, db.QueryRow("SELECT COUNT(*) FROM script_runs").Scan(&count))
+	require.NoError(t, db.QueryRow("SELECT COUNT(*) FROM script_run_jobs").Scan(&count))
+
+	// Index must exist
+	rows, err := db.Query(`SELECT name FROM sqlite_master WHERE type='index' AND tbl_name='script_run_jobs'`)
+	require.NoError(t, err)
+	defer func() { _ = rows.Close() }()
+
+	var indexFound bool
+	for rows.Next() {
+		var name string
+		require.NoError(t, rows.Scan(&name))
+		if name == "idx_srj_run_id" {
+			indexFound = true
+		}
+	}
+	require.NoError(t, rows.Err())
+	assert.True(t, indexFound, "idx_srj_run_id index must exist")
+}
+
+func TestRunStoreSQL_CreateRun_GetRun(t *testing.T) {
+	store := newTestRunStore(t)
+
+	run := sampleRun("run-001", "tenant-abc")
+	require.NoError(t, store.CreateRun(run))
+
+	got, err := store.GetRun("run-001")
+	require.NoError(t, err)
+
+	assert.Equal(t, run.RunID, got.RunID)
+	assert.Equal(t, run.TenantID, got.TenantID)
+	assert.Equal(t, run.CreatedBy, got.CreatedBy)
+	assert.Equal(t, run.Status, got.Status)
+	assert.Equal(t, run.ScriptRef, got.ScriptRef)
+	assert.Equal(t, run.Shell, got.Shell)
+	assert.Equal(t, run.JobCount, got.JobCount)
+	assert.Equal(t, run.Filter.OS, got.Filter.OS)
+	assert.Equal(t, run.Filter.TenantID, got.Filter.TenantID)
+}
+
+func TestRunStoreSQL_GetRun_NotFound(t *testing.T) {
+	store := newTestRunStore(t)
+
+	_, err := store.GetRun("nonexistent")
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrNotFound), "expected ErrNotFound, got %v", err)
+}
+
+func TestRunStoreSQL_CreateRun_InlineContent(t *testing.T) {
+	store := newTestRunStore(t)
+
+	run := &RunRecord{
+		RunID:         "run-inline",
+		TenantID:      "tenant-x",
+		CreatedAt:     time.Now().UTC(),
+		Status:        RunStatusPending,
+		InlineContent: "#!/bin/bash\necho hello",
+		Shell:         scriptmodule.ShellBash,
+	}
+	require.NoError(t, store.CreateRun(run))
+
+	got, err := store.GetRun("run-inline")
+	require.NoError(t, err)
+	assert.Equal(t, run.InlineContent, got.InlineContent)
+}
+
+func TestRunStoreSQL_CreateJob_And_ListRunJobs(t *testing.T) {
+	store := newTestRunStore(t)
+
+	run := sampleRun("run-002", "tenant-abc")
+	require.NoError(t, store.CreateRun(run))
+
+	j1 := sampleJob("job-001", "run-002", "device-alpha")
+	j2 := sampleJob("job-002", "run-002", "device-beta")
+	j2.CreatedAt = j2.CreatedAt.Add(time.Second) // ensure ordering
+
+	require.NoError(t, store.CreateJob(j1))
+	require.NoError(t, store.CreateJob(j2))
+
+	jobs, err := store.ListRunJobs("run-002")
+	require.NoError(t, err)
+	require.Len(t, jobs, 2)
+
+	// Ordered by created_at ASC
+	assert.Equal(t, "job-001", jobs[0].JobID)
+	assert.Equal(t, "job-002", jobs[1].JobID)
+	assert.Equal(t, "device-alpha", jobs[0].DeviceID)
+	assert.Equal(t, "device-beta", jobs[1].DeviceID)
+	assert.Equal(t, "run-002", jobs[0].RunID)
+}
+
+func TestRunStoreSQL_ListRunJobs_EmptyForUnknownRun(t *testing.T) {
+	store := newTestRunStore(t)
+
+	jobs, err := store.ListRunJobs("no-such-run")
+	require.NoError(t, err)
+	assert.Empty(t, jobs)
+}
+
+func TestRunStoreSQL_UpdateJobStatus_NonTerminal(t *testing.T) {
+	store := newTestRunStore(t)
+
+	run := sampleRun("run-003", "tenant-abc")
+	require.NoError(t, store.CreateRun(run))
+
+	j := sampleJob("job-003", "run-003", "device-gamma")
+	require.NoError(t, store.CreateJob(j))
+
+	require.NoError(t, store.UpdateJobStatus("job-003", JobStatusRunning, "exec-xyz"))
+
+	jobs, err := store.ListRunJobs("run-003")
+	require.NoError(t, err)
+	require.Len(t, jobs, 1)
+	assert.Equal(t, JobStatusRunning, jobs[0].Status)
+	assert.Equal(t, "exec-xyz", jobs[0].ExecutionID)
+	assert.Nil(t, jobs[0].CompletedAt, "completed_at must remain nil for non-terminal status")
+}
+
+func TestRunStoreSQL_UpdateJobStatus_Terminal_SetsCompletedAt(t *testing.T) {
+	store := newTestRunStore(t)
+
+	run := sampleRun("run-004", "tenant-abc")
+	require.NoError(t, store.CreateRun(run))
+
+	j := sampleJob("job-004", "run-004", "device-delta")
+	require.NoError(t, store.CreateJob(j))
+
+	before := time.Now().UTC().Add(-time.Second)
+	require.NoError(t, store.UpdateJobStatus("job-004", JobStatusCompleted, "exec-done"))
+	after := time.Now().UTC().Add(time.Second)
+
+	jobs, err := store.ListRunJobs("run-004")
+	require.NoError(t, err)
+	require.Len(t, jobs, 1)
+	assert.Equal(t, JobStatusCompleted, jobs[0].Status)
+	require.NotNil(t, jobs[0].CompletedAt, "completed_at must be set for terminal status")
+	assert.True(t, jobs[0].CompletedAt.After(before) && jobs[0].CompletedAt.Before(after),
+		"completed_at must be set to approximately now")
+}
+
+func TestRunStoreSQL_UpdateRunStatus(t *testing.T) {
+	store := newTestRunStore(t)
+
+	run := sampleRun("run-005", "tenant-abc")
+	require.NoError(t, store.CreateRun(run))
+
+	require.NoError(t, store.UpdateRunStatus("run-005", RunStatusRunning))
+
+	got, err := store.GetRun("run-005")
+	require.NoError(t, err)
+	assert.Equal(t, RunStatusRunning, got.Status)
+}
+
+func TestRunStoreSQL_UpdateRunCounts(t *testing.T) {
+	store := newTestRunStore(t)
+
+	run := sampleRun("run-006", "tenant-abc")
+	require.NoError(t, store.CreateRun(run))
+
+	require.NoError(t, store.UpdateRunCounts("run-006", 1, 1))
+
+	got, err := store.GetRun("run-006")
+	require.NoError(t, err)
+	assert.Equal(t, 1, got.CompletedJobs)
+	assert.Equal(t, 1, got.FailedJobs)
+}
+
+func TestRunStoreSQL_CreateJob_WithExecutionID(t *testing.T) {
+	store := newTestRunStore(t)
+
+	run := sampleRun("run-007", "tenant-abc")
+	require.NoError(t, store.CreateRun(run))
+
+	j := sampleJob("job-007", "run-007", "device-epsilon")
+	j.ExecutionID = "exec-pre-assigned"
+	require.NoError(t, store.CreateJob(j))
+
+	jobs, err := store.ListRunJobs("run-007")
+	require.NoError(t, err)
+	require.Len(t, jobs, 1)
+	assert.Equal(t, "exec-pre-assigned", jobs[0].ExecutionID)
+}
+
+// ---- RunStatus / JobStatus helpers ------------------------------------------
+
+func TestRunStatus_IsTerminal(t *testing.T) {
+	assert.False(t, RunStatusPending.IsTerminal())
+	assert.False(t, RunStatusRunning.IsTerminal())
+	assert.True(t, RunStatusCompleted.IsTerminal())
+	assert.True(t, RunStatusFailed.IsTerminal())
+	assert.True(t, RunStatusCancelled.IsTerminal())
+}
+
+func TestJobStatus_IsTerminal(t *testing.T) {
+	assert.False(t, JobStatusPending.IsTerminal())
+	assert.False(t, JobStatusRunning.IsTerminal())
+	assert.True(t, JobStatusCompleted.IsTerminal())
+	assert.True(t, JobStatusFailed.IsTerminal())
+	assert.True(t, JobStatusCancelled.IsTerminal())
+}
+
+// ---- Manager tests ----------------------------------------------------------
+
+func newTestManager(t *testing.T) (*Manager, *RunStoreSQL) {
+	t.Helper()
+	store := newTestRunStore(t)
+	manager := NewManager(store, nil)
+	return manager, store
+}
+
+func TestManager_GetRun_NotFound(t *testing.T) {
+	manager, _ := newTestManager(t)
+
+	_, err := manager.GetRun(context.Background(), "no-such-run")
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrNotFound))
+}
+
+func TestManager_GetRun_Found(t *testing.T) {
+	manager, store := newTestManager(t)
+
+	run := sampleRun("run-mgr-1", "tenant-abc")
+	require.NoError(t, store.CreateRun(run))
+
+	got, err := manager.GetRun(context.Background(), "run-mgr-1")
+	require.NoError(t, err)
+	assert.Equal(t, "run-mgr-1", got.RunID)
+}
+
+func TestManager_ListRunJobs_NotFound(t *testing.T) {
+	manager, _ := newTestManager(t)
+
+	_, err := manager.ListRunJobs(context.Background(), "no-such-run")
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrNotFound))
+}
+
+func TestManager_ListRunJobs_ReturnsJobs(t *testing.T) {
+	manager, store := newTestManager(t)
+
+	run := sampleRun("run-mgr-2", "tenant-abc")
+	require.NoError(t, store.CreateRun(run))
+	require.NoError(t, store.CreateJob(sampleJob("job-mgr-1", "run-mgr-2", "dev-a")))
+	require.NoError(t, store.CreateJob(sampleJob("job-mgr-2", "run-mgr-2", "dev-b")))
+
+	jobs, err := manager.ListRunJobs(context.Background(), "run-mgr-2")
+	require.NoError(t, err)
+	assert.Len(t, jobs, 2)
+}
+
+func TestManager_CancelRun_NotFound(t *testing.T) {
+	manager, _ := newTestManager(t)
+
+	err := manager.CancelRun(context.Background(), "no-such-run")
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrNotFound))
+}
+
+func TestManager_CancelRun_AlreadyTerminal(t *testing.T) {
+	manager, store := newTestManager(t)
+
+	run := sampleRun("run-term", "tenant-abc")
+	run.Status = RunStatusCompleted
+	require.NoError(t, store.CreateRun(run))
+
+	err := manager.CancelRun(context.Background(), "run-term")
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrAlreadyTerminal))
+}
+
+func TestManager_CancelRun_CancelsRunAndJobs(t *testing.T) {
+	manager, store := newTestManager(t)
+
+	run := sampleRun("run-cancel", "tenant-abc")
+	run.Status = RunStatusRunning
+	require.NoError(t, store.CreateRun(run))
+
+	j1 := sampleJob("job-c1", "run-cancel", "dev-alpha")
+	j1.Status = JobStatusRunning
+	j2 := sampleJob("job-c2", "run-cancel", "dev-beta")
+	j2.Status = JobStatusCompleted // already terminal — must NOT be overwritten
+
+	require.NoError(t, store.CreateJob(j1))
+	require.NoError(t, store.CreateJob(j2))
+
+	require.NoError(t, manager.CancelRun(context.Background(), "run-cancel"))
+
+	// Run must be cancelled
+	got, err := store.GetRun("run-cancel")
+	require.NoError(t, err)
+	assert.Equal(t, RunStatusCancelled, got.Status)
+
+	// Non-terminal job must be cancelled
+	jobs, err := store.ListRunJobs("run-cancel")
+	require.NoError(t, err)
+	require.Len(t, jobs, 2)
+
+	jobsByID := map[string]*JobRecord{}
+	for _, j := range jobs {
+		jobsByID[j.JobID] = j
+	}
+
+	assert.Equal(t, JobStatusCancelled, jobsByID["job-c1"].Status, "running job must be cancelled")
+	assert.Equal(t, JobStatusCompleted, jobsByID["job-c2"].Status, "completed job must remain completed")
+}
+
+func TestManager_CancelRun_AlreadyCancelled(t *testing.T) {
+	manager, store := newTestManager(t)
+
+	run := sampleRun("run-already-cancelled", "tenant-abc")
+	run.Status = RunStatusCancelled
+	require.NoError(t, store.CreateRun(run))
+
+	err := manager.CancelRun(context.Background(), "run-already-cancelled")
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrAlreadyTerminal))
+}

--- a/features/controller/run/run_test.go
+++ b/features/controller/run/run_test.go
@@ -391,6 +391,117 @@ func TestManager_CancelRun_AlreadyCancelled(t *testing.T) {
 	assert.True(t, errors.Is(err, ErrAlreadyTerminal))
 }
 
+// ---- RecordJobCompletion tests ----------------------------------------------
+
+// TestManager_RecordJobCompletion_AdvancesRunToCompleted verifies AC3: once the
+// last job in a run reaches a terminal state, the run transitions to completed.
+func TestManager_RecordJobCompletion_AdvancesRunToCompleted(t *testing.T) {
+	manager, store := newTestManager(t)
+
+	run := sampleRun("run-rjc-1", "tenant-abc")
+	run.Status = RunStatusRunning
+	run.JobCount = 2
+	require.NoError(t, store.CreateRun(run))
+	require.NoError(t, store.CreateJob(sampleJob("job-rjc-1", "run-rjc-1", "dev-a")))
+	require.NoError(t, store.CreateJob(sampleJob("job-rjc-2", "run-rjc-1", "dev-b")))
+
+	// First job completes — run must remain running (one job still pending).
+	require.NoError(t, manager.RecordJobCompletion(context.Background(), "run-rjc-1", "job-rjc-1", "exec-a", false))
+
+	got, err := store.GetRun("run-rjc-1")
+	require.NoError(t, err)
+	assert.Equal(t, RunStatusRunning, got.Status, "run must stay running while a job is pending")
+	assert.Equal(t, 1, got.CompletedJobs)
+	assert.Equal(t, 0, got.FailedJobs)
+
+	// Second (final) job completes — run must transition to completed.
+	require.NoError(t, manager.RecordJobCompletion(context.Background(), "run-rjc-1", "job-rjc-2", "exec-b", false))
+
+	got, err = store.GetRun("run-rjc-1")
+	require.NoError(t, err)
+	assert.Equal(t, RunStatusCompleted, got.Status, "run must be completed once all jobs are terminal")
+	assert.Equal(t, 2, got.CompletedJobs)
+	assert.Equal(t, 0, got.FailedJobs)
+
+	// Both jobs must carry their execution IDs and terminal status.
+	jobs, err := store.ListRunJobs("run-rjc-1")
+	require.NoError(t, err)
+	require.Len(t, jobs, 2)
+	for _, j := range jobs {
+		assert.Equal(t, JobStatusCompleted, j.Status)
+		assert.NotNil(t, j.CompletedAt)
+	}
+}
+
+// TestManager_RecordJobCompletion_FailedJobMarksRunFailed verifies that a run
+// with at least one failed job transitions to failed (not completed) once all
+// jobs are terminal.
+func TestManager_RecordJobCompletion_FailedJobMarksRunFailed(t *testing.T) {
+	manager, store := newTestManager(t)
+
+	run := sampleRun("run-rjc-2", "tenant-abc")
+	run.Status = RunStatusRunning
+	run.JobCount = 2
+	require.NoError(t, store.CreateRun(run))
+	require.NoError(t, store.CreateJob(sampleJob("job-f1", "run-rjc-2", "dev-a")))
+	require.NoError(t, store.CreateJob(sampleJob("job-f2", "run-rjc-2", "dev-b")))
+
+	require.NoError(t, manager.RecordJobCompletion(context.Background(), "run-rjc-2", "job-f1", "exec-a", false))
+	require.NoError(t, manager.RecordJobCompletion(context.Background(), "run-rjc-2", "job-f2", "exec-b", true))
+
+	got, err := store.GetRun("run-rjc-2")
+	require.NoError(t, err)
+	assert.Equal(t, RunStatusFailed, got.Status, "run must be failed when a job failed")
+	assert.Equal(t, 1, got.CompletedJobs)
+	assert.Equal(t, 1, got.FailedJobs)
+}
+
+// TestManager_RecordJobCompletion_LeavesTerminalRunUntouched verifies that a
+// late completion callback does not resurrect a run that is already terminal
+// (e.g. cancelled via DELETE).
+func TestManager_RecordJobCompletion_LeavesTerminalRunUntouched(t *testing.T) {
+	manager, store := newTestManager(t)
+
+	run := sampleRun("run-rjc-3", "tenant-abc")
+	run.Status = RunStatusCancelled
+	run.JobCount = 1
+	require.NoError(t, store.CreateRun(run))
+	require.NoError(t, store.CreateJob(sampleJob("job-late", "run-rjc-3", "dev-a")))
+
+	require.NoError(t, manager.RecordJobCompletion(context.Background(), "run-rjc-3", "job-late", "exec-late", false))
+
+	got, err := store.GetRun("run-rjc-3")
+	require.NoError(t, err)
+	assert.Equal(t, RunStatusCancelled, got.Status, "cancelled run must stay cancelled after a late completion")
+}
+
+// TestManager_RecordJobCompletion_CancelledJobIsTerminal verifies that a
+// cancelled job counts as terminal for run aggregation but toward neither the
+// completed nor failed counters.
+func TestManager_RecordJobCompletion_CancelledJobIsTerminal(t *testing.T) {
+	manager, store := newTestManager(t)
+
+	run := sampleRun("run-rjc-4", "tenant-abc")
+	run.Status = RunStatusRunning
+	run.JobCount = 2
+	require.NoError(t, store.CreateRun(run))
+
+	j1 := sampleJob("job-x1", "run-rjc-4", "dev-a")
+	j2 := sampleJob("job-x2", "run-rjc-4", "dev-b")
+	j2.Status = JobStatusCancelled // already cancelled
+	require.NoError(t, store.CreateJob(j1))
+	require.NoError(t, store.CreateJob(j2))
+
+	// Completing the only non-terminal job makes all jobs terminal.
+	require.NoError(t, manager.RecordJobCompletion(context.Background(), "run-rjc-4", "job-x1", "exec-a", false))
+
+	got, err := store.GetRun("run-rjc-4")
+	require.NoError(t, err)
+	assert.Equal(t, RunStatusCompleted, got.Status, "run completes once all jobs terminal")
+	assert.Equal(t, 1, got.CompletedJobs)
+	assert.Equal(t, 0, got.FailedJobs)
+}
+
 // ---- Close tests ------------------------------------------------------------
 
 // TestRunStoreSQL_Close_ReleasesDBHandle verifies that Close releases the

--- a/features/controller/run/run_test.go
+++ b/features/controller/run/run_test.go
@@ -6,6 +6,8 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -387,4 +389,58 @@ func TestManager_CancelRun_AlreadyCancelled(t *testing.T) {
 	err := manager.CancelRun(context.Background(), "run-already-cancelled")
 	require.Error(t, err)
 	assert.True(t, errors.Is(err, ErrAlreadyTerminal))
+}
+
+// ---- Close tests ------------------------------------------------------------
+
+// TestRunStoreSQL_Close_ReleasesDBHandle verifies that Close releases the
+// underlying connection. A leaked file-backed connection blocks temp-directory
+// cleanup on Windows (Issue #1673 CI regression), so the file must be removable
+// once Close has run.
+func TestRunStoreSQL_Close_ReleasesDBHandle(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "runs.db")
+
+	db, err := sql.Open("sqlite", "file:"+dbPath)
+	require.NoError(t, err, "open file-backed sqlite")
+
+	store := NewRunStoreSQL(db)
+	require.NoError(t, store.Init(context.Background()), "Init must succeed")
+	require.NoError(t, store.CreateRun(sampleRun("run-close-1", "tenant-abc")))
+
+	require.NoError(t, store.Close(), "Close must succeed")
+
+	// After Close the connection is released — operations must fail.
+	_, err = store.GetRun("run-close-1")
+	require.Error(t, err, "GetRun must fail after Close")
+
+	// The DB file must be removable now that no handle is held open.
+	require.NoError(t, os.Remove(dbPath), "db file must be removable after Close")
+}
+
+// TestRunStoreSQL_Close_NilDB verifies Close is safe on a zero-value store.
+func TestRunStoreSQL_Close_NilDB(t *testing.T) {
+	store := &RunStoreSQL{}
+	require.NoError(t, store.Close())
+}
+
+// TestManager_Close_ClosesStore verifies Manager.Close propagates to a store
+// that implements io.Closer.
+func TestManager_Close_ClosesStore(t *testing.T) {
+	store := newTestRunStore(t)
+	manager := NewManager(store, nil)
+
+	require.NoError(t, manager.Close(), "Manager.Close must succeed")
+
+	_, err := store.GetRun("anything")
+	require.Error(t, err, "store must be closed after Manager.Close")
+}
+
+// closerlessStore is a RunStore that does not implement io.Closer; used to
+// verify Manager.Close is a no-op for non-closable stores.
+type closerlessStore struct{ RunStore }
+
+func TestManager_Close_NonClosableStore(t *testing.T) {
+	manager := NewManager(closerlessStore{}, nil)
+	require.NoError(t, manager.Close(), "Manager.Close must be a no-op for non-closable store")
 }

--- a/features/controller/run/synthesis.go
+++ b/features/controller/run/synthesis.go
@@ -1,0 +1,180 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+package run
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/cfgis/cfgms/features/controller/fleet"
+	scriptmodule "github.com/cfgis/cfgms/features/modules/script"
+)
+
+// SynthesizeScriptRun resolves matching devices from the fleet and creates a
+// RunRecord plus one JobRecord per device, each backed by a QueuedExecution.
+// It returns the new run ID so callers can redirect to GET /runs/{run_id}.
+//
+// The filter is tenant-scoped: filter.TenantID is always overwritten with tenantID
+// so that a principal cannot target devices outside its own tenant.
+func SynthesizeScriptRun(
+	ctx context.Context,
+	manager *Manager,
+	executionQueue *scriptmodule.ExecutionQueue,
+	fleetQuery fleet.FleetQuery,
+	tenantID, createdBy string,
+	filter fleet.Filter,
+	scriptRef, scriptVersion string,
+	shell scriptmodule.ShellType,
+	params map[string]string,
+) (string, error) {
+	filter.TenantID = tenantID
+
+	devices, err := fleetQuery.Search(ctx, filter)
+	if err != nil {
+		return "", fmt.Errorf("synthesize script run: fleet search: %w", err)
+	}
+
+	runID := uuid.New().String()
+	now := time.Now().UTC()
+
+	run := &RunRecord{
+		RunID:     runID,
+		TenantID:  tenantID,
+		CreatedBy: createdBy,
+		CreatedAt: now,
+		Status:    RunStatusPending,
+		Filter:    filter,
+		ScriptRef: scriptRef,
+		Shell:     shell,
+		JobCount:  len(devices),
+	}
+	if err := manager.store.CreateRun(run); err != nil {
+		return "", fmt.Errorf("synthesize script run: create run: %w", err)
+	}
+
+	for _, device := range devices {
+		jobID := uuid.New().String()
+		executionID := uuid.New().String()
+
+		job := &JobRecord{
+			JobID:       jobID,
+			RunID:       runID,
+			DeviceID:    device.ID,
+			ExecutionID: executionID,
+			Status:      JobStatusPending,
+			CreatedAt:   now,
+		}
+		if err := manager.store.CreateJob(job); err != nil {
+			return "", fmt.Errorf("synthesize script run: create job for device %s: %w", device.ID, err)
+		}
+
+		qe := &scriptmodule.QueuedExecution{
+			ExecutionID:   executionID,
+			ScriptRef:     scriptRef,
+			ScriptVersion: scriptVersion,
+			Shell:         shell,
+			Parameters:    params,
+			Metadata: map[string]interface{}{
+				"workflow_run_id": runID,
+				"job_id":          jobID,
+			},
+		}
+		if err := executionQueue.QueueExecution(device.ID, qe); err != nil {
+			if errors.Is(err, scriptmodule.ErrDuplicateExecution) {
+				continue
+			}
+			return "", fmt.Errorf("synthesize script run: enqueue for device %s: %w", device.ID, err)
+		}
+	}
+
+	if err := manager.store.UpdateRunStatus(runID, RunStatusRunning); err != nil {
+		return "", fmt.Errorf("synthesize script run: update run status: %w", err)
+	}
+
+	return runID, nil
+}
+
+// SynthesizeCommandRun resolves matching devices and creates a RunRecord plus one
+// JobRecord per device for an inline (ad-hoc) script. Inline content is stored in
+// QueuedExecution.Metadata["inline_script_content"]; actual delivery to the steward
+// is handled by the dispatcher.
+func SynthesizeCommandRun(
+	ctx context.Context,
+	manager *Manager,
+	executionQueue *scriptmodule.ExecutionQueue,
+	fleetQuery fleet.FleetQuery,
+	tenantID, createdBy string,
+	filter fleet.Filter,
+	inlineContent string,
+	shell scriptmodule.ShellType,
+	params map[string]string,
+) (string, error) {
+	filter.TenantID = tenantID
+
+	devices, err := fleetQuery.Search(ctx, filter)
+	if err != nil {
+		return "", fmt.Errorf("synthesize command run: fleet search: %w", err)
+	}
+
+	runID := uuid.New().String()
+	now := time.Now().UTC()
+
+	run := &RunRecord{
+		RunID:         runID,
+		TenantID:      tenantID,
+		CreatedBy:     createdBy,
+		CreatedAt:     now,
+		Status:        RunStatusPending,
+		Filter:        filter,
+		InlineContent: inlineContent,
+		Shell:         shell,
+		JobCount:      len(devices),
+	}
+	if err := manager.store.CreateRun(run); err != nil {
+		return "", fmt.Errorf("synthesize command run: create run: %w", err)
+	}
+
+	for _, device := range devices {
+		jobID := uuid.New().String()
+		executionID := uuid.New().String()
+
+		job := &JobRecord{
+			JobID:       jobID,
+			RunID:       runID,
+			DeviceID:    device.ID,
+			ExecutionID: executionID,
+			Status:      JobStatusPending,
+			CreatedAt:   now,
+		}
+		if err := manager.store.CreateJob(job); err != nil {
+			return "", fmt.Errorf("synthesize command run: create job for device %s: %w", device.ID, err)
+		}
+
+		qe := &scriptmodule.QueuedExecution{
+			ExecutionID: executionID,
+			Shell:       shell,
+			Parameters:  params,
+			Metadata: map[string]interface{}{
+				"workflow_run_id":       runID,
+				"job_id":                jobID,
+				"inline_script_content": inlineContent,
+			},
+		}
+		if err := executionQueue.QueueExecution(device.ID, qe); err != nil {
+			if errors.Is(err, scriptmodule.ErrDuplicateExecution) {
+				continue
+			}
+			return "", fmt.Errorf("synthesize command run: enqueue for device %s: %w", device.ID, err)
+		}
+	}
+
+	if err := manager.store.UpdateRunStatus(runID, RunStatusRunning); err != nil {
+		return "", fmt.Errorf("synthesize command run: update run status: %w", err)
+	}
+
+	return runID, nil
+}

--- a/features/controller/run/synthesis_test.go
+++ b/features/controller/run/synthesis_test.go
@@ -1,0 +1,281 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+package run
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cfgis/cfgms/features/controller/fleet"
+	scriptmodule "github.com/cfgis/cfgms/features/modules/script"
+)
+
+// staticFleetQuery is a real FleetQuery implementation that returns a fixed set
+// of StewardResults. Used in synthesis tests to avoid mocks.
+type staticFleetQuery struct {
+	results []fleet.StewardResult
+}
+
+func (q *staticFleetQuery) Search(_ context.Context, _ fleet.Filter) ([]fleet.StewardResult, error) {
+	return q.results, nil
+}
+
+func (q *staticFleetQuery) Count(_ context.Context, _ fleet.Filter) (int, error) {
+	return len(q.results), nil
+}
+
+// newTestExecutionQueue creates a real ExecutionQueue backed by an InMemoryQueueStore.
+func newTestExecutionQueue() *scriptmodule.ExecutionQueue {
+	monitor := scriptmodule.NewExecutionMonitor()
+	keyManager := scriptmodule.NewEphemeralKeyManager()
+	return scriptmodule.NewExecutionQueue(monitor, keyManager, 0, "", nil, nil, 0)
+}
+
+// newTestSynthesisManager creates a Manager backed by an in-memory SQLite store.
+func newTestSynthesisManager(t *testing.T) *Manager {
+	t.Helper()
+	store := newTestRunStore(t)
+	return NewManager(store, nil)
+}
+
+// ---- SynthesizeScriptRun tests ----------------------------------------------
+
+func TestSynthesizeScriptRun_TwoDevices_CreatesTwoJobs(t *testing.T) {
+	ctx := context.Background()
+	manager := newTestSynthesisManager(t)
+	queue := newTestExecutionQueue()
+
+	fq := &staticFleetQuery{
+		results: []fleet.StewardResult{
+			{ID: "device-001", TenantID: "tenant-abc"},
+			{ID: "device-002", TenantID: "tenant-abc"},
+		},
+	}
+
+	runID, err := SynthesizeScriptRun(
+		ctx, manager, queue, fq,
+		"tenant-abc", "user-1",
+		fleet.Filter{},
+		"scripts/deploy.sh", "v1.0.0",
+		scriptmodule.ShellBash,
+		map[string]string{"env": "prod"},
+	)
+	require.NoError(t, err)
+	assert.NotEmpty(t, runID)
+
+	// Run record must exist and have status=running
+	run, err := manager.GetRun(ctx, runID)
+	require.NoError(t, err)
+	assert.Equal(t, RunStatusRunning, run.Status)
+	assert.Equal(t, 2, run.JobCount)
+	assert.Equal(t, "tenant-abc", run.TenantID)
+	assert.Equal(t, "user-1", run.CreatedBy)
+	assert.Equal(t, "scripts/deploy.sh", run.ScriptRef)
+	assert.Equal(t, "tenant-abc", run.Filter.TenantID, "filter.TenantID must be scoped to tenantID")
+
+	// Two job records must exist, one per device
+	jobs, err := manager.ListRunJobs(ctx, runID)
+	require.NoError(t, err)
+	require.Len(t, jobs, 2)
+
+	deviceIDs := map[string]bool{}
+	for _, j := range jobs {
+		assert.Equal(t, runID, j.RunID)
+		assert.NotEmpty(t, j.JobID)
+		assert.NotEmpty(t, j.ExecutionID)
+		assert.Equal(t, JobStatusPending, j.Status)
+		deviceIDs[j.DeviceID] = true
+	}
+	assert.True(t, deviceIDs["device-001"], "job for device-001 must exist")
+	assert.True(t, deviceIDs["device-002"], "job for device-002 must exist")
+
+	// Two executions must be queued — one per device
+	exec1 := queue.PeekForDevice("device-001")
+	exec2 := queue.PeekForDevice("device-002")
+	require.Len(t, exec1, 1, "device-001 must have one queued execution")
+	require.Len(t, exec2, 1, "device-002 must have one queued execution")
+
+	// Metadata must carry the workflow_run_id and job_id
+	for _, e := range []*scriptmodule.QueuedExecution{exec1[0], exec2[0]} {
+		assert.Equal(t, runID, e.Metadata["workflow_run_id"], "workflow_run_id must be the run ID")
+		assert.NotEmpty(t, e.Metadata["job_id"], "job_id must be set")
+	}
+}
+
+func TestSynthesizeScriptRun_QueuedExecutionIDs_MatchJobRecords(t *testing.T) {
+	ctx := context.Background()
+	manager := newTestSynthesisManager(t)
+	queue := newTestExecutionQueue()
+
+	fq := &staticFleetQuery{
+		results: []fleet.StewardResult{
+			{ID: "device-A", TenantID: "tenant-test"},
+		},
+	}
+
+	runID, err := SynthesizeScriptRun(
+		ctx, manager, queue, fq,
+		"tenant-test", "user-x",
+		fleet.Filter{},
+		"scripts/check.sh", "",
+		scriptmodule.ShellBash,
+		nil,
+	)
+	require.NoError(t, err)
+
+	jobs, err := manager.ListRunJobs(ctx, runID)
+	require.NoError(t, err)
+	require.Len(t, jobs, 1)
+
+	queued := queue.PeekForDevice("device-A")
+	require.Len(t, queued, 1)
+
+	// The execution_id in the queue must match the job record
+	assert.Equal(t, jobs[0].ExecutionID, queued[0].ExecutionID,
+		"execution_id in queue must match the job record")
+	assert.Equal(t, jobs[0].JobID, queued[0].Metadata["job_id"],
+		"job_id in queue metadata must match the job record")
+}
+
+func TestSynthesizeScriptRun_NoDevices_CreatesEmptyRun(t *testing.T) {
+	ctx := context.Background()
+	manager := newTestSynthesisManager(t)
+	queue := newTestExecutionQueue()
+
+	fq := &staticFleetQuery{results: []fleet.StewardResult{}}
+
+	runID, err := SynthesizeScriptRun(
+		ctx, manager, queue, fq,
+		"tenant-abc", "user-1",
+		fleet.Filter{},
+		"scripts/noop.sh", "",
+		scriptmodule.ShellBash,
+		nil,
+	)
+	require.NoError(t, err)
+	assert.NotEmpty(t, runID)
+
+	run, err := manager.GetRun(ctx, runID)
+	require.NoError(t, err)
+	assert.Equal(t, 0, run.JobCount)
+	assert.Equal(t, RunStatusRunning, run.Status)
+
+	jobs, err := manager.ListRunJobs(ctx, runID)
+	require.NoError(t, err)
+	assert.Empty(t, jobs)
+}
+
+func TestSynthesizeScriptRun_TenantIsolation(t *testing.T) {
+	ctx := context.Background()
+	// Use a RunStoreSQL directly so we can inspect stored runs.
+	sqlStore := newTestRunStore(t)
+	manager := NewManager(sqlStore, nil)
+	queue := newTestExecutionQueue()
+
+	// Even if caller passes an empty filter, tenant scoping must be applied.
+	fq := &staticFleetQuery{
+		results: []fleet.StewardResult{
+			{ID: "device-isolated", TenantID: "tenant-xyz"},
+		},
+	}
+
+	runID, err := SynthesizeScriptRun(
+		ctx, manager, queue, fq,
+		"tenant-xyz", "user-2",
+		fleet.Filter{}, // no explicit tenantID
+		"scripts/test.sh", "",
+		scriptmodule.ShellBash,
+		nil,
+	)
+	require.NoError(t, err)
+
+	// The stored run must belong to tenant-xyz and filter.TenantID must be set.
+	run, err := sqlStore.GetRun(runID)
+	require.NoError(t, err)
+	assert.Equal(t, "tenant-xyz", run.TenantID)
+	assert.Equal(t, "tenant-xyz", run.Filter.TenantID,
+		"filter.TenantID must be overwritten with tenantID even when filter was empty")
+}
+
+// ---- SynthesizeCommandRun tests ---------------------------------------------
+
+func TestSynthesizeCommandRun_TwoDevices_CreatesTwoJobs(t *testing.T) {
+	ctx := context.Background()
+	manager := newTestSynthesisManager(t)
+	queue := newTestExecutionQueue()
+
+	fq := &staticFleetQuery{
+		results: []fleet.StewardResult{
+			{ID: "device-cmd-1", TenantID: "tenant-abc"},
+			{ID: "device-cmd-2", TenantID: "tenant-abc"},
+		},
+	}
+
+	runID, err := SynthesizeCommandRun(
+		ctx, manager, queue, fq,
+		"tenant-abc", "user-1",
+		fleet.Filter{},
+		"#!/bin/bash\necho hello",
+		scriptmodule.ShellBash,
+		nil,
+	)
+	require.NoError(t, err)
+	assert.NotEmpty(t, runID)
+
+	run, err := manager.GetRun(ctx, runID)
+	require.NoError(t, err)
+	assert.Equal(t, RunStatusRunning, run.Status)
+	assert.Equal(t, 2, run.JobCount)
+	assert.Equal(t, "#!/bin/bash\necho hello", run.InlineContent)
+	assert.Empty(t, run.ScriptRef, "script_ref must be empty for command runs")
+
+	jobs, err := manager.ListRunJobs(ctx, runID)
+	require.NoError(t, err)
+	require.Len(t, jobs, 2)
+
+	// Inline content must be stored in queue metadata
+	for _, deviceID := range []string{"device-cmd-1", "device-cmd-2"} {
+		queued := queue.PeekForDevice(deviceID)
+		require.Len(t, queued, 1, "device %s must have one queued execution", deviceID)
+		assert.Equal(t, "#!/bin/bash\necho hello",
+			queued[0].Metadata["inline_script_content"],
+			"inline content must be in queue metadata for device %s", deviceID)
+		assert.Equal(t, runID, queued[0].Metadata["workflow_run_id"])
+	}
+}
+
+func TestSynthesizeCommandRun_QueuedExecutionIDs_MatchJobRecords(t *testing.T) {
+	ctx := context.Background()
+	manager := newTestSynthesisManager(t)
+	queue := newTestExecutionQueue()
+
+	fq := &staticFleetQuery{
+		results: []fleet.StewardResult{
+			{ID: "device-cmd-A", TenantID: "tenant-test"},
+		},
+	}
+
+	runID, err := SynthesizeCommandRun(
+		ctx, manager, queue, fq,
+		"tenant-test", "user-cmd",
+		fleet.Filter{},
+		"echo test",
+		scriptmodule.ShellBash,
+		nil,
+	)
+	require.NoError(t, err)
+
+	jobs, err := manager.ListRunJobs(ctx, runID)
+	require.NoError(t, err)
+	require.Len(t, jobs, 1)
+
+	queued := queue.PeekForDevice("device-cmd-A")
+	require.Len(t, queued, 1)
+
+	assert.Equal(t, jobs[0].ExecutionID, queued[0].ExecutionID,
+		"execution_id in queue must match the job record")
+	assert.Equal(t, jobs[0].JobID, queued[0].Metadata["job_id"])
+}

--- a/features/controller/server/server.go
+++ b/features/controller/server/server.go
@@ -661,7 +661,12 @@ func New(cfg *config.Config, logger logging.Logger) (*Server, error) {
 	if runManager := initializeRunManager(context.Background(), cfg, executionQueue, logger); runManager != nil {
 		srv.runManager = runManager
 		httpServer.SetRunManager(runManager, executionQueue)
-		logger.Info("Run manager wired to HTTP API server")
+		// Wire the run manager as the dispatcher's completion sink so steward
+		// completion events advance run/job status to terminal (Issue #1673).
+		if jobDispatcher != nil {
+			jobDispatcher.SetRunCompletionSink(runManager)
+		}
+		logger.Info("Run manager wired to HTTP API server and job dispatcher")
 	}
 
 	// Story #416: Wire rollback manager into API server

--- a/features/controller/server/server.go
+++ b/features/controller/server/server.go
@@ -14,11 +14,14 @@ import (
 	"sync"
 	"time"
 
+	"database/sql"
+
 	transportpb "github.com/cfgis/cfgms/api/proto/transport"
 	"google.golang.org/grpc"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	common "github.com/cfgis/cfgms/api/proto/common"
+
 	"github.com/cfgis/cfgms/commercial/ha"
 	configgit "github.com/cfgis/cfgms/features/config/git"
 	gitStorage "github.com/cfgis/cfgms/features/config/git/storage"
@@ -34,6 +37,7 @@ import (
 	"github.com/cfgis/cfgms/features/controller/initialization"
 	"github.com/cfgis/cfgms/features/controller/push"
 	controllerRegistration "github.com/cfgis/cfgms/features/controller/registration"
+	controllerrun "github.com/cfgis/cfgms/features/controller/run"
 	"github.com/cfgis/cfgms/features/controller/service"
 	controllerTransport "github.com/cfgis/cfgms/features/controller/transport"
 	scriptmodule "github.com/cfgis/cfgms/features/modules/script"
@@ -649,6 +653,13 @@ func New(cfg *config.Config, logger logging.Logger) (*Server, error) {
 		storageManager:          storageManager,
 		executionQueue:          executionQueue, // Issue #1672
 		jobDispatcher:           jobDispatcher,  // Issue #1672
+	}
+
+	// Issue #1673: Wire run/job/execution model into API server.
+	// The run store opens a dedicated connection to the same SQLite database.
+	if runManager := initializeRunManager(context.Background(), cfg, executionQueue, logger); runManager != nil {
+		httpServer.SetRunManager(runManager, executionQueue)
+		logger.Info("Run manager wired to HTTP API server")
 	}
 
 	// Story #416: Wire rollback manager into API server
@@ -1708,4 +1719,46 @@ func (s *Server) GetTransportListenAddr() string {
 		return s.quicListener.Addr().String()
 	}
 	return s.cfg.Transport.ListenAddr
+}
+
+// initializeRunManager opens a dedicated SQLite connection for the run store,
+// initializes the schema, and returns a run.Manager. Returns nil on failure so
+// the controller starts without run support rather than failing.
+func initializeRunManager(
+	ctx context.Context,
+	cfg *config.Config,
+	executionQueue *scriptmodule.ExecutionQueue,
+	logger logging.Logger,
+) *controllerrun.Manager {
+	if cfg.Storage == nil || cfg.Storage.SQLitePath == "" {
+		logger.Warn("Run manager: SQLite path not configured, run API disabled")
+		return nil
+	}
+
+	dsn := cfg.Storage.SQLitePath
+	if !strings.HasPrefix(dsn, "file:") {
+		dsn = "file:" + dsn
+	}
+
+	db, err := sql.Open("sqlite", dsn)
+	if err != nil {
+		logger.Warn("Run manager: failed to open SQLite", "error", err)
+		return nil
+	}
+	// busy_timeout prevents SQLITE_BUSY errors when the main connection is writing.
+	if _, err := db.Exec("PRAGMA busy_timeout = 5000"); err != nil {
+		logger.Warn("Run manager: failed to set busy_timeout", "error", err)
+		_ = db.Close()
+		return nil
+	}
+
+	store := controllerrun.NewRunStoreSQL(db)
+	if err := store.Init(ctx); err != nil {
+		logger.Warn("Run manager: failed to initialize schema", "error", err)
+		_ = db.Close()
+		return nil
+	}
+
+	logger.Info("Run manager initialized", "sqlite_path", cfg.Storage.SQLitePath)
+	return controllerrun.NewManager(store, executionQueue)
 }

--- a/features/controller/server/server.go
+++ b/features/controller/server/server.go
@@ -113,6 +113,7 @@ type Server struct {
 	manualReviewHook        *api.ManualReviewApprovalHook       // Issue #1599: manual-review approval hook (nil if not in use)
 	executionQueue          *scriptmodule.ExecutionQueue        // Issue #1672: persistent queue for script executions
 	jobDispatcher           *dispatcher.Dispatcher              // Issue #1672: job dispatcher for script executions
+	runManager              *controllerrun.Manager              // Issue #1673: run/job tracking (must be closed on Stop to release SQLite handle)
 }
 
 // New creates a new server instance
@@ -658,6 +659,7 @@ func New(cfg *config.Config, logger logging.Logger) (*Server, error) {
 	// Issue #1673: Wire run/job/execution model into API server.
 	// The run store opens a dedicated connection to the same SQLite database.
 	if runManager := initializeRunManager(context.Background(), cfg, executionQueue, logger); runManager != nil {
+		srv.runManager = runManager
 		httpServer.SetRunManager(runManager, executionQueue)
 		logger.Info("Run manager wired to HTTP API server")
 	}
@@ -1260,6 +1262,14 @@ func (s *Server) Stop() error {
 	if s.dnaStorageManager != nil {
 		if err := s.dnaStorageManager.Close(); err != nil {
 			s.logger.Warn("Failed to close DNA storage manager", "error", err)
+		}
+	}
+
+	// Close run manager — releases the dedicated SQLite connection so temp-directory
+	// cleanup succeeds on Windows (Issue #1673).
+	if s.runManager != nil {
+		if err := s.runManager.Close(); err != nil {
+			s.logger.Warn("Failed to close run manager", "error", err)
 		}
 	}
 


### PR DESCRIPTION
## Summary

- Adds `features/controller/run/` package with durable RunRecord/JobRecord tracking backed by SQLite (idempotent schema init, WAL-safe dedicated connection)
- `SynthesizeScriptRun` and `SynthesizeCommandRun` fan out one QueuedExecution per matched steward, pre-assigning UUIDs so JobRecord.ExecutionID ↔ queue entry are always consistent
- Five new REST endpoints: `POST /api/v1/runs/script`, `POST /api/v1/runs/command`, `GET /api/v1/runs/{id}`, `GET /api/v1/runs/{id}/jobs`, `DELETE /api/v1/runs/{id}`
- Tenant isolation enforced at handler level — cross-tenant GET/jobs/DELETE returns 404 (IDOR prevention); synthesis always scopes `filter.TenantID = tenantID` from auth context

## Test plan

- [x] All three required AC tests pass: two-steward fanout creates 2 JobRecords + 2 QueuedExecutions with `workflow_run_id`; GET /jobs returns correct `device_id`+`execution_id`; permission gates enforced (403); DELETE returns 200/404/409
- [x] Cross-tenant IDOR test: `TestRunEndpoints_TenantIsolation` verifies GET/jobs/DELETE return 404 for a different tenant's run
- [x] `make test-agent-complete` passes: all unit, integration, lint, and cross-platform compilation checks green

Fixes #1673

🤖 Generated with [Claude Code](https://claude.com/claude-code)