### PR TITLE
fix: correct Serena MCP invocation and add project config + onboarding memories

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -6,7 +6,8 @@
       "args": [
         "--from",
         "git+https://github.com/oraios/serena",
-        "serena-mcp-server",
+        "serena",
+        "start-mcp-server",
         "--context",
         "ide-assistant"
       ],

--- a/.serena/.gitignore
+++ b/.serena/.gitignore
@@ -1,0 +1,2 @@
+/cache
+/project.local.yml

--- a/.serena/memories/architecture.md
+++ b/.serena/memories/architecture.md
@@ -1,0 +1,43 @@
+# Architecture
+
+## Central Provider System (enforced by `make check-architecture`)
+"Provider"/"plugin"/"pluggable" = this backend pattern ONLY (distinct from Modules).
+Rules:
+1. Functionality needed by >1 feature MUST use/become a central provider.
+2. New providers pluggable by default — define contract in an `interfaces/` subdir.
+3. Extend existing providers, don't create overlapping code. Never create a new central provider in agent mode — extend or flag for human review.
+
+Pluggable providers: `pkg/storage`, `pkg/logging`, `pkg/secrets`, `pkg/directory` (M365/AD), `pkg/controlplane` (gRPC), `pkg/dataplane` (gRPC).
+Direct providers: `pkg/cert`, `pkg/telemetry`, `pkg/cache`, `pkg/session`, `pkg/registration`, `pkg/monitoring`, `pkg/maintenance`, `pkg/security`, `pkg/ha`.
+Utilities (NOT providers): `pkg/config`, `pkg/testing`, `pkg/testutil`, `pkg/version`, `pkg/audit`.
+Decision tree: `pkg/README.md`.
+
+## Storage
+- All business logic imports `pkg/storage/interfaces` ONLY — never import `pkg/storage/providers/*` directly (anti-pattern, gated).
+- Default backend: Git + SOPS encryption. Write-through caching (memory → durable). No memory-only storage for durable features.
+
+## Certificates / mTLS
+- `pkg/cert.Manager` owns all cert ops (see `pkg/cert/manager.go`). Controllers auto-gen CA+certs on first boot.
+- Use `pkg/cert.LoadTLSCertificate()` — never manual cert loading. Don't duplicate TLS code.
+- Tests use auto-generated certs (never static test certs).
+- mTLS required for all internal gRPC-over-QUIC.
+
+## Modules (distinct from providers — never use "plugin" terminology)
+Unit of resource management; out-of-process gRPC binaries, publisher-signed bundles (ADR-006). One kind per module via `executors:` in `module.yaml`:
+- steward modules (manage own host), outpost modules (remote LAN devices), workflow modules (controller engine vs cloud APIs). Cross-kind unsupported.
+- Trust: `steward.cfg` `module_trust.mode` = strict | controller(default) | bypass(dev). End-to-end signing — controller never strips/re-signs. Publisher identity baked into steward binary at build time.
+- Stdlib (`file`,`service`,`package`,`script`,`firewall`,`patch`) ships in installer using same contract (governance, never compiled-in).
+- 4 steward execution paths: modules / scripts (`<interpreter> -File <path>`) / inline `cfg` CLI (mTLS-signed) / remote shell.
+- BANNED in modules+scripts: `iex`/`Invoke-Expression`, `powershell -Command`/`-EncodedCommand`/`-ExecutionPolicy Bypass`, `bash -c "<string>"`, `eval`, `python -c`, any runtime code composition.
+
+## Operating model docs (read before steward/controller behavior changes)
+- `docs/architecture/operating-model.md`, `steward-operating-model.md`, `controller-operating-model.md`.
+- ADRs in `docs/architecture/decisions/` (e.g. 006 module packaging, 008 durable execution substrate).
+
+## Multi-tenancy
+Recursive parent-child tenants, arbitrary depth, path-based IDs (`root/msp-a/client-1/servers`); inheritance resolves root→leaf. All code AGPL-3.0; single-root vs multi-root is architectural, not a license boundary.
+
+## Security specifics
+- Parameterized SQL only; validate/sanitize all user input; no info disclosure in errors.
+- `logging.SanitizeLogValue()` for HTTP params/URL paths/headers (anti-pattern to log unsanitized input).
+- CodeQL FPs: extend in-repo pack `.github/codeql/extensions/` (published to ghcr.io by `codeql-pack-publish.yml`; local-path packs unsupported; NOT the upstream github/codeql repo). Custom sanitizers use `barrierModel` (2.25.2+), not summaryModel.

