### PR TITLE
controlplane/types: add CommandPushStewardBinary and EventStewardUpgrade* constants (Issue #1940)

### DIFF
--- a/pkg/controlplane/types/messages.go
+++ b/pkg/controlplane/types/messages.go
@@ -40,6 +40,12 @@ const (
 	// Params: cert_pem (base64-encoded PEM certificate). Idempotent — same
 	// fingerprint triggers no disk write on the steward side. (Issue #1817)
 	CommandPushSigningCert CommandType = "push_signing_cert"
+
+	// CommandPushStewardBinary instructs the steward to download a new binary from the
+	// controller, verify its SHA-256 digest against the manifest, invoke the launcher
+	// swap subcommand, and restart via the OS service manager. (Epic #1930)
+	// Params: version (string), download_url (string), sha256 (string), platform (string), arch (string).
+	CommandPushStewardBinary CommandType = "push_steward_binary"
 )
 
 // Command represents a command sent from controller to steward.
@@ -105,6 +111,26 @@ const (
 	// call to the controller. Details carry method, path, headers, body, execution_id,
 	// and a per-execution sequence number for correlation.
 	EventRelayRequest EventType = "relay_request"
+
+	// EventStewardUpgradeDispatched is published by the controller when it fans out
+	// CommandPushStewardBinary to a steward. (Epic #1930)
+	EventStewardUpgradeDispatched EventType = "steward.upgrade.dispatched"
+
+	// EventStewardUpgradeDownloaded is published by the steward when the binary
+	// download completes and the SHA-256 digest is verified. (Epic #1930)
+	EventStewardUpgradeDownloaded EventType = "steward.upgrade.downloaded"
+
+	// EventStewardUpgradeSwapped is published by the steward immediately before
+	// invoking the launcher swap subcommand. (Epic #1930)
+	EventStewardUpgradeSwapped EventType = "steward.upgrade.swapped"
+
+	// EventStewardUpgradeCommitted is published by the steward on first heartbeat
+	// after restart with the new binary. (Epic #1930)
+	EventStewardUpgradeCommitted EventType = "steward.upgrade.committed"
+
+	// EventStewardUpgradeRolledBack is published by the steward when the launcher's
+	// auto-rollback budget has been exhausted and the previous binary is restored. (Epic #1930)
+	EventStewardUpgradeRolledBack EventType = "steward.upgrade.rolled_back"
 )
 
 // Event represents an event published from steward to controller.

--- a/pkg/controlplane/types/messages_test.go
+++ b/pkg/controlplane/types/messages_test.go
@@ -8,6 +8,15 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestUpgradeConstants(t *testing.T) {
+	assert.Equal(t, "push_steward_binary", string(CommandPushStewardBinary))
+	assert.Equal(t, "steward.upgrade.dispatched", string(EventStewardUpgradeDispatched))
+	assert.Equal(t, "steward.upgrade.downloaded", string(EventStewardUpgradeDownloaded))
+	assert.Equal(t, "steward.upgrade.swapped", string(EventStewardUpgradeSwapped))
+	assert.Equal(t, "steward.upgrade.committed", string(EventStewardUpgradeCommitted))
+	assert.Equal(t, "steward.upgrade.rolled_back", string(EventStewardUpgradeRolledBack))
+}
+
 func TestEventFilter_Match(t *testing.T) {
 	tests := []struct {
 		name     string


### PR DESCRIPTION
## Summary

- Adds `CommandPushStewardBinary CommandType = "push_steward_binary"` to the CommandType const block in `pkg/controlplane/types/messages.go`
- Adds five `EventStewardUpgrade*` EventType constants covering all lifecycle milestones for the steward fleet upgrade epic (#1930): dispatched, downloaded, swapped, committed, rolled_back
- Adds `TestUpgradeConstants` in `pkg/controlplane/types/messages_test.go` asserting exact wire string values for each new constant

## Motivation

Epic #1930 (steward fleet upgrade) requires shared constants for the controller→steward upgrade command and its lifecycle events. Adding them here — with no handler logic — establishes the symbols downstream stories can reference without cyclic imports.

## Specialist Review Results

| Reviewer | Result | Notes |
|---|---|---|
| QA Code Reviewer | **PASS** | No mocks, skips, empty assertions, or workarounds |
| Security Engineer | **PASS** | No secrets, injection vectors, or central provider violations; automated scans (gitleaks, truffleHog, gosec, Trivy, Nancy, check-architecture) all green |
| QA Test Runner | Story files **PASS** | 19 pre-existing lint failures in `cmd/cfgms-steward-launcher/` and `features/controller/api/middleware.go` confirmed present on `develop` baseline before this branch — not introduced by this change |

## Test Plan

- [x] `TestUpgradeConstants` asserts all six constant string values
- [x] All existing tests in `pkg/controlplane/types/...` pass
- [x] `make security-precommit` clean on changed files
- [x] `make check-architecture` passes

Fixes #1940