### PR TITLE
controller+steward: zero-trust script API access via per-execution socket + JIT grant (Issue #1675)

### DIFF
--- a/features/controller/api/handlers_runs.go
+++ b/features/controller/api/handlers_runs.go
@@ -3,6 +3,7 @@
 package api
 
 import (
+	"context"
 	"encoding/base64"
 	"encoding/json"
 	"errors"
@@ -86,19 +87,17 @@ func (s *Server) handlePostRunScript(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	// Look up admin-configured DNA path overrides for parameter resolution.
+	// Look up admin-configured privilege metadata: DNA path overrides for
+	// parameter resolution and the required API scope (Issue #1675). The scope
+	// is read from the store — never from the request body — so callers cannot
+	// widen it beyond what was set by script:admin.
 	var paramPlatformBindings map[string]string
+	var requiredAPIScope []string
 	if s.privilegeStore != nil {
-		key := &cfgconfig.ConfigKey{
-			TenantID:  tenantID,
-			Namespace: "script-privilege",
-			Name:      req.ScriptID,
-		}
-		if entry, err := s.privilegeStore.GetConfig(r.Context(), key); err == nil && entry != nil {
-			var privMeta ScriptPrivilegeMetadata
-			if json.Unmarshal(entry.Data, &privMeta) == nil {
-				paramPlatformBindings = privMeta.ParamPlatformBindings
-			}
+		meta, loadErr := s.loadPrivilegeMetadata(r.Context(), tenantID, req.ScriptID)
+		if loadErr == nil && meta != nil {
+			paramPlatformBindings = meta.ParamPlatformBindings
+			requiredAPIScope = meta.RequiredAPIScope
 		}
 	}
 
@@ -116,6 +115,7 @@ func (s *Server) handlePostRunScript(w http.ResponseWriter, r *http.Request) {
 		req.Params,
 		scriptMeta,
 		paramPlatformBindings,
+		requiredAPIScope,
 	)
 	if err != nil {
 		s.logger.Error("Failed to synthesize script run",
@@ -361,4 +361,25 @@ func parseRunTarget(target string) (fleet.Filter, error) {
 		return fleet.Filter{}, nil
 	}
 	return fleet.ParseTargetSelector(target)
+}
+
+// loadPrivilegeMetadata retrieves ScriptPrivilegeMetadata for the given script from
+// the privilege store. Returns (nil, nil) when the entry does not exist.
+func (s *Server) loadPrivilegeMetadata(ctx context.Context, tenantID, scriptID string) (*ScriptPrivilegeMetadata, error) {
+	if s.privilegeStore == nil {
+		return nil, nil
+	}
+	entry, err := s.privilegeStore.GetConfig(ctx, &cfgconfig.ConfigKey{
+		TenantID:  tenantID,
+		Namespace: "script-privilege",
+		Name:      scriptID,
+	})
+	if err != nil {
+		return nil, err
+	}
+	var meta ScriptPrivilegeMetadata
+	if err := json.Unmarshal(entry.Data, &meta); err != nil {
+		return nil, err
+	}
+	return &meta, nil
 }

--- a/features/controller/api/middleware.go
+++ b/features/controller/api/middleware.go
@@ -176,8 +176,21 @@ func hasHeaderCredentials(r *http.Request) bool {
 // States: (a) admin-marked cert only → admin principal; (b) admin-marked cert + header → 400;
 // (c) cert without admin marker → fall through to API-key auth; (d) no cert → API-key auth.
 // M-AUTH-1: Load API keys from secret store on-demand if not in cache.
+// Issue #1675: relay-injected principals bypass normal auth when relayPrincipalKey is set.
 func (s *Server) authenticationMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Issue #1675: relay principal — pre-validated by RelayHandler after grant check.
+		// The relayPrincipalKey is set only in the relay handler after LookupGrant succeeds,
+		// so this path can only be reached via an internal in-process call, never from the
+		// network. The principalContextKey is also set by the relay handler before calling
+		// ServeHTTP, so the context already carries both keys.
+		if injected, ok := r.Context().Value(relayPrincipalKey).(*Principal); ok && injected != nil {
+			// principalContextKey is already set by the relay handler; just proceed.
+			_ = injected // already in context
+			next.ServeHTTP(w, r)
+			return
+		}
+
 		// Test endpoints require explicit opt-in via CFGMS_ENABLE_TEST_ENDPOINTS=true.
 		// Without this env var, test endpoints require authentication like everything else.
 		if os.Getenv("CFGMS_ENABLE_TEST_ENDPOINTS") == "true" {
@@ -369,8 +382,20 @@ type AuthorizationDecision struct {
 func (s *Server) requirePermission(resourceType, action string) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			// Skip permission check if RBAC service is not available
+			// Skip permission check if RBAC service is not available.
+			// Relay principals are always enforced inline — scope isolation is their
+			// entire security guarantee and must hold even without the RBAC audit path.
 			if s.rbacService == nil {
+				if _, isRelay := r.Context().Value(relayPrincipalKey).(*Principal); isRelay {
+					p, _ := r.Context().Value(principalContextKey).(*Principal)
+					permID := s.buildPermissionID(resourceType, action)
+					if !s.hasPermission(p, permID) {
+						s.writeErrorResponse(w, http.StatusForbidden, "Insufficient permissions", "INSUFFICIENT_PERMISSIONS")
+						return
+					}
+					next.ServeHTTP(w, r)
+					return
+				}
 				s.logger.Warn("RBAC service not available, skipping permission check")
 				next.ServeHTTP(w, r)
 				return

--- a/features/controller/api/relay_handler.go
+++ b/features/controller/api/relay_handler.go
@@ -1,0 +1,247 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+package api
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/cfgis/cfgms/features/config/signature"
+	controllerrun "github.com/cfgis/cfgms/features/controller/run"
+	cpInterfaces "github.com/cfgis/cfgms/pkg/controlplane/interfaces"
+	cpTypes "github.com/cfgis/cfgms/pkg/controlplane/types"
+	"github.com/cfgis/cfgms/pkg/ctxkeys"
+	"github.com/cfgis/cfgms/pkg/logging"
+)
+
+// relayPrincipalKey is a private context key used by the relay handler to inject
+// a pre-validated, scope-limited Principal, bypassing normal mTLS/API-key auth.
+// It is only set by RelayHandler after grant validation — never from untrusted input.
+type relayPrincipalContextKeyType struct{}
+
+var relayPrincipalKey = relayPrincipalContextKeyType{}
+
+// RelayHandler subscribes to EventRelayRequest events, validates the per-execution
+// grant, routes the embedded HTTP request through the existing REST handler (using
+// a scope-limited Principal), and sends back a CommandRelayResponse.
+//
+// The device identity is always taken from event.StewardID (mTLS-verified by the
+// control plane transport) — never from any field in the relay message body.
+type RelayHandler struct {
+	controlPlane cpInterfaces.ControlPlaneProvider
+	runManager   *controllerrun.Manager
+	apiHandler   http.Handler
+	signer       signature.Signer // optional; nil = unsigned commands (test mode)
+	logger       logging.Logger
+}
+
+// NewRelayHandler creates a RelayHandler wired to the given control plane, run
+// manager, and API HTTP handler. signer may be nil in test or unsecured mode.
+func NewRelayHandler(
+	controlPlane cpInterfaces.ControlPlaneProvider,
+	runManager *controllerrun.Manager,
+	apiHandler http.Handler,
+	signer signature.Signer,
+	logger logging.Logger,
+) *RelayHandler {
+	return &RelayHandler{
+		controlPlane: controlPlane,
+		runManager:   runManager,
+		apiHandler:   apiHandler,
+		signer:       signer,
+		logger:       logger,
+	}
+}
+
+// Start subscribes to EventRelayRequest events. Returns when ctx is cancelled.
+func (h *RelayHandler) Start(ctx context.Context) error {
+	return h.controlPlane.SubscribeEvents(ctx, &cpTypes.EventFilter{
+		EventTypes: []cpTypes.EventType{cpTypes.EventRelayRequest},
+	}, h.handleRelayEvent)
+}
+
+// handleRelayEvent processes a single EventRelayRequest:
+//  1. Extracts deviceID (from event.StewardID — trusted) and executionID.
+//  2. Validates the grant keyed on (deviceID, executionID).
+//  3. Constructs a scoped, non-admin Principal from the grant.
+//  4. Routes the embedded HTTP request through the REST handler.
+//  5. Sends the response back as CommandRelayResponse.
+func (h *RelayHandler) handleRelayEvent(ctx context.Context, event *cpTypes.Event) error {
+	if event.Type != cpTypes.EventRelayRequest {
+		return nil
+	}
+
+	// Device identity from mTLS-verified StewardID — never from the message body.
+	deviceID := event.StewardID
+	if deviceID == "" {
+		h.logger.Warn("relay: received relay_request with empty steward_id — ignoring")
+		return nil
+	}
+
+	if event.Details == nil {
+		h.logger.Warn("relay: relay_request has no details", "device_id", logging.SanitizeLogValue(deviceID))
+		return nil
+	}
+
+	executionID, _ := event.Details["execution_id"].(string)
+	seq, _ := event.Details["sequence"].(float64)
+	method, _ := event.Details["method"].(string)
+	path, _ := event.Details["path"].(string)
+	bodyB64, _ := event.Details["body"].(string)
+
+	if executionID == "" || method == "" || path == "" {
+		h.logger.Warn("relay: missing required fields in relay_request",
+			"device_id", logging.SanitizeLogValue(deviceID),
+			"execution_id", logging.SanitizeLogValue(executionID))
+		return h.sendErrorResponse(ctx, deviceID, event.StewardID, executionID, seq, http.StatusBadRequest)
+	}
+
+	// Validate grant — keyed on (deviceID, executionID) so cross-device spoofing fails.
+	grant, err := h.runManager.LookupGrant(deviceID, executionID)
+	if err != nil {
+		h.logger.Info("relay: grant not found or consumed",
+			"device_id", logging.SanitizeLogValue(deviceID),
+			"execution_id", logging.SanitizeLogValue(executionID),
+			"error", err)
+		return h.sendErrorResponse(ctx, deviceID, event.StewardID, executionID, seq, http.StatusForbidden)
+	}
+
+	// Construct scope-limited, non-admin Principal. TenantID comes from the grant
+	// (set at dispatch time from device registration) — not from the event body.
+	principal := &Principal{
+		ID:          fmt.Sprintf("relay:%s:%s", deviceID, executionID),
+		Name:        fmt.Sprintf("relay-script:%s", deviceID),
+		IsAdmin:     false,
+		Permissions: grant.Scope,
+		TenantID:    grant.TenantID,
+	}
+
+	// Decode request body.
+	body, _ := base64.StdEncoding.DecodeString(bodyB64)
+
+	// Build the synthetic HTTP request.
+	var bodyReader io.Reader
+	if len(body) > 0 {
+		bodyReader = bytes.NewReader(body)
+	} else {
+		bodyReader = http.NoBody
+	}
+	req, err := http.NewRequestWithContext(ctx, method, path, bodyReader)
+	if err != nil {
+		h.logger.Error("relay: build request failed",
+			"device_id", logging.SanitizeLogValue(deviceID),
+			"path", logging.SanitizeLogValue(path),
+			"error", err)
+		return h.sendErrorResponse(ctx, deviceID, event.StewardID, executionID, seq, http.StatusInternalServerError)
+	}
+
+	// Copy only safe headers from the relay event. Auth tokens, correlation IDs, and
+	// routing headers are stripped so a script cannot forge audit entries or widen scope.
+	safeHeaders := map[string]bool{"content-type": true, "accept": true}
+	if headers, ok := event.Details["headers"].(map[string]interface{}); ok {
+		for k, v := range headers {
+			if safeHeaders[strings.ToLower(k)] {
+				if vs, ok := v.(string); ok {
+					req.Header.Set(k, vs)
+				}
+			}
+		}
+	}
+
+	// Inject the pre-built Principal into the request context so that
+	// authenticationMiddleware bypasses normal credential checks.
+	reqCtx := context.WithValue(req.Context(), relayPrincipalKey, principal)
+	reqCtx = context.WithValue(reqCtx, principalContextKey, principal)
+	reqCtx = context.WithValue(reqCtx, ctxkeys.UserIDKey, logging.SanitizeLogValue(principal.ID))
+	reqCtx = context.WithValue(reqCtx, ctxkeys.TenantID, principal.TenantID)
+	req = req.WithContext(reqCtx)
+
+	// Route through the existing REST handler (requirePermission checks Permissions).
+	rw := httptest.NewRecorder()
+	h.apiHandler.ServeHTTP(rw, req)
+	resp := rw.Result()
+	defer func() { _ = resp.Body.Close() }()
+
+	respBody, _ := io.ReadAll(resp.Body)
+
+	// Flatten response headers to map[string]interface{}.
+	respHeaders := make(map[string]interface{}, len(resp.Header))
+	for k, vs := range resp.Header {
+		if len(vs) > 0 {
+			respHeaders[k] = vs[0]
+		}
+	}
+
+	return h.sendRelayResponse(ctx, deviceID, executionID, seq, resp.StatusCode, respHeaders, respBody)
+}
+
+// sendErrorResponse sends a CommandRelayResponse with the given HTTP status code
+// and no body. Used for grant validation failures and malformed requests.
+func (h *RelayHandler) sendErrorResponse(ctx context.Context, targetSteward, _, executionID string, seq float64, statusCode int) error {
+	return h.sendRelayResponse(ctx, targetSteward, executionID, seq, statusCode, nil, []byte(http.StatusText(statusCode)))
+}
+
+// sendRelayResponse transmits a CommandRelayResponse to the target steward.
+func (h *RelayHandler) sendRelayResponse(
+	ctx context.Context,
+	targetSteward, executionID string,
+	seq float64,
+	statusCode int,
+	headers map[string]interface{},
+	body []byte,
+) error {
+	if headers == nil {
+		headers = map[string]interface{}{}
+	}
+	cmd := &cpTypes.Command{
+		ID:        uuid.New().String(),
+		Type:      cpTypes.CommandRelayResponse,
+		StewardID: targetSteward,
+		Timestamp: time.Now(),
+		Params: map[string]interface{}{
+			"execution_id": executionID,
+			"sequence":     seq,
+			"status":       float64(statusCode),
+			"headers":      headers,
+			"body":         base64.StdEncoding.EncodeToString(body),
+		},
+	}
+
+	signed := &cpTypes.SignedCommand{Command: *cmd}
+	if h.signer != nil {
+		rawParams := cpTypes.InterfaceParamsToStringMap(cmd.Params)
+		cmdBytes, err := cpTypes.CommandSigningBytes(cmd, rawParams)
+		if err != nil {
+			return fmt.Errorf("relay: sign response: %w", err)
+		}
+		sig, err := h.signer.Sign(cmdBytes)
+		if err != nil {
+			return fmt.Errorf("relay: sign response: %w", err)
+		}
+		signed.Signature = sig
+	}
+
+	if err := h.controlPlane.SendCommand(ctx, signed); err != nil {
+		h.logger.Error("relay: failed to send relay response",
+			"target_steward", logging.SanitizeLogValue(targetSteward),
+			"execution_id", logging.SanitizeLogValue(executionID),
+			"error", err)
+		return fmt.Errorf("relay: send command: %w", err)
+	}
+
+	h.logger.Debug("relay: sent relay response",
+		"target_steward", logging.SanitizeLogValue(targetSteward),
+		"execution_id", logging.SanitizeLogValue(executionID),
+		"status", statusCode)
+
+	return nil
+}

--- a/features/controller/api/relay_handler_test.go
+++ b/features/controller/api/relay_handler_test.go
@@ -384,7 +384,7 @@ func TestRelayHandler_AuthMiddlewareBypass(t *testing.T) {
 	inner := newRelayTestHandler()
 	// Wrap inner with a middleware that checks for the relay principal bypass.
 	wrapped := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// Simulate authenticationMiddleware: check relay bypass first.
+		// Mirror authenticationMiddleware: check relay bypass first.
 		if injected, ok := r.Context().Value(relayPrincipalKey).(*Principal); ok && injected != nil {
 			inner.ServeHTTP(w, r)
 			return

--- a/features/controller/api/relay_handler_test.go
+++ b/features/controller/api/relay_handler_test.go
@@ -1,0 +1,521 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+package api
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	controllerrun "github.com/cfgis/cfgms/features/controller/run"
+	cpInterfaces "github.com/cfgis/cfgms/pkg/controlplane/interfaces"
+	cpTypes "github.com/cfgis/cfgms/pkg/controlplane/types"
+	"github.com/cfgis/cfgms/pkg/logging"
+	_ "modernc.org/sqlite"
+)
+
+// recordingControlPlane is a test control plane that records sent commands and
+// allows tests to trigger events by calling TriggerEvent. It is NOT a mock:
+// it implements the full ControlPlaneProvider interface with real (if minimal) behaviour.
+type recordingControlPlane struct {
+	mu           sync.Mutex
+	sentCommands []*cpTypes.SignedCommand
+	eventHandler cpInterfaces.EventHandler
+}
+
+func (c *recordingControlPlane) Name() string      { return "recording" }
+func (c *recordingControlPlane) IsConnected() bool { return true }
+func (c *recordingControlPlane) Initialize(_ context.Context, _ map[string]interface{}) error {
+	return nil
+}
+func (c *recordingControlPlane) Start(_ context.Context) error     { return nil }
+func (c *recordingControlPlane) Stop(_ context.Context) error      { return nil }
+func (c *recordingControlPlane) Reconnect(_ context.Context) error { return nil }
+func (c *recordingControlPlane) SendCommand(_ context.Context, cmd *cpTypes.SignedCommand) error {
+	c.mu.Lock()
+	c.sentCommands = append(c.sentCommands, cmd)
+	c.mu.Unlock()
+	return nil
+}
+func (c *recordingControlPlane) FanOutCommand(_ context.Context, _ *cpTypes.SignedCommand, _ []string) (*cpTypes.FanOutResult, error) {
+	return &cpTypes.FanOutResult{}, nil
+}
+func (c *recordingControlPlane) SubscribeCommands(_ context.Context, _ string, _ cpInterfaces.CommandHandler) error {
+	return nil
+}
+func (c *recordingControlPlane) PublishEvent(_ context.Context, _ *cpTypes.Event) error { return nil }
+func (c *recordingControlPlane) SubscribeEvents(_ context.Context, _ *cpTypes.EventFilter, handler cpInterfaces.EventHandler) error {
+	c.mu.Lock()
+	c.eventHandler = handler
+	c.mu.Unlock()
+	return nil
+}
+func (c *recordingControlPlane) SendHeartbeat(_ context.Context, _ *cpTypes.Heartbeat) error {
+	return nil
+}
+func (c *recordingControlPlane) SubscribeHeartbeats(_ context.Context, _ cpInterfaces.HeartbeatHandler) error {
+	return nil
+}
+func (c *recordingControlPlane) GetStats(_ context.Context) (*cpTypes.ControlPlaneStats, error) {
+	return &cpTypes.ControlPlaneStats{}, nil
+}
+
+// TriggerEvent calls the registered event handler with the given event.
+func (c *recordingControlPlane) TriggerEvent(ctx context.Context, event *cpTypes.Event) error {
+	c.mu.Lock()
+	h := c.eventHandler
+	c.mu.Unlock()
+	if h == nil {
+		return nil
+	}
+	return h(ctx, event)
+}
+
+// SentCommands returns a copy of all sent commands.
+func (c *recordingControlPlane) SentCommands() []*cpTypes.SignedCommand {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	out := make([]*cpTypes.SignedCommand, len(c.sentCommands))
+	copy(out, c.sentCommands)
+	return out
+}
+
+// newRelayRunManager creates an in-memory RunStore backed manager for relay handler tests.
+func newRelayRunManager(t *testing.T) *controllerrun.Manager {
+	t.Helper()
+	db, err := sql.Open("sqlite", ":memory:")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+
+	store := controllerrun.NewRunStoreSQL(db)
+	require.NoError(t, store.Init(context.Background()))
+	return controllerrun.NewManager(store, nil)
+}
+
+// newRelayTestHandler returns an http.Handler that records the received
+// Principal and returns a 200 response with the principal's permissions as JSON.
+func newRelayTestHandler() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		principal, _ := r.Context().Value(principalContextKey).(*Principal)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		var perms []string
+		if principal != nil {
+			perms = principal.Permissions
+		}
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"permissions": perms,
+			"is_admin":    principal != nil && principal.IsAdmin,
+		})
+	})
+}
+
+// newRelayForbiddenHandler returns a handler that always rejects via requirePermission-like logic.
+func newRelayForbiddenHandler(requiredPerm string) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		principal, _ := r.Context().Value(principalContextKey).(*Principal)
+		if principal == nil || principal.IsAdmin {
+			// Admin or nil — not expected in relay path.
+			w.WriteHeader(http.StatusForbidden)
+			return
+		}
+		for _, p := range principal.Permissions {
+			if p == requiredPerm {
+				w.WriteHeader(http.StatusOK)
+				return
+			}
+		}
+		w.WriteHeader(http.StatusForbidden)
+	})
+}
+
+// TestRelayHandler_NoGrant_Returns403 verifies AC2: relay request with no grant returns 403.
+func TestRelayHandler_NoGrant_Returns403(t *testing.T) {
+	cp := &recordingControlPlane{}
+	manager := newRelayRunManager(t)
+	handler := NewRelayHandler(cp, manager, newRelayTestHandler(), nil, logging.NewNoopLogger())
+
+	ctx := context.Background()
+	require.NoError(t, handler.Start(ctx))
+
+	err := cp.TriggerEvent(ctx, &cpTypes.Event{
+		Type:      cpTypes.EventRelayRequest,
+		StewardID: "device-1",
+		Timestamp: time.Now(),
+		Details: map[string]interface{}{
+			"execution_id": "exec-no-grant",
+			"sequence":     float64(1),
+			"method":       "GET",
+			"path":         "/api/v1/runs",
+			"headers":      map[string]interface{}{},
+			"body":         "",
+		},
+	})
+	require.NoError(t, err)
+
+	cmds := cp.SentCommands()
+	require.Len(t, cmds, 1)
+	assert.Equal(t, cpTypes.CommandRelayResponse, cmds[0].Command.Type)
+	assert.Equal(t, float64(http.StatusForbidden), cmds[0].Command.Params["status"])
+}
+
+// TestRelayHandler_ConsumedGrant_Returns403 verifies AC2: after ConsumeGrant, relay returns 403.
+func TestRelayHandler_ConsumedGrant_Returns403(t *testing.T) {
+	cp := &recordingControlPlane{}
+	manager := newRelayRunManager(t)
+
+	// Create and immediately consume a grant.
+	require.NoError(t, manager.CreateGrant("device-1", "tenant-1", "exec-consumed", []string{"runs:read"}, time.Hour))
+	require.NoError(t, manager.ConsumeGrant("exec-consumed"))
+
+	handler := NewRelayHandler(cp, manager, newRelayTestHandler(), nil, logging.NewNoopLogger())
+
+	ctx := context.Background()
+	require.NoError(t, handler.Start(ctx))
+
+	err := cp.TriggerEvent(ctx, &cpTypes.Event{
+		Type:      cpTypes.EventRelayRequest,
+		StewardID: "device-1",
+		Timestamp: time.Now(),
+		Details: map[string]interface{}{
+			"execution_id": "exec-consumed",
+			"sequence":     float64(1),
+			"method":       "GET",
+			"path":         "/api/v1/runs",
+			"headers":      map[string]interface{}{},
+			"body":         "",
+		},
+	})
+	require.NoError(t, err)
+
+	cmds := cp.SentCommands()
+	require.Len(t, cmds, 1)
+	assert.Equal(t, float64(http.StatusForbidden), cmds[0].Command.Params["status"])
+}
+
+// TestRelayHandler_WrongDevice_Returns403 verifies AC3: relay request from device A
+// for an executionID whose grant was issued to device B returns 403.
+func TestRelayHandler_WrongDevice_Returns403(t *testing.T) {
+	cp := &recordingControlPlane{}
+	manager := newRelayRunManager(t)
+
+	// Grant issued to device-B.
+	require.NoError(t, manager.CreateGrant("device-B", "tenant-1", "exec-B", []string{"runs:read"}, time.Hour))
+
+	handler := NewRelayHandler(cp, manager, newRelayTestHandler(), nil, logging.NewNoopLogger())
+	ctx := context.Background()
+	require.NoError(t, handler.Start(ctx))
+
+	// Relay request arrives claiming device-A but using device-B's execution ID.
+	err := cp.TriggerEvent(ctx, &cpTypes.Event{
+		Type:      cpTypes.EventRelayRequest,
+		StewardID: "device-A", // different device — grant lookup (device-A, exec-B) fails
+		Timestamp: time.Now(),
+		Details: map[string]interface{}{
+			"execution_id": "exec-B",
+			"sequence":     float64(1),
+			"method":       "GET",
+			"path":         "/api/v1/runs",
+			"headers":      map[string]interface{}{},
+			"body":         "",
+		},
+	})
+	require.NoError(t, err)
+
+	cmds := cp.SentCommands()
+	require.Len(t, cmds, 1)
+	assert.Equal(t, float64(http.StatusForbidden), cmds[0].Command.Params["status"])
+}
+
+// TestRelayHandler_ScopeEnforcement_Returns403 verifies AC4: relay request to an
+// endpoint requiring a permission NOT in the grant scope returns 403.
+func TestRelayHandler_ScopeEnforcement_Returns403(t *testing.T) {
+	cp := &recordingControlPlane{}
+	manager := newRelayRunManager(t)
+
+	// Grant includes only "runs:read"; handler requires "runs:write".
+	require.NoError(t, manager.CreateGrant("device-1", "tenant-1", "exec-scope", []string{"runs:read"}, time.Hour))
+
+	// Use a handler that enforces "runs:write" permission.
+	apiHandler := newRelayForbiddenHandler("runs:write")
+	handler := NewRelayHandler(cp, manager, apiHandler, nil, logging.NewNoopLogger())
+	ctx := context.Background()
+	require.NoError(t, handler.Start(ctx))
+
+	err := cp.TriggerEvent(ctx, &cpTypes.Event{
+		Type:      cpTypes.EventRelayRequest,
+		StewardID: "device-1",
+		Timestamp: time.Now(),
+		Details: map[string]interface{}{
+			"execution_id": "exec-scope",
+			"sequence":     float64(1),
+			"method":       "POST",
+			"path":         "/api/v1/runs/script",
+			"headers":      map[string]interface{}{},
+			"body":         "",
+		},
+	})
+	require.NoError(t, err)
+
+	cmds := cp.SentCommands()
+	require.Len(t, cmds, 1)
+	assert.Equal(t, float64(http.StatusForbidden), cmds[0].Command.Params["status"])
+}
+
+// TestRelayHandler_ValidGrant_RoutesRequest verifies that a valid grant results
+// in the request being routed with the correct scoped Principal.
+func TestRelayHandler_ValidGrant_RoutesRequest(t *testing.T) {
+	cp := &recordingControlPlane{}
+	manager := newRelayRunManager(t)
+
+	scope := []string{"runs:read", "scripts:execute"}
+	require.NoError(t, manager.CreateGrant("device-1", "tenant-1", "exec-valid", scope, time.Hour))
+
+	// Use the test handler that returns the principal's permissions.
+	handler := NewRelayHandler(cp, manager, newRelayTestHandler(), nil, logging.NewNoopLogger())
+	ctx := context.Background()
+	require.NoError(t, handler.Start(ctx))
+
+	err := cp.TriggerEvent(ctx, &cpTypes.Event{
+		Type:      cpTypes.EventRelayRequest,
+		StewardID: "device-1",
+		Timestamp: time.Now(),
+		Details: map[string]interface{}{
+			"execution_id": "exec-valid",
+			"sequence":     float64(1),
+			"method":       "GET",
+			"path":         "/api/v1/runs",
+			"headers":      map[string]interface{}{},
+			"body":         "",
+		},
+	})
+	require.NoError(t, err)
+
+	cmds := cp.SentCommands()
+	require.Len(t, cmds, 1)
+	cmd := cmds[0]
+	assert.Equal(t, cpTypes.CommandRelayResponse, cmd.Command.Type)
+	assert.Equal(t, float64(http.StatusOK), cmd.Command.Params["status"])
+}
+
+// TestRelayHandler_AdminPrincipal_NeverConstructed verifies that the relay handler
+// always constructs non-admin principals regardless of grant scope.
+func TestRelayHandler_AdminPrincipal_NeverConstructed(t *testing.T) {
+	cp := &recordingControlPlane{}
+	manager := newRelayRunManager(t)
+
+	// Even if the grant scope includes something like "admin", IsAdmin stays false.
+	require.NoError(t, manager.CreateGrant("device-1", "tenant-1", "exec-admin-test", []string{"*"}, time.Hour))
+
+	var capturedPrincipal *Principal
+	captureHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedPrincipal, _ = r.Context().Value(principalContextKey).(*Principal)
+		w.WriteHeader(http.StatusOK)
+	})
+
+	handler := NewRelayHandler(cp, manager, captureHandler, nil, logging.NewNoopLogger())
+	ctx := context.Background()
+	require.NoError(t, handler.Start(ctx))
+
+	require.NoError(t, cp.TriggerEvent(ctx, &cpTypes.Event{
+		Type:      cpTypes.EventRelayRequest,
+		StewardID: "device-1",
+		Timestamp: time.Now(),
+		Details: map[string]interface{}{
+			"execution_id": "exec-admin-test",
+			"sequence":     float64(1),
+			"method":       "GET",
+			"path":         "/api/v1/runs",
+			"headers":      map[string]interface{}{},
+			"body":         "",
+		},
+	}))
+
+	require.NotNil(t, capturedPrincipal)
+	assert.False(t, capturedPrincipal.IsAdmin, "relay principal must never be admin")
+	assert.Equal(t, "tenant-1", capturedPrincipal.TenantID)
+}
+
+// TestRelayHandler_ExpiredGrant_Returns403 verifies that an expired grant returns 403.
+func TestRelayHandler_ExpiredGrant_Returns403(t *testing.T) {
+	cp := &recordingControlPlane{}
+	manager := newRelayRunManager(t)
+
+	// Grant with a 1 nanosecond TTL — effectively already expired.
+	require.NoError(t, manager.CreateGrant("device-1", "tenant-1", "exec-expired", []string{"runs:read"}, time.Nanosecond))
+	time.Sleep(10 * time.Millisecond) // ensure TTL has elapsed
+
+	handler := NewRelayHandler(cp, manager, newRelayTestHandler(), nil, logging.NewNoopLogger())
+	ctx := context.Background()
+	require.NoError(t, handler.Start(ctx))
+
+	require.NoError(t, cp.TriggerEvent(ctx, &cpTypes.Event{
+		Type:      cpTypes.EventRelayRequest,
+		StewardID: "device-1",
+		Timestamp: time.Now(),
+		Details: map[string]interface{}{
+			"execution_id": "exec-expired",
+			"sequence":     float64(1),
+			"method":       "GET",
+			"path":         "/api/v1/runs",
+			"headers":      map[string]interface{}{},
+			"body":         "",
+		},
+	}))
+
+	cmds := cp.SentCommands()
+	require.Len(t, cmds, 1)
+	assert.Equal(t, float64(http.StatusForbidden), cmds[0].Command.Params["status"])
+}
+
+// TestRelayHandler_AuthMiddlewareBypass verifies that the relay principal injected
+// by the relay handler bypasses authenticationMiddleware, and that requirePermission
+// still enforces scope (regression guard for the middleware bypass path).
+func TestRelayHandler_AuthMiddlewareBypass(t *testing.T) {
+	// Build a minimal server with auth middleware wrapping the test handler.
+	inner := newRelayTestHandler()
+	// Wrap inner with a middleware that checks for the relay principal bypass.
+	wrapped := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Simulate authenticationMiddleware: check relay bypass first.
+		if injected, ok := r.Context().Value(relayPrincipalKey).(*Principal); ok && injected != nil {
+			inner.ServeHTTP(w, r)
+			return
+		}
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+	})
+
+	cp := &recordingControlPlane{}
+	manager := newRelayRunManager(t)
+	require.NoError(t, manager.CreateGrant("device-1", "tenant-1", "exec-bypass", []string{"runs:read"}, time.Hour))
+
+	handler := NewRelayHandler(cp, manager, wrapped, nil, logging.NewNoopLogger())
+	ctx := context.Background()
+	require.NoError(t, handler.Start(ctx))
+
+	require.NoError(t, cp.TriggerEvent(ctx, &cpTypes.Event{
+		Type:      cpTypes.EventRelayRequest,
+		StewardID: "device-1",
+		Timestamp: time.Now(),
+		Details: map[string]interface{}{
+			"execution_id": "exec-bypass",
+			"sequence":     float64(1),
+			"method":       "GET",
+			"path":         "/api/v1/runs",
+			"headers":      map[string]interface{}{},
+			"body":         "",
+		},
+	}))
+
+	cmds := cp.SentCommands()
+	require.Len(t, cmds, 1)
+	// Should succeed (not 401 unauthorized) because relay principal bypassed auth.
+	assert.Equal(t, float64(http.StatusOK), cmds[0].Command.Params["status"])
+}
+
+// TestRelayHandler_IgnoresNonRelayEvents ensures the handler ignores events of
+// other types without sending a response.
+func TestRelayHandler_IgnoresNonRelayEvents(t *testing.T) {
+	cp := &recordingControlPlane{}
+	manager := newRelayRunManager(t)
+	handler := NewRelayHandler(cp, manager, newRelayTestHandler(), nil, logging.NewNoopLogger())
+	ctx := context.Background()
+	require.NoError(t, handler.Start(ctx))
+
+	require.NoError(t, cp.TriggerEvent(ctx, &cpTypes.Event{
+		Type:      cpTypes.EventScriptCompleted,
+		StewardID: "device-1",
+		Timestamp: time.Now(),
+	}))
+
+	assert.Empty(t, cp.SentCommands(), "non-relay events must not trigger a relay response")
+}
+
+// TestRunStore_GrantLifecycle is a RunStore-level test for the grant management
+// methods added in Issue #1675.
+func TestRunStore_GrantLifecycle(t *testing.T) {
+	db, err := sql.Open("sqlite", ":memory:")
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	store := controllerrun.NewRunStoreSQL(db)
+	require.NoError(t, store.Init(context.Background()))
+
+	// Create grant.
+	require.NoError(t, store.CreateExecutionGrant("dev-1", "tenant-1", "exec-1", []string{"runs:read"}, time.Hour))
+
+	// LookupGrant — should succeed.
+	g, err := store.LookupGrant("dev-1", "exec-1")
+	require.NoError(t, err)
+	require.NotNil(t, g)
+	assert.Equal(t, []string{"runs:read"}, g.Scope)
+	assert.Equal(t, "tenant-1", g.TenantID)
+	assert.False(t, g.Consumed)
+
+	// Wrong device — should fail.
+	_, err = store.LookupGrant("dev-other", "exec-1")
+	assert.ErrorIs(t, err, controllerrun.ErrGrantNotFound)
+
+	// Consume.
+	require.NoError(t, store.ConsumeGrant("exec-1"))
+
+	// LookupGrant after consume — should return ErrGrantConsumed.
+	_, err = store.LookupGrant("dev-1", "exec-1")
+	assert.ErrorIs(t, err, controllerrun.ErrGrantConsumed)
+}
+
+// TestRunStore_GrantExpiry verifies that expired grants return ErrGrantNotFound.
+func TestRunStore_GrantExpiry(t *testing.T) {
+	db, err := sql.Open("sqlite", ":memory:")
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	store := controllerrun.NewRunStoreSQL(db)
+	require.NoError(t, store.Init(context.Background()))
+
+	require.NoError(t, store.CreateExecutionGrant("dev-1", "tenant-1", "exec-exp", []string{"runs:read"}, time.Nanosecond))
+	time.Sleep(10 * time.Millisecond)
+
+	_, err = store.LookupGrant("dev-1", "exec-exp")
+	assert.ErrorIs(t, err, controllerrun.ErrGrantNotFound)
+}
+
+// TestRequirePermission_RelayPrincipal_ScopeEnforcedWhenRBACNil is a regression
+// guard for the Fix #2 (Issue #1675): relay scope must be enforced by requirePermission
+// even when s.rbacService is nil (OSS mode). Before the fix, the nil-rbacService
+// early-return bypassed all permission checks, granting relay scripts full access.
+func TestRequirePermission_RelayPrincipal_ScopeEnforcedWhenRBACNil(t *testing.T) {
+	s := &Server{rbacService: nil, logger: logging.NewNoopLogger()}
+
+	var reached bool
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		reached = true
+		w.WriteHeader(http.StatusOK)
+	})
+	handler := s.requirePermission("steward", "execute-scripts")(inner)
+
+	// Relay principal has only read-scripts — not execute-scripts.
+	relay := &Principal{IsAdmin: false, Permissions: []string{"steward:read-scripts"}, TenantID: "t1"}
+	ctx := context.WithValue(
+		context.WithValue(context.Background(), relayPrincipalKey, relay),
+		principalContextKey, relay)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/runs/script", nil).WithContext(ctx)
+
+	rw := httptest.NewRecorder()
+	handler.ServeHTTP(rw, req)
+
+	assert.Equal(t, http.StatusForbidden, rw.Code,
+		"relay scope must be enforced even when rbacService is nil")
+	assert.False(t, reached, "inner handler must not be reached when scope is insufficient")
+}
+
+// noopResponseRecorder satisfies httptest.ResponseRecorder contract for tests
+// that need to pass an http.Handler without a real server.
+var _ *httptest.ResponseRecorder = (*httptest.ResponseRecorder)(nil)

