### PR TITLE
registration: gate mTLS cert issuance on approval — quarantine returns 202 with no cert (Issue #1693)

### DIFF
--- a/cmd/steward/main.go
+++ b/cmd/steward/main.go
@@ -552,9 +552,22 @@ func registerAndConnect(ctx context.Context, token string, logger logging.Logger
 	regCtx, regCancel := context.WithTimeout(ctx, 30*time.Second)
 	defer regCancel()
 
-	regResp, err := httpClient.Register(regCtx, token)
+	regResp, pendingResp, err := httpClient.Register(regCtx, token)
 	if err != nil {
 		return nil, fmt.Errorf("HTTP registration failed: %w", err)
+	}
+
+	// Issue #1693: quarantine returns 202 with no certificates. The steward cannot
+	// proceed to transport setup without certs. The poll loop is deferred to story 7;
+	// surface the pending state as a retriable error so the caller knows to retry.
+	if pendingResp != nil {
+		logger.Info("Registration is pending operator approval — no certificates issued",
+			"pending_id", pendingResp.PendingID,
+			"steward_id", pendingResp.StewardID,
+			"tenant_id", pendingResp.TenantID,
+			"status", pendingResp.Status)
+		return nil, fmt.Errorf("registration pending operator approval (pending_id=%s): administrator must run 'cfg registration approve %s'",
+			pendingResp.PendingID, pendingResp.PendingID)
 	}
 
 	logger.Info("Registration successful via HTTP",

--- a/docs/architecture/steward-operating-model.md
+++ b/docs/architecture/steward-operating-model.md
@@ -345,8 +345,11 @@ The administrator chooses which flavor fits the deployment workflow. Both arrive
 1. Administrator creates a registration token or code on the controller.
 2. Steward is started with `--regtoken <token>`.
 3. Steward contacts its compile-time controller URL (HTTPS), submits the token.
-4. Controller validates the token (perennial token: check expiry and revocation; long-lived code: look up the matching tenant/group record), applies the registration approval workflow (`auto-approve` or `manual-review`), and on approval issues mTLS certificates scoped to the steward's tenant/group identity.
-5. Steward imports the issued cert into its local `cert.Manager` (stored under the platform cert dir) for use in TLS handshakes, records the node ID, and establishes a gRPC-over-QUIC transport connection.
+4. Controller validates the token (perennial token: check expiry and revocation; long-lived code: look up the matching tenant/group record) and applies the registration approval workflow:
+   - **Approved** (HTTP 200): controller issues mTLS certificates scoped to the steward's tenant/group identity and returns the full `RegistrationResponse` with `client_cert`, `client_key`, and `ca_cert`.
+   - **Quarantined** (HTTP 202): controller returns a `RegistrationPendingResponse` with a `pending_id` and `status: "pending"`. No certificates are issued. The steward must enter a poll loop (see story 7) waiting for operator approval via `cfg registration approve <id>`.
+   - **Rejected** (HTTP 403): registration is denied; steward exits.
+5. On approval (HTTP 200): steward imports the issued cert into its local `cert.Manager` (stored under the platform cert dir) for use in TLS handshakes, records the node ID, and establishes a gRPC-over-QUIC transport connection.
 6. Steward checks for a cfg from the controller.
 7. Normal operation begins.
 

--- a/features/controller/api/handlers_registration.go
+++ b/features/controller/api/handlers_registration.go
@@ -24,7 +24,7 @@ type RegistrationRequest struct {
 	Token string `json:"token"`
 }
 
-// RegistrationResponse represents the steward registration response
+// RegistrationResponse represents the steward registration response for an approved registration.
 type RegistrationResponse struct {
 	StewardID        string `json:"steward_id"`
 	TenantID         string `json:"tenant_id"`
@@ -32,7 +32,7 @@ type RegistrationResponse struct {
 	ControllerURL    string `json:"controller_url"`
 	TransportAddress string `json:"transport_address"`
 
-	// Certificate information (optional for alpha, required for production mTLS)
+	// Certificate information (required for production mTLS)
 	ClientCert string `json:"client_cert,omitempty"`
 	ClientKey  string `json:"client_key,omitempty"`
 	CACert     string `json:"ca_cert,omitempty"`
@@ -46,15 +46,22 @@ type RegistrationResponse struct {
 	// When present, stewards should use this for config signature verification instead of ServerCert
 	// In unified mode, this is empty and ServerCert is used for both
 	SigningCert string `json:"signing_cert,omitempty"`
+}
 
-	// Issue #422: Quarantined indicates the steward has been quarantined by the approval workflow.
-	// Quarantined stewards receive certificates but are restricted to baseline configuration
-	// (no secrets, no scripts) until an administrator promotes them.
-	Quarantined bool `json:"quarantined,omitempty"`
+// RegistrationPendingResponse is returned with HTTP 202 when a registration is quarantined
+// pending operator approval. It contains no certificate fields — cert issuance is gated on
+// the approval decision (Issue #1693).
+type RegistrationPendingResponse struct {
+	PendingID string `json:"pending_id"`
+	StewardID string `json:"steward_id"`
+	TenantID  string `json:"tenant_id"`
+	Group     string `json:"group"`
+	Status    string `json:"status"`
 }
 
 // PendingRegistration represents a quarantined steward awaiting admin approval.
 type PendingRegistration struct {
+	PendingID    string    `json:"pending_id"`
 	StewardID    string    `json:"steward_id"`
 	TenantID     string    `json:"tenant_id"`
 	SourceIP     string    `json:"source_ip"`
@@ -195,10 +202,8 @@ func (s *Server) handleRegister(w http.ResponseWriter, r *http.Request) {
 		"steward_id", stewardID)
 
 	// Issue #422: Run registration approval hook.
-	// The token is consumed before the hook runs, preventing a second attempt while
-	// the hook is evaluating. Hook errors are non-fatal: we log and fall back to approve
-	// so transient failures do not block legitimate registrations.
-	quarantined := false
+	// Hook errors are non-fatal: we log and fall back to approve so transient failures
+	// do not block legitimate registrations.
 	{
 		input := RegistrationInput{
 			Token:    token,
@@ -222,13 +227,46 @@ func (s *Server) handleRegister(w http.ResponseWriter, r *http.Request) {
 				http.Error(w, "Registration rejected", http.StatusForbidden)
 				return
 			case DecisionQuarantine:
-				quarantined = true
+				// Issue #1693: quarantine returns 202 with no cert — cert issuance is gated on approval.
+				pendingID := fmt.Sprintf("pending-%d", time.Now().UnixNano())
 				s.logger.Info("Registration quarantined by approval workflow",
-					"tenant_id", token.TenantID)
+					"tenant_id", token.TenantID,
+					"pending_id", pendingID)
+				// A registry write failure is non-fatal; the steward will re-appear on re-registration.
+				if err := s.controllerService.RegisterSteward(stewardID, token.TenantID, s.getTransportAddress(), "quarantined"); err != nil {
+					s.logger.Error("Failed to register quarantined steward in controller service",
+						"steward_id", stewardID, "error", err)
+				} else {
+					s.registrationQueue.Store(stewardID, PendingRegistration{
+						PendingID:    pendingID,
+						StewardID:    stewardID,
+						TenantID:     token.TenantID,
+						SourceIP:     extractSourceIP(r),
+						RegisteredAt: time.Now().UTC(),
+					})
+				}
+				// emitRegistrationAudit calls logging.RedactedID internally; raw token is not stored
+				s.emitRegistrationAudit(r.Context(), req.Token, token.TenantID, stewardID,
+					business.AuditEventAuthentication, "registration_quarantined",
+					business.AuditResultSuccess, business.AuditSeverityHigh,
+					map[string]interface{}{"quarantined": true})
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusAccepted)
+				if err := json.NewEncoder(w).Encode(RegistrationPendingResponse{
+					PendingID: pendingID,
+					StewardID: stewardID,
+					TenantID:  token.TenantID,
+					Group:     token.Group,
+					Status:    "pending",
+				}); err != nil {
+					s.logger.Error("Failed to encode pending registration response", "error", err)
+				}
+				return
 			}
 		}
 	}
 
+	// Approve path: generate mTLS certificates and return the full registration response.
 	s.logger.Info("Steward registered successfully",
 		"steward_id", stewardID,
 		"tenant_id", token.TenantID,
@@ -329,43 +367,18 @@ func (s *Server) handleRegister(w http.ResponseWriter, r *http.Request) {
 		"steward_id", stewardID,
 		"validity_days", validityDays)
 
-	// Issue #422: Set quarantine flag on the response so the steward knows its status.
-	if quarantined {
-		resp.Quarantined = true
-	}
-
-	// Register steward in the single authoritative registry
-	initialStatus := "registered" // Initial status before first heartbeat
-	if quarantined {
-		initialStatus = "quarantined"
-	}
 	// A registry write failure is non-fatal: the steward already has valid certificates and
 	// will re-appear in the registry on its first heartbeat. Blocking the response here would
 	// leave the steward with credentials it cannot use and no way to recover without re-registering.
-	if err := s.controllerService.RegisterSteward(stewardID, token.TenantID, resp.TransportAddress, initialStatus); err != nil {
+	if err := s.controllerService.RegisterSteward(stewardID, token.TenantID, resp.TransportAddress, "registered"); err != nil {
 		s.logger.Error("Failed to register steward in controller service",
 			"steward_id", stewardID, "error", err)
-	} else if quarantined {
-		// Issue #1568: Track quarantined steward in the pending approval queue.
-		s.registrationQueue.Store(stewardID, PendingRegistration{
-			StewardID:    stewardID,
-			TenantID:     token.TenantID,
-			SourceIP:     extractSourceIP(r),
-			RegisteredAt: time.Now().UTC(),
-		})
 	}
 
-	// Emit success audit event before writing the response
-	successAction := "steward_registered"
-	var successExtras map[string]interface{}
-	if quarantined {
-		successAction = "registration_quarantined"
-		successExtras = map[string]interface{}{"quarantined": true}
-	}
 	// emitRegistrationAudit calls logging.RedactedID internally; raw token is not stored
 	s.emitRegistrationAudit(r.Context(), req.Token, token.TenantID, stewardID,
-		business.AuditEventAuthentication, successAction,
-		business.AuditResultSuccess, business.AuditSeverityHigh, successExtras)
+		business.AuditEventAuthentication, "steward_registered",
+		business.AuditResultSuccess, business.AuditSeverityHigh, nil)
 
 	// Return response
 	w.Header().Set("Content-Type", "application/json")

--- a/features/controller/api/handlers_registration_test.go
+++ b/features/controller/api/handlers_registration_test.go
@@ -515,6 +515,111 @@ func TestHandleApproveRegistration(t *testing.T) {
 	})
 }
 
+// quarantineHookForTest is a test-only RegistrationApprovalHook that always quarantines.
+type quarantineHookForTest struct{}
+
+func (*quarantineHookForTest) Evaluate(_ context.Context, _ RegistrationInput) (ApprovalDecision, string, error) {
+	return DecisionQuarantine, "test quarantine", nil
+}
+
+// rejectHookForTest is a test-only RegistrationApprovalHook that always rejects.
+type rejectHookForTest struct{}
+
+func (*rejectHookForTest) Evaluate(_ context.Context, _ RegistrationInput) (ApprovalDecision, string, error) {
+	return DecisionReject, "test rejection", nil
+}
+
+func TestHandleRegister_QuarantineReturns202NoCert(t *testing.T) {
+	tokenStore := newTestRegistrationStore(t)
+	// No cert manager: quarantine path must not reach cert generation.
+	server, auditMgr := newHandleRegisterServer(t, tokenStore, nil)
+	server.SetApprovalHook(&quarantineHookForTest{})
+
+	tok := &registration.Token{
+		Token:         "cfgms_reg_quarantine_test",
+		TenantID:      "test-tenant",
+		ControllerURL: "grpc://controller:7443",
+	}
+	require.NoError(t, tokenStore.SaveToken(context.Background(), tok))
+
+	rec := postRegister(server, "cfgms_reg_quarantine_test")
+
+	assert.Equal(t, http.StatusAccepted, rec.Code, "quarantine decision must return HTTP 202")
+
+	var pending RegistrationPendingResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &pending))
+	assert.NotEmpty(t, pending.PendingID, "pending_id must be non-empty")
+	assert.Equal(t, "test-tenant", pending.TenantID)
+	assert.Equal(t, "pending", pending.Status)
+
+	// Verify no cert fields in the raw JSON — the struct definition must not carry them.
+	var raw map[string]interface{}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &raw))
+	assert.NotContains(t, raw, "client_cert", "quarantine response must not contain client_cert")
+	assert.NotContains(t, raw, "client_key", "quarantine response must not contain client_key")
+	assert.NotContains(t, raw, "ca_cert", "quarantine response must not contain ca_cert")
+
+	// Verify the quarantine audit event was emitted.
+	require.NoError(t, auditMgr.Flush(context.Background()))
+	entries, err := auditMgr.QueryEntries(context.Background(), &business.AuditFilter{TenantID: "test-tenant"})
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+	assert.Equal(t, "registration_quarantined", entries[0].Action)
+	assert.Equal(t, string(business.AuditResultSuccess), string(entries[0].Result))
+	assert.Equal(t, string(business.AuditEventAuthentication), string(entries[0].EventType))
+}
+
+func TestHandleRegister_ApproveReturns200WithCert(t *testing.T) {
+	tokenStore := newTestRegistrationStore(t)
+	certMgr := newTestCertManager(t)
+	server, _ := newHandleRegisterServer(t, tokenStore, certMgr)
+	// Default hook approves unconditionally.
+
+	tok := &registration.Token{
+		Token:         "cfgms_reg_approve_test",
+		TenantID:      "test-tenant",
+		ControllerURL: "grpc://controller:7443",
+	}
+	require.NoError(t, tokenStore.SaveToken(context.Background(), tok))
+
+	rec := postRegister(server, "cfgms_reg_approve_test")
+
+	assert.Equal(t, http.StatusOK, rec.Code, "approve decision must return HTTP 200")
+
+	var resp RegistrationResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.NotEmpty(t, resp.ClientCert, "client_cert must be present and non-empty on approve")
+	assert.NotEmpty(t, resp.ClientKey, "client_key must be present and non-empty on approve")
+	assert.NotEmpty(t, resp.CACert, "ca_cert must be present and non-empty on approve")
+	assert.NotEmpty(t, resp.StewardID, "steward_id must be present on approve")
+	assert.Equal(t, "test-tenant", resp.TenantID)
+}
+
+func TestHandleRegister_RejectReturns403(t *testing.T) {
+	tokenStore := newTestRegistrationStore(t)
+	server, auditMgr := newHandleRegisterServer(t, tokenStore, nil)
+	server.SetApprovalHook(&rejectHookForTest{})
+
+	tok := &registration.Token{
+		Token:         "cfgms_reg_reject_test",
+		TenantID:      "test-tenant",
+		ControllerURL: "grpc://controller:7443",
+	}
+	require.NoError(t, tokenStore.SaveToken(context.Background(), tok))
+
+	rec := postRegister(server, "cfgms_reg_reject_test")
+
+	assert.Equal(t, http.StatusForbidden, rec.Code, "reject decision must return HTTP 403")
+
+	require.NoError(t, auditMgr.Flush(context.Background()))
+	entries, err := auditMgr.QueryEntries(context.Background(), &business.AuditFilter{TenantID: "test-tenant"})
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+	assert.Equal(t, "registration_rejected", entries[0].Action)
+	assert.Equal(t, string(business.AuditResultDenied), string(entries[0].Result))
+	assert.Equal(t, string(business.AuditEventSecurityEvent), string(entries[0].EventType))
+}
+
 func TestHandleDenyRegistration(t *testing.T) {
 	server, ts := newRegistrationApprovalServer(t)
 	defer ts.Close()

--- a/features/controller/registration/ip_trust_evaluator.go
+++ b/features/controller/registration/ip_trust_evaluator.go
@@ -8,8 +8,8 @@ import (
 	"sync"
 	"time"
 
-	business "github.com/cfgis/cfgms/pkg/storage/interfaces/business"
 	"github.com/cfgis/cfgms/pkg/logging"
+	business "github.com/cfgis/cfgms/pkg/storage/interfaces/business"
 )
 
 const defaultIPTrustThreshold = 30 * time.Minute

--- a/features/controller/server/health_adapters.go
+++ b/features/controller/server/health_adapters.go
@@ -6,9 +6,9 @@ import (
 	"context"
 	"time"
 
-	controlplaneInterfaces "github.com/cfgis/cfgms/pkg/controlplane/interfaces"
 	"github.com/cfgis/cfgms/features/controller/heartbeat"
 	controllerRegistration "github.com/cfgis/cfgms/features/controller/registration"
+	controlplaneInterfaces "github.com/cfgis/cfgms/pkg/controlplane/interfaces"
 	"github.com/cfgis/cfgms/pkg/logging"
 	business "github.com/cfgis/cfgms/pkg/storage/interfaces/business"
 )

--- a/features/controller/server/health_adapters_test.go
+++ b/features/controller/server/health_adapters_test.go
@@ -190,9 +190,9 @@ func (s *testStewardStore) DeregisterSteward(_ context.Context, _ string) error 
 func (s *testStewardStore) GetStewardsSeen(_ context.Context, _ time.Time) ([]*business.StewardRecord, error) {
 	return nil, nil
 }
-func (s *testStewardStore) HealthCheck(_ context.Context) error  { return nil }
-func (s *testStewardStore) Initialize(_ context.Context) error   { return nil }
-func (s *testStewardStore) Close() error                         { return nil }
+func (s *testStewardStore) HealthCheck(_ context.Context) error { return nil }
+func (s *testStewardStore) Initialize(_ context.Context) error  { return nil }
+func (s *testStewardStore) Close() error                        { return nil }
 
 var _ business.StewardStore = (*testStewardStore)(nil)
 

--- a/features/steward/registration/client_http.go
+++ b/features/steward/registration/client_http.go
@@ -23,7 +23,7 @@ type RegistrationRequest struct {
 	Token string `json:"token"`
 }
 
-// RegistrationResponse represents the response from the controller.
+// RegistrationResponse represents the response from the controller for an approved registration.
 type RegistrationResponse struct {
 	Success       bool   `json:"success"`
 	StewardID     string `json:"steward_id,omitempty"`
@@ -48,6 +48,17 @@ type RegistrationResponse struct {
 	// Story #377: Dedicated config signing certificate (separated architecture)
 	// When present, steward should prefer this for config signature verification
 	SigningCert string `json:"signing_cert,omitempty"`
+}
+
+// RegistrationPendingResponse is returned by the controller with HTTP 202 when a registration
+// is quarantined pending operator approval. It contains no certificate fields (Issue #1693).
+// Callers must check whether Register returned a pending response and enter a poll loop (story 7).
+type RegistrationPendingResponse struct {
+	PendingID string `json:"pending_id"`
+	StewardID string `json:"steward_id"`
+	TenantID  string `json:"tenant_id"`
+	Group     string `json:"group"`
+	Status    string `json:"status"`
 }
 
 // HTTPClient handles steward registration via REST API
@@ -110,35 +121,36 @@ func NewHTTPClient(cfg *HTTPConfig) (*HTTPClient, error) {
 	}, nil
 }
 
-// Register registers the steward with the controller using a registration token
-func (c *HTTPClient) Register(ctx context.Context, token string) (*RegistrationResponse, error) {
-	// Build registration URL
+// Register registers the steward with the controller using a registration token.
+//
+// Returns (*RegistrationResponse, nil, nil) on HTTP 200 (approved).
+// Returns (nil, *RegistrationPendingResponse, nil) on HTTP 202 (quarantined, pending approval).
+// Returns (nil, nil, error) on any other status or transport failure.
+// Callers must distinguish the pending case and enter a poll loop (story 7).
+func (c *HTTPClient) Register(ctx context.Context, token string) (*RegistrationResponse, *RegistrationPendingResponse, error) {
 	registrationURL := fmt.Sprintf("%s/api/v1/register", c.controllerURL)
 
-	// Create request body
 	reqBody := RegistrationRequest{
 		Token: token,
 	}
 
 	jsonBody, err := json.Marshal(reqBody)
 	if err != nil {
-		return nil, fmt.Errorf("failed to marshal registration request: %w", err)
+		return nil, nil, fmt.Errorf("failed to marshal registration request: %w", err)
 	}
 
-	// Create HTTP request
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, registrationURL, bytes.NewBuffer(jsonBody))
 	if err != nil {
-		return nil, fmt.Errorf("failed to create HTTP request: %w", err)
+		return nil, nil, fmt.Errorf("failed to create HTTP request: %w", err)
 	}
 
 	req.Header.Set("Content-Type", "application/json")
 
 	c.logger.Info("Sending registration request to controller", "url", registrationURL)
 
-	// Send request
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
-		return nil, fmt.Errorf("failed to send registration request: %w", err)
+		return nil, nil, fmt.Errorf("failed to send registration request: %w", err)
 	}
 	defer func() {
 		if closeErr := resp.Body.Close(); closeErr != nil {
@@ -146,27 +158,35 @@ func (c *HTTPClient) Register(ctx context.Context, token string) (*RegistrationR
 		}
 	}()
 
-	// Read response body
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return nil, fmt.Errorf("failed to read response body: %w", err)
+		return nil, nil, fmt.Errorf("failed to read response body: %w", err)
 	}
 
-	// Check status code
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("registration failed with status %d: %s", resp.StatusCode, string(body))
+	switch resp.StatusCode {
+	case http.StatusOK:
+		var regResp RegistrationResponse
+		if err := json.Unmarshal(body, &regResp); err != nil {
+			return nil, nil, fmt.Errorf("failed to parse registration response: %w", err)
+		}
+		c.logger.Info("Registration successful",
+			"steward_id", regResp.StewardID,
+			"tenant_id", regResp.TenantID,
+			"group", regResp.Group)
+		return &regResp, nil, nil
+
+	case http.StatusAccepted:
+		var pending RegistrationPendingResponse
+		if err := json.Unmarshal(body, &pending); err != nil {
+			return nil, nil, fmt.Errorf("failed to parse pending registration response: %w", err)
+		}
+		c.logger.Info("Registration pending operator approval",
+			"pending_id", pending.PendingID,
+			"steward_id", pending.StewardID,
+			"tenant_id", pending.TenantID)
+		return nil, &pending, nil
+
+	default:
+		return nil, nil, fmt.Errorf("registration failed with status %d: %s", resp.StatusCode, string(body))
 	}
-
-	// Parse response
-	var regResp RegistrationResponse
-	if err := json.Unmarshal(body, &regResp); err != nil {
-		return nil, fmt.Errorf("failed to parse registration response: %w", err)
-	}
-
-	c.logger.Info("Registration successful",
-		"steward_id", regResp.StewardID,
-		"tenant_id", regResp.TenantID,
-		"group", regResp.Group)
-
-	return &regResp, nil
 }

