### PR TITLE
pipeline: route stories by execution environment + self-dispatch mode

### DIFF
--- a/.claude/agents/ba.md
+++ b/.claude/agents/ba.md
@@ -124,13 +124,21 @@ genuinely no nearby code is at risk of being touched.>
 
 ## Environment
 
-(Optional — omit for ordinary Linux-buildable work, which is the default. Add it
-only when the story needs a specific OS execution environment to build or
-live-test — e.g. native Windows or macOS behavior that a Linux container can't
-exercise. Recognized values: `windows`, `macos`, `linux`. A `windows`/`macos`
-story is routed off the Linux orchestrator to a host that serves that
-environment — see Self-Dispatch Mode in `.claude/agents/po.md` §7. If unsure,
-omit it.)
+(Optional — omit for ordinary Linux-buildable work, which is the default.
+Recognized values: `windows`, `macos`, `linux`. Set `windows` when the story
+needs the Windows host's execution environment. That covers two cases:
+
+1. **Native OS behavior** a Linux container can't build or live-test — Windows
+   (or macOS) APIs, registry, services, installer/MSI, etc.
+2. **Full end-to-end deployment tests and troubleshooting** — the Windows host
+   runs the complete deployment matrix (a Linux controller with Linux *or*
+   Windows minions/stewards), so e2e fleet/deployment validation and
+   reproduce-on-real-hardware troubleshooting belong there even when the code is
+   Linux-buildable. A Linux container can't exercise the Windows-minion side.
+
+A `windows`/`macos` story is routed off the Linux orchestrator to a host that
+serves that environment — see Self-Dispatch Mode in `.claude/agents/po.md` §7. If
+the story is a pure Linux unit/integration change, omit the section.)
 
 ```
 ## Environment

--- a/.claude/agents/ba.md
+++ b/.claude/agents/ba.md
@@ -122,6 +122,21 @@ genuinely no nearby code is at risk of being touched.>
 
 (Use "None" only if the story genuinely does not change product shape. See "Documentation & Tests Currency" rule below.)
 
+## Environment
+
+(Optional — omit for ordinary Linux-buildable work, which is the default. Add it
+only when the story needs a specific OS execution environment to build or
+live-test — e.g. native Windows or macOS behavior that a Linux container can't
+exercise. Recognized values: `windows`, `macos`, `linux`. A `windows`/`macos`
+story is routed off the Linux orchestrator to a host that serves that
+environment — see Self-Dispatch Mode in `.claude/agents/po.md` §7. If unsure,
+omit it.)
+
+```
+## Environment
+windows
+```
+
 ## Reference Implementation
 
 - <Pointers to existing patterns in the codebase to follow>

--- a/.claude/agents/po.md
+++ b/.claude/agents/po.md
@@ -104,6 +104,13 @@ Display sections in this order. **Omit any section with zero items.**
 
 **Section 3: ACTIVE MILESTONE** — current roadmap milestone, open item count, blockers.
 
+**Section 3.5: WINDOWS QUEUE** — Ready stories whose required execution
+environment this host cannot serve. In a cron context read `windows_queue` from
+the preflight output; for the interactive dashboard (no preflight run) use
+`gh issue list --repo cfg-is/cfgms --label needs-windows --state open`. These are
+held, not dispatched, on the Linux orchestrator; they are worked on the Windows
+host via Self-Dispatch Mode (§7). Omit if empty.
+
 **Section 4: AGENT TEAM** — running containers, fix cycle PRs, failed agents, queued stories.
 
 **Section 5: PIPELINE DEPTH** — counts by stage (epics, drafts, ready, fix, review).
@@ -450,6 +457,20 @@ Find stories with project status `Ready` that are not `In Progress`. Before disp
 
 Both gates are computed by the preflight script (`dispatch_recommendations` with `action: "dispatch"` vs `"hold"` and a `reason` string). Trust its recommendation by default, override only if `parse_warnings` are non-empty on the story.
 
+**Execution-environment routing (multi-host).** The preflight filters dispatch by
+this host's capabilities (`CFGMS_PO_HOST_CAPS`, default `linux`). A story whose
+required execution environment isn't in this host's caps gets `action: "hold"`
+with a `route` hint (e.g. `route: "windows"`) — it is **not** container-dispatched
+here. On the Linux orchestrator, windows-tagged stories therefore stay held and
+appear in the dashboard's Windows queue (§1.2); the Windows host picks them up via
+Self-Dispatch Mode (§7). Because each host works a **disjoint slice by
+environment**, two cron loops on different hosts can run out of phase without ever
+claiming the same story — no distributed lock is required. The per-story claim
+(`po-act.sh dispatch` flips `Ready → In Progress` *before* clone/launch) is the
+backstop that also protects against overlapping cycles on a single host. A story's
+required env comes from a `## Environment` body section and/or a `needs-<env>`
+label (see Reference: Story Body Conventions).
+
 For each story the preflight recommends dispatching:
 ```bash
 ./.claude/scripts/po-act.sh dispatch <ITEM_ID>
@@ -652,6 +673,64 @@ When the founder asks about a specific issue or PR:
 
 -----
 
+## 7. Self-Dispatch Mode (no-docker, in-session)
+
+Triggered by `/po work`. For a host whose `CFGMS_PO_HOST_CAPS` names a non-default
+execution environment (e.g. a Windows host with `CFGMS_PO_HOST_CAPS=windows`),
+this mode lets the **local session** work that host's tagged stories natively —
+no docker container, because a Linux container can't provide a Windows execution
+environment. Stories are worked **one at a time, in-process**.
+
+**Why no distributed lock is needed.** The orchestrator (Linux, docker dispatch)
+and this host serve **disjoint execution-environment slices**, so the two cron
+loops never select the same story even when out of phase. The only required
+guard is claiming each story (`Ready → In Progress`) **before** working it —
+`po-act.sh claim` does this with the same status check the docker path uses.
+
+### Loop
+
+1. **Preflight** with this host's caps already set in the environment:
+   ```bash
+   ./.claude/scripts/po-act.sh preflight
+   ```
+   Read `windows_queue` (or, generally, `dispatch_recommendations` entries with
+   `action: "dispatch"` — under this host's caps, its environment's stories
+   become dispatchable while `linux` stories are held). Also honor the
+   `dispatch_blocked` code-health gate exactly as §4.0 (don't start work on a
+   broken `develop`).
+
+2. **Pick the first eligible story** (ascending order — same ordering the
+   preflight uses).
+
+3. **Claim it** before doing any work:
+   ```bash
+   ./.claude/scripts/po-act.sh claim <ITEM_ID>
+   ```
+   - `CLAIMED:<item>` → proceed.
+   - `CLAIM_LOST:<item>` → another host/cycle took it (or it left Ready); skip to
+     the next story. Never work an unclaimed story.
+
+4. **Work it locally in this session** — run the standard dev workflow against the
+   claimed story: `/story-start <NUM>` → implement (TDD, real components, no
+   mocks) → validation gates (`make test-complete`) → `/story-complete` (opens a
+   PR targeting `develop`). This runs natively on the host, so Windows-only
+   build/test paths are exercised for real.
+
+5. **Next.** Repeat 2–4 until no eligible stories remain for this host's caps,
+   then idle. Re-invoked each tick via `/loop /po work`.
+
+**Scope.** This host only **produces** PRs for its environment's stories. Review,
+fix-cycle, merge-queue, and decomposition stay with the Linux orchestrator
+(host-agnostic; they run fine in Linux containers). Exception: a `Fix` cycle on a
+PR whose story is windows-required cannot be auto-fixed in a Linux container —
+it must be picked up the same way (work it in this session). Until that routing
+is automated, treat a windows-required PR in `Fix` as manual pickup.
+
+**Idempotency.** Same as §4.2 — never work a story that isn't `Ready` at claim
+time; the `claim` guard enforces this.
+
+-----
+
 ## Reference: Sub-Issue GraphQL Operations
 
 ### Create sub-issue link
@@ -712,6 +791,26 @@ Every file the story will touch listed in either backtick-quoted form (`` `path/
 
 If the section is present but contains no recognizable file paths, `parse_warnings` is set. Do not write prose-only file lists like "all controller package files".
 
