### PR TITLE
controller: deliver tenant-cascade-merged config to stewards (Issue #1722)

### DIFF
--- a/features/controller/service/config_service_test.go
+++ b/features/controller/service/config_service_test.go
@@ -564,6 +564,51 @@ func TestGetConfiguration_CascadeMergedDelivery(t *testing.T) {
 	})
 }
 
+// TestGetConfiguration_TenantWithoutHierarchyRecord verifies that a steward whose tenant
+// exists only as an identifier — e.g. registered via a registration token but never
+// promoted to a full TenantData hierarchy record — still receives its device-level
+// config from the delivery path.
+//
+// Regression: routing GetConfiguration through InheritanceResolver.ResolveConfiguration
+// makes it walk the tenant ancestor chain, which fails when the tenant has no
+// TenantData record. The fleet E2E stewards register under registration-token tenants
+// with no hierarchy record, so the delivery path must degrade gracefully instead of
+// returning NOT_FOUND for an already-configured steward.
+func TestGetConfiguration_TenantWithoutHierarchyRecord(t *testing.T) {
+	ctx := context.Background()
+	sm := pkgtesting.SetupTestStorage(t)
+	svc := NewConfigurationServiceV2(logging.NewNoopLogger(), sm, nil)
+
+	// Deliberately do NOT create a TenantData record for this tenant — it exists
+	// only as the identifier carried by the steward's registration.
+	const tenantID = "registration-token-tenant"
+	tenantCtx := context.WithValue(ctx, ctxkeys.TenantID, tenantID)
+
+	t.Run("device config delivered when tenant has no hierarchy record", func(t *testing.T) {
+		deviceCfg := createTestStewardConfig("fleet-steward-1")
+		require.NoError(t, svc.SetConfiguration(ctx, tenantID, "fleet-steward-1", deviceCfg))
+
+		resp, err := svc.GetConfiguration(tenantCtx, &controller.ConfigRequest{StewardId: "fleet-steward-1"})
+		require.NoError(t, err)
+		require.Equal(t, common.Status_OK, resp.Status.Code,
+			"steward must receive device config even when its tenant has no hierarchy record")
+
+		require.NotNil(t, resp.Config)
+		require.NotNil(t, resp.Config.Config)
+		retrieved, err := stewardconfig.FromProto(resp.Config.Config)
+		require.NoError(t, err)
+		assert.Equal(t, "fleet-steward-1", retrieved.Steward.ID)
+		assert.Len(t, retrieved.Resources, 2)
+	})
+
+	t.Run("NOT_FOUND when tenant has no hierarchy record and steward has no config", func(t *testing.T) {
+		resp, err := svc.GetConfiguration(tenantCtx, &controller.ConfigRequest{StewardId: "unconfigured-steward"})
+		require.NoError(t, err)
+		assert.Equal(t, common.Status_NOT_FOUND, resp.Status.Code,
+			"an unconfigured steward must still resolve to NOT_FOUND, not a device-level fallback")
+	})
+}
+
 // TestGetConfiguration_TenantIsolation verifies that the cascade merges only the steward's
 // own ancestor chain and never includes resources from sibling or unrelated tenants.
 //
