### PR TITLE
controller: module cache, git source resolver, and approval workflow (Issue #1883)

### DIFF
--- a/cmd/cfg/cmd/module.go
+++ b/cmd/cfg/cmd/module.go
@@ -1,0 +1,277 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 CFGMS Contributors
+// Package cmd implements the CLI commands for cfg
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"regexp"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/spf13/cobra"
+)
+
+// moduleRefRE validates "publisher/name@version" module references.
+// Allows alphanumerics, dots, hyphens, and underscores in each component.
+var moduleRefRE = regexp.MustCompile(`^[a-zA-Z0-9._-]+/[a-zA-Z0-9._-]+@[a-zA-Z0-9._-]+$`)
+
+var (
+	moduleAPIURL      string
+	moduleAPIKey      string
+	moduleTLSCACert   string
+	moduleTLSInsecure bool
+
+	moduleListTenant string
+	moduleListStatus string
+	moduleListJSON   bool
+)
+
+// moduleCmd is the parent command for module management operations.
+var moduleCmd = &cobra.Command{
+	Use:   "module",
+	Short: "Manage modules in the controller cache",
+	Long: `Manage the controller's module cache and approval queue.
+
+Modules are fetched from configured git sources, verified, and staged in the
+controller's content-addressed cache. Use these commands to inspect and manage
+the approval state of cached module bundles.
+
+This command communicates with the controller's REST API. The controller URL can
+be provided via flags or environment variables:
+  - CFGMS_API_URL: Controller REST API URL (default: http://localhost:9080)
+  - CFGMS_API_KEY: API key for authentication (optional; mTLS bundle preferred)
+  - CFGMS_TLS_CA_CERT: Path to CA certificate for TLS verification
+  - CFGMS_TLS_INSECURE: Skip TLS verification (development only)
+
+Examples:
+  # List all modules in the cache
+  cfg module list
+
+  # List pending modules for a specific tenant
+  cfg module list --tenant root/msp-a --status pending
+
+  # Approve a queued module
+  cfg module approve cfgms/hyperv@0.2.1`,
+}
+
+// moduleListCmd lists cached modules with their approval status.
+var moduleListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List cached modules and their approval status",
+	Long: `List all modules in the controller module cache.
+
+The --status flag filters the output:
+  pending   — modules awaiting admin approval (QueueForReview)
+  approved  — modules approved and available for steward delivery
+  rejected  — modules rejected due to signature verification failure
+
+Examples:
+  cfg module list
+  cfg module list --status pending
+  cfg module list --tenant root/msp-a
+  cfg module list --status approved --json`,
+	RunE: runModuleList,
+}
+
+// moduleApproveCmd promotes a queued module to approved.
+var moduleApproveCmd = &cobra.Command{
+	Use:   "approve <publisher>/<name>@<version>",
+	Short: "Approve a queued module",
+	Long: `Approve a module that is queued for review.
+
+The module reference must be in the form publisher/name@version, for example:
+  cfgms/hyperv@0.2.1
+
+Only modules in "pending" state (QueueForReview) can be approved. Modules that
+are already approved or rejected return an error.
+
+This command requires admin mTLS authentication via an admin bundle file.
+
+Examples:
+  cfg module approve cfgms/hyperv@0.2.1
+  cfg module approve acme-corp/custom-module@1.3.0`,
+	Args: cobra.ExactArgs(1),
+	RunE: runModuleApprove,
+}
+
+func init() {
+	moduleCmd.PersistentFlags().StringVar(&moduleAPIURL, "api-url", "", "Controller REST API URL (env: CFGMS_API_URL)")
+	moduleCmd.PersistentFlags().StringVar(&moduleAPIKey, "api-key", "", "API key for authentication (env: CFGMS_API_KEY)")
+	moduleCmd.PersistentFlags().StringVar(&moduleTLSCACert, "tls-ca-cert", "", "Path to CA certificate for TLS verification (env: CFGMS_TLS_CA_CERT)")
+	moduleCmd.PersistentFlags().BoolVar(&moduleTLSInsecure, "tls-insecure", false, "Skip TLS verification (development only)")
+
+	moduleListCmd.Flags().StringVar(&moduleListTenant, "tenant", "", "Filter by tenant path (e.g. root/msp-a); default shows all tenants")
+	moduleListCmd.Flags().StringVar(&moduleListStatus, "status", "", "Filter by approval status: pending, approved, or rejected")
+	moduleListCmd.Flags().BoolVar(&moduleListJSON, "json", false, "Emit JSON output instead of human-readable table")
+
+	moduleCmd.AddCommand(moduleListCmd)
+	moduleCmd.AddCommand(moduleApproveCmd)
+}
+
+func getModuleAPIClient() (*APIClient, error) {
+	apiURL := moduleAPIURL
+	if apiURL == "" {
+		apiURL = os.Getenv("CFGMS_API_URL")
+	}
+
+	client, err := resolveBundleClient(apiURL)
+	if err != nil {
+		return nil, fmt.Errorf("bundle lookup failed: %w", err)
+	}
+	if client != nil {
+		return client, nil
+	}
+
+	if apiURL == "" {
+		apiURL = "http://localhost:9080"
+	}
+
+	apiKey := moduleAPIKey
+	if apiKey == "" {
+		apiKey = os.Getenv("CFGMS_API_KEY")
+	}
+
+	tlsInsecure := moduleTLSInsecure
+	if !tlsInsecure && os.Getenv("CFGMS_TLS_INSECURE") == "true" {
+		tlsInsecure = true
+	}
+
+	tlsCACertPath := moduleTLSCACert
+	if tlsCACertPath == "" {
+		tlsCACertPath = os.Getenv("CFGMS_TLS_CA_CERT")
+	}
+
+	return newClientFromFlags(apiURL, apiKey, tlsCACertPath, tlsInsecure)
+}
+
+// moduleCacheEntry mirrors the JSON response from GET /api/v1/modules.
+type moduleCacheEntry struct {
+	Publisher   string `json:"publisher"`
+	Name        string `json:"name"`
+	Version     string `json:"version"`
+	ContentHash string `json:"content_hash"`
+	Status      string `json:"status"`
+	TenantID    string `json:"tenant_id,omitempty"`
+}
+
+type moduleListResponse struct {
+	Modules []moduleCacheEntry `json:"modules"`
+	Total   int                `json:"total"`
+}
+
+func runModuleList(cmd *cobra.Command, _ []string) error {
+	if moduleListStatus != "" {
+		allowed := map[string]bool{"pending": true, "approved": true, "rejected": true}
+		if !allowed[moduleListStatus] {
+			return fmt.Errorf("invalid --status %q: must be pending, approved, or rejected", moduleListStatus)
+		}
+	}
+
+	client, err := getModuleAPIClient()
+	if err != nil {
+		return fmt.Errorf("failed to create API client: %w", err)
+	}
+
+	// Build query string.
+	params := url.Values{}
+	if moduleListTenant != "" {
+		params.Set("tenant", moduleListTenant)
+	}
+	if moduleListStatus != "" {
+		params.Set("status", moduleListStatus)
+	}
+
+	path := "/api/v1/modules"
+	if len(params) > 0 {
+		path += "?" + params.Encode()
+	}
+
+	resp, err := client.doRequest(context.Background(), http.MethodGet, path, nil)
+	if err != nil {
+		return fmt.Errorf("request failed: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("controller returned %s: %s", resp.Status, string(body))
+	}
+
+	var result moduleListResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return fmt.Errorf("failed to decode response: %w", err)
+	}
+
+	if moduleListJSON {
+		enc := json.NewEncoder(cmd.OutOrStdout())
+		enc.SetIndent("", "  ")
+		return enc.Encode(result.Modules)
+	}
+
+	w := tabwriter.NewWriter(cmd.OutOrStdout(), 0, 0, 2, ' ', 0)
+	if _, err := fmt.Fprintln(w, "PUBLISHER\tNAME\tVERSION\tSTATUS\tCONTENT HASH"); err != nil {
+		return err
+	}
+	for _, m := range result.Modules {
+		if _, err := fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n",
+			m.Publisher, m.Name, m.Version, m.Status, shortHash(m.ContentHash)); err != nil {
+			return err
+		}
+	}
+	return w.Flush()
+}
+
+func runModuleApprove(_ *cobra.Command, args []string) error {
+	ref := args[0]
+	if !moduleRefRE.MatchString(ref) {
+		return fmt.Errorf("invalid module reference %q: must match publisher/name@version (alphanumerics, dots, hyphens, underscores only)", ref)
+	}
+
+	// Split ref into publisher/name and version.
+	atIdx := strings.LastIndex(ref, "@")
+	namespacedName := ref[:atIdx]
+	version := ref[atIdx+1:]
+	slashIdx := strings.Index(namespacedName, "/")
+	publisher := namespacedName[:slashIdx]
+	name := namespacedName[slashIdx+1:]
+
+	client, err := getModuleAPIClient()
+	if err != nil {
+		return fmt.Errorf("failed to create API client: %w", err)
+	}
+
+	// POST /api/v1/modules/{publisher}/{name}/{version}/approve
+	// url.PathEscape on each component closes path-injection sinks (CWE-918);
+	// defense-in-depth with the moduleRefRE validation above.
+	path := fmt.Sprintf("/api/v1/modules/%s/%s/%s/approve",
+		url.PathEscape(publisher), url.PathEscape(name), url.PathEscape(version))
+
+	resp, err := client.doRequest(context.Background(), http.MethodPost, path, nil)
+	if err != nil {
+		return fmt.Errorf("request failed: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNoContent {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("controller returned %s: %s", resp.Status, string(body))
+	}
+
+	fmt.Printf("module approved: %s\n", ref)
+	return nil
+}
+
+// shortHash returns the first 12 characters of a hash for display purposes.
+func shortHash(hash string) string {
+	if len(hash) <= 12 {
+		return hash
+	}
+	return hash[:12] + "..."
+}

--- a/cmd/cfg/cmd/module_test.go
+++ b/cmd/cfg/cmd/module_test.go
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 CFGMS Contributors
+package cmd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestModuleRefRE_ValidRefs(t *testing.T) {
+	valid := []string{
+		"cfgms/hyperv@0.2.1",
+		"acme-corp/custom-module@1.3.0",
+		"publisher/name@version",
+		"a/b@c",
+		"vendor_a/tool.v2@1.0.0-rc1",
+	}
+	for _, ref := range valid {
+		assert.True(t, moduleRefRE.MatchString(ref), "expected valid ref: %q", ref)
+	}
+}
+
+func TestModuleRefRE_InvalidRefs(t *testing.T) {
+	invalid := []string{
+		"no-at-sign",
+		"publisher/name",
+		"@version",
+		"/name@version",
+		"publisher//name@version",
+		"publisher/name@",
+		"publisher name@version",
+		"../evil/name@version",
+	}
+	for _, ref := range invalid {
+		assert.False(t, moduleRefRE.MatchString(ref), "expected invalid ref: %q", ref)
+	}
+}
+
+// TestModuleListCmd_StatusValidation verifies the status flag rejects illegal values.
+// Only the validation path is tested here; valid statuses proceed to network I/O
+// which is out of scope for unit tests.
+func TestModuleListCmd_StatusValidation(t *testing.T) {
+	invalidStatuses := []string{"invalid", "PENDING", "Approved", "queued", "ALL"}
+	for _, s := range invalidStatuses {
+		t.Run("invalid_"+s, func(t *testing.T) {
+			origStatus := moduleListStatus
+			moduleListStatus = s
+			defer func() { moduleListStatus = origStatus }()
+
+			err := runModuleList(moduleListCmd, nil)
+			assert.ErrorContains(t, err, "invalid --status", "status %q must be rejected", s)
+		})
+	}
+}
+
+func TestModuleApproveCmd_ParsesRef(t *testing.T) {
+	// Verify that a well-formed ref passes moduleRefRE validation.
+	ref := "cfgms/hyperv@0.2.1"
+	require.True(t, moduleRefRE.MatchString(ref))
+
+	// Verify that runModuleApprove rejects an invalid ref without calling the API.
+	err := runModuleApprove(moduleApproveCmd, []string{"invalid-ref-no-at"})
+	assert.ErrorContains(t, err, "invalid module reference")
+}
+
+func TestShortHash(t *testing.T) {
+	assert.Equal(t, "abc123def456...", shortHash("abc123def456xyz"))
+	assert.Equal(t, "abc123", shortHash("abc123"))
+	assert.Equal(t, "abc123456789", shortHash("abc123456789"))
+}

--- a/cmd/cfg/cmd/root.go
+++ b/cmd/cfg/cmd/root.go
@@ -58,6 +58,7 @@ func init() {
 	rootCmd.AddCommand(workflowCmd)
 	rootCmd.AddCommand(configCmd)
 	rootCmd.AddCommand(installerCmd)
+	rootCmd.AddCommand(moduleCmd)
 }
 
 // versionCmd represents the version command

--- a/docs/architecture/controller-operating-model.md
+++ b/docs/architecture/controller-operating-model.md
@@ -771,3 +771,85 @@ The REST API is the admin interface to the controller. All operations are authen
 | **HA** | Cluster status, leader info, node list |
 | **Workflows** | Create, trigger, monitor workflows |
 | **Orchestration** | Initiate and monitor multi-node operations [GAP: not implemented — see Orchestration section above] |
+| **Modules** | List cached modules, approve queued bundles |
+
+---
+
+## Module Cache and Approval Workflow
+
+The controller fetches module bundles from configured git sources, verifies publisher signatures, assigns an approval decision, and stages approved bundles in a content-addressed on-disk cache.
+
+### Cache Filesystem Layout
+
+Bundles are stored at:
+
+```
+<data_dir>/module-cache/<publisher>/<name>/<version>/<content_hash>/
+    manifest.yaml      — module metadata (ModuleMetadata)
+    binaries.yaml      — os-arch → relative binary path index
+    signatures.yaml    — publisher signatures
+    content_hash.txt   — original content hash (pre-path-sanitization)
+    approval.yaml      — current approval state
+```
+
+The `<content_hash>` directory name is a path-safe transformation of the bundle's SHA-256 content hash. Standard base64 characters (`/`, `+`, `=`) are replaced with filesystem-safe equivalents; the original hash is preserved in `content_hash.txt` and returned by all cache operations.
+
+**Idempotency:** `Put()` with the same content hash is a no-op. `Put()` with a different hash at the same `(publisher, name, version)` returns `ErrContentAddressConflict`.
+
+### Git Source Resolver
+
+`GitSourceResolver` maps `module_sources:` config blocks to git clone URLs:
+
+```yaml
+module_sources:
+  cfgms:
+    type: git
+    base: https://modules.example.com/cfgms
+```
+
+For a reference like `cfgms/hyperv@0.2.1`, the clone URL is `<base>/<name>` (e.g. `https://modules.example.com/cfgms/hyperv`). Clones use `--depth 1` for minimal network and disk usage. Publisher, name, and version components are validated to reject path traversal sequences before use.
+
+### Approval State Machine
+
+Each bundle in the cache has one of three approval states:
+
+```
+                    ┌─────────────────┐
+  Trusted publisher │                 │
+  + valid signature │  auto-approve   │──────────────┐
+                    └─────────────────┘              │
+                                                     ▼
+  [bundle arrives]──►  evaluate()  ──► pending ──► approved
+                                          │
+                    Unknown publisher     │  (admin Approve())
+                                          │
+                    ┌─────────────────┐   │
+  Signature fails   │                 │   │
+  (tampered bundle) │     reject      │◄──┘ (only from pending)
+                    └─────────────────┘
+                          ▼
+                       rejected
+```
+
+**`ApprovalWorkflow.Evaluate(bundle, store)` rules:**
+
+| Condition | Decision |
+|-----------|----------|
+| Publisher in trust store AND signature passes `VerifyBundleSignature` | `AutoApprove` |
+| Publisher NOT in trust store | `QueueForReview` |
+| Publisher in trust store but signature fails | `Reject` |
+
+**Default trust list:** `["cfgms"]` (seeded from `pkg/modules/trust.CFGMSPublisherIdentity()`).
+
+### `cfg module` CLI
+
+```
+cfg module list [--tenant <tenant-path>] [--status pending|approved|rejected]
+cfg module approve <publisher>/<name>@<version>
+```
+
+`cfg module list` calls `GET /api/v1/modules` with optional `?tenant=...&status=...` query parameters and renders a tabular summary of publisher, name, version, approval status, and (truncated) content hash.
+
+`cfg module approve` calls `POST /api/v1/modules/<publisher>/<name>/<version>/approve`, which invokes `ApprovalWorkflow.Approve()` server-side. Only bundles in `pending` state can be approved; an error is returned for bundles that are already approved or rejected.
+
+Admin mTLS authentication (via admin bundle file) is required for both commands, following the same auth pattern as `cfg registration approve`.

--- a/docs/architecture/modules/distribution.md
+++ b/docs/architecture/modules/distribution.md
@@ -179,6 +179,57 @@ directory without overwriting the old one.
 
 ---
 
+## Controller Approval Workflow (S5)
+
+After a bundle is fetched from a git source and placed in the cache, the controller runs it through an approval workflow before making it available for steward delivery.
+
+### Approval State Machine
+
+```
+                         ┌──────────────────────────────┐
+  Trusted publisher      │  ApprovalWorkflow.Evaluate() │
+  + valid signature  ────►   AutoApprove                ├──► approved
+                         │                              │
+  Unknown publisher  ────►   QueueForReview             ├──► pending ──► approved
+                         │                              │       (admin Approve())
+  Sig verify fails   ────►   Reject                     ├──► rejected
+                         └──────────────────────────────┘
+```
+
+### Decision Rules
+
+| Condition | `ApprovalDecision` | Cache status |
+|-----------|--------------------|--------------|
+| Publisher in trust store AND `VerifyBundleSignature` passes | `AutoApprove` | `approved` |
+| Publisher NOT in trust store | `QueueForReview` | `pending` |
+| Publisher in trust store, signature fails | `Reject` | `rejected` |
+
+### `cfg module approve` CLI Usage
+
+Operators can promote a queued bundle to approved:
+
+```
+cfg module approve cfgms/hyperv@0.2.1
+```
+
+This calls `ApprovalWorkflow.Approve(addr)`, which transitions the cache entry from `pending` to `approved`. Only `pending` entries can be approved; `approved` and `rejected` entries return an error.
+
+To inspect pending bundles:
+
+```
+cfg module list --status pending
+cfg module list --tenant root/msp-a --status pending
+```
+
+### Implementation Reference
+
+- `features/controller/modules/approval` — `ApprovalWorkflow`
+- `features/controller/modules/cache` — `ModuleCache`
+- `features/controller/modules/sources/git` — `GitSourceResolver`
+- `cmd/cfg/cmd/module.go` — CLI commands
+
+---
+
 ## Steward Trust Mode (S7 reference)
 
 The steward enforces trust before loading a bundle:

--- a/features/controller/controller.go
+++ b/features/controller/controller.go
@@ -265,19 +265,6 @@ func (c *Controller) ListModules() []string {
 	return modules
 }
 
-// GetModule returns a module by name (for ModuleRegistry interface)
-func (c *Controller) GetModule(name string) (interface{}, error) {
-	c.mu.RLock()
-	defer c.mu.RUnlock()
-
-	module, exists := c.modules[name]
-	if !exists {
-		return nil, ErrModuleNotFound
-	}
-
-	return module, nil
-}
-
 // GetModuleTyped returns a module by name with proper typing
 func (c *Controller) GetModuleTyped(name string) (Module, error) {
 	c.mu.RLock()
@@ -288,17 +275,5 @@ func (c *Controller) GetModuleTyped(name string) (Module, error) {
 		return nil, ErrModuleNotFound
 	}
 
-	return module, nil
-}
-
-// ExecuteModuleOperation executes an operation on a module
-func (c *Controller) ExecuteModuleOperation(ctx context.Context, moduleName, operation string, params map[string]interface{}) (interface{}, error) {
-	module, err := c.GetModule(moduleName)
-	if err != nil {
-		return nil, err
-	}
-
-	// Design decision: module interface is injected at controller startup; this comment block describes the expected call site pattern, not a missing implementation.
-	c.logger.Info("Executing module operation", "module", moduleName, "operation", operation)
 	return module, nil
 }

--- a/features/controller/controller_test.go
+++ b/features/controller/controller_test.go
@@ -14,6 +14,14 @@ import (
 	pkgtestutil "github.com/cfgis/cfgms/pkg/testutil"
 )
 
+// testModule is a minimal real implementation of Module for registration tests.
+type testModule struct{ moduleName string }
+
+func (m *testModule) Name() string                                      { return m.moduleName }
+func (m *testModule) Get(_ context.Context, _ string) (string, error)   { return "", nil }
+func (m *testModule) Set(_ context.Context, _, _ string) error          { return nil }
+func (m *testModule) Test(_ context.Context, _, _ string) (bool, error) { return true, nil }
+
 func TestControllerCreation(t *testing.T) {
 	// Create a test logger
 	logger := testutil.NewMockLogger(true)
@@ -187,30 +195,25 @@ func TestModuleRegistration(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = ctrl.Close() })
 
-	// Create mock modules
-	moduleA := testutil.NewMockModule("moduleA")
-	moduleB := testutil.NewMockModule("moduleB")
-
 	// Register the first module
-	err = ctrl.RegisterModule(moduleA)
+	err = ctrl.RegisterModule(&testModule{moduleName: "moduleA"})
 	assert.NoError(t, err)
 
 	// Register the second module
-	err = ctrl.RegisterModule(moduleB)
+	err = ctrl.RegisterModule(&testModule{moduleName: "moduleB"})
 	assert.NoError(t, err)
 
 	// Try to register a duplicate module
-	duplicateModule := testutil.NewMockModule("moduleA")
-	err = ctrl.RegisterModule(duplicateModule)
+	err = ctrl.RegisterModule(&testModule{moduleName: "moduleA"})
 	assert.Error(t, err)
 	assert.Equal(t, ErrModuleExists, err)
 
-	// Get a registered module
-	_, err = ctrl.GetModule("moduleA")
+	// Verify typed lookup still works for registered modules.
+	_, err = ctrl.GetModuleTyped("moduleA")
 	assert.NoError(t, err)
 
-	// Get a non-existent module
-	_, err = ctrl.GetModule("nonExistentModule")
+	// GetModuleTyped returns ErrModuleNotFound for non-existent modules.
+	_, err = ctrl.GetModuleTyped("nonExistentModule")
 	assert.Error(t, err)
 	assert.Equal(t, ErrModuleNotFound, err)
 }

