### PR TITLE
steward/controller: enforce 1 MB output cap and 4 MB controller ceiling (Issue #1978)

### DIFF
--- a/features/controller/dispatcher/dispatcher.go
+++ b/features/controller/dispatcher/dispatcher.go
@@ -467,17 +467,17 @@ func (d *Dispatcher) handleCompletionEvent(ctx context.Context, event *controlpl
 		if ec, ok := event.Details["exit_code"].(float64); ok {
 			result.ExitCode = int(ec)
 		}
-		// The steward emits stdout_preview/stderr_preview (execute_script.go);
-		// accept the bare stdout/stderr keys too for forward compatibility
-		// (Issue #1995, root cause D — key alignment).
-		if stdout, ok := event.Details["stdout_preview"].(string); ok {
+		// Prefer the full capped stdout/stderr keys (Issue #1978: steward now sends up to 1 MB
+		// under the "stdout"/"stderr" keys). Fall back to stdout_preview/stderr_preview (4 KB)
+		// for compatibility with older stewards that only send preview keys.
+		if stdout, ok := event.Details["stdout"].(string); ok {
 			result.Stdout = stdout
-		} else if stdout, ok := event.Details["stdout"].(string); ok {
+		} else if stdout, ok := event.Details["stdout_preview"].(string); ok {
 			result.Stdout = stdout
 		}
-		if stderr, ok := event.Details["stderr_preview"].(string); ok {
+		if stderr, ok := event.Details["stderr"].(string); ok {
 			result.Stderr = stderr
-		} else if stderr, ok := event.Details["stderr"].(string); ok {
+		} else if stderr, ok := event.Details["stderr_preview"].(string); ok {
 			result.Stderr = stderr
 		}
 		// On a command_failed event there is no result; surface the error string
@@ -489,6 +489,21 @@ func (d *Dispatcher) handleCompletionEvent(ctx context.Context, event *controlpl
 		}
 		if durMs, ok := event.Details["duration_ms"].(float64); ok {
 			result.Duration = time.Duration(durMs) * time.Millisecond
+		}
+
+		// 4 MB controller ceiling: defense-in-depth against a compromised or buggy steward
+		// bypassing the steward-side 1 MB cap (Issue #1978). Drop oversized output rather
+		// than storing unbounded data. The steward-side cap (1 MB) should prevent this from
+		// triggering under normal operation.
+		const controllerOutputCapBytes = 4 * 1024 * 1024
+		if len(result.Stdout)+len(result.Stderr) > controllerOutputCapBytes {
+			d.logger.Error("Execution output exceeds 4 MB controller ceiling; dropping output",
+				"device_id", logging.SanitizeLogValue(deviceID),
+				"execution_id", logging.SanitizeLogValue(executionID),
+				"stdout_bytes", len(result.Stdout),
+				"stderr_bytes", len(result.Stderr))
+			result.Stdout = ""
+			result.Stderr = ""
 		}
 	}
 

--- a/features/controller/dispatcher/dispatcher_test.go
+++ b/features/controller/dispatcher/dispatcher_test.go
@@ -111,8 +111,9 @@ func (p *testControlPlane) injectCompletion(ctx context.Context, deviceID, execu
 }
 
 // injectCompletionWithOutput simulates a steward publishing EventScriptCompleted
-// with the stdout_preview/stderr_preview keys the steward actually emits
-// (execute_script.go), used to verify output capture (Issue #1995, root cause D).
+// with the stdout/stderr keys current stewards emit (Issue #1978: steward now sends
+// full capped output under "stdout"/"stderr"; controller prefers these over *_preview).
+// Used to verify output capture (Issue #1995, root cause D).
 func (p *testControlPlane) injectCompletionWithOutput(ctx context.Context, deviceID, executionID string, exitCode int, stdout, stderr string) error {
 	p.mu.Lock()
 	h := p.eventHandler
@@ -129,10 +130,24 @@ func (p *testControlPlane) injectCompletionWithOutput(ctx context.Context, devic
 		Details: map[string]interface{}{
 			"execution_id":   executionID,
 			"exit_code":      float64(exitCode),
-			"stdout_preview": stdout,
+			"stdout":         stdout,
+			"stderr":         stderr,
+			"stdout_preview": stdout, // kept for compat; dispatcher prefers "stdout"
 			"stderr_preview": stderr,
 			"duration_ms":    float64(100),
 		},
+	}
+	return h(ctx, event)
+}
+
+// injectEvent sends an arbitrary EventScriptCompleted event to the registered handler.
+// Used for edge-case tests (e.g. oversized output) that need full control over event fields.
+func (p *testControlPlane) injectEvent(ctx context.Context, event *controlplaneTypes.Event) error {
+	p.mu.Lock()
+	h := p.eventHandler
+	p.mu.Unlock()
+	if h == nil {
+		return fmt.Errorf("no event handler registered")
 	}
 	return h(ctx, event)
 }
@@ -1194,8 +1209,69 @@ func TestDispatcher_OutputThreadedToJobRecord(t *testing.T) {
 	jobs, err := manager.ListRunJobs(context.Background(), runID)
 	require.NoError(t, err)
 	require.Len(t, jobs, 1)
-	assert.Equal(t, "CFG-70-02\n", jobs[0].Output, "stdout_preview must be persisted as Output")
+	assert.Equal(t, "CFG-70-02\n", jobs[0].Output, "stdout must be persisted as Output")
 	assert.Equal(t, 0, jobs[0].ExitCode)
+}
+
+// TestDispatcher_OutputExceedsControllerCeiling verifies Issue #1978 AC:
+// when a completion event carries combined stdout+stderr exceeding the 4 MB controller
+// ceiling, the dispatcher drops the output before storage so the job record has empty
+// output rather than unbounded data. This is defense-in-depth against a compromised
+// steward bypassing the steward-side 1 MB cap.
+func TestDispatcher_OutputExceedsControllerCeiling(t *testing.T) {
+	store := run.NewRunStoreSQL(mustOpenMemDB(t))
+	require.NoError(t, store.Init(context.Background()))
+	manager := run.NewManager(store, nil)
+
+	const runID = "run-ceiling-1"
+	require.NoError(t, store.CreateRun(&run.RunRecord{
+		RunID: runID, TenantID: "tenant-abc", CreatedAt: time.Now().UTC(),
+		Status: run.RunStatusRunning, JobCount: 1,
+	}))
+	require.NoError(t, store.CreateJob(&run.JobRecord{
+		JobID: "job-ceiling", RunID: runID, DeviceID: "device-1",
+		ExecutionID: "exec-ceiling", Status: run.JobStatusPending, CreatedAt: time.Now().UTC(),
+	}))
+
+	cp := &testControlPlane{}
+	q := newTestQueue(t, nil)
+	d := newTestDispatcher(t, q, cp)
+	d.SetRunCompletionSink(manager)
+
+	require.NoError(t, d.Start(context.Background()))
+	t.Cleanup(d.Stop)
+
+	require.NoError(t, q.QueueExecution("device-1", runTrackedExec("exec-ceiling", "script-ceiling", runID, "job-ceiling")))
+	d.OnHeartbeat("device-1")
+	require.Eventually(t, func() bool { return cp.sentCount() >= 1 }, 2*time.Second, 10*time.Millisecond)
+
+	// Inject an event with 5 MB of stdout — exceeds the 4 MB controller ceiling.
+	fiveMBOutput := strings.Repeat("X", 5*1024*1024)
+	oversizedEvent := &controlplaneTypes.Event{
+		ID:        "evt-ceiling",
+		Type:      controlplaneTypes.EventScriptCompleted,
+		StewardID: "device-1",
+		Timestamp: time.Now(),
+		Details: map[string]interface{}{
+			"execution_id": "exec-ceiling",
+			"exit_code":    float64(0),
+			"stdout":       fiveMBOutput,
+			"stderr":       "",
+			"duration_ms":  float64(100),
+		},
+	}
+	require.NoError(t, cp.injectEvent(context.Background(), oversizedEvent))
+
+	require.Eventually(t, func() bool {
+		jobs, err := manager.ListRunJobs(context.Background(), runID)
+		return err == nil && len(jobs) == 1 && jobs[0].Status == run.JobStatusCompleted
+	}, 2*time.Second, 10*time.Millisecond, "job must reach terminal state despite ceiling enforcement")
+
+	jobs, err := manager.ListRunJobs(context.Background(), runID)
+	require.NoError(t, err)
+	require.Len(t, jobs, 1)
+	assert.Empty(t, jobs[0].Output,
+		"output exceeding the 4 MB ceiling must be dropped — job record must have empty output")
 }
 
 // mustOpenMemDB opens an in-memory SQLite database closed via t.Cleanup.

--- a/features/steward/commands/execute_script.go
+++ b/features/steward/commands/execute_script.go
@@ -21,6 +21,8 @@ import (
 
 const (
 	scriptPreviewMaxBytes   = 4096
+	execOutputHardCapBytes  = 1 << 20 // 1 MB combined stdout+stderr cap
+	execOutputTruncMarker   = "\n[output truncated at 1 MB]"
 	defaultScriptTimeoutSec = 900 // 15 minutes
 )
 
@@ -194,6 +196,9 @@ func (h *Handler) handleExecuteScript(ctx context.Context, cmd *cpTypes.Command)
 		return nil
 	}
 
+	// Apply 1 MB hard cap on combined stdout+stderr before generating previews.
+	result.Stdout, result.Stderr = applyOutputCap(result.Stdout, result.Stderr, execOutputHardCapBytes)
+
 	// Truncate previews to cap; excess bytes are silently dropped.
 	// stdout_preview and stderr_preview are NEVER logged — only byte counts are.
 	stdoutPreview := truncatePreview(result.Stdout, scriptPreviewMaxBytes)
@@ -219,6 +224,8 @@ func (h *Handler) handleExecuteScript(ctx context.Context, cmd *cpTypes.Command)
 			"duration_ms":    result.Duration.Milliseconds(),
 			"stdout_preview": stdoutPreview,
 			"stderr_preview": stderrPreview,
+			"stdout":         result.Stdout, // full capped output (up to 1 MB); controller reads this key
+			"stderr":         result.Stderr, // full capped output (up to 1 MB); controller reads this key
 		},
 	})
 	return nil