--- a/.serena/memories/conventions.md
+++ b/.serena/memories/conventions.md
@@ -1,0 +1,31 @@
+# Conventions
+
+## Testing (TDD — write tests first, real components, no mocks)
+- Test error paths and race conditions.
+- Use `t.TempDir()` for anything that writes files — never write to repo root.
+- Test file taxonomy (placement is enforced by intent):
+  | type | location | protocol in filename? |
+  | contract | `pkg/*/interfaces/contract_test.go` | NO |
+  | provider unit | `pkg/*/providers/{name}/*_test.go` | YES ok |
+  | integration | `test/integration/transport/` | NO |
+  | e2e | `test/e2e/` | NO |
+  `test/integration/transport/` and `test/e2e/` filenames must NEVER name a specific protocol. Protocol-specific tests belong in `pkg/*/providers/{name}/`.
+
+## Anti-patterns (avoid)
+- Direct import of storage providers in business logic (use `pkg/storage/interfaces`).
+- Mocking CFGMS components; storing cleartext secrets; duplicating TLS code (use `pkg/cert`).
+- Custom cache (use `pkg/cache.Cache`); manual cert loading (use `pkg/cert.LoadTLSCertificate()`).
+- Logging unsanitized input (use `logging.SanitizeLogValue()`); committing test artifacts.
+
+## Commit / PR
+- Format: `<scope>: <what changed> (Issue #XXX)`, `Fixes #XXX` in body. FACTS ONLY — claims from real measurements, not estimates.
+- See `docs/development/commit-and-pr-standards.md`.
+
+## Desired State Development (DSD)
+Stories are outcome-based; done = entire system reflects desired end state (source, tests, fixtures, configs, Docker, docs, CI all updated). No "pre-existing condition" excuses — if a file blocks the desired state, it's in scope. Done = all tests pass, not "code compiles".
+
+## Pre-GA posture
+Prefer hard breaking changes over migration shims/deprecation windows.
+
+## Docs language
+No competitor analogies, no real third-party vendor names as illustrative examples (use `vendor-a`/`acme-corp`); real integrations (M365) stated as factual capabilities. No history (story numbers/dates/status) in `CLAUDE.md`.

--- a/.serena/memories/core.md
+++ b/.serena/memories/core.md
@@ -1,0 +1,35 @@
+# CFGMS — Core
+
+Go config-management system. Zero-trust, mutual-TLS, feature-organized. Targets MSPs managing 50k+ endpoints (Windows/Linux/macOS).
+
+## Three-tier system
+- **Controller** — central mgmt, SaaS ops, fleet orchestration. Runs Linux/Windows (amd64).
+- **Steward** — endpoint agent, local host ops. Runs Linux/Windows/macOS (amd64+arm64).
+- **Outpost** (future) — proxy cache for stewards, agentless LAN probe/monitor.
+
+Comms: gRPC-over-QUIC + mTLS internal; REST/HTTPS external.
+
+## Source map (relative to repo root)
+- `cmd/` — CLI entrypoints: `controller`, `steward`, `cfg` (user-facing CLI = the UX), `cert-manager`, `cfgms-steward-launcher`.
+- `api/proto/` — protobuf defs.
+- `pkg/` — shared packages + central providers (see `mem:architecture`).
+- `features/` — business logic, feature-organized: config, controller, modules, monitoring, rbac, reports, saas, siem, steward, tenant.
+- `test/` — `test/integration/`, `test/e2e/`.
+- `docs/` — architecture, ADRs, development guides.
+
+## Project-wide invariants
+- PRs target `develop`, never `main`. `develop`→`main` only for releases. `develop` is protected: feature branch + PR even for scripts/docs.
+- Branch naming: `feature/story-<N>-<description>` from `develop`.
+- No mocks in tests — use real CFGMS components. No `t.Skip()` without justification.
+- No hardcoded/cleartext secrets anywhere (OS keychain only). No insecure defaults (TLS in dev too).
+- `git add <specific files>` only — never `git add .` / `-A`.
+- Squash-merge only via GitHub merge queue on develop (`gh pr merge <N> --squash` to enqueue).
+- Canonical docs describe CFGMS directly: no "X-inspired"/competitor analogies, no real third-party vendor names as examples (use `vendor-a`, `acme-corp`); real integrations like M365 stated as facts.
+
+## Domain memories
+- Build/run/lint/test commands: `mem:suggested_commands`
+- Languages, deps, version pins: `mem:tech_stack`
+- Central-provider pattern, storage, certs, modules: `mem:architecture`
+- Code style, test taxonomy, naming: `mem:conventions`
+- Exact gates to run before declaring a task done: `mem:task_completion`
+- Memory file conventions (read before adding/editing memories): `mem:memory_maintenance`

