### PR TITLE
hyperv: host detection + injectable HypervDetector interface (Issue #1825)

### DIFF
--- a/features/modules/hyperv/detection.go
+++ b/features/modules/hyperv/detection.go
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+package hyperv
+
+import (
+	"context"
+	"errors"
+)
+
+// ErrHostNotHyperV is returned by Get and Set when the local host is not a
+// Hyper-V host. Inject a fakeDetector in tests to control this gate.
+var ErrHostNotHyperV = errors.New("hyperv: host is not a Hyper-V host")
+
+// HypervDetector detects whether the local host has Hyper-V enabled.
+type HypervDetector interface {
+	IsHypervHost(ctx context.Context) (bool, error)
+}

--- a/features/modules/hyperv/detection_nonwindows.go
+++ b/features/modules/hyperv/detection_nonwindows.go
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+
+//go:build !windows
+
+package hyperv
+
+import "context"
+
+// nonWindowsDetector is the production fallback on non-Windows hosts. Hyper-V is
+// a Windows-only feature; this represents real production behaviour on Linux and
+// macOS, not a test stub.
+type nonWindowsDetector struct{}
+
+func (nonWindowsDetector) IsHypervHost(_ context.Context) (bool, error) {
+	return false, nil
+}
+
+func newDefaultDetector() HypervDetector {
+	return nonWindowsDetector{}
+}
+
+// NewDefaultDetector returns the platform-appropriate HypervDetector for
+// production use. Called by the steward module factory.
+func NewDefaultDetector() HypervDetector {
+	return newDefaultDetector()
+}

--- a/features/modules/hyperv/detection_test.go
+++ b/features/modules/hyperv/detection_test.go
@@ -1,0 +1,122 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+package hyperv
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/cfgis/cfgms/features/modules"
+)
+
+// noopDetector always returns (false, nil). Used in tests that need a concrete
+// HypervDetector value but do not exercise detection logic.
+type noopDetector struct{}
+
+func (noopDetector) IsHypervHost(_ context.Context) (bool, error) { return false, nil }
+
+// fakeDetector returns a configurable result and tracks how many times
+// IsHypervHost has been called. Set err to simulate detector failures.
+type fakeDetector struct {
+	result bool
+	err    error
+	mu     sync.Mutex
+	count  int
+}
+
+func (f *fakeDetector) IsHypervHost(_ context.Context) (bool, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.count++
+	return f.result, f.err
+}
+
+// Calls returns the number of IsHypervHost invocations recorded so far.
+func (f *fakeDetector) Calls() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.count
+}
+
+// TestHostDetection_UsesInjectedDetector verifies that a module constructed
+// with fakeDetector{result: true} proceeds past the detection gate, while
+// fakeDetector{result: false} returns ErrHostNotHyperV.
+func TestHostDetection_UsesInjectedDetector(t *testing.T) {
+	t.Run("true activates", func(t *testing.T) {
+		m := newModuleWithDetector(nil, &fakeDetector{result: true})
+		// "any-vm" has no colon — falls through to ErrNotImplemented, proving
+		// the detector returned true and the gate was passed.
+		_, err := m.Get(context.Background(), "any-vm")
+		if !errors.Is(err, modules.ErrNotImplemented) {
+			t.Errorf("Get with true detector = %v, want ErrNotImplemented", err)
+		}
+	})
+	t.Run("false returns ErrHostNotHyperV", func(t *testing.T) {
+		m := newModuleWithDetector(nil, &fakeDetector{result: false})
+		_, err := m.Get(context.Background(), "any-vm")
+		if !errors.Is(err, ErrHostNotHyperV) {
+			t.Errorf("Get with false detector = %v, want ErrHostNotHyperV", err)
+		}
+	})
+}
+
+// TestCheckDetection_NilDetector_ReturnsErrHostNotHyperV verifies that a module
+// constructed with no detector (nil) returns ErrHostNotHyperV on every call.
+func TestCheckDetection_NilDetector_ReturnsErrHostNotHyperV(t *testing.T) {
+	m := newModuleWithDetector(nil, nil)
+	_, err := m.Get(context.Background(), "vm:some-vm")
+	if !errors.Is(err, ErrHostNotHyperV) {
+		t.Errorf("Get with nil detector = %v, want ErrHostNotHyperV", err)
+	}
+}
+
+// TestCheckDetection_PropagatesDetectorError verifies that a detector error is
+// surfaced directly from Get and Set without wrapping or swallowing.
+func TestCheckDetection_PropagatesDetectorError(t *testing.T) {
+	detErr := errors.New("detector: winrm timeout")
+	fake := &fakeDetector{err: detErr}
+
+	m := newModuleWithDetector(nil, fake)
+	_, err := m.Get(context.Background(), "vm:some-vm")
+	if !errors.Is(err, detErr) {
+		t.Errorf("Get() detector error = %v, want %v", err, detErr)
+	}
+
+	setErr := m.Set(context.Background(), "vm:some-vm", &VMConfig{})
+	if !errors.Is(setErr, detErr) {
+		t.Errorf("Set() detector error = %v, want %v", setErr, detErr)
+	}
+}
+
+// TestDetection_CachedFor5Min_CallsDetectorOnce verifies that the module-level
+// detection cache prevents redundant calls to the injected detector within 5
+// minutes. After the cache expires the detector is called exactly once more.
+func TestDetection_CachedFor5Min_CallsDetectorOnce(t *testing.T) {
+	fake := &fakeDetector{result: true}
+	m := newModuleWithDetector(nil, fake)
+
+	ctx := context.Background()
+
+	// Three Get calls within a 5-minute window.
+	for i := 0; i < 3; i++ {
+		_, _ = m.Get(ctx, "any-vm") // ErrNotImplemented is expected and irrelevant here
+	}
+
+	if got := fake.Calls(); got != 1 {
+		t.Errorf("detector calls within 5-min window = %d, want 1", got)
+	}
+
+	// Simulate cache expiry by rewinding the stored expiry timestamp.
+	m.detMu.Lock()
+	m.detExpiry = time.Now().Add(-time.Second)
+	m.detMu.Unlock()
+
+	_, _ = m.Get(ctx, "any-vm")
+
+	if got := fake.Calls(); got != 2 {
+		t.Errorf("detector calls after cache expiry = %d, want 2", got)
+	}
+}

