### PR TITLE
modules: bundle format, content addressing, and publisher trust primitives (Issue #1882)

### DIFF
--- a/docs/architecture/modules/distribution.md
+++ b/docs/architecture/modules/distribution.md
@@ -1,0 +1,192 @@
+# Module Distribution Architecture
+
+This document is the canonical reference for the CFGMS module bundle format, content
+addressing scheme, trust store shape, and signature verification flow. It is the primary
+guide for S5 (controller cache) and S7 (steward trust mode enforcement) implementors.
+
+## Overview
+
+CFGMS modules are distributed as signed bundles. Each bundle carries:
+
+1. A **manifest** (`ModuleMetadata`) describing the module.
+2. **Binary paths** keyed by `os-arch` (e.g. `linux-amd64`, `windows-amd64`).
+3. **Signatures** — one or more Ed25519 detached signatures over the bundle's content hash.
+4. A **content hash** — a deterministic SHA-256 fingerprint of all binary content and
+   the manifest YAML.
+
+---
+
+## Content Addressing
+
+Every bundle is uniquely identified by a four-tuple:
+
+```
+(publisher, name, version, content_hash)
+```
+
+This tuple is called a `ContentAddress` and is returned by `Bundle.ContentAddress()`.
+
+### How the content hash is computed
+
+`pkg/modules/bundle.ComputeContentHash` produces the hash:
+
+1. Collect `(os-arch, binary-content)` pairs from the bundle's binaries map.
+2. Sort the pairs lexicographically by `os-arch` key.
+3. Feed each `key || content` in sorted order into a SHA-256 digest.
+4. Feed the manifest YAML bytes last.
+5. Base64-encode (standard encoding) the 32-byte digest.
+
+The sort step makes the hash independent of Go map iteration order. Two bundles with
+identical binary content and manifest always produce the same hash.
+
+---
+
+## Bundle Format
+
+```go
+// pkg/modules/bundle.Bundle
+type Bundle struct {
+    Manifest    *ModuleMetadata   `yaml:"manifest"`
+    Binaries    map[string]string `yaml:"binaries"`   // os-arch → file path
+    Signatures  []BundleSignature `yaml:"signatures"`
+    ContentHash string            `yaml:"content_hash"`
+}
+```
+
+`Binaries` values are file paths relative to the bundle root directory. Actual binary
+content is not embedded in the bundle struct — the controller cache resolves paths to
+file content when computing or verifying hashes.
+
+```go
+// pkg/modules/bundle.BundleSignature
+type BundleSignature struct {
+    Publisher string `yaml:"publisher"` // must match a registered PublisherIdentity
+    Algorithm string `yaml:"algorithm"` // "ed25519" for v1
+    Signature []byte `yaml:"signature"` // 64-byte Ed25519 signature
+}
+```
+
+---
+
+## Signing Scheme
+
+**Ed25519 detached signature** — the only scheme for v1 bundles.
+
+**What is signed:** the UTF-8 encoding of `Bundle.ContentHash`.
+
+**Why Ed25519:**
+- No external CA dependency — publisher identity is a raw 32-byte public key.
+- Deterministic — same message + key always produces the same signature.
+- Compact — 64-byte signature, 32-byte public key.
+- Fast — ~70k verifications/second on modest hardware.
+- Stdlib — `crypto/ed25519` ships with every Go release; no external dependencies.
+
+Additional verifiers (cosign, minisign) can be added in future stories without changing
+the bundle format by adding new `BundleSignature` entries with different `Algorithm`
+values.
+
+---
+
+## Publisher Identity
+
+```go
+// pkg/modules/trust.PublisherIdentity
+type PublisherIdentity struct {
+    Name      string // human-readable identifier, e.g. "cfgms"
+    PublicKey []byte // raw 32-byte Ed25519 public key
+    Algorithm string // "ed25519"
+}
+```
+
+### CFGMS publisher key
+
+`pkg/modules/trust.CFGMSPublisherIdentity()` returns the built-in CFGMS publisher
+identity. The public key is stored in the package-level variable:
+
+```go
+var cfgmsPublisherPublicKey = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
+```
+
+This is a placeholder (32 zero bytes). The real key is injected by the release pipeline:
+
+```
+go build -ldflags "-X github.com/cfgis/cfgms/pkg/modules/trust.cfgmsPublisherPublicKey=<base64>"
+```
+
+---
+
+## Trust Store
+
+```go
+// pkg/modules/trust.TrustStore
+type TrustStore interface {
+    AddPublisher(PublisherIdentity) error
+    GetPublisher(name string) (PublisherIdentity, bool)
+    ListPublishers() []PublisherIdentity
+    IsTrusted(name string, pubKey []byte) bool
+}
+```
+
+The default implementation is `InMemoryTrustStore` — thread-safe, non-persistent. It is
+pre-seeded at startup from:
+
+1. `CFGMSPublisherIdentity()` — the baked-in CFGMS publisher.
+2. Additional publishers declared in `steward.cfg` (steward) or controller tenant
+   configuration (controller). Persistence is a S5 (controller) and S7 (steward) concern.
+
+The trust store is rebuilt at each startup. There is no durable persistence of trust
+store state in this story — that is deferred to S5 and S7.
+
+---
+
+## Signature Verification Flow
+
+`pkg/modules/trust.VerifyBundleSignature(bundle, sig, store)`:
+
+```
+1. Look up sig.Publisher in store.
+   → Not found: ErrPublisherNotTrusted
+
+2. Validate stored key length == 32 bytes.
+   → Wrong length: ErrKeyMismatch
+
+3. ed25519.Verify(storedPublicKey, []byte(bundle.ContentHash), sig.Signature)
+   → Verify returns false: ErrInvalidSignature
+
+4. Return nil (verification passed).
+```
+
+---
+
+## Controller Cache Layout (S5 reference)
+
+The controller caches bundles at a path derived from the content address:
+
+```
+<cache-root>/<publisher>/<name>/<version>/<content_hash>/
+    manifest.yaml
+    binaries/
+        linux-amd64
+        linux-arm64
+        windows-amd64
+        ...
+    signatures.yaml
+```
+
+The `content_hash` path component makes each unique bundle version immutable — a new
+build of the same `(publisher, name, version)` tuple is stored under a different hash
+directory without overwriting the old one.
+
+---
+
+## Steward Trust Mode (S7 reference)
+
+The steward enforces trust before loading a bundle:
+
+1. Compute the content hash of the received bundle and compare to `ContentHash`.
+   Mismatch → reject (content integrity).
+2. For each `BundleSignature`, call `VerifyBundleSignature`. At least one signature must
+   pass from a publisher in the steward's trust store.
+3. If no trusted signature is found → reject with `ErrPublisherNotTrusted`.
+
+Trust mode policy (permissive vs. strict) and per-publisher allowlists are S7 concerns.

--- a/pkg/modules/bundle/bundle.go
+++ b/pkg/modules/bundle/bundle.go
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 CFGMS Contributors
+
+// Package bundle defines the CFGMS module bundle format, content addressing,
+// and serialization.
+//
+// # Signing scheme: Ed25519 detached signatures
+//
+// Each bundle carries one or more BundleSignature values. Signatures use
+// Ed25519 (RFC 8032) with a detached 64-byte signature over the bundle's
+// ContentHash bytes encoded as UTF-8.
+//
+// Rationale for Ed25519:
+//   - No external CA dependency — publisher identity is a raw 32-byte public key
+//   - Deterministic — same message + key → same signature (unlike ECDSA without RFC 6979)
+//   - Compact — 64-byte signature and 32-byte public key
+//   - Fast verify — ~70k verifications/second on modest hardware
+//   - stdlib — crypto/ed25519 ships with every Go release; zero external deps
+//
+// One scheme for v1. cosign/minisign can be added as additional verifiers in a
+// future story without changing the bundle format — the Signatures slice accepts
+// multiple entries, each tagged with an Algorithm field.
+package bundle
+
+import (
+	modules "github.com/cfgis/cfgms/features/modules"
+)
+
+// BundleSignature is a detached Ed25519 signature over the bundle's ContentHash.
+//
+// Signature is a 64-byte Ed25519 signature over the UTF-8 encoding of
+// Bundle.ContentHash. Publisher must match a PublisherIdentity registered in
+// the TrustStore at verification time.
+type BundleSignature struct {
+	Publisher string `yaml:"publisher" json:"publisher"`
+	// Algorithm is always "ed25519" for v1 bundles.
+	Algorithm string `yaml:"algorithm" json:"algorithm"`
+	// Signature is the raw 64-byte Ed25519 signature bytes.
+	Signature []byte `yaml:"signature" json:"signature"`
+}
+
+// Bundle is the top-level artifact exchanged between the controller cache and
+// the steward. It carries a module manifest, OS/arch-keyed binary paths, one or
+// more publisher signatures, and a deterministic content hash.
+//
+// Binaries maps os-arch keys (e.g. "linux-amd64", "windows-amd64") to the file
+// path of the corresponding contract binary. Paths are relative to the bundle
+// root directory.
+type Bundle struct {
+	Manifest    *modules.ModuleMetadata `yaml:"manifest" json:"manifest"`
+	Binaries    map[string]string       `yaml:"binaries" json:"binaries"`
+	Signatures  []BundleSignature       `yaml:"signatures,omitempty" json:"signatures,omitempty"`
+	ContentHash string                  `yaml:"content_hash" json:"content_hash"`
+}
+
+// ContentAddress returns the (publisher, name, version, content_hash) tuple
+// that uniquely identifies this bundle.
+func (b *Bundle) ContentAddress() ContentAddress {
+	publisher := ""
+	name := ""
+	version := ""
+	if b.Manifest != nil {
+		publisher = b.Manifest.Publisher
+		name = b.Manifest.Name
+		version = b.Manifest.Version
+	}
+	return ContentAddress{
+		Publisher:   publisher,
+		Name:        name,
+		Version:     version,
+		ContentHash: b.ContentHash,
+	}
+}

--- a/pkg/modules/bundle/bundle_test.go
+++ b/pkg/modules/bundle/bundle_test.go
@@ -1,0 +1,138 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 CFGMS Contributors
+package bundle_test
+
+import (
+	"encoding/base64"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+
+	modules "github.com/cfgis/cfgms/features/modules"
+	"github.com/cfgis/cfgms/pkg/modules/bundle"
+)
+
+func makeTestMetadata() *modules.ModuleMetadata {
+	return &modules.ModuleMetadata{
+		Name:      "test-module",
+		Version:   "1.0.0",
+		Publisher: "cfgms",
+	}
+}
+
+func TestBundle_ContentAddress(t *testing.T) {
+	b := &bundle.Bundle{
+		Manifest: makeTestMetadata(),
+		Binaries: map[string]string{
+			"linux-amd64":   "binaries/test-module-linux-amd64",
+			"linux-arm64":   "binaries/test-module-linux-arm64",
+			"windows-amd64": "binaries/test-module-windows-amd64",
+		},
+		ContentHash: "somehash",
+	}
+
+	ca := b.ContentAddress()
+	assert.Equal(t, "cfgms", ca.Publisher)
+	assert.Equal(t, "test-module", ca.Name)
+	assert.Equal(t, "1.0.0", ca.Version)
+	assert.Equal(t, "somehash", ca.ContentHash)
+}
+
+// TestBundle_RoundTrip verifies that a bundle can be serialized to YAML and
+// deserialized back with ContentHash unchanged.
+func TestBundle_RoundTrip(t *testing.T) {
+	meta := makeTestMetadata()
+	binContent := map[string][]byte{
+		"linux-amd64": []byte("fake-binary-linux-amd64-content"),
+		"linux-arm64": []byte("fake-binary-linux-arm64-content"),
+	}
+
+	// Compute hash from binary content and manifest
+	manifestBytes, err := yaml.Marshal(meta)
+	require.NoError(t, err)
+
+	hash, err := bundle.ComputeContentHash(binContent, manifestBytes)
+	require.NoError(t, err)
+
+	// Build a bundle with paths (not inline content)
+	b := &bundle.Bundle{
+		Manifest: meta,
+		Binaries: map[string]string{
+			"linux-amd64": "path/to/linux-amd64",
+			"linux-arm64": "path/to/linux-arm64",
+		},
+		ContentHash: hash,
+	}
+
+	// Serialize
+	data, err := yaml.Marshal(b)
+	require.NoError(t, err)
+
+	// Deserialize
+	var b2 bundle.Bundle
+	err = yaml.Unmarshal(data, &b2)
+	require.NoError(t, err)
+
+	assert.Equal(t, b.ContentHash, b2.ContentHash)
+	assert.Equal(t, b.Manifest.Name, b2.Manifest.Name)
+	assert.Equal(t, b.Manifest.Version, b2.Manifest.Version)
+	assert.Equal(t, b.Manifest.Publisher, b2.Manifest.Publisher)
+	assert.Equal(t, b.Binaries["linux-amd64"], b2.Binaries["linux-amd64"])
+}
+
+// TestBundle_HashDeterminism verifies that identical binary content always
+// produces the same content hash regardless of map iteration order.
+func TestBundle_HashDeterminism(t *testing.T) {
+	meta := makeTestMetadata()
+	manifestBytes, err := yaml.Marshal(meta)
+	require.NoError(t, err)
+
+	binContent := map[string][]byte{
+		"linux-amd64":   []byte("binary-content-amd64"),
+		"linux-arm64":   []byte("binary-content-arm64"),
+		"windows-amd64": []byte("binary-content-windows"),
+	}
+
+	// Compute the hash multiple times; all results must be identical.
+	hash1, err := bundle.ComputeContentHash(binContent, manifestBytes)
+	require.NoError(t, err)
+
+	hash2, err := bundle.ComputeContentHash(binContent, manifestBytes)
+	require.NoError(t, err)
+
+	hash3, err := bundle.ComputeContentHash(binContent, manifestBytes)
+	require.NoError(t, err)
+
+	assert.Equal(t, hash1, hash2)
+	assert.Equal(t, hash2, hash3)
+
+	// Verify the hash is a valid base64 string (non-empty)
+	decoded, err := base64.StdEncoding.DecodeString(hash1)
+	require.NoError(t, err)
+	assert.Len(t, decoded, 32) // SHA-256 is 32 bytes
+}
+
+// TestBundle_TamperedContentProducesDifferentHash verifies that modifying binary
+// content changes the hash.
+func TestBundle_TamperedContentProducesDifferentHash(t *testing.T) {
+	meta := makeTestMetadata()
+	manifestBytes, err := yaml.Marshal(meta)
+	require.NoError(t, err)
+
+	original := map[string][]byte{
+		"linux-amd64": []byte("original-binary-content"),
+	}
+	tampered := map[string][]byte{
+		"linux-amd64": []byte("TAMPERED-binary-content"),
+	}
+
+	hashOriginal, err := bundle.ComputeContentHash(original, manifestBytes)
+	require.NoError(t, err)
+
+	hashTampered, err := bundle.ComputeContentHash(tampered, manifestBytes)
+	require.NoError(t, err)
+
+	assert.NotEqual(t, hashOriginal, hashTampered)
+}

--- a/pkg/modules/bundle/hash.go
+++ b/pkg/modules/bundle/hash.go
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 CFGMS Contributors
+package bundle
+
+import (
+	"crypto/sha256"
+	"encoding/base64"
+	"sort"
+)
+
+// ContentAddress uniquely identifies a module bundle by publisher, name, version,
+// and the deterministic hash of its binary content and manifest.
+type ContentAddress struct {
+	Publisher   string `yaml:"publisher" json:"publisher"`
+	Name        string `yaml:"name" json:"name"`
+	Version     string `yaml:"version" json:"version"`
+	ContentHash string `yaml:"content_hash" json:"content_hash"`
+}
+
+// ComputeContentHash produces a deterministic SHA-256 hash over binary content and
+// the manifest YAML bytes.
+//
+// Determinism is achieved by sorting the (os-arch, binary-content) pairs
+// lexicographically before hashing so the result is independent of map iteration
+// order. The manifest bytes are hashed last, after all binaries.
+func ComputeContentHash(binaries map[string][]byte, manifestBytes []byte) (string, error) {
+	type entry struct {
+		key     string
+		content []byte
+	}
+
+	entries := make([]entry, 0, len(binaries))
+	for k, v := range binaries {
+		entries = append(entries, entry{key: k, content: v})
+	}
+	sort.Slice(entries, func(i, j int) bool {
+		return entries[i].key < entries[j].key
+	})
+
+	h := sha256.New()
+	for _, e := range entries {
+		h.Write([]byte(e.key))
+		h.Write(e.content)
+	}
+	h.Write(manifestBytes)
+
+	return base64.StdEncoding.EncodeToString(h.Sum(nil)), nil
+}

--- a/pkg/modules/trust/identity.go
+++ b/pkg/modules/trust/identity.go
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 CFGMS Contributors
+package trust
+
+import (
+	"encoding/base64"
+	"fmt"
+)
+
+// cfgmsPublisherPublicKey is the base64-encoded Ed25519 public key for the CFGMS
+// publisher. This is a placeholder (32 zero bytes) for development builds.
+//
+// The real key is injected by the release pipeline at build time:
+//
+//	go build -ldflags "-X github.com/cfgis/cfgms/pkg/modules/trust.cfgmsPublisherPublicKey=<base64>"
+//
+// The variable (not const) declaration is required to allow ldflags injection.
+var cfgmsPublisherPublicKey = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
+
+// CFGMSPublisherIdentity returns the PublisherIdentity for the CFGMS module
+// publisher, decoded from the package-level cfgmsPublisherPublicKey variable.
+// Panics if the variable contains invalid base64 or the decoded key is not 32 bytes
+// (which would indicate a broken build pipeline).
+func CFGMSPublisherIdentity() PublisherIdentity {
+	keyBytes, err := base64.StdEncoding.DecodeString(cfgmsPublisherPublicKey)
+	if err != nil {
+		panic(fmt.Sprintf("pkg/modules/trust: cfgmsPublisherPublicKey is not valid base64: %v", err))
+	}
+	if len(keyBytes) != 32 {
+		panic(fmt.Sprintf("pkg/modules/trust: cfgmsPublisherPublicKey decoded to %d bytes, expected 32", len(keyBytes)))
+	}
+	return PublisherIdentity{
+		Name:      "cfgms",
+		PublicKey: keyBytes,
+		Algorithm: algorithmEd25519,
+	}
+}

--- a/pkg/modules/trust/store.go
+++ b/pkg/modules/trust/store.go
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 CFGMS Contributors
+package trust
+
+import (
+	"bytes"
+	"sync"
+)
+
+// algorithmEd25519 is the only signing algorithm supported by v1 bundles.
+const algorithmEd25519 = "ed25519"
+
+// PublisherIdentity represents a trusted module publisher identified by name and
+// their raw Ed25519 public key.
+type PublisherIdentity struct {
+	// Name is the human-readable publisher identifier (e.g. "cfgms").
+	Name string
+	// PublicKey is the raw 32-byte Ed25519 public key.
+	PublicKey []byte
+	// Algorithm is always "ed25519" for v1 bundles.
+	Algorithm string
+}
+
+// TrustStore is the interface for managing trusted publisher identities.
+// The default implementation is InMemoryTrustStore; durable persistence is a
+// controller (S5) and steward (S7) concern handled in later stories.
+type TrustStore interface {
+	// AddPublisher registers a publisher identity as trusted.
+	AddPublisher(PublisherIdentity) error
+	// GetPublisher returns the identity for the named publisher, if known.
+	GetPublisher(name string) (PublisherIdentity, bool)
+	// ListPublishers returns all registered publisher identities.
+	ListPublishers() []PublisherIdentity
+	// IsTrusted reports whether the named publisher with the given public key is trusted.
+	IsTrusted(name string, pubKey []byte) bool
+}
+
+// InMemoryTrustStore is a thread-safe, non-persistent TrustStore implementation
+// suitable for use in tests and at startup before durable state is loaded.
+type InMemoryTrustStore struct {
+	mu         sync.RWMutex
+	publishers map[string]PublisherIdentity
+}
+
+// NewInMemoryTrustStore creates an empty InMemoryTrustStore.
+func NewInMemoryTrustStore() *InMemoryTrustStore {
+	return &InMemoryTrustStore{
+		publishers: make(map[string]PublisherIdentity),
+	}
+}
+
+// AddPublisher registers the identity as trusted. Overwrites any existing
+// entry for the same publisher name.
+func (s *InMemoryTrustStore) AddPublisher(id PublisherIdentity) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.publishers[id.Name] = id
+	return nil
+}
+
+// GetPublisher returns the identity registered under name, if any.
+func (s *InMemoryTrustStore) GetPublisher(name string) (PublisherIdentity, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	id, ok := s.publishers[name]
+	return id, ok
+}
+
+// ListPublishers returns a snapshot of all registered identities.
+func (s *InMemoryTrustStore) ListPublishers() []PublisherIdentity {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	out := make([]PublisherIdentity, 0, len(s.publishers))
+	for _, id := range s.publishers {
+		out = append(out, id)
+	}
+	return out
+}
+
+// IsTrusted reports whether the publisher is registered and the stored public key
+// matches pubKey exactly.
+func (s *InMemoryTrustStore) IsTrusted(name string, pubKey []byte) bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	id, ok := s.publishers[name]
+	if !ok {
+		return false
+	}
+	return bytes.Equal(id.PublicKey, pubKey)
+}

