### PR TITLE
config: create features/config/stewardtypes shared package (Issue #1755)

### DIFF
--- a/features/config/stewardtypes/stewardtypes_test.go
+++ b/features/config/stewardtypes/stewardtypes_test.go
@@ -1,0 +1,255 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+
+package stewardtypes
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateConfiguration_ValidConfig(t *testing.T) {
+	cfg := StewardConfig{
+		Steward: StewardSettings{
+			ID:   "test-steward",
+			Mode: ModeStandalone,
+			Logging: LoggingConfig{
+				Level:  "info",
+				Format: "text",
+			},
+		},
+		Resources: []ResourceConfig{
+			{
+				Name:   "test-resource",
+				Module: "test-module",
+				Config: map[string]interface{}{"key": "value"},
+			},
+		},
+	}
+	assert.NoError(t, ValidateConfiguration(cfg))
+}
+
+func TestValidateConfiguration_MissingID(t *testing.T) {
+	cfg := StewardConfig{
+		Steward: StewardSettings{
+			Mode:    ModeStandalone,
+			Logging: LoggingConfig{Level: "info"},
+		},
+	}
+	err := ValidateConfiguration(cfg)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "ID")
+}
+
+func TestValidateConfiguration_InvalidLogLevel(t *testing.T) {
+	cfg := StewardConfig{
+		Steward: StewardSettings{
+			ID:      "test-steward",
+			Mode:    ModeStandalone,
+			Logging: LoggingConfig{Level: "verbose"},
+		},
+	}
+	err := ValidateConfiguration(cfg)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "log level")
+}
+
+func TestValidateConfiguration_InvalidOperationMode(t *testing.T) {
+	cfg := StewardConfig{
+		Steward: StewardSettings{
+			ID:      "test-steward",
+			Mode:    "distributed",
+			Logging: LoggingConfig{Level: "info"},
+		},
+	}
+	err := ValidateConfiguration(cfg)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "operation mode")
+}
+
+func TestValidateConfiguration_EmptyLogLevelValid(t *testing.T) {
+	// Empty log level is valid — applyDefaults fills in "info"
+	cfg := StewardConfig{
+		Steward: StewardSettings{
+			ID:   "test-steward",
+			Mode: ModeController,
+		},
+	}
+	assert.NoError(t, ValidateConfiguration(cfg))
+}
+
+func TestValidateConfiguration_ResourceMissingName(t *testing.T) {
+	cfg := StewardConfig{
+		Steward: StewardSettings{
+			ID:   "test-steward",
+			Mode: ModeStandalone,
+		},
+		Resources: []ResourceConfig{
+			{Module: "mod", Config: map[string]interface{}{"k": "v"}},
+		},
+	}
+	err := ValidateConfiguration(cfg)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "name")
+}
+
+func TestValidateConfiguration_ResourceMissingModule(t *testing.T) {
+	cfg := StewardConfig{
+		Steward: StewardSettings{
+			ID:   "test-steward",
+			Mode: ModeStandalone,
+		},
+		Resources: []ResourceConfig{
+			{Name: "r1", Config: map[string]interface{}{"k": "v"}},
+		},
+	}
+	err := ValidateConfiguration(cfg)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "module")
+}
+
+func TestValidateConfiguration_DuplicateResourceNames(t *testing.T) {
+	cfg := StewardConfig{
+		Steward: StewardSettings{
+			ID:   "test-steward",
+			Mode: ModeStandalone,
+		},
+		Resources: []ResourceConfig{
+			{Name: "dup", Module: "m1", Config: map[string]interface{}{"k": "v"}},
+			{Name: "dup", Module: "m2", Config: map[string]interface{}{"k": "v"}},
+		},
+	}
+	err := ValidateConfiguration(cfg)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "duplicate")
+}
+
+func TestValidateConfiguration_ConvergeIntervalInvalid(t *testing.T) {
+	cfg := StewardConfig{
+		Steward: StewardSettings{
+			ID:               "test-steward",
+			Mode:             ModeStandalone,
+			ConvergeInterval: "not-a-duration",
+		},
+	}
+	err := ValidateConfiguration(cfg)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "converge_interval")
+}
+
+func TestValidateConfiguration_ConvergeIntervalZero(t *testing.T) {
+	cfg := StewardConfig{
+		Steward: StewardSettings{
+			ID:               "test-steward",
+			Mode:             ModeStandalone,
+			ConvergeInterval: "0s",
+		},
+	}
+	err := ValidateConfiguration(cfg)
+	require.Error(t, err)
+}
+
+// --- MergeScriptSigningConfig ---
+
+func TestMergeScriptSigningConfig_ChildInheritsParentPolicy(t *testing.T) {
+	parent := ScriptSigningConfig{
+		Policy:    ScriptSigningPolicyOptional,
+		TrustMode: TrustModeAnyValid,
+	}
+	child := ScriptSigningConfig{}
+	result, err := MergeScriptSigningConfig(parent, child)
+	require.NoError(t, err)
+	assert.Equal(t, ScriptSigningPolicyOptional, result.Policy)
+	assert.Equal(t, TrustModeAnyValid, result.TrustMode)
+}
+
+func TestMergeScriptSigningConfig_ChildTighteningAllowed(t *testing.T) {
+	parent := ScriptSigningConfig{
+		Policy:    ScriptSigningPolicyOptional,
+		TrustMode: TrustModeAnyValid,
+	}
+	child := ScriptSigningConfig{
+		Policy:    ScriptSigningPolicyRequired,
+		TrustMode: TrustModeTrustedKeys,
+		TrustedKeys: []TrustedKeyRef{
+			{Name: "corp-key", Thumbprint: "abc123"},
+		},
+	}
+	result, err := MergeScriptSigningConfig(parent, child)
+	require.NoError(t, err)
+	assert.Equal(t, ScriptSigningPolicyRequired, result.Policy)
+	assert.Equal(t, TrustModeTrustedKeys, result.TrustMode)
+}
+
+func TestMergeScriptSigningConfig_ChildLooseningFails(t *testing.T) {
+	parent := ScriptSigningConfig{
+		Policy:    ScriptSigningPolicyRequired,
+		TrustMode: TrustModeAnyValid,
+	}
+	child := ScriptSigningConfig{
+		Policy: ScriptSigningPolicyOptional,
+	}
+	_, err := MergeScriptSigningConfig(parent, child)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "loosen")
+}
+
+func TestMergeScriptSigningConfig_ChildLooseningFromNoneFails(t *testing.T) {
+	parent := ScriptSigningConfig{Policy: ScriptSigningPolicyRequired}
+	child := ScriptSigningConfig{Policy: ScriptSigningPolicyNone}
+	_, err := MergeScriptSigningConfig(parent, child)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "loosen")
+}
+
+func TestMergeScriptSigningConfig_EmptyBothReturnsNone(t *testing.T) {
+	result, err := MergeScriptSigningConfig(ScriptSigningConfig{}, ScriptSigningConfig{})
+	require.NoError(t, err)
+	assert.Equal(t, ScriptSigningPolicyNone, result.Policy)
+}
+
+func TestMergeScriptSigningConfig_InheritsRequireSignedAdhoc(t *testing.T) {
+	parent := ScriptSigningConfig{
+		Policy:             ScriptSigningPolicyOptional,
+		RequireSignedAdhoc: true,
+	}
+	result, err := MergeScriptSigningConfig(parent, ScriptSigningConfig{})
+	require.NoError(t, err)
+	assert.True(t, result.RequireSignedAdhoc)
+}
+
+// --- GetConvergeInterval ---
+
+func TestGetConvergeInterval_ValidInterval(t *testing.T) {
+	cfg := StewardConfig{Steward: StewardSettings{ConvergeInterval: "15m"}}
+	assert.Equal(t, 15*time.Minute, GetConvergeInterval(cfg))
+}
+
+func TestGetConvergeInterval_EmptyFallback(t *testing.T) {
+	cfg := StewardConfig{Steward: StewardSettings{}}
+	assert.Equal(t, 30*time.Minute, GetConvergeInterval(cfg))
+}
+
+// --- GetConfiguredModules ---
+
+func TestGetConfiguredModules_DeduplicatesModules(t *testing.T) {
+	cfg := StewardConfig{
+		Resources: []ResourceConfig{
+			{Name: "r1", Module: "directory"},
+			{Name: "r2", Module: "file"},
+			{Name: "r3", Module: "directory"},
+		},
+	}
+	modules := GetConfiguredModules(cfg)
+	assert.Len(t, modules, 2)
+	assert.Contains(t, modules, "directory")
+	assert.Contains(t, modules, "file")
+}
+
+func TestGetConfiguredModules_EmptyResources(t *testing.T) {
+	cfg := StewardConfig{}
+	assert.Empty(t, GetConfiguredModules(cfg))
+}

