### PR TITLE
cfg/steward: add run-script, run-command, run-status, run-result, run-cancel subcommands (Issue #1676)

### DIFF
--- a/cmd/cfg/cmd/steward.go
+++ b/cmd/cfg/cmd/steward.go
@@ -4,8 +4,14 @@
 package cmd
 
 import (
+	"bytes"
 	"context"
+	"crypto/ecdsa"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/base64"
 	"encoding/json"
+	"encoding/pem"
 	"fmt"
 	"io"
 	"net/http"
@@ -14,6 +20,7 @@ import (
 	"text/tabwriter"
 	"time"
 
+	"github.com/cfgis/cfgms/pkg/cert/bundle"
 	"github.com/spf13/cobra"
 )
 
@@ -52,6 +59,97 @@ Examples:
 	RunE: runStewardList,
 }
 
+// ---------------------------------------------------------------------------
+// Package-level variables for steward run subcommands.
+// ---------------------------------------------------------------------------
+
+var (
+	stewardRunTarget       string
+	stewardRunScript       string
+	stewardRunVersion      string
+	stewardRunParams       []string
+	stewardRunWait         bool
+	stewardRunSkipOffline  bool
+	stewardRunWaitTimeout  time.Duration
+	stewardRunShell        string
+	stewardRunResultDevice string
+)
+
+// runWaitPollInterval is the delay between status polls in the --wait loop.
+// Overridable in tests to avoid real sleeps.
+var runWaitPollInterval = 5 * time.Second
+
+// ---------------------------------------------------------------------------
+// Run subcommand definitions
+// ---------------------------------------------------------------------------
+
+var stewardRunScriptCmd = &cobra.Command{
+	Use:   "run-script",
+	Short: "Run a library script against matching stewards",
+	Long: `Submit a library script to matching stewards and return a run ID.
+
+Exits immediately (async) by default. Use --wait to block until completion.
+
+Examples:
+  cfg steward run-script --target os:linux --script my-script
+  cfg steward run-script --script my-script --version v2 --wait --wait-timeout 10m`,
+	RunE: runRunScript,
+}
+
+var stewardRunCommandCmd = &cobra.Command{
+	Use:   "run-command <inline-content-or-file>",
+	Short: "Run an inline command against matching stewards",
+	Long: `Sign and submit an inline command or script file to matching stewards.
+
+The argument is treated as a file path if the path exists on disk; otherwise
+it is used as the inline script body. Content is base64-encoded and signed with
+the operator's mTLS bundle key before transmission.
+
+Requires an admin bundle with a private key (--bundle or CFGMS_ADMIN_BUNDLE).
+
+Examples:
+  cfg steward run-command --shell bash "echo hello"
+  cfg steward run-command --shell bash ./scripts/deploy.sh --target os:linux`,
+	Args: cobra.ExactArgs(1),
+	RunE: runRunCommand,
+}
+
+var stewardRunStatusCmd = &cobra.Command{
+	Use:   "run-status <run-id>",
+	Short: "Show status of a run",
+	Long: `Display the status and job counts for a run.
+
+Examples:
+  cfg steward run-status 550e8400-e29b-41d4-a716-446655440000`,
+	Args: cobra.ExactArgs(1),
+	RunE: runRunStatus,
+}
+
+var stewardRunResultCmd = &cobra.Command{
+	Use:   "run-result <run-id>",
+	Short: "Show job output for a run",
+	Long: `Display per-steward job details for a completed or in-progress run.
+
+Use --device to filter output to a single steward.
+
+Examples:
+  cfg steward run-result 550e8400-e29b-41d4-a716-446655440000
+  cfg steward run-result 550e8400-e29b-41d4-a716-446655440000 --device steward-abc`,
+	Args: cobra.ExactArgs(1),
+	RunE: runRunResult,
+}
+
+var stewardRunCancelCmd = &cobra.Command{
+	Use:   "run-cancel <run-id>",
+	Short: "Cancel a run",
+	Long: `Cancel all pending and running jobs within a run.
+
+Examples:
+  cfg steward run-cancel 550e8400-e29b-41d4-a716-446655440000`,
+	Args: cobra.ExactArgs(1),
+	RunE: runRunCancel,
+}
+
 func init() {
 	stewardListCmd.Flags().StringVar(&stewardURL, "url", "", "Controller API URL")
 	stewardListCmd.Flags().StringVar(&stewardAPIKey, "api-key", "", "API key for authentication")
@@ -64,8 +162,57 @@ func init() {
 	stewardStatusCmd.Flags().BoolVar(&stewardTLSInsecure, "tls-insecure", false, "Skip TLS verification (development only, env: CFGMS_TLS_INSECURE)")
 	stewardStatusCmd.Flags().BoolVar(&stewardStatusJSONOutput, "json", false, "Emit JSON output instead of human-readable text")
 
+	// run-script flags
+	stewardRunScriptCmd.Flags().StringVar(&stewardURL, "url", "", "Controller API URL")
+	stewardRunScriptCmd.Flags().StringVar(&stewardAPIKey, "api-key", "", "API key for authentication")
+	stewardRunScriptCmd.Flags().StringVar(&stewardTLSCACert, "tls-ca-cert", "", "Path to CA certificate (env: CFGMS_TLS_CA_CERT)")
+	stewardRunScriptCmd.Flags().BoolVar(&stewardTLSInsecure, "tls-insecure", false, "Skip TLS verification (env: CFGMS_TLS_INSECURE)")
+	stewardRunScriptCmd.Flags().StringVar(&stewardRunTarget, "target", "", "Fleet selector (e.g. os:linux, group:prod)")
+	stewardRunScriptCmd.Flags().StringVar(&stewardRunScript, "script", "", "Script ID from the controller library")
+	stewardRunScriptCmd.Flags().StringVar(&stewardRunVersion, "version", "", "Script version (default: latest)")
+	stewardRunScriptCmd.Flags().StringArrayVar(&stewardRunParams, "param", nil, "Parameter key=value (repeatable)")
+	stewardRunScriptCmd.Flags().BoolVar(&stewardRunWait, "wait", false, "Block until all jobs reach terminal state")
+	stewardRunScriptCmd.Flags().BoolVar(&stewardRunSkipOffline, "skip-offline", false, "Skip offline stewards instead of queuing for them")
+	stewardRunScriptCmd.Flags().DurationVar(&stewardRunWaitTimeout, "wait-timeout", 5*time.Minute, "Maximum time to wait when --wait is set")
+
+	// run-command flags
+	stewardRunCommandCmd.Flags().StringVar(&stewardURL, "url", "", "Controller API URL")
+	stewardRunCommandCmd.Flags().StringVar(&stewardAPIKey, "api-key", "", "API key for authentication")
+	stewardRunCommandCmd.Flags().StringVar(&stewardTLSCACert, "tls-ca-cert", "", "Path to CA certificate (env: CFGMS_TLS_CA_CERT)")
+	stewardRunCommandCmd.Flags().BoolVar(&stewardTLSInsecure, "tls-insecure", false, "Skip TLS verification (env: CFGMS_TLS_INSECURE)")
+	stewardRunCommandCmd.Flags().StringVar(&stewardRunTarget, "target", "", "Fleet selector (e.g. os:linux, group:prod)")
+	stewardRunCommandCmd.Flags().StringVar(&stewardRunShell, "shell", "", "Shell to use (e.g. bash, sh, powershell)")
+	stewardRunCommandCmd.Flags().StringArrayVar(&stewardRunParams, "param", nil, "Parameter key=value (repeatable)")
+	stewardRunCommandCmd.Flags().BoolVar(&stewardRunWait, "wait", false, "Block until all jobs reach terminal state")
+	stewardRunCommandCmd.Flags().BoolVar(&stewardRunSkipOffline, "skip-offline", false, "Skip offline stewards instead of queuing for them")
+	stewardRunCommandCmd.Flags().DurationVar(&stewardRunWaitTimeout, "wait-timeout", 5*time.Minute, "Maximum time to wait when --wait is set")
+
+	// run-status flags
+	stewardRunStatusCmd.Flags().StringVar(&stewardURL, "url", "", "Controller API URL")
+	stewardRunStatusCmd.Flags().StringVar(&stewardAPIKey, "api-key", "", "API key for authentication")
+	stewardRunStatusCmd.Flags().StringVar(&stewardTLSCACert, "tls-ca-cert", "", "Path to CA certificate (env: CFGMS_TLS_CA_CERT)")
+	stewardRunStatusCmd.Flags().BoolVar(&stewardTLSInsecure, "tls-insecure", false, "Skip TLS verification (env: CFGMS_TLS_INSECURE)")
+
+	// run-result flags
+	stewardRunResultCmd.Flags().StringVar(&stewardURL, "url", "", "Controller API URL")
+	stewardRunResultCmd.Flags().StringVar(&stewardAPIKey, "api-key", "", "API key for authentication")
+	stewardRunResultCmd.Flags().StringVar(&stewardTLSCACert, "tls-ca-cert", "", "Path to CA certificate (env: CFGMS_TLS_CA_CERT)")
+	stewardRunResultCmd.Flags().BoolVar(&stewardTLSInsecure, "tls-insecure", false, "Skip TLS verification (env: CFGMS_TLS_INSECURE)")
+	stewardRunResultCmd.Flags().StringVar(&stewardRunResultDevice, "device", "", "Filter output to a single device ID")
+
+	// run-cancel flags
+	stewardRunCancelCmd.Flags().StringVar(&stewardURL, "url", "", "Controller API URL")
+	stewardRunCancelCmd.Flags().StringVar(&stewardAPIKey, "api-key", "", "API key for authentication")
+	stewardRunCancelCmd.Flags().StringVar(&stewardTLSCACert, "tls-ca-cert", "", "Path to CA certificate (env: CFGMS_TLS_CA_CERT)")
+	stewardRunCancelCmd.Flags().BoolVar(&stewardTLSInsecure, "tls-insecure", false, "Skip TLS verification (env: CFGMS_TLS_INSECURE)")
+
 	stewardCmd.AddCommand(stewardListCmd)
 	stewardCmd.AddCommand(stewardStatusCmd)
+	stewardCmd.AddCommand(stewardRunScriptCmd)
+	stewardCmd.AddCommand(stewardRunCommandCmd)
+	stewardCmd.AddCommand(stewardRunStatusCmd)
+	stewardCmd.AddCommand(stewardRunResultCmd)
+	stewardCmd.AddCommand(stewardRunCancelCmd)
 }
 
 // getStewardClient creates an API client using bundle auth (mTLS) when available,
@@ -277,4 +424,440 @@ func runStewardList(cmd *cobra.Command, args []string) error {
 		}
 	}
 	return w.Flush()
+}
+
+// ---------------------------------------------------------------------------
+// Run subcommand types
+// ---------------------------------------------------------------------------
+
+// commandSignature holds the cryptographic signature embedded in run-command requests.
+type commandSignature struct {
+	Algorithm string `json:"algorithm"`
+	Value     string `json:"value"`      // base64-encoded raw signature bytes
+	PublicKey string `json:"public_key"` // cert PEM from the operator bundle
+}
+
+// runRecord mirrors the fields returned by GET /api/v1/runs/{run_id}.
+type runRecord struct {
+	RunID         string `json:"run_id"`
+	Status        string `json:"status"`
+	JobCount      int    `json:"job_count"`
+	CompletedJobs int    `json:"completed_jobs"`
+	FailedJobs    int    `json:"failed_jobs"`
+}
+
+// runJobRecord mirrors the fields returned by GET /api/v1/runs/{run_id}/jobs.
+type runJobRecord struct {
+	JobID       string `json:"job_id"`
+	RunID       string `json:"run_id"`
+	DeviceID    string `json:"device_id"`
+	ExecutionID string `json:"execution_id,omitempty"`
+	Status      string `json:"status"`
+}
+
+// ---------------------------------------------------------------------------
+// run-script
+// ---------------------------------------------------------------------------
+
+func runRunScript(_ *cobra.Command, _ []string) error {
+	params, err := parseRunParams(stewardRunParams)
+	if err != nil {
+		return err
+	}
+
+	reqBody := map[string]interface{}{
+		"target":         stewardRunTarget,
+		"script_id":      stewardRunScript,
+		"script_version": stewardRunVersion,
+		"params":         params,
+		"skip_offline":   stewardRunSkipOffline,
+	}
+
+	bodyJSON, err := json.Marshal(reqBody)
+	if err != nil {
+		return fmt.Errorf("failed to encode request: %w", err)
+	}
+
+	client, err := getStewardClient()
+	if err != nil {
+		return fmt.Errorf("failed to create API client: %w", err)
+	}
+
+	resp, err := client.doRequest(context.Background(), http.MethodPost, "/api/v1/runs/script", bytes.NewReader(bodyJSON))
+	if err != nil {
+		return fmt.Errorf("failed to submit run: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("API request failed: %s - %s", resp.Status, string(body))
+	}
+
+	var apiResp struct {
+		Data struct {
+			RunID string `json:"run_id"`
+		} `json:"data"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&apiResp); err != nil {
+		return fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	runID := apiResp.Data.RunID
+
+	if stewardRunWait {
+		fmt.Printf("Run ID: %s\n", runID)
+		return waitForRun(context.Background(), client, runID, stewardRunWaitTimeout)
+	}
+
+	fmt.Println(runID)
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// run-command
+// ---------------------------------------------------------------------------
+
+func runRunCommand(_ *cobra.Command, args []string) error {
+	content, err := readCommandContent(args[0])
+	if err != nil {
+		return err
+	}
+
+	sig, err := signCommandContent(content)
+	if err != nil {
+		return err
+	}
+
+	params, err := parseRunParams(stewardRunParams)
+	if err != nil {
+		return err
+	}
+
+	reqBody := map[string]interface{}{
+		"target":       stewardRunTarget,
+		"content":      base64.StdEncoding.EncodeToString(content),
+		"shell":        stewardRunShell,
+		"params":       params,
+		"skip_offline": stewardRunSkipOffline,
+		"signature":    sig,
+	}
+
+	bodyJSON, err := json.Marshal(reqBody)
+	if err != nil {
+		return fmt.Errorf("failed to encode request: %w", err)
+	}
+
+	client, err := getStewardClient()
+	if err != nil {
+		return fmt.Errorf("failed to create API client: %w", err)
+	}
+
+	resp, err := client.doRequest(context.Background(), http.MethodPost, "/api/v1/runs/command", bytes.NewReader(bodyJSON))
+	if err != nil {
+		return fmt.Errorf("failed to submit run: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("API request failed: %s - %s", resp.Status, string(body))
+	}
+
+	var apiResp struct {
+		Data struct {
+			RunID string `json:"run_id"`
+		} `json:"data"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&apiResp); err != nil {
+		return fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	runID := apiResp.Data.RunID
+
+	if stewardRunWait {
+		fmt.Printf("Run ID: %s\n", runID)
+		return waitForRun(context.Background(), client, runID, stewardRunWaitTimeout)
+	}
+
+	fmt.Println(runID)
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// run-status
+// ---------------------------------------------------------------------------
+
+func runRunStatus(_ *cobra.Command, args []string) error {
+	runID := args[0]
+
+	client, err := getStewardClient()
+	if err != nil {
+		return fmt.Errorf("failed to create API client: %w", err)
+	}
+
+	run, err := fetchRunRecord(context.Background(), client, runID)
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("Run ID:    %s\n", run.RunID)
+	fmt.Printf("Status:    %s\n", run.Status)
+	fmt.Printf("Jobs:      %d total, %d completed, %d failed\n", run.JobCount, run.CompletedJobs, run.FailedJobs)
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// run-result
+// ---------------------------------------------------------------------------
+
+func runRunResult(_ *cobra.Command, args []string) error {
+	runID := args[0]
+
+	client, err := getStewardClient()
+	if err != nil {
+		return fmt.Errorf("failed to create API client: %w", err)
+	}
+
+	resp, err := client.Get(context.Background(), "/api/v1/runs/"+runID+"/jobs")
+	if err != nil {
+		return fmt.Errorf("failed to fetch run jobs: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode == http.StatusNotFound {
+		return fmt.Errorf("run %s not found", runID)
+	}
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("API request failed: %s - %s", resp.Status, string(body))
+	}
+
+	var apiResp struct {
+		Data []runJobRecord `json:"data"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&apiResp); err != nil {
+		return fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	jobs := apiResp.Data
+	if stewardRunResultDevice != "" {
+		filtered := jobs[:0]
+		for _, j := range jobs {
+			if j.DeviceID == stewardRunResultDevice {
+				filtered = append(filtered, j)
+			}
+		}
+		jobs = filtered
+	}
+
+	if len(jobs) == 0 {
+		fmt.Println("No jobs found.")
+		return nil
+	}
+
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	if _, err := fmt.Fprintln(w, "DEVICE\tSTATUS\tJOB ID\tEXECUTION ID"); err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintln(w, "------\t------\t------\t------------"); err != nil {
+		return err
+	}
+	for _, j := range jobs {
+		if _, err := fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", j.DeviceID, j.Status, j.JobID, j.ExecutionID); err != nil {
+			return err
+		}
+	}
+	return w.Flush()
+}
+
+// ---------------------------------------------------------------------------
+// run-cancel
+// ---------------------------------------------------------------------------
+
+func runRunCancel(_ *cobra.Command, args []string) error {
+	runID := args[0]
+
+	client, err := getStewardClient()
+	if err != nil {
+		return fmt.Errorf("failed to create API client: %w", err)
+	}
+
+	resp, err := client.doRequest(context.Background(), http.MethodDelete, "/api/v1/runs/"+runID, nil)
+	if err != nil {
+		return fmt.Errorf("failed to cancel run: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	switch resp.StatusCode {
+	case http.StatusNotFound:
+		return fmt.Errorf("run %s not found", runID)
+	case http.StatusConflict:
+		return fmt.Errorf("run %s is already in a terminal state", runID)
+	case http.StatusOK:
+		fmt.Printf("Run %s cancelled\n", runID)
+		return nil
+	default:
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("API request failed: %s - %s", resp.Status, string(body))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+// parseRunParams converts "key=value" strings to a map. Returns an error for
+// any entry that does not contain exactly one "=".
+func parseRunParams(params []string) (map[string]string, error) {
+	result := make(map[string]string, len(params))
+	for _, p := range params {
+		parts := strings.SplitN(p, "=", 2)
+		if len(parts) != 2 || parts[0] == "" {
+			return nil, fmt.Errorf("invalid parameter %q: expected key=value format", p)
+		}
+		result[parts[0]] = parts[1]
+	}
+	return result, nil
+}
+
+// readCommandContent returns the raw bytes to sign and execute.
+// If arg looks like an existing file path the file is read; otherwise arg
+// itself is used as inline content.
+func readCommandContent(arg string) ([]byte, error) {
+	if _, err := os.Stat(arg); err == nil {
+		data, err := os.ReadFile(arg) // #nosec G304 — user-provided path, intentional
+		if err != nil {
+			return nil, fmt.Errorf("read command file %q: %w", arg, err)
+		}
+		return data, nil
+	}
+	return []byte(arg), nil
+}
+
+// signCommandContent locates the operator's admin bundle, extracts its private
+// key, and signs content. Returns an error if no bundle or no private key is found.
+func signCommandContent(content []byte) (*commandSignature, error) {
+	bundleEnvVal, _ := os.LookupEnv("CFGMS_ADMIN_BUNDLE")
+	bundleFilePath, err := findBundlePath(bundleEnvVal)
+	if err != nil {
+		return nil, fmt.Errorf("bundle resolution failed: %w", err)
+	}
+	if bundleFilePath == "" {
+		return nil, fmt.Errorf("no admin bundle found: run-command requires a bundle with a private key for signing; use --bundle or set CFGMS_ADMIN_BUNDLE")
+	}
+
+	b, err := bundle.Read(bundleFilePath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read bundle at %s: %w", bundleFilePath, err)
+	}
+
+	if b.KeyPEM == "" {
+		return nil, fmt.Errorf("bundle at %s has no private key: run-command requires signing capability", bundleFilePath)
+	}
+
+	privKey, err := parsePrivKeyFromPEM(b.KeyPEM)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse bundle private key: %w", err)
+	}
+
+	var algorithm string
+	switch privKey.(type) {
+	case *rsa.PrivateKey:
+		algorithm = "rsa-sha256"
+	case *ecdsa.PrivateKey:
+		algorithm = "ecdsa-sha256"
+	default:
+		return nil, fmt.Errorf("unsupported key type %T in bundle (expected RSA or ECDSA)", privKey)
+	}
+
+	digest, err := hashContent(content, algorithm)
+	if err != nil {
+		return nil, err
+	}
+
+	sigBytes, err := signDigest(digest, privKey, algorithm)
+	if err != nil {
+		return nil, fmt.Errorf("signing failed: %w", err)
+	}
+
+	return &commandSignature{
+		Algorithm: algorithm,
+		Value:     base64.StdEncoding.EncodeToString(sigBytes),
+		PublicKey: b.CertPEM,
+	}, nil
+}
+
+// parsePrivKeyFromPEM decodes a PEM block and parses a PKCS#8 private key.
+func parsePrivKeyFromPEM(pemData string) (interface{}, error) {
+	block, _ := pem.Decode([]byte(pemData))
+	if block == nil {
+		return nil, fmt.Errorf("no PEM block found in key data")
+	}
+	key, err := x509.ParsePKCS8PrivateKey(block.Bytes)
+	if err != nil {
+		return nil, fmt.Errorf("parse private key: %w", err)
+	}
+	return key, nil
+}
+
+// fetchRunRecord calls GET /api/v1/runs/{runID} and returns the parsed record.
+func fetchRunRecord(ctx context.Context, client *APIClient, runID string) (*runRecord, error) {
+	resp, err := client.Get(ctx, "/api/v1/runs/"+runID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to poll run: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode == http.StatusNotFound {
+		return nil, fmt.Errorf("run %s not found", runID)
+	}
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("API request failed: %s - %s", resp.Status, string(body))
+	}
+
+	var apiResp struct {
+		Data runRecord `json:"data"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&apiResp); err != nil {
+		return nil, fmt.Errorf("failed to parse run response: %w", err)
+	}
+	return &apiResp.Data, nil
+}
+
+// waitForRun polls GET /api/v1/runs/{runID} every runWaitPollInterval until the
+// run reaches a terminal state or the timeout elapses.
+func waitForRun(ctx context.Context, client *APIClient, runID string, timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+
+	for {
+		run, err := fetchRunRecord(ctx, client, runID)
+		if err != nil {
+			return err
+		}
+
+		if isRunTerminal(run.Status) {
+			fmt.Printf("Status: %s\n", run.Status)
+			fmt.Printf("Jobs: %d total, %d completed, %d failed\n", run.JobCount, run.CompletedJobs, run.FailedJobs)
+			return nil
+		}
+
+		if time.Now().After(deadline) {
+			return fmt.Errorf("timed out after %s waiting for run %s (status: %s, %d/%d jobs completed)",
+				timeout, runID, run.Status, run.CompletedJobs, run.JobCount)
+		}
+
+		fmt.Printf("Waiting... status: %s (%d/%d completed)\n", run.Status, run.CompletedJobs, run.JobCount)
+
+		select {
+		case <-time.After(runWaitPollInterval):
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+}
+
+func isRunTerminal(status string) bool {
+	return status == "completed" || status == "failed" || status == "cancelled"
 }

--- a/cmd/cfg/cmd/steward_run_test.go
+++ b/cmd/cfg/cmd/steward_run_test.go
@@ -1,0 +1,679 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+package cmd
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/base64"
+	"encoding/json"
+	"encoding/pem"
+	"io"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	certbundle "github.com/cfgis/cfgms/pkg/cert/bundle"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// writeRunAPIResponse encodes a standard { "data": ..., "timestamp": ... } response.
+func writeRunAPIResponse(w http.ResponseWriter, data interface{}) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	_ = json.NewEncoder(w).Encode(map[string]interface{}{
+		"data":      data,
+		"timestamp": time.Now().UTC(),
+	})
+}
+
+// generateTestBundleWithRSA writes an admin bundle file containing a fresh RSA
+// private key and a self-signed certificate to dir, then returns the file path.
+func generateTestBundleWithRSA(t *testing.T, dir string) string {
+	t.Helper()
+
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	keyDER, err := x509.MarshalPKCS8PrivateKey(key)
+	require.NoError(t, err)
+	keyPEM := string(pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: keyDER}))
+
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "test-operator"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+	}
+	certDER, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	require.NoError(t, err)
+	certPEM := string(pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER}))
+
+	b := &certbundle.Bundle{
+		KeyPEM:  keyPEM,
+		CertPEM: certPEM,
+		CAPEM:   certPEM,
+	}
+	p := dir + "/admin.bundle.yaml"
+	require.NoError(t, certbundle.Write(p, b))
+	return p
+}
+
+// saveStewardRunGlobals captures the current values of all run-command flag variables
+// and all global function variables that affect bundle resolution, then restores them
+// via t.Cleanup so tests cannot pollute each other's state.
+func saveStewardRunGlobals(t *testing.T) {
+	t.Helper()
+	origURL := stewardURL
+	origInsecure := stewardTLSInsecure
+	origTarget := stewardRunTarget
+	origScript := stewardRunScript
+	origVersion := stewardRunVersion
+	origParams := stewardRunParams
+	origWait := stewardRunWait
+	origSkipOffline := stewardRunSkipOffline
+	origWaitTimeout := stewardRunWaitTimeout
+	origShell := stewardRunShell
+	origDevice := stewardRunResultDevice
+	origPollInterval := runWaitPollInterval
+	origBP := bundlePath
+	origNoBundle := noBundle
+	origUserConfigDir := userConfigDirFn
+	origSystemBundle := systemBundlePathFn
+	t.Cleanup(func() {
+		stewardURL = origURL
+		stewardTLSInsecure = origInsecure
+		stewardRunTarget = origTarget
+		stewardRunScript = origScript
+		stewardRunVersion = origVersion
+		stewardRunParams = origParams
+		stewardRunWait = origWait
+		stewardRunSkipOffline = origSkipOffline
+		stewardRunWaitTimeout = origWaitTimeout
+		stewardRunShell = origShell
+		stewardRunResultDevice = origDevice
+		runWaitPollInterval = origPollInterval
+		bundlePath = origBP
+		noBundle = origNoBundle
+		userConfigDirFn = origUserConfigDir
+		systemBundlePathFn = origSystemBundle
+	})
+}
+
+// ---------------------------------------------------------------------------
+// run-script tests
+// ---------------------------------------------------------------------------
+
+func TestStewardRunScript_AsyncReturnsRunID(t *testing.T) {
+	var requestPath, requestMethod string
+	var requestBody []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestPath = r.URL.Path
+		requestMethod = r.Method
+		requestBody, _ = io.ReadAll(r.Body)
+		writeRunAPIResponse(w, map[string]string{"run_id": "run-abc123"})
+	}))
+	defer server.Close()
+
+	saveStewardRunGlobals(t)
+	stewardURL = server.URL
+	stewardTLSInsecure = true
+	stewardRunScript = "my-script"
+	stewardRunTarget = "os:linux"
+	stewardRunVersion = "v2"
+	stewardRunWait = false
+
+	output := captureStdout(t, func() {
+		err := runRunScript(stewardRunScriptCmd, []string{})
+		require.NoError(t, err)
+	})
+
+	assert.Equal(t, http.MethodPost, requestMethod)
+	assert.Equal(t, "/api/v1/runs/script", requestPath)
+	assert.Contains(t, output, "run-abc123")
+
+	// Verify request body fields
+	var body map[string]interface{}
+	require.NoError(t, json.Unmarshal(requestBody, &body))
+	assert.Equal(t, "my-script", body["script_id"])
+	assert.Equal(t, "os:linux", body["target"])
+	assert.Equal(t, "v2", body["script_version"])
+}
+
+func TestStewardRunScript_NonOKStatusReturnsError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		_ = json.NewEncoder(w).Encode(map[string]string{"error": "invalid selector"})
+	}))
+	defer server.Close()
+
+	saveStewardRunGlobals(t)
+	stewardURL = server.URL
+	stewardTLSInsecure = true
+	stewardRunScript = "my-script"
+
+	err := runRunScript(stewardRunScriptCmd, []string{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "400")
+}
+
+func TestStewardRunScript_SkipOfflineIncludedInBody(t *testing.T) {
+	var requestBody []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestBody, _ = io.ReadAll(r.Body)
+		writeRunAPIResponse(w, map[string]string{"run_id": "run-skip-offline"})
+	}))
+	defer server.Close()
+
+	saveStewardRunGlobals(t)
+	stewardURL = server.URL
+	stewardTLSInsecure = true
+	stewardRunScript = "my-script"
+	stewardRunSkipOffline = true
+
+	_ = captureStdout(t, func() {
+		require.NoError(t, runRunScript(stewardRunScriptCmd, []string{}))
+	})
+
+	var body map[string]interface{}
+	require.NoError(t, json.Unmarshal(requestBody, &body))
+	assert.Equal(t, true, body["skip_offline"])
+}
+
+func TestStewardRunScript_ParamsIncludedInBody(t *testing.T) {
+	var requestBody []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestBody, _ = io.ReadAll(r.Body)
+		writeRunAPIResponse(w, map[string]string{"run_id": "run-params"})
+	}))
+	defer server.Close()
+
+	saveStewardRunGlobals(t)
+	stewardURL = server.URL
+	stewardTLSInsecure = true
+	stewardRunScript = "my-script"
+	stewardRunParams = []string{"env=prod", "region=us-east-1"}
+
+	_ = captureStdout(t, func() {
+		require.NoError(t, runRunScript(stewardRunScriptCmd, []string{}))
+	})
+
+	var body map[string]interface{}
+	require.NoError(t, json.Unmarshal(requestBody, &body))
+	params, ok := body["params"].(map[string]interface{})
+	require.True(t, ok, "params must be a JSON object")
+	assert.Equal(t, "prod", params["env"])
+	assert.Equal(t, "us-east-1", params["region"])
+}
+
+func TestStewardRunScript_InvalidParamReturnsError(t *testing.T) {
+	saveStewardRunGlobals(t)
+	stewardRunParams = []string{"no-equals-sign"}
+
+	err := runRunScript(stewardRunScriptCmd, []string{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no-equals-sign")
+}
+
+// ---------------------------------------------------------------------------
+// [REQUIRED TEST] run-command — base64-encodes content + includes signature block
+// ---------------------------------------------------------------------------
+
+func TestStewardRunCommand_SignsAndBase64Encodes(t *testing.T) {
+	dir := t.TempDir()
+	bundleFile := generateTestBundleWithRSA(t, dir)
+
+	var capturedBody []byte
+	var capturedPath string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedPath = r.URL.Path
+		capturedBody, _ = io.ReadAll(r.Body)
+		writeRunAPIResponse(w, map[string]string{"run_id": "cmd-run-id"})
+	}))
+	defer server.Close()
+
+	saveStewardRunGlobals(t)
+	stewardURL = server.URL
+	stewardTLSInsecure = true
+	bundlePath = bundleFile
+	stewardRunShell = "bash"
+	stewardRunTarget = "os:linux"
+
+	output := captureStdout(t, func() {
+		err := runRunCommand(stewardRunCommandCmd, []string{"echo hello"})
+		require.NoError(t, err)
+	})
+
+	assert.Equal(t, "/api/v1/runs/command", capturedPath)
+	assert.Contains(t, output, "cmd-run-id")
+
+	// Parse the captured request body and verify it
+	var body map[string]interface{}
+	require.NoError(t, json.Unmarshal(capturedBody, &body))
+
+	// content must be base64-encoded
+	contentB64, ok := body["content"].(string)
+	require.True(t, ok, "content field must be present and a string")
+	decoded, err := base64.StdEncoding.DecodeString(contentB64)
+	require.NoError(t, err, "content must be valid base64")
+	assert.Equal(t, "echo hello", string(decoded))
+
+	// signature block must be present with all required fields
+	sigRaw, ok := body["signature"]
+	require.True(t, ok, "signature block must be present in request body")
+	sigMap, ok := sigRaw.(map[string]interface{})
+	require.True(t, ok, "signature must be a JSON object")
+	assert.Equal(t, "rsa-sha256", sigMap["algorithm"], "algorithm must be rsa-sha256 for RSA key")
+	assert.NotEmpty(t, sigMap["value"], "signature value must not be empty")
+	assert.NotEmpty(t, sigMap["public_key"], "public_key must not be empty")
+
+	// signature value must be valid base64
+	sigVal, _ := sigMap["value"].(string)
+	_, err = base64.StdEncoding.DecodeString(sigVal)
+	require.NoError(t, err, "signature value must be valid base64")
+}
+
+func TestStewardRunCommand_FailsWithoutBundleKey(t *testing.T) {
+	saveStewardRunGlobals(t)
+
+	// Redirect bundle lookup to an empty temp dir (no bundle file)
+	emptyDir := t.TempDir()
+	bundlePath = ""
+	userConfigDirFn = func() (string, error) { return emptyDir, nil }
+	systemBundlePathFn = func() string { return emptyDir + "/nonexistent.bundle.yaml" }
+	noBundle = false
+	stewardRunShell = "bash"
+
+	err := runRunCommand(stewardRunCommandCmd, []string{"echo hello"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "bundle")
+}
+
+func TestStewardRunCommand_FailsWhenBundleHasNoKey(t *testing.T) {
+	dir := t.TempDir()
+
+	// Write bundle without a private key
+	b := &certbundle.Bundle{
+		CertPEM: "cert-placeholder",
+		CAPEM:   "ca-placeholder",
+		// KeyPEM intentionally empty
+	}
+	bundleFile := dir + "/admin.bundle.yaml"
+	require.NoError(t, certbundle.Write(bundleFile, b))
+
+	saveStewardRunGlobals(t)
+	bundlePath = bundleFile
+	stewardRunShell = "bash"
+
+	err := runRunCommand(stewardRunCommandCmd, []string{"echo hello"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "private key")
+}
+
+func TestStewardRunCommand_ReadsFileWhenArgIsFilePath(t *testing.T) {
+	dir := t.TempDir()
+	bundleFile := generateTestBundleWithRSA(t, dir)
+
+	scriptFile := dir + "/script.sh"
+	require.NoError(t, writeFileContent(scriptFile, "#!/bin/bash\necho from-file"))
+
+	var capturedBody []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedBody, _ = io.ReadAll(r.Body)
+		writeRunAPIResponse(w, map[string]string{"run_id": "file-run-id"})
+	}))
+	defer server.Close()
+
+	saveStewardRunGlobals(t)
+	stewardURL = server.URL
+	stewardTLSInsecure = true
+	bundlePath = bundleFile
+	stewardRunShell = "bash"
+
+	_ = captureStdout(t, func() {
+		require.NoError(t, runRunCommand(stewardRunCommandCmd, []string{scriptFile}))
+	})
+
+	var body map[string]interface{}
+	require.NoError(t, json.Unmarshal(capturedBody, &body))
+	contentB64, _ := body["content"].(string)
+	decoded, err := base64.StdEncoding.DecodeString(contentB64)
+	require.NoError(t, err)
+	assert.Equal(t, "#!/bin/bash\necho from-file", string(decoded))
+}
+
+// writeFileContent is a test helper that writes content to path.
+func writeFileContent(path, content string) error {
+	return os.WriteFile(path, []byte(content), 0600)
+}
+
+// ---------------------------------------------------------------------------
+// run-status tests
+// ---------------------------------------------------------------------------
+
+func TestStewardRunStatus_PrintsStatusAndCounts(t *testing.T) {
+	var requestPath string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestPath = r.URL.Path
+		writeRunAPIResponse(w, map[string]interface{}{
+			"run_id":         "run-status-id",
+			"status":         "running",
+			"job_count":      3,
+			"completed_jobs": 1,
+			"failed_jobs":    0,
+		})
+	}))
+	defer server.Close()
+
+	saveStewardRunGlobals(t)
+	stewardURL = server.URL
+	stewardTLSInsecure = true
+
+	output := captureStdout(t, func() {
+		err := runRunStatus(stewardRunStatusCmd, []string{"run-status-id"})
+		require.NoError(t, err)
+	})
+
+	assert.Equal(t, "/api/v1/runs/run-status-id", requestPath)
+	assert.Contains(t, output, "running")
+	assert.Contains(t, output, "3")
+	assert.Contains(t, output, "1")
+}
+
+func TestStewardRunStatus_NotFoundReturnsError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotFound)
+		_ = json.NewEncoder(w).Encode(map[string]string{"error": "not found"})
+	}))
+	defer server.Close()
+
+	saveStewardRunGlobals(t)
+	stewardURL = server.URL
+	stewardTLSInsecure = true
+
+	err := runRunStatus(stewardRunStatusCmd, []string{"nonexistent-run"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "nonexistent-run")
+}
+
+func TestStewardRunStatus_NonOKStatusReturnsError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusInternalServerError)
+		_ = json.NewEncoder(w).Encode(map[string]string{"error": "internal error"})
+	}))
+	defer server.Close()
+
+	saveStewardRunGlobals(t)
+	stewardURL = server.URL
+	stewardTLSInsecure = true
+
+	err := runRunStatus(stewardRunStatusCmd, []string{"some-run-id"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "500")
+}
+
+// ---------------------------------------------------------------------------
+// run-result tests
+// ---------------------------------------------------------------------------
+
+func TestStewardRunResult_PrintsJobInfo(t *testing.T) {
+	var requestPath string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestPath = r.URL.Path
+		writeRunAPIResponse(w, []map[string]interface{}{
+			{
+				"job_id":       "job-001",
+				"run_id":       "run-result-id",
+				"device_id":    "device-alpha",
+				"execution_id": "exec-111",
+				"status":       "completed",
+			},
+			{
+				"job_id":    "job-002",
+				"run_id":    "run-result-id",
+				"device_id": "device-beta",
+				"status":    "pending",
+			},
+		})
+	}))
+	defer server.Close()
+
+	saveStewardRunGlobals(t)
+	stewardURL = server.URL
+	stewardTLSInsecure = true
+	stewardRunResultDevice = ""
+
+	output := captureStdout(t, func() {
+		err := runRunResult(stewardRunResultCmd, []string{"run-result-id"})
+		require.NoError(t, err)
+	})
+
+	assert.Equal(t, "/api/v1/runs/run-result-id/jobs", requestPath)
+	assert.Contains(t, output, "device-alpha")
+	assert.Contains(t, output, "device-beta")
+	assert.Contains(t, output, "completed")
+	assert.Contains(t, output, "pending")
+}
+
+func TestStewardRunResult_DeviceFilterShowsOnlyMatchingJobs(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		writeRunAPIResponse(w, []map[string]interface{}{
+			{"job_id": "job-001", "device_id": "device-alpha", "status": "completed"},
+			{"job_id": "job-002", "device_id": "device-beta", "status": "running"},
+		})
+	}))
+	defer server.Close()
+
+	saveStewardRunGlobals(t)
+	stewardURL = server.URL
+	stewardTLSInsecure = true
+	stewardRunResultDevice = "device-alpha"
+
+	output := captureStdout(t, func() {
+		err := runRunResult(stewardRunResultCmd, []string{"run-result-id"})
+		require.NoError(t, err)
+	})
+
+	assert.Contains(t, output, "device-alpha")
+	assert.NotContains(t, output, "device-beta")
+}
+
+func TestStewardRunResult_NotFoundReturnsError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotFound)
+		_ = json.NewEncoder(w).Encode(map[string]string{"error": "not found"})
+	}))
+	defer server.Close()
+
+	saveStewardRunGlobals(t)
+	stewardURL = server.URL
+	stewardTLSInsecure = true
+
+	err := runRunResult(stewardRunResultCmd, []string{"missing-run"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "missing-run")
+}
+
+// ---------------------------------------------------------------------------
+// run-cancel tests
+// ---------------------------------------------------------------------------
+
+func TestStewardRunCancel_CallsDeleteAndPrintsConfirmation(t *testing.T) {
+	var requestPath, requestMethod string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestPath = r.URL.Path
+		requestMethod = r.Method
+		writeRunAPIResponse(w, map[string]bool{"cancelled": true})
+	}))
+	defer server.Close()
+
+	saveStewardRunGlobals(t)
+	stewardURL = server.URL
+	stewardTLSInsecure = true
+
+	output := captureStdout(t, func() {
+		err := runRunCancel(stewardRunCancelCmd, []string{"cancel-run-id"})
+		require.NoError(t, err)
+	})
+
+	assert.Equal(t, http.MethodDelete, requestMethod)
+	assert.Equal(t, "/api/v1/runs/cancel-run-id", requestPath)
+	assert.Contains(t, output, "cancel-run-id")
+}
+
+func TestStewardRunCancel_NotFoundReturnsError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotFound)
+		_ = json.NewEncoder(w).Encode(map[string]string{"error": "not found"})
+	}))
+	defer server.Close()
+
+	saveStewardRunGlobals(t)
+	stewardURL = server.URL
+	stewardTLSInsecure = true
+
+	err := runRunCancel(stewardRunCancelCmd, []string{"ghost-run"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "ghost-run")
+}
+
+func TestStewardRunCancel_AlreadyTerminalReturnsError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusConflict)
+		_ = json.NewEncoder(w).Encode(map[string]string{"error": "already terminal"})
+	}))
+	defer server.Close()
+
+	saveStewardRunGlobals(t)
+	stewardURL = server.URL
+	stewardTLSInsecure = true
+
+	err := runRunCancel(stewardRunCancelCmd, []string{"done-run"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "done-run")
+}
+
+// ---------------------------------------------------------------------------
+// [REQUIRED TEST] --wait — exits 0 and prints completion summary on second poll
+// ---------------------------------------------------------------------------
+
+func TestStewardRunWait_CompletesOnSecondPoll(t *testing.T) {
+	var pollCount int32
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/runs/script":
+			writeRunAPIResponse(w, map[string]string{"run_id": "wait-run-id"})
+		case r.Method == http.MethodGet:
+			n := atomic.AddInt32(&pollCount, 1)
+			status := "running"
+			completed := 0
+			if n >= 2 {
+				status = "completed"
+				completed = 2
+			}
+			writeRunAPIResponse(w, map[string]interface{}{
+				"run_id":         "wait-run-id",
+				"status":         status,
+				"job_count":      2,
+				"completed_jobs": completed,
+				"failed_jobs":    0,
+			})
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	saveStewardRunGlobals(t)
+	stewardURL = server.URL
+	stewardTLSInsecure = true
+	stewardRunScript = "my-script"
+	stewardRunWait = true
+	stewardRunWaitTimeout = 30 * time.Second
+	runWaitPollInterval = time.Millisecond // fast for testing
+
+	output := captureStdout(t, func() {
+		err := runRunScript(stewardRunScriptCmd, []string{})
+		require.NoError(t, err)
+	})
+
+	assert.Contains(t, output, "completed", "output must contain completion status")
+	assert.GreaterOrEqual(t, atomic.LoadInt32(&pollCount), int32(2), "must poll at least twice")
+}
+
+func TestStewardRunWait_TimesOutAndReturnsError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodPost:
+			writeRunAPIResponse(w, map[string]string{"run_id": "timeout-run"})
+		default:
+			writeRunAPIResponse(w, map[string]interface{}{
+				"run_id":         "timeout-run",
+				"status":         "running",
+				"job_count":      1,
+				"completed_jobs": 0,
+				"failed_jobs":    0,
+			})
+		}
+	}))
+	defer server.Close()
+
+	saveStewardRunGlobals(t)
+	stewardURL = server.URL
+	stewardTLSInsecure = true
+	stewardRunScript = "my-script"
+	stewardRunWait = true
+	stewardRunWaitTimeout = 10 * time.Millisecond
+	runWaitPollInterval = time.Millisecond
+
+	_ = captureStdout(t, func() {
+		err := runRunScript(stewardRunScriptCmd, []string{})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "timed out")
+	})
+}
+
+// ---------------------------------------------------------------------------
+// Flag registration tests
+// ---------------------------------------------------------------------------
+
+func TestStewardRunCommandsRegistered(t *testing.T) {
+	names := map[string]bool{}
+	for _, cmd := range stewardCmd.Commands() {
+		names[cmd.Name()] = true
+	}
+	for _, want := range []string{"run-script", "run-command", "run-status", "run-result", "run-cancel"} {
+		assert.True(t, names[want], "stewardCmd must have %q subcommand", want)
+	}
+}
+
+func TestStewardRunScript_FlagsRegistered(t *testing.T) {
+	for _, flag := range []string{"target", "script", "version", "param", "wait", "skip-offline", "wait-timeout"} {
+		assert.NotNil(t, stewardRunScriptCmd.Flags().Lookup(flag), "run-script must have --%s flag", flag)
+	}
+}
+
+func TestStewardRunCommand_FlagsRegistered(t *testing.T) {
+	for _, flag := range []string{"target", "shell", "param", "wait", "skip-offline", "wait-timeout"} {
+		assert.NotNil(t, stewardRunCommandCmd.Flags().Lookup(flag), "run-command must have --%s flag", flag)
+	}
+}
+
+func TestStewardRunResult_FlagsRegistered(t *testing.T) {
+	assert.NotNil(t, stewardRunResultCmd.Flags().Lookup("device"), "run-result must have --device flag")
+}