+### `## Environment` (optional)
+
+Declares the execution environment the story must run in, for multi-host routing.
+Recognized values (first match wins, case-insensitive): `windows`, `macos`,
+`linux`. **Absent ⇒ `linux`** (the default; most stories omit this section). The
+parser only looks for the keyword in the section text, so `Requires a Windows
+host for live testing` resolves to `windows`.
+
+```
+## Environment
+windows
+```
+
+A `windows`/`macos` story is held by the Linux orchestrator (not container-
+dispatched) and worked on a host that serves that environment via Self-Dispatch
+Mode (§7). Equivalent to applying the `needs-windows` / `needs-macos` GitHub label
+— the label is the ergonomic way to tag an existing **issue**; the body section is
+the way to tag a project **draft** (which has no labels). Either signal suffices;
+the label wins if both are present.
+
 ### When the parser disagrees with you
 
 The parser is strict on purpose — it's a gate, not a lint. If a story body looks valid to a human but produces a `parse_warning`, normalize the body to match the parser rather than relaxing the gate. The cost of a body edit is one second; the cost of a held story is a wasted cycle.
@@ -726,7 +825,7 @@ Work queue is managed via GitHub Projects V2 (see `scripts/project-queue.sh` and
 |----------------|---------|
 | Draft | Story awaiting Tech Lead review |
 | Ready | Story approved — eligible for dispatch |
-| In Progress | Dev agent container running |
+| In Progress | Claimed and being worked — a dev agent container (orchestrator) or a self-dispatch session (§7). Set at claim time, before any work starts. |
 | Reviewing | PR under acceptance review (container-gated, no label) |
 | Fix | PR failed QA — fix agent dispatched |
 | Failed | Dev agent failed, draft PR created |
@@ -739,3 +838,5 @@ GitHub issue labels still in use:
 | `epic` | Top-level epic issue |
 | `story` | Story sub-issue of an epic |
 | `high-priority` | Escalation tracking issue requiring founder attention |
+| `needs-windows` | Story requires a Windows execution environment — held by the Linux orchestrator, worked via Self-Dispatch Mode (§7) on a Windows host. Equivalent to a `## Environment: windows` body section. |
+| `needs-macos` | Story requires a macOS execution environment (reserved; same routing as `needs-windows`). |

--- a/.claude/agents/po.md
+++ b/.claude/agents/po.md
@@ -689,8 +689,11 @@ guard is claiming each story (`Ready → In Progress`) **before** working it —
 
 ### Loop
 
-1. **Preflight** with this host's caps already set in the environment:
+1. **Preflight** with this host's caps already set in the environment.
+   `CFGMS_PO_HOST_CAPS` must be **exported in the shell before** this call — the
+   preflight reads it to compute which stories are dispatchable here:
    ```bash
+   export CFGMS_PO_HOST_CAPS=windows   # set once per shell/session on this host
    ./.claude/scripts/po-act.sh preflight
    ```
    Read `windows_queue` (or, generally, `dispatch_recommendations` entries with

--- a/.claude/agents/po.md
+++ b/.claude/agents/po.md
@@ -811,6 +811,14 @@ Mode (§7). Equivalent to applying the `needs-windows` / `needs-macos` GitHub la
 the way to tag a project **draft** (which has no labels). Either signal suffices;
 the label wins if both are present.
 
+**When to tag `windows`.** Two cases, not just OS-native code:
+1. **Native Windows/macOS behavior** a Linux container can't build or live-test.
+2. **Full end-to-end deployment tests and troubleshooting.** The Windows host is
+   the e2e lab — it runs the complete deployment matrix (a Linux controller with
+   Linux *or* Windows minions/stewards), which a Linux container can't. Route e2e
+   fleet/deployment validation and reproduce-on-real-hardware troubleshooting to
+   `windows` even when the changed code is Linux-buildable.
+
 ### When the parser disagrees with you
 
 The parser is strict on purpose — it's a gate, not a lint. If a story body looks valid to a human but produces a `parse_warning`, normalize the body to match the parser rather than relaxing the gate. The cost of a body edit is one second; the cost of a held story is a wasted cycle.
@@ -838,5 +846,5 @@ GitHub issue labels still in use:
 | `epic` | Top-level epic issue |
 | `story` | Story sub-issue of an epic |
 | `high-priority` | Escalation tracking issue requiring founder attention |
-| `needs-windows` | Story requires a Windows execution environment — held by the Linux orchestrator, worked via Self-Dispatch Mode (§7) on a Windows host. Equivalent to a `## Environment: windows` body section. |
+| `needs-windows` | Story requires the Windows host — native Windows code OR full e2e deployment testing / troubleshooting (the Windows host runs the Linux-controller + Linux/Windows-minion matrix). Held by the Linux orchestrator, worked via Self-Dispatch Mode (§7). Equivalent to a `## Environment: windows` body section. |
 | `needs-macos` | Story requires a macOS execution environment (reserved; same routing as `needs-windows`). |

--- a/.claude/commands/po.md
+++ b/.claude/commands/po.md
@@ -3,7 +3,7 @@ name: po
 description: Product Owner — pipeline dashboard, intent capture, and autonomous orchestration
 parameters:
   - name: subcommand
-    description: "Optional: 'status' (default), 'intent <topic>', 'next', 'cron', 'cycle', 'decompose [<epic#>]', or 'plan [<epic#>]'"
+    description: "Optional: 'status' (default), 'intent <topic>', 'next', 'cron', 'cycle', 'work', 'decompose [<epic#>]', or 'plan [<epic#>]'"
     required: false
 ---
 
@@ -17,7 +17,7 @@ Two execution paths depending on `$ARGUMENTS`. The dividing line is whether the 
 
 ### Path A — team-relevant args (run inline in the main session)
 
-If `$ARGUMENTS` starts with any of `cron`, `cycle`, `decompose`, or `plan`, do **NOT** spawn the PO as a subagent. Instead, execute directly in the main session.
+If `$ARGUMENTS` starts with any of `cron`, `cycle`, `work`, `decompose`, or `plan`, do **NOT** spawn the PO as a subagent. Instead, execute directly in the main session.
 
 **Why:** A subagent cannot reliably spawn nested subagents (Acceptance Reviewer, BA, Tech Lead, Planning Team) — its `tools:` field is restricted (no `TeamCreate`, `TeamDelete`, `SendMessage`), and its bash commands trigger approval prompts despite `mode: auto`. Running inline gives the cycle full Agent-tool access and the parent session's allow list. Documented in memory `feedback_po_run_inline.md`.
 
@@ -25,8 +25,9 @@ If `$ARGUMENTS` starts with any of `cron`, `cycle`, `decompose`, or `plan`, do *
 
 | Args | Action |
 |------|--------|
-| `cron` | Pipeline Cycle (§4) — **skip Step 7 (Planning Team)**. Autonomous; cheap; runs every interval. |
+| `cron` | Pipeline Cycle (§4) — **skip Step 7 (Planning Team)**. Autonomous; cheap; runs every interval. Dispatches via docker containers (orchestrator role). |
 | `cycle` | Pipeline Cycle (§4) — **including Step 7**. Manual; full cycle on demand. |
+| `work` | Self-Dispatch Mode (§7) — **no docker**. The local session claims and works this host's tagged stories one at a time, in-process. For a host (e.g. Windows) whose `CFGMS_PO_HOST_CAPS` names a non-default execution environment. Pace via `/loop /po work`. |
 | `decompose [<epic#>]` | Run §4.1 Step 7 (Planning Team) only — for the named epic, or every `epic` with no sub-issues if no number is given. |
 | `plan [<epic#>]` | Alias for `decompose`. |
 

--- a/.claude/scripts/po-act.sh
+++ b/.claude/scripts/po-act.sh
@@ -5,7 +5,8 @@
 # All actions target the cfg-is/cfgms repo and the develop branch queue.
 #
 # Subcommands:
-#   dispatch <STORY_NUM>            Fresh story: check-conflicts + clone + launch + status update
+#   dispatch <STORY_NUM>            Fresh story: claim (Ready->In Progress) + check-conflicts + clone + launch
+#   claim <ITEM_ID>                 Claim a Ready story (Ready->In Progress) for in-session work; CLAIMED/CLAIM_LOST
 #   dispatch-fix <PR_NUM>           Fix cycle: remove stale container + clone-pr + launch
 #   close-merged <ISSUE> <PR>       Close issue that didn't auto-close after PR merge
 #   enqueue <PR_NUM> [<STORY>]      Add PR to merge queue. If STORY is given,
@@ -41,6 +42,70 @@ else
 fi
 CACHE_FILE="$CACHE_DIR/preflight.json"
 
+# ── Shared claim / routing helpers ──────────────────────────────────────────
+# The pipeline can run on more than one host (e.g. a Linux orchestrator dispatching
+# docker agents + a Windows host self-dispatching its tagged stories in-session).
+# Hosts work disjoint slices by execution environment, so no distributed lock is
+# needed — but each host MUST claim a story (set status away from Ready) BEFORE it
+# starts any work, so two out-of-phase loops can't both pick the same item.
+
+# _claim_item <item_id>
+#   Atomically-ish claim: re-read status; proceed only if still Ready; set it to
+#   In Progress. Prints CLAIMED:<item> (rc 0) or CLAIM_LOST:<item> (rc 1). The
+#   read-then-set is last-writer-wins (Projects V2 has no CAS), but combined with
+#   disjoint per-host env slices it is sufficient to prevent cross-host collisions.
+_claim_item() {
+  local item_id="$1" cur
+  cur=$(bash "$PROJECT_QUEUE" get-item "$item_id" 2>/dev/null \
+    | python3 -c "import json,sys
+try: print(json.load(sys.stdin).get('status') or '')
+except Exception: print('')" 2>/dev/null || echo "")
+  if [ "$cur" != "Ready" ]; then
+    echo "CLAIM_LOST:${item_id} (status=${cur:-unknown})"
+    return 1
+  fi
+  if ! bash "$PROJECT_QUEUE" update-field "$item_id" status "In Progress" >/dev/null 2>&1; then
+    echo "CLAIM_LOST:${item_id} (status update failed)"
+    return 1
+  fi
+  echo "CLAIMED:${item_id}"
+  return 0
+}
+
+# _requires_env <item_id> [<issue_num>]
+#   Resolve the story's required execution environment, reusing the preflight's
+#   single-sourced detection (## Environment body section + needs-<env> labels).
+#   Always prints one of: linux | windows | macos.
+_requires_env() {
+  local item_id="$1" issue="${2:-}" body labels_json="[]"
+  body=$(bash "$PROJECT_QUEUE" get-item "$item_id" 2>/dev/null \
+    | python3 -c "import json,sys
+try: print(json.load(sys.stdin).get('body') or '')
+except Exception: print('')" 2>/dev/null || echo "")
+  if [ -n "$issue" ]; then
+    labels_json=$(gh issue view "$issue" --repo "$REPO" --json labels --jq '.labels' 2>/dev/null || echo "[]")
+  fi
+  STORY_BODY="$body" STORY_LABELS="$labels_json" PF="$PREFLIGHT" python3 - <<'PY' 2>/dev/null || echo "linux"
+import importlib.util, json, os
+spec = importlib.util.spec_from_file_location("preflight", os.environ["PF"])
+m = importlib.util.module_from_spec(spec); spec.loader.exec_module(m)
+try:
+    labels = json.loads(os.environ.get("STORY_LABELS", "[]"))
+except Exception:
+    labels = []
+print(m.detect_required_env(m.extract_section(os.environ.get("STORY_BODY", ""), "Environment"), labels))
+PY
+}
+
+# _host_serves_env <env>
+#   True if CFGMS_PO_HOST_CAPS (comma-separated, default "linux") includes <env>.
+_host_serves_env() {
+  local env caps
+  env="$(printf '%s' "$1" | tr '[:upper:]' '[:lower:]')"
+  caps=",$(printf '%s' "${CFGMS_PO_HOST_CAPS:-linux}" | tr -d ' ' | tr '[:upper:]' '[:lower:]'),"
+  [[ "$caps" == *",${env},"* ]]
+}
+
 cmd="${1:-}"
 shift || true
 
@@ -69,15 +134,15 @@ except Exception: print('')" 2>/dev/null || echo "")
       fi
     fi
 
+    # Phase 1 — resolve identifiers WITHOUT side effects (no clone yet). We must
+    # know the item_id so we can claim the story (status -> In Progress) BEFORE
+    # any clone/launch work; otherwise a second host's out-of-phase cycle could
+    # clone+launch the same Ready story before this one records the claim.
+    story=""
+    issue_for_env=""
     if [[ "$arg" =~ ^[0-9]+$ ]]; then
-      # Issue number path: existing create-clone flow
       story="$arg"
-      "$DISPATCH" check-conflicts "$story" >/dev/null
-      "$DISPATCH" create-clone "$story" | tail -1
-
-      # Fetch item_id BEFORE launch so CFGMS_PROJECT_ITEM_ID can be passed to the
-      # container. The entrypoint refuses to run without this var. When we
-      # resolved from an item_id arg we already have it; otherwise look it up.
+      issue_for_env="$story"
       if [[ -n "$resolved_item_id" ]]; then
         item_id="$resolved_item_id"
       else
@@ -89,7 +154,6 @@ except Exception: print('')" 2>/dev/null || echo "")
           exit 1
         fi
       fi
-
       clone_path="${WORKTREE_BASE}/story-${story}"
       container_name="cfg-agent-${story}"
       first_arg="${story}"
@@ -98,11 +162,35 @@ except Exception: print('')" 2>/dev/null || echo "")
       # that did not resolve to an issue number above).
       item_id="$arg"
       LAST12=$(echo "$item_id" | tr -cd 'a-zA-Z0-9' | rev | cut -c1-12 | rev)
-      "$DISPATCH" create-clone-item "$item_id" | tail -1
-
       clone_path="${WORKTREE_BASE}/item-${LAST12}"
       container_name="cfg-agent-item-${LAST12}"
       first_arg="${item_id}"
+    fi
+
+    # Phase 2 — capability guard (defense in depth; the preflight already filters
+    # by host caps). Refuse to dispatch a story whose required execution env this
+    # host cannot serve — e.g. a windows-tagged story on the linux orchestrator
+    # must not land in a Linux container.
+    req_env=$(_requires_env "$item_id" "$issue_for_env")
+    req_env="${req_env:-linux}"
+    if ! _host_serves_env "$req_env"; then
+      echo "DISPATCH_REFUSED:${first_arg}:requires ${req_env} env; host caps=${CFGMS_PO_HOST_CAPS:-linux}"
+      exit 0
+    fi
+
+    # Phase 3 — claim before work. Only the host that flips Ready -> In Progress
+    # proceeds; a loser exits cleanly without touching the clone or container.
+    if ! _claim_item "$item_id"; then
+      exit 0
+    fi
+
+    # Phase 4 — now do the work. Roll the claim back to Ready on any failure so a
+    # later cycle (or another host) can retry.
+    if [[ "$arg" =~ ^[0-9]+$ ]]; then
+      "$DISPATCH" check-conflicts "$story" >/dev/null
+      "$DISPATCH" create-clone "$story" | tail -1
+    else
+      "$DISPATCH" create-clone-item "$item_id" | tail -1
     fi
 
     # Launch with CFGMS_PROJECT_ITEM_ID so entrypoint sources content from Projects V2.
@@ -141,11 +229,22 @@ except Exception: print('')" 2>/dev/null || echo "")
       echo "LAUNCH_FAILED:${first_arg}:${container_id}"
       rm -rf "$clone_path"
       echo "CLEANED:clone:${clone_path}"
+      # Release the claim: launch never happened, so return the story to Ready.
+      bash "$PROJECT_QUEUE" update-field "$item_id" status "Ready" >/dev/null 2>&1 || true
+      echo "ROLLED_BACK:${item_id} -> Ready"
       exit 1
     fi
 
-    bash "$PROJECT_QUEUE" update-field "$item_id" status "In Progress" >/dev/null 2>&1 || true
+    # Status is already In Progress from the claim in Phase 3.
     echo "DISPATCHED:${first_arg}"
+    ;;
+
+  claim)
+    # Standalone claim primitive for self-dispatch (no-docker, in-session) mode:
+    # a host claims a Ready story before working it locally. Same Ready->In
+    # Progress guard the docker dispatch path uses. Exit 0 = CLAIMED, 1 = lost.
+    item_id="${1:?item_id required}"
+    _claim_item "$item_id"
     ;;
 
   dispatch-fix)

--- a/.claude/scripts/po-act.sh
+++ b/.claude/scripts/po-act.sh
@@ -185,7 +185,12 @@ except Exception: print('')" 2>/dev/null || echo "")
     fi
 
     # Phase 4 — now do the work. Roll the claim back to Ready on any failure so a
-    # later cycle (or another host) can retry.
+    # later cycle (or another host) can retry. The ERR trap covers the steps that
+    # run under `set -e` (check-conflicts, create-clone); without it a clone/conflict
+    # failure would exit with the story stuck In Progress. The docker-run failure is
+    # handled explicitly in the LAUNCH_FAILED branch below (it runs inside an `if`
+    # condition, which `set -e`/ERR does not trap).
+    trap 'rc=$?; bash "$PROJECT_QUEUE" update-field "$item_id" status "Ready" >/dev/null 2>&1 || true; echo "ROLLED_BACK:${item_id} -> Ready (dispatch failed before launch, rc=$rc)"; exit "$rc"' ERR
     if [[ "$arg" =~ ^[0-9]+$ ]]; then
       "$DISPATCH" check-conflicts "$story" >/dev/null
       "$DISPATCH" create-clone "$story" | tail -1
@@ -224,8 +229,10 @@ except Exception: print('')" 2>/dev/null || echo "")
       --cap-add NET_ADMIN \
       cfg-agent:latest \
       "${first_arg}" 2>&1); then
+      trap - ERR
       echo "LAUNCHED:${first_arg}:${container_id}"
     else
+      trap - ERR
       echo "LAUNCH_FAILED:${first_arg}:${container_id}"
       rm -rf "$clone_path"
       echo "CLEANED:clone:${clone_path}"

--- a/.claude/scripts/po-cycle-preflight.py
+++ b/.claude/scripts/po-cycle-preflight.py
@@ -1731,7 +1731,9 @@ def main():
     out["host_caps"] = sorted(caps)
     # Ready stories whose required env this host cannot serve — surfaced so the
     # dashboard can show the cross-host backlog (e.g. the Windows queue) and so a
-    # self-dispatch host can pick up exactly its slice.
+    # self-dispatch host can pick up exactly its slice. Intentionally windows-only
+    # for now (macos routing is reserved — see the needs-macos label); add a
+    # parallel macos_queue here if/when a macOS host comes online.
     out["windows_queue"] = [
         {"number": s["number"], "item_id": s.get("item_id", ""), "title": s["title"]}
         for s in ready_parsed

--- a/.claude/scripts/po-cycle-preflight.py
+++ b/.claude/scripts/po-cycle-preflight.py
@@ -49,6 +49,44 @@ BARE_PATH_RE = re.compile(
 )
 BRANCH_STORY_RE = re.compile(r"feature/(?:story-(\d+)|item-([a-zA-Z0-9]+)-agent)")
 
+# Execution-environment routing. A story declares the environment it must run in
+# via a `## Environment` body section and/or a `needs-<env>` GitHub label; a host
+# declares the environments it can serve via CFGMS_PO_HOST_CAPS. The default for
+# both is "linux". A host only works stories whose required env is in its caps —
+# this is how the Linux orchestrator and a Windows self-dispatch host stay on
+# disjoint slices without a shared lock.
+DEFAULT_ENV = "linux"
+
+
+def host_caps():
+    """Environments this host can serve. Comma-separated CFGMS_PO_HOST_CAPS,
+    lowercased; defaults to {"linux"}."""
+    raw = os.environ.get("CFGMS_PO_HOST_CAPS", DEFAULT_ENV)
+    caps = {c.strip().lower() for c in raw.split(",") if c.strip()}
+    return caps or {DEFAULT_ENV}
+
+
+def detect_required_env(env_section, labels):
+    """Resolve a story's required execution environment from its `## Environment`
+    section text and its GitHub labels. Label wins (explicit founder/Planning
+    signal); body marker is the fallback that also works for label-less project
+    drafts. Defaults to "linux"."""
+    label_names = {
+        ((l.get("name") if isinstance(l, dict) else l) or "").lower()
+        for l in (labels or [])
+    }
+    if "needs-windows" in label_names:
+        return "windows"
+    if "needs-macos" in label_names:
+        return "macos"
+    if env_section:
+        t = env_section.strip().lower()
+        if "windows" in t:
+            return "windows"
+        if "macos" in t or "darwin" in t:
+            return "macos"
+    return DEFAULT_ENV
+
 
 def cache_dir():
     """Auto-discover a cache directory under $HOME so we don't hit /tmp."""
@@ -770,6 +808,8 @@ def parse_story(issue):
 
     deps_raw = extract_section(body, "Dependencies")
     files_raw = extract_section(body, "Files In Scope")
+    env_raw = extract_section(body, "Environment")
+    requires_env = detect_required_env(env_raw, issue.get("labels"))
 
     deps_parsed = []
     if deps_raw is None:
@@ -805,6 +845,8 @@ def parse_story(issue):
         "deps_raw": deps_raw,
         "files_parsed": files_parsed,
         "files_raw": files_raw,
+        "requires_env": requires_env,
+        "env_raw": env_raw,
         "all_issue_numbers_in_body": all_nums,
         "all_paths_in_body": all_paths,
     }
@@ -851,14 +893,17 @@ def ci_summary(checks):
     }
 
 
