### PR TITLE
controller: repopulate admin steward registry on authenticated reconnect (Issue #2008)

### DIFF
--- a/features/controller/server/server.go
+++ b/features/controller/server/server.go
@@ -453,11 +453,18 @@ func New(cfg *config.Config, logger logging.Logger) (*Server, error) {
 		// we can inject it as the on-connect hook. The publisher is wired after
 		// commandPublisher is constructed below (breaks the init cycle).
 		connRegistry = registry.NewRegistry()
+		// Issue #2008: compose the admin-registry upsert hook alongside the
+		// signing-rotation hook so every authenticated (re)connect repopulates
+		// ControllerService.s.stewards (which backs cfg steward list/status/exec).
+		// A cert-reuse reconnect never re-runs HTTP registration, so without this
+		// the registry stays empty for a reconnecting steward until a restart.
+		registryConnectHook := service.NewStewardRegistryConnectHook(controllerService, logger)
 		if certManager != nil {
 			signingRotationSvc = service.NewSigningRotationService(certManager, logger)
-			controlPlane = grpcCP.New(grpcCP.ModeServer, grpcCP.WithOnConnectHook(signingRotationSvc))
+			composite := service.NewCompositeOnConnectHook(logger, signingRotationSvc, registryConnectHook)
+			controlPlane = grpcCP.New(grpcCP.ModeServer, grpcCP.WithOnConnectHook(composite))
 		} else {
-			controlPlane = grpcCP.New(grpcCP.ModeServer)
+			controlPlane = grpcCP.New(grpcCP.ModeServer, grpcCP.WithOnConnectHook(registryConnectHook))
 		}
 		if err := controlPlane.Initialize(context.Background(), map[string]interface{}{
 			"mode":       "server",

--- a/features/controller/service/controller_service.go
+++ b/features/controller/service/controller_service.go
@@ -355,24 +355,175 @@ func (s *ControllerService) RecordHeartbeat(stewardID, version string, ts time.T
 		ts = time.Now()
 	}
 
+	// Fast path: the steward is already in the registry. Hold the lock only long
+	// enough to mutate the in-memory entry; never call storage under s.mu.
 	s.mu.Lock()
-	defer s.mu.Unlock()
+	if steward, exists := s.stewards[stewardID]; exists {
+		steward.LastHeartbeat = ts
+		if version != "" {
+			steward.Version = version
+		}
+		// Promote registered -> active on the first heartbeat. Leave any other
+		// lifecycle status (e.g. an operator-set state) untouched.
+		if steward.Status == "" || steward.Status == "registered" {
+			steward.Status = "active"
+		}
+		s.mu.Unlock()
+		return true
+	}
+	s.mu.Unlock()
 
-	steward, exists := s.stewards[stewardID]
-	if !exists {
+	// BACKSTOP (Issue #2008): a steward that reconnected via cert-reuse never
+	// re-runs HTTP registration, so it can heartbeat while absent from this
+	// registry (e.g. after a controller restart that warm-loaded nothing for it).
+	// Self-heal by adding it — but ONLY when we can resolve its tenant
+	// authoritatively from durable storage. The tenant drives exec cross-tenant
+	// scoping (api/handlers_runs.go enforceExecTenantScope) and the config storage
+	// location, so fabricating an entry with a wrong or empty tenant is worse than
+	// leaving it absent. When no durable tenant is available we decline here and
+	// let the connect hook (which has the same authoritative lookup) handle it,
+	// preserving the no-fabrication contract.
+	//
+	// The durable lookup is blocking storage I/O, so it runs OUTSIDE s.mu to keep
+	// the whole registry from serializing behind storage at fleet scale (50k+
+	// stewards, amplified under heartbeat flapping).
+	tenantID, dna, ok := s.lookupDurableTenant(stewardID)
+	if !ok {
 		return false
 	}
 
-	steward.LastHeartbeat = ts
-	if version != "" {
-		steward.Version = version
+	// Re-acquire and double-check: a concurrent connect-hook upsert or another
+	// heartbeat may have inserted the steward while the lock was released. Refresh
+	// the existing entry rather than overwriting it.
+	s.mu.Lock()
+	if steward, exists := s.stewards[stewardID]; exists {
+		steward.LastHeartbeat = ts
+		if version != "" {
+			steward.Version = version
+		}
+		if steward.Status == "" || steward.Status == "registered" {
+			steward.Status = "active"
+		}
+		s.mu.Unlock()
+		return true
 	}
-	// Promote registered -> active on the first heartbeat. Leave any other
-	// lifecycle status (e.g. an operator-set state) untouched.
-	if steward.Status == "" || steward.Status == "registered" {
-		steward.Status = "active"
+	s.stewards[stewardID] = &StewardInfo{
+		ID:            stewardID,
+		TenantID:      tenantID,
+		Version:       version,
+		DNA:           dna,
+		LastHeartbeat: ts,
+		Status:        "active",
+		Metrics:       make(map[string]string),
 	}
+	s.mu.Unlock()
+
+	// Persist so the durable record's timestamp is refreshed consistently with
+	// EnsureSteward. storeDNA runs outside s.mu.
+	s.storeDNA(context.Background(), stewardID, tenantID, dna, "active")
 	return true
+}
+
+// EnsureSteward upserts a steward into the in-memory admin registry on an
+// authenticated (re)connect (Issue #2008). It is the PRIMARY fix for the
+// cert-reuse reconnect gap: the steward's normal reconnect reuses its existing
+// certificate and returns WITHOUT calling HTTP /register, so RegisterSteward —
+// the only other live-path writer — never runs. Wired to the gRPC OnConnect hook
+// (server.go), it fires on every successful ControlChannel registration with the
+// mTLS-authenticated CN, making a reconnecting steward visible to
+// list/status/exec without waiting for a second controller restart.
+//
+// Behaviour:
+//   - Absent: add a "active" entry. Tenant is resolved authoritatively from
+//     durable storage; the supplied tenantID is used only as a fallback and is
+//     never preferred over a storage-derived value. DNA is persisted (mirroring
+//     RegisterSteward) so the entry survives a later controller restart.
+//   - Present: refresh LastHeartbeat and promote registered -> active.
+//
+// Idempotent: repeated calls do not duplicate the entry.
+//
+// "Truly new" steward (no durable record AND no supplied tenant): no-op. A
+// genuinely new steward reaches the controller through HTTP registration first,
+// which mints its durable record; declining here avoids creating an entry with
+// an unknown tenant that would corrupt cross-tenant exec scoping.
+func (s *ControllerService) EnsureSteward(stewardID, tenantID, status string) {
+	if stewardID == "" {
+		return
+	}
+	if status == "" {
+		status = "active"
+	}
+	now := time.Now()
+
+	// Resolve the authoritative tenant from durable storage. The storage-derived
+	// tenant always wins over the caller-supplied value, which (for the connect
+	// hook) is empty anyway — the hook only knows the mTLS CN, never a tenant.
+	durableTenant, durableDNA, haveDurable := s.lookupDurableTenant(stewardID)
+	if haveDurable {
+		tenantID = durableTenant
+	}
+
+	s.mu.Lock()
+	if existing, ok := s.stewards[stewardID]; ok {
+		existing.LastHeartbeat = now
+		if existing.Status == "" || existing.Status == "registered" {
+			existing.Status = "active"
+		}
+		s.mu.Unlock()
+		return
+	}
+
+	if !haveDurable && tenantID == "" {
+		// Truly new steward we have no authoritative tenant for: decline rather
+		// than fabricate an entry with an unknown tenant. HTTP registration is
+		// the correct first-contact path and will populate the registry.
+		s.mu.Unlock()
+		s.logger.Debug("EnsureSteward declined: no durable tenant for unknown steward",
+			"steward_id", logging.SanitizeLogValue(stewardID))
+		return
+	}
+
+	dna := durableDNA
+	if dna == nil {
+		dna = &common.DNA{Id: stewardID}
+	}
+	s.stewards[stewardID] = &StewardInfo{
+		ID:            stewardID,
+		TenantID:      tenantID,
+		DNA:           dna,
+		LastHeartbeat: now,
+		Status:        status,
+		Metrics:       make(map[string]string),
+	}
+	s.mu.Unlock()
+
+	// Persist so the entry survives a later restart's warm-load, mirroring
+	// RegisterSteward's durable write.
+	s.storeDNA(context.Background(), stewardID, tenantID, dna, status)
+
+	s.logger.Info("Steward ensured in registry on authenticated connect",
+		"steward_id", logging.SanitizeLogValue(stewardID),
+		"tenant_id", logging.SanitizeLogValue(tenantID),
+		"status", logging.SanitizeLogValue(status))
+}
+
+// lookupDurableTenant resolves a steward's authoritative tenant (and last DNA
+// snapshot) from durable storage by stewardID. The tenant comes from the
+// registration-minted DNA record, never from a steward-supplied value, so that
+// cross-tenant exec scoping and config storage paths stay correct (Issue #2008).
+//
+// Returns ok=false when there is no durable backend or no record for the
+// steward; callers must treat that as "tenant unknown" and decline to fabricate
+// a tenant-scoped registry entry.
+func (s *ControllerService) lookupDurableTenant(stewardID string) (tenantID string, dna *common.DNA, ok bool) {
+	if s.dnaStorage == nil {
+		return "", nil, false
+	}
+	record, err := s.dnaStorage.GetLatestByDeviceID(context.Background(), stewardID)
+	if err != nil || record == nil {
+		return "", nil, false
+	}
+	return record.TenantID, record.DNA, true
 }
 
 // RegisterSteward records or updates a steward that registered via the HTTP path.

--- a/features/controller/service/controller_service_test.go
+++ b/features/controller/service/controller_service_test.go
@@ -4,6 +4,7 @@ package service
 
 import (
 	"context"
+	"sync"
 	"testing"
 	"time"
 
@@ -449,4 +450,216 @@ func TestRegisterSteward_FieldsPopulated(t *testing.T) {
 	assert.Equal(t, "registered", info.Status)
 	assert.True(t, !info.LastHeartbeat.Before(before))
 	assert.True(t, !info.LastHeartbeat.After(after))
+}
+
+// --- Issue #2008: registry repopulation on cert-reuse reconnect / restart ---
+
+// TestEnsureSteward_AddsAbsentStewardWithDurableTenant proves the PRIMARY fix:
+// a steward that reconnects via cert-reuse (no fresh HTTP registration) is added
+// to the admin registry on the authenticated connect, with its tenant resolved
+// authoritatively from durable storage.
+func TestEnsureSteward_AddsAbsentStewardWithDurableTenant(t *testing.T) {
+	storage := newTestFleetStorage(t)
+	ctx := context.Background()
+
+	// Seed durable storage as if the steward had registered in a previous run.
+	dna := makeTestDNA("dev-1", map[string]string{"os": "linux"})
+	require.NoError(t, storage.Store(ctx, "dev-1", dna, &fleetStorage.StoreOptions{TenantID: "tenant-a", Status: "registered"}))
+
+	// Fresh service WITHOUT warm-load: the steward is absent from the registry,
+	// exactly the cert-reuse reconnect gap.
+	svc := NewControllerServiceWithStorage(logging.NewNoopLogger(), storage)
+	_, found := svc.GetStewardInfo("dev-1")
+	require.False(t, found, "precondition: steward must be absent before the connect hook fires")
+
+	// Connect hook supplies only the mTLS CN and an empty tenant.
+	svc.EnsureSteward("dev-1", "", "active")
+
+	info, ok := svc.GetStewardInfo("dev-1")
+	require.True(t, ok, "EnsureSteward must add the absent steward")
+	assert.Equal(t, "active", info.Status)
+	assert.Equal(t, "tenant-a", info.TenantID, "tenant must come from durable storage, not the empty hook value")
+	assert.NotNil(t, info.DNA)
+}
+
+// TestEnsureSteward_IgnoresCallerTenantWhenDurableExists proves a steward-supplied
+// tenant can never override the authoritative storage-derived tenant.
+func TestEnsureSteward_IgnoresCallerTenantWhenDurableExists(t *testing.T) {
+	storage := newTestFleetStorage(t)
+	ctx := context.Background()
+
+	dna := makeTestDNA("dev-1", map[string]string{"os": "linux"})
+	require.NoError(t, storage.Store(ctx, "dev-1", dna, &fleetStorage.StoreOptions{TenantID: "tenant-real", Status: "registered"}))
+
+	svc := NewControllerServiceWithStorage(logging.NewNoopLogger(), storage)
+
+	// A hostile/incorrect tenant is passed in; storage must win.
+	svc.EnsureSteward("dev-1", "tenant-attacker", "active")
+
+	info, ok := svc.GetStewardInfo("dev-1")
+	require.True(t, ok)
+	assert.Equal(t, "tenant-real", info.TenantID, "durable tenant must override any caller-supplied tenant")
+}
+
+// TestEnsureSteward_RefreshesExistingWithoutDuplicating proves idempotence: an
+// already-present entry is refreshed (LastHeartbeat advanced, registered->active)
+// rather than duplicated.
+func TestEnsureSteward_RefreshesExistingWithoutDuplicating(t *testing.T) {
+	svc := NewControllerService(logging.NewNoopLogger())
+
+	old := time.Now().Add(-time.Hour)
+	svc.mu.Lock()
+	svc.stewards["dev-1"] = &StewardInfo{
+		ID:            "dev-1",
+		TenantID:      "tenant-a",
+		LastHeartbeat: old,
+		Status:        "registered",
+		Metrics:       make(map[string]string),
+	}
+	svc.mu.Unlock()
+
+	svc.EnsureSteward("dev-1", "", "active")
+
+	assert.Equal(t, 1, svc.GetStewardCount(), "existing steward must not be duplicated")
+	info, ok := svc.GetStewardInfo("dev-1")
+	require.True(t, ok)
+	assert.Equal(t, "active", info.Status, "registered must be promoted to active on reconnect")
+	assert.True(t, info.LastHeartbeat.After(old), "LastHeartbeat must be refreshed")
+	assert.Equal(t, "tenant-a", info.TenantID, "tenant must be preserved")
+}
+
+// TestEnsureSteward_TrulyNewStewardNoOp proves the safe behaviour for a steward
+// with no durable record and no supplied tenant: EnsureSteward declines rather
+// than fabricating an entry with an unknown tenant (HTTP registration is the
+// correct first-contact path).
+func TestEnsureSteward_TrulyNewStewardNoOp(t *testing.T) {
+	storage := newTestFleetStorage(t)
+	svc := NewControllerServiceWithStorage(logging.NewNoopLogger(), storage)
+
+	svc.EnsureSteward("brand-new", "", "active")
+
+	_, found := svc.GetStewardInfo("brand-new")
+	assert.False(t, found, "a steward with no durable tenant must not be fabricated")
+	assert.Equal(t, 0, svc.GetStewardCount())
+}
+
+// TestEnsureSteward_SurvivesControllerRestart proves the upserted entry is
+// persisted to durable storage so a later restart's warm-load finds it.
+func TestEnsureSteward_SurvivesControllerRestart(t *testing.T) {
+	dataDir := t.TempDir()
+	ctx := context.Background()
+
+	// Run 1: seed registration record, then a reconnecting steward is ensured.
+	mgr1 := openFleetStorageAt(t, dataDir)
+	dna := makeTestDNA("dev-1", map[string]string{"os": "linux"})
+	require.NoError(t, mgr1.Store(ctx, "dev-1", dna, &fleetStorage.StoreOptions{TenantID: "tenant-a", Status: "registered"}))
+	svc1 := NewControllerServiceWithStorage(logging.NewNoopLogger(), mgr1)
+	svc1.EnsureSteward("dev-1", "", "active")
+	info1, ok := svc1.GetStewardInfo("dev-1")
+	require.True(t, ok)
+	assert.Equal(t, "active", info1.Status)
+	require.NoError(t, mgr1.Close())
+
+	// Run 2: simulated restart — fresh manager + service, warm-load from disk.
+	mgr2 := openFleetStorageAt(t, dataDir)
+	t.Cleanup(func() { _ = mgr2.Close() })
+	svc2 := NewControllerServiceWithStorage(logging.NewNoopLogger(), mgr2)
+	require.NoError(t, svc2.LoadFromStorage(ctx))
+
+	info2, ok := svc2.GetStewardInfo("dev-1")
+	require.True(t, ok, "ensured steward must survive a controller restart via warm-load")
+	assert.Equal(t, "tenant-a", info2.TenantID)
+	assert.Equal(t, "active", info2.Status, "persisted status must round-trip as active across restart")
+	assert.NotNil(t, info2.DNA, "DNA must round-trip across restart")
+}
+
+// TestEnsureSteward_ConcurrentCallsNoDuplicate proves the check-and-insert under
+// s.mu serializes concurrent connect-hook upserts: many simultaneous
+// EnsureSteward calls for the same steward produce exactly one registry entry
+// (no TOCTOU duplicate) carrying the durable tenant.
+func TestEnsureSteward_ConcurrentCallsNoDuplicate(t *testing.T) {
+	storage := newTestFleetStorage(t)
+	ctx := context.Background()
+	dna := makeTestDNA("dev-1", map[string]string{"os": "linux"})
+	require.NoError(t, storage.Store(ctx, "dev-1", dna, &fleetStorage.StoreOptions{TenantID: "tenant-a", Status: "registered"}))
+
+	svc := NewControllerServiceWithStorage(logging.NewNoopLogger(), storage)
+
+	const goroutines = 16
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			defer wg.Done()
+			svc.EnsureSteward("dev-1", "", "active")
+		}()
+	}
+	wg.Wait()
+
+	assert.Equal(t, 1, svc.GetStewardCount(), "concurrent EnsureSteward must not duplicate the entry")
+	info, ok := svc.GetStewardInfo("dev-1")
+	require.True(t, ok)
+	assert.Equal(t, "tenant-a", info.TenantID)
+	assert.Equal(t, "active", info.Status)
+}
+
+// TestRecordHeartbeat_BackstopAddsAbsentStewardWithDurableTenant proves the
+// BACKSTOP: a heartbeat from a steward absent in the registry self-heals within
+// one beat when a durable tenant is resolvable.
+func TestRecordHeartbeat_BackstopAddsAbsentStewardWithDurableTenant(t *testing.T) {
+	storage := newTestFleetStorage(t)
+	ctx := context.Background()
+
+	dna := makeTestDNA("dev-1", map[string]string{"os": "linux"})
+	require.NoError(t, storage.Store(ctx, "dev-1", dna, &fleetStorage.StoreOptions{TenantID: "tenant-a", Status: "registered"}))
+
+	svc := NewControllerServiceWithStorage(logging.NewNoopLogger(), storage)
+	_, found := svc.GetStewardInfo("dev-1")
+	require.False(t, found, "precondition: steward absent before heartbeat")
+
+	beat := time.Now()
+	ok := svc.RecordHeartbeat("dev-1", "v1", beat)
+	require.True(t, ok, "backstop must record the heartbeat for an absent-but-known steward")
+
+	info, found := svc.GetStewardInfo("dev-1")
+	require.True(t, found, "backstop must add the absent steward")
+	assert.Equal(t, "active", info.Status)
+	assert.Equal(t, "tenant-a", info.TenantID, "tenant must be durable-derived, not steward-supplied")
+	assert.WithinDuration(t, beat, info.LastHeartbeat, time.Millisecond)
+}
+
+// TestRecordHeartbeat_BackstopDeclinesWithoutDurableTenant proves the
+// no-fabrication contract is preserved when no durable tenant exists: rather
+// than guessing a tenant, RecordHeartbeat returns false and leaves repopulation
+// to the connect hook / HTTP registration.
+func TestRecordHeartbeat_BackstopDeclinesWithoutDurableTenant(t *testing.T) {
+	storage := newTestFleetStorage(t)
+	svc := NewControllerServiceWithStorage(logging.NewNoopLogger(), storage)
+
+	ok := svc.RecordHeartbeat("ghost", "v1", time.Now())
+	assert.False(t, ok, "no durable tenant -> must not fabricate a tenant-scoped entry")
+	_, found := svc.GetStewardInfo("ghost")
+	assert.False(t, found)
+}
+
+// TestRecordHeartbeat_BackstopRefreshesExisting proves the backstop does not
+// duplicate or disturb an already-present entry.
+func TestRecordHeartbeat_BackstopRefreshesExisting(t *testing.T) {
+	storage := newTestFleetStorage(t)
+	ctx := context.Background()
+	dna := makeTestDNA("dev-1", map[string]string{"os": "linux"})
+	require.NoError(t, storage.Store(ctx, "dev-1", dna, &fleetStorage.StoreOptions{TenantID: "tenant-a", Status: "registered"}))
+
+	svc := NewControllerServiceWithStorage(logging.NewNoopLogger(), storage)
+	require.NoError(t, svc.LoadFromStorage(ctx))
+	require.Equal(t, 1, svc.GetStewardCount())
+
+	beat := time.Now()
+	ok := svc.RecordHeartbeat("dev-1", "v2", beat)
+	require.True(t, ok)
+
+	assert.Equal(t, 1, svc.GetStewardCount(), "existing steward must not be duplicated by the backstop")
+	info, _ := svc.GetStewardInfo("dev-1")
+	assert.Equal(t, "active", info.Status)
+	assert.Equal(t, "v2", info.Version)
 }

--- a/features/controller/service/steward_connect_hook.go
+++ b/features/controller/service/steward_connect_hook.go
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+
+package service
+
+import (
+	"context"
+
+	"github.com/cfgis/cfgms/pkg/logging"
+)
+
+// StewardRegistryConnectHook upserts a steward into the admin registry on every
+// authenticated (re)connect (Issue #2008). It implements the gRPC
+// StewardOnConnectHook contract (OnConnect(ctx, stewardID) error).
+//
+// This is the PRIMARY fix for the cert-reuse reconnect gap: a steward's normal
+// reconnect reuses its existing certificate and returns WITHOUT calling HTTP
+// /register, so the registry's only live-path writer (RegisterSteward) never
+// runs. The connect hook fires on every successful ControlChannel registration
+// with the mTLS-authenticated CN, so list/status/exec see the steward again
+// without waiting for a controller restart.
+//
+// Tenant is resolved authoritatively inside EnsureSteward from durable storage
+// by stewardID; the hook only carries the mTLS CN and never supplies a tenant,
+// so cross-tenant exec scoping cannot be influenced by a steward-supplied value.
+type StewardRegistryConnectHook struct {
+	controllerService *ControllerService
+	logger            logging.Logger
+}
+
+// NewStewardRegistryConnectHook constructs the registry connect hook.
+func NewStewardRegistryConnectHook(controllerService *ControllerService, logger logging.Logger) *StewardRegistryConnectHook {
+	return &StewardRegistryConnectHook{
+		controllerService: controllerService,
+		logger:            logger,
+	}
+}
+
+// OnConnect implements the StewardOnConnectHook interface. stewardID is the
+// mTLS-authenticated CN of the connecting steward. EnsureSteward upserts the
+// registry entry and resolves the tenant from durable storage; the empty tenant
+// passed here is only a fallback EnsureSteward ignores when a durable record
+// exists. Fail-open: EnsureSteward never errors, so the stream is never refused.
+func (h *StewardRegistryConnectHook) OnConnect(_ context.Context, stewardID string) error {
+	if h == nil || h.controllerService == nil {
+		return nil
+	}
+	h.controllerService.EnsureSteward(stewardID, "", "active")
+	return nil
+}
+
+// CompositeOnConnectHook chains multiple StewardOnConnectHook implementations so
+// the single hook slot on the gRPC provider can drive several independent
+// on-connect concerns (e.g. signing-cert refresh AND admin-registry upsert).
+// Hooks run in order; one hook's error does not prevent later hooks from
+// running, and all errors are joined into the returned error (logged fail-open
+// by the provider).
+type CompositeOnConnectHook struct {
+	hooks  []onConnectHook
+	logger logging.Logger
+}
+
+// onConnectHook is the minimal contract the composite chains. It matches the
+// gRPC StewardOnConnectHook interface without importing the provider package
+// (avoids an import cycle: the provider already depends on this package's hooks
+// only structurally, via the interface).
+type onConnectHook interface {
+	OnConnect(ctx context.Context, stewardID string) error
+}
+
+// NewCompositeOnConnectHook builds a composite from the given hooks, skipping
+// nil entries so callers can pass optionally-constructed hooks directly.
+func NewCompositeOnConnectHook(logger logging.Logger, hooks ...onConnectHook) *CompositeOnConnectHook {
+	filtered := make([]onConnectHook, 0, len(hooks))
+	for _, h := range hooks {
+		if h == nil {
+			continue
+		}
+		filtered = append(filtered, h)
+	}
+	return &CompositeOnConnectHook{hooks: filtered, logger: logger}
+}
+
+// OnConnect runs every chained hook. A hook error is logged and the chain
+// continues, so an admin-registry upsert is not skipped because a signing-cert
+// push failed (or vice versa). The first non-nil error is returned for the
+// provider's fail-open logging.
+func (c *CompositeOnConnectHook) OnConnect(ctx context.Context, stewardID string) error {
+	var firstErr error
+	for _, h := range c.hooks {
+		if err := h.OnConnect(ctx, stewardID); err != nil {
+			if c.logger != nil {
+				c.logger.Warn("on-connect hook in chain errored, continuing",
+					"steward_id", logging.SanitizeLogValue(stewardID), "error", err)
+			}
+			if firstErr == nil {
+				firstErr = err
+			}
+		}
+	}
+	return firstErr
+}

--- a/features/controller/service/steward_connect_hook_test.go
+++ b/features/controller/service/steward_connect_hook_test.go
@@ -1,0 +1,154 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+package service
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	fleetStorage "github.com/cfgis/cfgms/features/controller/fleet/storage"
+	"github.com/cfgis/cfgms/pkg/logging"
+)
+
+// TestStewardRegistryConnectHook_UpsertsAbsentStewardOnConnect drives the real
+// connect-hook path (the same OnConnect the gRPC provider calls on session
+// establishment) and proves an absent-but-durably-known steward is repopulated
+// with its authoritative tenant (Issue #2008 PRIMARY fix).
+func TestStewardRegistryConnectHook_UpsertsAbsentStewardOnConnect(t *testing.T) {
+	storage := newTestFleetStorage(t)
+	ctx := context.Background()
+
+	dna := makeTestDNA("dev-1", map[string]string{"os": "linux"})
+	require.NoError(t, storage.Store(ctx, "dev-1", dna, &fleetStorage.StoreOptions{TenantID: "tenant-a", Status: "registered"}))
+
+	svc := NewControllerServiceWithStorage(logging.NewNoopLogger(), storage)
+	hook := NewStewardRegistryConnectHook(svc, logging.NewNoopLogger())
+
+	_, found := svc.GetStewardInfo("dev-1")
+	require.False(t, found, "precondition: steward absent before connect")
+
+	// Same call the gRPC provider makes: stewardID is the mTLS-authenticated CN.
+	require.NoError(t, hook.OnConnect(ctx, "dev-1"))
+
+	info, ok := svc.GetStewardInfo("dev-1")
+	require.True(t, ok, "connect hook must upsert the absent steward")
+	assert.Equal(t, "active", info.Status)
+	assert.Equal(t, "tenant-a", info.TenantID)
+}
+
+// TestStewardRegistryConnectHook_Idempotent proves repeated connects (the normal
+// reconnect cadence) do not duplicate the registry entry.
+func TestStewardRegistryConnectHook_Idempotent(t *testing.T) {
+	storage := newTestFleetStorage(t)
+	ctx := context.Background()
+	dna := makeTestDNA("dev-1", map[string]string{"os": "linux"})
+	require.NoError(t, storage.Store(ctx, "dev-1", dna, &fleetStorage.StoreOptions{TenantID: "tenant-a", Status: "registered"}))
+
+	svc := NewControllerServiceWithStorage(logging.NewNoopLogger(), storage)
+	hook := NewStewardRegistryConnectHook(svc, logging.NewNoopLogger())
+
+	require.NoError(t, hook.OnConnect(ctx, "dev-1"))
+	require.NoError(t, hook.OnConnect(ctx, "dev-1"))
+
+	assert.Equal(t, 1, svc.GetStewardCount(), "repeated connects must not duplicate the steward")
+}
+
+// stubHook is a minimal in-package StewardOnConnectHook used to exercise the
+// composite ordering and error handling. It is a test double for an arbitrary
+// hook, not a mock of any CFGMS component.
+type stubHook struct {
+	calls *[]string
+	name  string
+	err   error
+}
+
+func (s *stubHook) OnConnect(_ context.Context, _ string) error {
+	*s.calls = append(*s.calls, s.name)
+	return s.err
+}
+
+// TestCompositeOnConnectHook_RunsAllHooksInOrder proves the composite drives
+// every chained hook so the signing-cert refresh and admin-registry upsert both
+// fire on a single connect.
+func TestCompositeOnConnectHook_RunsAllHooksInOrder(t *testing.T) {
+	var calls []string
+	h1 := &stubHook{calls: &calls, name: "first"}
+	h2 := &stubHook{calls: &calls, name: "second"}
+
+	composite := NewCompositeOnConnectHook(logging.NewNoopLogger(), h1, h2)
+	require.NoError(t, composite.OnConnect(context.Background(), "dev-1"))
+
+	assert.Equal(t, []string{"first", "second"}, calls)
+}
+
+// TestCompositeOnConnectHook_ContinuesAfterError proves one hook's failure does
+// not skip later hooks (e.g. a signing-push failure must not prevent the
+// registry upsert), and the first error is surfaced for fail-open logging.
+func TestCompositeOnConnectHook_ContinuesAfterError(t *testing.T) {
+	var calls []string
+	boom := errors.New("boom")
+	h1 := &stubHook{calls: &calls, name: "failing", err: boom}
+	h2 := &stubHook{calls: &calls, name: "registry"}
+
+	composite := NewCompositeOnConnectHook(logging.NewNoopLogger(), h1, h2)
+	err := composite.OnConnect(context.Background(), "dev-1")
+
+	require.ErrorIs(t, err, boom)
+	assert.Equal(t, []string{"failing", "registry"}, calls, "later hooks must run even after an earlier hook errors")
+}
+
+// TestCompositeOnConnectHook_SkipsNilHooks proves nil hooks passed to the
+// constructor are filtered (server.go composes optionally-constructed hooks).
+func TestCompositeOnConnectHook_SkipsNilHooks(t *testing.T) {
+	var calls []string
+	h := &stubHook{calls: &calls, name: "only"}
+
+	composite := NewCompositeOnConnectHook(logging.NewNoopLogger(), nil, h, nil)
+	require.NoError(t, composite.OnConnect(context.Background(), "dev-1"))
+
+	assert.Equal(t, []string{"only"}, calls)
+}
+
+// TestCompositeOnConnectHook_RealRegistryHookFiresAfterEarlierError proves the
+// production wiring's fail-open contract end-to-end: with a REAL
+// StewardRegistryConnectHook (real SQLite storage, durable tenant seeded) as the
+// SECOND element behind a FIRST hook that errors (mirroring a signing-cert push
+// failure), the registry upsert still fires AND the first hook's error is
+// surfaced — the stream is never refused. This is the scenario that matters at
+// runtime: a signing-rotation failure must not leave a reconnecting steward
+// invisible to list/status/exec.
+func TestCompositeOnConnectHook_RealRegistryHookFiresAfterEarlierError(t *testing.T) {
+	storage := newTestFleetStorage(t)
+	ctx := context.Background()
+
+	dna := makeTestDNA("dev-1", map[string]string{"os": "linux"})
+	require.NoError(t, storage.Store(ctx, "dev-1", dna, &fleetStorage.StoreOptions{TenantID: "tenant-a", Status: "registered"}))
+
+	svc := NewControllerServiceWithStorage(logging.NewNoopLogger(), storage)
+	realRegistryHook := NewStewardRegistryConnectHook(svc, logging.NewNoopLogger())
+
+	var calls []string
+	firstErr := errors.New("signing push failed")
+	failing := &stubHook{calls: &calls, name: "signing", err: firstErr}
+
+	composite := NewCompositeOnConnectHook(logging.NewNoopLogger(), failing, realRegistryHook)
+
+	_, found := svc.GetStewardInfo("dev-1")
+	require.False(t, found, "precondition: steward absent before connect")
+
+	err := composite.OnConnect(ctx, "dev-1")
+
+	// (b) the first hook's error is surfaced (fail-open: logged by the provider,
+	// stream not refused).
+	require.ErrorIs(t, err, firstErr, "the earlier hook's error must be surfaced")
+
+	// (a) the registry upsert still fired despite the earlier error.
+	info, ok := svc.GetStewardInfo("dev-1")
+	require.True(t, ok, "registry upsert must fire even when an earlier hook errors")
+	assert.Equal(t, "active", info.Status)
+	assert.Equal(t, "tenant-a", info.TenantID)
+}


### PR DESCRIPTION
## What

The controller's admin steward registry (which backs `cfg steward list`, `status`, and `exec`) is only written by the HTTP registration path. The steward's normal **cert-reuse reconnect bypasses HTTP registration**, `RecordHeartbeat` was update-only, and `LoadFromStorage` runs once at boot — so a cert-reconnecting steward was **invisible to admin surfaces until a controller restart**, even though its data plane (heartbeats, convergence, commands) worked fine. This breaks admin/fleet control across any controller restart. Surfaced live during the checkpoint-#1 blue/green cutover proof. Fixes #2008.

## How

- `EnsureSteward` — idempotent upsert (add active + persist if absent, refresh if present).
- `StewardRegistryConnectHook` wired into the gRPC `OnConnect` path (composed with the existing signing-rotation hook via `CompositeOnConnectHook`), so it fires on **every** authenticated (re)connect, keyed on the mTLS CN.
- `RecordHeartbeat` upsert backstop (self-heals within one heartbeat).
- **Tenant is always resolved from durable storage** (`lookupDurableTenant`), never from a steward- or caller-supplied value; both paths **decline rather than fabricate** a tenant when no durable record exists — preserving cross-tenant `exec`/config isolation.
- Neither path holds `s.mu` across storage I/O (lookup + `storeDNA` outside the lock; insert uses double-checked locking).

## Tests (real components, no mocks)

connect-hook upsert; heartbeat backstop; tenant-from-storage-not-caller (hostile caller value ignored); no-duplicate refresh; restart survival (status + DNA round-trip); composite test with the **real** registry hook behind a failing first hook (fail-open: error surfaced, steward still registered); 16-goroutine concurrency proof (no duplicate).

## Review

Story-complete team: acceptance-checker PASS, security-engineer PASS (multi-tenant isolation verified — tenant storage-derived, steward-supplied tenant structurally dropped, CN-authenticated IDs, decline-not-fabricate), qa-test-runner PASS, qa-code-reviewer PASS after one fix cycle (eliminated storage I/O under the registry lock).

## Note (separate)

The heartbeat >60s-gap flapping (a transport/cadence issue) is out of scope and tracked separately; this fix makes flapping harmless to `list`/`status`/`exec`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