--- a/features/controller/registration/ip_trust_evaluator.go
+++ b/features/controller/registration/ip_trust_evaluator.go
@@ -8,8 +8,8 @@ import (
 	"sync"
 	"time"
 
-	business "github.com/cfgis/cfgms/pkg/storage/interfaces/business"
 	"github.com/cfgis/cfgms/pkg/logging"
+	business "github.com/cfgis/cfgms/pkg/storage/interfaces/business"
 )
 
 const defaultIPTrustThreshold = 30 * time.Minute

--- a/features/controller/server/health_adapters.go
+++ b/features/controller/server/health_adapters.go
@@ -6,9 +6,9 @@ import (
 	"context"
 	"time"
 
-	controlplaneInterfaces "github.com/cfgis/cfgms/pkg/controlplane/interfaces"
 	"github.com/cfgis/cfgms/features/controller/heartbeat"
 	controllerRegistration "github.com/cfgis/cfgms/features/controller/registration"
+	controlplaneInterfaces "github.com/cfgis/cfgms/pkg/controlplane/interfaces"
 	"github.com/cfgis/cfgms/pkg/logging"
 	business "github.com/cfgis/cfgms/pkg/storage/interfaces/business"
 )

--- a/features/controller/server/health_adapters_test.go
+++ b/features/controller/server/health_adapters_test.go
@@ -190,9 +190,9 @@ func (s *testStewardStore) DeregisterSteward(_ context.Context, _ string) error 
 func (s *testStewardStore) GetStewardsSeen(_ context.Context, _ time.Time) ([]*business.StewardRecord, error) {
 	return nil, nil
 }