--- a/features/modules/hyperv/detection_windows.go
+++ b/features/modules/hyperv/detection_windows.go
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+
+//go:build windows
+
+package hyperv
+
+import (
+	"context"
+	"os/exec"
+	"strings"
+	"sync"
+	"time"
+)
+
+// windowsHypervDetector checks whether the local Windows host has Hyper-V
+// enabled by running Get-VMHost via PowerShell. Results are cached for 5
+// minutes to avoid repeated PowerShell invocations on every module operation.
+type windowsHypervDetector struct {
+	mu           sync.Mutex
+	cachedResult bool
+	cacheExpiry  time.Time
+}
+
+// psRunFn executes the Get-VMHost powershell command and returns combined output.
+// Overridden in tests to avoid invoking a real powershell.exe.
+var psRunFn = func(ctx context.Context) ([]byte, error) {
+	return exec.CommandContext(ctx, "powershell.exe", "-NonInteractive", "-Command", "Get-VMHost | ConvertTo-Json").CombinedOutput()
+}
+
+// isSoftError returns true for cmdlet-not-found and access-denied failures,
+// which indicate Hyper-V is not installed or accessible. All other errors are
+// propagated to the caller.
+func isSoftError(output []byte) bool {
+	text := strings.ToLower(string(output))
+	return strings.Contains(text, "commandnotfoundexception") ||
+		strings.Contains(text, "is not recognized") ||
+		strings.Contains(text, "access is denied") ||
+		strings.Contains(text, "access denied")
+}
+
+// IsHypervHost runs Get-VMHost. Cmdlet-not-found and access-denied failures
+// are soft failures that return (false, nil). Other exec errors return (false, err).
+func (d *windowsHypervDetector) IsHypervHost(ctx context.Context) (bool, error) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	if time.Now().Before(d.cacheExpiry) {
+		return d.cachedResult, nil
+	}
+
+	output, err := psRunFn(ctx)
+	if err != nil {
+		if isSoftError(output) {
+			return false, nil
+		}
+		return false, err
+	}
+
+	d.cachedResult = true
+	d.cacheExpiry = time.Now().Add(5 * time.Minute)
+	return true, nil
+}
+
+func newDefaultDetector() HypervDetector {
+	return &windowsHypervDetector{}
+}
+
+// NewDefaultDetector returns the platform-appropriate HypervDetector for
+// production use. Called by the steward module factory.
+func NewDefaultDetector() HypervDetector {
+	return newDefaultDetector()
+}

