### PR TITLE
pipeline: epic-review + pipeline-sweep skills with PO Step 7.5 auto-invocation (Issue #1782)

### DIFF
--- a/.claude/agents/po.md
+++ b/.claude/agents/po.md
@@ -600,6 +600,16 @@ rm /tmp/convergence-failure-<EPIC_NUM>.md
 ```
 `po-act.sh block <ISSUE> -` reads the reason from stdin so multi-line summaries don't need command-line argument escaping. The block subcommand idempotently adds the epic to the project queue (if not present) and sets status to Blocked.
 
+**Step 7.5 — Pipeline sweep (closeout + reconciliation):**
+
+Run the `pipeline-sweep` skill. It closes every open epic whose sub-tasks are all done AND whose AC verification passes on `origin/develop`, drafts a remediation story under any epic whose sub-tasks are done but AC verification fails, and moves any CLOSED-on-GitHub project item whose status is stale (anything other than `Done`) to `Done`. Runs in both `cycle` and `cron` modes; cheap and idempotent.
+
+```
+Skill: pipeline-sweep
+```
+
+Include the sweep's headline + verdict tables in the cycle summary you return to the founder. If the sweep surfaces a "Needs founder review" Blocked anomaly (project item Blocked but GH issue closed — e.g. a founder action was completed but the project status was not advanced), flag it in the §6 (Cron PO) section of the cycle report.
+
 **Step 8 — Forward edge:**
 If active milestone >80% complete and next milestone has no epics, create a `high-priority` tracking issue requesting intent capture and add it to the project queue as Blocked.
 

--- a/.claude/skills/epic-review/SKILL.md
+++ b/.claude/skills/epic-review/SKILL.md
@@ -1,0 +1,219 @@
+---
+name: epic-review
+description: Review every open epic — confirm sub-task completion is reflected in the epic body, verify the desired functionality was actually delivered for fully-complete epics, close passing epics with a closeout comment, and draft remediation stories under epics whose AC verification fails. Use when sweeping for closeable epics, after a story batch lands, or as part of /pipeline-sweep.
+context: fork
+agent: general-purpose
+allowed-tools: Bash, Read, Grep, Glob
+---
+
+# Epic Review Skill
+
+You review every OPEN epic and decide one of three outcomes per epic:
+
+1. **CLOSE** — sub-tasks all done, AC verification passes on `origin/develop`
+2. **FLAG + REMEDIATE** — sub-tasks all done, but AC verification fails → draft a remediation story
+3. **KEEP OPEN (no-op)** — sub-tasks still in progress, or epic not yet decomposed
+
+Always verify against `origin/develop`, never your local checkout (memory `feedback_verify_against_origin_develop.md`).
+
+## Inputs
+
+`$ARGUMENTS` is one of:
+- empty — sweep every open epic
+- `<issue_num>` — focused single-epic run (e.g. `1714`)
+
+## Phase 1: Discover
+
+```bash
+git fetch origin develop --quiet
+gh issue list --repo cfg-is/cfgms --label "epic" --state open \
+  --json number,title,id,body --limit 100
+```
+
+If `$ARGUMENTS` names a specific epic, filter to that one and error clearly if it isn't open / isn't labeled `epic`.
+
+For each epic, query sub-issue status (parallel where possible — separate `gh api graphql` calls in one assistant turn):
+
+```bash
+gh api graphql -f query='
+  query($id: ID!) {
+    node(id: $id) {
+      ... on Issue {
+        subIssuesSummary { total completed }
+        subIssues(first: 50) {
+          nodes {
+            number
+            title
+            state
+            closedAt
+            closedByPullRequestsReferences(first: 5) {
+              nodes { number mergedAt }
+            }
+          }
+        }
+      }
+    }
+  }
+' -f id="<EPIC_NODE_ID>"
+```
+
+## Phase 2: Bucket
+
+For each epic:
+
+| Condition | Bucket | Next phase |
+|---|---|---|
+| `total == 0` | **Not decomposed** | Skip; record only |
+| `completed < total` | **In progress** | Skip; record only |
+| `completed == total && total > 0` | **Candidate** | → Phase 3 AC verification |
+
+## Phase 3: AC verification (candidates only)
+
+Read the epic body. Extract 2-4 verifiable claims from its Acceptance Criteria / Success Criteria / Goal sections. Prefer claims most central to the epic's stated outcome.
+
+Verifiable claim types:
+- file paths exist on origin/develop (`pkg/foo/bar.go`)
+- exported function / type / method names (`Manager.Install`, `CertificateTypeServer`)
+- test names (`TestControllerRestart`, `TestDriftAutoCorrection`)
+- CLI subcommands (`cfg steward run-script`)
+- script paths (`scripts/foo.sh`)
+- doc file content (`docs/legal/CLA.md` contains "Version 2.0")
+- negative claims (e.g. *"zero hits for `import ... steward/config`"* — these are the highest-signal because they catch incomplete removals)
+
+For each claim, verify on origin/develop:
+
+```bash
+# File existence
+git cat-file -e "origin/develop:pkg/foo/bar.go" 2>/dev/null && echo PRESENT || echo MISSING
+
+# Function / type / symbol presence
+git grep -nE 'func \(.*\) Install\b' origin/develop -- 'pkg/cert/'
+
+# Test name
+git grep -nE 'func TestControllerRestart\b' origin/develop -- 'test/e2e/fleet/'
+
+# CLI subcommand
+git grep -nE '"run-script"' origin/develop -- 'cmd/cfg/'
+
+# Negative claim — hits should be zero
+git grep -l 'features/steward/config' origin/develop -- 'features/controller/' || echo NONE
+```
+
+Verdict:
+- **PASS** — every spot-checked claim verified
+- **FAIL** — one or more claims unverified despite sub-tasks all closed
+
+When choosing claims, balance coverage and confidence: 2 strong negative claims beat 4 weak file-existence checks. The point is to catch *"epic AC says X, sub-issue closed but X was deferred or never built"*, not to re-run per-story acceptance.
+
+## Phase 4: Act on verdict
+
+### PASS — close the epic
+
+Compose a closeout comment that maps each AC to its delivering sub-issue + PR + merge date. Pull PR numbers and merge dates from the `closedByPullRequestsReferences` query in Phase 1.
+
+```bash
+cat > /tmp/epic-closeout-<N>.md <<'EOF'
+## Epic closeout — <YYYY-MM-DD>
+
+All <N> sub-issues closed; AC verification PASSED on `origin/develop`.
+
+**Delivery map:**
+
+| Acceptance Criterion | Sub-issue | PR | Merged |
+|---|---|---|---|
+| <claim 1> | #<sub> | #<pr> | YYYY-MM-DD |
+| <claim 2> | #<sub> | #<pr> | YYYY-MM-DD |
+| <claim 3> | #<sub> | #<pr> | YYYY-MM-DD |
+
+**Verification commands run:**
+```
+<command 1>  → PASS
+<command 2>  → PASS
+```
+
+**Follow-up work captured elsewhere:**
+- #<NNN> — <brief description if relevant>
+
+Closing.
+EOF
+
+gh issue comment <epic_num> --body-file /tmp/epic-closeout-<N>.md
+gh issue close <epic_num> --reason completed
+```
+
+### FAIL — flag the gap, draft remediation
+
+Post a comment naming the gap. Then create one Draft remediation story under the epic. If multiple claims fail, list all in one story — never create more than one remediation per epic per run.
+
+```bash
+cat > /tmp/epic-acfail-<N>.md <<'EOF'
+## Epic AC verification FAIL — <YYYY-MM-DD>
+
+All <N> sub-issues are closed, but the following claim(s) from the epic body could not be verified on `origin/develop`:
+
+- **<claim 1>** — <why: grep returned X matches expected zero / file missing / function not present>
+  ```
+  <command run>
+  <output>
+  ```
+- **<claim 2>** — <reason>
+
+Drafted remediation story: #<remediation_num>.
+Epic stays OPEN until remediation lands.
+EOF
+
+gh issue comment <epic_num> --body-file /tmp/epic-acfail-<N>.md
+
+# Create remediation story
+cat > /tmp/epic-remediation-<N>.md <<'EOF'
+## Parent epic
+#<epic_num> — <epic title>
+
+## Gap
+The epic's sub-issues are all closed, but AC verification on `origin/develop` failed:
+
+- <claim 1> — <reason, verbatim from the fail comment>
+- <claim 2> — <reason>
+
+## Acceptance Criteria
+- [ ] <claim 1> satisfied on origin/develop (verifiable via `<command>`)
+- [ ] <claim 2> satisfied on origin/develop (verifiable via `<command>`)
+- [ ] Re-running /epic-review on #<epic_num> reports PASS
+
+## Notes
+Drafted by /epic-review on <YYYY-MM-DD>. Tech Lead to refine implementation notes before dispatch.
+EOF
+
+remediation_num=$(gh issue create --repo cfg-is/cfgms \
+  --title "remediation: <shortened epic title> — <one-line gap>" \
+  --label "epic-followup" \
+  --body-file /tmp/epic-remediation-<N>.md | grep -oE '/[0-9]+$' | tr -d /)
+
+item_id=$(/workspace/scripts/project-queue.sh add-issue "$remediation_num" | jq -r '.item_id')
+/workspace/scripts/project-queue.sh update-field "$item_id" status Draft
+```
+
+### KEEP OPEN — record only
+
+No mutations. Just log the bucket and the current `completed/total` for the report.
+
+## Phase 5: Report
+
+Print one verdict table:
+
+| Epic | Title | Sub-issues | Verdict | Action |
+|---|---|---|---|---|
+| #1523 | steward job execution | 9/9 | PASS | CLOSED with closeout comment |
+| #1754 | controller decoupling | 5/6 | IN PROGRESS | — |
+| #XXXX | <title> | N/N | FAIL | Remediation #YYYY drafted |
+| #YYYY | <title> | 0/0 | NOT DECOMPOSED | — |
+
+Then a one-line summary: `Reviewed: X. Closed: Y. Remediation drafted: Z. In progress: W. Not decomposed: V.`
+
+## Conventions
+
+- `git fetch origin develop` is mandatory before any AC verification. The skill is designed for long-running sessions where the local checkout drifts behind develop.
+- AC spot-check uses 2-4 claims chosen for signal, not coverage. Per-sub-issue exhaustive verification is the acceptance-checker agent's job, not this skill's.
+- Closeout comments must cross-link follow-up work that landed in *other* epics — readers should never have to guess whether a deferred concern was tracked forward.
+- Maximum one remediation story per epic per run. Multi-claim failures get one story listing all claims.
+- Never modify CLAUDE.md, roadmap.md, or any doc the epic itself listed as untouchable per its body.

--- a/.claude/skills/pipeline-sweep/SKILL.md
+++ b/.claude/skills/pipeline-sweep/SKILL.md
@@ -1,0 +1,119 @@
+---
+name: pipeline-sweep
+description: Run the closeout and reconciliation sweep — epic review followed by project board status sync. Closes fully-delivered epics, drafts remediation stories for epics with AC gaps, and moves closed GitHub issues whose project status is stale to Done. Invoked automatically at the end of /po cron and /po cycle; also runnable on demand.
+context: fork
+agent: general-purpose
+allowed-tools: Bash, Read, Grep, Skill
+---
+
+# Pipeline Sweep Skill
+
+You run two reconciliation passes against the pipeline:
+
+1. **Epic review** — close every open epic whose work is fully delivered; draft remediation stories for epics whose sub-tasks are done but AC verification fails.
+2. **Project status sync** — for every CLOSED GitHub issue on the project board, ensure its project status is `Done`.
+
+The sync direction is **one-way only**: CLOSED-on-GitHub → status `Done`. Never close a GH issue based on its project status — that hides bad merges into sibling branches (see #1760/#1773).
+
+## Phase 1: Epic review
+
+Invoke the `epic-review` skill with no arguments (sweep all open epics):
+
+```
+Skill: epic-review
+```
+
+Capture its verdict table for the final report. If `Skill` is unavailable in this session, follow the steps from `.claude/skills/epic-review/SKILL.md` inline.
+
+## Phase 2: Project status sync
+
+For each non-terminal status, list its items and check whether their backing GitHub issue is actually CLOSED. Any CLOSED issue at a non-`Done` status is stale and must be updated.
+
+```bash
+# Non-terminal statuses worth checking. Done and Blocked are excluded:
+#   Done    — already terminal
+#   Blocked — may be intentionally held by founder action; don't auto-resolve
+for status in "Draft" "Ready" "In Progress" "Reviewing" "Fix" "Failed"; do
+    /workspace/scripts/project-queue.sh list-by-status "$status" 2>/dev/null \
+      | jq -r --arg s "$status" '.[] | "\($s)\t\(.item_id)\t\(.issue_num)\t\(.title)"'
+done > /tmp/pipeline-sweep-nonterm.tsv
+```
+
+Batch-query the state of every issue_num found:
+
+```bash
+issue_nums=$(awk -F'\t' '{print $3}' /tmp/pipeline-sweep-nonterm.tsv | sort -u | paste -sd,)
+gh api graphql -f query='
+  query($q: String!) {
+    search(query: $q, type: ISSUE, first: 100) {
+      nodes { ... on Issue { number state closedAt } }
+    }
+  }
+' -f q="repo:cfg-is/cfgms is:issue state:closed $(awk -F'\t' '{print $3}' /tmp/pipeline-sweep-nonterm.tsv | sed 's/^/ /' | tr -d '\n')" \
+  > /tmp/pipeline-sweep-closed.json
+```
+
+Or simpler per-issue check (slower but unambiguous, fine for sweep cadence):
+
+```bash
+while IFS=$'\t' read -r prev_status item_id issue_num title; do
+    state=$(gh issue view "$issue_num" --repo cfg-is/cfgms --json state -q .state 2>/dev/null || echo MISSING)
+    if [[ "$state" == "CLOSED" ]]; then
+        echo -e "$issue_num\t$prev_status\t$item_id\t$title"
+    fi
+done < /tmp/pipeline-sweep-nonterm.tsv > /tmp/pipeline-sweep-stale.tsv
+```
+
+For each stale entry, move the project item to `Done`:
+
+```bash
+while IFS=$'\t' read -r issue_num prev_status item_id title; do
+    /workspace/scripts/project-queue.sh update-field "$item_id" status Done
+    echo "Updated #$issue_num ($title): $prev_status → Done"
+done < /tmp/pipeline-sweep-stale.tsv
+```
+
+**Special case — Blocked items:** do NOT touch Blocked items even if the backing issue is CLOSED. Blocked is held intentionally by founder action (CLA Assistant configuration, release tagging, etc.); if a Blocked item's issue is closed, that's a state worth surfacing to the founder, not auto-resolving.
+
+```bash
+/workspace/scripts/project-queue.sh list-by-status Blocked \
+  | jq -r '.[] | "\(.item_id)\t\(.issue_num)\t\(.title)"' \
+  | while IFS=$'\t' read -r item_id issue_num title; do
+      state=$(gh issue view "$issue_num" --repo cfg-is/cfgms --json state -q .state 2>/dev/null || echo MISSING)
+      if [[ "$state" == "CLOSED" ]]; then
+          echo "⚠ Blocked item #$issue_num ($title) is CLOSED on GitHub — review needed (NOT auto-resolved)"
+      fi
+  done > /tmp/pipeline-sweep-blocked-anomaly.txt
+```
+
+## Phase 3: Report
+
+Two sections plus a one-line headline.
+
+### Epic review
+
+Reproduce the verdict table from Phase 1 verbatim.
+
+### Status sync
+
+| Issue | Title | Previous status | Action |
+|---|---|---|---|
+| #NNNN | <title> | In Progress | → Done |
+| #MMMM | <title> | Reviewing | → Done |
+
+If nothing needed correcting: `No stale project items found.`
+
+If any Blocked anomalies in `/tmp/pipeline-sweep-blocked-anomaly.txt`, surface them under a separate "Needs founder review" subsection.
+
+### Headline
+
+One line:
+`Epics closed: X. Remediation stories drafted: Y. Status mismatches corrected: Z. Blocked anomalies: W.`
+
+## Conventions
+
+- One-way sync only: closed-GH → `Done`. Never close GH from project state.
+- Blocked items are surfaced, never mutated.
+- Safe to run repeatedly — idempotent. No-ops when state is already correct.
+- Designed to run at the tail of `/po cron` and `/po cycle`. Standalone invocation `/pipeline-sweep` is also supported.
+- Read-only on the working tree. All side effects go through `gh issue` and `project-queue.sh` — no file edits, no commits.


### PR DESCRIPTION
## Summary

Codifies the manual epic-closeout + project-board-reconciliation pattern that PO has been running by hand. Two new skills plus a PO cycle integration point so every `/po cron` and `/po cycle` ends with a closeout + sync pass.

## What's in this PR

**`.claude/skills/epic-review/SKILL.md`** (new)
- For every open epic, bucket as Not-decomposed / In-progress / Candidate
- Candidates (all sub-issues closed) get AC-spot-checked against `origin/develop` — 2-4 verifiable claims (file paths, exported symbols, test names, negative greps)
- PASS → closeout comment with AC-to-PR delivery map, then `gh issue close`
- FAIL → comment naming the gap + ONE draft remediation story per epic per run (`epic-followup` label, project status Draft)

**`.claude/skills/pipeline-sweep/SKILL.md`** (new)
- Invokes `epic-review`, then project status sync
- For every non-terminal status (Draft / Ready / In Progress / Reviewing / Fix / Failed), find items whose backing GitHub issue is CLOSED and move them to Done
- Blocked items surfaced as "Needs founder review" anomaly, **never auto-resolved**
- **One-way sync only**: closed-GH → Done. Never closes GH from project state — that hides bad merges into sibling branches (#1760 / PR #1773 was the cautionary case)

**`.claude/agents/po.md`** (modified, +10 lines)
- New `Step 7.5 — Pipeline sweep` inserted between Step 7 (Planning Team) and Step 8 (Forward edge)
- Invokes `pipeline-sweep` skill via the Skill tool
- Runs on both `cycle` and `cron` paths (cron skips Step 7 Planning Team but runs 7.5)
- Headline + verdict tables included in cycle summary; Blocked anomalies surfaced under §6 (Cron PO)

## Smoke test (already executed against current pipeline)

- **Epic #1664** closed via the manual sweep equivalent — 9/9 sub-issues done, AC spot-check passed on 4 claims:
  - `cfg registration` CLI surface (`approve-all`, `approve-by-cidr`, `ip-trust add/revoke`)
  - Heartbeat 20s + offline-detection 60s constants present with epic reference comment
  - IP-trust 30-min sustained-liveness threshold (`defaultIPTrustThreshold = 30 * time.Minute`)
  - Tenant-scoped IP-trust store with CIDR support (dedicated handler + evaluator files)
- **Status sync**: zero drift found on current board state
- **Open epic count**: 6 → 3 over the course of this conversation (#1523, #1714, #1664 closed)

## Why now

PO has been running this pattern manually several times per week. Codifying it:
1. Removes founder/PO cycles re-deriving the methodology each time
2. Ensures every cron cycle ends with the board in a consistent state
3. Catches AC-vs-sub-issue drift (epic body says X delivered, sub-issue closed, but X never built)
4. Surfaces Blocked anomalies (founder action done but project status not advanced) without auto-resolving them

## Design decisions captured

- **AC-fail action**: flag + draft one remediation story per epic per run (chosen over flag-only, and over reopening sub-issues, after explicit decision)
- **Sync direction**: closed-GH → Done only. The reverse direction is unsafe (proven by PR #1773 sibling-branch merge)
- **Blocked items**: surface, never auto-resolve. Blocked is held intentionally (CLA Assistant config, release tag, etc.)
- **Auto-trigger**: end of `/po cron` and `/po cycle`. Manual invocation also supported

## Scope

Markdown / process tooling only — no Go changes, no CI changes, no Docker changes.

Fixes #1782

🤖 Generated with [Claude Code](https://claude.com/claude-code)
