### PR TITLE
controller: allow admin mTLS principals on installer-publish + steward-upgrade endpoints (Issue #1999)

### DIFF
--- a/features/controller/api/handlers_steward_binary.go
+++ b/features/controller/api/handlers_steward_binary.go
@@ -48,6 +48,18 @@ func (s *Server) stewardBinaryTrust() trust.TrustStore {
 	return store
 }
 
+// installerBlobTenant maps a caller tenant to the tenant namespace used for steward-binary
+// blob storage. The blob store requires a non-empty tenant (blob.ErrBlobTenantRequired), so
+// an admin mTLS principal with global scope (empty tenant) writes/reads under the "default"
+// namespace — the same fallback handlers_configs.go uses for admin writes (middleware.go:170,
+// Issue #1999). Scoped (non-admin) callers always carry their own non-empty tenant.
+func installerBlobTenant(callerTenantID string) string {
+	if callerTenantID == "" {
+		return "default"
+	}
+	return callerTenantID
+}
+
 // stewardBinaryBlobKey builds the BlobKey for a steward binary within the steward-binaries namespace.
 // Name format: "{version}-{platform}-{arch}" (e.g. "v0.5.12-linux-amd64").
 // The blob key Name must not contain "/" — the filesystem provider rejects path separators.
@@ -67,11 +79,15 @@ func (s *Server) handlePublishStewardBinary(w http.ResponseWriter, r *http.Reque
 		s.writeErrorResponse(w, http.StatusServiceUnavailable, "Binary storage not available", "SERVICE_UNAVAILABLE")
 		return
 	}
-	tenantID, _ := r.Context().Value(ctxkeys.TenantID).(string)
-	if tenantID == "" {
-		s.writeErrorResponse(w, http.StatusUnauthorized, "Authentication required", "AUTHENTICATION_REQUIRED")
+	// Admin mTLS principals carry global scope with an empty tenant (middleware.go:173)
+	// and publish into the global namespace; only a NON-admin caller with no tenant is a
+	// genuine auth failure (Issue #1999, same pattern as #1990's authRunAccess).
+	_, callerTenantID, ok := s.authRunAccess(w, r)
+	if !ok {
 		return
 	}
+	// Admins (empty tenant) store under the "default" namespace; scoped callers under their own.
+	tenantID := installerBlobTenant(callerTenantID)
 
 	vars := mux.Vars(r)
 	version := vars["version"]
@@ -239,11 +255,15 @@ func (s *Server) handleGetStewardBinary(w http.ResponseWriter, r *http.Request) 
 		s.writeErrorResponse(w, http.StatusServiceUnavailable, "Binary storage not available", "SERVICE_UNAVAILABLE")
 		return
 	}
-	tenantID, _ := r.Context().Value(ctxkeys.TenantID).(string)
-	if tenantID == "" {
-		s.writeErrorResponse(w, http.StatusUnauthorized, "Authentication required", "AUTHENTICATION_REQUIRED")
+	// Admin mTLS principals carry global scope with an empty tenant (middleware.go:173)
+	// and read from the global namespace; only a NON-admin caller with no tenant is a
+	// genuine auth failure (Issue #1999, same pattern as #1990's authRunAccess).
+	_, callerTenantID, ok := s.authRunAccess(w, r)
+	if !ok {
 		return
 	}
+	// Admins (empty tenant) read from the "default" namespace; scoped callers from their own.
+	tenantID := installerBlobTenant(callerTenantID)
 
 	vars := mux.Vars(r)
 	version := vars["version"]

--- a/features/controller/api/handlers_steward_binary_test.go
+++ b/features/controller/api/handlers_steward_binary_test.go
@@ -81,7 +81,9 @@ func doPublish(server *Server, version, platform, arch, tenantID, sigBase64 stri
 		rawURL += "?" + q.Encode()
 	}
 	req := httptest.NewRequest(http.MethodPost, rawURL, bytes.NewReader(body))
-	req = req.WithContext(context.WithValue(req.Context(), ctxkeys.TenantID, tenantID))
+	// A tenant-scoped (non-admin) caller carries both a principal and its tenant, exactly
+	// as authenticationMiddleware injects them for an X-API-Key request (Issue #1999).
+	req = withScopedPrincipal(req, tenantID)
 	req = mux.SetURLVars(req, map[string]string{
 		"version":  version,
 		"platform": platform,
@@ -92,11 +94,32 @@ func doPublish(server *Server, version, platform, arch, tenantID, sigBase64 stri
 	return rec
 }
 
+// withScopedPrincipal injects a non-admin principal bound to tenantID plus the tenant
+// context value, mirroring authenticationMiddleware for an API-key request. An empty
+// tenantID models a non-admin caller with no tenant (a genuine auth failure).
+func withScopedPrincipal(req *http.Request, tenantID string) *http.Request {
+	p := &Principal{ID: "api-key:" + tenantID, IsAdmin: false, TenantID: tenantID}
+	ctx := context.WithValue(req.Context(), principalContextKey, p)
+	ctx = context.WithValue(ctx, ctxkeys.TenantID, tenantID)
+	return req.WithContext(ctx)
+}
+
+// withAdminPrincipal injects an admin mTLS principal (IsAdmin=true, empty tenant) plus
+// the empty tenant context value, mirroring authenticationMiddleware for an mTLS admin
+// cert (middleware.go:173). This is the global-scope path that cannot be reached via an
+// X-API-Key request (Issue #1999).
+func withAdminPrincipal(req *http.Request) *http.Request {
+	p := &Principal{ID: "mtls-admin:cn", Name: "mtls-admin:cn", IsAdmin: true, TenantID: ""}
+	ctx := context.WithValue(req.Context(), principalContextKey, p)
+	ctx = context.WithValue(ctx, ctxkeys.TenantID, "")
+	return req.WithContext(ctx)
+}
+
 // doGet calls handleGetStewardBinary directly.
 func doGet(server *Server, version, platform, arch, tenantID string) *httptest.ResponseRecorder {
 	req := httptest.NewRequest(http.MethodGet,
 		"/api/v1/installer/steward-binaries/"+version+"/"+platform+"/"+arch, nil)
-	req = req.WithContext(context.WithValue(req.Context(), ctxkeys.TenantID, tenantID))
+	req = withScopedPrincipal(req, tenantID)
 	req = mux.SetURLVars(req, map[string]string{
 		"version":  version,
 		"platform": platform,
@@ -253,7 +276,7 @@ func TestHandlePublishStewardBinary_ForceOverwrite(t *testing.T) {
 	q.Set("force", "true")
 	rawURL := "/api/v1/installer/steward-binaries/v1.0.0/linux/amd64?" + q.Encode()
 	req := httptest.NewRequest(http.MethodPost, rawURL, bytes.NewReader(newContent))
-	req = req.WithContext(context.WithValue(req.Context(), ctxkeys.TenantID, "test-tenant"))
+	req = withScopedPrincipal(req, "test-tenant")
 	req = mux.SetURLVars(req, map[string]string{"version": "v1.0.0", "platform": "linux", "arch": "amd64"})
 	rec2 := httptest.NewRecorder()
 	server.handlePublishStewardBinary(rec2, req)
@@ -421,9 +444,8 @@ func TestHandlePublishStewardBinary_LabelsStoredCorrectly(t *testing.T) {
 	req := httptest.NewRequest(http.MethodPost,
 		"/api/v1/installer/steward-binaries/v2.0.0/windows/amd64?"+q2.Encode(),
 		bytes.NewReader(content))
-	ctx := context.WithValue(req.Context(), ctxkeys.TenantID, "label-tenant")
-	ctx = context.WithValue(ctx, ctxkeys.UserIDKey, "admin@example.com")
-	req = req.WithContext(ctx)
+	req = withScopedPrincipal(req, "label-tenant")
+	req = req.WithContext(context.WithValue(req.Context(), ctxkeys.UserIDKey, "admin@example.com"))
 	req = mux.SetURLVars(req, map[string]string{"version": "v2.0.0", "platform": "windows", "arch": "amd64"})
 	rec := httptest.NewRecorder()
 	server.handlePublishStewardBinary(rec, req)
@@ -465,4 +487,89 @@ func TestHandlePublishStewardBinary_LabelsStoredCorrectly(t *testing.T) {
 	got, readErr := io.ReadAll(rc)
 	require.NoError(t, readErr)
 	assert.Equal(t, content, got)
+}
+
+// --- Admin mTLS empty-tenant tests (Issue #1999) ---
+
+// publishWithPrincipal calls handlePublishStewardBinary with the given principal injected
+// into the request context (admin mTLS or scoped non-admin), exactly as the middleware does.
+func publishWithPrincipal(server *Server, principalReq func(*http.Request) *http.Request, version, platform, arch, sigBase64 string, body []byte) *httptest.ResponseRecorder {
+	q := url.Values{}
+	q.Set("signature", sigBase64)
+	rawURL := "/api/v1/installer/steward-binaries/" + version + "/" + platform + "/" + arch + "?" + q.Encode()
+	req := httptest.NewRequest(http.MethodPost, rawURL, bytes.NewReader(body))
+	req = principalReq(req)
+	req = mux.SetURLVars(req, map[string]string{"version": version, "platform": platform, "arch": arch})
+	rec := httptest.NewRecorder()
+	server.handlePublishStewardBinary(rec, req)
+	return rec
+}
+
+// getWithPrincipal calls handleGetStewardBinary with the given principal injected.
+func getWithPrincipal(server *Server, principalReq func(*http.Request) *http.Request, version, platform, arch string) *httptest.ResponseRecorder {
+	req := httptest.NewRequest(http.MethodGet,
+		"/api/v1/installer/steward-binaries/"+version+"/"+platform+"/"+arch, nil)
+	req = principalReq(req)
+	req = mux.SetURLVars(req, map[string]string{"version": version, "platform": platform, "arch": arch})
+	rec := httptest.NewRecorder()
+	server.handleGetStewardBinary(rec, req)
+	return rec
+}
+
+// TestPublish_AdminEmptyTenant_NotUnauthorized verifies that an admin mTLS principal
+// (IsAdmin=true, TenantID="") is NOT rejected with 401 on publish — it proceeds to the
+// global (empty-tenant) namespace and succeeds (Issue #1999).
+func TestPublish_AdminEmptyTenant_NotUnauthorized(t *testing.T) {
+	server, fix := setupStewardBinaryServer(t)
+	content := []byte("admin-published steward binary")
+	sigBase64 := fix.signContent(content)
+
+	rec := publishWithPrincipal(server, withAdminPrincipal, "v1.0.0", "linux", "amd64", sigBase64, content)
+
+	require.NotEqual(t, http.StatusUnauthorized, rec.Code,
+		"admin mTLS principal with empty tenant must not be rejected with 401: %s", rec.Body.String())
+	assert.Equal(t, http.StatusOK, rec.Code, "admin publish must succeed: %s", rec.Body.String())
+}
+
+// TestPublish_NonAdminEmptyTenant_Unauthorized verifies that a NON-admin principal with
+// no tenant still gets 401 on publish (regression guard, Issue #1999).
+func TestPublish_NonAdminEmptyTenant_Unauthorized(t *testing.T) {
+	server, fix := setupStewardBinaryServer(t)
+	content := []byte("scoped-but-tenantless binary")
+	sigBase64 := fix.signContent(content)
+
+	emptyScoped := func(req *http.Request) *http.Request { return withScopedPrincipal(req, "") }
+	rec := publishWithPrincipal(server, emptyScoped, "v1.0.0", "linux", "amd64", sigBase64, content)
+
+	assert.Equal(t, http.StatusUnauthorized, rec.Code)
+	assert.Contains(t, rec.Body.String(), "AUTHENTICATION_REQUIRED")
+}
+
+// TestGetStewardBinary_AdminEmptyTenant_NotUnauthorized verifies that an admin mTLS
+// principal can GET from the global (empty-tenant) namespace it published into, without 401.
+func TestGetStewardBinary_AdminEmptyTenant_NotUnauthorized(t *testing.T) {
+	server, fix := setupStewardBinaryServer(t)
+	content := []byte("admin binary for get")
+	sigBase64 := fix.signContent(content)
+
+	pubRec := publishWithPrincipal(server, withAdminPrincipal, "v1.2.3", "darwin", "arm64", sigBase64, content)
+	require.Equal(t, http.StatusOK, pubRec.Code, "admin publish must succeed: %s", pubRec.Body.String())
+
+	getRec := getWithPrincipal(server, withAdminPrincipal, "v1.2.3", "darwin", "arm64")
+	require.NotEqual(t, http.StatusUnauthorized, getRec.Code,
+		"admin mTLS principal with empty tenant must not be rejected with 401 on GET")
+	assert.Equal(t, http.StatusOK, getRec.Code)
+	assert.Equal(t, content, getRec.Body.Bytes())
+}
+
+// TestGetStewardBinary_NonAdminEmptyTenant_Unauthorized verifies that a NON-admin caller
+// with no tenant still gets 401 on the authenticated GET (regression guard, Issue #1999).
+func TestGetStewardBinary_NonAdminEmptyTenant_Unauthorized(t *testing.T) {
+	server, _ := setupStewardBinaryServer(t)
+
+	emptyScoped := func(req *http.Request) *http.Request { return withScopedPrincipal(req, "") }
+	getRec := getWithPrincipal(server, emptyScoped, "v1.0.0", "linux", "amd64")
+
+	assert.Equal(t, http.StatusUnauthorized, getRec.Code)
+	assert.Contains(t, getRec.Body.String(), "AUTHENTICATION_REQUIRED")
 }

--- a/features/controller/api/handlers_upgrade.go
+++ b/features/controller/api/handlers_upgrade.go
@@ -76,12 +76,19 @@ func (s *Server) handleDispatchUpgrade(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	callerTenantID, _ := r.Context().Value(ctxkeys.TenantID).(string)
-	if callerTenantID == "" {
-		s.writeErrorResponse(w, http.StatusUnauthorized, "Authentication required", "AUTHENTICATION_REQUIRED")
+	// Admin mTLS principals carry global (cross-tenant) scope with an empty tenant
+	// (middleware.go:173); an empty tenant yields an unscoped fleet search and the
+	// per-tenant isolation filter below is skipped for admins. Only a NON-admin caller
+	// with no tenant is a genuine auth failure (Issue #1999, same pattern as #1990).
+	principal, callerTenantID, ok := s.authRunAccess(w, r)
+	if !ok {
 		return
 	}
 	callerUserID, _ := r.Context().Value(ctxkeys.UserIDKey).(string)
+	// The blob store requires a non-empty tenant; admins (empty tenant) read the binary
+	// from and key the upgrade record under the "default" namespace, matching the publish
+	// path's installerBlobTenant fallback (Issue #1999).
+	blobTenantID := installerBlobTenant(callerTenantID)
 
 	var req dispatchUpgradeRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
@@ -133,11 +140,17 @@ func (s *Server) handleDispatchUpgrade(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Enforce tenant isolation: drop stewards from other tenants, return 403 if none remain.
+	// Enforce tenant isolation for scoped (non-admin) callers: drop stewards from other
+	// tenants, return 403 if none remain. Admin mTLS principals (empty tenant) have global
+	// scope and act on every matched steward (Issue #1999).
 	var tenantStewards []fleet.StewardResult
-	for _, st := range stewards {
-		if st.TenantID == callerTenantID {
-			tenantStewards = append(tenantStewards, st)
+	if principal.IsAdmin {
+		tenantStewards = stewards
+	} else {
+		for _, st := range stewards {
+			if st.TenantID == callerTenantID {
+				tenantStewards = append(tenantStewards, st)
+			}
 		}
 	}
 	if len(tenantStewards) == 0 {
@@ -148,7 +161,7 @@ func (s *Server) handleDispatchUpgrade(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Fetch the approved binary blob.
-	blobKey := stewardBinaryBlobKey(callerTenantID, req.Version, req.Platform, req.Arch)
+	blobKey := stewardBinaryBlobKey(blobTenantID, req.Version, req.Platform, req.Arch)
 	rc, blobMeta, err := s.blobStore.GetBlob(r.Context(), blobKey)
 	if err != nil {
 		if errors.Is(err, blob.ErrBlobNotFound) {
@@ -230,11 +243,22 @@ func (s *Server) handleDispatchUpgrade(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
+		// Record tenant: scoped callers are bound to their own tenant (== steward tenant by
+		// the isolation filter above). Admins (empty tenant) attribute each record to the
+		// target steward's tenant so per-tenant status/rollback isolation keeps working
+		// (Issue #1999).
+		recordTenantID := callerTenantID
+		authMethod := "api_key"
+		if principal.IsAdmin {
+			recordTenantID = st.TenantID
+			authMethod = "mtls_admin"
+		}
+
 		upgradeID := uuid.New().String()
 		record := &business.UpgradeRecord{
 			ID:        upgradeID,
 			StewardID: st.ID,
-			TenantID:  callerTenantID,
+			TenantID:  recordTenantID,
 			Version:   req.Version,
 			Platform:  req.Platform,
 			Arch:      req.Arch,
@@ -242,8 +266,8 @@ func (s *Server) handleDispatchUpgrade(w http.ResponseWriter, r *http.Request) {
 			Status:    business.UpgradeStatusDispatched,
 			InitiatedBy: business.InitiatedByIdentity{
 				Subject:    callerUserID,
-				TenantID:   callerTenantID,
-				AuthMethod: "api_key",
+				TenantID:   recordTenantID,
+				AuthMethod: authMethod,
 			},
 			Publisher:       publisher,
 			SignatureDigest: sigDigest,
@@ -280,7 +304,7 @@ func (s *Server) handleDispatchUpgrade(w http.ResponseWriter, r *http.Request) {
 			baseURL = "https://localhost:9080"
 		}
 		downloadURL := fmt.Sprintf("%s/api/v1/public/steward-binaries/%s/%s/%s?tenant=%s",
-			baseURL, req.Version, req.Platform, req.Arch, url.QueryEscape(callerTenantID))
+			baseURL, req.Version, req.Platform, req.Arch, url.QueryEscape(blobTenantID))
 		params := map[string]interface{}{
 			"version":      req.Version,
 			"download_url": downloadURL,
@@ -368,9 +392,11 @@ func (s *Server) handleUpgradeStatus(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	callerTenantID, _ := r.Context().Value(ctxkeys.TenantID).(string)
-	if callerTenantID == "" {
-		s.writeErrorResponse(w, http.StatusUnauthorized, "Authentication required", "AUTHENTICATION_REQUIRED")
+	// Admin mTLS principals carry global scope with an empty tenant (middleware.go:173)
+	// and may view any tenant's record; only a NON-admin caller with no tenant is a
+	// genuine auth failure (Issue #1999, same pattern as #1990).
+	principal, callerTenantID, ok := s.authRunAccess(w, r)
+	if !ok {
 		return
 	}
 
@@ -393,8 +419,9 @@ func (s *Server) handleUpgradeStatus(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Tenant isolation: caller can only view records in their own tenant.
-	if record.TenantID != callerTenantID {
+	// Tenant isolation: scoped (non-admin) callers can only view records in their own
+	// tenant; admin mTLS principals have global access (Issue #1999).
+	if !principal.IsAdmin && record.TenantID != callerTenantID {
 		s.writeErrorResponse(w, http.StatusForbidden, "Access denied", "FORBIDDEN")
 		return
 	}
@@ -419,9 +446,11 @@ func (s *Server) handleUpgradeRollback(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	callerTenantID, _ := r.Context().Value(ctxkeys.TenantID).(string)
-	if callerTenantID == "" {
-		s.writeErrorResponse(w, http.StatusUnauthorized, "Authentication required", "AUTHENTICATION_REQUIRED")
+	// Admin mTLS principals carry global scope with an empty tenant (middleware.go:173)
+	// and may roll back any tenant's record; only a NON-admin caller with no tenant is a
+	// genuine auth failure (Issue #1999, same pattern as #1990).
+	principal, callerTenantID, ok := s.authRunAccess(w, r)
+	if !ok {
 		return
 	}
 	callerUserID, _ := r.Context().Value(ctxkeys.UserIDKey).(string)
@@ -443,10 +472,23 @@ func (s *Server) handleUpgradeRollback(w http.ResponseWriter, r *http.Request) {
 		s.writeErrorResponse(w, http.StatusInternalServerError, "Failed to retrieve upgrade record", "GET_RECORD_ERROR")
 		return
 	}
-	if original.TenantID != callerTenantID {
+	// Tenant isolation: scoped (non-admin) callers can only roll back records in their own
+	// tenant; admin mTLS principals have global access (Issue #1999).
+	if !principal.IsAdmin && original.TenantID != callerTenantID {
 		s.writeErrorResponse(w, http.StatusForbidden, "Access denied", "FORBIDDEN")
 		return
 	}
+	// Record tenant: the rollback record is attributed to the original record's tenant for
+	// admins (global scope) and to the caller's tenant for scoped callers (== original tenant
+	// by the isolation check above), so per-tenant status/listing stays consistent (Issue #1999).
+	effectiveTenantID := callerTenantID
+	if principal.IsAdmin {
+		effectiveTenantID = original.TenantID
+	}
+	// Blob namespace: the rollback binary is read from the caller's namespace, the same place
+	// the caller publishes to — scoped callers from their own tenant, admins from "default"
+	// (the blob store requires a non-empty tenant; matches installerBlobTenant) — Issue #1999.
+	rollbackBlobTenant := installerBlobTenant(callerTenantID)
 
 	var req rollbackRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
@@ -465,7 +507,7 @@ func (s *Server) handleUpgradeRollback(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Fetch the rollback binary blob.
-	blobKey := stewardBinaryBlobKey(callerTenantID, req.Version, original.Platform, original.Arch)
+	blobKey := stewardBinaryBlobKey(rollbackBlobTenant, req.Version, original.Platform, original.Arch)
 	rc, blobMeta, err := s.blobStore.GetBlob(r.Context(), blobKey)
 	if err != nil {
 		if errors.Is(err, blob.ErrBlobNotFound) {
@@ -516,11 +558,15 @@ func (s *Server) handleUpgradeRollback(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	rollbackAuthMethod := "api_key"
+	if principal.IsAdmin {
+		rollbackAuthMethod = "mtls_admin"
+	}
 	rollbackUpgradeID := uuid.New().String()
 	record := &business.UpgradeRecord{
 		ID:        rollbackUpgradeID,
 		StewardID: original.StewardID,
-		TenantID:  callerTenantID,
+		TenantID:  effectiveTenantID,
 		Version:   req.Version,
 		Platform:  original.Platform,
 		Arch:      original.Arch,
@@ -528,8 +574,8 @@ func (s *Server) handleUpgradeRollback(w http.ResponseWriter, r *http.Request) {
 		Status:    business.UpgradeStatusDispatched,
 		InitiatedBy: business.InitiatedByIdentity{
 			Subject:    callerUserID,
-			TenantID:   callerTenantID,
-			AuthMethod: "api_key",
+			TenantID:   effectiveTenantID,
+			AuthMethod: rollbackAuthMethod,
 		},
 		Publisher:       publisher,
 		SignatureDigest: sigDigest,
@@ -555,7 +601,7 @@ func (s *Server) handleUpgradeRollback(w http.ResponseWriter, r *http.Request) {
 			baseURL = "https://localhost:9080"
 		}
 		downloadURL := fmt.Sprintf("%s/api/v1/public/steward-binaries/%s/%s/%s?tenant=%s",
-			baseURL, req.Version, original.Platform, original.Arch, url.QueryEscape(callerTenantID))
+			baseURL, req.Version, original.Platform, original.Arch, url.QueryEscape(rollbackBlobTenant))
 		params := map[string]interface{}{
 			"version":      req.Version,
 			"download_url": downloadURL,

--- a/features/controller/api/handlers_upgrade_test.go
+++ b/features/controller/api/handlers_upgrade_test.go
@@ -21,8 +21,11 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/cfgis/cfgms/features/controller/commands"
 	"github.com/cfgis/cfgms/features/controller/fleet"
-	"github.com/cfgis/cfgms/pkg/ctxkeys"
+	controlplaneInterfaces "github.com/cfgis/cfgms/pkg/controlplane/interfaces"
+	controlplaneTypes "github.com/cfgis/cfgms/pkg/controlplane/types"
+	"github.com/cfgis/cfgms/pkg/logging"
 	blob "github.com/cfgis/cfgms/pkg/storage/interfaces/blob"
 	business "github.com/cfgis/cfgms/pkg/storage/interfaces/business"
 )
@@ -202,7 +205,9 @@ func doDispatchUpgrade(server *Server, tenantID, selector, version, platform, ar
 	}
 	b, _ := json.Marshal(body)
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/stewards/upgrade", bytes.NewReader(b))
-	req = req.WithContext(context.WithValue(req.Context(), ctxkeys.TenantID, tenantID))
+	// Tenant-scoped (non-admin) caller: principal + tenant injected as the middleware
+	// would for an X-API-Key request (Issue #1999).
+	req = withScopedPrincipal(req, tenantID)
 	rec := httptest.NewRecorder()
 	server.handleDispatchUpgrade(rec, req)
 	return rec
@@ -211,7 +216,7 @@ func doDispatchUpgrade(server *Server, tenantID, selector, version, platform, ar
 // doUpgradeStatus calls handleUpgradeStatus for the given upgrade_id.
 func doUpgradeStatus(server *Server, tenantID, upgradeID string) *httptest.ResponseRecorder {
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/stewards/upgrade/"+upgradeID, nil)
-	req = req.WithContext(context.WithValue(req.Context(), ctxkeys.TenantID, tenantID))
+	req = withScopedPrincipal(req, tenantID)
 	req = mux.SetURLVars(req, map[string]string{"upgrade_id": upgradeID})
 	rec := httptest.NewRecorder()
 	server.handleUpgradeStatus(rec, req)
@@ -223,7 +228,7 @@ func doUpgradeRollback(server *Server, tenantID, upgradeID, targetVersion string
 	body := rollbackRequest{Version: targetVersion}
 	b, _ := json.Marshal(body)
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/stewards/upgrade/"+upgradeID+"/rollback", bytes.NewReader(b))
-	req = req.WithContext(context.WithValue(req.Context(), ctxkeys.TenantID, tenantID))
+	req = withScopedPrincipal(req, tenantID)
 	req = mux.SetURLVars(req, map[string]string{"upgrade_id": upgradeID})
 	rec := httptest.NewRecorder()
 	server.handleUpgradeRollback(rec, req)
@@ -719,7 +724,7 @@ func TestDispatch_InvalidBody(t *testing.T) {
 
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/stewards/upgrade",
 		bytes.NewReader([]byte("not-json")))
-	req = req.WithContext(context.WithValue(req.Context(), ctxkeys.TenantID, "tenant-a"))
+	req = withScopedPrincipal(req, "tenant-a")
 	rec := httptest.NewRecorder()
 	server.handleDispatchUpgrade(rec, req)
 
@@ -762,4 +767,380 @@ func TestDispatch_UpgradeStoreRecordsCanBeReadByStatus(t *testing.T) {
 	require.NoError(t, json.Unmarshal(statusRec.Body.Bytes(), &statusResp))
 	statusData := statusResp.Data.(map[string]interface{})
 	assert.Equal(t, "steward-e2e", statusData["StewardID"])
+}
+
+// --- Admin mTLS empty-tenant tests (Issue #1999) ---
+
+// dispatchUpgradeAsAdmin calls handleDispatchUpgrade with an admin mTLS principal
+// (IsAdmin=true, empty tenant) injected, exactly as the middleware does for an mTLS cert.
+func dispatchUpgradeAsAdmin(server *Server, selector, version, platform, arch string) *httptest.ResponseRecorder {
+	body := dispatchUpgradeRequest{Selector: selector, Version: version, Platform: platform, Arch: arch}
+	b, _ := json.Marshal(body)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/stewards/upgrade", bytes.NewReader(b))
+	req = withAdminPrincipal(req)
+	rec := httptest.NewRecorder()
+	server.handleDispatchUpgrade(rec, req)
+	return rec
+}
+
+// statusUpgradeAsAdmin calls handleUpgradeStatus with an admin mTLS principal injected.
+func statusUpgradeAsAdmin(server *Server, upgradeID string) *httptest.ResponseRecorder {
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/stewards/upgrade/"+upgradeID, nil)
+	req = withAdminPrincipal(req)
+	req = mux.SetURLVars(req, map[string]string{"upgrade_id": upgradeID})
+	rec := httptest.NewRecorder()
+	server.handleUpgradeStatus(rec, req)
+	return rec
+}
+
+// rollbackUpgradeAsAdmin calls handleUpgradeRollback with an admin mTLS principal injected.
+func rollbackUpgradeAsAdmin(server *Server, upgradeID, targetVersion string) *httptest.ResponseRecorder {
+	body := rollbackRequest{Version: targetVersion}
+	b, _ := json.Marshal(body)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/stewards/upgrade/"+upgradeID+"/rollback", bytes.NewReader(b))
+	req = withAdminPrincipal(req)
+	req = mux.SetURLVars(req, map[string]string{"upgrade_id": upgradeID})
+	rec := httptest.NewRecorder()
+	server.handleUpgradeRollback(rec, req)
+	return rec
+}
+
+// emptyScopedReq models a NON-admin caller with no tenant (genuine auth failure).
+func emptyScopedReq(req *http.Request) *http.Request { return withScopedPrincipal(req, "") }
+
+// TestDispatch_AdminEmptyTenant_NotUnauthorized verifies that an admin mTLS principal
+// (empty tenant) is NOT rejected with 401 on dispatch; it acts on every matched steward
+// regardless of tenant, using the global (empty-tenant) binary namespace (Issue #1999).
+func TestDispatch_AdminEmptyTenant_NotUnauthorized(t *testing.T) {
+	stewards := []fleet.StewardData{
+		{ID: "steward-x", TenantID: "tenant-x", Status: "online"},
+	}
+	server, upgradeStore := setupUpgradeServer(t, "tenant-x", stewards)
+	// Admins (empty tenant) read the binary from the "default" namespace — the blob store
+	// requires a non-empty tenant, so admin writes/reads fall back to "default" (Issue #1999).
+	publishApprovedBinary(t, server, "default", "v0.5.12", "linux", "amd64")
+
+	rec := dispatchUpgradeAsAdmin(server, "id:steward-x", "v0.5.12", "linux", "amd64")
+
+	require.NotEqual(t, http.StatusUnauthorized, rec.Code,
+		"admin mTLS principal with empty tenant must not be rejected with 401: %s", rec.Body.String())
+	require.Equal(t, http.StatusAccepted, rec.Code, "admin dispatch must be accepted: %s", rec.Body.String())
+
+	var resp APIResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	data := resp.Data.(map[string]interface{})
+	upgradeID := data["upgrade_id"].(string)
+	record, err := upgradeStore.GetUpgrade(context.Background(), upgradeID)
+	require.NoError(t, err)
+	assert.Equal(t, "steward-x", record.StewardID)
+	// Admin-dispatched records are attributed to the target steward's tenant.
+	assert.Equal(t, "tenant-x", record.TenantID)
+	assert.Equal(t, "mtls_admin", record.InitiatedBy.AuthMethod)
+}
+
+// TestDispatch_NonAdminEmptyTenant_Unauthorized verifies that a NON-admin principal with
+// no tenant gets 401 from authRunAccess on dispatch, and — critically — that the auth gate
+// PRECEDES the tenant-isolation loop. The only steward belongs to "tenant-a", so if the
+// empty-tenant auth check were removed, execution would fall through to the isolation loop
+// (callerTenantID="" matches no steward) and return 403 CROSS_TENANT instead. Asserting 401
+// AUTHENTICATION_REQUIRED (not 403) pins the ordering: auth before isolation (Issue #1999, B3).
+func TestDispatch_NonAdminEmptyTenant_Unauthorized(t *testing.T) {
+	stewards := []fleet.StewardData{
+		{ID: "steward-1", TenantID: "tenant-a", Status: "online"},
+	}
+	server, _ := setupUpgradeServer(t, "tenant-a", stewards)
+	publishApprovedBinary(t, server, "tenant-a", "v0.5.12", "linux", "amd64")
+
+	body := dispatchUpgradeRequest{Selector: "id:steward-1", Version: "v0.5.12", Platform: "linux", Arch: "amd64"}
+	b, _ := json.Marshal(body)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/stewards/upgrade", bytes.NewReader(b))
+	req = emptyScopedReq(req)
+	rec := httptest.NewRecorder()
+	server.handleDispatchUpgrade(rec, req)
+
+	// Must be 401 from the auth gate, NOT 403 from the isolation loop further down.
+	assert.Equal(t, http.StatusUnauthorized, rec.Code,
+		"non-admin empty-tenant must be rejected by authRunAccess (401), before the isolation loop")
+	assert.Contains(t, rec.Body.String(), "AUTHENTICATION_REQUIRED")
+	assert.NotContains(t, rec.Body.String(), "CROSS_TENANT",
+		"401 must precede the isolation loop; a CROSS_TENANT (403) here would mean auth ran after isolation")
+}
+
+// TestUpgradeStatus_AdminEmptyTenant_SeesAnyTenantRecord verifies that an admin mTLS
+// principal can read a record owned by any tenant (no 401, no 403) — Issue #1999.
+func TestUpgradeStatus_AdminEmptyTenant_SeesAnyTenantRecord(t *testing.T) {
+	stewards := []fleet.StewardData{
+		{ID: "steward-1", TenantID: "tenant-a", Status: "online"},
+	}
+	server, _ := setupUpgradeServer(t, "tenant-a", stewards)
+	publishApprovedBinary(t, server, "tenant-a", "v0.5.12", "linux", "amd64")
+
+	// A tenant-scoped caller creates the record (TenantID=tenant-a).
+	rec := doDispatchUpgrade(server, "tenant-a", "id:steward-1", "v0.5.12", "linux", "amd64")
+	require.Equal(t, http.StatusAccepted, rec.Code)
+	var resp APIResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	upgradeID := resp.Data.(map[string]interface{})["upgrade_id"].(string)
+
+	// Admin (empty tenant) must be able to view tenant-a's record.
+	statusRec := statusUpgradeAsAdmin(server, upgradeID)
+	require.NotEqual(t, http.StatusUnauthorized, statusRec.Code,
+		"admin mTLS principal with empty tenant must not be rejected with 401 on status")
+	assert.Equal(t, http.StatusOK, statusRec.Code, "admin must see any tenant's record: %s", statusRec.Body.String())
+}
+
+// TestUpgradeStatus_NonAdminEmptyTenant_Unauthorized verifies that a NON-admin caller
+// with no tenant still gets 401 on status (regression guard, Issue #1999).
+func TestUpgradeStatus_NonAdminEmptyTenant_Unauthorized(t *testing.T) {
+	server, _ := setupUpgradeServer(t, "tenant-a", nil)
+	server.upgradeStore = newTestUpgradeStore()
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/stewards/upgrade/some-id", nil)
+	req = emptyScopedReq(req)
+	req = mux.SetURLVars(req, map[string]string{"upgrade_id": "some-id"})
+	rec := httptest.NewRecorder()
+	server.handleUpgradeStatus(rec, req)
+
+	assert.Equal(t, http.StatusUnauthorized, rec.Code)
+	assert.Contains(t, rec.Body.String(), "AUTHENTICATION_REQUIRED")
+}
+
+// TestUpgradeStatus_NonAdminCrossTenant_StillForbidden verifies that the existing
+// cross-tenant isolation is preserved for scoped (non-admin) callers (Issue #1999).
+func TestUpgradeStatus_NonAdminCrossTenant_StillForbidden(t *testing.T) {
+	stewards := []fleet.StewardData{
+		{ID: "steward-1", TenantID: "tenant-a", Status: "online"},
+	}
+	server, _ := setupUpgradeServer(t, "tenant-a", stewards)
+	publishApprovedBinary(t, server, "tenant-a", "v0.5.12", "linux", "amd64")
+
+	rec := doDispatchUpgrade(server, "tenant-a", "id:steward-1", "v0.5.12", "linux", "amd64")
+	require.Equal(t, http.StatusAccepted, rec.Code)
+	var resp APIResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	upgradeID := resp.Data.(map[string]interface{})["upgrade_id"].(string)
+
+	// tenant-b (scoped non-admin) must still be forbidden from viewing tenant-a's record.
+	statusRec := doUpgradeStatus(server, "tenant-b", upgradeID)
+	assert.Equal(t, http.StatusForbidden, statusRec.Code)
+}
+
+// TestUpgradeRollback_AdminEmptyTenant_NotUnauthorized verifies that an admin mTLS
+// principal can roll back a record owned by any tenant (no 401, no 403). Two distinct
+// namespaces are at play and must not be conflated (Issue #1999):
+//   - The rollback BINARY is fetched from the admin's "default" blob namespace
+//     (handlers_upgrade.go uses installerBlobTenant(callerTenantID), and an admin's caller
+//     tenant is empty → "default"); it is NOT fetched from the original record's tenant.
+//   - The rollback RECORD's TenantID inherits original.TenantID (effectiveTenantID) so
+//     per-tenant status/listing isolation stays consistent.
+func TestUpgradeRollback_AdminEmptyTenant_NotUnauthorized(t *testing.T) {
+	stewards := []fleet.StewardData{
+		{ID: "steward-1", TenantID: "tenant-a", Status: "online"},
+	}
+	server, upgradeStore := setupUpgradeServer(t, "tenant-a", stewards)
+	publishApprovedBinary(t, server, "tenant-a", "v0.5.12", "linux", "amd64")
+	// The admin rollback fetches the rollback binary from the admin "default" namespace.
+	publishApprovedBinary(t, server, "default", "v0.5.11", "linux", "amd64")
+
+	// Tenant-scoped caller creates and commits the original upgrade record.
+	rec := doDispatchUpgrade(server, "tenant-a", "id:steward-1", "v0.5.12", "linux", "amd64")
+	require.Equal(t, http.StatusAccepted, rec.Code)
+	var resp APIResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	upgradeID := resp.Data.(map[string]interface{})["upgrade_id"].(string)
+	require.NoError(t, upgradeStore.UpdateUpgradeStatus(context.Background(), upgradeID, business.UpgradeStatusCommitted, ""))
+
+	// Admin (empty tenant) rolls back tenant-a's record.
+	rollbackRec := rollbackUpgradeAsAdmin(server, upgradeID, "v0.5.11")
+	require.NotEqual(t, http.StatusUnauthorized, rollbackRec.Code,
+		"admin mTLS principal with empty tenant must not be rejected with 401 on rollback")
+	assert.Equal(t, http.StatusAccepted, rollbackRec.Code, "admin rollback must be accepted: %s", rollbackRec.Body.String())
+
+	// The rollback record must carry the original record's tenant (not empty).
+	var rbResp APIResponse
+	require.NoError(t, json.Unmarshal(rollbackRec.Body.Bytes(), &rbResp))
+	rbID := rbResp.Data.(map[string]interface{})["upgrade_id"].(string)
+	rbRecord, err := upgradeStore.GetUpgrade(context.Background(), rbID)
+	require.NoError(t, err)
+	assert.Equal(t, "tenant-a", rbRecord.TenantID, "admin rollback record must inherit the original record's tenant")
+}
+
+// TestUpgradeRollback_AdminEmptyTenant_BinaryAbsentFromDefault404 pins the actual fetch
+// namespace for an admin rollback: the binary is read from "default", NOT from the original
+// record's tenant. The rollback target binary is published ONLY under the original record's
+// tenant ("tenant-a") and is intentionally absent from "default", so the admin rollback must
+// return 404 — proving the fetch resolves against "default" (Issue #1999).
+func TestUpgradeRollback_AdminEmptyTenant_BinaryAbsentFromDefault404(t *testing.T) {
+	stewards := []fleet.StewardData{
+		{ID: "steward-1", TenantID: "tenant-a", Status: "online"},
+	}
+	server, upgradeStore := setupUpgradeServer(t, "tenant-a", stewards)
+	publishApprovedBinary(t, server, "tenant-a", "v0.5.12", "linux", "amd64")
+	// Rollback target published ONLY under tenant-a, NOT under "default".
+	publishApprovedBinary(t, server, "tenant-a", "v0.5.11", "linux", "amd64")
+
+	rec := doDispatchUpgrade(server, "tenant-a", "id:steward-1", "v0.5.12", "linux", "amd64")
+	require.Equal(t, http.StatusAccepted, rec.Code)
+	var resp APIResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	upgradeID := resp.Data.(map[string]interface{})["upgrade_id"].(string)
+	require.NoError(t, upgradeStore.UpdateUpgradeStatus(context.Background(), upgradeID, business.UpgradeStatusCommitted, ""))
+
+	// Admin rollback must look in "default" (where v0.5.11 is absent) and 404 — not find
+	// the tenant-a copy. This is the negative proof of the actual fetch namespace.
+	rollbackRec := rollbackUpgradeAsAdmin(server, upgradeID, "v0.5.11")
+	require.NotEqual(t, http.StatusUnauthorized, rollbackRec.Code,
+		"admin auth must pass; this asserts the blob namespace, not auth")
+	assert.Equal(t, http.StatusNotFound, rollbackRec.Code,
+		"admin rollback binary is fetched from \"default\", not the record tenant: %s", rollbackRec.Body.String())
+	assert.Contains(t, rollbackRec.Body.String(), "BINARY_NOT_FOUND")
+}
+
+// TestUpgradeRollback_NonAdminEmptyTenant_Unauthorized verifies that a NON-admin caller
+// with no tenant still gets 401 on rollback (regression guard, Issue #1999).
+func TestUpgradeRollback_NonAdminEmptyTenant_Unauthorized(t *testing.T) {
+	server, _ := setupUpgradeServer(t, "tenant-a", nil)
+	server.upgradeStore = newTestUpgradeStore()
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/stewards/upgrade/some-id/rollback",
+		bytes.NewReader([]byte(`{"version":"v0.5.11"}`)))
+	req = emptyScopedReq(req)
+	req = mux.SetURLVars(req, map[string]string{"upgrade_id": "some-id"})
+	rec := httptest.NewRecorder()
+	server.handleUpgradeRollback(rec, req)
+
+	assert.Equal(t, http.StatusUnauthorized, rec.Code)
+	assert.Contains(t, rec.Body.String(), "AUTHENTICATION_REQUIRED")
+}
+
+// --- B2: end-to-end admin delivery-path round-trip (Issue #1999) ---
+
+// capturingControlPlane is a real controlplaneInterfaces.ControlPlaneProvider that records
+// the SignedCommands dispatched through it (including their params). It is NOT a mock — it
+// has no expectations and satisfies the full provider contract.
+type capturingControlPlane struct {
+	mu       sync.Mutex
+	commands []*controlplaneTypes.SignedCommand
+}
+
+func (c *capturingControlPlane) Name() string      { return "capturing" }
+func (c *capturingControlPlane) IsConnected() bool { return true }
+func (c *capturingControlPlane) Initialize(_ context.Context, _ map[string]interface{}) error {
+	return nil
+}
+func (c *capturingControlPlane) Start(_ context.Context) error { return nil }
+func (c *capturingControlPlane) Stop(_ context.Context) error  { return nil }
+func (c *capturingControlPlane) SendCommand(_ context.Context, cmd *controlplaneTypes.SignedCommand) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.commands = append(c.commands, cmd)
+	return nil
+}
+func (c *capturingControlPlane) FanOutCommand(_ context.Context, _ *controlplaneTypes.SignedCommand, _ []string) (*controlplaneTypes.FanOutResult, error) {
+	return nil, fmt.Errorf("FanOutCommand must not be called in this test")
+}
+func (c *capturingControlPlane) SubscribeCommands(_ context.Context, _ string, _ controlplaneInterfaces.CommandHandler) error {
+	return nil
+}
+func (c *capturingControlPlane) PublishEvent(_ context.Context, _ *controlplaneTypes.Event) error {
+	return nil
+}
+func (c *capturingControlPlane) SubscribeEvents(_ context.Context, _ *controlplaneTypes.EventFilter, _ controlplaneInterfaces.EventHandler) error {
+	return nil
+}
+func (c *capturingControlPlane) SendHeartbeat(_ context.Context, _ *controlplaneTypes.Heartbeat) error {
+	return nil
+}
+func (c *capturingControlPlane) SubscribeHeartbeats(_ context.Context, _ controlplaneInterfaces.HeartbeatHandler) error {
+	return nil
+}
+func (c *capturingControlPlane) GetStats(_ context.Context) (*controlplaneTypes.ControlPlaneStats, error) {
+	return &controlplaneTypes.ControlPlaneStats{}, nil
+}
+func (c *capturingControlPlane) Reconnect(_ context.Context) error { return nil }
+
+// downloadURLs returns the download_url param from every captured PushStewardBinary command.
+func (c *capturingControlPlane) downloadURLs() []string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	var out []string
+	for _, cmd := range c.commands {
+		if du, ok := cmd.Command.Params["download_url"].(string); ok {
+			out = append(out, du)
+		}
+	}
+	return out
+}
+
+// doGetStewardBinaryPublic calls handleGetStewardBinaryPublic with the given tenant query
+// param (no auth — the public endpoint authenticates via the binary signature steward-side).
+func doGetStewardBinaryPublic(server *Server, version, platform, arch, tenant string) *httptest.ResponseRecorder {
+	req := httptest.NewRequest(http.MethodGet,
+		"/api/v1/public/steward-binaries/"+version+"/"+platform+"/"+arch+"?tenant="+tenant, nil)
+	req = mux.SetURLVars(req, map[string]string{"version": version, "platform": platform, "arch": arch})
+	rec := httptest.NewRecorder()
+	server.handleGetStewardBinaryPublic(rec, req)
+	return rec
+}
+
+// TestAdminDispatch_EndToEndDeliveryPath_DefaultNamespace exercises the full admin delivery
+// path: admin publish (lands in "default") → admin dispatch (download_url must carry
+// tenant=default, not empty) → public download with ?tenant=default returns those exact bytes.
+// This covers the publish-namespace ↔ dispatch-download-URL ↔ public-download contract that
+// was previously untested (Issue #1999, B2).
+func TestAdminDispatch_EndToEndDeliveryPath_DefaultNamespace(t *testing.T) {
+	stewards := []fleet.StewardData{
+		{ID: "steward-x", TenantID: "tenant-x", Status: "online"},
+	}
+	server, _ := setupUpgradeServer(t, "tenant-x", stewards)
+
+	// Wire a real command publisher backed by a capturing control plane so the dispatch
+	// fan-out goroutine records the download_url it would send to the steward.
+	cp := &capturingControlPlane{}
+	pub, err := commands.New(&commands.Config{
+		ControlPlane: cp,
+		Signer:       nil,
+		Logger:       logging.NewNoopLogger(),
+	})
+	require.NoError(t, err)
+	server.commandPublisher = pub
+
+	// 1. Admin publishes the steward binary via the publish handler (no manual blob seeding),
+	//    proving the publish handler itself lands the blob in "default" for an admin.
+	content := []byte("cfgms-steward-binary-e2e-admin")
+	fix := newStewardBinaryFixture(t)
+	server.stewardBinaryTrustStore = fix.store
+	sigBase64 := fix.signContent(content)
+	pubRec := publishWithPrincipal(server, withAdminPrincipal, "v0.5.12", "linux", "amd64", sigBase64, content)
+	require.Equal(t, http.StatusOK, pubRec.Code, "admin publish must succeed: %s", pubRec.Body.String())
+
+	// The publish path does not auto-approve; dispatch requires approved_by. Re-publish the
+	// same content with the approved label into "default" so dispatch's approval gate passes.
+	approvedContent := publishApprovedBinary(t, server, "default", "v0.5.12", "linux", "amd64")
+
+	// 2. Admin dispatches the upgrade.
+	rec := dispatchUpgradeAsAdmin(server, "id:steward-x", "v0.5.12", "linux", "amd64")
+	require.Equal(t, http.StatusAccepted, rec.Code, "admin dispatch must be accepted: %s", rec.Body.String())
+
+	// The dispatch fan-out runs in a background goroutine; wait for the command to land.
+	require.Eventually(t, func() bool {
+		return len(cp.downloadURLs()) > 0
+	}, 2*time.Second, 5*time.Millisecond, "dispatch must publish a PushStewardBinary command")
+
+	// 2a. The download_url must carry tenant=default (not empty), pointing at the public path.
+	urls := cp.downloadURLs()
+	require.Len(t, urls, 1)
+	assert.Contains(t, urls[0], "tenant=default",
+		"admin dispatch download_url must reference the default namespace: %s", urls[0])
+	assert.NotRegexp(t, `tenant=($|&)`, urls[0], "download_url tenant param must not be empty")
+	assert.Contains(t, urls[0], "/api/v1/public/steward-binaries/v0.5.12/linux/amd64",
+		"download_url must target the public download endpoint")
+
+	// 2b. The public download endpoint with ?tenant=default returns the approved binary that
+	//     was published under "default", closing the delivery loop.
+	getRec := doGetStewardBinaryPublic(server, "v0.5.12", "linux", "amd64", "default")
+	require.Equal(t, http.StatusOK, getRec.Code,
+		"public download with tenant=default must return the published binary: %s", getRec.Body.String())
+	assert.Equal(t, approvedContent, getRec.Body.Bytes(),
+		"public download must return the exact bytes published under default")
 }


### PR DESCRIPTION
## Summary

Fixes #1999. `cfg installer publish --kind=steward` and `cfg steward upgrade/status/rollback` via the admin mTLS bundle returned 401 — the installer/upgrade handlers rejected the admin's empty tenant before the admin-aware logic. Same class as #1990 (which fixed the run handlers).

## Change

Reuse `Server.authRunAccess` (the #1990 helper) across `handlePublishStewardBinary`, `handleGetStewardBinary`, `handleDispatchUpgrade`, `handleUpgradeStatus`, `handleUpgradeRollback`: authenticate on the principal; reject empty tenant only for non-admin; admin mTLS principals proceed globally. Admin uses the `"default"` blob namespace (`installerBlobTenant`, mirroring `handlers_configs.go`); admin-dispatched upgrade records are attributed to the target steward's tenant; rollback records inherit the original record's tenant. Tenant isolation for non-admin (API-key) callers preserved on every endpoint (cross-tenant publish/dispatch/status/rollback still 403/404).

## Review

Adversarial team: acceptance ✅, security ✅ (IsAdmin cert-gated only; no new cross-tenant exposure; publish↔dispatch blob namespaces consistent; downstream signature/approval/host-pin checks intact), QA-code ✅ (after test-quality fixes), tests green.

## Tests

admin empty-tenant not-401 on publish/get/dispatch/status/rollback; non-admin empty-tenant still-401; cross-tenant isolation preserved; end-to-end admin publish→dispatch→public-download round-trip (real control plane, no mocks) asserting `download_url` carries `tenant=default`; rollback-binary-absent-from-default → 404 (negative proof); auth-before-isolation ordering pinned.

Unblocks checkpoint #2 (paste-free `cfg steward upgrade`). Follow-up: rename authRunAccess to a tenant-neutral name (now shared across run/installer/upgrade).

🤖 Generated with [Claude Code](https://claude.com/claude-code)