--- a/.serena/memories/memory_maintenance.md
+++ b/.serena/memories/memory_maintenance.md
@@ -1,0 +1,33 @@
+# Memory Maintenance
+
+## Discovery Model
+
+- Core principle: progressive discovery through references, building a graph of memories.
+- Initially, agents are provided with the list of all memories (names only).
+- Agents should read `mem:core` as the top-level entry point (graph root).
+  This memory should contain references to other memories covering major project domains.
+  The referenced memories shall, in turn, shall contain references to even more specific memories, and so on.
+  The depth of the graph shall depend on the project complexity.
+- Use topics/folders to group related memories in order to make the content structure explicit.
+  Folders can mirror project structure (e.g. modules like frontend/backend) or topics like debugging, architecture, etc.
+- Memory references must use a mem: prefix inside backticks, e.g. `mem:frontend/core`.
+  The surrounding text should clearly indicate when to read the memory/which content to expect.
+  The text should provide more precise guidance than the memory name alone, 
+  i.e. avoid a reference like "frontend debugging: `mem:frontend/debugging` and instead make clear which aspects of frontend debugging are covered.
+- Memories themselves should not contain information about when to read them; this is the responsibility of the referring memory.
+
+## Style
+
+Dense agent notes, not prose docs. Prefer invariants, terse bullets. 
+Avoid obvious context, rationale, and examples unless they prevent likely mistakes. 
+Keep guidance durable and generalizable, not task-local.
+
+## Add/update threshold
+
+Add or update memories only with stable, non-obvious project conventions that avoid complex rediscovery in the future.
+Do not add: quick-read facts; generic language/framework knowledge; one-off task notes; volatile line-level details; behavior likely to change soon.
+
+## Maintenance Actions
+
+- Renaming memories: References are updated automatically if handled via Serena's memory rename tool.
+- Checking for stale memories (e.g. after deletion): Call `serena memories check` for a report.

