### PR TITLE
refresh-pins: discover GitHub Action SHA pins (Issue #1778)

### DIFF
--- a/.claude/skills/refresh-pins/references/inventory-schema.md
+++ b/.claude/skills/refresh-pins/references/inventory-schema.md
@@ -22,7 +22,9 @@
 ## `kind` values
 
 - **`lockstep`** — the pin appears in multiple files that must all move together. The dev agent's story must update every entry in `locations[]` in a single PR. The acceptance verification AC must grep for the old version (expect 0) and new version (expect `len(locations)`).
-- **`tool`** — pin is enumerated in `dependency-pin-check.yml` and appears in additional usage locations (Dockerfile installs, workflow install steps, shell scripts). The `locations[]` array contains the `check_version` declaration as its first entry, followed by every additional install/usage site discovered by grepping the in-scope paths (`.github/workflows/`, `.devcontainer/Dockerfile`, `Makefile`, `cmd/*/Dockerfile`, `scripts/*.sh`) for the literal version string. All entries must move together in a single bump PR — the dispatcher uses this array to compute file-overlap conflicts.
+- **`tool`** — covers two distinct sub-cases that share the same downstream Phase 2/3 handling:
+  - **Tool-pin declarations** in `dependency-pin-check.yml` (gosec, staticcheck, trivy, …). `locations[]` starts with the `check_version` declaration, then every install/usage site found by grepping `.github/workflows/`, `.devcontainer/Dockerfile`, `Makefile`, `cmd/*/Dockerfile`, and `scripts/*.sh` for the literal version string. All entries must move together in a single bump PR.
+  - **GitHub Action SHA pins** (`uses: <owner>/<name>@<sha>` lines in workflows). The name embeds the short SHA (`gha:actions/checkout@34e11487`) so each unique (action, sha) pair is its own inventory entry. `locations[]` lists every workflow file:line that uses that exact SHA. Multiple entries for the same action with different SHAs is the natural representation of SHA drift across workflows — a drift-finder consumer can group by stripping `@<sha>` from `name`.
 
 ## `release_source` values
 
@@ -46,6 +48,7 @@ Common mappings (extend as needed):
 ## Notes on the discover script's output
 
 - The script does NOT verify lockstep consistency — if `go.mod` is at 1.25.10 but one workflow is still on 1.25.9, both versions appear in the same `go-toolchain` pin's `locations[]`. The CONSUMER (Claude in Phase 3) is expected to detect this and surface it as a lockstep-drift finding. This is the bug class that bit us on 2026-05-12 with PR #1433.
+- For GitHub Action SHA pins, the equivalent drift signal is **multiple inventory entries with the same prefix before the `@`** — e.g., both `gha:actions/checkout@34e11487` and `gha:actions/checkout@93cb6efe` in the same inventory means two workflows pin different SHAs of the same action. Phase 3 should consolidate the bump story for the older entry(s).
 - For `kind: tool` pins, `locations[]` includes the `check_version` declaration in `dependency-pin-check.yml` plus every additional install/usage site found by grepping for the literal version string across `.github/workflows/` (excluding `dependency-pin-check.yml`), `.devcontainer/Dockerfile`, `Makefile`, `cmd/*/Dockerfile`, and `scripts/*.sh`. A dispatched dev agent must update all listed locations to avoid lockstep drift.
 - The order of `locations[]` is deterministic (alphabetical by file path), which makes diffs of the inventory readable.
 - The script is read-only; no side effects.

--- a/.claude/skills/refresh-pins/scripts/discover-pins.py
+++ b/.claude/skills/refresh-pins/scripts/discover-pins.py
@@ -13,6 +13,10 @@ Discovery sources:
 - .devcontainer/Dockerfile — same
 - .github/workflows/dependency-pin-check.yml — the existing tool pin list
   (check_version <name> <repo> <version> calls)
+- .github/workflows/*.yml — GitHub Action SHA pins (uses: <owner>/<name>@<sha>)
+  — one inventory entry per unique (action, sha) tuple so SHA drift across
+  workflows is naturally visible (multiple entries with the same action name
+  but different SHAs).
 
 Run from repo root or any subdir — uses `git rev-parse --show-toplevel`
 to anchor.
@@ -186,10 +190,86 @@ def discover_tool_pins(root: Path) -> list[dict]:
     return pins
 
 
+_GITHUB_ACTION_USES_RE = re.compile(
+    # Match:  uses: <owner>/<name>[/<subpath>]@<40-hex-sha>  [# v<tag-hint>]
+    # Owner and name use the GitHub allowed-character set; subpath is optional
+    # (some actions live in subdirs of a monorepo, e.g. actions/cache/save).
+    r"""
+    ^\s*-?\s*uses:\s*
+    (?P<action>[A-Za-z0-9._-]+/[A-Za-z0-9._/-]+)
+    @
+    (?P<sha>[a-fA-F0-9]{40})
+    (?:\s*\#\s*(?P<hint>\S+))?
+    """,
+    re.VERBOSE,
+)
+
+
+def discover_github_actions(root: Path) -> list[dict]:
+    """Discover GitHub Action SHA pins across every workflow file.
+
+    One inventory entry per unique (action, sha) tuple — so when the same
+    action appears at different SHAs across workflows (drift, or intentional
+    pin-back), each version becomes its own entry. The optional `# vN` hint
+    after the SHA is captured into the match string for human readability;
+    it is not parsed as the canonical version (the SHA is the source of
+    truth, since release notes and tags can be retconned).
+
+    The `name` slug embeds the short SHA so multiple entries for the same
+    action remain unique inventory keys (a downstream consumer can group
+    by stripping `@<sha>`).
+    """
+    workflows = sorted((root / ".github/workflows").glob("*.yml"))
+
+    # (action, sha) → {"hint": "v4" or None, "locations": [...]}
+    by_pin: dict[tuple[str, str], dict] = {}
+
+    for wf in workflows:
+        if not wf.is_file():
+            continue
+        try:
+            lines = wf.read_text().splitlines()
+        except UnicodeDecodeError:
+            continue
+        for i, line in enumerate(lines, 1):
+            m = _GITHUB_ACTION_USES_RE.match(line)
+            if not m:
+                continue
+            action = m.group("action")
+            sha = m.group("sha")
+            hint = m.group("hint")
+            key = (action, sha)
+            entry = by_pin.setdefault(key, {"hint": hint, "locations": []})
+            # Keep the first non-None hint we see (they should all agree).
+            if entry["hint"] is None and hint is not None:
+                entry["hint"] = hint
+            entry["locations"].append({
+                "file": str(wf.relative_to(root)),
+                "line": i,
+                "match": line.strip(),
+            })
+
+    pins = []
+    for (action, sha), entry in sorted(by_pin.items()):
+        # `current` is the full SHA — the canonical identity of the pinned
+        # version. Tag hints (e.g. `# v4`) are advisory only.
+        pins.append({
+            "name": f"gha:{action}@{sha[:8]}",
+            "kind": "tool",
+            "current": sha,
+            "release_source": f"gh:{action.split('/', 1)[0]}/{action.split('/', 1)[1].split('/', 1)[0]}",
+            "ecosystem": None,
+            "package": None,
+            "locations": entry["locations"],
+        })
+    return pins
+
+
 def main() -> int:
     root = repo_root()
     inventory = [discover_go_toolchain(root)]
     inventory.extend(discover_tool_pins(root))
+    inventory.extend(discover_github_actions(root))
     json.dump(inventory, sys.stdout, indent=2)
     sys.stdout.write("\n")
     return 0


### PR DESCRIPTION
Fixes #1778.

## Why
The `refresh-pins` skill was sweeping Go toolchain + `dependency-pin-check.yml` tool pins but ignoring GitHub Action `uses:` SHA references entirely. That's why three Node.js 20 deprecation warnings have been visible on Production Risk Gates for weeks without ever surfacing as bump stories:

- `actions/upload-artifact@ea165f8d…` (14 workflow uses)
- `actions/checkout@34e11487…` (41 workflow uses)
- `actions/setup-go@40f1582b…` (25 workflow uses)

GitHub forces Node 24 default on 2026-06-02 (~10 days out) and removes Node 20 from runners on 2026-09-16.

## Changes
- `.claude/skills/refresh-pins/scripts/discover-pins.py`: new `discover_github_actions(root)` regex-matches `uses: <owner>/<name>@<sha>` across `.github/workflows/*.yml`. Emits one inventory entry per unique (action, sha) tuple — SHA drift across workflows naturally shows as multiple entries with the same action prefix.
- `.claude/skills/refresh-pins/references/inventory-schema.md`: documents the new entries + drift-detection pattern (group by `name` prefix-before-`@` to consolidate stories).

Phase 2 research (`gh:<owner>/<repo>/releases/latest`) and Phase 3 decision matrix work unchanged — the existing `gh:` release-source path handles the new entries natively.

## Sample output (the bonus finding)
First inventory run after this change surfaces **23 GHA pins** and reveals significant drift:

| Action | SHAs in use |
|---|---|
| `actions/checkout` | 2 (34e11487:41x, 93cb6efe:1x) |
| `actions/setup-go` | 3 (40f1582b:25x, 4a360112:1x, 7b8cf10d:1x) |
| `actions/cache` | 3 |
| `actions/upload-artifact` | 2 |

Each variant pinning the older SHA is a separate inventory entry; the consumer (Phase 3) can group by stripping `@<sha>` to consolidate bump stories.

## Validation
- `./.claude/skills/refresh-pins/scripts/discover-pins.py` runs to completion
- Output validates against schema (each entry has all required fields)
- 32 total entries (was 9 before — 1 lockstep, 8 tool, +23 new GHA)
- No regression in existing `go-toolchain` / `tool` pin discovery
- `make test` 147/147 PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)