### PR TITLE
modules/script: namespace literal param env vars to prevent shadowing (Issue #1906)

### DIFF
--- a/docs/architecture/modules/README.md
+++ b/docs/architecture/modules/README.md
@@ -88,6 +88,29 @@ The `executors` field must contain exactly one element. `kind` is computed at pa
 
 - `m365/*` - Microsoft 365 modules (auth, conditional access, Entra groups/users/apps/admin units, Intune policy, GDAP)
 
+## Script Module — Parameter Environment Variables
+
+Script parameters are injected into the child process environment only (the steward process environment is never modified). Two namespaces are used:
+
+| Type | Env var name | Example |
+|------|-------------|---------|
+| Literal param | `CFGMS_PARAM_<NAME_UPPER>` | `path` → `CFGMS_PARAM_PATH` |
+| Secret-store param | `CFGMS_SECRET_<NAME_UPPER>` (PowerShell/CMD) or `<NAME_UPPER>` (Unix shells) | `dbPass` → `CFGMS_SECRET_DBPASS` / `DBPASS` |
+
+The `CFGMS_PARAM_` prefix prevents a literal param from silently overwriting a standard environment variable (e.g., a param named `path` becomes `CFGMS_PARAM_PATH`, not `PATH`). Scripts read params via the namespaced name:
+
+```bash
+# bash/sh/zsh — literal param named "install_path"
+echo "$CFGMS_PARAM_INSTALL_PATH"
+```
+
+```powershell
+# PowerShell — literal param named "install_path"
+Write-Output $env:CFGMS_PARAM_INSTALL_PATH
+```
+
+Secret params on Windows use `CFGMS_SECRET_` to avoid logging the value via Event 4688 command-line auditing. On Unix shells, secrets use a bare uppercase name (`<NAME_UPPER>`) following the 12-factor convention.
+
 ## Documentation
 
 - [Module Interface](interface.md) - Essential interface specification and ConfigState details

--- a/features/modules/script/executor.go
+++ b/features/modules/script/executor.go
@@ -67,8 +67,8 @@ func (e *Executor) Execute(ctx context.Context) (*ExecutionResult, error) {
 	// Env var naming by binding type:
 	//   secret-store  → SecretEnvVarName(): CFGMS_SECRET_<PARAM> on Windows (avoids
 	//                   Event 4688 cmdline logging), <PARAM> on Unix (12-factor)
-	//   literal       → strings.ToUpper(param.Name) on all platforms — no secret
-	//                   prefix because the value is not a credential
+	//   literal       → ParamEnvVarName(): CFGMS_PARAM_<PARAM> on all platforms —
+	//                   namespaced to prevent shadowing standard env vars (e.g. PATH)
 	var secretEnvEntries []string
 	if len(e.secretBindings) > 0 {
 		resolved, err := ResolveSecretBindings(ctx, e.secretStore, e.secretBindings)
@@ -81,7 +81,7 @@ func (e *Executor) Execute(ctx context.Context) (*ExecutionResult, error) {
 			if param.IsSecret {
 				envKey = SecretEnvVarName(e.config.Shell, param.Name)
 			} else {
-				envKey = strings.ToUpper(param.Name)
+				envKey = ParamEnvVarName(e.config.Shell, param.Name)
 			}
 			secretEnvEntries = append(secretEnvEntries, fmt.Sprintf("%s=%s", envKey, param.Value))
 		}

--- a/features/modules/script/param_binding.go
+++ b/features/modules/script/param_binding.go
@@ -95,3 +95,12 @@ func SecretEnvVarName(shell ShellType, paramName string) string {
 		return upper
 	}
 }
+
+// ParamEnvVarName returns the environment variable name for a resolved literal param.
+// Literal params always use the CFGMS_PARAM_<PARAM_UPPER> namespace on all platforms
+// to prevent shadowing standard environment variables (e.g., a param named "path"
+// would otherwise overwrite PATH). The shell parameter is accepted for API symmetry
+// with SecretEnvVarName; the namespace is platform-invariant.
+func ParamEnvVarName(_ ShellType, paramName string) string {
+	return "CFGMS_PARAM_" + strings.ToUpper(paramName)
+}

--- a/features/modules/script/param_binding_test.go
+++ b/features/modules/script/param_binding_test.go
@@ -160,6 +160,81 @@ func TestResolveSecretBindings_EmptyBindings(t *testing.T) {
 	assert.Empty(t, resolved)
 }
 
+// TestParamEnvVarName_AllShells verifies that literal params always use the
+// CFGMS_PARAM_ prefix regardless of shell, preventing shadowing of standard env vars.
+func TestParamEnvVarName_AllShells(t *testing.T) {
+	cases := []struct {
+		shell    ShellType
+		input    string
+		expected string
+	}{
+		{ShellBash, "path", "CFGMS_PARAM_PATH"},
+		{ShellSh, "home", "CFGMS_PARAM_HOME"},
+		{ShellZsh, "temp", "CFGMS_PARAM_TEMP"},
+		{ShellPowerShell, "path", "CFGMS_PARAM_PATH"},
+		{ShellCmd, "userprofile", "CFGMS_PARAM_USERPROFILE"},
+		{ShellPython, "script", "CFGMS_PARAM_SCRIPT"},
+		{ShellPython3, "myParam", "CFGMS_PARAM_MYPARAM"},
+	}
+
+	for _, tc := range cases {
+		got := ParamEnvVarName(tc.shell, tc.input)
+		assert.Equal(t, tc.expected, got, "shell=%s param=%s", tc.shell, tc.input)
+	}
+}
+
+// TestLiteralParamDoesNotShadowStandardEnv runs a real script with a literal
+// param named "path" and asserts that CFGMS_PARAM_PATH carries the injected
+// value while the inherited PATH is unchanged.
+func TestLiteralParamDoesNotShadowStandardEnv(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping execution test in short mode")
+	}
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix-only test; PATH shadowing semantics verified on Unix")
+	}
+
+	const paramValue = "/custom/injected/bin"
+
+	bindings := []ParamBinding{
+		{Name: "path", From: ParamSourceLiteral, Value: paramValue},
+	}
+
+	config := &ScriptConfig{
+		Content: `printf "CFGMS_PARAM_PATH=%s\n" "$CFGMS_PARAM_PATH"; printf "PATH=%s\n" "$PATH"`,
+		Shell:   ShellBash,
+		Timeout: 10 * time.Second,
+	}
+	require.NoError(t, config.Validate())
+
+	executor := NewExecutorWithSecrets(config, nil, bindings)
+	result, err := executor.Execute(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, 0, result.ExitCode, "script should exit 0; stderr: %s", result.Stderr)
+
+	// Literal param named "path" must appear under CFGMS_PARAM_PATH.
+	assert.Contains(t, result.Stdout, "CFGMS_PARAM_PATH="+paramValue,
+		"literal param 'path' must be injected as CFGMS_PARAM_PATH")
+
+	// Inherited PATH must not be overwritten by the literal param value.
+	// Parse line by line to avoid false-positive from the CFGMS_PARAM_PATH line.
+	var pathLine string
+	for _, line := range strings.Split(strings.TrimSpace(result.Stdout), "\n") {
+		if strings.HasPrefix(line, "PATH=") {
+			pathLine = line
+			break
+		}
+	}
+	require.NotEmpty(t, pathLine, "script output must include a PATH= line")
+	assert.NotEqual(t, "PATH="+paramValue, pathLine,
+		"PATH must not be overwritten by the literal param value")
+	parentPATH := os.Getenv("PATH")
+	if parentPATH != "" {
+		assert.Equal(t, "PATH="+parentPATH, pathLine,
+			"inherited PATH must be preserved in the child environment")
+	}
+}
+
 // TestSecretEnvVarName_PowerShell verifies the Windows-safe CFGMS_SECRET_ prefix.
 func TestSecretEnvVarName_PowerShell(t *testing.T) {
 	name := SecretEnvVarName(ShellPowerShell, "DbPassword")
@@ -269,11 +344,11 @@ func TestExecutorWithSecrets_BlocksOnMissingSecret(t *testing.T) {
 	assert.Contains(t, err.Error(), "secret injection blocked")
 }
 
-// TestExecutorWithSecrets_LiteralParamUsesPlainName verifies that literal
-// (non-secret) param bindings are injected with a plain uppercase env var name
-// (no CFGMS_SECRET_ prefix) even when secrets in the same executor would use
-// the prefixed name on Windows-targeted shells.
-func TestExecutorWithSecrets_LiteralParamUsesPlainName(t *testing.T) {
+// TestExecutorWithSecrets_LiteralParamUsesNamespacedName verifies that literal
+// (non-secret) param bindings are injected with the CFGMS_PARAM_ prefix so they
+// cannot shadow standard environment variables (e.g., a param named "apiurl"
+// becomes CFGMS_PARAM_APIURL, never plain APIURL).
+func TestExecutorWithSecrets_LiteralParamUsesNamespacedName(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping literal param env var integration test in short mode")
 	}
@@ -285,9 +360,9 @@ func TestExecutorWithSecrets_LiteralParamUsesPlainName(t *testing.T) {
 		{Name: "ApiUrl", From: ParamSourceLiteral, Value: "https://example.com"},
 	}
 
-	// Script echoes the env var; literal params use plain UPPER name.
+	// Script echoes the namespaced env var; literal params use CFGMS_PARAM_ prefix.
 	config := &ScriptConfig{
-		Content: "echo $APIURL",
+		Content: "echo $CFGMS_PARAM_APIURL",
 		Shell:   ShellBash,
 		Timeout: 10 * time.Second,
 	}
@@ -300,10 +375,10 @@ func TestExecutorWithSecrets_LiteralParamUsesPlainName(t *testing.T) {
 
 	assert.Equal(t, 0, result.ExitCode, "script should exit 0; stderr: %s", result.Stderr)
 	assert.Contains(t, strings.TrimSpace(result.Stdout), "https://example.com",
-		"literal param should be accessible as plain uppercase env var APIURL")
+		"literal param should be accessible as CFGMS_PARAM_APIURL")
 
-	assert.Empty(t, os.Getenv("APIURL"),
-		"APIURL env var must not appear in the parent process (child-process-scoped only)")
+	assert.Empty(t, os.Getenv("CFGMS_PARAM_APIURL"),
+		"CFGMS_PARAM_APIURL env var must not appear in the parent process (child-process-scoped only)")
 }
 
 // TestExecutorWithSecrets_CleansUpOnFailure verifies that secret env vars are


### PR DESCRIPTION
## Summary

- Added `ParamEnvVarName(shell, name)` helper in `param_binding.go` that returns `CFGMS_PARAM_<NAME_UPPER>` for all shells, placed next to `SecretEnvVarName()` and mirroring its signature
- Changed literal param env var injection in `executor.go` from `strings.ToUpper(param.Name)` to `ParamEnvVarName(e.config.Shell, param.Name)` — a literal param named `path` now produces `CFGMS_PARAM_PATH` instead of overwriting `PATH`
- Added `TestParamEnvVarName_AllShells` and `TestLiteralParamDoesNotShadowStandardEnv`; updated `TestExecutorWithSecrets_LiteralParamUsesPlainName` → `TestExecutorWithSecrets_LiteralParamUsesNamespacedName`
- Documented `CFGMS_PARAM_` and `CFGMS_SECRET_` namespaces in `docs/architecture/modules/README.md`

Fixes #1906

## Specialist Review Results

**QA Test Runner**: PASS for all script-module gates (unit tests, lint, architecture check, security precommit, cross-platform builds). One pre-existing flaky test (`TestSystemMonitorResourceMetrics/collect_resource_metrics` in `features/monitoring`) failed under parallel load — confirmed to exist on `develop` as well and unrelated to this branch.

**QA Code Reviewer**: PASS — no blocking issues. One cosmetic warning (missing `ShellPython` case in `TestParamEnvVarName_AllShells`) was addressed before commit.

**Security Engineer**: PASS — no blocking issues. Scans passed: security-precommit, check-architecture, security-scan all clean. Noted the change closes an env var shadowing footgun aligned with the "no insecure defaults" mandate.

## Test plan

- [ ] `go test ./features/modules/script/... -run TestParamEnvVarName_AllShells` — unit test covers all 7 shell types
- [ ] `go test ./features/modules/script/... -run TestLiteralParamDoesNotShadowStandardEnv` — integration test: runs real bash, asserts `CFGMS_PARAM_PATH` set and `PATH` unchanged
- [ ] `go test ./features/modules/script/... -run TestExecutorWithSecrets_LiteralParamUsesNamespacedName` — integration test for updated behavior
- [ ] `make test-agent-complete` passes all script-module gates

🤖 Generated with [Claude Code](https://claude.com/claude-code)