### PR TITLE
hyperv: unattended-profile model + ConfigBackedProfileStore + secret rendering (Issue #2045)

### DIFF
--- a/features/modules/hyperv/module.go
+++ b/features/modules/hyperv/module.go
@@ -13,6 +13,7 @@ import (
 	"github.com/cfgis/cfgms/features/modules"
 	"github.com/cfgis/cfgms/pkg/audit"
 	"github.com/cfgis/cfgms/pkg/logging"
+	cfgconfig "github.com/cfgis/cfgms/pkg/storage/interfaces/config"
 )
 
 var (
@@ -65,6 +66,13 @@ type hypervModule struct {
 	// in-memory store via New(); tests inject an alternative with
 	// WithProvisionStore.
 	provisionStore ProvisionStore
+
+	// profileStore loads unattended-install profiles referenced as
+	// profile://<name> in a VM source (ADR-009 §7). It is wired from the
+	// controller's stored-config backend in Configure() when a "config_store"
+	// is supplied, or injected directly in tests via WithProfileStore. It may
+	// be nil when no config store is available; callers must handle that.
+	profileStore ProfileStore
 }
 
 // HypervOption configures a hypervModule at construction time.
@@ -76,6 +84,17 @@ func WithProvisionStore(s ProvisionStore) HypervOption {
 	return func(m *hypervModule) {
 		if s != nil {
 			m.provisionStore = s
+		}
+	}
+}
+
+// WithProfileStore overrides the ProfileStore wired from the config store.
+// Tests inject a memProfileStore (or another ProfileStore) to supply profiles
+// without a stored-config backend. A nil store is ignored.
+func WithProfileStore(s ProfileStore) HypervOption {
+	return func(m *hypervModule) {
+		if s != nil {
+			m.profileStore = s
 		}
 	}
 }
@@ -173,6 +192,17 @@ func (m *hypervModule) Configure(config modules.ConfigState) error {
 
 	m.tenantID, _ = configMap["tenant_id"].(string)
 	m.auditMgr, _ = configMap["audit_manager"].(*audit.Manager)
+
+	// Wire the stored-config-backed profile store when a config store is
+	// supplied (same injection pattern as audit_manager). Operators define
+	// unattended-install profiles in the controller's stored-config backend and
+	// reference them as profile://<name>; this makes them loadable without code
+	// changes (ADR-009 §7). When no config store is provided, profileStore stays
+	// as set by WithProfileStore (nil in production without a backend).
+	if configStore, ok := configMap["config_store"].(cfgconfig.ConfigStore); ok && configStore != nil {
+		m.profileStore = &ConfigBackedProfileStore{store: configStore, tenantID: m.tenantID}
+	}
+
 	stewardID, _ := configMap["steward_id"].(string)
 	if stewardID == "" {
 		stewardID = m.tenantID + "/hyperv"

--- a/features/modules/hyperv/profile.go
+++ b/features/modules/hyperv/profile.go
@@ -1,0 +1,233 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+package hyperv
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"regexp"
+	"strings"
+	"text/template"
+
+	secretsif "github.com/cfgis/cfgms/pkg/secrets/interfaces"
+)
+
+// profileURIPrefix is the scheme used to reference an unattended-install profile
+// from a VM source's unattend field (e.g. "profile://debian-12-base").
+const profileURIPrefix = "profile://"
+
+// profileNamePattern bounds profile names to a safe character set and length so
+// they map cleanly onto config-store keys and cannot smuggle path separators or
+// other control characters into the stored-config backend. (ADR-009 §7,
+// ADR-003 key-path conventions.)
+var profileNamePattern = regexp.MustCompile(`^[a-zA-Z0-9_\-]{1,64}$`)
+
+var (
+	// ErrProfileNotFound is the sentinel returned by ProfileStore implementations
+	// when no profile exists under the requested name.
+	ErrProfileNotFound = errors.New("hyperv: unattend profile not found")
+
+	// ErrInvalidProfileName is returned when a profile reference does not match
+	// the allowed name pattern after the profile:// prefix is stripped.
+	ErrInvalidProfileName = errors.New("hyperv: invalid profile name: must match ^[a-zA-Z0-9_\\-]{1,64}$")
+
+	// ErrInvalidAnswerFormat is returned when a profile's answer_format is not one
+	// of the formats supported in v1 (preseed, autounattend).
+	ErrInvalidAnswerFormat = errors.New("hyperv: invalid answer_format: must be preseed or autounattend")
+)
+
+// AnswerFormat enumerates the unattended-answer file formats supported in v1.
+// preseed is the Debian/Ubuntu installer format; autounattend is the Windows
+// Setup answer-file format. The concrete templates for each format are provided
+// by sibling stories (#2046 preseed, #2047 autounattend); this story only
+// validates the format value and renders the profile's template bytes.
+type AnswerFormat string
+
+const (
+	// AnswerFormatPreseed is the Debian/Ubuntu preseed.cfg format.
+	AnswerFormatPreseed AnswerFormat = "preseed"
+	// AnswerFormatAutounattend is the Windows Setup autounattend.xml format.
+	AnswerFormatAutounattend AnswerFormat = "autounattend"
+)
+
+// valid reports whether the AnswerFormat is one of the v1-supported formats.
+func (f AnswerFormat) valid() bool {
+	switch f {
+	case AnswerFormatPreseed, AnswerFormatAutounattend:
+		return true
+	default:
+		return false
+	}
+}
+
+// EnrollConfig describes how a freshly provisioned VM enrolls back into CFGMS.
+// It carries the secret KEY NAME of the registration token (never the token
+// value) plus the bundle URL and a correlation label. The token value is
+// resolved from the SecretStore at render time and never persisted in the
+// profile or on committed media.
+type EnrollConfig struct {
+	// RegistrationTokenSecretKey is the SecretStore key under which the
+	// enrollment registration token is stored (e.g. "hyperv/enroll/regtoken").
+	// The value is fetched at render time; only the key is stored in the profile.
+	RegistrationTokenSecretKey string `yaml:"registration_token_secret_key,omitempty"`
+	// BundleURL is the location the new endpoint pulls its enrollment bundle from.
+	BundleURL string `yaml:"bundle_url,omitempty"`
+	// CorrelationLabel ties the provisioned VM back to a provisioning request for
+	// the controller-side completion reconciler (sibling story S8).
+	CorrelationLabel string `yaml:"correlation_label,omitempty"`
+}
+
+// UnattendProfile is the operator-authored, stored-config definition of an
+// unattended install. It is YAML-serialised into the controller's stored-config
+// backend under hyperv/profiles/<name> (ADR-003) and referenced from a VM
+// source as profile://<name>. No secret VALUES live here — only secret key
+// names, which are resolved from the secrets provider at render time.
+type UnattendProfile struct {
+	// Name is the profile identifier (matches the profile:// reference suffix).
+	Name string `yaml:"name"`
+	// OSFamily is the installer family: linux or windows.
+	OSFamily string `yaml:"os_family"`
+	// AnswerFormat is the answer-file format: preseed or autounattend.
+	AnswerFormat AnswerFormat `yaml:"answer_format"`
+	// Template is the text/template source for the answer file. It may reference
+	// per-VM vars ({{ .VMName }}, {{ .OSFamily }}, {{ .EnrollToken }}) and
+	// secrets ({{ secret "key" }}). It is NOT HTML and is never HTML-escaped.
+	Template string `yaml:"template"`
+	// Enroll carries enrollment wiring (token secret key, bundle URL, label).
+	Enroll EnrollConfig `yaml:"enroll,omitempty"`
+}
+
+// validate checks the profile's structural invariants that must hold before any
+// rendering is attempted. It returns a typed error (ErrInvalidAnswerFormat,
+// ErrInvalidProfileName) so callers and tests can assert on the cause.
+func (p *UnattendProfile) validate() error {
+	if !profileNamePattern.MatchString(p.Name) {
+		return fmt.Errorf("%w: %q", ErrInvalidProfileName, p.Name)
+	}
+	if !p.AnswerFormat.valid() {
+		return fmt.Errorf("%w: %q", ErrInvalidAnswerFormat, p.AnswerFormat)
+	}
+	return nil
+}
+
+// ProfileStore loads unattended-install profiles by name. Implementations read
+// from a durable backend (ConfigBackedProfileStore) or, in unit tests, from an
+// in-memory double (memProfileStore). GetProfile returns ErrProfileNotFound
+// when the named profile does not exist.
+type ProfileStore interface {
+	GetProfile(ctx context.Context, name string) (*UnattendProfile, error)
+}
+
+// ProfileVars are the per-VM values substituted into a profile template at
+// render time. They are supplied by the caller (the create-from-source path),
+// never stored in the profile itself.
+type ProfileVars struct {
+	// VMName is the host-side VM name being provisioned.
+	VMName string
+	// OSFamily is the installer family for this VM (linux or windows).
+	OSFamily string
+	// EnrollToken is the resolved registration token for this VM. It is supplied
+	// pre-resolved by the caller (or left empty when not applicable). Secret
+	// VALUES referenced via {{ secret "key" }} are resolved separately from the
+	// SecretStore at render time.
+	EnrollToken string
+}
+
+// ProfileRenderer renders an UnattendProfile's template into answer-file bytes,
+// substituting per-VM vars and resolving {{ secret "key" }} placeholders against
+// an injected SecretStore at render time. Secret values are inserted into the
+// output bytes and never logged. Output is plain text (preseed.cfg or XML);
+// text/template is used (NOT html/template) so installer syntax is not corrupted
+// by HTML escaping.
+type ProfileRenderer struct{}
+
+// NewProfileRenderer returns a ProfileRenderer. It carries no state; a value is
+// returned for symmetry with the other store/renderer constructors.
+func NewProfileRenderer() *ProfileRenderer {
+	return &ProfileRenderer{}
+}
+
+// secretResolver is the closure type backing the template "secret" function.
+type secretResolver func(key string) (string, error)
+
+// Render validates the profile, then renders its template with the supplied
+// per-VM vars and a "secret" function bound to store.GetSecret. On any error —
+// invalid profile, unknown template field, parse failure, or a secret lookup
+// failure (including secretsif.ErrSecretNotFound) — Render returns the error and
+// NO partial output (the all-or-nothing guarantee required by the AC).
+func (r *ProfileRenderer) Render(ctx context.Context, profile *UnattendProfile, vars ProfileVars, store secretsif.SecretStore) ([]byte, error) {
+	if profile == nil {
+		return nil, errors.New("hyperv: nil profile")
+	}
+	if err := profile.validate(); err != nil {
+		return nil, err
+	}
+	if store == nil {
+		return nil, errors.New("hyperv: nil secret store")
+	}
+
+	// secretErr captures a failure from inside the "secret" template func so we
+	// can surface the real cause (e.g. ErrSecretNotFound) instead of the wrapped
+	// text/template execution error, and guarantee no partial output is returned.
+	var secretErr error
+	resolve := secretResolver(func(key string) (string, error) {
+		sec, err := store.GetSecret(ctx, key)
+		if err != nil {
+			secretErr = fmt.Errorf("hyperv: resolving secret %q: %w", key, err)
+			return "", secretErr
+		}
+		return sec.Value, nil
+	})
+
+	funcMap := template.FuncMap{
+		"secret": func(key string) (string, error) { return resolve(key) },
+	}
+
+	tmpl, err := template.New(profile.Name).Option("missingkey=error").Funcs(funcMap).Parse(profile.Template)
+	if err != nil {
+		return nil, fmt.Errorf("hyperv: parsing profile template %q: %w", profile.Name, err)
+	}
+
+	data := struct {
+		VMName      string
+		OSFamily    string
+		EnrollToken string
+	}{
+		VMName:      vars.VMName,
+		OSFamily:    vars.OSFamily,
+		EnrollToken: vars.EnrollToken,
+	}
+
+	var buf bytes.Buffer
+	if err := tmpl.Execute(&buf, data); err != nil {
+		// A secret-resolution failure inside the func surfaces here wrapped in a
+		// template error; return the real cause so errors.Is(err, ErrSecretNotFound)
+		// works and no partial output escapes.
+		if secretErr != nil {
+			return nil, secretErr
+		}
+		return nil, fmt.Errorf("hyperv: rendering profile template %q: %w", profile.Name, err)
+	}
+	if secretErr != nil {
+		return nil, secretErr
+	}
+
+	return buf.Bytes(), nil
+}
+
+// parseProfileName strips the profile:// prefix from a source.unattend reference
+// and validates the remainder against profileNamePattern. It returns
+// ErrInvalidProfileName for any reference that is malformed or whose name fails
+// validation, so the caller never issues a store lookup for an unsafe key.
+func parseProfileName(ref string) (string, error) {
+	if !strings.HasPrefix(ref, profileURIPrefix) {
+		return "", fmt.Errorf("%w: missing %q prefix in %q", ErrInvalidProfileName, profileURIPrefix, ref)
+	}
+	name := strings.TrimPrefix(ref, profileURIPrefix)
+	if !profileNamePattern.MatchString(name) {
+		return "", fmt.Errorf("%w: %q", ErrInvalidProfileName, name)
+	}
+	return name, nil
+}

--- a/features/modules/hyperv/profile_store.go
+++ b/features/modules/hyperv/profile_store.go
@@ -1,0 +1,114 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+package hyperv
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"gopkg.in/yaml.v3"
+
+	cfgconfig "github.com/cfgis/cfgms/pkg/storage/interfaces/config"
+)
+
+// profileNamespace is the stored-config namespace that holds unattended-install
+// profiles. Combined with the profile name it forms the documented key path
+// hyperv/profiles/<name> (ADR-003 stored-config conventions). The slash-joined
+// "hyperv/profiles" maps onto the ConfigKey namespace; the profile name is the
+// ConfigKey name.
+const profileNamespace = "hyperv/profiles"
+
+// ConfigBackedProfileStore implements ProfileStore by reading YAML-serialised
+// UnattendProfile values from the controller's stored-config backend. It depends
+// only on the pkg/storage/interfaces config contract (never a concrete provider
+// implementation, per the CLAUDE.md anti-pattern rule) so any config-store
+// backend (flatfile, database, test double) works unchanged.
+type ConfigBackedProfileStore struct {
+	store cfgconfig.ConfigStore
+	// tenantID scopes profile lookups to a tenant. Empty is permitted for
+	// single-tenant/root deployments; the config backend treats it as the root
+	// scope.
+	tenantID string
+}
+
+// NewConfigBackedProfileStore constructs a ConfigBackedProfileStore over the
+// given config store and tenant. It is used by Configure() wiring and by tests.
+func NewConfigBackedProfileStore(store cfgconfig.ConfigStore, tenantID string) *ConfigBackedProfileStore {
+	return &ConfigBackedProfileStore{store: store, tenantID: tenantID}
+}
+
+// profileConfigKey builds the ConfigKey for a profile name under the documented
+// hyperv/profiles namespace.
+func (s *ConfigBackedProfileStore) profileConfigKey(name string) *cfgconfig.ConfigKey {
+	return &cfgconfig.ConfigKey{
+		TenantID:  s.tenantID,
+		Namespace: profileNamespace,
+		Name:      name,
+	}
+}
+
+// GetProfile reads the named profile from the config-store backend at key path
+// hyperv/profiles/<name>, YAML-decodes it, and validates structural invariants.
+// The name is validated against the profile name pattern before any lookup so
+// an unsafe name never reaches the backend. Returns ErrProfileNotFound when the
+// profile is absent.
+func (s *ConfigBackedProfileStore) GetProfile(ctx context.Context, name string) (*UnattendProfile, error) {
+	if s.store == nil {
+		return nil, errors.New("hyperv: ConfigBackedProfileStore has no config store")
+	}
+	if !profileNamePattern.MatchString(name) {
+		return nil, fmt.Errorf("%w: %q", ErrInvalidProfileName, name)
+	}
+
+	entry, err := s.store.GetConfig(ctx, s.profileConfigKey(name))
+	if err != nil {
+		if errors.Is(err, cfgconfig.ErrConfigNotFound) {
+			return nil, fmt.Errorf("%w: %q", ErrProfileNotFound, name)
+		}
+		return nil, fmt.Errorf("hyperv: loading profile %q: %w", name, err)
+	}
+	if entry == nil {
+		return nil, fmt.Errorf("%w: %q", ErrProfileNotFound, name)
+	}
+
+	var profile UnattendProfile
+	if err := yaml.Unmarshal(entry.Data, &profile); err != nil {
+		return nil, fmt.Errorf("hyperv: decoding profile %q: %w", name, err)
+	}
+	// The stored Name may be omitted; the key name is authoritative.
+	if profile.Name == "" {
+		profile.Name = name
+	}
+	if err := profile.validate(); err != nil {
+		return nil, err
+	}
+	return &profile, nil
+}
+
+// ListProfiles returns the names of all profiles stored under the hyperv/profiles
+// namespace for the store's tenant. It is used by operator tooling to enumerate
+// available profiles. Returns an empty slice (not an error) when none exist.
+func (s *ConfigBackedProfileStore) ListProfiles(ctx context.Context) ([]string, error) {
+	if s.store == nil {
+		return nil, errors.New("hyperv: ConfigBackedProfileStore has no config store")
+	}
+	entries, err := s.store.ListConfigs(ctx, &cfgconfig.ConfigFilter{
+		TenantID:  s.tenantID,
+		Namespace: profileNamespace,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("hyperv: listing profiles: %w", err)
+	}
+	names := make([]string, 0, len(entries))
+	for _, e := range entries {
+		if e == nil || e.Key == nil {
+			continue
+		}
+		names = append(names, e.Key.Name)
+	}
+	return names, nil
+}
+
+// Verify ConfigBackedProfileStore satisfies the ProfileStore contract.
+var _ ProfileStore = (*ConfigBackedProfileStore)(nil)

--- a/features/modules/hyperv/profile_store_test.go
+++ b/features/modules/hyperv/profile_store_test.go
@@ -1,0 +1,264 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+package hyperv
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+
+	"github.com/cfgis/cfgms/features/modules"
+	cfgconfig "github.com/cfgis/cfgms/pkg/storage/interfaces/config"
+)
+
+// MockConfigStore is an in-memory ConfigStore test double. It is a real
+// implementation of the cfgconfig.ConfigStore contract (it actually stores and
+// returns entries keyed by ConfigKey.String()), not a mock framework — so it can
+// round-trip a profile through ConfigBackedProfileStore as the AC requires. The
+// stateless struct{} double in pkg/storage/interfaces/provider_test.go cannot
+// round-trip and lives in an un-importable _test.go, so the round-trip double is
+// defined here in-package.
+type MockConfigStore struct {
+	mu      sync.Mutex
+	entries map[string]*cfgconfig.ConfigEntry
+}
+
+func newMockConfigStore() *MockConfigStore {
+	return &MockConfigStore{entries: make(map[string]*cfgconfig.ConfigEntry)}
+}
+
+func (m *MockConfigStore) StoreConfig(_ context.Context, entry *cfgconfig.ConfigEntry) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.entries[entry.Key.String()] = entry
+	return nil
+}
+
+func (m *MockConfigStore) GetConfig(_ context.Context, key *cfgconfig.ConfigKey) (*cfgconfig.ConfigEntry, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	e, ok := m.entries[key.String()]
+	if !ok {
+		return nil, cfgconfig.ErrConfigNotFound
+	}
+	return e, nil
+}
+
+func (m *MockConfigStore) DeleteConfig(_ context.Context, key *cfgconfig.ConfigKey) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	delete(m.entries, key.String())
+	return nil
+}
+
+func (m *MockConfigStore) ListConfigs(_ context.Context, filter *cfgconfig.ConfigFilter) ([]*cfgconfig.ConfigEntry, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	var out []*cfgconfig.ConfigEntry
+	for _, e := range m.entries {
+		if filter != nil {
+			if filter.TenantID != "" && e.Key.TenantID != filter.TenantID {
+				continue
+			}
+			if filter.Namespace != "" && e.Key.Namespace != filter.Namespace {
+				continue
+			}
+		}
+		out = append(out, e)
+	}
+	return out, nil
+}
+
+func (m *MockConfigStore) GetConfigHistory(_ context.Context, _ *cfgconfig.ConfigKey, _ int) ([]*cfgconfig.ConfigEntry, error) {
+	return nil, nil
+}
+func (m *MockConfigStore) GetConfigVersion(_ context.Context, _ *cfgconfig.ConfigKey, _ int64) (*cfgconfig.ConfigEntry, error) {
+	return nil, cfgconfig.ErrConfigNotFound
+}
+func (m *MockConfigStore) StoreConfigBatch(_ context.Context, _ []*cfgconfig.ConfigEntry) error {
+	return nil
+}
+func (m *MockConfigStore) DeleteConfigBatch(_ context.Context, _ []*cfgconfig.ConfigKey) error {
+	return nil
+}
+func (m *MockConfigStore) ResolveConfigWithInheritance(_ context.Context, _ *cfgconfig.ConfigKey) (*cfgconfig.ConfigEntry, error) {
+	return nil, cfgconfig.ErrConfigNotFound
+}
+func (m *MockConfigStore) ValidateConfig(_ context.Context, _ *cfgconfig.ConfigEntry) error {
+	return nil
+}
+func (m *MockConfigStore) GetConfigStats(_ context.Context) (*cfgconfig.ConfigStats, error) {
+	return &cfgconfig.ConfigStats{}, nil
+}
+
+var _ cfgconfig.ConfigStore = (*MockConfigStore)(nil)
+
+// seedProfile stores a profile in the config store under hyperv/profiles/<name>
+// for the given tenant, mirroring how an operator would author it.
+func seedProfile(t *testing.T, store *MockConfigStore, tenantID string, p *UnattendProfile) {
+	t.Helper()
+	data, err := yaml.Marshal(p)
+	require.NoError(t, err)
+	require.NoError(t, store.StoreConfig(context.Background(), &cfgconfig.ConfigEntry{
+		Key:    &cfgconfig.ConfigKey{TenantID: tenantID, Namespace: profileNamespace, Name: p.Name},
+		Data:   data,
+		Format: cfgconfig.ConfigFormatYAML,
+	}))
+}
+
+// TestConfigBackedProfileStore_GetProfile is the REQUIRED TEST from the AC: it
+// round-trips a profile through ConfigBackedProfileStore using a real config
+// store double.
+func TestConfigBackedProfileStore_GetProfile(t *testing.T) {
+	store := newMockConfigStore()
+	want := &UnattendProfile{
+		Name:         "debian-12-base",
+		OSFamily:     "linux",
+		AnswerFormat: AnswerFormatPreseed,
+		Template:     "hostname={{ .VMName }}\nregtoken={{ secret \"hyperv/enroll/regtoken\" }}",
+		Enroll: EnrollConfig{
+			RegistrationTokenSecretKey: "hyperv/enroll/regtoken",
+			BundleURL:                  "https://controller.example/bundle",
+			CorrelationLabel:           "fleet-a",
+		},
+	}
+	seedProfile(t, store, "root", want)
+
+	ps := NewConfigBackedProfileStore(store, "root")
+	got, err := ps.GetProfile(context.Background(), "debian-12-base")
+	require.NoError(t, err)
+
+	assert.Equal(t, want.Name, got.Name)
+	assert.Equal(t, want.OSFamily, got.OSFamily)
+	assert.Equal(t, want.AnswerFormat, got.AnswerFormat)
+	assert.Equal(t, want.Template, got.Template)
+	assert.Equal(t, want.Enroll, got.Enroll)
+}
+
+// TestConfigBackedProfileStore_GetProfile_NotFound asserts the not-found path
+// returns ErrProfileNotFound (mapped from cfgconfig.ErrConfigNotFound).
+func TestConfigBackedProfileStore_GetProfile_NotFound(t *testing.T) {
+	store := newMockConfigStore()
+	ps := NewConfigBackedProfileStore(store, "root")
+
+	_, err := ps.GetProfile(context.Background(), "no-such-profile")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrProfileNotFound)
+}
+
+// TestConfigBackedProfileStore_GetProfile_RejectsInvalidName asserts an unsafe
+// name is rejected before any store lookup.
+func TestConfigBackedProfileStore_GetProfile_RejectsInvalidName(t *testing.T) {
+	store := newMockConfigStore()
+	ps := NewConfigBackedProfileStore(store, "root")
+
+	_, err := ps.GetProfile(context.Background(), "../etc/passwd")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrInvalidProfileName)
+}
+
+// TestConfigBackedProfileStore_GetProfile_RejectsBadAnswerFormat asserts a
+// stored profile with an invalid answer_format fails validation on load.
+func TestConfigBackedProfileStore_GetProfile_RejectsBadAnswerFormat(t *testing.T) {
+	store := newMockConfigStore()
+	seedProfile(t, store, "root", &UnattendProfile{
+		Name:         "bad",
+		OSFamily:     "linux",
+		AnswerFormat: AnswerFormat("nope"),
+		Template:     "x",
+	})
+
+	ps := NewConfigBackedProfileStore(store, "root")
+	_, err := ps.GetProfile(context.Background(), "bad")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrInvalidAnswerFormat)
+}
+
+// TestConfigBackedProfileStore_ListProfiles round-trips multiple profiles and
+// asserts ListProfiles enumerates them by name within the tenant scope.
+func TestConfigBackedProfileStore_ListProfiles(t *testing.T) {
+	store := newMockConfigStore()
+	seedProfile(t, store, "root", &UnattendProfile{Name: "p1", OSFamily: "linux", AnswerFormat: AnswerFormatPreseed, Template: "x"})
+	seedProfile(t, store, "root", &UnattendProfile{Name: "p2", OSFamily: "windows", AnswerFormat: AnswerFormatAutounattend, Template: "y"})
+	// A different tenant's profile must not leak into root's listing.
+	seedProfile(t, store, "other", &UnattendProfile{Name: "p3", OSFamily: "linux", AnswerFormat: AnswerFormatPreseed, Template: "z"})
+
+	ps := NewConfigBackedProfileStore(store, "root")
+	names, err := ps.ListProfiles(context.Background())
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{"p1", "p2"}, names)
+}
+
+// TestConfigure_WiresConfigBackedProfileStore asserts that passing a config
+// store under the "config_store" key at Configure time wires a
+// ConfigBackedProfileStore onto the module (same injection pattern as
+// audit_manager). The profile is then loadable end-to-end through the module's
+// wired store.
+func TestConfigure_WiresConfigBackedProfileStore(t *testing.T) {
+	store := newMockConfigStore()
+	seedProfile(t, store, "tenant-x", &UnattendProfile{
+		Name:         "win-2025-base",
+		OSFamily:     "windows",
+		AnswerFormat: AnswerFormatAutounattend,
+		Template:     "<ComputerName>{{ .VMName }}</ComputerName>",
+	})
+
+	secrets := newInlineStore()
+	m := newModuleWithDetector(secrets, &fakeDetector{result: true})
+
+	require.NoError(t, m.Configure(mapConfigState{
+		"tenant_id":         "tenant-x",
+		"config_store":      cfgconfig.ConfigStore(store),
+		"winrm_host":        "host.example",
+		"winrm_user_secret": "user-key",
+		"winrm_pass_secret": "pass-key",
+		"transport":         "winrm",
+	}))
+
+	require.NotNil(t, m.profileStore, "config_store should wire a ProfileStore")
+
+	got, err := m.profileStore.GetProfile(context.Background(), "win-2025-base")
+	require.NoError(t, err)
+	assert.Equal(t, "win-2025-base", got.Name)
+	assert.Equal(t, AnswerFormatAutounattend, got.AnswerFormat)
+}
+
+// TestConfigure_NoConfigStoreLeavesProfileStoreNil asserts that without a
+// config_store key, the profile store remains whatever WithProfileStore set
+// (nil here), so the absence of a backend is handled gracefully.
+func TestConfigure_NoConfigStoreLeavesProfileStoreNil(t *testing.T) {
+	secrets := newInlineStore()
+	m := newModuleWithDetector(secrets, &fakeDetector{result: true})
+
+	require.NoError(t, m.Configure(mapConfigState{
+		"winrm_host":        "host.example",
+		"winrm_user_secret": "user-key",
+		"winrm_pass_secret": "pass-key",
+		"transport":         "winrm",
+	}))
+
+	assert.Nil(t, m.profileStore)
+}
+
+// TestWithProfileStore_Overrides asserts the option setter injects a store
+// usable without any config backend.
+func TestWithProfileStore_Overrides(t *testing.T) {
+	ms := newMemProfileStore()
+	ms.put(&UnattendProfile{Name: "p1", OSFamily: "linux", AnswerFormat: AnswerFormatPreseed, Template: "x"})
+
+	var m *hypervModule
+	mod := New(&fakeDetector{result: true}, WithProfileStore(ms))
+	m = mod.(*hypervModule)
+	require.NotNil(t, m.profileStore)
+
+	got, err := m.profileStore.GetProfile(context.Background(), "p1")
+	require.NoError(t, err)
+	assert.Equal(t, "p1", got.Name)
+}
+
+// ensure the modules import is used (mapConfigState satisfies modules.ConfigState).
+var _ modules.ConfigState = mapConfigState(nil)

