### PR TITLE
steward/api: add cfg steward logs command + controller log-pull API endpoint (Issue #1937)

### DIFF
--- a/cmd/cfg/cmd/steward.go
+++ b/cmd/cfg/cmd/steward.go
@@ -15,6 +15,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"os"
 	"strings"
 	"text/tabwriter"
@@ -30,6 +31,14 @@ var (
 	stewardTLSCACert        string
 	stewardTLSInsecure      bool
 	stewardStatusJSONOutput bool
+)
+
+var (
+	stewardLogsTail   int
+	stewardLogsSince  string
+	stewardLogsLevel  string
+	stewardLogsModule string
+	stewardLogsJSON   bool
 )
 
 // stewardCmd is the parent command for steward subcommands.
@@ -150,6 +159,95 @@ Examples:
 	RunE: runRunCancel,
 }
 
+// stewardLogsCmd pulls recent log entries from a steward via the controller REST API.
+var stewardLogsCmd = &cobra.Command{
+	Use:   "logs <id>",
+	Short: "Pull recent log entries from a steward",
+	Long: `Pull recent log entries from the controller's log-pull endpoint for a steward.
+
+Note: Log pull is not yet available. Collect logs directly from the steward host.
+
+Examples:
+  cfg steward logs <steward-id>
+  cfg steward logs <steward-id> --tail 50 --level WARN
+  cfg steward logs <steward-id> --since 1h --module file`,
+	Args: cobra.ExactArgs(1),
+	RunE: runStewardLogs,
+}
+
+func runStewardLogs(_ *cobra.Command, args []string) error {
+	stewardID := args[0]
+
+	client, err := getStewardClient()
+	if err != nil {
+		return fmt.Errorf("failed to create API client: %w", err)
+	}
+
+	v := url.Values{}
+	v.Set("tail", fmt.Sprintf("%d", stewardLogsTail))
+	if stewardLogsSince != "" {
+		v.Set("since", stewardLogsSince)
+	}
+	if stewardLogsLevel != "" {
+		v.Set("level", stewardLogsLevel)
+	}
+	if stewardLogsModule != "" {
+		v.Set("module", stewardLogsModule)
+	}
+	path := "/api/v1/stewards/" + stewardID + "/logs?" + v.Encode()
+
+	resp, err := client.Get(context.Background(), path)
+	if err != nil {
+		return fmt.Errorf("failed to fetch logs: %w", err)
+	}
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			fmt.Fprintf(os.Stderr, "failed to close response body: %v\n", err)
+		}
+	}()
+
+	if resp.StatusCode == http.StatusNotFound {
+		return fmt.Errorf("steward %s not found", stewardID)
+	}
+
+	if resp.StatusCode == http.StatusNotImplemented {
+		fmt.Println("Log pull not yet available for this steward. Collect logs directly from the host.")
+		return nil
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("API request failed: %s - %s", resp.Status, string(body))
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("failed to read response: %w", err)
+	}
+
+	if stewardLogsJSON {
+		_, err := os.Stdout.Write(body)
+		return err
+	}
+
+	var apiResp struct {
+		Lines []struct {
+			Timestamp string `json:"timestamp"`
+			Level     string `json:"level"`
+			Module    string `json:"module"`
+			Message   string `json:"message"`
+		} `json:"lines"`
+	}
+	if err := json.Unmarshal(body, &apiResp); err != nil {
+		return fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	for _, line := range apiResp.Lines {
+		fmt.Printf("%s [%s] [%s] %s\n", line.Timestamp, line.Level, line.Module, line.Message)
+	}
+	return nil
+}
+
 func init() {
 	stewardListCmd.Flags().StringVar(&stewardURL, "url", "", "Controller API URL")
 	stewardListCmd.Flags().StringVar(&stewardAPIKey, "api-key", "", "API key for authentication")
@@ -206,6 +304,17 @@ func init() {
 	stewardRunCancelCmd.Flags().StringVar(&stewardTLSCACert, "tls-ca-cert", "", "Path to CA certificate (env: CFGMS_TLS_CA_CERT)")
 	stewardRunCancelCmd.Flags().BoolVar(&stewardTLSInsecure, "tls-insecure", false, "Skip TLS verification (env: CFGMS_TLS_INSECURE)")
 
+	// logs flags
+	stewardLogsCmd.Flags().StringVar(&stewardURL, "url", "", "Controller API URL")
+	stewardLogsCmd.Flags().StringVar(&stewardAPIKey, "api-key", "", "API key for authentication")
+	stewardLogsCmd.Flags().StringVar(&stewardTLSCACert, "tls-ca-cert", "", "Path to CA certificate (env: CFGMS_TLS_CA_CERT)")
+	stewardLogsCmd.Flags().BoolVar(&stewardTLSInsecure, "tls-insecure", false, "Skip TLS verification (env: CFGMS_TLS_INSECURE)")
+	stewardLogsCmd.Flags().IntVar(&stewardLogsTail, "tail", 100, "Number of log lines to return (1-1000)")
+	stewardLogsCmd.Flags().StringVar(&stewardLogsSince, "since", "", "Return logs from this duration ago (e.g. 1h, 30m)")
+	stewardLogsCmd.Flags().StringVar(&stewardLogsLevel, "level", "", "Filter by log level (DEBUG, INFO, WARN, ERROR)")
+	stewardLogsCmd.Flags().StringVar(&stewardLogsModule, "module", "", "Filter by module name")
+	stewardLogsCmd.Flags().BoolVar(&stewardLogsJSON, "json", false, "Emit raw JSON output instead of human-readable text")
+
 	stewardCmd.AddCommand(stewardListCmd)
 	stewardCmd.AddCommand(stewardStatusCmd)
 	stewardCmd.AddCommand(stewardRunScriptCmd)
@@ -213,6 +322,7 @@ func init() {
 	stewardCmd.AddCommand(stewardRunStatusCmd)
 	stewardCmd.AddCommand(stewardRunResultCmd)
 	stewardCmd.AddCommand(stewardRunCancelCmd)
+	stewardCmd.AddCommand(stewardLogsCmd)
 }
 
 // getStewardClient creates an API client using bundle auth (mTLS) when available,

--- a/cmd/cfg/cmd/steward_test.go
+++ b/cmd/cfg/cmd/steward_test.go
@@ -262,6 +262,61 @@ func TestStewardStatusCommand(t *testing.T) {
 	})
 }
 
