### PR TITLE
deps: bump nancy v1.2.0 → v2.0.0 (Issue #1870)

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -64,7 +64,7 @@ RUN set -eu; \
 
 # Nancy (Go dependency scanner)
 RUN GOPATH=$(go env GOPATH) \
-    && curl -L "https://github.com/sonatype-nexus-community/nancy/releases/download/v1.2.0/nancy-v1.2.0-linux-amd64" \
+    && curl -L "https://github.com/sonatype-nexus-community/nancy/releases/download/v2.0.0/nancy-v2.0.0-linux-amd64" \
        -o "$GOPATH/bin/nancy" \
     && chmod +x "$GOPATH/bin/nancy"
 

--- a/.github/workflows/dependency-pin-check.yml
+++ b/.github/workflows/dependency-pin-check.yml
@@ -119,7 +119,7 @@ jobs:
         check_version "gosec"       "securego/gosec"                          "v2.26.1"
         check_version "staticcheck" "dominikh/go-tools"                       "2026.1"
         check_version "gitleaks"    "zricethezav/gitleaks"                    "v8.30.1"
-        check_version "nancy"       "sonatype-nexus-community/nancy"          "v1.2.0"
+        check_version "nancy"       "sonatype-nexus-community/nancy"          "v2.0.0"
         check_version "trufflehog"  "trufflesecurity/trufflehog"              "v3.95.3"
         check_version "trivy"       "aquasecurity/trivy"                      "v0.70.0"
         check_version "go-licenses" "google/go-licenses"                      "v2.0.1"

--- a/Makefile
+++ b/Makefile
@@ -803,7 +803,7 @@ test-data-consistency:
 
 # Automatic Nancy installation (cross-platform)
 install-nancy:
-	@echo "📦 Installing Nancy v1.2.0..."
+	@echo "📦 Installing Nancy v2.0.0..."
 	@echo "============================="
 	@if command -v nancy >/dev/null 2>&1; then \
 		echo "✅ Nancy is already installed: $$(nancy --version)"; \
@@ -821,16 +821,16 @@ install-nancy:
 	case "$$os" in \
 		linux) \
 			if [ "$$arch" = "x86_64" ]; then \
-				curl -L "https://github.com/sonatype-nexus-community/nancy/releases/download/v1.2.0/nancy-v1.2.0-linux-amd64" -o "$$gopath/bin/nancy"; \
+				curl -L "https://github.com/sonatype-nexus-community/nancy/releases/download/v2.0.0/nancy-v2.0.0-linux-amd64" -o "$$gopath/bin/nancy"; \
 			else \
 				echo "❌ Unsupported architecture: $$arch"; \
 				exit 1; \
 			fi ;; \
 		darwin) \
 			if [ "$$arch" = "x86_64" ]; then \
-				curl -L "https://github.com/sonatype-nexus-community/nancy/releases/download/v1.2.0/nancy-v1.2.0-darwin-amd64" -o "$$gopath/bin/nancy"; \
+				curl -L "https://github.com/sonatype-nexus-community/nancy/releases/download/v2.0.0/nancy-v2.0.0-darwin-amd64" -o "$$gopath/bin/nancy"; \
 			elif [ "$$arch" = "arm64" ]; then \
-				curl -L "https://github.com/sonatype-nexus-community/nancy/releases/download/v1.2.0/nancy-v1.2.0-darwin-arm64" -o "$$gopath/bin/nancy"; \
+				curl -L "https://github.com/sonatype-nexus-community/nancy/releases/download/v2.0.0/nancy-v2.0.0-darwin-arm64" -o "$$gopath/bin/nancy"; \
 			else \
 				echo "❌ Unsupported architecture: $$arch"; \
 				exit 1; \
@@ -880,25 +880,25 @@ security-deps:
 	@if ! command -v nancy >/dev/null 2>&1; then \
 		echo "❌ Error: nancy is not installed"; \
 		echo ""; \