--- a/features/controller/directory/service.go
+++ b/features/controller/directory/service.go
@@ -49,14 +49,8 @@ type providerMetrics struct {
 
 // ModuleRegistry defines how the directory service integrates with CFGMS modules
 type ModuleRegistry interface {
-	// GetModule returns a module by name
-	GetModule(name string) (interface{}, error)
-
-	// ListModules returns all available modules
+	// ListModules returns all available module names
 	ListModules() []string
-
-	// ExecuteModuleOperation executes an operation on a module
-	ExecuteModuleOperation(ctx context.Context, moduleName, operation string, params map[string]interface{}) (interface{}, error)
 }
 
 // NewDirectoryService creates a new directory service instance

--- a/features/controller/modules/approval/workflow.go
+++ b/features/controller/modules/approval/workflow.go
@@ -1,0 +1,125 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 CFGMS Contributors
+
+// Package approval implements the module bundle approval workflow.
+// The workflow evaluates an incoming bundle against the trust store and assigns
+// an approval decision. Admin operators may explicitly approve queued bundles
+// via Approve().
+package approval
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/cfgis/cfgms/features/controller/modules/cache"
+	"github.com/cfgis/cfgms/pkg/modules/bundle"
+	"github.com/cfgis/cfgms/pkg/modules/trust"
+)
+
+// ApprovalDecision is the outcome of evaluating a bundle against the trust store.
+type ApprovalDecision int
+
+const (
+	// AutoApprove means the bundle is from a trusted publisher with a valid signature.
+	AutoApprove ApprovalDecision = iota
+	// QueueForReview means the publisher is unknown; an admin must act before the bundle is staged.
+	QueueForReview
+	// Reject means the signature verification failed (tampered or malformed bundle).
+	Reject
+)
+
+// ErrNotQueued is returned by Approve when the entry is not in QueueForReview (pending) state.
+var ErrNotQueued = errors.New("module is not queued for review")
+
+// ApprovalWorkflow evaluates incoming bundles and manages their approval state.
+// State is persisted via the ModuleCache (filesystem-backed durable storage).
+type ApprovalWorkflow struct {
+	cache *cache.ModuleCache
+}
+
+// New returns an ApprovalWorkflow backed by the given cache.
+func New(c *cache.ModuleCache) *ApprovalWorkflow {
+	return &ApprovalWorkflow{cache: c}
+}
+
+// Evaluate determines the approval decision for b against store.
+//
+// Decision rules:
+//   - Publisher in trust store AND at least one signature from that publisher passes
+//     VerifyBundleSignature → AutoApprove.
+//   - Publisher NOT in trust store → QueueForReview.
+//   - Publisher in trust store but no valid signature found → Reject.
+//
+// Evaluate is a pure read: it does not modify the cache. The caller must call
+// cache.Put followed by cache.SetApprovalStatus to persist the decision.
+func (w *ApprovalWorkflow) Evaluate(b *bundle.Bundle, store trust.TrustStore) (ApprovalDecision, error) {
+	if b == nil || b.Manifest == nil {
+		return Reject, errors.New("bundle or manifest is nil")
+	}
+
+	publisher := b.Manifest.Publisher
+	_, known := store.GetPublisher(publisher)
+	if !known {
+		return QueueForReview, nil
+	}
+
+	// Publisher is trusted — verify their signature.
+	for _, sig := range b.Signatures {
+		if sig.Publisher != publisher {
+			continue
+		}
+		if err := trust.VerifyBundleSignature(b, sig, store); err == nil {
+			return AutoApprove, nil
+		}
+	}
+
+	// Publisher trusted but no valid signature found.
+	return Reject, nil
+}
+
+// Approve transitions a queued (pending) cache entry to approved.
+// Returns ErrNotQueued if the entry is not in pending state.
+// Returns cache.ErrBundleNotFound if no entry exists for addr.
+func (w *ApprovalWorkflow) Approve(addr bundle.ContentAddress) error {
+	status, err := w.cache.GetApprovalStatus(addr)
+	if err != nil {
+		return fmt.Errorf("get approval status: %w", err)
+	}
+	if status != cache.ApprovalStatusPending {
+		return fmt.Errorf("%w: current status is %q", ErrNotQueued, status)
+	}
+	return w.cache.SetApprovalStatus(addr, cache.ApprovalStatusApproved)
+}
+
+// EvaluateAndStore evaluates b, stores it in the cache, and persists the decision as
+// the initial approval status. It is a convenience method that combines Evaluate +
+// cache.Put + cache.SetApprovalStatus into a single atomic-ish operation.
+//
+// Rejected bundles are still stored in the cache (with rejected status) so operators
+// can audit what was blocked.
+func (w *ApprovalWorkflow) EvaluateAndStore(b *bundle.Bundle, store trust.TrustStore) (ApprovalDecision, error) {
+	decision, err := w.Evaluate(b, store)
+	if err != nil {
+		return decision, err
+	}
+
+	if putErr := w.cache.Put(b); putErr != nil {
+		return decision, fmt.Errorf("cache Put: %w", putErr)
+	}
+
+	var targetStatus cache.ApprovalStatus
+	switch decision {
+	case AutoApprove:
+		targetStatus = cache.ApprovalStatusApproved
+	case QueueForReview:
+		targetStatus = cache.ApprovalStatusPending
+	case Reject:
+		targetStatus = cache.ApprovalStatusRejected
+	}
+
+	if setErr := w.cache.SetApprovalStatus(b.ContentAddress(), targetStatus); setErr != nil {
+		return decision, fmt.Errorf("set approval status: %w", setErr)
+	}
+
+	return decision, nil
+}

