### PR TITLE
chore: add Serena MCP server (project scope) + uv prerequisite docs

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,16 @@
+{
+  "mcpServers": {
+    "serena": {
+      "type": "stdio",
+      "command": "uvx",
+      "args": [
+        "--from",
+        "git+https://github.com/oraios/serena",
+        "serena-mcp-server",
+        "--context",
+        "ide-assistant"
+      ],
+      "env": {}
+    }
+  }
+}

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -63,6 +63,20 @@ This guide provides instructions for setting up a local CFGMS development enviro
   go install github.com/securego/gosec/v2/cmd/gosec@v2.27.1
   ```
 
+- **Serena MCP server** - Semantic code navigation/editing for Claude Code. The
+  server config ships with the repo in `.mcp.json` (project scope), but the
+  runtime is per-machine: install [`uv`](https://docs.astral.sh/uv/), then
+  approve the server on first interactive `claude` launch.
+  ```bash
+  # Install uv (provides uvx, which fetches/runs Serena on demand)
+  curl -LsSf https://astral.sh/uv/install.sh | sh
+
+  # Confirm Claude Code sees the project-scoped server, then approve it
+  claude mcp list   # shows: serena ... (pending approval until you run `claude`)
+  ```
+  No manual `claude mcp add` is needed — `.mcp.json` is committed. Serena
+  auto-manages the language servers it needs (e.g. `gopls` for this repo).
+
 ### System Requirements
 
 **For Building**:


### PR DESCRIPTION
## What

- Adds project-scoped `.mcp.json` registering the **Serena** MCP server (semantic code navigation/editing) for Claude Code. Project scope means the config is committed and travels with the repo on clone.
- Documents `uv` as an optional dev tool in `DEVELOPMENT.md`, since the Serena runtime is per-machine even though the config ships.

## Why

The `.mcp.json` is configuration-as-code (the launch recipe), not a binary — each dev still needs `uv` installed and must approve the project-scoped server on first interactive `claude` launch (Claude Code's security gate for committed MCP servers).

## Notes

- `--project` absolute path was intentionally omitted from the committed config so Serena binds to whatever directory Claude Code launches from (portable across machines/checkouts).
- Verified locally: `claude mcp list` recognizes the server (shows pending-approval until approved interactively).

🤖 Generated with [Claude Code](https://claude.com/claude-code)