### PR TITLE
controller/api: add steward binary publish endpoint and cfg installer publish subcommand (Issue #1944)

### DIFF
--- a/cmd/cfg/cmd/installer.go
+++ b/cmd/cfg/cmd/installer.go
@@ -4,10 +4,12 @@ package cmd
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"os"
 	"strings"
 
@@ -21,6 +23,13 @@ var (
 	installerAPIKey      string
 	installerTLSCACert   string
 	installerTLSInsecure bool
+
+	// publish subcommand flags
+	publishKind      string
+	publishVersion   string
+	publishBinary    string
+	publishSignature string
+	publishForce     bool
 )
 
 var validInstallerPlatforms = map[string]bool{
@@ -55,6 +64,23 @@ Examples:
 	RunE: runInstallerUpload,
 }
 
+var installerPublishCmd = &cobra.Command{
+	Use:   "publish",
+	Short: "Publish a versioned steward binary to the controller",
+	Long: `Publish a publisher-signed steward binary to the controller blob store.
+
+Uploads the binary to POST /api/v1/installer/steward-binaries/{version}/{platform}/{arch}
+and verifies the Ed25519 publisher signature on the server before storing. Only binaries
+signed by the CFGMS publisher identity are accepted.
+
+Examples:
+  cfg installer publish --kind steward --version v0.5.12 --platform linux --arch amd64 \
+      --binary ./cfgms-steward --signature ./cfgms-steward.sig
+  cfg installer publish --kind steward --version v1.0.0 --platform windows --arch amd64 \
+      --binary cfgms-steward.exe --signature cfgms-steward.exe.sig --force`,
+	RunE: runInstallerPublish,
+}
+
 var installerDownloadURLCmd = &cobra.Command{
 	Use:   "download-url",
 	Short: "Print the download URL for an installer artifact",
@@ -86,8 +112,27 @@ func init() {
 	_ = installerDownloadURLCmd.MarkFlagRequired("platform")
 	_ = installerDownloadURLCmd.MarkFlagRequired("arch")
 
+	installerPublishCmd.Flags().StringVar(&publishKind, "kind", "", "Binary kind: steward (required)")
+	installerPublishCmd.Flags().StringVar(&publishVersion, "version", "", "Semantic version, e.g. v0.5.12 (required)")
+	installerPublishCmd.Flags().StringVar(&installerPlatform, "platform", "", "Target platform: windows, darwin, linux (required)")
+	installerPublishCmd.Flags().StringVar(&installerArch, "arch", "", "Target architecture: amd64, arm64 (required)")
+	installerPublishCmd.Flags().StringVar(&publishBinary, "binary", "", "Path to the binary file to publish (required)")
+	installerPublishCmd.Flags().StringVar(&publishSignature, "signature", "", "Path to the Ed25519 signature file (required)")
+	installerPublishCmd.Flags().BoolVar(&publishForce, "force", false, "Overwrite an existing binary with the same version/platform/arch")
+	installerPublishCmd.Flags().StringVar(&installerAPIURL, "api-url", "", "Controller API URL (env: CFGMS_API_URL)")
+	installerPublishCmd.Flags().StringVar(&installerAPIKey, "api-key", "", "API key for authentication (env: CFGMS_API_KEY)")
+	installerPublishCmd.Flags().StringVar(&installerTLSCACert, "tls-ca-cert", "", "Path to CA certificate for TLS verification (env: CFGMS_TLS_CA_CERT)")
+	installerPublishCmd.Flags().BoolVar(&installerTLSInsecure, "tls-insecure", false, "Skip TLS verification (development only)")
+	_ = installerPublishCmd.MarkFlagRequired("kind")
+	_ = installerPublishCmd.MarkFlagRequired("version")
+	_ = installerPublishCmd.MarkFlagRequired("platform")
+	_ = installerPublishCmd.MarkFlagRequired("arch")
+	_ = installerPublishCmd.MarkFlagRequired("binary")
+	_ = installerPublishCmd.MarkFlagRequired("signature")
+
 	installerCmd.AddCommand(installerUploadCmd)
 	installerCmd.AddCommand(installerDownloadURLCmd)
+	installerCmd.AddCommand(installerPublishCmd)
 }
 
 func getInstallerClient() (*APIClient, error) {
@@ -177,6 +222,109 @@ func runInstallerDownloadURL(cmd *cobra.Command, args []string) error {
 	apiURL = strings.TrimRight(apiURL, "/")
 
 	fmt.Printf("%s/api/v1/installer/download/%s/%s\n", apiURL, installerPlatform, installerArch)
+	return nil
+}
+
+func runInstallerPublish(cmd *cobra.Command, args []string) error {
+	if publishKind != "steward" {
+		return fmt.Errorf("--kind must be %q; got %q", "steward", publishKind)
+	}
+	if !validInstallerPlatforms[installerPlatform] {
+		return fmt.Errorf("unknown platform %q; valid values: windows, darwin, linux", installerPlatform)
+	}
+	if !validInstallerArchs[installerArch] {
+		return fmt.Errorf("unknown arch %q; valid values: amd64, arm64", installerArch)
+	}
+
+	binaryInfo, err := os.Stat(publishBinary)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return fmt.Errorf("binary file not found: %s", publishBinary)
+		}
+		return fmt.Errorf("cannot access binary file %s: %w", publishBinary, err)
+	}
+	if binaryInfo.Size() == 0 {
+		return fmt.Errorf("binary file is empty: %s", publishBinary)
+	}
+
+	// #nosec G304 - file path provided by user via CLI flag
+	sigBytes, err := os.ReadFile(publishSignature)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return fmt.Errorf("signature file not found: %s", publishSignature)
+		}
+		return fmt.Errorf("cannot read signature file %s: %w", publishSignature, err)
+	}
+	if len(sigBytes) == 0 {
+		return fmt.Errorf("signature file is empty: %s", publishSignature)
+	}
+
+	// #nosec G304 - file path provided by user via CLI flag
+	f, err := os.Open(publishBinary)
+	if err != nil {
+		return fmt.Errorf("failed to open binary file %s: %w", publishBinary, err)
+	}
+	defer func() { _ = f.Close() }()
+
+	client, err := getInstallerClient()
+	if err != nil {
+		return fmt.Errorf("failed to create API client: %w", err)
+	}
+
+	return client.PublishStewardBinary(context.Background(),
+		publishVersion, installerPlatform, installerArch, sigBytes, publishForce, f)
+}
+
+// stewardBinaryPublishAPIResponse mirrors the server-side stewardBinaryPublishResponse wrapped in APIResponse.
+type stewardBinaryPublishAPIResponse struct {
+	Data struct {
+		Version         string `json:"version"`
+		Platform        string `json:"platform"`
+		Arch            string `json:"arch"`
+		Size            int64  `json:"size"`
+		SHA256          string `json:"sha256"`
+		PublishedBy     string `json:"published_by"`
+		Publisher       string `json:"publisher"`
+		SignatureDigest string `json:"signature_digest"`
+	} `json:"data"`
+}
+
+// PublishStewardBinary streams r to POST /api/v1/installer/steward-binaries/{version}/{platform}/{arch}
+// with the base64-encoded signature as a query param. Prints the confirmation on success.
+func (c *APIClient) PublishStewardBinary(
+	ctx context.Context, version, platform, arch string, sigBytes []byte, force bool, r io.Reader,
+) error {
+	q := url.Values{}
+	// Use URL-safe base64 without padding so the signature survives query-param sanitization.
+	q.Set("signature", base64.RawURLEncoding.EncodeToString(sigBytes))
+	if force {
+		q.Set("force", "true")
+	}
+	path := "/api/v1/installer/steward-binaries/" + version + "/" + platform + "/" + arch + "?" + q.Encode()
+
+	resp, err := c.doRequestWithContentType(ctx, "POST", path, r, "application/octet-stream")
+	if err != nil {
+		return fmt.Errorf("failed to publish steward binary: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return c.parseError(resp)
+	}
+
+	var apiResp stewardBinaryPublishAPIResponse
+	if err := json.NewDecoder(resp.Body).Decode(&apiResp); err != nil {
+		return fmt.Errorf("failed to decode response: %w", err)
+	}
+
+	fmt.Printf("Published steward binary %s %s/%s (%d bytes, sha256: %s, published_by: %s)\n",
+		apiResp.Data.Version,
+		apiResp.Data.Platform,
+		apiResp.Data.Arch,
+		apiResp.Data.Size,
+		strings.TrimPrefix(apiResp.Data.SHA256, "sha256:"),
+		apiResp.Data.PublishedBy,
+	)
 	return nil
 }
 

--- a/cmd/cfg/cmd/installer_test.go
+++ b/cmd/cfg/cmd/installer_test.go
@@ -3,6 +3,12 @@
 package cmd
 
 import (
+	"bytes"
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -371,4 +377,226 @@ func TestInstallerUpload(t *testing.T) {
 		assert.Equal(t, "/api/v1/installer/artifacts/darwin/arm64", receivedPath)
 		assert.Contains(t, output, "darwin/arm64")
 	})
+}
+
+// ---- Publish subcommand tests ----
+
+// TestPublishCLI_RequiresPlatformAndArch verifies that cfg installer publish returns a usage
+// error before making any HTTP call when --platform or --arch is absent.
+func TestPublishCLI_RequiresPlatformAndArch(t *testing.T) {
+	// resetPublishFlags restores package-level flag vars after each sub-test.
+	resetPublishFlags := func(t *testing.T) {
+		t.Helper()
+		t.Cleanup(func() {
+			publishKind = ""
+			publishVersion = ""
+			installerPlatform = ""
+			installerArch = ""
+			publishBinary = ""
+			publishSignature = ""
+			publishForce = false
+			installerAPIURL = ""
+			noBundle = false
+		})
+	}
+
+	t.Run("rejects missing platform", func(t *testing.T) {
+		resetPublishFlags(t)
+		noBundle = true
+		publishKind = "steward"
+		publishVersion = "v1.0.0"
+		installerPlatform = "" // omitted
+		installerArch = "amd64"
+		publishBinary = "somefile"
+		publishSignature = "somefile.sig"
+
+		err := runInstallerPublish(installerPublishCmd, []string{})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "unknown platform")
+	})
+
+	t.Run("rejects missing arch", func(t *testing.T) {
+		resetPublishFlags(t)
+		noBundle = true
+		publishKind = "steward"
+		publishVersion = "v1.0.0"
+		installerPlatform = "linux"
+		installerArch = "" // omitted
+		publishBinary = "somefile"
+		publishSignature = "somefile.sig"
+
+		err := runInstallerPublish(installerPublishCmd, []string{})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "unknown arch")
+	})
+
+	t.Run("rejects unknown kind", func(t *testing.T) {
+		resetPublishFlags(t)
+		noBundle = true
+		publishKind = "outpost" // invalid kind
+		publishVersion = "v1.0.0"
+		installerPlatform = "linux"
+		installerArch = "amd64"
+
+		err := runInstallerPublish(installerPublishCmd, []string{})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "--kind")
+	})
+
+	t.Run("rejects missing binary file", func(t *testing.T) {
+		resetPublishFlags(t)
+		noBundle = true
+		publishKind = "steward"
+		publishVersion = "v1.0.0"
+		installerPlatform = "linux"
+		installerArch = "amd64"
+		publishBinary = "/nonexistent/path/binary"
+		publishSignature = "somefile.sig"
+
+		err := runInstallerPublish(installerPublishCmd, []string{})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "binary file not found")
+	})
+}
+
+// TestPublishCLI_SuccessfulPublish verifies that a valid publish call sends the correct request
+// and prints the expected output.
+func TestPublishCLI_SuccessfulPublish(t *testing.T) {
+	// Generate a real Ed25519 key pair for signing.
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	require.NoError(t, err)
+	_ = pub
+
+	binaryContent := []byte("cfgms-steward-test-binary")
+
+	// Create temporary binary and signature files.
+	dir := t.TempDir()
+	binaryPath := filepath.Join(dir, "cfgms-steward")
+	require.NoError(t, os.WriteFile(binaryPath, binaryContent, 0600))
+
+	// Sign: Ed25519 over the SHA-256 hex of the binary content.
+	sum := sha256.Sum256(binaryContent)
+	hash := hex.EncodeToString(sum[:])
+	sig := ed25519.Sign(priv, []byte(hash))
+	sigPath := filepath.Join(dir, "cfgms-steward.sig")
+	require.NoError(t, os.WriteFile(sigPath, sig, 0600))
+
+	// Save and restore flag state.
+	origKind := publishKind
+	origVersion := publishVersion
+	origPlatform := installerPlatform
+	origArch := installerArch
+	origBinary := publishBinary
+	origSig := publishSignature
+	origURL := installerAPIURL
+	origNoBundle := noBundle
+	t.Cleanup(func() {
+		publishKind = origKind
+		publishVersion = origVersion
+		installerPlatform = origPlatform
+		installerArch = origArch
+		publishBinary = origBinary
+		publishSignature = origSig
+		installerAPIURL = origURL
+		noBundle = origNoBundle
+	})
+
+	publishKind = "steward"
+	publishVersion = "v1.2.3"
+	installerPlatform = "linux"
+	installerArch = "amd64"
+	publishBinary = binaryPath
+	publishSignature = sigPath
+	noBundle = true
+
+	var receivedPath string
+	var receivedSigHeader string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedPath = r.URL.Path
+		receivedSigHeader = r.URL.Query().Get("signature")
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"data": map[string]interface{}{
+				"version":          "v1.2.3",
+				"platform":         "linux",
+				"arch":             "amd64",
+				"size":             int64(len(binaryContent)),
+				"sha256":           "sha256:abc123",
+				"published_by":     "admin@example.com",
+				"publisher":        "cfgms",
+				"signature_digest": "deadbeef",
+			},
+		})
+	}))
+	defer server.Close()
+	installerAPIURL = server.URL
+
+	output := captureStdout(t, func() {
+		err := runInstallerPublish(installerPublishCmd, []string{})
+		require.NoError(t, err)
+	})
+
+	assert.Equal(t, "/api/v1/installer/steward-binaries/v1.2.3/linux/amd64", receivedPath)
+	assert.NotEmpty(t, receivedSigHeader, "signature query param must be sent")
+	// Verify the signature is valid URL-safe base64 (no padding).
+	_, decErr := base64.RawURLEncoding.DecodeString(receivedSigHeader)
+	assert.NoError(t, decErr, "signature must be valid URL-safe base64")
+
+	assert.Contains(t, output, "v1.2.3")
+	assert.Contains(t, output, "linux/amd64")
+	assert.Contains(t, output, "admin@example.com")
+}
+
+// TestPublishCLI_DuplicateReturns409 verifies that a 409 response from the server
+// results in an error returned to the caller (no silent swallow).
+func TestPublishCLI_DuplicateReturns409(t *testing.T) {
+	dir := t.TempDir()
+	binaryPath := filepath.Join(dir, "cfgms-steward")
+	require.NoError(t, os.WriteFile(binaryPath, []byte("content"), 0600))
+	sigPath := filepath.Join(dir, "cfgms-steward.sig")
+	require.NoError(t, os.WriteFile(sigPath, bytes.Repeat([]byte{0}, 64), 0600))
+
+	origKind := publishKind
+	origVersion := publishVersion
+	origPlatform := installerPlatform
+	origArch := installerArch
+	origBinary := publishBinary
+	origSig := publishSignature
+	origURL := installerAPIURL
+	origNoBundle := noBundle
+	t.Cleanup(func() {
+		publishKind = origKind
+		publishVersion = origVersion
+		installerPlatform = origPlatform
+		installerArch = origArch
+		publishBinary = origBinary
+		publishSignature = origSig
+		installerAPIURL = origURL
+		noBundle = origNoBundle
+	})
+
+	publishKind = "steward"
+	publishVersion = "v1.0.0"
+	installerPlatform = "linux"
+	installerArch = "amd64"
+	publishBinary = binaryPath
+	publishSignature = sigPath
+	noBundle = true
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusConflict)
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"error":   "DUPLICATE_BINARY",
+			"message": "Steward binary already exists; use --force to overwrite",
+		})
+	}))
+	defer server.Close()
+	installerAPIURL = server.URL
+
+	err := runInstallerPublish(installerPublishCmd, []string{})
+	require.Error(t, err)
+	assert.True(t, strings.Contains(err.Error(), "409") || strings.Contains(err.Error(), "DUPLICATE") || strings.Contains(err.Error(), "Conflict"),
+		"expected 409/conflict in error: %v", err)
 }