--- a/features/controller/modules/approval/workflow_test.go
+++ b/features/controller/modules/approval/workflow_test.go
@@ -1,0 +1,225 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 CFGMS Contributors
+package approval_test
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+
+	"github.com/cfgis/cfgms/features/controller/modules/approval"
+	"github.com/cfgis/cfgms/features/controller/modules/cache"
+	modules "github.com/cfgis/cfgms/features/modules"
+	"github.com/cfgis/cfgms/pkg/modules/bundle"
+	"github.com/cfgis/cfgms/pkg/modules/trust"
+)
+
+// testKeys holds an Ed25519 key pair for a named publisher.
+type testKeys struct {
+	publisher string
+	pubKey    ed25519.PublicKey
+	privKey   ed25519.PrivateKey
+}
+
+func generateKeys(t *testing.T, publisher string) testKeys {
+	t.Helper()
+	pubKey, privKey, err := ed25519.GenerateKey(rand.Reader)
+	require.NoError(t, err)
+	return testKeys{publisher: publisher, pubKey: pubKey, privKey: privKey}
+}
+
+// makeSignedBundle creates a Bundle with a valid Ed25519 signature for the given publisher.
+func makeSignedBundle(t *testing.T, keys testKeys, name, version string) *bundle.Bundle {
+	t.Helper()
+	meta := &modules.ModuleMetadata{
+		Name:      name,
+		Version:   version,
+		Publisher: keys.publisher,
+		Executors: []string{"steward"},
+	}
+	binaries := map[string][]byte{"linux-amd64": []byte("fake-binary-content")}
+	manifestBytes, err := yaml.Marshal(meta)
+	require.NoError(t, err)
+
+	contentHash, err := bundle.ComputeContentHash(binaries, manifestBytes)
+	require.NoError(t, err)
+
+	sig := ed25519.Sign(keys.privKey, []byte(contentHash))
+	return &bundle.Bundle{
+		Manifest: meta,
+		Binaries: map[string]string{"linux-amd64": "binaries/linux-amd64"},
+		Signatures: []bundle.BundleSignature{
+			{Publisher: keys.publisher, Algorithm: "ed25519", Signature: sig},
+		},
+		ContentHash: contentHash,
+	}
+}
+
+func makeWorkflow(t *testing.T) (*approval.ApprovalWorkflow, *cache.ModuleCache) {
+	t.Helper()
+	c, err := cache.New(t.TempDir() + "/module-cache")
+	require.NoError(t, err)
+	return approval.New(c), c
+}
+
+func makeTrustStore(keys ...testKeys) trust.TrustStore {
+	store := trust.NewInMemoryTrustStore()
+	for _, k := range keys {
+		_ = store.AddPublisher(trust.PublisherIdentity{
+			Name:      k.publisher,
+			PublicKey: []byte(k.pubKey),
+			Algorithm: "ed25519",
+		})
+	}
+	return store
+}
+
+// [REQUIRED TEST] Trusted publisher + valid signature → AutoApprove.
+func TestApprovalWorkflow_Evaluate_TrustedPublisher_ValidSignature(t *testing.T) {
+	wf, _ := makeWorkflow(t)
+	keys := generateKeys(t, "cfgms")
+	b := makeSignedBundle(t, keys, "hyperv", "0.2.1")
+	store := makeTrustStore(keys)
+
+	decision, err := wf.Evaluate(b, store)
+	require.NoError(t, err)
+	assert.Equal(t, approval.AutoApprove, decision)
+}
+
+// [REQUIRED TEST] Unknown publisher → QueueForReview.
+func TestApprovalWorkflow_Evaluate_UnknownPublisher(t *testing.T) {
+	wf, _ := makeWorkflow(t)
+	keys := generateKeys(t, "unknown-vendor")
+	b := makeSignedBundle(t, keys, "hyperv", "0.2.1")
+	// Trust store only knows "cfgms", not "unknown-vendor".
+	cfgmsKeys := generateKeys(t, "cfgms")
+	store := makeTrustStore(cfgmsKeys)
+
+	decision, err := wf.Evaluate(b, store)
+	require.NoError(t, err)
+	assert.Equal(t, approval.QueueForReview, decision)
+}
+
+// [REQUIRED TEST] Tampered bundle (hash mismatch) → Reject.
+func TestApprovalWorkflow_Evaluate_TamperedBundle(t *testing.T) {
+	wf, _ := makeWorkflow(t)
+	keys := generateKeys(t, "cfgms")
+	b := makeSignedBundle(t, keys, "hyperv", "0.2.1")
+	store := makeTrustStore(keys)
+
+	// Tamper: change the content hash so the signature is no longer valid.
+	b.ContentHash = "tampered-hash-that-was-not-signed"
+
+	decision, err := wf.Evaluate(b, store)
+	require.NoError(t, err)
+	assert.Equal(t, approval.Reject, decision)
+}
+
+// [REQUIRED TEST] Admin Approve() call transitions QueueForReview entry to approved.
+func TestApprovalWorkflow_Approve_TransitionsToApproved(t *testing.T) {
+	wf, c := makeWorkflow(t)
+	keys := generateKeys(t, "unknown-vendor")
+	b := makeSignedBundle(t, keys, "tool", "1.0.0")
+
+	// Store the bundle manually in pending state (simulating QueueForReview from Evaluate).
+	require.NoError(t, c.Put(b))
+	addr := b.ContentAddress()
+
+	// Verify it starts as pending.
+	status, err := c.GetApprovalStatus(addr)
+	require.NoError(t, err)
+	assert.Equal(t, cache.ApprovalStatusPending, status)
+
+	// Admin approves.
+	require.NoError(t, wf.Approve(addr))
+
+	// Verify it is now approved.
+	status, err = c.GetApprovalStatus(addr)
+	require.NoError(t, err)
+	assert.Equal(t, cache.ApprovalStatusApproved, status)
+}
+
+// TestApprovalWorkflow_Approve_AlreadyApproved returns ErrNotQueued.
+func TestApprovalWorkflow_Approve_AlreadyApproved(t *testing.T) {
+	wf, c := makeWorkflow(t)
+	keys := generateKeys(t, "cfgms")
+	b := makeSignedBundle(t, keys, "mod", "1.0.0")
+	require.NoError(t, c.Put(b))
+	require.NoError(t, c.SetApprovalStatus(b.ContentAddress(), cache.ApprovalStatusApproved))
+
+	err := wf.Approve(b.ContentAddress())
+	assert.ErrorIs(t, err, approval.ErrNotQueued)
+}
+
+// TestApprovalWorkflow_Approve_NotFound returns ErrBundleNotFound for missing entries.
+func TestApprovalWorkflow_Approve_NotFound(t *testing.T) {
+	wf, _ := makeWorkflow(t)
+	addr := bundle.ContentAddress{Publisher: "cfgms", Name: "missing", Version: "1.0.0", ContentHash: "nohash"}
+	err := wf.Approve(addr)
+	assert.ErrorIs(t, err, cache.ErrBundleNotFound)
+}
+
+// TestApprovalWorkflow_EvaluateAndStore_AutoApprove persists AutoApprove correctly.
+func TestApprovalWorkflow_EvaluateAndStore_AutoApprove(t *testing.T) {
+	wf, c := makeWorkflow(t)
+	keys := generateKeys(t, "cfgms")
+	b := makeSignedBundle(t, keys, "hyperv", "0.2.1")
+	store := makeTrustStore(keys)
+
+	decision, err := wf.EvaluateAndStore(b, store)
+	require.NoError(t, err)
+	assert.Equal(t, approval.AutoApprove, decision)
+
+	status, err := c.GetApprovalStatus(b.ContentAddress())
+	require.NoError(t, err)
+	assert.Equal(t, cache.ApprovalStatusApproved, status)
+}
+
+// TestApprovalWorkflow_EvaluateAndStore_QueueForReview persists pending status correctly.
+func TestApprovalWorkflow_EvaluateAndStore_QueueForReview(t *testing.T) {
+	wf, c := makeWorkflow(t)
+	keys := generateKeys(t, "unknown-vendor")
+	b := makeSignedBundle(t, keys, "tool", "1.0.0")
+	store := makeTrustStore(generateKeys(t, "cfgms"))
+
+	decision, err := wf.EvaluateAndStore(b, store)
+	require.NoError(t, err)
+	assert.Equal(t, approval.QueueForReview, decision)
+
+	status, err := c.GetApprovalStatus(b.ContentAddress())
+	require.NoError(t, err)
+	assert.Equal(t, cache.ApprovalStatusPending, status)
+}
+
+// TestApprovalWorkflow_EvaluateAndStore_Reject persists rejected status correctly.
+func TestApprovalWorkflow_EvaluateAndStore_Reject(t *testing.T) {
+	wf, c := makeWorkflow(t)
+	keys := generateKeys(t, "cfgms")
+	b := makeSignedBundle(t, keys, "hyperv", "0.2.1")
+	store := makeTrustStore(keys)
+
+	// Tamper the bundle.
+	b.ContentHash = "tampered"
+
+	decision, err := wf.EvaluateAndStore(b, store)
+	require.NoError(t, err)
+	assert.Equal(t, approval.Reject, decision)
+
+	status, err := c.GetApprovalStatus(b.ContentAddress())
+	require.NoError(t, err)
+	assert.Equal(t, cache.ApprovalStatusRejected, status)
+}
+
+// TestApprovalWorkflow_Evaluate_NilBundle returns Reject and an error.
+func TestApprovalWorkflow_Evaluate_NilBundle(t *testing.T) {
+	wf, _ := makeWorkflow(t)
+	store := trust.NewInMemoryTrustStore()
+
+	decision, err := wf.Evaluate(nil, store)
+	assert.Equal(t, approval.Reject, decision)
+	assert.Error(t, err)
+}

