### PR TITLE
hyperv: source schema, ProvisionState machine types, and per-VM provisioning record (Issue #2043)

### DIFF
--- a/features/modules/hyperv/provision.go
+++ b/features/modules/hyperv/provision.go
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+package hyperv
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"time"
+)
+
+// ProvisionState is the lifecycle position of a VM that is being provisioned
+// from install media. It is a string type so it serialises cleanly to JSON.
+type ProvisionState string
+
+const (
+	ProvisionStateAbsent     ProvisionState = "absent"
+	ProvisionStateCreating   ProvisionState = "creating"
+	ProvisionStateInstalling ProvisionState = "installing"
+	ProvisionStateFinalizing ProvisionState = "finalizing"
+	ProvisionStateReady      ProvisionState = "ready"
+	ProvisionStateFailed     ProvisionState = "failed"
+	ProvisionStateDegraded   ProvisionState = "degraded"
+)
+
+// ErrProvisionNotFound is returned when no provisioning record exists for a VM.
+var ErrProvisionNotFound = errors.New("hyperv: provision record not found")
+
+// ProvisionRecord tracks the in-progress state of a VM being provisioned from
+// install media. It is JSON-serialisable so a controller restart can resume
+// from the recorded state. CorrelationID is baked from the VM name and
+// enrollment label at provision start; the controller-side completion
+// reconciler (story #2050) uses it to match a registered steward to this VM.
+type ProvisionRecord struct {
+	VMName        string         `json:"vm_name"`
+	State         ProvisionState `json:"state"`
+	CorrelationID string         `json:"correlation_id"`
+	StartedAt     time.Time      `json:"started_at"`
+	UpdatedAt     time.Time      `json:"updated_at"`
+	LastError     string         `json:"last_error,omitempty"`
+}
+
+// ProvisionStore is the persistence interface for VM provisioning records.
+// Implementations are pluggable; the in-memory implementation is used in tests.
+// Wiring into hypervModule is deferred to story #2044.
+type ProvisionStore interface {
+	GetProvision(ctx context.Context, vmName string) (*ProvisionRecord, error)
+	SetProvision(ctx context.Context, record *ProvisionRecord) error
+	DeleteProvision(ctx context.Context, vmName string) error
+}
+
+// memProvisionStore is a thread-safe in-memory ProvisionStore for tests.
+type memProvisionStore struct {
+	mu      sync.RWMutex
+	records map[string]*ProvisionRecord
+}
+
+func newMemProvisionStore() *memProvisionStore {
+	return &memProvisionStore{records: make(map[string]*ProvisionRecord)}
+}
+
+func (s *memProvisionStore) GetProvision(_ context.Context, vmName string) (*ProvisionRecord, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	r, ok := s.records[vmName]
+	if !ok {
+		return nil, ErrProvisionNotFound
+	}
+	cp := *r
+	return &cp, nil
+}
+
+func (s *memProvisionStore) SetProvision(_ context.Context, record *ProvisionRecord) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	cp := *record
+	s.records[record.VMName] = &cp
+	return nil
+}
+
+func (s *memProvisionStore) DeleteProvision(_ context.Context, vmName string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, ok := s.records[vmName]; !ok {
+		return ErrProvisionNotFound
+	}
+	delete(s.records, vmName)
+	return nil
+}