--- a/features/modules/hyperv/profile_test.go
+++ b/features/modules/hyperv/profile_test.go
@@ -1,0 +1,230 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+package hyperv
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	secretsif "github.com/cfgis/cfgms/pkg/secrets/interfaces"
+)
+
+// memProfileStore is an in-memory ProfileStore double used by unit tests. It is
+// a real implementation of the ProfileStore contract (not a mock framework):
+// it stores profiles in a map and returns ErrProfileNotFound for unknown names.
+type memProfileStore struct {
+	profiles map[string]*UnattendProfile
+}
+
+func newMemProfileStore() *memProfileStore {
+	return &memProfileStore{profiles: make(map[string]*UnattendProfile)}
+}
+
+func (m *memProfileStore) put(p *UnattendProfile) { m.profiles[p.Name] = p }
+
+func (m *memProfileStore) GetProfile(_ context.Context, name string) (*UnattendProfile, error) {
+	p, ok := m.profiles[name]
+	if !ok {
+		return nil, ErrProfileNotFound
+	}
+	return p, nil
+}
+
+var _ ProfileStore = (*memProfileStore)(nil)
+
+// TestProfileRenderer_SubstitutesSecretsAtRenderTime is the REQUIRED TEST from
+// the AC: a real inlineStore supplies known key/value pairs; the rendered output
+// must contain the resolved secret values and per-VM vars, and must NOT contain
+// the raw secret key names.
+func TestProfileRenderer_SubstitutesSecretsAtRenderTime(t *testing.T) {
+	store := newInlineStore(
+		"hyperv/enroll/regtoken", "tok-abc123",
+		"hyperv/admin/password", "S3cr3t-Pass",
+	)
+
+	profile := &UnattendProfile{
+		Name:         "debian-12-base",
+		OSFamily:     "linux",
+		AnswerFormat: AnswerFormatPreseed,
+		Template: strings.Join([]string{
+			"hostname={{ .VMName }}",
+			"os={{ .OSFamily }}",
+			"enroll-token={{ .EnrollToken }}",
+			`regtoken={{ secret "hyperv/enroll/regtoken" }}`,
+			`admin-pass={{ secret "hyperv/admin/password" }}`,
+		}, "\n"),
+	}
+
+	r := NewProfileRenderer()
+	out, err := r.Render(context.Background(), profile, ProfileVars{
+		VMName:      "vm-web-01",
+		OSFamily:    "linux",
+		EnrollToken: "enroll-xyz",
+	}, store)
+	require.NoError(t, err)
+
+	rendered := string(out)
+	assert.Contains(t, rendered, "hostname=vm-web-01")
+	assert.Contains(t, rendered, "os=linux")
+	assert.Contains(t, rendered, "enroll-token=enroll-xyz")
+	assert.Contains(t, rendered, "regtoken=tok-abc123")
+	assert.Contains(t, rendered, "admin-pass=S3cr3t-Pass")
+
+	// The raw secret key names must never appear in the rendered output.
+	assert.NotContains(t, rendered, "hyperv/enroll/regtoken")
+	assert.NotContains(t, rendered, "hyperv/admin/password")
+}
+
+// TestProfileRenderer_RejectsUnknownAnswerFormat is the REQUIRED TEST from the
+// AC: a profile whose answer_format is not preseed/autounattend is rejected with
+// a typed error before any rendering happens.
+func TestProfileRenderer_RejectsUnknownAnswerFormat(t *testing.T) {
+	store := newInlineStore()
+	profile := &UnattendProfile{
+		Name:         "bad-format",
+		OSFamily:     "linux",
+		AnswerFormat: AnswerFormat("invalid"),
+		Template:     "should-not-render={{ .VMName }}",
+	}
+
+	r := NewProfileRenderer()
+	out, err := r.Render(context.Background(), profile, ProfileVars{VMName: "vm-x"}, store)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrInvalidAnswerFormat)
+	assert.Nil(t, out, "no output on validation failure")
+}
+
+// TestProfileRenderer_AcceptsAutounattendFormat confirms the second valid v1
+// format renders successfully.
+func TestProfileRenderer_AcceptsAutounattendFormat(t *testing.T) {
+	store := newInlineStore()
+	profile := &UnattendProfile{
+		Name:         "win-2025-base",
+		OSFamily:     "windows",
+		AnswerFormat: AnswerFormatAutounattend,
+		Template:     "<ComputerName>{{ .VMName }}</ComputerName>",
+	}
+
+	r := NewProfileRenderer()
+	out, err := r.Render(context.Background(), profile, ProfileVars{VMName: "WIN-01"}, store)
+	require.NoError(t, err)
+	assert.Equal(t, "<ComputerName>WIN-01</ComputerName>", string(out))
+}
+
+// TestProfileRenderer_SecretNotFoundReturnsErrorNoOutput is the AC path for a
+// missing secret: Render returns an error (wrapping ErrSecretNotFound) and emits
+// no partial output.
+func TestProfileRenderer_SecretNotFoundReturnsErrorNoOutput(t *testing.T) {
+	store := newInlineStore() // empty: every secret lookup misses
+
+	profile := &UnattendProfile{
+		Name:         "needs-secret",
+		OSFamily:     "linux",
+		AnswerFormat: AnswerFormatPreseed,
+		Template:     `token={{ secret "missing/key" }}`,
+	}
+
+	r := NewProfileRenderer()
+	out, err := r.Render(context.Background(), profile, ProfileVars{VMName: "vm-y"}, store)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, secretsif.ErrSecretNotFound)
+	assert.Nil(t, out, "no partial output when a secret cannot be resolved")
+}
+
+// TestProfileRenderer_RejectsInvalidProfileName confirms name validation runs
+// before rendering.
+func TestProfileRenderer_RejectsInvalidProfileName(t *testing.T) {
+	store := newInlineStore()
+	profile := &UnattendProfile{
+		Name:         "bad name/with/slash",
+		OSFamily:     "linux",
+		AnswerFormat: AnswerFormatPreseed,
+		Template:     "x={{ .VMName }}",
+	}
+
+	r := NewProfileRenderer()
+	out, err := r.Render(context.Background(), profile, ProfileVars{VMName: "vm"}, store)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrInvalidProfileName)
+	assert.Nil(t, out)
+}
+
+// TestProfileRenderer_BadTemplateSyntaxReturnsError confirms a malformed
+// template surfaces a parse error with no output.
+func TestProfileRenderer_BadTemplateSyntaxReturnsError(t *testing.T) {
+	store := newInlineStore()
+	profile := &UnattendProfile{
+		Name:         "bad-template",
+		OSFamily:     "linux",
+		AnswerFormat: AnswerFormatPreseed,
+		Template:     "x={{ .VMName ", // unterminated action
+	}
+
+	r := NewProfileRenderer()
+	out, err := r.Render(context.Background(), profile, ProfileVars{VMName: "vm"}, store)
+	require.Error(t, err)
+	assert.Nil(t, out)
+}
+
+// TestProfileRenderer_UnknownTemplateFieldReturnsError confirms missingkey=error
+// makes references to unknown fields fail rather than emit "<no value>".
+func TestProfileRenderer_UnknownTemplateFieldReturnsError(t *testing.T) {
+	store := newInlineStore()
+	profile := &UnattendProfile{
+		Name:         "unknown-field",
+		OSFamily:     "linux",
+		AnswerFormat: AnswerFormatPreseed,
+		Template:     "x={{ .DoesNotExist }}",
+	}
+
+	r := NewProfileRenderer()
+	out, err := r.Render(context.Background(), profile, ProfileVars{VMName: "vm"}, store)
+	require.Error(t, err)
+	assert.Nil(t, out)
+}
+
+// TestParseProfileName covers the profile:// extraction + validation used before
+// any store lookup.
+func TestParseProfileName(t *testing.T) {
+	t.Run("valid", func(t *testing.T) {
+		name, err := parseProfileName("profile://debian-12_base")
+		require.NoError(t, err)
+		assert.Equal(t, "debian-12_base", name)
+	})
+	t.Run("missing prefix", func(t *testing.T) {
+		_, err := parseProfileName("debian-12")
+		require.Error(t, err)
+		assert.ErrorIs(t, err, ErrInvalidProfileName)
+	})
+	t.Run("illegal chars", func(t *testing.T) {
+		_, err := parseProfileName("profile://../etc/passwd")
+		require.Error(t, err)
+		assert.ErrorIs(t, err, ErrInvalidProfileName)
+	})
+	t.Run("too long", func(t *testing.T) {
+		_, err := parseProfileName("profile://" + strings.Repeat("a", 65))
+		require.Error(t, err)
+		assert.ErrorIs(t, err, ErrInvalidProfileName)
+	})
+}
+
+// TestMemProfileStore_GetProfile exercises the in-memory double used by other
+// unit tests, including the not-found path.
+func TestMemProfileStore_GetProfile(t *testing.T) {
+	ms := newMemProfileStore()
+	want := &UnattendProfile{Name: "p1", OSFamily: "linux", AnswerFormat: AnswerFormatPreseed, Template: "x"}
+	ms.put(want)
+
+	got, err := ms.GetProfile(context.Background(), "p1")
+	require.NoError(t, err)
+	assert.Equal(t, want, got)
+
+	_, err = ms.GetProfile(context.Background(), "nope")
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrProfileNotFound))
+}


