### PR TITLE
docs: update README, CLAUDE.md, and PR template for AGPL-3.0 single license (Issue #1749)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,10 +12,10 @@ Closes #
 **⚠️ REQUIRED: All contributors must sign the CLA before code can be merged.**
 
 - [ ] **I have signed the CLA** by adding my name to [CONTRIBUTORS.md](../CONTRIBUTORS.md)
-- [ ] **I have read the CLA**: [docs/legal/CLA.md](../docs/legal/CLA.md)
+- [ ] **I have read the CLA v2.0**: [docs/legal/CLA.md](../docs/legal/CLA.md)
 
 **For first-time contributors:**
-1. Read the [Contributor License Agreement](../docs/legal/CLA.md)
+1. Read the [Contributor License Agreement v2.0](../docs/legal/CLA.md)
 2. Add your name to [CONTRIBUTORS.md](../CONTRIBUTORS.md) in this PR
 3. Check the box above
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -152,7 +152,7 @@ Consult these before implementing steward or controller behavior changes:
 3. Extend existing providers rather than creating overlapping code
 4. `make check-architecture` enforces this automatically
 
-**Why pluggable by default:** Multi-tenant SaaS with different backend needs, commercial/OSS feature gating, 50k+ steward scale, cloud vs on-prem flexibility, testing without mocks (use test implementations). Cheap to do now, expensive to retrofit.
+**Why pluggable by default:** Multi-tenant SaaS with different backend needs, deployment-scale flexibility, 50k+ steward scale, cloud vs on-prem flexibility, testing without mocks (use test implementations). Cheap to do now, expensive to retrofit.
 
 **Pluggable Providers:**
 
@@ -165,7 +165,7 @@ Consult these before implementing steward or controller behavior changes:
 | `pkg/controlplane` | Control plane communication (gRPC) |
 | `pkg/dataplane` | Data plane communication (gRPC) |
 
-**Direct Providers:** `pkg/cert`, `pkg/telemetry`, `pkg/cache`, `pkg/session`, `pkg/registration`, `pkg/monitoring`, `pkg/maintenance`, `pkg/security`
+**Direct Providers:** `pkg/cert`, `pkg/telemetry`, `pkg/cache`, `pkg/session`, `pkg/registration`, `pkg/monitoring`, `pkg/maintenance`, `pkg/security`, `pkg/ha`
 
 **Utilities (not providers):** `pkg/config`, `pkg/testing`, `pkg/testutil`, `pkg/version`, `pkg/audit`
 
@@ -240,10 +240,7 @@ Recursive parent-child tenant model with arbitrary depth. Path-based identificat
 
 ### Licensing Boundary
 
-- **Apache (OSS):** Single root tenant tree — one MSP, unlimited depth
-- **Elastic (Commercial):** Multi-root / platform mode — multiple independent MSP trees
-
-Ask: "Does this work within a single tenant tree, or require awareness of multiple roots?" Single-tree = Apache. Multi-root = Elastic.
+All CFGMS code is AGPL-3.0. A commercial embedding license is available via private agreement for third parties shipping CFGMS in proprietary products. The single-root vs multi-root deployment distinction is an architectural boundary, not a license boundary — all deployment shapes run AGPL-3.0 code.
 
 ## Quick Reference
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ CFGMS is a modern configuration management system designed with resilience, secu
 [![CodeQL](https://github.com/cfg-is/cfgms/workflows/CodeQL%20Security%20Analysis/badge.svg)](https://github.com/cfg-is/cfgms/security/code-scanning)
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/cfg-is/cfgms/badge)](https://securityscorecards.dev/viewer/?uri=github.com/cfg-is/cfgms)
 [![Go Report Card](https://goreportcard.com/badge/github.com/cfg-is/cfgms)](https://goreportcard.com/report/github.com/cfg-is/cfgms)
-[![License](https://img.shields.io/badge/License-Apache%202.0%20%2B%20Elastic%20v2-blue.svg)](LICENSING.md)
+[![License](https://img.shields.io/badge/License-AGPL--3.0-blue.svg)](LICENSE)
 
 ## Project Status
 
@@ -34,20 +34,17 @@ This project board provides real-time visibility into:
 
 ## License
 
-CFGMS uses a **dual licensing model**:
+CFGMS is licensed under the **[GNU Affero General Public License v3.0](LICENSE)** (AGPL-3.0).
 
-- **[Apache License 2.0](LICENSE-APACHE-2.0)** - The vast majority of CFGMS (all modules, integrations, CLI/API, workflow engine, DNA system, RBAC, monitoring)
-- **[Elastic License 2.0](LICENSE-ELASTIC-2.0)** - Small subset of enterprise features (HA clustering, future Web UI)
-
-**Quick Summary:**
-- **Open Source (Apache 2.0)**: Free forever, use commercially, modify and distribute freely
-- **Commercial (Elastic 2.0)**: Free to use in your infrastructure, cannot offer as a hosted service
+- **Self-hosted use** (on-premises or private cloud) is fully permitted — no commercial license required.
+- **MSPs** managing client endpoints under a single CFGMS deployment require no commercial license.
+- **Commercial embedding** (compiling CFGMS source into a proprietary product) requires a private commercial license. Contact [licensing@cfg.is](mailto:licensing@cfg.is).
 
 For complete licensing details and FAQ, see [LICENSING.md](LICENSING.md).
 
 ## Enterprise Features
 
-Enterprise features (HA clustering, Web UI, multi-MSP) are available by building with `-tags commercial`. These features are **free for internal use** under Elastic License 2.0.
+HA clustering is included in all builds. Web UI is planned for a future release.
 
 For hosted deployment or support contracts, contact [licensing@cfg.is](mailto:licensing@cfg.is). See [LICENSING.md](LICENSING.md) for complete details.
 


### PR DESCRIPTION
## Summary

- Rewrites `README.md` license section and Enterprise Features section for AGPL-3.0 single-license model (removes Apache 2.0/Elastic 2.0 dual-license description, false multi-MSP claim, and `-tags commercial` build instruction)
- Rewrites `CLAUDE.md` Licensing Boundary sub-section; replaces "commercial/OSS feature gating" with "deployment-scale flexibility"; adds `pkg/ha` to Direct Providers table
- Updates `.github/PULL_REQUEST_TEMPLATE.md` CLA section to reference CLA v2.0 without dual-license framing

Fixes #1749

## Specialist Review Results

- **QA Test Runner**: PASS — all tests pass (unit, lint, cross-platform compilation); Docker-dependent tests appropriately deferred to CI; marker file written
- **QA Code Reviewer**: PASS — no blocking issues; 2 non-blocking warnings about `pkg/README.md` documentation drift (out of scope for this story)
- **Security Engineer**: PASS — no secrets, no information disclosure, no central provider violations; gitleaks and truffleHog clean; `make security-scan` appropriately skipped for docs-only change

## Test plan

- [x] `grep -n "Elastic License\|Apache License 2.0\|-tags commercial\|multi-MSP" README.md` — no results
- [x] `grep -n "Elastic (Commercial)\|Apache (OSS)" CLAUDE.md` — no results
- [x] `pkg/ha` appears in CLAUDE.md Direct Providers table
- [x] `.github/PULL_REQUEST_TEMPLATE.md` CLA section references CLA v2.0
- [x] `make test-agent-complete` — PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)