### PR TITLE
controller: resolve DNA store path absolutely so blue/green candidate reads the live registry (Issue #2010)

### DIFF
--- a/features/controller/server/dna_data_root_test.go
+++ b/features/controller/server/dna_data_root_test.go
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+package server
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/cfgis/cfgms/features/controller/config"
+)
+
+// Tests use t.TempDir()-derived paths (absolute and OS-appropriate on both the
+// Linux CI runners and a Windows dev box) rather than hard-coded "/var/..."
+// literals, which are not absolute under Windows filepath semantics.
+
+// TestResolveDNADataRoot_RelativeDataDirDerivesAbsoluteFromStorage is the
+// regression guard for Issue #2010: a relative (non-empty) DataDir — the
+// shipped default is "data/" — must NOT yield a CWD-relative DNA store path.
+// Before the fix the relative DataDir was used verbatim, so a blue/green
+// candidate launched from a different working directory opened a different,
+// empty dna.db and warm-loaded zero stewards.
+func TestResolveDNADataRoot_RelativeDataDirDerivesAbsoluteFromStorage(t *testing.T) {
+	storageRoot := filepath.Join(t.TempDir(), "storage")
+	cfg := &config.Config{
+		DataDir: "data/", // the shipped relative default
+		Storage: &config.StorageConfig{
+			SQLitePath:   filepath.Join(storageRoot, "cfgms.db"),
+			FlatfileRoot: filepath.Join(storageRoot, "flatfile"),
+		},
+	}
+
+	got := resolveDNADataRoot(cfg)
+
+	if !filepath.IsAbs(got) {
+		t.Fatalf("resolveDNADataRoot returned a non-absolute path %q; a CWD-relative DNA store breaks blue/green warm-load (Issue #2010)", got)
+	}
+	if got != storageRoot {
+		t.Fatalf("resolveDNADataRoot = %q, want %q (derived from SQLitePath dir)", got, storageRoot)
+	}
+}
+
+// TestResolveDNADataRoot_EmptyDataDirDerivesFromStorage covers the original
+// guarded case (empty DataDir) which must keep working.
+func TestResolveDNADataRoot_EmptyDataDirDerivesFromStorage(t *testing.T) {
+	dbDir := filepath.Join(t.TempDir(), "db")
+	cfg := &config.Config{
+		DataDir: "",
+		Storage: &config.StorageConfig{SQLitePath: filepath.Join(dbDir, "cfgms.db")},
+	}
+	got := resolveDNADataRoot(cfg)
+	if got != dbDir {
+		t.Fatalf("resolveDNADataRoot = %q, want %q", got, dbDir)
+	}
+}
+
+// TestResolveDNADataRoot_FlatfileFallback exercises the FlatfileRoot branch
+// when no SQLitePath is configured.
+func TestResolveDNADataRoot_FlatfileFallback(t *testing.T) {
+	root := t.TempDir()
+	cfg := &config.Config{
+		DataDir: "data/",
+		Storage: &config.StorageConfig{FlatfileRoot: filepath.Join(root, "flat")},
+	}
+	got := resolveDNADataRoot(cfg)
+	if got != root {
+		t.Fatalf("resolveDNADataRoot = %q, want %q", got, root)
+	}
+}
+
+// TestResolveDNADataRoot_AbsoluteDataDirHonored asserts an explicitly-set
+// absolute DataDir is returned unchanged (storage derivation must not override
+// an operator's deliberate choice).
+func TestResolveDNADataRoot_AbsoluteDataDirHonored(t *testing.T) {
+	abs := t.TempDir() // absolute, OS-appropriate
+	cfg := &config.Config{
+		DataDir: abs,
+		Storage: &config.StorageConfig{SQLitePath: filepath.Join(t.TempDir(), "cfgms.db")},
+	}
+	got := resolveDNADataRoot(cfg)
+	if got != abs {
+		t.Fatalf("resolveDNADataRoot = %q, want %q (absolute DataDir must be honored)", got, abs)
+	}
+}
+
+// TestResolveDNADataRoot_NoStorageStillAbsolute is the degenerate last-resort:
+// no storage configured and a relative/empty DataDir must still yield an
+// absolute path rather than silently landing in an arbitrary CWD. The exact
+// resolved path is deliberately NOT asserted — the last-resort branch anchors
+// to the process CWD at test time, which is not a valid configuration for a
+// real deployment; only the absoluteness invariant is meaningful here.
+func TestResolveDNADataRoot_NoStorageStillAbsolute(t *testing.T) {
+	cfg := &config.Config{DataDir: "data/", Storage: nil}
+	got := resolveDNADataRoot(cfg)
+	if !filepath.IsAbs(got) {
+		t.Fatalf("resolveDNADataRoot = %q, want an absolute path even with no storage configured", got)
+	}
+}

