### PR TITLE
modules: extend ModuleMetadata schema with executors, kind, publisher, behavioral_envelope (Issue #1880)

### DIFF
--- a/docs/architecture/modules/README.md
+++ b/docs/architecture/modules/README.md
@@ -26,8 +26,42 @@ modules/
 
 **Required Files:**
 
-- `module.yaml` - Module metadata (name, version, description)
+- `module.yaml` - Module metadata (name, version, description, publisher, executors)
 - `*.go` - Implementation that implements the `Module` interface with `ConfigState`
+
+## Module Manifest Fields
+
+Every `module.yaml` must include the following fields:
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `name` | string | yes | Unique module identifier |
+| `version` | string | yes | Semantic version (e.g. `1.0.0`) |
+| `description` | string | no | Human-readable description |
+| `publisher` | string | yes | Module publisher (e.g. `cfgms`) |
+| `executors` | list | yes | Exactly one executor: `steward`, `outpost`, or `controller` |
+| `kind` | — | derived | Derived from `executors[0]`; never set in YAML (see below) |
+| `behavioral_envelope` | object | no | Runtime behavior declaration for security auditing |
+
+### Executor values and derived `kind`
+
+The `executors` field must contain exactly one element. `kind` is computed at parse time and never stored in YAML:
+
+| `executors[0]` | Derived `kind` | Where the module runs |
+|----------------|----------------|-----------------------|
+| `steward` | `steward` | Endpoint agent (local resources) |
+| `outpost` | `outpost` | Proxy/network probe component |
+| `controller` | `workflow` | Central controller (SaaS operations) |
+
+### `behavioral_envelope` sub-fields
+
+| Sub-field | Type | Description |
+|-----------|------|-------------|
+| `shells_out_to` | list | Shells or interpreters the module invokes |
+| `writes_paths` | list | File-system paths the module writes |
+| `reads_paths` | list | File-system paths the module reads |
+| `network_egress` | list | External hosts/ports the module connects to |
+| `lolbin_usage_justification` | string | Why a living-off-the-land binary is needed |
 
 ## Available Modules
 
@@ -35,8 +69,12 @@ modules/
 - `file` - File content and attributes
 - `firewall` - Firewall rules and policies
 - `package` - Software package management
+- `script` - Cross-platform script execution
+- `service` - OS service state management
 - `acme` - ACME/Let's Encrypt certificate management
-- `activedirectory` - Active Directory integration
+- `activedirectory` - Local Active Directory integration (steward)
+- `network_activedirectory` - Network-based AD integration via LDAP (outpost)
+- `hyperv` - Remote Hyper-V management via WinRM
 - `m365/*` - Microsoft 365 modules (auth, conditional access, Entra groups/users/apps/admin units, Intune policy, GDAP)
 
 ## Documentation

--- a/features/modules/acme/module.yaml
+++ b/features/modules/acme/module.yaml
@@ -6,11 +6,10 @@ description: >
   HTTP-01 and DNS-01 challenge types. Uses lego library
   for pure-Go, cross-platform certificate management.
 
+publisher: cfgms
+
 executors:
   - steward
-  - controller
-
-dependencies: []
 
 requirements:
   os: [linux, darwin, windows]

--- a/features/modules/activedirectory/module.yaml
+++ b/features/modules/activedirectory/module.yaml
@@ -2,6 +2,8 @@ name: activedirectory
 version: "1.0.0"
 description: "Local Active Directory integration module using Windows system context for secure, credential-free AD management on domain controllers"
 
+publisher: cfgms
+
 # Supported execution environments
 executors:
   - steward  # Local AD management using Windows system context APIs
@@ -73,13 +75,6 @@ supported_operations:
     - update_group
     - delete_group
 
-# Dependencies
-dependencies:
-  system:
-    windows:
-      - "Active Directory Domain Services"
-      - "Windows Management Framework"
-
 # Health checks
 health_checks:
   - name: "system_context"
@@ -96,7 +91,7 @@ monitoring:
     - "ad_local_request_duration_seconds"
     - "ad_local_errors_total"
     - "ad_dna_collection_status"
-  
+
 # Security considerations
 security:
   sensitive_fields: []  # No stored credentials

--- a/features/modules/compatibility_test.go
+++ b/features/modules/compatibility_test.go
@@ -19,6 +19,8 @@ func TestDefaultCompatibilityMatrix_RecordCompatibility(t *testing.T) {
 		Name:        "test-module",
 		Version:     "1.0.0",
 		Description: "Test module",
+		Publisher:   "cfgms",
+		Executors:   []string{"steward"},
 	}
 	require.NoError(t, registry.RegisterVersion(metadata))
 
@@ -117,6 +119,8 @@ func TestDefaultCompatibilityMatrix_GetCompatibility(t *testing.T) {
 		Name:        "test-module",
 		Version:     "1.0.0",
 		Description: "Test module",
+		Publisher:   "cfgms",
+		Executors:   []string{"steward"},
 	}
 	require.NoError(t, registry.RegisterVersion(metadata))
 
@@ -158,6 +162,8 @@ func TestDefaultCompatibilityMatrix_UpdateCompatibility(t *testing.T) {
 		Name:        "test-module",
 		Version:     "1.0.0",
 		Description: "Test module",
+		Publisher:   "cfgms",
+		Executors:   []string{"steward"},
 	}
 	require.NoError(t, registry.RegisterVersion(metadata))
 
@@ -203,6 +209,8 @@ func TestDefaultCompatibilityMatrix_RemoveCompatibility(t *testing.T) {
 		Name:        "test-module",
 		Version:     "1.0.0",
 		Description: "Test module",
+		Publisher:   "cfgms",
+		Executors:   []string{"steward"},
 	}
 	require.NoError(t, registry.RegisterVersion(metadata))
 
@@ -255,6 +263,8 @@ func TestDefaultCompatibilityMatrix_CheckCrossModuleCompatibility(t *testing.T) 
 			Name:        module.name,
 			Version:     module.version,
 			Description: "Test module",
+			Publisher:   "cfgms",
+			Executors:   []string{"steward"},
 		}
 		require.NoError(t, registry.RegisterVersion(metadata))
 
@@ -352,6 +362,8 @@ func TestDefaultCompatibilityMatrix_FindCompatibleVersionSet(t *testing.T) {
 				Name:        moduleName,
 				Version:     version,
 				Description: "Test module",
+				Publisher:   "cfgms",
+				Executors:   []string{"steward"},
 			}
 			require.NoError(t, registry.RegisterVersion(metadata))
 		}
@@ -410,11 +422,15 @@ func TestDefaultCompatibilityMatrix_BreakingChangeAnalysis(t *testing.T) {
 		Name:        "test-module",
 		Version:     "1.0.0",
 		Description: "Test module",
+		Publisher:   "cfgms",
+		Executors:   []string{"steward"},
 	}
 	metadata2 := &ModuleMetadata{
 		Name:        "test-module",
 		Version:     "2.0.0",
 		Description: "Test module v2",
+		Publisher:   "cfgms",
+		Executors:   []string{"steward"},
 	}
 	require.NoError(t, registry.RegisterVersion(metadata1))
 	require.NoError(t, registry.RegisterVersion(metadata2))
@@ -496,6 +512,8 @@ func TestDefaultCompatibilityMatrix_APIChanges(t *testing.T) {
 		Name:        "test-module",
 		Version:     "1.1.0",
 		Description: "Test module",
+		Publisher:   "cfgms",
+		Executors:   []string{"steward"},
 	}
 	require.NoError(t, registry.RegisterVersion(metadata))
 
@@ -552,6 +570,8 @@ func TestDefaultCompatibilityMatrix_CompatibilityQueries(t *testing.T) {
 		Name:        "test-module",
 		Version:     "1.0.0",
 		Description: "Test module",
+		Publisher:   "cfgms",
+		Executors:   []string{"steward"},
 	}
 	require.NoError(t, registry.RegisterVersion(metadata))
 
@@ -588,9 +608,9 @@ func TestDefaultCompatibilityMatrix_IsCompatible(t *testing.T) {
 	matrix := NewDefaultCompatibilityMatrix(registry)
 
 	// Register test versions
-	metadata1 := &ModuleMetadata{Name: "module-a", Version: "1.0.0", Description: "Test"}
-	metadata2 := &ModuleMetadata{Name: "module-a", Version: "1.1.0", Description: "Test"}
-	metadata3 := &ModuleMetadata{Name: "module-b", Version: "2.0.0", Description: "Test"}
+	metadata1 := &ModuleMetadata{Name: "module-a", Version: "1.0.0", Description: "Test", Publisher: "cfgms", Executors: []string{"steward"}}
+	metadata2 := &ModuleMetadata{Name: "module-a", Version: "1.1.0", Description: "Test", Publisher: "cfgms", Executors: []string{"steward"}}
+	metadata3 := &ModuleMetadata{Name: "module-b", Version: "2.0.0", Description: "Test", Publisher: "cfgms", Executors: []string{"steward"}}
 
 	require.NoError(t, registry.RegisterVersion(metadata1))
 	require.NoError(t, registry.RegisterVersion(metadata2))
@@ -696,6 +716,8 @@ func TestDefaultCompatibilityMatrix_GetMatrixStatus(t *testing.T) {
 				Name:        module.name,
 				Version:     module.version,
 				Description: "Test module",
+				Publisher:   "cfgms",
+				Executors:   []string{"steward"},
 			}
 			require.NoError(t, registry.RegisterVersion(metadata))
 
@@ -839,6 +861,8 @@ func BenchmarkCompatibilityMatrix_RecordCompatibility(b *testing.B) {
 			Name:        fmt.Sprintf("bench-module-%d", i),
 			Version:     "1.0.0",
 			Description: "Benchmark module",
+			Publisher:   "cfgms",
+			Executors:   []string{"steward"},
 		}
 		_ = registry.RegisterVersion(metadata) // Ignore error in test setup
 	}

