### PR TITLE
feat(installer): add per-platform install package download endpoint (Issue #1704)

### DIFF
--- a/features/controller/api/handlers_installer.go
+++ b/features/controller/api/handlers_installer.go
@@ -3,11 +3,20 @@
 package api
 
 import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"crypto/x509"
+	"encoding/pem"
 	"errors"
+	"fmt"
+	"io"
 	"net/http"
+	"time"
 
 	"github.com/gorilla/mux"
 
+	"github.com/cfgis/cfgms/features/controller/initialization"
 	"github.com/cfgis/cfgms/pkg/ctxkeys"
 	"github.com/cfgis/cfgms/pkg/logging"
 	blob "github.com/cfgis/cfgms/pkg/storage/interfaces/blob"
@@ -272,4 +281,203 @@ func parseInstallerName(name string) (platform, arch string, ok bool) {
 		}
 	}
 	return "", "", false
+}
+
+// downloadTenantID is the fixed tenant used to look up installer artifacts for public download.
+// Installer artifacts intended for public distribution must be uploaded by the root tenant.
+const downloadTenantID = "root"
+
+// caIsPrivate reports whether the controller is using a private (self-signed) CA.
+// When the cert manager is unavailable or the CA cannot be verified, it logs a warning
+// and returns false — a controller that cannot determine its CA type must not assert "private."
+func (s *Server) caIsPrivate() bool {
+	if s.certManager == nil {
+		s.logger.Warn("cert manager not available; skipping CA bundle in install package")
+		return false
+	}
+	caCertPEM, err := s.certManager.GetCACertificate()
+	if err != nil {
+		s.logger.Warn("failed to read CA certificate from cert manager; skipping CA bundle", "error", err)
+		return false
+	}
+	block, _ := pem.Decode(caCertPEM)
+	if block == nil {
+		s.logger.Warn("CA certificate PEM is invalid; skipping CA bundle")
+		return false
+	}
+	caCert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		s.logger.Warn("failed to parse CA certificate; skipping CA bundle", "error", err)
+		return false
+	}
+	// A self-signed CA has identical raw issuer and subject bytes, indicating a private
+	// CA controlled by this controller. Publicly-trusted CAs are signed by a root authority
+	// with different issuer and subject fields.
+	return bytes.Equal(caCert.RawIssuer, caCert.RawSubject)
+}
+
+// handleDownloadInstallPackage handles GET /api/v1/installer/download/{platform}/{arch}.
+// Assembles a tar.gz containing the installer artifact and, when the controller uses a
+// private CA, the CA certificate and SHA-256 fingerprint. No authentication required —
+// the download URL is the distribution mechanism (Issue #1704).
+func (s *Server) handleDownloadInstallPackage(w http.ResponseWriter, r *http.Request) {
+	if s.blobStore == nil {
+		s.writeErrorResponse(w, http.StatusServiceUnavailable, "Installer storage not available", "SERVICE_UNAVAILABLE")
+		return
+	}
+
+	vars := mux.Vars(r)
+	platform := vars["platform"]
+	arch := vars["arch"]
+
+	if !validPlatforms[platform] {
+		s.writeErrorResponse(w, http.StatusBadRequest,
+			"Unknown platform: "+logging.SanitizeLogValue(platform)+"; valid values: windows, darwin, linux",
+			"INVALID_PLATFORM")
+		return
+	}
+	if !validArchs[arch] {
+		s.writeErrorResponse(w, http.StatusBadRequest,
+			"Unknown arch: "+logging.SanitizeLogValue(arch)+"; valid values: amd64, arm64",
+			"INVALID_ARCH")
+		return
+	}
+
+	key := blob.BlobKey{
+		TenantID:  downloadTenantID,
+		Namespace: "installers",
+		Name:      platform + "-" + arch,
+	}
+
+	rc, _, err := s.blobStore.GetBlob(r.Context(), key)
+	if err != nil {
+		if errors.Is(err, blob.ErrBlobNotFound) {
+			s.writeErrorResponse(w, http.StatusNotFound, "Installer artifact not found", "ARTIFACT_NOT_FOUND")
+			return
+		}
+		s.logger.Error("Failed to get installer artifact for download",
+			"error", err,
+			"platform", logging.SanitizeLogValue(platform),
+			"arch", logging.SanitizeLogValue(arch))
+		s.writeErrorResponse(w, http.StatusInternalServerError, "Failed to read artifact", "GET_ERROR")
+		return
+	}
+	defer func() {
+		if cerr := rc.Close(); cerr != nil {
+			s.logger.Warn("failed to close installer artifact reader", "error", cerr)
+		}
+	}()
+
+	artifactBytes, err := io.ReadAll(rc)
+	if err != nil {
+		s.logger.Error("Failed to read installer artifact content", "error", err)
+		s.writeErrorResponse(w, http.StatusInternalServerError, "Failed to read artifact content", "READ_ERROR")
+		return
+	}
+
+	// Conditionally bundle the CA cert and fingerprint for private-CA deployments.
+	var caCertPEM []byte
+	var caFingerprint string
+	if s.caIsPrivate() {
+		caCertPEM, err = s.certManager.GetCACertificate()
+		if err != nil {
+			s.logger.Error("Failed to get CA certificate for install package", "error", err)
+			s.writeErrorResponse(w, http.StatusInternalServerError, "Failed to get CA certificate", "CA_ERROR")
+			return
+		}
+		if s.cfg.Certificate == nil || s.cfg.Certificate.CAPath == "" {
+			s.logger.Error("CA path not configured; cannot read CA fingerprint")
+			s.writeErrorResponse(w, http.StatusInternalServerError, "CA path not configured", "CA_PATH_ERROR")
+			return
+		}
+		marker, markerErr := initialization.ReadInitMarker(s.cfg.Certificate.CAPath)
+		if markerErr != nil {
+			s.logger.Error("Failed to read init marker for CA fingerprint", "error", markerErr)
+			s.writeErrorResponse(w, http.StatusInternalServerError, "Failed to read CA fingerprint", "FINGERPRINT_ERROR")
+			return
+		}
+		caFingerprint = marker.CAFingerprint
+	}
+
+	// Assemble the tar.gz archive entirely in memory before writing response headers.
+	var buf bytes.Buffer
+	gzWriter := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gzWriter)
+
+	artifactPath := "installer/" + platform + "-" + arch + "/" + installerFilename(platform, arch)
+	if err := addTarFile(tw, artifactPath, artifactBytes); err != nil {
+		s.logger.Error("Failed to write artifact to tar archive", "error", err)
+		s.writeErrorResponse(w, http.StatusInternalServerError, "Failed to build install package", "TAR_ERROR")
+		return
+	}
+
+	if caCertPEM != nil {
+		if err := addTarFile(tw, "installer/ca.crt", caCertPEM); err != nil {
+			s.logger.Error("Failed to write CA cert to tar archive", "error", err)
+			s.writeErrorResponse(w, http.StatusInternalServerError, "Failed to build install package", "TAR_ERROR")
+			return
+		}
+		if err := addTarFile(tw, "installer/ca.fingerprint", []byte(caFingerprint)); err != nil {
+			s.logger.Error("Failed to write CA fingerprint to tar archive", "error", err)
+			s.writeErrorResponse(w, http.StatusInternalServerError, "Failed to build install package", "TAR_ERROR")
+			return
+		}
+	}
+
+	if err := addTarFile(tw, "installer/README.txt", []byte(readmeText(platform, arch))); err != nil {
+		s.logger.Error("Failed to write README to tar archive", "error", err)
+		s.writeErrorResponse(w, http.StatusInternalServerError, "Failed to build install package", "TAR_ERROR")
+		return
+	}
+
+	if err := tw.Close(); err != nil {
+		s.logger.Error("Failed to close tar writer", "error", err)
+		s.writeErrorResponse(w, http.StatusInternalServerError, "Failed to build install package", "TAR_ERROR")
+		return
+	}
+	if err := gzWriter.Close(); err != nil {
+		s.logger.Error("Failed to close gzip writer", "error", err)
+		s.writeErrorResponse(w, http.StatusInternalServerError, "Failed to build install package", "TAR_ERROR")
+		return
+	}
+
+	archiveName := fmt.Sprintf("cfgms-steward-%s-%s.tar.gz", platform, arch)
+	w.Header().Set("Content-Type", "application/gzip")
+	w.Header().Set("Content-Disposition", fmt.Sprintf(`attachment; filename="%s"`, archiveName))
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write(buf.Bytes())
+}
+
+// installerFilename returns the filename for the installer binary within the package archive.
+func installerFilename(platform, arch string) string {
+	if platform == "windows" {
+		return "cfgms-steward-" + arch + ".exe"
+	}
+	return "cfgms-steward-" + arch
+}
+
+// readmeText returns a one-line platform-specific install instruction.
+func readmeText(platform, arch string) string {
+	switch platform {
+	case "windows":
+		return "Run cfgms-steward-" + arch + ".exe as Administrator to install the CFGMS steward agent."
+	case "darwin":
+		return "Run: sudo ./cfgms-steward-" + arch + " to install the CFGMS steward agent."
+	default:
+		return "Run: sudo ./cfgms-steward-" + arch + " to install the CFGMS steward agent."
+	}
+}
+
+// addTarFile writes a single file entry to a tar archive.
+func addTarFile(tw *tar.Writer, path string, content []byte) error {
+	if err := tw.WriteHeader(&tar.Header{
+		Name:    path,
+		Mode:    0644,
+		Size:    int64(len(content)),
+		ModTime: time.Now().UTC(),
+	}); err != nil {
+		return err
+	}
+	_, err := tw.Write(content)
+	return err
 }

