### PR TITLE
fleet/selector: add id: selector key for direct steward targeting (Issue #1913)

### DIFF
--- a/features/controller/api/handlers_fleet_test.go
+++ b/features/controller/api/handlers_fleet_test.go
@@ -194,6 +194,108 @@ func TestHandleResolveSelector_FleetQueryError_Returns500(t *testing.T) {
 	assert.Equal(t, "INTERNAL_ERROR", resp.Error.Code)
 }
 
+// ── handleResolveSelector: id: selector ──────────────────────────────────────
+
+// TestHandleResolveSelector_IDSelector_SingleMatch verifies that id:<steward-id>
+// returns the one matching steward and nothing else (exact match semantics).
+func TestHandleResolveSelector_IDSelector_SingleMatch(t *testing.T) {
+	server := setupTestServer(t)
+	server.fleetQuery = seededFleetQuery(
+		makeSeedSteward("steward-1780659937223058807", "host-a", "linux", "amd64", "prod"),
+		makeSeedSteward("steward-other", "host-b", "linux", "arm64", "dev"),
+	)
+
+	rec := postResolveSelector(server, `{"selector":"id:steward-1780659937223058807"}`)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var resp APIResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	list, ok := resp.Data.([]interface{})
+	require.True(t, ok)
+	require.Len(t, list, 1, "only the targeted steward should be returned")
+
+	item := list[0].(map[string]interface{})
+	assert.Equal(t, "steward-1780659937223058807", item["id"])
+}
+
+// TestHandleResolveSelector_IDSelector_NoMatch verifies that id: with an unknown
+// steward ID returns an empty result set without error (not 404).
+func TestHandleResolveSelector_IDSelector_NoMatch(t *testing.T) {
+	server := setupTestServer(t)
+	server.fleetQuery = seededFleetQuery(
+		makeSeedSteward("steward-known", "host-a", "linux", "amd64", "prod"),
+	)
+
+	rec := postResolveSelector(server, `{"selector":"id:steward-nonexistent"}`)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var resp APIResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	list, ok := resp.Data.([]interface{})
+	require.True(t, ok)
+	assert.Empty(t, list, "unknown steward ID must return empty result set, not an error")
+}
+
+// TestHandleResolveSelector_IDSelector_MultiValue verifies that id:a,b uses OR
+// semantics — a steward matching either ID is included.
+func TestHandleResolveSelector_IDSelector_MultiValue(t *testing.T) {
+	server := setupTestServer(t)
+	server.fleetQuery = seededFleetQuery(
+		makeSeedSteward("steward-abc", "host-a", "linux", "amd64", "prod"),
+		makeSeedSteward("steward-def", "host-b", "windows", "amd64", "prod"),
+		makeSeedSteward("steward-other", "host-c", "linux", "arm64", "dev"),
+	)
+
+	rec := postResolveSelector(server, `{"selector":"id:steward-abc,steward-def"}`)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var resp APIResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	list, ok := resp.Data.([]interface{})
+	require.True(t, ok)
+	require.Len(t, list, 2, "both comma-separated IDs should be returned")
+
+	ids := make([]string, len(list))
+	for i, item := range list {
+		ids[i] = item.(map[string]interface{})["id"].(string)
+	}
+	assert.ElementsMatch(t, []string{"steward-abc", "steward-def"}, ids)
+}
+
+// TestHandleResolveSelector_IDSelector_AND_WithOS verifies AND semantics when
+// id: is combined with another key — the steward must satisfy both.
+func TestHandleResolveSelector_IDSelector_AND_WithOS(t *testing.T) {
+	server := setupTestServer(t)
+	server.fleetQuery = seededFleetQuery(
+		makeSeedSteward("steward-linux", "host-a", "linux", "amd64", "prod"),
+		makeSeedSteward("steward-win", "host-b", "windows", "amd64", "prod"),
+	)
+
+	// steward-linux + os:windows → no match (AND semantics across keys).
+	rec := postResolveSelector(server, `{"selector":"id:steward-linux os:windows"}`)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var resp APIResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	list, ok := resp.Data.([]interface{})
+	require.True(t, ok)
+	assert.Empty(t, list, "id: and os: must be AND-combined — no match expected")
+}
+
+// TestHandleResolveSelector_IDSelector_UnknownKeyStillRejected verifies that other
+// unknown keys remain rejected now that id: is in the accepted set.
+func TestHandleResolveSelector_IDSelector_UnknownKeyStillRejected(t *testing.T) {
+	server := setupTestServer(t)
+
+	rec := postResolveSelector(server, `{"selector":"unknownkey:value"}`)
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+
+	var resp ErrorResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Equal(t, "INVALID_SELECTOR", resp.Error.Code)
+	assert.Contains(t, resp.Error.Message, "id", "error message must list id in the valid key set")
+}
+
 // TestHandleResolveSelector_TenantIsolation verifies that a caller authenticated
 // as tenant-a cannot see tenant-b stewards even when the selector would otherwise
 // match them (e.g. "all"). The authenticated tenant is always AND-ed onto the filter.

--- a/features/controller/fleet/fleet.go
+++ b/features/controller/fleet/fleet.go
@@ -37,6 +37,7 @@ type Filter struct {
 	Hostname      string            // Substring match on DNA["hostname"] (kept for backward compat)
 	Name          string            // Glob match on DNA["hostname"] via path.Match (use name: selector key)
 	DeviceID      string            // Match by exact device ID (id: selector)
+	IDs           []string          // Match stewards whose ID is any of these (OR within the set; id: selector)
 }
 
 // ParseTargetSelector parses a space-separated key:value selector string into a Filter.

--- a/features/controller/fleet/memory.go
+++ b/features/controller/fleet/memory.go
@@ -5,6 +5,7 @@ package fleet
 import (
 	"context"
 	"path"
+	"slices"
 	"strings"
 )
 
@@ -53,6 +54,9 @@ func matchesFilter(s StewardData, f Filter) bool {
 	}
 
 	if f.DeviceID != "" && s.ID != f.DeviceID {
+		return false
+	}
+	if len(f.IDs) > 0 && !slices.Contains(f.IDs, s.ID) {
 		return false
 	}
 	if f.TenantID != "" && s.TenantID != f.TenantID {

--- a/features/controller/fleet/memory_test.go
+++ b/features/controller/fleet/memory_test.go
@@ -333,3 +333,55 @@ func TestMemoryQuery_Tags_WhitespaceStripped(t *testing.T) {
 	require.NoError(t, err)
 	assert.Len(t, results, 1)
 }
+
+func TestMemoryQuery_FilterByIDs_SingleMatch(t *testing.T) {
+	q := newQuery(
+		testSteward("device-001", "t", "online", nil),
+		testSteward("device-002", "t", "online", nil),
+		testSteward("device-003", "t", "online", nil),
+	)
+
+	results, err := q.Search(context.Background(), Filter{IDs: []string{"device-001"}})
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	assert.Equal(t, "device-001", results[0].ID)
+}
+
+func TestMemoryQuery_FilterByIDs_MultiMatch_OR(t *testing.T) {
+	q := newQuery(
+		testSteward("device-001", "t", "online", nil),
+		testSteward("device-002", "t", "online", nil),
+		testSteward("device-003", "t", "online", nil),
+	)
+
+	results, err := q.Search(context.Background(), Filter{IDs: []string{"device-001", "device-003"}})
+	require.NoError(t, err)
+	require.Len(t, results, 2)
+	ids := []string{results[0].ID, results[1].ID}
+	assert.ElementsMatch(t, []string{"device-001", "device-003"}, ids)
+}
+
+func TestMemoryQuery_FilterByIDs_NoMatch(t *testing.T) {
+	q := newQuery(
+		testSteward("device-001", "t", "online", nil),
+	)
+
+	results, err := q.Search(context.Background(), Filter{IDs: []string{"nonexistent"}})
+	require.NoError(t, err)
+	assert.Empty(t, results)
+}
+
+func TestMemoryQuery_FilterByIDs_AND_WithOS(t *testing.T) {
+	q := newQuery(
+		testSteward("device-001", "t", "online", map[string]string{"os": "linux"}),
+		testSteward("device-002", "t", "online", map[string]string{"os": "windows"}),
+	)
+
+	// IDs includes device-001, but device-001 is linux not windows — no match.
+	results, err := q.Search(context.Background(), Filter{
+		IDs: []string{"device-001"},
+		OS:  "windows",
+	})
+	require.NoError(t, err)
+	assert.Empty(t, results)
+}

--- a/pkg/fleet/selector/selector.go
+++ b/pkg/fleet/selector/selector.go
@@ -14,6 +14,7 @@ import (
 // The expression is a space-separated list of key:value terms. Values may be
 // double-quoted to include spaces. Supported keys:
 //
+//	id:<steward-id>    — exact steward ID match; comma-separated for OR (id:a,b)
 //	name:<hostname>    — hostname match; trailing * enables prefix-glob
 //	os:<value>         — exact OS match
 //	platform:<value>   — exact platform match
@@ -119,6 +120,8 @@ func tokenize(expr string) ([]term, error) {
 // applyTerm merges a parsed key:value term into the filter.
 func applyTerm(f *fleet.Filter, t term) error {
 	switch {
+	case t.key == "id":
+		f.IDs = append(f.IDs, strings.Split(t.value, ",")...)
 	case t.key == "name":
 		f.Hostname = t.value
 	case t.key == "os":
@@ -139,7 +142,7 @@ func applyTerm(f *fleet.Filter, t term) error {
 		}
 		f.DNAAttributes[attr] = t.value
 	default:
-		return fmt.Errorf("unknown selector key %q: valid keys are name, os, platform, arch, tag, dna.<key>", t.key)
+		return fmt.Errorf("unknown selector key %q: valid keys are id, name, os, platform, arch, tag, dna.<key>", t.key)
 	}
 	return nil
 }

--- a/pkg/fleet/selector/selector_test.go
+++ b/pkg/fleet/selector/selector_test.go
@@ -279,3 +279,50 @@ func TestResolve_Combined_ExactSteward(t *testing.T) {
 	ids := resolveIDs(t, "name:es-hv0* os:linux arch:arm64")
 	assert.Equal(t, []string{"s-linux-arm64"}, ids)
 }
+
+// ── id: selector tests ────────────────────────────────────────────────────────
+
+func TestParse_ID_Single(t *testing.T) {
+	f, err := Parse("id:s-linux-arm64")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"s-linux-arm64"}, f.IDs)
+}
+
+func TestParse_ID_MultiValue(t *testing.T) {
+	f, err := Parse("id:s-linux-arm64,s-windows")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"s-linux-arm64", "s-windows"}, f.IDs)
+}
+
+func TestParse_UnknownKey_ErrorIncludesID(t *testing.T) {
+	_, err := Parse("typo:value")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "id")
+}
+
+func TestResolve_ID_ExactMatch(t *testing.T) {
+	ids := resolveIDs(t, "id:s-linux-arm64")
+	assert.Equal(t, []string{"s-linux-arm64"}, ids)
+}
+
+func TestResolve_ID_NoMatch(t *testing.T) {
+	ids := resolveIDs(t, "id:nonexistent-steward")
+	assert.Empty(t, ids)
+}
+
+func TestResolve_ID_MultiValue_OR(t *testing.T) {
+	ids := resolveIDs(t, "id:s-linux-arm64,s-windows")
+	assert.ElementsMatch(t, []string{"s-linux-arm64", "s-windows"}, ids)
+}
+
+func TestResolve_ID_Combined_AND_WithOS(t *testing.T) {
+	// s-linux-arm64 is linux; combining with os:windows yields no match.
+	ids := resolveIDs(t, `id:s-linux-arm64 os:"windows server"`)
+	assert.Empty(t, ids)
+}
+
+func TestResolve_ID_Combined_AND_Matches(t *testing.T) {
+	// id:s-linux-arm64 AND os:linux — s-linux-arm64 is linux, so exactly one match.
+	ids := resolveIDs(t, "id:s-linux-arm64 os:linux")
+	assert.Equal(t, []string{"s-linux-arm64"}, ids)
+}

