### PR TITLE
registration: implement IP-trust establishment evaluator (Issue #1694)

### DIFF
--- a/docs/architecture/controller-operating-model.md
+++ b/docs/architecture/controller-operating-model.md
@@ -222,6 +222,27 @@ The controller monitors steward heartbeats to detect connectivity loss:
 
 These fields must remain distinct. `HeartbeatTimeout` is intentionally short for fast HA-failover detection and must not be used for steward-liveness decisions.
 
+### IP-Trust Establishment
+
+The controller promotes a steward's source IP to **trusted status** only after it has been continuously healthy for at least the configured threshold (default: **30 minutes**). This is implemented by `IPTrustEvaluator` (`features/controller/registration/ip_trust_evaluator.go`, Issue #1694).
+
+**Mechanism:**
+
+1. Each heartbeat from a healthy steward triggers `RecordLiveness(tenantID, stewardID, ip, healthy=true)` via the `TrustEvaluator` wired into the heartbeat service.
+2. The evaluator maintains an in-memory per-(tenantID, ip) timer recording the first time a healthy liveness event was seen.
+3. When `now − firstSeen ≥ threshold`, the evaluator calls `store.AddTrustedRange(tenantID, ip+"/32", false)` and clears the timer.
+4. When the steward goes offline (`healthy=false`), the timer is reset. The IP must sustain liveness from scratch before trust is granted.
+
+**Sandbox-detonation resistance:** Analysis environments (VMs, containers) that auto-detonate after 3–15 minutes cannot sustain the 30-minute liveness window. Their IP is never promoted to trusted status.
+
+**Failure-safe restarts:** The in-memory timer is intentionally non-durable. After a controller restart the 30-minute clock resets, but existing trust entries in the `IPTrustStore` survive. This is fail-safe — the timer reset only delays trust establishment; it never revokes already-trusted IPs.
+
+**Configuration:** `registration.ip_trust_threshold` (YAML duration, default `30m`). The threshold is configurable per deployment; the default of 30 minutes is chosen to be well above sandbox lifetime (3–15 min) while remaining practical for legitimate registrations.
+
+| Parameter | Default | Purpose |
+|-----------|---------|---------|
+| `registration.ip_trust_threshold` | 30 min | Continuous liveness required before IP is trusted (Issue #1694) |
+
 ### Commands
 
 The controller can send commands to stewards over the gRPC control plane service:

--- a/features/controller/config/config.go
+++ b/features/controller/config/config.go
@@ -123,6 +123,11 @@ type RegistrationConfig struct {
 	//     PendingRegistrationStore and holds the steward in quarantine until an
 	//     operator acts via `cfg registration approve/deny` (#1522-B).
 	ApprovalMode string `yaml:"approval_mode,omitempty"`
+
+	// IPTrustThreshold is the minimum continuous liveness duration before an IP
+	// is promoted to trusted status (Issue #1694). Default: 30 minutes.
+	// Sandbox-detonation attempts (3–15 min lifetime) cannot sustain this window.
+	IPTrustThreshold Duration `yaml:"ip_trust_threshold,omitempty"`
 }
 
 // CertificateConfig contains certificate management settings
@@ -810,4 +815,13 @@ func (cc *CertificateConfig) GetPublicAPISource() string {
 		return cc.PublicAPI.Source
 	}
 	return "internal"
+}
+
+// GetIPTrustThreshold returns the IP-trust establishment threshold, defaulting
+// to 30 minutes when not configured (Issue #1694).
+func (rc *RegistrationConfig) GetIPTrustThreshold() time.Duration {
+	if rc == nil || rc.IPTrustThreshold == 0 {
+		return 30 * time.Minute
+	}
+	return rc.IPTrustThreshold.AsDuration()
 }

--- a/features/controller/config/config_test.go
+++ b/features/controller/config/config_test.go
@@ -282,3 +282,37 @@ func TestRegistrationConfigAutoApprove(t *testing.T) {
 	require.NotNil(t, cfg.Registration)
 	assert.Equal(t, "auto-approve", cfg.Registration.Workflow)
 }
+
+// TestRegistrationConfig_GetIPTrustThreshold verifies the IP-trust threshold
+// getter covers all three cases: nil receiver, zero value, and configured value
+// (Issue #1694).
+func TestRegistrationConfig_GetIPTrustThreshold(t *testing.T) {
+	// Nil receiver returns the 30-minute default.
+	var rc *RegistrationConfig
+	assert.Equal(t, 30*time.Minute, rc.GetIPTrustThreshold(),
+		"nil RegistrationConfig must default to 30 minutes")
+
+	// Zero value returns the 30-minute default.
+	zero := &RegistrationConfig{}
+	assert.Equal(t, 30*time.Minute, zero.GetIPTrustThreshold(),
+		"zero IPTrustThreshold must default to 30 minutes")
+
+	// Configured value is returned as-is.
+	configured := &RegistrationConfig{IPTrustThreshold: Duration(45 * time.Minute)}
+	assert.Equal(t, 45*time.Minute, configured.GetIPTrustThreshold(),
+		"configured threshold must be returned unchanged")
+}
+
+// TestRegistrationConfig_IPTrustThreshold_YAML verifies that the ip_trust_threshold
+// field is correctly parsed from YAML (Issue #1694).
+func TestRegistrationConfig_IPTrustThreshold_YAML(t *testing.T) {
+	yamlInput := "registration:\n  workflow: manual-review\n  ip_trust_threshold: 45m\n"
+
+	cfg := &Config{}
+	err := yaml.Unmarshal([]byte(yamlInput), cfg)
+	require.NoError(t, err)
+
+	require.NotNil(t, cfg.Registration)
+	assert.Equal(t, 45*time.Minute, cfg.Registration.GetIPTrustThreshold(),
+		"ip_trust_threshold must be parsed from YAML duration string")
+}

--- a/features/controller/heartbeat/service.go
+++ b/features/controller/heartbeat/service.go
@@ -61,6 +61,14 @@ type DNAHashMismatchCallback func(stewardID string)
 // can use the heartbeat as a trigger to drain pending work.
 type HeartbeatReceivedCallback func(stewardID string)
 
+// TrustEvaluator receives liveness signals from the heartbeat service and
+// decides whether an IP should be promoted to trusted status (Issue #1694).
+// The implementation (e.g. IPTrustEvaluator via the server.go adapter) is
+// responsible for resolving tenant and IP information from the steward store.
+type TrustEvaluator interface {
+	RecordLiveness(ctx context.Context, stewardID string, healthy bool) error
+}
+
 // Service monitors steward heartbeats via the ControlPlaneProvider.
 type Service struct {
 	mu sync.RWMutex
@@ -83,6 +91,9 @@ type Service struct {
 	onStatusChange      StatusChangeCallback
 	onDNAHashMismatch   DNAHashMismatchCallback
 	onHeartbeatReceived HeartbeatReceivedCallback
+
+	// Trust evaluator for IP-trust establishment (Issue #1694). Optional — nil disables.
+	trustEvaluator TrustEvaluator
 
 	// Control
 	ctx    context.Context
@@ -127,6 +138,11 @@ type Config struct {
 	// even when the steward remains healthy. Optional — nil disables.
 	OnHeartbeatReceived HeartbeatReceivedCallback
 
+	// TrustEvaluator receives healthy/unhealthy liveness signals so the
+	// IP-trust establishment gate (Issue #1694) can promote IPs to trusted
+	// status after sustained liveness. Optional — nil disables.
+	TrustEvaluator TrustEvaluator
+
 	// Logger for service logging
 	Logger logging.Logger
 }
@@ -163,6 +179,7 @@ func New(cfg *Config) (*Service, error) {
 		onStatusChange:        cfg.OnStatusChange,
 		onDNAHashMismatch:     cfg.OnDNAHashMismatch,
 		onHeartbeatReceived:   cfg.OnHeartbeatReceived,
+		trustEvaluator:        cfg.TrustEvaluator,
 		ctx:                   ctx,
 		cancel:                cancel,
 		logger:                cfg.Logger,
@@ -275,6 +292,14 @@ func (s *Service) handleHeartbeatFromProvider(ctx context.Context, hb *controlpl
 		s.onHeartbeatReceived(hb.StewardID)
 	}
 
+	// Notify the trust evaluator of a healthy liveness event (Issue #1694).
+	if s.trustEvaluator != nil {
+		if err := s.trustEvaluator.RecordLiveness(ctx, hb.StewardID, true); err != nil {
+			s.logger.Warn("Trust evaluator error on healthy heartbeat",
+				"steward_id", hb.StewardID, "error", err)
+		}
+	}
+
 	return nil
 }
 
@@ -315,6 +340,14 @@ func (s *Service) checkStaleHeartbeats() {
 
 				if s.onStatusChange != nil {
 					s.onStatusChange(stewardID, false, *status)
+				}
+
+				// Notify the trust evaluator that this steward went offline (Issue #1694).
+				if s.trustEvaluator != nil {
+					if err := s.trustEvaluator.RecordLiveness(context.Background(), stewardID, false); err != nil {
+						s.logger.Warn("Trust evaluator error on stale detection",
+							"steward_id", stewardID, "error", err)
+					}
 				}
 			}
 		}

--- a/features/controller/heartbeat/service_test.go
+++ b/features/controller/heartbeat/service_test.go
@@ -6,6 +6,7 @@ package heartbeat
 
 import (
 	"context"
+	"sync"
 	"testing"
 	"time"
 
@@ -13,6 +14,38 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// recordingTrustEvaluator is a real in-process TrustEvaluator used for testing.
+// It records every RecordLiveness call so tests can assert on call arguments.
+// It is NOT a mock — it is a functional test implementation that satisfies the
+// TrustEvaluator interface contract.
+type recordingTrustEvaluator struct {
+	mu    sync.Mutex
+	calls []trustCall
+}
+
+type trustCall struct {
+	stewardID string
+	healthy   bool
+}
+
+func (r *recordingTrustEvaluator) RecordLiveness(_ context.Context, stewardID string, healthy bool) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.calls = append(r.calls, trustCall{stewardID: stewardID, healthy: healthy})
+	return nil
+}
+
+func (r *recordingTrustEvaluator) allCalls() []trustCall {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make([]trustCall, len(r.calls))
+	copy(out, r.calls)
+	return out
+}
+
+// Compile-time: recordingTrustEvaluator satisfies TrustEvaluator.
+var _ TrustEvaluator = (*recordingTrustEvaluator)(nil)
 
 // TestHeartbeatService_StewardOfflineThreshold_60s verifies that:
 //  1. StewardOfflineTimeout defaults to 60 s when not configured.
@@ -100,4 +133,97 @@ func TestHeartbeatService_HAFailoverThreshold_15s(t *testing.T) {
 		"overriding StewardOfflineTimeout must not change HeartbeatTimeout")
 	assert.Equal(t, 120*time.Second, customSvc.stewardOfflineTimeout,
 		"custom StewardOfflineTimeout must be respected")
+}
+
+// TestHeartbeatService_TrustEvaluator_CalledOnHeartbeat verifies that the
+// TrustEvaluator.RecordLiveness is called with healthy=true on each incoming
+// heartbeat and with healthy=false when a steward is marked stale.
+// It also verifies that a nil TrustEvaluator causes no panic (Issue #1694).
+func TestHeartbeatService_TrustEvaluator_CalledOnHeartbeat(t *testing.T) {
+	evaluator := &recordingTrustEvaluator{}
+	_, cp := newTestService(t, func(cfg *Config) {
+		cfg.TrustEvaluator = evaluator
+	})
+	ctx := context.Background()
+
+	const stewardID = "steward-trust-test"
+
+	// Send a heartbeat — evaluator must receive healthy=true for this steward.
+	require.NoError(t, cp.sendHeartbeat(ctx, &controlplaneTypes.Heartbeat{
+		StewardID: stewardID,
+		Status:    controlplaneTypes.StatusHealthy,
+		Timestamp: time.Now(),
+	}))
+
+	calls := evaluator.allCalls()
+	require.NotEmpty(t, calls, "RecordLiveness must be called on heartbeat")
+	last := calls[len(calls)-1]
+	assert.Equal(t, stewardID, last.stewardID)
+	assert.True(t, last.healthy, "heartbeat event must report healthy=true")
+}
+
+// TestHeartbeatService_TrustEvaluator_CalledOnStale verifies that the
+// TrustEvaluator.RecordLiveness is called with healthy=false when a steward
+// is detected stale by checkStaleHeartbeats (Issue #1694).
+func TestHeartbeatService_TrustEvaluator_CalledOnStale(t *testing.T) {
+	evaluator := &recordingTrustEvaluator{}
+	svc, cp := newTestService(t, func(cfg *Config) {
+		cfg.TrustEvaluator = evaluator
+		cfg.StewardOfflineTimeout = 60 * time.Second
+	})
+	ctx := context.Background()
+
+	const stewardID = "steward-stale-test"
+
+	// Register the steward via an initial heartbeat.
+	require.NoError(t, cp.sendHeartbeat(ctx, &controlplaneTypes.Heartbeat{
+		StewardID: stewardID,
+		Status:    controlplaneTypes.StatusHealthy,
+		Timestamp: time.Now(),
+	}))
+
+	// Force the last-heartbeat timestamp past the stale threshold.
+	svc.mu.Lock()
+	svc.stewards[stewardID].LastHeartbeat = time.Now().Add(-61 * time.Second)
+	svc.stewards[stewardID].Healthy = true
+	svc.mu.Unlock()
+
+	// checkStaleHeartbeats must fire the evaluator with healthy=false.
+	svc.checkStaleHeartbeats()
+
+	unhealthyCalls := 0
+	for _, c := range evaluator.allCalls() {
+		if c.stewardID == stewardID && !c.healthy {
+			unhealthyCalls++
+		}
+	}
+	assert.Equal(t, 1, unhealthyCalls,
+		"RecordLiveness must be called exactly once with healthy=false on stale detection")
+}
+
+// TestHeartbeatService_TrustEvaluator_NilIsNoop verifies that a nil
+// TrustEvaluator does not panic when heartbeats arrive or when stale
+// detection fires (Issue #1694).
+func TestHeartbeatService_TrustEvaluator_NilIsNoop(t *testing.T) {
+	// newTestService wires no TrustEvaluator by default (nil).
+	svc, cp := newTestService(t)
+	ctx := context.Background()
+
+	const stewardID = "steward-nil-eval-test"
+
+	// Send heartbeat — must not panic.
+	require.NoError(t, cp.sendHeartbeat(ctx, &controlplaneTypes.Heartbeat{
+		StewardID: stewardID,
+		Status:    controlplaneTypes.StatusHealthy,
+		Timestamp: time.Now(),
+	}))
+
+	// Trigger stale detection — must not panic.
+	svc.mu.Lock()
+	svc.stewards[stewardID].LastHeartbeat = time.Now().Add(-61 * time.Second)
+	svc.stewards[stewardID].Healthy = true
+	svc.mu.Unlock()
+
+	assert.NotPanics(t, svc.checkStaleHeartbeats,
+		"nil TrustEvaluator must not cause a panic")
 }

--- a/features/controller/registration/ip_trust_evaluator.go
+++ b/features/controller/registration/ip_trust_evaluator.go
@@ -1,0 +1,144 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+// Package registration provides the IP-trust establishment evaluator (Issue #1694).
+package registration
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	business "github.com/cfgis/cfgms/pkg/storage/interfaces/business"
+	"github.com/cfgis/cfgms/pkg/logging"
+)
+
+const defaultIPTrustThreshold = 30 * time.Minute
+
+// IPTrustEvaluatorConfig holds construction parameters for IPTrustEvaluator.
+type IPTrustEvaluatorConfig struct {
+	// Store is the IP-trust durable storage backend.
+	Store business.IPTrustStore
+
+	// Threshold is the continuous-liveness window required before an IP is
+	// promoted to trusted. Defaults to 30 minutes when zero.
+	Threshold time.Duration
+
+	// Logger is used for diagnostic output.
+	Logger logging.Logger
+}
+
+// IPTrustEvaluator implements the 30-minute sustained-liveness IP-trust gate
+// (Issue #1694, epic #1664). Once an approved steward has been continuously
+// healthy from a given IP for at least Threshold, the evaluator calls
+// store.AddTrustedRange to promote that IP to trusted status.
+//
+// In-memory timer state is intentionally non-durable: on a controller restart
+// the 30-minute clock resets, which is fail-safe — existing trust entries in
+// the store survive and are not re-evaluated.
+type IPTrustEvaluator struct {
+	store     business.IPTrustStore
+	threshold time.Duration
+	logger    logging.Logger
+
+	mu     sync.Mutex
+	timers map[string]time.Time // key: tenantID+"\x00"+ip → first-seen-healthy-at
+}
+
+// NewIPTrustEvaluator creates an IPTrustEvaluator with the given configuration.
+func NewIPTrustEvaluator(cfg IPTrustEvaluatorConfig) *IPTrustEvaluator {
+	threshold := cfg.Threshold
+	if threshold <= 0 {
+		threshold = defaultIPTrustThreshold
+	}
+	return &IPTrustEvaluator{
+		store:     cfg.Store,
+		threshold: threshold,
+		logger:    cfg.Logger,
+		timers:    make(map[string]time.Time),
+	}
+}
+
+// HasTimer returns true if a liveness timer is active for the given
+// (tenantID, ip) pair. Used by tests to inspect internal state.
+func (e *IPTrustEvaluator) HasTimer(tenantID, ip string) bool {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	_, ok := e.timers[tenantID+"\x00"+ip]
+	return ok
+}
+
+// ForceTimerExpiry back-dates the liveness timer for (tenantID, ip) so the
+// next healthy RecordLiveness call will exceed the threshold. Used by tests.
+func (e *IPTrustEvaluator) ForceTimerExpiry(tenantID, ip string) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	key := tenantID + "\x00" + ip
+	if _, ok := e.timers[key]; ok {
+		e.timers[key] = time.Now().Add(-e.threshold)
+	}
+}
+
+// RecordLiveness records a liveness event for the given (tenantID, ip) pair.
+//
+// On healthy=true: upserts a per-(tenantID,ip) in-memory timer recording
+// first-seen-healthy-at. When now−firstSeen ≥ threshold, calls
+// store.AddTrustedRange(ctx, tenantID, ip+"/32", false) and clears the entry.
+//
+// On healthy=false: clears the timer entry, resetting the liveness clock.
+func (e *IPTrustEvaluator) RecordLiveness(ctx context.Context, tenantID, stewardID, ip string, healthy bool) error {
+	if ip == "" {
+		return nil
+	}
+
+	key := tenantID + "\x00" + ip
+
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	if !healthy {
+		if _, had := e.timers[key]; had {
+			delete(e.timers, key)
+			e.logger.Debug("IP trust timer reset — steward offline",
+				"tenant_id", tenantID,
+				"steward_id", stewardID,
+				"ip", ip)
+		}
+		return nil
+	}
+
+	// healthy=true path
+	firstSeen, exists := e.timers[key]
+	if !exists {
+		e.timers[key] = time.Now()
+		e.logger.Debug("IP trust timer started",
+			"tenant_id", tenantID,
+			"steward_id", stewardID,
+			"ip", ip,
+			"threshold", e.threshold)
+		return nil
+	}
+
+	elapsed := time.Since(firstSeen)
+	if elapsed < e.threshold {
+		return nil
+	}
+
+	// Threshold reached — promote to trusted.
+	cidr := ip + "/32"
+	if err := e.store.AddTrustedRange(ctx, tenantID, cidr, false); err != nil {
+		e.logger.Error("Failed to add trusted IP range",
+			"tenant_id", tenantID,
+			"steward_id", stewardID,
+			"cidr", cidr,
+			"error", err)
+		return err
+	}
+
+	delete(e.timers, key)
+	e.logger.Info("IP promoted to trusted status",
+		"tenant_id", tenantID,
+		"steward_id", stewardID,
+		"cidr", cidr,
+		"elapsed", elapsed)
+	return nil
+}