--- a/features/controller/modules/cache/cache.go
+++ b/features/controller/modules/cache/cache.go
@@ -1,0 +1,377 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 CFGMS Contributors
+
+// Package cache implements the controller module cache.
+// Bundles are stored content-addressed under:
+//
+//	<root>/<publisher>/<name>/<version>/<content_hash>/
+//	    manifest.yaml
+//	    binaries.yaml    (os-arch → relative path index)
+//	    signatures.yaml
+//	    approval.yaml    (approval state)
+package cache
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+
+	"gopkg.in/yaml.v3"
+
+	modules "github.com/cfgis/cfgms/features/modules"
+	"github.com/cfgis/cfgms/pkg/modules/bundle"
+)
+
+var (
+	// ErrBundleNotFound is returned when the requested bundle is not in the cache.
+	ErrBundleNotFound = errors.New("bundle not found in cache")
+
+	// ErrContentAddressConflict is returned when a different bundle already exists at the
+	// same (publisher, name, version) with a different content hash.
+	ErrContentAddressConflict = errors.New("content address conflict: different content hash already cached for this publisher/name/version")
+)
+
+// ApprovalStatus represents the approval state of a cached bundle.
+type ApprovalStatus string
+
+const (
+	ApprovalStatusPending  ApprovalStatus = "pending"
+	ApprovalStatusApproved ApprovalStatus = "approved"
+	ApprovalStatusRejected ApprovalStatus = "rejected"
+)
+
+// CacheEntry is a catalog record returned by List.
+type CacheEntry struct {
+	Addr   bundle.ContentAddress
+	Status ApprovalStatus
+}
+
+// approvalRecord is the on-disk format for approval state.
+type approvalRecord struct {
+	Status ApprovalStatus `yaml:"status"`
+}
+
+// ModuleCache is a content-addressed filesystem cache for module bundles.
+// All public methods are safe for concurrent use.
+type ModuleCache struct {
+	mu      sync.RWMutex
+	rootDir string
+}
+
+// New creates a ModuleCache rooted at rootDir, creating it if needed.
+func New(rootDir string) (*ModuleCache, error) {
+	if err := os.MkdirAll(rootDir, 0750); err != nil {
+		return nil, fmt.Errorf("create module cache root: %w", err)
+	}
+	return &ModuleCache{rootDir: rootDir}, nil
+}
+
+// bundleDir returns the filesystem path for the given content address.
+// The content hash is converted to a filesystem-safe directory name via hashToDir.
+func (c *ModuleCache) bundleDir(addr bundle.ContentAddress) (string, error) {
+	if err := validateComponent(addr.Publisher); err != nil {
+		return "", fmt.Errorf("invalid publisher: %w", err)
+	}
+	if err := validateComponent(addr.Name); err != nil {
+		return "", fmt.Errorf("invalid name: %w", err)
+	}
+	if err := validateComponent(addr.Version); err != nil {
+		return "", fmt.Errorf("invalid version: %w", err)
+	}
+	if addr.ContentHash == "" {
+		return "", fmt.Errorf("invalid content hash: must not be empty")
+	}
+	if strings.Contains(addr.ContentHash, "..") {
+		return "", fmt.Errorf("invalid content hash: must not contain dot sequences: %q", addr.ContentHash)
+	}
+	return filepath.Join(c.rootDir, addr.Publisher, addr.Name, addr.Version, hashToDir(addr.ContentHash)), nil
+}
+
+// validateComponent rejects empty strings and path traversal sequences.
+// Used for publisher, name, and version — not for content hashes (see hashToDir).
+func validateComponent(s string) error {
+	if s == "" {
+		return errors.New("must not be empty")
+	}
+	if strings.Contains(s, "..") || strings.ContainsRune(s, '/') || strings.ContainsRune(s, '\\') {
+		return fmt.Errorf("must not contain path separators or dot sequences: %q", s)
+	}
+	return nil
+}
+
+// hashToDir converts a base64 content hash to a filesystem-safe directory name.
+// Standard base64 uses '+', '/', and '=' which are problematic in path components.
+// This replaces them with URL-safe equivalents and strips padding so the name is
+// unambiguous on all supported filesystems.
+func hashToDir(hash string) string {
+	r := strings.NewReplacer("/", "_", "+", "-", "=", "")
+	return r.Replace(hash)
+}
+
+// Put stores b in the cache.
+//
+// Idempotent: if b.ContentAddress() already exists in the cache (same content hash),
+// Put returns nil without re-writing any files.
+//
+// Returns ErrContentAddressConflict if the same (publisher, name, version) tuple already
+// exists under a different content hash — this indicates tampering or a hash collision.
+func (c *ModuleCache) Put(b *bundle.Bundle) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	addr := b.ContentAddress()
+	dir, err := c.bundleDir(addr)
+	if err != nil {
+		return err
+	}
+
+	// Idempotent: exact content address already stored.
+	if _, err := os.Stat(filepath.Join(dir, "manifest.yaml")); err == nil {
+		return nil
+	}
+
+	// Conflict check: a different hash exists for the same (publisher/name/version).
+	safeHash := hashToDir(addr.ContentHash)
+	versionDir := filepath.Join(c.rootDir, addr.Publisher, addr.Name, addr.Version)
+	if ents, readErr := os.ReadDir(versionDir); readErr == nil {
+		for _, e := range ents {
+			if e.IsDir() && e.Name() != safeHash {
+				return ErrContentAddressConflict
+			}
+		}
+	}
+
+	if err := os.MkdirAll(dir, 0750); err != nil {
+		return fmt.Errorf("create bundle dir: %w", err)
+	}
+
+	manifestBytes, err := yaml.Marshal(b.Manifest)
+	if err != nil {
+		return fmt.Errorf("marshal manifest: %w", err)
+	}
+	if err := writeFileAtomic(filepath.Join(dir, "manifest.yaml"), manifestBytes, 0640); err != nil {
+		return fmt.Errorf("write manifest: %w", err)
+	}
+
+	sigBytes, err := yaml.Marshal(b.Signatures)
+	if err != nil {
+		return fmt.Errorf("marshal signatures: %w", err)
+	}
+	if err := writeFileAtomic(filepath.Join(dir, "signatures.yaml"), sigBytes, 0640); err != nil {
+		return fmt.Errorf("write signatures: %w", err)
+	}
+
+	binBytes, err := yaml.Marshal(b.Binaries)
+	if err != nil {
+		return fmt.Errorf("marshal binaries index: %w", err)
+	}
+	if err := writeFileAtomic(filepath.Join(dir, "binaries.yaml"), binBytes, 0640); err != nil {
+		return fmt.Errorf("write binaries index: %w", err)
+	}
+
+	// Store the original content hash so List() can recover it from the directory name.
+	if err := writeFileAtomic(filepath.Join(dir, "content_hash.txt"), []byte(addr.ContentHash), 0640); err != nil {
+		return fmt.Errorf("write content hash: %w", err)
+	}
+
+	rec := approvalRecord{Status: ApprovalStatusPending}
+	recBytes, err := yaml.Marshal(rec)
+	if err != nil {
+		return fmt.Errorf("marshal approval record: %w", err)
+	}
+	if err := writeFileAtomic(filepath.Join(dir, "approval.yaml"), recBytes, 0640); err != nil {
+		return fmt.Errorf("write approval record: %w", err)
+	}
+
+	return nil
+}
+
+// Get retrieves a bundle from the cache by content address.
+// Returns ErrBundleNotFound if no bundle exists at the given address.
+func (c *ModuleCache) Get(addr bundle.ContentAddress) (*bundle.Bundle, error) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	dir, err := c.bundleDir(addr)
+	if err != nil {
+		return nil, err
+	}
+
+	if _, err := os.Stat(filepath.Join(dir, "manifest.yaml")); errors.Is(err, os.ErrNotExist) {
+		return nil, ErrBundleNotFound
+	}
+
+	manifestBytes, err := os.ReadFile(filepath.Join(dir, "manifest.yaml"))
+	if err != nil {
+		return nil, fmt.Errorf("read manifest: %w", err)
+	}
+	var meta modules.ModuleMetadata
+	if err := yaml.Unmarshal(manifestBytes, &meta); err != nil {
+		return nil, fmt.Errorf("unmarshal manifest: %w", err)
+	}
+
+	sigBytes, err := os.ReadFile(filepath.Join(dir, "signatures.yaml"))
+	if err != nil {
+		return nil, fmt.Errorf("read signatures: %w", err)
+	}
+	var sigs []bundle.BundleSignature
+	if err := yaml.Unmarshal(sigBytes, &sigs); err != nil {
+		return nil, fmt.Errorf("unmarshal signatures: %w", err)
+	}
+
+	binBytes, err := os.ReadFile(filepath.Join(dir, "binaries.yaml"))
+	if err != nil {
+		return nil, fmt.Errorf("read binaries index: %w", err)
+	}
+	var binaries map[string]string
+	if err := yaml.Unmarshal(binBytes, &binaries); err != nil {
+		return nil, fmt.Errorf("unmarshal binaries index: %w", err)
+	}
+
+	return &bundle.Bundle{
+		Manifest:    &meta,
+		Binaries:    binaries,
+		Signatures:  sigs,
+		ContentHash: addr.ContentHash,
+	}, nil
+}
+
+// SetApprovalStatus updates the approval state for a cached bundle.
+// Returns ErrBundleNotFound if no bundle exists at the given address.
+func (c *ModuleCache) SetApprovalStatus(addr bundle.ContentAddress, status ApprovalStatus) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	dir, err := c.bundleDir(addr)
+	if err != nil {
+		return err
+	}
+	if _, err := os.Stat(filepath.Join(dir, "manifest.yaml")); errors.Is(err, os.ErrNotExist) {
+		return ErrBundleNotFound
+	}
+
+	rec := approvalRecord{Status: status}
+	recBytes, err := yaml.Marshal(rec)
+	if err != nil {
+		return fmt.Errorf("marshal approval record: %w", err)
+	}
+	return writeFileAtomic(filepath.Join(dir, "approval.yaml"), recBytes, 0640)
+}
+
+// GetApprovalStatus returns the current approval state for a cached bundle.
+// Returns ErrBundleNotFound if no bundle exists at the given address.
+func (c *ModuleCache) GetApprovalStatus(addr bundle.ContentAddress) (ApprovalStatus, error) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	dir, err := c.bundleDir(addr)
+	if err != nil {
+		return "", err
+	}
+
+	recBytes, err := os.ReadFile(filepath.Join(dir, "approval.yaml"))
+	if errors.Is(err, os.ErrNotExist) {
+		return "", ErrBundleNotFound
+	}
+	if err != nil {
+		return "", fmt.Errorf("read approval record: %w", err)
+	}
+
+	var rec approvalRecord
+	if err := yaml.Unmarshal(recBytes, &rec); err != nil {
+		return "", fmt.Errorf("unmarshal approval record: %w", err)
+	}
+	return rec.Status, nil
+}
+
+// List returns all entries in the cache with their current approval status.
+func (c *ModuleCache) List() ([]CacheEntry, error) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	var entries []CacheEntry
+
+	publishers, err := os.ReadDir(c.rootDir)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("read cache root: %w", err)
+	}
+
+	for _, pub := range publishers {
+		if !pub.IsDir() {
+			continue
+		}
+		names, _ := os.ReadDir(filepath.Join(c.rootDir, pub.Name()))
+		for _, name := range names {
+			if !name.IsDir() {
+				continue
+			}
+			versions, _ := os.ReadDir(filepath.Join(c.rootDir, pub.Name(), name.Name()))
+			for _, ver := range versions {
+				if !ver.IsDir() {
+					continue
+				}
+				hashes, _ := os.ReadDir(filepath.Join(c.rootDir, pub.Name(), name.Name(), ver.Name()))
+				for _, hash := range hashes {
+					if !hash.IsDir() {
+						continue
+					}
+					hashDir := filepath.Join(c.rootDir, pub.Name(), name.Name(), ver.Name(), hash.Name())
+					// Skip incomplete writes.
+					if _, statErr := os.Stat(filepath.Join(hashDir, "manifest.yaml")); statErr != nil {
+						continue
+					}
+					// Recover the original content hash (pre-sanitization).
+					originalHash := hash.Name()
+					if hashBytes, readErr := os.ReadFile(filepath.Join(hashDir, "content_hash.txt")); readErr == nil {
+						originalHash = strings.TrimSpace(string(hashBytes))
+					}
+					addr := bundle.ContentAddress{
+						Publisher:   pub.Name(),
+						Name:        name.Name(),
+						Version:     ver.Name(),
+						ContentHash: originalHash,
+					}
+					status := ApprovalStatusPending
+					if recBytes, readErr := os.ReadFile(filepath.Join(hashDir, "approval.yaml")); readErr == nil {
+						var rec approvalRecord
+						if yaml.Unmarshal(recBytes, &rec) == nil {
+							status = rec.Status
+						}
+					}
+					entries = append(entries, CacheEntry{Addr: addr, Status: status})
+				}
+			}
+		}
+	}
+
+	return entries, nil
+}
+
+// writeFileAtomic writes data to path using a temp-file + rename for atomicity.
+func writeFileAtomic(path string, data []byte, perm os.FileMode) error {
+	tmp, err := os.CreateTemp(filepath.Dir(path), ".tmp-")
+	if err != nil {
+		return err
+	}
+	tmpPath := tmp.Name()
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		_ = os.Remove(tmpPath)
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		_ = os.Remove(tmpPath)
+		return err
+	}
+	if err := os.Chmod(tmpPath, perm); err != nil {
+		_ = os.Remove(tmpPath)
+		return err
+	}
+	return os.Rename(tmpPath, path)
+}

