### PR TITLE
registration: convert token model to perennial per-tenant with immediate-invalidation rotation (Issue #1690)

### DIFF
--- a/cmd/cfg/cmd/api_client.go
+++ b/cmd/cfg/cmd/api_client.go
@@ -35,16 +35,15 @@ type APIClientConfig struct {
 	ServerName    string // Server name for TLS verification (extracted from URL if empty)
 }
 
-// TokenCreateRequest represents the request body for creating a registration token
+// APITokenCreateRequest represents the request body for creating a registration token
 type APITokenCreateRequest struct {
 	TenantID      string `json:"tenant_id"`
 	ControllerURL string `json:"controller_url"`
 	Group         string `json:"group,omitempty"`
 	ExpiresIn     string `json:"expires_in,omitempty"`
-	SingleUse     bool   `json:"single_use,omitempty"`
 }
 
-// TokenResponse represents a registration token in API responses
+// APITokenResponse represents a registration token in API responses
 type APITokenResponse struct {
 	Token         string  `json:"token"`
 	TenantID      string  `json:"tenant_id"`
@@ -52,9 +51,6 @@ type APITokenResponse struct {
 	Group         string  `json:"group,omitempty"`
 	CreatedAt     string  `json:"created_at"`
 	ExpiresAt     *string `json:"expires_at,omitempty"`
-	SingleUse     bool    `json:"single_use"`
-	UsedAt        *string `json:"used_at,omitempty"`
-	UsedBy        string  `json:"used_by,omitempty"`
 	Revoked       bool    `json:"revoked"`
 	RevokedAt     *string `json:"revoked_at,omitempty"`
 }
@@ -210,6 +206,37 @@ func (c *APIClient) RevokeToken(ctx context.Context, tokenStr string) (*APIToken
 	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
+		return nil, c.parseError(resp)
+	}
+
+	var tokenResp APITokenResponse
+	if err := json.NewDecoder(resp.Body).Decode(&tokenResp); err != nil {
+		return nil, fmt.Errorf("failed to decode response: %w", err)
+	}
+
+	return &tokenResp, nil
+}
+
+// APIRotateTokenRequest is the optional request body for the rotate endpoint.
+type APIRotateTokenRequest struct {
+	Group string `json:"group,omitempty"`
+}
+
+// RotateToken atomically revokes all prior tokens for a tenant+group and returns the new token.
+func (c *APIClient) RotateToken(ctx context.Context, tenantID, group string) (*APITokenResponse, error) {
+	req := &APIRotateTokenRequest{Group: group}
+	body, err := json.Marshal(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal request: %w", err)
+	}
+
+	resp, err := c.doRequest(ctx, "POST", "/api/v1/registration/tokens/"+tenantID+"/rotate", bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusCreated {
 		return nil, c.parseError(resp)
 	}
 

--- a/cmd/cfg/cmd/api_client_test.go
+++ b/cmd/cfg/cmd/api_client_test.go
@@ -174,7 +174,6 @@ func TestAPIClientCreateToken(t *testing.T) {
 				TenantID:      req.TenantID,
 				ControllerURL: req.ControllerURL,
 				CreatedAt:     "2025-01-01T00:00:00Z",
-				SingleUse:     false,
 				Revoked:       false,
 			}
 
@@ -422,6 +421,62 @@ func TestAPIClientRevokeToken(t *testing.T) {
 
 		assert.True(t, resp.Revoked)
 		assert.NotNil(t, resp.RevokedAt)
+	})
+}
+
+func TestAPIClientRotateToken(t *testing.T) {
+	t.Run("rotate returns new token", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "POST", r.Method)
+			assert.Equal(t, "/api/v1/registration/tokens/test-tenant/rotate", r.URL.Path)
+
+			var body APIRotateTokenRequest
+			_ = json.NewDecoder(r.Body).Decode(&body)
+			assert.Equal(t, "production", body.Group)
+
+			resp := APITokenResponse{
+				Token:         "newtoken123",
+				TenantID:      "test-tenant",
+				ControllerURL: "controller:4433",
+				Group:         "production",
+				CreatedAt:     "2025-01-01T00:00:00Z",
+				Revoked:       false,
+			}
+
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusCreated)
+			_ = json.NewEncoder(w).Encode(resp)
+		}))
+		defer server.Close()
+
+		cfg := &APIClientConfig{BaseURL: server.URL, APIKey: "test-key", TLSInsecure: true}
+		client, err := NewAPIClient(cfg)
+		require.NoError(t, err)
+
+		resp, err := client.RotateToken(context.Background(), "test-tenant", "production")
+		require.NoError(t, err)
+
+		assert.Equal(t, "newtoken123", resp.Token)
+		assert.Equal(t, "test-tenant", resp.TenantID)
+		assert.Equal(t, "production", resp.Group)
+	})
+
+	t.Run("no active tokens returns error", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = w.Write([]byte(`{"error":"no active tokens found for tenant"}`))
+		}))
+		defer server.Close()
+
+		cfg := &APIClientConfig{BaseURL: server.URL, TLSInsecure: true}
+		client, err := NewAPIClient(cfg)
+		require.NoError(t, err)
+
+		resp, err := client.RotateToken(context.Background(), "empty-tenant", "")
+		assert.Nil(t, resp)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "no active tokens found")
 	})
 }
 

