### PR TITLE
dev: add .gitattributes forcing LF on shell scripts and Go sources

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,36 @@
+# Force LF on text files that are executed in Linux containers.
+#
+# Without this, a Windows host with core.autocrlf=true checks files out with
+# CRLF, and any subsequent docker run that mounts the worktree (e.g. the
+# cfg-agent dispatch flow, dev containers) sees `bash\r: No such file or
+# directory` because the kernel reads the shebang line including the CR.
+
+# Shell scripts — Linux execution
+*.sh        text eol=lf
+*.bash      text eol=lf
+
+# Dockerfile + compose — used by docker, expects LF
+Dockerfile  text eol=lf
+*.dockerfile text eol=lf
+docker-compose*.yml text eol=lf
+
+# Go source — gofmt is LF-only by convention; protect against churn
+*.go        text eol=lf
+
+# Module / pin files used by Go tooling
+go.mod      text eol=lf
+go.sum      text eol=lf
+
+# YAML used by CI and module manifests
+*.yml       text eol=lf
+*.yaml      text eol=lf
+
+# Markdown — keep LF to avoid noisy diffs on cross-platform commits
+*.md        text eol=lf
+
+# Binary catch-all (Git auto-detects but explicit is clearer)
+*.png       binary
+*.jpg       binary
+*.gz        binary
+*.zip       binary
+*.exe       binary


### PR DESCRIPTION
## Summary

Without a `.gitattributes`, a Windows host with `core.autocrlf=true` checks files out with CRLF. The cfg-agent dispatch flow does a local `git clone` of the host worktree into `~/git/worktrees/story-N` and mounts that into a Linux container; the kernel chokes on shebang lines with CR and the agent immediately dies with `bash\r: No such file or directory`.

Hit during a real dispatch test of #1940 today.

## What lands

Forces `eol=lf` on:
- `*.sh`, `*.bash`
- `Dockerfile`, `*.dockerfile`, `docker-compose*.yml`
- `*.go`, `go.mod`, `go.sum`
- `*.yml`, `*.yaml`
- `*.md`

And marks common binary types explicitly to make the intent clear.

## Test plan

- [ ] CI green (no source code change — pure git-config metadata)
- [ ] After merge, re-clone develop on the Windows host; verify `.sh` files have LF endings (`file .claude/scripts/agent-dispatch.sh` → "LF line terminators")
- [ ] Dispatch #1940 via `po-act.sh dispatch 1940`; verify agent container does NOT crash with `bash\r`

No effect on Linux/macOS hosts where the default is already LF.

🤖 Generated with [Claude Code](https://claude.com/claude-code)