### PR TITLE
hyperv: Debian 12 preseed profile + host-gated E2E provision (Issue #2046)

### DIFF
--- a/features/modules/hyperv/linux_profile.go
+++ b/features/modules/hyperv/linux_profile.go
@@ -1,0 +1,149 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+package hyperv
+
+// FILE NAME NOTE: this file is named linux_profile.go (Linux-first), NOT
+// profile_linux.go. Go applies an IMPLICIT "//go:build linux" constraint to any
+// file whose name ends in "_linux.go", which would exclude this file on the
+// Windows steward host (where Hyper-V actually runs) and from cross-platform
+// (GOOS=linux) build/test of the always-on create-from-source orchestration in
+// vm_provision.go. That implicit GOOS constraint cannot be overridden by an
+// explicit build tag, so the file is named linux_profile.go (the trailing
+// element "profile" is not a GOOS) to keep the Linux preseed content compiled on
+// every platform. The story (#2046) requested profile_linux.go; this rename is
+// the only way to satisfy the same story's "no build tag / cross-platform clean"
+// requirement.
+
+// Linux preseed answer-file template for the create-from-source path (ADR-009
+// §6, Linux row). This file carries NO build tag: the create-from-source
+// orchestration in provisionVM() renders the preseed on every platform (driven
+// by the recording transport in tests), so the template constant must compile
+// on every platform.
+//
+// The template is rendered by ProfileRenderer.Render (profile.go) using
+// text/template — NOT html/template — so preseed syntax is never HTML-escaped.
+// Per-VM values ({{ .VMName }}, {{ .CorrelationID }}) and secret values
+// ({{ secret "key" }}) travel into the rendered bytes at render time; secret
+// VALUES are never stored in the template, the profile, or committed media.
+
+// linuxDefaultProfileName is the built-in Debian 12 profile used when a Linux
+// VM source declares no profile:// reference. Operators may override it by
+// authoring a stored-config profile of the same name (ADR-009 §7).
+const linuxDefaultProfileName = "debian-12-base"
+
+// preseedRegTokenSecretKey is the SecretStore key the built-in Debian profile
+// resolves the registration token from at render time. Only the KEY is baked
+// into the template; the token VALUE is fetched from the secret store during
+// rendering and inserted into the late_command, never persisted to the profile.
+const preseedRegTokenSecretKey = "hyperv/enroll/regtoken"
+
+// preseedBundleURL is the default enrollment-bundle URL the built-in Debian
+// profile pulls the steward .deb from in late_command. Operators override it by
+// authoring a stored-config profile with a different BundleURL var binding.
+const preseedBundleURL = "https://controller.cfg.is/enroll/cfgms-steward.deb"
+
+// preseedTemplate is a Debian 12 preseed.cfg template (ADR-009 §6, Linux row).
+// It covers locale/keyboard/timezone, DHCP networking, guided LVM partitioning,
+// a non-interactive base install, and a late_command that downloads and
+// installs the steward bundle then enrolls.
+//
+// The late_command uses declared paths only and contains NO banned patterns:
+// no `eval`, no `bash -c "<string>"`, no `iex`, no inline code composition. Each
+// step is a discrete invocation joined with `&&`; the registration token and
+// the CorrelationID hostname hint are substituted at render time, not composed
+// at install time inside the guest.
+//
+// The {{ .CorrelationID }} value is passed as the enrollment hostname/label so
+// the controller-side completion reconciler (#2050) can match the registered
+// steward's mTLS CN back to this VM's provisioning record.
+const preseedTemplate = `# Debian 12 (bookworm) preseed — CFGMS create-from-source (ADR-009 §6)
+# Rendered for VM {{ .VMName }} (correlation {{ .CorrelationID }}).
+
+### Localization
+d-i debian-installer/locale string en_US.UTF-8
+d-i keyboard-configuration/xkb-keymap select us
+
+### Clock and time zone
+d-i clock-setup/utc boolean true
+d-i time/zone string Etc/UTC
+d-i clock-setup/ntp boolean true
+
+### Network configuration (DHCP)
+d-i netcfg/choose_interface select auto
+d-i netcfg/get_hostname string {{ .CorrelationID }}
+d-i netcfg/get_domain string cfg.is
+d-i netcfg/hostname string {{ .CorrelationID }}
+
+### Mirror settings
+d-i mirror/country string manual
+d-i mirror/http/hostname string deb.debian.org
+d-i mirror/http/directory string /debian
+d-i mirror/http/proxy string
+
+### Account setup (root locked; a single sudo-capable user)
+d-i passwd/root-login boolean false
+d-i passwd/make-user boolean true
+d-i passwd/user-fullname string CFGMS Operator
+d-i passwd/username string cfgms
+d-i passwd/user-password-crypted password {{ secret "hyperv/enroll/user-password-crypted" }}
+d-i user-setup/allow-password-weak boolean false
+d-i user-setup/encrypt-home boolean false
+
+### Partitioning (guided, entire disk, LVM)
+d-i partman-auto/method string lvm
+d-i partman-auto/disk string /dev/sda
+d-i partman-lvm/device_remove_lvm boolean true
+d-i partman-md/device_remove_md boolean true
+d-i partman-lvm/confirm boolean true
+d-i partman-lvm/confirm_nooverwrite boolean true
+d-i partman-auto/choose_recipe select atomic
+d-i partman-partitioning/confirm_write_new_label boolean true
+d-i partman/choose_partition select finish
+d-i partman/confirm boolean true
+d-i partman/confirm_nooverwrite boolean true
+
+### Base system + apt
+d-i apt-setup/non-free-firmware boolean true
+d-i apt-setup/contrib boolean false
+d-i apt-setup/non-free boolean false
+tasksel tasksel/first multiselect standard, ssh-server
+d-i pkgsel/include string wget ca-certificates
+d-i pkgsel/upgrade select full-upgrade
+popularity-contest popularity-contest/participate boolean false
+
+### Boot loader
+d-i grub-installer/only_debian boolean true
+d-i grub-installer/with_other_os boolean true
+d-i grub-installer/bootdev string default
+
+### Finish install without prompting
+d-i finish-install/reboot_in_progress note
+
+### First-boot enrollment.
+# Declared paths only: download the steward bundle, install it, then enroll using
+# the registration token (resolved from the secret store at render time) and the
+# CorrelationID as the enrollment label so the controller-side reconciler (#2050)
+# can match this VM. Each step is a discrete declared invocation joined with a
+# command separator; no runtime code composition.
+d-i preseed/late_command string \
+  in-target wget -q {{ .BundleURL }} -O /tmp/cfgms-steward.deb ; \
+  in-target dpkg -i /tmp/cfgms-steward.deb ; \
+  in-target cfgms-steward enroll --token {{ secret "hyperv/enroll/regtoken" }} --label {{ .CorrelationID }}
+`
+
+// defaultLinuxProfile returns the built-in Debian 12 UnattendProfile used when a
+// Linux VM source declares no profile:// reference. It is a real, renderable
+// profile (preseed format) wired to the default registration-token secret key
+// and bundle URL; operators override it by authoring a stored-config profile.
+func defaultLinuxProfile() *UnattendProfile {
+	return &UnattendProfile{
+		Name:         linuxDefaultProfileName,
+		OSFamily:     "linux",
+		AnswerFormat: AnswerFormatPreseed,
+		Template:     preseedTemplate,
+		Enroll: EnrollConfig{
+			RegistrationTokenSecretKey: preseedRegTokenSecretKey,
+			BundleURL:                  preseedBundleURL,
+		},
+	}
+}

--- a/features/modules/hyperv/linux_profile_test.go
+++ b/features/modules/hyperv/linux_profile_test.go
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+package hyperv
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// preseedTestStore returns an in-memory SecretStore seeded with the secret keys
+// the built-in Debian profile resolves at render time (registration token +
+// crypted user password). No mocks — a real in-memory store double.
+func preseedTestStore() *inlineSecretStore {
+	return newInlineStore(
+		"hyperv/enroll/regtoken", "reg-token-stub-value",
+		"hyperv/enroll/user-password-crypted", "$6$rounds=4096$stub$cryptedstub",
+	)
+}
+
+// TestLinuxPreseed_TemplateRendersValidSyntax renders the built-in Debian 12
+// preseed template with synthetic vars/secrets and asserts no template errors
+// and the presence of the key preseed directives (ADR-009 §6).
+func TestLinuxPreseed_TemplateRendersValidSyntax(t *testing.T) {
+	profile := defaultLinuxProfile()
+	out, err := NewProfileRenderer().Render(context.Background(), profile, ProfileVars{
+		VMName:        "stw-lin-01",
+		OSFamily:      "linux",
+		CorrelationID: "stw-lin-01",
+		BundleURL:     profile.Enroll.BundleURL,
+	}, preseedTestStore())
+	require.NoError(t, err, "preseed template must render without errors")
+
+	rendered := string(out)
+	for _, directive := range []string{
+		"d-i partman",
+		"d-i passwd",
+		"late_command",
+		"d-i debian-installer/locale",
+		"d-i netcfg",
+	} {
+		assert.Contains(t, rendered, directive, "rendered preseed must contain %q", directive)
+	}
+
+	// The resolved secret value lands in the output (not the key name).
+	assert.Contains(t, rendered, "reg-token-stub-value", "registration token secret must be substituted")
+	assert.NotContains(t, rendered, `secret "hyperv/enroll/regtoken"`, "secret template call must be resolved, not left literal")
+}
+
+// TestLinuxPreseed_CorrelationIDInOutput asserts the CorrelationID is threaded
+// into the rendered preseed (as the enrollment hostname/label) so the
+// controller-side reconciler (#2050) can match the steward back to the record.
+func TestLinuxPreseed_CorrelationIDInOutput(t *testing.T) {
+	profile := defaultLinuxProfile()
+	const corr = "stw-corr-abc123"
+	out, err := NewProfileRenderer().Render(context.Background(), profile, ProfileVars{
+		VMName:        "stw-lin-01",
+		OSFamily:      "linux",
+		CorrelationID: corr,
+		BundleURL:     profile.Enroll.BundleURL,
+	}, preseedTestStore())
+	require.NoError(t, err)
+
+	rendered := string(out)
+	assert.Contains(t, rendered, "d-i netcfg/get_hostname string "+corr,
+		"CorrelationID must be the enrollment hostname hint")
+	assert.Contains(t, rendered, "--label "+corr,
+		"CorrelationID must be passed as the enroll label in late_command")
+}
+
+// TestLinuxPreseed_NoBannedPatterns scans the rendered preseed for the banned
+// runtime-code-composition patterns (CLAUDE.md module/script rules) and asserts
+// none are present.
+func TestLinuxPreseed_NoBannedPatterns(t *testing.T) {
+	profile := defaultLinuxProfile()
+	out, err := NewProfileRenderer().Render(context.Background(), profile, ProfileVars{
+		VMName:        "stw-lin-01",
+		OSFamily:      "linux",
+		CorrelationID: "stw-lin-01",
+		BundleURL:     profile.Enroll.BundleURL,
+	}, preseedTestStore())
+	require.NoError(t, err)
+
+	rendered := strings.ToLower(string(out))
+	for _, banned := range []string{"eval", "bash -c", "iex"} {
+		assert.NotContains(t, rendered, banned,
+			"rendered preseed must not contain banned pattern %q", banned)
+	}
+}

--- a/features/modules/hyperv/profile.go
+++ b/features/modules/hyperv/profile.go
@@ -92,8 +92,9 @@ type UnattendProfile struct {
 	// AnswerFormat is the answer-file format: preseed or autounattend.
 	AnswerFormat AnswerFormat `yaml:"answer_format"`
 	// Template is the text/template source for the answer file. It may reference
-	// per-VM vars ({{ .VMName }}, {{ .OSFamily }}, {{ .EnrollToken }}) and
-	// secrets ({{ secret "key" }}). It is NOT HTML and is never HTML-escaped.
+	// per-VM vars ({{ .VMName }}, {{ .OSFamily }}, {{ .EnrollToken }},
+	// {{ .CorrelationID }}, {{ .BundleURL }}) and secrets ({{ secret "key" }}).
+	// It is NOT HTML and is never HTML-escaped.
 	Template string `yaml:"template"`
 	// Enroll carries enrollment wiring (token secret key, bundle URL, label).
 	Enroll EnrollConfig `yaml:"enroll,omitempty"`
@@ -133,6 +134,16 @@ type ProfileVars struct {
 	// VALUES referenced via {{ secret "key" }} are resolved separately from the
 	// SecretStore at render time.
 	EnrollToken string
+	// CorrelationID ties the rendered answer file back to the VM's provisioning
+	// record. The Linux preseed template (#2046) substitutes it as the
+	// enrollment hostname/label ({{ .CorrelationID }}) so the controller-side
+	// completion reconciler (#2050) can match the registered steward's mTLS CN
+	// to this VM.
+	CorrelationID string
+	// BundleURL is the enrollment-bundle URL the answer file's first-boot enroll
+	// step pulls the steward package from ({{ .BundleURL }}). It is supplied by
+	// the caller from the profile's Enroll config; it is not a secret.
+	BundleURL string
 }
 
 // ProfileRenderer renders an UnattendProfile's template into answer-file bytes,
@@ -191,13 +202,17 @@ func (r *ProfileRenderer) Render(ctx context.Context, profile *UnattendProfile, 
 	}
 
 	data := struct {
-		VMName      string
-		OSFamily    string
-		EnrollToken string
+		VMName        string
+		OSFamily      string
+		EnrollToken   string
+		CorrelationID string
+		BundleURL     string
 	}{
-		VMName:      vars.VMName,
-		OSFamily:    vars.OSFamily,
-		EnrollToken: vars.EnrollToken,
+		VMName:        vars.VMName,
+		OSFamily:      vars.OSFamily,
+		EnrollToken:   vars.EnrollToken,
+		CorrelationID: vars.CorrelationID,
+		BundleURL:     vars.BundleURL,
 	}
 
 	var buf bytes.Buffer

--- a/features/modules/hyperv/vm.go
+++ b/features/modules/hyperv/vm.go
@@ -687,6 +687,17 @@ func (m *hypervModule) setVM(ctx context.Context, resourceID string, config modu
 	}
 
 	if vmExists {
+		// Create-from-source convergence (ADR-009 §6/§8): when the VM already
+		// exists and carries a source block, drive the installing → finalizing
+		// transition (detect install completion + detach the seed VHDX). The
+		// host-side module never advances to ready — that is controller-side
+		// (#2050). finalizeProvision is a no-op unless the record is at installing
+		// and the conservative settle conditions are met.
+		if cfg.Source != nil {
+			if err := m.finalizeProvision(ctx, vmName, hostName, cfg); err != nil {
+				return err
+			}
+		}
 		return m.applyVMState(ctx, vmName, hostName, cfg, &currentVM, state)
 	}
 

--- a/features/modules/hyperv/vm_provision.go
+++ b/features/modules/hyperv/vm_provision.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 )
 
 // ── Provisioning PS verb constants (ADR-009 §5) ────────────────────────────
@@ -193,10 +194,19 @@ func (m *hypervModule) provisionVM(ctx context.Context, vmName, hostName string,
 	}
 	recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.host, "Format-Volume", hostName, nil)
 
