### PR TITLE
ops: Tier 1 controller smoke-test script (Issue #1849)

### DIFF
--- a/scripts/test-scripts.sh
+++ b/scripts/test-scripts.sh
@@ -170,6 +170,8 @@ test_executable_permissions() {
         "scripts/generate-test-credentials.sh"
         "scripts/wait-for-services.sh"
         "scripts/test-with-infrastructure.sh"
+        "scripts/tier1-smoke-test.sh"
+        "scripts/tier1-smoke-test_test.sh"
     )
 
     for script in "${critical_scripts[@]}"; do
@@ -2465,6 +2467,45 @@ PYEOF
     fi
 }
 
+test_tier1_smoke_test() {
+    log_test "Testing tier1-smoke-test.sh fixtures..."
+
+    local smoke_script="scripts/tier1-smoke-test.sh"
+    local test_script="scripts/tier1-smoke-test_test.sh"
+
+    if [[ ! -f "$smoke_script" ]]; then
+        log_fail "tier1-smoke-test.sh: Not found"
+        return
+    fi
+
+    if [[ ! -x "$smoke_script" ]]; then
+        log_fail "tier1-smoke-test.sh: Not executable (chmod +x needed)"
+        return
+    fi
+
+    if [[ ! -f "$test_script" ]]; then
+        log_fail "tier1-smoke-test_test.sh: Not found"
+        return
+    fi
+
+    if [[ ! -x "$test_script" ]]; then
+        log_fail "tier1-smoke-test_test.sh: Not executable (chmod +x needed)"
+        return
+    fi
+
+    local out_file rc=0
+    out_file=$(mktemp)
+    bash "$test_script" >"$out_file" 2>&1 || rc=$?
+
+    if [[ $rc -eq 0 ]]; then
+        log_pass "tier1-smoke-test_test.sh: All fixture tests passed"
+    else
+        log_fail "tier1-smoke-test_test.sh: Fixture tests failed (exit $rc)"
+        sed 's/^/    /' "$out_file" >&2
+    fi
+    rm -f "$out_file"
+}
+
 # Main execution
 echo "🔍 Script Validation Test Suite"
 echo "================================"
@@ -2536,6 +2577,8 @@ echo ""
 test_trust_boundary
 echo ""
 test_no_pipeline_label_refs
+echo ""
+test_tier1_smoke_test
 echo ""
 echo ""
 echo "📊 Test Summary"