--- a/features/modules/hyperv/provision_test.go
+++ b/features/modules/hyperv/provision_test.go
@@ -1,0 +1,156 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+package hyperv
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ─── ProvisionStore CRUD tests ────────────────────────────────────────────────
+
+// TestProvisionStore_CRUD exercises Get/Set/Delete/ErrProvisionNotFound
+// round-trips on memProvisionStore.
+func TestProvisionStore_CRUD(t *testing.T) {
+	ctx := context.Background()
+	store := newMemProvisionStore()
+
+	// Get on empty store returns ErrProvisionNotFound.
+	_, err := store.GetProvision(ctx, "vm-01")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrProvisionNotFound, "Get on absent record must return ErrProvisionNotFound")
+
+	// Delete on empty store returns ErrProvisionNotFound.
+	err = store.DeleteProvision(ctx, "vm-01")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrProvisionNotFound, "Delete on absent record must return ErrProvisionNotFound")
+
+	// Set creates a record.
+	now := time.Now().Truncate(time.Second)
+	record := &ProvisionRecord{
+		VMName:        "vm-01",
+		State:         ProvisionStateCreating,
+		CorrelationID: "corr-abc-123",
+		StartedAt:     now,
+		UpdatedAt:     now,
+	}
+	require.NoError(t, store.SetProvision(ctx, record))
+
+	// Get returns the stored record.
+	got, err := store.GetProvision(ctx, "vm-01")
+	require.NoError(t, err)
+	assert.Equal(t, "vm-01", got.VMName)
+	assert.Equal(t, ProvisionStateCreating, got.State)
+	assert.Equal(t, "corr-abc-123", got.CorrelationID)
+	assert.Equal(t, now, got.StartedAt)
+	assert.Equal(t, now, got.UpdatedAt)
+
+	// Set overwrites with a new state.
+	record.State = ProvisionStateInstalling
+	record.UpdatedAt = now.Add(time.Minute)
+	require.NoError(t, store.SetProvision(ctx, record))
+
+	got, err = store.GetProvision(ctx, "vm-01")
+	require.NoError(t, err)
+	assert.Equal(t, ProvisionStateInstalling, got.State, "Set must overwrite existing record")
+
+	// Mutating the returned pointer does not corrupt the store.
+	got.State = ProvisionStateFailed
+	reFetch, err := store.GetProvision(ctx, "vm-01")
+	require.NoError(t, err)
+	assert.Equal(t, ProvisionStateInstalling, reFetch.State,
+		"Get must return a copy; mutating it must not affect the store")
+
+	// Delete removes the record.
+	require.NoError(t, store.DeleteProvision(ctx, "vm-01"))
+	_, err = store.GetProvision(ctx, "vm-01")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrProvisionNotFound, "Get after Delete must return ErrProvisionNotFound")
+
+	// Second Delete returns ErrProvisionNotFound.
+	err = store.DeleteProvision(ctx, "vm-01")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrProvisionNotFound, "Delete on already-deleted record must return ErrProvisionNotFound")
+}
+
+// TestProvisionStore_MultipleVMs verifies independent records for different VMs.
+func TestProvisionStore_MultipleVMs(t *testing.T) {
+	ctx := context.Background()
+	store := newMemProvisionStore()
+	now := time.Now().Truncate(time.Second)
+
+	recordA := &ProvisionRecord{VMName: "vm-a", State: ProvisionStateCreating, CorrelationID: "corr-a", StartedAt: now, UpdatedAt: now}
+	recordB := &ProvisionRecord{VMName: "vm-b", State: ProvisionStateReady, CorrelationID: "corr-b", StartedAt: now, UpdatedAt: now}
+
+	require.NoError(t, store.SetProvision(ctx, recordA))
+	require.NoError(t, store.SetProvision(ctx, recordB))
+
+	gotA, err := store.GetProvision(ctx, "vm-a")
+	require.NoError(t, err)
+	assert.Equal(t, ProvisionStateCreating, gotA.State)
+
+	gotB, err := store.GetProvision(ctx, "vm-b")
+	require.NoError(t, err)
+	assert.Equal(t, ProvisionStateReady, gotB.State)
+
+	// Deleting A does not affect B.
+	require.NoError(t, store.DeleteProvision(ctx, "vm-a"))
+	_, err = store.GetProvision(ctx, "vm-a")
+	assert.ErrorIs(t, err, ErrProvisionNotFound)
+	_, err = store.GetProvision(ctx, "vm-b")
+	require.NoError(t, err, "vm-b must survive deletion of vm-a")
+}
+
+// TestProvisionRecord_LastError verifies that LastError is carried through Set/Get.
+func TestProvisionRecord_LastError(t *testing.T) {
+	ctx := context.Background()
+	store := newMemProvisionStore()
+	now := time.Now().Truncate(time.Second)
+
+	record := &ProvisionRecord{
+		VMName:        "vm-err",
+		State:         ProvisionStateFailed,
+		CorrelationID: "corr-x",
+		StartedAt:     now,
+		UpdatedAt:     now,
+		LastError:     "timeout waiting for steward registration",
+	}
+	require.NoError(t, store.SetProvision(ctx, record))
+
+	got, err := store.GetProvision(ctx, "vm-err")
+	require.NoError(t, err)
+	assert.Equal(t, "timeout waiting for steward registration", got.LastError)
+}
+
+// TestProvisionState_Values verifies the ProvisionState string enum values are
+// stable and serialise to the expected strings.
+func TestProvisionState_Values(t *testing.T) {
+	cases := []struct {
+		state ProvisionState
+		want  string
+	}{
+		{ProvisionStateAbsent, "absent"},
+		{ProvisionStateCreating, "creating"},
+		{ProvisionStateInstalling, "installing"},
+		{ProvisionStateFinalizing, "finalizing"},
+		{ProvisionStateReady, "ready"},
+		{ProvisionStateFailed, "failed"},
+		{ProvisionStateDegraded, "degraded"},
+	}
+	for _, tc := range cases {
+		assert.Equal(t, tc.want, string(tc.state),
+			"ProvisionState(%q) must serialise to %q", tc.state, tc.want)
+	}
+}
+
+// TestProvisionNotFound_IsSentinel verifies that ErrProvisionNotFound is a
+// standalone sentinel, not wrapping another error.
+func TestProvisionNotFound_IsSentinel(t *testing.T) {
+	assert.False(t, errors.Is(ErrProvisionNotFound, ErrVMNotFound),
+		"ErrProvisionNotFound must be a distinct sentinel from ErrVMNotFound")
+}