--- a/features/controller/api/handlers_installer_test.go
+++ b/features/controller/api/handlers_installer_test.go
@@ -3,9 +3,17 @@
 package api
 
 import (
+	"archive/tar"
 	"bytes"
+	"compress/gzip"
 	"context"
+	"crypto/sha256"
+	"crypto/x509"
 	"encoding/json"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -15,6 +23,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/cfgis/cfgms/features/controller/config"
+	"github.com/cfgis/cfgms/features/controller/initialization"
+	"github.com/cfgis/cfgms/pkg/cert"
 	"github.com/cfgis/cfgms/pkg/ctxkeys"
 	blob "github.com/cfgis/cfgms/pkg/storage/interfaces/blob"
 )
@@ -449,4 +460,234 @@ func TestInstallerArtifactRouterDeletePermission(t *testing.T) {
 	server.router.ServeHTTP(rec2, req2)
 	assert.Equal(t, http.StatusNoContent, rec2.Code,
 		"installer:delete key must be allowed to DELETE an artifact")
+}
+
+// --- Download ---
+
+// extractTarGz parses a tar.gz byte slice and returns a map of path → content.
+func extractTarGz(t *testing.T, data []byte) map[string][]byte {
+	t.Helper()
+	files := make(map[string][]byte)
+	gzr, err := gzip.NewReader(bytes.NewReader(data))
+	require.NoError(t, err, "response must be valid gzip")
+	defer func() {
+		if cerr := gzr.Close(); cerr != nil {
+			t.Logf("failed to close gzip reader: %v", cerr)
+		}
+	}()
+	tr := tar.NewReader(gzr)
+	for {
+		header, err := tr.Next()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		require.NoError(t, err, "tar read error")
+		content, err := io.ReadAll(tr)
+		require.NoError(t, err, "tar entry read error")
+		files[header.Name] = content
+	}
+	return files
+}
+
+// setupTestCertManager creates a cert.Manager backed by a self-signed CA for tests.
+// It also writes an init marker with the computed CA fingerprint to caPath.
+func setupTestCertManager(t *testing.T, caPath string) (*cert.Manager, string) {
+	t.Helper()
+	certMgr, err := cert.NewManager(&cert.ManagerConfig{
+		StoragePath: t.TempDir(),
+		CAConfig: &cert.CAConfig{
+			Organization: "Test CFGMS",
+			Country:      "US",
+			ValidityDays: 365,
+		},
+	})
+	require.NoError(t, err)
+
+	caCertPEM, err := certMgr.GetCACertificate()
+	require.NoError(t, err)
+
+	block, _ := pem.Decode(caCertPEM)
+	require.NotNil(t, block, "CA cert PEM must be decodable")
+	caCert, err := x509.ParseCertificate(block.Bytes)
+	require.NoError(t, err)
+
+	hash := sha256.Sum256(caCert.Raw)
+	fingerprint := fmt.Sprintf("%x", hash)
+
+	marker := &initialization.InitMarker{
+		Version:           1,
+		InitializedAt:     time.Now().UTC(),
+		ControllerVersion: "test",
+		StorageProvider:   "test",
+		CAFingerprint:     fingerprint,
+	}
+	require.NoError(t, initialization.WriteInitMarker(caPath, marker))
+
+	return certMgr, fingerprint
+}
+
+// TestHandleDownloadInstallPackage_WithCA is the [REQUIRED TEST]:
+// a Server with a filesystem BlobStore containing a dummy artifact and a cert.Manager
+// with a self-signed CA; the archive must contain ca.crt and ca.fingerprint with
+// correct content.
+func TestHandleDownloadInstallPackage_WithCA(t *testing.T) {
+	server, store := setupTestServerWithBlobStore(t)
+
+	// Wire a self-signed cert manager and write an init marker.
+	caPath := t.TempDir()
+	certMgr, expectedFingerprint := setupTestCertManager(t, caPath)
+	server.certManager = certMgr
+	server.cfg.Certificate = &config.CertificateConfig{CAPath: caPath}
+
+	// Get the CA cert PEM to verify the archive content later.
+	expectedCACertPEM, err := certMgr.GetCACertificate()
+	require.NoError(t, err)
+
+	// Upload a dummy artifact under the root tenant.
+	artifactContent := []byte("fake-linux-amd64-installer-binary")
+	require.NoError(t, store.PutBlob(
+		context.Background(),
+		blob.BlobKey{TenantID: downloadTenantID, Namespace: "installers", Name: "linux-amd64"},
+		bytes.NewReader(artifactContent),
+		blob.BlobMeta{ContentType: "application/octet-stream"},
+	))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/installer/download/linux/amd64", nil)
+	req = withVars(req, map[string]string{"platform": "linux", "arch": "amd64"})
+	rec := httptest.NewRecorder()
+
+	server.handleDownloadInstallPackage(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, "application/gzip", rec.Header().Get("Content-Type"))
+	assert.Contains(t, rec.Header().Get("Content-Disposition"), "cfgms-steward-linux-amd64.tar.gz")
+
+	files := extractTarGz(t, rec.Body.Bytes())
+
+	// Installer artifact must be present with the correct content.
+	require.Contains(t, files, "installer/linux-amd64/cfgms-steward-amd64", "artifact must be in archive")
+	assert.Equal(t, artifactContent, files["installer/linux-amd64/cfgms-steward-amd64"])
+
+	// CA files must be present and correct (private CA).
+	require.Contains(t, files, "installer/ca.crt", "ca.crt must be in archive for private CA")
+	assert.Equal(t, expectedCACertPEM, files["installer/ca.crt"])
+
+	require.Contains(t, files, "installer/ca.fingerprint", "ca.fingerprint must be in archive for private CA")
+	assert.Equal(t, expectedFingerprint, string(files["installer/ca.fingerprint"]))
+
+	// README must be present.
+	assert.Contains(t, files, "installer/README.txt")
+}
+
+// TestHandleDownloadInstallPackage_WithoutCA is the [REQUIRED TEST]:
+// same setup but certManager is nil so caIsPrivate() returns false; ca.crt must be absent.
+func TestHandleDownloadInstallPackage_WithoutCA(t *testing.T) {
+	server, store := setupTestServerWithBlobStore(t)
+	// certManager remains nil → caIsPrivate() returns false, no CA bundle included.
+
+	artifactContent := []byte("fake-windows-amd64-installer-binary")
+	require.NoError(t, store.PutBlob(
+		context.Background(),
+		blob.BlobKey{TenantID: downloadTenantID, Namespace: "installers", Name: "windows-amd64"},
+		bytes.NewReader(artifactContent),
+		blob.BlobMeta{ContentType: "application/octet-stream"},
+	))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/installer/download/windows/amd64", nil)
+	req = withVars(req, map[string]string{"platform": "windows", "arch": "amd64"})
+	rec := httptest.NewRecorder()
+
+	server.handleDownloadInstallPackage(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, "application/gzip", rec.Header().Get("Content-Type"))
+
+	files := extractTarGz(t, rec.Body.Bytes())
+
+	// Installer artifact must be present (Windows uses .exe extension).
+	require.Contains(t, files, "installer/windows-amd64/cfgms-steward-amd64.exe", "artifact must be in archive")
+	assert.Equal(t, artifactContent, files["installer/windows-amd64/cfgms-steward-amd64.exe"])
+
+	// CA files must NOT be present (public/nil CA).
+	assert.NotContains(t, files, "installer/ca.crt", "ca.crt must not be in archive when CA is not private")
+	assert.NotContains(t, files, "installer/ca.fingerprint", "ca.fingerprint must not be in archive when CA is not private")
+
+	// README must still be present.
+	assert.Contains(t, files, "installer/README.txt")
+}
+
+// TestHandleDownloadInstallPackage_NotFound verifies that a missing artifact returns
+// 404 with the writeErrorResponse JSON shape (not a raw http.Error string).
+func TestHandleDownloadInstallPackage_NotFound(t *testing.T) {
+	server, _ := setupTestServerWithBlobStore(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/installer/download/linux/amd64", nil)
+	req = withVars(req, map[string]string{"platform": "linux", "arch": "amd64"})
+	rec := httptest.NewRecorder()
+
+	server.handleDownloadInstallPackage(rec, req)
+
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+
+	// Response must be JSON-shaped (writeErrorResponse), not a raw string.
+	var errResp ErrorResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &errResp), "404 must use JSON error shape")
+	require.NotNil(t, errResp.Error)
+	assert.Equal(t, "ARTIFACT_NOT_FOUND", errResp.Error.Code)
+}
+
+// TestHandleDownloadInstallPackage_InvalidPlatform verifies that an unknown platform
+// returns 400 with the JSON error shape.
+func TestHandleDownloadInstallPackage_InvalidPlatform(t *testing.T) {
+	server, _ := setupTestServerWithBlobStore(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/installer/download/solaris/amd64", nil)
+	req = withVars(req, map[string]string{"platform": "solaris", "arch": "amd64"})
+	rec := httptest.NewRecorder()
+
+	server.handleDownloadInstallPackage(rec, req)
+
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	var errResp ErrorResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &errResp))
+	assert.Equal(t, "INVALID_PLATFORM", errResp.Error.Code)
+}
+
+// TestHandleDownloadInstallPackage_InvalidArch verifies that an unknown arch
+// returns 400 with the JSON error shape.
+func TestHandleDownloadInstallPackage_InvalidArch(t *testing.T) {
+	server, _ := setupTestServerWithBlobStore(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/installer/download/linux/mips", nil)
+	req = withVars(req, map[string]string{"platform": "linux", "arch": "mips"})
+	rec := httptest.NewRecorder()
+
+	server.handleDownloadInstallPackage(rec, req)
+
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	var errResp ErrorResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &errResp))
+	assert.Equal(t, "INVALID_ARCH", errResp.Error.Code)
+}
+
+// TestHandleDownloadInstallPackage_RouterNoAuth verifies that the download route is
+// accessible without an API key (no auth required).
+func TestHandleDownloadInstallPackage_RouterNoAuth(t *testing.T) {
+	server, store := setupTestServerWithBlobStore(t)
+
+	require.NoError(t, store.PutBlob(
+		context.Background(),
+		blob.BlobKey{TenantID: downloadTenantID, Namespace: "installers", Name: "linux-amd64"},
+		bytes.NewReader([]byte("dummy")),
+		blob.BlobMeta{ContentType: "application/octet-stream"},
+	))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/installer/download/linux/amd64", nil)
+	// Deliberately no X-API-Key header.
+	rec := httptest.NewRecorder()
+	server.router.ServeHTTP(rec, req)
+
+	// Must succeed — the download route is public.
+	assert.Equal(t, http.StatusOK, rec.Code, "download endpoint must be accessible without auth")
+	assert.Equal(t, "application/gzip", rec.Header().Get("Content-Type"))
 }

