### PR TITLE
hyperv: harden host detection — absolute powershell.exe + content check + decline log (Issue #1936)

### DIFF
--- a/features/modules/hyperv/README.md
+++ b/features/modules/hyperv/README.md
@@ -99,6 +99,27 @@ config:
 4. **Basic auth is structurally disabled** — Only NTLM over HTTPS (port 5986) is supported. WinRM must be configured for HTTPS on the target host.
 5. **Integration tests require a live host** — Unit tests use a test implementation of the WinRM transport interface; full end-to-end validation requires `CFGMS_HYPERV_HOST` to be set.
 
+## Host detection
+
+The module activates only on hosts where Hyper-V is actually present, and cleanly declines work on hosts where it isn't. This avoids two failure modes the M2 epic explicitly calls out: a steward on a Linux host crashing when a config pushes a `module: hyperv` resource at it, and a misconfigured `%PATH%` on a Windows host tricking the detector into running Hyper-V cmdlets that don't exist.
+
+### Detection on Windows
+
+1. The detector invokes `powershell.exe` via the absolute path `%SystemRoot%\System32\WindowsPowerShell\v1.0\powershell.exe`. It never resolves `powershell.exe` through `%PATH%`. Without this, a directory writable by the steward's service account that appears earlier on `%PATH%` than `System32` could host a `powershell.exe` shim that exits 0 with empty output — bypassing the detection gate. The absolute-path resolution closes that bypass.
+2. The cmdlet run is `Get-VMHost | ConvertTo-Json`. A successful exit code on its own is not sufficient: the detector parses the JSON output and requires a non-empty `Name` field (the host's own hostname, as reported by Hyper-V). Empty or unparseable stdout is treated as "not a Hyper-V host." This is defense-in-depth against the same shim-bypass scenario, and also fails closed against a degraded Hyper-V install whose cmdlet returns a stub object.
+3. Cmdlet-not-found and access-denied errors are classified as soft failures and return `(false, nil)` — the module declines work on those hosts rather than crashing.
+4. Positive detection is cached for 5 minutes at the detector level. Negative results are not cached at the detector level. The module wraps the detector with a second 5-minute positive-result cache (`checkDetection` in `module.go`) so that operations within a single steward run don't re-invoke PowerShell on every Set/Get call. A host that gains the Hyper-V role mid-operation is picked up after the longer of the two caches expires.
+
+### Behavior on non-Hyper-V hosts (including all Linux and macOS)
+
+`Get` and `Set` short-circuit at the detection gate and return `ErrHostNotHyperV`. Before returning, both methods emit a structured warning via `slog`:
+
+```
+hyperv: declining resource — host is not a Hyper-V host  resource_id=vm:web-01
+```
+
+The `resource_id` is sanitised via `logging.SanitizeLogValue()` to defend against log-injection payloads in attacker-controlled resource names. The module does not panic, does not call into the WinRM transport, and does not invoke any Hyper-V cmdlet — operators reading the steward log can immediately see which resource was declined and why.
+
 ## Service Account Requirements
 
 The WinRM service account must be a member of the **Hyper-V Administrators** local group on the target host. Domain Admin is not required and must not be granted — follow the principle of least privilege.

--- a/features/modules/hyperv/detection_nonwindows_test.go
+++ b/features/modules/hyperv/detection_nonwindows_test.go
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+
+//go:build !windows
+
+package hyperv
+
+import (
+	"context"
+	"testing"
+)
+
+// TestNonWindowsDetector_AlwaysReturnsFalse pins the production contract on
+// non-Windows hosts: Hyper-V is a Windows-only feature, so the detector must
+// uniformly return (false, nil). This is what makes a steward on ctrl-01 /
+// stw-lin-01 cleanly decline a config with hyperv resources instead of
+// crashing or attempting a Hyper-V operation (B4 epic AC).
+func TestNonWindowsDetector_AlwaysReturnsFalse(t *testing.T) {
+	d := nonWindowsDetector{}
+	ok, err := d.IsHypervHost(context.Background())
+	if err != nil {
+		t.Errorf("nonWindowsDetector.IsHypervHost = err %v, want nil", err)
+	}
+	if ok {
+		t.Errorf("nonWindowsDetector.IsHypervHost = true, want false")
+	}
+}

--- a/features/modules/hyperv/detection_windows.go
+++ b/features/modules/hyperv/detection_windows.go
@@ -7,7 +7,10 @@ package hyperv
 
 import (
 	"context"
+	"encoding/json"
+	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"sync"
 	"time"
@@ -22,10 +25,47 @@ type windowsHypervDetector struct {
 	cacheExpiry  time.Time
 }
 
+// powershellExe resolves powershell.exe via an absolute path under %SystemRoot%
+// rather than relying on %PATH%. Without this, an attacker (or misconfigured
+// service account) who controls a directory earlier on PATH can plant a
+// `powershell.exe` shim that exits 0 with empty output and convince the
+// detector that Hyper-V is present on a host that isn't a Hyper-V host —
+// trivially bypassing the security gate on the module.
+//
+// SystemRoot fallback: if %SystemRoot% is unset (e.g. the process started
+// with a sanitised environment that dropped it) we fall back to %windir%,
+// then to the hardcoded `C:\Windows`. A relative path here would defeat the
+// whole defense — exec.Command would resolve it via %PATH%, reopening the
+// shim bypass. The final guard returns an empty string only when literally
+// nothing resolves; the caller treats psRunFn errors as "not Hyper-V" so
+// that case still fails closed.
+//
+// WOW64 note: a 32-bit steward on 64-bit Windows hits the filesystem path
+// `C:\Windows\SysWOW64\WindowsPowerShell\v1.0\powershell.exe` via the WOW64
+// redirector. PowerShell exists there too, so the absolute-path under
+// `System32` resolves correctly under both 32-bit and 64-bit stewards.
+// Server Core ships PowerShell at the same path; no special case needed.
+func powershellExe() string {
+	root := os.Getenv("SystemRoot")
+	if root == "" {
+		root = os.Getenv("windir")
+	}
+	if root == "" {
+		root = `C:\Windows`
+	}
+	p := filepath.Join(root, "System32", "WindowsPowerShell", "v1.0", "powershell.exe")
+	if !filepath.IsAbs(p) {
+		// Belt and braces: if everything above somehow produced a relative
+		// path, return empty rather than allowing PATH resolution.
+		return ""
+	}
+	return p
+}
+
 // psRunFn executes the Get-VMHost powershell command and returns combined output.
 // Overridden in tests to avoid invoking a real powershell.exe.
 var psRunFn = func(ctx context.Context) ([]byte, error) {
-	return exec.CommandContext(ctx, "powershell.exe", "-NonInteractive", "-Command", "Get-VMHost | ConvertTo-Json").CombinedOutput()
+	return exec.CommandContext(ctx, powershellExe(), "-NonInteractive", "-Command", "Get-VMHost | ConvertTo-Json").CombinedOutput()
 }
 
 // isSoftError returns true for cmdlet-not-found and access-denied failures,
@@ -41,6 +81,14 @@ func isSoftError(output []byte) bool {
 
 // IsHypervHost runs Get-VMHost. Cmdlet-not-found and access-denied failures
 // are soft failures that return (false, nil). Other exec errors return (false, err).
+//
+// A successful exit code alone is not sufficient: a PATH-resident shim could
+// exit 0 with empty output. We parse the `Get-VMHost | ConvertTo-Json` result
+// and require a non-empty `Name` field — that's the host's own hostname as
+// reported by Hyper-V, which a shim cannot fabricate without actually running
+// Hyper-V. Empty / unparseable output returns (false, nil) — i.e. "not a
+// Hyper-V host" — rather than an error, because the same conditions apply
+// when the cmdlet itself returns nothing on a degraded install.
 func (d *windowsHypervDetector) IsHypervHost(ctx context.Context) (bool, error) {
 	d.mu.Lock()
 	defer d.mu.Unlock()
@@ -55,6 +103,24 @@ func (d *windowsHypervDetector) IsHypervHost(ctx context.Context) (bool, error) 
 			return false, nil
 		}
 		return false, err
+	}
+
+	// Positive-content check: the stdout must parse as Hyper-V's VMHost JSON
+	// and carry a non-empty Name field. Anything else — empty output, garbage
+	// from a PATH shim, or a malformed Get-VMHost response — is treated as
+	// "not a Hyper-V host," not as an exec error.
+	trimmed := strings.TrimSpace(string(output))
+	if trimmed == "" {
+		return false, nil
+	}
+	var probe struct {
+		Name string `json:"Name"`
+	}
+	if jsonErr := json.Unmarshal([]byte(trimmed), &probe); jsonErr != nil {
+		return false, nil
+	}
+	if probe.Name == "" {
+		return false, nil
 	}
 
 	d.cachedResult = true

--- a/features/modules/hyperv/detection_windows_test.go
+++ b/features/modules/hyperv/detection_windows_test.go
@@ -8,6 +8,9 @@ package hyperv
 import (
 	"context"
 	"errors"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 )
@@ -77,7 +80,10 @@ func TestWindowsDetector_CachesPositiveResult(t *testing.T) {
 	t.Cleanup(func() { psRunFn = restore })
 	psRunFn = func(_ context.Context) ([]byte, error) {
 		callCount++
-		return []byte(`{"ComputerName":"testhost"}`), nil
+		// Get-VMHost | ConvertTo-Json returns the host's own hostname in
+		// the Name field — that's the canonical positive-presence signal
+		// the detector requires (see Name-field check in IsHypervHost).
+		return []byte(`{"Name":"testhost"}`), nil
 	}
 
 	d := &windowsHypervDetector{}
@@ -112,5 +118,173 @@ func TestWindowsDetector_CachesPositiveResult(t *testing.T) {
 	}
 	if callCount != 2 {
 		t.Errorf("psRunFn called %d times after cache expiry, want 2", callCount)
+	}
+}
+
+// TestWindowsDetector_RejectsEmptyOutput confirms the positive-content gate:
+// a successful exit with empty stdout is treated as "not a Hyper-V host" rather
+// than as a successful detection. This is the in-process complement to the
+// out-of-process PATH-spoof test below — the kernel-level path resolution
+// changed but the content check is what actually blocks the bypass.
+func TestWindowsDetector_RejectsEmptyOutput(t *testing.T) {
+	restore := psRunFn
+	t.Cleanup(func() { psRunFn = restore })
+	psRunFn = func(_ context.Context) ([]byte, error) {
+		return []byte(""), nil
+	}
+
+	d := &windowsHypervDetector{}
+	ok, err := d.IsHypervHost(context.Background())
+	if err != nil {
+		t.Errorf("empty output produced non-nil err = %v, want nil", err)
+	}
+	if ok {
+		t.Errorf("empty output produced ok=true, want false (PATH-spoof defense bypassed)")
+	}
+}
+
+// TestWindowsDetector_RejectsEmptyNameField confirms that a Get-VMHost
+// response whose Name field is empty is treated as "not a Hyper-V host."
+// This covers a degraded or partially-disabled Hyper-V install whose cmdlet
+// returns a stub object — the detector should fail closed rather than
+// activate the module against a host that can't actually run VMs.
+func TestWindowsDetector_RejectsEmptyNameField(t *testing.T) {
+	restore := psRunFn
+	t.Cleanup(func() { psRunFn = restore })
+	psRunFn = func(_ context.Context) ([]byte, error) {
+		return []byte(`{"Name":""}`), nil
+	}
+
+	d := &windowsHypervDetector{}
+	ok, err := d.IsHypervHost(context.Background())
+	if err != nil {
+		t.Errorf("empty Name produced non-nil err = %v, want nil", err)
+	}
+	if ok {
+		t.Errorf("empty Name produced ok=true, want false")
+	}
+}
+
+// TestWindowsDetector_RejectsNonJSONOutput covers the case where a PATH-resident
+// shim prints non-JSON garbage on stdout while exiting 0. The detector must
+// treat unparseable output as "not a Hyper-V host," not as a soft error to
+// propagate.
+func TestWindowsDetector_RejectsNonJSONOutput(t *testing.T) {
+	restore := psRunFn
+	t.Cleanup(func() { psRunFn = restore })
+	psRunFn = func(_ context.Context) ([]byte, error) {
+		return []byte("hello from a fake shell"), nil
+	}
+
+	d := &windowsHypervDetector{}
+	ok, err := d.IsHypervHost(context.Background())
+	if err != nil {
+		t.Errorf("non-JSON output produced non-nil err = %v, want nil", err)
+	}
+	if ok {
+		t.Errorf("non-JSON output produced ok=true, want false")
+	}
+}
+
+// TestPowershellExe_ReturnsAbsolutePath is the actually-falsifiable unit test
+// of the PATH-spoof defense: it asserts that `powershellExe()` returns an
+// absolute path under %SystemRoot% (or the documented fallback chain), and
+// that the path does not depend on PATH content. If a future refactor
+// accidentally went back to a bare basename or to PATH-relative resolution,
+// THIS test would fail clearly, whereas TestWindowsDetector_RejectsPathSpoofing
+// can only prove the defense fired by absence of a shim sentinel.
+func TestPowershellExe_ReturnsAbsolutePath(t *testing.T) {
+	// Sanity: in the normal case, return an absolute path.
+	p := powershellExe()
+	if !filepath.IsAbs(p) {
+		t.Errorf("powershellExe()=%q, want absolute path", p)
+	}
+	if !strings.HasSuffix(strings.ToLower(p), `\windowspowershell\v1.0\powershell.exe`) {
+		t.Errorf("powershellExe()=%q, want path ending in WindowsPowerShell\\v1.0\\powershell.exe", p)
+	}
+
+	// PATH content must not influence the result. Set PATH to nothing and
+	// confirm we still return the same absolute path. This is the
+	// regression-pin for the spoof defense.
+	t.Setenv("PATH", "")
+	p2 := powershellExe()
+	if p2 != p {
+		t.Errorf("powershellExe() with empty PATH=%q, want same as default %q", p2, p)
+	}
+	if !filepath.IsAbs(p2) {
+		t.Errorf("powershellExe() with empty PATH=%q, want absolute", p2)
+	}
+
+	// SystemRoot empty → falls back to %windir%.
+	t.Setenv("SystemRoot", "")
+	t.Setenv("windir", `D:\NotARealWindows`)
+	p3 := powershellExe()
+	if !filepath.IsAbs(p3) {
+		t.Errorf("powershellExe() with SystemRoot='' fallback to windir=%q, want absolute", p3)
+	}
+	if !strings.HasPrefix(p3, `D:\NotARealWindows`) {
+		t.Errorf("powershellExe() with SystemRoot='' did not honour windir fallback; got %q", p3)
+	}
+
+	// Both empty → hardcoded `C:\Windows` last-resort.
+	t.Setenv("SystemRoot", "")
+	t.Setenv("windir", "")
+	p4 := powershellExe()
+	if !filepath.IsAbs(p4) {
+		t.Errorf("powershellExe() with both env empty=%q, want absolute (last-resort fallback)", p4)
+	}
+	if !strings.HasPrefix(p4, `C:\Windows`) {
+		t.Errorf("powershellExe() last-resort fallback=%q, want path under C:\\Windows", p4)
+	}
+}
+
+// TestWindowsDetector_RejectsPathSpoofing exercises the absolute-path defense
+// end-to-end. We rebind psRunFn to invoke the configured powershellExe()
+// against a PATH that has a "powershell.exe" shim prepended. If the detector
+// were to resolve powershell.exe via PATH, the shim would win, exit 0 with
+// empty stdout, and the detector would (incorrectly) return true. Because
+// powershellExe() returns an absolute path under %SystemRoot%, the PATH shim
+// is never consulted. The content check provides defense-in-depth: even if
+// the absolute path was bypassed and the shim ran, the empty-output gate
+// would catch it.
+func TestWindowsDetector_RejectsPathSpoofing(t *testing.T) {
+	dir := t.TempDir()
+	// Sentinel marker: the shim writes this file when it runs. After the
+	// detector call we assert the file does NOT exist, which is the
+	// load-bearing evidence that the absolute-path defense actually fired
+	// (rather than the shim running and returning an empty/false result
+	// that happens to match the expected "not Hyper-V" outcome). Without
+	// this sentinel, the test passes trivially on any non-Hyper-V dev
+	// box even if the absolute-path resolution were broken.
+	sentinel := filepath.Join(t.TempDir(), "shim-ran.marker")
+	shimBat := filepath.Join(dir, "powershell.bat")
+	shimBatBody := "@echo off\r\necho SHIM_RAN > \"" + sentinel + "\"\r\nexit /b 0\r\n"
+	if err := os.WriteFile(shimBat, []byte(shimBatBody), 0o755); err != nil {
+		t.Fatalf("write shim: %v", err)
+	}
+	// A trivial .exe in the same dir to cover cmd.exe's basename
+	// resolution order; not executable but its presence with the right
+	// name is enough to prove the shim dir wasn't honored.
+	if err := os.WriteFile(filepath.Join(dir, "powershell.exe"), []byte(""), 0o755); err != nil {
+		t.Fatalf("touch shim exe: %v", err)
+	}
+
+	// Prepend the shim dir so a basename-only resolution would pick it up.
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	// Run the real psRunFn — production code path against real exec.Command.
+	// On a non-Hyper-V dev box the expected result is (false, nil) regardless.
+	// What we pin here is that the SENTINEL was not written: the absolute
+	// path resolution under %SystemRoot% means our shim was never invoked.
+	d := &windowsHypervDetector{}
+	ok, err := d.IsHypervHost(context.Background())
+	if err != nil {
+		t.Logf("PATH-spoof test surfaced %v — acceptable as long as sentinel absent (PATH was not honored)", err)
+	}
+	if ok {
+		t.Errorf("PATH-spoof test produced ok=true — detector honored the shim instead of the absolute powershell.exe path")
+	}
+	if _, statErr := os.Stat(sentinel); statErr == nil {
+		t.Errorf("sentinel %q was written — the PATH-resident shim ran. Absolute-path defense is broken.", sentinel)
 	}
 }

--- a/features/modules/hyperv/detection_windows_test.go
+++ b/features/modules/hyperv/detection_windows_test.go
@@ -273,16 +273,18 @@ func TestWindowsDetector_RejectsPathSpoofing(t *testing.T) {
 	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
 
 	// Run the real psRunFn — production code path against real exec.Command.
-	// On a non-Hyper-V dev box the expected result is (false, nil) regardless.
-	// What we pin here is that the SENTINEL was not written: the absolute
-	// path resolution under %SystemRoot% means our shim was never invoked.
+	// The load-bearing assertion is "sentinel NOT written": if the absolute
+	// path resolution works, our shim is never invoked, so the marker file
+	// is never created. The boolean return is NOT asserted: on a real
+	// Hyper-V host (including GitHub windows-latest runners, which ship the
+	// Hyper-V module and return a valid Get-VMHost result), the detector
+	// legitimately returns true via the real powershell.exe — that is the
+	// defense working correctly, not failing. The falsifiable absolute-path
+	// regression-pin lives in TestPowershellExe_ReturnsAbsolutePath above.
 	d := &windowsHypervDetector{}
-	ok, err := d.IsHypervHost(context.Background())
+	_, err := d.IsHypervHost(context.Background())
 	if err != nil {
 		t.Logf("PATH-spoof test surfaced %v — acceptable as long as sentinel absent (PATH was not honored)", err)
-	}
-	if ok {
-		t.Errorf("PATH-spoof test produced ok=true — detector honored the shim instead of the absolute powershell.exe path")
 	}
 	if _, statErr := os.Stat(sentinel); statErr == nil {
 		t.Errorf("sentinel %q was written — the PATH-resident shim ran. Absolute-path defense is broken.", sentinel)

--- a/features/modules/hyperv/module.go
+++ b/features/modules/hyperv/module.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/cfgis/cfgms/features/modules"
 	"github.com/cfgis/cfgms/pkg/audit"
+	"github.com/cfgis/cfgms/pkg/logging"
 )
 
 var (
@@ -159,6 +160,12 @@ func (m *hypervModule) Configure(config modules.ConfigState) error {
 //   - "vmattach:<vmName>/<switchName>": retrieve VMAttachmentConfig for the named attachment
 func (m *hypervModule) Get(ctx context.Context, resourceID string) (modules.ConfigState, error) {
 	if err := m.checkDetection(ctx); err != nil {
+		if errors.Is(err, ErrHostNotHyperV) {
+			if logger, ok := m.GetLogger(); ok {
+				logger.Warn("hyperv: declining resource — host is not a Hyper-V host",
+					"resource_id", logging.SanitizeLogValue(resourceID))
+			}
+		}
 		return nil, err
 	}
 	prefix, name, ok := splitResourceID(resourceID)
@@ -191,6 +198,12 @@ func (m *hypervModule) Get(ctx context.Context, resourceID string) (modules.Conf
 //   - "vmattach:<vmName>/<switchName>": attach or detach a VM network adapter
 func (m *hypervModule) Set(ctx context.Context, resourceID string, config modules.ConfigState) error {
 	if err := m.checkDetection(ctx); err != nil {
+		if errors.Is(err, ErrHostNotHyperV) {
+			if logger, ok := m.GetLogger(); ok {
+				logger.Warn("hyperv: declining resource — host is not a Hyper-V host",
+					"resource_id", logging.SanitizeLogValue(resourceID))
+			}
+		}
 		return err
 	}
 	prefix, _, ok := splitResourceID(resourceID)

--- a/features/modules/hyperv/module_test.go
+++ b/features/modules/hyperv/module_test.go
@@ -608,6 +608,66 @@ func TestModule_Set_ReturnsErrHostNotHyperV_WhenDetectorReturnsFalse(t *testing.
 	assert.ErrorIs(t, err, ErrHostNotHyperV)
 }
 
+// TestModule_LogsDeclineOnNonHypervHost verifies that Get and Set emit a
+// structured warning via the module's INJECTED logger (not the slog global)
+// when the host is not a Hyper-V host. Without this log an operator who
+// pushes a config containing hyperv resources to a Linux steward sees only
+// the bare ErrHostNotHyperV — no explanation of what went wrong or which
+// resource was declined. The log carries resource_id, sanitised via
+// logging.SanitizeLogValue to defend against log-injection payloads in
+// attacker-controlled resource names.
+//
+// Uses the per-module bufferLogger via SetLogger so the test never touches
+// the process-global slog default — that would race any other test in the
+// package that emits warnings (especially under `go test -race`).
+func TestModule_LogsDeclineOnNonHypervHost(t *testing.T) {
+	t.Run("Get logs decline", func(t *testing.T) {
+		m := newModuleWithDetector(nil, &fakeDetector{result: false})
+		bufLog := newBufferLogger()
+		require.NoError(t, m.SetLogger(bufLog))
+
+		_, err := m.Get(context.Background(), "vm:web-01")
+		assert.ErrorIs(t, err, ErrHostNotHyperV)
+
+		out := bufLog.buf.String()
+		assert.Contains(t, out, "declining resource",
+			"Get must log a decline warning when host is not Hyper-V; got %q", out)
+		assert.Contains(t, out, "not a Hyper-V host",
+			"decline log must include 'not a Hyper-V host' rationale; got %q", out)
+		assert.Contains(t, out, "vm:web-01",
+			"decline log must include the resource_id; got %q", out)
+	})
+
+	t.Run("Set logs decline", func(t *testing.T) {
+		m := newModuleWithDetector(nil, &fakeDetector{result: false})
+		bufLog := newBufferLogger()
+		require.NoError(t, m.SetLogger(bufLog))
+
+		err := m.Set(context.Background(), "vm:web-01", &VMConfig{})
+		assert.ErrorIs(t, err, ErrHostNotHyperV)
+
+		out := bufLog.buf.String()
+		assert.Contains(t, out, "declining resource",
+			"Set must log a decline warning when host is not Hyper-V; got %q", out)
+		assert.Contains(t, out, "not a Hyper-V host",
+			"decline log must include 'not a Hyper-V host' rationale; got %q", out)
+		assert.Contains(t, out, "vm:web-01",
+			"decline log must include the resource_id; got %q", out)
+	})
+
+	t.Run("no-op when no logger injected", func(t *testing.T) {
+		// When SetLogger has not been called, the module must NOT panic
+		// or fall back to the slog global. It just silently skips the
+		// log call — the error return still tells the caller what
+		// happened.
+		m := newModuleWithDetector(nil, &fakeDetector{result: false})
+		_, err := m.Get(context.Background(), "vm:web-01")
+		assert.ErrorIs(t, err, ErrHostNotHyperV)
+		err = m.Set(context.Background(), "vm:web-01", &VMConfig{})
+		assert.ErrorIs(t, err, ErrHostNotHyperV)
+	})
+}
+
 // ─── buildInvokeCommand unit tests ─────────────────────────────────────────────
 
 func TestBuildInvokeCommand_NoArgs(t *testing.T) {


### PR DESCRIPTION
## Summary

Epic D Story B4 from Hyper-V M2 validation epic (#1936). Closes two security gaps in the hyperv module's host-detection gate:

1. **PATH-spoof bypass.** `windowsHypervDetector` previously invoked bare `powershell.exe`. A directory writable by the steward's service account and earlier on `%PATH%` could host a shim that exits 0 with empty output — silently flipping the gate to "Hyper-V present" on a host that isn't. The detector now resolves powershell.exe to the absolute path under `%SystemRoot%\System32\WindowsPowerShell\v1.0\powershell.exe`, with a `SystemRoot → windir → C:\Windows` fallback chain (covers sanitised process environments) and a `filepath.IsAbs` guard.

2. **Empty-output detection.** Successful exit codes alone were enough to convince the detector that Hyper-V was present. `Get-VMHost | ConvertTo-Json` is now parsed and the `Name` field must be non-empty. Empty / unparseable stdout returns `(false, nil)`. Defense-in-depth against the same shim scenario and against degraded Hyper-V installs that return stub objects.

3. **Structured decline log.** `Get` and `Set` emit a `Warn` via the module's injected logger (`DefaultLoggingSupport.GetLogger`) — not the process-global slog default — when `checkDetection` returns `ErrHostNotHyperV`. `resource_id` is run through `logging.SanitizeLogValue` for log-injection defense.

## Files
- `features/modules/hyperv/detection_windows.go` — `powershellExe()` resolver, content check
- `features/modules/hyperv/detection_windows_test.go` — empty-output, empty-Name, non-JSON, PATH-spoof (with sentinel-marker), absolute-path falsifiable test
- `features/modules/hyperv/detection_nonwindows_test.go` — non-Windows stub pin
- `features/modules/hyperv/module.go` — decline-log on `ErrHostNotHyperV`
- `features/modules/hyperv/module_test.go` — `TestModule_LogsDeclineOnNonHypervHost` (uses per-module `bufferLogger` via `SetLogger`, never `slog.SetDefault`)
- `features/modules/hyperv/README.md` — "Host detection" section

## Review

- security-engineer (inline): PASS with 4 informational notes
- qa-code-reviewer (inline): FAIL → all 3 blockers addressed in this commit (SystemRoot fallback, falsifiable `TestPowershellExe_ReturnsAbsolutePath`, slog race eliminated by switching to module-scoped `bufferLogger`)

## Test plan

- [x] `go test -short -timeout=2m ./features/modules/hyperv/` (windows, green)
- [x] `go vet ./features/modules/hyperv/...` (windows, clean)
- [x] `CGO_ENABLED=0 GOOS=linux go vet ./features/modules/hyperv/...` (cross-build clean)
- [ ] CI required checks (unit, integration, build-gate, security-deployment-gate)

Fixes #1936 (Story B4 scope).

🤖 Generated with [Claude Code](https://claude.com/claude-code)