-		echo "Install nancy (v1.2.0) for your platform:"; \
+		echo "Install nancy (v2.0.0) for your platform:"; \
 		echo ""; \
 		echo "🚀 Quick Install (recommended):"; \
 		echo "  make install-nancy"; \
 		echo ""; \
 		echo "📥 Manual Install - Linux (amd64):"; \
-		echo "  curl -L https://github.com/sonatype-nexus-community/nancy/releases/download/v1.2.0/nancy-v1.2.0-linux-amd64 -o ~/nancy"; \
+		echo "  curl -L https://github.com/sonatype-nexus-community/nancy/releases/download/v2.0.0/nancy-v2.0.0-linux-amd64 -o ~/nancy"; \
 		echo "  chmod +x ~/nancy && mv ~/nancy \$$(go env GOPATH)/bin/nancy"; \
 		echo ""; \
 		echo "🍎 Manual Install - macOS (Intel):"; \
-		echo "  curl -L https://github.com/sonatype-nexus-community/nancy/releases/download/v1.2.0/nancy-v1.2.0-darwin-amd64 -o ~/nancy"; \
+		echo "  curl -L https://github.com/sonatype-nexus-community/nancy/releases/download/v2.0.0/nancy-v2.0.0-darwin-amd64 -o ~/nancy"; \
 		echo "  chmod +x ~/nancy && mv ~/nancy \$$(go env GOPATH)/bin/nancy"; \
 		echo ""; \
 		echo "🍎 Manual Install - macOS (Apple Silicon):"; \
-		echo "  curl -L https://github.com/sonatype-nexus-community/nancy/releases/download/v1.2.0/nancy-v1.2.0-darwin-arm64 -o ~/nancy"; \
+		echo "  curl -L https://github.com/sonatype-nexus-community/nancy/releases/download/v2.0.0/nancy-v2.0.0-darwin-arm64 -o ~/nancy"; \
 		echo "  chmod +x ~/nancy && mv ~/nancy \$$(go env GOPATH)/bin/nancy"; \
 		echo ""; \
 		echo "🪟 Manual Install - Windows (PowerShell):"; \
-		echo "  Invoke-WebRequest -Uri 'https://github.com/sonatype-nexus-community/nancy/releases/download/v1.2.0/nancy-v1.2.0-windows-amd64.exe' -OutFile 'nancy.exe'"; \
+		echo "  Invoke-WebRequest -Uri 'https://github.com/sonatype-nexus-community/nancy/releases/download/v2.0.0/nancy-v2.0.0-windows-amd64.exe' -OutFile 'nancy.exe'"; \
 		echo "  Move-Item nancy.exe \$$(go env GOPATH)\\bin\\nancy.exe"; \
 		echo ""; \
 		echo "📦 Package Managers:"; \

--- a/docs/development/security-setup.md
+++ b/docs/development/security-setup.md
@@ -92,7 +92,7 @@ make install-nancy
 
 ```bash
 # Binary download to Go bin directory
-curl -L https://github.com/sonatype-nexus-community/nancy/releases/download/v1.2.0/nancy-v1.2.0-linux-amd64 -o ~/nancy
+curl -L https://github.com/sonatype-nexus-community/nancy/releases/download/v2.0.0/nancy-v2.0.0-linux-amd64 -o ~/nancy
 chmod +x ~/nancy && mv ~/nancy $(go env GOPATH)/bin/nancy
 ```
 
@@ -103,7 +103,7 @@ chmod +x ~/nancy && mv ~/nancy $(go env GOPATH)/bin/nancy
 brew install nancy
 
 # Binary download to Go bin directory