--- a/features/controller/dispatcher/dispatcher.go
+++ b/features/controller/dispatcher/dispatcher.go
@@ -54,6 +54,10 @@ type Dispatcher struct {
 	// before Start; nil when no run manager is wired.
 	runSink RunCompletionSink
 
+	// grantManager, when set, creates and consumes per-execution relay grants
+	// (Issue #1675). Set once via SetGrantManager before Start; nil = no grants.
+	grantManager GrantManager
+
 	ctx    context.Context
 	cancel context.CancelFunc
 	wg     sync.WaitGroup
@@ -70,6 +74,15 @@ type Dispatcher struct {
 // interface rather than importing the run package directly.
 type RunCompletionSink interface {
 	RecordJobCompletion(ctx context.Context, runID, jobID, executionID string, failed bool) error
+}
+
+// GrantManager creates and consumes per-execution relay grants (Issue #1675).
+// It is implemented by *run.Manager.
+type GrantManager interface {
+	// CreateGrant records a JIT relay grant at dispatch time.
+	CreateGrant(deviceID, tenantID, executionID string, scope []string, ttl time.Duration) error
+	// ConsumeGrant marks the grant consumed when the execution completes.
+	ConsumeGrant(executionID string) error
 }
 
 // Config holds Dispatcher configuration.
@@ -122,6 +135,12 @@ func New(cfg *Config) (*Dispatcher, error) {
 // Start so the field is published before the event subscription begins.
 func (d *Dispatcher) SetRunCompletionSink(sink RunCompletionSink) {
 	d.runSink = sink
+}
+
+// SetGrantManager wires the grant manager for zero-trust script API access
+// (Issue #1675). Must be called before Start.
+func (d *Dispatcher) SetGrantManager(gm GrantManager) {
+	d.grantManager = gm
 }
 
 // Start begins the polling loop and subscribes to EventScriptCompleted events.
@@ -332,6 +351,24 @@ func (d *Dispatcher) sendCommand(ctx context.Context, deviceID string, exec *scr
 		params["environment"] = prepared.Environment
 	}
 
+	// Issue #1675: create JIT relay grant when the script requires API access.
+	// The scope comes from QueuedExecution.Metadata["required_api_scope"] which is set
+	// by SynthesizeScriptRun from the stored ScriptPrivilegeMetadata — never from runtime input.
+	if scope := extractMetaStringSlice(exec.Metadata, "required_api_scope"); len(scope) > 0 {
+		params["required_api_scope"] = scope
+
+		if d.grantManager != nil {
+			tenantID, _ := exec.Metadata["tenant_id"].(string)
+			ttl := exec.Timeout
+			if ttl <= 0 {
+				ttl = 15 * time.Minute // matches defaultScriptTimeoutSec in steward handler
+			}
+			if err := d.grantManager.CreateGrant(deviceID, tenantID, exec.ExecutionID, scope, ttl); err != nil {
+				return fmt.Errorf("create execution grant: %w", err)
+			}
+		}
+	}
+
 	cmd := &controlplaneTypes.Command{
 		ID:        uuid.New().String(),
 		Type:      controlplaneTypes.CommandExecuteScript,
@@ -495,6 +532,15 @@ func (d *Dispatcher) handleCompletionEvent(ctx context.Context, event *controlpl
 					"error", err)
 			}
 		}
+
+		// Issue #1675: consume the relay grant on execution completion so further
+		// relay requests return 403. Best-effort — a failure must not stall dispatch.
+		if d.grantManager != nil {
+			if err := d.grantManager.ConsumeGrant(executionID); err != nil {
+				d.logger.Debug("ConsumeGrant: no grant for execution (inline or no API scope)",
+					"execution_id", logging.SanitizeLogValue(executionID))
+			}
+		}
 	}
 
 	// Release the per-device lock so the next queued execution can be dispatched.
@@ -509,5 +555,30 @@ func (d *Dispatcher) handleCompletionEvent(ctx context.Context, event *controlpl
 		}()
 	}
 
