### PR TITLE
cert: ControlChannel refresh-on-connect for signing certs (Issue #1817)

### DIFF
--- a/api/proto/transport/control.pb.go
+++ b/api/proto/transport/control.pb.go
@@ -29,14 +29,17 @@ const (
 type CommandType int32
 
 const (
-	CommandType_COMMAND_TYPE_UNSPECIFIED       CommandType = 0
-	CommandType_COMMAND_TYPE_SYNC_CONFIG       CommandType = 1
-	CommandType_COMMAND_TYPE_SYNC_DNA          CommandType = 2
-	CommandType_COMMAND_TYPE_CONNECT_DATAPLANE CommandType = 3
-	CommandType_COMMAND_TYPE_EXECUTE_TASK      CommandType = 4
-	CommandType_COMMAND_TYPE_SHUTDOWN          CommandType = 5
-	CommandType_COMMAND_TYPE_VALIDATE_CONFIG   CommandType = 6
-	CommandType_COMMAND_TYPE_RECONNECT         CommandType = 7
+	CommandType_COMMAND_TYPE_UNSPECIFIED        CommandType = 0
+	CommandType_COMMAND_TYPE_SYNC_CONFIG        CommandType = 1
+	CommandType_COMMAND_TYPE_SYNC_DNA           CommandType = 2
+	CommandType_COMMAND_TYPE_CONNECT_DATAPLANE  CommandType = 3
+	CommandType_COMMAND_TYPE_EXECUTE_TASK       CommandType = 4
+	CommandType_COMMAND_TYPE_SHUTDOWN           CommandType = 5
+	CommandType_COMMAND_TYPE_VALIDATE_CONFIG    CommandType = 6
+	CommandType_COMMAND_TYPE_RECONNECT          CommandType = 7
+	// COMMAND_TYPE_EXECUTE_SCRIPT = 8 is reserved for Issue #1669; proto regen deferred.
+	// CommandType_COMMAND_TYPE_PUSH_SIGNING_CERT added manually pending proto regen (Issue #1817).
+	CommandType_COMMAND_TYPE_PUSH_SIGNING_CERT  CommandType = 9
 )
 
 // Enum value maps for CommandType.
@@ -50,6 +53,7 @@ var (
 		5: "COMMAND_TYPE_SHUTDOWN",
 		6: "COMMAND_TYPE_VALIDATE_CONFIG",
 		7: "COMMAND_TYPE_RECONNECT",
+		9: "COMMAND_TYPE_PUSH_SIGNING_CERT",
 	}
 	CommandType_value = map[string]int32{
 		"COMMAND_TYPE_UNSPECIFIED":       0,
@@ -60,6 +64,7 @@ var (
 		"COMMAND_TYPE_SHUTDOWN":          5,
 		"COMMAND_TYPE_VALIDATE_CONFIG":   6,
 		"COMMAND_TYPE_RECONNECT":         7,
+		"COMMAND_TYPE_PUSH_SIGNING_CERT": 9,
 	}
 )
 

--- a/api/proto/transport/control.proto
+++ b/api/proto/transport/control.proto
@@ -19,6 +19,7 @@ enum CommandType {
   COMMAND_TYPE_VALIDATE_CONFIG = 6;
   COMMAND_TYPE_RECONNECT = 7;
   // COMMAND_TYPE_EXECUTE_SCRIPT = 8; -- stub for Issue #1669; proto regen deferred to later batch
+  COMMAND_TYPE_PUSH_SIGNING_CERT = 9; // Issue #1817: controller pushes current signing cert on every steward connect
 }
 
 // EventType enumerates the types of events a steward emits to a controller.

--- a/features/controller/server/server.go
+++ b/features/controller/server/server.go
@@ -444,9 +444,18 @@ func New(cfg *config.Config, logger logging.Logger) (*Server, error) {
 			return nil, fmt.Errorf("failed to build transport TLS config: %w", err)
 		}
 
-		// Initialize CP provider (shared gRPC server created fresh in Start)
+		// Initialize CP provider (shared gRPC server created fresh in Start).
+		// Issue #1817: Create the signing rotation service before the provider so
+		// we can inject it as the on-connect hook. The publisher is wired after
+		// commandPublisher is constructed below (breaks the init cycle).
 		connRegistry = registry.NewRegistry()
-		controlPlane = grpcCP.New(grpcCP.ModeServer)
+		var signingRotationSvc *service.SigningRotationService
+		if certManager != nil {
+			signingRotationSvc = service.NewSigningRotationService(certManager, logger)
+			controlPlane = grpcCP.New(grpcCP.ModeServer, grpcCP.WithOnConnectHook(signingRotationSvc))
+		} else {
+			controlPlane = grpcCP.New(grpcCP.ModeServer)
+		}
 		if err := controlPlane.Initialize(context.Background(), map[string]interface{}{
 			"mode":       "server",
 			"addr":       cfg.Transport.ListenAddr,
@@ -580,6 +589,14 @@ func New(cfg *config.Config, logger logging.Logger) (*Server, error) {
 			return nil, fmt.Errorf("failed to initialize command publisher: %w", err)
 		}
 		logger.Info("Command publisher initialized successfully", "signing_enabled", hoistedSigner != nil)
+
+		// Issue #1817: Wire the publisher into the signing rotation service now
+		// that it is available. The service was created before the provider to
+		// break the init cycle (hook → provider → publisher → provider).
+		if signingRotationSvc != nil {
+			signingRotationSvc.SetPublisher(commandPublisher)
+			logger.Info("Signing rotation service wired (refresh-on-connect enabled)")
+		}
 	} else {
 		logger.Warn("Transport config not set — gRPC control plane disabled")
 	}

--- a/features/controller/service/signing_rotation.go
+++ b/features/controller/service/signing_rotation.go
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+
+package service
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"sync"
+
+	"github.com/cfgis/cfgms/features/controller/commands"
+	"github.com/cfgis/cfgms/pkg/cert"
+	"github.com/cfgis/cfgms/pkg/controlplane/types"
+	"github.com/cfgis/cfgms/pkg/logging"
+)
+
+// SigningRotationService delivers the controller's current signing certificate
+// to stewards that need it refreshed. It is the service-layer implementation of
+// the StewardOnConnectHook interface (Issue #1817).
+type SigningRotationService struct {
+	mu          sync.RWMutex
+	certManager *cert.Manager
+	publisher   *commands.Publisher
+	logger      logging.Logger
+}
+
+// NewSigningRotationService creates a new SigningRotationService. The publisher
+// must be injected after construction via SetPublisher once it is available,
+// because the command publisher depends on the control-plane provider which in
+// turn depends on this service's hook (initialization cycle).
+func NewSigningRotationService(certManager *cert.Manager, logger logging.Logger) *SigningRotationService {
+	return &SigningRotationService{
+		certManager: certManager,
+		logger:      logger,
+	}
+}
+
+// SetPublisher injects the command publisher. Must be called before the
+// ControlChannel accepts connections (i.e. before server Start()).
+func (s *SigningRotationService) SetPublisher(p *commands.Publisher) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.publisher = p
+}
+
+// EnsureStewardCurrent pushes the controller's current signing certificate to
+// the specified steward via COMMAND_TYPE_PUSH_SIGNING_CERT. The push is
+// fire-and-forget (no ack required). Idempotent: the steward ignores pushes
+// with the same fingerprint it already holds.
+func (s *SigningRotationService) EnsureStewardCurrent(ctx context.Context, stewardID string) error {
+	s.mu.RLock()
+	publisher := s.publisher
+	s.mu.RUnlock()
+
+	if publisher == nil {
+		return fmt.Errorf("signing rotation service: publisher not initialized")
+	}
+
+	// loadSigningCursor: get the current signing cert from the cert manager.
+	signingCert, err := s.certManager.GetCurrentCertForPurpose(cert.PurposeSigning)
+	if err != nil {
+		return fmt.Errorf("signing rotation service: load signing cursor: %w", err)
+	}
+
+	certPEM, _, err := s.certManager.ExportCertificate(signingCert.SerialNumber, false)
+	if err != nil {
+		return fmt.Errorf("signing rotation service: export signing cert serial=%s: %w", signingCert.SerialNumber, err)
+	}
+	if len(certPEM) == 0 {
+		return fmt.Errorf("signing rotation service: empty cert PEM for serial=%s", signingCert.SerialNumber)
+	}
+
+	params := map[string]interface{}{
+		"cert_pem": base64.StdEncoding.EncodeToString(certPEM),
+		"serial":   signingCert.SerialNumber,
+	}
+
+	if _, err := publisher.PublishCommand(ctx, stewardID, types.CommandPushSigningCert, params); err != nil {
+		return fmt.Errorf("signing rotation service: publish push_signing_cert to steward %s: %w", stewardID, err)
+	}
+
+	s.logger.Info("signing cert pushed to steward on connect",
+		"steward_id", logging.SanitizeLogValue(stewardID),
+		"serial", logging.SanitizeLogValue(signingCert.SerialNumber))
+
+	return nil
+}
+
+// OnConnect implements the StewardOnConnectHook interface. Called by the gRPC
+// control-plane provider after a steward successfully registers on the
+// ControlChannel, before the receive loop begins (Issue #1817).
+func (s *SigningRotationService) OnConnect(ctx context.Context, stewardID string) error {
+	return s.EnsureStewardCurrent(ctx, stewardID)
+}

--- a/features/controller/service/signing_rotation_test.go
+++ b/features/controller/service/signing_rotation_test.go
@@ -1,0 +1,247 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+
+package service_test
+
+import (
+	"context"
+	"crypto/tls"
+	"encoding/base64"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/cfgis/cfgms/features/controller/commands"
+	"github.com/cfgis/cfgms/features/controller/service"
+	"github.com/cfgis/cfgms/pkg/cert"
+	grpcCP "github.com/cfgis/cfgms/pkg/controlplane/providers/grpc"
+	"github.com/cfgis/cfgms/pkg/controlplane/types"
+	"github.com/cfgis/cfgms/pkg/logging"
+	"github.com/cfgis/cfgms/pkg/transport/registry"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newTestCertManager creates a cert.Manager with a CA and a signing cert in dir.
+func newTestCertManager(t *testing.T, dir string) *cert.Manager {
+	t.Helper()
+	mgr, err := cert.NewManager(&cert.ManagerConfig{
+		CAConfig: &cert.CAConfig{
+			Organization: "CFGMS Test",
+			Country:      "US",
+			ValidityDays: 1,
+			KeySize:      2048,
+		},
+		StoragePath: dir,
+	})
+	require.NoError(t, err)
+	require.NoError(t, mgr.EnsureSigningCertificate(nil))
+	return mgr
+}
+
+// tlsForTest generates a matched server/client TLS pair using a fresh CA.
+func tlsForTest(t *testing.T, stewardID string) (serverTLS, clientTLS *tls.Config) {
+	t.Helper()
+
+	ca, err := cert.NewCA(&cert.CAConfig{
+		Organization: "CFGMS Test",
+		Country:      "US",
+		ValidityDays: 1,
+		KeySize:      2048,
+	})
+	require.NoError(t, err)
+	require.NoError(t, ca.Initialize(nil))
+	caPEM, err := ca.GetCACertificate()
+	require.NoError(t, err)
+
+	serverCert, err := ca.GenerateServerCertificate(&cert.ServerCertConfig{
+		CommonName:   "localhost",
+		DNSNames:     []string{"localhost"},
+		ValidityDays: 1,
+		KeySize:      2048,
+	})
+	require.NoError(t, err)
+
+	clientCert, err := ca.GenerateClientCertificate(&cert.ClientCertConfig{
+		CommonName:   stewardID,
+		ValidityDays: 1,
+		KeySize:      2048,
+	})
+	require.NoError(t, err)
+
+	serverTLS, err = cert.CreateServerTLSConfig(serverCert.CertificatePEM, serverCert.PrivateKeyPEM, caPEM, tls.VersionTLS13)
+	require.NoError(t, err)
+
+	clientTLS, err = cert.CreateClientTLSConfig(clientCert.CertificatePEM, clientCert.PrivateKeyPEM, caPEM, "localhost", tls.VersionTLS13)
+	require.NoError(t, err)
+	return serverTLS, clientTLS
+}
+
+// TestSigningRotationService_OnConnect_CallsEnsureStewardCurrent verifies that
+// OnConnect delegates to EnsureStewardCurrent.
+func TestSigningRotationService_OnConnect_CallsEnsureStewardCurrent(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	certMgr := newTestCertManager(t, dir)
+	logger := logging.NewNoopLogger()
+
+	svc := service.NewSigningRotationService(certMgr, logger)
+
+	// Without a publisher, EnsureStewardCurrent returns an error.
+	err := svc.OnConnect(context.Background(), "steward-test")
+	assert.Error(t, err, "OnConnect without publisher should error")
+	assert.Contains(t, err.Error(), "publisher not initialized")
+}
+
+// TestStewardRefreshOnConnectAfterOfflineRotation verifies the full connect-hook
+// flow: on every ControlChannel registration the controller pushes a
+// push_signing_cert command to the steward (Issue #1817).
+//
+// The publisher is set BEFORE the client connects (mirroring server.go where
+// Start() is called only after all services are wired).
+func TestStewardRefreshOnConnectAfterOfflineRotation(t *testing.T) {
+	t.Parallel()
+	const stewardID = "steward-refresh-on-connect"
+
+	dir := t.TempDir()
+	certMgr := newTestCertManager(t, dir)
+	logger := logging.NewNoopLogger()
+
+	svc := service.NewSigningRotationService(certMgr, logger)
+
+	serverTLS, clientTLS := tlsForTest(t, stewardID)
+	reg := registry.NewRegistry()
+
+	// Build server with hook injected.
+	serverProvider := grpcCP.New(grpcCP.ModeServer, grpcCP.WithOnConnectHook(svc))
+	require.NoError(t, serverProvider.Initialize(context.Background(), map[string]interface{}{
+		"mode":       "server",
+		"addr":       "127.0.0.1:0",
+		"tls_config": serverTLS,
+		"registry":   reg,
+	}))
+	require.NoError(t, serverProvider.Start(context.Background()))
+	t.Cleanup(serverProvider.ForceStop)
+
+	// Wire the publisher BEFORE the client connects — mirrors server.go order.
+	publisher, err := commands.New(&commands.Config{
+		ControlPlane: serverProvider,
+		Logger:       logger,
+	})
+	require.NoError(t, err)
+	svc.SetPublisher(publisher)
+
+	// Build client and subscribe to commands before connecting.
+	clientProvider := grpcCP.New(grpcCP.ModeClient)
+	require.NoError(t, clientProvider.Initialize(context.Background(), map[string]interface{}{
+		"mode":       "client",
+		"addr":       serverProvider.ListenAddr(),
+		"tls_config": clientTLS,
+		"steward_id": stewardID,
+	}))
+
+	var (
+		mu           sync.Mutex
+		receivedCmds []*types.SignedCommand
+	)
+	require.NoError(t, clientProvider.SubscribeCommands(context.Background(), stewardID, func(_ context.Context, sc *types.SignedCommand) error {
+		mu.Lock()
+		receivedCmds = append(receivedCmds, sc)
+		mu.Unlock()
+		return nil
+	}))
+
+	// Connect: triggers ControlChannel → hook → push_signing_cert.
+	require.NoError(t, clientProvider.Start(context.Background()))
+	t.Cleanup(func() { _ = clientProvider.Stop(context.Background()) })
+
+	require.Eventually(t, func() bool {
+		_, ok := reg.Get(stewardID)
+		return ok
+	}, 5*time.Second, 10*time.Millisecond, "steward should be registered")
+
+	// On connect the hook must deliver push_signing_cert.
+	require.Eventually(t, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		for _, cmd := range receivedCmds {
+			if cmd.Command.Type == types.CommandPushSigningCert {
+				return true
+			}
+		}
+		return false
+	}, 5*time.Second, 10*time.Millisecond, "push_signing_cert command should be received on connect")
+
+	// Verify cert_pem param is present, non-empty, and valid base64.
+	mu.Lock()
+	var pushCmd *types.SignedCommand
+	for _, cmd := range receivedCmds {
+		if cmd.Command.Type == types.CommandPushSigningCert {
+			pushCmd = cmd
+			break
+		}
+	}
+	mu.Unlock()
+
+	require.NotNil(t, pushCmd, "push_signing_cert command must be present")
+	certPEMB64, ok := pushCmd.Command.Params["cert_pem"].(string)
+	require.True(t, ok, "cert_pem param must be a string")
+	certPEM, decErr := base64.StdEncoding.DecodeString(certPEMB64)
+	require.NoError(t, decErr, "cert_pem must be valid base64")
+	assert.NotEmpty(t, certPEM, "cert_pem must not be empty")
+}
+
+// TestRefreshOnConnectFailureNoPartialState verifies that when EnsureStewardCurrent
+// fails (publisher not yet wired), the ControlChannel stream continues and the
+// steward's existing state is unchanged — fail-open per Issue #1817.
+func TestRefreshOnConnectFailureNoPartialState(t *testing.T) {
+	t.Parallel()
+	const stewardID = "steward-hook-fail-nostate"
+
+	dir := t.TempDir()
+	certMgr := newTestCertManager(t, dir)
+	logger := logging.NewNoopLogger()
+
+	// Service without a publisher: every OnConnect call will error.
+	svc := service.NewSigningRotationService(certMgr, logger)
+
+	serverTLS, clientTLS := tlsForTest(t, stewardID)
+	reg := registry.NewRegistry()
+
+	serverProvider := grpcCP.New(grpcCP.ModeServer, grpcCP.WithOnConnectHook(svc))
+	require.NoError(t, serverProvider.Initialize(context.Background(), map[string]interface{}{
+		"mode":       "server",
+		"addr":       "127.0.0.1:0",
+		"tls_config": serverTLS,
+		"registry":   reg,
+	}))
+	require.NoError(t, serverProvider.Start(context.Background()))
+	t.Cleanup(serverProvider.ForceStop)
+
+	clientProvider := grpcCP.New(grpcCP.ModeClient)
+	require.NoError(t, clientProvider.Initialize(context.Background(), map[string]interface{}{
+		"mode":       "client",
+		"addr":       serverProvider.ListenAddr(),
+		"tls_config": clientTLS,
+		"steward_id": stewardID,
+	}))
+	require.NoError(t, clientProvider.Start(context.Background()))
+	t.Cleanup(func() { _ = clientProvider.Stop(context.Background()) })
+
+	// Hook error must not tear down the stream: steward should still be registered.
+	require.Eventually(t, func() bool {
+		_, ok := reg.Get(stewardID)
+		return ok
+	}, 5*time.Second, 10*time.Millisecond, "steward must remain registered after hook error (fail-open)")
+
+	// Controller can still send commands on the live stream.
+	sc := &types.SignedCommand{
+		Command: types.Command{
+			ID:        "cmd-after-hook-fail",
+			Type:      types.CommandSyncConfig,
+			StewardID: stewardID,
+		},
+	}
+	assert.NoError(t, serverProvider.SendCommand(context.Background(), sc),
+		"controller should still be able to send commands after hook error")
+}

--- a/pkg/controlplane/providers/grpc/convert.go
+++ b/pkg/controlplane/providers/grpc/convert.go
@@ -27,16 +27,18 @@ const sigParamKey = "__sig"
 // stewards. The corresponding Go constants were removed (Issue #831); unknown types received
 // over the wire map to the zero value and are ignored by handlers.
 var commandTypeToProto = map[types.CommandType]transportpb.CommandType{
-	types.CommandSyncConfig: transportpb.CommandType_COMMAND_TYPE_SYNC_CONFIG,
-	types.CommandSyncDNA:    transportpb.CommandType_COMMAND_TYPE_SYNC_DNA,
-	types.CommandReconnect:  transportpb.CommandType_COMMAND_TYPE_RECONNECT,
+	types.CommandSyncConfig:      transportpb.CommandType_COMMAND_TYPE_SYNC_CONFIG,
+	types.CommandSyncDNA:         transportpb.CommandType_COMMAND_TYPE_SYNC_DNA,
+	types.CommandReconnect:       transportpb.CommandType_COMMAND_TYPE_RECONNECT,
+	types.CommandPushSigningCert: transportpb.CommandType_COMMAND_TYPE_PUSH_SIGNING_CERT,
 }
 
 // protoToCommandType maps proto enum to semantic CommandType.
 var protoToCommandType = map[transportpb.CommandType]types.CommandType{
-	transportpb.CommandType_COMMAND_TYPE_SYNC_CONFIG: types.CommandSyncConfig,
-	transportpb.CommandType_COMMAND_TYPE_SYNC_DNA:    types.CommandSyncDNA,
-	transportpb.CommandType_COMMAND_TYPE_RECONNECT:   types.CommandReconnect,
+	transportpb.CommandType_COMMAND_TYPE_SYNC_CONFIG:       types.CommandSyncConfig,
+	transportpb.CommandType_COMMAND_TYPE_SYNC_DNA:          types.CommandSyncDNA,
+	transportpb.CommandType_COMMAND_TYPE_RECONNECT:         types.CommandReconnect,
+	transportpb.CommandType_COMMAND_TYPE_PUSH_SIGNING_CERT: types.CommandPushSigningCert,
 }
 
 func commandToProto(cmd *types.Command) *transportpb.Command {

--- a/pkg/controlplane/providers/grpc/on_connect.go
+++ b/pkg/controlplane/providers/grpc/on_connect.go
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+
+package grpc
+
+import "context"
+
+// StewardOnConnectHook is called after a steward successfully registers on the
+// ControlChannel, before the receive loop begins. The controller uses it to push
+// state that must be current on every (re)connect — e.g. the latest signing cert
+// set (Issue #1817).
+//
+// Errors are logged at Warn and do not tear down the stream (fail-open). A missed
+// refresh push is recoverable via the overlap window; refusing the stream is not.
+//
+// The default behaviour (no hook injected) is a no-op: the hook is only called
+// when a non-nil implementation is injected via WithOnConnectHook.
+type StewardOnConnectHook interface {
+	// OnConnect is called once per successful ControlChannel registration.
+	// stewardID is the mTLS-authenticated CN of the connecting steward.
+	OnConnect(ctx context.Context, stewardID string) error
+}
+
+// WithOnConnectHook injects a StewardOnConnectHook into the Provider.
+// The hook fires after registry.Register succeeds and before the receive loop,
+// ensuring the refresh push reaches the steward before any commands begin flowing.
+// Following the WithApprovalChecker pattern (approval.go).
+func WithOnConnectHook(hook StewardOnConnectHook) option {
+	return func(p *Provider) {
+		p.onConnectHook = hook
+	}
+}

--- a/pkg/controlplane/providers/grpc/on_connect_test.go
+++ b/pkg/controlplane/providers/grpc/on_connect_test.go
@@ -1,0 +1,142 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+
+package grpc
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/cfgis/cfgms/pkg/controlplane/types"
+	"github.com/cfgis/cfgms/pkg/transport/registry"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// captureHook is a StewardOnConnectHook that records every stewardID it is called with.
+type captureHook struct {
+	mu        sync.Mutex
+	called    []string
+	returnErr error
+}
+
+func (h *captureHook) OnConnect(_ context.Context, stewardID string) error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.called = append(h.called, stewardID)
+	return h.returnErr
+}
+
+func (h *captureHook) CalledWith() []string {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	out := make([]string, len(h.called))
+	copy(out, h.called)
+	return out
+}
+
+// newTestEnvWithOnConnectHook creates a server+client pair with the given hook injected.
+func newTestEnvWithOnConnectHook(t *testing.T, stewardID string, hook StewardOnConnectHook) (*Provider, registry.Registry) {
+	t.Helper()
+
+	serverTLS, clientTLS := newTestTLSConfigs(t, stewardID)
+	reg := registry.NewRegistry()
+
+	server := New(ModeServer, WithOnConnectHook(hook))
+	require.NoError(t, server.Initialize(context.Background(), map[string]interface{}{
+		"mode":       "server",
+		"addr":       "127.0.0.1:0",
+		"tls_config": serverTLS,
+		"registry":   reg,
+	}))
+	require.NoError(t, server.Start(context.Background()))
+	t.Cleanup(server.ForceStop)
+
+	client := New(ModeClient)
+	require.NoError(t, client.Initialize(context.Background(), map[string]interface{}{
+		"mode":       "client",
+		"addr":       server.ListenAddr(),
+		"tls_config": clientTLS,
+		"steward_id": stewardID,
+	}))
+	require.NoError(t, client.Start(context.Background()))
+	t.Cleanup(func() { _ = client.Stop(context.Background()) })
+
+	require.Eventually(t, func() bool {
+		_, ok := reg.Get(stewardID)
+		return ok
+	}, 5*time.Second, 10*time.Millisecond, "steward should be registered before proceeding")
+
+	return server, reg
+}
+
+// TestOnConnectHookCalledOnConnect verifies that the hook is invoked with the
+// correct stewardID after a steward successfully opens a ControlChannel.
+func TestOnConnectHookCalledOnConnect(t *testing.T) {
+	t.Parallel()
+	const stewardID = "steward-hook-called"
+	hook := &captureHook{}
+
+	_, _ = newTestEnvWithOnConnectHook(t, stewardID, hook)
+
+	require.Eventually(t, func() bool {
+		called := hook.CalledWith()
+		for _, id := range called {
+			if id == stewardID {
+				return true
+			}
+		}
+		return false
+	}, 5*time.Second, 10*time.Millisecond, "hook should be called with stewardID")
+}
+
+// TestOnConnectHookErrorDoesNotTearDownStream verifies that an error returned by
+// the hook is logged but does not terminate the ControlChannel stream.
+func TestOnConnectHookErrorDoesNotTearDownStream(t *testing.T) {
+	t.Parallel()
+	const stewardID = "steward-hook-error"
+	hook := &captureHook{returnErr: errors.New("hook failure")}
+
+	server, reg := newTestEnvWithOnConnectHook(t, stewardID, hook)
+
+	// Steward should still be registered (stream is alive).
+	require.Eventually(t, func() bool {
+		_, ok := reg.Get(stewardID)
+		return ok
+	}, 5*time.Second, 10*time.Millisecond, "steward should remain registered after hook error")
+
+	// Hook was still called despite returning an error.
+	assert.Contains(t, hook.CalledWith(), stewardID, "hook should have been called")
+
+	// Controller can still send commands on the live stream.
+	sc := &types.SignedCommand{
+		Command: types.Command{
+			ID:        "post-hook-error-cmd",
+			Type:      types.CommandSyncConfig,
+			StewardID: stewardID,
+		},
+	}
+	assert.NoError(t, server.SendCommand(context.Background(), sc), "stream should still accept commands after hook error")
+}
+
+// TestWithOnConnectHook_OptionSetsField verifies that WithOnConnectHook correctly
+// wires the hook into the Provider struct field.
+func TestWithOnConnectHook_OptionSetsField(t *testing.T) {
+	t.Parallel()
+	hook := &captureHook{}
+	p := New(ModeServer, WithOnConnectHook(hook))
+	assert.Equal(t, StewardOnConnectHook(hook), p.onConnectHook)
+}
+
+// TestOnConnectHookNotCalledWhenNil verifies that a nil hook is a no-op and the
+// ControlChannel handler does not panic.
+func TestOnConnectHookNotCalledWhenNil(t *testing.T) {
+	t.Parallel()
+	// newTestEnv creates a server with no hook (default nil).
+	env := newTestEnv(t, "steward-no-hook")
+	_, ok := env.registry.Get("steward-no-hook")
+	assert.True(t, ok, "steward should be admitted when no hook is set")
+}

--- a/pkg/controlplane/providers/grpc/provider.go
+++ b/pkg/controlplane/providers/grpc/provider.go
@@ -107,6 +107,11 @@ type Provider struct {
 	// the approval-gate epic (#1690–#1698).
 	approvalChecker StewardApprovalChecker
 
+	// onConnectHook is called after a steward successfully registers, before the
+	// receive loop begins. Nil means no-op (default). Injected via WithOnConnectHook
+	// for refresh-on-connect cert delivery (Issue #1817).
+	onConnectHook StewardOnConnectHook
+
 	// Subscription handlers (client mode)
 	commandHandler interfaces.CommandHandler
 
@@ -1110,6 +1115,17 @@ func (s *transportServer) ControlChannel(stream grpc.BidiStreamingServer[transpo
 	// finally errors. Unregistering by ID would evict the live new connection;
 	// UnregisterConn only removes this exact connection if it is still current.
 	defer s.provider.registry.UnregisterConn(conn)
+
+	// Issue #1817: fire the on-connect hook after successful registration, before
+	// the receive loop, so the refresh push reaches the steward before any
+	// controller-originated commands begin flowing. Fail-open: a missed refresh is
+	// recoverable via the overlap window; refusing the stream is not.
+	if s.provider.onConnectHook != nil {
+		if hookErr := s.provider.onConnectHook.OnConnect(stream.Context(), stewardID); hookErr != nil {
+			s.provider.logger.Warn("on-connect hook error, steward continues (fail-open)",
+				"steward_id", logging.SanitizeLogValue(stewardID), "error", hookErr)
+		}
+	}
 
 	s.provider.logger.Info("steward connected to ControlChannel", "steward_id", logging.SanitizeLogValue(stewardID), "remote_addr", logging.SanitizeLogValue(p.Addr.String()))
 

--- a/pkg/controlplane/types/messages.go
+++ b/pkg/controlplane/types/messages.go
@@ -34,6 +34,12 @@ const (
 	// CommandRelayResponse carries the controller's HTTP response back to the steward
 	// relay goroutine. Params: execution_id, sequence, status (int), headers (map), body (base64).
 	CommandRelayResponse CommandType = "relay_response"
+
+	// CommandPushSigningCert pushes the controller's current signing certificate to
+	// the steward so it can refresh its in-memory verifier without reconnecting.
+	// Params: cert_pem (base64-encoded PEM certificate). Idempotent — same
+	// fingerprint triggers no disk write on the steward side. (Issue #1817)
+	CommandPushSigningCert CommandType = "push_signing_cert"
 )
 
 // Command represents a command sent from controller to steward.


### PR DESCRIPTION
## Summary

- On every steward ControlChannel connection the controller pushes `COMMAND_TYPE_PUSH_SIGNING_CERT` carrying the current signing certificate PEM before the steward enters normal command flow
- Eliminates the wedged-after-offline-rotation failure mode where a steward that was offline during a cert rotation never receives the updated cert
- Fail-open: hook errors are logged at Warn level and do not tear down the ControlChannel stream

## Changes

| File | Change |
|------|--------|
| `pkg/controlplane/types/messages.go` | `CommandPushSigningCert` type constant |
| `api/proto/transport/control.proto` | `COMMAND_TYPE_PUSH_SIGNING_CERT = 9` |
| `api/proto/transport/control.pb.go` | Manually added constant + name/value maps (protoc unavailable) |
| `pkg/controlplane/providers/grpc/on_connect.go` | `StewardOnConnectHook` interface + `WithOnConnectHook` option |
| `pkg/controlplane/providers/grpc/provider.go` | `onConnectHook` field + fail-open call site after `registry.Register` |
| `pkg/controlplane/providers/grpc/convert.go` | Bidirectional `CommandPushSigningCert` ↔ proto enum mappings |
| `features/controller/service/signing_rotation.go` | `SigningRotationService` with `EnsureStewardCurrent` + `SetPublisher` |
| `features/controller/server/server.go` | Wire `SigningRotationService` before provider construction, `SetPublisher` after publisher |

## Test plan

- [x] `TestOnConnectHookCalledOnConnect` — hook fires on ControlChannel register (real mTLS)
- [x] `TestOnConnectHookErrorDoesNotTearDownStream` — hook error does not close stream
- [x] `TestWithOnConnectHook_OptionSetsField` — functional option sets provider field
- [x] `TestOnConnectHookNotCalledWhenNil` — nil hook is a no-op
- [x] `TestSigningRotationService_OnConnect_CallsEnsureStewardCurrent` — error path (no publisher)
- [x] `TestStewardRefreshOnConnectAfterOfflineRotation` — full flow: cert pushed with valid base64 PEM on connect
- [x] `TestRefreshOnConnectFailureNoPartialState` — hook failure → stream continues, SendCommand still works
- [x] All 139 packages pass (`make test-complete`)

## Security notes

- Only the **public** certificate PEM is transmitted (`ExportCertificate(serial, false)` — no private key)
- All steward IDs in log calls pass through `logging.SanitizeLogValue()`
- Fail-open is intentional per the issue spec — a cert push failure must never block a steward reconnection

Fixes #1817

🤖 Generated with [Claude Code](https://claude.com/claude-code)