### PR TITLE
hyperv: Gen1/Gen2 VM create from source + host-native seed VHDX + secure-boot template (Issue #2044)

### DIFF
--- a/features/modules/hyperv/module.go
+++ b/features/modules/hyperv/module.go
@@ -59,17 +59,43 @@ type hypervModule struct {
 	// transport success only.
 	vswitchesMu sync.RWMutex
 	vswitches   map[string]VSwitchConfig
+
+	// provisionStore persists per-VM provisioning records for the
+	// create-from-source state machine (ADR-009 §2/§3). Defaults to an
+	// in-memory store via New(); tests inject an alternative with
+	// WithProvisionStore.
+	provisionStore ProvisionStore
+}
+
+// HypervOption configures a hypervModule at construction time.
+type HypervOption func(*hypervModule)
+
+// WithProvisionStore overrides the default in-memory ProvisionStore. Tests
+// inject an alternative store to inspect or seed provisioning records.
+func WithProvisionStore(s ProvisionStore) HypervOption {
+	return func(m *hypervModule) {
+		if s != nil {
+			m.provisionStore = s
+		}
+	}
 }
 
 // New creates a new hypervModule. Production callers pass newDefaultDetector();
-// tests inject a fakeDetector via newModuleWithDetector.
-func New(detector HypervDetector) modules.Module {
-	return &hypervModule{
-		executor:  newExecutor(),
-		vms:       make(map[string]VMConfig),
-		vswitches: make(map[string]VSwitchConfig),
-		detector:  detector,
+// tests inject a fakeDetector via newModuleWithDetector. Optional HypervOption
+// values override defaults (e.g. WithProvisionStore for the provisioning
+// record store, which otherwise defaults to an in-memory store).
+func New(detector HypervDetector, opts ...HypervOption) modules.Module {
+	m := &hypervModule{
+		executor:       newExecutor(),
+		vms:            make(map[string]VMConfig),
+		vswitches:      make(map[string]VSwitchConfig),
+		detector:       detector,
+		provisionStore: newMemProvisionStore(),
 	}
+	for _, opt := range opts {
+		opt(m)
+	}
+	return m
 }
 
 // checkDetection calls the injected HypervDetector and enforces the 5-minute

--- a/features/modules/hyperv/provision.go
+++ b/features/modules/hyperv/provision.go
@@ -7,6 +7,8 @@ import (
 	"errors"
 	"sync"
 	"time"
+
+	"github.com/cfgis/cfgms/pkg/logging"
 )
 
 // ProvisionState is the lifecycle position of a VM that is being provisioned
@@ -25,6 +27,12 @@ const (
 
 // ErrProvisionNotFound is returned when no provisioning record exists for a VM.
 var ErrProvisionNotFound = errors.New("hyperv: provision record not found")
+
+// ErrInvalidSeedPath is returned when a derived seed VHDX path is not a safe
+// absolute local Windows path (e.g. a UNC \\server\share path or a path with
+// no drive letter). The seed must live on a local/CSV drive next to the VM's
+// VHD, never on an arbitrary network share.
+var ErrInvalidSeedPath = errors.New("hyperv: invalid seed path: must be an absolute local Windows path (no UNC share)")
 
 // ProvisionRecord tracks the in-progress state of a VM being provisioned from
 // install media. It is JSON-serialisable so a controller restart can resume
@@ -86,4 +94,78 @@ func (s *memProvisionStore) DeleteProvision(_ context.Context, vmName string) er
 	}
 	delete(s.records, vmName)
 	return nil
+}
+
+// loadOrInitProvision returns the existing provisioning record for vmName, or
+// initialises a fresh one at absent when none exists. A freshly initialised
+// record carries StartedAt and the correlation identity baked from the VM name
+// (the expected enrollment label per ADR-009 §8) so the controller-side
+// reconciler (#2050) can match a registered steward to this VM. It is NOT
+// persisted until advanceProvision writes a state.
+func (m *hypervModule) loadOrInitProvision(ctx context.Context, vmName string) (*ProvisionRecord, error) {
+	if m.provisionStore == nil {
+		m.provisionStore = newMemProvisionStore()
+	}
+	record, err := m.provisionStore.GetProvision(ctx, vmName)
+	if err == nil {
+		return record, nil
+	}
+	if !errors.Is(err, ErrProvisionNotFound) {
+		return nil, err
+	}
+	now := time.Now().UTC()
+	return &ProvisionRecord{
+		VMName:        vmName,
+		State:         ProvisionStateAbsent,
+		CorrelationID: vmName,
+		StartedAt:     now,
+		UpdatedAt:     now,
+	}, nil
+}
+
+// advanceProvision sets the record to newState, stamps UpdatedAt, persists it,
+// and emits a structured log event. It mutates the passed record in place so
+// the caller's subsequent state checks see the new state.
+func (m *hypervModule) advanceProvision(ctx context.Context, vmName string, record *ProvisionRecord, newState ProvisionState) error {
+	if m.provisionStore == nil {
+		m.provisionStore = newMemProvisionStore()
+	}
+	prev := record.State
+	record.State = newState
+	record.UpdatedAt = time.Now().UTC()
+	record.LastError = ""
+	if err := m.provisionStore.SetProvision(ctx, record); err != nil {
+		return err
+	}
+	if logger, ok := m.GetLogger(); ok {
+		logger.Info("hyperv: provisioning state advanced",
+			"vm_name", logging.SanitizeLogValue(vmName),
+			"from_state", string(prev),
+			"to_state", string(newState),
+			"correlation_id", logging.SanitizeLogValue(record.CorrelationID))
+	}
+	return nil
+}
+
+// failProvision records the failure on the provisioning record (state=failed,
+// LastError set), persists it, emits a structured log event, and returns the
+// original error so the caller can propagate it. The error message is not
+// exposed via the log at error-detail level beyond the sanitized value.
+func (m *hypervModule) failProvision(ctx context.Context, vmName string, record *ProvisionRecord, cause error) error {
+	if m.provisionStore == nil {
+		m.provisionStore = newMemProvisionStore()
+	}
+	record.State = ProvisionStateFailed
+	record.UpdatedAt = time.Now().UTC()
+	if cause != nil {
+		record.LastError = cause.Error()
+	}
+	// Persist best-effort; the original cause is the error we surface.
+	_ = m.provisionStore.SetProvision(ctx, record)
+	if logger, ok := m.GetLogger(); ok {
+		logger.Warn("hyperv: provisioning failed",
+			"vm_name", logging.SanitizeLogValue(vmName),
+			"correlation_id", logging.SanitizeLogValue(record.CorrelationID))
+	}
+	return cause
 }

--- a/features/modules/hyperv/pstransport_dispatch_windows.go
+++ b/features/modules/hyperv/pstransport_dispatch_windows.go
@@ -44,7 +44,8 @@ func (t *psHostTransport) ExecutePS(ctx context.Context, psCommand string, psArg
 				" -MemoryMB "+intArg(psArgs, "MemoryMB")+
 				" -CPU "+intArg(psArgs, "CPU")+
 				" -VHDPath "+quoteArg(psArgs, "VHDPath")+
-				" -SwitchName "+quoteArg(psArgs, "SwitchName"))
+				" -SwitchName "+quoteArg(psArgs, "SwitchName")+
+				" -Generation "+intArg(psArgs, "Generation"))
 	case psRemoveVM:
 		return t.run(ctx, "Cfgms-RemoveVM -Name "+quoteArg(psArgs, "Name"))
 	case psStartVM:
@@ -59,6 +60,33 @@ func (t *psHostTransport) ExecutePS(ctx context.Context, psCommand string, psArg
 		return t.run(ctx,
 			"Cfgms-SetVMMemory -Name "+quoteArg(psArgs, "Name")+
 				" -MemoryMB "+intArg(psArgs, "MemoryMB"))
+
+	// ── VM provisioning: seed VHDX + media attach + firmware (#2044) ──
+	case psNewSeedVHD:
+		return t.run(ctx,
+			"Cfgms-NewSeedVHD -Path "+quoteArg(psArgs, "Path")+
+				" -SizeBytes "+intArg(psArgs, "SizeBytes"))
+	case psMountSeedVHD:
+		return t.run(ctx, "Cfgms-MountSeedVHD -Path "+quoteArg(psArgs, "Path"))
+	case psCopyToSeedVHD:
+		return t.run(ctx,
+			"Cfgms-CopyToSeedVHD -SeedPath "+quoteArg(psArgs, "SeedPath")+
+				" -FileName "+quoteArg(psArgs, "FileName")+
+				" -Content "+quoteArg(psArgs, "Content"))
+	case psDetachSeedVHD:
+		return t.run(ctx, "Cfgms-DetachSeedVHD -Path "+quoteArg(psArgs, "Path"))
+	case psAttachSeedDisk:
+		return t.run(ctx,
+			"Cfgms-AttachSeedDisk -Name "+quoteArg(psArgs, "Name")+
+				" -SeedPath "+quoteArg(psArgs, "SeedPath"))
+	case psAttachDVD:
+		return t.run(ctx,
+			"Cfgms-AttachDVD -Name "+quoteArg(psArgs, "Name")+
+				" -ISOPath "+quoteArg(psArgs, "ISOPath"))
+	case psSetVMFirmware:
+		return t.run(ctx,
+			"Cfgms-SetVMFirmware -Name "+quoteArg(psArgs, "Name")+
+				" -Template "+quoteArg(psArgs, "Template"))
 
 	// ── VM network reconcile (declarative multi-NIC, #2021) ──────────
 	case psConnectVMNic:

--- a/features/modules/hyperv/pstransport_dispatch_windows_test.go
+++ b/features/modules/hyperv/pstransport_dispatch_windows_test.go
@@ -58,7 +58,28 @@ func dispatchForTest(ctx context.Context, psCommand string, psArgs map[string]st
 			" -MemoryMB " + intArg(psArgs, "MemoryMB") +
 			" -CPU " + intArg(psArgs, "CPU") +
 			" -VHDPath " + quoteArg(psArgs, "VHDPath") +
-			" -SwitchName " + quoteArg(psArgs, "SwitchName"))
+			" -SwitchName " + quoteArg(psArgs, "SwitchName") +
+			" -Generation " + intArg(psArgs, "Generation"))
+	case psNewSeedVHD:
+		return emit("Cfgms-NewSeedVHD -Path " + quoteArg(psArgs, "Path") +
+			" -SizeBytes " + intArg(psArgs, "SizeBytes"))
+	case psMountSeedVHD:
+		return emit("Cfgms-MountSeedVHD -Path " + quoteArg(psArgs, "Path"))
+	case psCopyToSeedVHD:
+		return emit("Cfgms-CopyToSeedVHD -SeedPath " + quoteArg(psArgs, "SeedPath") +
+			" -FileName " + quoteArg(psArgs, "FileName") +
+			" -Content " + quoteArg(psArgs, "Content"))
+	case psDetachSeedVHD:
+		return emit("Cfgms-DetachSeedVHD -Path " + quoteArg(psArgs, "Path"))
+	case psAttachSeedDisk:
+		return emit("Cfgms-AttachSeedDisk -Name " + quoteArg(psArgs, "Name") +
+			" -SeedPath " + quoteArg(psArgs, "SeedPath"))
+	case psAttachDVD:
+		return emit("Cfgms-AttachDVD -Name " + quoteArg(psArgs, "Name") +
+			" -ISOPath " + quoteArg(psArgs, "ISOPath"))
+	case psSetVMFirmware:
+		return emit("Cfgms-SetVMFirmware -Name " + quoteArg(psArgs, "Name") +
+			" -Template " + quoteArg(psArgs, "Template"))
 	case psRemoveVM:
 		return emit("Cfgms-RemoveVM -Name " + quoteArg(psArgs, "Name"))
 	case psStartVM:
@@ -136,8 +157,62 @@ func TestPSDispatch_VMVerbs(t *testing.T) {
 				"CPU":        "4",
 				"VHDPath":    "C:\\VMs\\web-01.vhdx",
 				"SwitchName": "External",
+				"Generation": "2",
 			},
-			want: "Cfgms-CreateVM -Name 'cfgms-t__web-01' -MemoryMB 4096 -CPU 4 -VHDPath 'C:\\VMs\\web-01.vhdx' -SwitchName 'External'",
+			want: "Cfgms-CreateVM -Name 'cfgms-t__web-01' -MemoryMB 4096 -CPU 4 -VHDPath 'C:\\VMs\\web-01.vhdx' -SwitchName 'External' -Generation 2",
+		},
+		{
+			name:      "New-VM Gen1",
+			psCommand: psCreateVM,
+			psArgs: map[string]string{
+				"Name":       "cfgms-t__web-01",
+				"MemoryMB":   "2048",
+				"CPU":        "2",
+				"VHDPath":    "C:\\VMs\\web-01.vhdx",
+				"SwitchName": "External",
+				"Generation": "1",
+			},
+			want: "Cfgms-CreateVM -Name 'cfgms-t__web-01' -MemoryMB 2048 -CPU 2 -VHDPath 'C:\\VMs\\web-01.vhdx' -SwitchName 'External' -Generation 1",
+		},
+		{
+			name:      "New-VHD seed",
+			psCommand: psNewSeedVHD,
+			psArgs:    map[string]string{"Path": "C:\\VMs\\cfgms-seed-web-01.vhdx", "SizeBytes": "67108864"},
+			want:      "Cfgms-NewSeedVHD -Path 'C:\\VMs\\cfgms-seed-web-01.vhdx' -SizeBytes 67108864",
+		},
+		{
+			name:      "Mount-VHD seed",
+			psCommand: psMountSeedVHD,
+			psArgs:    map[string]string{"Path": "C:\\VMs\\cfgms-seed-web-01.vhdx"},
+			want:      "Cfgms-MountSeedVHD -Path 'C:\\VMs\\cfgms-seed-web-01.vhdx'",
+		},
+		{
+			name:      "Copy seed answer file",
+			psCommand: psCopyToSeedVHD,
+			psArgs: map[string]string{
+				"SeedPath": "C:\\VMs\\cfgms-seed-web-01.vhdx",
+				"FileName": "autounattend.xml",
+				"Content":  "<!-- placeholder autounattend -->",
+			},
+			want: "Cfgms-CopyToSeedVHD -SeedPath 'C:\\VMs\\cfgms-seed-web-01.vhdx' -FileName 'autounattend.xml' -Content '<!-- placeholder autounattend -->'",
+		},
+		{
+			name:      "Attach seed disk",
+			psCommand: psAttachSeedDisk,
+			psArgs:    map[string]string{"Name": "cfgms-t__web-01", "SeedPath": "C:\\VMs\\cfgms-seed-web-01.vhdx"},
+			want:      "Cfgms-AttachSeedDisk -Name 'cfgms-t__web-01' -SeedPath 'C:\\VMs\\cfgms-seed-web-01.vhdx'",
+		},
+		{
+			name:      "Attach install ISO DVD",
+			psCommand: psAttachDVD,
+			psArgs:    map[string]string{"Name": "cfgms-t__web-01", "ISOPath": "C:\\ISO\\server.iso"},
+			want:      "Cfgms-AttachDVD -Name 'cfgms-t__web-01' -ISOPath 'C:\\ISO\\server.iso'",
+		},
+		{
+			name:      "Set firmware secure-boot template",
+			psCommand: psSetVMFirmware,
+			psArgs:    map[string]string{"Name": "cfgms-t__web-01", "Template": "MicrosoftWindows"},
+			want:      "Cfgms-SetVMFirmware -Name 'cfgms-t__web-01' -Template 'MicrosoftWindows'",
 		},
 		{
 			name:      "Set-VMProcessor",
@@ -253,7 +328,7 @@ func TestDispatch_AllKnownCommands(t *testing.T) {
 	}{
 		// VM verbs (vm.go)
 		{"psGetVM", psGetVM, map[string]string{"Name": "cfgms-t__web-01"}},
-		{"psCreateVM", psCreateVM, map[string]string{"Name": "cfgms-t__web-01", "MemoryMB": "1024", "CPU": "1", "VHDPath": "C:\\test.vhdx", "SwitchName": "sw"}},
+		{"psCreateVM", psCreateVM, map[string]string{"Name": "cfgms-t__web-01", "MemoryMB": "1024", "CPU": "1", "VHDPath": "C:\\test.vhdx", "SwitchName": "sw", "Generation": "2"}},
 		{"psRemoveVM", psRemoveVM, map[string]string{"Name": "cfgms-t__web-01"}},
 		{"psStartVM", psStartVM, map[string]string{"Name": "cfgms-t__web-01"}},
 		{"psStopVM", psStopVM, map[string]string{"Name": "cfgms-t__web-01"}},
@@ -261,6 +336,14 @@ func TestDispatch_AllKnownCommands(t *testing.T) {
 		{"psSetVMMemory", psSetVMMemory, map[string]string{"Name": "cfgms-t__web-01", "MemoryMB": "2048"}},
 		{"psConnectVMNic", psConnectVMNic, map[string]string{"Name": "cfgms-t__web-01", "SwitchName": "External"}},
 		{"psDisconnectVMNic", psDisconnectVMNic, map[string]string{"Name": "cfgms-t__web-01", "SwitchName": "External"}},
+		// VM provisioning verbs (#2044)
+		{"psNewSeedVHD", psNewSeedVHD, map[string]string{"Path": "C:\\VMs\\cfgms-seed-web-01.vhdx", "SizeBytes": "67108864"}},
+		{"psMountSeedVHD", psMountSeedVHD, map[string]string{"Path": "C:\\VMs\\cfgms-seed-web-01.vhdx"}},
+		{"psCopyToSeedVHD", psCopyToSeedVHD, map[string]string{"SeedPath": "C:\\VMs\\cfgms-seed-web-01.vhdx", "FileName": "preseed.cfg", "Content": "# placeholder preseed"}},
+		{"psDetachSeedVHD", psDetachSeedVHD, map[string]string{"Path": "C:\\VMs\\cfgms-seed-web-01.vhdx"}},
+		{"psAttachSeedDisk", psAttachSeedDisk, map[string]string{"Name": "cfgms-t__web-01", "SeedPath": "C:\\VMs\\cfgms-seed-web-01.vhdx"}},
+		{"psAttachDVD", psAttachDVD, map[string]string{"Name": "cfgms-t__web-01", "ISOPath": "C:\\ISO\\server.iso"}},
+		{"psSetVMFirmware", psSetVMFirmware, map[string]string{"Name": "cfgms-t__web-01", "Template": "MicrosoftWindows"}},
 		// VSwitch verbs (vswitch.go)
 		{"psGetVSwitch", psGetVSwitch, map[string]string{"Name": "cfgms-t__sw01"}},
 		{"psRemoveVSwitch", psRemoveVSwitch, map[string]string{"Name": "cfgms-t__sw01"}},

--- a/features/modules/hyperv/pstransport_preamble_windows.go
+++ b/features/modules/hyperv/pstransport_preamble_windows.go
@@ -83,6 +83,12 @@ function Cfgms-CreateVM {
         [Parameter(Mandatory)][int]$CPU,
         [Parameter(Mandatory)][string]$VHDPath,
         [Parameter(Mandatory)][string]$SwitchName,
+        # Generation is a typed parameter (ADR-009 §5 supports Gen1 AND Gen2 —
+        # the host-native seed VHDX boots on both, no floppy). The Go dispatcher
+        # always passes -Generation (defaulting to 2 when the config omits it),
+        # so it is mandatory here; a missing value is a dispatcher bug, not a
+        # silent default.
+        [Parameter(Mandatory)][int]$Generation,
         # Optional — defaults to a 64 GB dynamic VHD. The schema currently
         # doesn't expose vhd_size_gb so the Go dispatcher never passes one;
         # 64 GB matches the Hyper-V Manager default and is fine for any test
@@ -93,7 +99,7 @@ function Cfgms-CreateVM {
     # New-VM does NOT accept -ProcessorCount (real PS pitfall — surfaced by
     # PR #1912 live B1 bucket). Create with default 1 vCPU, then resize via
     # Set-VMProcessor only when the operator asked for something different.
-    New-VM -Name $Name -MemoryStartupBytes ($MemoryMB * 1MB) -NewVHDPath $VHDPath -NewVHDSizeBytes ($VHDSizeGB * 1GB) -SwitchName $SwitchName -Generation 2 | Out-Null
+    New-VM -Name $Name -MemoryStartupBytes ($MemoryMB * 1MB) -NewVHDPath $VHDPath -NewVHDSizeBytes ($VHDSizeGB * 1GB) -SwitchName $SwitchName -Generation $Generation | Out-Null
     if ($CPU -ne 1) {
         Set-VMProcessor -VMName $Name -Count $CPU
     }
@@ -148,6 +154,82 @@ function Cfgms-DisconnectVMNic {
         Where-Object { $_.SwitchName -eq $SwitchName } |
         Select-Object -First 1
     if ($a) { Remove-VMNetworkAdapter -VMNetworkAdapter $a }
+}
+
+# ── VM provisioning: seed VHDX + media attach + firmware (ADR-009 §5) ──
+# Host-native seed disk (NOT an ISO — oscdimg/ADK is absent on a stock
+# Hyper-V host; New-VHD/Mount-VHD/Format-Volume ship with the Hyper-V +
+# Storage roles the host already runs). Each function wraps a single logical
+# host-atomic step; all user-controlled values travel via parameters.
+
+# Cfgms-NewSeedVHD creates an empty dynamic VHDX for the answer-file seed.
+function Cfgms-NewSeedVHD {
+    param([Parameter(Mandatory)][string]$Path, [int]$SizeBytes = 67108864)
+    New-VHD -Path $Path -SizeBytes $SizeBytes -Dynamic | Out-Null
+}
+
+# Cfgms-MountSeedVHD mounts the seed VHDX and lays down a single FAT32
+# volume labelled CFGMS_SEED. Windows Setup and debian-installer both
+# auto-discover their answer file from a removable/labelled volume. This is
+# a single host-atomic "make the seed a usable filesystem" step — the
+# pipeline cannot be decomposed into Go without holding the mounted-disk
+# handle across calls, so it intentionally chains more than one cmdlet
+# (same exception class as Cfgms-RemoveVM / Cfgms-GetVM).
+function Cfgms-MountSeedVHD {
+    param([Parameter(Mandatory)][string]$Path)
+    Mount-VHD -Path $Path -Passthru |
+        Initialize-Disk -PartitionStyle MBR -PassThru |
+        New-Partition -UseMaximumSize -AssignDriveLetter |
+        Format-Volume -FileSystem FAT32 -NewFileSystemLabel 'CFGMS_SEED' -Confirm:$false | Out-Null
+}
+
+# Cfgms-CopyToSeedVHD writes the answer file to the root of the seed volume.
+# It mounts the VHDX, resolves the drive letter of the CFGMS_SEED volume,
+# writes $Content to <drive>:\$FileName, then dismounts. $Content and
+# $FileName travel via ArgumentList — never interpolated into script text.
+function Cfgms-CopyToSeedVHD {
+    param(
+        [Parameter(Mandatory)][string]$SeedPath,
+        [Parameter(Mandatory)][string]$FileName,
+        [Parameter(Mandatory)][string]$Content
+    )
+    $disk = Mount-VHD -Path $SeedPath -Passthru
+    $letter = ($disk | Get-Disk | Get-Partition | Get-Volume |
+        Where-Object { $_.FileSystemLabel -eq 'CFGMS_SEED' } |
+        Select-Object -First 1).DriveLetter
+    Set-Content -Path ($letter + ':\' + $FileName) -Value $Content -NoNewline
+    Dismount-VHD -Path $SeedPath
+}
+
+# Cfgms-DetachSeedVHD dismounts the seed VHDX from the host (called at
+# finalizing — not in this story's create path). Idempotent on an already
+# dismounted disk via -ErrorAction.
+function Cfgms-DetachSeedVHD {
+    param([Parameter(Mandatory)][string]$Path)
+    Dismount-VHD -Path $Path -ErrorAction SilentlyContinue
+}
+
+# Cfgms-AttachSeedDisk attaches the seed VHDX to the VM as a secondary hard
+# disk. $SeedPath travels via ArgumentList.
+function Cfgms-AttachSeedDisk {
+    param([Parameter(Mandatory)][string]$Name, [Parameter(Mandatory)][string]$SeedPath)
+    Add-VMHardDiskDrive -VMName $Name -Path $SeedPath
+}
+
+# Cfgms-AttachDVD attaches the install ISO (host path) to the VM as a DVD
+# drive. The ISO is never repacked or re-signed (ADR-009 §5). $ISOPath
+# travels via ArgumentList.
+function Cfgms-AttachDVD {
+    param([Parameter(Mandatory)][string]$Name, [Parameter(Mandatory)][string]$ISOPath)
+    Add-VMDvdDrive -VMName $Name -Path $ISOPath
+}
+
+# Cfgms-SetVMFirmware selects the Gen2 secure-boot template by os_family
+# (MicrosoftWindows vs MicrosoftUEFICertificateAuthority). Gen1 VMs have no
+# UEFI/secure boot and never call this. $Template travels via ArgumentList.
+function Cfgms-SetVMFirmware {
+    param([Parameter(Mandatory)][string]$Name, [Parameter(Mandatory)][string]$Template)
+    Set-VMFirmware -VMName $Name -EnableSecureBoot On -SecureBootTemplate $Template
 }
 
 # ── VSwitch read + lifecycle ──────────────────────────────────────────

--- a/features/modules/hyperv/vm.go
+++ b/features/modules/hyperv/vm.go
@@ -312,6 +312,31 @@ func (s *SourceConfig) validate() error {
 	return nil
 }
 
+// parseSourceMap reconstructs a *SourceConfig from the generic config map shape
+// produced by VMConfig.AsMap (and by the executor). Returns nil when no source
+// block is present, so the create path stays on the plain lifecycle.
+func parseSourceMap(v interface{}) *SourceConfig {
+	m, ok := v.(map[string]interface{})
+	if !ok || m == nil {
+		return nil
+	}
+	src := &SourceConfig{}
+	src.ISO, _ = m["iso"].(string)
+	src.OSFamily, _ = m["os_family"].(string)
+	src.Unattend, _ = m["unattend"].(string)
+	src.OnExisting, _ = m["on_existing"].(string)
+	if comp, ok := m["completion"].(map[string]interface{}); ok {
+		src.Completion.Mode, _ = comp["mode"].(string)
+		src.Completion.Timeout, _ = comp["timeout"].(string)
+	}
+	// An entirely empty source map (all fields zero) is treated as no source.
+	if src.ISO == "" && src.OSFamily == "" && src.Unattend == "" &&
+		src.OnExisting == "" && src.Completion.Mode == "" && src.Completion.Timeout == "" {
+		return nil
+	}
+	return src
+}
+
 // AsMap implements modules.ConfigState.
 //
 // switch_name carries the primary (first) desired switch for back-compat;
@@ -414,7 +439,11 @@ const psGetVM = `$vm = Get-VM -Name $Name -ErrorAction SilentlyContinue; if (-no
 //     Manager's default new-VM size and is the minimum sensible value
 //     for any Server 2022/2025 guest). The schema does not currently
 //     expose vhd_size_gb; future #1887 follow-up should add it.
-const psCreateVM = `New-VM -Name $Name -MemoryStartupBytes ($MemoryMB * 1MB) -NewVHDPath $VHDPath -NewVHDSizeBytes 64GB -SwitchName $SwitchName -Generation 2 | Out-Null; if ($CPU -ne 1) { Set-VMProcessor -VMName $Name -Count $CPU }`
+//   - -Generation is now a parameter ($Generation), not hardcoded to 2.
+//     ADR-009 §5 supports Gen1 and Gen2 VMs (the seed VHDX boots on both,
+//     no floppy needed). setVM passes cfg.Generation (defaulting to 2 when
+//     0). The value travels via ArgumentList as a bare integer literal.
+const psCreateVM = `New-VM -Name $Name -MemoryStartupBytes ($MemoryMB * 1MB) -NewVHDPath $VHDPath -NewVHDSizeBytes 64GB -SwitchName $SwitchName -Generation $Generation | Out-Null; if ($CPU -ne 1) { Set-VMProcessor -VMName $Name -Count $CPU }`
 
 // psRemoveVM deletes a VM. Hyper-V refuses to remove a VM that is not Off
 // ("the operation cannot be performed while the object is in its current
@@ -606,6 +635,13 @@ func (m *hypervModule) setVM(ctx context.Context, resourceID string, config modu
 	}
 	cfg.State = state
 
+	// source (the ISO provisioning block) arrives as a nested map on the
+	// executor-supplied config map. Parse it into a SourceConfig so the
+	// create-from-source path activates for the generic map shape too — the
+	// SourceConfig YAML unmarshal only runs when the module decodes its own
+	// YAML, not on this executor-supplied map.
+	cfg.Source = parseSourceMap(configMap["source"])
+
 	// Also handle *VMConfig passed directly
 	if vc, ok := config.(*VMConfig); ok {
 		*cfg = *vc
@@ -655,6 +691,54 @@ func (m *hypervModule) setVM(ctx context.Context, resourceID string, config modu
 	}
 
 	// VM does not exist — create it.
+	if err := m.createVM(ctx, vmName, hostName, cfg); err != nil {
+		return err
+	}
+
+	// Create-from-source (ADR-009): when a source block is declared, build and
+	// attach the seed VHDX, attach the install ISO, advance the provisioning
+	// record, and power on. The seed/ISO attach + power-on happens INSIDE
+	// provisionVM so the provisioning record reflects each step; the plain
+	// lifecycle start below is skipped for the source path.
+	if cfg.Source != nil {
+		if err := m.provisionVM(ctx, vmName, hostName, cfg); err != nil {
+			return err
+		}
+		// Write-through: update cache on success
+		cfgCopy := *cfg
+		cfgCopy.Name = vmName
+		m.vmsMu.Lock()
+		m.vms[vmName] = cfgCopy
+		m.vmsMu.Unlock()
+		return nil
+	}
+
+	if state == "running" {
+		if err := m.execStartVM(ctx, vmName, hostName); err != nil {
+			return err
+		}
+	}
+
+	// Write-through: update cache on success
+	cfgCopy := *cfg
+	cfgCopy.Name = vmName
+	m.vmsMu.Lock()
+	m.vms[vmName] = cfgCopy
+	m.vmsMu.Unlock()
+
+	return nil
+}
+
+// createVM issues New-VM with the desired generation and connects every
+// additional desired switch as a separate adapter. Generation defaults to 2
+// when unset (0). It does NOT power the VM on — the caller decides whether to
+// start (plain lifecycle) or hand off to provisionVM (create-from-source).
+func (m *hypervModule) createVM(ctx context.Context, vmName, hostName string, cfg *VMConfig) error {
+	// 0 means "accept the default" — ADR-009 §5 default is Generation 2.
+	generation := cfg.Generation
+	if generation == 0 {
+		generation = 2
+	}
 
 	psArgs := map[string]string{
 		"Name":       hostName,
@@ -662,6 +746,7 @@ func (m *hypervModule) setVM(ctx context.Context, resourceID string, config modu
 		"CPU":        fmt.Sprintf("%d", cfg.CPUCount),
 		"VHDPath":    cfg.VHDPath,
 		"SwitchName": cfg.SwitchName,
+		"Generation": fmt.Sprintf("%d", generation),
 	}
 
 	_, psErr := m.transport.ExecutePS(ctx, psCreateVM, psArgs)
@@ -679,19 +764,6 @@ func (m *hypervModule) setVM(ctx context.Context, resourceID string, config modu
 			return err
 		}
 	}
-
-	if state == "running" {
-		if err := m.execStartVM(ctx, vmName, hostName); err != nil {
-			return err
-		}
-	}
-
-	// Write-through: update cache on success
-	cfgCopy := *cfg
-	cfgCopy.Name = vmName
-	m.vmsMu.Lock()
-	m.vms[vmName] = cfgCopy
-	m.vmsMu.Unlock()
 
 	return nil
 }

--- a/features/modules/hyperv/vm_provision.go
+++ b/features/modules/hyperv/vm_provision.go
@@ -5,7 +5,6 @@ package hyperv
 import (
 	"context"
 	"fmt"
-	"path/filepath"
 	"strings"
 )
 
@@ -85,13 +84,19 @@ func seedAnswerFilePlaceholder(osFamily string) string {
 	return "# placeholder preseed"
 }
 
-// seedVHDPath derives the seed VHDX path from the VM's VHD directory so the
-// seed lands on the same CSV as the VM's primary disk:
-// <vhdDir>\cfgms-seed-<vmName>.vhdx. vhdDir is the DIRECTORY containing the
-// VM's VHD (filepath.Dir of cfg.VHDPath). Windows path separators are used so
-// the path is valid on the host regardless of the steward's own OS.
-func seedVHDPath(vmName, vhdDir string) string {
-	dir := strings.TrimRight(vhdDir, `\/`)
+// seedVHDPath derives the seed VHDX path from the VM's VHD path so the seed
+// lands in the same directory as the VM's primary disk:
+// <vhdDir>\cfgms-seed-<vmName>.vhdx. The parent directory is computed with
+// Windows path semantics (split on \ or /) rather than filepath.Dir, which is
+// OS-dependent: filepath.Dir("C:\\dir\\x.vhdx") returns "." on Linux (it does
+// not treat "\" as a separator), mangling the always-Windows Hyper-V path when
+// the steward or CI runs on a non-Windows OS (Issue #2044).
+func seedVHDPath(vmName, vhdPath string) string {
+	dir := vhdPath
+	if i := strings.LastIndexAny(vhdPath, `\/`); i >= 0 {
+		dir = vhdPath[:i]
+	}
+	dir = strings.TrimRight(dir, `\/`)
 	return dir + `\` + "cfgms-seed-" + vmName + ".vhdx"
 }
 
@@ -166,7 +171,7 @@ func (m *hypervModule) provisionVM(ctx context.Context, vmName, hostName string,
 	}
 
 	// Build the seed VHDX next to the VM's primary VHD.
-	seedPath := seedVHDPath(vmName, filepath.Dir(cfg.VHDPath))
+	seedPath := seedVHDPath(vmName, cfg.VHDPath)
 	if err := validateSeedPath(seedPath); err != nil {
 		return m.failProvision(ctx, vmName, record, err)
 	}

--- a/features/modules/hyperv/vm_provision.go
+++ b/features/modules/hyperv/vm_provision.go
@@ -1,0 +1,229 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+package hyperv
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"strings"
+)
+
+// ── Provisioning PS verb constants (ADR-009 §5) ────────────────────────────
+//
+// These are platform-neutral const strings: they are the dispatch keys the
+// Windows transport (pstransport_dispatch_windows.go) pattern-matches and the
+// scriptBlock the test transport records. They are NOT executed directly on
+// non-Windows — the production PS host transport only exists on Windows — but
+// the create-from-source orchestration in provisionVM() runs on every platform
+// (driven by the recording transport in tests), so the consts cannot be
+// gated behind a build tag.
+//
+// All user-controlled values (seed path, VM name, ISO path, file name,
+// answer-file content, firmware template) travel via PS function parameters
+// over ArgumentList — never interpolated into the script text. The dispatcher
+// maps each const to its Cfgms-* preamble function.
+
+const (
+	// psNewSeedVHD wraps New-VHD: create the empty dynamic seed disk.
+	psNewSeedVHD = `New-VHD -Path $Path -SizeBytes $SizeBytes -Dynamic | Out-Null`
+
+	// psMountSeedVHD wraps the Mount-VHD → Initialize-Disk → New-Partition →
+	// Format-Volume pipeline: lay a FAT32 CFGMS_SEED volume on the seed disk.
+	psMountSeedVHD = `Mount-VHD -Path $Path -Passthru | Initialize-Disk -PartitionStyle MBR -PassThru | New-Partition -UseMaximumSize -AssignDriveLetter | Format-Volume -FileSystem FAT32 -NewFileSystemLabel 'CFGMS_SEED' -Confirm:$false | Out-Null`
+
+	// psCopyToSeedVHD mounts the seed, writes $Content to <drive>:\$FileName,
+	// and dismounts. $Content and $FileName travel via ArgumentList.
+	psCopyToSeedVHD = `$disk = Mount-VHD -Path $SeedPath -Passthru; $letter = ($disk | Get-Disk | Get-Partition | Get-Volume | Where-Object { $_.FileSystemLabel -eq 'CFGMS_SEED' } | Select-Object -First 1).DriveLetter; Set-Content -Path ($letter + ':\' + $FileName) -Value $Content -NoNewline; Dismount-VHD -Path $SeedPath`
+
+	// psDetachSeedVHD wraps Dismount-VHD (called at finalizing, not in the
+	// create path this story implements).
+	psDetachSeedVHD = `Dismount-VHD -Path $Path -ErrorAction SilentlyContinue`
+
+	// psAttachSeedDisk wraps Add-VMHardDiskDrive: attach the seed VHDX as the
+	// VM's secondary disk.
+	psAttachSeedDisk = `Add-VMHardDiskDrive -VMName $Name -Path $SeedPath`
+
+	// psAttachDVD wraps Add-VMDvdDrive: attach the install ISO as the VM's DVD
+	// drive. The ISO is never repacked or re-signed.
+	psAttachDVD = `Add-VMDvdDrive -VMName $Name -Path $ISOPath`
+
+	// psSetVMFirmware wraps Set-VMFirmware: select the Gen2 secure-boot
+	// template. Gen1 VMs never reach this.
+	psSetVMFirmware = `Set-VMFirmware -VMName $Name -EnableSecureBoot On -SecureBootTemplate $Template`
+)
+
+// secureBootTemplate returns the Gen2 secure-boot firmware template for the
+// given os_family. Windows guests use the Microsoft Windows template; Linux
+// guests (and any non-Windows UEFI guest) use the third-party UEFI CA template
+// so shim/grub signed by the UEFI CA validate. Gen1 VMs have no secure boot
+// and never call this (ADR-009 §5).
+func secureBootTemplate(osFamily string) string {
+	if osFamily == "windows" {
+		return "MicrosoftWindows"
+	}
+	return "MicrosoftUEFICertificateAuthority"
+}
+
+// seedAnswerFileName returns the answer-file name for the os_family. Windows
+// Setup auto-reads autounattend.xml from removable media; debian-installer
+// reads preseed.cfg from the labelled seed volume (ADR-009 §6).
+func seedAnswerFileName(osFamily string) string {
+	if osFamily == "windows" {
+		return "autounattend.xml"
+	}
+	return "preseed.cfg"
+}
+
+// seedAnswerFilePlaceholder returns the placeholder answer-file content for the
+// os_family. Real templates are injected by #2046/#2047; this story only needs
+// the seed VHDX to be non-empty. The content is a one-line comment stub.
+func seedAnswerFilePlaceholder(osFamily string) string {
+	if osFamily == "windows" {
+		return "<!-- placeholder autounattend -->"
+	}
+	return "# placeholder preseed"
+}
+
+// seedVHDPath derives the seed VHDX path from the VM's VHD directory so the
+// seed lands on the same CSV as the VM's primary disk:
+// <vhdDir>\cfgms-seed-<vmName>.vhdx. vhdDir is the DIRECTORY containing the
+// VM's VHD (filepath.Dir of cfg.VHDPath). Windows path separators are used so
+// the path is valid on the host regardless of the steward's own OS.
+func seedVHDPath(vmName, vhdDir string) string {
+	dir := strings.TrimRight(vhdDir, `\/`)
+	return dir + `\` + "cfgms-seed-" + vmName + ".vhdx"
+}
+
+// validateSeedPath rejects a seed path that is not a safe absolute Windows
+// path before it can reach the PS transport. A non-absolute path (no drive
+// letter) and a UNC path (\\server\share) are both rejected: the seed must
+// live on a local/CSV drive next to the VM's VHD, never on an arbitrary
+// network share. Defense-in-depth even though the value travels via
+// ArgumentList.
+func validateSeedPath(path string) error {
+	if strings.HasPrefix(path, `\\`) {
+		return ErrInvalidSeedPath
+	}
+	if !vhdPathPattern.MatchString(path) {
+		return ErrInvalidSeedPath
+	}
+	return nil
+}
+
+// provisionVM performs the create-from-source flow for a VM that was just
+// created by createVM and carries a source block (ADR-009 §3, §5). It:
+//
+//  1. resumes from / initialises the provisioning record (absent → creating);
+//  2. selects the Gen2 secure-boot firmware template by os_family (Gen1 skips);
+//  3. builds the seed VHDX (New-VHD → Mount/format → copy answer file);
+//  4. attaches the seed VHDX as the secondary disk;
+//  5. attaches the install ISO as the DVD (never repacked/re-signed);
+//  6. powers the VM on and advances the record to installing.
+//
+// The ready transition is controller-side (#2050) and is NOT performed here —
+// the host-side module stops at installing.
+func (m *hypervModule) provisionVM(ctx context.Context, vmName, hostName string, cfg *VMConfig) error {
+	if cfg.Source == nil {
+		return nil
+	}
+
+	// Resolve the provisioning record. Resuming from an in-progress record must
+	// NOT restart from absent (ADR-009 §2 safety invariant): if a record exists
+	// at installing/finalizing, the steps below have already run and we leave it.
+	record, err := m.loadOrInitProvision(ctx, vmName)
+	if err != nil {
+		return err
+	}
+	if record.State == ProvisionStateInstalling ||
+		record.State == ProvisionStateFinalizing ||
+		record.State == ProvisionStateReady {
+		// Already past the host-side create steps — nothing to redo.
+		return nil
+	}
+
+	// absent → creating once the VM and disks exist.
+	if err := m.advanceProvision(ctx, vmName, record, ProvisionStateCreating); err != nil {
+		return err
+	}
+
+	generation := cfg.Generation
+	if generation == 0 {
+		generation = 2
+	}
+
+	// Gen2 secure-boot template by os_family; Gen1 has no UEFI/secure boot.
+	if generation == 2 {
+		template := secureBootTemplate(cfg.Source.OSFamily)
+		if _, psErr := m.transport.ExecutePS(ctx, psSetVMFirmware, map[string]string{
+			"Name":     hostName,
+			"Template": template,
+		}); psErr != nil {
+			recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.host, "Set-VMFirmware", hostName, psErr)
+			return m.failProvision(ctx, vmName, record, fmt.Errorf("hyperv: set firmware for VM %q: %w", vmName, psErr))
+		}
+		recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.host, "Set-VMFirmware", hostName, nil)
+	}
+
+	// Build the seed VHDX next to the VM's primary VHD.
+	seedPath := seedVHDPath(vmName, filepath.Dir(cfg.VHDPath))
+	if err := validateSeedPath(seedPath); err != nil {
+		return m.failProvision(ctx, vmName, record, err)
+	}
+
+	if _, psErr := m.transport.ExecutePS(ctx, psNewSeedVHD, map[string]string{
+		"Path":      seedPath,
+		"SizeBytes": "67108864", // 64 MiB
+	}); psErr != nil {
+		recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.host, "New-VHD", hostName, psErr)
+		return m.failProvision(ctx, vmName, record, fmt.Errorf("hyperv: create seed VHDX for VM %q: %w", vmName, psErr))
+	}
+	recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.host, "New-VHD", hostName, nil)
+
+	if _, psErr := m.transport.ExecutePS(ctx, psMountSeedVHD, map[string]string{
+		"Path": seedPath,
+	}); psErr != nil {
+		recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.host, "Format-Volume", hostName, psErr)
+		return m.failProvision(ctx, vmName, record, fmt.Errorf("hyperv: format seed VHDX for VM %q: %w", vmName, psErr))
+	}
+	recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.host, "Format-Volume", hostName, nil)
+
+	if _, psErr := m.transport.ExecutePS(ctx, psCopyToSeedVHD, map[string]string{
+		"SeedPath": seedPath,
+		"FileName": seedAnswerFileName(cfg.Source.OSFamily),
+		"Content":  seedAnswerFilePlaceholder(cfg.Source.OSFamily),
+	}); psErr != nil {
+		recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.host, "Set-Content", hostName, psErr)
+		return m.failProvision(ctx, vmName, record, fmt.Errorf("hyperv: write answer file to seed for VM %q: %w", vmName, psErr))
+	}
+	recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.host, "Set-Content", hostName, nil)
+
+	// Attach the seed VHDX as the secondary disk.
+	if _, psErr := m.transport.ExecutePS(ctx, psAttachSeedDisk, map[string]string{
+		"Name":     hostName,
+		"SeedPath": seedPath,
+	}); psErr != nil {
+		recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.host, "Add-VMHardDiskDrive", hostName, psErr)
+		return m.failProvision(ctx, vmName, record, fmt.Errorf("hyperv: attach seed disk to VM %q: %w", vmName, psErr))
+	}
+	recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.host, "Add-VMHardDiskDrive", hostName, nil)
+
+	// Attach the install ISO as the DVD drive (host path, never repacked).
+	if _, psErr := m.transport.ExecutePS(ctx, psAttachDVD, map[string]string{
+		"Name":    hostName,
+		"ISOPath": cfg.Source.ISO,
+	}); psErr != nil {
+		recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.host, "Add-VMDvdDrive", hostName, psErr)
+		return m.failProvision(ctx, vmName, record, fmt.Errorf("hyperv: attach install ISO to VM %q: %w", vmName, psErr))
+	}
+	recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.host, "Add-VMDvdDrive", hostName, nil)
+
+	// Power on and advance creating → installing. The unattended install runs
+	// inside the guest; the host-side module observes no further until the
+	// controller-side reconciler (#2050) flips ready.
+	if err := m.execStartVM(ctx, vmName, hostName); err != nil {
+		return m.failProvision(ctx, vmName, record, err)
+	}
+
+	return m.advanceProvision(ctx, vmName, record, ProvisionStateInstalling)
+}

--- a/features/modules/hyperv/vm_provision_test.go
+++ b/features/modules/hyperv/vm_provision_test.go
@@ -1,0 +1,388 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+package hyperv
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// provisionModuleWithTransport builds a hypervModule wired with the given
+// transport and an in-memory provision store for create-from-source tests.
+func provisionModuleWithTransport(transport winrmTransport) *hypervModule {
+	return &hypervModule{
+		executor:       &stubHypervExecutor{},
+		transport:      transport,
+		tenantID:       "ops",
+		vms:            make(map[string]VMConfig),
+		detector:       &fakeDetector{result: true},
+		provisionStore: newMemProvisionStore(),
+	}
+}
+
+// sourceVMConfigMap returns the executor-shaped config map for an absent VM
+// that carries a source block, for the requested generation and os_family.
+func sourceVMConfigMap(generation int, osFamily string) map[string]interface{} {
+	return map[string]interface{}{
+		"name":        "stw-01",
+		"memory_mb":   4096,
+		"cpu_count":   2,
+		"vhd_path":    `C:\ClusterStorage\CSV01\stw-01.vhdx`,
+		"generation":  generation,
+		"state":       "running",
+		"switch_name": "HVSwitch_1G",
+		"source": map[string]interface{}{
+			"iso":       `C:\ClusterStorage\CSV01\iso\server.iso`,
+			"os_family": osFamily,
+			"completion": map[string]interface{}{
+				"mode":    "steward-registration",
+				"timeout": "60m",
+			},
+			"on_existing": "never",
+		},
+	}
+}
+
+// ── REQUIRED TEST: secureBootTemplate ──────────────────────────────────────
+
+// TestProvisionVM_SecureBootTemplate asserts the os_family → secure-boot
+// template mapping required by ADR-009 §5.
+func TestProvisionVM_SecureBootTemplate(t *testing.T) {
+	assert.Equal(t, "MicrosoftWindows", secureBootTemplate("windows"))
+	assert.Equal(t, "MicrosoftUEFICertificateAuthority", secureBootTemplate("linux"))
+}
+
+// ── REQUIRED TEST: Gen1 skips firmware ──────────────────────────────────────
+
+// TestProvisionVM_Gen1SkipsFirmware drives an absent Gen1 VM with a source
+// block and asserts no Set-VMFirmware PS call is issued (Gen1 has no secure
+// boot), while the seed VHDX + ISO attach + create still run.
+func TestProvisionVM_Gen1SkipsFirmware(t *testing.T) {
+	transport := &testWinRMTransport{
+		perCallOutputs: []string{`{"found":false}`}, // getVM → absent
+	}
+	m := provisionModuleWithTransport(transport)
+
+	cfg := rawConfigState{m: sourceVMConfigMap(1, "linux")}
+	require.NoError(t, m.Set(context.Background(), "vm:stw-01", cfg))
+
+	transport.mu.Lock()
+	calls := transport.calls
+	transport.mu.Unlock()
+
+	assert.Empty(t, callsContaining(calls, "Set-VMFirmware"),
+		"Gen1 VMs must not issue Set-VMFirmware — Gen1 has no UEFI/secure boot")
+
+	// Create + seed build + attach still happen on the Gen1 path.
+	require.Len(t, callsContaining(calls, "New-VM"), 1, "Gen1 VM must still be created")
+	assert.NotEmpty(t, callsContaining(calls, "New-VHD"), "seed VHDX must still be built")
+	assert.NotEmpty(t, callsContaining(calls, "Add-VMDvdDrive"), "install ISO must still be attached")
+}
+
+// ── REQUIRED TEST: seed path validation ─────────────────────────────────────
+
+// TestProvisionVM_SeedPathValidation asserts that a non-absolute seed path and
+// a UNC path are rejected before reaching the PS transport.
+func TestProvisionVM_SeedPathValidation(t *testing.T) {
+	cases := []struct {
+		name string
+		path string
+		ok   bool
+	}{
+		{"absolute local", `C:\VMs\cfgms-seed-x.vhdx`, true},
+		{"non-absolute relative", `VMs\cfgms-seed-x.vhdx`, false},
+		{"non-absolute bare", `cfgms-seed-x.vhdx`, false},
+		{"UNC share", `\\server\share\cfgms-seed-x.vhdx`, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateSeedPath(tc.path)
+			if tc.ok {
+				assert.NoError(t, err)
+			} else {
+				assert.ErrorIs(t, err, ErrInvalidSeedPath)
+			}
+		})
+	}
+}
+
+// ── Gen1 create emits -Generation 1 ─────────────────────────────────────────
+
+// TestProvisionVM_Gen1CreatePassesGeneration drives an absent Gen1 VM (no
+// source) and asserts the New-VM call carries Generation 1 in args.
+func TestProvisionVM_Gen1CreatePassesGeneration(t *testing.T) {
+	transport := &testWinRMTransport{
+		perCallOutputs: []string{`{"found":false}`},
+	}
+	m := vmModuleWithTransport(transport, "ops")
+
+	cfg := rawConfigState{m: map[string]interface{}{
+		"name":        "gen1-vm",
+		"memory_mb":   2048,
+		"cpu_count":   2,
+		"vhd_path":    `C:\VMs\gen1-vm.vhdx`,
+		"generation":  1,
+		"state":       "stopped",
+		"switch_name": "sw-a",
+	}}
+	require.NoError(t, m.Set(context.Background(), "vm:gen1-vm", cfg))
+
+	transport.mu.Lock()
+	calls := transport.calls
+	transport.mu.Unlock()
+
+	newVM := callsContaining(calls, "New-VM")
+	require.Len(t, newVM, 1)
+	assert.True(t, argsContain(newVM[0], "1"), "New-VM must pass Generation 1 via args")
+	// Generation must never be interpolated into the script text.
+	assert.Contains(t, newVM[0].scriptBlock, "$Generation",
+		"generation must travel as the $Generation param reference")
+}
+
+// TestProvisionVM_Gen2CreateDefaultsGeneration drives an absent VM with
+// generation unset (0) and asserts New-VM defaults to Generation 2.
+func TestProvisionVM_Gen2CreateDefaultsGeneration(t *testing.T) {
+	transport := &testWinRMTransport{
+		perCallOutputs: []string{`{"found":false}`},
+	}
+	m := vmModuleWithTransport(transport, "ops")
+
+	cfg := rawConfigState{m: map[string]interface{}{
+		"name":        "def-vm",
+		"memory_mb":   2048,
+		"cpu_count":   2,
+		"vhd_path":    `C:\VMs\def-vm.vhdx`,
+		"state":       "stopped",
+		"switch_name": "sw-a",
+		// generation omitted → 0 → defaults to 2
+	}}
+	require.NoError(t, m.Set(context.Background(), "vm:def-vm", cfg))
+
+	transport.mu.Lock()
+	calls := transport.calls
+	transport.mu.Unlock()
+
+	newVM := callsContaining(calls, "New-VM")
+	require.Len(t, newVM, 1)
+	assert.True(t, argsContain(newVM[0], "2"), "unset generation must default to Generation 2 in args")
+}
+
+// ── Gen2 create-from-source: firmware template per os_family ─────────────────
+
+// TestProvisionVM_Gen2WindowsFirmwareTemplate drives an absent Gen2 windows VM
+// with a source block and asserts Set-VMFirmware travels with the
+// MicrosoftWindows template via args (never interpolated).
+func TestProvisionVM_Gen2WindowsFirmwareTemplate(t *testing.T) {
+	transport := &testWinRMTransport{
+		perCallOutputs: []string{`{"found":false}`},
+	}
+	m := provisionModuleWithTransport(transport)
+
+	cfg := rawConfigState{m: sourceVMConfigMap(2, "windows")}
+	require.NoError(t, m.Set(context.Background(), "vm:stw-01", cfg))
+
+	transport.mu.Lock()
+	calls := transport.calls
+	transport.mu.Unlock()
+
+	fw := callsContaining(calls, "Set-VMFirmware")
+	require.Len(t, fw, 1, "Gen2 VM must call Set-VMFirmware exactly once")
+	assert.True(t, argsContain(fw[0], "MicrosoftWindows"),
+		"windows os_family must select the MicrosoftWindows template")
+	assert.NotContains(t, fw[0].scriptBlock, "MicrosoftWindows",
+		"firmware template must travel via args, not the script text")
+}
+
+// TestProvisionVM_Gen2LinuxFirmwareTemplate asserts the linux os_family selects
+// the MicrosoftUEFICertificateAuthority template on the Gen2 source path.
+func TestProvisionVM_Gen2LinuxFirmwareTemplate(t *testing.T) {
+	transport := &testWinRMTransport{
+		perCallOutputs: []string{`{"found":false}`},
+	}
+	m := provisionModuleWithTransport(transport)
+
+	cfg := rawConfigState{m: sourceVMConfigMap(2, "linux")}
+	require.NoError(t, m.Set(context.Background(), "vm:stw-01", cfg))
+
+	transport.mu.Lock()
+	calls := transport.calls
+	transport.mu.Unlock()
+
+	fw := callsContaining(calls, "Set-VMFirmware")
+	require.Len(t, fw, 1)
+	assert.True(t, argsContain(fw[0], "MicrosoftUEFICertificateAuthority"),
+		"linux os_family must select the MicrosoftUEFICertificateAuthority template")
+}
+
+// ── Seed VHDX build + attach sequence ────────────────────────────────────────
+
+// TestProvisionVM_SeedVHDBuildAndAttachSequence drives an absent Gen2 windows
+// VM with a source block and asserts the full seed build + media attach
+// sequence is emitted in order: New-VHD → Format-Volume (Mount) → Set-Content
+// (copy) → Add-VMHardDiskDrive (seed attach) → Add-VMDvdDrive (ISO).
+func TestProvisionVM_SeedVHDBuildAndAttachSequence(t *testing.T) {
+	transport := &testWinRMTransport{
+		perCallOutputs: []string{`{"found":false}`},
+	}
+	m := provisionModuleWithTransport(transport)
+
+	cfg := rawConfigState{m: sourceVMConfigMap(2, "windows")}
+	require.NoError(t, m.Set(context.Background(), "vm:stw-01", cfg))
+
+	transport.mu.Lock()
+	calls := transport.calls
+	transport.mu.Unlock()
+
+	// Each provisioning verb runs exactly once.
+	require.Len(t, callsContaining(calls, "New-VHD"), 1, "one New-VHD (seed create)")
+	require.Len(t, callsContaining(calls, "Format-Volume"), 1, "one Format-Volume (seed mount/format)")
+	require.Len(t, callsContaining(calls, "Set-Content"), 1, "one Set-Content (answer file copy)")
+	require.Len(t, callsContaining(calls, "Add-VMHardDiskDrive"), 1, "one Add-VMHardDiskDrive (seed attach)")
+	require.Len(t, callsContaining(calls, "Add-VMDvdDrive"), 1, "one Add-VMDvdDrive (install ISO)")
+
+	// Assert ordering by scanning the recorded call sequence.
+	order := map[string]int{}
+	for i, c := range calls {
+		for _, verb := range []string{"New-VHD", "Format-Volume", "Set-Content", "Add-VMHardDiskDrive", "Add-VMDvdDrive", "Start-VM"} {
+			if _, seen := order[verb]; !seen && strings.Contains(c.scriptBlock, verb) {
+				order[verb] = i
+			}
+		}
+	}
+	assert.Less(t, order["New-VHD"], order["Format-Volume"], "New-VHD before Format-Volume")
+	assert.Less(t, order["Format-Volume"], order["Set-Content"], "Format before copy")
+	assert.Less(t, order["Set-Content"], order["Add-VMHardDiskDrive"], "copy before seed attach")
+	assert.Less(t, order["Add-VMHardDiskDrive"], order["Add-VMDvdDrive"], "seed attach before ISO attach")
+	assert.Less(t, order["Add-VMDvdDrive"], order["Start-VM"], "media attached before power on")
+
+	// The seed path and answer file name travel via args, never the script.
+	seedNew := callsContaining(calls, "New-VHD")[0]
+	assert.True(t, argsContain(seedNew, `C:\ClusterStorage\CSV01\cfgms-seed-stw-01.vhdx`),
+		"seed path must derive from the VM VHD directory and travel via args")
+	assert.NotContains(t, seedNew.scriptBlock, "cfgms-seed-stw-01",
+		"seed path must not be interpolated into the script text")
+
+	copy := callsContaining(calls, "Set-Content")[0]
+	assert.True(t, argsContain(copy, "autounattend.xml"),
+		"windows os_family must seed autounattend.xml")
+}
+
+// TestProvisionVM_AttachesInstallISOFromHostPath asserts the install ISO is
+// attached from the host path via args, never repacked or interpolated.
+func TestProvisionVM_AttachesInstallISOFromHostPath(t *testing.T) {
+	transport := &testWinRMTransport{
+		perCallOutputs: []string{`{"found":false}`},
+	}
+	m := provisionModuleWithTransport(transport)
+
+	cfg := rawConfigState{m: sourceVMConfigMap(2, "windows")}
+	require.NoError(t, m.Set(context.Background(), "vm:stw-01", cfg))
+
+	transport.mu.Lock()
+	calls := transport.calls
+	transport.mu.Unlock()
+
+	dvd := callsContaining(calls, "Add-VMDvdDrive")
+	require.Len(t, dvd, 1)
+	assert.True(t, argsContain(dvd[0], `C:\ClusterStorage\CSV01\iso\server.iso`),
+		"install ISO host path must travel via args")
+	assert.NotContains(t, dvd[0].scriptBlock, "server.iso",
+		"ISO path must not be interpolated into the script text")
+}
+
+// ── Provisioning record advancement ──────────────────────────────────────────
+
+// TestProvisionVM_AdvancesRecordAbsentToInstalling asserts the create-from-source
+// path advances the provisioning record absent → creating → installing with
+// timestamps and the correlation identity baked in.
+func TestProvisionVM_AdvancesRecordAbsentToInstalling(t *testing.T) {
+	transport := &testWinRMTransport{
+		perCallOutputs: []string{`{"found":false}`},
+	}
+	store := newMemProvisionStore()
+	m := provisionModuleWithTransport(transport)
+	m.provisionStore = store
+
+	cfg := rawConfigState{m: sourceVMConfigMap(2, "windows")}
+	require.NoError(t, m.Set(context.Background(), "vm:stw-01", cfg))
+
+	rec, err := store.GetProvision(context.Background(), "stw-01")
+	require.NoError(t, err)
+	assert.Equal(t, ProvisionStateInstalling, rec.State,
+		"host-side provisioning must end at installing (ready is controller-side, #2050)")
+	assert.Equal(t, "stw-01", rec.CorrelationID, "correlation id baked from the VM name")
+	assert.False(t, rec.StartedAt.IsZero(), "StartedAt must be stamped")
+	assert.False(t, rec.UpdatedAt.IsZero(), "UpdatedAt must be stamped")
+}
+
+// TestProvisionVM_ResumeFromInstallingDoesNotRestart asserts that re-running the
+// create-from-source path while a record already sits at installing does not
+// rebuild the seed or re-attach media (no restart from absent — ADR-009 §2).
+func TestProvisionVM_ResumeFromInstallingDoesNotRestart(t *testing.T) {
+	transport := &testWinRMTransport{
+		perCallOutputs: []string{`{"found":false}`},
+	}
+	store := newMemProvisionStore()
+	require.NoError(t, store.SetProvision(context.Background(), &ProvisionRecord{
+		VMName:        "stw-01",
+		State:         ProvisionStateInstalling,
+		CorrelationID: "stw-01",
+	}))
+	m := provisionModuleWithTransport(transport)
+	m.provisionStore = store
+
+	cfg := rawConfigState{m: sourceVMConfigMap(2, "windows")}
+	require.NoError(t, m.Set(context.Background(), "vm:stw-01", cfg))
+
+	transport.mu.Lock()
+	calls := transport.calls
+	transport.mu.Unlock()
+
+	// The VM is still absent on the host (getVM → not found) so createVM runs,
+	// but provisionVM must short-circuit on the installing record: no seed
+	// rebuild, no media re-attach, no firmware re-apply.
+	assert.Empty(t, callsContaining(calls, "New-VHD"),
+		"resume from installing must not rebuild the seed VHDX")
+	assert.Empty(t, callsContaining(calls, "Add-VMDvdDrive"),
+		"resume from installing must not re-attach the install ISO")
+	assert.Empty(t, callsContaining(calls, "Set-VMFirmware"),
+		"resume from installing must not re-apply firmware")
+}
+
+// TestProvisionVM_NoSourceSkipsProvisioning asserts a plain absent VM (no
+// source) takes the normal lifecycle path: no seed build, no media attach, and
+// no provisioning record written.
+func TestProvisionVM_NoSourceSkipsProvisioning(t *testing.T) {
+	transport := &testWinRMTransport{
+		perCallOutputs: []string{`{"found":false}`},
+	}
+	store := newMemProvisionStore()
+	m := provisionModuleWithTransport(transport)
+	m.provisionStore = store
+
+	cfg := rawConfigState{m: map[string]interface{}{
+		"name":        "plain-vm",
+		"memory_mb":   2048,
+		"cpu_count":   2,
+		"vhd_path":    `C:\VMs\plain-vm.vhdx`,
+		"generation":  2,
+		"state":       "running",
+		"switch_name": "sw-a",
+	}}
+	require.NoError(t, m.Set(context.Background(), "vm:plain-vm", cfg))
+
+	transport.mu.Lock()
+	calls := transport.calls
+	transport.mu.Unlock()
+
+	assert.Empty(t, callsContaining(calls, "New-VHD"), "no source: no seed build")
+	assert.Empty(t, callsContaining(calls, "Add-VMDvdDrive"), "no source: no ISO attach")
+	assert.Empty(t, callsContaining(calls, "Set-VMFirmware"), "no source: no firmware step")
+
+	_, err := store.GetProvision(context.Background(), "plain-vm")
+	assert.ErrorIs(t, err, ErrProvisionNotFound, "no source: no provisioning record")
+}


### PR DESCRIPTION
Fixes #2044. Implements the create-from-source path on `hyperv.vm`, building on the #2043 provisioning types. Per **ADR-009 §5/§6** and the PO gap-resolutions on #1851.

## What's implemented
- **Generation parameterized** on `psCreateVM`/`Cfgms-CreateVM` (`[int]$Generation`, Gen1 + Gen2).
- **Host-native seed VHDX** (no oscdimg/ADK, no new Go dep): `Cfgms-NewSeedVHD`, `Cfgms-MountSeedVHD` (New-VHD → Initialize-Disk → New-Partition → Format-Volume FAT32 `CFGMS_SEED`), `Cfgms-CopyToSeedVHD`, `Cfgms-DetachSeedVHD`, `Cfgms-AttachSeedDisk`; matching dispatch cases. All user values travel via `-ArgumentList` (banned-pattern-safe).
- **Secure-boot template by `os_family`** (`Cfgms-SetVMFirmware`: `MicrosoftWindows` vs `MicrosoftUEFICertificateAuthority`); Gen1 skips firmware.
- **Create-from-source wiring** (`vm_provision.go`): absent + `source` → create (gen1/2) + build & attach seed VHDX + attach install ISO from the host path + advance `ProvisionState` absent→creating→installing via the `ProvisionRecord`. The `ready` transition is controller-side (#2050), not here.

## Tests
14 recording-transport tests (no mocks, no skips): Gen1/Gen2 create, firmware template per os_family, seed VHDX build+attach sequence, ISO attach from host path, ProvisionState advance, resume-from-installing (idempotent), no-source skip, seed-path validation, PS quoting. `go vet` + hyperv package tests green; `go build ./...` + `make check-architecture` clean.

## Scope / validation notes
- Stays within #2044 — does **not** implement #2050's controller-side reconciler or #2046/#2047's preseed/autounattend templates.
- Live Hyper-V provisioning is validated end-to-end by **#2046 (Debian) / #2047 (Windows)**; #2044's tests are recording-transport (CI-runnable). The seed cmdlets (`New-VHD`/`Format-Volume`/`Mount-VHD`) are confirmed present on the Hyper-V host.
- Built on the Windows self-dispatch host (#2039 / `/po work`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)