### PR TITLE
deps: bump trivy v0.70.0 → v0.71.0 + checksum re-pin (Issue #1871)

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -45,15 +45,15 @@ RUN go install github.com/securego/gosec/v2/cmd/gosec@v2.27.1 \
     && curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh \
        | sh -s -- -b "$(go env GOPATH)/bin" v2.12.2
 
-# Trivy — v0.69.4-v0.69.6 are compromised (CVE-2026-33634); v0.70.0 is the
+# Trivy — v0.69.4-v0.69.6 are compromised (CVE-2026-33634); v0.71.0 is the
 # post-incident clean release. We download the project's release archive and
 # verify its SHA-256 against a pinned value before extraction, rather than
 # piping the trivy main branch's install.sh through `sh` (whose contents are
 # fetched at install time and can be tampered with). See
 # docs/runbooks/trivy-rollback.md for rollback procedure.
 RUN set -eu; \
-    TRIVY_VERSION='v0.70.0'; \
-    TRIVY_SHA256='8b4376d5d6befe5c24d503f10ff136d9e0c49f9127a4279fd110b727929a5aa9'; \
+    TRIVY_VERSION='v0.71.0'; \
+    TRIVY_SHA256='30a3d22b23f88c233f1658f562fb477cae3b3e8b4761109d515b7698daf85814'; \
     ARCHIVE="trivy_${TRIVY_VERSION#v}_Linux-64bit.tar.gz"; \
     curl -sSfL -o "/tmp/${ARCHIVE}" \
       "https://github.com/aquasecurity/trivy/releases/download/${TRIVY_VERSION}/${ARCHIVE}"; \

--- a/.github/scripts/install-trivy.sh
+++ b/.github/scripts/install-trivy.sh
@@ -4,7 +4,7 @@
 # versions per the GHSA-69fq-xp46-6x23 advisory (CVE-2026-33634).
 #
 # Usage: install-trivy.sh <version> <sha256> [dest_dir]
-#   version    Trivy version tag (e.g. "v0.70.0")
+#   version    Trivy version tag (e.g. "v0.71.0")
 #   sha256     Expected SHA-256 of trivy_<v>_Linux-64bit.tar.gz from the
 #              upstream release's checksums.txt — pinned in caller's env.
 #   dest_dir   Install directory (default: /usr/local/bin)

--- a/.github/workflows/dependency-pin-check.yml
+++ b/.github/workflows/dependency-pin-check.yml
@@ -50,7 +50,7 @@ jobs:
           echo "" >&2
           echo "ERROR: a known-compromised Trivy version (v0.69.4 - v0.69.6) was found in a pin-usage context." >&2
           echo "These releases are part of the CVE-2026-33634 supply-chain compromise." >&2
-          echo "Use v0.70.0 (post-incident clean release) or v0.69.3 (pre-incident)." >&2
+          echo "Use v0.71.0 (post-incident clean release) or v0.69.3 (pre-incident)." >&2
           echo "See docs/runbooks/trivy-rollback.md for context." >&2
           exit 1
         fi
@@ -121,7 +121,7 @@ jobs:
         check_version "gitleaks"    "zricethezav/gitleaks"                    "v8.30.1"
         check_version "nancy"       "sonatype-nexus-community/nancy"          "v2.0.0"
         check_version "trufflehog"  "trufflesecurity/trufflehog"              "v3.95.3"
-        check_version "trivy"       "aquasecurity/trivy"                      "v0.70.0"
+        check_version "trivy"       "aquasecurity/trivy"                      "v0.71.0"
         check_version "go-licenses" "google/go-licenses"                      "v2.0.1"
         check_version "golangci-lint" "golangci/golangci-lint"                "v2.12.2"
 

--- a/.github/workflows/docker-security.yml
+++ b/.github/workflows/docker-security.yml
@@ -32,7 +32,7 @@ env:
   GO_VERSION: '1.26.4'
   REGISTRY: ghcr.io
   IMAGE_PREFIX: cfg-is/cfgms
-  TRIVY_VERSION: 'v0.70.0'
+  TRIVY_VERSION: 'v0.71.0'
 
 jobs:
   # Scan Controller Docker Image

--- a/.github/workflows/production-gates.yml
+++ b/.github/workflows/production-gates.yml
@@ -60,10 +60,10 @@ jobs:
         echo "=============================================="
         
         # Install Trivy — v0.69.4-v0.69.6 are compromised (CVE-2026-33634);
-        # v0.70.0 is the post-incident clean release. The install helper
+        # v0.71.0 is the post-incident clean release. The install helper
         # verifies the archive SHA-256 against the pinned value before
         # extraction. See docs/runbooks/trivy-rollback.md for rollback.
-        sudo .github/scripts/install-trivy.sh 'v0.70.0' '8b4376d5d6befe5c24d503f10ff136d9e0c49f9127a4279fd110b727929a5aa9'
+        sudo .github/scripts/install-trivy.sh 'v0.71.0' '30a3d22b23f88c233f1658f562fb477cae3b3e8b4761109d515b7698daf85814'
 
         # Install other security tools
         make install-nancy

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -53,12 +53,12 @@ jobs:
 
     - name: Install Trivy
       env:
-        # Trivy v0.69.4-v0.69.6 are compromised (CVE-2026-33634); v0.70.0 is
+        # Trivy v0.69.4-v0.69.6 are compromised (CVE-2026-33634); v0.71.0 is
         # the post-incident clean release. The install helper verifies the
         # archive SHA-256 against this pinned value before extraction. See
         # docs/runbooks/trivy-rollback.md for rollback procedure.
-        TRIVY_VERSION: 'v0.70.0'
-        TRIVY_SHA256: '8b4376d5d6befe5c24d503f10ff136d9e0c49f9127a4279fd110b727929a5aa9'
+        TRIVY_VERSION: 'v0.71.0'
+        TRIVY_SHA256: '30a3d22b23f88c233f1658f562fb477cae3b3e8b4761109d515b7698daf85814'
       run: sudo .github/scripts/install-trivy.sh "$TRIVY_VERSION" "$TRIVY_SHA256"
 
     - name: Run Trivy Scan
@@ -324,10 +324,10 @@ jobs:
         make install-nancy
         
         # Install Trivy — v0.69.4-v0.69.6 are compromised (CVE-2026-33634);
-        # v0.70.0 is the post-incident clean release. The install helper
+        # v0.71.0 is the post-incident clean release. The install helper
         # verifies the archive SHA-256 against the pinned value before
         # extraction. See docs/runbooks/trivy-rollback.md for rollback.
-        sudo .github/scripts/install-trivy.sh 'v0.70.0' '8b4376d5d6befe5c24d503f10ff136d9e0c49f9127a4279fd110b727929a5aa9'
+        sudo .github/scripts/install-trivy.sh 'v0.71.0' '30a3d22b23f88c233f1658f562fb477cae3b3e8b4761109d515b7698daf85814'
 
         # Install gosec and staticcheck
         go install github.com/securego/gosec/v2/cmd/gosec@v2.27.1

--- a/Makefile
+++ b/Makefile
@@ -852,10 +852,10 @@ security-trivy:
 	@if ! command -v trivy >/dev/null 2>&1; then \
 		echo "❌ Error: trivy is not installed"; \
 		echo ""; \
-		echo "Install trivy v0.70.0 — NEVER use v0.69.4-v0.69.6 (CVE-2026-33634)"; \
+		echo "Install trivy v0.71.0 — NEVER use v0.69.4-v0.69.6 (CVE-2026-33634)"; \
 		echo "and NEVER use @latest:"; \
-		echo "  ./.github/scripts/install-trivy.sh v0.70.0 \\"; \
-		echo "    8b4376d5d6befe5c24d503f10ff136d9e0c49f9127a4279fd110b727929a5aa9"; \
+		echo "  ./.github/scripts/install-trivy.sh v0.71.0 \\"; \
+		echo "    30a3d22b23f88c233f1658f562fb477cae3b3e8b4761109d515b7698daf85814"; \
 		echo ""; \
 		echo "Official documentation: https://aquasecurity.github.io/trivy/latest/getting-started/installation/"; \
 		echo "Rollback procedure: docs/runbooks/trivy-rollback.md"; \

--- a/docs/development/security-setup.md
+++ b/docs/development/security-setup.md
@@ -15,8 +15,8 @@ CFGMS uses a multi-layered security scanning approach with four primary tools:
 
 ```bash
 # 1. Install security tools
-./.github/scripts/install-trivy.sh v0.70.0 \
-    8b4376d5d6befe5c24d503f10ff136d9e0c49f9127a4279fd110b727929a5aa9
+./.github/scripts/install-trivy.sh v0.71.0 \
+    30a3d22b23f88c233f1658f562fb477cae3b3e8b4761109d515b7698daf85814
 go install github.com/securego/gosec/v2/cmd/gosec@v2.27.1
 go install honnef.co/go/tools/cmd/staticcheck@2026.1
 make install-nancy     # Auto-install Nancy for your platform
@@ -40,14 +40,14 @@ make security-check    # Same as security-scan but optimized for development
 
 Trivy scans for vulnerabilities, secrets, and misconfigurations in the filesystem.
 
-**Pin v0.70.0 (post-CVE-2026-33634 clean release).** NEVER use v0.69.4-v0.69.6 (compromised) and NEVER use `@latest`. The `go install` route is unsupported by Trivy upstream since v0.29.0 and must not be used.
+**Pin v0.71.0 (post-CVE-2026-33634 clean release).** NEVER use v0.69.4-v0.69.6 (compromised) and NEVER use `@latest`. The `go install` route is unsupported by Trivy upstream since v0.29.0 and must not be used.
 
 #### Linux / macOS (x86_64 + arm64)
 
 ```bash
 # Recommended: verified install via project helper (SHA-256 pinned)
-./.github/scripts/install-trivy.sh v0.70.0 \
-    8b4376d5d6befe5c24d503f10ff136d9e0c49f9127a4279fd110b727929a5aa9
+./.github/scripts/install-trivy.sh v0.71.0 \
+    30a3d22b23f88c233f1658f562fb477cae3b3e8b4761109d515b7698daf85814
 ```
 
 The helper refuses any version in the v0.69.4-v0.69.6 compromised range and verifies the SHA-256 of the release archive before extraction. See `docs/runbooks/trivy-rollback.md` for rollback procedure.
@@ -55,7 +55,7 @@ The helper refuses any version in the v0.69.4-v0.69.6 compromised range and veri
 #### macOS (alternative)
 
 ```bash
-# Homebrew (verify version after install matches v0.70.0: trivy --version)
+# Homebrew (verify version after install matches v0.71.0: trivy --version)
 brew install trivy
 ```
 
@@ -63,8 +63,8 @@ brew install trivy
 
 ```powershell
 # Binary download with hash verification
-$version = "v0.70.0"
-$expectedHash = "8b4376d5d6befe5c24d503f10ff136d9e0c49f9127a4279fd110b727929a5aa9"
+$version = "v0.71.0"
+$expectedHash = "382250158fb9431ff9b87904205027b066a544234b8952b2dd764bd712d55387"
 Invoke-WebRequest -Uri "https://github.com/aquasecurity/trivy/releases/download/$version/trivy_$($version.TrimStart('v'))_Windows-64bit.zip" -OutFile "trivy.zip"
 $actual = (Get-FileHash trivy.zip -Algorithm SHA256).Hash.ToLower()
 if ($actual -ne $expectedHash) { throw "SHA-256 mismatch: expected $expectedHash, got $actual" }
@@ -420,7 +420,7 @@ make security-check      # Quick security validation for development
 
 Current tool versions (as of v0.3.1):
 
-- **Trivy**: v0.70.0 (pinned — v0.69.4-v0.69.6 compromised per CVE-2026-33634; v0.70.0 is the post-incident clean rebuild with new GPG key. Install via `./.github/scripts/install-trivy.sh`. NEVER use @latest, NEVER use `go install`.)
+- **Trivy**: v0.71.0 (pinned — v0.69.4-v0.69.6 compromised per CVE-2026-33634; v0.71.0 is the post-incident clean release. Install via `./.github/scripts/install-trivy.sh`. NEVER use @latest, NEVER use `go install`.)
 - **Nancy**: v1.2.0
 - **gosec**: v2.27.1 (pinned — avoid @latest)
 - **staticcheck**: 2026.1 (pinned — avoid @latest)

--- a/docs/runbooks/trivy-rollback.md
+++ b/docs/runbooks/trivy-rollback.md
@@ -1,19 +1,19 @@
 # Trivy Rollback Runbook
 
-This runbook covers what to do if the currently-pinned Trivy release (`v0.70.0`) is later flagged as compromised, OR if Trivy itself starts producing untrusted results.
+This runbook covers what to do if the currently-pinned Trivy release (`v0.71.0`) is later flagged as compromised, OR if Trivy itself starts producing untrusted results.
 
 ## Context
 
 Trivy was the target of a supply-chain compromise in March 2026 (advisory [GHSA-69fq-xp46-6x23](https://github.com/aquasecurity/trivy/security/advisories/GHSA-69fq-xp46-6x23), CVE-2026-33634). The threat actor "TeamPCP" published malicious releases as `v0.69.4`, `v0.69.5`, and `v0.69.6` and force-pushed compromised tags on `aquasecurity/trivy-action` and `aquasecurity/setup-trivy`. The advisory's safe versions were `v0.69.2` and `v0.69.3` (binary), `v0.35.0` (trivy-action SHA `57a97c7e7821a5776cebc9bb87c984fa69cba8f1`), and `v0.2.6` (setup-trivy SHA `3fb12ec12f41e471780db15c232d5dd185dcb514`).
 
-`v0.70.0` is the project's first post-incident release, published 2026-04-17 with a new GPG key (`B5690EEEBB952194`) for deb/rpm repositories. CFGMS adopts `v0.70.0` based on the project's release announcement and the SHA-256 verification baked into our install path.
+`v0.71.0` is the project's current post-incident release. CFGMS adopts `v0.71.0` based on the project's release announcement and the SHA-256 verification baked into our install path.
 
 ## Detection — when to roll back
 
 Roll back if any of these conditions hold:
 
-1. The advisory page is updated to mark `v0.70.0` as compromised or revoked.
-2. A subsequent release publishes its own advisory referencing `v0.70.0` as malicious.
+1. The advisory page is updated to mark `v0.71.0` as compromised or revoked.
+2. A subsequent release publishes its own advisory referencing `v0.71.0` as malicious.
 3. Trivy in CI starts producing anomalous output: unexpected network calls, unusually large binary size, scan results that don't match other scanners, mass-false-positive or mass-false-negative vulnerability data.
 4. The project rotates GPG / sigstore signing keys again without a clear announcement.
 
@@ -30,7 +30,7 @@ Do NOT roll forward to `v0.69.4`, `v0.69.5`, or `v0.69.6` under any circumstance
   1816b632dfe529869c740c0913e36bd1629cb7688bd5634f4a858c1d57c88b75
 ```
 
-This is the same install helper used by `v0.70.0`. It verifies the archive SHA-256 before extraction. The hash above is the upstream-published SHA-256 of `trivy_0.69.3_Linux-64bit.tar.gz` and is hardcoded here so that a runtime fetch of `checksums.txt` (which would defeat the purpose if the supply chain is mid-compromise) is not required.
+This is the same install helper used by `v0.71.0`. It verifies the archive SHA-256 before extraction. The hash above is the upstream-published SHA-256 of `trivy_0.69.3_Linux-64bit.tar.gz` and is hardcoded here so that a runtime fetch of `checksums.txt` (which would defeat the purpose if the supply chain is mid-compromise) is not required.
 
 ### Manual procedure (if the install helper itself is suspect)
 
@@ -52,11 +52,11 @@ rm "/tmp/${ARCHIVE}" /tmp/trivy
 2. `.github/workflows/security-scan.yml` — both invocations of `install-trivy.sh`.
 3. `.github/workflows/production-gates.yml` — the install invocation.
 4. `.github/workflows/docker-security.yml` — `TRIVY_VERSION` env var (line 35). The SHA-pinned `aquasecurity/trivy-action` and `aquasecurity/setup-trivy` references at lines 53/81/104/140/168/191 must NOT change — those SHAs are the advisory-confirmed safe versions.
-5. `.github/workflows/dependency-pin-check.yml` — `check_version "trivy"` argument and the denylist regex (the v0.69.4–v0.69.6 entries stay; do NOT add v0.70.0 to the denylist on rollback unless the advisory confirms compromise).
+5. `.github/workflows/dependency-pin-check.yml` — `check_version "trivy"` argument and the denylist regex (the v0.69.4–v0.69.6 entries stay; do NOT add v0.71.0 to the denylist on rollback unless the advisory confirms compromise).
 6. `Makefile` — error-handler echo strings in the `security-trivy` target.
 7. This runbook — update the rollback SHA if you're rolling back to a different version.
 
 ## Out of scope
 
 - Rolling back the `aquasecurity/trivy-action` or `aquasecurity/setup-trivy` SHA pins. Those are advisory-blessed and should remain pinned at `57a97c7e...` and `3fb12ec1...` respectively until the advisory recommends new SHAs.
-- Replacing Trivy with another scanner. If `v0.69.3` and `v0.70.0` are both compromised, that is a project-wide incident requiring a different decision (Grype, Snyk OSS, etc.) — not a one-line pin change.
+- Replacing Trivy with another scanner. If `v0.69.3` and `v0.71.0` are both compromised, that is a project-wide incident requiring a different decision (Grype, Snyk OSS, etc.) — not a one-line pin change.


### PR DESCRIPTION
## Summary

- Bump trivy from v0.70.0 to v0.71.0 with lockstep checksum re-pin across all 12 usage sites (CI workflows, devcontainer, Makefile, docs)

Fixes #1871

## Changes

**Trivy v0.70.0 → v0.71.0 (checksum re-pin)**

New SHA-256 for `trivy_0.71.0_Linux-64bit.tar.gz`: `30a3d22b23f88c233f1658f562fb477cae3b3e8b4761109d515b7698daf85814`
(verified against upstream `trivy_0.71.0_checksums.txt`)

Files updated: `.devcontainer/Dockerfile`, `.github/scripts/install-trivy.sh`, `.github/workflows/dependency-pin-check.yml`, `.github/workflows/docker-security.yml`, `.github/workflows/production-gates.yml`, `.github/workflows/security-scan.yml`, `Makefile`, `docs/development/security-setup.md`, `docs/runbooks/trivy-rollback.md`

## Specialist Review Results

| Reviewer | Result | Notes |
|----------|--------|-------|
| QA Test Runner | ✅ PASS | 265 packages, 160 script tests; all green |
| QA Code Reviewer | ✅ PASS | 0 stale v0.70.0 refs; 27 v0.71.0 refs; old SHA absent |
| Security Engineer | ✅ PASS | Supply-chain consistency verified; denylist intact; automated scans clean |

## Test plan

- [x] `make test` passes (160/160 script tests, 265 Go packages)
- [x] `make test-agent-complete` passes
- [x] `grep -rE "v0\.70\.0" .github .devcontainer Makefile docs/` → 0 matches
- [x] `grep -rE "v0\.71\.0" .github .devcontainer Makefile docs/` → 27 matches
- [x] Old SHA `8b4376d5...` absent from all scoped paths
- [x] Compromised-version denylist (v0.69.4–v0.69.6) remains intact
- [ ] CI: docker-security trivy scan with new pinned version + checksum (CI-only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