### PR DESCRIPTION
Fixes #2045. Implements the unattended-profile model per **ADR-009 §7** + ADR-003. Reimplemented cleanly after the cron's prior attempt (#2065) was an incomplete WIP — it wired `module.go` but never created the files defining the types, and conflicted with merged #2044.

## What's implemented
- `profile.go` — `UnattendProfile` (Name, OSFamily, AnswerFormat, Template, Enroll), `EnrollConfig` (stores the secret **key name**, never the value), `ProfileStore` interface, `ProfileRenderer` (`text/template`, `missingkey=error`, `{{ secret "key" }}` → `SecretStore.GetSecret`, no partial output on error), `parseProfileName` (`profile://` strip + `^[a-zA-Z0-9_\-]{1,64}$`), sentinels (`ErrProfileNotFound`, `ErrInvalidProfileName`, `ErrInvalidAnswerFormat`). AnswerFormat ∈ {preseed, autounattend}.
- `profile_store.go` — `ConfigBackedProfileStore` over `pkg/storage/interfaces/config` ONLY (no provider import), key path `hyperv/profiles/<name>`, YAML-serialised; `GetProfile`/`ListProfiles`, tenant-scoped.
- `module.go` — `profileStore` field, `WithProfileStore()` setter, `Configure()` wiring from the `config_store` key (mirrors `audit_manager`); integrated cleanly with #2044's changes.

## Tests (no mocks, no skips)
Renderer secret-substitution + format/template/secret error paths; `ConfigBackedProfileStore` round-trip + not-found + validation; Configure wiring (config-store present/absent) + WithProfileStore override. Native `go test` green; **`GOOS=linux go vet` + whole-repo `GOOS=linux go build` clean** (cross-platform-verified); `make check-architecture` clean.

Note: the spec's named `MockConfigStore` in `pkg/storage/interfaces/provider_test.go` is a stateless stub that can't round-trip a profile, so the test uses a real in-memory `ConfigStore` implementation (not a mock framework) to satisfy the round-trip AC + no-mocks rule.

## Scope
Profile model only — preseed/autounattend content is #2046/#2047; seed-write is #2044; E2E is #2046/#2047. Supersedes #2065 (failed cron WIP).

🤖 Generated with [Claude Code](https://claude.com/claude-code)