### PR TITLE
ops: Tier 1 controller bootstrap script + runbook (Issue #1850)

### DIFF
--- a/docs/operations/tier1-controller-bringup.md
+++ b/docs/operations/tier1-controller-bringup.md
@@ -1,0 +1,347 @@
+# Tier 1 Controller Bring-Up
+
+**M1 deliverable.** This runbook is the source of truth for `scripts/tier1-bootstrap.sh`.
+Every Tier 1 rebuild from here on is: provision VM, copy script, run script.
+
+Storage backend: flatfile + SQLite. No git, no SOPS, no external database.
+
+---
+
+## 1. Overview
+
+`tier1-bootstrap.sh` orchestrates every step of a fresh Tier 1 controller deployment:
+OS baseline, binary install, certificate initialization, systemd service, tenant tree
+seeding, and smoke test. It is idempotent — re-running it on a fully-bootstrapped host
+exits 0 with no destructive action.
+
+The few steps that flank the script are covered in §4 (run bootstrap), §5 (distribute
+admin bundle), and §2 (prerequisites). Everything else is automated.
+
+---
+
+## 2. Prerequisites
+
+**VM specification** (Hyper-V Gen 2):
+
+| Resource  | Minimum          | Notes                          |
+|-----------|------------------|--------------------------------|
+| OS        | Debian 12         | Bookworm. Other Debian-family distros not tested. |
+| vCPU      | 2                 |                                |
+| RAM       | 4 GB              |                                |
+| Disk      | 40 GB             | `/var/lib/cfgms` grows with fleet size. |
+| Secure Boot | Enabled (Gen 2) | Controller binary is unsigned; disable Secure Boot if it blocks execution. |
+
+**Network:**
+
+- SSH access from operator workstation to the VM
+- VM outbound HTTPS (port 443) to `github.com` — binary download during bootstrap
+- Ports 9080/TCP (REST API) and 4433/UDP (gRPC-over-QUIC) reachable from stewards and the `cfg` CLI
+
+**Files to copy to the VM before running bootstrap:**
+
+```bash
+scp scripts/tier1-bootstrap.sh scripts/tier1-smoke-test.sh \
+    <operator>@ctrl.cfgms.lab:/tmp/
+```
+
+Both scripts must be in the same directory at runtime (the smoke test script is
+invoked by the bootstrap script via relative path).
+
+---
+
+## 3. Hostname vs IP and SAN
+
+The TLS certificate generated during initialization embeds the hostname you supply
+via `--hostname` in the Subject Alternative Name (SAN). Clients — stewards and the
+`cfg` CLI — verify the SAN against what they dial. If they dial an IP address instead
+of a hostname, the IP must match an entry in the cert's `ip_addresses` list.
+
+**Default behavior:** the bootstrap script sets `common_name` and `dns_names` to the
+`--hostname` value and always includes `127.0.0.1` in `ip_addresses`.
+
+**Operator responsibility for routing:** Stewards and the `cfg` CLI must be able to
+reach the controller at the hostname you provide. DNS or `/etc/hosts` entries are the
+operator's responsibility — the bootstrap script does not configure network routing.
+
+If the controller is reachable at additional hostnames or IPs (load balancer VIPs,
+secondary interfaces), edit `/etc/cfgms/controller.cfg` before running `--init`, or
+re-initialize with a `--config` override that includes the additional SANs.
+
+---
+
+## 4. Run Bootstrap
+
+**Single command — run as root on the controller VM:**
+
+```bash
+sudo bash /tmp/tier1-bootstrap.sh --hostname=ctrl.cfgms.lab
+```
+
+Optional flags:
+
+| Flag                    | Default                 | Purpose                                |
+|-------------------------|-------------------------|----------------------------------------|
+| `--hostname HOST`       | _(required)_            | Cert SAN + controller config hostname  |
+| `--version TAG`         | latest tagged release   | Pin to a specific release tag          |
+| `--binary-path PATH`    | _(download)_            | Air-gapped: provide binary locally     |
+| `--config PATH`         | _(generated)_           | Provide a custom controller.cfg        |
+| `--skip-tenant-seed`    | _(off)_                 | Skip tenant tree seeding               |
+| `--skip-smoke`          | _(off)_                 | Skip smoke test                        |
+
+Expected output (abbreviated):
+
+```
+[bootstrap] Step 1: Pre-flight checks
+[bootstrap] Pre-flight checks passed.
+[bootstrap] Step 2: OS baseline (idempotent)
+[bootstrap] Directory layout ready.
+[bootstrap] Step 3: Binary fetch
+[bootstrap] Installing cfgms-controller version v1.x.y
+[bootstrap] Binary installed to /usr/local/bin/cfgms-controller
+[bootstrap] Step 4: Config
+[bootstrap] Config rendered to /etc/cfgms/controller.cfg
+[bootstrap] Step 5: Controller init
+Controller initialization complete:
+  CA Fingerprint:    SHA256:xxxx...
+  Storage Provider:  flatfile
+  Initialized At:    2026-06-02T00:00:00Z
+[bootstrap] Step 6: Systemd service
+[bootstrap] cfgms-controller service started.
+[bootstrap] Step 7: Tenant seed
+[bootstrap]   Tenant team-root: created.
+[bootstrap]   Tenant agent-test: created.
+[bootstrap]   Tenant infra-hyperv: created.
+[bootstrap] Tenant seeding complete.
+[bootstrap] Step 8: Smoke test
+[PASS] health: GET /api/v1/health
+[PASS] tenant-exists: team-root
+[PASS] tenant-exists: agent-test
+[PASS] tenant-exists: infra-hyperv
+
+Result: 4 passed, 0 failed
+
+==========================================
+ Tier 1 Controller Bootstrap Complete
+==========================================
+
+Admin bundle:  /etc/cfgms/admin.bundle.yaml
+...
+```
+
+If any step fails, the script exits non-zero and the error message identifies the
+failing step. Correct the issue and re-run — the script is idempotent and will skip
+already-completed steps.
+
+---
+
+## 5. Distribute Admin Bundle
+
+The admin bundle (`/etc/cfgms/admin.bundle.yaml`) grants full admin access to the
+controller REST API. Treat it like a root SSH key: never leave it on disk longer than
+necessary to copy it to the keychain.
+
+**Step 1 — Copy bundle to workstation (operator machine):**
+
+```bash
+scp ctrl.cfgms.lab:/etc/cfgms/admin.bundle.yaml /tmp/admin.bundle.yaml
+```
+
+**Step 2 — Store in OS keychain:**
+
+Linux:
+```bash
+secret-tool store --label="CFGMS Admin Bundle" service cfgms bundle admin \
+  < /tmp/admin.bundle.yaml
+```
+
+macOS:
+```bash
+security add-generic-password -s cfgms -a admin \
+  -w "$(cat /tmp/admin.bundle.yaml)"
+```
+
+**Step 3 — Remove the plaintext copy:**
+
+```bash
+rm /tmp/admin.bundle.yaml
+```
+
+**Step 4 — Load the bundle in future shell sessions:**
+
+```bash
+source scripts/cfgms-bundle-load
+```
+
+`cfgms-bundle-load` retrieves the bundle from the keychain, writes it to a temp file,
+exports `CFGMS_ADMIN_BUNDLE`, and registers a `trap` to delete the temp file when the
+shell exits. After sourcing it, `cfg` and `tier1-smoke-test.sh` pick up `CFGMS_ADMIN_BUNDLE`
+automatically.
+
+---
+
+## 6. Manual Upgrade
+
+To upgrade the controller binary without reprovisioning:
+
+```bash
+sudo systemctl stop cfgms-controller
+sudo cp /path/to/new/cfgms-controller /usr/local/bin/cfgms-controller
+sudo chmod +x /usr/local/bin/cfgms-controller
+sudo systemctl start cfgms-controller
+```
+
+Run the smoke test after upgrade to confirm the new version operates correctly:
+
+```bash
+source scripts/cfgms-bundle-load
+bash scripts/tier1-smoke-test.sh
+```
+
+Do not re-run `tier1-bootstrap.sh` for upgrades — the `--init` step is idempotent
+but binary placement goes through the download path. Use `--binary-path` if you
+need to re-run the full bootstrap with a specific binary.
+
+---
+
+## 7. Operator Routing Responsibility
+
+The bootstrap script provisions the controller and its TLS configuration but does not
+manage network routing. The operator is responsible for:
+
+- **Steward → controller**: UDP port 4433 must be open from steward network segments
+  to the controller IP. Configure firewall rules, security groups, or VLAN policies
+  as appropriate for the environment.
+- **cfg CLI → controller**: TCP port 9080 must be reachable from operator workstations.
+  For lab environments, direct reachability is typical. For production, consider a
+  jump host or VPN.
+- **DNS / hosts**: If stewards dial the controller by hostname, that hostname must
+  resolve to the controller's IP from steward network segments.
+
+The `--hostname` value supplied to bootstrap is embedded in the TLS SAN. If stewards
+dial a different address (IP or alternate hostname), either re-bootstrap with the
+correct `--hostname` or add the address to the config's `dns_names`/`ip_addresses`
+before `--init`.
+
+---
+
+## 8. Recovery
+
+Tier 1 has no automated backup. The controller's state lives in `/var/lib/cfgms/`.
+If the VM is lost or unrecoverable, all state is discarded.
+
+**To rebuild from scratch:**
+
+1. Provision a new Debian 12 VM (§2)
+2. Copy `tier1-bootstrap.sh` and `tier1-smoke-test.sh` to the new VM
+3. Run bootstrap: `sudo bash /tmp/tier1-bootstrap.sh --hostname=<hostname>`
+4. Distribute the new admin bundle (§5)
+5. Re-register stewards — existing steward registrations are not portable across
+   controller reinitializations (new CA means all mTLS credentials are invalid)
+
+For disaster recovery planning, consider scheduling periodic exports of tenant
+configuration data using `cfg` before they are needed.
+
+---
+
+## 9. Per-Step Deviation Guide
+
+If the bootstrap script cannot run (e.g., no outbound internet, restricted shell),
+each step can be performed manually:
+
+**Step 1 — Pre-flight**
+The script checks for root, Debian OS, and port 9080 availability. Run manually:
+`id` (must be 0), `grep -i debian /etc/os-release`, `ss -tlnp | grep ':9080'`.
+
+**Step 2 — OS baseline**
+The script runs `apt-get update && apt-get install -y git curl`, creates the `cfgms`
+system user, and creates directories with correct ownership. Manually:
+```bash
+apt-get install -y git curl
+useradd --system --no-create-home --shell /usr/sbin/nologin cfgms
+mkdir -p /etc/cfgms /var/lib/cfgms/storage /var/lib/cfgms/certs/ca /var/log/cfgms
+chown -R cfgms:cfgms /var/lib/cfgms /var/log/cfgms
+chmod 750 /var/lib/cfgms /var/log/cfgms /etc/cfgms
+```
+
+**Step 3 — Binary fetch**
+The script downloads the latest tagged release tarball from GitHub and extracts
+`cfgms-controller` and `cfg` to `/usr/local/bin/`. Manually for air-gapped:
+build from source (`make build-controller build-cli`) and copy to `/usr/local/bin/`.
+Never use the develop tip for Tier 1 — always use a tagged release.
+
+**Step 4 — Config**
+The script renders `/etc/cfgms/controller.cfg` from the canonical template
+(`docs/deployment/controller.cfg`) with `--hostname` substituted into
+`common_name` and `dns_names`. Manually: copy the template and edit those fields.
+Storage backend must be `flatfile_root` + `sqlite_path` (no git, no SOPS).
+
+**Step 5 — Init**
+The script runs `cfgms-controller --init --config /etc/cfgms/controller.cfg`.
+This is idempotent: if `/etc/cfgms/.admin-bundle-issued` exists, init is skipped.
+The init command creates the CA, server certificates, storage backend, and admin
+bundle. Save the CA fingerprint printed at this step — stewards need it at
+registration time.
+
+**Step 6 — Systemd**
+The script writes the unit file to `/etc/systemd/system/cfgms-controller.service`
+and runs `systemctl daemon-reload && systemctl enable --now cfgms-controller`.
+Manually: copy the unit from `docs/deployment/single-controller/cfgms-controller.service`
+and run the same systemctl commands.
+
+**Step 7 — Tenant seed**
+The script runs `cfg tenant create` three times (idempotent):
+```bash
+cfg tenant create --tenant-id=team-root
+cfg tenant create --tenant-id=agent-test --parent=team-root
+cfg tenant create --tenant-id=infra-hyperv --parent=team-root
+```
+The `cfg` binary uses `CFGMS_ADMIN_BUNDLE` for authentication. Run these after
+the controller is running and the admin bundle is available.
+
+**Step 8 — Smoke test**
+The script runs `scripts/tier1-smoke-test.sh`. Manually run it the same way:
+```bash
+CFGMS_ADMIN_BUNDLE=/etc/cfgms/admin.bundle.yaml bash scripts/tier1-smoke-test.sh
+```
+Expected: 4 checks pass (health + 3 tenant-exists). See §10.
+
+---
+
+## 10. Smoke Test
+
+The smoke test (`scripts/tier1-smoke-test.sh`) validates the bootstrapped controller:
+
+| Check | What it verifies |
+|-------|-----------------|
+| `health: GET /api/v1/health` | REST API accepts mTLS connections and returns HTTP 200 |
+| `tenant-exists: team-root` | Root tenant seeded successfully |
+| `tenant-exists: agent-test` | Child tenant seeded under team-root |
+| `tenant-exists: infra-hyperv` | Child tenant seeded under team-root |
+
+Expected output:
+```
+[PASS] health: GET /api/v1/health
+[PASS] tenant-exists: team-root
+[PASS] tenant-exists: agent-test
+[PASS] tenant-exists: infra-hyperv
+
+Result: 4 passed, 0 failed
+```
+
+To run it manually after bootstrap:
+
+```bash
+CFGMS_ADMIN_BUNDLE=/etc/cfgms/admin.bundle.yaml bash scripts/tier1-smoke-test.sh
+```
+
+Or from an operator workstation after sourcing the bundle:
+
+```bash
+source scripts/cfgms-bundle-load
+bash scripts/tier1-smoke-test.sh --controller-url=https://ctrl.cfgms.lab:9080
+```
+
+If the smoke test fails, check the controller logs:
+```bash
+sudo journalctl -u cfgms-controller --no-pager -n 50
+```

--- a/scripts/cfgms-bundle-load
+++ b/scripts/cfgms-bundle-load
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026 Jordan Ritz
+#
+# cfgms-bundle-load — Load the CFGMS admin bundle from the OS keychain.
+#
+# Sources this file into your shell; do not execute it directly.
+#
+# Usage:
+#   source scripts/cfgms-bundle-load
+#
+# After sourcing, CFGMS_ADMIN_BUNDLE points to a temp file containing the
+# bundle YAML. The temp file is removed automatically when the shell exits.
+#
+# Requires:
+#   Linux:  secret-tool (libsecret-tools package)
+#   macOS:  security (built-in Keychain utility)
+#
+# To store the bundle first, see:
+#   docs/operations/tier1-controller-bringup.md § "Distribute Admin Bundle"
+
+_cfgms_os="$(uname -s)"
+_cfgms_bundle=""
+
+if [[ "$_cfgms_os" == "Linux" ]]; then
+    if ! command -v secret-tool &>/dev/null; then
+        echo "cfgms-bundle-load: secret-tool not found." >&2
+        echo "  Install with: sudo apt install libsecret-tools" >&2
+        return 1 2>/dev/null || exit 1
+    fi
+    _cfgms_bundle="$(secret-tool lookup service cfgms bundle admin 2>/dev/null || true)"
+elif [[ "$_cfgms_os" == "Darwin" ]]; then
+    if ! command -v security &>/dev/null; then
+        echo "cfgms-bundle-load: security command not found." >&2
+        return 1 2>/dev/null || exit 1
+    fi
+    _cfgms_bundle="$(security find-generic-password -s cfgms -a admin -w 2>/dev/null || true)"
+else
+    echo "cfgms-bundle-load: unsupported OS: $_cfgms_os (supported: Linux, Darwin)" >&2
+    return 1 2>/dev/null || exit 1
+fi
+
+if [[ -z "$_cfgms_bundle" ]]; then
+    echo "cfgms-bundle-load: admin bundle not found in keychain." >&2
+    echo "  Store it first — see docs/operations/tier1-controller-bringup.md § 'Distribute Admin Bundle'" >&2
+    unset _cfgms_os _cfgms_bundle
+    return 1 2>/dev/null || exit 1
+fi
+
+_cfgms_tmpfile="$(mktemp /tmp/cfgms-bundle-XXXXXX.yaml)"
+printf '%s' "$_cfgms_bundle" > "$_cfgms_tmpfile"
+chmod 600 "$_cfgms_tmpfile"
+
+export CFGMS_ADMIN_BUNDLE="$_cfgms_tmpfile"
+
+# Ensure temp file is removed when the calling shell exits.
+trap 'rm -f "$CFGMS_ADMIN_BUNDLE"' EXIT
+
+echo "cfgms-bundle-load: CFGMS_ADMIN_BUNDLE=$CFGMS_ADMIN_BUNDLE"
+
+unset _cfgms_os _cfgms_bundle _cfgms_tmpfile

--- a/scripts/test-scripts.sh
+++ b/scripts/test-scripts.sh
@@ -172,6 +172,9 @@ test_executable_permissions() {
         "scripts/test-with-infrastructure.sh"
         "scripts/tier1-smoke-test.sh"
         "scripts/tier1-smoke-test_test.sh"
+        "scripts/tier1-bootstrap.sh"
+        "scripts/tier1-bootstrap_test.sh"
+        "scripts/cfgms-bundle-load"
     )
 
     for script in "${critical_scripts[@]}"; do
@@ -2506,6 +2509,45 @@ test_tier1_smoke_test() {
     rm -f "$out_file"
 }
 
+test_tier1_bootstrap() {
+    log_test "Testing tier1-bootstrap.sh..."
+
+    local bootstrap_script="scripts/tier1-bootstrap.sh"
+    local test_script="scripts/tier1-bootstrap_test.sh"
+
+    if [[ ! -f "$bootstrap_script" ]]; then
+        log_fail "tier1-bootstrap.sh: Not found"
+        return
+    fi
+
+    if [[ ! -x "$bootstrap_script" ]]; then
+        log_fail "tier1-bootstrap.sh: Not executable (chmod +x needed)"
+        return
+    fi
+
+    if [[ ! -f "$test_script" ]]; then
+        log_fail "tier1-bootstrap_test.sh: Not found"
+        return
+    fi
+
+    if [[ ! -x "$test_script" ]]; then
+        log_fail "tier1-bootstrap_test.sh: Not executable (chmod +x needed)"
+        return
+    fi
+
+    local out_file rc=0
+    out_file=$(mktemp)
+    bash "$test_script" >"$out_file" 2>&1 || rc=$?
+
+    if [[ $rc -eq 0 ]]; then
+        log_pass "tier1-bootstrap_test.sh: All tests passed"
+    else
+        log_fail "tier1-bootstrap_test.sh: Tests failed (exit $rc)"
+        sed 's/^/    /' "$out_file" >&2
+    fi
+    rm -f "$out_file"
+}
+
 # Main execution
 echo "🔍 Script Validation Test Suite"
 echo "================================"
@@ -2579,6 +2621,8 @@ echo ""
 test_no_pipeline_label_refs
 echo ""
 test_tier1_smoke_test
+echo ""
+test_tier1_bootstrap
 echo ""
 echo ""
 echo "📊 Test Summary"

--- a/scripts/tier1-bootstrap.sh
+++ b/scripts/tier1-bootstrap.sh
@@ -1,0 +1,427 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026 Jordan Ritz
+#
+# tier1-bootstrap.sh — Bootstrap a Tier 1 CFGMS controller on Debian 12.
+# Idempotent. Re-run safe.
+#
+# Usage:
+#   sudo bash tier1-bootstrap.sh --hostname=ctrl.cfgms.lab [options]
+#
+# Flags:
+#   --hostname HOST         Controller hostname for cert SAN (required)
+#   --version TAG           Release tag to install (default: latest tagged release)
+#   --binary-path PATH      Local binary path instead of downloading (air-gapped)
+#   --config PATH           Alternate controller.cfg template (default: generated)
+#   --skip-tenant-seed      Skip tenant tree seeding (step 7)
+#   --skip-smoke            Skip smoke test (step 8)
+#
+# Test isolation:
+#   CFGMS_INSTALL_PREFIX=/tmp/test bash tier1-bootstrap.sh --hostname=test-host
+#   All write paths are prefixed. Binary must be pre-populated at
+#   $CFGMS_INSTALL_PREFIX/usr/local/bin/cfgms-controller (and cfg).
+#   System calls (apt, useradd, chown, systemctl) are skipped.
+#
+# See: docs/operations/tier1-controller-bringup.md
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+INSTALL_PREFIX="${CFGMS_INSTALL_PREFIX:-}"
+
+# ── Argument parsing ──────────────────────────────────────────────────────────
+
+HOSTNAME_FLAG=""
+VERSION_FLAG=""
+BINARY_PATH=""
+CONFIG_OVERRIDE=""
+SKIP_TENANT_SEED=false
+SKIP_SMOKE=false
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --hostname=*)       HOSTNAME_FLAG="${1#*=}"; shift ;;
+        --hostname)         HOSTNAME_FLAG="$2"; shift 2 ;;
+        --version=*)        VERSION_FLAG="${1#*=}"; shift ;;
+        --version)          VERSION_FLAG="$2"; shift 2 ;;
+        --binary-path=*)    BINARY_PATH="${1#*=}"; shift ;;
+        --binary-path)      BINARY_PATH="$2"; shift 2 ;;
+        --config=*)         CONFIG_OVERRIDE="${1#*=}"; shift ;;
+        --config)           CONFIG_OVERRIDE="$2"; shift 2 ;;
+        --skip-tenant-seed) SKIP_TENANT_SEED=true; shift ;;
+        --skip-smoke)       SKIP_SMOKE=true; shift ;;
+        *) echo "Unknown argument: $1" >&2; exit 1 ;;
+    esac
+done
+
+if [[ -z "$HOSTNAME_FLAG" ]]; then
+    echo "Usage: sudo bash tier1-bootstrap.sh --hostname=<hostname> [options]" >&2
+    echo "" >&2
+    echo "  --hostname HOST         Controller hostname for cert SAN (required)" >&2
+    echo "  --version TAG           Release tag (default: latest tagged release)" >&2
+    echo "  --binary-path PATH      Local binary path (air-gapped install)" >&2
+    echo "  --config PATH           Alternate controller.cfg template" >&2
+    echo "  --skip-tenant-seed      Skip tenant tree seeding" >&2
+    echo "  --skip-smoke            Skip smoke test" >&2
+    exit 1
+fi
+
+# ── Path helpers ──────────────────────────────────────────────────────────────
+
+# All write paths use CFGMS_INSTALL_PREFIX when set (test isolation).
+CFGMS_BIN_DIR="${INSTALL_PREFIX}/usr/local/bin"
+CFGMS_ETC_DIR="${INSTALL_PREFIX}/etc/cfgms"
+CFGMS_DATA_DIR="${INSTALL_PREFIX}/var/lib/cfgms"
+CFGMS_LOG_DIR="${INSTALL_PREFIX}/var/log/cfgms"
+CFGMS_SYSTEMD_DIR="${INSTALL_PREFIX}/etc/systemd/system"
+CONTROLLER_BIN="${CFGMS_BIN_DIR}/cfgms-controller"
+CFG_BIN="${CFGMS_BIN_DIR}/cfg"
+CONTROLLER_CFG="${CFGMS_ETC_DIR}/controller.cfg"
+CONTROLLER_SERVICE="${CFGMS_SYSTEMD_DIR}/cfgms-controller.service"
+ADMIN_BUNDLE="${CFGMS_ETC_DIR}/admin.bundle.yaml"
+INIT_MARKER="${CFGMS_ETC_DIR}/.admin-bundle-issued"
+
+log() { echo "[bootstrap] $*"; }
+
+# ── Step 1: Pre-flight ────────────────────────────────────────────────────────
+
+log "Step 1: Pre-flight checks"
+
+if [[ -z "$INSTALL_PREFIX" ]]; then
+    if [[ "$(id -u)" -ne 0 ]]; then
+        echo "Error: must be run as root (sudo bash $(basename "$0") --hostname=...)" >&2
+        exit 1
+    fi
+
+    if ! grep -qi "debian" /etc/os-release 2>/dev/null; then
+        echo "Error: this script targets Debian 12. Detected OS:" >&2
+        grep PRETTY_NAME /etc/os-release 2>/dev/null || echo "  (unknown)" >&2
+        exit 1
+    fi
+
+    if ss -tlnp 2>/dev/null | grep -q ':9080 '; then
+        echo "Error: port 9080 is already in use." >&2
+        echo "  Find the process: ss -tlnp | grep ':9080'" >&2
+        exit 1
+    fi
+fi
+
+log "Pre-flight checks passed."
+
+# ── Step 2: OS baseline ───────────────────────────────────────────────────────
+
+log "Step 2: OS baseline (idempotent)"
+
+if [[ -z "$INSTALL_PREFIX" ]]; then
+    if command -v apt-get &>/dev/null; then
+        apt-get -qq update -y
+        apt-get -qq install -y git curl
+    fi
+
+    if ! id cfgms &>/dev/null; then
+        useradd --system --no-create-home --shell /usr/sbin/nologin cfgms
+        log "Created cfgms system user."
+    else
+        log "cfgms user already exists."
+    fi
+fi
+
+mkdir -p \
+    "${CFGMS_ETC_DIR}" \
+    "${CFGMS_DATA_DIR}/storage" \
+    "${CFGMS_DATA_DIR}/certs/ca" \
+    "${CFGMS_LOG_DIR}" \
+    "${CFGMS_BIN_DIR}" \
+    "${CFGMS_SYSTEMD_DIR}"
+
+if [[ -z "$INSTALL_PREFIX" ]]; then
+    chown -R cfgms:cfgms "${CFGMS_DATA_DIR}" "${CFGMS_LOG_DIR}"
+    chmod 750 "${CFGMS_DATA_DIR}"
+    chmod 750 "${CFGMS_LOG_DIR}"
+    chmod 750 "${CFGMS_ETC_DIR}"
+fi
+
+log "Directory layout ready."
+
+# ── Step 3: Binary fetch ──────────────────────────────────────────────────────
+
+log "Step 3: Binary fetch"
+
+if [[ -x "$CONTROLLER_BIN" ]]; then
+    log "Binary already present at $CONTROLLER_BIN — skipping download."
+elif [[ -n "$BINARY_PATH" ]]; then
+    cp "$BINARY_PATH" "$CONTROLLER_BIN"
+    chmod +x "$CONTROLLER_BIN"
+    log "Installed binary from $BINARY_PATH"
+elif [[ -n "$INSTALL_PREFIX" ]]; then
+    echo "Error: test isolation requires cfgms-controller pre-populated at $CONTROLLER_BIN" >&2
+    exit 1
+else
+    # Resolve version from latest tagged release (never develop tip).
+    if [[ -z "$VERSION_FLAG" ]]; then
+        if command -v gh &>/dev/null; then
+            VERSION_FLAG="$(gh release view --repo cfg-is/cfgms --json tagName -q .tagName 2>/dev/null || true)"
+        fi
+        if [[ -z "$VERSION_FLAG" ]]; then
+            VERSION_FLAG="$(curl -fsSL https://api.github.com/repos/cfg-is/cfgms/releases/latest \
+                | sed -n 's/.*"tag_name": *"\([^"]*\)".*/\1/p' 2>/dev/null | head -1 || true)"
+        fi
+        if [[ -z "$VERSION_FLAG" ]]; then
+            echo "Error: could not determine latest release tag." >&2
+            echo "  Pass --version <tag> or check network connectivity." >&2
+            exit 1
+        fi
+    fi
+    log "Installing cfgms-controller version $VERSION_FLAG"
+
+    ARCH="amd64"
+    if [[ "$(uname -m)" == "aarch64" || "$(uname -m)" == "arm64" ]]; then
+        ARCH="arm64"
+    fi
+    TARBALL_URL="https://github.com/cfg-is/cfgms/releases/download/${VERSION_FLAG}/cfgms-linux-${ARCH}.tar.gz"
+
+    TMPTAR="$(mktemp /tmp/cfgms-XXXXXX.tar.gz)"
+    cleanup_tar() { rm -f "$TMPTAR"; }
+    trap cleanup_tar EXIT INT TERM
+
+    curl -fsSL "$TARBALL_URL" -o "$TMPTAR"
+
+    # Extract cfgms-controller binary from the tarball.
+    if tar -tzf "$TMPTAR" 2>/dev/null | grep -q "^cfgms-controller$"; then
+        tar -xzf "$TMPTAR" -C "$CFGMS_BIN_DIR" cfgms-controller
+    else
+        tar -xzf "$TMPTAR" -O 2>/dev/null > "$CONTROLLER_BIN" \
+            || { echo "Error: could not extract cfgms-controller from $TARBALL_URL" >&2; exit 1; }
+    fi
+    chmod +x "$CONTROLLER_BIN"
+
+    # Extract cfg CLI binary if present in the tarball.
+    if tar -tzf "$TMPTAR" 2>/dev/null | grep -q "^cfg$"; then
+        tar -xzf "$TMPTAR" -C "$CFGMS_BIN_DIR" cfg
+        chmod +x "$CFG_BIN"
+        log "cfg CLI installed from tarball."
+    fi
+
+    rm -f "$TMPTAR"
+    trap - EXIT INT TERM
+    log "Binary installed to $CONTROLLER_BIN"
+fi
+
+# Locate cfg CLI for tenant seeding (may have been installed separately or from tarball).
+if [[ ! -x "$CFG_BIN" ]]; then
+    CFG_IN_PATH="$(command -v cfg 2>/dev/null || true)"
+    if [[ -n "$CFG_IN_PATH" ]]; then
+        CFG_BIN="$CFG_IN_PATH"
+        log "Using cfg from PATH: $CFG_BIN"
+    else
+        log "Warning: cfg CLI not found at $CFGMS_BIN_DIR/cfg or in PATH."
+        log "  Tenant seeding will be skipped unless --skip-tenant-seed is passed."
+        if [[ "$SKIP_TENANT_SEED" != "true" ]]; then
+            echo "Error: cfg CLI required for tenant seeding. Install it or pass --skip-tenant-seed." >&2
+            exit 1
+        fi
+    fi
+fi
+
+# ── Step 4: Config ────────────────────────────────────────────────────────────
+
+log "Step 4: Config"
+
+if [[ -f "$CONTROLLER_CFG" ]]; then
+    log "Config already exists at $CONTROLLER_CFG — skipping generation."
+else
+    if [[ -n "$CONFIG_OVERRIDE" ]]; then
+        cp "$CONFIG_OVERRIDE" "$CONTROLLER_CFG"
+        log "Config installed from override: $CONFIG_OVERRIDE"
+    else
+        cat > "$CONTROLLER_CFG" <<EOF
+# CFGMS Controller Configuration
+# Generated by tier1-bootstrap.sh on $(date -u +%Y-%m-%dT%H:%M:%SZ)
+# Hostname: ${HOSTNAME_FLAG}
+
+listen_addr: "0.0.0.0:9080"
+
+certificate:
+  enable_cert_management: true
+  ca_path: "/var/lib/cfgms/certs/ca"
+  cert_path: "/var/lib/cfgms/certs"
+  renewal_threshold_days: 30
+  server_cert_validity_days: 365
+  client_cert_validity_days: 365
+  server:
+    common_name: "${HOSTNAME_FLAG}"
+    dns_names:
+      - "${HOSTNAME_FLAG}"
+      - "localhost"
+    ip_addresses:
+      - "127.0.0.1"
+    organization: "CFGMS Tier 1"
+
+storage:
+  flatfile_root: "/var/lib/cfgms/storage"
+  sqlite_path: "/var/lib/cfgms/cfgms.db"
+
+logging:
+  level: "info"
+  provider: "file"
+  config:
+    directory: "/var/log/cfgms"
+    max_file_size: 10485760
+    max_files: 5
+
+transport:
+  listen_addr: "0.0.0.0:4433"
+  use_cert_manager: true
+  max_connections: 50000
+  keepalive_period: "30s"
+  idle_timeout: "5m"
+EOF
+        log "Config rendered to $CONTROLLER_CFG"
+    fi
+    if [[ -z "$INSTALL_PREFIX" ]]; then
+        chown cfgms:cfgms "$CONTROLLER_CFG"
+        chmod 640 "$CONTROLLER_CFG"
+    fi
+fi
+
+# ── Step 5: Init ──────────────────────────────────────────────────────────────
+
+log "Step 5: Controller init"
+
+if [[ -f "$INIT_MARKER" ]]; then
+    log "Init marker found at $INIT_MARKER — controller already initialized, skipping."
+else
+    "$CONTROLLER_BIN" --init --config "$CONTROLLER_CFG"
+fi
+
+# ── Step 6: Systemd ───────────────────────────────────────────────────────────
+
+log "Step 6: Systemd service"
+
+cat > "$CONTROLLER_SERVICE" <<EOF
+[Unit]
+Description=CFGMS Controller
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+ExecStart=/usr/local/bin/cfgms-controller --config /etc/cfgms/controller.cfg
+Restart=on-failure
+RestartSec=5
+User=root
+WorkingDirectory=/var/lib/cfgms
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=cfgms-controller
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+if [[ -z "$INSTALL_PREFIX" ]]; then
+    systemctl daemon-reload
+    systemctl enable cfgms-controller 2>/dev/null || true
+    if systemctl is-active --quiet cfgms-controller 2>/dev/null; then
+        log "cfgms-controller service already running."
+    else
+        systemctl start cfgms-controller
+        log "cfgms-controller service started."
+    fi
+else
+    log "Test isolation: systemd unit written to $CONTROLLER_SERVICE (not loaded)."
+fi
+
+# ── Step 7: Tenant seed ───────────────────────────────────────────────────────
+
+if [[ "$SKIP_TENANT_SEED" == "true" ]]; then
+    log "Step 7: Tenant seeding skipped (--skip-tenant-seed)."
+else
+    log "Step 7: Tenant seed"
+
+    if [[ -z "$INSTALL_PREFIX" ]]; then
+        # Wait for the REST API to accept connections before seeding.
+        RETRIES=12
+        for ((i = 1; i <= RETRIES; i++)); do
+            if curl -fsk "https://localhost:9080/api/v1/health" &>/dev/null; then
+                break
+            fi
+            if [[ $i -eq $RETRIES ]]; then
+                echo "Error: controller REST API did not become ready after $((RETRIES * 5))s." >&2
+                exit 1
+            fi
+            log "  Waiting for controller REST API... (${i}/${RETRIES})"
+            sleep 5
+        done
+    fi
+
+    _seed_tenant() {
+        local tenant_id="$1"
+        local parent_flag="${2:-}"
+        local args=(tenant create "--tenant-id=${tenant_id}")
+        if [[ -n "$parent_flag" ]]; then
+            args+=("--parent=${parent_flag}")
+        fi
+        if [[ -n "$INSTALL_PREFIX" ]]; then
+            CFGMS_ADMIN_BUNDLE="$ADMIN_BUNDLE" "$CFG_BIN" "${args[@]}" 2>/dev/null \
+                && log "  Tenant ${tenant_id}: created." \
+                || log "  Tenant ${tenant_id}: already exists (idempotent)."
+        else
+            CFGMS_ADMIN_BUNDLE="$ADMIN_BUNDLE" "$CFG_BIN" "${args[@]}" \
+                && log "  Tenant ${tenant_id}: created." \
+                || log "  Tenant ${tenant_id}: already exists (idempotent)."
+        fi
+    }
+
+    _seed_tenant "team-root"
+    _seed_tenant "agent-test" "team-root"
+    _seed_tenant "infra-hyperv" "team-root"
+
+    log "Tenant seeding complete."
+fi
+
+# ── Step 8: Smoke test ────────────────────────────────────────────────────────
+
+if [[ "$SKIP_SMOKE" == "true" ]]; then
+    log "Step 8: Smoke test skipped (--skip-smoke)."
+else
+    log "Step 8: Smoke test"
+
+    SMOKE_SCRIPT="${SCRIPT_DIR}/tier1-smoke-test.sh"
+    if [[ ! -f "$SMOKE_SCRIPT" ]]; then
+        echo "Error: tier1-smoke-test.sh not found at $SMOKE_SCRIPT" >&2
+        echo "  Copy it alongside tier1-bootstrap.sh and retry." >&2
+        exit 1
+    fi
+
+    if [[ -n "$INSTALL_PREFIX" ]]; then
+        log "Test isolation: smoke test skipped (no live controller in test mode)."
+    else
+        CFGMS_ADMIN_BUNDLE="$ADMIN_BUNDLE" bash "$SMOKE_SCRIPT"
+    fi
+fi
+
+# ── Step 9: Final output ──────────────────────────────────────────────────────
+
+DISPLAY_HOST="$(hostname -f 2>/dev/null || echo "${HOSTNAME_FLAG}")"
+
+echo ""
+echo "=========================================="
+echo " Tier 1 Controller Bootstrap Complete"
+echo "=========================================="
+echo ""
+echo "Admin bundle:  ${ADMIN_BUNDLE}"
+echo ""
+echo "To copy the admin bundle to your workstation:"
+echo "  scp ${DISPLAY_HOST}:${ADMIN_BUNDLE} /tmp/admin.bundle.yaml"
+echo ""
+echo "Then store it in your OS keychain:"
+echo "  Linux:  secret-tool store --label='CFGMS Admin Bundle' service cfgms bundle admin < /tmp/admin.bundle.yaml"
+echo "  macOS:  security add-generic-password -s cfgms -a admin -w \"\$(cat /tmp/admin.bundle.yaml)\""
+echo "  Then:   rm /tmp/admin.bundle.yaml"
+echo ""
+echo "Load the bundle in future sessions:"
+echo "  source scripts/cfgms-bundle-load"
+echo ""
+echo "See docs/operations/tier1-controller-bringup.md for the full runbook."
+echo ""

--- a/scripts/tier1-bootstrap_test.sh
+++ b/scripts/tier1-bootstrap_test.sh
@@ -1,0 +1,395 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026 Jordan Ritz
+#
+# tier1-bootstrap_test.sh — Tests for scripts/tier1-bootstrap.sh.
+#
+# Uses CFGMS_INSTALL_PREFIX for isolation: all paths are prefixed and mock
+# binaries are pre-populated, so tests run without root or network access.
+# Mirrors the pattern from build/linux/install_test.sh.
+#
+# Usage:
+#   bash scripts/tier1-bootstrap_test.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BOOTSTRAP_SH="${SCRIPT_DIR}/tier1-bootstrap.sh"
+
+PASS=0
+FAIL=0
+
+pass() { echo "PASS: $1"; ((PASS++)) || true; }
+fail() { echo "FAIL: $1"; ((FAIL++)) || true; }
+
+# ── Mock binary helpers ───────────────────────────────────────────────────────
+
+# make_mock_controller writes a mock cfgms-controller binary to the given
+# prefix directory. The mock implements --init: creates the init marker and
+# a stub admin bundle so bootstrap steps 5+ can verify their logic.
+make_mock_controller() {
+    local prefix="$1"
+    local bin_dir="${prefix}/usr/local/bin"
+    mkdir -p "$bin_dir"
+
+    cat > "${bin_dir}/cfgms-controller" <<'MOCK'
+#!/usr/bin/env bash
+# Mock cfgms-controller for tier1-bootstrap tests.
+PREFIX="${CFGMS_INSTALL_PREFIX:-}"
+ETC="${PREFIX}/etc/cfgms"
+INIT_MARKER="${ETC}/.admin-bundle-issued"
+ADMIN_BUNDLE="${ETC}/admin.bundle.yaml"
+
+DO_INIT=false
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --init) DO_INIT=true; shift ;;
+        --config) shift 2 ;;
+        *) shift ;;
+    esac
+done
+
+if [[ "$DO_INIT" == "true" ]]; then
+    if [[ -f "$INIT_MARKER" ]]; then
+        echo "Controller already initialized (mock: idempotent skip)"
+        exit 0
+    fi
+    mkdir -p "$ETC"
+    touch "$INIT_MARKER"
+    cat > "$ADMIN_BUNDLE" <<'YAML'
+controller_url: "https://test-host:9080"
+cert_pem: |
+  -----BEGIN CERTIFICATE-----
+  TESTCERT
+  -----END CERTIFICATE-----
+key_pem: |
+  -----BEGIN PRIVATE KEY-----
+  TESTKEY
+  -----END PRIVATE KEY-----
+ca_pem: |
+  -----BEGIN CERTIFICATE-----
+  TESTCA
+  -----END CERTIFICATE-----
+YAML
+    chmod 600 "$ADMIN_BUNDLE"
+    echo "Controller initialization complete (mock)"
+fi
+exit 0
+MOCK
+    chmod +x "${bin_dir}/cfgms-controller"
+}
+
+# make_mock_cfg writes a mock cfg binary that implements tenant create.
+# The mock records created tenants in a marker file and is idempotent.
+make_mock_cfg() {
+    local prefix="$1"
+    local bin_dir="${prefix}/usr/local/bin"
+    mkdir -p "$bin_dir"
+
+    cat > "${bin_dir}/cfg" <<'MOCK'
+#!/usr/bin/env bash
+# Mock cfg for tier1-bootstrap tests.
+PREFIX="${CFGMS_INSTALL_PREFIX:-}"
+TENANT_MARKER="${PREFIX}/etc/cfgms/.tenants-seeded"
+mkdir -p "${PREFIX}/etc/cfgms"
+
+CMD="${1:-}"
+SUBCMD="${2:-}"
+TENANT_ID=""
+shift 2 2>/dev/null || true
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --tenant-id=*) TENANT_ID="${1#*=}"; shift ;;
+        --tenant-id)   TENANT_ID="$2"; shift 2 ;;
+        --parent=*)    shift ;;
+        --parent)      shift 2 ;;
+        *)             shift ;;
+    esac
+done
+
+if [[ "$CMD" == "tenant" && "$SUBCMD" == "create" && -n "$TENANT_ID" ]]; then
+    if grep -q "^${TENANT_ID}$" "$TENANT_MARKER" 2>/dev/null; then
+        echo "tenant already exists: ${TENANT_ID}"
+        exit 0
+    fi
+    echo "$TENANT_ID" >> "$TENANT_MARKER"
+    echo "tenant created: ${TENANT_ID}"
+fi
+exit 0
+MOCK
+    chmod +x "${bin_dir}/cfg"
+}
+
+# run_bootstrap executes tier1-bootstrap.sh with CFGMS_INSTALL_PREFIX=PREFIX.
+# Additional arguments are forwarded. Sets LAST_EXIT and LAST_OUTPUT.
+LAST_EXIT=0
+LAST_OUTPUT=""
+run_bootstrap() {
+    local prefix="$1"
+    shift
+    LAST_EXIT=0
+    LAST_OUTPUT="$(CFGMS_INSTALL_PREFIX="$prefix" bash "$BOOTSTRAP_SH" "$@" 2>&1)" \
+        || LAST_EXIT=$?
+}
+
+# ── Test 1: Missing --hostname exits 1 with usage ─────────────────────────────
+
+T1_PREFIX="$(mktemp -d)"
+run_bootstrap "$T1_PREFIX"
+
+if [[ $LAST_EXIT -eq 1 ]] && echo "$LAST_OUTPUT" | grep -qi "hostname"; then
+    pass "test1: missing --hostname exits 1 with usage message"
+else
+    fail "test1: expected exit 1 and 'hostname' in output (exit=${LAST_EXIT} output='${LAST_OUTPUT}')"
+fi
+rm -rf "$T1_PREFIX"
+
+# ── Test 2: Happy path creates expected file structure ────────────────────────
+
+T2_PREFIX="$(mktemp -d)"
+make_mock_controller "$T2_PREFIX"
+make_mock_cfg "$T2_PREFIX"
+
+run_bootstrap "$T2_PREFIX" --hostname=ctrl.test.lab --skip-smoke
+
+if [[ $LAST_EXIT -ne 0 ]]; then
+    fail "test2: happy path exited ${LAST_EXIT} (expected 0); output='${LAST_OUTPUT}'"
+else
+    PASS_THIS=true
+
+    # Controller config rendered with hostname
+    CFG_FILE="${T2_PREFIX}/etc/cfgms/controller.cfg"
+    if [[ ! -f "$CFG_FILE" ]]; then
+        fail "test2: controller.cfg not created"
+        PASS_THIS=false
+    elif ! grep -q "ctrl.test.lab" "$CFG_FILE"; then
+        fail "test2: controller.cfg does not contain hostname"
+        PASS_THIS=false
+    fi
+
+    # Init marker created
+    MARKER="${T2_PREFIX}/etc/cfgms/.admin-bundle-issued"
+    if [[ ! -f "$MARKER" ]]; then
+        fail "test2: init marker not created"
+        PASS_THIS=false
+    fi
+
+    # Admin bundle created
+    BUNDLE="${T2_PREFIX}/etc/cfgms/admin.bundle.yaml"
+    if [[ ! -f "$BUNDLE" ]]; then
+        fail "test2: admin bundle not created"
+        PASS_THIS=false
+    fi
+
+    # Systemd unit written
+    SERVICE="${T2_PREFIX}/etc/systemd/system/cfgms-controller.service"
+    if [[ ! -f "$SERVICE" ]]; then
+        fail "test2: systemd unit not written"
+        PASS_THIS=false
+    fi
+
+    # Required directories created
+    for d in \
+        "${T2_PREFIX}/etc/cfgms" \
+        "${T2_PREFIX}/var/lib/cfgms/storage" \
+        "${T2_PREFIX}/var/lib/cfgms/certs/ca" \
+        "${T2_PREFIX}/var/log/cfgms"; do
+        if [[ ! -d "$d" ]]; then
+            fail "test2: directory not created: $d"
+            PASS_THIS=false
+        fi
+    done
+
+    # Three tenants seeded
+    SEED_MARKER="${T2_PREFIX}/etc/cfgms/.tenants-seeded"
+    for tenant in team-root agent-test infra-hyperv; do
+        if ! grep -q "^${tenant}$" "$SEED_MARKER" 2>/dev/null; then
+            fail "test2: tenant not seeded: $tenant"
+            PASS_THIS=false
+        fi
+    done
+
+    if [[ "$PASS_THIS" == "true" ]]; then
+        pass "test2: happy path creates expected file structure and seeds tenants"
+    fi
+fi
+rm -rf "$T2_PREFIX"
+
+# ── Test 3: Idempotent re-run exits 0 without overwriting state ───────────────
+
+T3_PREFIX="$(mktemp -d)"
+make_mock_controller "$T3_PREFIX"
+make_mock_cfg "$T3_PREFIX"
+
+# First run
+run_bootstrap "$T3_PREFIX" --hostname=ctrl.test.lab --skip-smoke
+if [[ $LAST_EXIT -ne 0 ]]; then
+    fail "test3: first run exited ${LAST_EXIT} (expected 0)"
+    rm -rf "$T3_PREFIX"
+else
+    # Record mtime of key state files before the second run
+    CFG_FILE="${T3_PREFIX}/etc/cfgms/controller.cfg"
+    MARKER="${T3_PREFIX}/etc/cfgms/.admin-bundle-issued"
+    BUNDLE="${T3_PREFIX}/etc/cfgms/admin.bundle.yaml"
+    MTIME_CFG="$(stat -c %Y "$CFG_FILE" 2>/dev/null || stat -f %m "$CFG_FILE" 2>/dev/null)"
+    MTIME_MARKER="$(stat -c %Y "$MARKER" 2>/dev/null || stat -f %m "$MARKER" 2>/dev/null)"
+    MTIME_BUNDLE="$(stat -c %Y "$BUNDLE" 2>/dev/null || stat -f %m "$BUNDLE" 2>/dev/null)"
+
+    # Wait a tick so any re-write would produce a different mtime
+    sleep 1
+
+    # Second run (idempotent re-run)
+    run_bootstrap "$T3_PREFIX" --hostname=ctrl.test.lab --skip-smoke
+
+    if [[ $LAST_EXIT -ne 0 ]]; then
+        fail "test3: idempotent re-run exited ${LAST_EXIT} (expected 0)"
+    else
+        MTIME_CFG2="$(stat -c %Y "$CFG_FILE" 2>/dev/null || stat -f %m "$CFG_FILE" 2>/dev/null)"
+        MTIME_MARKER2="$(stat -c %Y "$MARKER" 2>/dev/null || stat -f %m "$MARKER" 2>/dev/null)"
+        MTIME_BUNDLE2="$(stat -c %Y "$BUNDLE" 2>/dev/null || stat -f %m "$BUNDLE" 2>/dev/null)"
+
+        if [[ "$MTIME_CFG" == "$MTIME_CFG2" && "$MTIME_MARKER" == "$MTIME_MARKER2" && "$MTIME_BUNDLE" == "$MTIME_BUNDLE2" ]]; then
+            pass "test3: idempotent re-run exits 0 and does not modify existing state"
+        else
+            fail "test3: idempotent re-run modified existing files (cfg=${MTIME_CFG}=>${MTIME_CFG2} marker=${MTIME_MARKER}=>${MTIME_MARKER2})"
+        fi
+    fi
+    rm -rf "$T3_PREFIX"
+fi
+
+# ── Test 4: Partial-state recovery completes remaining steps ──────────────────
+
+T4_PREFIX="$(mktemp -d)"
+make_mock_controller "$T4_PREFIX"
+make_mock_cfg "$T4_PREFIX"
+
+# Simulate partial state: OS baseline done (dirs created), but config not yet written.
+mkdir -p \
+    "${T4_PREFIX}/etc/cfgms" \
+    "${T4_PREFIX}/var/lib/cfgms/storage" \
+    "${T4_PREFIX}/var/lib/cfgms/certs/ca" \
+    "${T4_PREFIX}/var/log/cfgms" \
+    "${T4_PREFIX}/usr/local/bin" \
+    "${T4_PREFIX}/etc/systemd/system"
+
+# Run bootstrap to complete the remaining steps
+run_bootstrap "$T4_PREFIX" --hostname=ctrl.test.lab --skip-smoke
+
+if [[ $LAST_EXIT -ne 0 ]]; then
+    fail "test4: partial-state recovery exited ${LAST_EXIT} (expected 0); output='${LAST_OUTPUT}'"
+else
+    CFG_FILE="${T4_PREFIX}/etc/cfgms/controller.cfg"
+    BUNDLE="${T4_PREFIX}/etc/cfgms/admin.bundle.yaml"
+    if [[ -f "$CFG_FILE" && -f "$BUNDLE" ]]; then
+        pass "test4: partial-state recovery completes remaining steps"
+    else
+        fail "test4: partial-state recovery did not create config (${CFG_FILE}: $([ -f "$CFG_FILE" ] && echo present || echo missing)) or bundle (${BUNDLE}: $([ -f "$BUNDLE" ] && echo present || echo missing))"
+    fi
+fi
+rm -rf "$T4_PREFIX"
+
+# ── Test 5: --skip-tenant-seed skips tenant seeding ──────────────────────────
+
+T5_PREFIX="$(mktemp -d)"
+make_mock_controller "$T5_PREFIX"
+make_mock_cfg "$T5_PREFIX"
+
+run_bootstrap "$T5_PREFIX" --hostname=ctrl.test.lab --skip-tenant-seed --skip-smoke
+
+SEED_MARKER="${T5_PREFIX}/etc/cfgms/.tenants-seeded"
+if [[ $LAST_EXIT -eq 0 ]] && [[ ! -f "$SEED_MARKER" ]]; then
+    pass "test5: --skip-tenant-seed exits 0 and does not create tenant seed marker"
+else
+    fail "test5: expected exit 0 and no seed marker (exit=${LAST_EXIT} marker_exists=$([ -f "$SEED_MARKER" ] && echo yes || echo no))"
+fi
+rm -rf "$T5_PREFIX"
+
+# ── Test 6: --skip-smoke flag passes through without error ────────────────────
+
+T6_PREFIX="$(mktemp -d)"
+make_mock_controller "$T6_PREFIX"
+make_mock_cfg "$T6_PREFIX"
+
+run_bootstrap "$T6_PREFIX" --hostname=ctrl.test.lab --skip-tenant-seed --skip-smoke
+
+if [[ $LAST_EXIT -eq 0 ]] && echo "$LAST_OUTPUT" | grep -q "Smoke test skipped"; then
+    pass "test6: --skip-smoke exits 0 and logs skip message"
+else
+    fail "test6: expected exit 0 and skip message (exit=${LAST_EXIT} output='${LAST_OUTPUT}')"
+fi
+rm -rf "$T6_PREFIX"
+
+# ── Test 7: --version flag accepted without error ────────────────────────────
+
+T7_PREFIX="$(mktemp -d)"
+make_mock_controller "$T7_PREFIX"
+make_mock_cfg "$T7_PREFIX"
+
+# Pre-populate binary so the download step is skipped; --version should still
+# be accepted (it's recorded but the download is elided because binary exists).
+run_bootstrap "$T7_PREFIX" --hostname=ctrl.test.lab --version=v1.2.3 --skip-tenant-seed --skip-smoke
+
+if [[ $LAST_EXIT -eq 0 ]]; then
+    pass "test7: --version flag accepted when binary already present"
+else
+    fail "test7: expected exit 0 with --version flag (exit=${LAST_EXIT} output='${LAST_OUTPUT}')"
+fi
+rm -rf "$T7_PREFIX"
+
+# ── Test 8: --binary-path installs the provided binary ───────────────────────
+
+T8_PREFIX="$(mktemp -d)"
+make_mock_cfg "$T8_PREFIX"
+# Do NOT pre-populate cfgms-controller: the --binary-path flag should install it.
+
+# Create a minimal stand-in binary to copy
+T8_BIN="$(mktemp)"
+cat > "$T8_BIN" <<'MOCK'
+#!/usr/bin/env bash
+PREFIX="${CFGMS_INSTALL_PREFIX:-}"
+ETC="${PREFIX}/etc/cfgms"
+INIT_MARKER="${ETC}/.admin-bundle-issued"
+ADMIN_BUNDLE="${ETC}/admin.bundle.yaml"
+DO_INIT=false
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --init) DO_INIT=true; shift ;;
+        --config) shift 2 ;;
+        *) shift ;;
+    esac
+done
+if [[ "$DO_INIT" == "true" ]]; then
+    if [[ ! -f "$INIT_MARKER" ]]; then
+        mkdir -p "$ETC"
+        touch "$INIT_MARKER"
+        printf 'controller_url: "https://test-host:9080"\ncert_pem: |\n  TEST\nkey_pem: |\n  TEST\nca_pem: |\n  TEST\n' > "$ADMIN_BUNDLE"
+    fi
+fi
+exit 0
+MOCK
+chmod +x "$T8_BIN"
+
+mkdir -p "${T8_PREFIX}/usr/local/bin" \
+         "${T8_PREFIX}/etc/systemd/system"
+
+run_bootstrap "$T8_PREFIX" --hostname=ctrl.test.lab \
+    --binary-path="$T8_BIN" --skip-tenant-seed --skip-smoke
+
+T8_INSTALLED="${T8_PREFIX}/usr/local/bin/cfgms-controller"
+if [[ $LAST_EXIT -eq 0 ]] && [[ -x "$T8_INSTALLED" ]]; then
+    pass "test8: --binary-path installs the provided binary"
+else
+    fail "test8: expected exit 0 and installed binary (exit=${LAST_EXIT} binary_exists=$([ -x "$T8_INSTALLED" ] && echo yes || echo no))"
+fi
+rm -rf "$T8_PREFIX"
+rm -f "$T8_BIN"
+
+# ── Summary ───────────────────────────────────────────────────────────────────
+
+echo ""
+echo "Results: ${PASS} passed, ${FAIL} failed"
+
+if [[ $FAIL -gt 0 ]]; then
+    exit 1
+fi


