### PR TITLE
storage: steward registry extension + refresh stores (Issue #2093)

### DIFF
--- a/features/controller/server/health_adapters_test.go
+++ b/features/controller/server/health_adapters_test.go
@@ -190,6 +190,17 @@ func (s *testStewardStore) DeregisterSteward(_ context.Context, _ string) error 
 func (s *testStewardStore) GetStewardsSeen(_ context.Context, _ time.Time) ([]*business.StewardRecord, error) {
 	return nil, nil
 }
+func (s *testStewardStore) GetStewardByDeviceID(_ context.Context, deviceID string) (*business.StewardRecord, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	for _, r := range s.stewards {
+		if r.DeviceID == deviceID {
+			cp := *r
+			return &cp, nil
+		}
+	}
+	return nil, business.ErrStewardNotFound
+}
 func (s *testStewardStore) HealthCheck(_ context.Context) error { return nil }
 func (s *testStewardStore) Initialize(_ context.Context) error  { return nil }
 func (s *testStewardStore) Close() error                        { return nil }

--- a/pkg/storage/interfaces/business/pending_refresh_store.go
+++ b/pkg/storage/interfaces/business/pending_refresh_store.go
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+// Package business defines the PendingRefreshStore interface for the
+// registration-refresh approval flow (ADR-010, Issue #2093).
+package business
+
+import (
+	"context"
+	"errors"
+	"time"
+)
+
+// ErrPendingRefreshNotFound is returned when a pending refresh record does not exist.
+var ErrPendingRefreshNotFound = errors.New("pending refresh not found")
+
+// Pending refresh status values.
+const (
+	PendingRefreshStatusPending  = "pending"
+	PendingRefreshStatusApproved = "approved"
+	PendingRefreshStatusRejected = "rejected"
+	PendingRefreshStatusExpired  = "expired"
+)
+
+// PendingRefreshEntry holds the durable state for a single registration-refresh
+// request awaiting manual review or auto-accept processing (ADR-010 §4).
+//
+// ClaimBundle is populated by StoreClaimBundle once the steward submits its
+// proof-of-possession response. It is never stored until after the challenge
+// phase succeeds; a nil ClaimBundle means the steward has not yet responded.
+type PendingRefreshEntry struct {
+	// PendingID is the unique pending-refresh identifier (e.g. "refresh-<nanoseconds>").
+	PendingID string
+
+	// DeviceID is the 64-character hex fingerprint of the steward's Ed25519 identity key.
+	DeviceID string
+
+	// TenantID is the tenant the refreshing steward belongs to.
+	TenantID string
+
+	// SourceIP is the remote address of the refreshing steward at challenge time.
+	SourceIP string
+
+	// ProvenanceMatchedFields is the number of provenance signal fields that matched
+	// the last recorded provenance snapshot (LastProvenanceJSON in StewardRecord).
+	ProvenanceMatchedFields int
+
+	// ProvenanceTotalFields is the total number of provenance signal fields evaluated.
+	ProvenanceTotalFields int
+
+	// ClaimBundle is the serialised proof-of-possession payload submitted by the
+	// steward during the /refresh/complete call. Nil until StoreClaimBundle is called.
+	ClaimBundle []byte
+
+	// Status is the current lifecycle state: pending | approved | rejected | expired.
+	Status string
+
+	// CreatedAt is the time the refresh challenge was issued.
+	CreatedAt time.Time
+
+	// ExpiresAt is the deadline after which the entry is eligible for expiry sweep.
+	// Nonce TTL is 65 seconds (ADR-010 §2); entries are typically short-lived.
+	ExpiresAt time.Time
+
+	// ResolvedAt is set when the entry reaches a terminal state (approved/rejected/expired).
+	ResolvedAt *time.Time
+}
+
+// PendingRefreshStore defines the storage interface for durable persistence of
+// registration-refresh requests in the ADR-010 approval flow.
+type PendingRefreshStore interface {
+	// AddPendingRefresh inserts a new pending-refresh entry.
+	// Returns an error if an entry with the same PendingID already exists.
+	AddPendingRefresh(ctx context.Context, entry *PendingRefreshEntry) error
+
+	// GetPendingRefreshByID retrieves the entry for the given pending_id.
+	// Returns ErrPendingRefreshNotFound if no record exists.
+	GetPendingRefreshByID(ctx context.Context, pendingID string) (*PendingRefreshEntry, error)
+
+	// UpdateRefreshStatus updates the status of the entry identified by pendingID.
+	// For terminal statuses (approved, rejected), resolved_at is also set to now.
+	// Returns ErrPendingRefreshNotFound if no record exists for the ID.
+	UpdateRefreshStatus(ctx context.Context, pendingID, status string) error
+
+	// ListPendingRefresh returns all entries for the given tenantID ordered by
+	// created_at ascending. An empty tenantID returns entries for all tenants.
+	ListPendingRefresh(ctx context.Context, tenantID string) ([]*PendingRefreshEntry, error)
+
+	// ExpireStaleRefresh marks entries whose expires_at is at or before cutoff and
+	// whose status is "pending" as "expired", setting resolved_at to now.
+	// Returns the number of entries updated.
+	ExpireStaleRefresh(ctx context.Context, cutoff time.Time) (int, error)
+
+	// StoreClaimBundle persists the proof-of-possession payload for the given
+	// pendingID. Called by the /refresh/complete handler after signature verification.
+	// Returns ErrPendingRefreshNotFound if no record exists for the ID.
+	StoreClaimBundle(ctx context.Context, pendingID string, bundle []byte) error
+}

--- a/pkg/storage/interfaces/business/pending_refresh_store_test.go
+++ b/pkg/storage/interfaces/business/pending_refresh_store_test.go
@@ -1,0 +1,248 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+package business_test
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cfgis/cfgms/pkg/storage/interfaces/business"
+)
+
+// inMemPendingRefreshStore is a minimal in-memory PendingRefreshStore for contract tests.
+type inMemPendingRefreshStore struct {
+	mu      sync.RWMutex
+	entries map[string]*business.PendingRefreshEntry
+}
+
+func newInMemPendingRefreshStore() business.PendingRefreshStore {
+	return &inMemPendingRefreshStore{entries: make(map[string]*business.PendingRefreshEntry)}
+}
+
+func (s *inMemPendingRefreshStore) AddPendingRefresh(_ context.Context, entry *business.PendingRefreshEntry) error {
+	if entry == nil {
+		return fmt.Errorf("nil entry")
+	}
+	if entry.PendingID == "" {
+		return fmt.Errorf("pending_id cannot be empty")
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, exists := s.entries[entry.PendingID]; exists {
+		return fmt.Errorf("duplicate pending_id: %s", entry.PendingID)
+	}
+	cp := *entry
+	if cp.Status == "" {
+		cp.Status = business.PendingRefreshStatusPending
+	}
+	if cp.CreatedAt.IsZero() {
+		cp.CreatedAt = time.Now().UTC()
+	}
+	s.entries[entry.PendingID] = &cp
+	return nil
+}
+
+func (s *inMemPendingRefreshStore) GetPendingRefreshByID(_ context.Context, pendingID string) (*business.PendingRefreshEntry, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	e, ok := s.entries[pendingID]
+	if !ok {
+		return nil, business.ErrPendingRefreshNotFound
+	}
+	cp := *e
+	return &cp, nil
+}
+
+func (s *inMemPendingRefreshStore) UpdateRefreshStatus(_ context.Context, pendingID, status string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	e, ok := s.entries[pendingID]
+	if !ok {
+		return business.ErrPendingRefreshNotFound
+	}
+	e.Status = status
+	isTerminal := status == business.PendingRefreshStatusApproved || status == business.PendingRefreshStatusRejected
+	if isTerminal {
+		now := time.Now().UTC()
+		e.ResolvedAt = &now
+	}
+	return nil
+}
+
+func (s *inMemPendingRefreshStore) ListPendingRefresh(_ context.Context, tenantID string) ([]*business.PendingRefreshEntry, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	var out []*business.PendingRefreshEntry
+	for _, e := range s.entries {
+		if tenantID == "" || e.TenantID == tenantID {
+			cp := *e
+			out = append(out, &cp)
+		}
+	}
+	return out, nil
+}
+
+func (s *inMemPendingRefreshStore) ExpireStaleRefresh(_ context.Context, cutoff time.Time) (int, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	count := 0
+	for _, e := range s.entries {
+		if e.Status == business.PendingRefreshStatusPending && !e.ExpiresAt.After(cutoff) {
+			e.Status = business.PendingRefreshStatusExpired
+			now := time.Now().UTC()
+			e.ResolvedAt = &now
+			count++
+		}
+	}
+	return count, nil
+}
+
+func (s *inMemPendingRefreshStore) StoreClaimBundle(_ context.Context, pendingID string, bundle []byte) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	e, ok := s.entries[pendingID]
+	if !ok {
+		return business.ErrPendingRefreshNotFound
+	}
+	e.ClaimBundle = bundle
+	return nil
+}
+
+// Compile-time assertion.
+var _ business.PendingRefreshStore = (*inMemPendingRefreshStore)(nil)
+
+// --- Contract tests ---
+
+func newTestRefreshEntry(id, deviceID, tenant string) *business.PendingRefreshEntry {
+	now := time.Now().UTC()
+	return &business.PendingRefreshEntry{
+		PendingID:               id,
+		DeviceID:                deviceID,
+		TenantID:                tenant,
+		SourceIP:                "10.0.0.1",
+		ProvenanceMatchedFields: 3,
+		ProvenanceTotalFields:   5,
+		Status:                  business.PendingRefreshStatusPending,
+		CreatedAt:               now,
+		ExpiresAt:               now.Add(65 * time.Second),
+	}
+}
+
+func TestPendingRefreshStore_AddAndGetByID(t *testing.T) {
+	store := newInMemPendingRefreshStore()
+	ctx := context.Background()
+
+	entry := newTestRefreshEntry("pr-1", "devid-1", "tenant-1")
+	require.NoError(t, store.AddPendingRefresh(ctx, entry))
+
+	got, err := store.GetPendingRefreshByID(ctx, "pr-1")
+	require.NoError(t, err)
+	assert.Equal(t, "pr-1", got.PendingID)
+	assert.Equal(t, "devid-1", got.DeviceID)
+	assert.Equal(t, "tenant-1", got.TenantID)
+	assert.Equal(t, business.PendingRefreshStatusPending, got.Status)
+	assert.Nil(t, got.ResolvedAt)
+}
+
+func TestPendingRefreshStore_GetByID_NotFound(t *testing.T) {
+	store := newInMemPendingRefreshStore()
+	_, err := store.GetPendingRefreshByID(context.Background(), "nonexistent")
+	assert.ErrorIs(t, err, business.ErrPendingRefreshNotFound)
+}
+
+func TestPendingRefreshStore_UpdateRefreshStatus_ApprovedSetsResolvedAt(t *testing.T) {
+	store := newInMemPendingRefreshStore()
+	ctx := context.Background()
+
+	require.NoError(t, store.AddPendingRefresh(ctx, newTestRefreshEntry("pr-appr", "dev-1", "t1")))
+
+	before := time.Now().UTC()
+	require.NoError(t, store.UpdateRefreshStatus(ctx, "pr-appr", business.PendingRefreshStatusApproved))
+
+	got, err := store.GetPendingRefreshByID(ctx, "pr-appr")
+	require.NoError(t, err)
+	assert.Equal(t, business.PendingRefreshStatusApproved, got.Status)
+	require.NotNil(t, got.ResolvedAt)
+	assert.WithinDuration(t, before, *got.ResolvedAt, 2*time.Second)
+}
+
+func TestPendingRefreshStore_UpdateRefreshStatus_NotFound(t *testing.T) {
+	store := newInMemPendingRefreshStore()
+	err := store.UpdateRefreshStatus(context.Background(), "missing", business.PendingRefreshStatusRejected)
+	assert.ErrorIs(t, err, business.ErrPendingRefreshNotFound)
+}
+
+func TestPendingRefreshStore_StoreClaimBundle_Contract(t *testing.T) {
+	store := newInMemPendingRefreshStore()
+	ctx := context.Background()
+
+	require.NoError(t, store.AddPendingRefresh(ctx, newTestRefreshEntry("pr-bundle", "dev-2", "t1")))
+
+	bundle := []byte(`{"nonce":"abc","sig":"deadbeef"}`)
+	require.NoError(t, store.StoreClaimBundle(ctx, "pr-bundle", bundle))
+
+	got, err := store.GetPendingRefreshByID(ctx, "pr-bundle")
+	require.NoError(t, err)
+	assert.Equal(t, bundle, got.ClaimBundle)
+}
+
+func TestPendingRefreshStore_StoreClaimBundle_NotFound(t *testing.T) {
+	store := newInMemPendingRefreshStore()
+	err := store.StoreClaimBundle(context.Background(), "missing", []byte("bundle"))
+	assert.ErrorIs(t, err, business.ErrPendingRefreshNotFound)
+}
+
+func TestPendingRefreshStore_ListPendingRefresh_TenantFilter(t *testing.T) {
+	store := newInMemPendingRefreshStore()
+	ctx := context.Background()
+
+	require.NoError(t, store.AddPendingRefresh(ctx, newTestRefreshEntry("pr-a", "dev-a", "tenant-1")))
+	require.NoError(t, store.AddPendingRefresh(ctx, newTestRefreshEntry("pr-b", "dev-b", "tenant-2")))
+
+	all, err := store.ListPendingRefresh(ctx, "")
+	require.NoError(t, err)
+	assert.Len(t, all, 2)
+
+	filtered, err := store.ListPendingRefresh(ctx, "tenant-1")
+	require.NoError(t, err)
+	require.Len(t, filtered, 1)
+	assert.Equal(t, "pr-a", filtered[0].PendingID)
+}
+
+func TestPendingRefreshStore_ExpireStaleRefresh_OnlyPending(t *testing.T) {
+	store := newInMemPendingRefreshStore()
+	ctx := context.Background()
+
+	now := time.Now().UTC()
+
+	stale := newTestRefreshEntry("pr-stale", "dev-stale", "t1")
+	stale.ExpiresAt = now.Add(-1 * time.Hour)
+	require.NoError(t, store.AddPendingRefresh(ctx, stale))
+
+	approved := newTestRefreshEntry("pr-appr", "dev-appr", "t1")
+	approved.ExpiresAt = now.Add(-1 * time.Hour)
+	require.NoError(t, store.AddPendingRefresh(ctx, approved))
+	require.NoError(t, store.UpdateRefreshStatus(ctx, "pr-appr", business.PendingRefreshStatusApproved))
+
+	count, err := store.ExpireStaleRefresh(ctx, now)
+	require.NoError(t, err)
+	assert.Equal(t, 1, count, "only pending entries may be expired")
+}
+
+func TestPendingRefreshStore_StatusConstants(t *testing.T) {
+	assert.Equal(t, "pending", business.PendingRefreshStatusPending)
+	assert.Equal(t, "approved", business.PendingRefreshStatusApproved)
+	assert.Equal(t, "rejected", business.PendingRefreshStatusRejected)
+	assert.Equal(t, "expired", business.PendingRefreshStatusExpired)
+}
+
+func TestErrPendingRefreshNotFound(t *testing.T) {
+	assert.NotNil(t, business.ErrPendingRefreshNotFound)
+	assert.Equal(t, "pending refresh not found", business.ErrPendingRefreshNotFound.Error())
+}

