### PR TITLE
cfg: unwrap {data:...} envelope in steward upgrade client (Issue #2006)

### DIFF
--- a/cmd/cfg/cmd/api_client.go
+++ b/cmd/cfg/cmd/api_client.go
@@ -603,9 +603,16 @@ func (c *APIClient) DispatchUpgrade(ctx context.Context, req *APIDispatchUpgrade
 		return nil, c.parseError(resp)
 	}
 
-	var result APIDispatchUpgradeResponse
-	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+	// Unwrap APIResponse envelope: {"data": {...}, "timestamp": "..."}
+	var envelope struct {
+		Data json.RawMessage `json:"data"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&envelope); err != nil {
 		return nil, fmt.Errorf("failed to decode response: %w", err)
+	}
+	var result APIDispatchUpgradeResponse
+	if err := json.Unmarshal(envelope.Data, &result); err != nil {
+		return nil, fmt.Errorf("failed to decode dispatch data: %w", err)
 	}
 	return &result, nil
 }
@@ -634,9 +641,16 @@ func (c *APIClient) GetUpgradeStatusWithHTTPStatus(ctx context.Context, upgradeI
 		return nil, resp.StatusCode, c.parseError(resp)
 	}
 
-	var result APIUpgradeStatusResponse
-	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+	// Unwrap APIResponse envelope: {"data": {...}, "timestamp": "..."}
+	var envelope struct {
+		Data json.RawMessage `json:"data"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&envelope); err != nil {
 		return nil, resp.StatusCode, fmt.Errorf("failed to decode response: %w", err)
+	}
+	var result APIUpgradeStatusResponse
+	if err := json.Unmarshal(envelope.Data, &result); err != nil {
+		return nil, resp.StatusCode, fmt.Errorf("failed to decode status data: %w", err)
 	}
 	return &result, resp.StatusCode, nil
 }
@@ -656,9 +670,16 @@ func (c *APIClient) ListUpgradeStatusBySelector(ctx context.Context, selector st
 		return nil, c.parseError(resp)
 	}
 
-	var result APIUpgradeStatusResponse
-	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+	// Unwrap APIResponse envelope: {"data": {...}, "timestamp": "..."}
+	var envelope struct {
+		Data json.RawMessage `json:"data"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&envelope); err != nil {
 		return nil, fmt.Errorf("failed to decode response: %w", err)
+	}
+	var result APIUpgradeStatusResponse
+	if err := json.Unmarshal(envelope.Data, &result); err != nil {
+		return nil, fmt.Errorf("failed to decode status data: %w", err)
 	}
 	return &result, nil
 }
@@ -680,9 +701,16 @@ func (c *APIClient) RollbackUpgrade(ctx context.Context, upgradeID string, req *
 		return nil, c.parseError(resp)
 	}
 
-	var result APIUpgradeStatusResponse
-	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+	// Unwrap APIResponse envelope: {"data": {...}, "timestamp": "..."}
+	var envelope struct {
+		Data json.RawMessage `json:"data"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&envelope); err != nil {
 		return nil, fmt.Errorf("failed to decode response: %w", err)
+	}
+	var result APIUpgradeStatusResponse
+	if err := json.Unmarshal(envelope.Data, &result); err != nil {
+		return nil, fmt.Errorf("failed to decode rollback data: %w", err)
 	}
 	return &result, nil
 }

--- a/cmd/cfg/cmd/steward_upgrade_test.go
+++ b/cmd/cfg/cmd/steward_upgrade_test.go
@@ -55,22 +55,32 @@ func saveStewardUpgradeGlobals(t *testing.T) {
 	})
 }
 