--- a/scripts/tier1-smoke-test.sh
+++ b/scripts/tier1-smoke-test.sh
@@ -1,0 +1,296 @@
+#!/bin/bash
+# Tier 1 controller smoke test.
+#
+# Verifies REST API reachability, mTLS authentication from the admin bundle,
+# expected health response, and presence of three required tenants on a live
+# Tier 1 controller after a bootstrap run.
+#
+# Dependencies (runtime): bash >=4, curl, python3 (standard on Debian/Ubuntu)
+#
+# NOTE: Story #1848 (cfg tenant create + GET /api/v1/tenants/{id}) must be
+#       merged and run before the tenant-existence checks here can pass on a
+#       freshly bootstrapped controller.
+#
+# Usage:
+#   ./tier1-smoke-test.sh [--bundle <path>] [--controller-url <url>]
+#
+# Flags:
+#   --bundle <path>        Path to the CFGMS admin bundle YAML.
+#                          Default: $CFGMS_ADMIN_BUNDLE or /etc/cfgms/admin.bundle.yaml
+#   --controller-url <url> Controller base URL (overrides bundle controller_url field).
+#
+# Exit codes:
+#   0 — all checks passed
+#   1 — one or more checks failed, or fatal setup error
+
+set -uo pipefail
+
+BUNDLE_PATH="${CFGMS_ADMIN_BUNDLE:-/etc/cfgms/admin.bundle.yaml}"
+CONTROLLER_URL=""
+PASS_COUNT=0
+FAIL_COUNT=0
+
+# --- Argument parsing ---
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --bundle)
+      if [[ $# -lt 2 || -z "$2" ]]; then
+        echo "ERROR: --bundle requires a path argument" >&2
+        exit 1
+      fi
+      BUNDLE_PATH="$2"
+      shift 2
+      ;;
+    --controller-url)
+      if [[ $# -lt 2 || -z "$2" ]]; then
+        echo "ERROR: --controller-url requires a URL argument" >&2
+        exit 1
+      fi
+      CONTROLLER_URL="$2"
+      shift 2
+      ;;
+    -h|--help)
+      sed -n 's/^# //p; s/^#$//p' "$0" | head -40
+      exit 0
+      ;;
+    *)
+      echo "ERROR: unknown argument: $1" >&2
+      echo "Usage: $0 [--bundle <path>] [--controller-url <url>]" >&2
+      exit 1
+      ;;
+  esac
+done
+
+# --- Validate bundle file exists ---
+if [[ ! -f "$BUNDLE_PATH" ]]; then
+  echo "[FAIL] bundle-load: bundle file not found: $BUNDLE_PATH"
+  echo ""
+  echo "Result: 0 passed, 1 failed"
+  exit 1
+fi
+
+# --- Temp files for cert material ---
+CERT_FILE=$(mktemp /tmp/cfgms-smoke-cert-XXXXXX.pem)
+KEY_FILE=$(mktemp /tmp/cfgms-smoke-key-XXXXXX.pem)
+CA_FILE=$(mktemp /tmp/cfgms-smoke-ca-XXXXXX.pem)
+
+# Never leave private key material on disk after exit (success, failure, or Ctrl+C).
+trap 'rm -f "$CERT_FILE" "$KEY_FILE" "$CA_FILE"' EXIT INT TERM
+
+# --- Extract certs from bundle ---
+# Uses yaml if available, falls back to a minimal inline parser for the
+# block-literal format produced by Go's gopkg.in/yaml.v3 marshal.
+_extract_rc=0
+BUNDLE_PATH="$BUNDLE_PATH" CERT_FILE="$CERT_FILE" KEY_FILE="$KEY_FILE" CA_FILE="$CA_FILE" \
+  python3 - <<'PYTHON' 2>&1 || _extract_rc=$?
+
+import os, sys
+
+def parse_bundle(path):
+    """Parse the bundle YAML file. Tries pyyaml first; falls back to inline parser."""
+    try:
+        import yaml
+        with open(path) as fh:
+            return yaml.safe_load(fh)
+    except ImportError:
+        pass
+    # Inline parser for Go yaml.v3 block-literal format (no external deps needed).
+    result = {}
+    with open(path) as fh:
+        lines = fh.read().splitlines()
+    i = 0
+    while i < len(lines):
+        line = lines[i]
+        stripped = line.rstrip()
+        if not stripped or stripped.lstrip().startswith('#'):
+            i += 1
+            continue
+        if ': |' in stripped or stripped.endswith(': |'):
+            key = stripped[:stripped.index(':')].strip()
+            i += 1
+            content, indent = [], None
+            while i < len(lines):
+                cl = lines[i]
+                if not cl.strip():
+                    content.append('')
+                    i += 1
+                    continue
+                sp = len(cl) - len(cl.lstrip())
+                if indent is None:
+                    indent = sp
+                if sp < indent:
+                    break
+                content.append(cl[indent:])
+                i += 1
+            result[key] = '\n'.join(content) + '\n'
+        elif ': ' in stripped:
+            colon = stripped.index(': ')
+            key = stripped[:colon].strip()
+            val = stripped[colon + 2:].strip()
+            if (val.startswith('"') and val.endswith('"')) or \
+               (val.startswith("'") and val.endswith("'")):
+                val = val[1:-1]
+            result[key] = val
+            i += 1
+        else:
+            i += 1
+    return result
+
+bundle_path = os.environ['BUNDLE_PATH']
+try:
+    b = parse_bundle(bundle_path)
+except Exception as exc:
+    print(f"failed to parse bundle: {exc}", file=sys.stderr)
+    sys.exit(1)
+
+for field, path in [('cert_pem', os.environ['CERT_FILE']),
+                    ('key_pem',  os.environ['KEY_FILE']),
+                    ('ca_pem',   os.environ['CA_FILE'])]:
+    val = b.get(field, '')
+    if not val:
+        print(f"bundle missing required field: {field}", file=sys.stderr)
+        sys.exit(1)
+    with open(path, 'w') as fh:
+        fh.write(val)
+PYTHON
+
+if [[ $_extract_rc -ne 0 ]]; then
+  echo "[FAIL] bundle-load: failed to extract certs from $BUNDLE_PATH (see above)"
+  echo ""
+  echo "Result: 0 passed, 1 failed"
+  exit 1
+fi
+
+# --- Resolve controller URL from bundle if not provided via flag ---
+if [[ -z "$CONTROLLER_URL" ]]; then
+  _url_rc=0
+  CONTROLLER_URL=$(BUNDLE_PATH="$BUNDLE_PATH" python3 - 2>/dev/null <<'PYTHON'
+import os, sys
+
+def parse_bundle(path):
+    try:
+        import yaml
+        with open(path) as fh:
+            return yaml.safe_load(fh)
+    except ImportError:
+        pass
+    result = {}
+    with open(path) as fh:
+        lines = fh.read().splitlines()
+    i = 0
+    while i < len(lines):
+        line = lines[i]
+        stripped = line.rstrip()
+        if not stripped or stripped.lstrip().startswith('#'):
+            i += 1
+            continue
+        if ': |' in stripped or stripped.endswith(': |'):
+            key = stripped[:stripped.index(':')].strip()
+            i += 1
+            content, indent = [], None
+            while i < len(lines):
+                cl = lines[i]
+                if not cl.strip():
+                    content.append('')
+                    i += 1
+                    continue
+                sp = len(cl) - len(cl.lstrip())
+                if indent is None:
+                    indent = sp
+                if sp < indent:
+                    break
+                content.append(cl[indent:])
+                i += 1
+            result[key] = '\n'.join(content) + '\n'
+        elif ': ' in stripped:
+            colon = stripped.index(': ')
+            key = stripped[:colon].strip()
+            val = stripped[colon + 2:].strip()
+            if (val.startswith('"') and val.endswith('"')) or \
+               (val.startswith("'") and val.endswith("'")):
+                val = val[1:-1]
+            result[key] = val
+            i += 1
+        else:
+            i += 1
+    return result
+
+bundle_path = os.environ['BUNDLE_PATH']
+try:
+    b = parse_bundle(bundle_path)
+    url = b.get('controller_url', '').rstrip('/')
+    if not url:
+        print("bundle missing controller_url field", file=sys.stderr)
+        sys.exit(1)
+    print(url)
+except Exception as exc:
+    print(f"failed to read controller_url: {exc}", file=sys.stderr)
+    sys.exit(1)
+PYTHON
+) || _url_rc=$?
+
+  if [[ $_url_rc -ne 0 || -z "$CONTROLLER_URL" ]]; then
+    echo "[FAIL] bundle-load: controller_url not found in bundle; pass --controller-url"
+    echo ""
+    echo "Result: 0 passed, 1 failed"
+    exit 1
+  fi
+fi
+
+CONTROLLER_URL="${CONTROLLER_URL%/}"
+
+# --- Per-check record helpers ---
+_record_pass() {
+  echo "[PASS] $1"
+  PASS_COUNT=$((PASS_COUNT + 1))
+}
+
+_record_fail() {
+  echo "[FAIL] $1: $2"
+  FAIL_COUNT=$((FAIL_COUNT + 1))
+}
+
+# --- Check 1: health endpoint returns 200 ---
+_health_code="000"
+_health_code=$(curl \
+  --cert "$CERT_FILE" --key "$KEY_FILE" --cacert "$CA_FILE" \
+  -s -o /dev/null -w "%{http_code}" \
+  "${CONTROLLER_URL}/api/v1/health" 2>/dev/null) || _health_code="000"
+
+if [[ "$_health_code" == "200" ]]; then
+  _record_pass "health: GET /api/v1/health"
+else
+  _record_fail "health: GET /api/v1/health" "expected HTTP 200, got ${_health_code}"
+fi
+
+# --- Checks 2-4: required tenant existence ---
+_check_tenant() {
+  local tenant_id="$1"
+  local code="000"
+  code=$(curl \
+    --cert "$CERT_FILE" --key "$KEY_FILE" --cacert "$CA_FILE" \
+    -s -o /dev/null -w "%{http_code}" \
+    "${CONTROLLER_URL}/api/v1/tenants/${tenant_id}" 2>/dev/null) || code="000"
+
+  if [[ "$code" == "200" ]]; then
+    _record_pass "tenant-exists: ${tenant_id}"
+  elif [[ "$code" == "404" ]]; then
+    _record_fail "tenant-exists: ${tenant_id}" \
+      "tenant not found (404) — run 'cfg tenant create' first (story #1848)"
+  else
+    _record_fail "tenant-exists: ${tenant_id}" "unexpected HTTP ${code}"
+  fi
+}
+
+_check_tenant "team-root"
+_check_tenant "agent-test"
+_check_tenant "infra-hyperv"
+
+# --- Summary ---
+echo ""
+echo "Result: ${PASS_COUNT} passed, ${FAIL_COUNT} failed"
+
+if [[ $FAIL_COUNT -gt 0 ]]; then
+  exit 1
+fi
+exit 0

--- a/scripts/tier1-smoke-test_test.sh
+++ b/scripts/tier1-smoke-test_test.sh
@@ -1,0 +1,512 @@
+#!/bin/bash
+# Fixture-based tests for tier1-smoke-test.sh.
+#
+# Starts a stub HTTPS server (Python ssl) with generated test certs to cover
+# both the all-pass path and several failure modes without a real controller.
+#
+# Dependencies: bash >=4, openssl, python3, curl
+#
+# Exit codes: 0 = all tests passed, 1 = any test failed
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SMOKE="$SCRIPT_DIR/tier1-smoke-test.sh"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+PASS_COUNT=0
+FAIL_COUNT=0
+
+_pass() {
+  echo -e "${GREEN}[PASS]${NC} $1"
+  PASS_COUNT=$((PASS_COUNT + 1))
+}
+
+_fail() {
+  echo -e "${RED}[FAIL]${NC} $1"
+  FAIL_COUNT=$((FAIL_COUNT + 1))
+}
+
+# ---------------------------------------------------------------------------
+# Cert generation
+# ---------------------------------------------------------------------------
+_setup_certs() {
+  local d="$1"
+  # CA
+  openssl req -x509 -newkey rsa:2048 -keyout "$d/ca.key" -out "$d/ca.crt" \
+    -days 1 -nodes -subj "/CN=Test CA" 2>/dev/null
+
+  # Server cert with Subject Alternative Name so curl trusts 127.0.0.1
+  openssl req -newkey rsa:2048 -keyout "$d/server.key" -out "$d/server.csr" \
+    -nodes -subj "/CN=127.0.0.1" 2>/dev/null
+  openssl x509 -req -in "$d/server.csr" -CA "$d/ca.crt" -CAkey "$d/ca.key" \
+    -CAcreateserial -out "$d/server.crt" -days 1 \
+    -extfile <(printf "subjectAltName=IP:127.0.0.1,DNS:localhost\n") 2>/dev/null
+
+  # Client cert (mTLS)
+  openssl req -newkey rsa:2048 -keyout "$d/client.key" -out "$d/client.csr" \
+    -nodes -subj "/CN=admin" 2>/dev/null
+  openssl x509 -req -in "$d/client.csr" -CA "$d/ca.crt" -CAkey "$d/ca.key" \
+    -CAcreateserial -out "$d/client.crt" -days 1 \
+    -extfile <(printf "extendedKeyUsage=clientAuth\n") 2>/dev/null
+}
+
+# ---------------------------------------------------------------------------
+# Bundle YAML generation (no pyyaml needed: produces Go yaml.v3 block-literal format)
+# ---------------------------------------------------------------------------
+_make_bundle() {
+  local d="$1"
+  local port="$2"
+  D="$d" PORT="$port" python3 - <<'PYEOF'
+import os
+
+def block(s):
+    """Format a string as a YAML block literal (|) with 4-space indent."""
+    lines = s.rstrip('\n').split('\n')
+    return '|\n' + ''.join('    ' + l + '\n' for l in lines)
+
+d    = os.environ['D']
+port = os.environ['PORT']
+
+cert = open(d + '/client.crt').read()
+key  = open(d + '/client.key').read()
+ca   = open(d + '/ca.crt').read()
+
+yaml_text = (
+    'cert_pem: '      + block(cert) +
+    'key_pem: '       + block(key) +
+    'ca_pem: '        + block(ca) +
+    'controller_url: https://127.0.0.1:' + port + '\n' +
+    'audit_subject: ""\n' +
+    'cert_serial: "01"\n' +
+    'cert_fingerprint: test\n'
+)
+with open(d + '/bundle.yaml', 'w') as f:
+    f.write(yaml_text)
+PYEOF
+}
+
+# Same as _make_bundle but uses a deliberately wrong controller_url.
+_make_bundle_bad_url() {
+  local d="$1"
+  D="$d" python3 - <<'PYEOF'
+import os
+
+def block(s):
+    lines = s.rstrip('\n').split('\n')
+    return '|\n' + ''.join('    ' + l + '\n' for l in lines)
+
+d = os.environ['D']
+
+cert = open(d + '/client.crt').read()
+key  = open(d + '/client.key').read()
+ca   = open(d + '/ca.crt').read()
+
+yaml_text = (
+    'cert_pem: '      + block(cert) +
+    'key_pem: '       + block(key) +
+    'ca_pem: '        + block(ca) +
+    'controller_url: https://127.0.0.1:9\n' +
+    'audit_subject: ""\n' +
+    'cert_serial: "01"\n' +
+    'cert_fingerprint: test\n'
+)
+with open(d + '/bundle_bad_url.yaml', 'w') as f:
+    f.write(yaml_text)
+PYEOF
+}
+
+# ---------------------------------------------------------------------------
+# Stub HTTPS server (Python ssl + http.server, no pyyaml dependency)
+# ---------------------------------------------------------------------------
+_write_stub_server() {
+  local path="$1"
+  cat > "$path" << 'PYEOF'
+import ssl, http.server, json, os
+
+MODE    = os.environ.get('STUB_MODE', 'all-pass')
+READY_F = os.environ['STUB_READY_FILE']
+PORT_F  = os.environ['STUB_PORT_FILE']
+
+TENANTS = {
+    'all-pass':           ['team-root', 'agent-test', 'infra-hyperv'],
+    'health-fail':        ['team-root', 'agent-test', 'infra-hyperv'],
+    'missing-team-root':  ['agent-test', 'infra-hyperv'],
+}
+present = TENANTS.get(MODE, TENANTS['all-pass'])
+
+class Handler(http.server.BaseHTTPRequestHandler):
+    def do_GET(self):
+        try:
+            if self.path == '/api/v1/health':
+                if MODE == 'health-fail':
+                    self.send_response(503)
+                    self.end_headers()
+                    self.wfile.write(b'{"status":"unhealthy"}')
+                else:
+                    self.send_response(200)
+                    self.end_headers()
+                    self.wfile.write(b'{"status":"healthy"}')
+            elif self.path.startswith('/api/v1/tenants/'):
+                tid = self.path.rsplit('/', 1)[-1]
+                if tid in present:
+                    self.send_response(200)
+                    self.send_header('Content-Type', 'application/json')
+                    self.end_headers()
+                    self.wfile.write(json.dumps({'id': tid}).encode())
+                else:
+                    self.send_response(404)
+                    self.end_headers()
+            else:
+                self.send_response(404)
+                self.end_headers()
+        except Exception:
+            pass
+
+    def log_message(self, *args):
+        pass
+
+ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+ctx.load_cert_chain(os.environ['STUB_CRT'], os.environ['STUB_KEY'])
+ctx.verify_mode = ssl.CERT_REQUIRED
+ctx.load_verify_locations(os.environ['STUB_CA'])
+
+httpd = http.server.HTTPServer(('127.0.0.1', 0), Handler)
+httpd.socket = ctx.wrap_socket(httpd.socket, server_side=True)
+
+port = httpd.server_address[1]
+with open(PORT_F, 'w') as f:
+    f.write(str(port))
+with open(READY_F, 'w') as f:
+    f.write('ready')
+
+httpd.serve_forever()
+PYEOF
+}
+
+# ---------------------------------------------------------------------------
+# Server lifecycle helpers
+# ---------------------------------------------------------------------------
+SERVER_PID=""
+SERVER_PORT=""
+
+_start_server() {
+  local mode="$1"
+  local d="$2"
+
+  rm -f "$d/ready" "$d/port"
+
+  STUB_MODE="$mode" \
+  STUB_CRT="$d/server.crt" \
+  STUB_KEY="$d/server.key" \
+  STUB_CA="$d/ca.crt" \
+  STUB_READY_FILE="$d/ready" \
+  STUB_PORT_FILE="$d/port" \
+    python3 "$d/stub_server.py" &
+  SERVER_PID=$!
+
+  # Wait up to 5 s for ready signal
+  local waited=0
+  while [[ ! -f "$d/ready" && $waited -lt 50 ]]; do
+    sleep 0.1
+    waited=$((waited + 1))
+  done
+
+  if [[ ! -f "$d/ready" ]]; then
+    _fail "stub server ($mode): did not become ready within 5 s"
+    kill "$SERVER_PID" 2>/dev/null || true
+    SERVER_PID=""
+    SERVER_PORT=""
+    return 1
+  fi
+
+  SERVER_PORT=$(cat "$d/port")
+}
+
+_stop_server() {
+  if [[ -n "$SERVER_PID" ]]; then
+    kill "$SERVER_PID" 2>/dev/null || true
+    wait "$SERVER_PID" 2>/dev/null || true
+    SERVER_PID=""
+  fi
+  SERVER_PORT=""
+}
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+test_syntax() {
+  if bash -n "$SMOKE" 2>/dev/null; then
+    _pass "syntax: tier1-smoke-test.sh has valid bash syntax"
+  else
+    _fail "syntax: tier1-smoke-test.sh has a syntax error"
+  fi
+}
+
+test_bundle_missing() {
+  local out="" rc=0
+  out=$(bash "$SMOKE" --bundle "/nonexistent/path/bundle.yaml" 2>&1) || rc=$?
+
+  if [[ $rc -eq 1 ]]; then
+    _pass "bundle-missing: exits 1 when bundle file does not exist"
+  else
+    _fail "bundle-missing: expected exit 1, got $rc"
+  fi
+
+  if grep -q '\[FAIL\].*bundle' <<< "$out"; then
+    _pass "bundle-missing: output contains [FAIL] bundle line"
+  else
+    _fail "bundle-missing: expected [FAIL] bundle line — output: $out"
+  fi
+}
+
+test_bundle_malformed() {
+  local d="$TMPDIR_ROOT/malformed"
+  mkdir -p "$d"
+
+  # A file that exists but has cert field pointing to obviously invalid PEM
+  printf 'cert_pem: "not-a-cert"\nkey_pem: ""\nca_pem: ""\ncontroller_url: https://127.0.0.1:9\n' \
+    > "$d/malformed.yaml"
+
+  local out="" rc=0
+  out=$(bash "$SMOKE" --bundle "$d/malformed.yaml" 2>&1) || rc=$?
+
+  if [[ $rc -eq 1 ]]; then
+    _pass "bundle-malformed: exits 1 when required cert fields are empty"
+  else
+    _fail "bundle-malformed: expected exit 1, got $rc — output: $out"
+  fi
+
+  if grep -q '\[FAIL\].*bundle' <<< "$out"; then
+    _pass "bundle-malformed: output contains [FAIL] bundle-load line"
+  else
+    _fail "bundle-malformed: expected [FAIL] bundle-load line — output: $out"
+  fi
+}
+
+test_bundle_missing_controller_url() {
+  local d="$TMPDIR_ROOT/no-controller-url"
+  mkdir -p "$d"
+  _setup_certs "$d"
+
+  # Bundle with valid certs but no controller_url field
+  D="$d" python3 - <<'PYEOF'
+import os
+
+def block(s):
+    lines = s.rstrip('\n').split('\n')
+    return '|\n' + ''.join('    ' + l + '\n' for l in lines)
+
+d = os.environ['D']
+cert = open(d + '/client.crt').read()
+key  = open(d + '/client.key').read()
+ca   = open(d + '/ca.crt').read()
+
+# Intentionally omit controller_url
+yaml_text = (
+    'cert_pem: '  + block(cert) +
+    'key_pem: '   + block(key) +
+    'ca_pem: '    + block(ca) +
+    'cert_serial: "01"\n' +
+    'cert_fingerprint: test\n'
+)
+with open(d + '/bundle_no_url.yaml', 'w') as f:
+    f.write(yaml_text)
+PYEOF
+
+  local out="" rc=0
+  out=$(bash "$SMOKE" --bundle "$d/bundle_no_url.yaml" 2>&1) || rc=$?
+
+  if [[ $rc -eq 1 ]]; then
+    _pass "bundle-no-url: exits 1 when controller_url absent and --controller-url not passed"
+  else
+    _fail "bundle-no-url: expected exit 1, got $rc — output: $out"
+  fi
+
+  if grep -q '\[FAIL\].*bundle-load.*controller_url' <<< "$out"; then
+    _pass "bundle-no-url: output contains [FAIL] bundle-load controller_url line"
+  else
+    _fail "bundle-no-url: expected [FAIL] bundle-load controller_url line — output: $out"
+  fi
+}
+
+test_all_pass() {
+  local d="$TMPDIR_ROOT/all-pass"
+  mkdir -p "$d"
+  _setup_certs "$d"
+  _write_stub_server "$d/stub_server.py"
+  _start_server "all-pass" "$d" || return
+
+  _make_bundle "$d" "$SERVER_PORT"
+
+  local out="" rc=0
+  out=$(bash "$SMOKE" --bundle "$d/bundle.yaml" 2>&1) || rc=$?
+  _stop_server
+
+  if [[ $rc -eq 0 ]]; then
+    _pass "all-pass: exits 0 when all checks succeed"
+  else
+    _fail "all-pass: expected exit 0, got $rc — output: $out"
+    return
+  fi
+
+  local pass_lines
+  pass_lines=$(grep -c '^\[PASS\]' <<< "$out" 2>/dev/null) || pass_lines=0
+  if [[ "$pass_lines" -eq 4 ]]; then
+    _pass "all-pass: output contains 4 [PASS] lines"
+  else
+    _fail "all-pass: expected 4 [PASS] lines, got $pass_lines — output: $out"
+  fi
+
+  local fail_lines
+  fail_lines=$(grep -c '^\[FAIL\]' <<< "$out" 2>/dev/null) || fail_lines=0
+  if [[ "$fail_lines" -eq 0 ]]; then
+    _pass "all-pass: output contains 0 [FAIL] lines"
+  else
+    _fail "all-pass: expected 0 [FAIL] lines, got $fail_lines — output: $out"
+  fi
+
+  if grep -q '^Result: 4 passed, 0 failed' <<< "$out"; then
+    _pass "all-pass: summary line correct"
+  else
+    _fail "all-pass: missing or wrong summary line — output: $out"
+  fi
+}
+
+test_health_fail() {
+  local d="$TMPDIR_ROOT/health-fail"
+  mkdir -p "$d"
+  _setup_certs "$d"
+  _write_stub_server "$d/stub_server.py"
+  _start_server "health-fail" "$d" || return
+
+  _make_bundle "$d" "$SERVER_PORT"
+
+  local out="" rc=0
+  out=$(bash "$SMOKE" --bundle "$d/bundle.yaml" 2>&1) || rc=$?
+  _stop_server
+
+  if [[ $rc -eq 1 ]]; then
+    _pass "health-fail: exits 1 when health check fails"
+  else
+    _fail "health-fail: expected exit 1, got $rc — output: $out"
+  fi
+
+  if grep -q '^\[FAIL\] health:' <<< "$out"; then
+    _pass "health-fail: [FAIL] line present for health check"
+  else
+    _fail "health-fail: missing [FAIL] health line — output: $out"
+  fi
+
+  # Tenant checks must still run even after health failure (3 [PASS] lines expected)
+  local pass_lines
+  pass_lines=$(grep -c '^\[PASS\]' <<< "$out" 2>/dev/null) || pass_lines=0
+  if [[ "$pass_lines" -eq 3 ]]; then
+    _pass "health-fail: tenant checks still run (3 [PASS] tenant lines)"
+  else
+    _fail "health-fail: expected 3 [PASS] tenant lines, got $pass_lines — output: $out"
+  fi
+}
+
+test_missing_tenant() {
+  local d="$TMPDIR_ROOT/missing-tenant"
+  mkdir -p "$d"
+  _setup_certs "$d"
+  _write_stub_server "$d/stub_server.py"
+  _start_server "missing-team-root" "$d" || return
+
+  _make_bundle "$d" "$SERVER_PORT"
+
+  local out="" rc=0
+  out=$(bash "$SMOKE" --bundle "$d/bundle.yaml" 2>&1) || rc=$?
+  _stop_server
+
+  if [[ $rc -eq 1 ]]; then
+    _pass "missing-tenant: exits 1 when a tenant is absent"
+  else
+    _fail "missing-tenant: expected exit 1, got $rc — output: $out"
+  fi
+
+  if grep -q '^\[FAIL\] tenant-exists: team-root' <<< "$out"; then
+    _pass "missing-tenant: [FAIL] line present for team-root"
+  else
+    _fail "missing-tenant: missing [FAIL] tenant-exists: team-root line — output: $out"
+  fi
+
+  if grep -q '^\[PASS\] tenant-exists: agent-test' <<< "$out" &&
+     grep -q '^\[PASS\] tenant-exists: infra-hyperv' <<< "$out"; then
+    _pass "missing-tenant: remaining tenants still pass"
+  else
+    _fail "missing-tenant: expected [PASS] for agent-test and infra-hyperv — output: $out"
+  fi
+}
+
+test_controller_url_override() {
+  local d="$TMPDIR_ROOT/url-override"
+  mkdir -p "$d"
+  _setup_certs "$d"
+  _write_stub_server "$d/stub_server.py"
+  _start_server "all-pass" "$d" || return
+
+  # Bundle has a wrong URL; --controller-url flag must override it
+  _make_bundle_bad_url "$d"
+
+  local out="" rc=0
+  out=$(bash "$SMOKE" \
+    --bundle "$d/bundle_bad_url.yaml" \
+    --controller-url "https://127.0.0.1:${SERVER_PORT}" \
+    2>&1) || rc=$?
+  _stop_server
+
+  if [[ $rc -eq 0 ]]; then
+    _pass "url-override: --controller-url flag overrides bundle controller_url"
+  else
+    _fail "url-override: expected exit 0, got $rc — output: $out"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+if [[ ! -f "$SMOKE" ]]; then
+  _fail "tier1-smoke-test.sh not found at $SMOKE"
+  echo ""
+  echo "Result: 0 passed, 1 failed"
+  exit 1
+fi
+
+TMPDIR_ROOT=$(mktemp -d)
+trap 'rm -rf "$TMPDIR_ROOT"; _stop_server' EXIT
+
+echo "tier1-smoke-test fixture tests"
+echo "=============================="
+echo ""
+
+test_syntax
+echo ""
+test_bundle_missing
+echo ""
+test_bundle_malformed
+echo ""
+test_bundle_missing_controller_url
+echo ""
+test_all_pass
+echo ""
+test_health_fail
+echo ""
+test_missing_tenant
+echo ""
+test_controller_url_override
+echo ""
+
+echo "Result: ${PASS_COUNT} passed, ${FAIL_COUNT} failed"
+echo ""
+
+if [[ $FAIL_COUNT -gt 0 ]]; then
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

- Adds `scripts/tier1-smoke-test.sh`: bash smoke-test that verifies a live Tier 1 controller after bootstrap — mTLS auth via admin bundle, `/api/v1/health` returns 200, and three required tenants (`team-root`, `agent-test`, `infra-hyperv`) exist via `GET /api/v1/tenants/{id}`
- Outputs `[PASS]`/`[FAIL]` per check plus a summary line; exits 0 if all pass, 1 if any fail
- Temp cert/key files cleaned via `trap EXIT INT TERM` — private key never persists on disk
- Accepts `--bundle` and `--controller-url` flags with documented defaults
- Adds `scripts/tier1-smoke-test_test.sh`: 8 fixture-based tests against a stub HTTPS server (real mTLS with generated certs, Python ssl)
- Updates `scripts/test-scripts.sh` to run the fixture tests as part of the script validation suite

Fixes #1849

## Specialist Review Results

- **QA Test Runner**: PASS — all Go tests, script tests (154/154), and tier1 fixture tests pass; cross-platform builds verified
- **QA Code Reviewer**: PASS — error paths covered (bundle-missing, bundle-malformed, missing-controller_url, health-fail, missing-tenant); real HTTPS stub server; no mocks
- **Security Engineer**: PASS — no hardcoded secrets, key files use 0600 mode with trap cleanup, no command injection, YAML parser uses no `eval`, heredocs use `<<'PYTHON'` to block shell interpolation

## Test plan

- [ ] `bash scripts/tier1-smoke-test_test.sh` — 18 fixture tests all pass
- [ ] `bash scripts/test-scripts.sh` — 154/154 pass including tier1 fixture suite
- [ ] `scripts/tier1-smoke-test.sh --help` — prints usage
- [ ] `scripts/tier1-smoke-test.sh --bundle /nonexistent` — exits 1 with `[FAIL] bundle-load`
- [ ] On a real Tier 1 controller with admin bundle: all 4 checks pass, exits 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)