--- a/test/e2e/fleet/selector_test.go
+++ b/test/e2e/fleet/selector_test.go
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+package fleet
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// resolveSelectorResponse mirrors the data envelope from POST /api/v1/fleet/resolve.
+type resolveSelectorResponse struct {
+	Data []struct {
+		ID string `json:"id"`
+	} `json:"data"`
+}
+
+// resolveSelector calls POST /api/v1/fleet/resolve with the given selector expression
+// and returns the list of matching steward IDs. Uses s.httpClient (mTLS admin bundle).
+func (s *FleetTestSuite) resolveSelector(t *testing.T, selector string) ([]string, int) {
+	t.Helper()
+
+	body, err := json.Marshal(map[string]string{"selector": selector})
+	require.NoError(t, err, "marshal resolve request")
+
+	url := fmt.Sprintf("%s/api/v1/fleet/resolve", s.controllerURL)
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, url,
+		bytes.NewReader(body))
+	require.NoError(t, err, "build resolve request")
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := s.httpClient.Do(req)
+	require.NoError(t, err, "POST /api/v1/fleet/resolve")
+	defer func() { _ = resp.Body.Close() }()
+
+	rawBody, err := io.ReadAll(resp.Body)
+	require.NoError(t, err, "read resolve response body")
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, resp.StatusCode
+	}
+
+	var result resolveSelectorResponse
+	require.NoError(t, json.Unmarshal(rawBody, &result), "unmarshal resolve response: %s", string(rawBody))
+
+	ids := make([]string, 0, len(result.Data))
+	for _, item := range result.Data {
+		ids = append(ids, item.ID)
+	}
+	return ids, resp.StatusCode
+}
+
+// TestFleetIDSelector exercises the id: selector key against real registered stewards.
+//
+// This test satisfies AC #6 (Issue #1913): an integration test that calls the
+// POST /api/v1/fleet/resolve endpoint with an id: selector where the ID comes from
+// a steward registered during the test run — not seeded in-memory data.
+//
+// Scenarios:
+//   - Single-ID exact match returns the targeted steward and no others
+//   - Unknown ID returns an empty result set (no error)
+//   - Multi-value id:a,b selects both stewards (OR semantics)
+func TestFleetIDSelector(t *testing.T) {
+	s := setupFleetSuite(t)
+
+	steward1ID := s.stewardIDs["fleet-steward-1"]
+	steward2ID := s.stewardIDs["fleet-steward-2"]
+
+	// Both stewards must be connected before selector tests can be meaningful.
+	for _, id := range []string{steward1ID, steward2ID} {
+		if !s.waitForConvergence(t, id, 30*time.Second) {
+			t.Fatalf("steward %s not connected within 30s; cannot test id: selector", id)
+		}
+	}
+
+	t.Run("SingleIDExactMatch", func(t *testing.T) {
+		ids, status := s.resolveSelector(t, "id:"+steward1ID)
+		require.Equal(t, http.StatusOK, status)
+		require.Len(t, ids, 1, "id: selector must return exactly the targeted steward; got %v", ids)
+		assert.Equal(t, steward1ID, ids[0])
+	})
+
+	t.Run("UnknownIDReturnsEmpty", func(t *testing.T) {
+		ids, status := s.resolveSelector(t, "id:steward-nonexistent-0000000000")
+		require.Equal(t, http.StatusOK, status, "unknown id: must return 200 with empty result, not an error")
+		assert.Empty(t, ids, "unknown steward ID must yield empty result set")
+	})
+
+	t.Run("MultiValueOR", func(t *testing.T) {
+		selector := fmt.Sprintf("id:%s,%s", steward1ID, steward2ID)
+		ids, status := s.resolveSelector(t, selector)
+		require.Equal(t, http.StatusOK, status)
+		require.Len(t, ids, 2, "comma-separated id: must return both stewards (OR semantics); got %v", ids)
+		assert.ElementsMatch(t, []string{steward1ID, steward2ID}, ids)
+	})
+}


