### PR TITLE
hyperv: existence-gating enforcement + degraded surface + on_existing safety (Issue #2048)

### DIFF
--- a/features/modules/hyperv/provision.go
+++ b/features/modules/hyperv/provision.go
@@ -175,6 +175,62 @@ func (m *hypervModule) failProvision(ctx context.Context, vmName string, record 
 	return cause
 }
 
+// isOwnIncompleteAttempt reports whether a provisioning record exists for vmName
+// in a non-terminal, host-side-in-progress state — i.e. one of {creating,
+// installing, finalizing}. Such a record proves the VM (or a half-built VM under
+// the same name) is the module's own incomplete provisioning attempt rather than
+// a pre-existing operator workload, which the existence-gating safety invariant
+// (ADR-009 §2) treats differently: an own-incomplete attempt is surfaced-and-
+// waited-on (never auto-destroyed), while a real existing VM is left untouched.
+//
+// A missing record, or a record in a terminal state (absent/ready/failed/
+// degraded), returns false. A store read error is treated as "no in-progress
+// attempt" (false) — the caller's downstream gating is conservative regardless.
+func (m *hypervModule) isOwnIncompleteAttempt(ctx context.Context, vmName string) bool {
+	if m.provisionStore == nil {
+		return false
+	}
+	record, err := m.provisionStore.GetProvision(ctx, vmName)
+	if err != nil || record == nil {
+		return false
+	}
+	switch record.State {
+	case ProvisionStateCreating, ProvisionStateInstalling, ProvisionStateFinalizing:
+		return true
+	default:
+		return false
+	}
+}
+
+// degradeProvision records that a VM which already exists on the host is in a
+// broken/unhealthy state (ADR-009 §2 degraded surface). It writes a
+// ProvisionRecord at state=degraded with LastError describing the observed
+// Hyper-V state, persists it, and emits a structured log event. It is the
+// non-destructive surface for an existing-but-broken VM: the module NEVER
+// delete-and-rebuilds — degradation is observed and reported, not remediated.
+// observedState is the raw VM power/health state string and is sanitised before
+// it reaches any log field.
+func (m *hypervModule) degradeProvision(ctx context.Context, vmName string, record *ProvisionRecord, observedState string) error {
+	if m.provisionStore == nil {
+		m.provisionStore = NewMemProvisionStore()
+	}
+	prev := record.State
+	record.State = ProvisionStateDegraded
+	record.UpdatedAt = time.Now().UTC()
+	record.LastError = "hyperv: VM in broken state: " + observedState
+	if err := m.provisionStore.SetProvision(ctx, record); err != nil {
+		return err
+	}
+	if logger, ok := m.GetLogger(); ok {
+		logger.Warn("hyperv: existing VM is in a broken state; surfaced as degraded (not torn down)",
+			"vm_name", logging.SanitizeLogValue(vmName),
+			"from_state", string(prev),
+			"observed_state", logging.SanitizeLogValue(observedState),
+			"correlation_id", logging.SanitizeLogValue(record.CorrelationID))
+	}
+	return nil
+}
+
 // ListProvisions returns snapshot copies of all provisioning records. Used by
 // the controller-side completion reconciler (#2050) to match a registered
 // steward to a provisioning VM via CorrelationID.

--- a/features/modules/hyperv/provision_test.go
+++ b/features/modules/hyperv/provision_test.go
@@ -162,6 +162,52 @@ func TestProvisionRecord_LastError(t *testing.T) {
 	assert.Equal(t, "timeout waiting for steward registration", got.LastError)
 }
 
+// TestIsOwnIncompleteAttempt verifies the existence-gating helper: a record in a
+// host-side in-progress state (creating/installing/finalizing) reports true;
+// missing or terminal-state records report false. This is the discriminator that
+// separates "our own incomplete attempt" (safe to surface-and-wait) from "a real
+// existing VM" (never destroyed) in the ADR-009 §2 decision tree.
+func TestIsOwnIncompleteAttempt(t *testing.T) {
+	ctx := context.Background()
+	m := &hypervModule{provisionStore: NewMemProvisionStore()}
+
+	// No record → false.
+	assert.False(t, m.isOwnIncompleteAttempt(ctx, "vm-x"),
+		"no provisioning record must report not-in-progress")
+
+	cases := []struct {
+		state ProvisionState
+		want  bool
+	}{
+		{ProvisionStateAbsent, false},
+		{ProvisionStateCreating, true},
+		{ProvisionStateInstalling, true},
+		{ProvisionStateFinalizing, true},
+		{ProvisionStateReady, false},
+		{ProvisionStateFailed, false},
+		{ProvisionStateDegraded, false},
+	}
+	for _, tc := range cases {
+		require.NoError(t, m.provisionStore.SetProvision(ctx, &ProvisionRecord{
+			VMName: "vm-x", State: tc.state, CorrelationID: "vm-x",
+		}))
+		assert.Equal(t, tc.want, m.isOwnIncompleteAttempt(ctx, "vm-x"),
+			"isOwnIncompleteAttempt for state %q", tc.state)
+	}
+}
+
+// TestIsHealthyVMState verifies the broken-state classifier used by the degraded
+// surface: running/stopped/off/paused/saved/absent are healthy; any other state
+// (critical, off-critical, paused-critical, unknown) is broken (ADR-009 §2).
+func TestIsHealthyVMState(t *testing.T) {
+	for _, s := range []string{"running", "stopped", "off", "paused", "saved", "absent", "Running", "Off"} {
+		assert.True(t, isHealthyVMState(s), "%q must be classified healthy", s)
+	}
+	for _, s := range []string{"critical", "off-critical", "paused-critical", "Critical", "starting-critical", "weird"} {
+		assert.False(t, isHealthyVMState(s), "%q must be classified broken", s)
+	}
+}
+
 // TestProvisionState_Values verifies the ProvisionState string enum values are
 // stable and serialise to the expected strings.
 func TestProvisionState_Values(t *testing.T) {

--- a/features/modules/hyperv/vm.go
+++ b/features/modules/hyperv/vm.go
@@ -14,6 +14,7 @@ import (
 	"gopkg.in/yaml.v3"
 
 	"github.com/cfgis/cfgms/features/modules"
+	"github.com/cfgis/cfgms/pkg/logging"
 )
 
 var (
@@ -480,6 +481,23 @@ const psSetVMProcessor = `Set-VMProcessor -VMName $Name -Count $CPU`
 // Set-VMMemory is not a standard Hyper-V cmdlet; Set-VM with MemoryStartupBytes is used instead.
 const psSetVMMemory = `Set-VM -Name $Name -MemoryStartupBytes ($MemoryMB * 1MB)`
 
+// isHealthyVMState reports whether a getVM-normalised state string represents a
+// healthy, operable VM. getVM maps the Hyper-V "Running" → "running" and "Off" →
+// "stopped"; every other Hyper-V State (e.g. "Critical", "Off-Critical",
+// "Paused-Critical") is lower-cased verbatim. Per ADR-009 §2 the existence-gating
+// degraded surface treats any state that is neither running nor stopped (nor the
+// synthetic "absent") as broken. "off" and "paused"/"saved" are accepted as
+// non-broken benign power states; only states carrying a "-critical"/"critical"
+// (or otherwise unrecognised) health signal mark the VM degraded.
+func isHealthyVMState(state string) bool {
+	switch strings.ToLower(state) {
+	case "running", "stopped", "off", "paused", "saved", "absent":
+		return true
+	default:
+		return false
+	}
+}
+
 // getVM returns the current state of a VM on the host, queried by its exact name.
 //
 // Contract (matches the directory/file modules):
@@ -686,42 +704,30 @@ func (m *hypervModule) setVM(ctx context.Context, resourceID string, config modu
 		return err
 	}
 
+	// Existence-gating safety invariant (ADR-009 §2): source provisioning is
+	// existence-gated, never health-gated. When a source block is declared, the
+	// create/destroy decision is made HERE — before any plain-lifecycle apply —
+	// so that an existing VM can never be auto-destroyed or recreated by default,
+	// regardless of its health. The decision tree:
+	//
+	//   1. VM absent, own incomplete provisioning record → surface-and-wait.
+	//   2. VM absent, no in-progress record               → provision (create).
+	//   3. VM exists, on_existing == recreate             → removeVM + provision.
+	//   4. VM exists, broken state, on_existing != recreate → degraded surface.
+	//   5. VM exists, healthy, on_existing != recreate    → source inert;
+	//                                                        drive finalize +
+	//                                                        plain lifecycle.
+	if cfg.Source != nil {
+		return m.applySourceGated(ctx, vmName, hostName, cfg, &currentVM, vmExists, state)
+	}
+
 	if vmExists {
-		// Create-from-source convergence (ADR-009 §6/§8): when the VM already
-		// exists and carries a source block, drive the installing → finalizing
-		// transition (detect install completion + detach the seed VHDX). The
-		// host-side module never advances to ready — that is controller-side
-		// (#2050). finalizeProvision is a no-op unless the record is at installing
-		// and the conservative settle conditions are met.
-		if cfg.Source != nil {
-			if err := m.finalizeProvision(ctx, vmName, hostName, cfg); err != nil {
-				return err
-			}
-		}
 		return m.applyVMState(ctx, vmName, hostName, cfg, &currentVM, state)
 	}
 
-	// VM does not exist — create it.
+	// VM does not exist — create it (plain lifecycle, no source block).
 	if err := m.createVM(ctx, vmName, hostName, cfg); err != nil {
 		return err
-	}
-
-	// Create-from-source (ADR-009): when a source block is declared, build and
-	// attach the seed VHDX, attach the install ISO, advance the provisioning
-	// record, and power on. The seed/ISO attach + power-on happens INSIDE
-	// provisionVM so the provisioning record reflects each step; the plain
-	// lifecycle start below is skipped for the source path.
-	if cfg.Source != nil {
-		if err := m.provisionVM(ctx, vmName, hostName, cfg); err != nil {
-			return err
-		}
-		// Write-through: update cache on success
-		cfgCopy := *cfg
-		cfgCopy.Name = vmName
-		m.vmsMu.Lock()
-		m.vms[vmName] = cfgCopy
-		m.vmsMu.Unlock()
-		return nil
 	}
 
 	if state == "running" {
@@ -738,6 +744,111 @@ func (m *hypervModule) setVM(ctx context.Context, resourceID string, config modu
 	m.vmsMu.Unlock()
 
 	return nil
+}
+
+// applySourceGated enforces the ADR-009 §2 existence-gating safety invariant for
+// a hyperv.vm resource that declares a source block. It is the SINGLE place that
+// decides whether source provisioning creates, resumes, recreates, or stands
+// inert — so that an existing VM is NEVER auto-destroyed or recreated under the
+// default (on_existing: never / absent) regardless of its health.
+//
+// Decision tree (mirrors ADR-009 §2 and the story #2048 implementation notes):
+//
+//	VM absent + own incomplete record  → surface-and-wait (no New-VM, no retry).
+//	VM absent + no in-progress record  → createVM + provisionVM (normal create).
+//	VM exists + on_existing==recreate  → removeVM, reset record, then provision.
+//	VM exists + broken state           → degraded record; never destroyed.
+//	VM exists + healthy                → source inert; finalize + plain lifecycle.
+func (m *hypervModule) applySourceGated(ctx context.Context, vmName, hostName string, cfg *VMConfig, currentVM *VMConfig, vmExists bool, state string) error {
+	onExisting := cfg.Source.OnExisting // "" is treated as "never"
+
+	if !vmExists {
+		// The VM is absent on the host. Distinguish our OWN incomplete
+		// provisioning attempt (a record at creating/installing/finalizing —
+		// provably holds no operator workload, safe to resume) from a fresh
+		// create. Auto-retry of an own-incomplete attempt is OFF by default
+		// (surface-and-wait, ADR-009 §2): the install may simply be mid-flight
+		// and a half-built VM transiently absent from Get-VM. We do NOT re-issue
+		// New-VM — that is what protects against thrashing an in-progress build.
+		if m.isOwnIncompleteAttempt(ctx, vmName) {
+			if logger, ok := m.GetLogger(); ok {
+				logger.Warn("hyperv: in-progress provisioning attempt; surface-and-wait (no auto-retry)",
+					"vm_name", logging.SanitizeLogValue(vmName))
+			}
+			return nil
+		}
+		// No in-progress record → normal create-from-source path.
+		if err := m.createVM(ctx, vmName, hostName, cfg); err != nil {
+			return err
+		}
+		if err := m.provisionVM(ctx, vmName, hostName, cfg); err != nil {
+			return err
+		}
+		cfgCopy := *cfg
+		cfgCopy.Name = vmName
+		m.vmsMu.Lock()
+		m.vms[vmName] = cfgCopy
+		m.vmsMu.Unlock()
+		return nil
+	}
+
+	// ── The VM EXISTS on the host. ──────────────────────────────────────────
+	// Existence-gating: existence alone makes source inert by default. The ONLY
+	// path that may destroy an existing VM is the explicit on_existing: recreate
+	// opt-in. Health/bootability is NEVER the trigger — a broken VM is surfaced
+	// as degraded, not rebuilt.
+	if onExisting == "recreate" {
+		// Explicit destructive opt-in. Tear the existing VM down, reset any
+		// provisioning record so the create path starts clean (absent), then
+		// provision from source.
+		if err := m.removeVM(ctx, vmName); err != nil {
+			return err
+		}
+		if m.provisionStore != nil {
+			if err := m.provisionStore.DeleteProvision(ctx, vmName); err != nil && !errors.Is(err, ErrProvisionNotFound) {
+				return err
+			}
+		}
+		if err := m.createVM(ctx, vmName, hostName, cfg); err != nil {
+			return err
+		}
+		if err := m.provisionVM(ctx, vmName, hostName, cfg); err != nil {
+			return err
+		}
+		cfgCopy := *cfg
+		cfgCopy.Name = vmName
+		m.vmsMu.Lock()
+		m.vms[vmName] = cfgCopy
+		m.vmsMu.Unlock()
+		return nil
+	}
+
+	// on_existing is never (or empty). The VM is never destroyed.
+	if !isHealthyVMState(currentVM.State) {
+		// Existing-but-broken VM → surface as degraded (ADR-009 §2). Never
+		// delete-and-rebuild. The record records the observed state so the
+		// operator (and the controller-side reconciler) can see it.
+		record, err := m.loadOrInitProvision(ctx, vmName)
+		if err != nil {
+			return err
+		}
+		return m.degradeProvision(ctx, vmName, record, currentVM.State)
+	}
+
+	// Existing healthy VM → source is inert. Log the inert decision, then drive
+	// the create-from-source convergence (installing → finalizing detach, a
+	// no-op unless an own record is at installing and settle conditions hold)
+	// and the plain lifecycle (power/resize/NIC) so an already-provisioned VM
+	// still converges to its declared running/stopped state without provisioning.
+	if logger, ok := m.GetLogger(); ok {
+		logger.Warn("hyperv: VM exists; source is inert (on_existing: never)",
+			"vm_name", logging.SanitizeLogValue(vmName),
+			"observed_state", logging.SanitizeLogValue(currentVM.State))
+	}
+	if err := m.finalizeProvision(ctx, vmName, hostName, cfg); err != nil {
+		return err
+	}
+	return m.applyVMState(ctx, vmName, hostName, cfg, currentVM, state)
 }
 
 // createVM issues New-VM with the desired generation and connects every

--- a/features/modules/hyperv/vm_reconcile_integration_test.go
+++ b/features/modules/hyperv/vm_reconcile_integration_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -240,4 +241,181 @@ func TestReconcile_PowerIdempotent_NoStartWhenAlreadyRunning(t *testing.T) {
 		"already-running host must not be issued a redundant Start-VM")
 	assert.Empty(t, callsContaining(calls, "Stop-VM"))
 	require.Len(t, calls, 1, "fully converged running VM: only the getVM read runs")
+}
+
+// ── Existence-gating safety invariant (ADR-009 §2, Story #2048) ─────────────
+//
+// These tests prove the non-negotiable safety invariant: source provisioning is
+// existence-gated, never health-gated. An existing VM is NEVER auto-destroyed or
+// recreated by default; a broken existing VM is surfaced as degraded, not torn
+// down; only an explicit on_existing: recreate permits destruction; an own
+// in-progress attempt surfaces-and-waits rather than auto-retrying.
+
+// existingSourceVMJSON builds a getVM-shaped JSON for a VM that already exists on
+// the host, in the given raw Hyper-V State string (e.g. "Running", "Off",
+// "Critical"). Used to drive the existence-gating decision tree against a VM the
+// host reports as present.
+func existingSourceVMJSON(name, hvState string) string {
+	return `{"found":true,"Name":"` + name + `","MemoryStartupBytes":4294967296,` +
+		`"ProcessorCount":2,"Generation":2,"Path":"C:\\ClusterStorage\\CSV01\\` + name + `.vhdx",` +
+		`"SwitchName":"HVSwitch_1G","SwitchNames":["HVSwitch_1G"],"State":"` + hvState + `"}`
+}
+
+// TestExistenceGating_ExistingVMNotRecreatedByDefault is the headline [REQUIRED
+// TEST]: when a VM already exists on the host and the desired config carries a
+// source block with on_existing: never (the default), the module must issue
+// ZERO New-VM and ZERO Remove-VM calls — the existing VM is never auto-destroyed
+// or recreated. This is the core ADR-009 §2 safety invariant.
+func TestExistenceGating_ExistingVMNotRecreatedByDefault(t *testing.T) {
+	// getVM (call 0) reports the VM already present and running.
+	transport := &testWinRMTransport{
+		output: existingSourceVMJSON("stw-01", "Running"),
+	}
+	m := provisionModuleWithTransport(transport)
+
+	cfg := rawConfigState{m: sourceVMConfigMap(2, "linux")} // on_existing: never
+
+	require.NoError(t, m.Set(context.Background(), "vm:stw-01", cfg))
+
+	transport.mu.Lock()
+	calls := transport.calls
+	transport.mu.Unlock()
+
+	assert.Empty(t, callsContaining(calls, "New-VM"),
+		"existing VM must NEVER be (re)created when on_existing is never")
+	assert.Empty(t, callsContaining(calls, "Remove-VM"),
+		"existing VM must NEVER be destroyed when on_existing is never")
+	// Source orchestration must not have run any of its create-path verbs either.
+	assert.Empty(t, callsContaining(calls, "New-VHD"),
+		"no seed VHDX may be built for an existing VM under the default")
+	assert.Empty(t, callsContaining(calls, "Add-VMDvdDrive"),
+		"no install ISO may be attached to an existing VM under the default")
+}
+
+// TestExistenceGating_ExistingStoppedVMNotRecreatedByDefault proves the invariant
+// holds for an existing STOPPED VM too — existence, not power state, gates source.
+// A stopped VM with desired state running is started, but never recreated.
+func TestExistenceGating_ExistingStoppedVMNotRecreatedByDefault(t *testing.T) {
+	transport := &testWinRMTransport{
+		output: existingSourceVMJSON("stw-01", "Off"),
+	}
+	m := provisionModuleWithTransport(transport)
+
+	cfg := rawConfigState{m: sourceVMConfigMap(2, "linux")} // desired running, on_existing: never
+
+	require.NoError(t, m.Set(context.Background(), "vm:stw-01", cfg))
+
+	transport.mu.Lock()
+	calls := transport.calls
+	transport.mu.Unlock()
+
+	assert.Empty(t, callsContaining(calls, "New-VM"), "existing stopped VM must not be recreated")
+	assert.Empty(t, callsContaining(calls, "Remove-VM"), "existing stopped VM must not be destroyed")
+	// Plain lifecycle still converges power state: desired running → Start-VM.
+	require.Len(t, callsContaining(calls, "Start-VM"), 1,
+		"an existing healthy VM still converges to its declared power state")
+}
+
+// TestExistenceGating_BrokenVMSurfacesAsDegraded is the second [REQUIRED TEST]:
+// a VM that exists in an unexpected/broken Hyper-V state ("Critical") under the
+// default on_existing must be surfaced as a degraded provisioning record with
+// LastError describing the observed state — and NEVER torn down.
+func TestExistenceGating_BrokenVMSurfacesAsDegraded(t *testing.T) {
+	transport := &testWinRMTransport{
+		output: existingSourceVMJSON("stw-01", "Critical"),
+	}
+	m := provisionModuleWithTransport(transport)
+
+	cfg := rawConfigState{m: sourceVMConfigMap(2, "linux")} // on_existing: never
+
+	require.NoError(t, m.Set(context.Background(), "vm:stw-01", cfg))
+
+	transport.mu.Lock()
+	calls := transport.calls
+	transport.mu.Unlock()
+
+	assert.Empty(t, callsContaining(calls, "Remove-VM"),
+		"a broken existing VM must NEVER be torn down — degraded is observed, not remediated")
+	assert.Empty(t, callsContaining(calls, "New-VM"),
+		"a broken existing VM must NEVER be recreated")
+
+	rec, err := m.provisionStore.GetProvision(context.Background(), "stw-01")
+	require.NoError(t, err, "a degraded provisioning record must be written")
+	assert.Equal(t, ProvisionStateDegraded, rec.State,
+		"a broken existing VM surfaces as a degraded provisioning record")
+	assert.Contains(t, strings.ToLower(rec.LastError), "critical",
+		"LastError must describe the observed broken VM state")
+}
+
+// TestExistenceGating_RecreateOnlyWhenExplicit proves the ONLY destructive path:
+// when on_existing is recreate and the VM exists, the module issues Remove-VM
+// THEN New-VM (in that order) — the explicit opt-in reprovision.
+func TestExistenceGating_RecreateOnlyWhenExplicit(t *testing.T) {
+	transport := &testWinRMTransport{
+		output: existingSourceVMJSON("stw-01", "Running"),
+	}
+	m := provisionModuleWithTransport(transport)
+
+	configMap := sourceVMConfigMap(2, "linux")
+	src := configMap["source"].(map[string]interface{})
+	src["on_existing"] = "recreate"
+
+	cfg := rawConfigState{m: configMap}
+	require.NoError(t, m.Set(context.Background(), "vm:stw-01", cfg))
+
+	transport.mu.Lock()
+	calls := transport.calls
+	transport.mu.Unlock()
+
+	removes := callsContaining(calls, "Remove-VM")
+	news := callsContaining(calls, "New-VM")
+	require.Len(t, removes, 1, "on_existing: recreate must destroy the existing VM exactly once")
+	require.Len(t, news, 1, "on_existing: recreate must recreate the VM exactly once")
+
+	// Remove must precede New (tear down, then rebuild) — assert by call ordering.
+	var removeIdx, newIdx int
+	for i, c := range calls {
+		if strings.Contains(c.scriptBlock, "Remove-VM") && !strings.Contains(c.scriptBlock, "Remove-VMNetworkAdapter") {
+			removeIdx = i
+		}
+		if strings.Contains(c.scriptBlock, "New-VM") {
+			newIdx = i
+		}
+	}
+	assert.Less(t, removeIdx, newIdx, "Remove-VM must precede New-VM on the recreate path")
+}
+
+// TestExistenceGating_OwnIncompleteAttemptDoesNotAutoRetry proves surface-and-
+// wait: when an own provisioning record exists at installing but the VM is
+// absent from the host (mid-install / transiently not yet visible), the module
+// must NOT re-issue New-VM — auto-retry is off by default (ADR-009 §2).
+func TestExistenceGating_OwnIncompleteAttemptDoesNotAutoRetry(t *testing.T) {
+	transport := &testWinRMTransport{
+		output: `{"found":false}`, // host reports the VM absent
+	}
+	m := provisionModuleWithTransport(transport)
+	require.NoError(t, m.provisionStore.SetProvision(context.Background(), &ProvisionRecord{
+		VMName:        "stw-01",
+		State:         ProvisionStateInstalling,
+		CorrelationID: "stw-01",
+		StartedAt:     time.Now(),
+	}))
+
+	cfg := rawConfigState{m: sourceVMConfigMap(2, "linux")}
+	require.NoError(t, m.Set(context.Background(), "vm:stw-01", cfg))
+
+	transport.mu.Lock()
+	calls := transport.calls
+	transport.mu.Unlock()
+
+	assert.Empty(t, callsContaining(calls, "New-VM"),
+		"an own in-progress provisioning attempt must surface-and-wait, not auto-retry New-VM")
+	assert.Empty(t, callsContaining(calls, "New-VHD"),
+		"no seed rebuild for an in-progress own attempt")
+
+	// The record must remain at installing — surface-and-wait leaves it untouched.
+	rec, err := m.provisionStore.GetProvision(context.Background(), "stw-01")
+	require.NoError(t, err)
+	assert.Equal(t, ProvisionStateInstalling, rec.State,
+		"surface-and-wait must leave the in-progress record at installing")
 }


### PR DESCRIPTION
Fixes #2048. Enforces the ADR-009 §2 safety invariant: **`source` provisioning never destroys/recreates an existing VM by default.**

## What's enforced (`applySourceGated` in `vm.go`)
The create/destroy decision for a source-VM now routes through one gate implementing the §2 decision tree:
- **absent + our own incomplete record** (creating/installing/finalizing) → surface-and-wait (no `New-VM`, no blind retry)
- **absent + no record** → `createVM` + `provisionVM`
- **exists + `on_existing: recreate`** → `removeVM` (record reset) then recreate — the only path that destroys
- **exists + broken state** (e.g. `Critical`) → **degraded** record, never torn down
- **exists + healthy** → inert for provisioning; still converges power/NIC/resize via `finalizeProvision` + `applyVMState`

New helpers: `isOwnIncompleteAttempt`, `degradeProvision`, `isHealthyVMState`. All log values sanitized.

## Tests (recording transport, no mocks/skips)
- `[REQUIRED]` `TestExistenceGating_ExistingVMNotRecreatedByDefault` — asserts **zero** `New-VM`/`Remove-VM`/`New-VHD` when the VM exists + `source` present + default `on_existing`.
- `[REQUIRED]` `TestExistenceGating_BrokenVMSurfacesAsDegraded` — broken VM → degraded, no destroy.
- `TestExistenceGating_RecreateOnlyWhenExplicit` (Remove precedes New), `..._OwnIncompleteAttemptDoesNotAutoRetry`, `..._ExistingStoppedVMNotRecreated`, + unit tests for the helpers.
- Cross-platform verified (`GOOS=linux` build+vet), `make check-architecture` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)