-def compute_dispatch_recommendations(ready_stories, active_stories, dep_states):
+def compute_dispatch_recommendations(ready_stories, active_stories, dep_states, caps=None):
     """Greedy conflict-free selection.
 
     Order: ascending story number (stable, predictable); pure drafts (number=None) last.
+    Hold if the story's required execution env is not in this host's caps (routing
+    to another host — e.g. windows stories on the linux orchestrator).
     Skip if any dep is not CLOSED.
     Skip if files overlap with an active story (status In Progress or open PR) or a
     story already picked this cycle.
     """
+    caps = caps or {DEFAULT_ENV}
     active_file_sets = [
         (s["number"], set(s["files_parsed"])) for s in active_stories
     ]
@@ -869,6 +914,17 @@ def compute_dispatch_recommendations(ready_stories, active_stories, dep_states):
     for s in sorted(ready_stories, key=lambda x: (x.get("number") is None, x.get("number") or 0)):
         num = s["number"]
         item_id = s.get("item_id", "")
+        req_env = s.get("requires_env", DEFAULT_ENV)
+        if req_env not in caps:
+            recommendations.append({
+                "number": num,
+                "item_id": item_id,
+                "action": "hold",
+                "reason": f"requires {req_env} execution env; host caps={','.join(sorted(caps))}",
+                "route": req_env,
+            })
+            continue
+
         open_deps = [d for d in s["deps_parsed"] if dep_states.get(d) != "CLOSED"]
         if open_deps:
             dep_desc = ", ".join(
@@ -1671,8 +1727,18 @@ def main():
         })
     out["prs_open"] = pr_summaries
 
