### PR TITLE
registration: add bulk-approve and ip-trust CLI commands (Issue #1698)

### DIFF
--- a/cmd/cfg/cmd/api_client.go
+++ b/cmd/cfg/cmd/api_client.go
@@ -254,6 +254,7 @@ type APIPendingRegistration struct {
 	StewardID    string    `json:"steward_id"`
 	TenantID     string    `json:"tenant_id"`
 	SourceIP     string    `json:"source_ip"`
+	RDNS         string    `json:"rdns,omitempty"` // populated by CLI at display time via net.LookupAddr
 	RegisteredAt time.Time `json:"registered_at"`
 }
 
@@ -311,6 +312,95 @@ func (c *APIClient) DenyRegistration(ctx context.Context, pendingID, reason stri
 		return c.parseError(resp)
 	}
 
+	return nil
+}
+
+// ApproveAllRegistrations approves all pending registrations and returns the count of newly approved.
+func (c *APIClient) ApproveAllRegistrations(ctx context.Context) (int, error) {
+	resp, err := c.doRequest(ctx, "POST", "/api/v1/registration/approve-all", nil)
+	if err != nil {
+		return 0, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return 0, c.parseError(resp)
+	}
+
+	var result struct {
+		Approved int `json:"approved"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return 0, fmt.Errorf("failed to decode response: %w", err)
+	}
+	return result.Approved, nil
+}
+
+// ApproveByCIDR approves pending registrations whose source IP falls within the given CIDR.
+func (c *APIClient) ApproveByCIDR(ctx context.Context, cidr string) (int, error) {
+	body, err := json.Marshal(struct {
+		CIDR string `json:"cidr"`
+	}{CIDR: cidr})
+	if err != nil {
+		return 0, fmt.Errorf("failed to marshal request: %w", err)
+	}
+
+	resp, err := c.doRequest(ctx, "POST", "/api/v1/registration/approve-by-cidr", bytes.NewReader(body))
+	if err != nil {
+		return 0, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return 0, c.parseError(resp)
+	}
+
+	var result struct {
+		Approved int `json:"approved"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return 0, fmt.Errorf("failed to decode response: %w", err)
+	}
+	return result.Approved, nil
+}
+
+// AddIPTrust adds a trusted CIDR range for a tenant (pre-seeded by default).
+func (c *APIClient) AddIPTrust(ctx context.Context, tenantID, cidr string) error {
+	body, err := json.Marshal(struct {
+		TenantID  string `json:"tenant_id"`
+		CIDR      string `json:"cidr"`
+		PreSeeded bool   `json:"pre_seeded"`
+	}{TenantID: tenantID, CIDR: cidr, PreSeeded: true})
+	if err != nil {
+		return fmt.Errorf("failed to marshal request: %w", err)
+	}
+
+	resp, err := c.doRequest(ctx, "POST", "/api/v1/registration/ip-trust", bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusNoContent && resp.StatusCode != http.StatusOK {
+		return c.parseError(resp)
+	}
+	return nil
+}
+
+// RevokeIPTrust revokes a trusted CIDR range for a tenant.
+func (c *APIClient) RevokeIPTrust(ctx context.Context, tenantID, cidr string) error {
+	// PathEscape encodes '/' as '%2F' so the CIDR survives as a single path segment;
+	// the server uses {cidr:.+} to match the decoded form.
+	path := "/api/v1/registration/ip-trust/" + url.PathEscape(tenantID) + "/" + url.PathEscape(cidr)
+	resp, err := c.doRequest(ctx, "DELETE", path, nil)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusNoContent && resp.StatusCode != http.StatusOK {
+		return c.parseError(resp)
+	}
 	return nil
 }
 

--- a/cmd/cfg/cmd/api_client_test.go
+++ b/cmd/cfg/cmd/api_client_test.go
@@ -695,3 +695,191 @@ func TestAPIClientGet(t *testing.T) {
 		assert.Error(t, err)
 	})
 }
+
+func TestAPIClientApproveAllRegistrations(t *testing.T) {
+	t.Run("returns count of approved registrations", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "POST", r.Method)
+			assert.Equal(t, "/api/v1/registration/approve-all", r.URL.Path)
+
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"approved":3}`))
+		}))
+		defer server.Close()
+
+		cfg := &APIClientConfig{BaseURL: server.URL, TLSInsecure: true}
+		client, err := NewAPIClient(cfg)
+		require.NoError(t, err)
+
+		count, err := client.ApproveAllRegistrations(context.Background())
+		require.NoError(t, err)
+		assert.Equal(t, 3, count)
+	})
+
+	t.Run("returns 0 on second call (idempotent)", func(t *testing.T) {
+		callCount := 0
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			callCount++
+			w.Header().Set("Content-Type", "application/json")
+			if callCount == 1 {
+				_, _ = w.Write([]byte(`{"approved":2}`))
+			} else {
+				_, _ = w.Write([]byte(`{"approved":0}`))
+			}
+		}))
+		defer server.Close()
+
+		cfg := &APIClientConfig{BaseURL: server.URL, TLSInsecure: true}
+		client, err := NewAPIClient(cfg)
+		require.NoError(t, err)
+
+		count1, err := client.ApproveAllRegistrations(context.Background())
+		require.NoError(t, err)
+		assert.Equal(t, 2, count1)
+
+		count2, err := client.ApproveAllRegistrations(context.Background())
+		require.NoError(t, err)
+		assert.Equal(t, 0, count2)
+	})
+
+	t.Run("API error is returned", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = w.Write([]byte(`{"error":"store unavailable"}`))
+		}))
+		defer server.Close()
+
+		cfg := &APIClientConfig{BaseURL: server.URL, TLSInsecure: true}
+		client, err := NewAPIClient(cfg)
+		require.NoError(t, err)
+
+		_, err = client.ApproveAllRegistrations(context.Background())
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "store unavailable")
+	})
+}
+
+func TestAPIClientApproveByCIDR(t *testing.T) {
+	t.Run("sends CIDR in request body and returns count", func(t *testing.T) {
+		var capturedBody string
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "POST", r.Method)
+			assert.Equal(t, "/api/v1/registration/approve-by-cidr", r.URL.Path)
+
+			buf := make([]byte, 256)
+			n, _ := r.Body.Read(buf)
+			capturedBody = string(buf[:n])
+
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"approved":2}`))
+		}))
+		defer server.Close()
+
+		cfg := &APIClientConfig{BaseURL: server.URL, TLSInsecure: true}
+		client, err := NewAPIClient(cfg)
+		require.NoError(t, err)
+
+		count, err := client.ApproveByCIDR(context.Background(), "192.168.1.0/24")
+		require.NoError(t, err)
+		assert.Equal(t, 2, count)
+		assert.Contains(t, capturedBody, "192.168.1.0/24")
+	})
+
+	t.Run("API error is returned", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = w.Write([]byte(`{"error":"invalid CIDR"}`))
+		}))
+		defer server.Close()
+
+		cfg := &APIClientConfig{BaseURL: server.URL, TLSInsecure: true}
+		client, err := NewAPIClient(cfg)
+		require.NoError(t, err)
+
+		_, err = client.ApproveByCIDR(context.Background(), "not-a-cidr")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid CIDR")
+	})
+}
+
+func TestAPIClientAddIPTrust(t *testing.T) {
+	t.Run("sends tenant_id, cidr and pre_seeded=true", func(t *testing.T) {
+		var capturedBody string
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "POST", r.Method)
+			assert.Equal(t, "/api/v1/registration/ip-trust", r.URL.Path)
+
+			buf := make([]byte, 256)
+			n, _ := r.Body.Read(buf)
+			capturedBody = string(buf[:n])
+
+			w.WriteHeader(http.StatusNoContent)
+		}))
+		defer server.Close()
+
+		cfg := &APIClientConfig{BaseURL: server.URL, TLSInsecure: true}
+		client, err := NewAPIClient(cfg)
+		require.NoError(t, err)
+
+		err = client.AddIPTrust(context.Background(), "acme", "10.0.0.0/8")
+		require.NoError(t, err)
+		assert.Contains(t, capturedBody, "acme")
+		assert.Contains(t, capturedBody, "10.0.0.0/8")
+		assert.Contains(t, capturedBody, `"pre_seeded":true`)
+	})
+
+	t.Run("API error is returned", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			_, _ = w.Write([]byte(`{"error":"ip-trust store unavailable"}`))
+		}))
+		defer server.Close()
+
+		cfg := &APIClientConfig{BaseURL: server.URL, TLSInsecure: true}
+		client, err := NewAPIClient(cfg)
+		require.NoError(t, err)
+
+		err = client.AddIPTrust(context.Background(), "acme", "10.0.0.0/8")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "ip-trust store unavailable")
+	})
+}
+
+func TestAPIClientRevokeIPTrust(t *testing.T) {
+	t.Run("sends DELETE to correct path with encoded CIDR", func(t *testing.T) {
+		var capturedMethod, capturedRawPath string
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			capturedMethod = r.Method
+			capturedRawPath = r.URL.RawPath
+			w.WriteHeader(http.StatusNoContent)
+		}))
+		defer server.Close()
+
+		cfg := &APIClientConfig{BaseURL: server.URL, TLSInsecure: true}
+		client, err := NewAPIClient(cfg)
+		require.NoError(t, err)
+
+		err = client.RevokeIPTrust(context.Background(), "acme", "10.0.0.0/8")
+		require.NoError(t, err)
+		assert.Equal(t, "DELETE", capturedMethod)
+		// The CIDR slash should be percent-encoded to preserve it as a single path segment.
+		assert.Contains(t, capturedRawPath, "10.0.0.0%2F8")
+		assert.Contains(t, capturedRawPath, "acme")
+	})
+
+	t.Run("not found returns error", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = w.Write([]byte(`{"error":"ip trust entry not found"}`))
+		}))
+		defer server.Close()
+
+		cfg := &APIClientConfig{BaseURL: server.URL, TLSInsecure: true}
+		client, err := NewAPIClient(cfg)
+		require.NoError(t, err)
+
+		err = client.RevokeIPTrust(context.Background(), "acme", "10.0.0.0/8")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "ip trust entry not found")
+	})
+}