--- a/pkg/storage/interfaces/business/refresh_policy_store.go
+++ b/pkg/storage/interfaces/business/refresh_policy_store.go
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+// Package business defines the RefreshPolicyStore interface for per-tenant
+// registration-refresh policy (ADR-010 §4, Issue #2093).
+package business
+
+import "context"
+
+// RefreshPolicy describes how the controller handles registration-refresh
+// requests from archived or dormant stewards within a given tenant.
+type RefreshPolicy struct {
+	// TenantID is the tenant this policy applies to.
+	TenantID string
+
+	// Mode controls the default disposition for incoming refresh requests:
+	//   "auto_accept"      — approve automatically when provenance score is sufficient
+	//   "require_approval" — queue for manual operator review (default, ADR-010 §4)
+	//   "reject"           — deny all refresh requests for this tenant
+	Mode string
+
+	// MaxDormancyDays is the maximum number of days a steward may remain in the
+	// archived state before being transitioned to dormant and auto-rejected.
+	// Nil means the dormancy backstop is disabled (default OFF, ADR-010 §4).
+	MaxDormancyDays *int
+}
+
+// RefreshPolicyStore defines the storage interface for per-tenant refresh policies.
+type RefreshPolicyStore interface {
+	// GetPolicy returns the refresh policy for the given tenant.
+	// When no record exists, it returns a default policy of
+	// {Mode: "require_approval", MaxDormancyDays: nil} without error.
+	GetPolicy(ctx context.Context, tenantID string) (*RefreshPolicy, error)
+
+	// SetPolicy creates or replaces the refresh policy for the tenant identified
+	// by policy.TenantID. A nil policy returns an error.
+	SetPolicy(ctx context.Context, policy *RefreshPolicy) error
+}

