### PR TITLE
controller: measure heartbeat staleness by receipt time, not steward clock (Issue #2037)

### DIFF
--- a/features/controller/heartbeat/service.go
+++ b/features/controller/heartbeat/service.go
@@ -21,13 +21,25 @@ import (
 
 // StewardStatus represents the current status of a steward.
 type StewardStatus struct {
-	StewardID      string
+	StewardID string
+	// LastHeartbeat is the steward-supplied send time (steward clock) from the
+	// most recent heartbeat. It is reported for observability ONLY and must NOT
+	// be used for staleness detection — see receivedAt. Trusting a steward-
+	// asserted timestamp for the controller's own liveness accounting is unsound
+	// under clock skew, delivery latency, or a compromised steward.
 	LastHeartbeat  time.Time
 	Status         string
 	Healthy        bool
 	Metrics        map[string]string
 	MissedBeats    int
 	ConnectedSince time.Time
+
+	// receivedAt is the controller's wall-clock time when the most recent
+	// heartbeat was received. Staleness is measured against this (not the
+	// steward-supplied LastHeartbeat) so offline detection is purely controller-
+	// local and immune to clock skew and steward-supplied-time manipulation
+	// (Issue #2037).
+	receivedAt time.Time
 
 	// DNAHash is the most-recently reported DNA hash from the steward heartbeat.
 	// Empty when the steward has not yet sent a DNA hash (older steward versions).
@@ -238,8 +250,11 @@ func (s *Service) handleHeartbeatFromProvider(ctx context.Context, hb *controlpl
 
 	previouslyHealthy := status.Healthy
 
-	// Update status
+	// Update status. LastHeartbeat records the steward-supplied send time for
+	// observability; receivedAt records the controller receipt time and is the
+	// authoritative basis for staleness detection (Issue #2037).
 	status.LastHeartbeat = hb.Timestamp
+	status.receivedAt = time.Now()
 	status.Status = string(hb.Status)
 
 	// Convert metrics from map[string]interface{} to map[string]string
@@ -326,7 +341,9 @@ func (s *Service) checkStaleHeartbeats() {
 	now := time.Now()
 	for stewardID, status := range s.stewards {
 		if status.Healthy {
-			timeSinceLastBeat := now.Sub(status.LastHeartbeat)
+			// Measure staleness against the controller receipt time (Issue #2037),
+			// never the steward-supplied LastHeartbeat, which may be skewed.
+			timeSinceLastBeat := now.Sub(status.receivedAt)
 			if timeSinceLastBeat > s.stewardOfflineTimeout {
 				// Mark as unhealthy
 				status.Healthy = false
@@ -335,7 +352,8 @@ func (s *Service) checkStaleHeartbeats() {
 
 				s.logger.Warn("Steward heartbeat timeout",
 					"steward_id", stewardID,
-					"last_heartbeat", status.LastHeartbeat,
+					"last_received", status.receivedAt,
+					"last_heartbeat_reported", status.LastHeartbeat,
 					"timeout", timeSinceLastBeat)
 
 				if s.onStatusChange != nil {

--- a/features/controller/heartbeat/service_test.go
+++ b/features/controller/heartbeat/service_test.go
@@ -77,7 +77,7 @@ func TestHeartbeatService_StewardOfflineThreshold_60s(t *testing.T) {
 
 	// Simulate 59 s of silence — must NOT trigger offline (under threshold).
 	svc.mu.Lock()
-	svc.stewards["steward-offline-test"].LastHeartbeat = time.Now().Add(-59 * time.Second)
+	svc.stewards["steward-offline-test"].receivedAt = time.Now().Add(-59 * time.Second)
 	svc.stewards["steward-offline-test"].Healthy = true
 	svc.mu.Unlock()
 
@@ -90,7 +90,7 @@ func TestHeartbeatService_StewardOfflineThreshold_60s(t *testing.T) {
 
 	// Simulate 61 s of silence — must trigger offline (over threshold).
 	svc.mu.Lock()
-	svc.stewards["steward-offline-test"].LastHeartbeat = time.Now().Add(-61 * time.Second)
+	svc.stewards["steward-offline-test"].receivedAt = time.Now().Add(-61 * time.Second)
 	svc.stewards["steward-offline-test"].Healthy = true
 	svc.mu.Unlock()
 
@@ -184,7 +184,7 @@ func TestHeartbeatService_TrustEvaluator_CalledOnStale(t *testing.T) {
 
 	// Force the last-heartbeat timestamp past the stale threshold.
 	svc.mu.Lock()
-	svc.stewards[stewardID].LastHeartbeat = time.Now().Add(-61 * time.Second)
+	svc.stewards[stewardID].receivedAt = time.Now().Add(-61 * time.Second)
 	svc.stewards[stewardID].Healthy = true
 	svc.mu.Unlock()
 
@@ -220,10 +220,64 @@ func TestHeartbeatService_TrustEvaluator_NilIsNoop(t *testing.T) {
 
 	// Trigger stale detection — must not panic.
 	svc.mu.Lock()
-	svc.stewards[stewardID].LastHeartbeat = time.Now().Add(-61 * time.Second)
+	svc.stewards[stewardID].receivedAt = time.Now().Add(-61 * time.Second)
 	svc.stewards[stewardID].Healthy = true
 	svc.mu.Unlock()
 
 	assert.NotPanics(t, svc.checkStaleHeartbeats,
 		"nil TrustEvaluator must not cause a panic")
+}
+
+// TestHeartbeatService_StalenessUsesReceiptTime_NotStewardClock is the Issue #2037
+// regression test. Staleness must be measured against the controller's receipt
+// time, never the steward-supplied heartbeat timestamp. A steward whose clock is
+// skewed far into the past (e.g. NTP drift) sends heartbeats stamped with an old
+// timestamp, but if the controller is receiving them on time the steward is NOT
+// offline. On the pre-fix code (which aged status.LastHeartbeat against now) this
+// steward flapped to "timeout" on every check despite arriving on schedule.
+func TestHeartbeatService_StalenessUsesReceiptTime_NotStewardClock(t *testing.T) {
+	svc, cp := newTestService(t, func(cfg *Config) {
+		cfg.StewardOfflineTimeout = 60 * time.Second
+	})
+	ctx := context.Background()
+
+	const stewardID = "steward-skewed-clock"
+
+	// The steward's clock is 90s behind the controller (> the 60s offline
+	// timeout). It stamps the heartbeat with its own (old) time, but the
+	// controller receives it right now.
+	skewedSendTime := time.Now().Add(-90 * time.Second)
+	require.NoError(t, cp.sendHeartbeat(ctx, &controlplaneTypes.Heartbeat{
+		StewardID: stewardID,
+		Status:    controlplaneTypes.StatusHealthy,
+		Timestamp: skewedSendTime,
+	}))
+
+	// A stale check immediately after receipt must NOT mark the steward offline:
+	// only ~0s have elapsed since the controller received the heartbeat.
+	svc.checkStaleHeartbeats()
+
+	status, ok := svc.GetStatus(stewardID)
+	require.True(t, ok)
+	assert.True(t, status.Healthy,
+		"steward with a skewed-old send timestamp but fresh receipt must stay healthy (Issue #2037)")
+
+	// The reported send time is preserved for observability (steward clock),
+	// while staleness is governed by the controller receipt time.
+	assert.WithinDuration(t, skewedSendTime, status.LastHeartbeat, time.Second,
+		"LastHeartbeat must still report the steward-supplied send time")
+
+	// Sanity: once the controller has genuinely not received a heartbeat for
+	// longer than the timeout, it IS marked offline — regardless of send time.
+	svc.mu.Lock()
+	svc.stewards[stewardID].receivedAt = time.Now().Add(-61 * time.Second)
+	svc.stewards[stewardID].Healthy = true
+	svc.mu.Unlock()
+
+	svc.checkStaleHeartbeats()
+
+	status, ok = svc.GetStatus(stewardID)
+	require.True(t, ok)
+	assert.False(t, status.Healthy,
+		"steward must be marked offline after 61s with no receipt")
 }


### PR DESCRIPTION
## Summary

Fixes #2037. The controller's heartbeat staleness check aged each steward against the **steward-supplied** heartbeat timestamp (`status.LastHeartbeat = hb.Timestamp`) using the controller's own clock. Any clock skew between the steward host and the controller — or delivery latency — inflated the computed age, so the 60s offline timeout tripped on nearly every cycle even though heartbeats were arriving on schedule. Result: relentless `Steward heartbeat timeout` → `recovered` flapping.

Root-caused live on cfg-lab: the steward host clock was ~40s behind the controller, and the controller logged a timeout→recovered cycle every ~25-50s for an active, converging steward.

## Change

- Add an unexported `receivedAt time.Time` to `StewardStatus`, set to the controller's `time.Now()` on every received heartbeat.
- `checkStaleHeartbeats` now ages against `receivedAt`, not `LastHeartbeat`.
- `LastHeartbeat` is retained for observability only (steward-reported send time); the timeout log now emits both `last_received` (controller clock) and `last_heartbeat_reported` (steward clock).

This makes offline detection purely controller-local and immune to clock skew, delivery latency, and steward-supplied-time manipulation. Per the zero-trust threat model, a compromised steward can no longer suppress offline detection by sending a future timestamp; the design also fails **closed** (a `Healthy` steward with an unset `receivedAt` would be marked offline on the next check, never immune).

## Testing

- New regression test `TestHeartbeatService_StalenessUsesReceiptTime_NotStewardClock` drives the real `heartbeat.Service`: a heartbeat stamped 90s in the past but received now stays healthy (and a genuine 61s receipt gap still marks it offline). **Verified it fails on the pre-fix logic** (marked offline at computed age 1m30s) and passes on the fix.
- 4 existing silence-simulation tests updated to set `receivedAt` (the staleness field); offline-threshold semantics unchanged.
- `go build ./...`, `go vet ./features/controller/...`, `go test ./features/controller/...` (21 packages) all pass; heartbeat package 12/12.
- Adversarial review team (security-engineer + QA code + QA test-runner): all PASS, zero blocking findings.

## Scope notes

- Does **not** change the registry "last seen" shown by `cfg steward list` (still steward-clock via the #1986 bridge `RecordHeartbeat`); that display-skew is a noted related follow-up, not part of this fix.
- Exec "0/0 jobs" was a transient during a realign reconnect, not gated on the flapping health flag — out of scope here (see #2037).
- Live-verification on ctrl-01 (confirm the periodic flapping stops) to follow deploy.

Fixes #2037

🤖 Generated with [Claude Code](https://claude.com/claude-code)