--- a/features/config/stewardtypes/types.go
+++ b/features/config/stewardtypes/types.go
@@ -1,0 +1,138 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+
+// Package stewardtypes provides the shared data types and validation functions
+// for steward configuration used by both the controller and the steward.
+//
+// These types are extracted so the controller can reference steward configuration
+// shapes without importing steward-internal packages.
+package stewardtypes
+
+import "time"
+
+// StewardConfig represents the complete steward configuration.
+type StewardConfig struct {
+	Steward   StewardSettings   `yaml:"steward" json:"steward"`
+	Resources []ResourceConfig  `yaml:"resources" json:"resources"`
+	Modules   map[string]string `yaml:"modules,omitempty" json:"modules,omitempty"`
+}
+
+// StewardSettings contains steward-specific configuration options.
+type StewardSettings struct {
+	ID          string        `yaml:"id"`
+	Mode        OperationMode `yaml:"mode"`
+	ModulePaths []string      `yaml:"module_paths,omitempty"`
+	Logging     LoggingConfig `yaml:"logging"`
+
+	ErrorHandling ErrorHandlingConfig `yaml:"error_handling"`
+	Secrets       SecretsConfig       `yaml:"secrets,omitempty"`
+
+	// ConvergeInterval is how often the steward re-converges (e.g. "30m").
+	ConvergeInterval string `yaml:"converge_interval,omitempty"`
+
+	// ScriptSigning configures script signing policy and trusted keys.
+	// Child tenants may only tighten (not loosen) the inherited policy.
+	ScriptSigning ScriptSigningConfig `yaml:"script_signing,omitempty"`
+
+	// SignedCommandReplayWindow is the maximum age of an accepted command timestamp.
+	SignedCommandReplayWindow time.Duration `yaml:"signed_command_replay_window,omitempty"`
+
+	// SignedCommandMaxParamsBytes is the maximum JSON-serialized size of Command.Params.
+	SignedCommandMaxParamsBytes int `yaml:"signed_command_max_params_bytes,omitempty"`
+
+	// DriftMode controls how the steward responds to detected configuration drift.
+	// Must be sourced exclusively from the controller-delivered cfg.
+	DriftMode DriftMode `yaml:"drift_mode,omitempty"`
+}
+
+// SecretsConfig defines configuration for steward-side secret storage.
+type SecretsConfig struct {
+	SecretsDir string `yaml:"secrets_dir,omitempty"`
+	Provider   string `yaml:"provider,omitempty"`
+}
+
+// ScriptSigningPolicy defines the enforcement level for script signatures.
+type ScriptSigningPolicy string
+
+const (
+	ScriptSigningPolicyNone     ScriptSigningPolicy = "none"
+	ScriptSigningPolicyOptional ScriptSigningPolicy = "optional"
+	ScriptSigningPolicyRequired ScriptSigningPolicy = "required"
+)
+
+// ScriptTrustMode defines which signing keys or CAs are considered trustworthy.
+type ScriptTrustMode string
+
+const (
+	TrustModeAnyValid             ScriptTrustMode = "any_valid"
+	TrustModeTrustedKeys          ScriptTrustMode = "trusted_keys"
+	TrustModeTrustedKeysAndPublic ScriptTrustMode = "trusted_keys_and_public"
+)
+
+// TrustedKeyRef identifies a trusted signing key by name, thumbprint, or key reference.
+type TrustedKeyRef struct {
+	Name         string `yaml:"name"`
+	Thumbprint   string `yaml:"thumbprint,omitempty"`
+	PublicKeyRef string `yaml:"public_key_ref,omitempty"`
+}
+
+// ScriptSigningConfig defines the steward-level script signing policy.
+//
+// Child tenants inherit parent config via MergeScriptSigningConfig and may only
+// tighten policy (none→optional→required), never loosen it.
+type ScriptSigningConfig struct {
+	Policy        ScriptSigningPolicy `yaml:"policy,omitempty"`
+	TrustMode     ScriptTrustMode     `yaml:"trust_mode,omitempty"`
+	TrustedKeys   []TrustedKeyRef     `yaml:"trusted_keys,omitempty"`
+	AllowPublicCA bool                `yaml:"allow_public_ca,omitempty"`
+
+	// RequireSignedAdhoc requires a valid signature on all ad-hoc script commands.
+	// Incompatible with policy: none.
+	RequireSignedAdhoc bool `yaml:"require_signed_adhoc,omitempty"`
+}
+
+// ResourceConfig defines a single resource to be managed by the steward.
+type ResourceConfig struct {
+	Name   string                 `yaml:"name" json:"name"`
+	Module string                 `yaml:"module" json:"module"`
+	Config map[string]interface{} `yaml:"config" json:"config"`
+}
+
+// OperationMode defines how the steward operates.
+type OperationMode string
+
+const (
+	ModeStandalone OperationMode = "standalone"
+	ModeController OperationMode = "controller"
+)
+
+// DriftMode defines how the steward responds to detected configuration drift.
+// Set exclusively from controller-delivered cfg bytes — never from local steward.cfg.
+type DriftMode string
+
+const (
+	DriftModeApply   DriftMode = "apply"
+	DriftModeMonitor DriftMode = "monitor"
+)
+
+// LoggingConfig defines logging output settings.
+type LoggingConfig struct {
+	Level  string `yaml:"level"`
+	Format string `yaml:"format"`
+}
+
+// ErrorHandlingConfig defines how to handle various error conditions.
+type ErrorHandlingConfig struct {
+	ModuleLoadFailure  ErrorAction `yaml:"module_load_failure"`
+	ResourceFailure    ErrorAction `yaml:"resource_failure"`
+	ConfigurationError ErrorAction `yaml:"configuration_error"`
+}
+
+// ErrorAction defines the available error handling strategies.
+type ErrorAction string
+
+const (
+	ActionContinue ErrorAction = "continue"
+	ActionFail     ErrorAction = "fail"
+	ActionWarn     ErrorAction = "warn"
+)