--- a/.serena/memories/suggested_commands.md
+++ b/.serena/memories/suggested_commands.md
@@ -1,0 +1,29 @@
+# Suggested Commands
+
+Run from repo root. Make is the entrypoint for nearly everything.
+
+## Core dev loop
+- `make test` — pre-flight validation; MUST pass before any commit/push (`go build` alone is NOT enough).
+- `make build` — all binaries for current platform (steward, launcher, controller, cli, cert-manager, stdlib-modules).
+- `make test-commit` — pre-commit gate = test + lint + lint-log-injection + check-license-headers + security-precommit + check-architecture + security-scan.
+- `make test-complete` — story-completion gate; matches ALL required CI checks (adds cross-platform compile, Docker integration, E2E). Gap: native Windows/macOS builds are CI-only.
+
+## Targeted
+- `make test-unit`, `make test-integration`, `make test-fast`
+- `make test-e2e-ci` (alias: `test-e2e-transport`), `test-e2e-controller`, `test-e2e-scenarios`, `test-e2e-fleet`
+- `make lint`, `make lint-log-injection`
+- `make security-scan` — trivy + deps(nancy) + gosec + staticcheck; blocking on critical/high.
+- `make check-architecture` — central-provider violation detection.
+- `make check-license-headers`, `make validate-providers`
+- `make proto` — regen protobuf.
+
+## Agent mode
+- `make test-agent-complete` — Phase-2 validation when `CFGMS_AGENT_MODE=true`.
+
+## Git hooks
+- `./scripts/install-git-hooks.sh` — installs pre-commit (artifact detection) + pre-push (`make test`). Bypass `--no-verify` emergencies only.
+
+## Env
+- `CFGMS_TRANSPORT_USE_CERT_MANAGER=true` — never disable.
+
+System: Linux; standard GNU coreutils (`grep`, `ls`, `find`, `sed` behave as on standard unix). `gh` CLI for all GitHub ops.

--- a/.serena/memories/task_completion.md
+++ b/.serena/memories/task_completion.md
@@ -1,0 +1,27 @@
+# Task Completion Gates
+
+Run before declaring any coding task done. Identical validation in both execution modes.
+
+## Minimum before every commit
+- `make test` — must be green (100% pass; `go build` is NOT sufficient).
+
+## Before commit (full pre-commit gate)
+- `make test-commit` = test + lint + lint-log-injection + check-license-headers + security-precommit + check-architecture + security-scan.
+
+## Before opening a PR (story completion)
+- `make test-complete` — matches ALL required CI checks (unit, integration, cross-platform compile, Docker integration, E2E, security gate). Native Windows/macOS builds are CI-only (local gap).
+- Agent mode: `make test-agent-complete` (Phase 2).
+
+## Self-review checklist (Phase 3)
+- No mocks. No `t.Skip()` without justification. No hardcoded secrets.
+- `make check-architecture` clean (no central-provider violations).
+- Storage imports use `pkg/storage/interfaces` only.
+
+## Required CI checks (all must pass before merge to develop)
+`unit-tests`, `integration-tests`, `Build Gate`, `security-deployment-gate`. Docs-only PRs get stub-green fast path.
+
+## Failure handling
+After 3 fix iterations, open a DRAFT PR with error output. Never force-merge, force-push, `reset --hard`, delete branches, or skip validation.
+
+## Merge
+Squash via GitHub merge queue: `gh pr merge <N> --squash` to enqueue (queue auto-rebases + re-validates). Manual rebase only for genuine content conflicts.

--- a/.serena/memories/tech_stack.md
+++ b/.serena/memories/tech_stack.md
@@ -1,0 +1,14 @@
+# Tech Stack
+
+- Language: Go. Module path `github.com/cfgis/cfgms`. `go 1.25.0`, toolchain `go1.26.4` (pinned in go.mod — toolchain/pin bumps go through the `refresh-pins` workflow + per-pin stories).
+- Build: GNU Make (root `Makefile` is the orchestrator; do not modify root targets unless story requires).
+- Protobuf/gRPC codegen via `make proto` (needs proto tools; `make proto-gen`, `proto-gen-modules`).
+
+## Key deps
+- `spf13/cobra` — CLI framework.
+- `quic-go/quic-go` — QUIC transport.
+- `google.golang.org/grpc`, `google.golang.org/protobuf`.
+- `stretchr/testify` — test assertions (real components still required; testify is for asserts only).
+- `go-git/go-git/v5`, AWS SDK v2 (s3/config/credentials), `go-acme/lego/v4` (ACME), `Microsoft/go-winio`, `creack/pty`.
+
+Do not add Go module deps without story justification.