--- a/features/controller/server/server.go
+++ b/features/controller/server/server.go
@@ -115,6 +115,48 @@ type Server struct {
 	pendingExpiryJob        *controllerRegistration.PendingExpiryJob // Issue #1697: 5-day pending-registration expiry
 }
 
+// resolveDNADataRoot returns an ABSOLUTE directory under which the durable DNA
+// store (dna-reports/dna.db) is placed. The result MUST be independent of the
+// process working directory: two controllers of the same deployment may be
+// launched from different CWDs — most importantly the systemd unit
+// (WorkingDirectory=/) versus a blue/green candidate spawned by
+// `cfg controller upgrade run` (inheriting the operator's CWD). If the DNA path
+// were CWD-relative, the candidate would open a DIFFERENT, empty dna.db, warm-
+// load zero stewards, and the steward admin registry (cfg list/status/exec)
+// would be blind to the whole fleet after a cutover. (Issue #2010)
+//
+// Resolution:
+//   - An absolute cfg.DataDir is honored as-is.
+//   - An empty OR relative cfg.DataDir is replaced by a root derived from the
+//     configured durable storage paths (SQLitePath dir, then FlatfileRoot dir),
+//     which are absolute in any real deployment, co-locating the DNA store with
+//     the controller's other durable state.
+//   - As a last resort (no storage paths configured, e.g. minimal tests) the
+//     value is anchored to an absolute path via filepath.Abs so it is at least
+//     deterministic within the process. Note this last-resort anchor is the
+//     process CWD at startup, so true cross-CWD consistency in an all-defaults
+//     deployment still relies on absolute storage paths being configured (every
+//     real deployment, e.g. ctrl-01, sets absolute Storage.SQLitePath).
+func resolveDNADataRoot(cfg *config.Config) string {
+	root := cfg.DataDir
+	if root == "" || !filepath.IsAbs(root) {
+		if cfg.Storage != nil {
+			switch {
+			case cfg.Storage.SQLitePath != "":
+				root = filepath.Dir(cfg.Storage.SQLitePath)
+			case cfg.Storage.FlatfileRoot != "":
+				root = filepath.Dir(cfg.Storage.FlatfileRoot)
+			}
+		}
+	}
+	if !filepath.IsAbs(root) {
+		if abs, err := filepath.Abs(root); err == nil {
+			root = abs
+		}
+	}
+	return root
+}
+
 // New creates a new server instance
 func New(cfg *config.Config, logger logging.Logger) (*Server, error) {
 	if cfg == nil {
@@ -193,21 +235,14 @@ func New(cfg *config.Config, logger logging.Logger) (*Server, error) {
 	// controller service (warm-loading the steward registry after a restart)
 	// and the reports engine. (Issue #1572)
 	//
-	// The data root is cfg.DataDir when set; otherwise it is derived from the
-	// configured storage path so the DNA store is always co-located with the
-	// controller's other durable state and isolated per deployment. Falling
-	// back to a bare relative path would put the SQLite file in the process
-	// working directory, where concurrent controllers (and tests) collide.
-	dnaDataRoot := cfg.DataDir
-	if dnaDataRoot == "" {
-		if cfg.Storage.SQLitePath != "" {
-			dnaDataRoot = filepath.Dir(cfg.Storage.SQLitePath)
-		} else if cfg.Storage.FlatfileRoot != "" {
-			dnaDataRoot = filepath.Dir(cfg.Storage.FlatfileRoot)
-		}
-	}
+	// The data root must be an ABSOLUTE, CWD-independent path: two controllers
+	// of the same deployment can be launched from different working directories
+	// (notably the systemd unit vs. a blue/green candidate spawned by
+	// `cfg controller upgrade`), and they must resolve the SAME DNA store or the
+	// candidate comes up with an empty steward registry. See resolveDNADataRoot
+	// and Issue #2010.
 	dnaStorageConfig := dnaStorage.DefaultConfig()
-	dnaStorageConfig.DataDir = filepath.Join(dnaDataRoot, "dna-reports")
+	dnaStorageConfig.DataDir = filepath.Join(resolveDNADataRoot(cfg), "dna-reports")
 	dnaStorageManager, dnaErr := dnaStorage.NewManager(dnaStorageConfig, logger)
 	if dnaErr != nil {
 		logger.Warn("Failed to initialize DNA storage; steward registry will not survive a controller restart", "error", dnaErr)


### PR DESCRIPTION
## What & why

Root-caused live on ctrl-01 while proving Checkpoint #1 (controller blue/green) of the Hyper-V readiness program: after a `cfg controller upgrade` cutover, the green controller's steward admin registry was **empty** — `cfg steward list/status/exec` were blind to the whole fleet for the entire cutover window, even though the data plane (convergence, commands, heartbeats) was fine.

Evidence (same box, same `controller.cfg`): systemd controller boots warm-loaded `device_count=6`; the orchestrator-spawned green warm-loaded `device_count=0`. Two `dna.db` files existed at **CWD-relative** paths — `/data/dna-reports/dna.db` (systemd, CWD `/`) vs `/home/cfgms/data/dna-reports/dna.db` (green, CWD `/home/cfgms`).

**Mechanism:** `server.go` derived the DNA data root but only replaced it when `cfg.DataDir == ""`. The shipped default is the relative `"data/"` (non-empty), so the guard was skipped and the DNA store resolved against the process working directory. A blue/green candidate launched with a different CWD than systemd opens a different, empty `dna.db` → `LoadFromStorage` warm-loads 0 → on cert-reuse reconnect #2008's `EnsureSteward`/`RecordHeartbeat` query the same empty DB via `lookupDurableTenant` and decline (no-fabrication) → steward never enters the admin registry.

## Change

`resolveDNADataRoot(cfg)` resolves the DNA data root to an **absolute, CWD-independent** path whenever `DataDir` is empty **or relative**, deriving from configured storage paths (`SQLitePath` dir, then `FlatfileRoot` dir). An explicit absolute `DataDir` is honored unchanged. The existing code comment already anticipated this collision; the guard just didn't cover a relative-but-non-empty `DataDir`.

## Tests

5 unit tests in `dna_data_root_test.go` (portable via `t.TempDir()` for Linux CI + Windows dev): the relative-default regression guard, empty→storage, flatfile fallback, absolute-honored, and the no-storage last-resort. Affected packages (`server`, `service`, `fleet/storage`) pass with no regression.

## Review

Adversarial team (security-engineer, qa-code-reviewer, qa-test-runner, acceptance-checker) all PASS, zero blocking findings. Security: no path-traversal/tenant-isolation surface (config-only inputs, `filepath.Abs` cleans). Architecture: no new central-provider violations.

## Remaining (post-merge)

AC5 is a live re-prove: deploy to ctrl-01 (including a one-time copy of the existing `/data/dna-reports/dna.db` to the absolute location so the live fleet isn't lost), then run a `cfg controller upgrade` cutover and confirm the steward stays visible in `cfg steward list/exec` on the green — completing Checkpoint #1.

Fixes #2010

🤖 Generated with [Claude Code](https://claude.com/claude-code)
