### PR TITLE
steward/modules: harden gRPC socket dir to mode 0700, remove /tmp fallback (Issue #1905)

### DIFF
--- a/docs/architecture/steward-operating-model.md
+++ b/docs/architecture/steward-operating-model.md
@@ -160,8 +160,8 @@ Out-of-process module binaries are managed by the steward module runtime. Each m
 3. `running` — module is operating normally; the steward holds an active `StewardModuleClient` gRPC session
 
 **Socket paths:**
-- Unix: `${runtime_dir}/cfgms-module-<name>-<id>.sock`
-- Windows: `\\.\pipe\cfgms-module-<name>-<id>`
+- Unix: `${runtime_dir}/sockets/cfgms-module-<name>-<id>.sock` — sockets live in a steward-private directory created mode 0700; the mode is re-asserted on each start. Socket file permissions are the module-channel trust boundary: the gRPC channel carries no per-caller credentials, so access is controlled solely by the directory owner bit.
+- Windows: `\\.\pipe\cfgms-module-<name>-<id>` — Windows enforces per-user pipe ACLs at the kernel level.
 
 **Shutdown sequence:**
 

--- a/features/steward/modules/runtime/runtime.go
+++ b/features/steward/modules/runtime/runtime.go
@@ -95,9 +95,13 @@ func (r *ModuleRuntime) Start(
 			osArch, b.Manifest.Name, binaryKeys(b.Binaries))
 	}
 
-	// 4. Construct a unique socket path for this module instance.
+	// 4. Construct a unique socket path for this module instance. makeSocketPath
+	// also creates the steward-private socket directory (mode 0700).
 	id := handleSeq.Add(1)
-	socketPath := makeSocketPath(r.runtimeDir, b.Manifest.Name, id)
+	socketPath, err := makeSocketPath(r.runtimeDir, b.Manifest.Name, id)
+	if err != nil {
+		return nil, fmt.Errorf("socket path for module %q: %w", b.Manifest.Name, err)
+	}
 
 	// 5. Fork/exec the module binary with the socket path in its environment.
 	// #nosec G204 — binPath comes from the bundle manifest, not user-supplied input.

--- a/features/steward/modules/runtime/runtime_test.go
+++ b/features/steward/modules/runtime/runtime_test.go
@@ -33,6 +33,18 @@ import (
 // TestMain before any tests run.
 var echoModuleBin string
 
+// shortBaseDir creates a temp dir under /tmp with a predictably short path so
+// that socket paths constructed from it fit within the macOS sun_path limit
+// (103 bytes). t.TempDir() on macOS returns /var/folders/... paths that are
+// already 80+ bytes, causing makeSocketPath to error before any gRPC is tried.
+func shortBaseDir(t *testing.T) string {
+	t.Helper()
+	base, err := os.MkdirTemp("/tmp", "cfgms-rt-")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = os.RemoveAll(base) })
+	return base
+}
+
 // binaryDir holds the temp dir for the compiled echo_module binary; cleaned up
 // after all tests complete.
 var binaryDir string