--- a/features/steward/registration/client_http_test.go
+++ b/features/steward/registration/client_http_test.go
@@ -3,8 +3,10 @@
 package registration
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"testing"
@@ -14,6 +16,81 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// TestRegister_202_ReturnsPendingResponse verifies that the real HTTPClient (the CFGMS component
+// under test) correctly parses a 202 Accepted response and returns a non-nil
+// *RegistrationPendingResponse with PendingID populated. The httptest.Server is a standard
+// Go HTTP fixture — not a mock of a CFGMS component — used here because the steward package
+// cannot import the controller package without inverting the dependency direction.
+func TestRegister_202_ReturnsPendingResponse(t *testing.T) {
+	pending := RegistrationPendingResponse{
+		PendingID: "pending-1234567890",
+		StewardID: "steward-abc",
+		TenantID:  "test-tenant",
+		Group:     "prod",
+		Status:    "pending",
+	}
+	body, err := json.Marshal(pending)
+	require.NoError(t, err)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusAccepted)
+		_, _ = w.Write(body)
+	}))
+	defer srv.Close()
+
+	client, err := NewHTTPClient(&HTTPConfig{
+		ControllerURL: srv.URL,
+		Logger:        logging.NewLogger("debug"),
+	})
+	require.NoError(t, err)
+
+	regResp, pendingResp, err := client.Register(context.Background(), "test-token")
+	require.NoError(t, err)
+	assert.Nil(t, regResp, "RegistrationResponse must be nil on 202")
+	require.NotNil(t, pendingResp, "RegistrationPendingResponse must be non-nil on 202")
+	assert.Equal(t, "pending-1234567890", pendingResp.PendingID, "PendingID must be populated")
+	assert.Equal(t, "test-tenant", pendingResp.TenantID)
+	assert.Equal(t, "pending", pendingResp.Status)
+}
+
+// TestRegister_ErrorStatus_ReturnsError verifies that the HTTP client surfaces a non-nil
+// error when the controller returns a non-200/202 status (e.g., 403 Forbidden on reject,
+// 401 Unauthorized on invalid token). Neither RegistrationResponse nor
+// RegistrationPendingResponse should be returned.
+func TestRegister_ErrorStatus_ReturnsError(t *testing.T) {
+	cases := []struct {
+		name       string
+		statusCode int
+		body       string
+	}{
+		{name: "403 Forbidden", statusCode: http.StatusForbidden, body: "Registration rejected\n"},
+		{name: "401 Unauthorized", statusCode: http.StatusUnauthorized, body: "Invalid or expired registration token\n"},
+		{name: "500 InternalServerError", statusCode: http.StatusInternalServerError, body: "Server misconfiguration\n"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				http.Error(w, tc.body, tc.statusCode)
+			}))
+			defer srv.Close()
+
+			client, err := NewHTTPClient(&HTTPConfig{
+				ControllerURL: srv.URL,
+				Logger:        logging.NewLogger("debug"),
+			})
+			require.NoError(t, err)
+
+			regResp, pendingResp, err := client.Register(context.Background(), "test-token")
+			require.Error(t, err, "non-200/202 status must return an error")
+			assert.Nil(t, regResp, "RegistrationResponse must be nil on error status")
+			assert.Nil(t, pendingResp, "RegistrationPendingResponse must be nil on error status")
+			assert.Contains(t, err.Error(), "registration failed with status")
+		})
+	}
+}
 
 // TestRegistrationResponse_JSONFieldNames is a regression guard that ensures
 // the wire format of RegistrationResponse has not changed. The JSON field names