+	// Render the answer file written to the seed. For the Linux path (#2046)
+	// this renders the REAL preseed from the referenced (or built-in Debian)
+	// profile, substituting per-VM vars + secrets; for Windows the placeholder
+	// stands until #2047 supplies the autounattend template.
+	answerContent, err := m.renderSeedAnswerFile(ctx, cfg, record.CorrelationID)
+	if err != nil {
+		return m.failProvision(ctx, vmName, record, err)
+	}
+
 	if _, psErr := m.transport.ExecutePS(ctx, psCopyToSeedVHD, map[string]string{
 		"SeedPath": seedPath,
 		"FileName": seedAnswerFileName(cfg.Source.OSFamily),
-		"Content":  seedAnswerFilePlaceholder(cfg.Source.OSFamily),
+		"Content":  answerContent,
 	}); psErr != nil {
 		recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.host, "Set-Content", hostName, psErr)
 		return m.failProvision(ctx, vmName, record, fmt.Errorf("hyperv: write answer file to seed for VM %q: %w", vmName, psErr))
@@ -231,4 +241,151 @@ func (m *hypervModule) provisionVM(ctx context.Context, vmName, hostName string,
 	}
 
 	return m.advanceProvision(ctx, vmName, record, ProvisionStateInstalling)
+}
+
+// renderSeedAnswerFile produces the answer-file content written to the seed VHDX
+// for the given source (ADR-009 §6). For the Linux path (#2046) it resolves the
+// unattended-install profile — the one referenced as source.unattend
+// (profile://<name>), or the built-in Debian 12 profile when none is referenced
+// — and renders its preseed template with this VM's vars + secrets. The
+// CorrelationID is threaded into the template ({{ .CorrelationID }}) so the
+// controller-side reconciler (#2050) can match the registered steward back to
+// the provisioning record.
+//
+// For the Windows path the placeholder content stands until #2047 supplies the
+// autounattend template; this story is Linux-only by scope.
+func (m *hypervModule) renderSeedAnswerFile(ctx context.Context, cfg *VMConfig, correlationID string) (string, error) {
+	if cfg.Source == nil || cfg.Source.OSFamily != "linux" {
+		// Windows / non-Linux: keep the placeholder (autounattend is #2047).
+		return seedAnswerFilePlaceholder(cfg.Source.OSFamily), nil
+	}
+
+	profile, err := m.resolveLinuxProfile(ctx, cfg.Source.Unattend)
+	if err != nil {
+		return "", err
+	}
+
+	store, injected := m.GetSecretStore()
+	if !injected || store == nil {
+		return "", fmt.Errorf("hyperv: cannot render preseed for VM %q: secret store not injected", cfg.Name)
+	}
+
+	rendered, err := NewProfileRenderer().Render(ctx, profile, ProfileVars{
+		VMName:        cfg.Name,
+		OSFamily:      cfg.Source.OSFamily,
+		CorrelationID: correlationID,
+		BundleURL:     profile.Enroll.BundleURL,
+	}, store)
+	if err != nil {
+		return "", fmt.Errorf("hyperv: render preseed for VM %q: %w", cfg.Name, err)
+	}
+	return string(rendered), nil
+}
+
+// resolveLinuxProfile returns the UnattendProfile for a Linux VM source. When
+// the source references a profile (profile://<name>) it is loaded from the
+// profile store; when no reference is given the built-in Debian 12 profile is
+// used so a minimal Linux source ("iso" + "os_family: linux") provisions
+// without operator-authored config (ADR-009 §6/§7).
+func (m *hypervModule) resolveLinuxProfile(ctx context.Context, unattendRef string) (*UnattendProfile, error) {
+	if unattendRef == "" {
+		return defaultLinuxProfile(), nil
+	}
+	name, err := parseProfileName(unattendRef)
+	if err != nil {
+		return nil, err
+	}
+	if m.profileStore == nil {
+		return nil, fmt.Errorf("hyperv: profile %q referenced but no profile store configured: %w", name, ErrProfileNotFound)
+	}
+	profile, err := m.profileStore.GetProfile(ctx, name)
+	if err != nil {
+		return nil, fmt.Errorf("hyperv: load profile %q: %w", name, err)
+	}
+	return profile, nil
+}
+
+// finalizeProvision advances a VM whose provisioning record is at installing to
+// finalizing once the unattended install is judged complete, detaching the seed
+// VHDX so the installed OS does not re-read the answer file on subsequent boots
+// (ADR-009 §6/§8). It is invoked on a convergence cycle for a VM that already
+// exists on the host and carries a source block.
+//
+// Completion detection is deliberately conservative (ADR-009 §8 implementation
+// note): the install is judged complete only after at least completion.timeout/2
+// has elapsed since StartedAt AND the VM is observed Running. The host-side
+// module NEVER advances to ready — that transition is owned by the
+// controller-side completion reconciler (#2050) keyed on CorrelationID. When the
+// record is not at installing, or the settle conditions are not met, this is a
+// no-op and the record is left unchanged.
+func (m *hypervModule) finalizeProvision(ctx context.Context, vmName, hostName string, cfg *VMConfig) error {
+	if cfg.Source == nil {
+		return nil
+	}
+	record, err := m.loadOrInitProvision(ctx, vmName)
+	if err != nil {
+		return err
+	}
+	if record.State != ProvisionStateInstalling {
+		// Only an installing record is eligible to advance to finalizing.
+		return nil
+	}
+
+	settle := installSettleDuration(cfg.Source.Completion.Timeout)
+	if time.Since(record.StartedAt) < settle {
+		// Too early — err on the side of waiting (conservative completion).
+		return nil
+	}
+
+	// Confirm the VM is running (booted into the installed OS / past installer).
+	running, err := m.vmIsRunning(ctx, vmName)
+	if err != nil {
+		return err
+	}
+	if !running {
+		return nil
+	}
+
+	// Detach the seed VHDX so the answer file is gone on the next boot.
+	seedPath := seedVHDPath(vmName, cfg.VHDPath)
+	if vErr := validateSeedPath(seedPath); vErr != nil {
+		return m.failProvision(ctx, vmName, record, vErr)
+	}
+	if _, psErr := m.transport.ExecutePS(ctx, psDetachSeedVHD, map[string]string{
+		"Path": seedPath,
+	}); psErr != nil {
+		recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.host, "Dismount-VHD", hostName, psErr)
+		return m.failProvision(ctx, vmName, record, fmt.Errorf("hyperv: detach seed VHDX for VM %q: %w", vmName, psErr))
+	}
+	recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.host, "Dismount-VHD", hostName, nil)
+
+	// Advance installing → finalizing. ready is controller-side (#2050).
+	return m.advanceProvision(ctx, vmName, record, ProvisionStateFinalizing)
+}
+
+// installSettleDuration returns half of the parsed completion.timeout, the
+// minimum elapsed time before the host judges an install complete. An empty or
+// unparseable timeout falls back to half of the default completion timeout. The
+// timeout string is validated upstream by SourceConfig.Validate, so a parse
+// failure here is defensive only.
+func installSettleDuration(timeout string) time.Duration {
+	const defaultCompletionTimeout = 30 * time.Minute
+	if timeout == "" {
+		return defaultCompletionTimeout / 2
+	}
+	d, err := time.ParseDuration(timeout)
+	if err != nil || d <= 0 {
+		return defaultCompletionTimeout / 2
+	}
+	return d / 2
+}
+
+// vmIsRunning queries live host state via getVM and reports whether the VM is in
+// the running power state. A VM that is absent or stopped reports false.
+func (m *hypervModule) vmIsRunning(ctx context.Context, vmName string) (bool, error) {
+	current, err := m.getVM(ctx, vmName)
+	if err != nil {
+		return false, err
+	}
+	return strings.EqualFold(current.State, "running"), nil
 }

