### PR TITLE
steward: failed mTLS config is now fatal in Connect() (Issue #1662)

### DIFF
--- a/features/steward/client/client_transport.go
+++ b/features/steward/client/client_transport.go
@@ -451,11 +451,11 @@ func (c *TransportClient) Connect(ctx context.Context) error {
 		return fmt.Errorf("not registered - call SetStewardID first")
 	}
 
-	// Create TLS configuration for gRPC-over-QUIC
+	// Create TLS configuration for gRPC-over-QUIC. mTLS is mandatory; a
+	// configuration failure is fatal — there is no legitimate path without TLS.
 	tlsConfig, err := c.createTLSConfig()
 	if err != nil {
-		c.logger.Warn("Failed to load TLS config, continuing without TLS", "error", err)
-		tlsConfig = nil
+		return fmt.Errorf("failed to create TLS config: %w", err)
 	}
 
 	// Initialize gRPC control plane provider if not already set

--- a/features/steward/client/client_transport_test.go
+++ b/features/steward/client/client_transport_test.go
@@ -287,3 +287,33 @@ func TestStartConvergenceLoop_IntervalChangeResetsTicker(t *testing.T) {
 	assert.True(t, fired,
 		"convergence loop must reset its ticker on a converge_interval change and fire a scheduled convergence within 5s")
 }
+
+// TestConnect_FatalOnTLSConfigFailure verifies that a createTLSConfig failure causes
+// Connect to return the underlying error immediately rather than swallowing it and
+// continuing with a nil TLS config (Issue #1662).
+//
+// A TransportClient with certPath set to an empty temp directory causes createTLSConfig
+// to fail when it cannot read ca.crt. Connect must return that error; the misleading
+// downstream "client mode requires 'tls_config'" error must never be reached.
+func TestConnect_FatalOnTLSConfigFailure(t *testing.T) {
+	// certPath points to a real dir with no cert files — triggers the disk path
+	// in createTLSConfig, which fails on the missing ca.crt read.
+	dir := t.TempDir()
+
+	c := &TransportClient{
+		stewardID:        "steward-tls-fail-test",
+		transportAddress: "localhost:0",
+		certPath:         dir,
+		logger:           logging.NewLogger("info"),
+		heartbeatStop:    make(chan struct{}),
+		convergenceStop:  make(chan struct{}),
+		convergeInterval: 30 * time.Minute,
+	}
+
+	ctx := context.Background()
+	err := c.Connect(ctx)
+
+	require.Error(t, err, "Connect must return an error when createTLSConfig fails")
+	assert.Contains(t, err.Error(), "failed to create TLS config",
+		"Connect error must wrap the createTLSConfig failure, not obscure it with a downstream provider error")
+}


### PR DESCRIPTION
## Summary

- `Connect()` previously swallowed `createTLSConfig()` failures with a `Warn` log and continued with `tlsConfig = nil`, producing a misleading downstream error ("client mode requires 'tls_config' in config") that obscured the real cause
- `Connect()` now returns the `createTLSConfig()` error immediately, making the nil-config code path unreachable via a swallowed TLS failure
- mTLS is mandatory; there is no legitimate "continue without TLS" path

## Changes

- `features/steward/client/client_transport.go`: replaced Warn + nil-fallback at lines 456-459 with `return fmt.Errorf("failed to create TLS config: %w", err)`
- `features/steward/client/client_transport_test.go`: added `TestConnect_FatalOnTLSConfigFailure` — injects a `certPath` pointing to an empty temp dir (deterministically triggers `createTLSConfig` disk-path failure), asserts `Connect` returns the wrapped error rather than nil

## Specialist Review Results

- **QA Test Runner**: PASS — `make test-agent-complete` all gates green; `TestConnect_FatalOnTLSConfigFailure` passes in the `features/steward/client` package
- **QA Code Reviewer**: PASS — no mocks, no skips, real assertions on the error path, 0 blocking issues
- **Security Engineer**: PASS — net security improvement (closes fail-open path), `make check-architecture` and `make security-scan` clean, 0 blocking issues

## Test Plan

- [x] `TestConnect_FatalOnTLSConfigFailure` passes (new, exercises the error path)
- [x] All existing `features/steward/client` tests pass (no regressions)
- [x] `make test-agent-complete` passes (all CI-equivalent gates)

Fixes #1662

🤖 Generated with [Claude Code](https://claude.com/claude-code)