-curl -L https://github.com/sonatype-nexus-community/nancy/releases/download/v1.2.0/nancy-v1.2.0-darwin-amd64 -o ~/nancy
+curl -L https://github.com/sonatype-nexus-community/nancy/releases/download/v2.0.0/nancy-v2.0.0-darwin-amd64 -o ~/nancy
 chmod +x ~/nancy && mv ~/nancy $(go env GOPATH)/bin/nancy
 ```
 
@@ -111,7 +111,7 @@ chmod +x ~/nancy && mv ~/nancy $(go env GOPATH)/bin/nancy
 
 ```bash
 # Binary download to Go bin directory
-curl -L https://github.com/sonatype-nexus-community/nancy/releases/download/v1.2.0/nancy-v1.2.0-darwin-arm64 -o ~/nancy
+curl -L https://github.com/sonatype-nexus-community/nancy/releases/download/v2.0.0/nancy-v2.0.0-darwin-arm64 -o ~/nancy
 chmod +x ~/nancy && mv ~/nancy $(go env GOPATH)/bin/nancy
 ```
 
@@ -126,7 +126,7 @@ yay -S nancy-bin
 
 ```powershell
 # Binary download to Go bin directory
-Invoke-WebRequest -Uri 'https://github.com/sonatype-nexus-community/nancy/releases/download/v1.2.0/nancy-v1.2.0-windows-amd64.exe' -OutFile 'nancy.exe'
+Invoke-WebRequest -Uri 'https://github.com/sonatype-nexus-community/nancy/releases/download/v2.0.0/nancy-v2.0.0-windows-amd64.exe' -OutFile 'nancy.exe'
 Move-Item nancy.exe $(go env GOPATH)\bin\nancy.exe
 ```
 


### PR DESCRIPTION
## Summary

- Bump nancy Go dependency scanner from v1.2.0 to v2.0.0 across all 11 pinned references in 4 files
- Verified v2.0.0 GitHub release publishes identical per-platform asset naming — URL pattern unchanged, only version string differs
- Fixed DSD gap in `docs/development/security-setup.md` (manual-install docs were still referencing v1.2.0)

Fixes #1870

## Files Changed

| File | Change |
|------|--------|
| `.github/workflows/dependency-pin-check.yml` | Pinned version check: `v1.2.0` → `v2.0.0` |
| `.devcontainer/Dockerfile` | curl download URL: `v1.2.0` → `v2.0.0` |
| `Makefile` | install-nancy target URLs + error-message echo strings (9 lines) |
| `docs/development/security-setup.md` | Manual-install docs for all 4 platforms (DSD gap fix) |

## Verification

```
# AC2 — old version absent (0 matches):
grep -rE "nancy.*v1\.2\.0|v1\.2\.0.*nancy" .github .devcontainer Makefile
# returns: (empty)

# AC3 — new version present (11 matches):
grep -rE "v2\.0\.0" .github .devcontainer Makefile | wc -l
# returns: 11
```

## Specialist Review Results

**QA Test Runner**: PASS (121 Go packages, 160 script tests — all green). `security-trivy` reports pre-existing CVE-2026-40898 in `quic-go v0.59.0` unrelated to this change.

**QA Code Reviewer**: PASS — all 11 occurrences updated, no Go source changes, no test files needed for a pure version bump.

**Security Engineer**: PASS — all URLs use HTTPS and point to the official `sonatype-nexus-community/nancy` repo. No hardcoded secrets. No central provider violations. Pre-existing `quic-go` CVE is out of scope and tracked separately.

## Test plan

- [x] `grep -rE "nancy.*v1\.2\.0|v1\.2\.0.*nancy" .github .devcontainer Makefile` returns 0 matches
- [x] `grep -rE "v2\.0\.0" .github .devcontainer Makefile | wc -l` returns 11
- [x] `make test` passes (121 Go packages + 160 script tests all green)
- [x] nancy v2.0.0 binary downloads and runs (`nancy version 2.0.0` confirmed)
- [x] All CI required checks expected to pass (unit-tests, integration-tests, Build Gate, security-deployment-gate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)