### PR TITLE
controlplane: add execute_script to command proto enum + descriptor + convert maps (Issue #1992)

### DIFF
--- a/api/proto/transport/control.pb.go
+++ b/api/proto/transport/control.pb.go
@@ -29,19 +29,17 @@ const (
 type CommandType int32
 
 const (
-	CommandType_COMMAND_TYPE_UNSPECIFIED       CommandType = 0
-	CommandType_COMMAND_TYPE_SYNC_CONFIG       CommandType = 1
-	CommandType_COMMAND_TYPE_SYNC_DNA          CommandType = 2
-	CommandType_COMMAND_TYPE_CONNECT_DATAPLANE CommandType = 3
-	CommandType_COMMAND_TYPE_EXECUTE_TASK      CommandType = 4
-	CommandType_COMMAND_TYPE_SHUTDOWN          CommandType = 5
-	CommandType_COMMAND_TYPE_VALIDATE_CONFIG   CommandType = 6
-	CommandType_COMMAND_TYPE_RECONNECT         CommandType = 7
-	// COMMAND_TYPE_EXECUTE_SCRIPT = 8 is reserved for Issue #1669; proto regen deferred.
-	// CommandType_COMMAND_TYPE_PUSH_SIGNING_CERT added manually pending proto regen (Issue #1817).
-	CommandType_COMMAND_TYPE_PUSH_SIGNING_CERT CommandType = 9
-	// CommandType_COMMAND_TYPE_PUSH_STEWARD_BINARY added manually pending proto regen (Issue #1943).
-	CommandType_COMMAND_TYPE_PUSH_STEWARD_BINARY CommandType = 10
+	CommandType_COMMAND_TYPE_UNSPECIFIED         CommandType = 0
+	CommandType_COMMAND_TYPE_SYNC_CONFIG         CommandType = 1
+	CommandType_COMMAND_TYPE_SYNC_DNA            CommandType = 2
+	CommandType_COMMAND_TYPE_CONNECT_DATAPLANE   CommandType = 3
+	CommandType_COMMAND_TYPE_EXECUTE_TASK        CommandType = 4
+	CommandType_COMMAND_TYPE_SHUTDOWN            CommandType = 5
+	CommandType_COMMAND_TYPE_VALIDATE_CONFIG     CommandType = 6
+	CommandType_COMMAND_TYPE_RECONNECT           CommandType = 7
+	CommandType_COMMAND_TYPE_EXECUTE_SCRIPT      CommandType = 8  // Issue #1669/#1992: controller dispatches a signed script execution to a steward
+	CommandType_COMMAND_TYPE_PUSH_SIGNING_CERT   CommandType = 9  // Issue #1817: controller pushes current signing cert on every steward connect
+	CommandType_COMMAND_TYPE_PUSH_STEWARD_BINARY CommandType = 10 // Issue #1943: controller pushes a new steward binary for self-upgrade
 )
 
 // Enum value maps for CommandType.
@@ -55,6 +53,7 @@ var (
 		5:  "COMMAND_TYPE_SHUTDOWN",
 		6:  "COMMAND_TYPE_VALIDATE_CONFIG",
 		7:  "COMMAND_TYPE_RECONNECT",
+		8:  "COMMAND_TYPE_EXECUTE_SCRIPT",
 		9:  "COMMAND_TYPE_PUSH_SIGNING_CERT",
 		10: "COMMAND_TYPE_PUSH_STEWARD_BINARY",
 	}
@@ -67,6 +66,7 @@ var (
 		"COMMAND_TYPE_SHUTDOWN":            5,
 		"COMMAND_TYPE_VALIDATE_CONFIG":     6,
 		"COMMAND_TYPE_RECONNECT":           7,
+		"COMMAND_TYPE_EXECUTE_SCRIPT":      8,
 		"COMMAND_TYPE_PUSH_SIGNING_CERT":   9,
 		"COMMAND_TYPE_PUSH_STEWARD_BINARY": 10,
 	}
@@ -103,16 +103,15 @@ func (CommandType) EnumDescriptor() ([]byte, []int) {
 type EventType int32
 
 const (
-	EventType_EVENT_TYPE_UNSPECIFIED    EventType = 0
-	EventType_EVENT_TYPE_CONFIG_APPLIED EventType = 1
-	EventType_EVENT_TYPE_DNA_SYNCED     EventType = 2
-	EventType_EVENT_TYPE_TASK_COMPLETED EventType = 3
-	EventType_EVENT_TYPE_TASK_FAILED    EventType = 4
-	EventType_EVENT_TYPE_ERROR          EventType = 5
-	// Command lifecycle events added manually pending proto regen (Issue #1948).
-	EventType_EVENT_TYPE_COMMAND_RECEIVED  EventType = 6
-	EventType_EVENT_TYPE_COMMAND_COMPLETED EventType = 7
-	EventType_EVENT_TYPE_COMMAND_FAILED    EventType = 8
+	EventType_EVENT_TYPE_UNSPECIFIED       EventType = 0
+	EventType_EVENT_TYPE_CONFIG_APPLIED    EventType = 1
+	EventType_EVENT_TYPE_DNA_SYNCED        EventType = 2
+	EventType_EVENT_TYPE_TASK_COMPLETED    EventType = 3
+	EventType_EVENT_TYPE_TASK_FAILED       EventType = 4
+	EventType_EVENT_TYPE_ERROR             EventType = 5
+	EventType_EVENT_TYPE_COMMAND_RECEIVED  EventType = 6 // Issue #1948: steward acknowledges a dispatched command
+	EventType_EVENT_TYPE_COMMAND_COMPLETED EventType = 7 // Issue #1948: command handler succeeded (drives upgrade commit)
+	EventType_EVENT_TYPE_COMMAND_FAILED    EventType = 8 // Issue #1948: command handler failed (drives upgrade failure)
 )
 
 // Enum value maps for EventType.
@@ -598,9 +597,9 @@ type Heartbeat struct {
 	Timestamp       *timestamppb.Timestamp `protobuf:"bytes,4,opt,name=timestamp,proto3" json:"timestamp,omitempty"`
 	Metrics         map[string]string      `protobuf:"bytes,5,rep,name=metrics,proto3" json:"metrics,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
 	Version         string                 `protobuf:"bytes,6,opt,name=version,proto3" json:"version,omitempty"`
-	DnaHash         string                 `protobuf:"bytes,7,opt,name=dna_hash,json=dnaHash,proto3" json:"dna_hash,omitempty"`
-	ActiveSessions  int32                  `protobuf:"varint,8,opt,name=active_sessions,json=activeSessions,proto3" json:"active_sessions,omitempty"`
-	ConnectionState string                 `protobuf:"bytes,9,opt,name=connection_state,json=connectionState,proto3" json:"connection_state,omitempty"`
+	DnaHash         string                 `protobuf:"bytes,7,opt,name=dna_hash,json=dnaHash,proto3" json:"dna_hash,omitempty"`                         // for hash-based sync detection
+	ActiveSessions  int32                  `protobuf:"varint,8,opt,name=active_sessions,json=activeSessions,proto3" json:"active_sessions,omitempty"`   // number of active control-channel streams (1 when connected, 0 otherwise)
+	ConnectionState string                 `protobuf:"bytes,9,opt,name=connection_state,json=connectionState,proto3" json:"connection_state,omitempty"` // steward connection state ("connected", "disconnected", "connecting", "reconnecting")
 	unknownFields   protoimpl.UnknownFields
 	sizeCache       protoimpl.SizeCache
 }
@@ -786,72 +785,101 @@ func (x *Response) GetDetails() map[string]string {
 var File_transport_control_proto protoreflect.FileDescriptor
 
 const file_transport_control_proto_rawDesc = "" +
-	"\n\x17transport/control.proto\x12\x0fcfgms.transport\x1a\x1fg" +
-	"oogle/protobuf/timestamp.proto\"\xf6\x01\n\x0eControlMessage\x12" +
-	"4\n\x07command\x18\x01 \x01(\x0b2\x18.cfgms.transport.Command" +
-	"H\x00R\x07command\x12.\n\x05event\x18\x02 \x01(\x0b2\x16.cfgm" +
-	"s.transport.EventH\x00R\x05event\x12:\n\theartbeat\x18\x03 \x01" +
-	"(\x0b2\x1a.cfgms.transport.HeartbeatH\x00R\theartbeat\x127\n\x08" +
-	"response\x18\x04 \x01(\x0b2\x19.cfgms.transport.ResponseH\x00" +
-	"R\x08responseB\t\n\x07payload\"\xd6\x02\n\x07Command\x12\x0e\n" +
-	"\x02id\x18\x01 \x01(\tR\x02id\x120\n\x04type\x18\x02 \x01(\x0e" +
-	"2\x1c.cfgms.transport.CommandTypeR\x04type\x12\x1d\n\nsteward" +
-	"_id\x18\x03 \x01(\tR\tstewardId\x12\x1b\n\ttenant_id\x18\x04 " +
-	"\x01(\tR\x08tenantId\x128\n\ttimestamp\x18\x05 \x01(\x0b2\x1a" +
-	".google.protobuf.TimestampR\ttimestamp\x12<\n\x06params\x18\x06" +
-	" \x03(\x0b2$.cfgms.transport.Command.ParamsEntryR\x06params\x12" +
-	"\x1a\n\x08priority\x18\x07 \x01(\x05R\x08priority\x1a9\n\x0bP" +
-	"aramsEntry\x12\x10\n\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
-	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\x8e\x03\n\x05" +
-	"Event\x12\x0e\n\x02id\x18\x01 \x01(\tR\x02id\x12.\n\x04type\x18" +
-	"\x02 \x01(\x0e2\x1a.cfgms.transport.EventTypeR\x04type\x12\x1d" +
-	"\n\nsteward_id\x18\x03 \x01(\tR\tstewardId\x12\x1b\n\ttenant_" +
-	"id\x18\x04 \x01(\tR\x08tenantId\x128\n\ttimestamp\x18\x05 \x01" +
-	"(\x0b2\x1a.google.protobuf.TimestampR\ttimestamp\x12\x1d\n\nc" +
-	"ommand_id\x18\x06 \x01(\tR\tcommandId\x12=\n\x07details\x18\x07" +
-	" \x03(\x0b2#.cfgms.transport.Event.DetailsEntryR\x07details\x12" +
-	"5\n\x08severity\x18\x08 \x01(\x0e2\x19.cfgms.transport.Severi" +
-	"tyR\x08severity\x1a:\n\x0cDetailsEntry\x12\x10\n\x03key\x18\x01" +
-	" \x01(\tR\x03key\x12\x14\n\x05value\x18\x02 \x01(\tR\x05value" +
-	":\x028\x01\"\xc1\x03\n\tHeartbeat\x12\x1d\n\nsteward_id\x18\x01" +
-	" \x01(\tR\tstewardId\x12\x1b\n\ttenant_id\x18\x02 \x01(\tR\x08" +
-	"tenantId\x126\n\x06status\x18\x03 \x01(\x0e2\x1e.cfgms.transp" +
-	"ort.StewardStatusR\x06status\x128\n\ttimestamp\x18\x04 \x01(\x0b" +
-	"2\x1a.google.protobuf.TimestampR\ttimestamp\x12A\n\x07metrics" +
-	"\x18\x05 \x03(\x0b2'.cfgms.transport.Heartbeat.MetricsEntryR\x07" +
-	"metrics\x12\x18\n\x07version\x18\x06 \x01(\tR\x07version\x12\x19" +
-	"\n\x08dna_hash\x18\x07 \x01(\tR\x07dnaHash\x12'\n\x0factive_s" +
-	"essions\x18\x08 \x01(\x05R\x0eactiveSessions\x12)\n\x10connec" +
-	"tion_state\x18\t \x01(\tR\x0fconnectionState\x1a:\n\x0cMetric" +
-	"sEntry\x12\x10\n\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n\x05" +
-	"value\x18\x02 \x01(\tR\x05value:\x028\x01\"\xb4\x02\n\x08Resp" +
-	"onse\x12\x1d\n\ncommand_id\x18\x01 \x01(\tR\tcommandId\x12\x1d" +
-	"\n\nsteward_id\x18\x02 \x01(\tR\tstewardId\x12\x18\n\x07succe" +
-	"ss\x18\x03 \x01(\x08R\x07success\x12\x18\n\x07message\x18\x04" +
-	" \x01(\tR\x07message\x128\n\ttimestamp\x18\x05 \x01(\x0b2\x1a" +
-	".google.protobuf.TimestampR\ttimestamp\x12@\n\x07details\x18\x06" +
-	" \x03(\x0b2&.cfgms.transport.Response.DetailsEntryR\x07detail" +
-	"s\x1a:\n\x0cDetailsEntry\x12\x10\n\x03key\x18\x01 \x01(\tR\x03" +
-	"key\x12\x14\n\x05value\x18\x02 \x01(\tR\x05value:\x028\x01*\xe4" +
-	"\x01\n\x0bCommandType\x12\x1c\n\x18COMMAND_TYPE_UNSPECIFIED\x10" +
-	"\x00\x12\x1c\n\x18COMMAND_TYPE_SYNC_CONFIG\x10\x01\x12\x19\n\x15" +
-	"COMMAND_TYPE_SYNC_DNA\x10\x02\x12\"\n\x1eCOMMAND_TYPE_CONNECT" +
-	"_DATAPLANE\x10\x03\x12\x1d\n\x19COMMAND_TYPE_EXECUTE_TASK\x10" +
-	"\x04\x12\x19\n\x15COMMAND_TYPE_SHUTDOWN\x10\x05\x12 \n\x1cCOM" +
-	"MAND_TYPE_VALIDATE_CONFIG\x10\x06*\xb2\x01\n\tEventType\x12\x1a" +
-	"\n\x16EVENT_TYPE_UNSPECIFIED\x10\x00\x12\x1d\n\x19EVENT_TYPE_" +
-	"CONFIG_APPLIED\x10\x01\x12\x19\n\x15EVENT_TYPE_DNA_SYNCED\x10" +
-	"\x02\x12\x1d\n\x19EVENT_TYPE_TASK_COMPLETED\x10\x03\x12\x1a\n" +
-	"\x16EVENT_TYPE_TASK_FAILED\x10\x04\x12\x14\n\x10EVENT_TYPE_ER" +
-	"ROR\x10\x05*x\n\x08Severity\x12\x18\n\x14SEVERITY_UNSPECIFIED" +
-	"\x10\x00\x12\x11\n\x0dSEVERITY_INFO\x10\x01\x12\x14\n\x10SEVE" +
-	"RITY_WARNING\x10\x02\x12\x12\n\x0eSEVERITY_ERROR\x10\x03\x12\x15" +
-	"\n\x11SEVERITY_CRITICAL\x10\x04*\xa3\x01\n\x0dStewardStatus\x12" +
-	"\x1e\n\x1aSTEWARD_STATUS_UNSPECIFIED\x10\x00\x12\x1a\n\x16STE" +
-	"WARD_STATUS_HEALTHY\x10\x01\x12\x1b\n\x17STEWARD_STATUS_DEGRA" +
-	"DED\x10\x02\x12\x18\n\x14STEWARD_STATUS_ERROR\x10\x03\x12\x1f" +
-	"\n\x1bSTEWARD_STATUS_DISCONNECTED\x10\x04B,Z*github.com/cfgis" +
-	"/cfgms/api/proto/transportb\x06proto3"
+	"\n" +
+	"\x17transport/control.proto\x12\x0fcfgms.transport\x1a\x1fgoogle/protobuf/timestamp.proto\"\xf6\x01\n" +
+	"\x0eControlMessage\x124\n" +
+	"\acommand\x18\x01 \x01(\v2\x18.cfgms.transport.CommandH\x00R\acommand\x12.\n" +
+	"\x05event\x18\x02 \x01(\v2\x16.cfgms.transport.EventH\x00R\x05event\x12:\n" +
+	"\theartbeat\x18\x03 \x01(\v2\x1a.cfgms.transport.HeartbeatH\x00R\theartbeat\x127\n" +
+	"\bresponse\x18\x04 \x01(\v2\x19.cfgms.transport.ResponseH\x00R\bresponseB\t\n" +
+	"\apayload\"\xd6\x02\n" +
+	"\aCommand\x12\x0e\n" +
+	"\x02id\x18\x01 \x01(\tR\x02id\x120\n" +
+	"\x04type\x18\x02 \x01(\x0e2\x1c.cfgms.transport.CommandTypeR\x04type\x12\x1d\n" +
+	"\n" +
+	"steward_id\x18\x03 \x01(\tR\tstewardId\x12\x1b\n" +
+	"\ttenant_id\x18\x04 \x01(\tR\btenantId\x128\n" +
+	"\ttimestamp\x18\x05 \x01(\v2\x1a.google.protobuf.TimestampR\ttimestamp\x12<\n" +
+	"\x06params\x18\x06 \x03(\v2$.cfgms.transport.Command.ParamsEntryR\x06params\x12\x1a\n" +
+	"\bpriority\x18\a \x01(\x05R\bpriority\x1a9\n" +
+	"\vParamsEntry\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\x8e\x03\n" +
+	"\x05Event\x12\x0e\n" +
+	"\x02id\x18\x01 \x01(\tR\x02id\x12.\n" +
+	"\x04type\x18\x02 \x01(\x0e2\x1a.cfgms.transport.EventTypeR\x04type\x12\x1d\n" +
+	"\n" +
+	"steward_id\x18\x03 \x01(\tR\tstewardId\x12\x1b\n" +
+	"\ttenant_id\x18\x04 \x01(\tR\btenantId\x128\n" +
+	"\ttimestamp\x18\x05 \x01(\v2\x1a.google.protobuf.TimestampR\ttimestamp\x12\x1d\n" +
+	"\n" +
+	"command_id\x18\x06 \x01(\tR\tcommandId\x12=\n" +
+	"\adetails\x18\a \x03(\v2#.cfgms.transport.Event.DetailsEntryR\adetails\x125\n" +
+	"\bseverity\x18\b \x01(\x0e2\x19.cfgms.transport.SeverityR\bseverity\x1a:\n" +
+	"\fDetailsEntry\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\xc1\x03\n" +
+	"\tHeartbeat\x12\x1d\n" +
+	"\n" +
+	"steward_id\x18\x01 \x01(\tR\tstewardId\x12\x1b\n" +
+	"\ttenant_id\x18\x02 \x01(\tR\btenantId\x126\n" +
+	"\x06status\x18\x03 \x01(\x0e2\x1e.cfgms.transport.StewardStatusR\x06status\x128\n" +
+	"\ttimestamp\x18\x04 \x01(\v2\x1a.google.protobuf.TimestampR\ttimestamp\x12A\n" +
+	"\ametrics\x18\x05 \x03(\v2'.cfgms.transport.Heartbeat.MetricsEntryR\ametrics\x12\x18\n" +
+	"\aversion\x18\x06 \x01(\tR\aversion\x12\x19\n" +
+	"\bdna_hash\x18\a \x01(\tR\adnaHash\x12'\n" +
+	"\x0factive_sessions\x18\b \x01(\x05R\x0eactiveSessions\x12)\n" +
+	"\x10connection_state\x18\t \x01(\tR\x0fconnectionState\x1a:\n" +
+	"\fMetricsEntry\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\xb4\x02\n" +
+	"\bResponse\x12\x1d\n" +
+	"\n" +
+	"command_id\x18\x01 \x01(\tR\tcommandId\x12\x1d\n" +
+	"\n" +
+	"steward_id\x18\x02 \x01(\tR\tstewardId\x12\x18\n" +
+	"\asuccess\x18\x03 \x01(\bR\asuccess\x12\x18\n" +
+	"\amessage\x18\x04 \x01(\tR\amessage\x128\n" +
+	"\ttimestamp\x18\x05 \x01(\v2\x1a.google.protobuf.TimestampR\ttimestamp\x12@\n" +
+	"\adetails\x18\x06 \x03(\v2&.cfgms.transport.Response.DetailsEntryR\adetails\x1a:\n" +
+	"\fDetailsEntry\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01*\xeb\x02\n" +
+	"\vCommandType\x12\x1c\n" +
+	"\x18COMMAND_TYPE_UNSPECIFIED\x10\x00\x12\x1c\n" +
+	"\x18COMMAND_TYPE_SYNC_CONFIG\x10\x01\x12\x19\n" +
+	"\x15COMMAND_TYPE_SYNC_DNA\x10\x02\x12\"\n" +
+	"\x1eCOMMAND_TYPE_CONNECT_DATAPLANE\x10\x03\x12\x1d\n" +
+	"\x19COMMAND_TYPE_EXECUTE_TASK\x10\x04\x12\x19\n" +
+	"\x15COMMAND_TYPE_SHUTDOWN\x10\x05\x12 \n" +
+	"\x1cCOMMAND_TYPE_VALIDATE_CONFIG\x10\x06\x12\x1a\n" +
+	"\x16COMMAND_TYPE_RECONNECT\x10\a\x12\x1f\n" +
+	"\x1bCOMMAND_TYPE_EXECUTE_SCRIPT\x10\b\x12\"\n" +
+	"\x1eCOMMAND_TYPE_PUSH_SIGNING_CERT\x10\t\x12$\n" +
+	" COMMAND_TYPE_PUSH_STEWARD_BINARY\x10\n" +
+	"*\x94\x02\n" +
+	"\tEventType\x12\x1a\n" +
+	"\x16EVENT_TYPE_UNSPECIFIED\x10\x00\x12\x1d\n" +
+	"\x19EVENT_TYPE_CONFIG_APPLIED\x10\x01\x12\x19\n" +
+	"\x15EVENT_TYPE_DNA_SYNCED\x10\x02\x12\x1d\n" +
+	"\x19EVENT_TYPE_TASK_COMPLETED\x10\x03\x12\x1a\n" +
+	"\x16EVENT_TYPE_TASK_FAILED\x10\x04\x12\x14\n" +
+	"\x10EVENT_TYPE_ERROR\x10\x05\x12\x1f\n" +
+	"\x1bEVENT_TYPE_COMMAND_RECEIVED\x10\x06\x12 \n" +
+	"\x1cEVENT_TYPE_COMMAND_COMPLETED\x10\a\x12\x1d\n" +
+	"\x19EVENT_TYPE_COMMAND_FAILED\x10\b*x\n" +
+	"\bSeverity\x12\x18\n" +
+	"\x14SEVERITY_UNSPECIFIED\x10\x00\x12\x11\n" +
+	"\rSEVERITY_INFO\x10\x01\x12\x14\n" +
+	"\x10SEVERITY_WARNING\x10\x02\x12\x12\n" +
+	"\x0eSEVERITY_ERROR\x10\x03\x12\x15\n" +
+	"\x11SEVERITY_CRITICAL\x10\x04*\xa3\x01\n" +
+	"\rStewardStatus\x12\x1e\n" +
+	"\x1aSTEWARD_STATUS_UNSPECIFIED\x10\x00\x12\x1a\n" +
+	"\x16STEWARD_STATUS_HEALTHY\x10\x01\x12\x1b\n" +
+	"\x17STEWARD_STATUS_DEGRADED\x10\x02\x12\x18\n" +
+	"\x14STEWARD_STATUS_ERROR\x10\x03\x12\x1f\n" +
+	"\x1bSTEWARD_STATUS_DISCONNECTED\x10\x04B,Z*github.com/cfgis/cfgms/api/proto/transportb\x06proto3"
 
 var (
 	file_transport_control_proto_rawDescOnce sync.Once

--- a/api/proto/transport/control.proto
+++ b/api/proto/transport/control.proto
@@ -18,7 +18,7 @@ enum CommandType {
   COMMAND_TYPE_SHUTDOWN = 5;
   COMMAND_TYPE_VALIDATE_CONFIG = 6;
   COMMAND_TYPE_RECONNECT = 7;
-  // COMMAND_TYPE_EXECUTE_SCRIPT = 8; -- stub for Issue #1669; proto regen deferred to later batch
+  COMMAND_TYPE_EXECUTE_SCRIPT = 8; // Issue #1669/#1992: controller dispatches a signed script execution to a steward
   COMMAND_TYPE_PUSH_SIGNING_CERT = 9; // Issue #1817: controller pushes current signing cert on every steward connect
   COMMAND_TYPE_PUSH_STEWARD_BINARY = 10; // Issue #1943: controller pushes a new steward binary for self-upgrade
 }

--- a/pkg/controlplane/providers/grpc/convert.go
+++ b/pkg/controlplane/providers/grpc/convert.go
@@ -30,6 +30,7 @@ var commandTypeToProto = map[types.CommandType]transportpb.CommandType{
 	types.CommandSyncConfig:        transportpb.CommandType_COMMAND_TYPE_SYNC_CONFIG,
 	types.CommandSyncDNA:           transportpb.CommandType_COMMAND_TYPE_SYNC_DNA,
 	types.CommandReconnect:         transportpb.CommandType_COMMAND_TYPE_RECONNECT,
+	types.CommandExecuteScript:     transportpb.CommandType_COMMAND_TYPE_EXECUTE_SCRIPT,
 	types.CommandPushSigningCert:   transportpb.CommandType_COMMAND_TYPE_PUSH_SIGNING_CERT,
 	types.CommandPushStewardBinary: transportpb.CommandType_COMMAND_TYPE_PUSH_STEWARD_BINARY,
 }
@@ -39,6 +40,7 @@ var protoToCommandType = map[transportpb.CommandType]types.CommandType{
 	transportpb.CommandType_COMMAND_TYPE_SYNC_CONFIG:         types.CommandSyncConfig,
 	transportpb.CommandType_COMMAND_TYPE_SYNC_DNA:            types.CommandSyncDNA,
 	transportpb.CommandType_COMMAND_TYPE_RECONNECT:           types.CommandReconnect,
+	transportpb.CommandType_COMMAND_TYPE_EXECUTE_SCRIPT:      types.CommandExecuteScript,
 	transportpb.CommandType_COMMAND_TYPE_PUSH_SIGNING_CERT:   types.CommandPushSigningCert,
 	transportpb.CommandType_COMMAND_TYPE_PUSH_STEWARD_BINARY: types.CommandPushStewardBinary,
 }

--- a/pkg/controlplane/providers/grpc/convert_test.go
+++ b/pkg/controlplane/providers/grpc/convert_test.go
@@ -4,10 +4,13 @@
 package grpc
 
 import (
+	"encoding/base64"
 	"testing"
 	"time"
 
 	transportpb "github.com/cfgis/cfgms/api/proto/transport"
+	"github.com/cfgis/cfgms/features/config/signature"
+	"github.com/cfgis/cfgms/pkg/cert"
 	"github.com/cfgis/cfgms/pkg/controlplane/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -94,6 +97,7 @@ func TestCommandTypeRoundTrip(t *testing.T) {
 		types.CommandSyncConfig,
 		types.CommandSyncDNA,
 		types.CommandReconnect,
+		types.CommandExecuteScript,
 		types.CommandPushSigningCert,
 		types.CommandPushStewardBinary,
 	}
@@ -107,6 +111,130 @@ func TestCommandTypeRoundTrip(t *testing.T) {
 			assert.Equal(t, ct, result)
 		})
 	}
+}
+
+// TestCommandTypeProtoDescriptorComplete verifies that the embedded proto file
+// descriptor (rawDesc) carries every CommandType enum value, so String(),
+// gRPC reflection, and protojson render the symbolic name rather than the bare
+// integer. Before the proto regen for Issue #1992, the hand-added values
+// (7/8/9/10) were present only as Go constants and name/value maps — the
+// descriptor blob still lacked them, so CommandType(8).String() rendered "8".
+func TestCommandTypeProtoDescriptorComplete(t *testing.T) {
+	cases := map[transportpb.CommandType]string{
+		transportpb.CommandType_COMMAND_TYPE_RECONNECT:           "COMMAND_TYPE_RECONNECT",
+		transportpb.CommandType_COMMAND_TYPE_EXECUTE_SCRIPT:      "COMMAND_TYPE_EXECUTE_SCRIPT",
+		transportpb.CommandType_COMMAND_TYPE_PUSH_SIGNING_CERT:   "COMMAND_TYPE_PUSH_SIGNING_CERT",
+		transportpb.CommandType_COMMAND_TYPE_PUSH_STEWARD_BINARY: "COMMAND_TYPE_PUSH_STEWARD_BINARY",
+	}
+	for ct, name := range cases {
+		t.Run(name, func(t *testing.T) {
+			// String() resolves through the descriptor; a missing descriptor value
+			// would yield the decimal number instead of the symbolic name.
+			assert.Equal(t, name, ct.String())
+			// The descriptor must expose the value by number.
+			vd := ct.Descriptor().Values().ByNumber(ct.Number())
+			require.NotNil(t, vd, "enum value %d missing from proto descriptor", ct)
+			assert.Equal(t, name, string(vd.Name()))
+		})
+	}
+}
+
+// newTestSigner returns a real Signer + Verifier pair backed by a fresh
+// in-process CA. No mocks — real cryptographic operations.
+func newTestSigner(t *testing.T) (signature.Signer, signature.Verifier) {
+	t.Helper()
+	ca, err := cert.NewCA(&cert.CAConfig{
+		Organization: "CFGMS Test",
+		Country:      "US",
+		ValidityDays: 1,
+		KeySize:      2048,
+	})
+	require.NoError(t, err)
+	require.NoError(t, ca.Initialize(nil))
+
+	sc, err := ca.GenerateServerCertificate(&cert.ServerCertConfig{
+		CommonName:   "controller.test",
+		DNSNames:     []string{"controller.test"},
+		ValidityDays: 1,
+		KeySize:      2048,
+	})
+	require.NoError(t, err)
+
+	signer, err := signature.NewSigner(&signature.SignerConfig{
+		PrivateKeyPEM:  sc.PrivateKeyPEM,
+		CertificatePEM: sc.CertificatePEM,
+	})
+	require.NoError(t, err)
+
+	verifier, err := signature.NewVerifier(&signature.VerifierConfig{
+		CertificatePEM: sc.CertificatePEM,
+	})
+	require.NoError(t, err)
+
+	return signer, verifier
+}
+
+// TestExecuteScriptSignedRoundTrip is the end-to-end regression for Issue #1992.
+//
+// The controller signs CommandSigningBytes over the execute_script command, the
+// signed command is serialised to the wire proto, then reconstructed on the steward
+// side. Before the fix, CommandExecuteScript was absent from both command-type
+// conversion maps, so the proto Type collapsed to COMMAND_TYPE_UNSPECIFIED and the
+// reconstructed Command.Type became "" — making the signing bytes (which include
+// Type) differ and the steward-side signature verification fail.
+//
+// This test proves byte-for-byte signing-payload equality across the wire and that
+// the real verifier accepts the reconstructed command.
+func TestExecuteScriptSignedRoundTrip(t *testing.T) {
+	signer, verifier := newTestSigner(t)
+
+	cmd := &types.Command{
+		ID:        "cmd-exec-1",
+		Type:      types.CommandExecuteScript,
+		StewardID: "steward-7",
+		TenantID:  "root/msp-a/client-1",
+		Timestamp: time.Now().Truncate(time.Microsecond),
+		Params: map[string]interface{}{
+			"script_content": base64.StdEncoding.EncodeToString([]byte("Write-Output 'hello'")),
+			"execution_id":   "exec-abc-123",
+			"shell":          "powershell",
+			"run_id":         "run-42",
+		},
+	}
+
+	// Controller side: sign the canonical bytes using the proto-wire-stable param map.
+	rawParams := types.InterfaceParamsToStringMap(cmd.Params)
+	signingBytes, err := types.CommandSigningBytes(cmd, rawParams)
+	require.NoError(t, err)
+	sig, err := signer.Sign(signingBytes)
+	require.NoError(t, err)
+
+	sc := &types.SignedCommand{Command: *cmd, Signature: sig}
+
+	// Serialise to the wire proto and reconstruct on the steward side.
+	pb := signedCommandToProto(sc)
+	require.NotNil(t, pb)
+	require.Equal(t, transportpb.CommandType_COMMAND_TYPE_EXECUTE_SCRIPT, pb.GetType(),
+		"execute_script must not collapse to UNSPECIFIED on the wire")
+
+	reconstructed := signedCommandFromProto(pb)
+	require.NotNil(t, reconstructed)
+	require.NotNil(t, reconstructed.Signature)
+
+	// The Type must survive the round-trip — this is the field whose collapse
+	// broke the signature in Issue #1992.
+	require.Equal(t, types.CommandExecuteScript, reconstructed.Command.Type)
+
+	// The signing bytes computed from the reconstructed command must equal the
+	// original signing bytes byte-for-byte.
+	reconstructedBytes, err := types.CommandSigningBytes(&reconstructed.Command, reconstructed.RawParams)
+	require.NoError(t, err)
+	assert.Equal(t, signingBytes, reconstructedBytes,
+		"signing payload must be identical across the wire")
+
+	// And the real verifier must accept the reconstructed command's signature.
+	require.NoError(t, verifier.Verify(reconstructedBytes, reconstructed.Signature),
+		"steward-side verification must succeed after the round-trip")
 }
 
 func TestEventRoundTrip(t *testing.T) {


### PR DESCRIPTION
## Summary

Fixes #1992. `cfg steward exec` dispatched but the steward rejected the `execute_script` command with `signature verification failed against all N certificate(s)`. Root cause: `CommandExecuteScript` was missing from the transport proto enum and both convert maps, so its `Type` collapsed to `COMMAND_TYPE_UNSPECIFIED` → `""` over the gRPC round-trip. Since `CommandSigningBytes` includes `Type`, the controller signed `type:"execute_script"` but the steward verified `type:""` → mismatch. The same omission also broke handler dispatch. `push_signing_cert` was unaffected because it *was* in the maps. Verified live on CFG-70-02.

## Change

- `control.proto`: define `COMMAND_TYPE_EXECUTE_SCRIPT = 8` (reserved slot, previously a commented stub).
- `control.pb.go`: **properly regenerated** with the repo's pinned toolchain (protoc v5.27.0 / protoc-gen-go v1.36.11 / protoc-gen-go-grpc v1.6.1, via a `golang:1.24` container matching `make proto-gen`). The regen also backfilled the previously-stale descriptor slots 7/9/10 (RECONNECT/PUSH_SIGNING_CERT/PUSH_STEWARD_BINARY), fixing a systemic `rawDesc` gap so `String()`/reflection/protojson resolve symbolic names.
- `convert.go`: add `CommandExecuteScript` to both `commandTypeToProto` and `protoToCommandType`.

## Tests

- `TestCommandTypeRoundTrip` now includes `execute_script`.
- `TestExecuteScriptSignedRoundTrip`: real CA + signer/verifier, proves byte-for-byte signing-payload equality and verifier acceptance across the proto round-trip (no mocks); negative control confirmed (fails without the fix).
- `TestCommandTypeProtoDescriptorComplete`: asserts `String()` + descriptor resolution for slots 7/8/9/10.
- Full `pkg/controlplane/...` + `features/steward/commands` suites pass; build/vet clean.

## Review

Adversarial team: acceptance ✅, security ✅ (signature path restored not weakened; slot 8 reserved/no collision; downstream steward authz intact), QA-code ✅ (after proper regen), test-runner ✅.

Follow-up (separate): `CommandRelayResponse` has the same missing-from-convert-maps gap — filed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)