--- a/features/modules/hyperv/schema.yaml
+++ b/features/modules/hyperv/schema.yaml
@@ -39,8 +39,8 @@ resources:
               pattern: "^[a-zA-Z0-9_\\- ]{1,64}$"
       generation:
         type: integer
-        description: VM generation (must be 2 or omitted for default)
-        enum: [2]
+        description: VM generation (1 or 2; omit for default Generation 2)
+        enum: [1, 2]
         default: 2
       state:
         type: string
@@ -50,6 +50,54 @@ resources:
           - stopped
           - absent
         default: running
+      source:
+        type: object
+        description: >
+          ISO boot-provisioning parameters. When present, the module activates
+          the provisioning state machine (absent → creating → installing →
+          finalizing → ready) one step per convergence cycle. Absent source:
+          block leaves the VM managed by the existing lifecycle only.
+        required:
+          - iso
+          - os_family
+        properties:
+          iso:
+            type: string
+            description: Absolute Windows path to the installation ISO (e.g. C:\ISO\server.iso)
+          os_family:
+            type: string
+            description: Installer type
+            enum:
+              - linux
+              - windows
+          unattend:
+            type: string
+            description: >
+              Optional reference to an unattended-install profile expressed as a
+              profile:// URI (e.g. profile://windows/server2022).
+          completion:
+            type: object
+            description: Specifies how the module detects that provisioning succeeded.
+            properties:
+              mode:
+                type: string
+                description: Detection strategy; steward-registration is the only supported value in v1.
+                enum:
+                  - steward-registration
+              timeout:
+                type: string
+                description: >
+                  Go duration string bounding the provisioning wait
+                  (e.g. "60m"). Omit to use the module default.
+          on_existing:
+            type: string
+            description: >
+              Behaviour when the VM already exists. never (default) leaves it
+              untouched; recreate destroys and re-provisions.
+            enum:
+              - never
+              - recreate
+            default: never
 
   vswitch:
     description: Hyper-V virtual switch (external, internal, or private)

--- a/features/modules/hyperv/tests/basic_test.yaml
+++ b/features/modules/hyperv/tests/basic_test.yaml
@@ -58,7 +58,7 @@ tests:
       state: stopped
     expected_error: "invalid VHD path"
 
-  - name: Invalid generation (Generation 1)
+  - name: Valid generation (Generation 1)
     config:
       name: "gen1-vm"
       memory_mb: 2048
@@ -67,4 +67,6 @@ tests:
       switch_name: "Default Switch"
       generation: 1
       state: stopped
-    expected_error: "invalid generation"
+    expected:
+      name: "gen1-vm"
+      state: stopped

--- a/features/modules/hyperv/vm.go
+++ b/features/modules/hyperv/vm.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"regexp"
 	"strings"
+	"time"
 
 	"gopkg.in/yaml.v3"
 