--- a/cmd/cfg/cmd/token.go
+++ b/cmd/cfg/cmd/token.go
@@ -18,7 +18,6 @@ var (
 	tokenControllerURL string
 	tokenGroup         string
 	tokenExpiresIn     string
-	tokenSingleUse     bool
 	tokenJSONOutput    bool
 
 	// API connection flags
@@ -35,8 +34,11 @@ var tokenCmd = &cobra.Command{
 	Long: `Manage registration tokens for steward deployment.
 
 Registration tokens are short API key-style strings that stewards use to
-auto-register with the controller. Tokens contain tenant information and
-can be time-limited, single-use, and revocable.
+auto-register with the controller. Tokens are perennial (survive multiple
+registrations), time-limited (optional), and revocable.
+
+Use 'cfg token rotate' to atomically replace the active token for a
+tenant/group with a fresh one, invalidating the old one immediately.
 
 This command communicates with the controller's REST API to manage tokens.
 The controller URL and API key can be provided via flags or environment variables:
@@ -49,8 +51,8 @@ Examples:
   # Create a token that expires in 7 days
   cfg token create --tenant-id=acme-corp --controller-url=controller.acme.com:4433 --expires=7d
 
-  # Create a single-use token for production group
-  cfg token create --tenant-id=acme-corp --controller-url=controller.acme.com:4433 --group=production --single-use
+  # Rotate the active token for a tenant/group
+  cfg token rotate --tenant-id=acme-corp --group=production
 
   # List all tokens for a tenant
   cfg token list --tenant-id=acme-corp
@@ -66,7 +68,8 @@ var tokenCreateCmd = &cobra.Command{
 	Long: `Create a new registration token for steward deployment.
 
 The token will be a bare base32-encoded string (e.g., abcdefghijklmnopqrstuvwxyz)
-that stewards can use to auto-register with the controller.
+that stewards can use to auto-register with the controller. Tokens are perennial:
+they survive multiple registrations until explicitly revoked or rotated.
 
 Expiration formats:
   - "24h" = 24 hours
@@ -78,12 +81,27 @@ Examples:
   # 7-day expiring token
   cfg token create --tenant-id=acme-corp --controller-url=controller.acme.com:4433 --expires=7d
 
-  # Single-use token
-  cfg token create --tenant-id=acme-corp --controller-url=controller.acme.com:4433 --single-use
-
   # Token for specific group
   cfg token create --tenant-id=acme-corp --controller-url=controller.acme.com:4433 --group=production`,
 	RunE: runTokenCreate,
+}
+
+// tokenRotateCmd represents the token rotate command
+var tokenRotateCmd = &cobra.Command{
+	Use:   "rotate",
+	Short: "Rotate the active token for a tenant/group",
+	Long: `Atomically replace the active registration token for a tenant/group.
+
+The old token is revoked and a new one is created in a single transaction,
+ensuring no window where a device could register with neither token.
+
+Examples:
+  # Rotate the token for all groups of a tenant
+  cfg token rotate --tenant-id=acme-corp
+
+  # Rotate the token for a specific group
+  cfg token rotate --tenant-id=acme-corp --group=production`,
+	RunE: runTokenRotate,
 }
 
 // tokenListCmd represents the token list command
@@ -158,11 +176,16 @@ func init() {
 	tokenCreateCmd.Flags().StringVar(&tokenControllerURL, "controller-url", "", "Controller transport URL for steward connections (required)")
 	tokenCreateCmd.Flags().StringVar(&tokenGroup, "group", "", "Optional group identifier")
 	tokenCreateCmd.Flags().StringVar(&tokenExpiresIn, "expires", "", "Expiration duration (e.g., 24h, 7d, 30d)")
-	tokenCreateCmd.Flags().BoolVar(&tokenSingleUse, "single-use", false, "Token can only be used once")
 	tokenCreateCmd.Flags().BoolVar(&tokenJSONOutput, "json", false, "Emit JSON output instead of human-readable text")
 
 	_ = tokenCreateCmd.MarkFlagRequired("tenant-id")
 	_ = tokenCreateCmd.MarkFlagRequired("controller-url")
+
+	// Rotate command flags
+	tokenRotateCmd.Flags().StringVar(&tokenTenantID, "tenant-id", "", "Tenant ID (required)")
+	tokenRotateCmd.Flags().StringVar(&tokenGroup, "group", "", "Group to rotate (rotates all active tokens if omitted)")
+	tokenRotateCmd.Flags().BoolVar(&tokenJSONOutput, "json", false, "Emit JSON output instead of human-readable text")
+	_ = tokenRotateCmd.MarkFlagRequired("tenant-id")
 
 	// List command flags
 	tokenListCmd.Flags().StringVar(&tokenTenantID, "tenant-id", "", "Filter by tenant ID (optional)")
@@ -173,6 +196,7 @@ func init() {
 
 	// Add subcommands
 	tokenCmd.AddCommand(tokenCreateCmd)
+	tokenCmd.AddCommand(tokenRotateCmd)
 	tokenCmd.AddCommand(tokenListCmd)
 	tokenCmd.AddCommand(tokenRevokeCmd)
 	tokenCmd.AddCommand(tokenDeleteCmd)
@@ -226,13 +250,11 @@ func runTokenCreate(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to create API client: %w", err)
 	}
 
-	// Create token via API
 	req := &APITokenCreateRequest{
 		TenantID:      tokenTenantID,
 		ControllerURL: tokenControllerURL,
 		Group:         tokenGroup,
 		ExpiresIn:     tokenExpiresIn,
-		SingleUse:     tokenSingleUse,
 	}
 
 	token, err := client.CreateToken(context.Background(), req)
@@ -244,7 +266,6 @@ func runTokenCreate(cmd *cobra.Command, args []string) error {
 		return json.NewEncoder(os.Stdout).Encode(token)
 	}
 
-	// Output results
 	fmt.Printf("Registration Token: %s\n\n", token.Token)
 
 	fmt.Println("Token Details:")
@@ -258,7 +279,6 @@ func runTokenCreate(cmd *cobra.Command, args []string) error {
 	} else {
 		fmt.Printf("  Expires:        Never\n")
 	}
-	fmt.Printf("  Single Use:     %v\n", token.SingleUse)
 
 	fmt.Println()
 	fmt.Println("Deployment Examples:")
@@ -271,6 +291,38 @@ func runTokenCreate(cmd *cobra.Command, args []string) error {
 	fmt.Println()
 	fmt.Println("Direct execution:")
 	fmt.Printf("  cfgms-steward --regtoken=%s\n", token.Token)
+
+	return nil
+}
+
+func runTokenRotate(cmd *cobra.Command, args []string) error {
+	client, err := getAPIClient()
+	if err != nil {
+		return fmt.Errorf("failed to create API client: %w", err)
+	}
+
+	token, err := client.RotateToken(context.Background(), tokenTenantID, tokenGroup)
+	if err != nil {
+		return fmt.Errorf("failed to rotate token: %w", err)
+	}
+
+	if tokenJSONOutput {
+		return json.NewEncoder(os.Stdout).Encode(token)
+	}
+
+	fmt.Printf("Token rotated successfully.\n\n")
+	fmt.Printf("New Registration Token: %s\n\n", token.Token)
+	fmt.Println("Token Details:")
+	fmt.Printf("  Tenant ID:      %s\n", token.TenantID)
+	fmt.Printf("  Controller URL: %s\n", token.ControllerURL)
+	if token.Group != "" {
+		fmt.Printf("  Group:          %s\n", token.Group)
+	}
+	if token.ExpiresAt != nil {
+		fmt.Printf("  Expires:        %s\n", *token.ExpiresAt)
+	} else {
+		fmt.Printf("  Expires:        Never\n")
+	}
 
 	return nil
 }
@@ -309,11 +361,6 @@ func runTokenList(cmd *cobra.Command, args []string) error {
 			fmt.Printf("  Expires:        %s\n", *token.ExpiresAt)
 		} else {
 			fmt.Printf("  Expires:        Never\n")
-		}
-		fmt.Printf("  Single Use:     %v\n", token.SingleUse)
-		if token.UsedAt != nil {
-			fmt.Printf("  Used At:        %s\n", *token.UsedAt)
-			fmt.Printf("  Used By:        %s\n", token.UsedBy)
 		}
 		if token.Revoked {
 			fmt.Printf("  Status:         REVOKED")
@@ -393,11 +440,6 @@ func runTokenGet(cmd *cobra.Command, args []string) error {
 		fmt.Printf("  Expires:        %s\n", *token.ExpiresAt)
 	} else {
 		fmt.Printf("  Expires:        Never\n")
-	}
-	fmt.Printf("  Single Use:     %v\n", token.SingleUse)
-	if token.UsedAt != nil {
-		fmt.Printf("  Used At:        %s\n", *token.UsedAt)
-		fmt.Printf("  Used By:        %s\n", token.UsedBy)
 	}
 	if token.Revoked {
 		fmt.Printf("  Status:         REVOKED")

--- a/cmd/cfg/cmd/token_test.go
+++ b/cmd/cfg/cmd/token_test.go
@@ -59,7 +59,6 @@ func newTokenServer(t *testing.T) *httptest.Server {
 		Group:         "production",
 		CreatedAt:     "2026-05-01T00:00:00Z",
 		ExpiresAt:     &expiresAt,
-		SingleUse:     false,
 		Revoked:       false,
 	}
 
@@ -95,7 +94,6 @@ func TestRunTokenCreate_JSONOutput(t *testing.T) {
 	origControllerURL := tokenControllerURL
 	origGroup := tokenGroup
 	origExpiresIn := tokenExpiresIn
-	origSingleUse := tokenSingleUse
 	origJSON := tokenJSONOutput
 	t.Cleanup(func() {
 		tokenAPIURL = origAPIURL
@@ -105,7 +103,6 @@ func TestRunTokenCreate_JSONOutput(t *testing.T) {
 		tokenControllerURL = origControllerURL
 		tokenGroup = origGroup
 		tokenExpiresIn = origExpiresIn
-		tokenSingleUse = origSingleUse
 		tokenJSONOutput = origJSON
 	})
 
@@ -115,7 +112,6 @@ func TestRunTokenCreate_JSONOutput(t *testing.T) {
 	tokenControllerURL = "controller.example.com:4433"
 	tokenGroup = ""
 	tokenExpiresIn = ""
-	tokenSingleUse = false
 	tokenJSONOutput = true
 
 	output := captureStdout(t, func() {
@@ -147,7 +143,6 @@ func TestRunTokenCreate_TextOutput(t *testing.T) {
 	origControllerURL := tokenControllerURL
 	origGroup := tokenGroup
 	origExpiresIn := tokenExpiresIn
-	origSingleUse := tokenSingleUse
 	origJSON := tokenJSONOutput
 	t.Cleanup(func() {
 		tokenAPIURL = origAPIURL
@@ -157,7 +152,6 @@ func TestRunTokenCreate_TextOutput(t *testing.T) {
 		tokenControllerURL = origControllerURL
 		tokenGroup = origGroup
 		tokenExpiresIn = origExpiresIn
-		tokenSingleUse = origSingleUse
 		tokenJSONOutput = origJSON
 	})
 
@@ -167,7 +161,6 @@ func TestRunTokenCreate_TextOutput(t *testing.T) {
 	tokenControllerURL = "controller.example.com:4433"
 	tokenGroup = ""
 	tokenExpiresIn = ""
-	tokenSingleUse = false
 	tokenJSONOutput = false
 
 	output := captureStdout(t, func() {

--- a/cmd/cfg/cmd/token_test.go
+++ b/cmd/cfg/cmd/token_test.go
@@ -74,6 +74,9 @@ func newTokenServer(t *testing.T) *httptest.Server {
 				Total:  1,
 			}
 			_ = json.NewEncoder(w).Encode(resp)
+		case r.Method == "POST" && strings.HasSuffix(r.URL.Path, "/rotate"):
+			w.WriteHeader(http.StatusCreated)
+			_ = json.NewEncoder(w).Encode(token)
 		case r.Method == "GET" && strings.HasPrefix(r.URL.Path, "/api/v1/registration/tokens/"):
 			_ = json.NewEncoder(w).Encode(token)
 		default:
@@ -207,6 +210,116 @@ func TestRunTokenCreate_APIError(t *testing.T) {
 	err := runTokenCreate(tokenCreateCmd, nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to create token")
+}
+
+func TestRunTokenRotate_JSONOutput(t *testing.T) {
+	server := newTokenServer(t)
+	defer server.Close()
+
+	origAPIURL := tokenAPIURL
+	origTLSInsecure := tokenTLSInsecure
+	origTenantID := tokenTenantID
+	origGroup := tokenGroup
+	origJSON := tokenJSONOutput
+	t.Cleanup(func() {
+		tokenAPIURL = origAPIURL
+		tokenTLSInsecure = origTLSInsecure
+		tokenTenantID = origTenantID
+		tokenGroup = origGroup
+		tokenJSONOutput = origJSON
+	})
+
+	tokenAPIURL = server.URL
+	tokenTLSInsecure = true
+	tokenTenantID = "test-tenant"
+	tokenGroup = "production"
+	tokenJSONOutput = true
+
+	output := captureStdout(t, func() {
+		err := runTokenRotate(tokenRotateCmd, nil)
+		require.NoError(t, err)
+	})
+
+	// Output must be valid JSON parseable as APITokenResponse
+	var parsed APITokenResponse
+	require.NoError(t, json.Unmarshal([]byte(output), &parsed), "output must be valid JSON")
+
+	assert.Equal(t, "abc123testtoken", parsed.Token)
+	assert.Equal(t, "test-tenant", parsed.TenantID)
+	assert.Equal(t, "controller.example.com:4433", parsed.ControllerURL)
+
+	// No human-readable text on stdout
+	assert.NotContains(t, output, "Token rotated successfully")
+	assert.NotContains(t, output, "New Registration Token:")
+}
+
+func TestRunTokenRotate_TextOutput(t *testing.T) {
+	server := newTokenServer(t)
+	defer server.Close()
+
+	origAPIURL := tokenAPIURL
+	origTLSInsecure := tokenTLSInsecure
+	origTenantID := tokenTenantID
+	origGroup := tokenGroup
+	origJSON := tokenJSONOutput
+	t.Cleanup(func() {
+		tokenAPIURL = origAPIURL
+		tokenTLSInsecure = origTLSInsecure
+		tokenTenantID = origTenantID
+		tokenGroup = origGroup
+		tokenJSONOutput = origJSON
+	})
+
+	tokenAPIURL = server.URL
+	tokenTLSInsecure = true
+	tokenTenantID = "test-tenant"
+	tokenGroup = ""
+	tokenJSONOutput = false
+
+	output := captureStdout(t, func() {
+		err := runTokenRotate(tokenRotateCmd, nil)
+		require.NoError(t, err)
+	})
+
+	// Human-readable output must be present
+	assert.Contains(t, output, "Token rotated successfully")
+	assert.Contains(t, output, "New Registration Token:")
+	assert.Contains(t, output, "abc123testtoken")
+
+	// Must not be bare JSON
+	assert.False(t, json.Valid([]byte(strings.TrimSpace(output))), "text output must not be valid JSON")
+}
+
+func TestRunTokenRotate_NoActiveTokens(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"error":"no active tokens found for the specified tenant/group"}`))
+	}))
+	defer server.Close()
+
+	origAPIURL := tokenAPIURL
+	origTLSInsecure := tokenTLSInsecure
+	origTenantID := tokenTenantID
+	origGroup := tokenGroup
+	origJSON := tokenJSONOutput
+	t.Cleanup(func() {
+		tokenAPIURL = origAPIURL
+		tokenTLSInsecure = origTLSInsecure
+		tokenTenantID = origTenantID
+		tokenGroup = origGroup
+		tokenJSONOutput = origJSON
+	})
+
+	tokenAPIURL = server.URL
+	tokenTLSInsecure = true
+	tokenTenantID = "test-tenant"
+	tokenGroup = ""
+	tokenJSONOutput = false
+
+	err := runTokenRotate(tokenRotateCmd, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to rotate token")
 }
 
 func TestRunTokenList_JSONOutput(t *testing.T) {

--- a/docs/architecture/controller-operating-model.md
+++ b/docs/architecture/controller-operating-model.md
@@ -424,10 +424,10 @@ The workflow engine must support the following capabilities to fulfill its role 
 
 The controller is the certificate authority and identity provider for stewards. Two credential flavors support different deployment workflows:
 
-**Short-lived / single-use registration tokens**
-- Generated via REST API or `cfg token create --expires=<duration> --single-use`
-- Scoped to tenant/group, with expiry
-- Consumed on use (single-use enforces one-time pairing; expiry enforces time bounds)
+**Perennial registration tokens**
+- Generated via REST API or `cfg token create --expires=<duration>`
+- Scoped to tenant/group, with optional expiry
+- Survive multiple registrations (never consumed on use); rotate with `cfg token rotate` to atomically invalidate all prior tokens and issue a fresh one
 - Suitable for: manual onboarding, small fleets, time-bounded provisioning
 
 **Long-lived tenant/group registration codes**
@@ -440,7 +440,7 @@ The controller is the certificate authority and identity provider for stewards. 
 
 1. Admin creates a token or code on the controller (scoped to tenant/group, with optional expiry for tokens).
 2. Steward presents the token/code during registration via the compile-time controller URL.
-3. Controller validates the credential — single-use: consume; long-lived code: look up matching record.
+3. Controller validates the credential — perennial token: check expiry and revocation; long-lived code: look up matching record.
 4. Controller runs the registration approval workflow via `RegistrationApprovalHook`. The active workflow is selected by `registration.workflow` in `controller.cfg`:
    - **`auto-approve`** (default): approves every valid registration unconditionally. Implemented as a built-in workflow with `Variables: {policy: accept}` which short-circuits the engine. Equivalent to the legacy `DefaultApprovalHook`.
    - **`manual-review`** (production): quarantines the steward pending operator action. Sets `registration_decision: quarantine` so the steward is restricted to baseline config until promoted. Operators use `cfg registration pending` to list quarantined stewards, `cfg registration approve <id>` to promote, and `cfg registration deny <id> [--reason ...]` to reject.

--- a/docs/architecture/steward-operating-model.md
+++ b/docs/architecture/steward-operating-model.md
@@ -335,8 +335,8 @@ A steward binary today connects to exactly one controller URL. Multi-controller 
 
 Two credential flavors, both flow through the same registration API:
 
-1. **Short-lived / single-use registration tokens** — generated on the controller via `cfg token create --expires=<duration> --single-use`. Suitable for manual onboarding, small fleets, or time-bounded provisioning windows. The token is consumed on use; expiry enforces time bounds.
-2. **Long-lived tenant/group registration codes** — durable, non-single-use random opaque strings stored as a join field on the controller's tenant/group record. Suitable for RMM/GPO mass deployment where the same code is baked into a deployment script and reused by many devices. On registration the controller looks up the code in its records and assigns the steward to the matching tenant/group; the code itself carries no meaning, so renames of the tenant/group don't break previously issued codes.
+1. **Perennial registration tokens** — generated on the controller via `cfg token create --expires=<duration>`. Suitable for manual onboarding, small fleets, or time-bounded provisioning windows. Tokens survive multiple registrations (never consumed on use); rotate with `cfg token rotate --tenant-id <id>` to atomically invalidate all prior tokens and issue a new one. Expiry enforces time bounds.
+2. **Long-lived tenant/group registration codes** — durable random opaque strings stored as a join field on the controller's tenant/group record. Suitable for RMM/GPO mass deployment where the same code is baked into a deployment script and reused by many devices. On registration the controller looks up the code in its records and assigns the steward to the matching tenant/group; the code itself carries no meaning, so renames of the tenant/group don't break previously issued codes.
 
 The administrator chooses which flavor fits the deployment workflow. Both arrive at the steward as a plain string passed via `--regtoken <token>` (or `cfgms-steward install --regtoken <token>` for the OS-service install).
 
@@ -345,7 +345,7 @@ The administrator chooses which flavor fits the deployment workflow. Both arrive
 1. Administrator creates a registration token or code on the controller.
 2. Steward is started with `--regtoken <token>`.
 3. Steward contacts its compile-time controller URL (HTTPS), submits the token.
-4. Controller validates the token (single-use: consume; long-lived code: look up the matching tenant/group record), applies the registration approval workflow (`auto-approve` or `manual-review`), and on approval issues mTLS certificates scoped to the steward's tenant/group identity.
+4. Controller validates the token (perennial token: check expiry and revocation; long-lived code: look up the matching tenant/group record), applies the registration approval workflow (`auto-approve` or `manual-review`), and on approval issues mTLS certificates scoped to the steward's tenant/group identity.
 5. Steward imports the issued cert into its local `cert.Manager` (stored under the platform cert dir) for use in TLS handshakes, records the node ID, and establishes a gRPC-over-QUIC transport connection.
 6. Steward checks for a cfg from the controller.
 7. Normal operation begins.

--- a/docs/deployment/fleet/walkthrough.md
+++ b/docs/deployment/fleet/walkthrough.md
@@ -175,24 +175,21 @@ steward knows where to connect after registration.
 > ongoing communication. This is distinct from the REST API (port `9080/TCP`) used
 > by the `cfg` operator CLI. Do not mix them up.
 
-Create one token per group (or per steward if you prefer single-use tokens):
+Create a token for the group. Tokens are perennial — they survive multiple registrations until explicitly rotated or revoked:
 
 ```bash
-# Token for steward-1 (single-use, 7-day window)
+# Token for the production group (7-day expiry window)
 cfg token create \
   --tenant-id=default \
   --controller-url=<CONTROLLER_IP>:4433 \
   --group=production \
-  --expires=7d \
-  --single-use
+  --expires=7d
+```
 
-# Token for steward-2 (single-use, 7-day window)
-cfg token create \
-  --tenant-id=default \
-  --controller-url=<CONTROLLER_IP>:4433 \
-  --group=production \
-  --expires=7d \
-  --single-use
+To invalidate the current token and issue a fresh one (e.g., after a deployment completes or a credential rotation policy requires it):
+
+```bash
+cfg token rotate --tenant-id=default --group=production
 ```
 
 Replace `<CONTROLLER_IP>` with the IP or hostname steward VMs use to reach the controller.
@@ -207,7 +204,6 @@ Token Details:
   Controller URL: 192.0.2.10:4433
   Group:          production
   Expires:        2026-05-26T00:00:00Z
-  Single Use:     true
 
 Deployment Examples:
 
@@ -218,7 +214,7 @@ Direct execution:
   cfgms-steward --regtoken=abcdefghijklmnopqrstuvwxyz123456
 ```
 
-Save both token strings — you'll use them in Phase 4.
+Save the token string — you'll use it in Phase 4.
 
 List all active tokens at any time:
 

--- a/features/controller/api/handlers_registration.go
+++ b/features/controller/api/handlers_registration.go
@@ -5,7 +5,6 @@ package api
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"net/http"
 	"os"
@@ -187,29 +186,15 @@ func (s *Server) handleRegister(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Generate steward ID before the atomic claim so it is recorded inside ConsumeToken
 	stewardID := fmt.Sprintf("steward-%d", time.Now().UnixNano())
 
-	// Atomically claim the token. For single-use tokens this is the TOCTOU gate:
-	// if two goroutines both pass GetToken and the revoke/expire checks, only the
-	// first ConsumeToken caller wins; the second gets ErrTokenAlreadyUsed.
-	if err := s.registrationTokenStore.ConsumeToken(r.Context(), req.Token, stewardID); err != nil {
-		if errors.Is(err, business.ErrTokenAlreadyUsed) {
-			s.logger.Warn("Single-use token already consumed",
-				"token_prefix", logging.RedactedID(req.Token))
-			// emitRegistrationAudit calls logging.RedactedID internally; raw token is not stored
-			s.emitRegistrationAudit(r.Context(), req.Token, token.TenantID, stewardID,
-				business.AuditEventSecurityEvent, "registration_rejected",
-				business.AuditResultFailure, business.AuditSeverityCritical, nil)
-			http.Error(w, "Registration token has already been used", http.StatusConflict)
-			return
-		}
-		s.logger.Error("Failed to consume registration token", "error", err)
-		http.Error(w, "Registration service error", http.StatusInternalServerError)
-		return
-	}
+	// Perennial tokens survive registration; log the use for auditability.
+	s.logger.Info("Token used for registration",
+		"token_prefix", logging.RedactedID(req.Token),
+		"tenant_id", token.TenantID,
+		"steward_id", stewardID)
 
-	// Issue #422: Run registration approval hook after token consumption.
+	// Issue #422: Run registration approval hook.
 	// The token is consumed before the hook runs, preventing a second attempt while
 	// the hook is evaluating. Hook errors are non-fatal: we log and fall back to approve
 	// so transient failures do not block legitimate registrations.

--- a/features/controller/api/handlers_registration_test.go
+++ b/features/controller/api/handlers_registration_test.go
@@ -6,7 +6,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"sync"
@@ -40,19 +39,6 @@ func newTestRegistrationStore(t *testing.T) registration.Store {
 	t.Cleanup(func() { _ = store.Close() })
 	require.NoError(t, store.Initialize(context.Background()))
 	return registration.NewStorageAdapter(store)
-}
-
-// controlledConsumeStore wraps a registration.Store and injects a fixed error from ConsumeToken.
-type controlledConsumeStore struct {
-	registration.Store
-	consumeErr error
-}
-
-func (c *controlledConsumeStore) ConsumeToken(ctx context.Context, tokenStr, stewardID string) error {
-	if c.consumeErr != nil {
-		return c.consumeErr
-	}
-	return c.Store.ConsumeToken(ctx, tokenStr, stewardID)
 }
 
 // newHandleRegisterServer creates a minimal server for handleRegister unit tests.
@@ -147,39 +133,6 @@ func postRegister(server *Server, token string) *httptest.ResponseRecorder {
 	return rec
 }
 
-func TestHandleRegister_AlreadyUsedSingleUseToken_Returns409(t *testing.T) {
-	tokenStore := newTestRegistrationStore(t)
-	server, auditMgr := newHandleRegisterServer(t, tokenStore, nil)
-
-	usedAt := time.Now().Add(-time.Hour)
-	tok := &registration.Token{
-		Token:         "cfgms_reg_used_token",
-		TenantID:      "test-tenant",
-		ControllerURL: "grpc://controller:7443",
-		SingleUse:     true,
-		UsedAt:        &usedAt,
-		UsedBy:        "steward-previous",
-	}
-	require.NoError(t, tokenStore.SaveToken(context.Background(), tok))
-
-	rec := postRegister(server, "cfgms_reg_used_token")
-
-	assert.Equal(t, http.StatusConflict, rec.Code)
-	assert.Contains(t, rec.Body.String(), "already been used")
-
-	// Verify audit entry was recorded for the rejected registration
-	require.NoError(t, auditMgr.Flush(context.Background()))
-	entries, err := auditMgr.QueryEntries(context.Background(), &business.AuditFilter{
-		TenantID: "test-tenant",
-	})
-	require.NoError(t, err)
-	require.Len(t, entries, 1)
-	assert.Equal(t, "registration_rejected", entries[0].Action)
-	assert.Equal(t, string(business.AuditResultFailure), string(entries[0].Result))
-	assert.Equal(t, string(business.AuditEventSecurityEvent), string(entries[0].EventType))
-	assert.Equal(t, "test-tenant", entries[0].TenantID)
-}
-
 func TestHandleRegister_RevokedToken_Returns401(t *testing.T) {
 	tokenStore := newTestRegistrationStore(t)
 	server, auditMgr := newHandleRegisterServer(t, tokenStore, nil)
@@ -241,83 +194,22 @@ func TestHandleRegister_ExpiredToken_Returns401(t *testing.T) {
 		"token_prefix in audit detail must be redacted by the audit manager")
 }
 
-func TestHandleRegister_StoreError_Returns500(t *testing.T) {
-	storeErr := fmt.Errorf("failed to persist token state: %w", fmt.Errorf("connection refused"))
-	tokenStore := &controlledConsumeStore{
-		Store:      newTestRegistrationStore(t),
-		consumeErr: storeErr,
-	}
-	server, _ := newHandleRegisterServer(t, tokenStore, nil)
-
-	tok := &registration.Token{
-		Token:         "cfgms_reg_store_err_token",
-		TenantID:      "test-tenant",
-		ControllerURL: "grpc://controller:7443",
-		SingleUse:     true,
-	}
-	require.NoError(t, tokenStore.SaveToken(context.Background(), tok))
-
-	rec := postRegister(server, "cfgms_reg_store_err_token")
-
-	assert.Equal(t, http.StatusInternalServerError, rec.Code)
-}
-
-func TestHandleRegister_ValidSingleUseToken_Returns200ThenSubsequent409(t *testing.T) {
-	tokenStore := newTestRegistrationStore(t)
-	certMgr := newTestCertManager(t)
-	server, auditMgr := newHandleRegisterServer(t, tokenStore, certMgr)
-
-	tok := &registration.Token{
-		Token:         "cfgms_reg_singleuse_valid",
-		TenantID:      "test-tenant",
-		ControllerURL: "grpc://controller:7443",
-		SingleUse:     true,
-	}
-	require.NoError(t, tokenStore.SaveToken(context.Background(), tok))
-
-	// First request should succeed
-	rec1 := postRegister(server, "cfgms_reg_singleuse_valid")
-	assert.Equal(t, http.StatusOK, rec1.Code)
-
-	var resp RegistrationResponse
-	require.NoError(t, json.Unmarshal(rec1.Body.Bytes(), &resp))
-	assert.NotEmpty(t, resp.StewardID)
-	assert.Equal(t, "test-tenant", resp.TenantID)
-
-	// Verify audit entry for successful registration
-	require.NoError(t, auditMgr.Flush(context.Background()))
-	entries, err := auditMgr.QueryEntries(context.Background(), &business.AuditFilter{
-		TenantID: "test-tenant",
-	})
-	require.NoError(t, err)
-	require.Len(t, entries, 1)
-	assert.Equal(t, "steward_registered", entries[0].Action)
-	assert.Equal(t, string(business.AuditResultSuccess), string(entries[0].Result))
-	assert.Equal(t, string(business.AuditEventAuthentication), string(entries[0].EventType))
-	assert.Equal(t, "test-tenant", entries[0].TenantID)
-
-	// Second request with same token must be rejected as already used
-	rec2 := postRegister(server, "cfgms_reg_singleuse_valid")
-	assert.Equal(t, http.StatusConflict, rec2.Code)
-}
-
-func TestHandleRegister_ValidMultiUseToken_AllowsTwoRegistrations(t *testing.T) {
+func TestHandleRegister_PerennialToken_AllowsMultipleRegistrations(t *testing.T) {
 	tokenStore := newTestRegistrationStore(t)
 	certMgr := newTestCertManager(t)
 	server, _ := newHandleRegisterServer(t, tokenStore, certMgr)
 
 	tok := &registration.Token{
-		Token:         "cfgms_reg_multiuse_valid",
+		Token:         "cfgms_reg_perennial_valid",
 		TenantID:      "test-tenant",
 		ControllerURL: "grpc://controller:7443",
-		SingleUse:     false,
 	}
 	require.NoError(t, tokenStore.SaveToken(context.Background(), tok))
 
-	rec1 := postRegister(server, "cfgms_reg_multiuse_valid")
+	rec1 := postRegister(server, "cfgms_reg_perennial_valid")
 	assert.Equal(t, http.StatusOK, rec1.Code)
 
-	rec2 := postRegister(server, "cfgms_reg_multiuse_valid")
+	rec2 := postRegister(server, "cfgms_reg_perennial_valid")
 	assert.Equal(t, http.StatusOK, rec2.Code)
 
 	// Both registrations should have distinct steward IDs
@@ -325,108 +217,6 @@ func TestHandleRegister_ValidMultiUseToken_AllowsTwoRegistrations(t *testing.T) 
 	require.NoError(t, json.Unmarshal(rec1.Body.Bytes(), &resp1))
 	require.NoError(t, json.Unmarshal(rec2.Body.Bytes(), &resp2))
 	assert.NotEqual(t, resp1.StewardID, resp2.StewardID)
-}
-
-func TestHandleRegister_ConsumeToken_NoSaveTokenCall(t *testing.T) {
-	// Verify that a successful registration does NOT call SaveToken (ConsumeToken handles it).
-	// We use the real MemoryStore and verify token state after registration.
-	tokenStore := newTestRegistrationStore(t)
-	certMgr := newTestCertManager(t)
-	server, _ := newHandleRegisterServer(t, tokenStore, certMgr)
-
-	tok := &registration.Token{
-		Token:         "cfgms_reg_nosave_check",
-		TenantID:      "test-tenant",
-		ControllerURL: "grpc://controller:7443",
-		SingleUse:     true,
-	}
-	require.NoError(t, tokenStore.SaveToken(context.Background(), tok))
-
-	rec := postRegister(server, "cfgms_reg_nosave_check")
-	require.Equal(t, http.StatusOK, rec.Code)
-
-	// Token should now be marked as used by ConsumeToken
-	updated, err := tokenStore.GetToken(context.Background(), "cfgms_reg_nosave_check")
-	require.NoError(t, err)
-	assert.NotNil(t, updated.UsedAt, "ConsumeToken must have marked the token as used")
-	assert.NotEmpty(t, updated.UsedBy, "ConsumeToken must have recorded the steward ID")
-}
-
-func TestHandleRegister_ConcurrentSingleUseToken_ExactlyOneSucceeds(t *testing.T) {
-	tokenStore := newTestRegistrationStore(t)
-	certMgr := newTestCertManager(t)
-	server, _ := newHandleRegisterServer(t, tokenStore, certMgr)
-
-	tok := &registration.Token{
-		Token:         "cfgms_reg_concurrent_token",
-		TenantID:      "test-tenant",
-		ControllerURL: "grpc://controller:7443",
-		SingleUse:     true,
-	}
-	require.NoError(t, tokenStore.SaveToken(context.Background(), tok))
-
-	// Use an httptest.Server so goroutines share a real HTTP stack
-	ts := httptest.NewServer(server.router)
-	t.Cleanup(ts.Close)
-
-	type result struct {
-		code int
-	}
-	results := make([]result, 2)
-	var wg sync.WaitGroup
-	for i := 0; i < 2; i++ {
-		wg.Add(1)
-		go func(idx int) {
-			defer wg.Done()
-			body, _ := json.Marshal(RegistrationRequest{Token: "cfgms_reg_concurrent_token"})
-			resp, err := ts.Client().Post(ts.URL+"/api/v1/register", "application/json", bytes.NewReader(body))
-			if err != nil {
-				return
-			}
-			defer func() { _ = resp.Body.Close() }()
-			results[idx] = result{code: resp.StatusCode}
-		}(i)
-	}
-	wg.Wait()
-
-	codes := []int{results[0].code, results[1].code}
-	assert.Contains(t, codes, http.StatusOK, "exactly one goroutine must succeed")
-	assert.Contains(t, codes, http.StatusConflict, "exactly one goroutine must get 409")
-
-	okCount := 0
-	conflictCount := 0
-	for _, r := range results {
-		switch r.code {
-		case http.StatusOK:
-			okCount++
-		case http.StatusConflict:
-			conflictCount++
-		}
-	}
-	assert.Equal(t, 1, okCount, "exactly one registration must succeed")
-	assert.Equal(t, 1, conflictCount, "exactly one registration must return 409")
-}
-
-// TestHandleRegister_ConsumeTokenNotAlreadyUsed_Returns401 verifies that ConsumeToken
-// returns ErrTokenAlreadyUsed (not a plain error) for the 409 path.
-func TestHandleRegister_ErrTokenAlreadyUsed_IsDistinctFrom500(t *testing.T) {
-	// This test uses the sentinel directly to confirm the error distinction matters.
-	tokenStore := &controlledConsumeStore{
-		Store:      newTestRegistrationStore(t),
-		consumeErr: business.ErrTokenAlreadyUsed,
-	}
-	server, _ := newHandleRegisterServer(t, tokenStore, nil)
-
-	tok := &registration.Token{
-		Token:         "cfgms_reg_sentinel_test",
-		TenantID:      "test-tenant",
-		ControllerURL: "grpc://controller:7443",
-		SingleUse:     true,
-	}
-	require.NoError(t, tokenStore.SaveToken(context.Background(), tok))
-
-	rec := postRegister(server, "cfgms_reg_sentinel_test")
-	assert.Equal(t, http.StatusConflict, rec.Code, "ErrTokenAlreadyUsed must map to 409 not 500")
 }
 
 // kvCapturingLogger captures both Warn message and key-value pairs for security assertions.
@@ -591,7 +381,6 @@ func TestHandleRegister_ValidToken_LogsRedactedPrefixNotFullToken(t *testing.T) 
 		Token:         fullToken,
 		TenantID:      "test-tenant",
 		ControllerURL: "grpc://controller:7443",
-		SingleUse:     true,
 	}
 	require.NoError(t, tokenStore.SaveToken(context.Background(), tok))
 

--- a/features/controller/api/handlers_registration_tokens.go
+++ b/features/controller/api/handlers_registration_tokens.go
@@ -20,9 +20,6 @@ type TokenResponse struct {
 	Group         string  `json:"group,omitempty"`
 	CreatedAt     string  `json:"created_at"`
 	ExpiresAt     *string `json:"expires_at,omitempty"`
-	SingleUse     bool    `json:"single_use"`
-	UsedAt        *string `json:"used_at,omitempty"`
-	UsedBy        string  `json:"used_by,omitempty"`
 	Revoked       bool    `json:"revoked"`
 	RevokedAt     *string `json:"revoked_at,omitempty"`
 }
@@ -33,6 +30,18 @@ type TokenListResponse struct {
 	Total  int             `json:"total"`
 }
 
+// rotateTokenRequest is the optional request body for the rotate endpoint.
+type rotateTokenRequest struct {
+	Group string `json:"group,omitempty"`
+}
+
+// createTokenRequestWithSingleUseCheck wraps TokenCreateRequest to detect the removed
+// single_use field and return 400 if a caller still sends it.
+type createTokenRequestWithSingleUseCheck struct {
+	registration.TokenCreateRequest
+	SingleUse *bool `json:"single_use,omitempty"`
+}
+
 // handleCreateRegistrationToken handles POST /api/v1/registration/tokens
 func (s *Server) handleCreateRegistrationToken(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
@@ -40,11 +49,16 @@ func (s *Server) handleCreateRegistrationToken(w http.ResponseWriter, r *http.Re
 		return
 	}
 
-	// Parse request body
-	var req registration.TokenCreateRequest
+	// Parse request body; detect removed single_use field.
+	var req createTokenRequestWithSingleUseCheck
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		s.logger.Warn("Failed to parse token create request", "error", err)
 		http.Error(w, "Invalid request body", http.StatusBadRequest)
+		return
+	}
+
+	if req.SingleUse != nil {
+		http.Error(w, "single_use is no longer supported; tokens are perennial by default", http.StatusBadRequest)
 		return
 	}
 
@@ -66,7 +80,7 @@ func (s *Server) handleCreateRegistrationToken(w http.ResponseWriter, r *http.Re
 	}
 
 	// Create token using registration package
-	token, err := registration.CreateToken(&req)
+	token, err := registration.CreateToken(&req.TokenCreateRequest)
 	if err != nil {
 		s.logger.Error("Failed to create registration token", "error", err)
 		http.Error(w, "Failed to create token", http.StatusInternalServerError)
@@ -82,8 +96,7 @@ func (s *Server) handleCreateRegistrationToken(w http.ResponseWriter, r *http.Re
 
 	s.logger.Info("Created registration token",
 		"token_prefix", token.Token[:min(len(token.Token), 6)],
-		"tenant_id", token.TenantID,
-		"single_use", token.SingleUse)
+		"tenant_id", token.TenantID)
 
 	// Return token response
 	resp := tokenToResponse(token)
@@ -268,6 +281,53 @@ func (s *Server) handleRevokeRegistrationToken(w http.ResponseWriter, r *http.Re
 	}
 }
 
+// handleRotateRegistrationToken handles POST /api/v1/registration/tokens/{tenant_id}/rotate
+func (s *Server) handleRotateRegistrationToken(w http.ResponseWriter, r *http.Request) {
+	// Check if registration token store is available
+	if s.registrationTokenStore == nil {
+		s.logger.Error("Registration token store not available")
+		http.Error(w, "Registration service unavailable", http.StatusInternalServerError)
+		return
+	}
+
+	// Get tenant_id from path
+	vars := mux.Vars(r)
+	tenantID := vars["tenant_id"]
+	if tenantID == "" {
+		http.Error(w, "tenant_id is required", http.StatusBadRequest)
+		return
+	}
+
+	// Parse optional request body for group filter
+	var req rotateTokenRequest
+	if r.ContentLength > 0 {
+		_ = json.NewDecoder(r.Body).Decode(&req)
+	}
+
+	// Rotate token atomically
+	newToken, err := s.registrationTokenStore.RotateToken(r.Context(), tenantID, req.Group)
+	if err != nil {
+		if strings.Contains(err.Error(), "no active tokens found") {
+			http.Error(w, "No active tokens found for the specified tenant/group", http.StatusNotFound)
+			return
+		}
+		s.logger.Error("Failed to rotate registration token", "error", err, "tenant_id", tenantID)
+		http.Error(w, "Failed to rotate token", http.StatusInternalServerError)
+		return
+	}
+
+	s.logger.Info("Rotated registration token",
+		"token_prefix", newToken.Token[:min(len(newToken.Token), 6)],
+		"tenant_id", tenantID)
+
+	resp := tokenToResponse(newToken)
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusCreated)
+	if err := json.NewEncoder(w).Encode(resp); err != nil {
+		s.logger.Error("Failed to encode rotate token response", "error", err)
+	}
+}
+
 // tokenToResponse converts a registration.Token to TokenResponse
 func tokenToResponse(token *registration.Token) TokenResponse {
 	resp := TokenResponse{
@@ -276,19 +336,12 @@ func tokenToResponse(token *registration.Token) TokenResponse {
 		ControllerURL: token.ControllerURL,
 		Group:         token.Group,
 		CreatedAt:     token.CreatedAt.Format("2006-01-02T15:04:05Z07:00"),
-		SingleUse:     token.SingleUse,
-		UsedBy:        token.UsedBy,
 		Revoked:       token.Revoked,
 	}
 
 	if token.ExpiresAt != nil {
 		exp := token.ExpiresAt.Format("2006-01-02T15:04:05Z07:00")
 		resp.ExpiresAt = &exp
-	}
-
-	if token.UsedAt != nil {
-		used := token.UsedAt.Format("2006-01-02T15:04:05Z07:00")
-		resp.UsedAt = &used
 	}
 
 	if token.RevokedAt != nil {

--- a/features/controller/api/handlers_registration_tokens.go
+++ b/features/controller/api/handlers_registration_tokens.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/gorilla/mux"
 
+	"github.com/cfgis/cfgms/pkg/logging"
 	"github.com/cfgis/cfgms/pkg/registration"
 )
 
@@ -96,7 +97,7 @@ func (s *Server) handleCreateRegistrationToken(w http.ResponseWriter, r *http.Re
 
 	s.logger.Info("Created registration token",
 		"token_prefix", token.Token[:min(len(token.Token), 6)],
-		"tenant_id", token.TenantID)
+		"tenant_id", logging.SanitizeLogValue(token.TenantID))
 
 	// Return token response
 	resp := tokenToResponse(token)
@@ -311,14 +312,16 @@ func (s *Server) handleRotateRegistrationToken(w http.ResponseWriter, r *http.Re
 			http.Error(w, "No active tokens found for the specified tenant/group", http.StatusNotFound)
 			return
 		}
-		s.logger.Error("Failed to rotate registration token", "error", err, "tenant_id", tenantID)
+		s.logger.Error("Failed to rotate registration token",
+			"error", logging.SanitizeLogValue(err.Error()),
+			"tenant_id", logging.SanitizeLogValue(tenantID))
 		http.Error(w, "Failed to rotate token", http.StatusInternalServerError)
 		return
 	}
 
 	s.logger.Info("Rotated registration token",
 		"token_prefix", newToken.Token[:min(len(newToken.Token), 6)],
-		"tenant_id", tenantID)
+		"tenant_id", logging.SanitizeLogValue(tenantID))
 
 	resp := tokenToResponse(newToken)
 	w.Header().Set("Content-Type", "application/json")

--- a/features/controller/api/handlers_registration_tokens_test.go
+++ b/features/controller/api/handlers_registration_tokens_test.go
@@ -127,7 +127,6 @@ func TestCreateRegistrationToken(t *testing.T) {
 			ControllerURL: "grpc://controller.example.com:7443",
 			Group:         "production",
 			ExpiresIn:     "7d",
-			SingleUse:     false,
 		}
 
 		body, err := json.Marshal(reqBody)
@@ -151,19 +150,12 @@ func TestCreateRegistrationToken(t *testing.T) {
 		assert.Equal(t, "test-tenant", resp.TenantID)
 		assert.Equal(t, "grpc://controller.example.com:7443", resp.ControllerURL)
 		assert.Equal(t, "production", resp.Group)
-		assert.False(t, resp.SingleUse)
 		assert.NotNil(t, resp.ExpiresAt)
 	})
 
-	t.Run("single-use token creation", func(t *testing.T) {
-		reqBody := registration.TokenCreateRequest{
-			TenantID:      "test-tenant",
-			ControllerURL: "grpc://controller.example.com:7443",
-			SingleUse:     true,
-		}
-
-		body, err := json.Marshal(reqBody)
-		require.NoError(t, err)
+	t.Run("single_use field returns 400", func(t *testing.T) {
+		// single_use was removed in Issue #1690; sending it must return 400
+		body := []byte(`{"tenant_id":"test-tenant","controller_url":"grpc://controller.example.com:7443","single_use":true}`)
 
 		req := httptest.NewRequest("POST", "/api/v1/registration/tokens", bytes.NewReader(body))
 		req.Header.Set("X-API-Key", apiKey)
@@ -172,13 +164,8 @@ func TestCreateRegistrationToken(t *testing.T) {
 
 		server.router.ServeHTTP(rec, req)
 
-		assert.Equal(t, http.StatusCreated, rec.Code)
-
-		var resp TokenResponse
-		err = json.Unmarshal(rec.Body.Bytes(), &resp)
-		require.NoError(t, err)
-
-		assert.True(t, resp.SingleUse)
+		assert.Equal(t, http.StatusBadRequest, rec.Code)
+		assert.Contains(t, rec.Body.String(), "single_use")
 	})
 
 	t.Run("missing tenant_id returns error", func(t *testing.T) {
@@ -528,6 +515,70 @@ func TestRevokeRegistrationToken(t *testing.T) {
 	})
 }
 
+func TestRotateRegistrationToken(t *testing.T) {
+	server, tokenStore := setupTestServerWithTokenStore(t)
+
+	// Create API key with rotate permission
+	apiKey := NewTestKey(t, server, []string{"registration:rotate-token"})
+	ctx := context.Background()
+
+	// Seed a token for rotation
+	seed, err := registration.CreateToken(&registration.TokenCreateRequest{
+		TenantID:      "rotate-tenant",
+		ControllerURL: "grpc://controller.example.com:7443",
+		Group:         "rotate-group",
+	})
+	require.NoError(t, err)
+	require.NoError(t, tokenStore.SaveToken(ctx, seed))
+
+	t.Run("rotate returns new token and revokes old", func(t *testing.T) {
+		body := []byte(`{"group":"rotate-group"}`)
+		req := httptest.NewRequest("POST", "/api/v1/registration/tokens/rotate-tenant/rotate", bytes.NewReader(body))
+		req.Header.Set("X-API-Key", apiKey)
+		req.Header.Set("Content-Type", "application/json")
+		rec := httptest.NewRecorder()
+
+		server.router.ServeHTTP(rec, req)
+
+		assert.Equal(t, http.StatusCreated, rec.Code)
+
+		var resp TokenResponse
+		err := json.Unmarshal(rec.Body.Bytes(), &resp)
+		require.NoError(t, err)
+
+		assert.NotEmpty(t, resp.Token)
+		assert.NotEqual(t, seed.Token, resp.Token, "rotated token must differ from seed")
+		assert.Equal(t, "rotate-tenant", resp.TenantID)
+		assert.Equal(t, "grpc://controller.example.com:7443", resp.ControllerURL)
+		assert.Equal(t, "rotate-group", resp.Group)
+		assert.False(t, resp.Revoked)
+
+		// Old token must be revoked in the store
+		old, err := tokenStore.GetToken(ctx, seed.Token)
+		require.NoError(t, err)
+		assert.True(t, old.Revoked, "seed token must be revoked after rotation")
+	})
+
+	t.Run("rotate with no active tokens returns 404", func(t *testing.T) {
+		req := httptest.NewRequest("POST", "/api/v1/registration/tokens/nonexistent-tenant/rotate", nil)
+		req.Header.Set("X-API-Key", apiKey)
+		rec := httptest.NewRecorder()
+
+		server.router.ServeHTTP(rec, req)
+
+		assert.Equal(t, http.StatusNotFound, rec.Code)
+	})
+
+	t.Run("unauthorized without API key", func(t *testing.T) {
+		req := httptest.NewRequest("POST", "/api/v1/registration/tokens/rotate-tenant/rotate", nil)
+		rec := httptest.NewRecorder()
+
+		server.router.ServeHTTP(rec, req)
+
+		assert.Equal(t, http.StatusUnauthorized, rec.Code)
+	})
+}
+
 func TestRegistrationTokenCRUDFlow(t *testing.T) {
 	server, _ := setupTestServerWithTokenStore(t)
 
@@ -549,7 +600,6 @@ func TestRegistrationTokenCRUDFlow(t *testing.T) {
 			ControllerURL: "grpc://controller.example.com:7443",
 			Group:         "crud-test-group",
 			ExpiresIn:     "24h",
-			SingleUse:     false,
 		}
 
 		body, err := json.Marshal(reqBody)
@@ -686,7 +736,6 @@ func TestTokenResponseFormat(t *testing.T) {
 	// Create a token with all fields populated
 	now := time.Now()
 	expiresAt := now.Add(24 * time.Hour)
-	usedAt := now.Add(1 * time.Hour)
 	revokedAt := now.Add(2 * time.Hour)
 
 	token := &registration.Token{
@@ -696,9 +745,6 @@ func TestTokenResponseFormat(t *testing.T) {
 		Group:         "format-group",
 		CreatedAt:     now,
 		ExpiresAt:     &expiresAt,
-		SingleUse:     true,
-		UsedAt:        &usedAt,
-		UsedBy:        "steward-001",
 		Revoked:       true,
 		RevokedAt:     &revokedAt,
 	}
@@ -725,9 +771,6 @@ func TestTokenResponseFormat(t *testing.T) {
 	assert.Equal(t, "format-group", resp.Group)
 	assert.NotEmpty(t, resp.CreatedAt)
 	assert.NotNil(t, resp.ExpiresAt)
-	assert.True(t, resp.SingleUse)
-	assert.NotNil(t, resp.UsedAt)
-	assert.Equal(t, "steward-001", resp.UsedBy)
 	assert.True(t, resp.Revoked)
 	assert.NotNil(t, resp.RevokedAt)
 

--- a/features/controller/api/permissions.go
+++ b/features/controller/api/permissions.go
@@ -45,6 +45,7 @@ var knownPermissions = map[string]bool{
 	"registration:read-token":   true,
 	"registration:delete-token": true,
 	"registration:revoke-token": true,
+	"registration:rotate-token": true,
 	// Registration approval management (Issue #1568)
 	"registration:list-pending": true,
 	"registration:approve":      true,

--- a/features/controller/api/registration_hook.go
+++ b/features/controller/api/registration_hook.go
@@ -127,10 +127,9 @@ func (h *WorkflowApprovalHook) Evaluate(ctx context.Context, input RegistrationI
 
 	// Build input variables passed to the workflow execution.
 	vars := map[string]interface{}{
-		"tenant_id":  input.Token.TenantID,
-		"group":      input.Token.Group,
-		"single_use": input.Token.SingleUse,
-		"source_ip":  input.SourceIP,
+		"tenant_id": input.Token.TenantID,
+		"group":     input.Token.Group,
+		"source_ip": input.SourceIP,
 	}
 	if input.Token.ExpiresAt != nil {
 		vars["token_expiry"] = input.Token.ExpiresAt.UTC().Format(time.RFC3339)

--- a/features/controller/api/registration_hook_test.go
+++ b/features/controller/api/registration_hook_test.go
@@ -49,10 +49,9 @@ func newTestApprovalHook(t *testing.T) (*WorkflowApprovalHook, cfgconfig.ConfigS
 func sampleInput() RegistrationInput {
 	return RegistrationInput{
 		Token: &registration.Token{
-			Token:     "testtoken12345",
-			TenantID:  "test-tenant",
-			Group:     "prod",
-			SingleUse: false,
+			Token:    "testtoken12345",
+			TenantID: "test-tenant",
+			Group:    "prod",
 		},
 		SourceIP: "192.168.1.100",
 	}
@@ -263,7 +262,6 @@ func TestWorkflowApprovalHook_TokenWithExpiry_WorkflowRuns(t *testing.T) {
 			Token:     "sometoken",
 			TenantID:  "test-tenant", // must match stored workflow tenant
 			Group:     "servers",
-			SingleUse: true,
 			ExpiresAt: &exp,
 		},
 		SourceIP: "10.0.0.1",
@@ -316,7 +314,6 @@ func TestHandleRegister_HookRejects_Returns403(t *testing.T) {
 		TenantID:  "test-tenant",
 		Group:     "prod",
 		CreatedAt: time.Now(),
-		SingleUse: false,
 	}
 	err := tokenStore.SaveToken(context.Background(), token)
 	require.NoError(t, err)
@@ -355,7 +352,6 @@ func TestHandleRegister_HookError_FailsOpen(t *testing.T) {
 		TenantID:  "test-tenant",
 		Group:     "prod",
 		CreatedAt: time.Now(),
-		SingleUse: false,
 	}
 	err := tokenStore.SaveToken(context.Background(), token)
 	require.NoError(t, err)

--- a/features/controller/api/server.go
+++ b/features/controller/api/server.go
@@ -380,6 +380,7 @@ func (s *Server) setupRouter() {
 	regTokens.Handle("/{token}", s.requirePermission("registration", "read-token")(http.HandlerFunc(s.handleGetRegistrationToken))).Methods("GET")
 	regTokens.Handle("/{token}", s.requirePermission("registration", "delete-token")(http.HandlerFunc(s.handleDeleteRegistrationToken))).Methods("DELETE")
 	regTokens.Handle("/{token}/revoke", s.requirePermission("registration", "revoke-token")(http.HandlerFunc(s.handleRevokeRegistrationToken))).Methods("POST")
+	regTokens.Handle("/{tenant_id}/rotate", s.requirePermission("registration", "rotate-token")(http.HandlerFunc(s.handleRotateRegistrationToken))).Methods("POST")
 
 	// Registration approval endpoints (Issue #1568)
 	api.Handle("/registration/pending", s.requirePermission("registration", "list-pending")(http.HandlerFunc(s.handleListPendingRegistrations))).Methods("GET")

--- a/features/controller/api/validation_middleware.go
+++ b/features/controller/api/validation_middleware.go
@@ -90,8 +90,8 @@ func (s *Server) validateURLParameters(validator *security.EnhancedValidator, re
 			// Certificate serial numbers
 			validator.ValidateString(result, "path."+param, value, "required", "charset:alphanumeric", "max_length:40")
 		case "tenantId", "tenant_id":
-			// Tenant IDs should be UUIDs
-			validator.ValidateString(result, "path."+param, value, "required", "charset:uuid")
+			// Tenant IDs are human-readable identifiers (e.g., "acme-corp", "test-tenant")
+			validator.ValidateString(result, "path."+param, value, "required", "charset:alphanumeric_dash", "max_length:128")
 		case "stewardId", "steward_id":
 			// Steward IDs
 			validator.ValidateString(result, "path."+param, value, "required", "charset:alphanumeric_dash", "max_length:64")

--- a/features/controller/server/server.go
+++ b/features/controller/server/server.go
@@ -328,7 +328,6 @@ func New(cfg *config.Config, logger logging.Logger) (*Server, error) {
 					Group:         "test-group",
 					CreatedAt:     now,
 					ExpiresAt:     nil,
-					SingleUse:     false,
 					Revoked:       false,
 				},
 				{
@@ -338,7 +337,6 @@ func New(cfg *config.Config, logger logging.Logger) (*Server, error) {
 					Group:         "production",
 					CreatedAt:     now,
 					ExpiresAt:     nil,
-					SingleUse:     false,
 					Revoked:       false,
 				},
 				{
@@ -348,7 +346,6 @@ func New(cfg *config.Config, logger logging.Logger) (*Server, error) {
 					Group:         "production",
 					CreatedAt:     now.Add(-2 * time.Hour),
 					ExpiresAt:     &expiredTime,
-					SingleUse:     true,
 					Revoked:       false,
 				},
 				{
@@ -358,19 +355,8 @@ func New(cfg *config.Config, logger logging.Logger) (*Server, error) {
 					Group:         "production",
 					CreatedAt:     now,
 					ExpiresAt:     nil,
-					SingleUse:     true,
 					Revoked:       true,
 					RevokedAt:     &now,
-				},
-				{
-					Token:         "integration_singleuse", //nolint:gosec // test-only seeding, env-gated
-					TenantID:      "test-tenant-integration",
-					ControllerURL: "tcp://localhost:1886",
-					Group:         "production",
-					CreatedAt:     now,
-					ExpiresAt:     nil,
-					SingleUse:     true,
-					Revoked:       false,
 				},
 				{
 					Token:         "dockertest_fleet", //nolint:gosec // test-only seeding, env-gated
@@ -379,7 +365,6 @@ func New(cfg *config.Config, logger logging.Logger) (*Server, error) {
 					Group:         "test-group",
 					CreatedAt:     now,
 					ExpiresAt:     nil,
-					SingleUse:     false,
 					Revoked:       false,
 				},
 			}

--- a/features/controller/server/server_test.go
+++ b/features/controller/server/server_test.go
@@ -22,7 +22,7 @@ var hardcodedTestTokens = []string{
 	"integration_reusable",
 	"integration_expired",
 	"integration_revoked",
-	"integration_singleuse",
+	"dockertest_fleet",
 }
 
 // TestServer_ProductionStartup_NoHardcodedTokens verifies that a controller

--- a/pkg/controlplane/providers/grpc/provider_register_identity_test.go
+++ b/pkg/controlplane/providers/grpc/provider_register_identity_test.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"sync"
 	"testing"
+	"time"
 
 	commonpb "github.com/cfgis/cfgms/api/proto/common"
 	controllerpb "github.com/cfgis/cfgms/api/proto/controller"
@@ -78,15 +79,24 @@ func (s *inMemoryTokenStore) ListTokens(_ context.Context, filter *business.Regi
 	return result, nil
 }
 
-func (s *inMemoryTokenStore) ConsumeToken(_ context.Context, tokenStr, stewardID string) error {
+func (s *inMemoryTokenStore) RotateToken(_ context.Context, tenantID, group string) (*business.RegistrationTokenData, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	token, ok := s.tokens[tokenStr]
-	if !ok {
-		return fmt.Errorf("token not found")
+	for _, t := range s.tokens {
+		if t.TenantID == tenantID && t.Group == group && !t.Revoked {
+			now := time.Now()
+			t.Revoked = true
+			t.RevokedAt = &now
+		}
 	}
-	token.MarkUsed(stewardID)
-	return nil
+	newTok := &business.RegistrationTokenData{
+		Token:     fmt.Sprintf("rotated-%d", len(s.tokens)),
+		TenantID:  tenantID,
+		Group:     group,
+		CreatedAt: time.Now(),
+	}
+	s.tokens[newTok.Token] = newTok
+	return newTok, nil
 }
 
 func (s *inMemoryTokenStore) Initialize(_ context.Context) error { return nil }

--- a/pkg/registration/adapter.go
+++ b/pkg/registration/adapter.go
@@ -63,9 +63,13 @@ func (a *StorageAdapter) DeleteToken(ctx context.Context, tokenStr string) error
 	return a.store.DeleteToken(ctx, tokenStr)
 }
 
-// ConsumeToken atomically validates and marks a token as used, delegating to the storage provider.
-func (a *StorageAdapter) ConsumeToken(ctx context.Context, tokenStr, stewardID string) error {
-	return a.store.ConsumeToken(ctx, tokenStr, stewardID)
+// RotateToken atomically revokes all prior tokens for tenant+group and returns the new token.
+func (a *StorageAdapter) RotateToken(ctx context.Context, tenantID, group string) (*Token, error) {
+	data, err := a.store.RotateToken(ctx, tenantID, group)
+	if err != nil {
+		return nil, err
+	}
+	return dataToToken(data), nil
 }
 
 // tokenToData converts a Token to RegistrationTokenData
@@ -77,9 +81,6 @@ func tokenToData(token *Token) *business.RegistrationTokenData {
 		Group:         token.Group,
 		CreatedAt:     token.CreatedAt,
 		ExpiresAt:     token.ExpiresAt,
-		SingleUse:     token.SingleUse,
-		UsedAt:        token.UsedAt,
-		UsedBy:        token.UsedBy,
 		Revoked:       token.Revoked,
 		RevokedAt:     token.RevokedAt,
 	}
@@ -94,9 +95,6 @@ func dataToToken(data *business.RegistrationTokenData) *Token {
 		Group:         data.Group,
 		CreatedAt:     data.CreatedAt,
 		ExpiresAt:     data.ExpiresAt,
-		SingleUse:     data.SingleUse,
-		UsedAt:        data.UsedAt,
-		UsedBy:        data.UsedBy,
 		Revoked:       data.Revoked,
 		RevokedAt:     data.RevokedAt,
 	}

--- a/pkg/registration/adapter_test.go
+++ b/pkg/registration/adapter_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/cfgis/cfgms/pkg/storage/interfaces"
-	business "github.com/cfgis/cfgms/pkg/storage/interfaces/business"
 	_ "github.com/cfgis/cfgms/pkg/testing"
 )
 
@@ -44,7 +43,6 @@ func TestStorageAdapter_WithSQLiteStore(t *testing.T) {
 			ControllerURL: "tcp://localhost:1883",
 			Group:         "adapter-group",
 			CreatedAt:     now,
-			SingleUse:     false,
 			Revoked:       false,
 		}
 
@@ -67,8 +65,8 @@ func TestStorageAdapter_WithSQLiteStore(t *testing.T) {
 		token, err := adapter.GetToken(ctx, "adapter_test_token")
 		require.NoError(t, err)
 
-		// Mark as used using the Token method
-		token.MarkUsed("steward-adapter-001")
+		// Revoke the token to test mutable state update
+		token.Revoke()
 
 		err = adapter.UpdateToken(ctx, token)
 		require.NoError(t, err)
@@ -76,8 +74,8 @@ func TestStorageAdapter_WithSQLiteStore(t *testing.T) {
 		// Verify update
 		updated, err := adapter.GetToken(ctx, "adapter_test_token")
 		require.NoError(t, err)
-		assert.NotNil(t, updated.UsedAt)
-		assert.Equal(t, "steward-adapter-001", updated.UsedBy)
+		assert.True(t, updated.Revoked)
+		assert.NotNil(t, updated.RevokedAt)
 	})
 
 	// Test ListTokens
@@ -90,7 +88,6 @@ func TestStorageAdapter_WithSQLiteStore(t *testing.T) {
 			ControllerURL: "tcp://localhost:1883",
 			Group:         "adapter-group-2",
 			CreatedAt:     now,
-			SingleUse:     true,
 			Revoked:       false,
 		}
 		err := adapter.SaveToken(ctx, token2)
@@ -112,30 +109,23 @@ func TestStorageAdapter_WithSQLiteStore(t *testing.T) {
 		require.Error(t, err)
 	})
 
-	// Test Token.IsValid method
-	t.Run("Token_IsValid", func(t *testing.T) {
-		token, err := adapter.GetToken(ctx, "adapter_test_token")
-		require.NoError(t, err)
-		// Token was marked as used but it's not single-use, so still valid
-		assert.True(t, token.IsValid())
-	})
-
-	// Test Token.Revoke method
-	t.Run("Token_Revoke", func(t *testing.T) {
-		token, err := adapter.GetToken(ctx, "adapter_test_token")
-		require.NoError(t, err)
-
-		// Revoke the token
-		token.Revoke()
-		err = adapter.UpdateToken(ctx, token)
+	// Test Token.IsValid method (non-revoked token with future expiry)
+	t.Run("Token_IsValid_FutureExpiry", func(t *testing.T) {
+		future := time.Now().Add(24 * time.Hour)
+		tok := &Token{
+			Token:         "adapter_valid_token",
+			TenantID:      "tenant-adapter",
+			ControllerURL: "tcp://localhost:1883",
+			Group:         "valid-group",
+			CreatedAt:     time.Now(),
+			ExpiresAt:     &future,
+		}
+		err := adapter.SaveToken(ctx, tok)
 		require.NoError(t, err)
 
-		// Verify it's no longer valid
-		updated, err := adapter.GetToken(ctx, "adapter_test_token")
+		got, err := adapter.GetToken(ctx, "adapter_valid_token")
 		require.NoError(t, err)
-		assert.True(t, updated.Revoked)
-		assert.NotNil(t, updated.RevokedAt)
-		assert.False(t, updated.IsValid())
+		assert.True(t, got.IsValid())
 	})
 }
 
@@ -163,7 +153,6 @@ func TestStorageAdapter_InterfaceCompliance(t *testing.T) {
 		Group:         "compliance-group",
 		CreatedAt:     now,
 		ExpiresAt:     &expiresAt,
-		SingleUse:     true,
 		Revoked:       false,
 	}
 
@@ -179,14 +168,11 @@ func TestStorageAdapter_InterfaceCompliance(t *testing.T) {
 	assert.WithinDuration(t, original.CreatedAt, got.CreatedAt, time.Second)
 	require.NotNil(t, got.ExpiresAt)
 	assert.WithinDuration(t, *original.ExpiresAt, *got.ExpiresAt, time.Second)
-	assert.Equal(t, original.SingleUse, got.SingleUse)
-	assert.Nil(t, got.UsedAt)
-	assert.Empty(t, got.UsedBy)
-	assert.Equal(t, original.Revoked, got.Revoked)
 	assert.Nil(t, got.RevokedAt)
+	assert.Equal(t, original.Revoked, got.Revoked)
 }
 
-func TestStorageAdapter_ConsumeToken_Race(t *testing.T) {
+func TestStorageAdapter_RotateToken_Race(t *testing.T) {
 	tempDir := t.TempDir()
 
 	store, err := interfaces.CreateRegistrationTokenStoreFromConfig(
@@ -201,18 +187,19 @@ func TestStorageAdapter_ConsumeToken_Race(t *testing.T) {
 
 	adapter := NewStorageAdapter(store)
 
+	// Seed initial token
 	token := &Token{
-		Token:     "sqlite-race-token",
-		TenantID:  "tenant-race",
-		SingleUse: true,
-		CreatedAt: time.Now(),
+		Token:         "sqlite-rotate-seed",
+		TenantID:      "tenant-race",
+		ControllerURL: "grpc://controller:7443",
+		Group:         "race-group",
+		CreatedAt:     time.Now(),
 	}
 	require.NoError(t, adapter.SaveToken(ctx, token))
 
-	const goroutines = 50
+	const goroutines = 20
 	var (
 		successCount atomic.Int32
-		alreadyUsed  atomic.Int32
 		wg           sync.WaitGroup
 		start        = make(chan struct{})
 	)
@@ -222,14 +209,9 @@ func TestStorageAdapter_ConsumeToken_Race(t *testing.T) {
 		go func(id int) {
 			defer wg.Done()
 			<-start
-			err := adapter.ConsumeToken(ctx, "sqlite-race-token", "steward-"+string(rune('A'+id)))
-			switch err {
-			case nil:
+			_, err := adapter.RotateToken(ctx, "tenant-race", "race-group")
+			if err == nil {
 				successCount.Add(1)
-			case business.ErrTokenAlreadyUsed:
-				alreadyUsed.Add(1)
-			default:
-				t.Errorf("goroutine %d: unexpected error: %v", id, err)
 			}
 		}(i)
 	}
@@ -237,6 +219,18 @@ func TestStorageAdapter_ConsumeToken_Race(t *testing.T) {
 	close(start)
 	wg.Wait()
 
-	assert.Equal(t, int32(1), successCount.Load(), "exactly one goroutine must succeed")
-	assert.Equal(t, int32(goroutines-1), alreadyUsed.Load(), "all others must get ErrTokenAlreadyUsed")
+	// All rotations must succeed (each one finds the previous rotation's token as active)
+	assert.Equal(t, int32(goroutines), successCount.Load(), "all concurrent rotations must succeed")
+
+	// Exactly one valid token must remain
+	tokens, err := adapter.ListTokens(ctx, "tenant-race")
+	require.NoError(t, err)
+
+	validCount := 0
+	for _, tok := range tokens {
+		if !tok.Revoked {
+			validCount++
+		}
+	}
+	assert.Equal(t, 1, validCount, "exactly one valid token must exist after all rotations")
 }

--- a/pkg/registration/generator.go
+++ b/pkg/registration/generator.go
@@ -90,7 +90,6 @@ func CreateToken(req *TokenCreateRequest) (*Token, error) {
 		Group:         req.Group,
 		CreatedAt:     time.Now(),
 		ExpiresAt:     expiresAt,
-		SingleUse:     req.SingleUse,
 	}
 
 	return token, nil

--- a/pkg/registration/store.go
+++ b/pkg/registration/store.go
@@ -6,8 +6,7 @@ import (
 	"context"
 	"fmt"
 	"sync"
-
-	business "github.com/cfgis/cfgms/pkg/storage/interfaces/business"
+	"time"
 )
 
 // Store defines the interface for registration token storage.
@@ -27,9 +26,10 @@ type Store interface {
 	// DeleteToken deletes a token
 	DeleteToken(ctx context.Context, tokenStr string) error
 
-	// ConsumeToken atomically validates and marks a token as used in a single operation.
-	// For single-use tokens, returns business.ErrTokenAlreadyUsed if already consumed.
-	ConsumeToken(ctx context.Context, tokenStr, stewardID string) error
+	// RotateToken atomically revokes all prior tokens for tenant+group and returns a new token.
+	// controller_url is inherited from an existing active token.
+	// Returns an error if no active tokens exist for the given tenant+group.
+	RotateToken(ctx context.Context, tenantID, group string) (*Token, error)
 }
 
 // memoryStore is an in-memory implementation of Store (for use within this package only).
@@ -104,30 +104,53 @@ func (s *memoryStore) DeleteToken(ctx context.Context, tokenStr string) error {
 	return nil
 }
 
-// ConsumeToken atomically validates and marks a token as used under a single write lock,
-// preventing TOCTOU races when multiple callers attempt to consume the same single-use token.
-func (s *memoryStore) ConsumeToken(ctx context.Context, tokenStr, stewardID string) error {
+// RotateToken atomically revokes all prior tokens for tenant+group and creates a new token
+// under a single write lock, ensuring no overlap window between old and new tokens.
+func (s *memoryStore) RotateToken(ctx context.Context, tenantID, group string) (*Token, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	token, exists := s.tokens[tokenStr]
-	if !exists {
-		return fmt.Errorf("token not found")
-	}
-
-	if token.Revoked {
-		return fmt.Errorf("token is revoked")
-	}
-
-	if !token.IsValid() {
-		// Distinguish already-used single-use tokens from expired tokens.
-		if token.SingleUse && token.UsedAt != nil {
-			return business.ErrTokenAlreadyUsed
+	// Collect active tokens to identify controller_url and tokens to revoke.
+	var controllerURL string
+	var tokensToRevoke []string
+	found := false
+	for _, t := range s.tokens {
+		if t.TenantID == tenantID && t.Group == group && !t.Revoked {
+			tokensToRevoke = append(tokensToRevoke, t.Token)
+			if !found {
+				controllerURL = t.ControllerURL
+				found = true
+			}
 		}
-		return fmt.Errorf("token is not valid")
+	}
+	if !found {
+		return nil, fmt.Errorf("no active tokens found for tenant %q group %q", tenantID, group)
 	}
 
-	token.MarkUsed(stewardID)
-	s.tokens[tokenStr] = token
-	return nil
+	// Generate new token string.
+	tokenStr, err := GenerateToken()
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate token: %w", err)
+	}
+
+	now := time.Now()
+
+	// Revoke all prior tokens atomically under the same lock.
+	for _, tok := range tokensToRevoke {
+		t := s.tokens[tok]
+		t.Revoked = true
+		t.RevokedAt = &now
+		s.tokens[tok] = t
+	}
+
+	newToken := &Token{
+		Token:         tokenStr,
+		TenantID:      tenantID,
+		ControllerURL: controllerURL,
+		Group:         group,
+		CreatedAt:     now,
+	}
+	s.tokens[tokenStr] = newToken
+
+	return newToken, nil
 }

--- a/pkg/registration/store_test.go
+++ b/pkg/registration/store_test.go
@@ -5,119 +5,121 @@ package registration
 import (
 	"context"
 	"sync"
-	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
-	business "github.com/cfgis/cfgms/pkg/storage/interfaces/business"
 )
 
-func TestMemoryStore_ConsumeToken_SingleUse_Race(t *testing.T) {
+func TestMemoryStore_RotateToken_Basic(t *testing.T) {
 	store := newMemoryStore()
 	ctx := context.Background()
 
-	token := &Token{
-		Token:     "single-use-race-token",
-		TenantID:  "tenant-1",
-		SingleUse: true,
-		CreatedAt: time.Now(),
+	// Seed an initial token.
+	initial := &Token{
+		Token:         "initial-token",
+		TenantID:      "tenant-1",
+		ControllerURL: "grpc://controller:7443",
+		Group:         "production",
+		CreatedAt:     time.Now(),
 	}
-	require.NoError(t, store.SaveToken(ctx, token))
+	require.NoError(t, store.SaveToken(ctx, initial))
 
-	const goroutines = 50
-	var (
-		successCount atomic.Int32
-		alreadyUsed  atomic.Int32
-		wg           sync.WaitGroup
-		start        = make(chan struct{})
-	)
+	newTok, err := store.RotateToken(ctx, "tenant-1", "production")
+	require.NoError(t, err)
+	assert.NotEmpty(t, newTok.Token)
+	assert.NotEqual(t, initial.Token, newTok.Token, "rotate must generate a different token string")
+	assert.Equal(t, "tenant-1", newTok.TenantID)
+	assert.Equal(t, "grpc://controller:7443", newTok.ControllerURL)
+	assert.Equal(t, "production", newTok.Group)
+
+	// Old token must now be revoked.
+	got, err := store.GetToken(ctx, initial.Token)
+	require.NoError(t, err)
+	assert.True(t, got.Revoked, "initial token must be revoked after rotation")
+}
+
+func TestMemoryStore_RotateToken_NoActiveTokens(t *testing.T) {
+	store := newMemoryStore()
+	ctx := context.Background()
+
+	_, err := store.RotateToken(ctx, "tenant-none", "group-none")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no active tokens found")
+}
+
+func TestRotateToken_InvalidatesOldTokenAtomically(t *testing.T) {
+	store := newMemoryStore()
+	ctx := context.Background()
+
+	// Seed an initial token.
+	initial := &Token{
+		Token:         "initial-concurrent-token",
+		TenantID:      "tenant-concurrent",
+		ControllerURL: "grpc://controller:7443",
+		Group:         "concurrent-group",
+		CreatedAt:     time.Now(),
+	}
+	require.NoError(t, store.SaveToken(ctx, initial))
+
+	const goroutines = 20
+	results := make([]*Token, goroutines)
+	errs := make([]error, goroutines)
+	var wg sync.WaitGroup
+	start := make(chan struct{})
 
 	wg.Add(goroutines)
 	for i := 0; i < goroutines; i++ {
 		go func(id int) {
 			defer wg.Done()
 			<-start
-			err := store.ConsumeToken(ctx, "single-use-race-token", "steward-"+string(rune('A'+id)))
-			switch err {
-			case nil:
-				successCount.Add(1)
-			case business.ErrTokenAlreadyUsed:
-				alreadyUsed.Add(1)
-			default:
-				t.Errorf("goroutine %d: unexpected error: %v", id, err)
-			}
+			results[id], errs[id] = store.RotateToken(ctx, "tenant-concurrent", "concurrent-group")
 		}(i)
 	}
 
 	close(start)
 	wg.Wait()
 
-	assert.Equal(t, int32(1), successCount.Load(), "exactly one goroutine must succeed")
-	assert.Equal(t, int32(goroutines-1), alreadyUsed.Load(), "all others must get ErrTokenAlreadyUsed")
-}
-
-func TestMemoryStore_ConsumeToken_MultiUse(t *testing.T) {
-	store := newMemoryStore()
-	ctx := context.Background()
-
-	token := &Token{
-		Token:     "multi-use-token",
-		TenantID:  "tenant-1",
-		SingleUse: false,
-		CreatedAt: time.Now(),
+	// All rotations must succeed.
+	for i, err := range errs {
+		require.NoError(t, err, "goroutine %d got unexpected error", i)
 	}
-	require.NoError(t, store.SaveToken(ctx, token))
 
-	// Multiple consumes of a multi-use token must all succeed.
-	require.NoError(t, store.ConsumeToken(ctx, "multi-use-token", "steward-1"))
-	require.NoError(t, store.ConsumeToken(ctx, "multi-use-token", "steward-2"))
-}
+	// After N concurrent rotations, exactly one token must be valid.
+	allTokens, err := store.ListTokens(ctx, "tenant-concurrent")
+	require.NoError(t, err)
 
-func TestMemoryStore_ConsumeToken_TokenNotFound(t *testing.T) {
-	store := newMemoryStore()
-	ctx := context.Background()
-
-	err := store.ConsumeToken(ctx, "nonexistent", "steward-1")
-	require.Error(t, err)
-	assert.NotEqual(t, business.ErrTokenAlreadyUsed, err)
-}
-
-func TestMemoryStore_ConsumeToken_RevokedToken(t *testing.T) {
-	store := newMemoryStore()
-	ctx := context.Background()
-
-	token := &Token{
-		Token:     "revoked-token",
-		TenantID:  "tenant-1",
-		SingleUse: true,
-		Revoked:   true,
-		CreatedAt: time.Now(),
+	validCount := 0
+	for _, tok := range allTokens {
+		if !tok.Revoked {
+			validCount++
+		}
 	}
-	require.NoError(t, store.SaveToken(ctx, token))
+	assert.Equal(t, 1, validCount, "exactly one valid token must exist after concurrent rotations")
 
-	err := store.ConsumeToken(ctx, "revoked-token", "steward-1")
-	require.Error(t, err)
-	assert.NotEqual(t, business.ErrTokenAlreadyUsed, err)
+	// The initial token must be revoked.
+	gotInitial, err := store.GetToken(ctx, initial.Token)
+	require.NoError(t, err)
+	assert.True(t, gotInitial.Revoked, "initial token must be revoked after rotation")
 }
 
-func TestMemoryStore_ConsumeToken_ExpiredToken(t *testing.T) {
+func TestMemoryStore_RotateToken_RevokedTokenNotCounted(t *testing.T) {
 	store := newMemoryStore()
 	ctx := context.Background()
 
-	past := time.Now().Add(-time.Hour)
-	token := &Token{
-		Token:     "expired-token",
-		TenantID:  "tenant-1",
-		SingleUse: false,
-		ExpiresAt: &past,
-		CreatedAt: time.Now().Add(-2 * time.Hour),
+	// Seed a revoked token — RotateToken must not consider it active.
+	revoked := &Token{
+		Token:         "already-revoked",
+		TenantID:      "tenant-2",
+		ControllerURL: "grpc://controller:7443",
+		Group:         "group-a",
+		Revoked:       true,
+		CreatedAt:     time.Now(),
 	}
-	require.NoError(t, store.SaveToken(ctx, token))
+	require.NoError(t, store.SaveToken(ctx, revoked))
 
-	err := store.ConsumeToken(ctx, "expired-token", "steward-1")
-	require.Error(t, err)
-	assert.NotEqual(t, business.ErrTokenAlreadyUsed, err)
+	_, err := store.RotateToken(ctx, "tenant-2", "group-a")
+	require.Error(t, err, "no active tokens should cause an error")
+	assert.Contains(t, err.Error(), "no active tokens found")
 }

--- a/pkg/registration/types.go
+++ b/pkg/registration/types.go
@@ -9,6 +9,8 @@ package registration
 import "time"
 
 // Token represents a registration token for steward deployment.
+// Tokens are perennial: they survive multiple registrations and are never consumed on use.
+// Rotation atomically revokes the old token and issues a new one.
 type Token struct {
 	// Token is the unique token string (e.g., "abcdefghijklmnopqrstuvwxyz")
 	Token string `json:"token"`
@@ -28,15 +30,6 @@ type Token struct {
 	// ExpiresAt is when the token expires (nil = never)
 	ExpiresAt *time.Time `json:"expires_at,omitempty"`
 
-	// SingleUse indicates if token can only be used once
-	SingleUse bool `json:"single_use"`
-
-	// UsedAt is when the token was first used (nil = unused)
-	UsedAt *time.Time `json:"used_at,omitempty"`
-
-	// UsedBy is the steward_id that used this token
-	UsedBy string `json:"used_by,omitempty"`
-
 	// Revoked indicates if token has been revoked
 	Revoked bool `json:"revoked"`
 
@@ -46,29 +39,13 @@ type Token struct {
 
 // IsValid returns whether the token is currently valid for use.
 func (t *Token) IsValid() bool {
-	// Check if revoked
 	if t.Revoked {
 		return false
 	}
-
-	// Check if expired
 	if t.ExpiresAt != nil && time.Now().After(*t.ExpiresAt) {
 		return false
 	}
-
-	// Check if single-use and already used
-	if t.SingleUse && t.UsedAt != nil {
-		return false
-	}
-
 	return true
-}
-
-// MarkUsed marks the token as used by a specific steward.
-func (t *Token) MarkUsed(stewardID string) {
-	now := time.Now()
-	t.UsedAt = &now
-	t.UsedBy = stewardID
 }
 
 // Revoke marks the token as revoked.
@@ -91,7 +68,4 @@ type TokenCreateRequest struct {
 
 	// ExpiresIn is the duration until token expires (e.g., "24h", "7d", "30d")
 	ExpiresIn string `json:"expires_in,omitempty"`
-
-	// SingleUse indicates if token can only be used once
-	SingleUse bool `json:"single_use"`
 }

--- a/pkg/registration/types_test.go
+++ b/pkg/registration/types_test.go
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+package registration
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestToken_IsValid_Revoked(t *testing.T) {
+	revokedAt := time.Now()
+	tok := &Token{
+		Token:     "test-token",
+		TenantID:  "tenant-1",
+		Revoked:   true,
+		RevokedAt: &revokedAt,
+		CreatedAt: time.Now(),
+	}
+	assert.False(t, tok.IsValid(), "revoked token must not be valid")
+}
+
+func TestToken_IsValid_Expired(t *testing.T) {
+	past := time.Now().Add(-time.Hour)
+	tok := &Token{
+		Token:     "test-token",
+		TenantID:  "tenant-1",
+		ExpiresAt: &past,
+		CreatedAt: time.Now().Add(-2 * time.Hour),
+	}
+	assert.False(t, tok.IsValid(), "expired token must not be valid")
+}
+
+func TestToken_IsValid_Valid(t *testing.T) {
+	future := time.Now().Add(24 * time.Hour)
+	tok := &Token{
+		Token:     "test-token",
+		TenantID:  "tenant-1",
+		ExpiresAt: &future,
+		CreatedAt: time.Now(),
+	}
+	assert.True(t, tok.IsValid(), "non-expired non-revoked token must be valid")
+}
+
+func TestToken_IsValid_NoExpiry(t *testing.T) {
+	tok := &Token{
+		Token:     "test-token",
+		TenantID:  "tenant-1",
+		CreatedAt: time.Now(),
+	}
+	assert.True(t, tok.IsValid(), "perennial token with no expiry must always be valid")
+}
+
+func TestToken_IsValid_RevokedAndExpired(t *testing.T) {
+	past := time.Now().Add(-time.Hour)
+	revokedAt := time.Now().Add(-30 * time.Minute)
+	tok := &Token{
+		Token:     "test-token",
+		TenantID:  "tenant-1",
+		ExpiresAt: &past,
+		Revoked:   true,
+		RevokedAt: &revokedAt,
+		CreatedAt: time.Now().Add(-2 * time.Hour),
+	}
+	assert.False(t, tok.IsValid(), "revoked+expired token must not be valid")
+}
+
+func TestToken_Revoke(t *testing.T) {
+	tok := &Token{
+		Token:     "test-token",
+		TenantID:  "tenant-1",
+		CreatedAt: time.Now(),
+	}
+	assert.True(t, tok.IsValid())
+
+	tok.Revoke()
+
+	assert.True(t, tok.Revoked)
+	assert.NotNil(t, tok.RevokedAt)
+	assert.False(t, tok.IsValid())
+}

--- a/pkg/storage/interfaces/business/registration_store.go
+++ b/pkg/storage/interfaces/business/registration_store.go
@@ -5,12 +5,8 @@ package business
 
 import (
 	"context"
-	"errors"
 	"time"
 )
-
-// ErrTokenAlreadyUsed is returned when a single-use token has already been consumed.
-var ErrTokenAlreadyUsed = errors.New("registration token already used")
 
 // RegistrationTokenStore defines storage interface for CFGMS registration token persistence
 // All registration token modules use this interface - storage provider is chosen by controller
@@ -22,9 +18,10 @@ type RegistrationTokenStore interface {
 	DeleteToken(ctx context.Context, tokenStr string) error
 	ListTokens(ctx context.Context, filter *RegistrationTokenFilter) ([]*RegistrationTokenData, error)
 
-	// ConsumeToken atomically validates and marks a token as used in a single operation.
-	// For single-use tokens, returns ErrTokenAlreadyUsed if already consumed.
-	ConsumeToken(ctx context.Context, tokenStr, stewardID string) error
+	// RotateToken atomically revokes all prior tokens for tenant+group and creates a new one.
+	// The controller_url is inherited from an existing active token. Returns the new token.
+	// Returns an error if no active tokens exist for the given tenant+group.
+	RotateToken(ctx context.Context, tenantID, group string) (*RegistrationTokenData, error)
 
 	// Initialize and cleanup
 	Initialize(ctx context.Context) error
@@ -51,15 +48,6 @@ type RegistrationTokenData struct {
 	// ExpiresAt is when the token expires (nil = never)
 	ExpiresAt *time.Time `json:"expires_at,omitempty" yaml:"expires_at,omitempty"`
 
-	// SingleUse indicates if token can only be used once
-	SingleUse bool `json:"single_use" yaml:"single_use"`
-
-	// UsedAt is when the token was first used (nil = unused)
-	UsedAt *time.Time `json:"used_at,omitempty" yaml:"used_at,omitempty"`
-
-	// UsedBy is the steward_id that used this token
-	UsedBy string `json:"used_by,omitempty" yaml:"used_by,omitempty"`
-
 	// Revoked indicates if token has been revoked
 	Revoked bool `json:"revoked" yaml:"revoked"`
 
@@ -69,29 +57,13 @@ type RegistrationTokenData struct {
 
 // IsValid returns whether the token is currently valid for use.
 func (t *RegistrationTokenData) IsValid() bool {
-	// Check if revoked
 	if t.Revoked {
 		return false
 	}
-
-	// Check if expired
 	if t.ExpiresAt != nil && time.Now().After(*t.ExpiresAt) {
 		return false
 	}
-
-	// Check if single-use and already used
-	if t.SingleUse && t.UsedAt != nil {
-		return false
-	}
-
 	return true
-}
-
-// MarkUsed marks the token as used by a specific steward.
-func (t *RegistrationTokenData) MarkUsed(stewardID string) {
-	now := time.Now()
-	t.UsedAt = &now
-	t.UsedBy = stewardID
 }
 
 // Revoke marks the token as revoked.
@@ -103,9 +75,7 @@ func (t *RegistrationTokenData) Revoke() {
 
 // RegistrationTokenFilter defines filtering criteria for token queries
 type RegistrationTokenFilter struct {
-	TenantID  string `json:"tenant_id,omitempty"`
-	Group     string `json:"group,omitempty"`
-	Revoked   *bool  `json:"revoked,omitempty"`
-	SingleUse *bool  `json:"single_use,omitempty"`
-	Used      *bool  `json:"used,omitempty"` // Filter by used/unused status
+	TenantID string `json:"tenant_id,omitempty"`
+	Group    string `json:"group,omitempty"`
+	Revoked  *bool  `json:"revoked,omitempty"`
 }

--- a/pkg/storage/interfaces/hybrid_manager_test.go
+++ b/pkg/storage/interfaces/hybrid_manager_test.go
@@ -696,8 +696,8 @@ func (s *mockRegistrationTokenStore) DeleteToken(_ context.Context, _ string) er
 func (s *mockRegistrationTokenStore) ListTokens(_ context.Context, _ *business.RegistrationTokenFilter) ([]*business.RegistrationTokenData, error) {
 	return nil, nil
 }
-func (s *mockRegistrationTokenStore) ConsumeToken(_ context.Context, _, _ string) error {
-	return nil
+func (s *mockRegistrationTokenStore) RotateToken(_ context.Context, _, _ string) (*business.RegistrationTokenData, error) {
+	return nil, nil
 }
 func (s *mockRegistrationTokenStore) Initialize(_ context.Context) error { return nil }
 func (s *mockRegistrationTokenStore) Close() error                       { return nil }

--- a/pkg/storage/interfaces/provider_test.go
+++ b/pkg/storage/interfaces/provider_test.go
@@ -402,8 +402,8 @@ func (m *MockRegistrationTokenStore) DeleteToken(_ context.Context, _ string) er
 func (m *MockRegistrationTokenStore) ListTokens(_ context.Context, _ *business.RegistrationTokenFilter) ([]*business.RegistrationTokenData, error) {
 	return nil, nil
 }
-func (m *MockRegistrationTokenStore) ConsumeToken(_ context.Context, _, _ string) error {
-	return nil
+func (m *MockRegistrationTokenStore) RotateToken(_ context.Context, _, _ string) (*business.RegistrationTokenData, error) {
+	return nil, nil
 }
 func (m *MockRegistrationTokenStore) Initialize(_ context.Context) error { return nil }
 func (m *MockRegistrationTokenStore) Close() error                       { return nil }

--- a/pkg/storage/providers/database/registration_store.go
+++ b/pkg/storage/providers/database/registration_store.go
@@ -4,8 +4,11 @@ package database
 
 import (
 	"context"
+	"crypto/rand"
 	"database/sql"
+	"encoding/base32"
 	"fmt"
+	"strings"
 	"sync"
 	"time"
 
@@ -24,13 +27,11 @@ type DatabaseRegistrationTokenStore struct {
 
 // NewDatabaseRegistrationTokenStore creates a new PostgreSQL-based registration token store
 func NewDatabaseRegistrationTokenStore(dsn string, config map[string]interface{}) (*DatabaseRegistrationTokenStore, error) {
-	// Open database connection with connection pooling
 	db, err := sql.Open("postgres", dsn)
 	if err != nil {
 		return nil, fmt.Errorf("failed to open database connection: %w", err)
 	}
 
-	// Configure connection pool
 	maxOpenConns := getIntFromConfig(config, "max_open_connections", 25)
 	maxIdleConns := getIntFromConfig(config, "max_idle_connections", 5)
 	connMaxLifetime := time.Duration(getIntFromConfig(config, "connection_max_lifetime_minutes", 30)) * time.Minute
@@ -39,7 +40,6 @@ func NewDatabaseRegistrationTokenStore(dsn string, config map[string]interface{}
 	db.SetMaxIdleConns(maxIdleConns)
 	db.SetConnMaxLifetime(connMaxLifetime)
 
-	// Test connection
 	if err := db.Ping(); err != nil {
 		_ = db.Close()
 		return nil, fmt.Errorf("failed to ping database: %w", err)
@@ -51,7 +51,6 @@ func NewDatabaseRegistrationTokenStore(dsn string, config map[string]interface{}
 		schemas: NewDatabaseSchemas(),
 	}
 
-	// Initialize database schema
 	if err := store.initializeSchema(); err != nil {
 		_ = db.Close()
 		return nil, fmt.Errorf("failed to initialize database schema: %w", err)
@@ -64,24 +63,18 @@ func NewDatabaseRegistrationTokenStore(dsn string, config map[string]interface{}
 func (s *DatabaseRegistrationTokenStore) initializeSchema() error {
 	ctx := context.Background()
 
-	// Use PostgreSQL advisory lock to prevent concurrent schema initialization
-	// Lock ID: 13579248 (different from other schemas)
 	const schemaLockID = 13579248
 
-	// Acquire advisory lock - will wait if another instance is initializing
 	if _, err := s.db.ExecContext(ctx, "SELECT pg_advisory_lock($1)", schemaLockID); err != nil {
 		return fmt.Errorf("failed to acquire registration token schema initialization lock: %w", err)
 	}
 
-	// Ensure we release the lock when done
 	defer func() {
 		if _, err := s.db.ExecContext(ctx, "SELECT pg_advisory_unlock($1)", schemaLockID); err != nil {
-			// Log but don't fail - lock will be released when connection closes
 			_ = err
 		}
 	}()
 
-	// Create registration token tables
 	if err := s.schemas.CreateRegistrationTokensTable(ctx, s.db); err != nil {
 		return fmt.Errorf("failed to create registration token tables: %w", err)
 	}
@@ -99,8 +92,7 @@ func (s *DatabaseRegistrationTokenStore) Close() error {
 	return s.db.Close()
 }
 
-// SaveToken implements RegistrationTokenStore.SaveToken
-// Uses UPSERT to handle both new tokens and updates to existing tokens
+// SaveToken implements RegistrationTokenStore.SaveToken using UPSERT semantics.
 func (s *DatabaseRegistrationTokenStore) SaveToken(ctx context.Context, token *business.RegistrationTokenData) error {
 	if token == nil {
 		return fmt.Errorf("token cannot be nil")
@@ -112,41 +104,29 @@ func (s *DatabaseRegistrationTokenStore) SaveToken(ctx context.Context, token *b
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
 
-	// Use UPSERT to handle both INSERT and UPDATE cases
-	// This ensures single-use token enforcement works correctly
-	query := `
-		INSERT INTO cfgms_registration_tokens (token, tenant_id, controller_url, group_name, created_at, expires_at, single_use, used_at, used_by, revoked, revoked_at)
-		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+	_, err := s.db.ExecContext(ctx, `
+		INSERT INTO cfgms_registration_tokens
+			(token, tenant_id, controller_url, group_name, created_at, expires_at, revoked, revoked_at)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
 		ON CONFLICT (token) DO UPDATE SET
 			tenant_id = EXCLUDED.tenant_id,
 			controller_url = EXCLUDED.controller_url,
 			group_name = EXCLUDED.group_name,
 			expires_at = EXCLUDED.expires_at,
-			single_use = EXCLUDED.single_use,
-			used_at = EXCLUDED.used_at,
-			used_by = EXCLUDED.used_by,
 			revoked = EXCLUDED.revoked,
-			revoked_at = EXCLUDED.revoked_at
-	`
-
-	_, err := s.db.ExecContext(ctx, query,
+			revoked_at = EXCLUDED.revoked_at`,
 		token.Token,
 		token.TenantID,
 		token.ControllerURL,
 		token.Group,
 		token.CreatedAt,
 		nullTimeOrNil(token.ExpiresAt),
-		token.SingleUse,
-		nullTimeOrNil(token.UsedAt),
-		token.UsedBy,
 		token.Revoked,
 		nullTimeOrNil(token.RevokedAt),
 	)
-
 	if err != nil {
 		return fmt.Errorf("failed to save token: %w", err)
 	}
-
 	return nil
 }
 
@@ -159,31 +139,23 @@ func (s *DatabaseRegistrationTokenStore) GetToken(ctx context.Context, tokenStr 
 	s.mutex.RLock()
 	defer s.mutex.RUnlock()
 
-	query := `
-		SELECT token, tenant_id, controller_url, group_name, created_at, expires_at, single_use, used_at, used_by, revoked, revoked_at
-		FROM cfgms_registration_tokens
-		WHERE token = $1
-	`
-
 	var token business.RegistrationTokenData
-	var expiresAt, usedAt, revokedAt sql.NullTime
+	var expiresAt, revokedAt sql.NullTime
 	var group sql.NullString
-	var usedBy sql.NullString
 
-	err := s.db.QueryRowContext(ctx, query, tokenStr).Scan(
+	err := s.db.QueryRowContext(ctx, `
+		SELECT token, tenant_id, controller_url, group_name, created_at, expires_at, revoked, revoked_at
+		FROM cfgms_registration_tokens
+		WHERE token = $1`, tokenStr).Scan(
 		&token.Token,
 		&token.TenantID,
 		&token.ControllerURL,
 		&group,
 		&token.CreatedAt,
 		&expiresAt,
-		&token.SingleUse,
-		&usedAt,
-		&usedBy,
 		&token.Revoked,
 		&revokedAt,
 	)
-
 	if err != nil {
 		if err == sql.ErrNoRows {
 			return nil, fmt.Errorf("token not found")
@@ -191,15 +163,9 @@ func (s *DatabaseRegistrationTokenStore) GetToken(ctx context.Context, tokenStr 
 		return nil, fmt.Errorf("failed to get token: %w", err)
 	}
 
-	// Convert nullable fields
 	token.Group = group.String
-	token.UsedBy = usedBy.String
-
 	if expiresAt.Valid {
 		token.ExpiresAt = &expiresAt.Time
-	}
-	if usedAt.Valid {
-		token.UsedAt = &usedAt.Time
 	}
 	if revokedAt.Valid {
 		token.RevokedAt = &revokedAt.Time
@@ -220,25 +186,19 @@ func (s *DatabaseRegistrationTokenStore) UpdateToken(ctx context.Context, token 
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
 
-	query := `
+	result, err := s.db.ExecContext(ctx, `
 		UPDATE cfgms_registration_tokens
-		SET tenant_id = $2, controller_url = $3, group_name = $4, expires_at = $5, single_use = $6, used_at = $7, used_by = $8, revoked = $9, revoked_at = $10
-		WHERE token = $1
-	`
-
-	result, err := s.db.ExecContext(ctx, query,
+		SET tenant_id = $2, controller_url = $3, group_name = $4,
+		    expires_at = $5, revoked = $6, revoked_at = $7
+		WHERE token = $1`,
 		token.Token,
 		token.TenantID,
 		token.ControllerURL,
 		token.Group,
 		nullTimeOrNil(token.ExpiresAt),
-		token.SingleUse,
-		nullTimeOrNil(token.UsedAt),
-		token.UsedBy,
 		token.Revoked,
 		nullTimeOrNil(token.RevokedAt),
 	)
-
 	if err != nil {
 		return fmt.Errorf("failed to update token: %w", err)
 	}
@@ -247,11 +207,9 @@ func (s *DatabaseRegistrationTokenStore) UpdateToken(ctx context.Context, token 
 	if err != nil {
 		return fmt.Errorf("failed to get rows affected: %w", err)
 	}
-
 	if rowsAffected == 0 {
 		return fmt.Errorf("token not found")
 	}
-
 	return nil
 }
 
@@ -264,9 +222,7 @@ func (s *DatabaseRegistrationTokenStore) DeleteToken(ctx context.Context, tokenS
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
 
-	query := `DELETE FROM cfgms_registration_tokens WHERE token = $1`
-
-	result, err := s.db.ExecContext(ctx, query, tokenStr)
+	result, err := s.db.ExecContext(ctx, `DELETE FROM cfgms_registration_tokens WHERE token = $1`, tokenStr)
 	if err != nil {
 		return fmt.Errorf("failed to delete token: %w", err)
 	}
@@ -275,11 +231,9 @@ func (s *DatabaseRegistrationTokenStore) DeleteToken(ctx context.Context, tokenS
 	if err != nil {
 		return fmt.Errorf("failed to get rows affected: %w", err)
 	}
-
 	if rowsAffected == 0 {
 		return fmt.Errorf("token not found")
 	}
-
 	return nil
 }
 
@@ -289,14 +243,12 @@ func (s *DatabaseRegistrationTokenStore) ListTokens(ctx context.Context, filter 
 	defer s.mutex.RUnlock()
 
 	query := `
-		SELECT token, tenant_id, controller_url, group_name, created_at, expires_at, single_use, used_at, used_by, revoked, revoked_at
+		SELECT token, tenant_id, controller_url, group_name, created_at, expires_at, revoked, revoked_at
 		FROM cfgms_registration_tokens
-		WHERE 1=1
-	`
+		WHERE 1=1`
 	args := []interface{}{}
 	argCount := 1
 
-	// Apply filters
 	if filter != nil {
 		if filter.TenantID != "" {
 			query += fmt.Sprintf(" AND tenant_id = $%d", argCount)
@@ -313,19 +265,8 @@ func (s *DatabaseRegistrationTokenStore) ListTokens(ctx context.Context, filter 
 			args = append(args, *filter.Revoked)
 			argCount++
 		}
-		if filter.SingleUse != nil {
-			query += fmt.Sprintf(" AND single_use = $%d", argCount)
-			args = append(args, *filter.SingleUse)
-			// argCount not incremented as Used filter uses IS NULL/IS NOT NULL
-		}
-		if filter.Used != nil {
-			if *filter.Used {
-				query += " AND used_at IS NOT NULL"
-			} else {
-				query += " AND used_at IS NULL"
-			}
-		}
 	}
+	_ = argCount
 
 	query += " ORDER BY created_at DESC"
 
@@ -338,36 +279,25 @@ func (s *DatabaseRegistrationTokenStore) ListTokens(ctx context.Context, filter 
 	var tokens []*business.RegistrationTokenData
 	for rows.Next() {
 		var token business.RegistrationTokenData
-		var expiresAt, usedAt, revokedAt sql.NullTime
+		var expiresAt, revokedAt sql.NullTime
 		var group sql.NullString
-		var usedBy sql.NullString
 
-		err := rows.Scan(
+		if err := rows.Scan(
 			&token.Token,
 			&token.TenantID,
 			&token.ControllerURL,
 			&group,
 			&token.CreatedAt,
 			&expiresAt,
-			&token.SingleUse,
-			&usedAt,
-			&usedBy,
 			&token.Revoked,
 			&revokedAt,
-		)
-		if err != nil {
+		); err != nil {
 			return nil, fmt.Errorf("failed to scan token row: %w", err)
 		}
 
-		// Convert nullable fields
 		token.Group = group.String
-		token.UsedBy = usedBy.String
-
 		if expiresAt.Valid {
 			token.ExpiresAt = &expiresAt.Time
-		}
-		if usedAt.Valid {
-			token.UsedAt = &usedAt.Time
 		}
 		if revokedAt.Valid {
 			token.RevokedAt = &revokedAt.Time
@@ -383,72 +313,79 @@ func (s *DatabaseRegistrationTokenStore) ListTokens(ctx context.Context, filter 
 	return tokens, nil
 }
 
-// ConsumeToken atomically validates and marks a single-use token as used via a single UPDATE
-// with a WHERE guard. For single-use tokens that were already consumed, returns ErrTokenAlreadyUsed.
-func (s *DatabaseRegistrationTokenStore) ConsumeToken(ctx context.Context, tokenStr, stewardID string) error {
-	now := time.Now().UTC()
+// RotateToken atomically revokes all prior tokens for tenant+group and creates a new one in
+// a single PostgreSQL transaction, ensuring no overlap window between old and new tokens.
+func (s *DatabaseRegistrationTokenStore) RotateToken(ctx context.Context, tenantID, group string) (*business.RegistrationTokenData, error) {
+	newTokenStr, err := generateTokenString()
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate token: %w", err)
+	}
 
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
 
-	// Atomic mark-used for single-use tokens that are still unused and not revoked.
-	res, err := s.db.ExecContext(ctx, `
-		UPDATE cfgms_registration_tokens
-		SET used_at = $1, used_by = $2
-		WHERE token = $3 AND single_use = true AND used_at IS NULL AND revoked = false`,
-		now, stewardID, tokenStr,
-	)
+	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
-		return fmt.Errorf("failed to consume registration token: %w", err)
+		return nil, fmt.Errorf("failed to begin rotation transaction: %w", err)
 	}
-
-	n, _ := res.RowsAffected()
-	if n > 0 {
-		return nil
-	}
-
-	// Rows-affected == 0: inspect to determine why.
-	var token business.RegistrationTokenData
-	var expiresAt, usedAt, revokedAt sql.NullTime
-	var group, usedBy sql.NullString
-	err = s.db.QueryRowContext(ctx, `
-		SELECT token, single_use, used_at, revoked, expires_at, group_name, used_by, revoked_at
-		FROM cfgms_registration_tokens WHERE token = $1`, tokenStr).Scan(
-		&token.Token, &token.SingleUse, &usedAt, &token.Revoked,
-		&expiresAt, &group, &usedBy, &revokedAt,
-	)
-	if err != nil {
-		if err == sql.ErrNoRows {
-			return fmt.Errorf("token not found")
+	committed := false
+	defer func() {
+		if !committed {
+			_ = tx.Rollback()
 		}
-		return fmt.Errorf("failed to inspect registration token: %w", err)
+	}()
+
+	// Find an existing active token to inherit controller_url.
+	var controllerURL string
+	err = tx.QueryRowContext(ctx, `
+		SELECT controller_url FROM cfgms_registration_tokens
+		WHERE tenant_id = $1 AND group_name = $2 AND revoked = false
+		ORDER BY created_at DESC LIMIT 1`,
+		tenantID, group,
+	).Scan(&controllerURL)
+	if err == sql.ErrNoRows {
+		return nil, fmt.Errorf("no active tokens found for tenant %q group %q", tenantID, group)
 	}
-	if usedAt.Valid {
-		token.UsedAt = &usedAt.Time
-	}
-	if expiresAt.Valid {
-		token.ExpiresAt = &expiresAt.Time
+	if err != nil {
+		return nil, fmt.Errorf("failed to find existing token: %w", err)
 	}
 
-	if token.Revoked {
-		return fmt.Errorf("token is revoked")
-	}
-	if token.SingleUse && token.UsedAt != nil {
-		return business.ErrTokenAlreadyUsed
-	}
-	if !token.IsValid() {
-		return fmt.Errorf("token is not valid")
-	}
+	now := time.Now().UTC()
 
-	// Multi-use token: mark used.
-	_, err = s.db.ExecContext(ctx, `
-		UPDATE cfgms_registration_tokens SET used_at = $1, used_by = $2 WHERE token = $3`,
-		now, stewardID, tokenStr,
+	// Insert the new token.
+	_, err = tx.ExecContext(ctx, `
+		INSERT INTO cfgms_registration_tokens
+			(token, tenant_id, controller_url, group_name, created_at, revoked)
+		VALUES ($1, $2, $3, $4, $5, false)`,
+		newTokenStr, tenantID, controllerURL, group, now,
 	)
 	if err != nil {
-		return fmt.Errorf("failed to mark multi-use token as used: %w", err)
+		return nil, fmt.Errorf("failed to insert new token: %w", err)
 	}
-	return nil
+
+	// Revoke all prior tokens for this tenant+group atomically.
+	_, err = tx.ExecContext(ctx, `
+		UPDATE cfgms_registration_tokens
+		SET revoked = true, revoked_at = $1
+		WHERE tenant_id = $2 AND group_name = $3 AND revoked = false AND token != $4`,
+		now, tenantID, group, newTokenStr,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to revoke old tokens: %w", err)
+	}
+
+	if err := tx.Commit(); err != nil {
+		return nil, fmt.Errorf("failed to commit rotation: %w", err)
+	}
+	committed = true
+
+	return &business.RegistrationTokenData{
+		Token:         newTokenStr,
+		TenantID:      tenantID,
+		ControllerURL: controllerURL,
+		Group:         group,
+		CreatedAt:     now,
+	}, nil
 }
 
 // nullTimeOrNil converts a *time.Time pointer to sql.NullTime
@@ -457,4 +394,13 @@ func nullTimeOrNil(t *time.Time) sql.NullTime {
 		return sql.NullTime{Valid: false}
 	}
 	return sql.NullTime{Time: *t, Valid: true}
+}
+
+// generateTokenString produces a random base32-encoded token string (16 bytes / 128-bit entropy).
+func generateTokenString() (string, error) {
+	b := make([]byte, 16)
+	if _, err := rand.Read(b); err != nil {
+		return "", fmt.Errorf("failed to read random bytes: %w", err)
+	}
+	return strings.ToLower(base32.StdEncoding.WithPadding(base32.NoPadding).EncodeToString(b)), nil
 }

--- a/pkg/storage/providers/database/registration_store_test.go
+++ b/pkg/storage/providers/database/registration_store_test.go
@@ -25,115 +25,113 @@ func newTestRegistrationStore(t *testing.T) *DatabaseRegistrationTokenStore {
 	return &DatabaseRegistrationTokenStore{db: db, config: nil, schemas: schemas}
 }
 
-func TestDatabaseRegistrationStore_ConsumeToken_SingleUse(t *testing.T) {
+func TestDatabaseRegistrationStore_RotateToken_Basic(t *testing.T) {
 	store := newTestRegistrationStore(t)
 	ctx := context.Background()
 
-	token := &business.RegistrationTokenData{
-		Token:         "db-tok-consume-single",
-		TenantID:      "t",
-		ControllerURL: "https://c.example.com",
-		SingleUse:     true,
+	seed := &business.RegistrationTokenData{
+		Token:         "db-rotate-seed",
+		TenantID:      "tenant-rotate",
+		ControllerURL: "grpc://controller:7443",
+		Group:         "prod",
 		CreatedAt:     time.Now().UTC(),
 	}
-	require.NoError(t, store.SaveToken(ctx, token))
+	require.NoError(t, store.SaveToken(ctx, seed))
 
-	// First consume must succeed.
-	require.NoError(t, store.ConsumeToken(ctx, "db-tok-consume-single", "steward-1"))
+	newTok, err := store.RotateToken(ctx, "tenant-rotate", "prod")
+	require.NoError(t, err)
+	assert.NotEmpty(t, newTok.Token)
+	assert.NotEqual(t, seed.Token, newTok.Token)
+	assert.Equal(t, "tenant-rotate", newTok.TenantID)
+	assert.Equal(t, "grpc://controller:7443", newTok.ControllerURL)
+	assert.Equal(t, "prod", newTok.Group)
 
-	// Second consume must return ErrTokenAlreadyUsed.
-	err := store.ConsumeToken(ctx, "db-tok-consume-single", "steward-2")
-	require.ErrorIs(t, err, business.ErrTokenAlreadyUsed)
+	// Old token must be revoked.
+	old, err := store.GetToken(ctx, seed.Token)
+	require.NoError(t, err)
+	assert.True(t, old.Revoked)
+
+	// New token must be valid.
+	got, err := store.GetToken(ctx, newTok.Token)
+	require.NoError(t, err)
+	assert.True(t, got.IsValid())
 }
 
-func TestDatabaseRegistrationStore_ConsumeToken_MultiUse(t *testing.T) {
+func TestDatabaseRegistrationStore_RotateToken_NoActiveTokens(t *testing.T) {
 	store := newTestRegistrationStore(t)
 	ctx := context.Background()
 
-	token := &business.RegistrationTokenData{
-		Token:         "db-tok-consume-multi",
-		TenantID:      "t",
-		ControllerURL: "https://c.example.com",
-		SingleUse:     false,
-		CreatedAt:     time.Now().UTC(),
-	}
-	require.NoError(t, store.SaveToken(ctx, token))
-
-	// Multiple consumes of multi-use token must all succeed.
-	require.NoError(t, store.ConsumeToken(ctx, "db-tok-consume-multi", "steward-1"))
-	require.NoError(t, store.ConsumeToken(ctx, "db-tok-consume-multi", "steward-2"))
-}
-
-func TestDatabaseRegistrationStore_ConsumeToken_NotFound(t *testing.T) {
-	store := newTestRegistrationStore(t)
-	ctx := context.Background()
-
-	err := store.ConsumeToken(ctx, "db-nonexistent", "steward-1")
+	_, err := store.RotateToken(ctx, "tenant-none", "group-none")
 	require.Error(t, err)
-	require.NotErrorIs(t, err, business.ErrTokenAlreadyUsed)
+	assert.Contains(t, err.Error(), "no active tokens found")
 }
 
-func TestDatabaseRegistrationStore_ConsumeToken_Revoked(t *testing.T) {
+func TestDatabaseRegistrationStore_RotateToken_RevokedTokenNotCounted(t *testing.T) {
 	store := newTestRegistrationStore(t)
 	ctx := context.Background()
 
-	token := &business.RegistrationTokenData{
-		Token:         "db-tok-revoked",
-		TenantID:      "t",
-		ControllerURL: "https://c.example.com",
-		SingleUse:     true,
+	revoked := &business.RegistrationTokenData{
+		Token:         "db-already-revoked",
+		TenantID:      "tenant-rev",
+		ControllerURL: "grpc://controller:7443",
+		Group:         "group-a",
+		Revoked:       true,
 		CreatedAt:     time.Now().UTC(),
 	}
-	require.NoError(t, store.SaveToken(ctx, token))
-	token.Revoke()
-	require.NoError(t, store.UpdateToken(ctx, token))
+	require.NoError(t, store.SaveToken(ctx, revoked))
 
-	err := store.ConsumeToken(ctx, "db-tok-revoked", "steward-1")
+	_, err := store.RotateToken(ctx, "tenant-rev", "group-a")
 	require.Error(t, err)
-	require.NotErrorIs(t, err, business.ErrTokenAlreadyUsed)
+	assert.Contains(t, err.Error(), "no active tokens found")
 }
 
-func TestDatabaseRegistrationStore_ConsumeToken_Race(t *testing.T) {
+func TestDatabaseRegistrationStore_RotateToken_Race(t *testing.T) {
 	store := newTestRegistrationStore(t)
 	ctx := context.Background()
 
-	token := &business.RegistrationTokenData{
-		Token:         "db-tok-race",
-		TenantID:      "t",
-		ControllerURL: "https://c.example.com",
-		SingleUse:     true,
+	seed := &business.RegistrationTokenData{
+		Token:         "db-race-seed",
+		TenantID:      "tenant-race",
+		ControllerURL: "grpc://controller:7443",
+		Group:         "race-group",
 		CreatedAt:     time.Now().UTC(),
 	}
-	require.NoError(t, store.SaveToken(ctx, token))
+	require.NoError(t, store.SaveToken(ctx, seed))
 
-	const goroutines = 50
+	const goroutines = 20
 	var (
 		successCount atomic.Int32
-		alreadyUsed  atomic.Int32
 		wg           sync.WaitGroup
 		start        = make(chan struct{})
 	)
 
 	wg.Add(goroutines)
 	for i := 0; i < goroutines; i++ {
-		go func(id int) {
+		go func() {
 			defer wg.Done()
 			<-start
-			err := store.ConsumeToken(ctx, "db-tok-race", "steward-"+string(rune('A'+id)))
-			switch err {
-			case nil:
+			_, err := store.RotateToken(ctx, "tenant-race", "race-group")
+			if err == nil {
 				successCount.Add(1)
-			case business.ErrTokenAlreadyUsed:
-				alreadyUsed.Add(1)
-			default:
-				t.Errorf("goroutine %d: unexpected error: %v", id, err)
 			}
-		}(i)
+		}()
 	}
 
 	close(start)
 	wg.Wait()
 
-	assert.Equal(t, int32(1), successCount.Load(), "exactly one goroutine must succeed")
-	assert.Equal(t, int32(goroutines-1), alreadyUsed.Load(), "all others must get ErrTokenAlreadyUsed")
+	// All rotations must succeed (each finds the previous rotation's token as active).
+	assert.Equal(t, int32(goroutines), successCount.Load(), "all concurrent rotations must succeed")
+
+	// Exactly one valid token must remain.
+	tokens, err := store.ListTokens(ctx, &business.RegistrationTokenFilter{TenantID: "tenant-race"})
+	require.NoError(t, err)
+
+	validCount := 0
+	for _, tok := range tokens {
+		if !tok.Revoked {
+			validCount++
+		}
+	}
+	assert.Equal(t, 1, validCount, "exactly one valid token must exist after all rotations")
 }

--- a/pkg/storage/providers/database/schemas.go
+++ b/pkg/storage/providers/database/schemas.go
@@ -584,7 +584,9 @@ func (s DatabaseSchemas) CreateRBACRoleAssignmentsTable(ctx context.Context, db 
 	return nil
 }
 
-// CreateRegistrationTokensTable creates the registration_tokens table for token persistence
+// CreateRegistrationTokensTable creates the registration_tokens table for token persistence.
+// Migration note: single_use, used_at, and used_by columns were removed in Issue #1690
+// (perennial token model with immediate-invalidation rotation).
 func (s DatabaseSchemas) CreateRegistrationTokensTable(ctx context.Context, db *sql.DB) error {
 	createTableQuery := `
 		CREATE TABLE IF NOT EXISTS cfgms_registration_tokens (
@@ -594,9 +596,6 @@ func (s DatabaseSchemas) CreateRegistrationTokensTable(ctx context.Context, db *
 			group_name VARCHAR(255) DEFAULT '',
 			created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
 			expires_at TIMESTAMP WITH TIME ZONE DEFAULT NULL,
-			single_use BOOLEAN NOT NULL DEFAULT FALSE,
-			used_at TIMESTAMP WITH TIME ZONE DEFAULT NULL,
-			used_by VARCHAR(255) DEFAULT '',
 			revoked BOOLEAN NOT NULL DEFAULT FALSE,
 			revoked_at TIMESTAMP WITH TIME ZONE DEFAULT NULL
 		);
@@ -613,9 +612,7 @@ func (s DatabaseSchemas) CreateRegistrationTokensTable(ctx context.Context, db *
 		"CREATE INDEX IF NOT EXISTS idx_cfgms_reg_tokens_created_at ON cfgms_registration_tokens(created_at);",
 		"CREATE INDEX IF NOT EXISTS idx_cfgms_reg_tokens_expires_at ON cfgms_registration_tokens(expires_at);",
 		"CREATE INDEX IF NOT EXISTS idx_cfgms_reg_tokens_revoked ON cfgms_registration_tokens(revoked);",
-		"CREATE INDEX IF NOT EXISTS idx_cfgms_reg_tokens_single_use ON cfgms_registration_tokens(single_use);",
-		"CREATE INDEX IF NOT EXISTS idx_cfgms_reg_tokens_used_at ON cfgms_registration_tokens(used_at);",
-		// Composite index for filtering unused, non-revoked tokens by tenant
+		// Composite index for filtering non-revoked tokens by tenant
 		"CREATE INDEX IF NOT EXISTS idx_cfgms_reg_tokens_tenant_active ON cfgms_registration_tokens(tenant_id) WHERE revoked = FALSE;",
 	}
 

--- a/pkg/storage/providers/sqlite/plugin.go
+++ b/pkg/storage/providers/sqlite/plugin.go
@@ -137,7 +137,7 @@ func openDB(path string) (*sql.DB, error) {
 		"PRAGMA journal_mode = WAL",
 		"PRAGMA foreign_keys = ON",
 		// Retry for up to 5 s on SQLITE_BUSY instead of failing immediately.
-		// Required for correct concurrent-write semantics (e.g. ConsumeToken race).
+		// Required for correct concurrent-write semantics (e.g. RotateToken race).
 		"PRAGMA busy_timeout = 5000",
 	} {
 		if _, err := db.Exec(pragma); err != nil {

--- a/pkg/storage/providers/sqlite/registration_store.go
+++ b/pkg/storage/providers/sqlite/registration_store.go
@@ -5,8 +5,11 @@ package sqlite
 
 import (
 	"context"
+	"crypto/rand"
 	"database/sql"
+	"encoding/base32"
 	"fmt"
+	"strings"
 	"sync"
 
 	business "github.com/cfgis/cfgms/pkg/storage/interfaces/business"
@@ -14,8 +17,8 @@ import (
 
 // SQLiteRegistrationTokenStore implements business.RegistrationTokenStore using SQLite.
 type SQLiteRegistrationTokenStore struct {
-	db        *sql.DB
-	consumeMu sync.Mutex // serializes ConsumeToken to prevent SQLITE_BUSY under high concurrency
+	db       *sql.DB
+	rotateMu sync.Mutex // serializes concurrent RotateToken calls per-instance
 }
 
 // Initialize is a no-op; schema is applied in openAndInit.
@@ -30,8 +33,7 @@ func (s *SQLiteRegistrationTokenStore) Close() error {
 }
 
 // SaveToken persists a registration token. Uses UPSERT semantics so that
-// subsequent calls with the same token update mutable state — required for
-// single-use enforcement (Story #299 parity with the database provider).
+// subsequent calls with the same token update mutable state.
 func (s *SQLiteRegistrationTokenStore) SaveToken(ctx context.Context, token *business.RegistrationTokenData) error {
 	if token == nil {
 		return fmt.Errorf("token cannot be nil")
@@ -46,16 +48,13 @@ func (s *SQLiteRegistrationTokenStore) SaveToken(ctx context.Context, token *bus
 	_, err := s.db.ExecContext(ctx, `
 		INSERT INTO registration_tokens
 			(token, tenant_id, controller_url, group_name, created_at,
-			 expires_at, single_use, used_at, used_by, revoked, revoked_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+			 expires_at, revoked, revoked_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?)
 		ON CONFLICT(token) DO UPDATE SET
 			tenant_id = excluded.tenant_id,
 			controller_url = excluded.controller_url,
 			group_name = excluded.group_name,
 			expires_at = excluded.expires_at,
-			single_use = excluded.single_use,
-			used_at = excluded.used_at,
-			used_by = excluded.used_by,
 			revoked = excluded.revoked,
 			revoked_at = excluded.revoked_at`,
 		token.Token,
@@ -64,9 +63,6 @@ func (s *SQLiteRegistrationTokenStore) SaveToken(ctx context.Context, token *bus
 		token.Group,
 		formatTime(token.CreatedAt),
 		nullTime(token.ExpiresAt),
-		boolToInt(token.SingleUse),
-		nullTime(token.UsedAt),
-		token.UsedBy,
 		boolToInt(token.Revoked),
 		nullTime(token.RevokedAt),
 	)
@@ -80,7 +76,7 @@ func (s *SQLiteRegistrationTokenStore) SaveToken(ctx context.Context, token *bus
 func (s *SQLiteRegistrationTokenStore) GetToken(ctx context.Context, tokenStr string) (*business.RegistrationTokenData, error) {
 	row := s.db.QueryRowContext(ctx, `
 		SELECT token, tenant_id, controller_url, group_name, created_at,
-		       expires_at, single_use, used_at, used_by, revoked, revoked_at
+		       expires_at, revoked, revoked_at
 		FROM registration_tokens WHERE token = ?`, tokenStr)
 	return scanToken(row)
 }
@@ -94,16 +90,12 @@ func (s *SQLiteRegistrationTokenStore) UpdateToken(ctx context.Context, token *b
 	res, err := s.db.ExecContext(ctx, `
 		UPDATE registration_tokens
 		SET tenant_id = ?, controller_url = ?, group_name = ?,
-		    expires_at = ?, single_use = ?, used_at = ?, used_by = ?,
-		    revoked = ?, revoked_at = ?
+		    expires_at = ?, revoked = ?, revoked_at = ?
 		WHERE token = ?`,
 		token.TenantID,
 		token.ControllerURL,
 		token.Group,
 		nullTime(token.ExpiresAt),
-		boolToInt(token.SingleUse),
-		nullTime(token.UsedAt),
-		token.UsedBy,
 		boolToInt(token.Revoked),
 		nullTime(token.RevokedAt),
 		token.Token,
@@ -134,7 +126,7 @@ func (s *SQLiteRegistrationTokenStore) DeleteToken(ctx context.Context, tokenStr
 // ListTokens returns registration tokens matching an optional filter.
 func (s *SQLiteRegistrationTokenStore) ListTokens(ctx context.Context, filter *business.RegistrationTokenFilter) ([]*business.RegistrationTokenData, error) {
 	query := `SELECT token, tenant_id, controller_url, group_name, created_at,
-	                 expires_at, single_use, used_at, used_by, revoked, revoked_at
+	                 expires_at, revoked, revoked_at
 	          FROM registration_tokens WHERE 1=1`
 	var args []interface{}
 
@@ -150,17 +142,6 @@ func (s *SQLiteRegistrationTokenStore) ListTokens(ctx context.Context, filter *b
 		if filter.Revoked != nil {
 			query += ` AND revoked = ?`
 			args = append(args, boolToInt(*filter.Revoked))
-		}
-		if filter.SingleUse != nil {
-			query += ` AND single_use = ?`
-			args = append(args, boolToInt(*filter.SingleUse))
-		}
-		if filter.Used != nil {
-			if *filter.Used {
-				query += ` AND used_at IS NOT NULL`
-			} else {
-				query += ` AND used_at IS NULL`
-			}
 		}
 	}
 
@@ -183,62 +164,81 @@ func (s *SQLiteRegistrationTokenStore) ListTokens(ctx context.Context, filter *b
 	return tokens, rows.Err()
 }
 
-// ConsumeToken atomically validates and marks a single-use token as used via a single UPDATE
-// with a WHERE guard. If rows-affected == 0 for a single-use token, a follow-up SELECT
-// distinguishes "not found" from "already used" to return the correct error.
-// The consumeMu mutex serializes callers within the same process because the pure-Go SQLite
-// driver does not reliably propagate busy_timeout across all pool connections.
-func (s *SQLiteRegistrationTokenStore) ConsumeToken(ctx context.Context, tokenStr, stewardID string) error {
-	s.consumeMu.Lock()
-	defer s.consumeMu.Unlock()
+// RotateToken atomically revokes all prior tokens for tenant+group and creates a new one in
+// a single SQLite transaction, ensuring no overlap window between old and new tokens.
+// rotateMu serializes concurrent callers to prevent SQLite snapshot-isolation conflicts.
+func (s *SQLiteRegistrationTokenStore) RotateToken(ctx context.Context, tenantID, group string) (*business.RegistrationTokenData, error) {
+	s.rotateMu.Lock()
+	defer s.rotateMu.Unlock()
 
-	now := formatTime(nowUTC())
+	newTokenStr, err := generateTokenString()
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate token: %w", err)
+	}
 
-	// Attempt atomic mark-used for single-use tokens that are still unused.
-	res, err := s.db.ExecContext(ctx, `
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to begin rotation transaction: %w", err)
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_ = tx.Rollback()
+		}
+	}()
+
+	// Find an existing active token to inherit controller_url.
+	var controllerURL string
+	err = tx.QueryRowContext(ctx, `
+		SELECT controller_url FROM registration_tokens
+		WHERE tenant_id = ? AND group_name = ? AND revoked = 0
+		ORDER BY created_at DESC LIMIT 1`,
+		tenantID, group,
+	).Scan(&controllerURL)
+	if err == sql.ErrNoRows {
+		return nil, fmt.Errorf("no active tokens found for tenant %q group %q", tenantID, group)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("failed to find existing token: %w", err)
+	}
+
+	now := nowUTC()
+	nowStr := formatTime(now)
+
+	// Insert the new token.
+	_, err = tx.ExecContext(ctx, `
+		INSERT INTO registration_tokens
+			(token, tenant_id, controller_url, group_name, created_at, revoked)
+		VALUES (?, ?, ?, ?, ?, 0)`,
+		newTokenStr, tenantID, controllerURL, group, nowStr,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to insert new token: %w", err)
+	}
+
+	// Revoke all prior tokens for this tenant+group atomically.
+	_, err = tx.ExecContext(ctx, `
 		UPDATE registration_tokens
-		SET used_at = ?, used_by = ?
-		WHERE token = ? AND single_use = 1 AND used_at IS NULL AND revoked = 0`,
-		now, stewardID, tokenStr,
+		SET revoked = 1, revoked_at = ?
+		WHERE tenant_id = ? AND group_name = ? AND revoked = 0 AND token != ?`,
+		nowStr, tenantID, group, newTokenStr,
 	)
 	if err != nil {
-		return fmt.Errorf("failed to consume registration token: %w", err)
+		return nil, fmt.Errorf("failed to revoke old tokens: %w", err)
 	}
 
-	n, _ := res.RowsAffected()
-	if n > 0 {
-		return nil
+	if err := tx.Commit(); err != nil {
+		return nil, fmt.Errorf("failed to commit rotation: %w", err)
 	}
+	committed = true
 
-	// Rows-affected == 0: either not found, already used, revoked, or multi-use. Inspect.
-	data, err := s.GetToken(ctx, tokenStr)
-	if err != nil {
-		// Token genuinely does not exist.
-		return fmt.Errorf("token not found")
-	}
-
-	if data.Revoked {
-		return fmt.Errorf("token is revoked")
-	}
-
-	if data.SingleUse && data.UsedAt != nil {
-		return business.ErrTokenAlreadyUsed
-	}
-
-	// Multi-use token or expired — validate then mark used unconditionally.
-	if !data.IsValid() {
-		return fmt.Errorf("token is not valid")
-	}
-
-	// Multi-use: mark used (tracks last consumer; non-blocking for concurrent callers).
-	_, err = s.db.ExecContext(ctx, `
-		UPDATE registration_tokens SET used_at = ?, used_by = ? WHERE token = ?`,
-		now, stewardID, tokenStr,
-	)
-	if err != nil {
-		return fmt.Errorf("failed to mark multi-use token as used: %w", err)
-	}
-	return nil
+	return &business.RegistrationTokenData{
+		Token:         newTokenStr,
+		TenantID:      tenantID,
+		ControllerURL: controllerURL,
+		Group:         group,
+		CreatedAt:     now,
+	}, nil
 }
 
 // ---- helpers ----------------------------------------------------------------
@@ -246,13 +246,12 @@ func (s *SQLiteRegistrationTokenStore) ConsumeToken(ctx context.Context, tokenSt
 func scanToken(row *sql.Row) (*business.RegistrationTokenData, error) {
 	t := &business.RegistrationTokenData{}
 	var createdStr string
-	var expiresAt, usedAt, revokedAt sql.NullString
-	var singleUse, revoked int
+	var expiresAt, revokedAt sql.NullString
+	var revoked int
 
 	err := row.Scan(
 		&t.Token, &t.TenantID, &t.ControllerURL, &t.Group,
-		&createdStr, &expiresAt, &singleUse, &usedAt, &t.UsedBy,
-		&revoked, &revokedAt,
+		&createdStr, &expiresAt, &revoked, &revokedAt,
 	)
 	if err == sql.ErrNoRows {
 		return nil, fmt.Errorf("registration token not found")
@@ -260,38 +259,44 @@ func scanToken(row *sql.Row) (*business.RegistrationTokenData, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to scan registration token: %w", err)
 	}
-	return populateToken(t, createdStr, singleUse, revoked, expiresAt, usedAt, revokedAt)
+	return populateToken(t, createdStr, revoked, expiresAt, revokedAt)
 }
 
 func scanTokenRow(rows *sql.Rows) (*business.RegistrationTokenData, error) {
 	t := &business.RegistrationTokenData{}
 	var createdStr string
-	var expiresAt, usedAt, revokedAt sql.NullString
-	var singleUse, revoked int
+	var expiresAt, revokedAt sql.NullString
+	var revoked int
 
 	if err := rows.Scan(
 		&t.Token, &t.TenantID, &t.ControllerURL, &t.Group,
-		&createdStr, &expiresAt, &singleUse, &usedAt, &t.UsedBy,
-		&revoked, &revokedAt,
+		&createdStr, &expiresAt, &revoked, &revokedAt,
 	); err != nil {
 		return nil, fmt.Errorf("failed to scan registration token row: %w", err)
 	}
-	return populateToken(t, createdStr, singleUse, revoked, expiresAt, usedAt, revokedAt)
+	return populateToken(t, createdStr, revoked, expiresAt, revokedAt)
 }
 
 func populateToken(
 	t *business.RegistrationTokenData,
 	createdStr string,
-	singleUse, revoked int,
-	expiresAt, usedAt, revokedAt sql.NullString,
+	revoked int,
+	expiresAt, revokedAt sql.NullString,
 ) (*business.RegistrationTokenData, error) {
 	t.CreatedAt = parseTime(createdStr)
-	t.SingleUse = singleUse != 0
 	t.Revoked = revoked != 0
 	t.ExpiresAt = parseNullTime(expiresAt)
-	t.UsedAt = parseNullTime(usedAt)
 	t.RevokedAt = parseNullTime(revokedAt)
 	return t, nil
+}
+
+// generateTokenString produces a random base32-encoded token string (16 bytes / 128-bit entropy).
+func generateTokenString() (string, error) {
+	b := make([]byte, 16)
+	if _, err := rand.Read(b); err != nil {
+		return "", fmt.Errorf("failed to read random bytes: %w", err)
+	}
+	return strings.ToLower(base32.StdEncoding.WithPadding(base32.NoPadding).EncodeToString(b)), nil
 }
 
 // ensure SQLiteRegistrationTokenStore satisfies the interface at compile time

--- a/pkg/storage/providers/sqlite/registration_store_test.go
+++ b/pkg/storage/providers/sqlite/registration_store_test.go
@@ -36,7 +36,6 @@ func TestRegistrationStore_SaveAndGet(t *testing.T) {
 		TenantID:      "tenant-1",
 		ControllerURL: "https://controller.example.com",
 		Group:         "servers",
-		SingleUse:     true,
 	}
 	require.NoError(t, store.SaveToken(ctx, token))
 
@@ -46,9 +45,7 @@ func TestRegistrationStore_SaveAndGet(t *testing.T) {
 	assert.Equal(t, token.TenantID, got.TenantID)
 	assert.Equal(t, token.ControllerURL, got.ControllerURL)
 	assert.Equal(t, token.Group, got.Group)
-	assert.True(t, got.SingleUse)
 	assert.False(t, got.Revoked)
-	assert.Nil(t, got.UsedAt)
 	assert.Nil(t, got.ExpiresAt)
 }
 
@@ -67,24 +64,18 @@ func TestRegistrationStore_Update(t *testing.T) {
 		Token:         "tok-upd",
 		TenantID:      "tenant-1",
 		ControllerURL: "https://c.example.com",
-		SingleUse:     true,
 	}
 	require.NoError(t, store.SaveToken(ctx, token))
 
-	// Mark as used
-	token.MarkUsed("steward-xyz")
+	token.Revoke()
 	require.NoError(t, store.UpdateToken(ctx, token))
 
 	got, err := store.GetToken(ctx, "tok-upd")
 	require.NoError(t, err)
-	assert.NotNil(t, got.UsedAt)
-	assert.Equal(t, "steward-xyz", got.UsedBy)
+	assert.True(t, got.Revoked)
+	assert.NotNil(t, got.RevokedAt)
 }
 
-// TestRegistrationStore_SaveToken_Upsert verifies that SaveToken acts as an
-// UPSERT — saving the same token twice updates mutable state (e.g., used_at).
-// This matches the database provider behavior (Story #299) and is the basis
-// for single-use token enforcement in the registration handler.
 func TestRegistrationStore_SaveToken_Upsert(t *testing.T) {
 	store := newRegistrationStore(t)
 	ctx := context.Background()
@@ -93,20 +84,18 @@ func TestRegistrationStore_SaveToken_Upsert(t *testing.T) {
 		Token:         "tok-upsert",
 		TenantID:      "tenant-1",
 		ControllerURL: "https://c.example.com",
-		SingleUse:     true,
 	}
 	require.NoError(t, store.SaveToken(ctx, tok))
 
 	// Second SaveToken with the same primary key must not fail and must
-	// persist the updated state (used_at, used_by).
-	tok.MarkUsed("steward-xyz")
+	// persist the updated state (revoked).
+	tok.Revoke()
 	require.NoError(t, store.SaveToken(ctx, tok))
 
 	got, err := store.GetToken(ctx, "tok-upsert")
 	require.NoError(t, err)
-	assert.NotNil(t, got.UsedAt, "UsedAt must be persisted after second SaveToken")
-	assert.Equal(t, "steward-xyz", got.UsedBy)
-	assert.False(t, got.IsValid(), "single-use token must be invalid once used")
+	assert.True(t, got.Revoked, "revoked state must be persisted after second SaveToken")
+	assert.False(t, got.IsValid(), "revoked token must be invalid")
 }
 
 func TestRegistrationStore_Delete(t *testing.T) {
@@ -206,144 +195,110 @@ func TestRegistrationStore_List(t *testing.T) {
 	assert.Len(t, byGroup, 2)
 }
 
-func TestRegistrationStore_ListUsedFilter(t *testing.T) {
+func TestRegistrationStore_RotateToken_Basic(t *testing.T) {
 	store := newRegistrationStore(t)
 	ctx := context.Background()
 
-	tok := &business.RegistrationTokenData{
-		Token:         "tok-used",
-		TenantID:      "t",
-		ControllerURL: "https://c.example.com",
-		SingleUse:     true,
+	seed := &business.RegistrationTokenData{
+		Token:         "rotate-seed",
+		TenantID:      "tenant-rotate",
+		ControllerURL: "grpc://controller:7443",
+		Group:         "prod",
 	}
-	require.NoError(t, store.SaveToken(ctx, tok))
-	tok.MarkUsed("s-1")
-	require.NoError(t, store.UpdateToken(ctx, tok))
+	require.NoError(t, store.SaveToken(ctx, seed))
 
-	require.NoError(t, store.SaveToken(ctx, &business.RegistrationTokenData{
-		Token:         "tok-unused",
-		TenantID:      "t",
-		ControllerURL: "https://c.example.com",
-	}))
-
-	trueVal := true
-	falseVal := false
-
-	used, err := store.ListTokens(ctx, &business.RegistrationTokenFilter{Used: &trueVal})
+	newTok, err := store.RotateToken(ctx, "tenant-rotate", "prod")
 	require.NoError(t, err)
-	assert.Len(t, used, 1)
-	assert.Equal(t, "tok-used", used[0].Token)
+	assert.NotEmpty(t, newTok.Token)
+	assert.NotEqual(t, seed.Token, newTok.Token)
+	assert.Equal(t, "tenant-rotate", newTok.TenantID)
+	assert.Equal(t, "grpc://controller:7443", newTok.ControllerURL)
+	assert.Equal(t, "prod", newTok.Group)
 
-	unused, err := store.ListTokens(ctx, &business.RegistrationTokenFilter{Used: &falseVal})
+	// Old token must be revoked.
+	old, err := store.GetToken(ctx, seed.Token)
 	require.NoError(t, err)
-	assert.Len(t, unused, 1)
-	assert.Equal(t, "tok-unused", unused[0].Token)
+	assert.True(t, old.Revoked)
+
+	// New token must be valid.
+	got, err := store.GetToken(ctx, newTok.Token)
+	require.NoError(t, err)
+	assert.True(t, got.IsValid())
 }
 
-func TestRegistrationStore_ConsumeToken_SingleUse(t *testing.T) {
+func TestRegistrationStore_RotateToken_NoActiveTokens(t *testing.T) {
 	store := newRegistrationStore(t)
 	ctx := context.Background()
 
-	token := &business.RegistrationTokenData{
-		Token:         "tok-consume-single",
-		TenantID:      "t",
-		ControllerURL: "https://c.example.com",
-		SingleUse:     true,
-	}
-	require.NoError(t, store.SaveToken(ctx, token))
-
-	// First consume must succeed.
-	require.NoError(t, store.ConsumeToken(ctx, "tok-consume-single", "steward-1"))
-
-	// Second consume must return ErrTokenAlreadyUsed.
-	err := store.ConsumeToken(ctx, "tok-consume-single", "steward-2")
-	require.ErrorIs(t, err, business.ErrTokenAlreadyUsed)
-}
-
-func TestRegistrationStore_ConsumeToken_MultiUse(t *testing.T) {
-	store := newRegistrationStore(t)
-	ctx := context.Background()
-
-	token := &business.RegistrationTokenData{
-		Token:         "tok-consume-multi",
-		TenantID:      "t",
-		ControllerURL: "https://c.example.com",
-		SingleUse:     false,
-	}
-	require.NoError(t, store.SaveToken(ctx, token))
-
-	require.NoError(t, store.ConsumeToken(ctx, "tok-consume-multi", "steward-1"))
-	require.NoError(t, store.ConsumeToken(ctx, "tok-consume-multi", "steward-2"))
-}
-
-func TestRegistrationStore_ConsumeToken_NotFound(t *testing.T) {
-	store := newRegistrationStore(t)
-	ctx := context.Background()
-
-	err := store.ConsumeToken(ctx, "nonexistent-tok", "steward-1")
+	_, err := store.RotateToken(ctx, "tenant-none", "group-none")
 	require.Error(t, err)
-	require.NotErrorIs(t, err, business.ErrTokenAlreadyUsed)
+	assert.Contains(t, err.Error(), "no active tokens found")
 }
 
-func TestRegistrationStore_ConsumeToken_Revoked(t *testing.T) {
+func TestRegistrationStore_RotateToken_RevokedTokenNotCounted(t *testing.T) {
 	store := newRegistrationStore(t)
 	ctx := context.Background()
 
-	token := &business.RegistrationTokenData{
-		Token:         "tok-consume-revoked",
-		TenantID:      "t",
-		ControllerURL: "https://c.example.com",
-		SingleUse:     true,
+	revoked := &business.RegistrationTokenData{
+		Token:         "already-revoked",
+		TenantID:      "tenant-rev",
+		ControllerURL: "grpc://controller:7443",
+		Group:         "group-a",
+		Revoked:       true,
 	}
-	require.NoError(t, store.SaveToken(ctx, token))
-	token.Revoke()
-	require.NoError(t, store.UpdateToken(ctx, token))
+	require.NoError(t, store.SaveToken(ctx, revoked))
 
-	err := store.ConsumeToken(ctx, "tok-consume-revoked", "steward-1")
+	_, err := store.RotateToken(ctx, "tenant-rev", "group-a")
 	require.Error(t, err)
-	require.NotErrorIs(t, err, business.ErrTokenAlreadyUsed)
+	assert.Contains(t, err.Error(), "no active tokens found")
 }
 
-func TestRegistrationStore_ConsumeToken_Race(t *testing.T) {
+func TestRegistrationStore_RotateToken_Race(t *testing.T) {
 	store := newRegistrationStore(t)
 	ctx := context.Background()
 
-	token := &business.RegistrationTokenData{
-		Token:         "tok-race",
-		TenantID:      "t",
-		ControllerURL: "https://c.example.com",
-		SingleUse:     true,
+	seed := &business.RegistrationTokenData{
+		Token:         "race-seed",
+		TenantID:      "tenant-race",
+		ControllerURL: "grpc://controller:7443",
+		Group:         "race-group",
 	}
-	require.NoError(t, store.SaveToken(ctx, token))
+	require.NoError(t, store.SaveToken(ctx, seed))
 
-	const goroutines = 50
+	const goroutines = 20
 	var (
 		successCount atomic.Int32
-		alreadyUsed  atomic.Int32
 		wg           sync.WaitGroup
 		start        = make(chan struct{})
 	)
 
 	wg.Add(goroutines)
 	for i := 0; i < goroutines; i++ {
-		go func(id int) {
+		go func() {
 			defer wg.Done()
 			<-start
-			err := store.ConsumeToken(ctx, "tok-race", "steward-"+string(rune('A'+id)))
-			switch err {
-			case nil:
+			_, err := store.RotateToken(ctx, "tenant-race", "race-group")
+			if err == nil {
 				successCount.Add(1)
-			case business.ErrTokenAlreadyUsed:
-				alreadyUsed.Add(1)
-			default:
-				t.Errorf("goroutine %d: unexpected error: %v", id, err)
 			}
-		}(i)
+		}()
 	}
 
 	close(start)
 	wg.Wait()
 
-	assert.Equal(t, int32(1), successCount.Load(), "exactly one goroutine must succeed")
-	assert.Equal(t, int32(goroutines-1), alreadyUsed.Load(), "all others must get ErrTokenAlreadyUsed")
+	// All rotations must succeed (each one finds the previous rotation's token as active).
+	assert.Equal(t, int32(goroutines), successCount.Load(), "all concurrent rotations must succeed")
+
+	// Exactly one valid token must remain.
+	tokens, err := store.ListTokens(ctx, &business.RegistrationTokenFilter{TenantID: "tenant-race"})
+	require.NoError(t, err)
+
+	validCount := 0
+	for _, tok := range tokens {
+		if !tok.Revoked {
+			validCount++
+		}
+	}
+	assert.Equal(t, 1, validCount, "exactly one valid token must exist after all rotations")
 }

--- a/pkg/storage/providers/sqlite/schema.go
+++ b/pkg/storage/providers/sqlite/schema.go
@@ -249,7 +249,9 @@ func initializeSchema(ctx context.Context, db *sql.DB) error {
 		`CREATE INDEX IF NOT EXISTS idx_rbac_role_assignments_role_id    ON rbac_role_assignments(role_id)`,
 		`CREATE INDEX IF NOT EXISTS idx_rbac_role_assignments_tenant_id  ON rbac_role_assignments(tenant_id)`,
 
-		// Registration tokens
+		// Registration tokens — perennial model (Issue #1690)
+		// Migration note: single_use, used_at, and used_by columns were removed in Issue #1690.
+		// Pre-existing deployments must DROP these columns before upgrading.
 		`CREATE TABLE IF NOT EXISTS registration_tokens (
 			token          TEXT PRIMARY KEY,
 			tenant_id      TEXT NOT NULL,
@@ -257,9 +259,6 @@ func initializeSchema(ctx context.Context, db *sql.DB) error {
 			group_name     TEXT NOT NULL DEFAULT '',
 			created_at     TEXT NOT NULL,
 			expires_at     TEXT,
-			single_use     INTEGER NOT NULL DEFAULT 0,
-			used_at        TEXT,
-			used_by        TEXT NOT NULL DEFAULT '',
 			revoked        INTEGER NOT NULL DEFAULT 0,
 			revoked_at     TEXT
 		)`,

--- a/test/e2e/framework.go
+++ b/test/e2e/framework.go
@@ -480,8 +480,7 @@ func (f *E2ETestFramework) CreateRegistrationToken(tenantID string) (string, err
 		TenantID:      tenantID,
 		ControllerURL: "grpc://localhost:4433",
 		Group:         "e2e-test",
-		ExpiresIn:     "",    // Never expires for testing
-		SingleUse:     false, // Can be reused for testing
+		ExpiresIn:     "", // Never expires for testing
 	}
 
 	token, err := registration.CreateToken(tokenReq)

--- a/test/integration/certificate_registration_test.go
+++ b/test/integration/certificate_registration_test.go
@@ -35,7 +35,7 @@ import (
 // This test suite validates:
 //  1. Registration token validation logic
 //  2. Certificate generation during registration
-//  3. Token lifecycle (expiration, revocation, single-use)
+//  3. Token lifecycle (expiration, revocation, rotation)
 //  4. Certificate chain validity
 //
 // Philosophy: "Test what you ship, ship what you test"
@@ -128,7 +128,6 @@ func (s *CertificateRegistrationTestSuite) TestTokenValidation() {
 		ControllerURL: "tcp://localhost:1883",
 		Group:         "test-group",
 		CreatedAt:     time.Now(),
-		SingleUse:     false,
 		Revoked:       false,
 	}
 	err := s.adapter.SaveToken(ctx, token)
@@ -156,7 +155,6 @@ func (s *CertificateRegistrationTestSuite) TestExpiredTokenInvalid() {
 		ControllerURL: "tcp://localhost:1883",
 		CreatedAt:     time.Now().Add(-2 * time.Hour),
 		ExpiresAt:     &pastExpiry,
-		SingleUse:     false,
 		Revoked:       false,
 	}
 	err := s.adapter.SaveToken(ctx, token)
@@ -180,7 +178,6 @@ func (s *CertificateRegistrationTestSuite) TestRevokedTokenInvalid() {
 		TenantID:      "test-tenant",
 		ControllerURL: "tcp://localhost:1883",
 		CreatedAt:     time.Now(),
-		SingleUse:     false,
 	}
 	token.Revoke()
 	err := s.adapter.SaveToken(ctx, token)
@@ -196,71 +193,60 @@ func (s *CertificateRegistrationTestSuite) TestRevokedTokenInvalid() {
 	s.T().Log("Revoked token correctly marked as invalid")
 }
 
-// TestSingleUseTokenBecomesInvalidAfterUse validates single-use token behavior
-func (s *CertificateRegistrationTestSuite) TestSingleUseTokenBecomesInvalidAfterUse() {
+// TestPerennialTokenRemainsValidAfterMultipleUses validates perennial token behavior.
+// Tokens are never consumed on use — they survive multiple registrations until
+// explicitly revoked or rotated (Issue #1690).
+func (s *CertificateRegistrationTestSuite) TestPerennialTokenRemainsValidAfterMultipleUses() {
 	ctx := context.Background()
 
-	// Create a single-use token
 	token := &registration.Token{
-		Token:         "cfgms_reg_single_use_test_001",
+		Token:         "cfgms_reg_perennial_test_001",
 		TenantID:      "test-tenant",
 		ControllerURL: "tcp://localhost:1883",
 		CreatedAt:     time.Now(),
-		SingleUse:     true,
 		Revoked:       false,
 	}
 	err := s.adapter.SaveToken(ctx, token)
 	require.NoError(s.T(), err)
 
-	// Token should be valid initially
-	retrieved, err := s.adapter.GetToken(ctx, token.Token)
-	require.NoError(s.T(), err)
-	assert.True(s.T(), retrieved.IsValid(), "Single-use token should be valid initially")
+	// Token should remain valid across multiple retrievals (simulating multiple registrations).
+	for i := 0; i < 3; i++ {
+		retrieved, err := s.adapter.GetToken(ctx, token.Token)
+		require.NoError(s.T(), err)
+		assert.True(s.T(), retrieved.IsValid(), "Perennial token must remain valid after registration #%d", i+1)
+	}
 
-	// Mark as used
-	retrieved.MarkUsed("steward-001")
-	err = s.adapter.UpdateToken(ctx, retrieved)
-	require.NoError(s.T(), err)
-
-	// Token should now be invalid
-	afterUse, err := s.adapter.GetToken(ctx, token.Token)
-	require.NoError(s.T(), err)
-	assert.False(s.T(), afterUse.IsValid(), "Single-use token should be invalid after use")
-	assert.Equal(s.T(), "steward-001", afterUse.UsedBy, "UsedBy should be set")
-	assert.NotNil(s.T(), afterUse.UsedAt, "UsedAt should be set")
-
-	s.T().Log("Single-use token enforcement working correctly")
+	s.T().Log("Perennial token survives multiple uses correctly")
 }
 
-// TestMultiUseTokenRemainsValidAfterUse validates multi-use tokens stay valid
-func (s *CertificateRegistrationTestSuite) TestMultiUseTokenRemainsValidAfterUse() {
+// TestTokenRotateInvalidatesPriorToken validates that RotateToken revokes the old
+// token and returns a new valid one (Issue #1690).
+func (s *CertificateRegistrationTestSuite) TestTokenRotateInvalidatesPriorToken() {
 	ctx := context.Background()
 
-	// Create a multi-use token
 	token := &registration.Token{
-		Token:         "cfgms_reg_multi_use_test_001",
-		TenantID:      "test-tenant",
+		Token:         "cfgms_reg_rotate_test_001",
+		TenantID:      "rotate-tenant",
 		ControllerURL: "tcp://localhost:1883",
+		Group:         "test-group",
 		CreatedAt:     time.Now(),
-		SingleUse:     false,
-		Revoked:       false,
 	}
 	err := s.adapter.SaveToken(ctx, token)
 	require.NoError(s.T(), err)
 
-	// Mark as used (would happen during registration)
-	retrieved, err := s.adapter.GetToken(ctx, token.Token)
+	newTok, err := s.tokenStore.RotateToken(ctx, "rotate-tenant", "test-group")
 	require.NoError(s.T(), err)
-	retrieved.MarkUsed("steward-001")
-	err = s.adapter.UpdateToken(ctx, retrieved)
-	require.NoError(s.T(), err)
+	require.NotNil(s.T(), newTok)
+	assert.NotEqual(s.T(), token.Token, newTok.Token, "New token must differ from old")
+	assert.True(s.T(), newTok.IsValid(), "Newly rotated token must be valid")
 
-	// Token should still be valid (multi-use)
-	afterUse, err := s.adapter.GetToken(ctx, token.Token)
+	// Old token must be revoked.
+	old, err := s.tokenStore.GetToken(ctx, token.Token)
 	require.NoError(s.T(), err)
-	assert.True(s.T(), afterUse.IsValid(), "Multi-use token should remain valid after use")
+	assert.True(s.T(), old.Revoked, "Old token must be revoked after rotation")
+	assert.False(s.T(), old.IsValid(), "Old token must be invalid after rotation")
 
-	s.T().Log("Multi-use token allows multiple uses")
+	s.T().Log("Token rotation correctly invalidates the prior token")
 }
 
 // TestCertificateProvisioning validates certificate generation for steward
@@ -460,7 +446,6 @@ func (s *CertificateRegistrationTestSuite) TestTokenWithFutureExpiry() {
 		ControllerURL: "tcp://localhost:1883",
 		CreatedAt:     time.Now(),
 		ExpiresAt:     &futureExpiry,
-		SingleUse:     false,
 		Revoked:       false,
 	}
 	err := s.adapter.SaveToken(ctx, token)
@@ -526,7 +511,6 @@ func (s *CertificateRegistrationTestSuite) TestRegistrationFlowIntegration() {
 		ControllerURL: "tcp://localhost:1883",
 		Group:         "production",
 		CreatedAt:     time.Now(),
-		SingleUse:     true,
 		Revoked:       false,
 	}
 	err := s.adapter.SaveToken(ctx, token)
@@ -549,18 +533,12 @@ func (s *CertificateRegistrationTestSuite) TestRegistrationFlowIntegration() {
 	require.NoError(s.T(), err)
 	require.True(s.T(), certResp.Success)
 
-	// Step 5: Mark token as used (for single-use tokens)
-	retrieved.MarkUsed(stewardID)
-	err = s.adapter.UpdateToken(ctx, retrieved)
+	// Step 5: Perennial tokens survive registration — token stays valid.
+	stillValid, err := s.adapter.GetToken(ctx, token.Token)
 	require.NoError(s.T(), err)
+	assert.True(s.T(), stillValid.IsValid(), "Perennial token must remain valid after registration")
 
-	// Step 6: Verify token is now invalid (single-use)
-	afterUse, err := s.adapter.GetToken(ctx, token.Token)
-	require.NoError(s.T(), err)
-	assert.False(s.T(), afterUse.IsValid(), "Single-use token should be invalid after use")
-	assert.Equal(s.T(), stewardID, afterUse.UsedBy)
-
-	// Step 7: Verify certificate is valid
+	// Step 6: Verify certificate is valid
 	err = cert.ValidateKeyPair(certResp.CertificatePEM, certResp.PrivateKeyPEM)
 	require.NoError(s.T(), err)
 

--- a/test/integration/controller_test.go
+++ b/test/integration/controller_test.go
@@ -142,7 +142,6 @@ func (s *ControllerTestSuite) TestStewardRegistration() {
 		ControllerURL: fmt.Sprintf("quic://%s", s.env.Controller.GetListenAddr()),
 		Group:         "test-group",
 		ExpiresIn:     "1h",
-		SingleUse:     false,
 	})
 	require.NoError(s.T(), err, "Should create registration token")
 

--- a/test/integration/registration_token_persistence_test.go
+++ b/test/integration/registration_token_persistence_test.go
@@ -65,7 +65,6 @@ func TestRegistrationTokenPersistence_AcrossRestart(t *testing.T) {
 			ControllerURL: "tcp://localhost:1883",
 			Group:         "test-group",
 			CreatedAt:     now,
-			SingleUse:     false,
 			Revoked:       false,
 		},
 		{
@@ -75,7 +74,6 @@ func TestRegistrationTokenPersistence_AcrossRestart(t *testing.T) {
 			Group:         "test-group",
 			CreatedAt:     now,
 			ExpiresAt:     &futureExpiry,
-			SingleUse:     true,
 			Revoked:       false,
 		},
 		{
@@ -84,7 +82,6 @@ func TestRegistrationTokenPersistence_AcrossRestart(t *testing.T) {
 			ControllerURL: "tcp://localhost:1883",
 			Group:         "other-group",
 			CreatedAt:     now,
-			SingleUse:     false,
 			Revoked:       false,
 		},
 	}
@@ -95,13 +92,13 @@ func TestRegistrationTokenPersistence_AcrossRestart(t *testing.T) {
 		t.Logf("Saved token: %s (tenant: %s)", token.Token, token.TenantID)
 	}
 
-	// Mark one token as used
+	// Revoke token 2 to test revocation persistence.
 	token2, err := adapter1.GetToken(ctx, "cfgms_reg_persist_test_2")
 	require.NoError(t, err)
-	token2.MarkUsed("steward-001")
+	token2.Revoke()
 	err = adapter1.UpdateToken(ctx, token2)
 	require.NoError(t, err)
-	t.Log("Marked token 2 as used by steward-001")
+	t.Log("Revoked token 2")
 
 	// Verify tokens exist in first store
 	allTokens, err := adapter1.ListTokens(ctx, "tenant-persistence-1")
@@ -135,13 +132,13 @@ func TestRegistrationTokenPersistence_AcrossRestart(t *testing.T) {
 	assert.True(t, retrieved1.IsValid(), "Token 1 should be valid")
 	t.Log("Token 1 persisted correctly and is valid")
 
-	// Verify token 2 exists with used status preserved
+	// Verify token 2 exists with revoked status preserved.
 	retrieved2, err := adapter2.GetToken(ctx, "cfgms_reg_persist_test_2")
 	require.NoError(t, err, "Token 2 should persist after restart")
-	assert.NotNil(t, retrieved2.UsedAt, "Token 2 should retain used status")
-	assert.Equal(t, "steward-001", retrieved2.UsedBy, "Token 2 should retain used_by")
-	assert.False(t, retrieved2.IsValid(), "Token 2 should be invalid (single-use and used)")
-	t.Log("Token 2 persisted with used status preserved")
+	assert.True(t, retrieved2.Revoked, "Token 2 should retain revoked status")
+	assert.NotNil(t, retrieved2.RevokedAt, "Token 2 should retain revoked_at")
+	assert.False(t, retrieved2.IsValid(), "Token 2 should be invalid (revoked)")
+	t.Log("Token 2 persisted with revoked status preserved")
 
 	// Verify token 3 exists
 	retrieved3, err := adapter2.GetToken(ctx, "cfgms_reg_persist_test_3")
@@ -297,12 +294,11 @@ func TestRegistrationTokenPersistence_DeletePersists(t *testing.T) {
 	assert.Contains(t, err.Error(), "not found")
 }
 
-// TestConcurrentRegistration_SingleUseToken_ExactlyOneSucceeds validates that two
-// concurrent HTTP POST /api/v1/register requests with the same single-use token
-// produce exactly one 200 OK and one 409 Conflict against a real Server backed
-// by SQLite storage. This proves the TOCTOU race fixed in Issue #774 holds under
-// real concurrent HTTP load.
-func TestConcurrentRegistration_SingleUseToken_ExactlyOneSucceeds(t *testing.T) {
+// TestConcurrentRegistration_PerennialToken_AllRequestsSucceed validates that
+// multiple concurrent HTTP POST /api/v1/register requests with the same perennial
+// token all succeed (200 OK). Perennial tokens survive multiple registrations and
+// are never consumed on use (Issue #1690).
+func TestConcurrentRegistration_PerennialToken_AllRequestsSucceed(t *testing.T) {
 	tempDir, err := os.MkdirTemp("", "reg-concurrent-*")
 	require.NoError(t, err)
 	defer func() { _ = os.RemoveAll(tempDir) }()
@@ -373,12 +369,11 @@ func TestConcurrentRegistration_SingleUseToken_ExactlyOneSucceeds(t *testing.T) 
 	)
 	require.NoError(t, err)
 
-	// Seed a single-use token
+	// Seed a perennial token (no expiry, not revoked).
 	tok := &registration.Token{
 		Token:         "cfgms_reg_concurrent_integ_test",
 		TenantID:      "integ-tenant",
 		ControllerURL: "grpc://controller:7443",
-		SingleUse:     true,
 	}
 	require.NoError(t, tokenStore.SaveToken(ctx, tok))
 
@@ -386,10 +381,11 @@ func TestConcurrentRegistration_SingleUseToken_ExactlyOneSucceeds(t *testing.T) 
 	ts := httptest.NewServer(server.GetRouter())
 	defer ts.Close()
 
+	const concurrency = 3
 	type result struct{ code int }
-	results := make([]result, 2)
+	results := make([]result, concurrency)
 	var wg sync.WaitGroup
-	for i := 0; i < 2; i++ {
+	for i := 0; i < concurrency; i++ {
 		wg.Add(1)
 		go func(idx int) {
 			defer wg.Done()
@@ -408,19 +404,8 @@ func TestConcurrentRegistration_SingleUseToken_ExactlyOneSucceeds(t *testing.T) 
 	}
 	wg.Wait()
 
-	codes := []int{results[0].code, results[1].code}
-	assert.Contains(t, codes, http.StatusOK, "exactly one goroutine must succeed with 200")
-	assert.Contains(t, codes, http.StatusConflict, "exactly one goroutine must get 409")
-
-	okCount, conflictCount := 0, 0
-	for _, r := range results {
-		switch r.code {
-		case http.StatusOK:
-			okCount++
-		case http.StatusConflict:
-			conflictCount++
-		}
+	// Perennial tokens are never consumed: all concurrent registrations must succeed.
+	for i, r := range results {
+		assert.Equal(t, http.StatusOK, r.code, "request %d must succeed with 200 (perennial token)", i)
 	}
-	assert.Equal(t, 1, okCount, "exactly one 200")
-	assert.Equal(t, 1, conflictCount, "exactly one 409")
 }

--- a/test/integration/testutil/test_helper.go
+++ b/test/integration/testutil/test_helper.go
@@ -212,7 +212,6 @@ func createTestEnv(t *testing.T, tempDir string, logger *testpkg.MockLogger, ctx
 		ControllerURL: "grpc://localhost:0",
 		Group:         "test-group",
 		ExpiresIn:     "",
-		SingleUse:     false,
 	}
 	regTokenObj, regTokenErr := registration.CreateToken(tokenReq)
 	if regTokenErr != nil {

--- a/test/integration/transport/registration_test.go
+++ b/test/integration/transport/registration_test.go
@@ -93,24 +93,19 @@ func (s *RegistrationTestSuite) TestRevokedToken() {
 	s.Equal(http.StatusUnauthorized, resp.StatusCode, "Revoked token should return 401")
 }
 
-// TestSingleUseToken tests that single-use tokens can only be used once.
-func (s *RegistrationTestSuite) TestSingleUseToken() {
-	reqBody := map[string]string{"token": "integration_singleuse"}
+// TestPerennialToken tests that perennial tokens can be used multiple times (Issue #1690).
+func (s *RegistrationTestSuite) TestPerennialToken() {
+	reqBody := map[string]string{"token": "integration_reusable"}
 	reqJSON, err := json.Marshal(reqBody)
 	s.NoError(err)
 
 	registrationURL := fmt.Sprintf("%s/api/v1/register", s.helper.baseURL)
-	resp1, err := s.helper.httpClient.Post(registrationURL, "application/json", bytes.NewBuffer(reqJSON))
-	s.NoError(err)
-	defer func() { _ = resp1.Body.Close() }()
-
-	s.Equal(http.StatusOK, resp1.StatusCode, "First registration should succeed")
-
-	resp2, err := s.helper.httpClient.Post(registrationURL, "application/json", bytes.NewBuffer(reqJSON))
-	s.NoError(err)
-	defer func() { _ = resp2.Body.Close() }()
-
-	s.Equal(http.StatusConflict, resp2.StatusCode, "Second registration with single-use token should be rejected with 409 Conflict (token already consumed)")
+	for i := 0; i < 3; i++ {
+		resp, postErr := s.helper.httpClient.Post(registrationURL, "application/json", bytes.NewBuffer(reqJSON))
+		s.NoError(postErr)
+		_ = resp.Body.Close()
+		s.Equal(http.StatusOK, resp.StatusCode, "Registration #%d with perennial token must succeed", i+1)
+	}
 }
 
 // TestStewardIDUniqueness tests that each registration produces a unique steward ID.


### PR DESCRIPTION
## Summary

- Replaces single-use token model with perennial tokens that survive multiple registrations
- `RotateToken(ctx, tenantID, group)` atomically revokes all prior tokens and issues a new one in a single SQLite/Postgres transaction; `rotateMu` mutex serializes concurrent callers to avoid `SQLITE_BUSY_SNAPSHOT` conflicts
- Removes `ConsumeToken`, `SingleUse`, `MarkUsed`, `UsedAt`, `UsedBy` from the interface, all storage providers, adapter, CLI, and all tests across 42 files
- Adds `POST /api/v1/registration/tokens/{tenant_id}/rotate` endpoint with `registration:rotate-token` permission
- Adds `cfg token rotate` CLI command
- Fixes tenant_id URL path validation (was incorrectly enforcing UUID format; CFGMS tenant IDs are human-readable strings like "acme-corp")

## Test plan

- [x] `TestRegistrationStore_RotateToken_Race` — 20 concurrent goroutines all succeed (was failing with 3-5 successes before mutex fix)
- [x] `TestStorageAdapter_RotateToken_Race` — same race test at adapter layer
- [x] `TestRotateRegistrationToken` — all subtests pass: rotate returns 201, no active tokens returns 404, unauthorized returns 401
- [x] `TestServer_SeedTestTokens_WhenEnvVarEnabled` — updated to match actual seed token list (removed `integration_singleuse`)
- [x] `TestCertificateRegistration/TestPerennialTokenRemainsValidAfterMultipleUses` — perennial behavior confirmed
- [x] `TestCertificateRegistration/TestTokenRotateInvalidatesPriorToken` — atomic rotation confirmed
- [x] `make test-agent-complete` — all checks pass (pre-commit, fast, production-critical, cross-platform compilation)
- [x] `make check-architecture` — no central provider violations

Fixes #1690

🤖 Generated with [Claude Code](https://claude.com/claude-code)