### PR TITLE
controlplane: add script_completed (+ wire-crossing events) to proto enum + convert maps (Issue #1997)

### DIFF
--- a/api/proto/transport/control.pb.go
+++ b/api/proto/transport/control.pb.go
@@ -112,31 +112,54 @@ const (
 	EventType_EVENT_TYPE_COMMAND_RECEIVED  EventType = 6 // Issue #1948: steward acknowledges a dispatched command
 	EventType_EVENT_TYPE_COMMAND_COMPLETED EventType = 7 // Issue #1948: command handler succeeded (drives upgrade commit)
 	EventType_EVENT_TYPE_COMMAND_FAILED    EventType = 8 // Issue #1948: command handler failed (drives upgrade failure)
+	EventType_EVENT_TYPE_SCRIPT_COMPLETED  EventType = 9 // Issue #1997: execute_script finished (drives ad-hoc run completion)
+	// Issue #1997: the following events are also published steward->controller over the
+	// wire and were silently collapsing to UNSPECIFIED without an enum value.
+	EventType_EVENT_TYPE_DNA_CHANGED         EventType = 10 // steward DNA attributes changed (controller routes to handleDNAEvent)
+	EventType_EVENT_TYPE_RELAY_REQUEST       EventType = 11 // steward relays a script's REST call to the controller
+	EventType_EVENT_TYPE_UPGRADE_DOWNLOADED  EventType = 12 // steward.upgrade.downloaded
+	EventType_EVENT_TYPE_UPGRADE_SWAPPED     EventType = 13 // steward.upgrade.swapped
+	EventType_EVENT_TYPE_UPGRADE_COMMITTED   EventType = 14 // steward.upgrade.committed
+	EventType_EVENT_TYPE_UPGRADE_ROLLED_BACK EventType = 15 // steward.upgrade.rolled_back
 )
 
 // Enum value maps for EventType.
 var (
 	EventType_name = map[int32]string{
-		0: "EVENT_TYPE_UNSPECIFIED",
-		1: "EVENT_TYPE_CONFIG_APPLIED",
-		2: "EVENT_TYPE_DNA_SYNCED",
-		3: "EVENT_TYPE_TASK_COMPLETED",
-		4: "EVENT_TYPE_TASK_FAILED",
-		5: "EVENT_TYPE_ERROR",
-		6: "EVENT_TYPE_COMMAND_RECEIVED",
-		7: "EVENT_TYPE_COMMAND_COMPLETED",
-		8: "EVENT_TYPE_COMMAND_FAILED",
+		0:  "EVENT_TYPE_UNSPECIFIED",
+		1:  "EVENT_TYPE_CONFIG_APPLIED",
+		2:  "EVENT_TYPE_DNA_SYNCED",
+		3:  "EVENT_TYPE_TASK_COMPLETED",
+		4:  "EVENT_TYPE_TASK_FAILED",
+		5:  "EVENT_TYPE_ERROR",
+		6:  "EVENT_TYPE_COMMAND_RECEIVED",
+		7:  "EVENT_TYPE_COMMAND_COMPLETED",
+		8:  "EVENT_TYPE_COMMAND_FAILED",
+		9:  "EVENT_TYPE_SCRIPT_COMPLETED",
+		10: "EVENT_TYPE_DNA_CHANGED",
+		11: "EVENT_TYPE_RELAY_REQUEST",
+		12: "EVENT_TYPE_UPGRADE_DOWNLOADED",
+		13: "EVENT_TYPE_UPGRADE_SWAPPED",
+		14: "EVENT_TYPE_UPGRADE_COMMITTED",
+		15: "EVENT_TYPE_UPGRADE_ROLLED_BACK",
 	}
 	EventType_value = map[string]int32{
-		"EVENT_TYPE_UNSPECIFIED":       0,
-		"EVENT_TYPE_CONFIG_APPLIED":    1,
-		"EVENT_TYPE_DNA_SYNCED":        2,
-		"EVENT_TYPE_TASK_COMPLETED":    3,
-		"EVENT_TYPE_TASK_FAILED":       4,
-		"EVENT_TYPE_ERROR":             5,
-		"EVENT_TYPE_COMMAND_RECEIVED":  6,
-		"EVENT_TYPE_COMMAND_COMPLETED": 7,
-		"EVENT_TYPE_COMMAND_FAILED":    8,
+		"EVENT_TYPE_UNSPECIFIED":         0,
+		"EVENT_TYPE_CONFIG_APPLIED":      1,
+		"EVENT_TYPE_DNA_SYNCED":          2,
+		"EVENT_TYPE_TASK_COMPLETED":      3,
+		"EVENT_TYPE_TASK_FAILED":         4,
+		"EVENT_TYPE_ERROR":               5,
+		"EVENT_TYPE_COMMAND_RECEIVED":    6,
+		"EVENT_TYPE_COMMAND_COMPLETED":   7,
+		"EVENT_TYPE_COMMAND_FAILED":      8,
+		"EVENT_TYPE_SCRIPT_COMPLETED":    9,
+		"EVENT_TYPE_DNA_CHANGED":         10,
+		"EVENT_TYPE_RELAY_REQUEST":       11,
+		"EVENT_TYPE_UPGRADE_DOWNLOADED":  12,
+		"EVENT_TYPE_UPGRADE_SWAPPED":     13,
+		"EVENT_TYPE_UPGRADE_COMMITTED":   14,
+		"EVENT_TYPE_UPGRADE_ROLLED_BACK": 15,
 	}
 )
 
@@ -857,7 +880,7 @@ const file_transport_control_proto_rawDesc = "" +
 	"\x1bCOMMAND_TYPE_EXECUTE_SCRIPT\x10\b\x12\"\n" +
 	"\x1eCOMMAND_TYPE_PUSH_SIGNING_CERT\x10\t\x12$\n" +
 	" COMMAND_TYPE_PUSH_STEWARD_BINARY\x10\n" +
-	"*\x94\x02\n" +
+	"*\xf8\x03\n" +
 	"\tEventType\x12\x1a\n" +
 	"\x16EVENT_TYPE_UNSPECIFIED\x10\x00\x12\x1d\n" +
 	"\x19EVENT_TYPE_CONFIG_APPLIED\x10\x01\x12\x19\n" +
@@ -867,7 +890,15 @@ const file_transport_control_proto_rawDesc = "" +
 	"\x10EVENT_TYPE_ERROR\x10\x05\x12\x1f\n" +
 	"\x1bEVENT_TYPE_COMMAND_RECEIVED\x10\x06\x12 \n" +
 	"\x1cEVENT_TYPE_COMMAND_COMPLETED\x10\a\x12\x1d\n" +
-	"\x19EVENT_TYPE_COMMAND_FAILED\x10\b*x\n" +
+	"\x19EVENT_TYPE_COMMAND_FAILED\x10\b\x12\x1f\n" +
+	"\x1bEVENT_TYPE_SCRIPT_COMPLETED\x10\t\x12\x1a\n" +
+	"\x16EVENT_TYPE_DNA_CHANGED\x10\n" +
+	"\x12\x1c\n" +
+	"\x18EVENT_TYPE_RELAY_REQUEST\x10\v\x12!\n" +
+	"\x1dEVENT_TYPE_UPGRADE_DOWNLOADED\x10\f\x12\x1e\n" +
+	"\x1aEVENT_TYPE_UPGRADE_SWAPPED\x10\r\x12 \n" +
+	"\x1cEVENT_TYPE_UPGRADE_COMMITTED\x10\x0e\x12\"\n" +
+	"\x1eEVENT_TYPE_UPGRADE_ROLLED_BACK\x10\x0f*x\n" +
 	"\bSeverity\x12\x18\n" +
 	"\x14SEVERITY_UNSPECIFIED\x10\x00\x12\x11\n" +
 	"\rSEVERITY_INFO\x10\x01\x12\x14\n" +

--- a/api/proto/transport/control.proto
+++ b/api/proto/transport/control.proto
@@ -34,6 +34,15 @@ enum EventType {
   EVENT_TYPE_COMMAND_RECEIVED = 6;  // Issue #1948: steward acknowledges a dispatched command
   EVENT_TYPE_COMMAND_COMPLETED = 7; // Issue #1948: command handler succeeded (drives upgrade commit)
   EVENT_TYPE_COMMAND_FAILED = 8;    // Issue #1948: command handler failed (drives upgrade failure)
+  EVENT_TYPE_SCRIPT_COMPLETED = 9;  // Issue #1997: execute_script finished (drives ad-hoc run completion)
+  // Issue #1997: the following events are also published steward->controller over the
+  // wire and were silently collapsing to UNSPECIFIED without an enum value.
+  EVENT_TYPE_DNA_CHANGED = 10;        // steward DNA attributes changed (controller routes to handleDNAEvent)
+  EVENT_TYPE_RELAY_REQUEST = 11;      // steward relays a script's REST call to the controller
+  EVENT_TYPE_UPGRADE_DOWNLOADED = 12; // steward.upgrade.downloaded
+  EVENT_TYPE_UPGRADE_SWAPPED = 13;    // steward.upgrade.swapped
+  EVENT_TYPE_UPGRADE_COMMITTED = 14;  // steward.upgrade.committed
+  EVENT_TYPE_UPGRADE_ROLLED_BACK = 15; // steward.upgrade.rolled_back
 }
 
 // Severity is used by both Event and LogEntry to indicate importance level.

--- a/pkg/controlplane/providers/grpc/convert.go
+++ b/pkg/controlplane/providers/grpc/convert.go
@@ -165,6 +165,17 @@ var eventTypeToProto = map[types.EventType]transportpb.EventType{
 	types.EventCommandReceived:  transportpb.EventType_EVENT_TYPE_COMMAND_RECEIVED,
 	types.EventCommandCompleted: transportpb.EventType_EVENT_TYPE_COMMAND_COMPLETED,
 	types.EventCommandFailed:    transportpb.EventType_EVENT_TYPE_COMMAND_FAILED,
+	// Issue #1997: events published steward->controller over the wire. Without these
+	// entries the type collapses to EVENT_TYPE_UNSPECIFIED and decodes to "" on the
+	// controller, so type-routed handlers never fire (e.g. dispatcher script_completed,
+	// server DNA-change handler, relay handler, upgrade lifecycle).
+	types.EventScriptCompleted:          transportpb.EventType_EVENT_TYPE_SCRIPT_COMPLETED,
+	types.EventDNAChanged:               transportpb.EventType_EVENT_TYPE_DNA_CHANGED,
+	types.EventRelayRequest:             transportpb.EventType_EVENT_TYPE_RELAY_REQUEST,
+	types.EventStewardUpgradeDownloaded: transportpb.EventType_EVENT_TYPE_UPGRADE_DOWNLOADED,
+	types.EventStewardUpgradeSwapped:    transportpb.EventType_EVENT_TYPE_UPGRADE_SWAPPED,
+	types.EventStewardUpgradeCommitted:  transportpb.EventType_EVENT_TYPE_UPGRADE_COMMITTED,
+	types.EventStewardUpgradeRolledBack: transportpb.EventType_EVENT_TYPE_UPGRADE_ROLLED_BACK,
 }
 
 // protoToEventType maps proto enum to semantic EventType.
@@ -177,6 +188,14 @@ var protoToEventType = map[transportpb.EventType]types.EventType{
 	transportpb.EventType_EVENT_TYPE_COMMAND_RECEIVED:  types.EventCommandReceived,
 	transportpb.EventType_EVENT_TYPE_COMMAND_COMPLETED: types.EventCommandCompleted,
 	transportpb.EventType_EVENT_TYPE_COMMAND_FAILED:    types.EventCommandFailed,
+	// Issue #1997: reverse mapping for the wire-crossing events added above.
+	transportpb.EventType_EVENT_TYPE_SCRIPT_COMPLETED:    types.EventScriptCompleted,
+	transportpb.EventType_EVENT_TYPE_DNA_CHANGED:         types.EventDNAChanged,
+	transportpb.EventType_EVENT_TYPE_RELAY_REQUEST:       types.EventRelayRequest,
+	transportpb.EventType_EVENT_TYPE_UPGRADE_DOWNLOADED:  types.EventStewardUpgradeDownloaded,
+	transportpb.EventType_EVENT_TYPE_UPGRADE_SWAPPED:     types.EventStewardUpgradeSwapped,
+	transportpb.EventType_EVENT_TYPE_UPGRADE_COMMITTED:   types.EventStewardUpgradeCommitted,
+	transportpb.EventType_EVENT_TYPE_UPGRADE_ROLLED_BACK: types.EventStewardUpgradeRolledBack,
 }
 
 // severityToProto maps semantic severity string to proto enum.

--- a/pkg/controlplane/providers/grpc/convert_test.go
+++ b/pkg/controlplane/providers/grpc/convert_test.go
@@ -336,6 +336,12 @@ func TestEventTypeRoundTrip(t *testing.T) {
 	// value, decodes to "" on the far side, and type-routed handlers never fire —
 	// e.g. the dispatcher's script_completed filter, leaving `cfg steward exec`
 	// runs stuck 0/1 (Issue #1997; same class as #1948).
+	//
+	// Guard against drift: if a new event type is added to the convert maps but
+	// not to wireCrossingEventTypes, this list would silently stop being
+	// exhaustive. Pin the slice length to the map size so the omission fails here.
+	require.Len(t, wireCrossingEventTypes, len(eventTypeToProto),
+		"wireCrossingEventTypes is out of sync with eventTypeToProto — add the new type to the slice")
 	for _, et := range wireCrossingEventTypes {
 		t.Run(string(et), func(t *testing.T) {
 			pb, ok := eventTypeToProto[et]

--- a/pkg/controlplane/providers/grpc/convert_test.go
+++ b/pkg/controlplane/providers/grpc/convert_test.go
@@ -293,23 +293,50 @@ func TestEventNil(t *testing.T) {
 	assert.Nil(t, eventFromProto(nil))
 }
 
+// wireCrossingEventTypes lists every types.Event* constant that is published over
+// the control plane (steward->controller) and therefore must survive the proto
+// codec with its Type preserved. Each entry was confirmed against a real emit site
+// (steward) and/or a type-routed handler (controller):
+//
+//   - EventConfigApplied, EventDNASynced, EventTaskCompleted, EventTaskFailed,
+//     EventError                                  — pre-existing config/task/error reporting
+//   - EventCommandReceived/Completed/Failed       — command lifecycle (Issue #1948)
+//   - EventScriptCompleted                        — execute_script.go:212; dispatcher.go:158 (Issue #1997)
+//   - EventDNAChanged                             — client_transport.go:991; server.go:1810
+//   - EventRelayRequest                           — script_relay/relay.go:188; api/relay_handler.go:79
+//   - EventStewardUpgradeDownloaded/Swapped/Committed/RolledBack
+//     — client_transport_upgrade.go / PublishUpgradeLifecycleEvent
+//
+// Deliberately EXCLUDED:
+//   - EventStewardUpgradeDispatched — documented as a controller-side label, but it
+//     has no emit site (never passed to PublishEvent/publishEventWithQueue) and is
+//     never serialized over the transport, so it needs no proto enum. If a controller
+//     ever publishes it over the wire, add it here and to the proto enum.
+var wireCrossingEventTypes = []types.EventType{
+	types.EventConfigApplied,
+	types.EventDNASynced,
+	types.EventTaskCompleted,
+	types.EventTaskFailed,
+	types.EventError,
+	types.EventCommandReceived,
+	types.EventCommandCompleted,
+	types.EventCommandFailed,
+	types.EventScriptCompleted,
+	types.EventDNAChanged,
+	types.EventRelayRequest,
+	types.EventStewardUpgradeDownloaded,
+	types.EventStewardUpgradeSwapped,
+	types.EventStewardUpgradeCommitted,
+	types.EventStewardUpgradeRolledBack,
+}
+
 func TestEventTypeRoundTrip(t *testing.T) {
-	// Command lifecycle events must survive the round-trip: the controller's
-	// upgrade-dispatch callback keys off EventCommandCompleted/Failed to advance
-	// the upgrade record from dispatched → committed/failed. A missing mapping
-	// serialises to the zero enum, the controller sees Type="", and the upgrade
-	// hangs in "dispatched" until timeout (Issue #1948).
-	allTypes := []types.EventType{
-		types.EventConfigApplied,
-		types.EventDNASynced,
-		types.EventTaskCompleted,
-		types.EventTaskFailed,
-		types.EventError,
-		types.EventCommandReceived,
-		types.EventCommandCompleted,
-		types.EventCommandFailed,
-	}
-	for _, et := range allTypes {
+	// Every wire-crossing event type must survive the semantic→proto→semantic
+	// round-trip. A type missing from either map serialises to the zero enum
+	// value, decodes to "" on the far side, and type-routed handlers never fire —
+	// e.g. the dispatcher's script_completed filter, leaving `cfg steward exec`
+	// runs stuck 0/1 (Issue #1997; same class as #1948).
+	for _, et := range wireCrossingEventTypes {
 		t.Run(string(et), func(t *testing.T) {
 			pb, ok := eventTypeToProto[et]
 			require.True(t, ok, "event type %q missing from eventTypeToProto", et)
@@ -317,6 +344,61 @@ func TestEventTypeRoundTrip(t *testing.T) {
 				"event type %q maps to the zero enum value", et)
 			result := protoToEventType[pb]
 			assert.Equal(t, et, result)
+		})
+	}
+}
+
+// TestEventFullRoundTrip exercises the actual codec path (eventToProto ->
+// eventFromProto) for every wire-crossing event type and asserts the Type is
+// preserved. This is the guard that would have caught Issue #1997: building an
+// Event{Type: EventScriptCompleted} and running it through the real conversion
+// functions, rather than injecting it directly into a handler.
+func TestEventFullRoundTrip(t *testing.T) {
+	now := time.Now().Truncate(time.Microsecond)
+	for _, et := range wireCrossingEventTypes {
+		t.Run(string(et), func(t *testing.T) {
+			ev := &types.Event{
+				ID:        "evt-" + string(et),
+				Type:      et,
+				StewardID: "steward-1",
+				TenantID:  "root/msp-a/client-1",
+				Timestamp: now,
+				CommandID: "cmd-1",
+				Severity:  "info",
+			}
+			pb := eventToProto(ev)
+			require.NotNil(t, pb)
+			require.NotEqual(t, transportpb.EventType_EVENT_TYPE_UNSPECIFIED, pb.GetType(),
+				"event type %q collapsed to UNSPECIFIED on the wire", et)
+
+			result := eventFromProto(pb)
+			require.NotNil(t, result)
+			assert.Equal(t, et, result.Type,
+				"event type %q did not survive eventToProto->eventFromProto", et)
+		})
+	}
+}
+
+// TestEventTypeProtoDescriptorComplete verifies the embedded proto file
+// descriptor (rawDesc) carries the EventType enum values added for Issue #1997,
+// so String(), gRPC reflection, and protojson render the symbolic name rather
+// than the bare integer.
+func TestEventTypeProtoDescriptorComplete(t *testing.T) {
+	cases := map[transportpb.EventType]string{
+		transportpb.EventType_EVENT_TYPE_SCRIPT_COMPLETED:    "EVENT_TYPE_SCRIPT_COMPLETED",
+		transportpb.EventType_EVENT_TYPE_DNA_CHANGED:         "EVENT_TYPE_DNA_CHANGED",
+		transportpb.EventType_EVENT_TYPE_RELAY_REQUEST:       "EVENT_TYPE_RELAY_REQUEST",
+		transportpb.EventType_EVENT_TYPE_UPGRADE_DOWNLOADED:  "EVENT_TYPE_UPGRADE_DOWNLOADED",
+		transportpb.EventType_EVENT_TYPE_UPGRADE_SWAPPED:     "EVENT_TYPE_UPGRADE_SWAPPED",
+		transportpb.EventType_EVENT_TYPE_UPGRADE_COMMITTED:   "EVENT_TYPE_UPGRADE_COMMITTED",
+		transportpb.EventType_EVENT_TYPE_UPGRADE_ROLLED_BACK: "EVENT_TYPE_UPGRADE_ROLLED_BACK",
+	}
+	for et, name := range cases {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, name, et.String())
+			vd := et.Descriptor().Values().ByNumber(et.Number())
+			require.NotNil(t, vd, "enum value %d missing from proto descriptor", et)
+			assert.Equal(t, name, string(vd.Name()))
 		})
 	}
 }


### PR DESCRIPTION
## Summary

Fixes #1997. After #1990/#1992/#1995, `cfg steward exec` executes successfully on the steward (exit 0, real stdout) but the controller run stayed 0/1. Root cause (same class as #1992, for EVENTS): `EventScriptCompleted` ("script_completed") had no proto `EventType` enum and was missing from both event convert maps, so the steward's success event collapsed to `EVENT_TYPE_UNSPECIFIED` over gRPC and decoded to `""` on the controller — the dispatcher's `script_completed` filter never matched, so `RecordJobResult` never fired and the device lock never released.

## Change

- `control.proto`: add `EVENT_TYPE_SCRIPT_COMPLETED = 9` plus the other steward→controller wire-crossing events that were also unmapped (`DNA_CHANGED=10`, `RELAY_REQUEST=11`, upgrade lifecycle `DOWNLOADED/SWAPPED/COMMITTED/ROLLED_BACK=12..15`), each verified against a real emit site.
- `control.pb.go`: **properly regenerated** (Docker + pinned toolchain, as #1992) — rawDesc carries all new values; `String()`/reflection resolve.
- `convert.go`: add all 7 to both `eventTypeToProto` and `protoToEventType`.
- Deliberately excluded `EventStewardUpgradeDispatched` (no emit site — never crosses the wire).

## Tests

- `TestEventTypeRoundTrip` / `TestEventFullRoundTrip`: every wire-crossing event type survives `eventToProto`→`eventFromProto` with type preserved (the test that would have caught this); negative control confirmed. Plus a drift guard pinning the slice to the map size.
- `TestEventTypeProtoDescriptorComplete`: descriptor/`String()` resolution for the new enums.

## Review

Adversarial team: acceptance ✅, security ✅ (identity mTLS-bound before type routing; no new trust surface; only `script_completed` drives state and it's device+execution-scoped), QA-code ✅, tests green.

This also proactively fixes the same latent class for DNA/relay/upgrade events (relevant to checkpoints #2/#4). Follows #1990/#1992/#1995; related latent #1994.

🤖 Generated with [Claude Code](https://claude.com/claude-code)