-func (s *testStewardStore) HealthCheck(_ context.Context) error  { return nil }
-func (s *testStewardStore) Initialize(_ context.Context) error   { return nil }
-func (s *testStewardStore) Close() error                         { return nil }
+func (s *testStewardStore) HealthCheck(_ context.Context) error { return nil }
+func (s *testStewardStore) Initialize(_ context.Context) error  { return nil }
+func (s *testStewardStore) Close() error                        { return nil }
 
 var _ business.StewardStore = (*testStewardStore)(nil)
 


### PR DESCRIPTION
## Summary

- Adds five async `cfg steward` subcommands for script dispatch and monitoring: `run-script`, `run-command`, `run-status`, `run-result`, `run-cancel`
- `run-command` signs inline content with the operator's mTLS bundle private key (rsa-sha256 / ecdsa-sha256) before POSTing, and fails immediately if no bundle key is available
- `--wait` polls `GET /api/v1/runs/{id}` every 5 s (overridable in tests) until all jobs reach terminal state; `--wait-timeout` defaults to 5 min
- All commands reuse `getStewardClient()` / `resolveBundleClient()` for the same auth pattern as existing steward subcommands

Fixes #1676

## Files Changed

- `cmd/cfg/cmd/steward.go` — added 5 subcommands, flag registration, and implementation (run-script, run-command, run-status, run-result, run-cancel)
- `cmd/cfg/cmd/steward_run_test.go` — 20 tests including both REQUIRED tests
- `features/controller/registration/ip_trust_evaluator.go` — pre-existing gofmt fix (not touched by story logic)
- `features/controller/server/health_adapters.go` — pre-existing gofmt fix
- `features/controller/server/health_adapters_test.go` — pre-existing gofmt fix

