### PR TITLE
promote: CodeQL log-injection fix + docs/model to main

### DIFF
--- a/.github/codeql/extensions/models/path-injection-sanitizers.model.yml
+++ b/.github/codeql/extensions/models/path-injection-sanitizers.model.yml
@@ -39,3 +39,20 @@ extensions:
     data:
       - ["github.com/cfgis/cfgms/pkg/storage/providers/flatfile", "", false, "safeJoin", "", "", "Argument[0]", "ReturnValue[0]", "value", "manual"]
       - ["github.com/cfgis/cfgms/pkg/storage/providers/flatfile", "", false, "safeJoin", "", "", "Argument[1]", "ReturnValue[0]", "value", "manual"]
+
+  # Durable upgrade: barrierModel (CodeQL >=2.25.2) marks safeJoin's cleaned
+  # return value as a path-injection barrier directly, rather than relying on
+  # summaryModel(kind=value) to suppress propagation (which the log-injection
+  # model notes is unreliable on some flow paths — e.g. json.Decode field
+  # selections). Kept ALONGSIDE the summaryModel entries above so this is purely
+  # additive: if the barrierModel kind/format needs adjustment, protection does
+  # not regress. Format mirrors log-injection-sanitizers.model.yml:
+  #   [package, type, subtypes, name, signature, ext, output, kind, provenance]
+  # NOTE: the exact barrierModel tuple/kind must be confirmed by the CodeQL CI
+  # run (it cannot be fully verified locally); see the path-injection FP notes
+  # in docs/development/security-workflow-guide.md.
+  - addsTo:
+      pack: codeql/go-all
+      extensible: barrierModel
+    data:
+      - ["github.com/cfgis/cfgms/pkg/storage/providers/flatfile", "", false, "safeJoin", "", "", "ReturnValue[0]", "path-injection", "manual"]

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -104,7 +104,7 @@ jobs:
     # run that workflow manually with `--ref <branch>` before re-running
     # this one.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4
+      uses: github/codeql-action/init@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0
       with:
         languages: ${{ matrix.language }}
         config-file: ./.github/codeql/codeql-config.yml
@@ -127,7 +127,7 @@ jobs:
 
     # Perform CodeQL Analysis
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4
+      uses: github/codeql-action/analyze@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0
       with:
         category: "/language:${{ matrix.language }}"
         # Upload results to GitHub Security tab (SARIF format)

--- a/.github/workflows/docker-security.yml
+++ b/.github/workflows/docker-security.yml
@@ -95,7 +95,7 @@ jobs:
         skip-setup-trivy: true
 
     - name: Upload Trivy results to GitHub Security tab
-      uses: github/codeql-action/upload-sarif@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4
+      uses: github/codeql-action/upload-sarif@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0
       if: always()
       with:
         sarif_file: 'trivy-controller-results.sarif'
@@ -184,7 +184,7 @@ jobs:
         skip-setup-trivy: true
 
     - name: Upload Trivy results to GitHub Security tab
-      uses: github/codeql-action/upload-sarif@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4
+      uses: github/codeql-action/upload-sarif@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0
       if: always()
       with:
         sarif_file: 'trivy-steward-results.sarif'

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -81,7 +81,7 @@ jobs:
         fi
     
     - name: Upload Trivy SARIF
-      uses: github/codeql-action/upload-sarif@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4
+      uses: github/codeql-action/upload-sarif@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0
       if: always() && hashFiles('sarif-results/trivy.sarif') != ''
       with:
         sarif_file: sarif-results/trivy.sarif
@@ -206,7 +206,7 @@ jobs:
     # configuration, and results are still available via workflow artifacts.
     #
     # - name: Upload gosec SARIF
