### PR TITLE
registration: replace DefaultApprovalHook with IP-trust default approval workflow (Issue #1695)

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -465,6 +465,9 @@ services:
       CFGMS_HA_ENABLED: "false"
       # Seed well-known test tokens for integration test suites (Issue #700)
       CFGMS_SEED_TEST_TOKENS: "1"
+      # Issue #1695: integration tests exercise the full register → mTLS flow.
+      # Opt into auto-approve so stewards are not quarantined by the ip-trust default.
+      CFGMS_REGISTRATION_WORKFLOW: "auto-approve"
       # Enable test endpoints for integration testing (auth bypass for /api/v1/test/*)
       CFGMS_ENABLE_TEST_ENDPOINTS: "true"
       CFGMS_CERT_PATH: "/app/certs"
@@ -670,6 +673,9 @@ services:
       - "8090:9080"       # HTTP API
     environment:
       CFGMS_SEED_TEST_TOKENS: "1"
+      # Issue #1695: fleet stewards must complete the full register → mTLS flow.
+      # Opt into auto-approve so they are not quarantined by the ip-trust default.
+      CFGMS_REGISTRATION_WORKFLOW: "auto-approve"
       CFGMS_ENABLE_TEST_ENDPOINTS: "true"
       CFGMS_TRANSPORT_USE_CERT_MANAGER: "true"
       # Transport listen addr is 0.0.0.0:4433; the controller rewrites the

--- a/docs/architecture/controller-operating-model.md
+++ b/docs/architecture/controller-operating-model.md
@@ -463,8 +463,9 @@ The controller is the certificate authority and identity provider for stewards. 
 2. Steward presents the token/code during registration via the compile-time controller URL.
 3. Controller validates the credential — perennial token: check expiry and revocation; long-lived code: look up matching record.
 4. Controller runs the registration approval workflow via `RegistrationApprovalHook`. The active workflow is selected by `registration.workflow` in `controller.cfg`:
-   - **`auto-approve`** (default): approves every valid registration unconditionally. Implemented as a built-in workflow with `Variables: {policy: accept}` which short-circuits the engine. Equivalent to the legacy `DefaultApprovalHook`.
+   - **`ip-trust`** (default): approves the registration when the steward's source IP is trusted for its tenant; quarantines otherwise. The first steward from any new tenant always quarantines because no IP is trusted yet. The hook is code-wired (`IPTrustApprovalHook`), not seeded as a workflow. It fails closed — a nil or erroring trust store quarantines rather than admits.
    - **`manual-review`** (production): quarantines the steward pending operator action. Sets `registration_decision: quarantine` so the steward is restricted to baseline config until promoted. Operators use `cfg registration pending` to list quarantined stewards, `cfg registration approve <id>` to promote, and `cfg registration deny <id> [--reason ...]` to reject.
+   - **`auto-approve`** (deprecated): approves every valid registration unconditionally. Dev/test environments only — a startup warning is logged. Replaces the legacy `DefaultApprovalHook`.
    - Custom workflows can implement arbitrary policy (e.g., approve `tenant=lab` registrations, reject everything else)
 5. On approval (`approve`): controller generates the steward ID and issues an mTLS client certificate scoped to the steward's tenant/group identity.
    On quarantine (`quarantine`): controller issues certificates but restricts the steward to baseline configuration only (no secrets, no scripts) until an administrator promotes it.
@@ -476,15 +477,22 @@ The controller is the certificate authority and identity provider for stewards. 
 
 ```yaml
 registration:
-  workflow: auto-approve   # or: manual-review (default: auto-approve)
+  workflow: ip-trust       # or: manual-review, auto-approve (default: ip-trust)
+  # trusted_proxies lists CIDR ranges of reverse proxies trusted to set
+  # X-Forwarded-For. Empty (default) means X-Forwarded-For is never trusted.
+  trusted_proxies:
+    - "10.0.0.0/8"
 ```
 
 | Value | Behavior |
 |---|---|
-| `auto-approve` (default) | Approves all valid registrations immediately. Seeds a built-in workflow with `Variables: {policy: accept}` that short-circuits the approval engine. |
+| `ip-trust` (default) | Approves the registration when the source IP is trusted for the tenant; quarantines otherwise. Code-wired (`IPTrustApprovalHook`) — no workflow is seeded. Fails closed on a missing or erroring trust store. |
 | `manual-review` | Quarantines every new steward pending operator action. Seeds a built-in workflow with `Variables: {registration_decision: quarantine}`. Use `cfg registration pending` / `approve` / `deny` to manage the queue. |
+| `auto-approve` (deprecated) | Approves all valid registrations immediately. Dev/test environments only — a startup deprecation warning is logged. |
 
-If `registration.workflow` is omitted and no `steward-registration-approval` workflow exists in the config store, the controller defaults to `auto-approve`. If a custom workflow already exists in the store, seeding is skipped to preserve operator-authored policy.
+If `registration.workflow` is omitted, the controller defaults to `ip-trust`. The `CFGMS_REGISTRATION_WORKFLOW` environment variable overrides the config-file value (used by test environments to opt into `auto-approve`).
+
+**X-Forwarded-For spoofing protection:** The controller derives the steward's source IP for the IP-trust decision from the TCP peer address (`r.RemoteAddr`). It honors an `X-Forwarded-For` header **only** when the TCP peer falls within a `trusted_proxies` CIDR range. With `trusted_proxies` empty (the default), `X-Forwarded-For` is always ignored, so an attacker on an untrusted network position cannot bypass IP-trust by injecting a forged header. When the controller runs behind a load balancer, set `trusted_proxies` to the load balancer's address range so the real client IP is used.
 
 **Managing pending registrations with `cfg registration`:**
 

--- a/docs/deployment/fleet/walkthrough.md
+++ b/docs/deployment/fleet/walkthrough.md
@@ -349,6 +349,33 @@ Connected to controller via gRPC transport
 Configuration executor initialized  tenant_id=default
 ```
 
+> **First steward quarantines under the `ip-trust` default.** With the default
+> `registration.workflow: ip-trust`, the controller approves a registration only
+> when the steward's source IP is already trusted for its tenant. The **first**
+> steward from a new tenant always quarantines: the controller responds `202
+> Accepted` with `status: pending` and issues **no certificate** until the IP is
+> established. The steward holds in a restricted state and retries. To inspect or
+> promote quarantined stewards, use `cfg registration pending` / `approve`. To
+> approve every registration immediately in a lab or pre-production fleet, set
+> `registration.workflow: auto-approve` in `controller.cfg` (a deprecated
+> dev/test-only mode).
+>
+> **Behind a load balancer:** the IP-trust decision uses the TCP peer address.
+> If the controller sits behind a reverse proxy or load balancer, the peer
+> address is the proxy, not the steward. Set `registration.trusted_proxies` to
+> the proxy's CIDR range so the controller honors the `X-Forwarded-For` header
+> and evaluates the real steward IP:
+>
+> ```yaml
+> registration:
+>   workflow: ip-trust
+>   trusted_proxies:
+>     - "10.0.0.0/8"
+> ```
+>
+> When `trusted_proxies` is empty (the default), `X-Forwarded-For` is never
+> trusted — this prevents an attacker from spoofing a trusted source IP.
+
 ---
 
 ## Phase 5 — Verify Fleet

--- a/features/controller/api/handlers_registration.go
+++ b/features/controller/api/handlers_registration.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net"
 	"net/http"
 	"os"
 	"strings"
@@ -207,7 +208,7 @@ func (s *Server) handleRegister(w http.ResponseWriter, r *http.Request) {
 	{
 		input := RegistrationInput{
 			Token:    token,
-			SourceIP: extractSourceIP(r),
+			SourceIP: extractSourceIP(r, s.trustedProxies),
 		}
 		decision, reason, hookErr := s.approvalHook.Evaluate(r.Context(), input)
 		if hookErr != nil {
@@ -241,7 +242,7 @@ func (s *Server) handleRegister(w http.ResponseWriter, r *http.Request) {
 						PendingID:    pendingID,
 						StewardID:    stewardID,
 						TenantID:     token.TenantID,
-						SourceIP:     extractSourceIP(r),
+						SourceIP:     extractSourceIP(r, s.trustedProxies),
 						RegisteredAt: time.Now().UTC(),
 					})
 				}
@@ -422,21 +423,39 @@ func replaceBindAddress(addr string) string {
 }
 
 // extractSourceIP returns the source IP from the HTTP request.
-// It prefers X-Forwarded-For (first entry) when present, falling back to RemoteAddr.
-func extractSourceIP(r *http.Request) string {
-	if xff := r.Header.Get("X-Forwarded-For"); xff != "" {
-		// Take the first address (client IP before any proxies)
-		if idx := strings.Index(xff, ","); idx != -1 {
-			return strings.TrimSpace(xff[:idx])
+// It honors X-Forwarded-For only when the TCP peer (r.RemoteAddr) is within
+// trustedProxies. When trustedProxies is empty or the peer is not in the list,
+// the TCP peer address is always used — XFF is untrusted and ignored.
+// This prevents spoofing: an attacker cannot bypass IP-trust checks by injecting
+// a forged X-Forwarded-For header from an untrusted network position.
+func extractSourceIP(r *http.Request, trustedProxies []net.IPNet) string {
+	// Parse the TCP peer host (strip port). net.SplitHostPort handles IPv6
+	// bracket notation ([::1]:port) correctly; fall back to the raw value
+	// if SplitHostPort fails (e.g. no port present, unlikely for net/http).
+	peerHost := r.RemoteAddr
+	if host, _, err := net.SplitHostPort(r.RemoteAddr); err == nil {
+		peerHost = host
+	}
+
+	// Honor XFF only when the peer is a trusted proxy.
+	if len(trustedProxies) > 0 {
+		peerIP := net.ParseIP(peerHost)
+		if peerIP != nil {
+			for i := range trustedProxies {
+				if trustedProxies[i].Contains(peerIP) {
+					if xff := r.Header.Get("X-Forwarded-For"); xff != "" {
+						if idx := strings.Index(xff, ","); idx != -1 {
+							return strings.TrimSpace(xff[:idx])
+						}
+						return strings.TrimSpace(xff)
+					}
+					break
+				}
+			}
 		}
-		return strings.TrimSpace(xff)
 	}
-	// RemoteAddr is "host:port"; strip the port
-	addr := r.RemoteAddr
-	if idx := strings.LastIndex(addr, ":"); idx != -1 {
-		return addr[:idx]
-	}
-	return addr
+
+	return peerHost
 }
 
 // emitRegistrationAudit records a registration audit event. It is a no-op when auditManager is nil.

--- a/features/controller/api/handlers_registration_test.go
+++ b/features/controller/api/handlers_registration_test.go
@@ -6,6 +6,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"sync"
@@ -198,6 +199,9 @@ func TestHandleRegister_PerennialToken_AllowsMultipleRegistrations(t *testing.T)
 	tokenStore := newTestRegistrationStore(t)
 	certMgr := newTestCertManager(t)
 	server, _ := newHandleRegisterServer(t, tokenStore, certMgr)
+	// Explicitly use always-approve hook: this test verifies perennial token behaviour
+	// on the approve path, not registration approval policy.
+	server.SetApprovalHook(&AlwaysApproveHook{})
 
 	tok := &registration.Token{
 		Token:         "cfgms_reg_perennial_valid",
@@ -375,6 +379,8 @@ func TestHandleRegister_ValidToken_LogsRedactedPrefixNotFullToken(t *testing.T) 
 	certMgr := newTestCertManager(t)
 	capLogger := &kvCapturingLogger{}
 	server, _ := newHandleRegisterServer(t, tokenStore, certMgr, capLogger)
+	// Explicitly use always-approve hook: this test exercises the success (approve) log path.
+	server.SetApprovalHook(&AlwaysApproveHook{})
 
 	fullToken := "cfgms_reg_valid_loggingtest_12345"
 	tok := &registration.Token{
@@ -573,7 +579,8 @@ func TestHandleRegister_ApproveReturns200WithCert(t *testing.T) {
 	tokenStore := newTestRegistrationStore(t)
 	certMgr := newTestCertManager(t)
 	server, _ := newHandleRegisterServer(t, tokenStore, certMgr)
-	// Default hook approves unconditionally.
+	// Explicitly use always-approve hook: this test exercises the 200+cert approve path.
+	server.SetApprovalHook(&AlwaysApproveHook{})
 
 	tok := &registration.Token{
 		Token:         "cfgms_reg_approve_test",
@@ -684,4 +691,59 @@ func TestHandleDenyRegistration(t *testing.T) {
 
 		assert.Equal(t, http.StatusNotFound, resp.StatusCode)
 	})
+}
+
+// TestExtractSourceIP_XFFIgnoredWhenPeerNotProxy verifies that a spoofed
+// X-Forwarded-For header is ignored when the TCP peer is not in the
+// TrustedProxies list. The TCP peer address must be used instead (Issue #1695).
+func TestExtractSourceIP_XFFIgnoredWhenPeerNotProxy(t *testing.T) {
+	const peerAddr = "203.0.113.5"  // "legitimate" attacker IP
+	const spoofedXFF = "10.0.0.100" // attacker claims to be this trusted-looking IP
+	const trustedProxy = "192.168.1.0/24"
+
+	_, trustedNet, err := net.ParseCIDR(trustedProxy)
+	require.NoError(t, err)
+	proxies := []net.IPNet{*trustedNet}
+
+	// Request with spoofed XFF from an untrusted peer.
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/register", nil)
+	req.RemoteAddr = peerAddr + ":54321"
+	req.Header.Set("X-Forwarded-For", spoofedXFF)
+
+	// With empty trusted proxies: XFF must be ignored.
+	got := extractSourceIP(req, nil)
+	assert.Equal(t, peerAddr, got,
+		"empty trustedProxies: must use TCP peer, not XFF")
+
+	// With trustedProxies configured but peerAddr NOT in the list:
+	// XFF must still be ignored.
+	got = extractSourceIP(req, proxies)
+	assert.Equal(t, peerAddr, got,
+		"peer not in trustedProxies: must use TCP peer, not the spoofed XFF")
+
+	// When the peer IS in trustedProxies, XFF should be honored.
+	reqFromProxy := httptest.NewRequest(http.MethodPost, "/api/v1/register", nil)
+	reqFromProxy.RemoteAddr = "192.168.1.10:54321" // inside 192.168.1.0/24
+	reqFromProxy.Header.Set("X-Forwarded-For", spoofedXFF)
+
+	got = extractSourceIP(reqFromProxy, proxies)
+	assert.Equal(t, spoofedXFF, got,
+		"peer in trustedProxies: XFF must be honored")
+
+	// When the peer IS in trustedProxies but XFF is absent, use peer address.
+	reqFromProxyNoXFF := httptest.NewRequest(http.MethodPost, "/api/v1/register", nil)
+	reqFromProxyNoXFF.RemoteAddr = "192.168.1.10:54321"
+
+	got = extractSourceIP(reqFromProxyNoXFF, proxies)
+	assert.Equal(t, "192.168.1.10", got,
+		"peer in trustedProxies but no XFF: must use TCP peer address")
+
+	// IPv6 peer address: net.SplitHostPort must correctly strip brackets and port.
+	reqIPv6 := httptest.NewRequest(http.MethodPost, "/api/v1/register", nil)
+	reqIPv6.RemoteAddr = "[::1]:54321"
+	reqIPv6.Header.Set("X-Forwarded-For", spoofedXFF)
+
+	got = extractSourceIP(reqIPv6, nil)
+	assert.Equal(t, "::1", got,
+		"IPv6 peer: must return bare IPv6 address without brackets or port")
 }

--- a/features/controller/api/handlers_workflows.go
+++ b/features/controller/api/handlers_workflows.go
@@ -66,11 +66,11 @@ func (h *WorkflowHandler) RegisterWorkflowRoutes(router *mux.Router) {
 }
 
 // NewRegistrationApprovalHook creates a RegistrationApprovalHook backed by this handler's
-// workflow engine and config store.  If the engine or config store are unavailable it
-// returns a DefaultApprovalHook so the controller always has a valid hook.
+// workflow engine and config store. If the engine or config store are unavailable it
+// returns an AlwaysApproveHook so the controller always has a valid (if permissive) hook.
 func (h *WorkflowHandler) NewRegistrationApprovalHook(logger logging.Logger) RegistrationApprovalHook {
 	if h.engine == nil || h.configStore == nil {
-		return &DefaultApprovalHook{}
+		return &AlwaysApproveHook{}
 	}
 	return NewWorkflowApprovalHook(h.engine, h.configStore, logger)
 }

--- a/features/controller/api/registration_hook.go
+++ b/features/controller/api/registration_hook.go
@@ -16,6 +16,9 @@ import (
 	cfgconfig "github.com/cfgis/cfgms/pkg/storage/interfaces/config"
 )
 
+// Compile-time assertion: IPTrustApprovalHook satisfies RegistrationApprovalHook.
+var _ RegistrationApprovalHook = (*IPTrustApprovalHook)(nil)
+
 // ApprovalDecision represents the outcome of a registration approval evaluation.
 type ApprovalDecision string
 
@@ -61,13 +64,52 @@ type RegistrationApprovalHook interface {
 	Evaluate(ctx context.Context, input RegistrationInput) (decision ApprovalDecision, reason string, err error)
 }
 
-// DefaultApprovalHook approves every valid registration unconditionally.
-// It is the out-of-box hook used when no workflow engine is available.
-type DefaultApprovalHook struct{}
+// AlwaysApproveHook approves every valid registration unconditionally.
+// Used only for the deprecated "auto-approve" workflow alias and as a fallback
+// when no workflow engine is available. Dev/test environments only (Issue #1695).
+type AlwaysApproveHook struct{}
 
 // Evaluate always returns DecisionApprove.
-func (*DefaultApprovalHook) Evaluate(_ context.Context, _ RegistrationInput) (ApprovalDecision, string, error) {
+func (*AlwaysApproveHook) Evaluate(_ context.Context, _ RegistrationInput) (ApprovalDecision, string, error) {
 	return DecisionApprove, "", nil
+}
+
+// IPTrustApprovalHook evaluates registration decisions based on IP trust (Issue #1695).
+// It calls store.IsTrusted for the registering steward's source IP and returns
+// DecisionApprove for trusted IPs, DecisionQuarantine otherwise. On store error
+// or when the store is nil, it returns DecisionQuarantine (fail-closed): an
+// unavailable trust store must not grant unrestricted fleet access.
+type IPTrustApprovalHook struct {
+	store  business.IPTrustStore
+	logger logging.Logger
+}
+
+// NewIPTrustApprovalHook creates an IPTrustApprovalHook. When store is nil,
+// Evaluate always returns DecisionQuarantine.
+func NewIPTrustApprovalHook(store business.IPTrustStore, logger logging.Logger) *IPTrustApprovalHook {
+	return &IPTrustApprovalHook{store: store, logger: logger}
+}
+
+// Evaluate checks whether the source IP is trusted for the tenant.
+// Fails closed: returns DecisionQuarantine on store error or nil store.
+func (h *IPTrustApprovalHook) Evaluate(ctx context.Context, input RegistrationInput) (ApprovalDecision, string, error) {
+	if h.store == nil {
+		return DecisionQuarantine, "", nil
+	}
+	trusted, err := h.store.IsTrusted(ctx, input.Token.TenantID, input.SourceIP)
+	if err != nil {
+		if h.logger != nil {
+			h.logger.Warn("IPTrustApprovalHook: store error, quarantining (fail-closed)",
+				"tenant_id", input.Token.TenantID,
+				"source_ip", logging.SanitizeLogValue(input.SourceIP),
+				"error", err)
+		}
+		return DecisionQuarantine, "", nil
+	}
+	if trusted {
+		return DecisionApprove, "", nil
+	}
+	return DecisionQuarantine, "", nil
 }
 
 // WorkflowApprovalHook delegates registration approval to the workflow engine.

--- a/features/controller/api/registration_hook.go
+++ b/features/controller/api/registration_hook.go
@@ -99,10 +99,12 @@ func (h *IPTrustApprovalHook) Evaluate(ctx context.Context, input RegistrationIn
 	trusted, err := h.store.IsTrusted(ctx, input.Token.TenantID, input.SourceIP)
 	if err != nil {
 		if h.logger != nil {
+			// SourceIP flows from the HTTP request into IsTrusted and may be echoed
+			// back in the error; sanitize the error string to close go/log-injection.
 			h.logger.Warn("IPTrustApprovalHook: store error, quarantining (fail-closed)",
 				"tenant_id", input.Token.TenantID,
 				"source_ip", logging.SanitizeLogValue(input.SourceIP),
-				"error", err)
+				"error", logging.SanitizeLogValue(err.Error()))
 		}
 		return DecisionQuarantine, "", nil
 	}

--- a/features/controller/api/registration_hook_test.go
+++ b/features/controller/api/registration_hook_test.go
@@ -7,8 +7,10 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net"
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"testing"
 	"time"
 
@@ -25,6 +27,65 @@ import (
 	cfgconfig "github.com/cfgis/cfgms/pkg/storage/interfaces/config"
 	pkgtesting "github.com/cfgis/cfgms/pkg/testing"
 )
+
+// testIPTrustStore is a minimal in-memory IPTrustStore for hook unit tests.
+type testIPTrustStore struct {
+	mu      sync.RWMutex
+	trusted map[string]bool // key: tenantID+"\x00"+ip
+	err     error           // when non-nil, IsTrusted returns this error
+}
+
+func newTestIPTrustStore() *testIPTrustStore {
+	return &testIPTrustStore{trusted: make(map[string]bool)}
+}
+
+func (s *testIPTrustStore) key(tenantID, ip string) string { return tenantID + "\x00" + ip }
+
+func (s *testIPTrustStore) AddTrustedRange(_ context.Context, tenantID, cidr string, _ bool) error {
+	_, ipNet, err := net.ParseCIDR(cidr)
+	if err != nil {
+		return err
+	}
+	// For testing simplicity, record the network address as "trusted".
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.trusted[s.key(tenantID, ipNet.IP.String())] = true
+	return nil
+}
+
+func (s *testIPTrustStore) IsTrusted(_ context.Context, tenantID, ip string) (bool, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if s.err != nil {
+		return false, s.err
+	}
+	return s.trusted[s.key(tenantID, ip)], nil
+}
+
+func (s *testIPTrustStore) ListTrustedRanges(_ context.Context, _ string) ([]*business.IPTrustEntry, error) {
+	return nil, nil
+}
+func (s *testIPTrustStore) RevokeTrustedRange(_ context.Context, _, _ string) error { return nil }
+func (s *testIPTrustStore) RecordHealthySteward(_ context.Context, _, _ string, _ time.Time) error {
+	return nil
+}
+func (s *testIPTrustStore) GetLastActivity(_ context.Context, _, _ string) (*business.IPTrustActivity, error) {
+	return nil, nil
+}
+
+// setTrusted marks an IP as trusted for a tenant.
+func (s *testIPTrustStore) setTrusted(tenantID, ip string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.trusted[s.key(tenantID, ip)] = true
+}
+
+// setError makes IsTrusted return the given error.
+func (s *testIPTrustStore) setError(err error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.err = err
+}
 
 // newTestApprovalHook builds a WorkflowApprovalHook backed by real git storage and workflow engine.
 func newTestApprovalHook(t *testing.T) (*WorkflowApprovalHook, cfgconfig.ConfigStore) {
@@ -98,24 +159,97 @@ func (*errorHook) Evaluate(_ context.Context, _ RegistrationInput) (ApprovalDeci
 	return DecisionApprove, "", fmt.Errorf("hook failure injected by test")
 }
 
-// --- DefaultApprovalHook ---
+// --- AlwaysApproveHook (replaces removed DefaultApprovalHook) ---
 
-func TestDefaultApprovalHook_AlwaysApproves(t *testing.T) {
-	hook := &DefaultApprovalHook{}
+func TestAlwaysApproveHook_AlwaysApproves(t *testing.T) {
+	hook := &AlwaysApproveHook{}
 	decision, reason, err := hook.Evaluate(context.Background(), sampleInput())
 	require.NoError(t, err)
 	assert.Equal(t, DecisionApprove, decision)
 	assert.Empty(t, reason)
 }
 
-func TestDefaultApprovalHook_ApprovesWithExpiredToken(t *testing.T) {
-	hook := &DefaultApprovalHook{}
+func TestAlwaysApproveHook_ApprovesWithExpiredToken(t *testing.T) {
+	hook := &AlwaysApproveHook{}
 	exp := time.Now().Add(-1 * time.Hour) // expired
 	input := sampleInput()
 	input.Token.ExpiresAt = &exp
 	decision, _, err := hook.Evaluate(context.Background(), input)
 	require.NoError(t, err)
 	assert.Equal(t, DecisionApprove, decision)
+}
+
+// --- IPTrustApprovalHook ---
+
+func TestIPTrustApprovalHook_TrustedIP_ReturnsApprove(t *testing.T) {
+	store := newTestIPTrustStore()
+	store.setTrusted("test-tenant", "192.168.1.100")
+
+	hook := NewIPTrustApprovalHook(store, logging.NewNoopLogger())
+	decision, reason, err := hook.Evaluate(context.Background(), sampleInput())
+
+	require.NoError(t, err, "Evaluate must not return an error for trusted IP")
+	assert.Equal(t, DecisionApprove, decision, "trusted IP must get DecisionApprove")
+	assert.Empty(t, reason)
+}
+
+func TestIPTrustApprovalHook_UntrustedIP_ReturnsQuarantine(t *testing.T) {
+	store := newTestIPTrustStore()
+	// "192.168.1.100" is NOT added as trusted.
+
+	hook := NewIPTrustApprovalHook(store, logging.NewNoopLogger())
+	decision, reason, err := hook.Evaluate(context.Background(), sampleInput())
+
+	require.NoError(t, err, "Evaluate must not return an error for untrusted IP")
+	assert.Equal(t, DecisionQuarantine, decision, "untrusted IP must get DecisionQuarantine")
+	assert.Empty(t, reason)
+}
+
+func TestIPTrustApprovalHook_StoreError_ReturnsQuarantine(t *testing.T) {
+	store := newTestIPTrustStore()
+	store.setError(fmt.Errorf("store unavailable"))
+
+	hook := NewIPTrustApprovalHook(store, logging.NewNoopLogger())
+	decision, reason, err := hook.Evaluate(context.Background(), sampleInput())
+
+	// Fail-closed: store error must produce quarantine with nil error so the
+	// registration handler honours the quarantine decision instead of defaulting to approve.
+	require.NoError(t, err, "Evaluate must return nil error on store failure (fail-closed)")
+	assert.Equal(t, DecisionQuarantine, decision, "store error must fail closed (quarantine)")
+	assert.Empty(t, reason)
+}
+
+func TestIPTrustApprovalHook_NilStore_ReturnsQuarantine(t *testing.T) {
+	hook := NewIPTrustApprovalHook(nil, logging.NewNoopLogger())
+	decision, _, err := hook.Evaluate(context.Background(), sampleInput())
+
+	require.NoError(t, err)
+	assert.Equal(t, DecisionQuarantine, decision, "nil store must fail closed (quarantine)")
+}
+
+func TestIPTrustApprovalHook_DifferentTenants_Isolated(t *testing.T) {
+	store := newTestIPTrustStore()
+	// Only trust the IP under "tenant-a", not "tenant-b".
+	store.setTrusted("tenant-a", "10.0.0.1")
+
+	hook := NewIPTrustApprovalHook(store, logging.NewNoopLogger())
+
+	inputA := RegistrationInput{
+		Token:    &registration.Token{Token: "tok", TenantID: "tenant-a"},
+		SourceIP: "10.0.0.1",
+	}
+	inputB := RegistrationInput{
+		Token:    &registration.Token{Token: "tok", TenantID: "tenant-b"},
+		SourceIP: "10.0.0.1",
+	}
+
+	decA, _, err := hook.Evaluate(context.Background(), inputA)
+	require.NoError(t, err)
+	assert.Equal(t, DecisionApprove, decA, "tenant-a trusts this IP")
+
+	decB, _, err := hook.Evaluate(context.Background(), inputB)
+	require.NoError(t, err)
+	assert.Equal(t, DecisionQuarantine, decB, "tenant-b does not trust this IP")
 }
 
 // --- WorkflowApprovalHook: no workflow configured ---
@@ -293,7 +427,7 @@ func TestWorkflowHandler_NewRegistrationApprovalHook_NilEngine_ReturnsDefault(t 
 	hook := h.NewRegistrationApprovalHook(logger)
 	require.NotNil(t, hook)
 
-	// Should be the DefaultApprovalHook (nil engine → always approve)
+	// nil engine → AlwaysApproveHook (always approve)
 	decision, _, err := hook.Evaluate(context.Background(), sampleInput())
 	require.NoError(t, err)
 	assert.Equal(t, DecisionApprove, decision)

--- a/features/controller/api/registration_hook_test.go
+++ b/features/controller/api/registration_hook_test.go
@@ -219,6 +219,38 @@ func TestIPTrustApprovalHook_StoreError_ReturnsQuarantine(t *testing.T) {
 	assert.Empty(t, reason)
 }
 
+// TestIPTrustApprovalHook_StoreError_SanitizesLogValue verifies the store-error
+// Warn log sanitizes the error string. The trust store echoes the request-derived
+// source IP back in its error; an attacker-injected CR/LF must not reach the log
+// verbatim (closes the CodeQL go/log-injection alert).
+func TestIPTrustApprovalHook_StoreError_SanitizesLogValue(t *testing.T) {
+	store := newTestIPTrustStore()
+	store.setError(fmt.Errorf("invalid IP address: 10.0.0.1\nforged-log-line key=value"))
+
+	logger := pkgtesting.NewMockLogger(true)
+	hook := NewIPTrustApprovalHook(store, logger)
+	decision, _, err := hook.Evaluate(context.Background(), sampleInput())
+
+	require.NoError(t, err)
+	assert.Equal(t, DecisionQuarantine, decision)
+
+	warnLogs := logger.GetLogs("warn")
+	require.Len(t, warnLogs, 1, "store error must emit exactly one Warn log")
+
+	var errVal string
+	var found bool
+	data := warnLogs[0].Data
+	for i := 0; i+1 < len(data); i += 2 {
+		if key, ok := data[i].(string); ok && key == "error" {
+			errVal, _ = data[i+1].(string)
+			found = true
+		}
+	}
+	require.True(t, found, "Warn log must carry an 'error' key")
+	assert.NotContains(t, errVal, "\n", "logged error must not contain a raw newline (log-injection)")
+	assert.NotContains(t, errVal, "\r", "logged error must not contain a raw carriage return")
+}
+
 func TestIPTrustApprovalHook_NilStore_ReturnsQuarantine(t *testing.T) {
 	hook := NewIPTrustApprovalHook(nil, logging.NewNoopLogger())
 	decision, _, err := hook.Evaluate(context.Background(), sampleInput())

--- a/features/controller/api/server.go
+++ b/features/controller/api/server.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
+	"net"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -87,6 +88,7 @@ type Server struct {
 	registrationQueue       sync.Map                       // Issue #1568: quarantined stewards awaiting approval
 	runManager              *controllerrun.Manager         // Issue #1673: run/job/execution model
 	runExecutionQueue       *script.ExecutionQueue         // Issue #1673: queue for ad-hoc run synthesis
+	trustedProxies          []net.IPNet                    // Issue #1695: parsed from TrustedProxies config; XFF honored only when peer is in this list
 	stopCleanup             chan struct{}                  // signals startAPIKeyCleanup to exit
 	cleanupDone             chan struct{}                  // closed when cleanup goroutine exits
 	closeOnce               sync.Once                      // idempotent Close
@@ -146,6 +148,21 @@ func New(
 		return nil, fmt.Errorf("failed to initialize secret store: %w", err)
 	}
 
+	// Issue #1695: Parse TrustedProxies CIDRs once at startup so per-request
+	// extractSourceIP calls never parse strings.
+	var trustedProxies []net.IPNet
+	if cfg.Registration != nil {
+		for _, cidr := range cfg.Registration.TrustedProxies {
+			_, ipNet, parseErr := net.ParseCIDR(cidr)
+			if parseErr != nil {
+				logger.Warn("Invalid trusted_proxy CIDR, skipping",
+					"cidr", logging.SanitizeLogValue(cidr), "error", parseErr)
+				continue
+			}
+			trustedProxies = append(trustedProxies, *ipNet)
+		}
+	}
+
 	server := &Server{
 		cfg:                     cfg,
 		logger:                  logger,
@@ -163,7 +180,8 @@ func New(
 		signerCertSerial:        signerCertSerial,         // Story #378: For registration handler
 		apiKeys:                 make(map[string]*APIKey), // In-memory cache
 		secretStore:             secretStore,              // M-AUTH-1: Central secrets provider
-		approvalHook:            &DefaultApprovalHook{},   // Issue #422: accept-all default
+		approvalHook:            &IPTrustApprovalHook{},   // Issue #1695: nil store → fail-closed (quarantine all)
+		trustedProxies:          trustedProxies,           // Issue #1695: parsed from TrustedProxies config
 		auditManager:            auditManager,             // Issue #775: registration audit events
 		commandPublisher:        commandPublisher,         // Issue #1319: fan-out config push to active stewards
 		pushStore:               pushStore,                // Issue #1320: durable push-state persistence for HA failover

--- a/features/controller/config/config.go
+++ b/features/controller/config/config.go
@@ -110,11 +110,21 @@ type Config struct {
 type RegistrationConfig struct {
 	// Workflow selects the built-in registration approval workflow.
 	// Valid values:
-	//   "auto-approve" (default) — all registrations approved immediately; safe for development.
-	//   "manual-review"          — stewards quarantined pending operator approval via `cfg registration approve`.
-	// If empty and no "steward-registration-approval" workflow exists in the config store,
-	// the controller defaults to "auto-approve" behaviour.
+	//   "ip-trust" (default) — auto-approve if the source IP is trusted for the tenant;
+	//     quarantine otherwise. The first steward from a new tenant always quarantines
+	//     until its IP is established via the 30-minute liveness window (Issue #1694).
+	//   "manual-review"      — stewards quarantined pending operator approval via
+	//     `cfg registration approve`.
+	//   "auto-approve"       — DEPRECATED. Approves all registrations immediately.
+	//     Use only in dev/test environments. A startup warning is logged.
+	// If empty, defaults to "ip-trust".
 	Workflow string `yaml:"workflow"`
+
+	// TrustedProxies is a list of CIDR ranges identifying reverse proxies that are
+	// trusted to set the X-Forwarded-For header. When empty (the default),
+	// X-Forwarded-For is never trusted and the TCP peer address is always used
+	// for the IP-trust decision. Parse once at startup, not per-request (Issue #1695).
+	TrustedProxies []string `yaml:"trusted_proxies,omitempty"`
 
 	// ApprovalMode selects the registration approval hook implementation.
 	// Valid values:

--- a/features/controller/config/config.go
+++ b/features/controller/config/config.go
@@ -755,6 +755,17 @@ func LoadWithPath(configPath string) (*Config, error) {
 		cfg.ListenAddr = httpListenAddr
 	}
 
+	// Registration configuration environment variables (Issue #1695).
+	// CFGMS_REGISTRATION_WORKFLOW selects the approval workflow ("ip-trust",
+	// "manual-review", "auto-approve"). Test/dev environments use this to opt
+	// into "auto-approve" without mounting a config file.
+	if regWorkflow := os.Getenv("CFGMS_REGISTRATION_WORKFLOW"); regWorkflow != "" {
+		if cfg.Registration == nil {
+			cfg.Registration = &RegistrationConfig{}
+		}
+		cfg.Registration.Workflow = regWorkflow
+	}
+
 	return cfg, nil
 }
 

--- a/features/controller/config/config_test.go
+++ b/features/controller/config/config_test.go
@@ -283,6 +283,48 @@ func TestRegistrationConfigAutoApprove(t *testing.T) {
 	assert.Equal(t, "auto-approve", cfg.Registration.Workflow)
 }
 
+// TestLoadWithPath_RegistrationWorkflowEnvVar verifies CFGMS_REGISTRATION_WORKFLOW
+// creates the Registration section when absent and sets the workflow (Issue #1695).
+func TestLoadWithPath_RegistrationWorkflowEnvVar(t *testing.T) {
+	t.Setenv("CFGMS_REGISTRATION_WORKFLOW", "auto-approve")
+
+	cfg, err := Load()
+	require.NoError(t, err)
+	require.NotNil(t, cfg.Registration,
+		"CFGMS_REGISTRATION_WORKFLOW must create the Registration section when absent")
+	assert.Equal(t, "auto-approve", cfg.Registration.Workflow)
+}
+
+// TestLoadWithPath_RegistrationWorkflowEnvVarOverridesFile verifies the env var
+// overrides a workflow value loaded from the config file (Issue #1695).
+func TestLoadWithPath_RegistrationWorkflowEnvVarOverridesFile(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "controller.cfg")
+	require.NoError(t, os.WriteFile(configPath,
+		[]byte("registration:\n  workflow: manual-review\n"), 0600))
+
+	t.Setenv("CFGMS_REGISTRATION_WORKFLOW", "auto-approve")
+
+	cfg, err := LoadWithPath(configPath)
+	require.NoError(t, err)
+	require.NotNil(t, cfg.Registration)
+	assert.Equal(t, "auto-approve", cfg.Registration.Workflow,
+		"CFGMS_REGISTRATION_WORKFLOW must override registration.workflow from the config file")
+}
+
+// TestLoadWithPath_RegistrationWorkflowUnsetLeavesDefault verifies an unset
+// env var does not create or mutate the Registration section (Issue #1695).
+func TestLoadWithPath_RegistrationWorkflowUnsetLeavesDefault(t *testing.T) {
+	// Explicitly clear the env var so the test is deterministic even if a CI
+	// runner sets CFGMS_REGISTRATION_WORKFLOW in its ambient environment.
+	t.Setenv("CFGMS_REGISTRATION_WORKFLOW", "")
+
+	cfg, err := Load()
+	require.NoError(t, err)
+	assert.Nil(t, cfg.Registration,
+		"Registration must stay nil when CFGMS_REGISTRATION_WORKFLOW is unset and no config file is present")
+}
+
 // TestRegistrationConfig_GetIPTrustThreshold verifies the IP-trust threshold
 // getter covers all three cases: nil receiver, zero value, and configured value
 // (Issue #1694).

--- a/features/controller/server/server.go
+++ b/features/controller/server/server.go
@@ -695,32 +695,69 @@ func New(cfg *config.Config, logger logging.Logger) (*Server, error) {
 		httpServer.SetWorkflowHandler(workflowHandler)
 		srv.triggerManager = triggerMgr
 		logger.Info("Workflow engine wired to HTTP API server")
+	}
 
-		// Issue #1527: Seed the built-in registration approval workflow before wiring the hook.
-		seedBuiltinRegistrationWorkflow(cfg, storageManager.GetConfigStore(), logger)
+	// Issue #1695: Wire the registration approval hook based on registration.workflow.
+	// ip-trust is the new default and does not require the workflow engine.
+	{
+		workflowName := ""
+		if cfg.Registration != nil {
+			workflowName = cfg.Registration.Workflow
+		}
+		// Legacy: if Workflow is empty but ApprovalMode is set, honour it.
+		if workflowName == "" && cfg.Registration != nil && cfg.Registration.ApprovalMode == "manual-review" {
+			workflowName = "manual-review"
+		}
+		// Default to ip-trust (Issue #1695).
+		if workflowName == "" {
+			workflowName = "ip-trust"
+		}
 
-		// Issue #1599: When approval_mode = "manual-review", use ManualReviewApprovalHook
-		// which persists requests to PendingRegistrationStore for CLI approve/deny (#1522-B).
-		// Otherwise fall back to the workflow-engine hook (Issue #422).
-		if cfg.Registration != nil && cfg.Registration.ApprovalMode == "manual-review" {
+		switch workflowName {
+		case "ip-trust":
+			// ip-trust hook is code-wired; seedBuiltinRegistrationWorkflow is a no-op for this path.
+			ipTrustStore := storageManager.GetIPTrustStore()
+			httpServer.SetApprovalHook(api.NewIPTrustApprovalHook(ipTrustStore, logger))
+			if ipTrustStore != nil {
+				logger.Info("IP-trust registration approval hook wired (Issue #1695)")
+			} else {
+				logger.Warn("IP-trust store not available (OSS composite storage); registrations will quarantine until an IP-trust store is wired")
+			}
+
+		case "manual-review":
+			// Issue #1527: Seed the manual-review workflow before wiring the hook.
+			if workflowHandler != nil {
+				seedBuiltinRegistrationWorkflow(cfg, storageManager.GetConfigStore(), logger)
+			}
+			// Issue #1599: Use ManualReviewApprovalHook which persists requests to
+			// PendingRegistrationStore for CLI approve/deny (#1522-B).
 			pendingStore := storageManager.GetPendingRegistrationStore()
 			if pendingStore != nil {
 				hook := api.NewManualReviewApprovalHook(pendingStore, 24*time.Hour, logger)
 				httpServer.SetApprovalHook(hook)
 				srv.manualReviewHook = hook
 				logger.Info("Manual-review registration approval hook wired (Issue #1599)")
-			} else {
-				logger.Warn("approval_mode=manual-review requested but PendingRegistrationStore unavailable, falling back to workflow hook")
+			} else if workflowHandler != nil {
+				logger.Warn("manual-review requested but PendingRegistrationStore unavailable, falling back to workflow hook")
 				approvalHook := workflowHandler.NewRegistrationApprovalHook(logger)
 				httpServer.SetApprovalHook(approvalHook)
-				logger.Info("Registration approval hook wired (Issue #422)")
+				logger.Info("Registration approval hook wired (Issue #422, manual-review fallback)")
 			}
-		} else {
-			// Issue #422: Wire registration approval hook backed by the workflow engine.
-			// Operators configure the "steward-registration-approval" workflow to customise policy.
-			approvalHook := workflowHandler.NewRegistrationApprovalHook(logger)
-			httpServer.SetApprovalHook(approvalHook)
-			logger.Info("Registration approval hook wired (Issue #422)")
+
+		case "auto-approve":
+			// Deprecated: log a warning but continue to support dev environments.
+			logger.Warn("registration.workflow 'auto-approve' is deprecated; use 'ip-trust' (Issue #1695)")
+			if workflowHandler != nil {
+				seedBuiltinRegistrationWorkflow(cfg, storageManager.GetConfigStore(), logger)
+			}
+			httpServer.SetApprovalHook(&api.AlwaysApproveHook{})
+			logger.Info("auto-approve registration approval hook wired (deprecated)")
+
+		default:
+			logger.Warn("Unknown registration.workflow value, defaulting to ip-trust (Issue #1695)",
+				"workflow", logging.SanitizeLogValue(workflowName))
+			ipTrustStore := storageManager.GetIPTrustStore()
+			httpServer.SetApprovalHook(api.NewIPTrustApprovalHook(ipTrustStore, logger))
 		}
 	}
 
@@ -778,9 +815,17 @@ const builtinWorkflowTenantID = "root"
 // workflow into the config store under the root tenant scope based on
 // cfg.Registration.Workflow (Issue #1527).
 //
+// No-op when Workflow == "ip-trust": the IP-trust hook is wired in code, not via a
+// workflow entry (Issue #1695).
+//
 // If the workflow field is empty and a custom "steward-registration-approval" workflow
 // already exists in the root scope, seeding is skipped to preserve operator-authored workflows.
 func seedBuiltinRegistrationWorkflow(cfg *config.Config, configStore cfgconfig.ConfigStore, logger logging.Logger) {
+	// ip-trust hook is code-wired; no workflow seeding is needed.
+	if cfg.Registration != nil && cfg.Registration.Workflow == "ip-trust" {
+		return
+	}
+
 	ctx := context.Background()
 
 	// Root-tenant workflow store.

--- a/features/controller/server/server_test.go
+++ b/features/controller/server/server_test.go
@@ -209,8 +209,38 @@ func TestInitializeHAManager_UsesDefaultConfig(t *testing.T) {
 	assert.NotEmpty(t, node.ID, "auto-generated node ID must not be empty")
 }
 
-// TestBuiltinWorkflowSeedingAutoApprove verifies that a controller started with no
-// registration config seeds the auto-approve built-in workflow (Issue #1527).
+// TestBuiltinWorkflowSeedingIPTrust verifies that a controller started with no
+// registration config (defaulting to ip-trust) does NOT seed a built-in workflow,
+// because ip-trust approval is handled by the IPTrustApprovalHook directly in code
+// rather than through the workflow engine (Issue #1695).
+func TestBuiltinWorkflowSeedingIPTrust(t *testing.T) {
+	tempDir := t.TempDir()
+	cfg := &config.Config{
+		ListenAddr: "127.0.0.1:0",
+		Certificate: &config.CertificateConfig{
+			EnableCertManagement: false,
+		},
+		Storage: &config.StorageConfig{
+			Provider:     "flatfile",
+			FlatfileRoot: tempDir + "/flatfile",
+			SQLitePath:   tempDir + "/cfgms.db",
+		},
+		// No Registration block: defaults to ip-trust mode, which does not seed a workflow.
+	}
+
+	srv, err := New(cfg, logging.NewNoopLogger())
+	require.NoError(t, err)
+	require.NotNil(t, srv)
+	t.Cleanup(func() { _ = srv.Stop() })
+
+	ctx := context.Background()
+	store := workflow.NewWorkflowStore(srv.GetConfigStore(), builtinWorkflowTenantID)
+	_, err = store.GetLatestWorkflow(ctx, "steward-registration-approval")
+	require.Error(t, err, "ip-trust mode must NOT seed a built-in workflow — approval is handled by IPTrustApprovalHook in code")
+}
+
+// TestBuiltinWorkflowSeedingAutoApprove verifies that a controller explicitly configured
+// with registration.workflow=auto-approve seeds the auto-approve built-in workflow (Issue #1527).
 func TestBuiltinWorkflowSeedingAutoApprove(t *testing.T) {
 	tempDir := t.TempDir()
 	cfg := &config.Config{
@@ -223,7 +253,9 @@ func TestBuiltinWorkflowSeedingAutoApprove(t *testing.T) {
 			FlatfileRoot: tempDir + "/flatfile",
 			SQLitePath:   tempDir + "/cfgms.db",
 		},
-		// No Registration block: defaults to auto-approve seeding.
+		Registration: &config.RegistrationConfig{
+			Workflow: "auto-approve",
+		},
 	}
 
 	srv, err := New(cfg, logging.NewNoopLogger())

--- a/test/e2e/framework.go
+++ b/test/e2e/framework.go
@@ -355,6 +355,13 @@ func (f *E2ETestFramework) initializeController() error {
 			KeepalivePeriod: controllerConfig.Duration(30 * time.Second),
 			IdleTimeout:     controllerConfig.Duration(5 * time.Minute),
 		},
+		// Issue #1695: the e2e harness exercises the full registration → mTLS →
+		// transport flow, so the test controller opts into auto-approve. The
+		// ip-trust default would quarantine every steward (no trusted source IP),
+		// leaving stewards without certificates and unable to connect.
+		Registration: &controllerConfig.RegistrationConfig{
+			Workflow: "auto-approve",
+		},
 	}
 
 	// Create storage directories

--- a/test/integration/controller_test.go
+++ b/test/integration/controller_test.go
@@ -167,18 +167,20 @@ func (s *ControllerTestSuite) TestStewardRegistration() {
 	err = json.NewDecoder(resp.Body).Decode(&regResp)
 	require.NoError(s.T(), err, "Registration response should be valid JSON")
 
-	// Verify registration succeeded - response must contain a steward_id
+	// With ip-trust as the default workflow (Issue #1695), the first steward from a new
+	// tenant always quarantines because no source IP is yet trusted for that tenant.
+	// The controller returns 202 Accepted with status="pending".
+	s.Equal(http.StatusAccepted, resp.StatusCode, "First registration for new tenant should return 202 (quarantine)")
 	s.Contains(regResp, "steward_id", "Registration response should contain steward_id")
 	s.NotEmpty(regResp["steward_id"], "Steward ID should not be empty")
-
-	// Verify tenant info is correct
 	s.Equal("test-tenant", regResp["tenant_id"], "Response should contain correct tenant_id")
+	s.Equal("pending", regResp["status"], "First registration should be quarantined (status=pending)")
+	s.Contains(regResp, "pending_id", "Quarantined registration should include a pending_id")
 
-	// Verify certificates were provided (proves cert manager is working)
-	s.Contains(regResp, "ca_cert", "Registration response should contain CA certificate")
-	s.Contains(regResp, "client_cert", "Registration response should contain client certificate")
+	// No client cert is issued for quarantined stewards (Issue #1693).
+	s.NotContains(regResp, "client_cert", "Quarantined registration must not include a client certificate")
 
-	s.T().Logf("Registration successful: steward_id=%v, tenant_id=%v", regResp["steward_id"], regResp["tenant_id"])
+	s.T().Logf("Registration quarantined as expected: steward_id=%v, pending_id=%v", regResp["steward_id"], regResp["pending_id"])
 }
 
 func TestControllerIntegration(t *testing.T) {


### PR DESCRIPTION
## Summary

- **Replace auto-approve default with ip-trust**: `IPTrustApprovalHook` approves registrations only when the steward's source IP is trusted for its tenant; quarantines otherwise. The first steward from any new tenant always quarantines.
- **XFF spoofing hardened**: `extractSourceIP` now only honors `X-Forwarded-For` when the TCP peer (`r.RemoteAddr`) falls within the configured `TrustedProxies` CIDR list. Empty `TrustedProxies` (default) means XFF is never trusted. Uses `net.SplitHostPort` for correct IPv6 handling.
- **Fail-closed by design**: `IPTrustApprovalHook` quarantines on nil store, store error, or unrecognized `registration.workflow` value — never fails open.
- **Deprecated auto-approve preserved**: `AlwaysApproveHook` replaces removed `DefaultApprovalHook`; `Workflow: "auto-approve"` still seeds the built-in workflow with a deprecation warning.

## Files changed

- `features/controller/api/registration_hook.go` — `IPTrustApprovalHook`, `AlwaysApproveHook` (removed `DefaultApprovalHook`)
- `features/controller/api/handlers_registration.go` — `extractSourceIP` hardened with `TrustedProxies` + IPv6 fix
- `features/controller/api/server.go` — `trustedProxies []net.IPNet` field; default hook changed to `&IPTrustApprovalHook{}`
- `features/controller/config/config.go` — `TrustedProxies []string`; `Workflow` default documented as `"ip-trust"`
- `features/controller/server/server.go` — approval hook wiring restructured; `ip-trust` no-ops workflow seeding
- `features/controller/server/server_test.go` — `TestBuiltinWorkflowSeedingIPTrust` (new default); explicit `auto-approve` test
- `test/integration/controller_test.go` — `TestStewardRegistration` updated for quarantine-first behavior

## Test plan

- [x] `go test ./features/controller/api/...` — all pass including new `IPTrustApprovalHook` tests and XFF spoofing test (IPv4 + IPv6)
- [x] `go test ./features/controller/server/...` — `TestBuiltinWorkflowSeedingIPTrust`, `TestBuiltinWorkflowSeedingAutoApprove`, `TestBuiltinWorkflowSeedingManualReview` all pass
- [x] `go test ./test/integration/...` — `TestStewardRegistration` updated and passes (verifies 202 quarantine on first registration)
- [x] `make test-agent-complete` — all checks pass (pre-commit, fast, production-critical, cross-platform build)

Fixes #1695

🤖 Generated with [Claude Code](https://claude.com/claude-code)