### PR TITLE
modules/script: quote temp script path for cmd.exe /c to handle spaces in %TEMP% (Issue #1907)

### DIFF
--- a/features/modules/script/executor.go
+++ b/features/modules/script/executor.go
@@ -255,10 +255,10 @@ func (e *Executor) buildWindowsCommand(ctx context.Context) (*exec.Cmd, func(), 
 		if err != nil {
 			return nil, noop, err
 		}
-		// cmd.exe /c <filepath> executes the batch file by path; content is on disk,
-		// not passed inline. This differs from the banned pattern cmd.exe /c <inline-content>.
-		// #nosec G204 - tmpPath is a temp file created by this process; not user input
-		return exec.CommandContext(ctx, "cmd.exe", "/c", tmpPath), cleanup, nil
+		// buildCmdExeCommand (executor_windows.go) sets SysProcAttr.CmdLine so that
+		// the path is quoted before cmd.exe /c sees it. This is required when %TEMP%
+		// contains a space (e.g. a user-profile directory under logged_in_user context).
+		return buildCmdExeCommand(ctx, tmpPath), cleanup, nil
 
 	case ShellPython:
 		tmpPath, cleanup, err := writeTempScript("cfgms-script-*.py", e.config.Content)

--- a/features/modules/script/executor_unix.go
+++ b/features/modules/script/executor_unix.go
@@ -16,6 +16,13 @@ import (
 	"strings"
 )
 
+// buildCmdExeCommand is a Windows-only helper; this stub satisfies the compiler
+// on Unix platforms. buildWindowsCommand is only reached on Windows via the
+// runtime.GOOS switch in buildCommand, so this stub is never executed.
+func buildCmdExeCommand(_ context.Context, _ string) *exec.Cmd {
+	return nil
+}
+
 // detectLoggedInUser detects the currently logged-in console user on Unix systems.
 // Returns ErrNoUserLoggedIn if no interactive user is currently logged in.
 // The caller should queue execution for retry when ErrNoUserLoggedIn is returned.

--- a/features/modules/script/executor_windows.go
+++ b/features/modules/script/executor_windows.go
@@ -158,6 +158,33 @@ func applyExecutionContext(ctx context.Context, config *ScriptConfig, cmd *exec.
 	return cmd, username, cleanup, nil
 }
 
+// buildCmdExeCommand constructs a cmd.exe /c <path> command using
+// SysProcAttr.CmdLine to bypass Go's argv-encoding layer.
+//
+// When %TEMP% resolves to a user-profile directory that contains a space
+// (e.g. C:\Users\John Smith\AppData\Local\Temp\), Go wraps the path in
+// double-quotes via EscapeArg when building the argv string, which is correct.
+// However, cmd.exe /c applies its own quote-stripping before locating the
+// batch file: it strips the outermost double-quotes from the remainder of the
+// line, leaving a bare unquoted path that fails for spaced directories.
+// Setting CmdLine directly passes the quoted path intact, bypassing that
+// stripping.
+//
+// The CmdLine contains cmd.exe /c <file-path> — a file path, never inline
+// script content. This satisfies the same constraint as the argv form and
+// does not introduce banned patterns.
+func buildCmdExeCommand(ctx context.Context, tmpPath string) *exec.Cmd {
+	// #nosec G204 - tmpPath is a temp file created by this process; not user input
+	cmd := exec.CommandContext(ctx, "cmd.exe")
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		// EscapeArg double-quotes tmpPath when it contains spaces, producing
+		// cmd.exe /c "C:\path with spaces\file.cmd". cmd.exe /c interprets the
+		// quoted token as the batch-file path and executes it correctly.
+		CmdLine: fmt.Sprintf("cmd.exe /c %s", syscall.EscapeArg(tmpPath)),
+	}
+	return cmd
+}
+
 // ResolveExecutionUID is not applicable on Windows: process identity is
 // SID-based, not POSIX UID-based, and the relay named pipe is access-controlled
 // via an explicit DACL rather than file ownership. It always returns -1, which

--- a/features/modules/script/executor_windows_test.go
+++ b/features/modules/script/executor_windows_test.go
@@ -182,3 +182,57 @@ func TestResolveExecutionUID_Windows(t *testing.T) {
 		assert.Equal(t, -1, uid, "Windows ResolveExecutionUID must return -1 (no UID chown)")
 	}
 }