@@ -25,8 +26,26 @@ var (
 	// ErrInvalidVHDPath is returned when a VHD path is not a valid absolute Windows path.
 	ErrInvalidVHDPath = errors.New("hyperv: invalid VHD path: must be an absolute Windows path (e.g. C:\\VMs\\disk.vhdx)")
 
-	// ErrInvalidGeneration is returned when a VM generation other than 2 (or 0/unset) is specified.
-	ErrInvalidGeneration = errors.New("hyperv: invalid generation: must be 2 (or 0 to accept the default)")
+	// ErrInvalidGeneration is returned when a VM generation outside {1, 2} (or 0/unset) is specified.
+	ErrInvalidGeneration = errors.New("hyperv: invalid generation: must be 1 or 2 (or 0 to accept the default)")
+
+	// ErrInvalidSourceISO is returned when the source iso field is missing or not an absolute Windows path.
+	ErrInvalidSourceISO = errors.New("hyperv: invalid source iso: must be a non-empty absolute Windows path (e.g. C:\\ISO\\server.iso)")
+
+	// ErrInvalidSourceOSFamily is returned when source os_family is not linux or windows.
+	ErrInvalidSourceOSFamily = errors.New("hyperv: invalid source os_family: must be linux or windows")
+
+	// ErrInvalidSourceUnattend is returned when source unattend does not start with profile://.
+	ErrInvalidSourceUnattend = errors.New("hyperv: invalid source unattend: must start with profile://")
+
+	// ErrInvalidSourceCompletionMode is returned when source completion.mode is not steward-registration.
+	ErrInvalidSourceCompletionMode = errors.New("hyperv: invalid source completion.mode: must be steward-registration")
+
+	// ErrInvalidSourceCompletionTimeout is returned when source completion.timeout cannot be parsed as a duration.
+	ErrInvalidSourceCompletionTimeout = errors.New("hyperv: invalid source completion.timeout: must be a valid duration string (e.g. 60m)")
+
+	// ErrInvalidSourceOnExisting is returned when source on_existing is not never or recreate.
+	ErrInvalidSourceOnExisting = errors.New("hyperv: invalid source on_existing: must be never or recreate")
 )
 
 // vmNamePattern is the allowlist for user-supplied VM names. It is an injection
@@ -35,6 +54,34 @@ var vmNamePattern = regexp.MustCompile(`^[a-zA-Z0-9_\-]{1,64}$`)
 
 // vhdPathPattern validates Windows absolute paths.
 var vhdPathPattern = regexp.MustCompile(`^[A-Za-z]:\\.*`)
+
+// CompletionConfig specifies how the provisioner detects that the installed OS
+// is ready and has registered its steward.
+type CompletionConfig struct {
+	// Mode is the detection strategy; steward-registration is the only
+	// supported value in v1.
+	Mode string `yaml:"mode,omitempty"`
+	// Timeout is a Go duration string (e.g. "60m") bounding the wait.
+	Timeout string `yaml:"timeout,omitempty"`
+}
+
+// SourceConfig describes the ISO boot-provisioning parameters for a VM.
+// Presence of a source block in a hyperv.vm resource triggers the provisioning
+// state machine (absent → creating → installing → finalizing → ready).
+type SourceConfig struct {
+	// ISO is the absolute Windows path to the installation ISO.
+	ISO string `yaml:"iso"`
+	// OSFamily distinguishes the installer type: linux or windows.
+	OSFamily string `yaml:"os_family"`
+	// Unattend is an optional reference to an unattended-install profile,
+	// expressed as a profile:// URI.
+	Unattend string `yaml:"unattend,omitempty"`
+	// Completion defines how the module knows provisioning succeeded.
+	Completion CompletionConfig `yaml:"completion,omitempty"`
+	// OnExisting controls behaviour when the VM already exists:
+	// never (default) leaves it untouched; recreate destroys and re-provisions.
+	OnExisting string `yaml:"on_existing,omitempty"`
+}
 
 // VMConfig represents the desired state of a Hyper-V virtual machine.
 //
@@ -60,6 +107,9 @@ type VMConfig struct {
 	Generation  int                `yaml:"generation"`
 	// State is the desired lifecycle: "running", "stopped", or "absent" (delete).
 	State string `yaml:"state,omitempty"`
+	// Source, when non-nil, activates the ISO provisioning state machine.
+	// Absent source: block leaves the VM managed by the existing lifecycle only.
+	Source *SourceConfig `yaml:"source,omitempty"`
 }
 
 // stringOrStringList is a YAML scalar-or-sequence: switch_name may be a single