--- a/features/controller/modules/cache/cache_test.go
+++ b/features/controller/modules/cache/cache_test.go
@@ -1,0 +1,244 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 CFGMS Contributors
+package cache_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+
+	"github.com/cfgis/cfgms/features/controller/modules/cache"
+	modules "github.com/cfgis/cfgms/features/modules"
+	"github.com/cfgis/cfgms/pkg/modules/bundle"
+)
+
+func makeTestBundle(publisher, name, version, hash string) *bundle.Bundle {
+	return &bundle.Bundle{
+		Manifest: &modules.ModuleMetadata{
+			Name:      name,
+			Version:   version,
+			Publisher: publisher,
+			Executors: []string{"steward"},
+		},
+		Binaries:    map[string]string{"linux-amd64": "binaries/linux-amd64"},
+		Signatures:  []bundle.BundleSignature{{Publisher: publisher, Algorithm: "ed25519", Signature: make([]byte, 64)}},
+		ContentHash: hash,
+	}
+}
+
+func makeTestCache(t *testing.T) *cache.ModuleCache {
+	t.Helper()
+	c, err := cache.New(t.TempDir() + "/module-cache")
+	require.NoError(t, err)
+	return c
+}
+
+// [REQUIRED TEST] Put then Get round-trip returns identical bundle.
+func TestModuleCache_PutGet_RoundTrip(t *testing.T) {
+	c := makeTestCache(t)
+	b := makeTestBundle("cfgms", "hyperv", "0.2.1", "abc123hash")
+
+	require.NoError(t, c.Put(b))
+
+	got, err := c.Get(b.ContentAddress())
+	require.NoError(t, err)
+
+	assert.Equal(t, b.Manifest.Name, got.Manifest.Name)
+	assert.Equal(t, b.Manifest.Version, got.Manifest.Version)
+	assert.Equal(t, b.Manifest.Publisher, got.Manifest.Publisher)
+	assert.Equal(t, b.ContentHash, got.ContentHash)
+	assert.Equal(t, b.Binaries, got.Binaries)
+	require.Len(t, got.Signatures, 1)
+	assert.Equal(t, b.Signatures[0].Publisher, got.Signatures[0].Publisher)
+	assert.Equal(t, b.Signatures[0].Algorithm, got.Signatures[0].Algorithm)
+}
+
+// [REQUIRED TEST] Put of identical bundle (same content hash) is idempotent (no error, no duplicate).
+func TestModuleCache_Put_Idempotent(t *testing.T) {
+	c := makeTestCache(t)
+	b := makeTestBundle("cfgms", "hyperv", "0.2.1", "abc123hash")
+
+	require.NoError(t, c.Put(b))
+	// Second Put with same bundle must succeed without error.
+	require.NoError(t, c.Put(b))
+
+	entries, err := c.List()
+	require.NoError(t, err)
+	assert.Len(t, entries, 1, "idempotent Put must not create duplicate entries")
+}
+
+// TestModuleCache_Put_ConflictDifferentHash ensures ErrContentAddressConflict is returned
+// when a different hash exists at the same (publisher/name/version).
+func TestModuleCache_Put_ConflictDifferentHash(t *testing.T) {
+	c := makeTestCache(t)
+	b1 := makeTestBundle("cfgms", "hyperv", "0.2.1", "hash-original")
+	b2 := makeTestBundle("cfgms", "hyperv", "0.2.1", "hash-different")
+
+	require.NoError(t, c.Put(b1))
+	err := c.Put(b2)
+	assert.ErrorIs(t, err, cache.ErrContentAddressConflict)
+}
+
+// TestModuleCache_Get_NotFound returns ErrBundleNotFound for unknown addresses.
+func TestModuleCache_Get_NotFound(t *testing.T) {
+	c := makeTestCache(t)
+	addr := bundle.ContentAddress{
+		Publisher:   "cfgms",
+		Name:        "missing",
+		Version:     "1.0.0",
+		ContentHash: "nohash",
+	}
+	_, err := c.Get(addr)
+	assert.ErrorIs(t, err, cache.ErrBundleNotFound)
+}
+
+// TestModuleCache_List returns all stored entries with correct approval status.
+func TestModuleCache_List(t *testing.T) {
+	c := makeTestCache(t)
+
+	b1 := makeTestBundle("cfgms", "hyperv", "0.2.1", "hash1")
+	b2 := makeTestBundle("cfgms", "file", "1.0.0", "hash2")
+	require.NoError(t, c.Put(b1))
+	require.NoError(t, c.Put(b2))
+
+	entries, err := c.List()
+	require.NoError(t, err)
+	assert.Len(t, entries, 2)
+
+	for _, e := range entries {
+		assert.Equal(t, cache.ApprovalStatusPending, e.Status, "new entries must start as pending")
+	}
+}
+
+// TestModuleCache_List_EmptyCache returns nil/empty for an empty cache.
+func TestModuleCache_List_EmptyCache(t *testing.T) {
+	c := makeTestCache(t)
+	entries, err := c.List()
+	require.NoError(t, err)
+	assert.Empty(t, entries)
+}
+
+// TestModuleCache_SetGetApprovalStatus round-trips status updates.
+func TestModuleCache_SetGetApprovalStatus(t *testing.T) {
+	c := makeTestCache(t)
+	b := makeTestBundle("cfgms", "hyperv", "0.2.1", "abc123hash")
+	require.NoError(t, c.Put(b))
+	addr := b.ContentAddress()
+
+	// Initial status is pending.
+	status, err := c.GetApprovalStatus(addr)
+	require.NoError(t, err)
+	assert.Equal(t, cache.ApprovalStatusPending, status)
+
+	// Approve it.
+	require.NoError(t, c.SetApprovalStatus(addr, cache.ApprovalStatusApproved))
+	status, err = c.GetApprovalStatus(addr)
+	require.NoError(t, err)
+	assert.Equal(t, cache.ApprovalStatusApproved, status)
+
+	// Reject it.
+	require.NoError(t, c.SetApprovalStatus(addr, cache.ApprovalStatusRejected))
+	status, err = c.GetApprovalStatus(addr)
+	require.NoError(t, err)
+	assert.Equal(t, cache.ApprovalStatusRejected, status)
+}
+
+// TestModuleCache_SetApprovalStatus_NotFound returns ErrBundleNotFound for missing bundles.
+func TestModuleCache_SetApprovalStatus_NotFound(t *testing.T) {
+	c := makeTestCache(t)
+	addr := bundle.ContentAddress{Publisher: "cfgms", Name: "missing", Version: "1.0.0", ContentHash: "nohash"}
+	err := c.SetApprovalStatus(addr, cache.ApprovalStatusApproved)
+	assert.ErrorIs(t, err, cache.ErrBundleNotFound)
+}
+
+// TestModuleCache_InvalidPathComponents rejects path traversal in both Get and Put.
+func TestModuleCache_InvalidPathComponents(t *testing.T) {
+	type testCase struct {
+		publisher   string
+		name        string
+		version     string
+		contentHash string
+	}
+
+	cases := []testCase{
+		{publisher: "../evil", name: "mod", version: "1.0.0", contentHash: "hash"},
+		{publisher: "cfgms", name: "../evil", version: "1.0.0", contentHash: "hash"},
+		{publisher: "cfgms", name: "mod", version: "../evil", contentHash: "hash"},
+		{publisher: "", name: "mod", version: "1.0.0", contentHash: "hash"},
+	}
+	// Note: ContentHash with ".." is rejected; "/" and "\" in hash cause Rename failure
+	// on some platforms but are validated via the dot-sequence check.
+	dotCases := []testCase{
+		{publisher: "cfgms", name: "mod", version: "1.0.0", contentHash: "../evil"},
+	}
+
+	c := makeTestCache(t)
+
+	for _, tc := range append(cases, dotCases...) {
+		addr := bundle.ContentAddress{
+			Publisher:   tc.publisher,
+			Name:        tc.name,
+			Version:     tc.version,
+			ContentHash: tc.contentHash,
+		}
+
+		// Both Get and Put must reject path traversal.
+		_, getErr := c.Get(addr)
+		assert.Error(t, getErr, "Get must reject addr %+v", addr)
+
+		b := &bundle.Bundle{
+			Manifest: &modules.ModuleMetadata{
+				Name:      tc.name,
+				Version:   tc.version,
+				Publisher: tc.publisher,
+				Executors: []string{"steward"},
+			},
+			ContentHash: tc.contentHash,
+		}
+		putErr := c.Put(b)
+		assert.Error(t, putErr, "Put must reject addr %+v", addr)
+	}
+}
+
+// TestModuleCache_List_ShowsApprovedStatus verifies List reflects updated status.
+func TestModuleCache_List_ShowsApprovedStatus(t *testing.T) {
+	c := makeTestCache(t)
+	b := makeTestBundle("cfgms", "hyperv", "0.2.1", "hash1")
+	require.NoError(t, c.Put(b))
+	require.NoError(t, c.SetApprovalStatus(b.ContentAddress(), cache.ApprovalStatusApproved))
+
+	entries, err := c.List()
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+	assert.Equal(t, cache.ApprovalStatusApproved, entries[0].Status)
+}
+
+// TestModuleCache_PutManifestContentPreserved verifies manifest YAML roundtrip preserves fields.
+func TestModuleCache_PutManifestContentPreserved(t *testing.T) {
+	c := makeTestCache(t)
+	meta := &modules.ModuleMetadata{
+		Name:        "hyperv",
+		Version:     "0.2.1",
+		Publisher:   "cfgms",
+		Description: "Hyper-V module",
+		Executors:   []string{"steward"},
+	}
+	manifestBytes, err := yaml.Marshal(meta)
+	require.NoError(t, err)
+	hash, err := bundle.ComputeContentHash(map[string][]byte{"linux-amd64": []byte("bin")}, manifestBytes)
+	require.NoError(t, err)
+
+	b := &bundle.Bundle{
+		Manifest:    meta,
+		Binaries:    map[string]string{"linux-amd64": "binaries/linux-amd64"},
+		ContentHash: hash,
+	}
+	require.NoError(t, c.Put(b))
+
+	got, err := c.Get(b.ContentAddress())
+	require.NoError(t, err)
+	assert.Equal(t, "Hyper-V module", got.Manifest.Description)
+	assert.Equal(t, hash, got.ContentHash)
+}

