### PR TITLE
codeql: bump extension pack to 0.0.5 to publish safeJoin barrierModel

### DIFF
--- a/.github/codeql/extensions/qlpack.yml
+++ b/.github/codeql/extensions/qlpack.yml
@@ -1,5 +1,5 @@
 name: cfg-is/cfgms-go-extensions
-version: 0.0.4
+version: 0.0.5
 library: true
 
 # Apply our model extensions on top of the standard Go query pack so that

--- a/docs/development/security-workflow-guide.md
+++ b/docs/development/security-workflow-guide.md
@@ -61,6 +61,7 @@ CodeQL cannot see our runtime validators, so it raises false positives where a v
 
 - **Pack source**: `.github/codeql/extensions/` — `qlpack.yml` (`cfg-is/cfgms-go-extensions`) plus `models/*.model.yml`.
 - **Publish requirement**: the pack is referenced *by name* from `.github/codeql/codeql-config.yml` (`packs:`) and **must be published to the ghcr.io CodeQL pack registry** by `.github/workflows/codeql-pack-publish.yml`. **Local-path pack references are not supported by the codeql-action** — a model file on disk does nothing until the pack is republished.
+- **Bump the version (REQUIRED for every model change)**: editing a `models/*.yml` does nothing on its own. `codeql pack publish` refuses to overwrite an existing `<name>@<version>` and no-ops (`"already exists"`); the publish workflow treats that as a green no-op. You **must bump `version:` in `.github/codeql/extensions/qlpack.yml`** in the same change, or the registry keeps serving the old pack and your model stays inert (it will still *bundle* fine, masking the problem).
 - **Already modeled**: `safeJoin` (path-injection), `SanitizeLogValue` + `RedactedID` (log-injection / clear-text-logging).
 
 Decision path for a CodeQL alert:


### PR DESCRIPTION
## Summary

The `safeJoin` path-injection `barrierModel` added in #2026 never went live. The pack `version:` stayed `0.0.4`, so `codeql pack publish` no-op'd (`"already exists"`) and ghcr.io kept serving the old pack — the barrier entry bundled cleanly but was never published (verified in the develop publish-workflow log).

- **`qlpack.yml`**: bump `version: 0.0.4 → 0.0.5` so the next develop push republishes the pack with the barrier model.
- **`security-workflow-guide.md`**: document the gotcha — editing a `models/*.yml` does nothing until the `version:` is bumped; the publish workflow treats `"already exists"` as a green no-op and a stale-version model still bundles, masking that it is inert.

## Verification
- CodeQL CLI 2.25.5 already bundled the barrier model without schema error (format/arity valid); this only changes the published version so it actually deploys.
- On merge, the "Publish CodeQL Extension Pack" workflow should publish `cfg-is/cfgms-go-extensions@0.0.5`; the subsequent CodeQL analysis will resolve the new pack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)