--- a/features/controller/api/server.go
+++ b/features/controller/api/server.go
@@ -463,6 +463,10 @@ func (s *Server) setupRouter() {
 	installer.Handle("/{platform}/{arch}", s.requirePermission("installer", "read")(http.HandlerFunc(s.handleGetInstallerArtifact))).Methods("GET")
 	installer.Handle("/{platform}/{arch}", s.requirePermission("installer", "delete")(http.HandlerFunc(s.handleDeleteInstallerArtifact))).Methods("DELETE")
 
+	// Installer package download — public, no auth required (Issue #1704).
+	// Assembles a per-platform tar.gz on the fly. The download URL is the distribution mechanism.
+	s.router.HandleFunc("/api/v1/installer/download/{platform}/{arch}", s.handleDownloadInstallPackage).Methods("GET")
+
 	// Ad-hoc run endpoints (Issue #1673). Always registered — returns 503 when
 	// run manager is not wired (transport-disabled deployments).
 	runs := api.PathPrefix("/runs").Subrouter()


### PR DESCRIPTION
## Summary

- Adds `GET /api/v1/installer/download/{platform}/{arch}` — a public (no-auth) endpoint that assembles a tar.gz install package on the fly
- When the controller uses a private (self-signed) CA, the archive includes `ca.crt` and `ca.fingerprint` so stewards can pin the CA before registration
- Missing artifact returns 404; all error responses use `writeErrorResponse` JSON shape (no raw `http.Error`)

## Changes

- **`handlers_installer.go`**: `handleDownloadInstallPackage`, `caIsPrivate()` (RawIssuer vs RawSubject self-signed detection), `installerFilename`, `readmeText`, `addTarFile` helpers
- **`server.go`**: Route registered on `s.router` (public, bypasses auth middleware)
- **`handlers_installer_test.go`**: 6 new tests including both required tests (with-CA and without-CA archive content verified against real `cert.Manager` + real filesystem `BlobStore`)

## Adversarial Review Results

**QA Test Runner: PASS** — All quality validation gates passed. Cross-platform compilation verified. Two `errcheck` lint issues fixed during review (`defer rc.Close()` and `defer gzr.Close()`).

**QA Code Reviewer: PASS** — No blocking issues. Real components used throughout (no mocks). Both required tests implemented. 2 non-blocking warnings: nil blobStore 503 path not separately tested (consistent with prior handlers), caIsPrivate() graceful-degradation sub-paths not directly tested.

**Security Engineer: PASS** — All automated scans clean (gosec, staticcheck, Trivy, Nancy, check-architecture, secret-scan). Input validation via allow-lists verified. No path traversal, no information disclosure, no hardcoded secrets. 3 low-severity non-blocking notes: rate limiting on the public endpoint, comment accuracy on caIsPrivate, and the documented trust model for `downloadTenantID = "root"`.

## Test Plan

- [ ] `TestHandleDownloadInstallPackage_WithCA` — archive contains `ca.crt` and `ca.fingerprint` with correct content
- [ ] `TestHandleDownloadInstallPackage_WithoutCA` — `ca.crt` absent when certManager is nil
- [ ] `TestHandleDownloadInstallPackage_NotFound` — 404 with JSON error shape
- [ ] `TestHandleDownloadInstallPackage_InvalidPlatform` — 400 with JSON error shape
- [ ] `TestHandleDownloadInstallPackage_InvalidArch` — 400 with JSON error shape
- [ ] `TestHandleDownloadInstallPackage_RouterNoAuth` — 200 without API key header

Fixes #1704

🤖 Generated with [Claude Code](https://claude.com/claude-code)