### PR TITLE
controller: allow admin mTLS principals to dispatch + manage ad-hoc runs (Issue #1990)

### DIFF
--- a/features/controller/api/handlers_runs.go
+++ b/features/controller/api/handlers_runs.go
@@ -89,6 +89,35 @@ type postRunCommandRequest struct {
 	Signature *execCommandSignature `json:"signature"` // optional mTLS signing envelope
 }
 
+// authRunAccess authenticates a request to the ad-hoc run API and returns the
+// principal and its tenant scope. Admin mTLS principals carry global
+// (cross-tenant) scope with an empty TenantID (middleware.go); the run path is
+// designed for that — an empty tenant yields an unscoped fleet search, the
+// dispatch RBAC check is skipped, and the audit uses the system-tenant sentinel.
+// Only a NON-admin principal with no tenant is a genuine auth failure. On failure
+// it writes the 401 and returns ok=false (Issue #1990).
+func (s *Server) authRunAccess(w http.ResponseWriter, r *http.Request) (principal *Principal, tenantID string, ok bool) {
+	principal, hasPrincipal := r.Context().Value(principalContextKey).(*Principal)
+	if !hasPrincipal || principal == nil {
+		s.writeErrorResponse(w, http.StatusUnauthorized, "Authentication required", "AUTHENTICATION_REQUIRED")
+		return nil, "", false
+	}
+	tenantID, _ = r.Context().Value(ctxkeys.TenantID).(string)
+	if tenantID == "" && !principal.IsAdmin {
+		s.writeErrorResponse(w, http.StatusUnauthorized, "Authentication required", "AUTHENTICATION_REQUIRED")
+		return nil, "", false
+	}
+	return principal, tenantID, true
+}
+
+// runVisibleTo reports whether the principal may read/cancel the given run. Admin
+// mTLS principals have global access; tenant-scoped callers may access only runs
+// owned by their tenant. Callers return 404 (not 403) on false to avoid leaking
+// cross-tenant run existence (Issue #1990).
+func runVisibleTo(principal *Principal, run *controllerrun.RunRecord, tenantID string) bool {
+	return principal.IsAdmin || run.TenantID == tenantID
+}
+
 // handlePostRunScript handles POST /api/v1/runs/script.
 // Creates a run record and fans out one QueuedExecution per matched steward.
 func (s *Server) handlePostRunScript(w http.ResponseWriter, r *http.Request) {
@@ -97,19 +126,8 @@ func (s *Server) handlePostRunScript(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	principal, ok := r.Context().Value(principalContextKey).(*Principal)
-	if !ok || principal == nil {
-		s.writeErrorResponse(w, http.StatusUnauthorized, "Authentication required", "AUTHENTICATION_REQUIRED")
-		return
-	}
-	tenantID, _ := r.Context().Value(ctxkeys.TenantID).(string)
-	// Admin mTLS principals carry global (cross-tenant) scope with an empty TenantID
-	// (middleware.go); this path is designed for it — an empty tenant yields an
-	// unscoped fleet search, the RBAC check below is skipped, and the audit uses the
-	// system-tenant sentinel. Only a NON-admin principal with no tenant is a genuine
-	// auth failure (Issue #1990).
-	if tenantID == "" && !principal.IsAdmin {
-		s.writeErrorResponse(w, http.StatusUnauthorized, "Authentication required", "AUTHENTICATION_REQUIRED")
+	principal, tenantID, ok := s.authRunAccess(w, r)
+	if !ok {
 		return
 	}
 
@@ -148,9 +166,12 @@ func (s *Server) handlePostRunScript(w http.ResponseWriter, r *http.Request) {
 	// parameter resolution and the required API scope (Issue #1675). The scope
 	// is read from the store — never from the request body — so callers cannot
 	// widen it beyond what was set by script:admin.
+	// Privilege metadata is tenant-scoped. A global admin (empty tenant) is not
+	// bound by per-tenant script scope, so skip the lookup rather than querying the
+	// store with an empty tenant key (which is undefined/store-dependent) — Issue #1990.
 	var paramPlatformBindings map[string]string
 	var requiredAPIScope []string
-	if s.privilegeStore != nil {
+	if s.privilegeStore != nil && tenantID != "" {
 		meta, loadErr := s.loadPrivilegeMetadata(r.Context(), tenantID, req.ScriptID)
 		if loadErr == nil && meta != nil {
 			paramPlatformBindings = meta.ParamPlatformBindings
@@ -195,19 +216,8 @@ func (s *Server) handlePostRunCommand(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	principal, ok := r.Context().Value(principalContextKey).(*Principal)
-	if !ok || principal == nil {
-		s.writeErrorResponse(w, http.StatusUnauthorized, "Authentication required", "AUTHENTICATION_REQUIRED")
-		return
-	}
-	tenantID, _ := r.Context().Value(ctxkeys.TenantID).(string)
-	// Admin mTLS principals carry global (cross-tenant) scope with an empty TenantID
-	// (middleware.go); this path is designed for it — an empty tenant yields an
-	// unscoped fleet search, the RBAC check below is skipped, and the audit uses the
-	// system-tenant sentinel. Only a NON-admin principal with no tenant is a genuine
-	// auth failure (Issue #1990).
-	if tenantID == "" && !principal.IsAdmin {
-		s.writeErrorResponse(w, http.StatusUnauthorized, "Authentication required", "AUTHENTICATION_REQUIRED")
+	principal, tenantID, ok := s.authRunAccess(w, r)
+	if !ok {
 		return
 	}
 
@@ -311,9 +321,8 @@ func (s *Server) handleGetRun(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	tenantID, _ := r.Context().Value(ctxkeys.TenantID).(string)
-	if tenantID == "" {
-		s.writeErrorResponse(w, http.StatusUnauthorized, "Authentication required", "AUTHENTICATION_REQUIRED")
+	principal, tenantID, ok := s.authRunAccess(w, r)
+	if !ok {
 		return
 	}
 
@@ -336,7 +345,7 @@ func (s *Server) handleGetRun(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Tenant isolation: return 404 (not 403) to avoid leaking existence across tenants.
-	if run.TenantID != tenantID {
+	if !runVisibleTo(principal, run, tenantID) {
 		s.writeErrorResponse(w, http.StatusNotFound, "Run not found", "NOT_FOUND")
 		return
 	}
@@ -351,9 +360,8 @@ func (s *Server) handleGetRunJobs(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	tenantID, _ := r.Context().Value(ctxkeys.TenantID).(string)
-	if tenantID == "" {
-		s.writeErrorResponse(w, http.StatusUnauthorized, "Authentication required", "AUTHENTICATION_REQUIRED")
+	principal, tenantID, ok := s.authRunAccess(w, r)
+	if !ok {
 		return
 	}
 
@@ -375,7 +383,7 @@ func (s *Server) handleGetRunJobs(w http.ResponseWriter, r *http.Request) {
 		s.writeErrorResponse(w, http.StatusInternalServerError, "Failed to list jobs", "INTERNAL_ERROR")
 		return
 	}
-	if run.TenantID != tenantID {
+	if !runVisibleTo(principal, run, tenantID) {
 		s.writeErrorResponse(w, http.StatusNotFound, "Run not found", "NOT_FOUND")
 		return
 	}
@@ -401,9 +409,8 @@ func (s *Server) handleDeleteRun(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	tenantID, _ := r.Context().Value(ctxkeys.TenantID).(string)
-	if tenantID == "" {
-		s.writeErrorResponse(w, http.StatusUnauthorized, "Authentication required", "AUTHENTICATION_REQUIRED")
+	principal, tenantID, ok := s.authRunAccess(w, r)
+	if !ok {
 		return
 	}
 
@@ -426,7 +433,7 @@ func (s *Server) handleDeleteRun(w http.ResponseWriter, r *http.Request) {
 		s.writeErrorResponse(w, http.StatusInternalServerError, "Failed to cancel run", "INTERNAL_ERROR")
 		return
 	}
-	if run.TenantID != tenantID {
+	if !runVisibleTo(principal, run, tenantID) {
 		s.writeErrorResponse(w, http.StatusNotFound, "Run not found", "NOT_FOUND")
 		return
 	}

--- a/features/controller/api/handlers_runs.go
+++ b/features/controller/api/handlers_runs.go
@@ -97,13 +97,18 @@ func (s *Server) handlePostRunScript(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	tenantID, _ := r.Context().Value(ctxkeys.TenantID).(string)
-	if tenantID == "" {
+	principal, ok := r.Context().Value(principalContextKey).(*Principal)
+	if !ok || principal == nil {
 		s.writeErrorResponse(w, http.StatusUnauthorized, "Authentication required", "AUTHENTICATION_REQUIRED")
 		return
 	}
-	principal, ok := r.Context().Value(principalContextKey).(*Principal)
-	if !ok || principal == nil {
+	tenantID, _ := r.Context().Value(ctxkeys.TenantID).(string)
+	// Admin mTLS principals carry global (cross-tenant) scope with an empty TenantID
+	// (middleware.go); this path is designed for it — an empty tenant yields an
+	// unscoped fleet search, the RBAC check below is skipped, and the audit uses the
+	// system-tenant sentinel. Only a NON-admin principal with no tenant is a genuine
+	// auth failure (Issue #1990).
+	if tenantID == "" && !principal.IsAdmin {
 		s.writeErrorResponse(w, http.StatusUnauthorized, "Authentication required", "AUTHENTICATION_REQUIRED")
 		return
 	}
@@ -190,13 +195,18 @@ func (s *Server) handlePostRunCommand(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	tenantID, _ := r.Context().Value(ctxkeys.TenantID).(string)
-	if tenantID == "" {
+	principal, ok := r.Context().Value(principalContextKey).(*Principal)
+	if !ok || principal == nil {
 		s.writeErrorResponse(w, http.StatusUnauthorized, "Authentication required", "AUTHENTICATION_REQUIRED")
 		return
 	}
-	principal, ok := r.Context().Value(principalContextKey).(*Principal)
-	if !ok || principal == nil {
+	tenantID, _ := r.Context().Value(ctxkeys.TenantID).(string)
+	// Admin mTLS principals carry global (cross-tenant) scope with an empty TenantID
+	// (middleware.go); this path is designed for it — an empty tenant yields an
+	// unscoped fleet search, the RBAC check below is skipped, and the audit uses the
+	// system-tenant sentinel. Only a NON-admin principal with no tenant is a genuine
+	// auth failure (Issue #1990).
+	if tenantID == "" && !principal.IsAdmin {
 		s.writeErrorResponse(w, http.StatusUnauthorized, "Authentication required", "AUTHENTICATION_REQUIRED")
 		return
 	}

--- a/features/controller/api/handlers_runs_test.go
+++ b/features/controller/api/handlers_runs_test.go
@@ -15,12 +15,22 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/gorilla/mux"
+
 	"github.com/cfgis/cfgms/features/controller/fleet"
 	controllerrun "github.com/cfgis/cfgms/features/controller/run"
 	scriptmodule "github.com/cfgis/cfgms/features/modules/script"
 	"github.com/cfgis/cfgms/pkg/ctxkeys"
 	_ "modernc.org/sqlite"
 )
+
+// withPrincipal injects a principal + its tenant into the request context exactly
+// as authenticationMiddleware does for an mTLS admin cert (Issue #1990).
+func withPrincipal(req *http.Request, p *Principal) *http.Request {
+	ctx := context.WithValue(req.Context(), principalContextKey, p)
+	ctx = context.WithValue(ctx, ctxkeys.TenantID, p.TenantID)
+	return req.WithContext(ctx)
+}
 
 // postRunWithPrincipal calls a run handler directly with the given principal +
 // its tenant injected into the request context, exactly as authenticationMiddleware
@@ -254,6 +264,74 @@ func TestRunCommand_NonAdminEmptyTenant_StillUnauthorized(t *testing.T) {
 
 	assert.Equal(t, http.StatusUnauthorized, rec.Code,
 		"a non-admin principal with no tenant must remain unauthorized")
+}
+
+// TestRunLifecycle_AdminMTLSEmptyTenant covers the FULL cfg steward exec lifecycle
+// for an admin mTLS principal (Issue #1990): dispatch, then read the run + jobs and
+// cancel it. The exec CLI dispatches and then polls GET /runs/{id} for output, so
+// fixing only the POST gate would leave exec broken — the GET/DELETE handlers must
+// also admit admin principals. Before the full fix those handlers 401'd admins.
+func TestRunLifecycle_AdminMTLSEmptyTenant(t *testing.T) {
+	stewards := []fleet.StewardResult{{ID: "steward-1", TenantID: "infra-hyperv"}}
+	server, _, _ := setupRunServer(t, stewards)
+	admin := &Principal{ID: "cfgms-admin", IsAdmin: true, TenantID: ""}
+
+	// 1. Dispatch (POST) as admin.
+	rec := postRunWithPrincipal(t, server.handlePostRunCommand, "/api/v1/runs/command", admin, map[string]interface{}{
+		"target":  "id:steward-1",
+		"content": base64.StdEncoding.EncodeToString([]byte("hostname")),
+		"shell":   "pwsh",
+	})
+	require.Equal(t, http.StatusOK, rec.Code, "dispatch body: %s", rec.Body.String())
+	var resp APIResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	runID, _ := resp.Data.(map[string]interface{})["run_id"].(string)
+	require.NotEmpty(t, runID, "dispatch must return a run_id")
+
+	// 2. GET the run as admin (the exec CLI polls this) — must not 401, must find it.
+	getReq := withPrincipal(mux.SetURLVars(httptest.NewRequest(http.MethodGet, "/api/v1/runs/"+runID, nil), map[string]string{"run_id": runID}), admin)
+	getRec := httptest.NewRecorder()
+	server.handleGetRun(getRec, getReq)
+	require.Equal(t, http.StatusOK, getRec.Code, "admin GET run must succeed (not 401/404); body: %s", getRec.Body.String())
+
+	// 3. GET the run's jobs as admin — must not 401.
+	jobsReq := withPrincipal(mux.SetURLVars(httptest.NewRequest(http.MethodGet, "/api/v1/runs/"+runID+"/jobs", nil), map[string]string{"run_id": runID}), admin)
+	jobsRec := httptest.NewRecorder()
+	server.handleGetRunJobs(jobsRec, jobsReq)
+	require.Equal(t, http.StatusOK, jobsRec.Code, "admin GET jobs must succeed; body: %s", jobsRec.Body.String())
+
+	// 4. DELETE/cancel the run as admin — must not 401 (200 cancel or 409 if already terminal).
+	delReq := withPrincipal(mux.SetURLVars(httptest.NewRequest(http.MethodDelete, "/api/v1/runs/"+runID, nil), map[string]string{"run_id": runID}), admin)
+	delRec := httptest.NewRecorder()
+	server.handleDeleteRun(delRec, delReq)
+	require.NotEqual(t, http.StatusUnauthorized, delRec.Code, "admin DELETE must not 401; body: %s", delRec.Body.String())
+	require.NotEqual(t, http.StatusNotFound, delRec.Code, "admin DELETE must find the run; body: %s", delRec.Body.String())
+}
+
+// TestGetRun_NonAdminCrossTenant_NotFound guards isolation: a tenant-scoped caller
+// cannot read another tenant's run (admin-aware ownership check must not weaken this).
+func TestGetRun_NonAdminCrossTenant_NotFound(t *testing.T) {
+	stewards := []fleet.StewardResult{{ID: "steward-1", TenantID: "tenant-a"}}
+	server, _, _ := setupRunServer(t, stewards)
+
+	// Admin dispatches a run owned by the global/empty tenant.
+	rec := postRunWithPrincipal(t, server.handlePostRunCommand, "/api/v1/runs/command",
+		&Principal{ID: "cfgms-admin", IsAdmin: true, TenantID: ""}, map[string]interface{}{
+			"target":  "id:steward-1",
+			"content": base64.StdEncoding.EncodeToString([]byte("hostname")),
+			"shell":   "pwsh",
+		})
+	require.Equal(t, http.StatusOK, rec.Code)
+	var resp APIResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	runID := resp.Data.(map[string]interface{})["run_id"].(string)
+
+	// A tenant-scoped (non-admin) caller from a different tenant must get 404.
+	scoped := &Principal{ID: "tenant-b-key", IsAdmin: false, TenantID: "tenant-b"}
+	getReq := withPrincipal(mux.SetURLVars(httptest.NewRequest(http.MethodGet, "/api/v1/runs/"+runID, nil), map[string]string{"run_id": runID}), scoped)
+	getRec := httptest.NewRecorder()
+	server.handleGetRun(getRec, getReq)
+	assert.Equal(t, http.StatusNotFound, getRec.Code, "a scoped caller must not see another tenant's run")
 }
 
 // ---- [REQUIRED TEST] GET /api/v1/runs/{run_id}/jobs accuracy ---------------

--- a/features/controller/api/handlers_runs_test.go
+++ b/features/controller/api/handlers_runs_test.go
@@ -304,8 +304,8 @@ func TestRunLifecycle_AdminMTLSEmptyTenant(t *testing.T) {
 	delReq := withPrincipal(mux.SetURLVars(httptest.NewRequest(http.MethodDelete, "/api/v1/runs/"+runID, nil), map[string]string{"run_id": runID}), admin)
 	delRec := httptest.NewRecorder()
 	server.handleDeleteRun(delRec, delReq)
-	require.NotEqual(t, http.StatusUnauthorized, delRec.Code, "admin DELETE must not 401; body: %s", delRec.Body.String())
-	require.NotEqual(t, http.StatusNotFound, delRec.Code, "admin DELETE must find the run; body: %s", delRec.Body.String())
+	require.Contains(t, []int{http.StatusOK, http.StatusConflict}, delRec.Code,
+		"admin DELETE must succeed (200) or be already-terminal (409) — never 401/404/5xx; body: %s", delRec.Body.String())
 }
 
 // TestGetRun_NonAdminCrossTenant_NotFound guards isolation: a tenant-scoped caller

--- a/features/controller/api/handlers_runs_test.go
+++ b/features/controller/api/handlers_runs_test.go
@@ -18,8 +18,27 @@ import (
 	"github.com/cfgis/cfgms/features/controller/fleet"
 	controllerrun "github.com/cfgis/cfgms/features/controller/run"
 	scriptmodule "github.com/cfgis/cfgms/features/modules/script"
+	"github.com/cfgis/cfgms/pkg/ctxkeys"
 	_ "modernc.org/sqlite"
 )
+
+// postRunWithPrincipal calls a run handler directly with the given principal +
+// its tenant injected into the request context, exactly as authenticationMiddleware
+// would for an mTLS admin cert. An X-API-Key request always carries a tenant, so it
+// cannot reproduce the admin-mTLS global-scope (empty-tenant) path — Issue #1990.
+func postRunWithPrincipal(t *testing.T, handler http.HandlerFunc, path string, p *Principal, body interface{}) *httptest.ResponseRecorder {
+	t.Helper()
+	b, err := json.Marshal(body)
+	require.NoError(t, err)
+	req := httptest.NewRequest(http.MethodPost, path, bytes.NewReader(b))
+	req.Header.Set("Content-Type", "application/json")
+	ctx := context.WithValue(req.Context(), principalContextKey, p)
+	ctx = context.WithValue(ctx, ctxkeys.TenantID, p.TenantID)
+	req = req.WithContext(ctx)
+	rec := httptest.NewRecorder()
+	handler(rec, req)
+	return rec
+}
 
 // ---- test helpers -----------------------------------------------------------
 
@@ -181,6 +200,60 @@ func TestPostRunScript_TwoStewardFanout(t *testing.T) {
 			"queued execution must carry workflow_run_id")
 		assert.NotEmpty(t, e.Metadata["job_id"], "queued execution must carry job_id")
 	}
+}
+
+// ---- [REQUIRED TEST] admin mTLS (empty-tenant) run dispatch (Issue #1990) ---
+
+// TestRunCommand_AdminMTLSEmptyTenant_NotUnauthorized proves the Issue #1990 fix:
+// an admin mTLS principal (global scope, TenantID="") can dispatch cfg steward exec.
+// Before the fix the early tenantID=="" gate returned 401 before the admin-aware
+// logic ran.
+func TestRunCommand_AdminMTLSEmptyTenant_NotUnauthorized(t *testing.T) {
+	stewards := []fleet.StewardResult{{ID: "steward-1", TenantID: "infra-hyperv"}}
+	server, _, _ := setupRunServer(t, stewards)
+
+	body := map[string]interface{}{
+		"target":  "id:steward-1",
+		"content": base64.StdEncoding.EncodeToString([]byte("hostname")),
+		"shell":   "pwsh",
+	}
+	rec := postRunWithPrincipal(t, server.handlePostRunCommand, "/api/v1/runs/command",
+		&Principal{ID: "cfgms-admin", IsAdmin: true, TenantID: ""}, body)
+
+	require.NotEqual(t, http.StatusUnauthorized, rec.Code,
+		"admin mTLS principal (empty tenant) must not be rejected as unauthenticated; body: %s", rec.Body.String())
+	assert.Equal(t, http.StatusOK, rec.Code, "admin exec should reach run synthesis; body: %s", rec.Body.String())
+}
+
+// TestRunScript_AdminMTLSEmptyTenant_NotUnauthorized is the same guard for run-script.
+func TestRunScript_AdminMTLSEmptyTenant_NotUnauthorized(t *testing.T) {
+	stewards := []fleet.StewardResult{{ID: "steward-1", TenantID: "infra-hyperv"}}
+	server, _, _ := setupRunServer(t, stewards)
+
+	body := map[string]interface{}{"target": "all", "script_id": "scripts/check.sh"}
+	rec := postRunWithPrincipal(t, server.handlePostRunScript, "/api/v1/runs/script",
+		&Principal{ID: "cfgms-admin", IsAdmin: true, TenantID: ""}, body)
+
+	require.NotEqual(t, http.StatusUnauthorized, rec.Code,
+		"admin mTLS principal (empty tenant) must not be rejected; body: %s", rec.Body.String())
+	assert.Equal(t, http.StatusOK, rec.Code, "body: %s", rec.Body.String())
+}
+
+// TestRunCommand_NonAdminEmptyTenant_StillUnauthorized guards against regression:
+// a non-admin principal with no tenant must remain unauthorized.
+func TestRunCommand_NonAdminEmptyTenant_StillUnauthorized(t *testing.T) {
+	server, _, _ := setupRunServer(t, nil)
+
+	body := map[string]interface{}{
+		"target":  "all",
+		"content": base64.StdEncoding.EncodeToString([]byte("hostname")),
+		"shell":   "pwsh",
+	}
+	rec := postRunWithPrincipal(t, server.handlePostRunCommand, "/api/v1/runs/command",
+		&Principal{ID: "scoped-key", IsAdmin: false, TenantID: ""}, body)
+
+	assert.Equal(t, http.StatusUnauthorized, rec.Code,
+		"a non-admin principal with no tenant must remain unauthorized")
 }
 
 // ---- [REQUIRED TEST] GET /api/v1/runs/{run_id}/jobs accuracy ---------------


### PR DESCRIPTION
## Summary

Fixes #1990. `cfg steward exec` / `run-command` / `run-script` via the admin mTLS bundle returned **401**. The run handlers rejected requests with an empty `ctxkeys.TenantID`, but admin mTLS principals intentionally carry no tenant scope (global access) — so every admin was treated as unauthenticated. Verified live on CFG-70-02.

## Change

- Shared `authRunAccess` helper across all five run handlers: authenticate on the **principal**; reject an empty tenant only for **non-admin** principals. Admin mTLS principals proceed with the empty tenant the downstream already expects (unscoped fleet search; RBAC scope check skipped; audit uses the system-tenant sentinel).
- `runVisibleTo(principal, run, tenant)` makes the run-ownership check on GET/jobs/DELETE explicitly admin-aware (admins have global access; tenant-scoped callers stay bound to their tenant, 404 on mismatch).
- run-script skips the tenant-scoped privilege-metadata lookup for global admins rather than querying with an empty tenant key.

The POST-only fix would be incomplete: `cfg steward exec` dispatches then **polls GET /runs/{id}** for output, so GET/jobs/DELETE must admit admins too.

## Security

`Principal.IsAdmin` is set only by `extractAdminPrincipal` (TLS-chain-verified, admin-marked, revocation-checked cert); API-key and relay principals are hardcoded `IsAdmin=false`. Tenant isolation for scoped callers is preserved (RBAC prefix check + `filter.TenantID` scoping in synthesis + `runVisibleTo`).

## Tests

Dispatch not-401 (run-command + run-script), non-admin empty-tenant still-401, full admin **lifecycle** (dispatch → GET run → GET jobs → DELETE), and cross-tenant isolation (a scoped caller cannot read another tenant's run). Full `features/controller/api` suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)