### PR TITLE
hyperv: implement Start-VM/Stop-VM/Set-VM lifecycle and add module.yaml (Issue #1842)

### DIFF
--- a/features/modules/hyperv/README.md
+++ b/features/modules/hyperv/README.md
@@ -2,6 +2,103 @@
 
 Remote Hyper-V management via WinRM for CFGMS. Manages VMs, snapshots, and virtual switches on Windows Server hosts running the Hyper-V role. All PowerShell commands are executed over an authenticated, TLS-encrypted WinRM connection.
 
+## Purpose and scope
+
+The Hyper-V module provides desired-state management of Hyper-V resources on Windows Server hosts via WinRM. It enables CFGMS to create, start, stop, resize, and remove virtual machines, manage checkpoints (snapshots), configure virtual switches, and attach VM network adapters — all through an authenticated, TLS-encrypted WinRM connection.
+
+The module's scope includes:
+
+- **VM lifecycle**: create (`New-VM`), start (`Start-VM`), stop (`Stop-VM`), remove (`Remove-VM`)
+- **VM resize**: update CPU count (`Set-VMProcessor`) and startup memory (`Set-VM -MemoryStartupBytes`) on stopped VMs
+- **Snapshots**: create, restore, and delete Hyper-V checkpoints
+- **Virtual switches**: create and remove External, Internal, and Private vSwitches
+- **VM attachment**: add and remove network adapter-to-switch connections
+
+Out of scope: Hyper-V role installation, storage pool management, live migration, replication policies, and controller dispatch wiring (see issue #1790).
+
+## Configuration options
+
+The module accepts the following configuration options via `Configure(cfg)`:
+
+| Option | Type | Required | Description |
+|--------|------|----------|-------------|
+| `winrm_host` | string | Yes | Hostname or IP of the Hyper-V host |
+| `winrm_user_secret` | string | Yes | SecretStore key for the WinRM username |
+| `winrm_pass_secret` | string | Yes | SecretStore key for the WinRM password |
+| `tenant_id` | string | No | Tenant identifier used to namespace host-side resource names |
+| `steward_id` | string | No | Steward identifier for audit records (defaults to `<tenantID>/hyperv`) |
+| `audit_manager` | `*audit.Manager` | No | Audit manager for recording Hyper-V operations |
+
+VM resource configuration fields (`vm:<name>`):
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `memory_mb` | integer | Yes (create) | Startup memory in MiB |
+| `cpu_count` | integer | Yes (create) | Number of virtual processors |
+| `vhd_path` | string | Yes (create) | Absolute Windows path to VHD/VHDX |
+| `switch_name` | string | Yes (create) | Virtual switch name |
+| `generation` | integer | No | VM generation (must be 2 or omitted) |
+| `state` | string | No | Desired state: `running`, `stopped`, or `absent` |
+
+## Usage examples
+
+### Create and start a VM
+
+```yaml
+resource: vm:web-01
+config:
+  memory_mb: 4096
+  cpu_count: 2
+  vhd_path: C:\VMs\web-01.vhdx
+  switch_name: External
+  generation: 2
+  state: running
+```
+
+### Stop a VM
+
+```yaml
+resource: vm:web-01
+config:
+  state: stopped
+```
+
+### Resize an existing VM (stop → resize → start)
+
+```yaml
+resource: vm:web-01
+config:
+  cpu_count: 4
+  memory_mb: 8192
+  state: running
+```
+
+### Create a snapshot
+
+```yaml
+resource: snapshot:web-01/pre-patch
+config:
+  state: present
+```
+
+### Create an external virtual switch
+
+```yaml
+resource: vswitch:External-Switch
+config:
+  switch_type: external
+  net_adapter_name: Ethernet0
+  state: present
+```
+
+## Known limitations
+
+1. **CPU/memory resize requires a stopped VM** — Hyper-V does not support hot-resize. The module handles this automatically: when `state: running` with a resize, it stops the VM, resizes, then starts it. A brief outage occurs during this sequence.
+2. **Generation is fixed at creation** — VM generation cannot be changed after the VM is created.
+3. **VHD path is immutable** — The virtual disk path is set at creation and cannot be changed via this module.
+4. **Basic auth is structurally disabled** — Only NTLM over HTTPS (port 5986) is supported. WinRM must be configured for HTTPS on the target host.
+5. **Integration tests require a live host** — Unit tests use a test implementation of the WinRM transport interface; full end-to-end validation requires `CFGMS_HYPERV_HOST` to be set.
+
 ## Service Account Requirements
 
 The WinRM service account must be a member of the **Hyper-V Administrators** local group on the target host. Domain Admin is not required and must not be granted — follow the principle of least privilege.
@@ -138,8 +235,14 @@ The following are **not** managed by this module:
 - Controller dispatch wiring (see issue #1790)
 - Load or performance testing
 
-## Security Notes
+## Security considerations
 
-- PowerShell injection is prevented by the `Invoke-Command` parameter injection pattern — user values are passed as WinRM `Arguments`, never embedded in the script block text
-- Credentials are fetched from the SecretStore on every call and never logged
-- All log values that could contain user input are passed through `logging.SanitizeLogValue()`
+- **PowerShell injection prevention**: The `Invoke-Command` parameter injection pattern is used — user values are passed as WinRM `Arguments`, never embedded in the script block text
+- **Credential handling**: Credentials are fetched from the SecretStore on every WinRM call and never cached or logged
+- **Log sanitization**: All log values that could contain user input are passed through `logging.SanitizeLogValue()`
+- **TLS always on**: WinRM connects on port 5986 (HTTPS); `InsecureSkipVerify` is explicitly `false`
+- **Least privilege**: The WinRM account needs only the `Hyper-V Administrators` local group — Domain Admin must not be granted
+
+## Related Hypervisor Modules
+
+A future Proxmox, VMware, or KVM module would be implemented as a separate, independent module — not as an extension of this Hyper-V module. Each hypervisor module follows the same shape: a `New(detector)` constructor, a `Configure` method for connection details, and `Get`/`Set` operations with typed resource IDs (e.g., `vm:<name>`, `snapshot:<vmname>/<snapname>`). Tenant-prefix naming uses the same `cfgms-<sanitizedTenantID>__<resourceName>` convention. Modules do not share code beyond the common `modules.Module` interface — each is platform-specific and ships independently as a copy of this shape, not an extension of it.

--- a/features/modules/hyperv/module.yaml
+++ b/features/modules/hyperv/module.yaml
@@ -1,0 +1,23 @@
+name: hyperv
+description: Remote Hyper-V management via WinRM — manages VMs, snapshots, and virtual switches on Windows Server hosts
+version: 0.1.0
+
+executors:
+  - outpost
+
+author: CFGMS Team
+license: AGPL-3.0
+platforms:
+  - windows
+
+schema: schema.yaml
+interfaces:
+  - Get
+  - Set
+  - Test
+
+security:
+  requires_root: false
+  capabilities: []
+  ports:
+    - 5986  # WinRM HTTPS

--- a/features/modules/hyperv/module_test.go
+++ b/features/modules/hyperv/module_test.go
@@ -25,11 +25,17 @@ import (
 // testWinRMTransport implements winrmTransport and records every ExecutePS call.
 // Stories 2–4 tests use this to assert that user-supplied values appear in args,
 // never embedded in the scriptBlock (psCommand) text.
+//
+// Per-call overrides: if perCallOutputs or perCallErrors are non-empty, the
+// element at the call's zero-based index is used instead of output/execErr.
+// Beyond the slice length the defaults (output, execErr) apply.
 type testWinRMTransport struct {
-	mu      sync.Mutex
-	calls   []winRMCall
-	output  string
-	execErr error
+	mu             sync.Mutex
+	calls          []winRMCall
+	output         string
+	execErr        error
+	perCallOutputs []string
+	perCallErrors  []error
 }
 
 // winRMCall records a single ExecutePS invocation.
@@ -56,8 +62,19 @@ func (t *testWinRMTransport) ExecutePS(_ context.Context, psCommand string, psAr
 		args[i] = psArgs[k]
 	}
 
+	callIdx := len(t.calls)
 	t.calls = append(t.calls, winRMCall{scriptBlock: psCommand, args: args})
-	return t.output, t.execErr
+
+	out := t.output
+	err := t.execErr
+	if callIdx < len(t.perCallOutputs) {
+		out = t.perCallOutputs[callIdx]
+	}
+	if callIdx < len(t.perCallErrors) {
+		err = t.perCallErrors[callIdx]
+	}
+
+	return out, err
 }
 
 // recordingShell implements winrmShell and captures the scriptBlock and args

--- a/features/modules/hyperv/tests/basic_test.yaml
+++ b/features/modules/hyperv/tests/basic_test.yaml
@@ -1,0 +1,70 @@
+name: Basic Hyper-V Operations
+description: Tests basic Hyper-V VM lifecycle management via WinRM
+tests:
+  - name: Create a Generation 2 VM
+    config:
+      name: "test-vm"
+      memory_mb: 4096
+      cpu_count: 2
+      vhd_path: "C:\\VMs\\test-vm.vhdx"
+      switch_name: "Default Switch"
+      generation: 2
+      state: stopped
+    expected:
+      name: "test-vm"
+      memory_mb: 4096
+      cpu_count: 2
+      state: stopped
+
+  - name: Start an existing VM
+    config:
+      name: "test-vm"
+      state: running
+    expected:
+      name: "test-vm"
+      state: running
+
+  - name: Stop a running VM
+    config:
+      name: "test-vm"
+      state: stopped
+    expected:
+      name: "test-vm"
+      state: stopped
+
+  - name: Remove a VM
+    config:
+      name: "test-vm"
+      state: absent
+    expected_absent: true
+
+  - name: Invalid VM name with double underscore
+    config:
+      name: "bad__name"
+      memory_mb: 2048
+      cpu_count: 1
+      vhd_path: "C:\\VMs\\bad.vhdx"
+      switch_name: "Default Switch"
+      state: stopped
+    expected_error: "invalid VM name"
+
+  - name: Invalid VHD path (non-Windows)
+    config:
+      name: "linux-path-vm"
+      memory_mb: 2048
+      cpu_count: 1
+      vhd_path: "/var/lib/vms/disk.vhd"
+      switch_name: "Default Switch"
+      state: stopped
+    expected_error: "invalid VHD path"
+
+  - name: Invalid generation (Generation 1)
+    config:
+      name: "gen1-vm"
+      memory_mb: 2048
+      cpu_count: 1
+      vhd_path: "C:\\VMs\\gen1.vhdx"
+      switch_name: "Default Switch"
+      generation: 1
+      state: stopped
+    expected_error: "invalid generation"

--- a/features/modules/hyperv/vm.go
+++ b/features/modules/hyperv/vm.go
@@ -125,6 +125,19 @@ const psCreateVM = `New-VM -Name $Name -MemoryStartupBytes ($MemoryMB * 1MB) -Pr
 // $Name is the only parameter; its value is transmitted via ArgumentList.
 const psRemoveVM = `Remove-VM -Name $Name -Force`
 
+// psStartVM starts a VM that already exists on the host.
+const psStartVM = `Start-VM -Name $Name`
+
+// psStopVM stops a running VM (Force prevents interactive confirmation).
+const psStopVM = `Stop-VM -Name $Name -Force`
+
+// psSetVMProcessor updates the virtual processor count on an existing VM.
+const psSetVMProcessor = `Set-VMProcessor -VMName $Name -Count $CPU`
+
+// psSetVMMemory updates the startup memory on an existing VM.
+// Set-VMMemory is not a standard Hyper-V cmdlet; Set-VM with MemoryStartupBytes is used instead.
+const psSetVMMemory = `Set-VM -Name $Name -MemoryStartupBytes ($MemoryMB * 1MB)`
+
 // getVM retrieves the current state of a VM by user-visible name.
 func (m *hypervModule) getVM(ctx context.Context, vmName string) (*VMConfig, error) {
 	if m.transport == nil {
@@ -191,6 +204,15 @@ func (m *hypervModule) getVM(ctx context.Context, vmName string) (*VMConfig, err
 
 // setVM applies the desired VM configuration.
 // Write-through cache semantics: transport is called first; cache updated on success only.
+//
+// Dispatch logic:
+//   - state == "absent"                 → removeVM
+//   - VM exists in cache or on host:
+//     state == "running"               → Start-VM (with optional stop/resize/start if resize needed)
+//     state == "stopped"               → Stop-VM (with optional resize after)
+//   - VM not found:
+//     state == "running"               → New-VM, then Start-VM
+//     state == "stopped"               → New-VM (Hyper-V starts VMs in Off state by default)
 func (m *hypervModule) setVM(ctx context.Context, resourceID string, config modules.ConfigState) error {
 	if m.transport == nil {
 		return modules.ErrNotImplemented
@@ -236,11 +258,38 @@ func (m *hypervModule) setVM(ctx context.Context, resourceID string, config modu
 		cfg.Name = vmName
 	}
 
+	// Check cache for VM existence first, bypassing transport for known VMs.
+	m.vmsMu.RLock()
+	cachedVM, inCache := m.vms[vmName]
+	m.vmsMu.RUnlock()
+
+	var vmExists bool
+	var currentVM VMConfig
+	if inCache {
+		vmExists = true
+		currentVM = cachedVM
+	} else {
+		current, err := m.getVM(ctx, vmName)
+		if err != nil && !errors.Is(err, ErrVMNotFound) {
+			return fmt.Errorf("hyperv: check VM %q existence: %w", vmName, err)
+		}
+		if err == nil {
+			vmExists = true
+			currentVM = *current
+		}
+	}
+
+	hostName := vmHostName(m.tenantID, vmName)
+
+	if vmExists {
+		return m.applyVMState(ctx, vmName, hostName, cfg, &currentVM, state)
+	}
+
+	// VM does not exist — create it.
 	if err := cfg.Validate(); err != nil {
 		return err
 	}
 
-	hostName := vmHostName(m.tenantID, vmName)
 	psArgs := map[string]string{
 		"Name":       hostName,
 		"MemoryMB":   fmt.Sprintf("%d", cfg.MemoryMB),
@@ -255,6 +304,12 @@ func (m *hypervModule) setVM(ctx context.Context, resourceID string, config modu
 		return fmt.Errorf("hyperv: create VM %q: %w", vmName, psErr)
 	}
 
+	if state == "running" {
+		if err := m.execStartVM(ctx, vmName, hostName); err != nil {
+			return err
+		}
+	}
+
 	// Write-through: update cache on success
 	cfgCopy := *cfg
 	cfgCopy.Name = vmName
@@ -262,6 +317,105 @@ func (m *hypervModule) setVM(ctx context.Context, resourceID string, config modu
 	m.vms[vmName] = cfgCopy
 	m.vmsMu.Unlock()
 
+	return nil
+}
+
+// applyVMState transitions an existing VM to the desired power state, applying
+// CPU/memory resize when the desired values differ from current.
+func (m *hypervModule) applyVMState(ctx context.Context, vmName, hostName string, desired, current *VMConfig, state string) error {
+	needsCPUResize := desired.CPUCount != 0 && desired.CPUCount != current.CPUCount
+	needsMemResize := desired.MemoryMB != 0 && desired.MemoryMB != current.MemoryMB
+
+	switch state {
+	case "running":
+		if needsCPUResize || needsMemResize {
+			// CPU/memory can only be changed on a stopped VM — stop, resize, then start.
+			if err := m.execStopVM(ctx, vmName, hostName); err != nil {
+				return err
+			}
+			if needsCPUResize {
+				if err := m.execSetVMProcessor(ctx, vmName, hostName, desired.CPUCount); err != nil {
+					return err
+				}
+			}
+			if needsMemResize {
+				if err := m.execSetVMMemory(ctx, vmName, hostName, desired.MemoryMB); err != nil {
+					return err
+				}
+			}
+		}
+		if err := m.execStartVM(ctx, vmName, hostName); err != nil {
+			return err
+		}
+		m.vmsMu.Lock()
+		updated := *current
+		updated.State = "running"
+		m.vms[vmName] = updated
+		m.vmsMu.Unlock()
+
+	case "stopped":
+		if err := m.execStopVM(ctx, vmName, hostName); err != nil {
+			return err
+		}
+		if needsCPUResize {
+			if err := m.execSetVMProcessor(ctx, vmName, hostName, desired.CPUCount); err != nil {
+				return err
+			}
+		}
+		if needsMemResize {
+			if err := m.execSetVMMemory(ctx, vmName, hostName, desired.MemoryMB); err != nil {
+				return err
+			}
+		}
+		m.vmsMu.Lock()
+		updated := *current
+		updated.State = "stopped"
+		m.vms[vmName] = updated
+		m.vmsMu.Unlock()
+	}
+
+	return nil
+}
+
+func (m *hypervModule) execStartVM(ctx context.Context, vmName, hostName string) error {
+	_, psErr := m.transport.ExecutePS(ctx, psStartVM, map[string]string{"Name": hostName})
+	recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.host, "Start-VM", hostName, psErr)
+	if psErr != nil {
+		return fmt.Errorf("hyperv: Start-VM %q: %w", vmName, psErr)
+	}
+	return nil
+}
+
+func (m *hypervModule) execStopVM(ctx context.Context, vmName, hostName string) error {
+	_, psErr := m.transport.ExecutePS(ctx, psStopVM, map[string]string{"Name": hostName})
+	recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.host, "Stop-VM", hostName, psErr)
+	if psErr != nil {
+		return fmt.Errorf("hyperv: Stop-VM %q: %w", vmName, psErr)
+	}
+	return nil
+}
+
+func (m *hypervModule) execSetVMProcessor(ctx context.Context, vmName, hostName string, cpuCount int) error {
+	_, psErr := m.transport.ExecutePS(ctx, psSetVMProcessor, map[string]string{
+		"Name": hostName,
+		"CPU":  fmt.Sprintf("%d", cpuCount),
+	})
+	recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.host, "Set-VMProcessor", hostName, psErr)
+	if psErr != nil {
+		return fmt.Errorf("hyperv: Set-VMProcessor %q: %w", vmName, psErr)
+	}
+	return nil
+}
+
+func (m *hypervModule) execSetVMMemory(ctx context.Context, vmName, hostName string, memoryMB int64) error {
+	_, psErr := m.transport.ExecutePS(ctx, psSetVMMemory, map[string]string{
+		"Name":     hostName,
+		"MemoryMB": fmt.Sprintf("%d", memoryMB),
+	})
+	recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.host, "Set-VMMemory", hostName, psErr)
+	if psErr != nil {
+		return fmt.Errorf("hyperv: Set-VMMemory %q: %w", vmName, psErr)
+	}
 	return nil
 }
 

--- a/features/modules/hyperv/vm_test.go
+++ b/features/modules/hyperv/vm_test.go
@@ -5,6 +5,7 @@ package hyperv
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -366,6 +367,8 @@ func TestGet_VM_ReturnsConfig(t *testing.T) {
 }
 
 // TestSet_VMCreate verifies that Set creates a VM and passes all fields via ArgumentList.
+// setVM now calls getVM first to check existence; empty transport output → ErrVMNotFound →
+// falls through to New-VM. So two transport calls are expected: getVM (call[0]) + New-VM (call[1]).
 func TestSet_VMCreate(t *testing.T) {
 	transport := &testWinRMTransport{}
 	m := vmModuleWithTransport(transport, "dev")
@@ -386,8 +389,9 @@ func TestSet_VMCreate(t *testing.T) {
 	calls := transport.calls
 	transport.mu.Unlock()
 
-	require.Len(t, calls, 1)
-	call := calls[0]
+	// Two calls: getVM existence check (returns not-found) + New-VM creation
+	require.Len(t, calls, 2)
+	call := calls[1] // New-VM is the second call
 
 	// Script must reference $Name parameter, not literal prefixed name
 	assert.Contains(t, call.scriptBlock, "$Name",
@@ -404,4 +408,235 @@ func TestSet_VMCreate(t *testing.T) {
 		}
 	}
 	assert.True(t, found, "prefixed VM name must appear in args")
+}
+
+// ─── VM power state tests ──────────────────────────────────────────────────────
+
+// TestSetVM_RunningState_CallsStartVM asserts that Set with state "running" on an
+// existing VM issues Start-VM and does not issue New-VM.
+func TestSetVM_RunningState_CallsStartVM(t *testing.T) {
+	transport := &testWinRMTransport{}
+	m := vmModuleWithTransport(transport, "ops")
+
+	// Pre-seed VM cache to simulate existing stopped VM, bypassing getVM transport call.
+	m.vmsMu.Lock()
+	m.vms["foo"] = VMConfig{Name: "foo", State: "stopped", CPUCount: 2, MemoryMB: 4096}
+	m.vmsMu.Unlock()
+
+	cfg := &VMConfig{
+		Name:     "foo",
+		State:    "running",
+		CPUCount: 2,
+		MemoryMB: 4096,
+	}
+
+	err := m.Set(context.Background(), "vm:foo", cfg)
+	require.NoError(t, err)
+
+	transport.mu.Lock()
+	calls := transport.calls
+	transport.mu.Unlock()
+
+	require.Len(t, calls, 1, "cache-seeded VM must produce exactly one transport call (Start-VM)")
+	assert.Contains(t, calls[0].scriptBlock, "Start-VM",
+		"Set with state running must invoke Start-VM")
+	assert.NotContains(t, calls[0].scriptBlock, "New-VM",
+		"Set with state running on existing VM must not invoke New-VM")
+}
+
+// TestSetVM_StoppedState_CallsStopVM asserts that Set with state "stopped" on an
+// existing VM issues Stop-VM and does not issue New-VM.
+func TestSetVM_StoppedState_CallsStopVM(t *testing.T) {
+	transport := &testWinRMTransport{}
+	m := vmModuleWithTransport(transport, "ops")
+
+	// Pre-seed VM cache to simulate existing running VM.
+	m.vmsMu.Lock()
+	m.vms["foo"] = VMConfig{Name: "foo", State: "running", CPUCount: 2, MemoryMB: 4096}
+	m.vmsMu.Unlock()
+
+	cfg := &VMConfig{
+		Name:     "foo",
+		State:    "stopped",
+		CPUCount: 2,
+		MemoryMB: 4096,
+	}
+
+	err := m.Set(context.Background(), "vm:foo", cfg)
+	require.NoError(t, err)
+
+	transport.mu.Lock()
+	calls := transport.calls
+	transport.mu.Unlock()
+
+	require.Len(t, calls, 1, "cache-seeded VM must produce exactly one transport call (Stop-VM)")
+	assert.Contains(t, calls[0].scriptBlock, "Stop-VM",
+		"Set with state stopped must invoke Stop-VM")
+	assert.NotContains(t, calls[0].scriptBlock, "New-VM",
+		"Set with state stopped on existing VM must not invoke New-VM")
+}
+
+// TestSetVM_ExistingVM_ResizesViaCmdlets asserts that Set on an existing VM with
+// changed cpu_count and memory_mb issues Set-VMProcessor and Set-VM (for memory)
+// without issuing New-VM.
+func TestSetVM_ExistingVM_ResizesViaCmdlets(t *testing.T) {
+	transport := &testWinRMTransport{}
+	m := vmModuleWithTransport(transport, "ops")
+
+	// Existing VM: 2 CPUs, 4096 MB.
+	m.vmsMu.Lock()
+	m.vms["foo"] = VMConfig{Name: "foo", State: "stopped", CPUCount: 2, MemoryMB: 4096}
+	m.vmsMu.Unlock()
+
+	// Desired: 4 CPUs, 8192 MB — both differ from current.
+	cfg := &VMConfig{
+		Name:     "foo",
+		State:    "stopped",
+		CPUCount: 4,
+		MemoryMB: 8192,
+	}
+
+	err := m.Set(context.Background(), "vm:foo", cfg)
+	require.NoError(t, err)
+
+	transport.mu.Lock()
+	calls := transport.calls
+	transport.mu.Unlock()
+
+	// At minimum: Stop-VM + Set-VMProcessor + Set-VMMemory
+	require.GreaterOrEqual(t, len(calls), 3, "resize must produce Stop-VM + Set-VMProcessor + Set-VMMemory calls")
+
+	var scripts []string
+	for _, c := range calls {
+		scripts = append(scripts, c.scriptBlock)
+	}
+
+	for _, s := range scripts {
+		assert.NotContains(t, s, "New-VM", "resize on existing VM must not invoke New-VM")
+	}
+
+	hasSetVMProcessor := false
+	hasSetVMMemory := false
+	for _, s := range scripts {
+		if strings.Contains(s, "Set-VMProcessor") {
+			hasSetVMProcessor = true
+		}
+		if strings.Contains(s, "Set-VM") && strings.Contains(s, "MemoryStartupBytes") {
+			hasSetVMMemory = true
+		}
+	}
+	assert.True(t, hasSetVMProcessor, "resize must call Set-VMProcessor for CPU change")
+	assert.True(t, hasSetVMMemory, "resize must call Set-VM with MemoryStartupBytes for memory change")
+}
+
+// TestSetVM_RunningState_WithResize verifies that Set with state "running" and
+// changed CPU/memory issues Stop-VM → Set-VMProcessor → Set-VMMemory → Start-VM
+// (the resize-while-running path) without issuing New-VM.
+func TestSetVM_RunningState_WithResize(t *testing.T) {
+	transport := &testWinRMTransport{}
+	m := vmModuleWithTransport(transport, "ops")
+
+	// Existing running VM with 2 CPUs, 4096 MB.
+	m.vmsMu.Lock()
+	m.vms["foo"] = VMConfig{Name: "foo", State: "running", CPUCount: 2, MemoryMB: 4096}
+	m.vmsMu.Unlock()
+
+	// Desired: still running, but 4 CPUs and 8192 MB.
+	cfg := &VMConfig{
+		Name:     "foo",
+		State:    "running",
+		CPUCount: 4,
+		MemoryMB: 8192,
+	}
+
+	err := m.Set(context.Background(), "vm:foo", cfg)
+	require.NoError(t, err)
+
+	transport.mu.Lock()
+	calls := transport.calls
+	transport.mu.Unlock()
+
+	// Expected sequence: Stop-VM, Set-VMProcessor, Set-VMMemory, Start-VM
+	require.Len(t, calls, 4, "running+resize must produce Stop-VM + Set-VMProcessor + Set-VMMemory + Start-VM")
+
+	assert.Contains(t, calls[0].scriptBlock, "Stop-VM", "first call must be Stop-VM")
+	assert.Contains(t, calls[1].scriptBlock, "Set-VMProcessor", "second call must be Set-VMProcessor")
+	assert.Contains(t, calls[2].scriptBlock, "Set-VM", "third call must be Set-VM (memory)")
+	assert.Contains(t, calls[3].scriptBlock, "Start-VM", "fourth call must be Start-VM")
+	for _, c := range calls {
+		assert.NotContains(t, c.scriptBlock, "New-VM", "resize on existing VM must not invoke New-VM")
+	}
+}
+
+// ─── VM power state failure-mode tests ────────────────────────────────────────
+
+// TestSetVM_StartVM_TransportError verifies that a transport failure on Start-VM
+// surfaces an error containing "Start-VM".
+func TestSetVM_StartVM_TransportError(t *testing.T) {
+	transport := &testWinRMTransport{execErr: errors.New("winrm: timeout")}
+	m := vmModuleWithTransport(transport, "ops")
+
+	m.vmsMu.Lock()
+	m.vms["foo"] = VMConfig{Name: "foo", State: "stopped", CPUCount: 2, MemoryMB: 4096}
+	m.vmsMu.Unlock()
+
+	cfg := &VMConfig{Name: "foo", State: "running", CPUCount: 2, MemoryMB: 4096}
+	err := m.Set(context.Background(), "vm:foo", cfg)
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "Start-VM")
+}
+
+// TestSetVM_StopVM_TransportError verifies that a transport failure on Stop-VM
+// surfaces an error containing "Stop-VM".
+func TestSetVM_StopVM_TransportError(t *testing.T) {
+	transport := &testWinRMTransport{execErr: errors.New("winrm: timeout")}
+	m := vmModuleWithTransport(transport, "ops")
+
+	m.vmsMu.Lock()
+	m.vms["foo"] = VMConfig{Name: "foo", State: "running", CPUCount: 2, MemoryMB: 4096}
+	m.vmsMu.Unlock()
+
+	cfg := &VMConfig{Name: "foo", State: "stopped", CPUCount: 2, MemoryMB: 4096}
+	err := m.Set(context.Background(), "vm:foo", cfg)
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "Stop-VM")
+}
+
+// TestSetVM_SetVMProcessor_TransportError verifies that a transport failure on
+// Set-VMProcessor surfaces an error containing "Set-VMProcessor".
+// Stop-VM (call 0) succeeds; Set-VMProcessor (call 1) injects the error.
+func TestSetVM_SetVMProcessor_TransportError(t *testing.T) {
+	transport := &testWinRMTransport{
+		perCallErrors: []error{nil, errors.New("winrm: timeout")},
+	}
+	m := vmModuleWithTransport(transport, "ops")
+
+	m.vmsMu.Lock()
+	m.vms["foo"] = VMConfig{Name: "foo", State: "stopped", CPUCount: 2, MemoryMB: 4096}
+	m.vmsMu.Unlock()
+
+	cfg := &VMConfig{Name: "foo", State: "stopped", CPUCount: 4, MemoryMB: 4096}
+	err := m.Set(context.Background(), "vm:foo", cfg)
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "Set-VMProcessor")
+}
+
+// TestSetVM_SetVMMemory_TransportError verifies that a transport failure on
+// Set-VMMemory surfaces an error containing "Set-VMMemory".
+// Stop-VM (call 0) succeeds; Set-VMMemory (call 1) injects the error.
+func TestSetVM_SetVMMemory_TransportError(t *testing.T) {
+	transport := &testWinRMTransport{
+		perCallErrors: []error{nil, errors.New("winrm: timeout")},
+	}
+	m := vmModuleWithTransport(transport, "ops")
+
+	m.vmsMu.Lock()
+	m.vms["foo"] = VMConfig{Name: "foo", State: "stopped", CPUCount: 2, MemoryMB: 4096}
+	m.vmsMu.Unlock()
+
+	// Only memory changes — no CPU resize, so second call is Set-VMMemory.
+	cfg := &VMConfig{Name: "foo", State: "stopped", CPUCount: 2, MemoryMB: 8192}
+	err := m.Set(context.Background(), "vm:foo", cfg)
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "Set-VMMemory")
 }


### PR DESCRIPTION
## Summary

- Implements `Start-VM`, `Stop-VM`, `Set-VMProcessor`, and `Set-VM` (memory) in `features/modules/hyperv/vm.go` — `setVM` now honors the `state` enum for existing VMs (start/stop) and applies CPU/memory resize via `Set-VM*` rather than re-running `New-VM`
- Creates `features/modules/hyperv/module.yaml` with full module discovery metadata (passes `TestAllModules/hyperv`)
- Adds required README sections (`Purpose and scope`, `Configuration options`, `Usage examples`, `Known limitations`, `Security considerations`) and a `Related Hypervisor Modules` note describing how Proxmox/VMware/KVM modules would be independent copy-shapes

## What changed

**`vm.go`** — `setVM` now checks the write-through cache for VM existence before calling the transport (avoiding a round-trip for known VMs), then dispatches:
- Existing VM + `running` → `Start-VM` (with stop/resize/start if CPU/memory changed)
- Existing VM + `stopped` → `Stop-VM` (with resize if needed)
- Not found + `running` → `New-VM` then `Start-VM`
- Not found + `stopped` → `New-VM`

New constants: `psStartVM`, `psStopVM`, `psSetVMProcessor`, `psSetVMMemory`. All use the ArgumentList injection-safe pattern and call `recordHypervOp` on both success and failure paths.

**`vm_test.go`** — 8 new tests: 3 happy-path (Start-VM, Stop-VM, resize), 1 running+resize sequence (stop→resize→start), 4 failure-mode tests (one per new PS constant). `TestSet_VMCreate` updated to expect 2 transport calls (getVM + New-VM).

**`module_test.go`** — Extended `testWinRMTransport` with `perCallOutputs`/`perCallErrors` for per-call response injection.

## Specialist Review Results

- **QA test runner**: PASS — `make test-agent-complete` passes; all cross-platform builds pass
- **QA code reviewer**: PASS — no blocking issues; all new constants have error-path tests; running+resize path covered by `TestSetVM_RunningState_WithResize`
- **Security engineer**: PASS — all new PS constants use ArgumentList only (no interpolation); audit logging on all new verbs; no hardcoded secrets; gosec/staticcheck/architecture checks clean

Fixes #1842

🤖 Generated with [Claude Code](https://claude.com/claude-code)