+func TestStewardLogs_CallsEndpoint(t *testing.T) {
+	var requestPath string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestPath = r.URL.Path
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotImplemented)
+		_ = json.NewEncoder(w).Encode(map[string]string{
+			"code":    "LOGS_UNAVAILABLE",
+			"message": "steward log pull not yet supported; collect logs directly from the steward host",
+		})
+	}))
+	defer server.Close()
+
+	origURL := stewardURL
+	origInsecure := stewardTLSInsecure
+	origTail := stewardLogsTail
+	t.Cleanup(func() {
+		stewardURL = origURL
+		stewardTLSInsecure = origInsecure
+		stewardLogsTail = origTail
+	})
+	stewardURL = server.URL
+	stewardTLSInsecure = true
+	stewardLogsTail = 100
+
+	output := captureStdout(t, func() {
+		err := runStewardLogs(stewardLogsCmd, []string{"steward-abc"})
+		require.NoError(t, err)
+	})
+
+	assert.Equal(t, "/api/v1/stewards/steward-abc/logs", requestPath)
+	assert.Contains(t, output, "not yet available")
+}
+
+func TestStewardLogs_HandlesNotImplemented(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotImplemented)
+		_ = json.NewEncoder(w).Encode(map[string]string{"code": "LOGS_UNAVAILABLE"})
+	}))
+	defer server.Close()
+
+	origURL := stewardURL
+	origInsecure := stewardTLSInsecure
+	t.Cleanup(func() {
+		stewardURL = origURL
+		stewardTLSInsecure = origInsecure
+	})
+	stewardURL = server.URL
+	stewardTLSInsecure = true
+
+	err := runStewardLogs(stewardLogsCmd, []string{"steward-abc"})
+	assert.NoError(t, err, "501 response must not return an error")
+}
+
 func TestStewardList_UsesBundleClientPattern(t *testing.T) {
 	// Verify resolveBundleClient is used by confirming --no-bundle flag is inherited
 	// from rootCmd's persistent flags (the same flag resolveBundleClient reads).

--- a/docs/architecture/operating-model.md
+++ b/docs/architecture/operating-model.md
@@ -341,7 +341,7 @@ This is the same controller — it just has no stewards registered. The workflow
 
 Operators interact with CFGMS through layered UX surfaces.
 
-**`cfg` CLI — first-class community UI.** The canonical interaction surface for the open-source distribution. Every documented operator action works through the CLI. The CLI wraps REST endpoints so operators don't need to script against REST for documented workflows.
+**`cfg` CLI — first-class community UI.** The canonical interaction surface for the open-source distribution. Every documented operator action works through the CLI. The CLI wraps REST endpoints so operators don't need to script against REST for documented workflows. `cfg steward logs` is available but returns 501 until a log-pull transport is wired.
 
 **Web UI (planned before v1).** A separate UX layer for operators who prefer graphical workflows or shared-team views. Some power-user flows may remain CLI-only.
 

--- a/features/controller/api/handlers_stewards.go
+++ b/features/controller/api/handlers_stewards.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"net/http"
 	"regexp"
+	"strconv"
 	"strings"
 	"time"
 
@@ -548,6 +549,76 @@ func (s *Server) handleDeleteStewardConfig(w http.ResponseWriter, r *http.Reques
 
 	s.logger.Info("Configuration deleted", "steward_id", stewardIDForLog)
 	w.WriteHeader(http.StatusNoContent)
+}
+
+// handleGetStewardLogs handles GET /api/v1/stewards/{id}/logs.
+// Validates the steward exists and the query parameters, then returns 501 until a
+// log-pull transport is wired. The follow-up story must implement per-tenant ACL
+// gating, secret redaction via logging.SanitizeLogValue, and documented pagination caps.
+func (s *Server) handleGetStewardLogs(w http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+	stewardID := vars["id"]
+	stewardIDForLog := logging.SanitizeLogValue(stewardID)
+
+	if stewardID == "" {
+		s.writeErrorResponse(w, http.StatusBadRequest, "Steward ID is required", "MISSING_STEWARD_ID")
+		return
+	}
+
+	q := r.URL.Query()
+
+	// Parse and validate tail (default 100, max 1000).
+	tail := 100
+	if tailStr := q.Get("tail"); tailStr != "" {
+		v, err := strconv.Atoi(tailStr)
+		if err != nil || v < 1 || v > 1000 {
+			s.writeErrorResponse(w, http.StatusBadRequest, "tail must be an integer between 1 and 1000", "INVALID_PARAMETER")
+			return
+		}
+		tail = v
+	}
+
+	// Validate since is a parseable Go duration.
+	since := q.Get("since")
+	if since != "" {
+		if _, err := time.ParseDuration(since); err != nil {
+			s.writeErrorResponse(w, http.StatusBadRequest, "since must be a valid Go duration (e.g. 1h, 30m)", "INVALID_PARAMETER")
+			return
+		}
+	}
+
+	// Validate level is one of the four allowed values.
+	level := q.Get("level")
+	if level != "" && level != "DEBUG" && level != "INFO" && level != "WARN" && level != "ERROR" {
+		s.writeErrorResponse(w, http.StatusBadRequest, "level must be DEBUG, INFO, WARN, or ERROR", "INVALID_PARAMETER")
+		return
+	}
+
+	// Cap module at 128 characters.
+	module := q.Get("module")
+	if len(module) > 128 {
+		s.writeErrorResponse(w, http.StatusBadRequest, "module parameter exceeds maximum length of 128 characters", "INVALID_PARAMETER")
+		return
+	}
+
+	s.logger.Debug("Steward log pull request",
+		"steward_id", stewardIDForLog,
+		"tail", tail,
+		"since", logging.SanitizeLogValue(since),
+		"level", logging.SanitizeLogValue(level),
+		"module", logging.SanitizeLogValue(module),
+	)
+
+	_, exists := s.controllerService.GetStewardInfo(stewardID)
+	if !exists {
+		s.writeErrorResponse(w, http.StatusNotFound, "Steward not found", "STEWARD_NOT_FOUND")
+		return
+	}
+
+	s.respondJSON(w, http.StatusNotImplemented, map[string]string{
+		"code":    "LOGS_UNAVAILABLE",
+		"message": "steward log pull not yet supported; collect logs directly from the steward host",
+	})
 }
 
 // handleGetEffectiveConfig handles GET /api/v1/stewards/{id}/config/effective

--- a/features/controller/api/handlers_stewards_test.go
+++ b/features/controller/api/handlers_stewards_test.go
@@ -651,3 +651,57 @@ func TestHandleGetStewardConfig_InsufficientPermission(t *testing.T) {
 
 	assert.Equal(t, http.StatusForbidden, rec.Code)
 }
+
+// TestHandleGetStewardLogs_ReturnsNotImplemented verifies that GET /api/v1/stewards/{id}/logs
+// returns 501 with LOGS_UNAVAILABLE error code for a valid steward ID.
+func TestHandleGetStewardLogs_ReturnsNotImplemented(t *testing.T) {
+	server := setupTestServer(t)
+	apiKey := NewTestKey(t, server, []string{"steward:read-logs"})
+
+	stewardID := registerTestSteward(t, server.controllerService, map[string]string{
+		"hostname": "logs-test-host", "os": "linux",
+	})
+
+	req := httptest.NewRequest("GET", "/api/v1/stewards/"+stewardID+"/logs", nil)
+	req.Header.Set("X-API-Key", apiKey)
+	rec := httptest.NewRecorder()
+	server.router.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusNotImplemented, rec.Code)
+	var body map[string]string
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&body))
+	assert.Equal(t, "LOGS_UNAVAILABLE", body["code"])
+}
+
+// TestHandleGetStewardLogs_StewardNotFound verifies that GET /api/v1/stewards/{id}/logs
+// returns 404 when the steward ID is not found.
+func TestHandleGetStewardLogs_StewardNotFound(t *testing.T) {
+	server := setupTestServer(t)
+	apiKey := NewTestKey(t, server, []string{"steward:read-logs"})
+
+	req := httptest.NewRequest("GET", "/api/v1/stewards/nonexistent-steward/logs", nil)
+	req.Header.Set("X-API-Key", apiKey)
+	rec := httptest.NewRecorder()
+	server.router.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+}
+
+// TestHandleCreateAPIKey_AcceptsStewardReadLogs verifies that steward:read-logs is a
+// registered permission and can be granted via handleCreateAPIKey. Without this entry in
+// knownPermissions, operators cannot mint keys that reach the logs endpoint.
+func TestHandleCreateAPIKey_AcceptsStewardReadLogs(t *testing.T) {
+	server := setupTestServer(t)
+
+	// Call handleCreateAPIKey directly with the steward:read-logs permission.
+	body := []byte(`{"name":"logs-key","permissions":["steward:read-logs"]}`)
+	req := httptest.NewRequest("POST", "/api/v1/api-keys", strings.NewReader(string(body)))
+	req.Header.Set("Content-Type", "application/json")
+	ctx := req.Context()
+	ctx = context.WithValue(ctx, ctxkeys.TenantID, "test-tenant")
+	req = req.WithContext(ctx)
+	rec := httptest.NewRecorder()
+	server.handleCreateAPIKey(rec, req)
+
+	assert.Equal(t, http.StatusCreated, rec.Code, "steward:read-logs must be a known permission")
+}

