### PR TITLE
steward: module runtime — fork/exec, gRPC client, lifecycle, and trust mode enforcement (Issue #1885)

### DIFF
--- a/docs/architecture/steward-operating-model.md
+++ b/docs/architecture/steward-operating-model.md
@@ -122,6 +122,54 @@ Controller-side logging captures both the drift event and convergence result reg
 
 Modules are the code packages that manage resources. Each resource block in the cfg references a module by name and provides module-specific configuration.
 
+### Module Trust Modes
+
+The steward verifies module bundle signatures according to the `module_trust.mode` field in `steward.cfg`:
+
+| Mode | Verification | When to use |
+|------|-------------|-------------|
+| **`controller`** (default) | None — the steward accepts any bundle the controller has approved | Normal deployment; trust is delegated to the controller |
+| **`strict`** | Steward independently verifies Ed25519 signatures against its local trust set: the CFGMS publisher identity baked in at build time, plus any publishers listed in `additional_publishers` | High-security environments where a compromised controller must not be able to push arbitrary code to stewards |
+| **`bypass`** | None — no verification | Development and testing only |
+
+In `strict` mode, the trusted publisher set is:
+1. The `cfgms` publisher identity — a 32-byte Ed25519 public key compiled into the steward binary at build time via `-ldflags`. This identity cannot be changed via cfg push.
+2. Additional publishers listed in `steward.cfg` under `module_trust.additional_publishers` (v1: by name only; key material lookup from a durable trust store is future work).
+
+**Threat model invariant**: a compromised controller cannot push arbitrary modules to stewards running in `strict` mode — the steward rejects any bundle whose publisher key is not in its local trust set, regardless of controller approval.
+
+### Module Runtime Lifecycle
+
+Out-of-process module binaries are managed by the steward module runtime. Each module runs in a separate process connected over a local socket:
+
+**Startup sequence (per module):**
+
+1. `starting` — runtime fork/execs the module binary; passes the socket path via `CFGMS_MODULE_SOCKET` environment variable
+2. `ready` — runtime polls the socket until the module process starts listening, then dials gRPC and calls `Handshake`
+3. `running` — module is operating normally; the steward holds an active `StewardModuleClient` gRPC session
+
+**Socket paths:**
+- Unix: `${runtime_dir}/cfgms-module-<name>-<id>.sock`
+- Windows: `\\.\pipe\cfgms-module-<name>-<id>`
+
+**Shutdown sequence:**
+
+1. `stopping` — runtime sends the `Shutdown` RPC; module should exit cleanly
+2. `stopped` — if the module has not exited within **10 seconds** after the `Shutdown` RPC, the runtime kills the process; socket file is removed
+
+Trust verification (in `strict` mode) is performed **before** fork/exec. If the bundle fails trust verification, `Start()` returns `ErrPublisherNotTrusted` and no process is started.
+
+### Four Execution Paths
+
+Every byte of code that runs on a steward arrives through exactly one of these paths (see ADR-006 for full details):
+
+| Path | Trust anchor | Notes |
+|------|-------------|-------|
+| **Modules** | Publisher-signed bundle | gRPC module invoked to enforce cfg |
+| **Scripts** | Publisher-signed; cfg-content staged to disk with recorded hash | `<interpreter> -File <path>` against on-disk file |
+| **Inline cfg CLI commands** | Admin mTLS-signed payload, end-to-end | Separate epic |
+| **Remote shell** | Interactive admin session | Separate epic |
+
 ### Module Contract
 
 Every module implements the `Module` interface:

--- a/features/steward/discovery/discovery.go
+++ b/features/steward/discovery/discovery.go
@@ -29,8 +29,7 @@
 //
 // Module structure requirements:
 //   - module.yaml with name, version, and optional metadata
-//   - At least one .go source file
-//   - Standard Go module directory structure
+//   - At least one os-arch subdirectory (e.g. linux-amd64/) containing a compiled binary
 //
 // #nosec G304 - Steward discovery requires file access for detecting system configurations
 package discovery
@@ -202,35 +201,45 @@ func ParseModuleMetadata(metadataPath string) (ModuleInfo, error) {
 	return moduleInfo, nil
 }
 
-// ValidateModuleStructure checks if the module directory has the required structure
+// ValidateModuleStructure checks if the module directory has the required bundle
+// layout: a module.yaml file plus at least one OS/arch subdirectory containing
+// at least one file (the compiled module binary).
+//
+// Valid layout example:
+//
+//	my-module/
+//	  module.yaml
+//	  linux-amd64/
+//	    my-module          ← compiled binary
+//	  windows-amd64/
+//	    my-module.exe
 func ValidateModuleStructure(modulePath string) error {
-	// Check for required files
-	requiredFiles := []string{"module.yaml"}
-
-	for _, file := range requiredFiles {
-		filePath := filepath.Join(modulePath, file)
-		if _, err := os.Stat(filePath); os.IsNotExist(err) {
-			return fmt.Errorf("required file missing: %s", file)
-		}
+	// module.yaml is required.
+	yamlPath := filepath.Join(modulePath, "module.yaml")
+	if _, err := os.Stat(yamlPath); os.IsNotExist(err) {
+		return fmt.Errorf("required file missing: module.yaml")
 	}
 
-	// For Go modules, check for .go files
+	// At least one os-arch subdirectory with at least one file is required.
 	entries, err := os.ReadDir(modulePath)
 	if err != nil {
 		return fmt.Errorf("failed to read module directory: %w", err)
 	}
 
-	hasGoFiles := false
 	for _, entry := range entries {
-		if !entry.IsDir() && filepath.Ext(entry.Name()) == ".go" {
-			hasGoFiles = true
-			break
+		if !entry.IsDir() {
+			continue
+		}
+		subEntries, err := os.ReadDir(filepath.Join(modulePath, entry.Name()))
+		if err != nil {
+			continue
+		}
+		for _, sub := range subEntries {
+			if !sub.IsDir() {
+				return nil // found at least one binary file in an os-arch subdir
+			}
 		}
 	}
 
-	if !hasGoFiles {
-		return fmt.Errorf("no Go source files found in module directory")
-	}
-
-	return nil
+	return fmt.Errorf("no os-arch subdirectory with a binary found in module directory")
 }

--- a/features/steward/discovery/discovery_test.go
+++ b/features/steward/discovery/discovery_test.go
@@ -11,6 +11,17 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// createBundleLayout creates a valid bundle directory layout under modulePath:
+// module.yaml + a linux-amd64/ subdirectory with a placeholder binary.
+func createBundleLayout(t *testing.T, modulePath string, moduleYAML string) {
+	t.Helper()
+	require.NoError(t, os.MkdirAll(modulePath, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(modulePath, "module.yaml"), []byte(moduleYAML), 0644))
+	archDir := filepath.Join(modulePath, "linux-amd64")
+	require.NoError(t, os.MkdirAll(archDir, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(archDir, "module"), []byte("ELF"), 0755))
+}
+
 func TestDiscoverModules(t *testing.T) {
 	tests := []struct {
 		name        string
@@ -23,18 +34,13 @@ func TestDiscoverModules(t *testing.T) {
 			setupFunc: func(t *testing.T) ([]string, func()) {
 				tempDir := t.TempDir()
 				modulePath := filepath.Join(tempDir, "test-module")
-				require.NoError(t, os.MkdirAll(modulePath, 0755))
-
-				// Create module.yaml
 				moduleYAML := `name: test-module
 version: 1.0.0
 description: Test module
 capabilities:
   - file-management
 `
-				require.NoError(t, os.WriteFile(filepath.Join(modulePath, "module.yaml"), []byte(moduleYAML), 0644))
-				require.NoError(t, os.WriteFile(filepath.Join(modulePath, "module.go"), []byte("package testmodule"), 0644))
-
+				createBundleLayout(t, modulePath, moduleYAML)
 				return []string{tempDir}, func() {}
 			},
 			wantModules: []string{"test-module"},
@@ -53,26 +59,14 @@ capabilities:
 			setupFunc: func(t *testing.T) ([]string, func()) {
 				tempDir := t.TempDir()
 
-				// Create first module
-				module1Path := filepath.Join(tempDir, "module1")
-				require.NoError(t, os.MkdirAll(module1Path, 0755))
-				module1YAML := `name: module1
+				createBundleLayout(t, filepath.Join(tempDir, "module1"), `name: module1
 version: 1.0.0
 description: First module
-`
-				require.NoError(t, os.WriteFile(filepath.Join(module1Path, "module.yaml"), []byte(module1YAML), 0644))
-				require.NoError(t, os.WriteFile(filepath.Join(module1Path, "module.go"), []byte("package module1"), 0644))
-
-				// Create second module
-				module2Path := filepath.Join(tempDir, "module2")
-				require.NoError(t, os.MkdirAll(module2Path, 0755))
-				module2YAML := `name: module2
+`)
+				createBundleLayout(t, filepath.Join(tempDir, "module2"), `name: module2
 version: 2.0.0
 description: Second module
-`
-				require.NoError(t, os.WriteFile(filepath.Join(module2Path, "module.yaml"), []byte(module2YAML), 0644))
-				require.NoError(t, os.WriteFile(filepath.Join(module2Path, "module.go"), []byte("package module2"), 0644))
-
+`)
 				return []string{tempDir}, func() {}
 			},
 			wantModules: []string{"module1", "module2"},
@@ -177,11 +171,25 @@ func TestValidateModuleStructure(t *testing.T) {
 		wantErr   bool
 	}{
 		{
-			name: "valid module structure",
+			name: "valid bundle structure with os-arch subdir",
 			setupFunc: func(t *testing.T) string {
 				tempDir := t.TempDir()
 				require.NoError(t, os.WriteFile(filepath.Join(tempDir, "module.yaml"), []byte("name: test"), 0644))
-				require.NoError(t, os.WriteFile(filepath.Join(tempDir, "module.go"), []byte("package test"), 0644))
+				archDir := filepath.Join(tempDir, "linux-amd64")
+				require.NoError(t, os.MkdirAll(archDir, 0755))
+				require.NoError(t, os.WriteFile(filepath.Join(archDir, "module"), []byte("ELF"), 0755))
+				return tempDir
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid bundle structure with windows binary",
+			setupFunc: func(t *testing.T) string {
+				tempDir := t.TempDir()
+				require.NoError(t, os.WriteFile(filepath.Join(tempDir, "module.yaml"), []byte("name: test"), 0644))
+				archDir := filepath.Join(tempDir, "windows-amd64")
+				require.NoError(t, os.MkdirAll(archDir, 0755))
+				require.NoError(t, os.WriteFile(filepath.Join(archDir, "module.exe"), []byte("MZ"), 0755))
 				return tempDir
 			},
 			wantErr: false,
@@ -190,16 +198,28 @@ func TestValidateModuleStructure(t *testing.T) {
 			name: "missing module.yaml",
 			setupFunc: func(t *testing.T) string {
 				tempDir := t.TempDir()
-				require.NoError(t, os.WriteFile(filepath.Join(tempDir, "module.go"), []byte("package test"), 0644))
+				archDir := filepath.Join(tempDir, "linux-amd64")
+				require.NoError(t, os.MkdirAll(archDir, 0755))
+				require.NoError(t, os.WriteFile(filepath.Join(archDir, "module"), []byte("ELF"), 0755))
 				return tempDir
 			},
 			wantErr: true,
 		},
 		{
-			name: "missing go files",
+			name: "module.yaml present but no os-arch subdir",
 			setupFunc: func(t *testing.T) string {
 				tempDir := t.TempDir()
 				require.NoError(t, os.WriteFile(filepath.Join(tempDir, "module.yaml"), []byte("name: test"), 0644))
+				return tempDir
+			},
+			wantErr: true,
+		},
+		{
+			name: "os-arch subdir exists but is empty",
+			setupFunc: func(t *testing.T) string {
+				tempDir := t.TempDir()
+				require.NoError(t, os.WriteFile(filepath.Join(tempDir, "module.yaml"), []byte("name: test"), 0644))
+				require.NoError(t, os.MkdirAll(filepath.Join(tempDir, "linux-amd64"), 0755))
 				return tempDir
 			},
 			wantErr: true,

--- a/features/steward/modules/runtime/lifecycle.go
+++ b/features/steward/modules/runtime/lifecycle.go
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 CFGMS Contributors
+package runtime
+
+import (
+	"os/exec"
+	"sync"
+
+	"github.com/cfgis/cfgms/pkg/modules/contract"
+	"google.golang.org/grpc"
+)
+
+// LifecycleState tracks the state of a running module process.
+type LifecycleState int
+
+const (
+	// StateStarting: binary fork/exec'd, socket not yet connected.
+	StateStarting LifecycleState = iota + 1
+	// StateReady: gRPC connection established and Handshake completed.
+	StateReady
+	// StateRunning: module is operating normally, ready to serve RPCs.
+	StateRunning
+	// StateStopping: Shutdown RPC sent, waiting for process exit.
+	StateStopping
+	// StateStopped: process has exited and resources are cleaned up.
+	StateStopped
+)
+
+// ModuleHandle represents a running out-of-process module instance.
+// Obtain one via ModuleRuntime.Start; release with ModuleRuntime.Stop.
+type ModuleHandle struct {
+	// Name is the module's name from its manifest.
+	Name string
+
+	// Client is the gRPC client for this module session.
+	Client contract.StewardModuleClient
+
+	conn       *grpc.ClientConn
+	cmd        *exec.Cmd
+	socketPath string
+	state      LifecycleState
+	waitCh     chan struct{} // closed when the module process exits
+	mu         sync.Mutex
+}
+
+// GetState returns the current lifecycle state of the handle.
+func (h *ModuleHandle) GetState() LifecycleState {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return h.state
+}

--- a/features/steward/modules/runtime/runtime.go
+++ b/features/steward/modules/runtime/runtime.go
@@ -1,0 +1,220 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 CFGMS Contributors
+
+// Package runtime implements the steward module runtime: fork/exec, gRPC client,
+// lifecycle management, and trust mode enforcement for out-of-process modules.
+//
+// Only steward-kind modules may be started by this runtime. Outpost and workflow
+// modules are handled by separate runtimes (not in scope for this story).
+package runtime
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	goruntime "runtime"
+	"strings"
+	"sync/atomic"
+	"time"
+	"unicode"
+
+	proto "github.com/cfgis/cfgms/api/proto/modules"
+	"github.com/cfgis/cfgms/features/config/stewardtypes"
+	stewardtrust "github.com/cfgis/cfgms/features/steward/modules/trust"
+	"github.com/cfgis/cfgms/pkg/modules/bundle"
+)
+
+// ErrWrongModuleKind is returned by Start when the bundle's module kind is not
+// "steward". The steward runtime hosts only steward-kind modules.
+var ErrWrongModuleKind = errors.New("wrong module kind: steward runtime hosts only steward-kind modules")
+
+// handleSeq generates unique monotonic IDs for socket path generation.
+var handleSeq atomic.Int64
+
+// ModuleRuntime manages the lifecycle of out-of-process steward module binaries.
+// Create one per steward instance with NewModuleRuntime.
+type ModuleRuntime struct {
+	runtimeDir string
+	enforcer   *stewardtrust.StewardTrustEnforcer
+}
+
+// NewModuleRuntime returns a ModuleRuntime that creates sockets under runtimeDir.
+// runtimeDir must be a writable directory; use t.TempDir() in tests.
+func NewModuleRuntime(runtimeDir string) *ModuleRuntime {
+	return &ModuleRuntime{
+		runtimeDir: runtimeDir,
+		enforcer:   stewardtrust.NewStewardTrustEnforcer(),
+	}
+}
+
+// NewModuleRuntimeWithEnforcer returns a ModuleRuntime using the provided trust
+// enforcer. Use in tests to inject a custom enforcer with a known key pair;
+// use NewModuleRuntime in production code.
+func NewModuleRuntimeWithEnforcer(runtimeDir string, enforcer *stewardtrust.StewardTrustEnforcer) *ModuleRuntime {
+	return &ModuleRuntime{
+		runtimeDir: runtimeDir,
+		enforcer:   enforcer,
+	}
+}
+
+// Start verifies trust, fork/execs the module binary for the current OS/arch,
+// waits for it to start listening, dials gRPC, and returns a ModuleHandle ready
+// for RPC calls.
+//
+// Error precedence:
+//  1. ErrWrongModuleKind — bundle.Manifest.Kind != "steward"
+//  2. pkgtrust.ErrPublisherNotTrusted — trust verification failed (strict mode)
+//  3. binary not found in bundle.Binaries for current os-arch
+//  4. fork/exec, socket, or gRPC errors
+func (r *ModuleRuntime) Start(
+	b *bundle.Bundle,
+	mode stewardtypes.ModuleTrustMode,
+	additionalPublishers []stewardtrust.PublisherIdentity,
+) (*ModuleHandle, error) {
+	// 1. Kind gate — must be first; steward runtime hosts only steward-kind modules.
+	if b.Manifest == nil || b.Manifest.Kind != "steward" {
+		got := ""
+		if b.Manifest != nil {
+			got = b.Manifest.Kind
+		}
+		return nil, fmt.Errorf("%w: got %q", ErrWrongModuleKind, got)
+	}
+
+	// 2. Trust enforcement — must happen before any fork/exec.
+	if err := r.enforcer.VerifyForLoad(b, mode, additionalPublishers); err != nil {
+		return nil, err
+	}
+
+	// 3. Locate the binary for the current platform.
+	osArch := goruntime.GOOS + "-" + goruntime.GOARCH
+	binPath, ok := b.Binaries[osArch]
+	if !ok {
+		return nil, fmt.Errorf("no binary for %q in bundle %q (available: %v)",
+			osArch, b.Manifest.Name, binaryKeys(b.Binaries))
+	}
+
+	// 4. Construct a unique socket path for this module instance.
+	id := handleSeq.Add(1)
+	socketPath := makeSocketPath(r.runtimeDir, b.Manifest.Name, id)
+
+	// 5. Fork/exec the module binary with the socket path in its environment.
+	// #nosec G204 — binPath comes from the bundle manifest, not user-supplied input.
+	cmd := exec.Command(binPath)
+	cmd.Env = append(os.Environ(), "CFGMS_MODULE_SOCKET="+socketPath)
+
+	if err := cmd.Start(); err != nil {
+		return nil, fmt.Errorf("fork/exec module %q (%s): %w", b.Manifest.Name, binPath, err)
+	}
+
+	// 6. Wait for the module to start listening on its socket (up to 30 s).
+	startCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	if err := waitForSocket(startCtx, socketPath); err != nil {
+		_ = cmd.Process.Kill()
+		_ = cmd.Wait()
+		_ = os.Remove(socketPath)
+		return nil, fmt.Errorf("module %q did not start listening: %w", b.Manifest.Name, err)
+	}
+
+	// 7. Dial gRPC over the local socket.
+	conn, err := dialGRPCSocket(socketPath)
+	if err != nil {
+		_ = cmd.Process.Kill()
+		_ = cmd.Wait()
+		_ = os.Remove(socketPath)
+		return nil, fmt.Errorf("dial gRPC for module %q: %w", b.Manifest.Name, err)
+	}
+
+	client := proto.NewModuleServiceClient(conn)
+
+	// 8. Perform the module handshake to confirm the gRPC session.
+	hsCtx, hsCancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer hsCancel()
+
+	if _, err := client.Handshake(hsCtx, &proto.HandshakeRequest{
+		ModuleName:    b.Manifest.Name,
+		ModuleVersion: b.Manifest.Version,
+		Publisher:     b.Manifest.Publisher,
+		HostRuntime:   "steward",
+	}); err != nil {
+		_ = conn.Close()
+		_ = cmd.Process.Kill()
+		_ = cmd.Wait()
+		_ = os.Remove(socketPath)
+		return nil, fmt.Errorf("handshake with module %q: %w", b.Manifest.Name, err)
+	}
+
+	// 9. Start a goroutine to collect the process exit status.
+	waitCh := make(chan struct{})
+	go func() {
+		_ = cmd.Wait()
+		close(waitCh)
+	}()
+
+	h := &ModuleHandle{
+		Name:       b.Manifest.Name,
+		Client:     client,
+		conn:       conn,
+		cmd:        cmd,
+		socketPath: socketPath,
+		state:      StateRunning,
+		waitCh:     waitCh,
+	}
+	return h, nil
+}
+
+// Stop sends the Shutdown RPC, waits for the module process to exit, and kills
+// the process if it has not exited within 10 seconds. Stop is idempotent.
+func (r *ModuleRuntime) Stop(h *ModuleHandle) error {
+	h.mu.Lock()
+	if h.state >= StateStopping {
+		h.mu.Unlock()
+		return nil
+	}
+	h.state = StateStopping
+	h.mu.Unlock()
+
+	// Send Shutdown RPC (best-effort: process may already have exited).
+	shutCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	_, _ = h.Client.Shutdown(shutCtx, &proto.ShutdownRequest{})
+	cancel()
+
+	// Wait for process exit with a 10-second deadline.
+	select {
+	case <-h.waitCh:
+	case <-time.After(10 * time.Second):
+		_ = h.cmd.Process.Kill()
+		<-h.waitCh
+	}
+
+	h.mu.Lock()
+	h.state = StateStopped
+	h.mu.Unlock()
+
+	_ = h.conn.Close()
+	_ = os.Remove(h.socketPath)
+	return nil
+}
+
+// sanitizeName replaces characters that are unsafe in socket/pipe names with
+// hyphens so module names like "publisher/name" produce valid path components.
+func sanitizeName(name string) string {
+	return strings.Map(func(r rune) rune {
+		if unicode.IsLetter(r) || unicode.IsDigit(r) || r == '-' || r == '_' {
+			return r
+		}
+		return '-'
+	}, name)
+}
+
+// binaryKeys returns the keys of the binaries map for use in error messages.
+func binaryKeys(binaries map[string]string) []string {
+	keys := make([]string, 0, len(binaries))
+	for k := range binaries {
+		keys = append(keys, k)
+	}
+	return keys
+}

--- a/features/steward/modules/runtime/runtime_test.go
+++ b/features/steward/modules/runtime/runtime_test.go
@@ -1,0 +1,254 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 CFGMS Contributors
+
+//go:build !windows
+
+package runtime_test
+
+import (
+	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	goruntime "runtime"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	proto "github.com/cfgis/cfgms/api/proto/modules"
+	"github.com/cfgis/cfgms/features/config/stewardtypes"
+	featuremodules "github.com/cfgis/cfgms/features/modules"
+	"github.com/cfgis/cfgms/features/steward/modules/runtime"
+	stewardtrust "github.com/cfgis/cfgms/features/steward/modules/trust"
+	"github.com/cfgis/cfgms/pkg/modules/bundle"
+	pkgtrust "github.com/cfgis/cfgms/pkg/modules/trust"
+)
+
+// echoModuleBin is the path to the compiled echo_module binary. It is set by
+// TestMain before any tests run.
+var echoModuleBin string
+
+// binaryDir holds the temp dir for the compiled echo_module binary; cleaned up
+// after all tests complete.
+var binaryDir string
+
+func TestMain(m *testing.M) {
+	os.Exit(run(m))
+}
+
+func run(m *testing.M) int {
+	var err error
+	binaryDir, err = os.MkdirTemp("", "echo-module-test-*")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "runtime_test: failed to create temp dir: %v\n", err)
+		return 1
+	}
+	defer func() { _ = os.RemoveAll(binaryDir) }()
+
+	echoModuleBin = filepath.Join(binaryDir, "echo_module")
+	cmd := exec.Command("go", "build", "-o", echoModuleBin, "./testdata/echo_module")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		fmt.Fprintf(os.Stderr, "runtime_test: failed to build echo_module: %s: %v\n", out, err)
+		return 1
+	}
+
+	return m.Run()
+}
+
+// makeBypassBundle creates a minimal steward-kind bundle using the echo_module
+// binary. Trust mode bypass is used by tests that focus on lifecycle, not trust.
+func makeBypassBundle(binPath string) *bundle.Bundle {
+	return &bundle.Bundle{
+		Manifest: &featuremodules.ModuleMetadata{
+			Name:      "echo",
+			Version:   "0.1.0",
+			Executors: []string{"steward"},
+			Kind:      "steward",
+			Publisher: "test",
+		},
+		ContentHash: "sha256-echo-test-hash",
+		Binaries:    map[string]string{goruntime.GOOS + "-" + goruntime.GOARCH: binPath},
+	}
+}
+
+// TestEchoModuleLifecycle verifies the full lifecycle:
+//   - Start() fork/execs echo_module and connects via gRPC
+//   - Get() returns "echo:<resource_id>"
+//   - Stop() sends Shutdown RPC and the process exits within 10 s
+func TestEchoModuleLifecycle(t *testing.T) {
+	rt := runtime.NewModuleRuntime(t.TempDir())
+	b := makeBypassBundle(echoModuleBin)
+
+	handle, err := rt.Start(b, stewardtypes.ModuleTrustModeBypass, nil)
+	require.NoError(t, err)
+	require.NotNil(t, handle)
+	assert.Equal(t, runtime.StateRunning, handle.GetState())
+
+	// Call Get via gRPC; expect echo response.
+	ctx := context.Background()
+	resp, err := handle.Client.Get(ctx, &proto.GetRequest{ResourceId: "my-resource"})
+	require.NoError(t, err)
+	assert.Equal(t, "echo:my-resource", resp.ConfigData)
+
+	// Stop and verify clean shutdown.
+	require.NoError(t, rt.Stop(handle))
+	assert.Equal(t, runtime.StateStopped, handle.GetState())
+}
+
+// TestStartReturnsErrWrongModuleKindForNonStewardBundle verifies that Start()
+// returns ErrWrongModuleKind immediately, before any fork/exec, for bundles
+// whose kind is not "steward".
+func TestStartReturnsErrWrongModuleKindForNonStewardBundle(t *testing.T) {
+	rt := runtime.NewModuleRuntime(t.TempDir())
+
+	cases := []struct {
+		name string
+		kind string
+	}{
+		{"outpost kind", "outpost"},
+		{"workflow kind", "workflow"},
+		{"empty kind", ""},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			b := &bundle.Bundle{
+				Manifest: &featuremodules.ModuleMetadata{
+					Name:      "wrong-kind",
+					Version:   "1.0.0",
+					Kind:      tc.kind,
+					Publisher: "test",
+				},
+				Binaries: map[string]string{goruntime.GOOS + "-" + goruntime.GOARCH: "/nonexistent"},
+			}
+
+			_, err := rt.Start(b, stewardtypes.ModuleTrustModeBypass, nil)
+			require.Error(t, err)
+			assert.ErrorIs(t, err, runtime.ErrWrongModuleKind)
+		})
+	}
+}
+
+// TestStartReturnsErrWrongModuleKindForNilManifest verifies that a nil Manifest
+// returns ErrWrongModuleKind.
+func TestStartReturnsErrWrongModuleKindForNilManifest(t *testing.T) {
+	rt := runtime.NewModuleRuntime(t.TempDir())
+	b := &bundle.Bundle{
+		Manifest: nil,
+		Binaries: map[string]string{goruntime.GOOS + "-" + goruntime.GOARCH: "/nonexistent"},
+	}
+	_, err := rt.Start(b, stewardtypes.ModuleTrustModeBypass, nil)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, runtime.ErrWrongModuleKind)
+}
+
+// TestStrictModeRejectsControllerApprovedUnknownPublisher is the key threat-model
+// test: a compromised controller cannot push arbitrary modules to strict-mode
+// stewards. Even if the controller approved the bundle, if the steward's local
+// trust store does not contain the publisher's key, Start() must return
+// ErrPublisherNotTrusted before any fork/exec occurs.
+func TestStrictModeRejectsControllerApprovedUnknownPublisher(t *testing.T) {
+	// Generate an "unknown" publisher key pair — not in the steward's trust set.
+	_, unknownPriv, err := ed25519.GenerateKey(rand.Reader)
+	require.NoError(t, err)
+
+	// Sign a bundle with the unknown key.
+	b := &bundle.Bundle{
+		Manifest: &featuremodules.ModuleMetadata{
+			Name:      "malicious-module",
+			Version:   "1.0.0",
+			Executors: []string{"steward"},
+			Kind:      "steward",
+			Publisher: "unknown-vendor",
+		},
+		ContentHash: "sha256-controller-approved-hash",
+		Binaries:    map[string]string{goruntime.GOOS + "-" + goruntime.GOARCH: "/nonexistent/path"},
+	}
+	sig := ed25519.Sign(unknownPriv, []byte(b.ContentHash))
+	b.Signatures = []bundle.BundleSignature{
+		{Publisher: "unknown-vendor", Algorithm: "ed25519", Signature: sig},
+	}
+
+	rt := runtime.NewModuleRuntime(t.TempDir())
+
+	// Start in strict mode with no additional publishers.
+	_, err = rt.Start(b, stewardtypes.ModuleTrustModeStrict, nil)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, pkgtrust.ErrPublisherNotTrusted,
+		"strict-mode steward must reject bundles from untrusted publishers before fork/exec")
+}
+
+// TestControllerModePassesUnsignedBundle verifies that controller mode skips
+// signature verification.
+func TestControllerModePassesUnsignedBundle(t *testing.T) {
+	rt := runtime.NewModuleRuntime(t.TempDir())
+	b := makeBypassBundle(echoModuleBin)
+
+	handle, err := rt.Start(b, stewardtypes.ModuleTrustModeController, nil)
+	require.NoError(t, err)
+	require.NoError(t, rt.Stop(handle))
+}
+
+// TestBypassModePassesUnsignedBundle verifies that bypass mode skips
+// signature verification.
+func TestBypassModePassesUnsignedBundle(t *testing.T) {
+	rt := runtime.NewModuleRuntime(t.TempDir())
+	b := makeBypassBundle(echoModuleBin)
+
+	handle, err := rt.Start(b, stewardtypes.ModuleTrustModeBypass, nil)
+	require.NoError(t, err)
+	require.NoError(t, rt.Stop(handle))
+}
+
+// TestStopIsIdempotent verifies that calling Stop multiple times on the same
+// handle does not error or panic.
+func TestStopIsIdempotent(t *testing.T) {
+	rt := runtime.NewModuleRuntime(t.TempDir())
+	b := makeBypassBundle(echoModuleBin)
+
+	handle, err := rt.Start(b, stewardtypes.ModuleTrustModeBypass, nil)
+	require.NoError(t, err)
+
+	require.NoError(t, rt.Stop(handle))
+	require.NoError(t, rt.Stop(handle)) // second call must not error
+}
+
+// testEnforcerRuntimeWithKey returns a ModuleRuntime whose trust enforcer uses
+// the given public key as the CFGMS identity (for strict-mode tests that need to
+// sign with a known key).
+func testEnforcerRuntimeWithKey(t *testing.T, cfgmsPub ed25519.PublicKey) *runtime.ModuleRuntime {
+	t.Helper()
+	rt := runtime.NewModuleRuntimeWithEnforcer(
+		t.TempDir(),
+		stewardtrust.NewStewardTrustEnforcerWithIdentity(func() pkgtrust.PublisherIdentity {
+			return pkgtrust.PublisherIdentity{
+				Name:      "cfgms",
+				PublicKey: []byte(cfgmsPub),
+				Algorithm: "ed25519",
+			}
+		}),
+	)
+	return rt
+}
+
+// TestStrictModeAcceptsCFGMSSignedBundle verifies that strict mode accepts a
+// bundle signed with the configured CFGMS publisher identity.
+func TestStrictModeAcceptsCFGMSSignedBundle(t *testing.T) {
+	cfgmsPub, cfgmsPriv, err := ed25519.GenerateKey(rand.Reader)
+	require.NoError(t, err)
+
+	b := makeBypassBundle(echoModuleBin)
+	sig := ed25519.Sign(cfgmsPriv, []byte(b.ContentHash))
+	b.Signatures = []bundle.BundleSignature{
+		{Publisher: "cfgms", Algorithm: "ed25519", Signature: sig},
+	}
+
+	rt := testEnforcerRuntimeWithKey(t, cfgmsPub)
+	handle, err := rt.Start(b, stewardtypes.ModuleTrustModeStrict, nil)
+	require.NoError(t, err)
+	require.NoError(t, rt.Stop(handle))
+}

--- a/features/steward/modules/runtime/runtime_test.go
+++ b/features/steward/modules/runtime/runtime_test.go
@@ -99,6 +99,39 @@ func TestEchoModuleLifecycle(t *testing.T) {
 	assert.Equal(t, runtime.StateStopped, handle.GetState())
 }
 
+// TestEchoModuleLifecycleWithOverlongRuntimeDir is the regression test for the
+// macOS CI failures (PR #1897 review): on macOS, t.TempDir() returns paths
+// under /var/folders/... that, joined with the socket filename, exceed the
+// 104-byte sun_path limit. The runtime must fall back to a short hashed path
+// under /tmp so net.Listen("unix", ...) succeeds. This test forces the fallback
+// path on all platforms by passing a deliberately long runtimeDir.
+func TestEchoModuleLifecycleWithOverlongRuntimeDir(t *testing.T) {
+	// Build a runtime dir long enough that the natural socket path overflows
+	// 103 bytes — exercising the fallback even on Linux where t.TempDir() is
+	// normally short.
+	base := t.TempDir()
+	deep := filepath.Join(base,
+		"deeply", "nested", "directory", "tree",
+		"with", "enough", "path", "components",
+		"to", "blow", "past", "the", "macos", "sun_path", "limit",
+	)
+	require.NoError(t, os.MkdirAll(deep, 0o755))
+
+	rt := runtime.NewModuleRuntime(deep)
+	b := makeBypassBundle(echoModuleBin)
+
+	handle, err := rt.Start(b, stewardtypes.ModuleTrustModeBypass, nil)
+	require.NoError(t, err)
+	require.NotNil(t, handle)
+
+	ctx := context.Background()
+	resp, err := handle.Client.Get(ctx, &proto.GetRequest{ResourceId: "long-path"})
+	require.NoError(t, err)
+	assert.Equal(t, "echo:long-path", resp.ConfigData)
+
+	require.NoError(t, rt.Stop(handle))
+}
+
 // TestStartReturnsErrWrongModuleKindForNonStewardBundle verifies that Start()
 // returns ErrWrongModuleKind immediately, before any fork/exec, for bundles
 // whose kind is not "steward".

--- a/features/steward/modules/runtime/socket_unix.go
+++ b/features/steward/modules/runtime/socket_unix.go
@@ -7,6 +7,8 @@ package runtime
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"net"
 	"path/filepath"
@@ -16,10 +18,37 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 )
 
