### PR TITLE
cert: lifecycle state machine, purpose-cursor, and multi-key verifier (Issue #1814)

### DIFF
--- a/features/config/signature/multi_verifier.go
+++ b/features/config/signature/multi_verifier.go
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+//
+// MultiVerifier accepts a signature verified by any certificate in a trusted set.
+// Used during rotation overlap windows so stewards accept configs signed by either
+// the current or the rotating (previous) signing certificate.
+package signature
+
+import (
+	"crypto/x509"
+	"errors"
+	"fmt"
+	"strings"
+)
+
+// MultiVerifier holds a set of Verifier instances and accepts a signature that
+// any one of them can successfully verify. It implements the signature.Verifier
+// interface with OR semantics.
+type MultiVerifier struct {
+	verifiers []*ConfigVerifier
+}
+
+// NewMultiVerifier constructs a MultiVerifier from a slice of x509 certificates.
+// Returns ErrMissingPublicKey if the slice is nil or empty.
+func NewMultiVerifier(certs []*x509.Certificate) (*MultiVerifier, error) {
+	if len(certs) == 0 {
+		return nil, fmt.Errorf("at least one certificate is required: %w", ErrMissingPublicKey)
+	}
+
+	verifiers := make([]*ConfigVerifier, 0, len(certs))
+	for i, cert := range certs {
+		v, err := NewVerifierFromCertificate(cert)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create verifier for certificate at index %d: %w", i, err)
+		}
+		verifiers = append(verifiers, v)
+	}
+
+	return &MultiVerifier{verifiers: verifiers}, nil
+}
+
+// Verify checks the signature against each verifier in the set.
+// It applies a fingerprint-match optimisation: if sig.KeyFingerprint matches one
+// of the member verifiers, that verifier is tried first. On the first successful
+// verification the method returns nil immediately. If every verifier rejects the
+// signature a composite error is returned.
+func (mv *MultiVerifier) Verify(data []byte, sig *ConfigSignature) error {
+	if sig == nil {
+		return ErrMissingSignature
+	}
+
+	// Build an ordered trial list: fingerprint-matching verifier first, then the rest.
+	var first *ConfigVerifier
+	rest := make([]*ConfigVerifier, 0, len(mv.verifiers))
+	for _, v := range mv.verifiers {
+		if first == nil && sig.KeyFingerprint != "" && v.KeyFingerprint() == sig.KeyFingerprint {
+			first = v
+		} else {
+			rest = append(rest, v)
+		}
+	}
+
+	ordered := rest
+	if first != nil {
+		ordered = append([]*ConfigVerifier{first}, rest...)
+	}
+
+	errs := make([]error, 0, len(ordered))
+	for _, v := range ordered {
+		if err := v.Verify(data, sig); err == nil {
+			return nil
+		} else {
+			errs = append(errs, err)
+		}
+	}
+
+	return fmt.Errorf("signature verification failed against all %d certificate(s): %w",
+		len(mv.verifiers), errors.Join(errs...))
+}
+
+// SupportsAlgorithm returns true if any member verifier supports alg.
+func (mv *MultiVerifier) SupportsAlgorithm(alg Algorithm) bool {
+	for _, v := range mv.verifiers {
+		if v.SupportsAlgorithm(alg) {
+			return true
+		}
+	}
+	return false
+}
+
+// KeyFingerprint returns a comma-separated list of fingerprints from all member
+// verifiers — one fingerprint per certificate in the trusted set.
+func (mv *MultiVerifier) KeyFingerprint() string {
+	fps := make([]string, 0, len(mv.verifiers))
+	for _, v := range mv.verifiers {
+		fps = append(fps, v.KeyFingerprint())
+	}
+	return strings.Join(fps, ",")
+}