-    #   uses: github/codeql-action/upload-sarif@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4
+    #   uses: github/codeql-action/upload-sarif@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0
     #   if: always() && hashFiles('sarif-results/gosec.sarif') != ''
     #   with:
     #     sarif_file: sarif-results/gosec.sarif

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,48 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.7] - 2026-06-15
+
+Stable snapshot promoted to `main`. Bundles the controller in-place upgrade work (now proven
+live), the steward fleet-upgrade system, installer distribution, Hyper-V host onboarding, real
+DNA collectors, and architecture decisions ADR-006/007/008. See
+[`docs/product/roadmap.md`](docs/product/roadmap.md) for the full narrative.
+
+### Added
+
+- **Controller upgrade & state externalization** — smoketest-gated in-place restart upgrade
+  (real-state `/api/v1/ready` gate, keep-previous-binary rollback) and the GA host/container
+  blue-green target; documented in ADR-007 (Epic #2014).
+- **Steward fleet upgrade system** — `push_steward_binary` command handler (Issue #1943),
+  selector-based steward upgrade dispatch API with tenant isolation (Issue #1945),
+  `cfg steward upgrade/status/rollback` CLI (Issue #1947), `UpgradeStore` interface for upgrade
+  state (Issue #1941), and fleet steward upgrade integration tests (Issue #1948).
+- **Installer distribution** — multi-platform installer artifact upload and storage API
+  (Issues #1702, #1704), `cfg installer upload`/`download-url` commands (Issue #1705),
+  Linux `install.sh` with interactive fingerprint TOFU (Issue #1708), and a fleet
+  install-package docker-compose harness (Issue #1709).
+- **Hyper-V host onboarding** — Start-VM/Stop-VM/Set-VM lifecycle module (Issue #1842),
+  `install-hyperv-host.ps1` orchestrator (Issue #1854), and onboarding runbook (Issue #1855).
+- **Real DNA collectors** — Linux and Windows security collectors (Issue #1939) and network
+  collectors (Issue #1946).
+- **cfg CLI additions** — `cfg config diff` against live steward config (Issue #1938),
+  `cfg config rollback` (Issue #1942), `cfg steward dna` with `--attribute` filter (Issue #1933),
+  `cfg steward logs` + controller log-pull API (Issue #1937), `cfg steward modules` endpoint and
+  command (Issue #1949), and `cfg steward exec` for single-steward ad-hoc runs (Issue #1934).
+- **Control-plane protocol** — `execute_script` command (Issue #1992) and `script_completed`
+  plus wire-crossing events (Issue #1997) added to the proto enums; `CommandPushStewardBinary`
+  and `EventStewardUpgrade*` constants (Issue #1940).
+- **Architecture decisions** — ADR-006 module packaging and distribution (Issue #1879),
+  ADR-008 durable execution substrate for the workflow engine.
+
+### Changed
+
+- Container images add `HEALTHCHECK` and `--no-install-recommends`; CI hardened with
+  `persist-credentials: false` and action SHA pinning. `.gitattributes` forces LF on shell
+  scripts and Go sources.
+
 ### Removed
+
 - **BREAKING**: The `git` storage provider has been removed (Issue #664). Existing git-backed
   deployments must migrate to the OSS composite (flatfile + SQLite) using
   `cfg storage migrate --from git --to flatfile` before upgrading. The controller now rejects

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,6 +82,7 @@ Stewards run on hosts that may be compromised. Admin accounts may be phished or 
 - SQL injection prevention (parameterized queries only)
 - No information disclosure in error messages
 - Use `logging.SanitizeLogValue()` for HTTP params, URL paths, headers
+- **CodeQL findings:** genuine bug → fix the code; false positive → extend the in-repo data-extension pack `.github/codeql/extensions/` (republished to ghcr.io by `codeql-pack-publish.yml` — local-path packs are unsupported, and this is **not** the upstream `github/codeql` repo). Heuristic-source FPs that can't be modeled → dismiss with justification. See [security-workflow-guide](docs/development/security-workflow-guide.md#5-codeql---semantic-code-analysis).
 
 ### Documentation
 

--- a/docs/development/security-workflow-guide.md
+++ b/docs/development/security-workflow-guide.md
@@ -48,6 +48,27 @@ The CFGMS security workflow integrates four complementary security scanning tool
 - **Blocking**: No (code quality focus)
 - **SARIF Support**: Limited (JSON output converted)
 
+### 5. CodeQL - Semantic Code Analysis
+
+- **Purpose**: Deep semantic / data-flow analysis (taint tracking) for vulnerability classes like path-injection (CWE-22), log-injection (CWE-117), and clear-text logging (CWE-312)
+- **Scope**: Whole-program data flow, run in GitHub Actions (`codeql-analysis.yml`)
+- **Blocking**: Findings post as PR review threads; main's ruleset requires thread resolution, so they gate release PRs in practice
+- **SARIF Support**: Native (results land in the Security → Code scanning tab)
+
+#### Custom models & false positives (IMPORTANT)
+
+CodeQL cannot see our runtime validators, so it raises false positives where a value is actually sanitized. We correct this with a **CodeQL data-extension pack**, not by editing the upstream `github/codeql` repo:
+
+- **Pack source**: `.github/codeql/extensions/` — `qlpack.yml` (`cfg-is/cfgms-go-extensions`) plus `models/*.model.yml`.
+- **Publish requirement**: the pack is referenced *by name* from `.github/codeql/codeql-config.yml` (`packs:`) and **must be published to the ghcr.io CodeQL pack registry** by `.github/workflows/codeql-pack-publish.yml`. **Local-path pack references are not supported by the codeql-action** — a model file on disk does nothing until the pack is republished.
+- **Already modeled**: `safeJoin` (path-injection), `SanitizeLogValue` + `RedactedID` (log-injection / clear-text-logging).
+
+Decision path for a CodeQL alert:
+
+1. **Genuine bug** → fix the code (e.g. wrap operator-supplied values in `logging.SanitizeLogValue`).
+2. **False positive with a real, value-returning sanitizer** (e.g. `safeJoin`) → add/extend a model. Prefer **`barrierModel`** (kind = the sink kind, e.g. `path-injection`; CodeQL ≥ 2.25.2) over the older **`summaryModel(kind=value)`**, which is unreliable on some flow paths. Verify the exact `barrierModel` tuple format against `github/codeql:go/ql/lib/ext/` — the format is finicky and CI is the only reliable verification (CodeQL can't be modeled-and-tested purely locally).
+3. **False positive from a guard-style validator** (returns only `error`, e.g. blobstore `validateKey`/`validateKeyComponent`) or a **heuristic source** (CodeQL flagging a variable *named* `*SecretKey` that holds a SecretStore key *reference*, not a value) → data extensions can't cleanly model these; **dismiss the alert with justification** (or refactor to a value-returning sanitizer that *can* be modeled).
+
 ## Local Development Workflow
 
 ### Prerequisites

--- a/features/controller/service/signing_rotation.go
+++ b/features/controller/service/signing_rotation.go
@@ -140,7 +140,7 @@ func (s *SigningRotationService) Rotate(ctx context.Context, operatorSerial stri
 	}
 
 	s.logger.Info("signing-cert rotation",
-		"operator_serial", operatorSerial,
+		"operator_serial", logging.SanitizeLogValue(operatorSerial),
 		"old_serial", oldSerial,
 		"new_serial", newCert.SerialNumber,
 		"overlap_days", overlapDays,


### PR DESCRIPTION
## Summary

Fix-forward promotion of the post-v0.9.7 CodeQL work from `develop` to `main`. The primary driver is the **`go/log-injection` fix (#722)** — `main` currently carries the unsanitized `operator_serial` log in `SigningRotationService.Rotate`; this brings the `logging.SanitizeLogValue` fix to `main`.

Also included (all merged to develop via #2026):
- zizmor hash-pin version comment fix (`codeql-action` `# v4` → `# v4.36.0`)
- CodeQL pack-extension docs (`CLAUDE.md` + `security-workflow-guide.md`)
- additive `barrierModel` for `safeJoin` path-injection

No tag / no GitHub Release (per founder direction: no releases until post-v1). Merge commit preserves develop history, consistent with the v0.9.7 promotion (#2024).

## Notes
- Content is identical to `origin/develop`; `main` recorded as ancestor via `-s ours` to satisfy the strict up-to-date rule without altering develop's content.
- The 8 prior false-positive alerts are dismissed and #722 is fixed, so no blocking GHAS threads expected this time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)