--- a/cmd/cfg/cmd/registration.go
+++ b/cmd/cfg/cmd/registration.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net"
 	"os"
 	"strings"
 	"text/tabwriter"
@@ -16,12 +17,14 @@ import (
 )
 
 var (
-	registrationAPIURL      string
-	registrationAPIKey      string
-	registrationTLSCACert   string
-	registrationTLSInsecure bool
-	registrationJSONOutput  bool
-	registrationDenyReason  string
+	registrationAPIURL           string
+	registrationAPIKey           string
+	registrationTLSCACert        string
+	registrationTLSInsecure      bool
+	registrationJSONOutput       bool
+	registrationDenyReason       string
+	registrationIPTrustTenantID  string
+	registrationIPTrustPreSeeded bool
 )
 
 // registrationCmd is the parent command for registration management.
@@ -98,6 +101,68 @@ Examples:
 	RunE: runRegistrationDeny,
 }
 
+// registrationApproveAllCmd approves all pending steward registrations in one operation.
+var registrationApproveAllCmd = &cobra.Command{
+	Use:   "approve-all",
+	Short: "Approve all pending steward registrations",
+	Long: `Approve all quarantined steward registrations in one operation.
+
+Returns the count of newly approved registrations. Already-approved stewards
+are not counted (idempotent).
+
+Examples:
+  cfg registration approve-all`,
+	RunE: runRegistrationApproveAll,
+}
+
+// registrationApproveByCIDRCmd approves pending registrations by source IP CIDR.
+var registrationApproveByCIDRCmd = &cobra.Command{
+	Use:   "approve-by-cidr <cidr>",
+	Short: "Approve pending steward registrations whose source IP falls in the CIDR",
+	Long: `Approve pending registrations for stewards whose source IP falls within the
+given CIDR. Registrations outside the CIDR remain pending.
+
+Returns the count of newly approved registrations.
+
+Examples:
+  cfg registration approve-by-cidr 192.168.1.0/24`,
+	Args: cobra.ExactArgs(1),
+	RunE: runRegistrationApproveByCIDR,
+}
+
+// registrationIPTrustCmd is the parent for ip-trust subcommands.
+var registrationIPTrustCmd = &cobra.Command{
+	Use:   "ip-trust",
+	Short: "Manage IP trust ranges for automatic registration approval",
+	Long:  `Add or revoke trusted IP CIDR ranges for tenant-scoped automatic registration approval.`,
+}
+
+// registrationIPTrustAddCmd adds a trusted CIDR for a tenant.
+var registrationIPTrustAddCmd = &cobra.Command{
+	Use:   "add <cidr>",
+	Short: "Add a trusted IP CIDR for a tenant",
+	Long: `Add a trusted CIDR range for the given tenant. Stewards registering from IPs
+in this range are automatically approved.
+
+Examples:
+  cfg registration ip-trust add 10.0.0.0/8 --tenant-id acme`,
+	Args: cobra.ExactArgs(1),
+	RunE: runRegistrationIPTrustAdd,
+}
+
+// registrationIPTrustRevokeCmd revokes a trusted CIDR for a tenant.
+var registrationIPTrustRevokeCmd = &cobra.Command{
+	Use:   "revoke <cidr>",
+	Short: "Revoke a trusted IP CIDR for a tenant",
+	Long: `Revoke a trusted CIDR range for the given tenant. Subsequent registrations
+from IPs in this range will be quarantined for manual review.
+
+Examples:
+  cfg registration ip-trust revoke 10.0.0.0/8 --tenant-id acme`,
+	Args: cobra.ExactArgs(1),
+	RunE: runRegistrationIPTrustRevoke,
+}
+
 func init() {
 	registrationCmd.PersistentFlags().StringVar(&registrationAPIURL, "api-url", "", "Controller REST API URL (env: CFGMS_API_URL)")
 	registrationCmd.PersistentFlags().StringVar(&registrationAPIKey, "api-key", "", "API key for authentication (env: CFGMS_API_KEY)")
@@ -108,9 +173,22 @@ func init() {
 
 	registrationDenyCmd.Flags().StringVar(&registrationDenyReason, "reason", "", "Reason for denying the registration (optional)")
 
+	registrationIPTrustAddCmd.Flags().BoolVar(&registrationIPTrustPreSeeded, "pre-seeded", true, "Mark this CIDR as pre-seeded (operator intent: auto-approve)")
+	registrationIPTrustAddCmd.Flags().StringVar(&registrationIPTrustTenantID, "tenant-id", "", "Tenant ID to configure (required)")
+	_ = registrationIPTrustAddCmd.MarkFlagRequired("tenant-id")
+
+	registrationIPTrustRevokeCmd.Flags().StringVar(&registrationIPTrustTenantID, "tenant-id", "", "Tenant ID to configure (required)")
+	_ = registrationIPTrustRevokeCmd.MarkFlagRequired("tenant-id")
+
+	registrationIPTrustCmd.AddCommand(registrationIPTrustAddCmd)
+	registrationIPTrustCmd.AddCommand(registrationIPTrustRevokeCmd)
+
 	registrationCmd.AddCommand(registrationPendingCmd)
 	registrationCmd.AddCommand(registrationApproveCmd)
 	registrationCmd.AddCommand(registrationDenyCmd)
+	registrationCmd.AddCommand(registrationApproveAllCmd)
+	registrationCmd.AddCommand(registrationApproveByCIDRCmd)
+	registrationCmd.AddCommand(registrationIPTrustCmd)
 }
 
 // getRegistrationClient creates an API client using bundle auth (mTLS) when available,
@@ -151,6 +229,20 @@ func getRegistrationClient() (*APIClient, error) {
 	return newClientFromFlags(apiURL, apiKey, tlsCACertPath, tlsInsecure)
 }
 
+// lookupRDNS performs a best-effort reverse DNS lookup for the given IP.
+// Returns "-" on failure or timeout (2-second budget).
+func lookupRDNS(sourceIP string) string {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	var r net.Resolver
+	names, err := r.LookupAddr(ctx, sourceIP)
+	if err != nil || len(names) == 0 {
+		return "-"
+	}
+	return strings.TrimSuffix(names[0], ".")
+}
+
 func runRegistrationPending(cmd *cobra.Command, args []string) error {
 	client, err := getRegistrationClient()
 	if err != nil {
@@ -160,6 +252,11 @@ func runRegistrationPending(cmd *cobra.Command, args []string) error {
 	pending, err := client.ListPendingRegistrations(context.Background())
 	if err != nil {
 		return fmt.Errorf("failed to list pending registrations: %w", err)
+	}
+
+	// Populate RDNS at display time — best-effort, does not affect the server record.
+	for i := range pending {
+		pending[i].RDNS = lookupRDNS(pending[i].SourceIP)
 	}
 
 	if registrationJSONOutput {
@@ -173,10 +270,11 @@ func runRegistrationPending(cmd *cobra.Command, args []string) error {
 
 	fmt.Printf("Pending registrations (%d):\n\n", len(pending))
 	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
-	_, _ = fmt.Fprintf(w, "PENDING ID\tSTEWARD ID\tTENANT ID\tSOURCE IP\tREGISTERED AT\n")
+	_, _ = fmt.Fprintf(w, "PENDING ID\tSTEWARD ID\tTENANT ID\tSOURCE IP\tRDNS\tREGISTERED AT\n")
 	for _, pr := range pending {
 		registeredAt := pr.RegisteredAt.UTC().Format(time.RFC3339)
-		_, _ = fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n", pr.PendingID, pr.StewardID, pr.TenantID, pr.SourceIP, registeredAt)
+		_, _ = fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\n",
+			pr.PendingID, pr.StewardID, pr.TenantID, pr.SourceIP, pr.RDNS, registeredAt)
 	}
 	_ = w.Flush()
 
@@ -210,5 +308,66 @@ func runRegistrationDeny(cmd *cobra.Command, args []string) error {
 	}
 
 	fmt.Printf("Registration denied: %s\n", pendingID)
+	return nil
+}
+
+func runRegistrationApproveAll(cmd *cobra.Command, args []string) error {
+	client, err := getRegistrationClient()
+	if err != nil {
+		return fmt.Errorf("failed to create API client: %w", err)
+	}
+
+	count, err := client.ApproveAllRegistrations(context.Background())
+	if err != nil {
+		return fmt.Errorf("failed to approve all registrations: %w", err)
+	}
+
+	fmt.Printf("Approved %d registrations\n", count)
+	return nil
+}
+
+func runRegistrationApproveByCIDR(cmd *cobra.Command, args []string) error {
+	cidr := args[0]
+	client, err := getRegistrationClient()
+	if err != nil {
+		return fmt.Errorf("failed to create API client: %w", err)
+	}
+
+	count, err := client.ApproveByCIDR(context.Background(), cidr)
+	if err != nil {
+		return fmt.Errorf("failed to approve registrations by CIDR %s: %w", cidr, err)
+	}
+
+	fmt.Printf("Approved %d registrations\n", count)
+	return nil
+}
+
+func runRegistrationIPTrustAdd(cmd *cobra.Command, args []string) error {
+	cidr := args[0]
+	client, err := getRegistrationClient()
+	if err != nil {
+		return fmt.Errorf("failed to create API client: %w", err)
+	}
+
+	if err := client.AddIPTrust(context.Background(), registrationIPTrustTenantID, cidr); err != nil {
+		return fmt.Errorf("failed to add IP trust range %s for tenant %s: %w", cidr, registrationIPTrustTenantID, err)
+	}
+
+	fmt.Printf("IP trust range added: %s (tenant: %s)\n", cidr, registrationIPTrustTenantID)
+	return nil
+}
+
+func runRegistrationIPTrustRevoke(cmd *cobra.Command, args []string) error {
+	cidr := args[0]
+	client, err := getRegistrationClient()
+	if err != nil {
+		return fmt.Errorf("failed to create API client: %w", err)
+	}
+
+	if err := client.RevokeIPTrust(context.Background(), registrationIPTrustTenantID, cidr); err != nil {
+		return fmt.Errorf("failed to revoke IP trust range %s for tenant %s: %w", cidr, registrationIPTrustTenantID, err)
+	}
+
+	fmt.Printf("IP trust range revoked: %s (tenant: %s)\n", cidr, registrationIPTrustTenantID)
 	return nil
 }

--- a/cmd/cfg/cmd/registration_test.go
+++ b/cmd/cfg/cmd/registration_test.go
@@ -39,6 +39,14 @@ func newRegistrationServer(t *testing.T) *httptest.Server {
 			w.WriteHeader(http.StatusOK)
 		case r.Method == "POST" && strings.HasSuffix(r.URL.Path, "/deny"):
 			w.WriteHeader(http.StatusOK)
+		case r.Method == "POST" && r.URL.Path == "/api/v1/registration/approve-all":
+			_, _ = w.Write([]byte(`{"approved":1}`))
+		case r.Method == "POST" && r.URL.Path == "/api/v1/registration/approve-by-cidr":
+			_, _ = w.Write([]byte(`{"approved":1}`))
+		case r.Method == "POST" && r.URL.Path == "/api/v1/registration/ip-trust":
+			w.WriteHeader(http.StatusNoContent)
+		case r.Method == "DELETE" && strings.HasPrefix(r.URL.Path, "/api/v1/registration/ip-trust/"):
+			w.WriteHeader(http.StatusNoContent)
 		default:
 			w.WriteHeader(http.StatusNotFound)
 		}
@@ -72,6 +80,7 @@ func TestRegistrationPendingCommand(t *testing.T) {
 		assert.Contains(t, output, "steward-1234567890", "STEWARD ID column must appear")
 		assert.Contains(t, output, "test-tenant")
 		assert.Contains(t, output, "10.0.0.1")
+		assert.Contains(t, output, "RDNS", "RDNS column header must appear")
 		assert.Contains(t, output, "Pending registrations")
 	})
 
@@ -336,5 +345,205 @@ func TestRegistrationDenyCommand(t *testing.T) {
 		err := runRegistrationDeny(registrationDenyCmd, []string{"steward-xyz"})
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "failed to deny registration")
+	})
+}
+
+func TestRegistrationApproveAllCommand(t *testing.T) {
+	t.Run("approve-all prints count", func(t *testing.T) {
+		server := newRegistrationServer(t)
+		defer server.Close()
+
+		origAPIURL := registrationAPIURL
+		origTLSInsecure := registrationTLSInsecure
+		t.Cleanup(func() {
+			registrationAPIURL = origAPIURL
+			registrationTLSInsecure = origTLSInsecure
+		})
+
+		registrationAPIURL = server.URL
+		registrationTLSInsecure = true
+
+		output := captureStdout(t, func() {
+			err := runRegistrationApproveAll(registrationApproveAllCmd, nil)
+			require.NoError(t, err)
+		})
+
+		assert.Contains(t, output, "Approved 1 registrations")
+	})
+
+	t.Run("API error is returned", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = w.Write([]byte(`{"error":"store unavailable"}`))
+		}))
+		defer server.Close()
+
+		origAPIURL := registrationAPIURL
+		origTLSInsecure := registrationTLSInsecure
+		t.Cleanup(func() {
+			registrationAPIURL = origAPIURL
+			registrationTLSInsecure = origTLSInsecure
+		})
+
+		registrationAPIURL = server.URL
+		registrationTLSInsecure = true
+
+		err := runRegistrationApproveAll(registrationApproveAllCmd, nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to approve all registrations")
+	})
+}
+
+func TestRegistrationApproveByCIDRCommand(t *testing.T) {
+	t.Run("approve-by-cidr prints count", func(t *testing.T) {
+		server := newRegistrationServer(t)
+		defer server.Close()
+
+		origAPIURL := registrationAPIURL
+		origTLSInsecure := registrationTLSInsecure
+		t.Cleanup(func() {
+			registrationAPIURL = origAPIURL
+			registrationTLSInsecure = origTLSInsecure
+		})
+
+		registrationAPIURL = server.URL
+		registrationTLSInsecure = true
+
+		output := captureStdout(t, func() {
+			err := runRegistrationApproveByCIDR(registrationApproveByCIDRCmd, []string{"10.0.0.0/8"})
+			require.NoError(t, err)
+		})
+
+		assert.Contains(t, output, "Approved 1 registrations")
+	})
+
+	t.Run("API error is returned", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = w.Write([]byte(`{"error":"invalid CIDR"}`))
+		}))
+		defer server.Close()
+
+		origAPIURL := registrationAPIURL
+		origTLSInsecure := registrationTLSInsecure
+		t.Cleanup(func() {
+			registrationAPIURL = origAPIURL
+			registrationTLSInsecure = origTLSInsecure
+		})
+
+		registrationAPIURL = server.URL
+		registrationTLSInsecure = true
+
+		err := runRegistrationApproveByCIDR(registrationApproveByCIDRCmd, []string{"not-a-cidr"})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to approve registrations by CIDR")
+	})
+}
+
+func TestRegistrationIPTrustAddCommand(t *testing.T) {
+	t.Run("ip-trust add prints confirmation", func(t *testing.T) {
+		server := newRegistrationServer(t)
+		defer server.Close()
+
+		origAPIURL := registrationAPIURL
+		origTLSInsecure := registrationTLSInsecure
+		origTenantID := registrationIPTrustTenantID
+		t.Cleanup(func() {
+			registrationAPIURL = origAPIURL
+			registrationTLSInsecure = origTLSInsecure
+			registrationIPTrustTenantID = origTenantID
+		})
+
+		registrationAPIURL = server.URL
+		registrationTLSInsecure = true
+		registrationIPTrustTenantID = "acme"
+
+		output := captureStdout(t, func() {
+			err := runRegistrationIPTrustAdd(registrationIPTrustAddCmd, []string{"10.0.0.0/8"})
+			require.NoError(t, err)
+		})
+
+		assert.Contains(t, output, "IP trust range added")
+		assert.Contains(t, output, "10.0.0.0/8")
+		assert.Contains(t, output, "acme")
+	})
+
+	t.Run("API error is returned", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			_, _ = w.Write([]byte(`{"error":"ip-trust store unavailable"}`))
+		}))
+		defer server.Close()
+
+		origAPIURL := registrationAPIURL
+		origTLSInsecure := registrationTLSInsecure
+		origTenantID := registrationIPTrustTenantID
+		t.Cleanup(func() {
+			registrationAPIURL = origAPIURL
+			registrationTLSInsecure = origTLSInsecure
+			registrationIPTrustTenantID = origTenantID
+		})
+
+		registrationAPIURL = server.URL
+		registrationTLSInsecure = true
+		registrationIPTrustTenantID = "acme"
+
+		err := runRegistrationIPTrustAdd(registrationIPTrustAddCmd, []string{"10.0.0.0/8"})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to add IP trust range")
+	})
+}
+
+func TestRegistrationIPTrustRevokeCommand(t *testing.T) {
+	t.Run("ip-trust revoke prints confirmation", func(t *testing.T) {
+		server := newRegistrationServer(t)
+		defer server.Close()
+
+		origAPIURL := registrationAPIURL
+		origTLSInsecure := registrationTLSInsecure
+		origTenantID := registrationIPTrustTenantID
+		t.Cleanup(func() {
+			registrationAPIURL = origAPIURL
+			registrationTLSInsecure = origTLSInsecure
+			registrationIPTrustTenantID = origTenantID
+		})
+
+		registrationAPIURL = server.URL
+		registrationTLSInsecure = true
+		registrationIPTrustTenantID = "acme"
+
+		output := captureStdout(t, func() {
+			err := runRegistrationIPTrustRevoke(registrationIPTrustRevokeCmd, []string{"10.0.0.0/8"})
+			require.NoError(t, err)
+		})
+
+		assert.Contains(t, output, "IP trust range revoked")
+		assert.Contains(t, output, "10.0.0.0/8")
+		assert.Contains(t, output, "acme")
+	})
+
+	t.Run("not found returns error", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = w.Write([]byte(`{"error":"ip trust entry not found"}`))
+		}))
+		defer server.Close()
+
+		origAPIURL := registrationAPIURL
+		origTLSInsecure := registrationTLSInsecure
+		origTenantID := registrationIPTrustTenantID
+		t.Cleanup(func() {
+			registrationAPIURL = origAPIURL
+			registrationTLSInsecure = origTLSInsecure
+			registrationIPTrustTenantID = origTenantID
+		})
+
+		registrationAPIURL = server.URL
+		registrationTLSInsecure = true
+		registrationIPTrustTenantID = "acme"
+
+		err := runRegistrationIPTrustRevoke(registrationIPTrustRevokeCmd, []string{"10.0.0.0/8"})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to revoke IP trust range")
 	})
 }