--- a/features/modules/hyperv/detection_windows_test.go
+++ b/features/modules/hyperv/detection_windows_test.go
@@ -1,0 +1,116 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+
+//go:build windows
+
+package hyperv
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+// TestWindowsDetector_SoftErrors verifies that cmdlet-not-found and access-denied
+// outputs from powershell are treated as soft failures — returning (false, nil)
+// rather than surfacing the exec error to the caller.
+func TestWindowsDetector_SoftErrors(t *testing.T) {
+	softOutputs := []struct {
+		name   string
+		output []byte
+	}{
+		{"CommandNotFoundException", []byte("CommandNotFoundException: Get-VMHost is not recognized")},
+		{"is not recognized", []byte("The term 'Get-VMHost' is not recognized as the name of a cmdlet")},
+		{"access is denied", []byte("Access is denied. You need to run the script as Administrator")},
+		{"access denied", []byte("get-vmhost : access denied")},
+	}
+
+	for _, tc := range softOutputs {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			d := &windowsHypervDetector{}
+
+			restore := psRunFn
+			t.Cleanup(func() { psRunFn = restore })
+			psRunFn = func(_ context.Context) ([]byte, error) {
+				return tc.output, errors.New("exit status 1")
+			}
+
+			ok, err := d.IsHypervHost(context.Background())
+			if err != nil {
+				t.Errorf("soft error %q produced non-nil err = %v, want nil", tc.name, err)
+			}
+			if ok {
+				t.Errorf("soft error %q produced ok=true, want false", tc.name)
+			}
+		})
+	}
+}
+
+// TestWindowsDetector_HardError verifies that unexpected powershell errors (e.g.
+// a genuine exec failure unrelated to cmdlet availability) are surfaced as errors.
+func TestWindowsDetector_HardError(t *testing.T) {
+	d := &windowsHypervDetector{}
+	hardErr := errors.New("CreateProcess: file not found")
+
+	restore := psRunFn
+	t.Cleanup(func() { psRunFn = restore })
+	psRunFn = func(_ context.Context) ([]byte, error) {
+		return nil, hardErr
+	}
+
+	ok, err := d.IsHypervHost(context.Background())
+	if !errors.Is(err, hardErr) {
+		t.Errorf("hard error = %v, want %v", err, hardErr)
+	}
+	if ok {
+		t.Errorf("hard error produced ok=true, want false")
+	}
+}
+
+// TestWindowsDetector_CachesPositiveResult verifies that a successful detection
+// is cached for 5 minutes and the underlying PS command is not re-invoked.
+func TestWindowsDetector_CachesPositiveResult(t *testing.T) {
+	callCount := 0
+	restore := psRunFn
+	t.Cleanup(func() { psRunFn = restore })
+	psRunFn = func(_ context.Context) ([]byte, error) {
+		callCount++
+		return []byte(`{"ComputerName":"testhost"}`), nil
+	}
+
+	d := &windowsHypervDetector{}
+	ctx := context.Background()
+
+	// First call — hits PS.
+	ok, err := d.IsHypervHost(ctx)
+	if err != nil || !ok {
+		t.Fatalf("first call = (%v, %v), want (true, nil)", ok, err)
+	}
+
+	// Two more calls within the cache window — must not invoke PS again.
+	for i := 0; i < 2; i++ {
+		ok2, err2 := d.IsHypervHost(ctx)
+		if err2 != nil || !ok2 {
+			t.Errorf("cached call %d = (%v, %v), want (true, nil)", i+1, ok2, err2)
+		}
+	}
+
+	if callCount != 1 {
+		t.Errorf("psRunFn called %d times within cache window, want 1", callCount)
+	}
+
+	// Expire the cache and verify PS is called again.
+	d.mu.Lock()
+	d.cacheExpiry = time.Now().Add(-time.Second)
+	d.mu.Unlock()
+
+	ok3, err3 := d.IsHypervHost(ctx)
+	if err3 != nil || !ok3 {
+		t.Errorf("post-expiry call = (%v, %v), want (true, nil)", ok3, err3)
+	}
+	if callCount != 2 {
+		t.Errorf("psRunFn called %d times after cache expiry, want 2", callCount)
+	}
+}

