### PR TITLE
controlplane: CommandRelayResponse missing from convert maps + proto enum (Issue #1994)

### DIFF
--- a/api/proto/transport/control.pb.go
+++ b/api/proto/transport/control.pb.go
@@ -40,6 +40,7 @@ const (
 	CommandType_COMMAND_TYPE_EXECUTE_SCRIPT      CommandType = 8  // Issue #1669/#1992: controller dispatches a signed script execution to a steward
 	CommandType_COMMAND_TYPE_PUSH_SIGNING_CERT   CommandType = 9  // Issue #1817: controller pushes current signing cert on every steward connect
 	CommandType_COMMAND_TYPE_PUSH_STEWARD_BINARY CommandType = 10 // Issue #1943: controller pushes a new steward binary for self-upgrade
+	CommandType_COMMAND_TYPE_RELAY_RESPONSE      CommandType = 11 // Issue #1994: controller sends relay response back to steward relay goroutine
 )
 
 // Enum value maps for CommandType.
@@ -56,6 +57,7 @@ var (
 		8:  "COMMAND_TYPE_EXECUTE_SCRIPT",
 		9:  "COMMAND_TYPE_PUSH_SIGNING_CERT",
 		10: "COMMAND_TYPE_PUSH_STEWARD_BINARY",
+		11: "COMMAND_TYPE_RELAY_RESPONSE",
 	}
 	CommandType_value = map[string]int32{
 		"COMMAND_TYPE_UNSPECIFIED":         0,
@@ -69,6 +71,7 @@ var (
 		"COMMAND_TYPE_EXECUTE_SCRIPT":      8,
 		"COMMAND_TYPE_PUSH_SIGNING_CERT":   9,
 		"COMMAND_TYPE_PUSH_STEWARD_BINARY": 10,
+		"COMMAND_TYPE_RELAY_RESPONSE":      11,
 	}
 )
 
@@ -867,7 +870,7 @@ const file_transport_control_proto_rawDesc = "" +
 	"\adetails\x18\x06 \x03(\v2&.cfgms.transport.Response.DetailsEntryR\adetails\x1a:\n" +
 	"\fDetailsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
-	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01*\xeb\x02\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01*\x8c\x03\n" +
 	"\vCommandType\x12\x1c\n" +
 	"\x18COMMAND_TYPE_UNSPECIFIED\x10\x00\x12\x1c\n" +
 	"\x18COMMAND_TYPE_SYNC_CONFIG\x10\x01\x12\x19\n" +
@@ -880,7 +883,8 @@ const file_transport_control_proto_rawDesc = "" +
 	"\x1bCOMMAND_TYPE_EXECUTE_SCRIPT\x10\b\x12\"\n" +
 	"\x1eCOMMAND_TYPE_PUSH_SIGNING_CERT\x10\t\x12$\n" +
 	" COMMAND_TYPE_PUSH_STEWARD_BINARY\x10\n" +
-	"*\xf8\x03\n" +
+	"\x12\x1f\n" +
+	"\x1bCOMMAND_TYPE_RELAY_RESPONSE\x10\v*\xf8\x03\n" +
 	"\tEventType\x12\x1a\n" +
 	"\x16EVENT_TYPE_UNSPECIFIED\x10\x00\x12\x1d\n" +
 	"\x19EVENT_TYPE_CONFIG_APPLIED\x10\x01\x12\x19\n" +

--- a/api/proto/transport/control.proto
+++ b/api/proto/transport/control.proto
@@ -21,6 +21,7 @@ enum CommandType {
   COMMAND_TYPE_EXECUTE_SCRIPT = 8; // Issue #1669/#1992: controller dispatches a signed script execution to a steward
   COMMAND_TYPE_PUSH_SIGNING_CERT = 9; // Issue #1817: controller pushes current signing cert on every steward connect
   COMMAND_TYPE_PUSH_STEWARD_BINARY = 10; // Issue #1943: controller pushes a new steward binary for self-upgrade
+  COMMAND_TYPE_RELAY_RESPONSE = 11;      // Issue #1994: controller sends relay response back to steward relay goroutine
 }
 
 // EventType enumerates the types of events a steward emits to a controller.

--- a/pkg/controlplane/providers/grpc/convert.go
+++ b/pkg/controlplane/providers/grpc/convert.go
@@ -31,6 +31,7 @@ var commandTypeToProto = map[types.CommandType]transportpb.CommandType{
 	types.CommandSyncDNA:           transportpb.CommandType_COMMAND_TYPE_SYNC_DNA,
 	types.CommandReconnect:         transportpb.CommandType_COMMAND_TYPE_RECONNECT,
 	types.CommandExecuteScript:     transportpb.CommandType_COMMAND_TYPE_EXECUTE_SCRIPT,
+	types.CommandRelayResponse:     transportpb.CommandType_COMMAND_TYPE_RELAY_RESPONSE, // Issue #1994
 	types.CommandPushSigningCert:   transportpb.CommandType_COMMAND_TYPE_PUSH_SIGNING_CERT,
 	types.CommandPushStewardBinary: transportpb.CommandType_COMMAND_TYPE_PUSH_STEWARD_BINARY,
 }
@@ -41,6 +42,7 @@ var protoToCommandType = map[transportpb.CommandType]types.CommandType{
 	transportpb.CommandType_COMMAND_TYPE_SYNC_DNA:            types.CommandSyncDNA,
 	transportpb.CommandType_COMMAND_TYPE_RECONNECT:           types.CommandReconnect,
 	transportpb.CommandType_COMMAND_TYPE_EXECUTE_SCRIPT:      types.CommandExecuteScript,
+	transportpb.CommandType_COMMAND_TYPE_RELAY_RESPONSE:      types.CommandRelayResponse, // Issue #1994
 	transportpb.CommandType_COMMAND_TYPE_PUSH_SIGNING_CERT:   types.CommandPushSigningCert,
 	transportpb.CommandType_COMMAND_TYPE_PUSH_STEWARD_BINARY: types.CommandPushStewardBinary,
 }

--- a/pkg/controlplane/providers/grpc/convert_test.go
+++ b/pkg/controlplane/providers/grpc/convert_test.go
@@ -88,20 +88,26 @@ func TestCommandNil(t *testing.T) {
 	assert.Nil(t, commandFromProto(nil))
 }
 
+// allCommandTypes enumerates every types.Command* constant that must survive
+// the proto round-trip. Add new constants here as they are defined in
+// pkg/controlplane/types/messages.go. The guard test below asserts this list
+// stays in sync with commandTypeToProto (Issue #1994).
+var allCommandTypes = []types.CommandType{
+	types.CommandSyncConfig,
+	types.CommandSyncDNA,
+	types.CommandReconnect,
+	types.CommandExecuteScript,
+	types.CommandRelayResponse,
+	types.CommandPushSigningCert,
+	types.CommandPushStewardBinary,
+}
+
 func TestCommandTypeRoundTrip(t *testing.T) {
 	// Every command type the controller can dispatch must survive the
 	// semantic→proto→semantic round-trip. A type missing from either map
 	// serialises to the zero enum value, which mutates the signed Type field
 	// and makes steward-side signature verification fail (Issue #1943/#1948).
-	allTypes := []types.CommandType{
-		types.CommandSyncConfig,
-		types.CommandSyncDNA,
-		types.CommandReconnect,
-		types.CommandExecuteScript,
-		types.CommandPushSigningCert,
-		types.CommandPushStewardBinary,
-	}
-	for _, ct := range allTypes {
+	for _, ct := range allCommandTypes {
 		t.Run(string(ct), func(t *testing.T) {
 			pb, ok := commandTypeToProto[ct]
 			require.True(t, ok, "command type %q missing from commandTypeToProto", ct)
@@ -110,6 +116,26 @@ func TestCommandTypeRoundTrip(t *testing.T) {
 			result := protoToCommandType[pb]
 			assert.Equal(t, ct, result)
 		})
+	}
+}
+
+// TestCommandTypeConvertMapsComplete guards against the class of omission from
+// Issue #1992 and #1994: a Command* constant is added to messages.go but never
+// added to the convert maps, causing silent Type-collapse to UNSPECIFIED on the
+// wire. The slice length pin fails the test at compile-time if allCommandTypes
+// and commandTypeToProto diverge.
+func TestCommandTypeConvertMapsComplete(t *testing.T) {
+	require.Len(t, allCommandTypes, len(commandTypeToProto),
+		"allCommandTypes is out of sync with commandTypeToProto — "+
+			"add the new Command* constant to both the slice and the convert maps")
+
+	for _, ct := range allCommandTypes {
+		_, inToProto := commandTypeToProto[ct]
+		assert.True(t, inToProto, "command type %q missing from commandTypeToProto", ct)
+
+		pbVal := commandTypeToProto[ct]
+		_, inFromProto := protoToCommandType[pbVal]
+		assert.True(t, inFromProto, "proto value for command type %q missing from protoToCommandType", ct)
 	}
 }
 
@@ -125,6 +151,7 @@ func TestCommandTypeProtoDescriptorComplete(t *testing.T) {
 		transportpb.CommandType_COMMAND_TYPE_EXECUTE_SCRIPT:      "COMMAND_TYPE_EXECUTE_SCRIPT",
 		transportpb.CommandType_COMMAND_TYPE_PUSH_SIGNING_CERT:   "COMMAND_TYPE_PUSH_SIGNING_CERT",
 		transportpb.CommandType_COMMAND_TYPE_PUSH_STEWARD_BINARY: "COMMAND_TYPE_PUSH_STEWARD_BINARY",
+		transportpb.CommandType_COMMAND_TYPE_RELAY_RESPONSE:      "COMMAND_TYPE_RELAY_RESPONSE",
 	}
 	for ct, name := range cases {
 		t.Run(name, func(t *testing.T) {


### PR DESCRIPTION
## Summary

- `CommandRelayResponse` ("relay_response") was used in production relay paths but had no proto enum slot in `control.proto` and was absent from both `commandTypeToProto` and `protoToCommandType` in `convert.go`
- Over the gRPC wire its `Command.Type` collapsed to `COMMAND_TYPE_UNSPECIFIED` → `""`, breaking signature verification and handler dispatch for the relay-response path (same Type-collapse class as Issue #1992)
- Adds `COMMAND_TYPE_RELAY_RESPONSE = 11` to the proto enum, regenerates `control.pb.go`, adds both map entries in `convert.go`, extends `TestCommandTypeRoundTrip` with the new type, and adds `TestCommandTypeConvertMapsComplete` as a guard against future omissions

Fixes #1994

## Changes

| File | Change |
|------|--------|
| `api/proto/transport/control.proto` | Add `COMMAND_TYPE_RELAY_RESPONSE = 11` |
| `api/proto/transport/control.pb.go` | Regenerated (protoc 27.0 / protoc-gen-go v1.36.11). SPDX header kept as `AGPL-3.0-only`. |
| `pkg/controlplane/providers/grpc/convert.go` | Add `CommandRelayResponse` to both convert maps |
| `pkg/controlplane/providers/grpc/convert_test.go` | Add to `allCommandTypes`, add guard test `TestCommandTypeConvertMapsComplete`, add descriptor check |

## Specialist Review Results

**QA Test Runner: PASS**
- All packages passing including `pkg/controlplane/providers/grpc`, `features/controller/api`, `features/steward/script_relay`
- Cross-platform builds verified (linux/amd64, linux/arm64, darwin/amd64, darwin/arm64, windows/amd64)
- Lint, license headers, architecture checks all clean

**QA Code Reviewer: PASS**
- No mocks, no skipped tests, no empty assertions, no hacky workarounds
- Guard test `TestCommandTypeConvertMapsComplete` uses length-pin + bidirectional membership assertions
- One warning noted (license header in generated file, pre-existing proto source carries Apache-2.0) — resolved by restoring AGPL-3.0-only

**Security Engineer: PASS**
- security-precommit: PASS (no leaks in changed files)
- check-architecture: PASS (no central provider violations)
- security-scan: PASS (Trivy, Nancy, gosec, staticcheck all green)
- The fix itself closes a security-relevant gap: missing map entry collapses the signed `Type` field to UNSPECIFIED, breaking steward-side signature verification

## Test Plan

- [x] `TestCommandTypeRoundTrip/relay_response` — round-trip through both maps passes
- [x] `TestCommandTypeConvertMapsComplete` — guard test asserting map completeness passes
- [x] `TestCommandTypeProtoDescriptorComplete/COMMAND_TYPE_RELAY_RESPONSE` — binary descriptor verified
- [x] `features/controller/api` tests (relay_handler_test.go) — CommandRelayResponse assertions pass
- [x] `features/steward/script_relay` tests — relay response delivery tests pass
- [x] Full `make test-agent-complete` suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)