### PR TITLE
docs: documentation sweep — module packaging and distribution canonical docs (Item #BX5ezzguyzr4)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -193,7 +193,7 @@ pkg/{provider}/providers/   ← Never import directly
 - Scale from single-server to distributed deployments
 - Gate commercial features through provider selection
 
-See [docs/architecture/plugin-architecture.md](docs/architecture/plugin-architecture.md) for detailed provider development guidelines.
+See [docs/architecture/provider-architecture.md](docs/architecture/provider-architecture.md) for detailed provider development guidelines.
 
 ## Module System
 
@@ -362,7 +362,7 @@ Designed for:
 
 **Design Philosophy**: Make providers pluggable by default. This allows the system to scale from single-server deployments to distributed, multi-region architectures without refactoring business logic.
 
-See [pkg/README.md](pkg/README.md) for provider development guidelines and [docs/architecture/plugin-architecture.md](docs/architecture/plugin-architecture.md) for the complete pattern.
+See [pkg/README.md](pkg/README.md) for provider development guidelines and [docs/architecture/provider-architecture.md](docs/architecture/provider-architecture.md) for the complete pattern.
 
 ### 3. Test-Driven Development
 
@@ -422,7 +422,7 @@ See [pkg/README.md](pkg/README.md) for provider development guidelines and [docs
 ### Key Files to Review
 
 - `CLAUDE.md` - AI-assisted development guidelines
-- `docs/architecture/plugin-architecture.md` - Plugin system design
+- `docs/architecture/provider-architecture.md` - Provider system design
 - `docs/architecture/modules/interface.md` - Module development
 - `docs/development/story-checklist.md` - Development workflow
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -206,6 +206,8 @@ A module commits to exactly one kind via `executors:` in `module.yaml`. Cross-ki
 
 **Provider vs Module:** "Provider" / "plugin" / "pluggable" refer to the central-provider pattern (storage, logging, secrets, etc.). Modules are a different concept and never use "plugin" terminology.
 
+See ADR-006 (`docs/architecture/decisions/006-module-packaging-and-distribution.md`) for the full module packaging architecture.
+
 ## Testing
 
 ### Standards

--- a/docs/DOCUMENTATION_REVIEW_REPORT.md
+++ b/docs/DOCUMENTATION_REVIEW_REPORT.md
@@ -162,7 +162,7 @@ The following files appear accurate and ready for OSS launch:
 - `docs/architecture/hybrid-storage-solution.md` ✅
 - `docs/architecture/modules/interface.md` ✅
 - `docs/architecture/modules/README.md` ✅
-- `docs/architecture/plugin-architecture.md` ✅
+- `docs/architecture/provider-architecture.md` ✅
 - `docs/architecture/rollback-design.md` ✅
 - `docs/architecture/steward-configuration.md` ✅
 - `docs/architecture/template-engine-design.md` ✅
@@ -248,7 +248,7 @@ The following files appear accurate and ready for OSS launch:
 - [Code of Conduct](../CODE_OF_CONDUCT.md) - Community standards
 
 ## Architecture & Design
-- [Plugin Architecture](architecture/plugin-architecture.md)
+- [Provider Architecture](architecture/provider-architecture.md)
 - [Storage Architecture](architecture/git-backend-design.md)
 - [Communication Layer Migration](architecture/communication-layer-migration.md) - Transport architecture
 - [Module System](architecture/modules/README.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -18,7 +18,7 @@ If you're new to the project, start with these essential documents:
 ### Core Architecture
 
 - [Architecture Document](architecture.md) - Detailed architecture documentation
-- [Plugin Architecture](architecture/plugin-architecture.md) - Extensible module system design
+- [Provider Architecture](architecture/provider-architecture.md) - Pluggable provider system design
 - [Git Backend Design](architecture/git-backend-design.md) - GitOps storage backend
 - [Storage Architecture](architecture/storage-architecture.md) - Five-type storage taxonomy (ADR-003)
 - [Communication Layer Migration](architecture/communication-layer-migration.md) - Transport architecture (gRPC-over-QUIC)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -47,28 +47,57 @@ Proxy cache component that:
 
 ## Module System
 
-All resource management is performed through modules that implement a standard interface:
+All resource management is performed through modules — out-of-process gRPC binaries that implement a standard contract. The steward (or workflow engine) spawns each module binary as a child process over a local socket. Modules are distributed as publisher-signed bundles cached at the controller; stewards pull bundles from the controller rather than from external registries.
 
-```go
-type Module interface {
-    Get(ctx context.Context, resourceID string) (ConfigState, error)
-    Set(ctx context.Context, resourceID string, config ConfigState) error
-}
-```
+For the full module packaging architecture, see [ADR-006](architecture/decisions/006-module-packaging-and-distribution.md).
+
+### Three module kinds
+
+Every module commits to exactly one kind, declared via `executors:` in `module.yaml`:
+
+| Kind | Where it runs | What it manages |
+|------|--------------|-----------------|
+| `steward` | Endpoint agent | Local device resources (files, packages, firewall, services) |
+| `outpost` | Steward host acting as a proxy | Remote LAN devices that cannot run a steward (switches, printers, IoT) |
+| `workflow` | Controller workflow engine | Cloud and SaaS APIs (M365, identity providers, ticketing) |
+
+Cross-kind modules are not supported. The same logical resource on different host kinds is implemented as separate modules.
+
+### Four execution paths on a steward
+
+Every byte of code that runs on a steward arrives through exactly one of these paths:
+
+1. **Modules** — publisher-signed bundle spawned as a child process, communicates via gRPC
+2. **Scripts** — operator-authored script staged to disk and executed via OS process (publisher-signed)
+3. **Inline cfg CLI** — admin mTLS-signed payload, end-to-end *(separate epic)*
+4. **Remote shell** — interactive admin session *(separate epic)*
+
+### Three trust modes
+
+The steward verifies module bundles according to the `module_trust.mode` setting in `hostname.cfg`:
+
+| Mode | Verification | When to use |
+|------|-------------|-------------|
+| `controller` | Steward accepts the controller's attestation (default) | Standard managed deployments |
+| `strict` | Steward independently verifies the publisher signature against compiled-in keys | Regulated environments, highest-value modules |
+| `bypass` | Signature verification skipped | Development only; never production |
+
+Publisher public keys are baked into the steward binary at build time and cannot be changed via `cfg push`. See [distribution.md](architecture/modules/distribution.md) for the full trust and signing model.
 
 **Key Features:**
 
 - **ConfigState Interface**: Efficient field-level comparison without marshal/unmarshal overhead
 - **System-Level Testing**: Steward automatically compares current vs desired state
 - **Managed Fields**: Only specified fields are modified, others left unchanged
-- **Extensible Design**: Easy addition of new resource types
+- **Out-of-process isolation**: A module crash cannot corrupt steward state
 
 **Available Modules:**
 
-- `directory` - Directory creation and permissions
-- `file` - File content and attributes
+- `file` - File content, directory creation, and permissions
 - `firewall` - Firewall rules and policies  
 - `package` - Software package management
+- `service` - OS service state management
+- `script` - Cross-platform script execution (file-based)
 
 ## Operational Modes
 

--- a/docs/architecture/communication-layer-migration.md
+++ b/docs/architecture/communication-layer-migration.md
@@ -99,6 +99,6 @@ dp := dpgrpc.New(dpgrpc.ModeClient)
 
 ## Related Documentation
 
-- [Plugin Architecture](plugin-architecture.md) - Provider pattern foundation
+- [Provider Architecture](provider-architecture.md) - Provider pattern foundation
 - [Central Provider Compliance](decisions/001-central-provider-compliance-enforcement.md) - Enforcement ADR
 - Archived: Previous transport protocol design (removed in Phase 10.11)

--- a/docs/architecture/decisions/001-central-provider-compliance-enforcement.md
+++ b/docs/architecture/decisions/001-central-provider-compliance-enforcement.md
@@ -222,7 +222,7 @@ check-architecture:
 - **Architecture Compliance**: Commit `157bf9b` (Add central provider compliance checks)
 - **Documentation**: Commit `e76e63a` (Add central provider documentation and validation helper)
 - **Pluggable by Default**: Commit `2e8c8dd` (Establish pluggable by default principle)
-- **Related Architecture**: `docs/architecture/plugin-architecture.md`
+- **Related Architecture**: `docs/architecture/provider-architecture.md`
 
 ## Lessons Learned
 

--- a/docs/architecture/decisions/006-module-packaging-and-distribution.md
+++ b/docs/architecture/decisions/006-module-packaging-and-distribution.md
@@ -240,4 +240,4 @@ Allow operators to inject publisher keys via `cfg push` at runtime without a ste
 - Story #1879 — modules: write ADR-006 — Module Packaging and Distribution
 - [ADR-001](001-central-provider-compliance-enforcement.md) — Central Provider Compliance Enforcement
 - [ADR-003](003-storage-data-taxonomy.md) — Storage Data Taxonomy
-- `docs/architecture/plugin-architecture.md` — CFGMS pluggable provider architecture
+- `docs/architecture/provider-architecture.md` — CFGMS pluggable provider architecture

--- a/docs/architecture/modules/behavioral-envelope.md
+++ b/docs/architecture/modules/behavioral-envelope.md
@@ -1,0 +1,157 @@
+# Module Behavioral Envelope
+
+Every CFGMS module declares a behavioral envelope in `module.yaml` as part of the signed bundle. The envelope is a machine-readable description of what the module does at runtime: which file-system paths it reads or writes, which network destinations it contacts, which shells or interpreters it invokes, and why.
+
+The behavioral envelope is **part of the signed bundle** — it cannot be changed without invalidating the publisher signature and the bundle's content hash. An operator, reviewer, or automated gate can inspect the declared envelope before approving a module for deployment.
+
+---
+
+## Why the envelope exists
+
+Modules run on managed endpoints, often under application allowlisting and EDR monitoring. The behavioral envelope serves two audiences:
+
+1. **Operators** — the envelope is the module's "what will this do to my device" promise. An operator approving a bundle sees exactly which paths, processes, and network destinations the module declares.
+2. **Security tooling** — on platforms where the OS supports process-level observation (Linux namespaces, Windows Job Objects, macOS sandbox), the steward enforces the envelope at runtime. On platforms where enforcement is not available, the envelope is recorded and logged for audit purposes.
+
+CI lint gates on declared permissions at bundle publish time on all supported platforms.
+
+---
+
+## Envelope schema
+
+The envelope is declared under the `behavioral_envelope:` key in `module.yaml`.
+
+```yaml
+# module.yaml — behavioral_envelope fields
+behavioral_envelope:
+  shells_out_to:
+    - "/bin/sh"
+    - "C:\\Windows\\System32\\cmd.exe"
+  writes_paths:
+    - "/etc/cfgms/"
+    - "/var/lib/cfgms/"
+  reads_paths:
+    - "/etc/hosts"
+    - "/var/log/cfgms/"
+  network_egress:
+    - "10.0.0.0/8"
+    - "ldap.corp.example:389"
+  lolbin_usage_justification: |
+    This module invokes cmd.exe to call netsh.exe for firewall rule management.
+    The netsh.exe path is declared in shells_out_to. No dynamic command strings
+    are constructed; the argument list is fully static.
+```
+
+All fields are optional. An absent field means the module makes no claim for that category. Omitting a field is not equivalent to declaring an empty list — the distinction matters for enforcement: an empty `writes_paths: []` asserts the module writes nothing; an absent `writes_paths` makes no assertion.
+
+---
+
+## Field reference
+
+### `shells_out_to`
+
+**Type**: list of strings  
+**Content**: Absolute paths to shells or interpreters this module invokes as child processes (e.g. `/bin/sh`, `C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe`).
+
+Declaring a shell here is an explicit statement that the module shells out. A module that does not need to shell out should omit this field or declare an empty list. The steward's EDR-friendly posture requires that every shell invocation be declared; undeclared shell invocations are a CI lint failure.
+
+If a module shells out to a LOLBIN (living-off-the-land binary — a legitimate OS binary that can be misused), it must also populate `lolbin_usage_justification`.
+
+### `writes_paths`
+
+**Type**: list of strings (path prefixes or exact paths)  
+**Content**: File-system paths or path prefixes the module writes to. Glob patterns are not supported in v1; use path prefixes (e.g. `/etc/cfgms/` matches all files under that directory).
+
+The steward uses this list to configure OS-level write restrictions where supported. On Linux, this maps to `seccomp` or namespace path restrictions. On Windows, this maps to Job Object write filters. On macOS, this maps to the sandbox profile.
+
+### `reads_paths`
+
+**Type**: list of strings (path prefixes or exact paths)  
+**Content**: File-system paths or path prefixes the module reads. The same path-prefix semantics as `writes_paths` apply.
+
+Reads are less strictly enforced than writes on most platforms, but declaring them supports audit tooling and makes the module's intent inspectable.
+
+### `network_egress`
+
+**Type**: list of strings (CIDR ranges or `host:port` pairs)  
+**Content**: External hosts or network ranges the module connects to.
+
+Examples:
+- `"10.0.0.0/8"` — any host on the 10.x.x.x subnet
+- `"ldap.corp.example:389"` — a specific host and port
+- `"443"` — any host on port 443 (port-only format; use sparingly)
+
+The steward uses this list to configure egress filtering where the OS supports it. Undeclared outbound connections are blocked on platforms with enforcement capability.
+
+### `lolbin_usage_justification`
+
+**Type**: string (free-form text)  
+**Required when**: `shells_out_to` lists a binary that is also a known LOLBIN.
+
+LOLBIN (living-off-the-land binary) usage must be justified because the same binaries are commonly used in attack chains. The justification must explain:
+
+1. Which binary is a LOLBIN and why it is needed.
+2. That the argument list is static (no dynamic string construction).
+3. What the module would do differently if the LOLBIN were unavailable.
+
+A justification that says "needed for X" without explaining the static-argument constraint does not satisfy the CI lint gate.
+
+**Examples of LOLBIN binaries that require justification:**
+- `cmd.exe`, `powershell.exe`, `wscript.exe`, `cscript.exe` (Windows)
+- `bash`, `sh`, `python`, `perl`, `ruby` (Unix)
+- `netsh.exe`, `reg.exe`, `schtasks.exe`, `wmic.exe` (Windows admin tools with broad capabilities)
+
+---
+
+## Banned execution patterns
+
+The following patterns are unconditionally banned from module payloads. CI lint rejects bundles that contain them, regardless of what the behavioral envelope declares:
+
+| Pattern | Why banned |
+|---------|-----------|
+| `iex` / `Invoke-Expression` | Executes arbitrary strings — no static analysis possible |
+| `powershell -Command "<string>"` | Inline string execution bypasses disk-based content addressing |
+| `-EncodedCommand <base64>` | Base64-encoded PowerShell — obfuscates intent from tooling |
+| `-ExecutionPolicy Bypass` | Disables the PowerShell execution policy boundary |
+| `bash -c "<string>"` | Shell inline string execution — same bypass as PowerShell |
+| `eval` | Shell `eval` — executes arbitrary strings at runtime |
+| `python -c "<code>"` | Python inline execution — same bypass pattern |
+| Any runtime code composition | Constructing a command string from variables and executing it |
+
+Scripts must be **staged to disk** before execution. Inline string execution bypasses disk-based content addressing and behavioral envelope enforcement, and is prohibited regardless of trust mode or publisher identity.
+
+Modules that cannot perform their task without one of these patterns must be redesigned. The preference is in-process managed APIs (WMI, OS syscalls, vendor SDKs). Shelling out at all is a deliberate choice declared in the manifest; shelling out to inline-evaluated strings is never acceptable.
+
+---
+
+## EDR-friendly patterns
+
+The behavioral envelope exists to make modules look like predictable admin tooling to EDR products. To preserve EDR signal fidelity:
+
+- **Declared paths**: every file the module reads or writes appears in `reads_paths` or `writes_paths`. Modules that write to undeclared paths create noise in file-integrity monitoring.
+- **Declared LOLBINs**: every LOLBIN invocation is in `shells_out_to` with a justification. Undeclared LOLBIN invocations are the highest-signal EDR alert pattern and will trigger alerts on allowlisted endpoints.
+- **Static argument lists**: shell invocations use static, fully-constructed argument arrays — not `fmt.Sprintf`-assembled strings. Static lists are detectable by static analysis; dynamic assembly is not.
+- **Signed binaries**: all module binaries carry the publisher's Ed25519 signature. The steward verifies the signature before spawning the process. An EDR product observing a process spawn from the steward can confirm the binary hash matches the declared bundle.
+- **No in-memory tricks**: all code that runs arrives from a file on disk. No `mmap`-and-execute, no `memfd_create`, no process injection.
+
+---
+
+## Enforcement by platform
+
+| Platform | `writes_paths` | `reads_paths` | `network_egress` | `shells_out_to` |
+|----------|---------------|--------------|-----------------|----------------|
+| Linux | seccomp + namespace | namespace (best-effort) | network namespace / iptables | seccomp execve filter |
+| Windows | Job Object write ACL | ACL (best-effort) | Windows Filtering Platform | Job Object process creation |
+| macOS | sandbox profile | sandbox profile | sandbox profile | sandbox profile |
+
+On platforms where enforcement is not available for a given dimension, the envelope is recorded in steward logs and available for offline audit. The module is not blocked from running — enforcement degrades gracefully without breaking the module contract.
+
+---
+
+## Related documentation
+
+- [ADR-006](../decisions/006-module-packaging-and-distribution.md) — Module packaging architecture and design rationale
+- [Module System](README.md) — Module kinds, manifest fields, and available modules
+- [Module Contract](interface.md) — gRPC wire contract (Handshake/Get/Set/Test/Shutdown)
+- [Distribution](distribution.md) — Bundle format, content addressing, and trust store
+- [Steward Configuration](../steward-configuration.md) — `module_trust:` configuration

--- a/docs/architecture/operating-model.md
+++ b/docs/architecture/operating-model.md
@@ -139,7 +139,7 @@ The controller is the central management server. It does not manage devices dire
 1. **Store cfgs** — Version-controlled configuration storage. Cfgs are authored here (via API, workflow, or direct edit) and distributed to stewards
 2. **Distribute cfgs** — Push cfgs to stewards over the data plane. The controller decides which steward gets which cfg (based on tenant hierarchy, groups, targeting rules)
 3. **Collect reports** — Receive status, events, DNA, health, and historical performance metrics from stewards. Aggregate for fleet-wide dashboards, compliance reporting, trend analysis, and troubleshooting. This data is the foundation for future Digital Experience (DEX) capabilities
-4. **Run workflows** — Execute automation workflows for cloud/SaaS operations that don't require a steward (desired-state convergence for cloud resources, orchestration and data sync between third-party services, and imperative automation). See [controller operating model](controller-operating-model.md) for details
+4. **Run workflows** — Execute automation workflows for cloud/SaaS operations that don't require a steward (desired-state convergence for cloud resources, orchestration and data sync between third-party services, and imperative automation). The workflow engine runs **workflow-kind modules** (`executors: [workflow]`) — out-of-process gRPC binaries that the controller spawns to interact with cloud APIs on behalf of the workflow. See [controller operating model](controller-operating-model.md) for details
 5. **Manage identity** — Certificate authority, steward registration, tenant management
 6. **Orchestrate multi-node operations** — The controller is aware of application dependencies and infrastructure roles (e.g., Hyper-V clusters, SQL clusters, domain controllers, DNS/DHCP roles). Operations that span multiple devices — rolling updates, coordinated reboots, cluster-aware patching — are sequenced by the controller to maintain service availability. Individual stewards apply their cfgs; the controller decides the order and timing
 
@@ -205,6 +205,8 @@ Regional infrastructure component deployed at site level. Two roles:
 
 1. **Proxy cache** — Caches binaries, packages, and cfg artifacts used by multiple stewards at the site, reducing WAN bandwidth and speeding up deployments
 2. **Network operations** — Manages agentless endpoints that can't run a steward (switches, firewalls, APs, printers) via SSH, SNMP, and vendor APIs. Also performs network scans and topology discovery
+
+The outpost runs **outpost-kind modules** (`executors: [outpost]`) to manage remote LAN devices. Outpost modules run on the outpost host and use the outpost as a proxy agent for devices that cannot run a steward. The outpost module runtime is the same gRPC-based runtime as the steward, scoped to the outpost process.
 
 Reports to controller. Not yet implemented.
 

--- a/docs/architecture/provider-architecture.md
+++ b/docs/architecture/provider-architecture.md
@@ -1,8 +1,8 @@
-# CFGMS Plugin Architecture Guide
+# CFGMS Provider Architecture Guide
 
 ## Overview
 
-CFGMS implements a **Salt-inspired pluggable architecture** that separates interface definitions from implementations, enabling runtime plugin discovery and configuration-driven backend selection.
+CFGMS implements a **pluggable provider architecture** that separates interface definitions from implementations, enabling runtime provider discovery and configuration-driven backend selection.
 
 ## Design Principles
 
@@ -13,9 +13,9 @@ Based on CFGMS's documented "Pluggable Infrastructure Design Paradigm":
 ### Core Principles
 
 1. **Interface-First Development** - Define contracts before implementations
-2. **Runtime Discovery** - Plugins register themselves at startup via `init()`
+2. **Runtime Discovery** - Providers register themselves at startup via `init()`
 3. **Configuration-Driven Selection** - Users choose backends via YAML config
-4. **Graceful Degradation** - Missing plugins don't break the system
+4. **Graceful Degradation** - Missing providers don't break the system
 5. **Clear Separation** - Business logic never imports specific providers
 
 ## Directory Structure
@@ -71,7 +71,7 @@ type ConfigStore interface {
     DeleteConfig(tenantID, key string) error
 }
 
-// pkg/storage/interfaces/plugin.go
+// pkg/storage/interfaces/provider.go
 // StorageProvider implements ALL storage interfaces for a backend
 type StorageProvider interface {
     Name() string
@@ -89,7 +89,7 @@ type StorageProvider interface {
 ### Step 2: Provider Implementation (One Provider = All Storage Types)
 
 ```go
-// pkg/storage/providers/database/plugin.go
+// pkg/storage/providers/database/provider.go
 package database
 
 import "your.domain/cfgms/pkg/storage/interfaces"
@@ -118,7 +118,7 @@ func (p *DatabaseProvider) Description() string {
     return "PostgreSQL-backed storage for production-scale deployments"
 }
 
-// Salt-style auto-registration
+// Auto-registration
 func init() {
     interfaces.RegisterStorageProvider(&DatabaseProvider{})
 }
@@ -180,29 +180,29 @@ The actual `StorageManager` in `pkg/storage/interfaces` composes providers for e
 
 See `pkg/storage/interfaces/provider.go` for the `StorageManager` and `CreateOSSStorageManager` wiring.
 
-## Plugin Discovery and Management
+## Provider Discovery and Management
 
-### List Available Plugins
+### List Available Providers
 
 ```bash
-cfg plugins list storage
+cfg providers list storage
 ```
 
 ```
-Available Storage Plugins (business data):
+Available Storage Providers (business data):
   ✅ sqlite      - SQLite storage (default)
   ✅ database    - PostgreSQL storage (requires: postgresql client)
 
-Available Storage Plugins (config storage):
+Available Storage Providers (config storage):
   ✅ flatfile    - Flat-file storage (default)
   ✅ database    - PostgreSQL storage (production scale / SaaS)
 
-Available Storage Plugins (blob storage):
+Available Storage Providers (blob storage):
   ✅ filesystem  - Local filesystem (default)
   ✅ s3          - S3-compatible object storage
 ```
 
-### Runtime Plugin Information
+### Runtime Provider Information
 
 ```go
 // Get all registered storage providers
@@ -223,12 +223,12 @@ if err != nil {
 
 ```go
 // features/storage/interfaces/compliance_test.go
-func TestStoragePluginCompliance(t *testing.T) {
-    plugins := interfaces.GetAvailableStoragePlugins()
+func TestStorageProviderCompliance(t *testing.T) {
+    providers := interfaces.GetAvailableStorageProviders()
     
-    for name, plugin := range plugins {
+    for name, provider := range providers {
         t.Run(name, func(t *testing.T) {
-            store, err := plugin.Create(map[string]interface{}{})
+            store, err := provider.Create(map[string]interface{}{})
             require.NoError(t, err)
             
             // Test all interface methods
@@ -256,11 +256,11 @@ func TestAdminConsentFlow(t *testing.T) {
 }
 ```
 
-## Plugin Development Guidelines
+## Provider Development Guidelines
 
-### 1. Plugin Naming Convention
+### 1. Provider Naming Convention
 
-- Plugin names should be lowercase, descriptive
+- Provider names should be lowercase, descriptive
 - Use hyphens for multi-word names: `azure-sql`, `s3-bucket`
 
 ### 2. Dependency Management
@@ -271,16 +271,16 @@ func TestAdminConsentFlow(t *testing.T) {
 ### 3. Configuration Schema
 
 - Use simple `map[string]interface{}` for flexibility
-- Document required/optional fields in plugin description
+- Document required/optional fields in provider description
 
 ### 4. Error Handling
 
-- Return wrapped errors with plugin context
-- Use consistent error formats across plugins
+- Return wrapped errors with provider context
+- Use consistent error formats across providers
 
 ### 5. Documentation
 
-- Each plugin must have a README.md in its directory
+- Each provider must have a README.md in its directory
 - Document configuration options and examples
 
 ## Migration from Existing Patterns
@@ -300,17 +300,17 @@ func NewBackend(backendType BackendType, config *Config, logger Logger) (Backend
 }
 ```
 
-### Target State (Plugin Pattern)
+### Target State (Provider Pattern)
 
 ```go
-// Features automatically discover plugins via init() registration
+// Features automatically discover providers via init() registration
 func CreateStorageFromConfig(backendType string, config map[string]interface{}) (Backend, error) {
-    plugin, err := GetStoragePlugin(backendType)
+    provider, err := GetStorageProvider(backendType)
     if err != nil {
-        available := GetAvailableStoragePlugins()
+        available := GetAvailableStorageProviders()
         return nil, fmt.Errorf("backend '%s' unavailable. Available: %v", backendType, available)
     }
-    return plugin.Create(config)
+    return provider.Create(config)
 }
 ```
 
@@ -346,11 +346,11 @@ Modules get injected with the specific interface they need
 
 1. **Consistency**: All data in same storage system (no mixed backends)
 2. **Simplicity**: One storage decision affects entire system
-3. **Developer Experience**: Clear separation between plugin development and usage
+3. **Developer Experience**: Clear separation between provider development and usage
 4. **Testing**: Easy to test against all available backends
-5. **Deployment Flexibility**: Runtime plugin discovery based on environment
+5. **Deployment Flexibility**: Runtime provider discovery based on environment
 6. **User Experience**: Simple configuration with automatic capability detection
-7. **Maintainability**: Plugins can be developed/tested independently
+7. **Maintainability**: Providers can be developed/tested independently
 
 ## Examples in Codebase
 

--- a/docs/terminology.md
+++ b/docs/terminology.md
@@ -262,7 +262,47 @@ The DNA system continuously updates this digital twin through:
 
 ### Module
 
-A Module is a discrete, reusable, and self-contained unit of functionality that implements Get/Set/Test for a resource type.
+A **Module** is an out-of-process gRPC binary that manages a specific resource type. The steward (or workflow engine) spawns the module binary as a child process; the module communicates back over a local Unix socket or named pipe using the CFGMS module gRPC API. Every module implements the standard contract: `Handshake` / `Get` / `Set` / `Test` / `Shutdown`. Modules commit to exactly one kind (`steward`, `outpost`, or `workflow`) via `executors:` in `module.yaml`.
+
+**Disambiguation**: "Module" is not the same as "pluggable provider." Pluggable providers (storage, logging, secrets, etc.) are central infrastructure backends. Modules are resource-management units that run on endpoints or the controller. See **Pluggable provider** below.
+
+### Module bundle
+
+A **module bundle** is a signed archive containing the module binary (cross-compiled for each supported `os-arch`), the `module.yaml` manifest, and one or more Ed25519 detached signatures. Bundles are content-addressed by the four-tuple `(publisher, name, version, content_hash)`. The content hash makes silent bundle mutation detectable — any change to binary content or manifest produces a different hash and therefore a different cache entry.
+
+### Module contract
+
+The **module contract** is the gRPC API that every CFGMS module must implement. It is defined in `api/proto/modules/` and documented in [`docs/architecture/modules/interface.md`](modules/interface.md). The contract has two variants: `ModuleService` (steward and outpost modules) and `WorkflowModuleService` (workflow modules). The only difference is the `Handshake` message, which carries the calling context. `Get`, `Set`, `Test`, and `Shutdown` messages are shared.
+
+### Module runtime
+
+The **module runtime** is the host-side component that manages the module process lifecycle: spawn, health-check, graceful shutdown. On a steward the module runtime is part of the steward binary. On the controller the module runtime is embedded in the workflow engine. The module runtime enforces the behavioral envelope declared in `module.yaml` where OS primitives support it (Linux namespaces, Windows Job Objects, macOS sandbox).
+
+### Module host
+
+A **module host** is the system component that owns a module runtime: the steward for `steward`- and `outpost`-kind modules, and the controller workflow engine for `workflow`-kind modules. The module host is responsible for fetching the bundle, verifying the content hash and trust, spawning the binary, and enforcing the behavioral envelope.
+
+### Publisher
+
+A **publisher** is the identity whose Ed25519 signing key is in a module bundle's signature block. Publisher public keys are baked into the steward binary at build time — they cannot be changed via `cfg push` or any runtime configuration path. The `publisher` field in `module.yaml` must match a registered publisher identity. CFGMS ships a built-in publisher identity (`cfgms`) for stdlib modules; third-party publishers require a steward binary rebuild to add their key to the trusted set.
+
+### Workflow module
+
+A **workflow module** is a module with `executors: [workflow]` in `module.yaml`. Workflow modules run on the controller's workflow engine against cloud and SaaS APIs (e.g. M365, identity providers, ticketing systems). They do not run on endpoints. The workflow engine dials the module process over a local socket and provides a tenant-scoped auth token in the `WorkflowHandshakeRequest`.
+
+### Steward module
+
+A **steward module** is a module with `executors: [steward]` in `module.yaml`. Steward modules run on the endpoint where the steward is installed and manage local resources on that device (files, packages, firewall rules, services, registry keys). Steward modules may use localhost transports (e.g. direct WMI) but never span to other hosts.
+
+### Outpost module
+
+An **outpost module** is a module with `executors: [outpost]` in `module.yaml`. Outpost modules run on a steward host but manage remote LAN devices — network gear, printers, IoT devices, or hypervisors that cannot run a steward themselves. The outpost module uses the steward as a proxy agent. The outpost runtime is reserved in ADR-006; its process model is not yet defined.
+
+### Pluggable provider
+
+A **pluggable provider** is a backend implementation of a central CFGMS infrastructure interface (storage, logging, secrets, directory, control-plane transport, data-plane transport). Pluggable providers live under `pkg/*/providers/` and are selected via YAML configuration at runtime. They register themselves at startup via `init()`.
+
+**Disambiguation from Module**: "Pluggable provider" refers strictly to the central-provider pattern described in `pkg/README.md` and [`docs/architecture/provider-architecture.md`](provider-architecture.md). Modules are a distinct concept: they manage endpoint resources, run out-of-process, and use a different interface (`ModuleService` gRPC). The terms "provider", "plugin", and "pluggable" in CFGMS documentation always refer to the central-provider pattern unless the surrounding context explicitly says "module."
 
 ### Configuration-Data
 
@@ -278,7 +318,7 @@ A managed system or service that a Steward is responsible for.
 
 ## Version Information
 
-- **Document Version:** 1.4
-- **Last Updated:** 2026-03-26
+- **Document Version:** 1.5
+- **Last Updated:** 2026-06-09
 - **Status:** Current
-- **Changes:** Updated communication diagrams to reflect gRPC-over-QUIC transport
+- **Changes:** Added module system terminology (Module, Module bundle, Module contract, Module runtime, Module host, Publisher, Workflow module, Steward module, Outpost module, Pluggable provider)

--- a/features/modules/acme/README.md
+++ b/features/modules/acme/README.md
@@ -1,5 +1,7 @@
 # ACME Module
 
+**Kind:** steward
+
 ## Purpose and scope
 
 The ACME Module provides automated TLS certificate management via the ACME protocol (RFC 8555). It uses the lego library to interact with ACME-compatible servers such as Let's Encrypt for certificate issuance and renewal. Supports both HTTP-01 and DNS-01 challenge types with Cloudflare, Route53, and Azure DNS providers.

--- a/features/modules/activedirectory/README.md
+++ b/features/modules/activedirectory/README.md
@@ -1,5 +1,7 @@
 # Active Directory Module (System Context)
 
+**Kind:** steward
+
 ## Purpose and scope
 
 The Active Directory module provides secure, credential-free integration with local Active Directory domains using Windows system context APIs. This module is designed to run on Windows stewards that are members of an Active Directory domain, leveraging the system service account for authentication and authorization.

--- a/features/modules/file/README.md
+++ b/features/modules/file/README.md
@@ -1,5 +1,7 @@
 # File Module
 
+**Kind:** steward
+
 ## Purpose and scope
 
 The File Module provides configuration management capabilities for file resources. It implements the core Module interface (Get/Set/Test) to manage file content and attributes.

--- a/features/modules/firewall/README.md
+++ b/features/modules/firewall/README.md
@@ -1,5 +1,7 @@
 # Firewall Module
 
+**Kind:** steward
+
 ## Purpose and scope
 
 The Firewall module provides a unified interface for managing firewall rules across different operating systems. It enables consistent configuration and management of firewall rules regardless of the underlying platform, supporting Linux (iptables/nftables), macOS (pf), and Windows (Windows Firewall).

--- a/features/modules/hyperv/README.md
+++ b/features/modules/hyperv/README.md
@@ -1,5 +1,7 @@
 # Hyper-V Module
 
+**Kind:** steward
+
 Remote Hyper-V management via WinRM for CFGMS. Manages VMs, snapshots, and virtual switches on Windows Server hosts running the Hyper-V role. All PowerShell commands are executed over an authenticated, TLS-encrypted WinRM connection.
 
 ## Purpose and scope

--- a/features/modules/package/README.md
+++ b/features/modules/package/README.md
@@ -1,5 +1,7 @@
 # Package Module
 
+**Kind:** steward
+
 ## Purpose and scope
 
 The Package module provides a unified interface for managing system packages across different package managers. It abstracts away the differences between package managers (apt, yum, dnf, pacman, brew, chocolatey, winget) and provides a consistent way to install, update, and remove packages.

--- a/features/modules/script/README.md
+++ b/features/modules/script/README.md
@@ -1,5 +1,7 @@
 # Script Module
 
+**Kind:** steward
+
 ## Purpose and scope
 
 The Script module provides cross-platform script execution capabilities for CFGMS. It is designed for:

--- a/features/modules/service/README.md
+++ b/features/modules/service/README.md
@@ -1,5 +1,7 @@
 # Service Module
 
+**Kind:** steward
+
 ## Purpose and scope
 
 The Service Module provides idempotent configuration management for OS services.


### PR DESCRIPTION
Fixes #1888

## Summary

- Renames `docs/architecture/plugin-architecture.md` → `provider-architecture.md`; removes "Salt-inspired" phrase; replaces all "plugin" with "provider" in provider contexts; updates 14 cross-reference links
- Adds nine new entries to `docs/terminology.md`: Module, Module bundle, Module contract, Module runtime, Module host, Publisher, Workflow module, Steward module, Outpost module, Pluggable provider (with disambiguation from Module)
- Expands `docs/architecture.md` Module System section with three-kinds table, four-execution-paths list, three-trust-modes table, and links to ADR-006
- Creates `docs/architecture/modules/behavioral-envelope.md` with complete envelope schema, field reference, EDR-friendly patterns, banned execution patterns, and per-platform enforcement table
- Adds `**Kind:** steward` annotation to all eight module READMEs under `features/modules/`
- Updates `docs/architecture/operating-model.md` with outpost-module and workflow-module routing descriptions
- Adds ADR-006 file path pointer to CLAUDE.md Modules section

## Specialist Review Results

- **QA Test Runner**: PASS — `make test-agent-complete` exit 0; all unit, integration, cross-platform compilation gates passed
- **QA Code Reviewer**: PASS — docs-only change; zero Go files modified; no test quality issues; all link updates verified consistent
- **Security Engineer**: PASS — security-precommit (gitleaks + truffleHog) clean; check-architecture clean; security-scan deployment approved; no secrets or insecure content in new docs

## Test plan

- [ ] `grep -rn "plugin-architecture.md" /workspace/docs/` returns zero results ✅
- [ ] `grep -rn "Salt-inspired\|Salt inspired" /workspace/docs/` returns zero results ✅
- [ ] `docs/terminology.md` has all nine new term entries ✅
- [ ] `docs/architecture.md` has Module System section with three-kinds table, four-execution-paths, three-trust-modes ✅
- [ ] `docs/architecture/modules/behavioral-envelope.md` exists and documents complete envelope schema ✅
- [ ] CLAUDE.md has ADR-006 file path pointer ✅
- [ ] All eight module READMEs have `**Kind:** steward` annotation ✅
- [ ] `docs/architecture/operating-model.md` references outpost-kind and workflow-kind modules ✅
- [ ] `make test-agent-complete` passes ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)