--- a/features/controller/registration/ip_trust_evaluator_test.go
+++ b/features/controller/registration/ip_trust_evaluator_test.go
@@ -1,0 +1,318 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+package registration
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/cfgis/cfgms/pkg/logging"
+	business "github.com/cfgis/cfgms/pkg/storage/interfaces/business"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// recordingIPTrustStore is a real, in-memory IPTrustStore for evaluator tests.
+// It is NOT a mock — it fully implements the IPTrustStore contract using
+// net.ParseCIDR-based containment checks, matching production behaviour.
+type recordingIPTrustStore struct {
+	mu      sync.Mutex
+	entries []*business.IPTrustEntry
+	seq     int
+	calls   []string // records AddTrustedRange cidr arguments for assertion
+}
+
+func (s *recordingIPTrustStore) AddTrustedRange(_ context.Context, tenantID, cidr string, preSeeded bool) error {
+	_, ipNet, err := net.ParseCIDR(cidr)
+	if err != nil {
+		return fmt.Errorf("invalid CIDR %q: %w", cidr, err)
+	}
+	normalised := ipNet.String()
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.calls = append(s.calls, tenantID+"/"+normalised)
+
+	for _, e := range s.entries {
+		if e.TenantID == tenantID && e.CIDR == normalised {
+			e.PreSeeded = preSeeded
+			e.TrustedSince = time.Now()
+			e.Revoked = false
+			e.RevokedAt = nil
+			return nil
+		}
+	}
+	s.seq++
+	s.entries = append(s.entries, &business.IPTrustEntry{
+		ID:           fmt.Sprintf("entry-%d", s.seq),
+		TenantID:     tenantID,
+		CIDR:         normalised,
+		PreSeeded:    preSeeded,
+		TrustedSince: time.Now(),
+	})
+	return nil
+}
+
+func (s *recordingIPTrustStore) IsTrusted(_ context.Context, tenantID, ip string) (bool, error) {
+	parsed := net.ParseIP(ip)
+	if parsed == nil {
+		return false, fmt.Errorf("invalid IP: %s", ip)
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, e := range s.entries {
+		if e.TenantID != tenantID || e.Revoked {
+			continue
+		}
+		_, ipNet, err := net.ParseCIDR(e.CIDR)
+		if err != nil {
+			continue
+		}
+		if ipNet.Contains(parsed) {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func (s *recordingIPTrustStore) ListTrustedRanges(_ context.Context, tenantID string) ([]*business.IPTrustEntry, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	var out []*business.IPTrustEntry
+	for _, e := range s.entries {
+		if e.TenantID == tenantID {
+			cp := *e
+			out = append(out, &cp)
+		}
+	}
+	return out, nil
+}
+
+func (s *recordingIPTrustStore) RevokeTrustedRange(_ context.Context, tenantID, cidr string) error {
+	_, ipNet, err := net.ParseCIDR(cidr)
+	if err != nil {
+		return fmt.Errorf("invalid CIDR %q: %w", cidr, err)
+	}
+	normalised := ipNet.String()
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, e := range s.entries {
+		if e.TenantID == tenantID && e.CIDR == normalised && !e.Revoked {
+			now := time.Now()
+			e.Revoked = true
+			e.RevokedAt = &now
+			return nil
+		}
+	}
+	return business.ErrIPTrustEntryNotFound
+}
+
+func (s *recordingIPTrustStore) RecordHealthySteward(_ context.Context, _, _ string, _ time.Time) error {
+	return nil
+}
+
+func (s *recordingIPTrustStore) GetLastActivity(_ context.Context, _, _ string) (*business.IPTrustActivity, error) {
+	return nil, nil
+}
+
+// addTrustedRangeCalls returns a snapshot of all AddTrustedRange call arguments.
+func (s *recordingIPTrustStore) addTrustedRangeCalls() []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]string, len(s.calls))
+	copy(out, s.calls)
+	return out
+}
+
+// Compile-time: ensure recordingIPTrustStore satisfies the interface.
+var _ business.IPTrustStore = (*recordingIPTrustStore)(nil)
+
+func newTestEvaluator(t *testing.T, threshold time.Duration) (*IPTrustEvaluator, *recordingIPTrustStore) {
+	t.Helper()
+	store := &recordingIPTrustStore{}
+	ev := NewIPTrustEvaluator(IPTrustEvaluatorConfig{
+		Store:     store,
+		Threshold: threshold,
+		Logger:    logging.NewLogger("debug"),
+	})
+	return ev, store
+}
+
+// TestIPTrustEvaluator_ThresholdNotMet_NoTrust verifies that repeated healthy
+// calls arriving just under the threshold do not call AddTrustedRange.
+// Acceptance criterion: trust is not granted before the threshold is reached.
+func TestIPTrustEvaluator_ThresholdNotMet_NoTrust(t *testing.T) {
+	threshold := 5 * time.Second
+	ev, store := newTestEvaluator(t, threshold)
+	ctx := context.Background()
+
+	// Start the liveness clock.
+	require.NoError(t, ev.RecordLiveness(ctx, "tenant-1", "steward-1", "10.0.0.1", true))
+
+	// Simulate multiple healthy calls but back-date firstSeen to just under threshold.
+	ev.mu.Lock()
+	key := "tenant-1\x0010.0.0.1"
+	ev.timers[key] = time.Now().Add(-(threshold - time.Millisecond))
+	ev.mu.Unlock()
+
+	// One more healthy call — elapsed is still < threshold.
+	require.NoError(t, ev.RecordLiveness(ctx, "tenant-1", "steward-1", "10.0.0.1", true))
+
+	assert.Empty(t, store.addTrustedRangeCalls(),
+		"AddTrustedRange must not be called when threshold is not yet met")
+}
+
+// TestIPTrustEvaluator_ThresholdMet_AddsTrust verifies that a healthy call
+// spanning ≥ threshold results in AddTrustedRange called exactly once.
+// Acceptance criterion: trust is granted exactly when threshold is met.
+func TestIPTrustEvaluator_ThresholdMet_AddsTrust(t *testing.T) {
+	threshold := 5 * time.Second
+	ev, store := newTestEvaluator(t, threshold)
+	ctx := context.Background()
+
+	// Start the liveness clock.
+	require.NoError(t, ev.RecordLiveness(ctx, "tenant-1", "steward-1", "10.0.0.1", true))
+
+	// Back-date firstSeen to exactly the threshold ago so the next call tips over.
+	ev.mu.Lock()
+	key := "tenant-1\x0010.0.0.1"
+	ev.timers[key] = time.Now().Add(-threshold)
+	ev.mu.Unlock()
+
+	// This call must tip over the threshold and call AddTrustedRange.
+	require.NoError(t, ev.RecordLiveness(ctx, "tenant-1", "steward-1", "10.0.0.1", true))
+
+	calls := store.addTrustedRangeCalls()
+	require.Len(t, calls, 1, "AddTrustedRange must be called exactly once")
+	assert.Equal(t, "tenant-1/10.0.0.1/32", calls[0], "CIDR must be a /32 host entry")
+
+	// Timer entry must be cleared after promotion.
+	ev.mu.Lock()
+	_, timerExists := ev.timers[key]
+	ev.mu.Unlock()
+	assert.False(t, timerExists, "timer entry must be cleared after trust promotion")
+
+	// A second call should NOT trigger another AddTrustedRange (timer is cleared,
+	// so it starts fresh and the threshold won't be met immediately).
+	require.NoError(t, ev.RecordLiveness(ctx, "tenant-1", "steward-1", "10.0.0.1", true))
+	assert.Len(t, store.addTrustedRangeCalls(), 1,
+		"AddTrustedRange must not be called again before threshold is met again")
+}
+
+// TestIPTrustEvaluator_OfflineResetsTimer verifies that healthy → offline →
+// healthy again restarts the timer; trust is not granted until the threshold
+// is met from the new start.
+// Acceptance criterion: an intervening healthy=false resets the liveness timer.
+func TestIPTrustEvaluator_OfflineResetsTimer(t *testing.T) {
+	threshold := 5 * time.Second
+	ev, store := newTestEvaluator(t, threshold)
+	ctx := context.Background()
+
+	// First healthy call starts the timer.
+	require.NoError(t, ev.RecordLiveness(ctx, "tenant-1", "steward-1", "10.0.0.1", true))
+
+	// Back-date firstSeen to just under threshold.
+	ev.mu.Lock()
+	key := "tenant-1\x0010.0.0.1"
+	ev.timers[key] = time.Now().Add(-(threshold - time.Millisecond))
+	ev.mu.Unlock()
+
+	// Steward goes offline — timer must be cleared.
+	require.NoError(t, ev.RecordLiveness(ctx, "tenant-1", "steward-1", "10.0.0.1", false))
+
+	ev.mu.Lock()
+	_, timerExists := ev.timers[key]
+	ev.mu.Unlock()
+	assert.False(t, timerExists, "timer must be cleared after offline event")
+	assert.Empty(t, store.addTrustedRangeCalls(), "no trust before offline was cleared")
+
+	// Steward comes back — starts fresh. A single call with elapsed < threshold must not trust.
+	require.NoError(t, ev.RecordLiveness(ctx, "tenant-1", "steward-1", "10.0.0.1", true))
+	assert.Empty(t, store.addTrustedRangeCalls(),
+		"trust must not be granted immediately after restart; threshold must be met from scratch")
+
+	// Now tip the new timer over the threshold.
+	ev.mu.Lock()
+	ev.timers[key] = time.Now().Add(-threshold)
+	ev.mu.Unlock()
+
+	require.NoError(t, ev.RecordLiveness(ctx, "tenant-1", "steward-1", "10.0.0.1", true))
+
+	calls := store.addTrustedRangeCalls()
+	require.Len(t, calls, 1, "trust must be granted after threshold met from new start")
+}
+
+// TestIPTrustEvaluator_ConcurrentCalls verifies that concurrent calls from
+// multiple goroutines are race-free (run with -race to detect violations).
+func TestIPTrustEvaluator_ConcurrentCalls(t *testing.T) {
+	ev, _ := newTestEvaluator(t, time.Hour) // large threshold so no AddTrustedRange races
+	ctx := context.Background()
+
+	const goroutines = 20
+	var wg sync.WaitGroup
+	errs := make(chan error, goroutines*50)
+	wg.Add(goroutines)
+	for i := 0; i < goroutines; i++ {
+		i := i
+		go func() {
+			defer wg.Done()
+			ip := fmt.Sprintf("10.0.0.%d", i+1)
+			for j := 0; j < 50; j++ {
+				if err := ev.RecordLiveness(ctx, "tenant-1", fmt.Sprintf("steward-%d", i), ip, j%3 != 0); err != nil {
+					errs <- err
+				}
+			}
+		}()
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		require.NoError(t, err, "concurrent RecordLiveness must not return errors")
+	}
+}
+
+// TestIPTrustEvaluator_EmptyIPIsNoop verifies that an empty IP string is
+// silently ignored and does not cause a panic or store call.
+func TestIPTrustEvaluator_EmptyIPIsNoop(t *testing.T) {
+	ev, store := newTestEvaluator(t, time.Millisecond)
+	ctx := context.Background()
+
+	require.NoError(t, ev.RecordLiveness(ctx, "tenant-1", "steward-1", "", true))
+	assert.Empty(t, store.addTrustedRangeCalls())
+}
+
+// TestIPTrustEvaluator_DefaultThreshold verifies that zero-threshold in config
+// defaults to 30 minutes.
+func TestIPTrustEvaluator_DefaultThreshold(t *testing.T) {
+	ev, _ := newTestEvaluator(t, 0)
+	assert.Equal(t, defaultIPTrustThreshold, ev.threshold,
+		"zero threshold must default to 30 minutes")
+}
+
+// TestIPTrustEvaluator_MultiTenantIsolation verifies that two tenants sharing
+// the same IP are tracked independently.
+func TestIPTrustEvaluator_MultiTenantIsolation(t *testing.T) {
+	threshold := 5 * time.Second
+	ev, store := newTestEvaluator(t, threshold)
+	ctx := context.Background()
+
+	// Start timers for both tenants.
+	require.NoError(t, ev.RecordLiveness(ctx, "tenant-A", "steward-1", "10.0.0.1", true))
+	require.NoError(t, ev.RecordLiveness(ctx, "tenant-B", "steward-2", "10.0.0.1", true))
+
+	// Back-date only tenant-A's timer to exceed threshold.
+	ev.mu.Lock()
+	ev.timers["tenant-A\x0010.0.0.1"] = time.Now().Add(-threshold)
+	ev.mu.Unlock()
+
+	require.NoError(t, ev.RecordLiveness(ctx, "tenant-A", "steward-1", "10.0.0.1", true))
+
+	calls := store.addTrustedRangeCalls()
+	require.Len(t, calls, 1)
+	assert.Equal(t, "tenant-A/10.0.0.1/32", calls[0],
+		"only tenant-A must be promoted; tenant-B timer is still running")
+}

--- a/features/controller/server/health_adapters.go
+++ b/features/controller/server/health_adapters.go
@@ -7,6 +7,10 @@ import (
 	"time"
 
 	controlplaneInterfaces "github.com/cfgis/cfgms/pkg/controlplane/interfaces"
+	"github.com/cfgis/cfgms/features/controller/heartbeat"
+	controllerRegistration "github.com/cfgis/cfgms/features/controller/registration"
+	"github.com/cfgis/cfgms/pkg/logging"
+	business "github.com/cfgis/cfgms/pkg/storage/interfaces/business"
 )
 
 // GRPCTransportStatsAdapter adapts the gRPC ControlPlaneProvider's GetStats() to
@@ -133,3 +137,48 @@ func (n *NoOpApplicationQueueStats) GetScriptStats() (queueDepth int64, maxWaitT
 func (n *NoOpApplicationQueueStats) GetConfigQueueDepth() int64 {
 	return 0
 }
+
+// stewardIPTrustAdapter bridges the heartbeat.TrustEvaluator interface to
+// IPTrustEvaluator by resolving tenantID and IP from the StewardStore on each
+// call (Issue #1694). The heartbeat service only knows the stewardID; this
+// adapter does the fleet-registry lookup so IPTrustEvaluator receives the
+// full (tenantID, ip) needed for the liveness gate.
+type stewardIPTrustAdapter struct {
+	evaluator    *controllerRegistration.IPTrustEvaluator
+	stewardStore business.StewardStore
+	logger       logging.Logger
+}
+
+// newStewardIPTrustAdapter creates an adapter wrapping the IP-trust evaluator
+// with a steward store for tenantID/IP resolution.
+func newStewardIPTrustAdapter(
+	evaluator *controllerRegistration.IPTrustEvaluator,
+	stewardStore business.StewardStore,
+	logger logging.Logger,
+) *stewardIPTrustAdapter {
+	return &stewardIPTrustAdapter{
+		evaluator:    evaluator,
+		stewardStore: stewardStore,
+		logger:       logger,
+	}
+}
+
+// RecordLiveness implements heartbeat.TrustEvaluator. It looks up the steward's
+// tenantID and IPAddress from the fleet registry and delegates to IPTrustEvaluator.
+func (a *stewardIPTrustAdapter) RecordLiveness(ctx context.Context, stewardID string, healthy bool) error {
+	if a.stewardStore == nil {
+		return nil
+	}
+	record, err := a.stewardStore.GetSteward(ctx, stewardID)
+	if err != nil {
+		// Steward not yet persisted — skip (best-effort, not an error).
+		return nil
+	}
+	if record.IPAddress == "" {
+		return nil
+	}
+	return a.evaluator.RecordLiveness(ctx, record.TenantID, stewardID, record.IPAddress, healthy)
+}
+
+// Compile-time: stewardIPTrustAdapter satisfies heartbeat.TrustEvaluator.
+var _ heartbeat.TrustEvaluator = (*stewardIPTrustAdapter)(nil)

--- a/features/controller/server/health_adapters_test.go
+++ b/features/controller/server/health_adapters_test.go
@@ -4,14 +4,21 @@ package server
 
 import (
 	"context"
+	"errors"
+	"fmt"
+	"net"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	controllerRegistration "github.com/cfgis/cfgms/features/controller/registration"
 	controlplaneInterfaces "github.com/cfgis/cfgms/pkg/controlplane/interfaces"
 	controlplaneTypes "github.com/cfgis/cfgms/pkg/controlplane/types"
+	"github.com/cfgis/cfgms/pkg/logging"
+	business "github.com/cfgis/cfgms/pkg/storage/interfaces/business"
 )
 
 // stubControlPlaneProvider implements controlplaneInterfaces.ControlPlaneProvider for testing.
@@ -132,3 +139,269 @@ func TestNoOpApplicationQueueStats_ReturnsZeros(t *testing.T) {
 
 	assert.Equal(t, int64(0), stats.GetConfigQueueDepth())
 }
+
+// --- stewardIPTrustAdapter tests ---
+
+// testStewardStore is a real in-memory StewardStore used for adapter testing.
+// It is NOT a mock — it holds actual StewardRecord data and satisfies the
+// StewardStore contract for the GetSteward lookup path.
+type testStewardStore struct {
+	mu       sync.RWMutex
+	stewards map[string]*business.StewardRecord
+}
+
+func newTestStewardStore(records ...*business.StewardRecord) *testStewardStore {
+	s := &testStewardStore{stewards: make(map[string]*business.StewardRecord)}
+	for _, r := range records {
+		s.stewards[r.ID] = r
+	}
+	return s
+}
+
+func (s *testStewardStore) RegisterSteward(_ context.Context, record *business.StewardRecord) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.stewards[record.ID] = record
+	return nil
+}
+
+func (s *testStewardStore) GetSteward(_ context.Context, id string) (*business.StewardRecord, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	r, ok := s.stewards[id]
+	if !ok {
+		return nil, business.ErrStewardNotFound
+	}
+	cp := *r
+	return &cp, nil
+}
+
+func (s *testStewardStore) UpdateHeartbeat(_ context.Context, _ string) error { return nil }
+func (s *testStewardStore) ListStewards(_ context.Context) ([]*business.StewardRecord, error) {
+	return nil, nil
+}
+func (s *testStewardStore) ListStewardsByStatus(_ context.Context, _ business.StewardStatus) ([]*business.StewardRecord, error) {
+	return nil, nil
+}
+func (s *testStewardStore) UpdateStewardStatus(_ context.Context, _ string, _ business.StewardStatus) error {
+	return nil
+}
+func (s *testStewardStore) DeregisterSteward(_ context.Context, _ string) error { return nil }
+func (s *testStewardStore) GetStewardsSeen(_ context.Context, _ time.Time) ([]*business.StewardRecord, error) {
+	return nil, nil
+}
+func (s *testStewardStore) HealthCheck(_ context.Context) error  { return nil }
+func (s *testStewardStore) Initialize(_ context.Context) error   { return nil }
+func (s *testStewardStore) Close() error                         { return nil }
+
+var _ business.StewardStore = (*testStewardStore)(nil)
+
+// testIPTrustStoreForAdapter is a minimal in-memory IPTrustStore for adapter tests.
+type testIPTrustStoreForAdapter struct {
+	mu    sync.Mutex
+	calls []string
+}
+
+func (s *testIPTrustStoreForAdapter) AddTrustedRange(_ context.Context, tenantID, cidr string, _ bool) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.calls = append(s.calls, tenantID+"/"+cidr)
+	return nil
+}
+func (s *testIPTrustStoreForAdapter) IsTrusted(_ context.Context, _, _ string) (bool, error) {
+	return false, nil
+}
+func (s *testIPTrustStoreForAdapter) ListTrustedRanges(_ context.Context, _ string) ([]*business.IPTrustEntry, error) {
+	return nil, nil
+}
+func (s *testIPTrustStoreForAdapter) RevokeTrustedRange(_ context.Context, _, _ string) error {
+	return business.ErrIPTrustEntryNotFound
+}
+func (s *testIPTrustStoreForAdapter) RecordHealthySteward(_ context.Context, _, _ string, _ time.Time) error {
+	return nil
+}
+func (s *testIPTrustStoreForAdapter) GetLastActivity(_ context.Context, _, _ string) (*business.IPTrustActivity, error) {
+	return nil, nil
+}
+func (s *testIPTrustStoreForAdapter) addTrustedRangeCalls() []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]string, len(s.calls))
+	copy(out, s.calls)
+	return out
+}
+
+var _ business.IPTrustStore = (*testIPTrustStoreForAdapter)(nil)
+
+// normaliseCIDRForAdapter returns the network address form of a CIDR.
+func normaliseCIDRForAdapter(cidr string) string {
+	_, ipNet, err := net.ParseCIDR(cidr)
+	if err != nil {
+		return cidr
+	}
+	return ipNet.String()
+}
+
+func newTestAdapter(stewardStore business.StewardStore, trustStore business.IPTrustStore) *stewardIPTrustAdapter {
+	evaluator := controllerRegistration.NewIPTrustEvaluator(controllerRegistration.IPTrustEvaluatorConfig{
+		Store:     trustStore,
+		Threshold: time.Millisecond, // tiny threshold so tests tip it instantly
+		Logger:    logging.NewLogger("debug"),
+	})
+	return newStewardIPTrustAdapter(evaluator, stewardStore, logging.NewLogger("debug"))
+}
+
+// TestStewardIPTrustAdapter_ResolvesIPFromStewardStore verifies that the adapter
+// looks up the steward's IP from the fleet registry and passes it to the
+// IPTrustEvaluator (Issue #1694).
+func TestStewardIPTrustAdapter_ResolvesIPFromStewardStore(t *testing.T) {
+	stewardStore := newTestStewardStore(&business.StewardRecord{
+		ID:        "steward-1",
+		TenantID:  "tenant-1",
+		IPAddress: "10.0.0.1",
+		Status:    business.StewardStatusActive,
+	})
+	trustStore := &testIPTrustStoreForAdapter{}
+	adapter := newTestAdapter(stewardStore, trustStore)
+	ctx := context.Background()
+
+	// Send first healthy call to start the timer.
+	require.NoError(t, adapter.RecordLiveness(ctx, "steward-1", true))
+
+	// Manually advance the evaluator's timer past the threshold.
+	adapter.evaluator.ForceTimerExpiry("tenant-1", "10.0.0.1")
+
+	// Second call tips over threshold — must call AddTrustedRange with the resolved IP.
+	require.NoError(t, adapter.RecordLiveness(ctx, "steward-1", true))
+
+	calls := trustStore.addTrustedRangeCalls()
+	require.Len(t, calls, 1, "AddTrustedRange must be called with the correct IP")
+	assert.Equal(t, fmt.Sprintf("tenant-1/%s", normaliseCIDRForAdapter("10.0.0.1/32")), calls[0])
+}
+
+// TestStewardIPTrustAdapter_StewardNotFound_IsNoop verifies that a missing steward
+// record is silently ignored without returning an error (best-effort).
+func TestStewardIPTrustAdapter_StewardNotFound_IsNoop(t *testing.T) {
+	stewardStore := newTestStewardStore() // empty
+	trustStore := &testIPTrustStoreForAdapter{}
+	adapter := newTestAdapter(stewardStore, trustStore)
+	ctx := context.Background()
+
+	err := adapter.RecordLiveness(ctx, "unknown-steward", true)
+	assert.NoError(t, err, "missing steward must not return an error")
+	assert.Empty(t, trustStore.addTrustedRangeCalls())
+}
+
+// TestStewardIPTrustAdapter_NilStewardStore_IsNoop verifies that a nil steward
+// store does not cause a panic.
+func TestStewardIPTrustAdapter_NilStewardStore_IsNoop(t *testing.T) {
+	trustStore := &testIPTrustStoreForAdapter{}
+	evaluator := controllerRegistration.NewIPTrustEvaluator(controllerRegistration.IPTrustEvaluatorConfig{
+		Store:     trustStore,
+		Threshold: time.Millisecond,
+		Logger:    logging.NewLogger("debug"),
+	})
+	adapter := newStewardIPTrustAdapter(evaluator, nil, logging.NewLogger("debug"))
+
+	err := adapter.RecordLiveness(context.Background(), "steward-1", true)
+	assert.NoError(t, err)
+	assert.Empty(t, trustStore.addTrustedRangeCalls())
+}
+
+// TestStewardIPTrustAdapter_EmptyIP_IsNoop verifies that a steward with no IP
+// address stored is silently skipped.
+func TestStewardIPTrustAdapter_EmptyIP_IsNoop(t *testing.T) {
+	stewardStore := newTestStewardStore(&business.StewardRecord{
+		ID:        "steward-noip",
+		TenantID:  "tenant-1",
+		IPAddress: "", // no IP stored yet
+	})
+	trustStore := &testIPTrustStoreForAdapter{}
+	adapter := newTestAdapter(stewardStore, trustStore)
+
+	err := adapter.RecordLiveness(context.Background(), "steward-noip", true)
+	assert.NoError(t, err)
+	assert.Empty(t, trustStore.addTrustedRangeCalls())
+}
+
+// TestStewardIPTrustAdapter_OfflineCall_ResetsTimer verifies that a healthy=false
+// call resets the trust timer for the steward's IP.
+func TestStewardIPTrustAdapter_OfflineCall_ResetsTimer(t *testing.T) {
+	stewardStore := newTestStewardStore(&business.StewardRecord{
+		ID:        "steward-1",
+		TenantID:  "tenant-1",
+		IPAddress: "10.0.0.1",
+	})
+	trustStore := &testIPTrustStoreForAdapter{}
+	evaluator := controllerRegistration.NewIPTrustEvaluator(controllerRegistration.IPTrustEvaluatorConfig{
+		Store:     trustStore,
+		Threshold: time.Hour, // long threshold to prevent accidental promotion
+		Logger:    logging.NewLogger("debug"),
+	})
+	adapter := newStewardIPTrustAdapter(evaluator, stewardStore, logging.NewLogger("debug"))
+	ctx := context.Background()
+
+	// Start timer.
+	require.NoError(t, adapter.RecordLiveness(ctx, "steward-1", true))
+
+	// Timer entry must exist.
+	assert.True(t, evaluator.HasTimer("tenant-1", "10.0.0.1"), "timer must exist after healthy call")
+
+	// Go offline — timer must be cleared.
+	require.NoError(t, adapter.RecordLiveness(ctx, "steward-1", false))
+	assert.False(t, evaluator.HasTimer("tenant-1", "10.0.0.1"), "timer must be cleared after offline call")
+
+	assert.Empty(t, trustStore.addTrustedRangeCalls(), "no trust must be granted after offline reset")
+}
+
+// TestStewardIPTrustAdapter_EvaluatorError_IsPropagated verifies that an error
+// returned by IPTrustEvaluator (e.g. store failure) is returned to the caller.
+func TestStewardIPTrustAdapter_EvaluatorError_IsPropagated(t *testing.T) {
+	stewardStore := newTestStewardStore(&business.StewardRecord{
+		ID:        "steward-1",
+		TenantID:  "tenant-1",
+		IPAddress: "10.0.0.1",
+	})
+	failStore := &failingIPTrustStore{err: errors.New("storage unavailable")}
+	evaluator := controllerRegistration.NewIPTrustEvaluator(controllerRegistration.IPTrustEvaluatorConfig{
+		Store:     failStore,
+		Threshold: time.Millisecond,
+		Logger:    logging.NewLogger("debug"),
+	})
+	adapter := newStewardIPTrustAdapter(evaluator, stewardStore, logging.NewLogger("debug"))
+	ctx := context.Background()
+
+	// First call starts the timer — no error expected.
+	require.NoError(t, adapter.RecordLiveness(ctx, "steward-1", true))
+
+	// Tip the timer.
+	evaluator.ForceTimerExpiry("tenant-1", "10.0.0.1")
+
+	// Second call should propagate the store error.
+	err := adapter.RecordLiveness(ctx, "steward-1", true)
+	require.Error(t, err, "store error must be propagated")
+}
+
+// failingIPTrustStore always returns an error from AddTrustedRange.
+type failingIPTrustStore struct{ err error }
+
+func (f *failingIPTrustStore) AddTrustedRange(_ context.Context, _, _ string, _ bool) error {
+	return f.err
+}
+func (f *failingIPTrustStore) IsTrusted(_ context.Context, _, _ string) (bool, error) {
+	return false, nil
+}
+func (f *failingIPTrustStore) ListTrustedRanges(_ context.Context, _ string) ([]*business.IPTrustEntry, error) {
+	return nil, nil
+}
+func (f *failingIPTrustStore) RevokeTrustedRange(_ context.Context, _, _ string) error {
+	return nil
+}
+func (f *failingIPTrustStore) RecordHealthySteward(_ context.Context, _, _ string, _ time.Time) error {
+	return nil
+}
+func (f *failingIPTrustStore) GetLastActivity(_ context.Context, _, _ string) (*business.IPTrustActivity, error) {
+	return nil, nil
+}
+
+var _ business.IPTrustStore = (*failingIPTrustStore)(nil)

