### PR TITLE
workflow: introduce ModuleLoader interface and NullModuleFactory (Issue #1756)

### DIFF
--- a/features/workflow/engine.go
+++ b/features/workflow/engine.go
@@ -13,7 +13,6 @@ import (
 	"gopkg.in/yaml.v3"
 
 	"github.com/cfgis/cfgms/features/modules"
-	"github.com/cfgis/cfgms/features/steward/factory"
 	"github.com/cfgis/cfgms/pkg/logging"
 )
 
@@ -32,7 +31,7 @@ type TransformStepExecutor interface {
 
 // Engine implements the WorkflowEngine interface
 type Engine struct {
-	moduleFactory     *factory.ModuleFactory
+	moduleFactory     ModuleLoader
 	logger            *logging.ModuleLogger
 	executions        map[string]*WorkflowExecution
 	workflows         map[string]Workflow
@@ -48,7 +47,7 @@ type Engine struct {
 // NewEngine creates a new workflow engine instance.
 // transformExecutor handles StepTypeTransform steps; pass nil if transform steps
 // are not used (executeStep will return an error for any transform step encountered).
-func NewEngine(moduleFactory *factory.ModuleFactory, logger logging.Logger, transformExecutor TransformStepExecutor) *Engine {
+func NewEngine(moduleFactory ModuleLoader, logger logging.Logger, transformExecutor TransformStepExecutor) *Engine {
 	// Create module logger for structured workflow logging
 	workflowLogger := logging.ForModule("workflow").WithField("component", "engine")
 

--- a/features/workflow/module_loader.go
+++ b/features/workflow/module_loader.go
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+package workflow
+
+import (
+	"fmt"
+
+	"github.com/cfgis/cfgms/features/modules"
+)
+
+// ModuleLoader creates module instances by name for use by the workflow engine.
+// Placing this interface here (rather than in features/modules/) keeps it
+// workflow-internal — only Engine consumes it, so no central-provider
+// interfaces/ subdirectory is required.
+type ModuleLoader interface {
+	CreateModuleInstance(moduleName string) (modules.Module, error)
+}
+
+// NullModuleFactory is a ModuleLoader for contexts (e.g. the controller) where
+// steward modules must not be loaded.  Every call returns an error.
+type NullModuleFactory struct{}
+
+// NewNullModuleFactory returns a ModuleLoader that rejects every module name.
+func NewNullModuleFactory() ModuleLoader {
+	return &NullModuleFactory{}
+}
+
+// CreateModuleInstance always returns an error documenting that the controller
+// workflow engine does not load steward modules.
+func (n *NullModuleFactory) CreateModuleInstance(moduleName string) (modules.Module, error) {
+	return nil, fmt.Errorf("controller workflow engine does not load steward modules: %s", moduleName)
+}

--- a/features/workflow/module_loader_test.go
+++ b/features/workflow/module_loader_test.go
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+package workflow
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNullModuleFactory_CreateModuleInstance_ReturnsError(t *testing.T) {
+	moduleName := "any-module"
+	loader := NewNullModuleFactory()
+	module, err := loader.CreateModuleInstance(moduleName)
+
+	require.Error(t, err)
+	assert.Nil(t, module)
+	assert.Contains(t, err.Error(), moduleName)
+}


### PR DESCRIPTION
## Summary

- Defines a `ModuleLoader` interface in `features/workflow/module_loader.go` with a single method `CreateModuleInstance(moduleName string) (modules.Module, error)`, keeping it workflow-internal (only `Engine` consumes it).
- Adds `NullModuleFactory` (exported constructor `NewNullModuleFactory() ModuleLoader`) that returns an error for every module name, documenting that the controller workflow engine does not load steward modules.
- Updates `features/workflow/engine.go` to use `ModuleLoader` instead of `*factory.ModuleFactory`, removing the `features/steward/factory` import.

The existing `*factory.ModuleFactory` structurally satisfies `ModuleLoader` so `features/workflow/integration.go` and all `engine_test.go` usages compile without any changes.

Fixes #1756

## Specialist Review Results

### QA Test Runner: PASS
- All quality validation gates passed (100+ packages, race detection, cross-platform builds linux/darwin/windows amd64+arm64, integration tests, linting, license headers)
- 0 test failures

### QA Code Reviewer: PASS
- 0 blocking issues, 0 warnings
- New test covers the only code path in `NullModuleFactory` with three active assertions (error non-nil, module nil, message contains module name)
- No mocks, no t.Skip(), no error swallowing

### Security Engineer: PASS
- security-precommit: PASS
- check-architecture: PASS (no central provider violations)
- security-scan: PASS (Trivy, Nancy, gosec, staticcheck)
- No hardcoded secrets, no information disclosure, secure-by-default design (fails closed)

## Test plan

- [x] `go list -deps ./features/workflow/engine.go | grep steward/factory` returns empty
- [x] `features/workflow/module_loader_test.go` passes: `NewNullModuleFactory().CreateModuleInstance("any-module")` returns non-nil error containing the module name
- [x] All existing workflow tests pass unchanged
- [x] `make test-agent-complete` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)