--- a/docs/architecture/controller-operating-model.md
+++ b/docs/architecture/controller-operating-model.md
@@ -511,10 +511,10 @@ If `registration.workflow` is omitted, the controller defaults to `ip-trust`. Th
 
 **Managing pending registrations with `cfg registration`:**
 
-When using `manual-review`, quarantined stewards accumulate in the controller's in-memory pending queue until approved or denied. Use the `cfg registration` CLI commands to manage them:
+When using `manual-review`, quarantined stewards accumulate in the controller's durable pending queue until approved or denied. Use the `cfg registration` CLI commands to manage them:
 
 ```bash
-# List all quarantined stewards awaiting approval
+# List all quarantined stewards awaiting approval (shows SOURCE_IP and RDNS columns)
 cfg registration pending
 
 # Approve a steward (promotes from quarantined → registered)
@@ -522,17 +522,37 @@ cfg registration approve <steward-id>
 
 # Deny a steward (removes from queue; steward must re-register to retry)
 cfg registration deny <steward-id> --reason "Unauthorized deployment"
+
+# Approve all pending registrations in one call
+cfg registration approve-all
+
+# Approve only pending entries whose source IP is in a given CIDR range
+cfg registration approve-by-cidr 10.0.0.0/8
+
+# Add a pre-seeded trusted CIDR range for a tenant (ip-trust workflow)
+cfg registration ip-trust add 10.0.0.0/8 --tenant-id acme-corp
+
+# Revoke a trusted CIDR range for a tenant
+cfg registration ip-trust revoke 10.0.0.0/8 --tenant-id acme-corp
 ```
 
 | Command | HTTP call | Effect |
 |---|---|---|