+// unixSocketPathMax is the maximum Unix domain socket path length set by the
+// strictest mainstream platform. macOS sockaddr_un.sun_path is 104 bytes
+// (including the null terminator), so the usable path length is 103 chars.
+// Linux allows 108. Picking the smaller value keeps cross-platform behavior
+// predictable.
+const unixSocketPathMax = 103
+
 // makeSocketPath returns the Unix domain socket path for a module instance.
 // Format: ${runtimeDir}/cfgms-module-${name}-${id}.sock
+//
+// If the natural path would exceed the platform's sun_path limit, it falls
+// back to a short hashed path under /tmp. This handles long temp dirs on
+// macOS (/var/folders/xx/yyy/T/...), where t.TempDir() in tests produces
+// paths that exceed the 104-byte sun_path limit.
+//
+// TODO(production-wiring): when ModuleRuntime is wired into the steward boot
+// path, ensure the configured runtimeDir is short enough that the fallback is
+// never reached on macOS — or replace this fallback with a steward-owned,
+// mode-0700 subdirectory so /tmp predictability cannot be exploited locally.
 func makeSocketPath(runtimeDir, moduleName string, id int64) string {
-	return filepath.Join(runtimeDir, fmt.Sprintf("cfgms-module-%s-%d.sock", sanitizeName(moduleName), id))
+	name := fmt.Sprintf("cfgms-module-%s-%d.sock", sanitizeName(moduleName), id)
+	natural := filepath.Join(runtimeDir, name)
+	if len(natural) <= unixSocketPathMax {
+		return natural
+	}
+	// Hash the natural path (including runtimeDir and id) to retain uniqueness
+	// across runtime instances. 12 hex chars gives 48 bits of entropy — ample
+	// for collision avoidance within a host.
+	sum := sha256.Sum256([]byte(natural))
+	hash := hex.EncodeToString(sum[:6])
+	return filepath.Join("/tmp", fmt.Sprintf("cfgms-%s.sock", hash))
 }
 
 // waitForSocket polls the Unix socket at socketPath until it accepts a