@@ -239,6 +246,28 @@ func resolveRelayUID(execCtx script.ExecutionContext, logger logging.Logger) int
 		return os.Getuid()
 	}
 	return uid
+}
+
+// applyOutputCap enforces a combined hard cap on stdout+stderr.
+// stdout is filled first; remaining capacity goes to stderr.
+// Appends execOutputTruncMarker to whichever buffer is truncated.
+// Returns unchanged strings when len(stdout)+len(stderr) <= capBytes.
+func applyOutputCap(stdout, stderr string, capBytes int) (string, string) {
+	if len(stdout)+len(stderr) <= capBytes {
+		return stdout, stderr
+	}
+	markerLen := len(execOutputTruncMarker)
+	available := capBytes - markerLen
+	if available < 0 {
+		available = 0
+	}
+	if len(stdout) >= available {
+		// stdout alone fills or exceeds the available budget; drop stderr.
+		return stdout[:available] + execOutputTruncMarker, ""
+	}
+	// stdout fits; give stderr the remaining budget.
+	remaining := available - len(stdout)
+	return stdout, stderr[:remaining] + execOutputTruncMarker
 }
 
 // truncatePreview returns at most maxBytes bytes of s; excess is silently dropped.

--- a/features/steward/commands/execute_script_test.go
+++ b/features/steward/commands/execute_script_test.go
@@ -19,6 +19,154 @@ import (
 	"github.com/cfgis/cfgms/pkg/logging"
 )
 
