### PR TITLE
ops: cfg tenant create command for tenant-tree seeding (Issue #1848)

### DIFF
--- a/cmd/cfg/cmd/api_client.go
+++ b/cmd/cfg/cmd/api_client.go
@@ -465,6 +465,92 @@ func (c *APIClient) doRequestWithContentType(ctx context.Context, method, path s
 	return c.httpClient.Do(req)
 }
 
+// APITenantCreateRequest is the request body for POST /api/v1/tenants.
+type APITenantCreateRequest struct {
+	ID       string `json:"id,omitempty"`
+	Name     string `json:"name,omitempty"`
+	ParentID string `json:"parent_id,omitempty"`
+}
+
+// APITenantResponse represents a tenant returned by the controller API.
+type APITenantResponse struct {
+	ID          string            `json:"id"`
+	Name        string            `json:"name"`
+	Description string            `json:"description,omitempty"`
+	ParentID    string            `json:"parent_id,omitempty"`
+	Status      string            `json:"status"`
+	Metadata    map[string]string `json:"metadata,omitempty"`
+	CreatedAt   string            `json:"created_at"`
+	UpdatedAt   string            `json:"updated_at"`
+}
+
+// ErrTenantAlreadyExists is returned by CreateTenantViaAPI when the server responds HTTP 409.
+var ErrTenantAlreadyExists = fmt.Errorf("tenant already exists")
+
+// CreateTenantViaAPI creates a tenant via the controller REST API.
+// Returns ErrTenantAlreadyExists when the server responds HTTP 409 (idempotent callers
+// should treat that as success and exit 0).
+func (c *APIClient) CreateTenantViaAPI(ctx context.Context, req *APITenantCreateRequest) (*APITenantResponse, error) {
+	body, err := json.Marshal(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal request: %w", err)
+	}
+
+	resp, err := c.doRequest(ctx, "POST", "/api/v1/tenants", bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode == http.StatusConflict {
+		return nil, ErrTenantAlreadyExists
+	}
+	if resp.StatusCode != http.StatusCreated {
+		return nil, c.parseError(resp)
+	}
+
+	// Unwrap APIResponse envelope: {"data": {...}, "timestamp": "..."}
+	var envelope struct {
+		Data json.RawMessage `json:"data"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&envelope); err != nil {
+		return nil, fmt.Errorf("failed to decode response: %w", err)
+	}
+	var tenant APITenantResponse
+	if err := json.Unmarshal(envelope.Data, &tenant); err != nil {
+		return nil, fmt.Errorf("failed to decode tenant data: %w", err)
+	}
+	return &tenant, nil
+}
+
+// GetTenantViaAPI retrieves a tenant by ID via the controller REST API.
+func (c *APIClient) GetTenantViaAPI(ctx context.Context, tenantID string) (*APITenantResponse, error) {
+	resp, err := c.doRequest(ctx, "GET", "/api/v1/tenants/"+tenantID, nil)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode == http.StatusNotFound {
+		return nil, fmt.Errorf("tenant not found: %s", tenantID)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, c.parseError(resp)
+	}
+
+	var envelope struct {
+		Data json.RawMessage `json:"data"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&envelope); err != nil {
+		return nil, fmt.Errorf("failed to decode response: %w", err)
+	}
+	var tenant APITenantResponse
+	if err := json.Unmarshal(envelope.Data, &tenant); err != nil {
+		return nil, fmt.Errorf("failed to decode tenant data: %w", err)
+	}
+	return &tenant, nil
+}
+
 // parseError extracts error message from HTTP response
 func (c *APIClient) parseError(resp *http.Response) error {
 	body, err := io.ReadAll(resp.Body)

--- a/cmd/cfg/cmd/root.go
+++ b/cmd/cfg/cmd/root.go
@@ -49,6 +49,7 @@ func init() {
 	rootCmd.AddCommand(versionCmd)
 	rootCmd.AddCommand(regcodeCmd)
 	rootCmd.AddCommand(tokenCmd)
+	rootCmd.AddCommand(tenantCmd)
 	rootCmd.AddCommand(registrationCmd)
 	rootCmd.AddCommand(controllerCmd)
 	rootCmd.AddCommand(traceCmd)

--- a/cmd/cfg/cmd/tenant.go
+++ b/cmd/cfg/cmd/tenant.go
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+// Package cmd implements the CLI commands for cfg
+package cmd
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	tenantCreateID     string
+	tenantCreateParent string
+	tenantAPIURL       string
+	tenantTLSInsecure  bool
+)
+
+// tenantCmd is the parent command for tenant management operations.
+var tenantCmd = &cobra.Command{
+	Use:   "tenant",
+	Short: "Manage tenants",
+	Long: `Manage tenants on the controller.
+
+Tenant operations require admin mTLS authentication via an admin bundle file.
+The bundle path can be provided via --bundle or the CFGMS_ADMIN_BUNDLE environment variable.
+
+Examples:
+  # Create a root tenant
+  cfg tenant create --tenant-id=team-root
+
+  # Create a child tenant
+  cfg tenant create --tenant-id=agent-test --parent=team-root`,
+}
+
+// tenantCreateCmd creates a named tenant on the controller.
+var tenantCreateCmd = &cobra.Command{
+	Use:   "create",
+	Short: "Create a tenant",
+	Long: `Create a tenant with an explicit Kubernetes-compatible ID.
+
+The tenant ID must conform to Kubernetes RFC 1123 DNS label rules:
+  - Lowercase alphanumeric characters and hyphens only
+  - Must not start or end with a hyphen
+  - Maximum 63 characters
+
+The command is idempotent: re-running it on an existing tenant exits 0.
+
+Examples:
+  cfg tenant create --tenant-id=team-root
+  cfg tenant create --tenant-id=agent-test --parent=team-root`,
+	RunE: runTenantCreate,
+}
+
+func init() {
+	tenantCmd.PersistentFlags().StringVar(&tenantAPIURL, "api-url", "", "Controller REST API URL (env: CFGMS_API_URL)")
+	tenantCmd.PersistentFlags().BoolVar(&tenantTLSInsecure, "tls-insecure", false, "Skip TLS verification (development only)")
+
+	tenantCreateCmd.Flags().StringVar(&tenantCreateID, "tenant-id", "", "Tenant ID (Kubernetes-compatible, required)")
+	tenantCreateCmd.Flags().StringVar(&tenantCreateParent, "parent", "", "Parent tenant ID (optional)")
+	_ = tenantCreateCmd.MarkFlagRequired("tenant-id")
+
+	tenantCmd.AddCommand(tenantCreateCmd)
+}
+
+func getTenantAPIClient() (*APIClient, error) {
+	apiURL := tenantAPIURL
+	if apiURL == "" {
+		apiURL = os.Getenv("CFGMS_API_URL")
+	}
+
+	client, err := resolveBundleClient(apiURL)
+	if err != nil {
+		return nil, fmt.Errorf("bundle lookup failed: %w", err)
+	}
+	if client != nil {
+		return client, nil
+	}
+
+	if apiURL == "" {
+		apiURL = "http://localhost:9080"
+	}
+
+	tlsInsecure := tenantTLSInsecure
+	if !tlsInsecure && os.Getenv("CFGMS_TLS_INSECURE") == "true" {
+		tlsInsecure = true
+	}
+
+	return newClientFromFlags(apiURL, "", "", tlsInsecure)
+}
+
+func runTenantCreate(_ *cobra.Command, _ []string) error {
+	client, err := getTenantAPIClient()
+	if err != nil {
+		return fmt.Errorf("failed to create API client: %w", err)
+	}
+
+	req := &APITenantCreateRequest{
+		ID:       tenantCreateID,
+		ParentID: tenantCreateParent,
+	}
+
+	td, err := client.CreateTenantViaAPI(context.Background(), req)
+	if err != nil {
+		if errors.Is(err, ErrTenantAlreadyExists) {
+			fmt.Printf("tenant already exists: %s\n", tenantCreateID)
+			return nil
+		}
+		return fmt.Errorf("failed to create tenant: %w", err)
+	}
+
+	fmt.Printf("tenant created: %s\n", td.ID)
+	return nil
+}

--- a/cmd/cfg/cmd/tenant_test.go
+++ b/cmd/cfg/cmd/tenant_test.go
@@ -1,0 +1,220 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+// Package cmd implements the CLI commands for cfg
+package cmd
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newTenantServer creates an httptest server that serves canned tenant API responses.
+func newTenantServer(t *testing.T) *httptest.Server {
+	t.Helper()
+
+	tenant := APITenantResponse{
+		ID:     "team-root",
+		Name:   "team-root",
+		Status: "active",
+	}
+
+	envelope := map[string]interface{}{
+		"data": tenant,
+	}
+
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/tenants":
+			w.WriteHeader(http.StatusCreated)
+			_ = json.NewEncoder(w).Encode(envelope)
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/tenants/team-root":
+			_ = json.NewEncoder(w).Encode(envelope)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+}
+
+// newTenantConflictServer returns a server that always responds 409 to POST /api/v1/tenants.
+func newTenantConflictServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusConflict)
+		_, _ = w.Write([]byte(`{"error":{"code":"TENANT_EXISTS","message":"tenant already exists"}}`))
+	}))
+}
+
+func TestCreateTenantCommand_HappyPath(t *testing.T) {
+	server := newTenantServer(t)
+	defer server.Close()
+
+	origAPIURL := tenantAPIURL
+	origTLSInsecure := tenantTLSInsecure
+	origID := tenantCreateID
+	origParent := tenantCreateParent
+	t.Cleanup(func() {
+		tenantAPIURL = origAPIURL
+		tenantTLSInsecure = origTLSInsecure
+		tenantCreateID = origID
+		tenantCreateParent = origParent
+	})
+
+	tenantAPIURL = server.URL
+	tenantTLSInsecure = true
+	tenantCreateID = "team-root"
+	tenantCreateParent = ""
+
+	output := captureStdout(t, func() {
+		err := runTenantCreate(tenantCreateCmd, nil)
+		require.NoError(t, err)
+	})
+
+	assert.Contains(t, output, "team-root", "success output must include the tenant ID")
+}
+
+func TestCreateTenantCommand_AlreadyExists(t *testing.T) {
+	server := newTenantConflictServer(t)
+	defer server.Close()
+
+	origAPIURL := tenantAPIURL
+	origTLSInsecure := tenantTLSInsecure
+	origID := tenantCreateID
+	origParent := tenantCreateParent
+	t.Cleanup(func() {
+		tenantAPIURL = origAPIURL
+		tenantTLSInsecure = origTLSInsecure
+		tenantCreateID = origID
+		tenantCreateParent = origParent
+	})
+
+	tenantAPIURL = server.URL
+	tenantTLSInsecure = true
+	tenantCreateID = "team-root"
+	tenantCreateParent = ""
+
+	output := captureStdout(t, func() {
+		// Must exit 0 (no error) when tenant already exists
+		err := runTenantCreate(tenantCreateCmd, nil)
+		require.NoError(t, err, "idempotent: already-existing tenant must exit 0")
+	})
+
+	assert.Contains(t, output, "tenant already exists")
+}
+
+func TestCreateTenantCommand_WithParent(t *testing.T) {
+	// bodyErrCh carries any read error from the server goroutine to the test goroutine.
+	bodyErrCh := make(chan error, 1)
+	bodyCh := make(chan []byte, 1)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPost && r.URL.Path == "/api/v1/tenants" {
+			body, err := io.ReadAll(r.Body)
+			bodyErrCh <- err
+			bodyCh <- body
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusCreated)
+			resp := map[string]interface{}{
+				"data": map[string]interface{}{
+					"id":        "agent-test",
+					"name":      "agent-test",
+					"parent_id": "team-root",
+					"status":    "active",
+				},
+			}
+			_ = json.NewEncoder(w).Encode(resp)
+		} else {
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	origAPIURL := tenantAPIURL
+	origTLSInsecure := tenantTLSInsecure
+	origID := tenantCreateID
+	origParent := tenantCreateParent
+	t.Cleanup(func() {
+		tenantAPIURL = origAPIURL
+		tenantTLSInsecure = origTLSInsecure
+		tenantCreateID = origID
+		tenantCreateParent = origParent
+	})
+
+	tenantAPIURL = server.URL
+	tenantTLSInsecure = true
+	tenantCreateID = "agent-test"
+	tenantCreateParent = "team-root"
+
+	output := captureStdout(t, func() {
+		err := runTenantCreate(tenantCreateCmd, nil)
+		require.NoError(t, err)
+	})
+
+	assert.Contains(t, output, "agent-test")
+
+	// Verify the request body contained the parent_id (read from the server goroutine via channels)
+	require.NoError(t, <-bodyErrCh, "server must be able to read the request body")
+	capturedBody := <-bodyCh
+	var reqBody APITenantCreateRequest
+	require.NoError(t, json.Unmarshal(capturedBody, &reqBody), "request body must be valid JSON")
+	assert.Equal(t, "team-root", reqBody.ParentID, "--parent flag must set parent_id in the request")
+}
+
+func TestCreateTenantCommand_APIError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"error":"internal error"}`))
+	}))
+	defer server.Close()
+
+	origAPIURL := tenantAPIURL
+	origTLSInsecure := tenantTLSInsecure
+	origID := tenantCreateID
+	t.Cleanup(func() {
+		tenantAPIURL = origAPIURL
+		tenantTLSInsecure = origTLSInsecure
+		tenantCreateID = origID
+	})
+
+	tenantAPIURL = server.URL
+	tenantTLSInsecure = true
+	tenantCreateID = "some-tenant"
+
+	err := runTenantCreate(tenantCreateCmd, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to create tenant")
+}
+
+func TestGetTenantViaAPI_Exists(t *testing.T) {
+	server := newTenantServer(t)
+	defer server.Close()
+
+	client, err := newClientFromFlags(server.URL, "", "", true)
+	require.NoError(t, err)
+
+	td, err := client.GetTenantViaAPI(t.Context(), "team-root")
+	require.NoError(t, err)
+	assert.Equal(t, "team-root", td.ID)
+}
+
+func TestGetTenantViaAPI_NotFound(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"error":{"code":"TENANT_NOT_FOUND","message":"tenant not found"}}`))
+	}))
+	defer server.Close()
+
+	client, err := newClientFromFlags(server.URL, "", "", true)
+	require.NoError(t, err)
+
+	_, err = client.GetTenantViaAPI(t.Context(), "missing-tenant")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "tenant not found")
+}

