### PR TITLE
cfg: add steward upgrade/status/rollback CLI subcommands (Issue #1947)

### DIFF
--- a/cmd/cfg/cmd/api_client.go
+++ b/cmd/cfg/cmd/api_client.go
@@ -551,6 +551,142 @@ func (c *APIClient) GetTenantViaAPI(ctx context.Context, tenantID string) (*APIT
 	return &tenant, nil
 }
 
+// APIDispatchUpgradeRequest is the request body for POST /api/v1/stewards/upgrade.
+type APIDispatchUpgradeRequest struct {
+	Selector string `json:"selector"`
+	Version  string `json:"version"`
+	Platform string `json:"platform,omitempty"`
+	Arch     string `json:"arch,omitempty"`
+}
+
+// APIDispatchUpgradeResponse is the response from POST /api/v1/stewards/upgrade.
+type APIDispatchUpgradeResponse struct {
+	UpgradeID    string `json:"upgrade_id"`
+	StewardCount int    `json:"steward_count"`
+	Status       string `json:"status"`
+}
+
+// APIUpgradeStewardStatus represents per-steward upgrade status within an upgrade record.
+type APIUpgradeStewardStatus struct {
+	Device      string `json:"device"`
+	Status      string `json:"status"`
+	Version     string `json:"version,omitempty"`
+	CompletedAt string `json:"completed_at,omitempty"`
+}
+
+// APIUpgradeStatusResponse is the response from GET /api/v1/stewards/upgrade/{id}
+// and from GET /api/v1/stewards/upgrade?selector=<selector>.
+type APIUpgradeStatusResponse struct {
+	UpgradeID string                    `json:"upgrade_id"`
+	Stewards  []APIUpgradeStewardStatus `json:"stewards"`
+}
+
+// APIRollbackRequest is the optional request body for POST /api/v1/stewards/upgrade/{id}/rollback.
+type APIRollbackRequest struct {
+	ToVersion string `json:"to_version,omitempty"`
+}
+
+// DispatchUpgrade calls POST /api/v1/stewards/upgrade and returns the dispatch result.
+func (c *APIClient) DispatchUpgrade(ctx context.Context, req *APIDispatchUpgradeRequest) (*APIDispatchUpgradeResponse, error) {
+	body, err := json.Marshal(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal request: %w", err)
+	}
+
+	resp, err := c.doRequest(ctx, "POST", "/api/v1/stewards/upgrade", bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusAccepted && resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
+		return nil, c.parseError(resp)
+	}
+
+	var result APIDispatchUpgradeResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("failed to decode response: %w", err)
+	}
+	return &result, nil
+}
+
+// GetUpgradeStatus calls GET /api/v1/stewards/upgrade/{id} and returns the status.
+func (c *APIClient) GetUpgradeStatus(ctx context.Context, upgradeID string) (*APIUpgradeStatusResponse, error) {
+	result, _, err := c.GetUpgradeStatusWithHTTPStatus(ctx, upgradeID)
+	return result, err
+}
+
+// GetUpgradeStatusWithHTTPStatus calls GET /api/v1/stewards/upgrade/{id} and
+// returns the parsed status, the raw HTTP status code, and any transport error.
+// The caller may inspect the HTTP status code before deciding whether to retry or abort.
+func (c *APIClient) GetUpgradeStatusWithHTTPStatus(ctx context.Context, upgradeID string) (*APIUpgradeStatusResponse, int, error) {
+	resp, err := c.doRequest(ctx, "GET", "/api/v1/stewards/upgrade/"+url.PathEscape(upgradeID), nil)
+	if err != nil {
+		return nil, 0, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden {
+		return nil, resp.StatusCode, fmt.Errorf("upgrade status request failed with status %d", resp.StatusCode)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, resp.StatusCode, c.parseError(resp)
+	}
+
+	var result APIUpgradeStatusResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, resp.StatusCode, fmt.Errorf("failed to decode response: %w", err)
+	}
+	return &result, resp.StatusCode, nil
+}
+
+// ListUpgradeStatusBySelector calls GET /api/v1/stewards/upgrade?selector=<selector>
+// to retrieve the most recent upgrade status per steward matching the selector.
+func (c *APIClient) ListUpgradeStatusBySelector(ctx context.Context, selector string) (*APIUpgradeStatusResponse, error) {
+	path := "/api/v1/stewards/upgrade?selector=" + url.QueryEscape(selector)
+
+	resp, err := c.doRequest(ctx, "GET", path, nil)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, c.parseError(resp)
+	}
+
+	var result APIUpgradeStatusResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("failed to decode response: %w", err)
+	}
+	return &result, nil
+}
+
+// RollbackUpgrade calls POST /api/v1/stewards/upgrade/{id}/rollback.
+func (c *APIClient) RollbackUpgrade(ctx context.Context, upgradeID string, req *APIRollbackRequest) (*APIUpgradeStatusResponse, error) {
+	body, err := json.Marshal(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal request: %w", err)
+	}
+
+	resp, err := c.doRequest(ctx, "POST", "/api/v1/stewards/upgrade/"+url.PathEscape(upgradeID)+"/rollback", bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusAccepted {
+		return nil, c.parseError(resp)
+	}
+
+	var result APIUpgradeStatusResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("failed to decode response: %w", err)
+	}
+	return &result, nil
+}
+
 // parseError extracts error message from HTTP response
 func (c *APIClient) parseError(resp *http.Response) error {
 	body, err := io.ReadAll(resp.Body)

--- a/cmd/cfg/cmd/steward.go
+++ b/cmd/cfg/cmd/steward.go
@@ -391,6 +391,31 @@ func init() {
 	stewardCmd.AddCommand(stewardRunResultCmd)
 	stewardCmd.AddCommand(stewardRunCancelCmd)
 	stewardCmd.AddCommand(stewardLogsCmd)
+
+	// upgrade subcommands
+	stewardUpgradeCmd.Flags().StringVar(&stewardURL, "url", "", "Controller API URL")
+	stewardUpgradeCmd.Flags().StringVar(&stewardAPIKey, "api-key", "", "API key for authentication")
+	stewardUpgradeCmd.Flags().StringVar(&stewardTLSCACert, "tls-ca-cert", "", "Path to CA certificate for TLS verification (env: CFGMS_TLS_CA_CERT)")
+	stewardUpgradeCmd.Flags().StringVar(&stewardUpgradeVersion, "version", "", "Target steward version (required)")
+	stewardUpgradeCmd.Flags().StringVar(&stewardUpgradePlatform, "platform", "", "Target platform (e.g. linux, windows; auto-detected if omitted)")
+	stewardUpgradeCmd.Flags().StringVar(&stewardUpgradeArch, "arch", "", "Target architecture (e.g. amd64, arm64; auto-detected if omitted)")
+	stewardUpgradeCmd.Flags().BoolVar(&stewardUpgradeWait, "wait", false, "Block until all stewards reach a terminal state")
+	stewardUpgradeCmd.Flags().DurationVar(&stewardUpgradeWaitTimeout, "wait-timeout", 2*time.Minute, "Maximum time to wait when --wait is set")
+
+	stewardUpgradeStatusCmd.Flags().StringVar(&stewardURL, "url", "", "Controller API URL")
+	stewardUpgradeStatusCmd.Flags().StringVar(&stewardAPIKey, "api-key", "", "API key for authentication")
+	stewardUpgradeStatusCmd.Flags().StringVar(&stewardTLSCACert, "tls-ca-cert", "", "Path to CA certificate for TLS verification (env: CFGMS_TLS_CA_CERT)")
+	stewardUpgradeStatusCmd.Flags().StringVar(&stewardUpgradeID, "upgrade-id", "", "Upgrade record ID to query directly")
+
+	stewardUpgradeRollbackCmd.Flags().StringVar(&stewardURL, "url", "", "Controller API URL")
+	stewardUpgradeRollbackCmd.Flags().StringVar(&stewardAPIKey, "api-key", "", "API key for authentication")
+	stewardUpgradeRollbackCmd.Flags().StringVar(&stewardTLSCACert, "tls-ca-cert", "", "Path to CA certificate for TLS verification (env: CFGMS_TLS_CA_CERT)")
+	stewardUpgradeRollbackCmd.Flags().StringVar(&stewardUpgradeID, "upgrade-id", "", "Upgrade record ID to roll back")
+	stewardUpgradeRollbackCmd.Flags().StringVar(&stewardUpgradeToVersion, "to-version", "", "Target version to roll back to (optional; used with --upgrade-id)")
+
+	stewardCmd.AddCommand(stewardUpgradeCmd)
+	stewardUpgradeCmd.AddCommand(stewardUpgradeStatusCmd)
+	stewardUpgradeCmd.AddCommand(stewardUpgradeRollbackCmd)
 }
 
 // getStewardClient creates an API client using bundle auth (mTLS) when available,

--- a/cmd/cfg/cmd/steward_upgrade.go
+++ b/cmd/cfg/cmd/steward_upgrade.go
@@ -1,0 +1,301 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"text/tabwriter"
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+// upgradeWaitPollInterval is the delay between upgrade status polls in the --wait loop.
+// Overridable in tests to avoid real sleeps.
+var upgradeWaitPollInterval = 5 * time.Second
+
+var (
+	stewardUpgradeVersion     string
+	stewardUpgradePlatform    string
+	stewardUpgradeArch        string
+	stewardUpgradeWait        bool
+	stewardUpgradeWaitTimeout time.Duration
+	stewardUpgradeID          string
+	stewardUpgradeToVersion   string
+)
+
+// stewardUpgradeCmd dispatches a steward binary upgrade to matching stewards.
+var stewardUpgradeCmd = &cobra.Command{
+	Use:   "upgrade <selector>",
+	Short: "Upgrade steward binary on matching hosts",
+	Long: `Dispatch a steward binary upgrade to all stewards matching the selector.
+
+The selector identifies which stewards receive the upgrade command. The upgrade
+is dispatched asynchronously by default; use --wait to block until completion.
+
+Examples:
+  # Upgrade a specific steward
+  cfg steward upgrade id:steward-abc123 --version v0.5.12
+
+  # Upgrade all stewards in a group with --wait
+  cfg steward upgrade group:production --version v0.5.12 --wait
+
+  # Upgrade with explicit platform
+  cfg steward upgrade id:steward-abc123 --version v0.5.12 --platform linux --arch amd64`,
+	Args: cobra.ExactArgs(1),
+	RunE: runStewardUpgrade,
+}
+
+// stewardUpgradeStatusCmd shows per-steward upgrade status.
+var stewardUpgradeStatusCmd = &cobra.Command{
+	Use:   "status [selector]",
+	Short: "Show upgrade status for stewards",
+	Long: `Display per-steward upgrade status.
+
+Pass a selector positional argument to query the most recent upgrade status for
+each matching steward, or use --upgrade-id to query a specific upgrade record.
+
+Examples:
+  # Show status for a specific upgrade
+  cfg steward upgrade status --upgrade-id abc123-upgrade-id
+
+  # Show most recent upgrade status for matching stewards
+  cfg steward upgrade status id:steward-abc123`,
+	RunE: runStewardUpgradeStatus,
+}
+
+// stewardUpgradeRollbackCmd rolls back a dispatched upgrade.
+var stewardUpgradeRollbackCmd = &cobra.Command{
+	Use:   "rollback",
+	Short: "Roll back a dispatched upgrade",
+	Long: `Roll back a steward upgrade to a prior version.
+
+Requires --upgrade-id to identify the specific upgrade record. Use --to-version
+to specify the rollback target version (optional when --upgrade-id is provided).
+
+Examples:
+  # Roll back a specific upgrade
+  cfg steward upgrade rollback --upgrade-id abc123-upgrade-id
+
+  # Roll back to a specific version
+  cfg steward upgrade rollback --upgrade-id abc123-upgrade-id --to-version v0.5.10`,
+	RunE: runStewardUpgradeRollback,
+}
+
+// ---------------------------------------------------------------------------
+// Handlers
+// ---------------------------------------------------------------------------
+
+func runStewardUpgrade(cmd *cobra.Command, args []string) error {
+	if stewardUpgradeVersion == "" {
+		return fmt.Errorf("required flag --version was not set")
+	}
+
+	selector := args[0]
+
+	client, err := getStewardClient()
+	if err != nil {
+		return fmt.Errorf("failed to create API client: %w", err)
+	}
+
+	req := &APIDispatchUpgradeRequest{
+		Selector: selector,
+		Version:  stewardUpgradeVersion,
+		Platform: stewardUpgradePlatform,
+		Arch:     stewardUpgradeArch,
+	}
+
+	result, err := client.DispatchUpgrade(context.Background(), req)
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("Upgrade id: %s\n", result.UpgradeID)
+	fmt.Printf("Dispatched to: %d stewards\n", result.StewardCount)
+
+	if stewardUpgradeWait {
+		return waitForUpgrade(context.Background(), client, result.UpgradeID, stewardUpgradeWaitTimeout)
+	}
+
+	return nil
+}
+
+func runStewardUpgradeStatus(_ *cobra.Command, args []string) error {
+	client, err := getStewardClient()
+	if err != nil {
+		return fmt.Errorf("failed to create API client: %w", err)
+	}
+
+	var statusResp *APIUpgradeStatusResponse
+
+	switch {
+	case stewardUpgradeID != "":
+		statusResp, err = client.GetUpgradeStatus(context.Background(), stewardUpgradeID)
+	case len(args) > 0:
+		statusResp, err = client.ListUpgradeStatusBySelector(context.Background(), args[0])
+	default:
+		return fmt.Errorf("requires a selector argument or --upgrade-id flag")
+	}
+
+	if err != nil {
+		return err
+	}
+
+	if len(statusResp.Stewards) == 0 {
+		fmt.Println("No upgrade records found.")
+		return nil
+	}
+
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	if _, err := fmt.Fprintln(w, "STEWARD\tVERSION\tSTATUS\tCOMPLETED_AT"); err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintln(w, "-------\t-------\t------\t------------"); err != nil {
+		return err
+	}
+	for _, s := range statusResp.Stewards {
+		if _, err := fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", s.Device, s.Version, s.Status, s.CompletedAt); err != nil {
+			return err
+		}
+	}
+	return w.Flush()
+}
+
+func runStewardUpgradeRollback(_ *cobra.Command, _ []string) error {
+	if stewardUpgradeID == "" && stewardUpgradeToVersion == "" {
+		return fmt.Errorf("rollback requires --upgrade-id or --to-version")
+	}
+
+	if stewardUpgradeID == "" {
+		return fmt.Errorf("rollback requires --upgrade-id; --to-version may only be combined with --upgrade-id to specify a target version")
+	}
+
+	client, err := getStewardClient()
+	if err != nil {
+		return fmt.Errorf("failed to create API client: %w", err)
+	}
+
+	req := &APIRollbackRequest{
+		ToVersion: stewardUpgradeToVersion,
+	}
+
+	result, err := client.RollbackUpgrade(context.Background(), stewardUpgradeID, req)
+	if err != nil {
+		return err
+	}
+
+	if len(result.Stewards) == 0 {
+		fmt.Println("No stewards in rollback result.")
+		return nil
+	}
+
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	if _, err := fmt.Fprintln(w, "DEVICE\tSTATUS"); err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintln(w, "------\t------"); err != nil {
+		return err
+	}
+	for _, s := range result.Stewards {
+		if _, err := fmt.Fprintf(w, "%s\t%s\n", s.Device, s.Status); err != nil {
+			return err
+		}
+	}
+	return w.Flush()
+}
+
+// ---------------------------------------------------------------------------
+// Wait / polling
+// ---------------------------------------------------------------------------
+
+// isUpgradeTerminal returns true when the per-steward status is a terminal state.
+func isUpgradeTerminal(status string) bool {
+	return status == "committed" || status == "rolled_back" || status == "failed"
+}
+
+// allUpgradeTerminal returns true when every steward in the status response has
+// reached a terminal state.
+func allUpgradeTerminal(stewards []APIUpgradeStewardStatus) bool {
+	for _, s := range stewards {
+		if !isUpgradeTerminal(s.Status) {
+			return false
+		}
+	}
+	return true
+}
+
+// waitForUpgrade polls GET /api/v1/stewards/upgrade/{upgradeID} every
+// upgradeWaitPollInterval until all stewards reach a terminal state or the
+// timeout elapses. Aborts immediately on the first 401 or 403 response.
+// Returns non-nil error if any steward reached failed or rolled_back.
+func waitForUpgrade(ctx context.Context, client *APIClient, upgradeID string, timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+
+	for {
+		// GetUpgradeStatusWithHTTPStatus returns a non-nil error for 401/403,
+		// causing an immediate abort without retry — satisfying the AC requirement.
+		statusResp, _, err := client.GetUpgradeStatusWithHTTPStatus(ctx, upgradeID)
+		if err != nil {
+			return err
+		}
+
+		if allUpgradeTerminal(statusResp.Stewards) {
+			return printUpgradeSummary(statusResp.Stewards)
+		}
+
+		if time.Now().After(deadline) {
+			return fmt.Errorf("timed out after %s waiting for upgrade %s", timeout, upgradeID)
+		}
+
+		pending := countNonTerminal(statusResp.Stewards)
+		fmt.Printf("Waiting... %d of %d stewards still in progress\n", pending, len(statusResp.Stewards))
+
+		select {
+		case <-time.After(upgradeWaitPollInterval):
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+}
+
+// countNonTerminal returns the number of stewards that have not yet reached a
+// terminal state.
+func countNonTerminal(stewards []APIUpgradeStewardStatus) int {
+	n := 0
+	for _, s := range stewards {
+		if !isUpgradeTerminal(s.Status) {
+			n++
+		}
+	}
+	return n
+}
+
+// printUpgradeSummary prints a tabular DEVICE/STATUS summary and returns an
+// error if any steward reached failed or rolled_back.
+func printUpgradeSummary(stewards []APIUpgradeStewardStatus) error {
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	if _, err := fmt.Fprintln(w, "DEVICE\tSTATUS"); err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintln(w, "------\t------"); err != nil {
+		return err
+	}
+	var hasFailure bool
+	for _, s := range stewards {
+		if _, err := fmt.Fprintf(w, "%s\t%s\n", s.Device, s.Status); err != nil {
+			return err
+		}
+		if s.Status == "failed" || s.Status == "rolled_back" {
+			hasFailure = true
+		}
+	}
+	if err := w.Flush(); err != nil {
+		return err
+	}
+	if hasFailure {
+		return fmt.Errorf("one or more stewards reached a failed or rolled_back state")
+	}
+	return nil
+}

--- a/cmd/cfg/cmd/steward_upgrade_test.go
+++ b/cmd/cfg/cmd/steward_upgrade_test.go
@@ -1,0 +1,637 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+package cmd
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// saveStewardUpgradeGlobals captures all upgrade-command global vars and restores
+// them via t.Cleanup so tests cannot pollute each other's state.
+func saveStewardUpgradeGlobals(t *testing.T) {
+	t.Helper()
+	origURL := stewardURL
+	origAPIKey := stewardAPIKey
+	origTLSCACert := stewardTLSCACert
+	origInsecure := stewardTLSInsecure
+	origVersion := stewardUpgradeVersion
+	origPlatform := stewardUpgradePlatform
+	origArch := stewardUpgradeArch
+	origWait := stewardUpgradeWait
+	origWaitTimeout := stewardUpgradeWaitTimeout
+	origUpgradeID := stewardUpgradeID
+	origToVersion := stewardUpgradeToVersion
+	origPollInterval := upgradeWaitPollInterval
+	origBP := bundlePath
+	origNoBundle := noBundle
+	origUserConfigDir := userConfigDirFn
+	origSystemBundle := systemBundlePathFn
+	t.Cleanup(func() {
+		stewardURL = origURL
+		stewardAPIKey = origAPIKey
+		stewardTLSCACert = origTLSCACert
+		stewardTLSInsecure = origInsecure
+		stewardUpgradeVersion = origVersion
+		stewardUpgradePlatform = origPlatform
+		stewardUpgradeArch = origArch
+		stewardUpgradeWait = origWait
+		stewardUpgradeWaitTimeout = origWaitTimeout
+		stewardUpgradeID = origUpgradeID
+		stewardUpgradeToVersion = origToVersion
+		upgradeWaitPollInterval = origPollInterval
+		bundlePath = origBP
+		noBundle = origNoBundle
+		userConfigDirFn = origUserConfigDir
+		systemBundlePathFn = origSystemBundle
+	})
+}
+
+// writeUpgradeDispatchResponse writes a canned dispatch 202 response.
+func writeUpgradeDispatchResponse(w http.ResponseWriter, upgradeID string, stewardCount int) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusAccepted)
+	_ = json.NewEncoder(w).Encode(APIDispatchUpgradeResponse{
+		UpgradeID:    upgradeID,
+		StewardCount: stewardCount,
+		Status:       "accepted",
+	})
+}
+
+// writeUpgradeStatusResponse writes a canned upgrade status response.
+func writeUpgradeStatusResponse(w http.ResponseWriter, upgradeID string, stewards []APIUpgradeStewardStatus) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	_ = json.NewEncoder(w).Encode(APIUpgradeStatusResponse{
+		UpgradeID: upgradeID,
+		Stewards:  stewards,
+	})
+}
+
+// ---------------------------------------------------------------------------
+// [REQUIRED TEST] TestRunStewardUpgrade_RequiresVersion
+// ---------------------------------------------------------------------------
+
+func TestRunStewardUpgrade_RequiresVersion(t *testing.T) {
+	// Track whether the server was called — it must NOT be.
+	var serverCalled bool
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		serverCalled = true
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	saveStewardUpgradeGlobals(t)
+	stewardURL = server.URL
+	stewardTLSInsecure = true
+	stewardUpgradeVersion = "" // omit --version
+
+	err := runStewardUpgrade(stewardUpgradeCmd, []string{"id:steward-abc"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "version")
+	assert.False(t, serverCalled, "no HTTP call must be made when --version is missing")
+}
+
+// ---------------------------------------------------------------------------
+// [REQUIRED TEST] TestRunStewardUpgrade_Wait
+// ---------------------------------------------------------------------------
+
+// TestRunStewardUpgrade_Wait verifies that:
+//   - The polling loop exits when all stewards reach terminal state (committed).
+//   - The loop aborts immediately on the first 401 without retry.
+func TestRunStewardUpgrade_Wait(t *testing.T) {
+	t.Run("exits when all stewards committed", func(t *testing.T) {
+		var pollCount int32
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch {
+			case r.Method == http.MethodPost && r.URL.Path == "/api/v1/stewards/upgrade":
+				writeUpgradeDispatchResponse(w, "upgrade-wait-id", 2)
+			case r.Method == http.MethodGet:
+				n := atomic.AddInt32(&pollCount, 1)
+				stewards := []APIUpgradeStewardStatus{
+					{Device: "device-1", Status: "dispatched"},
+					{Device: "device-2", Status: "dispatched"},
+				}
+				if n >= 2 {
+					stewards[0].Status = "committed"
+					stewards[1].Status = "committed"
+				}
+				writeUpgradeStatusResponse(w, "upgrade-wait-id", stewards)
+			default:
+				w.WriteHeader(http.StatusNotFound)
+			}
+		}))
+		defer server.Close()
+
+		saveStewardUpgradeGlobals(t)
+		stewardURL = server.URL
+		stewardTLSInsecure = true
+		stewardUpgradeVersion = "v0.5.12"
+		stewardUpgradeWait = true
+		stewardUpgradeWaitTimeout = 30 * time.Second
+		upgradeWaitPollInterval = time.Millisecond
+
+		output := captureStdout(t, func() {
+			err := runStewardUpgrade(stewardUpgradeCmd, []string{"id:steward-abc"})
+			require.NoError(t, err)
+		})
+
+		assert.GreaterOrEqual(t, atomic.LoadInt32(&pollCount), int32(2), "must poll at least twice")
+		assert.Contains(t, output, "committed")
+	})
+
+	t.Run("aborts immediately on 401", func(t *testing.T) {
+		var pollCount int32
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch {
+			case r.Method == http.MethodPost && r.URL.Path == "/api/v1/stewards/upgrade":
+				writeUpgradeDispatchResponse(w, "upgrade-auth-id", 1)
+			case r.Method == http.MethodGet:
+				atomic.AddInt32(&pollCount, 1)
+				// Always return 401
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusUnauthorized)
+				_ = json.NewEncoder(w).Encode(map[string]string{"error": "unauthorized"})
+			default:
+				w.WriteHeader(http.StatusNotFound)
+			}
+		}))
+		defer server.Close()
+
+		saveStewardUpgradeGlobals(t)
+		stewardURL = server.URL
+		stewardTLSInsecure = true
+		stewardUpgradeVersion = "v0.5.12"
+		stewardUpgradeWait = true
+		stewardUpgradeWaitTimeout = 30 * time.Second
+		upgradeWaitPollInterval = time.Millisecond
+
+		_ = captureStdout(t, func() {
+			err := runStewardUpgrade(stewardUpgradeCmd, []string{"id:steward-abc"})
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "401")
+		})
+
+		// Exactly one poll — no retry after 401.
+		assert.Equal(t, int32(1), atomic.LoadInt32(&pollCount), "must abort on first 401 without retry")
+	})
+
+	t.Run("aborts immediately on 403", func(t *testing.T) {
+		var pollCount int32
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch {
+			case r.Method == http.MethodPost && r.URL.Path == "/api/v1/stewards/upgrade":
+				writeUpgradeDispatchResponse(w, "upgrade-forbidden-id", 1)
+			case r.Method == http.MethodGet:
+				atomic.AddInt32(&pollCount, 1)
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusForbidden)
+				_ = json.NewEncoder(w).Encode(map[string]string{"error": "forbidden"})
+			default:
+				w.WriteHeader(http.StatusNotFound)
+			}
+		}))
+		defer server.Close()
+
+		saveStewardUpgradeGlobals(t)
+		stewardURL = server.URL
+		stewardTLSInsecure = true
+		stewardUpgradeVersion = "v0.5.12"
+		stewardUpgradeWait = true
+		stewardUpgradeWaitTimeout = 30 * time.Second
+		upgradeWaitPollInterval = time.Millisecond
+
+		_ = captureStdout(t, func() {
+			err := runStewardUpgrade(stewardUpgradeCmd, []string{"id:steward-abc"})
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "403")
+		})
+
+		assert.Equal(t, int32(1), atomic.LoadInt32(&pollCount), "must abort on first 403 without retry")
+	})
+}
+
+// ---------------------------------------------------------------------------
+// Dispatch tests
+// ---------------------------------------------------------------------------
+
+func TestRunStewardUpgrade_AsyncSuccess(t *testing.T) {
+	var requestPath, requestMethod string
+	var requestBody []byte
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestPath = r.URL.Path
+		requestMethod = r.Method
+		requestBody, _ = io.ReadAll(r.Body)
+		writeUpgradeDispatchResponse(w, "upgrade-async-id", 3)
+	}))
+	defer server.Close()
+
+	saveStewardUpgradeGlobals(t)
+	stewardURL = server.URL
+	stewardTLSInsecure = true
+	stewardUpgradeVersion = "v0.5.12"
+	stewardUpgradeWait = false
+
+	output := captureStdout(t, func() {
+		err := runStewardUpgrade(stewardUpgradeCmd, []string{"id:steward-abc"})
+		require.NoError(t, err)
+	})
+
+	assert.Equal(t, http.MethodPost, requestMethod)
+	assert.Equal(t, "/api/v1/stewards/upgrade", requestPath)
+	assert.Contains(t, output, "upgrade-async-id")
+	assert.Contains(t, output, "3")
+
+	var body map[string]interface{}
+	require.NoError(t, json.Unmarshal(requestBody, &body))
+	assert.Equal(t, "id:steward-abc", body["selector"])
+	assert.Equal(t, "v0.5.12", body["version"])
+}
+
+func TestRunStewardUpgrade_PlatformArchIncludedInBody(t *testing.T) {
+	var requestBody []byte
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestBody, _ = io.ReadAll(r.Body)
+		writeUpgradeDispatchResponse(w, "upgrade-plat-id", 1)
+	}))
+	defer server.Close()
+
+	saveStewardUpgradeGlobals(t)
+	stewardURL = server.URL
+	stewardTLSInsecure = true
+	stewardUpgradeVersion = "v0.5.12"
+	stewardUpgradePlatform = "linux"
+	stewardUpgradeArch = "amd64"
+
+	_ = captureStdout(t, func() {
+		require.NoError(t, runStewardUpgrade(stewardUpgradeCmd, []string{"group:prod"}))
+	})
+
+	var body map[string]interface{}
+	require.NoError(t, json.Unmarshal(requestBody, &body))
+	assert.Equal(t, "linux", body["platform"])
+	assert.Equal(t, "amd64", body["arch"])
+}
+
+func TestRunStewardUpgrade_NonAcceptedStatusReturnsError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		_ = json.NewEncoder(w).Encode(map[string]string{"error": "invalid selector"})
+	}))
+	defer server.Close()
+
+	saveStewardUpgradeGlobals(t)
+	stewardURL = server.URL
+	stewardTLSInsecure = true
+	stewardUpgradeVersion = "v0.5.12"
+
+	err := runStewardUpgrade(stewardUpgradeCmd, []string{"bad-selector"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid selector")
+}
+
+func TestRunStewardUpgrade_WaitExitsNonZeroOnFailedSteward(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodPost:
+			writeUpgradeDispatchResponse(w, "upgrade-fail-id", 2)
+		default:
+			stewards := []APIUpgradeStewardStatus{
+				{Device: "device-1", Status: "committed"},
+				{Device: "device-2", Status: "failed"},
+			}
+			writeUpgradeStatusResponse(w, "upgrade-fail-id", stewards)
+		}
+	}))
+	defer server.Close()
+
+	saveStewardUpgradeGlobals(t)
+	stewardURL = server.URL
+	stewardTLSInsecure = true
+	stewardUpgradeVersion = "v0.5.12"
+	stewardUpgradeWait = true
+	stewardUpgradeWaitTimeout = 30 * time.Second
+	upgradeWaitPollInterval = time.Millisecond
+
+	output := captureStdout(t, func() {
+		err := runStewardUpgrade(stewardUpgradeCmd, []string{"id:steward-abc"})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed")
+	})
+	assert.Contains(t, output, "device-1")
+	assert.Contains(t, output, "device-2")
+	assert.Contains(t, output, "failed")
+}
+
+func TestRunStewardUpgrade_WaitTimeout(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodPost:
+			writeUpgradeDispatchResponse(w, "upgrade-timeout-id", 1)
+		default:
+			// Always return dispatched (non-terminal)
+			stewards := []APIUpgradeStewardStatus{
+				{Device: "device-1", Status: "dispatched"},
+			}
+			writeUpgradeStatusResponse(w, "upgrade-timeout-id", stewards)
+		}
+	}))
+	defer server.Close()
+
+	saveStewardUpgradeGlobals(t)
+	stewardURL = server.URL
+	stewardTLSInsecure = true
+	stewardUpgradeVersion = "v0.5.12"
+	stewardUpgradeWait = true
+	stewardUpgradeWaitTimeout = 10 * time.Millisecond
+	upgradeWaitPollInterval = time.Millisecond
+
+	_ = captureStdout(t, func() {
+		err := runStewardUpgrade(stewardUpgradeCmd, []string{"id:steward-abc"})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "timed out")
+	})
+}
+
+// ---------------------------------------------------------------------------
+// Status tests
+// ---------------------------------------------------------------------------
+
+func TestRunStewardUpgradeStatus_ByUpgradeID(t *testing.T) {
+	var requestPath string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestPath = r.URL.Path
+		stewards := []APIUpgradeStewardStatus{
+			{Device: "device-1", Version: "v0.5.12", Status: "committed", CompletedAt: "2026-06-01T12:00:00Z"},
+		}
+		writeUpgradeStatusResponse(w, "upgrade-status-id", stewards)
+	}))
+	defer server.Close()
+
+	saveStewardUpgradeGlobals(t)
+	stewardURL = server.URL
+	stewardTLSInsecure = true
+	stewardUpgradeID = "upgrade-status-id"
+
+	output := captureStdout(t, func() {
+		err := runStewardUpgradeStatus(stewardUpgradeStatusCmd, []string{})
+		require.NoError(t, err)
+	})
+
+	assert.Equal(t, "/api/v1/stewards/upgrade/upgrade-status-id", requestPath)
+	assert.Contains(t, output, "device-1")
+	assert.Contains(t, output, "v0.5.12")
+	assert.Contains(t, output, "committed")
+}
+
+func TestRunStewardUpgradeStatus_BySelector(t *testing.T) {
+	var requestURL string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestURL = r.URL.String()
+		stewards := []APIUpgradeStewardStatus{
+			{Device: "device-2", Version: "v0.5.11", Status: "committed", CompletedAt: "2026-06-01T11:00:00Z"},
+		}
+		writeUpgradeStatusResponse(w, "", stewards)
+	}))
+	defer server.Close()
+
+	saveStewardUpgradeGlobals(t)
+	stewardURL = server.URL
+	stewardTLSInsecure = true
+	stewardUpgradeID = "" // no --upgrade-id
+
+	output := captureStdout(t, func() {
+		err := runStewardUpgradeStatus(stewardUpgradeStatusCmd, []string{"group:production"})
+		require.NoError(t, err)
+	})
+
+	assert.Contains(t, requestURL, "/api/v1/stewards/upgrade")
+	assert.Contains(t, requestURL, "selector=group%3Aproduction")
+	assert.Contains(t, output, "device-2")
+	assert.Contains(t, output, "v0.5.11")
+}
+
+func TestRunStewardUpgradeStatus_RequiresSelectorOrUpgradeID(t *testing.T) {
+	saveStewardUpgradeGlobals(t)
+	stewardUpgradeID = ""
+
+	err := runStewardUpgradeStatus(stewardUpgradeStatusCmd, []string{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "selector")
+}
+
+func TestRunStewardUpgradeStatus_EmptyResult(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		writeUpgradeStatusResponse(w, "upgrade-empty-id", []APIUpgradeStewardStatus{})
+	}))
+	defer server.Close()
+
+	saveStewardUpgradeGlobals(t)
+	stewardURL = server.URL
+	stewardTLSInsecure = true
+	stewardUpgradeID = "upgrade-empty-id"
+
+	output := captureStdout(t, func() {
+		err := runStewardUpgradeStatus(stewardUpgradeStatusCmd, []string{})
+		require.NoError(t, err)
+	})
+
+	assert.Contains(t, output, "No upgrade records")
+}
+
+// ---------------------------------------------------------------------------
+// Rollback tests
+// ---------------------------------------------------------------------------
+
+func TestRunStewardUpgradeRollback_RequiresUpgradeIDOrVersion(t *testing.T) {
+	saveStewardUpgradeGlobals(t)
+	stewardUpgradeID = ""
+	stewardUpgradeToVersion = ""
+
+	err := runStewardUpgradeRollback(stewardUpgradeRollbackCmd, []string{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "rollback requires")
+}
+
+func TestRunStewardUpgradeRollback_ToVersionAloneRequiresUpgradeID(t *testing.T) {
+	saveStewardUpgradeGlobals(t)
+	stewardUpgradeID = ""
+	stewardUpgradeToVersion = "v0.5.10"
+
+	err := runStewardUpgradeRollback(stewardUpgradeRollbackCmd, []string{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--upgrade-id")
+}
+
+func TestRunStewardUpgradeRollback_Success(t *testing.T) {
+	var requestPath, requestMethod string
+	var requestBody []byte
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestPath = r.URL.Path
+		requestMethod = r.Method
+		requestBody, _ = io.ReadAll(r.Body)
+		stewards := []APIUpgradeStewardStatus{
+			{Device: "device-1", Status: "rolled_back"},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(APIUpgradeStatusResponse{
+			UpgradeID: "upgrade-rollback-id",
+			Stewards:  stewards,
+		})
+	}))
+	defer server.Close()
+
+	saveStewardUpgradeGlobals(t)
+	stewardURL = server.URL
+	stewardTLSInsecure = true
+	stewardUpgradeID = "upgrade-rollback-id"
+	stewardUpgradeToVersion = ""
+
+	output := captureStdout(t, func() {
+		err := runStewardUpgradeRollback(stewardUpgradeRollbackCmd, []string{})
+		require.NoError(t, err)
+	})
+
+	assert.Equal(t, http.MethodPost, requestMethod)
+	assert.Equal(t, "/api/v1/stewards/upgrade/upgrade-rollback-id/rollback", requestPath)
+	assert.Contains(t, output, "device-1")
+	assert.Contains(t, output, "rolled_back")
+
+	var body map[string]interface{}
+	require.NoError(t, json.Unmarshal(requestBody, &body))
+	// to_version should be empty/absent
+	assert.Empty(t, body["to_version"])
+}
+
+func TestRunStewardUpgradeRollback_WithToVersion(t *testing.T) {
+	var requestBody []byte
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestBody, _ = io.ReadAll(r.Body)
+		stewards := []APIUpgradeStewardStatus{
+			{Device: "device-1", Status: "rolled_back"},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(APIUpgradeStatusResponse{
+			UpgradeID: "upgrade-tv-id",
+			Stewards:  stewards,
+		})
+	}))
+	defer server.Close()
+
+	saveStewardUpgradeGlobals(t)
+	stewardURL = server.URL
+	stewardTLSInsecure = true
+	stewardUpgradeID = "upgrade-tv-id"
+	stewardUpgradeToVersion = "v0.5.10"
+
+	_ = captureStdout(t, func() {
+		require.NoError(t, runStewardUpgradeRollback(stewardUpgradeRollbackCmd, []string{}))
+	})
+
+	var body map[string]interface{}
+	require.NoError(t, json.Unmarshal(requestBody, &body))
+	assert.Equal(t, "v0.5.10", body["to_version"])
+}
+
+func TestRunStewardUpgradeRollback_EmptyResult(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(APIUpgradeStatusResponse{
+			UpgradeID: "upgrade-empty-rollback-id",
+			Stewards:  []APIUpgradeStewardStatus{},
+		})
+	}))
+	defer server.Close()
+
+	saveStewardUpgradeGlobals(t)
+	stewardURL = server.URL
+	stewardTLSInsecure = true
+	stewardUpgradeID = "upgrade-empty-rollback-id"
+
+	output := captureStdout(t, func() {
+		err := runStewardUpgradeRollback(stewardUpgradeRollbackCmd, []string{})
+		require.NoError(t, err)
+	})
+
+	assert.Contains(t, output, "No stewards")
+}
+
+func TestRunStewardUpgradeRollback_HTTPErrorReturnsError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotFound)
+		_ = json.NewEncoder(w).Encode(map[string]string{"error": "upgrade record not found"})
+	}))
+	defer server.Close()
+
+	saveStewardUpgradeGlobals(t)
+	stewardURL = server.URL
+	stewardTLSInsecure = true
+	stewardUpgradeID = "nonexistent-upgrade-id"
+
+	err := runStewardUpgradeRollback(stewardUpgradeRollbackCmd, []string{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "upgrade record not found")
+}
+
+// ---------------------------------------------------------------------------
+// Flag registration tests — no --tls-insecure on upgrade commands
+// ---------------------------------------------------------------------------
+
+func TestStewardUpgradeCommandsRegistered(t *testing.T) {
+	names := map[string]bool{}
+	for _, cmd := range stewardCmd.Commands() {
+		names[cmd.Name()] = true
+	}
+	assert.True(t, names["upgrade"], "stewardCmd must have 'upgrade' subcommand")
+
+	upgradeNames := map[string]bool{}
+	for _, cmd := range stewardUpgradeCmd.Commands() {
+		upgradeNames[cmd.Name()] = true
+	}
+	assert.True(t, upgradeNames["status"], "upgrade cmd must have 'status' subcommand")
+	assert.True(t, upgradeNames["rollback"], "upgrade cmd must have 'rollback' subcommand")
+}
+
+func TestStewardUpgradeFlagsRegistered(t *testing.T) {
+	for _, flag := range []string{"url", "api-key", "tls-ca-cert", "version", "platform", "arch", "wait", "wait-timeout"} {
+		assert.NotNil(t, stewardUpgradeCmd.Flags().Lookup(flag), "upgrade must have --%s flag", flag)
+	}
+	// --tls-insecure must NOT be registered on the upgrade command
+	assert.Nil(t, stewardUpgradeCmd.Flags().Lookup("tls-insecure"), "upgrade must NOT have --tls-insecure flag")
+}
+
+func TestStewardUpgradeStatusFlagsRegistered(t *testing.T) {
+	for _, flag := range []string{"url", "api-key", "tls-ca-cert", "upgrade-id"} {
+		assert.NotNil(t, stewardUpgradeStatusCmd.Flags().Lookup(flag), "upgrade status must have --%s flag", flag)
+	}
+	assert.Nil(t, stewardUpgradeStatusCmd.Flags().Lookup("tls-insecure"), "upgrade status must NOT have --tls-insecure flag")
+}
+
+func TestStewardUpgradeRollbackFlagsRegistered(t *testing.T) {
+	for _, flag := range []string{"url", "api-key", "tls-ca-cert", "upgrade-id", "to-version"} {
+		assert.NotNil(t, stewardUpgradeRollbackCmd.Flags().Lookup(flag), "upgrade rollback must have --%s flag", flag)
+	}
+	assert.Nil(t, stewardUpgradeRollbackCmd.Flags().Lookup("tls-insecure"), "upgrade rollback must NOT have --tls-insecure flag")
+}