--- a/features/controller/modules/sources/git/resolver.go
+++ b/features/controller/modules/sources/git/resolver.go
@@ -1,0 +1,265 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 CFGMS Contributors
+
+// Package git implements a GitSourceResolver that maps module references of the
+// form "publisher/name@version" to git clone URLs using a module_sources config
+// block, clones the repository, and returns a parsed Bundle.
+package git
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+
+	modules "github.com/cfgis/cfgms/features/modules"
+	"github.com/cfgis/cfgms/pkg/logging"
+	"github.com/cfgis/cfgms/pkg/modules/bundle"
+)
+
+// SourceConfig describes a module source repository namespace.
+type SourceConfig struct {
+	// Type is always "git" for this resolver.
+	Type string `yaml:"type"`
+	// Base is the base URL; the module name is appended as a path segment.
+	// e.g. "https://github.com/cfgis" → clone URL "https://github.com/cfgis/<name>"
+	Base string `yaml:"base"`
+}
+
+// GitSourceResolver maps publisher namespaces to git repositories using a
+// module_sources config block and resolves module references to bundles.
+type GitSourceResolver struct {
+	// sources maps publisher names to their SourceConfig.
+	sources map[string]SourceConfig
+	// cloneRoot is the parent directory for cloned repositories.
+	cloneRoot string
+	// logger is used for structured log output.
+	logger logging.Logger
+}
+
+// New creates a GitSourceResolver.
+// sources maps publisher name → SourceConfig.
+// cloneRoot is the directory under which cloned repos are placed; it is created
+// if it does not exist.
+func New(sources map[string]SourceConfig, cloneRoot string, logger logging.Logger) (*GitSourceResolver, error) {
+	if logger == nil {
+		logger = logging.NewNoopLogger()
+	}
+	if err := os.MkdirAll(cloneRoot, 0750); err != nil {
+		return nil, fmt.Errorf("create clone root: %w", err)
+	}
+	return &GitSourceResolver{
+		sources:   sources,
+		cloneRoot: cloneRoot,
+		logger:    logger,
+	}, nil
+}
+
+// Resolve fetches the module identified by ref ("publisher/name@version"), clones
+// it from the configured git source, and returns a parsed Bundle.
+//
+// The clone URL is constructed as "<source.Base>/<name>" (no trailing slash).
+// Shallow clone (--depth 1) is used to minimise network and disk usage.
+func (r *GitSourceResolver) Resolve(ctx context.Context, ref string) (*bundle.Bundle, error) {
+	publisher, name, version, err := parseRef(ref)
+	if err != nil {
+		return nil, err
+	}
+
+	src, ok := r.sources[publisher]
+	if !ok {
+		return nil, fmt.Errorf("no module source configured for publisher %q", publisher)
+	}
+	if src.Type != "git" {
+		return nil, fmt.Errorf("unsupported source type %q for publisher %q", src.Type, publisher)
+	}
+
+	cloneURL, err := buildCloneURL(src.Base, name)
+	if err != nil {
+		return nil, err
+	}
+
+	cloneDir, err := r.cloneRepo(ctx, publisher, name, version, cloneURL)
+	if err != nil {
+		return nil, fmt.Errorf("clone %s: %w", logging.SanitizeLogValue(cloneURL), err)
+	}
+
+	return parseBundleFromDir(cloneDir, version)
+}
+
+// ResolveURL returns the git clone URL for the given ref without cloning.
+// Useful for diagnostics and testing URL mapping without network access.
+func (r *GitSourceResolver) ResolveURL(ref string) (string, error) {
+	publisher, name, _, err := parseRef(ref)
+	if err != nil {
+		return "", err
+	}
+	src, ok := r.sources[publisher]
+	if !ok {
+		return "", fmt.Errorf("no module source configured for publisher %q", publisher)
+	}
+	return buildCloneURL(src.Base, name)
+}
+
+// parseRef parses "publisher/name@version" into its components.
+func parseRef(ref string) (publisher, name, version string, err error) {
+	atIdx := strings.LastIndex(ref, "@")
+	if atIdx < 0 {
+		return "", "", "", fmt.Errorf("invalid module ref %q: missing @version (expected publisher/name@version)", ref)
+	}
+	version = ref[atIdx+1:]
+	namespacedName := ref[:atIdx]
+
+	slashIdx := strings.Index(namespacedName, "/")
+	if slashIdx < 0 {
+		return "", "", "", fmt.Errorf("invalid module ref %q: missing publisher/ prefix (expected publisher/name@version)", ref)
+	}
+	publisher = namespacedName[:slashIdx]
+	name = namespacedName[slashIdx+1:]
+
+	if err := validatePathComponent(publisher); err != nil {
+		return "", "", "", fmt.Errorf("publisher: %w", err)
+	}
+	if err := validatePathComponent(name); err != nil {
+		return "", "", "", fmt.Errorf("name: %w", err)
+	}
+	if err := validatePathComponent(version); err != nil {
+		return "", "", "", fmt.Errorf("version: %w", err)
+	}
+	return publisher, name, version, nil
+}
+
+// buildCloneURL constructs the git clone URL from base and name.
+func buildCloneURL(base, name string) (string, error) {
+	if base == "" {
+		return "", errors.New("source base URL is empty")
+	}
+	// Strip trailing slash from base before joining.
+	return strings.TrimRight(base, "/") + "/" + name, nil
+}
+
+// cloneRepo clones cloneURL to a subdirectory of cloneRoot.
+// Idempotent: if the destination already exists (has a .git dir), it is reused.
+func (r *GitSourceResolver) cloneRepo(ctx context.Context, publisher, name, version, cloneURL string) (string, error) {
+	// Derive a stable local directory name from the content-addressed tuple.
+	dirName := publisher + "-" + name + "-" + version
+	cloneDir := filepath.Join(r.cloneRoot, dirName)
+
+	// Idempotent: reuse existing clone.
+	if _, err := os.Stat(filepath.Join(cloneDir, ".git")); err == nil {
+		return cloneDir, nil
+	}
+
+	gitBin, err := exec.LookPath("git")
+	if err != nil {
+		return "", fmt.Errorf("git binary not found in PATH: %w", err)
+	}
+
+	r.logger.Info("cloning module repository",
+		"publisher", logging.SanitizeLogValue(publisher),
+		"name", logging.SanitizeLogValue(name),
+		"version", logging.SanitizeLogValue(version),
+		"url", logging.SanitizeLogValue(cloneURL),
+	)
+
+	// "--" prevents git from interpreting a URL starting with "-" as a flag.
+	// #nosec G204 - gitBin is resolved via exec.LookPath; cloneURL is separated by "--"
+	cmd := exec.CommandContext(ctx, gitBin, "clone", "--depth", "1", "--", cloneURL, cloneDir)
+	if out, runErr := cmd.CombinedOutput(); runErr != nil {
+		return "", fmt.Errorf("git clone failed: %w (output: %s)", runErr, string(out))
+	}
+
+	return cloneDir, nil
+}
+
+// parseBundleFromDir reads module.yaml, binary files, and signature files from cloneDir
+// and assembles a Bundle with a computed content hash.
+func parseBundleFromDir(cloneDir, version string) (*bundle.Bundle, error) {
+	// Read module.yaml.
+	metaPath := filepath.Join(cloneDir, "module.yaml")
+	metaData, err := os.ReadFile(metaPath)
+	if err != nil {
+		return nil, fmt.Errorf("read module.yaml: %w", err)
+	}
+
+	var meta modules.ModuleMetadata
+	if err := yaml.Unmarshal(metaData, &meta); err != nil {
+		return nil, fmt.Errorf("parse module.yaml: %w", err)
+	}
+
+	// Discover binary files under binaries/.
+	binDir := filepath.Join(cloneDir, "binaries")
+	binaries := make(map[string]string)
+	binContent := make(map[string][]byte)
+
+	if entries, readErr := os.ReadDir(binDir); readErr == nil {
+		for _, e := range entries {
+			entryPath := filepath.Join(binDir, e.Name())
+			// Use Lstat so symlinks are never followed: only regular files are valid
+			// binary entries. A malicious publisher could commit a symlink whose target
+			// points outside the clone root; rejecting non-regular files prevents that.
+			fi, statErr := os.Lstat(entryPath)
+			if statErr != nil {
+				continue
+			}
+			if !fi.Mode().IsRegular() {
+				continue
+			}
+			relPath := filepath.Join("binaries", e.Name())
+			binaries[e.Name()] = relPath
+			content, readErr := os.ReadFile(entryPath)
+			if readErr != nil {
+				return nil, fmt.Errorf("read binary %q: %w", e.Name(), readErr)
+			}
+			binContent[e.Name()] = content
+		}
+	}
+
+	// Compute content hash from binary content and manifest YAML.
+	contentHash, err := bundle.ComputeContentHash(binContent, metaData)
+	if err != nil {
+		return nil, fmt.Errorf("compute content hash: %w", err)
+	}
+
+	// Read signature files from signatures/.
+	var sigs []bundle.BundleSignature
+	sigDir := filepath.Join(cloneDir, "signatures")
+	if entries, readErr := os.ReadDir(sigDir); readErr == nil {
+		for _, e := range entries {
+			if e.IsDir() || !strings.HasSuffix(e.Name(), ".yaml") {
+				continue
+			}
+			sigData, readErr := os.ReadFile(filepath.Join(sigDir, e.Name()))
+			if readErr != nil {
+				continue
+			}
+			var sig bundle.BundleSignature
+			if yaml.Unmarshal(sigData, &sig) == nil {
+				sigs = append(sigs, sig)
+			}
+		}
+	}
+
+	return &bundle.Bundle{
+		Manifest:    &meta,
+		Binaries:    binaries,
+		Signatures:  sigs,
+		ContentHash: contentHash,
+	}, nil
+}
+
+// validatePathComponent rejects empty strings and path traversal sequences.
+func validatePathComponent(s string) error {
+	if s == "" {
+		return errors.New("must not be empty")
+	}
+	if strings.Contains(s, "..") || strings.ContainsRune(s, '/') || strings.ContainsRune(s, '\\') {
+		return fmt.Errorf("must not contain path separators or dot sequences: %q", s)
+	}
+	return nil
+}