--- a/features/modules/hyperv/vm_provision_test.go
+++ b/features/modules/hyperv/vm_provision_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -14,7 +15,7 @@ import (
 // provisionModuleWithTransport builds a hypervModule wired with the given
 // transport and an in-memory provision store for create-from-source tests.
 func provisionModuleWithTransport(transport winrmTransport) *hypervModule {
-	return &hypervModule{
+	m := &hypervModule{
 		executor:       &stubHypervExecutor{},
 		transport:      transport,
 		tenantID:       "ops",
@@ -22,6 +23,12 @@ func provisionModuleWithTransport(transport winrmTransport) *hypervModule {
 		detector:       &fakeDetector{result: true},
 		provisionStore: NewMemProvisionStore(),
 	}
+	// The Linux create path renders the built-in Debian preseed, which resolves
+	// registration-token + user-password secrets at render time. Inject an
+	// in-memory store carrying those keys so the create-from-source provisioning
+	// tests exercise the real render path (no mocks).
+	_ = m.SetSecretStore(preseedTestStore())
+	return m
 }
 
 // sourceVMConfigMap returns the executor-shaped config map for an absent VM
@@ -292,6 +299,136 @@ func TestProvisionVM_AttachesInstallISOFromHostPath(t *testing.T) {
 		"install ISO host path must travel via args")
 	assert.NotContains(t, dvd[0].scriptBlock, "server.iso",
 		"ISO path must not be interpolated into the script text")
+}
+
+// ── REQUIRED TEST: installing → finalizing detaches the seed ─────────────────
+
+// runningSourceVMJSON returns a getVM JSON response for a running VM whose
+// CPU/memory/switch match sourceVMConfigMap so applyVMState issues no resize,
+// start, or network reconcile — isolating the finalize behaviour under test.
+func runningSourceVMJSON() string {
+	return `{"found":true,"Name":"stw-01","MemoryStartupBytes":4294967296,` +
+		`"ProcessorCount":2,"Generation":2,"Path":"C:\\ClusterStorage\\CSV01\\stw-01.vhdx",` +
+		`"SwitchName":"HVSwitch_1G","SwitchNames":["HVSwitch_1G"],"State":"Running"}`
+}
+
+// TestProvision_InstallingToFinalizingDetachesSeed asserts that a convergence
+// cycle on a VM whose record sits at installing — once the conservative settle
+// window has elapsed and the VM is observed running — advances the record to
+// finalizing and issues Cfgms-DetachSeedVHD (Dismount-VHD). The host-side
+// module must NOT advance to ready (that is controller-side, #2050).
+func TestProvision_InstallingToFinalizingDetachesSeed(t *testing.T) {
+	// getVM is queried twice before detach: once by setVM (existence) and once
+	// by vmIsRunning inside finalizeProvision. Both report Running.
+	transport := &testWinRMTransport{
+		output: runningSourceVMJSON(),
+	}
+	store := NewMemProvisionStore()
+	// Seed an installing record whose StartedAt is well past the settle window
+	// (completion.timeout is 60m → settle is 30m).
+	require.NoError(t, store.SetProvision(context.Background(), &ProvisionRecord{
+		VMName:        "stw-01",
+		State:         ProvisionStateInstalling,
+		CorrelationID: "stw-01",
+		StartedAt:     time.Now().Add(-2 * time.Hour),
+	}))
+	m := provisionModuleWithTransport(transport)
+	m.provisionStore = store
+
+	cfg := rawConfigState{m: sourceVMConfigMap(2, "linux")}
+	require.NoError(t, m.Set(context.Background(), "vm:stw-01", cfg))
+
+	transport.mu.Lock()
+	calls := transport.calls
+	transport.mu.Unlock()
+
+	detach := callsContaining(calls, "Dismount-VHD")
+	require.Len(t, detach, 1, "finalizing must issue exactly one Cfgms-DetachSeedVHD (Dismount-VHD)")
+	assert.True(t, argsContain(detach[0], `C:\ClusterStorage\CSV01\cfgms-seed-stw-01.vhdx`),
+		"seed path must travel via args, derived from the VM VHD directory")
+	assert.NotContains(t, detach[0].scriptBlock, "cfgms-seed-stw-01",
+		"seed path must not be interpolated into the script text")
+
+	rec, err := store.GetProvision(context.Background(), "stw-01")
+	require.NoError(t, err)
+	assert.Equal(t, ProvisionStateFinalizing, rec.State,
+		"host-side module must advance installing → finalizing")
+	assert.NotEqual(t, ProvisionStateReady, rec.State,
+		"host-side module must NOT advance to ready — that is controller-side (#2050)")
+}
+
+// TestProvision_InstallingNotSettledDoesNotDetach asserts that a VM whose
+// installing record has not yet passed the settle window is left at installing
+// with no seed detach — the conservative completion guard (ADR-009 §8).
+func TestProvision_InstallingNotSettledDoesNotDetach(t *testing.T) {
+	transport := &testWinRMTransport{
+		output: runningSourceVMJSON(),
+	}
+	store := NewMemProvisionStore()
+	require.NoError(t, store.SetProvision(context.Background(), &ProvisionRecord{
+		VMName:        "stw-01",
+		State:         ProvisionStateInstalling,
+		CorrelationID: "stw-01",
+		StartedAt:     time.Now(), // just started — well within the settle window
+	}))
+	m := provisionModuleWithTransport(transport)
+	m.provisionStore = store
+
+	cfg := rawConfigState{m: sourceVMConfigMap(2, "linux")}
+	require.NoError(t, m.Set(context.Background(), "vm:stw-01", cfg))
+
+	transport.mu.Lock()
+	calls := transport.calls
+	transport.mu.Unlock()
+
+	assert.Empty(t, callsContaining(calls, "Dismount-VHD"),
+		"install not yet settled must not detach the seed")
+
+	rec, err := store.GetProvision(context.Background(), "stw-01")
+	require.NoError(t, err)
+	assert.Equal(t, ProvisionStateInstalling, rec.State,
+		"record must remain at installing until the settle window elapses")
+}
+
+// TestProvision_RealPreseedRenderedToSeed asserts the Linux create path writes
+// the REAL rendered preseed (not the placeholder) to the seed VHDX, with the
+// resolved registration-token secret and the CorrelationID hostname hint
+// present, and no banned patterns.
+func TestProvision_RealPreseedRenderedToSeed(t *testing.T) {
+	transport := &testWinRMTransport{
+		perCallOutputs: []string{`{"found":false}`}, // getVM → absent
+	}
+	m := provisionModuleWithTransport(transport)
+	require.NoError(t, m.SetSecretStore(preseedTestStore()))
+
+	cfg := rawConfigState{m: sourceVMConfigMap(2, "linux")}
+	require.NoError(t, m.Set(context.Background(), "vm:stw-01", cfg))
+
+	transport.mu.Lock()
+	calls := transport.calls
+	transport.mu.Unlock()
+
+	copyCalls := callsContaining(calls, "Set-Content")
+	require.Len(t, copyCalls, 1, "one Set-Content (answer file copy)")
+	// The answer file name is preseed.cfg for linux.
+	assert.True(t, argsContain(copyCalls[0], "preseed.cfg"), "linux must seed preseed.cfg")
+
+	// Find the rendered content arg (the longest string arg is the preseed body).
+	var content string
+	for _, a := range copyCalls[0].args {
+		if s, ok := a.(string); ok && len(s) > len(content) {
+			content = s
+		}
+	}
+	require.NotEmpty(t, content, "preseed content must be present in the copy args")
+	assert.NotContains(t, content, "placeholder preseed", "linux path must render the REAL preseed, not the placeholder")
+	assert.Contains(t, content, "d-i partman", "rendered preseed must carry partitioning directives")
+	assert.Contains(t, content, "reg-token-stub-value", "registration token secret must be resolved into the preseed")
+	assert.Contains(t, content, "stw-01", "CorrelationID must appear in the preseed")
+	lower := strings.ToLower(content)
+	for _, banned := range []string{"eval", "bash -c", "iex"} {
+		assert.NotContains(t, lower, banned, "rendered preseed must not contain banned pattern %q", banned)
+	}
 }
 
 // ── Provisioning record advancement ──────────────────────────────────────────

--- a/test/e2e/hyperv/provision_debian_test.go
+++ b/test/e2e/hyperv/provision_debian_test.go
@@ -1,0 +1,301 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+
+//go:build e2e
+
+// Package hyperv_e2e contains the host-gated end-to-end provisioning tests for
+// the Hyper-V create-from-source path (ADR-009). These tests provision REAL
+// virtual machines on a REAL Hyper-V host and therefore:
+//
+//   - are gated behind the `e2e` build tag (excluded from `make test-complete`
+//     and CI, which never build with `-tags e2e`), and
+//   - skip cleanly (t.Skip) when the required host/env vars are not set.
+//
+// They run only on the cfg-lab Hyper-V host where the operator stages the
+// Debian 12 ISO and the registration-token secret. No mocks: the real hyperv
+// module drives the real PowerShell-host transport, and the real controller-side
+// completion reconciler (#2050) — wired over the SAME provision store the module
+// writes — flips the record to ready when the installed steward registers.
+package hyperv_e2e
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cfgis/cfgms/features/modules"
+	"github.com/cfgis/cfgms/features/modules/hyperv"
+	"github.com/cfgis/cfgms/features/modules/hyperv/completion"
+	"github.com/cfgis/cfgms/pkg/logging"
+	secretsif "github.com/cfgis/cfgms/pkg/secrets/interfaces"
+)
+
+// Env vars that gate and parameterise the live provisioning E2E (ADR-009 §8
+// implementation notes). All but the controller URL are required; the test
+// skips when any required one is unset so CI and non-host runs never fail.
+const (
+	envHypervHost      = "CFGMS_E2E_HYPERV_HOST"          // Hyper-V host name/IP (gate)
+	envLinuxISO        = "CFGMS_E2E_LINUX_ISO"            // host path to the Debian 12 ISO (gate)
+	envRegTokenSecret  = "CFGMS_E2E_REGTOKEN_SECRET_KEY"  // SecretStore key for the registration token (gate)
+	envRegTokenValue   = "CFGMS_E2E_REGTOKEN_VALUE"       // registration token value to seed into the store
+	envUserPwdCrypted  = "CFGMS_E2E_USER_PWD_CRYPTED"     // crypted preseed user password
+	envVHDPath         = "CFGMS_E2E_LINUX_VHD_PATH"       // host path for the new VM's primary VHD
+	envSwitchName      = "CFGMS_E2E_SWITCH_NAME"          // external vSwitch to attach
+	envControllerURL   = "CFGMS_E2E_CONTROLLER_URL"       // controller admin API base URL (optional)
+	envControllerToken = "CFGMS_E2E_CONTROLLER_API_TOKEN" // bearer token for the admin API (optional)
+)
+
+// e2eSecretStore is a minimal in-memory SecretStore seeded with the secret
+// values the preseed render resolves at provisioning time. It is a real store
+// (not a mock): GetSecret performs an ordinary map lookup. Secret VALUES are
+// supplied by the operator via env vars and never logged.
+type e2eSecretStore struct{ secrets map[string]string }
+
+func (s *e2eSecretStore) GetSecret(_ context.Context, key string) (*secretsif.Secret, error) {
+	v, ok := s.secrets[key]
+	if !ok {
+		return nil, secretsif.ErrSecretNotFound
+	}
+	return &secretsif.Secret{Key: key, Value: v}, nil
+}
+func (s *e2eSecretStore) StoreSecret(_ context.Context, _ *secretsif.SecretRequest) error { return nil }
+func (s *e2eSecretStore) DeleteSecret(_ context.Context, _ string) error                  { return nil }
+func (s *e2eSecretStore) ListSecrets(_ context.Context, _ *secretsif.SecretFilter) ([]*secretsif.SecretMetadata, error) {
+	return nil, nil
+}
+func (s *e2eSecretStore) GetSecrets(_ context.Context, _ []string) (map[string]*secretsif.Secret, error) {
+	return nil, nil
+}
+func (s *e2eSecretStore) StoreSecrets(_ context.Context, _ map[string]*secretsif.SecretRequest) error {
+	return nil
+}
+func (s *e2eSecretStore) GetSecretVersion(_ context.Context, _ string, _ int) (*secretsif.Secret, error) {
+	return nil, secretsif.ErrSecretNotFound
+}
+func (s *e2eSecretStore) ListSecretVersions(_ context.Context, _ string) ([]*secretsif.SecretVersion, error) {
+	return nil, nil
+}
+func (s *e2eSecretStore) GetSecretMetadata(_ context.Context, _ string) (*secretsif.SecretMetadata, error) {
+	return nil, secretsif.ErrSecretNotFound
+}
+func (s *e2eSecretStore) UpdateSecretMetadata(_ context.Context, _ string, _ map[string]string) error {
+	return nil
+}
+func (s *e2eSecretStore) RotateSecret(_ context.Context, _ string, _ string) error { return nil }
+func (s *e2eSecretStore) ExpireSecret(_ context.Context, _ string) error           { return nil }
+func (s *e2eSecretStore) HealthCheck(_ context.Context) error                      { return nil }
+func (s *e2eSecretStore) Close() error                                             { return nil }
+
+// e2eConfigState wraps the VM config map as a modules.ConfigState.
+type e2eConfigState map[string]interface{}
+
+func (c e2eConfigState) AsMap() map[string]interface{} { return map[string]interface{}(c) }
+func (c e2eConfigState) ToYAML() ([]byte, error)       { return nil, nil }
+func (c e2eConfigState) FromYAML(_ []byte) error       { return nil }
+func (c e2eConfigState) Validate() error               { return nil }
+func (c e2eConfigState) GetManagedFields() []string    { return nil }
+
+// requireEnv returns the value of key, or skips the test when it is unset. Used
+// for the gating vars so the E2E is silently skipped in CI / off-host runs.
+func requireEnv(t *testing.T, key string) string {
+	t.Helper()
+	v := os.Getenv(key)
+	if v == "" {
+		t.Skipf("%s not set — live Hyper-V host + Debian 12 ISO required for this E2E; skipping", key)
+	}
+	return v
+}
+
+// TestE2E_ProvisionDebian_ToStewardRegistered provisions a real Debian 12 VM
+// from an ISO + the built-in preseed profile and asserts the provisioning record
+// reaches `ready` — the controller-side transition (#2050) that fires when the
+// installed steward registers and the completion reconciler matches its mTLS CN
+// to the record's CorrelationID. The test never polls the steward directly
+// (ADR-009 §8): readiness is asserted via the provision record, and the steward
+// is confirmed via the controller's registered-steward list.
+func TestE2E_ProvisionDebian_ToStewardRegistered(t *testing.T) {
+	// ── Gate: skip cleanly unless the live host env is configured. ──
+	hostName := requireEnv(t, envHypervHost)
+	isoPath := requireEnv(t, envLinuxISO)
+	regTokenKey := requireEnv(t, envRegTokenSecret)
+	t.Logf("E2E provisioning Debian 12 on Hyper-V host %q from ISO %q", hostName, isoPath)
+
+	vhdPath := os.Getenv(envVHDPath)
+	if vhdPath == "" {
+		vhdPath = `C:\ClusterStorage\CSV01\cfgms-e2e-debian.vhdx`
+	}
+	switchName := os.Getenv(envSwitchName)
+	if switchName == "" {
+		switchName = "HVSwitch_1G"
+	}
+
+	const vmName = "cfgms-e2e-debian"
+
+	ctx := context.Background()
+
+	// ── Real secret store seeded with the values the preseed resolves. ──
+	store := &e2eSecretStore{secrets: map[string]string{
+		regTokenKey:                           os.Getenv(envRegTokenValue),
+		"hyperv/enroll/regtoken":              os.Getenv(envRegTokenValue),
+		"hyperv/enroll/user-password-crypted": os.Getenv(envUserPwdCrypted),
+	}}
+
+	// ── Shared provision store: the module WRITES it; the controller-side
+	// completion reconciler READS/UPDATES it. This is exactly the real
+	// controller wiring (features/controller/server/server.go #2050). ──
+	provisionStore := hyperv.NewMemProvisionStore()
+	reconciler := completion.New(provisionStore, logging.NewNoopLogger())
+
+	// ── Real hyperv module over the real PowerShell-host transport. ──
+	mod := hyperv.New(hyperv.NewDefaultDetector(), hyperv.WithProvisionStore(provisionStore))
+	injectable, ok := mod.(modules.SecretStoreInjectable)
+	require.True(t, ok, "hyperv module must accept a SecretStore")
+	require.NoError(t, injectable.SetSecretStore(store))
+
+	configurable, ok := mod.(modules.Configurable)
+	require.True(t, ok, "hyperv module must be Configurable")
+	require.NoError(t, configurable.Configure(e2eConfigState{
+		"transport": "ps-host",
+		"tenant_id": "e2e",
+	}), "configure hyperv module against the local PS host")
+
+	// ── Cleanup: remove the VM, the seed VHDX, and the primary VHD. ──
+	t.Cleanup(func() {
+		bg := context.Background()
+		// state:absent drives the module's delete path (stop + remove VM).
+		_ = mod.(modules.Module).Set(bg, "vm:"+vmName, e2eConfigState{
+			"name":     vmName,
+			"state":    "absent",
+			"vhd_path": vhdPath,
+		})
+	})
+
+	vmConfig := e2eConfigState{
+		"name":        vmName,
+		"memory_mb":   4096,
+		"cpu_count":   2,
+		"vhd_path":    vhdPath,
+		"generation":  2,
+		"state":       "running",
+		"switch_name": switchName,
+		"source": map[string]interface{}{
+			"iso":       isoPath,
+			"os_family": "linux",
+			// No unattend reference → the built-in Debian 12 preseed profile.
+			"completion": map[string]interface{}{
+				"mode":    "steward-registration",
+				"timeout": "90m",
+			},
+			"on_existing": "never",
+		},
+	}
+
+	// ── Drive the create-from-source path: create VM, build+attach seed +
+	// ISO, power on, record → installing. ──
+	require.NoError(t, mod.(modules.Module).Set(ctx, "vm:"+vmName, vmConfig),
+		"create-from-source apply must succeed")
+
+	rec, err := provisionStore.GetProvision(ctx, vmName)
+	require.NoError(t, err, "a provisioning record must exist after the create apply")
+	require.Equal(t, hyperv.ProvisionStateInstalling, rec.State,
+		"host-side create must end at installing")
+	correlationID := rec.CorrelationID
+	require.NotEmpty(t, correlationID, "record must carry a CorrelationID")
+
+	// ── Converge to ready within the 90-minute timeout. Each cycle:
+	//   1. re-apply (drives installing → finalizing once the install settles),
+	//   2. when a steward whose CN matches the CorrelationID appears in the
+	//      controller's registered-steward list, invoke the REAL completion
+	//      reconciler (the controller's OnConnect path) to flip the record,
+	//   3. check the shared store for `ready`. ──
+	deadline := time.Now().Add(90 * time.Minute)
+	stewardRegistered := false
+	for time.Now().Before(deadline) {
+		// Convergence cycle: advance installing → finalizing when settled.
+		_ = mod.(modules.Module).Set(ctx, "vm:"+vmName, vmConfig)
+
+		if stewardInControllerList(t, correlationID) {
+			stewardRegistered = true
+			// Drive the real reconciler exactly as the controller's gRPC
+			// OnConnect hook does, with the steward's mTLS CN.
+			require.NoError(t, reconciler.OnConnect(ctx, correlationID),
+				"completion reconciler OnConnect must not error")
+		}
+
+		cur, getErr := provisionStore.GetProvision(ctx, vmName)
+		require.NoError(t, getErr)
+		if cur.State == hyperv.ProvisionStateReady {
+			break
+		}
+		if cur.State == hyperv.ProvisionStateFailed {
+			t.Fatalf("provisioning failed: %s", cur.LastError)
+		}
+
+		time.Sleep(30 * time.Second)
+	}
+
+	final, err := provisionStore.GetProvision(ctx, vmName)
+	require.NoError(t, err)
+	assert.Equal(t, hyperv.ProvisionStateReady, final.State,
+		"provisioning record must reach ready (set controller-side by the completion reconciler, #2050)")
+	assert.True(t, stewardRegistered,
+		"the provisioned steward must appear in the controller's registered-steward list")
+}
+
+// stewardInControllerList reports whether a steward whose ID/CN matches
+// correlationID appears in the controller's registered-steward list. When the
+// controller URL is not configured it returns false (the test continues
+// polling); the operator sets CFGMS_E2E_CONTROLLER_URL + token on the live host
+// so the registered-steward assertion is exercised end to end.
+func stewardInControllerList(t *testing.T, correlationID string) bool {
+	t.Helper()
+	baseURL := os.Getenv(envControllerURL)
+	if baseURL == "" {
+		return false
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet,
+		strings.TrimRight(baseURL, "/")+"/api/v1/stewards", nil)
+	if err != nil {
+		return false
+	}
+	if token := os.Getenv(envControllerToken); token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return false
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return false
+	}
+
+	// The list handler wraps results in a success envelope; decode loosely and
+	// scan any steward id/CN for a correlation match.
+	var payload struct {
+		Data []struct {
+			ID string `json:"id"`
+		} `json:"data"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		return false
+	}
+	for _, s := range payload.Data {
+		if strings.EqualFold(s.ID, correlationID) {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
Fixes #2046. The Linux preseed path — builds on merged #2043/#2044/#2045/#2050. Per ADR-009 §6.

## What's implemented
- **`linux_profile.go`** — Debian 12 `preseed.cfg` template + `defaultLinuxProfile()` (`debian-12-base`). Named `linux_profile.go` (not `profile_linux.go`) to avoid Go's implicit `_linux.go` GOOS build constraint.
- **Render-into-seed** — on the Linux create path, `renderSeedAnswerFile` resolves the profile (`source.unattend` → `profileStore`, else the built-in), `ProfileRenderer.Render` substitutes `{{ .VMName }}`/`{{ .CorrelationID }}`/`{{ .BundleURL }}` + `{{ secret "..." }}` (regtoken, crypted pw) from the SecretStore, and the rendered bytes are written as `preseed.cfg` to the `CFGMS_SEED` volume (replacing #2044's placeholder for the linux path). `late_command` uses declared paths only (`wget`/`dpkg`/`cfgms-steward enroll --token … --label <CorrelationID>`) — banned-pattern-scanned by a test.
- **`installing → finalizing`** — `finalizeProvision` detaches the seed and advances only when the VM is `Running` past the settle window; never sets `ready` (that's #2050's controller-side reconciler).

## Tests
- Unit: preseed renders valid syntax, no banned patterns, CorrelationID present; installing→finalizing detach + not-settled guard; real-preseed-rendered-to-seed. No mocks.
- **Host-gated E2E** `test/e2e/hyperv/provision_debian_test.go` (build tag `e2e`) — provisions Debian 12 from ISO + preseed and asserts the record reaches `ready` via the #2050 reconciler (no steward polling). **Excluded from CI** (CI doesn't build `-tags e2e`); skips cleanly unless `CFGMS_E2E_HYPERV_HOST`/`CFGMS_E2E_LINUX_ISO`/`CFGMS_E2E_REGTOKEN_SECRET_KEY` are set.
- Cross-platform verified: `GOOS=linux` vet+build clean, native `go test -race` green, `make check-architecture` clean.

## Live validation (separate, on the Hyper-V host)
The real ISO→VM→steward-registered run is the host-gated E2E; it needs a Debian 12 netinst ISO staged on a CSV + the env vars above. To be run on cfg-lab post-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)