### PR TITLE
pipeline: auto-run refresh-pins from cron on new dependency-pins check

### DIFF
--- a/.claude/agents/po.md
+++ b/.claude/agents/po.md
@@ -286,6 +286,8 @@ Each step sets project status `Blocked` on unrecoverable failure and continues t
 
 **Priority order (cap-constrained):** in-flight work is processed before new work. The 7-container cap is shared across all autonomous activity (dev agents, fix-pr, review containers), so when slots are scarce the cycle finishes existing PRs first — they unblock the merge queue, which is more valuable than starting more dev work that would just queue behind them. The numbered steps below reflect this priority: Step 3 (rebase) → Step 4 (review) → Step 5 (fix-cycle) → Step 6 (dispatch new dev). If the cap is exhausted by Steps 3-5, defer Step 6 to the next cycle.
 
+Maintenance steps that create new work (Step 1.6 — pin refresh) or reconcile state run regardless of the container cap, since they do not consume container slots.
+
 **Step 1 — Unblock check:**
 Find recently merged PRs. Check if any `Draft` stories had `## Dependencies` referencing the merged story. If satisfied, they're eligible for Tech Lead review.
 
@@ -295,6 +297,45 @@ Remove stale agent containers and clones. Run:
 ./.claude/scripts/agent-dispatch.sh cleanup-stale
 ```
 This finds containers whose stories are closed, have project status `Failed`, or project status `Blocked` and removes them. Runs before dispatch so re-dispatched stories start with a clean environment. Safe to run every cycle — idempotent, skips containers whose stories are still active.
+
+**Step 1.6 — Dependency pin refresh (cron + cycle):**
+
+The `dependency-pin-check` GitHub Actions workflow appends a `## Weekly Pin Check — <date>` comment (authored by `github-actions`) to a long-lived issue labelled `dependency-pins` whenever a pinned tool/toolchain has a newer upstream release. This step turns that signal into dispatchable bump stories by running the `refresh-pins` skill — which researches every pin against upstream, applies the cooldown + CVE policy, and creates one Draft `story,dependencies` issue per pin that should bump. Those drafts are then promoted by the Tech Lead pass (Step 2) in this same cycle.
+
+Runs in both `cron` and `cycle` modes. It is **orchestrator-only** — the no-docker self-dispatch hosts do not run §4 steps. It needs no Docker (just `gh`/`curl`/`WebFetch`), so the remote `po-cron` trigger can run it too.
+
+**Idempotency gate (do this BEFORE invoking the skill — the skill does a full network sweep, so don't run it every cycle):**
+
+1. Find the open pin-check issue:
+   ```bash
+   gh issue list --repo cfg-is/cfgms --label dependency-pins --state open \
+     --json number --jq '.[0].number'
+   ```
+   If none, skip the step.
+
+2. Compare the latest automated weekly-check comment against the last time this step processed one. Both are read from the issue's comments — the marker is an HTML comment `<!-- po-pin-refresh -->` this step posts after a run:
+   ```bash
+   gh issue view <PIN_ISSUE> --repo cfg-is/cfgms --json comments --jq '{
+     latest_check: ([.comments[] | select(.author.login=="github-actions") | select(.body|test("Weekly Pin Check")) | .createdAt] | last // ""),
+     last_processed: ([.comments[] | select(.body|test("po-pin-refresh")) | .createdAt] | last // "")
+   }'
+   ```
+   Run the skill only if `latest_check` is non-empty AND (`last_processed` is empty OR `latest_check > last_processed`) — ISO-8601 UTC strings compare lexicographically. Otherwise report "pins current (last processed <last_processed>)" and skip.
+
+3. Run the skill (empty args = sweep every pin; it is itself idempotent and will comment on, not duplicate, any bump story that already exists):
+   ```
+   Skill: refresh-pins
+   ```
+
+4. After it returns, record the marker so later cycles (and the other host) don't re-sweep the same weekly check. Include the story numbers the skill reported:
+   ```bash
+   ./.claude/scripts/po-act.sh log <PIN_ISSUE> - <<'EOF'
+   <!-- po-pin-refresh -->
+   Processed weekly pin check via refresh-pins. Bump stories created/updated: <#NNNN, #NNNN or "none — all pins within cooldown/up to date">. Drafts enter the Tech Lead queue (Step 2).
+   EOF
+   ```
+
+Include the skill's headline (bumping / holding / up-to-date counts + story numbers) in the cycle summary's pipeline-depth section.
 
 **Step 2 — Tech Lead pass (legacy only):**
 Handles `Draft` stories that were created before the Planning Team was introduced. New epics go through Step 7 (Planning Team) and produce `Ready` stories directly. Once the backlog of legacy drafts clears, this step becomes a no-op.

--- a/.claude/agents/po.md
+++ b/.claude/agents/po.md
@@ -334,6 +334,12 @@ Runs in both `cron` and `cycle` modes. It is **orchestrator-only** — the no-do
    Processed weekly pin check via refresh-pins. Bump stories created/updated: <#NNNN, #NNNN or "none — all pins within cooldown/up to date">. Drafts enter the Tech Lead queue (Step 2).
    EOF
    ```
+   If the marker post fails (network, etc.), the next cycle re-sweeps the same
+   check — harmless, because `refresh-pins` is idempotent (it comments on, never
+   duplicates, an existing bump story); the only cost is one redundant network
+   sweep. If `gh issue list` ever returns more than one open `dependency-pins`
+   issue, treat that as an anomaly and process the most recently updated one (the
+   label is meant for a single long-lived issue).
 
 Include the skill's headline (bumping / holding / up-to-date counts + story numbers) in the cycle summary's pipeline-depth section.
 

--- a/.claude/commands/po.md
+++ b/.claude/commands/po.md
@@ -32,7 +32,7 @@ If `$ARGUMENTS` starts with any of `cron`, `cycle`, `decompose`, or `plan`, do *
 
 **How:**
 1. Read `.claude/agents/po.md` to load the PO's behavioral rules and the relevant section.
-2. Execute the section directly in the main session in priority order — preflight, unblock check, agent cleanup, Tech Lead pass, rebase (§4.1 Step 3), Acceptance Reviewer (§4.1 Step 4), fix cycle (§4.1 Step 5), dispatch (§4.1 Step 6), Planning Team (§4.1 Step 7 — see routing table above), forward edge, session log.
+2. Execute the section directly in the main session in priority order — preflight, unblock check, agent cleanup, pin refresh (§4.1 Step 1.6), Tech Lead pass, rebase (§4.1 Step 3), Acceptance Reviewer (§4.1 Step 4), fix cycle (§4.1 Step 5), dispatch (§4.1 Step 6), Planning Team (§4.1 Step 7 — see routing table above), forward edge, session log.
 3. Honor the 7-container cap from `feedback_max_running_agents.md` — the cap is on docker containers (`./.claude/scripts/agent-dispatch.sh list-running` count) shared across all autonomous activity (dev, fix-pr, review). When slots are scarce, finish in-flight work first (Steps 3-5) and defer new dev dispatch (Step 6) to the next cycle.
 4. Spawn nested subagents via the Agent tool with `mode: auto`. Spawn the Planning Team via `TeamCreate` + Agent calls with `team_name` (per `.claude/agents/po.md` §4.1 Step 7c).
 5. Report the summary back to the founder using the same format the PO subagent uses.


### PR DESCRIPTION
## What & why

The `dependency-pin-check` workflow appends a weekly `## Weekly Pin Check — <date>`
comment to the long-lived `dependency-pins` issue (#1807) whenever a pinned tool
or the Go toolchain has a newer upstream release. Nothing consumed that signal —
the `refresh-pins` skill was manual-only, so updated pins sat untouched until a
human ran it.

This adds **Step 1.6** to the PO cron/cycle: detect a *new* weekly-check comment
and run `refresh-pins` to turn it into dispatchable Draft bump stories, which the
Tech Lead pass (Step 2) promotes to Ready in the same cycle.

## How it works

- **Trigger:** an updated `dependency-pins` issue — specifically a new
  `github-actions` "Weekly Pin Check" comment.
- **Idempotency gate (before the skill, which does a full network sweep):**
  compare the latest weekly-check comment's `createdAt` against the last
  `<!-- po-pin-refresh -->` marker comment this step posts. Run only if the
  check is newer (ISO-8601 lexicographic compare). Otherwise skip.
- **Action:** `Skill: refresh-pins` (itself idempotent — comments on, never
  duplicates, an existing bump story), then post the marker recording the run.
- **Scope:** orchestrator-only (self-dispatch hosts don't run §4 steps), no
  Docker, so the remote `po-cron` trigger can run it too.

## Verification

- Gate jq validated against the live #1807: `latest_check=2026-06-17T12:51:04Z`,
  `last_processed=""` → correctly evaluates to "run". After a run posts the
  marker, the same check no longer triggers.
- The skill's bump-story template (`assets/story-template.md`) is already
  preflight-parser-compliant (`## Files In Scope`, `## Dependencies: None`), so
  the created drafts flow through dispatch without `parse_warnings`.

Pipeline-infra docs only (`.claude/agents/po.md`, `.claude/commands/po.md`) —
edited directly, no Go code, no dev-agent dispatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