--- a/features/controller/modules/sources/git/resolver_test.go
+++ b/features/controller/modules/sources/git/resolver_test.go
@@ -1,0 +1,176 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 CFGMS Contributors
+package git_test
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+
+	gitresolver "github.com/cfgis/cfgms/features/controller/modules/sources/git"
+	modules "github.com/cfgis/cfgms/features/modules"
+	"github.com/cfgis/cfgms/pkg/logging"
+)
+
+// skipIfNoGit skips the test if the git binary is not available.
+// git is an external binary dependency required for clone operations.
+func skipIfNoGit(t *testing.T) string {
+	t.Helper()
+	gitBin, err := exec.LookPath("git")
+	if err != nil {
+		t.Skip("git binary not found in PATH; required for git resolver integration tests")
+	}
+	return gitBin
+}
+
+// initLocalGitRepo creates a bare-ish local git repository at dir with a valid
+// module.yaml, a fake binary under binaries/, and commits everything.
+// Returns the absolute path to the repo (usable as a file:// clone URL).
+func initLocalGitRepo(t *testing.T, gitBin, repoDir, publisher, name, version string) {
+	t.Helper()
+
+	git := func(args ...string) {
+		t.Helper()
+		cmd := exec.Command(gitBin, args...)
+		cmd.Dir = repoDir
+		out, err := cmd.CombinedOutput()
+		require.NoError(t, err, "git %v: %s", args, string(out))
+	}
+
+	git("init", repoDir)
+	git("-C", repoDir, "config", "user.email", "test@cfgms.test")
+	git("-C", repoDir, "config", "user.name", "CFGMS Test")
+
+	// Write module.yaml.
+	meta := modules.ModuleMetadata{
+		Name:        name,
+		Version:     version,
+		Publisher:   publisher,
+		Description: "Test module for git resolver",
+		Executors:   []string{"steward"},
+	}
+	metaBytes, err := yaml.Marshal(meta)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(repoDir, "module.yaml"), metaBytes, 0640))
+
+	// Write a fake binary.
+	binDir := filepath.Join(repoDir, "binaries")
+	require.NoError(t, os.MkdirAll(binDir, 0750))
+	require.NoError(t, os.WriteFile(filepath.Join(binDir, "linux-amd64"), []byte("fake-binary-content"), 0640))
+
+	git("add", "module.yaml", filepath.Join("binaries", "linux-amd64"))
+	git("commit", "-m", "Initial module commit")
+}
+
+// [REQUIRED TEST] git resolver maps publisher namespace to git base URL and returns a parsed Bundle.
+func TestGitSourceResolver_Resolve_ReturnsBundle(t *testing.T) {
+	gitBin := skipIfNoGit(t)
+
+	// Create a local git repo acting as the module source.
+	repoDir := t.TempDir()
+	initLocalGitRepo(t, gitBin, repoDir, "cfgms", "test-module", "1.0.0")
+
+	// Configure the resolver to use the local repo dir as the base URL.
+	// file:// protocol lets git clone from local paths.
+	sources := map[string]gitresolver.SourceConfig{
+		"cfgms": {Type: "git", Base: "file://" + filepath.Dir(repoDir)},
+	}
+	// The repo dir name is the "name" segment.
+	repoName := filepath.Base(repoDir)
+
+	cloneRoot := t.TempDir()
+	logger := logging.NewNoopLogger()
+	r, err := gitresolver.New(sources, cloneRoot, logger)
+	require.NoError(t, err)
+
+	ref := "cfgms/" + repoName + "@1.0.0"
+	b, err := r.Resolve(context.Background(), ref)
+	require.NoError(t, err, "Resolve must succeed for a valid local git module")
+
+	assert.NotNil(t, b)
+	assert.NotEmpty(t, b.ContentHash, "resolved bundle must have a content hash")
+	assert.Equal(t, "test-module", b.Manifest.Name)
+	assert.Equal(t, "1.0.0", b.Manifest.Version)
+	assert.Equal(t, "cfgms", b.Manifest.Publisher)
+	assert.Contains(t, b.Binaries, "linux-amd64", "binaries map must contain linux-amd64 key")
+}
+
+// TestGitSourceResolver_ResolveURL_MapsPublisherToURL verifies URL construction without cloning.
+func TestGitSourceResolver_ResolveURL_MapsPublisherToURL(t *testing.T) {
+	sources := map[string]gitresolver.SourceConfig{
+		"cfgms": {Type: "git", Base: "https://modules.example.com/cfgms"},
+	}
+	r, err := gitresolver.New(sources, t.TempDir(), logging.NewNoopLogger())
+	require.NoError(t, err)
+
+	url, err := r.ResolveURL("cfgms/hyperv@0.2.1")
+	require.NoError(t, err)
+	assert.Equal(t, "https://modules.example.com/cfgms/hyperv", url)
+}
+
+// TestGitSourceResolver_ResolveURL_UnknownPublisher returns an error.
+func TestGitSourceResolver_ResolveURL_UnknownPublisher(t *testing.T) {
+	sources := map[string]gitresolver.SourceConfig{
+		"cfgms": {Type: "git", Base: "https://modules.example.com/cfgms"},
+	}
+	r, err := gitresolver.New(sources, t.TempDir(), logging.NewNoopLogger())
+	require.NoError(t, err)
+
+	_, err = r.ResolveURL("unknown-vendor/tool@1.0.0")
+	assert.Error(t, err)
+}
+
+// TestGitSourceResolver_ParseRef_Invalid returns an error for malformed refs.
+func TestGitSourceResolver_ParseRef_Invalid(t *testing.T) {
+	sources := map[string]gitresolver.SourceConfig{
+		"cfgms": {Type: "git", Base: "https://modules.example.com"},
+	}
+	r, err := gitresolver.New(sources, t.TempDir(), logging.NewNoopLogger())
+	require.NoError(t, err)
+
+	invalidRefs := []string{
+		"no-at-sign",
+		"@version",
+		"publisher/name",
+		"../evil/name@version",
+		"publisher/../name@version",
+	}
+
+	for _, ref := range invalidRefs {
+		_, err := r.ResolveURL(ref)
+		assert.Error(t, err, "expected error for ref %q", ref)
+	}
+}
+
+// TestGitSourceResolver_Resolve_Idempotent verifies that resolving twice uses cached clone.
+func TestGitSourceResolver_Resolve_Idempotent(t *testing.T) {
+	gitBin := skipIfNoGit(t)
+
+	repoDir := t.TempDir()
+	initLocalGitRepo(t, gitBin, repoDir, "cfgms", "my-module", "2.0.0")
+	repoName := filepath.Base(repoDir)
+
+	sources := map[string]gitresolver.SourceConfig{
+		"cfgms": {Type: "git", Base: "file://" + filepath.Dir(repoDir)},
+	}
+
+	cloneRoot := t.TempDir()
+	r, err := gitresolver.New(sources, cloneRoot, logging.NewNoopLogger())
+	require.NoError(t, err)
+
+	ref := "cfgms/" + repoName + "@2.0.0"
+
+	b1, err := r.Resolve(context.Background(), ref)
+	require.NoError(t, err)
+
+	b2, err := r.Resolve(context.Background(), ref)
+	require.NoError(t, err)
+
+	assert.Equal(t, b1.ContentHash, b2.ContentHash, "repeated Resolve must return same content hash")
+}


