### PR TITLE
fix(steward+hyperv+logging): unblock M2 validation (Issue #1852)

### DIFF
--- a/cmd/steward/service/cert_test.go
+++ b/cmd/steward/service/cert_test.go
@@ -15,6 +15,7 @@ import (
 	"math/big"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -77,6 +78,14 @@ func TestVerifyCACertFingerprintInvalidPEM(t *testing.T) {
 }
 
 func TestWriteCACertMode(t *testing.T) {
+	// Windows does not honor Unix mode bits in os.WriteFile — Go's runtime
+	// reports 0666 for any writable file regardless of the mode argument.
+	// The CA cert is public material; mode-bit enforcement is a Unix-only
+	// concern. TestWriteCACertContent covers the platform-agnostic invariant.
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix mode bits are not enforced on Windows file writes")
+	}
+
 	dir := t.TempDir()
 	destPath := filepath.Join(dir, "etc", "cfgms", "controller-ca.crt")
 	certPEM, _ := generateTestCACert(t)

--- a/cmd/steward/service/hyperv_windows.go
+++ b/cmd/steward/service/hyperv_windows.go
@@ -53,17 +53,30 @@ $cert.Thumbprint`
 // loopback-bound listener at 127.0.0.1:5986 (not 0.0.0.0).
 // thumbprint is passed as $args[0] — never interpolated into the script block.
 // Idempotent: delete-then-create.
+//
+// Uses `winrm create` (not `winrm set`). `winrm set` only modifies an existing
+// listener; on a fresh host it silently no-ops, leaving 5986 unbound — the
+// install reports "Step 3/8 Configuring WinRM HTTPS listener" success but
+// nothing is actually listening, so every later WinRM call fails with
+// "actively refused".
 func setupWinRMListener(ps psRunner, thumbprint string) error {
 	// Delete any existing HTTPS listener; non-fatal if it does not exist.
+	// We try both the wildcard (Address=*) and the loopback-pinned form to
+	// cover both an Enable-PSRemoting-created listener and a previous run of
+	// this same install.
 	_, _ = ps.RunPS(
-		`& winrm delete 'winrm/config/Listener?Address=*+Transport=HTTPS' 2>$null; $true`,
+		`& winrm delete 'winrm/config/Listener?Address=*+Transport=HTTPS' 2>$null; & winrm delete 'winrm/config/Listener?Address=IP:127.0.0.1+Transport=HTTPS' 2>$null; $true`,
 		nil, "")
 
 	// Address=IP:127.0.0.1 binds only to loopback — NOT Address=* (0.0.0.0).
 	// Thumbprint is $args[0], assembled via string concat in PS to avoid interpolation.
+	// Hostname='127.0.0.1' aligns the listener record with the address clients
+	// actually dial (`winrm_host: 127.0.0.1` in steward config). Using
+	// `localhost` here would resolve to ::1 on IPv6-first Windows and the
+	// IPv4-bound listener would refuse the connection.
 	script := `$thumb = $args[0]
-$config = "@{CertificateThumbprint='" + $thumb + "'}"
-& winrm set 'winrm/config/Listener?Address=IP:127.0.0.1+Transport=HTTPS' $config`
+$config = "@{Hostname='127.0.0.1';CertificateThumbprint='" + $thumb + "'}"
+& winrm create 'winrm/config/Listener?Address=IP:127.0.0.1+Transport=HTTPS' $config`
 	_, err := ps.RunPS(script, []string{thumbprint}, "")
 	return err
 }

--- a/cmd/steward/service/manager_windows_test.go
+++ b/cmd/steward/service/manager_windows_test.go
@@ -67,8 +67,15 @@ func TestWindowsInstallFingerprintMismatch(t *testing.T) {
 	assert.True(t, os.IsNotExist(statErr), "cert file must not exist after fingerprint mismatch")
 }
 
-// TestWindowsInstallCACertWritten verifies that the CA cert is written to the prefixed
-// platform path with mode 0644 when a correct fingerprint is provided.
+// TestWindowsInstallCACertWritten verifies that the CA cert is written to the
+// prefixed platform path with the expected on-disk shape after a successful
+// fingerprint verification.
+//
+// On Windows the Go runtime reports a writable file's mode as 0666 regardless
+// of the mode passed to os.WriteFile — Unix mode bits are not enforced. The
+// CA cert is public material (see writeCACert's #nosec G306 comment), so the
+// security-relevant invariants are: the file exists, sits inside the
+// configured prefix, and is readable.
 func TestWindowsInstallCACertWritten(t *testing.T) {
 	dir := t.TempDir()
 	t.Setenv("CFGMS_INSTALL_PREFIX", dir)
@@ -82,7 +89,11 @@ func TestWindowsInstallCACertWritten(t *testing.T) {
 
 	info, err := os.Stat(destPath)
 	require.NoError(t, err)
-	assert.Equal(t, os.FileMode(0644), info.Mode().Perm(), "CA cert must be written with mode 0644")
+	assert.False(t, info.IsDir(), "destination must be a regular file")
+	assert.Greater(t, info.Size(), int64(0), "CA cert file must be non-empty")
+	written, err := os.ReadFile(destPath) // #nosec G304 -- test reads a path it just wrote
+	require.NoError(t, err)
+	assert.Equal(t, certPEM, string(written), "on-disk content must match the input PEM")
 }
 
 func TestWindowsManagerUninstallRequiresElevation(t *testing.T) {
@@ -273,6 +284,14 @@ func TestInstallHyperV_SecretsReadableByServiceAccount(t *testing.T) {
 // TestInstallHyperV_LogsAreSanitized verifies that a winrmUser value containing
 // \n and \r does not produce log forgery when processed through
 // logging.SanitizeLogValue, as required for all InstallHyperV log statements.
+//
+// The sanitizer's contract is to REPLACE every control character (including
+// CR/LF) with an underscore — not to strip content after the first control
+// character. That contract is sufficient to prevent CWE-117 log forgery
+// because the injected payload can no longer end the host log line; it
+// becomes visible single-line user-controlled input. The substring after the
+// original CR/LF may still appear in the sanitized string — that is the
+// expected and intended behavior.
 func TestInstallHyperV_LogsAreSanitized(t *testing.T) {
 	craftedUsername := "legit-user\r\nINFO: fake-log-entry injected"
 	sanitized := logging.SanitizeLogValue(craftedUsername)
@@ -281,16 +300,16 @@ func TestInstallHyperV_LogsAreSanitized(t *testing.T) {
 		"sanitized value must not contain carriage returns")
 	assert.NotContains(t, sanitized, "\n",
 		"sanitized value must not contain newlines")
-	assert.NotContains(t, sanitized, "fake-log-entry",
-		"log-injected content after CR/LF must be stripped")
 
 	// Verify InstallHyperV log pattern: fmt.Printf("... %s ...", logging.SanitizeLogValue(winrmUser))
-	// does not propagate the injection.
+	// does not propagate the newline injection — the resulting log line must
+	// remain a single line so the injected payload cannot impersonate a
+	// separate log record.
 	logLine := "Creating local service account " + logging.SanitizeLogValue(craftedUsername)
+	assert.NotContains(t, logLine, "\r",
+		"log line using SanitizeLogValue must not contain carriage returns")
 	assert.NotContains(t, logLine, "\n",
 		"log line using SanitizeLogValue must not contain newlines")
-	assert.NotContains(t, logLine, "fake-log-entry",
-		"log line using SanitizeLogValue must not contain injected content")
 }
 
 // TestInstallHyperV_HyperVInstallerInterface verifies that *windowsManager satisfies

--- a/cmd/steward/service/manager_windows_test.go
+++ b/cmd/steward/service/manager_windows_test.go
@@ -176,7 +176,12 @@ func TestInstallHyperV_RequiresElevation(t *testing.T) {
 }
 
 // TestInstallHyperV_ListenerBindsLocalhostOnly verifies that setupWinRMListener
-// uses IP:127.0.0.1 (not Address=*) in the winrm set command.
+// creates a loopback-bound HTTPS listener via `winrm create` (NOT `winrm set`,
+// which silently no-ops on hosts with no existing HTTPS listener). The
+// `Hostname='127.0.0.1'` clause aligns the listener record with the
+// IP literal the steward will dial — using `localhost` would land on ::1
+// on IPv6-first Windows and refuse the IPv4 connection.
+//
 // Uses recordingPSRunner — no PowerShell execution, no elevation required.
 func TestInstallHyperV_ListenerBindsLocalhostOnly(t *testing.T) {
 	rec := &recordingPSRunner{}
@@ -184,18 +189,20 @@ func TestInstallHyperV_ListenerBindsLocalhostOnly(t *testing.T) {
 	err := setupWinRMListener(rec, "AABBCCDDEEFF00112233445566778899AABBCCDD")
 	require.NoError(t, err)
 
-	// Find the set command call and verify it uses IP:127.0.0.1, not *.
+	// Find the listener-create call and verify it binds to IP:127.0.0.1.
 	var foundLoopback bool
 	for _, call := range rec.Calls {
-		if strings.Contains(call.ScriptBlock, "winrm set") {
+		if strings.Contains(call.ScriptBlock, "winrm create") {
 			assert.Contains(t, call.ScriptBlock, "IP:127.0.0.1",
 				"listener must be bound to IP:127.0.0.1, not *")
 			assert.NotContains(t, call.ScriptBlock, "Address=*",
 				"listener must not use Address=* (binds 0.0.0.0)")
+			assert.Contains(t, call.ScriptBlock, "Hostname='127.0.0.1'",
+				"Hostname must be the IPv4 literal so it survives IPv6-first DNS resolution")
 			foundLoopback = true
 		}
 	}
-	assert.True(t, foundLoopback, "must have a winrm set call for the HTTPS listener")
+	assert.True(t, foundLoopback, "must have a winrm create call for the HTTPS listener")
 }
 
 // TestInstallHyperV_FirewallRuleLoopbackOnly verifies that setupHyperVFirewall

--- a/cmd/steward/service/powershell_windows.go
+++ b/cmd/steward/service/powershell_windows.go
@@ -49,9 +49,15 @@ func (r *execPSRunner) RunPS(scriptBlock string, args []string, stdinData string
 // User-supplied values in args appear in cmd.Args as separate elements after the
 // script block. Sensitive values (passwords) must NOT be in args — pass via
 // cmd.Stdin in the caller (or stdinData in execPSRunner.RunPS).
+//
+// The script block is wrapped in `& { ... }` because powershell.exe -Command
+// does NOT bind trailing CLI arguments to $args by default — it concatenates
+// them onto the command string. Invoking via the call operator (`&`) on a
+// script-block literal does bind $args, which is the contract every caller
+// in this package relies on.
 func buildPSCmd(scriptBlock string, args []string) *exec.Cmd {
 	exeArgs := make([]string, 0, 4+len(args))
-	exeArgs = append(exeArgs, "-NonInteractive", "-NoProfile", "-Command", scriptBlock)
+	exeArgs = append(exeArgs, "-NonInteractive", "-NoProfile", "-Command", "& { "+scriptBlock+" }")
 	exeArgs = append(exeArgs, args...)
 	return exec.Command("powershell.exe", exeArgs...) //#nosec G204 -- scriptBlock is a hardcoded template; user values are in args[]
 }

--- a/cmd/steward/service/powershell_windows_test.go
+++ b/cmd/steward/service/powershell_windows_test.go
@@ -90,9 +90,12 @@ func TestInstallHyperVPSHelper_InjectionSafe(t *testing.T) {
 
 			scriptBlockInCmd := cmd.Args[4]
 
-			// Verify the script block is unmodified.
-			assert.Equal(t, tc.scriptBlock, scriptBlockInCmd,
-				"script block must not be modified")
+			// Verify the user-supplied script content is preserved inside the
+			// `& { ... }` wrapper. The wrapper is what makes PowerShell bind
+			// $args from trailing CLI arguments; the wrapped content itself
+			// MUST equal the input scriptBlock byte-for-byte.
+			assert.Equal(t, "& { "+tc.scriptBlock+" }", scriptBlockInCmd,
+				"script block must be wrapped in `& { ... }` with content unchanged")
 
 			// Verify each user-supplied arg is a separate element (not in script block).
 			for _, arg := range tc.args {
@@ -125,6 +128,11 @@ func TestInstallHyperVPSHelper_InjectionSafe(t *testing.T) {
 
 // TestBuildPSCmd_StructureIsCorrect verifies the fixed argument positions
 // that TestInstallHyperV_PassNotInArgv relies on.
+//
+// cmd.Args[4] wraps the user script in `& { ... }` so that powershell.exe
+// invokes it as a script block and binds the trailing args to $args.
+// Without the wrapper, `-Command "<script>" arg1` appends arg1 textually to
+// the script string and $args stays empty.
 func TestBuildPSCmd_StructureIsCorrect(t *testing.T) {
 	cmd := buildPSCmd("Write-Output 'hello'", []string{"arg1", "arg2"})
 
@@ -132,8 +140,49 @@ func TestBuildPSCmd_StructureIsCorrect(t *testing.T) {
 	require.Equal(t, "-NonInteractive", cmd.Args[1])
 	require.Equal(t, "-NoProfile", cmd.Args[2])
 	require.Equal(t, "-Command", cmd.Args[3])
-	require.Equal(t, "Write-Output 'hello'", cmd.Args[4])
+	require.Equal(t, "& { Write-Output 'hello' }", cmd.Args[4])
 	require.Equal(t, "arg1", cmd.Args[5])
 	require.Equal(t, "arg2", cmd.Args[6])
 	assert.Len(t, cmd.Args, 7)
+}
+
+// TestExecPSRunner_ArgsBoundToArgsArray verifies that values passed in args[]
+// are reachable as $args[N] inside the executing script block when invoked
+// by the real powershell.exe.
+//
+// Regression test: prior to wrapping the script block in `& { ... }`, calling
+// `powershell.exe -Command "<script>" arg0` appended arg0 textually after the
+// script content and $args[0] stayed undefined — breaking every Hyper-V install
+// helper that relied on $args. The structural-only test passed because it
+// inspected cmd.Args layout without ever launching PowerShell.
+func TestExecPSRunner_ArgsBoundToArgsArray(t *testing.T) {
+	runner := &execPSRunner{}
+	out, err := runner.RunPS(`Write-Output $args[0]`, []string{"hello-world"}, "")
+	require.NoError(t, err)
+	assert.Equal(t, "hello-world", out)
+}
+
+// TestExecPSRunner_ArgsBoundForMultiStatementScript ensures that $args is
+// bound for every reference site in a multi-line script — mirrors the shape
+// of generateHyperVCert in hyperv_windows.go where $args[0] is read at the
+// top and its derivative is emitted at the bottom of a multi-line block.
+func TestExecPSRunner_ArgsBoundForMultiStatementScript(t *testing.T) {
+	script := `$x = $args[0]
+$y = $args[1]
+Write-Output "$x|$y"`
+	runner := &execPSRunner{}
+	out, err := runner.RunPS(script, []string{"first", "second"}, "")
+	require.NoError(t, err)
+	assert.Equal(t, "first|second", out)
+}
+
+// TestExecPSRunner_StdinDeliveredToScript verifies that stdinData is readable
+// from the executing script block via [Console]::In.ReadToEnd(). This is the
+// path the WinRM service-account password takes — argv stays clean, the
+// secret lives only on stdin.
+func TestExecPSRunner_StdinDeliveredToScript(t *testing.T) {
+	runner := &execPSRunner{}
+	out, err := runner.RunPS(`[Console]::In.ReadToEnd()`, nil, "piped-stdin-data")
+	require.NoError(t, err)
+	assert.Equal(t, "piped-stdin-data", out)
 }

--- a/features/modules/hyperv/snapshot.go
+++ b/features/modules/hyperv/snapshot.go
@@ -121,6 +121,17 @@ const psRestoreSnapshot = `Restore-VMSnapshot -VMName $VMName -Name $Name -Confi
 // getSnapshot retrieves the current state of a snapshot by user-visible names.
 // Returns ErrSnapshotNotFound if the snapshot does not exist or the transport fails.
 // State is always "present" when found — Get never returns "restored" (Hyper-V semantics).
+// getSnapshot returns the current state of a Hyper-V checkpoint.
+//
+// Contract (matches the directory/file modules):
+//   - snapshot exists   → (&SnapshotConfig{State: "present", ...}, nil)
+//   - snapshot absent   → (&SnapshotConfig{VMName, Name, State: "absent"}, nil)
+//   - module not ready  → (nil, ErrSnapshotNotFound)
+//   - validation/transport failed → (nil, wrapped error)
+//
+// Returning state:"absent" rather than an error lets the unified executor
+// detect drift against a desired state:"present" config and proceed to Set,
+// instead of treating "absent" as a fatal Get failure.
 func (m *hypervModule) getSnapshot(ctx context.Context, vmName, snapName string) (*SnapshotConfig, error) {
 	if m.transport == nil {
 		return nil, ErrSnapshotNotFound
@@ -129,7 +140,7 @@ func (m *hypervModule) getSnapshot(ctx context.Context, vmName, snapName string)
 	// Validate before any WinRM call — defense-in-depth even though ArgumentList
 	// already prevents injection at the transport layer.
 	if err := (&SnapshotConfig{VMName: vmName, Name: snapName}).Validate(); err != nil {
-		return nil, ErrSnapshotNotFound
+		return nil, fmt.Errorf("hyperv: validate snapshot %q/%q: %w", vmName, snapName, err)
 	}
 
 	hostVMName := vmHostName(m.tenantID, vmName)
@@ -140,17 +151,19 @@ func (m *hypervModule) getSnapshot(ctx context.Context, vmName, snapName string)
 		"VMName": hostVMName,
 	})
 	if err != nil {
-		return nil, ErrSnapshotNotFound
+		return nil, fmt.Errorf("hyperv: get snapshot %q/%q: %w", vmName, snapName, err)
 	}
 
 	var parsed map[string]interface{}
 	if jsonErr := json.Unmarshal([]byte(strings.TrimSpace(output)), &parsed); jsonErr != nil {
-		return nil, ErrSnapshotNotFound
+		return nil, fmt.Errorf("hyperv: parse get-snapshot response for %q/%q: %w", vmName, snapName, jsonErr)
 	}
 
 	found, _ := parsed["found"].(bool)
 	if !found {
-		return nil, ErrSnapshotNotFound
+		// Absent is a valid current state — the executor compares this against
+		// the desired state and calls Set to create the snapshot when needed.
+		return &SnapshotConfig{VMName: vmName, Name: snapName, State: "absent"}, nil
 	}
 
 	// Hyper-V does not delete checkpoints on restore, so the only observable

--- a/features/modules/hyperv/snapshot_test.go
+++ b/features/modules/hyperv/snapshot_test.go
@@ -248,26 +248,37 @@ func TestGet_Snapshot_AfterRestore_ReturnsPresent(t *testing.T) {
 
 // ─── Not found tests ───────────────────────────────────────────────────────────
 
-// TestGet_Snapshot_ReturnsErrSnapshotNotFound_WhenMissing verifies that Get returns
-// ErrSnapshotNotFound when the host reports the snapshot does not exist.
-func TestGet_Snapshot_ReturnsErrSnapshotNotFound_WhenMissing(t *testing.T) {
+// TestGet_Snapshot_ReturnsAbsentWhenMissing verifies that Get returns a
+// state:"absent" ConfigState (no error) when the host reports the snapshot
+// does not exist. This matches the contract honored by the directory and file
+// modules and lets the unified executor detect drift against a desired
+// state:"present" configuration.
+func TestGet_Snapshot_ReturnsAbsentWhenMissing(t *testing.T) {
 	transport := &testWinRMTransport{output: `{"found":false}`}
 	m := snapModuleWithTransport(transport, "t")
 
-	_, err := m.Get(context.Background(), "snapshot:myvm/nonexistent")
-	require.Error(t, err)
-	assert.ErrorIs(t, err, ErrSnapshotNotFound)
+	state, err := m.Get(context.Background(), "snapshot:myvm/nonexistent")
+	require.NoError(t, err, "missing snapshot must NOT be reported as an error")
+	require.NotNil(t, state)
+	assert.Equal(t, "absent", state.AsMap()["state"],
+		"missing snapshot must surface as state:absent so the executor can drive Set")
 }
 
-// TestGet_Snapshot_ReturnsErrSnapshotNotFound_OnTransportError verifies that transport
-// errors are surfaced as ErrSnapshotNotFound.
-func TestGet_Snapshot_ReturnsErrSnapshotNotFound_OnTransportError(t *testing.T) {
+// TestGet_Snapshot_WrapsTransportError verifies that transport-layer failures
+// are returned as wrapped errors (NOT as ErrSnapshotNotFound) so the executor
+// can distinguish "absent" from "transport broken". Conflating the two was
+// part of F14 — every failed Get aborted the Set even when the host was
+// simply offline.
+func TestGet_Snapshot_WrapsTransportError(t *testing.T) {
 	transport := &testWinRMTransport{execErr: errors.New("winrm: connection refused")}
 	m := snapModuleWithTransport(transport, "t")
 
 	_, err := m.Get(context.Background(), "snapshot:myvm/unreachable")
 	require.Error(t, err)
-	assert.ErrorIs(t, err, ErrSnapshotNotFound)
+	assert.NotErrorIs(t, err, ErrSnapshotNotFound,
+		"transport errors must NOT be reported as ErrSnapshotNotFound")
+	assert.Contains(t, err.Error(), "winrm: connection refused",
+		"underlying transport error message must be preserved in the chain")
 }
 
 // TestGet_Snapshot_NoTransport verifies that Get returns ErrSnapshotNotFound when

--- a/features/modules/hyperv/vm.go
+++ b/features/modules/hyperv/vm.go
@@ -139,6 +139,17 @@ const psSetVMProcessor = `Set-VMProcessor -VMName $Name -Count $CPU`
 const psSetVMMemory = `Set-VM -Name $Name -MemoryStartupBytes ($MemoryMB * 1MB)`
 
 // getVM retrieves the current state of a VM by user-visible name.
+// getVM returns the current state of a VM on the host.
+//
+// Contract (matches the directory/file modules):
+//   - resource exists  → (&VMConfig{State: "running"|"stopped"|..., ...}, nil)
+//   - resource absent  → (&VMConfig{Name, State: "absent"}, nil)
+//   - module not ready → (nil, ErrVMNotFound)
+//   - transport failed → (nil, wrapped error)
+//
+// Returning state:"absent" rather than an error lets the unified executor
+// detect drift against a desired state:"present"/"running" config and
+// proceed to Set, instead of treating "absent" as a fatal Get failure.
 func (m *hypervModule) getVM(ctx context.Context, vmName string) (*VMConfig, error) {
 	if m.transport == nil {
 		return nil, ErrVMNotFound
@@ -147,17 +158,19 @@ func (m *hypervModule) getVM(ctx context.Context, vmName string) (*VMConfig, err
 	hostName := vmHostName(m.tenantID, vmName)
 	output, err := m.transport.ExecutePS(ctx, psGetVM, map[string]string{"Name": hostName})
 	if err != nil {
-		return nil, ErrVMNotFound
+		return nil, fmt.Errorf("hyperv: get vm %q: %w", vmName, err)
 	}
 
 	var parsed map[string]interface{}
 	if jsonErr := json.Unmarshal([]byte(strings.TrimSpace(output)), &parsed); jsonErr != nil {
-		return nil, ErrVMNotFound
+		return nil, fmt.Errorf("hyperv: parse get-vm response for %q: %w", vmName, jsonErr)
 	}
 
 	found, _ := parsed["found"].(bool)
 	if !found {
-		return nil, ErrVMNotFound
+		// Absent is a valid current state — the executor compares this against
+		// the desired state and calls Set to create the resource when needed.
+		return &VMConfig{Name: vmName, State: "absent"}, nil
 	}
 
 	// Strip the host-side prefix to recover the user-visible VM name.
@@ -270,10 +283,14 @@ func (m *hypervModule) setVM(ctx context.Context, resourceID string, config modu
 		currentVM = cachedVM
 	} else {
 		current, err := m.getVM(ctx, vmName)
-		if err != nil && !errors.Is(err, ErrVMNotFound) {
+		if err != nil {
+			// getVM no longer returns a sentinel for "not found" — absence is
+			// signalled by State=="absent" with err==nil. Any real error here
+			// (module not configured, transport down, malformed response) is
+			// fatal for this Set call.
 			return fmt.Errorf("hyperv: check VM %q existence: %w", vmName, err)
 		}
-		if err == nil {
+		if current.State != "absent" {
 			vmExists = true
 			currentVM = *current
 		}

--- a/features/modules/hyperv/vm_test.go
+++ b/features/modules/hyperv/vm_test.go
@@ -175,27 +175,38 @@ func TestSet_VMAbsent_CallsRemoveVM(t *testing.T) {
 
 // ─── Get not found tests ───────────────────────────────────────────────────────
 
-// TestGet_VM_ReturnsErrVMNotFound_WhenMissing verifies that Get returns ErrVMNotFound
-// when the remote host reports the VM does not exist.
-func TestGet_VM_ReturnsErrVMNotFound_WhenMissing(t *testing.T) {
+// TestGet_VM_ReturnsAbsentWhenMissing verifies that Get returns a state:"absent"
+// ConfigState (no error) when the remote host reports the VM does not exist.
+// This matches the contract honored by the directory and file modules and lets
+// the unified executor detect drift against a desired state:"present"/"running"
+// configuration.
+func TestGet_VM_ReturnsAbsentWhenMissing(t *testing.T) {
 	// Transport returns not-found JSON (VM absent on host)
 	transport := &testWinRMTransport{output: `{"found":false}`}
 	m := vmModuleWithTransport(transport, "t")
 
-	_, err := m.Get(context.Background(), "vm:nonexistent")
-	require.Error(t, err)
-	assert.ErrorIs(t, err, ErrVMNotFound)
+	state, err := m.Get(context.Background(), "vm:nonexistent")
+	require.NoError(t, err, "missing VM must NOT be reported as an error")
+	require.NotNil(t, state)
+	assert.Equal(t, "absent", state.AsMap()["state"],
+		"missing VM must surface as state:absent so the executor can drive Set")
 }
 
-// TestGet_VM_ReturnsErrVMNotFound_OnTransportError verifies that transport errors
-// (e.g., WinRM connection failure) are surfaced as ErrVMNotFound.
-func TestGet_VM_ReturnsErrVMNotFound_OnTransportError(t *testing.T) {
+// TestGet_VM_WrapsTransportError verifies that transport-layer failures (e.g.
+// WinRM connection refused) are returned as wrapped errors, NOT as
+// ErrVMNotFound. Conflating "absent" with "transport broken" was the root
+// cause of F14: every failed Get aborted the Set even when the host was
+// simply offline.
+func TestGet_VM_WrapsTransportError(t *testing.T) {
 	transport := &testWinRMTransport{execErr: errors.New("winrm: connection refused")}
 	m := vmModuleWithTransport(transport, "t")
 
 	_, err := m.Get(context.Background(), "vm:unreachable")
 	require.Error(t, err)
-	assert.ErrorIs(t, err, ErrVMNotFound)
+	assert.NotErrorIs(t, err, ErrVMNotFound,
+		"transport errors must NOT be reported as ErrVMNotFound")
+	assert.Contains(t, err.Error(), "winrm: connection refused",
+		"underlying transport error message must be preserved in the chain")
 }
 
 // ─── Tenant isolation tests ────────────────────────────────────────────────────
@@ -367,10 +378,14 @@ func TestGet_VM_ReturnsConfig(t *testing.T) {
 }
 
 // TestSet_VMCreate verifies that Set creates a VM and passes all fields via ArgumentList.
-// setVM now calls getVM first to check existence; empty transport output → ErrVMNotFound →
-// falls through to New-VM. So two transport calls are expected: getVM (call[0]) + New-VM (call[1]).
+// setVM calls getVM first to check existence: the mock returns `{"found":false}`
+// for call[0] so getVM reports state:"absent" (per the F14 contract), then Set
+// falls through to New-VM as call[1]. Two transport calls expected total:
+// getVM (call[0]) + New-VM (call[1]).
 func TestSet_VMCreate(t *testing.T) {
-	transport := &testWinRMTransport{}
+	transport := &testWinRMTransport{
+		perCallOutputs: []string{`{"found":false}`},
+	}
 	m := vmModuleWithTransport(transport, "dev")
 
 	cfg := &VMConfig{

--- a/features/modules/hyperv/vswitch.go
+++ b/features/modules/hyperv/vswitch.go
@@ -216,6 +216,17 @@ func psCreateVSwitchExternal(allowManagementOS bool) string {
 
 // getVSwitch retrieves the current state of a virtual switch by user-visible name.
 // Returns ErrVSwitchNotFound if the switch does not exist or the transport fails.
+// getVSwitch returns the current state of a virtual switch on the host.
+//
+// Contract (matches the directory/file modules):
+//   - resource exists  → (&VSwitchConfig{State: "present", ...}, nil)
+//   - resource absent  → (&VSwitchConfig{Name, State: "absent"}, nil)
+//   - module not ready → (nil, ErrVSwitchNotFound)
+//   - transport failed → (nil, wrapped error)
+//
+// Returning state:"absent" rather than an error lets the unified executor
+// detect drift against a desired state:"present" config and proceed to Set,
+// instead of treating "absent" as a fatal Get failure.
 func (m *hypervModule) getVSwitch(ctx context.Context, switchName string) (*VSwitchConfig, error) {
 	if m.transport == nil {
 		return nil, ErrVSwitchNotFound
@@ -224,17 +235,19 @@ func (m *hypervModule) getVSwitch(ctx context.Context, switchName string) (*VSwi
 	hostName := vswitchHostName(m.tenantID, switchName)
 	output, err := m.transport.ExecutePS(ctx, psGetVSwitch, map[string]string{"Name": hostName})
 	if err != nil {
-		return nil, ErrVSwitchNotFound
+		return nil, fmt.Errorf("hyperv: get vswitch %q: %w", switchName, err)
 	}
 
 	var parsed map[string]interface{}
 	if jsonErr := json.Unmarshal([]byte(strings.TrimSpace(output)), &parsed); jsonErr != nil {
-		return nil, ErrVSwitchNotFound
+		return nil, fmt.Errorf("hyperv: parse get-vswitch response for %q: %w", switchName, jsonErr)
 	}
 
 	found, _ := parsed["found"].(bool)
 	if !found {
-		return nil, ErrVSwitchNotFound
+		// Absent is a valid current state — the executor compares this against
+		// the desired state and calls Set to create the resource when needed.
+		return &VSwitchConfig{Name: switchName, State: "absent"}, nil
 	}
 
 	cfg := &VSwitchConfig{Name: switchName, State: "present"}

--- a/features/modules/hyperv/vswitch_test.go
+++ b/features/modules/hyperv/vswitch_test.go
@@ -356,26 +356,37 @@ func TestNonEmptyAdapterName_IncludesNameParam(t *testing.T) {
 
 // ─── Get not found tests ───────────────────────────────────────────────────────
 
-// TestGet_VSwitch_ReturnsErrVSwitchNotFound_WhenMissing verifies that Get returns
-// ErrVSwitchNotFound when the remote host reports the switch does not exist.
-func TestGet_VSwitch_ReturnsErrVSwitchNotFound_WhenMissing(t *testing.T) {
+// TestGet_VSwitch_ReturnsAbsentWhenMissing verifies that Get returns a
+// state:"absent" ConfigState (no error) when the remote host reports the
+// switch does not exist. This matches the contract honored by the directory
+// and file modules and lets the unified executor detect drift against a
+// desired state:"present" configuration.
+func TestGet_VSwitch_ReturnsAbsentWhenMissing(t *testing.T) {
 	transport := &testWinRMTransport{output: `{"found":false}`}
 	m := vswitchModuleWithTransport(transport, "t")
 
-	_, err := m.Get(context.Background(), "vswitch:nonexistent")
-	require.Error(t, err)
-	assert.ErrorIs(t, err, ErrVSwitchNotFound)
+	state, err := m.Get(context.Background(), "vswitch:nonexistent")
+	require.NoError(t, err, "missing resource must NOT be reported as an error — caller would interpret it as a Get failure")
+	require.NotNil(t, state)
+	assert.Equal(t, "absent", state.AsMap()["state"],
+		"missing vSwitch must surface as state:absent so the executor can drive Set")
 }
 
-// TestGet_VSwitch_ReturnsErrVSwitchNotFound_OnTransportError verifies that transport
-// errors are surfaced as ErrVSwitchNotFound.
-func TestGet_VSwitch_ReturnsErrVSwitchNotFound_OnTransportError(t *testing.T) {
+// TestGet_VSwitch_WrapsTransportError verifies that transport-layer failures
+// are returned as wrapped errors (NOT as ErrVSwitchNotFound) so the executor
+// can distinguish "absent" from "transport broken". Conflating the two was the
+// root cause of F14 — every failed Get aborted the Set even though the host
+// was simply offline.
+func TestGet_VSwitch_WrapsTransportError(t *testing.T) {
 	transport := &testWinRMTransport{execErr: errors.New("winrm: connection refused")}
 	m := vswitchModuleWithTransport(transport, "t")
 
 	_, err := m.Get(context.Background(), "vswitch:unreachable")
 	require.Error(t, err)
-	assert.ErrorIs(t, err, ErrVSwitchNotFound)
+	assert.NotErrorIs(t, err, ErrVSwitchNotFound,
+		"transport errors must NOT be reported as ErrVSwitchNotFound")
+	assert.Contains(t, err.Error(), "winrm: connection refused",
+		"underlying transport error message must be preserved in the chain")
 }
 
 // TestGet_VSwitch_NoTransport verifies that Get returns ErrVSwitchNotFound when the

--- a/features/steward/client/client_transport.go
+++ b/features/steward/client/client_transport.go
@@ -128,6 +128,14 @@ type TransportClient struct {
 	// Issue #419: drained in order after a successful reconnect.
 	offlineQueue *OfflineQueue
 
+	// secretStore is the steward's secret store, retained here so that
+	// InitializeConfigExecutor can pass it to the unified Executor's default
+	// factory. Modules implementing SecretStoreInjectable (e.g. hyperv) need
+	// the store wired into the factory before Configure runs. Without this,
+	// every controller-pushed config that touches a hyperv resource fails
+	// with `hyperv: secret store must be injected before Configure`.
+	secretStore secretsif.SecretStore
+
 	// DNA state for hash-based sync (Issue #418).
 	// dnaMu guards currentDNAHash and lastPublishedDNA.
 	dnaMu            sync.RWMutex
@@ -277,6 +285,7 @@ func NewTransportClient(cfg *TransportConfig) (*TransportClient, error) {
 		commandMaxParamsBytes: cfg.SignedCommandMaxParamsBytes,
 		scriptSigning:         cfg.ScriptSigning,
 		identityPersistFunc:   cfg.IdentityPersistFunc,
+		secretStore:           cfg.SecretStore,
 		logger:                cfg.Logger,
 	}
 
@@ -288,8 +297,9 @@ func NewTransportClient(cfg *TransportConfig) (*TransportClient, error) {
 // Uses the unified execution engine (all 7 modules, Get→Compare→Set→Verify).
 func (c *TransportClient) InitializeConfigExecutor(tenantID string) error {
 	execCfg := &execution.ExecutorConfig{
-		TenantID: tenantID,
-		Logger:   c.logger,
+		TenantID:    tenantID,
+		Logger:      c.logger,
+		SecretStore: c.secretStore,
 	}
 	executor, err := execution.NewExecutor(execCfg)
 	if err != nil {

--- a/features/steward/execution/executor.go
+++ b/features/steward/execution/executor.go
@@ -20,6 +20,7 @@ import (
 	stewardtesting "github.com/cfgis/cfgms/features/steward/testing"
 	cpTypes "github.com/cfgis/cfgms/pkg/controlplane/types"
 	"github.com/cfgis/cfgms/pkg/logging"
+	secretsif "github.com/cfgis/cfgms/pkg/secrets/interfaces"
 )
 
 // ExecutorConfig holds configuration for creating an Executor.
@@ -46,6 +47,13 @@ type ExecutorConfig struct {
 	// Defaults to DriftModeApply (current behavior) when not set.
 	// Thread from controller-delivered cfg via SetDriftMode; never from local files.
 	DriftMode config.DriftMode
+
+	// SecretStore is the steward's secret store. When non-nil, NewExecutor injects
+	// it into the default factory it creates so that modules implementing
+	// SecretStoreInjectable (e.g. hyperv) receive the store before Configure runs.
+	// Ignored when Factory is supplied — callers wiring their own factory are
+	// responsible for injecting the secret store themselves.
+	SecretStore secretsif.SecretStore
 }
 
 // Executor applies configurations using the unified Get→Compare→Set→Verify workflow.
@@ -81,6 +89,14 @@ func NewExecutor(cfg *ExecutorConfig) (*Executor, error) {
 		// Empty registry — all 7 built-in modules are loaded on demand by the factory
 		f = factory.New(discovery.ModuleRegistry{}, defaultErrCfg, cfg.Logger)
 		errCfg = defaultErrCfg
+		// Wire the secret store into the auto-created factory so modules that
+		// implement SecretStoreInjectable (e.g. hyperv) receive it before
+		// Configure runs. Without this, controller-connected stewards see
+		// `secret store must be injected before Configure` on every secret-
+		// using resource.
+		if cfg.SecretStore != nil {
+			f.SetSecretStore(cfg.SecretStore)
+		}
 	}
 	if comp == nil {
 		comp = stewardtesting.NewStateComparator()

--- a/features/steward/execution/executor_test.go
+++ b/features/steward/execution/executor_test.go
@@ -9,16 +9,19 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/cfgis/cfgms/features/modules"
 	stewardconfig "github.com/cfgis/cfgms/features/steward/config"
 	"github.com/cfgis/cfgms/features/steward/execution"
 	stewardtesting "github.com/cfgis/cfgms/features/steward/testing"
 	"github.com/cfgis/cfgms/pkg/logging"
+	secretsif "github.com/cfgis/cfgms/pkg/secrets/interfaces"
 )
 
 // testFileConfig returns a file resource config appropriate for the current platform.
@@ -576,4 +579,141 @@ func TestApplyConfiguration_ApplyMode_ModeAliasConfigVerifiesClean(t *testing.T)
 	require.NoError(t, readErr)
 	assert.Equal(t, "fleet-managed-content\n", string(got),
 		"drifted resource declared with the mode alias must be re-applied to desired state")
+}
+
+// stubExecutorSecretStore is a minimal in-memory SecretStore used to verify
+// that ExecutorConfig.SecretStore is threaded into the auto-created factory.
+// Implements pkg/secrets/interfaces.SecretStore.
+type stubExecutorSecretStore struct {
+	mu      sync.Mutex
+	secrets map[string]string
+}
+
+func newStubExecutorSecretStore(kv ...string) *stubExecutorSecretStore {
+	s := &stubExecutorSecretStore{secrets: make(map[string]string)}
+	for i := 0; i+1 < len(kv); i += 2 {
+		s.secrets[kv[i]] = kv[i+1]
+	}
+	return s
+}
+
+func (s *stubExecutorSecretStore) GetSecret(_ context.Context, key string) (*secretsif.Secret, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	v, ok := s.secrets[key]
+	if !ok {
+		return nil, secretsif.ErrSecretNotFound
+	}
+	return &secretsif.Secret{Key: key, Value: v}, nil
+}
+
+func (s *stubExecutorSecretStore) StoreSecret(_ context.Context, req *secretsif.SecretRequest) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.secrets[req.Key] = req.Value
+	return nil
+}
+func (s *stubExecutorSecretStore) DeleteSecret(_ context.Context, _ string) error { return nil }
+func (s *stubExecutorSecretStore) ListSecrets(_ context.Context, _ *secretsif.SecretFilter) ([]*secretsif.SecretMetadata, error) {
+	return nil, nil
+}
+func (s *stubExecutorSecretStore) GetSecrets(_ context.Context, _ []string) (map[string]*secretsif.Secret, error) {
+	return nil, nil
+}
+func (s *stubExecutorSecretStore) StoreSecrets(_ context.Context, _ map[string]*secretsif.SecretRequest) error {
+	return nil
+}
+func (s *stubExecutorSecretStore) GetSecretVersion(_ context.Context, _ string, _ int) (*secretsif.Secret, error) {
+	return nil, secretsif.ErrSecretNotFound
+}
+func (s *stubExecutorSecretStore) ListSecretVersions(_ context.Context, _ string) ([]*secretsif.SecretVersion, error) {
+	return nil, nil
+}
+func (s *stubExecutorSecretStore) GetSecretMetadata(_ context.Context, _ string) (*secretsif.SecretMetadata, error) {
+	return nil, secretsif.ErrSecretNotFound
+}
+func (s *stubExecutorSecretStore) UpdateSecretMetadata(_ context.Context, _ string, _ map[string]string) error {
+	return nil
+}
+func (s *stubExecutorSecretStore) RotateSecret(_ context.Context, _ string, _ string) error {
+	return nil
+}
+func (s *stubExecutorSecretStore) ExpireSecret(_ context.Context, _ string) error { return nil }
+func (s *stubExecutorSecretStore) HealthCheck(_ context.Context) error            { return nil }
+func (s *stubExecutorSecretStore) Close() error                                   { return nil }
+
+// stubHypervConfig is a minimal modules.ConfigState whose AsMap carries the
+// keys hyperv.Configure requires. It exists solely to drive Configure past
+// the secret-store check; ToYAML/FromYAML/Validate are unused in this test.
+type stubHypervConfig map[string]interface{}
+
+func (c stubHypervConfig) AsMap() map[string]interface{} { return map[string]interface{}(c) }
+func (c stubHypervConfig) ToYAML() ([]byte, error)       { return nil, nil }
+func (c stubHypervConfig) FromYAML(_ []byte) error       { return nil }
+func (c stubHypervConfig) Validate() error               { return nil }
+func (c stubHypervConfig) GetManagedFields() []string    { return nil }
+
+// TestNewExecutor_SecretStoreInjectedIntoAutoCreatedFactory pins the F15 fix:
+// when ExecutorConfig.SecretStore is non-nil and Factory is nil, NewExecutor
+// must forward the store to the auto-created factory so that
+// SecretStoreInjectable modules (hyperv today, ad/m365 tomorrow) receive it
+// before Configure runs.
+//
+// Behavioural check: load the hyperv module via the factory, then call
+// Configure with valid keys. Without the F15 wiring, Configure returns
+// "secret store must be injected before Configure"; with the wiring it
+// reaches host validation and succeeds.
+func TestNewExecutor_SecretStoreInjectedIntoAutoCreatedFactory(t *testing.T) {
+	logger := logging.ForModule("executor_test")
+	store := newStubExecutorSecretStore("hyperv/user", "admin", "hyperv/pass", "secret")
+
+	executor, err := execution.NewExecutor(&execution.ExecutorConfig{
+		Logger:      logger,
+		SecretStore: store,
+	})
+	require.NoError(t, err)
+
+	mod, err := execution.ExecutorFactory(executor).LoadModule("hyperv")
+	require.NoError(t, err)
+
+	configurable, ok := mod.(modules.Configurable)
+	require.True(t, ok, "hyperv module must implement modules.Configurable")
+
+	err = configurable.Configure(stubHypervConfig{
+		"winrm_host":        "127.0.0.1",
+		"winrm_user_secret": "hyperv/user",
+		"winrm_pass_secret": "hyperv/pass",
+	})
+	require.NoError(t, err,
+		"F15 regression: SecretStore on ExecutorConfig must propagate to the factory so hyperv.Configure passes the secret-store check")
+}
+
+// TestNewExecutor_NilSecretStoreLeavesFactoryUnwired is the control case for
+// TestNewExecutor_SecretStoreInjectedIntoAutoCreatedFactory. Confirms that
+// without the SecretStore field set, the auto-created factory does NOT have
+// a store, so hyperv.Configure returns the documented sentinel error — which
+// is the exact failure mode F15 fixes.
+func TestNewExecutor_NilSecretStoreLeavesFactoryUnwired(t *testing.T) {
+	logger := logging.ForModule("executor_test")
+
+	executor, err := execution.NewExecutor(&execution.ExecutorConfig{
+		Logger: logger,
+		// SecretStore intentionally omitted.
+	})
+	require.NoError(t, err)
+
+	mod, err := execution.ExecutorFactory(executor).LoadModule("hyperv")
+	require.NoError(t, err)
+
+	configurable, ok := mod.(modules.Configurable)
+	require.True(t, ok, "hyperv module must implement modules.Configurable")
+
+	err = configurable.Configure(stubHypervConfig{
+		"winrm_host":        "127.0.0.1",
+		"winrm_user_secret": "hyperv/user",
+		"winrm_pass_secret": "hyperv/pass",
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "secret store must be injected",
+		"without SecretStore on ExecutorConfig, hyperv.Configure must surface the documented sentinel")
 }

--- a/pkg/logging/sanitize.go
+++ b/pkg/logging/sanitize.go
@@ -149,13 +149,16 @@ func RedactedID(s string) string {
 	return SanitizeLogValue(s[:8]) + "…"
 }
 
-// sanitizeMapValues sanitizes all string values in a map for safe logging.
-// Non-string values are left unchanged.
+// sanitizeMapValues sanitizes every value in a map for safe logging.
+//
+// String values are sanitized via SanitizeLogValue. Go `error` and
+// fmt.Stringer values are converted to their textual form and sanitized so
+// they don't render as `{}` (a Go `error` such as *errors.errorString has
+// only unexported fields and serializes to an empty JSON object). Maps and
+// slices are walked recursively. Other types are left as-is.
 func sanitizeMapValues(fields map[string]any) {
 	for k, v := range fields {
-		if str, ok := v.(string); ok {
-			fields[k] = SanitizeLogValue(str)
-		}
+		fields[k] = sanitizeValueRecursive(v, 0)
 	}
 }
 

--- a/pkg/logging/sanitize_test.go
+++ b/pkg/logging/sanitize_test.go
@@ -3,6 +3,7 @@
 package logging
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 	"testing"
@@ -206,6 +207,29 @@ func TestSanitizeMapValues(t *testing.T) {
 	assert.Equal(t, "tenant__forged", fields["tenant_id"])
 	assert.Equal(t, 3.14, fields["float_value"])
 	assert.Nil(t, fields["nil_value"])
+}
+
+// TestSanitizeMapValues_GoErrorTextified verifies that Go `error` values are
+// converted to their textual form before logging, so they don't serialize to
+// `{}` via the default JSON marshaller (the underlying type for errors.New
+// has only unexported fields).
+//
+// Regression: prior to wiring sanitizeValueRecursive into sanitizeMapValues
+// every `"error", err` pair in the codebase rendered as an empty JSON object
+// in file logs, hiding actual failures from operators.
+func TestSanitizeMapValues_GoErrorTextified(t *testing.T) {
+	fields := map[string]any{
+		"plain_err": errors.New("boom"),
+		"wrapped":   fmt.Errorf("outer: %w", errors.New("inner")),
+		// Control-character-laced error messages must still be sanitized.
+		"sneaky_err": errors.New("oops\r\nINFO: forged-line"),
+	}
+
+	sanitizeMapValues(fields)
+
+	assert.Equal(t, "boom", fields["plain_err"])
+	assert.Equal(t, "outer: inner", fields["wrapped"])
+	assert.Equal(t, "oops__INFO: forged-line", fields["sneaky_err"])
 }
 
 func TestSanitizeKeysAndValues(t *testing.T) {

--- a/scripts/install-hyperv-host.ps1
+++ b/scripts/install-hyperv-host.ps1
@@ -214,9 +214,12 @@ if ($CACertPath -ne "") {
 if ($CAFingerprint -ne "") {
     $InstallArgs += @("--fingerprint", ($CAFingerprint.ToLowerInvariant() -replace ":", ""))
 }
-if ($ControllerURL -ne "") {
-    $InstallArgs += @("--controller-url", $ControllerURL)
-}
+
+# Note: -ControllerURL is NOT passed to `cfgms-steward install`. The controller
+# endpoint is baked into the steward binary at build time via
+# `-ldflags "-X main.ControllerURL=https://..."` and is read at service start.
+# The script-level -ControllerURL parameter is kept for operator-facing clarity
+# (it documents which deployment the operator believes they are wiring up).
 
 $bstr  = [Runtime.InteropServices.Marshal]::SecureStringToBSTR($WinRMPass)
 $plain = [Runtime.InteropServices.Marshal]::PtrToStringAuto($bstr)


### PR DESCRIPTION
## Summary

Eight defects surfaced during #1852 M2 validation against the live pilot Hyper-V host on CFG-70-02. The full validation log is on #1852 ([comment](https://github.com/cfg-is/cfgms/issues/1852#issuecomment-4634891551)); this PR ships the fixes that are safely in-place against the existing WinRM transport while #1887 (WMI replacement) lands.

## Defects fixed

| # | Defect | Files |
|---|---|---|
| **F1** | `install-hyperv-host.ps1` passed `--controller-url` to `cfgms-steward install`; no such flag (URL is ldflags-baked). The script is going away with #1894 but operators running the M1 runbook before then would hit this every time. | `scripts/install-hyperv-host.ps1` |
| **F2** | `buildPSCmd` built `powershell.exe -Command "<script>" arg`, which appends `arg` *textually to the script string* instead of binding to `$args`. The unit test only inspected `cmd.Args` layout — never launched PowerShell. Every Hyper-V install helper that read `$args[N]` parse-errored. | `cmd/steward/service/powershell_windows.go` + `_test.go` |
| **F4** | `TestWriteCACertMode` / `TestWindowsInstallCACertWritten` asserted Unix mode 0644 on Windows where Go reports 0666 for any writable file | `cmd/steward/service/cert_test.go`, `manager_windows_test.go` |
| **F5** | `TestInstallHyperV_LogsAreSanitized` over-asserted the sanitizer contract — expected stripping; sanitizer replaces with `_` | `cmd/steward/service/manager_windows_test.go` |
| **F13** | `sanitizeMapValues` only handled strings; Go `error` values marshalled to `{}` in JSON logs, hiding every actual failure | `pkg/logging/sanitize.go` + `_test.go` |
| **F14** | hyperv module `Get` returned `ErrXNotFound` for three distinct cases (module-not-configured, transport-error, resource-genuinely-absent). The unified executor treats any Get error as fatal → no resource ever reached Set. Re-aligned with the directory/file module contract: absent → `(&XConfig{State: "absent"}, nil)`; transport error → wrapped; module-not-ready → keep sentinel. | `features/modules/hyperv/{vm,vswitch,snapshot}.{go,_test.go}` |
| **F15** | Controller-connected `InitializeConfigExecutor` created an executor whose default factory had no secret store wired. Every `SecretStoreInjectable` module (hyperv today, ad/m365 tomorrow) hit *"secret store must be injected before Configure"*. Standalone mode does inject; controller path didn't. | `features/steward/{client,execution}/*` |
| **F17** | `setupWinRMListener` used `winrm set` (modifies an existing listener) on a fresh host — silently no-ops, install reports success, port 5986 stays unbound. Switched to `winrm create`; aligned listener `Hostname='127.0.0.1'` to match an IPv4 client (#1894 will delete this code path; throwaway but necessary in the meantime). | `cmd/steward/service/hyperv_windows.go` + `manager_windows_test.go` |

## Defects routed to other issues

The next ~6 defects (F16–F21, WinRM-auth-layer) were left unpatched in this PR because #1887 (WMI transport replacement) eliminates the entire WinRM stack. They're documented as a comment on #1887 so the WMI design avoids the same class of issues, and as a comment on #1894 listing the code to delete.

Six net-new findings unrelated to WinRM were filed as separate stories: #1898 (F6), #1899 (F8), #1900 (F9), #1901 (F10), #1902 (F11), #1903 (F12).

## Test plan

- [x] `go test ./cmd/steward/service/...` on Windows — green, including three new real PowerShell-execution tests
- [x] `go test ./pkg/logging/...` — green; new `TestSanitizeMapValues_GoErrorTextified`
- [x] `go test ./features/modules/hyperv/...` — green; renamed `ReturnsErrXNotFound_*` to `ReturnsAbsentWhenMissing` / `WrapsTransportError` to match the new contract
- [x] `go test ./features/steward/{execution,client}/...` — green
- [x] Live end-to-end install + register on CFG-70-02 through to WinRM TCP+TLS round-trip
- [ ] `make test-complete` — to be run by CI. Two pre-existing Windows-only failures (DNA `TestDNACollectionPerformance` uint underflow, `TestEntraAdminUnit_Integration_BasicOperations`) are unrelated to this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)