+    caps = host_caps()
+    out["host_caps"] = sorted(caps)
+    # Ready stories whose required env this host cannot serve — surfaced so the
+    # dashboard can show the cross-host backlog (e.g. the Windows queue) and so a
+    # self-dispatch host can pick up exactly its slice.
+    out["windows_queue"] = [
+        {"number": s["number"], "item_id": s.get("item_id", ""), "title": s["title"]}
+        for s in ready_parsed
+        if s.get("requires_env", DEFAULT_ENV) == "windows"
+    ]
     out["dispatch_recommendations"] = compute_dispatch_recommendations(
-        ready_parsed, active_parsed, dep_states,
+        ready_parsed, active_parsed, dep_states, caps,
     )
     # Pull the active fix-agent set out of running_containers so the review
     # recommender can skip rebase/dispatch-fix work for any PR with an
@@ -1757,6 +1823,8 @@ def write_output(out, mode):
             "merge_queue": len(out.get("merge_queue", [])),
             "undecomposed_epics": len(out.get("epics_undecomposed", [])),
         },
+        "host_caps": out.get("host_caps", [DEFAULT_ENV]),
+        "windows_queue": out.get("windows_queue", []),
         "running_containers": out.get("running_containers", []),
         "merge_queue": out.get("merge_queue", []),
         "dispatch_recommendations": out.get("dispatch_recommendations", []),