--- a/features/modules/directory/module.yaml
+++ b/features/modules/directory/module.yaml
@@ -2,6 +2,8 @@ name: directory
 version: 0.1.0
 description: Manages system directories, providing functionality to create, modify, and verify directory configurations
 
+publisher: cfgms
+
 # Supported execution environments
 executors:
   - steward  # Local directory management on steward systems
@@ -13,4 +15,4 @@ interfaces:
 security:
   requires_root: false
   capabilities: []
-  ports: [] 
+  ports: []

--- a/features/modules/factory_lifecycle_test.go
+++ b/features/modules/factory_lifecycle_test.go
@@ -409,8 +409,10 @@ func TestLifecycleAwareModuleFactory_Integration(t *testing.T) {
 
 	// Register module in module registry
 	testMetadata := &ModuleMetadata{
-		Name:    "test-module",
-		Version: "1.0.0",
+		Name:      "test-module",
+		Version:   "1.0.0",
+		Publisher: "cfgms",
+		Executors: []string{"steward"},
 	}
 	err := moduleRegistry.RegisterModule(testMetadata, testModule)
 	if err != nil {

--- a/features/modules/file/module.yaml
+++ b/features/modules/file/module.yaml
@@ -4,11 +4,11 @@ description: >
   Manages file resources on the system.
   Supports reading, writing, and validating file contents.
 
+publisher: cfgms
+
 # Supported execution environments
 executors:
   - steward  # Local file management on steward systems
-
-dependencies: []
 
 requirements:
   os: [windows, linux, darwin]
@@ -28,4 +28,4 @@ security:
 
 documentation:
   api: "docs/api.md"
-  examples: "docs/examples/" 
+  examples: "docs/examples/"

--- a/features/modules/firewall/module.yaml
+++ b/features/modules/firewall/module.yaml
@@ -2,6 +2,8 @@ name: firewall
 description: Manages firewall rules across different operating systems
 version: 0.1.0
 
+publisher: cfgms
+
 # Supported execution environments
 executors:
   - steward  # Local firewall management on steward systems
@@ -10,11 +12,6 @@ author: CFGMS Team
 license: MIT
 platforms:
   - linux
-dependencies:
-  - name: yaml
-    version: v3
-  - name: net
-    version: standard
 schema: schema.yaml
 interfaces:
   - Get
@@ -23,4 +20,4 @@ interfaces:
 security:
   requires_root: true
   capabilities: []
-  ports: [] 
+  ports: []

--- a/features/modules/hyperv/module.yaml
+++ b/features/modules/hyperv/module.yaml
@@ -2,9 +2,10 @@ name: hyperv
 description: Remote Hyper-V management via WinRM — manages VMs, snapshots, and virtual switches on Windows Server hosts
 version: 0.1.0
 
+publisher: cfgms
+
 executors:
   - steward
-  - outpost
 
 author: CFGMS Team
 license: AGPL-3.0

--- a/features/modules/hyperv/module_test.go
+++ b/features/modules/hyperv/module_test.go
@@ -635,8 +635,10 @@ func TestBuildInvokeCommand_SingleArg(t *testing.T) {
 func TestModule_RegistrationRoundtrip(t *testing.T) {
 	registry := modules.NewModuleRegistry()
 	metadata := &modules.ModuleMetadata{
-		Name:    "hyperv",
-		Version: "0.1.0",
+		Name:      "hyperv",
+		Version:   "0.1.0",
+		Publisher: "cfgms",
+		Executors: []string{"steward"},
 	}
 
 	err := registry.RegisterModule(metadata, New(noopDetector{}))
@@ -661,8 +663,8 @@ func TestBuildInvokeCommand_MultipleArgs_SortedOrder(t *testing.T) {
 
 // ─── module.yaml executor declaration test ────────────────────────────────────
 
-// TestModuleYAMLHasStewardExecutor verifies that module.yaml declares both
-// "steward" and "outpost" in its executors list.
+// TestModuleYAMLHasStewardExecutor verifies that module.yaml declares exactly
+// "steward" as its single executor (single-executor invariant from ADR-006).
 //
 // executors is semantic metadata only — the steward loader does not gate on
 // this field (discovery.go:51 has no Executors).
@@ -680,6 +682,6 @@ func TestModuleYAMLHasStewardExecutor(t *testing.T) {
 	var schema moduleYAMLSchema
 	require.NoError(t, yaml.Unmarshal(data, &schema), "module.yaml must be valid YAML")
 
-	assert.Contains(t, schema.Executors, "steward", "executors must include steward")
-	assert.Contains(t, schema.Executors, "outpost", "executors must include outpost")
+	require.Len(t, schema.Executors, 1, "executors must contain exactly one element")
+	assert.Equal(t, "steward", schema.Executors[0], "executor must be steward")
 }

--- a/features/modules/manager_test.go
+++ b/features/modules/manager_test.go
@@ -286,14 +286,16 @@ func TestModuleLifecycleManager_StartStopAllModules(t *testing.T) {
 	baseModule := &mockLifecycleModule{
 		health: HealthStatus{Status: HealthStateHealthy, Timestamp: time.Now()},
 	}
-	baseMetadata := &ModuleMetadata{Name: "base", Version: "1.0.0"}
+	baseMetadata := &ModuleMetadata{Name: "base", Version: "1.0.0", Publisher: "cfgms", Executors: []string{"steward"}}
 
 	appModule := &mockLifecycleModule{
 		health: HealthStatus{Status: HealthStateHealthy, Timestamp: time.Now()},
 	}
 	appMetadata := &ModuleMetadata{
-		Name:    "app",
-		Version: "1.0.0",
+		Name:      "app",
+		Version:   "1.0.0",
+		Publisher: "cfgms",
+		Executors: []string{"steward"},
 		ModuleDependencies: []ModuleDependency{
 			{Name: "base", Version: "1.0.0"},
 		},

--- a/features/modules/metadata.go
+++ b/features/modules/metadata.go
@@ -21,13 +21,17 @@ type ModuleMetadata struct {
 	Description string `yaml:"description" json:"description"`
 	Author      string `yaml:"author,omitempty" json:"author,omitempty"`
 	License     string `yaml:"license,omitempty" json:"license,omitempty"`
+	Publisher   string `yaml:"publisher,omitempty" json:"publisher,omitempty"`
 
-	// Module dependencies (NEW - for inter-module dependencies)
+	// Execution environment — exactly one value required
+	// Valid values: steward, outpost, controller
+	Executors []string `yaml:"executors,omitempty" json:"executors,omitempty"`
+	// Kind is derived from Executors[0] at parse time, never read from YAML.
+	// steward→"steward", outpost→"outpost", controller→"workflow"
+	Kind string `yaml:"-" json:"kind,omitempty"`
+
+	// Module dependencies (for inter-module dependencies)
 	ModuleDependencies []ModuleDependency `yaml:"module_dependencies,omitempty" json:"module_dependencies,omitempty"`
-
-	// Legacy dependencies field (for Go package dependencies)
-	// This maintains backwards compatibility with existing modules
-	Dependencies []interface{} `yaml:"dependencies,omitempty" json:"dependencies,omitempty"`
 
 	// Platform and system requirements
 	Requirements *ModuleRequirements `yaml:"requirements,omitempty" json:"requirements,omitempty"`
@@ -44,6 +48,18 @@ type ModuleMetadata struct {
 
 	// Schema file reference for configuration validation
 	Schema string `yaml:"schema,omitempty" json:"schema,omitempty"`
+
+	// BehavioralEnvelope documents what the module does at runtime
+	BehavioralEnvelope *BehavioralEnvelope `yaml:"behavioral_envelope,omitempty" json:"behavioral_envelope,omitempty"`
+}
+
+// BehavioralEnvelope documents the runtime behavior of a module for security auditing
+type BehavioralEnvelope struct {
+	ShellsOutTo              []string `yaml:"shells_out_to,omitempty" json:"shells_out_to,omitempty"`
+	WritesPaths              []string `yaml:"writes_paths,omitempty" json:"writes_paths,omitempty"`
+	ReadsPaths               []string `yaml:"reads_paths,omitempty" json:"reads_paths,omitempty"`
+	NetworkEgress            []string `yaml:"network_egress,omitempty" json:"network_egress,omitempty"`
+	LolbinUsageJustification string   `yaml:"lolbin_usage_justification,omitempty" json:"lolbin_usage_justification,omitempty"`
 }
 
 // ModuleRequirements defines system requirements for a module
@@ -110,6 +126,16 @@ func ParseModuleMetadata(reader io.Reader) (*ModuleMetadata, error) {
 		return nil, fmt.Errorf("invalid module version '%s': %v", metadata.Version, err)
 	}
 
+	// Validate executors and derive kind
+	if err := validateAndDeriveKind(&metadata); err != nil {
+		return nil, err
+	}
+
+	// Validate publisher
+	if metadata.Publisher == "" {
+		return nil, fmt.Errorf("publisher is required")
+	}
+
 	// Validate dependency version constraints
 	for i, dep := range metadata.ModuleDependencies {
 		if dep.Name == "" {
@@ -126,6 +152,28 @@ func ParseModuleMetadata(reader io.Reader) (*ModuleMetadata, error) {
 	}
 
 	return &metadata, nil
+}
+
+// validateAndDeriveKind enforces the single-executor invariant and sets Kind.
+// steward→"steward", outpost→"outpost", controller→"workflow"
+func validateAndDeriveKind(m *ModuleMetadata) error {
+	if len(m.Executors) == 0 {
+		return fmt.Errorf("executors is required: must contain exactly one value (steward, outpost, or controller)")
+	}
+	if len(m.Executors) > 1 {
+		return fmt.Errorf("executors must contain exactly one element, got %d: %v", len(m.Executors), m.Executors)
+	}
+	switch m.Executors[0] {
+	case "steward":
+		m.Kind = "steward"
+	case "outpost":
+		m.Kind = "outpost"
+	case "controller":
+		m.Kind = "workflow"
+	default:
+		return fmt.Errorf("invalid executor %q: must be steward, outpost, or controller", m.Executors[0])
+	}
+	return nil
 }
 
 // SaveModuleMetadata saves module metadata to a module.yaml file
@@ -173,6 +221,16 @@ func (m *ModuleMetadata) Validate() error {
 	// Validate version format
 	if _, err := ParseVersion(m.Version); err != nil {
 		return fmt.Errorf("invalid module version '%s': %v", m.Version, err)
+	}
+
+	// Validate executors and derive Kind as a side effect
+	if err := validateAndDeriveKind(m); err != nil {
+		return err
+	}
+
+	// Validate publisher
+	if m.Publisher == "" {
+		return fmt.Errorf("publisher is required")
 	}
 
 	// Validate dependency version constraints
@@ -266,18 +324,20 @@ func (m *ModuleMetadata) Clone() *ModuleMetadata {
 		Author:      m.Author,
 		License:     m.License,
 		Schema:      m.Schema,
+		Publisher:   m.Publisher,
+		Kind:        m.Kind,
+	}
+
+	// Deep copy executors
+	if m.Executors != nil {
+		clone.Executors = make([]string, len(m.Executors))
+		copy(clone.Executors, m.Executors)
 	}
 
 	// Deep copy module dependencies
 	if m.ModuleDependencies != nil {
 		clone.ModuleDependencies = make([]ModuleDependency, len(m.ModuleDependencies))
 		copy(clone.ModuleDependencies, m.ModuleDependencies)
-	}
-
-	// Deep copy legacy dependencies
-	if m.Dependencies != nil {
-		clone.Dependencies = make([]interface{}, len(m.Dependencies))
-		copy(clone.Dependencies, m.Dependencies)
 	}
 
 	// Deep copy platforms
@@ -327,6 +387,28 @@ func (m *ModuleMetadata) Clone() *ModuleMetadata {
 			API:      m.Documentation.API,
 			Examples: m.Documentation.Examples,
 			README:   m.Documentation.README,
+		}
+	}
+
+	if m.BehavioralEnvelope != nil {
+		clone.BehavioralEnvelope = &BehavioralEnvelope{
+			LolbinUsageJustification: m.BehavioralEnvelope.LolbinUsageJustification,
+		}
+		if m.BehavioralEnvelope.ShellsOutTo != nil {
+			clone.BehavioralEnvelope.ShellsOutTo = make([]string, len(m.BehavioralEnvelope.ShellsOutTo))
+			copy(clone.BehavioralEnvelope.ShellsOutTo, m.BehavioralEnvelope.ShellsOutTo)
+		}
+		if m.BehavioralEnvelope.WritesPaths != nil {
+			clone.BehavioralEnvelope.WritesPaths = make([]string, len(m.BehavioralEnvelope.WritesPaths))
+			copy(clone.BehavioralEnvelope.WritesPaths, m.BehavioralEnvelope.WritesPaths)
+		}
+		if m.BehavioralEnvelope.ReadsPaths != nil {
+			clone.BehavioralEnvelope.ReadsPaths = make([]string, len(m.BehavioralEnvelope.ReadsPaths))
+			copy(clone.BehavioralEnvelope.ReadsPaths, m.BehavioralEnvelope.ReadsPaths)
+		}
+		if m.BehavioralEnvelope.NetworkEgress != nil {
+			clone.BehavioralEnvelope.NetworkEgress = make([]string, len(m.BehavioralEnvelope.NetworkEgress))
+			copy(clone.BehavioralEnvelope.NetworkEgress, m.BehavioralEnvelope.NetworkEgress)
 		}
 	}
 

--- a/features/modules/metadata_test.go
+++ b/features/modules/metadata_test.go
@@ -21,6 +21,9 @@ version: 1.2.3
 description: A test module
 author: Test Author
 license: MIT
+publisher: cfgms
+executors:
+  - steward
 module_dependencies:
   - name: dependency1
     version: ">=1.0.0"
@@ -59,6 +62,18 @@ security:
 
 	if metadata.Version != "1.2.3" {
 		t.Errorf("Version = %v, expected 1.2.3", metadata.Version)
+	}
+
+	if metadata.Publisher != "cfgms" {
+		t.Errorf("Publisher = %v, expected cfgms", metadata.Publisher)
+	}
+
+	if len(metadata.Executors) != 1 || metadata.Executors[0] != "steward" {
+		t.Errorf("Executors = %v, expected [steward]", metadata.Executors)
+	}
+
+	if metadata.Kind != "steward" {
+		t.Errorf("Kind = %v, expected steward", metadata.Kind)
 	}
 
 	if len(metadata.ModuleDependencies) != 2 {
@@ -103,7 +118,10 @@ func TestParseModuleMetadata(t *testing.T) {
 		{
 			name: "valid minimal metadata",
 			yaml: `name: test
-version: 1.0.0`,
+version: 1.0.0
+publisher: cfgms
+executors:
+  - steward`,
 			expectError: false,
 			validate: func(m *ModuleMetadata) error {
 				if m.Name != "test" {
@@ -111,6 +129,9 @@ version: 1.0.0`,
 				}
 				if m.Version != "1.0.0" {
 					t.Errorf("Version = %v, expected 1.0.0", m.Version)
+				}
+				if m.Kind != "steward" {
+					t.Errorf("Kind = %v, expected steward", m.Kind)
 				}
 				return nil
 			},
@@ -135,6 +156,9 @@ version: invalid`,
 			name: "invalid dependency version constraint",
 			yaml: `name: test
 version: 1.0.0
+publisher: cfgms
+executors:
+  - steward
 module_dependencies:
   - name: dep1
     version: "invalid_constraint"`,
@@ -144,6 +168,9 @@ module_dependencies:
 			name: "dependency without name",
 			yaml: `name: test
 version: 1.0.0
+publisher: cfgms
+executors:
+  - steward
 module_dependencies:
   - version: "1.0.0"`,
 			expectError: true,
@@ -155,6 +182,9 @@ version: 2.1.0-alpha.1
 description: A complex module with all features
 author: CFGMS Team
 license: Apache-2.0
+publisher: cfgms
+executors:
+  - steward
 module_dependencies:
   - name: base
     version: "^1.0.0"
@@ -200,6 +230,76 @@ schema: schema.yaml`,
 				if !m.Security.RequiresRoot {
 					t.Error("Security.RequiresRoot should be true")
 				}
+				if m.Publisher != "cfgms" {
+					t.Errorf("Publisher = %v, expected cfgms", m.Publisher)
+				}
+				if m.Kind != "steward" {
+					t.Errorf("Kind = %v, expected steward", m.Kind)
+				}
+				return nil
+			},
+		},
+		{
+			name: "missing executors",
+			yaml: `name: test
+version: 1.0.0
+publisher: cfgms`,
+			expectError: true,
+		},
+		{
+			name: "multiple executors rejected",
+			yaml: `name: test
+version: 1.0.0
+publisher: cfgms
+executors:
+  - steward
+  - outpost`,
+			expectError: true,
+		},
+		{
+			name: "invalid executor value",
+			yaml: `name: test
+version: 1.0.0
+publisher: cfgms
+executors:
+  - agent`,
+			expectError: true,
+		},
+		{
+			name: "missing publisher",
+			yaml: `name: test
+version: 1.0.0
+executors:
+  - steward`,
+			expectError: true,
+		},
+		{
+			name: "outpost executor derives correct kind",
+			yaml: `name: test
+version: 1.0.0
+publisher: cfgms
+executors:
+  - outpost`,
+			expectError: false,
+			validate: func(m *ModuleMetadata) error {
+				if m.Kind != "outpost" {
+					t.Errorf("Kind = %v, expected outpost", m.Kind)
+				}
+				return nil
+			},
+		},
+		{
+			name: "controller executor derives workflow kind",
+			yaml: `name: test
+version: 1.0.0
+publisher: cfgms
+executors:
+  - controller`,
+			expectError: false,
+			validate: func(m *ModuleMetadata) error {
+				if m.Kind != "workflow" {
+					t.Errorf("Kind = %v, expected workflow for controller executor", m.Kind)
+				}
 				return nil
 			},
 		},
@@ -223,9 +323,106 @@ schema: schema.yaml`,
 			}
 
 			if tt.validate != nil {
-				_ = tt.validate(metadata) // Ignore error in test validation
+				if err := tt.validate(metadata); err != nil {
+					t.Errorf("validate function returned error: %v", err)
+				}
 			}
 		})
+	}
+}
+
+func TestParseModuleMetadata_BehavioralEnvelopeRoundTrip(t *testing.T) {
+	input := `name: test-module
+version: 1.0.0
+publisher: cfgms
+executors:
+  - steward
+behavioral_envelope:
+  shells_out_to:
+    - /bin/sh
+    - /usr/bin/bash
+  writes_paths:
+    - /etc/config
+  reads_paths:
+    - /etc/config
+    - /var/run/state
+  network_egress:
+    - api.example.com:443
+  lolbin_usage_justification: "required for system management"
+`
+
+	reader := strings.NewReader(input)
+	metadata, err := ParseModuleMetadata(reader)
+	if err != nil {
+		t.Fatalf("unexpected parse error: %v", err)
+	}
+
+	if metadata.BehavioralEnvelope == nil {
+		t.Fatal("BehavioralEnvelope should not be nil")
+	}
+
+	be := metadata.BehavioralEnvelope
+	if len(be.ShellsOutTo) != 2 {
+		t.Errorf("ShellsOutTo length = %d, expected 2", len(be.ShellsOutTo))
+	}
+	if be.ShellsOutTo[0] != "/bin/sh" {
+		t.Errorf("ShellsOutTo[0] = %v, expected /bin/sh", be.ShellsOutTo[0])
+	}
+	if len(be.WritesPaths) != 1 || be.WritesPaths[0] != "/etc/config" {
+		t.Errorf("WritesPaths = %v, expected [/etc/config]", be.WritesPaths)
+	}
+	if len(be.ReadsPaths) != 2 {
+		t.Errorf("ReadsPaths length = %d, expected 2", len(be.ReadsPaths))
+	}
+	if len(be.NetworkEgress) != 1 || be.NetworkEgress[0] != "api.example.com:443" {
+		t.Errorf("NetworkEgress = %v, expected [api.example.com:443]", be.NetworkEgress)
+	}
+	if be.LolbinUsageJustification != "required for system management" {
+		t.Errorf("LolbinUsageJustification = %v, expected 'required for system management'", be.LolbinUsageJustification)
+	}
+
+	// Verify round-trip via YAML: kind must not appear in serialized output
+	yamlBytes, err := metadata.ToYAML()
+	if err != nil {
+		t.Fatalf("ToYAML() error: %v", err)
+	}
+
+	yamlStr := string(yamlBytes)
+	if strings.Contains(yamlStr, "kind:") {
+		t.Error("serialized YAML must not contain 'kind:' — kind is derived, not stored")
+	}
+
+	// Deserialize and verify behavioral_envelope survives the round-trip
+	var reparsed ModuleMetadata
+	if err := yaml.Unmarshal(yamlBytes, &reparsed); err != nil {
+		t.Fatalf("failed to unmarshal round-tripped YAML: %v", err)
+	}
+	if reparsed.BehavioralEnvelope == nil {
+		t.Fatal("BehavioralEnvelope missing after round-trip")
+	}
+	if len(reparsed.BehavioralEnvelope.ShellsOutTo) != 2 {
+		t.Errorf("ShellsOutTo after round-trip = %v, expected 2 entries", reparsed.BehavioralEnvelope.ShellsOutTo)
+	}
+}
+
+func TestParseModuleMetadata_KindNotParsedFromYAML(t *testing.T) {
+	// kind: field in YAML must be ignored; Kind is always derived from Executors[0]
+	input := `name: test
+version: 1.0.0
+publisher: cfgms
+executors:
+  - steward
+kind: workflow
+`
+	reader := strings.NewReader(input)
+	metadata, err := ParseModuleMetadata(reader)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Kind must be derived from executors[0]="steward", not read from YAML ("workflow")
+	if metadata.Kind != "steward" {
+		t.Errorf("Kind = %v, expected steward (derived), not the YAML value 'workflow'", metadata.Kind)
 	}
 }
 
@@ -237,6 +434,9 @@ func TestModuleMetadata_SaveModuleMetadata(t *testing.T) {
 		Name:        "save-test",
 		Version:     "1.0.0",
 		Description: "Test saving metadata",
+		Publisher:   "cfgms",
+		Executors:   []string{"steward"},
+		Kind:        "steward",
 		ModuleDependencies: []ModuleDependency{
 			{Name: "dep1", Version: "^1.0.0"},
 		},
@@ -268,6 +468,15 @@ func TestModuleMetadata_SaveModuleMetadata(t *testing.T) {
 		t.Errorf("Version mismatch after round-trip: got %v, expected %v", loaded.Version, metadata.Version)
 	}
 
+	if loaded.Publisher != "cfgms" {
+		t.Errorf("Publisher mismatch after round-trip: got %v, expected cfgms", loaded.Publisher)
+	}
+
+	// Kind is derived from executors on load, not stored in YAML
+	if loaded.Kind != "steward" {
+		t.Errorf("Kind after round-trip: got %v, expected steward (derived from executors)", loaded.Kind)
+	}
+
 	if len(loaded.ModuleDependencies) != len(metadata.ModuleDependencies) {
 		t.Errorf("Dependencies length mismatch after round-trip: got %v, expected %v",
 			len(loaded.ModuleDependencies), len(metadata.ModuleDependencies))
@@ -276,8 +485,10 @@ func TestModuleMetadata_SaveModuleMetadata(t *testing.T) {
 
 func TestModuleMetadata_ToYAML(t *testing.T) {
 	metadata := &ModuleMetadata{
-		Name:    "yaml-test",
-		Version: "1.0.0",
+		Name:      "yaml-test",
+		Version:   "1.0.0",
+		Publisher: "cfgms",
+		Executors: []string{"steward"},
 		ModuleDependencies: []ModuleDependency{
 			{Name: "dep1", Version: "^1.0.0"},
 		},
@@ -327,42 +538,76 @@ func TestModuleMetadata_Validate(t *testing.T) {
 		name        string
 		metadata    *ModuleMetadata
 		expectError bool
+		wantKind    string
 	}{
 		{
 			name: "valid metadata",
 			metadata: &ModuleMetadata{
-				Name:    "valid",
-				Version: "1.0.0",
+				Name:      "valid",
+				Version:   "1.0.0",
+				Publisher: "cfgms",
+				Executors: []string{"steward"},
 			},
 			expectError: false,
+			wantKind:    "steward",
+		},
+		{
+			name: "valid outpost executor",
+			metadata: &ModuleMetadata{
+				Name:      "valid",
+				Version:   "1.0.0",
+				Publisher: "cfgms",
+				Executors: []string{"outpost"},
+			},
+			expectError: false,
+			wantKind:    "outpost",
+		},
+		{
+			name: "valid controller executor",
+			metadata: &ModuleMetadata{
+				Name:      "valid",
+				Version:   "1.0.0",
+				Publisher: "cfgms",
+				Executors: []string{"controller"},
+			},
+			expectError: false,
+			wantKind:    "workflow",
 		},
 		{
 			name: "missing name",
 			metadata: &ModuleMetadata{
-				Version: "1.0.0",
+				Version:   "1.0.0",
+				Publisher: "cfgms",
+				Executors: []string{"steward"},
 			},
 			expectError: true,
 		},
 		{
 			name: "missing version",
 			metadata: &ModuleMetadata{
-				Name: "test",
+				Name:      "test",
+				Publisher: "cfgms",
+				Executors: []string{"steward"},
 			},
 			expectError: true,
 		},
 		{
 			name: "invalid version",
 			metadata: &ModuleMetadata{
-				Name:    "test",
-				Version: "invalid",
+				Name:      "test",
+				Version:   "invalid",
+				Publisher: "cfgms",
+				Executors: []string{"steward"},
 			},
 			expectError: true,
 		},
 		{
 			name: "invalid dependency",
 			metadata: &ModuleMetadata{
-				Name:    "test",
-				Version: "1.0.0",
+				Name:      "test",
+				Version:   "1.0.0",
+				Publisher: "cfgms",
+				Executors: []string{"steward"},
 				ModuleDependencies: []ModuleDependency{
 					{Name: "", Version: "1.0.0"},
 				},
@@ -372,11 +617,51 @@ func TestModuleMetadata_Validate(t *testing.T) {
 		{
 			name: "invalid dependency version constraint",
 			metadata: &ModuleMetadata{
-				Name:    "test",
-				Version: "1.0.0",
+				Name:      "test",
+				Version:   "1.0.0",
+				Publisher: "cfgms",
+				Executors: []string{"steward"},
 				ModuleDependencies: []ModuleDependency{
 					{Name: "dep", Version: "invalid_constraint"},
 				},
+			},
+			expectError: true,
+		},
+		{
+			name: "missing executors",
+			metadata: &ModuleMetadata{
+				Name:      "test",
+				Version:   "1.0.0",
+				Publisher: "cfgms",
+			},
+			expectError: true,
+		},
+		{
+			name: "multiple executors rejected",
+			metadata: &ModuleMetadata{
+				Name:      "test",
+				Version:   "1.0.0",
+				Publisher: "cfgms",
+				Executors: []string{"steward", "outpost"},
+			},
+			expectError: true,
+		},
+		{
+			name: "invalid executor value",
+			metadata: &ModuleMetadata{
+				Name:      "test",
+				Version:   "1.0.0",
+				Publisher: "cfgms",
+				Executors: []string{"agent"},
+			},
+			expectError: true,
+		},
+		{
+			name: "missing publisher",
+			metadata: &ModuleMetadata{
+				Name:      "test",
+				Version:   "1.0.0",
+				Executors: []string{"steward"},
 			},
 			expectError: true,
 		},
@@ -393,14 +678,22 @@ func TestModuleMetadata_Validate(t *testing.T) {
 			if !tt.expectError && err != nil {
 				t.Errorf("unexpected error: %v", err)
 			}
+
+			if !tt.expectError && err == nil && tt.wantKind != "" {
+				if tt.metadata.Kind != tt.wantKind {
+					t.Errorf("Kind = %q, want %q after Validate()", tt.metadata.Kind, tt.wantKind)
+				}
+			}
 		})
 	}
 }
 
 func TestModuleMetadata_DependencyMethods(t *testing.T) {
 	metadata := &ModuleMetadata{
-		Name:    "dependency-test",
-		Version: "1.0.0",
+		Name:      "dependency-test",
+		Version:   "1.0.0",
+		Publisher: "cfgms",
+		Executors: []string{"steward"},
 		ModuleDependencies: []ModuleDependency{
 			{Name: "dep1", Version: "^1.0.0"},
 			{Name: "dep2", Version: "~2.0.0", Optional: true},
@@ -484,6 +777,9 @@ func TestModuleMetadata_Clone(t *testing.T) {
 		Author:      "Test Author",
 		License:     "MIT",
 		Schema:      "schema.yaml",
+		Publisher:   "cfgms",
+		Executors:   []string{"steward"},
+		Kind:        "steward",
 		ModuleDependencies: []ModuleDependency{
 			{Name: "dep1", Version: "^1.0.0"},
 		},
@@ -505,6 +801,13 @@ func TestModuleMetadata_Clone(t *testing.T) {
 			Examples: "examples/",
 			README:   "README.md",
 		},
+		BehavioralEnvelope: &BehavioralEnvelope{
+			ShellsOutTo:              []string{"/bin/sh"},
+			WritesPaths:              []string{"/etc/config"},
+			ReadsPaths:               []string{"/etc/config"},
+			NetworkEgress:            []string{"api.example.com:443"},
+			LolbinUsageJustification: "required",
+		},
 	}
 
 	// Clone the metadata
@@ -515,10 +818,28 @@ func TestModuleMetadata_Clone(t *testing.T) {
 		t.Errorf("Clone Name = %v, expected %v", clone.Name, original.Name)
 	}
 
+	if clone.Publisher != original.Publisher {
+		t.Errorf("Clone Publisher = %v, expected %v", clone.Publisher, original.Publisher)
+	}
+
+	if clone.Kind != original.Kind {
+		t.Errorf("Clone Kind = %v, expected %v", clone.Kind, original.Kind)
+	}
+
+	if len(clone.Executors) != len(original.Executors) || clone.Executors[0] != original.Executors[0] {
+		t.Errorf("Clone Executors = %v, expected %v", clone.Executors, original.Executors)
+	}
+
 	// Verify deep copy by modifying clone
 	clone.Name = "modified"
 	if original.Name == "modified" {
 		t.Error("Modifying clone affected original")
+	}
+
+	// Verify executors deep copy
+	clone.Executors[0] = "outpost"
+	if original.Executors[0] == "outpost" {
+		t.Error("Modifying clone executors affected original")
 	}
 
 	// Verify slice deep copy
@@ -542,6 +863,19 @@ func TestModuleMetadata_Clone(t *testing.T) {
 	if original.Documentation.API == "modified.md" {
 		t.Error("Modifying clone documentation affected original")
 	}
+
+	// Verify behavioral envelope deep copy
+	if clone.BehavioralEnvelope == nil {
+		t.Fatal("Clone BehavioralEnvelope should not be nil")
+	}
+	clone.BehavioralEnvelope.ShellsOutTo[0] = "/bin/zsh"
+	if original.BehavioralEnvelope.ShellsOutTo[0] == "/bin/zsh" {
+		t.Error("Modifying clone BehavioralEnvelope.ShellsOutTo affected original")
+	}
+	clone.BehavioralEnvelope.LolbinUsageJustification = "modified"
+	if original.BehavioralEnvelope.LolbinUsageJustification == "modified" {
+		t.Error("Modifying clone BehavioralEnvelope.LolbinUsageJustification affected original")
+	}
 }
 
 // Benchmark tests
@@ -553,6 +887,9 @@ func BenchmarkLoadModuleMetadata(b *testing.B) {
 	yamlContent := `name: benchmark-module
 version: 1.0.0
 description: Benchmark test module
+publisher: cfgms
+executors:
+  - steward
 module_dependencies:
   - name: dep1
     version: "^1.0.0"
@@ -578,8 +915,10 @@ interfaces:
 
 func BenchmarkModuleMetadata_ToYAML(b *testing.B) {
 	metadata := &ModuleMetadata{
-		Name:    "benchmark",
-		Version: "1.0.0",
+		Name:      "benchmark",
+		Version:   "1.0.0",
+		Publisher: "cfgms",
+		Executors: []string{"steward"},
 		ModuleDependencies: []ModuleDependency{
 			{Name: "dep1", Version: "^1.0.0"},
 			{Name: "dep2", Version: "~2.0.0"},
@@ -597,8 +936,10 @@ func BenchmarkModuleMetadata_ToYAML(b *testing.B) {
 
 func BenchmarkModuleMetadata_Clone(b *testing.B) {
 	metadata := &ModuleMetadata{
-		Name:    "benchmark",
-		Version: "1.0.0",
+		Name:      "benchmark",
+		Version:   "1.0.0",
+		Publisher: "cfgms",
+		Executors: []string{"steward"},
 		ModuleDependencies: []ModuleDependency{
 			{Name: "dep1", Version: "^1.0.0"},
 			{Name: "dep2", Version: "~2.0.0"},

--- a/features/modules/network_activedirectory/module.yaml
+++ b/features/modules/network_activedirectory/module.yaml
@@ -2,6 +2,8 @@ name: network_activedirectory
 version: "1.0.0"
 description: "Network-based Active Directory integration module for reading and managing AD objects via LDAP from remote systems (future Outpost component)"
 
+publisher: cfgms
+
 # Supported execution environments
 executors:
   - outpost  # Network-based AD management for remote domain controllers
@@ -91,17 +93,6 @@ supported_operations:
     - update_group
     - delete_group
 
-# Dependencies
-dependencies:
-  go_packages:
-    - "github.com/go-ldap/ldap/v3"
-    - "github.com/jcmturner/gokrb5/v8"
-  system:
-    windows:
-      - "Active Directory Domain Services"
-    linux:
-      - "Network connectivity to domain controller"
-
 # Health checks
 health_checks:
   - name: "ad_connectivity"
@@ -118,7 +109,7 @@ monitoring:
     - "ad_request_duration_seconds"
     - "ad_errors_total"
     - "ad_connection_status"
-  
+
 # Security considerations
 security:
   sensitive_fields:

--- a/features/modules/package/module.yaml
+++ b/features/modules/package/module.yaml
@@ -2,6 +2,8 @@ name: package
 description: Manages system packages across different package managers (apt, yum, brew, etc.)
 version: 0.1.0
 
+publisher: cfgms
+
 # Supported execution environments
 executors:
   - steward  # Local package management on steward systems
@@ -12,11 +14,6 @@ platforms:
   - linux
   - darwin
   - windows
-dependencies:
-  - name: yaml
-    version: v3
-  - name: exec
-    version: standard
 schema: schema.yaml
 interfaces:
   - Get
@@ -25,4 +22,4 @@ interfaces:
 security:
   requires_root: true
   capabilities: []
-  ports: [] 
+  ports: []

--- a/features/modules/registry_test.go
+++ b/features/modules/registry_test.go
@@ -108,7 +108,7 @@ func TestModuleRegistry_RegisterModule(t *testing.T) {
 		},
 		{
 			name:        "valid registration",
-			metadata:    &ModuleMetadata{Name: "valid", Version: "1.0.0"},
+			metadata:    newTestMetadata("valid", "1.0.0"),
 			instance:    &mockModule{name: "valid"},
 			expectError: false,
 		},
@@ -129,7 +129,7 @@ func TestModuleRegistry_RegisterModule(t *testing.T) {
 	}
 
 	// Test duplicate registration
-	metadata := &ModuleMetadata{Name: "duplicate", Version: "1.0.0"}
+	metadata := newTestMetadata("duplicate", "1.0.0")
 	instance := &mockModule{name: "duplicate"}
 
 	err := registry.RegisterModule(metadata, instance)
@@ -143,7 +143,7 @@ func TestModuleRegistry_RegisterModule(t *testing.T) {
 	}
 
 	// Test version conflict
-	conflictMetadata := &ModuleMetadata{Name: "duplicate", Version: "2.0.0"}
+	conflictMetadata := newTestMetadata("duplicate", "2.0.0")
 	err = registry.RegisterModule(conflictMetadata, instance)
 	if err == nil {
 		t.Error("expected error for version conflict")
@@ -160,12 +160,14 @@ func TestModuleRegistry_UnregisterModule(t *testing.T) {
 	}
 
 	// Register modules with dependencies
-	baseMetadata := &ModuleMetadata{Name: "base", Version: "1.0.0"}
+	baseMetadata := newTestMetadata("base", "1.0.0")
 	baseInstance := &mockModule{name: "base"}
 
 	appMetadata := &ModuleMetadata{
-		Name:    "app",
-		Version: "1.0.0",
+		Name:      "app",
+		Version:   "1.0.0",
+		Publisher: "cfgms",
+		Executors: []string{"steward"},
 		ModuleDependencies: []ModuleDependency{
 			{Name: "base", Version: "1.0.0"},
 		},
@@ -204,7 +206,7 @@ func TestModuleRegistry_GetModule(t *testing.T) {
 	}
 
 	// Register and get module
-	metadata := &ModuleMetadata{Name: "test", Version: "1.0.0"}
+	metadata := newTestMetadata("test", "1.0.0")
 	instance := &mockModule{name: "test"}
 
 	_ = registry.RegisterModule(metadata, instance) // Ignore error in test setup
@@ -229,7 +231,7 @@ func TestModuleRegistry_GetModuleMetadata(t *testing.T) {
 	}
 
 	// Register and get metadata
-	metadata := &ModuleMetadata{Name: "test", Version: "1.0.0", Description: "Test module"}
+	metadata := &ModuleMetadata{Name: "test", Version: "1.0.0", Description: "Test module", Publisher: "cfgms", Executors: []string{"steward"}}
 	instance := &mockModule{name: "test"}
 
 	_ = registry.RegisterModule(metadata, instance) // Ignore error in test setup
@@ -262,7 +264,7 @@ func TestModuleRegistry_ListModules(t *testing.T) {
 	// Register modules
 	moduleNames := []string{"module1", "module2", "module3"}
 	for _, name := range moduleNames {
-		metadata := &ModuleMetadata{Name: name, Version: "1.0.0"}
+		metadata := newTestMetadata(name, "1.0.0")
 		instance := &mockModule{name: name}
 		_ = registry.RegisterModule(metadata, instance) // Ignore error in test setup
 	}
@@ -301,16 +303,20 @@ func TestModuleRegistry_Initialize(t *testing.T) {
 	registry = NewModuleRegistry()
 
 	moduleA := &ModuleMetadata{
-		Name:    "a",
-		Version: "1.0.0",
+		Name:      "a",
+		Version:   "1.0.0",
+		Publisher: "cfgms",
+		Executors: []string{"steward"},
 		ModuleDependencies: []ModuleDependency{
 			{Name: "b", Version: "1.0.0"},
 		},
 	}
 
 	moduleB := &ModuleMetadata{
-		Name:    "b",
-		Version: "1.0.0",
+		Name:      "b",
+		Version:   "1.0.0",
+		Publisher: "cfgms",
+		Executors: []string{"steward"},
 		ModuleDependencies: []ModuleDependency{
 			{Name: "a", Version: "1.0.0"},
 		},
@@ -328,8 +334,10 @@ func TestModuleRegistry_Initialize(t *testing.T) {
 	registry = NewModuleRegistry()
 
 	moduleWithMissingDep := &ModuleMetadata{
-		Name:    "app",
-		Version: "1.0.0",
+		Name:      "app",
+		Version:   "1.0.0",
+		Publisher: "cfgms",
+		Executors: []string{"steward"},
 		ModuleDependencies: []ModuleDependency{
 			{Name: "missing", Version: "1.0.0"},
 		},
@@ -356,31 +364,39 @@ func TestModuleRegistry_GetLoadingOrder(t *testing.T) {
 	// crypto <- auth <- middleware <- app
 	//      <- database <-
 
-	crypto := &ModuleMetadata{Name: "crypto", Version: "1.0.0"}
+	crypto := newTestMetadata("crypto", "1.0.0")
 	auth := &ModuleMetadata{
-		Name:    "auth",
-		Version: "1.0.0",
+		Name:      "auth",
+		Version:   "1.0.0",
+		Publisher: "cfgms",
+		Executors: []string{"steward"},
 		ModuleDependencies: []ModuleDependency{
 			{Name: "crypto", Version: "1.0.0"},
 		},
 	}
 	database := &ModuleMetadata{
-		Name:    "database",
-		Version: "1.0.0",
+		Name:      "database",
+		Version:   "1.0.0",
+		Publisher: "cfgms",
+		Executors: []string{"steward"},
 		ModuleDependencies: []ModuleDependency{
 			{Name: "crypto", Version: "1.0.0"},
 		},
 	}
 	middleware := &ModuleMetadata{
-		Name:    "middleware",
-		Version: "1.0.0",
+		Name:      "middleware",
+		Version:   "1.0.0",
+		Publisher: "cfgms",
+		Executors: []string{"steward"},
 		ModuleDependencies: []ModuleDependency{
 			{Name: "auth", Version: "1.0.0"},
 		},
 	}
 	app := &ModuleMetadata{
-		Name:    "app",
-		Version: "1.0.0",
+		Name:      "app",
+		Version:   "1.0.0",
+		Publisher: "cfgms",
+		Executors: []string{"steward"},
 		ModuleDependencies: []ModuleDependency{
 			{Name: "middleware", Version: "1.0.0"},
 			{Name: "database", Version: "1.0.0"},
@@ -441,7 +457,7 @@ func TestModuleRegistry_DetectConflicts(t *testing.T) {
 	registry := NewModuleRegistry()
 
 	// Test no conflicts
-	crypto := &ModuleMetadata{Name: "crypto", Version: "1.0.0"}
+	crypto := newTestMetadata("crypto", "1.0.0")
 	_ = registry.RegisterModule(crypto, &mockModule{name: "crypto"}) // Ignore error in test setup
 
 	conflicts, err := registry.DetectConflicts()
@@ -457,16 +473,20 @@ func TestModuleRegistry_DetectConflicts(t *testing.T) {
 	registry = NewModuleRegistry()
 
 	moduleA := &ModuleMetadata{
-		Name:    "a",
-		Version: "1.0.0",
+		Name:      "a",
+		Version:   "1.0.0",
+		Publisher: "cfgms",
+		Executors: []string{"steward"},
 		ModuleDependencies: []ModuleDependency{
 			{Name: "b", Version: "1.0.0"},
 		},
 	}
 
 	moduleB := &ModuleMetadata{
-		Name:    "b",
-		Version: "1.0.0",
+		Name:      "b",
+		Version:   "1.0.0",
+		Publisher: "cfgms",
+		Executors: []string{"steward"},
 		ModuleDependencies: []ModuleDependency{
 			{Name: "a", Version: "1.0.0"},
 		},
@@ -498,11 +518,17 @@ func TestModuleRegistry_LoadModulesFromDirectory(t *testing.T) {
 	// Create module.yaml files
 	module1YAML := `name: module1
 version: 1.0.0
-description: Test module 1`
+description: Test module 1
+publisher: cfgms
+executors:
+  - steward`
 
 	module2YAML := `name: module2
 version: 1.0.0
 description: Test module 2
+publisher: cfgms
+executors:
+  - steward
 module_dependencies:
   - name: module1
     version: "^1.0.0"`
@@ -547,8 +573,8 @@ func TestModuleRegistry_GetRegistryStatus(t *testing.T) {
 	}
 
 	// Add modules and initialize
-	module1 := &ModuleMetadata{Name: "module1", Version: "1.0.0"}
-	module2 := &ModuleMetadata{Name: "module2", Version: "1.0.0"}
+	module1 := newTestMetadata("module1", "1.0.0")
+	module2 := newTestMetadata("module2", "1.0.0")
 
 	_ = registry.RegisterModule(module1, &mockModule{name: "module1"}) // Ignore error in test setup
 	_ = registry.RegisterModule(module2, &mockModule{name: "module2"}) // Ignore error in test setup
@@ -598,7 +624,7 @@ func TestModuleRegistry_ConcurrentAccess(t *testing.T) {
 	// Register some modules
 	for i := 0; i < 10; i++ {
 		name := fmt.Sprintf("module%d", i)
-		metadata := &ModuleMetadata{Name: name, Version: "1.0.0"}
+		metadata := newTestMetadata(name, "1.0.0")
 		instance := &mockModule{name: name}
 		_ = registry.RegisterModule(metadata, instance) // Ignore error in test setup
 	}
@@ -642,7 +668,7 @@ func BenchmarkModuleRegistry_RegisterModule(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		name := fmt.Sprintf("module%d", i)
-		metadata := &ModuleMetadata{Name: name, Version: "1.0.0"}
+		metadata := newTestMetadata(name, "1.0.0")
 		instance := &mockModule{name: name}
 		_ = registry.RegisterModule(metadata, instance) // Ignore error in benchmark
 	}
@@ -654,7 +680,7 @@ func BenchmarkModuleRegistry_GetModule(b *testing.B) {
 	// Register modules
 	for i := 0; i < 100; i++ {
 		name := fmt.Sprintf("module%d", i)
-		metadata := &ModuleMetadata{Name: name, Version: "1.0.0"}
+		metadata := newTestMetadata(name, "1.0.0")
 		instance := &mockModule{name: name}
 		_ = registry.RegisterModule(metadata, instance) // Ignore error in benchmark setup
 	}
@@ -685,6 +711,8 @@ func BenchmarkModuleRegistry_Initialize(b *testing.B) {
 			metadata := &ModuleMetadata{
 				Name:               name,
 				Version:            "1.0.0",
+				Publisher:          "cfgms",
+				Executors:          []string{"steward"},
 				ModuleDependencies: deps,
 			}
 			instance := &mockModule{name: name}

--- a/features/modules/script/module.yaml
+++ b/features/modules/script/module.yaml
@@ -5,12 +5,11 @@ description: >
   PowerShell scripts, and Python scripts with configurable timeouts, environment
   variables, and optional signature validation.
 
+publisher: cfgms
+
 # Supported execution environments
 executors:
   - steward  # Local script execution on steward systems
-  - outpost  # Remote script execution via SSH/WinRM on outpost systems
-
-dependencies: []
 
 requirements:
   os: [windows, linux, darwin]

--- a/features/modules/service/module.yaml
+++ b/features/modules/service/module.yaml
@@ -6,11 +6,11 @@ description: >
   configuration via the native service manager (systemd on Linux, SCM on Windows,
   launchd on macOS).
 
+publisher: cfgms
+
 # Supported execution environments
 executors:
   - steward  # Local service management on steward systems
-
-dependencies: []
 
 requirements:
   os: [windows, linux, darwin]

--- a/features/modules/testhelpers_test.go
+++ b/features/modules/testhelpers_test.go
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+package modules
+
+// newTestMetadata returns a ModuleMetadata with the minimum valid fields for use in tests
+// that are not testing metadata validation itself. Kind is empty until Validate() or
+// ParseModuleMetadata() is called — callers that need Kind set should call m.Validate() first.
+func newTestMetadata(name, version string) *ModuleMetadata {
+	return &ModuleMetadata{
+		Name:      name,
+		Version:   version,
+		Publisher: "cfgms",
+		Executors: []string{"steward"},
+	}
+}

--- a/features/modules/version_migration_test.go
+++ b/features/modules/version_migration_test.go
@@ -23,6 +23,8 @@ func TestDefaultVersionMigrator_CanMigrate(t *testing.T) {
 			Name:        "test-module",
 			Version:     version,
 			Description: "Test module",
+			Publisher:   "cfgms",
+			Executors:   []string{"steward"},
 		}
 		require.NoError(t, registry.RegisterVersion(metadata))
 	}
@@ -120,6 +122,8 @@ func TestDefaultVersionMigrator_GetMigrationPath(t *testing.T) {
 			Name:        "test-module",
 			Version:     version,
 			Description: "Test module",
+			Publisher:   "cfgms",
+			Executors:   []string{"steward"},
 		}
 		require.NoError(t, registry.RegisterVersion(metadata))
 	}
@@ -213,11 +217,15 @@ func TestDefaultVersionMigrator_ValidateMigrationPath(t *testing.T) {
 		Name:        "test-module",
 		Version:     "1.0.0",
 		Description: "Test module",
+		Publisher:   "cfgms",
+		Executors:   []string{"steward"},
 	}
 	metadata2 := &ModuleMetadata{
 		Name:        "test-module",
 		Version:     "1.1.0",
 		Description: "Test module v1.1.0",
+		Publisher:   "cfgms",
+		Executors:   []string{"steward"},
 	}
 	require.NoError(t, registry.RegisterVersion(metadata1))
 	require.NoError(t, registry.RegisterVersion(metadata2))
@@ -315,11 +323,15 @@ func TestDefaultVersionMigrator_ExecuteMigration(t *testing.T) {
 		Name:        "test-module",
 		Version:     "1.0.0",
 		Description: "Test module",
+		Publisher:   "cfgms",
+		Executors:   []string{"steward"},
 	}
 	metadata2 := &ModuleMetadata{
 		Name:        "test-module",
 		Version:     "1.1.0",
 		Description: "Test module v1.1.0",
+		Publisher:   "cfgms",
+		Executors:   []string{"steward"},
 	}
 	require.NoError(t, registry.RegisterVersion(metadata1))
 	require.NoError(t, registry.RegisterVersion(metadata2))
@@ -417,11 +429,15 @@ func TestDefaultVersionMigrator_GetMigrationStatus(t *testing.T) {
 		Name:        "test-module",
 		Version:     "1.0.0",
 		Description: "Test module",
+		Publisher:   "cfgms",
+		Executors:   []string{"steward"},
 	}
 	metadata2 := &ModuleMetadata{
 		Name:        "test-module",
 		Version:     "1.1.0",
 		Description: "Test module v1.1.0",
+		Publisher:   "cfgms",
+		Executors:   []string{"steward"},
 	}
 	require.NoError(t, registry.RegisterVersion(metadata1))
 	require.NoError(t, registry.RegisterVersion(metadata2))
@@ -476,6 +492,8 @@ func TestDefaultVersionMigrator_ListActiveMigrations(t *testing.T) {
 				Name:        fmt.Sprintf("test-module-%d", i),
 				Version:     []string{"1.0.0", "1.1.0"}[version],
 				Description: "Test module",
+				Publisher:   "cfgms",
+				Executors:   []string{"steward"},
 			}
 			require.NoError(t, registry.RegisterVersion(metadata))
 		}
@@ -568,11 +586,15 @@ func TestDefaultVersionMigrator_RollbackMigration(t *testing.T) {
 		Name:        "test-module",
 		Version:     "1.0.0",
 		Description: "Test module",
+		Publisher:   "cfgms",
+		Executors:   []string{"steward"},
 	}
 	metadata2 := &ModuleMetadata{
 		Name:        "test-module",
 		Version:     "1.0.1",
 		Description: "Test module v1.0.1",
+		Publisher:   "cfgms",
+		Executors:   []string{"steward"},
 	}
 	require.NoError(t, registry.RegisterVersion(metadata1))
 	require.NoError(t, registry.RegisterVersion(metadata2))
@@ -644,8 +666,8 @@ func TestDefaultVersionMigrator_RollbackMigration(t *testing.T) {
 func TestWaitForMigration(t *testing.T) {
 	t.Run("returns nil when migration completes successfully", func(t *testing.T) {
 		registry := NewDefaultModuleVersionRegistry()
-		require.NoError(t, registry.RegisterVersion(&ModuleMetadata{Name: "wm", Version: "1.0.0", Description: "v1"}))
-		require.NoError(t, registry.RegisterVersion(&ModuleMetadata{Name: "wm", Version: "2.0.0", Description: "v2"}))
+		require.NoError(t, registry.RegisterVersion(&ModuleMetadata{Name: "wm", Version: "1.0.0", Description: "v1", Publisher: "cfgms", Executors: []string{"steward"}}))
+		require.NoError(t, registry.RegisterVersion(&ModuleMetadata{Name: "wm", Version: "2.0.0", Description: "v2", Publisher: "cfgms", Executors: []string{"steward"}}))
 		migrator := NewDefaultVersionMigrator(registry)
 
 		path, err := migrator.GetMigrationPath("wm", "1.0.0", "2.0.0")
@@ -998,8 +1020,8 @@ func newStepRegistry(t *testing.T) (*DefaultModuleVersionRegistry, *DefaultVersi
 	t.Helper()
 	registry := NewDefaultModuleVersionRegistry()
 	migrator := NewDefaultVersionMigrator(registry)
-	require.NoError(t, registry.RegisterVersion(&ModuleMetadata{Name: "mod", Version: "1.0.0", Description: "v1"}))
-	require.NoError(t, registry.RegisterVersion(&ModuleMetadata{Name: "mod", Version: "2.0.0", Description: "v2"}))
+	require.NoError(t, registry.RegisterVersion(&ModuleMetadata{Name: "mod", Version: "1.0.0", Description: "v1", Publisher: "cfgms", Executors: []string{"steward"}}))
+	require.NoError(t, registry.RegisterVersion(&ModuleMetadata{Name: "mod", Version: "2.0.0", Description: "v2", Publisher: "cfgms", Executors: []string{"steward"}}))
 	return registry, migrator
 }
 
@@ -1458,7 +1480,7 @@ func TestExecuteStep_Cleanup(t *testing.T) {
 
 func TestExecuteStep_StructuredError(t *testing.T) {
 	registry := NewDefaultModuleVersionRegistry()
-	require.NoError(t, registry.RegisterVersion(&ModuleMetadata{Name: "mod", Version: "2.0.0", Description: "v2"}))
+	require.NoError(t, registry.RegisterVersion(&ModuleMetadata{Name: "mod", Version: "2.0.0", Description: "v2", Publisher: "cfgms", Executors: []string{"steward"}}))
 	migrator := NewDefaultVersionMigrator(registry)
 
 	// Only toVersion is installed; fromVersion missing → validation must fail
@@ -1482,8 +1504,8 @@ func TestExecuteStep_AllStepTypesDispatch(t *testing.T) {
 	// End-to-end: run a full high-complexity migration and assert every step type
 	// reaches a real implementation (StepStatusCompleted, non-empty output).
 	registry := NewDefaultModuleVersionRegistry()
-	require.NoError(t, registry.RegisterVersion(&ModuleMetadata{Name: "e2e", Version: "1.0.0", Description: "v1"}))
-	require.NoError(t, registry.RegisterVersion(&ModuleMetadata{Name: "e2e", Version: "2.0.0", Description: "v2"}))
+	require.NoError(t, registry.RegisterVersion(&ModuleMetadata{Name: "e2e", Version: "1.0.0", Description: "v1", Publisher: "cfgms", Executors: []string{"steward"}}))
+	require.NoError(t, registry.RegisterVersion(&ModuleMetadata{Name: "e2e", Version: "2.0.0", Description: "v2", Publisher: "cfgms", Executors: []string{"steward"}}))
 	migrator := NewDefaultVersionMigrator(registry)
 
 	path, err := migrator.GetMigrationPath("e2e", "1.0.0", "2.0.0")
@@ -1521,8 +1543,8 @@ func BenchmarkMigrationPath_Generation(b *testing.B) {
 	migrator := NewDefaultVersionMigrator(registry)
 
 	// Register test versions
-	metadata1 := &ModuleMetadata{Name: "bench-module", Version: "1.0.0", Description: "Bench"}
-	metadata2 := &ModuleMetadata{Name: "bench-module", Version: "2.0.0", Description: "Bench"}
+	metadata1 := &ModuleMetadata{Name: "bench-module", Version: "1.0.0", Description: "Bench", Publisher: "cfgms", Executors: []string{"steward"}}
+	metadata2 := &ModuleMetadata{Name: "bench-module", Version: "2.0.0", Description: "Bench", Publisher: "cfgms", Executors: []string{"steward"}}
 	_ = registry.RegisterVersion(metadata1) // Ignore error in benchmark setup
 	_ = registry.RegisterVersion(metadata2) // Ignore error in benchmark setup
 

--- a/features/modules/version_registry_test.go
+++ b/features/modules/version_registry_test.go
@@ -24,6 +24,8 @@ func TestDefaultModuleVersionRegistry_RegisterVersion(t *testing.T) {
 				Name:        "test-module",
 				Version:     "1.0.0",
 				Description: "Test module",
+				Publisher:   "cfgms",
+				Executors:   []string{"steward"},
 			},
 			expectErr: false,
 		},
@@ -59,6 +61,8 @@ func TestDefaultModuleVersionRegistry_RegisterVersion(t *testing.T) {
 				Name:        "duplicate-module",
 				Version:     "1.0.0",
 				Description: "Duplicate test",
+				Publisher:   "cfgms",
+				Executors:   []string{"steward"},
 			},
 			expectErr: false, // First registration should succeed
 		},
@@ -102,6 +106,8 @@ func TestDefaultModuleVersionRegistry_GetAvailableVersions(t *testing.T) {
 			Name:        "test-module",
 			Version:     version,
 			Description: "Test module",
+			Publisher:   "cfgms",
+			Executors:   []string{"steward"},
 		}
 		require.NoError(t, registry.RegisterVersion(metadata))
 	}
@@ -129,6 +135,8 @@ func TestDefaultModuleVersionRegistry_GetLatestVersion(t *testing.T) {
 			Name:        "test-module",
 			Version:     version,
 			Description: "Test module",
+			Publisher:   "cfgms",
+			Executors:   []string{"steward"},
 		}
 		require.NoError(t, registry.RegisterVersion(metadata))
 	}
@@ -155,6 +163,8 @@ func TestDefaultModuleVersionRegistry_GetCompatibleVersions(t *testing.T) {
 			Name:        "test-module",
 			Version:     version,
 			Description: "Test module",
+			Publisher:   "cfgms",
+			Executors:   []string{"steward"},
 		}
 		require.NoError(t, registry.RegisterVersion(metadata))
 	}
@@ -213,6 +223,8 @@ func TestDefaultModuleVersionRegistry_UnregisterVersion(t *testing.T) {
 		Name:        "test-module",
 		Version:     "1.0.0",
 		Description: "Test module",
+		Publisher:   "cfgms",
+		Executors:   []string{"steward"},
 	}
 	require.NoError(t, registry.RegisterVersion(metadata))
 
@@ -254,6 +266,8 @@ func TestDefaultModuleVersionRegistry_ResolveVersionConstraints(t *testing.T) {
 				Name:        moduleName,
 				Version:     version,
 				Description: fmt.Sprintf("Test module %s", moduleName),
+				Publisher:   "cfgms",
+				Executors:   []string{"steward"},
 			}
 			require.NoError(t, registry.RegisterVersion(metadata))
 		}
@@ -317,6 +331,8 @@ func TestDefaultModuleVersionRegistry_VersionHistory(t *testing.T) {
 		Name:        "test-module",
 		Version:     "1.0.0",
 		Description: "Test module",
+		Publisher:   "cfgms",
+		Executors:   []string{"steward"},
 	}
 	require.NoError(t, registry.RegisterVersion(metadata))
 
@@ -341,6 +357,8 @@ func TestDefaultModuleVersionRegistry_VersionHistory(t *testing.T) {
 			Name:        "test-module",
 			Version:     "1.1.0",
 			Description: "Test module v1.1.0",
+			Publisher:   "cfgms",
+			Executors:   []string{"steward"},
 		}
 		require.NoError(t, registry.RegisterVersion(metadata2))
 
@@ -407,6 +425,8 @@ func TestDefaultModuleVersionRegistry_RegistryStatus(t *testing.T) {
 				Name:        module.name,
 				Version:     module.version,
 				Description: "Test module",
+				Publisher:   "cfgms",
+				Executors:   []string{"steward"},
 			}
 			require.NoError(t, registry.RegisterVersion(metadata))
 		}
@@ -438,6 +458,8 @@ func TestDefaultModuleVersionRegistry_ListAllVersions(t *testing.T) {
 				Name:        moduleName,
 				Version:     version,
 				Description: "Test module",
+				Publisher:   "cfgms",
+				Executors:   []string{"steward"},
 			}
 			require.NoError(t, registry.RegisterVersion(metadata))
 		}
@@ -461,6 +483,8 @@ func TestDefaultModuleVersionRegistry_ActiveVersionManagement(t *testing.T) {
 			Name:        "test-module",
 			Version:     "1.0.0",
 			Description: "Test module",
+			Publisher:   "cfgms",
+			Executors:   []string{"steward"},
 		}
 		require.NoError(t, registry.RegisterVersion(metadata))
 
@@ -473,6 +497,8 @@ func TestDefaultModuleVersionRegistry_ActiveVersionManagement(t *testing.T) {
 			Name:        "test-module",
 			Version:     "1.1.0",
 			Description: "Test module v1.1.0",
+			Publisher:   "cfgms",
+			Executors:   []string{"steward"},
 		}
 		require.NoError(t, registry.RegisterVersion(metadata))
 
@@ -485,6 +511,8 @@ func TestDefaultModuleVersionRegistry_ActiveVersionManagement(t *testing.T) {
 			Name:        "test-module",
 			Version:     "0.9.0",
 			Description: "Test module v0.9.0",
+			Publisher:   "cfgms",
+			Executors:   []string{"steward"},
 		}
 		require.NoError(t, registry.RegisterVersion(metadata))
 
@@ -510,12 +538,16 @@ func TestDefaultModuleVersionRegistry_ConcurrencyBasics(t *testing.T) {
 			Name:        "concurrent-module",
 			Version:     "1.0.0",
 			Description: "Concurrent test",
+			Publisher:   "cfgms",
+			Executors:   []string{"steward"},
 		}
 
 		metadata2 := &ModuleMetadata{
 			Name:        "concurrent-module",
 			Version:     "1.1.0",
 			Description: "Concurrent test",
+			Publisher:   "cfgms",
+			Executors:   []string{"steward"},
 		}
 
 		// Register versions concurrently
@@ -553,6 +585,8 @@ func BenchmarkVersionRegistry_RegisterVersion(b *testing.B) {
 			Name:        fmt.Sprintf("bench-module-%d", i),
 			Version:     "1.0.0",
 			Description: "Benchmark module",
+			Publisher:   "cfgms",
+			Executors:   []string{"steward"},
 		}
 		_ = registry.RegisterVersion(metadata) // Ignore error in test setup
 	}
@@ -567,6 +601,8 @@ func BenchmarkVersionRegistry_GetAvailableVersions(b *testing.B) {
 			Name:        "bench-module",
 			Version:     fmt.Sprintf("1.%d.0", i),
 			Description: "Benchmark module",
+			Publisher:   "cfgms",
+			Executors:   []string{"steward"},
 		}
 		_ = registry.RegisterVersion(metadata) // Ignore error in test setup
 	}
@@ -587,6 +623,8 @@ func BenchmarkVersionRegistry_ResolveVersionConstraints(b *testing.B) {
 				Name:        fmt.Sprintf("bench-module-%d", moduleIdx),
 				Version:     fmt.Sprintf("1.%d.0", versionIdx),
 				Description: "Benchmark module",
+				Publisher:   "cfgms",
+				Executors:   []string{"steward"},
 			}
 			_ = registry.RegisterVersion(metadata) // Ignore error in test setup
 		}


### PR DESCRIPTION
## Summary

- Adds `Executors []string`, `Kind string` (derived, `yaml:"-"`), `Publisher string`, and `BehavioralEnvelope *BehavioralEnvelope` to `ModuleMetadata` per ADR-006 vocabulary
- `Kind` is derived from `Executors[0]` by `validateAndDeriveKind()` — called by both `ParseModuleMetadata()` and `Validate()` — so structs are always fully populated regardless of construction path
- Removes legacy `Dependencies []interface{}` field; updates all 10 `module.yaml` manifests under `features/modules/` with `publisher: cfgms` and single-element `executors` list
- Updates `docs/architecture/modules/README.md` with manifest field tables, executor→kind derivation table, and `behavioral_envelope` sub-field table

## Test plan

- [x] `TestParseModuleMetadata` — all executor values, error cases, missing publisher, behavioral_envelope round-trip, `kind:` YAML key ignored
- [x] `TestModuleMetadata_Validate` — asserts `Kind` is correctly derived for steward/outpost/controller after `Validate()` call
- [x] `TestParseModuleMetadata_KindNotParsedFromYAML` — YAML-supplied `kind:` cannot override derived value
- [x] `TestModuleYAMLHasStewardExecutor` (hyperv) — single-executor invariant enforced
- [x] `make test` — 160/160 passed, cross-platform builds clean, security scans PASS
- [x] Adversarial review: QA test runner PASS, Security engineer PASS, QA code reviewer PASS (2 blocking issues found and fixed before commit)

Fixes #1880

🤖 Generated with [Claude Code](https://claude.com/claude-code)