-| `cfg registration pending` | `GET /api/v1/registration/pending` | Lists all quarantined stewards |
+| `cfg registration pending` | `GET /api/v1/registration/pending` | Lists all quarantined stewards with SOURCE_IP and RDNS |
 | `cfg registration approve <id>` | `POST /api/v1/registration/{id}/approve` | Promotes steward status to `registered` |
 | `cfg registration deny <id>` | `POST /api/v1/registration/{id}/deny` | Removes steward from pending queue |
+| `cfg registration approve-all` | `POST /api/v1/registration/approve-all` | Approves all pending registrations; prints count approved |
+| `cfg registration approve-by-cidr <cidr>` | `POST /api/v1/registration/approve-by-cidr` | Approves pending entries whose source IP falls in the CIDR |
+| `cfg registration ip-trust add <cidr>` | `POST /api/v1/registration/ip-trust` | Adds a pre-seeded trusted CIDR for `--tenant-id` |
+| `cfg registration ip-trust revoke <cidr>` | `DELETE /api/v1/registration/ip-trust/{tenant_id}/{cidr}` | Revokes a trusted CIDR for `--tenant-id` |
 
-Required API key permissions: `registration:list-pending`, `registration:approve`, `registration:deny`.
+Required API key permissions: `registration:list-pending`, `registration:approve`, `registration:deny` for individual and bulk approval operations; `registration:manage-ip-trust` for ip-trust subcommands.
 
-The pending queue is in-memory only — it does not survive controller restarts. Quarantined stewards must re-register after a controller restart to reappear in the queue.
+The `pending` output includes a `SOURCE_IP` column showing the steward's source IP at registration time, and an `RDNS` column populated by a best-effort reverse DNS lookup at display time (shows `-` on failure or timeout).
+
+The `approve-by-cidr` command performs IP containment filtering on the controller using `net.ParseCIDR` + `ipNet.Contains` — the CIDR is not delegated to the database. All approved entries are updated atomically per-entry; partial approval (some entries approved, others skipped) is the expected outcome.
+
+The pending queue is backed by the durable `PendingRegistrationStore` (SQLite in OSS, PostgreSQL in commercial) and survives controller restarts.
 
 ### RBAC
 