--- a/features/config/stewardtypes/validation.go
+++ b/features/config/stewardtypes/validation.go
@@ -1,0 +1,191 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+
+package stewardtypes
+
+import (
+	"fmt"
+	"time"
+)
+
+// scriptSigningPolicyLevel returns the numeric strictness level of a signing policy.
+// Higher values are more restrictive. Returns -1 for unknown values.
+func scriptSigningPolicyLevel(p ScriptSigningPolicy) int {
+	switch p {
+	case ScriptSigningPolicyNone, "":
+		return 0
+	case ScriptSigningPolicyOptional:
+		return 1
+	case ScriptSigningPolicyRequired:
+		return 2
+	}
+	return -1
+}
+
+// ValidateScriptSigningConfig validates a ScriptSigningConfig for internal consistency.
+func ValidateScriptSigningConfig(cfg ScriptSigningConfig) error {
+	switch cfg.Policy {
+	case ScriptSigningPolicyNone, ScriptSigningPolicyOptional, ScriptSigningPolicyRequired, "":
+		// valid
+	default:
+		return fmt.Errorf("invalid script_signing policy %q: must be none, optional, or required", cfg.Policy)
+	}
+
+	switch cfg.TrustMode {
+	case TrustModeAnyValid, TrustModeTrustedKeys, TrustModeTrustedKeysAndPublic, "":
+		// valid
+	default:
+		return fmt.Errorf("invalid script_signing trust_mode %q: must be any_valid, trusted_keys, or trusted_keys_and_public", cfg.TrustMode)
+	}
+
+	if cfg.TrustMode == TrustModeTrustedKeys || cfg.TrustMode == TrustModeTrustedKeysAndPublic {
+		if len(cfg.TrustedKeys) == 0 {
+			return fmt.Errorf("script_signing trust_mode %q requires at least one entry in trusted_keys", cfg.TrustMode)
+		}
+	}
+
+	for i, key := range cfg.TrustedKeys {
+		if key.Thumbprint == "" && key.PublicKeyRef == "" {
+			return fmt.Errorf("script_signing trusted_keys[%d] (%q): must provide thumbprint or public_key_ref", i, key.Name)
+		}
+	}
+
+	if cfg.RequireSignedAdhoc && (cfg.Policy == ScriptSigningPolicyNone || cfg.Policy == "") {
+		return fmt.Errorf("script_signing require_signed_adhoc requires policy optional or required, got %q", cfg.Policy)
+	}
+
+	return nil
+}
+
+// ValidateConfiguration checks if the configuration is valid.
+func ValidateConfiguration(config StewardConfig) error {
+	if config.Steward.ID == "" {
+		return fmt.Errorf("steward ID is required")
+	}
+
+	switch config.Steward.Mode {
+	case ModeStandalone, ModeController:
+		// valid
+	default:
+		return fmt.Errorf("invalid operation mode: %s", config.Steward.Mode)
+	}
+
+	if config.Steward.Logging.Level != "" {
+		validLogLevels := []string{"debug", "info", "warn", "error"}
+		isValidLevel := false
+		for _, level := range validLogLevels {
+			if config.Steward.Logging.Level == level {
+				isValidLevel = true
+				break
+			}
+		}
+		if !isValidLevel {
+			return fmt.Errorf("invalid log level: %s", config.Steward.Logging.Level)
+		}
+	}
+
+	if config.Steward.ConvergeInterval != "" {
+		d, err := time.ParseDuration(config.Steward.ConvergeInterval)
+		if err != nil {
+			return fmt.Errorf("invalid converge_interval %q: must be a valid duration (e.g. \"30m\", \"5m\", \"1h\")", config.Steward.ConvergeInterval)
+		}
+		if d <= 0 {
+			return fmt.Errorf("converge_interval must be positive, got %q", config.Steward.ConvergeInterval)
+		}
+	}
+
+	if err := ValidateScriptSigningConfig(config.Steward.ScriptSigning); err != nil {
+		return fmt.Errorf("script_signing configuration invalid: %w", err)
+	}
+
+	resourceNames := make(map[string]bool)
+	for i, resource := range config.Resources {
+		if resource.Name == "" {
+			return fmt.Errorf("resource %d: name is required", i)
+		}
+		if resource.Module == "" {
+			return fmt.Errorf("resource %s: module is required", resource.Name)
+		}
+		if resourceNames[resource.Name] {
+			return fmt.Errorf("duplicate resource name: %s", resource.Name)
+		}
+		resourceNames[resource.Name] = true
+		if resource.Config == nil {
+			return fmt.Errorf("resource %s: config is required", resource.Name)
+		}
+	}
+
+	return nil
+}
+
+// MergeScriptSigningConfig merges a parent ScriptSigningConfig into a child, applying inheritance rules.
+//
+// The child inherits all parent settings that the child has not explicitly set.
+// Policy may only be tightened (none→optional→required) — if the child specifies a policy
+// less restrictive than the parent's, an error is returned.
+func MergeScriptSigningConfig(parent, child ScriptSigningConfig) (ScriptSigningConfig, error) {
+	result := child
+
+	if result.Policy == "" {
+		result.Policy = parent.Policy
+	}
+	if result.Policy == "" {
+		result.Policy = ScriptSigningPolicyNone
+	}
+
+	parentLevel := scriptSigningPolicyLevel(parent.Policy)
+	childLevel := scriptSigningPolicyLevel(result.Policy)
+	if parentLevel < 0 || childLevel < 0 {
+		return ScriptSigningConfig{}, fmt.Errorf("invalid signing policy value")
+	}
+	if childLevel < parentLevel {
+		return ScriptSigningConfig{}, fmt.Errorf(
+			"child tenant cannot loosen script_signing policy: parent requires %q, child specified %q",
+			parent.Policy, child.Policy,
+		)
+	}
+
+	if result.TrustMode == "" {
+		result.TrustMode = parent.TrustMode
+	}
+
+	if len(result.TrustedKeys) == 0 && len(parent.TrustedKeys) > 0 {
+		result.TrustedKeys = parent.TrustedKeys
+	}
+
+	if !result.AllowPublicCA && parent.AllowPublicCA {
+		result.AllowPublicCA = parent.AllowPublicCA
+	}
+
+	if !result.RequireSignedAdhoc && parent.RequireSignedAdhoc {
+		result.RequireSignedAdhoc = parent.RequireSignedAdhoc
+	}
+
+	return result, nil
+}
+
+// GetConvergeInterval returns the parsed convergence interval.
+// Falls back to 30 minutes if the field is empty or unparseable.
+func GetConvergeInterval(cfg StewardConfig) time.Duration {
+	if cfg.Steward.ConvergeInterval == "" {
+		return 30 * time.Minute
+	}
+	d, err := time.ParseDuration(cfg.Steward.ConvergeInterval)
+	if err != nil || d <= 0 {
+		return 30 * time.Minute
+	}
+	return d
+}
+
+// GetConfiguredModules returns a deduplicated list of module names required by the configuration.
+func GetConfiguredModules(config StewardConfig) []string {
+	moduleSet := make(map[string]bool)
+	for _, resource := range config.Resources {
+		moduleSet[resource.Module] = true
+	}
+	modules := make([]string, 0, len(moduleSet))
+	for module := range moduleSet {
+		modules = append(modules, module)
+	}
+	return modules
+}

