### PR TITLE
pipeline: detect stalled In-Progress stories in preflight (Issue #1678)

### DIFF
--- a/.claude/agents/po.md
+++ b/.claude/agents/po.md
@@ -500,6 +500,23 @@ For each story with project status `Fix`, find its PR and dispatch the fix agent
 This cleans any stale container from a prior failed attempt, re-clones, and launches.
 
 **Step 6 — Dispatch:**
+
+**6a — Stalled-dispatch recovery (run before new dispatch):**
+
+The preflight emits `stalled_dispatches` — a list of `In Progress` stories whose agent container (`cfg-agent-<N>`) is not running AND which have no open PR (including WIP drafts). These are silently stalled stories: the container was hard-killed (OOM, docker daemon crash, host restart, `docker rm -f`) and left the pipeline item frozen with no artifact.
+
+For each entry in `preflight.stalled_dispatches`:
+- If the story has a WIP draft PR (`is_draft: true` in `prs_open`): route through `dispatch-fix` instead (Step 5 path) — the draft PR is the work artifact to resume.
+- Otherwise: re-dispatch the story to restart the agent from scratch:
+```bash
+./.claude/scripts/po-act.sh dispatch <ITEM_ID>
+```
+
+The `item_id` comes from `stalled_dispatches[*].item_id`. Re-dispatch resets the story to `In Progress` with a fresh container. This is safe — no existing container or PR would be clobbered (preflight only flags stories where neither exists).
+
+Report stalled recoveries in the cycle summary as: `Re-dispatched stalled story #NNN (no container, no PR)`.
+
+**6b — New story dispatch:**
 Find stories with project status `Ready` that are not `In Progress`. Before dispatching, check for file conflicts with in-flight agents:
 
 Both gates are computed by the preflight script (`dispatch_recommendations` with `action: "dispatch"` vs `"hold"` and a `reason` string). Trust its recommendation by default, override only if `parse_warnings` are non-empty on the story.

--- a/.claude/scripts/po-cycle-preflight.py
+++ b/.claude/scripts/po-cycle-preflight.py
@@ -955,6 +955,53 @@ def ci_summary(checks):
     }
 
 
