### PR TITLE
dna: implement real Linux and Windows network collectors (Issue #1946)

### DIFF
--- a/docs/architecture/dna-collection.md
+++ b/docs/architecture/dna-collection.md
@@ -1,0 +1,86 @@
+# DNA Collection Audit
+
+Tracks which DNA attributes are collected on each platform, whether each implementation emits real data or stub values, and which gaps have been resolved.
+
+**Status legend:**
+
+| Symbol | Meaning |
+|--------|---------|
+| GREEN | Real value emitted by a platform-specific collector |
+| RED/GAP | Stub or placeholder — not yet implemented |
+| N/A | Not applicable on this platform |
+
+---
+
+## Network Attributes
+
+### Routing
+
+| Attribute | Linux | Windows | macOS | Source |
+|-----------|-------|---------|-------|--------|
+| `default_gateway` | GREEN | GREEN | GREEN | Linux: `/proc/net/route`; Windows: `route print -4`; macOS: `route get default` |
+| `ipv4_route_count` | GREEN | GREEN | GREEN | Linux: `/proc/net/route` (capped at 500); Windows: `route print -4` (capped at 500); macOS: `netstat -rn -f inet` |
+
+**Linux note:** `/proc/net/route` stores addresses in host byte order (little-endian on x86/x64). The collector decodes the hex values to dotted-decimal before storing.
+
+**Sensitivity:** IP/gateway values expose internal RFC1918 topology. Multi-tenant exposure is controlled by controller-side ACLs (dependency on the ACL story). Values are sanitised with `logging.SanitizeLogValue()` before storage.
+
+### DNS
+
+| Attribute | Linux | Windows | macOS | Source |
+|-----------|-------|---------|-------|--------|
+| `dns_servers` | GREEN | GREEN | GREEN | Linux: `/etc/resolv.conf`; Windows: registry `Tcpip\Parameters\Interfaces` per-adapter `DhcpNameServer`/`NameServer`; macOS: `scutil --dns` + `networksetup` |
+| `dns_search_domains` | GREEN | N/A | GREEN | Linux: `/etc/resolv.conf` `search`/`domain` lines |
+| `dns_domain` | N/A | GREEN | N/A | Windows: registry `Tcpip\Parameters` `Domain`/`DhcpDomain` |
+
+**Linux note:** On systemd-resolved systems the nameserver is the stub `127.0.0.53` — this is expected and is stored as-is (not treated as an error).
+
+**Truncation:** `dns_servers` joined string is truncated to 256 characters before storage.
+
+**Sensitivity:** DNS server addresses and domain names expose internal routing data. Values are sanitised with `logging.SanitizeLogValue()` before storage.
+
+### Firewall
+
+| Attribute | Linux | Windows | macOS | Source |
+|-----------|-------|---------|-------|--------|
+| `ufw_firewall_state` | GREEN | N/A | N/A | Linux: `ufw status` (values: `active`, `inactive`) |
+| `iptables_rule_count` | GREEN | N/A | N/A | Linux: `iptables -L --line-numbers` fallback when ufw is absent |
+| `firewall_state` | GREEN | N/A | N/A | Linux: `unknown` when both ufw and iptables are unavailable or permission denied |
+| `windows_firewall_domain_profile` | N/A | GREEN | N/A | Windows: `netsh advfirewall show allprofiles state` (values: `enabled`, `disabled`) |
+| `windows_firewall_private_profile` | N/A | GREEN | N/A | Windows: `netsh advfirewall show allprofiles state` |
+| `windows_firewall_public_profile` | N/A | GREEN | N/A | Windows: `netsh advfirewall show allprofiles state` |
+| `macos_firewall_state` | N/A | N/A | GREEN | macOS: `defaults read /Library/Preferences/com.apple.alf globalstate` |
+| `pfctl_rule_count` | N/A | N/A | GREEN | macOS: `pfctl -s rules` |
+
+**Linux degradation order:**
+1. `ufw status` → sets `ufw_firewall_state`
+2. `iptables -L --line-numbers` → sets `iptables_rule_count`
+3. Either unavailable or permission denied → sets `firewall_state=unknown`
+
+---
+
+## Hardware Attributes
+
+Hardware collection status is managed by the hardware collectors (`LinuxHardwareCollector`, `WindowsHardwareCollector`, `DarwinHardwareCollector`). See the hardware collector implementations for full attribute lists.
+
+---
+
+## Software Attributes
+
+Software collection status is managed by the software collectors. See the software collector implementations for full attribute lists.
+
+---
+
+## Security Attributes
+
+Security collection status is managed by the security collectors. See the security collector implementations for full attribute lists.
+
+---
+
+## Gap Tracking
+
+Stories that resolved gaps in this document:
+
+| Story | Gap Resolved |
+|-------|-------------|
+| #1946 | Linux and Windows routing, DNS, and firewall attributes implemented (previously RED/GAP) |

--- a/features/steward/dna/factory_linux.go
+++ b/features/steward/dna/factory_linux.go
@@ -17,7 +17,7 @@ func newPlatformSoftwareCollector(_ context.Context) SoftwareCollector {
 }
 
 func newPlatformNetworkCollector() NetworkCollector {
-	return &GenericNetworkCollector{}
+	return &LinuxNetworkCollector{}
 }
 
 func newPlatformSecurityCollector() SecurityCollector {

--- a/features/steward/dna/factory_windows.go
+++ b/features/steward/dna/factory_windows.go
@@ -17,7 +17,7 @@ func newPlatformSoftwareCollector(_ context.Context) SoftwareCollector {
 }
 
 func newPlatformNetworkCollector() NetworkCollector {
-	return &GenericNetworkCollector{}
+	return &WindowsNetworkCollector{}
 }
 
 func newPlatformSecurityCollector() SecurityCollector {

--- a/features/steward/dna/network.go
+++ b/features/steward/dna/network.go
@@ -111,5 +111,11 @@ func (g *GenericNetworkCollector) CollectFirewall(_ context.Context, attributes 
 	return nil
 }
 
+// LinuxNetworkCollector handles Linux-specific network collection
+type LinuxNetworkCollector struct{}
+
 // DarwinNetworkCollector handles macOS-specific network collection
 type DarwinNetworkCollector struct{}
+
+// WindowsNetworkCollector handles Windows-specific network collection.
+// Full definition is in network_windows.go.

--- a/features/steward/dna/network_linux.go
+++ b/features/steward/dna/network_linux.go
@@ -1,0 +1,203 @@
+//go:build linux
+
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+
+package dna
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"net"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+
+	"github.com/cfgis/cfgms/pkg/logging"
+)
+
+// CollectInterfaces delegates to GenericNetworkCollector for base interface data.
+func (l *LinuxNetworkCollector) CollectInterfaces(ctx context.Context, attributes map[string]string) error {
+	return (&GenericNetworkCollector{}).CollectInterfaces(ctx, attributes)
+}
+
+// CollectRouting gathers routing table information on Linux by reading /proc/net/route.
+// Attribute keys: default_gateway (first default route next-hop IP, sanitised),
+// ipv4_route_count (total routes, capped at 500).
+// IP/gateway values are tenant-sensitive (internal RFC1918 topology); sanitised before storage.
+func (l *LinuxNetworkCollector) CollectRouting(_ context.Context, attributes map[string]string) error {
+	f, err := os.Open("/proc/net/route")
+	if err != nil {
+		return nil
+	}
+	defer func() { _ = f.Close() }()
+
+	const maxRoutes = 500
+	routeCount := 0
+	firstLine := true
+
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		if firstLine {
+			firstLine = false
+			continue
+		}
+
+		fields := strings.Fields(scanner.Text())
+		if len(fields) < 8 {
+			continue
+		}
+
+		if routeCount >= maxRoutes {
+			break
+		}
+		routeCount++
+
+		dest := fields[1]
+		gateway := fields[2]
+		mask := fields[7]
+
+		// Default route: destination and mask both 00000000
+		if dest == "00000000" && mask == "00000000" && attributes["default_gateway"] == "" {
+			if gw := parseLinuxHexIP(gateway); gw != "" {
+				attributes["default_gateway"] = logging.SanitizeLogValue(gw)
+			}
+		}
+	}
+
+	if routeCount > 0 {
+		attributes["ipv4_route_count"] = fmt.Sprintf("%d", routeCount)
+	}
+
+	return nil
+}
+
+// parseLinuxHexIP converts a little-endian 32-bit hex string (as used in /proc/net/route)
+// to a dotted-decimal IPv4 address string. Returns empty string on parse failure.
+func parseLinuxHexIP(hexStr string) string {
+	n, err := strconv.ParseUint(hexStr, 16, 32)
+	if err != nil {
+		return ""
+	}
+	// /proc/net/route stores addresses in host byte order (little-endian on x86/x64).
+	// The first byte of the uint32 (least significant) is the first octet.
+	return net.IPv4(byte(n), byte(n>>8), byte(n>>16), byte(n>>24)).String()
+}
+
+// CollectDNS parses /etc/resolv.conf for DNS server and search domain configuration.
+// Attribute keys: dns_servers (comma-separated, sanitised, truncated to 256 chars),
+// dns_search_domains (sanitised, truncated to 256 chars).
+// Note: On systemd-resolved systems the nameserver is the stub 127.0.0.53 — this is normal and not an error.
+// DNS server addresses are tenant-sensitive routing data; sanitised before storage.
+func (l *LinuxNetworkCollector) CollectDNS(_ context.Context, attributes map[string]string) error {
+	f, err := os.Open("/etc/resolv.conf")
+	if err != nil {
+		return nil
+	}
+	defer func() { _ = f.Close() }()
+
+	var servers []string
+	var searchDomains []string
+
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || strings.HasPrefix(line, "#") || strings.HasPrefix(line, ";") {
+			continue
+		}
+
+		fields := strings.Fields(line)
+		if len(fields) < 2 {
+			continue
+		}
+
+		switch fields[0] {
+		case "nameserver":
+			servers = append(servers, logging.SanitizeLogValue(fields[1]))
+		case "search", "domain":
+			for _, d := range fields[1:] {
+				searchDomains = append(searchDomains, logging.SanitizeLogValue(d))
+			}
+		}
+	}
+
+	if len(servers) > 0 {
+		joined := strings.Join(servers, ",")
+		if len(joined) > 256 {
+			joined = joined[:256]
+		}
+		attributes["dns_servers"] = joined
+	}
+
+	if len(searchDomains) > 0 {
+		joined := strings.Join(searchDomains, ",")
+		if len(joined) > 256 {
+			joined = joined[:256]
+		}
+		attributes["dns_search_domains"] = joined
+	}
+
+	return nil
+}
+
+// CollectFirewall detects Linux firewall state.
+// Tries ufw first; falls back to counting iptables rules; degrades to firewall_state=unknown
+// when tools are absent or permission is denied.
+func (l *LinuxNetworkCollector) CollectFirewall(ctx context.Context, attributes map[string]string) error {
+	// Primary: ufw status
+	cmdCtx, cancel := context.WithTimeout(ctx, linuxCmdTimeout)
+	output, err := exec.CommandContext(cmdCtx, "ufw", "status").Output()
+	cancel()
+	if err == nil {
+		l.parseUFWStatus(string(output), attributes)
+		return nil
+	}
+
+	// Fallback: iptables -L --line-numbers; degrades gracefully on permission denied
+	cmdCtx2, cancel2 := context.WithTimeout(ctx, linuxCmdTimeout)
+	output2, err2 := exec.CommandContext(cmdCtx2, "iptables", "-L", "--line-numbers").Output()
+	cancel2()
+	if err2 != nil {
+		attributes["firewall_state"] = "unknown"
+		return nil
+	}
+
+	attributes["iptables_rule_count"] = fmt.Sprintf("%d", l.countIPTablesRules(string(output2)))
+	return nil
+}
+
+// parseUFWStatus parses "ufw status" output to extract the firewall state.
+func (l *LinuxNetworkCollector) parseUFWStatus(output string, attributes map[string]string) {
+	for _, line := range strings.Split(output, "\n") {
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(strings.ToLower(line), "status:") {
+			parts := strings.SplitN(line, ":", 2)
+			if len(parts) == 2 {
+				state := strings.TrimSpace(strings.ToLower(parts[1]))
+				// Use HasPrefix to avoid "inactive" matching "active" via Contains.
+				if strings.HasPrefix(state, "active") {
+					attributes["ufw_firewall_state"] = "active"
+				} else {
+					attributes["ufw_firewall_state"] = "inactive"
+				}
+				return
+			}
+		}
+	}
+	attributes["ufw_firewall_state"] = "inactive"
+}
+
+// countIPTablesRules counts non-header lines in iptables -L output.
+func (l *LinuxNetworkCollector) countIPTablesRules(output string) int {
+	count := 0
+	for _, line := range strings.Split(output, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "Chain ") || strings.HasPrefix(line, "target ") {
+			continue
+		}
+		count++
+	}
+	return count
+}