--- a/features/steward/config/config.go
+++ b/features/steward/config/config.go
@@ -58,11 +58,45 @@ import (
 	"regexp"
 	"runtime"
 	"strings"
-	"time"
 
 	"gopkg.in/yaml.v3"
 
+	"github.com/cfgis/cfgms/features/config/stewardtypes"
 	"github.com/cfgis/cfgms/features/modules/script"
+)
+
+// Type aliases — re-export from stewardtypes so existing callers compile unchanged.
+type (
+	StewardConfig       = stewardtypes.StewardConfig
+	StewardSettings     = stewardtypes.StewardSettings
+	ResourceConfig      = stewardtypes.ResourceConfig
+	ErrorHandlingConfig = stewardtypes.ErrorHandlingConfig
+	DriftMode           = stewardtypes.DriftMode
+	LoggingConfig       = stewardtypes.LoggingConfig
+	SecretsConfig       = stewardtypes.SecretsConfig
+	ScriptSigningConfig = stewardtypes.ScriptSigningConfig
+	ScriptSigningPolicy = stewardtypes.ScriptSigningPolicy
+	ScriptTrustMode     = stewardtypes.ScriptTrustMode
+	TrustedKeyRef       = stewardtypes.TrustedKeyRef
+	OperationMode       = stewardtypes.OperationMode
+	ErrorAction         = stewardtypes.ErrorAction
+)
+
+// Constant re-exports from stewardtypes.
+const (
+	ScriptSigningPolicyNone       = stewardtypes.ScriptSigningPolicyNone
+	ScriptSigningPolicyOptional   = stewardtypes.ScriptSigningPolicyOptional
+	ScriptSigningPolicyRequired   = stewardtypes.ScriptSigningPolicyRequired
+	TrustModeAnyValid             = stewardtypes.TrustModeAnyValid
+	TrustModeTrustedKeys          = stewardtypes.TrustModeTrustedKeys
+	TrustModeTrustedKeysAndPublic = stewardtypes.TrustModeTrustedKeysAndPublic
+	ModeStandalone                = stewardtypes.ModeStandalone
+	ModeController                = stewardtypes.ModeController
+	DriftModeApply                = stewardtypes.DriftModeApply
+	DriftModeMonitor              = stewardtypes.DriftModeMonitor
+	ActionContinue                = stewardtypes.ActionContinue
+	ActionFail                    = stewardtypes.ActionFail
+	ActionWarn                    = stewardtypes.ActionWarn
 )
 
 // envVarPattern matches ${VAR} patterns without defaults
