### PR TITLE
controller/api: add steward upgrade dispatch API with selector-based fan-out and tenant isolation (Issue #1945)

### DIFF
--- a/docs/architecture/operating-model.md
+++ b/docs/architecture/operating-model.md
@@ -379,6 +379,66 @@ The controller blob store (`pkg/storage/interfaces/blob.BlobStore`) partitions b
 
 Steward binary distribution uses the `steward-binaries` namespace exclusively. Blob keys take the form `{version}-{platform}-{arch}` (e.g. `v0.5.12-linux-amd64`). Binaries must carry a valid Ed25519 publisher signature verified against the CFGMS publisher identity before storage.
 
+## Steward Upgrade Dispatch Flow (Epic #1930)
+
+The controller can push a new steward binary to one or more stewards via a selector-based fan-out.
+The flow enforces an approval gate before dispatch and records per-steward lifecycle state in a durable `UpgradeStore`.
+
+### Dispatch steps
+
+1. **Publish**: operator calls `POST /api/v1/installer/steward-binaries/{version}/{platform}/{arch}`.
+   The controller verifies the Ed25519 publisher signature and stores the blob with `publisher`, `publisher_tenant`, and `signature` labels.
+2. **Approve**: a separate operator (with `installer:approve:steward` permission) sets the `approved_by` label on the blob.
+   The controller records the approver identity in `BlobMeta.Labels["approved_by"]`.
+3. **Dispatch**: operator calls `POST /api/v1/stewards/upgrade` with a fleet selector (e.g. `id:steward-abc`), version, platform, and arch.
+   The controller:
+   a. Parses the selector and applies the caller's tenant scope.
+   b. Resolves matching stewards via `FleetQuery.Search`; drops stewards from other tenants (403 if none remain).
+   c. Verifies the blob's `approved_by` label is non-empty (403 if missing — "published but not approved").
+   d. Recomputes SHA-256 from the stored blob bytes (does not trust `BlobMeta.Checksum`).
+   e. Checks for non-terminal upgrade records per steward; returns 409 if any exist.
+   f. Creates one `UpgradeRecord` per steward (status: `dispatched`) with publisher provenance fields (`Publisher`, `BundleSignature`, `SignatureDigest`) and a 32-byte `OperationNonce` for replay defense.
+   g. Fans out `CommandPushStewardBinary` to each steward via the control plane (fire-and-forget goroutine).
+   h. Returns `202 Accepted` with `upgrade_id` (the first steward's record ID) and `steward_count`.
+
+### Approval state machine
+
+```
+published ──► approved ──► dispatchable
+   │               │
+   └── dispatch    └── dispatch blocked
+       blocked         unblocked
+```
+
+| Blob label       | Meaning |
+|-----------------|---------|
+| (absent)         | Not yet published (blob does not exist) |
+| `published_by`   | Binary has been published; awaiting approval |
+| `approved_by`    | Binary is approved and dispatchable |
+
+### UpgradeRecord lifecycle
+
+```
+dispatched ──► downloaded ──► swapped ──► committed
+                                     └──► rolled_back
+(any state) ──► failed
+```
+
+Terminal states (`committed`, `rolled_back`, `failed`) unblock re-dispatch to the same steward.
+
+### Durable store requirement
+
+The controller refuses dispatch with `503 Service Unavailable` if no durable `UpgradeStore` is
+configured at server startup. There is no silent in-memory fallback — durable state is required
+to survive controller restarts and HA failover replay.
+
+### Rollback
+
+`POST /api/v1/stewards/upgrade/{upgrade_id}/rollback` requires an explicit `version` field
+(named target, not most-recent). The rollback is a dispatch-equivalent action: it looks up the
+original steward, fetches the target-version blob (must be approved), creates a new `UpgradeRecord`,
+and fans out `CommandPushStewardBinary`. Requires `installer:dispatch:steward` permission.
+
 ## Monitoring Export Credentials
 
 OTLP exporter credentials (API keys / bearer tokens) are stored in `pkg/secrets`, not in config files. Configure the secret key name via `config["secret_key"]` and use `NewOTLPExporterWithSecrets` to wire the store at construction time.

--- a/docs/product/feature-boundaries.md
+++ b/docs/product/feature-boundaries.md
@@ -1,0 +1,47 @@
+# CFGMS Feature Boundaries
+
+This document lists what functionality is part of CFGMS OSS (AGPL-3.0) and what is
+available only under a commercial embedding license. All deployment shapes run the same
+AGPL-3.0 code; the distinction is between features shipped in the OSS repository and
+features delivered under a separate commercial agreement.
+
+## Fleet Management
+
+All fleet management features in this section are part of CFGMS OSS.
+
+| Feature | Status | Notes |
+|---------|--------|-------|
+| Steward registration and approval | OSS | Includes token-based and IP-trust bulk approval |
+| Fleet selector (name:, os:, platform:, arch:, tag:, dna.*, id:) | OSS | id: resolves a single steward by device ID |
+| Config push fan-out | OSS | POST /api/v1/config/push — selector-based fan-out via CommandSyncConfig |
+| Steward DNA collection | OSS | Convergence loop reports DNA attributes to controller |
+| Steward module inventory | OSS | GET /api/v1/stewards/{id}/modules |
+| **Steward binary distribution** | **OSS** | POST /api/v1/installer/steward-binaries — publish, approve, dispatch (Epic #1930) |
+| Steward upgrade dispatch | OSS | POST /api/v1/stewards/upgrade — selector-based fan-out via CommandPushStewardBinary with approval gate and durable UpgradeStore (Issue #1945) |
+| Per-steward upgrade status | OSS | GET /api/v1/stewards/upgrade/{upgrade_id} — lifecycle tracking from dispatched → downloaded → swapped → committed/rolled_back |
+| Rollback dispatch | OSS | POST /api/v1/stewards/upgrade/{upgrade_id}/rollback — named-version target only |
+
+## Configuration Management
+
+| Feature | Status | Notes |
+|---------|--------|-------|
+| Cfg push and sync | OSS | Pull and push paths both supported |
+| Config rollback | OSS | Snapshot-based rollback with compliance reporting |
+| Module trust enforcement | OSS | Publisher signing, strict/controller/bypass trust modes |
+
+## Installer Distribution
+
+| Feature | Status | Notes |
+|---------|--------|-------|
+| Installer artifact storage | OSS | BlobStore-backed; PUT/GET/DELETE /api/v1/installer/artifacts |
+| Steward binary publish | OSS | POST /api/v1/installer/steward-binaries/{version}/{platform}/{arch} with Ed25519 signature verification |
+| Binary approval gate | OSS | approved_by label required before dispatch; separate from publish identity |
+| Installer package download | OSS | Public GET /api/v1/installer/download/{platform}/{arch} — assembles per-platform tar.gz on the fly |
+
+## Multi-Tenancy
+
+| Feature | Status | Notes |
+|---------|--------|-------|
+| Recursive parent-child tenant model | OSS | Arbitrary depth; path-based identification |
+| Config inheritance | OSS | Root-to-leaf resolution |
+| Tenant-scoped API keys and permissions | OSS | RBAC with per-tenant key scoping |

--- a/features/controller/api/handlers_upgrade.go
+++ b/features/controller/api/handlers_upgrade.go
@@ -1,0 +1,535 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+package api
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/gorilla/mux"
+
+	"github.com/cfgis/cfgms/features/controller/fleet"
+	cpTypes "github.com/cfgis/cfgms/pkg/controlplane/types"
+	"github.com/cfgis/cfgms/pkg/ctxkeys"
+	"github.com/cfgis/cfgms/pkg/logging"
+	blob "github.com/cfgis/cfgms/pkg/storage/interfaces/blob"
+	business "github.com/cfgis/cfgms/pkg/storage/interfaces/business"
+)
+
+// dispatchUpgradeRequest is the JSON body for POST /api/v1/stewards/upgrade.
+type dispatchUpgradeRequest struct {
+	Selector string `json:"selector"`
+	Version  string `json:"version"`
+	Platform string `json:"platform"`
+	Arch     string `json:"arch"`
+}
+
+// dispatchUpgradeResponse is the JSON body returned on 202 Accepted.
+type dispatchUpgradeResponse struct {
+	UpgradeID    string `json:"upgrade_id"`
+	StewardCount int    `json:"steward_count"`
+	Status       string `json:"status"`
+}
+
+// rollbackRequest is the JSON body for POST /api/v1/stewards/upgrade/{upgrade_id}/rollback.
+type rollbackRequest struct {
+	Version string `json:"version"`
+}
+
+// isTerminalUpgradeStatus reports whether the given upgrade status is terminal
+// (committed, rolled_back, or failed). Non-terminal records block re-dispatch.
+func isTerminalUpgradeStatus(s business.UpgradeStatus) bool {
+	return s == business.UpgradeStatusCommitted ||
+		s == business.UpgradeStatusRolledBack ||
+		s == business.UpgradeStatusFailed
+}
+
+// handleDispatchUpgrade handles POST /api/v1/stewards/upgrade.
+//
+// Resolves the selector against the fleet, enforces tenant isolation, verifies the
+// binary blob is approved, recomputes SHA-256 at dispatch time, creates UpgradeRecords
+// in the durable store, and fans out CommandPushStewardBinary to matching stewards.
+// Returns 202 Accepted immediately; fan-out runs in a background goroutine.
+func (s *Server) handleDispatchUpgrade(w http.ResponseWriter, r *http.Request) {
+	if s.upgradeStore == nil {
+		s.writeErrorResponse(w, http.StatusServiceUnavailable,
+			"Upgrade store not configured; durable UpgradeStore is required",
+			"UPGRADE_STORE_UNAVAILABLE")
+		return
+	}
+	if s.blobStore == nil {
+		s.writeErrorResponse(w, http.StatusServiceUnavailable,
+			"Binary storage not available",
+			"BINARY_STORE_UNAVAILABLE")
+		return
+	}
+
+	callerTenantID, _ := r.Context().Value(ctxkeys.TenantID).(string)
+	if callerTenantID == "" {
+		s.writeErrorResponse(w, http.StatusUnauthorized, "Authentication required", "AUTHENTICATION_REQUIRED")
+		return
+	}
+	callerUserID, _ := r.Context().Value(ctxkeys.UserIDKey).(string)
+
+	var req dispatchUpgradeRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		s.logger.Warn("Failed to decode dispatch upgrade body", "error", err)
+		s.writeErrorResponse(w, http.StatusBadRequest, "Invalid request body", "INVALID_BODY")
+		return
+	}
+
+	if req.Selector == "" || req.Version == "" || req.Platform == "" || req.Arch == "" {
+		s.writeErrorResponse(w, http.StatusBadRequest,
+			"selector, version, platform, and arch are required",
+			"MISSING_FIELDS")
+		return
+	}
+	if !stewardBinaryVersionRe.MatchString(req.Version) {
+		s.writeErrorResponse(w, http.StatusBadRequest,
+			"Invalid version: "+logging.SanitizeLogValue(req.Version)+"; must match ^v\\d+\\.\\d+\\.\\d+",
+			"INVALID_VERSION")
+		return
+	}
+	if !validPlatforms[req.Platform] {
+		s.writeErrorResponse(w, http.StatusBadRequest,
+			"Unknown platform: "+logging.SanitizeLogValue(req.Platform)+"; valid values: windows, darwin, linux",
+			"INVALID_PLATFORM")
+		return
+	}
+	if !validArchs[req.Arch] {
+		s.writeErrorResponse(w, http.StatusBadRequest,
+			"Unknown arch: "+logging.SanitizeLogValue(req.Arch)+"; valid values: amd64, arm64",
+			"INVALID_ARCH")
+		return
+	}
+
+	// Parse selector and apply tenant scope.
+	filter, err := fleet.ParseTargetSelector(req.Selector)
+	if err != nil {
+		s.writeErrorResponse(w, http.StatusBadRequest,
+			"Invalid selector: "+err.Error(),
+			"INVALID_SELECTOR")
+		return
+	}
+	filter.TenantID = callerTenantID
+
+	// Resolve matching stewards.
+	stewards, err := s.fleetQuery.Search(r.Context(), filter)
+	if err != nil {
+		s.logger.Error("Fleet query failed during upgrade dispatch", "error", err)
+		s.writeErrorResponse(w, http.StatusInternalServerError, "Fleet query failed", "FLEET_QUERY_ERROR")
+		return
+	}
+
+	// Enforce tenant isolation: drop stewards from other tenants, return 403 if none remain.
+	var tenantStewards []fleet.StewardResult
+	for _, st := range stewards {
+		if st.TenantID == callerTenantID {
+			tenantStewards = append(tenantStewards, st)
+		}
+	}
+	if len(tenantStewards) == 0 {
+		s.writeErrorResponse(w, http.StatusForbidden,
+			"No stewards in caller tenant match the given selector",
+			"CROSS_TENANT")
+		return
+	}
+
+	// Fetch the approved binary blob.
+	blobKey := stewardBinaryBlobKey(callerTenantID, req.Version, req.Platform, req.Arch)
+	rc, blobMeta, err := s.blobStore.GetBlob(r.Context(), blobKey)
+	if err != nil {
+		if errors.Is(err, blob.ErrBlobNotFound) {
+			s.writeErrorResponse(w, http.StatusNotFound,
+				fmt.Sprintf("Steward binary not found: %s/%s/%s", logging.SanitizeLogValue(req.Version), logging.SanitizeLogValue(req.Platform), logging.SanitizeLogValue(req.Arch)),
+				"BINARY_NOT_FOUND")
+			return
+		}
+		s.logger.Error("Failed to retrieve steward binary", "error", err)
+		s.writeErrorResponse(w, http.StatusInternalServerError, "Failed to retrieve binary", "GET_BINARY_ERROR")
+		return
+	}
+
+	// Recompute SHA-256 from stored blob at dispatch time (do not trust BlobMeta.Checksum).
+	blobContent, err := io.ReadAll(rc)
+	_ = rc.Close()
+	if err != nil {
+		s.logger.Error("Failed to read steward binary for SHA-256 recompute", "error", err)
+		s.writeErrorResponse(w, http.StatusInternalServerError, "Failed to read binary", "READ_BINARY_ERROR")
+		return
+	}
+	blobSum := sha256.Sum256(blobContent)
+	computedSHA256 := hex.EncodeToString(blobSum[:])
+
+	// Approval gate: approved_by label must be present.
+	if blobMeta.Labels["approved_by"] == "" {
+		s.writeErrorResponse(w, http.StatusForbidden,
+			"Binary has not been approved; transition from published to approved state is required before dispatch",
+			"NOT_APPROVED")
+		return
+	}
+
+	// Extract publisher provenance from blob labels.
+	publisher := blobMeta.Labels["publisher"]
+	sigDigest := blobMeta.Labels["signature_digest"]
+	sigBase64 := blobMeta.Labels["signature"]
+	var bundleSig []byte
+	if sigBase64 != "" {
+		bundleSig, err = base64.RawURLEncoding.DecodeString(sigBase64)
+		if err != nil {
+			s.logger.Error("Failed to decode bundle signature from blob label", "error", err)
+			s.writeErrorResponse(w, http.StatusInternalServerError, "Failed to decode signature", "SIGNATURE_DECODE_ERROR")
+			return
+		}
+	}
+
+	// Reject concurrent upgrades and create UpgradeRecords.
+	// For single-steward dispatch (id:) this is one record; upgrade_id = that record's ID.
+	type createdRecord struct {
+		stewardID string
+		upgradeID string
+	}
+	var created []createdRecord
+
+	for _, st := range tenantStewards {
+		// Check for non-terminal upgrade records for this steward.
+		existing, listErr := s.upgradeStore.ListUpgradesBySteward(r.Context(), st.ID)
+		if listErr != nil {
+			s.logger.Error("Failed to list upgrades for steward",
+				"error", listErr,
+				"steward_id", logging.SanitizeLogValue(st.ID))
+			s.writeErrorResponse(w, http.StatusInternalServerError, "Failed to check existing upgrades", "LIST_UPGRADES_ERROR")
+			return
+		}
+		for _, rec := range existing {
+			if !isTerminalUpgradeStatus(rec.Status) {
+				s.writeErrorResponse(w, http.StatusConflict,
+					fmt.Sprintf("Steward %s has a non-terminal upgrade in progress (status: %s)", logging.SanitizeLogValue(st.ID), rec.Status),
+					"CONCURRENT_UPGRADE")
+				return
+			}
+		}
+
+		// Generate nonce for replay defense.
+		nonce := make([]byte, 32)
+		if _, nErr := rand.Read(nonce); nErr != nil {
+			s.logger.Error("Failed to generate operation nonce", "error", nErr)
+			s.writeErrorResponse(w, http.StatusInternalServerError, "Failed to generate nonce", "NONCE_ERROR")
+			return
+		}
+
+		upgradeID := uuid.New().String()
+		record := &business.UpgradeRecord{
+			ID:        upgradeID,
+			StewardID: st.ID,
+			TenantID:  callerTenantID,
+			Version:   req.Version,
+			Platform:  req.Platform,
+			Arch:      req.Arch,
+			SHA256:    computedSHA256,
+			Status:    business.UpgradeStatusDispatched,
+			InitiatedBy: business.InitiatedByIdentity{
+				Subject:    callerUserID,
+				TenantID:   callerTenantID,
+				AuthMethod: "api_key",
+			},
+			Publisher:       publisher,
+			SignatureDigest: sigDigest,
+			BundleSignature: bundleSig,
+			CreatedAt:       time.Now().UTC(),
+			OperationNonce:  nonce,
+			DispatchedAt:    time.Now().UTC(),
+		}
+		if createErr := s.upgradeStore.CreateUpgrade(r.Context(), record); createErr != nil {
+			s.logger.Error("Failed to create upgrade record",
+				"error", createErr,
+				"steward_id", logging.SanitizeLogValue(st.ID))
+			s.writeErrorResponse(w, http.StatusInternalServerError, "Failed to record upgrade", "CREATE_RECORD_ERROR")
+			return
+		}
+		created = append(created, createdRecord{stewardID: st.ID, upgradeID: upgradeID})
+	}
+
+	// Return upgrade_id as the first record's ID (single-steward: maps directly to the record).
+	returnUpgradeID := created[0].upgradeID
+
+	// Fan-out CommandPushStewardBinary — fire-and-forget goroutine.
+	if s.commandPublisher != nil {
+		downloadURL := fmt.Sprintf("/api/v1/tenants/%s/installer/steward-binaries/%s/%s/%s",
+			callerTenantID, req.Version, req.Platform, req.Arch)
+		params := map[string]interface{}{
+			"version":          req.Version,
+			"download_url":     downloadURL,
+			"sha256":           computedSHA256,
+			"platform":         req.Platform,
+			"arch":             req.Arch,
+			"publisher":        publisher,
+			"bundle_signature": base64.RawURLEncoding.EncodeToString(bundleSig),
+		}
+		createdSnapshot := created
+		go func() {
+			for _, entry := range createdSnapshot {
+				if _, pubErr := s.commandPublisher.PublishCommand(
+					context.Background(),
+					entry.stewardID,
+					cpTypes.CommandPushStewardBinary,
+					params,
+				); pubErr != nil {
+					s.logger.Error("Failed to dispatch CommandPushStewardBinary",
+						"error", pubErr,
+						"steward_id", logging.SanitizeLogValue(entry.stewardID),
+						"upgrade_id", entry.upgradeID)
+				} else {
+					s.logger.Info("CommandPushStewardBinary dispatched",
+						"steward_id", logging.SanitizeLogValue(entry.stewardID),
+						"upgrade_id", entry.upgradeID,
+						"version", logging.SanitizeLogValue(req.Version))
+				}
+			}
+		}()
+	}
+
+	s.writeResponse(w, http.StatusAccepted, dispatchUpgradeResponse{
+		UpgradeID:    returnUpgradeID,
+		StewardCount: len(created),
+		Status:       "accepted",
+	})
+}
+
+// handleUpgradeStatus handles GET /api/v1/stewards/upgrade/{upgrade_id}.
+// Returns the upgrade record for the given ID, enforcing tenant isolation.
+func (s *Server) handleUpgradeStatus(w http.ResponseWriter, r *http.Request) {
+	if s.upgradeStore == nil {
+		s.writeErrorResponse(w, http.StatusServiceUnavailable,
+			"Upgrade store not configured",
+			"UPGRADE_STORE_UNAVAILABLE")
+		return
+	}
+
+	callerTenantID, _ := r.Context().Value(ctxkeys.TenantID).(string)
+	if callerTenantID == "" {
+		s.writeErrorResponse(w, http.StatusUnauthorized, "Authentication required", "AUTHENTICATION_REQUIRED")
+		return
+	}
+
+	upgradeID := mux.Vars(r)["upgrade_id"]
+	if upgradeID == "" {
+		s.writeErrorResponse(w, http.StatusBadRequest, "upgrade_id is required", "MISSING_UPGRADE_ID")
+		return
+	}
+
+	record, err := s.upgradeStore.GetUpgrade(r.Context(), upgradeID)
+	if err != nil {
+		if errors.Is(err, business.ErrUpgradeNotFound) {
+			s.writeErrorResponse(w, http.StatusNotFound, "Upgrade record not found", "UPGRADE_NOT_FOUND")
+			return
+		}
+		s.logger.Error("Failed to retrieve upgrade record",
+			"error", err,
+			"upgrade_id", logging.SanitizeLogValue(upgradeID))
+		s.writeErrorResponse(w, http.StatusInternalServerError, "Failed to retrieve upgrade record", "GET_RECORD_ERROR")
+		return
+	}
+
+	// Tenant isolation: caller can only view records in their own tenant.
+	if record.TenantID != callerTenantID {
+		s.writeErrorResponse(w, http.StatusForbidden, "Access denied", "FORBIDDEN")
+		return
+	}
+
+	s.writeSuccessResponse(w, record)
+}
+
+// handleUpgradeRollback handles POST /api/v1/stewards/upgrade/{upgrade_id}/rollback.
+// Dispatches CommandPushStewardBinary for the target version to the steward referenced
+// by the original upgrade record. Requires installer:dispatch:steward permission.
+func (s *Server) handleUpgradeRollback(w http.ResponseWriter, r *http.Request) {
+	if s.upgradeStore == nil {
+		s.writeErrorResponse(w, http.StatusServiceUnavailable,
+			"Upgrade store not configured",
+			"UPGRADE_STORE_UNAVAILABLE")
+		return
+	}
+	if s.blobStore == nil {
+		s.writeErrorResponse(w, http.StatusServiceUnavailable,
+			"Binary storage not available",
+			"BINARY_STORE_UNAVAILABLE")
+		return
+	}
+
+	callerTenantID, _ := r.Context().Value(ctxkeys.TenantID).(string)
+	if callerTenantID == "" {
+		s.writeErrorResponse(w, http.StatusUnauthorized, "Authentication required", "AUTHENTICATION_REQUIRED")
+		return
+	}
+	callerUserID, _ := r.Context().Value(ctxkeys.UserIDKey).(string)
+
+	upgradeID := mux.Vars(r)["upgrade_id"]
+	if upgradeID == "" {
+		s.writeErrorResponse(w, http.StatusBadRequest, "upgrade_id is required", "MISSING_UPGRADE_ID")
+		return
+	}
+
+	// Look up original upgrade record to get steward/tenant/platform/arch.
+	original, err := s.upgradeStore.GetUpgrade(r.Context(), upgradeID)
+	if err != nil {
+		if errors.Is(err, business.ErrUpgradeNotFound) {
+			s.writeErrorResponse(w, http.StatusNotFound, "Upgrade record not found", "UPGRADE_NOT_FOUND")
+			return
+		}
+		s.logger.Error("Failed to retrieve upgrade record for rollback", "error", err)
+		s.writeErrorResponse(w, http.StatusInternalServerError, "Failed to retrieve upgrade record", "GET_RECORD_ERROR")
+		return
+	}
+	if original.TenantID != callerTenantID {
+		s.writeErrorResponse(w, http.StatusForbidden, "Access denied", "FORBIDDEN")
+		return
+	}
+
+	var req rollbackRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		s.writeErrorResponse(w, http.StatusBadRequest, "Invalid request body", "INVALID_BODY")
+		return
+	}
+	if req.Version == "" {
+		s.writeErrorResponse(w, http.StatusBadRequest, "version is required for rollback", "MISSING_VERSION")
+		return
+	}
+	if !stewardBinaryVersionRe.MatchString(req.Version) {
+		s.writeErrorResponse(w, http.StatusBadRequest,
+			"Invalid version: "+logging.SanitizeLogValue(req.Version)+"; must match ^v\\d+\\.\\d+\\.\\d+",
+			"INVALID_VERSION")
+		return
+	}
+
+	// Fetch the rollback binary blob.
+	blobKey := stewardBinaryBlobKey(callerTenantID, req.Version, original.Platform, original.Arch)
+	rc, blobMeta, err := s.blobStore.GetBlob(r.Context(), blobKey)
+	if err != nil {
+		if errors.Is(err, blob.ErrBlobNotFound) {
+			s.writeErrorResponse(w, http.StatusNotFound,
+				fmt.Sprintf("Rollback binary not found: %s/%s/%s", logging.SanitizeLogValue(req.Version), logging.SanitizeLogValue(original.Platform), logging.SanitizeLogValue(original.Arch)),
+				"BINARY_NOT_FOUND")
+			return
+		}
+		s.logger.Error("Failed to retrieve rollback binary", "error", err)
+		s.writeErrorResponse(w, http.StatusInternalServerError, "Failed to retrieve binary", "GET_BINARY_ERROR")
+		return
+	}
+
+	blobContent, err := io.ReadAll(rc)
+	_ = rc.Close()
+	if err != nil {
+		s.logger.Error("Failed to read rollback binary for SHA-256 recompute", "error", err)
+		s.writeErrorResponse(w, http.StatusInternalServerError, "Failed to read binary", "READ_BINARY_ERROR")
+		return
+	}
+	blobSum := sha256.Sum256(blobContent)
+	computedSHA256 := hex.EncodeToString(blobSum[:])
+
+	if blobMeta.Labels["approved_by"] == "" {
+		s.writeErrorResponse(w, http.StatusForbidden,
+			"Rollback binary has not been approved",
+			"NOT_APPROVED")
+		return
+	}
+
+	publisher := blobMeta.Labels["publisher"]
+	sigDigest := blobMeta.Labels["signature_digest"]
+	sigBase64 := blobMeta.Labels["signature"]
+	var bundleSig []byte
+	if sigBase64 != "" {
+		bundleSig, err = base64.RawURLEncoding.DecodeString(sigBase64)
+		if err != nil {
+			s.logger.Error("Failed to decode bundle signature for rollback", "error", err)
+			s.writeErrorResponse(w, http.StatusInternalServerError, "Failed to decode signature", "SIGNATURE_DECODE_ERROR")
+			return
+		}
+	}
+
+	nonce := make([]byte, 32)
+	if _, nErr := rand.Read(nonce); nErr != nil {
+		s.logger.Error("Failed to generate operation nonce for rollback", "error", nErr)
+		s.writeErrorResponse(w, http.StatusInternalServerError, "Failed to generate nonce", "NONCE_ERROR")
+		return
+	}
+
+	rollbackUpgradeID := uuid.New().String()
+	record := &business.UpgradeRecord{
+		ID:        rollbackUpgradeID,
+		StewardID: original.StewardID,
+		TenantID:  callerTenantID,
+		Version:   req.Version,
+		Platform:  original.Platform,
+		Arch:      original.Arch,
+		SHA256:    computedSHA256,
+		Status:    business.UpgradeStatusDispatched,
+		InitiatedBy: business.InitiatedByIdentity{
+			Subject:    callerUserID,
+			TenantID:   callerTenantID,
+			AuthMethod: "api_key",
+		},
+		Publisher:       publisher,
+		SignatureDigest: sigDigest,
+		BundleSignature: bundleSig,
+		CreatedAt:       time.Now().UTC(),
+		OperationNonce:  nonce,
+		DispatchedAt:    time.Now().UTC(),
+	}
+	if createErr := s.upgradeStore.CreateUpgrade(r.Context(), record); createErr != nil {
+		s.logger.Error("Failed to create rollback upgrade record",
+			"error", createErr,
+			"steward_id", logging.SanitizeLogValue(original.StewardID))
+		s.writeErrorResponse(w, http.StatusInternalServerError, "Failed to record rollback upgrade", "CREATE_RECORD_ERROR")
+		return
+	}
+
+	if s.commandPublisher != nil {
+		downloadURL := fmt.Sprintf("/api/v1/tenants/%s/installer/steward-binaries/%s/%s/%s",
+			callerTenantID, req.Version, original.Platform, original.Arch)
+		params := map[string]interface{}{
+			"version":          req.Version,
+			"download_url":     downloadURL,
+			"sha256":           computedSHA256,
+			"platform":         original.Platform,
+			"arch":             original.Arch,
+			"publisher":        publisher,
+			"bundle_signature": base64.RawURLEncoding.EncodeToString(bundleSig),
+		}
+		stewardID := original.StewardID
+		go func() {
+			if _, pubErr := s.commandPublisher.PublishCommand(
+				context.Background(),
+				stewardID,
+				cpTypes.CommandPushStewardBinary,
+				params,
+			); pubErr != nil {
+				s.logger.Error("Failed to dispatch rollback CommandPushStewardBinary",
+					"error", pubErr,
+					"steward_id", logging.SanitizeLogValue(stewardID),
+					"rollback_upgrade_id", rollbackUpgradeID)
+			} else {
+				s.logger.Info("Rollback CommandPushStewardBinary dispatched",
+					"steward_id", logging.SanitizeLogValue(stewardID),
+					"rollback_upgrade_id", rollbackUpgradeID,
+					"version", logging.SanitizeLogValue(req.Version))
+			}
+		}()
+	}
+
+	s.writeResponse(w, http.StatusAccepted, dispatchUpgradeResponse{
+		UpgradeID:    rollbackUpgradeID,
+		StewardCount: 1,
+		Status:       "accepted",
+	})
+}

--- a/features/controller/api/handlers_upgrade_test.go
+++ b/features/controller/api/handlers_upgrade_test.go
@@ -1,0 +1,765 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+package api
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sort"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/gorilla/mux"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cfgis/cfgms/features/controller/fleet"
+	"github.com/cfgis/cfgms/pkg/ctxkeys"
+	blob "github.com/cfgis/cfgms/pkg/storage/interfaces/blob"
+	business "github.com/cfgis/cfgms/pkg/storage/interfaces/business"
+)
+
+// --- Test-only in-memory UpgradeStore ---
+
+type testUpgradeStore struct {
+	mu      sync.RWMutex
+	records map[string]*business.UpgradeRecord
+}
+
+func newTestUpgradeStore() *testUpgradeStore {
+	return &testUpgradeStore{records: make(map[string]*business.UpgradeRecord)}
+}
+
+func (s *testUpgradeStore) CreateUpgrade(_ context.Context, record *business.UpgradeRecord) error {
+	if len(record.BundleSignature) == 0 {
+		return fmt.Errorf("bundle signature is required")
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, exists := s.records[record.ID]; exists {
+		return fmt.Errorf("duplicate upgrade ID: %s", record.ID)
+	}
+	cp := *record
+	s.records[record.ID] = &cp
+	return nil
+}
+
+func (s *testUpgradeStore) UpdateUpgradeStatus(_ context.Context, id string, status business.UpgradeStatus, errorMsg string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	r, ok := s.records[id]
+	if !ok {
+		return business.ErrUpgradeNotFound
+	}
+	r.Status = status
+	r.ErrorMessage = errorMsg
+	if status == business.UpgradeStatusCommitted ||
+		status == business.UpgradeStatusRolledBack ||
+		status == business.UpgradeStatusFailed {
+		now := time.Now().UTC()
+		r.CompletedAt = &now
+	}
+	return nil
+}
+
+func (s *testUpgradeStore) GetUpgrade(_ context.Context, id string) (*business.UpgradeRecord, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	r, ok := s.records[id]
+	if !ok {
+		return nil, business.ErrUpgradeNotFound
+	}
+	cp := *r
+	return &cp, nil
+}
+
+func (s *testUpgradeStore) ListUpgradesBySteward(_ context.Context, stewardID string) ([]*business.UpgradeRecord, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	var out []*business.UpgradeRecord
+	for _, r := range s.records {
+		if r.StewardID == stewardID {
+			cp := *r
+			out = append(out, &cp)
+		}
+	}
+	sort.Slice(out, func(i, j int) bool {
+		return out[i].CreatedAt.After(out[j].CreatedAt)
+	})
+	return out, nil
+}
+
+func (s *testUpgradeStore) ListUpgradesByTenant(_ context.Context, tenantID string) ([]*business.UpgradeRecord, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	var out []*business.UpgradeRecord
+	for _, r := range s.records {
+		if r.TenantID == tenantID {
+			cp := *r
+			out = append(out, &cp)
+		}
+	}
+	sort.Slice(out, func(i, j int) bool {
+		return out[i].CreatedAt.After(out[j].CreatedAt)
+	})
+	return out, nil
+}
+
+func (s *testUpgradeStore) HealthCheck(_ context.Context) error { return nil }
+func (s *testUpgradeStore) Initialize(_ context.Context) error  { return nil }
+func (s *testUpgradeStore) Close() error                        { return nil }
+
+var _ business.UpgradeStore = (*testUpgradeStore)(nil)
+
+// --- Upgrade test helpers ---
+
+// setupUpgradeServer creates a test server with a blob store, upgrade store, and fleet query.
+func setupUpgradeServer(t *testing.T, tenantID string, stewards []fleet.StewardData) (*Server, *testUpgradeStore) {
+	t.Helper()
+	server, _ := setupTestServerWithBlobStore(t)
+	store := newTestUpgradeStore()
+	server.upgradeStore = store
+	server.fleetQuery = fleet.NewMemoryQuery(&fleetTestStewardProvider{stewards: stewards})
+	return server, store
+}
+
+// publishApprovedBinary puts a steward binary blob with approved_by label set.
+// This simulates a binary that has been published AND approved for dispatch.
+func publishApprovedBinary(t *testing.T, server *Server, tenantID, version, platform, arch string) []byte {
+	t.Helper()
+	content := []byte(fmt.Sprintf("cfgms-steward-binary-%s-%s-%s", version, platform, arch))
+	sum := sha256.Sum256(content)
+
+	// Create a fake 64-byte signature
+	fakeSig := make([]byte, 64)
+	for i := range fakeSig {
+		fakeSig[i] = byte(i)
+	}
+	sigDigest := sha256.Sum256(fakeSig)
+
+	key := stewardBinaryBlobKey(tenantID, version, platform, arch)
+	meta := blob.BlobMeta{
+		ContentType: "application/octet-stream",
+		Labels: map[string]string{
+			"version":          version,
+			"platform":         platform,
+			"arch":             arch,
+			"publisher":        "cfgms",
+			"published_by":     "publisher@example.com",
+			"publisher_tenant": tenantID,
+			"signature":        base64.RawURLEncoding.EncodeToString(fakeSig),
+			"signature_digest": hex.EncodeToString(sigDigest[:]),
+			"sha256":           hex.EncodeToString(sum[:]),
+			"approved_by":      "approver@example.com",
+		},
+	}
+	err := server.blobStore.PutBlob(context.Background(), key, bytes.NewReader(content), meta)
+	require.NoError(t, err, "publishApprovedBinary: PutBlob must not fail")
+	return content
+}
+
+// publishUnapprovedBinary puts a steward binary blob WITHOUT approved_by label.
+func publishUnapprovedBinary(t *testing.T, server *Server, tenantID, version, platform, arch string) {
+	t.Helper()
+	content := []byte(fmt.Sprintf("cfgms-steward-binary-%s-%s-%s-unapproved", version, platform, arch))
+	fakeSig := make([]byte, 64)
+	sigDigest := sha256.Sum256(fakeSig)
+
+	key := stewardBinaryBlobKey(tenantID, version, platform, arch)
+	meta := blob.BlobMeta{
+		ContentType: "application/octet-stream",
+		Labels: map[string]string{
+			"version":          version,
+			"platform":         platform,
+			"arch":             arch,
+			"publisher":        "cfgms",
+			"published_by":     "publisher@example.com",
+			"publisher_tenant": tenantID,
+			"signature":        base64.RawURLEncoding.EncodeToString(fakeSig),
+			"signature_digest": hex.EncodeToString(sigDigest[:]),
+			// approved_by intentionally absent
+		},
+	}
+	err := server.blobStore.PutBlob(context.Background(), key, bytes.NewReader(content), meta)
+	require.NoError(t, err, "publishUnapprovedBinary: PutBlob must not fail")
+}
+
+// doDispatchUpgrade calls handleDispatchUpgrade with the given params.
+func doDispatchUpgrade(server *Server, tenantID, selector, version, platform, arch string) *httptest.ResponseRecorder {
+	body := dispatchUpgradeRequest{
+		Selector: selector,
+		Version:  version,
+		Platform: platform,
+		Arch:     arch,
+	}
+	b, _ := json.Marshal(body)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/stewards/upgrade", bytes.NewReader(b))
+	req = req.WithContext(context.WithValue(req.Context(), ctxkeys.TenantID, tenantID))
+	rec := httptest.NewRecorder()
+	server.handleDispatchUpgrade(rec, req)
+	return rec
+}
+
+// doUpgradeStatus calls handleUpgradeStatus for the given upgrade_id.
+func doUpgradeStatus(server *Server, tenantID, upgradeID string) *httptest.ResponseRecorder {
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/stewards/upgrade/"+upgradeID, nil)
+	req = req.WithContext(context.WithValue(req.Context(), ctxkeys.TenantID, tenantID))
+	req = mux.SetURLVars(req, map[string]string{"upgrade_id": upgradeID})
+	rec := httptest.NewRecorder()
+	server.handleUpgradeStatus(rec, req)
+	return rec
+}
+
+// doUpgradeRollback calls handleUpgradeRollback for the given upgrade_id and target version.
+func doUpgradeRollback(server *Server, tenantID, upgradeID, targetVersion string) *httptest.ResponseRecorder {
+	body := rollbackRequest{Version: targetVersion}
+	b, _ := json.Marshal(body)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/stewards/upgrade/"+upgradeID+"/rollback", bytes.NewReader(b))
+	req = req.WithContext(context.WithValue(req.Context(), ctxkeys.TenantID, tenantID))
+	req = mux.SetURLVars(req, map[string]string{"upgrade_id": upgradeID})
+	rec := httptest.NewRecorder()
+	server.handleUpgradeRollback(rec, req)
+	return rec
+}
+
+// --- Required tests (AC) ---
+
+// TestDispatch_RequiresDurableStore verifies that dispatch returns 503 when no
+// durable UpgradeStore is configured (no in-memory fallback).
+func TestDispatch_RequiresDurableStore(t *testing.T) {
+	server, _ := setupTestServerWithBlobStore(t)
+	// upgradeStore is nil — not configured.
+
+	rec := doDispatchUpgrade(server, "tenant-a", "id:steward-1", "v0.5.12", "linux", "amd64")
+
+	assert.Equal(t, http.StatusServiceUnavailable, rec.Code)
+	body := rec.Body.String()
+	assert.Contains(t, body, "UPGRADE_STORE_UNAVAILABLE")
+}
+
+// TestDispatch_RejectsCrossTenantSelector verifies that dispatching with stewards
+// from a different tenant returns 403.
+func TestDispatch_RejectsCrossTenantSelector(t *testing.T) {
+	stewards := []fleet.StewardData{
+		{ID: "steward-other-tenant", TenantID: "tenant-b", Status: "online"},
+	}
+	server, _ := setupUpgradeServer(t, "tenant-a", stewards)
+	publishApprovedBinary(t, server, "tenant-a", "v0.5.12", "linux", "amd64")
+
+	// Caller is tenant-a, but the steward resolved by id: belongs to tenant-b.
+	rec := doDispatchUpgrade(server, "tenant-a", "id:steward-other-tenant", "v0.5.12", "linux", "amd64")
+
+	assert.Equal(t, http.StatusForbidden, rec.Code)
+	body := rec.Body.String()
+	assert.Contains(t, body, "CROSS_TENANT")
+}
+
+// TestDispatch_RejectsUnapprovedBlob verifies that a blob in published state
+// (approved_by label absent) returns 403.
+func TestDispatch_RejectsUnapprovedBlob(t *testing.T) {
+	stewards := []fleet.StewardData{
+		{ID: "steward-1", TenantID: "tenant-a", Status: "online"},
+	}
+	server, _ := setupUpgradeServer(t, "tenant-a", stewards)
+	publishUnapprovedBinary(t, server, "tenant-a", "v0.5.12", "linux", "amd64")
+
+	rec := doDispatchUpgrade(server, "tenant-a", "id:steward-1", "v0.5.12", "linux", "amd64")
+
+	assert.Equal(t, http.StatusForbidden, rec.Code)
+	body := rec.Body.String()
+	assert.Contains(t, body, "NOT_APPROVED")
+}
+
+// TestDispatch_RejectsConcurrentUpgrade verifies that a second dispatch to the
+// same steward with an active (non-terminal) upgrade record returns 409 Conflict.
+func TestDispatch_RejectsConcurrentUpgrade(t *testing.T) {
+	stewards := []fleet.StewardData{
+		{ID: "steward-1", TenantID: "tenant-a", Status: "online"},
+	}
+	server, upgradeStore := setupUpgradeServer(t, "tenant-a", stewards)
+	publishApprovedBinary(t, server, "tenant-a", "v0.5.12", "linux", "amd64")
+
+	// First dispatch must succeed.
+	rec1 := doDispatchUpgrade(server, "tenant-a", "id:steward-1", "v0.5.12", "linux", "amd64")
+	require.Equal(t, http.StatusAccepted, rec1.Code, "first dispatch must succeed: %s", rec1.Body.String())
+
+	// Verify that a non-terminal record now exists.
+	records, err := upgradeStore.ListUpgradesBySteward(context.Background(), "steward-1")
+	require.NoError(t, err)
+	require.NotEmpty(t, records, "first dispatch must have created an upgrade record")
+	assert.Equal(t, business.UpgradeStatusDispatched, records[0].Status)
+
+	// Second dispatch to the same steward must return 409.
+	rec2 := doDispatchUpgrade(server, "tenant-a", "id:steward-1", "v0.5.12", "linux", "amd64")
+	assert.Equal(t, http.StatusConflict, rec2.Code)
+	body := rec2.Body.String()
+	assert.Contains(t, body, "CONCURRENT_UPGRADE")
+}
+
+// --- Happy path tests ---
+
+// TestDispatch_Returns202WithUpgradeID verifies that a valid dispatch request
+// returns 202 Accepted with a non-empty upgrade_id and steward_count=1.
+func TestDispatch_Returns202WithUpgradeID(t *testing.T) {
+	stewards := []fleet.StewardData{
+		{ID: "steward-1", TenantID: "tenant-a", Status: "online"},
+	}
+	server, upgradeStore := setupUpgradeServer(t, "tenant-a", stewards)
+	publishApprovedBinary(t, server, "tenant-a", "v0.5.12", "linux", "amd64")
+
+	rec := doDispatchUpgrade(server, "tenant-a", "id:steward-1", "v0.5.12", "linux", "amd64")
+	require.Equal(t, http.StatusAccepted, rec.Code, "response body: %s", rec.Body.String())
+
+	var resp APIResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	data, ok := resp.Data.(map[string]interface{})
+	require.True(t, ok, "expected Data to be a JSON object")
+	assert.NotEmpty(t, data["upgrade_id"])
+	count, _ := data["steward_count"].(float64)
+	assert.Equal(t, float64(1), count)
+	assert.Equal(t, "accepted", data["status"])
+
+	// Verify an UpgradeRecord was created in the durable store.
+	upgradeID, _ := data["upgrade_id"].(string)
+	record, err := upgradeStore.GetUpgrade(context.Background(), upgradeID)
+	require.NoError(t, err, "upgrade record must be retrievable by upgrade_id")
+	assert.Equal(t, "steward-1", record.StewardID)
+	assert.Equal(t, "tenant-a", record.TenantID)
+	assert.Equal(t, business.UpgradeStatusDispatched, record.Status)
+	assert.Equal(t, "cfgms", record.Publisher)
+	assert.NotEmpty(t, record.BundleSignature)
+	assert.NotEmpty(t, record.OperationNonce)
+	assert.NotEmpty(t, record.SHA256)
+}
+
+// TestDispatch_CreatesRecordWithCorrectProvenance verifies that UpgradeRecord
+// fields are set from blob labels (Publisher, BundleSignature, SignatureDigest).
+func TestDispatch_CreatesRecordWithCorrectProvenance(t *testing.T) {
+	stewards := []fleet.StewardData{
+		{ID: "steward-prov", TenantID: "tenant-prov", Status: "online"},
+	}
+	server, upgradeStore := setupUpgradeServer(t, "tenant-prov", stewards)
+	content := publishApprovedBinary(t, server, "tenant-prov", "v1.0.0", "linux", "amd64")
+
+	rec := doDispatchUpgrade(server, "tenant-prov", "id:steward-prov", "v1.0.0", "linux", "amd64")
+	require.Equal(t, http.StatusAccepted, rec.Code)
+
+	var resp APIResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	data := resp.Data.(map[string]interface{})
+	upgradeID := data["upgrade_id"].(string)
+
+	record, err := upgradeStore.GetUpgrade(context.Background(), upgradeID)
+	require.NoError(t, err)
+
+	// Publisher must come from blob label.
+	assert.Equal(t, "cfgms", record.Publisher)
+	// BundleSignature must be non-empty (decoded from blob label).
+	assert.NotEmpty(t, record.BundleSignature)
+	// SHA-256 must be recomputed from blob content.
+	sum := sha256.Sum256(content)
+	assert.Equal(t, hex.EncodeToString(sum[:]), record.SHA256)
+}
+
+// TestDispatch_NoBlobStore verifies 503 when blob store is not configured.
+func TestDispatch_NoBlobStore(t *testing.T) {
+	stewards := []fleet.StewardData{
+		{ID: "steward-1", TenantID: "tenant-a", Status: "online"},
+	}
+	server := setupTestServer(t)
+	server.upgradeStore = newTestUpgradeStore()
+	server.fleetQuery = fleet.NewMemoryQuery(&fleetTestStewardProvider{stewards: stewards})
+	// blobStore is nil.
+
+	rec := doDispatchUpgrade(server, "tenant-a", "id:steward-1", "v0.5.12", "linux", "amd64")
+
+	assert.Equal(t, http.StatusServiceUnavailable, rec.Code)
+	assert.Contains(t, rec.Body.String(), "BINARY_STORE_UNAVAILABLE")
+}
+
+// TestDispatch_EmptySelectorReturns400 verifies that an empty selector returns 400.
+func TestDispatch_EmptySelectorReturns400(t *testing.T) {
+	stewards := []fleet.StewardData{
+		{ID: "steward-1", TenantID: "tenant-a", Status: "online"},
+	}
+	server, _ := setupUpgradeServer(t, "tenant-a", stewards)
+
+	rec := doDispatchUpgrade(server, "tenant-a", "", "v0.5.12", "linux", "amd64")
+
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+// TestDispatch_NoMatchingStewardsReturns403 verifies 403 when selector matches
+// no stewards in the caller's tenant.
+func TestDispatch_NoMatchingStewardsReturns403(t *testing.T) {
+	server, _ := setupUpgradeServer(t, "tenant-a", nil /* no stewards */)
+	publishApprovedBinary(t, server, "tenant-a", "v0.5.12", "linux", "amd64")
+
+	rec := doDispatchUpgrade(server, "tenant-a", "id:nonexistent-steward", "v0.5.12", "linux", "amd64")
+
+	assert.Equal(t, http.StatusForbidden, rec.Code)
+	assert.Contains(t, rec.Body.String(), "CROSS_TENANT")
+}
+
+// TestDispatch_BlobNotFoundReturns404 verifies 404 when blob does not exist.
+func TestDispatch_BlobNotFoundReturns404(t *testing.T) {
+	stewards := []fleet.StewardData{
+		{ID: "steward-1", TenantID: "tenant-a", Status: "online"},
+	}
+	server, _ := setupUpgradeServer(t, "tenant-a", stewards)
+	// No binary published.
+
+	rec := doDispatchUpgrade(server, "tenant-a", "id:steward-1", "v9.9.9", "linux", "amd64")
+
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+}
+
+// TestDispatch_InvalidVersionReturns400 verifies 400 for invalid version format.
+func TestDispatch_InvalidVersionReturns400(t *testing.T) {
+	stewards := []fleet.StewardData{
+		{ID: "steward-1", TenantID: "tenant-a", Status: "online"},
+	}
+	server, _ := setupUpgradeServer(t, "tenant-a", stewards)
+
+	rec := doDispatchUpgrade(server, "tenant-a", "id:steward-1", "1.0.0", "linux", "amd64")
+
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Contains(t, rec.Body.String(), "INVALID_VERSION")
+}
+
+// TestDispatch_AllowsTerminalRecordReplacement verifies that a second dispatch
+// succeeds when the prior upgrade record is in a terminal state (failed/committed/rolled_back).
+func TestDispatch_AllowsTerminalRecordReplacement(t *testing.T) {
+	stewards := []fleet.StewardData{
+		{ID: "steward-1", TenantID: "tenant-a", Status: "online"},
+	}
+	server, upgradeStore := setupUpgradeServer(t, "tenant-a", stewards)
+	publishApprovedBinary(t, server, "tenant-a", "v0.5.12", "linux", "amd64")
+
+	// First dispatch.
+	rec1 := doDispatchUpgrade(server, "tenant-a", "id:steward-1", "v0.5.12", "linux", "amd64")
+	require.Equal(t, http.StatusAccepted, rec1.Code)
+
+	// Advance the record to a terminal state (failed).
+	var resp1 APIResponse
+	require.NoError(t, json.Unmarshal(rec1.Body.Bytes(), &resp1))
+	data1 := resp1.Data.(map[string]interface{})
+	upgradeID := data1["upgrade_id"].(string)
+	require.NoError(t, upgradeStore.UpdateUpgradeStatus(context.Background(), upgradeID, business.UpgradeStatusFailed, "disk full"))
+
+	// Second dispatch should now succeed (prior record is terminal).
+	rec2 := doDispatchUpgrade(server, "tenant-a", "id:steward-1", "v0.5.12", "linux", "amd64")
+	assert.Equal(t, http.StatusAccepted, rec2.Code)
+}
+
+// TestUpgradeStatus_Returns200WithRecord verifies that GET /stewards/upgrade/{id}
+// returns the upgrade record after a successful dispatch.
+func TestUpgradeStatus_Returns200WithRecord(t *testing.T) {
+	stewards := []fleet.StewardData{
+		{ID: "steward-1", TenantID: "tenant-a", Status: "online"},
+	}
+	server, _ := setupUpgradeServer(t, "tenant-a", stewards)
+	publishApprovedBinary(t, server, "tenant-a", "v0.5.12", "linux", "amd64")
+
+	rec := doDispatchUpgrade(server, "tenant-a", "id:steward-1", "v0.5.12", "linux", "amd64")
+	require.Equal(t, http.StatusAccepted, rec.Code)
+
+	var dispatchResp APIResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &dispatchResp))
+	data := dispatchResp.Data.(map[string]interface{})
+	upgradeID := data["upgrade_id"].(string)
+
+	// Query status.
+	statusRec := doUpgradeStatus(server, "tenant-a", upgradeID)
+	assert.Equal(t, http.StatusOK, statusRec.Code)
+
+	var statusResp APIResponse
+	require.NoError(t, json.Unmarshal(statusRec.Body.Bytes(), &statusResp))
+	statusData, ok := statusResp.Data.(map[string]interface{})
+	require.True(t, ok)
+	// UpgradeRecord has no JSON tags so fields serialize with their Go field names.
+	assert.Equal(t, upgradeID, statusData["ID"])
+	assert.Equal(t, "dispatched", statusData["Status"])
+}
+
+// TestUpgradeStatus_CrossTenantReturns403 verifies that a tenant cannot query
+// another tenant's upgrade record.
+func TestUpgradeStatus_CrossTenantReturns403(t *testing.T) {
+	stewards := []fleet.StewardData{
+		{ID: "steward-1", TenantID: "tenant-a", Status: "online"},
+	}
+	server, _ := setupUpgradeServer(t, "tenant-a", stewards)
+	publishApprovedBinary(t, server, "tenant-a", "v0.5.12", "linux", "amd64")
+
+	rec := doDispatchUpgrade(server, "tenant-a", "id:steward-1", "v0.5.12", "linux", "amd64")
+	require.Equal(t, http.StatusAccepted, rec.Code)
+
+	var dispatchResp APIResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &dispatchResp))
+	data := dispatchResp.Data.(map[string]interface{})
+	upgradeID := data["upgrade_id"].(string)
+
+	// tenant-b must not see tenant-a's record.
+	statusRec := doUpgradeStatus(server, "tenant-b", upgradeID)
+	assert.Equal(t, http.StatusForbidden, statusRec.Code)
+}
+
+// TestUpgradeStatus_NotFoundReturns404 verifies 404 for unknown upgrade_id.
+func TestUpgradeStatus_NotFoundReturns404(t *testing.T) {
+	server, _ := setupUpgradeServer(t, "tenant-a", nil)
+
+	statusRec := doUpgradeStatus(server, "tenant-a", "no-such-upgrade")
+	assert.Equal(t, http.StatusNotFound, statusRec.Code)
+}
+
+// TestUpgradeStatus_NoDurableStoreReturns503 verifies 503 when upgradeStore is nil.
+func TestUpgradeStatus_NoDurableStoreReturns503(t *testing.T) {
+	server := setupTestServer(t)
+	// upgradeStore is nil.
+
+	statusRec := doUpgradeStatus(server, "tenant-a", "some-id")
+	assert.Equal(t, http.StatusServiceUnavailable, statusRec.Code)
+}
+
+// TestUpgradeRollback_Returns202 verifies that a rollback dispatch returns 202
+// given an approved binary at the target version.
+func TestUpgradeRollback_Returns202(t *testing.T) {
+	stewards := []fleet.StewardData{
+		{ID: "steward-1", TenantID: "tenant-a", Status: "online"},
+	}
+	server, upgradeStore := setupUpgradeServer(t, "tenant-a", stewards)
+	publishApprovedBinary(t, server, "tenant-a", "v0.5.12", "linux", "amd64")
+	publishApprovedBinary(t, server, "tenant-a", "v0.5.11", "linux", "amd64")
+
+	// Create an initial upgrade record so rollback has something to reference.
+	rec := doDispatchUpgrade(server, "tenant-a", "id:steward-1", "v0.5.12", "linux", "amd64")
+	require.Equal(t, http.StatusAccepted, rec.Code)
+
+	var dispatchResp APIResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &dispatchResp))
+	data := dispatchResp.Data.(map[string]interface{})
+	upgradeID := data["upgrade_id"].(string)
+
+	// Mark original upgrade as committed so rollback doesn't conflict.
+	require.NoError(t, upgradeStore.UpdateUpgradeStatus(context.Background(), upgradeID, business.UpgradeStatusCommitted, ""))
+
+	// Rollback to v0.5.11.
+	rollbackRec := doUpgradeRollback(server, "tenant-a", upgradeID, "v0.5.11")
+	assert.Equal(t, http.StatusAccepted, rollbackRec.Code, "body: %s", rollbackRec.Body.String())
+}
+
+// TestUpgradeRollback_NoDurableStoreReturns503 verifies 503 when upgradeStore is nil.
+func TestUpgradeRollback_NoDurableStoreReturns503(t *testing.T) {
+	server, _ := setupTestServerWithBlobStore(t)
+	// upgradeStore is nil.
+
+	rollbackRec := doUpgradeRollback(server, "tenant-a", "some-id", "v0.5.11")
+	assert.Equal(t, http.StatusServiceUnavailable, rollbackRec.Code)
+}
+
+// TestUpgradeRollback_MissingVersionReturns400 verifies 400 when target version
+// is omitted from rollback body.
+func TestUpgradeRollback_MissingVersionReturns400(t *testing.T) {
+	stewards := []fleet.StewardData{
+		{ID: "steward-1", TenantID: "tenant-a", Status: "online"},
+	}
+	server, upgradeStore := setupUpgradeServer(t, "tenant-a", stewards)
+
+	// Create a record manually so the rollback has something to look up.
+	fakeSig := make([]byte, 64)
+	record := &business.UpgradeRecord{
+		ID:              "upgrade-for-rollback",
+		StewardID:       "steward-1",
+		TenantID:        "tenant-a",
+		Version:         "v0.5.12",
+		Platform:        "linux",
+		Arch:            "amd64",
+		Status:          business.UpgradeStatusCommitted,
+		Publisher:       "cfgms",
+		BundleSignature: fakeSig,
+		CreatedAt:       time.Now().UTC(),
+		OperationNonce:  make([]byte, 32),
+	}
+	require.NoError(t, upgradeStore.CreateUpgrade(context.Background(), record))
+
+	rollbackRec := doUpgradeRollback(server, "tenant-a", "upgrade-for-rollback", "" /* empty version */)
+	assert.Equal(t, http.StatusBadRequest, rollbackRec.Code)
+}
+
+// TestUpgradeStatus_MissingTenantReturns401 verifies 401 when caller has no tenant.
+func TestUpgradeStatus_MissingTenantReturns401(t *testing.T) {
+	server, _ := setupUpgradeServer(t, "tenant-a", nil)
+	server.upgradeStore = newTestUpgradeStore()
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/stewards/upgrade/some-id", nil)
+	// No TenantID in context.
+	req = mux.SetURLVars(req, map[string]string{"upgrade_id": "some-id"})
+	rec := httptest.NewRecorder()
+	server.handleUpgradeStatus(rec, req)
+
+	assert.Equal(t, http.StatusUnauthorized, rec.Code)
+}
+
+// TestUpgradeRollback_MissingTenantReturns401 verifies 401 when caller has no tenant.
+func TestUpgradeRollback_MissingTenantReturns401(t *testing.T) {
+	server, _ := setupUpgradeServer(t, "tenant-a", nil)
+	server.upgradeStore = newTestUpgradeStore()
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/stewards/upgrade/some-id/rollback",
+		bytes.NewReader([]byte(`{"version":"v0.5.11"}`)))
+	// No TenantID in context.
+	req = mux.SetURLVars(req, map[string]string{"upgrade_id": "some-id"})
+	rec := httptest.NewRecorder()
+	server.handleUpgradeRollback(rec, req)
+
+	assert.Equal(t, http.StatusUnauthorized, rec.Code)
+}
+
+// TestUpgradeRollback_CrossTenantReturns403 verifies that a tenant cannot roll
+// back another tenant's upgrade record.
+func TestUpgradeRollback_CrossTenantReturns403(t *testing.T) {
+	stewards := []fleet.StewardData{
+		{ID: "steward-1", TenantID: "tenant-a", Status: "online"},
+	}
+	server, upgradeStore := setupUpgradeServer(t, "tenant-a", stewards)
+
+	// Create an upgrade record owned by tenant-a.
+	fakeSig := make([]byte, 64)
+	record := &business.UpgradeRecord{
+		ID:              "upgrade-tenant-a",
+		StewardID:       "steward-1",
+		TenantID:        "tenant-a",
+		Version:         "v0.5.12",
+		Platform:        "linux",
+		Arch:            "amd64",
+		Status:          business.UpgradeStatusCommitted,
+		Publisher:       "cfgms",
+		BundleSignature: fakeSig,
+		CreatedAt:       time.Now().UTC(),
+		OperationNonce:  make([]byte, 32),
+	}
+	require.NoError(t, upgradeStore.CreateUpgrade(context.Background(), record))
+
+	// tenant-b attempts rollback of tenant-a's record.
+	rollbackRec := doUpgradeRollback(server, "tenant-b", "upgrade-tenant-a", "v0.5.11")
+	assert.Equal(t, http.StatusForbidden, rollbackRec.Code)
+}
+
+// TestUpgradeRollback_BinaryNotFoundReturns404 verifies 404 when the rollback
+// target binary is absent from the blob store.
+func TestUpgradeRollback_BinaryNotFoundReturns404(t *testing.T) {
+	stewards := []fleet.StewardData{
+		{ID: "steward-1", TenantID: "tenant-a", Status: "online"},
+	}
+	server, upgradeStore := setupUpgradeServer(t, "tenant-a", stewards)
+	// No rollback binary published for v0.5.11.
+
+	fakeSig := make([]byte, 64)
+	record := &business.UpgradeRecord{
+		ID:              "upgrade-for-404-rollback",
+		StewardID:       "steward-1",
+		TenantID:        "tenant-a",
+		Version:         "v0.5.12",
+		Platform:        "linux",
+		Arch:            "amd64",
+		Status:          business.UpgradeStatusCommitted,
+		Publisher:       "cfgms",
+		BundleSignature: fakeSig,
+		CreatedAt:       time.Now().UTC(),
+		OperationNonce:  make([]byte, 32),
+	}
+	require.NoError(t, upgradeStore.CreateUpgrade(context.Background(), record))
+
+	rollbackRec := doUpgradeRollback(server, "tenant-a", "upgrade-for-404-rollback", "v0.5.11")
+	assert.Equal(t, http.StatusNotFound, rollbackRec.Code)
+	assert.Contains(t, rollbackRec.Body.String(), "BINARY_NOT_FOUND")
+}
+
+// TestUpgradeRollback_UnapprovedBinaryReturns403 verifies 403 when the rollback
+// target binary exists but has not been approved.
+func TestUpgradeRollback_UnapprovedBinaryReturns403(t *testing.T) {
+	stewards := []fleet.StewardData{
+		{ID: "steward-1", TenantID: "tenant-a", Status: "online"},
+	}
+	server, upgradeStore := setupUpgradeServer(t, "tenant-a", stewards)
+	publishUnapprovedBinary(t, server, "tenant-a", "v0.5.11", "linux", "amd64")
+
+	fakeSig := make([]byte, 64)
+	record := &business.UpgradeRecord{
+		ID:              "upgrade-for-403-rollback",
+		StewardID:       "steward-1",
+		TenantID:        "tenant-a",
+		Version:         "v0.5.12",
+		Platform:        "linux",
+		Arch:            "amd64",
+		Status:          business.UpgradeStatusCommitted,
+		Publisher:       "cfgms",
+		BundleSignature: fakeSig,
+		CreatedAt:       time.Now().UTC(),
+		OperationNonce:  make([]byte, 32),
+	}
+	require.NoError(t, upgradeStore.CreateUpgrade(context.Background(), record))
+
+	rollbackRec := doUpgradeRollback(server, "tenant-a", "upgrade-for-403-rollback", "v0.5.11")
+	assert.Equal(t, http.StatusForbidden, rollbackRec.Code)
+	assert.Contains(t, rollbackRec.Body.String(), "NOT_APPROVED")
+}
+
+// TestDispatch_InvalidBody verifies 400 for malformed JSON body.
+func TestDispatch_InvalidBody(t *testing.T) {
+	server, _ := setupUpgradeServer(t, "tenant-a", nil)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/stewards/upgrade",
+		bytes.NewReader([]byte("not-json")))
+	req = req.WithContext(context.WithValue(req.Context(), ctxkeys.TenantID, "tenant-a"))
+	rec := httptest.NewRecorder()
+	server.handleDispatchUpgrade(rec, req)
+
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+// TestDispatch_MissingTenantReturns401 verifies 401 when caller has no tenant.
+func TestDispatch_MissingTenantReturns401(t *testing.T) {
+	server, _ := setupUpgradeServer(t, "tenant-a", nil)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/stewards/upgrade",
+		bytes.NewReader([]byte(`{"selector":"id:s1","version":"v0.5.12","platform":"linux","arch":"amd64"}`)))
+	// No TenantID in context.
+	rec := httptest.NewRecorder()
+	server.handleDispatchUpgrade(rec, req)
+
+	assert.Equal(t, http.StatusUnauthorized, rec.Code)
+}
+
+// TestDispatch_UpgradeStoreRecordsCanBeReadByStatus verifies end-to-end: dispatch
+// creates a record that the status endpoint can retrieve.
+func TestDispatch_UpgradeStoreRecordsCanBeReadByStatus(t *testing.T) {
+	stewards := []fleet.StewardData{
+		{ID: "steward-e2e", TenantID: "tenant-e2e", Status: "online"},
+	}
+	server, _ := setupUpgradeServer(t, "tenant-e2e", stewards)
+	publishApprovedBinary(t, server, "tenant-e2e", "v0.5.12", "linux", "amd64")
+
+	rec := doDispatchUpgrade(server, "tenant-e2e", "id:steward-e2e", "v0.5.12", "linux", "amd64")
+	require.Equal(t, http.StatusAccepted, rec.Code)
+
+	var dispatchResp APIResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &dispatchResp))
+	upgradeID := dispatchResp.Data.(map[string]interface{})["upgrade_id"].(string)
+
+	statusRec := doUpgradeStatus(server, "tenant-e2e", upgradeID)
+	require.Equal(t, http.StatusOK, statusRec.Code)
+
+	var statusResp APIResponse
+	require.NoError(t, json.Unmarshal(statusRec.Body.Bytes(), &statusResp))
+	statusData := statusResp.Data.(map[string]interface{})
+	assert.Equal(t, "steward-e2e", statusData["StewardID"])
+}