--- a/features/config/signature/multi_verifier_test.go
+++ b/features/config/signature/multi_verifier_test.go
@@ -1,0 +1,260 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+package signature
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// makeCertAndSigner generates a fresh ECDSA cert+signer pair for testing.
+func makeCertAndSigner(t *testing.T) (*x509.Certificate, *ConfigSigner, []byte) {
+	t.Helper()
+
+	privateKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	keyBytes, err := x509.MarshalECPrivateKey(privateKey)
+	require.NoError(t, err)
+	privateKeyPEM := pem.EncodeToMemory(&pem.Block{
+		Type:  "EC PRIVATE KEY",
+		Bytes: keyBytes,
+	})
+
+	serial, err := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 64))
+	require.NoError(t, err)
+
+	template := &x509.Certificate{
+		SerialNumber: serial,
+		Subject: pkix.Name{
+			CommonName: "test-signer",
+		},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(24 * time.Hour),
+		KeyUsage:              x509.KeyUsageDigitalSignature,
+		BasicConstraintsValid: true,
+	}
+
+	certDER, err := x509.CreateCertificate(rand.Reader, template, template, &privateKey.PublicKey, privateKey)
+	require.NoError(t, err)
+
+	certPEM := pem.EncodeToMemory(&pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: certDER,
+	})
+
+	x509Cert, err := x509.ParseCertificate(certDER)
+	require.NoError(t, err)
+
+	signer, err := NewSigner(&SignerConfig{
+		PrivateKeyPEM:  privateKeyPEM,
+		CertificatePEM: certPEM,
+	})
+	require.NoError(t, err)
+
+	return x509Cert, signer, certPEM
+}
+
+// TestMultiVerifierAcceptsAny verifies that a MultiVerifier accepts data signed
+// by any certificate in the set.
+//
+// (a) old cert only — verifier holds old cert, data signed with old cert -> passes
+// (b) new cert only — verifier holds new cert, data signed with new cert -> passes
+// (c) both certs, old-signed data -> passes
+// (d) both certs, new-signed data -> passes
+func TestMultiVerifierAcceptsAny(t *testing.T) {
+	oldCert, oldSigner, _ := makeCertAndSigner(t)
+	newCert, newSigner, _ := makeCertAndSigner(t)
+
+	data := []byte("config data payload")
+
+	oldSig, err := oldSigner.Sign(data)
+	require.NoError(t, err)
+
+	newSig, err := newSigner.Sign(data)
+	require.NoError(t, err)
+
+	t.Run("old_cert_only", func(t *testing.T) {
+		mv, err := NewMultiVerifier([]*x509.Certificate{oldCert})
+		require.NoError(t, err)
+		assert.NoError(t, mv.Verify(data, oldSig))
+	})
+
+	t.Run("new_cert_only", func(t *testing.T) {
+		mv, err := NewMultiVerifier([]*x509.Certificate{newCert})
+		require.NoError(t, err)
+		assert.NoError(t, mv.Verify(data, newSig))
+	})
+
+	t.Run("both_certs_old_signed_data", func(t *testing.T) {
+		mv, err := NewMultiVerifier([]*x509.Certificate{oldCert, newCert})
+		require.NoError(t, err)
+		assert.NoError(t, mv.Verify(data, oldSig))
+	})
+
+	t.Run("both_certs_new_signed_data", func(t *testing.T) {
+		mv, err := NewMultiVerifier([]*x509.Certificate{oldCert, newCert})
+		require.NoError(t, err)
+		assert.NoError(t, mv.Verify(data, newSig))
+	})
+}
+
+// TestMultiVerifierRejectsRetiredOnly verifies that a MultiVerifier holding only
+// a "retired" certificate rejects data signed with a different (new) certificate.
+func TestMultiVerifierRejectsRetiredOnly(t *testing.T) {
+	retiredCert, _, _ := makeCertAndSigner(t)
+	_, newSigner, _ := makeCertAndSigner(t)
+
+	data := []byte("config data payload")
+
+	newSig, err := newSigner.Sign(data)
+	require.NoError(t, err)
+
+	// Verifier holds only the retired cert
+	mv, err := NewMultiVerifier([]*x509.Certificate{retiredCert})
+	require.NoError(t, err)
+
+	// Verification of new-cert-signed data must fail
+	err = mv.Verify(data, newSig)
+	assert.Error(t, err, "retired-only verifier must reject new-cert-signed data")
+}
+
+// TestMultiVerifierNilOrEmptyCerts verifies that NewMultiVerifier returns an
+// error when given a nil or empty certificate slice.
+func TestMultiVerifierNilOrEmptyCerts(t *testing.T) {
+	t.Run("nil_slice", func(t *testing.T) {
+		_, err := NewMultiVerifier(nil)
+		assert.ErrorIs(t, err, ErrMissingPublicKey)
+	})
+
+	t.Run("empty_slice", func(t *testing.T) {
+		_, err := NewMultiVerifier([]*x509.Certificate{})
+		assert.ErrorIs(t, err, ErrMissingPublicKey)
+	})
+
+	t.Run("nil_certificate_in_slice", func(t *testing.T) {
+		_, err := NewMultiVerifier([]*x509.Certificate{nil})
+		assert.Error(t, err)
+	})
+}
+
+// TestMultiVerifierVerifyNilSignature verifies that Verify returns ErrMissingSignature
+// when sig is nil.
+func TestMultiVerifierVerifyNilSignature(t *testing.T) {
+	cert, _, _ := makeCertAndSigner(t)
+
+	mv, err := NewMultiVerifier([]*x509.Certificate{cert})
+	require.NoError(t, err)
+
+	err = mv.Verify([]byte("data"), nil)
+	assert.ErrorIs(t, err, ErrMissingSignature)
+}
+
+// TestMultiVerifierSupportsAlgorithm verifies that SupportsAlgorithm returns true
+// if any member supports the given algorithm.
+func TestMultiVerifierSupportsAlgorithm(t *testing.T) {
+	ecdsaCert, _, _ := makeCertAndSigner(t) // ECDSA cert
+
+	mv, err := NewMultiVerifier([]*x509.Certificate{ecdsaCert})
+	require.NoError(t, err)
+
+	assert.True(t, mv.SupportsAlgorithm(AlgorithmECDSASHA256))
+	assert.False(t, mv.SupportsAlgorithm(AlgorithmRSASHA256))
+}
+
+// TestMultiVerifierKeyFingerprint verifies that KeyFingerprint returns a
+// comma-separated list of member fingerprints.
+func TestMultiVerifierKeyFingerprint(t *testing.T) {
+	cert1, _, _ := makeCertAndSigner(t)
+	cert2, _, _ := makeCertAndSigner(t)
+
+	mv1, err := NewMultiVerifier([]*x509.Certificate{cert1})
+	require.NoError(t, err)
+
+	mv2, err := NewMultiVerifier([]*x509.Certificate{cert1, cert2})
+	require.NoError(t, err)
+
+	fp1 := mv1.KeyFingerprint()
+	fp2 := mv2.KeyFingerprint()
+
+	assert.NotEmpty(t, fp1)
+	assert.NotEmpty(t, fp2)
+	// Two certs should produce a different (longer) fingerprint string
+	assert.NotEqual(t, fp1, fp2)
+	assert.Contains(t, fp2, fp1, "combined fingerprint should contain the individual cert fingerprint")
+}
+
+// TestMultiVerifierImplementsVerifier verifies that *MultiVerifier satisfies
+// the signature.Verifier interface.
+func TestMultiVerifierImplementsVerifier(t *testing.T) {
+	cert, _, _ := makeCertAndSigner(t)
+
+	mv, err := NewMultiVerifier([]*x509.Certificate{cert})
+	require.NoError(t, err)
+
+	// Compile-time check via interface assignment
+	var _ Verifier = mv
+}
+
+// TestMultiVerifierRejectsTamperedData verifies that Verify returns an error when
+// the data does not match the signature (data was tampered after signing).
+func TestMultiVerifierRejectsTamperedData(t *testing.T) {
+	cert, signer, _ := makeCertAndSigner(t)
+
+	original := []byte("original payload")
+	sig, err := signer.Sign(original)
+	require.NoError(t, err)
+
+	mv, err := NewMultiVerifier([]*x509.Certificate{cert})
+	require.NoError(t, err)
+
+	// Tampered data must be rejected
+	tampered := []byte("tampered payload")
+	err = mv.Verify(tampered, sig)
+	assert.Error(t, err, "tampered data must be rejected by MultiVerifier")
+}
+
+// TestMultiVerifierConcurrentVerify verifies that concurrent Verify calls are
+// safe under the race detector.
+// Run with: go test -race ./features/config/signature/...
+func TestMultiVerifierConcurrentVerify(t *testing.T) {
+	cert1, signer1, _ := makeCertAndSigner(t)
+	cert2, signer2, _ := makeCertAndSigner(t)
+
+	mv, err := NewMultiVerifier([]*x509.Certificate{cert1, cert2})
+	require.NoError(t, err)
+
+	data := []byte("concurrent verify payload")
+
+	sig1, err := signer1.Sign(data)
+	require.NoError(t, err)
+
+	sig2, err := signer2.Sign(data)
+	require.NoError(t, err)
+
+	const goroutines = 50
+	var wg sync.WaitGroup
+	for i := 0; i < goroutines; i++ {
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			assert.NoError(t, mv.Verify(data, sig1))
+		}()
+		go func() {
+			defer wg.Done()
+			assert.NoError(t, mv.Verify(data, sig2))
+		}()
+	}
+	wg.Wait()
+}