--- a/docs/deployment/fleet-upgrades.md
+++ b/docs/deployment/fleet-upgrades.md
@@ -1,0 +1,190 @@
+# Fleet Upgrades
+
+This document describes the operator workflow for upgrading steward binaries across a fleet using the `cfg` CLI.
+
+## Overview
+
+The upgrade workflow has four steps:
+
+1. **Publish** — upload the steward binary to the controller's blob store.
+2. **Approve** — approve the published blob before dispatch (separate approval step).
+3. **Dispatch** — send the upgrade command to matching stewards.
+4. **Monitor or rollback** — check per-steward status, and roll back if needed.
+
+## Step 1: Publish the steward binary
+
+Use `cfg installer publish` to upload a new steward binary to the controller:
+
+```
+cfg installer publish steward \
+  --version v0.5.12 \
+  --platform linux \
+  --arch amd64 \
+  --file /path/to/steward-linux-amd64
+```
+
+The command prints the blob ID on success. The blob starts in `published` state
+and must be approved before it can be dispatched.
+
+## Step 2: Approve the binary (separate approval step)
+
+Approval is performed via the controller API or admin tooling. A blob in
+`published` state cannot be dispatched — dispatch returns 403 until the blob
+transitions to `approved`. See the controller administration guide for the
+approval workflow.
+
+## Step 3: Dispatch the upgrade
+
+Use `cfg steward upgrade` to dispatch the upgrade to stewards matching a selector:
+
+```
+cfg steward upgrade <selector> --version <version>
+```
+
+### Flags
+
+| Flag | Required | Description |
+|------|----------|-------------|
+| `--version` | Yes | Target steward version (e.g. `v0.5.12`) |
+| `--platform` | No | Target platform (`linux`, `windows`). Auto-detected from blob metadata if omitted. |
+| `--arch` | No | Target architecture (`amd64`, `arm64`). Auto-detected from blob metadata if omitted. |
+| `--wait` | No | Block until all dispatched stewards reach a terminal state |
+| `--wait-timeout` | No | Maximum wait duration when `--wait` is set (default: `2m`) |
+| `--url` | No | Controller API URL (overrides `CFGMS_API_URL`) |
+| `--api-key` | No | API key for authentication |
+| `--tls-ca-cert` | No | Path to CA certificate for TLS verification |
+
+Note: `--tls-insecure` is not available on the upgrade command.
+
+### Examples
+
+```bash
+# Upgrade a specific steward (async — prints upgrade ID and returns)
+cfg steward upgrade id:steward-1780659937223058807 --version v0.5.12
+
+# Upgrade all stewards in a group and wait for completion
+cfg steward upgrade group:production --version v0.5.12 --wait --wait-timeout 10m
+
+# Upgrade with explicit platform and arch
+cfg steward upgrade id:steward-abc123 --version v0.5.12 --platform linux --arch amd64
+```
+
+### Output (async)
+
+```
+Upgrade id: abc123-upgrade-id
+Dispatched to: 12 stewards
+```
+
+### Output (with --wait)
+
+```
+Upgrade id: abc123-upgrade-id
+Dispatched to: 3 stewards
+Waiting... 3 of 3 stewards still in progress
+Waiting... 1 of 3 stewards still in progress
+DEVICE                                STATUS
+------                                ------
+steward-1780659937223058807           committed
+steward-2890769947334169918           committed
+steward-3901879957445270929           committed
+```
+
+Exit code is 1 if any steward reaches `failed` or `rolled_back` state.
+
+## Step 4a: Check upgrade status
+
+Use `cfg steward upgrade status` to check per-steward upgrade progress:
+
+```
+cfg steward upgrade status [selector]
+cfg steward upgrade status --upgrade-id <id>
+```
+
+### Flags
+
+| Flag | Description |
+|------|-------------|
+| `--upgrade-id` | Query a specific upgrade record by ID |
+| `--url` | Controller API URL |
+| `--api-key` | API key for authentication |
+| `--tls-ca-cert` | Path to CA certificate |
+
+Pass either a positional selector argument or `--upgrade-id`. If a selector is
+given, the most recent upgrade record per matching steward is returned.
+
+### Examples
+
+```bash
+# Check a specific upgrade by ID
+cfg steward upgrade status --upgrade-id abc123-upgrade-id
+
+# Check the most recent upgrade status for a steward
+cfg steward upgrade status id:steward-abc123
+
+# Check upgrade status for all production stewards
+cfg steward upgrade status group:production
+```
+
+### Output
+
+```
+STEWARD                                VERSION   STATUS     COMPLETED_AT
+-------                                -------   ------     ------------
+steward-1780659937223058807            v0.5.12   committed  2026-06-09T10:00:00Z
+steward-2890769947334169918            v0.5.11   committed  2026-06-08T14:30:00Z
+```
+
+## Step 4b: Roll back an upgrade
+
+Use `cfg steward upgrade rollback` to roll back a dispatched upgrade:
+
+```
+cfg steward upgrade rollback --upgrade-id <id> [--to-version <ver>]
+```
+
+### Flags
+
+| Flag | Required | Description |
+|------|----------|-------------|
+| `--upgrade-id` | Yes | Upgrade record ID to roll back |
+| `--to-version` | No | Target version to roll back to (optional; used with `--upgrade-id`) |
+| `--url` | No | Controller API URL |
+| `--api-key` | No | API key for authentication |
+| `--tls-ca-cert` | No | Path to CA certificate |
+
+Rollback requires an explicit `--upgrade-id`. There is no selector-based
+most-recent rollback — the upgrade record must be identified explicitly to
+prevent accidental fleet-wide rollbacks.
+
+### Examples
+
+```bash
+# Roll back a specific upgrade
+cfg steward upgrade rollback --upgrade-id abc123-upgrade-id
+
+# Roll back to a specific prior version
+cfg steward upgrade rollback --upgrade-id abc123-upgrade-id --to-version v0.5.10
+```
+
+### Output
+
+```
+DEVICE                                STATUS
+------                                ------
+steward-1780659937223058807           rolled_back
+```
+
+## Upgrade state machine
+
+Each steward tracks upgrade state independently:
+
+| State | Description |
+|-------|-------------|
+| `dispatched` | Upgrade command sent to steward; awaiting acknowledgement |
+| `committed` | Steward successfully upgraded and running new version |
+| `failed` | Upgrade failed; steward is on the previous version |
+| `rolled_back` | Upgrade was explicitly rolled back |
+
+Terminal states are `committed`, `failed`, and `rolled_back`. The `--wait` flag
+polls until all stewards reach a terminal state.