--- a/features/controller/api/handlers_ip_trust.go
+++ b/features/controller/api/handlers_ip_trust.go
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/gorilla/mux"
+
+	"github.com/cfgis/cfgms/pkg/logging"
+	business "github.com/cfgis/cfgms/pkg/storage/interfaces/business"
+)
+
+// addIPTrustRequest is the request body for POST /api/v1/registration/ip-trust.
+type addIPTrustRequest struct {
+	TenantID  string `json:"tenant_id"`
+	CIDR      string `json:"cidr"`
+	PreSeeded bool   `json:"pre_seeded"`
+}
+
+// handleAddIPTrust handles POST /api/v1/registration/ip-trust.
+// Adds a trusted CIDR range for a tenant; pre_seeded marks the range as operator-seeded.
+func (s *Server) handleAddIPTrust(w http.ResponseWriter, r *http.Request) {
+	if s.ipTrustStore == nil {
+		http.Error(w, "ip-trust store unavailable", http.StatusServiceUnavailable)
+		return
+	}
+
+	var req addIPTrustRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "invalid request body", http.StatusBadRequest)
+		return
+	}
+	if req.TenantID == "" || req.CIDR == "" {
+		http.Error(w, "tenant_id and cidr are required", http.StatusBadRequest)
+		return
+	}
+
+	if err := s.ipTrustStore.AddTrustedRange(r.Context(), req.TenantID, req.CIDR, req.PreSeeded); err != nil {
+		s.logger.Error("Failed to add IP trust range",
+			"tenant_id", logging.SanitizeLogValue(req.TenantID),
+			"cidr", logging.SanitizeLogValue(req.CIDR),
+			"error", err)
+		http.Error(w, "Failed to add IP trust range", http.StatusInternalServerError)
+		return
+	}
+
+	s.logger.Info("IP trust range added",
+		"tenant_id", logging.SanitizeLogValue(req.TenantID),
+		"cidr", logging.SanitizeLogValue(req.CIDR),
+		"pre_seeded", req.PreSeeded)
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// handleRevokeIPTrust handles DELETE /api/v1/registration/ip-trust/{tenant_id}/{cidr:.+}.
+// Revokes a trusted CIDR range for a tenant. The {cidr:.+} pattern allows the CIDR slash
+// to appear in the URL path (gorilla/mux decodes %2F before extraction).
+func (s *Server) handleRevokeIPTrust(w http.ResponseWriter, r *http.Request) {
+	if s.ipTrustStore == nil {
+		http.Error(w, "ip-trust store unavailable", http.StatusServiceUnavailable)
+		return
+	}
+
+	vars := mux.Vars(r)
+	tenantID := vars["tenant_id"]
+	cidr := vars["cidr"]
+
+	if tenantID == "" || cidr == "" {
+		http.Error(w, "tenant_id and cidr are required", http.StatusBadRequest)
+		return
+	}
+
+	if err := s.ipTrustStore.RevokeTrustedRange(r.Context(), tenantID, cidr); err != nil {
+		if err == business.ErrIPTrustEntryNotFound {
+			http.Error(w, "ip trust entry not found", http.StatusNotFound)
+			return
+		}
+		s.logger.Error("Failed to revoke IP trust range",
+			"tenant_id", logging.SanitizeLogValue(tenantID),
+			"cidr", logging.SanitizeLogValue(cidr),
+			"error", err)
+		http.Error(w, "Failed to revoke IP trust range", http.StatusInternalServerError)
+		return
+	}
+
+	s.logger.Info("IP trust range revoked",
+		"tenant_id", logging.SanitizeLogValue(tenantID),
+		"cidr", logging.SanitizeLogValue(cidr))
+	w.WriteHeader(http.StatusNoContent)
+}

--- a/features/controller/api/handlers_ip_trust_test.go
+++ b/features/controller/api/handlers_ip_trust_test.go
@@ -1,0 +1,351 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Jordan Ritz
+package api
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	business "github.com/cfgis/cfgms/pkg/storage/interfaces/business"
+)
+
+// inMemIPTrustStore is a minimal in-memory IPTrustStore for handler tests.
+// The SQLite backend used by SetupTestStorage does not support IPTrustStore,
+// so we provide a simple in-memory implementation here.
+type inMemIPTrustStore struct {
+	mu      sync.Mutex
+	entries []*business.IPTrustEntry
+}
+
+func newInMemIPTrustStore() business.IPTrustStore {
+	return &inMemIPTrustStore{}
+}
+
+func (s *inMemIPTrustStore) AddTrustedRange(_ context.Context, tenantID, cidr string, preSeeded bool) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	// Re-activate revoked entries.
+	for _, e := range s.entries {
+		if e.TenantID == tenantID && e.CIDR == cidr {
+			e.Revoked = false
+			e.RevokedAt = nil
+			e.PreSeeded = preSeeded
+			return nil
+		}
+	}
+	s.entries = append(s.entries, &business.IPTrustEntry{
+		ID:           cidr + "@" + tenantID,
+		TenantID:     tenantID,
+		CIDR:         cidr,
+		PreSeeded:    preSeeded,
+		TrustedSince: time.Now().UTC(),
+	})
+	return nil
+}
+
+func (s *inMemIPTrustStore) IsTrusted(_ context.Context, tenantID, ip string) (bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, e := range s.entries {
+		if e.TenantID != tenantID || e.Revoked {
+			continue
+		}
+		// Simple prefix check: accept exact CIDR match containing the IP.
+		_ = ip // containment check omitted for test simplicity — not needed here
+	}
+	return false, nil
+}
+
+func (s *inMemIPTrustStore) ListTrustedRanges(_ context.Context, tenantID string) ([]*business.IPTrustEntry, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	var out []*business.IPTrustEntry
+	for _, e := range s.entries {
+		if e.TenantID == tenantID {
+			cp := *e
+			out = append(out, &cp)
+		}
+	}
+	return out, nil
+}
+
+func (s *inMemIPTrustStore) RevokeTrustedRange(_ context.Context, tenantID, cidr string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, e := range s.entries {
+		if e.TenantID == tenantID && e.CIDR == cidr && !e.Revoked {
+			now := time.Now().UTC()
+			e.Revoked = true
+			e.RevokedAt = &now
+			return nil
+		}
+	}
+	return business.ErrIPTrustEntryNotFound
+}
+
+func (s *inMemIPTrustStore) RecordHealthySteward(_ context.Context, _, _ string, _ time.Time) error {
+	return nil
+}
+
+func (s *inMemIPTrustStore) GetLastActivity(_ context.Context, _, _ string) (*business.IPTrustActivity, error) {
+	return nil, nil
+}
+
+// Compile-time assertion: inMemIPTrustStore satisfies the interface.
+var _ business.IPTrustStore = (*inMemIPTrustStore)(nil)
+
+// newIPTrustServer creates a minimal test server with ip-trust management permissions.
+func newIPTrustServer(t *testing.T) (*Server, *httptest.Server, business.IPTrustStore) {
+	t.Helper()
+	tokenStore := newTestRegistrationStore(t)
+	server, _ := newHandleRegisterServer(t, tokenStore, nil)
+
+	ipStore := newInMemIPTrustStore()
+	server.SetIPTrustStore(ipStore)
+
+	server.apiKeys["ip-trust-key"] = &APIKey{
+		ID:          "ip-trust-key-id",
+		Key:         "ip-trust-key",
+		Permissions: []string{"registration:manage-ip-trust"},
+		TenantID:    "default",
+	}
+
+	ts := httptest.NewServer(server.router)
+	return server, ts, ipStore
+}
+
+func TestHandleAddIPTrust(t *testing.T) {
+	_, ts, ipStore := newIPTrustServer(t)
+	defer ts.Close()
+
+	makeAdd := func(t *testing.T, body string) *http.Response {
+		t.Helper()
+		req, err := http.NewRequestWithContext(context.Background(), "POST",
+			ts.URL+"/api/v1/registration/ip-trust",
+			bytes.NewReader([]byte(body)))
+		require.NoError(t, err)
+		req.Header.Set("Authorization", "Bearer ip-trust-key")
+		req.Header.Set("Content-Type", "application/json")
+		resp, err := ts.Client().Do(req)
+		require.NoError(t, err)
+		return resp
+	}
+
+	t.Run("happy path - adds trusted range", func(t *testing.T) {
+		resp := makeAdd(t, `{"tenant_id":"acme","cidr":"10.0.0.0/8","pre_seeded":true}`)
+		defer func() { _ = resp.Body.Close() }()
+
+		assert.Equal(t, http.StatusNoContent, resp.StatusCode)
+
+		// Verify the range was actually stored.
+		entries, err := ipStore.ListTrustedRanges(context.Background(), "acme")
+		require.NoError(t, err)
+		require.Len(t, entries, 1)
+		assert.Equal(t, "10.0.0.0/8", entries[0].CIDR)
+		assert.True(t, entries[0].PreSeeded)
+	})
+
+	t.Run("missing tenant_id returns 400", func(t *testing.T) {
+		resp := makeAdd(t, `{"cidr":"10.0.0.0/8"}`)
+		defer func() { _ = resp.Body.Close() }()
+
+		assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	})
+
+	t.Run("missing cidr returns 400", func(t *testing.T) {
+		resp := makeAdd(t, `{"tenant_id":"acme"}`)
+		defer func() { _ = resp.Body.Close() }()
+
+		assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	})
+
+	t.Run("invalid JSON returns 400", func(t *testing.T) {
+		resp := makeAdd(t, `{not-json}`)
+		defer func() { _ = resp.Body.Close() }()
+
+		assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	})
+}
+
+func TestHandleAddIPTrust_NoStore(t *testing.T) {
+	tokenStore := newTestRegistrationStore(t)
+	server, _ := newHandleRegisterServer(t, tokenStore, nil)
+	// Do NOT set ipTrustStore.
+	server.apiKeys["ip-trust-key"] = &APIKey{
+		ID:          "ip-trust-key-id",
+		Key:         "ip-trust-key",
+		Permissions: []string{"registration:manage-ip-trust"},
+		TenantID:    "default",
+	}
+	ts := httptest.NewServer(server.router)
+	defer ts.Close()
+
+	req, err := http.NewRequestWithContext(context.Background(), "POST",
+		ts.URL+"/api/v1/registration/ip-trust",
+		bytes.NewReader([]byte(`{"tenant_id":"acme","cidr":"10.0.0.0/8"}`)))
+	require.NoError(t, err)
+	req.Header.Set("Authorization", "Bearer ip-trust-key")
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := ts.Client().Do(req)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+
+	assert.Equal(t, http.StatusServiceUnavailable, resp.StatusCode)
+}
+
+func TestHandleRevokeIPTrust(t *testing.T) {
+	_, ts, ipStore := newIPTrustServer(t)
+	defer ts.Close()
+
+	// Pre-seed an entry to revoke.
+	require.NoError(t, ipStore.AddTrustedRange(context.Background(), "acme", "10.0.0.0/8", true))
+
+	makeRevoke := func(t *testing.T, tenantID, cidr string) *http.Response {
+		t.Helper()
+		// Use literal slash in the URL path; gorilla/mux {cidr:.+} matches across path segments.
+		path := ts.URL + "/api/v1/registration/ip-trust/" + tenantID + "/" + cidr
+		req, err := http.NewRequestWithContext(context.Background(), "DELETE", path, nil)
+		require.NoError(t, err)
+		req.Header.Set("Authorization", "Bearer ip-trust-key")
+		resp, err := ts.Client().Do(req)
+		require.NoError(t, err)
+		return resp
+	}
+
+	t.Run("happy path - revokes trusted range", func(t *testing.T) {
+		// Use literal slash in URL path; gorilla/mux {cidr:.+} matches across segments.
+		resp := makeRevoke(t, "acme", "10.0.0.0/8")
+		defer func() { _ = resp.Body.Close() }()
+
+		assert.Equal(t, http.StatusNoContent, resp.StatusCode)
+
+		// Verify revocation in store.
+		entries, err := ipStore.ListTrustedRanges(context.Background(), "acme")
+		require.NoError(t, err)
+		require.Len(t, entries, 1)
+		assert.True(t, entries[0].Revoked)
+	})
+
+	t.Run("not found returns 404", func(t *testing.T) {
+		resp := makeRevoke(t, "acme", "192.168.0.0/16")
+		defer func() { _ = resp.Body.Close() }()
+
+		assert.Equal(t, http.StatusNotFound, resp.StatusCode)
+	})
+}
+
+func TestHandleRevokeIPTrust_NoStore(t *testing.T) {
+	tokenStore := newTestRegistrationStore(t)
+	server, _ := newHandleRegisterServer(t, tokenStore, nil)
+	server.apiKeys["ip-trust-key"] = &APIKey{
+		ID:          "ip-trust-key-id",
+		Key:         "ip-trust-key",
+		Permissions: []string{"registration:manage-ip-trust"},
+		TenantID:    "default",
+	}
+	ts := httptest.NewServer(server.router)
+	defer ts.Close()
+
+	req, err := http.NewRequestWithContext(context.Background(), "DELETE",
+		ts.URL+"/api/v1/registration/ip-trust/acme/10.0.0.0/8", nil)
+	require.NoError(t, err)
+	req.Header.Set("Authorization", "Bearer ip-trust-key")
+
+	resp, err := ts.Client().Do(req)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+
+	assert.Equal(t, http.StatusServiceUnavailable, resp.StatusCode)
+}
+
+// errIPTrustStore wraps inMemIPTrustStore to inject errors for error-path tests.
+type errIPTrustStore struct {
+	addErr    error
+	revokeErr error
+}
+
+func (s *errIPTrustStore) AddTrustedRange(_ context.Context, _, _ string, _ bool) error {
+	return s.addErr
+}
+
+func (s *errIPTrustStore) IsTrusted(_ context.Context, _, _ string) (bool, error) { return false, nil }
+
+func (s *errIPTrustStore) ListTrustedRanges(_ context.Context, _ string) ([]*business.IPTrustEntry, error) {
+	return nil, nil
+}
+
+func (s *errIPTrustStore) RevokeTrustedRange(_ context.Context, _, _ string) error {
+	return s.revokeErr
+}
+
+func (s *errIPTrustStore) RecordHealthySteward(_ context.Context, _, _ string, _ time.Time) error {
+	return nil
+}
+
+func (s *errIPTrustStore) GetLastActivity(_ context.Context, _, _ string) (*business.IPTrustActivity, error) {
+	return nil, nil
+}
+
+var _ business.IPTrustStore = (*errIPTrustStore)(nil)
+
+func TestHandleAddIPTrust_StoreError(t *testing.T) {
+	tokenStore := newTestRegistrationStore(t)
+	server, _ := newHandleRegisterServer(t, tokenStore, nil)
+	server.SetIPTrustStore(&errIPTrustStore{addErr: errors.New("db failure")})
+	server.apiKeys["ip-trust-key"] = &APIKey{
+		ID:          "ip-trust-key-id",
+		Key:         "ip-trust-key",
+		Permissions: []string{"registration:manage-ip-trust"},
+		TenantID:    "default",
+	}
+	ts := httptest.NewServer(server.router)
+	defer ts.Close()
+
+	req, err := http.NewRequestWithContext(context.Background(), "POST",
+		ts.URL+"/api/v1/registration/ip-trust",
+		bytes.NewReader([]byte(`{"tenant_id":"acme","cidr":"10.0.0.0/8"}`)))
+	require.NoError(t, err)
+	req.Header.Set("Authorization", "Bearer ip-trust-key")
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := ts.Client().Do(req)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+
+	assert.Equal(t, http.StatusInternalServerError, resp.StatusCode)
+}
+
+func TestHandleRevokeIPTrust_StoreError(t *testing.T) {
+	tokenStore := newTestRegistrationStore(t)
+	server, _ := newHandleRegisterServer(t, tokenStore, nil)
+	server.SetIPTrustStore(&errIPTrustStore{revokeErr: errors.New("db failure")})
+	server.apiKeys["ip-trust-key"] = &APIKey{
+		ID:          "ip-trust-key-id",
+		Key:         "ip-trust-key",
+		Permissions: []string{"registration:manage-ip-trust"},
+		TenantID:    "default",
+	}
+	ts := httptest.NewServer(server.router)
+	defer ts.Close()
+
+	req, err := http.NewRequestWithContext(context.Background(), "DELETE",
+		ts.URL+"/api/v1/registration/ip-trust/acme/10.0.0.0/8", nil)
+	require.NoError(t, err)
+	req.Header.Set("Authorization", "Bearer ip-trust-key")
+
+	resp, err := ts.Client().Do(req)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+
+	assert.Equal(t, http.StatusInternalServerError, resp.StatusCode)
+}

