### PR TITLE
hyperv: audit log integration for all PS verbs (Issue #1826)

### DIFF
--- a/features/modules/hyperv/audit.go
+++ b/features/modules/hyperv/audit.go
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+package hyperv
+
+import (
+	"context"
+	"log/slog"
+
+	"github.com/cfgis/cfgms/pkg/audit"
+	business "github.com/cfgis/cfgms/pkg/storage/interfaces/business"
+)
+
+// recordHypervOp emits a pkg/audit entry for a Hyper-V mutation operation.
+// It is nil-safe: when mgr is nil the function returns immediately so lightweight
+// stewards that do not configure an audit manager are unaffected.
+//
+// Structured fields only — no raw PowerShell script text or user-supplied
+// argument values (VM names, VHD paths, switch names) appear in Details.
+func recordHypervOp(ctx context.Context, mgr *audit.Manager, tenantID, stewardID, host, verb, resourceID string, opErr error) {
+	if mgr == nil {
+		return
+	}
+
+	builder := audit.NewEventBuilder().
+		Tenant(tenantID).
+		Type(business.AuditEventConfiguration).
+		Action(verb).
+		User(audit.SystemUserID, business.AuditUserTypeSystem).
+		Resource("hyperv/"+verb, resourceID, "").
+		Detail("host", host).
+		Detail("steward_id", stewardID)
+
+	if opErr == nil {
+		builder = builder.Result(business.AuditResultSuccess)
+	} else {
+		builder = builder.Result(business.AuditResultFailure).Error("", opErr.Error())
+	}
+
+	if err := mgr.RecordEvent(ctx, builder); err != nil {
+		slog.Warn("hyperv: failed to record audit event",
+			"verb", verb,
+			"resource_id", resourceID,
+			"error", err,
+		)
+	}
+}

--- a/features/modules/hyperv/audit_test.go
+++ b/features/modules/hyperv/audit_test.go
@@ -1,0 +1,204 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+package hyperv
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cfgis/cfgms/pkg/audit"
+	business "github.com/cfgis/cfgms/pkg/storage/interfaces/business"
+)
+
+// fakeAuditStore is an in-memory business.AuditStore for testing.
+// Only StoreAuditEntry and GetLastAuditEntry have real logic;
+// all other methods are no-ops so the drain loop can operate.
+type fakeAuditStore struct {
+	mu      sync.Mutex
+	entries []*business.AuditEntry
+}
+
+func (f *fakeAuditStore) StoreAuditEntry(_ context.Context, entry *business.AuditEntry) error {
+	f.mu.Lock()
+	f.entries = append(f.entries, entry)
+	f.mu.Unlock()
+	return nil
+}
+
+func (f *fakeAuditStore) GetAuditEntry(_ context.Context, _ string) (*business.AuditEntry, error) {
+	return nil, nil
+}
+
+func (f *fakeAuditStore) ListAuditEntries(_ context.Context, _ *business.AuditFilter) ([]*business.AuditEntry, error) {
+	return nil, nil
+}
+
+func (f *fakeAuditStore) StoreAuditBatch(_ context.Context, entries []*business.AuditEntry) error {
+	f.mu.Lock()
+	f.entries = append(f.entries, entries...)
+	f.mu.Unlock()
+	return nil
+}
+
+func (f *fakeAuditStore) GetAuditsByUser(_ context.Context, _ string, _ *business.TimeRange) ([]*business.AuditEntry, error) {
+	return nil, nil
+}
+
+func (f *fakeAuditStore) GetAuditsByResource(_ context.Context, _, _ string, _ *business.TimeRange) ([]*business.AuditEntry, error) {
+	return nil, nil
+}
+
+func (f *fakeAuditStore) GetAuditsByAction(_ context.Context, _ string, _ *business.TimeRange) ([]*business.AuditEntry, error) {
+	return nil, nil
+}
+
+func (f *fakeAuditStore) GetFailedActions(_ context.Context, _ *business.TimeRange, _ int) ([]*business.AuditEntry, error) {
+	return nil, nil
+}
+
+func (f *fakeAuditStore) GetSuspiciousActivity(_ context.Context, _ string, _ *business.TimeRange) ([]*business.AuditEntry, error) {
+	return nil, nil
+}
+
+func (f *fakeAuditStore) GetAuditStats(_ context.Context) (*business.AuditStats, error) {
+	return &business.AuditStats{LastUpdated: time.Now()}, nil
+}
+
+func (f *fakeAuditStore) GetLastAuditEntry(_ context.Context, tenantID string) (*business.AuditEntry, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	for i := len(f.entries) - 1; i >= 0; i-- {
+		if f.entries[i].TenantID == tenantID {
+			return f.entries[i], nil
+		}
+	}
+	return nil, nil
+}
+
+func (f *fakeAuditStore) ArchiveAuditEntries(_ context.Context, _ time.Time) (int64, error) {
+	return 0, nil
+}
+
+func (f *fakeAuditStore) PurgeAuditEntries(_ context.Context, _ time.Time) (int64, error) {
+	return 0, nil
+}
+
+func (f *fakeAuditStore) Close() error { return nil }
+
+// captured returns a snapshot copy of all stored entries.
+func (f *fakeAuditStore) captured() []*business.AuditEntry {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := make([]*business.AuditEntry, len(f.entries))
+	copy(out, f.entries)
+	return out
+}
+
+// newFakeAuditManager returns an audit.Manager backed by an in-memory store.
+func newFakeAuditManager(t *testing.T) (*audit.Manager, *fakeAuditStore) {
+	t.Helper()
+	store := &fakeAuditStore{}
+	mgr, err := audit.NewManager(store, "hyperv-test")
+	require.NoError(t, err)
+	return mgr, store
+}
+
+// ─── recordHypervOp tests ──────────────────────────────────────────────────────
+
+// TestAuditRecordHypervOp_NilSafe verifies that a nil audit manager does not panic.
+func TestAuditRecordHypervOp_NilSafe(t *testing.T) {
+	// Must not panic — nil mgr is the default for lightweight edge stewards.
+	recordHypervOp(context.Background(), nil, "tenant-1", "steward-1", "host-1", "New-VM", "cfgms-tenant-1__vm1", nil)
+}
+
+// TestAuditRecordHypervOp_NoRawPS verifies that Details contains no raw PowerShell
+// script text or argument values such as VM names, VHD paths, or switch names.
+func TestAuditRecordHypervOp_NoRawPS(t *testing.T) {
+	mgr, store := newFakeAuditManager(t)
+	defer func() { _ = mgr.Stop(context.Background()) }()
+
+	recordHypervOp(context.Background(), mgr, "tenant-1", "steward-1", "host-1", "New-VM", "cfgms-tenant-1__vm1", nil)
+
+	require.NoError(t, mgr.Flush(context.Background()))
+	entries := store.captured()
+	require.Len(t, entries, 1)
+
+	entry := entries[0]
+	// None of the Detail values should contain raw PS script text fragments
+	// or any other user-supplied argument value that belongs in ArgumentList.
+	for k, v := range entry.Details {
+		vStr, _ := v.(string)
+		assert.NotContains(t, vStr, "New-VM -Name", "Details[%q] must not contain raw PS command", k)
+		assert.NotContains(t, vStr, "ArgumentList", "Details[%q] must not contain ArgumentList", k)
+		assert.NotContains(t, vStr, ".vhdx", "Details[%q] must not contain VHD path fragments", k)
+		assert.NotContains(t, vStr, "-MemoryStartupBytes", "Details[%q] must not contain PS parameter names", k)
+	}
+	// Only the allowed structured keys should appear.
+	for k := range entry.Details {
+		assert.Contains(t, []string{"host", "steward_id"}, k,
+			"unexpected Detail key %q: only 'host' and 'steward_id' are allowed", k)
+	}
+}
+
+// TestAuditRecordHypervOp_ErrorPath verifies that a non-nil opErr produces a
+// non-success result with an error message, and that recordHypervOp does not
+// change what error the caller sees (separation of concerns).
+func TestAuditRecordHypervOp_ErrorPath(t *testing.T) {
+	mgr, store := newFakeAuditManager(t)
+	defer func() { _ = mgr.Stop(context.Background()) }()
+
+	opErr := errors.New("VM creation failed: disk quota exceeded")
+	recordHypervOp(context.Background(), mgr, "tenant-1", "steward-1", "host-1", "New-VM", "cfgms-tenant-1__vm1", opErr)
+
+	require.NoError(t, mgr.Flush(context.Background()))
+	entries := store.captured()
+	require.Len(t, entries, 1)
+
+	entry := entries[0]
+	// Result must indicate failure (not success).
+	assert.NotEqual(t, business.AuditResultSuccess, entry.Result,
+		"opErr != nil must produce a non-success result")
+	// Error message must carry the original message for forensics.
+	assert.Contains(t, entry.ErrorMessage, "VM creation failed",
+		"error message must contain the original error text")
+}
+
+// TestAuditLog_VMOperation verifies that a New-VM operation produces an audit
+// entry with all required fields correctly populated and result Success.
+func TestAuditLog_VMOperation(t *testing.T) {
+	mgr, store := newFakeAuditManager(t)
+	defer func() { _ = mgr.Stop(context.Background()) }()
+
+	tenantID := "tenant-a"
+	stewardID := "steward-a"
+	host := "winhost.example.com"
+	verb := "New-VM"
+	resourceID := vmHostName(tenantID, "myvm") // cfgms-tenant-a__myvm
+
+	recordHypervOp(context.Background(), mgr, tenantID, stewardID, host, verb, resourceID, nil)
+
+	require.NoError(t, mgr.Flush(context.Background()))
+	entries := store.captured()
+	require.Len(t, entries, 1)
+
+	entry := entries[0]
+	assert.Equal(t, tenantID, entry.TenantID, "tenant_id")
+	assert.Equal(t, verb, entry.Action, "action/verb")
+	assert.Equal(t, "hyperv/"+verb, entry.ResourceType, "resource_type")
+	assert.Equal(t, resourceID, entry.ResourceID, "resource_id")
+	assert.Equal(t, business.AuditResultSuccess, entry.Result, "result")
+
+	hostVal, ok := entry.Details["host"].(string)
+	assert.True(t, ok, "Details[host] must be a string")
+	assert.Equal(t, host, hostVal, "Details[host]")
+
+	stewardVal, ok := entry.Details["steward_id"].(string)
+	assert.True(t, ok, "Details[steward_id] must be a string")
+	assert.Equal(t, stewardID, stewardVal, "Details[steward_id]")
+}

