### PR TITLE
cert: rotation CLI + fleet e2e + docs (Issue #1818)

### DIFF
--- a/cmd/cfg/cmd/controller.go
+++ b/cmd/cfg/cmd/controller.go
@@ -4,6 +4,7 @@
 package cmd
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -23,6 +24,9 @@ var (
 	healthFormat          string
 	controllerTLSCACert   string
 	controllerTLSInsecure bool
+
+	// signing-cert rotate flags
+	signingCertOverlapDays int
 )
 
 // controllerCmd represents the controller command
@@ -88,6 +92,47 @@ Examples:
 	RunE: runControllerMetrics,
 }
 
+// signingCertCmd groups signing-certificate management operations.
+var signingCertCmd = &cobra.Command{
+	Use:   "signing-cert",
+	Short: "Signing certificate management",
+	Long: `Manage the controller signing certificate used to sign config and DNA payloads.
+
+The signing certificate is a CodeSigning-EKU certificate minted by the controller CA.
+Stewards pin this certificate at registration and reject payloads signed by a different key.
+
+Subcommands:
+  rotate    Rotate the signing certificate with a configurable overlap window`,
+}
+
+// signingCertRotateCmd triggers a signing-cert rotation.
+var signingCertRotateCmd = &cobra.Command{
+	Use:   "rotate",
+	Short: "Rotate the controller signing certificate",
+	Long: `Rotate the signing certificate and notify connected stewards.
+
+Rotation replaces the active signing certificate and starts an overlap window
+during which configs signed by either the old or the new certificate are accepted.
+Stewards that are offline during rotation receive the new certificate via
+refresh-on-connect when they reconnect.
+
+The --overlap-days flag sets the length of the overlap window (default: 30 days).
+For fleets where stewards may be offline for extended periods, set --overlap-days
+to a value that exceeds the expected maximum offline duration. With refresh-on-connect
+enabled, overlap expiry is a defense-in-depth parameter rather than a hard deadline.
+
+Examples:
+  # Rotate with the default 30-day overlap window
+  cfg controller signing-cert rotate
+
+  # Rotate with a 14-day overlap window
+  cfg controller signing-cert rotate --overlap-days 14
+
+  # Expire the old certificate immediately (test environments only)
+  cfg controller signing-cert rotate --overlap-days 0`,
+	RunE: runSigningCertRotate,
+}
+
 func init() {
 	// Controller command flags
 	controllerCmd.PersistentFlags().StringVar(&healthURL, "url", "", "Controller API URL (required)")
@@ -98,9 +143,17 @@ func init() {
 
 	_ = controllerCmd.MarkPersistentFlagRequired("url")
 
+	// signing-cert rotate flags
+	signingCertRotateCmd.Flags().IntVar(&signingCertOverlapDays, "overlap-days", 30,
+		"Days the old signing certificate remains valid after rotation (default: 30)")
+
+	// signing-cert subcommand tree
+	signingCertCmd.AddCommand(signingCertRotateCmd)
+
 	// Add subcommands
 	controllerCmd.AddCommand(controllerStatusCmd)
 	controllerCmd.AddCommand(controllerMetricsCmd)
+	controllerCmd.AddCommand(signingCertCmd)
 }
 
 // getControllerClient creates an API client using bundle auth (mTLS) when available,
@@ -366,6 +419,65 @@ func runControllerMetrics(cmd *cobra.Command, args []string) error {
 		fmt.Println()
 	}
 
+	return nil
+}
+
+// signingCertRotateRequest is the JSON body for POST /api/v1/certificates/signing/rotate.
+type signingCertRotateRequest struct {
+	OverlapDays int `json:"overlap_days"`
+}
+
+// signingCertRotateResult holds the fields returned by the rotation endpoint.
+type signingCertRotateResult struct {
+	OldSerial        string `json:"old_serial"`
+	NewSerial        string `json:"new_serial"`
+	OverlapDays      int    `json:"overlap_days"`
+	StewardsNotified int    `json:"stewards_notified"`
+}
+
+func runSigningCertRotate(cmd *cobra.Command, args []string) error {
+	if signingCertOverlapDays < 0 {
+		return fmt.Errorf("--overlap-days must be >= 0 (got %d)", signingCertOverlapDays)
+	}
+
+	client, err := getControllerClient()
+	if err != nil {
+		return fmt.Errorf("failed to create API client: %w", err)
+	}
+
+	reqBody, err := json.Marshal(signingCertRotateRequest{OverlapDays: signingCertOverlapDays})
+	if err != nil {
+		return fmt.Errorf("failed to marshal request: %w", err)
+	}
+
+	resp, err := client.doRequest(context.Background(), "POST", "/api/v1/certificates/signing/rotate", bytes.NewReader(reqBody))
+	if err != nil {
+		return fmt.Errorf("failed to call rotation API: %w", err)
+	}
+	defer func() {
+		if closeErr := resp.Body.Close(); closeErr != nil {
+			fmt.Printf("Warning: failed to close response body: %v\n", closeErr)
+		}
+	}()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("rotation failed: %s - %s", resp.Status, strings.TrimSpace(string(body)))
+	}
+
+	var apiResp struct {
+		Data signingCertRotateResult `json:"data"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&apiResp); err != nil {
+		return fmt.Errorf("failed to parse rotation response: %w", err)
+	}
+
+	result := apiResp.Data
+	fmt.Printf("Signing certificate rotated successfully\n\n")
+	fmt.Printf("Old serial:        %s\n", result.OldSerial)
+	fmt.Printf("New serial:        %s\n", result.NewSerial)
+	fmt.Printf("Overlap days:      %d\n", result.OverlapDays)
+	fmt.Printf("Stewards notified: %d\n", result.StewardsNotified)
 	return nil
 }
 

--- a/cmd/cfg/cmd/controller_test.go
+++ b/cmd/cfg/cmd/controller_test.go
@@ -393,3 +393,189 @@ func TestRunControllerMetrics_APIError(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "API request failed")
 }
+
+func newSigningCertRotateServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/api/v1/certificates/signing/rotate" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		var req struct {
+			OverlapDays int `json:"overlap_days"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		resp := map[string]interface{}{
+			"data": map[string]interface{}{
+				"old_serial":        "abc123",
+				"new_serial":        "def456",
+				"overlap_days":      req.OverlapDays,
+				"stewards_notified": 2,
+			},
+			"timestamp": time.Now().UTC().Format(time.RFC3339),
+		}
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+}
+
+func TestRunSigningCertRotate_Success(t *testing.T) {
+	server := newSigningCertRotateServer(t)
+	defer server.Close()
+
+	origURL := healthURL
+	origInsecure := controllerTLSInsecure
+	origOverlap := signingCertOverlapDays
+	t.Cleanup(func() {
+		healthURL = origURL
+		controllerTLSInsecure = origInsecure
+		signingCertOverlapDays = origOverlap
+	})
+
+	healthURL = server.URL
+	controllerTLSInsecure = true
+	signingCertOverlapDays = 30
+
+	output := captureStdout(t, func() {
+		err := runSigningCertRotate(signingCertRotateCmd, nil)
+		require.NoError(t, err)
+	})
+
+	assert.Contains(t, output, "rotated successfully")
+	assert.Contains(t, output, "abc123")
+	assert.Contains(t, output, "def456")
+	assert.Contains(t, output, "30")
+	assert.Contains(t, output, "2")
+}
+
+func TestRunSigningCertRotate_OverlapDaysFlag(t *testing.T) {
+	var receivedOverlap int
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/certificates/signing/rotate", func(w http.ResponseWriter, r *http.Request) {
+		var req struct {
+			OverlapDays int `json:"overlap_days"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		receivedOverlap = req.OverlapDays
+		w.Header().Set("Content-Type", "application/json")
+		resp := map[string]interface{}{
+			"data": map[string]interface{}{
+				"old_serial":        "old",
+				"new_serial":        "new",
+				"overlap_days":      req.OverlapDays,
+				"stewards_notified": 0,
+			},
+			"timestamp": time.Now().UTC().Format(time.RFC3339),
+		}
+		_ = json.NewEncoder(w).Encode(resp)
+	})
+	capServer := httptest.NewServer(mux)
+	defer capServer.Close()
+
+	origURL := healthURL
+	origInsecure := controllerTLSInsecure
+	origOverlap := signingCertOverlapDays
+	t.Cleanup(func() {
+		healthURL = origURL
+		controllerTLSInsecure = origInsecure
+		signingCertOverlapDays = origOverlap
+	})
+
+	healthURL = capServer.URL
+	controllerTLSInsecure = true
+	signingCertOverlapDays = 14
+
+	err := runSigningCertRotate(signingCertRotateCmd, nil)
+	require.NoError(t, err)
+	assert.Equal(t, 14, receivedOverlap, "--overlap-days value must be sent in request body")
+}
+
+func TestRunSigningCertRotate_APIError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"error":{"code":"INTERNAL","message":"rotation failed"}}`))
+	}))
+	defer server.Close()
+
+	origURL := healthURL
+	origInsecure := controllerTLSInsecure
+	t.Cleanup(func() {
+		healthURL = origURL
+		controllerTLSInsecure = origInsecure
+	})
+
+	healthURL = server.URL
+	controllerTLSInsecure = true
+
+	err := runSigningCertRotate(signingCertRotateCmd, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "rotation failed")
+}
+
+func TestRunSigningCertRotate_MalformedResponseBody(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("not-valid-json{{"))
+	}))
+	defer server.Close()
+
+	origURL := healthURL
+	origInsecure := controllerTLSInsecure
+	t.Cleanup(func() {
+		healthURL = origURL
+		controllerTLSInsecure = origInsecure
+	})
+
+	healthURL = server.URL
+	controllerTLSInsecure = true
+
+	err := runSigningCertRotate(signingCertRotateCmd, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to parse rotation response")
+}
+
+func TestRunSigningCertRotate_NegativeOverlapDaysRejected(t *testing.T) {
+	origOverlap := signingCertOverlapDays
+	t.Cleanup(func() { signingCertOverlapDays = origOverlap })
+	signingCertOverlapDays = -1
+
+	// We set no server URL so getControllerClient would fail, but the bounds
+	// check should fire first.
+	origURL := healthURL
+	t.Cleanup(func() { healthURL = origURL })
+	healthURL = "https://controller.example.com"
+
+	err := runSigningCertRotate(signingCertRotateCmd, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "overlap-days")
+}
+
+func TestSigningCertCmd_SubcommandsRegistered(t *testing.T) {
+	var found bool
+	for _, sub := range controllerCmd.Commands() {
+		if sub.Use == "signing-cert" {
+			found = true
+			var rotateFound bool
+			for _, rsub := range sub.Commands() {
+				if rsub.Use == "rotate" {
+					rotateFound = true
+				}
+			}
+			assert.True(t, rotateFound, "signing-cert must have a rotate subcommand")
+		}
+	}
+	assert.True(t, found, "controllerCmd must have a signing-cert subcommand")
+}
+
+func TestSigningCertRotateCmd_OverlapDaysFlagRegistered(t *testing.T) {
+	f := signingCertRotateCmd.Flags().Lookup("overlap-days")
+	require.NotNil(t, f, "--overlap-days flag must be registered on signing-cert rotate")
+	assert.Equal(t, "30", f.DefValue, "--overlap-days default must be 30")
+}

