### PR TITLE
scripts: add install-hyperv-host.ps1 PowerShell orchestrator (Issue #1854)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -238,6 +238,15 @@ test-install-sh:
 	@bash build/linux/install_test.sh
 	@echo "✅ Linux install.sh tests passed"
 
+# Run Hyper-V host install script Pester tests (Story #1854).
+# Windows CI only — pwsh + Pester 5 required. NOT included in test-complete
+# (same precedent as test-install-sh). Run manually on Windows CI runner.
+test-install-hyperv-ps1:
+	@echo "🪟 Testing scripts/install-hyperv-host.ps1"
+	@echo "============================================"
+	@pwsh -NonInteractive -File scripts/install-hyperv-host_test.ps1
+	@echo "✅ Hyper-V install script tests passed"
+
 # Smart test - core modules + changed modules only
 test: fix-git-bare
 	@echo "🧪 Running Tests (Smart Mode)"

--- a/scripts/install-hyperv-host.ps1
+++ b/scripts/install-hyperv-host.ps1
@@ -1,0 +1,265 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026 Jordan Ritz
+#
+# install-hyperv-host.ps1 — Install cfgms-steward on a Windows Hyper-V host.
+#
+# Downloads (or uses a pre-built) cfgms-steward binary, verifies the controller
+# CA cert fingerprint, then delegates to `cfgms-steward install --hyperv` with
+# the WinRM service-account password delivered via stdin pipe — never as argv.
+# Polls until the steward reports healthy (up to 60 s). Mirrors the shape of
+# build/linux/install.sh for operators familiar with the Linux flow.
+#
+# Usage (non-interactive):
+#   .\scripts\install-hyperv-host.ps1 `
+#       -ControllerURL https://ctrl.example.com `
+#       -RegToken <token> `
+#       -CAFingerprint <lowercase-hex-no-colons>
+#
+# Usage with pre-built binary (mirrors build/windows/build-msi.ps1 -BinaryPath):
+#   .\scripts\install-hyperv-host.ps1 `
+#       -ControllerURL https://ctrl.example.com `
+#       -RegToken <token> `
+#       -CAFingerprint <hash> `
+#       -BinaryPath .\artifacts\cfgms-steward.exe
+#
+# Security notes:
+#   - -WinRMPass is a SecureString; its plaintext is live only during the stdin
+#     pipe write, then immediately cleared with Remove-Variable + ZeroFreeBSTR.
+#   - The plaintext NEVER appears in stdout, stderr, Windows event log, or
+#     PowerShell transcripts.
+#   - WARNING: Do not pass the same -WinRMPass value across multiple hosts —
+#     use the auto-generate path (omit -WinRMPass) for each host so that each
+#     host has a unique credential, limiting blast radius if one is compromised.
+
+[CmdletBinding()]
+param(
+    # Controller URL (required).
+    [Parameter(Mandatory = $true)]
+    [string]$ControllerURL,
+
+    # Registration token (required).
+    [Parameter(Mandatory = $true)]
+    [string]$RegToken,
+
+    # CA cert SHA-256 fingerprint, lowercase hex without colons (required for
+    # non-interactive runs). Mirrors --fingerprint in build/linux/install.sh.
+    [Parameter(Mandatory = $false)]
+    [string]$CAFingerprint = "",
+
+    # Path to the controller CA cert PEM file.
+    # Default: ca.crt in the same directory as this script (matches bundle layout).
+    [Parameter(Mandatory = $false)]
+    [string]$CACertPath = "",
+
+    # Version tag to download when BinaryPath is empty (e.g. "v1.2.3").
+    # When omitted, the latest GitHub release tag is resolved at runtime.
+    [Parameter(Mandatory = $false)]
+    [string]$Version = "",
+
+    # Path to a pre-downloaded cfgms-steward binary.
+    # When empty, the binary is downloaded from GitHub Releases.
+    # Mirrors -BinaryPath in build/windows/build-msi.ps1.
+    [Parameter(Mandatory = $false)]
+    [string]$BinaryPath = "",
+
+    # WinRM service-account username created during install.
+    [Parameter(Mandatory = $false)]
+    [string]$WinRMUser = "cfgms-hyperv",
+
+    # WinRM service-account password as a SecureString.
+    # WARNING: Do not pass the same -WinRMPass value across multiple hosts —
+    # use the auto-generate path (omit -WinRMPass) for each host so that each
+    # host has a unique credential, limiting blast radius if one is compromised.
+    # When omitted, a 32-byte random password is generated automatically.
+    [Parameter(Mandatory = $false)]
+    [System.Security.SecureString]$WinRMPass = $null,
+
+    # Maximum seconds to wait for the steward to report healthy.
+    # Override via $env:CFGMS_INSTALL_STATUS_TIMEOUT for test isolation
+    # (mirrors the CFGMS_INSTALL_PREFIX pattern in build/linux/install.sh).
+    [Parameter(Mandatory = $false)]
+    [int]$StatusPollTimeoutSeconds = $(
+        if ($env:CFGMS_INSTALL_STATUS_TIMEOUT) { [int]$env:CFGMS_INSTALL_STATUS_TIMEOUT } else { 60 }
+    )
+)
+
+$ErrorActionPreference = "Stop"
+
+$ScriptDir = $PSScriptRoot
+
+# ── Locate CA cert ─────────────────────────────────────────────────────────────
+
+if ($CACertPath -eq "") {
+    $DefaultCACert = Join-Path $ScriptDir "ca.crt"
+    if (Test-Path $DefaultCACert) {
+        $CACertPath = $DefaultCACert
+    }
+}
+
+# ── Fingerprint verification ───────────────────────────────────────────────────
+# Mirrors build/linux/install.sh:73-110. Compute SHA-256 from $CACertPath,
+# normalise to lowercase hex without colons, compare to caller-supplied value.
+# Exit non-zero before any install action if there is a mismatch.
+
+if ($CACertPath -ne "") {
+    if (-not (Test-Path $CACertPath)) {
+        Write-Error "CA cert not found: $CACertPath"
+    }
+
+    if ($CAFingerprint -ne "") {
+        # Non-interactive: compute and compare.
+        $CertBytes  = [System.IO.File]::ReadAllBytes($CACertPath)
+        $Cert        = [System.Security.Cryptography.X509Certificates.X509Certificate2]::new($CertBytes)
+        $Sha256      = [System.Security.Cryptography.SHA256]::Create()
+        $Hash        = $Sha256.ComputeHash($Cert.RawData)
+        $Computed    = ($Hash | ForEach-Object { $_.ToString("x2") }) -join ""
+        $Expected    = $CAFingerprint.ToLowerInvariant() -replace ":", ""
+
+        if ($Computed -ne $Expected) {
+            Write-Host "Fingerprint mismatch:" -ForegroundColor Red
+            Write-Host "  expected: $Expected"
+            Write-Host "  computed: $Computed"
+            Write-Host "Installation aborted. Verify the CA fingerprint before deploying." -ForegroundColor Red
+            exit 1
+        }
+        Write-Host "CA fingerprint verified." -ForegroundColor Green
+    } else {
+        # Interactive: display computed fingerprint and prompt.
+        $CertBytes = [System.IO.File]::ReadAllBytes($CACertPath)
+        $Cert      = [System.Security.Cryptography.X509Certificates.X509Certificate2]::new($CertBytes)
+        $Sha256    = [System.Security.Cryptography.SHA256]::Create()
+        $Hash      = $Sha256.ComputeHash($Cert.RawData)
+        $Displayed = ($Hash | ForEach-Object { $_.ToString("x2") }) -join ""
+
+        Write-Host ""
+        Write-Host "CA Certificate Fingerprint (SHA-256):"
+        Write-Host "  $Displayed"
+        Write-Host ""
+        $Answer = Read-Host "Verify this fingerprint against your controller --init output. Continue? [y/N]"
+        if ($Answer -notmatch "^[yY]") {
+            Write-Host "Installation aborted. Verify the CA fingerprint before deploying." -ForegroundColor Red
+            exit 1
+        }
+    }
+}
+
+# ── Resolve binary ─────────────────────────────────────────────────────────────
+
+if ($BinaryPath -eq "") {
+    # Resolve version from latest GitHub release when not specified.
+    if ($Version -eq "") {
+        Write-Host "Resolving latest cfgms-steward release..." -ForegroundColor Yellow
+        try {
+            $Release = Invoke-RestMethod -Uri "https://api.github.com/repos/cfg-is/cfgms/releases/latest" `
+                -Headers @{ "User-Agent" = "cfgms-install-hyperv-host" }
+            $Version = $Release.tag_name
+        } catch {
+            Write-Error "Failed to resolve latest release tag: $_"
+        }
+        Write-Host "  Latest version: $Version"
+    }
+
+    $DownloadURL = "https://github.com/cfg-is/cfgms/releases/download/$Version/cfgms-steward-windows-amd64.exe"
+    $TempBinary  = Join-Path $env:TEMP "cfgms-steward-$Version.exe"
+
+    if (-not (Test-Path $TempBinary)) {
+        Write-Host "Downloading cfgms-steward $Version..." -ForegroundColor Yellow
+        try {
+            Invoke-WebRequest -Uri $DownloadURL -OutFile $TempBinary -UseBasicParsing
+        } catch {
+            Write-Error "Failed to download binary from $DownloadURL`: $_"
+        }
+        Write-Host "  Downloaded: $TempBinary" -ForegroundColor Green
+    } else {
+        Write-Host "Using cached binary: $TempBinary"
+    }
+
+    $BinaryPath = $TempBinary
+} else {
+    if (-not (Test-Path $BinaryPath)) {
+        Write-Error "Binary not found: $BinaryPath"
+    }
+    Write-Host "Using pre-built binary: $BinaryPath"
+}
+
+# ── Generate WinRM password when not supplied ─────────────────────────────────
+
+if ($null -eq $WinRMPass) {
+    $RandomBytes = [byte[]]::new(32)
+    [System.Security.Cryptography.RandomNumberGenerator]::Create().GetBytes($RandomBytes)
+    $RandomBase64 = [Convert]::ToBase64String($RandomBytes)
+    $WinRMPass   = ConvertTo-SecureString -String $RandomBase64 -AsPlainText -Force
+    Remove-Variable RandomBytes, RandomBase64
+    Write-Host "WinRM password auto-generated (unique per host)." -ForegroundColor Green
+}
+
+# ── Invoke cfgms-steward install via stdin pipe ────────────────────────────────
+# SECURITY: plaintext is live only for the duration of the pipe write.
+# Remove-Variable immediately follows. The value MUST NOT appear in argv.
+
+Write-Host ""
+Write-Host "Installing CFGMS Steward (Hyper-V host)..." -ForegroundColor Cyan
+
+$InstallArgs = @(
+    "install",
+    "--regtoken", $RegToken,
+    "--hyperv",
+    "--winrm-user", $WinRMUser,
+    "--winrm-pass-stdin"
+)
+
+if ($CACertPath -ne "") {
+    $InstallArgs += @("--ca-cert", $CACertPath)
+}
+if ($CAFingerprint -ne "") {
+    $InstallArgs += @("--fingerprint", ($CAFingerprint.ToLowerInvariant() -replace ":", ""))
+}
+if ($ControllerURL -ne "") {
+    $InstallArgs += @("--controller-url", $ControllerURL)
+}
+
+$bstr  = [Runtime.InteropServices.Marshal]::SecureStringToBSTR($WinRMPass)
+$plain = [Runtime.InteropServices.Marshal]::PtrToStringAuto($bstr)
+[Runtime.InteropServices.Marshal]::ZeroFreeBSTR($bstr)
+
+$plain | & $BinaryPath @InstallArgs
+$InstallExit = $LASTEXITCODE
+
+Remove-Variable plain
+
+if ($InstallExit -ne 0) {
+    Write-Host "cfgms-steward install failed (exit $InstallExit)." -ForegroundColor Red
+    exit $InstallExit
+}
+
+Write-Host "Install command succeeded." -ForegroundColor Green
+
+# ── Poll until steward reports healthy ────────────────────────────────────────
+
+Write-Host ""
+Write-Host "Waiting for steward to report healthy (up to $StatusPollTimeoutSeconds s)..." -ForegroundColor Yellow
+
+$Deadline = (Get-Date).AddSeconds($StatusPollTimeoutSeconds)
+$Healthy  = $false
+
+while ((Get-Date) -lt $Deadline) {
+    $StatusExit = 0
+    & $BinaryPath status 2>&1 | Out-Null
+    $StatusExit = $LASTEXITCODE
+    if ($StatusExit -eq 0) {
+        $Healthy = $true
+        break
+    }
+    Start-Sleep -Seconds 5
+}
+
+if ($Healthy) {
+    Write-Host ""
+    Write-Host "CFGMS Steward is registered and healthy." -ForegroundColor Green
+    exit 0
+} else {
+    Write-Host ""
+    Write-Host "Timeout: steward did not report healthy within $StatusPollTimeoutSeconds s." -ForegroundColor Red
+    Write-Host "Check the steward logs: Get-EventLog -LogName Application -Source cfgms-steward" -ForegroundColor Yellow
+    exit 1
+}

--- a/scripts/install-hyperv-host_test.ps1
+++ b/scripts/install-hyperv-host_test.ps1
@@ -1,0 +1,411 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026 Jordan Ritz
+#
+# install-hyperv-host_test.ps1 — Pester 5 tests for install-hyperv-host.ps1.
+#
+# The story spec explicitly prescribes a "mock cfgms-steward.exe stub" for
+# logic tests (the binary is not available in test environments). This follows
+# the same pattern as build/linux/install_test.sh, which injects a mock
+# cfgms-steward shell script to verify install.sh argument-passing conventions.
+# The no-mocks rule applies to Go unit tests; script orchestrator tests require
+# a stub to exercise the script's argument-passing and security properties.
+#
+# Run with:
+#   pwsh -NonInteractive -File scripts/install-hyperv-host_test.ps1
+# Or via Make:
+#   make test-install-hyperv-ps1
+
+#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0.0' }
+
+param()
+
+$ErrorActionPreference = "Stop"
+
+$ScriptUnderTest = Join-Path $PSScriptRoot "install-hyperv-host.ps1"
+
+# ── Helpers ────────────────────────────────────────────────────────────────────
+
+function New-TempDir {
+    $d = Join-Path $env:TEMP ("cfgms-test-" + [System.IO.Path]::GetRandomFileName())
+    New-Item -ItemType Directory -Path $d | Out-Null
+    $d
+}
+
+# Generate a self-signed test CA cert and return its path and SHA-256 fingerprint.
+function New-TestCACert {
+    param([string]$Dir)
+
+    $CertPath = Join-Path $Dir "ca.crt"
+
+    $Rsa = [System.Security.Cryptography.RSA]::Create(2048)
+    $Req = [System.Security.Cryptography.X509Certificates.CertificateRequest]::new(
+        "CN=test-ca",
+        $Rsa,
+        [System.Security.Cryptography.HashAlgorithmName]::SHA256,
+        [System.Security.Cryptography.RSASignaturePadding]::Pkcs1
+    )
+    $Cert = $Req.CreateSelfSigned(
+        [DateTimeOffset]::UtcNow.AddMinutes(-1),
+        [DateTimeOffset]::UtcNow.AddDays(1)
+    )
+
+    $DerBytes = $Cert.Export([System.Security.Cryptography.X509Certificates.X509ContentType]::Cert)
+    $B64      = [Convert]::ToBase64String($DerBytes, [Base64FormattingOptions]::InsertLineBreaks)
+    $Pem      = "-----BEGIN CERTIFICATE-----`n$B64`n-----END CERTIFICATE-----"
+    [System.IO.File]::WriteAllText($CertPath, $Pem)
+
+    $Sha256 = [System.Security.Cryptography.SHA256]::Create()
+    $Hash   = $Sha256.ComputeHash($DerBytes)
+    $Fp     = ($Hash | ForEach-Object { $_.ToString("x2") }) -join ""
+
+    [PSCustomObject]@{ Path = $CertPath; Fingerprint = $Fp }
+}
+
+# Build a mock cfgms-steward stub (a .ps1 script).
+# The stub records argv and stdin to log files so tests can assert them
+# without the real binary. This mirrors the approach in
+# build/linux/install_test.sh where a mock cfgms-steward shell script records
+# arguments to verify install.sh's argument-passing conventions.
+#
+# The stub always creates the argv log on startup (even for status subcommand),
+# so tests can assert its existence or absence unconditionally.
+function New-MockSteward {
+    param([string]$Dir, [string]$StatusBehavior = "healthy")
+
+    $ArgvLog  = Join-Path $Dir "argv.txt"
+    $StdinLog = Join-Path $Dir "stdin.txt"
+
+    $StubPs1 = Join-Path $Dir "cfgms-steward.ps1"
+    $StubContent = @"
+param()
+`$ArgvLog  = '$($ArgvLog -replace "'","''")'
+`$StdinLog = '$($StdinLog -replace "'","''")'
+`$StatusBehavior = '$StatusBehavior'
+
+# Always write the argv log so tests can assert it exists unconditionally.
+(`$args -join "`n") | Out-File -FilePath `$ArgvLog -Encoding utf8 -Append -Force
+
+# Capture piped stdin when present.
+if ([Console]::IsInputRedirected) {
+    `$stdin = `$input | Out-String
+    `$stdin | Out-File -FilePath `$StdinLog -Encoding utf8 -Append -Force
+}
+
+`$sub = if (`$args.Count -gt 0) { `$args[0] } else { "" }
+switch (`$sub) {
+    "install" { exit 0 }
+    "status"  {
+        if (`$StatusBehavior -eq "healthy") { exit 0 }
+        exit 1
+    }
+    default   { exit 0 }
+}
+"@
+    Set-Content -Path $StubPs1 -Value $StubContent -Encoding utf8
+
+    [PSCustomObject]@{
+        Ps1Path  = $StubPs1
+        ArgvLog  = $ArgvLog
+        StdinLog = $StdinLog
+    }
+}
+
+# Invoke the script under test in a child pwsh process, capturing exit code and output.
+# Additional environment variables can be passed via $Env hashtable.
+function Invoke-Script {
+    param(
+        [hashtable]$Params,
+        [string]$BinaryPath = "",
+        [hashtable]$Env     = @{}
+    )
+
+    $ArgList = @("-NonInteractive", "-File", $ScriptUnderTest)
+    foreach ($kv in $Params.GetEnumerator()) {
+        $ArgList += "-$($kv.Key)"
+        if ($null -ne $kv.Value -and $kv.Value -ne "") {
+            $ArgList += "$($kv.Value)"
+        }
+    }
+    if ($BinaryPath -ne "") {
+        $ArgList += "-BinaryPath"
+        $ArgList += $BinaryPath
+    }
+
+    $psi = [System.Diagnostics.ProcessStartInfo]::new()
+    $psi.FileName               = "pwsh"
+    $psi.UseShellExecute        = $false
+    $psi.RedirectStandardOutput = $true
+    $psi.RedirectStandardError  = $true
+
+    foreach ($a in $ArgList) { $psi.ArgumentList.Add($a) }
+    foreach ($kv in $Env.GetEnumerator()) {
+        $psi.Environment[$kv.Key] = $kv.Value
+    }
+
+    $proc   = [System.Diagnostics.Process]::Start($psi)
+    $stdout = $proc.StandardOutput.ReadToEnd()
+    $stderr = $proc.StandardError.ReadToEnd()
+    $proc.WaitForExit()
+
+    [PSCustomObject]@{
+        ExitCode = $proc.ExitCode
+        Output   = $stdout + $stderr
+    }
+}
+
+# ── Pester suite ───────────────────────────────────────────────────────────────
+
+Describe "install-hyperv-host.ps1" {
+
+    # ── Fingerprint mismatch ───────────────────────────────────────────────────
+
+    Context "Fingerprint mismatch" {
+        It "exits non-zero before any install action" {
+            $TmpDir = New-TempDir
+            try {
+                $CA     = New-TestCACert -Dir $TmpDir
+                $Stub   = New-MockSteward -Dir $TmpDir
+                $WrongFP = "0000000000000000000000000000000000000000000000000000000000000000"
+
+                $Result = Invoke-Script -Params @{
+                    ControllerURL = "https://ctrl.example.com"
+                    RegToken      = "tok-test"
+                    CAFingerprint = $WrongFP
+                    CACertPath    = $CA.Path
+                    WinRMUser     = "cfgms-hyperv"
+                } -BinaryPath $Stub.Ps1Path
+
+                # Must exit non-zero.
+                $Result.ExitCode | Should -Not -Be 0
+
+                # Output must mention mismatch or aborted.
+                $Result.Output | Should -Match "(?i)(mismatch|aborted)"
+
+                # The stub always creates the argv log on any invocation.
+                # If install was never called, the argv log must not exist.
+                $Stub.ArgvLog | Should -Not -Exist
+            } finally {
+                Remove-Item $TmpDir -Recurse -Force -ErrorAction SilentlyContinue
+            }
+        }
+    }
+
+    # ── Correct fingerprint ────────────────────────────────────────────────────
+
+    Context "Correct fingerprint" {
+        It "exits 0 when steward becomes healthy" {
+            $TmpDir = New-TempDir
+            try {
+                $CA   = New-TestCACert -Dir $TmpDir
+                $Stub = New-MockSteward -Dir $TmpDir -StatusBehavior "healthy"
+
+                $Result = Invoke-Script -Params @{
+                    ControllerURL = "https://ctrl.example.com"
+                    RegToken      = "tok-test"
+                    CAFingerprint = $CA.Fingerprint
+                    CACertPath    = $CA.Path
+                    WinRMUser     = "cfgms-hyperv"
+                } -BinaryPath $Stub.Ps1Path
+
+                $Result.ExitCode | Should -Be 0
+                $Result.Output   | Should -Match "(?i)healthy"
+            } finally {
+                Remove-Item $TmpDir -Recurse -Force -ErrorAction SilentlyContinue
+            }
+        }
+    }
+
+    # ── Password not in argv ───────────────────────────────────────────────────
+
+    Context "WinRM password delivery" {
+        It "does not appear in child process argv, stdout, stderr, or any written file" {
+            $TmpDir = New-TempDir
+            try {
+                $CA     = New-TestCACert -Dir $TmpDir
+                $Stub   = New-MockSteward -Dir $TmpDir -StatusBehavior "healthy"
+                $Secret = "SUPERSECRET-$(New-Guid)"
+
+                $ArgList = @(
+                    "-NonInteractive", "-File", $ScriptUnderTest,
+                    "-ControllerURL",  "https://ctrl.example.com",
+                    "-RegToken",       "tok-test",
+                    "-CAFingerprint",  $CA.Fingerprint,
+                    "-CACertPath",     $CA.Path,
+                    "-WinRMUser",      "cfgms-hyperv",
+                    "-BinaryPath",     $Stub.Ps1Path,
+                    # Pass as plain string so the test holds the sentinel to verify
+                    # it doesn't propagate into the child binary's argv or output.
+                    # PowerShell parameter binding coerces [string] → [SecureString].
+                    "-WinRMPass",      $Secret
+                )
+
+                $psi = [System.Diagnostics.ProcessStartInfo]::new()
+                $psi.FileName               = "pwsh"
+                $psi.UseShellExecute        = $false
+                $psi.RedirectStandardOutput = $true
+                $psi.RedirectStandardError  = $true
+                foreach ($a in $ArgList) { $psi.ArgumentList.Add($a) }
+                $proc   = [System.Diagnostics.Process]::Start($psi)
+                $stdout = $proc.StandardOutput.ReadToEnd()
+                $stderr = $proc.StandardError.ReadToEnd()
+                $proc.WaitForExit()
+
+                $AllOutput = $stdout + $stderr
+
+                # Argv log must exist (stub was called) and must NOT contain the secret.
+                $Stub.ArgvLog | Should -Exist
+                $ArgvContent  = Get-Content $Stub.ArgvLog -Raw
+                $ArgvContent  | Should -Not -Match ([regex]::Escape($Secret))
+
+                # Script output must not contain the secret.
+                $AllOutput | Should -Not -Match ([regex]::Escape($Secret))
+
+                # No files in the temp dir should contain the secret.
+                Get-ChildItem $TmpDir -Recurse -File | ForEach-Object {
+                    $FileContent = Get-Content $_.FullName -Raw -ErrorAction SilentlyContinue
+                    if ($null -ne $FileContent) {
+                        $FileContent | Should -Not -Match ([regex]::Escape($Secret))
+                    }
+                }
+            } finally {
+                Remove-Item $TmpDir -Recurse -Force -ErrorAction SilentlyContinue
+            }
+        }
+
+        It "passes password via stdin — not via argv" {
+            $TmpDir = New-TempDir
+            try {
+                $CA     = New-TestCACert -Dir $TmpDir
+                $Stub   = New-MockSteward -Dir $TmpDir -StatusBehavior "healthy"
+                $Secret = "PIPE-CHECK-$(New-Guid)"
+
+                $ArgList = @(
+                    "-NonInteractive", "-File", $ScriptUnderTest,
+                    "-ControllerURL",  "https://ctrl.example.com",
+                    "-RegToken",       "tok-test",
+                    "-CAFingerprint",  $CA.Fingerprint,
+                    "-CACertPath",     $CA.Path,
+                    "-WinRMUser",      "cfgms-hyperv",
+                    "-BinaryPath",     $Stub.Ps1Path,
+                    "-WinRMPass",      $Secret
+                )
+
+                $psi = [System.Diagnostics.ProcessStartInfo]::new()
+                $psi.FileName               = "pwsh"
+                $psi.UseShellExecute        = $false
+                $psi.RedirectStandardOutput = $true
+                $psi.RedirectStandardError  = $true
+                foreach ($a in $ArgList) { $psi.ArgumentList.Add($a) }
+                $proc = [System.Diagnostics.Process]::Start($psi)
+                $proc.StandardOutput.ReadToEnd() | Out-Null
+                $proc.StandardError.ReadToEnd()  | Out-Null
+                $proc.WaitForExit()
+
+                # Argv log must exist and must NOT contain the secret.
+                $Stub.ArgvLog | Should -Exist
+                $ArgvContent  = Get-Content $Stub.ArgvLog -Raw
+                $ArgvContent  | Should -Not -Match ([regex]::Escape($Secret))
+
+                # Stdin log must exist — the password must have arrived via pipe.
+                $Stub.StdinLog | Should -Exist
+                $StdinContent  = Get-Content $Stub.StdinLog -Raw
+                $StdinContent  | Should -Match ([regex]::Escape($Secret))
+            } finally {
+                Remove-Item $TmpDir -Recurse -Force -ErrorAction SilentlyContinue
+            }
+        }
+    }
+
+    # ── Idempotency ────────────────────────────────────────────────────────────
+
+    Context "Idempotency" {
+        It "succeeds on second invocation with same parameters" {
+            $TmpDir = New-TempDir
+            try {
+                $CA   = New-TestCACert -Dir $TmpDir
+                $Stub = New-MockSteward -Dir $TmpDir -StatusBehavior "healthy"
+
+                $Params = @{
+                    ControllerURL = "https://ctrl.example.com"
+                    RegToken      = "tok-test"
+                    CAFingerprint = $CA.Fingerprint
+                    CACertPath    = $CA.Path
+                    WinRMUser     = "cfgms-hyperv"
+                }
+
+                $First  = Invoke-Script -Params $Params -BinaryPath $Stub.Ps1Path
+                $Second = Invoke-Script -Params $Params -BinaryPath $Stub.Ps1Path
+
+                $First.ExitCode  | Should -Be 0
+                $Second.ExitCode | Should -Be 0
+            } finally {
+                Remove-Item $TmpDir -Recurse -Force -ErrorAction SilentlyContinue
+            }
+        }
+    }
+
+    # ── Health poll timeout ────────────────────────────────────────────────────
+
+    Context "Health poll timeout" {
+        It "exits non-zero with a clear message when steward never becomes healthy" {
+            $TmpDir = New-TempDir
+            try {
+                $CA   = New-TestCACert -Dir $TmpDir
+                # StatusBehavior = "unhealthy" makes the stub always exit 1 for `status`.
+                $Stub = New-MockSteward -Dir $TmpDir -StatusBehavior "unhealthy"
+
+                # Use CFGMS_INSTALL_STATUS_TIMEOUT=10 to shorten the poll deadline
+                # from 60 s to 10 s (mirrors the CFGMS_INSTALL_PREFIX isolation
+                # pattern in build/linux/install.sh). This exercises the real
+                # polling loop in install-hyperv-host.ps1 without a 60-second wait.
+                $Result = Invoke-Script -Params @{
+                    ControllerURL = "https://ctrl.example.com"
+                    RegToken      = "tok-test"
+                    CAFingerprint = $CA.Fingerprint
+                    CACertPath    = $CA.Path
+                    WinRMUser     = "cfgms-hyperv"
+                } -BinaryPath $Stub.Ps1Path -Env @{ CFGMS_INSTALL_STATUS_TIMEOUT = "10" }
+
+                $Result.ExitCode | Should -Not -Be 0
+                $Result.Output   | Should -Match "(?i)(timeout|healthy)"
+            } finally {
+                Remove-Item $TmpDir -Recurse -Force -ErrorAction SilentlyContinue
+            }
+        }
+    }
+
+    # ── Pre-built binary ───────────────────────────────────────────────────────
+
+    Context "Pre-built binary (-BinaryPath)" {
+        It "uses the pre-supplied binary without download" {
+            $TmpDir = New-TempDir
+            try {
+                $CA   = New-TestCACert -Dir $TmpDir
+                $Stub = New-MockSteward -Dir $TmpDir -StatusBehavior "healthy"
+
+                $Result = Invoke-Script -Params @{
+                    ControllerURL = "https://ctrl.example.com"
+                    RegToken      = "tok-test"
+                    CAFingerprint = $CA.Fingerprint
+                    CACertPath    = $CA.Path
+                    WinRMUser     = "cfgms-hyperv"
+                } -BinaryPath $Stub.Ps1Path
+
+                $Result.ExitCode | Should -Be 0
+                # Stub was invoked — argv log must exist.
+                $Stub.ArgvLog | Should -Exist
+            } finally {
+                Remove-Item $TmpDir -Recurse -Force -ErrorAction SilentlyContinue
+            }
+        }
+    }
+}
+
+# ── Run Pester ─────────────────────────────────────────────────────────────────
+
+$PesterConfig = New-PesterConfiguration
+$PesterConfig.Output.Verbosity = "Normal"
+$PesterConfig.Run.Path         = $PSCommandPath
+$PesterConfig.Run.Exit         = $true
+
+Invoke-Pester -Configuration $PesterConfig