### PR DESCRIPTION
## Summary

- `POST /api/v1/register` with a quarantine decision now returns HTTP 202 with `RegistrationPendingResponse` (fields: `pending_id`, `steward_id`, `tenant_id`, `group`, `status: "pending"`). No certificate fields exist in the struct definition — cert issuance is structurally gated on the approval decision.
- `Quarantined bool` removed from `RegistrationResponse`; the quarantine signal is the 202 status code plus the distinct response struct.
- Approved registrations (HTTP 200) are unchanged: full mTLS bundle returned.
- Steward HTTP client `Register` returns `(*RegistrationResponse, *RegistrationPendingResponse, error)` — callers must distinguish pending from success.
- Steward binary surfaces HTTP 202 as a named retriable error until the poll loop lands in story 7.

Fixes #1693

## Specialist Review Results

**QA Test Runner: PASS** — 130+ packages, 146 script tests, lint, license headers, architecture compliance, security scan, integration tests, cross-platform build (linux/amd64, linux/arm64, darwin/amd64, darwin/arm64, windows/amd64) all passed.

**QA Code Reviewer: PASS** — No blocking issues. Three required tests verified: `TestHandleRegister_QuarantineReturns202NoCert` (202, absent cert fields, audit event), `TestHandleRegister_ApproveReturns200WithCert` (200, cert fields present), `TestHandleRegister_RejectReturns403` (403, audit event). Steward client tests cover 200, 202, and error branches. Two pre-existing warnings in unrelated files (not introduced by this story).

**Security Engineer: PASS** — Cert issuance structurally unreachable from the quarantine path (verified by code path analysis and by running with `certMgr == nil`). `RegistrationPendingResponse` struct has zero cert fields. No information disclosure, no tenant isolation regression. Automated scans: gosec PASS, Trivy PASS, Nancy PASS, staticcheck PASS, architecture compliance PASS.

## Test plan

- [ ] `TestHandleRegister_QuarantineReturns202NoCert` — 202, `pending_id` non-empty, no cert fields in raw JSON, audit event `registration_quarantined`
- [ ] `TestHandleRegister_ApproveReturns200WithCert` — 200, `client_cert`/`client_key`/`ca_cert` all non-empty
- [ ] `TestHandleRegister_RejectReturns403` — 403, audit event `registration_rejected`/`AuditResultDenied`
- [ ] `TestRegister_202_ReturnsPendingResponse` — steward client returns `*RegistrationPendingResponse` with `PendingID` non-empty
- [ ] `TestRegister_ErrorStatus_ReturnsError` — table-driven 403/401/500, nil response structs, error message contains "registration failed with status"
- [ ] `make test-agent-complete` — all gates green

🤖 Generated with [Claude Code](https://claude.com/claude-code)