--- a/features/controller/api/handlers_tenants.go
+++ b/features/controller/api/handlers_tenants.go
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+package api
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"strings"
+
+	"github.com/gorilla/mux"
+
+	"github.com/cfgis/cfgms/features/tenant"
+	business "github.com/cfgis/cfgms/pkg/storage/interfaces/business"
+)
+
+// handleCreateTenant implements POST /api/v1/tenants.
+// Creates a tenant with an optional explicit ID. When req.ID is provided
+// the store uses that exact value (K8s-compatible naming required). Returns
+// HTTP 201 on success, 409 when the tenant ID already exists (idempotent
+// callers should treat 409 as success).
+func (s *Server) handleCreateTenant(w http.ResponseWriter, r *http.Request) {
+	var req tenant.TenantRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		s.writeErrorResponse(w, http.StatusBadRequest, "invalid request body", "INVALID_REQUEST")
+		return
+	}
+
+	td, err := s.tenantManager.CreateTenant(r.Context(), &req)
+	if err != nil {
+		if errors.Is(err, business.ErrTenantAlreadyExists) {
+			s.writeErrorResponse(w, http.StatusConflict, "tenant already exists", "TENANT_EXISTS")
+			return
+		}
+		s.writeErrorResponse(w, http.StatusBadRequest, err.Error(), "CREATE_FAILED")
+		return
+	}
+
+	s.writeResponse(w, http.StatusCreated, td)
+}
+
+// handleGetTenant implements GET /api/v1/tenants/{id}.
+// Returns 200 + tenant JSON for an existing tenant, 404 for a missing one.
+func (s *Server) handleGetTenant(w http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+	tenantID := vars["id"]
+	if tenantID == "" {
+		s.writeErrorResponse(w, http.StatusBadRequest, "tenant id is required", "MISSING_TENANT_ID")
+		return
+	}
+
+	td, err := s.tenantManager.GetTenant(r.Context(), tenantID)
+	if err != nil {
+		if strings.Contains(err.Error(), "tenant not found") {
+			s.writeErrorResponse(w, http.StatusNotFound, "tenant not found", "TENANT_NOT_FOUND")
+			return
+		}
+		s.writeErrorResponse(w, http.StatusInternalServerError, "failed to get tenant", "GET_FAILED")
+		return
+	}
+
+	s.writeSuccessResponse(w, td)
+}