--- a/cmd/cfgms-steward-launcher/lifecycle.go
+++ b/cmd/cfgms-steward-launcher/lifecycle.go
@@ -65,7 +65,7 @@ type clock interface {
 
 type realClock struct{}
 
-func (realClock) Now() time.Time              { return time.Now() }
+func (realClock) Now() time.Time                  { return time.Now() }
 func (realClock) Since(t time.Time) time.Duration { return time.Since(t) }
 
 // Supervise runs the supervision loop until ctx is cancelled, the child
@@ -169,7 +169,7 @@ func (s *Supervisor) Supervise(ctx context.Context) error {
 			return fmt.Errorf("launcher: rollback after child failure: %w", rbErr)
 		}
 		rollbacksRemaining--
-		fmt.Fprintf(s.Stderr, "launcher: rolled back to version %q after child failure (ran for %s)\n", newCurrent, ranFor)
+		_, _ = fmt.Fprintf(s.Stderr, "launcher: rolled back to version %q after child failure (ran for %s)\n", newCurrent, ranFor)
 	}
 }
 

--- a/cmd/cfgms-steward-launcher/lifecycle_test.go
+++ b/cmd/cfgms-steward-launcher/lifecycle_test.go
@@ -100,31 +100,6 @@ func runSupervisor(t *testing.T, s *Supervisor, timeout time.Duration) error {
 	return s.Supervise(ctx)
 }
 