@@ -116,226 +150,6 @@ func expandEnvWithDefaults(content string) string {
 	// Then expand remaining ${VAR} patterns using os.ExpandEnv
 	return os.ExpandEnv(result)
 }
-
-// StewardConfig represents the complete steward configuration loaded from hostname.cfg.
-//
-// This is the root configuration structure that contains all settings needed
-// for standalone steward operation, including steward-specific settings,
-// resource definitions, and optional module path mappings.
-type StewardConfig struct {
-	// Steward contains steward-specific configuration settings
-	Steward StewardSettings `yaml:"steward" json:"steward"`
-
-	// Resources defines the list of resources to be managed
-	Resources []ResourceConfig `yaml:"resources" json:"resources"`
-
-	// Modules provides optional custom paths for specific modules
-	Modules map[string]string `yaml:"modules,omitempty" json:"modules,omitempty"` // module_name -> custom_path
-}
-
-// StewardSettings contains steward-specific configuration options.
-//
-// These settings control steward behavior, logging, error handling,
-// and module discovery paths.
-type StewardSettings struct {
-	// ID is the unique identifier for this steward instance
-	ID string `yaml:"id"`
-
-	// Mode defines the operation mode (standalone or controller)
-	Mode OperationMode `yaml:"mode"`
-
-	// ModulePaths lists additional directories to search for modules
-	ModulePaths []string `yaml:"module_paths,omitempty"`
-
-	// Logging configures log output format and verbosity
-	Logging LoggingConfig `yaml:"logging"`
-
-	// ErrorHandling defines how to handle various error conditions
-	ErrorHandling ErrorHandlingConfig `yaml:"error_handling"`
-
-	// Secrets configures the steward secret store
-	Secrets SecretsConfig `yaml:"secrets,omitempty"`
-
-	// ConvergeInterval is how often the steward re-converges against the cfg
-	// (e.g. "30m", "5m", "1h"). Defaults to "30m" when not specified.
-	// Applies in both standalone and controller-connected modes.
-	ConvergeInterval string `yaml:"converge_interval,omitempty"`
-
-	// ScriptSigning configures script signing policy, trust modes, and trusted key allowlist.
-	// Child tenants inherit this config and may only tighten (not loosen) the policy.
-	ScriptSigning ScriptSigningConfig `yaml:"script_signing,omitempty"`
-
-	// SignedCommandReplayWindow is the maximum age of an accepted command timestamp.
-	// Commands with a Timestamp older than this window are rejected as potential replays.
-	// Shorter windows enforce stricter freshness; longer windows tolerate clock skew.
-	// Defaults to 5 minutes when zero.
-	SignedCommandReplayWindow time.Duration `yaml:"signed_command_replay_window,omitempty"`
-
-	// SignedCommandMaxParamsBytes is the maximum JSON-serialized size of Command.Params
-	// in bytes. Commands whose Params serialise to more than this limit are rejected
-	// before dispatch. Defaults to 65536 (64 KiB) when zero.
-	SignedCommandMaxParamsBytes int `yaml:"signed_command_max_params_bytes,omitempty"`
-
-	// DriftMode controls how the steward responds to detected configuration drift.
-	// Must be sourced exclusively from the controller-delivered cfg — the local-file
-	// loading path (loadFromPath) clears this field after parsing so that editing
-	// hostname.cfg cannot flip a controller-connected steward into monitor mode.
-	DriftMode DriftMode `yaml:"drift_mode,omitempty"`
-}
-
-// SecretsConfig defines configuration for steward-side secret storage.
-type SecretsConfig struct {
-	// SecretsDir overrides the default platform-specific secrets directory
-	SecretsDir string `yaml:"secrets_dir,omitempty"`
-
-	// Provider selects the secrets provider (default: "steward")
-	Provider string `yaml:"provider,omitempty"`
-}
-
-// ScriptSigningPolicy defines the enforcement level for script signatures at the steward level.
-type ScriptSigningPolicy string
-
-const (
-	// ScriptSigningPolicyNone does not require or validate script signatures.
-	ScriptSigningPolicyNone ScriptSigningPolicy = "none"
-
-	// ScriptSigningPolicyOptional validates signatures when present but does not require them.
-	ScriptSigningPolicyOptional ScriptSigningPolicy = "optional"
-
-	// ScriptSigningPolicyRequired rejects any script that lacks a valid signature.
-	ScriptSigningPolicyRequired ScriptSigningPolicy = "required"
-)
-
-// ScriptTrustMode defines which signing keys or CAs are considered trustworthy.
-type ScriptTrustMode string
-
-const (
-	// TrustModeAnyValid accepts any valid signature from a well-formed key.
-	TrustModeAnyValid ScriptTrustMode = "any_valid"
-
-	// TrustModeTrustedKeys accepts signatures only from keys in TrustedKeys.
-	TrustModeTrustedKeys ScriptTrustMode = "trusted_keys"
-
-	// TrustModeTrustedKeysAndPublic accepts TrustedKeys and, when AllowPublicCA is true, public CAs.
-	TrustModeTrustedKeysAndPublic ScriptTrustMode = "trusted_keys_and_public"
-)
-
-// TrustedKeyRef identifies a trusted signing key or certificate by name, thumbprint, or key reference.
-type TrustedKeyRef struct {
-	// Name is a human-readable label for this key entry.
-	Name string `yaml:"name"`
-
-	// Thumbprint is the certificate thumbprint used to identify the key.
-	Thumbprint string `yaml:"thumbprint,omitempty"`
-
-	// PublicKeyRef is an opaque reference to a public key stored in the secrets provider.
-	PublicKeyRef string `yaml:"public_key_ref,omitempty"`
-}
-
-// ScriptSigningConfig defines the steward-level script signing policy and trust configuration.
-//
-// Config inheritance: child tenants inherit parent config via MergeScriptSigningConfig.
-// Children may tighten policy (e.g. optional→required) but may not loosen it.
-type ScriptSigningConfig struct {
-	// Policy sets the enforcement level: none, optional, or required.
-	Policy ScriptSigningPolicy `yaml:"policy,omitempty"`
-
-	// TrustMode defines which keys are accepted: any_valid, trusted_keys, or trusted_keys_and_public.
-	TrustMode ScriptTrustMode `yaml:"trust_mode,omitempty"`
-
-	// TrustedKeys lists keys/certificates that are allowed to sign scripts.
-	// Required when TrustMode is trusted_keys or trusted_keys_and_public.
-	TrustedKeys []TrustedKeyRef `yaml:"trusted_keys,omitempty"`
-
-	// AllowPublicCA, when true alongside trusted_keys_and_public mode, also accepts
-	// signatures from public certificate authorities.
-	AllowPublicCA bool `yaml:"allow_public_ca,omitempty"`
-
-	// RequireSignedAdhoc, when true, requires a valid signature on all ad-hoc (inline)
-	// script commands dispatched to this steward. Library scripts (identified by a
-	// non-empty script_id param) always require their CI signature regardless of this
-	// setting. Incompatible with policy: none — use optional or required.
-	RequireSignedAdhoc bool `yaml:"require_signed_adhoc,omitempty"`
-}
-
-// ResourceConfig defines a single resource to be managed by the steward.
-//
-// Each resource specifies which module should manage it and provides
-// module-specific configuration data.
-type ResourceConfig struct {
-	// Name is the unique identifier for this resource
-	Name string `yaml:"name" json:"name"`
-
-	// Module is the name of the module that will manage this resource
-	Module string `yaml:"module" json:"module"`
-
-	// Config contains module-specific configuration data
-	Config map[string]interface{} `yaml:"config" json:"config"`
-}
-
-// OperationMode defines how the steward operates.
-type OperationMode string
-
-const (
-	// ModeStandalone operates using local configuration files and modules
-	ModeStandalone OperationMode = "standalone"
-
-	// ModeController connects to a remote CFGMS controller (legacy)
-	ModeController OperationMode = "controller"
-)
-
-// DriftMode defines how the steward responds to detected configuration drift.
-// Set exclusively from controller-delivered cfg bytes — never from local steward.cfg —
-// so a tampered local file cannot bypass the authenticated delivery channel.
-type DriftMode string
-
-const (
-	// DriftModeApply corrects detected drift by calling module.Set() and Verify().
-	// This is the default behavior when drift_mode is absent.
-	DriftModeApply DriftMode = "apply"
-
-	// DriftModeMonitor emits a non-compliance event upstream but does not call
-	// module.Set() or module.Verify(). Drift is observed, not corrected.
-	DriftModeMonitor DriftMode = "monitor"
-)
-
-// LoggingConfig defines logging output settings.
-type LoggingConfig struct {
-	// Level sets the logging verbosity (debug, info, warn, error)
-	Level string `yaml:"level"`
-
-	// Format sets the log output format (text, json)
-	Format string `yaml:"format"`
-}
-
-// ErrorHandlingConfig defines how to handle various error conditions.
-//
-// Each error type can be configured to continue (log and proceed),
-// warn (log warning and proceed), or fail (log error and stop).
-type ErrorHandlingConfig struct {
-	// ModuleLoadFailure defines how to handle module loading errors
-	ModuleLoadFailure ErrorAction `yaml:"module_load_failure"`
-
-	// ResourceFailure defines how to handle resource execution errors
-	ResourceFailure ErrorAction `yaml:"resource_failure"`
-
-	// ConfigurationError defines how to handle configuration validation errors
-	ConfigurationError ErrorAction `yaml:"configuration_error"`
-}
-
-// ErrorAction defines the available error handling strategies.
-type ErrorAction string
-
-const (
-	// ActionContinue logs the error and continues execution
-	ActionContinue ErrorAction = "continue"
-
-	// ActionFail logs the error and stops execution
-	ActionFail ErrorAction = "fail"
-
-	// ActionWarn logs a warning and continues execution
-	ActionWarn ErrorAction = "warn"
-)
 
 // LoadConfiguration searches for and loads the steward configuration from hostname.cfg.
 //