--- a/features/controller/api/handlers_tenants_test.go
+++ b/features/controller/api/handlers_tenants_test.go
@@ -1,0 +1,185 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+package api
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cfgis/cfgms/features/tenant"
+	business "github.com/cfgis/cfgms/pkg/storage/interfaces/business"
+)
+
+func TestHandleCreateTenant_ExplicitID(t *testing.T) {
+	server := setupTestServer(t)
+	apiKey := NewTestKey(t, server, []string{"tenant:create"})
+
+	body, _ := json.Marshal(map[string]string{"id": "team-root"})
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/tenants", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-API-Key", apiKey)
+	w := httptest.NewRecorder()
+
+	server.router.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusCreated, w.Code, "expected 201 on successful tenant creation")
+
+	var resp APIResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+
+	data, ok := resp.Data.(map[string]interface{})
+	require.True(t, ok, "response data must be a map")
+	assert.Equal(t, "team-root", data["id"], "stored ID must match the requested explicit ID exactly")
+}
+
+func TestHandleCreateTenant_DuplicateID(t *testing.T) {
+	server := setupTestServer(t)
+	apiKey := NewTestKey(t, server, []string{"tenant:create"})
+
+	// Create the tenant once
+	ctx := context.Background()
+	_, err := server.tenantManager.CreateTenant(ctx, &tenant.TenantRequest{ID: "dup-tenant"})
+	require.NoError(t, err)
+
+	// Attempt to create with the same ID — must return 409
+	body, _ := json.Marshal(map[string]string{"id": "dup-tenant"})
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/tenants", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-API-Key", apiKey)
+	w := httptest.NewRecorder()
+
+	server.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusConflict, w.Code, "duplicate tenant ID must return 409")
+}
+
+func TestHandleCreateTenant_InvalidBody(t *testing.T) {
+	server := setupTestServer(t)
+	apiKey := NewTestKey(t, server, []string{"tenant:create"})
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/tenants", bytes.NewBufferString("not-json"))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-API-Key", apiKey)
+	w := httptest.NewRecorder()
+
+	server.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestHandleCreateTenant_InvalidExplicitID(t *testing.T) {
+	server := setupTestServer(t)
+	apiKey := NewTestKey(t, server, []string{"tenant:create"})
+
+	body, _ := json.Marshal(map[string]string{"id": "Team_Root"})
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/tenants", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-API-Key", apiKey)
+	w := httptest.NewRecorder()
+
+	server.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code, "non-K8s-compatible ID must be rejected")
+}
+
+func TestHandleCreateTenant_MissingPermission(t *testing.T) {
+	server := setupTestServer(t)
+	apiKey := NewTestKey(t, server, []string{"steward:read"})
+
+	body, _ := json.Marshal(map[string]string{"id": "no-perm-tenant"})
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/tenants", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-API-Key", apiKey)
+	w := httptest.NewRecorder()
+
+	server.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusForbidden, w.Code)
+}
+
+func TestHandleGetTenant_Exists(t *testing.T) {
+	server := setupTestServer(t)
+	apiKey := NewTestKey(t, server, []string{"tenant:read"})
+
+	// Create a tenant to retrieve
+	ctx := context.Background()
+	td, err := server.tenantManager.CreateTenant(ctx, &tenant.TenantRequest{ID: "readable-tenant"})
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/v1/tenants/%s", td.ID), nil)
+	req.Header.Set("X-API-Key", apiKey)
+	w := httptest.NewRecorder()
+
+	server.router.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var resp APIResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	data, ok := resp.Data.(map[string]interface{})
+	require.True(t, ok)
+	assert.Equal(t, "readable-tenant", data["id"])
+}
+
+func TestHandleGetTenant_NotFound(t *testing.T) {
+	server := setupTestServer(t)
+	apiKey := NewTestKey(t, server, []string{"tenant:read"})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/tenants/nonexistent-tenant", nil)
+	req.Header.Set("X-API-Key", apiKey)
+	w := httptest.NewRecorder()
+
+	server.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+func TestHandleGetTenant_MissingPermission(t *testing.T) {
+	server := setupTestServer(t)
+	apiKey := NewTestKey(t, server, []string{"steward:read"})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/tenants/some-tenant", nil)
+	req.Header.Set("X-API-Key", apiKey)
+	w := httptest.NewRecorder()
+
+	server.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusForbidden, w.Code)
+}
+
+// TestHandleGetTenant_ResponseShape verifies the full shape of the tenant JSON response.
+func TestHandleGetTenant_ResponseShape(t *testing.T) {
+	server := setupTestServer(t)
+	apiKey := NewTestKey(t, server, []string{"tenant:read"})
+
+	ctx := context.Background()
+	td, err := server.tenantManager.CreateTenant(ctx, &tenant.TenantRequest{
+		ID:          "shape-tenant",
+		Description: "test description",
+	})
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/tenants/shape-tenant", nil)
+	req.Header.Set("X-API-Key", apiKey)
+	w := httptest.NewRecorder()
+
+	server.router.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var resp APIResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	data, ok := resp.Data.(map[string]interface{})
+	require.True(t, ok)
+	assert.Equal(t, td.ID, data["id"])
+	assert.Equal(t, string(business.TenantStatusActive), data["status"])
+	assert.NotEmpty(t, data["created_at"])
+}