--- a/docs/security/certificate-architecture.md
+++ b/docs/security/certificate-architecture.md
@@ -156,6 +156,12 @@ CFGMS_CERT_PUBLIC_API_KEY_PATH=/etc/letsencrypt/live/api.example.com/privkey.pem
 The controller loads these files on startup. Renewal (certbot auto-renew) takes effect on
 the next controller restart or when the HTTP server reloads its TLS config.
 
+## Certificate Rotation
+
+See [certificate-rotation.md](certificate-rotation.md) for the full rotation methodology,
+operator runbook, `cfg controller signing-cert rotate` CLI reference, overlap window
+guidance, and offline-steward recovery via refresh-on-connect.
+
 ## Future Work
 
 - **Issue #401**: Let's Encrypt automation via certbot module (v0.9.3)

--- a/docs/security/certificate-rotation.md
+++ b/docs/security/certificate-rotation.md
@@ -1,0 +1,215 @@
+# Certificate Rotation
+
+## Overview
+
+CFGMS supports online rotation of the signing certificate — the CodeSigning-EKU
+certificate that authenticates config and DNA payloads delivered to stewards.
+Rotation replaces the active signing key while maintaining fleet continuity through
+a configurable **overlap window** and an automatic **refresh-on-connect** mechanism
+for stewards that were offline during rotation.
+
+See [certificate-architecture.md](certificate-architecture.md) for the full purpose
+model, key properties, and type enum stability rules.
+
+## Rotation Model
+
+### Signing Certificate Role
+
+The signing certificate (`PurposeSigning`, `CertificateTypeConfigSigning`) is the
+steward's trust anchor for config verification. Stewards pin this certificate when
+they register with the controller. Any config payload signed by a different key is
+rejected — this is an intentional fail-closed defense.
+
+### Overlap Window
+
+When a rotation is triggered, the controller mints a new signing cert and enters a
+**rotation overlap** state. During this window:
+
+- The controller signs new outgoing configs with the **new** cert.
+- The controller accepts steward-facing operations that reference either the **old
+  or the new** serial.
+- Stewards that are online receive the new cert via the refresh-on-connect push
+  immediately after the rotation completes.
+
+The overlap window closes after `overlap_days` days (default: 30). After the window
+closes, only the new cert serial is trusted.
+
+### Refresh-on-Connect (Story B2d)
+
+Stewards that are offline during rotation receive the updated signing cert
+automatically when they reconnect via the ControlChannel. This is the primary
+recovery path for offline stewards:
+
+- **During overlap**: the steward reconnects, receives the new cert, and can verify
+  configs signed by either cert (overlap acceptance).
+- **After overlap expiry**: the steward reconnects, receives the new cert via
+  refresh-on-connect, updates its trust anchor, and can then verify configs signed
+  by the new cert.
+
+Refresh-on-connect makes the overlap window a **defense-in-depth parameter** rather
+than a hard deadline. Even if a steward is offline for longer than `overlap_days`,
+it will recover on its next connection.
+
+### Rotation State Machine
+
+The rotation lifecycle is guarded by a cursor with the following states:
+
+| State | Description |
+|-------|-------------|
+| `Stable` | No rotation in progress; single active signing cert. |
+| `Rotating` (RotatingSerial set) | Rotation in progress; overlap window open. |
+
+A second `rotate` call while `RotatingSerial` is set is rejected with HTTP 409
+"rotation in progress". Operators must wait for the first rotation to complete
+before starting another.
+
+## CLI Reference
+
+### `cfg controller signing-cert rotate`
+
+```
+USAGE:
+  cfg controller signing-cert rotate [--overlap-days N] [flags]
+
+FLAGS:
+  --overlap-days int   Days the old signing certificate remains valid after rotation
+                       (default: 30)
+  --url string         Controller API URL (required, or set CFGMS_API_URL)
+  --api-key string     API key for authentication
+  --bundle string      Path to admin bundle file for mTLS auth
+  --tls-ca-cert string Path to CA cert for TLS verification
+  --tls-insecure       Skip TLS verification (dev only)
+```
+
+**Example output:**
+
+```
+Signing certificate rotated successfully
+
+Old serial:        3a4b5c6d7e8f...
+New serial:        9a0b1c2d3e4f...
+Overlap days:      30
+Stewards notified: 12
+```
+
+### Examples
+
+```bash
+# Rotate with default 30-day overlap (recommended for most fleets)
+cfg controller signing-cert rotate --url https://controller.example.com
+
+# Rotate with a 14-day overlap window
+cfg controller signing-cert rotate --url https://controller.example.com --overlap-days 14
+
+# Expire the old certificate immediately (test environments only — breaks offline stewards)
+cfg controller signing-cert rotate --url https://controller.example.com --overlap-days 0
+
+# With explicit admin bundle (mTLS auth)
+cfg controller signing-cert rotate --bundle /etc/cfgms/admin.bundle.yaml
+```
+
+## Operator Runbook
+
+### Planned Rotation
+
+**Recommended frequency:** Annually, or when a signing key is suspected compromised.
+
+**Before you start:**
+
+1. Determine the longest expected offline duration for any steward in the fleet.
+2. Set `--overlap-days` to at least that value (see [Choosing overlap-days](#choosing-overlap-days)).
+3. Verify all stewards are currently connected (`cfg controller steward list`).
+4. Confirm no other rotation is in progress (second rotate call returns HTTP 409).
+
+**Procedure:**
+
+```bash
+# 1. Trigger rotation
+cfg controller signing-cert rotate \
+  --url https://controller.example.com \
+  --overlap-days 30
+
+# 2. Verify output shows distinct old/new serials and the expected steward count
+#    Old serial:        <old>
+#    New serial:        <new>
+#    Overlap days:      30
+#    Stewards notified: <N>
+
+# 3. Monitor steward connectivity — all online stewards should remain connected
+cfg controller status --url https://controller.example.com
+
+# 4. After overlap_days have passed, the old cert serial is automatically
+#    deactivated by the controller. No manual step required.
+```
+
+**Post-rotation checklist:**
+
+- [ ] All online stewards received refresh push (check controller logs: `signing_cert_refreshed`)
+- [ ] Config pushes succeed for all stewards
+- [ ] No steward reports cert verification failures
+
+### Emergency Key Compromise Rotation
+
+If the signing key is suspected compromised:
+
+1. Rotate immediately with `--overlap-days 0`:
+   ```bash
+   cfg controller signing-cert rotate --overlap-days 0
+   ```
+   This expires the compromised cert instantly. **Offline stewards will be unable to
+   verify configs until they reconnect and receive the new cert via refresh-on-connect.**
+
+2. Bring offline stewards online as soon as possible so refresh-on-connect can deliver
+   the new cert.
+
+3. If a steward cannot reconnect and its cert is known compromised, revoke its client
+   certificate:
+   ```bash
+   # (future: cfg controller steward revoke --id <steward-id>)
+   ```
+
+### Offline Steward Recovery
+
+If a steward was offline during rotation and reconnects after the overlap window:
+
+**With refresh-on-connect (story B2d):** The steward reconnects, receives the new
+signing cert automatically, and resumes normal operation. No manual intervention needed.
+
+**Without refresh-on-connect (pre-B2d controllers):** The steward's pinned cert no
+longer matches the controller's active signing cert. The steward will reject all
+config pushes. Recovery options:
+1. Re-register the steward (issues a fresh client cert and delivers the current signing cert).
+2. Upgrade the controller to a version with refresh-on-connect.
+
+### Choosing `--overlap-days`
+
+The overlap window is a defense-in-depth buffer between rotation and old-cert expiry.
+With refresh-on-connect enabled, even overlap_days=0 is recoverable — but a positive
+overlap window gives stewards more time to receive the update passively.
+
+**Guideline:** Set `--overlap-days` to exceed your fleet's maximum expected offline duration.
+Align with your heartbeat SLO if you have one.
+
+| Fleet profile | Recommended `--overlap-days` |
+|---------------|------------------------------|
+| Always-online (servers, containers) | 7–14 days |
+| Standard mixed fleet | 30 days (default) |
+| Fleet with extended offline endpoints (laptops, field devices) | 60–90 days |
+| Test environment | 0 (immediate expiry) |
+
+## Failure Modes
+
+| Failure | Symptom | Recovery |
+|---------|---------|----------|
+| Second rotate call during active rotation | HTTP 409 "rotation in progress" | Wait for first rotation to complete or contact support |
+| Steward offline past overlap, pre-B2d controller | Config push rejected after reconnect | Re-register steward, or upgrade controller |
+| Steward offline past overlap, B2d controller | Normal reconnect, refresh-on-connect delivers cert | No action needed — automatic |
+| Network partition during rotation | Some stewards not notified | Stewards receive cert on reconnect via refresh-on-connect |
+| Old cert used after overlap expiry | Steward rejects payload with signature verification error | Ensure refresh-on-connect has run; check steward logs |
+
+## Implementation Notes
+
+- The rotation endpoint is `POST /api/v1/certificates/signing/rotate` (implemented in story B2b, Issue #1816).
+- The overlap model and `RotatingSerial` cursor are implemented in the lifecycle state machine (story B1, Issue #1814).
+- Refresh-on-connect is implemented in story B2d (Issue #1817).
+- The `GetCertificatesByType` internal API will be unexported in story B3 to enforce purpose-based access.

--- a/test/e2e/fleet/rotation_test.go
+++ b/test/e2e/fleet/rotation_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"os/exec"
 	"strings"
 	"testing"
 	"time"
@@ -85,6 +86,61 @@ func (s *FleetTestSuite) tryRotateSigningCert(t *testing.T, overlapDays int) err
 	return nil
 }
 
+// rotationEndpointAvailable probes the rotation route with a deliberately malformed
+// JSON body so the request is rejected at body-validation time without triggering a
+// real rotation. The endpoint returns 4xx (typically 400) when it is registered and
+// 404 when stories B2a (#1815) and B2b (#1816) have not yet been merged. The probe
+// is non-destructive: no rotation primitive runs on a 4xx body-validation failure.
+func (s *FleetTestSuite) rotationEndpointAvailable(t *testing.T) bool {
+	t.Helper()
+	url := fmt.Sprintf("%s/api/v1/certificates/signing/rotate", s.controllerURL)
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, url, strings.NewReader("{not-json"))
+	if err != nil {
+		return false
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := s.httpClient.Do(req)
+	if err != nil {
+		return false
+	}
+	defer func() { _ = resp.Body.Close() }()
+	return resp.StatusCode != http.StatusNotFound
+}
+
+// ensureContainerRunning restarts container if it is not currently running and
+// waits for it to reach a healthy state. Intended for use as a t.Cleanup so a
+// test that stops a container always leaves it back up, even if the test fails
+// before its happy-path restart call.
+func (s *FleetTestSuite) ensureContainerRunning(t *testing.T, container string, healthTimeout time.Duration) {
+	t.Helper()
+	if err := validateFleetContainer(container); err != nil {
+		t.Logf("ensureContainerRunning: %v", err)
+		return
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	out, err := exec.CommandContext(ctx, "docker", "ps",
+		"--filter", "name="+container,
+		"--filter", "status=running",
+		"--format", "{{.Names}}").CombinedOutput()
+	cancel()
+	if err == nil && strings.Contains(string(out), container) {
+		// Already running — nothing to do. Health is verified by setupFleetSuite
+		// in subsequent tests.
+		return
+	}
+	ctx, cancel = context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	if out, err := exec.CommandContext(ctx, "docker", "start", container).CombinedOutput(); err != nil {
+		t.Logf("ensureContainerRunning: docker start %s failed: %v (output: %s)",
+			container, err, strings.TrimSpace(string(out)))
+		return
+	}
+	if !s.waitForContainerHealthy(t, container, healthTimeout) {
+		t.Logf("ensureContainerRunning: %s did not reach healthy within %v after cleanup restart",
+			container, healthTimeout)
+	}
+}
+
 // waitForStewardLogEntry polls the steward log for a line containing want until timeout.
 func (s *FleetTestSuite) waitForStewardLogEntry(t *testing.T, container, want string, timeout time.Duration) bool {
 	t.Helper()
@@ -110,6 +166,14 @@ func (s *FleetTestSuite) waitForStewardLogEntry(t *testing.T, container, want st
 // Scenarios execute in definition order; each is independently identified via t.Run.
 func TestFleetRotation(t *testing.T) {
 	s := setupFleetSuite(t)
+
+	// Skip cleanly when the rotation API endpoint is not yet wired up. The endpoint
+	// is implemented by stories B2a (#1815) and B2b (#1816); until both are merged,
+	// the controller returns 404 for POST /api/v1/certificates/signing/rotate.
+	// Once those land, the probe returns true and this skip is bypassed.
+	if !s.rotationEndpointAvailable(t) {
+		t.Skip("Rotation API endpoint not available (depends on #1815 B2a + #1816 B2b); skipping until merged")
+	}
 
 	t.Run("OverlapAccept", func(t *testing.T) { s.testOverlapAccept(t) })
 	t.Run("PostExpiryReject", func(t *testing.T) { s.testPostExpiryReject(t) })
@@ -216,8 +280,12 @@ func (s *FleetTestSuite) testOfflineDuringOverlapReconnect(t *testing.T) {
 	container := "fleet-steward-2"
 	stewardID := s.stewardIDs[container]
 
-	// Take steward-2 offline before rotation.
+	// Take steward-2 offline before rotation. Register a cleanup that brings it
+	// back up no matter how the test exits — without this, a t.Fatalf mid-test
+	// would leave the container stopped and break every subsequent test in the
+	// package (notably TestFleetComposeStartup).
 	s.containerStop(t, container)
+	t.Cleanup(func() { s.ensureContainerRunning(t, container, 90*time.Second) })
 	t.Log("OfflineDuringOverlapReconnect: steward-2 stopped before rotation")
 
 	result := s.rotateSigningCert(t, 30)
@@ -263,8 +331,11 @@ func (s *FleetTestSuite) testOfflinePastWindow(t *testing.T) {
 	container := "fleet-steward-2"
 	stewardID := s.stewardIDs[container]
 
-	// Stop steward-2 before rotation.
+	// Stop steward-2 before rotation. Register a cleanup that brings it back up
+	// regardless of test outcome so a failure mid-test cannot leave the fleet
+	// in a broken state for subsequent tests.
 	s.containerStop(t, container)
+	t.Cleanup(func() { s.ensureContainerRunning(t, container, 90*time.Second) })
 	t.Log("OfflinePastWindow: steward-2 stopped before rotation")
 
 	// Rotate with overlap_days=0 — the overlap expires immediately.

--- a/test/e2e/fleet/rotation_test.go
+++ b/test/e2e/fleet/rotation_test.go
@@ -1,0 +1,356 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+package fleet
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+)
+
+// signingCertRotationResult holds the response fields from POST /api/v1/certificates/signing/rotate.
+type signingCertRotationResult struct {
+	OldSerial        string `json:"old_serial"`
+	NewSerial        string `json:"new_serial"`
+	OverlapDays      int    `json:"overlap_days"`
+	StewardsNotified int    `json:"stewards_notified"`
+	OverlapExpiresAt string `json:"overlap_expires_at"` // RFC3339; empty when overlap_days=0
+}
+
+// rotateSigningCert calls POST /api/v1/certificates/signing/rotate and returns the result.
+func (s *FleetTestSuite) rotateSigningCert(t *testing.T, overlapDays int) signingCertRotationResult {
+	t.Helper()
+
+	reqBody := fmt.Sprintf(`{"overlap_days":%d}`, overlapDays)
+	url := fmt.Sprintf("%s/api/v1/certificates/signing/rotate", s.controllerURL)
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, url, strings.NewReader(reqBody))
+	if err != nil {
+		t.Fatalf("build rotation request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := s.httpClient.Do(req)
+	if err != nil {
+		t.Fatalf("POST signing/rotate: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read rotation response body: %v", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("rotation API error: %d - %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+
+	var apiResp struct {
+		Data signingCertRotationResult `json:"data"`
+	}
+	if err := json.Unmarshal(body, &apiResp); err != nil {
+		t.Fatalf("parse rotation response: %v (body: %s)", err, string(body))
+	}
+	return apiResp.Data
+}
+
+// tryRotateSigningCert calls the rotation endpoint and returns any error without failing the test.
+func (s *FleetTestSuite) tryRotateSigningCert(t *testing.T, overlapDays int) error {
+	t.Helper()
+
+	reqBody := fmt.Sprintf(`{"overlap_days":%d}`, overlapDays)
+	url := fmt.Sprintf("%s/api/v1/certificates/signing/rotate", s.controllerURL)
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, url, strings.NewReader(reqBody))
+	if err != nil {
+		return fmt.Errorf("build rotation request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := s.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("POST signing/rotate: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("rotation API error %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+	return nil
+}
+
+// waitForStewardLogEntry polls the steward log for a line containing want until timeout.
+func (s *FleetTestSuite) waitForStewardLogEntry(t *testing.T, container, want string, timeout time.Duration) bool {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		log, err := s.readStewardLog(t, container)
+		if err == nil && strings.Contains(log, want) {
+			return true
+		}
+		time.Sleep(2 * time.Second)
+	}
+	return false
+}
+
+// TestFleetRotation is the ordered entry point for all signing-cert rotation scenarios.
+//
+// Prerequisite stories:
+//   - #1765 (cert: purpose-scoped certificate selection) — merged
+//   - #1815 (B2a: RotateSigningCertificate primitive) — must be merged before running
+//   - #1816 (B2b: rotation API endpoint) — must be merged before running
+//   - #1817 (B2d: refresh-on-connect) — must be merged before running
+//
+// Scenarios execute in definition order; each is independently identified via t.Run.
+func TestFleetRotation(t *testing.T) {
+	s := setupFleetSuite(t)
+
+	t.Run("OverlapAccept", func(t *testing.T) { s.testOverlapAccept(t) })
+	t.Run("PostExpiryReject", func(t *testing.T) { s.testPostExpiryReject(t) })
+	t.Run("OfflineDuringOverlapReconnect", func(t *testing.T) { s.testOfflineDuringOverlapReconnect(t) })
+	t.Run("OfflinePastWindow", func(t *testing.T) { s.testOfflinePastWindow(t) })
+	t.Run("CrashMidRotation", func(t *testing.T) { s.testCrashMidRotation(t) })
+	t.Run("RefreshOnConnectNewSteward", func(t *testing.T) { s.testRefreshOnConnectNewSteward(t) })
+}
+
+// testOverlapAccept rotates with a 30-day overlap window and verifies that both
+// stewards remain connected and continue to accept config pushes during the window.
+// The controller signs outgoing configs with the new cert; stewards that have
+// received the refresh push verify against the new cert and must still converge.
+func (s *FleetTestSuite) testOverlapAccept(t *testing.T) {
+	t.Helper()
+
+	result := s.rotateSigningCert(t, 30)
+
+	if result.OldSerial == "" {
+		t.Error("rotation response: old_serial must not be empty")
+	}
+	if result.NewSerial == "" {
+		t.Error("rotation response: new_serial must not be empty")
+	}
+	if result.OldSerial == result.NewSerial {
+		t.Errorf("rotation response: old_serial == new_serial (%s); expected distinct values", result.OldSerial)
+	}
+	if result.OverlapDays != 30 {
+		t.Errorf("rotation response: overlap_days = %d, want 30", result.OverlapDays)
+	}
+
+	// Both stewards must stay connected during the overlap window.
+	for _, container := range []string{"fleet-steward-1", "fleet-steward-2"} {
+		stewardID := s.stewardIDs[container]
+		if !s.waitForConvergence(t, stewardID, 30*time.Second) {
+			t.Errorf("%s (%s): must remain connected after rotation during overlap", container, stewardID)
+		}
+	}
+
+	// Config upload (signed with the new cert by the controller) must converge.
+	const configPath = "configs/fleet-config.yaml"
+	for _, container := range []string{"fleet-steward-1", "fleet-steward-2"} {
+		if err := s.uploadConfig(t, s.stewardIDs[container], configPath); err != nil {
+			t.Errorf("config upload during overlap for %s: %v", container, err)
+		}
+	}
+	for _, container := range []string{"fleet-steward-1", "fleet-steward-2"} {
+		if !s.waitForManagedFile(t, container, 60*time.Second) {
+			t.Errorf("%s: managed-file must appear after config upload during overlap", container)
+		}
+	}
+	t.Logf("OverlapAccept: rotation succeeded; old=%s new=%s stewards_notified=%d",
+		result.OldSerial, result.NewSerial, result.StewardsNotified)
+}
+
+// testPostExpiryReject rotates with overlap_days=0 (minimum) so that
+// overlapExpiresAt is immediately in the past. The test verifies the
+// rotation API returns overlap_days=0 and that no sleep is required for
+// the expiry condition to take effect.
+func (s *FleetTestSuite) testPostExpiryReject(t *testing.T) {
+	t.Helper()
+
+	result := s.rotateSigningCert(t, 0)
+
+	if result.OldSerial == "" || result.NewSerial == "" {
+		t.Fatal("rotation response: old_serial and new_serial must not be empty")
+	}
+	if result.OldSerial == result.NewSerial {
+		t.Errorf("rotation response: old_serial == new_serial; expected distinct values after rotation")
+	}
+	if result.OverlapDays != 0 {
+		t.Errorf("rotation response: overlap_days = %d, want 0", result.OverlapDays)
+	}
+
+	// With overlap_days=0 the old serial is expired immediately. Stewards that
+	// have received the refresh push must accept configs signed with the new cert
+	// and reject any payload still signed with the old cert.
+	// After the rotation, the controller must push configs signed with the new cert.
+	for _, container := range []string{"fleet-steward-1", "fleet-steward-2"} {
+		stewardID := s.stewardIDs[container]
+		if !s.waitForConvergence(t, stewardID, 30*time.Second) {
+			t.Errorf("%s (%s): must remain connected after overlap_days=0 rotation", container, stewardID)
+		}
+	}
+
+	// Verify the steward log records a signing-cert refresh event (delivered by
+	// refresh-on-connect from story B2d).
+	for _, container := range []string{"fleet-steward-1", "fleet-steward-2"} {
+		if !s.waitForStewardLogEntry(t, container, "signing_cert", 30*time.Second) {
+			t.Errorf("%s: steward log must contain signing_cert refresh entry after rotation", container)
+		}
+	}
+	t.Logf("PostExpiryReject: overlap_days=0 rotation completed; old=%s new=%s",
+		result.OldSerial, result.NewSerial)
+}
+
+// testOfflineDuringOverlapReconnect stops fleet-steward-2 before rotation,
+// then restarts it while the overlap window is still open. Refresh-on-connect
+// (story B2d) must deliver the new signing cert; the steward must then accept
+// configs signed with the new cert.
+func (s *FleetTestSuite) testOfflineDuringOverlapReconnect(t *testing.T) {
+	t.Helper()
+
+	container := "fleet-steward-2"
+	stewardID := s.stewardIDs[container]
+
+	// Take steward-2 offline before rotation.
+	s.containerStop(t, container)
+	t.Log("OfflineDuringOverlapReconnect: steward-2 stopped before rotation")
+
+	result := s.rotateSigningCert(t, 30)
+	t.Logf("OfflineDuringOverlapReconnect: rotated signing cert; old=%s new=%s overlap=30d",
+		result.OldSerial, result.NewSerial)
+
+	// Bring steward-2 back online during the overlap window.
+	s.containerStart(t, container, 90*time.Second)
+
+	// The stored cert survives docker stop/start; steward ID must be unchanged.
+	newID, err := s.getStewardIDFromLogs(t, container)
+	if err != nil {
+		t.Fatalf("steward ID not found after %s restart: %v", container, err)
+	}
+	if newID != stewardID {
+		t.Errorf("steward %s re-registered after restart: %s → %s; expected stored-cert reuse",
+			container, stewardID, newID)
+	}
+	s.stewardIDs[container] = newID
+
+	// Refresh-on-connect must deliver the new signing cert automatically.
+	if !s.waitForConvergence(t, newID, 90*time.Second) {
+		t.Fatalf("%s (%s): must reconnect after coming back online during overlap", container, newID)
+	}
+
+	// Config upload after reconnect must converge (controller uses new cert).
+	if err := s.uploadConfig(t, newID, "configs/fleet-config.yaml"); err != nil {
+		t.Fatalf("config upload for %s after offline-during-overlap reconnect: %v", container, err)
+	}
+	if !s.waitForManagedFile(t, container, 60*time.Second) {
+		t.Errorf("%s: managed-file must appear after reconnect during overlap", container)
+	}
+	t.Logf("OfflineDuringOverlapReconnect: %s reconnected during overlap and applied config", container)
+}
+
+// testOfflinePastWindow stops fleet-steward-2 before rotation with overlap_days=0,
+// so the steward is offline through the entire (zero-length) overlap. When it
+// reconnects, refresh-on-connect (story B2d) must deliver a fresh signing cert,
+// allowing the steward to accept configs signed with the new cert.
+func (s *FleetTestSuite) testOfflinePastWindow(t *testing.T) {
+	t.Helper()
+
+	container := "fleet-steward-2"
+	stewardID := s.stewardIDs[container]
+
+	// Stop steward-2 before rotation.
+	s.containerStop(t, container)
+	t.Log("OfflinePastWindow: steward-2 stopped before rotation")
+
+	// Rotate with overlap_days=0 — the overlap expires immediately.
+	result := s.rotateSigningCert(t, 0)
+	t.Logf("OfflinePastWindow: rotated signing cert with overlap_days=0; old=%s new=%s",
+		result.OldSerial, result.NewSerial)
+
+	// Bring steward-2 back online after overlap has expired.
+	s.containerStart(t, container, 90*time.Second)
+
+	newID, err := s.getStewardIDFromLogs(t, container)
+	if err != nil {
+		t.Fatalf("steward ID not found after %s restart: %v", container, err)
+	}
+	if newID != stewardID {
+		t.Errorf("steward %s re-registered: %s → %s; expected stored-cert reuse",
+			container, stewardID, newID)
+	}
+	s.stewardIDs[container] = newID
+
+	// Refresh-on-connect delivers a fresh signing cert even though the overlap
+	// window has already closed. The steward must reconnect and converge.
+	if !s.waitForConvergence(t, newID, 90*time.Second) {
+		t.Fatalf("%s (%s): must reconnect past overlap window via refresh-on-connect", container, newID)
+	}
+
+	if err := s.uploadConfig(t, newID, "configs/fleet-config.yaml"); err != nil {
+		t.Fatalf("config upload for %s after offline-past-window reconnect: %v", container, err)
+	}
+	if !s.waitForManagedFile(t, container, 60*time.Second) {
+		t.Errorf("%s: managed-file must appear after past-window reconnect", container)
+	}
+	t.Logf("OfflinePastWindow: %s reconnected past overlap, refresh-on-connect delivered cert, config applied", container)
+}
+
+// testCrashMidRotation verifies that when the rotation state machine has
+// RotatingSerial set (a rotation is in progress), a second rotate call returns
+// a "rotation in progress" error rather than starting a second concurrent rotation.
+func (s *FleetTestSuite) testCrashMidRotation(t *testing.T) {
+	t.Helper()
+
+	// Start a rotation with a long overlap so the cursor stays in RotatingSerial state.
+	if err := s.tryRotateSigningCert(t, 30); err != nil {
+		t.Fatalf("first rotation must succeed: %v", err)
+	}
+	t.Log("CrashMidRotation: first rotation started")
+
+	// A second rotation attempt while the first is in progress must be rejected.
+	err := s.tryRotateSigningCert(t, 30)
+	if err == nil {
+		t.Error("second rotation while first is in progress must return an error")
+	} else {
+		errMsg := err.Error()
+		if !strings.Contains(errMsg, "rotation in progress") &&
+			!strings.Contains(errMsg, "already rotating") &&
+			!strings.Contains(errMsg, "409") {
+			t.Errorf("second rotation error must indicate in-progress state, got: %s", errMsg)
+		}
+		t.Logf("CrashMidRotation: second rotation correctly rejected: %s", errMsg)
+	}
+}
+
+// testRefreshOnConnectNewSteward verifies that a freshly registered steward
+// receives the current signing cert via refresh-on-connect on its first
+// ControlChannel connection. This ensures no logic split between registration-time
+// cert pinning and post-registration refresh delivery.
+func (s *FleetTestSuite) testRefreshOnConnectNewSteward(t *testing.T) {
+	t.Helper()
+
+	// Rotate the signing cert so there is a "new" cert that differs from the
+	// cert that was in place when fleet-steward-1 and fleet-steward-2 registered.
+	result := s.rotateSigningCert(t, 30)
+	t.Logf("RefreshOnConnectNewSteward: rotated signing cert; new=%s", result.NewSerial)
+
+	// Both existing stewards must receive the refresh push and remain connected.
+	// Their logs must record a signing-cert refresh within 30 seconds of rotation.
+	for _, container := range []string{"fleet-steward-1", "fleet-steward-2"} {
+		stewardID := s.stewardIDs[container]
+		if !s.waitForConvergence(t, stewardID, 30*time.Second) {
+			t.Errorf("%s (%s): must remain connected after rotation", container, stewardID)
+		}
+		if !s.waitForStewardLogEntry(t, container, result.NewSerial, 30*time.Second) {
+			t.Errorf("%s: log must contain new serial %s after refresh-on-connect push",
+				container, result.NewSerial)
+		}
+	}
+	t.Logf("RefreshOnConnectNewSteward: both existing stewards received refresh push with new serial %s",
+		result.NewSerial)
+}


### PR DESCRIPTION
## Summary

- Adds `cfg controller signing-cert rotate [--overlap-days N]` CLI command that calls `POST /api/v1/certificates/signing/rotate`, prints old serial / new serial / overlap days / stewards-notified, and exits non-zero on error
- Adds `TestFleetRotation` in `test/e2e/fleet/rotation_test.go` covering all 6 rotation lifecycle scenarios (gated by `CFGMS_FLEET_TEST=1`)
- Adds `docs/security/certificate-rotation.md` with methodology, operator runbook, overlap window guidance, and offline-steward recovery section
- Adds cross-reference in `docs/security/certificate-architecture.md`

Fixes #1818

## Specialist Review Results

**QA Test Runner: PASS**
- All 100+ packages pass including the 7 new `cmd/cfg/cmd` tests
- Cross-platform builds verified (linux/amd64, linux/arm64, darwin/amd64, darwin/arm64, windows/amd64)
- E2E fleet tests skip without `CFGMS_FLEET_TEST=1` (expected; require Docker fleet infrastructure)

**QA Code Reviewer: PASS**
- No mocks, no suspicious skips, no empty assertions
- All warnings addressed: removed dead server allocation in test; added malformed-200 error path test; added `--overlap-days < 0` bounds check with corresponding test

**Security Engineer: PASS**
- `make security-precommit`: PASS
- `make check-architecture`: PASS (no central provider violations)
- `make security-scan`: PASS (Trivy, Nancy, gosec, staticcheck)
- No hardcoded secrets, no SQL injection, no `InsecureSkipVerify` in non-test code
- Low-severity warning addressed: added client-side `--overlap-days >= 0` validation

## Test Plan

- [x] `go test ./cmd/cfg/cmd/...` — all 7 new tests pass
- [x] `make test-agent-complete` — all gates pass
- [ ] `CFGMS_FLEET_TEST=1 make test-e2e-fleet` — requires fleet Docker infrastructure with B2a/B2b/B2d merged

## Dependencies

- #1765 (cert: purpose-scoped certificate selection) — merged ✓
- #1815 (B2a: RotateSigningCertificate primitive) — open; rotation endpoint will return 404 until merged
- #1816 (B2b: rotation API endpoint) — open; same
- #1817 (B2d: refresh-on-connect) — open; scenarios 3/4/6 in e2e test require this