--- a/.serena/project.yml
+++ b/.serena/project.yml
@@ -1,0 +1,133 @@
+# the name by which the project can be referenced within Serena
+project_name: "cfgms"
+
+
+# list of languages for which language servers are started; choose from:
+#   al                  angular             ansible             bash                clojure
+#   cpp                 cpp_ccls            crystal             csharp              csharp_omnisharp
+#   dart                elixir              elm                 erlang              fortran
+#   fsharp              go                  groovy              haskell             haxe
+#   hlsl                html                java                json                julia
+#   kotlin              lean4               lua                 luau                markdown
+#   matlab              msl                 nix                 ocaml               pascal
+#   perl                php                 php_phpactor        powershell          python
+#   python_jedi         python_ty           r                   rego                ruby
+#   ruby_solargraph     rust                scala               scss                solidity
+#   svelte              swift               systemverilog       terraform           toml
+#   typescript          typescript_vts      vue                 yaml                zig
+#   (This list may be outdated. For the current list, see values of Language enum here:
+#   https://github.com/oraios/serena/blob/main/src/solidlsp/ls_config.py
+#   For some languages, there are alternative language servers, e.g. csharp_omnisharp, ruby_solargraph.)
+# Note:
+#   - For C, use cpp
+#   - For JavaScript, use typescript
+#   - For Angular projects, use angular (subsumes typescript+html; requires `npm install` in the project root)
+#   - For Svelte projects, use svelte (subsumes typescript/javascript for .svelte projects; requires npm)
+#   - For SCSS / Sass / plain CSS, use scss (some-sass-language-server handles all three)
+#   - For Free Pascal/Lazarus, use pascal
+# Special requirements:
+#   Some languages require additional setup/installations.
+#   See here for details: https://oraios.github.io/serena/01-about/020_programming-languages.html#language-servers
+# When using multiple languages, the first language server that supports a given file will be used for that file.
+# The first language is the default language and the respective language server will be used as a fallback.
+# Note that when using the JetBrains backend, language servers are not used and this list is correspondingly ignored.
+languages:
+- go
+
+# the encoding used by text files in the project
+# For a list of possible encodings, see https://docs.python.org/3.11/library/codecs.html#standard-encodings
+encoding: "utf-8"
+
+# line ending convention to use when writing source files.
+# Possible values: unset (use global setting), "lf", "crlf", or "native" (platform default)
+# This does not affect Serena's own files (e.g. memories and configuration files), which always use native line endings.
+line_ending:
+
+# The language backend to use for this project.
+# If not set, the global setting from serena_config.yml is used.
+# Valid values: LSP, JetBrains
+# Note: the backend is fixed at startup. If a project with a different backend
+# is activated post-init, an error will be returned.
+language_backend:
+
+# whether to use project's .gitignore files to ignore files
+ignore_all_files_in_gitignore: true
+
+# advanced configuration option allowing to configure language server-specific options.
+# Maps the language key to the options.
+# Have a look at the docstring of the constructors of the LS implementations within solidlsp (e.g., for C# or PHP) to see which options are available.
+# No documentation on options means no options are available.
+ls_specific_settings: {}
+
+# list of additional workspace folder paths for cross-package reference support (e.g. in monorepos).
+# Paths can be absolute or relative to the project root.
+# Each folder is registered as an LSP workspace folder, enabling language servers to discover
+# symbols and references across package boundaries.
+# Currently supported for: TypeScript.
+# Example:
+#   additional_workspace_folders:
+#     - ../sibling-package
+#     - ../shared-lib
+additional_workspace_folders: []
+
+# list of additional paths to ignore in this project.
+# Same syntax as gitignore, so you can use * and **.
+# Note: global ignored_paths from serena_config.yml are also applied additively.
+ignored_paths: []
+
+# whether the project is in read-only mode
+# If set to true, all editing tools will be disabled and attempts to use them will result in an error
+# Added on 2025-04-18
+read_only: false
+
+# list of tool names to exclude.
+# This extends the existing exclusions (e.g. from the global configuration)
+# Find the list of tools here: https://oraios.github.io/serena/01-about/035_tools.html
+excluded_tools: []
+
+# list of tools to include that would otherwise be disabled (particularly optional tools that are disabled by default).
+# This extends the existing inclusions (e.g. from the global configuration).
+# Find the list of tools here: https://oraios.github.io/serena/01-about/035_tools.html
+included_optional_tools: []
+
+# fixed set of tools to use as the base tool set (if non-empty), replacing Serena's default set of tools.
+# This cannot be combined with non-empty excluded_tools or included_optional_tools.
+# Find the list of tools here: https://oraios.github.io/serena/01-about/035_tools.html
+fixed_tools: []
+
+# list of mode names that are to be activated by default, overriding the setting in the global configuration.
+# The full set of modes to be activated is base_modes (from global config) + default_modes + added_modes.
+# If the setting is undefined/empty, the default_modes from the global configuration (serena_config.yml) apply.
+# Otherwise, this overrides the setting from the global configuration (serena_config.yml).
+# Therefore, you can set this to [] if you do not want the default modes defined in the global config to apply
+# for this project.
+# This setting can, in turn, be overridden by CLI parameters (--mode).
+# See https://oraios.github.io/serena/02-usage/050_configuration.html#modes
+default_modes:
+
+# list of mode names to be activated additionally for this project, e.g. ["query-projects"]
+# The full set of modes to be activated is base_modes (from global config) + default_modes + added_modes.
+# See https://oraios.github.io/serena/02-usage/050_configuration.html#modes
+added_modes:
+
+# initial prompt for the project. It will always be given to the LLM upon activating the project
+# (contrary to the memories, which are loaded on demand).
+initial_prompt: ""
+
+# time budget (seconds) per tool call for the retrieval of additional symbol information
+# such as docstrings or parameter information.
+# This overrides the corresponding setting in the global configuration; see the documentation there.
+# If null or missing, use the setting from the global configuration.
+symbol_info_budget:
+
+# list of regex patterns which, when matched, mark a memory entry as read‑only.
+# Extends the list from the global configuration, merging the two lists.
+read_only_memory_patterns: []
+
+# list of regex patterns for memories to completely ignore.
+# Matching memories will not appear in list_memories or activate_project output
+# and cannot be accessed via read_memory or write_memory.
+# To access ignored memory files, use the read_file tool on the raw file path.
+# Extends the list from the global configuration, merging the two lists.
+# Example: ["_archive/.*", "_episodes/.*"]
+ignored_memory_patterns: []


