### PR TITLE
deps: bump trufflehog v3.95.3 → v3.95.5 (Issue #1984)

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -69,7 +69,7 @@ RUN GOPATH=$(go env GOPATH) \
     && chmod +x "$GOPATH/bin/nancy"
 
 # truffleHog (optional, best-effort secret scanning — pinned version, not @main)
-RUN curl -sSfL https://raw.githubusercontent.com/trufflesecurity/trufflehog/v3.95.3/scripts/install.sh | sh -s -- -b /usr/local/bin v3.95.3 || true
+RUN curl -sSfL https://raw.githubusercontent.com/trufflesecurity/trufflehog/v3.95.5/scripts/install.sh | sh -s -- -b /usr/local/bin v3.95.5 || true
 
 # Claude Code
 RUN npm install -g @anthropic-ai/claude-code

--- a/.github/workflows/dependency-pin-check.yml
+++ b/.github/workflows/dependency-pin-check.yml
@@ -120,7 +120,7 @@ jobs:
         check_version "staticcheck" "dominikh/go-tools"                       "2026.1"
         check_version "gitleaks"    "zricethezav/gitleaks"                    "v8.30.1"
         check_version "nancy"       "sonatype-nexus-community/nancy"          "v2.0.0"
-        check_version "trufflehog"  "trufflesecurity/trufflehog"              "v3.95.3"
+        check_version "trufflehog"  "trufflesecurity/trufflehog"              "v3.95.5"
         check_version "trivy"       "aquasecurity/trivy"                      "v0.71.0"
         check_version "go-licenses" "google/go-licenses"                      "v2.0.1"
         check_version "golangci-lint" "golangci/golangci-lint"                "v2.12.2"


### PR DESCRIPTION
## Summary

- Bump trufflehog from `v3.95.3` to `v3.95.5` in all pinned locations (lockstep required)
- v3.95.5 released 2026-06-02; 3-day cooldown elapsed; no CVEs against current pin

## Files Changed

- `.github/workflows/dependency-pin-check.yml:123` — freshness-check pin updated
- `.devcontainer/Dockerfile:72` — install script URL and version arg updated

## Verification

- `grep -rE "v3\.95\.3" .github/workflows/dependency-pin-check.yml .devcontainer/Dockerfile` → 0 matches ✓
- `grep -rE "v3\.95\.5" .github/workflows/dependency-pin-check.yml .devcontainer/Dockerfile` → 2 matches ✓
- `make test` → PASS ✓

## Specialist Review Results

**QA Test Runner**: PASS — story changes verified clean; 2 pre-existing flaky timing tests in `pkg/audit` and `pkg/cache` are unrelated to this bump.

**QA Code Reviewer**: PASS — both occurrences correctly updated; 0 old-version matches, 2 new-version matches confirmed.

**Security Engineer**: PASS — upstream v3.95.5 confirmed legitimate (non-draft, non-prerelease, published 2026-06-02); install script fetched from pinned immutable git tag; no hardcoded secrets or injection vectors; all security scans passed.

Fixes #1984

🤖 Generated with [Claude Code](https://claude.com/claude-code)