--- a/features/controller/api/handlers_registration.go
+++ b/features/controller/api/handlers_registration.go
@@ -348,6 +348,104 @@ func (s *Server) buildClaimResponse(ctx context.Context, entry *business.Pending
 	return resp, nil
 }
 
+// approveAllResponse is the JSON body returned by approve-all and approve-by-cidr.
+type approveAllResponse struct {
+	Approved int `json:"approved"`
+}
+
+// approveByCIDRRequest is the request body for POST /api/v1/registration/approve-by-cidr.
+type approveByCIDRRequest struct {
+	CIDR string `json:"cidr"`
+}
+
+// handleApproveAllRegistrations handles POST /api/v1/registration/approve-all.
+// Approves every entry currently in "pending" status and returns the count.
+// Idempotent: entries already approved/claimed/denied are skipped without error.
+func (s *Server) handleApproveAllRegistrations(w http.ResponseWriter, r *http.Request) {
+	if s.pendingStore == nil {
+		http.Error(w, "registration store unavailable", http.StatusServiceUnavailable)
+		return
+	}
+	entries, err := s.pendingStore.ListPending(r.Context(), "")
+	if err != nil {
+		s.logger.Error("Failed to list pending registrations for approve-all", "error", err)
+		http.Error(w, "Failed to list pending registrations", http.StatusInternalServerError)
+		return
+	}
+
+	approved := 0
+	for _, e := range entries {
+		if e.Status != business.PendingRegistrationStatusPending {
+			continue
+		}
+		if err := s.pendingStore.UpdateStatus(r.Context(), e.PendingID, business.PendingRegistrationStatusApproved); err != nil {
+			s.logger.Error("Failed to approve pending registration in bulk",
+				"pending_id", logging.SanitizeLogValue(e.PendingID), "error", err)
+			continue
+		}
+		approved++
+	}
+
+	s.logger.Info("Bulk approve-all completed", "approved", approved)
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(approveAllResponse{Approved: approved}); err != nil {
+		s.logger.Error("Failed to encode approve-all response", "error", err)
+	}
+}
+
+// handleApproveByCIDR handles POST /api/v1/registration/approve-by-cidr.
+// Filters pending entries by source IP containment in the given CIDR (evaluated in Go,
+// not delegated to storage) and approves matching entries. Returns the count approved.
+func (s *Server) handleApproveByCIDR(w http.ResponseWriter, r *http.Request) {
+	if s.pendingStore == nil {
+		http.Error(w, "registration store unavailable", http.StatusServiceUnavailable)
+		return
+	}
+
+	var req approveByCIDRRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil || req.CIDR == "" {
+		http.Error(w, "cidr is required", http.StatusBadRequest)
+		return
+	}
+
+	_, ipNet, err := net.ParseCIDR(req.CIDR)
+	if err != nil {
+		http.Error(w, "invalid CIDR", http.StatusBadRequest)
+		return
+	}
+
+	entries, err := s.pendingStore.ListPending(r.Context(), "")
+	if err != nil {
+		s.logger.Error("Failed to list pending registrations for approve-by-cidr", "error", err)
+		http.Error(w, "Failed to list pending registrations", http.StatusInternalServerError)
+		return
+	}
+
+	approved := 0
+	for _, e := range entries {
+		if e.Status != business.PendingRegistrationStatusPending {
+			continue
+		}
+		ip := net.ParseIP(e.SourceIP)
+		if ip == nil || !ipNet.Contains(ip) {
+			continue
+		}
+		if err := s.pendingStore.UpdateStatus(r.Context(), e.PendingID, business.PendingRegistrationStatusApproved); err != nil {
+			s.logger.Error("Failed to approve pending registration in CIDR bulk",
+				"pending_id", logging.SanitizeLogValue(e.PendingID), "error", err)
+			continue
+		}
+		approved++
+	}
+
+	s.logger.Info("CIDR bulk approve completed",
+		"cidr", logging.SanitizeLogValue(req.CIDR), "approved", approved)
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(approveAllResponse{Approved: approved}); err != nil {
+		s.logger.Error("Failed to encode approve-by-cidr response", "error", err)
+	}
+}
+
 // handleRegister handles steward registration via REST API
 // POST /api/v1/register
 func (s *Server) handleRegister(w http.ResponseWriter, r *http.Request) {

--- a/features/controller/api/handlers_registration_test.go
+++ b/features/controller/api/handlers_registration_test.go
@@ -9,6 +9,7 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -926,4 +927,198 @@ func TestHandleRegistrationStatus_NoAuth(t *testing.T) {
 	defer func() { _ = resp.Body.Close() }()
 
 	assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+}
+
+// newBulkApprovalServer creates a test server with approve + approve-all + approve-by-cidr permissions.
+func newBulkApprovalServer(t *testing.T) (*Server, *httptest.Server, business.PendingRegistrationStore) {
+	t.Helper()
+	tokenStore := newTestRegistrationStore(t)
+	server, _ := newHandleRegisterServer(t, tokenStore, nil)
+
+	pendingStore := pkgtesting.SetupTestStorage(t).GetPendingRegistrationStore()
+	require.NotNil(t, pendingStore, "test storage must provide a PendingRegistrationStore")
+	server.SetPendingStore(pendingStore)
+
+	server.apiKeys["bulk-key"] = &APIKey{
+		ID:          "bulk-key-id",
+		Key:         "bulk-key",
+		Permissions: []string{"registration:list-pending", "registration:approve", "registration:deny"},
+		TenantID:    "default",
+	}
+
+	ts := httptest.NewServer(server.router)
+	return server, ts, pendingStore
+}
+
+// addPendingEntry is a helper that inserts a pending entry into the store.
+func addPendingEntry(t *testing.T, store business.PendingRegistrationStore, pendingID, stewardID, tenantID, sourceIP string) {
+	t.Helper()
+	now := time.Now().UTC()
+	require.NoError(t, store.AddPending(context.Background(), &business.PendingRegistrationEntry{
+		PendingID:    pendingID,
+		StewardID:    stewardID,
+		TenantID:     tenantID,
+		TokenStr:     "tok-" + pendingID,
+		SourceIP:     sourceIP,
+		RegisteredAt: now,
+		ExpiresAt:    now.Add(5 * 24 * time.Hour),
+		Status:       business.PendingRegistrationStatusPending,
+	}))
+}
+
+// TestApproveByCIDR_FiltersCorrectly verifies that only entries whose source IP is in the
+// CIDR are approved; entries outside it remain pending (required test from AC).
+func TestApproveByCIDR_FiltersCorrectly(t *testing.T) {
+	_, ts, pendingStore := newBulkApprovalServer(t)
+	defer ts.Close()
+
+	// Two entries inside the CIDR 192.168.1.0/24, one outside.
+	addPendingEntry(t, pendingStore, "pending-cidr-in-1", "steward-in-1", "tenant-a", "192.168.1.10")
+	addPendingEntry(t, pendingStore, "pending-cidr-in-2", "steward-in-2", "tenant-a", "192.168.1.200")
+	addPendingEntry(t, pendingStore, "pending-cidr-out-1", "steward-out-1", "tenant-a", "10.0.0.5")
+
+	body := `{"cidr":"192.168.1.0/24"}`
+	req, err := http.NewRequestWithContext(context.Background(), "POST",
+		ts.URL+"/api/v1/registration/approve-by-cidr",
+		strings.NewReader(body))
+	require.NoError(t, err)
+	req.Header.Set("Authorization", "Bearer bulk-key")
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := ts.Client().Do(req)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var result struct {
+		Approved int `json:"approved"`
+	}
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&result))
+	assert.Equal(t, 2, result.Approved, "only two entries inside the CIDR should be approved")
+
+	// Verify store state: inside entries approved, outside entry still pending.
+	in1, err := pendingStore.GetPendingByID(context.Background(), "pending-cidr-in-1")
+	require.NoError(t, err)
+	assert.Equal(t, business.PendingRegistrationStatusApproved, in1.Status)
+
+	in2, err := pendingStore.GetPendingByID(context.Background(), "pending-cidr-in-2")
+	require.NoError(t, err)
+	assert.Equal(t, business.PendingRegistrationStatusApproved, in2.Status)
+
+	out1, err := pendingStore.GetPendingByID(context.Background(), "pending-cidr-out-1")
+	require.NoError(t, err)
+	assert.Equal(t, business.PendingRegistrationStatusPending, out1.Status,
+		"entry outside CIDR must remain pending")
+}
+
+// TestApproveAll_Idempotent verifies that calling approve-all twice does not error and
+// the second call returns 0 approved (required test from AC).
+func TestApproveAll_Idempotent(t *testing.T) {
+	_, ts, pendingStore := newBulkApprovalServer(t)
+	defer ts.Close()
+
+	addPendingEntry(t, pendingStore, "pending-idem-1", "steward-idem-1", "tenant-a", "10.0.0.1")
+	addPendingEntry(t, pendingStore, "pending-idem-2", "steward-idem-2", "tenant-a", "10.0.0.2")
+
+	doApproveAll := func(t *testing.T) int {
+		t.Helper()
+		req, err := http.NewRequestWithContext(context.Background(), "POST",
+			ts.URL+"/api/v1/registration/approve-all", nil)
+		require.NoError(t, err)
+		req.Header.Set("Authorization", "Bearer bulk-key")
+
+		resp, err := ts.Client().Do(req)
+		require.NoError(t, err)
+		defer func() { _ = resp.Body.Close() }()
+
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+
+		var result struct {
+			Approved int `json:"approved"`
+		}
+		require.NoError(t, json.NewDecoder(resp.Body).Decode(&result))
+		return result.Approved
+	}
+
+	// First call: both pending entries should be approved.
+	count1 := doApproveAll(t)
+	assert.Equal(t, 2, count1, "first approve-all should approve all pending entries")
+
+	// Second call: no pending entries remain, count must be 0.
+	count2 := doApproveAll(t)
+	assert.Equal(t, 0, count2, "second approve-all must return 0 (idempotent)")
+}
+
+// TestHandleApproveByCIDR_InvalidCIDR verifies that a malformed CIDR returns 400.
+func TestHandleApproveByCIDR_InvalidCIDR(t *testing.T) {
+	_, ts, _ := newBulkApprovalServer(t)
+	defer ts.Close()
+
+	req, err := http.NewRequestWithContext(context.Background(), "POST",
+		ts.URL+"/api/v1/registration/approve-by-cidr",
+		strings.NewReader(`{"cidr":"not-a-cidr"}`))
+	require.NoError(t, err)
+	req.Header.Set("Authorization", "Bearer bulk-key")
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := ts.Client().Do(req)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+}
+
+// TestHandleApproveByCIDR_NoPendingStore verifies 503 when pendingStore is nil.
+func TestHandleApproveByCIDR_NoPendingStore(t *testing.T) {
+	tokenStore := newTestRegistrationStore(t)
+	server, _ := newHandleRegisterServer(t, tokenStore, nil)
+	// Do NOT set pendingStore.
+	server.apiKeys["bulk-key"] = &APIKey{
+		ID:          "bulk-key-id",
+		Key:         "bulk-key",
+		Permissions: []string{"registration:approve"},
+		TenantID:    "default",
+	}
+	ts := httptest.NewServer(server.router)
+	defer ts.Close()
+
+	req, err := http.NewRequestWithContext(context.Background(), "POST",
+		ts.URL+"/api/v1/registration/approve-by-cidr",
+		strings.NewReader(`{"cidr":"10.0.0.0/8"}`))
+	require.NoError(t, err)
+	req.Header.Set("Authorization", "Bearer bulk-key")
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := ts.Client().Do(req)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+
+	assert.Equal(t, http.StatusServiceUnavailable, resp.StatusCode)
+}
+
+// TestHandleApproveAll_NoPendingStore verifies 503 when pendingStore is nil.
+func TestHandleApproveAll_NoPendingStore(t *testing.T) {
+	tokenStore := newTestRegistrationStore(t)
+	server, _ := newHandleRegisterServer(t, tokenStore, nil)
+	// Do NOT set pendingStore.
+	server.apiKeys["bulk-key"] = &APIKey{
+		ID:          "bulk-key-id",
+		Key:         "bulk-key",
+		Permissions: []string{"registration:approve"},
+		TenantID:    "default",
+	}
+	ts := httptest.NewServer(server.router)
+	defer ts.Close()
+
+	req, err := http.NewRequestWithContext(context.Background(), "POST",
+		ts.URL+"/api/v1/registration/approve-all", nil)
+	require.NoError(t, err)
+	req.Header.Set("Authorization", "Bearer bulk-key")
+
+	resp, err := ts.Client().Do(req)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+
+	assert.Equal(t, http.StatusServiceUnavailable, resp.StatusCode)
 }