-// fakeClock simulates time so we can deterministically test the
-// startup-window logic without sleeping in real time.
-type fakeClock struct {
-	mu  sync.Mutex
-	now time.Time
-}
-
-func (c *fakeClock) Now() time.Time {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	return c.now
-}
-
-func (c *fakeClock) Since(t time.Time) time.Duration {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	return c.now.Sub(t)
-}
-
-func (c *fakeClock) advance(d time.Duration) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	c.now = c.now.Add(d)
-}
-
 // envForChild returns the env vars to pass to a child fake-steward by
 // re-using the test process env. The launcher inherits its environment;
 // to vary per-test behaviour we just mutate t.Setenv before invocation.

--- a/cmd/cfgms-steward-launcher/main.go
+++ b/cmd/cfgms-steward-launcher/main.go
@@ -133,11 +133,11 @@ func runSwap(args []string) int {
 
 	dst, err := layout.StageBinary(version, sourceExe)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "launcher swap: %v\n", err)
+		_, _ = fmt.Fprintf(os.Stderr, "launcher swap: %v\n", err)
 		return 1
 	}
-	fmt.Fprintf(os.Stdout, "launcher: staged %q as version %q at %q\n", sourceExe, version, dst)
-	fmt.Fprintf(os.Stdout, "launcher: next steward restart will exec the new version\n")
+	_, _ = fmt.Fprintf(os.Stdout, "launcher: staged %q as version %q at %q\n", sourceExe, version, dst)
+	_, _ = fmt.Fprintf(os.Stdout, "launcher: next steward restart will exec the new version\n")
 	return 0
 }
 
@@ -145,18 +145,18 @@ func runRollback(args []string) int {
 	fs := flag.NewFlagSet("rollback", flag.ExitOnError)
 	root := fs.String("root", defaultRoot(), "Install root holding current.txt + versions/")
 	if err := fs.Parse(args); err != nil {
-		fmt.Fprintf(os.Stderr, "launcher rollback: %v\n", err)
+		_, _ = fmt.Fprintf(os.Stderr, "launcher rollback: %v\n", err)
 		return 2
 	}
 
 	layout := Layout{Root: *root, StewardBinaryName: defaultStewardBinaryName()}
 	newCurrent, err := layout.Rollback()
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "launcher rollback: %v\n", err)
+		_, _ = fmt.Fprintf(os.Stderr, "launcher rollback: %v\n", err)
 		return 1
 	}
-	fmt.Fprintf(os.Stdout, "launcher: rolled back; new active version is %q\n", newCurrent)
-	fmt.Fprintf(os.Stdout, "launcher: next steward restart will exec the rolled-back version\n")
+	_, _ = fmt.Fprintf(os.Stdout, "launcher: rolled back; new active version is %q\n", newCurrent)
+	_, _ = fmt.Fprintf(os.Stdout, "launcher: next steward restart will exec the rolled-back version\n")
 	return 0
 }
 
@@ -164,7 +164,7 @@ func runStatus(args []string) int {
 	fs := flag.NewFlagSet("status", flag.ExitOnError)
 	root := fs.String("root", defaultRoot(), "Install root holding current.txt + versions/")
 	if err := fs.Parse(args); err != nil {
-		fmt.Fprintf(os.Stderr, "launcher status: %v\n", err)
+		_, _ = fmt.Fprintf(os.Stderr, "launcher status: %v\n", err)
 		return 2
 	}
 
@@ -177,9 +177,9 @@ func runStatus(args []string) int {
 	if previous == "" {
 		previous = "<none>"
 	}
-	fmt.Fprintf(os.Stdout, "Root:     %s\n", *root)
-	fmt.Fprintf(os.Stdout, "Current:  %s\n", current)
-	fmt.Fprintf(os.Stdout, "Previous: %s\n", previous)
+	_, _ = fmt.Fprintf(os.Stdout, "Root:     %s\n", *root)
+	_, _ = fmt.Fprintf(os.Stdout, "Current:  %s\n", current)
+	_, _ = fmt.Fprintf(os.Stdout, "Previous: %s\n", previous)
 	return 0
 }
 

--- a/cmd/cfgms-steward-launcher/state.go
+++ b/cmd/cfgms-steward-launcher/state.go
@@ -251,4 +251,3 @@ func (l Layout) Rollback() (string, error) {
 	}
 	return newPS.Current, nil
 }
-

