### PR TITLE
deps: bump gosec v2.26.1 → v2.27.1 (Issue #1869)

### DIFF
--- a/.claude/skills/refresh-pins/references/decision-matrix.md
+++ b/.claude/skills/refresh-pins/references/decision-matrix.md
@@ -60,9 +60,9 @@ Verdict: **HOLD**. Founder summary line: `trivy v0.70.0→v0.71.0 — released 2
 
 ### Example 3 — newer release, past cooldown, no CVE (Verdict: BUMP)
 
-- Pin: `gosec`, current `v2.26.1`
-- Latest: `v2.27.0`, published 9 days ago
-- CVEs in v2.26.1: none
+- Pin: `gosec`, current `v2.27.1`
+- Latest: `v2.27.1`, published 4 days ago
+- CVEs in v2.27.1: none
 - CI signal: none
 - Cooldown: elapsed (9 > 3 days)
 

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -38,7 +38,7 @@ RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
 
 # Go-based security and quality tools
 # Versions MUST match .github/workflows/dependency-pin-check.yml
-RUN go install github.com/securego/gosec/v2/cmd/gosec@v2.26.1 \
+RUN go install github.com/securego/gosec/v2/cmd/gosec@v2.27.1 \
     && go install honnef.co/go/tools/cmd/staticcheck@2026.1 \
     && go install github.com/zricethezav/gitleaks/v8@v8.30.1 \
     && go install github.com/google/go-licenses/v2@v2.0.1 \

--- a/.github/workflows/dependency-pin-check.yml
+++ b/.github/workflows/dependency-pin-check.yml
@@ -116,7 +116,7 @@ jobs:
         }
 
         echo "Checking pinned tool versions..."
-        check_version "gosec"       "securego/gosec"                          "v2.26.1"
+        check_version "gosec"       "securego/gosec"                          "v2.27.1"
         check_version "staticcheck" "dominikh/go-tools"                       "2026.1"
         check_version "gitleaks"    "zricethezav/gitleaks"                    "v8.30.1"
         check_version "nancy"       "sonatype-nexus-community/nancy"          "v1.2.0"

--- a/.github/workflows/production-gates.yml
+++ b/.github/workflows/production-gates.yml
@@ -67,7 +67,7 @@ jobs:
 
         # Install other security tools
         make install-nancy
-        go install github.com/securego/gosec/v2/cmd/gosec@v2.26.1
+        go install github.com/securego/gosec/v2/cmd/gosec@v2.27.1
         go install honnef.co/go/tools/cmd/staticcheck@2026.1
         
         echo "✅ Security tools installed"

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -173,7 +173,7 @@ jobs:
     #   continue-on-error: true
 
     - name: Install gosec
-      run: go install github.com/securego/gosec/v2/cmd/gosec@v2.26.1
+      run: go install github.com/securego/gosec/v2/cmd/gosec@v2.27.1
     
     - name: Run gosec Scan
       id: scan
@@ -330,7 +330,7 @@ jobs:
         sudo .github/scripts/install-trivy.sh 'v0.70.0' '8b4376d5d6befe5c24d503f10ff136d9e0c49f9127a4279fd110b727929a5aa9'
 
         # Install gosec and staticcheck
-        go install github.com/securego/gosec/v2/cmd/gosec@v2.26.1
+        go install github.com/securego/gosec/v2/cmd/gosec@v2.27.1
         go install honnef.co/go/tools/cmd/staticcheck@2026.1
     
     - name: Generate Remediation Report on Failure

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@
 repos:
   # Go security pattern analysis with gosec
   - repo: https://github.com/securego/gosec
-    rev: v2.26.1
+    rev: v2.27.1
     hooks:
       - id: gosec
         name: gosec security scan

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -60,7 +60,7 @@ This guide provides instructions for setting up a local CFGMS development enviro
 
 - **gosec** - Security scanning
   ```bash
-  go install github.com/securego/gosec/v2/cmd/gosec@v2.26.1
+  go install github.com/securego/gosec/v2/cmd/gosec@v2.27.1
   ```
 
 ### System Requirements

--- a/Makefile
+++ b/Makefile
@@ -929,7 +929,7 @@ security-gosec:
 		echo "❌ Error: gosec is not installed"; \
 		echo ""; \
 		echo "Install gosec using Go:"; \
-		echo "  go install github.com/securego/gosec/v2/cmd/gosec@v2.26.1"; \
+		echo "  go install github.com/securego/gosec/v2/cmd/gosec@v2.27.1"; \
 		echo ""; \
 		echo "For more info: https://github.com/securego/gosec"; \
 		exit 1; \

--- a/docs/development/security-setup.md
+++ b/docs/development/security-setup.md
@@ -17,7 +17,7 @@ CFGMS uses a multi-layered security scanning approach with four primary tools:
 # 1. Install security tools
 ./.github/scripts/install-trivy.sh v0.70.0 \
     8b4376d5d6befe5c24d503f10ff136d9e0c49f9127a4279fd110b727929a5aa9
-go install github.com/securego/gosec/v2/cmd/gosec@v2.26.1
+go install github.com/securego/gosec/v2/cmd/gosec@v2.27.1
 go install honnef.co/go/tools/cmd/staticcheck@2026.1
 make install-nancy     # Auto-install Nancy for your platform
 
@@ -136,7 +136,7 @@ gosec analyzes Go source code for security problems and anti-patterns.
 
 ```bash
 # Go installation (all platforms) - RECOMMENDED
-go install github.com/securego/gosec/v2/cmd/gosec@v2.26.1
+go install github.com/securego/gosec/v2/cmd/gosec@v2.27.1
 
 # Verify installation
 gosec --version
@@ -422,7 +422,7 @@ Current tool versions (as of v0.3.1):
 
 - **Trivy**: v0.70.0 (pinned — v0.69.4-v0.69.6 compromised per CVE-2026-33634; v0.70.0 is the post-incident clean rebuild with new GPG key. Install via `./.github/scripts/install-trivy.sh`. NEVER use @latest, NEVER use `go install`.)
 - **Nancy**: v1.2.0
-- **gosec**: v2.26.1 (pinned — avoid @latest)
+- **gosec**: v2.27.1 (pinned — avoid @latest)
 - **staticcheck**: 2026.1 (pinned — avoid @latest)
 
 ## Contributing to Security Setup
@@ -560,7 +560,7 @@ pre-commit install --install-hooks
 ```bash
 # Install missing Go tools
 go install honnef.co/go/tools/cmd/staticcheck@2026.1
-go install github.com/securego/gosec/v2/cmd/gosec@v2.26.1
+go install github.com/securego/gosec/v2/cmd/gosec@v2.27.1
 
 # Verify PATH
 which staticcheck gosec

--- a/docs/development/security-troubleshooting.md
+++ b/docs/development/security-troubleshooting.md
@@ -416,11 +416,11 @@ make security-remediation-report 2>&1 | tee remediation-debug.log
 # Check current versions
 trivy --version      # Should be latest stable
 nancy --version      # Should be v1.0.51+
-gosec -version       # Should be v2.26.1+
+gosec -version       # Should be v2.27.1+
 staticcheck -version # Should be 2023.1+
 
 # Update to compatible versions
-go install github.com/securego/gosec/v2/cmd/gosec@v2.26.1
+go install github.com/securego/gosec/v2/cmd/gosec@v2.27.1
 go install honnef.co/go/tools/cmd/staticcheck@2026.1
 ```
 
@@ -541,7 +541,7 @@ rm -rf ~/.cache/staticcheck
 
 # Reinstall tools
 make install-nancy
-go install github.com/securego/gosec/v2/cmd/gosec@v2.26.1
+go install github.com/securego/gosec/v2/cmd/gosec@v2.27.1
 go install honnef.co/go/tools/cmd/staticcheck@2026.1
 
 # Test installations

--- a/docs/development/security-workflow-guide.md
+++ b/docs/development/security-workflow-guide.md
@@ -60,7 +60,7 @@ make install-nancy
 
 # Install individual tools (Ubuntu/Debian)
 sudo apt-get install trivy
-go install github.com/securego/gosec/v2/cmd/gosec@v2.26.1
+go install github.com/securego/gosec/v2/cmd/gosec@v2.27.1
 go install honnef.co/go/tools/cmd/staticcheck@2026.1
 ```
 


### PR DESCRIPTION
## Summary

Bumps `gosec` from `v2.26.1` to `v2.27.1` across all enforcement surfaces and documentation in lockstep.

- gosec v2.27.1 released 2026-06-01 (3-day cooldown elapsed)
- Release is routine maintenance: "Downgrade google lib to avoid min Go version bump"
- No CVE in gosec itself, no CI-blocking signal

## Files Changed (11)

| File | Change |
|------|--------|
| `.github/workflows/dependency-pin-check.yml:119` | `v2.26.1` → `v2.27.1` |
| `.github/workflows/production-gates.yml:70` | `v2.26.1` → `v2.27.1` |
| `.github/workflows/security-scan.yml:176,333` | `v2.26.1` → `v2.27.1` |
| `.devcontainer/Dockerfile:41` | `v2.26.1` → `v2.27.1` |
| `Makefile:932` | `v2.26.1` → `v2.27.1` |
| `.pre-commit-config.yaml:12` | `v2.26.1` → `v2.27.1` |
| `docs/development/security-setup.md` | 4 occurrences updated |
| `docs/development/security-workflow-guide.md:63` | `v2.26.1` → `v2.27.1` |
| `docs/development/security-troubleshooting.md` | 3 occurrences updated |
| `DEVELOPMENT.md:63` | `v2.26.1` → `v2.27.1` |
| `.claude/skills/refresh-pins/references/decision-matrix.md` | pin example updated |

## Verification

- `grep -rE "v2\.26\.1" .github .devcontainer Makefile .pre-commit-config.yaml docs DEVELOPMENT.md` → **0 matches**
- `grep -rE "v2\.27\.1" .github .devcontainer Makefile .pre-commit-config.yaml` → **7 matches**
- `make test` → **PASS**

## Pre-existing Issue (not introduced by this PR)

Trivy reports CVE-2026-40898 (MEDIUM) in `github.com/quic-go/quic-go` v0.59.0 on `develop`. This PR makes no changes to `go.mod`/`go.sum` and does not introduce or worsen this finding.

## Specialist Review Results

| Reviewer | Result |
|----------|--------|
| QA Test Runner | **PASS** — `make test` all gates green; Trivy MEDIUM is pre-existing on develop |
| QA Code Reviewer | **PASS** — 0 residual v2.26.1 references, all 11 files consistent, no unintended changes |
| Security Engineer | **PASS** — gosec v2.27.1 confirmed legitimate release, no secrets introduced, no central provider violations |

Fixes #1869

🤖 Generated with [Claude Code](https://claude.com/claude-code)