### PR TITLE
sqlite: retry steward writes on SQLITE_BUSY to fix concurrent-writes flake (Issue #2068)

### DIFF
--- a/pkg/storage/providers/sqlite/retry.go
+++ b/pkg/storage/providers/sqlite/retry.go
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+package sqlite
+
+import (
+	"context"
+	"strings"
+	"time"
+)
+
+// busyMaxAttempts and busyBaseBackoff bound the Go-level retry that backstops
+// the connection-level busy_timeout pragma (see openDB). Six attempts with
+// 10ms→320ms exponential backoff (~630ms worst case) is ample headroom for the
+// single-writer contention SQLite serialises: the contending writer's commit
+// is sub-millisecond, so a retry almost always succeeds on the next attempt.
+const (
+	busyMaxAttempts = 6
+	busyBaseBackoff = 10 * time.Millisecond
+)
+
+// isBusyErr reports whether err is a SQLite lock-contention error
+// (SQLITE_BUSY / SQLITE_LOCKED). modernc.org/sqlite surfaces these as text;
+// match on the documented substrings rather than a numeric code so the check
+// is driver-version-stable.
+func isBusyErr(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	return strings.Contains(msg, "SQLITE_BUSY") ||
+		strings.Contains(msg, "database is locked") ||
+		strings.Contains(msg, "database table is locked")
+}
+
+// retryOnBusy runs fn, retrying with bounded exponential backoff while it
+// returns a SQLite lock-contention error. It is a Go-level backstop for the
+// residual SQLITE_BUSY that modernc.org/sqlite can surface under heavy
+// concurrent writers on slow I/O (observed on Windows CI runners — Issue
+// #2068) even with busy_timeout=15s set per connection: the C busy handler is
+// not always honored across the database/sql pool. SQLite is single-writer, so
+// the contending lock is always released promptly and a retry converges.
+//
+// Only lock-contention errors are retried; every other error (and success)
+// returns immediately, so semantic errors like a UNIQUE-constraint violation
+// are surfaced to the caller unchanged on the first attempt. fn MUST be
+// idempotent under a BUSY failure — true for a single autocommit statement,
+// which does not partially apply when it returns BUSY.
+func retryOnBusy(ctx context.Context, fn func() error) error {
+	backoff := busyBaseBackoff
+	var err error
+	for attempt := 0; attempt < busyMaxAttempts; attempt++ {
+		err = fn()
+		if !isBusyErr(err) {
+			return err
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(backoff):
+		}
+		backoff *= 2
+	}
+	return err
+}

--- a/pkg/storage/providers/sqlite/retry_test.go
+++ b/pkg/storage/providers/sqlite/retry_test.go
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+package sqlite
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestIsBusyErr(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"sqlite_busy", errors.New("sqlite: SQLITE_BUSY: database is locked (5)"), true},
+		{"database is locked", errors.New("database is locked (5)"), true},
+		{"table locked", errors.New("database table is locked: stewards"), true},
+		{"unique constraint not retried", errors.New("UNIQUE constraint failed: stewards.id"), false},
+		{"unrelated", errors.New("no such table: stewards"), false},
+	}
+	for _, tc := range cases {
+		if got := isBusyErr(tc.err); got != tc.want {
+			t.Errorf("%s: isBusyErr=%v want %v", tc.name, got, tc.want)
+		}
+	}
+}
+
+// TestRetryOnBusy_RetriesThenSucceeds: a write that reports BUSY twice then
+// succeeds must succeed (the single-writer contention clears) — and fn is
+// invoked exactly the number of times it took.
+func TestRetryOnBusy_RetriesThenSucceeds(t *testing.T) {
+	calls := 0
+	err := retryOnBusy(context.Background(), func() error {
+		calls++
+		if calls < 3 {
+			return errors.New("SQLITE_BUSY: database is locked (5)")
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("expected success after retries, got %v", err)
+	}
+	if calls != 3 {
+		t.Fatalf("expected 3 attempts, got %d", calls)
+	}
+}
+
+// TestRetryOnBusy_NonBusyReturnsImmediately: a semantic error (e.g. UNIQUE
+// violation) must be returned on the first attempt, never retried.
+func TestRetryOnBusy_NonBusyReturnsImmediately(t *testing.T) {
+	calls := 0
+	sentinel := errors.New("UNIQUE constraint failed: stewards.id")
+	err := retryOnBusy(context.Background(), func() error {
+		calls++
+		return sentinel
+	})
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("expected sentinel returned unchanged, got %v", err)
+	}
+	if calls != 1 {
+		t.Fatalf("expected exactly 1 attempt for a non-busy error, got %d", calls)
+	}
+}
+
+// TestRetryOnBusy_GivesUpAfterMaxAttempts: persistent BUSY surfaces the last
+// error after busyMaxAttempts (does not loop forever).
+func TestRetryOnBusy_GivesUpAfterMaxAttempts(t *testing.T) {
+	calls := 0
+	err := retryOnBusy(context.Background(), func() error {
+		calls++
+		return errors.New("SQLITE_BUSY: database is locked (5)")
+	})
+	if !isBusyErr(err) {
+		t.Fatalf("expected a busy error after exhausting retries, got %v", err)
+	}
+	if calls != busyMaxAttempts {
+		t.Fatalf("expected %d attempts, got %d", busyMaxAttempts, calls)
+	}
+}
+
+// TestRetryOnBusy_RespectsContextCancellation: a cancelled context stops the
+// retry loop promptly with the context error.
+func TestRetryOnBusy_RespectsContextCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	err := retryOnBusy(ctx, func() error {
+		return errors.New("SQLITE_BUSY: database is locked (5)")
+	})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context.Canceled, got %v", err)
+	}
+}
+
+// Guard: backoff math stays bounded and small.
+func TestRetryOnBusy_BackoffBounded(t *testing.T) {
+	start := time.Now()
+	_ = retryOnBusy(context.Background(), func() error {
+		return errors.New("database is locked")
+	})
+	// 10+20+40+80+160+ (5 sleeps after the first 5 failures; last attempt no sleep)
+	// ~310ms worst case; allow generous ceiling to avoid CI flakiness.
+	if elapsed := time.Since(start); elapsed > 5*time.Second {
+		t.Fatalf("retry backoff took too long: %v", elapsed)
+	}
+}

