### PR TITLE
controller: bridge control-plane heartbeats into the API steward registry (Issue #1986)

### DIFF
--- a/features/controller/server/server.go
+++ b/features/controller/server/server.go
@@ -581,6 +581,54 @@ func New(cfg *config.Config, logger logging.Logger) (*Server, error) {
 		}
 		logger.Info("Heartbeat monitoring service initialized successfully")
 
+		// Issue #1986: bridge control-plane heartbeats into the steward registry
+		// the API serves. heartbeat.Service tracks liveness in its own in-memory
+		// map but never updates ControllerService, so GET /api/v1/stewards/{id}
+		// would report a last_seen frozen at registration time and a status stuck
+		// at "registered" even while the steward heartbeats. Register a second
+		// heartbeat handler that advances the registry via RecordHeartbeat.
+		//
+		// The same handler carries Layer-3 instrumentation: it records the
+		// controller-side receipt cadence per steward and warns when a gap exceeds
+		// the expected steward interval, so intermittent heartbeat loss is
+		// observable without changing log levels.
+		if controllerService != nil {
+			var heartbeatGapTracker sync.Map // stewardID -> time.Time (last receipt)
+			const heartbeatGapWarnThreshold = 45 * time.Second
+			if subErr := controlPlane.SubscribeHeartbeats(context.Background(), func(_ context.Context, hb *controlplaneTypes.Heartbeat) error {
+				if hb == nil {
+					return nil
+				}
+				recorded := controllerService.RecordHeartbeat(hb.StewardID, hb.Version, hb.Timestamp)
+
+				now := time.Now()
+				if prev, ok := heartbeatGapTracker.Load(hb.StewardID); ok {
+					gap := now.Sub(prev.(time.Time))
+					if gap > heartbeatGapWarnThreshold {
+						logger.Warn("Steward heartbeat receipt gap exceeded expected interval (Issue #1986 Layer 3)",
+							"steward_id", logging.SanitizeLogValue(hb.StewardID),
+							"gap", gap.Round(time.Millisecond),
+							"recorded", recorded)
+					} else {
+						logger.Debug("heartbeat received",
+							"steward_id", logging.SanitizeLogValue(hb.StewardID),
+							"gap", gap.Round(time.Millisecond),
+							"recorded", recorded)
+					}
+				} else {
+					logger.Debug("heartbeat received (first)",
+						"steward_id", logging.SanitizeLogValue(hb.StewardID),
+						"recorded", recorded)
+				}
+				heartbeatGapTracker.Store(hb.StewardID, now)
+				return nil
+			}); subErr != nil {
+				logger.Warn("Failed to register steward-registry heartbeat bridge", "error", subErr)
+			} else {
+				logger.Info("Steward-registry heartbeat bridge registered (Issue #1986)")
+			}
+		}
+
 		// Initialize command publisher (Story #198, Story #363, Story #514, Story #919)
 		logger.Info("Initializing command publisher...")
 		commandPublisher, err = commands.New(&commands.Config{

--- a/features/controller/service/controller_service.go
+++ b/features/controller/service/controller_service.go
@@ -336,6 +336,45 @@ func (s *ControllerService) GetStewardInfo(stewardID string) (*StewardInfo, bool
 	return info, exists
 }
 
+// RecordHeartbeat advances the live heartbeat state for a registered steward in
+// the in-memory registry that the steward API serves (handlers_stewards.go ->
+// GetStewardInfo). It is the bridge from the control-plane heartbeat dispatch
+// into that registry.
+//
+// Without this bridge the registry is only ever populated by registration and
+// warm-load (LastHeartbeat = record.StoredAt), so GET /api/v1/stewards/{id}
+// reports a last_seen frozen at registration time and a status stuck at
+// "registered" even while the steward is actively heartbeating (Issue #1986).
+//
+// On the first heartbeat a freshly-registered steward is promoted to "active",
+// mirroring the durable StewardStore lifecycle. A zero ts falls back to now.
+// Returns false when the steward is unknown to this controller (e.g. a heartbeat
+// arriving before warm-load or for a deregistered steward).
+func (s *ControllerService) RecordHeartbeat(stewardID, version string, ts time.Time) bool {
+	if ts.IsZero() {
+		ts = time.Now()
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	steward, exists := s.stewards[stewardID]
+	if !exists {
+		return false
+	}
+
+	steward.LastHeartbeat = ts
+	if version != "" {
+		steward.Version = version
+	}
+	// Promote registered -> active on the first heartbeat. Leave any other
+	// lifecycle status (e.g. an operator-set state) untouched.
+	if steward.Status == "" || steward.Status == "registered" {
+		steward.Status = "active"
+	}
+	return true
+}
+
 // RegisterSteward records or updates a steward that registered via the HTTP path.
 // It is idempotent: calling it twice with the same stewardID overwrites the entry.
 //

--- a/features/controller/service/controller_service_test.go
+++ b/features/controller/service/controller_service_test.go
@@ -133,6 +133,63 @@ func TestLoadFromStorage_LiveStewardNotOverwritten(t *testing.T) {
 	assert.Equal(t, "online", info.Status)
 }
 
+// TestRecordHeartbeat_AdvancesRegistryAndPromotes proves the Issue #1986 fix:
+// a control-plane heartbeat advances the API-served registry's LastHeartbeat and
+// promotes a freshly-registered steward to "active". Without RecordHeartbeat the
+// registry is frozen at the warm-loaded StoredAt and status never leaves
+// "registered" even while the steward heartbeats.
+func TestRecordHeartbeat_AdvancesRegistryAndPromotes(t *testing.T) {
+	svc := NewControllerService(logging.NewNoopLogger())
+
+	registeredAt := time.Now().Add(-72 * time.Hour)
+	svc.mu.Lock()
+	svc.stewards["dev-1"] = &StewardInfo{
+		ID:            "dev-1",
+		TenantID:      "tenant-a",
+		LastHeartbeat: registeredAt,
+		Status:        "registered",
+		Metrics:       make(map[string]string),
+	}
+	svc.mu.Unlock()
+
+	beat := time.Now()
+	ok := svc.RecordHeartbeat("dev-1", "v0.5.0-dev", beat)
+	require.True(t, ok, "heartbeat for a known steward must be recorded")
+
+	info, found := svc.GetStewardInfo("dev-1")
+	require.True(t, found)
+	assert.WithinDuration(t, beat, info.LastHeartbeat, time.Millisecond,
+		"last_seen must advance to the heartbeat timestamp, not stay at registration time")
+	assert.Equal(t, "active", info.Status, "first heartbeat must promote registered -> active")
+	assert.Equal(t, "v0.5.0-dev", info.Version, "heartbeat must populate the reported version")
+}
+
+// TestRecordHeartbeat_ZeroTimestampFallsBackToNow ensures a heartbeat carrying no
+// timestamp still advances last_seen rather than zeroing it.
+func TestRecordHeartbeat_ZeroTimestampFallsBackToNow(t *testing.T) {
+	svc := NewControllerService(logging.NewNoopLogger())
+	svc.mu.Lock()
+	svc.stewards["dev-1"] = &StewardInfo{ID: "dev-1", Status: "active", LastHeartbeat: time.Now().Add(-time.Hour)}
+	svc.mu.Unlock()
+
+	before := time.Now()
+	ok := svc.RecordHeartbeat("dev-1", "", time.Time{})
+	require.True(t, ok)
+
+	info, _ := svc.GetStewardInfo("dev-1")
+	assert.False(t, info.LastHeartbeat.Before(before), "zero ts must fall back to now, not zero out last_seen")
+}
+
+// TestRecordHeartbeat_UnknownStewardReturnsFalse ensures heartbeats for stewards
+// this controller does not know about are reported (not silently created).
+func TestRecordHeartbeat_UnknownStewardReturnsFalse(t *testing.T) {
+	svc := NewControllerService(logging.NewNoopLogger())
+	ok := svc.RecordHeartbeat("ghost", "v1", time.Now())
+	assert.False(t, ok, "heartbeat for an unknown steward must return false")
+	_, found := svc.GetStewardInfo("ghost")
+	assert.False(t, found, "RecordHeartbeat must not fabricate a registry entry")
+}
+
 func TestStoreDNA_WriteOnSync(t *testing.T) {
 	storage := newTestFleetStorage(t)
 	ctx := context.Background()


### PR DESCRIPTION
## Summary

Fixes #1986. A live, heartbeating steward showed a `last_seen` frozen at its registration time and a status stuck at `registered` in the controller API (`cfg steward status`). Root-caused live on CFG-70-02 against ctrl-01.

**Cause:** steward heartbeats arrive over the control plane and are processed by `heartbeat.Service` — but that service keeps liveness in its **own** in-memory map and never updates `ControllerService`, which is the registry the steward API actually serves (`handlers_stewards.go` → `GetStewardInfo().LastHeartbeat`). `ControllerService.LastHeartbeat` is set once at registration / warm-load (`record.StoredAt`) and never advances. `ControllerService.ProcessHeartbeat` (the only updater) had **zero callers**.

## Change

- **`ControllerService.RecordHeartbeat(stewardID, version, ts)`** — advances `LastHeartbeat`, records the reported version, and promotes `registered`→`active` on the first heartbeat. Returns false for unknown stewards (no fabricated entries).
- **Server wiring** registers a second control-plane heartbeat handler that calls `RecordHeartbeat`, bridging the dispatch into the API registry.
- **Layer-3 instrumentation:** the same handler logs per-steward controller-side receipt cadence and `Warn`s when a gap exceeds the expected interval, so the *separate* intermittent-delivery issue becomes observable in production logs (to be root-caused/fixed in a follow-up once the instrumented data localizes it).

## Notes / scope

- The 15s `HeartbeatTimeout` (`server.go:566`) is **dead config** — only emitted in a log line (`heartbeat/service.go:192`), never used for detection. The effective stale-timeout is the correctly-sized 60s `stewardOfflineTimeout` (3 missed beats @ 20s). No timeout change needed.
- DNA staleness (`cfg steward dna` empty) flows through a different path (DNA sync) and is out of scope here.

## Tests

- `TestRecordHeartbeat_AdvancesRegistryAndPromotes`, `_ZeroTimestampFallsBackToNow`, `_UnknownStewardReturnsFalse` (TDD).
- `go build ./...`, `go vet`, and `features/controller/{service,heartbeat,server}` suites pass.
- Live verification (watching `last_seen` advance on ctrl-01) to be done post-merge with the reviewed binary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)