### PR TITLE
logging: fix circular proof in central_logging_validation MockLogger (Issue #1908)

### DIFF
--- a/pkg/logging/central_logging_validation_test.go
+++ b/pkg/logging/central_logging_validation_test.go
@@ -9,7 +9,6 @@ package logging_test
 import (
 	"context"
 	"path/filepath"
-	"strings"
 	"testing"
 	"time"
 
@@ -230,15 +229,16 @@ func testStructuredLoggingCompliance(t *testing.T) {
 	ctx = logging.WithSession(ctx, "test-session-456")
 	ctx = logging.WithOperation(ctx, "validation_test")
 
-	// Create test configuration — include allowed_base_path and type so the
-	// file module dispatches to setDirectory and reaches the logging code.
+	// Create test configuration — use the real file.FileConfig so GetManagedFields()
+	// matches the actual module's platform-aware behaviour.
 	tmpBase := t.TempDir()
 	targetPath := filepath.Join(tmpBase, "cfgms-logging-test")
 	// No explicit permissions: the directory uses the platform default mode so the
 	// logging code path is exercised on every OS (Unix permission bits are rejected
 	// on Windows, where windows_acl is the supported mechanism).
-	testConfig := &TestDirectoryConfig{
-		Path:            targetPath,
+	testConfig := &file.FileConfig{
+		Type:            "directory",
+		State:           "present",
 		AllowedBasePath: tmpBase,
 	}
 
@@ -316,8 +316,11 @@ func testTenantIsolationValidation(t *testing.T) {
 
 	// Verify no cross-tenant contamination
 	for _, entry := range entries {
-		tenantID := entry.Fields["tenant_id"].(string)
-		assert.Contains(t, tenants, tenantID, "all tenant IDs should be from test set")
+		tid, ok := entry.Fields["tenant_id"].(string)
+		if !ok {
+			t.Fatalf("log entry has missing or non-string tenant_id: fields=%v", entry.Fields)
+		}
+		assert.Contains(t, tenants, tid, "all tenant IDs should be from test set")
 	}
 }
 
@@ -394,7 +397,6 @@ type MockLogEntry struct {
 	Level   string
 	Message string
 	Fields  map[string]interface{}
-	Context context.Context
 }
 
 func (m *MockLogger) InfoCtx(ctx context.Context, msg string, fields ...interface{}) {
@@ -402,10 +404,8 @@ func (m *MockLogger) InfoCtx(ctx context.Context, msg string, fields ...interfac
 		Level:   "INFO",
 		Message: msg,
 		Fields:  make(map[string]interface{}),
-		Context: ctx,
 	}
 
-	// Parse fields - this is where tenant_id, resource_type, etc. are passed
 	for i := 0; i < len(fields); i += 2 {
 		if i+1 < len(fields) {
 			if key, ok := fields[i].(string); ok {
@@ -413,9 +413,6 @@ func (m *MockLogger) InfoCtx(ctx context.Context, msg string, fields ...interfac
 			}
 		}
 	}
-
-	// Extract context information like the real logger does (as fallback)
-	m.extractContextFields(ctx, entry.Fields)
 
 	m.entries = append(m.entries, entry)
 }
@@ -425,10 +422,8 @@ func (m *MockLogger) ErrorCtx(ctx context.Context, msg string, fields ...interfa
 		Level:   "ERROR",
 		Message: msg,
 		Fields:  make(map[string]interface{}),
-		Context: ctx,
 	}
 
-	// Parse fields
 	for i := 0; i < len(fields); i += 2 {
 		if i+1 < len(fields) {
 			if key, ok := fields[i].(string); ok {
@@ -436,9 +431,6 @@ func (m *MockLogger) ErrorCtx(ctx context.Context, msg string, fields ...interfa
 			}
 		}
 	}
-
-	// Extract context information like the real logger does
-	m.extractContextFields(ctx, entry.Fields)
 
 	m.entries = append(m.entries, entry)
 }
@@ -448,10 +440,8 @@ func (m *MockLogger) WarnCtx(ctx context.Context, msg string, fields ...interfac
 		Level:   "WARN",
 		Message: msg,
 		Fields:  make(map[string]interface{}),
-		Context: ctx,
 	}
 
-	// Parse fields
 	for i := 0; i < len(fields); i += 2 {
 		if i+1 < len(fields) {
 			if key, ok := fields[i].(string); ok {
@@ -459,9 +449,6 @@ func (m *MockLogger) WarnCtx(ctx context.Context, msg string, fields ...interfac
 			}
 		}
 	}
-
-	// Extract context information like the real logger does
-	m.extractContextFields(ctx, entry.Fields)
 
 	m.entries = append(m.entries, entry)
 }
@@ -471,10 +458,8 @@ func (m *MockLogger) DebugCtx(ctx context.Context, msg string, fields ...interfa
 		Level:   "DEBUG",
 		Message: msg,
 		Fields:  make(map[string]interface{}),
-		Context: ctx,
 	}
 
-	// Parse fields
 	for i := 0; i < len(fields); i += 2 {
 		if i+1 < len(fields) {
 			if key, ok := fields[i].(string); ok {
@@ -482,9 +467,6 @@ func (m *MockLogger) DebugCtx(ctx context.Context, msg string, fields ...interfa
 			}
 		}
 	}
-
-	// Extract context information like the real logger does
-	m.extractContextFields(ctx, entry.Fields)
 
 	m.entries = append(m.entries, entry)
 }
@@ -494,10 +476,8 @@ func (m *MockLogger) Debug(msg string, fields ...interface{}) {
 		Level:   "DEBUG",
 		Message: msg,
 		Fields:  make(map[string]interface{}),
-		Context: context.Background(),
 	}
 
-	// Parse fields
 	for i := 0; i < len(fields); i += 2 {
 		if i+1 < len(fields) {
 			if key, ok := fields[i].(string); ok {
@@ -514,10 +494,8 @@ func (m *MockLogger) Info(msg string, fields ...interface{}) {
 		Level:   "INFO",
 		Message: msg,
 		Fields:  make(map[string]interface{}),
-		Context: context.Background(),
 	}
 
-	// Parse fields
 	for i := 0; i < len(fields); i += 2 {
 		if i+1 < len(fields) {
 			if key, ok := fields[i].(string); ok {
@@ -534,10 +512,8 @@ func (m *MockLogger) Warn(msg string, fields ...interface{}) {
 		Level:   "WARN",
 		Message: msg,
 		Fields:  make(map[string]interface{}),
-		Context: context.Background(),
 	}
 
-	// Parse fields
 	for i := 0; i < len(fields); i += 2 {
 		if i+1 < len(fields) {
 			if key, ok := fields[i].(string); ok {
@@ -554,10 +530,8 @@ func (m *MockLogger) Error(msg string, fields ...interface{}) {
 		Level:   "ERROR",
 		Message: msg,
 		Fields:  make(map[string]interface{}),
-		Context: context.Background(),
 	}
 
-	// Parse fields
 	for i := 0; i < len(fields); i += 2 {
 		if i+1 < len(fields) {
 			if key, ok := fields[i].(string); ok {
@@ -574,10 +548,8 @@ func (m *MockLogger) Fatal(msg string, fields ...interface{}) {
 		Level:   "FATAL",
 		Message: msg,
 		Fields:  make(map[string]interface{}),
-		Context: context.Background(),
 	}
 
-	// Parse fields
 	for i := 0; i < len(fields); i += 2 {
 		if i+1 < len(fields) {
 			if key, ok := fields[i].(string); ok {
@@ -594,10 +566,8 @@ func (m *MockLogger) FatalCtx(ctx context.Context, msg string, fields ...interfa
 		Level:   "FATAL",
 		Message: msg,
 		Fields:  make(map[string]interface{}),
-		Context: ctx,
 	}
 
-	// Parse fields
 	for i := 0; i < len(fields); i += 2 {
 		if i+1 < len(fields) {
 			if key, ok := fields[i].(string); ok {
@@ -605,9 +575,6 @@ func (m *MockLogger) FatalCtx(ctx context.Context, msg string, fields ...interfa
 			}
 		}
 	}
-
-	// Extract context information like the real logger does
-	m.extractContextFields(ctx, entry.Fields)
 
 	m.entries = append(m.entries, entry)
 }
@@ -620,78 +587,7 @@ func (m *MockLogger) GetEntries() []MockLogEntry {
 	return m.entries
 }
 
-// extractContextFields extracts context information similar to the real logging framework
-func (m *MockLogger) extractContextFields(ctx context.Context, fields map[string]interface{}) {
-	// Use the public helper functions from the logging package to extract context values
-	// This ensures we use the exact same context key types as the real implementation
-
-	// Extract tenant ID from context if not already provided by the module
-	// The module should be passing tenant_id explicitly, but we'll supplement from context if missing
-	tenantIDFromCtx := logging.ExtractTenantFromContext(ctx)
-	if _, hasTenantID := fields["tenant_id"]; !hasTenantID && tenantIDFromCtx != "" {
-		fields["tenant_id"] = tenantIDFromCtx
-	}
-
-	// Extract operation using the public helper function, but only if not already set by the module
-	if _, hasOperation := fields["operation"]; !hasOperation {
-		if operation := logging.ExtractOperation(ctx); operation != "" {
-			fields["operation"] = operation
-		}
-	}
-
-	// The module should be providing resource_type explicitly, so we don't override it
-	// But if it's missing, we can infer it from the operation field
-	if _, hasResourceType := fields["resource_type"]; !hasResourceType {
-		if operation, hasOp := fields["operation"]; hasOp {
-			if opStr, ok := operation.(string); ok {
-				if strings.Contains(opStr, "directory") {
-					fields["resource_type"] = "directory"
-				} else if strings.Contains(opStr, "script") {
-					fields["resource_type"] = "script"
-				} else if strings.Contains(opStr, "file") {
-					fields["resource_type"] = "file"
-				} else {
-					fields["resource_type"] = "unknown"
-				}
-			}
-		} else {
-			fields["resource_type"] = "unknown"
-		}
-	}
-}
-
 // Test configuration implementations
-
-type TestDirectoryConfig struct {
-	Path            string
-	Permissions     int
-	AllowedBasePath string
-}
-
-func (c *TestDirectoryConfig) AsMap() map[string]interface{} {
-	return map[string]interface{}{
-		"type":              "directory",
-		"path":              c.Path,
-		"permissions":       c.Permissions,
-		"allowed_base_path": c.AllowedBasePath,
-	}
-}
-
-func (c *TestDirectoryConfig) ToYAML() ([]byte, error) {
-	return []byte{}, nil
-}
-
-func (c *TestDirectoryConfig) FromYAML(data []byte) error {
-	return nil
-}
-
-func (c *TestDirectoryConfig) Validate() error {
-	return nil
-}
-
-func (c *TestDirectoryConfig) GetManagedFields() []string {
-	return []string{"path", "permissions"}
-}
 
 type TestScriptConfig struct {
 	Content       string


### PR DESCRIPTION
## Summary

- Remove `extractContextFields` from `MockLogger` — it synthesized `resource_type` (and `tenant_id`, `operation`) when the module didn't emit them, making `assert.Contains(t, entry.Fields, "resource_type")` pass regardless of module behaviour (circular proof). The recorder now stores only the verbatim key-value fields the module actually passed.
- Replace `TestDirectoryConfig` stub with the real `file.FileConfig` — the stub's `GetManagedFields()` returned `["path", "permissions"]` on all platforms; the real type is platform-aware.
- Fix two-value type assertion for `tenant_id` in the cross-tenant contamination loop — the direct type assertion would panic on an absent or non-string field; replaced with the two-value form and `t.Fatalf`.
- Remove the dead `Context context.Context` field from `MockLogEntry` (stored but never asserted).
- Remove the now-unused `"strings"` import.

All changes are test-only; no production code was modified.

Fixes #1908

## Specialist Review Results

**QA Test Runner: PASS**
- 114 packages tested, all passing
- Cross-platform builds: linux/amd64, linux/arm64, darwin/amd64, darwin/arm64, windows/amd64 — all PASS
- Integration tests: PASS

**QA Code Reviewer: PASS**
- 0 blocking issues
- 3 pre-existing warnings (not introduced by this story, not blocking)

**Security Engineer: PASS**
- security-precommit: PASS
- check-architecture: PASS
- security-scan: PASS (Trivy, Nancy, gosec, staticcheck)
- No hardcoded secrets, no central provider violations, no information disclosure

## Test Plan

- [ ] `go test ./pkg/logging/... -run TestCentralLoggingValidation -v` passes with no failures
- [ ] `make test-agent-complete` passes (validated by qa-test-runner specialist)
- [ ] All assertions in `StructuredLoggingCompliance` reference only fields the real file module emits
- [ ] Cross-tenant loop uses safe two-value type assertion (no panic path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)