--- a/features/steward/dna/network_linux_test.go
+++ b/features/steward/dna/network_linux_test.go
@@ -1,0 +1,167 @@
+//go:build linux
+
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+
+package dna
+
+import (
+	"context"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLinuxNetworkCollector(t *testing.T) {
+	ctx := context.Background()
+	collector := &LinuxNetworkCollector{}
+
+	t.Run("CollectRouting", func(t *testing.T) {
+		attrs := make(map[string]string)
+		err := collector.CollectRouting(ctx, attrs)
+		require.NoError(t, err)
+
+		assert.NotEmpty(t, attrs["default_gateway"], "default_gateway must be non-empty")
+
+		countStr := attrs["ipv4_route_count"]
+		require.NotEmpty(t, countStr, "ipv4_route_count must be set")
+		count, err := strconv.Atoi(countStr)
+		require.NoError(t, err, "ipv4_route_count must be a parseable integer")
+		assert.GreaterOrEqual(t, count, 1, "ipv4_route_count must be >= 1")
+	})
+
+	t.Run("CollectDNS", func(t *testing.T) {
+		attrs := make(map[string]string)
+		err := collector.CollectDNS(ctx, attrs)
+		require.NoError(t, err)
+
+		assert.NotEmpty(t, attrs["dns_servers"], "dns_servers must be non-empty")
+	})
+
+	t.Run("CollectFirewall", func(t *testing.T) {
+		attrs := make(map[string]string)
+		err := collector.CollectFirewall(ctx, attrs)
+		require.NoError(t, err)
+
+		// At least one firewall attribute must be present and not the stub value
+		firewallKeys := []string{"ufw_firewall_state", "iptables_rule_count", "firewall_state"}
+		found := false
+		for _, key := range firewallKeys {
+			if val, ok := attrs[key]; ok && val != "" && val != "generic_collector_limited" {
+				found = true
+				break
+			}
+		}
+		assert.True(t, found, "at least one non-stub firewall attribute must be present (got: %v)", attrs)
+	})
+
+	t.Run("CollectInterfaces_PopulatesInterfaceCount", func(t *testing.T) {
+		attrs := make(map[string]string)
+		err := collector.CollectInterfaces(ctx, attrs)
+		require.NoError(t, err)
+
+		count, exists := attrs["network_interface_count"]
+		assert.True(t, exists, "network_interface_count must be set by CollectInterfaces")
+		n, err := strconv.Atoi(count)
+		require.NoError(t, err, "network_interface_count must be parseable as integer")
+		assert.GreaterOrEqual(t, n, 1, "network_interface_count must be >= 1")
+	})
+
+	t.Run("CollectRouting_RouteCountCappedAt500", func(t *testing.T) {
+		attrs := make(map[string]string)
+		err := collector.CollectRouting(ctx, attrs)
+		require.NoError(t, err)
+
+		if countStr, ok := attrs["ipv4_route_count"]; ok {
+			count, err := strconv.Atoi(countStr)
+			require.NoError(t, err)
+			assert.LessOrEqual(t, count, 500, "ipv4_route_count must not exceed 500")
+		}
+	})
+
+	t.Run("CollectDNS_TruncatedTo256", func(t *testing.T) {
+		attrs := make(map[string]string)
+		err := collector.CollectDNS(ctx, attrs)
+		require.NoError(t, err)
+
+		if servers, ok := attrs["dns_servers"]; ok {
+			assert.LessOrEqual(t, len(servers), 256, "dns_servers must be truncated to 256 chars")
+		}
+	})
+}
+
+func TestParseLinuxHexIP(t *testing.T) {
+	cases := []struct {
+		input    string
+		expected string
+	}{
+		// /proc/net/route gateway for 172.17.0.1 in little-endian hex
+		{"010011AC", "172.17.0.1"},
+		// 192.168.1.1
+		{"0101A8C0", "192.168.1.1"},
+		// 10.0.0.1
+		{"0100000A", "10.0.0.1"},
+		// Default route gateway field value of 0 (no gateway)
+		{"00000000", "0.0.0.0"},
+		// Invalid hex
+		{"GGGGGGGG", ""},
+		// Empty string
+		{"", ""},
+	}
+
+	for _, tc := range cases {
+		result := parseLinuxHexIP(tc.input)
+		assert.Equal(t, tc.expected, result, "parseLinuxHexIP(%q)", tc.input)
+	}
+}
+
+func TestParseUFWStatus(t *testing.T) {
+	collector := &LinuxNetworkCollector{}
+
+	t.Run("Active", func(t *testing.T) {
+		attrs := make(map[string]string)
+		collector.parseUFWStatus("Status: active\n\n     To   Action   From\n", attrs)
+		assert.Equal(t, "active", attrs["ufw_firewall_state"])
+	})
+
+	t.Run("Inactive", func(t *testing.T) {
+		attrs := make(map[string]string)
+		collector.parseUFWStatus("Status: inactive\n", attrs)
+		assert.Equal(t, "inactive", attrs["ufw_firewall_state"])
+	})
+
+	t.Run("NoStatusLine_DefaultsInactive", func(t *testing.T) {
+		attrs := make(map[string]string)
+		collector.parseUFWStatus("some output\nwithout a status line\n", attrs)
+		assert.Equal(t, "inactive", attrs["ufw_firewall_state"])
+	})
+
+	t.Run("EmptyOutput_DefaultsInactive", func(t *testing.T) {
+		attrs := make(map[string]string)
+		collector.parseUFWStatus("", attrs)
+		assert.Equal(t, "inactive", attrs["ufw_firewall_state"])
+	})
+}
+
+func TestCountIPTablesRules(t *testing.T) {
+	collector := &LinuxNetworkCollector{}
+
+	t.Run("OneRule", func(t *testing.T) {
+		output := "Chain INPUT (policy ACCEPT)\ntarget     prot opt source               destination\nDROP       all  --  0.0.0.0/0            0.0.0.0/0\n\nChain FORWARD (policy DROP)\ntarget     prot opt source               destination\n\n"
+		count := collector.countIPTablesRules(output)
+		assert.Equal(t, 1, count, "should count one actual rule")
+	})
+
+	t.Run("NoRules", func(t *testing.T) {
+		output := "Chain INPUT (policy ACCEPT)\ntarget     prot opt source               destination\n\nChain FORWARD (policy DROP)\ntarget     prot opt source               destination\n\n"
+		count := collector.countIPTablesRules(output)
+		assert.Equal(t, 0, count)
+	})
+
+	t.Run("EmptyOutput", func(t *testing.T) {
+		count := collector.countIPTablesRules("")
+		assert.Equal(t, 0, count)
+	})
+}

--- a/features/steward/dna/network_windows.go
+++ b/features/steward/dna/network_windows.go
@@ -1,0 +1,234 @@
+//go:build windows
+
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+
+package dna
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"golang.org/x/sys/windows/registry"
+
+	"github.com/cfgis/cfgms/pkg/logging"
+)
+
+// WindowsNetworkCollector handles Windows-specific network collection.
+type WindowsNetworkCollector struct{}
+
+// CollectInterfaces delegates to GenericNetworkCollector for base interface data.
+func (w *WindowsNetworkCollector) CollectInterfaces(ctx context.Context, attributes map[string]string) error {
+	return (&GenericNetworkCollector{}).CollectInterfaces(ctx, attributes)
+}
+
+// CollectRouting gathers routing table information on Windows using route print -4.
+// Attribute keys: default_gateway (sanitised), ipv4_route_count (capped at 500).
+// IP/gateway values are tenant-sensitive (internal RFC1918 topology); sanitised before storage.
+func (w *WindowsNetworkCollector) CollectRouting(ctx context.Context, attributes map[string]string) error {
+	output, err := runCommand(ctx, "route", "print", "-4")
+	if err != nil {
+		return nil
+	}
+	w.parseWindowsRouteOutput(output, attributes)
+	return nil
+}
+
+// parseWindowsRouteOutput parses "route print -4" output, extracting default gateway and route count.
+func (w *WindowsNetworkCollector) parseWindowsRouteOutput(output string, attributes map[string]string) {
+	const maxRoutes = 500
+	routeCount := 0
+	inActiveRoutes := false
+
+	for _, line := range strings.Split(output, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+
+		if line == "Active Routes:" {
+			inActiveRoutes = true
+			continue
+		}
+
+		if strings.HasPrefix(line, "Persistent Routes:") {
+			break
+		}
+
+		if !inActiveRoutes {
+			continue
+		}
+
+		if strings.HasPrefix(line, "Network Destination") {
+			continue
+		}
+
+		// Skip separator lines
+		fields := strings.Fields(line)
+		if len(fields) < 3 {
+			continue
+		}
+
+		if routeCount >= maxRoutes {
+			break
+		}
+		routeCount++
+
+		// Default route: destination 0.0.0.0, netmask 0.0.0.0
+		if fields[0] == "0.0.0.0" && fields[1] == "0.0.0.0" && attributes["default_gateway"] == "" {
+			if fields[2] != "On-link" {
+				attributes["default_gateway"] = logging.SanitizeLogValue(fields[2])
+			}
+		}
+	}
+
+	if routeCount > 0 {
+		attributes["ipv4_route_count"] = fmt.Sprintf("%d", routeCount)
+	}
+}
+
+// CollectDNS reads DNS server configuration from the Windows registry.
+// Primary source: per-adapter keys under Tcpip\Parameters\Interfaces (DhcpNameServer / NameServer).
+// Attribute keys: dns_servers (comma-separated, sanitised, truncated to 256 chars), dns_domain (sanitised).
+// DNS server addresses are tenant-sensitive routing data; sanitised before storage.
+func (w *WindowsNetworkCollector) CollectDNS(_ context.Context, attributes map[string]string) error {
+	w.collectDNSServersFromRegistry(attributes)
+	w.collectDNSDomainFromRegistry(attributes)
+	return nil
+}
+
+// collectDNSServersFromRegistry enumerates per-adapter interface registry keys to gather DNS servers.
+func (w *WindowsNetworkCollector) collectDNSServersFromRegistry(attributes map[string]string) {
+	ifaceKey, err := registry.OpenKey(registry.LOCAL_MACHINE,
+		`SYSTEM\CurrentControlSet\Services\Tcpip\Parameters\Interfaces`,
+		registry.READ)
+	if err != nil {
+		return
+	}
+	defer ifaceKey.Close()
+
+	subkeys, err := ifaceKey.ReadSubKeyNames(-1)
+	if err != nil {
+		return
+	}
+
+	seen := make(map[string]struct{})
+	var servers []string
+
+	for _, subkey := range subkeys {
+		w.collectDNSFromAdapter(ifaceKey, subkey, seen, &servers)
+	}
+
+	if len(servers) > 0 {
+		joined := strings.Join(servers, ",")
+		if len(joined) > 256 {
+			joined = joined[:256]
+		}
+		attributes["dns_servers"] = joined
+	}
+}
+
+// collectDNSFromAdapter reads DhcpNameServer and NameServer from one adapter's registry key.
+func (w *WindowsNetworkCollector) collectDNSFromAdapter(
+	parent registry.Key, subkey string,
+	seen map[string]struct{}, servers *[]string,
+) {
+	adapterKey, err := registry.OpenKey(parent, subkey, registry.QUERY_VALUE)
+	if err != nil {
+		return
+	}
+	defer adapterKey.Close()
+
+	for _, valueName := range []string{"DhcpNameServer", "NameServer"} {
+		val, _, err := adapterKey.GetStringValue(valueName)
+		if err != nil || val == "" {
+			continue
+		}
+		// Values may be space- or comma-separated
+		for _, s := range strings.FieldsFunc(val, func(r rune) bool { return r == ',' || r == ' ' }) {
+			s = strings.TrimSpace(s)
+			if s == "" {
+				continue
+			}
+			if _, exists := seen[s]; !exists {
+				seen[s] = struct{}{}
+				*servers = append(*servers, logging.SanitizeLogValue(s))
+			}
+		}
+	}
+}
+
+// collectDNSDomainFromRegistry reads the configured DNS domain from global Tcpip parameters.
+func (w *WindowsNetworkCollector) collectDNSDomainFromRegistry(attributes map[string]string) {
+	key, err := registry.OpenKey(registry.LOCAL_MACHINE,
+		`SYSTEM\CurrentControlSet\Services\Tcpip\Parameters`,
+		registry.QUERY_VALUE)
+	if err != nil {
+		return
+	}
+	defer key.Close()
+
+	for _, valueName := range []string{"Domain", "DhcpDomain"} {
+		val, _, err := key.GetStringValue(valueName)
+		if err != nil || val == "" {
+			continue
+		}
+		attributes["dns_domain"] = logging.SanitizeLogValue(val)
+		return
+	}
+}
+
+// CollectFirewall reads Windows Firewall profile states via netsh advfirewall.
+// Attribute keys: windows_firewall_domain_profile, windows_firewall_private_profile,
+// windows_firewall_public_profile. Each value is "enabled" or "disabled".
+func (w *WindowsNetworkCollector) CollectFirewall(ctx context.Context, attributes map[string]string) error {
+	output, err := runCommand(ctx, "netsh", "advfirewall", "show", "allprofiles", "state")
+	if err != nil {
+		return nil
+	}
+	w.parseNetshFirewallOutput(output, attributes)
+	return nil
+}
+
+// parseNetshFirewallOutput parses "netsh advfirewall show allprofiles state" output.
+func (w *WindowsNetworkCollector) parseNetshFirewallOutput(output string, attributes map[string]string) {
+	currentProfile := ""
+
+	for _, line := range strings.Split(output, "\n") {
+		line = strings.TrimSpace(line)
+		lower := strings.ToLower(line)
+
+		switch {
+		case strings.Contains(lower, "domain profile"):
+			currentProfile = "domain"
+		case strings.Contains(lower, "private profile"):
+			currentProfile = "private"
+		case strings.Contains(lower, "public profile"):
+			currentProfile = "public"
+		case strings.HasPrefix(lower, "state") && currentProfile != "":
+			fields := strings.Fields(line)
+			if len(fields) < 2 {
+				continue
+			}
+			state := strings.ToLower(fields[len(fields)-1])
+			var val string
+			switch state {
+			case "on":
+				val = "enabled"
+			case "off":
+				val = "disabled"
+			default:
+				continue
+			}
+			switch currentProfile {
+			case "domain":
+				attributes["windows_firewall_domain_profile"] = val
+			case "private":
+				attributes["windows_firewall_private_profile"] = val
+			case "public":
+				attributes["windows_firewall_public_profile"] = val
+			}
+		}
+	}
+}

