### PR TITLE
cert: RotateSigningCertificate primitive + SigningRotationService (Issue #1815)

### DIFF
--- a/features/controller/service/signing_rotation.go
+++ b/features/controller/service/signing_rotation.go
@@ -8,6 +8,7 @@ import (
 	"encoding/base64"
 	"fmt"
 	"sync"
+	"time"
 
 	"github.com/cfgis/cfgms/features/controller/commands"
 	"github.com/cfgis/cfgms/pkg/cert"
@@ -15,14 +16,23 @@ import (
 	"github.com/cfgis/cfgms/pkg/logging"
 )
 
+// RotationResult summarises the outcome of a signing certificate rotation.
+type RotationResult struct {
+	OldSerial         string
+	NewSerial         string
+	OverlapWindowDays int
+	StewardsNotified  int
+}
+
 // SigningRotationService delivers the controller's current signing certificate
 // to stewards that need it refreshed. It is the service-layer implementation of
 // the StewardOnConnectHook interface (Issue #1817).
 type SigningRotationService struct {
-	mu          sync.RWMutex
-	certManager *cert.Manager
-	publisher   *commands.Publisher
-	logger      logging.Logger
+	mu                sync.RWMutex
+	certManager       *cert.Manager
+	publisher         *commands.Publisher
+	controllerService *ControllerService
+	logger            logging.Logger
 }
 
 // NewSigningRotationService creates a new SigningRotationService. The publisher
@@ -44,6 +54,75 @@ func (s *SigningRotationService) SetPublisher(p *commands.Publisher) {
 	s.publisher = p
 }
 
+// SetControllerService injects the controller service used by Rotate to enumerate
+// connected stewards for fan-out.
+func (s *SigningRotationService) SetControllerService(cs *ControllerService) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.controllerService = cs
+}
+
+// Rotate generates a new ConfigSigning certificate, transitions the lifecycle
+// cursor, and fans out a COMMAND_TYPE_PUSH_SIGNING_CERT command to all currently
+// connected stewards. Per-steward delivery errors are logged but do not abort
+// the rotation. An audit log entry is emitted that contains no PEM body data.
+func (s *SigningRotationService) Rotate(ctx context.Context, operatorSerial string, overlapDays int) (*RotationResult, error) {
+	// Capture the old serial before rotating.
+	cursor, err := s.certManager.GetSigningCursorState()
+	if err != nil {
+		return nil, fmt.Errorf("signing rotation: get cursor state: %w", err)
+	}
+	var oldSerial string
+	if cursor != nil {
+		oldSerial = cursor.CurrentSerial
+	}
+
+	newCert, err := s.certManager.RotateSigningCertificate(overlapDays)
+	if err != nil {
+		return nil, fmt.Errorf("signing rotation: rotate certificate: %w", err)
+	}
+
+	overlapExpiresAt := time.Now().UTC().Add(time.Duration(overlapDays) * 24 * time.Hour).Format(time.RFC3339)
+
+	s.mu.RLock()
+	publisher := s.publisher
+	controllerSvc := s.controllerService
+	s.mu.RUnlock()
+
+	var stewardsNotified int
+	if publisher != nil && controllerSvc != nil {
+		stewards := controllerSvc.GetAllStewards()
+		certPEM := base64.StdEncoding.EncodeToString(newCert.CertificatePEM)
+		params := map[string]interface{}{
+			"cert_pem":           certPEM,
+			"overlap_expires_at": overlapExpiresAt,
+		}
+		for _, steward := range stewards {
+			if _, pubErr := publisher.PublishCommand(ctx, steward.ID, types.CommandPushSigningCert, params); pubErr != nil {
+				s.logger.Error("failed to push signing cert to steward",
+					"steward_id", logging.SanitizeLogValue(steward.ID),
+					"error", pubErr)
+			} else {
+				stewardsNotified++
+			}
+		}
+	}
+
+	s.logger.Info("signing-cert rotation",
+		"operator_serial", operatorSerial,
+		"old_serial", oldSerial,
+		"new_serial", newCert.SerialNumber,
+		"overlap_days", overlapDays,
+		"stewards_notified", stewardsNotified)
+
+	return &RotationResult{
+		OldSerial:         oldSerial,
+		NewSerial:         newCert.SerialNumber,
+		OverlapWindowDays: overlapDays,
+		StewardsNotified:  stewardsNotified,
+	}, nil
+}
+
 // EnsureStewardCurrent pushes the controller's current signing certificate to
 // the specified steward via COMMAND_TYPE_PUSH_SIGNING_CERT. The push is
 // fire-and-forget (no ack required). Idempotent: the steward ignores pushes
@@ -57,7 +136,6 @@ func (s *SigningRotationService) EnsureStewardCurrent(ctx context.Context, stewa
 		return fmt.Errorf("signing rotation service: publisher not initialized")
 	}
 
-	// loadSigningCursor: get the current signing cert from the cert manager.
 	signingCert, err := s.certManager.GetCurrentCertForPurpose(cert.PurposeSigning)
 	if err != nil {
 		return fmt.Errorf("signing rotation service: load signing cursor: %w", err)
@@ -71,13 +149,21 @@ func (s *SigningRotationService) EnsureStewardCurrent(ctx context.Context, stewa
 		return fmt.Errorf("signing rotation service: empty cert PEM for serial=%s", signingCert.SerialNumber)
 	}
 
-	params := map[string]interface{}{
-		"cert_pem": base64.StdEncoding.EncodeToString(certPEM),
-		"serial":   signingCert.SerialNumber,
+	// Compute overlap_expires_at from the active cursor if rotation is in progress.
+	var overlapExpiresAt string
+	if rotCursor, cursorErr := s.certManager.GetSigningCursorState(); cursorErr == nil && rotCursor != nil && rotCursor.RotatingSerial != "" {
+		deadline := rotCursor.RotatedAt.Add(time.Duration(rotCursor.OverlapWindowDays) * 24 * time.Hour)
+		overlapExpiresAt = deadline.UTC().Format(time.RFC3339)
 	}
 
-	if _, err := publisher.PublishCommand(ctx, stewardID, types.CommandPushSigningCert, params); err != nil {
-		return fmt.Errorf("signing rotation service: publish push_signing_cert to steward %s: %w", stewardID, err)
+	params := map[string]interface{}{
+		"cert_pem":           base64.StdEncoding.EncodeToString(certPEM),
+		"serial":             signingCert.SerialNumber,
+		"overlap_expires_at": overlapExpiresAt,
+	}
+
+	if _, pubErr := publisher.PublishCommand(ctx, stewardID, types.CommandPushSigningCert, params); pubErr != nil {
+		return fmt.Errorf("signing rotation service: publish push_signing_cert to steward %s: %w", stewardID, pubErr)
 	}
 
 	s.logger.Info("signing cert pushed to steward on connect",

--- a/features/controller/service/signing_rotation_test.go
+++ b/features/controller/service/signing_rotation_test.go
@@ -7,6 +7,11 @@ import (
 	"context"
 	"crypto/tls"
 	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -21,6 +26,61 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// recordingLogger captures all log calls for assertion in tests.
+type recordingLogger struct {
+	mu      sync.Mutex
+	entries []recordedLogEntry
+}
+
+type recordedLogEntry struct {
+	level  string
+	msg    string
+	fields []interface{}
+}
+
+func (r *recordingLogger) allText() string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	var b strings.Builder
+	for _, e := range r.entries {
+		b.WriteString(e.level)
+		b.WriteString(" ")
+		b.WriteString(e.msg)
+		for i := 0; i+1 < len(e.fields); i += 2 {
+			fmt.Fprintf(&b, " %v=%v", e.fields[i], e.fields[i+1])
+		}
+		b.WriteString("\n")
+	}
+	return b.String()
+}
+
+func (r *recordingLogger) record(level, msg string, kv []interface{}) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.entries = append(r.entries, recordedLogEntry{level: level, msg: msg, fields: kv})
+}
+
+func (r *recordingLogger) Debug(msg string, kv ...interface{}) { r.record("DEBUG", msg, kv) }
+func (r *recordingLogger) Info(msg string, kv ...interface{})  { r.record("INFO", msg, kv) }
+func (r *recordingLogger) Warn(msg string, kv ...interface{})  { r.record("WARN", msg, kv) }
+func (r *recordingLogger) Error(msg string, kv ...interface{}) { r.record("ERROR", msg, kv) }
+func (r *recordingLogger) Fatal(msg string, kv ...interface{}) { r.record("FATAL", msg, kv) }
+func (r *recordingLogger) DebugCtx(_ context.Context, msg string, kv ...interface{}) {
+	r.record("DEBUG", msg, kv)
+}
+func (r *recordingLogger) InfoCtx(_ context.Context, msg string, kv ...interface{}) {
+	r.record("INFO", msg, kv)
+}
+func (r *recordingLogger) WarnCtx(_ context.Context, msg string, kv ...interface{}) {
+	r.record("WARN", msg, kv)
+}
+func (r *recordingLogger) ErrorCtx(_ context.Context, msg string, kv ...interface{}) {
+	r.record("ERROR", msg, kv)
+}
+func (r *recordingLogger) FatalCtx(_ context.Context, msg string, kv ...interface{}) {
+	r.record("FATAL", msg, kv)
+}
 
 // newTestCertManager creates a cert.Manager with a CA and a signing cert in dir.
 func newTestCertManager(t *testing.T, dir string) *cert.Manager {
@@ -244,4 +304,168 @@ func TestRefreshOnConnectFailureNoPartialState(t *testing.T) {
 	}
 	assert.NoError(t, serverProvider.SendCommand(context.Background(), sc),
 		"controller should still be able to send commands after hook error")
+}
+
+// TestEnsureStewardCurrentDelivery verifies that EnsureStewardCurrent delivers a
+// push_signing_cert command with a valid cert_pem and overlap_expires_at param.
+func TestEnsureStewardCurrentDelivery(t *testing.T) {
+	t.Parallel()
+	const stewardID = "steward-ensure-current-delivery"
+
+	dir := t.TempDir()
+	certMgr := newTestCertManager(t, dir)
+	// newTestCertManager creates an initial signing cert (cert v1) via EnsureSigningCertificate.
+
+	// Generate a second signing cert (2048-bit for speed) to act as the "rotated" cert.
+	rotatedCert, genErr := certMgr.GenerateSigningCertificate(&cert.SigningCertConfig{
+		CommonName:   "cfgms-config-signer-v2",
+		ValidityDays: 30,
+		KeySize:      2048,
+	})
+	require.NoError(t, genErr)
+
+	// Find the initial cert serial (the one that is NOT rotatedCert).
+	allSigning, listErr := certMgr.GetAllValidCertificatesForPurpose(cert.PurposeSigning)
+	require.NoError(t, listErr)
+	require.GreaterOrEqual(t, len(allSigning), 2, "must have at least 2 signing certs")
+	var initialSerial string
+	for _, c := range allSigning {
+		if c.SerialNumber != rotatedCert.SerialNumber {
+			initialSerial = c.SerialNumber
+			break
+		}
+	}
+	require.NotEmpty(t, initialSerial, "initial signing cert serial must be found")
+
+	// Write a cursor that mirrors what RotateSigningCertificate would produce for a
+	// second rotation: CurrentSerial = rotatedCert, RotatingSerial = initialCert (active
+	// 7-day overlap window). This makes EnsureStewardCurrent produce a non-empty
+	// overlap_expires_at for assertion.
+	cursorToWrite := &cert.SigningCertCursor{
+		CurrentSerial:     rotatedCert.SerialNumber,
+		RotatingSerial:    initialSerial,
+		OverlapWindowDays: 7,
+		RotatedAt:         time.Now().UTC(),
+	}
+	cursorJSON, marshalErr := json.Marshal(cursorToWrite)
+	require.NoError(t, marshalErr)
+	require.NoError(t, os.WriteFile(
+		filepath.Join(certMgr.GetStoragePath(), "signing-cursor.json"),
+		cursorJSON, 0600,
+	))
+
+	logger := logging.NewNoopLogger()
+
+	svc := service.NewSigningRotationService(certMgr, logger)
+
+	serverTLS, clientTLS := tlsForTest(t, stewardID)
+	reg := registry.NewRegistry()
+
+	serverProvider := grpcCP.New(grpcCP.ModeServer)
+	require.NoError(t, serverProvider.Initialize(context.Background(), map[string]interface{}{
+		"mode":       "server",
+		"addr":       "127.0.0.1:0",
+		"tls_config": serverTLS,
+		"registry":   reg,
+	}))
+	require.NoError(t, serverProvider.Start(context.Background()))
+	t.Cleanup(serverProvider.ForceStop)
+
+	publisher, err := commands.New(&commands.Config{
+		ControlPlane: serverProvider,
+		Logger:       logger,
+	})
+	require.NoError(t, err)
+	svc.SetPublisher(publisher)
+
+	clientProvider := grpcCP.New(grpcCP.ModeClient)
+	require.NoError(t, clientProvider.Initialize(context.Background(), map[string]interface{}{
+		"mode":       "client",
+		"addr":       serverProvider.ListenAddr(),
+		"tls_config": clientTLS,
+		"steward_id": stewardID,
+	}))
+
+	var (
+		mu           sync.Mutex
+		receivedCmds []*types.SignedCommand
+	)
+	require.NoError(t, clientProvider.SubscribeCommands(context.Background(), stewardID, func(_ context.Context, sc *types.SignedCommand) error {
+		mu.Lock()
+		receivedCmds = append(receivedCmds, sc)
+		mu.Unlock()
+		return nil
+	}))
+
+	require.NoError(t, clientProvider.Start(context.Background()))
+	t.Cleanup(func() { _ = clientProvider.Stop(context.Background()) })
+
+	require.Eventually(t, func() bool {
+		_, ok := reg.Get(stewardID)
+		return ok
+	}, 5*time.Second, 10*time.Millisecond, "steward should be registered")
+
+	require.NoError(t, svc.EnsureStewardCurrent(context.Background(), stewardID))
+
+	require.Eventually(t, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		for _, cmd := range receivedCmds {
+			if cmd.Command.Type == types.CommandPushSigningCert {
+				return true
+			}
+		}
+		return false
+	}, 5*time.Second, 10*time.Millisecond, "push_signing_cert must be received")
+
+	mu.Lock()
+	var pushCmd *types.SignedCommand
+	for _, cmd := range receivedCmds {
+		if cmd.Command.Type == types.CommandPushSigningCert {
+			pushCmd = cmd
+			break
+		}
+	}
+	mu.Unlock()
+
+	require.NotNil(t, pushCmd)
+
+	// cert_pem must be present and decode to non-empty PEM bytes.
+	certPEMB64, ok := pushCmd.Command.Params["cert_pem"].(string)
+	require.True(t, ok, "cert_pem param must be a string")
+	certPEMBytes, decErr := base64.StdEncoding.DecodeString(certPEMB64)
+	require.NoError(t, decErr, "cert_pem must be valid base64")
+	assert.NotEmpty(t, certPEMBytes, "decoded cert_pem must not be empty")
+
+	// overlap_expires_at must be present, non-empty, and a valid RFC3339 timestamp.
+	overlapVal, hasOverlap := pushCmd.Command.Params["overlap_expires_at"]
+	require.True(t, hasOverlap, "overlap_expires_at must be present in push_signing_cert params")
+	overlapStr, isStr := overlapVal.(string)
+	require.True(t, isStr, "overlap_expires_at must be a string")
+	require.NotEmpty(t, overlapStr, "overlap_expires_at must be non-empty when rotation is in progress")
+	_, parseErr := time.Parse(time.RFC3339, overlapStr)
+	assert.NoError(t, parseErr, "overlap_expires_at must be a valid RFC3339 timestamp, got: %s", overlapStr)
+}
+
+// TestRotateAuditLogNoPEMBody verifies that SigningRotationService.Rotate emits a
+// structured audit log entry that contains no PEM block header ("-----BEGIN").
+func TestRotateAuditLogNoPEMBody(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	rl := &recordingLogger{}
+	certMgr := newTestCertManager(t, dir)
+
+	svc := service.NewSigningRotationService(certMgr, rl)
+	// Inject a controller service with no stewards so fan-out is a no-op.
+	svc.SetControllerService(service.NewControllerService(logging.NewNoopLogger()))
+
+	result, err := svc.Rotate(context.Background(), "operator-serial-test", 7)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.NotEmpty(t, result.NewSerial)
+
+	// The combined log output must not contain any PEM block header.
+	allLog := rl.allText()
+	assert.NotContains(t, allLog, "-----BEGIN",
+		"audit log must not contain PEM body data; full log:\n%s", allLog)
 }

--- a/pkg/cert/manager.go
+++ b/pkg/cert/manager.go
@@ -49,6 +49,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"path/filepath"
+	"sync"
 	"time"
 )
 
@@ -76,6 +77,7 @@ type Manager struct {
 	renewer    *Renewer
 	config     *ManagerConfig
 	revocation *revocationStore
+	rotateMu   sync.Mutex // serialises RotateSigningCertificate calls
 }
 
 // NewManager creates a new certificate manager
@@ -321,6 +323,54 @@ func (m *Manager) EnsureSigningCertificate(signingCfg *SigningCertConfig) error 
 		return fmt.Errorf("failed to generate config signing certificate: %w", err)
 	}
 	return nil
+}
+
+// RotateSigningCertificate generates a new ConfigSigning certificate and atomically
+// transitions the lifecycle cursor, making the new cert active and keeping the old
+// one valid for the overlap window so in-flight verifications are not disrupted.
+//
+// Returns an error if a rotation is already in progress (RotatingSerial is set and
+// still within the overlap window). Concurrent callers are serialised; the second
+// caller will fail with "rotation already in progress" once the first completes.
+func (m *Manager) RotateSigningCertificate(overlapWindowDays int) (*Certificate, error) {
+	m.rotateMu.Lock()
+	defer m.rotateMu.Unlock()
+
+	// Early guard: reject if an active rotation is still within its overlap window.
+	cursor, err := loadSigningCursor(m.store.basePath)
+	if err != nil {
+		return nil, fmt.Errorf("load signing cursor: %w", err)
+	}
+	if cursor != nil && cursor.RotatingSerial != "" {
+		overlapDuration := time.Duration(cursor.OverlapWindowDays) * 24 * time.Hour
+		if time.Since(cursor.RotatedAt) < overlapDuration {
+			return nil, fmt.Errorf(
+				"rotation already in progress: rotating serial %q is still within %d-day overlap window (rotated %s ago)",
+				cursor.RotatingSerial,
+				cursor.OverlapWindowDays,
+				time.Since(cursor.RotatedAt).Truncate(time.Second),
+			)
+		}
+	}
+
+	newCert, err := m.ca.GenerateSigningCertificate(&SigningCertConfig{
+		CommonName:   "cfgms-config-signer",
+		ValidityDays: 1095,
+		KeySize:      4096,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("generate signing certificate: %w", err)
+	}
+
+	if err := m.store.StoreCertificate(newCert); err != nil {
+		return nil, fmt.Errorf("store signing certificate: %w", err)
+	}
+
+	if err := transitionSigningCursor(m.store, m.store.basePath, newCert.SerialNumber, overlapWindowDays); err != nil {
+		return nil, fmt.Errorf("transition signing cursor: %w", err)
+	}
+
+	return newCert, nil
 }
 
 // purposeToType maps a CertificatePurpose to its underlying CertificateType.

--- a/pkg/cert/rotation_test.go
+++ b/pkg/cert/rotation_test.go
@@ -1,0 +1,179 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+package cert
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRotateSigningCertificateSuccess verifies that a rotation from an expired overlap
+// window creates a new cert, promotes it to CurrentSerial, and moves the old serial
+// to RotatingSerial.
+func TestRotateSigningCertificateSuccess(t *testing.T) {
+	m := newTestManager(t)
+
+	initialCert, err := m.GenerateSigningCertificate(&SigningCertConfig{
+		CommonName:   "cfgms-config-signer",
+		ValidityDays: 30,
+		KeySize:      2048,
+	})
+	require.NoError(t, err)
+
+	// Establish cursor with an already-expired overlap window so next rotation is allowed.
+	require.NoError(t, transitionSigningCursor(m.store, m.store.basePath, initialCert.SerialNumber, 1))
+	cursor, err := loadSigningCursor(m.store.basePath)
+	require.NoError(t, err)
+	cursor.RotatedAt = time.Now().UTC().Add(-2 * 24 * time.Hour)
+	require.NoError(t, saveSigningCursor(m.store.basePath, cursor))
+
+	newCert, err := m.RotateSigningCertificate(7)
+	require.NoError(t, err)
+	require.NotNil(t, newCert)
+	assert.NotEqual(t, initialCert.SerialNumber, newCert.SerialNumber)
+	assert.Equal(t, CertificateTypeConfigSigning, newCert.Type)
+
+	loaded, err := loadSigningCursor(m.store.basePath)
+	require.NoError(t, err)
+	require.NotNil(t, loaded)
+	assert.Equal(t, newCert.SerialNumber, loaded.CurrentSerial)
+	assert.Equal(t, initialCert.SerialNumber, loaded.RotatingSerial)
+	assert.Equal(t, 7, loaded.OverlapWindowDays)
+}
+
+// TestRotateSigningCertificateInProgressError verifies that RotateSigningCertificate
+// returns "rotation already in progress" when RotatingSerial is still within the
+// overlap window.
+func TestRotateSigningCertificateInProgressError(t *testing.T) {
+	m := newTestManager(t)
+
+	oldCert, err := m.GenerateSigningCertificate(&SigningCertConfig{
+		CommonName:   "cfgms-config-signer-old",
+		ValidityDays: 30,
+		KeySize:      2048,
+	})
+	require.NoError(t, err)
+
+	newCert, err := m.GenerateSigningCertificate(&SigningCertConfig{
+		CommonName:   "cfgms-config-signer-current",
+		ValidityDays: 30,
+		KeySize:      2048,
+	})
+	require.NoError(t, err)
+
+	// Active rotation: RotatedAt is now, window is 30 days — far from expired.
+	cursor := &SigningCertCursor{
+		CurrentSerial:     newCert.SerialNumber,
+		RotatingSerial:    oldCert.SerialNumber,
+		OverlapWindowDays: 30,
+		RotatedAt:         time.Now().UTC(),
+	}
+	require.NoError(t, saveSigningCursor(m.store.basePath, cursor))
+
+	_, err = m.RotateSigningCertificate(7)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "rotation already in progress")
+
+	// Cursor must be unchanged.
+	unchanged, err := loadSigningCursor(m.store.basePath)
+	require.NoError(t, err)
+	assert.Equal(t, newCert.SerialNumber, unchanged.CurrentSerial)
+	assert.Equal(t, oldCert.SerialNumber, unchanged.RotatingSerial)
+}
+
+// TestRotateSigningCertificateCrashRecovery verifies that a leftover .tmp file from
+// a crash mid-write does not prevent a subsequent successful rotation.
+func TestRotateSigningCertificateCrashRecovery(t *testing.T) {
+	m := newTestManager(t)
+
+	initialCert, err := m.GenerateSigningCertificate(&SigningCertConfig{
+		CommonName:   "cfgms-config-signer",
+		ValidityDays: 30,
+		KeySize:      2048,
+	})
+	require.NoError(t, err)
+
+	// Cursor with an expired overlap window so rotation is allowed.
+	cursor := &SigningCertCursor{
+		CurrentSerial:     initialCert.SerialNumber,
+		OverlapWindowDays: 1,
+		RotatedAt:         time.Now().UTC().Add(-2 * 24 * time.Hour),
+	}
+	require.NoError(t, saveSigningCursor(m.store.basePath, cursor))
+
+	// Simulate a crash: write an orphaned .tmp file that saveSigningCursor would
+	// leave behind if the process died between WriteFile and Rename.
+	tmpPath := filepath.Join(m.store.basePath, "signing-cursor.json.tmp")
+	require.NoError(t, os.WriteFile(tmpPath, []byte(`{"partial": true}`), 0600))
+
+	// Rotation must succeed despite the orphaned tmp file.
+	newCert, err := m.RotateSigningCertificate(7)
+	require.NoError(t, err)
+	require.NotNil(t, newCert)
+	assert.NotEqual(t, initialCert.SerialNumber, newCert.SerialNumber)
+
+	loaded, err := loadSigningCursor(m.store.basePath)
+	require.NoError(t, err)
+	require.NotNil(t, loaded)
+	assert.Equal(t, newCert.SerialNumber, loaded.CurrentSerial)
+	assert.Equal(t, initialCert.SerialNumber, loaded.RotatingSerial)
+	assert.Equal(t, 7, loaded.OverlapWindowDays)
+}
+
+// TestRotateSigningCertificateConcurrency verifies that concurrent calls to
+// RotateSigningCertificate are serialised: exactly one call succeeds and the
+// rest return "rotation already in progress".
+// Run with: go test -race ./pkg/cert/...
+func TestRotateSigningCertificateConcurrency(t *testing.T) {
+	m := newTestManager(t)
+
+	// Generate initial cert so a cursor can be established.
+	initialCert, err := m.GenerateSigningCertificate(&SigningCertConfig{
+		CommonName:   "cfgms-config-signer",
+		ValidityDays: 30,
+		KeySize:      2048,
+	})
+	require.NoError(t, err)
+
+	// Establish cursor with an expired overlap window so the first rotation is allowed.
+	require.NoError(t, transitionSigningCursor(m.store, m.store.basePath, initialCert.SerialNumber, 1))
+	cursor, err := loadSigningCursor(m.store.basePath)
+	require.NoError(t, err)
+	cursor.RotatedAt = time.Now().UTC().Add(-2 * 24 * time.Hour)
+	require.NoError(t, saveSigningCursor(m.store.basePath, cursor))
+
+	const goroutines = 5
+	errs := make(chan error, goroutines)
+
+	var wg sync.WaitGroup
+	for i := 0; i < goroutines; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, rotErr := m.RotateSigningCertificate(30)
+			errs <- rotErr
+		}()
+	}
+
+	wg.Wait()
+	close(errs)
+
+	var successes, inProgressErrors int
+	for rotErr := range errs {
+		if rotErr == nil {
+			successes++
+		} else if strings.Contains(rotErr.Error(), "rotation already in progress") {
+			inProgressErrors++
+		}
+	}
+
+	assert.Equal(t, 1, successes, "exactly one concurrent rotation must succeed")
+	assert.Equal(t, goroutines-1, inProgressErrors, "all other goroutines must report rotation in progress")
+}


