### PR TITLE
docs/legal: amend CLA to v2.0 with license-discretion and AI-contribution language (Issue #1744)

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -8,7 +8,7 @@ By adding your name to this file as part of your contribution, you indicate your
 
 The CLA:
 - Assigns copyright in your contributions to Jordan Ritz (current copyright holder)
-- Allows your contributions to be licensed under both Apache License 2.0 and Elastic License 2.0
+- Allows your contributions to be licensed under any license selected by the Copyright Holder at its sole discretion, including AGPL-3.0 and private commercial licenses
 - Provides for future assignment to cfg.is entity when formed
 - Protects both you and the project
 
@@ -42,8 +42,8 @@ Format: `- [Company Name] (authorized by [Name] <email>) - YYYY-MM-DD`
 
 - **Total Individual Contributors**: 1
 - **Total Corporate Contributors**: 0
-- **CLA Version**: 1.0
-- **Last Updated**: 2026-01-10
+- **CLA Version**: 2.0
+- **Last Updated**: 2026-05-22
 
 ---
 

--- a/docs/legal/CLA-ENFORCEMENT.md
+++ b/docs/legal/CLA-ENFORCEMENT.md
@@ -132,13 +132,13 @@ For future contributions with code or substantial documentation changes, you'll 
 
 If a contributor doesn't want to sign the CLA:
 
-1. Politely explain why we need it (dual-license model, copyright clarity)
+1. Politely explain why we need it (copyright assignment enables AGPL-3.0 enforcement and license discretion)
 2. Point them to the FAQ: [docs/legal/README.md#faq](../docs/legal/README.md#faq)
 3. If they still refuse, close the PR with thanks
 
 **Example response:**
 ```markdown
-We understand CLAs aren't for everyone. CFGMS requires a CLA to support our dual-license model (Apache 2.0 + Elastic License 2.0).
+We understand CLAs aren't for everyone. CFGMS requires a CLA to support copyright assignment, which enables enforcement of AGPL-3.0 obligations and outbound license discretion.
 
 If you'd prefer not to sign the CLA, we won't be able to merge this PR. However, we appreciate you reporting the issue/suggesting the improvement!
 
@@ -253,5 +253,5 @@ For complex cases or legal questions, consult with project leadership.
 
 ---
 
-**Last Updated:** 2026-01-10
-**Version:** 1.0
+**Last Updated:** 2026-05-22
+**Version:** 2.0

--- a/docs/legal/CLA.md
+++ b/docs/legal/CLA.md
@@ -1,8 +1,19 @@
 # CFGMS Contributor License Agreement
 
-**Version 1.0 - Effective January 2026**
+**Version 2.0 - Effective 2026-05-22**
 
 Thank you for your interest in contributing to CFGMS (the "Project"). This Contributor License Agreement ("Agreement") documents the intellectual property rights granted by contributors to Jordan Ritz ("Copyright Holder").
+
+<!-- §1 retains full copyright assignment rather than a license grant because AGPL-3.0
+     enforcement against third parties requires the Copyright Holder to hold standing
+     as the copyright owner. A bare license grant is insufficient to bring infringement
+     actions or compel source disclosure under the AGPL copyleft provisions. -->
+
+## Amendment Notice (per §12)
+
+This Agreement is amended effective 2026-05-22 to reflect the Project's adoption of AGPL-3.0 as its single in-repository license. §3 and §4 have been replaced with broadened license-discretion language; §5 has been expanded to include AI-assisted contribution disclosure requirements. All other terms remain in effect.
+
+---
 
 ## Purpose
 
@@ -15,8 +26,6 @@ This Agreement clarifies the intellectual property license granted with Contribu
 **"Contribution"** means any original work of authorship, including any modifications or additions to an existing work, that is intentionally submitted by You to the Copyright Holder for inclusion in, or documentation of, the Project. This includes source code, documentation, configuration files, build scripts, and any other materials.
 
 **"Submit"** means any form of electronic, verbal, or written communication sent to the Copyright Holder or its representatives, including but not limited to communication on electronic mailing lists, source code control systems, and issue tracking systems.
-
-**"Dual-License Model"** means the Project's licensing structure where certain components are licensed under the Apache License 2.0 (open source) and other components are licensed under the Elastic License 2.0 (commercial/source-available).
 
 ## Terms and Conditions
 
@@ -33,7 +42,7 @@ This assignment includes, without limitation:
 
 ### 2. Future Entity Assignment
 
-You acknowledge and agree that Jordan Ritz may assign all rights granted under this Agreement to cfg.is (or any successor legal entity formed to manage the Project), and such assignment includes all rights necessary for dual-license distribution.
+You acknowledge and agree that Jordan Ritz may assign all rights granted under this Agreement to cfg.is (or any successor legal entity formed to manage the Project), and such assignment includes all rights necessary for the Copyright Holder to license the Project.
 
 When such assignment occurs:
 - The new entity (cfg.is) will become the Copyright Holder
@@ -41,19 +50,13 @@ When such assignment occurs:
 - You will be notified via the Project's communication channels
 - No additional signature or consent from You will be required
 
-### 3. Dual-License Awareness and Grant
+### 3. License Discretion
 
-You understand and agree that Your Contribution may be distributed under **both** of the following licenses, at the Copyright Holder's discretion:
-
-**a) Apache License 2.0** - For open source components of the Project
-
-**b) Elastic License 2.0** - For commercial/source-available components of the Project
-
-You grant the Copyright Holder the perpetual, irrevocable right to determine which license applies to any portion of Your Contribution, and to change that determination in the future.
+You understand and agree that Your Contribution may be distributed under any license selected by the Copyright Holder at its sole discretion, including without limitation the Apache License 2.0, the GNU Affero General Public License v3.0, or a private commercial license. You grant the Copyright Holder the perpetual, irrevocable right to determine which license applies to any portion of Your Contribution.
 
 ### 4. Patent Grant
 
-If Your Contribution includes any patents (now or in the future), You hereby grant to the Copyright Holder and to recipients of software distributed by the Copyright Holder a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable patent license to make, have made, use, offer to sell, sell, import, and otherwise transfer Your Contribution under both licenses described in Section 3.
+If Your Contribution includes any patents (now or in the future), You hereby grant to the Copyright Holder and to recipients of software distributed by the Copyright Holder a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable patent license to make, have made, use, offer to sell, sell, import, and otherwise transfer Your Contribution under any license applied to the Project.
 
 ### 5. Your Representations and Warranties
 
@@ -71,6 +74,11 @@ You represent and warrant that:
 **d) No Conflicting Obligations**: You are not subject to any agreement or obligation that would prevent You from entering into this Agreement or making Your Contributions.
 
 **e) Compliance with Laws**: Your Contribution complies with all applicable laws and regulations, including export control laws.
+
+**f) AI-Assisted Contributions**: If Your Contribution was wholly or substantially generated by AI tooling (including but not limited to large language models, code generation systems, or similar automated tools), You represent that:
+   - You have disclosed this fact to the Copyright Holder by including a note in the pull request or commit message (e.g., "Generated with assistance from [tool name]")
+   - You have reviewed the AI-generated content in full and take personal responsibility for its accuracy, originality, and compliance with this Agreement
+   - To the best of Your knowledge, the Contribution does not reproduce third-party training data or other copyrighted material in a manner that would conflict with the copyright assignment made in Section 1
 
 ### 6. Notification of Issues
 
@@ -150,7 +158,7 @@ If You have questions about this Agreement, please:
 
 ## Acknowledgment for Use of Standard Language
 
-This CLA is based on standard contributor license agreements used in open source projects, including the Apache Software Foundation CLA and Project Harmony templates, adapted for CFGMS's dual-license model.
+This CLA is based on standard contributor license agreements used in open source projects, including the Apache Software Foundation CLA and Project Harmony templates, adapted for CFGMS's license management model.
 
 ---
 
@@ -162,5 +170,5 @@ https://github.com/cfg-is/cfgms
 
 ---
 
-**Last Updated:** January 10, 2026
-**Version:** 1.0
+**Last Updated:** 2026-05-22
+**Version:** 2.0

--- a/docs/legal/README.md
+++ b/docs/legal/README.md
@@ -12,13 +12,13 @@ The formal legal agreement that contributors must accept before their contributi
 
 When you contribute to CFGMS, you agree to:
 1. **Assign copyright** to Jordan Ritz (current copyright holder)
-2. **Allow dual-licensing** of your contributions under both Apache 2.0 (OSS) and Elastic License 2.0 (commercial)
+2. **Allow outbound licensing** of your contributions under any license selected by the Copyright Holder at its sole discretion, including AGPL-3.0 and private commercial licenses
 3. **Future transfer** to cfg.is entity when it's formed
 4. **Certify** that your contribution is original work and doesn't violate anyone else's rights
 
 **Why do we need this?**
-- CFGMS has both open source (Apache 2.0) and commercial (Elastic 2.0) components
-- Clear copyright ownership is needed to enforce license terms
+- CFGMS is licensed under AGPL-3.0; clear copyright ownership is needed to enforce the license terms
+- Copyright assignment enables the Copyright Holder to exercise outbound license discretion
 - Protects both contributors and the project from legal issues
 
 **How to sign:**
@@ -28,31 +28,21 @@ Add your name to [CONTRIBUTORS.md](../../CONTRIBUTORS.md) in your first Pull Req
 
 ## Why a CLA?
 
-### Dual-License Model
+### AGPL-3.0 Single License
 
-CFGMS uses a dual-license model:
+CFGMS is distributed under the GNU Affero General Public License v3.0 (AGPL-3.0). The CLA ensures the Copyright Holder can:
 
-**Apache License 2.0** (Open Source)
-- Core platform features
-- Standard modules and plugins
-- Development tools
-- Located in: `cmd/`, `pkg/`, `features/`, `api/`
-
-**Elastic License 2.0** (Source-Available, Commercial)
-- High-availability features
-- Enterprise management capabilities
-- Advanced failover and clustering
-- Located in: `commercial/ha/`
-
-The CLA ensures contributions can be used under both licenses as appropriate.
+- Enforce the AGPL-3.0 copyleft requirements against third parties who violate source-disclosure obligations
+- Exercise outbound license discretion — including the right to apply a private commercial license to contributions where appropriate
+- Maintain clean copyright ownership across all contributions as the project grows
 
 ### Copyright Assignment
 
 Why assign copyright instead of just granting a license?
 
-1. **License Enforcement**: Only the copyright holder can enforce license violations (e.g., if someone violates the "no hosted service" restriction in Elastic License 2.0)
+1. **License Enforcement**: Only the copyright holder can enforce license violations (e.g., if someone fails to provide source code as required by AGPL-3.0)
 
-2. **Dual-License Management**: Allows flexibility to include contributions in either Apache 2.0 or Elastic 2.0 components
+2. **Outbound License Discretion**: Allows the Copyright Holder to determine the outbound license for any portion of the codebase without requiring contributor approval
 
 3. **Future Entity Formation**: Simplifies transfer when cfg.is becomes a legal entity
 
@@ -60,12 +50,12 @@ Why assign copyright instead of just granting a license?
 
 ### Similar Projects
 
-Many dual-license and commercial open source projects use CLAs with copyright assignment:
+Many open source and commercial open source projects use CLAs with copyright assignment:
 
-- **Elasticsearch** (Apache 2.0 + Elastic License) - Uses CLA
 - **MongoDB** (SSPL) - Uses CLA
 - **GitLab** (MIT + Enterprise) - Uses CLA
 - **Sentry** (BSL + Enterprise) - Uses CLA
+- **HashiCorp** (BSL) - Uses CLA
 
 ---
 
@@ -89,8 +79,7 @@ If your employer has rights to code you write, you need their permission to cont
 
 **If you're concerned about this:**
 - Consult a lawyer in your jurisdiction
-- Consider whether CFGMS's dual-license model aligns with your goals
-- Note that open source components remain Apache 2.0 licensed (permissive)
+- Consider whether CFGMS's license model aligns with your goals
 
 ### What happens when cfg.is is formed?
 
@@ -110,10 +99,10 @@ Yes, the copyright holder can update the CLA. If changes are made:
 ### What if I don't want to sign?
 
 That's okay! You can still:
-- Use CFGMS (under Apache 2.0 for OSS components, Elastic 2.0 for commercial)
+- Use CFGMS (under AGPL-3.0)
 - Report bugs and issues
 - Participate in discussions
-- Fork the project (under the respective licenses)
+- Fork the project (under AGPL-3.0)
 
 You just can't have your code merged into the official repository without signing the CLA.
 
@@ -161,4 +150,4 @@ If you have questions about your legal rights or obligations, consult an attorne
 
 ---
 
-**Last Updated:** 2026-01-10
+**Last Updated:** 2026-05-22


### PR DESCRIPTION
## Summary

- Amends `docs/legal/CLA.md` to Version 2.0 (effective 2026-05-22): removes "Dual-License Model" definition, rewrites §2/§3/§4 for AGPL-3.0 single-license posture with broadened outbound license discretion, adds §5(f) AI-assisted contribution disclosure clause, and adds §12 amendment notice
- Updates `docs/legal/CLA-ENFORCEMENT.md` and `docs/legal/README.md` to remove all dual-license framing and reference CLA v2.0
- Updates `CONTRIBUTORS.md` preamble to reference CLA v2.0

Fixes #1744

## Acceptance Criteria Verification

- [x] `docs/legal/CLA.md` is Version 2.0 with effective date 2026-05-22 and amendment notice per §12
- [x] No surviving reference to "Dual-License Model" in `docs/legal/` — `grep` returns 0 results
- [x] No surviving reference to "Elastic License 2.0" in `docs/legal/` — `grep` returns 0 results
- [x] §3 explicitly authorizes any license at Copyright Holder's discretion, naming AGPL-3.0 and private commercial license
- [x] §5(f) contains AI-assisted contribution disclosure covering: (a) disclosure in PR/commit, (b) review responsibility, (c) training-data conflict representation
- [x] All four in-scope docs updated

## Specialist Review Results

| Reviewer | Result | Notes |
|----------|--------|-------|
| qa-test-runner | **PASS** | All unit/integration/build tests pass; Docker-dependent tests deferred to CI as expected |
| qa-code-reviewer | **PASS** | All 7 acceptance criteria verified against file contents; zero blocking issues |
| security-engineer | **PASS** | gitleaks/truffleHog clean, architecture check clean, no Go files modified |

## Test Plan

- [ ] Verify `grep -r "Dual-License Model" docs/legal/` returns no results
- [ ] Verify `grep -r "Elastic License 2.0" docs/legal/` returns no results
- [ ] Confirm `docs/legal/CLA.md` header shows Version 2.0 / 2026-05-22
- [ ] Confirm §3 grants license discretion including AGPL-3.0
- [ ] Confirm §5(f) AI-assisted contribution clause is present
- [ ] CI required checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)