### PR TITLE
gdap: move blank storage-provider imports to providers_test.go (Issue #2055)

### DIFF
--- a/features/modules/script/types.go
+++ b/features/modules/script/types.go
@@ -26,7 +26,7 @@ type ShellType string
 const (
 	// Windows shells
 	ShellPowerShell ShellType = "powershell" // Windows PowerShell 5.1 (powershell.exe)
-	ShellPwsh       ShellType = "pwsh"        // PowerShell Core / cross-platform (pwsh.exe)
+	ShellPwsh       ShellType = "pwsh"       // PowerShell Core / cross-platform (pwsh.exe)
 	ShellCmd        ShellType = "cmd"
 
 	// Unix shells

--- a/features/workflow/modules/m365/gdap/benchmark_test.go
+++ b/features/workflow/modules/m365/gdap/benchmark_test.go
@@ -21,8 +21,6 @@ import (
 	"github.com/cfgis/cfgms/features/workflow/modules/m365/auth"
 	storageInterfaces "github.com/cfgis/cfgms/pkg/storage/interfaces"
 	business "github.com/cfgis/cfgms/pkg/storage/interfaces/business"
-	_ "github.com/cfgis/cfgms/pkg/storage/providers/flatfile"
-	_ "github.com/cfgis/cfgms/pkg/storage/providers/sqlite"
 
 	"github.com/stretchr/testify/require"
 )

--- a/features/workflow/modules/m365/gdap/providers_test.go
+++ b/features/workflow/modules/m365/gdap/providers_test.go
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+package gdap
+
+// Provider registration for tests in this package.
+// Benchmark and other tests use interfaces.CreateOSSStorageManager which
+// requires these providers to be registered via their init() functions.
+import (
+	_ "github.com/cfgis/cfgms/pkg/storage/providers/flatfile"
+	_ "github.com/cfgis/cfgms/pkg/storage/providers/sqlite"
+)


### PR DESCRIPTION
## Summary

- Moves `_ "github.com/cfgis/cfgms/pkg/storage/providers/flatfile"` and `_ "github.com/cfgis/cfgms/pkg/storage/providers/sqlite"` from `benchmark_test.go` to a new `providers_test.go` in the same package, which is in the `*/providers_test.go` allowlist in `scripts/check-providers.sh`
- Fixes the `make check-architecture` failure that was blocking all agent dispatch on `develop`
- Also fixes a pre-existing `gofmt` alignment violation in `features/modules/script/types.go` (introduced by commit `36c5214e`, caused `make test-agent-complete` to fail)

Fixes #2055

## Test plan

- [x] `make check-architecture` passes — 0 storage-provider import violations
- [x] `go test -run X -bench . ./features/workflow/modules/m365/gdap/` — benchmark compiles and runs (10 iterations, ~103ms/op)
- [x] `go test ./features/workflow/modules/m365/gdap/...` — all existing package tests pass
- [x] `make test-agent-complete` — full suite passes (~95% CI coverage)

## Specialist Review Results

- **QA Code Reviewer**: PASS — follows established `*/providers_test.go` pattern exactly; no mocks, no skips, no quality issues
- **Security Engineer**: PASS — 0 blocking issues; secret scans, architecture check, and security scans all green
- **QA Test Runner**: PASS (after gofmt fix) — all pre-commit checks, fast tests, production-critical tests, and cross-platform compilation passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)