### PR TITLE
pipeline: extend preflight regex for .ps1/.wxs/Makefile + document story format (Issue #1861)

### DIFF
--- a/.claude/agents/ba.md
+++ b/.claude/agents/ba.md
@@ -81,7 +81,12 @@ Each story must use this exact format:
 
 ## Dependencies
 
-<List other stories from this epic that must be completed first. Use "None" if independent.>
+<List other stories from this epic that must be completed first.>
+
+**Format rules (PO cycle preflight at `.claude/scripts/po-cycle-preflight.py:770-793` enforces these):**
+
+- If the story has no dependencies, the section body must be exactly `None` (or `none.` / `n/a` / empty). Anything else — including `"None — independent of X"` — fails the empty whitelist and gets flagged as malformed.
+- If the story has dependencies, the section MUST contain at least one `#NNN` GitHub issue reference. Prose like `"Sibling story: foo"` without a numeric reference triggers the same malformed warning.
 
 For each dependency, list the issue number AND the PR number (once known) so the
 dev agent can run a `git merge-base --is-ancestor` check before starting:
@@ -90,9 +95,13 @@ dev agent can run a `git merge-base --is-ancestor` check before starting:
 - #NNN — <reason> — must be merged into develop before this story starts (PR: #MMM when known)
 ```
 
+**Sibling stories whose issue numbers aren't assigned at draft time:** use placeholder tokens like `#SIBLING-S1`, `#SIBLING-S2`. The PO uses a two-pass create flow — files all stories, captures numbers, then `gh issue edit` replaces placeholders with actual issue numbers before linking sub-issues and promoting to Ready.
+
 If the dev agent finds a listed PR has not yet merged, it halts and re-queues
 the story. This prevents the multi-module sequencing failures observed in
 issue #923 where parallel stories were dispatched out of order.
+
+The full reference template lives at `docs/development/story-template.md`.
 
 ## Out of Scope
 

--- a/.claude/scripts/po-cycle-preflight.py
+++ b/.claude/scripts/po-cycle-preflight.py
@@ -40,11 +40,12 @@ REPO = "cfg-is/cfgms"
 SECTION_RE = re.compile(r"(?m)^##\s+(.+?)\s*$")
 ISSUE_NUM_RE = re.compile(r"#(\d+)")
 BACKTICK_PATH_RE = re.compile(
-    r"`([^`\n]+?\.(?:go|md|proto|sh|yaml|yml|json|toml|ts|tsx))`"
+    r"`((?:[^`\n]+\.(?:go|md|proto|sh|yaml|yml|json|toml|ts|tsx|ps1|wxs|py))"
+    r"|(?:[a-zA-Z0-9_./-]*/)?(?:Makefile|Dockerfile(?:\.[\w-]+)?))`"
 )
 BARE_PATH_RE = re.compile(
     r"(?:^|[\s(\[])"
-    r"([a-zA-Z0-9_./-]+/[a-zA-Z0-9_./-]+\.(?:go|md|proto|sh|yaml|yml|json|toml|ts|tsx))"
+    r"([a-zA-Z0-9_./-]+/[a-zA-Z0-9_./-]+\.(?:go|md|proto|sh|yaml|yml|json|toml|ts|tsx|ps1|wxs|py))"
 )
 BRANCH_STORY_RE = re.compile(r"feature/(?:story-(\d+)|item-([a-zA-Z0-9]+)-agent)")
 

--- a/.claude/scripts/tests/preflight_path_regex.test.sh
+++ b/.claude/scripts/tests/preflight_path_regex.test.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# Regression test for BACKTICK_PATH_RE and BARE_PATH_RE in po-cycle-preflight.py.
+#
+# Covers Issue #1861: the preflight parser must recognize every file extension
+# and special-case filename we ship — .ps1 (PowerShell), .wxs (WiX MSI), .py
+# (Python scripts), Makefile, and Dockerfile(.variant)?. Story #1854 surfaced
+# the gap: a PowerShell-shaped story's Files In Scope parsed to zero matches
+# and got flagged as malformed by the cron.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PREFLIGHT="${SCRIPT_DIR}/../po-cycle-preflight.py"
+
+if [[ ! -f "${PREFLIGHT}" ]]; then
+  printf 'FAIL: preflight not found at %s\n' "${PREFLIGHT}" >&2
+  exit 1
+fi
+
+ran=0
+fail=0
+
+# Invokes a small Python helper that imports the two regexes from preflight
+# and runs the supplied snippet against them. Asserts the resulting union
+# matches the expected set.
+assert_paths() {
+  local description="$1"
+  local snippet="$2"
+  local expected="$3"  # comma-separated expected matches
+  ran=$((ran + 1))
+  local actual
+  actual=$(SNIPPET="$snippet" PREFLIGHT_PATH="$PREFLIGHT" python3 - <<'PY'
+import importlib.util, os, sys
+spec = importlib.util.spec_from_file_location("preflight", os.environ["PREFLIGHT_PATH"])
+m = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(m)
+snippet = os.environ["SNIPPET"]
+hits = sorted(set(m.BACKTICK_PATH_RE.findall(snippet)) | set(m.BARE_PATH_RE.findall(snippet)))
+print(",".join(hits))
+PY
+)
+  if [[ "$actual" == "$expected" ]]; then
+    printf '  ok    %s\n' "$description"
+  else
+    printf '  FAIL  %s\n         expected: %s\n         actual:   %s\n' "$description" "$expected" "$actual"
+    fail=$((fail + 1))
+  fi
+}
+
+echo "preflight_path_regex.test.sh"
+echo "----------------------------"
+
+# ── Positive cases: each tracked extension matches in backticks ──
+assert_paths "backtick .go"   '- `features/foo.go` — change' "features/foo.go"
+assert_paths "backtick .md"   '- `docs/op.md` — new'         "docs/op.md"
+assert_paths "backtick .sh"   '- `scripts/foo.sh` — new'     "scripts/foo.sh"
+assert_paths "backtick .yaml" '- `pkg/m.yaml` — edit'        "pkg/m.yaml"
+assert_paths "backtick .yml"  '- `ci/build.yml` — edit'      "ci/build.yml"
+assert_paths "backtick .json" '- `pkg/data.json` — edit'     "pkg/data.json"
+assert_paths "backtick .toml" '- `cfg/foo.toml` — edit'      "cfg/foo.toml"
+assert_paths "backtick .proto" '- `api/proto/x.proto` — edit' "api/proto/x.proto"
+assert_paths "backtick .ts"   '- `web/src/x.ts` — edit'      "web/src/x.ts"
+assert_paths "backtick .tsx"  '- `web/src/x.tsx` — edit'     "web/src/x.tsx"
+
+# ── New extensions from Issue #1861 ──
+assert_paths "backtick .ps1"  '- `scripts/install.ps1` — new' "scripts/install.ps1"
+assert_paths "backtick .wxs"  '- `build/windows/x.wxs` — edit' "build/windows/x.wxs"
+assert_paths "backtick .py"   '- `.claude/scripts/po.py` — edit' ".claude/scripts/po.py"
+
+# ── Special-case files: Makefile + Dockerfile variants ──
+assert_paths "backtick Makefile"           '- `Makefile` — add target'             "Makefile"
+assert_paths "backtick Dockerfile"         '- `Dockerfile` — edit'                 "Dockerfile"
+assert_paths "backtick Dockerfile.debian"  '- `cmd/controller/Dockerfile.debian` — edit' "cmd/controller/Dockerfile.debian"
+
+# ── Bare paths still require a directory separator ──
+assert_paths "bare .ps1 with path"        'See scripts/install.ps1 for details.' "scripts/install.ps1"
+assert_paths "bare .wxs with path"        'See build/windows/cfgms.wxs.'         "build/windows/cfgms.wxs"
+assert_paths "bare Makefile (no slash)"   'See the Makefile.'                    ""
+
+# ── False-positive guards ──
+assert_paths "prose 'all controller files'" 'Touch all controller package files.' ""
+assert_paths "version number is not a path" 'Bump to v1.2.3 today.'               ""
+assert_paths "empty section"                ''                                      ""
+
+# ── #1854's actual Files In Scope (the regression that started this) ──
+FIS_1854='- `scripts/install-hyperv-host.ps1` — new file
+- `scripts/install-hyperv-host_test.ps1` — Pester 5 tests (logic tests against a mock `cfgms-steward.exe` stub)
+- `Makefile` — add `test-install-hyperv-ps1` target'
+assert_paths "#1854 Files In Scope literal" "$FIS_1854" "Makefile,scripts/install-hyperv-host.ps1,scripts/install-hyperv-host_test.ps1"
+
+printf '\nran=%d  fail=%d\n' "$ran" "$fail"
+if (( fail > 0 )); then
+  exit 1
+fi

--- a/docs/development/story-template.md
+++ b/docs/development/story-template.md
@@ -1,0 +1,64 @@
+## Parent epic: #<EPIC_NUMBER>
+
+## Goal
+
+<One paragraph describing what should be observable / true when this story is done. Outcome, not task list.>
+
+## Dependencies
+
+<One of three forms:>
+
+<Form 1 — no deps:>
+None
+
+<Form 2 — existing issue deps:>
+- #NNN — <reason> — must be merged into develop before this story starts
+- #MMM — <reason> — <when external PR known: (PR: #PPP)>
+
+<Form 3 — sibling deps with placeholders for two-pass create:>
+- #SIBLING-S1 — <reason> — must be merged into develop before this story starts
+- #SIBLING-S2 — <reason> — must be merged before this story starts
+
+<IMPORTANT: PO cron preflight rejects prose without #NNN. Only `None` / `none.` / `n/a` / empty are accepted as empty markers.>
+
+## Out of Scope
+
+- <Explicit list of nearby code/files/behaviors the dev agent must NOT touch>
+- <Use "None" only if genuinely nothing adjacent is at risk>
+
+## Files In Scope
+
+- `path/to/file.go` — <what to do with this file>
+- `path/to/file_test.go` — <what tests to add>
+
+<IMPORTANT: PO cron preflight requires at least one file path (backticked or bare) in this section.>
+
+## Docs In Scope
+
+- `docs/path/to/doc.md` — <what to update>
+
+<Use "None — no product-shape change" with justification only if the story genuinely doesn't change observable shape. See ba.md "Documentation & Tests Currency" rule.>
+
+## Reference Implementation
+
+- <Pointer to existing pattern in the codebase to follow, with file:line>
+- <Relevant architecture doc>
+
+## Implementation Notes
+
+<Specific technical guidance for the dev agent:>
+- Central providers to use
+- Interfaces to implement
+- Edge cases to handle
+- Security considerations
+
+## Acceptance Criteria
+
+- [ ] <Specific, testable criterion>
+- [ ] [REQUIRED TEST] <Test that MUST exist for the story to be accepted>
+- [ ] <Another criterion>
+- [ ] Tests added/updated for all behavior changes (unit + integration where applicable)
+- [ ] Docs updated — enumerate or write "N/A — no product-shape change" with justification
+- [ ] `make test-complete` passes
+
+<Mark every AC requiring a specific test with [REQUIRED TEST]. Acceptance review treats these as hard gates.>


### PR DESCRIPTION
## Summary

- PO preflight regex now recognizes `.ps1`, `.wxs`, `.py`, `Makefile`, and `Dockerfile(.variant)?` — fixes false-malformed flag on PowerShell-shaped stories like #1854
- BA spec (`.claude/agents/ba.md`) documents the strict `## Dependencies` whitelist and `#SIBLING-S<n>` two-pass-create placeholder convention
- New canonical story template at `docs/development/story-template.md`
- 23 regex test cases including #1854's literal `## Files In Scope` as a regression lock

Fixes #1861.

## Test plan

- [ ] `bash .claude/scripts/tests/preflight_path_regex.test.sh` reports 23 ran / 0 failed
- [ ] `python3 .claude/scripts/po-cycle-preflight.py --stdout` shows zero `parse_warnings` across all currently-ready stories (verified against #1848–#1850, #1853–#1857)
- [ ] CI required checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)