@@ -605,6 +650,10 @@ func TestGetConfiguration_TenantIsolation(t *testing.T) {
 
 	retrieved, err := stewardconfig.FromProto(resp.Config.Config)
 	require.NoError(t, err)
+
+	// steward-b must receive its own device config — without this the isolation
+	// loop below would pass vacuously on an empty resource slice.
+	require.NotEmpty(t, retrieved.Resources, "steward-b must receive its own device config")
 
 	for _, r := range retrieved.Resources {
 		assert.NotEqual(t, "msp-a-policy", r.Name,

--- a/features/controller/service/config_service_test.go
+++ b/features/controller/service/config_service_test.go
@@ -12,12 +12,16 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
 
 	common "github.com/cfgis/cfgms/api/proto/common"
 	controller "github.com/cfgis/cfgms/api/proto/controller"
 	stewardconfig "github.com/cfgis/cfgms/features/steward/config"
+	"github.com/cfgis/cfgms/pkg/ctxkeys"
 	"github.com/cfgis/cfgms/pkg/logging"
 	"github.com/cfgis/cfgms/pkg/storage/interfaces"
+	business "github.com/cfgis/cfgms/pkg/storage/interfaces/business"
+	cfgconfig "github.com/cfgis/cfgms/pkg/storage/interfaces/config"
 	pkgtesting "github.com/cfgis/cfgms/pkg/testing"
 )
 
@@ -65,17 +69,26 @@ func createTestStewardConfig(stewardID string) *stewardconfig.StewardConfig {
 	}
 }
 
-// createTestServiceV2 creates a ConfigurationServiceV2 backed by a real git StorageManager
+// createTestServiceV2 creates a ConfigurationServiceV2 backed by a real git StorageManager.
+// A "default" tenant is seeded so that single-tenant tests can call GetConfiguration
+// (which now routes through InheritanceResolver and requires the tenant to exist).
 func createTestServiceV2(t *testing.T) *ConfigurationServiceV2 {
 	t.Helper()
 	logger := logging.NewNoopLogger()
 	storageManager := pkgtesting.SetupTestStorage(t)
-	return NewConfigurationServiceV2(logger, storageManager, nil)
+	svc := NewConfigurationServiceV2(logger, storageManager, nil)
+	require.NoError(t, storageManager.GetTenantStore().CreateTenant(
+		context.Background(),
+		&business.TenantData{ID: "default", Name: "Default", Status: business.TenantStatusActive},
+	))
+	return svc
 }
 
 // createTestServiceV2WithFlatfileRoot creates a ConfigurationServiceV2 backed by real
 // git storage at rootDir. Use this when a test needs to manipulate the storage directory
 // (e.g. chmod to read-only) to simulate storage write errors.
+// A "default" tenant is seeded in the SQLite business store so that any GetConfiguration
+// calls work correctly with the InheritanceResolver.
 func createTestServiceV2WithFlatfileRoot(t *testing.T, rootDir string) *ConfigurationServiceV2 {
 	t.Helper()
 	seq := atomic.AddInt64(&configSvcTestSeq, 1)
@@ -83,7 +96,12 @@ func createTestServiceV2WithFlatfileRoot(t *testing.T, rootDir string) *Configur
 	storageManager, err := interfaces.CreateOSSStorageManager(rootDir, sqlitePath)
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = storageManager.Close() })
-	return NewConfigurationServiceV2(logging.NewNoopLogger(), storageManager, nil)
+	svc := NewConfigurationServiceV2(logging.NewNoopLogger(), storageManager, nil)
+	require.NoError(t, storageManager.GetTenantStore().CreateTenant(
+		context.Background(),
+		&business.TenantData{ID: "default", Name: "Default", Status: business.TenantStatusActive},
+	))
+	return svc
 }
 
 func TestNewConfigurationServiceV2(t *testing.T) {
@@ -457,4 +475,139 @@ func TestConfigurationServiceV2Concurrency(t *testing.T) {
 	resp, err := svc.GetConfiguration(ctx, req)
 	assert.NoError(t, err)
 	assert.Equal(t, common.Status_OK, resp.Status.Code)
+}
+
+// marshalStewardConfigYAML encodes a StewardConfig to YAML bytes for direct config-store writes.
+func marshalStewardConfigYAML(t *testing.T, cfg stewardconfig.StewardConfig) []byte {
+	t.Helper()
+	data, err := yaml.Marshal(cfg)
+	require.NoError(t, err)
+	return data
+}
+
+// seedTwoLevelTenants creates a two-level tenant hierarchy: mspID (root) → childID.
+func seedTwoLevelTenants(t *testing.T, ctx context.Context, sm interface{ GetTenantStore() business.TenantStore }, mspID, childID string) {
+	t.Helper()
+	ts := sm.GetTenantStore()
+	require.NoError(t, ts.CreateTenant(ctx, &business.TenantData{
+		ID: mspID, Name: mspID, Status: business.TenantStatusActive,
+	}))
+	require.NoError(t, ts.CreateTenant(ctx, &business.TenantData{
+		ID: childID, Name: childID, ParentID: mspID, Status: business.TenantStatusActive,
+	}))
+}
+
+// TestGetConfiguration_CascadeMergedDelivery verifies that GetConfiguration (the steward
+// delivery path) performs a full tenant-cascade merge, not a most-specific-wins lookup.
+//
+// AC covered:
+//   - A steward in a child tenant receives a parent-tenant policy resource for which it has
+//     no device-level override.
+//   - A device-level resource with the same name overrides the parent resource.
+func TestGetConfiguration_CascadeMergedDelivery(t *testing.T) {
+	ctx := context.Background()
+	sm := pkgtesting.SetupTestStorage(t)
+	svc := NewConfigurationServiceV2(logging.NewNoopLogger(), sm, nil)
+
+	// Two-level hierarchy: msp (root) → client (child)
+	seedTwoLevelTenants(t, ctx, sm, "msp", "client")
+
+	cs := sm.GetConfigStore()
+
+	// MSP-level policy: two resources — one the device will inherit without override,
+	// one the device will override with its own version.
+	require.NoError(t, cs.StoreConfig(ctx, &cfgconfig.ConfigEntry{
+		Key: &cfgconfig.ConfigKey{TenantID: "msp", Namespace: "msp-policies", Name: "global"},
+		Data: marshalStewardConfigYAML(t, stewardconfig.StewardConfig{
+			Resources: []stewardconfig.ResourceConfig{
+				{Name: "msp-inherited", Module: "file", Config: map[string]interface{}{"path": "/etc/inherited.conf"}},
+				{Name: "shared-resource", Module: "file", Config: map[string]interface{}{"path": "/etc/parent.conf"}},
+			},
+		}),
+	}))
+
+	// Device-level config for steward-1 under client tenant.
+	// Includes "shared-resource" to test child-overrides-parent behaviour.
+	deviceCfg := createTestStewardConfig("steward-1")
+	deviceCfg.Resources = append(deviceCfg.Resources, stewardconfig.ResourceConfig{
+		Name: "shared-resource", Module: "file",
+		Config: map[string]interface{}{"path": "/etc/device.conf"},
+	})
+	// "file" is already in the Modules map from createTestStewardConfig; no missing-module error.
+	require.NoError(t, svc.SetConfiguration(ctx, "client", "steward-1", deviceCfg))
+
+	// Request config for steward-1 with the client tenant in context.
+	// controllerSvc is nil, so tenantID is read from ctxkeys.TenantID.
+	clientCtx := context.WithValue(ctx, ctxkeys.TenantID, "client")
+	resp, err := svc.GetConfiguration(clientCtx, &controller.ConfigRequest{StewardId: "steward-1"})
+	require.NoError(t, err)
+	require.Equal(t, common.Status_OK, resp.Status.Code)
+
+	retrieved, err := stewardconfig.FromProto(resp.Config.Config)
+	require.NoError(t, err)
+
+	byName := make(map[string]stewardconfig.ResourceConfig)
+	for _, r := range retrieved.Resources {
+		byName[r.Name] = r
+	}
+
+	t.Run("parent resource delivered when steward has no device-level override", func(t *testing.T) {
+		_, ok := byName["msp-inherited"]
+		assert.True(t, ok, "MSP-level resource 'msp-inherited' must be delivered to steward in child tenant")
+	})
+
+	t.Run("device-level resource overrides same-named parent resource", func(t *testing.T) {
+		r, ok := byName["shared-resource"]
+		require.True(t, ok, "'shared-resource' must appear in delivered config")
+		assert.Equal(t, "/etc/device.conf", r.Config["path"],
+			"device-level 'shared-resource' must override the MSP-level version")
+	})
+}
+
+// TestGetConfiguration_TenantIsolation verifies that the cascade merges only the steward's
+// own ancestor chain and never includes resources from sibling or unrelated tenants.
+//
+// AC covered: a test asserts tenant isolation.
+func TestGetConfiguration_TenantIsolation(t *testing.T) {
+	ctx := context.Background()
+	sm := pkgtesting.SetupTestStorage(t)
+	svc := NewConfigurationServiceV2(logging.NewNoopLogger(), sm, nil)
+
+	ts := sm.GetTenantStore()
+	// Two independent root tenants — no shared ancestry.
+	require.NoError(t, ts.CreateTenant(ctx, &business.TenantData{
+		ID: "msp-a", Name: "MSP A", Status: business.TenantStatusActive,
+	}))
+	require.NoError(t, ts.CreateTenant(ctx, &business.TenantData{
+		ID: "msp-b", Name: "MSP B", Status: business.TenantStatusActive,
+	}))
+
+	cs := sm.GetConfigStore()
+
+	// msp-a has an MSP-level policy that should be invisible to msp-b stewards.
+	require.NoError(t, cs.StoreConfig(ctx, &cfgconfig.ConfigEntry{
+		Key: &cfgconfig.ConfigKey{TenantID: "msp-a", Namespace: "msp-policies", Name: "global"},
+		Data: marshalStewardConfigYAML(t, stewardconfig.StewardConfig{
+			Resources: []stewardconfig.ResourceConfig{
+				{Name: "msp-a-policy", Module: "file", Config: map[string]interface{}{"path": "/etc/msp-a.conf"}},
+			},
+		}),
+	}))
+
+	// steward-b lives entirely within the msp-b tree; no relationship to msp-a.
+	stewardBCfg := createTestStewardConfig("steward-b")
+	require.NoError(t, svc.SetConfiguration(ctx, "msp-b", "steward-b", stewardBCfg))
+
+	mspBCtx := context.WithValue(ctx, ctxkeys.TenantID, "msp-b")
+	resp, err := svc.GetConfiguration(mspBCtx, &controller.ConfigRequest{StewardId: "steward-b"})
+	require.NoError(t, err)
+	require.Equal(t, common.Status_OK, resp.Status.Code)
+
+	retrieved, err := stewardconfig.FromProto(resp.Config.Config)
+	require.NoError(t, err)
+
+	for _, r := range retrieved.Resources {
+		assert.NotEqual(t, "msp-a-policy", r.Name,
+			"steward-b must not receive resources from msp-a's ancestor chain (tenant isolation violated)")
+	}
 }

--- a/features/controller/service/config_service_v2.go
+++ b/features/controller/service/config_service_v2.go
@@ -119,8 +119,10 @@ func (s *ConfigurationServiceV2) GetConfiguration(ctx context.Context, req *cont
 		tenantID = stewardInfo.TenantID
 	}
 
-	// Get configuration with inheritance from storage
-	stewardConfig, err := s.configManager.GetConfigurationWithInheritance(ctx, tenantID, req.StewardId)
+	// Resolve full tenant-cascade-merged effective config via InheritanceResolver.
+	// ResolveConfiguration walks the ancestor chain (MSP→Client→Group→Device),
+	// child resources overriding parent resources of the same name (Issue #1722).
+	effective, err := s.inheritanceResolver.ResolveConfiguration(ctx, tenantID, req.StewardId)
 	if err != nil {
 		s.logger.Debug("No configuration found for steward", "steward_id", logging.SanitizeLogValue(req.StewardId), "error", err)
 		return &controller.ConfigResponse{
@@ -130,9 +132,18 @@ func (s *ConfigurationServiceV2) GetConfiguration(ctx context.Context, req *cont
 			},
 		}, nil
 	}
+	if len(effective.Sources) == 0 {
+		s.logger.Debug("No configuration found for steward at any hierarchy level", "steward_id", logging.SanitizeLogValue(req.StewardId))
+		return &controller.ConfigResponse{
+			Status: &common.Status{
+				Code:    common.Status_NOT_FOUND,
+				Message: "No configuration found for steward",
+			},
+		}, nil
+	}
 
 	// Filter configuration by requested modules if specified
-	filteredConfig := s.filterConfigByModules(stewardConfig, req.Modules)
+	filteredConfig := s.filterConfigByModules(effective.Config, req.Modules)
 
 	// Convert Go struct to protobuf
 	protoConfig, err := stewardconfig.ToProto(filteredConfig)

--- a/features/controller/service/config_service_v2.go
+++ b/features/controller/service/config_service_v2.go
@@ -124,13 +124,24 @@ func (s *ConfigurationServiceV2) GetConfiguration(ctx context.Context, req *cont
 	// child resources overriding parent resources of the same name (Issue #1722).
 	effective, err := s.inheritanceResolver.ResolveConfiguration(ctx, tenantID, req.StewardId)
 	if err != nil {
-		s.logger.Debug("No configuration found for steward", "steward_id", logging.SanitizeLogValue(req.StewardId), "error", err)
-		return &controller.ConfigResponse{
-			Status: &common.Status{
-				Code:    common.Status_NOT_FOUND,
-				Message: "No configuration found for steward",
-			},
-		}, nil
+		// ResolveConfiguration walks the steward's tenant ancestor chain, which
+		// requires the tenant to exist as a full tenant-hierarchy record. A
+		// steward can be registered under a tenant that exists only as an
+		// identifier — created from a registration token, never promoted to a
+		// TenantData record — and such a tenant has no ancestor chain to walk.
+		// Fall back to delivering the device-level config directly so SyncConfig
+		// still serves the steward; the full cascade still applies whenever the
+		// tenant hierarchy is known. (Issue #1722)
+		effective = s.resolveDeviceLevelFallback(ctx, tenantID, req.StewardId)
+		if effective == nil {
+			s.logger.Debug("No configuration found for steward", "steward_id", logging.SanitizeLogValue(req.StewardId), "error", err)
+			return &controller.ConfigResponse{
+				Status: &common.Status{
+					Code:    common.Status_NOT_FOUND,
+					Message: "No configuration found for steward",
+				},
+			}, nil
+		}
 	}
 	if len(effective.Sources) == 0 {
 		s.logger.Debug("No configuration found for steward at any hierarchy level", "steward_id", logging.SanitizeLogValue(req.StewardId))
@@ -174,6 +185,39 @@ func (s *ConfigurationServiceV2) GetConfiguration(ctx context.Context, req *cont
 		Config:  &controller.SignedConfig{Config: protoConfig}, // Unsigned, QUIC handler will sign
 		Version: version,
 	}, nil
+}
+
+// resolveDeviceLevelFallback returns the steward's device-level configuration as an
+// EffectiveConfiguration when the full tenant cascade cannot be resolved because the
+// steward's tenant has no tenant-hierarchy record. It returns nil — leaving the caller
+// to report NOT_FOUND — when the tenant does exist (the cascade error is then a genuine
+// failure that must not be masked) or when no device-level config is stored for the
+// steward. (Issue #1722)
+func (s *ConfigurationServiceV2) resolveDeviceLevelFallback(ctx context.Context, tenantID, stewardID string) *config.EffectiveConfiguration {
+	if _, err := s.storageManager.GetTenantStore().GetTenant(ctx, tenantID); err == nil {
+		// The tenant exists as a full record, so the cascade failure is a real
+		// error — do not paper over it with a device-only fallback.
+		return nil
+	}
+
+	deviceCfg, err := s.configManager.GetConfiguration(ctx, tenantID, stewardID)
+	if err != nil {
+		return nil
+	}
+
+	return &config.EffectiveConfiguration{
+		StewardID: stewardID,
+		TenantID:  tenantID,
+		Config:    deviceCfg,
+		Sources: map[string]*config.InheritanceSource{
+			"steward.config": {
+				Level:    int(config.LevelDevice),
+				TenantID: tenantID,
+				Source:   "Device Configuration (tenant has no hierarchy record)",
+			},
+		},
+		GeneratedAt: time.Now(),
+	}
 }
 
 // SetConfiguration stores a configuration for a specific steward using ConfigStore

--- a/features/controller/transport/config_handler_test.go
+++ b/features/controller/transport/config_handler_test.go
@@ -26,6 +26,7 @@ import (
 	cfgcert "github.com/cfgis/cfgms/pkg/cert"
 	dataplaneTypes "github.com/cfgis/cfgms/pkg/dataplane/types"
 	"github.com/cfgis/cfgms/pkg/logging"
+	business "github.com/cfgis/cfgms/pkg/storage/interfaces/business"
 	pkgtesting "github.com/cfgis/cfgms/pkg/testing"
 )
 
@@ -92,10 +93,17 @@ func peerContextWithCA(t *testing.T, ca *cfgcert.CA, cn string) context.Context 
 
 // createTestService returns a ConfigurationServiceV2 backed by real flatfile+SQLite
 // storage rooted in a temporary directory that is cleaned up after the test.
+// A "default" tenant is seeded so that GetConfiguration (which routes through
+// InheritanceResolver) can resolve tenant paths for single-tenant test setups.
 func createTestService(t *testing.T) *service.ConfigurationServiceV2 {
 	t.Helper()
 	storageManager := pkgtesting.SetupTestStorage(t)
-	return service.NewConfigurationServiceV2(logging.NewNoopLogger(), storageManager, nil)
+	svc := service.NewConfigurationServiceV2(logging.NewNoopLogger(), storageManager, nil)
+	require.NoError(t, storageManager.GetTenantStore().CreateTenant(
+		context.Background(),
+		&business.TenantData{ID: "default", Name: "Default", Status: business.TenantStatusActive},
+	))
+	return svc
 }
 
 // minimalStewardConfig returns a valid StewardConfig for stewardID.


### PR DESCRIPTION
## Summary

- Replaces `GetConfigurationWithInheritance` (most-specific-wins, `stewards/` namespace only) in `GetConfiguration` with `InheritanceResolver.ResolveConfiguration` — the same full cascade the `/effective` read endpoint already uses
- MSP/Client/Group policy resources from a steward's ancestor tenant chain are now delivered during `SyncConfig`; device-level resources override same-named parent resources
- Adds `len(effective.Sources)==0` guard to preserve NOT_FOUND semantics for unconfigured stewards
- Seeds "default" tenant in test helpers (`config_service_test.go`, `transport/config_handler_test.go`) so single-tenant tests work with the resolver path

## Acceptance Criteria

- [x] Steward delivery path returns full tenant-cascade-merged effective config
- [x] A steward in a child tenant receives a parent-tenant policy resource it has no device-level override for
- [x] A device-level resource with the same name overrides the parent resource
- [x] `TestGetConfiguration_CascadeMergedDelivery` asserts both behaviours
- [x] `TestGetConfiguration_TenantIsolation` asserts cascade merges only the steward's own ancestor chain
- [x] `make test-agent-complete` passes

## Specialist Review Results

- **qa-test-runner**: PASS — all unit, integration, cross-platform compilation, linting, secret scan, architecture compliance gates passed
- **qa-code-reviewer**: PASS — no mocks, no t.Skip, substantive assertions on both happy and error paths
- **security-engineer**: PASS — tenant isolation structurally preserved, all input sanitized via SanitizeLogValue, gosec/Trivy/Nancy/staticcheck all passed, no blocking findings

Fixes #1722