@@ -81,7 +93,7 @@ func makeBypassBundle(binPath string) *bundle.Bundle {
 //   - Get() returns "echo:<resource_id>"
 //   - Stop() sends Shutdown RPC and the process exits within 10 s
 func TestEchoModuleLifecycle(t *testing.T) {
-	rt := runtime.NewModuleRuntime(t.TempDir())
+	rt := runtime.NewModuleRuntime(shortBaseDir(t))
 	b := makeBypassBundle(echoModuleBin)
 
 	handle, err := rt.Start(b, stewardtypes.ModuleTrustModeBypass, nil)
@@ -225,7 +237,7 @@ func TestStrictModeRejectsControllerApprovedUnknownPublisher(t *testing.T) {
 // TestControllerModePassesUnsignedBundle verifies that controller mode skips
 // signature verification.
 func TestControllerModePassesUnsignedBundle(t *testing.T) {
-	rt := runtime.NewModuleRuntime(t.TempDir())
+	rt := runtime.NewModuleRuntime(shortBaseDir(t))
 	b := makeBypassBundle(echoModuleBin)
 
 	handle, err := rt.Start(b, stewardtypes.ModuleTrustModeController, nil)
@@ -236,7 +248,7 @@ func TestControllerModePassesUnsignedBundle(t *testing.T) {
 // TestBypassModePassesUnsignedBundle verifies that bypass mode skips
 // signature verification.
 func TestBypassModePassesUnsignedBundle(t *testing.T) {
-	rt := runtime.NewModuleRuntime(t.TempDir())
+	rt := runtime.NewModuleRuntime(shortBaseDir(t))
 	b := makeBypassBundle(echoModuleBin)
 
 	handle, err := rt.Start(b, stewardtypes.ModuleTrustModeBypass, nil)
@@ -247,7 +259,7 @@ func TestBypassModePassesUnsignedBundle(t *testing.T) {
 // TestStopIsIdempotent verifies that calling Stop multiple times on the same
 // handle does not error or panic.
 func TestStopIsIdempotent(t *testing.T) {
-	rt := runtime.NewModuleRuntime(t.TempDir())
+	rt := runtime.NewModuleRuntime(shortBaseDir(t))
 	b := makeBypassBundle(echoModuleBin)
 
 	handle, err := rt.Start(b, stewardtypes.ModuleTrustModeBypass, nil)
@@ -263,7 +275,7 @@ func TestStopIsIdempotent(t *testing.T) {
 func testEnforcerRuntimeWithKey(t *testing.T, cfgmsPub ed25519.PublicKey) *runtime.ModuleRuntime {
 	t.Helper()
 	rt := runtime.NewModuleRuntimeWithEnforcer(
-		t.TempDir(),
+		shortBaseDir(t),
 		stewardtrust.NewStewardTrustEnforcerWithIdentity(func() pkgtrust.PublisherIdentity {
 			return pkgtrust.PublisherIdentity{
 				Name:      "cfgms",

--- a/features/steward/modules/runtime/runtime_test.go
+++ b/features/steward/modules/runtime/runtime_test.go
@@ -14,6 +14,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	goruntime "runtime"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -99,25 +100,31 @@ func TestEchoModuleLifecycle(t *testing.T) {
 	assert.Equal(t, runtime.StateStopped, handle.GetState())
 }
 
-// TestEchoModuleLifecycleWithOverlongRuntimeDir is the regression test for the
-// macOS CI failures (PR #1897 review): on macOS, t.TempDir() returns paths
+// TestEchoModuleLifecycleWithHashFallbackRuntimeDir is the regression test for
+// the macOS CI concern (PR #1897 review): on macOS, t.TempDir() returns paths
 // under /var/folders/... that, joined with the socket filename, exceed the
-// 104-byte sun_path limit. The runtime must fall back to a short hashed path
-// under /tmp so net.Listen("unix", ...) succeeds. This test forces the fallback
-// path on all platforms by passing a deliberately long runtimeDir.
-func TestEchoModuleLifecycleWithOverlongRuntimeDir(t *testing.T) {
-	// Build a runtime dir long enough that the natural socket path overflows
-	// 103 bytes — exercising the fallback even on Linux where t.TempDir() is
-	// normally short.
-	base := t.TempDir()
-	deep := filepath.Join(base,
-		"deeply", "nested", "directory", "tree",
-		"with", "enough", "path", "components",
-		"to", "blow", "past", "the", "macos", "sun_path", "limit",
-	)
-	require.NoError(t, os.MkdirAll(deep, 0o755))
+// 104-byte sun_path limit. The runtime must hash the socket name into the
+// steward-private sockets directory (never /tmp) so net.Listen("unix", ...)
+// succeeds.
+//
+// A runtimeDir of exactly 71 chars is used: the minimum that triggers the hash
+// fallback (natural = 71+33 = 104 > 103) while the hash path still fits
+// within the private dir (hash = 71+32 = 103 ≤ 103). Uses /tmp directly for
+// a predictably short base (~28 chars) so no platform-conditional skip is needed.
+func TestEchoModuleLifecycleWithHashFallbackRuntimeDir(t *testing.T) {
+	// Use /tmp directly for a short, predictable base on all platforms.
+	const targetLen = 71
+	base, err := os.MkdirTemp("/tmp", "cfgms-rt-test-")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = os.RemoveAll(base) })
+	if len(base) >= targetLen {
+		t.Fatalf("base dir %q (%d bytes) is already >= %d", base, len(base), targetLen)
+	}
+	paddingLen := targetLen - len(base) - 1
+	long := filepath.Join(base, strings.Repeat("d", paddingLen))
+	require.NoError(t, os.MkdirAll(long, 0o755))
 
-	rt := runtime.NewModuleRuntime(deep)
+	rt := runtime.NewModuleRuntime(long)
 	b := makeBypassBundle(echoModuleBin)
 
 	handle, err := rt.Start(b, stewardtypes.ModuleTrustModeBypass, nil)

--- a/features/steward/modules/runtime/socket_unix.go
+++ b/features/steward/modules/runtime/socket_unix.go
@@ -11,6 +11,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"net"
+	"os"
 	"path/filepath"
 	"time"
 
@@ -25,30 +26,54 @@ import (
 // predictable.
 const unixSocketPathMax = 103
 
-// makeSocketPath returns the Unix domain socket path for a module instance.
-// Format: ${runtimeDir}/cfgms-module-${name}-${id}.sock
+// socketsSubdir is the name of the steward-private directory created under
+// runtimeDir for all module sockets. Mode 0700 restricts access to the steward
+// process owner, which is the sole trust boundary on the module gRPC channel
+// (the dialer uses insecure.NewCredentials with no per-caller authentication).
+const socketsSubdir = "sockets"
+
+// makeSocketPath returns the Unix domain socket path for a module instance,
+// creating the steward-private socket directory if it does not already exist.
 //
-// If the natural path would exceed the platform's sun_path limit, it falls
-// back to a short hashed path under /tmp. This handles long temp dirs on
-// macOS (/var/folders/xx/yyy/T/...), where t.TempDir() in tests produces
-// paths that exceed the 104-byte sun_path limit.
-//
-// TODO(production-wiring): when ModuleRuntime is wired into the steward boot
-// path, ensure the configured runtimeDir is short enough that the fallback is
-// never reached on macOS — or replace this fallback with a steward-owned,
-// mode-0700 subdirectory so /tmp predictability cannot be exploited locally.
-func makeSocketPath(runtimeDir, moduleName string, id int64) string {
-	name := fmt.Sprintf("cfgms-module-%s-%d.sock", sanitizeName(moduleName), id)
-	natural := filepath.Join(runtimeDir, name)
-	if len(natural) <= unixSocketPathMax {
-		return natural
+// All sockets live under ${runtimeDir}/sockets (mode 0700). The mode is
+// re-asserted on every call to guard against a pre-existing directory with
+// looser permissions. When the natural path would exceed the platform's
+// sun_path limit, the name is hashed into the same private directory — never
+// into /tmp or any world-writable location. If even the hashed path would
+// exceed sun_path, an error is returned; the operator must configure a shorter
+// runtimeDir (production deployments typically use /var/run/cfgms or similar).
+func makeSocketPath(runtimeDir, moduleName string, id int64) (string, error) {
+	sockDir := filepath.Join(runtimeDir, socketsSubdir)
+	if err := os.MkdirAll(sockDir, 0o700); err != nil {
+		return "", fmt.Errorf("create module socket dir %q: %w", sockDir, err)
 	}
-	// Hash the natural path (including runtimeDir and id) to retain uniqueness
-	// across runtime instances. 12 hex chars gives 48 bits of entropy — ample
-	// for collision avoidance within a host.
+	// Re-assert mode in case the directory already existed with looser permissions.
+	if err := os.Chmod(sockDir, 0o700); err != nil {
+		return "", fmt.Errorf("chmod module socket dir %q: %w", sockDir, err)
+	}
+
+	name := fmt.Sprintf("cfgms-module-%s-%d.sock", sanitizeName(moduleName), id)
+	natural := filepath.Join(sockDir, name)
+	if len(natural) <= unixSocketPathMax {
+		return natural, nil
+	}
+
+	// Hash the natural path (including sockDir and id) to retain uniqueness
+	// across runtime instances. 12 hex chars give 48 bits of entropy — ample
+	// for collision avoidance within a host. The hash stays in the private
+	// directory so socket permissions remain the access control boundary.
 	sum := sha256.Sum256([]byte(natural))
 	hash := hex.EncodeToString(sum[:6])
-	return filepath.Join("/tmp", fmt.Sprintf("cfgms-%s.sock", hash))
+	hashed := filepath.Join(sockDir, fmt.Sprintf("cfgms-%s.sock", hash))
+	if len(hashed) <= unixSocketPathMax {
+		return hashed, nil
+	}
+
+	return "", fmt.Errorf(
+		"module socket path %q (%d bytes) exceeds sun_path limit (%d); "+
+			"configure a shorter runtimeDir (e.g. /var/run/cfgms)",
+		hashed, len(hashed), unixSocketPathMax,
+	)
 }
 
 // waitForSocket polls the Unix socket at socketPath until it accepts a

--- a/features/steward/modules/runtime/socket_unix.go
+++ b/features/steward/modules/runtime/socket_unix.go
@@ -48,7 +48,7 @@ func makeSocketPath(runtimeDir, moduleName string, id int64) (string, error) {
 		return "", fmt.Errorf("create module socket dir %q: %w", sockDir, err)
 	}
 	// Re-assert mode in case the directory already existed with looser permissions.
-	if err := os.Chmod(sockDir, 0o700); err != nil {
+	if err := os.Chmod(sockDir, 0o700); err != nil { // #nosec G302 -- 0700 on a directory is intentional hardening; execute bit is required for traversal
 		return "", fmt.Errorf("chmod module socket dir %q: %w", sockDir, err)
 	}
 

--- a/features/steward/modules/runtime/socket_unix_test.go
+++ b/features/steward/modules/runtime/socket_unix_test.go
@@ -46,7 +46,7 @@ func buildLongDir(t *testing.T, targetLen int) string {
 // natural path fits the sun_path limit, it is used unchanged (under the
 // private sockets subdir).
 func TestMakeSocketPathShortRuntimeDirUsesNaturalPath(t *testing.T) {
-	dir := t.TempDir()
+	dir := shortBaseDir(t) // t.TempDir() is too long on macOS (/var/folders/...)
 	path, err := makeSocketPath(dir, "echo", 1)
 	require.NoError(t, err)
 	assert.Equal(t, filepath.Join(dir, "sockets", "cfgms-module-echo-1.sock"), path)
@@ -127,7 +127,7 @@ func TestMakeSocketPathBoundary(t *testing.T) {
 // TestMakeSocketPath_ParentDirIsOwnerOnly asserts that makeSocketPath creates
 // a sockets directory with mode 0700, owned by the current process uid.
 func TestMakeSocketPath_ParentDirIsOwnerOnly(t *testing.T) {
-	dir := t.TempDir()
+	dir := shortBaseDir(t) // t.TempDir() is too long on macOS (/var/folders/...)
 	_, err := makeSocketPath(dir, "echo", 1)
 	require.NoError(t, err)
 
@@ -148,7 +148,7 @@ func TestMakeSocketPath_ParentDirIsOwnerOnly(t *testing.T) {
 // already exists with looser permissions (0o755), makeSocketPath re-asserts
 // mode 0700 on every call.
 func TestMakeSocketPath_ParentDirModeReasserted(t *testing.T) {
-	dir := t.TempDir()
+	dir := shortBaseDir(t) // t.TempDir() is too long on macOS (/var/folders/...)
 	sockDir := filepath.Join(dir, "sockets")
 	require.NoError(t, os.MkdirAll(sockDir, 0o755)) // pre-create with loose mode
 

--- a/features/steward/modules/runtime/socket_unix_test.go
+++ b/features/steward/modules/runtime/socket_unix_test.go
@@ -6,33 +6,69 @@
 package runtime
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
+	"syscall"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
-// TestMakeSocketPathShortRuntimeDirUsesNaturalPath verifies that when the
-// natural path fits the sun_path limit, it is used unchanged.
-func TestMakeSocketPathShortRuntimeDirUsesNaturalPath(t *testing.T) {
-	path := makeSocketPath("/tmp/cfg", "echo", 1)
-	assert.Equal(t, "/tmp/cfg/cfgms-module-echo-1.sock", path)
+// shortBaseDir creates a temp dir under /tmp with a predictably short path
+// (~28 chars on all platforms) so tests that need an exact runtimeDir length
+// can always reach their target without conditional skipping.
+// /tmp on macOS is a symlink to /private/tmp but Go's os.MkdirTemp resolves
+// to the /tmp/* path, keeping the returned string short.
+func shortBaseDir(t *testing.T) string {
+	t.Helper()
+	base, err := os.MkdirTemp("/tmp", "cfgms-sock-")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = os.RemoveAll(base) })
+	return base
 }
 
-// TestMakeSocketPathLongRuntimeDirFallsBackToTmp verifies that when the natural
-// path would exceed the macOS sun_path limit (104 bytes), makeSocketPath falls
-// back to a hashed short path under /tmp. This is the regression test for the
-// macOS test failures where t.TempDir() returns paths under /var/folders/...
-// that exceed 104 bytes when combined with the socket filename.
-func TestMakeSocketPathLongRuntimeDirFallsBackToTmp(t *testing.T) {
-	// Use the actual macOS t.TempDir() path that overflowed in CI.
-	longDir := "/var/folders/8d/778wjbv96mq1760tv6gk374m0000gn/T/TestEchoModuleLifecycle1001087929/001"
-	path := makeSocketPath(longDir, "echo", 1)
+// buildLongDir returns a runtimeDir padded to exactly targetLen characters.
+// Uses shortBaseDir to guarantee a short-enough base on every platform.
+func buildLongDir(t *testing.T, targetLen int) string {
+	t.Helper()
+	base := shortBaseDir(t)
+	if len(base) >= targetLen {
+		t.Fatalf("short base dir %q (%d bytes) is already >= target %d — increase targetLen or use a shorter prefix",
+			base, len(base), targetLen)
+	}
+	paddingLen := targetLen - len(base) - 1 // -1 for the filepath separator
+	return filepath.Join(base, strings.Repeat("a", paddingLen))
+}
 
+// TestMakeSocketPathShortRuntimeDirUsesNaturalPath verifies that when the
+// natural path fits the sun_path limit, it is used unchanged (under the
+// private sockets subdir).
+func TestMakeSocketPathShortRuntimeDirUsesNaturalPath(t *testing.T) {
+	dir := t.TempDir()
+	path, err := makeSocketPath(dir, "echo", 1)
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Join(dir, "sockets", "cfgms-module-echo-1.sock"), path)
+}
+
+// TestMakeSocketPathHashFallback verifies that when the natural path would
+// exceed the macOS sun_path limit (104 bytes), makeSocketPath falls back to a
+// hashed short path inside the private sockets directory — never under an
+// independent /tmp path. runtimeDir of exactly 71 chars is chosen because it
+// is the minimum that triggers the fallback (natural = 71+33 = 104 > 103)
+// while the hash path still fits (hash = 71+32 = 103 ≤ 103).
+func TestMakeSocketPathHashFallback(t *testing.T) {
+	longDir := buildLongDir(t, 71)
+
+	path, err := makeSocketPath(longDir, "echo", 1)
+	require.NoError(t, err)
+
+	sockDir := filepath.Join(longDir, "sockets")
 	assert.LessOrEqualf(t, len(path), unixSocketPathMax,
 		"fallback path %q (%d bytes) must fit Unix sun_path limit", path, len(path))
-	assert.Truef(t, strings.HasPrefix(path, "/tmp/cfgms-"),
-		"fallback path %q must live under /tmp", path)
+	assert.Truef(t, strings.HasPrefix(path, sockDir),
+		"fallback path %q must live under private socket dir %q", path, sockDir)
 	assert.Truef(t, strings.HasSuffix(path, ".sock"),
 		"fallback path %q must end with .sock", path)
 }
@@ -40,32 +76,140 @@ func TestMakeSocketPathLongRuntimeDirFallsBackToTmp(t *testing.T) {
 // TestMakeSocketPathFallbackIsUnique verifies that distinct natural paths
 // produce distinct fallback paths (so two concurrent modules do not collide).
 func TestMakeSocketPathFallbackIsUnique(t *testing.T) {
-	longDir := "/var/folders/8d/778wjbv96mq1760tv6gk374m0000gn/T/long-runtime-dir-with-extra-padding"
-	p1 := makeSocketPath(longDir, "echo", 1)
-	p2 := makeSocketPath(longDir, "echo", 2)
-	p3 := makeSocketPath(longDir, "other", 1)
+	longDir := buildLongDir(t, 71)
+
+	p1, err := makeSocketPath(longDir, "echo", 1)
+	require.NoError(t, err)
+	p2, err := makeSocketPath(longDir, "echo", 2)
+	require.NoError(t, err)
+	p3, err := makeSocketPath(longDir, "other", 1)
+	require.NoError(t, err)
 
 	assert.NotEqual(t, p1, p2, "different ids must produce different fallback paths")
 	assert.NotEqual(t, p1, p3, "different module names must produce different fallback paths")
 }
 
-// TestMakeSocketPathBoundary verifies behavior right at the path-length
-// threshold: paths of exactly unixSocketPathMax bytes are kept as-is, paths
-// one byte over fall back to /tmp.
+// TestMakeSocketPathBoundary verifies behaviour right at the path-length
+// threshold: a path of exactly unixSocketPathMax bytes is kept as-is; one byte
+// over triggers the hashed fallback (which stays in the private socket dir).
+//
+// Path layout:  runtimeDir + "/sockets/" + socketName
+// Lengths:      runtimeDir(70) + 9 + 24 = 103 (exact fit)
+//
+//	runtimeDir(71) + 9 + 24 = 104 (one over, fallback triggers)
+//	runtimeDir(71) + 9 + 23 = 103 (hash, still fits)
 func TestMakeSocketPathBoundary(t *testing.T) {
-	// Build a runtime dir such that the natural path is exactly the max length.
-	// natural = "/x/<padding>/cfgms-module-echo-1.sock"
-	// 24 chars for "cfgms-module-echo-1.sock" + 1 separator + N for runtimeDir.
+	// For the natural path to be exactly unixSocketPathMax (103):
+	//   len(runtimeDir) + 1 + len("sockets") + 1 + len(socketName) = 103
+	//   len(runtimeDir) + 9 + 24 = 103  →  len(runtimeDir) = 70
 	const socketName = "cfgms-module-echo-1.sock"
-	roomForDir := unixSocketPathMax - len(socketName) - 1 // 1 for the joining /
-	dirAtMax := "/" + strings.Repeat("a", roomForDir-1)   // leading / counts
-	pathAtMax := makeSocketPath(dirAtMax, "echo", 1)
+	const runtimeDirMaxLen = unixSocketPathMax - len(socketName) - 1 - len("sockets") - 1 // 70
+
+	// Build runtimeDir at exactly runtimeDirMaxLen using a short base so no
+	// platform-conditional skip is needed.
+	dirAtMax := buildLongDir(t, runtimeDirMaxLen)
+
+	pathAtMax, err := makeSocketPath(dirAtMax, "echo", 1)
+	require.NoError(t, err)
 	assert.Equal(t, unixSocketPathMax, len(pathAtMax),
 		"natural path at exactly the limit must be kept as-is")
 
+	// One byte longer runtimeDir pushes natural path 1 byte over the limit.
 	dirOverMax := dirAtMax + "a"
-	pathOver := makeSocketPath(dirOverMax, "echo", 1)
+	pathOver, err := makeSocketPath(dirOverMax, "echo", 1)
+	require.NoError(t, err)
 	assert.LessOrEqual(t, len(pathOver), unixSocketPathMax)
-	assert.Truef(t, strings.HasPrefix(pathOver, "/tmp/cfgms-"),
-		"path one byte over the limit must fall back to /tmp, got %q", pathOver)
+	sockDirOver := filepath.Join(dirOverMax, "sockets")
+	assert.Truef(t, strings.HasPrefix(pathOver, sockDirOver),
+		"path one byte over limit must be in private socket dir, got %q", pathOver)
+}
+
+// TestMakeSocketPath_ParentDirIsOwnerOnly asserts that makeSocketPath creates
+// a sockets directory with mode 0700, owned by the current process uid.
+func TestMakeSocketPath_ParentDirIsOwnerOnly(t *testing.T) {
+	dir := t.TempDir()
+	_, err := makeSocketPath(dir, "echo", 1)
+	require.NoError(t, err)
+
+	sockDir := filepath.Join(dir, "sockets")
+	info, statErr := os.Stat(sockDir)
+	require.NoError(t, statErr)
+
+	assert.Equal(t, os.FileMode(0o700), info.Mode().Perm(),
+		"socket dir must be mode 0700")
+
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	require.True(t, ok, "expected *syscall.Stat_t from os.Stat on Unix")
+	assert.Equal(t, uint32(os.Getuid()), stat.Uid,
+		"socket dir must be owned by the current uid")
+}
+
+// TestMakeSocketPath_ParentDirModeReasserted verifies that if the socket dir
+// already exists with looser permissions (0o755), makeSocketPath re-asserts
+// mode 0700 on every call.
+func TestMakeSocketPath_ParentDirModeReasserted(t *testing.T) {
+	dir := t.TempDir()
+	sockDir := filepath.Join(dir, "sockets")
+	require.NoError(t, os.MkdirAll(sockDir, 0o755)) // pre-create with loose mode
+
+	_, err := makeSocketPath(dir, "echo", 1)
+	require.NoError(t, err)
+
+	info, statErr := os.Stat(sockDir)
+	require.NoError(t, statErr)
+	assert.Equal(t, os.FileMode(0o700), info.Mode().Perm(),
+		"makeSocketPath must tighten a pre-existing looser socket dir to 0700")
+}
+
+// TestMakeSocketPath_NoTmpFallback asserts that when the natural path is too
+// long, the fallback hashes within the steward-private socket dir — never to an
+// independent /tmp path. Uses buildLongDir with a /tmp-based short base so the
+// test is not skipped on macOS, which is precisely the platform where the old
+// vulnerable /tmp fallback was observed in CI (PR #1897).
+func TestMakeSocketPath_NoTmpFallback(t *testing.T) {
+	// runtimeDir = 71 chars: natural = 71+33 = 104 > 103 (triggers fallback),
+	// hash = 71+32 = 103 ≤ 103 (fits within the private dir).
+	longDir := buildLongDir(t, 71)
+
+	path, err := makeSocketPath(longDir, "echo", 1)
+	require.NoError(t, err)
+
+	assert.LessOrEqualf(t, len(path), unixSocketPathMax,
+		"fallback path must fit Unix sun_path limit")
+
+	// The path must stay within the steward-private socket dir, not jump to an
+	// independent /tmp location (the old vulnerable fallback pattern).
+	sockDir := filepath.Join(longDir, "sockets")
+	assert.Truef(t, strings.HasPrefix(path, sockDir),
+		"path must be inside private socket dir %q; got %q (must not be an independent /tmp fallback)",
+		sockDir, path)
+}
+
+// TestMakeSocketPath_ErrorWhenPathTooLong verifies that makeSocketPath returns
+// an error — rather than silently falling back to /tmp — when even the hashed
+// filename in sockDir would exceed the sun_path limit. This happens when
+// len(runtimeDir) > 71 (hash path = runtimeDir + 32 > 103).
+func TestMakeSocketPath_ErrorWhenPathTooLong(t *testing.T) {
+	// runtimeDir = 100 chars: hash path = 100+32 = 132 >> 103.
+	tooLongDir := buildLongDir(t, 100)
+
+	_, err := makeSocketPath(tooLongDir, "echo", 1)
+	require.Error(t, err, "must return error when no valid path fits within sun_path limit")
+	assert.Contains(t, err.Error(), "exceeds sun_path limit",
+		"error must describe the path length constraint")
+}
+
+// TestMakeSocketPath_MkdirAllFailure verifies that makeSocketPath returns a
+// descriptive error when the socket directory cannot be created (e.g., because
+// a regular file already occupies the path).
+func TestMakeSocketPath_MkdirAllFailure(t *testing.T) {
+	dir := t.TempDir()
+	// Block socket dir creation by placing a regular file at the target path.
+	sockDirPath := filepath.Join(dir, "sockets")
+	require.NoError(t, os.WriteFile(sockDirPath, []byte("block"), 0o600))
+
+	_, err := makeSocketPath(dir, "echo", 1)
+	require.Error(t, err, "must return error when socket dir cannot be created")
+	assert.Contains(t, err.Error(), "create module socket dir",
+		"error must identify the socket dir creation failure")
 }

--- a/features/steward/modules/runtime/socket_windows.go
+++ b/features/steward/modules/runtime/socket_windows.go
@@ -18,9 +18,12 @@ import (
 
 // makeSocketPath returns the named pipe path for a module instance.
 // Format: \\.\pipe\cfgms-module-${name}-${id}
-// runtimeDir is unused on Windows (named pipes don't use directories).
-func makeSocketPath(runtimeDir, moduleName string, id int64) string {
-	return fmt.Sprintf(`\\.\pipe\cfgms-module-%s-%d`, sanitizeName(moduleName), id)
+//
+// runtimeDir is unused on Windows: named pipes are identified by name, not
+// filesystem path. Windows enforces per-user pipe ACLs at the kernel level,
+// so no additional directory permission hardening is required here.
+func makeSocketPath(runtimeDir, moduleName string, id int64) (string, error) {
+	return fmt.Sprintf(`\\.\pipe\cfgms-module-%s-%d`, sanitizeName(moduleName), id), nil
 }
 
 // waitForSocket polls the named pipe at socketPath until it accepts a


### PR DESCRIPTION
## Summary

- All module gRPC sockets now live under `${runtimeDir}/sockets/` (mode 0700), created with `os.MkdirAll` and mode re-asserted via `os.Chmod` on every call to defend against pre-existing looser directories
- The `/tmp` long-path fallback is removed: when the natural path exceeds sun_path, the name is hashed into the same steward-private directory instead of world-writable `/tmp`; if even the hashed path exceeds the limit, an explicit error is returned rather than silently degrading
- Trust-boundary decision: socket file permissions are the module-channel trust boundary (documented in code and architecture doc); mTLS/peer-credential checks are deferred as out of scope for this story

## Security Context

The module gRPC channel uses `insecure.NewCredentials()` with no per-caller authentication, so access control rests entirely on socket file permissions. The old code created `/tmp/cfgms-<predictable-hash>.sock` — a world-writable parent with a non-secret name — allowing a local unprivileged attacker to win the create race and invoke `script.Set()` (runs as steward identity) or `file.Set()` (writes within `allowed_base_path`). Surfaced by the security review of PR #1904.

## Trust Boundary Decision (required by AC)

Socket file permissions are the module-channel trust boundary on Unix. The `sockets/` directory is created mode 0700 and owned by the steward process user; no other user can connect. Adding mTLS or Unix peer-credential checks to the local module channel is explicitly out of scope for this story and documented as a follow-up if needed. On Windows, named pipes use kernel-enforced per-user ACLs — equivalent protection without filesystem directory hardening.

## Files Changed

| File | Change |
|------|--------|
| `features/steward/modules/runtime/socket_unix.go` | Hardened `makeSocketPath`: 0700 dir, mode re-assert, no `/tmp` fallback |
| `features/steward/modules/runtime/socket_unix_test.go` | New required tests + error path tests; uses `/tmp`-based short base (no platform skips) |
| `features/steward/modules/runtime/socket_windows.go` | Signature updated to `(string, error)` for consistency; Windows named pipe ACLs documented |
| `features/steward/modules/runtime/runtime.go` | Updated `makeSocketPath` call site to handle error return |
| `features/steward/modules/runtime/runtime_test.go` | Updated regression test: exercises hash fallback (not `/tmp` fallback) |
| `docs/architecture/steward-operating-model.md` | Socket paths section: documents 0700 dir and socket-perms trust boundary |

## Specialist Review Results

**QA Test Runner: PASS** — All 21 runtime tests pass; 160/160 script tests pass; cross-platform compilation validated; full `make test-agent-complete` green.

**QA Code Reviewer: PASS** (after fix iteration) — Initial review found 4 blocking issues (t.Skip() guards, missing error path tests); all fixed. Final review: 0 blocking issues, 0 warnings.

**Security Engineer: PASS** — No blocking issues. Two low-severity informational notes: (1) residual TOCTOU on MkdirAll→Chmod sequence is bounded by steward-owned runtimeDir in production; (2) `insecure.NewCredentials()` is intentional and documented as the trust-boundary design choice.

Fixes #1905