### PR TITLE
ci: add persist-credentials:false and fix action SHA-pin issues (Item #BX5ezzgt5raU)

### DIFF
--- a/.github/actions/sign-scripts/action.yml
+++ b/.github/actions/sign-scripts/action.yml
@@ -156,7 +156,12 @@ runs:
         $cfgBin = Join-Path $env:RUNNER_TEMP 'cfg.exe'
         Write-Host "Downloading cfg from $url"
         Invoke-WebRequest -Uri $url -OutFile $cfgBin -UseBasicParsing
-        # Add RUNNER_TEMP to PATH for subsequent steps
+        # zizmor: ignore[dangerous-environment-file]
+        # RUNNER_TEMP is a GitHub Actions runner-provided environment variable; it is
+        # not influenced by repository content or pull-request authors. Writing it to
+        # GITHUB_PATH adds the runner's temp directory to PATH so that the cfg binary
+        # downloaded in this step is discoverable by subsequent sign steps. No
+        # user-controlled data flows into this write.
         "$env:RUNNER_TEMP" | Out-File -FilePath $env:GITHUB_PATH -Append -Encoding utf8
         & $cfgBin version
 

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -104,7 +104,7 @@ jobs:
     # run that workflow manually with `--ref <branch>` before re-running
     # this one.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@9e0d7b8d25671d64c341c19c0152d693099fb5ba # v4
+      uses: github/codeql-action/init@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4
       with:
         languages: ${{ matrix.language }}
         config-file: ./.github/codeql/codeql-config.yml
@@ -127,7 +127,7 @@ jobs:
 
     # Perform CodeQL Analysis
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@9e0d7b8d25671d64c341c19c0152d693099fb5ba # v4
+      uses: github/codeql-action/analyze@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4
       with:
         category: "/language:${{ matrix.language }}"
         # Upload results to GitHub Security tab (SARIF format)

--- a/.github/workflows/cross-platform-build.yml
+++ b/.github/workflows/cross-platform-build.yml
@@ -30,6 +30,8 @@ jobs:
     timeout-minutes: 15
     steps:
     - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      with:
+        persist-credentials: false
 
     - name: Set up Go
       uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
@@ -78,6 +80,8 @@ jobs:
     timeout-minutes: 30
     steps:
     - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      with:
+        persist-credentials: false
 
     - name: Set up Go
       uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
@@ -113,6 +117,8 @@ jobs:
     timeout-minutes: 30
     steps:
     - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      with:
+        persist-credentials: false
 
     - name: Set up Go
       uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5

--- a/.github/workflows/dependency-pin-check.yml
+++ b/.github/workflows/dependency-pin-check.yml
@@ -34,6 +34,8 @@ jobs:
       contents: read
     steps:
     - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      with:
+        persist-credentials: false
     - name: Scan for known-compromised trivy versions
       run: |
         # Match v0.69.4 / v0.69.5 / v0.69.6 (plus pre-release suffixes like
@@ -66,6 +68,8 @@ jobs:
       issues: write
     steps:
     - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      with:
+        persist-credentials: false
     - name: Check for outdated pinned tools
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/develop-sanity.yml
+++ b/.github/workflows/develop-sanity.yml
@@ -19,6 +19,8 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Set up Go
         uses: actions/setup-go@7b8cf10d4e4a01d4992d18a89f4d7dc5a3e6d6f4 # v4

--- a/.github/workflows/docker-security.yml
+++ b/.github/workflows/docker-security.yml
@@ -48,6 +48,8 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      with:
+        persist-credentials: false
 
     - name: Install Trivy (cached)
       uses: aquasecurity/setup-trivy@3fb12ec12f41e471780db15c232d5dd185dcb514 # v0.2.6 — pinned to SHA per CVE-2026-33634
@@ -93,7 +95,7 @@ jobs:
         skip-setup-trivy: true
 
     - name: Upload Trivy results to GitHub Security tab
-      uses: github/codeql-action/upload-sarif@9e0d7b8d25671d64c341c19c0152d693099fb5ba # v4
+      uses: github/codeql-action/upload-sarif@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4
       if: always()
       with:
         sarif_file: 'trivy-controller-results.sarif'
@@ -135,6 +137,8 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      with:
+        persist-credentials: false
 
     - name: Install Trivy (cached)
       uses: aquasecurity/setup-trivy@3fb12ec12f41e471780db15c232d5dd185dcb514 # v0.2.6 — pinned to SHA per CVE-2026-33634
@@ -180,7 +184,7 @@ jobs:
         skip-setup-trivy: true
 
     - name: Upload Trivy results to GitHub Security tab
-      uses: github/codeql-action/upload-sarif@9e0d7b8d25671d64c341c19c0152d693099fb5ba # v4
+      uses: github/codeql-action/upload-sarif@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4
       if: always()
       with:
         sarif_file: 'trivy-steward-results.sarif'

--- a/.github/workflows/label-decommission-gate.yml
+++ b/.github/workflows/label-decommission-gate.yml
@@ -11,7 +11,9 @@ jobs:
     name: No pipeline/agent label references in executable code
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Assert zero executable label references
         run: |

--- a/.github/workflows/production-gates.yml
+++ b/.github/workflows/production-gates.yml
@@ -46,7 +46,9 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-    
+      with:
+        persist-credentials: false
+
     - name: Set up Go
       uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
       with:
@@ -280,6 +282,8 @@ jobs:
     if: github.ref == 'refs/heads/main'
     steps:
     - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      with:
+        persist-credentials: false
 
     - name: Set up Go
       uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
@@ -416,6 +420,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      with:
+        persist-credentials: false
 
     - name: Set up Go
       uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
@@ -503,7 +509,9 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-    
+      with:
+        persist-credentials: false
+
     - name: Set up Go
       uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
       with:
@@ -556,7 +564,9 @@ jobs:
     needs: [integration-tests-controller]
     steps:
     - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-    
+      with:
+        persist-credentials: false
+
     - name: Set up Go
       uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
       with:
@@ -766,7 +776,9 @@ jobs:
     needs: [integration-tests-controller, integration-tests-steward]
     steps:
     - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-    
+      with:
+        persist-credentials: false
+
     - name: Set up Go
       uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
       with:

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -48,7 +48,9 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-    
+      with:
+        persist-credentials: false
+
     - name: Install Trivy
       env:
         # Trivy v0.69.4-v0.69.6 are compromised (CVE-2026-33634); v0.70.0 is
@@ -79,7 +81,7 @@ jobs:
         fi
     
     - name: Upload Trivy SARIF
-      uses: github/codeql-action/upload-sarif@9e0d7b8d25671d64c341c19c0152d693099fb5ba # v4
+      uses: github/codeql-action/upload-sarif@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4
       if: always() && hashFiles('sarif-results/trivy.sarif') != ''
       with:
         sarif_file: sarif-results/trivy.sarif
@@ -105,12 +107,14 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-    
+      with:
+        persist-credentials: false
+
     - name: Set up Go
       uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
       with:
         go-version: ${{ env.GO_VERSION }}
-    
+
     # Cache disabled due to parallel job conflicts causing tar extraction failures
     # - name: Cache Go modules
     #   uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c # v3
@@ -121,7 +125,7 @@ jobs:
     #       ${{ runner.os }}-go-modules-
     #       ${{ runner.os }}-nancy-
     #   continue-on-error: true
-    
+
     - name: Install Nancy
       run: make install-nancy
     
@@ -149,6 +153,8 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      with:
+        persist-credentials: false
 
     - name: Set up Go
       uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
@@ -165,7 +171,7 @@ jobs:
     #       ${{ runner.os }}-go-modules-
     #       ${{ runner.os }}-gosec-
     #   continue-on-error: true
-    
+
     - name: Install gosec
       run: go install github.com/securego/gosec/v2/cmd/gosec@v2.26.1
     
@@ -200,7 +206,7 @@ jobs:
     # configuration, and results are still available via workflow artifacts.
     #
     # - name: Upload gosec SARIF
-    #   uses: github/codeql-action/upload-sarif@9e0d7b8d25671d64c341c19c0152d693099fb5ba # v4
+    #   uses: github/codeql-action/upload-sarif@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4
     #   if: always() && hashFiles('sarif-results/gosec.sarif') != ''
     #   with:
     #     sarif_file: sarif-results/gosec.sarif
@@ -226,12 +232,14 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-    
+      with:
+        persist-credentials: false
+
     - name: Set up Go
       uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
       with:
         go-version: ${{ env.GO_VERSION }}
-    
+
     # Cache disabled due to parallel job conflicts causing tar extraction failures
     # - name: Cache Go modules
     #   uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c # v3
@@ -242,7 +250,7 @@ jobs:
     #       ${{ runner.os }}-go-modules-
     #       ${{ runner.os }}-staticcheck-
     #   continue-on-error: true
-    
+
     - name: Install staticcheck
       run: go install honnef.co/go/tools/cmd/staticcheck@2026.1
     
@@ -276,12 +284,14 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      with:
+        persist-credentials: false
 
     - name: Set up Go
       uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
       with:
         go-version: ${{ env.GO_VERSION }}
-    
+
     - name: Security Summary
       id: summary
       run: |


### PR DESCRIPTION
## Summary

- **Category A**: Added `persist-credentials: false` to all `actions/checkout` steps in 7 workflow files (cross-platform-build.yml ×3, dependency-pin-check.yml ×2, develop-sanity.yml ×1, label-decommission-gate.yml ×1, production-gates.yml ×6, docker-security.yml ×2, security-scan.yml ×5). Prevents GITHUB_TOKEN from being persisted into `.git/config` where subsequent steps could read it.
- **Category B**: Updated `github/codeql-action` SHA from `9e0d7b8d25671d64c341c19c0152d693099fb5ba` (v4 from Feb 2025) to `7211b7c8077ea37d8641b6271f6a365a22a5fbfa` (current v4, verified via GitHub API) in codeql-analysis.yml, docker-security.yml, and security-scan.yml. All other pinned SHAs verified correct against their version comments (see below).
- **Category C**: Replaced floating `actions/checkout@v4` tag in label-decommission-gate.yml with SHA-pinned form + `persist-credentials: false`.
- **Category D**: Added `# zizmor: ignore[dangerous-environment-file]` annotation with written justification in sign-scripts/action.yml — `$RUNNER_TEMP` is runner-provided and not user-controlled.

**`codeql-analysis.yml` intentionally excluded from Category A**: its workflow-level `permissions: {}` means zizmor does not generate an `artipacked` alert for its checkout step.

## Category B SHA Verification

All SHAs verified against version comments via `gh api repos/<owner>/<repo>/git/ref/tags/<version>`:

| Action | Version comment | SHA in file | Verified |
|--------|----------------|-------------|----------|
| `actions/checkout` | `# v5` | `93cb6efe18208431cddfb8368fd83d5badbf9bfd` | ✅ matches v5 tag (commit) |
| `actions/setup-go` | `# v6` | `4a3601121dd01d1626a1e23e37211e3254c1c06c` | ✅ matches v6 tag (commit) |
| `actions/cache` | `# v5` | `27d5ce7f107fe9357f9df03efb73ab90386fccae` | ✅ matches v5 tag (commit) |
| `actions/upload-artifact` | `# v6` | `b7c566a772e6b6bfb58ed0dc250532a479d7789f` | ✅ matches v6 tag (commit) |
| `aquasecurity/trivy-action` | `# v0.35.0` | `57a97c7e7821a5776cebc9bb87c984fa69cba8f1` | ✅ matches v0.35.0 tag (commit) |
| `github/codeql-action/init` | `# v4` | `9e0d7b8d...` → **`7211b7c8077ea37d8641b6271f6a365a22a5fbfa`** | 🔧 Fixed (was stale v4 commit) |
| `github/codeql-action/analyze` | `# v4` | `9e0d7b8d...` → **`7211b7c8...`** | 🔧 Fixed |
| `github/codeql-action/upload-sarif` | `# v4` | `9e0d7b8d...` → **`7211b7c8...`** | 🔧 Fixed (docker-security.yml ×2, security-scan.yml ×1) |

## Specialist Review Results

- **QA Test Runner**: PASS — no Go source changes; all unit tests, linting, cross-platform compilation pass
- **QA Code Reviewer**: PASS — all active checkout steps verified to have `persist-credentials: false`; SHA changes and zizmor annotation correct
- **Security Engineer**: PASS — no security regressions; security-precommit, check-architecture, and security-scan all clean

## Test Plan

- [ ] `zizmor` CI check passes with no new `artipacked`, `incorrect-version-annotation`, or `dangerous-environment-file` findings on any modified file
- [ ] `unit-tests` CI check passes (no Go source changes)
- [ ] `Build Gate` CI check passes (no build changes)
- [ ] `security-deployment-gate` CI check passes

Closes #1801

🤖 Generated with [Claude Code](https://claude.com/claude-code)