### PR TITLE
controller: smoketest-gated in-place restart as supported upgrade path (Issue #2015)

### DIFF
--- a/cmd/cfg/cmd/controller_upgrade.go
+++ b/cmd/cfg/cmd/controller_upgrade.go
@@ -6,13 +6,34 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"time"
 
+	"github.com/cfgis/cfgms/cmd/controller/service"
 	"github.com/cfgis/cfgms/features/controller/cutover"
 	"github.com/spf13/cobra"
 )
+
+// upgradeRestartMgrFn creates the service.Manager used by cfg controller upgrade
+// restart to stage the binary and restart the supervisor. Overridable in tests.
+var upgradeRestartMgrFn = func() (service.Manager, error) {
+	exe, err := os.Executable()
+	if err != nil {
+		return nil, fmt.Errorf("restart: resolve executable path: %w", err)
+	}
+	return service.New(exe), nil
+}
+
+// upgradeRestartSpawnFn creates the ExecProcessHandle for the candidate
+// pre-restart probe subprocess. Overridable in tests.
+var upgradeRestartSpawnFn = func(binaryPath, configPath string) *cutover.ExecProcessHandle {
+	h := cutover.NewExecProcessHandle(binaryPath, configPath)
+	h.Stdout = os.Stdout
+	h.Stderr = os.Stderr
+	return h
+}
 
 // Flags / shared state for the cutover subcommands.
 var (
@@ -302,6 +323,195 @@ func newOrchestrator(initial *cutover.ExecProcessHandle) (*cutover.Orchestrator,
 		spawn,
 	)
 	return orch, swap, nil
+}
+
+// controllerUpgradeRestartCmd is the supported production upgrade path (Issue
+// #2015). It replaces the experimental port-swap orchestrator as the
+// recommended upgrade procedure.
+var controllerUpgradeRestartCmd = &cobra.Command{
+	Use:   "restart",
+	Short: "Smoketest-gated in-place restart upgrade for the local cfgms-controller (supported path)",
+	Long: `cfg controller upgrade restart is the supported production upgrade path (Issue #2015).
+
+Replaces the experimental port-swap orchestrator (cfg controller upgrade run)
+as the recommended upgrade procedure. The port-swap orchestrator is frozen per
+ADR-007 (docs/architecture/decisions/007-controller-upgrade-and-state-externalization.md)
+and will be removed once this restart-gated path is the documented default.
+
+The upgrade proceeds as follows:
+
+  1. Stage the new binary (validate it exists and is not a directory).
+  2. Start it on side ports (--candidate-api-addr / --candidate-transport-addr).
+  3. Probe GET /api/v1/ready — the real-state readiness gate (Issue #2012).
+     /api/v1/ready round-trips durable storage; a 200 proves the candidate can
+     actually serve. A 503 (storage unreachable) or any non-200 is a gate
+     failure; the orchestrator must not promote a binary that cannot serve.
+  4. If ready: copy the new binary to the service install path, then restart
+     the supervisor (e.g. systemctl restart cfgms-controller). The new binary
+     reloads the same durable storage; downtime is bounded by boot + warm-load.
+  5. If not ready (before or after restart): retain the previous binary at the
+     install path and return an error — keep-previous-binary rollback is automatic.
+
+A deliberately storage-broken binary is rejected at the /api/v1/ready gate and
+the previous binary keeps serving.
+
+Examples:
+  cfg controller upgrade restart --binary /opt/cfgms/cfgms-controller-v0.5.12 \
+      --config /etc/cfgms/controller.cfg`,
+	RunE: runControllerUpgradeRestart,
+}
+
+func init() {
+	controllerUpgradeRestartCmd.Flags().StringVar(&upgradeBinaryPath, "binary", "", "Path to the new cfgms-controller binary (required)")
+	controllerUpgradeRestartCmd.Flags().StringVar(&upgradeConfigPath, "config", "", "Path to controller.cfg (required)")
+	controllerUpgradeRestartCmd.Flags().StringVar(&upgradeCanonicalAPIAddr, "canonical-api-addr", ":8080", "Canonical API address (probed after restart)")
+	controllerUpgradeRestartCmd.Flags().StringVar(&upgradeCanonicalTransAdr, "canonical-transport-addr", ":4433", "Canonical transport address")
+	controllerUpgradeRestartCmd.Flags().StringVar(&upgradeCandidateAPIAddr, "candidate-api-addr", ":8081", "Side port for pre-restart smoketest")
+	controllerUpgradeRestartCmd.Flags().StringVar(&upgradeCandidateTransAdr, "candidate-transport-addr", ":4434", "Side transport port for pre-restart smoketest")
+	controllerUpgradeRestartCmd.Flags().DurationVar(&upgradeSmoketestTimeout, "smoketest-timeout", 30*time.Second, "Cap on the readiness probe duration")
+	_ = controllerUpgradeRestartCmd.MarkFlagRequired("binary")
+	_ = controllerUpgradeRestartCmd.MarkFlagRequired("config")
+
+	controllerUpgradeCmd.AddCommand(controllerUpgradeRestartCmd)
+}
+
+// runControllerUpgradeRestart implements the supported smoketest-gated in-place
+// restart upgrade. See controllerUpgradeRestartCmd.Long for the full algorithm.
+func runControllerUpgradeRestart(_ *cobra.Command, _ []string) error {
+	if upgradeBinaryPath == "" {
+		return fmt.Errorf("--binary is required")
+	}
+	if upgradeConfigPath == "" {
+		return fmt.Errorf("--config is required")
+	}
+	info, err := os.Stat(upgradeBinaryPath)
+	if err != nil {
+		return fmt.Errorf("restart: --binary %s not accessible: %w", upgradeBinaryPath, err)
+	}
+	if info.IsDir() {
+		return fmt.Errorf("restart: --binary %s is a directory, not an executable", upgradeBinaryPath)
+	}
+
+	mgr, err := upgradeRestartMgrFn()
+	if err != nil {
+		return err
+	}
+	installPath := mgr.InstallPath()
+
+	// Back up the current binary so we can restore it if the post-restart
+	// readiness check fails (keep-previous-binary rollback).
+	prevBinaryPath := ""
+	if _, statErr := os.Stat(installPath); statErr == nil {
+		prevBinaryPath = installPath + ".prev"
+		if copyErr := copyBinaryForRestart(installPath, prevBinaryPath); copyErr != nil {
+			return fmt.Errorf("restart: back up current binary at %s: %w", installPath, copyErr)
+		}
+	}
+
+	// Stage 1: start the new binary on side ports for the pre-restart probe.
+	candidate := upgradeRestartSpawnFn(upgradeBinaryPath, upgradeConfigPath)
+
+	ctx, cancel := makeUpgradeContext(2 * time.Minute)
+	defer cancel()
+
+	if err := candidate.Start(ctx, upgradeCandidateAPIAddr, upgradeCandidateTransAdr); err != nil {
+		cleanupRestartBackup(prevBinaryPath)
+		return fmt.Errorf("restart: start candidate on side ports: %w", err)
+	}
+
+	// Stage 2: probe GET /api/v1/ready on the side port. A 503 (storage
+	// unreachable) or any non-200 means the binary cannot serve — reject it.
+	smoketester := &cutover.HTTPSmoketester{
+		ReadyTimeout:   upgradeSmoketestTimeout,
+		RequestTimeout: 5 * time.Second,
+		SkipTLSVerify:  true,
+	}
+	preProbeErr := smoketester.Probe(ctx, candidate, upgradeCandidateAPIAddr, upgradeCandidateTransAdr)
+
+	// Stop the side-port subprocess regardless of probe outcome; it has done its job.
+	stopCtx, stopCancel := context.WithTimeout(context.Background(), 10*time.Second)
+	_ = candidate.Stop(stopCtx)
+	stopCancel()
+
+	if preProbeErr != nil {
+		// Pre-restart readiness check failed; install path is untouched.
+		cleanupRestartBackup(prevBinaryPath)
+		return fmt.Errorf("restart: readiness check failed (previous binary retained at %s): %w",
+			installPath, preProbeErr)
+	}
+
+	// Stage 3: readiness check passed — stage the binary and restart the service.
+	if err := mgr.StageBinaryAndRestart(upgradeBinaryPath, upgradeConfigPath); err != nil {
+		// Stage/restart failed; attempt to restore the previous binary.
+		if prevBinaryPath != "" {
+			if restoreErr := mgr.StageBinaryAndRestart(prevBinaryPath, upgradeConfigPath); restoreErr != nil {
+				return fmt.Errorf("restart: stage new binary failed AND restore of previous binary failed — manual intervention required: stage=%v restore=%w", err, restoreErr)
+			}
+			cleanupRestartBackup(prevBinaryPath)
+			return fmt.Errorf("restart: stage new binary failed (restored previous binary at %s): %w", installPath, err)
+		}
+		return fmt.Errorf("restart: stage new binary failed: %w", err)
+	}
+
+	// Stage 4: post-restart readiness check on the canonical port. Waits for
+	// the supervisor to bring up the new binary before declaring success.
+	postProbeErr := smoketester.Probe(ctx, nil, upgradeCanonicalAPIAddr, upgradeCanonicalTransAdr)
+	if postProbeErr != nil {
+		if prevBinaryPath != "" {
+			if restoreErr := mgr.StageBinaryAndRestart(prevBinaryPath, upgradeConfigPath); restoreErr != nil {
+				return fmt.Errorf("restart: post-restart readiness check failed AND restore of previous binary failed — manual intervention required: probe=%v restore=%w", postProbeErr, restoreErr)
+			}
+			cleanupRestartBackup(prevBinaryPath)
+			return fmt.Errorf("restart: post-restart readiness check failed (restored previous binary at %s): %w", installPath, postProbeErr)
+		}
+		return fmt.Errorf("restart: post-restart readiness check failed: %w", postProbeErr)
+	}
+
+	cleanupRestartBackup(prevBinaryPath)
+	fmt.Printf("controller restart upgrade complete\n")
+	fmt.Printf("  install path: %s\n", installPath)
+	fmt.Printf("  new binary:   %s\n", upgradeBinaryPath)
+	return nil
+}
+
+// copyBinaryForRestart copies src to dst preserving source permissions,
+// using an atomic temp-file + rename to avoid partial writes.
+func copyBinaryForRestart(src, dst string) error {
+	in, err := os.Open(src) //#nosec G304 -- caller validates src
+	if err != nil {
+		return err
+	}
+	defer func() { _ = in.Close() }()
+
+	srcInfo, err := in.Stat()
+	if err != nil {
+		return err
+	}
+
+	tmp := dst + ".tmp"
+	out, err := os.OpenFile(tmp, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, srcInfo.Mode().Perm()) //#nosec G304 -- tmp derived from install-path backup target, not user input
+	if err != nil {
+		return err
+	}
+	if _, err := io.Copy(out, in); err != nil {
+		_ = out.Close()
+		_ = os.Remove(tmp)
+		return err
+	}
+	if err := out.Close(); err != nil {
+		_ = os.Remove(tmp)
+		return err
+	}
+	return os.Rename(tmp, dst)
+}
+
+// cleanupRestartBackup removes the backup file created before staging. Errors
+// are ignored — a stale .prev file is harmless; the important invariant is the
+// install-path binary itself.
+func cleanupRestartBackup(prevBinaryPath string) {
+	if prevBinaryPath != "" {
+		_ = os.Remove(prevBinaryPath)
+	}
 }
 
 func makeUpgradeContext(d time.Duration) (context.Context, context.CancelFunc) {

--- a/cmd/cfg/cmd/controller_upgrade_test.go
+++ b/cmd/cfg/cmd/controller_upgrade_test.go
@@ -3,15 +3,71 @@
 package cmd
 
 import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/cfgis/cfgms/cmd/controller/service"
 	"github.com/cfgis/cfgms/features/controller/cutover"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// fakeRestartManager is a test double for service.Manager that records
+// StageBinaryAndRestart calls and uses caller-supplied paths.
+type fakeRestartManager struct {
+	installPathVal string
+	stagedBinary   string
+	stageFn        func(newBinaryPath, configPath string) error
+}
+
+func (f *fakeRestartManager) InstallPath() string { return f.installPathVal }
+func (f *fakeRestartManager) IsElevated() bool    { return true }
+func (f *fakeRestartManager) Install(_ string) error {
+	return nil
+}
+func (f *fakeRestartManager) Uninstall(_ bool) error { return nil }
+func (f *fakeRestartManager) Status() (*service.ServiceStatus, error) {
+	return &service.ServiceStatus{}, nil
+}
+func (f *fakeRestartManager) StageBinaryAndRestart(newBinaryPath, configPath string) error {
+	f.stagedBinary = newBinaryPath
+	if f.stageFn != nil {
+		return f.stageFn(newBinaryPath, configPath)
+	}
+	return nil
+}
+
+// saveRestartGlobals captures the upgrade-restart package-level vars that tests
+// modify and restores them via t.Cleanup. Call at the top of every restart test.
+func saveRestartGlobals(t *testing.T) {
+	t.Helper()
+	origBinary := upgradeBinaryPath
+	origConfig := upgradeConfigPath
+	origCandidateAPI := upgradeCandidateAPIAddr
+	origCandidateTrans := upgradeCandidateTransAdr
+	origCanonicalAPI := upgradeCanonicalAPIAddr
+	origCanonicalTrans := upgradeCanonicalTransAdr
+	origSmoketestTO := upgradeSmoketestTimeout
+	origMgrFn := upgradeRestartMgrFn
+	origSpawnFn := upgradeRestartSpawnFn
+	t.Cleanup(func() {
+		upgradeBinaryPath = origBinary
+		upgradeConfigPath = origConfig
+		upgradeCandidateAPIAddr = origCandidateAPI
+		upgradeCandidateTransAdr = origCandidateTrans
+		upgradeCanonicalAPIAddr = origCanonicalAPI
+		upgradeCanonicalTransAdr = origCanonicalTrans
+		upgradeSmoketestTimeout = origSmoketestTO
+		upgradeRestartMgrFn = origMgrFn
+		upgradeRestartSpawnFn = origSpawnFn
+	})
+}
 
 // TestControllerUpgradeRunCmd_ExperimentalNotice asserts that the upgrade run
 // subcommand's help text contains an experimental/unsupported notice referencing
@@ -142,6 +198,7 @@ func TestControllerUpgradeCmd_FlagsRegistered(t *testing.T) {
 		{"upgrade run", []string{"binary", "config", "state", "canonical-api-addr", "canonical-transport-addr", "candidate-api-addr", "candidate-transport-addr", "quarantine-window", "smoketest-timeout"}},
 		{"upgrade status", []string{"state", "json"}},
 		{"upgrade rollback", []string{"state", "config", "canonical-api-addr", "canonical-transport-addr", "candidate-api-addr", "candidate-transport-addr"}},
+		{"upgrade restart", []string{"binary", "config", "canonical-api-addr", "canonical-transport-addr", "candidate-api-addr", "candidate-transport-addr", "smoketest-timeout"}},
 	} {
 		t.Run(c.name, func(t *testing.T) {
 			switch c.name {
@@ -157,7 +214,124 @@ func TestControllerUpgradeCmd_FlagsRegistered(t *testing.T) {
 				for _, f := range c.want {
 					assert.NotNil(t, controllerUpgradeRollbackCmd.Flags().Lookup(f), "missing flag %q on rollback", f)
 				}
+			case "upgrade restart":
+				for _, f := range c.want {
+					assert.NotNil(t, controllerUpgradeRestartCmd.Flags().Lookup(f), "missing flag %q on restart", f)
+				}
 			}
 		})
 	}
+}
+
+// TestControllerUpgradeRestartCmd_IsDocumentedSupportedPath verifies that the
+// restart subcommand's help text identifies it as the supported production path
+// and references Issue #2015.
+func TestControllerUpgradeRestartCmd_IsDocumentedSupportedPath(t *testing.T) {
+	longHelp := controllerUpgradeRestartCmd.Long
+	assert.True(t,
+		strings.Contains(strings.ToLower(longHelp), "supported") ||
+			strings.Contains(strings.ToLower(longHelp), "production"),
+		"controllerUpgradeRestartCmd.Long must identify the restart subcommand as the supported path; got:\n%s", longHelp)
+	assert.Contains(t, longHelp, "#2015",
+		"controllerUpgradeRestartCmd.Long must reference Issue #2015")
+}
+
+// TestControllerUpgradeRestart_RequiresBinary verifies --binary is required.
+func TestControllerUpgradeRestart_RequiresBinary(t *testing.T) {
+	saveRestartGlobals(t)
+	upgradeBinaryPath = ""
+	upgradeConfigPath = "/etc/cfgms/controller.cfg"
+
+	err := runControllerUpgradeRestart(controllerUpgradeRestartCmd, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--binary is required")
+}
+
+// TestControllerUpgradeRestart_RequiresConfig verifies --config is required.
+func TestControllerUpgradeRestart_RequiresConfig(t *testing.T) {
+	saveRestartGlobals(t)
+	upgradeBinaryPath = "/tmp/some-binary"
+	upgradeConfigPath = ""
+
+	err := runControllerUpgradeRestart(controllerUpgradeRestartCmd, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--config is required")
+}
+
+// TestControllerUpgradeRestart_BinaryNotAccessible verifies validation before
+// any side effects.
+func TestControllerUpgradeRestart_BinaryNotAccessible(t *testing.T) {
+	saveRestartGlobals(t)
+	dir := t.TempDir()
+	upgradeBinaryPath = filepath.Join(dir, "ghost-binary")
+	upgradeConfigPath = filepath.Join(dir, "ghost.cfg")
+
+	err := runControllerUpgradeRestart(controllerUpgradeRestartCmd, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not accessible")
+}
+
+// TestControllerUpgradeRestart_503AbortsAndRetainsPreviousBinary is the
+// required test (Issue #2015): when the staged binary's /api/v1/ready returns
+// 503, the upgrade must abort and the previous binary at the install path must
+// be retained unchanged.
+func TestControllerUpgradeRestart_503AbortsAndRetainsPreviousBinary(t *testing.T) {
+	saveRestartGlobals(t)
+
+	dir := t.TempDir()
+
+	// Lay down a "previous" binary at the fake install path.
+	installPath := filepath.Join(dir, "cfgms-controller")
+	prevContent := []byte("previous binary content")
+	require.NoError(t, os.WriteFile(installPath, prevContent, 0750))
+
+	// A binary file for --binary (just needs to exist and not be a directory).
+	newBinaryPath := filepath.Join(dir, "cfgms-controller-new")
+	require.NoError(t, os.WriteFile(newBinaryPath, []byte("new binary content"), 0755))
+
+	// Fake service manager: tracks whether StageBinaryAndRestart is called.
+	fakeMgr := &fakeRestartManager{installPathVal: installPath}
+	upgradeRestartMgrFn = func() (service.Manager, error) { return fakeMgr, nil }
+
+	// Override the spawner: re-exec the test binary with a filter that matches
+	// no test (exits 0 without binding to any port). The TLS test server below
+	// already owns the candidate port, so waitForPortReady returns immediately.
+	exe, err := os.Executable()
+	require.NoError(t, err)
+	upgradeRestartSpawnFn = func(binaryPath, configPath string) *cutover.ExecProcessHandle {
+		h := cutover.NewExecProcessHandle(exe, configPath)
+		h.ArgsOverride = []string{"-test.run=TestNonExistentHelperXXX_DoesNotMatch"}
+		h.Stdout = io.Discard
+		h.Stderr = io.Discard
+		return h
+	}
+
+	// TLS server serving 503 on /api/v1/ready.
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/ready", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	})
+	srv := httptest.NewTLSServer(mux)
+	defer srv.Close()
+
+	// Point the candidate smoketest at the fake TLS server.
+	upgradeBinaryPath = newBinaryPath
+	upgradeConfigPath = filepath.Join(dir, "controller.cfg")
+	upgradeCandidateAPIAddr = srv.Listener.Addr().String()
+	upgradeSmoketestTimeout = 5 * time.Second
+
+	err = runControllerUpgradeRestart(controllerUpgradeRestartCmd, nil)
+	require.Error(t, err, "upgrade must fail when /api/v1/ready returns 503")
+	assert.Contains(t, err.Error(), "503",
+		"error must surface the 503 status so the operator knows why the gate rejected the binary")
+
+	// The previous binary at the install path must be unchanged.
+	got, readErr := os.ReadFile(installPath)
+	require.NoError(t, readErr)
+	assert.Equal(t, prevContent, got,
+		"previous binary at install path must be retained when /api/v1/ready returns 503")
+
+	// StageBinaryAndRestart must NOT have been called.
+	assert.Empty(t, fakeMgr.stagedBinary,
+		"StageBinaryAndRestart must not be called when the pre-restart readiness check fails")
 }

--- a/cmd/controller/service/manager.go
+++ b/cmd/controller/service/manager.go
@@ -52,6 +52,15 @@ type Manager interface {
 	// InstallPath returns the platform-standard path the binary will be
 	// copied to during Install.
 	InstallPath() string
+
+	// StageBinaryAndRestart copies newBinaryPath to the platform-standard
+	// install path, then signals the supervisor to restart the service
+	// in-place (e.g. systemctl restart cfgms-controller). This is an atomic
+	// binary swap followed by a supervisor-managed restart; the service
+	// reloads the same durable storage. The caller is responsible for backing
+	// up the previous binary before invoking this method.
+	// Requires elevated privileges on all platforms.
+	StageBinaryAndRestart(newBinaryPath, configPath string) error
 }
 
 // New returns the platform-specific Manager for the current OS.

--- a/cmd/controller/service/manager_darwin.go
+++ b/cmd/controller/service/manager_darwin.go
@@ -105,6 +105,21 @@ func (m *darwinManager) Uninstall(purge bool) error {
 	return nil
 }
 
+// StageBinaryAndRestart copies newBinaryPath to the service install path,
+// then issues a `launchctl kickstart -k` for an in-place binary swap. The
+// -k flag kills the currently running daemon instance before relaunching it,
+// so the plist and config path are unchanged.
+func (m *darwinManager) StageBinaryAndRestart(newBinaryPath, configPath string) error {
+	if err := copyBinary(newBinaryPath, darwinInstallPath); err != nil {
+		return fmt.Errorf("stage binary: %w", err)
+	}
+	target := "system/" + darwinServiceName
+	if out, err := exec.Command("launchctl", "kickstart", "-k", target).CombinedOutput(); err != nil {
+		return fmt.Errorf("launchctl kickstart %s: %w\n%s", target, err, out)
+	}
+	return nil
+}
+
 // Status returns the current state of the launchd daemon without requiring
 // elevated privileges.
 func (m *darwinManager) Status() (*ServiceStatus, error) {

--- a/cmd/controller/service/manager_darwin_test.go
+++ b/cmd/controller/service/manager_darwin_test.go
@@ -125,3 +125,14 @@ func TestDarwinManagerNew(t *testing.T) {
 	_, ok := m.(*darwinManager)
 	assert.True(t, ok, "New() should return a *darwinManager on macOS")
 }
+
+// TestDarwinManagerStageBinaryAndRestart_SourceNotFound verifies that
+// StageBinaryAndRestart fails fast at the copy step when the source binary
+// does not exist.
+func TestDarwinManagerStageBinaryAndRestart_SourceNotFound(t *testing.T) {
+	m := New("/usr/local/bin/cfgms-controller")
+	err := m.StageBinaryAndRestart("/nonexistent/ghost-binary", "/etc/cfgms/controller.cfg")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "stage binary",
+		"error must indicate failure in the copy/stage step")
+}

--- a/cmd/controller/service/manager_linux.go
+++ b/cmd/controller/service/manager_linux.go
@@ -113,6 +113,20 @@ func (m *linuxManager) Uninstall(purge bool) error {
 	return nil
 }
 
+// StageBinaryAndRestart copies newBinaryPath to the service install path,
+// then issues a `systemctl restart` for an in-place binary swap. The service
+// reloads without a full enable/disable cycle; the unit file and config path
+// are unchanged.
+func (m *linuxManager) StageBinaryAndRestart(newBinaryPath, configPath string) error {
+	if err := copyBinary(newBinaryPath, linuxInstallPath); err != nil {
+		return fmt.Errorf("stage binary: %w", err)
+	}
+	if out, err := exec.Command("systemctl", "restart", linuxServiceName).CombinedOutput(); err != nil {
+		return fmt.Errorf("systemctl restart %s: %w\n%s", linuxServiceName, err, out)
+	}
+	return nil
+}
+
 // Status returns the current state of the systemd service without requiring
 // elevated privileges.
 func (m *linuxManager) Status() (*ServiceStatus, error) {

--- a/cmd/controller/service/manager_linux_test.go
+++ b/cmd/controller/service/manager_linux_test.go
@@ -143,3 +143,14 @@ func TestSystemdUnitFilePermissions(t *testing.T) {
 	// 0600: owner rw (root only); systemd reads as root, group read is unnecessary
 	assert.Equal(t, os.FileMode(0600), info.Mode().Perm())
 }
+
+// TestLinuxManagerStageBinaryAndRestart_SourceNotFound verifies that
+// StageBinaryAndRestart fails fast at the copy step when the source binary
+// does not exist.
+func TestLinuxManagerStageBinaryAndRestart_SourceNotFound(t *testing.T) {
+	m := New("/usr/bin/cfgms-controller")
+	err := m.StageBinaryAndRestart("/nonexistent/ghost-binary", "/etc/cfgms/controller.cfg")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "stage binary",
+		"error must indicate failure in the copy/stage step")
+}

--- a/cmd/controller/service/manager_stub.go
+++ b/cmd/controller/service/manager_stub.go
@@ -31,3 +31,7 @@ func (m *stubManager) Uninstall(purge bool) error {
 func (m *stubManager) Status() (*ServiceStatus, error) {
 	return &ServiceStatus{}, fmt.Errorf("service status is not supported on %s", runtime.GOOS)
 }
+
+func (m *stubManager) StageBinaryAndRestart(newBinaryPath, configPath string) error {
+	return fmt.Errorf("StageBinaryAndRestart is not supported on %s", runtime.GOOS)
+}

--- a/cmd/controller/service/manager_windows.go
+++ b/cmd/controller/service/manager_windows.go
@@ -176,6 +176,35 @@ func (m *windowsManager) Uninstall(purge bool) error {
 	return nil
 }
 
+// StageBinaryAndRestart copies newBinaryPath to the service install path,
+// then stops and starts the Windows service for an in-place binary swap.
+// The service definition is unchanged; only the binary on disk is replaced.
+func (m *windowsManager) StageBinaryAndRestart(newBinaryPath, configPath string) error {
+	if err := copyBinary(newBinaryPath, windowsInstallPath); err != nil {
+		return fmt.Errorf("stage binary: %w", err)
+	}
+	scm, err := mgr.Connect()
+	if err != nil {
+		return fmt.Errorf("connect to SCM: %w", err)
+	}
+	defer scm.Disconnect()
+
+	existing, err := scm.OpenService(windowsServiceName)
+	if err != nil {
+		return fmt.Errorf("open service %s: %w", windowsServiceName, err)
+	}
+	defer existing.Close()
+
+	_, _ = existing.Control(svc.Stop)
+	if stopErr := waitForStop(existing, 30*time.Second); stopErr != nil {
+		return fmt.Errorf("stop service for restart: %w", stopErr)
+	}
+	if startErr := existing.Start(); startErr != nil {
+		return fmt.Errorf("start service after binary swap: %w", startErr)
+	}
+	return nil
+}
+
 // Status returns the current service state without requiring elevated privileges.
 func (m *windowsManager) Status() (*ServiceStatus, error) {
 	status := &ServiceStatus{


### PR DESCRIPTION
## Summary

- Adds `cfg controller upgrade restart` — the supported production upgrade path per ADR-007 (replaces the experimental port-swap orchestrator frozen by #2019)
- Adds `StageBinaryAndRestart(newBinaryPath, configPath string) error` to the `cmd/controller/service.Manager` interface with platform implementations (Linux: systemctl restart, macOS: launchctl kickstart -k, Windows: SCM Stop+Start, stub: unsupported error)
- Reuses `HTTPSmoketester` from `features/controller/cutover` without modification — it already probes `GET /api/v1/ready` and enforces the 200-only real-state gate from #2012

## Algorithm

1. Validate new binary exists and is not a directory
2. Spawn it on side ports (`--candidate-api-addr` / `--candidate-transport-addr`)
3. Probe `GET /api/v1/ready` — rejects binary on any non-200 (keep-previous-binary rollback: install path untouched)
4. If ready: back up current binary, copy new binary to install path, `systemctl restart` (or equivalent)
5. Probe `GET /api/v1/ready` on canonical port (post-restart gate)
6. If post-restart probe fails: restore previous binary via `StageBinaryAndRestart` and return error

## Test Plan

- [x] `TestControllerUpgradeRestart_503AbortsAndRetainsPreviousBinary` — required story test: TLS server returning 503 drives the probe gate; `fakeRestartManager` (OS interface double) confirms `StageBinaryAndRestart` is never called and install-path binary is unchanged
- [x] `TestControllerUpgradeRestart_{RequiresBinary,RequiresConfig,BinaryNotAccessible}` — input validation
- [x] `TestControllerUpgradeRestartCmd_IsDocumentedSupportedPath` — help text references supported path + Issue #2015
- [x] `TestControllerUpgradeCmd_FlagsRegistered` — extended to include restart flags
- [x] `TestLinuxManagerStageBinaryAndRestart_SourceNotFound` — Linux error path
- [x] `TestDarwinManagerStageBinaryAndRestart_SourceNotFound` — macOS error path
- [x] All pre-existing tests continue to pass

## Specialist Review Results

**QA Test Runner: PASS** — All 130+ packages pass, cross-platform builds verified (linux/amd64, linux/arm64, darwin/amd64, darwin/arm64, windows/amd64)

**QA Code Reviewer: PASS** — No blocking issues. Warnings: missing happy-path test for restart command (non-blocking per story scope), darwin/windows test files lack error path tests for new method (linux test added, darwin added; windows SCM requires Administrator so not testable in CI)

**Security Engineer: PASS** — No blocking issues. `SkipTLSVerify: true` routes through `pkg/cert.CreateProbeClientTLSConfig()` (TLS 1.2 minimum enforced, centralized in audited helper). All `exec.Command` calls use static string-literal arguments. Both `#nosec G304` annotations carry justification comments.

Fixes #2015

🤖 Generated with [Claude Code](https://claude.com/claude-code)