--- a/.claude/scripts/tests/env_routing.test.sh
+++ b/.claude/scripts/tests/env_routing.test.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# Regression test for execution-environment routing in po-cycle-preflight.py.
+#
+# Covers capability-aware story routing: a story declares its required execution
+# environment via a `## Environment` body section and/or a `needs-<env>` GitHub
+# label; a host declares the environments it serves via CFGMS_PO_HOST_CAPS. The
+# preflight must (1) resolve requires_env correctly, (2) hold stories whose env
+# is not in the host's caps with a route hint, and (3) dispatch matching stories
+# through the existing dep/file-conflict gate.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PREFLIGHT="${SCRIPT_DIR}/../po-cycle-preflight.py"
+
+if [[ ! -f "${PREFLIGHT}" ]]; then
+  printf 'FAIL: preflight not found at %s\n' "${PREFLIGHT}" >&2
+  exit 1
+fi
+
+echo "env_routing.test.sh"
+echo "-------------------"
+
+PREFLIGHT_PATH="$PREFLIGHT" python3 - <<'PY'
+import importlib.util, os, sys
+spec = importlib.util.spec_from_file_location("preflight", os.environ["PREFLIGHT_PATH"])
+m = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(m)
+
+ran = 0
+fail = 0
+
+def check(desc, got, want):
+    global ran, fail
+    ran += 1
+    if got == want:
+        print(f"  ok    {desc}")
+    else:
+        fail += 1
+        print(f"  FAIL  {desc}\n         expected: {want!r}\n         actual:   {got!r}")
+
+# ── detect_required_env: body section ──
+check("env body 'windows'", m.detect_required_env("windows", []), "windows")
+check("env body 'Windows 11 host'", m.detect_required_env("Windows 11 host", []), "windows")
+check("env body 'macos'", m.detect_required_env("macos", []), "macos")
+check("env body 'linux'", m.detect_required_env("linux", []), "linux")
+check("env body None -> linux", m.detect_required_env(None, []), "linux")
+check("env body empty -> linux", m.detect_required_env("", []), "linux")
+
+# ── detect_required_env: labels (dict and str forms), label wins ──
+check("label needs-windows (dict)", m.detect_required_env(None, [{"name": "needs-windows"}]), "windows")
+check("label needs-windows (str)", m.detect_required_env(None, ["needs-windows"]), "windows")
+check("label needs-macos", m.detect_required_env(None, [{"name": "needs-macos"}]), "macos")
+check("label overrides linux body", m.detect_required_env("linux", [{"name": "needs-windows"}]), "windows")
+check("unrelated label -> linux", m.detect_required_env(None, [{"name": "story"}]), "linux")
+
+# ── host_caps ──
+def caps_with(val):
+    if val is None:
+        os.environ.pop("CFGMS_PO_HOST_CAPS", None)
+    else:
+        os.environ["CFGMS_PO_HOST_CAPS"] = val
+    return m.host_caps()
+
+check("caps default", caps_with(None), {"linux"})
+check("caps windows", caps_with("windows"), {"windows"})
+check("caps multi", caps_with("windows,linux"), {"windows", "linux"})
+check("caps spaces/case", caps_with(" Windows , Linux "), {"windows", "linux"})
+caps_with(None)
+
+# ── compute_dispatch_recommendations: capability filter ──
+def story(num, env="linux", files=None, deps=None):
+    return {
+        "number": num,
+        "item_id": f"item-{num}",
+        "requires_env": env,
+        "files_parsed": files or [f"pkg/f{num}.go"],
+        "deps_parsed": deps or [],
+    }
+
+# Linux host holds a windows story, dispatches a linux story.
+recs = m.compute_dispatch_recommendations(
+    [story(1, "windows"), story(2, "linux")], [], {}, {"linux"}
+)
+by_num = {r["number"]: r for r in recs}
+check("linux host holds windows story", by_num[1]["action"], "hold")
+check("hold reason names env", "windows execution env" in by_num[1]["reason"], True)
+check("hold carries route hint", by_num[1].get("route"), "windows")
+check("linux host dispatches linux story", by_num[2]["action"], "dispatch")
+
+# Windows host inverts the routing.
+recs = m.compute_dispatch_recommendations(
+    [story(1, "windows"), story(2, "linux")], [], {}, {"windows"}
+)
+by_num = {r["number"]: r for r in recs}
+check("windows host dispatches windows story", by_num[1]["action"], "dispatch")
+check("windows host holds linux story", by_num[2]["action"], "hold")
+
+# Env filter precedes the dep gate: a windows story with an open dep is still
+# held for env (routing), not held for deps.
+recs = m.compute_dispatch_recommendations(
+    [story(1, "windows", deps=[999])], [], {999: "OPEN"}, {"linux"}
+)
+check("env hold precedes dep hold", recs[0].get("route"), "windows")
+
+print(f"\nran={ran}  fail={fail}")
+sys.exit(1 if fail else 0)
+PY