+def compute_stalled_dispatches(in_progress_issues, containers, pr_summaries):
+    """Detect In-Progress stories with no running agent container and no open PR.
+
+    A story is stalled when:
+    - Its project status is `In Progress`
+    - No container named `cfg-agent-<N>` is currently running
+    - No open PR (including WIP drafts) references this story number
+
+    Draft PRs count as "open PR" — they should go through dispatch-fix, not
+    re-dispatch. Only pure container deaths with no PR artifact trigger this.
+
+    Returns a list of:
+      {"number": N, "item_id": "...", "title": "...", "reason": "..."}
+
+    Pure draft items (number=None) are skipped — they have no container or
+    branch naming convention to cross-reference.
+    """
+    running_story_nums = set()
+    for name in containers or []:
+        tail = name.removeprefix("cfg-agent-")
+        if tail != name and tail.isdigit():
+            running_story_nums.add(int(tail))
+
+    pr_story_nums = {
+        s["story_number"]
+        for s in pr_summaries
+        if s.get("story_number") is not None
+    }
+
+    stalled = []
+    for item in in_progress_issues:
+        n = item.get("number")
+        if n is None:
+            continue
+        if n in running_story_nums:
+            continue
+        if n in pr_story_nums:
+            continue
+        stalled.append({
+            "number": n,
+            "item_id": item.get("item_id", ""),
+            "title": item.get("title", ""),
+            "reason": f"no container cfg-agent-{n} running and no open PR",
+        })
+    return stalled
+
+
 def compute_dispatch_recommendations(ready_stories, active_stories, dep_states, caps=None):
     """Greedy conflict-free selection.
 
@@ -1826,6 +1873,9 @@ def main():
     )
     out["fix_recommendations"] = compute_fix_recommendations(
         fix_issues, pr_summaries, active_fix_pr_nums, queued_pr_numbers,
+    )
+    out["stalled_dispatches"] = compute_stalled_dispatches(
+        in_progress_issues, containers, pr_summaries,
     )
 
     parse_warning_count = sum(

--- a/.claude/scripts/tests/stalled_dispatch.test.sh
+++ b/.claude/scripts/tests/stalled_dispatch.test.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+# Unit tests for compute_stalled_dispatches() in po-cycle-preflight.py.
+#
+# Covers all three AC cases from Issue #1678:
+#   1. Stalled: In Progress story with no running container and no open PR → flagged
+#   2. Running container: In Progress story with cfg-agent-<N> running → not flagged
+#   3. Open PR: In Progress story with an open PR (even a draft) → not flagged
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PREFLIGHT="${SCRIPT_DIR}/../po-cycle-preflight.py"
+
+if [[ ! -f "${PREFLIGHT}" ]]; then
+  printf 'FAIL: preflight not found at %s\n' "${PREFLIGHT}" >&2
+  exit 1
+fi
+
+echo "stalled_dispatch.test.sh"
+echo "------------------------"
+
+PREFLIGHT_PATH="$PREFLIGHT" python3 - <<'PY'
+import importlib.util, os, sys
+spec = importlib.util.spec_from_file_location("preflight", os.environ["PREFLIGHT_PATH"])
+m = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(m)
+
+ran = 0
+fail = 0
+
+def check(desc, got, want):
+    global ran, fail
+    ran += 1
+    if got == want:
+        print(f"  ok    {desc}")
+    else:
+        fail += 1
+        print(f"  FAIL  {desc}\n         expected: {want!r}\n         actual:   {got!r}")
+
+def mk_pr(story_num, is_draft=False):
+    return {"story_number": story_num, "is_draft": is_draft}
+
+def mk_issue(num, title="Story title"):
+    return {"number": num, "title": title, "item_id": f"item-{num}"}
+
+# ── Case 1: stalled — no container, no PR ──
+result = m.compute_stalled_dispatches(
+    [mk_issue(1678)],
+    containers=["cfg-agent-999"],   # different story running
+    pr_summaries=[mk_pr(100)],      # different story has PR
+)
+check("stalled story is flagged", len(result), 1)
+check("flagged entry has correct number", result[0]["number"], 1678)
+check("flagged entry has item_id", result[0]["item_id"], "item-1678")
+check("flagged entry has reason", "cfg-agent-1678" in result[0]["reason"], True)
+
+# ── Case 2: running container — must NOT be flagged ──
+result = m.compute_stalled_dispatches(
+    [mk_issue(1678)],
+    containers=["cfg-agent-1678"],   # story's container is running
+    pr_summaries=[],
+)
+check("running container — not flagged", len(result), 0)
+
+# ── Case 3: open PR (non-draft) — must NOT be flagged ──
+result = m.compute_stalled_dispatches(
+    [mk_issue(1678)],
+    containers=[],
+    pr_summaries=[mk_pr(1678, is_draft=False)],
+)
+check("open PR (non-draft) — not flagged", len(result), 0)
+
+# ── Case 3b: open draft PR — must NOT be flagged (goes through dispatch-fix) ──
+result = m.compute_stalled_dispatches(
+    [mk_issue(1678)],
+    containers=[],
+    pr_summaries=[mk_pr(1678, is_draft=True)],
+)
+check("open draft PR — not flagged (dispatch-fix path)", len(result), 0)
+
+# ── Pure draft item (number=None) — skip, no container convention ──
+result = m.compute_stalled_dispatches(
+    [{"number": None, "title": "Draft item", "item_id": "PVTI_abc"}],
+    containers=[],
+    pr_summaries=[],
+)
+check("pure draft item (number=None) — skipped", len(result), 0)
+
+# ── Multiple stories: only the stalled one is flagged ──
+result = m.compute_stalled_dispatches(
+    [mk_issue(100), mk_issue(200), mk_issue(300)],
+    containers=["cfg-agent-100"],             # #100 container running
+    pr_summaries=[mk_pr(200)],               # #200 has open PR
+    # #300 has neither → stalled
+)
+check("multi-story: only stalled one flagged", len(result), 1)
+check("multi-story: correct story flagged", result[0]["number"], 300)
+
+# ── Fix container (cfg-agent-pr-fix-<PR>) does NOT count as story container ──
+result = m.compute_stalled_dispatches(
+    [mk_issue(1678)],
+    containers=["cfg-agent-pr-fix-1678"],   # fix container, not story container
+    pr_summaries=[],
+)
+check("pr-fix container does not prevent stall flag", len(result), 1)
+
+# ── Empty inputs — no crash ──
+result = m.compute_stalled_dispatches([], containers=[], pr_summaries=[])
+check("empty inputs — no crash, empty result", result, [])
+
+# ── docker unavailable (containers=None) — treated as empty ──
+result = m.compute_stalled_dispatches(
+    [mk_issue(1678)],
+    containers=None,
+    pr_summaries=[],
+)
+check("containers=None (docker unavailable) — still detects stall", len(result), 1)
+
+print(f"\nran={ran}  fail={fail}")
+sys.exit(1 if fail else 0)
+PY


### PR DESCRIPTION
## Summary

- Adds `compute_stalled_dispatches()` to `po-cycle-preflight.py` to detect `In Progress` stories with no running `cfg-agent-<N>` container and no open PR (the silent stall pattern after a hard container kill)
- Emits `stalled_dispatches` list in the preflight JSON output so the PO cron can re-dispatch each via `po-act.sh dispatch <ITEM_ID>`
- Documents the detection and cron response in `po.md` under new §6a (Stalled-dispatch recovery)
- Unit test (`stalled_dispatch.test.sh`) covers all three AC cases and edge cases

Fixes #1678

## Acceptance Criteria Verification

- [x] An `In Progress` story with no running `cfg-agent-<N>` container and no open PR is flagged in `stalled_dispatches`
- [x] An `In Progress` story whose agent container IS running is not flagged
- [x] An `In Progress` story with an open PR (even a WIP draft) is not flagged as stalled
- [x] Unit test covers all three cases: stalled (flag), running container (no flag), open PR (no flag)
- [x] `.claude/agents/po.md` documents the stalled-dispatch detection and cron response
- [x] `make test-agent-complete` passes

## Specialist Review Results

**QA Test Runner: PASS**
- All 13 unit tests in `stalled_dispatch.test.sh` passed
- Full `make test-agent-complete` suite passed (exit code 0)
- All existing preflight tests unaffected

**QA Code Reviewer: PASS**
- No blocking issues
- Test covers all three AC cases plus edge cases (fix container guard, pure draft items, docker-unavailable, multi-story selectivity)
- Implementation correctness verified (`removeprefix` + `isdigit()` guard is watertight)

**Security Engineer: PASS**
- security-precommit: PASS (no secrets)
- check-architecture: PASS (no central-provider violations)
- security-scan: PASS (gosec, staticcheck, Trivy, Nancy all clean)
- No command injection: `compute_stalled_dispatches()` is a pure function; data paths from `running_containers()` use fixed-argument subprocess calls with no `shell=True`

## Test Plan

- [x] Run `bash .claude/scripts/tests/stalled_dispatch.test.sh` — 13/13 pass
- [x] Run `bash .claude/scripts/tests/env_routing.test.sh` — 23/23 pass (no regression)
- [x] Run `bash .claude/scripts/tests/preflight_path_regex.test.sh` — 23/23 pass (no regression)
- [x] Run `make test-agent-complete` — all gates pass