--- a/features/steward/modules/runtime/socket_unix.go
+++ b/features/steward/modules/runtime/socket_unix.go
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 CFGMS Contributors
+
+//go:build !windows
+
+package runtime
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"path/filepath"
+	"time"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+)
+
+// makeSocketPath returns the Unix domain socket path for a module instance.
+// Format: ${runtimeDir}/cfgms-module-${name}-${id}.sock
+func makeSocketPath(runtimeDir, moduleName string, id int64) string {
+	return filepath.Join(runtimeDir, fmt.Sprintf("cfgms-module-%s-%d.sock", sanitizeName(moduleName), id))
+}
+
+// waitForSocket polls the Unix socket at socketPath until it accepts a
+// connection or ctx is cancelled.
+func waitForSocket(ctx context.Context, socketPath string) error {
+	for {
+		conn, err := net.DialTimeout("unix", socketPath, 100*time.Millisecond)
+		if err == nil {
+			_ = conn.Close()
+			return nil
+		}
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("socket %q not ready: %w", socketPath, ctx.Err())
+		case <-time.After(50 * time.Millisecond):
+		}
+	}
+}
+
+// dialGRPCSocket creates a gRPC client connection over the Unix socket at socketPath.
+func dialGRPCSocket(socketPath string) (*grpc.ClientConn, error) {
+	return grpc.NewClient(
+		"unix://"+socketPath,
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+}

--- a/features/steward/modules/runtime/socket_unix_test.go
+++ b/features/steward/modules/runtime/socket_unix_test.go
@@ -25,7 +25,7 @@ func TestMakeSocketPathShortRuntimeDirUsesNaturalPath(t *testing.T) {
 // macOS test failures where t.TempDir() returns paths under /var/folders/...
 // that exceed 104 bytes when combined with the socket filename.
 func TestMakeSocketPathLongRuntimeDirFallsBackToTmp(t *testing.T) {
-	// Simulate the macOS t.TempDir() path that overflowed in CI.
+	// Use the actual macOS t.TempDir() path that overflowed in CI.
 	longDir := "/var/folders/8d/778wjbv96mq1760tv6gk374m0000gn/T/TestEchoModuleLifecycle1001087929/001"
 	path := makeSocketPath(longDir, "echo", 1)
 

--- a/features/steward/modules/runtime/socket_unix_test.go
+++ b/features/steward/modules/runtime/socket_unix_test.go
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 CFGMS Contributors
+
+//go:build !windows
+
+package runtime
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestMakeSocketPathShortRuntimeDirUsesNaturalPath verifies that when the
+// natural path fits the sun_path limit, it is used unchanged.
+func TestMakeSocketPathShortRuntimeDirUsesNaturalPath(t *testing.T) {
+	path := makeSocketPath("/tmp/cfg", "echo", 1)
+	assert.Equal(t, "/tmp/cfg/cfgms-module-echo-1.sock", path)
+}
+
+// TestMakeSocketPathLongRuntimeDirFallsBackToTmp verifies that when the natural
+// path would exceed the macOS sun_path limit (104 bytes), makeSocketPath falls
+// back to a hashed short path under /tmp. This is the regression test for the
+// macOS test failures where t.TempDir() returns paths under /var/folders/...
+// that exceed 104 bytes when combined with the socket filename.
+func TestMakeSocketPathLongRuntimeDirFallsBackToTmp(t *testing.T) {
+	// Simulate the macOS t.TempDir() path that overflowed in CI.
+	longDir := "/var/folders/8d/778wjbv96mq1760tv6gk374m0000gn/T/TestEchoModuleLifecycle1001087929/001"
+	path := makeSocketPath(longDir, "echo", 1)
+
+	assert.LessOrEqualf(t, len(path), unixSocketPathMax,
+		"fallback path %q (%d bytes) must fit Unix sun_path limit", path, len(path))
+	assert.Truef(t, strings.HasPrefix(path, "/tmp/cfgms-"),
+		"fallback path %q must live under /tmp", path)
+	assert.Truef(t, strings.HasSuffix(path, ".sock"),
+		"fallback path %q must end with .sock", path)
+}
+
+// TestMakeSocketPathFallbackIsUnique verifies that distinct natural paths
+// produce distinct fallback paths (so two concurrent modules do not collide).
+func TestMakeSocketPathFallbackIsUnique(t *testing.T) {
+	longDir := "/var/folders/8d/778wjbv96mq1760tv6gk374m0000gn/T/long-runtime-dir-with-extra-padding"
+	p1 := makeSocketPath(longDir, "echo", 1)
+	p2 := makeSocketPath(longDir, "echo", 2)
+	p3 := makeSocketPath(longDir, "other", 1)
+
+	assert.NotEqual(t, p1, p2, "different ids must produce different fallback paths")
+	assert.NotEqual(t, p1, p3, "different module names must produce different fallback paths")
+}
+
+// TestMakeSocketPathBoundary verifies behavior right at the path-length
+// threshold: paths of exactly unixSocketPathMax bytes are kept as-is, paths
+// one byte over fall back to /tmp.
+func TestMakeSocketPathBoundary(t *testing.T) {
+	// Build a runtime dir such that the natural path is exactly the max length.
+	// natural = "/x/<padding>/cfgms-module-echo-1.sock"
+	// 24 chars for "cfgms-module-echo-1.sock" + 1 separator + N for runtimeDir.
+	const socketName = "cfgms-module-echo-1.sock"
+	roomForDir := unixSocketPathMax - len(socketName) - 1 // 1 for the joining /
+	dirAtMax := "/" + strings.Repeat("a", roomForDir-1)   // leading / counts
+	pathAtMax := makeSocketPath(dirAtMax, "echo", 1)
+	assert.Equal(t, unixSocketPathMax, len(pathAtMax),
+		"natural path at exactly the limit must be kept as-is")
+
+	dirOverMax := dirAtMax + "a"
+	pathOver := makeSocketPath(dirOverMax, "echo", 1)
+	assert.LessOrEqual(t, len(pathOver), unixSocketPathMax)
+	assert.Truef(t, strings.HasPrefix(pathOver, "/tmp/cfgms-"),
+		"path one byte over the limit must fall back to /tmp, got %q", pathOver)
+}

--- a/features/steward/modules/runtime/socket_windows.go
+++ b/features/steward/modules/runtime/socket_windows.go
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 CFGMS Contributors
+
+//go:build windows
+
+package runtime
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"time"
+
+	"github.com/Microsoft/go-winio"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+)
+
+// makeSocketPath returns the named pipe path for a module instance.
+// Format: \\.\pipe\cfgms-module-${name}-${id}
+// runtimeDir is unused on Windows (named pipes don't use directories).
+func makeSocketPath(runtimeDir, moduleName string, id int64) string {
+	return fmt.Sprintf(`\\.\pipe\cfgms-module-%s-%d`, sanitizeName(moduleName), id)
+}
+
+// waitForSocket polls the named pipe at socketPath until it accepts a
+// connection or ctx is cancelled.
+func waitForSocket(ctx context.Context, socketPath string) error {
+	for {
+		conn, err := winio.DialPipeContext(ctx, socketPath)
+		if err == nil {
+			_ = conn.Close()
+			return nil
+		}
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("named pipe %q not ready: %w", socketPath, ctx.Err())
+		case <-time.After(50 * time.Millisecond):
+		}
+	}
+}
+
+// dialGRPCSocket creates a gRPC client connection over the Windows named pipe.
+func dialGRPCSocket(socketPath string) (*grpc.ClientConn, error) {
+	return grpc.NewClient(
+		socketPath,
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithContextDialer(func(ctx context.Context, addr string) (net.Conn, error) {
+			return winio.DialPipeContext(ctx, addr)
+		}),
+	)
+}

--- a/features/steward/modules/runtime/testdata/echo_module/main.go
+++ b/features/steward/modules/runtime/testdata/echo_module/main.go
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 CFGMS Contributors
+
+// echo_module is a minimal out-of-process module binary used exclusively by
+// runtime tests. It implements the ModuleService gRPC contract:
+//
+//   - Handshake: acknowledges the session with an "echo" capability.
+//   - Get: returns ConfigData = "echo:" + req.ResourceId.
+//   - Set: acknowledges with Applied = true.
+//   - Test: returns InCompliance = true.
+//   - Shutdown: stops the gRPC server and exits cleanly.
+//
+// The socket path is supplied via the CFGMS_MODULE_SOCKET environment variable.
+package main
+
+import (
+	"context"
+	"log"
+	"net"
+	"os"
+	"os/signal"
+	"syscall"
+
+	proto "github.com/cfgis/cfgms/api/proto/modules"
+	"google.golang.org/grpc"
+)
+
+type echoServer struct {
+	proto.UnimplementedModuleServiceServer
+	srv *grpc.Server
+}
+
+func (s *echoServer) Handshake(_ context.Context, _ *proto.HandshakeRequest) (*proto.HandshakeResponse, error) {
+	return &proto.HandshakeResponse{Capabilities: []string{"echo"}}, nil
+}
+
+func (s *echoServer) Get(_ context.Context, req *proto.GetRequest) (*proto.GetResponse, error) {
+	return &proto.GetResponse{ConfigData: "echo:" + req.ResourceId}, nil
+}
+
+func (s *echoServer) Set(_ context.Context, _ *proto.SetRequest) (*proto.SetResponse, error) {
+	return &proto.SetResponse{Applied: true}, nil
+}
+
+func (s *echoServer) Test(_ context.Context, _ *proto.TestRequest) (*proto.TestResponse, error) {
+	return &proto.TestResponse{InCompliance: true}, nil
+}
+
+func (s *echoServer) Shutdown(_ context.Context, _ *proto.ShutdownRequest) (*proto.ShutdownResponse, error) {
+	go s.srv.GracefulStop()
+	return &proto.ShutdownResponse{}, nil
+}
+
+func main() {
+	socketPath := os.Getenv("CFGMS_MODULE_SOCKET")
+	if socketPath == "" {
+		log.Fatal("echo_module: CFGMS_MODULE_SOCKET environment variable is required")
+	}
+
+	lis, err := net.Listen("unix", socketPath)
+	if err != nil {
+		log.Fatalf("echo_module: failed to listen on %s: %v", socketPath, err)
+	}
+
+	srv := grpc.NewServer()
+	es := &echoServer{srv: srv}
+	proto.RegisterModuleServiceServer(srv, es)
+
+	// Handle SIGTERM/SIGINT for graceful shutdown when killed by the runtime.
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGTERM, syscall.SIGINT)
+	go func() {
+		<-sigCh
+		srv.GracefulStop()
+	}()
+
+	if err := srv.Serve(lis); err != nil {
+		log.Fatalf("echo_module: gRPC server exited with error: %v", err)
+	}
+}

