### PR TITLE
registration: implement durable PendingRegistrationStore with poll status endpoint (Issue #1696)

### DIFF
--- a/cmd/cfg/cmd/api_client.go
+++ b/cmd/cfg/cmd/api_client.go
@@ -250,6 +250,7 @@ func (c *APIClient) RotateToken(ctx context.Context, tenantID, group string) (*A
 
 // APIPendingRegistration represents a quarantined steward awaiting approval in API responses.
 type APIPendingRegistration struct {
+	PendingID    string    `json:"pending_id"`
 	StewardID    string    `json:"steward_id"`
 	TenantID     string    `json:"tenant_id"`
 	SourceIP     string    `json:"source_ip"`
@@ -276,9 +277,9 @@ func (c *APIClient) ListPendingRegistrations(ctx context.Context) ([]APIPendingR
 	return pending, nil
 }
 
-// ApproveRegistration approves a quarantined steward, promoting it to registered status.
-func (c *APIClient) ApproveRegistration(ctx context.Context, stewardID string) error {
-	resp, err := c.doRequest(ctx, "POST", "/api/v1/registration/"+stewardID+"/approve", nil)
+// ApproveRegistration approves a quarantined steward registration by pending_id.
+func (c *APIClient) ApproveRegistration(ctx context.Context, pendingID string) error {
+	resp, err := c.doRequest(ctx, "POST", "/api/v1/registration/"+pendingID+"/approve", nil)
 	if err != nil {
 		return err
 	}
@@ -291,8 +292,8 @@ func (c *APIClient) ApproveRegistration(ctx context.Context, stewardID string) e
 	return nil
 }
 
-// DenyRegistration denies a quarantined steward registration with an optional reason.
-func (c *APIClient) DenyRegistration(ctx context.Context, stewardID, reason string) error {
+// DenyRegistration denies a quarantined steward registration by pending_id with an optional reason.
+func (c *APIClient) DenyRegistration(ctx context.Context, pendingID, reason string) error {
 	body, err := json.Marshal(struct {
 		Reason string `json:"reason,omitempty"`
 	}{Reason: reason})
@@ -300,7 +301,7 @@ func (c *APIClient) DenyRegistration(ctx context.Context, stewardID, reason stri
 		return fmt.Errorf("failed to marshal request: %w", err)
 	}
 
-	resp, err := c.doRequest(ctx, "POST", "/api/v1/registration/"+stewardID+"/deny", bytes.NewReader(body))
+	resp, err := c.doRequest(ctx, "POST", "/api/v1/registration/"+pendingID+"/deny", bytes.NewReader(body))
 	if err != nil {
 		return err
 	}

--- a/cmd/cfg/cmd/registration.go
+++ b/cmd/cfg/cmd/registration.go
@@ -69,32 +69,31 @@ Examples:
 
 // registrationApproveCmd approves a quarantined steward registration.
 var registrationApproveCmd = &cobra.Command{
-	Use:   "approve <steward-id>",
+	Use:   "approve <pending-id>",
 	Short: "Approve a pending steward registration",
-	Long: `Approve a quarantined steward, promoting it to registered status.
+	Long: `Approve a quarantined steward registration by its pending_id.
 
-After approval, the steward gains full access to its configured policies,
-secrets, and scripts.
+After approval, the steward's next poll returns the mTLS certificate bundle and
+it gains full access to its configured policies, secrets, and scripts.
 
 Examples:
-  cfg registration approve steward-1234567890`,
+  cfg registration approve pending-1234567890`,
 	Args: cobra.ExactArgs(1),
 	RunE: runRegistrationApprove,
 }
 
 // registrationDenyCmd denies a quarantined steward registration.
 var registrationDenyCmd = &cobra.Command{
-	Use:   "deny <steward-id>",
+	Use:   "deny <pending-id>",
 	Short: "Deny a pending steward registration",
-	Long: `Deny a quarantined steward registration, removing it from the pending queue.
+	Long: `Deny a quarantined steward registration by its pending_id.
 
-The steward's registration record is kept (it remains quarantined in the fleet
-registry) but it is removed from the approval queue. The steward must re-register
-to appear in the pending queue again.
+The entry is marked denied; the steward's next poll returns status="denied".
+The steward must re-register to obtain a new pending_id.
 
 Examples:
-  cfg registration deny steward-1234567890
-  cfg registration deny steward-1234567890 --reason "Unauthorized deployment"`,
+  cfg registration deny pending-1234567890
+  cfg registration deny pending-1234567890 --reason "Unauthorized deployment"`,
 	Args: cobra.ExactArgs(1),
 	RunE: runRegistrationDeny,
 }
@@ -174,10 +173,10 @@ func runRegistrationPending(cmd *cobra.Command, args []string) error {
 
 	fmt.Printf("Pending registrations (%d):\n\n", len(pending))
 	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
-	_, _ = fmt.Fprintf(w, "STEWARD ID\tTENANT ID\tSOURCE IP\tREGISTERED AT\n")
+	_, _ = fmt.Fprintf(w, "PENDING ID\tSTEWARD ID\tTENANT ID\tSOURCE IP\tREGISTERED AT\n")
 	for _, pr := range pending {
 		registeredAt := pr.RegisteredAt.UTC().Format(time.RFC3339)
-		_, _ = fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", pr.StewardID, pr.TenantID, pr.SourceIP, registeredAt)
+		_, _ = fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n", pr.PendingID, pr.StewardID, pr.TenantID, pr.SourceIP, registeredAt)
 	}
 	_ = w.Flush()
 
@@ -185,31 +184,31 @@ func runRegistrationPending(cmd *cobra.Command, args []string) error {
 }
 
 func runRegistrationApprove(cmd *cobra.Command, args []string) error {
-	stewardID := args[0]
+	pendingID := args[0]
 	client, err := getRegistrationClient()
 	if err != nil {
 		return fmt.Errorf("failed to create API client: %w", err)
 	}
 
-	if err := client.ApproveRegistration(context.Background(), stewardID); err != nil {
-		return fmt.Errorf("failed to approve registration for %s: %w", stewardID, err)
+	if err := client.ApproveRegistration(context.Background(), pendingID); err != nil {
+		return fmt.Errorf("failed to approve registration %s: %w", pendingID, err)
 	}
 
-	fmt.Printf("Registration approved: %s\n", stewardID)
+	fmt.Printf("Registration approved: %s\n", pendingID)
 	return nil
 }
 
 func runRegistrationDeny(cmd *cobra.Command, args []string) error {
-	stewardID := args[0]
+	pendingID := args[0]
 	client, err := getRegistrationClient()
 	if err != nil {
 		return fmt.Errorf("failed to create API client: %w", err)
 	}
 
-	if err := client.DenyRegistration(context.Background(), stewardID, registrationDenyReason); err != nil {
-		return fmt.Errorf("failed to deny registration for %s: %w", stewardID, err)
+	if err := client.DenyRegistration(context.Background(), pendingID, registrationDenyReason); err != nil {
+		return fmt.Errorf("failed to deny registration %s: %w", pendingID, err)
 	}
 
-	fmt.Printf("Registration denied: %s\n", stewardID)
+	fmt.Printf("Registration denied: %s\n", pendingID)
 	return nil
 }

--- a/cmd/cfg/cmd/registration_test.go
+++ b/cmd/cfg/cmd/registration_test.go
@@ -22,6 +22,7 @@ func newRegistrationServer(t *testing.T) *httptest.Server {
 	registeredAt := time.Now().UTC()
 	pending := []APIPendingRegistration{
 		{
+			PendingID:    "pending-1234567890",
 			StewardID:    "steward-1234567890",
 			TenantID:     "test-tenant",
 			SourceIP:     "10.0.0.1",
@@ -67,7 +68,8 @@ func TestRegistrationPendingCommand(t *testing.T) {
 			require.NoError(t, err)
 		})
 
-		assert.Contains(t, output, "steward-1234567890")
+		assert.Contains(t, output, "pending-1234567890", "PENDING ID column must appear")
+		assert.Contains(t, output, "steward-1234567890", "STEWARD ID column must appear")
 		assert.Contains(t, output, "test-tenant")
 		assert.Contains(t, output, "10.0.0.1")
 		assert.Contains(t, output, "Pending registrations")
@@ -98,6 +100,7 @@ func TestRegistrationPendingCommand(t *testing.T) {
 		var parsed []APIPendingRegistration
 		require.NoError(t, json.Unmarshal([]byte(output), &parsed), "output must be valid JSON")
 		require.Len(t, parsed, 1)
+		assert.Equal(t, "pending-1234567890", parsed[0].PendingID)
 		assert.Equal(t, "steward-1234567890", parsed[0].StewardID)
 		assert.Equal(t, "test-tenant", parsed[0].TenantID)
 	})
@@ -169,12 +172,12 @@ func TestRegistrationApproveCommand(t *testing.T) {
 		registrationTLSInsecure = true
 
 		output := captureStdout(t, func() {
-			err := runRegistrationApprove(registrationApproveCmd, []string{"steward-1234567890"})
+			err := runRegistrationApprove(registrationApproveCmd, []string{"pending-1234567890"})
 			require.NoError(t, err)
 		})
 
 		assert.Contains(t, output, "Registration approved")
-		assert.Contains(t, output, "steward-1234567890")
+		assert.Contains(t, output, "pending-1234567890")
 	})
 
 	t.Run("not found returns error", func(t *testing.T) {
@@ -242,12 +245,12 @@ func TestRegistrationDenyCommand(t *testing.T) {
 		registrationDenyReason = ""
 
 		output := captureStdout(t, func() {
-			err := runRegistrationDeny(registrationDenyCmd, []string{"steward-1234567890"})
+			err := runRegistrationDeny(registrationDenyCmd, []string{"pending-1234567890"})
 			require.NoError(t, err)
 		})
 
 		assert.Contains(t, output, "Registration denied")
-		assert.Contains(t, output, "steward-1234567890")
+		assert.Contains(t, output, "pending-1234567890")
 	})
 
 	t.Run("deny with reason", func(t *testing.T) {
@@ -279,7 +282,7 @@ func TestRegistrationDenyCommand(t *testing.T) {
 		registrationDenyReason = "Unauthorized deployment"
 
 		output := captureStdout(t, func() {
-			err := runRegistrationDeny(registrationDenyCmd, []string{"steward-1234567890"})
+			err := runRegistrationDeny(registrationDenyCmd, []string{"pending-1234567890"})
 			require.NoError(t, err)
 		})
 

--- a/docs/architecture/controller-operating-model.md
+++ b/docs/architecture/controller-operating-model.md
@@ -467,11 +467,26 @@ The controller is the certificate authority and identity provider for stewards. 
    - **`manual-review`** (production): quarantines the steward pending operator action. Sets `registration_decision: quarantine` so the steward is restricted to baseline config until promoted. Operators use `cfg registration pending` to list quarantined stewards, `cfg registration approve <id>` to promote, and `cfg registration deny <id> [--reason ...]` to reject.
    - **`auto-approve`** (deprecated): approves every valid registration unconditionally. Dev/test environments only — a startup warning is logged. Replaces the legacy `DefaultApprovalHook`.
    - Custom workflows can implement arbitrary policy (e.g., approve `tenant=lab` registrations, reject everything else)
-5. On approval (`approve`): controller generates the steward ID and issues an mTLS client certificate scoped to the steward's tenant/group identity.
-   On quarantine (`quarantine`): controller issues certificates but restricts the steward to baseline configuration only (no secrets, no scripts) until an administrator promotes it.
-   On rejection (`reject`): registration is denied.
-6. Controller distributes the CA cert, signing cert, and connection details.
-7. Steward is now a trusted member of the fleet and stores its cert for subsequent startups.
+5. On approval (`approve`): controller generates the steward ID and issues an mTLS client certificate scoped to the steward's tenant/group identity (HTTP 200 with full cert bundle).
+   On quarantine (`quarantine`): controller returns HTTP 202 with a `pending_id` and no certificates. The pending entry is written to the durable `PendingRegistrationStore` (SQLite in OSS, PostgreSQL in commercial). The steward polls `GET /api/v1/registration/status/{pending_id}` with its registration token as a Bearer credential until the operator acts. Operators use `cfg registration approve <pending-id>` or `cfg registration deny <pending-id>`.
+   On rejection (`reject`): HTTP 403 is returned; registration is denied.
+6. **Generate-on-claim (quarantine path):** When the operator approves an entry and the steward polls again, the controller generates the mTLS certificate in memory for that single response, marks the entry as `claimed`, and returns the full cert bundle in HTTP 200. A subsequent poll on an already-claimed entry returns HTTP 410 Gone — the cert is never re-issued. Private keys are never stored in the database.
+7. Controller distributes the CA cert, signing cert, and connection details.
+8. Steward is now a trusted member of the fleet and stores its cert for subsequent startups.
+
+**Registration status endpoint (Issue #1696):**
+
+`GET /api/v1/registration/status/{pending_id}` — authenticated with `Authorization: Bearer <regToken>`.
+
+| Response | Meaning |
+|----------|---------|
+| HTTP 200 `{"status":"pending"}` | Operator has not yet acted |
+| HTTP 200 `{"status":"claimed", "client_cert":..., ...}` | Approved and cert issued — steward should connect now |
+| HTTP 410 Gone | Already claimed (duplicate poll) — stop polling |
+| HTTP 200 `{"status":"denied"}` | Operator denied — steward should exit or re-register |
+| HTTP 200 `{"status":"expired"}` | Entry expired before operator acted — steward should re-register |
+| HTTP 403 | Token tenant ≠ entry tenant (tenant isolation) |
+| HTTP 401 | Invalid or missing Bearer token |
 
 **Configuring the registration workflow (`controller.cfg`):**
 

--- a/docs/architecture/steward-operating-model.md
+++ b/docs/architecture/steward-operating-model.md
@@ -347,9 +347,15 @@ The administrator chooses which flavor fits the deployment workflow. Both arrive
 3. Steward contacts its compile-time controller URL (HTTPS), submits the token.
 4. Controller validates the token (perennial token: check expiry and revocation; long-lived code: look up the matching tenant/group record) and applies the registration approval workflow:
    - **Approved** (HTTP 200): controller issues mTLS certificates scoped to the steward's tenant/group identity and returns the full `RegistrationResponse` with `client_cert`, `client_key`, and `ca_cert`.
-   - **Quarantined** (HTTP 202): controller returns a `RegistrationPendingResponse` with a `pending_id` and `status: "pending"`. No certificates are issued. The steward must enter a poll loop (see story 7) waiting for operator approval via `cfg registration approve <id>`.
+   - **Quarantined** (HTTP 202): controller returns a `RegistrationPendingResponse` with a `pending_id` and `status: "pending"`. No certificates are issued. The steward enters a **Phase 2 poll loop** (see below).
    - **Rejected** (HTTP 403): registration is denied; steward exits.
-5. On approval (HTTP 200): steward imports the issued cert into its local `cert.Manager` (stored under the platform cert dir) for use in TLS handshakes, records the node ID, and establishes a gRPC-over-QUIC transport connection.
+5. **Phase 2 — Poll loop (quarantine path):** The steward polls `GET /api/v1/registration/status/{pending_id}` using `Authorization: Bearer <regToken>`. Poll interval = `baseInterval + rand(jitter)` (default 90 s base, 30 s jitter). Possible outcomes:
+   - `{"status":"pending"}` (HTTP 200): operator has not yet acted — continue polling.
+   - `{"status":"claimed", "client_cert":..., ...}` (HTTP 200): operator approved; cert bundle returned exactly once. Steward imports certs and proceeds to step 6.
+   - HTTP 410 Gone: steward already collected the cert (duplicate poll) — stop polling.
+   - `{"status":"denied"}` or `{"status":"expired"}` (HTTP 200): registration was rejected — steward exits or re-registers.
+   The cert is generated on first approved poll (generate-on-claim); the controller never stores private keys in the database.
+6. On approval: steward imports the issued cert into its local `cert.Manager` (stored under the platform cert dir) for use in TLS handshakes, records the node ID, and establishes a gRPC-over-QUIC transport connection.
 6. Steward checks for a cfg from the controller.
 7. Normal operation begins.
 

--- a/features/controller/api/handlers_registration.go
+++ b/features/controller/api/handlers_registration.go
@@ -137,7 +137,7 @@ func (s *Server) handleApproveRegistration(w http.ResponseWriter, r *http.Reques
 		return
 	}
 	if err := s.pendingStore.UpdateStatus(r.Context(), pendingID, business.PendingRegistrationStatusApproved); err != nil {
-		s.logger.Error("Failed to approve pending registration", "pending_id", logging.SanitizeLogValue(pendingID), "error", err)
+		s.logger.Error("Failed to approve pending registration", "pending_id", logging.SanitizeLogValue(pendingID), "error", logging.SanitizeLogValue(err.Error()))
 		http.Error(w, "Failed to approve registration", http.StatusInternalServerError)
 		return
 	}
@@ -165,7 +165,7 @@ func (s *Server) handleDenyRegistration(w http.ResponseWriter, r *http.Request) 
 	var req denyRegistrationRequest
 	_ = json.NewDecoder(r.Body).Decode(&req)
 	if err := s.pendingStore.UpdateStatus(r.Context(), pendingID, business.PendingRegistrationStatusDenied); err != nil {
-		s.logger.Error("Failed to deny pending registration", "pending_id", logging.SanitizeLogValue(pendingID), "error", err)
+		s.logger.Error("Failed to deny pending registration", "pending_id", logging.SanitizeLogValue(pendingID), "error", logging.SanitizeLogValue(err.Error()))
 		http.Error(w, "Failed to deny registration", http.StatusInternalServerError)
 		return
 	}
@@ -241,7 +241,7 @@ func (s *Server) handleRegistrationStatus(w http.ResponseWriter, r *http.Request
 				w.WriteHeader(http.StatusGone)
 				return
 			}
-			s.logger.Error("Failed to mark pending entry as claimed", "pending_id", logging.SanitizeLogValue(pendingID), "error", err)
+			s.logger.Error("Failed to mark pending entry as claimed", "pending_id", logging.SanitizeLogValue(pendingID), "error", logging.SanitizeLogValue(err.Error()))
 			http.Error(w, "Failed to claim registration", http.StatusInternalServerError)
 			return
 		}

--- a/features/controller/api/handlers_registration.go
+++ b/features/controller/api/handlers_registration.go
@@ -81,7 +81,7 @@ type RegistrationStatusResponse struct {
 	ClientKey        string `json:"client_key,omitempty"`
 	CACert           string `json:"ca_cert,omitempty"`
 	ServerCert       string `json:"server_cert,omitempty"`
-	SigningCert       string `json:"signing_cert,omitempty"`
+	SigningCert      string `json:"signing_cert,omitempty"`
 }
 
 // denyRegistrationRequest is the optional request body for the deny endpoint.
@@ -132,16 +132,16 @@ func (s *Server) handleApproveRegistration(w http.ResponseWriter, r *http.Reques
 			http.Error(w, "pending registration not found", http.StatusNotFound)
 			return
 		}
-		s.logger.Error("Failed to look up pending registration", "pending_id", pendingID, "error", err)
+		s.logger.Error("Failed to look up pending registration", "pending_id", logging.SanitizeLogValue(pendingID), "error", err)
 		http.Error(w, "Failed to look up pending registration", http.StatusInternalServerError)
 		return
 	}
 	if err := s.pendingStore.UpdateStatus(r.Context(), pendingID, business.PendingRegistrationStatusApproved); err != nil {
-		s.logger.Error("Failed to approve pending registration", "pending_id", pendingID, "error", err)
+		s.logger.Error("Failed to approve pending registration", "pending_id", logging.SanitizeLogValue(pendingID), "error", err)
 		http.Error(w, "Failed to approve registration", http.StatusInternalServerError)
 		return
 	}
-	s.logger.Info("Steward registration approved (awaiting claim)", "pending_id", pendingID)
+	s.logger.Info("Steward registration approved (awaiting claim)", "pending_id", logging.SanitizeLogValue(pendingID))
 	w.WriteHeader(http.StatusOK)
 }
 
@@ -158,19 +158,19 @@ func (s *Server) handleDenyRegistration(w http.ResponseWriter, r *http.Request) 
 			http.Error(w, "pending registration not found", http.StatusNotFound)
 			return
 		}
-		s.logger.Error("Failed to look up pending registration", "pending_id", pendingID, "error", err)
+		s.logger.Error("Failed to look up pending registration", "pending_id", logging.SanitizeLogValue(pendingID), "error", err)
 		http.Error(w, "Failed to look up pending registration", http.StatusInternalServerError)
 		return
 	}
 	var req denyRegistrationRequest
 	_ = json.NewDecoder(r.Body).Decode(&req)
 	if err := s.pendingStore.UpdateStatus(r.Context(), pendingID, business.PendingRegistrationStatusDenied); err != nil {
-		s.logger.Error("Failed to deny pending registration", "pending_id", pendingID, "error", err)
+		s.logger.Error("Failed to deny pending registration", "pending_id", logging.SanitizeLogValue(pendingID), "error", err)
 		http.Error(w, "Failed to deny registration", http.StatusInternalServerError)
 		return
 	}
 	s.logger.Info("Steward registration denied",
-		"pending_id", pendingID,
+		"pending_id", logging.SanitizeLogValue(pendingID),
 		"reason", logging.SanitizeLogValue(req.Reason))
 	w.WriteHeader(http.StatusOK)
 }
@@ -212,7 +212,7 @@ func (s *Server) handleRegistrationStatus(w http.ResponseWriter, r *http.Request
 			http.Error(w, "pending registration not found", http.StatusNotFound)
 			return
 		}
-		s.logger.Error("Failed to retrieve pending registration", "pending_id", pendingID, "error", err)
+		s.logger.Error("Failed to retrieve pending registration", "pending_id", logging.SanitizeLogValue(pendingID), "error", err)
 		http.Error(w, "Failed to retrieve pending registration", http.StatusInternalServerError)
 		return
 	}
@@ -241,14 +241,14 @@ func (s *Server) handleRegistrationStatus(w http.ResponseWriter, r *http.Request
 				w.WriteHeader(http.StatusGone)
 				return
 			}
-			s.logger.Error("Failed to mark pending entry as claimed", "pending_id", pendingID, "error", err)
+			s.logger.Error("Failed to mark pending entry as claimed", "pending_id", logging.SanitizeLogValue(pendingID), "error", err)
 			http.Error(w, "Failed to claim registration", http.StatusInternalServerError)
 			return
 		}
 		resp, err := s.buildClaimResponse(r.Context(), entry)
 		if err != nil {
 			s.logger.Error("Failed to generate cert for claimed registration",
-				"pending_id", pendingID, "steward_id", entry.StewardID, "error", err)
+				"pending_id", logging.SanitizeLogValue(pendingID), "steward_id", logging.SanitizeLogValue(entry.StewardID), "error", err)
 			// Entry is already "claimed" — steward must re-register if cert was not received.
 			http.Error(w, "Failed to generate client certificate", http.StatusInternalServerError)
 			return

--- a/features/controller/api/handlers_registration.go
+++ b/features/controller/api/handlers_registration.go
@@ -39,13 +39,9 @@ type RegistrationResponse struct {
 	CACert     string `json:"ca_cert,omitempty"`
 
 	// Controller's server certificate (public key) for configuration signature verification
-	// Stewards use this to verify configs signed by this controller
-	// In HA clusters, stewards collect and trust certs from all controllers they connect to
 	ServerCert string `json:"server_cert,omitempty"`
 
 	// Story #377: Dedicated config signing certificate (separated architecture)
-	// When present, stewards should use this for config signature verification instead of ServerCert
-	// In unified mode, this is empty and ServerCert is used for both
 	SigningCert string `json:"signing_cert,omitempty"`
 }
 
@@ -60,13 +56,32 @@ type RegistrationPendingResponse struct {
 	Status    string `json:"status"`
 }
 
-// PendingRegistration represents a quarantined steward awaiting admin approval.
+// PendingRegistration represents a quarantined steward awaiting admin approval in list responses.
 type PendingRegistration struct {
 	PendingID    string    `json:"pending_id"`
 	StewardID    string    `json:"steward_id"`
 	TenantID     string    `json:"tenant_id"`
 	SourceIP     string    `json:"source_ip"`
 	RegisteredAt time.Time `json:"registered_at"`
+}
+
+// RegistrationStatusResponse is returned by GET /api/v1/registration/status/{pending_id}.
+// For terminal-approved (claimed) entries it includes the full cert bundle; other states
+// include only Status.
+type RegistrationStatusResponse struct {
+	Status string `json:"status"`
+
+	// Populated only when status transitions from "approved" to "claimed":
+	StewardID        string `json:"steward_id,omitempty"`
+	TenantID         string `json:"tenant_id,omitempty"`
+	Group            string `json:"group,omitempty"`
+	ControllerURL    string `json:"controller_url,omitempty"`
+	TransportAddress string `json:"transport_address,omitempty"`
+	ClientCert       string `json:"client_cert,omitempty"`
+	ClientKey        string `json:"client_key,omitempty"`
+	CACert           string `json:"ca_cert,omitempty"`
+	ServerCert       string `json:"server_cert,omitempty"`
+	SigningCert       string `json:"signing_cert,omitempty"`
 }
 
 // denyRegistrationRequest is the optional request body for the deny endpoint.
@@ -77,15 +92,26 @@ type denyRegistrationRequest struct {
 // handleListPendingRegistrations handles GET /api/v1/registration/pending.
 // Returns all quarantined stewards awaiting operator approval.
 func (s *Server) handleListPendingRegistrations(w http.ResponseWriter, r *http.Request) {
-	var pending []PendingRegistration
-	s.registrationQueue.Range(func(_, value interface{}) bool {
-		if pr, ok := value.(PendingRegistration); ok {
-			pending = append(pending, pr)
-		}
-		return true
-	})
-	if pending == nil {
-		pending = []PendingRegistration{}
+	if s.pendingStore == nil {
+		http.Error(w, "registration store unavailable", http.StatusServiceUnavailable)
+		return
+	}
+	entries, err := s.pendingStore.ListPending(r.Context(), "")
+	if err != nil {
+		s.logger.Error("Failed to list pending registrations", "error", err)
+		http.Error(w, "Failed to list pending registrations", http.StatusInternalServerError)
+		return
+	}
+
+	pending := make([]PendingRegistration, 0, len(entries))
+	for _, e := range entries {
+		pending = append(pending, PendingRegistration{
+			PendingID:    e.PendingID,
+			StewardID:    e.StewardID,
+			TenantID:     e.TenantID,
+			SourceIP:     e.SourceIP,
+			RegisteredAt: e.RegisteredAt,
+		})
 	}
 	w.Header().Set("Content-Type", "application/json")
 	if err := json.NewEncoder(w).Encode(pending); err != nil {
@@ -94,38 +120,232 @@ func (s *Server) handleListPendingRegistrations(w http.ResponseWriter, r *http.R
 }
 
 // handleApproveRegistration handles POST /api/v1/registration/{id}/approve.
-// Promotes a quarantined steward to registered status.
+// Marks the pending entry as approved; no cert is generated here (generate-on-claim).
 func (s *Server) handleApproveRegistration(w http.ResponseWriter, r *http.Request) {
-	stewardID := mux.Vars(r)["id"]
-	if _, ok := s.registrationQueue.Load(stewardID); !ok {
-		http.Error(w, "steward not found in pending queue", http.StatusNotFound)
+	pendingID := mux.Vars(r)["id"]
+	if s.pendingStore == nil {
+		http.Error(w, "registration store unavailable", http.StatusServiceUnavailable)
 		return
 	}
-	if err := s.controllerService.UpdateStewardStatus(stewardID, "registered"); err != nil {
-		s.logger.Error("Failed to update steward status", "steward_id", stewardID, "error", err)
-		http.Error(w, "Failed to update steward status", http.StatusInternalServerError)
+	if _, err := s.pendingStore.GetPendingByID(r.Context(), pendingID); err != nil {
+		if err == business.ErrPendingRegistrationNotFound {
+			http.Error(w, "pending registration not found", http.StatusNotFound)
+			return
+		}
+		s.logger.Error("Failed to look up pending registration", "pending_id", pendingID, "error", err)
+		http.Error(w, "Failed to look up pending registration", http.StatusInternalServerError)
 		return
 	}
-	s.registrationQueue.Delete(stewardID)
-	s.logger.Info("Steward registration approved", "steward_id", stewardID)
+	if err := s.pendingStore.UpdateStatus(r.Context(), pendingID, business.PendingRegistrationStatusApproved); err != nil {
+		s.logger.Error("Failed to approve pending registration", "pending_id", pendingID, "error", err)
+		http.Error(w, "Failed to approve registration", http.StatusInternalServerError)
+		return
+	}
+	s.logger.Info("Steward registration approved (awaiting claim)", "pending_id", pendingID)
 	w.WriteHeader(http.StatusOK)
 }
 
 // handleDenyRegistration handles POST /api/v1/registration/{id}/deny.
-// Removes a quarantined steward from the pending queue without promoting it.
+// Marks the pending entry as denied; no certs are issued.
 func (s *Server) handleDenyRegistration(w http.ResponseWriter, r *http.Request) {
-	stewardID := mux.Vars(r)["id"]
-	if _, ok := s.registrationQueue.Load(stewardID); !ok {
-		http.Error(w, "steward not found in pending queue", http.StatusNotFound)
+	pendingID := mux.Vars(r)["id"]
+	if s.pendingStore == nil {
+		http.Error(w, "registration store unavailable", http.StatusServiceUnavailable)
+		return
+	}
+	if _, err := s.pendingStore.GetPendingByID(r.Context(), pendingID); err != nil {
+		if err == business.ErrPendingRegistrationNotFound {
+			http.Error(w, "pending registration not found", http.StatusNotFound)
+			return
+		}
+		s.logger.Error("Failed to look up pending registration", "pending_id", pendingID, "error", err)
+		http.Error(w, "Failed to look up pending registration", http.StatusInternalServerError)
 		return
 	}
 	var req denyRegistrationRequest
 	_ = json.NewDecoder(r.Body).Decode(&req)
-	s.registrationQueue.Delete(stewardID)
+	if err := s.pendingStore.UpdateStatus(r.Context(), pendingID, business.PendingRegistrationStatusDenied); err != nil {
+		s.logger.Error("Failed to deny pending registration", "pending_id", pendingID, "error", err)
+		http.Error(w, "Failed to deny registration", http.StatusInternalServerError)
+		return
+	}
 	s.logger.Info("Steward registration denied",
-		"steward_id", stewardID,
+		"pending_id", pendingID,
 		"reason", logging.SanitizeLogValue(req.Reason))
 	w.WriteHeader(http.StatusOK)
+}
+
+// handleRegistrationStatus handles GET /api/v1/registration/status/{pending_id}.
+// Auth: Bearer <regToken> header; token must belong to the same tenant as the pending entry.
+// State machine: pending→200 status, approved→claim+cert+200, claimed→410, denied/expired→200 status.
+func (s *Server) handleRegistrationStatus(w http.ResponseWriter, r *http.Request) {
+	pendingID := mux.Vars(r)["pending_id"]
+
+	if s.pendingStore == nil || s.registrationTokenStore == nil {
+		http.Error(w, "registration service unavailable", http.StatusServiceUnavailable)
+		return
+	}
+
+	// Extract Bearer token from Authorization header.
+	authHeader := r.Header.Get("Authorization")
+	if !strings.HasPrefix(authHeader, "Bearer ") {
+		http.Error(w, "Authorization: Bearer <token> required", http.StatusUnauthorized)
+		return
+	}
+	tokenStr := strings.TrimPrefix(authHeader, "Bearer ")
+
+	// Validate the registration token.
+	token, err := s.registrationTokenStore.GetToken(r.Context(), tokenStr)
+	if err != nil {
+		http.Error(w, "Invalid or expired registration token", http.StatusUnauthorized)
+		return
+	}
+	if !token.IsValid() {
+		http.Error(w, "Registration token is revoked or expired", http.StatusUnauthorized)
+		return
+	}
+
+	// Retrieve the pending entry.
+	entry, err := s.pendingStore.GetPendingByID(r.Context(), pendingID)
+	if err != nil {
+		if err == business.ErrPendingRegistrationNotFound {
+			http.Error(w, "pending registration not found", http.StatusNotFound)
+			return
+		}
+		s.logger.Error("Failed to retrieve pending registration", "pending_id", pendingID, "error", err)
+		http.Error(w, "Failed to retrieve pending registration", http.StatusInternalServerError)
+		return
+	}
+
+	// Tenant isolation: a token from a different tenant cannot observe this entry.
+	if entry.TenantID != token.TenantID {
+		http.Error(w, "forbidden: token tenant does not match pending entry tenant", http.StatusForbidden)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+
+	switch entry.Status {
+	case business.PendingRegistrationStatusPending:
+		_ = json.NewEncoder(w).Encode(RegistrationStatusResponse{Status: "pending"})
+
+	case business.PendingRegistrationStatusApproved:
+		// Generate-on-claim: persist "claimed" + claimed_at BEFORE generating the cert so
+		// a restart between this step and the response cannot yield a second cert.
+		// The UPDATE has AND status = 'approved', so a concurrent poll racing this one
+		// will get RowsAffected = 0 (returned as ErrPendingRegistrationNotFound), which
+		// we surface as 410 Gone rather than 500, preventing double cert issuance.
+		if err := s.pendingStore.UpdateStatus(r.Context(), pendingID, business.PendingRegistrationStatusClaimed); err != nil {
+			if err == business.ErrPendingRegistrationNotFound {
+				// Already claimed by a concurrent poll.
+				w.WriteHeader(http.StatusGone)
+				return
+			}
+			s.logger.Error("Failed to mark pending entry as claimed", "pending_id", pendingID, "error", err)
+			http.Error(w, "Failed to claim registration", http.StatusInternalServerError)
+			return
+		}
+		resp, err := s.buildClaimResponse(r.Context(), entry)
+		if err != nil {
+			s.logger.Error("Failed to generate cert for claimed registration",
+				"pending_id", pendingID, "steward_id", entry.StewardID, "error", err)
+			// Entry is already "claimed" — steward must re-register if cert was not received.
+			http.Error(w, "Failed to generate client certificate", http.StatusInternalServerError)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		if err := json.NewEncoder(w).Encode(resp); err != nil {
+			s.logger.Error("Failed to encode registration status response", "error", err)
+		}
+
+	case business.PendingRegistrationStatusClaimed:
+		w.WriteHeader(http.StatusGone)
+
+	case business.PendingRegistrationStatusDenied:
+		_ = json.NewEncoder(w).Encode(RegistrationStatusResponse{Status: "denied"})
+
+	case business.PendingRegistrationStatusExpired:
+		_ = json.NewEncoder(w).Encode(RegistrationStatusResponse{Status: "expired"})
+
+	default:
+		_ = json.NewEncoder(w).Encode(RegistrationStatusResponse{Status: entry.Status})
+	}
+}
+
+// buildClaimResponse generates the cert and builds the RegistrationStatusResponse.
+// Mirrors the approved path in handleRegister (lines ~286–365).
+func (s *Server) buildClaimResponse(ctx context.Context, entry *business.PendingRegistrationEntry) (*RegistrationStatusResponse, error) {
+	if s.certManager == nil {
+		return nil, fmt.Errorf("certificate manager not initialized")
+	}
+
+	// Re-fetch the token to obtain Group and ControllerURL.
+	tok, err := s.registrationTokenStore.GetToken(ctx, entry.TokenStr)
+	if err != nil {
+		return nil, fmt.Errorf("failed to retrieve token for claim: %w", err)
+	}
+
+	validityDays := 365
+	if s.cfg.Certificate != nil && s.cfg.Certificate.ClientCertValidityDays > 0 {
+		validityDays = s.cfg.Certificate.ClientCertValidityDays
+	}
+
+	clientCert, err := s.certManager.GenerateClientCertificate(&cert.ClientCertConfig{
+		CommonName:   entry.StewardID,
+		Organization: "CFGMS Stewards",
+		ClientID:     entry.StewardID,
+		ValidityDays: validityDays,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate client certificate: %w", err)
+	}
+
+	caCert, err := s.certManager.GetCACertificate()
+	if err != nil || len(caCert) == 0 {
+		return nil, fmt.Errorf("CA certificate unavailable: %w", err)
+	}
+
+	var serverCert []byte
+	if s.signerCertSerial != "" {
+		certPEM, _, err := s.certManager.ExportCertificate(s.signerCertSerial, false)
+		if err == nil && len(certPEM) > 0 {
+			serverCert = certPEM
+		}
+	}
+
+	resp := &RegistrationStatusResponse{
+		Status:           business.PendingRegistrationStatusClaimed,
+		StewardID:        entry.StewardID,
+		TenantID:         entry.TenantID,
+		Group:            tok.Group,
+		ControllerURL:    tok.ControllerURL,
+		TransportAddress: s.getTransportAddress(),
+		ClientCert:       string(clientCert.CertificatePEM),
+		ClientKey:        string(clientCert.PrivateKeyPEM),
+		CACert:           string(caCert),
+		ServerCert:       string(serverCert),
+	}
+
+	if s.cfg.Certificate != nil && s.cfg.Certificate.IsSeparatedArchitecture() {
+		signingCertPEM, err := s.certManager.GetSigningCertificate()
+		if err == nil && len(signingCertPEM) > 0 {
+			resp.SigningCert = string(signingCertPEM)
+			resp.ServerCert = string(signingCertPEM)
+		}
+	}
+
+	// Promote steward to registered in the fleet registry.
+	if err := s.controllerService.UpdateStewardStatus(entry.StewardID, "registered"); err != nil {
+		s.logger.Warn("Failed to update steward status to registered after claim",
+			"steward_id", entry.StewardID, "error", err)
+	}
+
+	s.logger.Info("Generated client certificate for claimed registration",
+		"pending_id", entry.PendingID,
+		"steward_id", entry.StewardID,
+		"validity_days", validityDays)
+
+	return resp, nil
 }
 
 // handleRegister handles steward registration via REST API
@@ -229,23 +449,37 @@ func (s *Server) handleRegister(w http.ResponseWriter, r *http.Request) {
 				return
 			case DecisionQuarantine:
 				// Issue #1693: quarantine returns 202 with no cert — cert issuance is gated on approval.
+				// Issue #1696: store the pending entry durably instead of in-memory sync.Map.
 				pendingID := fmt.Sprintf("pending-%d", time.Now().UnixNano())
 				s.logger.Info("Registration quarantined by approval workflow",
 					"tenant_id", token.TenantID,
 					"pending_id", pendingID)
-				// A registry write failure is non-fatal; the steward will re-appear on re-registration.
+
 				if err := s.controllerService.RegisterSteward(stewardID, token.TenantID, s.getTransportAddress(), "quarantined"); err != nil {
 					s.logger.Error("Failed to register quarantined steward in controller service",
 						"steward_id", stewardID, "error", err)
-				} else {
-					s.registrationQueue.Store(stewardID, PendingRegistration{
+				}
+
+				if s.pendingStore != nil {
+					pendingEntry := &business.PendingRegistrationEntry{
 						PendingID:    pendingID,
 						StewardID:    stewardID,
 						TenantID:     token.TenantID,
+						TokenStr:     req.Token,
 						SourceIP:     extractSourceIP(r, s.trustedProxies),
 						RegisteredAt: time.Now().UTC(),
-					})
+						ExpiresAt:    time.Now().UTC().Add(5 * 24 * time.Hour),
+						Status:       business.PendingRegistrationStatusPending,
+					}
+					if err := s.pendingStore.AddPending(r.Context(), pendingEntry); err != nil {
+						s.logger.Error("Failed to persist pending registration",
+							"pending_id", pendingID, "steward_id", stewardID, "error", err)
+					}
+				} else {
+					s.logger.Warn("Pending store not available; registration queue is not durable",
+						"pending_id", pendingID)
 				}
+
 				// emitRegistrationAudit calls logging.RedactedID internally; raw token is not stored
 				s.emitRegistrationAudit(r.Context(), req.Token, token.TenantID, stewardID,
 					business.AuditEventAuthentication, "registration_quarantined",
@@ -317,13 +551,8 @@ func (s *Server) handleRegister(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Get server certificate (public key) for configuration signature verification
-	// Stewards need this to verify configs signed by this controller
-	// CRITICAL (Story #378): Must use THE EXACT SAME certificate that the signer uses
-	// We use the signerCertSerial that was stored during signer creation to ensure they match
 	var serverCert []byte
 	if s.certManager != nil && s.signerCertSerial != "" {
-		// Use THE SAME cert serial that the signer uses (from server startup)
-		// This guarantees signature verification will work
 		certPEM, _, err := s.certManager.ExportCertificate(s.signerCertSerial, false)
 		if err == nil && len(certPEM) > 0 {
 			serverCert = certPEM
@@ -349,12 +578,10 @@ func (s *Server) handleRegister(w http.ResponseWriter, r *http.Request) {
 	resp.ServerCert = string(serverCert) // For config signature verification (backward compat)
 
 	// Story #377: In separated mode, also provide the dedicated signing certificate
-	// Stewards should prefer SigningCert for config verification when present
 	if s.cfg.Certificate != nil && s.cfg.Certificate.IsSeparatedArchitecture() && s.certManager != nil {
 		signingCertPEM, err := s.certManager.GetSigningCertificate()
 		if err == nil && len(signingCertPEM) > 0 {
 			resp.SigningCert = string(signingCertPEM)
-			// Also set ServerCert to signing cert for backward compatibility with older stewards
 			resp.ServerCert = string(signingCertPEM)
 			s.logger.Info("Providing dedicated signing certificate to steward",
 				"steward_id", stewardID)
@@ -368,9 +595,6 @@ func (s *Server) handleRegister(w http.ResponseWriter, r *http.Request) {
 		"steward_id", stewardID,
 		"validity_days", validityDays)
 
-	// A registry write failure is non-fatal: the steward already has valid certificates and
-	// will re-appear in the registry on its first heartbeat. Blocking the response here would
-	// leave the steward with credentials it cannot use and no way to recover without re-registering.
 	if err := s.controllerService.RegisterSteward(stewardID, token.TenantID, resp.TransportAddress, "registered"); err != nil {
 		s.logger.Error("Failed to register steward in controller service",
 			"steward_id", stewardID, "error", err)
@@ -390,34 +614,23 @@ func (s *Server) handleRegister(w http.ResponseWriter, r *http.Request) {
 }
 
 // getTransportAddress returns the unified transport address for steward connections.
-// This is a host:port string (e.g., "controller:4433"); the transport provider handles protocol details.
 func (s *Server) getTransportAddress() string {
 	addr := "localhost:4433" // Default transport address
 	if s.cfg.Transport != nil && s.cfg.Transport.ListenAddr != "" {
 		addr = s.cfg.Transport.ListenAddr
 	}
-
-	// Replace 0.0.0.0 with external hostname if configured (Docker/test mode)
 	return replaceBindAddress(addr)
 }
 
 // replaceBindAddress replaces 0.0.0.0 bind addresses with external hostname
-// This is needed for Docker/test environments where the controller binds to 0.0.0.0
-// but stewards need a real hostname to connect to
 func replaceBindAddress(addr string) string {
-	// Check if address starts with 0.0.0.0
 	if !strings.HasPrefix(addr, "0.0.0.0:") {
 		return addr
 	}
-
-	// Get external hostname from environment (Docker/test mode)
 	externalHostname := os.Getenv("CFGMS_EXTERNAL_HOSTNAME")
 	if externalHostname == "" {
-		// Default to localhost if not specified
 		externalHostname = "localhost"
 	}
-
-	// Replace 0.0.0.0 with external hostname
 	port := strings.TrimPrefix(addr, "0.0.0.0:")
 	return externalHostname + ":" + port
 }
@@ -426,18 +639,12 @@ func replaceBindAddress(addr string) string {
 // It honors X-Forwarded-For only when the TCP peer (r.RemoteAddr) is within
 // trustedProxies. When trustedProxies is empty or the peer is not in the list,
 // the TCP peer address is always used — XFF is untrusted and ignored.
-// This prevents spoofing: an attacker cannot bypass IP-trust checks by injecting
-// a forged X-Forwarded-For header from an untrusted network position.
 func extractSourceIP(r *http.Request, trustedProxies []net.IPNet) string {
-	// Parse the TCP peer host (strip port). net.SplitHostPort handles IPv6
-	// bracket notation ([::1]:port) correctly; fall back to the raw value
-	// if SplitHostPort fails (e.g. no port present, unlikely for net/http).
 	peerHost := r.RemoteAddr
 	if host, _, err := net.SplitHostPort(r.RemoteAddr); err == nil {
 		peerHost = host
 	}
 
-	// Honor XFF only when the peer is a trusted proxy.
 	if len(trustedProxies) > 0 {
 		peerIP := net.ParseIP(peerHost)
 		if peerIP != nil {
@@ -459,7 +666,6 @@ func extractSourceIP(r *http.Request, trustedProxies []net.IPNet) string {
 }
 
 // emitRegistrationAudit records a registration audit event. It is a no-op when auditManager is nil.
-// Errors are logged at Warn and do not affect the caller's control flow.
 func (s *Server) emitRegistrationAudit(
 	ctx context.Context,
 	tokenStr, tenantID, stewardID string,

--- a/features/controller/api/handlers_registration_test.go
+++ b/features/controller/api/handlers_registration_test.go
@@ -404,12 +404,18 @@ func TestHandleRegister_ValidToken_LogsRedactedPrefixNotFullToken(t *testing.T) 
 }
 
 // newRegistrationApprovalServer creates a minimal server with a test API key that has
-// all three registration approval permissions, wired to a real httptest.Server.
-// Returns the server and the httptest.Server (caller must close the httptest.Server).
-func newRegistrationApprovalServer(t *testing.T) (*Server, *httptest.Server) {
+// all three registration approval permissions, wired to a real httptest.Server and a durable
+// pending registration store (Issue #1696).
+// Returns the server, the httptest.Server (caller must close it), and the pending store.
+func newRegistrationApprovalServer(t *testing.T) (*Server, *httptest.Server, business.PendingRegistrationStore) {
 	t.Helper()
 	tokenStore := newTestRegistrationStore(t)
 	server, _ := newHandleRegisterServer(t, tokenStore, nil)
+
+	// Wire a real SQLite-backed pending store (Issue #1696).
+	pendingStore := pkgtesting.SetupTestStorage(t).GetPendingRegistrationStore()
+	require.NotNil(t, pendingStore, "test storage must provide a PendingRegistrationStore")
+	server.SetPendingStore(pendingStore)
 
 	// Add a test API key with all registration approval permissions.
 	server.apiKeys["reg-approval-key"] = &APIKey{
@@ -420,11 +426,11 @@ func newRegistrationApprovalServer(t *testing.T) (*Server, *httptest.Server) {
 	}
 
 	ts := httptest.NewServer(server.router)
-	return server, ts
+	return server, ts, pendingStore
 }
 
 func TestHandleListPendingRegistrations(t *testing.T) {
-	server, ts := newRegistrationApprovalServer(t)
+	_, ts, pendingStore := newRegistrationApprovalServer(t)
 	defer ts.Close()
 
 	makeRequest := func(t *testing.T) *http.Response {
@@ -437,7 +443,7 @@ func TestHandleListPendingRegistrations(t *testing.T) {
 		return resp
 	}
 
-	t.Run("empty queue returns empty array", func(t *testing.T) {
+	t.Run("empty store returns empty array", func(t *testing.T) {
 		resp := makeRequest(t)
 		defer func() { _ = resp.Body.Close() }()
 
@@ -448,15 +454,19 @@ func TestHandleListPendingRegistrations(t *testing.T) {
 		assert.Empty(t, pending)
 	})
 
-	t.Run("returns queued registrations", func(t *testing.T) {
+	t.Run("returns pending entries from durable store", func(t *testing.T) {
 		now := time.Now().UTC()
-		server.registrationQueue.Store("steward-test-list-1", PendingRegistration{
-			StewardID:    "steward-test-list-1",
+		entry := &business.PendingRegistrationEntry{
+			PendingID:    "pending-list-test-1",
+			StewardID:    "steward-list-test-1",
 			TenantID:     "tenant-a",
+			TokenStr:     "tok-list-1",
 			SourceIP:     "192.168.1.1",
 			RegisteredAt: now,
-		})
-		t.Cleanup(func() { server.registrationQueue.Delete("steward-test-list-1") })
+			ExpiresAt:    now.Add(5 * 24 * time.Hour),
+			Status:       business.PendingRegistrationStatusPending,
+		}
+		require.NoError(t, pendingStore.AddPending(context.Background(), entry))
 
 		resp := makeRequest(t)
 		defer func() { _ = resp.Body.Close() }()
@@ -466,20 +476,21 @@ func TestHandleListPendingRegistrations(t *testing.T) {
 		var pending []PendingRegistration
 		require.NoError(t, json.NewDecoder(resp.Body).Decode(&pending))
 		require.Len(t, pending, 1)
-		assert.Equal(t, "steward-test-list-1", pending[0].StewardID)
+		assert.Equal(t, "pending-list-test-1", pending[0].PendingID)
+		assert.Equal(t, "steward-list-test-1", pending[0].StewardID)
 		assert.Equal(t, "tenant-a", pending[0].TenantID)
 		assert.Equal(t, "192.168.1.1", pending[0].SourceIP)
 	})
 }
 
 func TestHandleApproveRegistration(t *testing.T) {
-	server, ts := newRegistrationApprovalServer(t)
+	_, ts, pendingStore := newRegistrationApprovalServer(t)
 	defer ts.Close()
 
-	makeApprove := func(t *testing.T, stewardID string) *http.Response {
+	makeApprove := func(t *testing.T, pendingID string) *http.Response {
 		t.Helper()
 		req, err := http.NewRequestWithContext(context.Background(), "POST",
-			ts.URL+"/api/v1/registration/"+stewardID+"/approve", nil)
+			ts.URL+"/api/v1/registration/"+pendingID+"/approve", nil)
 		require.NoError(t, err)
 		req.Header.Set("Authorization", "Bearer reg-approval-key")
 		resp, err := ts.Client().Do(req)
@@ -487,33 +498,33 @@ func TestHandleApproveRegistration(t *testing.T) {
 		return resp
 	}
 
-	t.Run("happy path - promotes quarantined steward to registered", func(t *testing.T) {
-		// Register steward in controller service so UpdateStewardStatus can find it.
-		require.NoError(t, server.controllerService.RegisterSteward("steward-approve-1", "tenant-a", "", "quarantined"))
-		server.registrationQueue.Store("steward-approve-1", PendingRegistration{
+	t.Run("happy path - marks pending entry as approved", func(t *testing.T) {
+		now := time.Now().UTC()
+		entry := &business.PendingRegistrationEntry{
+			PendingID:    "pending-approve-1",
 			StewardID:    "steward-approve-1",
 			TenantID:     "tenant-a",
+			TokenStr:     "tok-approve-1",
 			SourceIP:     "10.0.0.1",
-			RegisteredAt: time.Now().UTC(),
-		})
+			RegisteredAt: now,
+			ExpiresAt:    now.Add(5 * 24 * time.Hour),
+			Status:       business.PendingRegistrationStatusPending,
+		}
+		require.NoError(t, pendingStore.AddPending(context.Background(), entry))
 
-		resp := makeApprove(t, "steward-approve-1")
+		resp := makeApprove(t, "pending-approve-1")
 		defer func() { _ = resp.Body.Close() }()
 
 		assert.Equal(t, http.StatusOK, resp.StatusCode)
 
-		// Steward must be removed from the pending queue.
-		_, inQueue := server.registrationQueue.Load("steward-approve-1")
-		assert.False(t, inQueue, "approved steward must be removed from pending queue")
-
-		// Steward status must be updated to "registered".
-		info, exists := server.controllerService.GetStewardInfo("steward-approve-1")
-		require.True(t, exists)
-		assert.Equal(t, "registered", info.Status)
+		// Entry status must be updated to "approved" in the durable store.
+		got, err := pendingStore.GetPendingByID(context.Background(), "pending-approve-1")
+		require.NoError(t, err)
+		assert.Equal(t, business.PendingRegistrationStatusApproved, got.Status)
 	})
 
 	t.Run("not found returns 404", func(t *testing.T) {
-		resp := makeApprove(t, "nonexistent-steward")
+		resp := makeApprove(t, "nonexistent-pending-id")
 		defer func() { _ = resp.Body.Close() }()
 
 		assert.Equal(t, http.StatusNotFound, resp.StatusCode)
@@ -628,10 +639,10 @@ func TestHandleRegister_RejectReturns403(t *testing.T) {
 }
 
 func TestHandleDenyRegistration(t *testing.T) {
-	server, ts := newRegistrationApprovalServer(t)
+	_, ts, pendingStore := newRegistrationApprovalServer(t)
 	defer ts.Close()
 
-	makeDeny := func(t *testing.T, stewardID, body string) *http.Response {
+	makeDeny := func(t *testing.T, pendingID, body string) *http.Response {
 		t.Helper()
 		var reqBody *bytes.Reader
 		if body != "" {
@@ -640,7 +651,7 @@ func TestHandleDenyRegistration(t *testing.T) {
 			reqBody = bytes.NewReader(nil)
 		}
 		req, err := http.NewRequestWithContext(context.Background(), "POST",
-			ts.URL+"/api/v1/registration/"+stewardID+"/deny", reqBody)
+			ts.URL+"/api/v1/registration/"+pendingID+"/deny", reqBody)
 		require.NoError(t, err)
 		req.Header.Set("Authorization", "Bearer reg-approval-key")
 		if body != "" {
@@ -651,42 +662,49 @@ func TestHandleDenyRegistration(t *testing.T) {
 		return resp
 	}
 
-	t.Run("happy path - removes steward from pending queue", func(t *testing.T) {
-		server.registrationQueue.Store("steward-deny-1", PendingRegistration{
-			StewardID:    "steward-deny-1",
-			TenantID:     "tenant-b",
-			SourceIP:     "10.0.0.2",
-			RegisteredAt: time.Now().UTC(),
-		})
+	addEntry := func(t *testing.T, pendingID, stewardID, tenantID, sourceIP string) {
+		t.Helper()
+		now := time.Now().UTC()
+		require.NoError(t, pendingStore.AddPending(context.Background(), &business.PendingRegistrationEntry{
+			PendingID:    pendingID,
+			StewardID:    stewardID,
+			TenantID:     tenantID,
+			TokenStr:     "tok-" + pendingID,
+			SourceIP:     sourceIP,
+			RegisteredAt: now,
+			ExpiresAt:    now.Add(5 * 24 * time.Hour),
+			Status:       business.PendingRegistrationStatusPending,
+		}))
+	}
 
-		resp := makeDeny(t, "steward-deny-1", "")
+	t.Run("happy path - marks entry as denied in durable store", func(t *testing.T) {
+		addEntry(t, "pending-deny-1", "steward-deny-1", "tenant-b", "10.0.0.2")
+
+		resp := makeDeny(t, "pending-deny-1", "")
 		defer func() { _ = resp.Body.Close() }()
 
 		assert.Equal(t, http.StatusOK, resp.StatusCode)
 
-		_, inQueue := server.registrationQueue.Load("steward-deny-1")
-		assert.False(t, inQueue, "denied steward must be removed from pending queue")
+		got, err := pendingStore.GetPendingByID(context.Background(), "pending-deny-1")
+		require.NoError(t, err)
+		assert.Equal(t, business.PendingRegistrationStatusDenied, got.Status)
 	})
 
-	t.Run("deny with reason - removes from queue", func(t *testing.T) {
-		server.registrationQueue.Store("steward-deny-2", PendingRegistration{
-			StewardID:    "steward-deny-2",
-			TenantID:     "tenant-b",
-			SourceIP:     "10.0.0.3",
-			RegisteredAt: time.Now().UTC(),
-		})
+	t.Run("deny with reason - marks entry as denied", func(t *testing.T) {
+		addEntry(t, "pending-deny-2", "steward-deny-2", "tenant-b", "10.0.0.3")
 
-		resp := makeDeny(t, "steward-deny-2", `{"reason":"Unauthorized deployment"}`)
+		resp := makeDeny(t, "pending-deny-2", `{"reason":"Unauthorized deployment"}`)
 		defer func() { _ = resp.Body.Close() }()
 
 		assert.Equal(t, http.StatusOK, resp.StatusCode)
 
-		_, inQueue := server.registrationQueue.Load("steward-deny-2")
-		assert.False(t, inQueue, "denied steward must be removed from pending queue")
+		got, err := pendingStore.GetPendingByID(context.Background(), "pending-deny-2")
+		require.NoError(t, err)
+		assert.Equal(t, business.PendingRegistrationStatusDenied, got.Status)
 	})
 
 	t.Run("not found returns 404", func(t *testing.T) {
-		resp := makeDeny(t, "nonexistent-steward", "")
+		resp := makeDeny(t, "nonexistent-pending-id", "")
 		defer func() { _ = resp.Body.Close() }()
 
 		assert.Equal(t, http.StatusNotFound, resp.StatusCode)
@@ -746,4 +764,166 @@ func TestExtractSourceIP_XFFIgnoredWhenPeerNotProxy(t *testing.T) {
 	got = extractSourceIP(reqIPv6, nil)
 	assert.Equal(t, "::1", got,
 		"IPv6 peer: must return bare IPv6 address without brackets or port")
+}
+
+// TestHandleRegistrationStatus_Lifecycle verifies the full poll lifecycle for Issue #1696:
+// pending → approve → poll returns cert bundle and marks claimed → second poll returns 410.
+func TestHandleRegistrationStatus_Lifecycle(t *testing.T) {
+	tokenStore := newTestRegistrationStore(t)
+	certMgr := newTestCertManager(t)
+	server, _ := newHandleRegisterServer(t, tokenStore, certMgr)
+
+	// Wire a real pending store.
+	pendingStore := pkgtesting.SetupTestStorage(t).GetPendingRegistrationStore()
+	require.NotNil(t, pendingStore)
+	server.SetPendingStore(pendingStore)
+
+	ts := httptest.NewServer(server.router)
+	defer ts.Close()
+
+	// Seed a valid registration token.
+	const regToken = "cfgms_reg_lifecycle_tok"
+	const tenantID = "test-tenant"
+	tok := &registration.Token{
+		Token:         regToken,
+		TenantID:      tenantID,
+		ControllerURL: "grpc://controller:7443",
+		Group:         "prod",
+	}
+	require.NoError(t, tokenStore.SaveToken(context.Background(), tok))
+
+	// Create a pending entry in the store.
+	now := time.Now().UTC()
+	entry := &business.PendingRegistrationEntry{
+		PendingID:    "pending-lifecycle-1",
+		StewardID:    "steward-lifecycle-1",
+		TenantID:     tenantID,
+		TokenStr:     regToken,
+		SourceIP:     "10.0.0.1",
+		RegisteredAt: now,
+		ExpiresAt:    now.Add(5 * 24 * time.Hour),
+		Status:       business.PendingRegistrationStatusPending,
+	}
+	require.NoError(t, pendingStore.AddPending(context.Background(), entry))
+
+	pollStatus := func(t *testing.T, pendingID, bearerToken string) *http.Response {
+		t.Helper()
+		req, err := http.NewRequestWithContext(context.Background(), "GET",
+			ts.URL+"/api/v1/registration/status/"+pendingID, nil)
+		require.NoError(t, err)
+		req.Header.Set("Authorization", "Bearer "+bearerToken)
+		resp, err := ts.Client().Do(req)
+		require.NoError(t, err)
+		return resp
+	}
+
+	t.Run("pending status returns 200 with status=pending", func(t *testing.T) {
+		resp := pollStatus(t, "pending-lifecycle-1", regToken)
+		defer func() { _ = resp.Body.Close() }()
+
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+		var body RegistrationStatusResponse
+		require.NoError(t, json.NewDecoder(resp.Body).Decode(&body))
+		assert.Equal(t, "pending", body.Status)
+		assert.Empty(t, body.ClientCert, "no cert in pending response")
+	})
+
+	t.Run("after approve, poll returns cert bundle and status=claimed", func(t *testing.T) {
+		// Operator approves.
+		require.NoError(t, pendingStore.UpdateStatus(context.Background(),
+			"pending-lifecycle-1", business.PendingRegistrationStatusApproved))
+
+		resp := pollStatus(t, "pending-lifecycle-1", regToken)
+		defer func() { _ = resp.Body.Close() }()
+
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+		var body RegistrationStatusResponse
+		require.NoError(t, json.NewDecoder(resp.Body).Decode(&body))
+		assert.Equal(t, "claimed", body.Status)
+		assert.NotEmpty(t, body.ClientCert, "client_cert must be present after approval")
+		assert.NotEmpty(t, body.ClientKey, "client_key must be present after approval")
+		assert.NotEmpty(t, body.CACert, "ca_cert must be present after approval")
+
+		// Entry must be persisted as claimed.
+		got, err := pendingStore.GetPendingByID(context.Background(), "pending-lifecycle-1")
+		require.NoError(t, err)
+		assert.Equal(t, business.PendingRegistrationStatusClaimed, got.Status)
+	})
+
+	t.Run("second poll after claim returns 410 Gone", func(t *testing.T) {
+		resp := pollStatus(t, "pending-lifecycle-1", regToken)
+		defer func() { _ = resp.Body.Close() }()
+
+		assert.Equal(t, http.StatusGone, resp.StatusCode,
+			"second poll after claim must return 410 Gone — cert must not be re-issued")
+	})
+}
+
+// TestHandleRegistrationStatus_TenantIsolation verifies that a token from a different tenant
+// cannot observe or interact with another tenant's pending entry.
+func TestHandleRegistrationStatus_TenantIsolation(t *testing.T) {
+	tokenStore := newTestRegistrationStore(t)
+	server, _ := newHandleRegisterServer(t, tokenStore, nil)
+
+	pendingStore := pkgtesting.SetupTestStorage(t).GetPendingRegistrationStore()
+	require.NotNil(t, pendingStore)
+	server.SetPendingStore(pendingStore)
+
+	ts := httptest.NewServer(server.router)
+	defer ts.Close()
+
+	// Token for tenant-a.
+	tokA := &registration.Token{Token: "tok-tenant-a", TenantID: "tenant-a", ControllerURL: "grpc://c:7443"}
+	require.NoError(t, tokenStore.SaveToken(context.Background(), tokA))
+
+	// Token for tenant-b.
+	tokB := &registration.Token{Token: "tok-tenant-b", TenantID: "tenant-b", ControllerURL: "grpc://c:7443"}
+	require.NoError(t, tokenStore.SaveToken(context.Background(), tokB))
+
+	now := time.Now().UTC()
+	require.NoError(t, pendingStore.AddPending(context.Background(), &business.PendingRegistrationEntry{
+		PendingID:    "pending-tenant-a-1",
+		StewardID:    "steward-a-1",
+		TenantID:     "tenant-a",
+		TokenStr:     "tok-tenant-a",
+		SourceIP:     "10.0.0.1",
+		RegisteredAt: now,
+		ExpiresAt:    now.Add(5 * 24 * time.Hour),
+		Status:       business.PendingRegistrationStatusPending,
+	}))
+
+	// tenant-b token must not be able to observe tenant-a's pending entry.
+	req, err := http.NewRequestWithContext(context.Background(), "GET",
+		ts.URL+"/api/v1/registration/status/pending-tenant-a-1", nil)
+	require.NoError(t, err)
+	req.Header.Set("Authorization", "Bearer tok-tenant-b")
+	resp, err := ts.Client().Do(req)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+
+	assert.Equal(t, http.StatusForbidden, resp.StatusCode,
+		"cross-tenant token must receive 403 Forbidden")
+}
+
+// TestHandleRegistrationStatus_NoAuth verifies that the status endpoint requires Bearer auth.
+func TestHandleRegistrationStatus_NoAuth(t *testing.T) {
+	tokenStore := newTestRegistrationStore(t)
+	server, _ := newHandleRegisterServer(t, tokenStore, nil)
+
+	pendingStore := pkgtesting.SetupTestStorage(t).GetPendingRegistrationStore()
+	require.NotNil(t, pendingStore)
+	server.SetPendingStore(pendingStore)
+
+	ts := httptest.NewServer(server.router)
+	defer ts.Close()
+
+	req, err := http.NewRequestWithContext(context.Background(), "GET",
+		ts.URL+"/api/v1/registration/status/pending-noauth-1", nil)
+	require.NoError(t, err)
+	// No Authorization header.
+	resp, err := ts.Client().Do(req)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+
+	assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
 }

--- a/features/controller/api/registration_hook.go
+++ b/features/controller/api/registration_hook.go
@@ -7,8 +7,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/google/uuid"
-
 	"github.com/cfgis/cfgms/features/workflow"
 	"github.com/cfgis/cfgms/pkg/logging"
 	"github.com/cfgis/cfgms/pkg/registration"
@@ -278,43 +276,14 @@ func (h *ManualReviewApprovalHook) Stop() {
 // enforce.
 func (h *ManualReviewApprovalHook) Evaluate(ctx context.Context, input RegistrationInput) (ApprovalDecision, string, error) {
 	if err := ctx.Err(); err != nil {
-		// Fail closed: quarantine rather than admit when the context is cancelled.
-		h.logger.Warn("ManualReviewApprovalHook: context cancelled before queueing, quarantining",
+		h.logger.Warn("ManualReviewApprovalHook: context cancelled, quarantining",
 			"error", err,
 			"tenant_id", input.Token.TenantID)
 		return DecisionQuarantine, "", nil
 	}
-
-	now := time.Now().UTC()
-	id := fmt.Sprintf("pr-%s", uuid.New().String())
-
-	record := &business.PendingRegistrationData{
-		ID:          id,
-		StewardID:   "", // assigned after approval; left empty until operator acts (#1522-B)
-		TenantID:    input.Token.TenantID,
-		SourceIP:    input.SourceIP,
-		TokenPrefix: logging.RedactedID(input.Token.Token),
-		Status:      business.PendingRegistrationStatusPending,
-		CreatedAt:   now,
-		ExpiresAt:   now.Add(h.timeout),
-	}
-
-	if err := h.store.CreatePending(ctx, record); err != nil {
-		// Fail closed: quarantine rather than admit when the request cannot be
-		// recorded. A nil error is returned so the handler honours the quarantine
-		// decision instead of defaulting to approve.
-		h.logger.Warn("ManualReviewApprovalHook: failed to store pending registration, quarantining",
-			"error", err,
-			"tenant_id", input.Token.TenantID)
-		return DecisionQuarantine, "", nil
-	}
-
 	h.logger.Info("Registration queued for manual review",
-		"pending_id", id,
 		"tenant_id", input.Token.TenantID,
-		"source_ip", logging.SanitizeLogValue(input.SourceIP),
-		"expires_at", record.ExpiresAt.Format(time.RFC3339))
-
+		"source_ip", logging.SanitizeLogValue(input.SourceIP))
 	return DecisionQuarantine, "", nil
 }
 
@@ -335,27 +304,16 @@ func (h *ManualReviewApprovalHook) runExpiry(ctx context.Context) {
 	}
 }
 
-// expireTimedOut finds all pending records whose expires_at has passed and
-// transitions them to the timed-out status.
+// expireTimedOut marks all pending entries whose expires_at is at or before now as expired.
 func (h *ManualReviewApprovalHook) expireTimedOut(ctx context.Context) {
-	now := time.Now().UTC()
-	pending := business.PendingRegistrationStatusPending
-	records, err := h.store.ListPending(ctx, &business.PendingRegistrationFilter{
-		Status:            &pending,
-		ExpiresBeforeOrAt: &now,
-	})
+	n, err := h.store.ExpireStale(ctx, time.Now().UTC())
 	if err != nil {
 		if ctx.Err() == nil {
-			h.logger.Warn("ManualReviewApprovalHook: failed to list expired pending registrations", "error", err)
+			h.logger.Warn("ManualReviewApprovalHook: failed to expire stale pending registrations", "error", err)
 		}
 		return
 	}
-	for _, r := range records {
-		if err := h.store.UpdatePendingStatus(ctx, r.ID, business.PendingRegistrationStatusTimedOut, "auto-rejected: review timeout exceeded"); err != nil {
-			if ctx.Err() == nil {
-				h.logger.Warn("ManualReviewApprovalHook: failed to expire pending registration",
-					"pending_id", r.ID, "error", err)
-			}
-		}
+	if n > 0 {
+		h.logger.Info("ManualReviewApprovalHook: expired stale pending registrations", "count", n)
 	}
 }

--- a/features/controller/api/registration_hook_test.go
+++ b/features/controller/api/registration_hook_test.go
@@ -550,49 +550,13 @@ func newTestManualReviewHook(t *testing.T) (*ManualReviewApprovalHook, business.
 	return hook, pendingStore
 }
 
-func TestManualReviewApprovalHook_StoresPendingAndReturnsQuarantine(t *testing.T) {
-	hook, pendingStore := newTestManualReviewHook(t)
+func TestManualReviewApprovalHook_ReturnsQuarantine(t *testing.T) {
+	hook, _ := newTestManualReviewHook(t)
 
 	decision, reason, err := hook.Evaluate(context.Background(), sampleInput())
 	require.NoError(t, err)
-	assert.Equal(t, DecisionQuarantine, decision, "manual-review hook must return quarantine")
+	assert.Equal(t, DecisionQuarantine, decision, "manual-review hook must always return quarantine")
 	assert.Empty(t, reason)
-
-	// Verify the pending record was created in the store.
-	pending := business.PendingRegistrationStatusPending
-	records, err := pendingStore.ListPending(context.Background(), &business.PendingRegistrationFilter{Status: &pending})
-	require.NoError(t, err)
-	require.Len(t, records, 1, "one pending registration must be stored")
-	assert.Equal(t, "test-tenant", records[0].TenantID)
-	assert.Equal(t, "192.168.1.100", records[0].SourceIP)
-	assert.Equal(t, business.PendingRegistrationStatusPending, records[0].Status)
-	// The full token must NOT be stored — only the redacted prefix.
-	assert.Empty(t, records[0].StewardID, "StewardID must be empty until operator approves")
-	assert.NotEmpty(t, records[0].TokenPrefix, "TokenPrefix must hold the redacted token prefix")
-	assert.NotContains(t, records[0].TokenPrefix, "testtoken12345", "full token must not appear in TokenPrefix")
-}
-
-func TestManualReviewApprovalHook_ExpiresAtSetToTimeout(t *testing.T) {
-	hook, pendingStore := newTestManualReviewHook(t)
-	before := time.Now().UTC()
-
-	_, _, err := hook.Evaluate(context.Background(), sampleInput())
-	require.NoError(t, err)
-
-	after := time.Now().UTC()
-
-	pending := business.PendingRegistrationStatusPending
-	records, err := pendingStore.ListPending(context.Background(), &business.PendingRegistrationFilter{Status: &pending})
-	require.NoError(t, err)
-	require.Len(t, records, 1)
-
-	// ExpiresAt should be approximately 24 hours from now.
-	expectedMin := before.Add(23 * time.Hour)
-	expectedMax := after.Add(25 * time.Hour)
-	assert.True(t, records[0].ExpiresAt.After(expectedMin),
-		"expires_at must be at least 23h from now, got %v", records[0].ExpiresAt)
-	assert.True(t, records[0].ExpiresAt.Before(expectedMax),
-		"expires_at must be at most 25h from now, got %v", records[0].ExpiresAt)
 }
 
 func TestManualReviewApprovalHook_ContextCancelled_FailsClosed(t *testing.T) {
@@ -608,63 +572,61 @@ func TestManualReviewApprovalHook_ContextCancelled_FailsClosed(t *testing.T) {
 		"cancelled context must fail closed (quarantine) — never admit without operator review")
 }
 
-func TestManualReviewApprovalHook_StoreError_FailsClosed(t *testing.T) {
+func TestManualReviewApprovalHook_ClosedStore_EvaluateStillQuarantines(t *testing.T) {
 	hook, pendingStore := newTestManualReviewHook(t)
 	ctx := context.Background()
 
-	// Close the underlying store so CreatePending fails.
+	// Close the underlying store.
 	if closer, ok := pendingStore.(interface{ Close() error }); ok {
 		require.NoError(t, closer.Close())
 	}
 
+	// Evaluate no longer calls the store, so a closed store must not affect the decision.
 	decision, _, err := hook.Evaluate(ctx, sampleInput())
-	require.NoError(t, err,
-		"a nil error must be returned so the handler honours the quarantine decision")
+	require.NoError(t, err)
 	assert.Equal(t, DecisionQuarantine, decision,
-		"a store error must fail closed (quarantine) — never admit without operator review")
+		"Evaluate must return quarantine regardless of store state")
 }
 
 func TestManualReviewApprovalHook_MultipleRegistrationsSameTenant(t *testing.T) {
-	hook, pendingStore := newTestManualReviewHook(t)
+	hook, _ := newTestManualReviewHook(t)
 	ctx := context.Background()
 
-	// Three stewards register concurrently.
+	// Three stewards register — all must be quarantined.
 	for i := 0; i < 3; i++ {
 		decision, _, err := hook.Evaluate(ctx, sampleInput())
 		require.NoError(t, err)
 		assert.Equal(t, DecisionQuarantine, decision)
 	}
-
-	records, err := pendingStore.ListPending(ctx, nil)
-	require.NoError(t, err)
-	assert.Len(t, records, 3, "each registration must create a separate pending record")
 }
 
 func TestManualReviewApprovalHook_ExpireTimedOut(t *testing.T) {
 	_, pendingStore := newTestManualReviewHook(t)
 	ctx := context.Background()
 
-	// Manually create a record that already expired.
-	record := &business.PendingRegistrationData{
-		ID:        "pr-expired-test",
-		StewardID: "steward-x",
-		TenantID:  "test-tenant",
-		SourceIP:  "10.0.0.1",
-		Status:    business.PendingRegistrationStatusPending,
-		CreatedAt: time.Now().UTC().Add(-25 * time.Hour),
-		ExpiresAt: time.Now().UTC().Add(-1 * time.Hour),
+	// Add a pending entry that has already expired.
+	now := time.Now().UTC()
+	entry := &business.PendingRegistrationEntry{
+		PendingID:    "pending-expired-test",
+		StewardID:    "steward-x",
+		TenantID:     "test-tenant",
+		TokenStr:     "tok-expired",
+		SourceIP:     "10.0.0.1",
+		RegisteredAt: now.Add(-25 * time.Hour),
+		ExpiresAt:    now.Add(-1 * time.Hour),
+		Status:       business.PendingRegistrationStatusPending,
 	}
-	require.NoError(t, pendingStore.CreatePending(ctx, record))
+	require.NoError(t, pendingStore.AddPending(ctx, entry))
 
-	// Use a fresh hook to trigger expiry via expireTimedOut directly.
+	// Use a fresh hook so the background goroutine is fresh.
 	hook := NewManualReviewApprovalHook(pendingStore, 24*time.Hour, logging.NewNoopLogger())
 	defer hook.Stop()
 
 	// Manually invoke the expiry sweep.
 	hook.expireTimedOut(ctx)
 
-	// The expired record must now be timed-out.
-	got, err := pendingStore.GetPending(ctx, "pr-expired-test")
+	// The expired record must now be marked "expired".
+	got, err := pendingStore.GetPendingByID(ctx, "pending-expired-test")
 	require.NoError(t, err)
-	assert.Equal(t, business.PendingRegistrationStatusTimedOut, got.Status)
+	assert.Equal(t, business.PendingRegistrationStatusExpired, got.Status)
 }

--- a/features/controller/api/server.go
+++ b/features/controller/api/server.go
@@ -60,38 +60,38 @@ type Server struct {
 	systemMonitor           *monitoring.SystemMonitor
 	healthCollector         *health.Collector
 	haManager               *ha.Manager
-	apiKeys                 map[string]*APIKey             // In-memory cache for fast lookup
-	secretStore             secretsif.SecretStore          // M-AUTH-1: Central secrets provider for API keys
-	registrationTokenStore  registration.Store             // Registration token store for steward registration
-	corsConfig              *CORSConfig                    // CORS configuration
-	signerCertSerial        string                         // Story #378: Serial of cert used for config signing
-	authDefense             *authdefense.AuthDefenseSystem // Story #380: Three-tier auth defense
-	rollbackManager         rollback.RollbackManager       // Story #416: Rollback system
-	reportsHandler          *reportapi.Handler             // Story #416: Reports engine
-	workflowHandler         *WorkflowHandler               // Story #414: Workflow engine REST API
-	approvalHook            RegistrationApprovalHook       // Issue #422: Registration approval hook
-	fleetQuery              fleet.FleetQuery               // Issue #603: Single query path for device filtering
-	gitSyncWebhookHandler   http.Handler                   // Issue #666: git-sync webhook endpoint (optional)
-	auditManager            *audit.Manager                 // Issue #775: registration audit events
-	scriptTracker           script.ExecutionTracker        // Issue #708: durable execution audit records
-	scriptAuditLogger       *script.AuditLogger            // Issue #708: in-memory execution metrics
-	scriptMonitor           *script.ExecutionMonitor       // Issue #708: active execution tracking
-	scriptRepo              script.ScriptRepository        // Issue #1670: git-backed script library
-	privilegeStore          cfgconfig.ConfigStore          // Issue #1670: controller-side script privilege metadata
-	pushLeaderStatus        leaderStatus                   // Issue #1318: leader check for config push (nil = leader)
-	commandPublisher        *commands.Publisher            // Issue #1319: fan-out config push to active stewards
-	pushStore               business.PushStore             // Issue #1320: durable push-state persistence for HA failover
-	registry                registry.Registry              // Issue #1323: active steward connection registry
-	mountPointValidator     MountPointValidator            // Issue #1396: config source connection test
-	configSourceSecretStore secretsif.SecretStore          // Issue #1396: secrets for config source validator
-	configSourceRateLimits  sync.Map                       // Issue #1396: per-tenant rate-limit counters
+	apiKeys                 map[string]*APIKey                // In-memory cache for fast lookup
+	secretStore             secretsif.SecretStore             // M-AUTH-1: Central secrets provider for API keys
+	registrationTokenStore  registration.Store                // Registration token store for steward registration
+	corsConfig              *CORSConfig                       // CORS configuration
+	signerCertSerial        string                            // Story #378: Serial of cert used for config signing
+	authDefense             *authdefense.AuthDefenseSystem    // Story #380: Three-tier auth defense
+	rollbackManager         rollback.RollbackManager          // Story #416: Rollback system
+	reportsHandler          *reportapi.Handler                // Story #416: Reports engine
+	workflowHandler         *WorkflowHandler                  // Story #414: Workflow engine REST API
+	approvalHook            RegistrationApprovalHook          // Issue #422: Registration approval hook
+	fleetQuery              fleet.FleetQuery                  // Issue #603: Single query path for device filtering
+	gitSyncWebhookHandler   http.Handler                      // Issue #666: git-sync webhook endpoint (optional)
+	auditManager            *audit.Manager                    // Issue #775: registration audit events
+	scriptTracker           script.ExecutionTracker           // Issue #708: durable execution audit records
+	scriptAuditLogger       *script.AuditLogger               // Issue #708: in-memory execution metrics
+	scriptMonitor           *script.ExecutionMonitor          // Issue #708: active execution tracking
+	scriptRepo              script.ScriptRepository           // Issue #1670: git-backed script library
+	privilegeStore          cfgconfig.ConfigStore             // Issue #1670: controller-side script privilege metadata
+	pushLeaderStatus        leaderStatus                      // Issue #1318: leader check for config push (nil = leader)
+	commandPublisher        *commands.Publisher               // Issue #1319: fan-out config push to active stewards
+	pushStore               business.PushStore                // Issue #1320: durable push-state persistence for HA failover
+	registry                registry.Registry                 // Issue #1323: active steward connection registry
+	mountPointValidator     MountPointValidator               // Issue #1396: config source connection test
+	configSourceSecretStore secretsif.SecretStore             // Issue #1396: secrets for config source validator
+	configSourceRateLimits  sync.Map                          // Issue #1396: per-tenant rate-limit counters
 	pendingStore            business.PendingRegistrationStore // Issue #1696: durable pending-registration queue
-	runManager              *controllerrun.Manager         // Issue #1673: run/job/execution model
-	runExecutionQueue       *script.ExecutionQueue         // Issue #1673: queue for ad-hoc run synthesis
-	trustedProxies          []net.IPNet                    // Issue #1695: parsed from TrustedProxies config; XFF honored only when peer is in this list
-	stopCleanup             chan struct{}                  // signals startAPIKeyCleanup to exit
-	cleanupDone             chan struct{}                  // closed when cleanup goroutine exits
-	closeOnce               sync.Once                      // idempotent Close
+	runManager              *controllerrun.Manager            // Issue #1673: run/job/execution model
+	runExecutionQueue       *script.ExecutionQueue            // Issue #1673: queue for ad-hoc run synthesis
+	trustedProxies          []net.IPNet                       // Issue #1695: parsed from TrustedProxies config; XFF honored only when peer is in this list
+	stopCleanup             chan struct{}                     // signals startAPIKeyCleanup to exit
+	cleanupDone             chan struct{}                     // closed when cleanup goroutine exits
+	closeOnce               sync.Once                         // idempotent Close
 }
 
 // APIKey represents an API key for external authentication

--- a/features/controller/api/server.go
+++ b/features/controller/api/server.go
@@ -85,7 +85,7 @@ type Server struct {
 	mountPointValidator     MountPointValidator            // Issue #1396: config source connection test
 	configSourceSecretStore secretsif.SecretStore          // Issue #1396: secrets for config source validator
 	configSourceRateLimits  sync.Map                       // Issue #1396: per-tenant rate-limit counters
-	registrationQueue       sync.Map                       // Issue #1568: quarantined stewards awaiting approval
+	pendingStore            business.PendingRegistrationStore // Issue #1696: durable pending-registration queue
 	runManager              *controllerrun.Manager         // Issue #1673: run/job/execution model
 	runExecutionQueue       *script.ExecutionQueue         // Issue #1673: queue for ad-hoc run synthesis
 	trustedProxies          []net.IPNet                    // Issue #1695: parsed from TrustedProxies config; XFF honored only when peer is in this list
@@ -320,6 +320,9 @@ func (s *Server) setupRouter() {
 
 	// Steward registration (no auth required - uses registration token)
 	s.router.HandleFunc("/api/v1/register", s.handleRegister).Methods("POST", "OPTIONS")
+
+	// Registration status poll (no API-key auth — authenticated by regtoken Bearer header)
+	s.router.HandleFunc("/api/v1/registration/status/{pending_id}", s.handleRegistrationStatus).Methods("GET")
 
 	// Test-mode config upload (no auth required - for integration tests only)
 	// Use separate path to avoid conflict with authenticated subrouter
@@ -734,6 +737,14 @@ func (s *Server) SetRunManager(m *controllerrun.Manager, queue *script.Execution
 	defer s.mu.Unlock()
 	s.runManager = m
 	s.runExecutionQueue = queue
+}
+
+// SetPendingStore wires the durable pending-registration store (Issue #1696).
+// Call this after New() returns but before Start() is called.
+func (s *Server) SetPendingStore(store business.PendingRegistrationStore) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.pendingStore = store
 }
 
 // getHTTPListenAddr determines the HTTP listen address.

--- a/features/controller/server/server.go
+++ b/features/controller/server/server.go
@@ -654,6 +654,12 @@ func New(cfg *config.Config, logger logging.Logger) (*Server, error) {
 		httpServer.SetRegistry(connRegistry)
 	}
 
+	// Issue #1696: Wire durable pending registration store for status poll endpoint.
+	if pendingStore := storageManager.GetPendingRegistrationStore(); pendingStore != nil {
+		httpServer.SetPendingStore(pendingStore)
+		logger.Info("Durable pending registration store wired to HTTP API server (Issue #1696)")
+	}
+
 	srv := &Server{
 		cfg:                     cfg,
 		logger:                  logger,

--- a/features/steward/registration/client_http.go
+++ b/features/steward/registration/client_http.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"math/rand/v2"
 	"net/http"
 	"net/url"
 	"os"
@@ -48,6 +49,23 @@ type RegistrationResponse struct {
 	// Story #377: Dedicated config signing certificate (separated architecture)
 	// When present, steward should prefer this for config signature verification
 	SigningCert string `json:"signing_cert,omitempty"`
+}
+
+// RegistrationStatusResponse is the response from GET /api/v1/registration/status/{pending_id}.
+// When status is "claimed", all cert fields are populated; other statuses include only Status.
+type RegistrationStatusResponse struct {
+	Status string `json:"status"`
+
+	StewardID        string `json:"steward_id,omitempty"`
+	TenantID         string `json:"tenant_id,omitempty"`
+	Group            string `json:"group,omitempty"`
+	ControllerURL    string `json:"controller_url,omitempty"`
+	TransportAddress string `json:"transport_address,omitempty"`
+	ClientCert       string `json:"client_cert,omitempty"`
+	ClientKey        string `json:"client_key,omitempty"`
+	CACert           string `json:"ca_cert,omitempty"`
+	ServerCert       string `json:"server_cert,omitempty"`
+	SigningCert      string `json:"signing_cert,omitempty"`
 }
 
 // RegistrationPendingResponse is returned by the controller with HTTP 202 when a registration
@@ -189,4 +207,62 @@ func (c *HTTPClient) Register(ctx context.Context, token string) (*RegistrationR
 	default:
 		return nil, nil, fmt.Errorf("registration failed with status %d: %s", resp.StatusCode, string(body))
 	}
+}
+
+// PollStatus polls GET /api/v1/registration/status/{pendingID} once, authenticating with regToken.
+// Before the HTTP call it sleeps for computePollInterval(baseInterval, jitter); pass both as 0 to
+// skip the sleep (useful in tests). On HTTP 410 Gone the entry was already claimed; returns
+// &RegistrationStatusResponse{Status:"claimed"} so callers can stop polling.
+func (c *HTTPClient) PollStatus(ctx context.Context, pendingID, regToken string, baseInterval, jitter time.Duration) (*RegistrationStatusResponse, error) {
+	if interval := computePollInterval(baseInterval, jitter); interval > 0 {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-time.After(interval):
+		}
+	}
+
+	pollURL := fmt.Sprintf("%s/api/v1/registration/status/%s", c.controllerURL, pendingID)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, pollURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create status request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+regToken)
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to poll registration status: %w", err)
+	}
+	defer func() {
+		if closeErr := resp.Body.Close(); closeErr != nil {
+			c.logger.Warn("Failed to close status response body", "error", closeErr)
+		}
+	}()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read status response body: %w", err)
+	}
+
+	if resp.StatusCode == http.StatusGone {
+		return &RegistrationStatusResponse{Status: "claimed"}, nil
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("status poll failed with HTTP %d: %s", resp.StatusCode, string(body))
+	}
+
+	var statusResp RegistrationStatusResponse
+	if err := json.Unmarshal(body, &statusResp); err != nil {
+		return nil, fmt.Errorf("failed to parse status response: %w", err)
+	}
+	return &statusResp, nil
+}
+
+// computePollInterval returns base + a random duration in [0, jitter).
+// Returns base unchanged when jitter is 0 (test/immediate-poll mode).
+func computePollInterval(base, jitter time.Duration) time.Duration {
+	if jitter <= 0 {
+		return base
+	}
+	return base + time.Duration(rand.N(uint64(jitter)))
 }

--- a/features/steward/registration/client_http_test.go
+++ b/features/steward/registration/client_http_test.go
@@ -207,10 +207,10 @@ func TestNewHTTPClientAlwaysVerifiesTLS(t *testing.T) {
 	})
 }
 
-// TestComputePollInterval_JitterRange samples 100 intervals with base=90s and jitter=30s and
+// TestPollStatus_JitterRange samples 100 intervals with base=90s and jitter=30s and
 // asserts every result is in [90s, 120s). This proves the jitter never causes an underrun
 // (below base) and never exceeds base+jitter.
-func TestComputePollInterval_JitterRange(t *testing.T) {
+func TestPollStatus_JitterRange(t *testing.T) {
 	const base = 90 * time.Second
 	const jitter = 30 * time.Second
 	for i := 0; i < 100; i++ {

--- a/features/steward/registration/client_http_test.go
+++ b/features/steward/registration/client_http_test.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	cfgcert "github.com/cfgis/cfgms/pkg/cert"
 	"github.com/cfgis/cfgms/pkg/logging"
@@ -204,4 +205,119 @@ func TestNewHTTPClientAlwaysVerifiesTLS(t *testing.T) {
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "logger is required")
 	})
+}
+
+// TestComputePollInterval_JitterRange samples 100 intervals with base=90s and jitter=30s and
+// asserts every result is in [90s, 120s). This proves the jitter never causes an underrun
+// (below base) and never exceeds base+jitter.
+func TestComputePollInterval_JitterRange(t *testing.T) {
+	const base = 90 * time.Second
+	const jitter = 30 * time.Second
+	for i := 0; i < 100; i++ {
+		got := computePollInterval(base, jitter)
+		assert.GreaterOrEqual(t, got, base, "interval must be >= base (iteration %d)", i)
+		assert.Less(t, got, base+jitter, "interval must be < base+jitter (iteration %d)", i)
+	}
+}
+
+// TestComputePollInterval_ZeroJitter verifies that zero jitter returns exactly base.
+func TestComputePollInterval_ZeroJitter(t *testing.T) {
+	assert.Equal(t, 90*time.Second, computePollInterval(90*time.Second, 0))
+}
+
+// TestPollStatus_Pending verifies that a 200 with status="pending" is returned correctly.
+func TestPollStatus_Pending(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/api/v1/registration/status/pending-123", r.URL.Path)
+		assert.Equal(t, "Bearer reg-token-abc", r.Header.Get("Authorization"))
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"status":"pending"}`))
+	}))
+	defer srv.Close()
+
+	client, err := NewHTTPClient(&HTTPConfig{ControllerURL: srv.URL, Logger: logging.NewLogger("debug")})
+	require.NoError(t, err)
+
+	resp, err := client.PollStatus(context.Background(), "pending-123", "reg-token-abc", 0, 0)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, "pending", resp.Status)
+}
+
+// TestPollStatus_Claimed_Returns410AsClaimedStatus verifies that HTTP 410 Gone is surfaced
+// as RegistrationStatusResponse{Status:"claimed"} without an error, so the steward loop can
+// stop without treating a second poll as an error condition.
+func TestPollStatus_Claimed_Returns410AsClaimedStatus(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusGone)
+	}))
+	defer srv.Close()
+
+	client, err := NewHTTPClient(&HTTPConfig{ControllerURL: srv.URL, Logger: logging.NewLogger("debug")})
+	require.NoError(t, err)
+
+	resp, err := client.PollStatus(context.Background(), "pending-xyz", "tok", 0, 0)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, "claimed", resp.Status)
+}
+
+// TestPollStatus_Denied_IsTerminal verifies that a "denied" status is returned without error
+// so the steward can cleanly exit the poll loop.
+func TestPollStatus_Denied_IsTerminal(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"status":"denied"}`))
+	}))
+	defer srv.Close()
+
+	client, err := NewHTTPClient(&HTTPConfig{ControllerURL: srv.URL, Logger: logging.NewLogger("debug")})
+	require.NoError(t, err)
+
+	resp, err := client.PollStatus(context.Background(), "pending-denied", "tok", 0, 0)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, "denied", resp.Status)
+}
+
+// TestPollStatus_ApprovedWithCerts verifies that a claimed response with cert fields is decoded.
+func TestPollStatus_ApprovedWithCerts(t *testing.T) {
+	body := `{"status":"claimed","steward_id":"s1","tenant_id":"t1","client_cert":"CERT","client_key":"KEY","ca_cert":"CA"}`
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(body))
+	}))
+	defer srv.Close()
+
+	client, err := NewHTTPClient(&HTTPConfig{ControllerURL: srv.URL, Logger: logging.NewLogger("debug")})
+	require.NoError(t, err)
+
+	resp, err := client.PollStatus(context.Background(), "pending-approved", "tok", 0, 0)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, "claimed", resp.Status)
+	assert.Equal(t, "CERT", resp.ClientCert)
+	assert.Equal(t, "KEY", resp.ClientKey)
+	assert.Equal(t, "CA", resp.CACert)
+	assert.Equal(t, "s1", resp.StewardID)
+}
+
+// TestPollStatus_ErrorStatus_ReturnsError verifies that non-200/non-410 statuses return an error.
+func TestPollStatus_ErrorStatus_ReturnsError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+	}))
+	defer srv.Close()
+
+	client, err := NewHTTPClient(&HTTPConfig{ControllerURL: srv.URL, Logger: logging.NewLogger("debug")})
+	require.NoError(t, err)
+
+	resp, err := client.PollStatus(context.Background(), "pending-unauth", "bad-tok", 0, 0)
+	require.Error(t, err)
+	assert.Nil(t, resp)
+	assert.Contains(t, err.Error(), "status poll failed with HTTP 401")
 }

--- a/pkg/storage/interfaces/business/pending_registration_store.go
+++ b/pkg/storage/interfaces/business/pending_registration_store.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2026 Jordan Ritz
 // Package business defines the PendingRegistrationStore interface for the
-// manual-review registration approval mode (Issue #1599).
+// generate-on-claim registration approval flow (Issue #1696).
 package business
 
 import (
@@ -13,91 +13,76 @@ import (
 // ErrPendingRegistrationNotFound is returned when a pending registration record does not exist.
 var ErrPendingRegistrationNotFound = errors.New("pending registration not found")
 
-// PendingRegistrationStatus represents the lifecycle state of a pending registration request.
-type PendingRegistrationStatus string
-
+// Pending registration status values.
 const (
-	// PendingRegistrationStatusPending indicates the request is awaiting operator action.
-	PendingRegistrationStatusPending PendingRegistrationStatus = "pending"
-
-	// PendingRegistrationStatusApproved indicates an operator approved the request.
-	PendingRegistrationStatusApproved PendingRegistrationStatus = "approved"
-
-	// PendingRegistrationStatusDenied indicates an operator denied the request.
-	PendingRegistrationStatusDenied PendingRegistrationStatus = "denied"
-
-	// PendingRegistrationStatusTimedOut indicates the request expired before an operator acted.
-	PendingRegistrationStatusTimedOut PendingRegistrationStatus = "timed-out"
+	PendingRegistrationStatusPending  = "pending"
+	PendingRegistrationStatusApproved = "approved"
+	PendingRegistrationStatusClaimed  = "claimed"
+	PendingRegistrationStatusDenied   = "denied"
+	PendingRegistrationStatusExpired  = "expired"
 )
 
-// PendingRegistrationData holds the durable state for a single registration request
-// queued for manual review.
+// PendingRegistrationEntry holds the durable state for a single registration request
+// awaiting manual review and generate-on-claim cert issuance.
 //
-// The full registration token is never stored. TokenPrefix holds only a redacted
-// identifier so operators can correlate the request without exposing the secret.
-type PendingRegistrationData struct {
-	// ID is the unique pending-registration identifier.
-	ID string
+// No private key or certificate bundle is ever stored — cert generation happens
+// in memory when the steward first polls an approved entry.
+type PendingRegistrationEntry struct {
+	// PendingID is the unique pending-registration identifier (e.g. "pending-<nanoseconds>").
+	PendingID string
 
-	// StewardID is the steward identifier assigned after approval. Empty while pending.
+	// StewardID is the steward identifier assigned at registration time.
 	StewardID string
 
 	// TenantID is the tenant the registering steward belongs to.
 	TenantID string
 
+	// TokenStr is the full registration token presented at registration time.
+	// Stored so GetPendingByToken can locate the entry without the pending_id.
+	TokenStr string
+
 	// SourceIP is the remote address of the registering steward.
 	SourceIP string
 
-	// TokenPrefix is the redacted registration-token identifier (never the full token).
-	TokenPrefix string
+	// RegisteredAt is the time the steward first registered (and was quarantined).
+	RegisteredAt time.Time
 
-	// Status is the current lifecycle state of the request.
-	Status PendingRegistrationStatus
-
-	// DenyReason is a human-readable reason set when the request is denied or timed out.
-	DenyReason string
-
-	// CreatedAt is the time the request was queued.
-	CreatedAt time.Time
-
-	// ExpiresAt is the deadline after which the request is auto-rejected.
+	// ExpiresAt is the deadline after which the entry is eligible for expiry sweep.
 	ExpiresAt time.Time
+
+	// ClaimedAt is set when the steward first polls an approved entry and receives its cert.
+	// It is persisted before cert generation so a restart cannot yield a second cert.
+	ClaimedAt *time.Time
+
+	// Status is the current lifecycle state: pending | approved | claimed | denied | expired.
+	Status string
 }
 
-// PendingRegistrationFilter narrows the results of ListPending. A nil filter, or a
-// filter with all fields nil, returns every pending-registration record.
-type PendingRegistrationFilter struct {
-	// Status, when set, restricts results to records with the given status.
-	Status *PendingRegistrationStatus
-
-	// ExpiresBeforeOrAt, when set, restricts results to records whose ExpiresAt
-	// is at or before the given time. Used by the expiry sweep to find timed-out records.
-	ExpiresBeforeOrAt *time.Time
-
-	// TenantID, when set, restricts results to records for the given tenant.
-	TenantID *string
-}
-
-// PendingRegistrationStore defines the storage interface for durable persistence
-// of registration requests awaiting manual review.
+// PendingRegistrationStore defines the storage interface for durable persistence of
+// registration requests in the generate-on-claim approval flow.
 type PendingRegistrationStore interface {
-	// CreatePending inserts a new pending-registration record.
-	// Returns an error if a record with the same ID already exists.
-	CreatePending(ctx context.Context, record *PendingRegistrationData) error
+	// AddPending inserts a new pending-registration entry.
+	// Returns an error if an entry with the same PendingID already exists.
+	AddPending(ctx context.Context, entry *PendingRegistrationEntry) error
 
-	// GetPending retrieves the pending-registration record for the given ID.
+	// GetPendingByID retrieves the entry for the given pending_id.
 	// Returns ErrPendingRegistrationNotFound if no record exists.
-	GetPending(ctx context.Context, id string) (*PendingRegistrationData, error)
+	GetPendingByID(ctx context.Context, pendingID string) (*PendingRegistrationEntry, error)
 
-	// ListPending returns all records matching the filter, ordered by CreatedAt ascending.
-	// A nil filter returns every record.
-	ListPending(ctx context.Context, filter *PendingRegistrationFilter) ([]*PendingRegistrationData, error)
+	// GetPendingByToken retrieves the entry whose TokenStr matches the given token.
+	// Returns ErrPendingRegistrationNotFound if no matching record exists.
+	GetPendingByToken(ctx context.Context, tokenStr string) (*PendingRegistrationEntry, error)
 
-	// UpdatePendingStatus updates the status and deny reason of the given record.
+	// UpdateStatus updates the status of the entry identified by pendingID.
+	// When status is "claimed", the implementation also persists claimed_at = now().
 	// Returns ErrPendingRegistrationNotFound if no record exists for the ID.
-	UpdatePendingStatus(ctx context.Context, id string, status PendingRegistrationStatus, reason string) error
+	UpdateStatus(ctx context.Context, pendingID, status string) error
 
-	// DeletePending removes the pending-registration record for the given ID.
-	// Returns ErrPendingRegistrationNotFound if no record exists.
-	DeletePending(ctx context.Context, id string) error
+	// ListPending returns all entries for the given tenantID, ordered by registered_at ascending.
+	// An empty tenantID returns entries for all tenants (operator list view).
+	ListPending(ctx context.Context, tenantID string) ([]*PendingRegistrationEntry, error)
+
+	// ExpireStale marks entries whose expires_at is at or before cutoff and whose status
+	// is "pending" as "expired". Returns the number of entries updated.
+	ExpireStale(ctx context.Context, cutoff time.Time) (int, error)
 }

--- a/pkg/storage/interfaces/business/pending_registration_store_test.go
+++ b/pkg/storage/interfaces/business/pending_registration_store_test.go
@@ -110,8 +110,8 @@ func (s *inMemPendingStore) ExpireStale(_ context.Context, cutoff time.Time) (in
 
 // test-only sentinel errors
 var (
-	ErrTestNilEntry   = errStr("nil entry")
-	ErrTestDuplicate  = errStr("duplicate pending_id")
+	ErrTestNilEntry  = errStr("nil entry")
+	ErrTestDuplicate = errStr("duplicate pending_id")
 )
 
 type errStr string

--- a/pkg/storage/interfaces/business/pending_registration_store_test.go
+++ b/pkg/storage/interfaces/business/pending_registration_store_test.go
@@ -1,0 +1,249 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+package business_test
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cfgis/cfgms/pkg/storage/interfaces/business"
+)
+
+// inMemPendingStore is a minimal in-memory PendingRegistrationStore for contract tests.
+type inMemPendingStore struct {
+	mu      sync.RWMutex
+	entries map[string]*business.PendingRegistrationEntry
+}
+
+func newInMemPendingStore() business.PendingRegistrationStore {
+	return &inMemPendingStore{entries: make(map[string]*business.PendingRegistrationEntry)}
+}
+
+func (s *inMemPendingStore) AddPending(_ context.Context, entry *business.PendingRegistrationEntry) error {
+	if entry == nil {
+		return ErrTestNilEntry
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, exists := s.entries[entry.PendingID]; exists {
+		return ErrTestDuplicate
+	}
+	cp := *entry
+	if cp.Status == "" {
+		cp.Status = business.PendingRegistrationStatusPending
+	}
+	if cp.RegisteredAt.IsZero() {
+		cp.RegisteredAt = time.Now().UTC()
+	}
+	s.entries[entry.PendingID] = &cp
+	return nil
+}
+
+func (s *inMemPendingStore) GetPendingByID(_ context.Context, pendingID string) (*business.PendingRegistrationEntry, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	e, ok := s.entries[pendingID]
+	if !ok {
+		return nil, business.ErrPendingRegistrationNotFound
+	}
+	cp := *e
+	return &cp, nil
+}
+
+func (s *inMemPendingStore) GetPendingByToken(_ context.Context, tokenStr string) (*business.PendingRegistrationEntry, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	for _, e := range s.entries {
+		if e.TokenStr == tokenStr {
+			cp := *e
+			return &cp, nil
+		}
+	}
+	return nil, business.ErrPendingRegistrationNotFound
+}
+
+func (s *inMemPendingStore) UpdateStatus(_ context.Context, pendingID, status string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	e, ok := s.entries[pendingID]
+	if !ok {
+		return business.ErrPendingRegistrationNotFound
+	}
+	e.Status = status
+	if status == business.PendingRegistrationStatusClaimed {
+		now := time.Now().UTC()
+		e.ClaimedAt = &now
+	}
+	return nil
+}
+
+func (s *inMemPendingStore) ListPending(_ context.Context, tenantID string) ([]*business.PendingRegistrationEntry, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	var out []*business.PendingRegistrationEntry
+	for _, e := range s.entries {
+		if tenantID == "" || e.TenantID == tenantID {
+			cp := *e
+			out = append(out, &cp)
+		}
+	}
+	return out, nil
+}
+
+func (s *inMemPendingStore) ExpireStale(_ context.Context, cutoff time.Time) (int, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	count := 0
+	for _, e := range s.entries {
+		if e.Status == business.PendingRegistrationStatusPending && !e.ExpiresAt.After(cutoff) {
+			e.Status = business.PendingRegistrationStatusExpired
+			count++
+		}
+	}
+	return count, nil
+}
+
+// test-only sentinel errors
+var (
+	ErrTestNilEntry   = errStr("nil entry")
+	ErrTestDuplicate  = errStr("duplicate pending_id")
+)
+
+type errStr string
+
+func (e errStr) Error() string { return string(e) }
+
+// Compile-time assertion.
+var _ business.PendingRegistrationStore = (*inMemPendingStore)(nil)
+
+// --- Contract tests ---
+
+func newTestEntry(id, tenant, token string) *business.PendingRegistrationEntry {
+	now := time.Now().UTC()
+	return &business.PendingRegistrationEntry{
+		PendingID:    id,
+		StewardID:    "steward-" + id,
+		TenantID:     tenant,
+		TokenStr:     token,
+		SourceIP:     "10.0.0.1",
+		RegisteredAt: now,
+		ExpiresAt:    now.Add(5 * 24 * time.Hour),
+		Status:       business.PendingRegistrationStatusPending,
+	}
+}
+
+func TestPendingRegistrationStore_AddAndGet(t *testing.T) {
+	store := newInMemPendingStore()
+	ctx := context.Background()
+
+	entry := newTestEntry("p-1", "tenant-1", "tok-abc")
+	require.NoError(t, store.AddPending(ctx, entry))
+
+	got, err := store.GetPendingByID(ctx, "p-1")
+	require.NoError(t, err)
+	assert.Equal(t, "p-1", got.PendingID)
+	assert.Equal(t, "tenant-1", got.TenantID)
+	assert.Equal(t, "tok-abc", got.TokenStr)
+	assert.Equal(t, business.PendingRegistrationStatusPending, got.Status)
+	assert.Nil(t, got.ClaimedAt)
+}
+
+func TestPendingRegistrationStore_GetByToken(t *testing.T) {
+	store := newInMemPendingStore()
+	ctx := context.Background()
+
+	require.NoError(t, store.AddPending(ctx, newTestEntry("p-tok", "tenant-1", "tok-xyz")))
+
+	got, err := store.GetPendingByToken(ctx, "tok-xyz")
+	require.NoError(t, err)
+	assert.Equal(t, "p-tok", got.PendingID)
+}
+
+func TestPendingRegistrationStore_GetByToken_NotFound(t *testing.T) {
+	store := newInMemPendingStore()
+	_, err := store.GetPendingByToken(context.Background(), "tok-missing")
+	assert.ErrorIs(t, err, business.ErrPendingRegistrationNotFound)
+}
+
+func TestPendingRegistrationStore_GetByID_NotFound(t *testing.T) {
+	store := newInMemPendingStore()
+	_, err := store.GetPendingByID(context.Background(), "nonexistent")
+	assert.ErrorIs(t, err, business.ErrPendingRegistrationNotFound)
+}
+
+func TestPendingRegistrationStore_UpdateStatus_Claimed_SetsClaimed(t *testing.T) {
+	store := newInMemPendingStore()
+	ctx := context.Background()
+
+	require.NoError(t, store.AddPending(ctx, newTestEntry("p-c", "tenant-1", "tok-c")))
+	require.NoError(t, store.UpdateStatus(ctx, "p-c", business.PendingRegistrationStatusApproved))
+
+	before := time.Now().UTC()
+	require.NoError(t, store.UpdateStatus(ctx, "p-c", business.PendingRegistrationStatusClaimed))
+
+	got, err := store.GetPendingByID(ctx, "p-c")
+	require.NoError(t, err)
+	assert.Equal(t, business.PendingRegistrationStatusClaimed, got.Status)
+	require.NotNil(t, got.ClaimedAt)
+	assert.WithinDuration(t, before, *got.ClaimedAt, 2*time.Second)
+}
+
+func TestPendingRegistrationStore_UpdateStatus_NotFound(t *testing.T) {
+	store := newInMemPendingStore()
+	err := store.UpdateStatus(context.Background(), "missing", business.PendingRegistrationStatusDenied)
+	assert.ErrorIs(t, err, business.ErrPendingRegistrationNotFound)
+}
+
+func TestPendingRegistrationStore_ListPending_TenantFilter(t *testing.T) {
+	store := newInMemPendingStore()
+	ctx := context.Background()
+
+	require.NoError(t, store.AddPending(ctx, newTestEntry("p-a", "tenant-1", "tok-a")))
+	require.NoError(t, store.AddPending(ctx, newTestEntry("p-b", "tenant-2", "tok-b")))
+
+	all, err := store.ListPending(ctx, "")
+	require.NoError(t, err)
+	assert.Len(t, all, 2)
+
+	filtered, err := store.ListPending(ctx, "tenant-1")
+	require.NoError(t, err)
+	require.Len(t, filtered, 1)
+	assert.Equal(t, "p-a", filtered[0].PendingID)
+}
+
+func TestPendingRegistrationStore_ExpireStale_OnlyPending(t *testing.T) {
+	store := newInMemPendingStore()
+	ctx := context.Background()
+
+	now := time.Now().UTC()
+	stale := newTestEntry("p-stale", "tenant-1", "tok-stale")
+	stale.ExpiresAt = now.Add(-1 * time.Hour)
+	require.NoError(t, store.AddPending(ctx, stale))
+
+	approved := newTestEntry("p-appr", "tenant-1", "tok-appr")
+	approved.ExpiresAt = now.Add(-1 * time.Hour)
+	require.NoError(t, store.AddPending(ctx, approved))
+	require.NoError(t, store.UpdateStatus(ctx, "p-appr", business.PendingRegistrationStatusApproved))
+
+	count, err := store.ExpireStale(ctx, now)
+	require.NoError(t, err)
+	assert.Equal(t, 1, count, "only pending entries may be expired")
+}
+
+func TestPendingRegistrationStore_StatusConstants(t *testing.T) {
+	assert.Equal(t, "pending", business.PendingRegistrationStatusPending)
+	assert.Equal(t, "approved", business.PendingRegistrationStatusApproved)
+	assert.Equal(t, "claimed", business.PendingRegistrationStatusClaimed)
+	assert.Equal(t, "denied", business.PendingRegistrationStatusDenied)
+	assert.Equal(t, "expired", business.PendingRegistrationStatusExpired)
+}
+
+func TestErrPendingRegistrationNotFound(t *testing.T) {
+	assert.NotNil(t, business.ErrPendingRegistrationNotFound)
+	assert.Equal(t, "pending registration not found", business.ErrPendingRegistrationNotFound.Error())
+}

--- a/pkg/storage/interfaces/hybrid_manager.go
+++ b/pkg/storage/interfaces/hybrid_manager.go
@@ -31,10 +31,11 @@ type HybridStorageManager struct {
 	operationalProvider   StorageProvider
 	configurationProvider StorageProvider
 
-	clientTenantStore business.ClientTenantStore
-	auditStore        business.AuditStore
-	configStore       cfgconfig.ConfigStore
-	ipTrustStore      business.IPTrustStore
+	clientTenantStore        business.ClientTenantStore
+	auditStore               business.AuditStore
+	configStore              cfgconfig.ConfigStore
+	ipTrustStore             business.IPTrustStore
+	pendingRegistrationStore business.PendingRegistrationStore
 
 	config HybridStorageConfig
 }
@@ -82,6 +83,14 @@ func NewHybridStorageManager(config HybridStorageConfig) (*HybridStorageManager,
 	}
 	manager.ipTrustStore = ipTrustStore
 
+	// Pending registration storage is operational-tier; providers that do not
+	// implement it leave the accessor nil rather than failing.
+	pendingRegistrationStore, err := opProvider.CreatePendingRegistrationStore(config.Operational.Config)
+	if err != nil && !errors.Is(err, business.ErrNotSupported) {
+		return nil, fmt.Errorf("failed to create pending registration store: %w", err)
+	}
+	manager.pendingRegistrationStore = pendingRegistrationStore
+
 	// Create configuration store (GitOps workflow)
 	configStore, err := cfgProvider.CreateConfigStore(config.Configuration.Config)
 	if err != nil {
@@ -111,6 +120,13 @@ func (h *HybridStorageManager) GetConfigStore() cfgconfig.ConfigStore {
 // nil if the operational provider does not support IP trust storage).
 func (h *HybridStorageManager) GetIPTrustStore() business.IPTrustStore {
 	return h.ipTrustStore
+}
+
+// GetPendingRegistrationStore returns the pending registration storage interface
+// (operational backend, nil if the operational provider does not support pending
+// registration storage).
+func (h *HybridStorageManager) GetPendingRegistrationStore() business.PendingRegistrationStore {
+	return h.pendingRegistrationStore
 }
 
 // GetOperationalProvider returns the operational storage provider.

--- a/pkg/storage/interfaces/hybrid_manager_test.go
+++ b/pkg/storage/interfaces/hybrid_manager_test.go
@@ -125,6 +125,9 @@ func TestHybridStorageManager_Creation(t *testing.T) {
 	// GetIPTrustStore must be wired in the constructor when the operational
 	// provider supports IP trust storage (Issue #1691, PR #1711 finding #1).
 	assert.NotNil(t, manager.GetIPTrustStore())
+	// GetPendingRegistrationStore must be wired in the constructor when the operational
+	// provider supports pending registration storage (Issue #1696).
+	assert.NotNil(t, manager.GetPendingRegistrationStore())
 
 	// Round-trip: store a client tenant and verify retrieval returns the same value.
 	wantTenant := &business.ClientTenant{ID: "hybrid-rt-1", TenantName: "Hybrid Round Trip"}
@@ -381,7 +384,7 @@ func (p *mockProvider) CreatePushStore(_ map[string]interface{}) (business.PushS
 }
 
 func (p *mockProvider) CreatePendingRegistrationStore(_ map[string]interface{}) (business.PendingRegistrationStore, error) {
-	return nil, business.ErrNotSupported
+	return &mockPendingRegistrationStore{}, nil
 }
 
 func (p *mockProvider) CreateIPTrustStore(_ map[string]interface{}) (business.IPTrustStore, error) {
@@ -727,4 +730,32 @@ func (s *mockIPTrustStore) RecordHealthySteward(_ context.Context, _, _ string, 
 
 func (s *mockIPTrustStore) GetLastActivity(_ context.Context, _, _ string) (*business.IPTrustActivity, error) {
 	return nil, nil
+}
+
+// mockPendingRegistrationStore implements business.PendingRegistrationStore for testing
+// HybridStorageManager wiring (Issue #1696).
+type mockPendingRegistrationStore struct{}
+
+func (s *mockPendingRegistrationStore) AddPending(_ context.Context, _ *business.PendingRegistrationEntry) error {
+	return nil
+}
+
+func (s *mockPendingRegistrationStore) GetPendingByID(_ context.Context, _ string) (*business.PendingRegistrationEntry, error) {
+	return nil, business.ErrPendingRegistrationNotFound
+}
+
+func (s *mockPendingRegistrationStore) GetPendingByToken(_ context.Context, _ string) (*business.PendingRegistrationEntry, error) {
+	return nil, business.ErrPendingRegistrationNotFound
+}
+
+func (s *mockPendingRegistrationStore) UpdateStatus(_ context.Context, _, _ string) error {
+	return nil
+}
+
+func (s *mockPendingRegistrationStore) ListPending(_ context.Context, _ string) ([]*business.PendingRegistrationEntry, error) {
+	return nil, nil
+}
+
+func (s *mockPendingRegistrationStore) ExpireStale(_ context.Context, _ time.Time) (int, error) {
+	return 0, nil
 }

--- a/pkg/storage/providers/database/pending_registration_store.go
+++ b/pkg/storage/providers/database/pending_registration_store.go
@@ -1,0 +1,230 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+// Package database implements PendingRegistrationStore using PostgreSQL (Issue #1696).
+package database
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"strings"
+	"time"
+
+	_ "github.com/lib/pq" // PostgreSQL driver
+
+	business "github.com/cfgis/cfgms/pkg/storage/interfaces/business"
+)
+
+// Compile-time assertion.
+var _ business.PendingRegistrationStore = (*DatabasePendingRegistrationStore)(nil)
+
+// DatabasePendingRegistrationStore implements PendingRegistrationStore using PostgreSQL.
+type DatabasePendingRegistrationStore struct {
+	db      *sql.DB
+	schemas DatabaseSchemas
+}
+
+// NewDatabasePendingRegistrationStore opens a PostgreSQL-backed PendingRegistrationStore at dsn.
+func NewDatabasePendingRegistrationStore(dsn string, config map[string]interface{}) (*DatabasePendingRegistrationStore, error) {
+	db, err := sql.Open("postgres", dsn)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open database connection: %w", err)
+	}
+	maxOpenConns := getIntFromConfig(config, "max_open_connections", 25)
+	maxIdleConns := getIntFromConfig(config, "max_idle_connections", 5)
+	connMaxLifetime := time.Duration(getIntFromConfig(config, "connection_max_lifetime_minutes", 30)) * time.Minute
+	db.SetMaxOpenConns(maxOpenConns)
+	db.SetMaxIdleConns(maxIdleConns)
+	db.SetConnMaxLifetime(connMaxLifetime)
+
+	if err := db.Ping(); err != nil {
+		_ = db.Close()
+		return nil, fmt.Errorf("failed to ping database: %w", err)
+	}
+
+	store := &DatabasePendingRegistrationStore{db: db, schemas: NewDatabaseSchemas()}
+	if err := store.initSchema(); err != nil {
+		_ = db.Close()
+		return nil, fmt.Errorf("failed to initialise pending registration schema: %w", err)
+	}
+	return store, nil
+}
+
+func (s *DatabasePendingRegistrationStore) initSchema() error {
+	ctx := context.Background()
+	const lockID = 16924999
+	if _, err := s.db.ExecContext(ctx, "SELECT pg_advisory_lock($1)", lockID); err != nil {
+		return fmt.Errorf("failed to acquire pending registration schema lock: %w", err)
+	}
+	defer func() {
+		_, _ = s.db.ExecContext(ctx, "SELECT pg_advisory_unlock($1)", lockID)
+	}()
+	return s.schemas.CreatePendingRegistrationsTable(ctx, s.db)
+}
+
+// AddPending inserts a new pending-registration entry.
+func (s *DatabasePendingRegistrationStore) AddPending(ctx context.Context, entry *business.PendingRegistrationEntry) error {
+	if entry == nil {
+		return fmt.Errorf("database: pending registration entry cannot be nil")
+	}
+	if entry.PendingID == "" {
+		return fmt.Errorf("database: pending_id cannot be empty")
+	}
+
+	registeredAt := entry.RegisteredAt
+	if registeredAt.IsZero() {
+		registeredAt = time.Now().UTC()
+	}
+	status := entry.Status
+	if status == "" {
+		status = business.PendingRegistrationStatusPending
+	}
+
+	_, err := s.db.ExecContext(ctx, `
+		INSERT INTO cfgms_pending_registrations
+			(pending_id, steward_id, tenant_id, token_str, source_ip, registered_at, expires_at, claimed_at, status)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)`,
+		entry.PendingID, entry.StewardID, entry.TenantID, entry.TokenStr, entry.SourceIP,
+		registeredAt, entry.ExpiresAt, entry.ClaimedAt, status,
+	)
+	if err != nil {
+		if strings.Contains(err.Error(), "duplicate key") || strings.Contains(err.Error(), "unique_violation") {
+			return fmt.Errorf("database: pending registration %s already exists", entry.PendingID)
+		}
+		return fmt.Errorf("database: failed to add pending registration %s: %w", entry.PendingID, err)
+	}
+	return nil
+}
+
+// GetPendingByID retrieves the entry for the given pending_id.
+func (s *DatabasePendingRegistrationStore) GetPendingByID(ctx context.Context, pendingID string) (*business.PendingRegistrationEntry, error) {
+	row := s.db.QueryRowContext(ctx, `
+		SELECT pending_id, steward_id, tenant_id, token_str, source_ip, registered_at, expires_at, claimed_at, status
+		FROM cfgms_pending_registrations WHERE pending_id = $1`, pendingID)
+	return scanDBPendingEntry(row)
+}
+
+// GetPendingByToken retrieves the entry whose token_str matches.
+func (s *DatabasePendingRegistrationStore) GetPendingByToken(ctx context.Context, tokenStr string) (*business.PendingRegistrationEntry, error) {
+	row := s.db.QueryRowContext(ctx, `
+		SELECT pending_id, steward_id, tenant_id, token_str, source_ip, registered_at, expires_at, claimed_at, status
+		FROM cfgms_pending_registrations WHERE token_str = $1 LIMIT 1`, tokenStr)
+	return scanDBPendingEntry(row)
+}
+
+// UpdateStatus updates the status of the entry.
+// When status is "claimed", claimed_at is also set to now.
+func (s *DatabasePendingRegistrationStore) UpdateStatus(ctx context.Context, pendingID, status string) error {
+	var res sql.Result
+	var err error
+
+	if status == business.PendingRegistrationStatusClaimed {
+		// Guard with AND status = 'approved' so concurrent polls of the same entry
+		// result in exactly one winner: RowsAffected = 0 means already claimed.
+		res, err = s.db.ExecContext(ctx, `
+			UPDATE cfgms_pending_registrations
+			SET status = $1, claimed_at = $2
+			WHERE pending_id = $3 AND status = 'approved'`,
+			status, time.Now().UTC(), pendingID,
+		)
+	} else {
+		res, err = s.db.ExecContext(ctx, `
+			UPDATE cfgms_pending_registrations SET status = $1 WHERE pending_id = $2`,
+			status, pendingID,
+		)
+	}
+	if err != nil {
+		return fmt.Errorf("database: failed to update status for %s: %w", pendingID, err)
+	}
+	n, _ := res.RowsAffected()
+	if n == 0 {
+		return business.ErrPendingRegistrationNotFound
+	}
+	return nil
+}
+
+// ListPending returns all entries for the given tenantID, or all tenants if empty.
+func (s *DatabasePendingRegistrationStore) ListPending(ctx context.Context, tenantID string) ([]*business.PendingRegistrationEntry, error) {
+	var (
+		rows *sql.Rows
+		err  error
+	)
+	if tenantID == "" {
+		rows, err = s.db.QueryContext(ctx, `
+			SELECT pending_id, steward_id, tenant_id, token_str, source_ip, registered_at, expires_at, claimed_at, status
+			FROM cfgms_pending_registrations ORDER BY registered_at ASC`)
+	} else {
+		rows, err = s.db.QueryContext(ctx, `
+			SELECT pending_id, steward_id, tenant_id, token_str, source_ip, registered_at, expires_at, claimed_at, status
+			FROM cfgms_pending_registrations WHERE tenant_id = $1 ORDER BY registered_at ASC`, tenantID)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("database: failed to list pending registrations: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var entries []*business.PendingRegistrationEntry
+	for rows.Next() {
+		e := &business.PendingRegistrationEntry{}
+		var claimedAt sql.NullTime
+		if err := rows.Scan(
+			&e.PendingID, &e.StewardID, &e.TenantID, &e.TokenStr, &e.SourceIP,
+			&e.RegisteredAt, &e.ExpiresAt, &claimedAt, &e.Status,
+		); err != nil {
+			return nil, fmt.Errorf("database: failed to scan pending registration: %w", err)
+		}
+		if claimedAt.Valid {
+			t := claimedAt.Time.UTC()
+			e.ClaimedAt = &t
+		}
+		entries = append(entries, e)
+	}
+	return entries, rows.Err()
+}
+
+// ExpireStale marks pending entries whose expires_at is at or before cutoff as expired.
+func (s *DatabasePendingRegistrationStore) ExpireStale(ctx context.Context, cutoff time.Time) (int, error) {
+	res, err := s.db.ExecContext(ctx, `
+		UPDATE cfgms_pending_registrations
+		SET status = $1
+		WHERE status = $2 AND expires_at <= $3`,
+		business.PendingRegistrationStatusExpired,
+		business.PendingRegistrationStatusPending,
+		cutoff,
+	)
+	if err != nil {
+		return 0, fmt.Errorf("database: failed to expire stale pending registrations: %w", err)
+	}
+	n, _ := res.RowsAffected()
+	return int(n), nil
+}
+
+// Close closes the database connection.
+func (s *DatabasePendingRegistrationStore) Close() error {
+	if s.db != nil {
+		return s.db.Close()
+	}
+	return nil
+}
+
+func scanDBPendingEntry(row *sql.Row) (*business.PendingRegistrationEntry, error) {
+	e := &business.PendingRegistrationEntry{}
+	var claimedAt sql.NullTime
+	err := row.Scan(
+		&e.PendingID, &e.StewardID, &e.TenantID, &e.TokenStr, &e.SourceIP,
+		&e.RegisteredAt, &e.ExpiresAt, &claimedAt, &e.Status,
+	)
+	if err == sql.ErrNoRows {
+		return nil, business.ErrPendingRegistrationNotFound
+	}
+	if err != nil {
+		return nil, fmt.Errorf("database: failed to scan pending registration: %w", err)
+	}
+	if claimedAt.Valid {
+		t := claimedAt.Time.UTC()
+		e.ClaimedAt = &t
+	}
+	e.RegisteredAt = e.RegisteredAt.UTC()
+	e.ExpiresAt = e.ExpiresAt.UTC()
+	return e, nil
+}

--- a/pkg/storage/providers/database/schemas.go
+++ b/pkg/storage/providers/database/schemas.go
@@ -660,6 +660,40 @@ func (s DatabaseSchemas) CreateIPTrustRangesTable(ctx context.Context, db *sql.D
 	return nil
 }
 
+// CreatePendingRegistrationsTable creates the cfgms_pending_registrations table (Issue #1696).
+// No cert bundle columns are included — generate-on-claim issues certs in memory only.
+func (s DatabaseSchemas) CreatePendingRegistrationsTable(ctx context.Context, db *sql.DB) error {
+	createTableQuery := `
+		CREATE TABLE IF NOT EXISTS cfgms_pending_registrations (
+			pending_id    TEXT PRIMARY KEY,
+			steward_id    TEXT NOT NULL DEFAULT '',
+			tenant_id     TEXT NOT NULL,
+			token_str     TEXT NOT NULL,
+			source_ip     TEXT NOT NULL DEFAULT '',
+			registered_at TIMESTAMP WITH TIME ZONE NOT NULL,
+			expires_at    TIMESTAMP WITH TIME ZONE NOT NULL,
+			claimed_at    TIMESTAMP WITH TIME ZONE,
+			status        TEXT NOT NULL DEFAULT 'pending'
+		);
+	`
+	if _, err := db.ExecContext(ctx, createTableQuery); err != nil {
+		return fmt.Errorf("failed to create cfgms_pending_registrations table: %w", err)
+	}
+
+	indexes := []string{
+		"CREATE INDEX IF NOT EXISTS idx_cfgms_pending_registrations_tenant_id  ON cfgms_pending_registrations(tenant_id);",
+		"CREATE INDEX IF NOT EXISTS idx_cfgms_pending_registrations_status     ON cfgms_pending_registrations(status);",
+		"CREATE INDEX IF NOT EXISTS idx_cfgms_pending_registrations_expires_at ON cfgms_pending_registrations(expires_at);",
+		"CREATE INDEX IF NOT EXISTS idx_cfgms_pending_registrations_token_str  ON cfgms_pending_registrations(token_str);",
+	}
+	for _, idx := range indexes {
+		if _, err := db.ExecContext(ctx, idx); err != nil {
+			return fmt.Errorf("failed to create cfgms_pending_registrations index: %w", err)
+		}
+	}
+	return nil
+}
+
 // CreateAllTables creates all necessary database tables and indexes
 func (s DatabaseSchemas) CreateAllTables(ctx context.Context, db *sql.DB) error {
 	// Create tables in dependency order

--- a/pkg/storage/providers/sqlite/pending_registration_store.go
+++ b/pkg/storage/providers/sqlite/pending_registration_store.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2026 Jordan Ritz
-// Package sqlite implements PendingRegistrationStore using SQLite for the
-// manual-review registration approval mode (Issue #1599).
+// Package sqlite implements PendingRegistrationStore using the cfgms_pending_registrations
+// table — the generate-on-claim durable queue (Issue #1696).
 package sqlite
 
 import (
@@ -9,20 +9,21 @@ import (
 	"database/sql"
 	"fmt"
 	"strings"
+	"time"
 
 	business "github.com/cfgis/cfgms/pkg/storage/interfaces/business"
 )
 
+// Compile-time assertion.
+var _ business.PendingRegistrationStore = (*SQLitePendingRegistrationStore)(nil)
+
 // SQLitePendingRegistrationStore implements business.PendingRegistrationStore
-// using a SQLite database. Records are stored in the pending_registrations table.
+// using a SQLite database backed by the cfgms_pending_registrations table.
 type SQLitePendingRegistrationStore struct {
 	db *sql.DB
 }
 
-// Initialize is a no-op; schema is applied in openAndInit.
-func (s *SQLitePendingRegistrationStore) Initialize(_ context.Context) error { return nil }
-
-// Close closes the database connection.
+// Close closes the underlying database connection.
 func (s *SQLitePendingRegistrationStore) Close() error {
 	if s.db != nil {
 		return s.db.Close()
@@ -30,97 +31,118 @@ func (s *SQLitePendingRegistrationStore) Close() error {
 	return nil
 }
 
-// CreatePending inserts a new pending-registration record. Returns an error if a
-// record with the same ID already exists.
-func (s *SQLitePendingRegistrationStore) CreatePending(ctx context.Context, record *business.PendingRegistrationData) error {
-	if record == nil {
-		return fmt.Errorf("sqlite: pending registration record cannot be nil")
+// AddPending inserts a new pending-registration entry.
+// Returns an error if an entry with the same PendingID already exists.
+func (s *SQLitePendingRegistrationStore) AddPending(ctx context.Context, entry *business.PendingRegistrationEntry) error {
+	if entry == nil {
+		return fmt.Errorf("sqlite: pending registration entry cannot be nil")
 	}
-	if record.ID == "" {
-		return fmt.Errorf("sqlite: pending registration ID cannot be empty")
+	if entry.PendingID == "" {
+		return fmt.Errorf("sqlite: pending_id cannot be empty")
+	}
+	if entry.TenantID == "" {
+		return fmt.Errorf("sqlite: tenant_id cannot be empty")
 	}
 
-	status := record.Status
+	registeredAt := entry.RegisteredAt
+	if registeredAt.IsZero() {
+		registeredAt = nowUTC()
+	}
+	status := entry.Status
 	if status == "" {
 		status = business.PendingRegistrationStatusPending
 	}
-	createdAt := record.CreatedAt
-	if createdAt.IsZero() {
-		createdAt = nowUTC()
-	}
 
 	_, err := s.db.ExecContext(ctx, `
-		INSERT INTO pending_registrations
-			(id, steward_id, tenant_id, source_ip, token_prefix, status, deny_reason, created_at, expires_at)
+		INSERT INTO cfgms_pending_registrations
+			(pending_id, steward_id, tenant_id, token_str, source_ip, registered_at, expires_at, claimed_at, status)
 		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-		record.ID,
-		record.StewardID,
-		record.TenantID,
-		record.SourceIP,
-		record.TokenPrefix,
-		string(status),
-		record.DenyReason,
-		formatTime(createdAt),
-		formatTime(record.ExpiresAt),
+		entry.PendingID,
+		entry.StewardID,
+		entry.TenantID,
+		entry.TokenStr,
+		entry.SourceIP,
+		formatTime(registeredAt),
+		formatTime(entry.ExpiresAt),
+		formatNullTime(entry.ClaimedAt),
+		status,
 	)
 	if err != nil {
 		if strings.Contains(err.Error(), "UNIQUE constraint failed") {
-			return fmt.Errorf("sqlite: pending registration %s already exists", record.ID)
+			return fmt.Errorf("sqlite: pending registration %s already exists", entry.PendingID)
 		}
-		return fmt.Errorf("sqlite: failed to create pending registration %s: %w", record.ID, err)
+		return fmt.Errorf("sqlite: failed to add pending registration %s: %w", entry.PendingID, err)
 	}
 	return nil
 }
 
-// GetPending retrieves the pending-registration record for the given ID.
+// GetPendingByID retrieves the entry for the given pending_id.
 // Returns ErrPendingRegistrationNotFound if no record exists.
-func (s *SQLitePendingRegistrationStore) GetPending(ctx context.Context, id string) (*business.PendingRegistrationData, error) {
+func (s *SQLitePendingRegistrationStore) GetPendingByID(ctx context.Context, pendingID string) (*business.PendingRegistrationEntry, error) {
 	row := s.db.QueryRowContext(ctx, `
-		SELECT id, steward_id, tenant_id, source_ip, token_prefix, status, deny_reason, created_at, expires_at
-		FROM pending_registrations WHERE id = ?`, id)
-
-	r := &business.PendingRegistrationData{}
-	var statusStr, createdStr, expiresStr string
-	err := row.Scan(
-		&r.ID, &r.StewardID, &r.TenantID, &r.SourceIP, &r.TokenPrefix,
-		&statusStr, &r.DenyReason, &createdStr, &expiresStr,
-	)
-	if err == sql.ErrNoRows {
-		return nil, business.ErrPendingRegistrationNotFound
-	}
-	if err != nil {
-		return nil, fmt.Errorf("sqlite: failed to scan pending registration: %w", err)
-	}
-	populatePendingRegistration(r, statusStr, createdStr, expiresStr)
-	return r, nil
+		SELECT pending_id, steward_id, tenant_id, token_str, source_ip, registered_at, expires_at, claimed_at, status
+		FROM cfgms_pending_registrations WHERE pending_id = ?`, pendingID)
+	return scanPendingEntry(row)
 }
 
-// ListPending returns all records matching the filter, ordered by created_at ascending.
-// A nil filter returns every record.
-func (s *SQLitePendingRegistrationStore) ListPending(ctx context.Context, filter *business.PendingRegistrationFilter) ([]*business.PendingRegistrationData, error) {
-	query := `
-		SELECT id, steward_id, tenant_id, source_ip, token_prefix, status, deny_reason, created_at, expires_at
-		FROM pending_registrations`
-	var conds []string
-	var args []interface{}
-	if filter != nil {
-		if filter.Status != nil {
-			conds = append(conds, "status = ?")
-			args = append(args, string(*filter.Status))
-		}
-		if filter.TenantID != nil {
-			conds = append(conds, "tenant_id = ?")
-			args = append(args, *filter.TenantID)
-		}
-		if filter.ExpiresBeforeOrAt != nil {
-			conds = append(conds, "expires_at <= ?")
-			args = append(args, formatTime(*filter.ExpiresBeforeOrAt))
-		}
+// GetPendingByToken retrieves the entry whose token_str matches the given token.
+// Returns ErrPendingRegistrationNotFound if no matching record exists.
+func (s *SQLitePendingRegistrationStore) GetPendingByToken(ctx context.Context, tokenStr string) (*business.PendingRegistrationEntry, error) {
+	row := s.db.QueryRowContext(ctx, `
+		SELECT pending_id, steward_id, tenant_id, token_str, source_ip, registered_at, expires_at, claimed_at, status
+		FROM cfgms_pending_registrations WHERE token_str = ? LIMIT 1`, tokenStr)
+	return scanPendingEntry(row)
+}
+
+// UpdateStatus updates the status of the entry identified by pendingID.
+// When status is "claimed", claimed_at is also set to the current UTC time.
+// Returns ErrPendingRegistrationNotFound if no record exists.
+func (s *SQLitePendingRegistrationStore) UpdateStatus(ctx context.Context, pendingID, status string) error {
+	var res sql.Result
+	var err error
+
+	if status == business.PendingRegistrationStatusClaimed {
+		// Guard with AND status = 'approved' so concurrent polls of the same entry
+		// result in exactly one winner: RowsAffected = 0 means already claimed.
+		res, err = s.db.ExecContext(ctx, `
+			UPDATE cfgms_pending_registrations
+			SET status = ?, claimed_at = ?
+			WHERE pending_id = ? AND status = 'approved'`,
+			status, formatTime(nowUTC()), pendingID,
+		)
+	} else {
+		res, err = s.db.ExecContext(ctx, `
+			UPDATE cfgms_pending_registrations SET status = ? WHERE pending_id = ?`,
+			status, pendingID,
+		)
 	}
-	if len(conds) > 0 {
-		query += " WHERE " + strings.Join(conds, " AND ")
+	if err != nil {
+		return fmt.Errorf("sqlite: failed to update status for %s: %w", pendingID, err)
 	}
-	query += " ORDER BY created_at ASC"
+	n, _ := res.RowsAffected()
+	if n == 0 {
+		return business.ErrPendingRegistrationNotFound
+	}
+	return nil
+}
+
+// ListPending returns all entries for the given tenantID ordered by registered_at ascending.
+// An empty tenantID returns entries for all tenants.
+func (s *SQLitePendingRegistrationStore) ListPending(ctx context.Context, tenantID string) ([]*business.PendingRegistrationEntry, error) {
+	var (
+		query string
+		args  []interface{}
+	)
+	if tenantID == "" {
+		query = `
+			SELECT pending_id, steward_id, tenant_id, token_str, source_ip, registered_at, expires_at, claimed_at, status
+			FROM cfgms_pending_registrations ORDER BY registered_at ASC`
+	} else {
+		query = `
+			SELECT pending_id, steward_id, tenant_id, token_str, source_ip, registered_at, expires_at, claimed_at, status
+			FROM cfgms_pending_registrations WHERE tenant_id = ? ORDER BY registered_at ASC`
+		args = []interface{}{tenantID}
+	}
 
 	rows, err := s.db.QueryContext(ctx, query, args...)
 	if err != nil {
@@ -128,59 +150,85 @@ func (s *SQLitePendingRegistrationStore) ListPending(ctx context.Context, filter
 	}
 	defer func() { _ = rows.Close() }()
 
-	var records []*business.PendingRegistrationData
+	var entries []*business.PendingRegistrationEntry
 	for rows.Next() {
-		r := &business.PendingRegistrationData{}
-		var statusStr, createdStr, expiresStr string
-		if err := rows.Scan(
-			&r.ID, &r.StewardID, &r.TenantID, &r.SourceIP, &r.TokenPrefix,
-			&statusStr, &r.DenyReason, &createdStr, &expiresStr,
-		); err != nil {
+		e, err := scanPendingRow(rows)
+		if err != nil {
 			return nil, fmt.Errorf("sqlite: failed to scan pending registration row: %w", err)
 		}
-		populatePendingRegistration(r, statusStr, createdStr, expiresStr)
-		records = append(records, r)
+		entries = append(entries, e)
 	}
-	return records, rows.Err()
+	return entries, rows.Err()
 }
 
-// UpdatePendingStatus updates the status and deny reason of the given record.
-// Returns ErrPendingRegistrationNotFound if no record exists for the ID.
-func (s *SQLitePendingRegistrationStore) UpdatePendingStatus(ctx context.Context, id string, status business.PendingRegistrationStatus, reason string) error {
+// ExpireStale marks entries whose expires_at is at or before cutoff and whose status
+// is "pending" as "expired". Returns the number of entries updated.
+func (s *SQLitePendingRegistrationStore) ExpireStale(ctx context.Context, cutoff time.Time) (int, error) {
 	res, err := s.db.ExecContext(ctx, `
-		UPDATE pending_registrations SET status = ?, deny_reason = ? WHERE id = ?`,
-		string(status), reason, id,
+		UPDATE cfgms_pending_registrations
+		SET status = ?
+		WHERE status = ? AND expires_at <= ?`,
+		business.PendingRegistrationStatusExpired,
+		business.PendingRegistrationStatusPending,
+		formatTime(cutoff),
 	)
 	if err != nil {
-		return fmt.Errorf("sqlite: failed to update pending registration status for %s: %w", id, err)
+		return 0, fmt.Errorf("sqlite: failed to expire stale pending registrations: %w", err)
 	}
 	n, _ := res.RowsAffected()
-	if n == 0 {
-		return business.ErrPendingRegistrationNotFound
-	}
-	return nil
+	return int(n), nil
 }
 
-// DeletePending removes the pending-registration record for the given ID.
-// Returns ErrPendingRegistrationNotFound if no record exists.
-func (s *SQLitePendingRegistrationStore) DeletePending(ctx context.Context, id string) error {
-	res, err := s.db.ExecContext(ctx, `DELETE FROM pending_registrations WHERE id = ?`, id)
+// --- helpers -----------------------------------------------------------------
+
+// formatNullTime formats a *time.Time for storage; NULL when nil.
+func formatNullTime(t *time.Time) interface{} {
+	if t == nil {
+		return nil
+	}
+	return formatTime(*t)
+}
+
+// scanPendingEntry scans a single row from a QueryRowContext call.
+func scanPendingEntry(row *sql.Row) (*business.PendingRegistrationEntry, error) {
+	e := &business.PendingRegistrationEntry{}
+	var registeredStr, expiresStr string
+	var claimedStr sql.NullString
+	err := row.Scan(
+		&e.PendingID, &e.StewardID, &e.TenantID, &e.TokenStr, &e.SourceIP,
+		&registeredStr, &expiresStr, &claimedStr, &e.Status,
+	)
+	if err == sql.ErrNoRows {
+		return nil, business.ErrPendingRegistrationNotFound
+	}
 	if err != nil {
-		return fmt.Errorf("sqlite: failed to delete pending registration %s: %w", id, err)
+		return nil, fmt.Errorf("sqlite: failed to scan pending registration: %w", err)
 	}
-	n, _ := res.RowsAffected()
-	if n == 0 {
-		return business.ErrPendingRegistrationNotFound
-	}
-	return nil
+	populatePendingEntry(e, registeredStr, expiresStr, claimedStr)
+	return e, nil
 }
 
-// populatePendingRegistration fills in the time and status fields from their string representations.
-func populatePendingRegistration(r *business.PendingRegistrationData, statusStr, createdStr, expiresStr string) {
-	r.Status = business.PendingRegistrationStatus(statusStr)
-	r.CreatedAt = parseTime(createdStr)
-	r.ExpiresAt = parseTime(expiresStr)
+// scanPendingRow scans a single row from an open Rows cursor.
+func scanPendingRow(rows *sql.Rows) (*business.PendingRegistrationEntry, error) {
+	e := &business.PendingRegistrationEntry{}
+	var registeredStr, expiresStr string
+	var claimedStr sql.NullString
+	if err := rows.Scan(
+		&e.PendingID, &e.StewardID, &e.TenantID, &e.TokenStr, &e.SourceIP,
+		&registeredStr, &expiresStr, &claimedStr, &e.Status,
+	); err != nil {
+		return nil, err
+	}
+	populatePendingEntry(e, registeredStr, expiresStr, claimedStr)
+	return e, nil
 }
 
-// Compile-time assertion
-var _ business.PendingRegistrationStore = (*SQLitePendingRegistrationStore)(nil)
+// populatePendingEntry fills time fields from their stored string representations.
+func populatePendingEntry(e *business.PendingRegistrationEntry, registeredStr, expiresStr string, claimedStr sql.NullString) {
+	e.RegisteredAt = parseTime(registeredStr)
+	e.ExpiresAt = parseTime(expiresStr)
+	if claimedStr.Valid && claimedStr.String != "" {
+		t := parseTime(claimedStr.String)
+		e.ClaimedAt = &t
+	}
+}

--- a/pkg/storage/providers/sqlite/pending_registration_store_test.go
+++ b/pkg/storage/providers/sqlite/pending_registration_store_test.go
@@ -13,7 +13,7 @@ import (
 	business "github.com/cfgis/cfgms/pkg/storage/interfaces/business"
 )
 
-// newTestPendingRegistrationStore creates an in-memory SQLite PendingRegistrationStore for tests.
+// newTestPendingRegistrationStore opens an in-memory SQLite store for testing.
 func newTestPendingRegistrationStore(t *testing.T) *SQLitePendingRegistrationStore {
 	t.Helper()
 	db, err := openAndInit(":memory:")
@@ -22,161 +22,233 @@ func newTestPendingRegistrationStore(t *testing.T) *SQLitePendingRegistrationSto
 	return &SQLitePendingRegistrationStore{db: db}
 }
 
-// testPendingRecord returns a PendingRegistrationData with sensible defaults.
-func testPendingRecord(id string) *business.PendingRegistrationData {
-	now := time.Now().UTC()
-	return &business.PendingRegistrationData{
-		ID:          id,
-		StewardID:   "",
-		TenantID:    "tenant-1",
-		SourceIP:    "10.0.0.5",
-		TokenPrefix: "tok-abcd",
-		Status:      business.PendingRegistrationStatusPending,
-		CreatedAt:   now,
-		ExpiresAt:   now.Add(24 * time.Hour),
+// testPendingEntry returns a PendingRegistrationEntry with sensible defaults.
+func testPendingEntry(pendingID, tenantID string) *business.PendingRegistrationEntry {
+	now := time.Now().UTC().Truncate(time.Second)
+	return &business.PendingRegistrationEntry{
+		PendingID:    pendingID,
+		StewardID:    "steward-" + pendingID,
+		TenantID:     tenantID,
+		TokenStr:     "cfgms_reg_tok_" + pendingID,
+		SourceIP:     "10.0.0.5",
+		RegisteredAt: now,
+		ExpiresAt:    now.Add(5 * 24 * time.Hour),
+		Status:       business.PendingRegistrationStatusPending,
 	}
 }
 
-func TestPendingRegistrationStore_CreateAndGet(t *testing.T) {
+func TestPendingRegistrationStore_AddAndGetByID(t *testing.T) {
 	store := newTestPendingRegistrationStore(t)
 	ctx := context.Background()
 
-	record := testPendingRecord("pr-1")
-	require.NoError(t, store.CreatePending(ctx, record))
+	entry := testPendingEntry("pr-1", "tenant-1")
+	require.NoError(t, store.AddPending(ctx, entry))
 
-	got, err := store.GetPending(ctx, "pr-1")
+	got, err := store.GetPendingByID(ctx, "pr-1")
 	require.NoError(t, err)
-	assert.Equal(t, "pr-1", got.ID)
+	assert.Equal(t, "pr-1", got.PendingID)
 	assert.Equal(t, "tenant-1", got.TenantID)
-	assert.Equal(t, "10.0.0.5", got.SourceIP)
-	assert.Equal(t, "tok-abcd", got.TokenPrefix)
+	assert.Equal(t, "cfgms_reg_tok_pr-1", got.TokenStr)
 	assert.Equal(t, business.PendingRegistrationStatusPending, got.Status)
-	assert.WithinDuration(t, record.ExpiresAt, got.ExpiresAt, time.Second)
+	assert.WithinDuration(t, entry.ExpiresAt, got.ExpiresAt, time.Second)
+	assert.Nil(t, got.ClaimedAt)
 }
 
-func TestPendingRegistrationStore_CreateNil(t *testing.T) {
-	store := newTestPendingRegistrationStore(t)
-	err := store.CreatePending(context.Background(), nil)
-	require.Error(t, err)
-}
-
-func TestPendingRegistrationStore_CreateEmptyID(t *testing.T) {
-	store := newTestPendingRegistrationStore(t)
-	record := testPendingRecord("")
-	err := store.CreatePending(context.Background(), record)
-	require.Error(t, err)
-}
-
-func TestPendingRegistrationStore_CreateDuplicate(t *testing.T) {
+func TestPendingRegistrationStore_GetByToken(t *testing.T) {
 	store := newTestPendingRegistrationStore(t)
 	ctx := context.Background()
 
-	require.NoError(t, store.CreatePending(ctx, testPendingRecord("pr-dup")))
-	err := store.CreatePending(ctx, testPendingRecord("pr-dup"))
-	require.Error(t, err, "creating a record with a duplicate ID must fail")
+	entry := testPendingEntry("pr-tok", "tenant-1")
+	require.NoError(t, store.AddPending(ctx, entry))
+
+	got, err := store.GetPendingByToken(ctx, "cfgms_reg_tok_pr-tok")
+	require.NoError(t, err)
+	assert.Equal(t, "pr-tok", got.PendingID)
 }
 
-func TestPendingRegistrationStore_GetNotFound(t *testing.T) {
+func TestPendingRegistrationStore_GetByToken_NotFound(t *testing.T) {
 	store := newTestPendingRegistrationStore(t)
-	_, err := store.GetPending(context.Background(), "nonexistent")
+	_, err := store.GetPendingByToken(context.Background(), "nonexistent-token")
 	assert.ErrorIs(t, err, business.ErrPendingRegistrationNotFound)
 }
 
-func TestPendingRegistrationStore_ListNoFilter(t *testing.T) {
+func TestPendingRegistrationStore_AddNil(t *testing.T) {
 	store := newTestPendingRegistrationStore(t)
-	ctx := context.Background()
-
-	require.NoError(t, store.CreatePending(ctx, testPendingRecord("pr-a")))
-	require.NoError(t, store.CreatePending(ctx, testPendingRecord("pr-b")))
-
-	records, err := store.ListPending(ctx, nil)
-	require.NoError(t, err)
-	assert.Len(t, records, 2)
+	err := store.AddPending(context.Background(), nil)
+	require.Error(t, err)
 }
 
-func TestPendingRegistrationStore_ListFilterByStatus(t *testing.T) {
+func TestPendingRegistrationStore_AddEmptyPendingID(t *testing.T) {
 	store := newTestPendingRegistrationStore(t)
-	ctx := context.Background()
-
-	require.NoError(t, store.CreatePending(ctx, testPendingRecord("pr-pending")))
-	denied := testPendingRecord("pr-denied")
-	denied.Status = business.PendingRegistrationStatusDenied
-	require.NoError(t, store.CreatePending(ctx, denied))
-
-	pending := business.PendingRegistrationStatusPending
-	records, err := store.ListPending(ctx, &business.PendingRegistrationFilter{Status: &pending})
-	require.NoError(t, err)
-	require.Len(t, records, 1)
-	assert.Equal(t, "pr-pending", records[0].ID)
+	entry := testPendingEntry("", "tenant-1")
+	err := store.AddPending(context.Background(), entry)
+	require.Error(t, err)
 }
 
-func TestPendingRegistrationStore_ListFilterByTenant(t *testing.T) {
+func TestPendingRegistrationStore_AddDuplicate(t *testing.T) {
 	store := newTestPendingRegistrationStore(t)
 	ctx := context.Background()
 
-	require.NoError(t, store.CreatePending(ctx, testPendingRecord("pr-t1")))
-	other := testPendingRecord("pr-t2")
-	other.TenantID = "tenant-2"
-	require.NoError(t, store.CreatePending(ctx, other))
-
-	tenant := "tenant-2"
-	records, err := store.ListPending(ctx, &business.PendingRegistrationFilter{TenantID: &tenant})
-	require.NoError(t, err)
-	require.Len(t, records, 1)
-	assert.Equal(t, "pr-t2", records[0].ID)
+	require.NoError(t, store.AddPending(ctx, testPendingEntry("pr-dup", "tenant-1")))
+	err := store.AddPending(ctx, testPendingEntry("pr-dup", "tenant-1"))
+	require.Error(t, err, "creating a record with a duplicate pending_id must fail")
 }
 
-func TestPendingRegistrationStore_ListFilterExpired(t *testing.T) {
+func TestPendingRegistrationStore_GetByID_NotFound(t *testing.T) {
 	store := newTestPendingRegistrationStore(t)
-	ctx := context.Background()
-
-	expired := testPendingRecord("pr-expired")
-	expired.ExpiresAt = time.Now().UTC().Add(-1 * time.Hour)
-	require.NoError(t, store.CreatePending(ctx, expired))
-
-	active := testPendingRecord("pr-active")
-	active.ExpiresAt = time.Now().UTC().Add(24 * time.Hour)
-	require.NoError(t, store.CreatePending(ctx, active))
-
-	now := time.Now().UTC()
-	records, err := store.ListPending(ctx, &business.PendingRegistrationFilter{ExpiresBeforeOrAt: &now})
-	require.NoError(t, err)
-	require.Len(t, records, 1)
-	assert.Equal(t, "pr-expired", records[0].ID)
+	_, err := store.GetPendingByID(context.Background(), "nonexistent")
+	assert.ErrorIs(t, err, business.ErrPendingRegistrationNotFound)
 }
 
-func TestPendingRegistrationStore_UpdateStatus(t *testing.T) {
+func TestPendingRegistrationStore_UpdateStatus_Approved(t *testing.T) {
 	store := newTestPendingRegistrationStore(t)
 	ctx := context.Background()
 
-	require.NoError(t, store.CreatePending(ctx, testPendingRecord("pr-upd")))
-	require.NoError(t, store.UpdatePendingStatus(ctx, "pr-upd", business.PendingRegistrationStatusDenied, "policy violation"))
+	require.NoError(t, store.AddPending(ctx, testPendingEntry("pr-appr", "tenant-1")))
+	require.NoError(t, store.UpdateStatus(ctx, "pr-appr", business.PendingRegistrationStatusApproved))
 
-	got, err := store.GetPending(ctx, "pr-upd")
+	got, err := store.GetPendingByID(ctx, "pr-appr")
+	require.NoError(t, err)
+	assert.Equal(t, business.PendingRegistrationStatusApproved, got.Status)
+	assert.Nil(t, got.ClaimedAt, "claimed_at must remain nil for approved status")
+}
+
+func TestPendingRegistrationStore_UpdateStatus_Claimed_SetsClaimed(t *testing.T) {
+	store := newTestPendingRegistrationStore(t)
+	ctx := context.Background()
+
+	require.NoError(t, store.AddPending(ctx, testPendingEntry("pr-claim", "tenant-1")))
+	// Must be approved first — UpdateStatus("claimed") has AND status='approved' guard.
+	require.NoError(t, store.UpdateStatus(ctx, "pr-claim", business.PendingRegistrationStatusApproved))
+
+	before := time.Now().UTC()
+	require.NoError(t, store.UpdateStatus(ctx, "pr-claim", business.PendingRegistrationStatusClaimed))
+
+	got, err := store.GetPendingByID(ctx, "pr-claim")
+	require.NoError(t, err)
+	assert.Equal(t, business.PendingRegistrationStatusClaimed, got.Status)
+	require.NotNil(t, got.ClaimedAt, "claimed_at must be set when status is claimed")
+	assert.WithinDuration(t, before, *got.ClaimedAt, 2*time.Second)
+}
+
+func TestPendingRegistrationStore_UpdateStatus_Denied(t *testing.T) {
+	store := newTestPendingRegistrationStore(t)
+	ctx := context.Background()
+
+	require.NoError(t, store.AddPending(ctx, testPendingEntry("pr-deny", "tenant-1")))
+	require.NoError(t, store.UpdateStatus(ctx, "pr-deny", business.PendingRegistrationStatusDenied))
+
+	got, err := store.GetPendingByID(ctx, "pr-deny")
 	require.NoError(t, err)
 	assert.Equal(t, business.PendingRegistrationStatusDenied, got.Status)
-	assert.Equal(t, "policy violation", got.DenyReason)
 }
 
-func TestPendingRegistrationStore_UpdateStatusNotFound(t *testing.T) {
+func TestPendingRegistrationStore_UpdateStatus_NotFound(t *testing.T) {
 	store := newTestPendingRegistrationStore(t)
-	err := store.UpdatePendingStatus(context.Background(), "missing", business.PendingRegistrationStatusApproved, "")
+	err := store.UpdateStatus(context.Background(), "missing", business.PendingRegistrationStatusApproved)
 	assert.ErrorIs(t, err, business.ErrPendingRegistrationNotFound)
 }
 
-func TestPendingRegistrationStore_Delete(t *testing.T) {
+func TestPendingRegistrationStore_ListPending_AllTenants(t *testing.T) {
 	store := newTestPendingRegistrationStore(t)
 	ctx := context.Background()
 
-	require.NoError(t, store.CreatePending(ctx, testPendingRecord("pr-del")))
-	require.NoError(t, store.DeletePending(ctx, "pr-del"))
+	require.NoError(t, store.AddPending(ctx, testPendingEntry("pr-a", "tenant-1")))
+	require.NoError(t, store.AddPending(ctx, testPendingEntry("pr-b", "tenant-2")))
 
-	_, err := store.GetPending(ctx, "pr-del")
-	assert.ErrorIs(t, err, business.ErrPendingRegistrationNotFound)
+	entries, err := store.ListPending(ctx, "")
+	require.NoError(t, err)
+	assert.Len(t, entries, 2)
 }
 
-func TestPendingRegistrationStore_DeleteNotFound(t *testing.T) {
+func TestPendingRegistrationStore_ListPending_FilterByTenant(t *testing.T) {
 	store := newTestPendingRegistrationStore(t)
-	err := store.DeletePending(context.Background(), "missing")
-	assert.ErrorIs(t, err, business.ErrPendingRegistrationNotFound)
+	ctx := context.Background()
+
+	require.NoError(t, store.AddPending(ctx, testPendingEntry("pr-t1", "tenant-1")))
+	require.NoError(t, store.AddPending(ctx, testPendingEntry("pr-t2", "tenant-2")))
+
+	entries, err := store.ListPending(ctx, "tenant-2")
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+	assert.Equal(t, "pr-t2", entries[0].PendingID)
+}
+
+func TestPendingRegistrationStore_ExpireStale(t *testing.T) {
+	store := newTestPendingRegistrationStore(t)
+	ctx := context.Background()
+
+	past := time.Now().UTC().Add(-2 * time.Hour)
+	future := time.Now().UTC().Add(24 * time.Hour)
+
+	stale := testPendingEntry("pr-stale", "tenant-1")
+	stale.ExpiresAt = past
+	require.NoError(t, store.AddPending(ctx, stale))
+
+	active := testPendingEntry("pr-active", "tenant-1")
+	active.ExpiresAt = future
+	require.NoError(t, store.AddPending(ctx, active))
+
+	count, err := store.ExpireStale(ctx, time.Now().UTC())
+	require.NoError(t, err)
+	assert.Equal(t, 1, count)
+
+	got, err := store.GetPendingByID(ctx, "pr-stale")
+	require.NoError(t, err)
+	assert.Equal(t, business.PendingRegistrationStatusExpired, got.Status)
+
+	activeGot, err := store.GetPendingByID(ctx, "pr-active")
+	require.NoError(t, err)
+	assert.Equal(t, business.PendingRegistrationStatusPending, activeGot.Status)
+}
+
+func TestPendingRegistrationStore_ExpireStale_SkipsNonPending(t *testing.T) {
+	store := newTestPendingRegistrationStore(t)
+	ctx := context.Background()
+
+	past := time.Now().UTC().Add(-1 * time.Hour)
+
+	approved := testPendingEntry("pr-appr", "tenant-1")
+	approved.ExpiresAt = past
+	require.NoError(t, store.AddPending(ctx, approved))
+	require.NoError(t, store.UpdateStatus(ctx, "pr-appr", business.PendingRegistrationStatusApproved))
+
+	count, err := store.ExpireStale(ctx, time.Now().UTC())
+	require.NoError(t, err)
+	assert.Equal(t, 0, count, "approved entries must not be expired")
+
+	got, err := store.GetPendingByID(ctx, "pr-appr")
+	require.NoError(t, err)
+	assert.Equal(t, business.PendingRegistrationStatusApproved, got.Status)
+}
+
+// TestPendingRegistrationStore_PersistAcrossInit verifies durability: an entry
+// added to one store instance is retrievable after the store is closed and
+// re-opened using the same on-disk file (Issue #1696 AC).
+func TestPendingRegistrationStore_PersistAcrossInit(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := dir + "/test.db"
+
+	// Open first store instance, add an entry, then close.
+	db1, err := openAndInit(dbPath)
+	require.NoError(t, err)
+	store1 := &SQLitePendingRegistrationStore{db: db1}
+
+	ctx := context.Background()
+	entry := testPendingEntry("pr-persist", "tenant-durable")
+	require.NoError(t, store1.AddPending(ctx, entry))
+	require.NoError(t, store1.UpdateStatus(ctx, "pr-persist", business.PendingRegistrationStatusApproved))
+	require.NoError(t, store1.Close())
+
+	// Open a fresh store instance pointing to the same file.
+	db2, err := openAndInit(dbPath)
+	require.NoError(t, err)
+	store2 := &SQLitePendingRegistrationStore{db: db2}
+	t.Cleanup(func() { _ = store2.Close() })
+
+	got, err := store2.GetPendingByID(ctx, "pr-persist")
+	require.NoError(t, err)
+	assert.Equal(t, "pr-persist", got.PendingID)
+	assert.Equal(t, "tenant-durable", got.TenantID)
+	assert.Equal(t, business.PendingRegistrationStatusApproved, got.Status)
 }

--- a/pkg/storage/providers/sqlite/schema.go
+++ b/pkg/storage/providers/sqlite/schema.go
@@ -373,6 +373,25 @@ func initializeSchema(ctx context.Context, db *sql.DB) error {
 		`CREATE INDEX IF NOT EXISTS idx_pending_registrations_status     ON pending_registrations(status)`,
 		`CREATE INDEX IF NOT EXISTS idx_pending_registrations_expires_at ON pending_registrations(expires_at)`,
 
+		// Generate-on-claim pending registrations (Issue #1696)
+		// Replaces the in-memory sync.Map registrationQueue with a durable store.
+		// No cert bundle is ever stored here — cert generation happens in memory on first approved poll.
+		`CREATE TABLE IF NOT EXISTS cfgms_pending_registrations (
+			pending_id    TEXT PRIMARY KEY,
+			steward_id    TEXT NOT NULL DEFAULT '',
+			tenant_id     TEXT NOT NULL,
+			token_str     TEXT NOT NULL,
+			source_ip     TEXT NOT NULL DEFAULT '',
+			registered_at TEXT NOT NULL,
+			expires_at    TEXT NOT NULL,
+			claimed_at    TEXT,
+			status        TEXT NOT NULL DEFAULT 'pending'
+		)`,
+		`CREATE INDEX IF NOT EXISTS idx_cfgms_pending_registrations_tenant_id    ON cfgms_pending_registrations(tenant_id)`,
+		`CREATE INDEX IF NOT EXISTS idx_cfgms_pending_registrations_status       ON cfgms_pending_registrations(status)`,
+		`CREATE INDEX IF NOT EXISTS idx_cfgms_pending_registrations_expires_at   ON cfgms_pending_registrations(expires_at)`,
+		`CREATE INDEX IF NOT EXISTS idx_cfgms_pending_registrations_token_str    ON cfgms_pending_registrations(token_str)`,
+
 		// Durable sessions (Persistent=true only)
 		`CREATE TABLE IF NOT EXISTS sessions (
 			session_id       TEXT PRIMARY KEY,


### PR DESCRIPTION
## Summary

- Replaces the ephemeral `sync.Map` registration queue with a durable `PendingRegistrationStore` (SQLite for OSS, PostgreSQL for commercial) so pending registrations survive controller restarts
- Adds `GET /api/v1/registration/status/{pending_id}` endpoint with Bearer token auth, generate-on-claim cert delivery, and concurrent-poll safety via `AND status='approved'` SQL guard
- Adds `PollStatus` client method to steward HTTP registration client with configurable base interval + jitter

## Changes

### Storage
- `pkg/storage/interfaces/business/pending_registration_store.go` — new `PendingRegistrationStore` interface with `AddPending`, `GetPendingByID`, `GetPendingByToken`, `UpdateStatus`, `ListPending`, `ExpireStale`; status constants; `ErrPendingRegistrationNotFound` sentinel
- `pkg/storage/providers/sqlite/pending_registration_store.go` — SQLite implementation; concurrent-claim guard: `WHERE pending_id = ? AND status = 'approved'`
- `pkg/storage/providers/sqlite/schema.go` — `cfgms_pending_registrations` table + 4 indices
- `pkg/storage/providers/database/pending_registration_store.go` — PostgreSQL implementation with `$N` placeholders and `pg_advisory_lock` schema migration
- `pkg/storage/providers/database/schemas.go` — `CreatePendingRegistrationsTable`

### Controller API
- `features/controller/api/handlers_registration.go` — status endpoint with Bearer auth, tenant isolation (403), state machine (pending→approved→claimed/denied/expired), generate-on-claim cert delivery
- `features/controller/api/server.go` — replaces `registrationQueue sync.Map` with `pendingStore`; adds `SetPendingStore` setter; registers status route on root router
- `features/controller/api/registration_hook.go` — `ManualReviewApprovalHook.Evaluate` no longer stores to pending store; `expireTimedOut` uses `ExpireStale(ctx, cutoff)`
- `features/controller/server/server.go` — wires `pendingStore` from storage manager to HTTP API server

### Steward Client
- `features/steward/registration/client_http.go` — adds `PollStatus` method, `RegistrationStatusResponse` struct, `computePollInterval` with `math/rand/v2` jitter

### CLI
- `cmd/cfg/cmd/api_client.go` — adds `PendingID` field to `APIPendingRegistration`; approve/deny now accept `pending-id`
- `cmd/cfg/cmd/registration.go` — updated `Use`, help text, output columns (`PENDING ID`, `STEWARD ID`)

### Docs
- `docs/architecture/steward-operating-model.md` — Phase 2 poll loop documentation
- `docs/architecture/controller-operating-model.md` — generate-on-claim description and status endpoint table

## Test plan

- [x] `pkg/storage/interfaces/business` contract tests — lifecycle, tenant filter, expire-stale
- [x] `pkg/storage/providers/sqlite` — AddAndGet, GetByToken, UpdateStatus (approved/claimed/denied), ListPending, ExpireStale, PersistAcrossInit (durability)
- [x] `features/controller/api` — full lifecycle, tenant isolation (403), missing auth (401), concurrent-claim (410)
- [x] `features/steward/registration` — PollStatus states, computePollInterval jitter range (100 samples)
- [x] `cmd/cfg/cmd` — pending list (text + JSON + empty + error), approve/deny (happy + 404 + error)
- [x] `go build ./...` clean

Fixes #1696

🤖 Generated with [Claude Code](https://claude.ai/claude-code)