+// ---------------------------------------------------------------------------
+// Issue #1978 — 1 MB hard cap on exec output.
+// ---------------------------------------------------------------------------
+
+// overCapStdoutScriptBody returns a script that writes approximately 2 MB to stdout
+// — twice the execOutputHardCapBytes limit — using fast shell builtins.
+func overCapStdoutScriptBody() string {
+	if runtime.GOOS == "windows" {
+		// PowerShell: write 2 MB of 'A' without buffering overhead.
+		return `[Console]::Out.Write([string]::new('A', 2097152))`
+	}
+	// bash: yes generates an infinite stream; head -c cuts at exactly 2 MB.
+	return `yes A | head -c 2097152`
+}
+
+// underCapStdoutScriptBody returns a script that writes 512 KB to stdout —
+// well under the execOutputHardCapBytes limit — using fast shell builtins.
+func underCapStdoutScriptBody() string {
+	if runtime.GOOS == "windows" {
+		return `[Console]::Out.Write([string]::new('A', 524288))`
+	}
+	return `yes A | head -c 524288`
+}
+
+// ---------------------------------------------------------------------------
+// Unit tests for applyOutputCap.
+// ---------------------------------------------------------------------------
+
+func TestApplyOutputCap_BelowLimit_NoChange(t *testing.T) {
+	out, err := applyOutputCap("hello", "world", execOutputHardCapBytes)
+	assert.Equal(t, "hello", out)
+	assert.Equal(t, "world", err)
+}
+
+func TestApplyOutputCap_AtExactLimit_NoChange(t *testing.T) {
+	stdout := strings.Repeat("A", execOutputHardCapBytes)
+	out, err := applyOutputCap(stdout, "", execOutputHardCapBytes)
+	assert.Equal(t, stdout, out, "output exactly at limit must not be truncated")
+	assert.Empty(t, err)
+	assert.NotContains(t, out, execOutputTruncMarker)
+}
+
+// TestApplyOutputCap_StdoutExceedsLimit is a required test verifying that
+// when a command produces 2 MB of stdout, the capped output contains the
+// truncation marker and does not exceed the 1 MB ceiling (plus marker length).
+func TestApplyOutputCap_StdoutExceedsLimit_TruncatedWithMarker(t *testing.T) {
+	twoMB := strings.Repeat("A", 2*execOutputHardCapBytes)
+	out, err := applyOutputCap(twoMB, "", execOutputHardCapBytes)
+	assert.True(t, strings.HasSuffix(out, execOutputTruncMarker),
+		"capped stdout must end with the truncation marker")
+	assert.Empty(t, err, "stderr must be empty when stdout fills the cap")
+	assert.LessOrEqual(t, len(out)+len(err), execOutputHardCapBytes+len(execOutputTruncMarker),
+		"combined capped output must not exceed cap + marker")
+	assert.NotEqual(t, twoMB, out, "output must be shorter than original 2 MB")
+}
+
+func TestApplyOutputCap_CombinedExceedsLimit_StderrTruncated(t *testing.T) {
+	halfCap := strings.Repeat("A", execOutputHardCapBytes/2)
+	// stdout alone fits; adding extra stderr pushes combined over the cap.
+	out, err := applyOutputCap(halfCap, halfCap+strings.Repeat("B", 100), execOutputHardCapBytes)
+	assert.Equal(t, halfCap, out, "stdout must be unchanged when it fits in the cap")
+	assert.True(t, strings.HasSuffix(err, execOutputTruncMarker),
+		"stderr must end with the truncation marker when it is the buffer that overflows")
+	assert.LessOrEqual(t, len(out)+len(err), execOutputHardCapBytes+len(execOutputTruncMarker))
+}
+
+func TestApplyOutputCap_EmptyInputs_NoChange(t *testing.T) {
+	out, err := applyOutputCap("", "", execOutputHardCapBytes)
+	assert.Empty(t, out)
+	assert.Empty(t, err)
+}
+
+// ---------------------------------------------------------------------------
+// Integration tests via handleExecuteScript — required by AC.
+// ---------------------------------------------------------------------------
+
+// TestExecuteScriptHandler_OutputOverCap_TruncatedWithMarker is a required test (Issue #1978 AC):
+// an exec command producing 2 MB of output must result in capped output ending with the
+// truncation marker. Verified via the full stdout field in EventScriptCompleted.
+func TestExecuteScriptHandler_OutputOverCap_TruncatedWithMarker(t *testing.T) {
+	cb, getEvents := collectEvents()
+	h, err := New(&Config{StewardID: "steward-test", OnStatus: cb, Logger: newTestLogger(t)})
+	require.NoError(t, err)
+	h.RegisterExecuteScriptHandler()
+
+	scriptContent := base64.StdEncoding.EncodeToString([]byte(overCapStdoutScriptBody()))
+	sc := testSignedCommandWithParams("esc-cap-over-001", cpTypes.CommandExecuteScript, map[string]interface{}{
+		"script_content": scriptContent,
+		"shell":          platformShell(),
+		"execution_id":   "esc-cap-over-001",
+	})
+
+	require.NoError(t, h.HandleCommand(context.Background(), sc))
+	h.Wait()
+
+	evt := firstEventOfType(getEvents(), cpTypes.EventScriptCompleted)
+	require.NotNil(t, evt, "expected EventScriptCompleted event")
+
+	// Full capped output is sent under the "stdout" key.
+	stdout, ok := evt.Details["stdout"].(string)
+	require.True(t, ok, "stdout field must be present and a string in EventScriptCompleted")
+
+	assert.True(t, strings.HasSuffix(stdout, execOutputTruncMarker),
+		"capped stdout must end with %q; got %d bytes ending in: %q",
+		execOutputTruncMarker, len(stdout), lastN(stdout, 50))
+	assert.LessOrEqual(t, len(stdout), execOutputHardCapBytes+len(execOutputTruncMarker),
+		"capped stdout must not exceed 1 MB + marker length")
+}
+
+// TestExecuteScriptHandler_OutputUnderCap_CapturedFully is a required test (Issue #1978 AC):
+// an exec command producing under 1 MB of output must be captured fully without a truncation marker.
+func TestExecuteScriptHandler_OutputUnderCap_CapturedFully(t *testing.T) {
+	cb, getEvents := collectEvents()
+	h, err := New(&Config{StewardID: "steward-test", OnStatus: cb, Logger: newTestLogger(t)})
+	require.NoError(t, err)
+	h.RegisterExecuteScriptHandler()
+
+	scriptContent := base64.StdEncoding.EncodeToString([]byte(underCapStdoutScriptBody()))
+	sc := testSignedCommandWithParams("esc-cap-under-001", cpTypes.CommandExecuteScript, map[string]interface{}{
+		"script_content": scriptContent,
+		"shell":          platformShell(),
+		"execution_id":   "esc-cap-under-001",
+	})
+
+	require.NoError(t, h.HandleCommand(context.Background(), sc))
+	h.Wait()
+
+	evt := firstEventOfType(getEvents(), cpTypes.EventScriptCompleted)
+	require.NotNil(t, evt, "expected EventScriptCompleted event")
+
+	stdout, ok := evt.Details["stdout"].(string)
+	require.True(t, ok, "stdout field must be present and a string in EventScriptCompleted")
+
+	assert.NotContains(t, stdout, execOutputTruncMarker,
+		"output under 1 MB must not contain the truncation marker")
+	// 512 KB = 524288; allow for newlines added by the shell.
+	assert.GreaterOrEqual(t, len(stdout), 500*1024,
+		"output under cap must not be silently dropped (expected ~512 KB)")
+}
+
+// lastN returns the last n bytes of s as a string, for readable test failure messages.
+func lastN(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[len(s)-n:]
+}
+
 // TestResolveRelayUID_SystemContext verifies that a system-context script
 // resolves to the steward process UID, making the relay socket chown a no-op.
 func TestResolveRelayUID_SystemContext(t *testing.T) {


### PR DESCRIPTION
## Summary

- **Steward**: adds `applyOutputCap()` in `execute_script.go` that enforces a 1 MB combined stdout+stderr cap; when the limit is reached appends `\n[output truncated at 1 MB]` to the captured buffer. Full capped output (≤1 MB) is now included in `EventScriptCompleted` under `stdout`/`stderr` keys alongside the existing 4 KB `stdout_preview`/`stderr_preview` fields.
- **Controller dispatcher**: updated to prefer the `stdout`/`stderr` keys over `stdout_preview`/`stderr_preview` (falls back for compat with older stewards), and added a 4 MB defense-in-depth ceiling that drops oversized output before storage — protecting against a compromised steward that bypasses the steward-side cap.
- **Tests**: five unit tests for `applyOutputCap`, two required integration tests via real exec commands (over-cap and under-cap), one dispatcher ceiling test.

Fixes #1978

## Architecture note on "HTTP 413"

The story spec references an HTTP 413 response for the controller ceiling. The exec result path in CFGMS is gRPC-based (steward pushes `EventScriptCompleted` events), not HTTP — there is no HTTP endpoint that ingests exec results. The 4 MB ceiling is therefore enforced in `dispatcher.handleCompletionEvent()`, which is the correct injection point. The protection is equivalent: oversized output is dropped and an error is logged before storage.

## Specialist review results

| Reviewer | Verdict |
|---|---|
| qa-test-runner | ✅ PASS — all gates including cross-platform build, race detection, integration tests |
| qa-code-reviewer | ✅ PASS — no mocks, no skips, real components, error paths covered |
| security-engineer | ✅ PASS — log injection clean, buffer safety verified, no central provider violations |

## Test plan

- [x] `TestApplyOutputCap_BelowLimit_NoChange` — no-op when under cap
- [x] `TestApplyOutputCap_AtExactLimit_NoChange` — no-op at exactly 1 MB
- [x] `TestApplyOutputCap_StdoutExceedsLimit_TruncatedWithMarker` — required: 2 MB stdout → truncated with marker
- [x] `TestApplyOutputCap_CombinedExceedsLimit_StderrTruncated` — combined over cap → stderr truncated
- [x] `TestApplyOutputCap_EmptyInputs_NoChange` — empty strings safe
- [x] `TestExecuteScriptHandler_OutputOverCap_TruncatedWithMarker` — required integration test: exec 2 MB → marker present
- [x] `TestExecuteScriptHandler_OutputUnderCap_CapturedFully` — required integration test: exec 512 KB → no marker
- [x] `TestDispatcher_OutputExceedsControllerCeiling` — 5 MB event → job record has empty output
- [x] `make test-agent-complete` passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)