--- a/features/steward/dna/network_windows_test.go
+++ b/features/steward/dna/network_windows_test.go
@@ -1,0 +1,176 @@
+//go:build windows
+
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+
+package dna
+
+import (
+	"context"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWindowsNetworkCollector(t *testing.T) {
+	ctx := context.Background()
+	collector := &WindowsNetworkCollector{}
+
+	t.Run("CollectRouting", func(t *testing.T) {
+		attrs := make(map[string]string)
+		err := collector.CollectRouting(ctx, attrs)
+		require.NoError(t, err)
+
+		assert.NotEmpty(t, attrs["default_gateway"], "default_gateway must be non-empty")
+
+		countStr := attrs["ipv4_route_count"]
+		require.NotEmpty(t, countStr, "ipv4_route_count must be set")
+		count, err := strconv.Atoi(countStr)
+		require.NoError(t, err, "ipv4_route_count must be a parseable integer")
+		assert.GreaterOrEqual(t, count, 1, "ipv4_route_count must be >= 1")
+		assert.LessOrEqual(t, count, 500, "ipv4_route_count must not exceed 500")
+	})
+
+	t.Run("CollectDNS", func(t *testing.T) {
+		attrs := make(map[string]string)
+		err := collector.CollectDNS(ctx, attrs)
+		require.NoError(t, err)
+
+		assert.NotEmpty(t, attrs["dns_servers"], "dns_servers must be non-empty")
+
+		if servers, ok := attrs["dns_servers"]; ok {
+			assert.LessOrEqual(t, len(servers), 256, "dns_servers must be truncated to 256 chars")
+		}
+	})
+
+	t.Run("CollectFirewall", func(t *testing.T) {
+		attrs := make(map[string]string)
+		err := collector.CollectFirewall(ctx, attrs)
+		require.NoError(t, err)
+
+		assert.NotEmpty(t, attrs["windows_firewall_domain_profile"], "domain firewall profile must be set")
+		assert.NotEmpty(t, attrs["windows_firewall_private_profile"], "private firewall profile must be set")
+		assert.NotEmpty(t, attrs["windows_firewall_public_profile"], "public firewall profile must be set")
+
+		validStates := map[string]bool{"enabled": true, "disabled": true}
+		assert.True(t, validStates[attrs["windows_firewall_domain_profile"]],
+			"domain profile must be 'enabled' or 'disabled', got: %q", attrs["windows_firewall_domain_profile"])
+		assert.True(t, validStates[attrs["windows_firewall_private_profile"]],
+			"private profile must be 'enabled' or 'disabled', got: %q", attrs["windows_firewall_private_profile"])
+		assert.True(t, validStates[attrs["windows_firewall_public_profile"]],
+			"public profile must be 'enabled' or 'disabled', got: %q", attrs["windows_firewall_public_profile"])
+	})
+
+	t.Run("CollectInterfaces_PopulatesInterfaceCount", func(t *testing.T) {
+		attrs := make(map[string]string)
+		err := collector.CollectInterfaces(ctx, attrs)
+		require.NoError(t, err)
+
+		count, exists := attrs["network_interface_count"]
+		assert.True(t, exists, "network_interface_count must be set by CollectInterfaces")
+		n, err := strconv.Atoi(count)
+		require.NoError(t, err, "network_interface_count must be parseable as integer")
+		assert.GreaterOrEqual(t, n, 1, "network_interface_count must be >= 1")
+	})
+}
+
+func TestParseWindowsRouteOutput(t *testing.T) {
+	collector := &WindowsNetworkCollector{}
+
+	sampleOutput := `
+===========================================================================
+Interface List
+ 14...00 15 5d 01 3c 02 ......Hyper-V Virtual Ethernet Adapter
+  1...........................Software Loopback Interface 1
+===========================================================================
+
+IPv4 Route Table
+===========================================================================
+Active Routes:
+Network Destination        Netmask          Gateway       Interface  Metric
+          0.0.0.0          0.0.0.0     192.168.1.1    192.168.1.100     21
+        127.0.0.0        255.0.0.0         On-link          127.0.0.1    331
+        127.0.0.1  255.255.255.255         On-link          127.0.0.1    331
+  192.168.1.0    255.255.255.0         On-link    192.168.1.100     21
+===========================================================================
+
+Persistent Routes:
+  None
+`
+
+	t.Run("ParsesDefaultGateway", func(t *testing.T) {
+		attrs := make(map[string]string)
+		collector.parseWindowsRouteOutput(sampleOutput, attrs)
+		assert.Equal(t, "192.168.1.1", attrs["default_gateway"])
+	})
+
+	t.Run("ParsesRouteCount", func(t *testing.T) {
+		attrs := make(map[string]string)
+		collector.parseWindowsRouteOutput(sampleOutput, attrs)
+		count, err := strconv.Atoi(attrs["ipv4_route_count"])
+		require.NoError(t, err)
+		assert.Equal(t, 4, count)
+	})
+
+	t.Run("EmptyOutput_NoAttributes", func(t *testing.T) {
+		attrs := make(map[string]string)
+		collector.parseWindowsRouteOutput("", attrs)
+		assert.Empty(t, attrs["default_gateway"])
+		assert.Empty(t, attrs["ipv4_route_count"])
+	})
+
+	t.Run("NoActiveRoutesSection", func(t *testing.T) {
+		attrs := make(map[string]string)
+		collector.parseWindowsRouteOutput("some unrelated output\n", attrs)
+		assert.Empty(t, attrs["default_gateway"])
+	})
+}
+
+func TestParseNetshFirewallOutput(t *testing.T) {
+	collector := &WindowsNetworkCollector{}
+
+	sampleOutput := `
+Domain Profile Settings:
+----------------------------------------------------------------------
+State                                 ON
+
+
+Private Profile Settings:
+----------------------------------------------------------------------
+State                                 OFF
+
+
+Public Profile Settings:
+----------------------------------------------------------------------
+State                                 ON
+
+Ok.
+`
+
+	t.Run("ParsesAllProfiles", func(t *testing.T) {
+		attrs := make(map[string]string)
+		collector.parseNetshFirewallOutput(sampleOutput, attrs)
+		assert.Equal(t, "enabled", attrs["windows_firewall_domain_profile"])
+		assert.Equal(t, "disabled", attrs["windows_firewall_private_profile"])
+		assert.Equal(t, "enabled", attrs["windows_firewall_public_profile"])
+	})
+
+	t.Run("EmptyOutput_NoAttributes", func(t *testing.T) {
+		attrs := make(map[string]string)
+		collector.parseNetshFirewallOutput("", attrs)
+		assert.Empty(t, attrs["windows_firewall_domain_profile"])
+		assert.Empty(t, attrs["windows_firewall_private_profile"])
+		assert.Empty(t, attrs["windows_firewall_public_profile"])
+	})
+
+	t.Run("AllDisabled", func(t *testing.T) {
+		output := "Domain Profile Settings:\nState OFF\nPrivate Profile Settings:\nState OFF\nPublic Profile Settings:\nState OFF\n"
+		attrs := make(map[string]string)
+		collector.parseNetshFirewallOutput(output, attrs)
+		assert.Equal(t, "disabled", attrs["windows_firewall_domain_profile"])
+		assert.Equal(t, "disabled", attrs["windows_firewall_private_profile"])
+		assert.Equal(t, "disabled", attrs["windows_firewall_public_profile"])
+	})
+}


### PR DESCRIPTION
## Summary

- `LinuxNetworkCollector` replaces `GenericNetworkCollector` on Linux with real routing (reads `/proc/net/route` — no exec, always available), DNS (`/etc/resolv.conf`), and firewall (`ufw status` → `iptables -L` fallback → `unknown` degradation)
- `WindowsNetworkCollector` replaces `GenericNetworkCollector` on Windows with real routing (`route print -4` argv form), DNS (registry `Tcpip\Parameters\Interfaces`), and firewall (`netsh advfirewall show allprofiles state`)
- All sensitive IP/domain values sanitised with `logging.SanitizeLogValue()` before storage
- `factory_linux.go` and `factory_windows.go` updated to return platform-specific collectors
- `docs/architecture/dna-collection.md` created with GREEN status audit table for routing, DNS, and firewall on Linux and Windows
- Bug fix: `parseUFWStatus` used `strings.Contains` which matched "inactive" as containing "active"; fixed to `strings.HasPrefix`

Fixes #1946

## Specialist Review Results

- **Security Engineer**: PASS — all exec calls use `exec.CommandContext` argv form, no shell string composition, no `-Command`/`-EncodedCommand`/`bash -c`, all sensitive values sanitised, no central provider violations, `make security-scan` clean
- **QA Code Reviewer**: PASS — parser unit tests cover `parseLinuxHexIP`, `parseUFWStatus`, `countIPTablesRules`, `parseWindowsRouteOutput`, `parseNetshFirewallOutput`; `CollectInterfaces` tests assert on `network_interface_count`; error paths covered; no mocks or skipped tests
- **QA Test Runner**: All Go unit tests pass including new platform-specific tests; 0 lint issues in the DNA package; pre-existing lint failures in unrelated packages (`cmd/cfgms-steward-launcher/`) are not introduced by this story and not gated by required CI checks

## Test plan

- [ ] Linux CI runner: `TestLinuxNetworkCollector` passes — `default_gateway` non-empty, `ipv4_route_count >= 1`, `dns_servers` non-empty, firewall attribute non-stub
- [ ] Windows CI runner: `TestWindowsNetworkCollector` passes — all three firewall profiles `enabled`/`disabled`, routing and DNS attributes populated
- [ ] Parser unit tests pass on all platforms: `TestParseLinuxHexIP`, `TestParseUFWStatus`, `TestCountIPTablesRules`, `TestParseWindowsRouteOutput`, `TestParseNetshFirewallOutput`
- [ ] `make security-scan` passes
- [ ] `make check-architecture` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)