--- a/features/modules/hyperv/integration_test.go
+++ b/features/modules/hyperv/integration_test.go
@@ -12,26 +12,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-
-	secretsif "github.com/cfgis/cfgms/pkg/secrets/interfaces"
 )
-
-// fakeDetector implements HypervDetector for integration tests, returning a
-// configurable result so detection does not require running Get-VMHost on the
-// CI test runner (which may be Linux).
-type fakeDetector struct{ result bool }
-
-func (f fakeDetector) IsAvailable() (bool, error) { return f.result, nil }
-
-// newModuleWithDetector creates a hypervModule with a SecretStore pre-injected and
-// a detector indicating whether Hyper-V is available, bypassing OS-level detection.
-func newModuleWithDetector(store secretsif.SecretStore, _ HypervDetector) (*hypervModule, error) {
-	m := &hypervModule{executor: newExecutor()}
-	if err := m.SetSecretStore(store); err != nil {
-		return nil, err
-	}
-	return m, nil
-}
 
 // integrationModule configures a hypervModule using env-var credentials.
 // Returns nil and skips the test if CFGMS_HYPERV_HOST is not set.
@@ -47,8 +28,7 @@ func integrationModule(t *testing.T) *hypervModule {
 	pass := os.Getenv("CFGMS_HYPERV_PASS")
 
 	store := newInlineStore("user-key", user, "pass-key", pass)
-	m, err := newModuleWithDetector(store, fakeDetector{result: true})
-	require.NoError(t, err)
+	m := newModuleWithDetector(store, &fakeDetector{result: true})
 
 	require.NoError(t, m.Configure(mapConfigState{
 		"winrm_host":        host,

--- a/features/modules/hyperv/module.go
+++ b/features/modules/hyperv/module.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/cfgis/cfgms/features/modules"
 )
@@ -18,12 +19,6 @@ var (
 	errUserSecretKeyRequired = errors.New("hyperv: winrm_user_secret key is required")
 	errPassSecretKeyRequired = errors.New("hyperv: winrm_pass_secret key is required")
 )
-
-// HypervDetector detects whether Hyper-V is available on the host.
-// The concrete implementation is added in Story 5 (host detection).
-type HypervDetector interface {
-	IsAvailable() (bool, error)
-}
 
 // hypervModule implements modules.Module and modules.Configurable for remote
 // Hyper-V management via WinRM. Credentials are fetched from SecretStore on
@@ -40,6 +35,13 @@ type hypervModule struct {
 	transport winrmTransport
 	executor  hypervExecutor
 
+	// detector gates every Get and Set — the module refuses operations when the
+	// host is not a Hyper-V host. detMu protects the 5-minute result cache.
+	detector  HypervDetector
+	detMu     sync.Mutex
+	detResult bool
+	detExpiry time.Time
+
 	// vms is the write-through VM cache. Keys are user-visible VM names
 	// (without the cfgms-<tenantID>__ prefix). Updated on executor success only.
 	vmsMu sync.RWMutex
@@ -51,14 +53,47 @@ type hypervModule struct {
 	vswitches   map[string]VSwitchConfig
 }
 
-// New creates a new hypervModule. detector is reserved for Story 5 host detection
-// and may be nil in Story 1.
+// New creates a new hypervModule. Production callers pass newDefaultDetector();
+// tests inject a fakeDetector via newModuleWithDetector.
 func New(detector HypervDetector) modules.Module {
 	return &hypervModule{
 		executor:  newExecutor(),
 		vms:       make(map[string]VMConfig),
 		vswitches: make(map[string]VSwitchConfig),
+		detector:  detector,
 	}
+}
+
+// checkDetection calls the injected HypervDetector and enforces the 5-minute
+// result cache. Returns ErrHostNotHyperV when the host is not a Hyper-V host
+// or when no detector was provided.
+func (m *hypervModule) checkDetection(ctx context.Context) error {
+	if m.detector == nil {
+		return ErrHostNotHyperV
+	}
+
+	m.detMu.Lock()
+	defer m.detMu.Unlock()
+
+	if time.Now().Before(m.detExpiry) {
+		if !m.detResult {
+			return ErrHostNotHyperV
+		}
+		return nil
+	}
+
+	result, err := m.detector.IsHypervHost(ctx)
+	if err != nil {
+		return err
+	}
+	if result {
+		m.detResult = true
+		m.detExpiry = time.Now().Add(5 * time.Minute)
+	}
+	if !result {
+		return ErrHostNotHyperV
+	}
+	return nil
 }
 
 // Configure implements modules.Configurable. It extracts WinRM connection details
@@ -114,6 +149,9 @@ func (m *hypervModule) Configure(config modules.ConfigState) error {
 //   - "vswitch:<name>": retrieve VSwitchConfig for the named virtual switch
 //   - "vmattach:<vmName>/<switchName>": retrieve VMAttachmentConfig for the named attachment
 func (m *hypervModule) Get(ctx context.Context, resourceID string) (modules.ConfigState, error) {
+	if err := m.checkDetection(ctx); err != nil {
+		return nil, err
+	}
 	prefix, name, ok := splitResourceID(resourceID)
 	if !ok {
 		return nil, modules.ErrNotImplemented
@@ -143,6 +181,9 @@ func (m *hypervModule) Get(ctx context.Context, resourceID string) (modules.Conf
 //   - "vswitch:<name>": create or delete the named virtual switch
 //   - "vmattach:<vmName>/<switchName>": attach or detach a VM network adapter
 func (m *hypervModule) Set(ctx context.Context, resourceID string, config modules.ConfigState) error {
+	if err := m.checkDetection(ctx); err != nil {
+		return err
+	}
 	prefix, _, ok := splitResourceID(resourceID)
 	if !ok {
 		return modules.ErrNotImplemented

--- a/features/modules/hyperv/module_test.go
+++ b/features/modules/hyperv/module_test.go
@@ -229,11 +229,20 @@ func (l *bufferLogger) String() string {
 // Verify bufferLogger satisfies logging.Logger at compile time.
 var _ logging.Logger = (*bufferLogger)(nil)
 
-// noopDetector implements HypervDetector for unit tests that need a concrete
-// detector value but do not exercise detection logic.
-type noopDetector struct{}
-
-func (noopDetector) IsAvailable() (bool, error) { return true, nil }
+// newModuleWithDetector creates a hypervModule with the given SecretStore and
+// HypervDetector pre-injected. Follows the newTestModule pattern from firewall.
+func newModuleWithDetector(store secretsif.SecretStore, detector HypervDetector) *hypervModule {
+	m := &hypervModule{
+		executor:  &stubHypervExecutor{},
+		vms:       make(map[string]VMConfig),
+		vswitches: make(map[string]VSwitchConfig),
+		detector:  detector,
+	}
+	if store != nil {
+		_ = m.SetSecretStore(store)
+	}
+	return m
+}
 
 // ─── WinRM client injection-safety tests ───────────────────────────────────────
 
@@ -442,6 +451,7 @@ func TestModule_NoCredentialInLogs_TransportError(t *testing.T) {
 		host:          "testhost",
 		userSecretKey: "user-key",
 		passSecretKey: "pass-key",
+		detector:      &fakeDetector{result: true},
 		transport: &testWinRMTransport{
 			execErr: errors.New("connection refused"),
 		},
@@ -518,14 +528,14 @@ func TestModule_Configure_MissingPassSecretKey(t *testing.T) {
 
 // TestModule_ImplementsConfigurable verifies that *hypervModule satisfies modules.Configurable.
 func TestModule_ImplementsConfigurable(t *testing.T) {
-	m := New(nil)
+	m := New(noopDetector{})
 	_, ok := m.(modules.Configurable)
 	require.True(t, ok, "hypervModule must implement modules.Configurable")
 }
 
 // TestModule_ImplementsSecretStoreInjectable verifies the module accepts SecretStore injection.
 func TestModule_ImplementsSecretStoreInjectable(t *testing.T) {
-	m := New(nil)
+	m := New(noopDetector{})
 	injectable, ok := m.(modules.SecretStoreInjectable)
 	require.True(t, ok, "hypervModule must implement modules.SecretStoreInjectable")
 
@@ -538,18 +548,45 @@ func TestModule_ImplementsSecretStoreInjectable(t *testing.T) {
 	assert.Equal(t, store, got)
 }
 
-// TestModule_GetReturnsNotImplemented verifies stub behaviour on Linux (Story 2 fills this in).
+// TestModule_GetReturnsNotImplemented verifies stub behaviour for unknown resource IDs.
 func TestModule_GetReturnsNotImplemented(t *testing.T) {
-	m := New(nil)
+	m := New(&fakeDetector{result: true})
 	_, err := m.Get(context.Background(), "any-vm")
 	assert.ErrorIs(t, err, modules.ErrNotImplemented)
 }
 
-// TestModule_SetReturnsNotImplemented verifies stub behaviour on Linux.
+// TestModule_SetReturnsNotImplemented verifies stub behaviour for unknown resource IDs.
 func TestModule_SetReturnsNotImplemented(t *testing.T) {
-	m := New(nil)
+	m := New(&fakeDetector{result: true})
 	err := m.Set(context.Background(), "any-vm", nil)
 	assert.ErrorIs(t, err, modules.ErrNotImplemented)
+}
+
+// TestModule_Get_ReturnsErrHostNotHyperV_WhenDetectorReturnsFalse verifies that
+// Get returns ErrHostNotHyperV when the detector reports the host is not Hyper-V.
+func TestModule_Get_ReturnsErrHostNotHyperV_WhenDetectorReturnsFalse(t *testing.T) {
+	m := newModuleWithDetector(nil, &fakeDetector{result: false})
+	_, err := m.Get(context.Background(), "vm:some-vm")
+	assert.ErrorIs(t, err, ErrHostNotHyperV)
+}
+
+// TestModule_Get_ProceedsWhenDetectorReturnsTrue verifies that Get proceeds past
+// the detection gate when the detector reports a Hyper-V host. On non-Windows
+// with no transport the operation fails with ErrVMNotFound, not ErrHostNotHyperV.
+func TestModule_Get_ProceedsWhenDetectorReturnsTrue(t *testing.T) {
+	m := newModuleWithDetector(nil, &fakeDetector{result: true})
+	_, err := m.Get(context.Background(), "vm:some-vm")
+	assert.False(t, errors.Is(err, ErrHostNotHyperV),
+		"Get with true detector must not return ErrHostNotHyperV, got %v", err)
+	assert.ErrorIs(t, err, ErrVMNotFound)
+}
+
+// TestModule_Set_ReturnsErrHostNotHyperV_WhenDetectorReturnsFalse verifies that
+// Set returns ErrHostNotHyperV when the detector reports the host is not Hyper-V.
+func TestModule_Set_ReturnsErrHostNotHyperV_WhenDetectorReturnsFalse(t *testing.T) {
+	m := newModuleWithDetector(nil, &fakeDetector{result: false})
+	err := m.Set(context.Background(), "vm:some-vm", &VMConfig{})
+	assert.ErrorIs(t, err, ErrHostNotHyperV)
 }
 
 // ─── buildInvokeCommand unit tests ─────────────────────────────────────────────

--- a/features/modules/hyperv/snapshot_test.go
+++ b/features/modules/hyperv/snapshot_test.go
@@ -22,6 +22,7 @@ func snapModuleWithTransport(transport winrmTransport, tenantID string) *hypervM
 		transport: transport,
 		tenantID:  tenantID,
 		vms:       make(map[string]VMConfig),
+		detector:  &fakeDetector{result: true},
 	}
 }
 
@@ -275,6 +276,7 @@ func TestGet_Snapshot_NoTransport(t *testing.T) {
 	m := &hypervModule{
 		executor: &stubHypervExecutor{},
 		vms:      make(map[string]VMConfig),
+		detector: &fakeDetector{result: true},
 	}
 	_, err := m.Get(context.Background(), "snapshot:myvm/mysnap")
 	require.Error(t, err)
@@ -373,6 +375,7 @@ func TestSet_Snapshot_NoTransport(t *testing.T) {
 	m := &hypervModule{
 		executor: &stubHypervExecutor{},
 		vms:      make(map[string]VMConfig),
+		detector: &fakeDetector{result: true},
 	}
 	cfg := &SnapshotConfig{VMName: "myvm", Name: "mysnap", State: "present"}
 	err := m.Set(context.Background(), "snapshot:myvm/mysnap", cfg)
@@ -385,6 +388,7 @@ func TestModule_Get_SnapshotPrefix_NoTransport(t *testing.T) {
 	m := &hypervModule{
 		executor: &stubHypervExecutor{},
 		vms:      make(map[string]VMConfig),
+		detector: &fakeDetector{result: true},
 	}
 	_, err := m.Get(context.Background(), "snapshot:vm/snap")
 	assert.ErrorIs(t, err, ErrSnapshotNotFound)

--- a/features/modules/hyperv/vm_test.go
+++ b/features/modules/hyperv/vm_test.go
@@ -21,6 +21,7 @@ func vmModuleWithTransport(transport winrmTransport, tenantID string) *hypervMod
 		transport: transport,
 		tenantID:  tenantID,
 		vms:       make(map[string]VMConfig),
+		detector:  &fakeDetector{result: true},
 	}
 }
 
@@ -314,14 +315,14 @@ func TestVMConfig_Validate_AcceptsValidConfig(t *testing.T) {
 // TestModule_Get_UnknownResourceIDReturnsNotImplemented verifies that resource IDs
 // without a known prefix still return ErrNotImplemented (backward compat).
 func TestModule_Get_UnknownResourceIDReturnsNotImplemented(t *testing.T) {
-	m := New(nil)
+	m := New(&fakeDetector{result: true})
 	_, err := m.Get(context.Background(), "unknown-resource")
 	assert.ErrorIs(t, err, modules.ErrNotImplemented)
 }
 
 // TestModule_Set_UnknownResourceIDReturnsNotImplemented verifies backward compat.
 func TestModule_Set_UnknownResourceIDReturnsNotImplemented(t *testing.T) {
-	m := New(nil)
+	m := New(&fakeDetector{result: true})
 	err := m.Set(context.Background(), "unknown-resource", nil)
 	assert.ErrorIs(t, err, modules.ErrNotImplemented)
 }
@@ -332,6 +333,7 @@ func TestModule_Get_VMPrefix_NoTransport(t *testing.T) {
 	m := &hypervModule{
 		executor: &stubHypervExecutor{},
 		vms:      make(map[string]VMConfig),
+		detector: &fakeDetector{result: true},
 	}
 	_, err := m.Get(context.Background(), "vm:somevm")
 	assert.ErrorIs(t, err, ErrVMNotFound)

--- a/features/modules/hyperv/vswitch_test.go
+++ b/features/modules/hyperv/vswitch_test.go
@@ -22,6 +22,7 @@ func vswitchModuleWithTransport(transport winrmTransport, tenantID string) *hype
 		tenantID:  tenantID,
 		vms:       make(map[string]VMConfig),
 		vswitches: make(map[string]VSwitchConfig),
+		detector:  &fakeDetector{result: true},
 	}
 }
 
@@ -384,6 +385,7 @@ func TestGet_VSwitch_NoTransport(t *testing.T) {
 		executor:  &stubHypervExecutor{},
 		vms:       make(map[string]VMConfig),
 		vswitches: make(map[string]VSwitchConfig),
+		detector:  &fakeDetector{result: true},
 	}
 	_, err := m.Get(context.Background(), "vswitch:myswitch")
 	assert.ErrorIs(t, err, ErrVSwitchNotFound)
@@ -541,6 +543,7 @@ func TestSet_VMAttach_NoTransport(t *testing.T) {
 		executor:  &stubHypervExecutor{},
 		vms:       make(map[string]VMConfig),
 		vswitches: make(map[string]VSwitchConfig),
+		detector:  &fakeDetector{result: true},
 	}
 	cfg := &VMAttachmentConfig{VMName: "myvm", SwitchName: "sw", State: "present"}
 	err := m.Set(context.Background(), "vmattach:myvm/sw", cfg)
@@ -554,6 +557,7 @@ func TestGet_VMAttach_NoTransport(t *testing.T) {
 		executor:  &stubHypervExecutor{},
 		vms:       make(map[string]VMConfig),
 		vswitches: make(map[string]VSwitchConfig),
+		detector:  &fakeDetector{result: true},
 	}
 	_, err := m.Get(context.Background(), "vmattach:myvm/myswitch")
 	assert.ErrorIs(t, err, ErrVSwitchNotFound)

--- a/features/steward/factory/factory.go
+++ b/features/steward/factory/factory.go
@@ -172,7 +172,7 @@ var builtinModuleConstructors = map[string]func() modules.Module{
 	"directory": func() modules.Module { return directory.New() },
 	"file":      func() modules.Module { return file.New() },
 	"firewall":  func() modules.Module { return firewall.New() },
-	"hyperv":    func() modules.Module { return hyperv.New(nil) },
+	"hyperv":    func() modules.Module { return hyperv.New(hyperv.NewDefaultDetector()) },
 	"package":   func() modules.Module { return package_module.New() },
 	"patch":     func() modules.Module { return patch.New() },
 	"script":    func() modules.Module { return script.New() },


### PR DESCRIPTION
## Summary

- Defines `HypervDetector` interface (`IsHypervHost(ctx) (bool, error)`) and `ErrHostNotHyperV` sentinel in `detection.go`
- Windows implementation (`windowsHypervDetector`) runs `Get-VMHost` via PowerShell with 5-minute positive-result cache; non-Windows production fallback (`nonWindowsDetector`) returns `(false, nil)` immediately
- Module detection gate added to every `Get` and `Set` call; 5-minute result cache prevents repeated detector invocations; `nil` detector is fail-closed (`ErrHostNotHyperV`)
- Test doubles (`noopDetector`, `fakeDetector` with call counter + error injection) live exclusively in `detection_test.go`; `newModuleWithDetector` unexported helper added to `module_test.go`
- Factory updated from `hyperv.New(nil)` to `hyperv.New(hyperv.NewDefaultDetector())`

Fixes #1825

## Acceptance Criteria Coverage

- [x] `HypervDetector` interface in `detection.go`: `IsHypervHost(ctx context.Context) (bool, error)`
- [x] `detection_windows.go`: `windowsHypervDetector` with 5-min cache + `newDefaultDetector()`
- [x] `detection_nonwindows.go`: `nonWindowsDetector` production fallback + `newDefaultDetector()`
- [x] `New(detector HypervDetector) modules.Module` — explicit dependency
- [x] `noopDetector` and `fakeDetector` only in `detection_test.go`
- [x] `TestHostDetection_UsesInjectedDetector` — passes
- [x] `TestModule_Get_ReturnsErrHostNotHyperV_WhenDetectorReturnsFalse` — passes
- [x] `TestModule_Get_ProceedsWhenDetectorReturnsTrue` — passes
- [x] `TestDetection_CachedFor5Min_CallsDetectorOnce` — passes
- [x] No `os.Getenv("CFGMS_HYPERV_SKIP_DETECTION")` in any non-test file
- [x] `newModuleWithDetector` in `module_test.go`
- [x] `make test-complete` passes on Linux

## Additional Tests Added (QA Review Resolution)

- `TestModule_Set_ReturnsErrHostNotHyperV_WhenDetectorReturnsFalse` — Set path detection gate
- `TestCheckDetection_NilDetector_ReturnsErrHostNotHyperV` — nil detector branch
- `TestCheckDetection_PropagatesDetectorError` — detector error propagation
- `detection_windows_test.go` (Windows-only): soft error classification, hard error, 5-min cache

## Specialist Review Results

- **QA Test Runner**: PASS — 149/149 script tests, all Go tests pass, lint clean, cross-platform compilation (linux/amd64, linux/arm64, darwin/amd64, darwin/arm64, windows/amd64) all pass
- **QA Code Reviewer**: PASS — all 5 initial blocking issues resolved; no mocks, no test seam env vars, test doubles in correct files
- **Security Engineer**: PASS — no hardcoded secrets, no detection bypass, command injection impossible (literal PS args), fail-closed nil detector, no central provider violations

🤖 Generated with [Claude Code](https://claude.com/claude-code)