### PR TITLE
controller: freeze port-swap upgrade orchestrator as experimental (Issue #2019)

### DIFF
--- a/cmd/cfg/cmd/controller_upgrade.go
+++ b/cmd/cfg/cmd/controller_upgrade.go
@@ -35,8 +35,13 @@ var controllerUpgradeCmd = &cobra.Command{
 	Long: `cfg controller upgrade orchestrates a blue/green controller upgrade
 via the port-ownership-swap pattern.
 
+EXPERIMENTAL — this is not the supported production upgrade path. The
+supported path is the smoketest-gated restart upgrade (cfg controller upgrade
+restart, Issue #2015). This port-swap orchestrator is frozen per ADR-007
+and will be removed once the restart-gated path is the documented default.
+
 Subcommands:
-  upgrade              Stage a new binary, smoketest it, and cut over.
+  upgrade run          Stage a new binary, smoketest it, and cut over (experimental).
   upgrade status       Show which binary is canonical and which is in quarantine.
   upgrade rollback     Restore the previously-quarantined binary as canonical.
 
@@ -49,8 +54,16 @@ Run --help on each subcommand for details.`,
 
 var controllerUpgradeRunCmd = &cobra.Command{
 	Use:   "run",
-	Short: "Stage a new controller binary, smoketest, and cut over",
-	Long: `Runs the full cutover orchestration synchronously:
+	Short: "Stage a new controller binary, smoketest, and cut over (EXPERIMENTAL — not the supported path)",
+	Long: `EXPERIMENTAL — this subcommand is not the supported production upgrade path.
+
+Use cfg controller upgrade restart (Issue #2015) for the supported
+smoketest-gated restart upgrade. This port-swap orchestrator is frozen per
+ADR-007 (docs/architecture/decisions/007-controller-upgrade-and-state-externalization.md)
+and will be removed once the restart-gated path is the documented default.
+Bugs in this subcommand are not prioritised.
+
+Runs the full port-swap cutover orchestration synchronously:
 
   1. Validate the new binary exists and is executable.
   2. Spawn it on the candidate listen addresses for smoketesting.

--- a/cmd/cfg/cmd/controller_upgrade_test.go
+++ b/cmd/cfg/cmd/controller_upgrade_test.go
@@ -4,6 +4,7 @@ package cmd
 
 import (
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -11,6 +12,19 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// TestControllerUpgradeRunCmd_ExperimentalNotice asserts that the upgrade run
+// subcommand's help text contains an experimental/unsupported notice referencing
+// ADR-007, as required by Issue #2019 (freeze the port-swap orchestrator).
+func TestControllerUpgradeRunCmd_ExperimentalNotice(t *testing.T) {
+	longHelp := controllerUpgradeRunCmd.Long
+	assert.True(t,
+		strings.Contains(strings.ToLower(longHelp), "experimental") ||
+			strings.Contains(strings.ToLower(longHelp), "not the supported"),
+		"controllerUpgradeRunCmd.Long must contain an experimental / not-the-supported-path notice; got:\n%s", longHelp)
+	assert.Contains(t, longHelp, "ADR-007",
+		"controllerUpgradeRunCmd.Long must reference ADR-007")
+}
 
 // TestControllerUpgradeStatus_NoStateFile covers the fresh-install
 // path: when the state file doesn't exist, status prints a friendly
@@ -130,8 +144,6 @@ func TestControllerUpgradeCmd_FlagsRegistered(t *testing.T) {
 		{"upgrade rollback", []string{"state", "config", "canonical-api-addr", "canonical-transport-addr", "candidate-api-addr", "candidate-transport-addr"}},
 	} {
 		t.Run(c.name, func(t *testing.T) {
-			var cmd interface{ Flag(string) interface{} } //nolint:unused // for symmetry
-			_ = cmd
 			switch c.name {
 			case "upgrade run":
 				for _, f := range c.want {

--- a/features/controller/cutover/cutover.go
+++ b/features/controller/cutover/cutover.go
@@ -7,6 +7,19 @@
 // docs/architecture/operating-model.md "Concurrent Controller Execution
 // (Blue/Green Pattern)" for the full architectural context.
 //
+// # Deprecation notice (Issue #2019, ADR-007)
+//
+// This port-swap orchestrator is EXPERIMENTAL and is not the supported
+// production upgrade path. Per ADR-007
+// (docs/architecture/decisions/007-controller-upgrade-and-state-externalization.md),
+// investment in this path has stopped. The supported upgrade path is the
+// smoketest-gated restart upgrade (Issue #2015, cfg controller upgrade
+// restart). The /api/v1/ready real-state smoketest (HTTPSmoketester) and
+// the keep-previous-binary rollback pattern from this package are reused by
+// the restart-gated upgrade and remain maintained. Removal of the remaining
+// port-swap orchestration is tracked for once the restart-gated path is the
+// documented default. No new feature work should target this package.
+//
 // # The cutover state machine
 //
 //	idle ─▶ preparing ─▶ smoketesting ─▶ swapping ─▶ quarantined ─▶ idle


### PR DESCRIPTION
## Summary

- Mark `cfg controller upgrade run` and its parent `upgrade` command as **EXPERIMENTAL / not the supported path** in their `Long` help strings, pointing to `cfg controller upgrade restart` (Issue #2015) and ADR-007
- Add matching deprecation notice to the `features/controller/cutover` package doc: no new feature work should target this package; removal tracked once restart-gated path is the documented default
- Remove pre-existing dead code (`var cmd interface{...}; _ = cmd`) in the test file spotted while touching it
- Add `TestControllerUpgradeRunCmd_ExperimentalNotice` to assert the experimental notice and ADR-007 reference are present in the help text

No logic, no rollback/status subcommands, and no smoketester behaviour was changed — text/comment surgery only per Issue #2019 scope.

Fixes #2019

## Specialist Review Results

| Specialist | Result |
|---|---|
| QA Test Runner | **PASS** — all packages pass, cross-platform builds verified, `TestControllerUpgradeRunCmd_ExperimentalNotice` passes |
| QA Code Reviewer | **PASS** — blocking dead-code issue fixed before commit; new test covers both experimental text and ADR-007 reference |
| Security Engineer | **PASS** — 0 blocking issues; no logic changes, no secrets, no log injection, architecture compliance confirmed |

## Test plan

- [ ] `go test ./cmd/cfg/cmd/... ./features/controller/cutover/...` — all pass
- [ ] `cfg controller upgrade run --help` shows EXPERIMENTAL notice and ADR-007 reference
- [ ] `cfg controller upgrade --help` shows EXPERIMENTAL notice
- [ ] `TestControllerUpgradeRunCmd_ExperimentalNotice` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)