--- a/.claude/scripts/tests/env_routing.test.sh
+++ b/.claude/scripts/tests/env_routing.test.sh
@@ -43,6 +43,7 @@ def check(desc, got, want):
 check("env body 'windows'", m.detect_required_env("windows", []), "windows")
 check("env body 'Windows 11 host'", m.detect_required_env("Windows 11 host", []), "windows")
 check("env body 'macos'", m.detect_required_env("macos", []), "macos")
+check("env body 'darwin' alias", m.detect_required_env("build on a darwin runner", []), "macos")
 check("env body 'linux'", m.detect_required_env("linux", []), "linux")
 check("env body None -> linux", m.detect_required_env(None, []), "linux")
 check("env body empty -> linux", m.detect_required_env("", []), "linux")

--- a/docs/development/story-template.md
+++ b/docs/development/story-template.md
@@ -39,6 +39,13 @@ None
 
 <Use "None — no product-shape change" with justification only if the story genuinely doesn't change observable shape. See ba.md "Documentation & Tests Currency" rule.>
 
+## Environment
+
+<Optional. Omit for ordinary Linux-buildable work (the default). Add only when the
+story needs a specific OS execution environment — `windows`, `macos`, or `linux` —
+to build or live-test behavior a Linux container can't exercise. Routes the story
+off the Linux orchestrator to a host serving that environment (see po.md §7).>
+
 ## Reference Implementation
 
 - <Pointer to existing pattern in the codebase to follow, with file:line>

