### PR TITLE
build(containers): add HEALTHCHECK and --no-install-recommends to Dockerfiles (Item #BX5ezzgt5rbQ)

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -25,7 +25,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # Node.js 22 (required by Claude Code — Debian Bookworm ships Node 18 which
 # lacks Array.with() and other APIs used since Claude Code 2.1.79)
 RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
-    && apt-get install -y nodejs \
+    && apt-get install -y --no-install-recommends nodejs \
     && rm -rf /var/lib/apt/lists/*
 
 # GitHub CLI
@@ -33,7 +33,7 @@ RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
       | gpg --dearmor -o /usr/share/keyrings/githubcli-archive-keyring.gpg \
     && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
       > /etc/apt/sources.list.d/github-cli.list \
-    && apt-get update && apt-get install -y gh \
+    && apt-get update && apt-get install -y --no-install-recommends gh \
     && rm -rf /var/lib/apt/lists/*
 
 # Go-based security and quality tools
@@ -108,6 +108,10 @@ ENV CFGMS_AGENT_MODE=true
 ENV TRIVY_CACHE_DIR=/home/agent/.cache/trivy
 ENV GOMODCACHE=/home/agent/go/pkg/mod
 ENV GOFLAGS=-modcacherw
+
+# Not a long-running service; health checks are not applicable for on-demand
+# agent containers. HEALTHCHECK NONE suppresses the Trivy DS-0026 advisory.
+HEALTHCHECK NONE
 
 USER agent
 WORKDIR /workspace

--- a/Dockerfile.test-runner
+++ b/Dockerfile.test-runner
@@ -32,6 +32,10 @@ ENV CFGMS_TEST_HTTP_ADDR="https://controller-standalone:9080" \
     CFGMS_TEST_MQTT_ADDR="ssl://controller-standalone:8883" \
     CFGMS_TEST_QUIC_ADDR="controller-standalone:4433"
 
+# Not a long-running service; this container is used as a CI test harness
+# and exits after running the test suite. HEALTHCHECK NONE is intentional.
+HEALTHCHECK NONE
+
 # Switch to non-root user
 # Note: Docker socket access is granted at runtime via --group-add flag
 USER testuser

--- a/cmd/steward/Dockerfile.debian
+++ b/cmd/steward/Dockerfile.debian
@@ -53,6 +53,10 @@ RUN mkdir -p /var/lib/cfgms/steward/certs
 # Change ownership
 RUN chown -R cfgms:cfgms /app /var/lib/cfgms
 
+# Steward is a long-running daemon. pgrep is available via procps (installed above).
+HEALTHCHECK --interval=30s --timeout=10s --start-period=30s --retries=3 \
+    CMD pgrep -x steward || exit 1
+
 # Switch to non-root user
 USER cfgms
 


### PR DESCRIPTION
Fixes #0

## Summary

- Adds `HEALTHCHECK NONE` to `.devcontainer/Dockerfile` and `Dockerfile.test-runner` (non-service containers; suppresses Trivy DS-0026 with justification comment)
- Adds `HEALTHCHECK --interval=30s --timeout=10s --start-period=30s --retries=3 CMD pgrep -x steward || exit 1` to `cmd/steward/Dockerfile.debian` (long-running daemon)
- Adds `--no-install-recommends` to the nodejs and gh `apt-get install` steps in `.devcontainer/Dockerfile` that were missing the flag (fixes Trivy DS-0029)

Resolves Trivy DS-0026 and DS-0029 alerts for the three Dockerfiles in scope. Part of epic #1801 (clean up pre-existing GHAS code-scanning alerts on develop).

## Specialist Review Results

| Reviewer | Result | Notes |
|---|---|---|
| QA Test Runner | PASS | All unit/integration tests, linting, cross-platform builds pass; Trivy 0 misconfigs on modified files |
| QA Code Reviewer | PASS | No blocking issues; 2 informational warnings about unchanged out-of-scope files |
| Security Engineer | PASS | All automated scans clean (security-precommit, check-architecture, security-scan); no new vulnerabilities introduced |

## Test plan

- [ ] `make test-agent-complete` passes (validated by QA test runner above)
- [ ] Trivy filesystem scan shows 0 DS-0026 / DS-0029 findings for the three modified files (validated by QA test runner — Trivy 0 misconfigs reported)
- [ ] Build Gate CI job confirms `docker build` succeeds for all three Dockerfiles

🤖 Generated with [Claude Code](https://claude.com/claude-code)