+	return nil
+}
+
+// extractMetaStringSlice extracts a []string value from a metadata map.
+// Handles []interface{} (JSON-decoded) and []string (direct).
+func extractMetaStringSlice(meta map[string]interface{}, key string) []string {
+	if meta == nil {
+		return nil
+	}
+	v := meta[key]
+	if v == nil {
+		return nil
+	}
+	if s, ok := v.([]interface{}); ok {
+		result := make([]string, 0, len(s))
+		for _, item := range s {
+			if str, ok := item.(string); ok && str != "" {
+				result = append(result, str)
+			}
+		}
+		return result
+	}
+	if s, ok := v.([]string); ok {
+		return s
+	}
 	return nil
 }

--- a/features/controller/run/run.go
+++ b/features/controller/run/run.go
@@ -21,6 +21,12 @@ var ErrNotFound = errors.New("run not found")
 // ErrAlreadyTerminal is returned when an operation targets a run that has already reached a terminal state.
 var ErrAlreadyTerminal = errors.New("run is already in a terminal state")
 
+// ErrGrantNotFound is returned when no active grant exists for (deviceID, executionID).
+var ErrGrantNotFound = errors.New("execution grant not found or expired")
+
+// ErrGrantConsumed is returned when the grant has already been consumed.
+var ErrGrantConsumed = errors.New("execution grant already consumed")
+
 // RunStatus represents the lifecycle state of a run.
 type RunStatus string
 
@@ -81,6 +87,18 @@ type JobRecord struct {
 	CompletedAt *time.Time `json:"completed_at,omitempty"`
 }
 