--- a/features/controller/api/permissions.go
+++ b/features/controller/api/permissions.go
@@ -79,6 +79,9 @@ var knownPermissions = map[string]bool{
 	"installer:delete": true,
 	// Steward binary publishing (Issue #1944)
 	"installer:publish:steward": true,
+	// Steward upgrade dispatch and approval (Issue #1945)
+	"installer:dispatch:steward": true,
+	"installer:approve:steward":  true,
 }
 
 // isKnownPermission reports whether p is a recognized permission ID.

--- a/features/controller/api/server.go
+++ b/features/controller/api/server.go
@@ -100,6 +100,7 @@ type Server struct {
 	moduleBundleApprover    resolution.BundleApprover         // Issue #1884: approval workflow for newly resolved modules
 	moduleTrustStore        trust.TrustStore                  // Issue #1884: publisher trust store consulted during approval
 	stewardBinaryTrustStore trust.TrustStore                  // Issue #1944: overridable trust store for steward binary signature verification (injected in tests)
+	upgradeStore            business.UpgradeStore             // Issue #1945: durable per-steward upgrade state; nil means dispatch is refused with 503
 	stopCleanup             chan struct{}                     // signals startAPIKeyCleanup to exit
 	cleanupDone             chan struct{}                     // closed when cleanup goroutine exits
 	closeOnce               sync.Once                         // idempotent Close
@@ -497,6 +498,16 @@ func (s *Server) setupRouter() {
 	stewardBinaries.Handle("/{version}/{platform}/{arch}",
 		s.requirePermission("installer", "read")(http.HandlerFunc(s.handleGetStewardBinary))).Methods("GET")
 
+	// Steward upgrade dispatch endpoints (Issue #1945).
+	// Always registered — handlers return 503 when upgradeStore is nil (nil-safe by design).
+	stewardUpgrade := api.PathPrefix("/stewards/upgrade").Subrouter()
+	stewardUpgrade.Handle("",
+		s.requirePermission("installer", "dispatch:steward")(http.HandlerFunc(s.handleDispatchUpgrade))).Methods("POST")
+	stewardUpgrade.Handle("/{upgrade_id}",
+		s.requirePermission("installer", "read")(http.HandlerFunc(s.handleUpgradeStatus))).Methods("GET")
+	stewardUpgrade.Handle("/{upgrade_id}/rollback",
+		s.requirePermission("installer", "dispatch:steward")(http.HandlerFunc(s.handleUpgradeRollback))).Methods("POST")
+
 	// Installer package download — public, no auth required (Issue #1704).
 	// Assembles a per-platform tar.gz on the fly. The download URL is the distribution mechanism.
 	s.router.HandleFunc("/api/v1/installer/download/{platform}/{arch}", s.handleDownloadInstallPackage).Methods("GET")
@@ -831,6 +842,15 @@ func (s *Server) SetIPTrustStore(store business.IPTrustStore) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.ipTrustStore = store
+}
+
+// SetUpgradeStore wires the durable UpgradeStore used by the steward upgrade
+// dispatch endpoint (Issue #1945). When nil, POST /api/v1/stewards/upgrade
+// returns 503. No silent in-memory fallback.
+func (s *Server) SetUpgradeStore(store business.UpgradeStore) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.upgradeStore = store
 }
 
 // SetSigningRotationService wires the signing rotation service for the