### PR DESCRIPTION
## Summary

- Adds `scripts/install-hyperv-host.ps1` — thin PowerShell orchestrator that downloads/verifies the cfgms-steward binary, verifies the controller CA cert fingerprint, invokes `cfgms-steward install --hyperv` with the WinRM password delivered exclusively via stdin pipe, and polls until the steward reports healthy
- Adds `scripts/install-hyperv-host_test.ps1` — Pester 5 tests covering all required acceptance criteria (fingerprint mismatch, password-not-in-argv, idempotency, timeout)
- Adds `make test-install-hyperv-ps1` Makefile target (Windows-CI-only, not in `test-complete` per same precedent as `test-install-sh`)

Fixes #1854

## Security properties

- CA fingerprint verified before any install action; exits non-zero on mismatch
- WinRM password delivered via stdin pipe only — never in process argv
- `SecureStringToBSTR` → pipe write → `ZeroFreeBSTR` → `Remove-Variable` sequence; plaintext window minimized
- Random password auto-generated per host via `RandomNumberGenerator` when omitted
- No credentials written to disk

## Specialist review results

| Reviewer | Result |
|---|---|
| QA test runner (`make test-agent-complete`) | **PASS** — 149/149 tests, 0 failures; cross-platform build, security scans, architecture check all green |
| QA code reviewer | **PASS** — all 5 blocking issues from round 1 resolved; unconditional assertions, real script exercised in timeout test via `CFGMS_INSTALL_STATUS_TIMEOUT` env override |
| Security engineer | **PASS** — 0 blocking issues; password delivery via stdin confirmed, BSTR cleanup verified, fingerprint-before-install ordering confirmed; automated scans (Trivy, Nancy, gosec, staticcheck, gitleaks, truffleHog) all green |

## Test plan

- [x] `make test-agent-complete` passes on Linux CI (Go build + cross-compile; Pester tests are Windows-CI-only)
- [ ] `make test-install-hyperv-ps1` — runs on Windows CI runner with `pwsh` + Pester 5
- [ ] Manual smoke: `.\scripts\install-hyperv-host.ps1 -ControllerURL https://ctrl -RegToken TOKEN -CAFingerprint HASH` on a Windows Server with Hyper-V role

🤖 Generated with [Claude Code](https://claude.com/claude-code)