### PR TITLE
hyperv: update module.yaml executor declaration (Issue #1856)

### DIFF
--- a/features/modules/hyperv/README.md
+++ b/features/modules/hyperv/README.md
@@ -14,7 +14,7 @@ The module's scope includes:
 - **Virtual switches**: create and remove External, Internal, and Private vSwitches
 - **VM attachment**: add and remove network adapter-to-switch connections
 
-Out of scope: Hyper-V role installation, storage pool management, live migration, replication policies, and controller dispatch wiring (see issue #1790).
+Out of scope: Hyper-V role installation, storage pool management, live migration, replication policies, and controller dispatch wiring; steward-on-host wiring is delivered by #1790.
 
 ## Configuration options
 

--- a/features/modules/hyperv/module.yaml
+++ b/features/modules/hyperv/module.yaml
@@ -3,6 +3,7 @@ description: Remote Hyper-V management via WinRM — manages VMs, snapshots, and
 version: 0.1.0
 
 executors:
+  - steward
   - outpost
 
 author: CFGMS Team

--- a/features/modules/hyperv/module_test.go
+++ b/features/modules/hyperv/module_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"sort"
 	"sync"
 	"testing"
@@ -14,6 +15,7 @@ import (
 	"github.com/masterzen/winrm"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
 
 	"github.com/cfgis/cfgms/features/modules"
 	"github.com/cfgis/cfgms/pkg/logging"
@@ -655,4 +657,29 @@ func TestBuildInvokeCommand_MultipleArgs_SortedOrder(t *testing.T) {
 	assert.Equal(t, []string{"myvm", "/vms/myvm"}, args)
 	assert.NotContains(t, block, "myvm")
 	assert.NotContains(t, block, "/vms/myvm")
+}
+
+// ─── module.yaml executor declaration test ────────────────────────────────────
+
+// TestModuleYAMLHasStewardExecutor verifies that module.yaml declares both
+// "steward" and "outpost" in its executors list.
+//
+// executors is semantic metadata only — the steward loader does not gate on
+// this field (discovery.go:51 has no Executors).
+//
+// Parsed into a local struct (NOT ModuleInfo) because features/steward/discovery/
+// discovery.go:51 has no Executors field and silently drops the value at unmarshal.
+func TestModuleYAMLHasStewardExecutor(t *testing.T) {
+	type moduleYAMLSchema struct {
+		Executors []string `yaml:"executors"`
+	}
+
+	data, err := os.ReadFile("module.yaml")
+	require.NoError(t, err, "module.yaml must be readable")
+
+	var schema moduleYAMLSchema
+	require.NoError(t, yaml.Unmarshal(data, &schema), "module.yaml must be valid YAML")
+
+	assert.Contains(t, schema.Executors, "steward", "executors must include steward")
+	assert.Contains(t, schema.Executors, "outpost", "executors must include outpost")
 }


### PR DESCRIPTION
## Summary

- Adds `steward` to `executors` in `features/modules/hyperv/module.yaml` alongside the existing `outpost` entry, reflecting the Option A architectural decision from epic #1790
- Adds `TestModuleYAMLHasStewardExecutor` in `module_test.go` that parses `module.yaml` via a local struct (not `ModuleInfo`) to verify both executors are declared — required because `discovery.go:51` has no `Executors` field and silently drops the value at unmarshal
- Updates README.md line 17 "Out of scope" section to note steward-on-host wiring is delivered by #1790

Fixes #1856

## Specialist Review Results

| Reviewer | Result |
|----------|--------|
| qa-test-runner | PASS — all packages passing, cross-platform builds verified, lint clean |
| qa-code-reviewer | PASS — no blocking issues; 2 pre-existing warnings on unrelated test doubles |
| security-engineer | PASS — security-precommit, check-architecture, security-scan all passed; no blocking issues |

## Test plan

- [x] `TestModuleYAMLHasStewardExecutor` passes (parses real `module.yaml`, asserts both `steward` and `outpost` in executors)
- [x] Full `features/modules/hyperv/...` test suite passes
- [x] `make test-agent-complete` passes
- [x] Cross-platform compilation verified (linux/amd64, linux/arm64, darwin/amd64, darwin/arm64, windows/amd64)

🤖 Generated with [Claude Code](https://claude.com/claude-code)