### PR TITLE
ci: add CLA signature check workflow — homegrown 'equivalent' per #1746

### DIFF
--- a/.github/workflows/cla-check.yml
+++ b/.github/workflows/cla-check.yml
@@ -1,0 +1,108 @@
+# CLA Signature Check
+#
+# Verifies that the author of every pull request has signed CFGMS's
+# Contributor License Agreement (v2.0) by adding their GitHub login to
+# CONTRIBUTORS.md, OR that the PR diff itself adds the signature.
+#
+# This is the "or equivalent" path for Issue #1746 — a self-hosted CLA
+# check that does not require the cla-assistant.io GitHub App. The
+# canonical CLA text lives in docs/legal/CLA.md; signatures live in
+# CONTRIBUTORS.md per the existing "How to Sign" instructions.
+#
+# Maintainers and bot accounts are bypassed automatically. External
+# contributors get a comment with sign-in instructions on the PR.
+
+name: CLA Check
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  cla-check:
+    name: CLA signature check
+    runs-on: ubuntu-latest
+    if: ${{ !github.event.pull_request.draft }}
+    timeout-minutes: 5
+    steps:
+      - name: Checkout default branch
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          ref: develop
+
+      - name: Verify CLA signature
+        env:
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          PR_AUTHOR_TYPE: ${{ github.event.pull_request.user.type }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          # Bypass GitHub bot accounts (dependabot, etc.)
+          if [ "$PR_AUTHOR_TYPE" = "Bot" ]; then
+            echo "::notice::CLA check bypassed for bot account: $PR_AUTHOR"
+            exit 0
+          fi
+
+          # Maintainer allowlist (signed CLA before file existed, or service accounts)
+          case "$PR_AUTHOR" in
+            jrdnr|cfg-agent)
+              echo "::notice::CLA check bypassed for maintainer: $PR_AUTHOR"
+              exit 0
+              ;;
+          esac
+
+          # Check current CONTRIBUTORS.md on the default branch
+          if grep -q "@$PR_AUTHOR\b" CONTRIBUTORS.md 2>/dev/null \
+             || grep -qF "github.com/$PR_AUTHOR" CONTRIBUTORS.md 2>/dev/null; then
+            echo "::notice::CLA already signed by $PR_AUTHOR"
+            exit 0
+          fi
+
+          # Check if this PR adds the contributor to CONTRIBUTORS.md
+          patch=$(gh api "repos/$GH_REPO/pulls/$PR_NUMBER/files" \
+            --jq '.[] | select(.filename == "CONTRIBUTORS.md") | .patch // ""')
+
+          if [ -n "$patch" ] && echo "$patch" \
+              | grep -q "^+.*\(@$PR_AUTHOR\b\|github\.com/$PR_AUTHOR\)"; then
+            echo "::notice::CLA signature added in this PR by $PR_AUTHOR"
+            exit 0
+          fi
+
+          # Post (or update) a CLA-bot comment with sign-in instructions
+          comment_body=$(cat <<EOF
+          <!-- cla-bot -->
+          ## CLA signature required
+
+          Hi @$PR_AUTHOR — thanks for the contribution! Before this PR can be merged, please sign the CFGMS Contributor License Agreement (v2.0).
+
+          **To sign:** add your name to [\`CONTRIBUTORS.md\`](https://github.com/$GH_REPO/blob/develop/CONTRIBUTORS.md) in this PR, using the format:
+
+          \`\`\`
+          - [Your Name] <your@email.com> (@$PR_AUTHOR) - $(date +%Y-%m-%d)
+          \`\`\`
+
+          By adding your name, you confirm you have read and agree to the [CLA v2.0](https://github.com/$GH_REPO/blob/develop/docs/legal/CLA.md). See [\`CONTRIBUTING.md\`](https://github.com/$GH_REPO/blob/develop/CONTRIBUTING.md) for the full process.
+
+          Once your name lands in this PR, this check will pass on the next push.
+          EOF
+          )
+
+          existing_id=$(gh api "repos/$GH_REPO/issues/$PR_NUMBER/comments" \
+            --jq '[.[] | select(.body | startswith("<!-- cla-bot -->"))][0].id // ""')
+
+          if [ -n "$existing_id" ]; then
+            gh api -X PATCH "repos/$GH_REPO/issues/comments/$existing_id" \
+              -f body="$comment_body" > /dev/null
+          else
+            gh pr comment "$PR_NUMBER" --repo "$GH_REPO" --body "$comment_body" > /dev/null
+          fi
+
+          echo "::error::CLA not signed by $PR_AUTHOR. See the bot comment on the PR for sign-in instructions."
+          exit 1

--- a/.github/workflows/cla-check.yml
+++ b/.github/workflows/cla-check.yml
@@ -15,6 +15,12 @@
 name: CLA Check
 
 on:
+  # zizmor: ignore[dangerous-triggers]
+  # `pull_request_target` is intentional: this workflow needs the elevated
+  # `pull-requests: write` token to post the CLA-bot comment on fork PRs.
+  # The workflow NEVER checks out the PR HEAD or executes PR-supplied code;
+  # it only checks out `develop` (a base-controlled ref) and calls `gh api`
+  # with `github.event`-supplied fields, which are GitHub-controlled.
   pull_request_target:
     types: [opened, synchronize, reopened, ready_for_review]
 
@@ -33,6 +39,7 @@ jobs:
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           ref: develop
+          persist-credentials: false
 
       - name: Verify CLA signature
         env:


### PR DESCRIPTION
## Summary

Adds `.github/workflows/cla-check.yml` — a self-hosted CLA signature verification workflow. Satisfies Issue #1746's AC: *"CLA Assistant (or equivalent) is active on cfg-is/cfgms"* without requiring the cla-assistant.io GitHub App (which would need founder authorization on the repo settings page).

## Why this instead of cla-assistant.io

| | cla-assistant.io App | This workflow |
|---|---|---|
| Install | Founder authorizes the App on org settings page (manual, not script-able) | Lands via normal PR |
| Storage | External (gist) | In-tree (`CONTRIBUTORS.md`, already the canonical signature file per CLA v2.0) |
| Secrets needed | Personal access token | `GITHUB_TOKEN` (default) |
| Auditability | External service logs | Native to repo's workflow run history |
| Customization | Limited to App UI | Full bash script |

The CLA text already lives in `docs/legal/CLA.md`; signatures already live in `CONTRIBUTORS.md` per the existing "How to Sign" instructions. This workflow just enforces what the CLA already says.

## Behavior

- **Triggers:** `pull_request_target` on open/sync/reopen/ready_for_review. Drafts skip.
- **Bypass paths:** GitHub `Bot` type accounts (dependabot, etc.), maintainer allowlist (`jrdnr`, `cfg-agent`).
- **Signature check:** searches `CONTRIBUTORS.md` on develop for `@<login>` or `github.com/<login>`. If absent, checks if the PR diff itself adds that signature.
- **First-time contributors:** posts a sticky CLA-bot comment with sign-in instructions; updates in place on subsequent pushes (idempotent via `<!-- cla-bot -->` marker).
- **Security:** uses `pull_request_target` (elevated token) but checks out `develop`, never the PR HEAD — safe pattern for fork PRs.

## Test plan

- `make test` passes locally (149/149 script tests + HA, exit 0)
- YAML syntax validates (`python3 -c "import yaml; yaml.safe_load(...)"` returns OK)
- Workflow design walkthrough — bypass paths first, then in-tree signature check, then in-diff signature check, then comment + fail

## Founder follow-up (out of this PR's scope)

For the workflow to actually **block** merges (not just report), add `CLA signature check` to develop's required-status-checks list in GitHub Ruleset ID `11647684`. This is a UI action that can't be automated via API at the org-admin scope. Once added, the AC4 of #1746 ("CLA check is required on develop branch protection") becomes met.

Refs #1746
Refs #1716

🤖 Generated with [Claude Code](https://claude.com/claude-code)