### PR TITLE
ci: make codeql-pack-publish tolerate "already exists" without failing red

### DIFF
--- a/.github/workflows/codeql-pack-publish.yml
+++ b/.github/workflows/codeql-pack-publish.yml
@@ -82,14 +82,29 @@ jobs:
           # exists; that's expected idempotent behavior. Bumping the version
           # in qlpack.yml is the trigger for a new publish.
           #
+          # GitHub runs `shell: bash` with `-e`, so a non-zero `codeql pack
+          # publish` (notably the "already exists" case) aborts this step
+          # before the classification below ever runs — which is why this
+          # workflow went red on every develop push that didn't bump the
+          # version. Drop `-e` around the publish and capture the output so we
+          # can tolerate "already exists" while still failing loudly on a real
+          # publish error (a silent `exit 0` would mask those).
+          #
           # --registries-auth-stdin expects a comma-separated list of
           # `<registry_url>=<token>` pairs (NOT JSON, despite docs in some
           # places suggesting otherwise — CodeQL CLI 2.25.5 strictly rejects
           # JSON with "Registry authentication must be a comma-separated...").
-          printf '%s' "https://containers.ghcr.io/v2/=$GITHUB_TOKEN" \
-            | codeql pack publish --registries-auth-stdin .github/codeql/extensions
+          set +e
+          out=$(printf '%s' "https://containers.ghcr.io/v2/=$GITHUB_TOKEN" \
+            | codeql pack publish --registries-auth-stdin .github/codeql/extensions 2>&1)
           status=$?
-          if [ $status -ne 0 ]; then
-            echo "::notice::pack publish exited $status — likely version already exists in registry (idempotent re-publish)"
+          set -e
+          echo "$out"
+          if [ "$status" -eq 0 ]; then
+            echo "::notice::Published a new CodeQL extension pack version."
+          elif printf '%s\n' "$out" | grep -q "already exists"; then
+            echo "::notice::Pack version already exists in the registry — no-op. Bump 'version:' in .github/codeql/extensions/qlpack.yml to publish model changes."
+          else
+            echo "::error::codeql pack publish failed (exit $status) — see output above."
+            exit 1
           fi
-          exit 0


### PR DESCRIPTION
## Summary

`codeql-pack-publish.yml` has gone red on every push to `develop`/`main` that didn't bump the pack version (observed 2026-05-24 / 05-27 / 05-28). Root cause: the publish step runs under GitHub's default `shell: bash` (`-e -o pipefail`), so a non-zero `codeql pack publish` aborts the step **before** the existing `status=$?` / `exit 0` lines run. Since `pack publish` exits non-zero whenever `name@version` already exists, the expected idempotent no-op was being reported as a failure.

This is cosmetic today (the pack `cfg-is/cfgms-go-extensions@0.0.4` is published and in sync with the models), but it (a) leaves red X's on protected-branch pushes and (b) would mask a *genuine* publish failure.

## Change

Drop `-e` around the publish, capture its output, then classify:
- exit 0 on a successful publish **or** the idempotent "already exists" case
- exit 1 (loudly) on any other failure — so a real publish problem is no longer swallowed

Verified all three branches under `bash -e -o pipefail` (success → exit 0, already-exists → exit 0, real error → exit 1).

No model or pack-version change — `cfg-is/cfgms-go-extensions` stays at `v0.0.4`.

## Note

Scoped strictly to the publish step's error handling. This does **not** touch `codeql-analysis.yml` or the sanitizer models, which are working correctly (the recent `CodeQL Analysis (go)` failure on #1912 was an unrelated transient SARIF-upload flake — it passes on develop and every other recent PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)