### PR TITLE
controller/api: admin principal has no tenant scope, not hardcoded 'default'

### DIFF
--- a/features/controller/api/middleware.go
+++ b/features/controller/api/middleware.go
@@ -157,7 +157,20 @@ func (s *Server) extractAdminPrincipal(r *http.Request) *Principal {
 		ID:              peerCert.Subject.CommonName,
 		Name:            "mtls-admin:" + peerCert.Subject.CommonName,
 		IsAdmin:         true,
-		TenantID:        "default",
+		// Admin principals have NO tenant scope. Earlier this was
+		// hardcoded to "default" which silently restricted every admin
+		// read to tenant "default" — `cfg steward list` returned 0
+		// records on any deployment with non-default tenants (caught
+		// during the CFG-70-02 launcher install: the host's steward
+		// registered with tenant_id=infra-hyperv via its regtoken; the
+		// admin bundle's cert had IsAdmin=true but TenantID="default"
+		// so handleListStewards never saw it). Empty means
+		// isEmptyFilter() returns true for the admin-no-query case →
+		// GetAllStewards() returns every tenant's stewards.
+		// Handlers that need a fallback tenant for admin WRITES (e.g.
+		// handlers_configs.go) already substitute "default" when this
+		// field is empty.
+		TenantID:        "",
 		CertSerial:      serial,
 		CertFingerprint: hex.EncodeToString(fpSum[:]),
 		CertNotAfter:    peerCert.NotAfter,


### PR DESCRIPTION
## Summary

extractAdminPrincipal hardcoded TenantID=\"default\" on every admin-cert authentication. Handlers like handleListStewards key off context's TenantID for filtering, so this silently restricted admin reads to the \"default\" tenant on every deployment. Stewards registered into non-default tenants became invisible to admin queries even though the admin bundle's IsAdmin=true marker should grant fleet-wide visibility.

## Surfaced

During the CFG-70-02 launcher install for epic #1917 (Story A live validation, 2026-06-07):

- Host's steward registered with \`tenant_id=infra-hyperv\` via its regtoken (regtokens are tenant-scoped).
- Lab admin bundle had \`IsAdmin=true\` but extracted \`TenantID=\"default\"\`.
- \`cfg steward list\` returned \"No stewards registered\" despite the steward actively heartbeating and visible in its own log.

## Fix

Leave TenantID empty for admin principals. Empty TenantID makes \`isEmptyFilter()\` return true in handleListStewards → falls through to \`GetAllStewards()\` → returns every tenant's stewards as IsAdmin=true implies. Admin WRITE paths (\`handlers_configs.go\` etc.) already substitute \"default\" when context TenantID is empty, so writes still land in the default tenant without behaviour change.

## Validation

- \`go test -race ./features/controller/api/\` clean.
- Live-verified against ctrl-01 in the lab: after deploying the patched controller binary, \`cfg steward list\` now returns the infra-hyperv steward with status \"registered\". Pre-deploy: empty list.

## Test plan

- [ ] CI: unit + integration + Build Gate + security gate green
- [ ] Lint / log-injection / arch / security clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)