--- a/docs/development/story-template.md
+++ b/docs/development/story-template.md
@@ -41,10 +41,12 @@ None
 
 ## Environment
 
-<Optional. Omit for ordinary Linux-buildable work (the default). Add only when the
-story needs a specific OS execution environment — `windows`, `macos`, or `linux` —
-to build or live-test behavior a Linux container can't exercise. Routes the story
-off the Linux orchestrator to a host serving that environment (see po.md §7).>
+<Optional. Omit for ordinary Linux-buildable work (the default). Set `windows`
+(or `macos`) when the story needs that host's environment: (1) native OS behavior
+a Linux container can't build/live-test, OR (2) full end-to-end deployment tests
+and troubleshooting — the Windows host runs the Linux-controller + Linux/Windows-
+minion matrix that a container can't. Routes the story off the Linux orchestrator
+to a host serving that environment (see po.md §7).>
 
 ## Reference Implementation
 


### PR DESCRIPTION
## What & why

The PO loop ran on a single host. The founder wants to involve a second
(Windows) host. The useful win isn't parallel throughput — it's **routing work
by execution environment**: a headless dev agent always runs in a Linux
container (on either host), so the Windows host's value is that its *local
session runs natively on Windows*. Work needing a Windows environment must run
in-session, not in a container.

