### PR TITLE
launcher: Windows Job Object containment so children die with launcher (Issue #1928)

### DIFF
--- a/cmd/cfgms-steward-launcher/lifecycle.go
+++ b/cmd/cfgms-steward-launcher/lifecycle.go
@@ -177,10 +177,35 @@ func (s *Supervisor) Supervise(ctx context.Context) error {
 // Wait. The child inherits the launcher's stdin/stdout/stderr (overridable
 // in tests via Supervisor.Stdout / .Stderr). The child also receives any
 // ExtraArgs.
+//
+// On Windows, the child is assigned to a Job Object with
+// JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE so that an abnormal launcher exit
+// (SCM TerminateProcess, crash, panic-without-defer) takes the steward
+// with it (#1928). attachChildToJobObject is a no-op on POSIX —
+// process-group / pdeathsig semantics already cover that case.
 func (s *Supervisor) execOnce(ctx context.Context, exe string) error {
 	cmd := exec.CommandContext(ctx, exe, s.ExtraArgs...) //#nosec G204 -- exe path is validated via Layout
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = s.Stdout
 	cmd.Stderr = s.Stderr
-	return cmd.Run()
+	if err := cmd.Start(); err != nil {
+		return err
+	}
+	if err := attachChildToJobObject(cmd); err != nil {
+		// Best-effort: if the assignment fails, the child is already
+		// running and orphaning it on launcher exit is the very bug we
+		// were trying to prevent. Kill the child and return so the
+		// supervisor can decide whether to retry / rollback. Surface
+		// any kill/wait error in the wrapped message so an unkillable
+		// child (very rare; insufficient privilege under a restricted
+		// token) does not hide as a plain attach failure while a
+		// fully-unsupervised steward keeps running.
+		killErr := cmd.Process.Kill()
+		waitErr := cmd.Wait()
+		if killErr != nil || waitErr != nil {
+			return fmt.Errorf("attachChildToJobObject failed: %w (cleanup: kill=%v wait=%v)", err, killErr, waitErr)
+		}
+		return fmt.Errorf("attachChildToJobObject failed: %w", err)
+	}
+	return cmd.Wait()
 }

--- a/cmd/cfgms-steward-launcher/lifecycle_posix.go
+++ b/cmd/cfgms-steward-launcher/lifecycle_posix.go
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+
+//go:build !windows
+
+package main
+
+import "os/exec"
+
+// attachChildToJobObject is a no-op on POSIX systems. The orphan-child
+// failure mode that this addresses on Windows (#1928) doesn't exist on
+// Linux or macOS:
+//
+//   - exec.CommandContext already propagates ctx cancellation as SIGKILL
+//     to the child.
+//   - Most launcher abnormal-exit paths leave the child in the same
+//     process group; a setsid-equivalent is the steward's responsibility
+//     if it wants to outlive the launcher (it doesn't).
+//   - On Linux, the prctl PR_SET_PDEATHSIG path inside the steward could
+//     also be wired if we wanted a kernel-enforced guarantee — but the
+//     current launcher relies on cmd.Run's normal lifecycle and that's
+//     proven adequate.
+//
+// Keeping a separate file gated by `!windows` lets us call
+// attachChildToJobObject unconditionally from lifecycle.go without a
+// runtime.GOOS check at the call site.
+func attachChildToJobObject(cmd *exec.Cmd) error {
+	_ = cmd
+	return nil
+}

--- a/cmd/cfgms-steward-launcher/lifecycle_test.go
+++ b/cmd/cfgms-steward-launcher/lifecycle_test.go
@@ -27,8 +27,14 @@ import (
 //
 //	FAKE_STEWARD_SLEEP_MS    Sleep this many ms before exiting. Default 0.
 //	FAKE_STEWARD_EXIT_CODE   Exit with this status. Default 0.
-//	FAKE_STEWARD_MARKER_FILE Touch this file before sleeping so the test can
-//	                         verify which version actually ran.
+//	FAKE_STEWARD_MARKER_FILE       Touch this file before sleeping so the test
+//	                               can verify which version actually ran.
+//	FAKE_STEWARD_EXIT_MARKER_FILE  Touch this file AFTER the sleep, just before
+//	                               os.Exit. Used by the #1928 Job-Object test
+//	                               to distinguish "naturally completed" from
+//	                               "killed by the Job Object when the parent
+//	                               died." If absent on file system after the
+//	                               sleep budget, the kill landed.
 func TestHelperProcess(t *testing.T) {
 	if os.Getenv("GO_WANT_HELPER_PROCESS") != "1" {
 		return
@@ -40,6 +46,9 @@ func TestHelperProcess(t *testing.T) {
 		if n, err := strconv.Atoi(sleepMs); err == nil && n > 0 {
 			time.Sleep(time.Duration(n) * time.Millisecond)
 		}
+	}
+	if exitMarker := os.Getenv("FAKE_STEWARD_EXIT_MARKER_FILE"); exitMarker != "" {
+		_ = os.WriteFile(exitMarker, []byte("natural-exit"), 0o600)
 	}
 	code := 0
 	if c := os.Getenv("FAKE_STEWARD_EXIT_CODE"); c != "" {

--- a/cmd/cfgms-steward-launcher/lifecycle_windows.go
+++ b/cmd/cfgms-steward-launcher/lifecycle_windows.go
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+
+//go:build windows
+
+package main
+
+import (
+	"fmt"
+	"os/exec"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+// attachChildToJobObject assigns the supervised steward child to a Windows
+// Job Object configured with JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE so that an
+// abnormal launcher exit (SCM TerminateProcess, crash, runtime panic without
+// defer) takes the steward with it — closing the launcher's last handle to
+// the job triggers the kernel to terminate every assigned process.
+//
+// This mirrors the POSIX process-group / pdeathsig safety net that the rest
+// of the supervisor already relies on. Without it, the abnormal-exit case
+// produces the symptom from #1928 — orphaned cfgms-steward.exe with a stale
+// ParentProcessId, racing the next launcher's child on the same registration
+// token.
+//
+// The job handle is intentionally NOT closed here. It's owned by the
+// launcher process for its lifetime; the kernel closes it automatically
+// at process exit, and that close is the trigger that kills the children.
+// Closing it earlier would defeat the purpose. A future story may wire
+// graceful shutdown that explicitly closes the job, but the current
+// auto-rollback flow already relies on the launcher's own exit semantics.
+//
+// Ordering note: cmd.Start has already created the process by the time
+// this runs. There's a microsecond-scale window where the child runs
+// outside the job; JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE applies
+// retroactively once assigned, so this is acceptable for the kill-on-close
+// guarantee. A CREATE_SUSPENDED + ResumeThread pattern would close that
+// window entirely but adds Win32 surface; deferred until evidence we need
+// it.
+func attachChildToJobObject(cmd *exec.Cmd) error {
+	if cmd == nil || cmd.Process == nil {
+		return fmt.Errorf("attachChildToJobObject: cmd has no process")
+	}
+
+	job, err := windows.CreateJobObject(nil, nil)
+	if err != nil {
+		return fmt.Errorf("CreateJobObject: %w", err)
+	}
+
+	// LimitFlags carries ONLY JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE. Two
+	// flags are intentionally NOT set; a future change MUST NOT add them
+	// without a fresh threat-model pass:
+	//
+	//   - JOB_OBJECT_LIMIT_BREAKAWAY_OK / SILENT_BREAKAWAY_OK: would let
+	//     a child process spawned with CREATE_BREAKAWAY_FROM_JOB escape
+	//     the kill-on-close net, reproducing the orphan bug #1928 set out
+	//     to prevent. Absent => Windows denies breakaway by default.
+	//   - JOB_OBJECT_LIMIT_PROCESS_MEMORY / JOB_TIME / etc: out of scope
+	//     for this story.
+	info := windows.JOBOBJECT_EXTENDED_LIMIT_INFORMATION{
+		BasicLimitInformation: windows.JOBOBJECT_BASIC_LIMIT_INFORMATION{
+			LimitFlags: windows.JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE,
+		},
+	}
+	if _, err := windows.SetInformationJobObject(
+		job,
+		windows.JobObjectExtendedLimitInformation,
+		uintptr(unsafe.Pointer(&info)),
+		uint32(unsafe.Sizeof(info)),
+	); err != nil {
+		_ = windows.CloseHandle(job)
+		return fmt.Errorf("SetInformationJobObject: %w", err)
+	}
+
+	// cmd.Process.Pid is a numeric PID, not a handle. Open a process
+	// handle with PROCESS_SET_QUOTA | PROCESS_TERMINATE so
+	// AssignProcessToJobObject is allowed.
+	//
+	// PID-recycle race note: Go's os/exec internally holds a process
+	// handle to the child for the lifetime of *exec.Cmd (created inside
+	// Start, released by Wait or Release). Windows guarantees that a
+	// process's PID is NOT recycled while any handle to that process
+	// remains open, so the PID we read from cmd.Process.Pid here cannot
+	// refer to a different process. The OpenProcess call below gets a
+	// second handle to the same child.
+	processHandle, err := windows.OpenProcess(
+		windows.PROCESS_SET_QUOTA|windows.PROCESS_TERMINATE,
+		false,
+		uint32(cmd.Process.Pid),
+	)
+	if err != nil {
+		_ = windows.CloseHandle(job)
+		return fmt.Errorf("OpenProcess(pid=%d): %w", cmd.Process.Pid, err)
+	}
+	defer windows.CloseHandle(processHandle)
+
+	if err := windows.AssignProcessToJobObject(job, processHandle); err != nil {
+		_ = windows.CloseHandle(job)
+		return fmt.Errorf("AssignProcessToJobObject: %w", err)
+	}
+
+	// Intentionally do NOT CloseHandle(job). The launcher's open handle is
+	// what keeps the job alive; the kernel terminates assigned children
+	// when the last handle closes (process exit).
+	_ = job // explicit: handle is retained for launcher lifetime
+
+	return nil
+}

--- a/cmd/cfgms-steward-launcher/lifecycle_windows_test.go
+++ b/cmd/cfgms-steward-launcher/lifecycle_windows_test.go
@@ -1,0 +1,160 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+
+//go:build windows
+
+package main
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestAttachChildToJobObject_KillsChildOnLauncherExit covers the #1928
+// guarantee: an abnormal launcher exit must take the supervised steward
+// with it.
+//
+// The test re-execs this binary twice:
+//
+//  1. an outer "launcher" sub-process that spawns
+//  2. an inner "steward" sub-process and calls attachChildToJobObject
+//     to put it in a kill-on-close Job Object.
+//
+// The outer process exits abnormally (os.Exit(2) without Wait) after
+// attaching the child to the job. If the Job Object did its job, the
+// inner process must terminate within a short window even though no
+// signal was delivered to it directly. The parent test polls a marker
+// file to detect whether the inner process completed its sleep (= bug:
+// still alive after launcher death) or was killed early (= fix
+// working).
+//
+// Outer-process knobs:
+//
+//	GO_WANT_OUTER_LAUNCHER=1
+//	OUTER_SELF_EXE     path to this test binary (re-exec target)
+//	OUTER_MARKER_FILE  marker file the inner steward writes on natural exit
+//
+// Inner steward uses the existing FAKE_STEWARD_* knobs from the
+// TestHelperProcess in lifecycle_test.go (sleep 10s, then write marker on
+// natural completion). If the marker is absent after the wait, the kill
+// landed before the steward could finish — the desired behaviour.
+func TestAttachChildToJobObject_KillsChildOnLauncherExit(t *testing.T) {
+	if os.Getenv("GO_WANT_OUTER_LAUNCHER") == "1" {
+		runOuterLauncher()
+		return
+	}
+
+	t.Logf("expected wall-clock: ~12s (3s post-kill grace + 8s past inner's 10s sleep budget, to prove the inner died early)")
+
+	exe, err := os.Executable()
+	require.NoError(t, err, "os.Executable for self re-exec")
+
+	dir := t.TempDir()
+	naturalExitMarker := filepath.Join(dir, "natural-exit.marker")
+	innerStartedMarker := filepath.Join(dir, "inner-started.marker")
+
+	outer := exec.Command(exe, "-test.run=TestAttachChildToJobObject_KillsChildOnLauncherExit") //#nosec G204 -- test self-exec
+	outer.Env = append(os.Environ(),
+		"GO_WANT_OUTER_LAUNCHER=1",
+		"OUTER_SELF_EXE="+exe,
+		"OUTER_MARKER_FILE="+naturalExitMarker,
+		"OUTER_STARTED_FILE="+innerStartedMarker,
+	)
+	var outerOutput strings.Builder
+	outer.Stdout = &outerOutput
+	outer.Stderr = &outerOutput
+
+	require.NoError(t, outer.Start(), "outer launcher start")
+
+	// Wait for the inner steward to actually launch (marker proves
+	// CreateProcess + AssignProcessToJobObject have completed).
+	deadline := time.Now().Add(5 * time.Second)
+	for !fileExists(innerStartedMarker) {
+		if time.Now().After(deadline) {
+			_ = outer.Process.Kill()
+			_ = outer.Wait()
+			t.Fatalf("inner steward never wrote started marker within 5s\nouter output: %s", outerOutput.String())
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+
+	// Wait for outer to die (it self-exits 2 after attaching the child).
+	require.Error(t, outer.Wait(), "outer launcher should exit non-zero")
+
+	// Give the kernel up to 3 s to honour KILL_ON_JOB_CLOSE. In
+	// practice it's near-instant after the launcher's handle closes.
+	time.Sleep(3 * time.Second)
+
+	// The inner steward was set to sleep 10 s before writing the natural-
+	// exit marker. We've waited ~3 s after launcher death (well under 10 s),
+	// so either (a) the kill worked and natural-exit.marker is absent, or
+	// (b) the kill didn't work and the inner is still running (also no
+	// marker yet). To disambiguate, wait the full 10 s window and assert
+	// the marker is STILL absent — proves the inner died before completing
+	// its sleep.
+	time.Sleep(8 * time.Second)
+	if fileExists(naturalExitMarker) {
+		t.Fatalf("inner steward reached its natural exit — Job Object did NOT kill it on launcher death (orphan bug #1928 not fixed)")
+	}
+}
+
+func fileExists(p string) bool {
+	_, err := os.Stat(p)
+	return err == nil
+}
+
+// runOuterLauncher executes inside the outer process. It spawns the inner
+// "fake steward", calls attachChildToJobObject, then exits abnormally
+// (os.Exit(2) without Wait) so the kernel-level JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE
+// is the only thing that can clean up the child.
+func runOuterLauncher() {
+	exe := os.Getenv("OUTER_SELF_EXE")
+	naturalMarker := os.Getenv("OUTER_MARKER_FILE")
+	startedMarker := os.Getenv("OUTER_STARTED_FILE")
+
+	cmd := exec.Command(exe, "-test.run=TestHelperProcess") //#nosec G204 -- test self-exec
+	// Inherit parent env (PATH, SystemRoot, etc. are required for the
+	// child Go test runtime to start on Windows) and append the helper
+	// knobs. The started-marker is written before the sleep; the
+	// exit-marker is written after the sleep so its presence proves the
+	// inner survived the 10s window. Job Object kill should land before
+	// then.
+	cmd.Env = append(os.Environ(),
+		"GO_WANT_HELPER_PROCESS=1",
+		"FAKE_STEWARD_SLEEP_MS=10000",
+		"FAKE_STEWARD_MARKER_FILE="+startedMarker,
+		"FAKE_STEWARD_EXIT_MARKER_FILE="+naturalMarker,
+	)
+
+	if err := cmd.Start(); err != nil {
+		_, _ = os.Stderr.WriteString("outer: cmd.Start failed: " + err.Error() + "\n")
+		os.Exit(3)
+	}
+	_, _ = os.Stderr.WriteString("outer: inner pid=" + strconv.Itoa(cmd.Process.Pid) + "\n")
+	if err := attachChildToJobObject(cmd); err != nil {
+		_, _ = os.Stderr.WriteString("outer: attachChildToJobObject failed: " + err.Error() + "\n")
+		_ = cmd.Process.Kill()
+		os.Exit(4)
+	}
+
+	// Give the inner a chance to write its started-marker. Without this,
+	// outer exits so fast the kernel kills the inner before it ever
+	// reaches the WriteFile call — the test then can't distinguish
+	// "killed before start" from "killed after start", both of which are
+	// the bug-fixed behavior we want, but the started-marker is how the
+	// test detects that the inner actually entered its sleep phase.
+	time.Sleep(500 * time.Millisecond)
+
+	// Abnormal exit: do NOT Wait. The launcher process terminates
+	// while the supervised steward is still running. The Job Object's
+	// kill-on-close limit is the only thing that can cull the child.
+	os.Exit(2)
+}
+


### PR DESCRIPTION
## Summary

Closes #1928. Fixes the Windows-only orphan-steward bug surfaced during the CFG-70-02 launcher install: abnormal launcher exit left the supervised steward alive with a stale ParentProcessId, racing the next launcher's child on the same registration token.

## Implementation

Wrap the supervised child in a Win32 Job Object with `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE`. When the launcher's last handle to the job closes (process exit), the kernel terminates every assigned process. Nested children inherit the job by default.

- `lifecycle.go`: `execOnce` now does `cmd.Start()` → `attachChildToJobObject(cmd)` → `cmd.Wait()` instead of `cmd.Run()`. On attach failure, kill the child and surface wrapped errors.
- `lifecycle_windows.go` (new): CreateJobObject + SetInformationJobObject + AssignProcessToJobObject via `golang.org/x/sys/windows`.
- `lifecycle_posix.go` (new): no-op so the call site stays unconditional.
- `lifecycle_windows_test.go` (new): real Job-Object kill test — outer process re-execs inner, attaches to job, then `os.Exit(2)`. Asserts the inner died before its 10s sleep budget.
- `lifecycle_test.go`: `TestHelperProcess` extended with `FAKE_STEWARD_EXIT_MARKER_FILE` for the new test.

## Security review (pre-PR)

3 reviewers ran in parallel:

| | Verdict |
|---|---|
| Acceptance | PASS — all AC verified |
| QA | PASS — one nit (test wall-clock ~12s; added `t.Logf` notice) |
| Security | PASS — 2 HIGH items addressed inline: |

- **Breakaway escape**: `LimitFlags` carries ONLY `KILL_ON_JOB_CLOSE`. `BREAKAWAY_OK` / `SILENT_BREAKAWAY_OK` intentionally absent — denies breakaway by default. Code comment cements intent so a future change can't silently add them.
- **PID race**: documented why OpenProcess on `cmd.Process.Pid` is safe (Go's `os/exec` holds an internal handle to the child, so Windows can't recycle the PID).

## Test plan

- [x] `go test -short -timeout=3m ./cmd/cfgms-steward-launcher/` — all green incl. the new test (~17s total)
- [x] `go vet ./cmd/cfgms-steward-launcher/...` clean
- [x] Cross-build verified for Linux + macOS (POSIX no-op)
- [ ] CI must pass `Native Build (windows-latest)` — this is the validation of the kernel-level kill

🤖 Generated with [Claude Code](https://claude.com/claude-code)