@@ -209,7 +259,9 @@ func (c *VMConfig) Validate() error {
 	if !vmNamePattern.MatchString(c.Name) {
 		return ErrInvalidVMName
 	}
-	if c.Generation != 0 && c.Generation != 2 {
+	// 0 means "accept the default" (Generation 2). 1 and 2 are explicitly valid
+	// per ADR-009 §5, which lifted the Gen-2-only restriction.
+	if c.Generation != 0 && c.Generation != 1 && c.Generation != 2 {
 		return ErrInvalidGeneration
 	}
 	if c.VHDPath != "" && !vhdPathPattern.MatchString(c.VHDPath) {
@@ -223,6 +275,40 @@ func (c *VMConfig) Validate() error {
 			return ErrInvalidSwitchName
 		}
 	}
+	if c.Source != nil {
+		if err := c.Source.validate(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// validate checks all SourceConfig fields against their constraints.
+func (s *SourceConfig) validate() error {
+	if !vhdPathPattern.MatchString(s.ISO) {
+		return ErrInvalidSourceISO
+	}
+	switch s.OSFamily {
+	case "linux", "windows":
+	default:
+		return ErrInvalidSourceOSFamily
+	}
+	if s.Unattend != "" && !strings.HasPrefix(s.Unattend, "profile://") {
+		return ErrInvalidSourceUnattend
+	}
+	if s.Completion.Mode != "" && s.Completion.Mode != "steward-registration" {
+		return ErrInvalidSourceCompletionMode
+	}
+	if s.Completion.Timeout != "" {
+		if _, err := time.ParseDuration(s.Completion.Timeout); err != nil {
+			return ErrInvalidSourceCompletionTimeout
+		}
+	}
+	switch s.OnExisting {
+	case "", "never", "recreate":
+	default:
+		return ErrInvalidSourceOnExisting
+	}
 	return nil
 }
 
@@ -233,7 +319,7 @@ func (c *VMConfig) Validate() error {
 // convergence logic reconciles against.
 func (c *VMConfig) AsMap() map[string]interface{} {
 	desired := c.desiredSwitches()
-	return map[string]interface{}{
+	m := map[string]interface{}{
 		"name":         c.Name,
 		"memory_mb":    c.MemoryMB,
 		"cpu_count":    c.CPUCount,
@@ -242,7 +328,21 @@ func (c *VMConfig) AsMap() map[string]interface{} {
 		"switch_names": desired,
 		"generation":   c.Generation,
 		"state":        c.State,
+		"source":       nil,
 	}
+	if c.Source != nil {
+		m["source"] = map[string]interface{}{
+			"iso":       c.Source.ISO,
+			"os_family": c.Source.OSFamily,
+			"unattend":  c.Source.Unattend,
+			"completion": map[string]interface{}{
+				"mode":    c.Source.Completion.Mode,
+				"timeout": c.Source.Completion.Timeout,
+			},
+			"on_existing": c.Source.OnExisting,
+		}
+	}
+	return m
 }
 
 // switchNameField renders the desired switch SET as the value the drift
@@ -285,7 +385,7 @@ func (c *VMConfig) FromYAML(data []byte) error {
 
 // GetManagedFields returns the list of fields this configuration manages.
 func (c *VMConfig) GetManagedFields() []string {
-	return []string{"name", "memory_mb", "cpu_count", "vhd_path", "switch_name", "generation", "state"}
+	return []string{"name", "memory_mb", "cpu_count", "vhd_path", "switch_name", "generation", "state", "source"}
 }
 
 // psGetVM is the script block passed to ExecutePS for VM retrieval.

--- a/features/modules/hyperv/vm_test.go
+++ b/features/modules/hyperv/vm_test.go
@@ -78,12 +78,11 @@ func TestVMConfig_Validate_AcceptsDoubleUnderscore(t *testing.T) {
 		"VM name containing __ must be accepted now that names are not namespaced")
 }
 
-// TestVMConfig_Validate_RejectsGen1 verifies that Generation 1 VMs are rejected.
-func TestVMConfig_Validate_RejectsGen1(t *testing.T) {
+// TestVMConfig_Validate_AcceptsGen1 verifies that Generation 1 VMs are accepted
+// (ADR-009 §5 lifted the Gen-2-only restriction).
+func TestVMConfig_Validate_AcceptsGen1(t *testing.T) {
 	cfg := &VMConfig{Name: "test-vm", Generation: 1, VHDPath: `C:\VMs\test.vhdx`}
-	err := cfg.Validate()
-	require.Error(t, err, "Generation 1 must be rejected")
-	assert.ErrorIs(t, err, ErrInvalidGeneration)
+	require.NoError(t, cfg.Validate(), "Generation 1 must be accepted per ADR-009 §5")
 }
 
 // TestVMConfig_Validate_AcceptsGen2 verifies that Generation 2 and unset (0) are accepted.
@@ -641,6 +640,153 @@ func contains(args []interface{}, want string) bool {
 		}
 	}
 	return false
+}
+
+// ─── SourceConfig validation tests ────────────────────────────────────────────
+
+// TestSourceConfig_Validate exercises every invalid-source error path via real
+// VMConfig.Validate() calls (no mocks).
+func TestSourceConfig_Validate(t *testing.T) {
+	validBase := func() *VMConfig {
+		return &VMConfig{
+			Name:    "src-vm",
+			VHDPath: `C:\VMs\src-vm.vhdx`,
+			Source: &SourceConfig{
+				ISO:      `C:\ISO\server.iso`,
+				OSFamily: "windows",
+				Completion: CompletionConfig{
+					Mode: "steward-registration",
+				},
+			},
+		}
+	}
+
+	t.Run("valid source passes validation", func(t *testing.T) {
+		require.NoError(t, validBase().Validate())
+	})
+
+	t.Run("non-absolute iso path", func(t *testing.T) {
+		cfg := validBase()
+		cfg.Source.ISO = "relative/path/server.iso"
+		err := cfg.Validate()
+		require.Error(t, err)
+		assert.ErrorIs(t, err, ErrInvalidSourceISO)
+	})
+
+	t.Run("empty iso path", func(t *testing.T) {
+		cfg := validBase()
+		cfg.Source.ISO = ""
+		err := cfg.Validate()
+		require.Error(t, err)
+		assert.ErrorIs(t, err, ErrInvalidSourceISO)
+	})
+
+	t.Run("unknown os_family", func(t *testing.T) {
+		cfg := validBase()
+		cfg.Source.OSFamily = "bsd"
+		err := cfg.Validate()
+		require.Error(t, err)
+		assert.ErrorIs(t, err, ErrInvalidSourceOSFamily)
+	})
+
+	t.Run("empty os_family", func(t *testing.T) {
+		cfg := validBase()
+		cfg.Source.OSFamily = ""
+		err := cfg.Validate()
+		require.Error(t, err)
+		assert.ErrorIs(t, err, ErrInvalidSourceOSFamily)
+	})
+
+	t.Run("os_family linux is valid", func(t *testing.T) {
+		cfg := validBase()
+		cfg.Source.OSFamily = "linux"
+		require.NoError(t, cfg.Validate())
+	})
+
+	t.Run("unattend without profile:// prefix", func(t *testing.T) {
+		cfg := validBase()
+		cfg.Source.Unattend = "s3://bucket/unattend.xml"
+		err := cfg.Validate()
+		require.Error(t, err)
+		assert.ErrorIs(t, err, ErrInvalidSourceUnattend)
+	})
+
+	t.Run("unattend with profile:// prefix is valid", func(t *testing.T) {
+		cfg := validBase()
+		cfg.Source.Unattend = "profile://windows/server2022"
+		require.NoError(t, cfg.Validate())
+	})
+
+	t.Run("unattend empty is valid (optional)", func(t *testing.T) {
+		cfg := validBase()
+		cfg.Source.Unattend = ""
+		require.NoError(t, cfg.Validate())
+	})
+
+	t.Run("unknown completion mode", func(t *testing.T) {
+		cfg := validBase()
+		cfg.Source.Completion.Mode = "ssh-probe"
+		err := cfg.Validate()
+		require.Error(t, err)
+		assert.ErrorIs(t, err, ErrInvalidSourceCompletionMode)
+	})
+
+	t.Run("empty completion mode is valid (optional)", func(t *testing.T) {
+		cfg := validBase()
+		cfg.Source.Completion.Mode = ""
+		require.NoError(t, cfg.Validate())
+	})
+
+	t.Run("unparseable completion timeout", func(t *testing.T) {
+		cfg := validBase()
+		cfg.Source.Completion.Timeout = "not-a-duration"
+		err := cfg.Validate()
+		require.Error(t, err)
+		assert.ErrorIs(t, err, ErrInvalidSourceCompletionTimeout)
+	})
+
+	t.Run("valid completion timeout", func(t *testing.T) {
+		cfg := validBase()
+		cfg.Source.Completion.Timeout = "60m"
+		require.NoError(t, cfg.Validate())
+	})
+
+	t.Run("empty completion timeout is valid (optional)", func(t *testing.T) {
+		cfg := validBase()
+		cfg.Source.Completion.Timeout = ""
+		require.NoError(t, cfg.Validate())
+	})
+
+	t.Run("unknown on_existing", func(t *testing.T) {
+		cfg := validBase()
+		cfg.Source.OnExisting = "replace"
+		err := cfg.Validate()
+		require.Error(t, err)
+		assert.ErrorIs(t, err, ErrInvalidSourceOnExisting)
+	})
+
+	t.Run("on_existing never is valid", func(t *testing.T) {
+		cfg := validBase()
+		cfg.Source.OnExisting = "never"
+		require.NoError(t, cfg.Validate())
+	})
+
+	t.Run("on_existing recreate is valid", func(t *testing.T) {
+		cfg := validBase()
+		cfg.Source.OnExisting = "recreate"
+		require.NoError(t, cfg.Validate())
+	})
+
+	t.Run("on_existing empty defaults to never (valid)", func(t *testing.T) {
+		cfg := validBase()
+		cfg.Source.OnExisting = ""
+		require.NoError(t, cfg.Validate())
+	})
+
+	t.Run("nil source leaves existing configs unchanged", func(t *testing.T) {
+		cfg := &VMConfig{Name: "no-src-vm", VHDPath: `C:\VMs\no-src.vhdx`}
+		require.NoError(t, cfg.Validate(), "absent source: block must not affect validation")
+	})
 }
 
 // TestVMConfig_AsMap_SwitchNameReflectsFullSet is the drift-detection


### PR DESCRIPTION
## Summary

- Adds `SourceConfig` struct and `Source *SourceConfig` field to `VMConfig`; `Validate()` now accepts Generation 1 (per ADR-009 §5) and validates all source fields with typed errors
- Adds `provision.go` with `ProvisionState` enum, `ProvisionRecord`, `ProvisionStore` interface, and thread-safe `memProvisionStore` — the data model for the ISO provisioning state machine
- Adds `provision_test.go` and extends `vm_test.go` with `TestProvisionStore_CRUD`, `TestVMConfig_Validate_AcceptsGen1`, and `TestSourceConfig_Validate` (19 subtests covering all error sentinels)
- Updates `schema.yaml` generation enum to `[1, 2]` and documents the full `source` sub-object; updates `tests/basic_test.yaml` Gen1 case to expect success

Fixes #2043

## Specialist Review Results

| Agent | Verdict | Notes |
|-------|---------|-------|
| QA Test Runner | **PASS** | All 100+ packages pass; cross-platform build verified; linting clean |
| QA Code Reviewer | **PASS** | 0 blocking issues; 2 warnings both pre-existing/non-blocking |
| Security Engineer | **PASS** | 0 blocking issues; all automated scans pass (gosec, Trivy, Nancy, staticcheck, architecture check) |

## Test plan

- [ ] `TestVMConfig_Validate_AcceptsGen1` — asserts no error for Generation 1
- [ ] `TestSourceConfig_Validate` — 19 subtests covering every invalid-source error path
- [ ] `TestProvisionStore_CRUD` — Get/Set/Delete/ErrProvisionNotFound round-trips on `memProvisionStore`
- [ ] `go test ./features/modules/hyperv/...` — full package passes with `-race`
- [ ] Cross-platform compilation: linux/amd64, linux/arm64, darwin/amd64, darwin/arm64, windows/amd64

🤖 Generated with [Claude Code](https://claude.com/claude-code)