This PR adds capability-aware routing plus a no-docker self-dispatch mode. The
two hosts work **disjoint slices by execution environment**, so two out-of-phase
cron loops can never select the same story — no distributed lock needed. Claiming
a story (`Ready → In Progress`) **before** any work is the backstop.

## Changes

- **preflight** (`po-cycle-preflight.py`): `parse_story` resolves `requires_env`
  from a `## Environment` body section and/or `needs-<env>` labels (default
  `linux`); `compute_dispatch_recommendations` takes `host_caps` and holds
  stories whose env isn't served (with a `route` hint); emits `host_caps` +
  `windows_queue`. Caps come from `CFGMS_PO_HOST_CAPS` (default `linux`).
- **po-act.sh**: claim each story (`Ready → In Progress`) *before* clone/launch,
  roll back to `Ready` on launch failure; new standalone `claim <item_id>`
  subcommand (used by self-dispatch); env-capability guard on `dispatch`.
- **po.md / commands**: new **Self-Dispatch Mode** (§7, `/po work`) — no docker,
  local session claims and works its tagged stories one at a time; Step 6 caps
  filtering + disjoint-role note; dashboard Windows queue; `## Environment`
  conventions; `needs-windows` / `needs-macos` labels.
- **ba.md / story-template.md**: document the optional `## Environment` section.
- **tests**: `env_routing.test.sh` — detection, caps parsing, routing inversion,
  env-hold-precedes-dep-hold.

## Verification

- `env_routing.test.sh` (22 assertions) + existing script tests pass.
- Real preflight runs clean: `host_caps`, `requires_env`, `windows_queue`
  populated; caps inversion verified against live ready stories
  (linux host dispatches linux stories / holds windows; windows host inverts).
- `bash -n` + `py_compile` clean.

These are pipeline-infra files (`.claude/`) — edited directly per workflow, not
dispatched to a dev agent. No Go code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