### PR DESCRIPTION
## Summary

- Adds `RotateSigningCertificate(overlapWindowDays int) (*Certificate, error)` to `pkg/cert.Manager` with a dedicated `rotateMu` mutex that serialises concurrent calls; concurrent callers fail with "rotation already in progress" after the first rotation completes
- Adds `Rotate(ctx, operatorSerial, overlapDays)` to `SigningRotationService`: generates new cert, fans out `CommandPushSigningCert` with `cert_pem` + `overlap_expires_at` to all stewards from `GetAllStewards()`, logs per-steward errors without aborting rotation, emits audit log with no PEM body data
- `EnsureStewardCurrent` extended to include `overlap_expires_at` (active cursor's window deadline); both fan-out paths standardised on the `cert_pem` param key

Fixes #1815

## Test plan

- [x] `TestRotateSigningCertificateConcurrency` — 5 goroutines, exactly one succeeds, rest return "rotation already in progress"; passes `go test -race`
- [x] `TestRotateSigningCertificateCrashRecovery` — orphaned `.tmp` cursor file does not block subsequent rotation
- [x] `TestRotateSigningCertificateSuccess` and `TestRotateSigningCertificateInProgressError` — happy path and guard path
- [x] `TestEnsureStewardCurrentDelivery` — full gRPC integration; asserts `cert_pem` is valid base64 PEM and `overlap_expires_at` is a non-empty RFC3339 timestamp
- [x] `TestRotateAuditLogNoPEMBody` — recording logger confirms no `"-----BEGIN"` in any audit log field
- [x] All pre-existing tests in `pkg/cert/...` and `features/controller/service/...` still pass

## Specialist Review Results

**QA Test Runner:** PASS — `make test-agent-complete` clean (0 lint issues, all tests pass, cross-platform builds pass, secret scan clean, architecture compliance clean)

**QA Code Reviewer:** PASS — No blocking issues. Both param key paths aligned to `cert_pem`. `TestEnsureStewardCurrentDelivery` asserts non-empty RFC3339 `overlap_expires_at`. `recordingLogger` is a real Logger implementation, not a CFGMS component mock.

**Security Engineer:** PASS — No blocking issues. Audit log confirmed PEM-free. `rotateMu` concurrency guard verified. No hardcoded secrets. `logging.SanitizeLogValue()` applied to steward IDs. `make security-scan` (gosec, Trivy, Nancy, staticcheck) all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)