### PR TITLE
feat(cfg): add installer upload and download-url commands (Issue #1705)

### DIFF
--- a/cmd/cfg/cmd/installer.go
+++ b/cmd/cfg/cmd/installer.go
@@ -1,0 +1,224 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	installerPlatform    string
+	installerArch        string
+	installerAPIURL      string
+	installerAPIKey      string
+	installerTLSCACert   string
+	installerTLSInsecure bool
+)
+
+var validInstallerPlatforms = map[string]bool{
+	"windows": true,
+	"darwin":  true,
+	"linux":   true,
+}
+
+var validInstallerArchs = map[string]bool{
+	"amd64": true,
+	"arm64": true,
+}
+
+var installerCmd = &cobra.Command{
+	Use:   "installer",
+	Short: "Manage installer artifacts",
+	Long:  `Commands for uploading and retrieving installer artifact download URLs.`,
+}
+
+var installerUploadCmd = &cobra.Command{
+	Use:   "upload <file>",
+	Short: "Upload an installer artifact to the controller",
+	Long: `Upload a platform-specific installer artifact to the controller.
+
+Streams the file to PUT /api/v1/installer/artifacts/{platform}/{arch} using
+the admin bundle mTLS auth. Prints the uploaded size and SHA-256 checksum on success.
+
+Examples:
+  cfg installer upload steward-windows-amd64.exe --platform windows --arch amd64
+  cfg installer upload steward-darwin-arm64.pkg --platform darwin --arch arm64`,
+	Args: cobra.ExactArgs(1),
+	RunE: runInstallerUpload,
+}
+
+var installerDownloadURLCmd = &cobra.Command{
+	Use:   "download-url",
+	Short: "Print the download URL for an installer artifact",
+	Long: `Print the public download URL for a platform/arch installer artifact.
+
+The URL points to GET /api/v1/installer/download/{platform}/{arch} on the controller.
+No authentication is required to download from this URL; operators can use curl or
+their RMM tool to retrieve the installer.
+
+Examples:
+  cfg installer download-url --platform windows --arch amd64
+  cfg installer download-url --platform darwin --arch arm64`,
+	RunE: runInstallerDownloadURL,
+}
+
+func init() {
+	installerUploadCmd.Flags().StringVar(&installerPlatform, "platform", "", "Target platform: windows, darwin, linux (required)")
+	installerUploadCmd.Flags().StringVar(&installerArch, "arch", "", "Target architecture: amd64, arm64 (required)")
+	installerUploadCmd.Flags().StringVar(&installerAPIURL, "api-url", "", "Controller API URL (env: CFGMS_API_URL)")
+	installerUploadCmd.Flags().StringVar(&installerAPIKey, "api-key", "", "API key for authentication (env: CFGMS_API_KEY)")
+	installerUploadCmd.Flags().StringVar(&installerTLSCACert, "tls-ca-cert", "", "Path to CA certificate for TLS verification (env: CFGMS_TLS_CA_CERT)")
+	installerUploadCmd.Flags().BoolVar(&installerTLSInsecure, "tls-insecure", false, "Skip TLS verification (development only)")
+	_ = installerUploadCmd.MarkFlagRequired("platform")
+	_ = installerUploadCmd.MarkFlagRequired("arch")
+
+	installerDownloadURLCmd.Flags().StringVar(&installerPlatform, "platform", "", "Target platform: windows, darwin, linux (required)")
+	installerDownloadURLCmd.Flags().StringVar(&installerArch, "arch", "", "Target architecture: amd64, arm64 (required)")
+	installerDownloadURLCmd.Flags().StringVar(&installerAPIURL, "api-url", "", "Controller API URL (env: CFGMS_API_URL)")
+	_ = installerDownloadURLCmd.MarkFlagRequired("platform")
+	_ = installerDownloadURLCmd.MarkFlagRequired("arch")
+
+	installerCmd.AddCommand(installerUploadCmd)
+	installerCmd.AddCommand(installerDownloadURLCmd)
+}
+
+func getInstallerClient() (*APIClient, error) {
+	apiURL := installerAPIURL
+	if apiURL == "" {
+		apiURL = os.Getenv("CFGMS_API_URL")
+	}
+
+	client, err := resolveBundleClient(apiURL)
+	if err != nil {
+		return nil, fmt.Errorf("bundle lookup failed: %w", err)
+	}
+	if client != nil {
+		return client, nil
+	}
+
+	apiKey := installerAPIKey
+	if apiKey == "" {
+		apiKey = os.Getenv("CFGMS_API_KEY")
+	}
+
+	insecure := installerTLSInsecure
+	if !insecure && os.Getenv("CFGMS_TLS_INSECURE") == "true" {
+		insecure = true
+	}
+
+	caCertPath := installerTLSCACert
+	if caCertPath == "" {
+		caCertPath = os.Getenv("CFGMS_TLS_CA_CERT")
+	}
+
+	return newClientFromFlags(apiURL, apiKey, caCertPath, insecure)
+}
+
+func runInstallerUpload(cmd *cobra.Command, args []string) error {
+	filePath := args[0]
+
+	if !validInstallerPlatforms[installerPlatform] {
+		return fmt.Errorf("unknown platform %q; valid values: windows, darwin, linux", installerPlatform)
+	}
+	if !validInstallerArchs[installerArch] {
+		return fmt.Errorf("unknown arch %q; valid values: amd64, arm64", installerArch)
+	}
+
+	info, err := os.Stat(filePath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return fmt.Errorf("file not found: %s", filePath)
+		}
+		return fmt.Errorf("cannot access file %s: %w", filePath, err)
+	}
+	if info.Size() == 0 {
+		return fmt.Errorf("file is empty: %s", filePath)
+	}
+
+	// #nosec G304 - file path provided by user via CLI argument
+	f, err := os.Open(filePath)
+	if err != nil {
+		return fmt.Errorf("failed to open file %s: %w", filePath, err)
+	}
+	defer func() { _ = f.Close() }()
+
+	client, err := getInstallerClient()
+	if err != nil {
+		return fmt.Errorf("failed to create API client: %w", err)
+	}
+
+	if err := client.UploadInstallerArtifact(context.Background(), installerPlatform, installerArch, f); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func runInstallerDownloadURL(cmd *cobra.Command, args []string) error {
+	if !validInstallerPlatforms[installerPlatform] {
+		return fmt.Errorf("unknown platform %q; valid values: windows, darwin, linux", installerPlatform)
+	}
+	if !validInstallerArchs[installerArch] {
+		return fmt.Errorf("unknown arch %q; valid values: amd64, arm64", installerArch)
+	}
+
+	apiURL := installerAPIURL
+	if apiURL == "" {
+		apiURL = os.Getenv("CFGMS_API_URL")
+	}
+	apiURL = strings.TrimRight(apiURL, "/")
+
+	fmt.Printf("%s/api/v1/installer/download/%s/%s\n", apiURL, installerPlatform, installerArch)
+	return nil
+}
+
+// installerUploadAPIResponse mirrors the server-side installerUploadResponse wrapped in APIResponse.
+type installerUploadAPIResponse struct {
+	Data struct {
+		Platform string `json:"platform"`
+		Arch     string `json:"arch"`
+		Size     int64  `json:"size"`
+		Checksum string `json:"checksum"`
+	} `json:"data"`
+}
+
+// UploadInstallerArtifact streams r to PUT /api/v1/installer/artifacts/{platform}/{arch}
+// and prints the confirmation line to stdout on success.
+func (c *APIClient) UploadInstallerArtifact(ctx context.Context, platform, arch string, r io.Reader) error {
+	path := "/api/v1/installer/artifacts/" + platform + "/" + arch
+	resp, err := c.doRequestWithContentType(ctx, "PUT", path, r, "application/octet-stream")
+	if err != nil {
+		return fmt.Errorf("failed to upload installer artifact: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return c.parseError(resp)
+	}
+
+	var apiResp installerUploadAPIResponse
+	if err := json.NewDecoder(resp.Body).Decode(&apiResp); err != nil {
+		return fmt.Errorf("failed to decode response: %w", err)
+	}
+
+	fmt.Printf("Uploaded %s/%s installer (%d bytes, sha256: %s)\n",
+		apiResp.Data.Platform,
+		apiResp.Data.Arch,
+		apiResp.Data.Size,
+		strings.TrimPrefix(apiResp.Data.Checksum, "sha256:"),
+	)
+	return nil
+}
+
+// InstallerDownloadURL returns the public download URL for the given platform/arch.
+func (c *APIClient) InstallerDownloadURL(platform, arch string) string {
+	return strings.TrimRight(c.baseURL, "/") + "/api/v1/installer/download/" + platform + "/" + arch
+}

--- a/cmd/cfg/cmd/installer_test.go
+++ b/cmd/cfg/cmd/installer_test.go
@@ -1,0 +1,374 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+package cmd
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestInstallerDownloadURL(t *testing.T) {
+	t.Run("constructs correct URL for darwin arm64", func(t *testing.T) {
+		origURL := installerAPIURL
+		origPlatform := installerPlatform
+		origArch := installerArch
+		t.Cleanup(func() {
+			installerAPIURL = origURL
+			installerPlatform = origPlatform
+			installerArch = origArch
+		})
+
+		installerAPIURL = "https://ctrl.example.com:9080"
+		installerPlatform = "darwin"
+		installerArch = "arm64"
+
+		output := captureStdout(t, func() {
+			err := runInstallerDownloadURL(installerDownloadURLCmd, []string{})
+			require.NoError(t, err)
+		})
+
+		assert.Equal(t, "https://ctrl.example.com:9080/api/v1/installer/download/darwin/arm64\n", output)
+	})
+
+	t.Run("constructs correct URL for windows amd64", func(t *testing.T) {
+		origURL := installerAPIURL
+		origPlatform := installerPlatform
+		origArch := installerArch
+		t.Cleanup(func() {
+			installerAPIURL = origURL
+			installerPlatform = origPlatform
+			installerArch = origArch
+		})
+
+		installerAPIURL = "https://controller.myorg.com"
+		installerPlatform = "windows"
+		installerArch = "amd64"
+
+		output := captureStdout(t, func() {
+			err := runInstallerDownloadURL(installerDownloadURLCmd, []string{})
+			require.NoError(t, err)
+		})
+
+		assert.Equal(t, "https://controller.myorg.com/api/v1/installer/download/windows/amd64\n", output)
+	})
+
+	t.Run("rejects unknown platform", func(t *testing.T) {
+		origPlatform := installerPlatform
+		origArch := installerArch
+		t.Cleanup(func() {
+			installerPlatform = origPlatform
+			installerArch = origArch
+		})
+
+		installerPlatform = "haiku"
+		installerArch = "amd64"
+
+		err := runInstallerDownloadURL(installerDownloadURLCmd, []string{})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "unknown platform")
+		assert.Contains(t, err.Error(), "haiku")
+	})
+
+	t.Run("rejects unknown arch", func(t *testing.T) {
+		origPlatform := installerPlatform
+		origArch := installerArch
+		t.Cleanup(func() {
+			installerPlatform = origPlatform
+			installerArch = origArch
+		})
+
+		installerPlatform = "linux"
+		installerArch = "mips64"
+
+		err := runInstallerDownloadURL(installerDownloadURLCmd, []string{})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "unknown arch")
+		assert.Contains(t, err.Error(), "mips64")
+	})
+
+	t.Run("uses env var for controller URL when flag not set", func(t *testing.T) {
+		origURL := installerAPIURL
+		origPlatform := installerPlatform
+		origArch := installerArch
+		t.Cleanup(func() {
+			installerAPIURL = origURL
+			installerPlatform = origPlatform
+			installerArch = origArch
+			require.NoError(t, os.Unsetenv("CFGMS_API_URL"))
+		})
+
+		installerAPIURL = ""
+		installerPlatform = "linux"
+		installerArch = "amd64"
+		require.NoError(t, os.Setenv("CFGMS_API_URL", "https://env.controller.com"))
+
+		output := captureStdout(t, func() {
+			err := runInstallerDownloadURL(installerDownloadURLCmd, []string{})
+			require.NoError(t, err)
+		})
+
+		assert.Equal(t, "https://env.controller.com/api/v1/installer/download/linux/amd64\n", output)
+	})
+}
+
+// TestInstallerDownloadURLMethod tests the APIClient.InstallerDownloadURL helper directly.
+func TestInstallerDownloadURLMethod(t *testing.T) {
+	t.Run("returns correct URL from base URL", func(t *testing.T) {
+		client := &APIClient{baseURL: "https://ctrl.example.com:9080"}
+		got := client.InstallerDownloadURL("linux", "amd64")
+		assert.Equal(t, "https://ctrl.example.com:9080/api/v1/installer/download/linux/amd64", got)
+	})
+
+	t.Run("strips trailing slash from base URL", func(t *testing.T) {
+		client := &APIClient{baseURL: "https://ctrl.example.com/"}
+		got := client.InstallerDownloadURL("darwin", "arm64")
+		assert.Equal(t, "https://ctrl.example.com/api/v1/installer/download/darwin/arm64", got)
+	})
+}
+
+func TestInstallerUpload(t *testing.T) {
+	t.Run("rejects unknown platform before HTTP call", func(t *testing.T) {
+		origPlatform := installerPlatform
+		origArch := installerArch
+		t.Cleanup(func() {
+			installerPlatform = origPlatform
+			installerArch = origArch
+		})
+
+		installerPlatform = "freebsd"
+		installerArch = "amd64"
+
+		f, err := os.CreateTemp(t.TempDir(), "installer-*.exe")
+		require.NoError(t, err)
+		_, _ = f.WriteString("fake installer content")
+		require.NoError(t, f.Close())
+
+		callCount := 0
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			callCount++
+		}))
+		defer server.Close()
+
+		origURL := installerAPIURL
+		t.Cleanup(func() { installerAPIURL = origURL })
+		installerAPIURL = server.URL
+
+		err = runInstallerUpload(installerUploadCmd, []string{f.Name()})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "unknown platform")
+		assert.Equal(t, 0, callCount, "HTTP call must not be made for invalid platform")
+	})
+
+	t.Run("rejects unknown arch before HTTP call", func(t *testing.T) {
+		origPlatform := installerPlatform
+		origArch := installerArch
+		t.Cleanup(func() {
+			installerPlatform = origPlatform
+			installerArch = origArch
+		})
+
+		installerPlatform = "windows"
+		installerArch = "riscv64"
+
+		f, err := os.CreateTemp(t.TempDir(), "installer-*.exe")
+		require.NoError(t, err)
+		_, _ = f.WriteString("fake installer content")
+		require.NoError(t, f.Close())
+
+		callCount := 0
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			callCount++
+		}))
+		defer server.Close()
+
+		origURL := installerAPIURL
+		t.Cleanup(func() { installerAPIURL = origURL })
+		installerAPIURL = server.URL
+
+		err = runInstallerUpload(installerUploadCmd, []string{f.Name()})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "unknown arch")
+		assert.Equal(t, 0, callCount, "HTTP call must not be made for invalid arch")
+	})
+
+	t.Run("rejects missing file", func(t *testing.T) {
+		origPlatform := installerPlatform
+		origArch := installerArch
+		t.Cleanup(func() {
+			installerPlatform = origPlatform
+			installerArch = origArch
+		})
+
+		installerPlatform = "linux"
+		installerArch = "amd64"
+
+		err := runInstallerUpload(installerUploadCmd, []string{"/nonexistent/path/installer.bin"})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+	})
+
+	t.Run("rejects empty file", func(t *testing.T) {
+		origPlatform := installerPlatform
+		origArch := installerArch
+		t.Cleanup(func() {
+			installerPlatform = origPlatform
+			installerArch = origArch
+		})
+
+		installerPlatform = "linux"
+		installerArch = "amd64"
+
+		emptyFile := filepath.Join(t.TempDir(), "empty.bin")
+		require.NoError(t, os.WriteFile(emptyFile, []byte{}, 0600))
+
+		err := runInstallerUpload(installerUploadCmd, []string{emptyFile})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "empty")
+	})
+
+	t.Run("streams file and prints confirmation on success", func(t *testing.T) {
+		origPlatform := installerPlatform
+		origArch := installerArch
+		origURL := installerAPIURL
+		origNoBundle := noBundle
+		t.Cleanup(func() {
+			installerPlatform = origPlatform
+			installerArch = origArch
+			installerAPIURL = origURL
+			noBundle = origNoBundle
+		})
+
+		installerPlatform = "windows"
+		installerArch = "amd64"
+		noBundle = true
+
+		fileContent := strings.Repeat("x", 1024)
+		f, err := os.CreateTemp(t.TempDir(), "installer-*.exe")
+		require.NoError(t, err)
+		_, _ = f.WriteString(fileContent)
+		require.NoError(t, f.Close())
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "PUT", r.Method)
+			assert.Equal(t, "/api/v1/installer/artifacts/windows/amd64", r.URL.Path)
+			assert.Equal(t, "application/octet-stream", r.Header.Get("Content-Type"))
+
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"data": map[string]interface{}{
+					"platform": "windows",
+					"arch":     "amd64",
+					"size":     int64(len(fileContent)),
+					"checksum": "sha256:abc123def456",
+				},
+				"timestamp": "2026-05-28T00:00:00Z",
+			})
+		}))
+		defer server.Close()
+
+		installerAPIURL = server.URL
+
+		output := captureStdout(t, func() {
+			err := runInstallerUpload(installerUploadCmd, []string{f.Name()})
+			require.NoError(t, err)
+		})
+
+		assert.Contains(t, output, "windows/amd64")
+		assert.Contains(t, output, "1024")
+		assert.Contains(t, output, "abc123def456")
+	})
+
+	t.Run("returns error on server failure", func(t *testing.T) {
+		origPlatform := installerPlatform
+		origArch := installerArch
+		origURL := installerAPIURL
+		origNoBundle := noBundle
+		t.Cleanup(func() {
+			installerPlatform = origPlatform
+			installerArch = origArch
+			installerAPIURL = origURL
+			noBundle = origNoBundle
+		})
+
+		installerPlatform = "linux"
+		installerArch = "amd64"
+		noBundle = true
+
+		f, err := os.CreateTemp(t.TempDir(), "installer-*.bin")
+		require.NoError(t, err)
+		_, _ = f.WriteString("content")
+		require.NoError(t, f.Close())
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusInternalServerError)
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"error": "storage backend unavailable",
+			})
+		}))
+		defer server.Close()
+
+		installerAPIURL = server.URL
+
+		err = runInstallerUpload(installerUploadCmd, []string{f.Name()})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "storage backend unavailable")
+	})
+
+	t.Run("verifies correct request path for darwin arm64", func(t *testing.T) {
+		origPlatform := installerPlatform
+		origArch := installerArch
+		origURL := installerAPIURL
+		origNoBundle := noBundle
+		t.Cleanup(func() {
+			installerPlatform = origPlatform
+			installerArch = origArch
+			installerAPIURL = origURL
+			noBundle = origNoBundle
+		})
+
+		installerPlatform = "darwin"
+		installerArch = "arm64"
+		noBundle = true
+
+		dir := t.TempDir()
+		installerPath := filepath.Join(dir, "cfgms-steward-darwin-arm64.pkg")
+		require.NoError(t, os.WriteFile(installerPath, []byte("pkg content"), 0600))
+
+		var receivedPath string
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			receivedPath = r.URL.Path
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"data": map[string]interface{}{
+					"platform": "darwin",
+					"arch":     "arm64",
+					"size":     int64(11),
+					"checksum": "sha256:deadbeef",
+				},
+				"timestamp": "2026-05-28T00:00:00Z",
+			})
+		}))
+		defer server.Close()
+
+		installerAPIURL = server.URL
+
+		output := captureStdout(t, func() {
+			err := runInstallerUpload(installerUploadCmd, []string{installerPath})
+			require.NoError(t, err)
+		})
+
+		assert.Equal(t, "/api/v1/installer/artifacts/darwin/arm64", receivedPath)
+		assert.Contains(t, output, "darwin/arm64")
+	})
+}