--- a/pkg/storage/interfaces/business/refresh_policy_store_test.go
+++ b/pkg/storage/interfaces/business/refresh_policy_store_test.go
@@ -1,0 +1,116 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+package business_test
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cfgis/cfgms/pkg/storage/interfaces/business"
+)
+
+// inMemRefreshPolicyStore is a minimal in-memory RefreshPolicyStore for contract tests.
+type inMemRefreshPolicyStore struct {
+	mu       sync.RWMutex
+	policies map[string]*business.RefreshPolicy
+}
+
+func newInMemRefreshPolicyStore() business.RefreshPolicyStore {
+	return &inMemRefreshPolicyStore{policies: make(map[string]*business.RefreshPolicy)}
+}
+
+func (s *inMemRefreshPolicyStore) GetPolicy(_ context.Context, tenantID string) (*business.RefreshPolicy, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	p, ok := s.policies[tenantID]
+	if !ok {
+		return &business.RefreshPolicy{
+			TenantID:        tenantID,
+			Mode:            "require_approval",
+			MaxDormancyDays: nil,
+		}, nil
+	}
+	cp := *p
+	if cp.MaxDormancyDays != nil {
+		v := *cp.MaxDormancyDays
+		cp.MaxDormancyDays = &v
+	}
+	return &cp, nil
+}
+
+func (s *inMemRefreshPolicyStore) SetPolicy(_ context.Context, policy *business.RefreshPolicy) error {
+	if policy == nil {
+		return errStr("nil policy")
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	cp := *policy
+	if cp.MaxDormancyDays != nil {
+		v := *cp.MaxDormancyDays
+		cp.MaxDormancyDays = &v
+	}
+	s.policies[policy.TenantID] = &cp
+	return nil
+}
+
+// Compile-time assertion.
+var _ business.RefreshPolicyStore = (*inMemRefreshPolicyStore)(nil)
+
+// --- Contract tests ---
+
+func TestRefreshPolicyStore_DefaultPolicy_Contract(t *testing.T) {
+	store := newInMemRefreshPolicyStore()
+
+	got, err := store.GetPolicy(context.Background(), "tenant-absent")
+	require.NoError(t, err, "absent record must not be an error")
+	require.NotNil(t, got)
+	assert.Equal(t, "tenant-absent", got.TenantID)
+	assert.Equal(t, "require_approval", got.Mode)
+	assert.Nil(t, got.MaxDormancyDays, "MaxDormancyDays must default to nil (backstop OFF)")
+}
+
+func TestRefreshPolicyStore_SetAndGet_Contract(t *testing.T) {
+	store := newInMemRefreshPolicyStore()
+	ctx := context.Background()
+
+	days := 30
+	require.NoError(t, store.SetPolicy(ctx, &business.RefreshPolicy{
+		TenantID:        "tenant-1",
+		Mode:            "auto_accept",
+		MaxDormancyDays: &days,
+	}))
+
+	got, err := store.GetPolicy(ctx, "tenant-1")
+	require.NoError(t, err)
+	assert.Equal(t, "auto_accept", got.Mode)
+	require.NotNil(t, got.MaxDormancyDays)
+	assert.Equal(t, 30, *got.MaxDormancyDays)
+}
+
+func TestRefreshPolicyStore_SetOverwrites_Contract(t *testing.T) {
+	store := newInMemRefreshPolicyStore()
+	ctx := context.Background()
+
+	require.NoError(t, store.SetPolicy(ctx, &business.RefreshPolicy{TenantID: "t-upd", Mode: "auto_accept"}))
+	require.NoError(t, store.SetPolicy(ctx, &business.RefreshPolicy{TenantID: "t-upd", Mode: "reject"}))
+
+	got, err := store.GetPolicy(ctx, "t-upd")
+	require.NoError(t, err)
+	assert.Equal(t, "reject", got.Mode)
+}
+
+func TestRefreshPolicyStore_SetNilPolicy_Contract(t *testing.T) {
+	store := newInMemRefreshPolicyStore()
+	err := store.SetPolicy(context.Background(), nil)
+	require.Error(t, err)
+}
+
+func TestRefreshPolicyStore_ModeValues(t *testing.T) {
+	assert.Equal(t, "require_approval", "require_approval")
+	assert.Equal(t, "auto_accept", "auto_accept")
+	assert.Equal(t, "reject", "reject")
+}

--- a/pkg/storage/interfaces/business/steward_store.go
+++ b/pkg/storage/interfaces/business/steward_store.go
@@ -15,6 +15,12 @@ var ErrStewardNotFound = errors.New("steward not found")
 // ErrStewardAlreadyExists is returned when attempting to register an already-registered steward.
 var ErrStewardAlreadyExists = errors.New("steward already exists")
 
+// ErrStewardRevoked is returned by callers of GetStewardByDeviceID when the
+// returned record has Status == StewardStatusRevoked. The gate handler must
+// check for revocation before verifying the proof-of-possession signature
+// (revocation-before-PoP invariant, ADR-010 §3).
+var ErrStewardRevoked = errors.New("steward revoked")
+
 // StewardStatus represents the lifecycle state of a steward in the fleet.
 // Records are never deleted; deregistered stewards are retained for audit.
 type StewardStatus string
@@ -33,6 +39,24 @@ const (
 	// StewardStatusDeregistered indicates the steward has been explicitly deregistered.
 	// Records are retained for audit history.
 	StewardStatusDeregistered StewardStatus = "deregistered"
+
+	// StewardStatusArchived indicates the steward's mTLS cert has expired and the
+	// steward is offline. The steward may re-enter the fleet via the registration-refresh
+	// flow (ADR-010). A pending_refresh_requests entry is created when a refresh challenge
+	// is received for an archived steward.
+	StewardStatusArchived StewardStatus = "archived"
+
+	// StewardStatusDormant indicates the steward has been archived for longer than
+	// RefreshPolicy.MaxDormancyDays. Refresh requests are auto-rejected unless an
+	// operator overrides the policy. MaxDormancyDays == nil means the dormancy backstop
+	// is disabled (default OFF, ADR-010 §4).
+	StewardStatusDormant StewardStatus = "dormant"
+
+	// StewardStatusRevoked indicates the steward has been permanently denied re-entry.
+	// GetStewardByDeviceID returns the record regardless; callers must check the status
+	// and return ErrStewardRevoked before performing any proof-of-possession verification
+	// (revocation-before-PoP ordering invariant, ADR-010 §3).
+	StewardStatusRevoked StewardStatus = "revoked"
 )
 
 // StewardRecord holds the durable fleet registration data for a single steward.
@@ -74,6 +98,25 @@ type StewardRecord struct {
 	// LastHeartbeatAt is the time of the last explicit heartbeat RPC.
 	// Distinct from LastSeen: a steward may be visible (last_seen recent) without sending heartbeats.
 	LastHeartbeatAt time.Time `json:"last_heartbeat_at"`
+
+	// DeviceID is the 64-character lowercase hex fingerprint of the steward's Ed25519
+	// identity key. Set by S2c (populate-identity-fields story). Empty for stewards
+	// registered before ADR-010 was implemented.
+	DeviceID string `json:"device_id"`
+
+	// IdentityKeyPub is the raw 32-byte Ed25519 public key for this steward's device
+	// identity. Separate from the rotating mTLS certificate (ADR-010 §1). Set by S2c.
+	IdentityKeyPub []byte `json:"identity_key_pub"`
+
+	// KeyProtectionLevel describes how the private key material is protected on the
+	// steward host: "file" (software-only) or "tpm" (hardware-backed). Set by S2c.
+	KeyProtectionLevel string `json:"key_protection_level"`
+
+	// LastProvenanceJSON is the last observed provenance snapshot serialised as JSON.
+	// Provenance is a set of device-identity signals (hostname, MAC, CPU serial, etc.)
+	// used by the gate handler (S3b) to score re-entry confidence. Updated at each
+	// successful refresh. Empty until the first refresh cycle completes.
+	LastProvenanceJSON string `json:"last_provenance_json"`
 }
 
 // StewardFilter defines criteria for filtering steward queries.
@@ -103,6 +146,14 @@ type StewardStore interface {
 	// GetSteward retrieves the record for the given steward ID.
 	// Returns ErrStewardNotFound if no record exists.
 	GetSteward(ctx context.Context, stewardID string) (*StewardRecord, error)
+
+	// GetStewardByDeviceID retrieves the record whose DeviceID matches the given
+	// 64-character hex fingerprint. Returns ErrStewardNotFound when no matching
+	// record exists. Callers must inspect the returned record's Status field and
+	// return ErrStewardRevoked if Status == StewardStatusRevoked — the store does
+	// not surface the revocation error directly (ADR-010 §3 revocation-before-PoP
+	// ordering invariant).
+	GetStewardByDeviceID(ctx context.Context, deviceID string) (*StewardRecord, error)
 
 	// ListStewards returns all steward records regardless of status.
 	ListStewards(ctx context.Context) ([]*StewardRecord, error)

--- a/pkg/storage/interfaces/provider_test.go
+++ b/pkg/storage/interfaces/provider_test.go
@@ -431,6 +431,9 @@ func (m *MockStewardStore) DeregisterSteward(_ context.Context, _ string) error 
 func (m *MockStewardStore) GetStewardsSeen(_ context.Context, _ time.Time) ([]*business.StewardRecord, error) {
 	return nil, nil
 }
+func (m *MockStewardStore) GetStewardByDeviceID(_ context.Context, _ string) (*business.StewardRecord, error) {
+	return nil, business.ErrStewardNotFound
+}
 func (m *MockStewardStore) HealthCheck(_ context.Context) error { return nil }
 func (m *MockStewardStore) Initialize(_ context.Context) error  { return nil }
 func (m *MockStewardStore) Close() error                        { return nil }

--- a/pkg/storage/providers/flatfile/steward_store.go
+++ b/pkg/storage/providers/flatfile/steward_store.go
@@ -137,6 +137,27 @@ func (s *FlatFileStewardStore) GetSteward(_ context.Context, stewardID string) (
 	return s.readSteward(stewardID)
 }
 
+// GetStewardByDeviceID returns the record whose DeviceID matches the given
+// 64-character hex fingerprint. Scans all steward files via readAllStewards.
+// Returns ErrStewardNotFound when no matching record exists.
+func (s *FlatFileStewardStore) GetStewardByDeviceID(_ context.Context, deviceID string) (*business.StewardRecord, error) {
+	if deviceID == "" {
+		return nil, fmt.Errorf("flatfile: device ID cannot be empty")
+	}
+	s.mutex.RLock()
+	defer s.mutex.RUnlock()
+	all, err := s.readAllStewards()
+	if err != nil {
+		return nil, err
+	}
+	for _, r := range all {
+		if r.DeviceID == deviceID {
+			return r, nil
+		}
+	}
+	return nil, business.ErrStewardNotFound
+}
+
 // ListStewards returns all steward records. Reads every file in the stewards directory.
 // For large fleets this is O(n); prefer the SQLite provider if query latency matters.
 func (s *FlatFileStewardStore) ListStewards(_ context.Context) ([]*business.StewardRecord, error) {

--- a/pkg/storage/providers/flatfile/steward_store_test.go
+++ b/pkg/storage/providers/flatfile/steward_store_test.go
@@ -243,3 +243,37 @@ func TestFlatFileStewardStore_DeregisterNotFound(t *testing.T) {
 	err = store.DeregisterSteward(context.Background(), "ghost")
 	assert.ErrorIs(t, err, business.ErrStewardNotFound)
 }
+
+func TestFlatFileStewardStore_GetStewardByDeviceID(t *testing.T) {
+	store, err := NewFlatFileStewardStore(t.TempDir())
+	require.NoError(t, err)
+	defer func() { _ = store.Close() }()
+
+	ctx := context.Background()
+
+	const deviceID = "aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899"
+	rec := testStewardRecord("s-dvc")
+	rec.DeviceID = deviceID
+	rec.IdentityKeyPub = []byte{0xde, 0xad}
+	rec.KeyProtectionLevel = "file"
+	rec.LastProvenanceJSON = `{"hostname":"host-s-dvc"}`
+	require.NoError(t, store.RegisterSteward(ctx, rec))
+
+	got, err := store.GetStewardByDeviceID(ctx, deviceID)
+	require.NoError(t, err)
+	assert.Equal(t, "s-dvc", got.ID)
+	assert.Equal(t, deviceID, got.DeviceID)
+	assert.Equal(t, []byte{0xde, 0xad}, got.IdentityKeyPub)
+	assert.Equal(t, "file", got.KeyProtectionLevel)
+	assert.Equal(t, `{"hostname":"host-s-dvc"}`, got.LastProvenanceJSON)
+
+	_, err = store.GetStewardByDeviceID(ctx, "0000000000000000000000000000000000000000000000000000000000000000")
+	assert.ErrorIs(t, err, business.ErrStewardNotFound)
+}
+
+func TestFlatFileStewardStore_GetStewardByDeviceID_EmptyID(t *testing.T) {
+	store, err := NewFlatFileStewardStore(t.TempDir())
+	require.NoError(t, err)
+	_, err = store.GetStewardByDeviceID(context.Background(), "")
+	require.Error(t, err, "empty device ID must return an error")
+}

--- a/pkg/storage/providers/sqlite/pending_refresh_store.go
+++ b/pkg/storage/providers/sqlite/pending_refresh_store.go
@@ -1,0 +1,253 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+// Package sqlite implements PendingRefreshStore using the pending_refresh_requests
+// table — the registration-refresh durable queue (ADR-010, Issue #2093).
+package sqlite
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"strings"
+	"time"
+
+	business "github.com/cfgis/cfgms/pkg/storage/interfaces/business"
+)
+
+// Compile-time assertion.
+var _ business.PendingRefreshStore = (*SQLitePendingRefreshStore)(nil)
+
+// SQLitePendingRefreshStore implements business.PendingRefreshStore using a
+// SQLite database backed by the pending_refresh_requests table.
+type SQLitePendingRefreshStore struct {
+	db *sql.DB
+}
+
+// Close closes the underlying database connection.
+func (s *SQLitePendingRefreshStore) Close() error {
+	if s.db != nil {
+		return s.db.Close()
+	}
+	return nil
+}
+
+// AddPendingRefresh inserts a new pending-refresh entry.
+// Returns an error if an entry with the same PendingID already exists.
+func (s *SQLitePendingRefreshStore) AddPendingRefresh(ctx context.Context, entry *business.PendingRefreshEntry) error {
+	if entry == nil {
+		return fmt.Errorf("sqlite: pending refresh entry cannot be nil")
+	}
+	if entry.PendingID == "" {
+		return fmt.Errorf("sqlite: pending_id cannot be empty")
+	}
+	if entry.DeviceID == "" {
+		return fmt.Errorf("sqlite: device_id cannot be empty")
+	}
+	if entry.TenantID == "" {
+		return fmt.Errorf("sqlite: tenant_id cannot be empty")
+	}
+
+	createdAt := entry.CreatedAt
+	if createdAt.IsZero() {
+		createdAt = nowUTC()
+	}
+	status := entry.Status
+	if status == "" {
+		status = business.PendingRefreshStatusPending
+	}
+
+	claimBundle := entry.ClaimBundle
+	if claimBundle == nil {
+		claimBundle = []byte{}
+	}
+
+	_, err := s.db.ExecContext(ctx, `
+		INSERT INTO pending_refresh_requests
+			(pending_id, device_id, tenant_id, source_ip,
+			 provenance_matched_fields, provenance_total_fields,
+			 claim_bundle, status, created_at, expires_at, resolved_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		entry.PendingID,
+		entry.DeviceID,
+		entry.TenantID,
+		entry.SourceIP,
+		entry.ProvenanceMatchedFields,
+		entry.ProvenanceTotalFields,
+		claimBundle,
+		status,
+		formatTime(createdAt),
+		formatTime(entry.ExpiresAt),
+		formatNullTime(entry.ResolvedAt),
+	)
+	if err != nil {
+		if strings.Contains(err.Error(), "UNIQUE constraint failed") {
+			return fmt.Errorf("sqlite: pending refresh %s already exists", entry.PendingID)
+		}
+		return fmt.Errorf("sqlite: failed to add pending refresh %s: %w", entry.PendingID, err)
+	}
+	return nil
+}
+
+// GetPendingRefreshByID retrieves the entry for the given pending_id.
+// Returns ErrPendingRefreshNotFound if no record exists.
+func (s *SQLitePendingRefreshStore) GetPendingRefreshByID(ctx context.Context, pendingID string) (*business.PendingRefreshEntry, error) {
+	row := s.db.QueryRowContext(ctx, `
+		SELECT pending_id, device_id, tenant_id, source_ip,
+		       provenance_matched_fields, provenance_total_fields,
+		       claim_bundle, status, created_at, expires_at, resolved_at
+		FROM pending_refresh_requests WHERE pending_id = ?`, pendingID)
+	return scanRefreshEntry(row)
+}
+
+// UpdateRefreshStatus updates the status of the entry identified by pendingID.
+// For terminal statuses (approved, rejected), resolved_at is also set to now.
+// Returns ErrPendingRefreshNotFound if no record exists.
+func (s *SQLitePendingRefreshStore) UpdateRefreshStatus(ctx context.Context, pendingID, status string) error {
+	var res sql.Result
+	var err error
+
+	isTerminal := status == business.PendingRefreshStatusApproved ||
+		status == business.PendingRefreshStatusRejected
+	if isTerminal {
+		res, err = s.db.ExecContext(ctx, `
+			UPDATE pending_refresh_requests
+			SET status = ?, resolved_at = ?
+			WHERE pending_id = ?`,
+			status, formatTime(nowUTC()), pendingID,
+		)
+	} else {
+		res, err = s.db.ExecContext(ctx, `
+			UPDATE pending_refresh_requests SET status = ? WHERE pending_id = ?`,
+			status, pendingID,
+		)
+	}
+	if err != nil {
+		return fmt.Errorf("sqlite: failed to update refresh status for %s: %w", pendingID, err)
+	}
+	n, _ := res.RowsAffected()
+	if n == 0 {
+		return business.ErrPendingRefreshNotFound
+	}
+	return nil
+}
+
+// ListPendingRefresh returns all entries for the given tenantID ordered by
+// created_at ascending. An empty tenantID returns entries for all tenants.
+func (s *SQLitePendingRefreshStore) ListPendingRefresh(ctx context.Context, tenantID string) ([]*business.PendingRefreshEntry, error) {
+	var (
+		query string
+		args  []interface{}
+	)
+	if tenantID == "" {
+		query = `
+			SELECT pending_id, device_id, tenant_id, source_ip,
+			       provenance_matched_fields, provenance_total_fields,
+			       claim_bundle, status, created_at, expires_at, resolved_at
+			FROM pending_refresh_requests ORDER BY created_at ASC`
+	} else {
+		query = `
+			SELECT pending_id, device_id, tenant_id, source_ip,
+			       provenance_matched_fields, provenance_total_fields,
+			       claim_bundle, status, created_at, expires_at, resolved_at
+			FROM pending_refresh_requests WHERE tenant_id = ? ORDER BY created_at ASC`
+		args = []interface{}{tenantID}
+	}
+
+	rows, err := s.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("sqlite: failed to list pending refresh requests: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var entries []*business.PendingRefreshEntry
+	for rows.Next() {
+		e, err := scanRefreshRow(rows)
+		if err != nil {
+			return nil, fmt.Errorf("sqlite: failed to scan pending refresh row: %w", err)
+		}
+		entries = append(entries, e)
+	}
+	return entries, rows.Err()
+}
+
+// ExpireStaleRefresh marks entries whose expires_at is at or before cutoff and
+// whose status is "pending" as "expired", setting resolved_at to now.
+func (s *SQLitePendingRefreshStore) ExpireStaleRefresh(ctx context.Context, cutoff time.Time) (int, error) {
+	res, err := s.db.ExecContext(ctx, `
+		UPDATE pending_refresh_requests
+		SET status = ?, resolved_at = ?
+		WHERE status = ? AND expires_at <= ?`,
+		business.PendingRefreshStatusExpired,
+		formatTime(nowUTC()),
+		business.PendingRefreshStatusPending,
+		formatTime(cutoff),
+	)
+	if err != nil {
+		return 0, fmt.Errorf("sqlite: failed to expire stale refresh requests: %w", err)
+	}
+	n, _ := res.RowsAffected()
+	return int(n), nil
+}
+
+// StoreClaimBundle persists the proof-of-possession payload for the given pendingID.
+// Returns ErrPendingRefreshNotFound if no record exists.
+func (s *SQLitePendingRefreshStore) StoreClaimBundle(ctx context.Context, pendingID string, bundle []byte) error {
+	res, err := s.db.ExecContext(ctx, `
+		UPDATE pending_refresh_requests SET claim_bundle = ? WHERE pending_id = ?`,
+		bundle, pendingID,
+	)
+	if err != nil {
+		return fmt.Errorf("sqlite: failed to store claim bundle for %s: %w", pendingID, err)
+	}
+	n, _ := res.RowsAffected()
+	if n == 0 {
+		return business.ErrPendingRefreshNotFound
+	}
+	return nil
+}
+
+// --- helpers -----------------------------------------------------------------
+
+// scanRefreshEntry scans a single row from a QueryRowContext call.
+func scanRefreshEntry(row *sql.Row) (*business.PendingRefreshEntry, error) {
+	e := &business.PendingRefreshEntry{}
+	var createdStr, expiresStr string
+	var resolvedStr sql.NullString
+	var claimBundle []byte
+	err := row.Scan(
+		&e.PendingID, &e.DeviceID, &e.TenantID, &e.SourceIP,
+		&e.ProvenanceMatchedFields, &e.ProvenanceTotalFields,
+		&claimBundle, &e.Status, &createdStr, &expiresStr, &resolvedStr,
+	)
+	if err == sql.ErrNoRows {
+		return nil, business.ErrPendingRefreshNotFound
+	}
+	if err != nil {
+		return nil, fmt.Errorf("sqlite: failed to scan pending refresh: %w", err)
+	}
+	e.ClaimBundle = claimBundle
+	e.CreatedAt = parseTime(createdStr)
+	e.ExpiresAt = parseTime(expiresStr)
+	e.ResolvedAt = parseNullTime(resolvedStr)
+	return e, nil
+}
+
+// scanRefreshRow scans a single row from an open Rows cursor.
+func scanRefreshRow(rows *sql.Rows) (*business.PendingRefreshEntry, error) {
+	e := &business.PendingRefreshEntry{}
+	var createdStr, expiresStr string
+	var resolvedStr sql.NullString
+	var claimBundle []byte
+	if err := rows.Scan(
+		&e.PendingID, &e.DeviceID, &e.TenantID, &e.SourceIP,
+		&e.ProvenanceMatchedFields, &e.ProvenanceTotalFields,
+		&claimBundle, &e.Status, &createdStr, &expiresStr, &resolvedStr,
+	); err != nil {
+		return nil, err
+	}
+	e.ClaimBundle = claimBundle
+	e.CreatedAt = parseTime(createdStr)
+	e.ExpiresAt = parseTime(expiresStr)
+	e.ResolvedAt = parseNullTime(resolvedStr)
+	return e, nil
+}

--- a/pkg/storage/providers/sqlite/pending_refresh_store_test.go
+++ b/pkg/storage/providers/sqlite/pending_refresh_store_test.go
@@ -1,0 +1,230 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+package sqlite
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	business "github.com/cfgis/cfgms/pkg/storage/interfaces/business"
+)
+
+// newTestPendingRefreshStore opens an in-memory SQLite store for testing.
+func newTestPendingRefreshStore(t *testing.T) *SQLitePendingRefreshStore {
+	t.Helper()
+	db, err := openAndInit(":memory:")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+	return &SQLitePendingRefreshStore{db: db}
+}
+
+// testRefreshEntry returns a PendingRefreshEntry with sensible defaults.
+func testRefreshEntry(pendingID, deviceID, tenantID string) *business.PendingRefreshEntry {
+	now := time.Now().UTC().Truncate(time.Second)
+	return &business.PendingRefreshEntry{
+		PendingID:               pendingID,
+		DeviceID:                deviceID,
+		TenantID:                tenantID,
+		SourceIP:                "10.0.0.5",
+		ProvenanceMatchedFields: 3,
+		ProvenanceTotalFields:   5,
+		Status:                  business.PendingRefreshStatusPending,
+		CreatedAt:               now,
+		ExpiresAt:               now.Add(65 * time.Second),
+	}
+}
+
+// TestPendingRefreshStore_RoundTrip verifies Add → Get → StoreClaimBundle →
+// UpdateRefreshStatus with full field fidelity (Issue #2093 AC).
+func TestPendingRefreshStore_RoundTrip(t *testing.T) {
+	store := newTestPendingRefreshStore(t)
+	ctx := context.Background()
+
+	const deviceID = "aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899"
+	entry := testRefreshEntry("pr-rt-1", deviceID, "tenant-rt")
+
+	// Add
+	require.NoError(t, store.AddPendingRefresh(ctx, entry))
+
+	// Get — verify field fidelity
+	got, err := store.GetPendingRefreshByID(ctx, "pr-rt-1")
+	require.NoError(t, err)
+	assert.Equal(t, "pr-rt-1", got.PendingID)
+	assert.Equal(t, deviceID, got.DeviceID)
+	assert.Equal(t, "tenant-rt", got.TenantID)
+	assert.Equal(t, "10.0.0.5", got.SourceIP)
+	assert.Equal(t, 3, got.ProvenanceMatchedFields)
+	assert.Equal(t, 5, got.ProvenanceTotalFields)
+	assert.Equal(t, business.PendingRefreshStatusPending, got.Status)
+	assert.WithinDuration(t, entry.CreatedAt, got.CreatedAt, time.Second)
+	assert.WithinDuration(t, entry.ExpiresAt, got.ExpiresAt, time.Second)
+	assert.Nil(t, got.ResolvedAt)
+	assert.Empty(t, got.ClaimBundle)
+
+	// StoreClaimBundle
+	bundle := []byte(`{"nonce":"abc123","signature":"deadbeef"}`)
+	require.NoError(t, store.StoreClaimBundle(ctx, "pr-rt-1", bundle))
+
+	got2, err := store.GetPendingRefreshByID(ctx, "pr-rt-1")
+	require.NoError(t, err)
+	assert.Equal(t, bundle, got2.ClaimBundle)
+
+	// UpdateRefreshStatus to approved (terminal — sets resolved_at)
+	before := time.Now().UTC()
+	require.NoError(t, store.UpdateRefreshStatus(ctx, "pr-rt-1", business.PendingRefreshStatusApproved))
+
+	got3, err := store.GetPendingRefreshByID(ctx, "pr-rt-1")
+	require.NoError(t, err)
+	assert.Equal(t, business.PendingRefreshStatusApproved, got3.Status)
+	require.NotNil(t, got3.ResolvedAt)
+	assert.WithinDuration(t, before, *got3.ResolvedAt, 2*time.Second)
+}
+
+func TestPendingRefreshStore_GetByID_NotFound(t *testing.T) {
+	store := newTestPendingRefreshStore(t)
+	_, err := store.GetPendingRefreshByID(context.Background(), "nonexistent")
+	assert.ErrorIs(t, err, business.ErrPendingRefreshNotFound)
+}
+
+func TestPendingRefreshStore_AddNil(t *testing.T) {
+	store := newTestPendingRefreshStore(t)
+	err := store.AddPendingRefresh(context.Background(), nil)
+	require.Error(t, err)
+}
+
+func TestPendingRefreshStore_AddEmptyPendingID(t *testing.T) {
+	store := newTestPendingRefreshStore(t)
+	entry := testRefreshEntry("", "devid", "t1")
+	err := store.AddPendingRefresh(context.Background(), entry)
+	require.Error(t, err)
+}
+
+func TestPendingRefreshStore_AddEmptyDeviceID(t *testing.T) {
+	store := newTestPendingRefreshStore(t)
+	entry := testRefreshEntry("pr-1", "", "t1")
+	err := store.AddPendingRefresh(context.Background(), entry)
+	require.Error(t, err)
+}
+
+func TestPendingRefreshStore_AddDuplicate(t *testing.T) {
+	store := newTestPendingRefreshStore(t)
+	ctx := context.Background()
+
+	entry := testRefreshEntry("pr-dup", "devid1", "t1")
+	require.NoError(t, store.AddPendingRefresh(ctx, entry))
+	err := store.AddPendingRefresh(ctx, entry)
+	require.Error(t, err, "duplicate pending_id must fail")
+}
+
+func TestPendingRefreshStore_UpdateRefreshStatus_NotFound(t *testing.T) {
+	store := newTestPendingRefreshStore(t)
+	err := store.UpdateRefreshStatus(context.Background(), "missing", business.PendingRefreshStatusApproved)
+	assert.ErrorIs(t, err, business.ErrPendingRefreshNotFound)
+}
+
+func TestPendingRefreshStore_UpdateRefreshStatus_Rejected(t *testing.T) {
+	store := newTestPendingRefreshStore(t)
+	ctx := context.Background()
+
+	entry := testRefreshEntry("pr-rej", "devid2", "t1")
+	require.NoError(t, store.AddPendingRefresh(ctx, entry))
+
+	before := time.Now().UTC()
+	require.NoError(t, store.UpdateRefreshStatus(ctx, "pr-rej", business.PendingRefreshStatusRejected))
+
+	got, err := store.GetPendingRefreshByID(ctx, "pr-rej")
+	require.NoError(t, err)
+	assert.Equal(t, business.PendingRefreshStatusRejected, got.Status)
+	require.NotNil(t, got.ResolvedAt)
+	assert.WithinDuration(t, before, *got.ResolvedAt, 2*time.Second)
+}
+
+func TestPendingRefreshStore_StoreClaimBundle_NotFound(t *testing.T) {
+	store := newTestPendingRefreshStore(t)
+	err := store.StoreClaimBundle(context.Background(), "ghost", []byte("bundle"))
+	assert.ErrorIs(t, err, business.ErrPendingRefreshNotFound)
+}
+
+func TestPendingRefreshStore_ListPendingRefresh_AllTenants(t *testing.T) {
+	store := newTestPendingRefreshStore(t)
+	ctx := context.Background()
+
+	require.NoError(t, store.AddPendingRefresh(ctx, testRefreshEntry("pr-a", "dev-a", "tenant-1")))
+	require.NoError(t, store.AddPendingRefresh(ctx, testRefreshEntry("pr-b", "dev-b", "tenant-2")))
+
+	entries, err := store.ListPendingRefresh(ctx, "")
+	require.NoError(t, err)
+	assert.Len(t, entries, 2)
+}
+
+func TestPendingRefreshStore_ListPendingRefresh_FilterByTenant(t *testing.T) {
+	store := newTestPendingRefreshStore(t)
+	ctx := context.Background()
+
+	require.NoError(t, store.AddPendingRefresh(ctx, testRefreshEntry("pr-t1", "dev-t1", "tenant-1")))
+	require.NoError(t, store.AddPendingRefresh(ctx, testRefreshEntry("pr-t2", "dev-t2", "tenant-2")))
+
+	entries, err := store.ListPendingRefresh(ctx, "tenant-2")
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+	assert.Equal(t, "pr-t2", entries[0].PendingID)
+}
+
+func TestPendingRefreshStore_ExpireStaleRefresh(t *testing.T) {
+	store := newTestPendingRefreshStore(t)
+	ctx := context.Background()
+
+	past := time.Now().UTC().Add(-2 * time.Hour)
+	future := time.Now().UTC().Add(24 * time.Hour)
+
+	stale := testRefreshEntry("pr-stale", "dev-stale", "tenant-1")
+	stale.ExpiresAt = past
+	require.NoError(t, store.AddPendingRefresh(ctx, stale))
+
+	active := testRefreshEntry("pr-active", "dev-active", "tenant-1")
+	active.ExpiresAt = future
+	require.NoError(t, store.AddPendingRefresh(ctx, active))
+
+	count, err := store.ExpireStaleRefresh(ctx, time.Now().UTC())
+	require.NoError(t, err)
+	assert.Equal(t, 1, count)
+
+	got, err := store.GetPendingRefreshByID(ctx, "pr-stale")
+	require.NoError(t, err)
+	assert.Equal(t, business.PendingRefreshStatusExpired, got.Status)
+	assert.NotNil(t, got.ResolvedAt)
+
+	activeGot, err := store.GetPendingRefreshByID(ctx, "pr-active")
+	require.NoError(t, err)
+	assert.Equal(t, business.PendingRefreshStatusPending, activeGot.Status)
+}
+
+func TestPendingRefreshStore_ExpireStaleRefresh_SkipsNonPending(t *testing.T) {
+	store := newTestPendingRefreshStore(t)
+	ctx := context.Background()
+
+	past := time.Now().UTC().Add(-1 * time.Hour)
+	entry := testRefreshEntry("pr-appr", "dev-appr", "tenant-1")
+	entry.ExpiresAt = past
+	require.NoError(t, store.AddPendingRefresh(ctx, entry))
+	require.NoError(t, store.UpdateRefreshStatus(ctx, "pr-appr", business.PendingRefreshStatusApproved))
+
+	count, err := store.ExpireStaleRefresh(ctx, time.Now().UTC())
+	require.NoError(t, err)
+	assert.Equal(t, 0, count, "approved entries must not be expired")
+
+	got, err := store.GetPendingRefreshByID(ctx, "pr-appr")
+	require.NoError(t, err)
+	assert.Equal(t, business.PendingRefreshStatusApproved, got.Status)
+}
+
+func TestPendingRefreshStore_AddEmptyTenantID(t *testing.T) {
+	store := newTestPendingRefreshStore(t)
+	entry := testRefreshEntry("pr-notenant", "dev-1", "")
+	err := store.AddPendingRefresh(context.Background(), entry)
+	require.Error(t, err, "empty tenant_id must return an error")
+}

--- a/pkg/storage/providers/sqlite/refresh_policy_store.go
+++ b/pkg/storage/providers/sqlite/refresh_policy_store.go
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+// Package sqlite implements RefreshPolicyStore using the refresh_policies table
+// (ADR-010 §4, Issue #2093).
+package sqlite
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+
+	business "github.com/cfgis/cfgms/pkg/storage/interfaces/business"
+)
+
+// Compile-time assertion.
+var _ business.RefreshPolicyStore = (*SQLiteRefreshPolicyStore)(nil)
+
+// SQLiteRefreshPolicyStore implements business.RefreshPolicyStore using a
+// SQLite database backed by the refresh_policies table.
+type SQLiteRefreshPolicyStore struct {
+	db *sql.DB
+}
+
+// Close closes the underlying database connection.
+func (s *SQLiteRefreshPolicyStore) Close() error {
+	if s.db != nil {
+		return s.db.Close()
+	}
+	return nil
+}
+
+// GetPolicy returns the refresh policy for the given tenant. When no record
+// exists, it returns a default policy of {Mode: "require_approval",
+// MaxDormancyDays: nil} without error (ADR-010 §4).
+func (s *SQLiteRefreshPolicyStore) GetPolicy(ctx context.Context, tenantID string) (*business.RefreshPolicy, error) {
+	row := s.db.QueryRowContext(ctx, `
+		SELECT tenant_id, mode, max_dormancy_days
+		FROM refresh_policies WHERE tenant_id = ?`, tenantID)
+
+	p := &business.RefreshPolicy{}
+	var maxDormancy sql.NullInt64
+	err := row.Scan(&p.TenantID, &p.Mode, &maxDormancy)
+	if err == sql.ErrNoRows {
+		return &business.RefreshPolicy{
+			TenantID:        tenantID,
+			Mode:            "require_approval",
+			MaxDormancyDays: nil,
+		}, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("sqlite: failed to get refresh policy for tenant %s: %w", tenantID, err)
+	}
+	if maxDormancy.Valid {
+		v := int(maxDormancy.Int64)
+		p.MaxDormancyDays = &v
+	}
+	return p, nil
+}
+
+// SetPolicy creates or replaces the refresh policy for the tenant identified
+// by policy.TenantID. Uses SQLite upsert semantics.
+func (s *SQLiteRefreshPolicyStore) SetPolicy(ctx context.Context, policy *business.RefreshPolicy) error {
+	if policy == nil {
+		return fmt.Errorf("sqlite: policy cannot be nil")
+	}
+	if policy.TenantID == "" {
+		return fmt.Errorf("sqlite: policy tenant_id cannot be empty")
+	}
+
+	_, err := s.db.ExecContext(ctx, `
+		INSERT INTO refresh_policies (tenant_id, mode, max_dormancy_days)
+		VALUES (?, ?, ?)
+		ON CONFLICT(tenant_id) DO UPDATE SET
+			mode              = excluded.mode,
+			max_dormancy_days = excluded.max_dormancy_days`,
+		policy.TenantID,
+		policy.Mode,
+		nullableInt(policy.MaxDormancyDays),
+	)
+	if err != nil {
+		return fmt.Errorf("sqlite: failed to set refresh policy for tenant %s: %w", policy.TenantID, err)
+	}
+	return nil
+}
+
+// nullableInt converts a *int to a value suitable for binding as a nullable
+// INTEGER column: nil pointers produce SQL NULL.
+func nullableInt(v *int) interface{} {
+	if v == nil {
+		return nil
+	}
+	return *v
+}

--- a/pkg/storage/providers/sqlite/refresh_policy_store_test.go
+++ b/pkg/storage/providers/sqlite/refresh_policy_store_test.go
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+package sqlite
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	business "github.com/cfgis/cfgms/pkg/storage/interfaces/business"
+)
+
+// newTestRefreshPolicyStore opens an in-memory SQLite store for testing.
+func newTestRefreshPolicyStore(t *testing.T) *SQLiteRefreshPolicyStore {
+	t.Helper()
+	db, err := openAndInit(":memory:")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+	return &SQLiteRefreshPolicyStore{db: db}
+}
+
+// TestRefreshPolicyStore_DefaultPolicy verifies that GetPolicy returns the
+// default require_approval policy when no record exists (ADR-010 §4, Issue #2093 AC).
+func TestRefreshPolicyStore_DefaultPolicy(t *testing.T) {
+	store := newTestRefreshPolicyStore(t)
+	ctx := context.Background()
+
+	got, err := store.GetPolicy(ctx, "tenant-no-record")
+	require.NoError(t, err, "absent record must not be an error")
+	require.NotNil(t, got)
+	assert.Equal(t, "tenant-no-record", got.TenantID)
+	assert.Equal(t, "require_approval", got.Mode)
+	assert.Nil(t, got.MaxDormancyDays, "MaxDormancyDays must default to nil (backstop OFF)")
+}
+
+func TestRefreshPolicyStore_SetAndGet(t *testing.T) {
+	store := newTestRefreshPolicyStore(t)
+	ctx := context.Background()
+
+	days := 30
+	policy := &business.RefreshPolicy{
+		TenantID:        "tenant-1",
+		Mode:            "auto_accept",
+		MaxDormancyDays: &days,
+	}
+	require.NoError(t, store.SetPolicy(ctx, policy))
+
+	got, err := store.GetPolicy(ctx, "tenant-1")
+	require.NoError(t, err)
+	assert.Equal(t, "tenant-1", got.TenantID)
+	assert.Equal(t, "auto_accept", got.Mode)
+	require.NotNil(t, got.MaxDormancyDays)
+	assert.Equal(t, 30, *got.MaxDormancyDays)
+}
+
+func TestRefreshPolicyStore_SetOverwritesExisting(t *testing.T) {
+	store := newTestRefreshPolicyStore(t)
+	ctx := context.Background()
+
+	require.NoError(t, store.SetPolicy(ctx, &business.RefreshPolicy{
+		TenantID: "tenant-upd",
+		Mode:     "auto_accept",
+	}))
+	require.NoError(t, store.SetPolicy(ctx, &business.RefreshPolicy{
+		TenantID: "tenant-upd",
+		Mode:     "reject",
+	}))
+
+	got, err := store.GetPolicy(ctx, "tenant-upd")
+	require.NoError(t, err)
+	assert.Equal(t, "reject", got.Mode, "second SetPolicy must overwrite")
+	assert.Nil(t, got.MaxDormancyDays)
+}
+
+func TestRefreshPolicyStore_NilMaxDormancyDays(t *testing.T) {
+	store := newTestRefreshPolicyStore(t)
+	ctx := context.Background()
+
+	require.NoError(t, store.SetPolicy(ctx, &business.RefreshPolicy{
+		TenantID:        "tenant-nil",
+		Mode:            "require_approval",
+		MaxDormancyDays: nil,
+	}))
+
+	got, err := store.GetPolicy(ctx, "tenant-nil")
+	require.NoError(t, err)
+	assert.Nil(t, got.MaxDormancyDays, "nil MaxDormancyDays must round-trip as nil")
+}
+
+func TestRefreshPolicyStore_SetNilPolicy(t *testing.T) {
+	store := newTestRefreshPolicyStore(t)
+	err := store.SetPolicy(context.Background(), nil)
+	require.Error(t, err)
+}
+
+func TestRefreshPolicyStore_SetEmptyTenantID(t *testing.T) {
+	store := newTestRefreshPolicyStore(t)
+	err := store.SetPolicy(context.Background(), &business.RefreshPolicy{Mode: "reject"})
+	require.Error(t, err)
+}

--- a/pkg/storage/providers/sqlite/schema.go
+++ b/pkg/storage/providers/sqlite/schema.go
@@ -9,7 +9,7 @@ import (
 	"fmt"
 )
 
-const currentSchemaVersion = 1
+const currentSchemaVersion = 2
 
 // tableExists reports whether the named table is present in the SQLite catalog.
 func tableExists(ctx context.Context, db *sql.DB, name string) (bool, error) {
@@ -83,6 +83,42 @@ func backfillAuditEntries(ctx context.Context, db *sql.DB) error {
 	return nil
 }
 
+// backfillStewardColumns adds the four registration-refresh identity columns to a
+// pre-existing stewards table that was created without them (Issue #2093, ADR-010).
+// Fresh databases (table absent) are skipped. Column-existence is checked via
+// PRAGMA before each ALTER TABLE so the pass is fully idempotent.
+func backfillStewardColumns(ctx context.Context, db *sql.DB) error {
+	exists, err := tableExists(ctx, db, "stewards")
+	if err != nil {
+		return fmt.Errorf("sqlite: steward back-fill probe failed: %w", err)
+	}
+	if !exists {
+		return nil
+	}
+	type col struct {
+		name string
+		ddl  string
+	}
+	for _, c := range []col{
+		{"device_id", `ALTER TABLE stewards ADD COLUMN device_id TEXT NOT NULL DEFAULT ''`},
+		{"identity_key_pub", `ALTER TABLE stewards ADD COLUMN identity_key_pub BLOB NOT NULL DEFAULT ''`},
+		{"key_protection_level", `ALTER TABLE stewards ADD COLUMN key_protection_level TEXT NOT NULL DEFAULT ''`},
+		{"last_provenance_json", `ALTER TABLE stewards ADD COLUMN last_provenance_json TEXT NOT NULL DEFAULT ''`},
+	} {
+		present, err := columnExists(ctx, db, "stewards", c.name)
+		if err != nil {
+			return fmt.Errorf("sqlite: steward back-fill column probe failed (%s): %w", c.name, err)
+		}
+		if present {
+			continue
+		}
+		if _, err := db.ExecContext(ctx, c.ddl); err != nil {
+			return fmt.Errorf("sqlite: stewards back-fill failed: %w\nSQL: %s", err, c.ddl)
+		}
+	}
+	return nil
+}
+
 // initializeSchema creates all tables and tracks schema version.
 // It is safe to call multiple times (all statements use IF NOT EXISTS).
 // All DDL statements are executed inside a single transaction to reduce WAL
@@ -90,6 +126,9 @@ func backfillAuditEntries(ctx context.Context, db *sql.DB) error {
 // transaction requires a full file-lock round-trip via the WAL SHM mechanism.
 func initializeSchema(ctx context.Context, db *sql.DB) error {
 	if err := backfillAuditEntries(ctx, db); err != nil {
+		return err
+	}
+	if err := backfillStewardColumns(ctx, db); err != nil {
 		return err
 	}
 
@@ -267,20 +306,28 @@ func initializeSchema(ctx context.Context, db *sql.DB) error {
 
 		// Stewards — durable fleet registry (ADR-003 §2, Issue #663)
 		// Records are never deleted; deregistered stewards are retained for audit.
+		// Columns device_id, identity_key_pub, key_protection_level, last_provenance_json
+		// were added in Issue #2093 (ADR-010 registration-refresh). Pre-existing rows
+		// receive empty defaults via backfillStewardColumns() before this transaction.
 		`CREATE TABLE IF NOT EXISTS stewards (
-			id                TEXT PRIMARY KEY,
-			hostname          TEXT NOT NULL DEFAULT '',
-			platform          TEXT NOT NULL DEFAULT '',
-			arch              TEXT NOT NULL DEFAULT '',
-			version           TEXT NOT NULL DEFAULT '',
-			ip_address        TEXT NOT NULL DEFAULT '',
-			status            TEXT NOT NULL DEFAULT 'registered',
-			registered_at     TEXT NOT NULL,
-			last_seen         TEXT NOT NULL,
-			last_heartbeat_at TEXT NOT NULL DEFAULT ''
+			id                   TEXT PRIMARY KEY,
+			hostname             TEXT NOT NULL DEFAULT '',
+			platform             TEXT NOT NULL DEFAULT '',
+			arch                 TEXT NOT NULL DEFAULT '',
+			version              TEXT NOT NULL DEFAULT '',
+			ip_address           TEXT NOT NULL DEFAULT '',
+			status               TEXT NOT NULL DEFAULT 'registered',
+			registered_at        TEXT NOT NULL,
+			last_seen            TEXT NOT NULL,
+			last_heartbeat_at    TEXT NOT NULL DEFAULT '',
+			device_id            TEXT NOT NULL DEFAULT '',
+			identity_key_pub     BLOB NOT NULL DEFAULT '',
+			key_protection_level TEXT NOT NULL DEFAULT '',
+			last_provenance_json TEXT NOT NULL DEFAULT ''
 		)`,
 		`CREATE INDEX IF NOT EXISTS idx_stewards_status    ON stewards(status)`,
 		`CREATE INDEX IF NOT EXISTS idx_stewards_last_seen ON stewards(last_seen)`,
+		`CREATE INDEX IF NOT EXISTS idx_stewards_device_id ON stewards(device_id)`,
 
 		// Commands — durable command dispatch state (ADR-003 §1 Deficiency #5, Issue #665)
 		// Records are append-only for audit purposes; PurgeExpiredRecords removes
@@ -391,6 +438,36 @@ func initializeSchema(ctx context.Context, db *sql.DB) error {
 		`CREATE INDEX IF NOT EXISTS idx_cfgms_pending_registrations_status       ON cfgms_pending_registrations(status)`,
 		`CREATE INDEX IF NOT EXISTS idx_cfgms_pending_registrations_expires_at   ON cfgms_pending_registrations(expires_at)`,
 		`CREATE INDEX IF NOT EXISTS idx_cfgms_pending_registrations_token_str    ON cfgms_pending_registrations(token_str)`,
+
+		// Pending registration-refresh requests (ADR-010, Issue #2093)
+		// Records are created by the /refresh/challenge handler and acted upon by
+		// the approval flow or auto-accept policy. ClaimBundle is populated by
+		// StoreClaimBundle once the steward completes the PoP exchange.
+		`CREATE TABLE IF NOT EXISTS pending_refresh_requests (
+			pending_id               TEXT PRIMARY KEY,
+			device_id                TEXT NOT NULL,
+			tenant_id                TEXT NOT NULL,
+			source_ip                TEXT NOT NULL DEFAULT '',
+			provenance_matched_fields INTEGER NOT NULL DEFAULT 0,
+			provenance_total_fields   INTEGER NOT NULL DEFAULT 0,
+			claim_bundle             BLOB NOT NULL DEFAULT '',
+			status                   TEXT NOT NULL DEFAULT 'pending',
+			created_at               TEXT NOT NULL,
+			expires_at               TEXT NOT NULL,
+			resolved_at              TEXT
+		)`,
+		`CREATE INDEX IF NOT EXISTS idx_pending_refresh_device_id  ON pending_refresh_requests(device_id)`,
+		`CREATE INDEX IF NOT EXISTS idx_pending_refresh_tenant_id  ON pending_refresh_requests(tenant_id)`,
+		`CREATE INDEX IF NOT EXISTS idx_pending_refresh_status     ON pending_refresh_requests(status)`,
+		`CREATE INDEX IF NOT EXISTS idx_pending_refresh_expires_at ON pending_refresh_requests(expires_at)`,
+
+		// Per-tenant registration-refresh policies (ADR-010 §4, Issue #2093)
+		// Absent rows return the default policy: mode=require_approval, max_dormancy_days=NULL.
+		`CREATE TABLE IF NOT EXISTS refresh_policies (
+			tenant_id         TEXT PRIMARY KEY,
+			mode              TEXT NOT NULL DEFAULT 'require_approval',
+			max_dormancy_days INTEGER
+		)`,
 
 		// Durable sessions (Persistent=true only)
 		`CREATE TABLE IF NOT EXISTS sessions (

--- a/pkg/storage/providers/sqlite/schema_backfill_test.go
+++ b/pkg/storage/providers/sqlite/schema_backfill_test.go
@@ -180,3 +180,84 @@ func TestBackfill_AlterFailure(t *testing.T) {
 	require.Error(t, err, "ALTER TABLE on read-only DB must return an error")
 	assert.Contains(t, err.Error(), "back-fill", "error must identify the back-fill stage")
 }
+
+// legacyStewardsSchema is the stewards DDL from before the four registration-refresh
+// identity columns were added. Used to simulate a pre-existing deployment.
+const legacyStewardsSchema = `CREATE TABLE IF NOT EXISTS stewards (
+	id                TEXT PRIMARY KEY,
+	hostname          TEXT NOT NULL DEFAULT '',
+	platform          TEXT NOT NULL DEFAULT '',
+	arch              TEXT NOT NULL DEFAULT '',
+	version           TEXT NOT NULL DEFAULT '',
+	ip_address        TEXT NOT NULL DEFAULT '',
+	status            TEXT NOT NULL DEFAULT 'registered',
+	registered_at     TEXT NOT NULL DEFAULT '',
+	last_seen         TEXT NOT NULL DEFAULT '',
+	last_heartbeat_at TEXT NOT NULL DEFAULT ''
+)`
+
+// TestBackfillStewardColumns_LegacyStewards verifies that initializeSchema adds the
+// four new identity columns to a pre-existing stewards table that lacks them.
+func TestBackfillStewardColumns_LegacyStewards(t *testing.T) {
+	db := openMemDB(t)
+	ctx := context.Background()
+
+	// Seed a legacy-shape stewards table without the four new columns.
+	_, err := db.ExecContext(ctx, legacyStewardsSchema)
+	require.NoError(t, err, "seed legacy stewards schema")
+
+	for _, col := range []string{"device_id", "identity_key_pub", "key_protection_level", "last_provenance_json"} {
+		assert.False(t, hasColumn(t, db, "stewards", col), "pre-condition: %s absent before back-fill", col)
+	}
+
+	// First invocation — should back-fill the missing columns and create the device_id index.
+	require.NoError(t, initializeSchema(ctx, db), "first initializeSchema call")
+
+	for _, col := range []string{"device_id", "identity_key_pub", "key_protection_level", "last_provenance_json"} {
+		assert.True(t, hasColumn(t, db, "stewards", col), "%s present after back-fill", col)
+	}
+	assert.True(t, hasIndex(t, db, "stewards", "idx_stewards_device_id"), "device_id index present after back-fill")
+}
+
+// TestBackfillStewardColumns_Idempotent verifies that calling initializeSchema a second
+// time on an already-migrated stewards table succeeds and existing rows survive.
+func TestBackfillStewardColumns_Idempotent(t *testing.T) {
+	db := openMemDB(t)
+	ctx := context.Background()
+
+	// Seed legacy table and migrate once.
+	_, err := db.ExecContext(ctx, legacyStewardsSchema)
+	require.NoError(t, err, "seed legacy stewards schema")
+	require.NoError(t, initializeSchema(ctx, db), "first initializeSchema call")
+
+	// Insert a row to prove it survives the second pass.
+	_, err = db.ExecContext(ctx, `
+		INSERT INTO stewards (id, registered_at, last_seen)
+		VALUES ('s-survive', '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z')`)
+	require.NoError(t, err, "insert test row")
+
+	// Second invocation must also succeed and leave rows intact.
+	require.NoError(t, initializeSchema(ctx, db), "second initializeSchema call (idempotency check)")
+
+	for _, col := range []string{"device_id", "identity_key_pub", "key_protection_level", "last_provenance_json"} {
+		assert.True(t, hasColumn(t, db, "stewards", col), "%s still present after second pass", col)
+	}
+
+	var count int
+	require.NoError(t, db.QueryRowContext(ctx, `SELECT COUNT(*) FROM stewards WHERE id='s-survive'`).Scan(&count))
+	assert.Equal(t, 1, count, "row must survive second initializeSchema")
+}
+
+// TestBackfillStewardColumns_FreshDB verifies that a fresh database initializes cleanly
+// with all four columns present from the CREATE TABLE statement.
+func TestBackfillStewardColumns_FreshDB(t *testing.T) {
+	db := openMemDB(t)
+	ctx := context.Background()
+
+	require.NoError(t, initializeSchema(ctx, db), "fresh DB initialization")
+
+	for _, col := range []string{"device_id", "identity_key_pub", "key_protection_level", "last_provenance_json"} {
+		assert.True(t, hasColumn(t, db, "stewards", col), "%s present on fresh DB", col)
+	}
+	assert.True(t, hasIndex(t, db, "stewards", "idx_stewards_device_id"), "device_id index on fresh DB")
+}

--- a/pkg/storage/providers/sqlite/steward_store.go
+++ b/pkg/storage/providers/sqlite/steward_store.go
@@ -48,11 +48,16 @@ func (s *SQLiteStewardStore) RegisterSteward(ctx context.Context, record *busine
 	}
 
 	err := retryOnBusy(ctx, func() error {
+		keyPub := record.IdentityKeyPub
+		if keyPub == nil {
+			keyPub = []byte{}
+		}
 		_, e := s.db.ExecContext(ctx, `
 			INSERT INTO stewards
 				(id, hostname, platform, arch, version, ip_address, status,
-				 registered_at, last_seen, last_heartbeat_at)
-			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+				 registered_at, last_seen, last_heartbeat_at,
+				 device_id, identity_key_pub, key_protection_level, last_provenance_json)
+			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 			record.ID,
 			record.Hostname,
 			record.Platform,
@@ -63,6 +68,10 @@ func (s *SQLiteStewardStore) RegisterSteward(ctx context.Context, record *busine
 			formatTime(now),
 			formatTime(now),
 			"", // last_heartbeat_at empty until first heartbeat
+			record.DeviceID,
+			keyPub,
+			record.KeyProtectionLevel,
+			record.LastProvenanceJSON,
 		)
 		return e
 	})
@@ -101,8 +110,23 @@ func (s *SQLiteStewardStore) UpdateHeartbeat(ctx context.Context, stewardID stri
 func (s *SQLiteStewardStore) GetSteward(ctx context.Context, stewardID string) (*business.StewardRecord, error) {
 	row := s.db.QueryRowContext(ctx, `
 		SELECT id, hostname, platform, arch, version, ip_address, status,
-		       registered_at, last_seen, last_heartbeat_at
+		       registered_at, last_seen, last_heartbeat_at,
+		       device_id, identity_key_pub, key_protection_level, last_provenance_json
 		FROM stewards WHERE id = ?`, stewardID)
+	return scanStewardRow(row)
+}
+
+// GetStewardByDeviceID retrieves the record whose device_id matches the given fingerprint.
+// Returns ErrStewardNotFound when no matching record exists.
+func (s *SQLiteStewardStore) GetStewardByDeviceID(ctx context.Context, deviceID string) (*business.StewardRecord, error) {
+	if deviceID == "" {
+		return nil, fmt.Errorf("sqlite: device ID cannot be empty")
+	}
+	row := s.db.QueryRowContext(ctx, `
+		SELECT id, hostname, platform, arch, version, ip_address, status,
+		       registered_at, last_seen, last_heartbeat_at,
+		       device_id, identity_key_pub, key_protection_level, last_provenance_json
+		FROM stewards WHERE device_id = ? LIMIT 1`, deviceID)
 	return scanStewardRow(row)
 }
 
@@ -110,7 +134,8 @@ func (s *SQLiteStewardStore) GetSteward(ctx context.Context, stewardID string) (
 func (s *SQLiteStewardStore) ListStewards(ctx context.Context) ([]*business.StewardRecord, error) {
 	rows, err := s.db.QueryContext(ctx, `
 		SELECT id, hostname, platform, arch, version, ip_address, status,
-		       registered_at, last_seen, last_heartbeat_at
+		       registered_at, last_seen, last_heartbeat_at,
+		       device_id, identity_key_pub, key_protection_level, last_provenance_json
 		FROM stewards ORDER BY registered_at ASC`)
 	if err != nil {
 		return nil, fmt.Errorf("sqlite: failed to list stewards: %w", err)
@@ -123,7 +148,8 @@ func (s *SQLiteStewardStore) ListStewards(ctx context.Context) ([]*business.Stew
 func (s *SQLiteStewardStore) ListStewardsByStatus(ctx context.Context, status business.StewardStatus) ([]*business.StewardRecord, error) {
 	rows, err := s.db.QueryContext(ctx, `
 		SELECT id, hostname, platform, arch, version, ip_address, status,
-		       registered_at, last_seen, last_heartbeat_at
+		       registered_at, last_seen, last_heartbeat_at,
+		       device_id, identity_key_pub, key_protection_level, last_provenance_json
 		FROM stewards WHERE status = ? ORDER BY registered_at ASC`,
 		string(status),
 	)
@@ -164,7 +190,8 @@ func (s *SQLiteStewardStore) DeregisterSteward(ctx context.Context, stewardID st
 func (s *SQLiteStewardStore) GetStewardsSeen(ctx context.Context, since time.Time) ([]*business.StewardRecord, error) {
 	rows, err := s.db.QueryContext(ctx, `
 		SELECT id, hostname, platform, arch, version, ip_address, status,
-		       registered_at, last_seen, last_heartbeat_at
+		       registered_at, last_seen, last_heartbeat_at,
+		       device_id, identity_key_pub, key_protection_level, last_provenance_json
 		FROM stewards WHERE last_seen > ? ORDER BY last_seen DESC`,
 		formatTime(since),
 	)
@@ -186,9 +213,11 @@ func (s *SQLiteStewardStore) HealthCheck(ctx context.Context) error {
 func scanStewardRow(row *sql.Row) (*business.StewardRecord, error) {
 	r := &business.StewardRecord{}
 	var statusStr, regStr, lastSeenStr, lastHBStr string
+	var keyPub []byte
 	err := row.Scan(
 		&r.ID, &r.Hostname, &r.Platform, &r.Arch, &r.Version, &r.IPAddress,
 		&statusStr, &regStr, &lastSeenStr, &lastHBStr,
+		&r.DeviceID, &keyPub, &r.KeyProtectionLevel, &r.LastProvenanceJSON,
 	)
 	if err == sql.ErrNoRows {
 		return nil, business.ErrStewardNotFound
@@ -196,6 +225,7 @@ func scanStewardRow(row *sql.Row) (*business.StewardRecord, error) {
 	if err != nil {
 		return nil, fmt.Errorf("sqlite: failed to scan steward: %w", err)
 	}
+	r.IdentityKeyPub = keyPub
 	return populateSteward(r, statusStr, regStr, lastSeenStr, lastHBStr), nil
 }
 
@@ -205,12 +235,15 @@ func scanStewardRows(rows *sql.Rows) ([]*business.StewardRecord, error) {
 	for rows.Next() {
 		r := &business.StewardRecord{}
 		var statusStr, regStr, lastSeenStr, lastHBStr string
+		var keyPub []byte
 		if err := rows.Scan(
 			&r.ID, &r.Hostname, &r.Platform, &r.Arch, &r.Version, &r.IPAddress,
 			&statusStr, &regStr, &lastSeenStr, &lastHBStr,
+			&r.DeviceID, &keyPub, &r.KeyProtectionLevel, &r.LastProvenanceJSON,
 		); err != nil {
 			return nil, fmt.Errorf("sqlite: failed to scan steward row: %w", err)
 		}
+		r.IdentityKeyPub = keyPub
 		records = append(records, populateSteward(r, statusStr, regStr, lastSeenStr, lastHBStr))
 	}
 	return records, rows.Err()

--- a/pkg/storage/providers/sqlite/steward_store_test.go
+++ b/pkg/storage/providers/sqlite/steward_store_test.go
@@ -233,3 +233,59 @@ func TestSQLiteStewardStore_DeregisterNotFound(t *testing.T) {
 	err := store.DeregisterSteward(context.Background(), "ghost")
 	assert.ErrorIs(t, err, business.ErrStewardNotFound)
 }
+
+func TestSQLiteStewardStore_GetStewardByDeviceID(t *testing.T) {
+	store := newTestStewardStore(t)
+	ctx := context.Background()
+
+	const deviceID = "aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899"
+	rec := testStewardRec("s-dvc")
+	rec.DeviceID = deviceID
+	rec.IdentityKeyPub = []byte{1, 2, 3, 4}
+	rec.KeyProtectionLevel = "file"
+	rec.LastProvenanceJSON = `{"hostname":"host-s-dvc"}`
+	require.NoError(t, store.RegisterSteward(ctx, rec))
+
+	got, err := store.GetStewardByDeviceID(ctx, deviceID)
+	require.NoError(t, err)
+	assert.Equal(t, "s-dvc", got.ID)
+	assert.Equal(t, deviceID, got.DeviceID)
+	assert.Equal(t, []byte{1, 2, 3, 4}, got.IdentityKeyPub)
+	assert.Equal(t, "file", got.KeyProtectionLevel)
+	assert.Equal(t, `{"hostname":"host-s-dvc"}`, got.LastProvenanceJSON)
+
+	_, err = store.GetStewardByDeviceID(ctx, "0000000000000000000000000000000000000000000000000000000000000000")
+	assert.ErrorIs(t, err, business.ErrStewardNotFound)
+}
+
+func TestSQLiteStewardStore_GetStewardByDeviceID_EmptyID(t *testing.T) {
+	store := newTestStewardStore(t)
+	_, err := store.GetStewardByDeviceID(context.Background(), "")
+	require.Error(t, err, "empty device ID must return an error")
+}
+
+// TestSQLiteStewardStore_MigrationIdempotent verifies that calling initializeSchema
+// twice on a populated database returns no error and existing rows survive.
+func TestSQLiteStewardStore_MigrationIdempotent(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "migration.db")
+	ctx := context.Background()
+
+	// First init — populate with a record.
+	db1, err := openAndInit(dbPath)
+	require.NoError(t, err)
+	store1 := &SQLiteStewardStore{db: db1}
+	require.NoError(t, store1.RegisterSteward(ctx, testStewardRec("s-mig")))
+	require.NoError(t, db1.Close())
+
+	// Reopen the raw DB and call initializeSchema a second time.
+	db2, err := openDB(dbPath)
+	require.NoError(t, err)
+	defer func() { _ = db2.Close() }()
+
+	require.NoError(t, initializeSchema(ctx, db2), "second initializeSchema must not error")
+
+	store2 := &SQLiteStewardStore{db: db2}
+	got, err := store2.GetSteward(ctx, "s-mig")
+	require.NoError(t, err)
+	assert.Equal(t, "s-mig", got.ID, "row must survive second initializeSchema")
+}


### PR DESCRIPTION
## Summary

- Extends `StewardRecord` with four new fields (`DeviceID`, `IdentityKeyPub`, `KeyProtectionLevel`, `LastProvenanceJSON`) and adds `StewardStatusArchived`, `StewardStatusDormant`, `StewardStatusRevoked` constants plus `ErrStewardRevoked` sentinel
- Adds `GetStewardByDeviceID(ctx, deviceID)` to `StewardStore` interface with SQLite and flatfile implementations; bumps SQLite schema to v2 with idempotent `backfillStewardColumns` migration (same guard pattern as `backfillAuditEntries`)
- Adds `PendingRefreshStore` and `RefreshPolicyStore` interfaces (`pkg/storage/interfaces/business/`) with full SQLite implementations; `GetPolicy` returns `{Mode: "require_approval"}` default when no record exists

## Test plan

- [ ] `TestSQLiteStewardStore_GetStewardByDeviceID` — found + not-found + empty-ID validation
- [ ] `TestSQLiteStewardStore_MigrationIdempotent` — rows survive second `initializeSchema` call
- [ ] `TestBackfillStewardColumns_LegacyStewards` / `_Idempotent` / `_FreshDB` — migration coverage
- [ ] `TestFlatFileStewardStore_GetStewardByDeviceID` — found + not-found + empty-ID validation
- [ ] `TestPendingRefreshStore_RoundTrip` — Add → Get → StoreClaimBundle → UpdateRefreshStatus field fidelity
- [ ] `TestRefreshPolicyStore_DefaultPolicy` — absent record returns `require_approval` default, no error
- [ ] Contract tests in `pkg/storage/interfaces/business/` — in-memory implementations verify interface invariants
- [ ] `features/controller/server` — `testStewardStore` updated with `GetStewardByDeviceID`, all adapter tests pass

Fixes #2093

🤖 Generated with [Claude Code](https://claude.ai/claude-code)