--- a/features/controller/api/server.go
+++ b/features/controller/api/server.go
@@ -463,8 +463,10 @@ func (s *Server) setupRouter() {
 	compliance := api.PathPrefix("/compliance").Subrouter()
 	compliance.Handle("/summary", s.requirePermission("compliance", "read-summary")(http.HandlerFunc(s.handleGetComplianceSummary))).Methods("GET")
 
-	// Tenant config-source management endpoints (Issue #1396)
+	// Tenant management endpoints (Issue #1396, Issue #1848)
 	tenants := api.PathPrefix("/tenants").Subrouter()
+	tenants.Handle("", s.requirePermission("tenant", "create")(http.HandlerFunc(s.handleCreateTenant))).Methods("POST")
+	tenants.Handle("/{id}", s.requirePermission("tenant", "read")(http.HandlerFunc(s.handleGetTenant))).Methods("GET")
 	tenants.Handle("/{id}/config-source/test",
 		s.requirePermission("tenant", "manage")(http.HandlerFunc(s.handleConfigSourceTest))).Methods("POST")
 

--- a/features/tenant/manager.go
+++ b/features/tenant/manager.go
@@ -68,6 +68,11 @@ func (m *Manager) WithAuditManager(a *audit.Manager) *Manager {
 
 // CreateTenant creates a new tenant with validation and RBAC setup
 func (m *Manager) CreateTenant(ctx context.Context, req *TenantRequest) (*business.TenantData, error) {
+	// When an explicit ID is provided without a name, use the ID as the display name.
+	if req.ID != "" && req.Name == "" {
+		req.Name = req.ID
+	}
+
 	// Validate the request
 	if err := m.validateTenantRequest(req); err != nil {
 		return nil, fmt.Errorf("validation failed: %w", err)
@@ -80,8 +85,14 @@ func (m *Manager) CreateTenant(ctx context.Context, req *TenantRequest) (*busine
 		}
 	}
 
-	// Generate tenant ID from name
+	// Generate tenant ID from name, or use the explicit ID when provided
 	tenantID := m.generateTenantID(req.Name)
+	if req.ID != "" {
+		if err := validateExplicitTenantID(req.ID); err != nil {
+			return nil, fmt.Errorf("invalid explicit tenant ID: %w", err)
+		}
+		tenantID = req.ID
+	}
 
 	// Create tenant object
 	now := time.Now()
@@ -364,4 +375,23 @@ func (m *Manager) generateTenantID(name string) string {
 	// Add timestamp suffix to ensure uniqueness
 	timestamp := time.Now().Unix()
 	return fmt.Sprintf("%s-%d", id, timestamp)
+}
+
+// k8sNameRegex matches Kubernetes-compatible DNS label names per RFC 1123.
+var k8sNameRegex = regexp.MustCompile(`^[a-z0-9]([-a-z0-9]*[a-z0-9])?$`)
+
+// validateExplicitTenantID validates a caller-supplied tenant ID against
+// Kubernetes RFC 1123 DNS label rules: lowercase alphanumeric and hyphens only,
+// no leading/trailing hyphens, max 63 characters.
+func validateExplicitTenantID(id string) error {
+	if id == "" {
+		return fmt.Errorf("tenant ID cannot be empty")
+	}
+	if len(id) > 63 {
+		return fmt.Errorf("tenant ID must be 63 characters or less (Kubernetes DNS label limit), got %d", len(id))
+	}
+	if !k8sNameRegex.MatchString(id) {
+		return fmt.Errorf("tenant ID %q is not Kubernetes-compatible: must contain only lowercase alphanumeric characters and hyphens, must not start or end with a hyphen", id)
+	}
+	return nil
 }

--- a/features/tenant/manager_test.go
+++ b/features/tenant/manager_test.go
@@ -5,6 +5,7 @@ package tenant
 import (
 	"context"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -585,4 +586,101 @@ func TestSanitizeAuditURL_RedactsUserinfo(t *testing.T) {
 			}
 		})
 	}
+}
+
+// --- Explicit tenant ID tests (Issue #1848) ---
+
+func TestManager_CreateTenant_WithExplicitID(t *testing.T) {
+	manager := newTestTenantManager(t)
+	ctx := context.Background()
+
+	req := &TenantRequest{
+		ID:   "team-root",
+		Name: "Team-Root",
+	}
+
+	td, err := manager.CreateTenant(ctx, req)
+	require.NoError(t, err)
+	assert.Equal(t, "team-root", td.ID, "explicit ID must be preserved exactly as provided")
+	assert.Equal(t, "Team-Root", td.Name)
+
+	// Verify the tenant can be retrieved by its exact ID
+	retrieved, err := manager.GetTenant(ctx, "team-root")
+	require.NoError(t, err)
+	assert.Equal(t, "team-root", retrieved.ID)
+}
+
+func TestManager_CreateTenant_ExplicitID_DefaultsNameToID(t *testing.T) {
+	manager := newTestTenantManager(t)
+	ctx := context.Background()
+
+	// When Name is omitted, ID is used as Name
+	req := &TenantRequest{
+		ID: "agent-test",
+	}
+
+	td, err := manager.CreateTenant(ctx, req)
+	require.NoError(t, err)
+	assert.Equal(t, "agent-test", td.ID)
+	assert.Equal(t, "agent-test", td.Name, "Name must default to ID when omitted")
+}
+
+func TestManager_CreateTenant_ExplicitID_WithParent(t *testing.T) {
+	manager := newTestTenantManager(t)
+	ctx := context.Background()
+
+	parent, err := manager.CreateTenant(ctx, &TenantRequest{ID: "team-root"})
+	require.NoError(t, err)
+
+	child, err := manager.CreateTenant(ctx, &TenantRequest{
+		ID:       "agent-test",
+		ParentID: parent.ID,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "agent-test", child.ID)
+	assert.Equal(t, "team-root", child.ParentID)
+}
+
+func TestValidateExplicitTenantID_K8sRules(t *testing.T) {
+	tests := []struct {
+		name    string
+		id      string
+		wantErr bool
+	}{
+		{"valid lowercase alphanumeric", "teamroot", false},
+		{"valid with hyphen", "team-root", false},
+		{"valid single char", "a", false},
+		{"valid with numbers", "agent-test-123", false},
+		{"valid 63 chars", strings.Repeat("a", 63), false},
+		{"empty string", "", true},
+		{"uppercase letter", "Team-Root", true},
+		{"uppercase only", "TEAM", true},
+		{"underscore", "team_root", true},
+		{"leading hyphen", "-team-root", true},
+		{"trailing hyphen", "team-root-", true},
+		{"64 chars (too long)", strings.Repeat("a", 64), true},
+		{"special char @", "team@root", true},
+		{"space", "team root", true},
+		{"dot", "team.root", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateExplicitTenantID(tt.id)
+			if tt.wantErr {
+				assert.Error(t, err, "expected error for id=%q", tt.id)
+			} else {
+				assert.NoError(t, err, "expected no error for id=%q", tt.id)
+			}
+		})
+	}
+}
+
+func TestManager_CreateTenant_InvalidExplicitID_ReturnsError(t *testing.T) {
+	manager := newTestTenantManager(t)
+	ctx := context.Background()
+
+	_, err := manager.CreateTenant(ctx, &TenantRequest{ID: "Team_Root"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid explicit tenant ID")
 }

--- a/features/tenant/types.go
+++ b/features/tenant/types.go
@@ -23,7 +23,8 @@ const (
 
 // TenantRequest represents a request to create or update a tenant
 type TenantRequest struct {
-	Name        string            `json:"name"`
+	ID          string            `json:"id,omitempty"`
+	Name        string            `json:"name,omitempty"`
 	Description string            `json:"description,omitempty"`
 	ParentID    string            `json:"parent_id,omitempty"`
 	Metadata    map[string]string `json:"metadata,omitempty"`

--- a/pkg/storage/interfaces/business/tenant_store.go
+++ b/pkg/storage/interfaces/business/tenant_store.go
@@ -6,8 +6,13 @@ package business
 
 import (
 	"context"
+	"errors"
 	"time"
 )
+
+// ErrTenantAlreadyExists is returned by TenantStore.CreateTenant when a tenant
+// with the given ID already exists. Handlers must use errors.Is to detect it.
+var ErrTenantAlreadyExists = errors.New("tenant already exists")
 
 // TenantStore defines storage interface for CFGMS tenant data persistence
 // All tenant modules use this interface - storage provider is chosen by controller

--- a/pkg/storage/providers/sqlite/tenant_store.go
+++ b/pkg/storage/providers/sqlite/tenant_store.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"strings"
 
 	business "github.com/cfgis/cfgms/pkg/storage/interfaces/business"
 )
@@ -62,6 +63,9 @@ func (s *SQLiteTenantStore) CreateTenant(ctx context.Context, tenant *business.T
 		formatTime(tenant.UpdatedAt),
 	)
 	if err != nil {
+		if isUniqueConstraintError(err) {
+			return fmt.Errorf("create tenant %s: %w", tenant.ID, business.ErrTenantAlreadyExists)
+		}
 		return fmt.Errorf("failed to create tenant %s: %w", tenant.ID, err)
 	}
 	return nil
@@ -309,6 +313,12 @@ func populateTenant(t *business.TenantData, parentID sql.NullString, metaStr, st
 	}
 
 	return t, nil
+}
+
+// isUniqueConstraintError returns true when the error is a SQLite UNIQUE constraint violation.
+// The mattn/go-sqlite3 driver embeds the text "UNIQUE constraint failed" in the error message.
+func isUniqueConstraintError(err error) bool {
+	return err != nil && strings.Contains(err.Error(), "UNIQUE constraint failed")
 }
 
 // ensure SQLiteTenantStore satisfies the interface at compile time


### PR DESCRIPTION
## Summary

- Adds `cfg tenant create --tenant-id=<id> [--parent=<parent-id>]` CLI command for scripted tenant-tree seeding with Kubernetes-compatible IDs and idempotent re-run (409 → exit 0)
- Adds `POST /api/v1/tenants` and `GET /api/v1/tenants/{id}` REST endpoints under `tenant:create` / `tenant:read` permissions
- Introduces `business.ErrTenantAlreadyExists` typed sentinel so SQLite UNIQUE constraint violations surface via `errors.Is` rather than string matching
- Adds `validateExplicitTenantID` (RFC 1123 DNS label rules) to `features/tenant/manager.go`

Fixes #1848

## Test plan

- [ ] `go test ./features/tenant/... ./features/controller/api/... ./cmd/cfg/cmd/... ./pkg/storage/...` — all pass
- [ ] `TestCreateTenantCommand_HappyPath` — flag parsing, API call, tenant ID in output
- [ ] `TestCreateTenantCommand_AlreadyExists` — idempotent 409 handling exits 0
- [ ] `TestCreateTenantCommand_WithParent` — `--parent` flag sets `parent_id` in request body (verified via goroutine-safe channel capture)
- [ ] `TestHandleCreateTenant_ExplicitID` — handler stores exact explicit ID
- [ ] `TestHandleCreateTenant_DuplicateID` — handler returns HTTP 409 via `errors.Is(err, business.ErrTenantAlreadyExists)`
- [ ] `TestValidateExplicitTenantID_K8sRules` — 15 cases: empty, uppercase, underscore, leading/trailing hyphen, >63 chars, valid variants
- [ ] `TestHandleGetTenant_Exists` / `TestHandleGetTenant_NotFound` — 200 and 404 responses
- [ ] `TestGetTenantViaAPI_Exists` / `TestGetTenantViaAPI_NotFound` — client error paths covered

## Specialist Review Results

- **QA Test Runner**: PASS — `make test-agent-complete` green; marker written at `/tmp/agent-validation-passed`
- **QA Code Reviewer**: PASS (after 1 fix cycle) — fixed body-read error swallowing in `TestCreateTenantCommand_WithParent` (channel-based goroutine-safe capture), replaced UNIQUE constraint string-matching with `errors.Is(err, business.ErrTenantAlreadyExists)`, added `GetTenantViaAPI` test coverage
- **Security Engineer**: PASS — no blocking issues; 4 low-severity warnings (all pre-existing CLI patterns: HTTP default, `--tls-insecure` opt-in, raw error reflection to admin callers); architecture check clean; gosec/Trivy/Nancy green

🤖 Generated with [Claude Code](https://claude.ai/claude-code)