+// ExecutionGrant records a per-execution API access grant created at dispatch time.
+// Grants are consumed when the execution completes and expire after their TTL.
+type ExecutionGrant struct {
+	DeviceID    string
+	TenantID    string
+	ExecutionID string
+	Scope       []string
+	CreatedAt   time.Time
+	ExpiresAt   time.Time
+	Consumed    bool
+}
+
 // RunStore is the durable storage interface for run and job records.
 type RunStore interface {
 	CreateRun(*RunRecord) error
@@ -90,6 +108,22 @@ type RunStore interface {
 	UpdateJobStatus(jobID string, status JobStatus, executionID string) error
 	UpdateRunStatus(runID string, status RunStatus) error
 	UpdateRunCounts(runID string, completedJobs, failedJobs int) error
+
+	// Grant management for zero-trust script API access (Issue #1675).
+
+	// CreateExecutionGrant records a JIT grant keyed on (deviceID, executionID).
+	// tenantID is stored with the grant so the relay handler can construct a scoped Principal.
+	// The grant expires after ttl elapses and is also invalidated by ConsumeGrant.
+	CreateExecutionGrant(deviceID, tenantID, executionID string, scope []string, ttl time.Duration) error
+
+	// LookupGrant returns the grant for (deviceID, executionID).
+	// Returns ErrGrantNotFound when no grant exists or it is expired.
+	// Returns ErrGrantConsumed when the grant has been consumed.
+	LookupGrant(deviceID, executionID string) (*ExecutionGrant, error)
+
+	// ConsumeGrant marks the grant for executionID as consumed so further relay
+	// requests return ErrGrantConsumed. Called when AcknowledgeCompletion fires.
+	ConsumeGrant(executionID string) error
 }
 
 // RunStoreSQL is the SQLite-backed implementation of RunStore.
@@ -104,8 +138,8 @@ func NewRunStoreSQL(db *sql.DB) *RunStoreSQL {
 	return &RunStoreSQL{db: db}
 }
 
-// Init creates the script_runs and script_run_jobs tables and their indexes if
-// they do not already exist. Safe to call multiple times (idempotent).
+// Init creates the script_runs, script_run_jobs, and execution_grants tables and
+// their indexes if they do not already exist. Safe to call multiple times (idempotent).
 func (s *RunStoreSQL) Init(_ context.Context) error {
 	const createRuns = `
 CREATE TABLE IF NOT EXISTS script_runs (
@@ -135,7 +169,20 @@ CREATE TABLE IF NOT EXISTS script_run_jobs (
 	const createJobsIndex = `
 CREATE INDEX IF NOT EXISTS idx_srj_run_id ON script_run_jobs(run_id);`
 
-	for _, stmt := range []string{createRuns, createJobs, createJobsIndex} {
+	const createGrants = `
+CREATE TABLE IF NOT EXISTS execution_grants (
+    execution_id TEXT NOT NULL PRIMARY KEY,
+    device_id    TEXT NOT NULL,
+    tenant_id    TEXT NOT NULL,
+    scope_json   TEXT NOT NULL,
+    created_at   DATETIME NOT NULL,
+    expires_at   DATETIME NOT NULL,
+    consumed     INTEGER NOT NULL DEFAULT 0
+);`
+	const createGrantsIndex = `
+CREATE INDEX IF NOT EXISTS idx_eg_device ON execution_grants(device_id, execution_id);`
+
+	for _, stmt := range []string{createRuns, createJobs, createJobsIndex, createGrants, createGrantsIndex} {
 		if _, err := s.db.Exec(stmt); err != nil {
 			return fmt.Errorf("run store init: %w", err)
 		}
@@ -293,6 +340,60 @@ func (s *RunStoreSQL) UpdateRunCounts(runID string, completedJobs, failedJobs in
 	return err
 }
 
+// CreateExecutionGrant stores a JIT relay grant keyed on (deviceID, executionID).
+func (s *RunStoreSQL) CreateExecutionGrant(deviceID, tenantID, executionID string, scope []string, ttl time.Duration) error {
+	scopeJSON, err := json.Marshal(scope)
+	if err != nil {
+		return fmt.Errorf("run store create grant: marshal scope: %w", err)
+	}
+	now := time.Now().UTC()
+	const q = `
+INSERT INTO execution_grants (execution_id, device_id, tenant_id, scope_json, created_at, expires_at, consumed)
+VALUES (?, ?, ?, ?, ?, ?, 0)`
+	_, err = s.db.Exec(q, executionID, deviceID, tenantID, string(scopeJSON), now, now.Add(ttl))
+	return err
+}
+
+// LookupGrant returns the grant for (deviceID, executionID).
+// Returns ErrGrantNotFound when no matching unexpired grant exists.
+// Returns ErrGrantConsumed when the grant has been consumed.
+func (s *RunStoreSQL) LookupGrant(deviceID, executionID string) (*ExecutionGrant, error) {
+	const q = `
+SELECT device_id, tenant_id, execution_id, scope_json, created_at, expires_at, consumed
+FROM execution_grants
+WHERE execution_id = ? AND device_id = ?`
+
+	row := s.db.QueryRow(q, executionID, deviceID)
+	g := &ExecutionGrant{}
+	var scopeJSON string
+	var consumed int
+	err := row.Scan(&g.DeviceID, &g.TenantID, &g.ExecutionID, &scopeJSON, &g.CreatedAt, &g.ExpiresAt, &consumed)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, ErrGrantNotFound
+		}
+		return nil, fmt.Errorf("run store lookup grant: %w", err)
+	}
+	if consumed != 0 {
+		return nil, ErrGrantConsumed
+	}
+	if time.Now().After(g.ExpiresAt) {
+		return nil, ErrGrantNotFound
+	}
+	if err := json.Unmarshal([]byte(scopeJSON), &g.Scope); err != nil {
+		return nil, fmt.Errorf("run store lookup grant: unmarshal scope: %w", err)
+	}
+	g.Consumed = consumed != 0
+	return g, nil
+}
+
+// ConsumeGrant marks the grant for executionID as consumed.
+func (s *RunStoreSQL) ConsumeGrant(executionID string) error {
+	const q = `UPDATE execution_grants SET consumed = 1 WHERE execution_id = ?`
+	_, err := s.db.Exec(q, executionID)
+	return err
+}
+
 // Close releases the underlying database connection. After Close, the store
 // must not be used. Safe to call on a store backed by a shared *sql.DB only
 // when that connection is dedicated to the run store.
@@ -431,6 +532,22 @@ func (m *Manager) RecordJobCompletion(_ context.Context, runID, jobID, execution
 		return fmt.Errorf("record job completion: update run status for run %s: %w", runID, err)
 	}
 	return nil
+}
+
+// CreateGrant creates a JIT relay grant. Called by the dispatcher at dispatch time.
+func (m *Manager) CreateGrant(deviceID, tenantID, executionID string, scope []string, ttl time.Duration) error {
+	return m.store.CreateExecutionGrant(deviceID, tenantID, executionID, scope, ttl)
+}
+
+// LookupGrant validates and returns the grant for (deviceID, executionID).
+// Used by the relay handler to construct the scoped Principal.
+func (m *Manager) LookupGrant(deviceID, executionID string) (*ExecutionGrant, error) {
+	return m.store.LookupGrant(deviceID, executionID)
+}
+
+// ConsumeGrant marks the grant consumed. Called by the dispatcher on AcknowledgeCompletion.
+func (m *Manager) ConsumeGrant(executionID string) error {
+	return m.store.ConsumeGrant(executionID)
 }
 
 // Close releases resources held by the Manager's store. If the store does not

--- a/features/controller/run/synthesis.go
+++ b/features/controller/run/synthesis.go
@@ -24,6 +24,10 @@ import (
 // runtimeParams are operator-supplied overrides. scriptMeta (optional) and
 // paramPlatformBindings (optional) drive per-device parameter resolution via
 // ResolveParams; when scriptMeta is nil the runtime params are used as-is.
+//
+// requiredAPIScope is the script's stored RequiredAPIScope from ScriptPrivilegeMetadata.
+// When non-empty it is threaded into QueuedExecution.Metadata so the dispatcher can
+// create a JIT relay grant at dispatch time (Issue #1675).
 func SynthesizeScriptRun(
 	ctx context.Context,
 	manager *Manager,
@@ -36,6 +40,7 @@ func SynthesizeScriptRun(
 	runtimeParams map[string]string,
 	scriptMeta *scriptmodule.ScriptMetadata,
 	paramPlatformBindings map[string]string,
+	requiredAPIScope []string,
 ) (string, error) {
 	filter.TenantID = tenantID
 
@@ -88,9 +93,13 @@ func SynthesizeScriptRun(
 		meta := map[string]interface{}{
 			"workflow_run_id": runID,
 			"job_id":          jobID,
+			"tenant_id":       tenantID,
 		}
 		if idempotent {
 			meta["idempotent"] = true
+		}
+		if len(requiredAPIScope) > 0 {
+			meta["required_api_scope"] = requiredAPIScope
 		}
 
 		qe := &scriptmodule.QueuedExecution{

--- a/features/controller/run/synthesis_test.go
+++ b/features/controller/run/synthesis_test.go
@@ -290,7 +290,7 @@ func TestSynthesizeScriptRun_ResolveParamsPerDevice(t *testing.T) {
 		"scripts/dna.sh", "",
 		scriptmodule.ShellBash,
 		map[string]string{"env": "prod"},
-		meta, nil,
+		meta, nil, nil,
 	)
 	require.NoError(t, err)
 
@@ -336,7 +336,7 @@ func TestSynthesizeScriptRun_IdempotentMetadata(t *testing.T) {
 		fleet.Filter{},
 		"scripts/idem.sh", "",
 		scriptmodule.ShellBash,
-		nil, meta, nil,
+		nil, meta, nil, nil,
 	)
 	require.NoError(t, err)
 
@@ -376,7 +376,7 @@ func TestSynthesizeScriptRun_MissingRequiredParam_Fails(t *testing.T) {
 		fleet.Filter{},
 		"scripts/req.sh", "",
 		scriptmodule.ShellBash,
-		nil, meta, nil,
+		nil, meta, nil, nil,
 	)
 	require.Error(t, err, "synthesis must fail when required param has no value")
 	assert.Contains(t, err.Error(), "must_have",

--- a/features/controller/run/synthesis_test.go
+++ b/features/controller/run/synthesis_test.go
@@ -62,7 +62,7 @@ func TestSynthesizeScriptRun_TwoDevices_CreatesTwoJobs(t *testing.T) {
 		"scripts/deploy.sh", "v1.0.0",
 		scriptmodule.ShellBash,
 		map[string]string{"env": "prod"},
-		nil, nil,
+		nil, nil, nil,
 	)
 	require.NoError(t, err)
 	assert.NotEmpty(t, runID)
@@ -123,7 +123,7 @@ func TestSynthesizeScriptRun_QueuedExecutionIDs_MatchJobRecords(t *testing.T) {
 		fleet.Filter{},
 		"scripts/check.sh", "",
 		scriptmodule.ShellBash,
-		nil, nil, nil,
+		nil, nil, nil, nil,
 	)
 	require.NoError(t, err)
 
@@ -154,7 +154,7 @@ func TestSynthesizeScriptRun_NoDevices_CreatesEmptyRun(t *testing.T) {
 		fleet.Filter{},
 		"scripts/noop.sh", "",
 		scriptmodule.ShellBash,
-		nil, nil, nil,
+		nil, nil, nil, nil,
 	)
 	require.NoError(t, err)
 	assert.NotEmpty(t, runID)
@@ -189,7 +189,7 @@ func TestSynthesizeScriptRun_TenantIsolation(t *testing.T) {
 		fleet.Filter{}, // no explicit tenantID
 		"scripts/test.sh", "",
 		scriptmodule.ShellBash,
-		nil, nil, nil,
+		nil, nil, nil, nil,
 	)
 	require.NoError(t, err)
 

--- a/features/modules/script/executor_unix.go
+++ b/features/modules/script/executor_unix.go
@@ -8,8 +8,11 @@ package script
 import (
 	"context"
 	"fmt"
+	"os"
 	"os/exec"
+	"os/user"
 	"runtime"
+	"strconv"
 	"strings"
 )
 
@@ -96,6 +99,34 @@ func detectLinuxUserViaWho() (string, error) {
 // unixDetectLoggedInUser is a test hook; override in tests to inject user detection
 // errors without calling the real OS utilities (loginctl/who/stat).
 var unixDetectLoggedInUser = detectLoggedInUser
+
+// ResolveExecutionUID returns the numeric UID the script will run as under the
+// given execution context. ExecutionContextSystem resolves to the steward
+// process UID (the script runs in-process under the steward's identity).
+// ExecutionContextLoggedInUser detects the logged-in console user and resolves
+// its UID; ErrNoUserLoggedIn is propagated when no interactive user is present.
+//
+// Callers use this to chown the per-execution relay socket so a script running
+// under a different UID (logged_in_user context, launched via `sudo -u`) can
+// still connect to it.
+func ResolveExecutionUID(execCtx ExecutionContext) (int, error) {
+	if execCtx != ExecutionContextLoggedInUser {
+		return os.Getuid(), nil
+	}
+	username, err := unixDetectLoggedInUser()
+	if err != nil {
+		return 0, err
+	}
+	u, err := user.Lookup(username)
+	if err != nil {
+		return 0, fmt.Errorf("lookup logged-in user %q: %w", username, err)
+	}
+	uid, err := strconv.Atoi(u.Uid)
+	if err != nil {
+		return 0, fmt.Errorf("parse uid %q for user %q: %w", u.Uid, username, err)
+	}
+	return uid, nil
+}
 
 // applyExecutionContext returns a (potentially modified) command configured to run
 // under the execution context specified in config, the actual OS user the script will

--- a/features/modules/script/executor_unix_test.go
+++ b/features/modules/script/executor_unix_test.go
@@ -7,8 +7,11 @@ package script
 
 import (
 	"context"
+	"os"
 	"os/exec"
+	"os/user"
 	"runtime"
+	"strconv"
 	"testing"
 	"time"
 
@@ -158,4 +161,55 @@ func TestApplyExecutionContext_LoggedInUser_WithUser(t *testing.T) {
 	assert.Equal(t, "-u", cmd.Args[1])
 	assert.Equal(t, user, cmd.Args[2])
 	assert.Equal(t, "--", cmd.Args[3])
+}
+
+// TestResolveExecutionUID_System verifies that system context resolves to the
+// current process UID (the relay socket chown is then a no-op).
+func TestResolveExecutionUID_System(t *testing.T) {
+	uid, err := ResolveExecutionUID(ExecutionContextSystem)
+	require.NoError(t, err)
+	assert.Equal(t, os.Getuid(), uid, "system context must resolve to the process UID")
+}
+
+// TestResolveExecutionUID_LoggedInUser_NoUser verifies that ErrNoUserLoggedIn is
+// propagated when no interactive user is present.
+func TestResolveExecutionUID_LoggedInUser_NoUser(t *testing.T) {
+	old := unixDetectLoggedInUser
+	unixDetectLoggedInUser = func() (string, error) { return "", ErrNoUserLoggedIn }
+	defer func() { unixDetectLoggedInUser = old }()
+
+	_, err := ResolveExecutionUID(ExecutionContextLoggedInUser)
+	assert.ErrorIs(t, err, ErrNoUserLoggedIn)
+}
+
+// TestResolveExecutionUID_LoggedInUser_Resolves verifies that a detected
+// username is resolved to its numeric UID.
+func TestResolveExecutionUID_LoggedInUser_Resolves(t *testing.T) {
+	current, err := user.Current()
+	require.NoError(t, err)
+	wantUID, err := strconv.Atoi(current.Uid)
+	require.NoError(t, err)
+
+	old := unixDetectLoggedInUser
+	unixDetectLoggedInUser = func() (string, error) { return current.Username, nil }
+	defer func() { unixDetectLoggedInUser = old }()
+
+	uid, err := ResolveExecutionUID(ExecutionContextLoggedInUser)
+	require.NoError(t, err)
+	assert.Equal(t, wantUID, uid, "logged_in_user context must resolve the detected user's UID")
+}
+
+// TestResolveExecutionUID_LoggedInUser_UnknownUser verifies that a detection
+// result that does not correspond to a real account surfaces an error rather
+// than a bogus UID.
+func TestResolveExecutionUID_LoggedInUser_UnknownUser(t *testing.T) {
+	old := unixDetectLoggedInUser
+	unixDetectLoggedInUser = func() (string, error) {
+		return "cfgms-nonexistent-user-9f3a", nil
+	}
+	defer func() { unixDetectLoggedInUser = old }()
+
+	_, err := ResolveExecutionUID(ExecutionContextLoggedInUser)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "lookup logged-in user")
 }

--- a/features/modules/script/executor_windows.go
+++ b/features/modules/script/executor_windows.go
@@ -76,7 +76,7 @@ func querySessionUsername(sessionID uint32) (string, error) {
 		0,
 		uintptr(sessionID),
 		uintptr(wtsUserName),
-		uintptr(unsafe.Pointer(&pBuffer)),  //nolint:gosec // unsafe required for WTS API
+		uintptr(unsafe.Pointer(&pBuffer)),       //nolint:gosec // unsafe required for WTS API
 		uintptr(unsafe.Pointer(&bytesReturned)), //nolint:gosec // unsafe required for WTS API
 	)
 	if r1 == 0 {

--- a/features/modules/script/executor_windows.go
+++ b/features/modules/script/executor_windows.go
@@ -157,3 +157,11 @@ func applyExecutionContext(ctx context.Context, config *ScriptConfig, cmd *exec.
 
 	return cmd, username, cleanup, nil
 }
+
+// ResolveExecutionUID is not applicable on Windows: process identity is
+// SID-based, not POSIX UID-based, and the relay named pipe is access-controlled
+// via an explicit DACL rather than file ownership. It always returns -1, which
+// signals the relay layer to skip UID-based ownership changes.
+func ResolveExecutionUID(_ ExecutionContext) (int, error) {
+	return -1, nil
+}

--- a/features/modules/script/executor_windows_test.go
+++ b/features/modules/script/executor_windows_test.go
@@ -171,3 +171,14 @@ func TestApplyExecutionContext_Windows_LoggedInUser_WithUser(t *testing.T) {
 	require.NotNil(t, cmd.SysProcAttr, "SysProcAttr must be non-nil after token attachment")
 	assert.NotZero(t, cmd.SysProcAttr.Token, "Token must be set to the active console session token")
 }
+
+// TestResolveExecutionUID_Windows verifies that ResolveExecutionUID returns -1
+// on Windows for every execution context: process identity is SID-based and the
+// relay named pipe uses an explicit DACL, so no POSIX-UID chown applies.
+func TestResolveExecutionUID_Windows(t *testing.T) {
+	for _, ec := range []ExecutionContext{ExecutionContextSystem, ExecutionContextLoggedInUser} {
+		uid, err := ResolveExecutionUID(ec)
+		require.NoError(t, err)
+		assert.Equal(t, -1, uid, "Windows ResolveExecutionUID must return -1 (no UID chown)")
+	}
+}

--- a/features/steward/commands/execute_script.go
+++ b/features/steward/commands/execute_script.go
@@ -10,11 +10,13 @@ import (
 	"encoding/hex"
 	"encoding/pem"
 	"fmt"
+	"os"
 	"time"
 
 	"github.com/cfgis/cfgms/features/modules/script"
 	scriptrelay "github.com/cfgis/cfgms/features/steward/script_relay"
 	cpTypes "github.com/cfgis/cfgms/pkg/controlplane/types"
+	"github.com/cfgis/cfgms/pkg/logging"
 )
 
 const (
@@ -91,7 +93,12 @@ func (h *Handler) handleExecuteScript(ctx context.Context, cmd *cpTypes.Command)
 	// Issue #1675: start per-execution relay when the script needs API access.
 	var relay *scriptrelay.Relay
 	if len(requiredAPIScope) > 0 {
-		r, err := scriptrelay.NewRelay(executionID, h.stewardID, h.sendStatus, h.logger)
+		// Resolve the UID the script will run as so the relay socket can be
+		// chowned to it — a logged_in_user script (launched via `sudo -u`)
+		// otherwise cannot connect to the 0700/0600 socket owned by the
+		// steward process.
+		relayUID := resolveRelayUID(execCtx, h.logger)
+		r, err := scriptrelay.NewRelay(executionID, h.stewardID, relayUID, h.sendStatus, h.logger)
 		if err != nil {
 			h.logger.Error("execute_script: failed to start relay",
 				"command_id", cmd.ID,
@@ -202,6 +209,23 @@ func (h *Handler) handleExecuteScript(ctx context.Context, cmd *cpTypes.Command)
 		},
 	})
 	return nil
+}
+
+// resolveRelayUID returns the UID the per-execution relay socket should be
+// owned by so the script process can connect to it. It mirrors the executor's
+// execution-context UID resolution. On resolution failure (e.g. no user is
+// logged in for a logged_in_user script) it falls back to the steward process
+// UID; the executor independently fails the run with the same underlying error,
+// so the fallback never produces an inconsistent outcome.
+func resolveRelayUID(execCtx script.ExecutionContext, logger logging.Logger) int {
+	uid, err := script.ResolveExecutionUID(execCtx)
+	if err != nil {
+		logger.Debug("execute_script: relay UID resolution fell back to process UID",
+			"execution_context", string(execCtx),
+			"error", err)
+		return os.Getuid()
+	}
+	return uid
 }
 
 // truncatePreview returns at most maxBytes bytes of s; excess is silently dropped.

--- a/features/steward/commands/execute_script.go
+++ b/features/steward/commands/execute_script.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/cfgis/cfgms/features/modules/script"
+	scriptrelay "github.com/cfgis/cfgms/features/steward/script_relay"
 	cpTypes "github.com/cfgis/cfgms/pkg/controlplane/types"
 )
 
@@ -62,6 +63,10 @@ func (h *Handler) handleExecuteScript(ctx context.Context, cmd *cpTypes.Command)
 		return nil
 	}
 
+	// Extract required_api_scope — non-empty only for library scripts with
+	// RequiredAPIScope set (Issue #1675). Inline run-command scripts never have a scope.
+	requiredAPIScope := extractStringSlice(cmd.Params["required_api_scope"])
+
 	// Extract timeout; default to 15 minutes per spec.
 	timeoutSecs := float64(defaultScriptTimeoutSec)
 	if ts, ok := cmd.Params["timeout_seconds"].(float64); ok && ts > 0 {
@@ -83,6 +88,49 @@ func (h *Handler) handleExecuteScript(ctx context.Context, cmd *cpTypes.Command)
 		SigningPolicy:    script.SigningPolicyNone, // pre-flight verification is done in preflightScriptSignature
 	}
 
+	// Issue #1675: start per-execution relay when the script needs API access.
+	var relay *scriptrelay.Relay
+	if len(requiredAPIScope) > 0 {
+		r, err := scriptrelay.NewRelay(executionID, h.stewardID, h.sendStatus, h.logger)
+		if err != nil {
+			h.logger.Error("execute_script: failed to start relay",
+				"command_id", cmd.ID,
+				"execution_id", executionID,
+				"error", err)
+			h.sendStatus(ctx, &cpTypes.Event{
+				ID:        newEventID(),
+				Type:      cpTypes.EventCommandFailed,
+				StewardID: h.stewardID,
+				CommandID: cmd.ID,
+				Timestamp: time.Now(),
+				Details: map[string]interface{}{
+					"execution_id": executionID,
+					"error":        "relay start failed: " + err.Error(),
+				},
+			})
+			return nil
+		}
+		if err := r.Start(ctx); err != nil {
+			h.logger.Error("execute_script: failed to start relay listener",
+				"execution_id", executionID,
+				"error", err)
+			r.Stop()
+			return nil
+		}
+		h.registerRelay(executionID, r)
+		cfg.Environment = mergeEnv(cfg.Environment, map[string]string{
+			"CFGMS_API_SOCKET": r.SocketPath(),
+		})
+		// Inject the shell helper function so the script can call cfgms_api / Invoke-CfgApi.
+		switch cfg.Shell {
+		case script.ShellBash, script.ShellSh, script.ShellZsh:
+			cfg.Content = scriptrelay.InjectBashPreamble(cfg.Content, r.SocketPath())
+		case script.ShellPowerShell:
+			cfg.Content = scriptrelay.InjectPowerShellPreamble(cfg.Content, r.SocketPath())
+		}
+		relay = r
+	}
+
 	// Log only non-sensitive correlation data: SHA-256 prefix + byte length, never content.
 	contentHash := sha256.Sum256(contentBytes)
 	h.logger.Info("execute_script: starting",
@@ -100,6 +148,12 @@ func (h *Handler) handleExecuteScript(ctx context.Context, cmd *cpTypes.Command)
 
 	executor := script.NewExecutor(cfg)
 	result, execErr := executor.Execute(timeoutCtx)
+
+	// Stop relay after execution regardless of outcome so the socket is cleaned up.
+	if relay != nil {
+		relay.Stop()
+		h.unregisterRelay(executionID)
+	}
 
 	if execErr != nil {
 		h.logger.Error("execute_script: executor failed",
@@ -259,6 +313,40 @@ func computeThumbprintFromPEM(pemStr string) string {
 	}
 	sum := sha256.Sum256(block.Bytes)
 	return hex.EncodeToString(sum[:])
+}
+
+// extractStringSlice converts an interface{} value (as stored in cmd.Params after
+// JSON deserialisation) to []string. Accepts []interface{} (from JSON) or []string.
+func extractStringSlice(v interface{}) []string {
+	if v == nil {
+		return nil
+	}
+	if s, ok := v.([]interface{}); ok {
+		result := make([]string, 0, len(s))
+		for _, item := range s {
+			if str, ok := item.(string); ok && str != "" {
+				result = append(result, str)
+			}
+		}
+		return result
+	}
+	if s, ok := v.([]string); ok {
+		return s
+	}
+	return nil
+}
+
+// mergeEnv merges additional key-value pairs into base, returning a new map.
+// base may be nil.
+func mergeEnv(base, additional map[string]string) map[string]string {
+	out := make(map[string]string, len(base)+len(additional))
+	for k, v := range base {
+		out[k] = v
+	}
+	for k, v := range additional {
+		out[k] = v
+	}
+	return out
 }
 
 // verifyOperatorCert parses publicKeyPEM as an X.509 certificate and verifies that it

--- a/features/steward/commands/execute_script.go
+++ b/features/steward/commands/execute_script.go
@@ -43,6 +43,7 @@ func (h *Handler) handleExecuteScript(ctx context.Context, cmd *cpTypes.Command)
 	shellStr, _ := cmd.Params["shell"].(string)
 	executionID, _ := cmd.Params["execution_id"].(string)
 	executionContextStr, _ := cmd.Params["execution_context"].(string)
+	scriptID, _ := cmd.Params["script_id"].(string)
 
 	// Decode base64 script content — content is NEVER stored in a variable that gets logged.
 	contentBytes, err := base64.StdEncoding.DecodeString(scriptContentB64)
@@ -91,8 +92,20 @@ func (h *Handler) handleExecuteScript(ctx context.Context, cmd *cpTypes.Command)
 	}
 
 	// Issue #1675: start per-execution relay when the script needs API access.
+	// Guard: only LIBRARY scripts (non-empty script_id) ever get a relay socket.
+	// Inline run-command dispatches NEVER create a socket regardless of
+	// required_api_scope — the steward enforces this invariant here at the
+	// handler layer rather than trusting the dispatcher to omit the param.
+	isLibraryScript := scriptID != ""
+	if !isLibraryScript && len(requiredAPIScope) > 0 {
+		// Anomaly: an inline command carrying required_api_scope indicates a
+		// dispatcher bug or tampering. Drop the scope and proceed without a relay.
+		h.logger.Warn("execute_script: ignoring required_api_scope on inline command — relay sockets are library-script only",
+			"command_id", cmd.ID,
+			"execution_id", executionID)
+	}
 	var relay *scriptrelay.Relay
-	if len(requiredAPIScope) > 0 {
+	if isLibraryScript && len(requiredAPIScope) > 0 {
 		// Resolve the UID the script will run as so the relay socket can be
 		// chowned to it — a logged_in_user script (launched via `sudo -u`)
 		// otherwise cannot connect to the 0700/0600 socket owned by the

--- a/features/steward/commands/execute_script_test.go
+++ b/features/steward/commands/execute_script_test.go
@@ -3,12 +3,19 @@
 package commands
 
 import (
+	"context"
+	"encoding/base64"
 	"os"
+	"runtime"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/cfgis/cfgms/features/modules/script"
+	cpTypes "github.com/cfgis/cfgms/pkg/controlplane/types"
 	"github.com/cfgis/cfgms/pkg/logging"
 )
 
@@ -29,4 +36,148 @@ func TestResolveRelayUID_LoggedInUser_FallsBackOnError(t *testing.T) {
 	// either the resolved logged-in user's UID, or the process-UID fallback.
 	// It must never be a negative/zero sentinel from a partial resolution.
 	assert.GreaterOrEqual(t, uid, 0, "resolveRelayUID must always return a usable UID")
+}
+
+// ---------------------------------------------------------------------------
+// Issue #1675 — handler-level relay-socket guard tests.
+//
+// AC1 [REQUIRED TEST]: a per-execution relay socket is created ONLY for a
+// library script (non-empty script_id) with a non-empty required_api_scope.
+// Inline run-command dispatches (empty script_id) must NOT create a socket
+// regardless of required_api_scope.
+//
+// Detection: the relay sets CFGMS_API_SOCKET in the script's environment. A
+// probe script echoes that variable; the value observed in stdout_preview is
+// the proof of whether a relay was created for this execution.
+// ---------------------------------------------------------------------------
+
+const socketProbeOpen = "SOCKVAL["
+const socketProbeClose = "]"
+
+// socketEnvProbeScriptBody returns a script body that writes the value of the
+// CFGMS_API_SOCKET environment variable to stdout, wrapped in SOCKVAL[...]
+// markers. An empty value (SOCKVAL[]) means no relay socket was injected.
+func socketEnvProbeScriptBody() string {
+	if runtime.GOOS == "windows" {
+		return `Write-Output ("` + socketProbeOpen + `" + $env:CFGMS_API_SOCKET + "` + socketProbeClose + `")`
+	}
+	return `echo "` + socketProbeOpen + `$CFGMS_API_SOCKET` + socketProbeClose + `"`
+}
+
+// socketValFromStdout extracts the CFGMS_API_SOCKET value the probe script
+// observed from a stdout_preview string. It requires the SOCKVAL[...] marker
+// to be present so a test never silently passes on missing output.
+func socketValFromStdout(t *testing.T, stdout string) string {
+	t.Helper()
+	start := strings.Index(stdout, socketProbeOpen)
+	require.GreaterOrEqual(t, start, 0, "probe marker %q missing from stdout: %q", socketProbeOpen, stdout)
+	rest := stdout[start+len(socketProbeOpen):]
+	end := strings.Index(rest, socketProbeClose)
+	require.GreaterOrEqual(t, end, 0, "probe close marker missing from stdout: %q", stdout)
+	return rest[:end]
+}
+
+// runScriptProbe executes the socket-env probe script through handleExecuteScript
+// with the supplied params merged in, and returns the observed CFGMS_API_SOCKET
+// value. extraParams supplies script_id / required_api_scope per test case.
+func runScriptProbe(t *testing.T, h *Handler, getEvents func() []*cpTypes.Event,
+	executionID string, extraParams map[string]interface{}) string {
+	t.Helper()
+
+	params := map[string]interface{}{
+		"script_content": base64.StdEncoding.EncodeToString([]byte(socketEnvProbeScriptBody())),
+		"shell":          platformShell(),
+		"execution_id":   executionID,
+	}
+	for k, v := range extraParams {
+		params[k] = v
+	}
+
+	cmd := &cpTypes.Command{
+		ID:        "cmd-" + executionID,
+		Type:      cpTypes.CommandExecuteScript,
+		StewardID: "steward-test",
+		Timestamp: time.Now(),
+		Params:    params,
+	}
+	require.NoError(t, h.handleExecuteScript(context.Background(), cmd))
+
+	events := getEvents()
+	failEvt := firstEventOfType(events, cpTypes.EventCommandFailed)
+	require.Nil(t, failEvt, "script execution must not fail: %+v", failEvt)
+	evt := firstEventOfType(events, cpTypes.EventScriptCompleted)
+	require.NotNil(t, evt, "expected EventScriptCompleted event")
+	stdout, ok := evt.Details["stdout_preview"].(string)
+	require.True(t, ok, "stdout_preview must be a string")
+	return socketValFromStdout(t, stdout)
+}
+
+// TestExecuteScriptHandler_LibraryScriptWithScope_CreatesRelaySocket verifies
+// that a library script (non-empty script_id) with a non-empty
+// required_api_scope runs with CFGMS_API_SOCKET pointing at a per-execution
+// relay socket — i.e. the relay IS created.
+func TestExecuteScriptHandler_LibraryScriptWithScope_CreatesRelaySocket(t *testing.T) {
+	cb, getEvents := collectEvents()
+	h, err := New(&Config{StewardID: "steward-test", OnStatus: cb, Logger: newTestLogger(t)})
+	require.NoError(t, err)
+	h.RegisterExecuteScriptHandler()
+
+	socketVal := runScriptProbe(t, h, getEvents, "exec-relay-lib", map[string]interface{}{
+		"script_id":          "lib-script-1",
+		"required_api_scope": []string{"read:inventory"},
+	})
+
+	assert.NotEmpty(t, socketVal,
+		"library script with non-empty required_api_scope must run with CFGMS_API_SOCKET set")
+	assert.Contains(t, socketVal, "exec-relay-lib",
+		"CFGMS_API_SOCKET must reference the per-execution relay for this execution_id")
+}
+
+// TestExecuteScriptHandler_LibraryScriptNoScope_NoRelaySocket verifies that a
+// library script with an EMPTY required_api_scope does NOT get a relay socket.
+func TestExecuteScriptHandler_LibraryScriptNoScope_NoRelaySocket(t *testing.T) {
+	cb, getEvents := collectEvents()
+	h, err := New(&Config{StewardID: "steward-test", OnStatus: cb, Logger: newTestLogger(t)})
+	require.NoError(t, err)
+	h.RegisterExecuteScriptHandler()
+
+	socketVal := runScriptProbe(t, h, getEvents, "exec-relay-noscope", map[string]interface{}{
+		"script_id": "lib-script-2",
+		// required_api_scope intentionally omitted
+	})
+
+	assert.Empty(t, socketVal,
+		"library script with empty required_api_scope must NOT create a relay socket")
+}
+
+// TestExecuteScriptHandler_InlineCommandWithScope_NoRelaySocket is the AC1
+// "regardless" guard: an inline run-command dispatch (empty script_id) must
+// NOT create a relay socket even when required_api_scope is non-empty. The
+// handler enforces this invariant rather than trusting the dispatcher to omit
+// the param.
+func TestExecuteScriptHandler_InlineCommandWithScope_NoRelaySocket(t *testing.T) {
+	capLog := &capturingLogger{}
+	cb, getEvents := collectEvents()
+	h, err := New(&Config{StewardID: "steward-test", OnStatus: cb, Logger: capLog})
+	require.NoError(t, err)
+	h.RegisterExecuteScriptHandler()
+
+	socketVal := runScriptProbe(t, h, getEvents, "exec-relay-inline", map[string]interface{}{
+		// script_id intentionally omitted → inline command
+		"required_api_scope": []string{"read:inventory"},
+	})
+
+	assert.Empty(t, socketVal,
+		"inline command must NOT create a relay socket regardless of required_api_scope")
+
+	// The handler must also surface the anomaly: an inline command carrying a
+	// non-empty required_api_scope indicates a dispatcher bug or tampering.
+	var sawWarn bool
+	for _, line := range capLog.Lines() {
+		if strings.Contains(line, "ignoring required_api_scope on inline command") {
+			sawWarn = true
+		}
+	}
+	assert.True(t, sawWarn,
+		"handler must log a warning when an inline command carries required_api_scope")
 }

--- a/features/steward/commands/execute_script_test.go
+++ b/features/steward/commands/execute_script_test.go
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+package commands
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/cfgis/cfgms/features/modules/script"
+	"github.com/cfgis/cfgms/pkg/logging"
+)
+
+// TestResolveRelayUID_SystemContext verifies that a system-context script
+// resolves to the steward process UID, making the relay socket chown a no-op.
+func TestResolveRelayUID_SystemContext(t *testing.T) {
+	uid := resolveRelayUID(script.ExecutionContextSystem, logging.NewNoopLogger())
+	assert.Equal(t, os.Getuid(), uid, "system context must resolve to the process UID")
+}
+
+// TestResolveRelayUID_LoggedInUser_FallsBackOnError verifies that when the
+// logged-in user cannot be resolved (e.g. no interactive session), resolveRelayUID
+// falls back to the steward process UID rather than returning a bogus value.
+// The executor independently fails the run with the same underlying error.
+func TestResolveRelayUID_LoggedInUser_FallsBackOnError(t *testing.T) {
+	uid := resolveRelayUID(script.ExecutionContextLoggedInUser, logging.NewNoopLogger())
+	// Regardless of whether a user is logged in, the result must be a valid UID:
+	// either the resolved logged-in user's UID, or the process-UID fallback.
+	// It must never be a negative/zero sentinel from a partial resolution.
+	assert.GreaterOrEqual(t, uid, 0, "resolveRelayUID must always return a usable UID")
+}

--- a/features/steward/commands/execute_script_test.go
+++ b/features/steward/commands/execute_script_test.go
@@ -32,9 +32,17 @@ func TestResolveRelayUID_SystemContext(t *testing.T) {
 // The executor independently fails the run with the same underlying error.
 func TestResolveRelayUID_LoggedInUser_FallsBackOnError(t *testing.T) {
 	uid := resolveRelayUID(script.ExecutionContextLoggedInUser, logging.NewNoopLogger())
-	// Regardless of whether a user is logged in, the result must be a valid UID:
-	// either the resolved logged-in user's UID, or the process-UID fallback.
-	// It must never be a negative/zero sentinel from a partial resolution.
+	if runtime.GOOS == "windows" {
+		// On Windows, ResolveExecutionUID always returns -1 with no error:
+		// process identity is SID-based and the relay pipe is DACL-controlled,
+		// so -1 is the intentional "skip UID ownership" sentinel, not a failure.
+		assert.Equal(t, -1, uid, "resolveRelayUID must return the Windows -1 sentinel")
+		return
+	}
+	// On Unix, regardless of whether a user is logged in, the result must be a
+	// valid UID: either the resolved logged-in user's UID, or the process-UID
+	// fallback. It must never be a negative/zero sentinel from a partial
+	// resolution.
 	assert.GreaterOrEqual(t, uid, 0, "resolveRelayUID must always return a usable UID")
 }
 

--- a/features/steward/commands/handler.go
+++ b/features/steward/commands/handler.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/cfgis/cfgms/features/config/signature"
 	"github.com/cfgis/cfgms/features/modules/script"
+	scriptrelay "github.com/cfgis/cfgms/features/steward/script_relay"
 	cpTypes "github.com/cfgis/cfgms/pkg/controlplane/types"
 	"github.com/cfgis/cfgms/pkg/logging"
 	business "github.com/cfgis/cfgms/pkg/storage/interfaces/business"
@@ -86,6 +87,10 @@ type Handler struct {
 	// controllerCARoots is the certificate pool for verifying operator-signed inline
 	// command certificates. When nil, CA chain verification of operator certs is skipped.
 	controllerCARoots *x509.CertPool
+
+	// Issue #1675: per-execution relay registry.
+	// relays maps executionID → *scriptrelay.Relay for CommandRelayResponse dispatch.
+	relays sync.Map
 }
 
 // CommandFunc is a function that handles a specific command type.
@@ -233,6 +238,32 @@ func (h *Handler) RegisterHandler(cmdType cpTypes.CommandType, handler CommandFu
 	defer h.mu.Unlock()
 	h.handlers[cmdType] = handler
 	h.logger.Info("Registered command handler", "type", cmdType)
+}
+
+// RegisterRelayResponseHandler registers a command handler for CommandRelayResponse
+// that dispatches incoming relay responses to the waiting per-execution Relay.
+// Call once after creating the Handler (Issue #1675).
+func (h *Handler) RegisterRelayResponseHandler() {
+	h.RegisterHandler(cpTypes.CommandRelayResponse, func(_ context.Context, cmd *cpTypes.Command) error {
+		execID, _ := cmd.Params["execution_id"].(string)
+		if execID == "" {
+			return nil
+		}
+		if v, ok := h.relays.Load(execID); ok {
+			v.(*scriptrelay.Relay).DeliverRelayResponse(cmd)
+		}
+		return nil
+	})
+}
+
+// registerRelay adds a relay to the handler's per-execution registry.
+func (h *Handler) registerRelay(executionID string, r *scriptrelay.Relay) {
+	h.relays.Store(executionID, r)
+}
+
+// unregisterRelay removes the relay for executionID from the handler's registry.
+func (h *Handler) unregisterRelay(executionID string) {
+	h.relays.Delete(executionID)
 }
 
 // HandleCommand processes an incoming signed command from the controller.

--- a/features/steward/script_relay/preamble.go
+++ b/features/steward/script_relay/preamble.go
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+// Package scriptrelay implements per-execution API relay for library scripts
+// with non-empty RequiredAPIScope. The relay opens a unix socket (Linux/macOS)
+// or named pipe (Windows) and proxies the script's REST calls over the steward's
+// existing mTLS connection to the controller.
+package scriptrelay
+
+import "fmt"
+
+// InjectBashPreamble prepends a cfgms_api shell function to content.
+// The function reads CFGMS_API_SOCKET and uses curl --unix-socket to relay
+// HTTP calls to the controller. Usage: cfgms_api GET /api/v1/runs
+func InjectBashPreamble(content, socketPath string) string {
+	preamble := fmt.Sprintf(`# cfgms relay preamble — injected by steward
+CFGMS_API_SOCKET=%q
+cfgms_api() {
+  local method="$1"; local path="$2"; shift 2
+  curl --silent --unix-socket "$CFGMS_API_SOCKET" \
+    -X "$method" \
+    -H "Content-Type: application/json" \
+    "$@" \
+    "http://localhost${path}"
+}
+
+`, socketPath)
+	return preamble + content
+}
+
+// InjectPowerShellPreamble prepends an Invoke-CfgApi function to content.
+// The function reads CFGMS_API_SOCKET and uses .NET's System.Net.Sockets.Socket
+// directly to send HTTP/1.1 requests over the unix socket path, since
+// Invoke-WebRequest does not support unix sockets on all Windows versions.
+// CRLF is built with [char]13+[char]10 to avoid backtick characters in the
+// Go raw-string literal that wraps this template.
+func InjectPowerShellPreamble(content, socketPath string) string {
+	preamble := fmt.Sprintf(`# cfgms relay preamble — injected by steward
+$env:CFGMS_API_SOCKET = %q
+
+function Invoke-CfgApi {
+    param(
+        [string]$Method = 'GET',
+        [string]$Path,
+        [string]$Body = ''
+    )
+    $socketPath = $env:CFGMS_API_SOCKET
+    $socket = [System.Net.Sockets.Socket]::new(
+        [System.Net.Sockets.AddressFamily]::Unix,
+        [System.Net.Sockets.SocketType]::Stream,
+        [System.Net.Sockets.ProtocolType]::Unspecified
+    )
+    $socket.Connect([System.Net.Sockets.UnixDomainSocketEndPoint]::new($socketPath))
+    $bodyBytes = if ($Body) { [System.Text.Encoding]::UTF8.GetBytes($Body) } else { [byte[]]@() }
+    $crlf = [char]13 + [char]10
+    $req = "$Method $Path HTTP/1.1${crlf}Host: cfgms${crlf}Content-Length: $($bodyBytes.Length)${crlf}Content-Type: application/json${crlf}Connection: close${crlf}${crlf}"
+    $reqBytes = [System.Text.Encoding]::UTF8.GetBytes($req)
+    $null = $socket.Send($reqBytes)
+    if ($bodyBytes.Length -gt 0) { $null = $socket.Send($bodyBytes) }
+    $buf = [byte[]]::new(65536)
+    $received = $socket.Receive($buf)
+    $socket.Close()
+    $response = [System.Text.Encoding]::UTF8.GetString($buf, 0, $received)
+    $sep = $crlf + $crlf
+    $parts = $response -split [regex]::Escape($sep), 2
+    if ($parts.Length -gt 1) { return $parts[1] }
+    return $response
+}
+
+`, socketPath)
+	return preamble + content
+}

--- a/features/steward/script_relay/preamble_test.go
+++ b/features/steward/script_relay/preamble_test.go
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+package scriptrelay
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestInjectBashPreamble(t *testing.T) {
+	socketPath := "/tmp/cfgms-exec123/api.sock"
+	script := `echo "hello world"`
+
+	result := InjectBashPreamble(script, socketPath)
+
+	// Must contain the CFGMS_API_SOCKET assignment.
+	assert.Contains(t, result, socketPath)
+	// Must define cfgms_api shell function.
+	assert.Contains(t, result, "cfgms_api()")
+	// Must reference curl --unix-socket.
+	assert.Contains(t, result, "--unix-socket")
+	// Must preserve original script content.
+	assert.Contains(t, result, script)
+	// Preamble must appear before original content.
+	preambleEnd := strings.Index(result, "cfgms_api()")
+	scriptStart := strings.Index(result, script)
+	require.Greater(t, scriptStart, preambleEnd, "preamble must precede original content")
+}
+
+func TestInjectBashPreamble_EmptyScript(t *testing.T) {
+	result := InjectBashPreamble("", "/tmp/cfgms-x/api.sock")
+	assert.Contains(t, result, "cfgms_api()")
+}
+
+func TestInjectPowerShellPreamble(t *testing.T) {
+	socketPath := `\\.\pipe\cfgms-exec456`
+	script := `Write-Host "hello"`
+
+	result := InjectPowerShellPreamble(script, socketPath)
+
+	// Must contain the socket path assignment.
+	assert.Contains(t, result, "CFGMS_API_SOCKET")
+	// Must define Invoke-CfgApi function.
+	assert.Contains(t, result, "function Invoke-CfgApi")
+	// Must use System.Net.Sockets.Socket (not Invoke-WebRequest).
+	assert.Contains(t, result, "System.Net.Sockets.Socket")
+	// Must reference UnixDomainSocketEndPoint.
+	assert.Contains(t, result, "UnixDomainSocketEndPoint")
+	// Must preserve original script content.
+	assert.Contains(t, result, script)
+}
+
+func TestInjectPowerShellPreamble_SyntaxCheck(t *testing.T) {
+	// Verify that the preamble can be parsed as valid PowerShell by checking
+	// for balanced braces — a parse-only sanity check without execution.
+	result := InjectPowerShellPreamble(`$x = 1`, "/tmp/test.sock")
+
+	open := strings.Count(result, "{")
+	close := strings.Count(result, "}")
+	assert.Equal(t, open, close, "PowerShell preamble must have balanced braces")
+
+	// Function definition must be present.
+	assert.Contains(t, result, "function Invoke-CfgApi {")
+}
+
+func TestInjectBashPreamble_SocketPathQuoting(t *testing.T) {
+	// Socket paths with spaces must be safely quoted.
+	socketPath := "/tmp/path with spaces/api.sock"
+	result := InjectBashPreamble("echo hi", socketPath)
+	// The path should appear quoted in the result.
+	assert.Contains(t, result, `"/tmp/path with spaces/api.sock"`)
+}

--- a/features/steward/script_relay/relay.go
+++ b/features/steward/script_relay/relay.go
@@ -34,6 +34,13 @@ type Relay struct {
 	executionID string
 	stewardID   string
 
+	// uid is the numeric UID the script executes as. The per-execution socket
+	// directory and socket file are chowned to this UID so a script running
+	// under a different user (logged_in_user context) can connect. A value < 0
+	// or equal to the steward process UID makes the chown a no-op. Unused on
+	// Windows, where the named pipe is access-controlled via an explicit DACL.
+	uid int
+
 	// socketPath is the path advertised to the script via CFGMS_API_SOCKET.
 	socketPath string
 
@@ -56,13 +63,19 @@ type Relay struct {
 // NewRelay creates a Relay for the given execution. Call Start to begin
 // accepting connections. The caller is responsible for calling Stop after
 // script execution completes to clean up the socket directory.
-func NewRelay(executionID, stewardID string, publish StatusCallback, logger logging.Logger) (*Relay, error) {
+//
+// uid is the numeric UID the script executes as; the per-execution socket
+// directory and socket file are chowned to it so a script running under a
+// different user can connect. Pass the steward process UID (or -1) to make the
+// chown a no-op for system-context scripts.
+func NewRelay(executionID, stewardID string, uid int, publish StatusCallback, logger logging.Logger) (*Relay, error) {
 	if executionID == "" {
 		return nil, fmt.Errorf("relay: executionID must not be empty")
 	}
 	r := &Relay{
 		executionID: executionID,
 		stewardID:   stewardID,
+		uid:         uid,
 		publish:     publish,
 		responseCh:  make(chan *cpTypes.Command, 1),
 		stopCh:      make(chan struct{}),

--- a/features/steward/script_relay/relay.go
+++ b/features/steward/script_relay/relay.go
@@ -1,0 +1,246 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+package scriptrelay
+
+import (
+	"bufio"
+	"context"
+	"encoding/base64"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	cpTypes "github.com/cfgis/cfgms/pkg/controlplane/types"
+	"github.com/cfgis/cfgms/pkg/logging"
+)
+
+// StatusCallback is called to publish control-plane events to the controller.
+// Same type as commands.StatusCallback to avoid cross-package imports.
+type StatusCallback func(ctx context.Context, event *cpTypes.Event)
+
+// Relay manages the per-execution socket / named-pipe for script API relay.
+// It accepts HTTP requests from the script process, forwards them as
+// EventRelayRequest events to the controller, and writes back the
+// CommandRelayResponse it receives via DeliverRelayResponse.
+//
+// Only one connection is accepted at a time (scripts are single-threaded
+// API callers). Each connection handles exactly one HTTP request-response
+// cycle, then closes. Stop must be called after script execution completes.
+type Relay struct {
+	executionID string
+	stewardID   string
+
+	// socketPath is the path advertised to the script via CFGMS_API_SOCKET.
+	socketPath string
+
+	// publish sends EventRelayRequest events to the controller.
+	publish StatusCallback
+
+	// responseCh receives CommandRelayResponse from the command handler.
+	responseCh chan *cpTypes.Command
+
+	seq int64 // atomic; per-relay request sequence counter
+
+	ln       net.Listener
+	stopCh   chan struct{}
+	stopOnce sync.Once
+	wg       sync.WaitGroup
+
+	logger logging.Logger
+}
+
+// NewRelay creates a Relay for the given execution. Call Start to begin
+// accepting connections. The caller is responsible for calling Stop after
+// script execution completes to clean up the socket directory.
+func NewRelay(executionID, stewardID string, publish StatusCallback, logger logging.Logger) (*Relay, error) {
+	if executionID == "" {
+		return nil, fmt.Errorf("relay: executionID must not be empty")
+	}
+	r := &Relay{
+		executionID: executionID,
+		stewardID:   stewardID,
+		publish:     publish,
+		responseCh:  make(chan *cpTypes.Command, 1),
+		stopCh:      make(chan struct{}),
+		logger:      logger,
+	}
+	if err := initSocket(r); err != nil {
+		return nil, fmt.Errorf("relay: init socket: %w", err)
+	}
+	return r, nil
+}
+
+// SocketPath returns the socket path that should be set in CFGMS_API_SOCKET.
+func (r *Relay) SocketPath() string { return r.socketPath }
+
+// ResponseCh returns the channel on which the command handler delivers
+// CommandRelayResponse commands. The channel has buffer size 1.
+func (r *Relay) ResponseCh() chan *cpTypes.Command { return r.responseCh }
+
+// Start begins accepting connections in a background goroutine.
+func (r *Relay) Start(ctx context.Context) error {
+	r.wg.Add(1)
+	go func() {
+		defer r.wg.Done()
+		r.serveLoop(ctx)
+	}()
+	return nil
+}
+
+// Stop signals the relay to stop accepting connections and cleans up the socket.
+func (r *Relay) Stop() {
+	r.stopOnce.Do(func() {
+		close(r.stopCh)
+		if r.ln != nil {
+			_ = r.ln.Close()
+		}
+		r.wg.Wait()
+		cleanupSocket(r)
+	})
+}
+
+// DeliverRelayResponse delivers a CommandRelayResponse to the waiting relay
+// goroutine. Called by the command handler from its relay response dispatcher.
+func (r *Relay) DeliverRelayResponse(cmd *cpTypes.Command) {
+	select {
+	case r.responseCh <- cmd:
+	default:
+		// Buffer full or relay already stopped — drop silently.
+	}
+}
+
+// serveLoop accepts one connection at a time and handles each HTTP request.
+func (r *Relay) serveLoop(ctx context.Context) {
+	for {
+		// Check for stop before each accept.
+		select {
+		case <-r.stopCh:
+			return
+		default:
+		}
+
+		// Accept with a deadline so we can check stopCh periodically.
+		if dl, ok := r.ln.(interface{ SetDeadline(time.Time) error }); ok {
+			_ = dl.SetDeadline(time.Now().Add(500 * time.Millisecond))
+		}
+
+		conn, err := r.ln.Accept()
+		if err != nil {
+			select {
+			case <-r.stopCh:
+				return
+			default:
+			}
+			if isNetTimeout(err) {
+				continue
+			}
+			r.logger.Debug("relay: accept error", "execution_id", r.executionID, "error", err)
+			return
+		}
+
+		r.handleConn(ctx, conn)
+	}
+}
+
+// handleConn reads one HTTP request, relays it to the controller, and writes
+// the response back. Closes the connection on return.
+func (r *Relay) handleConn(ctx context.Context, conn net.Conn) {
+	defer func() { _ = conn.Close() }()
+
+	req, err := http.ReadRequest(bufio.NewReader(conn))
+	if err != nil {
+		r.logger.Debug("relay: read request error", "execution_id", r.executionID, "error", err)
+		return
+	}
+	defer func() { _ = req.Body.Close() }()
+
+	body, _ := io.ReadAll(io.LimitReader(req.Body, 1<<20)) // 1 MiB cap
+
+	seq := atomic.AddInt64(&r.seq, 1)
+
+	// Flatten headers to map[string]string (first value per header).
+	headers := make(map[string]string, len(req.Header))
+	for k, vs := range req.Header {
+		if len(vs) > 0 {
+			headers[k] = vs[0]
+		}
+	}
+
+	event := &cpTypes.Event{
+		ID:        fmt.Sprintf("relay_%s_%d", r.executionID, seq),
+		Type:      cpTypes.EventRelayRequest,
+		StewardID: r.stewardID,
+		Timestamp: time.Now(),
+		Details: map[string]interface{}{
+			"execution_id": r.executionID,
+			"sequence":     seq,
+			"method":       req.Method,
+			"path":         req.URL.RequestURI(),
+			"headers":      headers,
+			"body":         base64.StdEncoding.EncodeToString(body),
+		},
+	}
+
+	r.publish(ctx, event)
+
+	// Wait for the controller's response.
+	var responseCmd *cpTypes.Command
+	select {
+	case responseCmd = <-r.responseCh:
+	case <-r.stopCh:
+		writeHTTPError(conn, http.StatusServiceUnavailable, "relay stopped")
+		return
+	case <-ctx.Done():
+		writeHTTPError(conn, http.StatusGatewayTimeout, "context cancelled")
+		return
+	case <-time.After(30 * time.Second):
+		writeHTTPError(conn, http.StatusGatewayTimeout, "relay response timeout")
+		return
+	}
+
+	writeRelayResponse(conn, responseCmd)
+}
+
+// writeRelayResponse serialises a CommandRelayResponse back to the script's connection.
+func writeRelayResponse(conn net.Conn, cmd *cpTypes.Command) {
+	statusCode := http.StatusOK
+	if v, ok := cmd.Params["status"].(float64); ok && v > 0 {
+		statusCode = int(v)
+	}
+
+	bodyB64, _ := cmd.Params["body"].(string)
+	bodyBytes, _ := base64.StdEncoding.DecodeString(bodyB64)
+
+	var headers map[string]interface{}
+	if h, ok := cmd.Params["headers"].(map[string]interface{}); ok {
+		headers = h
+	}
+
+	_, _ = fmt.Fprintf(conn, "HTTP/1.1 %d %s\r\n", statusCode, http.StatusText(statusCode))
+	for k, v := range headers {
+		if vStr, ok := v.(string); ok {
+			_, _ = fmt.Fprintf(conn, "%s: %s\r\n", k, vStr)
+		}
+	}
+	_, _ = fmt.Fprintf(conn, "Content-Length: %d\r\nConnection: close\r\n\r\n", len(bodyBytes))
+	_, _ = conn.Write(bodyBytes)
+}
+
+// writeHTTPError writes a minimal HTTP error response to the connection.
+func writeHTTPError(conn net.Conn, code int, msg string) {
+	body := []byte(msg)
+	_, _ = fmt.Fprintf(conn, "HTTP/1.1 %d %s\r\nContent-Length: %d\r\nContent-Type: text/plain\r\nConnection: close\r\n\r\n%s",
+		code, http.StatusText(code), len(body), msg)
+}
+
+// isNetTimeout reports whether err is a net.Error timeout.
+func isNetTimeout(err error) bool {
+	if ne, ok := err.(net.Error); ok {
+		return ne.Timeout()
+	}
+	return false
+}

--- a/features/steward/script_relay/relay_test.go
+++ b/features/steward/script_relay/relay_test.go
@@ -1,0 +1,243 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+//go:build !windows
+
+package scriptrelay
+
+import (
+	"bufio"
+	"context"
+	"encoding/base64"
+	"fmt"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	cpTypes "github.com/cfgis/cfgms/pkg/controlplane/types"
+	"github.com/cfgis/cfgms/pkg/logging"
+)
+
+// newTestRelay creates a Relay for testing. It captures published events and
+// returns a thread-safe accessor function for reading them.
+func newTestRelay(t *testing.T, executionID string) (*Relay, func() []cpTypes.Event) {
+	t.Helper()
+	var mu sync.Mutex
+	var events []cpTypes.Event
+
+	publish := func(_ context.Context, event *cpTypes.Event) {
+		mu.Lock()
+		events = append(events, *event)
+		mu.Unlock()
+	}
+
+	r, err := NewRelay(executionID, "steward-1", publish, logging.NewNoopLogger())
+	require.NoError(t, err)
+	getEvents := func() []cpTypes.Event {
+		mu.Lock()
+		defer mu.Unlock()
+		out := make([]cpTypes.Event, len(events))
+		copy(out, events)
+		return out
+	}
+	return r, getEvents
+}
+
+// TestRelay_SocketCreation verifies that Start creates a 0700 directory and
+// 0600 socket, and that Stop removes them (AC1 — socket lifecycle).
+func TestRelay_SocketCreation(t *testing.T) {
+	execID := "test-exec-socket"
+	r, _ := newTestRelay(t, execID)
+
+	sockPath := r.SocketPath()
+	require.NotEmpty(t, sockPath)
+
+	sockDir := filepath.Dir(sockPath)
+
+	// Directory must exist with mode 0700.
+	dirInfo, err := os.Stat(sockDir)
+	require.NoError(t, err, "socket directory must exist")
+	assert.Equal(t, os.FileMode(0700), dirInfo.Mode().Perm(), "socket directory must be 0700")
+
+	// Socket file must exist with mode 0600.
+	sockInfo, err := os.Stat(sockPath)
+	require.NoError(t, err, "socket file must exist")
+	assert.Equal(t, os.FileMode(0600), sockInfo.Mode().Perm(), "socket file must be 0600")
+
+	// Stop must remove both the socket and the directory.
+	r.Stop()
+	_, err = os.Stat(sockDir)
+	assert.True(t, os.IsNotExist(err), "socket directory must be removed after Stop")
+}
+
+// TestRelay_RequestResponseCycle tests the full steward-side relay lifecycle:
+// script connects, sends HTTP request, relay publishes event, response is
+// delivered, script receives HTTP response.
+func TestRelay_RequestResponseCycle(t *testing.T) {
+	execID := "test-exec-cycle"
+	r, capturedEvents := newTestRelay(t, execID)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	require.NoError(t, r.Start(ctx))
+	defer r.Stop()
+
+	// Simulate the script connecting and sending an HTTP request.
+	var wg sync.WaitGroup
+	wg.Add(1)
+	var gotResponseBody string
+	go func() {
+		defer wg.Done()
+
+		conn, err := net.DialTimeout("unix", r.SocketPath(), 2*time.Second)
+		if err != nil {
+			t.Errorf("dial relay socket: %v", err)
+			return
+		}
+		defer func() { _ = conn.Close() }()
+
+		// Write a minimal HTTP GET request.
+		_, _ = fmt.Fprintf(conn, "GET /api/v1/runs HTTP/1.1\r\nHost: cfgms\r\nConnection: close\r\n\r\n")
+
+		// Read back the HTTP response.
+		resp, err := http.ReadResponse(bufio.NewReader(conn), nil)
+		if err != nil {
+			t.Errorf("read relay response: %v", err)
+			return
+		}
+		defer func() { _ = resp.Body.Close() }()
+		var buf strings.Builder
+		_, _ = fmt.Fscan(resp.Body, &buf)
+		gotResponseBody = resp.Header.Get("X-Test")
+	}()
+
+	// Wait for the relay to publish an event, then inject a response.
+	var event cpTypes.Event
+	require.Eventually(t, func() bool {
+		events := capturedEvents()
+		if len(events) == 0 {
+			return false
+		}
+		event = events[0]
+		return true
+	}, 3*time.Second, 50*time.Millisecond, "relay must publish EventRelayRequest")
+
+	assert.Equal(t, cpTypes.EventRelayRequest, event.Type)
+	assert.Equal(t, execID, event.Details["execution_id"])
+	assert.Equal(t, "GET", event.Details["method"])
+	assert.Equal(t, "/api/v1/runs", event.Details["path"])
+
+	// Deliver the response command.
+	responseCmd := &cpTypes.Command{
+		ID:        "cmd-relay-1",
+		Type:      cpTypes.CommandRelayResponse,
+		StewardID: "steward-1",
+		Timestamp: time.Now(),
+		Params: map[string]interface{}{
+			"execution_id": execID,
+			"sequence":     float64(1),
+			"status":       float64(200),
+			"headers":      map[string]interface{}{"X-Test": "relay-ok"},
+			"body":         base64.StdEncoding.EncodeToString([]byte(`{"ok":true}`)),
+		},
+	}
+	r.DeliverRelayResponse(responseCmd)
+
+	wg.Wait()
+	assert.Equal(t, "relay-ok", gotResponseBody)
+}
+
+// TestRelay_StopCancelsWaiting verifies that Stop unblocks a relay goroutine
+// waiting for a response.
+func TestRelay_StopCancelsWaiting(t *testing.T) {
+	execID := "test-exec-stop"
+	r, _ := newTestRelay(t, execID)
+
+	ctx := context.Background()
+	require.NoError(t, r.Start(ctx))
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		conn, err := net.DialTimeout("unix", r.SocketPath(), 2*time.Second)
+		if err != nil {
+			return
+		}
+		defer func() { _ = conn.Close() }()
+		_, _ = fmt.Fprintf(conn, "GET /api/v1/runs HTTP/1.1\r\nHost: cfgms\r\nConnection: close\r\n\r\n")
+		resp, _ := http.ReadResponse(bufio.NewReader(conn), nil)
+		if resp != nil {
+			_ = resp.Body.Close()
+			// Expect 503 or similar when relay is stopped mid-flight.
+			assert.Equal(t, http.StatusServiceUnavailable, resp.StatusCode)
+		}
+	}()
+
+	// Let the relay accept the connection and block waiting for response.
+	time.Sleep(200 * time.Millisecond)
+	r.Stop()
+	wg.Wait()
+}
+
+// TestRelay_ExecutionIDInEvent verifies the execution_id in the event Details
+// matches the relay's bound execution_id (never from the request body).
+func TestRelay_ExecutionIDInEvent(t *testing.T) {
+	execID := "bound-exec-id"
+	r, capturedEvents := newTestRelay(t, execID)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	require.NoError(t, r.Start(ctx))
+	defer r.Stop()
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		conn, _ := net.DialTimeout("unix", r.SocketPath(), 2*time.Second)
+		if conn == nil {
+			return
+		}
+		defer func() { _ = conn.Close() }()
+		_, _ = fmt.Fprintf(conn, "GET /api/v1/runs HTTP/1.1\r\nHost: cfgms\r\nConnection: close\r\n\r\n")
+		// Drain response so the goroutine exits cleanly.
+		resp, _ := http.ReadResponse(bufio.NewReader(conn), nil)
+		if resp != nil {
+			_ = resp.Body.Close()
+		}
+	}()
+
+	// Wait for event then inject response.
+	require.Eventually(t, func() bool {
+		return len(capturedEvents()) > 0
+	}, 2*time.Second, 20*time.Millisecond)
+
+	event := capturedEvents()[0]
+	// execution_id in event must be the relay's bound ID, not anything from the request.
+	assert.Equal(t, execID, event.Details["execution_id"])
+
+	r.DeliverRelayResponse(&cpTypes.Command{
+		ID:        "resp-1",
+		Type:      cpTypes.CommandRelayResponse,
+		StewardID: "steward-1",
+		Timestamp: time.Now(),
+		Params: map[string]interface{}{
+			"execution_id": execID,
+			"sequence":     float64(1),
+			"status":       float64(200),
+			"headers":      map[string]interface{}{},
+			"body":         base64.StdEncoding.EncodeToString([]byte(`{}`)),
+		},
+	})
+
+	wg.Wait()
+}

--- a/features/steward/script_relay/relay_test.go
+++ b/features/steward/script_relay/relay_test.go
@@ -15,6 +15,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"syscall"
 	"testing"
 	"time"
 
@@ -26,8 +27,16 @@ import (
 )
 
 // newTestRelay creates a Relay for testing. It captures published events and
-// returns a thread-safe accessor function for reading them.
+// returns a thread-safe accessor function for reading them. The relay is
+// created with the current process UID so the socket chown is a no-op.
 func newTestRelay(t *testing.T, executionID string) (*Relay, func() []cpTypes.Event) {
+	t.Helper()
+	return newTestRelayWithUID(t, executionID, os.Getuid())
+}
+
+// newTestRelayWithUID is newTestRelay with an explicit execution UID, used to
+// exercise the socket-ownership chown path.
+func newTestRelayWithUID(t *testing.T, executionID string, uid int) (*Relay, func() []cpTypes.Event) {
 	t.Helper()
 	var mu sync.Mutex
 	var events []cpTypes.Event
@@ -38,7 +47,7 @@ func newTestRelay(t *testing.T, executionID string) (*Relay, func() []cpTypes.Ev
 		mu.Unlock()
 	}
 
-	r, err := NewRelay(executionID, "steward-1", publish, logging.NewNoopLogger())
+	r, err := NewRelay(executionID, "steward-1", uid, publish, logging.NewNoopLogger())
 	require.NoError(t, err)
 	getEvents := func() []cpTypes.Event {
 		mu.Lock()
@@ -50,8 +59,19 @@ func newTestRelay(t *testing.T, executionID string) (*Relay, func() []cpTypes.Ev
 	return r, getEvents
 }
 
+// statUID returns the owning UID of path via the underlying syscall.Stat_t.
+func statUID(t *testing.T, path string) uint32 {
+	t.Helper()
+	info, err := os.Stat(path)
+	require.NoError(t, err)
+	st, ok := info.Sys().(*syscall.Stat_t)
+	require.True(t, ok, "expected *syscall.Stat_t for %s", path)
+	return st.Uid
+}
+
 // TestRelay_SocketCreation verifies that Start creates a 0700 directory and
-// 0600 socket, and that Stop removes them (AC1 — socket lifecycle).
+// 0600 socket owned by the execution UID, and that Stop removes them
+// (AC1 — socket lifecycle and ownership).
 func TestRelay_SocketCreation(t *testing.T) {
 	execID := "test-exec-socket"
 	r, _ := newTestRelay(t, execID)
@@ -71,10 +91,67 @@ func TestRelay_SocketCreation(t *testing.T) {
 	require.NoError(t, err, "socket file must exist")
 	assert.Equal(t, os.FileMode(0600), sockInfo.Mode().Perm(), "socket file must be 0600")
 
+	// Directory and socket must be owned by the execution UID. newTestRelay
+	// uses the current process UID, so ownership equals os.Getuid().
+	wantUID := uint32(os.Getuid())
+	assert.Equal(t, wantUID, statUID(t, sockDir), "socket directory must be owned by the execution UID")
+	assert.Equal(t, wantUID, statUID(t, sockPath), "socket file must be owned by the execution UID")
+
 	// Stop must remove both the socket and the directory.
 	r.Stop()
 	_, err = os.Stat(sockDir)
 	assert.True(t, os.IsNotExist(err), "socket directory must be removed after Stop")
+}
+
+// TestRelay_SocketCreation_ChownsToExecutionUID verifies that the per-execution
+// socket directory and socket file are chowned to the script's execution UID
+// when it differs from the steward process UID (logged_in_user context). The
+// chown requires CAP_CHOWN, so the test only runs as root.
+func TestRelay_SocketCreation_ChownsToExecutionUID(t *testing.T) {
+	if os.Getuid() != 0 {
+		t.Skip("chown to a different UID requires root (CAP_CHOWN)")
+	}
+
+	// UID 1 (daemon/bin) exists on every POSIX system and is never root.
+	const execUID = 1
+	r, _ := newTestRelayWithUID(t, "test-exec-chown", execUID)
+	defer r.Stop()
+
+	sockPath := r.SocketPath()
+	sockDir := filepath.Dir(sockPath)
+
+	assert.Equal(t, uint32(execUID), statUID(t, sockDir),
+		"socket directory must be chowned to the execution UID")
+	assert.Equal(t, uint32(execUID), statUID(t, sockPath),
+		"socket file must be chowned to the execution UID")
+
+	// Mode must remain restrictive after the chown.
+	dirInfo, err := os.Stat(sockDir)
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0700), dirInfo.Mode().Perm())
+	sockInfo, err := os.Stat(sockPath)
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0600), sockInfo.Mode().Perm())
+}
+
+// TestNewRelay_InvalidUIDChownFails verifies NewRelay returns an error (rather
+// than silently producing an unconnectable socket) when the requested
+// execution UID cannot be applied. Running as non-root, chowning to root (UID 0)
+// is denied by the kernel.
+func TestNewRelay_InvalidUIDChownFails(t *testing.T) {
+	if os.Getuid() == 0 {
+		t.Skip("running as root: chown to any UID succeeds, cannot exercise the failure path")
+	}
+
+	publish := func(_ context.Context, _ *cpTypes.Event) {}
+	_, err := NewRelay("test-exec-badchown", "steward-1", 0, publish, logging.NewNoopLogger())
+	require.Error(t, err, "NewRelay must fail when the socket cannot be chowned to the execution UID")
+	assert.Contains(t, err.Error(), "chown")
+
+	// The failed socket directory must not be left behind.
+	sockDir := filepath.Join(os.TempDir(), "cfgms-test-exec-badchown")
+	_, statErr := os.Stat(sockDir)
+	assert.True(t, os.IsNotExist(statErr), "socket directory must be cleaned up after a failed chown")
 }
 
 // TestRelay_RequestResponseCycle tests the full steward-side relay lifecycle:
@@ -90,7 +167,7 @@ func TestRelay_RequestResponseCycle(t *testing.T) {
 	require.NoError(t, r.Start(ctx))
 	defer r.Stop()
 
-	// Simulate the script connecting and sending an HTTP request.
+	// Act as the script would: connect and send an HTTP request.
 	var wg sync.WaitGroup
 	wg.Add(1)
 	var gotResponseBody string

--- a/features/steward/script_relay/relay_unix.go
+++ b/features/steward/script_relay/relay_unix.go
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+//go:build !windows
+
+package scriptrelay
+
+import (
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+)
+
+// initSocket creates the per-execution directory (mode 0700) and opens a
+// unix socket inside it (mode 0600). The directory is created first so no
+// window exists between bind and chmod where the socket is world-accessible.
+func initSocket(r *Relay) error {
+	sockDir := filepath.Join(os.TempDir(), "cfgms-"+r.executionID)
+	if err := os.Mkdir(sockDir, 0700); err != nil && !os.IsExist(err) {
+		return fmt.Errorf("create socket dir: %w", err)
+	}
+
+	sockPath := filepath.Join(sockDir, "api.sock")
+
+	ln, err := net.Listen("unix", sockPath)
+	if err != nil {
+		_ = os.RemoveAll(sockDir)
+		return fmt.Errorf("listen unix socket: %w", err)
+	}
+
+	// Enforce 0600 on the socket file; the 0700 directory prevents access
+	// during the brief window before chmod.
+	if err := os.Chmod(sockPath, 0600); err != nil {
+		_ = ln.Close()
+		_ = os.RemoveAll(sockDir)
+		return fmt.Errorf("chmod socket: %w", err)
+	}
+
+	r.socketPath = sockPath
+	r.ln = ln
+	return nil
+}
+
+// cleanupSocket removes the per-execution socket directory and its contents.
+func cleanupSocket(r *Relay) {
+	if r.socketPath == "" {
+		return
+	}
+	sockDir := filepath.Dir(r.socketPath)
+	_ = os.RemoveAll(sockDir)
+}

--- a/features/steward/script_relay/relay_unix.go
+++ b/features/steward/script_relay/relay_unix.go
@@ -36,6 +36,27 @@ func initSocket(r *Relay) error {
 		return fmt.Errorf("chmod socket: %w", err)
 	}
 
+	// Chown the directory and socket to the script's execution UID. With mode
+	// 0700/0600, connecting requires write access to the socket inode, so a
+	// script running under a different user (logged_in_user context, launched
+	// via `sudo -u`) can only connect when it owns these files. When the
+	// execution UID equals the steward process UID (system context) or is
+	// unset (< 0), the chown is skipped as a no-op.
+	if r.uid >= 0 && r.uid != os.Getuid() {
+		if err := os.Chown(sockDir, r.uid, -1); err != nil {
+			_ = ln.Close()
+			_ = os.RemoveAll(sockDir)
+			return fmt.Errorf("chown socket dir to uid %d: %w", r.uid, err)
+		}
+		// Lchown the socket itself: it is never a symlink, but Lchown avoids
+		// following one if the path were ever swapped, matching the dir chown.
+		if err := os.Lchown(sockPath, r.uid, -1); err != nil {
+			_ = ln.Close()
+			_ = os.RemoveAll(sockDir)
+			return fmt.Errorf("chown socket to uid %d: %w", r.uid, err)
+		}
+	}
+
 	r.socketPath = sockPath
 	r.ln = ln
 	return nil

--- a/features/steward/script_relay/relay_windows.go
+++ b/features/steward/script_relay/relay_windows.go
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+//go:build windows
+
+package scriptrelay
+
+import (
+	"fmt"
+
+	winio "github.com/Microsoft/go-winio"
+)
+
+// initSocket creates a Windows named pipe for the execution with a DACL that
+// grants access only to the owner (OW). The default named-pipe DACL is too
+// broad; the explicit descriptor prevents other local users from connecting.
+func initSocket(r *Relay) error {
+	pipeName := `\\.\pipe\cfgms-` + r.executionID
+
+	// DACL: protected, allow generic-all to object owner only.
+	ln, err := winio.ListenPipe(pipeName, &winio.PipeConfig{
+		SecurityDescriptor: "D:P(A;;GA;;;OW)",
+		InputBufferSize:    65536,
+		OutputBufferSize:   65536,
+	})
+	if err != nil {
+		return fmt.Errorf("listen named pipe: %w", err)
+	}
+
+	r.socketPath = pipeName
+	r.ln = ln
+	return nil
+}
+
+// cleanupSocket closes the named pipe listener (already closed by Stop).
+// Windows named pipes are automatically removed when the last handle is closed.
+func cleanupSocket(_ *Relay) {}

--- a/pkg/controlplane/types/messages.go
+++ b/pkg/controlplane/types/messages.go
@@ -30,6 +30,10 @@ const (
 	// CommandExecuteScript runs a script on the steward via the script module executor.
 	// Params: script_content (base64), shell, execution_id, timeout_seconds, execution_context.
 	CommandExecuteScript CommandType = "execute_script"
+
+	// CommandRelayResponse carries the controller's HTTP response back to the steward
+	// relay goroutine. Params: execution_id, sequence, status (int), headers (map), body (base64).
+	CommandRelayResponse CommandType = "relay_response"
 )
 
 // Command represents a command sent from controller to steward.
@@ -90,6 +94,11 @@ const (
 	// EventScriptCompleted indicates an execute_script command finished running.
 	// The exit code may be non-zero; this event is emitted regardless of exit code.
 	EventScriptCompleted EventType = "script_completed"
+
+	// EventRelayRequest is published by the steward to relay a script's REST API
+	// call to the controller. Details carry method, path, headers, body, execution_id,
+	// and a per-execution sequence number for correlation.
+	EventRelayRequest EventType = "relay_request"
 )
 
 // Event represents an event published from steward to controller.


### PR DESCRIPTION
## Summary

- Adds per-execution unix socket (Linux/macOS) or named pipe (Windows) that proxies library-script REST calls over the steward's existing mTLS connection to the controller
- Controller validates by mTLS identity + JIT per-execution grant before routing into the existing REST handler via a scope-limited, non-admin `Principal`
- No bearer tokens or API keys created; device identity always from mTLS-verified `event.StewardID`; grant scope always equals stored `ScriptPrivilegeMetadata.RequiredAPIScope`, never a runtime value

## Changes

**Controller:**
- `pkg/controlplane/types/messages.go` — new `EventRelayRequest` and `CommandRelayResponse` message types
- `features/controller/run/run.go` — `ExecutionGrant` struct + `RunStore` grant methods (`CreateExecutionGrant`, `LookupGrant`, `ConsumeGrant`) backed by SQLite
- `features/controller/dispatcher/dispatcher.go` — JIT grant creation at dispatch; `ConsumeGrant` on `AcknowledgeCompletion`
- `features/controller/api/relay_handler.go` — `RelayHandler` subscribes to relay events, validates grants (keyed on `(deviceID, executionID)`), routes through REST router with scoped `Principal`, sends `CommandRelayResponse`
- `features/controller/api/middleware.go` — relay principal bypass in `authenticationMiddleware`; scope enforcement for relay principals enforced inline even when `rbacService == nil` (prevents scope escape in OSS mode)
- `features/controller/api/handlers_runs.go` — `loadPrivilegeMetadata` helper; `requiredAPIScope` threaded from stored metadata into `SynthesizeScriptRun`
- `features/controller/run/synthesis.go` — `requiredAPIScope` parameter passed into `QueuedExecution` metadata

**Steward:**
- `features/steward/script_relay/` — `relay.go`, `relay_unix.go`, `relay_windows.go`, `preamble.go` + tests; per-execution socket lifecycle + shell preamble injection
- `features/steward/commands/execute_script.go` — relay lifecycle (create → start → preamble-inject → execute → stop) for library scripts with non-empty `required_api_scope`
- `features/steward/commands/handler.go` — `sync.Map` relay registry + `CommandRelayResponse` dispatch

## Security properties

- No bearer token / API key string generated for or passed to library-script execution (AC1)
- Grant scope == script's stored `RequiredAPIScope`, never runtime-supplied (AC2)
- Device identity from mTLS `event.StewardID`, never relay message fields (AC3)
- `EphemeralKeyManager`/`GenerateAPIKey` path not used (AC4)
- Script-supplied relay headers sanitised to `Content-Type` and `Accept` allowlist only
- Grant consumed on `AcknowledgeCompletion` (one-time use); TTL expires on script timeout
- Relay scope enforced inline when RBAC service unavailable (OSS mode regression guard — `TestRequirePermission_RelayPrincipal_ScopeEnforcedWhenRBACNil`)

## Test plan

- [x] `make test-agent-complete` passes (all pre-commit, fast, production-critical, cross-platform build checks)
- [x] No data races (`-race` clean)
- [x] `TestRunStore_GrantLifecycle` — create/lookup/consume/expiry lifecycle
- [x] `TestRelayHandler_NoGrant_Returns403`, `TestRelayHandler_ConsumedGrant_Returns403`, `TestRelayHandler_WrongDevice_Returns403`, `TestRelayHandler_ScopeEnforcement_Returns403` — grant validation edge cases
- [x] `TestRelayHandler_ValidGrant_RoutesRequest` — happy path routing with scoped Principal
- [x] `TestRelayHandler_AdminPrincipal_NeverConstructed` — relay principal never admin
- [x] `TestRelayHandler_ExpiredGrant_Returns403` — TTL enforcement
- [x] `TestRelayHandler_AuthMiddlewareBypass` — relay principal bypasses auth middleware
- [x] `TestRequirePermission_RelayPrincipal_ScopeEnforcedWhenRBACNil` — scope enforced without RBAC service
- [x] `TestRelay_SocketCreation`, `TestRelay_RequestResponseCycle`, `TestRelay_StopCancelsWaiting`, `TestRelay_ExecutionIDInEvent` — socket lifecycle and relay protocol
- [x] `TestInjectBashPreamble_*`, `TestInjectPowerShellPreamble_*` — shell preamble correctness

Fixes #1675

🤖 Generated with [Claude Code](https://claude.com/claude-code)