--- a/features/controller/api/server.go
+++ b/features/controller/api/server.go
@@ -86,6 +86,7 @@ type Server struct {
 	configSourceSecretStore secretsif.SecretStore             // Issue #1396: secrets for config source validator
 	configSourceRateLimits  sync.Map                          // Issue #1396: per-tenant rate-limit counters
 	pendingStore            business.PendingRegistrationStore // Issue #1696: durable pending-registration queue
+	ipTrustStore            business.IPTrustStore             // Issue #1698: operator IP-trust management
 	runManager              *controllerrun.Manager            // Issue #1673: run/job/execution model
 	runExecutionQueue       *script.ExecutionQueue            // Issue #1673: queue for ad-hoc run synthesis
 	trustedProxies          []net.IPNet                       // Issue #1695: parsed from TrustedProxies config; XFF honored only when peer is in this list
@@ -410,6 +411,13 @@ func (s *Server) setupRouter() {
 	api.Handle("/registration/pending", s.requirePermission("registration", "list-pending")(http.HandlerFunc(s.handleListPendingRegistrations))).Methods("GET")
 	api.Handle("/registration/{id}/approve", s.requirePermission("registration", "approve")(http.HandlerFunc(s.handleApproveRegistration))).Methods("POST")
 	api.Handle("/registration/{id}/deny", s.requirePermission("registration", "deny")(http.HandlerFunc(s.handleDenyRegistration))).Methods("POST")
+
+	// Bulk registration approval and IP-trust management (Issue #1698)
+	api.Handle("/registration/approve-all", s.requirePermission("registration", "approve")(http.HandlerFunc(s.handleApproveAllRegistrations))).Methods("POST")
+	api.Handle("/registration/approve-by-cidr", s.requirePermission("registration", "approve")(http.HandlerFunc(s.handleApproveByCIDR))).Methods("POST")
+	api.Handle("/registration/ip-trust", s.requirePermission("registration", "manage-ip-trust")(http.HandlerFunc(s.handleAddIPTrust))).Methods("POST")
+	// {cidr:.+} allows the CIDR slash to appear literally in the URL path after decoding.
+	api.Handle("/registration/ip-trust/{tenant_id}/{cidr:.+}", s.requirePermission("registration", "manage-ip-trust")(http.HandlerFunc(s.handleRevokeIPTrust))).Methods("DELETE")
 
 	// Monitoring endpoints
 	monitoring := api.PathPrefix("/monitoring").Subrouter()
@@ -745,6 +753,14 @@ func (s *Server) SetPendingStore(store business.PendingRegistrationStore) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.pendingStore = store
+}
+
+// SetIPTrustStore wires the IP-trust store for operator ip-trust management (Issue #1698).
+// Call this after New() returns but before Start() is called.
+func (s *Server) SetIPTrustStore(store business.IPTrustStore) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.ipTrustStore = store
 }
 
 // getHTTPListenAddr determines the HTTP listen address.