--- a/pkg/cert/lifecycle.go
+++ b/pkg/cert/lifecycle.go
@@ -1,0 +1,137 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+//
+// Signing certificate lifecycle state machine for cert.Manager.
+//
+// The cursor tracks which certificate serial is "current" and which (if any) is
+// "rotating" during the overlap window. A single JSON sidecar file persists the
+// state atomically via temp-rename so that a crash mid-write never leaves a
+// half-updated cursor.
+package cert
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+const signingCursorFileName = "signing-cursor.json"
+
+// SigningCertLifecycleState describes the lifecycle phase of a config-signing certificate.
+type SigningCertLifecycleState int
+
+const (
+	// LifecycleStateCurrent is the sole active signer.
+	LifecycleStateCurrent SigningCertLifecycleState = iota
+	// LifecycleStateRotating is the previous signer still accepted during the overlap window.
+	LifecycleStateRotating
+	// LifecycleStateRetired is a signer no longer accepted for verification.
+	LifecycleStateRetired
+)
+
+// SigningCertCursor is the on-disk JSON state for the config-signing rotation.
+// It is written atomically to {basePath}/signing-cursor.json.
+// A missing file means no rotation has been initiated.
+type SigningCertCursor struct {
+	// CurrentSerial is the serial of the active signing certificate.
+	CurrentSerial string `json:"current_serial"`
+	// RotatingSerial is the serial of the previous signer still accepted during
+	// the overlap window. Empty when no rotation is in progress.
+	RotatingSerial string `json:"rotating_serial,omitempty"`
+	// OverlapWindowDays is the number of days RotatingSerial remains accepted
+	// after the rotation. Set at rotate-time (B2a); B1 reads it.
+	OverlapWindowDays int `json:"overlap_window_days"`
+	// RotatedAt is the wall-clock time when the last rotation occurred.
+	RotatedAt time.Time `json:"rotated_at"`
+	// RetiredAt records when RotatingSerial was retired (overlap window closed).
+	// Nil while the overlap window is still open or when no rotation has occurred.
+	RetiredAt *time.Time `json:"retired_at,omitempty"`
+}
+
+// loadSigningCursor reads the cursor file from basePath.
+// Returns (nil, nil) when the file does not exist — no rotation in progress.
+func loadSigningCursor(basePath string) (*SigningCertCursor, error) {
+	// #nosec G304 — path is controlled: constructed from the cert manager's storage path
+	data, err := os.ReadFile(filepath.Join(basePath, signingCursorFileName))
+	if os.IsNotExist(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("failed to read signing cursor: %w", err)
+	}
+
+	var cursor SigningCertCursor
+	if err := json.Unmarshal(data, &cursor); err != nil {
+		return nil, fmt.Errorf("failed to parse signing cursor: %w", err)
+	}
+	return &cursor, nil
+}
+
+// saveSigningCursor writes the cursor to basePath/signing-cursor.json atomically
+// via a temp-rename so a crash never leaves a half-written file.
+func saveSigningCursor(basePath string, cursor *SigningCertCursor) error {
+	data, err := json.MarshalIndent(cursor, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal signing cursor: %w", err)
+	}
+
+	filePath := filepath.Join(basePath, signingCursorFileName)
+	tmpPath := filePath + ".tmp"
+
+	if err := os.WriteFile(tmpPath, data, 0600); err != nil {
+		return fmt.Errorf("failed to write signing cursor: %w", err)
+	}
+
+	if err := os.Rename(tmpPath, filePath); err != nil {
+		_ = os.Remove(tmpPath)
+		return fmt.Errorf("failed to finalize signing cursor: %w", err)
+	}
+	return nil
+}
+
+// transitionSigningCursor atomically promotes newSerial to CurrentSerial and
+// moves the old CurrentSerial to RotatingSerial. The store's write lock is held
+// for the full read-modify-write so concurrent callers are serialised.
+//
+// Returns an error if RotatingSerial is already set and still within the overlap
+// window — a rotation is already in progress and must complete before the next one.
+func transitionSigningCursor(store *FileStore, basePath string, newSerial string, overlapDays int) error {
+	store.mu.Lock()
+	defer store.mu.Unlock()
+
+	cursor, err := loadSigningCursor(basePath)
+	if err != nil {
+		return fmt.Errorf("failed to load signing cursor: %w", err)
+	}
+
+	// Guard: reject if a rotation is already in progress and the overlap window has not expired.
+	if cursor != nil && cursor.RotatingSerial != "" {
+		overlapDuration := time.Duration(cursor.OverlapWindowDays) * 24 * time.Hour
+		if time.Since(cursor.RotatedAt) < overlapDuration {
+			return fmt.Errorf(
+				"rotation already in progress: rotating serial %q is still within %d-day overlap window (rotated %s ago)",
+				cursor.RotatingSerial,
+				cursor.OverlapWindowDays,
+				time.Since(cursor.RotatedAt).Truncate(time.Second),
+			)
+		}
+	}
+
+	oldCurrent := ""
+	if cursor != nil {
+		oldCurrent = cursor.CurrentSerial
+	}
+
+	next := &SigningCertCursor{
+		CurrentSerial:     newSerial,
+		OverlapWindowDays: overlapDays,
+		RotatedAt:         time.Now().UTC(),
+	}
+	if oldCurrent != "" {
+		next.RotatingSerial = oldCurrent
+	}
+
+	return saveSigningCursor(basePath, next)
+}