## Acceptance Criteria Status

- [x] `cfg steward run-script --target os:linux --script my-script` prints a UUID run ID and exits 0 (async default) — `TestStewardRunScript_AsyncReturnsRunID`
- [x] [REQUIRED TEST] `cfg steward run-command --shell bash "echo hello"` base64-encodes and includes `signature` block — `TestStewardRunCommand_SignsAndBase64Encodes`
- [x] `cfg steward run-status <run-id>` prints `Status: running`, job counts, exits 0 — `TestStewardRunStatus_PrintsStatusAndCounts`
- [x] `cfg steward run-cancel <run-id>` calls `DELETE /api/v1/runs/{run_id}` and prints confirmation — `TestStewardRunCancel_CallsDeleteAndPrintsConfirmation`
- [x] [REQUIRED TEST] `--wait` with mock server returning `status: completed` on second poll exits 0 — `TestStewardRunWait_CompletesOnSecondPoll`
- [x] `cfg steward run-command` fails fast with clear error when no bundle private key is available — `TestStewardRunCommand_FailsWithoutBundleKey`, `TestStewardRunCommand_FailsWhenBundleHasNoKey`
- [x] `make test-complete` passes

## Specialist Review Results

| Reviewer | Result | Notes |
|---|---|---|
| QA Test Runner | PASS | All 20 new tests pass; 142/142 script tests pass; pre-existing lint now fixed |
| QA Code Reviewer | PASS | Fixed global state restoration bug (`userConfigDirFn`/`systemBundlePathFn` now saved in `saveStewardRunGlobals`) |
| Security Engineer | PASS | All scans clean: security-precommit, check-architecture, security-scan all green; no hardcoded secrets, correct `pkg/cert` usage through APIClient |

🤖 Generated with [Claude Code](https://claude.ai/claude-code)