--- a/cmd/cfgms-steward-launcher/swap.go
+++ b/cmd/cfgms-steward-launcher/swap.go
@@ -52,7 +52,7 @@ func copyFile(src, dst string) error {
 	if err != nil {
 		return err
 	}
-	defer in.Close()
+	defer func() { _ = in.Close() }()
 
 	tmp := dst + ".tmp"
 	out, err := os.OpenFile(tmp, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o755) //#nosec G302 -- service binary must be executable

--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -43,9 +43,9 @@ func main() {
 // buildRootCommand constructs the cobra command tree for cfgms-controller.
 func buildRootCommand() *cobra.Command {
 	var (
-		configPath        string
-		initMode          bool
-		listenAPIAddr     string
+		configPath          string
+		initMode            bool
+		listenAPIAddr       string
 		listenTransportAddr string
 	)
 

--- a/docs/architecture/operating-model.md
+++ b/docs/architecture/operating-model.md
@@ -349,6 +349,17 @@ Operators interact with CFGMS through layered UX surfaces.
 
 **Workflow engine — automation surface.** For SaaS/cloud operations that don't require a steward (M365, identity providers, ticketing systems), the workflow engine is the primary expression mechanism. See [controller operating model](controller-operating-model.md#workflow-engine).
 
+## Controller Blob Store Namespaces
+
+The controller blob store (`pkg/storage/interfaces/blob.BlobStore`) partitions binary artifacts by namespace within each tenant.
+
+| Namespace | Purpose |
+|-----------|---------|
+| `installers` | Platform installer packages uploaded via `PUT /api/v1/installer/artifacts/{platform}/{arch}` |
+| `steward-binaries` | Versioned steward binaries published via `POST /api/v1/installer/steward-binaries/{version}/{platform}/{arch}`. Each entry carries publisher-signature metadata and the publishing operator identity. |
+
+Steward binary distribution uses the `steward-binaries` namespace exclusively. Blob keys take the form `{version}-{platform}-{arch}` (e.g. `v0.5.12-linux-amd64`). Binaries must carry a valid Ed25519 publisher signature verified against the CFGMS publisher identity before storage.
+
 ## Monitoring Export Credentials
 
 OTLP exporter credentials (API keys / bearer tokens) are stored in `pkg/secrets`, not in config files. Configure the secret key name via `config["secret_key"]` and use `NewOTLPExporterWithSecrets` to wire the store at construction time.

--- a/features/controller/api/handlers_steward_binary.go
+++ b/features/controller/api/handlers_steward_binary.go
@@ -1,0 +1,298 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+package api
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"errors"
+	"io"
+	"net/http"
+	"regexp"
+
+	"github.com/gorilla/mux"
+
+	"github.com/cfgis/cfgms/pkg/ctxkeys"
+	"github.com/cfgis/cfgms/pkg/logging"
+	"github.com/cfgis/cfgms/pkg/modules/bundle"
+	"github.com/cfgis/cfgms/pkg/modules/trust"
+	blob "github.com/cfgis/cfgms/pkg/storage/interfaces/blob"
+)
+
+// stewardBinaryVersionRe validates semantic version strings like v0.5.12.
+var stewardBinaryVersionRe = regexp.MustCompile(`^v\d+\.\d+\.\d+$`)
+
+// stewardBinaryPublishResponse is the JSON body returned by POST /api/v1/installer/steward-binaries/{version}/{platform}/{arch}.
+type stewardBinaryPublishResponse struct {
+	Version         string `json:"version"`
+	Platform        string `json:"platform"`
+	Arch            string `json:"arch"`
+	Size            int64  `json:"size"`
+	SHA256          string `json:"sha256"`
+	PublishedBy     string `json:"published_by"`
+	Publisher       string `json:"publisher"`
+	SignatureDigest string `json:"signature_digest"`
+}
+
+// stewardBinaryTrust returns the trust store used for steward binary signature verification.
+// Uses the server-level override when set (injected in tests); otherwise constructs a
+// fresh store seeded with CFGMSPublisherIdentity.
+func (s *Server) stewardBinaryTrust() trust.TrustStore {
+	if s.stewardBinaryTrustStore != nil {
+		return s.stewardBinaryTrustStore
+	}
+	store := trust.NewInMemoryTrustStore()
+	_ = store.AddPublisher(trust.CFGMSPublisherIdentity())
+	return store
+}
+
+// stewardBinaryBlobKey builds the BlobKey for a steward binary within the steward-binaries namespace.
+// Name format: "{version}-{platform}-{arch}" (e.g. "v0.5.12-linux-amd64").
+// The blob key Name must not contain "/" — the filesystem provider rejects path separators.
+func stewardBinaryBlobKey(tenantID, version, platform, arch string) blob.BlobKey {
+	return blob.BlobKey{
+		TenantID:  tenantID,
+		Namespace: "steward-binaries",
+		Name:      version + "-" + platform + "-" + arch,
+	}
+}
+
+// handlePublishStewardBinary handles POST /api/v1/installer/steward-binaries/{version}/{platform}/{arch}.
+// Verifies the Ed25519 publisher signature against CFGMSPublisherIdentity before storing the blob.
+// Returns 400 if signature is absent or invalid, 409 if the binary already exists (use ?force=true to overwrite).
+func (s *Server) handlePublishStewardBinary(w http.ResponseWriter, r *http.Request) {
+	if s.blobStore == nil {
+		s.writeErrorResponse(w, http.StatusServiceUnavailable, "Binary storage not available", "SERVICE_UNAVAILABLE")
+		return
+	}
+	tenantID, _ := r.Context().Value(ctxkeys.TenantID).(string)
+	if tenantID == "" {
+		s.writeErrorResponse(w, http.StatusUnauthorized, "Authentication required", "AUTHENTICATION_REQUIRED")
+		return
+	}
+
+	vars := mux.Vars(r)
+	version := vars["version"]
+	platform := vars["platform"]
+	arch := vars["arch"]
+
+	if !stewardBinaryVersionRe.MatchString(version) {
+		s.writeErrorResponse(w, http.StatusBadRequest,
+			"Invalid version: "+logging.SanitizeLogValue(version)+"; must match ^v\\d+\\.\\d+\\.\\d+",
+			"INVALID_VERSION")
+		return
+	}
+	if !validPlatforms[platform] {
+		s.writeErrorResponse(w, http.StatusBadRequest,
+			"Unknown platform: "+logging.SanitizeLogValue(platform)+"; valid values: windows, darwin, linux",
+			"INVALID_PLATFORM")
+		return
+	}
+	if !validArchs[arch] {
+		s.writeErrorResponse(w, http.StatusBadRequest,
+			"Unknown arch: "+logging.SanitizeLogValue(arch)+"; valid values: amd64, arm64",
+			"INVALID_ARCH")
+		return
+	}
+
+	// Require a publisher signature — unsigned uploads are rejected.
+	sigBase64 := r.URL.Query().Get("signature")
+	if sigBase64 == "" {
+		// Also check multipart form field (used when binary is uploaded as multipart).
+		if parseErr := r.ParseMultipartForm(32 << 20); parseErr == nil {
+			sigBase64 = r.FormValue("signature")
+		}
+	}
+	if sigBase64 == "" {
+		s.writeErrorResponse(w, http.StatusBadRequest,
+			"Signature required; provide ?signature=<base64> or a multipart 'signature' field",
+			"SIGNATURE_REQUIRED")
+		return
+	}
+
+	// Signature is URL-safe base64 (no padding) so it survives query-param sanitization.
+	sigBytes, err := base64.RawURLEncoding.DecodeString(sigBase64)
+	if err != nil {
+		s.writeErrorResponse(w, http.StatusBadRequest,
+			"Invalid signature encoding; must be URL-safe base64 (no padding)",
+			"INVALID_SIGNATURE_ENCODING")
+		return
+	}
+
+	// Buffer the binary body to compute SHA-256 for signature verification.
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		s.logger.Error("Failed to read request body", "error", err)
+		s.writeErrorResponse(w, http.StatusInternalServerError, "Failed to read request body", "READ_ERROR")
+		return
+	}
+
+	sum := sha256.Sum256(body)
+	contentHash := hex.EncodeToString(sum[:])
+
+	// Verify the publisher signature. The Ed25519 message is the UTF-8 bytes of contentHash.
+	b := bundle.Bundle{ContentHash: contentHash}
+	sig := bundle.BundleSignature{
+		Publisher: "cfgms",
+		Algorithm: "ed25519",
+		Signature: sigBytes,
+	}
+	if verifyErr := trust.VerifyBundleSignature(&b, sig, s.stewardBinaryTrust()); verifyErr != nil {
+		s.writeErrorResponse(w, http.StatusBadRequest,
+			"Signature verification failed: "+verifyErr.Error(),
+			"SIGNATURE_VERIFICATION_FAILED")
+		return
+	}
+
+	key := stewardBinaryBlobKey(tenantID, version, platform, arch)
+
+	// Enforce 409 Conflict on duplicate unless ?force=true.
+	if r.URL.Query().Get("force") != "true" {
+		existing, _, lookupErr := s.blobStore.GetBlob(r.Context(), key)
+		if lookupErr == nil {
+			_ = existing.Close()
+			s.writeErrorResponse(w, http.StatusConflict,
+				"Steward binary already exists for this version/platform/arch; use --force to overwrite",
+				"DUPLICATE_BINARY")
+			return
+		}
+		if !errors.Is(lookupErr, blob.ErrBlobNotFound) {
+			s.logger.Error("Failed to check for existing steward binary",
+				"error", lookupErr,
+				"version", logging.SanitizeLogValue(version),
+				"platform", logging.SanitizeLogValue(platform),
+				"arch", logging.SanitizeLogValue(arch))
+			s.writeErrorResponse(w, http.StatusInternalServerError, "Failed to check for existing binary", "CHECK_ERROR")
+			return
+		}
+	}
+
+	// Compute signature digest (SHA-256 of raw signature bytes) for the manifest.
+	sigHashBytes := sha256.Sum256(sigBytes)
+	sigDigest := hex.EncodeToString(sigHashBytes[:])
+
+	// Operator identity from auth context.
+	publishedBy, _ := r.Context().Value(ctxkeys.UserIDKey).(string)
+
+	meta := blob.BlobMeta{
+		ContentType: "application/octet-stream",
+		Labels: map[string]string{
+			"version":          version,
+			"platform":         platform,
+			"arch":             arch,
+			"published_by":     publishedBy,
+			"publisher":        "cfgms",
+			"signature_digest": sigDigest,
+			"signature":        base64.RawURLEncoding.EncodeToString(sigBytes),
+			"publisher_tenant": tenantID,
+		},
+	}
+
+	if putErr := s.blobStore.PutBlob(r.Context(), key, bytes.NewReader(body), meta); putErr != nil {
+		s.logger.Error("Failed to store steward binary",
+			"error", putErr,
+			"version", logging.SanitizeLogValue(version),
+			"platform", logging.SanitizeLogValue(platform),
+			"arch", logging.SanitizeLogValue(arch))
+		s.writeErrorResponse(w, http.StatusInternalServerError, "Failed to store binary", "STORE_ERROR")
+		return
+	}
+
+	// Retrieve stored metadata — provider populates Checksum and Size during PutBlob.
+	rc, storedMeta, err := s.blobStore.GetBlob(r.Context(), key)
+	if err != nil {
+		s.logger.Error("Failed to retrieve stored steward binary metadata",
+			"error", err,
+			"version", logging.SanitizeLogValue(version),
+			"platform", logging.SanitizeLogValue(platform),
+			"arch", logging.SanitizeLogValue(arch))
+		s.writeErrorResponse(w, http.StatusInternalServerError, "Failed to retrieve binary metadata", "METADATA_ERROR")
+		return
+	}
+	_ = rc.Close()
+
+	s.writeSuccessResponse(w, stewardBinaryPublishResponse{
+		Version:         version,
+		Platform:        platform,
+		Arch:            arch,
+		Size:            storedMeta.Size,
+		SHA256:          storedMeta.Checksum,
+		PublishedBy:     publishedBy,
+		Publisher:       "cfgms",
+		SignatureDigest: sigDigest,
+	})
+}
+
+// handleGetStewardBinary handles GET /api/v1/installer/steward-binaries/{version}/{platform}/{arch}.
+// Returns the raw binary stream. Returns 404 when the binary is absent for this tenant.
+func (s *Server) handleGetStewardBinary(w http.ResponseWriter, r *http.Request) {
+	if s.blobStore == nil {
+		s.writeErrorResponse(w, http.StatusServiceUnavailable, "Binary storage not available", "SERVICE_UNAVAILABLE")
+		return
+	}
+	tenantID, _ := r.Context().Value(ctxkeys.TenantID).(string)
+	if tenantID == "" {
+		s.writeErrorResponse(w, http.StatusUnauthorized, "Authentication required", "AUTHENTICATION_REQUIRED")
+		return
+	}
+
+	vars := mux.Vars(r)
+	version := vars["version"]
+	platform := vars["platform"]
+	arch := vars["arch"]
+
+	if !stewardBinaryVersionRe.MatchString(version) {
+		s.writeErrorResponse(w, http.StatusBadRequest,
+			"Invalid version: "+logging.SanitizeLogValue(version)+"; must match ^v\\d+\\.\\d+\\.\\d+",
+			"INVALID_VERSION")
+		return
+	}
+	if !validPlatforms[platform] {
+		s.writeErrorResponse(w, http.StatusBadRequest,
+			"Unknown platform: "+logging.SanitizeLogValue(platform)+"; valid values: windows, darwin, linux",
+			"INVALID_PLATFORM")
+		return
+	}
+	if !validArchs[arch] {
+		s.writeErrorResponse(w, http.StatusBadRequest,
+			"Unknown arch: "+logging.SanitizeLogValue(arch)+"; valid values: amd64, arm64",
+			"INVALID_ARCH")
+		return
+	}
+
+	key := stewardBinaryBlobKey(tenantID, version, platform, arch)
+	rc, meta, err := s.blobStore.GetBlob(r.Context(), key)
+	if err != nil {
+		if errors.Is(err, blob.ErrBlobNotFound) {
+			s.writeErrorResponse(w, http.StatusNotFound, "Steward binary not found", "BINARY_NOT_FOUND")
+			return
+		}
+		s.logger.Error("Failed to get steward binary",
+			"error", err,
+			"version", logging.SanitizeLogValue(version),
+			"platform", logging.SanitizeLogValue(platform),
+			"arch", logging.SanitizeLogValue(arch))
+		s.writeErrorResponse(w, http.StatusInternalServerError, "Failed to get binary", "GET_ERROR")
+		return
+	}
+	defer func() {
+		if cerr := rc.Close(); cerr != nil {
+			s.logger.Warn("failed to close steward binary reader", "error", cerr)
+		}
+	}()
+
+	contentType := meta.ContentType
+	if contentType == "" {
+		contentType = "application/octet-stream"
+	}
+	w.Header().Set("Content-Type", contentType)
+	if meta.Checksum != "" {
+		w.Header().Set("X-CFGMS-SHA256", meta.Checksum)
+	}
+	w.WriteHeader(http.StatusOK)
+	if _, copyErr := io.Copy(w, rc); copyErr != nil {
+		s.logger.Warn("Failed to stream steward binary to client", "error", copyErr)
+	}
+}

--- a/features/controller/api/handlers_steward_binary_test.go
+++ b/features/controller/api/handlers_steward_binary_test.go
@@ -1,0 +1,468 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+package api
+
+import (
+	"bytes"
+	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/gorilla/mux"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cfgis/cfgms/pkg/ctxkeys"
+	"github.com/cfgis/cfgms/pkg/modules/trust"
+	blob "github.com/cfgis/cfgms/pkg/storage/interfaces/blob"
+)
+
+// stewardBinaryTestFixture holds a generated Ed25519 key pair and the trust store
+// wired to the server for signature tests.
+type stewardBinaryTestFixture struct {
+	pub   ed25519.PublicKey
+	priv  ed25519.PrivateKey
+	store *trust.InMemoryTrustStore
+}
+
+// newStewardBinaryFixture generates a fresh Ed25519 key pair and returns a fixture
+// with an InMemoryTrustStore containing the corresponding publisher identity.
+func newStewardBinaryFixture(t *testing.T) stewardBinaryTestFixture {
+	t.Helper()
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	require.NoError(t, err)
+
+	store := trust.NewInMemoryTrustStore()
+	id := trust.PublisherIdentity{
+		Name:      "cfgms",
+		PublicKey: []byte(pub),
+		Algorithm: "ed25519",
+	}
+	require.NoError(t, store.AddPublisher(id))
+	return stewardBinaryTestFixture{pub: pub, priv: priv, store: store}
+}
+
+// setupStewardBinaryServer creates a test server with a real BlobStore and an
+// injectable test trust store so tests can produce valid Ed25519 signatures.
+func setupStewardBinaryServer(t *testing.T) (*Server, stewardBinaryTestFixture) {
+	t.Helper()
+	fix := newStewardBinaryFixture(t)
+	server, _ := setupTestServerWithBlobStore(t)
+	server.stewardBinaryTrustStore = fix.store
+	return server, fix
+}
+
+// signContent signs the SHA-256 hex of content with the fixture private key and returns
+// URL-safe base64 (no padding) signature bytes, as expected by the endpoint.
+func (f stewardBinaryTestFixture) signContent(content []byte) string {
+	sum := sha256.Sum256(content)
+	hash := hex.EncodeToString(sum[:])
+	sig := ed25519.Sign(f.priv, []byte(hash))
+	return base64.RawURLEncoding.EncodeToString(sig)
+}
+
+// doPublish calls handlePublishStewardBinary directly with the given body and signature.
+// Pass sigBase64="" to omit the signature query param.
+// Signature is URL-encoded so base64 '+' characters survive query-param parsing.
+func doPublish(server *Server, version, platform, arch, tenantID, sigBase64 string, body []byte) *httptest.ResponseRecorder {
+	rawURL := "/api/v1/installer/steward-binaries/" + version + "/" + platform + "/" + arch
+	if sigBase64 != "" {
+		q := url.Values{}
+		q.Set("signature", sigBase64)
+		rawURL += "?" + q.Encode()
+	}
+	req := httptest.NewRequest(http.MethodPost, rawURL, bytes.NewReader(body))
+	req = req.WithContext(context.WithValue(req.Context(), ctxkeys.TenantID, tenantID))
+	req = mux.SetURLVars(req, map[string]string{
+		"version":  version,
+		"platform": platform,
+		"arch":     arch,
+	})
+	rec := httptest.NewRecorder()
+	server.handlePublishStewardBinary(rec, req)
+	return rec
+}
+
+// doGet calls handleGetStewardBinary directly.
+func doGet(server *Server, version, platform, arch, tenantID string) *httptest.ResponseRecorder {
+	req := httptest.NewRequest(http.MethodGet,
+		"/api/v1/installer/steward-binaries/"+version+"/"+platform+"/"+arch, nil)
+	req = req.WithContext(context.WithValue(req.Context(), ctxkeys.TenantID, tenantID))
+	req = mux.SetURLVars(req, map[string]string{
+		"version":  version,
+		"platform": platform,
+		"arch":     arch,
+	})
+	rec := httptest.NewRecorder()
+	server.handleGetStewardBinary(rec, req)
+	return rec
+}
+
+// ---- Required tests (AC) ----
+
+// TestPublishEndpoint_RejectsUnsignedUpload verifies that POST without a signature returns 400.
+func TestPublishEndpoint_RejectsUnsignedUpload(t *testing.T) {
+	server, _ := setupStewardBinaryServer(t)
+
+	rec := doPublish(server, "v1.0.0", "linux", "amd64", "test-tenant", "", []byte("binary content"))
+
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	body := rec.Body.String()
+	assert.Contains(t, body, "SIGNATURE_REQUIRED")
+}
+
+// TestPublishEndpoint_RejectsInvalidSignature verifies that POST with wrong signature bytes returns 400.
+func TestPublishEndpoint_RejectsInvalidSignature(t *testing.T) {
+	server, _ := setupStewardBinaryServer(t)
+
+	// 64 bytes of zeros is syntactically valid URL-safe base64 but cryptographically wrong.
+	badSig := base64.RawURLEncoding.EncodeToString(make([]byte, 64))
+	rec := doPublish(server, "v1.0.0", "linux", "amd64", "test-tenant", badSig, []byte("binary content"))
+
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	body := rec.Body.String()
+	assert.Contains(t, body, "SIGNATURE_VERIFICATION_FAILED")
+}
+
+// TestPublishEndpoint_RejectsCrossTenantPublish verifies that a caller without
+// installer:publish:steward permission receives 403. This demonstrates tenant-namespace
+// isolation: a key scoped to tenant-b (without the required permission) cannot publish
+// steward binaries through the authenticated endpoint.
+func TestPublishEndpoint_RejectsCrossTenantPublish(t *testing.T) {
+	server, fix := setupStewardBinaryServer(t)
+
+	// Add an API key for tenant-b that only has installer:read, not installer:publish:steward.
+	server.apiKeys["cross-tenant-key"] = &APIKey{
+		ID:          "cross-tenant-key-id",
+		Key:         "cross-tenant-key",
+		Permissions: []string{"installer:read"},
+		TenantID:    "tenant-b",
+	}
+
+	ts := httptest.NewServer(server.router)
+	defer ts.Close()
+
+	content := []byte("steward binary content for tenant-b test")
+	sigBase64 := fix.signContent(content)
+
+	q := url.Values{}
+	q.Set("signature", sigBase64)
+	reqURL := ts.URL + "/api/v1/installer/steward-binaries/v1.0.0/linux/amd64?" + q.Encode()
+	req, err := http.NewRequestWithContext(context.Background(), "POST", reqURL, bytes.NewReader(content))
+	require.NoError(t, err)
+	req.Header.Set("Authorization", "Bearer cross-tenant-key")
+
+	resp, err := ts.Client().Do(req)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+
+	assert.Equal(t, http.StatusForbidden, resp.StatusCode)
+}
+
+// TestPublishEndpoint_DuplicatePublishReturns409 verifies that a second POST for the
+// same version/platform/arch/tenant returns 409 Conflict.
+func TestPublishEndpoint_DuplicatePublishReturns409(t *testing.T) {
+	server, fix := setupStewardBinaryServer(t)
+
+	content := []byte("steward binary content")
+	sigBase64 := fix.signContent(content)
+
+	// First publish — must succeed.
+	rec1 := doPublish(server, "v1.0.0", "linux", "amd64", "test-tenant", sigBase64, content)
+	require.Equal(t, http.StatusOK, rec1.Code, "first publish must succeed")
+
+	// Second publish with the same coordinates — must return 409.
+	rec2 := doPublish(server, "v1.0.0", "linux", "amd64", "test-tenant", sigBase64, content)
+	assert.Equal(t, http.StatusConflict, rec2.Code)
+	body := rec2.Body.String()
+	assert.Contains(t, body, "DUPLICATE_BINARY")
+}
+
+// TestPublishEndpoint_ValidatesPlatformAndArch verifies that the handler returns 400
+// for unknown platform and arch values in the URL path.
+func TestPublishEndpoint_ValidatesPlatformAndArch(t *testing.T) {
+	server, fix := setupStewardBinaryServer(t)
+	content := []byte("binary")
+	sig := fix.signContent(content)
+
+	t.Run("rejects unknown platform", func(t *testing.T) {
+		rec := doPublish(server, "v1.0.0", "solaris", "amd64", "test-tenant", sig, content)
+		assert.Equal(t, http.StatusBadRequest, rec.Code)
+		assert.Contains(t, rec.Body.String(), "INVALID_PLATFORM")
+	})
+
+	t.Run("rejects unknown arch", func(t *testing.T) {
+		rec := doPublish(server, "v1.0.0", "linux", "ppc64", "test-tenant", sig, content)
+		assert.Equal(t, http.StatusBadRequest, rec.Code)
+		assert.Contains(t, rec.Body.String(), "INVALID_ARCH")
+	})
+}
+
+// ---- Happy path tests ----
+
+// TestHandlePublishStewardBinary_ValidInput verifies a successful publish and correct response fields.
+func TestHandlePublishStewardBinary_ValidInput(t *testing.T) {
+	server, fix := setupStewardBinaryServer(t)
+
+	content := []byte("cfgms-steward binary content")
+	sigBase64 := fix.signContent(content)
+
+	rec := doPublish(server, "v0.5.12", "linux", "amd64", "test-tenant", sigBase64, content)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var resp APIResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+
+	data, ok := resp.Data.(map[string]interface{})
+	require.True(t, ok, "expected object in Data")
+	assert.Equal(t, "v0.5.12", data["version"])
+	assert.Equal(t, "linux", data["platform"])
+	assert.Equal(t, "amd64", data["arch"])
+	assert.NotEmpty(t, data["sha256"], "sha256 must be populated by the blob store")
+	size, _ := data["size"].(float64)
+	assert.Greater(t, size, float64(0), "size must be non-zero")
+	assert.Equal(t, "cfgms", data["publisher"])
+	assert.NotEmpty(t, data["signature_digest"])
+}
+
+// TestHandlePublishStewardBinary_ForceOverwrite verifies that ?force=true replaces an
+// existing binary without returning 409.
+func TestHandlePublishStewardBinary_ForceOverwrite(t *testing.T) {
+	server, fix := setupStewardBinaryServer(t)
+
+	content := []byte("original binary")
+	sigBase64 := fix.signContent(content)
+
+	rec := doPublish(server, "v1.0.0", "linux", "amd64", "test-tenant", sigBase64, content)
+	require.Equal(t, http.StatusOK, rec.Code, "first publish must succeed")
+
+	// Overwrite with --force.
+	newContent := []byte("updated binary")
+	newSig := fix.signContent(newContent)
+	q := url.Values{}
+	q.Set("signature", newSig)
+	q.Set("force", "true")
+	rawURL := "/api/v1/installer/steward-binaries/v1.0.0/linux/amd64?" + q.Encode()
+	req := httptest.NewRequest(http.MethodPost, rawURL, bytes.NewReader(newContent))
+	req = req.WithContext(context.WithValue(req.Context(), ctxkeys.TenantID, "test-tenant"))
+	req = mux.SetURLVars(req, map[string]string{"version": "v1.0.0", "platform": "linux", "arch": "amd64"})
+	rec2 := httptest.NewRecorder()
+	server.handlePublishStewardBinary(rec2, req)
+
+	assert.Equal(t, http.StatusOK, rec2.Code)
+}
+
+// TestHandlePublishStewardBinary_InvalidVersion verifies that a version not matching
+// ^v\d+\.\d+\.\d+ returns 400.
+func TestHandlePublishStewardBinary_InvalidVersion(t *testing.T) {
+	server, fix := setupStewardBinaryServer(t)
+	content := []byte("binary")
+	sigBase64 := fix.signContent(content)
+
+	rec := doPublish(server, "1.0.0", "linux", "amd64", "test-tenant", sigBase64, content)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Contains(t, rec.Body.String(), "INVALID_VERSION")
+}
+
+// TestHandlePublishStewardBinary_InvalidPlatform verifies unknown platform returns 400.
+func TestHandlePublishStewardBinary_InvalidPlatform(t *testing.T) {
+	server, fix := setupStewardBinaryServer(t)
+	content := []byte("binary")
+	sigBase64 := fix.signContent(content)
+
+	rec := doPublish(server, "v1.0.0", "solaris", "amd64", "test-tenant", sigBase64, content)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Contains(t, rec.Body.String(), "INVALID_PLATFORM")
+}
+
+// TestHandlePublishStewardBinary_NoTenant verifies missing auth context returns 401.
+func TestHandlePublishStewardBinary_NoTenant(t *testing.T) {
+	server, fix := setupStewardBinaryServer(t)
+	content := []byte("binary")
+	sigBase64 := fix.signContent(content)
+
+	req := httptest.NewRequest(http.MethodPost,
+		"/api/v1/installer/steward-binaries/v1.0.0/linux/amd64?signature="+sigBase64,
+		bytes.NewReader(content))
+	req = mux.SetURLVars(req, map[string]string{"version": "v1.0.0", "platform": "linux", "arch": "amd64"})
+	rec := httptest.NewRecorder()
+	server.handlePublishStewardBinary(rec, req)
+
+	assert.Equal(t, http.StatusUnauthorized, rec.Code)
+}
+
+// TestHandlePublishStewardBinary_NoBlobStore verifies 503 when blob store is absent.
+func TestHandlePublishStewardBinary_NoBlobStore(t *testing.T) {
+	server := setupTestServer(t)
+	// blobStore is nil by default in setupTestServer.
+
+	req := httptest.NewRequest(http.MethodPost,
+		"/api/v1/installer/steward-binaries/v1.0.0/linux/amd64", bytes.NewReader([]byte("content")))
+	req = req.WithContext(context.WithValue(req.Context(), ctxkeys.TenantID, "test-tenant"))
+	req = mux.SetURLVars(req, map[string]string{"version": "v1.0.0", "platform": "linux", "arch": "amd64"})
+	rec := httptest.NewRecorder()
+	server.handlePublishStewardBinary(rec, req)
+
+	assert.Equal(t, http.StatusServiceUnavailable, rec.Code)
+}
+
+// ---- GET handler tests ----
+
+// TestHandleGetStewardBinary_ReturnsStream verifies GET returns the binary with 200.
+func TestHandleGetStewardBinary_ReturnsStream(t *testing.T) {
+	server, fix := setupStewardBinaryServer(t)
+
+	content := []byte("cfgms-steward-binary-content-for-get-test")
+	sigBase64 := fix.signContent(content)
+
+	// Publish first.
+	rec := doPublish(server, "v1.2.3", "darwin", "arm64", "get-tenant", sigBase64, content)
+	require.Equal(t, http.StatusOK, rec.Code, "publish must succeed before GET test")
+
+	// GET must return the binary stream.
+	getRec := doGet(server, "v1.2.3", "darwin", "arm64", "get-tenant")
+	assert.Equal(t, http.StatusOK, getRec.Code)
+	assert.Equal(t, content, getRec.Body.Bytes())
+	assert.NotEmpty(t, getRec.Header().Get("X-CFGMS-SHA256"))
+}
+
+// TestHandleGetStewardBinary_Returns404WhenAbsent verifies GET returns 404 for missing binary.
+func TestHandleGetStewardBinary_Returns404WhenAbsent(t *testing.T) {
+	server, _ := setupStewardBinaryServer(t)
+
+	rec := doGet(server, "v9.9.9", "linux", "amd64", "test-tenant")
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+	assert.Contains(t, rec.Body.String(), "BINARY_NOT_FOUND")
+}
+
+// TestHandleGetStewardBinary_TenantIsolation verifies that a binary published under
+// tenant A is not accessible under tenant B.
+func TestHandleGetStewardBinary_TenantIsolation(t *testing.T) {
+	server, fix := setupStewardBinaryServer(t)
+
+	content := []byte("tenant-a binary")
+	sigBase64 := fix.signContent(content)
+
+	// Publish under tenant-a.
+	rec := doPublish(server, "v1.0.0", "linux", "amd64", "tenant-a", sigBase64, content)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	// GET from tenant-b must return 404 (different namespace).
+	getRec := doGet(server, "v1.0.0", "linux", "amd64", "tenant-b")
+	assert.Equal(t, http.StatusNotFound, getRec.Code)
+}
+
+// TestHandleGetStewardBinary_NoBlobStore verifies 503 when blob store is absent.
+func TestHandleGetStewardBinary_NoBlobStore(t *testing.T) {
+	server := setupTestServer(t)
+
+	req := httptest.NewRequest(http.MethodGet,
+		"/api/v1/installer/steward-binaries/v1.0.0/linux/amd64", nil)
+	req = req.WithContext(context.WithValue(req.Context(), ctxkeys.TenantID, "test-tenant"))
+	req = mux.SetURLVars(req, map[string]string{"version": "v1.0.0", "platform": "linux", "arch": "amd64"})
+	rec := httptest.NewRecorder()
+	server.handleGetStewardBinary(rec, req)
+
+	assert.Equal(t, http.StatusServiceUnavailable, rec.Code)
+}
+
+// TestHandleGetStewardBinary_ErrorPaths verifies the GET handler validation branches.
+func TestHandleGetStewardBinary_ErrorPaths(t *testing.T) {
+	server, _ := setupStewardBinaryServer(t)
+
+	t.Run("missing tenant returns 401", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet,
+			"/api/v1/installer/steward-binaries/v1.0.0/linux/amd64", nil)
+		req = mux.SetURLVars(req, map[string]string{"version": "v1.0.0", "platform": "linux", "arch": "amd64"})
+		rec := httptest.NewRecorder()
+		server.handleGetStewardBinary(rec, req)
+		assert.Equal(t, http.StatusUnauthorized, rec.Code)
+	})
+
+	t.Run("invalid version returns 400", func(t *testing.T) {
+		rec := doGet(server, "1.0.0", "linux", "amd64", "test-tenant")
+		assert.Equal(t, http.StatusBadRequest, rec.Code)
+		assert.Contains(t, rec.Body.String(), "INVALID_VERSION")
+	})
+
+	t.Run("invalid platform returns 400", func(t *testing.T) {
+		rec := doGet(server, "v1.0.0", "solaris", "amd64", "test-tenant")
+		assert.Equal(t, http.StatusBadRequest, rec.Code)
+		assert.Contains(t, rec.Body.String(), "INVALID_PLATFORM")
+	})
+
+	t.Run("invalid arch returns 400", func(t *testing.T) {
+		rec := doGet(server, "v1.0.0", "linux", "ppc64", "test-tenant")
+		assert.Equal(t, http.StatusBadRequest, rec.Code)
+		assert.Contains(t, rec.Body.String(), "INVALID_ARCH")
+	})
+}
+
+// TestHandlePublishStewardBinary_LabelsStoredCorrectly verifies that BlobMeta.Labels
+// are stored with the expected keys after a successful publish.
+func TestHandlePublishStewardBinary_LabelsStoredCorrectly(t *testing.T) {
+	server, fix := setupStewardBinaryServer(t)
+
+	content := []byte("binary for label test")
+	sigBase64 := fix.signContent(content)
+
+	// Inject an operator identity so published_by is non-empty.
+	q2 := url.Values{}
+	q2.Set("signature", sigBase64)
+	req := httptest.NewRequest(http.MethodPost,
+		"/api/v1/installer/steward-binaries/v2.0.0/windows/amd64?"+q2.Encode(),
+		bytes.NewReader(content))
+	ctx := context.WithValue(req.Context(), ctxkeys.TenantID, "label-tenant")
+	ctx = context.WithValue(ctx, ctxkeys.UserIDKey, "admin@example.com")
+	req = req.WithContext(ctx)
+	req = mux.SetURLVars(req, map[string]string{"version": "v2.0.0", "platform": "windows", "arch": "amd64"})
+	rec := httptest.NewRecorder()
+	server.handlePublishStewardBinary(rec, req)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	// Verify labels via ListBlobs.
+	blobs, err := server.blobStore.ListBlobs(context.Background(), blob.BlobKey{
+		TenantID:  "label-tenant",
+		Namespace: "steward-binaries",
+	})
+	require.NoError(t, err)
+	require.Len(t, blobs, 1)
+
+	labels := blobs[0].Meta.Labels
+	assert.Equal(t, "v2.0.0", labels["version"])
+	assert.Equal(t, "windows", labels["platform"])
+	assert.Equal(t, "amd64", labels["arch"])
+	assert.Equal(t, "admin@example.com", labels["published_by"])
+	assert.Equal(t, "cfgms", labels["publisher"])
+	assert.NotEmpty(t, labels["signature_digest"])
+	assert.NotEmpty(t, labels["signature"])
+	assert.Equal(t, "label-tenant", labels["publisher_tenant"])
+
+	// Verify the response JSON reflects the correct sha256.
+	var apiResp APIResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &apiResp))
+	data, ok := apiResp.Data.(map[string]interface{})
+	require.True(t, ok)
+	assert.Equal(t, "admin@example.com", data["published_by"])
+
+	// Verify io.Reader body can be compared (sanity-check stream content).
+	rc, _, getErr := server.blobStore.GetBlob(context.Background(), blob.BlobKey{
+		TenantID:  "label-tenant",
+		Namespace: "steward-binaries",
+		Name:      "v2.0.0-windows-amd64",
+	})
+	require.NoError(t, getErr)
+	defer func() { _ = rc.Close() }()
+	got, readErr := io.ReadAll(rc)
+	require.NoError(t, readErr)
+	assert.Equal(t, content, got)
+}

