### PR TITLE
docs: sweep architecture and guide docs to remove dual-license references (Issue #1750)

### DIFF
--- a/.github/WORKFLOWS.md
+++ b/.github/WORKFLOWS.md
@@ -98,7 +98,7 @@ This document describes the GitHub Actions workflows configured for the CFGMS pr
 - MIT, Apache-2.0, BSD (2-Clause, 3-Clause), ISC, MPL-2.0
 
 **Forbidden Licenses:**
-- GPL/LGPL/AGPL (copyleft incompatible with Apache-2.0)
+- GPL/LGPL/AGPL (stricter copyleft — review required)
 - CC-BY-NC (non-commercial restriction)
 - Commercial/Proprietary
 - SSPL (Server Side Public License)

--- a/docs/architecture/controller-operating-model.md
+++ b/docs/architecture/controller-operating-model.md
@@ -27,7 +27,7 @@ The `initialization.Run()` function performs the following steps in order:
 
 1. **Pre-flight validation** — verifies that config is present, certificate management is enabled (`certificate.enable_cert_management: true`), and `certificate.ca_path` is set
 2. **Idempotent guard** — reads the CA directory for an existing `.cfgms-initialized` marker. If the marker exists, init refuses to run and reports when and with what CA the controller was previously initialized. To re-initialize, the operator must remove the CA directory and run `--init` again
-3. **Storage backend creation** — initializes the storage backend. OSS deployments use the composite flatfile + SQLite backend via `interfaces.CreateOSSStorageManager()`; commercial single-provider deployments use a database backend via `interfaces.CreateAllStoresFromConfig()`
+3. **Storage backend creation** — initializes the storage backend. Default configuration deployments use the composite flatfile + SQLite backend via `interfaces.CreateOSSStorageManager()`; production-scale deployments may configure a database backend via `interfaces.CreateAllStoresFromConfig()`
 4. **CA directory and CA generation** — creates the CA directory (`os.MkdirAll` with `0700`), then creates a new Certificate Authority via `pkg/cert.Manager` with `LoadExistingCA: false`
 5. **Internal mTLS certificate** — if separated certificate architecture is configured, generates the `cfgms-internal` certificate used for gRPC-over-QUIC inter-component communication
 6. **Config signing certificate** — if separated architecture, generates the `cfgms-config-signer` certificate used to sign cfgs distributed to stewards (4096-bit RSA key)
@@ -99,7 +99,7 @@ For production fleets, a steward runs alongside the controller on each node. The
 | CA and certificates | Controller | Generated during `--init`, managed in-memory |
 | RBAC and tenant data | Controller | Stored in durable storage backend |
 | Fleet registry | Controller | Steward registrations and heartbeats persisted in `StewardStore` — survives controller restarts (Issue #663) |
-| Storage backend | Controller | Flatfile + SQLite (OSS) or PostgreSQL (commercial) operations |
+| Storage backend | Controller | Flatfile + SQLite (default) or PostgreSQL (production scale) operations |
 | Fleet orchestration | Controller | Config distribution, steward registration, workflows |
 
 See [Single Controller Deployment](../../deployment/single-controller/walkthrough.md) for the deployment guide and [ADR-002](decisions/002-steward-bootstrap-for-controllers.md) for the architectural decision.
@@ -150,7 +150,7 @@ The controller is the authoring and distribution point for steward cfgs. It does
 Author → Validate → Store → Distribute → Monitor Compliance
 ```
 
-1. **Author** — Cfgs are created or updated via the `cfg` CLI (`cfg config upload`), the commercial web UI, a GitOps webhook, or workflow output. All sources write through the same ConfigStore — there is no separate "fast path".
+1. **Author** — Cfgs are created or updated via the `cfg` CLI (`cfg config upload`), the administration web UI, a GitOps webhook, or workflow output. All sources write through the same ConfigStore — there is no separate "fast path".
 2. **Validate** — Controller validates cfg syntax, module references, and tenant scoping before accepting. Validation is part of the write path; an invalid cfg never lands in storage.
 3. **Store** — Cfg is persisted in durable, version-controlled ConfigStore. Every change is a new version with full audit trail.
 4. **Distribute** — A successful `ConfigStore` write inside `SetConfiguration()` triggers automatic distribution via a service-level callback (Issue #1521, Option A). The callback is registered at server startup (`server.go`) and invokes `push.Fanout()` scoped to the tenant from the write context. Distribution is fire-and-forget: `SetConfiguration()` returns without blocking on fanout completion. Cfgs are signed with the controller's signing certificate so stewards can verify authenticity. Note: debounce (burst-save absorption) and per-steward targeting evaluation are tracked as follow-on stories.
@@ -486,7 +486,7 @@ The controller is the certificate authority and identity provider for stewards. 
    - **`auto-approve`** (deprecated): approves every valid registration unconditionally. Dev/test environments only — a startup warning is logged. Replaces the legacy `DefaultApprovalHook`.
    - Custom workflows can implement arbitrary policy (e.g., approve `tenant=lab` registrations, reject everything else)
 5. On approval (`approve`): controller generates the steward ID and issues an mTLS client certificate scoped to the steward's tenant/group identity (HTTP 200 with full cert bundle).
-   On quarantine (`quarantine`): controller returns HTTP 202 with a `pending_id` and no certificates. The pending entry is written to the durable `PendingRegistrationStore` (SQLite in OSS, PostgreSQL in commercial). The steward polls `GET /api/v1/registration/status/{pending_id}` with its registration token as a Bearer credential until the operator acts. Operators use `cfg registration approve <pending-id>` or `cfg registration deny <pending-id>`.
+   On quarantine (`quarantine`): controller returns HTTP 202 with a `pending_id` and no certificates. The pending entry is written to the durable `PendingRegistrationStore` (SQLite by default, PostgreSQL at production scale). The steward polls `GET /api/v1/registration/status/{pending_id}` with its registration token as a Bearer credential until the operator acts. Operators use `cfg registration approve <pending-id>` or `cfg registration deny <pending-id>`.
    On rejection (`reject`): HTTP 403 is returned; registration is denied.
 6. **Generate-on-claim (quarantine path):** When the operator approves an entry and the steward polls again, the controller generates the mTLS certificate in memory for that single response, marks the entry as `claimed`, and returns the full cert bundle in HTTP 200. A subsequent poll on an already-claimed entry returns HTTP 410 Gone — the cert is never re-issued. Private keys are never stored in the database.
 7. Controller distributes the CA cert, signing cert, and connection details.
@@ -570,7 +570,7 @@ The `pending` output includes a `SOURCE_IP` column showing the steward's source 
 
 The `approve-by-cidr` command performs IP containment filtering on the controller using `net.ParseCIDR` + `ipNet.Contains` — the CIDR is not delegated to the database. All approved entries are updated atomically per-entry; partial approval (some entries approved, others skipped) is the expected outcome.
 
-The pending queue is backed by the durable `PendingRegistrationStore` (SQLite in OSS, PostgreSQL in commercial) and survives controller restarts.
+The pending queue is backed by the durable `PendingRegistrationStore` (SQLite by default, PostgreSQL at production scale) and survives controller restarts.
 
 ### RBAC
 
@@ -626,7 +626,7 @@ Tenants are identified by **path** (e.g., `root/msp-a/client-1/servers`). Path-b
 - **Wildcard targeting** — `root/msp-a/*/production` matches all production groups across clients
 - **Efficient resolution** — cfg inheritance walks the path from root to leaf
 
-#### Example: Single MSP (Apache / OSS)
+#### Example: Single MSP
 
 ```
 acme-msp (root)
@@ -645,9 +645,9 @@ acme-msp (root)
      └── device-6 (steward)
 ```
 
-One root tenant, unlimited depth. This is the Apache-licensed deployment model.
+One root tenant, unlimited depth.
 
-#### Example: SaaS Platform (Elastic / Commercial)
+#### Example: SaaS Platform
 
 ```
 cfg-is (platform root)
@@ -665,7 +665,7 @@ cfg-is (platform root)
      └── ...
 ```
 
-Multiple independent root tenants under a platform tenant. MSPs cannot see each other's trees. This is the Elastic-licensed deployment model — it enables cfg.is to host hundreds of MSPs on shared infrastructure with per-MSP isolation, resource scheduling, and billing.
+Multiple independent root tenants under a platform tenant. MSPs cannot see each other's trees. This topology enables cfg.is to host hundreds of MSPs on shared infrastructure with per-MSP isolation, resource scheduling, and billing.
 
 ### Cfg Inheritance
 
@@ -685,7 +685,7 @@ Every value in the effective cfg carries its **source path** and **version** for
 - **Certificate isolation** — each steward gets its own client certificate
 - **RBAC isolation** — permissions are scoped to tenant path; a client admin cannot manage another client's devices
 - **Cfg inheritance** — flows down the hierarchy only; children inherit from parents, never sideways
-- **Multi-root isolation** (commercial) — independent root tenants are fully isolated; no inheritance, no visibility, no shared state between roots
+- **Multi-root isolation** — independent root tenants are fully isolated; no inheritance, no visibility, no shared state between roots
 
 ## Monitoring and Reporting
 
@@ -718,11 +718,11 @@ The controller evaluates fleet-level conditions and raises alerts:
 
 ## High Availability
 
-### OSS (Single Server)
+### Single Server
 
 The controller runs as a single instance. If it goes down, stewards continue operating independently on their last-known cfgs. When the controller comes back, stewards reconnect and resync.
 
-### Commercial (Cluster)
+### Clustered
 
 Multiple controller instances form a **Raft consensus cluster**. Raft is the sole authority for cluster membership and leader election — there is no static or geographic node discovery layer, and no ad-hoc election logic outside Raft:
 

--- a/docs/architecture/decisions/003-storage-data-taxonomy.md
+++ b/docs/architecture/decisions/003-storage-data-taxonomy.md
@@ -37,16 +37,16 @@ CLAUDE.md states the target of **50k+ Stewards** per controller deployment. At t
 
 A single global backend cannot serve all five well.
 
-### Licensing Boundary
+### Storage Backend Context
 
-Prior documentation listed the OSS track as "Git, SQLite, PostgreSQL" and the commercial track as the same plus HA-optimized PostgreSQL. SQLite is advertised but not implemented. Git is listed as a storage backend but is a poor fit for anything other than small, human-edited config files.
+Prior documentation listed the default track as "Git, SQLite, PostgreSQL" and the production-scale track as the same plus HA-optimized PostgreSQL. SQLite is advertised but not implemented. Git is listed as a storage backend but is a poor fit for anything other than small, human-edited config files.
 
 ### Concrete Deficiencies
 
 Verified during exploration; each becomes a sub-issue under the epic tracked by this ADR:
 
 1. **No SQLite provider.** `pkg/storage/providers/` contains only `database/` (PostgreSQL) and `git/`.
-2. **No flat-file provider.** Needed to replace the git provider as the OSS file-based option.
+2. **No flat-file provider.** Needed to replace the git provider as the default file-based option.
 3. **Git provider's `RuntimeStore` is memory-backed.** `pkg/storage/providers/git/plugin.go:152-166` returns `cache.NewRuntimeCache(...)` with a comment admitting "runtime sessions are ephemeral." Persistent-session semantics silently lost on git deployments.
 4. **No `StewardStore`.** Steward fleet state (last-seen, heartbeat, status) is in-memory only in `features/steward/health.go`. Controller restart loses the fleet view.
 5. **No persistent command dispatch.** `features/steward/commands/handler.go` tracks executing commands in-memory. No crash-survivable audit trail.
@@ -60,8 +60,8 @@ Verified during exploration; each becomes a sub-issue under the epic tracked by 
 
 Storage is partitioned by data type, not by a single global backend. Each type has its own interfaces and its own backend selection. Deployments compose one provider per type.
 
-| Type | OSS default | Commercial/SaaS default |
-|------|-------------|-------------------------|
+| Type | Default configuration | Production scale |
+|------|----------------------|-----------------|
 | Business data | SQLite | PostgreSQL |
 | Config storage | Flat file | PostgreSQL |
 | Config *git sync* (optional, per-scope) | Flat file ⇄ external git origin | PostgreSQL ⇄ external git origin |
@@ -69,7 +69,7 @@ Storage is partitioned by data type, not by a single global backend. Each type h
 | Timeseries | Local log files | ClickHouse / Timescale / Influx |
 | Blobs | Local filesystem | S3-compatible object storage |
 
-**The OSS column shows the zero-config default, not a limit.** Any backend listed in the Commercial column is available to OSS deployments. The licensing boundary is single-root tenant tree shape, not backend choice — see [LICENSING.md](../../../LICENSING.md). An OSS single-root deployment is free to run PostgreSQL for business data, a key vault for secrets, and S3 for blobs if the operator wants that.
+**The default column shows the zero-config default, not a limit.** Any production-scale backend is available to all deployments. Deployment topology (single root vs. multi-root) is a separate concern from backend choice — see [LICENSING.md](../../../LICENSING.md). A single-root deployment is free to run PostgreSQL for business data, a key vault for secrets, and S3 for blobs if the operator wants that.
 
 ### 2. Interface Mapping
 
@@ -98,27 +98,27 @@ General rule for the epic: **anything named `*Store` is durable; anything epheme
 
 The existing `pkg/storage/providers/git/` is **deprecated and removed**. Git re-enters the architecture as an optional *sync source* for admin-designated config scopes.
 
-**Replacement for OSS file-based storage**: a new **flat-file** provider. The admin is responsible for backups of the flat-file tree (filesystem snapshots, rsync, restic, etc.). CFGMS does not manage versioning or history at the storage layer.
+**Replacement for the file-based default storage**: a new **flat-file** provider. The admin is responsible for backups of the flat-file tree (filesystem snapshots, rsync, restic, etc.). CFGMS does not manage versioning or history at the storage layer.
 
-**Git-sync model** (single component, shared across OSS and commercial):
+**Git-sync model** (single component, shared across all deployment scales):
 
 - Admin binds a config scope (tenant path + namespace, e.g., `root/msp-a/client-1/firewall`) to an external git origin: URL, branch, credentials reference.
 - Git-sync pulls from the origin on webhook (push event) with a polling fallback.
-- Imported configs write through to the chosen config backend — flat-file (OSS) or PostgreSQL (commercial).
+- Imported configs write through to the chosen config backend — flat-file (default) or PostgreSQL (production scale).
 - Scopes without a git binding live natively in the backend.
 - Read path is always the backend; git is the editing surface for bound scopes, not a query target.
 - **v1 is one-way, read-only** (git → backend). The controller never writes back to the git origin. For bound scopes, all edits happen at the git origin (PRs, commits, merges via the tenant's normal GitOps workflow) and flow down via sync. Bidirectional sync (backend → git commits for UI-initiated edits) is explicitly out of scope for v1 and will be a future ADR if demand emerges.
 
-This gives tenants their existing GitHub/GitLab PR workflow without CFGMS hosting git. One code path serves both OSS and commercial deployments.
+This gives tenants their existing GitHub/GitLab PR workflow without CFGMS hosting git. One code path serves all deployment scales.
 
 ### 4. Implementation Sequence
 
 Tracked under the epic referenced in [Code Changes Required](#code-changes-required). Ordered to unblock SaaS first:
 
-1. Flat-file provider (replaces git provider for OSS)
+1. Flat-file provider (replaces git provider for default file-based storage)
 2. `StewardStore` + persistent fleet registry
 3. ~~Deprecate and remove `pkg/storage/providers/git/`~~ **Done** (Issue #664)
-4. SQLite provider for OSS business data
+4. SQLite provider for default business data storage
 5. Persist command dispatch (audit-integrated)
 6. Git-sync component
 7. `BlobStore` interface + filesystem/S3 providers
@@ -134,11 +134,11 @@ Tracked under the epic referenced in [Code Changes Required](#code-changes-requi
 
 ### Positive
 
-1. **OSS↔commercial symmetry**: one git-sync path, two backend targets. No forked codebase.
+1. **Backend symmetry**: one git-sync path serves both default and production-scale backends. No forked codebase.
 2. **Admin-owned backups**: removing the git provider eliminates a surprising abstraction (git commits per write) and hands backup responsibility to the operator, who can use standard filesystem tools.
 3. **Tenant workflow preserved**: MSPs continue editing config on their own GitHub/GitLab; git-sync imports the result.
 4. **Clean swap boundaries**: a new timeseries backend doesn't force rewriting config or business stores.
-5. **SaaS-ready**: SQLite/flat-file for OSS, PostgreSQL/S3/vault for SaaS — each type picks its own scaling story.
+5. **SaaS-ready**: SQLite/flat-file for default deployments, PostgreSQL/S3/vault for production scale — each type picks its own scaling story.
 6. **Eliminates the `RuntimeStore` memory-cache lie**: the broken git implementation goes away. Durable pieces move to `SessionStore`; ephemeral pieces move to `pkg/cache`. No more interface pretending to be storage while returning a cache.
 7. **Purges controller concerns from steward paths**: drift event storage, M365 admin-consent `ClientTenantStore`, and similar controller-side interfaces currently living under `features/steward/*` and `features/modules/m365/auth/*` relocate to the canonical `pkg/storage/interfaces/` tree. One authoritative location per interface.
 
@@ -164,17 +164,17 @@ Tracked under the epic referenced in [Code Changes Required](#code-changes-requi
 
 **Rejected because**:
 - Two code paths doing substantially similar work (commit on write vs. pull from origin)
-- OSS and SaaS diverge architecturally — a bug found in one path doesn't necessarily fix the other
+- Default and SaaS deployments diverge architecturally — a bug found in one path doesn't necessarily fix the other
 - Git provider's `RuntimeStore` memory-cache issue remains
 - Admin still shoulders git-provider failure modes (merge conflicts on high-write paths) with no benefit
 
-### Alternative 2: Require Postgres for All OSS Deployments
+### Alternative 2: Require Postgres for All Deployments
 
 **Approach**: Drop file-based storage entirely; Postgres is the only supported backend.
 
 **Rejected because**:
-- Raises the OSS barrier to entry significantly — a single-binary MSP demo now requires a database
-- Contradicts the project's documented flat-file-class options for OSS deployments
+- Raises the barrier to entry significantly — a single-binary MSP demo now requires a database
+- Contradicts the project's documented flat-file-class default options
 - Over-serves the small-deployment end of the market
 
 ### Alternative 3: Per-Store Provider Selection Without the Taxonomy
@@ -188,7 +188,7 @@ Tracked under the epic referenced in [Code Changes Required](#code-changes-requi
 
 ### Chosen Approach: Five-Type Taxonomy + Flat-File + Git-Sync
 
-Cleanest shape for the backend-technology clusters we actually need, preserves the tenant GitOps workflow, and lets a single git-sync code path serve both OSS and SaaS.
+Cleanest shape for the backend-technology clusters we actually need, preserves the tenant GitOps workflow, and lets a single git-sync code path serve all deployment scales.
 
 ## Code Changes Required
 
@@ -196,13 +196,13 @@ This ADR ratifies the direction. Implementation is tracked by the epic **Storage
 
 | # | Title | Priority | Depends on | Status |
 |---|-------|----------|------------|--------|
-| A | Flat-file storage provider (OSS file-based backend) | P0 | — | **Merged** (Issue #661) |
-| C | SQLite storage provider for OSS business data | P0 | — | **Merged** (Issues #662, #663, #665) |
+| A | Flat-file storage provider (default file-based backend) | P0 | — | **Merged** (Issue #661) |
+| C | SQLite storage provider for default business data | P0 | — | **Merged** (Issues #662, #663, #665) |
 | D | `StewardStore` interface + persistent fleet registry | P0 | A, C | **Merged** (Issue #663) |
 | E | Persist command dispatch state (audit-integrated) | P1 | C | **Merged** (Issue #665) |
-| J | Composite storage manager + OSS factory (`NewStorageManagerFromStores`, `CreateOSSStorageManager`) | P0 | A, C, D, E | **Merged** (Issue #692) |
+| J | Composite storage manager + default factory (`NewStorageManagerFromStores`, `CreateOSSStorageManager`) | P0 | A, C, D, E | **Merged** (Issue #692) |
 | B | Deprecate and remove `pkg/storage/providers/git/` | P1 | A, J | In progress (Issue #664) |
-| F | Git-sync component (shared OSS/commercial) | P1 | A | Not started |
+| F | Git-sync component (shared across all scales) | P1 | A | Not started |
 | G | `BlobStore` interface + filesystem and S3-compatible providers | P2 | — | **Merged** (Issue #667) |
 | H | `SecretStore` interface unifying SOPS and key vaults | P2 | — | Not started |
 | I | Reorganize `pkg/storage/interfaces/` into type-based taxonomy | P2 | A, B, C, D, E, F, G, H | Not started |
@@ -215,7 +215,7 @@ A, C  →  D, E, F  →  B  →  G, H  →  I
 
 - A (flat-file) and C (SQLite) have no dependencies and can proceed in parallel.
 - D (StewardStore) needs at least one backend (A or C) to persist into; the story must be built against both.
-- B (remove git provider) can only land after A exists as its OSS replacement.
+- B (remove git provider) can only land after A exists as its replacement.
 - F (git-sync) requires A (flat-file write-through target).
 - I (interfaces reorganization) lands last so it doesn't cause churn during the earlier stories.
 
@@ -223,7 +223,7 @@ Each sub-story has its own testable acceptance criteria. This ADR is the shared 
 
 ## Documentation Currency
 
-Any sub-story under this epic that changes the shape of the product — adds or removes a backend, changes the OSS/commercial boundary, renames a public interface, changes config schema, or moves an interface between packages — **must update the following in the same PR**:
+Any sub-story under this epic that changes the shape of the product — adds or removes a backend, changes the deployment topology or backend defaults, renames a public interface, changes config schema, or moves an interface between packages — **must update the following in the same PR**:
 
 - `LICENSING.md` — if the licensing boundary description changes
 - `docs/architecture/storage-architecture.md` — operator walk-through of the taxonomy
@@ -243,7 +243,7 @@ Rule of thumb: **if a steward does not use the interface, it does not belong und
 ## References
 
 - `docs/architecture/decisions/001-central-provider-compliance-enforcement.md` — format template and the "pluggable by default" principle this ADR builds on
-- `LICENSING.md` — licensing details and commercial FAQ
+- `LICENSING.md` — licensing details and deployment topology FAQ
 - `docs/architecture/storage-architecture.md` — operator-facing walk-through of this decision (renamed from `hybrid-storage-solution.md`)
 - `pkg/storage/providers/git/plugin.go:152-166` — evidence for git-provider deprecation (`RuntimeStore` memory-cache admission)
 - `features/steward/health.go` — in-memory fleet state (motivates `StewardStore`)

--- a/docs/architecture/operating-model.md
+++ b/docs/architecture/operating-model.md
@@ -277,7 +277,7 @@ Operators interact with CFGMS through layered UX surfaces.
 
 **`cfg` CLI — first-class community UI.** The canonical interaction surface for the open-source distribution. Every documented operator action works through the CLI. The CLI wraps REST endpoints so operators don't need to script against REST for documented workflows.
 
-**Web UI — commercial layer (planned before v1).** A separate UX layer in the commercial distribution. Targets operators who prefer graphical workflows or shared-team views. Some power-user flows may remain CLI-only.
+**Web UI (planned before v1).** A separate UX layer for operators who prefer graphical workflows or shared-team views. Some power-user flows may remain CLI-only.
 
 **REST API — underlying contract.** The wire format the CLI and web UI both use. Stable, versioned, and documented at `docs/api/rest-api.md`. Available to operators and integrators for scripting and third-party tools.
 

--- a/docs/architecture/plugin-architecture.md
+++ b/docs/architecture/plugin-architecture.md
@@ -35,12 +35,12 @@ pkg/
 │   │   ├── secrets/          # SecretStore — credentials, API keys
 │   │   └── timeseries/       # MetricsStore, LogStore — append-only metrics
 │   └── providers/            # Storage implementations (one per type)
-│       ├── sqlite/           # Business data OSS default
-│       ├── flatfile/         # Config + audit OSS default
-│       ├── database/         # PostgreSQL (commercial/SaaS)
+│       ├── sqlite/           # Business data default
+│       ├── flatfile/         # Config + audit default
+│       ├── database/         # PostgreSQL (production scale / SaaS)
 │       └── blobstore/
-│           ├── filesystem/   # Blob storage OSS default
-│           └── s3/           # Blob storage commercial/SaaS
+│           ├── filesystem/   # Blob storage default
+│           └── s3/           # Blob storage production scale / SaaS
 features/
 ├── controller/               # Controller wires storage providers
 ├── modules/m365/auth/        # Uses pkg/storage/interfaces only
@@ -115,7 +115,7 @@ func (p *DatabaseProvider) CreateAuditStore(config map[string]interface{}) (inte
 }
 
 func (p *DatabaseProvider) Description() string {
-    return "PostgreSQL-backed storage for production and commercial deployments"
+    return "PostgreSQL-backed storage for production-scale deployments"
 }
 
 // Salt-style auto-registration
@@ -151,7 +151,7 @@ func NewAdminConsentFlow(clientStore interfaces.ClientTenantStore) *AdminConsent
 Storage is configured per data type (five-type composition). See [Storage Architecture](storage-architecture.md) for the full reference.
 
 ```yaml
-# cfgms.yaml - Controller configuration (OSS example)
+# cfgms.yaml - Controller configuration (default example)
 controller:
   storage:
     business:
@@ -190,15 +190,15 @@ cfg plugins list storage
 
 ```
 Available Storage Plugins (business data):
-  ✅ sqlite      - SQLite storage (OSS default)
+  ✅ sqlite      - SQLite storage (default)
   ✅ database    - PostgreSQL storage (requires: postgresql client)
 
 Available Storage Plugins (config storage):
-  ✅ flatfile    - Flat-file storage (OSS default)
-  ✅ database    - PostgreSQL storage (commercial/SaaS)
+  ✅ flatfile    - Flat-file storage (default)
+  ✅ database    - PostgreSQL storage (production scale / SaaS)
 
 Available Storage Plugins (blob storage):
-  ✅ filesystem  - Local filesystem (OSS default)
+  ✅ filesystem  - Local filesystem (default)
   ✅ s3          - S3-compatible object storage
 ```
 
@@ -320,11 +320,11 @@ func CreateStorageFromConfig(backendType string, config map[string]interface{}) 
 
 Per [ADR-003](decisions/003-storage-data-taxonomy.md), storage is split into five independent data types. Each type is configured with its own provider — there is no single global storage backend.
 
-- **Business data** (tenants, RBAC, sessions, commands, audit): `sqlite` (OSS), `database`/PostgreSQL (commercial)
-- **Config storage** (templates, policies, firewall rules): `flatfile` (OSS), `database`/PostgreSQL (commercial)
-- **Secrets** (credentials, certificates): `sops` (OSS), key vault (commercial)
-- **Timeseries** (metrics, logs): local files (OSS), ClickHouse/Timescale (commercial)
-- **Blobs** (installers, script bodies): `filesystem` (OSS), `s3` (commercial)
+- **Business data** (tenants, RBAC, sessions, commands, audit): `sqlite` (default), `database`/PostgreSQL (production scale)
+- **Config storage** (templates, policies, firewall rules): `flatfile` (default), `database`/PostgreSQL (production scale)
+- **Secrets** (credentials, certificates): `sops` (default), key vault (production scale / SaaS)
+- **Timeseries** (metrics, logs): local files (default), ClickHouse/Timescale (production scale)
+- **Blobs** (installers, script bodies): `filesystem` (default), `s3` (production scale / SaaS)
 
 ### Configuration Flow
 
@@ -359,10 +359,10 @@ Current implementations following this pattern:
 - **Business data**: `pkg/storage/providers/sqlite` (TenantStore, ClientTenantStore, AuditStore, RBACStore, SessionStore, CommandStore, StewardStore, RegistrationTokenStore, TriggerStore, PushStore)
 - **Config storage**: `pkg/storage/providers/flatfile` (ConfigStore, AuditStore, StewardStore)
 - **Blob storage**: `pkg/storage/providers/blobstore/filesystem` and `blobstore/s3`
-- **PostgreSQL**: `pkg/storage/providers/database` (business + config stores for commercial)
+- **PostgreSQL**: `pkg/storage/providers/database` (business + config stores, production scale / SaaS)
 - **Git sync**: `pkg/gitsync` — optional read-only import from external git repos into ConfigStore
 - **Control/data plane**: `pkg/controlplane/providers/grpc`, `pkg/dataplane/providers/grpc`
-- **Secrets**: `pkg/secrets` (SOPS-based for OSS)
+- **Secrets**: `pkg/secrets` (SOPS-based, default)
 - **Logging**: `pkg/logging` (file, timescale)
 
 Future:

--- a/docs/guides/configuration-inheritance.md
+++ b/docs/guides/configuration-inheritance.md
@@ -10,7 +10,7 @@ CFGMS implements a hierarchical configuration inheritance system that allows MSP
 - [Hierarchy Levels](#hierarchy-levels)
 - [Inheritance Rules](#inheritance-rules)
 - [Configuration Format](#configuration-format)
-- [Licensing Boundary: Apache vs Elastic](#licensing-boundary-apache-vs-elastic)
+- [Deployment Topology](#deployment-topology)
 - [Practical Examples](#practical-examples)
 - [Best Practices](#best-practices)
 - [API Usage](#api-usage)
@@ -195,42 +195,9 @@ resources:
         password=${DB_PASSWORD}   # required — startup fails if not set
 ```
 
-## Licensing Boundary: Apache vs Elastic
+## Deployment Topology
 
-The tenant depth capability is the same in both tiers, but the **number of root tenants** determines which license applies:
-
-### Apache License (OSS)
-
-A **single root tenant tree** — one MSP, unlimited depth beneath it.
-
-```
-acme-msp (single root)
- ├── client-a
- │   ├── production
- │   │   ├── device-1 (steward)
- │   │   └── device-2 (steward)
- │   └── development
- │       └── device-3 (steward)
- └── client-b
-     └── device-4 (steward)
-```
-
-### Elastic License (Commercial)
-
-**Multiple independent root tenants** under a platform root — the cfg.is SaaS deployment model.
-
-```
-cfg-is (platform root)
- ├── msp-alpha (root — isolated)
- │   ├── client-1
- │   └── client-2
- ├── msp-beta (root — isolated)
- │   └── client-1
- └── msp-gamma (root)
-     └── ...
-```
-
-MSPs cannot see each other's trees. Cfg inheritance never crosses root boundaries. Use the single-root model unless you are building a multi-MSP platform.
+Each controller deployment has a single root tenant. Multi-root (multiple independent MSP trees on shared infrastructure) is a future deployment topology not yet implemented.
 
 ## Practical Examples
 

--- a/docs/testing/release-validation-checklist.md
+++ b/docs/testing/release-validation-checklist.md
@@ -185,13 +185,11 @@ rm -rf /tmp/cfgms-release-* /tmp/controller-release-test.yaml
 
 ## Tier 3: High Availability Validation
 
-### 5. HA Cluster Tests (Commercial Only) ✅
-
-**For commercial builds only:**
+### 5. HA Cluster Tests ✅
 
 ```bash
 cd test/integration/ha
-go test -v -tags commercial -timeout 30m
+go test -v -timeout 30m
 ```
 
 **Tests Validated:**


### PR DESCRIPTION
## Summary

- Removes all dual-license, Elastic License, and Apache-vs-commercial framing from 7 documentation files in `docs/` and `.github/WORKFLOWS.md`
- Replaces OSS/commercial split language with deployment-scale framing: "default configuration" vs "production scale" for backends, "single root" vs "multi-root" for topology
- Deletes the 38-line "Licensing Boundary: Apache vs Elastic" section from `configuration-inheritance.md`; replaces with a 2-sentence "Deployment Topology" note
- Removes "For commercial builds only" gate and `-tags commercial` from the HA test section in `release-validation-checklist.md`
- Updates `.github/WORKFLOWS.md` AGPL comment from "incompatible with Apache-2.0" to "stricter copyleft — review required" (AGPL stays in forbidden list)

Fixes #1750

## Acceptance Criteria Verified

| Check | Result |
|-------|--------|
| `grep -r "Elastic License\|Elastic-2.0\|Elastic (Commercial)\|Elastic-licensed" docs/` | PASS — no matches |
| `grep -r "feature-boundaries.md\|ha-commercial-split.md" docs/` | PASS — no matches |
| No "Licensing Boundary: Apache vs Elastic" heading in `configuration-inheritance.md` | PASS |
| No "For commercial builds only" in `release-validation-checklist.md` | PASS |
| Architecture docs use scale/topology framing (not OSS vs commercial) | PASS |
| All 7 in-scope files updated | PASS |

## Specialist Review Results

**QA Test Runner**: PASS — 139 packages, 149 shell tests, cross-platform build (5 targets), integration + HA tests all passing. `make test-agent-complete` clean.

**QA Code Reviewer**: PASS — 0 blocking issues, 0 warnings. All 7 files confirmed clean of dual-license language. `CreateOSSStorageManager` code symbol references (function names in the codebase) correctly preserved unchanged.

**Security Engineer**: PASS — 0 blocking issues, 0 warnings. Security scans (Trivy, Nancy, gosec, staticcheck, `make check-architecture`) all green. No secrets, credentials, or internal infrastructure details introduced.

## Files Changed

1. `docs/architecture/controller-operating-model.md`
2. `docs/architecture/operating-model.md`
3. `docs/architecture/plugin-architecture.md`
4. `docs/architecture/decisions/003-storage-data-taxonomy.md`
5. `docs/guides/configuration-inheritance.md`
6. `docs/testing/release-validation-checklist.md`
7. `.github/WORKFLOWS.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)