@@ -520,112 +334,10 @@ func applyDefaults(config *StewardConfig) {
 	}
 }
 
-// scriptSigningPolicyLevel returns the numeric strictness level of a signing policy.
-// Higher values are more restrictive. Returns -1 for unknown values.
-func scriptSigningPolicyLevel(p ScriptSigningPolicy) int {
-	switch p {
-	case ScriptSigningPolicyNone, "":
-		return 0
-	case ScriptSigningPolicyOptional:
-		return 1
-	case ScriptSigningPolicyRequired:
-		return 2
-	}
-	return -1
-}
-
-// validateScriptSigningConfig validates a ScriptSigningConfig for internal consistency.
+// validateScriptSigningConfig delegates to the shared stewardtypes validator.
+// Kept as a package-internal function so tests in this package can call it directly.
 func validateScriptSigningConfig(cfg ScriptSigningConfig) error {
-	// Validate policy value
-	switch cfg.Policy {
-	case ScriptSigningPolicyNone, ScriptSigningPolicyOptional, ScriptSigningPolicyRequired, "":
-		// valid
-	default:
-		return fmt.Errorf("invalid script_signing policy %q: must be none, optional, or required", cfg.Policy)
-	}
-
-	// Validate trust_mode value
-	switch cfg.TrustMode {
-	case TrustModeAnyValid, TrustModeTrustedKeys, TrustModeTrustedKeysAndPublic, "":
-		// valid
-	default:
-		return fmt.Errorf("invalid script_signing trust_mode %q: must be any_valid, trusted_keys, or trusted_keys_and_public", cfg.TrustMode)
-	}
-
-	// trusted_keys and trusted_keys_and_public require a non-empty key list
-	if cfg.TrustMode == TrustModeTrustedKeys || cfg.TrustMode == TrustModeTrustedKeysAndPublic {
-		if len(cfg.TrustedKeys) == 0 {
-			return fmt.Errorf("script_signing trust_mode %q requires at least one entry in trusted_keys", cfg.TrustMode)
-		}
-	}
-
-	// Each key ref must have at least a thumbprint or public_key_ref
-	for i, key := range cfg.TrustedKeys {
-		if key.Thumbprint == "" && key.PublicKeyRef == "" {
-			return fmt.Errorf("script_signing trusted_keys[%d] (%q): must provide thumbprint or public_key_ref", i, key.Name)
-		}
-	}
-
-	// require_signed_adhoc is incompatible with policy: none (the default when unset).
-	// Operators must explicitly choose optional or required when enabling this setting.
-	if cfg.RequireSignedAdhoc && (cfg.Policy == ScriptSigningPolicyNone || cfg.Policy == "") {
-		return fmt.Errorf("script_signing require_signed_adhoc requires policy optional or required, got %q", cfg.Policy)
-	}
-
-	return nil
-}
-
-// MergeScriptSigningConfig merges a parent ScriptSigningConfig into a child, applying inheritance rules.
-//
-// The child inherits all parent settings that the child has not explicitly set.
-// Policy may only be tightened (none→optional→required) — if the child specifies a policy
-// less restrictive than the parent's, an error is returned.
-func MergeScriptSigningConfig(parent, child ScriptSigningConfig) (ScriptSigningConfig, error) {
-	// Apply parent defaults where child has not set values
-	result := child
-
-	// Inherit policy from parent if child has none
-	if result.Policy == "" {
-		result.Policy = parent.Policy
-	}
-	if result.Policy == "" {
-		result.Policy = ScriptSigningPolicyNone
-	}
-
-	// Enforce tightening-only: child cannot loosen what parent has set
-	parentLevel := scriptSigningPolicyLevel(parent.Policy)
-	childLevel := scriptSigningPolicyLevel(result.Policy)
-	if parentLevel < 0 || childLevel < 0 {
-		return ScriptSigningConfig{}, fmt.Errorf("invalid signing policy value")
-	}
-	if childLevel < parentLevel {
-		return ScriptSigningConfig{}, fmt.Errorf(
-			"child tenant cannot loosen script_signing policy: parent requires %q, child specified %q",
-			parent.Policy, child.Policy,
-		)
-	}
-
-	// Inherit trust_mode from parent if child has none
-	if result.TrustMode == "" {
-		result.TrustMode = parent.TrustMode
-	}
-
-	// Inherit trusted_keys from parent if child has none
-	if len(result.TrustedKeys) == 0 && len(parent.TrustedKeys) > 0 {
-		result.TrustedKeys = parent.TrustedKeys
-	}
-
-	// AllowPublicCA: child inherits parent value if not set (bool — treat parent true as inherited)
-	if !result.AllowPublicCA && parent.AllowPublicCA {
-		result.AllowPublicCA = parent.AllowPublicCA
-	}
-
-	// RequireSignedAdhoc: child inherits parent value when child has not enabled it.
-	if !result.RequireSignedAdhoc && parent.RequireSignedAdhoc {
-		result.RequireSignedAdhoc = parent.RequireSignedAdhoc
-	}
-
-	return result, nil
+	return stewardtypes.ValidateScriptSigningConfig(cfg)
 }
 
 // BuildModuleSigningConfig converts a steward ScriptSigningConfig into the