--- a/features/controller/server/server.go
+++ b/features/controller/server/server.go
@@ -500,6 +500,24 @@ func New(cfg *config.Config, logger logging.Logger) (*Server, error) {
 		}
 		logger.Info("Execution queue and job dispatcher initialized")
 
+		// Wire the IP-trust evaluator into the heartbeat service when the
+		// IP-trust store is available (Issue #1694). The database provider
+		// supplies an IPTrustStore; the OSS composite (flatfile+SQLite) returns
+		// nil, in which case the evaluator is skipped.
+		var heartbeatTrustEvaluator heartbeat.TrustEvaluator
+		if ipTrustStore := storageManager.GetIPTrustStore(); ipTrustStore != nil {
+			stewardStore := storageManager.GetStewardStore()
+			ipTrustThreshold := cfg.Registration.GetIPTrustThreshold()
+			evaluator := controllerRegistration.NewIPTrustEvaluator(controllerRegistration.IPTrustEvaluatorConfig{
+				Store:     ipTrustStore,
+				Threshold: ipTrustThreshold,
+				Logger:    logger,
+			})
+			heartbeatTrustEvaluator = newStewardIPTrustAdapter(evaluator, stewardStore, logger)
+			logger.Info("IP-trust evaluator wired into heartbeat service",
+				"threshold", ipTrustThreshold)
+		}
+
 		// Initialize heartbeat monitoring service
 		logger.Info("Initializing heartbeat monitoring service...")
 		heartbeatService, err = heartbeat.New(&heartbeat.Config{
@@ -514,6 +532,7 @@ func New(cfg *config.Config, logger logging.Logger) (*Server, error) {
 				}
 			},
 			OnHeartbeatReceived: jobDispatcher.OnHeartbeat,
+			TrustEvaluator:      heartbeatTrustEvaluator,
 			Logger:              logger,
 		})
 		if err != nil {

--- a/pkg/storage/interfaces/provider.go
+++ b/pkg/storage/interfaces/provider.go
@@ -488,6 +488,11 @@ func CreateAllStoresFromConfig(providerName string, config map[string]interface{
 		return nil, fmt.Errorf("failed to create push store: %w", err)
 	}
 
+	ipTrustStore, err := provider.CreateIPTrustStore(config)
+	if err != nil && !errors.Is(err, business.ErrNotSupported) {
+		return nil, fmt.Errorf("failed to create IP trust store: %w", err)
+	}
+
 	return &StorageManager{
 		providerName:           providerName,
 		provider:               provider,
@@ -502,6 +507,7 @@ func CreateAllStoresFromConfig(providerName string, config map[string]interface{
 		commandStore:           commandStore,
 		triggerStore:           triggerStore,
 		pushStore:              pushStore,
+		ipTrustStore:           ipTrustStore,
 	}, nil
 }
 
@@ -521,6 +527,7 @@ type StorageManager struct {
 	triggerStore             business.TriggerStore
 	pushStore                business.PushStore
 	pendingRegistrationStore business.PendingRegistrationStore
+	ipTrustStore             business.IPTrustStore
 }
 
 // GetProviderName returns the name of the storage provider.
@@ -598,6 +605,19 @@ func (sm *StorageManager) GetPendingRegistrationStore() business.PendingRegistra
 // Used by CreateOSSStorageManager when the SQLite bundle path is taken.
 func (sm *StorageManager) SetPendingRegistrationStore(s business.PendingRegistrationStore) {
 	sm.pendingRegistrationStore = s
+}
+
+// GetIPTrustStore returns the IP-trust storage interface (Issue #1694).
+// Returns nil when the current storage provider does not support IP-trust storage
+// (e.g. the OSS composite flatfile+SQLite backend). Only the database provider
+// supplies a non-nil value.
+func (sm *StorageManager) GetIPTrustStore() business.IPTrustStore {
+	return sm.ipTrustStore
+}
+
+// SetIPTrustStore wires the IP-trust store after construction.
+func (sm *StorageManager) SetIPTrustStore(s business.IPTrustStore) {
+	sm.ipTrustStore = s
 }
 
 // GetCapabilities returns the provider's capabilities.


### PR DESCRIPTION
## Summary

- Introduces `IPTrustEvaluator` — a 30-minute sustained-liveness gate that promotes a steward source IP to trusted status only after continuous healthy heartbeats for ≥ threshold (default: 30 min), blocking sandbox-detonation attempts (3–15 min lifetime)
- Wires the evaluator into the heartbeat service via `TrustEvaluator` interface and `stewardIPTrustAdapter` (resolves tenantID+IP from fleet registry)
- Adds `IPTrustThreshold` configuration field to `RegistrationConfig` and `GetIPTrustStore()` to `StorageManager`

## Changed files

| File | Change |
|------|--------|
| `features/controller/registration/ip_trust_evaluator.go` | New: IPTrustEvaluator with in-memory timer + AddTrustedRange promotion |
| `features/controller/registration/ip_trust_evaluator_test.go` | New: 7 tests including all 3 required AC tests |
| `features/controller/heartbeat/service.go` | Add TrustEvaluator interface and Config field |
| `features/controller/heartbeat/service_test.go` | Add 3 trust evaluator tests |
| `features/controller/server/health_adapters.go` | Add stewardIPTrustAdapter |
| `features/controller/server/health_adapters_test.go` | Add 5 adapter tests |
| `features/controller/server/server.go` | Wire evaluator into heartbeat config |
| `pkg/storage/interfaces/provider.go` | Add GetIPTrustStore()/SetIPTrustStore() to StorageManager |
| `features/controller/config/config.go` | Add IPTrustThreshold field and getter |
| `features/controller/config/config_test.go` | Add GetIPTrustThreshold tests |
| `docs/architecture/controller-operating-model.md` | Document IP-trust mechanism |

## Specialist review results

- **QA Test Runner**: Story #1694 packages PASS. One pre-existing terminal test failure (`TestWebSocketSlowClientDoesNotBlockOutput`, commit `71b52977`) unrelated to this change.
- **QA Code Reviewer**: PASS (blocking issue with error discard in goroutine fixed before commit)
- **Security Engineer**: PASS — no hardcoded secrets, no SQL injection, no central provider violations, input validation for empty/invalid IPs

Fixes #1694