### PR TITLE
cert: unexport GetCertificatesByType + AST lint rule (Issue #1819)

### DIFF
--- a/cmd/cert-manager/main.go
+++ b/cmd/cert-manager/main.go
@@ -251,15 +251,19 @@ func listCmd() *cobra.Command {
 
 			switch certType {
 			case "api":
-				certificates, err = manager.GetCertificatesByType(cert.CertificateTypePublicAPI)
+				certificates, err = manager.GetAllValidCertificatesForPurpose(cert.PurposeAPI)
 			case "internal":
-				certificates, err = manager.GetCertificatesByType(cert.CertificateTypeInternalServer)
+				certificates, err = manager.GetAllValidCertificatesForPurpose(cert.PurposeTransport)
 			case "signing":
-				certificates, err = manager.GetCertificatesByType(cert.CertificateTypeConfigSigning)
+				certificates, err = manager.GetAllValidCertificatesForPurpose(cert.PurposeSigning)
 			case "client":
-				certificates, err = manager.GetCertificatesByType(cert.CertificateTypeClient)
+				certificates, err = manager.GetAllValidCertificatesForPurpose(cert.PurposeClient)
 			case "ca":
-				certificates, err = manager.GetCertificatesByType(cert.CertificateTypeCA)
+				if caInfo, caErr := manager.GetCAInfo(); caErr != nil {
+					err = caErr
+				} else if caInfo != nil {
+					certificates = []*cert.CertificateInfo{caInfo}
+				}
 			default:
 				certificates, err = manager.ListCertificates()
 			}

--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -540,7 +540,7 @@ func runBootstrapAdminList(cfg *config.Config) error {
 		return fmt.Errorf("failed to load cert manager: %w", err)
 	}
 
-	certs, err := certManager.GetCertificatesByType(certpkg.CertificateTypeClient)
+	certs, err := certManager.GetAllValidCertificatesForPurpose(certpkg.PurposeClient)
 	if err != nil {
 		return fmt.Errorf("failed to list certificates: %w", err)
 	}

--- a/features/controller/server/server.go
+++ b/features/controller/server/server.go
@@ -477,7 +477,7 @@ func New(cfg *config.Config, logger logging.Logger) (*Server, error) {
 		// caches the controller's signing certificate at registration (and
 		// restores it from disk on a cert-reuse reconnect) and rejects any
 		// command or config signed by a different key. The gRPC server
-		// certificate must never be used as the signer: GetCertificatesByType
+		// certificate must never be used as the signer: listing certs by type
 		// returns every Server-typed cert newest-first, and the controller owns
 		// more than one (gRPC transport + HTTP API), so that selection is not
 		// stable across restarts. EnsureSigningCertificate is idempotent — it
@@ -486,9 +486,9 @@ func New(cfg *config.Config, logger logging.Logger) (*Server, error) {
 			if ensureErr := certManager.EnsureSigningCertificate(nil); ensureErr != nil {
 				logger.Warn("Failed to ensure config signing certificate", "error", ensureErr)
 			}
-			signerCerts, scErr := certManager.GetCertificatesByType(cert.CertificateTypeConfigSigning)
-			if scErr == nil && len(signerCerts) > 0 {
-				hoistedSignerCertSerial = signerCerts[0].SerialNumber
+			signerCert, scErr := certManager.GetCurrentCertForPurpose(cert.PurposeSigning)
+			if scErr == nil {
+				hoistedSignerCertSerial = signerCert.SerialNumber
 				certPEM, keyPEM, exportErr := certManager.ExportCertificate(hoistedSignerCertSerial, true)
 				if exportErr == nil && len(certPEM) > 0 && len(keyPEM) > 0 {
 					var signerErr error

--- a/features/steward/health.go
+++ b/features/steward/health.go
@@ -398,8 +398,8 @@ func (h *HealthMonitor) updateCertificateHealth() {
 		return
 	}
 
-	// Get current certificates and check their validity
-	certificates, err := h.certManager.GetCertificatesByType(cert.CertificateTypeClient)
+	// Get current valid certificates and check their validity
+	certificates, err := h.certManager.GetAllValidCertificatesForPurpose(cert.PurposeClient)
 	if err != nil {
 		h.logger.Error("Failed to get certificates for health check", "error", err)
 		h.metrics.CertificateErrors++

--- a/pkg/cert/architecture_test.go
+++ b/pkg/cert/architecture_test.go
@@ -4,6 +4,10 @@ package cert
 
 import (
 	"bytes"
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -21,11 +25,11 @@ func TestEnsureSeparatedCertificates_GeneratesMissing(t *testing.T) {
 	manager := setupTestManager(t)
 
 	// Verify no separated certs exist initially
-	internalCerts, err := manager.GetCertificatesByType(CertificateTypeInternalServer)
+	internalCerts, err := manager.GetAllValidCertificatesForPurpose(PurposeTransport)
 	require.NoError(t, err)
 	assert.Empty(t, internalCerts)
 
-	signingCerts, err := manager.GetCertificatesByType(CertificateTypeConfigSigning)
+	signingCerts, err := manager.GetAllValidCertificatesForPurpose(PurposeSigning)
 	require.NoError(t, err)
 	assert.Empty(t, signingCerts)
 
@@ -34,12 +38,12 @@ func TestEnsureSeparatedCertificates_GeneratesMissing(t *testing.T) {
 	require.NoError(t, err)
 
 	// Verify both cert types were generated
-	internalCerts, err = manager.GetCertificatesByType(CertificateTypeInternalServer)
+	internalCerts, err = manager.GetAllValidCertificatesForPurpose(PurposeTransport)
 	require.NoError(t, err)
 	assert.Len(t, internalCerts, 1, "should generate exactly one internal server cert")
 	assert.Equal(t, "cfgms-internal", internalCerts[0].CommonName)
 
-	signingCerts, err = manager.GetCertificatesByType(CertificateTypeConfigSigning)
+	signingCerts, err = manager.GetAllValidCertificatesForPurpose(PurposeSigning)
 	require.NoError(t, err)
 	assert.Len(t, signingCerts, 1, "should generate exactly one signing cert")
 	assert.Equal(t, "cfgms-config-signer", signingCerts[0].CommonName)
@@ -58,11 +62,11 @@ func TestEnsureSeparatedCertificates_Idempotent(t *testing.T) {
 	require.NoError(t, err)
 
 	// Should still have exactly one of each
-	internalCerts, err := manager.GetCertificatesByType(CertificateTypeInternalServer)
+	internalCerts, err := manager.GetAllValidCertificatesForPurpose(PurposeTransport)
 	require.NoError(t, err)
 	assert.Len(t, internalCerts, 1)
 
-	signingCerts, err := manager.GetCertificatesByType(CertificateTypeConfigSigning)
+	signingCerts, err := manager.GetAllValidCertificatesForPurpose(PurposeSigning)
 	require.NoError(t, err)
 	assert.Len(t, signingCerts, 1)
 }
@@ -88,12 +92,12 @@ func TestEnsureSeparatedCertificates_CustomConfig(t *testing.T) {
 	err := manager.EnsureSeparatedCertificates(internalCfg, signingCfg)
 	require.NoError(t, err)
 
-	internalCerts, err := manager.GetCertificatesByType(CertificateTypeInternalServer)
+	internalCerts, err := manager.GetAllValidCertificatesForPurpose(PurposeTransport)
 	require.NoError(t, err)
 	require.Len(t, internalCerts, 1)
 	assert.Equal(t, "my-custom-internal", internalCerts[0].CommonName)
 
-	signingCerts, err := manager.GetCertificatesByType(CertificateTypeConfigSigning)
+	signingCerts, err := manager.GetAllValidCertificatesForPurpose(PurposeSigning)
 	require.NoError(t, err)
 	require.Len(t, signingCerts, 1)
 	assert.Equal(t, "my-custom-signer", signingCerts[0].CommonName)
@@ -158,12 +162,12 @@ func TestRestartStability_InternalAndSigningCertsStable(t *testing.T) {
 	// First boot: generate certs
 	require.NoError(t, manager.EnsureSeparatedCertificates(nil, nil))
 
-	internalAfterBoot1, err := manager.GetCertificatesByType(CertificateTypeInternalServer)
+	internalAfterBoot1, err := manager.GetAllValidCertificatesForPurpose(PurposeTransport)
 	require.NoError(t, err)
 	require.Len(t, internalAfterBoot1, 1)
 	firstInternalSerial := internalAfterBoot1[0].SerialNumber
 
-	signingAfterBoot1, err := manager.GetCertificatesByType(CertificateTypeConfigSigning)
+	signingAfterBoot1, err := manager.GetAllValidCertificatesForPurpose(PurposeSigning)
 	require.NoError(t, err)
 	require.Len(t, signingAfterBoot1, 1)
 	firstSigningSerial := signingAfterBoot1[0].SerialNumber
@@ -173,14 +177,14 @@ func TestRestartStability_InternalAndSigningCertsStable(t *testing.T) {
 		require.NoError(t, manager.EnsureSeparatedCertificates(nil, nil))
 	}
 
-	internalAfterReboots, err := manager.GetCertificatesByType(CertificateTypeInternalServer)
+	internalAfterReboots, err := manager.GetAllValidCertificatesForPurpose(PurposeTransport)
 	require.NoError(t, err)
 	require.Len(t, internalAfterReboots, 1,
 		"EnsureSeparatedCertificates must not accrete InternalServer certs")
 	assert.Equal(t, firstInternalSerial, internalAfterReboots[0].SerialNumber,
 		"InternalServer cert serial must be stable across restarts (AC5)")
 
-	signingAfterReboots, err := manager.GetCertificatesByType(CertificateTypeConfigSigning)
+	signingAfterReboots, err := manager.GetAllValidCertificatesForPurpose(PurposeSigning)
 	require.NoError(t, err)
 	require.Len(t, signingAfterReboots, 1,
 		"EnsureSeparatedCertificates must not accrete ConfigSigning certs")
@@ -418,13 +422,13 @@ func findRepoRoot(t *testing.T) string {
 func TestEnsureSigningCertificate_GeneratesWhenMissing(t *testing.T) {
 	manager := setupTestManager(t)
 
-	signingCerts, err := manager.GetCertificatesByType(CertificateTypeConfigSigning)
+	signingCerts, err := manager.GetAllValidCertificatesForPurpose(PurposeSigning)
 	require.NoError(t, err)
 	assert.Empty(t, signingCerts)
 
 	require.NoError(t, manager.EnsureSigningCertificate(nil))
 
-	signingCerts, err = manager.GetCertificatesByType(CertificateTypeConfigSigning)
+	signingCerts, err = manager.GetAllValidCertificatesForPurpose(PurposeSigning)
 	require.NoError(t, err)
 	assert.Len(t, signingCerts, 1, "should generate exactly one config signing cert")
 	assert.Equal(t, "cfgms-config-signer", signingCerts[0].CommonName)
@@ -440,7 +444,7 @@ func TestEnsureSigningCertificate_StableAcrossCalls(t *testing.T) {
 	manager := setupTestManager(t)
 
 	require.NoError(t, manager.EnsureSigningCertificate(nil))
-	first, err := manager.GetCertificatesByType(CertificateTypeConfigSigning)
+	first, err := manager.GetAllValidCertificatesForPurpose(PurposeSigning)
 	require.NoError(t, err)
 	require.Len(t, first, 1)
 	firstSerial := first[0].SerialNumber
@@ -450,7 +454,7 @@ func TestEnsureSigningCertificate_StableAcrossCalls(t *testing.T) {
 		require.NoError(t, manager.EnsureSigningCertificate(nil))
 	}
 
-	after, err := manager.GetCertificatesByType(CertificateTypeConfigSigning)
+	after, err := manager.GetAllValidCertificatesForPurpose(PurposeSigning)
 	require.NoError(t, err)
 	require.Len(t, after, 1, "EnsureSigningCertificate must not accrete certificates")
 	assert.Equal(t, firstSerial, after[0].SerialNumber,
@@ -463,14 +467,136 @@ func TestEnsureSigningCertificate_NoOpAfterSeparatedCerts(t *testing.T) {
 	manager := setupTestManager(t)
 
 	require.NoError(t, manager.EnsureSeparatedCertificates(nil, nil))
-	before, err := manager.GetCertificatesByType(CertificateTypeConfigSigning)
+	before, err := manager.GetAllValidCertificatesForPurpose(PurposeSigning)
 	require.NoError(t, err)
 	require.Len(t, before, 1)
 
 	require.NoError(t, manager.EnsureSigningCertificate(nil))
 
-	after, err := manager.GetCertificatesByType(CertificateTypeConfigSigning)
+	after, err := manager.GetAllValidCertificatesForPurpose(PurposeSigning)
 	require.NoError(t, err)
 	require.Len(t, after, 1, "must reuse the existing signing cert")
 	assert.Equal(t, before[0].SerialNumber, after[0].SerialNumber)
+}
+
+// TestNoGetCertificatesByTypeOutsideCertPackage enforces that GetCertificatesByType
+// is never called outside pkg/cert. The method is package-private on FileStore and
+// removed from Manager's public API. Callers outside pkg/cert must use
+// GetCurrentCertForPurpose or GetAllValidCertificatesForPurpose instead.
+func TestNoGetCertificatesByTypeOutsideCertPackage(t *testing.T) {
+	repoRoot := findRepoRoot(t)
+	certPkgPath := filepath.Join(repoRoot, "pkg", "cert")
+
+	var violations []string
+	err := filepath.WalkDir(repoRoot, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			if d.Name() == "vendor" || d.Name() == "worktrees" {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+		// pkg/cert internals use the private getCertificatesByType — skip the whole directory
+		if rel, relErr := filepath.Rel(certPkgPath, path); relErr == nil && !strings.HasPrefix(rel, "..") {
+			return nil
+		}
+
+		fset := token.NewFileSet()
+		f, parseErr := parser.ParseFile(fset, path, nil, 0)
+		if parseErr != nil {
+			return nil
+		}
+
+		ast.Inspect(f, func(n ast.Node) bool {
+			sel, ok := n.(*ast.SelectorExpr)
+			if !ok {
+				return true
+			}
+			if sel.Sel.Name == "GetCertificatesByType" {
+				pos := fset.Position(sel.Pos())
+				rel, relErr := filepath.Rel(repoRoot, pos.Filename)
+				if relErr != nil {
+					rel = pos.Filename
+				}
+				violations = append(violations, fmt.Sprintf("%s:%d", filepath.ToSlash(rel), pos.Line))
+			}
+			return true
+		})
+		return nil
+	})
+	require.NoError(t, err)
+	assert.Empty(t, violations,
+		"external callers of GetCertificatesByType found outside pkg/cert; "+
+			"use GetCurrentCertForPurpose or GetAllValidCertificatesForPurpose: %v", violations)
+}
+
+// TestNoCertSliceIndex0InNonTest enforces that cert-collection variables are never
+// blindly indexed at position 0 outside pkg/cert. Selecting [0] from a cert slice
+// races with rotation: the newest cert may be invalid during a rotation overlap
+// window. Use GetCurrentCertForPurpose instead to get a single valid certificate.
+func TestNoCertSliceIndex0InNonTest(t *testing.T) {
+	repoRoot := findRepoRoot(t)
+	certPkgPath := filepath.Join(repoRoot, "pkg", "cert")
+
+	var violations []string
+	err := filepath.WalkDir(repoRoot, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			if d.Name() == "vendor" || d.Name() == "worktrees" {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+		// pkg/cert internals are exempt (e.g., clientCerts[0] in GetClientCertificate)
+		if rel, relErr := filepath.Rel(certPkgPath, path); relErr == nil && !strings.HasPrefix(rel, "..") {
+			return nil
+		}
+
+		fset := token.NewFileSet()
+		f, parseErr := parser.ParseFile(fset, path, nil, 0)
+		if parseErr != nil {
+			return nil
+		}
+
+		ast.Inspect(f, func(n ast.Node) bool {
+			indexExpr, ok := n.(*ast.IndexExpr)
+			if !ok {
+				return true
+			}
+			lit, isLit := indexExpr.Index.(*ast.BasicLit)
+			if !isLit || lit.Kind != token.INT || lit.Value != "0" {
+				return true
+			}
+			ident, isIdent := indexExpr.X.(*ast.Ident)
+			if !isIdent {
+				return true
+			}
+			name := ident.Name
+			if strings.Contains(name, "Certs") || strings.Contains(name, "certs") ||
+				strings.Contains(name, "Certificates") || strings.Contains(name, "certificates") {
+				pos := fset.Position(indexExpr.Pos())
+				rel, relErr := filepath.Rel(repoRoot, pos.Filename)
+				if relErr != nil {
+					rel = pos.Filename
+				}
+				violations = append(violations, fmt.Sprintf("%s:%d (%s[0])", filepath.ToSlash(rel), pos.Line, name))
+			}
+			return true
+		})
+		return nil
+	})
+	require.NoError(t, err)
+	assert.Empty(t, violations,
+		"cert-slice [0] indexing found outside pkg/cert; "+
+			"use GetCurrentCertForPurpose for single-cert access: %v", violations)
 }

--- a/pkg/cert/manager.go
+++ b/pkg/cert/manager.go
@@ -252,7 +252,7 @@ func (m *Manager) GenerateInternalServerCertificate(config *ServerCertConfig) (*
 // Idempotent: safe to call on every startup. Only generates certs that don't exist yet.
 func (m *Manager) EnsureSeparatedCertificates(internalCfg *ServerCertConfig, signingCfg *SigningCertConfig) error {
 	// Check for existing internal server certificate
-	internalCerts, err := m.store.GetCertificatesByType(CertificateTypeInternalServer)
+	internalCerts, err := m.store.getCertificatesByType(CertificateTypeInternalServer)
 	if err != nil {
 		return fmt.Errorf("failed to check for internal server certificates: %w", err)
 	}
@@ -272,7 +272,7 @@ func (m *Manager) EnsureSeparatedCertificates(internalCfg *ServerCertConfig, sig
 	}
 
 	// Check for existing config signing certificate
-	signingCerts, err := m.store.GetCertificatesByType(CertificateTypeConfigSigning)
+	signingCerts, err := m.store.getCertificatesByType(CertificateTypeConfigSigning)
 	if err != nil {
 		return fmt.Errorf("failed to check for config signing certificates: %w", err)
 	}
@@ -304,7 +304,7 @@ func (m *Manager) EnsureSeparatedCertificates(internalCfg *ServerCertConfig, sig
 // certificate, which may be regenerated per boot. When signingCfg is nil, a
 // default 1095-day RSA-4096 signing certificate is generated.
 func (m *Manager) EnsureSigningCertificate(signingCfg *SigningCertConfig) error {
-	signingCerts, err := m.store.GetCertificatesByType(CertificateTypeConfigSigning)
+	signingCerts, err := m.store.getCertificatesByType(CertificateTypeConfigSigning)
 	if err != nil {
 		return fmt.Errorf("failed to check for config signing certificates: %w", err)
 	}
@@ -399,12 +399,12 @@ func (m *Manager) GetCurrentCertForPurpose(purpose CertificatePurpose) (*Certifi
 		return nil, err
 	}
 
-	certs, err := m.store.GetCertificatesByType(certType)
+	certs, err := m.store.getCertificatesByType(certType)
 	if err != nil {
 		return nil, fmt.Errorf("failed to retrieve certificates for purpose %s: %w", purpose, err)
 	}
 
-	// GetCertificatesByType returns newest-first; return the first valid one.
+	// getCertificatesByType returns newest-first; return the first valid one.
 	for _, info := range certs {
 		if info.IsValid {
 			c, cerr := m.store.GetCertificate(info.SerialNumber)
@@ -427,7 +427,7 @@ func (m *Manager) GetAllValidCertificatesForPurpose(purpose CertificatePurpose) 
 		return nil, err
 	}
 
-	certs, err := m.store.GetCertificatesByType(certType)
+	certs, err := m.store.getCertificatesByType(certType)
 	if err != nil {
 		return nil, fmt.Errorf("failed to retrieve certificates for purpose %s: %w", purpose, err)
 	}
@@ -447,7 +447,7 @@ func (m *Manager) GetAllValidCertificatesForPurpose(purpose CertificatePurpose) 
 // See docs/security/certificate-architecture.md#migrating-from-unified-mode.
 func (m *Manager) CheckForLegacyCertificates() error {
 	const legacyServerType = CertificateType(1)
-	legacy, err := m.store.GetCertificatesByType(legacyServerType)
+	legacy, err := m.store.getCertificatesByType(legacyServerType)
 	if err != nil {
 		return fmt.Errorf("failed to scan for legacy certificates: %w", err)
 	}
@@ -484,11 +484,6 @@ func (m *Manager) GetCertificate(serialNumber string) (*Certificate, error) {
 // ListCertificates returns all certificates
 func (m *Manager) ListCertificates() ([]*CertificateInfo, error) {
 	return m.store.ListCertificates()
-}
-
-// GetCertificatesByType returns certificates of a specific type
-func (m *Manager) GetCertificatesByType(certType CertificateType) ([]*CertificateInfo, error) {
-	return m.store.GetCertificatesByType(certType)
 }
 
 // GetCertificateByCommonName retrieves certificates by common name
@@ -655,7 +650,7 @@ type ManagerStats struct {
 // Each call reads the current certificate from the store so cert rotations are picked
 // up automatically — no explicit notification needed.
 func (m *Manager) GetClientCertificate(_ context.Context) (*tls.Certificate, error) {
-	clientCerts, err := m.store.GetCertificatesByType(CertificateTypeClient)
+	clientCerts, err := m.store.getCertificatesByType(CertificateTypeClient)
 	if err != nil {
 		return nil, fmt.Errorf("failed to retrieve client certificates: %w", err)
 	}
@@ -663,7 +658,7 @@ func (m *Manager) GetClientCertificate(_ context.Context) (*tls.Certificate, err
 		return nil, fmt.Errorf("no client certificate found in store")
 	}
 
-	// GetCertificatesByType returns newest-first.
+	// getCertificatesByType returns newest-first.
 	certInfo := clientCerts[0]
 	c, err := m.store.GetCertificate(certInfo.SerialNumber)
 	if err != nil {

--- a/pkg/cert/manager_test.go
+++ b/pkg/cert/manager_test.go
@@ -272,11 +272,11 @@ func TestManager_ListCertificates(t *testing.T) {
 	assert.Len(t, certs, 2)
 
 	// Verify certificate types
-	serverCerts, err := manager.GetCertificatesByType(CertificateTypePublicAPI)
+	serverCerts, err := manager.GetAllValidCertificatesForPurpose(PurposeAPI)
 	require.NoError(t, err)
 	assert.Len(t, serverCerts, 1)
 
-	clientCerts, err := manager.GetCertificatesByType(CertificateTypeClient)
+	clientCerts, err := manager.GetAllValidCertificatesForPurpose(PurposeClient)
 	require.NoError(t, err)
 	assert.Len(t, clientCerts, 1)
 }

--- a/pkg/cert/storage.go
+++ b/pkg/cert/storage.go
@@ -205,8 +205,8 @@ func (fs *FileStore) GetCertificateByCommonName(commonName string) ([]*Certifica
 	return results, nil
 }
 
-// GetCertificatesByType retrieves certificates by type
-func (fs *FileStore) GetCertificatesByType(certType CertificateType) ([]*CertificateInfo, error) {
+// getCertificatesByType retrieves certificates by type (package-private; external callers use Manager.GetCurrentCertForPurpose or Manager.GetAllValidCertificatesForPurpose)
+func (fs *FileStore) getCertificatesByType(certType CertificateType) ([]*CertificateInfo, error) {
 	fs.mu.RLock()
 	defer fs.mu.RUnlock()
 

--- a/pkg/cert/storage_test.go
+++ b/pkg/cert/storage_test.go
@@ -129,7 +129,7 @@ func TestGetCertificatesByType_RecomputesIsValidForExpiredCert(t *testing.T) {
 	freshStore, err := NewFileStore(dir)
 	require.NoError(t, err)
 
-	results, err := freshStore.GetCertificatesByType(CertificateTypeClient)
+	results, err := freshStore.getCertificatesByType(CertificateTypeClient)
 	require.NoError(t, err)
 	require.Len(t, results, 1)
 
@@ -150,7 +150,7 @@ func TestGetCertificatesByType_ValidCertRemainsValid(t *testing.T) {
 	cert := minimalCert(serial, CertificateTypePublicAPI, time.Now().Add(365*24*time.Hour))
 	require.NoError(t, store.StoreCertificate(cert))
 
-	results, err := store.GetCertificatesByType(CertificateTypePublicAPI)
+	results, err := store.getCertificatesByType(CertificateTypePublicAPI)
 	require.NoError(t, err)
 	require.Len(t, results, 1)
 
@@ -196,7 +196,7 @@ func TestGetCertificatesByType_DaysUntilExpirationPositiveForValidCert(t *testin
 	cert := minimalCert(serial, CertificateTypePublicAPI, time.Now().Add(365*24*time.Hour))
 	require.NoError(t, store.StoreCertificate(cert))
 
-	results, err := store.GetCertificatesByType(CertificateTypePublicAPI)
+	results, err := store.getCertificatesByType(CertificateTypePublicAPI)
 	require.NoError(t, err)
 	require.Len(t, results, 1)
 

--- a/test/integration/certificate_test.go
+++ b/test/integration/certificate_test.go
@@ -214,12 +214,12 @@ func (s *CertificateTestSuite) TestStewardWithCertificates() {
 func (s *CertificateTestSuite) TestCertificatePersistenceAcrossReboots() {
 	// Get certificate info from first "boot"
 	certManager1 := s.env.GetCertificateManager()
-	caCerts1, err := certManager1.GetCertificatesByType(cert.CertificateTypeCA)
-	s.NoError(err, "Should retrieve CA certificates")
-	s.Len(caCerts1, 1, "Should have exactly one CA certificate")
-	originalCASerial := caCerts1[0].SerialNumber
+	caInfo1, err := certManager1.GetCAInfo()
+	s.NoError(err, "Should retrieve CA certificate")
+	s.NotNil(caInfo1, "Should have a CA certificate")
+	originalCASerial := caInfo1.SerialNumber
 
-	internalCerts1, err := certManager1.GetCertificatesByType(cert.CertificateTypeInternalServer)
+	internalCerts1, err := certManager1.GetAllValidCertificatesForPurpose(cert.PurposeTransport)
 	s.NoError(err, "Should retrieve internal server certificates")
 	s.GreaterOrEqual(len(internalCerts1), 1, "Should have at least one internal server certificate")
 	originalInternalSerial := internalCerts1[0].SerialNumber
@@ -231,12 +231,12 @@ func (s *CertificateTestSuite) TestCertificatePersistenceAcrossReboots() {
 
 	// Verify certificates were reloaded, not regenerated
 	certManager2 := s.env.GetCertificateManager()
-	caCerts2, err := certManager2.GetCertificatesByType(cert.CertificateTypeCA)
-	s.NoError(err, "Should retrieve CA certificates after reboot")
-	s.Len(caCerts2, 1, "Should still have exactly one CA certificate after reboot")
-	s.Equal(originalCASerial, caCerts2[0].SerialNumber, "CA certificate serial should be same after reboot (not regenerated)")
+	caInfo2, err := certManager2.GetCAInfo()
+	s.NoError(err, "Should retrieve CA certificate after reboot")
+	s.NotNil(caInfo2, "Should still have a CA certificate after reboot")
+	s.Equal(originalCASerial, caInfo2.SerialNumber, "CA certificate serial should be same after reboot (not regenerated)")
 
-	internalCerts2, err := certManager2.GetCertificatesByType(cert.CertificateTypeInternalServer)
+	internalCerts2, err := certManager2.GetAllValidCertificatesForPurpose(cert.PurposeTransport)
 	s.NoError(err, "Should retrieve internal server certificates after reboot")
 	s.GreaterOrEqual(len(internalCerts2), 1, "Should have at least one internal server certificate after reboot")
 	// Verify the internal server certificate was preserved (not regenerated)

--- a/test/integration/testutil/test_helper.go
+++ b/test/integration/testutil/test_helper.go
@@ -349,16 +349,16 @@ func (e *TestEnv) GetCertificateManager() *cert.Manager {
 // ValidateCertificateSetup validates that certificates are properly configured
 func (e *TestEnv) ValidateCertificateSetup() error {
 	// Check that CA is initialized
-	caCerts, err := e.CertManager.GetCertificatesByType(cert.CertificateTypeCA)
+	caInfo, err := e.CertManager.GetCAInfo()
 	if err != nil {
 		return err
 	}
-	if len(caCerts) == 0 {
+	if caInfo == nil {
 		return fmt.Errorf("no CA certificates found")
 	}
 
 	// Check that internal server certificate exists (separated architecture is mandatory)
-	internalCerts, err := e.CertManager.GetCertificatesByType(cert.CertificateTypeInternalServer)
+	internalCerts, err := e.CertManager.GetAllValidCertificatesForPurpose(cert.PurposeTransport)
 	if err != nil {
 		return err
 	}
@@ -367,7 +367,7 @@ func (e *TestEnv) ValidateCertificateSetup() error {
 	}
 
 	// Check that config signing certificate exists
-	signingCerts, err := e.CertManager.GetCertificatesByType(cert.CertificateTypeConfigSigning)
+	signingCerts, err := e.CertManager.GetAllValidCertificatesForPurpose(cert.PurposeSigning)
 	if err != nil {
 		return err
 	}
@@ -376,7 +376,7 @@ func (e *TestEnv) ValidateCertificateSetup() error {
 	}
 
 	// Check that client certificate exists
-	clientCerts, err := e.CertManager.GetCertificatesByType(cert.CertificateTypeClient)
+	clientCerts, err := e.CertManager.GetAllValidCertificatesForPurpose(cert.PurposeClient)
 	if err != nil {
 		return err
 	}
@@ -399,7 +399,28 @@ func (e *TestEnv) GenerateNewClientCertificate(clientID string) (*cert.Certifica
 	})
 }
 
-// GetCertificateInfo returns certificate information for testing
+// GetCertificateInfo returns certificate information for the given certificate type.
+// For CA certificates, uses GetCAInfo; for other types, uses ListCertificates filtered by type.
 func (e *TestEnv) GetCertificateInfo(certType cert.CertificateType) ([]*cert.CertificateInfo, error) {
-	return e.CertManager.GetCertificatesByType(certType)
+	if certType == cert.CertificateTypeCA {
+		info, err := e.CertManager.GetCAInfo()
+		if err != nil {
+			return nil, err
+		}
+		if info == nil {
+			return nil, nil
+		}
+		return []*cert.CertificateInfo{info}, nil
+	}
+	all, err := e.CertManager.ListCertificates()
+	if err != nil {
+		return nil, err
+	}
+	var filtered []*cert.CertificateInfo
+	for _, c := range all {
+		if c.Type == certType {
+			filtered = append(filtered, c)
+		}
+	}
+	return filtered, nil
 }


### PR DESCRIPTION
## Summary

- `GetCertificatesByType` renamed to `getCertificatesByType` (package-private) on `FileStore` and removed from `Manager`'s public API
- All 8 external callers migrated to `GetCurrentCertForPurpose(P)` or `GetAllValidCertificatesForPurpose(P)`
- Two permanent AST-walking lint tests added to `pkg/cert/architecture_test.go` enforcing the boundary via `go/parser`+`go/ast`

## Acceptance Criteria

- [x] `GetCertificatesByType` unexported on `FileStore`, removed from `Manager` public API; zero external references
- [x] `TestNoGetCertificatesByTypeOutsideCertPackage` — added, passes green after story
- [x] `TestNoCertSliceIndex0InNonTest` — added, passes green after story
- [x] Both AST tests execute via `make test-complete` (through `test-fast`) with no Makefile modification
- [x] `make test-complete` passes

## External Callers Migrated

| File | Before | After |
|------|--------|-------|
| `features/controller/server/server.go` | `GetCertificatesByType(ConfigSigning)` + `[0]` index | `GetCurrentCertForPurpose(PurposeSigning)` |
| `features/steward/health.go` | `GetCertificatesByType(Client)` | `GetAllValidCertificatesForPurpose(PurposeClient)` |
| `cmd/cert-manager/main.go` | `GetCertificatesByType(*)` for each type | `GetAllValidCertificatesForPurpose(Purpose*)`, CA via `GetCAInfo()` |
| `cmd/controller/main.go` | `GetCertificatesByType(Client)` | `GetAllValidCertificatesForPurpose(PurposeClient)` |
| `test/integration/testutil/test_helper.go` | `GetCertificatesByType(*)` in ValidateCertificateSetup + GetCertificateInfo | Purpose-scoped + GetCAInfo |
| `test/integration/certificate_test.go` | Direct `certManager.GetCertificatesByType(CA/InternalServer)` | `GetCAInfo()` + `GetAllValidCertificatesForPurpose(PurposeTransport)` |

## Specialist Review Results

**QA Test Runner**: PASS — 139 packages, all gates green including cross-platform compilation (linux/arm64, darwin, windows), integration tests, and new AST lint tests

**QA Code Reviewer**: PASS — No blocking issues; notes that AST tests correctly skip `_test.go` and `pkg/cert`, no false positives found in production codebase; GetCertificateInfo refactor correctly routes CA through GetCAInfo

**Security Engineer**: PASS — No blocking issues; security posture improved (rotation-window race-condition class blocked); all scans (gosec, Trivy, Nancy, staticcheck) clean

Fixes #1819