### PR TITLE
exec: fix inline-content, shell taxonomy, failure-event handling, output capture (Issue #1995)

### DIFF
--- a/features/controller/api/handlers_runs.go
+++ b/features/controller/api/handlers_runs.go
@@ -43,11 +43,17 @@ var bannedPatterns = []struct {
 
 // allowedShells is the set of shells accepted by POST /api/v1/runs/command.
 // Any value outside this set is rejected with UNSUPPORTED_SHELL.
+// The set is kept in lockstep with the steward executor's accepted shells
+// (features/modules/script/executor.go). Valid taxonomy per platform:
+//   - Unix:    bash, sh
+//   - Windows: powershell (Windows PowerShell 5.1), pwsh (PowerShell Core), cmd
+//   - pwsh is also valid on Unix (PowerShell Core is cross-platform).
 var allowedShells = map[string]bool{
-	"bash": true,
-	"sh":   true,
-	"pwsh": true,
-	"cmd":  true,
+	"bash":       true,
+	"sh":         true,
+	"powershell": true,
+	"pwsh":       true,
+	"cmd":        true,
 }
 
 // containsBannedPattern returns the pattern name and true if s contains any
@@ -236,7 +242,7 @@ func (s *Server) handlePostRunCommand(w http.ResponseWriter, r *http.Request) {
 	}
 	if !allowedShells[req.Shell] {
 		s.writeErrorResponse(w, http.StatusBadRequest,
-			fmt.Sprintf("unsupported shell %q; allowed: bash, sh, pwsh, cmd", logging.SanitizeLogValue(req.Shell)),
+			fmt.Sprintf("unsupported shell %q; allowed: bash, sh, powershell, pwsh, cmd", logging.SanitizeLogValue(req.Shell)),
 			"UNSUPPORTED_SHELL")
 		return
 	}

--- a/features/controller/api/handlers_runs_test.go
+++ b/features/controller/api/handlers_runs_test.go
@@ -776,3 +776,24 @@ func TestRunEndpoints_ServiceUnavailable_WhenManagerNotWired(t *testing.T) {
 		})
 	}
 }
+
+// TestAllowedShellsMatchesExecutorTaxonomy pins the controller allow-list to the
+// steward executor's accepted shells so the two never drift (Issue #1995, root
+// cause B). The unified taxonomy is: bash/sh (Unix), powershell/pwsh/cmd (Windows),
+// with pwsh also valid on Unix.
+func TestAllowedShellsMatchesExecutorTaxonomy(t *testing.T) {
+	want := map[string]bool{
+		string(scriptmodule.ShellBash):       true,
+		string(scriptmodule.ShellSh):         true,
+		string(scriptmodule.ShellPowerShell): true,
+		string(scriptmodule.ShellPwsh):       true,
+		string(scriptmodule.ShellCmd):        true,
+	}
+
+	assert.Equal(t, want, allowedShells,
+		"controller allow-list must match the executor shell taxonomy")
+
+	// Specifically guard the two shells regressed in Issue #1995.
+	assert.True(t, allowedShells["powershell"], "Windows PowerShell 5.1 must be dispatchable")
+	assert.True(t, allowedShells["pwsh"], "PowerShell Core must be dispatchable")
+}