--- a/features/modules/hyperv/module.go
+++ b/features/modules/hyperv/module.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/cfgis/cfgms/features/modules"
+	"github.com/cfgis/cfgms/pkg/audit"
 )
 
 var (
@@ -31,7 +32,9 @@ type hypervModule struct {
 	userSecretKey string
 	passSecretKey string
 	tenantID      string
+	stewardID     string
 
+	auditMgr  *audit.Manager
 	transport winrmTransport
 	executor  hypervExecutor
 
@@ -138,6 +141,12 @@ func (m *hypervModule) Configure(config modules.ConfigState) error {
 	m.passSecretKey = passSecretKey
 	m.tenantID, _ = configMap["tenant_id"].(string)
 	m.transport = newWinRMClientWithStore(host, userSecretKey, passSecretKey, store)
+	m.auditMgr, _ = configMap["audit_manager"].(*audit.Manager)
+	stewardID, _ := configMap["steward_id"].(string)
+	if stewardID == "" {
+		stewardID = m.tenantID + "/hyperv"
+	}
+	m.stewardID = stewardID
 
 	return nil
 }

--- a/features/modules/hyperv/snapshot.go
+++ b/features/modules/hyperv/snapshot.go
@@ -199,11 +199,13 @@ func (m *hypervModule) createSnapshot(ctx context.Context, vmName, snapName stri
 	hostVMName := vmHostName(m.tenantID, vmName)
 	hostSnapName := snapHostName(m.tenantID, snapName)
 
-	if _, err := m.transport.ExecutePS(ctx, psCreateSnapshot, map[string]string{
+	_, psErr := m.transport.ExecutePS(ctx, psCreateSnapshot, map[string]string{
 		"Name":   hostSnapName,
 		"VMName": hostVMName,
-	}); err != nil {
-		return fmt.Errorf("hyperv: create snapshot %q on VM %q: %w", snapName, vmName, err)
+	})
+	recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.host, "Checkpoint-VM", hostVMName, psErr)
+	if psErr != nil {
+		return fmt.Errorf("hyperv: create snapshot %q on VM %q: %w", snapName, vmName, psErr)
 	}
 	return nil
 }
@@ -213,11 +215,13 @@ func (m *hypervModule) removeSnapshot(ctx context.Context, vmName, snapName stri
 	hostVMName := vmHostName(m.tenantID, vmName)
 	hostSnapName := snapHostName(m.tenantID, snapName)
 
-	if _, err := m.transport.ExecutePS(ctx, psRemoveSnapshot, map[string]string{
+	_, psErr := m.transport.ExecutePS(ctx, psRemoveSnapshot, map[string]string{
 		"Name":   hostSnapName,
 		"VMName": hostVMName,
-	}); err != nil {
-		return fmt.Errorf("hyperv: remove snapshot %q on VM %q: %w", snapName, vmName, err)
+	})
+	recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.host, "Remove-VMSnapshot", hostVMName, psErr)
+	if psErr != nil {
+		return fmt.Errorf("hyperv: remove snapshot %q on VM %q: %w", snapName, vmName, psErr)
 	}
 	return nil
 }
@@ -229,11 +233,13 @@ func (m *hypervModule) restoreSnapshot(ctx context.Context, vmName, snapName str
 	hostVMName := vmHostName(m.tenantID, vmName)
 	hostSnapName := snapHostName(m.tenantID, snapName)
 
-	if _, err := m.transport.ExecutePS(ctx, psRestoreSnapshot, map[string]string{
+	_, psErr := m.transport.ExecutePS(ctx, psRestoreSnapshot, map[string]string{
 		"Name":   hostSnapName,
 		"VMName": hostVMName,
-	}); err != nil {
-		return fmt.Errorf("hyperv: restore snapshot %q on VM %q: %w", snapName, vmName, err)
+	})
+	recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.host, "Restore-VMCheckpoint", hostVMName, psErr)
+	if psErr != nil {
+		return fmt.Errorf("hyperv: restore snapshot %q on VM %q: %w", snapName, vmName, psErr)
 	}
 	return nil
 }

--- a/features/modules/hyperv/vm.go
+++ b/features/modules/hyperv/vm.go
@@ -249,8 +249,10 @@ func (m *hypervModule) setVM(ctx context.Context, resourceID string, config modu
 		"SwitchName": cfg.SwitchName,
 	}
 
-	if _, err := m.transport.ExecutePS(ctx, psCreateVM, psArgs); err != nil {
-		return fmt.Errorf("hyperv: create VM %q: %w", vmName, err)
+	_, psErr := m.transport.ExecutePS(ctx, psCreateVM, psArgs)
+	recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.host, "New-VM", hostName, psErr)
+	if psErr != nil {
+		return fmt.Errorf("hyperv: create VM %q: %w", vmName, psErr)
 	}
 
 	// Write-through: update cache on success
@@ -268,8 +270,10 @@ func (m *hypervModule) setVM(ctx context.Context, resourceID string, config modu
 func (m *hypervModule) removeVM(ctx context.Context, vmName string) error {
 	hostName := vmHostName(m.tenantID, vmName)
 
-	if _, err := m.transport.ExecutePS(ctx, psRemoveVM, map[string]string{"Name": hostName}); err != nil {
-		return fmt.Errorf("hyperv: remove VM %q: %w", vmName, err)
+	_, psErr := m.transport.ExecutePS(ctx, psRemoveVM, map[string]string{"Name": hostName})
+	recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.host, "Remove-VM", hostName, psErr)
+	if psErr != nil {
+		return fmt.Errorf("hyperv: remove VM %q: %w", vmName, psErr)
 	}
 
 	m.vmsMu.Lock()

--- a/features/modules/hyperv/vswitch.go
+++ b/features/modules/hyperv/vswitch.go
@@ -323,8 +323,10 @@ func (m *hypervModule) createVSwitch(ctx context.Context, switchName string, cfg
 		return ErrInvalidSwitchType
 	}
 
-	if _, err := m.transport.ExecutePS(ctx, psCmd, psArgs); err != nil {
-		return fmt.Errorf("hyperv: create vswitch %q: %w", switchName, err)
+	_, psErr := m.transport.ExecutePS(ctx, psCmd, psArgs)
+	recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.host, "New-VMSwitch", hostName, psErr)
+	if psErr != nil {
+		return fmt.Errorf("hyperv: create vswitch %q: %w", switchName, psErr)
 	}
 
 	cfgCopy := *cfg
@@ -341,8 +343,10 @@ func (m *hypervModule) createVSwitch(ctx context.Context, switchName string, cfg
 func (m *hypervModule) removeVSwitch(ctx context.Context, switchName string) error {
 	hostName := vswitchHostName(m.tenantID, switchName)
 
-	if _, err := m.transport.ExecutePS(ctx, psRemoveVSwitch, map[string]string{"Name": hostName}); err != nil {
-		return fmt.Errorf("hyperv: remove vswitch %q: %w", switchName, err)
+	_, psErr := m.transport.ExecutePS(ctx, psRemoveVSwitch, map[string]string{"Name": hostName})
+	recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.host, "Remove-VMSwitch", hostName, psErr)
+	if psErr != nil {
+		return fmt.Errorf("hyperv: remove vswitch %q: %w", switchName, psErr)
 	}
 
 	m.vswitchesMu.Lock()
@@ -466,8 +470,10 @@ func (m *hypervModule) attachVMToSwitch(ctx context.Context, vmName, switchName,
 		}
 	}
 
-	if _, err := m.transport.ExecutePS(ctx, psCmd, psArgs); err != nil {
-		return fmt.Errorf("hyperv: attach VM %q to switch %q: %w", vmName, switchName, err)
+	_, psErr := m.transport.ExecutePS(ctx, psCmd, psArgs)
+	recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.host, "Add-VMNetworkAdapter", hostVMName, psErr)
+	if psErr != nil {
+		return fmt.Errorf("hyperv: attach VM %q to switch %q: %w", vmName, switchName, psErr)
 	}
 	return nil
 }
@@ -476,11 +482,13 @@ func (m *hypervModule) attachVMToSwitch(ctx context.Context, vmName, switchName,
 func (m *hypervModule) detachVMFromSwitch(ctx context.Context, vmName, adapterName string) error {
 	hostVMName := vmHostName(m.tenantID, vmName)
 
-	if _, err := m.transport.ExecutePS(ctx, psDetachVM, map[string]string{
+	_, psErr := m.transport.ExecutePS(ctx, psDetachVM, map[string]string{
 		"VMName": hostVMName,
 		"Name":   adapterName,
-	}); err != nil {
-		return fmt.Errorf("hyperv: detach adapter %q from VM %q: %w", adapterName, vmName, err)
+	})
+	recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.host, "Remove-VMNetworkAdapter", hostVMName, psErr)
+	if psErr != nil {
+		return fmt.Errorf("hyperv: detach adapter %q from VM %q: %w", adapterName, vmName, psErr)
 	}
 	return nil
 }

--- a/test/e2e/fleet/install_package_test.go
+++ b/test/e2e/fleet/install_package_test.go
@@ -310,7 +310,6 @@ func placeCACert(t *testing.T, container string, caCertPEM []byte) {
 	dockerExecRoot(t, container, "chmod", "644", "/etc/cfgms/controller-ca.crt")
 }
 
-
 // dockerExecRoot runs a command in the container as root.
 func dockerExecRoot(t *testing.T, container string, args ...string) {
 	t.Helper()


### PR DESCRIPTION
## Summary

- Adds `recordHypervOp` helper in `features/modules/hyperv/audit.go` that emits a `pkg/audit` entry for every Hyper-V mutation operation (nil-safe, structured fields only)
- Wires audit calls into all 9 mutation methods across `vm.go`, `snapshot.go`, `vswitch.go` — after `ExecutePS` returns, regardless of success or failure
- Extends `hypervModule` with `auditMgr *audit.Manager` and `stewardID` fields; `Configure()` extracts them optionally from the config map
- Adds 4 required tests in `audit_test.go`: nil-safe, no-raw-PS, error-path, VM operation happy path
- Also fixes a pre-existing `gofmt` issue in `test/e2e/fleet/install_package_test.go` (from #1709) caught by the lint gate

Fixes #1826

## Specialist Review Results

| Reviewer | Result | Notes |
|---|---|---|
| QA Test Runner | PASS | All unit/integration/cross-platform checks pass after fixing pre-existing gofmt issue in test/e2e/fleet/install_package_test.go |
| QA Code Reviewer | PASS | 0 blocking issues; 2 non-blocking warnings (table-driven multi-verb test, queue-full coverage) |
| Security Engineer | PASS | 0 blocking issues, 0 warnings; all automated scans (gosec, Trivy, Nancy, staticcheck, gitleaks) green |

## Test plan

- [ ] `go test ./features/modules/hyperv/...` — all tests pass including the 4 new audit tests
- [ ] `make test-agent-complete` — all gates pass
- [ ] `TestAuditRecordHypervOp_NilSafe` — nil mgr does not panic
- [ ] `TestAuditRecordHypervOp_NoRawPS` — Details contains only `host` and `steward_id` keys
- [ ] `TestAuditRecordHypervOp_ErrorPath` — non-success result + error message on failure
- [ ] `TestAuditLog_VMOperation` — New-VM produces correct tenant_id, action, resource_type, resource_id, result

🤖 Generated with [Claude Code](https://claude.com/claude-code)