--- a/features/steward/dna/security_linux.go
+++ b/features/steward/dna/security_linux.go
@@ -67,7 +67,7 @@ func linuxParsePasswdCount() (int, error) {
 	if err != nil {
 		return 0, err
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	count := 0
 	scanner := bufio.NewScanner(f)
@@ -160,7 +160,7 @@ func linuxSSSDDomain() string {
 	if err != nil {
 		return ""
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	scanner := bufio.NewScanner(f)
 	for scanner.Scan() {
@@ -186,7 +186,7 @@ func linuxParseGroupFile() (int, int) {
 	if err != nil {
 		return 0, 0
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	groupCount := 0
 	adminsCount := 0


### PR DESCRIPTION
## Summary

- Adds `cfg steward upgrade <selector> --version <v>` to dispatch steward binary upgrades fleet-wide; supports `--wait` with polling and immediate 401/403 abort
- Adds `cfg steward upgrade status` (by upgrade ID or selector) and `cfg steward upgrade rollback --upgrade-id <id>` subcommands  
- Adds `DispatchUpgrade`, `GetUpgradeStatus`, `ListUpgradeStatusBySelector`, `RollbackUpgrade` methods to `APIClient` with proper `url.PathEscape`/`url.QueryEscape` on all user inputs
- Created `docs/deployment/fleet-upgrades.md` with full four-step operator workflow
- Fixed three pre-existing unchecked `defer f.Close()` in `features/steward/dna/security_linux.go` that were blocking the lint gate

## AC verification

- [x] `cfg steward upgrade id:<id> --version v0.5.12` calls POST /api/v1/stewards/upgrade with correct body and prints upgrade_id
- [x] `cfg steward upgrade status <selector>` prints per-steward upgrade status in tabular format
- [x] `cfg steward upgrade rollback` requires `--upgrade-id` or `--to-version`; no selector-based rollback
- [x] `--tls-insecure` flag is absent from upgrade, rollback, and status subcommands (verified by dedicated tests)
- [x] `TestRunStewardUpgrade_RequiresVersion` — omitting `--version` returns usage error before any HTTP call
- [x] `TestRunStewardUpgrade_Wait` — polling exits on terminal state; aborts immediately on first 401/403 (no retry), verified with `sync/atomic` poll counter
- [x] `docs/deployment/fleet-upgrades.md` created with full operator workflow
- [x] `make test-agent-complete` passes (all 152 test packages, lint clean, security scan clean)

## Specialist review results

- **QA Test Runner**: PASS — 152 packages, 0 failures; lint, security scan, cross-platform build all clean
- **QA Code Reviewer**: PASS — no mocks, no t.Skip(), proper error path coverage, dead code removed
- **Security Engineer**: PASS — `url.PathEscape(upgradeID)` and `url.QueryEscape(selector)` correctly applied; `--tls-insecure` absent from all three upgrade commands; no central provider violations; log injection scan clean

## Note on dependency

Issue #1945 (controller API handlers) is still in PR #1979. This story is CLI-only and does not touch controller handler code. All tests use stub HTTP servers matching the documented API shape.

Fixes #1947