-// writeUpgradeDispatchResponse writes a canned dispatch 202 response.
-func writeUpgradeDispatchResponse(w http.ResponseWriter, upgradeID string, stewardCount int) {
+// writeEnvelopedResponse mirrors the controller's writeResponse: it wraps the
+// payload in the {"data": {...}, "timestamp": "..."} envelope so test mocks
+// produce the exact shape the real controller returns.
+func writeEnvelopedResponse(w http.ResponseWriter, statusCode int, data interface{}) {
 	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(http.StatusAccepted)
-	_ = json.NewEncoder(w).Encode(APIDispatchUpgradeResponse{
+	w.WriteHeader(statusCode)
+	_ = json.NewEncoder(w).Encode(map[string]interface{}{
+		"data":      data,
+		"timestamp": time.Now().UTC(),
+	})
+}
+
+// writeUpgradeDispatchResponse writes a canned dispatch 202 response in the
+// controller envelope shape.
+func writeUpgradeDispatchResponse(w http.ResponseWriter, upgradeID string, stewardCount int) {
+	writeEnvelopedResponse(w, http.StatusAccepted, APIDispatchUpgradeResponse{
 		UpgradeID:    upgradeID,
 		StewardCount: stewardCount,
 		Status:       "accepted",
 	})
 }
 
-// writeUpgradeStatusResponse writes a canned upgrade status response.
+// writeUpgradeStatusResponse writes a canned upgrade status response in the
+// controller envelope shape.
 func writeUpgradeStatusResponse(w http.ResponseWriter, upgradeID string, stewards []APIUpgradeStewardStatus) {
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(http.StatusOK)
-	_ = json.NewEncoder(w).Encode(APIUpgradeStatusResponse{
+	writeEnvelopedResponse(w, http.StatusOK, APIUpgradeStatusResponse{
 		UpgradeID: upgradeID,
 		Stewards:  stewards,
 	})
@@ -490,9 +500,7 @@ func TestRunStewardUpgradeRollback_Success(t *testing.T) {
 		stewards := []APIUpgradeStewardStatus{
 			{Device: "device-1", Status: "rolled_back"},
 		}
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusOK)
-		_ = json.NewEncoder(w).Encode(APIUpgradeStatusResponse{
+		writeEnvelopedResponse(w, http.StatusOK, APIUpgradeStatusResponse{
 			UpgradeID: "upgrade-rollback-id",
 			Stewards:  stewards,
 		})
@@ -529,9 +537,7 @@ func TestRunStewardUpgradeRollback_WithToVersion(t *testing.T) {
 		stewards := []APIUpgradeStewardStatus{
 			{Device: "device-1", Status: "rolled_back"},
 		}
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusOK)
-		_ = json.NewEncoder(w).Encode(APIUpgradeStatusResponse{
+		writeEnvelopedResponse(w, http.StatusOK, APIUpgradeStatusResponse{
 			UpgradeID: "upgrade-tv-id",
 			Stewards:  stewards,
 		})
@@ -555,9 +561,7 @@ func TestRunStewardUpgradeRollback_WithToVersion(t *testing.T) {
 
 func TestRunStewardUpgradeRollback_EmptyResult(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusOK)
-		_ = json.NewEncoder(w).Encode(APIUpgradeStatusResponse{
+		writeEnvelopedResponse(w, http.StatusOK, APIUpgradeStatusResponse{
 			UpgradeID: "upgrade-empty-rollback-id",
 			Stewards:  []APIUpgradeStewardStatus{},
 		})


### PR DESCRIPTION
## What

Fixes `cfg steward upgrade` printing an empty `Upgrade id:` and `Dispatched to: 0 stewards` even though the controller returns 202 and dispatches the command (and `--wait`/`status` then 404 on the empty id). Fixes #2006.

## Root cause

The controller wraps every response in `{"data": {...}, "timestamp": ...}` (writeResponse), but the cfg upgrade client decoded the body **flat** into the payload struct — Go's decoder silently ignores the unknown top-level `data`/`timestamp` keys and yields a zero-value struct with no error. Other CLI methods already unwrap the envelope; the four upgrade methods didn't.

## Fix

`DispatchUpgrade`, `GetUpgradeStatusWithHTTPStatus`, `ListUpgradeStatusBySelector`, `RollbackUpgrade` now decode `struct{ Data json.RawMessage }` then unmarshal `data` into the payload — matching the existing pattern (api_client.go CreateTenantViaAPI/GetTenantViaAPI). Status checks/error handling unchanged. Controller untouched.

## Why it shipped / test fidelity

The upgrade test mocks returned flat JSON, so the flat decode "worked" in tests. The mocks now emit the real `{"data": ...}` envelope (writeEnvelopedResponse mirrors writeResponse). Verified: the enveloped tests FAIL against the old flat-decode code and PASS after the fix.

## Live evidence

Controller logged `POST /api/v1/stewards/upgrade status=202` + `CommandPushStewardBinary dispatched upgrade_id=... version=v0.5.6` while the CLI printed empty/0. The upgrade applied correctly (proven via the live auto-apply on cfg-lab); only the CLI display + wait/status were affected.

## Note (separate, pre-existing)

QA flagged that `ListUpgradeStatusBySelector` targets `GET /api/v1/stewards/upgrade?selector=...`, for which the server may not register a route (would 405). That's independent of this envelope-decode fix (the by-id status path and dispatch/--wait are fixed here); tracking separately if confirmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
