### PR TITLE
feat: add multi-platform installer artifact upload and storage API (Issue #1702)

### DIFF
--- a/docs/deployment/fleet/walkthrough.md
+++ b/docs/deployment/fleet/walkthrough.md
@@ -226,6 +226,10 @@ cfg token list --tenant-id=default
 
 ## Phase 4 — Build and Register Remote Stewards
 
+> **Note (Phase 4a — coming soon):** Once the install-package flow is complete, installer
+> artifacts will be uploadable via `cfg installer upload` and served directly from the
+> controller. See Issue #1661 (steward provisioning epic) for progress.
+
 ### Windows endpoints — MSI installer
 
 Windows endpoints can be enrolled silently using the `cfgms-steward-windows-amd64.msi`

--- a/features/controller/api/handlers_certificates_test.go
+++ b/features/controller/api/handlers_certificates_test.go
@@ -65,6 +65,7 @@ func setupCertTestServer(t *testing.T) (*Server, *cert.Manager) {
 		nil, nil, nil, "", nil, auditMgr,
 		nil, // No command publisher for basic tests
 		nil, // No push store for basic tests
+		nil, // No blob store for basic tests
 	)
 	require.NoError(t, err)
 	t.Cleanup(func() {

--- a/features/controller/api/handlers_deployments_test.go
+++ b/features/controller/api/handlers_deployments_test.go
@@ -71,6 +71,7 @@ func setupDeploymentServer(t *testing.T) (*Server, business.PushStore) {
 		auditMgr,
 		nil,       // No command publisher needed
 		pushStore, // Real push store
+		nil,       // No blob store needed
 	)
 	require.NoError(t, err)
 	t.Cleanup(func() {

--- a/features/controller/api/handlers_installer.go
+++ b/features/controller/api/handlers_installer.go
@@ -1,0 +1,275 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+package api
+
+import (
+	"errors"
+	"net/http"
+
+	"github.com/gorilla/mux"
+
+	"github.com/cfgis/cfgms/pkg/ctxkeys"
+	"github.com/cfgis/cfgms/pkg/logging"
+	blob "github.com/cfgis/cfgms/pkg/storage/interfaces/blob"
+)
+
+// validPlatforms is the allow-list of supported installer platforms (Issue #1702).
+var validPlatforms = map[string]bool{
+	"windows": true,
+	"darwin":  true,
+	"linux":   true,
+}
+
+// validArchs is the allow-list of supported installer architectures (Issue #1702).
+var validArchs = map[string]bool{
+	"amd64": true,
+	"arm64": true,
+}
+
+// installerUploadResponse is the JSON body returned by PUT /api/v1/installer/artifacts/{platform}/{arch}.
+type installerUploadResponse struct {
+	Platform string `json:"platform"`
+	Arch     string `json:"arch"`
+	Size     int64  `json:"size"`
+	Checksum string `json:"checksum"`
+}
+
+// installerArtifactInfo is one element in the list/get response for installer artifact endpoints.
+type installerArtifactInfo struct {
+	Platform    string `json:"platform"`
+	Arch        string `json:"arch"`
+	Size        int64  `json:"size"`
+	Checksum    string `json:"checksum"`
+	ContentType string `json:"content_type"`
+}
+
+// handleUploadInstallerArtifact handles PUT /api/v1/installer/artifacts/{platform}/{arch}.
+// Stores the request body as an installer artifact in the BlobStore under
+// Namespace "installers", Name "<platform>-<arch>". Returns 200 with the
+// computed size and SHA-256 checksum on success.
+func (s *Server) handleUploadInstallerArtifact(w http.ResponseWriter, r *http.Request) {
+	if s.blobStore == nil {
+		s.writeErrorResponse(w, http.StatusServiceUnavailable, "Installer storage not available", "SERVICE_UNAVAILABLE")
+		return
+	}
+	tenantID, _ := r.Context().Value(ctxkeys.TenantID).(string)
+	if tenantID == "" {
+		s.writeErrorResponse(w, http.StatusUnauthorized, "Authentication required", "AUTHENTICATION_REQUIRED")
+		return
+	}
+
+	vars := mux.Vars(r)
+	platform := vars["platform"]
+	arch := vars["arch"]
+
+	if !validPlatforms[platform] {
+		s.writeErrorResponse(w, http.StatusBadRequest,
+			"Unknown platform: "+logging.SanitizeLogValue(platform)+"; valid values: windows, darwin, linux",
+			"INVALID_PLATFORM")
+		return
+	}
+	if !validArchs[arch] {
+		s.writeErrorResponse(w, http.StatusBadRequest,
+			"Unknown arch: "+logging.SanitizeLogValue(arch)+"; valid values: amd64, arm64",
+			"INVALID_ARCH")
+		return
+	}
+
+	key := blob.BlobKey{
+		TenantID:  tenantID,
+		Namespace: "installers",
+		Name:      platform + "-" + arch,
+	}
+
+	if err := s.blobStore.PutBlob(r.Context(), key, r.Body, blob.BlobMeta{ContentType: "application/octet-stream"}); err != nil {
+		s.logger.Error("Failed to store installer artifact",
+			"error", err,
+			"platform", logging.SanitizeLogValue(platform),
+			"arch", logging.SanitizeLogValue(arch))
+		s.writeErrorResponse(w, http.StatusInternalServerError, "Failed to store artifact", "STORE_ERROR")
+		return
+	}
+
+	// Retrieve stored metadata (size + checksum computed by provider during PutBlob).
+	rc, storedMeta, err := s.blobStore.GetBlob(r.Context(), key)
+	if err != nil {
+		s.logger.Error("Failed to retrieve stored artifact metadata",
+			"error", err,
+			"platform", logging.SanitizeLogValue(platform),
+			"arch", logging.SanitizeLogValue(arch))
+		s.writeErrorResponse(w, http.StatusInternalServerError, "Failed to retrieve artifact metadata", "METADATA_ERROR")
+		return
+	}
+	// Close without reading content — the metadata sidecar is populated by PutBlob.
+	_ = rc.Close()
+
+	s.writeSuccessResponse(w, installerUploadResponse{
+		Platform: platform,
+		Arch:     arch,
+		Size:     storedMeta.Size,
+		Checksum: storedMeta.Checksum,
+	})
+}
+
+// handleListInstallerArtifacts handles GET /api/v1/installer/artifacts.
+// Returns the list of installer artifacts for the authenticated tenant.
+func (s *Server) handleListInstallerArtifacts(w http.ResponseWriter, r *http.Request) {
+	if s.blobStore == nil {
+		s.writeErrorResponse(w, http.StatusServiceUnavailable, "Installer storage not available", "SERVICE_UNAVAILABLE")
+		return
+	}
+	tenantID, _ := r.Context().Value(ctxkeys.TenantID).(string)
+	if tenantID == "" {
+		s.writeErrorResponse(w, http.StatusUnauthorized, "Authentication required", "AUTHENTICATION_REQUIRED")
+		return
+	}
+
+	blobs, err := s.blobStore.ListBlobs(r.Context(), blob.BlobKey{
+		TenantID:  tenantID,
+		Namespace: "installers",
+	})
+	if err != nil {
+		s.logger.Error("Failed to list installer artifacts", "error", err)
+		s.writeErrorResponse(w, http.StatusInternalServerError, "Failed to list artifacts", "LIST_ERROR")
+		return
+	}
+
+	artifacts := make([]installerArtifactInfo, 0, len(blobs))
+	for _, b := range blobs {
+		platform, arch, ok := parseInstallerName(b.Key.Name)
+		if !ok {
+			continue
+		}
+		artifacts = append(artifacts, installerArtifactInfo{
+			Platform:    platform,
+			Arch:        arch,
+			Size:        b.Meta.Size,
+			Checksum:    b.Meta.Checksum,
+			ContentType: b.Meta.ContentType,
+		})
+	}
+
+	s.writeSuccessResponse(w, artifacts)
+}
+
+// handleGetInstallerArtifact handles GET /api/v1/installer/artifacts/{platform}/{arch}.
+// Returns the metadata for a single installer artifact. Returns 404 when absent.
+func (s *Server) handleGetInstallerArtifact(w http.ResponseWriter, r *http.Request) {
+	if s.blobStore == nil {
+		s.writeErrorResponse(w, http.StatusServiceUnavailable, "Installer storage not available", "SERVICE_UNAVAILABLE")
+		return
+	}
+	tenantID, _ := r.Context().Value(ctxkeys.TenantID).(string)
+	if tenantID == "" {
+		s.writeErrorResponse(w, http.StatusUnauthorized, "Authentication required", "AUTHENTICATION_REQUIRED")
+		return
+	}
+
+	vars := mux.Vars(r)
+	platform := vars["platform"]
+	arch := vars["arch"]
+
+	if !validPlatforms[platform] {
+		s.writeErrorResponse(w, http.StatusBadRequest,
+			"Unknown platform: "+logging.SanitizeLogValue(platform)+"; valid values: windows, darwin, linux",
+			"INVALID_PLATFORM")
+		return
+	}
+	if !validArchs[arch] {
+		s.writeErrorResponse(w, http.StatusBadRequest,
+			"Unknown arch: "+logging.SanitizeLogValue(arch)+"; valid values: amd64, arm64",
+			"INVALID_ARCH")
+		return
+	}
+
+	key := blob.BlobKey{
+		TenantID:  tenantID,
+		Namespace: "installers",
+		Name:      platform + "-" + arch,
+	}
+
+	rc, meta, err := s.blobStore.GetBlob(r.Context(), key)
+	if err != nil {
+		if errors.Is(err, blob.ErrBlobNotFound) {
+			s.writeErrorResponse(w, http.StatusNotFound, "Artifact not found", "ARTIFACT_NOT_FOUND")
+			return
+		}
+		s.logger.Error("Failed to get installer artifact",
+			"error", err,
+			"platform", logging.SanitizeLogValue(platform),
+			"arch", logging.SanitizeLogValue(arch))
+		s.writeErrorResponse(w, http.StatusInternalServerError, "Failed to get artifact", "GET_ERROR")
+		return
+	}
+	// Metadata is read from the sidecar; close the content reader without streaming it.
+	_ = rc.Close()
+
+	s.writeSuccessResponse(w, installerArtifactInfo{
+		Platform:    platform,
+		Arch:        arch,
+		Size:        meta.Size,
+		Checksum:    meta.Checksum,
+		ContentType: meta.ContentType,
+	})
+}
+
+// handleDeleteInstallerArtifact handles DELETE /api/v1/installer/artifacts/{platform}/{arch}.
+// Removes the installer artifact. Returns 204 on success (including when it did not exist).
+func (s *Server) handleDeleteInstallerArtifact(w http.ResponseWriter, r *http.Request) {
+	if s.blobStore == nil {
+		s.writeErrorResponse(w, http.StatusServiceUnavailable, "Installer storage not available", "SERVICE_UNAVAILABLE")
+		return
+	}
+	tenantID, _ := r.Context().Value(ctxkeys.TenantID).(string)
+	if tenantID == "" {
+		s.writeErrorResponse(w, http.StatusUnauthorized, "Authentication required", "AUTHENTICATION_REQUIRED")
+		return
+	}
+
+	vars := mux.Vars(r)
+	platform := vars["platform"]
+	arch := vars["arch"]
+
+	if !validPlatforms[platform] {
+		s.writeErrorResponse(w, http.StatusBadRequest,
+			"Unknown platform: "+logging.SanitizeLogValue(platform)+"; valid values: windows, darwin, linux",
+			"INVALID_PLATFORM")
+		return
+	}
+	if !validArchs[arch] {
+		s.writeErrorResponse(w, http.StatusBadRequest,
+			"Unknown arch: "+logging.SanitizeLogValue(arch)+"; valid values: amd64, arm64",
+			"INVALID_ARCH")
+		return
+	}
+
+	key := blob.BlobKey{
+		TenantID:  tenantID,
+		Namespace: "installers",
+		Name:      platform + "-" + arch,
+	}
+
+	if err := s.blobStore.DeleteBlob(r.Context(), key); err != nil {
+		s.logger.Error("Failed to delete installer artifact",
+			"error", err,
+			"platform", logging.SanitizeLogValue(platform),
+			"arch", logging.SanitizeLogValue(arch))
+		s.writeErrorResponse(w, http.StatusInternalServerError, "Failed to delete artifact", "DELETE_ERROR")
+		return
+	}
+
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// parseInstallerName splits a blob name like "windows-amd64" into ("windows", "amd64", true).
+// Returns ("", "", false) for names that do not match a known platform-arch combination.
+func parseInstallerName(name string) (platform, arch string, ok bool) {
+	for p := range validPlatforms {
+		for a := range validArchs {
+			if name == p+"-"+a {
+				return p, a, true
+			}
+		}
+	}
+	return "", "", false
+}

--- a/features/controller/api/handlers_installer_test.go
+++ b/features/controller/api/handlers_installer_test.go
@@ -1,0 +1,452 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+package api
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gorilla/mux"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cfgis/cfgms/pkg/ctxkeys"
+	blob "github.com/cfgis/cfgms/pkg/storage/interfaces/blob"
+)
+
+// newFSBlobStore creates a temporary filesystem BlobStore for tests.
+// The filesystem provider is registered by providers_test.go (blank import).
+func newFSBlobStore(t *testing.T) blob.BlobStore {
+	t.Helper()
+	store, err := blob.CreateBlobStoreFromConfig("filesystem", map[string]interface{}{"root": t.TempDir()})
+	require.NoError(t, err)
+	return store
+}
+
+// setupTestServerWithBlobStore creates a test server wired with a real filesystem BlobStore.
+// setupTestServer (called internally) already isolates CFGMS_SECRETS_REPO_PATH per test.
+func setupTestServerWithBlobStore(t *testing.T) (*Server, blob.BlobStore) {
+	t.Helper()
+	store := newFSBlobStore(t)
+	server := setupTestServer(t)
+	server.blobStore = store
+	return server, store
+}
+
+// withTenant returns a copy of r with tenantID injected into the context.
+func withTenant(r *http.Request, tenantID string) *http.Request {
+	return r.WithContext(context.WithValue(r.Context(), ctxkeys.TenantID, tenantID))
+}
+
+// withVars returns a copy of r with gorilla/mux route variables injected.
+// Use this when calling handlers directly (not via the router).
+func withVars(r *http.Request, vars map[string]string) *http.Request {
+	return mux.SetURLVars(r, vars)
+}
+
+// --- Upload ---
+
+// TestHandleUploadInstallerArtifact_ValidInput verifies a PUT with valid platform/arch
+// stores the artifact and returns 200 with platform, arch, size, and checksum.
+func TestHandleUploadInstallerArtifact_ValidInput(t *testing.T) {
+	server, _ := setupTestServerWithBlobStore(t)
+
+	body := bytes.NewBufferString("fake-installer-content")
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/installer/artifacts/linux/amd64", body)
+	req = withTenant(req, "test-tenant")
+	req = withVars(req, map[string]string{"platform": "linux", "arch": "amd64"})
+	rec := httptest.NewRecorder()
+
+	server.handleUploadInstallerArtifact(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var resp APIResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+
+	data, ok := resp.Data.(map[string]interface{})
+	require.True(t, ok, "expected object in Data")
+	assert.Equal(t, "linux", data["platform"])
+	assert.Equal(t, "amd64", data["arch"])
+	assert.NotEmpty(t, data["checksum"], "checksum must be populated by the provider")
+	size, _ := data["size"].(float64)
+	assert.Greater(t, size, float64(0), "size must be non-zero")
+}
+
+// TestHandleUploadInstallerArtifact_InvalidPlatform verifies that an unknown platform returns 400.
+func TestHandleUploadInstallerArtifact_InvalidPlatform(t *testing.T) {
+	server, _ := setupTestServerWithBlobStore(t)
+
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/installer/artifacts/solaris/amd64",
+		bytes.NewBufferString("content"))
+	req = withTenant(req, "test-tenant")
+	req = withVars(req, map[string]string{"platform": "solaris", "arch": "amd64"})
+	rec := httptest.NewRecorder()
+
+	server.handleUploadInstallerArtifact(rec, req)
+
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+// TestHandleUploadInstallerArtifact_InvalidArch verifies that an unknown arch returns 400.
+func TestHandleUploadInstallerArtifact_InvalidArch(t *testing.T) {
+	server, _ := setupTestServerWithBlobStore(t)
+
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/installer/artifacts/linux/mips",
+		bytes.NewBufferString("content"))
+	req = withTenant(req, "test-tenant")
+	req = withVars(req, map[string]string{"platform": "linux", "arch": "mips"})
+	rec := httptest.NewRecorder()
+
+	server.handleUploadInstallerArtifact(rec, req)
+
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+// TestHandleUploadInstallerArtifact_NoAuth verifies that a missing tenant ID returns 401.
+func TestHandleUploadInstallerArtifact_NoAuth(t *testing.T) {
+	server, _ := setupTestServerWithBlobStore(t)
+
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/installer/artifacts/linux/amd64",
+		bytes.NewBufferString("content"))
+	req = withVars(req, map[string]string{"platform": "linux", "arch": "amd64"})
+	rec := httptest.NewRecorder()
+
+	server.handleUploadInstallerArtifact(rec, req)
+
+	assert.Equal(t, http.StatusUnauthorized, rec.Code)
+}
+
+// --- List ---
+
+// TestHandleListInstallerArtifacts_Empty verifies the list endpoint returns an empty array
+// when no artifacts have been uploaded.
+func TestHandleListInstallerArtifacts_Empty(t *testing.T) {
+	server, _ := setupTestServerWithBlobStore(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/installer/artifacts", nil)
+	req = withTenant(req, "test-tenant")
+	rec := httptest.NewRecorder()
+
+	server.handleListInstallerArtifacts(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var resp APIResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+
+	items, ok := resp.Data.([]interface{})
+	require.True(t, ok, "expected array in Data")
+	assert.Empty(t, items)
+}
+
+// TestHandleListInstallerArtifacts_NoAuth verifies the list endpoint returns 401 without auth.
+func TestHandleListInstallerArtifacts_NoAuth(t *testing.T) {
+	server, _ := setupTestServerWithBlobStore(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/installer/artifacts", nil)
+	rec := httptest.NewRecorder()
+
+	server.handleListInstallerArtifacts(rec, req)
+
+	assert.Equal(t, http.StatusUnauthorized, rec.Code)
+}
+
+// --- Get single ---
+
+// TestHandleGetInstallerArtifact_NotFound verifies the single-artifact endpoint returns 404
+// when the artifact does not exist.
+func TestHandleGetInstallerArtifact_NotFound(t *testing.T) {
+	server, _ := setupTestServerWithBlobStore(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/installer/artifacts/windows/amd64", nil)
+	req = withTenant(req, "test-tenant")
+	req = withVars(req, map[string]string{"platform": "windows", "arch": "amd64"})
+	rec := httptest.NewRecorder()
+
+	server.handleGetInstallerArtifact(rec, req)
+
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+}
+
+// TestHandleGetInstallerArtifact_InvalidPlatform verifies that an unknown platform returns 400.
+func TestHandleGetInstallerArtifact_InvalidPlatform(t *testing.T) {
+	server, _ := setupTestServerWithBlobStore(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/installer/artifacts/bsd/amd64", nil)
+	req = withTenant(req, "test-tenant")
+	req = withVars(req, map[string]string{"platform": "bsd", "arch": "amd64"})
+	rec := httptest.NewRecorder()
+
+	server.handleGetInstallerArtifact(rec, req)
+
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+// TestHandleGetInstallerArtifact_InvalidArch verifies that an unknown arch returns 400.
+func TestHandleGetInstallerArtifact_InvalidArch(t *testing.T) {
+	server, _ := setupTestServerWithBlobStore(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/installer/artifacts/linux/mips", nil)
+	req = withTenant(req, "test-tenant")
+	req = withVars(req, map[string]string{"platform": "linux", "arch": "mips"})
+	rec := httptest.NewRecorder()
+
+	server.handleGetInstallerArtifact(rec, req)
+
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+// TestHandleGetInstallerArtifact_NoAuth verifies that GET single without auth returns 401.
+func TestHandleGetInstallerArtifact_NoAuth(t *testing.T) {
+	server, _ := setupTestServerWithBlobStore(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/installer/artifacts/linux/amd64", nil)
+	req = withVars(req, map[string]string{"platform": "linux", "arch": "amd64"})
+	rec := httptest.NewRecorder()
+
+	server.handleGetInstallerArtifact(rec, req)
+
+	assert.Equal(t, http.StatusUnauthorized, rec.Code)
+}
+
+// --- Delete ---
+
+// TestHandleDeleteInstallerArtifact_InvalidPlatform verifies that an unknown platform returns 400.
+func TestHandleDeleteInstallerArtifact_InvalidPlatform(t *testing.T) {
+	server, _ := setupTestServerWithBlobStore(t)
+
+	req := httptest.NewRequest(http.MethodDelete, "/api/v1/installer/artifacts/bsd/amd64", nil)
+	req = withTenant(req, "test-tenant")
+	req = withVars(req, map[string]string{"platform": "bsd", "arch": "amd64"})
+	rec := httptest.NewRecorder()
+
+	server.handleDeleteInstallerArtifact(rec, req)
+
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+// TestHandleDeleteInstallerArtifact_InvalidArch verifies that an unknown arch returns 400.
+func TestHandleDeleteInstallerArtifact_InvalidArch(t *testing.T) {
+	server, _ := setupTestServerWithBlobStore(t)
+
+	req := httptest.NewRequest(http.MethodDelete, "/api/v1/installer/artifacts/linux/mips", nil)
+	req = withTenant(req, "test-tenant")
+	req = withVars(req, map[string]string{"platform": "linux", "arch": "mips"})
+	rec := httptest.NewRecorder()
+
+	server.handleDeleteInstallerArtifact(rec, req)
+
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+// TestHandleDeleteInstallerArtifact_NoAuth verifies that DELETE without auth returns 401.
+func TestHandleDeleteInstallerArtifact_NoAuth(t *testing.T) {
+	server, _ := setupTestServerWithBlobStore(t)
+
+	req := httptest.NewRequest(http.MethodDelete, "/api/v1/installer/artifacts/linux/amd64", nil)
+	req = withVars(req, map[string]string{"platform": "linux", "arch": "amd64"})
+	rec := httptest.NewRecorder()
+
+	server.handleDeleteInstallerArtifact(rec, req)
+
+	assert.Equal(t, http.StatusUnauthorized, rec.Code)
+}
+
+// --- Round-trip ---
+
+// TestInstallerArtifactRoundTrip is the REQUIRED round-trip test: upload → list → delete.
+// Uses a real filesystem BlobStore to verify the full lifecycle with durable storage.
+func TestInstallerArtifactRoundTrip(t *testing.T) {
+	server, _ := setupTestServerWithBlobStore(t)
+
+	const tenantID = "round-trip-tenant"
+	const platform = "darwin"
+	const arch = "arm64"
+	artifactContent := []byte("fake-darwin-arm64-installer-binary")
+
+	// Upload
+	uploadReq := httptest.NewRequest(http.MethodPut,
+		"/api/v1/installer/artifacts/"+platform+"/"+arch,
+		bytes.NewBuffer(artifactContent))
+	uploadReq = withTenant(uploadReq, tenantID)
+	uploadReq = withVars(uploadReq, map[string]string{"platform": platform, "arch": arch})
+	uploadRec := httptest.NewRecorder()
+
+	server.handleUploadInstallerArtifact(uploadRec, uploadReq)
+	require.Equal(t, http.StatusOK, uploadRec.Code, "upload should succeed")
+
+	var uploadResp APIResponse
+	require.NoError(t, json.Unmarshal(uploadRec.Body.Bytes(), &uploadResp))
+	uploadData, ok := uploadResp.Data.(map[string]interface{})
+	require.True(t, ok, "upload response should be an object")
+	assert.Equal(t, platform, uploadData["platform"])
+	assert.Equal(t, arch, uploadData["arch"])
+	uploadChecksum, _ := uploadData["checksum"].(string)
+	require.NotEmpty(t, uploadChecksum, "checksum must be populated")
+
+	// List
+	listReq := httptest.NewRequest(http.MethodGet, "/api/v1/installer/artifacts", nil)
+	listReq = withTenant(listReq, tenantID)
+	listRec := httptest.NewRecorder()
+
+	server.handleListInstallerArtifacts(listRec, listReq)
+	require.Equal(t, http.StatusOK, listRec.Code, "list should succeed")
+
+	var listResp APIResponse
+	require.NoError(t, json.Unmarshal(listRec.Body.Bytes(), &listResp))
+	items, ok := listResp.Data.([]interface{})
+	require.True(t, ok, "list response should be an array")
+	require.Len(t, items, 1, "expected exactly one artifact after upload")
+
+	item, ok := items[0].(map[string]interface{})
+	require.True(t, ok, "expected list element to be an object")
+	assert.Equal(t, platform, item["platform"])
+	assert.Equal(t, arch, item["arch"])
+	assert.Equal(t, uploadChecksum, item["checksum"])
+
+	// Get single
+	getReq := httptest.NewRequest(http.MethodGet,
+		"/api/v1/installer/artifacts/"+platform+"/"+arch, nil)
+	getReq = withTenant(getReq, tenantID)
+	getReq = withVars(getReq, map[string]string{"platform": platform, "arch": arch})
+	getRec := httptest.NewRecorder()
+
+	server.handleGetInstallerArtifact(getRec, getReq)
+	require.Equal(t, http.StatusOK, getRec.Code, "get single should succeed")
+
+	var getResp APIResponse
+	require.NoError(t, json.Unmarshal(getRec.Body.Bytes(), &getResp))
+	getItem, ok := getResp.Data.(map[string]interface{})
+	require.True(t, ok, "get single response should be an object")
+	assert.Equal(t, platform, getItem["platform"])
+	assert.Equal(t, arch, getItem["arch"])
+	assert.Equal(t, uploadChecksum, getItem["checksum"])
+
+	// Delete
+	delReq := httptest.NewRequest(http.MethodDelete,
+		"/api/v1/installer/artifacts/"+platform+"/"+arch, nil)
+	delReq = withTenant(delReq, tenantID)
+	delReq = withVars(delReq, map[string]string{"platform": platform, "arch": arch})
+	delRec := httptest.NewRecorder()
+
+	server.handleDeleteInstallerArtifact(delRec, delReq)
+	require.Equal(t, http.StatusNoContent, delRec.Code, "delete should return 204")
+
+	// Verify list is empty after delete
+	listAfterReq := httptest.NewRequest(http.MethodGet, "/api/v1/installer/artifacts", nil)
+	listAfterReq = withTenant(listAfterReq, tenantID)
+	listAfterRec := httptest.NewRecorder()
+
+	server.handleListInstallerArtifacts(listAfterRec, listAfterReq)
+	require.Equal(t, http.StatusOK, listAfterRec.Code)
+
+	var listAfterResp APIResponse
+	require.NoError(t, json.Unmarshal(listAfterRec.Body.Bytes(), &listAfterResp))
+	afterItems, ok := listAfterResp.Data.([]interface{})
+	require.True(t, ok)
+	assert.Empty(t, afterItems, "list should be empty after delete")
+
+	// Get after delete should return 404
+	getAfterReq := httptest.NewRequest(http.MethodGet,
+		"/api/v1/installer/artifacts/"+platform+"/"+arch, nil)
+	getAfterReq = withTenant(getAfterReq, tenantID)
+	getAfterReq = withVars(getAfterReq, map[string]string{"platform": platform, "arch": arch})
+	getAfterRec := httptest.NewRecorder()
+
+	server.handleGetInstallerArtifact(getAfterRec, getAfterReq)
+	assert.Equal(t, http.StatusNotFound, getAfterRec.Code, "get after delete should return 404")
+}
+
+// TestInstallerArtifactTenantIsolation verifies that tenants cannot see each other's artifacts.
+func TestInstallerArtifactTenantIsolation(t *testing.T) {
+	server, _ := setupTestServerWithBlobStore(t)
+
+	// Upload for tenant-a
+	uploadReq := httptest.NewRequest(http.MethodPut,
+		"/api/v1/installer/artifacts/linux/amd64",
+		bytes.NewBufferString("tenant-a-content"))
+	uploadReq = withTenant(uploadReq, "tenant-a")
+	uploadReq = withVars(uploadReq, map[string]string{"platform": "linux", "arch": "amd64"})
+	uploadRec := httptest.NewRecorder()
+	server.handleUploadInstallerArtifact(uploadRec, uploadReq)
+	require.Equal(t, http.StatusOK, uploadRec.Code)
+
+	// List as tenant-b — should see nothing
+	listReq := httptest.NewRequest(http.MethodGet, "/api/v1/installer/artifacts", nil)
+	listReq = withTenant(listReq, "tenant-b")
+	listRec := httptest.NewRecorder()
+	server.handleListInstallerArtifacts(listRec, listReq)
+	require.Equal(t, http.StatusOK, listRec.Code)
+
+	var resp APIResponse
+	require.NoError(t, json.Unmarshal(listRec.Body.Bytes(), &resp))
+	items, ok := resp.Data.([]interface{})
+	require.True(t, ok, "expected array in Data")
+	assert.Empty(t, items, "tenant-b must not see tenant-a's artifacts")
+}
+
+// TestInstallerArtifactRouterPermissions verifies that the installer routes enforce permissions
+// via the full router + auth middleware.
+func TestInstallerArtifactRouterPermissions(t *testing.T) {
+	server, _ := setupTestServerWithBlobStore(t)
+
+	// Generate a key with installer:upload permission.
+	uploadKey := NewEphemeralTestKey(t, server, []string{"installer:upload"}, "test-tenant", 5*time.Minute)
+
+	body := bytes.NewBufferString("test content")
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/installer/artifacts/linux/amd64", body)
+	req.Header.Set("X-API-Key", uploadKey)
+	rec := httptest.NewRecorder()
+	server.router.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code,
+		"installer:upload key should be allowed to PUT an artifact")
+}
+
+// TestInstallerArtifactRouterForbiddenWithoutPermission verifies that a key without
+// installer:upload cannot upload an artifact.
+func TestInstallerArtifactRouterForbiddenWithoutPermission(t *testing.T) {
+	server, _ := setupTestServerWithBlobStore(t)
+
+	// Generate a key with read-only permission — no installer:upload.
+	readKey := NewEphemeralTestKey(t, server, []string{"installer:read"}, "test-tenant", 5*time.Minute)
+
+	body := bytes.NewBufferString("test content")
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/installer/artifacts/linux/amd64", body)
+	req.Header.Set("X-API-Key", readKey)
+	rec := httptest.NewRecorder()
+	server.router.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusForbidden, rec.Code,
+		"installer:read key must not be allowed to PUT an artifact")
+}
+
+// TestInstallerArtifactRouterDeletePermission verifies that DELETE enforces installer:delete
+// via the full router + auth middleware stack.
+func TestInstallerArtifactRouterDeletePermission(t *testing.T) {
+	server, _ := setupTestServerWithBlobStore(t)
+
+	// A key with only installer:read must not be allowed to DELETE.
+	readKey := NewEphemeralTestKey(t, server, []string{"installer:read"}, "test-tenant", 5*time.Minute)
+	req := httptest.NewRequest(http.MethodDelete, "/api/v1/installer/artifacts/linux/amd64", nil)
+	req.Header.Set("X-API-Key", readKey)
+	rec := httptest.NewRecorder()
+	server.router.ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusForbidden, rec.Code,
+		"installer:read key must not be allowed to DELETE an artifact")
+
+	// A key with installer:delete must be allowed to DELETE (returns 204 — artifact absent is fine).
+	deleteKey := NewEphemeralTestKey(t, server, []string{"installer:delete"}, "test-tenant", 5*time.Minute)
+	req2 := httptest.NewRequest(http.MethodDelete, "/api/v1/installer/artifacts/linux/amd64", nil)
+	req2.Header.Set("X-API-Key", deleteKey)
+	rec2 := httptest.NewRecorder()
+	server.router.ServeHTTP(rec2, req2)
+	assert.Equal(t, http.StatusNoContent, rec2.Code,
+		"installer:delete key must be allowed to DELETE an artifact")
+}

--- a/features/controller/api/handlers_push_test.go
+++ b/features/controller/api/handlers_push_test.go
@@ -96,6 +96,7 @@ func setupPushServer(t *testing.T) (*Server, *audit.Manager) {
 		auditMgr,
 		nil, // No command publisher: fanout is out of scope for push handler unit tests
 		nil, // No push store for audit-only push tests
+		nil, // No blob store needed
 	)
 	require.NoError(t, err)
 	t.Cleanup(func() {
@@ -457,6 +458,7 @@ func TestHandleConfigPush_PersistenceRecord(t *testing.T) {
 		auditMgr,
 		nil,       // No command publisher: goroutine never runs, record stays in_progress
 		pushStore, // Wire real push store
+		nil,       // No blob store needed
 	)
 	require.NoError(t, err)
 	t.Cleanup(func() {
@@ -554,6 +556,7 @@ func makePushServerWithStore(t *testing.T, cp controlplaneInterfaces.ControlPlan
 		auditMgr,
 		pub,       // real command publisher
 		pushStore, // real push store
+		nil,       // No blob store needed
 	)
 	require.NoError(t, err)
 	t.Cleanup(func() {

--- a/features/controller/api/handlers_registration_test.go
+++ b/features/controller/api/handlers_registration_test.go
@@ -98,6 +98,7 @@ func newHandleRegisterServer(t *testing.T, tokenStore registration.Store, certMg
 		auditMgr,
 		nil, // No command publisher for basic tests
 		nil, // No push store for basic tests
+		nil, // No blob store for basic tests
 	)
 	require.NoError(t, err)
 	t.Cleanup(func() {

--- a/features/controller/api/handlers_registration_tokens_test.go
+++ b/features/controller/api/handlers_registration_tokens_test.go
@@ -102,6 +102,7 @@ func setupTestServerWithTokenStore(t *testing.T) (*Server, registration.Store) {
 		auditMgr, // Issue #775: registration audit events
 		nil,      // No command publisher for basic tests
 		nil,      // No push store for basic tests
+		nil,      // No blob store for basic tests
 	)
 	require.NoError(t, err)
 	t.Cleanup(func() {

--- a/features/controller/api/middleware_test.go
+++ b/features/controller/api/middleware_test.go
@@ -668,7 +668,7 @@ func setupTestServerWithCertMgr(t *testing.T, certManager *cert.Manager) *Server
 		cfg, logging.NewNoopLogger(),
 		controllerService, configService,
 		nil, rbacService, certManager, tenantManager, rbacManager,
-		nil, nil, nil, "", nil, auditMgr, nil, nil,
+		nil, nil, nil, "", nil, auditMgr, nil, nil, nil,
 	)
 	require.NoError(t, err)
 	t.Cleanup(func() {

--- a/features/controller/api/permissions.go
+++ b/features/controller/api/permissions.go
@@ -68,6 +68,10 @@ var knownPermissions = map[string]bool{
 	"tenant:manage": true,
 	// Script library administration (Issue #1670)
 	"script:admin": true,
+	// Installer artifact management (Issue #1702)
+	"installer:upload": true,
+	"installer:read":   true,
+	"installer:delete": true,
 }
 
 // isKnownPermission reports whether p is a recognized permission ID.

--- a/features/controller/api/providers_test.go
+++ b/features/controller/api/providers_test.go
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+// Package api test-only provider registrations.
+// The blank import triggers init() to register the filesystem blob provider so that
+// handlers_installer_test.go can use blob.CreateBlobStoreFromConfig("filesystem", ...).
+package api
+
+import (
+	_ "github.com/cfgis/cfgms/pkg/storage/providers/blobstore/filesystem" // register filesystem blob provider for installer tests
+)

--- a/features/controller/api/server.go
+++ b/features/controller/api/server.go
@@ -38,6 +38,7 @@ import (
 	"github.com/cfgis/cfgms/pkg/registration"
 	secretsif "github.com/cfgis/cfgms/pkg/secrets/interfaces"
 	_ "github.com/cfgis/cfgms/pkg/secrets/providers/sops" // Auto-register SOPS provider
+	blob "github.com/cfgis/cfgms/pkg/storage/interfaces/blob"
 	business "github.com/cfgis/cfgms/pkg/storage/interfaces/business"
 	cfgconfig "github.com/cfgis/cfgms/pkg/storage/interfaces/config"
 	"github.com/cfgis/cfgms/pkg/transport/registry"
@@ -90,6 +91,7 @@ type Server struct {
 	runManager              *controllerrun.Manager            // Issue #1673: run/job/execution model
 	runExecutionQueue       *script.ExecutionQueue            // Issue #1673: queue for ad-hoc run synthesis
 	trustedProxies          []net.IPNet                       // Issue #1695: parsed from TrustedProxies config; XFF honored only when peer is in this list
+	blobStore               blob.BlobStore                    // Issue #1702: installer artifact storage
 	stopCleanup             chan struct{}                     // signals startAPIKeyCleanup to exit
 	cleanupDone             chan struct{}                     // closed when cleanup goroutine exits
 	closeOnce               sync.Once                         // idempotent Close
@@ -138,6 +140,7 @@ func New(
 	auditManager *audit.Manager, // Issue #775: registration audit events
 	commandPublisher *commands.Publisher, // Issue #1319: fan-out config push to active stewards
 	pushStore business.PushStore, // Issue #1320: durable push-state persistence for HA failover
+	blobStore blob.BlobStore, // Issue #1702: installer artifact storage
 ) (*Server, error) {
 	if cfg == nil {
 		return nil, fmt.Errorf("config cannot be nil")
@@ -186,6 +189,7 @@ func New(
 		auditManager:            auditManager,             // Issue #775: registration audit events
 		commandPublisher:        commandPublisher,         // Issue #1319: fan-out config push to active stewards
 		pushStore:               pushStore,                // Issue #1320: durable push-state persistence for HA failover
+		blobStore:               blobStore,                // Issue #1702: installer artifact storage
 		stopCleanup:             make(chan struct{}),
 		cleanupDone:             make(chan struct{}),
 	}
@@ -450,6 +454,14 @@ func (s *Server) setupRouter() {
 	tenants := api.PathPrefix("/tenants").Subrouter()
 	tenants.Handle("/{id}/config-source/test",
 		s.requirePermission("tenant", "manage")(http.HandlerFunc(s.handleConfigSourceTest))).Methods("POST")
+
+	// Installer artifact management endpoints (Issue #1702).
+	// Always registered — handlers return 503 when blobStore is nil (nil-safe by design).
+	installer := api.PathPrefix("/installer/artifacts").Subrouter()
+	installer.Handle("", s.requirePermission("installer", "read")(http.HandlerFunc(s.handleListInstallerArtifacts))).Methods("GET")
+	installer.Handle("/{platform}/{arch}", s.requirePermission("installer", "upload")(http.HandlerFunc(s.handleUploadInstallerArtifact))).Methods("PUT")
+	installer.Handle("/{platform}/{arch}", s.requirePermission("installer", "read")(http.HandlerFunc(s.handleGetInstallerArtifact))).Methods("GET")
+	installer.Handle("/{platform}/{arch}", s.requirePermission("installer", "delete")(http.HandlerFunc(s.handleDeleteInstallerArtifact))).Methods("DELETE")
 
 	// Ad-hoc run endpoints (Issue #1673). Always registered — returns 503 when
 	// run manager is not wired (transport-disabled deployments).

--- a/features/controller/api/server_test.go
+++ b/features/controller/api/server_test.go
@@ -130,6 +130,7 @@ func setupTestServer(t *testing.T) *Server {
 		auditMgr, // Issue #775: registration audit events
 		nil,      // No command publisher for basic tests
 		nil,      // No push store for basic tests
+		nil,      // No blob store for basic tests
 	)
 	require.NoError(t, err)
 	t.Cleanup(func() {
@@ -928,6 +929,7 @@ func setupTestServerWithLogger(t *testing.T, logger logging.Logger) *Server {
 		nil, nil, nil, "", nil, auditMgr,
 		nil, // No command publisher for basic tests
 		nil, // No push store for basic tests
+		nil, // No blob store for basic tests
 	)
 	require.NoError(t, err)
 	t.Cleanup(func() {
@@ -1370,7 +1372,7 @@ func setupServerWithPublisher(t *testing.T, cp *testControlPlane) (*Server, *ser
 
 	server, err := New(
 		cfg, logger, controllerSvc, configSvc, nil, rbacSvc,
-		nil, tenantMgr, rbacMgr, nil, nil, nil, "", nil, auditMgr, publisher, nil,
+		nil, tenantMgr, rbacMgr, nil, nil, nil, "", nil, auditMgr, publisher, nil, nil,
 	)
 	require.NoError(t, err)
 	t.Cleanup(func() {

--- a/features/controller/config/config.go
+++ b/features/controller/config/config.go
@@ -5,6 +5,7 @@ package config
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"regexp"
 	"strconv"
 	"time"
@@ -66,6 +67,13 @@ func expandEnvWithDefaults(content string) string {
 	return os.ExpandEnv(result)
 }
 
+// BlobStorageConfig holds configuration for the blob storage backend (Issue #1702).
+type BlobStorageConfig struct {
+	// Root is the filesystem directory where installer artifacts are stored.
+	// Defaults to <DataDir>/installers when not explicitly set.
+	Root string `yaml:"root"`
+}
+
 // Config holds the controller configuration
 type Config struct {
 	// Controller listen address
@@ -104,6 +112,9 @@ type Config struct {
 	// Default: /etc/cfgms/admin.bundle.yaml (Linux) or %ProgramData%\cfgms\admin.bundle.yaml (Windows).
 	// Mode 0600, daemon-user-owned. Contains the admin mTLS cert, key, CA, and controller URL.
 	AdminBundlePath string `yaml:"admin_bundle_path,omitempty"`
+
+	// BlobStorage configures the blob storage backend for installer artifacts (Issue #1702).
+	BlobStorage BlobStorageConfig `yaml:"blob_storage,omitempty"`
 }
 
 // RegistrationConfig holds registration approval workflow settings.
@@ -399,7 +410,7 @@ func (t *TransportConfig) Validate() error {
 
 // DefaultConfig returns a Config with reasonable defaults
 func DefaultConfig() *Config {
-	return &Config{
+	cfg := &Config{
 		ListenAddr:  "127.0.0.1:8080",
 		ExternalURL: "https://localhost:8080", // Default external URL
 		CertPath:    "certs/",
@@ -454,6 +465,8 @@ func DefaultConfig() *Config {
 			IdleTimeout:     Duration(5 * time.Minute),
 		},
 	}
+	cfg.BlobStorage.Root = filepath.Join(cfg.DataDir, "installers")
+	return cfg
 }
 
 // findConfigFile searches for the controller configuration file using the following priority:

--- a/features/controller/server/server.go
+++ b/features/controller/server/server.go
@@ -61,10 +61,12 @@ import (
 	"github.com/cfgis/cfgms/pkg/logging"
 	pkgRegistration "github.com/cfgis/cfgms/pkg/registration"
 	"github.com/cfgis/cfgms/pkg/storage/interfaces"
+	blob "github.com/cfgis/cfgms/pkg/storage/interfaces/blob"
 	business "github.com/cfgis/cfgms/pkg/storage/interfaces/business"
 	cfgconfig "github.com/cfgis/cfgms/pkg/storage/interfaces/config"
-	_ "github.com/cfgis/cfgms/pkg/storage/providers/flatfile" // register flatfile provider for OSS composite manager
-	_ "github.com/cfgis/cfgms/pkg/storage/providers/sqlite"   // register sqlite provider for OSS composite manager
+	_ "github.com/cfgis/cfgms/pkg/storage/providers/blobstore/filesystem" // register filesystem blob provider (Issue #1702)
+	_ "github.com/cfgis/cfgms/pkg/storage/providers/flatfile"             // register flatfile provider for OSS composite manager
+	_ "github.com/cfgis/cfgms/pkg/storage/providers/sqlite"               // register sqlite provider for OSS composite manager
 	quictransport "github.com/cfgis/cfgms/pkg/transport/quic"
 	"github.com/cfgis/cfgms/pkg/transport/registry"
 	"gopkg.in/yaml.v3"
@@ -643,6 +645,24 @@ func New(cfg *config.Config, logger logging.Logger) (*Server, error) {
 		logger.Info("Health collectors initialized (Story #417)")
 	}
 
+	// Initialize installer artifact blob store (Issue #1702).
+	// Default BlobStorage.Root when not explicitly configured (e.g. in tests or
+	// minimal configs that rely on the storage path for co-location).
+	blobRoot := cfg.BlobStorage.Root
+	if blobRoot == "" {
+		if cfg.Storage.FlatfileRoot != "" {
+			blobRoot = filepath.Join(filepath.Dir(cfg.Storage.FlatfileRoot), "installers")
+		} else if cfg.Storage.SQLitePath != "" {
+			blobRoot = filepath.Join(filepath.Dir(cfg.Storage.SQLitePath), "installers")
+		}
+	}
+	installerBlobStore, blobErr := blob.CreateBlobStoreFromConfig("filesystem",
+		map[string]interface{}{"root": blobRoot})
+	if blobErr != nil {
+		return nil, fmt.Errorf("failed to initialize installer blob store: %w", blobErr)
+	}
+	logger.Info("Installer artifact blob store initialized", "root", blobRoot)
+
 	// Initialize HTTP API server
 	httpServer, err := api.New(
 		cfg,
@@ -662,6 +682,7 @@ func New(cfg *config.Config, logger logging.Logger) (*Server, error) {
 		auditManager,                  // Issue #775: registration audit events
 		commandPublisher,              // Issue #1319: fan-out config push to active stewards
 		storageManager.GetPushStore(), // Issue #1320: durable push-state for HA failover
+		installerBlobStore,            // Issue #1702: installer artifact storage
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize HTTP API server: %w", err)


### PR DESCRIPTION
## Summary

- Adds PUT/GET-list/GET-single/DELETE endpoints under `/api/v1/installer/artifacts/{platform}/{arch}` for managing pre-built steward installer artifacts per (platform, arch) tuple
- Artifacts stored via pluggable BlobStore (filesystem provider) with BlobKey `{TenantID, Namespace:"installers", Name:"<platform>-<arch>"}`
- Three new permissions: `installer:upload`, `installer:read`, `installer:delete`; config field `BlobStorageConfig.Root` defaults to `<DataDir>/installers`

Fixes #1702

## Specialist Review Results

| Reviewer | Verdict | Notes |
|---|---|---|
| qa-test-runner | **PASS** | All 100+ packages pass; 5 cross-platform builds pass; fixed empty BlobStorage.Root fallback + gofmt |
| qa-code-reviewer | **PASS** | 3 blocking issues found and fixed: nil-guard on blobStore (503 pattern), missing `_NoAuth` test for GET-single, discarded type-assertion in isolation test |
| security-engineer | **PASS** | 0 blocking issues; path traversal not exploitable (allow-list + filesystem provider defense-in-depth); tenant isolation verified |

## Test plan

- [x] `TestInstallerArtifactRoundTrip` — upload → list → get-single → delete → 404 (real filesystem BlobStore)
- [x] `TestInstallerArtifactTenantIsolation` — tenant-b cannot see tenant-a artifacts
- [x] `TestInstallerArtifactRouterPermissions` — `installer:upload` key allowed on PUT
- [x] `TestInstallerArtifactRouterForbiddenWithoutPermission` — `installer:read` key rejected on PUT (403)
- [x] `TestInstallerArtifactRouterDeletePermission` — `installer:delete` enforced via full router
- [x] All `_InvalidPlatform`, `_InvalidArch`, `_NoAuth` tests for each handler (400/401)
- [x] `go test ./features/controller/api/... ./features/controller/config/... ./features/controller/server/...` — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)