--- a/features/steward/modules/trust/trust.go
+++ b/features/steward/modules/trust/trust.go
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 CFGMS Contributors
+
+// Package trust enforces module trust policy on behalf of the steward runtime.
+// It bridges steward.cfg ModuleTrustMode settings with the cryptographic
+// verification primitives in pkg/modules/trust.
+package trust
+
+import (
+	"fmt"
+
+	"github.com/cfgis/cfgms/features/config/stewardtypes"
+	"github.com/cfgis/cfgms/pkg/modules/bundle"
+	pkgtrust "github.com/cfgis/cfgms/pkg/modules/trust"
+)
+
+// TrustMode aliases stewardtypes.ModuleTrustMode for use in the runtime API.
+type TrustMode = stewardtypes.ModuleTrustMode
+
+// PublisherIdentity aliases the pkg-level type for use in the runtime API.
+type PublisherIdentity = pkgtrust.PublisherIdentity
+
+// StewardTrustEnforcer enforces module trust policy before the steward runtime
+// fork/execs a module binary.
+//
+// In strict mode, the bundle must carry at least one signature verifiable
+// against the set of trusted publishers: CFGMSPublisherIdentity() (baked-in at
+// build time) plus any additional publishers supplied by the caller.
+//
+// In controller or bypass mode, no verification is performed.
+type StewardTrustEnforcer struct {
+	// getCFGMSIdentity returns the CFGMS publisher identity used in strict mode.
+	// Production code uses pkgtrust.CFGMSPublisherIdentity(); tests inject a
+	// known key pair via NewStewardTrustEnforcerWithIdentity.
+	getCFGMSIdentity func() pkgtrust.PublisherIdentity
+}
+
+// NewStewardTrustEnforcer returns a production-ready StewardTrustEnforcer that
+// uses the baked-in CFGMS publisher identity from the build pipeline.
+func NewStewardTrustEnforcer() *StewardTrustEnforcer {
+	return &StewardTrustEnforcer{
+		getCFGMSIdentity: pkgtrust.CFGMSPublisherIdentity,
+	}
+}
+
+// NewStewardTrustEnforcerWithIdentity returns a StewardTrustEnforcer that calls
+// identityFn to obtain the CFGMS publisher identity. Use in tests to inject a
+// known key pair; use NewStewardTrustEnforcer in production code.
+func NewStewardTrustEnforcerWithIdentity(identityFn func() pkgtrust.PublisherIdentity) *StewardTrustEnforcer {
+	return &StewardTrustEnforcer{
+		getCFGMSIdentity: identityFn,
+	}
+}
+
+// VerifyForLoad checks whether bundle b may be loaded under the given trust mode.
+//
+//   - strict: the bundle must carry at least one Ed25519 signature that
+//     verifies against the CFGMS publisher identity or any additionalPublishers.
+//   - controller: no-op (the controller has already approved the bundle).
+//   - bypass: no-op (development use only).
+func (e *StewardTrustEnforcer) VerifyForLoad(b *bundle.Bundle, mode TrustMode, additionalPublishers []PublisherIdentity) error {
+	switch mode {
+	case stewardtypes.ModuleTrustModeController, stewardtypes.ModuleTrustModeBypass:
+		return nil
+	case stewardtypes.ModuleTrustModeStrict:
+		return e.verifyStrict(b, additionalPublishers)
+	default:
+		return fmt.Errorf("unknown module trust mode: %q", mode)
+	}
+}
+
+// verifyStrict verifies that at least one bundle signature matches a trusted
+// publisher (CFGMS identity or additionalPublishers).
+func (e *StewardTrustEnforcer) verifyStrict(b *bundle.Bundle, additionalPublishers []PublisherIdentity) error {
+	store := pkgtrust.NewInMemoryTrustStore()
+
+	// Always include the baked-in CFGMS publisher identity.
+	_ = store.AddPublisher(e.getCFGMSIdentity())
+
+	// TODO: v2 — resolve additional_publishers names to key material from trust store
+	for _, pub := range additionalPublishers {
+		_ = store.AddPublisher(pub)
+	}
+
+	bundleName := ""
+	if b.Manifest != nil {
+		bundleName = b.Manifest.Name
+	}
+
+	if len(b.Signatures) == 0 {
+		return fmt.Errorf("%w: bundle %q has no signatures", pkgtrust.ErrPublisherNotTrusted, bundleName)
+	}
+
+	var lastErr error
+	for _, sig := range b.Signatures {
+		if err := pkgtrust.VerifyBundleSignature(b, sig, store); err == nil {
+			return nil
+		} else {
+			lastErr = err
+		}
+	}
+	return lastErr
+}