--- a/features/steward/dna/security_linux.go
+++ b/features/steward/dna/security_linux.go
@@ -67,7 +67,7 @@ func linuxParsePasswdCount() (int, error) {
 	if err != nil {
 		return 0, err
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	count := 0
 	scanner := bufio.NewScanner(f)
@@ -160,7 +160,7 @@ func linuxSSSDDomain() string {
 	if err != nil {
 		return ""
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	scanner := bufio.NewScanner(f)
 	for scanner.Scan() {
@@ -186,7 +186,7 @@ func linuxParseGroupFile() (int, int) {
 	if err != nil {
 		return 0, 0
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	groupCount := 0
 	adminsCount := 0


### PR DESCRIPTION
## Summary

- Adds `POST /api/v1/stewards/upgrade` — selector-based fleet fan-out dispatching `CommandPushStewardBinary` to matched stewards, enforcing the approval gate (`approved_by` label on blob), recomputing SHA-256 from blob bytes at dispatch time, blocking concurrent non-terminal upgrades (409), and refusing dispatch with no durable UpgradeStore (503)
- Adds `GET /api/v1/stewards/upgrade/{upgrade_id}` — per-steward upgrade lifecycle status with tenant isolation
- Adds `POST /api/v1/stewards/upgrade/{upgrade_id}/rollback` — named-version rollback dispatch through the same approval gate
- Adds `UpgradeStore` field to `api.Server` (wired via `SetUpgradeStore`), two new permissions (`installer:dispatch:steward`, `installer:approve:steward`), and full lifecycle tracking: dispatched → downloaded → swapped → committed / rolled_back / failed
- Creates `docs/product/feature-boundaries.md` enumerating OSS vs commercial boundaries
- Updates `docs/architecture/operating-model.md` with Steward Upgrade Dispatch Flow section
- Fixes pre-existing `errcheck` violations in `features/steward/dna/security_linux.go` (`defer f.Close()` → `defer func() { _ = f.Close() }()`)

## Acceptance criteria verified

- `TestDispatch_RejectsCrossTenantSelector` — cross-tenant stewards dropped; 403 when none remain
- `TestDispatch_RejectsUnapprovedBlob` — 403 when `approved_by` label absent
- `TestDispatch_RejectsConcurrentUpgrade` — 409 when a non-terminal upgrade record already exists for the steward
- `TestDispatch_RequiresDurableStore` — 503 when `upgradeStore` is nil

27 upgrade-specific tests, 121s api package run, all pass.

## Test plan

- [x] `make test-agent-complete` — all gates green (unit, integration, lint, security scan, cross-platform build, 160/160 script tests)
- [x] Security engineer review — PASS
- [x] QA code reviewer — PASS
- [x] QA test runner — PASS

Fixes #1945

🤖 Generated with [Claude Code](https://claude.com/claude-code)