--- a/features/controller/api/permissions.go
+++ b/features/controller/api/permissions.go
@@ -10,6 +10,7 @@ var knownPermissions = map[string]bool{
 	"steward:list":            true,
 	"steward:read":            true,
 	"steward:read-dna":        true,
+	"steward:read-logs":       true,
 	"steward:auth-refresh":    true,
 	"steward:read-config":     true,
 	"steward:write-config":    true,

--- a/features/controller/api/server.go
+++ b/features/controller/api/server.go
@@ -357,6 +357,7 @@ func (s *Server) setupRouter() {
 	stewards.Handle("", s.requirePermission("steward", "list")(http.HandlerFunc(s.handleListStewards))).Methods("GET")
 	stewards.Handle("/{id}", s.requirePermission("steward", "read")(http.HandlerFunc(s.handleGetSteward))).Methods("GET")
 	stewards.Handle("/{id}/dna", s.requirePermission("steward", "read-dna")(http.HandlerFunc(s.handleGetStewardDNA))).Methods("GET")
+	stewards.Handle("/{id}/logs", s.requirePermission("steward", "read-logs")(http.HandlerFunc(s.handleGetStewardLogs))).Methods("GET")
 	stewards.Handle("/{id}/auth/refresh", s.requirePermission("steward", "auth-refresh")(http.HandlerFunc(s.handleStewardAuthRefresh))).Methods("POST")
 
 	// Configuration management endpoints


### PR DESCRIPTION
## Summary

- Adds `GET /api/v1/stewards/{id}/logs` with a 501 placeholder (validates steward exists, parses/validates all query params, returns `LOGS_UNAVAILABLE`) gated by `requirePermission("steward","read-logs")`
- Adds `cfg steward logs <id> [--tail N] [--since 1h] [--level WARN] [--module file]` CLI command; prints human-readable message on 501, exits 0
- Registers `steward:read-logs` in `knownPermissions` so operators can mint API keys that reach the endpoint

Fixes #1937

## Follow-up checklist (real-handler story must address)

- [ ] Per-tenant ACL gating: `extractAdminPrincipal` check that `admin.tenant_path` covers the steward tenant; return 404 (not 403) for out-of-scope stewards
- [ ] Secret redaction: every log line MUST be processed through `logging.SanitizeLogValue()` before including in the response body
- [ ] Pagination caps: `tail` hard cap at 1000 lines; document the cap in the API response

## Specialist Review Results

### QA Test Runner: PASS
- All unit tests pass (75 packages, race detection enabled)
- `features/controller/api`: PASS; `cmd/cfg/cmd`: PASS
- Lint failures in scope are 19 pre-existing issues on develop from prior stories (#1918, #1919, #1929) — none introduced by this story

### QA Code Reviewer: PASS (no blocking issues)
- No mocks, no `t.Skip`, no empty assertions, no hacky workarounds
- Warnings (non-blocking): missing 400-path validation tests on handler; missing 404 CLI path test — both are advisory coverage gaps, not blocking

### Security Engineer: PASS (after fix)
- Initial run found blocking issue: `steward:read-logs` absent from `knownPermissions` in `permissions.go` — fixed immediately with a regression test (`TestHandleCreateAPIKey_AcceptsStewardReadLogs`)
- Re-check confirmed: allowlist fix in place, scans clean, test passes
- Log injection: all query-param values wrapped with `logging.SanitizeLogValue()` before logging
- `security-precommit`, `check-architecture`, `security-scan`: all PASS

## Test Plan

- [ ] `go test ./features/controller/api/... -run TestHandleGetStewardLogs` — both new handler tests pass
- [ ] `go test ./cmd/cfg/cmd/... -run TestStewardLogs` — both new CLI tests pass
- [ ] `go test ./features/controller/api/... -run TestHandleCreateAPIKey_AcceptsStewardReadLogs` — allowlist test passes
- [ ] `make check-architecture` — no central provider violations
- [ ] `make lint-log-injection` — exits 0, no findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)