### PR TITLE
pipeline: make po preflight run on a Windows self-dispatch host (Issue #2054)

### DIFF
--- a/.claude/scripts/po-cycle-preflight.py
+++ b/.claude/scripts/po-cycle-preflight.py
@@ -29,6 +29,7 @@ that would inherit the broken base.
 import json
 import os
 import re
+import shutil
 import subprocess
 import sys
 from concurrent.futures import ThreadPoolExecutor, as_completed
@@ -120,7 +121,7 @@ def gh_graphql_tolerant(query):
     _GH_CALL_COUNT += 1
     result = subprocess.run(
         ["gh", "api", "graphql", "-f", f"query={query}"],
-        capture_output=True, text=True, check=False, timeout=60,
+        capture_output=True, text=True, encoding="utf-8", errors="replace", check=False, timeout=60,
     )
     if not result.stdout.strip():
         return None
@@ -135,7 +136,7 @@ def gh(*args, check=True):
     global _GH_CALL_COUNT
     _GH_CALL_COUNT += 1
     result = subprocess.run(
-        ["gh", *args], capture_output=True, text=True, check=False, timeout=60
+        ["gh", *args], capture_output=True, text=True, encoding="utf-8", errors="replace", check=False, timeout=60
     )
     if result.returncode != 0:
         if check:
@@ -499,6 +500,67 @@ def fix_landed_after_review(pr):
     return commit_dt > review_dt
 
 
+def resolve_bash(platform=None, environ=None, exists=None, which=None):
+    """Resolve a usable ``bash`` executable for running project-queue.sh.
+
+    On Linux/macOS a bare ``bash`` resolves correctly via PATH, so we return it
+    unchanged. On a Windows self-dispatch host (#2039) Python resolves a bare
+    ``bash`` against the *Windows* PATH, which finds the WSL launcher
+    (``System32\\bash.exe``) or the Store alias (``WindowsApps\\bash.exe``)
+    before Git Bash. WSL is typically not functional on the Hyper-V host, so
+    those stubs fail with ``execvpe(/bin/bash) failed`` and degrade the whole
+    preflight (Issue #2054). Prefer an explicit ``CFGMS_BASH`` override, then
+    Git Bash (including the path derived from the ``git`` executable), and reject
+    the WSL/Store stubs outright.
+
+    All inputs are injectable so the Windows branch is testable on a Linux CI
+    runner without a real Windows host.
+    """
+    if platform is None:
+        platform = sys.platform
+    if environ is None:
+        environ = os.environ
+    if exists is None:
+        exists = os.path.exists
+    if which is None:
+        which = shutil.which
+
+    override = environ.get("CFGMS_BASH")
+    if override and exists(override):
+        return override
+
+    is_windows = platform.startswith("win") or platform == "cygwin"
+    if not is_windows:
+        return "bash"
+
+    candidates = [
+        r"C:\Program Files\Git\bin\bash.exe",
+        r"C:\Program Files\Git\usr\bin\bash.exe",
+        r"C:\Program Files (x86)\Git\bin\bash.exe",
+    ]
+    git = which("git")
+    if git:
+        # ...\Git\cmd\git.exe -> ...\Git ; append bin/ and usr/bin/ bash.
+        git_root = os.path.dirname(os.path.dirname(git))
+        candidates.append(os.path.join(git_root, "bin", "bash.exe"))
+        candidates.append(os.path.join(git_root, "usr", "bin", "bash.exe"))
+    for cand in candidates:
+        if exists(cand):
+            return cand
+
+    # Last resort: a PATH bash that is NOT the WSL launcher or Store alias.
+    found = which("bash")
+    if found:
+        low = found.lower()
+        if "system32" not in low and "windowsapps" not in low:
+            return found
+
+    raise RuntimeError(
+        "no usable bash found on Windows (the WSL/Store 'bash' stub is rejected); "
+        "set CFGMS_BASH to a Git Bash bash.exe (Issue #2054)"
+    )
+
+
 def _pq_script_path():
     """Return the project-queue.sh path, honoring CFGMS_TEST_PROJECT_QUEUE override."""
     override = os.environ.get("CFGMS_TEST_PROJECT_QUEUE")
@@ -515,8 +577,8 @@ def project_queue_list_by_status(status):
     """
     script = _pq_script_path()
     result = subprocess.run(
-        ["bash", script, "list-by-status", status],
-        capture_output=True, text=True, check=False, timeout=60,
+        [resolve_bash(), script, "list-by-status", status],
+        capture_output=True, text=True, encoding="utf-8", errors="replace", check=False, timeout=60,
     )
     if result.returncode != 0:
         raise RuntimeError(
@@ -548,8 +610,8 @@ def auto_close_merged_items(degraded_reasons=None):
     script = _pq_script_path()
 
     result = subprocess.run(
-        ["bash", script, "list-by-status", "In Progress"],
-        capture_output=True, text=True, check=False, timeout=60,
+        [resolve_bash(), script, "list-by-status", "In Progress"],
+        capture_output=True, text=True, encoding="utf-8", errors="replace", check=False, timeout=60,
     )
     if result.returncode != 0:
         degraded_reasons.append(
@@ -574,8 +636,8 @@ def auto_close_merged_items(degraded_reasons=None):
             continue
         try:
             get_result = subprocess.run(
-                ["bash", script, "get-item", item_id],
-                capture_output=True, text=True, check=False, timeout=60,
+                [resolve_bash(), script, "get-item", item_id],
+                capture_output=True, text=True, encoding="utf-8", errors="replace", check=False, timeout=60,
             )
             if get_result.returncode != 0:
                 degraded_reasons.append(
@@ -621,8 +683,8 @@ def auto_close_merged_items(degraded_reasons=None):
             continue
         try:
             update_result = subprocess.run(
-                ["bash", script, "update-field", item_id, "status", "Done"],
-                capture_output=True, text=True, check=False, timeout=60,
+                [resolve_bash(), script, "update-field", item_id, "status", "Done"],
+                capture_output=True, text=True, encoding="utf-8", errors="replace", check=False, timeout=60,
             )
             if update_result.returncode != 0:
                 degraded_reasons.append(
@@ -642,7 +704,7 @@ def running_containers():
     try:
         result = subprocess.run(
             ["docker", "ps", "--filter", "name=cfg-agent-", "--format", "{{.Names}}"],
-            capture_output=True, text=True, check=True, timeout=10,
+            capture_output=True, text=True, encoding="utf-8", errors="replace", check=True, timeout=10,
         )
         return [n for n in result.stdout.splitlines() if n.strip()]
     except (subprocess.CalledProcessError, subprocess.TimeoutExpired, FileNotFoundError):
@@ -690,17 +752,17 @@ def code_health_check():
     try:
         sha_proc = subprocess.run(
             ["git", "-C", str(repo_root), "rev-parse", "origin/develop"],
-            capture_output=True, text=True, check=False, timeout=10,
+            capture_output=True, text=True, encoding="utf-8", errors="replace", check=False, timeout=10,
         )
         if sha_proc.returncode != 0:
             # Try fetching first
             subprocess.run(
                 ["git", "-C", str(repo_root), "fetch", "--quiet", "origin", "develop"],
-                capture_output=True, text=True, check=False, timeout=30,
+                capture_output=True, text=True, encoding="utf-8", errors="replace", check=False, timeout=30,
             )
             sha_proc = subprocess.run(
                 ["git", "-C", str(repo_root), "rev-parse", "origin/develop"],
-                capture_output=True, text=True, check=False, timeout=10,
+                capture_output=True, text=True, encoding="utf-8", errors="replace", check=False, timeout=10,
             )
         if sha_proc.returncode != 0:
             result["skipped"] = True
@@ -723,7 +785,7 @@ def code_health_check():
         # Stale from a previous crash — remove via git so refs stay clean.
         subprocess.run(
             ["git", "-C", str(repo_root), "worktree", "remove", "--force", str(worktree)],
-            capture_output=True, text=True, check=False, timeout=15,
+            capture_output=True, text=True, encoding="utf-8", errors="replace", check=False, timeout=15,
         )
         if worktree.exists():
             # Filesystem leftover (worktree metadata already gone)
@@ -733,7 +795,7 @@ def code_health_check():
     add_proc = subprocess.run(
         ["git", "-C", str(repo_root), "worktree", "add", "--quiet", "--detach",
          str(worktree), develop_sha],
-        capture_output=True, text=True, check=False, timeout=30,
+        capture_output=True, text=True, encoding="utf-8", errors="replace", check=False, timeout=30,
     )
     if add_proc.returncode != 0:
         result["skipped"] = True
@@ -746,7 +808,7 @@ def code_health_check():
         arch = subprocess.run(
             ["make", "check-architecture"],
             cwd=str(worktree),
-            capture_output=True, text=True, check=False, timeout=120,
+            capture_output=True, text=True, encoding="utf-8", errors="replace", check=False, timeout=120,
         )
         result["checks"]["architecture"] = {
             "ok": arch.returncode == 0,
@@ -759,7 +821,7 @@ def code_health_check():
         build = subprocess.run(
             ["go", "build", "./..."],
             cwd=str(worktree),
-            capture_output=True, text=True, check=False, timeout=300,
+            capture_output=True, text=True, encoding="utf-8", errors="replace", check=False, timeout=300,
         )
         result["checks"]["build"] = {
             "ok": build.returncode == 0,
@@ -777,7 +839,7 @@ def code_health_check():
     finally:
         subprocess.run(
             ["git", "-C", str(repo_root), "worktree", "remove", "--force", str(worktree)],
-            capture_output=True, text=True, check=False, timeout=15,
+            capture_output=True, text=True, encoding="utf-8", errors="replace", check=False, timeout=15,
         )
 
     return result
@@ -1568,8 +1630,8 @@ def main():
     def _fetch_draft_body(item):
         try:
             res = subprocess.run(
-                ["bash", _pq, "get-item", item["item_id"]],
-                capture_output=True, text=True, check=False, timeout=60,
+                [resolve_bash(), _pq, "get-item", item["item_id"]],
+                capture_output=True, text=True, encoding="utf-8", errors="replace", check=False, timeout=60,
             )
             if res.returncode != 0:
                 return item["item_id"], None

--- a/.claude/scripts/tests/bash_resolution.test.sh
+++ b/.claude/scripts/tests/bash_resolution.test.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+# Regression test for resolve_bash() in po-cycle-preflight.py (Issue #2054).
+#
+# On a Windows self-dispatch host (#2039), Python resolves a bare `bash` against
+# the Windows PATH and finds the WSL launcher (System32\bash.exe) or the Store
+# alias (WindowsApps\bash.exe) before Git Bash. Those stubs fail and degrade the
+# whole preflight, blocking `/po work`. resolve_bash() must prefer CFGMS_BASH,
+# then Git Bash (incl. the git-derived path), and reject the stubs — while
+# leaving Linux/macOS unchanged. All inputs are injected so the Windows branch
+# is exercised here on a Linux CI runner.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PREFLIGHT="${SCRIPT_DIR}/../po-cycle-preflight.py"
+
+if [[ ! -f "${PREFLIGHT}" ]]; then
+  printf 'FAIL: preflight not found at %s\n' "${PREFLIGHT}" >&2
+  exit 1
+fi
+
+echo "bash_resolution.test.sh"
+echo "-----------------------"
+
+PREFLIGHT_PATH="$PREFLIGHT" python3 - <<'PY'
+import importlib.util, os, sys
+spec = importlib.util.spec_from_file_location("preflight", os.environ["PREFLIGHT_PATH"])
+m = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(m)
+
+ran = 0
+fail = 0
+
+def check(desc, got, want):
+    global ran, fail
+    ran += 1
+    if got == want:
+        print(f"  ok    {desc}")
+    else:
+        fail += 1
+        print(f"  FAIL  {desc}\n         expected: {want!r}\n         actual:   {got!r}")
+
+def check_raises(desc, fn):
+    global ran, fail
+    ran += 1
+    try:
+        got = fn()
+        fail += 1
+        print(f"  FAIL  {desc}\n         expected: RuntimeError\n         actual:   {got!r}")
+    except RuntimeError:
+        print(f"  ok    {desc}")
+
+NONE = lambda *a, **k: None
+NO_EXIST = lambda p: False
+
+# ── Linux/macOS passthrough (unchanged behavior) ──
+check("linux -> bash",
+      m.resolve_bash(platform="linux", environ={}, exists=NO_EXIST, which=NONE), "bash")
+check("darwin -> bash",
+      m.resolve_bash(platform="darwin", environ={}, exists=NO_EXIST, which=NONE), "bash")
+
+# ── CFGMS_BASH override ──
+check("CFGMS_BASH honored when it exists (windows)",
+      m.resolve_bash(platform="win32", environ={"CFGMS_BASH": r"X:\custom\bash.exe"},
+                     exists=lambda p: p == r"X:\custom\bash.exe", which=NONE),
+      r"X:\custom\bash.exe")
+check("CFGMS_BASH ignored when missing -> linux passthrough",
+      m.resolve_bash(platform="linux", environ={"CFGMS_BASH": "/nope/bash"},
+                     exists=NO_EXIST, which=NONE), "bash")
+
+# ── Windows: prefer Git Bash ──
+GITBASH = r"C:\Program Files\Git\bin\bash.exe"
+check("windows prefers Git Bash bin",
+      m.resolve_bash(platform="win32", environ={},
+                     exists=lambda p: p == GITBASH, which=NONE), GITBASH)
+
+# ── Windows: path derived from `git` location ──
+git_exe = os.path.join("C:\\Tools\\Git", "cmd", "git.exe")
+git_root = os.path.dirname(os.path.dirname(git_exe))
+git_derived = os.path.join(git_root, "usr", "bin", "bash.exe")
+check("windows uses git-derived usr/bin path",
+      m.resolve_bash(platform="win32", environ={},
+                     exists=lambda p: p == git_derived,
+                     which=lambda n: git_exe if n == "git" else None),
+      git_derived)
+
+# ── Windows: reject the WSL launcher and Store alias ──
+check_raises("windows rejects WSL System32 stub",
+             lambda: m.resolve_bash(platform="win32", environ={}, exists=NO_EXIST,
+                                    which=lambda n: r"C:\WINDOWS\System32\bash.exe" if n == "bash" else None))
+check_raises("windows rejects WindowsApps Store alias",
+             lambda: m.resolve_bash(platform="win32", environ={}, exists=NO_EXIST,
+                                    which=lambda n: r"C:\Users\x\AppData\Local\Microsoft\WindowsApps\bash.exe" if n == "bash" else None))
+
+# ── Windows: accept a non-stub PATH bash as last resort ──
+MSYS = r"C:\msys64\usr\bin\bash.exe"
+check("windows accepts non-stub PATH bash (last resort)",
+      m.resolve_bash(platform="win32", environ={}, exists=NO_EXIST,
+                     which=lambda n: MSYS if n == "bash" else None), MSYS)
+
+print(f"\n{ran - fail}/{ran} checks passed")
+sys.exit(1 if fail else 0)
+PY


### PR DESCRIPTION
Fixes #2054. Makes `/po work` Self-Dispatch Mode (#2039) actually runnable on the Windows Hyper-V host by correcting two Linux assumptions in `po-cycle-preflight.py`. Both are standard cross-platform-Python hygiene, not Windows-specific forks.

## 1. bash resolution
`subprocess.run(["bash", …])` resolves a bare `bash` against the **Windows** PATH → finds the WSL launcher (`System32\bash.exe`) / Store alias before Git Bash. WSL is non-functional on the host (`execvpe(/bin/bash) failed`), degrading every `project-queue.sh` call. New `resolve_bash()`: honors `CFGMS_BASH`, prefers Git Bash (incl. the path derived from `which("git")`), rejects the WSL/Store stubs, raises a clear error otherwise. Linux/macOS return `"bash"` unchanged. Injectable for testing.

## 2. UTF-8 decoding
`subprocess.run(…, text=True)` decoded `gh` output with the Windows locale codec (**cp1252**); a UTF-8 byte (e.g. an em-dash in an issue title) crashed the reader thread, so `stdout` became `None` and `.strip()` raised — failing the GraphQL board read. Pinned `encoding="utf-8", errors="replace"` on all text-capturing subprocess calls.

## Validation (live, on the Windows host)
Preflight progression as each layer was fixed:
- before: `degraded`, WSL `execvpe(/bin/bash)` errors, `ready=0`
- after bash fix: WSL errors gone, but cp1252 `UnicodeDecodeError` → `ready=0`
- after UTF-8 fix: **board reads, `ready=13`, `windows_queue` correctly = #2044/#2046/#2047**

Tests:
- New `bash_resolution.test.sh` — 9/9 (linux/darwin passthrough, CFGMS_BASH override, Git-Bash preference, git-derived path, WSL/Store stub rejection, non-stub last-resort). Runs on Linux CI via injected args.
- Existing `env_routing` / `preflight_path_regex` / `review_pr_detection` tests pass.

## Note (separate, pre-existing — not this PR)
The preflight now correctly reports `dispatch_blocked: true` because develop's `architecture` check is RED: `features/workflow/modules/m365/gdap/benchmark_test.go` imports `pkg/storage/providers/{flatfile,sqlite}` directly. That blocks all dispatch (Linux + Windows) until fixed — tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)