### PR DESCRIPTION
## Summary

Gets the Serena MCP server fully working for this repo and commits its project configuration so all contributors and agents share the same primed context.

- **`.mcp.json`** — corrected the Serena MCP server invocation (launches via `uvx --from git+https://github.com/oraios/serena`, `start-mcp-server`).
- **`.serena/project.yml`** — project config: Go LSP backend, project name `cfgms`, UTF-8.
- **`.serena/.gitignore`** — Serena-generated; excludes `cache/` and `project.local.yml` (local-only), keeps `project.yml` + memories versioned.
- **`.serena/memories/`** — onboarding memory graph: `core` (root) referencing `tech_stack`, `suggested_commands`, `architecture`, `conventions`, `task_completion`, plus `memory_maintenance`. Content distilled from `CLAUDE.md` (provider pattern, storage interfaces, cert manager, modules/ADR-006, test taxonomy, DSD, branch/merge rules).

## Verification

- Serena MCP server launches; gopls indexes the Go codebase; semantic symbol queries resolve to correct locations (e.g. `pkg/cert.Manager`).
- Memory cross-reference sanity-check: every `mem:` reference resolves to an existing memory (the two `mem:frontend/*` strings are syntax examples inside `memory_maintenance.md`, not real links).
- `make test`: all project packages pass. The sole failure, `pkg/cert/TestNoCertSliceIndex0InNonTest`, is a **local-environment false positive** — the test walks the repo root and flags `someCerts[0]` indexing in third-party sources under the gitignored local Go module cache (`.cache/go-mod/...`, e.g. lego, grpc, quic-go, x/crypto). This directory does not exist under the repo root in CI, so it does not affect required checks. No source files were changed by this branch.

## Scope

Config/docs only — no Go source changes. Does not touch `.claude/scratch/` or `scripts/agent-dispatch.sh` (unrelated working-tree files left untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)