--- a/pkg/modules/trust/trust_test.go
+++ b/pkg/modules/trust/trust_test.go
@@ -1,0 +1,209 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 CFGMS Contributors
+package trust_test
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cfgis/cfgms/pkg/modules/bundle"
+	"github.com/cfgis/cfgms/pkg/modules/trust"
+)
+
+func makeKeypair(t *testing.T) (ed25519.PublicKey, ed25519.PrivateKey) {
+	t.Helper()
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	require.NoError(t, err)
+	return pub, priv
+}
+
+func makeBundle(contentHash string) *bundle.Bundle {
+	return &bundle.Bundle{
+		ContentHash: contentHash,
+	}
+}
+
+func signHash(t *testing.T, priv ed25519.PrivateKey, contentHash string) []byte {
+	t.Helper()
+	sig := ed25519.Sign(priv, []byte(contentHash))
+	return sig
+}
+
+// TestVerifyBundleSignature_ValidSignature verifies that a valid Ed25519 signature
+// from a trusted publisher passes verification.
+func TestVerifyBundleSignature_ValidSignature(t *testing.T) {
+	pub, priv := makeKeypair(t)
+
+	store := trust.NewInMemoryTrustStore()
+	err := store.AddPublisher(trust.PublisherIdentity{
+		Name:      "cfgms",
+		PublicKey: []byte(pub),
+		Algorithm: "ed25519",
+	})
+	require.NoError(t, err)
+
+	b := makeBundle("abc123contenthash")
+	sig := bundle.BundleSignature{
+		Publisher: "cfgms",
+		Algorithm: "ed25519",
+		Signature: signHash(t, priv, b.ContentHash),
+	}
+
+	err = trust.VerifyBundleSignature(b, sig, store)
+	assert.NoError(t, err)
+}
+
+// TestVerifyBundleSignature_TamperedBundle verifies that a tampered bundle
+// (content hash bytes changed) fails verification.
+func TestVerifyBundleSignature_TamperedBundle(t *testing.T) {
+	pub, priv := makeKeypair(t)
+
+	store := trust.NewInMemoryTrustStore()
+	err := store.AddPublisher(trust.PublisherIdentity{
+		Name:      "cfgms",
+		PublicKey: []byte(pub),
+		Algorithm: "ed25519",
+	})
+	require.NoError(t, err)
+
+	originalHash := "original-content-hash"
+	tamperedHash := "tampered-content-hash"
+
+	// Sign the original hash
+	sig := bundle.BundleSignature{
+		Publisher: "cfgms",
+		Algorithm: "ed25519",
+		Signature: signHash(t, priv, originalHash),
+	}
+
+	// But verify against a bundle with a different hash
+	b := makeBundle(tamperedHash)
+	err = trust.VerifyBundleSignature(b, sig, store)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, trust.ErrInvalidSignature), "expected ErrInvalidSignature, got: %v", err)
+}
+
+// TestVerifyBundleSignature_UnknownPublisher verifies that a signature from an
+// unknown publisher (not in the trust store) returns ErrPublisherNotTrusted.
+func TestVerifyBundleSignature_UnknownPublisher(t *testing.T) {
+	_, priv := makeKeypair(t)
+
+	store := trust.NewInMemoryTrustStore()
+	// No publishers added to the store
+
+	b := makeBundle("some-content-hash")
+	sig := bundle.BundleSignature{
+		Publisher: "unknown-publisher",
+		Algorithm: "ed25519",
+		Signature: signHash(t, priv, b.ContentHash),
+	}
+
+	err := trust.VerifyBundleSignature(b, sig, store)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, trust.ErrPublisherNotTrusted), "expected ErrPublisherNotTrusted, got: %v", err)
+}
+
+// TestVerifyBundleSignature_WrongKey verifies that a known publisher signed with a
+// different private key returns ErrInvalidSignature (the stored key is valid length
+// but verification fails cryptographically).
+func TestVerifyBundleSignature_WrongKey(t *testing.T) {
+	pub1, _ := makeKeypair(t)
+	_, priv2 := makeKeypair(t) // Different keypair — priv2 doesn't pair with pub1
+
+	store := trust.NewInMemoryTrustStore()
+	err := store.AddPublisher(trust.PublisherIdentity{
+		Name:      "cfgms",
+		PublicKey: []byte(pub1),
+		Algorithm: "ed25519",
+	})
+	require.NoError(t, err)
+
+	b := makeBundle("some-content-hash")
+	sig := bundle.BundleSignature{
+		Publisher: "cfgms",
+		Algorithm: "ed25519",
+		Signature: signHash(t, priv2, b.ContentHash),
+	}
+
+	err = trust.VerifyBundleSignature(b, sig, store)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, trust.ErrInvalidSignature),
+		"expected ErrInvalidSignature for wrong keypair, got: %v", err)
+}
+
+// TestVerifyBundleSignature_MalformedStoredKey verifies that a publisher registered
+// with a malformed (short) public key returns ErrKeyMismatch.
+func TestVerifyBundleSignature_MalformedStoredKey(t *testing.T) {
+	_, priv := makeKeypair(t)
+
+	store := trust.NewInMemoryTrustStore()
+	// Register a short (malformed) public key — less than 32 bytes
+	err := store.AddPublisher(trust.PublisherIdentity{
+		Name:      "cfgms",
+		PublicKey: []byte("short"),
+		Algorithm: "ed25519",
+	})
+	require.NoError(t, err)
+
+	b := makeBundle("some-content-hash")
+	sig := bundle.BundleSignature{
+		Publisher: "cfgms",
+		Algorithm: "ed25519",
+		Signature: signHash(t, priv, b.ContentHash),
+	}
+
+	err = trust.VerifyBundleSignature(b, sig, store)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, trust.ErrKeyMismatch),
+		"expected ErrKeyMismatch for malformed stored key, got: %v", err)
+}
+
+// TestInMemoryTrustStore_Operations tests the basic operations of InMemoryTrustStore.
+func TestInMemoryTrustStore_Operations(t *testing.T) {
+	store := trust.NewInMemoryTrustStore()
+
+	pub, _ := makeKeypair(t)
+	id := trust.PublisherIdentity{
+		Name:      "test-publisher",
+		PublicKey: []byte(pub),
+		Algorithm: "ed25519",
+	}
+
+	// Not trusted initially
+	assert.False(t, store.IsTrusted("test-publisher", []byte(pub)))
+
+	err := store.AddPublisher(id)
+	require.NoError(t, err)
+
+	// Now trusted
+	assert.True(t, store.IsTrusted("test-publisher", []byte(pub)))
+
+	// GetPublisher returns the identity
+	got, ok := store.GetPublisher("test-publisher")
+	assert.True(t, ok)
+	assert.Equal(t, id.Name, got.Name)
+	assert.Equal(t, id.Algorithm, got.Algorithm)
+
+	// ListPublishers returns it
+	list := store.ListPublishers()
+	assert.Len(t, list, 1)
+	assert.Equal(t, "test-publisher", list[0].Name)
+
+	// Unknown publisher
+	_, ok = store.GetPublisher("nonexistent")
+	assert.False(t, ok)
+}
+
+// TestCFGMSPublisherIdentity verifies that CFGMSPublisherIdentity returns a well-formed
+// identity with the ed25519 algorithm set.
+func TestCFGMSPublisherIdentity(t *testing.T) {
+	id := trust.CFGMSPublisherIdentity()
+	assert.Equal(t, "cfgms", id.Name)
+	assert.Equal(t, "ed25519", id.Algorithm)
+	assert.Len(t, id.PublicKey, 32) // Ed25519 public key is 32 bytes
+}

