### PR TITLE
build+ci: macOS .pkg installer built by CI, reads regtoken and CA fingerprint from plist (Issue #1707)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -325,13 +325,67 @@ jobs:
         gh release upload "$VERSION" \
           "bin/cfgms-steward-windows-${ARCH}.msi"
 
+  # Build macOS .pkg installers (amd64 and arm64)
+  build-macos-pkg:
+    name: Build macOS pkg (${{ matrix.arch }})
+    runs-on: macos-latest
+    permissions:
+      contents: write
+    timeout-minutes: 30
+    needs: create-release
+    strategy:
+      matrix:
+        arch: [amd64, arm64]
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      with:
+        # Release jobs only use the GH_TOKEN env for `gh release upload`;
+        # the git-config credential is not needed and must not persist into
+        # the workspace (zizmor artipacked / credential persistence).
+        persist-credentials: false
+
+    - name: Set up Go
+      uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+      with:
+        go-version: ${{ env.GO_VERSION }}
+        # Caching disabled: release artifacts must be built from a clean
+        # module set, never a cache a PR workflow could have poisoned
+        # (zizmor cache-poisoning).
+        cache: false
+
+    - name: Build macOS pkg
+      env:
+        VERSION: ${{ needs.create-release.outputs.version }}
+        ARCH: ${{ matrix.arch }}
+        # APPLE_SIGNING_IDENTITY and APPLE_NOTARIZATION_PROFILE are intentionally
+        # omitted here: CI release pkgs are unsigned generic artifacts consistent
+        # with the cross-platform release binaries. Operators who need signed pkgs
+        # run build/darwin/build-pkg.sh with their own Apple credentials.
+      run: |
+        bash build/darwin/build-pkg.sh \
+          --arch "$ARCH" \
+          --version "$VERSION"
+
+    - name: Upload pkg to release
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        VERSION: ${{ needs.create-release.outputs.version }}
+        ARCH: ${{ matrix.arch }}
+      run: |
+        # VERSION and ARCH are read from the env block above rather than
+        # interpolated inline with ${{ }} to avoid template injection into
+        # the shell (zizmor template-injection).
+        gh release upload "$VERSION" \
+          "bin/cfgms-steward-darwin-${ARCH}.pkg"
+
   # Back-merge release to develop
   back-merge-to-develop:
     name: Back-merge to Develop
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    needs: [create-release, build-binaries, build-windows-msi]
+    needs: [create-release, build-binaries, build-windows-msi, build-macos-pkg]
     if: success()
     steps:
     - name: Checkout repository
@@ -387,7 +441,7 @@ jobs:
     name: Release Summary
     runs-on: ubuntu-latest
     permissions: {}
-    needs: [create-release, build-binaries, build-windows-msi, generate-sbom, back-merge-to-develop]
+    needs: [create-release, build-binaries, build-windows-msi, build-macos-pkg, generate-sbom, back-merge-to-develop]
     if: always()
     steps:
     - name: Generate Release Summary
@@ -399,16 +453,18 @@ jobs:
         echo "|-----------|--------|" >> $GITHUB_STEP_SUMMARY
         echo "| Binaries | ${{ needs.build-binaries.result == 'success' && '✅ Built' || '❌ Failed' }} |" >> $GITHUB_STEP_SUMMARY
         echo "| Windows MSI | ${{ needs.build-windows-msi.result == 'success' && '✅ Built' || '❌ Failed' }} |" >> $GITHUB_STEP_SUMMARY
+        echo "| macOS pkg | ${{ needs.build-macos-pkg.result == 'success' && '✅ Built' || '❌ Failed' }} |" >> $GITHUB_STEP_SUMMARY
         echo "| SBOM | ${{ needs.generate-sbom.result == 'success' && '✅ Generated' || '❌ Failed' }} |" >> $GITHUB_STEP_SUMMARY
         echo "| Back-merge | ${{ needs.back-merge-to-develop.result == 'success' && '✅ Completed' || '⚠️ Check manually' }} |" >> $GITHUB_STEP_SUMMARY
         echo "" >> $GITHUB_STEP_SUMMARY
         echo "### Platforms" >> $GITHUB_STEP_SUMMARY
         echo "- Linux (AMD64, ARM64)" >> $GITHUB_STEP_SUMMARY
-        echo "- macOS (AMD64, ARM64)" >> $GITHUB_STEP_SUMMARY
+        echo "- macOS (AMD64, ARM64) — binaries + .pkg installers" >> $GITHUB_STEP_SUMMARY
         echo "- Windows (AMD64, ARM64) — binaries + MSI installers" >> $GITHUB_STEP_SUMMARY
         echo "" >> $GITHUB_STEP_SUMMARY
         echo "### Release Assets" >> $GITHUB_STEP_SUMMARY
         echo "- Cross-platform binaries (controller, steward, CLI)" >> $GITHUB_STEP_SUMMARY
+        echo "- macOS pkg installers (cfgms-steward-darwin-amd64.pkg, cfgms-steward-darwin-arm64.pkg)" >> $GITHUB_STEP_SUMMARY
         echo "- Windows MSI installers (cfgms-steward-windows-amd64.msi, cfgms-steward-windows-arm64.msi)" >> $GITHUB_STEP_SUMMARY
         echo "- SHA256 checksums for verification" >> $GITHUB_STEP_SUMMARY
         echo "- SBOM files (SPDX-JSON format)" >> $GITHUB_STEP_SUMMARY

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build test test-unit test-integration-factory test-watch test-commit test-complete test-e2e-local test-e2e-parallel test-e2e-ci test-e2e-controller test-e2e-scenarios test-e2e-fleet test-ci test-integration test-security test-performance test-performance-baseline test-data-consistency test-docker test-cross-feature-integration test-failure-propagation proto proto-gen lint clean security-trivy security-deps security-scan security-check security-precommit check-architecture check-license-headers generate-test-certificates build-msi-windows
+.PHONY: build test test-unit test-integration-factory test-watch test-commit test-complete test-e2e-local test-e2e-parallel test-e2e-ci test-e2e-controller test-e2e-scenarios test-e2e-fleet test-ci test-integration test-security test-performance test-performance-baseline test-data-consistency test-docker test-cross-feature-integration test-failure-propagation proto proto-gen lint clean security-trivy security-deps security-scan security-check security-precommit check-architecture check-license-headers generate-test-certificates build-msi-windows build-pkg-darwin
 
 # Use bash for all recipe commands (required for credential loading scripts)
 SHELL := /bin/bash
@@ -211,6 +211,29 @@ build-msi-windows:
 		-Version "$(or $(VERSION),0.0.0)" \
 		$$SIGN_ARG
 	@echo "✅ MSI built: bin/cfgms-steward-windows-amd64.msi"
+
+# Build macOS .pkg installer for cfgms-steward (amd64 and arm64).
+# Requires Xcode Command Line Tools (pkgbuild + productbuild).
+# Must be run on macOS; cross-building is not supported by pkgbuild.
+#
+# Optional env vars (see build/darwin/build-pkg.sh for details):
+#   APPLE_SIGNING_IDENTITY  — Developer ID Installer certificate name (code signing)
+#   APPLE_NOTARIZATION_PROFILE — keychain profile name (notarization, requires signing)
+#
+# Examples:
+#   make build-pkg-darwin VERSION=v1.0.0
+#   APPLE_SIGNING_IDENTITY="Developer ID Installer: Acme (XXXXXXXXXX)" \
+#     make build-pkg-darwin VERSION=v1.0.0
+build-pkg-darwin:
+	@echo "🍎 Building macOS .pkg installer"
+	@echo "================================="
+	@if [[ "$$(uname)" != "Darwin" ]]; then \
+		echo "❌ build-pkg-darwin must be run on macOS (pkgbuild requires macOS)."; \
+		exit 1; \
+	fi
+	@bash build/darwin/build-pkg.sh --arch amd64 --version "$(or $(VERSION),0.0.0)"
+	@bash build/darwin/build-pkg.sh --arch arm64 --version "$(or $(VERSION),0.0.0)"
+	@echo "✅ Packages built: bin/cfgms-steward-darwin-amd64.pkg  bin/cfgms-steward-darwin-arm64.pkg"
 
 # Smart test - core modules + changed modules only
 test: fix-git-bare

--- a/build/darwin/Distribution.xml
+++ b/build/darwin/Distribution.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!-- Copyright 2026 Jordan Ritz -->
+<!--
+  Distribution.xml — productbuild distribution descriptor for cfgms-steward.
+
+  Produces a flat macOS .pkg suitable for silent MDM deployment (Jamf / Mosyle).
+  No interactive choices are presented; the package installs silently with:
+    sudo installer -pkg cfgms-steward-darwin-<arch>.pkg -target /
+
+  The postinstall script reads /Library/Application Support/cfgms/steward-deploy.plist
+  (deployed by the MDM before the .pkg) to obtain REGTOKEN, CA_FINGERPRINT, and
+  CA_CERT_PATH, then calls cfgms-steward install to register the launchd service.
+-->
+<installer-gui-script minSpecVersion="2">
+    <title>CFGMS Steward</title>
+    <options customize="never" require-scripts="false" rootVolumeOnly="true"/>
+    <choices-outline>
+        <line choice="default">
+            <line choice="com.cfgms.steward"/>
+        </line>
+    </choices-outline>
+    <choice id="default"/>
+    <choice id="com.cfgms.steward" visible="false">
+        <pkg-ref id="com.cfgms.steward"/>
+    </choice>
+    <pkg-ref id="com.cfgms.steward" version="0" onConclusion="none">cfgms-steward.pkg</pkg-ref>
+</installer-gui-script>

--- a/build/darwin/build-pkg.sh
+++ b/build/darwin/build-pkg.sh
@@ -1,0 +1,212 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Jordan Ritz
+#
+# build-pkg.sh — Build a macOS .pkg installer for cfgms-steward.
+#
+# Prerequisites:
+#   - Go toolchain (for building the binary when --binary-path is not supplied)
+#   - Xcode Command Line Tools (pkgbuild + productbuild, always present on macOS)
+#   - xcrun notarytool (Xcode 13+, for notarization)
+#
+# Code signing (optional):
+#   Set APPLE_SIGNING_IDENTITY to a Developer ID Installer certificate name
+#   (e.g. "Developer ID Installer: ACME Corp (XXXXXXXXXX)") to sign the pkg.
+#   Without it the pkg is produced unsigned and a warning is printed.
+#
+# Notarization (optional):
+#   Set APPLE_NOTARIZATION_PROFILE to a keychain profile created with:
+#     xcrun notarytool store-credentials <profile-name> --apple-id ... --team-id ...
+#   Notarization is skipped when the variable is absent or empty.
+#
+# Usage examples:
+#   # Build amd64 pkg:
+#   bash build/darwin/build-pkg.sh --arch amd64 --version v1.0.0
+#
+#   # Build arm64 pkg with signing:
+#   APPLE_SIGNING_IDENTITY="Developer ID Installer: Acme (XXXXXXXXXX)" \
+#     bash build/darwin/build-pkg.sh --arch arm64 --version v1.0.0
+#
+#   # Use a pre-built binary:
+#   bash build/darwin/build-pkg.sh \
+#     --arch amd64 \
+#     --version v1.0.0 \
+#     --binary-path ./bin/cfgms-steward-darwin-amd64
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+# ── Defaults ──────────────────────────────────────────────────────────────────
+
+ARCH="amd64"
+VERSION="0.0.0"
+BINARY_PATH=""
+CONTROLLER_URL=""
+
+# ── Argument parsing ──────────────────────────────────────────────────────────
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --arch)          ARCH="$2";           shift 2 ;;
+        --version)       VERSION="$2";        shift 2 ;;
+        --binary-path)   BINARY_PATH="$2";    shift 2 ;;
+        --controller-url) CONTROLLER_URL="$2"; shift 2 ;;
+        *) echo "Unknown argument: $1" >&2; exit 1 ;;
+    esac
+done
+
+# Strip leading 'v' from version for pkgbuild (requires N.N.N format).
+PKG_VERSION="${VERSION#v}"
+if ! [[ "$PKG_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9] ]]; then
+    PKG_VERSION="0.0.0"
+fi
+
+echo "=== CFGMS Steward macOS .pkg Build ==="
+echo "Version:        $VERSION"
+echo "Pkg version:    $PKG_VERSION"
+echo "ControllerURL:  ${CONTROLLER_URL:-(not set — generic build)}"
+echo "Arch:           $ARCH"
+
+# ── Step 1: Build the binary (when not pre-supplied) ─────────────────────────
+
+if [[ -z "$BINARY_PATH" ]]; then
+    echo ""
+    echo "Building cfgms-steward binary for darwin/$ARCH..."
+
+    BINARY_NAME="cfgms-steward-darwin-$ARCH"
+    BINARY_PATH="$REPO_ROOT/bin/$BINARY_NAME"
+    mkdir -p "$(dirname "$BINARY_PATH")"
+
+    VERSION_FLAG="-X github.com/cfgis/cfgms/pkg/version.Version=$VERSION"
+    if [[ -n "$CONTROLLER_URL" ]]; then
+        LD_FLAGS="-s -w -X main.ControllerURL=$CONTROLLER_URL $VERSION_FLAG"
+    else
+        LD_FLAGS="-s -w $VERSION_FLAG"
+    fi
+
+    GOOS=darwin GOARCH="$ARCH" CGO_ENABLED=0 go build \
+        -trimpath \
+        -ldflags "$LD_FLAGS" \
+        -o "$BINARY_PATH" \
+        "$REPO_ROOT/cmd/steward"
+
+    echo "  Binary: $BINARY_PATH"
+else
+    echo "Using pre-built binary: $BINARY_PATH"
+    if [[ ! -f "$BINARY_PATH" ]]; then
+        echo "ERROR: Binary not found: $BINARY_PATH" >&2
+        exit 1
+    fi
+fi
+
+# ── Step 2: Assemble the package payload ──────────────────────────────────────
+# pkgbuild expects a directory tree that mirrors the target filesystem.
+
+echo ""
+echo "Assembling package payload..."
+
+WORK_DIR="$(mktemp -d)"
+trap 'rm -rf "$WORK_DIR"' EXIT
+
+PAYLOAD_DIR="$WORK_DIR/payload"
+SCRIPTS_DIR="$WORK_DIR/scripts"
+mkdir -p "$PAYLOAD_DIR/usr/local/bin"
+mkdir -p "$SCRIPTS_DIR"
+
+# Install the binary into the payload tree.
+cp "$BINARY_PATH" "$PAYLOAD_DIR/usr/local/bin/cfgms-steward"
+chmod 755 "$PAYLOAD_DIR/usr/local/bin/cfgms-steward"
+
+# Copy the postinstall script.
+cp "$SCRIPT_DIR/scripts/postinstall" "$SCRIPTS_DIR/postinstall"
+chmod 755 "$SCRIPTS_DIR/postinstall"
+
+echo "  Payload: $PAYLOAD_DIR/usr/local/bin/cfgms-steward"
+echo "  Scripts: $SCRIPTS_DIR/postinstall"
+
+# ── Step 3: Build the component pkg with pkgbuild ─────────────────────────────
+
+COMPONENT_PKG="$WORK_DIR/cfgms-steward.pkg"
+OUTPUT_PKG="$REPO_ROOT/bin/cfgms-steward-darwin-$ARCH.pkg"
+mkdir -p "$REPO_ROOT/bin"
+
+echo ""
+echo "Building component pkg..."
+
+pkgbuild \
+    --root "$PAYLOAD_DIR" \
+    --scripts "$SCRIPTS_DIR" \
+    --identifier "com.cfgms.steward" \
+    --version "$PKG_VERSION" \
+    --install-location "/" \
+    "$COMPONENT_PKG"
+
+echo "  Component pkg: $COMPONENT_PKG"
+
+# ── Step 4: Wrap in a distribution pkg with productbuild ─────────────────────
+
+echo ""
+echo "Building distribution pkg..."
+
+productbuild \
+    --distribution "$SCRIPT_DIR/Distribution.xml" \
+    --package-path "$WORK_DIR" \
+    --version "$PKG_VERSION" \
+    "$OUTPUT_PKG"
+
+echo "  Distribution pkg: $OUTPUT_PKG"
+
+# ── Step 5: Code signing (optional) ──────────────────────────────────────────
+
+if [[ -n "${APPLE_SIGNING_IDENTITY:-}" ]]; then
+    echo ""
+    echo "Signing pkg with identity: $APPLE_SIGNING_IDENTITY"
+
+    SIGNED_PKG="$WORK_DIR/cfgms-steward-darwin-$ARCH-signed.pkg"
+    productsign \
+        --sign "$APPLE_SIGNING_IDENTITY" \
+        "$OUTPUT_PKG" \
+        "$SIGNED_PKG"
+
+    mv "$SIGNED_PKG" "$OUTPUT_PKG"
+    echo "  Pkg signed."
+else
+    echo ""
+    echo "WARNING: APPLE_SIGNING_IDENTITY not set — pkg is unsigned." >&2
+    echo "         macOS Gatekeeper may block unsigned packages on non-MDM endpoints." >&2
+    echo "         For production: set APPLE_SIGNING_IDENTITY to your Developer ID Installer certificate." >&2
+fi
+
+# ── Step 6: Notarization (optional) ──────────────────────────────────────────
+
+if [[ -n "${APPLE_NOTARIZATION_PROFILE:-}" ]]; then
+    echo ""
+    echo "Submitting for notarization (profile: $APPLE_NOTARIZATION_PROFILE)..."
+
+    xcrun notarytool submit "$OUTPUT_PKG" \
+        --keychain-profile "$APPLE_NOTARIZATION_PROFILE" \
+        --wait
+
+    xcrun stapler staple "$OUTPUT_PKG"
+    echo "  Pkg notarized and stapled."
+else
+    echo ""
+    echo "WARNING: APPLE_NOTARIZATION_PROFILE not set — skipping notarization." >&2
+    echo "         Notarized packages are required for distribution outside MDM on macOS 10.15+." >&2
+fi
+
+# ── Summary ───────────────────────────────────────────────────────────────────
+
+echo ""
+echo "=== Build Complete ==="
+echo "pkg: $OUTPUT_PKG"
+echo ""
+echo "Deploy via MDM (Jamf / Mosyle):"
+echo "  1. Push steward-deploy.plist to /Library/Application Support/cfgms/steward-deploy.plist"
+echo "     Plist keys: REGTOKEN (required), CA_FINGERPRINT, CA_CERT_PATH (optional)"
+echo "  2. Deploy $(basename "$OUTPUT_PKG") as a managed package"
+echo ""
+echo "Deploy manually (testing):"
+echo "  sudo installer -pkg $(basename "$OUTPUT_PKG") -target /"

--- a/build/darwin/build-pkg_test.sh
+++ b/build/darwin/build-pkg_test.sh
@@ -1,0 +1,175 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Jordan Ritz
+#
+# build-pkg_test.sh — Integration test for the macOS postinstall script.
+#
+# Tests that the postinstall script reads steward-deploy.plist correctly and
+# passes the expected arguments to cfgms-steward install.
+#
+# This test is macOS-only (uses PlistBuddy). On other platforms it prints
+# "skip: darwin only" and exits 0.
+#
+# Usage:
+#   bash build/darwin/build-pkg_test.sh
+
+[[ "$(uname)" == "Darwin" ]] || { echo "skip: darwin only"; exit 0; }
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+POSTINSTALL="$SCRIPT_DIR/scripts/postinstall"
+
+PASS=0
+FAIL=0
+
+pass() { echo "PASS: $1"; ((PASS++)) || true; }
+fail() { echo "FAIL: $1"; ((FAIL++)) || true; }
+
+# ── Helper: create a temp directory for each test case ───────────────────────
+
+run_postinstall() {
+    local plist_path="$1"
+    local install_prefix="$2"
+    shift 2
+
+    CFGMS_DEPLOY_PLIST="$plist_path" \
+    CFGMS_INSTALL_PREFIX="$install_prefix" \
+    bash "$POSTINSTALL" "$@" 2>&1
+}
+
+write_plist() {
+    local path="$1"
+    local regtoken="$2"
+    local fingerprint="${3:-}"
+    local ca_cert_path="${4:-}"
+
+    /usr/libexec/PlistBuddy -c "Clear dict" "$path" 2>/dev/null || true
+    /usr/libexec/PlistBuddy -c "Add :REGTOKEN string $regtoken" "$path"
+    if [[ -n "$fingerprint" ]]; then
+        /usr/libexec/PlistBuddy -c "Add :CA_FINGERPRINT string $fingerprint" "$path"
+    fi
+    if [[ -n "$ca_cert_path" ]]; then
+        /usr/libexec/PlistBuddy -c "Add :CA_CERT_PATH string $ca_cert_path" "$path"
+    fi
+}
+
+# ── Test fixture: mock cfgms-steward binary ───────────────────────────────────
+# The mock binary records all arguments to a file so tests can assert them.
+
+make_mock_binary() {
+    local dir="$1"
+    local record_file="$dir/recorded-args"
+    local binary="$dir/usr/local/bin/cfgms-steward"
+
+    mkdir -p "$(dirname "$binary")"
+    cat > "$binary" <<EOF
+#!/bin/bash
+echo "\$@" > "$record_file"
+EOF
+    chmod +x "$binary"
+    echo "$record_file"
+}
+
+# ── Test 1: REGTOKEN only — calls install with --regtoken ────────────────────
+
+T=$(mktemp -d)
+trap 'rm -rf "$T"' EXIT
+
+PLIST="$T/steward-deploy.plist"
+write_plist "$PLIST" "tok-abc-123"
+ARGS_FILE="$(make_mock_binary "$T")"
+
+OUTPUT="$(run_postinstall "$PLIST" "$T")"
+RECORDED="$(cat "$ARGS_FILE")"
+
+if [[ "$RECORDED" == "install --regtoken tok-abc-123" ]]; then
+    pass "test1: regtoken-only passes correct args"
+else
+    fail "test1: expected 'install --regtoken tok-abc-123', got '$RECORDED'"
+fi
+
+# ── Test 2: REGTOKEN + CA_FINGERPRINT — adds --fingerprint ──────────────────
+
+T2=$(mktemp -d)
+
+PLIST2="$T2/steward-deploy.plist"
+write_plist "$PLIST2" "tok-xyz" "aabbcc1122"
+ARGS_FILE2="$(make_mock_binary "$T2")"
+
+run_postinstall "$PLIST2" "$T2" >/dev/null
+RECORDED2="$(cat "$ARGS_FILE2")"
+
+if [[ "$RECORDED2" == "install --regtoken tok-xyz --fingerprint aabbcc1122" ]]; then
+    pass "test2: regtoken+fingerprint passes correct args"
+else
+    fail "test2: expected 'install --regtoken tok-xyz --fingerprint aabbcc1122', got '$RECORDED2'"
+fi
+
+rm -rf "$T2"
+
+# ── Test 3: All fields — adds --ca-cert ──────────────────────────────────────
+
+T3=$(mktemp -d)
+
+PLIST3="$T3/steward-deploy.plist"
+write_plist "$PLIST3" "tok-full" "ddeeff3344" "/etc/cfgms/controller-ca.crt"
+ARGS_FILE3="$(make_mock_binary "$T3")"
+
+run_postinstall "$PLIST3" "$T3" >/dev/null
+RECORDED3="$(cat "$ARGS_FILE3")"
+
+EXPECTED3="install --regtoken tok-full --fingerprint ddeeff3344 --ca-cert /etc/cfgms/controller-ca.crt"
+if [[ "$RECORDED3" == "$EXPECTED3" ]]; then
+    pass "test3: all fields passes correct args"
+else
+    fail "test3: expected '$EXPECTED3', got '$RECORDED3'"
+fi
+
+rm -rf "$T3"
+
+# ── Test 4: Missing plist — exits non-zero with error message ────────────────
+
+T4=$(mktemp -d)
+make_mock_binary "$T4" >/dev/null
+
+# Capture output separately: with pipefail, piping a failing command into grep
+# would propagate the non-zero exit code even when grep succeeds.
+T4_OUTPUT="$(run_postinstall "$T4/does-not-exist.plist" "$T4" 2>&1 || true)"
+if echo "$T4_OUTPUT" | grep -q "not found"; then
+    pass "test4: missing plist produces error message"
+else
+    fail "test4: expected 'not found' in output for missing plist (got: '$T4_OUTPUT')"
+fi
+
+rm -rf "$T4"
+
+# ── Test 5: Empty REGTOKEN — exits non-zero with error message ───────────────
+
+T5=$(mktemp -d)
+PLIST5="$T5/steward-deploy.plist"
+
+# Write a plist with no REGTOKEN key at all.
+/usr/libexec/PlistBuddy -c "Clear dict" "$PLIST5" 2>/dev/null || true
+/usr/libexec/PlistBuddy -c "Add :CA_FINGERPRINT string aabbcc" "$PLIST5"
+
+make_mock_binary "$T5" >/dev/null
+
+# Capture output separately: same pipefail reason as test 4.
+T5_OUTPUT="$(run_postinstall "$PLIST5" "$T5" 2>&1 || true)"
+if echo "$T5_OUTPUT" | grep -q "REGTOKEN"; then
+    pass "test5: missing REGTOKEN produces error message"
+else
+    fail "test5: expected 'REGTOKEN' in output for missing token (got: '$T5_OUTPUT')"
+fi
+
+rm -rf "$T5"
+
+# ── Summary ───────────────────────────────────────────────────────────────────
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+
+if [[ $FAIL -gt 0 ]]; then
+    exit 1
+fi

--- a/build/darwin/scripts/postinstall
+++ b/build/darwin/scripts/postinstall
@@ -1,0 +1,79 @@
+#!/bin/bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Jordan Ritz
+#
+# postinstall — runs as root during macOS .pkg installation.
+#
+# Reads deployment parameters from the companion plist file deployed by the MDM,
+# then calls cfgms-steward install to register the launchd service.
+#
+# Plist location (in priority order):
+#   1. $CFGMS_DEPLOY_PLIST env var (overrides default — used in tests)
+#   2. /Library/Application Support/cfgms/steward-deploy.plist (MDM-deployed)
+#
+# Plist format (Apple XML plist <dict>):
+#   REGTOKEN       — required; one-time registration token from the controller
+#   CA_FINGERPRINT — optional; SHA-256 hex fingerprint for private-CA TOFU
+#   CA_CERT_PATH   — optional; path to controller CA cert PEM for private-CA installs
+#
+# CFGMS_INSTALL_PREFIX — optional; prefix for the installed binary path (tests only)
+
+set -euo pipefail
+
+# ── Locate the plist ──────────────────────────────────────────────────────────
+
+DEFAULT_PLIST="/Library/Application Support/cfgms/steward-deploy.plist"
+PLIST="${CFGMS_DEPLOY_PLIST:-$DEFAULT_PLIST}"
+
+if [[ ! -f "$PLIST" ]]; then
+    echo "cfgms postinstall: ERROR — deployment plist not found: $PLIST" >&2
+    echo "  Deploy steward-deploy.plist via MDM before installing the .pkg." >&2
+    echo "  Expected plist keys: REGTOKEN (required), CA_FINGERPRINT, CA_CERT_PATH (optional)." >&2
+    exit 1
+fi
+
+# ── Extract keys from plist ───────────────────────────────────────────────────
+# Use PlistBuddy (always present on macOS) to read values by key.
+
+read_plist_key() {
+    local key="$1"
+    /usr/libexec/PlistBuddy -c "Print :$key" "$PLIST" 2>/dev/null || true
+}
+
+REGTOKEN="$(read_plist_key REGTOKEN)"
+CA_FINGERPRINT="$(read_plist_key CA_FINGERPRINT)"
+CA_CERT_PATH="$(read_plist_key CA_CERT_PATH)"
+
+if [[ -z "$REGTOKEN" ]]; then
+    echo "cfgms postinstall: ERROR — REGTOKEN is missing or empty in: $PLIST" >&2
+    exit 1
+fi
+
+# ── Locate the installed binary ───────────────────────────────────────────────
+# CFGMS_INSTALL_PREFIX lets tests redirect the binary path without root access.
+
+INSTALL_PREFIX="${CFGMS_INSTALL_PREFIX:-}"
+BINARY_PATH="${INSTALL_PREFIX}/usr/local/bin/cfgms-steward"
+
+if [[ ! -x "$BINARY_PATH" ]]; then
+    echo "cfgms postinstall: ERROR — binary not found or not executable: $BINARY_PATH" >&2
+    exit 1
+fi
+
+# ── Call cfgms-steward install ────────────────────────────────────────────────
+
+echo "cfgms postinstall: registering steward service..."
+
+INSTALL_ARGS=(install --regtoken "$REGTOKEN")
+
+if [[ -n "$CA_FINGERPRINT" ]]; then
+    INSTALL_ARGS+=(--fingerprint "$CA_FINGERPRINT")
+fi
+
+if [[ -n "$CA_CERT_PATH" ]]; then
+    INSTALL_ARGS+=(--ca-cert "$CA_CERT_PATH")
+fi
+
+"$BINARY_PATH" "${INSTALL_ARGS[@]}"
+
+echo "cfgms postinstall: done."


### PR DESCRIPTION
## Summary

- Adds `build/darwin/build-pkg.sh` that cross-compiles the steward for darwin/amd64 and darwin/arm64 and wraps each binary into a flat macOS `.pkg` using `pkgbuild` + `productbuild`; signs with `productsign` and notarizes with `xcrun notarytool` when Apple credentials are present (warns and continues when absent)
- Adds `build/darwin/scripts/postinstall` that reads `steward-deploy.plist` (MDM-deployed by the operator before the `.pkg`) via PlistBuddy and calls `cfgms-steward install --regtoken ... [--fingerprint ...] [--ca-cert ...]` with no interactive prompts
- Adds `build-macos-pkg` CI job to `release.yml` (matrix: amd64/arm64) that uploads `.pkg` files to the GitHub release; zizmor mitigations applied (persist-credentials: false, cache: false, env vars for shell args)

Fixes #1707

## Test plan

- [ ] `bash build/darwin/build-pkg_test.sh` — passes on macOS (5/5 tests); skips on Linux
- [ ] `bash -n build/darwin/build-pkg.sh && bash -n build/darwin/scripts/postinstall` — syntax clean on Linux CI
- [ ] `make test-complete` passes (141/142 pre-existing script tests pass; 1 failure in `trust_boundary_test.sh` is a pre-existing live GitHub API timing flap confirmed by running without this story's changes)

## Specialist review results

- **Security (PASS)**: No blocking issues. 3 LOW warnings (all acknowledged): plist values reach binary via quoted argv array (correct); Distribution.xml welcome.html reference removed; CONTROLLER_URL ldflags injection not exercised by CI. zizmor patterns correct. Automated scans (security-precommit, check-architecture, security-scan) all PASS.
- **QA Code Review (PASS after fix)**: Two blocking issues found and fixed — tests 4 and 5 in `build-pkg_test.sh` used `|` pipe from a failing command under `set -euo pipefail`, causing the error-path tests to always report FAIL. Fixed by capturing output into a variable with `|| true` before grepping.
- **QA Test Runner (PASS for story changes)**: 141/142 script tests pass. Single failure (`trust_boundary` phase2 step b) is a pre-existing live GitHub API timing flap confirmed present on `develop` before this story's changes were applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)