--- a/features/steward/modules/trust/trust_test.go
+++ b/features/steward/modules/trust/trust_test.go
@@ -1,0 +1,138 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 CFGMS Contributors
+package trust_test
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cfgis/cfgms/features/config/stewardtypes"
+	featuremodules "github.com/cfgis/cfgms/features/modules"
+	stewardtrust "github.com/cfgis/cfgms/features/steward/modules/trust"
+	"github.com/cfgis/cfgms/pkg/modules/bundle"
+	pkgtrust "github.com/cfgis/cfgms/pkg/modules/trust"
+)
+
+// testEnforcer returns a StewardTrustEnforcer whose CFGMS identity uses the
+// provided public key, so tests can sign bundles with the matching private key.
+func testEnforcer(cfgmsPub ed25519.PublicKey) *stewardtrust.StewardTrustEnforcer {
+	return stewardtrust.NewStewardTrustEnforcerWithIdentity(func() pkgtrust.PublisherIdentity {
+		return pkgtrust.PublisherIdentity{
+			Name:      "cfgms",
+			PublicKey: []byte(cfgmsPub),
+			Algorithm: "ed25519",
+		}
+	})
+}
+
+// signBundle signs b.ContentHash with priv and appends the signature to b.Signatures.
+func signBundle(b *bundle.Bundle, publisherName string, priv ed25519.PrivateKey) {
+	sig := ed25519.Sign(priv, []byte(b.ContentHash))
+	b.Signatures = append(b.Signatures, bundle.BundleSignature{
+		Publisher: publisherName,
+		Algorithm: "ed25519",
+		Signature: sig,
+	})
+}
+
+func makeTestBundle() *bundle.Bundle {
+	return &bundle.Bundle{
+		Manifest: &featuremodules.ModuleMetadata{
+			Name:      "test-module",
+			Version:   "1.0.0",
+			Executors: []string{"steward"},
+			Kind:      "steward",
+			Publisher: "test",
+		},
+		ContentHash: "sha256-test-content-hash-for-signing",
+	}
+}
+
+// TestStrictModeAcceptsCFGMSSignedBundle: bundle signed by CFGMSPublisherIdentity
+// key passes VerifyForLoad in strict mode.
+func TestStrictModeAcceptsCFGMSSignedBundle(t *testing.T) {
+	cfgmsPub, cfgmsPriv, err := ed25519.GenerateKey(rand.Reader)
+	require.NoError(t, err)
+
+	b := makeTestBundle()
+	signBundle(b, "cfgms", cfgmsPriv)
+
+	enforcer := testEnforcer(cfgmsPub)
+	assert.NoError(t, enforcer.VerifyForLoad(b, stewardtypes.ModuleTrustModeStrict, nil))
+}
+
+// TestStrictModeRejectsUnsignedBundle: bundle with no signatures fails in strict mode.
+func TestStrictModeRejectsUnsignedBundle(t *testing.T) {
+	cfgmsPub, _, err := ed25519.GenerateKey(rand.Reader)
+	require.NoError(t, err)
+
+	b := makeTestBundle()
+
+	enforcer := testEnforcer(cfgmsPub)
+	err = enforcer.VerifyForLoad(b, stewardtypes.ModuleTrustModeStrict, nil)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, pkgtrust.ErrPublisherNotTrusted)
+}
+
+// TestStrictModeRejectsUnknownPublisher: bundle signed by an unknown publisher
+// is rejected with ErrPublisherNotTrusted.
+func TestStrictModeRejectsUnknownPublisher(t *testing.T) {
+	cfgmsPub, _, err := ed25519.GenerateKey(rand.Reader)
+	require.NoError(t, err)
+
+	_, unknownPriv, err := ed25519.GenerateKey(rand.Reader)
+	require.NoError(t, err)
+
+	b := makeTestBundle()
+	signBundle(b, "unknown-vendor", unknownPriv)
+
+	enforcer := testEnforcer(cfgmsPub)
+	err = enforcer.VerifyForLoad(b, stewardtypes.ModuleTrustModeStrict, nil)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, pkgtrust.ErrPublisherNotTrusted)
+}
+
+// TestControllerModePassesUnsignedBundle: controller mode is a no-op.
+func TestControllerModePassesUnsignedBundle(t *testing.T) {
+	b := makeTestBundle()
+	enforcer := stewardtrust.NewStewardTrustEnforcer()
+	assert.NoError(t, enforcer.VerifyForLoad(b, stewardtypes.ModuleTrustModeController, nil))
+}
+
+// TestBypassModePassesUnsignedBundle: bypass mode is a no-op.
+func TestBypassModePassesUnsignedBundle(t *testing.T) {
+	b := makeTestBundle()
+	enforcer := stewardtrust.NewStewardTrustEnforcer()
+	assert.NoError(t, enforcer.VerifyForLoad(b, stewardtypes.ModuleTrustModeBypass, nil))
+}
+
+// TestStrictModeAcceptsAdditionalPublisher: bundle signed by a publisher in
+// additionalPublishers passes in strict mode.
+func TestStrictModeAcceptsAdditionalPublisher(t *testing.T) {
+	cfgmsPub, _, err := ed25519.GenerateKey(rand.Reader)
+	require.NoError(t, err)
+
+	extraPub, extraPriv, err := ed25519.GenerateKey(rand.Reader)
+	require.NoError(t, err)
+
+	b := makeTestBundle()
+	signBundle(b, "extra-vendor", extraPriv)
+
+	enforcer := testEnforcer(cfgmsPub)
+	additional := []stewardtrust.PublisherIdentity{
+		{Name: "extra-vendor", PublicKey: []byte(extraPub), Algorithm: "ed25519"},
+	}
+	assert.NoError(t, enforcer.VerifyForLoad(b, stewardtypes.ModuleTrustModeStrict, additional))
+}
+
+// TestUnknownModeReturnsError: an unrecognised mode string returns an error.
+func TestUnknownModeReturnsError(t *testing.T) {
+	b := makeTestBundle()
+	enforcer := stewardtrust.NewStewardTrustEnforcer()
+	err := enforcer.VerifyForLoad(b, stewardtypes.ModuleTrustMode("unsupported"), nil)
+	require.Error(t, err)
+}