--- a/pkg/cert/lifecycle_test.go
+++ b/pkg/cert/lifecycle_test.go
@@ -1,0 +1,374 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+package cert
+
+import (
+	"fmt"
+	"os"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newTestManager creates a Manager backed by a temp directory.
+func newTestManager(t *testing.T) *Manager {
+	t.Helper()
+	m, err := NewManager(&ManagerConfig{
+		StoragePath: t.TempDir(),
+		CAConfig: &CAConfig{
+			Organization: "Test",
+			Country:      "US",
+			ValidityDays: 365,
+		},
+	})
+	require.NoError(t, err)
+	return m
+}
+
+// TestSigningCursorPersistence verifies that a cursor written with saveSigningCursor
+// can be read back via loadSigningCursor with byte-identical field values.
+func TestSigningCursorPersistence(t *testing.T) {
+	dir := t.TempDir()
+
+	retiredAt := time.Now().UTC().Truncate(time.Second).Add(-48 * time.Hour)
+	cursor := &SigningCertCursor{
+		CurrentSerial:     "current-serial-abc123",
+		RotatingSerial:    "rotating-serial-def456",
+		OverlapWindowDays: 30,
+		RotatedAt:         time.Now().UTC().Truncate(time.Second).Add(-24 * time.Hour),
+		RetiredAt:         &retiredAt,
+	}
+
+	require.NoError(t, saveSigningCursor(dir, cursor))
+
+	loaded, err := loadSigningCursor(dir)
+	require.NoError(t, err)
+	require.NotNil(t, loaded)
+
+	assert.Equal(t, cursor.CurrentSerial, loaded.CurrentSerial)
+	assert.Equal(t, cursor.RotatingSerial, loaded.RotatingSerial)
+	assert.Equal(t, cursor.OverlapWindowDays, loaded.OverlapWindowDays)
+	assert.True(t, cursor.RotatedAt.Equal(loaded.RotatedAt), "RotatedAt mismatch: %v vs %v", cursor.RotatedAt, loaded.RotatedAt)
+	require.NotNil(t, loaded.RetiredAt)
+	assert.True(t, cursor.RetiredAt.Equal(*loaded.RetiredAt), "RetiredAt mismatch: %v vs %v", *cursor.RetiredAt, *loaded.RetiredAt)
+}
+
+// TestSigningCursorPersistence_NilRetiredAt verifies cursor round-trip when RetiredAt is nil.
+func TestSigningCursorPersistence_NilRetiredAt(t *testing.T) {
+	dir := t.TempDir()
+
+	cursor := &SigningCertCursor{
+		CurrentSerial:     "current-serial-xyz",
+		OverlapWindowDays: 30,
+		RotatedAt:         time.Now().UTC().Truncate(time.Second),
+	}
+
+	require.NoError(t, saveSigningCursor(dir, cursor))
+
+	loaded, err := loadSigningCursor(dir)
+	require.NoError(t, err)
+	require.NotNil(t, loaded)
+
+	assert.Equal(t, cursor.CurrentSerial, loaded.CurrentSerial)
+	assert.Empty(t, loaded.RotatingSerial)
+	assert.Nil(t, loaded.RetiredAt)
+}
+
+// TestLoadSigningCursor_MissingFile verifies that a missing cursor file returns nil, nil.
+func TestLoadSigningCursor_MissingFile(t *testing.T) {
+	dir := t.TempDir()
+
+	cursor, err := loadSigningCursor(dir)
+	require.NoError(t, err)
+	assert.Nil(t, cursor)
+}
+
+// TestLoadSigningCursor_CorruptFile verifies that a malformed cursor file returns an error.
+func TestLoadSigningCursor_CorruptFile(t *testing.T) {
+	dir := t.TempDir()
+
+	// Write unparseable JSON to the cursor file
+	cursorPath := dir + "/signing-cursor.json"
+	require.NoError(t, os.WriteFile(cursorPath, []byte("{not valid json"), 0600))
+
+	cursor, err := loadSigningCursor(dir)
+	require.Error(t, err)
+	assert.Nil(t, cursor)
+	assert.Contains(t, err.Error(), "failed to parse signing cursor")
+}
+
+// TestTransitionSigningCursor_FirstTransition verifies that the first transition (no existing
+// cursor) sets CurrentSerial and leaves RotatingSerial empty.
+func TestTransitionSigningCursor_FirstTransition(t *testing.T) {
+	dir := t.TempDir()
+	store, err := NewFileStore(dir)
+	require.NoError(t, err)
+
+	require.NoError(t, transitionSigningCursor(store, dir, "serial-v1", 30))
+
+	cursor, err := loadSigningCursor(dir)
+	require.NoError(t, err)
+	require.NotNil(t, cursor)
+
+	assert.Equal(t, "serial-v1", cursor.CurrentSerial)
+	assert.Empty(t, cursor.RotatingSerial)
+	assert.Equal(t, 30, cursor.OverlapWindowDays)
+	assert.False(t, cursor.RotatedAt.IsZero())
+}
+
+// TestTransitionSigningCursor_SecondTransition verifies that a second transition
+// promotes the new serial to CurrentSerial and moves the old one to RotatingSerial.
+func TestTransitionSigningCursor_SecondTransition(t *testing.T) {
+	dir := t.TempDir()
+	store, err := NewFileStore(dir)
+	require.NoError(t, err)
+
+	// First transition: establish initial signer
+	require.NoError(t, transitionSigningCursor(store, dir, "serial-v1", 30))
+
+	// Advance the RotatedAt time so the overlap window is considered expired
+	cursor, err := loadSigningCursor(dir)
+	require.NoError(t, err)
+	// Manually backdate RotatedAt so the overlap window has expired
+	cursor.RotatedAt = time.Now().UTC().Add(-31 * 24 * time.Hour)
+	require.NoError(t, saveSigningCursor(dir, cursor))
+
+	// Second transition: promote serial-v2, move serial-v1 to rotating
+	require.NoError(t, transitionSigningCursor(store, dir, "serial-v2", 30))
+
+	loaded, err := loadSigningCursor(dir)
+	require.NoError(t, err)
+	require.NotNil(t, loaded)
+
+	assert.Equal(t, "serial-v2", loaded.CurrentSerial)
+	assert.Equal(t, "serial-v1", loaded.RotatingSerial)
+}
+
+// TestTransitionSigningCursor_BlockedByActiveRotation verifies that a transition
+// fails when RotatingSerial is set and the overlap window has not expired.
+func TestTransitionSigningCursor_BlockedByActiveRotation(t *testing.T) {
+	dir := t.TempDir()
+	store, err := NewFileStore(dir)
+	require.NoError(t, err)
+
+	// Set up a cursor with an active rotation (RotatedAt within overlap window)
+	cursor := &SigningCertCursor{
+		CurrentSerial:     "serial-v2",
+		RotatingSerial:    "serial-v1",
+		OverlapWindowDays: 30,
+		RotatedAt:         time.Now().UTC(), // just happened
+	}
+	require.NoError(t, saveSigningCursor(dir, cursor))
+
+	// Trying another transition should fail
+	err = transitionSigningCursor(store, dir, "serial-v3", 30)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "rotation already in progress")
+
+	// Cursor should be unchanged
+	loaded, err := loadSigningCursor(dir)
+	require.NoError(t, err)
+	assert.Equal(t, "serial-v2", loaded.CurrentSerial)
+	assert.Equal(t, "serial-v1", loaded.RotatingSerial)
+}
+
+// TestTransitionSigningCursor_AllowedAfterWindowExpired verifies that a transition
+// succeeds once the overlap window has expired.
+func TestTransitionSigningCursor_AllowedAfterWindowExpired(t *testing.T) {
+	dir := t.TempDir()
+	store, err := NewFileStore(dir)
+	require.NoError(t, err)
+
+	// Set up a cursor with an expired rotation window
+	cursor := &SigningCertCursor{
+		CurrentSerial:     "serial-v2",
+		RotatingSerial:    "serial-v1",
+		OverlapWindowDays: 30,
+		RotatedAt:         time.Now().UTC().Add(-31 * 24 * time.Hour),
+	}
+	require.NoError(t, saveSigningCursor(dir, cursor))
+
+	// Transition should succeed
+	require.NoError(t, transitionSigningCursor(store, dir, "serial-v3", 30))
+
+	loaded, err := loadSigningCursor(dir)
+	require.NoError(t, err)
+	assert.Equal(t, "serial-v3", loaded.CurrentSerial)
+	assert.Equal(t, "serial-v2", loaded.RotatingSerial)
+}
+
+// TestTransitionSigningCursorConcurrency verifies that concurrent calls do not
+// both succeed when RotatingSerial would be set. Exactly one goroutine's transition
+// wins; all others are rejected with "rotation already in progress".
+// Run with: go test -race ./pkg/cert/...
+func TestTransitionSigningCursorConcurrency(t *testing.T) {
+	dir := t.TempDir()
+	store, err := NewFileStore(dir)
+	require.NoError(t, err)
+
+	// Establish an initial cursor (CurrentSerial only, no rotation in progress)
+	initialCursor := &SigningCertCursor{
+		CurrentSerial:     "old-serial",
+		OverlapWindowDays: 30,
+		RotatedAt:         time.Now().UTC().Add(-40 * 24 * time.Hour), // expired window
+	}
+	require.NoError(t, saveSigningCursor(dir, initialCursor))
+
+	const goroutines = 20
+	results := make(chan error, goroutines)
+
+	var wg sync.WaitGroup
+	for i := 0; i < goroutines; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			results <- transitionSigningCursor(store, dir, fmt.Sprintf("new-serial-%d", i), 30)
+		}(i)
+	}
+
+	wg.Wait()
+	close(results)
+
+	var successes int
+	for err := range results {
+		if err == nil {
+			successes++
+		}
+	}
+
+	assert.Equal(t, 1, successes, "exactly one concurrent transition must succeed")
+}
+
+// TestGetSigningCursorState_NoCursor verifies that GetSigningCursorState returns nil when
+// no cursor file has been written.
+func TestGetSigningCursorState_NoCursor(t *testing.T) {
+	m := newTestManager(t)
+
+	cursor, err := m.GetSigningCursorState()
+	require.NoError(t, err)
+	assert.Nil(t, cursor)
+}
+
+// TestGetSigningCursorState_WithCursor verifies that GetSigningCursorState returns the
+// cursor that was written via transitionSigningCursor.
+func TestGetSigningCursorState_WithCursor(t *testing.T) {
+	m := newTestManager(t)
+
+	require.NoError(t, transitionSigningCursor(m.store, m.store.basePath, "serial-v1", 30))
+
+	cursor, err := m.GetSigningCursorState()
+	require.NoError(t, err)
+	require.NotNil(t, cursor)
+	assert.Equal(t, "serial-v1", cursor.CurrentSerial)
+}
+
+// TestGetAllValidSigningCertificates_NoCursor verifies that when no cursor exists all
+// valid signing certs are returned.
+func TestGetAllValidSigningCertificates_NoCursor(t *testing.T) {
+	m := newTestManager(t)
+
+	// Generate a signing cert (no cursor written)
+	sigCert, err := m.GenerateSigningCertificate(&SigningCertConfig{
+		CommonName:   "cfgms-config-signer",
+		ValidityDays: 365,
+	})
+	require.NoError(t, err)
+
+	certs, err := m.GetAllValidSigningCertificates()
+	require.NoError(t, err)
+	require.Len(t, certs, 1)
+	assert.Equal(t, sigCert.SerialNumber, certs[0].SerialNumber)
+}
+
+// TestGetAllValidSigningCertificates_CurrentOnly verifies that when the cursor has only a
+// CurrentSerial, that certificate is returned.
+func TestGetAllValidSigningCertificates_CurrentOnly(t *testing.T) {
+	m := newTestManager(t)
+
+	sigCert, err := m.GenerateSigningCertificate(&SigningCertConfig{
+		CommonName:   "cfgms-config-signer",
+		ValidityDays: 365,
+	})
+	require.NoError(t, err)
+
+	// Establish cursor pointing at the cert
+	require.NoError(t, transitionSigningCursor(m.store, m.store.basePath, sigCert.SerialNumber, 30))
+
+	certs, err := m.GetAllValidSigningCertificates()
+	require.NoError(t, err)
+	require.Len(t, certs, 1)
+	assert.Equal(t, sigCert.SerialNumber, certs[0].SerialNumber)
+}
+
+// TestGetAllValidSigningCertificates_IncludesRotatingWithinWindow verifies that
+// RotatingSerial is included when the overlap window has not expired.
+func TestGetAllValidSigningCertificates_IncludesRotatingWithinWindow(t *testing.T) {
+	m := newTestManager(t)
+
+	oldCert, err := m.GenerateSigningCertificate(&SigningCertConfig{
+		CommonName:   "cfgms-config-signer-old",
+		ValidityDays: 365,
+	})
+	require.NoError(t, err)
+
+	newCert, err := m.GenerateSigningCertificate(&SigningCertConfig{
+		CommonName:   "cfgms-config-signer-new",
+		ValidityDays: 365,
+	})
+	require.NoError(t, err)
+
+	// Set up cursor: new is current, old is rotating, overlap window active
+	cursor := &SigningCertCursor{
+		CurrentSerial:     newCert.SerialNumber,
+		RotatingSerial:    oldCert.SerialNumber,
+		OverlapWindowDays: 30,
+		RotatedAt:         time.Now().UTC(), // just rotated, window is open
+	}
+	require.NoError(t, saveSigningCursor(m.store.basePath, cursor))
+
+	certs, err := m.GetAllValidSigningCertificates()
+	require.NoError(t, err)
+	require.Len(t, certs, 2, "both current and rotating certs must be returned within overlap window")
+
+	serials := make(map[string]bool, 2)
+	for _, c := range certs {
+		serials[c.SerialNumber] = true
+	}
+	assert.True(t, serials[newCert.SerialNumber], "current cert must be included")
+	assert.True(t, serials[oldCert.SerialNumber], "rotating cert must be included within window")
+}
+
+// TestGetAllValidSigningCertificates_ExcludesRotatingAfterWindow verifies that
+// RotatingSerial is excluded once the overlap window has expired.
+func TestGetAllValidSigningCertificates_ExcludesRotatingAfterWindow(t *testing.T) {
+	m := newTestManager(t)
+
+	oldCert, err := m.GenerateSigningCertificate(&SigningCertConfig{
+		CommonName:   "cfgms-config-signer-old",
+		ValidityDays: 365,
+	})
+	require.NoError(t, err)
+
+	newCert, err := m.GenerateSigningCertificate(&SigningCertConfig{
+		CommonName:   "cfgms-config-signer-new",
+		ValidityDays: 365,
+	})
+	require.NoError(t, err)
+
+	// Set up cursor with an expired overlap window
+	cursor := &SigningCertCursor{
+		CurrentSerial:     newCert.SerialNumber,
+		RotatingSerial:    oldCert.SerialNumber,
+		OverlapWindowDays: 30,
+		RotatedAt:         time.Now().UTC().Add(-31 * 24 * time.Hour), // window expired
+	}
+	require.NoError(t, saveSigningCursor(m.store.basePath, cursor))
+
+	certs, err := m.GetAllValidSigningCertificates()
+	require.NoError(t, err)
+	require.Len(t, certs, 1, "only current cert must be returned after overlap window expires")
+	assert.Equal(t, newCert.SerialNumber, certs[0].SerialNumber)
+}