@@ -648,106 +360,4 @@ func BuildModuleSigningConfig(cfg ScriptSigningConfig) script.ModuleSigningConfi
 		TrustedKeys:   entries,
 		AllowPublicCA: cfg.AllowPublicCA,
 	}
-}
-
-// ValidateConfiguration checks if the configuration is valid
-func ValidateConfiguration(config StewardConfig) error {
-	// Validate steward settings
-	if config.Steward.ID == "" {
-		return fmt.Errorf("steward ID is required")
-	}
-
-	// Validate operation mode
-	switch config.Steward.Mode {
-	case ModeStandalone, ModeController:
-		// Valid modes
-	default:
-		return fmt.Errorf("invalid operation mode: %s", config.Steward.Mode)
-	}
-
-	// Validate logging level (only when explicitly set; empty means the
-	// default "info" will be applied by applyDefaults, so an unset level is
-	// valid — mirrors the converge_interval handling below).
-	if config.Steward.Logging.Level != "" {
-		validLogLevels := []string{"debug", "info", "warn", "error"}
-		isValidLevel := false
-		for _, level := range validLogLevels {
-			if config.Steward.Logging.Level == level {
-				isValidLevel = true
-				break
-			}
-		}
-		if !isValidLevel {
-			return fmt.Errorf("invalid log level: %s", config.Steward.Logging.Level)
-		}
-	}
-
-	// Validate convergence interval (only when explicitly set; empty means default will apply)
-	if config.Steward.ConvergeInterval != "" {
-		d, err := time.ParseDuration(config.Steward.ConvergeInterval)
-		if err != nil {
-			return fmt.Errorf("invalid converge_interval %q: must be a valid duration (e.g. \"30m\", \"5m\", \"1h\")", config.Steward.ConvergeInterval)
-		}
-		if d <= 0 {
-			return fmt.Errorf("converge_interval must be positive, got %q", config.Steward.ConvergeInterval)
-		}
-	}
-
-	// Validate script signing config
-	if err := validateScriptSigningConfig(config.Steward.ScriptSigning); err != nil {
-		return fmt.Errorf("script_signing configuration invalid: %w", err)
-	}
-
-	// Validate resources
-	resourceNames := make(map[string]bool)
-	for i, resource := range config.Resources {
-		if resource.Name == "" {
-			return fmt.Errorf("resource %d: name is required", i)
-		}
-
-		if resource.Module == "" {
-			return fmt.Errorf("resource %s: module is required", resource.Name)
-		}
-
-		if resourceNames[resource.Name] {
-			return fmt.Errorf("duplicate resource name: %s", resource.Name)
-		}
-		resourceNames[resource.Name] = true
-
-		if resource.Config == nil {
-			return fmt.Errorf("resource %s: config is required", resource.Name)
-		}
-	}
-
-	return nil
-}
-
-// GetConvergeInterval returns the parsed convergence interval for this configuration.
-// Falls back to 30 minutes if the field is empty or unparseable (should not happen
-// after validation, but guards against direct struct construction in tests).
-func GetConvergeInterval(cfg StewardConfig) time.Duration {
-	if cfg.Steward.ConvergeInterval == "" {
-		return 30 * time.Minute
-	}
-	d, err := time.ParseDuration(cfg.Steward.ConvergeInterval)
-	if err != nil || d <= 0 {
-		return 30 * time.Minute
-	}
-	return d
-}
-
-// GetConfiguredModules returns a list of module names required by the configuration
-func GetConfiguredModules(config StewardConfig) []string {
-	moduleSet := make(map[string]bool)
-
-	for _, resource := range config.Resources {
-		moduleSet[resource.Module] = true
-	}
-
-	modules := make([]string, 0, len(moduleSet))
-	for module := range moduleSet {
-		modules = append(modules, module)
-	}
-
-	return modules
 }