### PR DESCRIPTION
## Summary

- Adds `features/controller/modules/cache` — content-addressed filesystem cache for module bundles with approval status tracking (`pending`/`approved`/`rejected`), atomic writes, and path-traversal defense
- Adds `features/controller/modules/sources/git` — `GitSourceResolver` that shallow-clones publisher namespaces from configured git bases, assembles `Bundle` from `module.yaml` + `binaries/` + `signatures/`, and rejects symlinks in binary directories
- Adds `features/controller/modules/approval` — `ApprovalWorkflow` that evaluates bundles against the trust store (trusted+valid sig → AutoApprove, unknown publisher → QueueForReview, bad sig → Reject) and exposes `Approve()` for operator promotion
- Adds `cmd/cfg/cmd/module.go` — `cfg module list` and `cfg module approve` CLI commands with `moduleRefRE` validation and `url.PathEscape` on all path components
- Removes `GetModule`/`ExecuteModuleOperation` stubs from `controller.go`; trims `ModuleRegistry` interface in `directory/service.go` to `ListModules()` only
- Updates `docs/architecture/controller-operating-model.md` and `docs/architecture/modules/distribution.md` with cache layout, approval state machine, and CLI usage

## Test plan

- [x] `TestModuleCache_PutGet_RoundTrip` — round-trip Put → Get returns identical bundle fields
- [x] `TestModuleCache_Put_Idempotent` — second Put of same bundle succeeds with no duplicate
- [x] `TestModuleCache_Put_ConflictDifferentHash` — returns `ErrContentAddressConflict`
- [x] `TestModuleCache_Get_NotFound` — returns `ErrBundleNotFound`
- [x] `TestModuleCache_List` — all new entries start as `ApprovalStatusPending`
- [x] `TestModuleCache_SetGetApprovalStatus` — pending → approved → rejected round-trips
- [x] `TestModuleCache_InvalidPathComponents` — path traversal rejected by both Get and Put
- [x] `TestApprovalWorkflow_Evaluate_TrustedPublisher_ValidSignature` → AutoApprove (real Ed25519 key)
- [x] `TestApprovalWorkflow_Evaluate_UnknownPublisher` → QueueForReview
- [x] `TestApprovalWorkflow_Evaluate_TamperedBundle` → Reject
- [x] `TestApprovalWorkflow_Approve_TransitionsToApproved`
- [x] `TestGitSourceResolver_Resolve_ReturnsBundle` — real local git repo via `file://`
- [x] `TestModuleRefRE_ValidRefs` / `TestModuleRefRE_InvalidRefs`
- [x] `TestModuleListCmd_StatusValidation` — invalid status values rejected before network I/O
- [x] `make test-agent-complete` — all tests pass, zero lint issues, all 5 platforms compile

Fixes #1883

🤖 Generated with [Claude Code](https://claude.com/claude-code)