--- a/features/controller/dispatcher/dispatcher.go
+++ b/features/controller/dispatcher/dispatcher.go
@@ -74,6 +74,10 @@ type Dispatcher struct {
 // interface rather than importing the run package directly.
 type RunCompletionSink interface {
 	RecordJobCompletion(ctx context.Context, runID, jobID, executionID string, failed bool) error
+	// RecordJobResult records the terminal completion together with the captured
+	// execution result (stdout/stderr/exit code) so `cfg steward exec` can surface
+	// output (Issue #1995, root cause D).
+	RecordJobResult(ctx context.Context, runID, jobID, executionID string, failed bool, output, stderr string, exitCode int) error
 }
 
 // GrantManager creates and consumes per-execution relay grants (Issue #1675).
@@ -143,10 +147,17 @@ func (d *Dispatcher) SetGrantManager(gm GrantManager) {
 	d.grantManager = gm
 }
 
-// Start begins the polling loop and subscribes to EventScriptCompleted events.
+// Start begins the polling loop and subscribes to script terminal events.
+// It subscribes to both EventScriptCompleted (success/non-zero exit) and
+// EventCommandFailed (executor error before a result is produced) so a failed
+// execution still records a terminal completion and releases the device lock
+// (Issue #1995, root cause C).
 func (d *Dispatcher) Start(ctx context.Context) error {
 	filter := &controlplaneTypes.EventFilter{
-		EventTypes: []controlplaneTypes.EventType{controlplaneTypes.EventScriptCompleted},
+		EventTypes: []controlplaneTypes.EventType{
+			controlplaneTypes.EventScriptCompleted,
+			controlplaneTypes.EventCommandFailed,
+		},
 	}
 	if err := d.controlPlane.SubscribeEvents(ctx, filter, d.handleCompletionEvent); err != nil {
 		return fmt.Errorf("dispatcher: subscribe events: %w", err)
@@ -409,14 +420,22 @@ func (d *Dispatcher) sendCommand(ctx context.Context, deviceID string, exec *scr
 // execution_id field alone is never trusted, preventing a compromised steward
 // from acknowledging another device's execution.
 func (d *Dispatcher) handleCompletionEvent(ctx context.Context, event *controlplaneTypes.Event) error {
-	if event.Type != controlplaneTypes.EventScriptCompleted {
+	// Both terminal event types are handled here (Issue #1995, root cause C):
+	//   - EventScriptCompleted: the executor ran and produced a result.
+	//   - EventCommandFailed:   the executor failed before producing a result
+	//     (e.g. unsupported shell, temp-file error). Treated as a terminal FAILED
+	//     completion so the run advances and the device lock is released.
+	if event.Type != controlplaneTypes.EventScriptCompleted &&
+		event.Type != controlplaneTypes.EventCommandFailed {
 		return nil
 	}
+	commandFailed := event.Type == controlplaneTypes.EventCommandFailed
 
 	// StewardID is set by the control plane from the mTLS peer certificate.
 	deviceID := event.StewardID
 	if deviceID == "" {
-		d.logger.Warn("Received script_completed event with empty steward_id — ignoring")
+		d.logger.Warn("Received script terminal event with empty steward_id — ignoring",
+			"event_type", string(event.Type))
 		return nil
 	}
 
@@ -425,14 +444,18 @@ func (d *Dispatcher) handleCompletionEvent(ctx context.Context, event *controlpl
 		executionID, _ = event.Details["execution_id"].(string)
 	}
 	if executionID == "" {
-		d.logger.Warn("Received script_completed event with no execution_id",
+		d.logger.Warn("Received script terminal event with no execution_id",
+			"event_type", string(event.Type),
 			"device_id", logging.SanitizeLogValue(deviceID))
 		return nil
 	}
 
-	// Determine completion state from exit code in event details.
+	// Determine completion state. A command_failed event is always terminal-failed.
+	// A script_completed event is failed only when the exit code is non-zero.
 	state := script.QueueStateCompleted
-	if event.Details != nil {
+	if commandFailed {
+		state = script.QueueStateFailed
+	} else if event.Details != nil {
 		if exitCode, ok := event.Details["exit_code"].(float64); ok && exitCode != 0 {
 			state = script.QueueStateFailed
 		}
@@ -444,11 +467,25 @@ func (d *Dispatcher) handleCompletionEvent(ctx context.Context, event *controlpl
 		if ec, ok := event.Details["exit_code"].(float64); ok {
 			result.ExitCode = int(ec)
 		}
-		if stdout, ok := event.Details["stdout"].(string); ok {
+		// The steward emits stdout_preview/stderr_preview (execute_script.go);
+		// accept the bare stdout/stderr keys too for forward compatibility
+		// (Issue #1995, root cause D — key alignment).
+		if stdout, ok := event.Details["stdout_preview"].(string); ok {
+			result.Stdout = stdout
+		} else if stdout, ok := event.Details["stdout"].(string); ok {
 			result.Stdout = stdout
 		}
-		if stderr, ok := event.Details["stderr"].(string); ok {
+		if stderr, ok := event.Details["stderr_preview"].(string); ok {
 			result.Stderr = stderr
+		} else if stderr, ok := event.Details["stderr"].(string); ok {
+			result.Stderr = stderr
+		}
+		// On a command_failed event there is no result; surface the error string
+		// as stderr so the CLI shows why the execution failed.
+		if commandFailed && result.Stderr == "" {
+			if errStr, ok := event.Details["error"].(string); ok {
+				result.Stderr = errStr
+			}
 		}
 		if durMs, ok := event.Details["duration_ms"].(float64); ok {
 			result.Duration = time.Duration(durMs) * time.Millisecond
@@ -477,69 +514,83 @@ func (d *Dispatcher) handleCompletionEvent(ctx context.Context, event *controlpl
 	// Determine whether to retry before acknowledging, so we hold the full QE.
 	shouldRetry := state == script.QueueStateFailed && isIdempotent && retryCount < 1
 
+	// AcknowledgeCompletion moves the queue entry out of the active set. A failure
+	// here (e.g. the entry was already evicted by a dispatch-timeout sweep) must NOT
+	// prevent run/job tracking from advancing — otherwise the job would be stuck
+	// pending forever even though the device lock is released, reproducing the very
+	// stall this handler exists to fix (Issue #1995, root cause B3). The run-sink
+	// update and grant consumption below therefore run regardless of ack success.
 	if err := d.queue.AcknowledgeCompletion(executionID, deviceID, state, result); err != nil {
-		d.logger.Error("Failed to acknowledge completion",
+		d.logger.Error("Failed to acknowledge completion; recording terminal outcome anyway",
 			"device_id", logging.SanitizeLogValue(deviceID),
 			"execution_id", executionID,
 			"error", err)
-		// Still release the lock to prevent permanent stall.
 	} else {
 		d.logger.Info("Script execution completed",
 			"device_id", logging.SanitizeLogValue(deviceID),
 			"execution_id", executionID,
 			"state", state)
+	}
 
-		if shouldRetry && origQE != nil {
-			// Re-queue the idempotent execution with an incremented retry count.
-			// The run/job tracking record is NOT advanced yet — it will be updated
-			// when the retry completes (success or second failure).
-			retryMeta := make(map[string]interface{}, len(origQE.Metadata))
-			for k, v := range origQE.Metadata {
-				retryMeta[k] = v
-			}
-			retryMeta["retry_count"] = retryCount + 1
-
-			retryQE := &script.QueuedExecution{
-				ExecutionID:   uuid.New().String(),
-				ScriptID:      origQE.ScriptID,
-				ScriptVersion: origQE.ScriptVersion,
-				ScriptRef:     origQE.ScriptRef,
-				Shell:         origQE.Shell,
-				Parameters:    origQE.Parameters,
-				Timeout:       origQE.Timeout,
-				Metadata:      retryMeta,
-			}
-			if err := d.queue.QueueExecution(deviceID, retryQE); err != nil {
-				d.logger.Error("Failed to re-queue idempotent execution after failure",
-					"device_id", logging.SanitizeLogValue(deviceID),
-					"execution_id", logging.SanitizeLogValue(retryQE.ExecutionID),
-					"error", err)
-			} else {
-				d.logger.Info("Re-queued idempotent execution after failure",
-					"device_id", logging.SanitizeLogValue(deviceID),
-					"execution_id", logging.SanitizeLogValue(retryQE.ExecutionID))
-			}
+	if shouldRetry && origQE != nil {
+		// Re-queue the idempotent execution with an incremented retry count.
+		// The run/job tracking record is NOT advanced yet — it will be updated
+		// when the retry completes (success or second failure).
+		retryMeta := make(map[string]interface{}, len(origQE.Metadata))
+		for k, v := range origQE.Metadata {
+			retryMeta[k] = v
 		}
+		retryMeta["retry_count"] = retryCount + 1
 
-		// Advance run/job tracking only when not retrying. On retry, the job
-		// remains in-progress until the retry execution reaches a terminal state.
-		if !shouldRetry && d.runSink != nil && runID != "" && jobID != "" {
-			if err := d.runSink.RecordJobCompletion(ctx, runID, jobID, executionID, state == script.QueueStateFailed); err != nil {
-				d.logger.Error("Failed to record job completion in run store",
-					"device_id", logging.SanitizeLogValue(deviceID),
-					"execution_id", logging.SanitizeLogValue(executionID),
-					"run_id", logging.SanitizeLogValue(runID),
-					"error", err)
-			}
+		retryQE := &script.QueuedExecution{
+			ExecutionID:   uuid.New().String(),
+			ScriptID:      origQE.ScriptID,
+			ScriptVersion: origQE.ScriptVersion,
+			ScriptRef:     origQE.ScriptRef,
+			Shell:         origQE.Shell,
+			Parameters:    origQE.Parameters,
+			Timeout:       origQE.Timeout,
+			Metadata:      retryMeta,
 		}
+		if err := d.queue.QueueExecution(deviceID, retryQE); err != nil {
+			d.logger.Error("Failed to re-queue idempotent execution after failure",
+				"device_id", logging.SanitizeLogValue(deviceID),
+				"execution_id", logging.SanitizeLogValue(retryQE.ExecutionID),
+				"error", err)
+		} else {
+			d.logger.Info("Re-queued idempotent execution after failure",
+				"device_id", logging.SanitizeLogValue(deviceID),
+				"execution_id", logging.SanitizeLogValue(retryQE.ExecutionID))
+		}
+	}
 
-		// Issue #1675: consume the relay grant on execution completion so further
-		// relay requests return 403. Best-effort — a failure must not stall dispatch.
-		if d.grantManager != nil {
-			if err := d.grantManager.ConsumeGrant(executionID); err != nil {
-				d.logger.Debug("ConsumeGrant: no grant for execution (inline or no API scope)",
-					"execution_id", logging.SanitizeLogValue(executionID))
-			}
+	// Advance run/job tracking only when not retrying. On retry, the job remains
+	// in-progress until the retry execution reaches a terminal state. This runs
+	// even when AcknowledgeCompletion failed so the job cannot be stuck pending.
+	if !shouldRetry && d.runSink != nil && runID != "" && jobID != "" {
+		var output, stderr string
+		var exitCode int
+		if result != nil {
+			output = result.Stdout
+			stderr = result.Stderr
+			exitCode = result.ExitCode
+		}
+		if err := d.runSink.RecordJobResult(ctx, runID, jobID, executionID,
+			state == script.QueueStateFailed, output, stderr, exitCode); err != nil {
+			d.logger.Error("Failed to record job completion in run store",
+				"device_id", logging.SanitizeLogValue(deviceID),
+				"execution_id", logging.SanitizeLogValue(executionID),
+				"run_id", logging.SanitizeLogValue(runID),
+				"error", err)
+		}
+	}
+
+	// Issue #1675: consume the relay grant on execution completion so further
+	// relay requests return 403. Best-effort — a failure must not stall dispatch.
+	if d.grantManager != nil {
+		if err := d.grantManager.ConsumeGrant(executionID); err != nil {
+			d.logger.Debug("ConsumeGrant: no grant for execution (inline or no API scope)",
+				"execution_id", logging.SanitizeLogValue(executionID))
 		}
 	}
 

--- a/features/controller/dispatcher/dispatcher_test.go
+++ b/features/controller/dispatcher/dispatcher_test.go
@@ -110,6 +110,56 @@ func (p *testControlPlane) injectCompletion(ctx context.Context, deviceID, execu
 	return h(ctx, event)
 }
 
+// injectCompletionWithOutput simulates a steward publishing EventScriptCompleted
+// with the stdout_preview/stderr_preview keys the steward actually emits
+// (execute_script.go), used to verify output capture (Issue #1995, root cause D).
+func (p *testControlPlane) injectCompletionWithOutput(ctx context.Context, deviceID, executionID string, exitCode int, stdout, stderr string) error {
+	p.mu.Lock()
+	h := p.eventHandler
+	p.mu.Unlock()
+
+	if h == nil {
+		return fmt.Errorf("no event handler registered")
+	}
+	event := &controlplaneTypes.Event{
+		ID:        "evt-" + executionID,
+		Type:      controlplaneTypes.EventScriptCompleted,
+		StewardID: deviceID,
+		Timestamp: time.Now(),
+		Details: map[string]interface{}{
+			"execution_id":   executionID,
+			"exit_code":      float64(exitCode),
+			"stdout_preview": stdout,
+			"stderr_preview": stderr,
+			"duration_ms":    float64(100),
+		},
+	}
+	return h(ctx, event)
+}
+
+// injectCommandFailed simulates a steward publishing EventCommandFailed, which it
+// emits when the executor fails before producing a result (execute_script.go).
+func (p *testControlPlane) injectCommandFailed(ctx context.Context, deviceID, executionID, errMsg string) error {
+	p.mu.Lock()
+	h := p.eventHandler
+	p.mu.Unlock()
+
+	if h == nil {
+		return fmt.Errorf("no event handler registered")
+	}
+	event := &controlplaneTypes.Event{
+		ID:        "evt-fail-" + executionID,
+		Type:      controlplaneTypes.EventCommandFailed,
+		StewardID: deviceID,
+		Timestamp: time.Now(),
+		Details: map[string]interface{}{
+			"execution_id": executionID,
+			"error":        errMsg,
+		},
+	}
+	return h(ctx, event)
+}
+
 // sentCount returns how many commands were recorded.
 func (p *testControlPlane) sentCount() int {
 	p.mu.Lock()
@@ -900,6 +950,252 @@ func TestDispatcher_NonIdempotentScript_FailureImmediatelyMarksJobFailed(t *test
 
 	// Confirm no re-queue occurred.
 	assert.Equal(t, 1, cp.sentCount(), "non-idempotent failure must not re-queue")
+}
+
+// TestDispatcher_CommandFailedMarksRunFailedAndReleasesLock verifies Issue #1995
+// root cause C: an EventCommandFailed (executor error before a result) is handled
+// as a terminal FAILED completion — the run transitions to failed AND the per-device
+// lock is released so a subsequent queued execution to the same device dispatches.
+func TestDispatcher_CommandFailedMarksRunFailedAndReleasesLock(t *testing.T) {
+	store := run.NewRunStoreSQL(mustOpenMemDB(t))
+	require.NoError(t, store.Init(context.Background()))
+	manager := run.NewManager(store, nil)
+
+	const runID = "run-cmdfail-1"
+	require.NoError(t, store.CreateRun(&run.RunRecord{
+		RunID: runID, TenantID: "tenant-abc", CreatedAt: time.Now().UTC(),
+		Status: run.RunStatusRunning, JobCount: 1,
+	}))
+	require.NoError(t, store.CreateJob(&run.JobRecord{
+		JobID: "job-cmdfail", RunID: runID, DeviceID: "device-1",
+		ExecutionID: "exec-cmdfail", Status: run.JobStatusPending, CreatedAt: time.Now().UTC(),
+	}))
+
+	// Second execution has its OWN real run + job so its completion path UPDATEs a
+	// real row — otherwise the lock-release-enables-next-dispatch claim would pass
+	// against phantom data (Issue #1995 review B4).
+	const runID2 = "run-cmdfail-2"
+	require.NoError(t, store.CreateRun(&run.RunRecord{
+		RunID: runID2, TenantID: "tenant-abc", CreatedAt: time.Now().UTC(),
+		Status: run.RunStatusRunning, JobCount: 1,
+	}))
+	require.NoError(t, store.CreateJob(&run.JobRecord{
+		JobID: "job-second", RunID: runID2, DeviceID: "device-1",
+		ExecutionID: "exec-second", Status: run.JobStatusPending, CreatedAt: time.Now().UTC(),
+	}))
+
+	cp := &testControlPlane{}
+	repo := newTestScriptRepo()
+	repo.addScript("script-cf-a", "#!/bin/bash\necho hi")
+	repo.addScript("script-cf-b", "#!/bin/bash\necho bye")
+	q := newTestQueue(t, repo)
+	d := newTestDispatcher(t, q, cp)
+	d.SetRunCompletionSink(manager)
+
+	require.NoError(t, d.Start(context.Background()))
+	t.Cleanup(d.Stop)
+
+	// Queue two distinct executions to the SAME device. Only the first can dispatch
+	// while the per-device lock is held; the second proves the lock was released.
+	require.NoError(t, q.QueueExecution("device-1", runTrackedExec("exec-cmdfail", "script-cf-a", runID, "job-cmdfail")))
+	require.NoError(t, q.QueueExecution("device-1", runTrackedExec("exec-second", "script-cf-b", runID2, "job-second")))
+
+	d.OnHeartbeat("device-1")
+	require.Eventually(t, func() bool { return cp.sentCount() >= 1 }, 2*time.Second, 10*time.Millisecond,
+		"first execution must dispatch")
+	// While the lock is held, the second execution must NOT have dispatched yet.
+	require.Equal(t, 1, cp.sentCount(), "second execution must wait for the device lock")
+
+	// Steward reports the executor failed before producing a result.
+	require.NoError(t, cp.injectCommandFailed(context.Background(), "device-1", "exec-cmdfail",
+		"unsupported shell on Windows: pwsh"))
+
+	// The run transitions to failed (not stuck 0/1).
+	require.Eventually(t, func() bool {
+		r, err := manager.GetRun(context.Background(), runID)
+		return err == nil && r.Status == run.RunStatusFailed && r.FailedJobs == 1
+	}, 2*time.Second, 10*time.Millisecond, "command_failed must drive the run to failed")
+
+	// The device lock was released → the second execution dispatches automatically.
+	require.Eventually(t, func() bool { return cp.sentCount() >= 2 }, 2*time.Second, 10*time.Millisecond,
+		"device lock must be released so the next execution dispatches")
+
+	// Complete the second execution and assert ITS run/job reaches a terminal state
+	// end-to-end — proving the lock release genuinely enabled the next dispatch.
+	require.NoError(t, cp.injectCompletion(context.Background(), "device-1", "exec-second", 0))
+	require.Eventually(t, func() bool {
+		r, err := manager.GetRun(context.Background(), runID2)
+		return err == nil && r.Status == run.RunStatusCompleted && r.CompletedJobs == 1
+	}, 2*time.Second, 10*time.Millisecond, "second run must reach completed after dispatch")
+
+	secondJobs, err := store.ListRunJobs(runID2)
+	require.NoError(t, err)
+	require.Len(t, secondJobs, 1)
+	assert.Equal(t, run.JobStatusCompleted, secondJobs[0].Status,
+		"second job must reach a terminal state (not stuck pending)")
+
+	// The failed job carries the error text as stderr for the CLI.
+	jobs, err := store.ListRunJobs(runID)
+	require.NoError(t, err)
+	require.Len(t, jobs, 1)
+	assert.Equal(t, run.JobStatusFailed, jobs[0].Status)
+	assert.Contains(t, jobs[0].Stderr, "unsupported shell",
+		"command_failed error text must be persisted as stderr")
+}
+
+// TestDispatcher_AcknowledgeFailureStillRecordsJob verifies Issue #1995 review B3:
+// when AcknowledgeCompletion fails, the run/job tracking must STILL advance to a
+// terminal state (not stuck pending) and the device lock must be released so the
+// next execution dispatches. A completion event for an execution that was never
+// dispatched (still in the queued state) makes the store's AcknowledgeCompletion
+// fail with "expected dispatched", while the metadata remains discoverable via
+// PeekForDevice — exactly the realistic stall this restructure guards against.
+func TestDispatcher_AcknowledgeFailureStillRecordsJob(t *testing.T) {
+	store := run.NewRunStoreSQL(mustOpenMemDB(t))
+	require.NoError(t, store.Init(context.Background()))
+	manager := run.NewManager(store, nil)
+
+	const runID = "run-ackfail-1"
+	require.NoError(t, store.CreateRun(&run.RunRecord{
+		RunID: runID, TenantID: "tenant-abc", CreatedAt: time.Now().UTC(),
+		Status: run.RunStatusRunning, JobCount: 1,
+	}))
+	require.NoError(t, store.CreateJob(&run.JobRecord{
+		JobID: "job-ackfail", RunID: runID, DeviceID: "device-1",
+		ExecutionID: "exec-ackfail", Status: run.JobStatusPending, CreatedAt: time.Now().UTC(),
+	}))
+
+	// Second run/job to prove the lock was released and the next dispatch proceeds.
+	const runID2 = "run-ackfail-2"
+	require.NoError(t, store.CreateRun(&run.RunRecord{
+		RunID: runID2, TenantID: "tenant-abc", CreatedAt: time.Now().UTC(),
+		Status: run.RunStatusRunning, JobCount: 1,
+	}))
+	require.NoError(t, store.CreateJob(&run.JobRecord{
+		JobID: "job-ackfail-next", RunID: runID2, DeviceID: "device-1",
+		ExecutionID: "exec-ackfail-next", Status: run.JobStatusPending, CreatedAt: time.Now().UTC(),
+	}))
+
+	cp := &testControlPlane{}
+	q := newTestQueue(t, nil)
+	d := newTestDispatcher(t, q, cp)
+	d.SetRunCompletionSink(manager)
+
+	require.NoError(t, d.Start(context.Background()))
+	t.Cleanup(d.Stop)
+
+	// Queue the execution but do NOT dispatch it (no OnHeartbeat) — it stays in the
+	// queued state, so AcknowledgeCompletion will reject the completion.
+	require.NoError(t, q.QueueExecution("device-1", runTrackedExec("exec-ackfail", "script-a", runID, "job-ackfail")))
+	require.Equal(t, 0, cp.sentCount(), "execution must not be dispatched yet")
+
+	// Inject completion → store.AcknowledgeCompletion fails (state != dispatched),
+	// but the job result must still be recorded.
+	require.NoError(t, cp.injectCompletion(context.Background(), "device-1", "exec-ackfail", 0))
+
+	require.Eventually(t, func() bool {
+		jobs, err := store.ListRunJobs(runID)
+		return err == nil && len(jobs) == 1 && jobs[0].Status.IsTerminal()
+	}, 2*time.Second, 10*time.Millisecond,
+		"job must reach a terminal state even when AcknowledgeCompletion fails (not stuck pending)")
+
+	jobs, err := store.ListRunJobs(runID)
+	require.NoError(t, err)
+	require.Len(t, jobs, 1)
+	assert.Equal(t, run.JobStatusCompleted, jobs[0].Status)
+
+	// Lock was released: a freshly queued + heartbeat-triggered execution dispatches.
+	require.NoError(t, q.QueueExecution("device-1", runTrackedExec("exec-ackfail-next", "script-b", runID2, "job-ackfail-next")))
+	d.OnHeartbeat("device-1")
+	require.Eventually(t, func() bool { return cp.sentCount() >= 1 }, 2*time.Second, 10*time.Millisecond,
+		"device lock must not be stuck after an AcknowledgeCompletion failure")
+}
+
+// TestDispatcher_ScriptCompletedSuccessPathStillWorks confirms the existing
+// EventScriptCompleted success path still records success and releases the lock
+// after adding EventCommandFailed handling (Issue #1995 regression guard).
+func TestDispatcher_ScriptCompletedSuccessPathStillWorks(t *testing.T) {
+	store := run.NewRunStoreSQL(mustOpenMemDB(t))
+	require.NoError(t, store.Init(context.Background()))
+	manager := run.NewManager(store, nil)
+
+	const runID = "run-success-1"
+	require.NoError(t, store.CreateRun(&run.RunRecord{
+		RunID: runID, TenantID: "tenant-abc", CreatedAt: time.Now().UTC(),
+		Status: run.RunStatusRunning, JobCount: 1,
+	}))
+	require.NoError(t, store.CreateJob(&run.JobRecord{
+		JobID: "job-ok", RunID: runID, DeviceID: "device-1",
+		ExecutionID: "exec-ok", Status: run.JobStatusPending, CreatedAt: time.Now().UTC(),
+	}))
+
+	cp := &testControlPlane{}
+	q := newTestQueue(t, nil)
+	d := newTestDispatcher(t, q, cp)
+	d.SetRunCompletionSink(manager)
+
+	require.NoError(t, d.Start(context.Background()))
+	t.Cleanup(d.Stop)
+
+	require.NoError(t, q.QueueExecution("device-1", runTrackedExec("exec-ok", "script-ok-a", runID, "job-ok")))
+	require.NoError(t, q.QueueExecution("device-1", runTrackedExec("exec-next", "script-ok-b", "run-next", "job-next")))
+
+	d.OnHeartbeat("device-1")
+	require.Eventually(t, func() bool { return cp.sentCount() >= 1 }, 2*time.Second, 10*time.Millisecond)
+
+	require.NoError(t, cp.injectCompletion(context.Background(), "device-1", "exec-ok", 0))
+	require.Eventually(t, func() bool {
+		r, err := manager.GetRun(context.Background(), runID)
+		return err == nil && r.Status == run.RunStatusCompleted && r.CompletedJobs == 1
+	}, 2*time.Second, 10*time.Millisecond, "successful completion must drive the run to completed")
+
+	// Lock released → next execution dispatches.
+	require.Eventually(t, func() bool { return cp.sentCount() >= 2 }, 2*time.Second, 10*time.Millisecond)
+}
+
+// TestDispatcher_OutputThreadedToJobRecord verifies Issue #1995 root cause D:
+// stdout/exit code from the steward's stdout_preview keys are persisted onto the
+// job record and surfaced via the run/job read path.
+func TestDispatcher_OutputThreadedToJobRecord(t *testing.T) {
+	store := run.NewRunStoreSQL(mustOpenMemDB(t))
+	require.NoError(t, store.Init(context.Background()))
+	manager := run.NewManager(store, nil)
+
+	const runID = "run-output-1"
+	require.NoError(t, store.CreateRun(&run.RunRecord{
+		RunID: runID, TenantID: "tenant-abc", CreatedAt: time.Now().UTC(),
+		Status: run.RunStatusRunning, JobCount: 1,
+	}))
+	require.NoError(t, store.CreateJob(&run.JobRecord{
+		JobID: "job-out", RunID: runID, DeviceID: "device-1",
+		ExecutionID: "exec-out", Status: run.JobStatusPending, CreatedAt: time.Now().UTC(),
+	}))
+
+	cp := &testControlPlane{}
+	q := newTestQueue(t, nil)
+	d := newTestDispatcher(t, q, cp)
+	d.SetRunCompletionSink(manager)
+
+	require.NoError(t, d.Start(context.Background()))
+	t.Cleanup(d.Stop)
+
+	require.NoError(t, q.QueueExecution("device-1", runTrackedExec("exec-out", "script-abc", runID, "job-out")))
+	d.OnHeartbeat("device-1")
+	require.Eventually(t, func() bool { return cp.sentCount() >= 1 }, 2*time.Second, 10*time.Millisecond)
+
+	require.NoError(t, cp.injectCompletionWithOutput(context.Background(), "device-1", "exec-out", 0,
+		"CFG-70-02\n", ""))
+
+	require.Eventually(t, func() bool {
+		jobs, err := manager.ListRunJobs(context.Background(), runID)
+		return err == nil && len(jobs) == 1 && jobs[0].Status == run.JobStatusCompleted
+	}, 2*time.Second, 10*time.Millisecond)
+
+	jobs, err := manager.ListRunJobs(context.Background(), runID)
+	require.NoError(t, err)
+	require.Len(t, jobs, 1)
+	assert.Equal(t, "CFG-70-02\n", jobs[0].Output, "stdout_preview must be persisted as Output")
+	assert.Equal(t, 0, jobs[0].ExitCode)
 }
 
 // mustOpenMemDB opens an in-memory SQLite database closed via t.Cleanup.

--- a/features/controller/run/run.go
+++ b/features/controller/run/run.go
@@ -85,6 +85,13 @@ type JobRecord struct {
 	Status      JobStatus  `json:"status"`
 	CreatedAt   time.Time  `json:"created_at"`
 	CompletedAt *time.Time `json:"completed_at,omitempty"`
+
+	// Captured execution result, persisted when the dispatcher records a terminal
+	// completion (Issue #1995, root cause D). Output is stdout; the CLI surfaces
+	// Output and ExitCode for `cfg steward exec`.
+	Output   string `json:"output,omitempty"`
+	Stderr   string `json:"stderr,omitempty"`
+	ExitCode int    `json:"exit_code,omitempty"`
 }
 
 // ExecutionGrant records a per-execution API access grant created at dispatch time.
@@ -106,6 +113,9 @@ type RunStore interface {
 	GetRun(runID string) (*RunRecord, error)
 	ListRunJobs(runID string) ([]*JobRecord, error)
 	UpdateJobStatus(jobID string, status JobStatus, executionID string) error
+	// UpdateJobResult sets the terminal status, executionID, and captured execution
+	// result (stdout/stderr/exit code) for a job (Issue #1995, root cause D).
+	UpdateJobResult(jobID string, status JobStatus, executionID, output, stderr string, exitCode int) error
 	UpdateRunStatus(runID string, status RunStatus) error
 	UpdateRunCounts(runID string, completedJobs, failedJobs int) error
 
@@ -181,7 +191,10 @@ CREATE TABLE IF NOT EXISTS script_run_jobs (
     execution_id  TEXT,
     status        TEXT NOT NULL,
     created_at    DATETIME NOT NULL,
-    completed_at  DATETIME
+    completed_at  DATETIME,
+    output        TEXT,
+    stderr        TEXT,
+    exit_code     INTEGER
 );`
 	const createJobsIndex = `
 CREATE INDEX IF NOT EXISTS idx_srj_run_id ON script_run_jobs(run_id);`
@@ -204,7 +217,74 @@ CREATE INDEX IF NOT EXISTS idx_eg_device ON execution_grants(device_id, executio
 			return fmt.Errorf("run store init: %w", err)
 		}
 	}
+
+	// Idempotent column migration for databases created before the output-capture
+	// columns existed (Issue #1995, root cause D). CREATE TABLE IF NOT EXISTS does
+	// not add columns to a pre-existing table. Detect which columns are already
+	// present via PRAGMA table_info and ADD only the missing ones — no reliance on
+	// driver-specific error-string matching, and no spurious error on fresh DBs.
+	if err := s.migrateJobColumns(); err != nil {
+		return fmt.Errorf("run store init: migrate jobs columns: %w", err)
+	}
 	return nil
+}
+
+// migrateJobColumns adds the output/stderr/exit_code columns to script_run_jobs
+// when they are missing. It inspects the live schema via PRAGMA table_info so it
+// is idempotent across repeated calls and across sqlite driver versions.
+func (s *RunStoreSQL) migrateJobColumns() error {
+	existing, err := s.jobColumns()
+	if err != nil {
+		return err
+	}
+
+	wanted := []struct {
+		name string
+		ddl  string
+	}{
+		{"output", "ALTER TABLE script_run_jobs ADD COLUMN output TEXT"},
+		{"stderr", "ALTER TABLE script_run_jobs ADD COLUMN stderr TEXT"},
+		{"exit_code", "ALTER TABLE script_run_jobs ADD COLUMN exit_code INTEGER"},
+	}
+	for _, c := range wanted {
+		if existing[c.name] {
+			continue
+		}
+		if _, err := s.db.Exec(c.ddl); err != nil {
+			return fmt.Errorf("add column %s: %w", c.name, err)
+		}
+	}
+	return nil
+}
+
+// jobColumns returns the set of column names currently defined on script_run_jobs.
+func (s *RunStoreSQL) jobColumns() (map[string]bool, error) {
+	rows, err := s.db.Query("PRAGMA table_info(script_run_jobs)")
+	if err != nil {
+		return nil, fmt.Errorf("inspect schema: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	cols := make(map[string]bool)
+	for rows.Next() {
+		// PRAGMA table_info columns: cid, name, type, notnull, dflt_value, pk.
+		var (
+			cid       int
+			name      string
+			ctype     string
+			notnull   int
+			dfltValue sql.NullString
+			pk        int
+		)
+		if err := rows.Scan(&cid, &name, &ctype, &notnull, &dfltValue, &pk); err != nil {
+			return nil, fmt.Errorf("scan schema row: %w", err)
+		}
+		cols[name] = true
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("read schema rows: %w", err)
+	}
+	return cols, nil
 }
 
 // CreateRun persists a new run record. RunID must be unique.
@@ -234,8 +314,8 @@ VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
 func (s *RunStoreSQL) CreateJob(j *JobRecord) error {
 	const q = `
 INSERT INTO script_run_jobs
-    (job_id, run_id, device_id, execution_id, status, created_at, completed_at)
-VALUES (?, ?, ?, ?, ?, ?, ?)`
+    (job_id, run_id, device_id, execution_id, status, created_at, completed_at, output, stderr, exit_code)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
 	var completedAt interface{}
 	if j.CompletedAt != nil {
 		completedAt = *j.CompletedAt
@@ -244,6 +324,7 @@ VALUES (?, ?, ?, ?, ?, ?, ?)`
 		j.JobID, j.RunID, j.DeviceID,
 		nullableStr(j.ExecutionID),
 		string(j.Status), j.CreatedAt, completedAt,
+		nullableStr(j.Output), nullableStr(j.Stderr), j.ExitCode,
 	)
 	return err
 }
@@ -290,7 +371,7 @@ WHERE run_id = ?`
 // ListRunJobs returns all job records for runID ordered by created_at ASC.
 func (s *RunStoreSQL) ListRunJobs(runID string) ([]*JobRecord, error) {
 	const q = `
-SELECT job_id, run_id, device_id, execution_id, status, created_at, completed_at
+SELECT job_id, run_id, device_id, execution_id, status, created_at, completed_at, output, stderr, exit_code
 FROM script_run_jobs
 WHERE run_id = ?
 ORDER BY created_at ASC`
@@ -306,9 +387,13 @@ ORDER BY created_at ASC`
 		j := &JobRecord{}
 		var executionID sql.NullString
 		var completedAt sql.NullTime
+		var output sql.NullString
+		var stderr sql.NullString
+		var exitCode sql.NullInt64
 		if err := rows.Scan(
 			&j.JobID, &j.RunID, &j.DeviceID, &executionID,
 			(*string)(&j.Status), &j.CreatedAt, &completedAt,
+			&output, &stderr, &exitCode,
 		); err != nil {
 			return nil, fmt.Errorf("run store scan job: %w", err)
 		}
@@ -317,6 +402,9 @@ ORDER BY created_at ASC`
 			t := completedAt.Time
 			j.CompletedAt = &t
 		}
+		j.Output = output.String
+		j.Stderr = stderr.String
+		j.ExitCode = int(exitCode.Int64)
 		jobs = append(jobs, j)
 	}
 	if err := rows.Err(); err != nil {
@@ -340,6 +428,28 @@ SET status       = ?,
     completed_at = COALESCE(?, completed_at)
 WHERE job_id = ?`
 	_, err := s.db.Exec(q, string(status), executionID, executionID, completedAt, jobID)
+	return err
+}
+
+// UpdateJobResult sets the terminal status, executionID, and captured execution
+// result (stdout/stderr/exit code) for a job (Issue #1995, root cause D).
+// When status is terminal, completed_at is set to the current UTC time.
+func (s *RunStoreSQL) UpdateJobResult(jobID string, status JobStatus, executionID, output, stderr string, exitCode int) error {
+	var completedAt interface{}
+	if status.IsTerminal() {
+		completedAt = time.Now().UTC()
+	}
+	const q = `
+UPDATE script_run_jobs
+SET status       = ?,
+    execution_id = CASE WHEN ? != '' THEN ? ELSE execution_id END,
+    completed_at = COALESCE(?, completed_at),
+    output       = ?,
+    stderr       = ?,
+    exit_code    = ?
+WHERE job_id = ?`
+	_, err := s.db.Exec(q, string(status), executionID, executionID, completedAt,
+		nullableStr(output), nullableStr(stderr), exitCode, jobID)
 	return err
 }
 
@@ -496,12 +606,19 @@ func (m *Manager) CancelRun(_ context.Context, runID string) error {
 // every job in the run is terminal the run transitions to completed, or to
 // failed if any job failed. A run that is already terminal (e.g. cancelled) is
 // left untouched so a late completion callback cannot resurrect it.
-func (m *Manager) RecordJobCompletion(_ context.Context, runID, jobID, executionID string, failed bool) error {
+func (m *Manager) RecordJobCompletion(ctx context.Context, runID, jobID, executionID string, failed bool) error {
+	return m.RecordJobResult(ctx, runID, jobID, executionID, failed, "", "", 0)
+}
+
+// RecordJobResult is RecordJobCompletion with the captured execution result
+// (stdout/stderr/exit code) persisted onto the job record (Issue #1995, root
+// cause D). The dispatcher calls this so `cfg steward exec` can surface output.
+func (m *Manager) RecordJobResult(_ context.Context, runID, jobID, executionID string, failed bool, output, stderr string, exitCode int) error {
 	jobStatus := JobStatusCompleted
 	if failed {
 		jobStatus = JobStatusFailed
 	}
-	if err := m.store.UpdateJobStatus(jobID, jobStatus, executionID); err != nil {
+	if err := m.store.UpdateJobResult(jobID, jobStatus, executionID, output, stderr, exitCode); err != nil {
 		return fmt.Errorf("record job completion: update job %s: %w", jobID, err)
 	}
 

--- a/features/controller/run/run_test.go
+++ b/features/controller/run/run_test.go
@@ -603,3 +603,94 @@ func TestManager_Close_NonClosableStore(t *testing.T) {
 	manager := NewManager(closerlessStore{}, nil)
 	require.NoError(t, manager.Close(), "Manager.Close must be a no-op for non-closable store")
 }
+
+// TestRunStore_Init_FreshDB_HasOutputColumns verifies Init on a fresh database
+// creates the output/stderr/exit_code columns (via CREATE TABLE) and that Init is
+// idempotent across repeated calls (Issue #1995 review B2).
+func TestRunStore_Init_FreshDB_HasOutputColumns(t *testing.T) {
+	db, err := sql.Open("sqlite", ":memory:")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+
+	store := NewRunStoreSQL(db)
+	require.NoError(t, store.Init(context.Background()), "Init on fresh DB must succeed")
+	// Idempotent: a second Init must not error.
+	require.NoError(t, store.Init(context.Background()), "repeated Init must be idempotent")
+
+	cols, err := store.jobColumns()
+	require.NoError(t, err)
+	assert.True(t, cols["output"], "fresh DB must have output column")
+	assert.True(t, cols["stderr"], "fresh DB must have stderr column")
+	assert.True(t, cols["exit_code"], "fresh DB must have exit_code column")
+}
+
+// TestRunStore_Init_OldSchema_MigratesColumns verifies that Init adds the
+// output/stderr/exit_code columns to a pre-existing jobs table that lacks them
+// (the upgrade-from-old-deployment case), and is idempotent across repeated calls
+// (Issue #1995 review B2).
+func TestRunStore_Init_OldSchema_MigratesColumns(t *testing.T) {
+	db, err := sql.Open("sqlite", ":memory:")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+
+	// Create the pre-#1995 jobs table (no output/stderr/exit_code columns).
+	const oldJobs = `
+CREATE TABLE script_run_jobs (
+    job_id        TEXT NOT NULL PRIMARY KEY,
+    run_id        TEXT NOT NULL,
+    device_id     TEXT NOT NULL,
+    execution_id  TEXT,
+    status        TEXT NOT NULL,
+    created_at    DATETIME NOT NULL,
+    completed_at  DATETIME
+);`
+	_, err = db.Exec(oldJobs)
+	require.NoError(t, err)
+
+	store := NewRunStoreSQL(db)
+
+	before, err := store.jobColumns()
+	require.NoError(t, err)
+	require.False(t, before["output"], "precondition: old schema must lack output column")
+
+	require.NoError(t, store.Init(context.Background()), "Init must migrate old schema")
+
+	after, err := store.jobColumns()
+	require.NoError(t, err)
+	assert.True(t, after["output"], "migration must add output column")
+	assert.True(t, after["stderr"], "migration must add stderr column")
+	assert.True(t, after["exit_code"], "migration must add exit_code column")
+
+	// Idempotent: running Init again on the now-migrated DB must not error or re-add.
+	require.NoError(t, store.Init(context.Background()), "repeated Init must be idempotent after migration")
+
+	// The migrated columns must be usable end-to-end.
+	require.NoError(t, store.CreateRun(sampleRun("run-mig", "tenant-mig")))
+	require.NoError(t, store.CreateJob(&JobRecord{
+		JobID: "job-mig", RunID: "run-mig", DeviceID: "dev-mig",
+		Status: JobStatusPending, CreatedAt: time.Now().UTC(),
+	}))
+	require.NoError(t, store.UpdateJobResult("job-mig", JobStatusCompleted, "exec-mig", "hello\n", "", 0))
+
+	jobs, err := store.ListRunJobs("run-mig")
+	require.NoError(t, err)
+	require.Len(t, jobs, 1)
+	assert.Equal(t, "hello\n", jobs[0].Output)
+	assert.Equal(t, 0, jobs[0].ExitCode)
+}
+
+// TestRunStore_Init_AlreadyMigrated_NoOp verifies that Init on a DB that already
+// has the columns (current-schema fresh DB re-opened) is a no-op and idempotent
+// (Issue #1995 review B2 — must not rely on error-string matching).
+func TestRunStore_Init_AlreadyMigrated_NoOp(t *testing.T) {
+	db, err := sql.Open("sqlite", ":memory:")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+
+	store := NewRunStoreSQL(db)
+	require.NoError(t, store.Init(context.Background()))
+
+	// migrateJobColumns called directly must be a clean no-op when columns exist.
+	require.NoError(t, store.migrateJobColumns(), "migrate must be a no-op when columns already exist")
+	require.NoError(t, store.migrateJobColumns(), "migrate must remain idempotent")
+}

--- a/features/modules/script/config.go
+++ b/features/modules/script/config.go
@@ -227,9 +227,12 @@ func (c *ScriptConfig) GetManagedFields() []string {
 func (c *ScriptConfig) isShellSupported() bool {
 	switch runtime.GOOS {
 	case "windows":
-		return c.Shell == ShellPowerShell || c.Shell == ShellCmd || c.Shell == ShellPython || c.Shell == ShellPython3
+		// pwsh (PowerShell Core) is cross-platform and valid on Windows alongside
+		// Windows PowerShell 5.1 (powershell).
+		return c.Shell == ShellPowerShell || c.Shell == ShellPwsh || c.Shell == ShellCmd || c.Shell == ShellPython || c.Shell == ShellPython3
 	case "linux", "darwin":
-		return c.Shell == ShellBash || c.Shell == ShellZsh || c.Shell == ShellSh || c.Shell == ShellPython || c.Shell == ShellPython3
+		// pwsh (PowerShell Core) is cross-platform and valid on Unix.
+		return c.Shell == ShellBash || c.Shell == ShellZsh || c.Shell == ShellSh || c.Shell == ShellPwsh || c.Shell == ShellPython || c.Shell == ShellPython3
 	default:
 		return false
 	}

--- a/features/modules/script/execution_queue.go
+++ b/features/modules/script/execution_queue.go
@@ -308,14 +308,24 @@ func (q *ExecutionQueue) PrepareExecutionForDevice(ctx context.Context, deviceID
 	var resolvedContent string
 	var resolvedVersion string
 
-	if q.scriptRepo != nil && scriptRef != "" {
-		pinVersion := execution.ScriptVersion // empty = resolve latest
-		script, err := q.scriptRepo.Get(scriptRef, pinVersion)
-		if err != nil {
-			return nil, fmt.Errorf("failed to resolve script %q from repository: %w", scriptRef, err)
+	if scriptRef != "" {
+		// Library script: resolve the latest (or pinned) content from the repository.
+		if q.scriptRepo != nil {
+			pinVersion := execution.ScriptVersion // empty = resolve latest
+			script, err := q.scriptRepo.Get(scriptRef, pinVersion)
+			if err != nil {
+				return nil, fmt.Errorf("failed to resolve script %q from repository: %w", scriptRef, err)
+			}
+			resolvedContent = script.Content
+			resolvedVersion = script.Metadata.Version.String()
 		}
-		resolvedContent = script.Content
-		resolvedVersion = script.Metadata.Version.String()
+	} else if execution.Metadata != nil {
+		// Inline (ad-hoc) execution: SynthesizeCommandRun threads the literal script
+		// body through Metadata["inline_script_content"] because there is no scriptRef
+		// to look up in the repository (Issue #1995, root cause A).
+		if inline, ok := execution.Metadata["inline_script_content"].(string); ok {
+			resolvedContent = inline
+		}
 	}
 
 	prepared := &PreparedExecution{

--- a/features/modules/script/execution_queue_test.go
+++ b/features/modules/script/execution_queue_test.go
@@ -951,3 +951,69 @@ func TestCancelTerminalStateEntry(t *testing.T) {
 	err = queue.CancelExecution("device-001", "exec-001")
 	assert.Error(t, err, "cancelling a completed entry must return an error")
 }
+
+// TestPrepareExecutionForDevice_InlineContentFromMetadata verifies Issue #1995
+// root cause A: an ad-hoc (inline) execution carries no ScriptRef/ScriptID, so
+// PrepareExecutionForDevice must resolve the literal script body from
+// Metadata["inline_script_content"] rather than leaving ScriptContent empty.
+func TestPrepareExecutionForDevice_InlineContentFromMetadata(t *testing.T) {
+	monitor := NewExecutionMonitor()
+	keyManager := NewEphemeralKeyManager()
+	defer keyManager.Stop()
+
+	// A repo is wired but must NOT be consulted for inline runs (no scriptRef).
+	repo := newTestScriptRepo()
+	queue := NewExecutionQueue(monitor, keyManager, 1*time.Hour, "https://localhost:8080", nil, repo, 0)
+	defer queue.Stop()
+
+	const inlineBody = "Write-Output 'hello from inline'"
+	execution := &QueuedExecution{
+		ExecutionID: "exec-inline-1",
+		Shell:       ShellPwsh,
+		Timeout:     5 * time.Minute,
+		Metadata: map[string]interface{}{
+			"inline_script_content": inlineBody,
+		},
+	}
+	require.NoError(t, queue.QueueExecution("device-001", execution))
+
+	dequeued, err := queue.DequeueForDevice("device-001")
+	require.NoError(t, err)
+	require.Len(t, dequeued, 1)
+
+	prepared, err := queue.PrepareExecutionForDevice(context.Background(), "device-001", "tenant-001", dequeued[0])
+	require.NoError(t, err)
+	assert.Equal(t, inlineBody, prepared.ScriptContent,
+		"inline content must be resolved from Metadata when scriptRef is empty")
+	assert.Empty(t, prepared.ScriptVersion, "inline content has no repository version")
+}
+
+// TestPrepareExecutionForDevice_LibraryScriptUnchanged verifies that the library
+// (scriptRef != "") path still resolves content from the repository and is NOT
+// affected by the inline fallback (Issue #1995 regression guard).
+func TestPrepareExecutionForDevice_LibraryScriptUnchanged(t *testing.T) {
+	monitor := NewExecutionMonitor()
+	keyManager := NewEphemeralKeyManager()
+	defer keyManager.Stop()
+
+	repo := newTestScriptRepo()
+	repo.scripts["script-lib"] = testScript("script-lib", "echo from-repo")
+	queue := NewExecutionQueue(monitor, keyManager, 1*time.Hour, "https://localhost:8080", nil, repo, 0)
+	defer queue.Stop()
+
+	// A library execution that ALSO has stray inline metadata must prefer the repo.
+	execution := newQueuedExec("exec-lib-1", "script-lib")
+	execution.Metadata = map[string]interface{}{
+		"inline_script_content": "echo SHOULD-NOT-BE-USED",
+	}
+	require.NoError(t, queue.QueueExecution("device-002", execution))
+
+	dequeued, err := queue.DequeueForDevice("device-002")
+	require.NoError(t, err)
+	require.Len(t, dequeued, 1)
+
+	prepared, err := queue.PrepareExecutionForDevice(context.Background(), "device-002", "tenant-001", dequeued[0])
+	require.NoError(t, err)
+	assert.Equal(t, "echo from-repo", prepared.ScriptContent,
+		"library script must resolve from the repository, ignoring inline metadata")
+}

--- a/features/modules/script/executor.go
+++ b/features/modules/script/executor.go
@@ -250,6 +250,16 @@ func (e *Executor) buildWindowsCommand(ctx context.Context) (*exec.Cmd, func(), 
 		// #nosec G204 - tmpPath is a temp file created by this process; not user input
 		return exec.CommandContext(ctx, "powershell.exe", "-NonInteractive", "-File", tmpPath), cleanup, nil
 
+	case ShellPwsh:
+		tmpPath, cleanup, err := writeTempScript("cfgms-script-*.ps1", e.config.Content)
+		if err != nil {
+			return nil, noop, err
+		}
+		// PowerShell Core (pwsh.exe). Same temp-script / -File pattern as Windows
+		// PowerShell — no -Command string, no inline composition (CLAUDE.md banned patterns).
+		// #nosec G204 - tmpPath is a temp file created by this process; not user input
+		return exec.CommandContext(ctx, "pwsh.exe", "-NonInteractive", "-File", tmpPath), cleanup, nil
+
 	case ShellCmd:
 		tmpPath, cleanup, err := writeTempScript("cfgms-script-*.cmd", e.config.Content)
 		if err != nil {
@@ -324,6 +334,18 @@ func (e *Executor) buildUnixCommand(ctx context.Context) (*exec.Cmd, func(), err
 		// #nosec G204 - tmpPath is a temp file created by this process; not user input
 		return exec.CommandContext(ctx, "/bin/sh", tmpPath), cleanup, nil
 
+	case ShellPwsh:
+		// PowerShell Core (pwsh) is cross-platform. Same safe temp-script / -File
+		// pattern as on Windows — no -Command string, no inline composition
+		// (CLAUDE.md banned patterns). Resolved via PATH since the install location
+		// varies across distributions.
+		tmpPath, cleanup, err := writeTempScript("cfgms-script-*.ps1", e.config.Content)
+		if err != nil {
+			return nil, noop, err
+		}
+		// #nosec G204 - tmpPath is a temp file created by this process; not user input
+		return exec.CommandContext(ctx, "pwsh", "-NonInteractive", "-File", tmpPath), cleanup, nil
+
 	case ShellPython:
 		tmpPath, cleanup, err := writeTempScript("cfgms-script-*", e.config.Content)
 		if err != nil {
@@ -364,6 +386,10 @@ func (e *Executor) validateWindowsShell() error {
 		if _, err := exec.LookPath("powershell.exe"); err != nil {
 			return fmt.Errorf("PowerShell is not available: %w", err)
 		}
+	case ShellPwsh:
+		if _, err := exec.LookPath("pwsh.exe"); err != nil {
+			return fmt.Errorf("PowerShell Core (pwsh) is not available: %w", err)
+		}
 	case ShellCmd:
 		if _, err := exec.LookPath("cmd.exe"); err != nil {
 			return fmt.Errorf("command prompt is not available: %w", err)
@@ -393,6 +419,12 @@ func (e *Executor) validateUnixShell() error {
 		shellPath = "/bin/zsh"
 	case ShellSh:
 		shellPath = "/bin/sh"
+	case ShellPwsh:
+		// PowerShell Core has no canonical install path on Unix; resolve via PATH.
+		if _, err := exec.LookPath("pwsh"); err != nil {
+			return fmt.Errorf("PowerShell Core (pwsh) is not available: %w", err)
+		}
+		return nil
 	case ShellPython:
 		shellPath = "/usr/bin/python"
 	case ShellPython3:

--- a/features/modules/script/executor_windows_command_test.go
+++ b/features/modules/script/executor_windows_command_test.go
@@ -1,0 +1,165 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+
+package script
+
+// This file is intentionally cross-platform (no _windows suffix): buildWindowsCommand
+// lives in executor.go and compiles on every platform (buildCmdExeCommand has a Unix
+// stub). The table-driven coverage here guarantees the steward executor's accepted
+// Windows shell taxonomy matches the controller allow-list (Issue #1995, root cause B).
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestBuildWindowsCommand_ShellTaxonomy verifies that the Windows executor accepts
+// powershell, pwsh, and cmd (and python/python3), and rejects unknown shells with
+// an "unsupported shell" error. This is the steward side of the unified taxonomy;
+// TestAllowedShellsMatchesExecutor (handlers_runs_test.go) pins the controller side.
+func TestBuildWindowsCommand_ShellTaxonomy(t *testing.T) {
+	tests := []struct {
+		name        string
+		shell       ShellType
+		wantErr     bool
+		wantExeHint string // substring expected in cmd.Path/Args[0] for accepted shells
+	}{
+		{name: "windows powershell 5.1", shell: ShellPowerShell, wantErr: false, wantExeHint: "powershell"},
+		{name: "powershell core pwsh", shell: ShellPwsh, wantErr: false, wantExeHint: "pwsh"},
+		{name: "cmd", shell: ShellCmd, wantErr: false},
+		{name: "python", shell: ShellPython, wantErr: false, wantExeHint: "python"},
+		{name: "python3", shell: ShellPython3, wantErr: false, wantExeHint: "python3"},
+		{name: "unknown shell rejected", shell: ShellType("nushell"), wantErr: true},
+		{name: "unix bash rejected on windows path", shell: ShellBash, wantErr: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			e := &Executor{config: &ScriptConfig{
+				Content: "echo hi",
+				Shell:   tc.shell,
+				Timeout: 5 * time.Second,
+			}}
+
+			cmd, cleanup, err := e.buildWindowsCommand(context.Background())
+			if cleanup != nil {
+				defer cleanup()
+			}
+
+			if tc.wantErr {
+				require.Error(t, err, "shell %q must be rejected by the Windows executor", tc.shell)
+				assert.Contains(t, err.Error(), "unsupported shell",
+					"rejection must be an unsupported-shell error")
+				return
+			}
+
+			require.NoError(t, err, "shell %q must be accepted by the Windows executor", tc.shell)
+
+			// The cmd case routes through buildCmdExeCommand, which is a no-op stub on
+			// Unix (returns nil). Skip the exe-name assertion for that case off-Windows.
+			if tc.wantExeHint == "" {
+				return
+			}
+			require.NotNil(t, cmd, "accepted shell %q must produce a command", tc.shell)
+			joined := strings.ToLower(cmd.Path + " " + strings.Join(cmd.Args, " "))
+			assert.Contains(t, joined, tc.wantExeHint,
+				"command for shell %q must invoke the %q interpreter", tc.shell, tc.wantExeHint)
+
+			// CLAUDE.md banned-pattern guard: PowerShell variants must execute by
+			// file (-File), never via -Command or an inline string.
+			if tc.shell == ShellPowerShell || tc.shell == ShellPwsh {
+				assert.Contains(t, cmd.Args, "-File",
+					"PowerShell shells must execute a temp script with -File, not -Command")
+				assert.NotContains(t, joined, "-command",
+					"PowerShell shells must not use -Command (inline composition is banned)")
+			}
+		})
+	}
+}
+
+// controllerAllowedShells mirrors the controller's allowedShells map
+// (features/controller/api/handlers_runs.go). The api-package test
+// TestAllowedShellsMatchesExecutorTaxonomy pins that map to the ShellType
+// constants; this list pins the EXECUTOR side so neither can drift away from the
+// other (Issue #1995, root cause B — pwsh added in some sites but not others).
+var controllerAllowedShells = []ShellType{
+	ShellBash, ShellSh, ShellPowerShell, ShellPwsh, ShellCmd,
+}
+
+// TestExecutorHandlesEveryControllerAllowedShell asserts that every shell the
+// controller will dispatch is handled by the steward executor's build AND validate
+// paths on the platform(s) where it is valid — never falling through to the
+// "unsupported shell" default.
+func TestExecutorHandlesEveryControllerAllowedShell(t *testing.T) {
+	// Platform applicability for each controller-allowed shell.
+	windowsShells := map[ShellType]bool{
+		ShellPowerShell: true, ShellPwsh: true, ShellCmd: true,
+	}
+	unixShells := map[ShellType]bool{
+		ShellBash: true, ShellSh: true, ShellPwsh: true,
+	}
+
+	for _, sh := range controllerAllowedShells {
+		sh := sh
+		t.Run(string(sh), func(t *testing.T) {
+			require.True(t, windowsShells[sh] || unixShells[sh],
+				"controller-allowed shell %q must be valid on at least one platform", sh)
+
+			e := &Executor{config: &ScriptConfig{Content: "echo hi", Shell: sh, Timeout: 5 * time.Second}}
+
+			if windowsShells[sh] {
+				_, cleanup, err := e.buildWindowsCommand(context.Background())
+				if cleanup != nil {
+					cleanup()
+				}
+				require.NoError(t, err, "Windows executor must handle controller-allowed shell %q", sh)
+			}
+			if unixShells[sh] {
+				cmd, cleanup, err := e.buildUnixCommand(context.Background())
+				if cleanup != nil {
+					cleanup()
+				}
+				require.NoError(t, err, "Unix executor must handle controller-allowed shell %q", sh)
+				require.NotNil(t, cmd)
+			}
+		})
+	}
+}
+
+// TestValidateWindowsShell_AcceptsPwsh pins that validateWindowsShell handles pwsh
+// (it previously fell through to the unsupported-shell default, inconsistent with
+// buildWindowsCommand — Issue #1995 review B1). pwsh.exe is unlikely to be present
+// on CI, so we assert the rejection is an availability error, never the
+// unsupported-shell taxonomy error.
+func TestValidateWindowsShell_AcceptsPwsh(t *testing.T) {
+	e := &Executor{config: &ScriptConfig{Content: "echo hi", Shell: ShellPwsh, Timeout: 5 * time.Second}}
+	err := e.validateWindowsShell()
+	if err != nil {
+		assert.NotContains(t, err.Error(), "unsupported shell on Windows",
+			"pwsh must be a recognized Windows shell (availability error is acceptable, taxonomy rejection is not)")
+		assert.Contains(t, err.Error(), "pwsh",
+			"a pwsh validation failure must reference pwsh availability")
+	}
+}
+
+// TestIsShellSupported_PwshCrossPlatform verifies pwsh is accepted by config
+// validation on the current platform (Windows and Unix), since PowerShell Core is
+// cross-platform (Issue #1995 review B1).
+func TestIsShellSupported_PwshCrossPlatform(t *testing.T) {
+	c := &ScriptConfig{Shell: ShellPwsh}
+	assert.True(t, c.isShellSupported(),
+		"pwsh (PowerShell Core) must be supported on the current platform")
+}
+
+// TestIsPowerShellScript_IncludesPwsh verifies the signing path treats pwsh as a
+// PowerShell variant (Issue #1995 review B1).
+func TestIsPowerShellScript_IncludesPwsh(t *testing.T) {
+	assert.True(t, isPowerShellScript(ShellPwsh), "pwsh must be treated as a PowerShell variant")
+	assert.True(t, isPowerShellScript(ShellPowerShell), "powershell must be treated as a PowerShell variant")
+	assert.False(t, isPowerShellScript(ShellBash), "bash is not a PowerShell variant")
+}

--- a/features/modules/script/signing.go
+++ b/features/modules/script/signing.go
@@ -68,9 +68,10 @@ type ModuleSigningConfig struct {
 // signature verification. This avoids a build-tag split on the shared dispatch function.
 var windowsAuthenticodeVerifier func(content []byte, sig *ScriptSignature, cfg ModuleSigningConfig) error
 
-// isPowerShellScript reports whether the shell type is a PowerShell variant.
+// isPowerShellScript reports whether the shell type is a PowerShell variant
+// (Windows PowerShell 5.1 or PowerShell Core).
 func isPowerShellScript(shell ShellType) bool {
-	return shell == ShellPowerShell
+	return shell == ShellPowerShell || shell == ShellPwsh
 }
 
 // verifyScriptSignature selects the appropriate verification method based on platform,

--- a/features/modules/script/types.go
+++ b/features/modules/script/types.go
@@ -25,7 +25,8 @@ type ShellType string
 
 const (
 	// Windows shells
-	ShellPowerShell ShellType = "powershell"
+	ShellPowerShell ShellType = "powershell" // Windows PowerShell 5.1 (powershell.exe)
+	ShellPwsh       ShellType = "pwsh"        // PowerShell Core / cross-platform (pwsh.exe)
 	ShellCmd        ShellType = "cmd"
 
 	// Unix shells


### PR DESCRIPTION
## Summary

Fixes #1995. With #1992 deployed, `cfg steward exec` reached the steward but didn't execute or return output. Four independent root causes in the ad-hoc run path, all fixed:

- **A — empty content**: `PrepareExecutionForDevice` now resolves inline content from `Metadata["inline_script_content"]` when there's no scriptRef (was only repo-keyed → inline ran 0 bytes).
- **B — shell taxonomy**: unified controller allow-list ↔ steward executor. Added `pwsh` (cross-platform, `-File`/temp-script, no `-Command`) to the executor (Windows+Unix build+validate), `config.isShellSupported`, `signing.isPowerShellScript`; added `powershell` to the controller allow-list. A bidirectional consistency test prevents future drift.
- **C — failure events**: dispatcher now subscribes to + handles `EventCommandFailed` (records job failed + releases the device lock); previously failures left the run stuck 0/1 and leaked the per-device lock.
- **D — output capture**: `JobRecord` gains `Output`/`Stderr`/`ExitCode`, threaded from the parsed result on both success/failure paths, with key alignment (`stdout_preview`/`stderr_preview`). PRAGMA-based idempotent migration for the new columns.

## Review

Adversarial team after one fix cycle: acceptance ✅, security ✅ (banned-pattern compliant `-File` exec, output bounded at 4KB previews, no execution_id spoofing), QA-code ✅, tests green. (Pre-existing Windows-only `go vet` unsafe.Pointer finding in executor_windows.go left out of scope.)

## Tests

Inline-content resolution; dispatcher EventCommandFailed (completion + lock release) + AcknowledgeCompletion-error path + output threading; PRAGMA migration idempotency (fresh/old/already-migrated); shell-taxonomy consistency (controller↔executor, pwsh validate/support/signing). Real components, no mocks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)