### PR TITLE
storage: flatfile IP-trust store for OSS composite backend (Issue #1900)

### DIFF
--- a/features/controller/server/server.go
+++ b/features/controller/server/server.go
@@ -593,9 +593,9 @@ func New(cfg *config.Config, logger logging.Logger) (*Server, error) {
 		logger.Info("Execution queue and job dispatcher initialized")
 
 		// Wire the IP-trust evaluator into the heartbeat service when the
-		// IP-trust store is available (Issue #1694). The database provider
-		// supplies an IPTrustStore; the OSS composite (flatfile+SQLite) returns
-		// nil, in which case the evaluator is skipped.
+		// IP-trust store is available (Issue #1694). Both the database provider
+		// and the OSS composite (flatfile+SQLite, Issue #1900) supply an
+		// IPTrustStore; the evaluator is skipped only when no store is wired.
 		var heartbeatTrustEvaluator heartbeat.TrustEvaluator
 		if ipTrustStore := storageManager.GetIPTrustStore(); ipTrustStore != nil {
 			stewardStore := storageManager.GetStewardStore()
@@ -982,8 +982,6 @@ func New(cfg *config.Config, logger logging.Logger) (*Server, error) {
 			httpServer.SetApprovalHook(api.NewIPTrustApprovalHook(ipTrustStore, logger))
 			if ipTrustStore != nil {
 				logger.Info("IP-trust registration approval hook wired (Issue #1695)")
-			} else {
-				logger.Warn("IP-trust store not available (OSS composite storage); registrations will quarantine until an IP-trust store is wired")
 			}
 
 		case "manual-review":

--- a/pkg/storage/interfaces/provider.go
+++ b/pkg/storage/interfaces/provider.go
@@ -790,6 +790,10 @@ func CreateOSSStorageManager(flatfileRoot, sqliteConnStr string) (*StorageManage
 	if err != nil {
 		return nil, fmt.Errorf("failed to create steward store (flatfile): %w", err)
 	}
+	ipTrustStore, err := ffProvider.CreateIPTrustStore(flatfileCfg)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create ip trust store (flatfile): %w", err)
+	}
 
 	// Prefer single-connection bundle when the provider supports it.
 	// This opens the SQLite database exactly once and shares the *sql.DB across
@@ -807,6 +811,7 @@ func CreateOSSStorageManager(flatfileRoot, sqliteConnStr string) (*StorageManage
 			stewardStore, bundle.Command, bundle.Trigger, bundle.Push,
 		)
 		sm.SetPendingRegistrationStore(bundle.PendingRegistration)
+		sm.SetIPTrustStore(ipTrustStore)
 		return sm, nil
 	}
 
@@ -853,5 +858,6 @@ func CreateOSSStorageManager(flatfileRoot, sqliteConnStr string) (*StorageManage
 		sessionStore, stewardStore, commandStore, triggerStore, pushStore,
 	)
 	sm.SetPendingRegistrationStore(pendingRegStore)
+	sm.SetIPTrustStore(ipTrustStore)
 	return sm, nil
 }

--- a/pkg/storage/interfaces/provider_test.go
+++ b/pkg/storage/interfaces/provider_test.go
@@ -519,6 +519,28 @@ func (m *MockPushStore) ListPushesByConfigID(_ context.Context, _, _ string) ([]
 	return []*business.PushRecord{}, nil
 }
 
+// MockIPTrustStore implements business.IPTrustStore for testing
+type MockIPTrustStore struct{}
+
+func (m *MockIPTrustStore) AddTrustedRange(_ context.Context, _, _ string, _ bool) error {
+	return nil
+}
+func (m *MockIPTrustStore) IsTrusted(_ context.Context, _, _ string) (bool, error) {
+	return false, nil
+}
+func (m *MockIPTrustStore) ListTrustedRanges(_ context.Context, _ string) ([]*business.IPTrustEntry, error) {
+	return nil, nil
+}
+func (m *MockIPTrustStore) RevokeTrustedRange(_ context.Context, _, _ string) error {
+	return business.ErrIPTrustEntryNotFound
+}
+func (m *MockIPTrustStore) RecordHealthySteward(_ context.Context, _, _ string, _ time.Time) error {
+	return nil
+}
+func (m *MockIPTrustStore) GetLastActivity(_ context.Context, _, _ string) (*business.IPTrustActivity, error) {
+	return nil, nil
+}
+
 // Test provider registration
 func TestRegisterStorageProvider(t *testing.T) {
 	// Clear registry for test
@@ -1010,6 +1032,11 @@ func TestCreateOSSStorageManager(t *testing.T) {
 			t.Errorf("TriggerStore should be nil when provider returns ErrNotSupported")
 		}
 
+		// IPTrustStore comes from the flatfile provider (Issue #1900)
+		if sm.GetIPTrustStore() == nil {
+			t.Errorf("IPTrustStore should not be nil — flatfile provider supplies it")
+		}
+
 		globalRegistry.mutex.Lock()
 		delete(globalRegistry.providers, "flatfile")
 		delete(globalRegistry.providers, "sqlite")
@@ -1070,7 +1097,7 @@ func (m *MockOSSProvider) CreatePendingRegistrationStore(_ map[string]interface{
 }
 
 func (m *MockOSSProvider) CreateIPTrustStore(_ map[string]interface{}) (business.IPTrustStore, error) {
-	return nil, business.ErrNotSupported
+	return &MockIPTrustStore{}, nil
 }
 
 // MockOSSProviderWithError is an interface stub that returns an error from a designated Create* method.
@@ -1172,7 +1199,10 @@ func (m *MockOSSProviderWithError) CreatePendingRegistrationStore(_ map[string]i
 }
 
 func (m *MockOSSProviderWithError) CreateIPTrustStore(_ map[string]interface{}) (business.IPTrustStore, error) {
-	return nil, business.ErrNotSupported
+	if err := m.mayFail("CreateIPTrustStore"); err != nil {
+		return nil, err
+	}
+	return &MockIPTrustStore{}, nil
 }
 
 func TestCreateOSSStorageManager_StoreCreationErrors(t *testing.T) {
@@ -1200,6 +1230,7 @@ func TestCreateOSSStorageManager_StoreCreationErrors(t *testing.T) {
 		"CreateConfigStore",
 		"CreateAuditStore",
 		"CreateStewardStore",
+		"CreateIPTrustStore",
 	}
 	sqliteFailures := []string{
 		"CreateRBACStore",

--- a/pkg/storage/providers/flatfile/ip_trust_store.go
+++ b/pkg/storage/providers/flatfile/ip_trust_store.go
@@ -1,0 +1,300 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+package flatfile
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+
+	business "github.com/cfgis/cfgms/pkg/storage/interfaces/business"
+)
+
+// Compile-time assertion.
+var _ business.IPTrustStore = (*FlatFileIPTrustStore)(nil)
+
+// FlatFileIPTrustStore implements business.IPTrustStore backed by a single JSON file.
+//
+// File layout: <root>/ip-trust/ip_trust.json
+//
+// All entries across all tenants are stored in a flat JSON array. Writes are
+// atomic (temp-file + rename). sync.RWMutex serializes goroutine access within
+// one process.
+type FlatFileIPTrustStore struct {
+	root string
+	mu   sync.RWMutex
+}
+
+// ipTrustEntryJSON is the on-disk representation of an IP trust entry.
+type ipTrustEntryJSON struct {
+	ID             string     `json:"id"`
+	TenantID       string     `json:"tenant_id"`
+	CIDR           string     `json:"cidr"`
+	PreSeeded      bool       `json:"pre_seeded"`
+	TrustedSince   time.Time  `json:"trusted_since"`
+	LastActivity   *time.Time `json:"last_activity,omitempty"`
+	LastActivityIP string     `json:"last_activity_ip,omitempty"`
+	Revoked        bool       `json:"revoked"`
+	RevokedAt      *time.Time `json:"revoked_at,omitempty"`
+}
+
+// NewFlatFileIPTrustStore creates a FlatFileIPTrustStore rooted at <root>/ip-trust.
+// The directory is created if it does not exist.
+func NewFlatFileIPTrustStore(root string) (*FlatFileIPTrustStore, error) {
+	dir := filepath.Join(root, "ip-trust")
+	if err := os.MkdirAll(dir, 0750); err != nil {
+		return nil, fmt.Errorf("flatfile: failed to create ip-trust directory: %w", err)
+	}
+	return &FlatFileIPTrustStore{root: root}, nil
+}
+
+func (s *FlatFileIPTrustStore) dataFilePath() string {
+	return filepath.Join(s.root, "ip-trust", "ip_trust.json")
+}
+
+// load reads and parses the ip_trust.json file.
+// Returns nil slice when the file does not exist.
+// Must be called with at least a read lock held.
+func (s *FlatFileIPTrustStore) load() ([]ipTrustEntryJSON, error) {
+	raw, err := readFile(s.dataFilePath())
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("flatfile: failed to read ip trust file: %w", err)
+	}
+	var entries []ipTrustEntryJSON
+	if err := json.Unmarshal(raw, &entries); err != nil {
+		return nil, fmt.Errorf("flatfile: failed to parse ip trust file: %w", err)
+	}
+	return entries, nil
+}
+
+// save atomically writes entries to ip_trust.json.
+// Must be called with a write lock held.
+func (s *FlatFileIPTrustStore) save(entries []ipTrustEntryJSON) error {
+	if entries == nil {
+		entries = []ipTrustEntryJSON{}
+	}
+	raw, err := json.MarshalIndent(entries, "", "  ")
+	if err != nil {
+		return fmt.Errorf("flatfile: failed to marshal ip trust entries: %w", err)
+	}
+	return writeAtomic(s.dataFilePath(), raw)
+}
+
+// normalizeCIDR returns the network-address form of cidr (e.g. "192.168.1.0/24").
+func normalizeCIDR(cidr string) (string, error) {
+	_, ipNet, err := net.ParseCIDR(cidr)
+	if err != nil {
+		return "", fmt.Errorf("invalid CIDR %q: %w", cidr, err)
+	}
+	return ipNet.String(), nil
+}
+
+// AddTrustedRange implements IPTrustStore.AddTrustedRange.
+// CIDR is normalised before storage. A previously revoked entry is re-activated.
+func (s *FlatFileIPTrustStore) AddTrustedRange(_ context.Context, tenantID, cidr string, preSeeded bool) error {
+	normalized, err := normalizeCIDR(cidr)
+	if err != nil {
+		return err
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	entries, err := s.load()
+	if err != nil {
+		return err
+	}
+
+	for i, e := range entries {
+		if e.TenantID == tenantID && e.CIDR == normalized {
+			entries[i].PreSeeded = preSeeded
+			entries[i].TrustedSince = time.Now().UTC()
+			entries[i].Revoked = false
+			entries[i].RevokedAt = nil
+			return s.save(entries)
+		}
+	}
+
+	entries = append(entries, ipTrustEntryJSON{
+		ID:           uuid.New().String(),
+		TenantID:     tenantID,
+		CIDR:         normalized,
+		PreSeeded:    preSeeded,
+		TrustedSince: time.Now().UTC(),
+	})
+	return s.save(entries)
+}
+
+// IsTrusted implements IPTrustStore.IsTrusted.
+// Containment is evaluated in Go via net.ParseCIDR + ipNet.Contains.
+func (s *FlatFileIPTrustStore) IsTrusted(_ context.Context, tenantID, ip string) (bool, error) {
+	parsedIP := net.ParseIP(ip)
+	if parsedIP == nil {
+		return false, fmt.Errorf("invalid IP address: %s", ip)
+	}
+
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	entries, err := s.load()
+	if err != nil {
+		return false, err
+	}
+
+	for _, e := range entries {
+		if e.TenantID != tenantID || e.Revoked {
+			continue
+		}
+		_, ipNet, err := net.ParseCIDR(e.CIDR)
+		if err != nil {
+			continue // skip malformed stored entries
+		}
+		if ipNet.Contains(parsedIP) {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// ListTrustedRanges implements IPTrustStore.ListTrustedRanges.
+// Returns all entries for the tenant (including revoked).
+func (s *FlatFileIPTrustStore) ListTrustedRanges(_ context.Context, tenantID string) ([]*business.IPTrustEntry, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	entries, err := s.load()
+	if err != nil {
+		return nil, err
+	}
+
+	var result []*business.IPTrustEntry
+	for _, e := range entries {
+		if e.TenantID != tenantID {
+			continue
+		}
+		entry := &business.IPTrustEntry{
+			ID:           e.ID,
+			TenantID:     e.TenantID,
+			CIDR:         e.CIDR,
+			PreSeeded:    e.PreSeeded,
+			TrustedSince: e.TrustedSince,
+			Revoked:      e.Revoked,
+			RevokedAt:    e.RevokedAt,
+		}
+		if e.LastActivity != nil {
+			entry.LastActivity = *e.LastActivity
+		}
+		result = append(result, entry)
+	}
+	return result, nil
+}
+
+// RevokeTrustedRange implements IPTrustStore.RevokeTrustedRange.
+// Returns ErrIPTrustEntryNotFound if no non-revoked entry exists for (tenantID, cidr).
+func (s *FlatFileIPTrustStore) RevokeTrustedRange(_ context.Context, tenantID, cidr string) error {
+	normalized, err := normalizeCIDR(cidr)
+	if err != nil {
+		return err
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	entries, err := s.load()
+	if err != nil {
+		return err
+	}
+
+	for i, e := range entries {
+		if e.TenantID == tenantID && e.CIDR == normalized && !e.Revoked {
+			now := time.Now().UTC()
+			entries[i].Revoked = true
+			entries[i].RevokedAt = &now
+			return s.save(entries)
+		}
+	}
+	return business.ErrIPTrustEntryNotFound
+}
+
+// RecordHealthySteward implements IPTrustStore.RecordHealthySteward.
+// Finds the CIDR entry containing ip and updates last_activity / last_activity_ip.
+// No-op if no matching non-revoked entry exists.
+func (s *FlatFileIPTrustStore) RecordHealthySteward(_ context.Context, tenantID, ip string, at time.Time) error {
+	parsedIP := net.ParseIP(ip)
+	if parsedIP == nil {
+		return fmt.Errorf("invalid IP address: %s", ip)
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	entries, err := s.load()
+	if err != nil {
+		return err
+	}
+
+	for i, e := range entries {
+		if e.TenantID != tenantID || e.Revoked {
+			continue
+		}
+		_, ipNet, err := net.ParseCIDR(e.CIDR)
+		if err != nil {
+			continue
+		}
+		if ipNet.Contains(parsedIP) {
+			t := at.UTC()
+			entries[i].LastActivity = &t
+			entries[i].LastActivityIP = ip
+			return s.save(entries)
+		}
+	}
+	return nil // no matching entry — no-op per spec
+}
+
+// GetLastActivity implements IPTrustStore.GetLastActivity.
+// Returns nil, nil when no matching entry or no activity has been recorded.
+func (s *FlatFileIPTrustStore) GetLastActivity(_ context.Context, tenantID, ip string) (*business.IPTrustActivity, error) {
+	parsedIP := net.ParseIP(ip)
+	if parsedIP == nil {
+		return nil, fmt.Errorf("invalid IP address: %s", ip)
+	}
+
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	entries, err := s.load()
+	if err != nil {
+		return nil, err
+	}
+
+	for _, e := range entries {
+		if e.TenantID != tenantID || e.Revoked {
+			continue
+		}
+		_, ipNet, err := net.ParseCIDR(e.CIDR)
+		if err != nil {
+			continue
+		}
+		if ipNet.Contains(parsedIP) {
+			if e.LastActivity == nil {
+				return nil, nil
+			}
+			return &business.IPTrustActivity{
+				TenantID: tenantID,
+				IP:       ip,
+				LastSeen: *e.LastActivity,
+			}, nil
+		}
+	}
+	return nil, nil
+}

--- a/pkg/storage/providers/flatfile/ip_trust_store_test.go
+++ b/pkg/storage/providers/flatfile/ip_trust_store_test.go
@@ -1,0 +1,378 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+package flatfile
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	business "github.com/cfgis/cfgms/pkg/storage/interfaces/business"
+)
+
+func newTestIPTrustStore(t *testing.T) *FlatFileIPTrustStore {
+	t.Helper()
+	store, err := NewFlatFileIPTrustStore(t.TempDir())
+	require.NoError(t, err)
+	return store
+}
+
+func TestFlatFileIPTrustStore_AddAndQuery(t *testing.T) {
+	store := newTestIPTrustStore(t)
+	ctx := context.Background()
+
+	require.NoError(t, store.AddTrustedRange(ctx, "tenant-1", "10.0.0.0/8", false))
+
+	trusted, err := store.IsTrusted(ctx, "tenant-1", "10.1.2.3")
+	require.NoError(t, err)
+	assert.True(t, trusted)
+
+	notTrusted, err := store.IsTrusted(ctx, "tenant-1", "192.168.1.1")
+	require.NoError(t, err)
+	assert.False(t, notTrusted)
+}
+
+func TestFlatFileIPTrustStore_ExactIPQuery(t *testing.T) {
+	store := newTestIPTrustStore(t)
+	ctx := context.Background()
+
+	require.NoError(t, store.AddTrustedRange(ctx, "tenant-1", "10.0.0.5/32", false))
+
+	trusted, err := store.IsTrusted(ctx, "tenant-1", "10.0.0.5")
+	require.NoError(t, err)
+	assert.True(t, trusted, "/32 exact match must be trusted")
+
+	notTrusted, err := store.IsTrusted(ctx, "tenant-1", "10.0.0.6")
+	require.NoError(t, err)
+	assert.False(t, notTrusted, "adjacent IP outside /32 must not be trusted")
+}
+
+func TestFlatFileIPTrustStore_CIDRRangeContainment(t *testing.T) {
+	store := newTestIPTrustStore(t)
+	ctx := context.Background()
+
+	require.NoError(t, store.AddTrustedRange(ctx, "tenant-1", "192.168.1.0/24", false))
+
+	tests := []struct {
+		ip   string
+		want bool
+		desc string
+	}{
+		{"192.168.1.1", true, "/24 containment — first host"},
+		{"192.168.1.254", true, "/24 containment — last host"},
+		{"192.168.2.1", false, "out-of-range — different subnet"},
+		{"192.168.0.255", false, "out-of-range — preceding subnet"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.desc, func(t *testing.T) {
+			got, err := store.IsTrusted(ctx, "tenant-1", tc.ip)
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestFlatFileIPTrustStore_TenantIsolation(t *testing.T) {
+	store := newTestIPTrustStore(t)
+	ctx := context.Background()
+
+	require.NoError(t, store.AddTrustedRange(ctx, "tenant-A", "10.0.0.0/8", false))
+
+	trusted, err := store.IsTrusted(ctx, "tenant-B", "10.1.2.3")
+	require.NoError(t, err)
+	assert.False(t, trusted, "tenant-B must not see tenant-A ranges")
+
+	trusted, err = store.IsTrusted(ctx, "tenant-A", "10.1.2.3")
+	require.NoError(t, err)
+	assert.True(t, trusted, "tenant-A must see its own ranges")
+}
+
+func TestFlatFileIPTrustStore_RevocationClearsAccess(t *testing.T) {
+	store := newTestIPTrustStore(t)
+	ctx := context.Background()
+
+	require.NoError(t, store.AddTrustedRange(ctx, "tenant-1", "10.0.0.0/8", false))
+
+	trusted, err := store.IsTrusted(ctx, "tenant-1", "10.1.2.3")
+	require.NoError(t, err)
+	require.True(t, trusted, "must be trusted before revoke")
+
+	require.NoError(t, store.RevokeTrustedRange(ctx, "tenant-1", "10.0.0.0/8"))
+
+	trusted, err = store.IsTrusted(ctx, "tenant-1", "10.1.2.3")
+	require.NoError(t, err)
+	assert.False(t, trusted, "must not be trusted after revoke")
+}
+
+func TestFlatFileIPTrustStore_RevokeNotFound(t *testing.T) {
+	store := newTestIPTrustStore(t)
+	ctx := context.Background()
+
+	err := store.RevokeTrustedRange(ctx, "tenant-1", "10.0.0.0/8")
+	require.ErrorIs(t, err, business.ErrIPTrustEntryNotFound)
+}
+
+func TestFlatFileIPTrustStore_RevokeThenReactivate(t *testing.T) {
+	store := newTestIPTrustStore(t)
+	ctx := context.Background()
+
+	require.NoError(t, store.AddTrustedRange(ctx, "tenant-1", "10.0.0.0/8", false))
+	require.NoError(t, store.RevokeTrustedRange(ctx, "tenant-1", "10.0.0.0/8"))
+
+	// Re-adding must reactivate.
+	require.NoError(t, store.AddTrustedRange(ctx, "tenant-1", "10.0.0.0/8", true))
+
+	trusted, err := store.IsTrusted(ctx, "tenant-1", "10.1.2.3")
+	require.NoError(t, err)
+	assert.True(t, trusted, "re-added CIDR must be trusted again")
+
+	// Must not create a second entry.
+	entries, err := store.ListTrustedRanges(ctx, "tenant-1")
+	require.NoError(t, err)
+	assert.Len(t, entries, 1, "re-add must not create a duplicate entry")
+}
+
+func TestFlatFileIPTrustStore_CIDRNormalization(t *testing.T) {
+	store := newTestIPTrustStore(t)
+	ctx := context.Background()
+
+	// Host-address form must be normalised to network address.
+	require.NoError(t, store.AddTrustedRange(ctx, "tenant-1", "192.168.1.99/24", false))
+
+	entries, err := store.ListTrustedRanges(ctx, "tenant-1")
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+	assert.Equal(t, "192.168.1.0/24", entries[0].CIDR, "host address must be normalised to network address")
+
+	// Re-adding via another host address in the same /24 must not create a second row.
+	require.NoError(t, store.AddTrustedRange(ctx, "tenant-1", "192.168.1.5/24", false))
+	entries, err = store.ListTrustedRanges(ctx, "tenant-1")
+	require.NoError(t, err)
+	assert.Len(t, entries, 1, "normalised duplicate must not create a second entry")
+}
+
+func TestFlatFileIPTrustStore_ListTrustedRanges(t *testing.T) {
+	store := newTestIPTrustStore(t)
+	ctx := context.Background()
+
+	require.NoError(t, store.AddTrustedRange(ctx, "tenant-1", "10.0.0.0/8", false))
+	require.NoError(t, store.AddTrustedRange(ctx, "tenant-1", "192.168.0.0/16", true))
+
+	entries, err := store.ListTrustedRanges(ctx, "tenant-1")
+	require.NoError(t, err)
+	assert.Len(t, entries, 2)
+}
+
+func TestFlatFileIPTrustStore_ListIncludesRevoked(t *testing.T) {
+	store := newTestIPTrustStore(t)
+	ctx := context.Background()
+
+	require.NoError(t, store.AddTrustedRange(ctx, "tenant-1", "10.0.0.0/8", false))
+	require.NoError(t, store.RevokeTrustedRange(ctx, "tenant-1", "10.0.0.0/8"))
+
+	entries, err := store.ListTrustedRanges(ctx, "tenant-1")
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+	assert.True(t, entries[0].Revoked)
+	assert.NotNil(t, entries[0].RevokedAt)
+}
+
+func TestFlatFileIPTrustStore_ListFiltersOtherTenants(t *testing.T) {
+	store := newTestIPTrustStore(t)
+	ctx := context.Background()
+
+	require.NoError(t, store.AddTrustedRange(ctx, "tenant-A", "10.0.0.0/8", false))
+	require.NoError(t, store.AddTrustedRange(ctx, "tenant-B", "192.168.0.0/16", false))
+
+	entriesA, err := store.ListTrustedRanges(ctx, "tenant-A")
+	require.NoError(t, err)
+	assert.Len(t, entriesA, 1)
+	assert.Equal(t, "10.0.0.0/8", entriesA[0].CIDR)
+
+	entriesB, err := store.ListTrustedRanges(ctx, "tenant-B")
+	require.NoError(t, err)
+	assert.Len(t, entriesB, 1)
+	assert.Equal(t, "192.168.0.0/16", entriesB[0].CIDR)
+}
+
+func TestFlatFileIPTrustStore_RecordHealthySteward_UpdatesActivity(t *testing.T) {
+	store := newTestIPTrustStore(t)
+	ctx := context.Background()
+
+	require.NoError(t, store.AddTrustedRange(ctx, "tenant-1", "10.0.0.0/8", false))
+
+	t1 := time.Now().UTC().Truncate(time.Millisecond)
+	require.NoError(t, store.RecordHealthySteward(ctx, "tenant-1", "10.0.0.1", t1))
+
+	activity, err := store.GetLastActivity(ctx, "tenant-1", "10.0.0.1")
+	require.NoError(t, err)
+	require.NotNil(t, activity)
+	assert.Equal(t, "tenant-1", activity.TenantID)
+	assert.Equal(t, "10.0.0.1", activity.IP)
+	assert.WithinDuration(t, t1, activity.LastSeen, time.Millisecond)
+
+	// Second call updates the timestamp.
+	t2 := t1.Add(time.Minute)
+	require.NoError(t, store.RecordHealthySteward(ctx, "tenant-1", "10.0.0.1", t2))
+
+	activity, err = store.GetLastActivity(ctx, "tenant-1", "10.0.0.1")
+	require.NoError(t, err)
+	require.NotNil(t, activity)
+	assert.WithinDuration(t, t2, activity.LastSeen, time.Millisecond)
+}
+
+func TestFlatFileIPTrustStore_RecordHealthySteward_NoMatchIsNoop(t *testing.T) {
+	store := newTestIPTrustStore(t)
+	ctx := context.Background()
+
+	// No entry exists — must be a no-op (no error).
+	err := store.RecordHealthySteward(ctx, "tenant-1", "10.0.0.1", time.Now())
+	assert.NoError(t, err)
+}
+
+func TestFlatFileIPTrustStore_GetLastActivity_NoActivity(t *testing.T) {
+	store := newTestIPTrustStore(t)
+	ctx := context.Background()
+
+	require.NoError(t, store.AddTrustedRange(ctx, "tenant-1", "10.0.0.0/8", false))
+
+	activity, err := store.GetLastActivity(ctx, "tenant-1", "10.0.0.1")
+	require.NoError(t, err)
+	assert.Nil(t, activity, "no activity recorded yet")
+}
+
+func TestFlatFileIPTrustStore_GetLastActivity_NotInRange(t *testing.T) {
+	store := newTestIPTrustStore(t)
+	ctx := context.Background()
+
+	require.NoError(t, store.AddTrustedRange(ctx, "tenant-1", "10.0.0.0/8", false))
+	require.NoError(t, store.RecordHealthySteward(ctx, "tenant-1", "10.0.0.1", time.Now()))
+
+	// IP outside the range must return nil.
+	activity, err := store.GetLastActivity(ctx, "tenant-1", "192.168.1.1")
+	require.NoError(t, err)
+	assert.Nil(t, activity)
+}
+
+func TestFlatFileIPTrustStore_Persistence(t *testing.T) {
+	dir := t.TempDir()
+	ctx := context.Background()
+
+	store1, err := NewFlatFileIPTrustStore(dir)
+	require.NoError(t, err)
+
+	require.NoError(t, store1.AddTrustedRange(ctx, "tenant-1", "10.0.0.0/8", false))
+	at := time.Now().UTC().Truncate(time.Millisecond)
+	require.NoError(t, store1.RecordHealthySteward(ctx, "tenant-1", "10.0.0.1", at))
+
+	// Open a second store at the same root — must see the same data.
+	store2, err := NewFlatFileIPTrustStore(dir)
+	require.NoError(t, err)
+
+	trusted, err := store2.IsTrusted(ctx, "tenant-1", "10.0.0.1")
+	require.NoError(t, err)
+	assert.True(t, trusted, "persisted entry must be visible after reload")
+
+	activity, err := store2.GetLastActivity(ctx, "tenant-1", "10.0.0.1")
+	require.NoError(t, err)
+	require.NotNil(t, activity)
+	assert.WithinDuration(t, at, activity.LastSeen, time.Millisecond)
+}
+
+func TestFlatFileIPTrustStore_PreSeeded_RoundTrip(t *testing.T) {
+	store := newTestIPTrustStore(t)
+	ctx := context.Background()
+
+	require.NoError(t, store.AddTrustedRange(ctx, "tenant-1", "172.16.0.0/12", true))
+
+	entries, err := store.ListTrustedRanges(ctx, "tenant-1")
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+	assert.True(t, entries[0].PreSeeded, "pre_seeded flag must round-trip")
+	assert.Equal(t, "172.16.0.0/12", entries[0].CIDR)
+	assert.False(t, entries[0].TrustedSince.IsZero(), "trusted_since must be set")
+
+	// Pre-seeded entry must be trusted.
+	trusted, err := store.IsTrusted(ctx, "tenant-1", "172.20.1.1")
+	require.NoError(t, err)
+	assert.True(t, trusted)
+}
+
+// TestFlatFileIPTrustStore_RegistrationWorkflow_TwoStewardsSameIP is the required
+// integration test for AC: first steward from a new tenant quarantines; second
+// steward auto-approves after the source IP is trusted.
+//
+// "Threshold elapses" in the ip-trust workflow means the IP was seen continuously
+// over the trust window and AddTrustedRange was called by the background trust
+// promoter. This test simulates that by calling AddTrustedRange directly and
+// verifying IsTrusted transitions from false to true.
+func TestFlatFileIPTrustStore_RegistrationWorkflow_TwoStewardsSameIP(t *testing.T) {
+	store := newTestIPTrustStore(t)
+	ctx := context.Background()
+
+	const tenantID = "tenant-acme"
+	const sourceIP = "10.20.30.40"
+
+	// --- First steward registration ---
+	// No trusted range exists yet; IsTrusted must return false → hook quarantines.
+	trusted, err := store.IsTrusted(ctx, tenantID, sourceIP)
+	require.NoError(t, err)
+	assert.False(t, trusted, "first registration must quarantine: source IP not yet trusted")
+
+	// Simulate ip-trust threshold elapsing: the controller's background promoter
+	// calls AddTrustedRange after the IP is observed continuously.
+	require.NoError(t, store.AddTrustedRange(ctx, tenantID, sourceIP+"/32", false))
+
+	// --- Second steward registration ---
+	// The IP is now in a trusted range; IsTrusted must return true → hook approves.
+	trusted, err = store.IsTrusted(ctx, tenantID, sourceIP)
+	require.NoError(t, err)
+	assert.True(t, trusted, "second registration must approve: source IP is now trusted")
+}
+
+func TestFlatFileIPTrustStore_InvalidIP(t *testing.T) {
+	store := newTestIPTrustStore(t)
+	ctx := context.Background()
+
+	_, err := store.IsTrusted(ctx, "tenant-1", "not-an-ip")
+	assert.Error(t, err, "invalid IP must return error")
+
+	err = store.RecordHealthySteward(ctx, "tenant-1", "not-an-ip", time.Now())
+	assert.Error(t, err, "invalid IP must return error")
+
+	_, err = store.GetLastActivity(ctx, "tenant-1", "not-an-ip")
+	assert.Error(t, err, "invalid IP must return error")
+}
+
+func TestFlatFileIPTrustStore_InvalidCIDR(t *testing.T) {
+	store := newTestIPTrustStore(t)
+	ctx := context.Background()
+
+	err := store.AddTrustedRange(ctx, "tenant-1", "not-a-cidr", false)
+	assert.Error(t, err, "invalid CIDR must return error")
+
+	err = store.RevokeTrustedRange(ctx, "tenant-1", "not-a-cidr")
+	assert.Error(t, err, "invalid CIDR must return error")
+}
+
+func TestFlatFileIPTrustStore_EmptyStore_IsTrusted(t *testing.T) {
+	store := newTestIPTrustStore(t)
+	ctx := context.Background()
+
+	trusted, err := store.IsTrusted(ctx, "tenant-1", "10.0.0.1")
+	require.NoError(t, err)
+	assert.False(t, trusted, "empty store must not trust any IP")
+}
+
+func TestFlatFileIPTrustStore_EmptyStore_ListTrustedRanges(t *testing.T) {
+	store := newTestIPTrustStore(t)
+	ctx := context.Background()
+
+	entries, err := store.ListTrustedRanges(ctx, "tenant-1")
+	require.NoError(t, err)
+	assert.Empty(t, entries, "empty store must return empty list")
+}

--- a/pkg/storage/providers/flatfile/plugin.go
+++ b/pkg/storage/providers/flatfile/plugin.go
@@ -53,10 +53,11 @@
 //
 // # Supported Stores
 //
-// This provider implements ConfigStore and AuditStore. All other store factory
-// methods (CreateRBACStore, CreateTenantStore,
-// CreateRegistrationTokenStore, CreateClientTenantStore) return ErrNotSupported,
-// as these belong to the business-data tier (SQLite, sub-story C).
+// This provider implements ConfigStore, AuditStore, StewardStore, and
+// IPTrustStore (Issue #1900). All other store factory methods (CreateRBACStore,
+// CreateTenantStore, CreateRegistrationTokenStore, CreateClientTenantStore)
+// return ErrNotSupported, as these belong to the business-data tier (SQLite,
+// sub-story C).
 package flatfile
 
 import (
@@ -243,10 +244,19 @@ func (p *FlatFileProvider) CreatePendingRegistrationStore(config map[string]inte
 	return nil, ErrNotSupported
 }
 
-// CreateIPTrustStore returns ErrNotSupported.
-// IP trust storage belongs in the business-data tier (Issue #1691).
-func (p *FlatFileProvider) CreateIPTrustStore(_ map[string]interface{}) (business.IPTrustStore, error) {
-	return nil, ErrNotSupported
+// CreateIPTrustStore creates a flat-file-backed IPTrustStore.
+// Config map must contain "root" (string): the root directory.
+// Entries are stored at <root>/ip-trust/ip_trust.json with atomic writes.
+func (p *FlatFileProvider) CreateIPTrustStore(config map[string]interface{}) (business.IPTrustStore, error) {
+	root, err := getRootFromConfig(config)
+	if err != nil {
+		return nil, err
+	}
+	store, err := NewFlatFileIPTrustStore(root)
+	if err != nil {
+		return nil, fmt.Errorf("flatfile: failed to create ip trust store: %w", err)
+	}
+	return store, nil
 }
 
 // init auto-registers the flat-file provider so that a blank import is sufficient.

--- a/pkg/storage/providers/flatfile/plugin_test.go
+++ b/pkg/storage/providers/flatfile/plugin_test.go
@@ -154,3 +154,23 @@ func TestCreateAuditStoreWithRoot(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotNil(t, store)
 }
+
+func TestCreateIPTrustStoreRequiresRoot(t *testing.T) {
+	p, err := interfaces.GetStorageProvider("flatfile")
+	require.NoError(t, err)
+
+	store, err := p.CreateIPTrustStore(map[string]interface{}{})
+	assert.Nil(t, store)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "root")
+}
+
+func TestCreateIPTrustStoreWithRoot(t *testing.T) {
+	root := t.TempDir()
+	p, err := interfaces.GetStorageProvider("flatfile")
+	require.NoError(t, err)
+
+	store, err := p.CreateIPTrustStore(map[string]interface{}{"root": root})
+	require.NoError(t, err)
+	assert.NotNil(t, store)
+}


### PR DESCRIPTION
## Summary

- Implements `FlatFileIPTrustStore` in the flatfile storage provider, backed by `<root>/ip-trust/ip_trust.json` with atomic writes and CIDR containment checks
- Wires the store into `CreateOSSStorageManager` so `GetIPTrustStore()` returns a non-nil store for every fresh OSS composite deployment
- Removes the startup `Warn` "IP-trust store not available (OSS composite storage)" — now always wired

Fixes #1900

## What this fixes

The default registration workflow (`ip-trust`) requires an IP-trust store. The OSS composite backend (flatfile + SQLite) returned `ErrNotSupported` from `CreateIPTrustStore` and `CreateOSSStorageManager` never called it, causing `GetIPTrustStore()` to return nil. The `IPTrustApprovalHook` fails closed (quarantine) when the store is nil, so every steward was quarantined on a fresh self-hosted deployment — the documented default was broken.

## Test plan

- [ ] 22 unit tests in `pkg/storage/providers/flatfile/ip_trust_store_test.go` covering add, exact-IP, CIDR containment, tenant isolation, revocation, CIDR normalization, persistence, and the required registration workflow integration scenario (`TestFlatFileIPTrustStore_RegistrationWorkflow_TwoStewardsSameIP`)
- [ ] `TestCreateOSSStorageManager` in `provider_test.go` asserts `GetIPTrustStore() != nil`
- [ ] `CreateIPTrustStore` error propagation added to `TestCreateOSSStorageManager_StoreCreationErrors`
- [ ] Factory-level tests `TestCreateIPTrustStoreRequiresRoot` and `TestCreateIPTrustStoreWithRoot` added to `plugin_test.go`
- [ ] `make test-agent-complete` passes across all packages

## Specialist review results

- **QA Test Runner**: PASS — all 100+ packages passing, 160/160 shell script tests, security scans clean, cross-platform compilation passing
- **QA Code Reviewer**: PASS — no blocking issues; two non-blocking warnings (no concurrent-stress test for IPTrustStore, hand-written doubles in provider_test.go justified by import cycle)
- **Security Engineer**: PASS — no blocking issues; path construction uses constants with no user-controlled input, JSON deserialization into typed struct, CIDR/IP validation present, tenant isolation verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)