### PR DESCRIPTION
## Summary

- `scripts/tier1-bootstrap.sh` — single idempotent script that bootstraps a Tier 1 controller on Debian 12 (binary install, systemd, mTLS init, tenant seed, smoke test)
- `scripts/tier1-bootstrap_test.sh` — 8-test bash suite using `CFGMS_INSTALL_PREFIX` isolation (no root, no network required)
- `docs/operations/tier1-controller-bringup.md` — 10-section runbook (source of truth for the script)
- `scripts/cfgms-bundle-load` — workstation-side bash wrapper: retrieves admin bundle from OS keychain, exports `CFGMS_ADMIN_BUNDLE`, traps cleanup on exit

Fixes #1850

## Specialist Review Results

**QA Test Runner: PASS**
- 160 script tests, 0 failed; all Go packages pass; cross-platform builds verified

**QA Code Reviewer: PASS** (5 low warnings, none blocking)
- Warnings: sleep-based mtime idempotency detection, missing error-path tests for binary-absent and cfg-absent cases, no cfgms-bundle-load behavioural test, near-duplicate test 5/6

**Security Engineer: PASS** (7 LOW warnings, none blocking)
- Warnings: systemd `User=root` mirrors pre-existing unit (pre-existing), hostname validation in YAML heredoc, curl `-k` health probe, tarball fallback, bundle-load trap chaining, macOS keychain command exposure, smoke-test env var visibility — all LOW severity, no blocking findings

## Test plan

- [ ] `scripts/tier1-bootstrap_test.sh` passes locally (8/8)
- [ ] `make test-agent-complete` passes (160 script tests, all Go packages)
- [ ] `scripts/tier1-bootstrap.sh --help` (missing --hostname) exits 1 with usage
- [ ] `CFGMS_INSTALL_PREFIX=/tmp/test bash scripts/tier1-bootstrap.sh --hostname=h --skip-smoke` creates expected file structure
- [ ] Re-run of the above exits 0 without modifying existing files

🤖 Generated with [Claude Code](https://claude.com/claude-code)