--- a/cmd/cfg/cmd/root.go
+++ b/cmd/cfg/cmd/root.go
@@ -56,6 +56,7 @@ func init() {
 	rootCmd.AddCommand(stewardCmd)
 	rootCmd.AddCommand(workflowCmd)
 	rootCmd.AddCommand(configCmd)
+	rootCmd.AddCommand(installerCmd)
 }
 
 // versionCmd represents the version command


### PR DESCRIPTION
## Summary

- Adds `cfg installer upload <file> --platform <p> --arch <a>` — streams installer to controller PUT endpoint with mTLS auth, prints size + SHA-256 on success
- Adds `cfg installer download-url --platform <p> --arch <a>` — prints the public download URL (no HTTP call; operators use curl/RMM)
- Platform (`windows`, `darwin`, `linux`) and arch (`amd64`, `arm64`) are validated client-side before any HTTP call; unknown values get a friendly error

## Test plan

- [ ] `go test ./cmd/cfg/cmd/... -run TestInstaller` — 14 tests, all passing
- [ ] `make test-agent-complete` — full validation suite passes (lint, unit tests, cross-platform builds)
- [ ] `cfg installer upload <file> --platform windows --arch amd64 --api-url <url>` streams file and prints `Uploaded windows/amd64 installer (N bytes, sha256: ...)`
- [ ] `cfg installer download-url --platform darwin --arch arm64 --api-url https://ctrl.example.com` prints `https://ctrl.example.com/api/v1/installer/download/darwin/arm64`
- [ ] `cfg installer upload <file> --platform freebsd --arch amd64` returns error before any HTTP call

## Specialist Review Results

- **QA Test Runner**: PASS — all quality gates passed (unit tests, lint, license headers, cross-platform builds, architecture compliance, security scans)
- **QA Code Reviewer**: PASS — no blocking issues; 14 tests cover flag validation, URL construction, HTTP error paths, empty file rejection, correct request path/content-type
- **Security Engineer**: PASS — no blocking issues; platform/arch allow-listed before HTTP, no hardcoded secrets, mTLS via admin bundle, `#nosec G304` for user-supplied file path

Fixes #1705

🤖 Generated with [Claude Code](https://claude.com/claude-code)