### PR TITLE
launcher: cfgms-steward-launcher binary with auto-rollback supervisor (Issue #1918)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,7 @@ STEWARD_BUILD_FLAGS=-trimpath -ldflags="-s -w -X main.ControllerURL=$(STEWARD_CO
 
 # Binary names
 STEWARD_BINARY=cfgms-steward
+STEWARD_LAUNCHER_BINARY=cfgms-steward-launcher
 CONTROLLER_BINARY=controller
 CLI_BINARY=cfg
 CERT_MANAGER_BINARY=cert-manager
@@ -102,12 +103,15 @@ proto-gen-modules: check-proto-grpc-tools
 
 # Build all binaries
 .PHONY: build
-build: fix-git-bare build-steward build-controller build-cli build-cert-manager build-stdlib-modules
+build: fix-git-bare build-steward build-steward-launcher build-controller build-cli build-cert-manager build-stdlib-modules
 
 # Build individual binaries
-.PHONY: build-steward build-controller build-cli build-cert-manager build-stdlib-modules
+.PHONY: build-steward build-steward-launcher build-controller build-cli build-cert-manager build-stdlib-modules
 build-steward:
 	go build ${STEWARD_BUILD_FLAGS} -o bin/${STEWARD_BINARY} ./cmd/steward
+
+build-steward-launcher:
+	go build ${GO_BUILD_FLAGS} -o bin/${STEWARD_LAUNCHER_BINARY} ./cmd/cfgms-steward-launcher
 
 build-controller:
 	go build ${GO_BUILD_FLAGS} -o bin/${CONTROLLER_BINARY} ./cmd/controller
@@ -146,6 +150,7 @@ build-cross-platform:
 		echo "  Building for $$GOOS/$$GOARCH..."; \
 		mkdir -p $$OUTDIR; \
 		go build ${STEWARD_BUILD_FLAGS} -o $$OUTDIR/${STEWARD_BINARY}$$EXT ./cmd/steward && \
+		go build ${GO_BUILD_FLAGS} -o $$OUTDIR/${STEWARD_LAUNCHER_BINARY}$$EXT ./cmd/cfgms-steward-launcher && \
 		go build ${GO_BUILD_FLAGS} -o $$OUTDIR/${CONTROLLER_BINARY}$$EXT ./cmd/controller && \
 		go build ${GO_BUILD_FLAGS} -o $$OUTDIR/${CLI_BINARY}$$EXT ./cmd/cfg && \
 		go build ${GO_BUILD_FLAGS} -o $$OUTDIR/${CERT_MANAGER_BINARY}$$EXT ./cmd/cert-manager || exit 1; \
@@ -167,6 +172,7 @@ build-cross-validate:
 		printf "  %-15s" "$$GOOS/$$GOARCH:"; \
 		ERROR_LOG=$$(mktemp); \
 		if go build ${STEWARD_BUILD_FLAGS} -o /dev/null ./cmd/steward 2>$$ERROR_LOG && \
+		   go build ${GO_BUILD_FLAGS} -o /dev/null ./cmd/cfgms-steward-launcher 2>>$$ERROR_LOG && \
 		   go build ${GO_BUILD_FLAGS} -o /dev/null ./cmd/controller 2>>$$ERROR_LOG && \
 		   go build ${GO_BUILD_FLAGS} -o /dev/null ./cmd/cfg 2>>$$ERROR_LOG && \
 		   go build ${GO_BUILD_FLAGS} -o /dev/null ./cmd/cert-manager 2>>$$ERROR_LOG; then \

--- a/cmd/cfgms-steward-launcher/lifecycle.go
+++ b/cmd/cfgms-steward-launcher/lifecycle.go
@@ -81,8 +81,14 @@ func (s *Supervisor) Supervise(ctx context.Context) error {
 	if s.StartupWindow <= 0 {
 		s.StartupWindow = 30 * time.Second
 	}
-	if s.MaxRollbackCycles <= 0 {
-		s.MaxRollbackCycles = 1
+	// MaxRollbackCycles: zero (or negative) is a legitimate operator
+	// choice — "no auto-rollback, just fail-fast and let the OS service
+	// manager retry per its recovery policy." The previous behaviour
+	// silently coerced 0 → 1, which masked the operator's intent and
+	// confused review tests. Only negative values get coerced (they
+	// represent a programming mistake, not a deliberate choice).
+	if s.MaxRollbackCycles < 0 {
+		s.MaxRollbackCycles = 0
 	}
 
 	rollbacksRemaining := s.MaxRollbackCycles
@@ -107,10 +113,32 @@ func (s *Supervisor) Supervise(ctx context.Context) error {
 		exitErr := s.execOnce(ctx, exe)
 		ranFor := s.clock.Since(started)
 
-		// Context cancelled → propagate normally; service manager is
-		// shutting us down, not the child crashing.
+		// Context cancelled → service manager is shutting us down.
+		// Distinguish two sub-cases:
+		//   (a) The child was still running when ctx fired and got
+		//       killed by exec.CommandContext. exitErr is non-nil but
+		//       reflects the cancellation, not a child fault. Return
+		//       nil so the service manager logs a clean shutdown.
+		//   (b) The child had ALREADY crashed by the time ctx fired —
+		//       e.g. SIGTERM and a crash arriving in the same scheduler
+		//       turn during an in-progress upgrade. exitErr is non-nil
+		//       AND ranFor < StartupWindow. Discarding this as "just a
+		//       cancellation" would silently mask the upgrade failure.
+		//       Differentiate by checking whether the child had time
+		//       to exit on its own: a child that ran past StartupWindow
+		//       definitionally wasn't crashing-during-startup, so
+		//       treat its exit as graceful regardless of code. A child
+		//       that exited inside the window with a non-zero code
+		//       gets the failure surfaced even on cancel.
 		if ctx.Err() != nil {
-			return nil
+			failedStartupOnCancel := ranFor < s.StartupWindow && exitErr != nil
+			if !failedStartupOnCancel {
+				return nil
+			}
+			// Fall through to the rollback logic below — this looks
+			// like a real upgrade failure that happened to coincide
+			// with a cancel. The operator (or the next startup) will
+			// observe the rolled-back state.
 		}
 
 		failedStartup := ranFor < s.StartupWindow

--- a/cmd/cfgms-steward-launcher/lifecycle.go
+++ b/cmd/cfgms-steward-launcher/lifecycle.go
@@ -1,0 +1,158 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"time"
+)
+
+// Supervisor exec's the steward and decides what to do when it exits.
+//
+// The lifecycle contract is intentionally simple for the Phase-1 launcher:
+//
+//   - Exit code 0 after at least StartupWindow elapsed → restart (operator
+//     stopped the steward intentionally, or the service manager sent stop;
+//     normal restart in either case).
+//   - Exit code != 0 or any exit BEFORE StartupWindow elapsed → consider
+//     the current version "broken." If a previous version is recorded,
+//     roll back and exec from there. If no previous, exit non-zero and let
+//     the OS service manager retry per its recovery actions.
+//
+// The launcher itself never panics on these branches. Edge cases (missing
+// binary, version-file pointing at nothing on disk) surface as errors
+// returned from Supervise; main() translates them to non-zero exits.
+type Supervisor struct {
+	// Layout describes the on-disk binary layout.
+	Layout Layout
+
+	// StartupWindow is the time a child must stay running before we
+	// consider its start "healthy." A child that exits inside this window
+	// is treated as a failed upgrade — auto-rollback fires.
+	StartupWindow time.Duration
+
+	// MaxRollbackCycles caps how many times we will roll back per Supervise
+	// call. Without this, a pair of binaries that each fail their startup
+	// window would ping-pong indefinitely. Default 1 — one fall-back, then
+	// give up.
+	MaxRollbackCycles int
+
+	// Stdout / Stderr are the streams the child inherits. Tests inject
+	// buffers; production callers pass os.Stdout / os.Stderr so the
+	// service-manager log captures the child output.
+	Stdout io.Writer
+	Stderr io.Writer
+
+	// ExtraArgs are appended to the child's argv after argv[0]. Production
+	// callers leave it empty; the OS service manager arranges --regtoken
+	// (and any other steward CLI flags) via the registered service-binPath
+	// arguments. Tests set this to control what their fake child does.
+	ExtraArgs []string
+
+	// clock is injectable for tests; production uses time.Now / time.Since.
+	clock clock
+}
+
+type clock interface {
+	Now() time.Time
+	Since(time.Time) time.Duration
+}
+
+type realClock struct{}
+
+func (realClock) Now() time.Time              { return time.Now() }
+func (realClock) Since(t time.Time) time.Duration { return time.Since(t) }
+
+// Supervise runs the supervision loop until ctx is cancelled, the child
+// exits normally without triggering rollback, or all rollback attempts are
+// exhausted.
+//
+// Returns nil if the child completed normally; an error describing the
+// final fault otherwise.
+func (s *Supervisor) Supervise(ctx context.Context) error {
+	if s.clock == nil {
+		s.clock = realClock{}
+	}
+	if s.StartupWindow <= 0 {
+		s.StartupWindow = 30 * time.Second
+	}
+	if s.MaxRollbackCycles <= 0 {
+		s.MaxRollbackCycles = 1
+	}
+
+	rollbacksRemaining := s.MaxRollbackCycles
+	for {
+		current, err := s.Layout.ReadCurrent()
+		if err != nil {
+			return fmt.Errorf("launcher: read current version: %w", err)
+		}
+		if current == "" {
+			return errors.New("launcher: no current version recorded — install layout is missing or corrupt")
+		}
+
+		exe, err := s.Layout.StewardExeFor(current)
+		if err != nil {
+			return fmt.Errorf("launcher: resolve steward exe for %q: %w", current, err)
+		}
+		if _, statErr := os.Stat(exe); statErr != nil {
+			return fmt.Errorf("launcher: steward exe %q for version %q is missing: %w", exe, current, statErr)
+		}
+
+		started := s.clock.Now()
+		exitErr := s.execOnce(ctx, exe)
+		ranFor := s.clock.Since(started)
+
+		// Context cancelled → propagate normally; service manager is
+		// shutting us down, not the child crashing.
+		if ctx.Err() != nil {
+			return nil
+		}
+
+		failedStartup := ranFor < s.StartupWindow
+		nonZeroExit := exitErr != nil
+
+		if !failedStartup && !nonZeroExit {
+			// Child stayed up past the startup window then exited cleanly.
+			// Normal restart-on-clean-exit path.
+			continue
+		}
+
+		// Anything else (early exit OR non-zero exit) is a "broken
+		// child" signal. Attempt rollback if we have a previous version
+		// AND we haven't exhausted our budget.
+		previous, perr := s.Layout.ReadPrevious()
+		if perr != nil {
+			return fmt.Errorf("launcher: read previous version after child failure: %w", perr)
+		}
+		if previous == "" || rollbacksRemaining == 0 {
+			if exitErr != nil {
+				return fmt.Errorf("launcher: child failed (ran for %s) and no rollback available: %w", ranFor, exitErr)
+			}
+			return fmt.Errorf("launcher: child exited inside startup window (%s) and no rollback available", ranFor)
+		}
+
+		newCurrent, rbErr := s.Layout.Rollback()
+		if rbErr != nil {
+			return fmt.Errorf("launcher: rollback after child failure: %w", rbErr)
+		}
+		rollbacksRemaining--
+		fmt.Fprintf(s.Stderr, "launcher: rolled back to version %q after child failure (ran for %s)\n", newCurrent, ranFor)
+	}
+}
+
+// execOnce runs the child to completion, returning any non-nil error from
+// Wait. The child inherits the launcher's stdin/stdout/stderr (overridable
+// in tests via Supervisor.Stdout / .Stderr). The child also receives any
+// ExtraArgs.
+func (s *Supervisor) execOnce(ctx context.Context, exe string) error {
+	cmd := exec.CommandContext(ctx, exe, s.ExtraArgs...) //#nosec G204 -- exe path is validated via Layout
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = s.Stdout
+	cmd.Stderr = s.Stderr
+	return cmd.Run()
+}

--- a/cmd/cfgms-steward-launcher/lifecycle_test.go
+++ b/cmd/cfgms-steward-launcher/lifecycle_test.go
@@ -10,7 +10,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"runtime"
 	"strconv"
 	"sync"
 	"sync/atomic"
@@ -241,6 +240,61 @@ func TestSupervise_BrokenChild_NoPreviousReturnsError(t *testing.T) {
 	}
 }
 
+// TestSupervise_ContextCancel_AfterHealthyChildStaysAlive covers the
+// review-flagged "exit code discarded as clean shutdown" race. Before
+// the fix-up, ANY ctx.Err() != nil short-circuited Supervise to return
+// nil — even when the child had already exited with a non-zero code
+// before the cancel arrived. The fix differentiates: cancellation
+// AFTER the startup window propagates as clean shutdown; non-zero exit
+// INSIDE the startup window still triggers rollback even on cancel.
+//
+// This test exercises the "healthy child past window, then cancel"
+// case: cancellation must return nil and not interpret the SIGTERM-
+// induced exit as a failure.
+func TestSupervise_ContextCancel_AfterHealthyChildStaysAlive(t *testing.T) {
+	l := newLayout(t)
+	installFakeSteward(t, l, "v1")
+	if err := l.WriteCurrent("v1"); err != nil {
+		t.Fatalf("WriteCurrent v1: %v", err)
+	}
+
+	// Child sleeps long; cancel fires mid-sleep. exec.CommandContext
+	// kills the child producing a non-zero exit. The supervisor must
+	// recognise this as a cancellation, not a child fault.
+	envForChild(t, map[string]string{
+		"FAKE_STEWARD_SLEEP_MS":  "60000",
+		"FAKE_STEWARD_EXIT_CODE": "0",
+	})
+
+	s := &Supervisor{
+		Layout:            l,
+		StartupWindow:     20 * time.Millisecond, // tiny window so the kill lands OUTSIDE it
+		MaxRollbackCycles: 0,
+		Stdout:            &bytes.Buffer{},
+		Stderr:            &bytes.Buffer{},
+		ExtraArgs:         []string{"-test.run=TestHelperProcess"},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	var result error
+	done := make(chan struct{})
+	go func() {
+		result = s.Supervise(ctx)
+		close(done)
+	}()
+	// Wait long enough that the child is well past StartupWindow.
+	time.Sleep(300 * time.Millisecond)
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("Supervise did not return after cancel")
+	}
+	if result != nil {
+		t.Errorf("Supervise returned %v on cancel after healthy child; want nil", result)
+	}
+}
+
 func TestSupervise_ContextCancel_ExitsClean(t *testing.T) {
 	l := newLayout(t)
 	installFakeSteward(t, l, "v1")
@@ -299,31 +353,42 @@ func TestSupervise_ContextCancel_ExitsClean(t *testing.T) {
 // cleanly past the startup window must NOT trigger rollback; the loop
 // must restart it. We bound the test by stopping the loop with a context
 // cancel after observing at least 2 child invocations.
+//
+// Timing budgets are intentionally generous so the test is robust on
+// Windows under CI load (the earlier 50ms-window/200ms-sleep numbers
+// raced fork-exec overhead on Windows, hence a previous Windows skip
+// the adversarial review correctly objected to). The current values
+// give a 5× safety margin between sleep duration and startup window;
+// fork/exec overhead would have to balloon over 350ms before false
+// positives kick in.
 func TestSupervise_HealthyChild_RestartsWithoutRollback(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		// On Windows, time.Sleep behaviour under heavy CI load can race
-		// our 50ms startup window. The behaviour is identical on Linux
-		// (where every other launcher test runs in CI), so we skip this
-		// timing-sensitive variant on Windows.
-		t.Skip("timing-sensitive; covered on Linux CI")
-	}
-
 	l := newLayout(t)
 	installFakeSteward(t, l, "v1")
 	if err := l.WriteCurrent("v1"); err != nil {
 		t.Fatalf("WriteCurrent v1: %v", err)
 	}
 
-	// Sleep just past the 50ms startup window then exit cleanly.
+	// Sleep well past the startup window then exit cleanly. The window
+	// is intentionally short (50ms) and the sleep long (500ms) so the
+	// classifier "this child stayed up past the startup window" stays
+	// stable even when Windows fork+exec overhead doubles or triples
+	// under CI load.
 	envForChild(t, map[string]string{
-		"FAKE_STEWARD_SLEEP_MS":  "200",
+		"FAKE_STEWARD_SLEEP_MS":  "500",
 		"FAKE_STEWARD_EXIT_CODE": "0",
 	})
 
 	s := &Supervisor{
-		Layout:            l,
-		StartupWindow:     50 * time.Millisecond,
-		MaxRollbackCycles: 0, // ZERO rollback budget — any rollback attempt would fail
+		Layout: l,
+		// 50ms startup window: any healthy child that completes a 500ms
+		// sleep + exit is comfortably outside the window.
+		StartupWindow: 50 * time.Millisecond,
+		// ZERO rollback budget. A healthy child must NOT trigger rollback
+		// regardless of budget, so this proves the classifier path even
+		// when no rollback is permitted. Previously this was coerced
+		// silently to 1; the fix-up exposes 0 as a legitimate operator
+		// choice.
+		MaxRollbackCycles: 0,
 		Stdout:            &bytes.Buffer{},
 		Stderr:            &bytes.Buffer{},
 		ExtraArgs:         []string{"-test.run=TestHelperProcess"},
@@ -339,13 +404,14 @@ func TestSupervise_HealthyChild_RestartsWithoutRollback(t *testing.T) {
 	}()
 
 	// Let the supervisor restart the child at least twice — proves the
-	// loop is in fact looping on clean exits.
-	time.Sleep(700 * time.Millisecond)
+	// loop is in fact looping on clean exits. 1500ms gives 3 iterations
+	// of 500ms sleep + restart, even with fork-exec overhead.
+	time.Sleep(1500 * time.Millisecond)
 	cancel()
 
 	select {
 	case <-done:
-	case <-time.After(5 * time.Second):
+	case <-time.After(10 * time.Second):
 		t.Fatal("Supervise did not return after cancel")
 	}
 	if result != nil {

--- a/cmd/cfgms-steward-launcher/lifecycle_test.go
+++ b/cmd/cfgms-steward-launcher/lifecycle_test.go
@@ -1,0 +1,435 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+package main
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// TestHelperProcess is the canonical Go pattern for testing exec.Cmd-based
+// code without shipping separate fake binaries. The launcher test re-exec's
+// this same test binary with GO_WANT_HELPER_PROCESS=1 set; that env var
+// switches the test process into "be the fake steward" mode, controlled by
+// the rest of the FAKE_STEWARD_* env vars.
+//
+// Behaviour knobs (read once, on start):
+//
+//	FAKE_STEWARD_SLEEP_MS    Sleep this many ms before exiting. Default 0.
+//	FAKE_STEWARD_EXIT_CODE   Exit with this status. Default 0.
+//	FAKE_STEWARD_MARKER_FILE Touch this file before sleeping so the test can
+//	                         verify which version actually ran.
+func TestHelperProcess(t *testing.T) {
+	if os.Getenv("GO_WANT_HELPER_PROCESS") != "1" {
+		return
+	}
+	if marker := os.Getenv("FAKE_STEWARD_MARKER_FILE"); marker != "" {
+		_ = os.WriteFile(marker, []byte("started"), 0o600)
+	}
+	if sleepMs := os.Getenv("FAKE_STEWARD_SLEEP_MS"); sleepMs != "" {
+		if n, err := strconv.Atoi(sleepMs); err == nil && n > 0 {
+			time.Sleep(time.Duration(n) * time.Millisecond)
+		}
+	}
+	code := 0
+	if c := os.Getenv("FAKE_STEWARD_EXIT_CODE"); c != "" {
+		if n, err := strconv.Atoi(c); err == nil {
+			code = n
+		}
+	}
+	os.Exit(code)
+}
+
+// helperExe returns the path of the running test binary so we can re-exec
+// it as the fake steward.
+func helperExe(t *testing.T) string {
+	t.Helper()
+	exe, err := os.Executable()
+	if err != nil {
+		t.Fatalf("os.Executable: %v", err)
+	}
+	return exe
+}
+
+// installFakeSteward stages a fake-steward binary into the layout's
+// versions/<name>/ directory. The fake-steward is just a shim that
+// re-exec's the test binary with GO_WANT_HELPER_PROCESS=1. We do this with
+// a small launcher-style trampoline: the binary at versions/<name>/<exe>
+// is actually the test binary, and Supervisor will run it. To control its
+// behaviour per-version, the Supervisor passes ExtraArgs and env via a
+// thin wrapper — but the simplest, most portable approach is: copy the
+// test binary into versions/<name>/ and use ExtraArgs + per-process env
+// (set in the Supervisor's exec by us hooking the command's Env).
+//
+// Since Supervisor.execOnce inherits the launcher's environment, we set
+// FAKE_STEWARD_* env vars on the test process and they propagate. To get
+// PER-VERSION behaviour, we encode the desired knobs in a side file that
+// the fake-steward reads at start. That keeps the launcher's
+// supervise-loop logic untouched.
+func installFakeSteward(t *testing.T, l Layout, version string) string {
+	t.Helper()
+	dst, err := l.StewardExeFor(version)
+	if err != nil {
+		t.Fatalf("StewardExeFor: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := copyFile(helperExe(t), dst); err != nil {
+		t.Fatalf("copy test binary into version dir: %v", err)
+	}
+	return dst
+}
+
+// runSupervisor runs Supervise with timeout-bounded context so a buggy
+// loop can't hang the test suite.
+func runSupervisor(t *testing.T, s *Supervisor, timeout time.Duration) error {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	return s.Supervise(ctx)
+}
+
+// fakeClock simulates time so we can deterministically test the
+// startup-window logic without sleeping in real time.
+type fakeClock struct {
+	mu  sync.Mutex
+	now time.Time
+}
+
+func (c *fakeClock) Now() time.Time {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.now
+}
+
+func (c *fakeClock) Since(t time.Time) time.Duration {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.now.Sub(t)
+}
+
+func (c *fakeClock) advance(d time.Duration) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.now = c.now.Add(d)
+}
+
+// envForChild returns the env vars to pass to a child fake-steward by
+// re-using the test process env. The launcher inherits its environment;
+// to vary per-test behaviour we just mutate t.Setenv before invocation.
+// But since we want different versions to behave differently within ONE
+// Supervise call, we instead set the env globally before Supervise and
+// rely on the fact that all spawned children inherit it.
+func envForChild(t *testing.T, knobs map[string]string) {
+	t.Helper()
+	t.Setenv("GO_WANT_HELPER_PROCESS", "1")
+	for k, v := range knobs {
+		t.Setenv(k, v)
+	}
+}
+
+func TestSupervise_NoCurrentVersion_ReturnsError(t *testing.T) {
+	l := newLayout(t)
+	s := &Supervisor{
+		Layout: l,
+		Stdout: &bytes.Buffer{},
+		Stderr: &bytes.Buffer{},
+	}
+	err := runSupervisor(t, s, 2*time.Second)
+	if err == nil {
+		t.Fatal("Supervise with no current.txt returned nil error")
+	}
+}
+
+func TestSupervise_BrokenChild_RollsBackWhenPreviousExists(t *testing.T) {
+	l := newLayout(t)
+
+	// Stage v1 (good) then v2 (broken). After WriteCurrent("v2"),
+	// current.txt=v2 previous.txt=v1.
+	installFakeSteward(t, l, "v1")
+	installFakeSteward(t, l, "v2")
+	if err := l.WriteCurrent("v1"); err != nil {
+		t.Fatalf("WriteCurrent v1: %v", err)
+	}
+	if err := l.WriteCurrent("v2"); err != nil {
+		t.Fatalf("WriteCurrent v2: %v", err)
+	}
+
+	// All children (regardless of version, due to shared env) will exit
+	// non-zero immediately AND touch a marker file so the test can prove
+	// the child actually ran (not just that exec.Command errored out).
+	// The Supervisor must:
+	//   - run v2 → it fails → roll back → current.txt becomes v1
+	//   - run v1 → it ALSO fails (same env) → no rollback budget left
+	//   - return error.
+	marker := filepath.Join(t.TempDir(), "ran")
+	envForChild(t, map[string]string{
+		"FAKE_STEWARD_EXIT_CODE":   "1",
+		"FAKE_STEWARD_SLEEP_MS":    "0",
+		"FAKE_STEWARD_MARKER_FILE": marker,
+	})
+
+	stderr := &bytes.Buffer{}
+	s := &Supervisor{
+		Layout:            l,
+		StartupWindow:     50 * time.Millisecond,
+		MaxRollbackCycles: 1,
+		Stdout:            &bytes.Buffer{},
+		Stderr:            stderr,
+		ExtraArgs:         []string{"-test.run=TestHelperProcess"},
+	}
+	err := runSupervisor(t, s, 10*time.Second)
+	if err == nil {
+		t.Fatal("Supervise returned nil error after both versions broken")
+	}
+
+	if _, statErr := os.Stat(marker); statErr != nil {
+		t.Errorf("fake-steward marker not present (%v) — child never actually ran; "+
+			"the supervisor must be returning an exec-not-found error instead of "+
+			"a real child-failure error", statErr)
+	}
+
+	// Rollback should have left current.txt pointing at v1.
+	cur, _ := l.ReadCurrent()
+	if cur != "v1" {
+		t.Errorf("current after rollback = %q, want v1", cur)
+	}
+	if !bytes.Contains(stderr.Bytes(), []byte(`rolled back to version "v1"`)) {
+		t.Errorf("stderr did not mention rollback to v1:\n%s", stderr.String())
+	}
+}
+
+func TestSupervise_BrokenChild_NoPreviousReturnsError(t *testing.T) {
+	l := newLayout(t)
+	installFakeSteward(t, l, "v1")
+	if err := l.WriteCurrent("v1"); err != nil {
+		t.Fatalf("WriteCurrent v1: %v", err)
+	}
+
+	marker := filepath.Join(t.TempDir(), "ran")
+	envForChild(t, map[string]string{
+		"FAKE_STEWARD_EXIT_CODE":   "1",
+		"FAKE_STEWARD_MARKER_FILE": marker,
+	})
+
+	s := &Supervisor{
+		Layout:            l,
+		StartupWindow:     50 * time.Millisecond,
+		MaxRollbackCycles: 1,
+		Stdout:            &bytes.Buffer{},
+		Stderr:            &bytes.Buffer{},
+		ExtraArgs:         []string{"-test.run=TestHelperProcess"},
+	}
+	err := runSupervisor(t, s, 10*time.Second)
+	if err == nil {
+		t.Fatal("Supervise returned nil when broken child had no rollback target")
+	}
+	if _, statErr := os.Stat(marker); statErr != nil {
+		t.Errorf("fake-steward marker not present (%v) — child never actually ran", statErr)
+	}
+}
+
+func TestSupervise_ContextCancel_ExitsClean(t *testing.T) {
+	l := newLayout(t)
+	installFakeSteward(t, l, "v1")
+	if err := l.WriteCurrent("v1"); err != nil {
+		t.Fatalf("WriteCurrent v1: %v", err)
+	}
+
+	// Child sleeps far longer than the test will give it; cancelling the
+	// context should kill it and Supervise should return nil (clean
+	// shutdown, not failure).
+	envForChild(t, map[string]string{
+		"FAKE_STEWARD_SLEEP_MS":  "60000",
+		"FAKE_STEWARD_EXIT_CODE": "0",
+	})
+
+	s := &Supervisor{
+		Layout:            l,
+		StartupWindow:     50 * time.Millisecond,
+		MaxRollbackCycles: 1,
+		Stdout:            &bytes.Buffer{},
+		Stderr:            &bytes.Buffer{},
+		ExtraArgs:         []string{"-test.run=TestHelperProcess"},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	var (
+		wg     sync.WaitGroup
+		result error
+	)
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		result = s.Supervise(ctx)
+	}()
+	time.Sleep(300 * time.Millisecond)
+	cancel()
+
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("Supervise did not return within 10s of cancel")
+	}
+
+	if result != nil {
+		t.Errorf("Supervise returned %v on context cancel, want nil", result)
+	}
+}
+
+// TestSupervise_HealthyChild_ExitsCleanWithoutRollback covers the
+// "supervisor restart loop" intentionally — a healthy child that exits
+// cleanly past the startup window must NOT trigger rollback; the loop
+// must restart it. We bound the test by stopping the loop with a context
+// cancel after observing at least 2 child invocations.
+func TestSupervise_HealthyChild_RestartsWithoutRollback(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		// On Windows, time.Sleep behaviour under heavy CI load can race
+		// our 50ms startup window. The behaviour is identical on Linux
+		// (where every other launcher test runs in CI), so we skip this
+		// timing-sensitive variant on Windows.
+		t.Skip("timing-sensitive; covered on Linux CI")
+	}
+
+	l := newLayout(t)
+	installFakeSteward(t, l, "v1")
+	if err := l.WriteCurrent("v1"); err != nil {
+		t.Fatalf("WriteCurrent v1: %v", err)
+	}
+
+	// Sleep just past the 50ms startup window then exit cleanly.
+	envForChild(t, map[string]string{
+		"FAKE_STEWARD_SLEEP_MS":  "200",
+		"FAKE_STEWARD_EXIT_CODE": "0",
+	})
+
+	s := &Supervisor{
+		Layout:            l,
+		StartupWindow:     50 * time.Millisecond,
+		MaxRollbackCycles: 0, // ZERO rollback budget — any rollback attempt would fail
+		Stdout:            &bytes.Buffer{},
+		Stderr:            &bytes.Buffer{},
+		ExtraArgs:         []string{"-test.run=TestHelperProcess"},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	var result error
+	done := make(chan struct{})
+	go func() {
+		result = s.Supervise(ctx)
+		close(done)
+	}()
+
+	// Let the supervisor restart the child at least twice — proves the
+	// loop is in fact looping on clean exits.
+	time.Sleep(700 * time.Millisecond)
+	cancel()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Supervise did not return after cancel")
+	}
+	if result != nil {
+		t.Errorf("Supervise returned %v on clean cancel after healthy restarts", result)
+	}
+	// current.txt must still be v1 — no rollback should have run.
+	cur, _ := l.ReadCurrent()
+	if cur != "v1" {
+		t.Errorf("current = %q after healthy restart loop, want v1 (no rollback)", cur)
+	}
+}
+
+// TestExecOnce_RespectsContextCancel verifies the exec-level wiring —
+// CommandContext cancellation must terminate the child.
+func TestExecOnce_RespectsContextCancel(t *testing.T) {
+	l := newLayout(t)
+	installFakeSteward(t, l, "v1")
+	envForChild(t, map[string]string{
+		"FAKE_STEWARD_SLEEP_MS":  "60000",
+		"FAKE_STEWARD_EXIT_CODE": "0",
+	})
+
+	exe, err := l.StewardExeFor("v1")
+	if err != nil {
+		t.Fatalf("StewardExeFor: %v", err)
+	}
+
+	s := &Supervisor{
+		Layout:    l,
+		Stdout:    &bytes.Buffer{},
+		Stderr:    &bytes.Buffer{},
+		ExtraArgs: []string{"-test.run=TestHelperProcess"},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	started := atomic.Int32{}
+	var execErr error
+	done := make(chan struct{})
+	go func() {
+		started.Store(1)
+		execErr = s.execOnce(ctx, exe)
+		close(done)
+	}()
+
+	// Wait for the goroutine to actually start running.
+	for started.Load() == 0 {
+		time.Sleep(5 * time.Millisecond)
+	}
+	time.Sleep(200 * time.Millisecond)
+	cancel()
+
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("execOnce did not return after context cancel")
+	}
+
+	if execErr == nil {
+		t.Error("execOnce returned nil error after context cancel — child was supposed to be killed")
+	}
+	// And specifically it should be the kind of error exec returns when
+	// the process was killed by signal/context — exec.ExitError typically.
+	var exitErr *exec.ExitError
+	if !errors.As(execErr, &exitErr) {
+		t.Logf("note: execOnce returned non-ExitError after cancel: %v", execErr)
+	}
+}
+
+// TestFakeChild_MarkerFileProvesWhichVersionRan is a sanity check on the
+// test helper itself — confirms the marker-file mechanism actually
+// captures which fake-steward binary ran. (Not used elsewhere; here to
+// guard against silent breakage of the helper.)
+func TestFakeChild_MarkerFileProvesWhichVersionRan(t *testing.T) {
+	marker := filepath.Join(t.TempDir(), "ran")
+	cmd := exec.Command(helperExe(t), "-test.run=TestHelperProcess") //nolint:gosec // test
+	cmd.Env = append(os.Environ(),
+		"GO_WANT_HELPER_PROCESS=1",
+		"FAKE_STEWARD_EXIT_CODE=0",
+		fmt.Sprintf("FAKE_STEWARD_MARKER_FILE=%s", marker),
+	)
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("fake child failed: %v", err)
+	}
+	if _, err := os.Stat(marker); err != nil {
+		t.Errorf("marker file not created: %v", err)
+	}
+}

--- a/cmd/cfgms-steward-launcher/main.go
+++ b/cmd/cfgms-steward-launcher/main.go
@@ -26,11 +26,20 @@ import (
 	"os/signal"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"syscall"
 	"time"
 )
 
 func main() {
+	// On Windows, the SCM invokes us with no console and expects the
+	// process to RegisterServiceCtrlHandler + report SERVICE_RUNNING.
+	// tryRunAsService detects that environment and dispatches into the
+	// svc.Run loop; on non-Windows or when invoked interactively it's a
+	// no-op and we fall through to the regular CLI handling.
+	if tryRunAsService() {
+		return
+	}
 	if len(os.Args) < 2 {
 		// Default behaviour: supervise. The OS service manager invokes
 		// the launcher without args.
@@ -60,11 +69,31 @@ func printUsage() {
 	fmt.Fprintf(os.Stderr, "Run with --help on each subcommand for details.\n")
 }
 
+// runRun is the interactive entry point (`cfgms-steward-launcher run`).
+// It parses the `run` flag set, then delegates to runSuperviseWithCtx
+// after wiring up signal handling on os.Interrupt / SIGTERM.
 func runRun(args []string) int {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, os.Interrupt, syscall.SIGTERM)
+	go func() {
+		<-sigCh
+		cancel()
+	}()
+	return runSuperviseWithCtx(ctx, args)
+}
+
+// runSuperviseWithCtx parses the `run` flag set and starts the
+// supervision loop. Shared by the interactive runRun() entry point and
+// the Windows-service Execute() handler (which cancels ctx on SCM
+// Stop / Shutdown instead of via signal).
+func runSuperviseWithCtx(ctx context.Context, args []string) int {
 	fs := flag.NewFlagSet("run", flag.ExitOnError)
 	root := fs.String("root", defaultRoot(), "Install root holding current.txt + versions/")
 	startupWindow := fs.Duration("startup-window", 30*time.Second, "How long a child must run to be considered healthy")
 	maxRollbacks := fs.Int("max-rollbacks", 1, "Cap on auto-rollback attempts per Supervise call")
+	childArgs := fs.String("child-args", "", "Space-separated args forwarded to the supervised steward (e.g. \"--regtoken xxx\")")
 	if err := fs.Parse(args); err != nil {
 		fmt.Fprintf(os.Stderr, "launcher run: %v\n", err)
 		return 2
@@ -76,17 +105,8 @@ func runRun(args []string) int {
 		MaxRollbackCycles: *maxRollbacks,
 		Stdout:            os.Stdout,
 		Stderr:            os.Stderr,
+		ExtraArgs:         strings.Fields(*childArgs),
 	}
-
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	sigCh := make(chan os.Signal, 1)
-	signal.Notify(sigCh, os.Interrupt, syscall.SIGTERM)
-	go func() {
-		<-sigCh
-		cancel()
-	}()
 
 	if err := sup.Supervise(ctx); err != nil {
 		fmt.Fprintf(os.Stderr, "launcher run: %v\n", err)

--- a/cmd/cfgms-steward-launcher/main.go
+++ b/cmd/cfgms-steward-launcher/main.go
@@ -1,0 +1,188 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+
+// cfgms-steward-launcher is the OS service entry point for the CFGMS
+// steward. It supervises the actual steward binary (kept in a versioned
+// subdirectory) and auto-rolls-back to the previous version when a new
+// one fails its startup window.
+//
+// # Subcommands
+//
+//	cfgms-steward-launcher run              Supervise the current version (the default; what the OS service manager invokes).
+//	cfgms-steward-launcher swap <ver> <exe> Stage <exe> as version <ver> and make it current. Used by the operator (or by `cfg steward upgrade`) to push a new binary.
+//	cfgms-steward-launcher rollback         Restore the previous-recorded version as current.
+//	cfgms-steward-launcher status           Print the current and previous version names.
+//
+// The launcher does NOT verify bundle signatures in this Phase-1 cut;
+// signature verification is a follow-up under epic #1917. Operators are
+// expected to stage from trusted sources for now.
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"runtime"
+	"syscall"
+	"time"
+)
+
+func main() {
+	if len(os.Args) < 2 {
+		// Default behaviour: supervise. The OS service manager invokes
+		// the launcher without args.
+		os.Exit(runRun([]string{}))
+	}
+	switch os.Args[1] {
+	case "run":
+		os.Exit(runRun(os.Args[2:]))
+	case "swap":
+		os.Exit(runSwap(os.Args[2:]))
+	case "rollback":
+		os.Exit(runRollback(os.Args[2:]))
+	case "status":
+		os.Exit(runStatus(os.Args[2:]))
+	case "-h", "--help", "help":
+		printUsage()
+		os.Exit(0)
+	default:
+		fmt.Fprintf(os.Stderr, "launcher: unknown subcommand %q\n", os.Args[1])
+		printUsage()
+		os.Exit(2)
+	}
+}
+
+func printUsage() {
+	fmt.Fprintf(os.Stderr, "Usage: cfgms-steward-launcher [run|swap|rollback|status] [flags]\n")
+	fmt.Fprintf(os.Stderr, "Run with --help on each subcommand for details.\n")
+}
+
+func runRun(args []string) int {
+	fs := flag.NewFlagSet("run", flag.ExitOnError)
+	root := fs.String("root", defaultRoot(), "Install root holding current.txt + versions/")
+	startupWindow := fs.Duration("startup-window", 30*time.Second, "How long a child must run to be considered healthy")
+	maxRollbacks := fs.Int("max-rollbacks", 1, "Cap on auto-rollback attempts per Supervise call")
+	if err := fs.Parse(args); err != nil {
+		fmt.Fprintf(os.Stderr, "launcher run: %v\n", err)
+		return 2
+	}
+
+	sup := &Supervisor{
+		Layout:            Layout{Root: *root, StewardBinaryName: defaultStewardBinaryName()},
+		StartupWindow:     *startupWindow,
+		MaxRollbackCycles: *maxRollbacks,
+		Stdout:            os.Stdout,
+		Stderr:            os.Stderr,
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, os.Interrupt, syscall.SIGTERM)
+	go func() {
+		<-sigCh
+		cancel()
+	}()
+
+	if err := sup.Supervise(ctx); err != nil {
+		fmt.Fprintf(os.Stderr, "launcher run: %v\n", err)
+		return 1
+	}
+	return 0
+}
+
+func runSwap(args []string) int {
+	fs := flag.NewFlagSet("swap", flag.ExitOnError)
+	root := fs.String("root", defaultRoot(), "Install root holding current.txt + versions/")
+	if err := fs.Parse(args); err != nil {
+		fmt.Fprintf(os.Stderr, "launcher swap: %v\n", err)
+		return 2
+	}
+	if fs.NArg() != 2 {
+		fmt.Fprintf(os.Stderr, "launcher swap: usage: cfgms-steward-launcher swap <version> <source-exe>\n")
+		return 2
+	}
+
+	layout := Layout{Root: *root, StewardBinaryName: defaultStewardBinaryName()}
+	version := fs.Arg(0)
+	sourceExe := fs.Arg(1)
+
+	dst, err := layout.StageBinary(version, sourceExe)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "launcher swap: %v\n", err)
+		return 1
+	}
+	fmt.Fprintf(os.Stdout, "launcher: staged %q as version %q at %q\n", sourceExe, version, dst)
+	fmt.Fprintf(os.Stdout, "launcher: next steward restart will exec the new version\n")
+	return 0
+}
+
+func runRollback(args []string) int {
+	fs := flag.NewFlagSet("rollback", flag.ExitOnError)
+	root := fs.String("root", defaultRoot(), "Install root holding current.txt + versions/")
+	if err := fs.Parse(args); err != nil {
+		fmt.Fprintf(os.Stderr, "launcher rollback: %v\n", err)
+		return 2
+	}
+
+	layout := Layout{Root: *root, StewardBinaryName: defaultStewardBinaryName()}
+	newCurrent, err := layout.Rollback()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "launcher rollback: %v\n", err)
+		return 1
+	}
+	fmt.Fprintf(os.Stdout, "launcher: rolled back; new active version is %q\n", newCurrent)
+	fmt.Fprintf(os.Stdout, "launcher: next steward restart will exec the rolled-back version\n")
+	return 0
+}
+
+func runStatus(args []string) int {
+	fs := flag.NewFlagSet("status", flag.ExitOnError)
+	root := fs.String("root", defaultRoot(), "Install root holding current.txt + versions/")
+	if err := fs.Parse(args); err != nil {
+		fmt.Fprintf(os.Stderr, "launcher status: %v\n", err)
+		return 2
+	}
+
+	layout := Layout{Root: *root, StewardBinaryName: defaultStewardBinaryName()}
+	current, _ := layout.ReadCurrent()
+	previous, _ := layout.ReadPrevious()
+	if current == "" {
+		current = "<none>"
+	}
+	if previous == "" {
+		previous = "<none>"
+	}
+	fmt.Fprintf(os.Stdout, "Root:     %s\n", *root)
+	fmt.Fprintf(os.Stdout, "Current:  %s\n", current)
+	fmt.Fprintf(os.Stdout, "Previous: %s\n", previous)
+	return 0
+}
+
+// defaultRoot returns the OS-conventional install root for the steward.
+// Operators can override with --root on any subcommand for testing.
+func defaultRoot() string {
+	switch runtime.GOOS {
+	case "windows":
+		programFiles := os.Getenv("ProgramFiles")
+		if programFiles == "" {
+			programFiles = `C:\Program Files`
+		}
+		return filepath.Join(programFiles, "CFGMS")
+	default:
+		return "/opt/cfgms"
+	}
+}
+
+// defaultStewardBinaryName returns the OS-conventional name of the steward
+// binary inside each versions/<name>/ directory.
+func defaultStewardBinaryName() string {
+	if runtime.GOOS == "windows" {
+		return "cfgms-steward.exe"
+	}
+	return "cfgms-steward"
+}

--- a/cmd/cfgms-steward-launcher/service_other.go
+++ b/cmd/cfgms-steward-launcher/service_other.go
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+
+//go:build !windows
+
+// Non-Windows stub for the Windows-service entry point. On Linux and
+// macOS the launcher is invoked by systemd/launchd as a regular
+// process — no special service-handshake dance is required.
+
+package main
+
+func tryRunAsService() bool { return false }

--- a/cmd/cfgms-steward-launcher/service_windows.go
+++ b/cmd/cfgms-steward-launcher/service_windows.go
@@ -1,0 +1,121 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+
+//go:build windows
+
+// Windows Service Control Manager integration.
+//
+// When the SCM invokes the launcher with no console (the StartService
+// path), the binary must call svc.Run with a Handler that reports
+// SERVICE_RUNNING within ~30s and responds to control codes (Stop,
+// Shutdown, Interrogate). Without this the SCM kills the process with
+// "Error 1053: the service did not respond in a timely fashion."
+//
+// tryRunAsService detects the SCM-invoked context via
+// svc.IsWindowsService(). When it returns true we never come back —
+// the function calls os.Exit after svc.Run completes (success or
+// failure). When it returns false (interactive invocation, e.g. an
+// operator running `cfgms-steward-launcher status`) main() proceeds
+// with normal CLI handling.
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"golang.org/x/sys/windows/svc"
+)
+
+// tryRunAsService returns true after handing control to svc.Run; the
+// caller should treat that as "process is done." Returns false if
+// we're NOT running under the SCM (interactive console invocation) so
+// the caller falls through to the regular CLI dispatch.
+func tryRunAsService() bool {
+	isService, err := svc.IsWindowsService()
+	if err != nil {
+		// Defensive: log to stderr (which the console branch will
+		// honour) and fall through to interactive.
+		fmt.Fprintf(os.Stderr, "launcher: svc.IsWindowsService failed: %v\n", err)
+		return false
+	}
+	if !isService {
+		return false
+	}
+	// We're under the SCM. Hand off to svc.Run, which blocks until the
+	// service stops. Any error from Run propagates to the OS as a
+	// non-zero process exit.
+	if err := svc.Run("cfgms-steward-launcher", &windowsServiceHandler{args: os.Args[1:]}); err != nil {
+		fmt.Fprintf(os.Stderr, "launcher: svc.Run failed: %v\n", err)
+		os.Exit(1)
+	}
+	os.Exit(0)
+	return true // unreachable, but the signature needs a return
+}
+
+// windowsServiceHandler bridges the SCM control protocol to the
+// launcher's regular Supervise loop.
+//
+// On Start: report StartPending, kick off runSuperviseWithCtx in a
+// goroutine, then report Running.
+// On Stop/Shutdown: cancel the context, wait for Supervise to return,
+// report Stopped.
+// On Interrogate: echo back the last known status.
+// On supervise-exit-on-its-own: report Stopped with the launcher's
+// return code as the service-specific exit code.
+type windowsServiceHandler struct {
+	// args is os.Args[1:] from the original launcher invocation —
+	// typically ["run", "--child-args", "..."]. The handler strips a
+	// leading "run" if present, since runSuperviseWithCtx parses the
+	// `run` flag set directly.
+	args []string
+}
+
+func (h *windowsServiceHandler) Execute(_ []string, r <-chan svc.ChangeRequest, status chan<- svc.Status) (bool, uint32) {
+	status <- svc.Status{State: svc.StartPending}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Filter the leading subcommand token if present so the supervise
+	// helper sees only its own flags.
+	superviseArgs := h.args
+	if len(superviseArgs) > 0 && superviseArgs[0] == "run" {
+		superviseArgs = superviseArgs[1:]
+	}
+
+	done := make(chan int, 1)
+	go func() {
+		done <- runSuperviseWithCtx(ctx, superviseArgs)
+	}()
+
+	const accepts = svc.AcceptStop | svc.AcceptShutdown
+	status <- svc.Status{State: svc.Running, Accepts: accepts}
+
+	for {
+		select {
+		case req := <-r:
+			switch req.Cmd {
+			case svc.Interrogate:
+				status <- req.CurrentStatus
+			case svc.Stop, svc.Shutdown:
+				status <- svc.Status{State: svc.StopPending}
+				cancel()
+				// Wait for the supervise goroutine to finish so the SCM
+				// knows we've fully released resources. Bounded by the
+				// SCM's own stop timeout (usually 30s).
+				code := <-done
+				status <- svc.Status{State: svc.Stopped}
+				return false, uint32(code)
+			}
+		case code := <-done:
+			// Supervise exited on its own (e.g. broken child, no
+			// rollback available). Report Stopped with the actual
+			// exit code so the SCM can log + apply recovery actions.
+			cancel()
+			status <- svc.Status{State: svc.Stopped}
+			return false, uint32(code)
+		}
+	}
+}

--- a/cmd/cfgms-steward-launcher/state.go
+++ b/cmd/cfgms-steward-launcher/state.go
@@ -3,6 +3,7 @@
 package main
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
@@ -13,18 +14,28 @@ import (
 // Layout describes the on-disk binary layout the launcher manages.
 //
 //	<Root>/
-//	    cfgms-steward-launcher.exe       ← the OS service binary
-//	    current.txt                       ← name of the currently-active version
-//	    previous.txt                      ← name of the previous-good version (for rollback)
+//	    cfgms-steward-launcher.exe   ← the OS service binary
+//	    state.json                    ← {current, previous} written atomically
 //	    versions/
-//	        <name1>/
-//	            cfgms-steward(.exe)
-//	        <name2>/
-//	            cfgms-steward(.exe)
+//	        <name1>/cfgms-steward(.exe)
+//	        <name2>/cfgms-steward(.exe)
 //
 // Version "name" is operator-chosen — typically a content hash, semver, or
 // short slug. The launcher never assigns one; the caller of swap() decides.
 // This keeps the launcher boring + free of any hashing/dependency surface.
+//
+// # Why a single state.json
+//
+// Earlier revisions stored current + previous in separate files
+// (current.txt, previous.txt). A crash between writing one and writing
+// the other could leave the launcher's pointer state inconsistent
+// (e.g. current.txt pointed at the broken upgrade but previous.txt
+// still pointed at the version BEFORE the previous-known-good). A
+// single JSON document written via temp-file + rename is atomic under
+// every supported filesystem and removes the two-write window
+// entirely. Old single-file pointers (current.txt / previous.txt) are
+// still read on startup if state.json is missing — one-time migration
+// for installations that booted before this commit.
 type Layout struct {
 	// Root is the install directory. On Windows that's C:\Program Files\CFGMS;
 	// on Linux it might be /opt/cfgms or /usr/local/cfgms; on macOS
@@ -40,13 +51,26 @@ type Layout struct {
 	StewardBinaryName string
 }
 
-// CurrentPath returns the path of the file recording the active version
-// name. The file's contents (a single line, no decoration) name the
-// subdirectory under versions/ to exec from.
+// pointerState is the JSON document persisted to state.json. Older
+// installations may not have this file yet, in which case the loader
+// falls back to the deprecated single-line pointer files (current.txt /
+// previous.txt).
+type pointerState struct {
+	Current  string `json:"current"`
+	Previous string `json:"previous,omitempty"`
+}
+
+// StatePath returns the path of the single JSON document that records
+// both the active version and the previous-good version.
+func (l Layout) StatePath() string { return filepath.Join(l.Root, "state.json") }
+
+// CurrentPath returns the path of the legacy single-line pointer file
+// recording the active version name. Kept for the one-time migration
+// path; new writes always go to state.json.
 func (l Layout) CurrentPath() string { return filepath.Join(l.Root, "current.txt") }
 
-// PreviousPath returns the path of the file recording the previous-good
-// version name. Used by Rollback().
+// PreviousPath returns the path of the legacy single-line pointer file
+// recording the previous-good version name. Kept for the migration path.
 func (l Layout) PreviousPath() string { return filepath.Join(l.Root, "previous.txt") }
 
 // VersionsDir returns the path of the directory holding all installed
@@ -65,10 +89,16 @@ func (l Layout) StewardExeFor(version string) (string, error) {
 }
 
 // validateVersion rejects empty strings and path-traversal candidates so a
-// malformed current.txt or operator typo can't read or write outside the
+// malformed state file or operator typo can't read or write outside the
 // versions directory. The launcher never tries to *interpret* the version
 // name beyond this check — version IDs are opaque tags chosen by the
 // operator (typically a content hash or semver).
+//
+// The ".." check rejects the substring (not just the exact value)
+// because filepath.Join("a..b") still produces an in-bounds path on
+// every platform — but a value like "../../etc/passwd" would escape.
+// Multi-dot semver pre-release tags ("v1.2.3-beta..1") are rejected;
+// operators using semver should drop the empty segment.
 func validateVersion(v string) error {
 	if v == "" {
 		return errors.New("launcher: version name must not be empty")
@@ -79,65 +109,80 @@ func validateVersion(v string) error {
 	return nil
 }
 
-// ReadCurrent returns the version name recorded in current.txt. Empty
-// string + nil error means "no version currently active" — caller decides
-// whether that's a fresh install or a configuration error.
-func (l Layout) ReadCurrent() (string, error) {
-	return readVersionFile(l.CurrentPath())
+// loadState reads the combined pointer state. If state.json exists it
+// is the source of truth; otherwise the loader falls back to the two
+// legacy pointer files for the one-time migration. Missing state with
+// missing legacy files is reported as zero-value (Current=="", no error)
+// so callers can distinguish "fresh install" from "read error."
+func (l Layout) loadState() (pointerState, error) {
+	if raw, err := os.ReadFile(l.StatePath()); err == nil { //#nosec G304 -- launcher owns its install root
+		var ps pointerState
+		if jerr := json.Unmarshal(raw, &ps); jerr != nil {
+			return pointerState{}, fmt.Errorf("launcher: parse state.json: %w", jerr)
+		}
+		return ps, nil
+	} else if !os.IsNotExist(err) {
+		return pointerState{}, err
+	}
+	// Legacy fallback: synthesise from the old single-line files.
+	cur, err := readLegacyPointer(l.CurrentPath())
+	if err != nil {
+		return pointerState{}, err
+	}
+	prev, err := readLegacyPointer(l.PreviousPath())
+	if err != nil {
+		return pointerState{}, err
+	}
+	return pointerState{Current: cur, Previous: prev}, nil
 }
 
-// ReadPrevious returns the version name recorded in previous.txt. Empty
-// string + nil error means "no rollback target available."
-func (l Layout) ReadPrevious() (string, error) {
-	return readVersionFile(l.PreviousPath())
-}
-
-// WriteCurrent atomically updates the active version. The previous value
-// is preserved in previous.txt so Rollback() can restore it.
-//
-// Atomicity is achieved by writing to a sibling temp file then renaming
-// over the target — on every supported OS, rename of a file within the
-// same directory is atomic with respect to readers that open by path.
-func (l Layout) WriteCurrent(version string) error {
-	if err := validateVersion(version); err != nil {
+// saveState writes the combined pointer state atomically. The whole
+// document lands via temp-file + rename so a reader is guaranteed to
+// observe either the pre-write state or the post-write state — never
+// a partially-updated one.
+func (l Layout) saveState(ps pointerState) error {
+	if err := os.MkdirAll(l.Root, 0o755); err != nil {
 		return err
 	}
-	// Stash the existing current as previous (so rollback can restore it).
-	if existing, err := l.ReadCurrent(); err == nil && existing != "" && existing != version {
-		if writeErr := writeVersionFile(l.PreviousPath(), existing); writeErr != nil {
-			return fmt.Errorf("launcher: stage previous version: %w", writeErr)
+	raw, err := json.Marshal(ps)
+	if err != nil {
+		return err
+	}
+	statePath := l.StatePath()
+	dir := filepath.Dir(statePath)
+	tmp, err := os.CreateTemp(dir, ".state-*.tmp")
+	if err != nil {
+		return err
+	}
+	tmpPath := tmp.Name()
+	success := false
+	defer func() {
+		if !success {
+			_ = os.Remove(tmpPath)
 		}
+	}()
+	if _, err := tmp.Write(raw); err != nil {
+		_ = tmp.Close()
+		return err
 	}
-	return writeVersionFile(l.CurrentPath(), version)
+	if err := tmp.Sync(); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	if err := os.Rename(tmpPath, statePath); err != nil {
+		return err
+	}
+	success = true
+	return nil
 }
 
-// Rollback swaps current and previous: the previously-recorded version
-// becomes active, and the currently-active version is recorded as the new
-// previous (so the rollback itself is reversible).
-//
-// Returns the name of the newly-active version on success.
-func (l Layout) Rollback() (string, error) {
-	current, err := l.ReadCurrent()
-	if err != nil {
-		return "", fmt.Errorf("launcher: read current: %w", err)
-	}
-	previous, err := l.ReadPrevious()
-	if err != nil {
-		return "", fmt.Errorf("launcher: read previous: %w", err)
-	}
-	if previous == "" {
-		return "", errors.New("launcher: no previous version recorded — nothing to roll back to")
-	}
-	if err := writeVersionFile(l.CurrentPath(), previous); err != nil {
-		return "", fmt.Errorf("launcher: write current during rollback: %w", err)
-	}
-	if err := writeVersionFile(l.PreviousPath(), current); err != nil {
-		return "", fmt.Errorf("launcher: write previous during rollback: %w", err)
-	}
-	return previous, nil
-}
-
-func readVersionFile(p string) (string, error) {
+// readLegacyPointer reads a deprecated single-line pointer file.
+// Returns "" on os.IsNotExist so callers can treat "no legacy file"
+// as "no pointer" without distinguishing it from "couldn't read."
+func readLegacyPointer(p string) (string, error) {
 	b, err := os.ReadFile(p) //#nosec G304 -- launcher owns these paths
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -148,13 +193,62 @@ func readVersionFile(p string) (string, error) {
 	return strings.TrimSpace(string(b)), nil
 }
 
-func writeVersionFile(p, value string) error {
-	if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
-		return err
-	}
-	tmp := p + ".tmp"
-	if err := os.WriteFile(tmp, []byte(value+"\n"), 0o644); err != nil { //#nosec G306 -- version pointers are plaintext, no secrets
-		return err
-	}
-	return os.Rename(tmp, p)
+// ReadCurrent returns the version name currently active. Empty string +
+// nil error means "no version currently active."
+func (l Layout) ReadCurrent() (string, error) {
+	ps, err := l.loadState()
+	return ps.Current, err
 }
+
+// ReadPrevious returns the version name recorded as the previous-good
+// rollback target. Empty string + nil error means "no rollback target
+// available."
+func (l Layout) ReadPrevious() (string, error) {
+	ps, err := l.loadState()
+	return ps.Previous, err
+}
+
+// WriteCurrent atomically updates the active version. The previously
+// active version (if any, and if different) is preserved in the
+// "previous" slot so Rollback() can restore it.
+//
+// Both fields land in one rename operation, so a crash mid-call leaves
+// the launcher in either the pre-call or post-call state — never a
+// partial one. This is the property that the earlier two-file
+// representation could not provide.
+func (l Layout) WriteCurrent(version string) error {
+	if err := validateVersion(version); err != nil {
+		return err
+	}
+	ps, err := l.loadState()
+	if err != nil {
+		return err
+	}
+	if ps.Current != "" && ps.Current != version {
+		ps.Previous = ps.Current
+	}
+	ps.Current = version
+	return l.saveState(ps)
+}
+
+// Rollback swaps current and previous: the previously-recorded version
+// becomes active, and the currently-active version is recorded as the new
+// previous (so the rollback itself is reversible). Both fields update
+// in one atomic rename.
+//
+// Returns the name of the newly-active version on success.
+func (l Layout) Rollback() (string, error) {
+	ps, err := l.loadState()
+	if err != nil {
+		return "", err
+	}
+	if ps.Previous == "" {
+		return "", errors.New("launcher: no previous version recorded — nothing to roll back to")
+	}
+	newPS := pointerState{Current: ps.Previous, Previous: ps.Current}
+	if err := l.saveState(newPS); err != nil {
+		return "", err
+	}
+	return newPS.Current, nil
+}
+

--- a/cmd/cfgms-steward-launcher/state.go
+++ b/cmd/cfgms-steward-launcher/state.go
@@ -1,0 +1,160 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+package main
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// Layout describes the on-disk binary layout the launcher manages.
+//
+//	<Root>/
+//	    cfgms-steward-launcher.exe       ← the OS service binary
+//	    current.txt                       ← name of the currently-active version
+//	    previous.txt                      ← name of the previous-good version (for rollback)
+//	    versions/
+//	        <name1>/
+//	            cfgms-steward(.exe)
+//	        <name2>/
+//	            cfgms-steward(.exe)
+//
+// Version "name" is operator-chosen — typically a content hash, semver, or
+// short slug. The launcher never assigns one; the caller of swap() decides.
+// This keeps the launcher boring + free of any hashing/dependency surface.
+type Layout struct {
+	// Root is the install directory. On Windows that's C:\Program Files\CFGMS;
+	// on Linux it might be /opt/cfgms or /usr/local/cfgms; on macOS
+	// /usr/local/cfgms. Default flag picks the OS-conventional location;
+	// operators can override with --root for testing or non-standard installs.
+	Root string
+
+	// StewardBinaryName is the file name the steward binary lives under
+	// inside each versions/<name>/ directory. Platform-default
+	// "cfgms-steward.exe" on Windows; "cfgms-steward" on Unix. The launcher
+	// never opens this file directly — only exec's it — so the lookup
+	// happens just before fork.
+	StewardBinaryName string
+}
+
+// CurrentPath returns the path of the file recording the active version
+// name. The file's contents (a single line, no decoration) name the
+// subdirectory under versions/ to exec from.
+func (l Layout) CurrentPath() string { return filepath.Join(l.Root, "current.txt") }
+
+// PreviousPath returns the path of the file recording the previous-good
+// version name. Used by Rollback().
+func (l Layout) PreviousPath() string { return filepath.Join(l.Root, "previous.txt") }
+
+// VersionsDir returns the path of the directory holding all installed
+// steward binary versions.
+func (l Layout) VersionsDir() string { return filepath.Join(l.Root, "versions") }
+
+// StewardExeFor returns the path of the steward binary inside the named
+// version directory. The version is the operator-chosen subdirectory
+// name; the launcher never validates it beyond rejecting empty strings
+// and obvious path traversal.
+func (l Layout) StewardExeFor(version string) (string, error) {
+	if err := validateVersion(version); err != nil {
+		return "", err
+	}
+	return filepath.Join(l.VersionsDir(), version, l.StewardBinaryName), nil
+}
+
+// validateVersion rejects empty strings and path-traversal candidates so a
+// malformed current.txt or operator typo can't read or write outside the
+// versions directory. The launcher never tries to *interpret* the version
+// name beyond this check — version IDs are opaque tags chosen by the
+// operator (typically a content hash or semver).
+func validateVersion(v string) error {
+	if v == "" {
+		return errors.New("launcher: version name must not be empty")
+	}
+	if strings.Contains(v, "..") || strings.ContainsRune(v, '/') || strings.ContainsRune(v, '\\') {
+		return fmt.Errorf("launcher: version name must not contain path separators or dot sequences: %q", v)
+	}
+	return nil
+}
+
+// ReadCurrent returns the version name recorded in current.txt. Empty
+// string + nil error means "no version currently active" — caller decides
+// whether that's a fresh install or a configuration error.
+func (l Layout) ReadCurrent() (string, error) {
+	return readVersionFile(l.CurrentPath())
+}
+
+// ReadPrevious returns the version name recorded in previous.txt. Empty
+// string + nil error means "no rollback target available."
+func (l Layout) ReadPrevious() (string, error) {
+	return readVersionFile(l.PreviousPath())
+}
+
+// WriteCurrent atomically updates the active version. The previous value
+// is preserved in previous.txt so Rollback() can restore it.
+//
+// Atomicity is achieved by writing to a sibling temp file then renaming
+// over the target — on every supported OS, rename of a file within the
+// same directory is atomic with respect to readers that open by path.
+func (l Layout) WriteCurrent(version string) error {
+	if err := validateVersion(version); err != nil {
+		return err
+	}
+	// Stash the existing current as previous (so rollback can restore it).
+	if existing, err := l.ReadCurrent(); err == nil && existing != "" && existing != version {
+		if writeErr := writeVersionFile(l.PreviousPath(), existing); writeErr != nil {
+			return fmt.Errorf("launcher: stage previous version: %w", writeErr)
+		}
+	}
+	return writeVersionFile(l.CurrentPath(), version)
+}
+
+// Rollback swaps current and previous: the previously-recorded version
+// becomes active, and the currently-active version is recorded as the new
+// previous (so the rollback itself is reversible).
+//
+// Returns the name of the newly-active version on success.
+func (l Layout) Rollback() (string, error) {
+	current, err := l.ReadCurrent()
+	if err != nil {
+		return "", fmt.Errorf("launcher: read current: %w", err)
+	}
+	previous, err := l.ReadPrevious()
+	if err != nil {
+		return "", fmt.Errorf("launcher: read previous: %w", err)
+	}
+	if previous == "" {
+		return "", errors.New("launcher: no previous version recorded — nothing to roll back to")
+	}
+	if err := writeVersionFile(l.CurrentPath(), previous); err != nil {
+		return "", fmt.Errorf("launcher: write current during rollback: %w", err)
+	}
+	if err := writeVersionFile(l.PreviousPath(), current); err != nil {
+		return "", fmt.Errorf("launcher: write previous during rollback: %w", err)
+	}
+	return previous, nil
+}
+
+func readVersionFile(p string) (string, error) {
+	b, err := os.ReadFile(p) //#nosec G304 -- launcher owns these paths
+	if err != nil {
+		if os.IsNotExist(err) {
+			return "", nil
+		}
+		return "", err
+	}
+	return strings.TrimSpace(string(b)), nil
+}
+
+func writeVersionFile(p, value string) error {
+	if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+		return err
+	}
+	tmp := p + ".tmp"
+	if err := os.WriteFile(tmp, []byte(value+"\n"), 0o644); err != nil { //#nosec G306 -- version pointers are plaintext, no secrets
+		return err
+	}
+	return os.Rename(tmp, p)
+}

--- a/cmd/cfgms-steward-launcher/state_test.go
+++ b/cmd/cfgms-steward-launcher/state_test.go
@@ -138,20 +138,94 @@ func TestRollback_NoPreviousReturnsError(t *testing.T) {
 	}
 }
 
-func TestReadVersionFile_TrimsTrailingNewline(t *testing.T) {
+func TestReadLegacyPointer_TrimsTrailingNewline(t *testing.T) {
 	dir := t.TempDir()
 	p := filepath.Join(dir, "current.txt")
 	if err := os.WriteFile(p, []byte("v1\n\n"), 0o600); err != nil {
 		t.Fatalf("write: %v", err)
 	}
-	got, err := readVersionFile(p)
+	got, err := readLegacyPointer(p)
 	if err != nil {
-		t.Fatalf("readVersionFile: %v", err)
+		t.Fatalf("readLegacyPointer: %v", err)
 	}
 	if got != "v1" {
-		t.Errorf("readVersionFile = %q, want %q", got, "v1")
+		t.Errorf("readLegacyPointer = %q, want %q", got, "v1")
 	}
 	if strings.ContainsAny(got, " \t\r\n") {
-		t.Errorf("readVersionFile returned whitespace: %q", got)
+		t.Errorf("readLegacyPointer returned whitespace: %q", got)
+	}
+}
+
+// TestLayout_LegacyPointerMigration verifies installations that booted
+// before state.json existed (with current.txt + previous.txt as the
+// pointer files) are correctly read on first load. After a WriteCurrent
+// call all subsequent reads come from state.json.
+func TestLayout_LegacyPointerMigration(t *testing.T) {
+	l := newLayout(t)
+	require := func(cond bool, msg string) {
+		t.Helper()
+		if !cond {
+			t.Fatal(msg)
+		}
+	}
+
+	// Pre-seed legacy single-line pointer files like an older installation.
+	require(os.WriteFile(l.CurrentPath(), []byte("v-legacy-current\n"), 0o600) == nil, "write legacy current.txt")
+	require(os.WriteFile(l.PreviousPath(), []byte("v-legacy-previous\n"), 0o600) == nil, "write legacy previous.txt")
+
+	cur, err := l.ReadCurrent()
+	if err != nil {
+		t.Fatalf("ReadCurrent: %v", err)
+	}
+	if cur != "v-legacy-current" {
+		t.Errorf("ReadCurrent = %q, want v-legacy-current", cur)
+	}
+	prev, err := l.ReadPrevious()
+	if err != nil {
+		t.Fatalf("ReadPrevious: %v", err)
+	}
+	if prev != "v-legacy-previous" {
+		t.Errorf("ReadPrevious = %q, want v-legacy-previous", prev)
+	}
+
+	// After WriteCurrent, the canonical source is state.json. The
+	// previous slot must still hold v-legacy-current (the value
+	// previously in current.txt) so a Rollback would still work.
+	if err := l.WriteCurrent("v-new"); err != nil {
+		t.Fatalf("WriteCurrent: %v", err)
+	}
+	if _, err := os.Stat(l.StatePath()); err != nil {
+		t.Errorf("state.json must exist after WriteCurrent: %v", err)
+	}
+	cur, _ = l.ReadCurrent()
+	prev, _ = l.ReadPrevious()
+	if cur != "v-new" || prev != "v-legacy-current" {
+		t.Errorf("post-migration state: current=%q previous=%q, want v-new / v-legacy-current", cur, prev)
+	}
+}
+
+// TestLayout_StateJSONAtomicity verifies the single-file pointer state
+// is the only on-disk source after migration: a manually corrupted
+// state.json results in a parse error, NOT a fallback to the legacy
+// files (because state.json existing is the signal that migration has
+// happened — silently re-reading the stale legacy files would mask
+// data loss).
+func TestLayout_StateJSONCorruption_DoesNotFallBack(t *testing.T) {
+	l := newLayout(t)
+	if err := l.WriteCurrent("v1"); err != nil {
+		t.Fatalf("WriteCurrent: %v", err)
+	}
+	// Corrupt state.json — write garbage that's not valid JSON.
+	if err := os.WriteFile(l.StatePath(), []byte("garbage{"), 0o600); err != nil {
+		t.Fatalf("corrupt write: %v", err)
+	}
+	// Pre-seed legacy files as a tempting-but-wrong fallback target.
+	if err := os.WriteFile(l.CurrentPath(), []byte("v-old-legacy\n"), 0o600); err != nil {
+		t.Fatalf("legacy write: %v", err)
+	}
+
+	_, err := l.ReadCurrent()
+	if err == nil {
+		t.Fatal("ReadCurrent must surface the state.json parse error, not silently fall back to current.txt")
 	}
 }

--- a/cmd/cfgms-steward-launcher/state_test.go
+++ b/cmd/cfgms-steward-launcher/state_test.go
@@ -1,0 +1,157 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func newLayout(t *testing.T) Layout {
+	t.Helper()
+	return Layout{
+		Root:              t.TempDir(),
+		StewardBinaryName: defaultStewardBinaryName(),
+	}
+}
+
+func TestLayout_PathsRoutedThroughRoot(t *testing.T) {
+	// Use a literal binary name so the path assertions below stay
+	// platform-independent; the launcher itself is OS-agnostic.
+	l := Layout{Root: "/opt/cfgms", StewardBinaryName: "cfgms-steward"}
+
+	if got, want := l.CurrentPath(), filepath.Join("/opt/cfgms", "current.txt"); got != want {
+		t.Errorf("CurrentPath = %q, want %q", got, want)
+	}
+	if got, want := l.PreviousPath(), filepath.Join("/opt/cfgms", "previous.txt"); got != want {
+		t.Errorf("PreviousPath = %q, want %q", got, want)
+	}
+	if got, want := l.VersionsDir(), filepath.Join("/opt/cfgms", "versions"); got != want {
+		t.Errorf("VersionsDir = %q, want %q", got, want)
+	}
+
+	exe, err := l.StewardExeFor("v1")
+	if err != nil {
+		t.Fatalf("StewardExeFor: %v", err)
+	}
+	if want := filepath.Join("/opt/cfgms", "versions", "v1", "cfgms-steward"); exe != want {
+		t.Errorf("StewardExeFor = %q, want %q", exe, want)
+	}
+}
+
+func TestValidateVersion_RejectsBadInput(t *testing.T) {
+	bad := []string{"", "..", "../escape", "a/b", `a\b`, "..\\evil", "v/1"}
+	for _, v := range bad {
+		if err := validateVersion(v); err == nil {
+			t.Errorf("validateVersion(%q) = nil, want error", v)
+		}
+	}
+	good := []string{"v1", "v1.2.3", "abc123", "release-2026.06", "sha256-deadbeef"}
+	for _, v := range good {
+		if err := validateVersion(v); err != nil {
+			t.Errorf("validateVersion(%q) = %v, want nil", v, err)
+		}
+	}
+}
+
+func TestReadCurrent_MissingFileReturnsEmpty(t *testing.T) {
+	l := newLayout(t)
+	got, err := l.ReadCurrent()
+	if err != nil {
+		t.Fatalf("ReadCurrent on fresh layout: %v", err)
+	}
+	if got != "" {
+		t.Errorf("ReadCurrent = %q, want empty string for missing current.txt", got)
+	}
+}
+
+func TestWriteCurrent_StagesPreviousOnReplace(t *testing.T) {
+	l := newLayout(t)
+
+	if err := l.WriteCurrent("v1"); err != nil {
+		t.Fatalf("WriteCurrent v1: %v", err)
+	}
+	if prev, _ := l.ReadPrevious(); prev != "" {
+		t.Errorf("after first WriteCurrent previous = %q, want empty", prev)
+	}
+
+	if err := l.WriteCurrent("v2"); err != nil {
+		t.Fatalf("WriteCurrent v2: %v", err)
+	}
+	cur, _ := l.ReadCurrent()
+	prev, _ := l.ReadPrevious()
+	if cur != "v2" || prev != "v1" {
+		t.Errorf("after WriteCurrent v2: current=%q previous=%q, want current=v2 previous=v1", cur, prev)
+	}
+}
+
+func TestWriteCurrent_SameVersionDoesNotShufflePrevious(t *testing.T) {
+	l := newLayout(t)
+	if err := l.WriteCurrent("v1"); err != nil {
+		t.Fatalf("WriteCurrent v1: %v", err)
+	}
+	if err := l.WriteCurrent("v2"); err != nil {
+		t.Fatalf("WriteCurrent v2: %v", err)
+	}
+	// Re-writing the same current value must not blow away the rollback target.
+	if err := l.WriteCurrent("v2"); err != nil {
+		t.Fatalf("WriteCurrent v2 again: %v", err)
+	}
+	prev, _ := l.ReadPrevious()
+	if prev != "v1" {
+		t.Errorf("previous = %q, want v1 (not shuffled away by no-op WriteCurrent)", prev)
+	}
+}
+
+func TestRollback_SwapsCurrentAndPrevious(t *testing.T) {
+	l := newLayout(t)
+	if err := l.WriteCurrent("v1"); err != nil {
+		t.Fatalf("WriteCurrent v1: %v", err)
+	}
+	if err := l.WriteCurrent("v2"); err != nil {
+		t.Fatalf("WriteCurrent v2: %v", err)
+	}
+
+	newCur, err := l.Rollback()
+	if err != nil {
+		t.Fatalf("Rollback: %v", err)
+	}
+	if newCur != "v1" {
+		t.Errorf("Rollback returned %q, want v1", newCur)
+	}
+	cur, _ := l.ReadCurrent()
+	prev, _ := l.ReadPrevious()
+	if cur != "v1" || prev != "v2" {
+		t.Errorf("after rollback: current=%q previous=%q, want current=v1 previous=v2", cur, prev)
+	}
+}
+
+func TestRollback_NoPreviousReturnsError(t *testing.T) {
+	l := newLayout(t)
+	if err := l.WriteCurrent("v1"); err != nil {
+		t.Fatalf("WriteCurrent v1: %v", err)
+	}
+	if _, err := l.Rollback(); err == nil {
+		t.Fatal("Rollback with no previous returned nil error, want error")
+	}
+}
+
+func TestReadVersionFile_TrimsTrailingNewline(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "current.txt")
+	if err := os.WriteFile(p, []byte("v1\n\n"), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	got, err := readVersionFile(p)
+	if err != nil {
+		t.Fatalf("readVersionFile: %v", err)
+	}
+	if got != "v1" {
+		t.Errorf("readVersionFile = %q, want %q", got, "v1")
+	}
+	if strings.ContainsAny(got, " \t\r\n") {
+		t.Errorf("readVersionFile returned whitespace: %q", got)
+	}
+}

--- a/cmd/cfgms-steward-launcher/swap.go
+++ b/cmd/cfgms-steward-launcher/swap.go
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+package main
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+)
+
+// StageBinary copies sourceExe into <Root>/versions/<version>/<StewardBinaryName>
+// and updates current.txt to point at it. Returns the path the new binary
+// landed at.
+//
+// Atomic-ish: the binary lands at a sibling temp file first, then is
+// renamed into place. current.txt update is its own atomic write.
+//
+// This is the only WRITE the swap surface exposes — the launcher does
+// NOT delete the previous-version directory. Retention is a separate
+// concern (epic #1917 Story D).
+func (l Layout) StageBinary(version, sourceExe string) (string, error) {
+	if err := validateVersion(version); err != nil {
+		return "", err
+	}
+
+	dst, err := l.StewardExeFor(version)
+	if err != nil {
+		return "", fmt.Errorf("launcher: resolve destination for %q: %w", version, err)
+	}
+
+	if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
+		return "", fmt.Errorf("launcher: create version dir: %w", err)
+	}
+
+	if err := copyFile(sourceExe, dst); err != nil {
+		return "", fmt.Errorf("launcher: copy steward exe into version dir: %w", err)
+	}
+
+	if err := l.WriteCurrent(version); err != nil {
+		return "", fmt.Errorf("launcher: update current.txt: %w", err)
+	}
+
+	return dst, nil
+}
+
+// copyFile copies src → dst via a sibling tmp file + rename so the
+// destination either exists with the full content or doesn't exist at all.
+// Preserves 0o755 mode bits on Unix; Windows ignores mode here.
+func copyFile(src, dst string) error {
+	in, err := os.Open(src) //#nosec G304 -- src is supplied by the operator on the CLI
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+
+	tmp := dst + ".tmp"
+	out, err := os.OpenFile(tmp, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o755) //#nosec G302 -- service binary must be executable
+	if err != nil {
+		return err
+	}
+	if _, err := io.Copy(out, in); err != nil {
+		_ = out.Close()
+		_ = os.Remove(tmp)
+		return err
+	}
+	if err := out.Close(); err != nil {
+		_ = os.Remove(tmp)
+		return err
+	}
+
+	if err := os.Rename(tmp, dst); err != nil {
+		_ = os.Remove(tmp)
+		return err
+	}
+	return nil
+}

--- a/cmd/cfgms-steward-launcher/swap_test.go
+++ b/cmd/cfgms-steward-launcher/swap_test.go
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func writeFile(t *testing.T, path string, content []byte) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(path, content, 0o755); err != nil { //nolint:gosec // test fixture
+		t.Fatalf("write: %v", err)
+	}
+}
+
+func TestStageBinary_CopiesAndMarksCurrent(t *testing.T) {
+	l := newLayout(t)
+
+	src := filepath.Join(t.TempDir(), "cfgms-steward-fresh")
+	payload := []byte("fresh-binary-bytes")
+	writeFile(t, src, payload)
+
+	dst, err := l.StageBinary("v1", src)
+	if err != nil {
+		t.Fatalf("StageBinary: %v", err)
+	}
+
+	got, err := os.ReadFile(dst) //nolint:gosec // test
+	if err != nil {
+		t.Fatalf("read staged file: %v", err)
+	}
+	if !bytes.Equal(got, payload) {
+		t.Errorf("staged content = %q, want %q", got, payload)
+	}
+
+	cur, _ := l.ReadCurrent()
+	if cur != "v1" {
+		t.Errorf("current after stage = %q, want v1", cur)
+	}
+}
+
+func TestStageBinary_SecondStageRecordsPrevious(t *testing.T) {
+	l := newLayout(t)
+	src1 := filepath.Join(t.TempDir(), "v1")
+	src2 := filepath.Join(t.TempDir(), "v2")
+	writeFile(t, src1, []byte("first"))
+	writeFile(t, src2, []byte("second"))
+
+	if _, err := l.StageBinary("v1", src1); err != nil {
+		t.Fatalf("StageBinary v1: %v", err)
+	}
+	if _, err := l.StageBinary("v2", src2); err != nil {
+		t.Fatalf("StageBinary v2: %v", err)
+	}
+
+	cur, _ := l.ReadCurrent()
+	prev, _ := l.ReadPrevious()
+	if cur != "v2" || prev != "v1" {
+		t.Errorf("after two stages: current=%q previous=%q, want v2/v1", cur, prev)
+	}
+}
+
+func TestStageBinary_RejectsBadVersion(t *testing.T) {
+	l := newLayout(t)
+	src := filepath.Join(t.TempDir(), "x")
+	writeFile(t, src, []byte("bytes"))
+
+	if _, err := l.StageBinary("../escape", src); err == nil {
+		t.Fatal("StageBinary with traversal version returned nil error")
+	}
+	if _, err := l.StageBinary("", src); err == nil {
+		t.Fatal("StageBinary with empty version returned nil error")
+	}
+}
+
+func TestStageBinary_MissingSourceReturnsError(t *testing.T) {
+	l := newLayout(t)
+	if _, err := l.StageBinary("v1", filepath.Join(t.TempDir(), "does-not-exist")); err == nil {
+		t.Fatal("StageBinary with missing source returned nil error")
+	}
+	// And current.txt must NOT have been written to half-committed state.
+	cur, _ := l.ReadCurrent()
+	if cur != "" {
+		t.Errorf("current.txt = %q after failed stage, want empty (no half-commit)", cur)
+	}
+}


### PR DESCRIPTION
## Summary

Story A of epic #1917 (zero-downtime upgrades). Lands a tiny static
binary the OS service manager registers as the steward "service." The
launcher supervises a versioned steward binary in `versions/<name>/`
and auto-rolls-back to the previous good version when a new one fails
its startup window.

## What changed

**New binary: `cmd/cfgms-steward-launcher/`**

- `state.go` — single atomic `state.json` document with `{current, previous}`. Legacy `current.txt` / `previous.txt` are read on first load for one-time migration.
- `swap.go` — `StageBinary(version, srcExe)` copies binary into `versions/<name>/`, updates `current` pointer.
- `lifecycle.go` — `Supervisor` state machine. Exit inside startup window OR non-zero exit → broken → auto-rollback if `previous` available + budget remains. Clean exit past window → restart.
- `main.go` — CLI: `run` (default — SCM-invoked), `swap`, `rollback`, `status`.

**Makefile wiring** — `make build`, `build-cross-platform`, `build-cross-validate` all include `cfgms-steward-launcher` across the 5 target platforms.

## Layout the launcher manages

```
<Root>/
    cfgms-steward-launcher.exe   ← the OS service binary
    state.json                    ← {current, previous} atomic
    versions/
        <name1>/cfgms-steward(.exe)
        <name2>/cfgms-steward(.exe)
```

## Lifecycle contract

- Exit inside `StartupWindow` (default 30s) → broken → rollback fires if previous + budget available.
- Non-zero exit → broken → same.
- Clean exit past startup window → normal restart.
- Context cancel (SIGTERM from SCM) → exit clean.

`MaxRollbackCycles` default 1; `0` is a legitimate "fail-fast, let SCM retry" choice (review-fixup).

## Validation

- `go test -race ./cmd/cfgms-steward-launcher/`: **22 tests pass** (1.5s on Windows local), including the previously-skipped healthy-child restart test that now uses a 50ms/500ms safety margin.
- Race-enabled `make test` reveals two **pre-existing Windows-only flakes** in `test/unit/controller/` (SQLite file-handle leak / NTFS lock retention) — filed as **#1923**, unrelated to this PR.
- Cross-platform compilation: all 5 platforms build (linux/amd64+arm64, darwin/amd64+arm64, windows/amd64).

## Adversarial review fixes (4 blockers from initial pass)

1. **Atomic pointer state.** Previous `current.txt` + `previous.txt` were two separate writes — crash between them could leave the launcher pointing at one version with `previous` stale. Single `state.json` written via temp+rename eliminates the window.
2. **Context-cancel race.** Old code returned `nil` whenever `ctx.Err() != nil`, silently discarding child failures arriving in the same scheduler turn as a SIGTERM. Now differentiated: post-window cancel propagates as clean shutdown; non-zero exit inside startup window triggers rollback even under cancel.
3. **Windows skip removed** on `TestSupervise_HealthyChild_RestartsWithoutRollback` — the primary deployment target. Now uses a 50ms startup window with 500ms sleep (10× margin against fork+exec overhead).
4. **MaxRollbackCycles=0** is now a legitimate "no auto-rollback" choice instead of being silently coerced to 1.

## Explicitly deferred (acknowledged in commit + this PR)

- **Live install on CFG-70-02** — needs an admin paste from the operator. Logged as a follow-up task in #1917 epic scope.
- **Bundle signature verification at the launcher level** — gated on epic #1882, explicitly out of this story's scope per the original spec.
- **Windows job-object setup for the child process** — currently the launcher and supervised steward share the SCM job object. Documented behaviour; can be tightened in a follow-up.

## Test plan

- [ ] CI: `unit-tests`, `integration-tests`, `Build Gate`, `security-deployment-gate` all green
- [ ] Lint / log-injection / architecture / security scans clean
- [ ] Cross-platform compilation clean

Fixes #1918

🤖 Generated with [Claude Code](https://claude.com/claude-code)