--- a/pkg/modules/trust/verify.go
+++ b/pkg/modules/trust/verify.go
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 CFGMS Contributors
+package trust
+
+import (
+	"crypto/ed25519"
+	"errors"
+	"fmt"
+
+	"github.com/cfgis/cfgms/pkg/modules/bundle"
+)
+
+var (
+	// ErrPublisherNotTrusted is returned when the bundle's signing publisher is not
+	// registered in the TrustStore.
+	ErrPublisherNotTrusted = errors.New("publisher not trusted")
+
+	// ErrKeyMismatch is returned when the publisher is known but the stored public
+	// key does not match the key that produced the signature.
+	ErrKeyMismatch = errors.New("publisher key mismatch")
+
+	// ErrInvalidSignature is returned when the Ed25519 signature does not verify
+	// against the bundle's ContentHash and the publisher's public key.
+	ErrInvalidSignature = errors.New("invalid bundle signature")
+)
+
+// VerifyBundleSignature verifies that sig is a valid Ed25519 signature over the
+// bundle's ContentHash bytes, produced by a publisher known to store.
+//
+// Error precedence:
+//  1. ErrPublisherNotTrusted — publisher name not in store
+//  2. ErrKeyMismatch — publisher known but stored key != key in store (defensive; the
+//     store only holds one key per publisher so the verification catches this implicitly)
+//  3. ErrInvalidSignature — signature bytes do not verify
+func VerifyBundleSignature(b *bundle.Bundle, sig bundle.BundleSignature, store TrustStore) error {
+	id, ok := store.GetPublisher(sig.Publisher)
+	if !ok {
+		return fmt.Errorf("%w: %q", ErrPublisherNotTrusted, sig.Publisher)
+	}
+
+	if len(id.PublicKey) != ed25519.PublicKeySize {
+		return fmt.Errorf("%w: stored key for %q has wrong length %d (expected %d)",
+			ErrKeyMismatch, sig.Publisher, len(id.PublicKey), ed25519.PublicKeySize)
+	}
+
+	message := []byte(b.ContentHash)
+	if !ed25519.Verify(ed25519.PublicKey(id.PublicKey), message, sig.Signature) {
+		return fmt.Errorf("%w: signature by %q over content hash %q is not valid",
+			ErrInvalidSignature, sig.Publisher, b.ContentHash)
+	}
+
+	return nil
+}