--- a/features/steward/config/validation.go
+++ b/features/steward/config/validation.go
@@ -1,3 +1,29 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2026 Jordan Ritz
 package config
+
+import (
+	"time"
+
+	"github.com/cfgis/cfgms/features/config/stewardtypes"
+)
+
+// ValidateConfiguration delegates to the shared stewardtypes validator.
+func ValidateConfiguration(c StewardConfig) error {
+	return stewardtypes.ValidateConfiguration(c)
+}
+
+// MergeScriptSigningConfig delegates to the shared stewardtypes implementation.
+func MergeScriptSigningConfig(parent, child ScriptSigningConfig) (ScriptSigningConfig, error) {
+	return stewardtypes.MergeScriptSigningConfig(parent, child)
+}
+
+// GetConvergeInterval delegates to the shared stewardtypes implementation.
+func GetConvergeInterval(cfg StewardConfig) time.Duration {
+	return stewardtypes.GetConvergeInterval(cfg)
+}
+
+// GetConfiguredModules delegates to the shared stewardtypes implementation.
+func GetConfiguredModules(config StewardConfig) []string {
+	return stewardtypes.GetConfiguredModules(config)
+}


### PR DESCRIPTION
## Summary

- Creates `features/config/stewardtypes` package with all shared data types (`StewardConfig`, `StewardSettings`, `ResourceConfig`, etc.) and validation functions (`ValidateConfiguration`, `MergeScriptSigningConfig`, `GetConvergeInterval`, `GetConfiguredModules`) extracted from `features/steward/config`
- Updates `features/steward/config/config.go` to use Go **type aliases** (not definitions) so `stewardconfig.StewardConfig` and `stewardtypes.StewardConfig` are identical types — no conversion needed when M1/M2/C1 migrate controller imports
- Updates `features/steward/config/validation.go` with thin one-line wrappers delegating to `stewardtypes`; all existing callers compile unchanged

Fixes #1755

## Changes

| File | Change |
|------|--------|
| `features/config/stewardtypes/types.go` | New — all shared types and constants |
| `features/config/stewardtypes/validation.go` | New — `ValidateConfiguration`, `ValidateScriptSigningConfig`, `MergeScriptSigningConfig`, `GetConvergeInterval`, `GetConfiguredModules` |
| `features/config/stewardtypes/stewardtypes_test.go` | New — tests for all exported functions |
| `features/steward/config/config.go` | Updated — type aliases + const re-exports; file-loading logic unchanged |
| `features/steward/config/validation.go` | Updated — thin wrappers delegating to stewardtypes |

## Specialist Review Results

- **QA Test Runner**: PASS — all unit tests, linting, cross-platform builds (linux/amd64, linux/arm64, darwin/amd64, darwin/arm64, windows/amd64) pass
- **QA Code Reviewer**: PASS — 0 blocking issues; 3 non-blocking warnings (nil-config test coverage gap, GetConvergeInterval fallback branch, direct ValidateScriptSigningConfig tests — all covered indirectly)
- **Security Engineer**: PASS — 0 blocking issues, 0 warnings; all scans clean (gosec, staticcheck, Trivy, Nancy, architecture check, secret scan)

## Test Plan

- [x] `go build ./features/config/stewardtypes/` — standalone compile verified
- [x] `go build ./features/steward/config/` — re-export aliases compile verified
- [x] `go build ./...` — full project compiles with zero errors
- [x] `go test ./features/config/stewardtypes/...` — new package tests pass
- [x] `go test ./features/steward/config/...` — all existing steward/config tests pass through wrappers
- [x] `make test-agent-complete` — full quality gate passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)