--- a/features/controller/api/middleware.go
+++ b/features/controller/api/middleware.go
@@ -154,9 +154,9 @@ func (s *Server) extractAdminPrincipal(r *http.Request) *Principal {
 	}
 	fpSum := sha256.Sum256(peerCert.Raw)
 	return &Principal{
-		ID:              peerCert.Subject.CommonName,
-		Name:            "mtls-admin:" + peerCert.Subject.CommonName,
-		IsAdmin:         true,
+		ID:      peerCert.Subject.CommonName,
+		Name:    "mtls-admin:" + peerCert.Subject.CommonName,
+		IsAdmin: true,
 		// Admin principals have NO tenant scope. Earlier this was
 		// hardcoded to "default" which silently restricted every admin
 		// read to tenant "default" — `cfg steward list` returned 0

--- a/features/controller/api/permissions.go
+++ b/features/controller/api/permissions.go
@@ -75,6 +75,8 @@ var knownPermissions = map[string]bool{
 	"installer:upload": true,
 	"installer:read":   true,
 	"installer:delete": true,
+	// Steward binary publishing (Issue #1944)
+	"installer:publish:steward": true,
 }
 
 // isKnownPermission reports whether p is a recognized permission ID.

--- a/features/controller/api/server.go
+++ b/features/controller/api/server.go
@@ -99,6 +99,7 @@ type Server struct {
 	moduleBundleResolver    resolution.BundleResolver         // Issue #1884: git source resolver for uncached modules
 	moduleBundleApprover    resolution.BundleApprover         // Issue #1884: approval workflow for newly resolved modules
 	moduleTrustStore        trust.TrustStore                  // Issue #1884: publisher trust store consulted during approval
+	stewardBinaryTrustStore trust.TrustStore                  // Issue #1944: overridable trust store for steward binary signature verification (injected in tests)
 	stopCleanup             chan struct{}                     // signals startAPIKeyCleanup to exit
 	cleanupDone             chan struct{}                     // closed when cleanup goroutine exits
 	closeOnce               sync.Once                         // idempotent Close
@@ -483,6 +484,14 @@ func (s *Server) setupRouter() {
 	installer.Handle("/{platform}/{arch}", s.requirePermission("installer", "upload")(http.HandlerFunc(s.handleUploadInstallerArtifact))).Methods("PUT")
 	installer.Handle("/{platform}/{arch}", s.requirePermission("installer", "read")(http.HandlerFunc(s.handleGetInstallerArtifact))).Methods("GET")
 	installer.Handle("/{platform}/{arch}", s.requirePermission("installer", "delete")(http.HandlerFunc(s.handleDeleteInstallerArtifact))).Methods("DELETE")
+
+	// Steward binary publish/get endpoints (Issue #1944).
+	// Distinct from the installer artifact namespace; blobs live under "steward-binaries".
+	stewardBinaries := api.PathPrefix("/installer/steward-binaries").Subrouter()
+	stewardBinaries.Handle("/{version}/{platform}/{arch}",
+		s.requirePermission("installer", "publish:steward")(http.HandlerFunc(s.handlePublishStewardBinary))).Methods("POST")
+	stewardBinaries.Handle("/{version}/{platform}/{arch}",
+		s.requirePermission("installer", "read")(http.HandlerFunc(s.handleGetStewardBinary))).Methods("GET")
 
 	// Installer package download — public, no auth required (Issue #1704).
 	// Assembles a per-platform tar.gz on the fly. The download URL is the distribution mechanism.

--- a/pkg/storage/providers/sqlite/concurrent_processes_test.go
+++ b/pkg/storage/providers/sqlite/concurrent_processes_test.go
@@ -53,7 +53,7 @@ func TestHelperProcess(t *testing.T) {
 		fmt.Fprintf(os.Stderr, "helper %s: openAndInit: %v\n", prefix, err)
 		os.Exit(2)
 	}
-	defer db.Close()
+	defer func() { _ = db.Close() }()
 
 	store := &SQLiteStewardStore{db: db}
 	ctx := context.Background()
@@ -152,7 +152,7 @@ func TestSQLite_TwoProcesses_ConcurrentWrites_NoCorruption(t *testing.T) {
 	// confirm all 1000 records are present.
 	db, err = openAndInit(dbPath)
 	require.NoError(t, err)
-	defer db.Close()
+	defer func() { _ = db.Close() }()
 	store := &SQLiteStewardStore{db: db}
 	records, err := store.ListStewards(context.Background())
 	require.NoError(t, err, "parent ListStewards")


### PR DESCRIPTION
## Summary

- Adds `POST /api/v1/installer/steward-binaries/{version}/{platform}/{arch}` that verifies an Ed25519 publisher signature before storing the binary blob; returns 400 on missing/invalid signature, 409 on duplicate (unless `?force=true`), 403 via `installer:publish:steward` RBAC
- Adds `GET /api/v1/installer/steward-binaries/{version}/{platform}/{arch}` that streams the binary with `X-CFGMS-SHA256` header; returns 404 when absent
- Adds `cfg installer publish --kind=steward --version=... --platform=... --arch=... --binary=... --signature=... [--force]` CLI subcommand
- Adds `installer:publish:steward` RBAC permission
- Documents `steward-binaries` blob namespace in `docs/architecture/operating-model.md`
- Also fixes pre-existing `golangci-lint` failures on develop that were blocking CI (`errcheck` on launcher/sqlite, `gofmt` on 4 files, unused `fakeClock` dead code)

## Key design decisions

- **Blob key format**: `{version}-{platform}-{arch}` (dash-separated, e.g. `v0.5.12-linux-amd64`) — the filesystem blobstore provider rejects `/` in key names
- **Signature encoding**: `base64.RawURLEncoding` (URL-safe, no padding) so the `?signature=` query param survives the existing `safe_text` charset validation middleware without percent-encoding
- **Trust store injection**: `stewardBinaryTrustStore trust.TrustStore` field on Server is nil in production (falls back to `CFGMSPublisherIdentity()`) and set to a fresh `InMemoryTrustStore` with a generated key pair in tests — avoids the all-zero dev key problem without mocks

## Test plan

- [ ] `TestPublishEndpoint_RejectsUnsignedUpload` — 400 SIGNATURE_REQUIRED
- [ ] `TestPublishEndpoint_RejectsInvalidSignature` — 400 SIGNATURE_VERIFICATION_FAILED
- [ ] `TestPublishEndpoint_RejectsCrossTenantPublish` — 403 via full HTTP stack with unpermissioned API key
- [ ] `TestPublishEndpoint_DuplicatePublishReturns409` — 409 DUPLICATE_BINARY on second publish
- [ ] `TestPublishCLI_RequiresPlatformAndArch` — `runInstallerPublish` returns error on missing platform/arch
- [ ] `TestHandleGetStewardBinary_ErrorPaths` — covers all GET validation branches (401, 400×3)
- [ ] `TestHandlePublishStewardBinary_LabelsStoredCorrectly` — BlobMeta.Labels has all 8 expected keys
- [ ] All 160 script tests pass
- [ ] `make lint` — 0 issues (including pre-existing debt fixed in this PR)

Fixes #1944

🤖 Generated with [Claude Code](https://claude.com/claude-code)