### PR DESCRIPTION
## Summary

- `pkg/modules/bundle/` — `Bundle` struct with `ContentAddress()`, deterministic SHA-256 content hash (sorted os-arch pairs + manifest YAML), `BundleSignature` with Ed25519 fields
- `pkg/modules/trust/` — `TrustStore` interface, `InMemoryTrustStore`, `PublisherIdentity`, `CFGMSPublisherIdentity()` with ldflags-injectable key, `VerifyBundleSignature` with `ErrPublisherNotTrusted`/`ErrKeyMismatch`/`ErrInvalidSignature` error hierarchy
- `docs/architecture/modules/distribution.md` — canonical reference for S5 (controller cache) and S7 (steward trust) implementors: content addressing tuple, bundle format, signing scheme rationale, verification flow, cache layout

Fixes #1882

## Specialist Review Results

**QA Test Runner: PASS**
- All packages pass; cross-platform compilation verified; make test-agent-complete passed

**QA Code Reviewer: PASS** (after fix iteration)
- Initial: 2 blocking issues — `TestVerifyBundleSignature_WrongKey` used disjunctive `||` assertion masking uncovered `ErrKeyMismatch` path
- Fixed: split into `TestVerifyBundleSignature_WrongKey` (asserts `ErrInvalidSignature` exactly) and new `TestVerifyBundleSignature_MalformedStoredKey` (asserts `ErrKeyMismatch` exactly for short stored key)
- Re-review: PASS — all three sentinel errors now have dedicated, unambiguous tests

**Security Engineer: PASS**
- `make security-precommit`, `make check-architecture`, `make security-scan` all green
- Ed25519 from stdlib, `crypto/rand` for test key generation, no hardcoded secrets
- Low-severity warning: placeholder all-zeros key will be replaced by release pipeline ldflags injection (documented in code and distribution.md); production guard deferred to S5/S7 per story scope

## Test plan

- [ ] `go test ./pkg/modules/bundle/... ./pkg/modules/trust/... -race -v` — all 11 tests pass
- [ ] `make check-architecture` — no central provider violations
- [ ] `make security-scan` — clean
- [ ] Content addressing: same binary content always produces same hash (determinism test)
- [ ] Tampered content produces different hash
- [ ] Valid Ed25519 signature from trusted publisher passes
- [ ] Tampered bundle fails with `ErrInvalidSignature`
- [ ] Unknown publisher fails with `ErrPublisherNotTrusted`
- [ ] Malformed stored key fails with `ErrKeyMismatch`

🤖 Generated with [Claude Code](https://claude.com/claude-code)