+
+// TestCmdScriptPathWithSpaces verifies that buildCmdExeCommand sets SysProcAttr.CmdLine
+// to a correctly quoted cmd.exe /c <path> invocation when the temp directory path
+// contains a space. This covers the logged_in_user execution context where %TEMP%
+// resolves to a user-profile directory such as C:\Users\John Smith\AppData\Local\Temp\.
+// Without the CmdLine override, cmd.exe /c strips the outer quotes and cannot locate
+// the batch file.
+func TestCmdScriptPathWithSpaces(t *testing.T) {
+	// Synthetic path with a space in the directory component — mirrors a real
+	// user-profile %TEMP% path. No file is created: we verify CmdLine construction only.
+	spacedPath := `C:\Users\John Smith\AppData\Local\Temp\cfgms-script-abc123.cmd`
+
+	cmd := buildCmdExeCommand(context.Background(), spacedPath)
+
+	require.NotNil(t, cmd)
+	require.NotNil(t, cmd.SysProcAttr, "SysProcAttr must be set to override cmd.exe arg parsing")
+
+	// EscapeArg wraps a path containing spaces in double-quotes, so the CmdLine must
+	// be: cmd.exe /c "C:\Users\John Smith\AppData\Local\Temp\cfgms-script-abc123.cmd"
+	expectedCmdLine := `cmd.exe /c "C:\Users\John Smith\AppData\Local\Temp\cfgms-script-abc123.cmd"`
+	assert.Equal(t, expectedCmdLine, cmd.SysProcAttr.CmdLine,
+		"CmdLine must double-quote the path to handle spaces in the %%TEMP%% directory")
+}
+
+// TestCmdScriptPathWithoutSpaces verifies that buildCmdExeCommand also works correctly
+// for paths without spaces (the SYSTEM-context case where %TEMP% is C:\Windows\Temp\).
+func TestCmdScriptPathWithoutSpaces(t *testing.T) {
+	noSpacePath := `C:\Windows\Temp\cfgms-script-abc123.cmd`
+
+	cmd := buildCmdExeCommand(context.Background(), noSpacePath)
+
+	require.NotNil(t, cmd)
+	require.NotNil(t, cmd.SysProcAttr)
+
+	// EscapeArg does not add quotes when the path contains no spaces.
+	expectedCmdLine := `cmd.exe /c C:\Windows\Temp\cfgms-script-abc123.cmd`
+	assert.Equal(t, expectedCmdLine, cmd.SysProcAttr.CmdLine)
+}
+
+// TestBuildCmdExeCommand_ContentNotInline verifies that the CmdLine for buildCmdExeCommand
+// contains a file path, never inline script content — the file-path-only constraint
+// that distinguishes it from the banned pattern cmd.exe /c <inline-content>.
+func TestBuildCmdExeCommand_ContentNotInline(t *testing.T) {
+	tmpPath := `C:\Windows\Temp\cfgms-script-abc123.cmd`
+	inlineContent := "@echo hello from cfgms"
+
+	cmd := buildCmdExeCommand(context.Background(), tmpPath)
+
+	require.NotNil(t, cmd.SysProcAttr)
+	assert.NotContains(t, cmd.SysProcAttr.CmdLine, inlineContent,
+		"CmdLine must not contain inline script content")
+	assert.Contains(t, cmd.SysProcAttr.CmdLine, "cfgms-script-",
+		"CmdLine must reference the temp script file path")
+}


### PR DESCRIPTION
## Summary

- **Problem**: When `%TEMP%` resolves to a user-profile directory containing a space (e.g. `C:\Users\John Smith\AppData\Local\Temp\`), the `ShellCmd` case in `buildWindowsCommand` used `exec.CommandContext(ctx, "cmd.exe", "/c", tmpPath)`. Go's argv encoder wraps the spaced path in double-quotes via `EscapeArg`, but `cmd.exe /c` then strips those outer quotes and receives a bare unquoted path — causing a "file not found" error.
- **Fix**: Added `buildCmdExeCommand` in `executor_windows.go` that sets `SysProcAttr.CmdLine` directly to `cmd.exe /c <EscapeArg(tmpPath)>`, bypassing Go's argv layer and delivering the correctly quoted path to cmd.exe intact.
- **Scope**: Only affects `logged_in_user` execution context with a spaced user-profile path. SYSTEM-context stewards (`C:\Windows\Temp\`) are unaffected.

## Files Changed

- `features/modules/script/executor_windows.go` — added `buildCmdExeCommand` using `syscall.SysProcAttr{CmdLine: ...}`
- `features/modules/script/executor.go` — ShellCmd case delegates to `buildCmdExeCommand` instead of inline `exec.CommandContext`
- `features/modules/script/executor_unix.go` — compile-time stub for `buildCmdExeCommand` (returns nil; unreachable on Unix)
- `features/modules/script/executor_windows_test.go` — added `TestCmdScriptPathWithSpaces`, `TestCmdScriptPathWithoutSpaces`, `TestBuildCmdExeCommand_ContentNotInline`

## Specialist Review Results

**QA Test Runner**: PASS — all 130+ packages pass, 0 lint issues, cross-platform builds (linux/amd64, linux/arm64, darwin/amd64, darwin/arm64, windows/amd64) all clean.

**QA Code Reviewer**: PASS — no mocks, no illegitimate skips, no empty assertions, no hacky workarounds. All new tests have real assertions.

**Security Engineer**: PASS — security-precommit, check-architecture, and security-scan all clean. Verified `CmdLine` contains a file path, never inline script content; no banned patterns introduced.

## Test Plan

- [ ] `TestCmdScriptPathWithSpaces` (Windows CI): asserts `SysProcAttr.CmdLine` correctly double-quotes a path containing a space
- [ ] `TestCmdScriptPathWithoutSpaces` (Windows CI): asserts space-free paths are passed through without added quotes
- [ ] `TestBuildCmdExeCommand_ContentNotInline` (Windows CI): asserts inline script content never appears in CmdLine
- [ ] `TestScriptExecutorNoBannedPatterns` (all platforms): unaffected — ShellCmd is not in the Windows banned-pattern cases; passing unchanged

Fixes #1907

🤖 Generated with [Claude Code](https://claude.com/claude-code)