### PR TITLE
registration: unblock fleet-e2e via auto-approve + suppress empty steward_id log (Issue #1776)

### DIFF
--- a/features/steward/execution/executor.go
+++ b/features/steward/execution/executor.go
@@ -389,9 +389,16 @@ func (e *Executor) ApplyConfiguration(ctx context.Context, configData []byte, ve
 		return report, fmt.Errorf("failed to parse configuration: %w", err)
 	}
 
-	e.logger.Info("Parsed configuration",
-		"steward_id", cfg.Steward.ID,
-		"resource_count", len(cfg.Resources))
+	// cfg.Steward.ID is the locally-declared steward identifier from the
+	// SYNCED config payload — which the controller does not populate (the
+	// runtime steward_id comes from registration, not configuration). Logging
+	// the empty value pollutes any `tail -1 | grep steward_id` consumer
+	// (notably the fleet-e2e framework_test.go:178 wait). Omit when empty.
+	logArgs := []interface{}{"resource_count", len(cfg.Resources)}
+	if cfg.Steward.ID != "" {
+		logArgs = append(logArgs, "steward_id", cfg.Steward.ID)
+	}
+	e.logger.Info("Parsed configuration", logArgs...)
 
 	// Add tenant context
 	if e.tenantID != "" {

--- a/test/e2e/fleet/configs/controller.cfg
+++ b/test/e2e/fleet/configs/controller.cfg
@@ -36,3 +36,13 @@ logging:
     directory: "/tmp/cfgms"
     max_file_size: 10485760
     max_files: 3
+
+# fleet-e2e stewards register from the docker-bridge subnet, which has no
+# IPTrustStore entries on a fresh test boot. The default "ip-trust" approval
+# workflow (Issue #1695) would quarantine them — they'd get certs but no
+# steward_id finalization — and TestFleetWalkthrough times out grepping
+# their logs for `"steward_id":"..."`. Use the deprecated auto-approve
+# workflow here: appropriate for an isolated docker compose harness where
+# every container is part of the test, never for production.
+registration:
+  workflow: auto-approve


### PR DESCRIPTION
Fixes #1776. Unblocks the merge queue.

## Why
fleet-e2e (`TestFleetWalkthrough`) has been failing on every PR and on the develop merge queue since PR #1770 merged. RCA on PR #1772 traced the regression to story #1696's IP-trust workflow change combined with an old logging bug that only became fatal once registration started succeeding fast enough.

## The two bugs that compounded

**1. IP-trust quarantines fleet stewards from docker-bridge IPs.** PR #1770 made `ip-trust` the default registration workflow. Fresh fleet-e2e stewards register from 172.x.x.x with no IPTrustStore entries → `IPTrustApprovalHook` returns `DecisionQuarantine` (fail-closed) → stewards get certs but never finalize a `steward_id`.

**Fix:** `test/e2e/fleet/configs/controller.cfg` — add `registration: workflow: auto-approve`. The deprecated auto-approve workflow is the documented dev-environment escape hatch. Appropriate for an isolated docker compose harness where every container is part of the test. **Production paths unchanged.**

**2. Convergence "Parsed configuration" log emits empty `steward_id`.** `features/steward/execution/executor.go:392` logs `cfg.Steward.ID` from the SYNCED config payload, which the controller doesn't populate. The runtime `steward_id` comes from registration, not synced resources. The empty value pollutes the test's `tail -1 | grep steward_id` consumer: registration logs the real ID, then convergence overwrites it on every 10-second cycle.

The bug is old (commit `07c90fc3a`, March 2026), but only became a hard failure once registration started succeeding fast enough that convergence ran inside the test's 30-second window.

**Fix:** omit `steward_id` from the log when empty.

## Validation
- `make test-e2e-fleet` **PASS** (all 9 sub-scenarios: VanillaState, ConfigUploadAndConvergence, IdempotentReUpload, PerModuleConvergence, ControllerRestart, StewardRestart, DeferredConfig, DriftAutoCorrection, ConfigCascade)
- `make test` **PASS** (147/147)
- `go build ./...` clean

## Merge-queue impact
After this lands on develop, PRs #1772 (CodeQL story), #1774 (CLI commands, after retarget), and #1775 (expiry jobs) all unblock — their fleet-e2e was failing for this same reason.

🤖 Generated with [Claude Code](https://claude.com/claude-code)