--- a/pkg/cert/manager.go
+++ b/pkg/cert/manager.go
@@ -658,3 +658,49 @@ func (m *Manager) IsRevoked(serial string) bool {
 func (m *Manager) ListRevoked() ([]RevocationEntry, error) {
 	return m.revocation.allEntries(), nil
 }
+
+// GetAllValidSigningCertificates returns the set of certificates that are valid
+// for verifying config signatures right now. It uses GetAllValidCertificatesForPurpose
+// as the source list, then filters by the signing cursor state:
+//   - CurrentSerial is always included (if valid).
+//   - RotatingSerial is included only while still within its overlap window.
+//   - If no cursor file exists (no rotation in progress) all valid signing certs are returned.
+func (m *Manager) GetAllValidSigningCertificates() ([]*CertificateInfo, error) {
+	all, err := m.GetAllValidCertificatesForPurpose(PurposeSigning)
+	if err != nil {
+		return nil, err
+	}
+
+	cursor, err := loadSigningCursor(m.store.basePath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load signing cursor: %w", err)
+	}
+
+	if cursor == nil {
+		return all, nil
+	}
+
+	allowed := make(map[string]bool, 2)
+	allowed[cursor.CurrentSerial] = true
+
+	if cursor.RotatingSerial != "" {
+		overlapDuration := time.Duration(cursor.OverlapWindowDays) * 24 * time.Hour
+		if time.Since(cursor.RotatedAt) < overlapDuration {
+			allowed[cursor.RotatingSerial] = true
+		}
+	}
+
+	result := make([]*CertificateInfo, 0, len(all))
+	for _, info := range all {
+		if allowed[info.SerialNumber] {
+			result = append(result, info)
+		}
+	}
+	return result, nil
+}
+
+// GetSigningCursorState returns the current signing cursor, or nil if no rotation
+// has been initiated. Use this to inspect lifecycle state without modifying it.
+func (m *Manager) GetSigningCursorState() (*SigningCertCursor, error) {
+	return loadSigningCursor(m.store.basePath)
+}


### PR DESCRIPTION
## Summary

- Adds `SigningCertCursor` JSON sidecar file tracking which signing cert serial is current vs. rotating, with atomic temp-rename persistence and a `store.mu` write lock guard preventing concurrent rotation
- Adds `GetAllValidSigningCertificates()` and `GetSigningCursorState()` to `cert.Manager`, sourcing from `GetAllValidCertificatesForPurpose(PurposeSigning)` and filtering by cursor state (RotatingSerial excluded once overlap window expires)
- Adds `MultiVerifier` to `features/config/signature` — OR-semantics verifier accepting a signature from any certificate in the trusted set, with fingerprint-match optimisation

## Test plan

- [x] `TestSigningCursorPersistence` — cursor round-trip with byte-identical fields
- [x] `TestTransitionSigningCursorConcurrency` — 20 goroutines, exactly one transition wins under `-race`
- [x] `TestMultiVerifierAcceptsAny` — all 4 sub-cases (old only, new only, both+old sig, both+new sig)
- [x] `TestMultiVerifierRejectsRetiredOnly` — retired-only set rejects new-cert-signed data
- [x] `TestMultiVerifierConcurrentVerify` — 100 concurrent Verify calls under `-race`
- [x] Full package test suites pass: `pkg/cert`, `features/config/signature`
- [x] Cross-platform builds: linux/amd64, linux/arm64, darwin/amd64, darwin/arm64, windows/amd64

## Specialist Review Results

**QA Test Runner**: PASS — all tests pass, lint clean, cross-platform builds verified, `/tmp/agent-validation-passed` written

**QA Code Reviewer**: PASS (0 blocking, 2 warnings addressed) — no mocks, no t.Skip(), real CFGMS components, race-detector compatible concurrency tests; two additional tests added (corrupt cursor file, tampered data) to close warning gaps

**Security Engineer**: PASS — gosec 0 issues, architecture check clean, no hardcoded secrets, no InsecureSkipVerify, G304 annotated correctly, cursor write uses 0600 permissions + atomic rename, overlap guard fails closed

## Dependencies

Depends on #1765 (merged as commit `52ae7d09`).

Fixes #1814

🤖 Generated with [Claude Code](https://claude.com/claude-code)