--- a/pkg/storage/providers/sqlite/steward_store.go
+++ b/pkg/storage/providers/sqlite/steward_store.go
@@ -47,22 +47,25 @@ func (s *SQLiteStewardStore) RegisterSteward(ctx context.Context, record *busine
 		status = business.StewardStatusRegistered
 	}
 
-	_, err := s.db.ExecContext(ctx, `
-		INSERT INTO stewards
-			(id, hostname, platform, arch, version, ip_address, status,
-			 registered_at, last_seen, last_heartbeat_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-		record.ID,
-		record.Hostname,
-		record.Platform,
-		record.Arch,
-		record.Version,
-		record.IPAddress,
-		string(status),
-		formatTime(now),
-		formatTime(now),
-		"", // last_heartbeat_at empty until first heartbeat
-	)
+	err := retryOnBusy(ctx, func() error {
+		_, e := s.db.ExecContext(ctx, `
+			INSERT INTO stewards
+				(id, hostname, platform, arch, version, ip_address, status,
+				 registered_at, last_seen, last_heartbeat_at)
+			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+			record.ID,
+			record.Hostname,
+			record.Platform,
+			record.Arch,
+			record.Version,
+			record.IPAddress,
+			string(status),
+			formatTime(now),
+			formatTime(now),
+			"", // last_heartbeat_at empty until first heartbeat
+		)
+		return e
+	})
 	if err != nil {
 		if strings.Contains(err.Error(), "UNIQUE constraint failed") {
 			return business.ErrStewardAlreadyExists
@@ -75,10 +78,15 @@ func (s *SQLiteStewardStore) RegisterSteward(ctx context.Context, record *busine
 // UpdateHeartbeat records a heartbeat, updating last_heartbeat_at and last_seen.
 func (s *SQLiteStewardStore) UpdateHeartbeat(ctx context.Context, stewardID string) error {
 	now := formatTime(nowUTC())
-	res, err := s.db.ExecContext(ctx, `
-		UPDATE stewards SET last_heartbeat_at = ?, last_seen = ? WHERE id = ?`,
-		now, now, stewardID,
-	)
+	var res sql.Result
+	err := retryOnBusy(ctx, func() error {
+		var e error
+		res, e = s.db.ExecContext(ctx, `
+			UPDATE stewards SET last_heartbeat_at = ?, last_seen = ? WHERE id = ?`,
+			now, now, stewardID,
+		)
+		return e
+	})
 	if err != nil {
 		return fmt.Errorf("sqlite: failed to update heartbeat for steward %s: %w", stewardID, err)
 	}
@@ -128,10 +136,15 @@ func (s *SQLiteStewardStore) ListStewardsByStatus(ctx context.Context, status bu
 
 // UpdateStewardStatus updates the lifecycle status of the given steward and bumps last_seen.
 func (s *SQLiteStewardStore) UpdateStewardStatus(ctx context.Context, stewardID string, status business.StewardStatus) error {
-	res, err := s.db.ExecContext(ctx, `
-		UPDATE stewards SET status = ?, last_seen = ? WHERE id = ?`,
-		string(status), formatTime(nowUTC()), stewardID,
-	)
+	var res sql.Result
+	err := retryOnBusy(ctx, func() error {
+		var e error
+		res, e = s.db.ExecContext(ctx, `
+			UPDATE stewards SET status = ?, last_seen = ? WHERE id = ?`,
+			string(status), formatTime(nowUTC()), stewardID,
+		)
+		return e
+	})
 	if err != nil {
 		return fmt.Errorf("sqlite: failed to update steward status %s: %w", stewardID, err)
 	}


### PR DESCRIPTION
Fixes #2068. Stops the recurring `TestSQLite_TwoStoreInstances_ConcurrentWrites_NoCorruption` flake that's been ejecting unrelated PRs from the merge queue on Windows runners.

## Root cause
The provider already sets `busy_timeout=15s` + WAL per-connection via DSN pragma (`plugin.go`). But under heavy concurrent writers on slow Windows-CI I/O, modernc.org/sqlite doesn't always honor the C busy handler across the `database/sql` pool, so `SQLITE_BUSY` reaches the caller anyway. `RegisterSteward` is a single autocommit `ExecContext` (no deferred-tx upgrade-deadlock) — so the fix is a Go-level retry, which the issue AC explicitly sanctions.

## Fix
- New `retry.go`: `isBusyErr` (matches SQLITE_BUSY / database is locked) + `retryOnBusy` (6 attempts, 10ms→320ms backoff, context-aware). SQLite is single-writer, so the contending lock clears promptly and a bounded retry converges. Only lock-contention errors retry; semantic errors (UNIQUE violation, etc.) surface unchanged on the first attempt.
- Wrapped the steward-store write paths: `RegisterSteward`, `UpdateHeartbeat`, `UpdateStewardStatus` (→ `DeregisterSteward`).
- `busy_timeout`/WAL DSN setup unchanged (retry is a backstop on top of it).

## Tests
- `retry_test.go`: matching, retry-then-succeed, no-retry-on-semantic-error, give-up-after-max-attempts, context-cancellation, bounded-backoff.
- The previously-flaky `concurrent_writers` test passes **10/10** locally; full sqlite package green; `make check-architecture` clean; cross-platform (`GOOS=linux`) build clean.

Note: other stores using deferred `BeginTx(ctx, nil)` have a separate latent upgrade-deadlock risk (better fixed with `BEGIN IMMEDIATE`); out of scope for this flake fix but worth a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)