### PR DESCRIPTION
## Summary

- Adds `id:<steward-id>` as a first-class selector key in `pkg/fleet/selector`, accepting the natural operator expression that was previously rejected with "unrecognised selector key 'id'"
- Multi-value `id:abc,def` splits on commas with OR semantics (either steward matches); combined with other keys uses AND semantics across keys
- Error message for unknown selector keys now lists `id` in the accepted set

Fixes #1913

## What Changed

**`pkg/fleet/selector/selector.go`** — added `id:` case to `applyTerm`; comma-separated values split into `Filter.IDs []string`; updated doc comment and error message.

**`features/controller/fleet/fleet.go`** — added `IDs []string` to `Filter` struct for multi-value ID matching with OR semantics (separate from existing `DeviceID string` used by `ParseTargetSelector`).

**`features/controller/fleet/memory.go`** — `matchesFilter` checks `Filter.IDs` via `slices.Contains`; AND-combined with all other filter fields.

## Test Coverage

Three levels of test coverage added:

- **`pkg/fleet/selector/selector_test.go`**: parse tests (single, multi-value) + resolution tests (exact match, no match, multi-value OR, AND combo with `os:`, error message lists `id`)
- **`features/controller/fleet/memory_test.go`**: `Filter.IDs` unit tests (single, multi-OR, no-match, AND-with-OS)
- **`features/controller/api/handlers_fleet_test.go`**: 5 handler integration tests exercising the full `handleResolveSelector → selector.Parse → fleet.Search` chain (single match, no match, multi-value OR, AND with os:, unknown key still rejected)

## Specialist Review Results

| Reviewer | Result | Notes |
|----------|--------|-------|
| qa-test-runner | PASS | All Go tests pass across 70+ packages; 2 pre-existing script flakes (GitHub API timing) unrelated to this story |
| qa-code-reviewer | PASS | No blocking issues; tests use real components at all three levels |
| security-engineer | PASS | All security scans pass (gosec, Trivy, Nancy, staticcheck, gitleaks); no injection surface, tenant isolation preserved |