--- a/features/controller/api/validation_middleware.go
+++ b/features/controller/api/validation_middleware.go
@@ -95,6 +95,9 @@ func (s *Server) validateURLParameters(validator *security.EnhancedValidator, re
 		case "stewardId", "steward_id":
 			// Steward IDs
 			validator.ValidateString(result, "path."+param, value, "required", "charset:alphanumeric_dash", "max_length:64")
+		case "cidr":
+			// CIDR ranges: IPv4 (10.0.0.0/8) and IPv6 (2001:db8::/32)
+			validator.ValidateString(result, "path."+param, value, "required", "charset:cidr", "max_length:64")
 		default:
 			// Generic validation for other path parameters
 			validator.ValidateString(result, "path."+param, value, "charset:safe_text", "max_length:128", "no_control_chars")

--- a/pkg/security/validation.go
+++ b/pkg/security/validation.go
@@ -86,6 +86,8 @@ func NewValidator() *Validator {
 	v.allowedCharsets["hostname"] = regexp.MustCompile(`^[a-zA-Z0-9]([a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])?(\.[a-zA-Z0-9]([a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])?)*$`)
 	v.allowedCharsets["safe_text"] = regexp.MustCompile(`^[a-zA-Z0-9\s\.\-_,;:!?\(\)\[\]]+$`)
 	v.allowedCharsets["base64"] = regexp.MustCompile(`^[A-Za-z0-9+/]*={0,2}$`)
+	// cidr: IPv4 (10.0.0.0/8) and IPv6 (2001:db8::/32) CIDR notation
+	v.allowedCharsets["cidr"] = regexp.MustCompile(`^[0-9a-fA-F.:\/]+$`)
 
 	v.dnsLookupTimeout = 5 * time.Second
 


### PR DESCRIPTION
## Summary

- Adds `cfg registration approve-all` and `approve-by-cidr <cidr>` for bulk pending-registration management
- Adds `cfg registration ip-trust add/revoke <cidr> --tenant-id <id>` for operator IP-trust management
- Updates `cfg registration pending` to show `SOURCE_IP` and `RDNS` columns (best-effort reverse DNS at display time)

## New API endpoints

| Method | Path | Permission |
|--------|------|-----------|
| POST | `/api/v1/registration/approve-all` | `registration:approve` |
| POST | `/api/v1/registration/approve-by-cidr` | `registration:approve` |
| POST | `/api/v1/registration/ip-trust` | `registration:manage-ip-trust` |
| DELETE | `/api/v1/registration/ip-trust/{tenant_id}/{cidr}` | `registration:manage-ip-trust` |

## Implementation notes

- `approve-by-cidr` filters on the controller using `net.ParseCIDR` + `ipNet.Contains`; not delegated to the database
- DELETE route uses gorilla/mux `{cidr:.+}` to match CIDR slashes across path segments; `url.PathEscape` on the client side
- `pkg/security/validation.go` gains a `cidr` charset (`^[0-9a-fA-F.:/]+$`) so CIDR path variables pass the validation middleware
- `lookupRDNS` uses a 2-second context timeout; returns `-` on any failure

## Security notes (pre-existing patterns, not regressions)

- Bulk approve endpoints and ip-trust endpoints do not scope to the caller's tenant — consistent with all other registration-management endpoints in this file. Follow-up scoping tracked separately.
- CIDR charset is syntactically permissive; semantic validity enforced by `net.ParseCIDR` in handlers.

## Test plan

- [x] `go test ./cmd/cfg/cmd/... ./features/controller/api/... ./pkg/security/...` — all pass
- [x] `make lint` — 0 issues
- [x] `make test-agent-complete` — all gates pass
- [x] QA test runner: PASS
- [x] QA code reviewer: PASS (2 additional error-path tests added per review)
- [x] Security engineer: PASS

Fixes #1698

🤖 Generated with [Claude Code](https://claude.com/claude-code)