### PR DESCRIPTION
## Summary

- **Module runtime** (`runtime.go`): `ModuleRuntime.Start()` fork/execs a steward-kind module binary, establishes a gRPC client over a Unix socket (or Windows named pipe), and returns a `ModuleHandle`. `Stop()` sends a `Shutdown` RPC, waits up to 10s for process exit, then kills. Both are safe to call concurrently.
- **Lifecycle state machine** (`lifecycle.go`): `StateStarting → StateReady → StateRunning → StateStopping → StateStopped` with mutex-guarded `GetState()`.
- **Trust enforcement** (`trust/trust.go`): `StewardTrustEnforcer.VerifyForLoad()` enforces strict/controller/bypass modes. Strict mode builds an `InMemoryTrustStore` from the baked-in CFGMS publisher identity plus any `additional_publishers` and verifies each bundle signature — rejecting bundles from unknown publishers before any fork/exec occurs.
- **Discovery update** (`discovery.go`): `ValidateModuleStructure` now validates the bundle layout (module.yaml + os-arch subdir with binary) rather than expecting `.go` source files.
- **Docs** (`steward-operating-model.md`): added trust modes table, module runtime lifecycle sequence, and four execution paths table.

## Threat model invariant

`Start()` enforces the order: **kind gate → trust verification → fork/exec**. `TestStrictModeRejectsControllerApprovedUnknownPublisher` verifies this by using a `/nonexistent/path` binary — if trust verification ran after fork/exec, the test would error on the fork rather than returning `ErrPublisherNotTrusted`.

## Specialist reviews

All three reviews PASS:
- **qa-test-runner**: all tests pass, 3 linter fixes applied (unused `setState`, defer errcheck, import ordering)
- **qa-code-reviewer**: required AC tests present and non-trivial, no mocks, real `echo_module` binary compiled in TestMain, all error paths covered
- **security-engineer**: trust enforcement ordering verified correct, `#nosec G204` justified (binary path comes from bundle manifest, not user input), insecure gRPC credentials appropriate for local IPC, no hardcoded secrets

## Test plan

- [ ] `make test-agent-complete` — all checks pass
- [ ] `TestEchoModuleLifecycle` — compiles echo_module, verifies Start→Get→Stop lifecycle
- [ ] `TestStrictModeRejectsControllerApprovedUnknownPublisher` — trust enforcement before fork/exec
- [ ] `TestStrictModeAcceptsCFGMSSignedBundle` — valid signature accepted in strict mode
- [ ] `TestStopIsIdempotent` — double-Stop does not error
- [ ] `TestStartReturnsErrWrongModuleKindForNonStewardBundle` — kind gate fires for outpost/workflow/empty kinds
- [ ] Discovery tests verify bundle layout validation

Fixes #1885

🤖 Generated with [Claude Code](https://claude.com/claude-code)