### PR TITLE
controller: migrate api and transport off features/steward/config (Issue #1759)

### DIFF
--- a/features/config/stewardtypes/proto_converter.go
+++ b/features/config/stewardtypes/proto_converter.go
@@ -1,0 +1,156 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+
+package stewardtypes
+
+import (
+	"fmt"
+	"time"
+
+	controller "github.com/cfgis/cfgms/api/proto/controller"
+	"google.golang.org/protobuf/types/known/durationpb"
+	"google.golang.org/protobuf/types/known/structpb"
+)
+
+// ToProto converts a StewardConfig to a protobuf StewardConfig.
+func ToProto(config *StewardConfig) (*controller.StewardConfig, error) {
+	if config == nil {
+		return nil, fmt.Errorf("config is nil")
+	}
+
+	stewardSettings := &controller.StewardSettings{
+		Id:   config.Steward.ID,
+		Mode: string(config.Steward.Mode),
+		Logging: &controller.LoggingConfig{
+			Level:  config.Steward.Logging.Level,
+			Format: config.Steward.Logging.Format,
+		},
+		ErrorHandling: &controller.ErrorHandlingConfig{
+			ModuleLoadFailure:  string(config.Steward.ErrorHandling.ModuleLoadFailure),
+			ResourceFailure:    string(config.Steward.ErrorHandling.ResourceFailure),
+			ConfigurationError: string(config.Steward.ErrorHandling.ConfigurationError),
+		},
+	}
+
+	if config.Steward.ModulePaths != nil {
+		stewardSettings.ModulePaths = config.Steward.ModulePaths
+	}
+
+	stewardSettings.Secrets = map[string]string{
+		"secrets_dir": config.Steward.Secrets.SecretsDir,
+		"provider":    config.Steward.Secrets.Provider,
+	}
+
+	if config.Steward.ConvergeInterval != "" {
+		d, err := time.ParseDuration(config.Steward.ConvergeInterval)
+		if err != nil {
+			return nil, fmt.Errorf("invalid converge_interval %q: %w", config.Steward.ConvergeInterval, err)
+		}
+		stewardSettings.ConvergeInterval = durationpb.New(d)
+	}
+
+	ss := config.Steward.ScriptSigning
+	protoSS := &controller.ScriptSigningConfig{
+		Policy:        string(ss.Policy),
+		TrustMode:     string(ss.TrustMode),
+		AllowPublicCa: ss.AllowPublicCA,
+	}
+	for _, key := range ss.TrustedKeys {
+		protoSS.TrustedKeys = append(protoSS.TrustedKeys, &controller.TrustedKeyRef{
+			Name:         key.Name,
+			Thumbprint:   key.Thumbprint,
+			PublicKeyRef: key.PublicKeyRef,
+		})
+	}
+	stewardSettings.ScriptSigning = protoSS
+
+	resources := make([]*controller.ResourceConfig, len(config.Resources))
+	for i, res := range config.Resources {
+		configStruct, err := structpb.NewStruct(res.Config)
+		if err != nil {
+			return nil, fmt.Errorf("failed to convert resource config to struct: %w", err)
+		}
+		resources[i] = &controller.ResourceConfig{
+			Name:   res.Name,
+			Module: res.Module,
+			Config: configStruct,
+		}
+	}
+
+	return &controller.StewardConfig{
+		Steward:   stewardSettings,
+		Resources: resources,
+		Modules:   config.Modules,
+	}, nil
+}
+
+// FromProto converts a protobuf StewardConfig to a StewardConfig.
+func FromProto(proto *controller.StewardConfig) (*StewardConfig, error) {
+	if proto == nil {
+		return nil, fmt.Errorf("proto config is nil")
+	}
+
+	config := &StewardConfig{
+		Steward: StewardSettings{
+			ID:          proto.Steward.Id,
+			Mode:        OperationMode(proto.Steward.Mode),
+			ModulePaths: proto.Steward.ModulePaths,
+		},
+		Modules: proto.Modules,
+	}
+
+	if proto.Steward.Logging != nil {
+		config.Steward.Logging = LoggingConfig{
+			Level:  proto.Steward.Logging.Level,
+			Format: proto.Steward.Logging.Format,
+		}
+	}
+
+	if proto.Steward.ErrorHandling != nil {
+		config.Steward.ErrorHandling = ErrorHandlingConfig{
+			ModuleLoadFailure:  ErrorAction(proto.Steward.ErrorHandling.ModuleLoadFailure),
+			ResourceFailure:    ErrorAction(proto.Steward.ErrorHandling.ResourceFailure),
+			ConfigurationError: ErrorAction(proto.Steward.ErrorHandling.ConfigurationError),
+		}
+	}
+
+	if proto.Steward.Secrets != nil {
+		config.Steward.Secrets = SecretsConfig{
+			SecretsDir: proto.Steward.Secrets["secrets_dir"],
+			Provider:   proto.Steward.Secrets["provider"],
+		}
+	}
+
+	if proto.Steward.ConvergeInterval != nil {
+		d := proto.Steward.ConvergeInterval.AsDuration()
+		config.Steward.ConvergeInterval = d.String()
+	}
+
+	if proto.Steward.ScriptSigning != nil {
+		ps := proto.Steward.ScriptSigning
+		sc := ScriptSigningConfig{
+			Policy:        ScriptSigningPolicy(ps.Policy),
+			TrustMode:     ScriptTrustMode(ps.TrustMode),
+			AllowPublicCA: ps.AllowPublicCa,
+		}
+		for _, key := range ps.TrustedKeys {
+			sc.TrustedKeys = append(sc.TrustedKeys, TrustedKeyRef{
+				Name:         key.Name,
+				Thumbprint:   key.Thumbprint,
+				PublicKeyRef: key.PublicKeyRef,
+			})
+		}
+		config.Steward.ScriptSigning = sc
+	}
+
+	config.Resources = make([]ResourceConfig, len(proto.Resources))
+	for i, res := range proto.Resources {
+		config.Resources[i] = ResourceConfig{
+			Name:   res.Name,
+			Module: res.Module,
+			Config: res.Config.AsMap(),
+		}
+	}
+
+	return config, nil
+}

--- a/features/config/stewardtypes/proto_converter_test.go
+++ b/features/config/stewardtypes/proto_converter_test.go
@@ -1,0 +1,238 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+
+package stewardtypes
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestToProtoFromProto_RoundTrip verifies that the basic StewardConfig fields
+// survive a ToProto→FromProto round-trip without loss.
+func TestToProtoFromProto_RoundTrip(t *testing.T) {
+	original := &StewardConfig{
+		Steward: StewardSettings{
+			ID:          "test-steward",
+			Mode:        ModeStandalone,
+			ModulePaths: []string{"/opt/modules", "/usr/local/modules"},
+			Logging: LoggingConfig{
+				Level:  "info",
+				Format: "json",
+			},
+			ErrorHandling: ErrorHandlingConfig{
+				ModuleLoadFailure:  ActionContinue,
+				ResourceFailure:    ActionWarn,
+				ConfigurationError: ActionFail,
+			},
+		},
+		Resources: []ResourceConfig{
+			{
+				Name:   "test-resource",
+				Module: "file",
+				Config: map[string]interface{}{"path": "/etc/test", "content": "hello"},
+			},
+		},
+		Modules: map[string]string{
+			"file": "/opt/modules/file",
+		},
+	}
+
+	proto, err := ToProto(original)
+	require.NoError(t, err)
+	require.NotNil(t, proto)
+
+	restored, err := FromProto(proto)
+	require.NoError(t, err)
+	require.NotNil(t, restored)
+
+	assert.Equal(t, original.Steward.ID, restored.Steward.ID)
+	assert.Equal(t, original.Steward.Mode, restored.Steward.Mode)
+	assert.Equal(t, original.Steward.ModulePaths, restored.Steward.ModulePaths)
+	assert.Equal(t, original.Steward.Logging.Level, restored.Steward.Logging.Level)
+	assert.Equal(t, original.Steward.Logging.Format, restored.Steward.Logging.Format)
+	assert.Equal(t, original.Steward.ErrorHandling.ModuleLoadFailure, restored.Steward.ErrorHandling.ModuleLoadFailure)
+	assert.Equal(t, original.Steward.ErrorHandling.ResourceFailure, restored.Steward.ErrorHandling.ResourceFailure)
+	assert.Equal(t, original.Steward.ErrorHandling.ConfigurationError, restored.Steward.ErrorHandling.ConfigurationError)
+	assert.Equal(t, original.Modules, restored.Modules)
+	require.Len(t, restored.Resources, 1)
+	assert.Equal(t, "test-resource", restored.Resources[0].Name)
+	assert.Equal(t, "file", restored.Resources[0].Module)
+}
+
+// TestToProtoFromProto_Secrets verifies the Secrets field survives a round-trip.
+func TestToProtoFromProto_Secrets(t *testing.T) {
+	original := &StewardConfig{
+		Steward: StewardSettings{
+			ID:   "secrets-steward",
+			Mode: ModeStandalone,
+			Secrets: SecretsConfig{
+				SecretsDir: "/var/lib/cfgms/secrets",
+				Provider:   "steward",
+			},
+			Logging:       LoggingConfig{Level: "info", Format: "text"},
+			ErrorHandling: ErrorHandlingConfig{ModuleLoadFailure: ActionContinue, ResourceFailure: ActionWarn, ConfigurationError: ActionFail},
+		},
+	}
+
+	proto, err := ToProto(original)
+	require.NoError(t, err)
+	require.NotNil(t, proto.Steward.Secrets)
+	assert.Equal(t, "/var/lib/cfgms/secrets", proto.Steward.Secrets["secrets_dir"])
+	assert.Equal(t, "steward", proto.Steward.Secrets["provider"])
+
+	restored, err := FromProto(proto)
+	require.NoError(t, err)
+	assert.Equal(t, "/var/lib/cfgms/secrets", restored.Steward.Secrets.SecretsDir)
+	assert.Equal(t, "steward", restored.Steward.Secrets.Provider)
+}
+
+// TestToProtoFromProto_ConvergeInterval verifies ConvergeInterval survives a round-trip.
+func TestToProtoFromProto_ConvergeInterval(t *testing.T) {
+	original := &StewardConfig{
+		Steward: StewardSettings{
+			ID:               "interval-steward",
+			Mode:             ModeStandalone,
+			ConvergeInterval: "45m",
+			Logging:          LoggingConfig{Level: "info", Format: "text"},
+			ErrorHandling:    ErrorHandlingConfig{ModuleLoadFailure: ActionContinue, ResourceFailure: ActionWarn, ConfigurationError: ActionFail},
+		},
+	}
+
+	proto, err := ToProto(original)
+	require.NoError(t, err)
+	require.NotNil(t, proto.Steward.ConvergeInterval)
+	assert.Equal(t, 45*time.Minute, proto.Steward.ConvergeInterval.AsDuration())
+
+	restored, err := FromProto(proto)
+	require.NoError(t, err)
+	// The round-trip converts "45m" → Duration → String(). Go formats 45m as "45m0s".
+	// Parse both and compare as durations.
+	originalDur, err := time.ParseDuration(original.Steward.ConvergeInterval)
+	require.NoError(t, err)
+	restoredDur, err := time.ParseDuration(restored.Steward.ConvergeInterval)
+	require.NoError(t, err)
+	assert.Equal(t, originalDur, restoredDur)
+}
+
+// TestToProtoFromProto_ScriptSigning verifies ScriptSigning survives a round-trip.
+func TestToProtoFromProto_ScriptSigning(t *testing.T) {
+	original := &StewardConfig{
+		Steward: StewardSettings{
+			ID:   "signing-steward",
+			Mode: ModeStandalone,
+			ScriptSigning: ScriptSigningConfig{
+				Policy:    ScriptSigningPolicyRequired,
+				TrustMode: TrustModeTrustedKeys,
+				TrustedKeys: []TrustedKeyRef{
+					{
+						Name:         "ops-key",
+						Thumbprint:   "AA:BB:CC:DD",
+						PublicKeyRef: "refs/keys/ops",
+					},
+				},
+			},
+			Logging:       LoggingConfig{Level: "info", Format: "text"},
+			ErrorHandling: ErrorHandlingConfig{ModuleLoadFailure: ActionContinue, ResourceFailure: ActionWarn, ConfigurationError: ActionFail},
+		},
+	}
+
+	proto, err := ToProto(original)
+	require.NoError(t, err)
+	require.NotNil(t, proto.Steward.ScriptSigning)
+	assert.Equal(t, "required", proto.Steward.ScriptSigning.Policy)
+	assert.Equal(t, "trusted_keys", proto.Steward.ScriptSigning.TrustMode)
+	require.Len(t, proto.Steward.ScriptSigning.TrustedKeys, 1)
+	assert.Equal(t, "ops-key", proto.Steward.ScriptSigning.TrustedKeys[0].Name)
+	assert.Equal(t, "AA:BB:CC:DD", proto.Steward.ScriptSigning.TrustedKeys[0].Thumbprint)
+	assert.Equal(t, "refs/keys/ops", proto.Steward.ScriptSigning.TrustedKeys[0].PublicKeyRef)
+
+	restored, err := FromProto(proto)
+	require.NoError(t, err)
+	ss := restored.Steward.ScriptSigning
+	assert.Equal(t, ScriptSigningPolicyRequired, ss.Policy)
+	assert.Equal(t, TrustModeTrustedKeys, ss.TrustMode)
+	require.Len(t, ss.TrustedKeys, 1)
+	assert.Equal(t, "ops-key", ss.TrustedKeys[0].Name)
+	assert.Equal(t, "AA:BB:CC:DD", ss.TrustedKeys[0].Thumbprint)
+	assert.Equal(t, "refs/keys/ops", ss.TrustedKeys[0].PublicKeyRef)
+}
+
+// TestToProtoFromProto_AllFields verifies Secrets, ConvergeInterval, and ScriptSigning
+// all survive a single round-trip together.
+func TestToProtoFromProto_AllFields(t *testing.T) {
+	original := &StewardConfig{
+		Steward: StewardSettings{
+			ID:   "full-steward",
+			Mode: ModeStandalone,
+			Secrets: SecretsConfig{
+				SecretsDir: "/run/secrets",
+				Provider:   "vault",
+			},
+			ConvergeInterval: "15m",
+			ScriptSigning: ScriptSigningConfig{
+				Policy:        ScriptSigningPolicyOptional,
+				TrustMode:     TrustModeAnyValid,
+				AllowPublicCA: true,
+			},
+			Logging:       LoggingConfig{Level: "debug", Format: "json"},
+			ErrorHandling: ErrorHandlingConfig{ModuleLoadFailure: ActionContinue, ResourceFailure: ActionWarn, ConfigurationError: ActionFail},
+		},
+	}
+
+	proto, err := ToProto(original)
+	require.NoError(t, err)
+
+	restored, err := FromProto(proto)
+	require.NoError(t, err)
+
+	assert.Equal(t, "/run/secrets", restored.Steward.Secrets.SecretsDir)
+	assert.Equal(t, "vault", restored.Steward.Secrets.Provider)
+
+	origDur, err := time.ParseDuration(original.Steward.ConvergeInterval)
+	require.NoError(t, err)
+	resDur, err := time.ParseDuration(restored.Steward.ConvergeInterval)
+	require.NoError(t, err)
+	assert.Equal(t, origDur, resDur)
+
+	assert.Equal(t, ScriptSigningPolicyOptional, restored.Steward.ScriptSigning.Policy)
+	assert.Equal(t, TrustModeAnyValid, restored.Steward.ScriptSigning.TrustMode)
+	assert.True(t, restored.Steward.ScriptSigning.AllowPublicCA)
+}
+
+// TestToProto_NilConfig verifies that ToProto returns an error on nil input.
+func TestToProto_NilConfig(t *testing.T) {
+	proto, err := ToProto(nil)
+	assert.Error(t, err)
+	assert.Nil(t, proto)
+	assert.Contains(t, err.Error(), "config is nil")
+}
+
+// TestFromProto_NilProto verifies that FromProto returns an error on nil input.
+func TestFromProto_NilProto(t *testing.T) {
+	cfg, err := FromProto(nil)
+	assert.Error(t, err)
+	assert.Nil(t, cfg)
+	assert.Contains(t, err.Error(), "proto config is nil")
+}
+
+// TestToProto_InvalidConvergeInterval verifies that an unparseable converge_interval
+// causes ToProto to return an error rather than silently dropping or corrupting the field.
+func TestToProto_InvalidConvergeInterval(t *testing.T) {
+	cfg := &StewardConfig{
+		Steward: StewardSettings{
+			ID:               "bad-interval-steward",
+			Mode:             ModeStandalone,
+			ConvergeInterval: "not-a-duration",
+			Logging:          LoggingConfig{Level: "info", Format: "text"},
+			ErrorHandling:    ErrorHandlingConfig{ModuleLoadFailure: ActionContinue, ResourceFailure: ActionWarn, ConfigurationError: ActionFail},
+		},
+	}
+	proto, err := ToProto(cfg)
+	assert.Error(t, err)
+	assert.Nil(t, proto)
+	assert.Contains(t, err.Error(), "invalid converge_interval")
+}

--- a/features/controller/api/handlers_configs_test.go
+++ b/features/controller/api/handlers_configs_test.go
@@ -14,8 +14,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	stewardtypes "github.com/cfgis/cfgms/features/config/stewardtypes"
 	"github.com/cfgis/cfgms/features/controller/service"
-	stewardconfig "github.com/cfgis/cfgms/features/steward/config"
 	"github.com/cfgis/cfgms/pkg/logging"
 	storageifaces "github.com/cfgis/cfgms/pkg/storage/interfaces"
 	cfgconfig "github.com/cfgis/cfgms/pkg/storage/interfaces/config"
@@ -64,22 +64,22 @@ func useFailingConfigService(t *testing.T, server *Server) {
 // storeTestConfig stores a minimal valid StewardConfig for the given tenant and steward.
 func storeTestConfig(t *testing.T, server *Server, tenantID, stewardID string) {
 	t.Helper()
-	cfg := &stewardconfig.StewardConfig{
-		Steward: stewardconfig.StewardSettings{
+	cfg := &stewardtypes.StewardConfig{
+		Steward: stewardtypes.StewardSettings{
 			ID:   stewardID,
-			Mode: stewardconfig.ModeController,
-			Logging: stewardconfig.LoggingConfig{
+			Mode: stewardtypes.ModeController,
+			Logging: stewardtypes.LoggingConfig{
 				Level:  "info",
 				Format: "text",
 			},
-			ErrorHandling: stewardconfig.ErrorHandlingConfig{
-				ModuleLoadFailure:  stewardconfig.ActionContinue,
-				ResourceFailure:    stewardconfig.ActionWarn,
-				ConfigurationError: stewardconfig.ActionFail,
+			ErrorHandling: stewardtypes.ErrorHandlingConfig{
+				ModuleLoadFailure:  stewardtypes.ActionContinue,
+				ResourceFailure:    stewardtypes.ActionWarn,
+				ConfigurationError: stewardtypes.ActionFail,
 			},
 		},
 		Modules:   map[string]string{"file": "file"},
-		Resources: []stewardconfig.ResourceConfig{},
+		Resources: []stewardtypes.ResourceConfig{},
 	}
 	err := server.configService.SetConfiguration(context.Background(), tenantID, stewardID, cfg)
 	require.NoError(t, err)

--- a/features/controller/api/handlers_stewards.go
+++ b/features/controller/api/handlers_stewards.go
@@ -16,8 +16,8 @@ import (
 	"gopkg.in/yaml.v3"
 
 	controller "github.com/cfgis/cfgms/api/proto/controller"
+	stewardtypes "github.com/cfgis/cfgms/features/config/stewardtypes"
 	"github.com/cfgis/cfgms/features/controller/fleet"
-	stewardconfig "github.com/cfgis/cfgms/features/steward/config"
 	"github.com/cfgis/cfgms/pkg/ctxkeys"
 	"github.com/cfgis/cfgms/pkg/logging"
 )
@@ -281,7 +281,7 @@ func (s *Server) handleGetStewardConfig(w http.ResponseWriter, r *http.Request) 
 	}
 
 	// Convert protobuf to Go struct
-	goConfig, err := stewardconfig.FromProto(protoConfig)
+	goConfig, err := stewardtypes.FromProto(protoConfig)
 	if err != nil {
 		s.logger.Error("Failed to convert protobuf to Go struct", "error", err)
 		s.writeErrorResponse(w, http.StatusInternalServerError, "Failed to convert configuration", "CONVERSION_ERROR")
@@ -330,7 +330,7 @@ func (s *Server) handleUpdateStewardConfig(w http.ResponseWriter, r *http.Reques
 
 	// Parse request body into StewardConfig
 	// Support both JSON (legacy) and YAML (production .cfg format)
-	var config stewardconfig.StewardConfig
+	var config stewardtypes.StewardConfig
 	contentType := r.Header.Get("Content-Type")
 
 	// Read body

--- a/features/controller/api/handlers_stewards_test.go
+++ b/features/controller/api/handlers_stewards_test.go
@@ -590,3 +590,64 @@ func TestHandleDeleteStewardConfig(t *testing.T) {
 		assert.Equal(t, "INTERNAL_ERROR", errResp.Error.Code)
 	})
 }
+
+// TestHandleGetStewardConfig_HappyPath exercises the stewardtypes.FromProto conversion
+// path inside handleGetStewardConfig: register a steward, store a config, then GET it.
+func TestHandleGetStewardConfig_HappyPath(t *testing.T) {
+	server := setupTestServer(t)
+	apiKey := NewTestKey(t, server, []string{"steward:read-config"})
+
+	// Register a steward so GetConfiguration can look up its tenant.
+	stewardID := registerTestSteward(t, server.controllerService, map[string]string{
+		"hostname": "cfg-test-host", "os": "linux",
+	})
+
+	// Store a config — uses the same "test-tenant" that registerTestSteward injects
+	// via context. The inheritance resolver will fall back to device-level config since
+	// "test-tenant" has no full TenantData record in this in-memory test setup.
+	storeTestConfig(t, server, "test-tenant", stewardID)
+
+	req := httptest.NewRequest("GET", "/api/v1/stewards/"+stewardID+"/config", nil)
+	req.Header.Set("X-API-Key", apiKey)
+	rec := httptest.NewRecorder()
+	server.router.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	var resp APIResponse
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
+	data, ok := resp.Data.(map[string]interface{})
+	require.True(t, ok, "response data must be a map, got %T", resp.Data)
+	assert.Equal(t, stewardID, data["steward_id"])
+	assert.Contains(t, data, "config")
+}
+
+// TestHandleGetStewardConfig_StewardNotRegistered verifies that requesting config for
+// an unknown steward returns 400 CONFIG_ERROR (configService returns NOT_FOUND).
+func TestHandleGetStewardConfig_StewardNotRegistered(t *testing.T) {
+	server := setupTestServer(t)
+	apiKey := NewTestKey(t, server, []string{"steward:read-config"})
+
+	req := httptest.NewRequest("GET", "/api/v1/stewards/nonexistent-steward/config", nil)
+	req.Header.Set("X-API-Key", apiKey)
+	rec := httptest.NewRecorder()
+	server.router.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+	var errResp ErrorResponse
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&errResp))
+	assert.Equal(t, "CONFIG_ERROR", errResp.Error.Code)
+}
+
+// TestHandleGetStewardConfig_InsufficientPermission verifies 403 when the API key
+// lacks steward:read-config permission.
+func TestHandleGetStewardConfig_InsufficientPermission(t *testing.T) {
+	server := setupTestServer(t)
+	apiKey := NewTestKey(t, server, []string{"steward:list"})
+
+	req := httptest.NewRequest("GET", "/api/v1/stewards/any-steward/config", nil)
+	req.Header.Set("X-API-Key", apiKey)
+	rec := httptest.NewRecorder()
+	server.router.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusForbidden, rec.Code)
+}

--- a/features/controller/api/server_test.go
+++ b/features/controller/api/server_test.go
@@ -15,11 +15,11 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	stewardtypes "github.com/cfgis/cfgms/features/config/stewardtypes"
 	"github.com/cfgis/cfgms/features/controller/commands"
 	"github.com/cfgis/cfgms/features/controller/config"
 	"github.com/cfgis/cfgms/features/controller/service"
 	"github.com/cfgis/cfgms/features/rbac"
-	stewardconfig "github.com/cfgis/cfgms/features/steward/config"
 	"github.com/cfgis/cfgms/features/tenant"
 	"github.com/cfgis/cfgms/pkg/audit"
 	cpInterfaces "github.com/cfgis/cfgms/pkg/controlplane/interfaces"
@@ -1386,20 +1386,20 @@ func setupServerWithPublisher(t *testing.T, cp *testControlPlane) (*Server, *ser
 // on the config service when commandPublisher is non-nil, and that the callback correctly
 // dispatches push.Fanout() to active stewards of the affected tenant only.
 func TestNew_FanoutCallbackWired(t *testing.T) {
-	minimalStewardCfg := func(id string) *stewardconfig.StewardConfig {
-		return &stewardconfig.StewardConfig{
-			Steward: stewardconfig.StewardSettings{
+	minimalStewardCfg := func(id string) *stewardtypes.StewardConfig {
+		return &stewardtypes.StewardConfig{
+			Steward: stewardtypes.StewardSettings{
 				ID:      id,
-				Mode:    stewardconfig.ModeController,
-				Logging: stewardconfig.LoggingConfig{Level: "info", Format: "text"},
-				ErrorHandling: stewardconfig.ErrorHandlingConfig{
-					ModuleLoadFailure:  stewardconfig.ActionContinue,
-					ResourceFailure:    stewardconfig.ActionWarn,
-					ConfigurationError: stewardconfig.ActionFail,
+				Mode:    stewardtypes.ModeController,
+				Logging: stewardtypes.LoggingConfig{Level: "info", Format: "text"},
+				ErrorHandling: stewardtypes.ErrorHandlingConfig{
+					ModuleLoadFailure:  stewardtypes.ActionContinue,
+					ResourceFailure:    stewardtypes.ActionWarn,
+					ConfigurationError: stewardtypes.ActionFail,
 				},
 			},
 			Modules: map[string]string{"file": "file"},
-			Resources: []stewardconfig.ResourceConfig{
+			Resources: []stewardtypes.ResourceConfig{
 				{Name: "f", Module: "file", Config: map[string]interface{}{"path": "/tmp/f", "content": "x"}},
 			},
 		}

--- a/features/controller/transport/config_handler_test.go
+++ b/features/controller/transport/config_handler_test.go
@@ -21,8 +21,8 @@ import (
 
 	transportpb "github.com/cfgis/cfgms/api/proto/transport"
 	"github.com/cfgis/cfgms/features/config/signature"
+	stewardtypes "github.com/cfgis/cfgms/features/config/stewardtypes"
 	"github.com/cfgis/cfgms/features/controller/service"
-	stewardconfig "github.com/cfgis/cfgms/features/steward/config"
 	cfgcert "github.com/cfgis/cfgms/pkg/cert"
 	dataplaneTypes "github.com/cfgis/cfgms/pkg/dataplane/types"
 	"github.com/cfgis/cfgms/pkg/logging"
@@ -107,25 +107,25 @@ func createTestService(t *testing.T) *service.ConfigurationServiceV2 {
 }
 
 // minimalStewardConfig returns a valid StewardConfig for stewardID.
-func minimalStewardConfig(stewardID string) *stewardconfig.StewardConfig {
-	return &stewardconfig.StewardConfig{
-		Steward: stewardconfig.StewardSettings{
+func minimalStewardConfig(stewardID string) *stewardtypes.StewardConfig {
+	return &stewardtypes.StewardConfig{
+		Steward: stewardtypes.StewardSettings{
 			ID:   stewardID,
-			Mode: stewardconfig.ModeController,
-			Logging: stewardconfig.LoggingConfig{
+			Mode: stewardtypes.ModeController,
+			Logging: stewardtypes.LoggingConfig{
 				Level:  "info",
 				Format: "text",
 			},
-			ErrorHandling: stewardconfig.ErrorHandlingConfig{
-				ModuleLoadFailure:  stewardconfig.ActionContinue,
-				ResourceFailure:    stewardconfig.ActionWarn,
-				ConfigurationError: stewardconfig.ActionFail,
+			ErrorHandling: stewardtypes.ErrorHandlingConfig{
+				ModuleLoadFailure:  stewardtypes.ActionContinue,
+				ResourceFailure:    stewardtypes.ActionWarn,
+				ConfigurationError: stewardtypes.ActionFail,
 			},
 		},
 		Modules: map[string]string{
 			"directory": "directory",
 		},
-		Resources: []stewardconfig.ResourceConfig{
+		Resources: []stewardtypes.ResourceConfig{
 			{
 				Name:   "test-dir",
 				Module: "directory",


### PR DESCRIPTION
## Summary

- Added `features/config/stewardtypes/proto_converter.go` with `FromProto`/`ToProto` functions so `stewardtypes` is self-contained and controller code no longer needs to reach into `features/steward/config` for proto conversion
- Swapped import `stewardconfig "features/steward/config"` → `stewardtypes "features/config/stewardtypes"` in `handlers_stewards.go`, `handlers_configs_test.go`, `server_test.go`, and `config_handler_test.go`
- Added 8 proto converter tests and 3 handler tests for `handleGetStewardConfig` (happy path through `FromProto`, unregistered steward 400, insufficient permission 403)

Fixes #1759

## Acceptance Criteria Verification

The AC grep returns zero hits:
```
grep '"github.com/cfgis/cfgms/features/steward/config"' \
  features/controller/api/ features/controller/transport/ \
  | grep -v 'handlers_workflows_test.go\|registration_hook_test.go'
```

`go vet ./features/controller/api/... ./features/controller/transport/...` — clean

## Specialist Review Results

| Reviewer | Result |
|----------|--------|
| QA Test Runner | ✅ PASS — all tests pass, golangci-lint clean, cross-platform builds pass |
| QA Code Reviewer | ✅ PASS — no blocking issues, test coverage verified |
| Security Engineer | ✅ PASS — no security findings, architecture checks clean |

🤖 Generated with [Claude Code](https://claude.com/claude-code)