### PR TITLE
steward/registration: device identity key + registration-refresh handshake (Issue #2094)

### DIFF
--- a/cmd/steward/identity.go
+++ b/cmd/steward/identity.go
@@ -108,6 +108,9 @@ type StewardIdentity struct {
 	SigningCertPEM   string     `json:"signing_cert_pem,omitempty"`   // backward compat: single cert (legacy)
 	SigningCertPEMs  []string   `json:"signing_cert_pems,omitempty"`  // Issue #1816: mutable rotation set
 	OverlapExpiresAt *time.Time `json:"overlap_expires_at,omitempty"` // Issue #1816: rotation overlap deadline
+	// Device identity fields (Issue #2094): stable across mTLS cert rotations.
+	DeviceID       string `json:"device_id,omitempty"`        // 64-char lowercase hex SHA-256 of Ed25519 public key
+	IdentityKeyPub string `json:"identity_key_pub,omitempty"` // base64-encoded Ed25519 public key (32 bytes)
 }
 
 // saveIdentity writes id to dir/steward-identity.json with permissions 0600

--- a/cmd/steward/main.go
+++ b/cmd/steward/main.go
@@ -7,7 +7,9 @@ import (
 	"bufio"
 	"context"
 	"crypto/ed25519"
+	"crypto/sha256"
 	"encoding/base64"
+	"encoding/binary"
 	"errors"
 	"fmt"
 	"log"
@@ -29,6 +31,7 @@ import (
 	cpTypes "github.com/cfgis/cfgms/pkg/controlplane/types"
 	"github.com/cfgis/cfgms/pkg/logging"
 	"github.com/cfgis/cfgms/pkg/modules/trust"
+	"github.com/cfgis/cfgms/pkg/registration/identity"
 	secretsif "github.com/cfgis/cfgms/pkg/secrets/interfaces"
 	"github.com/cfgis/cfgms/pkg/version"
 	"github.com/spf13/cobra"
@@ -171,7 +174,18 @@ func runSteward(ctx context.Context, regToken, configPath string) error {
 		runCtx, runCancel := context.WithCancel(ctx)
 		defer runCancel()
 
-		transportCl, err := registerAndConnect(runCtx, regToken, logger)
+		// Initialise device identity key store before registration so the refresh
+		// handshake path (Issue #2094) has a stable key available. Failure here is
+		// non-fatal: initial registration still works; only the refresh path is disabled.
+		ks, ksErr := identity.NewFileKeyStore(defaultCertStoreDir())
+		if ksErr != nil {
+			logger.Warn("Failed to create device identity key store; registration-refresh disabled", "error", ksErr)
+		} else if _, _, loadErr := ks.GenerateOrLoad(runCtx); loadErr != nil {
+			logger.Warn("Failed to load/generate device identity key; registration-refresh disabled", "error", loadErr)
+			ks = nil
+		}
+
+		transportCl, err := registerAndConnect(runCtx, regToken, ks, logger)
 		if err != nil {
 			return fmt.Errorf("failed to register with controller: %w", err)
 		}
@@ -586,6 +600,8 @@ type approvedRegistration struct {
 	CACert           string
 	ServerCert       string
 	SigningCert      string
+	DeviceID         string // stable device identity ID (Issue #2094)
+	IdentityKeyPub   string // base64-encoded Ed25519 public key (Issue #2094)
 }
 
 // registerAndConnect registers the steward using HTTP REST API
@@ -595,11 +611,15 @@ type approvedRegistration struct {
 // On restart with a valid stored cert and identity, HTTP registration is skipped
 // and the steward reconnects directly using the persisted credentials (Issue #1719).
 //
+// When the steward's mTLS cert is expired but a stored identity and device identity key
+// exist, registerAndConnect tries the registration-refresh handshake (Issue #2094) before
+// falling through to full HTTP re-registration.
+//
 // When the controller uses registration.workflow: manual (Issue #1899), the steward
 // persists the pending_id locally and polls GET /api/v1/registration/status/{pending_id}
 // with exponential backoff (5s → 60s max) until approved, denied, or timed out.
 // On restart, the persisted pending_id is resumed rather than creating a new pending record.
-func registerAndConnect(ctx context.Context, token string, logger logging.Logger) (*client.TransportClient, error) {
+func registerAndConnect(ctx context.Context, token string, ks *identity.FileKeyStore, logger logging.Logger) (*client.TransportClient, error) {
 	logger.Info("Starting steward connect sequence")
 
 	certStoreDir := defaultCertStoreDir()
@@ -608,7 +628,38 @@ func registerAndConnect(ctx context.Context, token string, logger logging.Logger
 	if tc, reconnErr := tryReconnectWithStoredIdentity(ctx, certStoreDir, token, logger); tc != nil {
 		return tc, nil
 	} else if reconnErr != nil {
-		logger.Warn("Stored-identity reconnect failed; falling back to HTTP registration", "error", reconnErr)
+		logger.Warn("Stored-identity reconnect failed; checking for expired-cert refresh path", "error", reconnErr)
+	}
+
+	// Expired-cert refresh path (Issue #2094): when a stored identity exists and all
+	// client certs are expired, attempt the registration-refresh handshake before
+	// falling through to full HTTP re-registration.
+	if ks != nil && ks.DeviceID() != "" {
+		if storedID, loadErr := loadIdentity(certStoreDir); loadErr == nil && storedID != nil {
+			certMgr, certMgrErr := cert.NewManager(&cert.ManagerConfig{
+				StoragePath:    certStoreDir,
+				LoadExistingCA: true,
+			})
+			if certMgrErr == nil {
+				if certs, listErr := certMgr.ListCertificates(); listErr == nil && hasExpiredClientCert(certs) {
+					tc, refreshErr := refreshAndConnect(ctx, storedID, ks, certStoreDir, token, logger)
+					if refreshErr == nil {
+						return tc, nil
+					}
+					if errors.Is(refreshErr, registration.ErrRefreshPending) {
+						logger.Warn("Registration refresh pending operator approval; retry later",
+							"device_id", logging.SanitizeLogValue(ks.DeviceID()))
+						return nil, refreshErr
+					}
+					if errors.Is(refreshErr, registration.ErrRefreshRejected) {
+						logger.Error("Registration refresh rejected; steward must be manually re-admitted",
+							"device_id", logging.SanitizeLogValue(ks.DeviceID()))
+						return nil, refreshErr
+					}
+					logger.Warn("Registration refresh failed; falling back to HTTP re-registration", "error", refreshErr)
+				}
+			}
+		}
 	}
 
 	logger.Info("Registering steward via HTTP API")
@@ -645,6 +696,7 @@ func registerAndConnect(ctx context.Context, token string, logger logging.Logger
 			return nil, pollErr
 		}
 		if approved != nil {
+			enrichApprovedWithDeviceIdentity(approved, ks)
 			_ = clearPendingState(certStoreDir)
 			return connectWithApprovedRegistration(ctx, *approved, certStoreDir, token, logger)
 		}
@@ -658,7 +710,15 @@ func registerAndConnect(ctx context.Context, token string, logger logging.Logger
 	regCtx, regCancel := context.WithTimeout(ctx, 30*time.Second)
 	defer regCancel()
 
-	regResp, pendingResp, err := httpClient.Register(regCtx, token)
+	regReq := registration.RegistrationRequest{Token: token}
+	if ks != nil && ks.DeviceID() != "" {
+		regReq.DeviceID = ks.DeviceID()
+		if pub := ks.PublicKey(); pub != nil {
+			regReq.IdentityKeyPub = base64.StdEncoding.EncodeToString([]byte(pub))
+		}
+	}
+
+	regResp, pendingResp, err := httpClient.Register(regCtx, regReq)
 	if err != nil {
 		return nil, fmt.Errorf("HTTP registration failed: %w", err)
 	}
@@ -685,6 +745,7 @@ func registerAndConnect(ctx context.Context, token string, logger logging.Logger
 			_ = clearPendingState(certStoreDir)
 			return nil, fmt.Errorf("registration approval timed out after %s; re-run with a fresh token if needed", pollTimeout)
 		}
+		enrichApprovedWithDeviceIdentity(approved, ks)
 		_ = clearPendingState(certStoreDir)
 		return connectWithApprovedRegistration(ctx, *approved, certStoreDir, token, logger)
 	}
@@ -707,6 +768,7 @@ func registerAndConnect(ctx context.Context, token string, logger logging.Logger
 		ServerCert:       regResp.ServerCert,
 		SigningCert:      regResp.SigningCert,
 	}
+	enrichApprovedWithDeviceIdentity(&bundle, ks)
 	return connectWithApprovedRegistration(ctx, bundle, certStoreDir, token, logger)
 }
 
@@ -798,18 +860,20 @@ func connectWithApprovedRegistration(
 ) (*client.TransportClient, error) {
 	// Persist the identity record so that a subsequent restart can reconnect
 	// without HTTP re-registration (Issue #1719).
-	identity := StewardIdentity{
+	persistedID := StewardIdentity{
 		StewardID:        reg.StewardID,
 		TenantID:         reg.TenantID,
 		TransportAddress: reg.TransportAddress,
 		CACertPEM:        reg.CACert,
 		ServerCertPEM:    reg.ServerCert,
 		SigningCertPEM:   reg.SigningCert,
+		DeviceID:         reg.DeviceID,
+		IdentityKeyPub:   reg.IdentityKeyPub,
 	}
-	if saveErr := saveIdentity(certStoreDir, identity); saveErr != nil {
+	if saveErr := saveIdentity(certStoreDir, persistedID); saveErr != nil {
 		logger.Warn("Failed to persist steward identity; next restart will re-register", "error", saveErr)
 	} else {
-		logger.Info("Steward identity persisted for restart reuse", "steward_id", identity.StewardID)
+		logger.Info("Steward identity persisted for restart reuse", "steward_id", persistedID.StewardID)
 	}
 
 	// Optionally load the local steward config to apply custom replay window,
@@ -1047,6 +1111,124 @@ func hasValidClientCert(certs []*cert.CertificateInfo) bool {
 		}
 	}
 	return false
+}
+
+// hasExpiredClientCert reports true only when certs contains at least one client certificate
+// AND every client certificate in the list is expired (IsValid == false).
+// Returns false when certs contains no client certificates at all.
+func hasExpiredClientCert(certs []*cert.CertificateInfo) bool {
+	found := false
+	for _, c := range certs {
+		if c.Type == cert.CertificateTypeClient {
+			found = true
+			if c.IsValid {
+				return false
+			}
+		}
+	}
+	return found
+}
+
+// enrichApprovedWithDeviceIdentity sets DeviceID and IdentityKeyPub on reg from ks when available,
+// so the identity file persists the device identity across restarts (Issue #2094).
+func enrichApprovedWithDeviceIdentity(reg *approvedRegistration, ks *identity.FileKeyStore) {
+	if ks == nil || ks.DeviceID() == "" {
+		return
+	}
+	reg.DeviceID = ks.DeviceID()
+	if pub := ks.PublicKey(); pub != nil {
+		reg.IdentityKeyPub = base64.StdEncoding.EncodeToString([]byte(pub))
+	}
+}
+
+// refreshAndConnect performs the registration-refresh handshake (ADR-011, Issue #2094)
+// for a steward whose mTLS cert has expired. The handshake proves device identity via
+// an Ed25519 proof-of-possession signature over a server-issued nonce.
+//
+// Returns ErrRefreshPending when the controller queues the request for manual approval.
+// Returns ErrRefreshRejected when the controller refuses (revoked or dormant device).
+// On success, persists the new cert via saveIdentity and reconnects.
+func refreshAndConnect(
+	ctx context.Context,
+	id *StewardIdentity,
+	ks *identity.FileKeyStore,
+	certStoreDir, token string,
+	logger logging.Logger,
+) (*client.TransportClient, error) {
+	controllerURL := ControllerURL
+	if controllerURL == "" {
+		return nil, fmt.Errorf("controller URL not set; cannot perform registration refresh")
+	}
+
+	httpClient, err := registration.NewHTTPClient(buildHTTPConfig(controllerURL, 30*time.Second, logger))
+	if err != nil {
+		return nil, fmt.Errorf("create HTTP client for refresh: %w", err)
+	}
+
+	logger.Info("Attempting registration-refresh handshake",
+		"device_id", logging.SanitizeLogValue(ks.DeviceID()),
+		"steward_id", logging.SanitizeLogValue(id.StewardID))
+
+	challengeCtx, challengeCancel := context.WithTimeout(ctx, 30*time.Second)
+	defer challengeCancel()
+
+	challenge, err := httpClient.RefreshChallenge(challengeCtx, ks.DeviceID())
+	if err != nil {
+		return nil, fmt.Errorf("refresh challenge: %w", err)
+	}
+
+	// Decode the nonce from base64url.
+	nonceBytes, err := base64.RawURLEncoding.DecodeString(challenge.Nonce)
+	if err != nil {
+		return nil, fmt.Errorf("decode refresh nonce: %w", err)
+	}
+
+	// Compute the PoP digest: sha256(nonce_bytes || device_id_utf8 || server_ts_big_endian_uint64)
+	// per ADR-011 §4. This formula must match the controller's implementation exactly.
+	var tsBuf [8]byte
+	binary.BigEndian.PutUint64(tsBuf[:], challenge.ServerTS)
+
+	digestInput := make([]byte, 0, len(nonceBytes)+len(ks.DeviceID())+8)
+	digestInput = append(digestInput, nonceBytes...)
+	digestInput = append(digestInput, []byte(ks.DeviceID())...)
+	digestInput = append(digestInput, tsBuf[:]...)
+	digest := sha256.Sum256(digestInput)
+
+	pop, err := ks.Sign(digest[:])
+	if err != nil {
+		return nil, fmt.Errorf("sign refresh digest: %w", err)
+	}
+
+	completeCtx, completeCancel := context.WithTimeout(ctx, 30*time.Second)
+	defer completeCancel()
+
+	completeResp, err := httpClient.RefreshComplete(completeCtx, ks.DeviceID(), challenge.Nonce, pop)
+	if err != nil {
+		return nil, err // ErrRefreshPending or ErrRefreshRejected propagated to caller
+	}
+
+	logger.Info("Registration refresh approved; storing new certificate",
+		"steward_id", logging.SanitizeLogValue(id.StewardID))
+
+	// Persist the refreshed identity with updated certs.
+	updatedID := *id
+	updatedID.CACertPEM = completeResp.CACert
+	updatedID.ServerCertPEM = completeResp.ServerCert
+	updatedID.TransportAddress = completeResp.TransportAddress
+	if saveErr := saveIdentity(certStoreDir, updatedID); saveErr != nil {
+		logger.Warn("Failed to persist refreshed identity; next restart may re-register", "error", saveErr)
+	}
+
+	bundle := approvedRegistration{
+		StewardID:        id.StewardID,
+		TenantID:         id.TenantID,
+		TransportAddress: completeResp.TransportAddress,
+		ClientCert:       completeResp.ClientCert,
+		ClientKey:        completeResp.ClientKey,
+		CACert:           completeResp.CACert,
+		ServerCert:       completeResp.ServerCert,
+	}
+	return connectWithApprovedRegistration(ctx, bundle, certStoreDir, token, logger)
 }
 
 // buildCertManagerAndSecretStore initialises a cert.Manager (holding the

--- a/cmd/steward/main.go
+++ b/cmd/steward/main.go
@@ -1228,6 +1228,7 @@ func refreshAndConnect(
 		CACert:           completeResp.CACert,
 		ServerCert:       completeResp.ServerCert,
 	}
+	enrichApprovedWithDeviceIdentity(&bundle, ks)
 	return connectWithApprovedRegistration(ctx, bundle, certStoreDir, token, logger)
 }
 

--- a/cmd/steward/main_test.go
+++ b/cmd/steward/main_test.go
@@ -506,6 +506,76 @@ func TestRefreshAndConnect_202_ReturnsErrRefreshPending(t *testing.T) {
 		"HTTP 202 from refresh/complete must return ErrRefreshPending, not a fatal error")
 }
 
+// TestRefreshAndConnect_SuccessPathPersistsDeviceIdentity verifies that when the
+// controller returns HTTP 200 for /refresh/complete, the persisted identity file
+// carries DeviceID and IdentityKeyPub from the key store — i.e. that
+// enrichApprovedWithDeviceIdentity is called before connectWithApprovedRegistration.
+// The transport connection itself will fail (no real controller), but saveIdentity
+// is called before the transport attempt, so the file is a reliable signal.
+func TestRefreshAndConnect_SuccessPathPersistsDeviceIdentity(t *testing.T) {
+	dir := t.TempDir()
+
+	ks, err := identity.NewFileKeyStoreForTesting(dir)
+	require.NoError(t, err)
+	_, _, err = ks.GenerateOrLoad(context.Background())
+	require.NoError(t, err)
+	expectedDeviceID := ks.DeviceID()
+	require.NotEmpty(t, expectedDeviceID)
+
+	var srvURL string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/refresh/challenge"):
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"nonce":"dGVzdA","server_ts":1,"expires_in":60}`))
+		case strings.HasSuffix(r.URL.Path, "/refresh/complete"):
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			resp := map[string]string{
+				"client_cert":       "fake-cert",
+				"client_key":        "fake-key",
+				"ca_cert":           "fake-ca",
+				"server_cert":       "fake-server",
+				"transport_address": srvURL,
+			}
+			_ = json.NewEncoder(w).Encode(resp)
+		default:
+			http.Error(w, "unexpected path", http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+	srvURL = srv.URL
+
+	origURL := ControllerURL
+	ControllerURL = srv.URL
+	t.Cleanup(func() { ControllerURL = origURL })
+
+	storedID := &StewardIdentity{
+		StewardID:        "steward-refresh-test",
+		TenantID:         "tenant-1",
+		TransportAddress: srv.URL,
+		CACertPEM:        "fake-ca",
+		ServerCertPEM:    "fake-server",
+	}
+
+	// refreshAndConnect will fail at connectWithApprovedRegistration (no real transport),
+	// but saveIdentity is invoked before the transport attempt so the identity file is written.
+	_, _ = refreshAndConnect(context.Background(), storedID, ks, dir, "tok", logging.NewLogger("error"))
+
+	// The identity file saved by connectWithApprovedRegistration must carry the
+	// DeviceID and IdentityKeyPub from the key store.  An empty DeviceID here
+	// means enrichApprovedWithDeviceIdentity was not called before the bundle was
+	// passed to connectWithApprovedRegistration.
+	savedID, loadErr := loadIdentity(dir)
+	require.NoError(t, loadErr)
+	require.NotNil(t, savedID, "identity file must exist after a successful refresh/complete response")
+	assert.Equal(t, expectedDeviceID, savedID.DeviceID,
+		"DeviceID must be populated in persisted identity after successful refresh")
+	assert.NotEmpty(t, savedID.IdentityKeyPub,
+		"IdentityKeyPub must be populated in persisted identity after successful refresh")
+}
+
 // TestPollForApproval_BackoffIntervalGrows verifies that the poll interval doubles
 // on each "pending" response up to maxInterval.
 func TestPollForApproval_BackoffIntervalGrows(t *testing.T) {

--- a/cmd/steward/main_test.go
+++ b/cmd/steward/main_test.go
@@ -11,13 +11,16 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/cfgis/cfgms/cmd/steward/service"
 	"github.com/cfgis/cfgms/features/steward/registration"
+	"github.com/cfgis/cfgms/pkg/cert"
 	"github.com/cfgis/cfgms/pkg/logging"
+	"github.com/cfgis/cfgms/pkg/registration/identity"
 	"github.com/spf13/pflag"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -429,6 +432,78 @@ func TestPollForApproval_ContextCanceled_ReturnsTimeoutError(t *testing.T) {
 	require.Error(t, err)
 	assert.Nil(t, result)
 	assert.Contains(t, err.Error(), "timed out")
+}
+
+// TestHasExpiredClientCert covers the three cases from the acceptance criteria:
+// all-expired → true; empty → false; mixed valid+expired → false.
+func TestHasExpiredClientCert(t *testing.T) {
+	makeClient := func(valid bool) *cert.CertificateInfo {
+		return &cert.CertificateInfo{Type: cert.CertificateTypeClient, IsValid: valid}
+	}
+	makeServer := func(valid bool) *cert.CertificateInfo {
+		return &cert.CertificateInfo{Type: cert.CertificateTypePublicAPI, IsValid: valid}
+	}
+
+	cases := []struct {
+		name  string
+		certs []*cert.CertificateInfo
+		want  bool
+	}{
+		{name: "all client certs expired", certs: []*cert.CertificateInfo{makeClient(false), makeClient(false)}, want: true},
+		{name: "single expired client cert", certs: []*cert.CertificateInfo{makeClient(false)}, want: true},
+		{name: "empty list", certs: nil, want: false},
+		{name: "no client certs (only server)", certs: []*cert.CertificateInfo{makeServer(false)}, want: false},
+		{name: "mixed: one valid one expired", certs: []*cert.CertificateInfo{makeClient(true), makeClient(false)}, want: false},
+		{name: "all client certs valid", certs: []*cert.CertificateInfo{makeClient(true)}, want: false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, hasExpiredClientCert(tc.certs))
+		})
+	}
+}
+
+// TestRefreshAndConnect_202_ReturnsErrRefreshPending verifies that when the controller
+// returns HTTP 202 for the /refresh/complete endpoint, refreshAndConnect returns
+// ErrRefreshPending rather than a fatal error or a successful connection.
+func TestRefreshAndConnect_202_ReturnsErrRefreshPending(t *testing.T) {
+	dir := t.TempDir()
+
+	ks, err := identity.NewFileKeyStoreForTesting(dir)
+	require.NoError(t, err)
+	_, _, err = ks.GenerateOrLoad(context.Background())
+	require.NoError(t, err)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/refresh/challenge"):
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"nonce":"dGVzdA","server_ts":1,"expires_in":60}`))
+		case strings.HasSuffix(r.URL.Path, "/refresh/complete"):
+			w.WriteHeader(http.StatusAccepted)
+		default:
+			http.Error(w, "unexpected path", http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	// Temporarily point ControllerURL at the test server.
+	origURL := ControllerURL
+	ControllerURL = srv.URL
+	t.Cleanup(func() { ControllerURL = origURL })
+
+	storedID := &StewardIdentity{
+		StewardID:        "steward-refresh-test",
+		TenantID:         "tenant-1",
+		TransportAddress: srv.URL,
+		CACertPEM:        "fake-ca",
+		ServerCertPEM:    "fake-server",
+	}
+
+	_, err = refreshAndConnect(context.Background(), storedID, ks, dir, "tok", logging.NewLogger("error"))
+	require.ErrorIs(t, err, registration.ErrRefreshPending,
+		"HTTP 202 from refresh/complete must return ErrRefreshPending, not a fatal error")
 }
 
 // TestPollForApproval_BackoffIntervalGrows verifies that the poll interval doubles

--- a/features/steward/registration/client_http.go
+++ b/features/steward/registration/client_http.go
@@ -6,6 +6,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/tls"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -21,7 +22,9 @@ import (
 
 // RegistrationRequest represents a registration request to the controller.
 type RegistrationRequest struct {
-	Token string `json:"token"`
+	Token          string `json:"token"`
+	DeviceID       string `json:"device_id,omitempty"`        // 64-char hex SHA-256 of Ed25519 public key (Issue #2094)
+	IdentityKeyPub string `json:"identity_key_pub,omitempty"` // base64-encoded Ed25519 public key (Issue #2094)
 }
 
 // RegistrationResponse represents the response from the controller for an approved registration.
@@ -145,28 +148,24 @@ func NewHTTPClient(cfg *HTTPConfig) (*HTTPClient, error) {
 // Returns (nil, *RegistrationPendingResponse, nil) on HTTP 202 (quarantined, pending approval).
 // Returns (nil, nil, error) on any other status or transport failure.
 // Callers must distinguish the pending case and enter a poll loop (story 7).
-func (c *HTTPClient) Register(ctx context.Context, token string) (*RegistrationResponse, *RegistrationPendingResponse, error) {
+func (c *HTTPClient) Register(ctx context.Context, req RegistrationRequest) (*RegistrationResponse, *RegistrationPendingResponse, error) {
 	registrationURL := fmt.Sprintf("%s/api/v1/register", c.controllerURL)
 
-	reqBody := RegistrationRequest{
-		Token: token,
-	}
-
-	jsonBody, err := json.Marshal(reqBody)
+	jsonBody, err := json.Marshal(req)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to marshal registration request: %w", err)
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, registrationURL, bytes.NewBuffer(jsonBody))
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, registrationURL, bytes.NewBuffer(jsonBody))
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to create HTTP request: %w", err)
 	}
 
-	req.Header.Set("Content-Type", "application/json")
+	httpReq.Header.Set("Content-Type", "application/json")
 
 	c.logger.Info("Sending registration request to controller", "url", registrationURL)
 
-	resp, err := c.httpClient.Do(req)
+	resp, err := c.httpClient.Do(httpReq)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to send registration request: %w", err)
 	}
@@ -265,4 +264,111 @@ func computePollInterval(base, jitter time.Duration) time.Duration {
 		return base
 	}
 	return base + time.Duration(rand.N(uint64(jitter)))
+}
+
+// RefreshChallenge requests a nonce from the controller for the registration-refresh handshake.
+// Returns ErrRefreshRejected when the controller returns HTTP 403 (revoked or dormant device).
+// Returns the challenge response on HTTP 200.
+func (c *HTTPClient) RefreshChallenge(ctx context.Context, deviceID string) (*RefreshChallengeResponse, error) {
+	challengeURL := fmt.Sprintf("%s/api/v1/stewards/%s/refresh/challenge", c.controllerURL, deviceID)
+
+	reqBody, err := json.Marshal(struct {
+		DeviceID string `json:"device_id"`
+	}{DeviceID: deviceID})
+	if err != nil {
+		return nil, fmt.Errorf("marshal refresh challenge request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, challengeURL, bytes.NewBuffer(reqBody))
+	if err != nil {
+		return nil, fmt.Errorf("create refresh challenge request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("send refresh challenge request: %w", err)
+	}
+	defer func() {
+		if closeErr := resp.Body.Close(); closeErr != nil {
+			c.logger.Warn("Failed to close refresh challenge response body", "error", closeErr)
+		}
+	}()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read refresh challenge response: %w", err)
+	}
+
+	switch resp.StatusCode {
+	case http.StatusOK:
+		var cr RefreshChallengeResponse
+		if err := json.Unmarshal(body, &cr); err != nil {
+			return nil, fmt.Errorf("parse refresh challenge response: %w", err)
+		}
+		return &cr, nil
+	case http.StatusForbidden:
+		return nil, ErrRefreshRejected
+	default:
+		return nil, fmt.Errorf("refresh challenge failed with HTTP %d: %s", resp.StatusCode, string(body))
+	}
+}
+
+// RefreshComplete submits the proof-of-possession signature to complete the registration-refresh handshake.
+// pop is the Ed25519 signature over sha256(nonce_bytes || device_id_utf8 || server_ts_big_endian_uint64).
+//
+// Returns (*RefreshCompleteResponse, nil) on HTTP 200 (cert issued immediately).
+// Returns (nil, ErrRefreshPending) on HTTP 202 (request queued for manual approval).
+// Returns (nil, ErrRefreshRejected) on HTTP 403 (device revoked or dormant).
+func (c *HTTPClient) RefreshComplete(ctx context.Context, deviceID, nonce string, pop []byte) (*RefreshCompleteResponse, error) {
+	completeURL := fmt.Sprintf("%s/api/v1/stewards/%s/refresh/complete", c.controllerURL, deviceID)
+
+	reqBody, err := json.Marshal(struct {
+		DeviceID string `json:"device_id"`
+		Nonce    string `json:"nonce"`
+		PoP      string `json:"pop"` // base64url-encoded Ed25519 signature
+	}{
+		DeviceID: deviceID,
+		Nonce:    nonce,
+		PoP:      base64.RawURLEncoding.EncodeToString(pop),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("marshal refresh complete request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, completeURL, bytes.NewBuffer(reqBody))
+	if err != nil {
+		return nil, fmt.Errorf("create refresh complete request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("send refresh complete request: %w", err)
+	}
+	defer func() {
+		if closeErr := resp.Body.Close(); closeErr != nil {
+			c.logger.Warn("Failed to close refresh complete response body", "error", closeErr)
+		}
+	}()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read refresh complete response: %w", err)
+	}
+
+	switch resp.StatusCode {
+	case http.StatusOK:
+		var cr RefreshCompleteResponse
+		if err := json.Unmarshal(body, &cr); err != nil {
+			return nil, fmt.Errorf("parse refresh complete response: %w", err)
+		}
+		return &cr, nil
+	case http.StatusAccepted:
+		return nil, ErrRefreshPending
+	case http.StatusForbidden:
+		return nil, ErrRefreshRejected
+	default:
+		return nil, fmt.Errorf("refresh complete failed with HTTP %d: %s", resp.StatusCode, string(body))
+	}
 }

--- a/features/steward/registration/client_http_test.go
+++ b/features/steward/registration/client_http_test.go
@@ -47,7 +47,7 @@ func TestRegister_202_ReturnsPendingResponse(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	regResp, pendingResp, err := client.Register(context.Background(), "test-token")
+	regResp, pendingResp, err := client.Register(context.Background(), RegistrationRequest{Token: "test-token"})
 	require.NoError(t, err)
 	assert.Nil(t, regResp, "RegistrationResponse must be nil on 202")
 	require.NotNil(t, pendingResp, "RegistrationPendingResponse must be non-nil on 202")
@@ -84,7 +84,7 @@ func TestRegister_ErrorStatus_ReturnsError(t *testing.T) {
 			})
 			require.NoError(t, err)
 
-			regResp, pendingResp, err := client.Register(context.Background(), "test-token")
+			regResp, pendingResp, err := client.Register(context.Background(), RegistrationRequest{Token: "test-token"})
 			require.Error(t, err, "non-200/202 status must return an error")
 			assert.Nil(t, regResp, "RegistrationResponse must be nil on error status")
 			assert.Nil(t, pendingResp, "RegistrationPendingResponse must be nil on error status")
@@ -320,4 +320,124 @@ func TestPollStatus_ErrorStatus_ReturnsError(t *testing.T) {
 	require.Error(t, err)
 	assert.Nil(t, resp)
 	assert.Contains(t, err.Error(), "status poll failed with HTTP 401")
+}
+
+// TestRegistrationRequest_IncludesDeviceIDAndIdentityKeyPub verifies that the new fields
+// are serialised to JSON and sent to the controller.
+func TestRegistrationRequest_IncludesDeviceIDAndIdentityKeyPub(t *testing.T) {
+	var gotBody RegistrationRequest
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&gotBody))
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"success":true,"steward_id":"s1","transport_address":"ctrl:4433"}`))
+	}))
+	defer srv.Close()
+
+	client, err := NewHTTPClient(&HTTPConfig{ControllerURL: srv.URL, Logger: logging.NewLogger("debug")})
+	require.NoError(t, err)
+
+	req := RegistrationRequest{
+		Token:          "tok",
+		DeviceID:       "abcd1234",
+		IdentityKeyPub: "base64pubkey==",
+	}
+	_, _, err = client.Register(context.Background(), req)
+	require.NoError(t, err)
+	assert.Equal(t, "tok", gotBody.Token)
+	assert.Equal(t, "abcd1234", gotBody.DeviceID)
+	assert.Equal(t, "base64pubkey==", gotBody.IdentityKeyPub)
+}
+
+// TestRefreshChallenge_200_ReturnsChallengeResponse verifies that a 200 response is decoded correctly.
+func TestRefreshChallenge_200_ReturnsChallengeResponse(t *testing.T) {
+	const deviceID = "aabbccdd"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "/api/v1/stewards/"+deviceID+"/refresh/challenge", r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"nonce":"dGVzdG5vbmNl","server_ts":1234567890,"expires_in":60}`))
+	}))
+	defer srv.Close()
+
+	cl, err := NewHTTPClient(&HTTPConfig{ControllerURL: srv.URL, Logger: logging.NewLogger("debug")})
+	require.NoError(t, err)
+
+	resp, err := cl.RefreshChallenge(context.Background(), deviceID)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, "dGVzdG5vbmNl", resp.Nonce)
+	assert.Equal(t, uint64(1234567890), resp.ServerTS)
+	assert.Equal(t, 60, resp.ExpiresIn)
+}
+
+// TestRefreshChallenge_403_ReturnsErrRefreshRejected verifies that HTTP 403 maps to ErrRefreshRejected.
+func TestRefreshChallenge_403_ReturnsErrRefreshRejected(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "revoked", http.StatusForbidden)
+	}))
+	defer srv.Close()
+
+	cl, err := NewHTTPClient(&HTTPConfig{ControllerURL: srv.URL, Logger: logging.NewLogger("debug")})
+	require.NoError(t, err)
+
+	resp, err := cl.RefreshChallenge(context.Background(), "device-id")
+	assert.Nil(t, resp)
+	require.ErrorIs(t, err, ErrRefreshRejected)
+}
+
+// TestRefreshComplete_200_ReturnsCerts verifies that HTTP 200 with cert fields is decoded.
+func TestRefreshComplete_200_ReturnsCerts(t *testing.T) {
+	const deviceID = "aabbccdd"
+	body := `{"client_cert":"CERT","client_key":"KEY","ca_cert":"CA","server_cert":"SRV","transport_address":"ctrl:4433"}`
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "/api/v1/stewards/"+deviceID+"/refresh/complete", r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(body))
+	}))
+	defer srv.Close()
+
+	cl, err := NewHTTPClient(&HTTPConfig{ControllerURL: srv.URL, Logger: logging.NewLogger("debug")})
+	require.NoError(t, err)
+
+	resp, err := cl.RefreshComplete(context.Background(), deviceID, "nonce123", []byte("signature"))
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, "CERT", resp.ClientCert)
+	assert.Equal(t, "KEY", resp.ClientKey)
+	assert.Equal(t, "CA", resp.CACert)
+	assert.Equal(t, "ctrl:4433", resp.TransportAddress)
+}
+
+// TestRefreshComplete_202_ReturnsErrRefreshPending verifies that HTTP 202 maps to ErrRefreshPending.
+func TestRefreshComplete_202_ReturnsErrRefreshPending(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	defer srv.Close()
+
+	cl, err := NewHTTPClient(&HTTPConfig{ControllerURL: srv.URL, Logger: logging.NewLogger("debug")})
+	require.NoError(t, err)
+
+	resp, err := cl.RefreshComplete(context.Background(), "device-id", "nonce", []byte("sig"))
+	assert.Nil(t, resp)
+	require.ErrorIs(t, err, ErrRefreshPending)
+}
+
+// TestRefreshComplete_403_ReturnsErrRefreshRejected verifies that HTTP 403 maps to ErrRefreshRejected.
+func TestRefreshComplete_403_ReturnsErrRefreshRejected(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "rejected", http.StatusForbidden)
+	}))
+	defer srv.Close()
+
+	cl, err := NewHTTPClient(&HTTPConfig{ControllerURL: srv.URL, Logger: logging.NewLogger("debug")})
+	require.NoError(t, err)
+
+	resp, err := cl.RefreshComplete(context.Background(), "device-id", "nonce", []byte("sig"))
+	assert.Nil(t, resp)
+	require.ErrorIs(t, err, ErrRefreshRejected)
 }

--- a/features/steward/registration/types.go
+++ b/features/steward/registration/types.go
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+
+package registration
+
+import "errors"
+
+// ErrRefreshPending is returned by RefreshComplete when the controller accepts the
+// proof-of-possession but queues the request for manual approval (HTTP 202).
+// Callers should log and schedule a retry rather than treating this as fatal.
+var ErrRefreshPending = errors.New("registration refresh pending operator approval")
+
+// ErrRefreshRejected is returned by RefreshChallenge or RefreshComplete when the
+// controller refuses the request for a revoked or dormant device (HTTP 403).
+// Callers must halt and not fall through to full re-registration.
+var ErrRefreshRejected = errors.New("registration refresh rejected by controller")
+
+// RefreshChallengeResponse is the response body from POST /api/v1/stewards/{device_id}/refresh/challenge.
+type RefreshChallengeResponse struct {
+	Nonce     string `json:"nonce"`      // base64url-encoded 32-byte random nonce
+	ServerTS  uint64 `json:"server_ts"`  // unix seconds, included in the PoP digest
+	ExpiresIn int    `json:"expires_in"` // seconds until the nonce expires (typically 60)
+}
+
+// RefreshCompleteResponse is the response body from POST /api/v1/stewards/{device_id}/refresh/complete
+// on HTTP 200 (cert issued immediately). HTTP 202 returns ErrRefreshPending; HTTP 403 returns ErrRefreshRejected.
+type RefreshCompleteResponse struct {
+	ClientCert       string `json:"client_cert"`
+	ClientKey        string `json:"client_key"`
+	CACert           string `json:"ca_cert"`
+	ServerCert       string `json:"server_cert,omitempty"`
+	TransportAddress string `json:"transport_address"`
+}

--- a/pkg/registration/identity/keystore.go
+++ b/pkg/registration/identity/keystore.go
@@ -1,0 +1,165 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+
+// Package identity manages the steward's stable Ed25519 device identity keypair
+// for the registration-refresh handshake defined in ADR-011.
+package identity
+
+import (
+	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+
+	stewardcrypto "github.com/cfgis/cfgms/pkg/secrets/providers/steward"
+)
+
+const keyFileName = "device_identity.enc"
+
+// KeyStore abstracts device identity key material storage for the registration-refresh handshake.
+type KeyStore interface {
+	GenerateOrLoad(ctx context.Context) (ed25519.PublicKey, ed25519.PrivateKey, error)
+	DeviceID() string
+	Sign(message []byte) ([]byte, error)
+}
+
+// FileKeyStore stores the Ed25519 device identity key encrypted at rest.
+// The private key is encrypted via the platform encryptor (AES-256-GCM on Linux/macOS,
+// DPAPI on Windows) and written to {identityDir}/device_identity.enc with mode 0600.
+// The plaintext private key is never written to disk.
+type FileKeyStore struct {
+	identityDir string
+	encryptor   stewardcrypto.Encryptor
+	mu          sync.Mutex
+	privateKey  ed25519.PrivateKey
+	publicKey   ed25519.PublicKey
+	deviceID    string
+}
+
+// NewFileKeyStore creates a FileKeyStore that stores the encrypted device identity key in identityDir.
+func NewFileKeyStore(identityDir string) (*FileKeyStore, error) {
+	enc, err := stewardcrypto.NewPlatformEncryptor(identityDir)
+	if err != nil {
+		return nil, fmt.Errorf("create platform encryptor: %w", err)
+	}
+	return newFileKeyStoreWithEncryptor(identityDir, enc), nil
+}
+
+// newFileKeyStoreWithEncryptor creates a FileKeyStore with an explicit encryptor.
+// Used in tests to inject a real AES-256-GCM encryptor with a fixed machine ID
+// when /etc/machine-id is unavailable in the test environment.
+func newFileKeyStoreWithEncryptor(identityDir string, enc stewardcrypto.Encryptor) *FileKeyStore {
+	return &FileKeyStore{
+		identityDir: identityDir,
+		encryptor:   enc,
+	}
+}
+
+// NewFileKeyStoreForTesting creates a FileKeyStore using a fixed AES-256-GCM encryptor
+// seeded with a predictable machine ID, independent of the platform machine ID.
+// Intended for use in external test packages where /etc/machine-id may be unavailable.
+func NewFileKeyStoreForTesting(identityDir string) (*FileKeyStore, error) {
+	enc, err := stewardcrypto.NewEncryptorFromBytes([]byte("cfgms-test-machine-id"), identityDir)
+	if err != nil {
+		return nil, fmt.Errorf("create test encryptor: %w", err)
+	}
+	return newFileKeyStoreWithEncryptor(identityDir, enc), nil
+}
+
+// GenerateOrLoad loads the existing device identity key or generates and stores a new one on first call.
+// The private key is stored encrypted at rest; the plaintext never leaves memory.
+func (ks *FileKeyStore) GenerateOrLoad(_ context.Context) (ed25519.PublicKey, ed25519.PrivateKey, error) {
+	ks.mu.Lock()
+	defer ks.mu.Unlock()
+
+	keyPath := filepath.Join(ks.identityDir, keyFileName)
+	data, err := os.ReadFile(keyPath) //#nosec G304 -- path constructed from configured identity directory
+	if err == nil {
+		plaintext, decErr := ks.encryptor.Decrypt(data)
+		if decErr != nil {
+			return nil, nil, fmt.Errorf("decrypt device identity key: %w", decErr)
+		}
+		if len(plaintext) != ed25519.PrivateKeySize {
+			return nil, nil, fmt.Errorf("device identity key corrupt: expected %d bytes, got %d", ed25519.PrivateKeySize, len(plaintext))
+		}
+		priv := ed25519.PrivateKey(plaintext)
+		pub := priv.Public().(ed25519.PublicKey)
+		ks.privateKey = priv
+		ks.publicKey = pub
+		ks.deviceID = computeDeviceID(pub)
+		return pub, priv, nil
+	}
+
+	if !errors.Is(err, os.ErrNotExist) {
+		return nil, nil, fmt.Errorf("read device identity key: %w", err)
+	}
+
+	pub, priv, genErr := ed25519.GenerateKey(rand.Reader)
+	if genErr != nil {
+		return nil, nil, fmt.Errorf("generate device identity key: %w", genErr)
+	}
+
+	ciphertext, encErr := ks.encryptor.Encrypt([]byte(priv))
+	if encErr != nil {
+		return nil, nil, fmt.Errorf("encrypt device identity key: %w", encErr)
+	}
+
+	if mkErr := os.MkdirAll(ks.identityDir, 0700); mkErr != nil {
+		return nil, nil, fmt.Errorf("create identity dir: %w", mkErr)
+	}
+
+	tmp := keyPath + ".tmp"
+	if writeErr := os.WriteFile(tmp, ciphertext, 0600); writeErr != nil {
+		_ = os.Remove(tmp)
+		return nil, nil, fmt.Errorf("write device identity key: %w", writeErr)
+	}
+	if renErr := os.Rename(tmp, keyPath); renErr != nil {
+		_ = os.Remove(tmp)
+		return nil, nil, fmt.Errorf("commit device identity key: %w", renErr)
+	}
+
+	ks.privateKey = priv
+	ks.publicKey = pub
+	ks.deviceID = computeDeviceID(pub)
+	return pub, priv, nil
+}
+
+// DeviceID returns the 64-char lowercase hex SHA-256 of the Ed25519 public key.
+// Returns empty string if GenerateOrLoad has not been called.
+func (ks *FileKeyStore) DeviceID() string {
+	ks.mu.Lock()
+	defer ks.mu.Unlock()
+	return ks.deviceID
+}
+
+// PublicKey returns the Ed25519 public key.
+// Returns nil if GenerateOrLoad has not been called.
+func (ks *FileKeyStore) PublicKey() ed25519.PublicKey {
+	ks.mu.Lock()
+	defer ks.mu.Unlock()
+	return ks.publicKey
+}
+
+// Sign signs message with the device identity private key using Ed25519.
+// Returns an error if GenerateOrLoad has not been called.
+func (ks *FileKeyStore) Sign(message []byte) ([]byte, error) {
+	ks.mu.Lock()
+	defer ks.mu.Unlock()
+	if ks.privateKey == nil {
+		return nil, fmt.Errorf("device identity key not loaded: call GenerateOrLoad first")
+	}
+	return ed25519.Sign(ks.privateKey, message), nil
+}
+
+// computeDeviceID returns the 64-char lowercase hex SHA-256 of the Ed25519 public key.
+// DeviceID = hex(sha256(publicKeyBytes)) per ADR-011.
+func computeDeviceID(pub ed25519.PublicKey) string {
+	h := sha256.Sum256([]byte(pub))
+	return hex.EncodeToString(h[:])
+}

--- a/pkg/registration/identity/keystore_test.go
+++ b/pkg/registration/identity/keystore_test.go
@@ -1,0 +1,155 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+
+package identity
+
+import (
+	"context"
+	"crypto/ed25519"
+	"crypto/x509"
+	"encoding/pem"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	stewardcrypto "github.com/cfgis/cfgms/pkg/secrets/providers/steward"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newTestKeyStoreInDir creates a FileKeyStore using a real AES-256-GCM encryptor
+// seeded with a fixed machine ID. This avoids the /etc/machine-id dependency in
+// test environments while still exercising real encryption (not a mock).
+func newTestKeyStoreInDir(t *testing.T, dir string) *FileKeyStore {
+	t.Helper()
+	enc, err := stewardcrypto.NewEncryptorFromBytes([]byte("cfgms-test-machine-id"), dir)
+	require.NoError(t, err)
+	return newFileKeyStoreWithEncryptor(dir, enc)
+}
+
+// TestFileKeyStore_KeyEncryptedAtRest verifies that the private key on disk is opaque
+// ciphertext — not valid PEM and not a valid PKCS8 structure.
+// This proves the plaintext private key is never written to disk.
+func TestFileKeyStore_KeyEncryptedAtRest(t *testing.T) {
+	dir := t.TempDir()
+	ks := newTestKeyStoreInDir(t, dir)
+
+	_, _, err := ks.GenerateOrLoad(context.Background())
+	require.NoError(t, err)
+
+	data, err := os.ReadFile(filepath.Join(dir, keyFileName))
+	require.NoError(t, err, "device_identity.enc must exist after GenerateOrLoad")
+
+	block, _ := pem.Decode(data)
+	assert.Nil(t, block, "on-disk bytes must not be valid PEM (plaintext key never written to disk)")
+
+	_, pkcs8Err := x509.ParsePKCS8PrivateKey(data)
+	assert.Error(t, pkcs8Err, "on-disk bytes must not parse as PKCS8 (plaintext key never written to disk)")
+}
+
+// TestFileKeyStore_RoundTrip verifies that loading a previously generated key from disk
+// yields the same public key bytes and DeviceID as the original generation.
+func TestFileKeyStore_RoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	ks1 := newTestKeyStoreInDir(t, dir)
+
+	pub1, _, err := ks1.GenerateOrLoad(context.Background())
+	require.NoError(t, err)
+	deviceID1 := ks1.DeviceID()
+	require.NotEmpty(t, deviceID1, "DeviceID must be set after GenerateOrLoad")
+	assert.Len(t, deviceID1, 64, "DeviceID must be 64-char lowercase hex")
+
+	// Load from the same directory with a new FileKeyStore instance.
+	ks2 := newTestKeyStoreInDir(t, dir)
+	pub2, _, err := ks2.GenerateOrLoad(context.Background())
+	require.NoError(t, err)
+	deviceID2 := ks2.DeviceID()
+
+	assert.Equal(t, []byte(pub1), []byte(pub2), "public key must be identical across load cycles")
+	assert.Equal(t, deviceID1, deviceID2, "DeviceID must be stable across load cycles")
+}
+
+// TestFileKeyStore_DeviceID_IsHexSHA256OfPublicKey proves the DeviceID formula:
+// hex(sha256(publicKeyBytes)) == 64-char lowercase hex.
+func TestFileKeyStore_DeviceID_IsHexSHA256OfPublicKey(t *testing.T) {
+	dir := t.TempDir()
+	ks := newTestKeyStoreInDir(t, dir)
+
+	pub, _, err := ks.GenerateOrLoad(context.Background())
+	require.NoError(t, err)
+
+	expected := computeDeviceID(pub)
+	assert.Equal(t, expected, ks.DeviceID())
+	assert.Len(t, ks.DeviceID(), 64)
+}
+
+// TestFileKeyStore_Sign verifies that Sign produces a valid Ed25519 signature
+// verifiable with the corresponding public key.
+func TestFileKeyStore_Sign(t *testing.T) {
+	dir := t.TempDir()
+	ks := newTestKeyStoreInDir(t, dir)
+
+	pub, _, err := ks.GenerateOrLoad(context.Background())
+	require.NoError(t, err)
+
+	msg := []byte("test-digest-bytes")
+	sig, err := ks.Sign(msg)
+	require.NoError(t, err)
+	assert.Len(t, sig, ed25519.SignatureSize)
+	assert.True(t, ed25519.Verify(pub, msg, sig), "signature must verify with the corresponding public key")
+}
+
+// TestFileKeyStore_Sign_BeforeLoad returns an error when Sign is called without GenerateOrLoad.
+func TestFileKeyStore_Sign_BeforeLoad(t *testing.T) {
+	dir := t.TempDir()
+	ks := newTestKeyStoreInDir(t, dir)
+
+	_, err := ks.Sign([]byte("message"))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "GenerateOrLoad")
+}
+
+// TestFileKeyStore_KeyFileMode verifies the on-disk key file has mode 0600.
+func TestFileKeyStore_KeyFileMode(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix file permission check not applicable on Windows")
+	}
+	dir := t.TempDir()
+	ks := newTestKeyStoreInDir(t, dir)
+
+	_, _, err := ks.GenerateOrLoad(context.Background())
+	require.NoError(t, err)
+
+	info, err := os.Stat(filepath.Join(dir, keyFileName))
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0600), info.Mode().Perm())
+}
+
+// TestFileKeyStore_GenerateOrLoad_Idempotent verifies that calling GenerateOrLoad twice
+// on the same FileKeyStore returns the same key (cached, not re-generated).
+func TestFileKeyStore_GenerateOrLoad_Idempotent(t *testing.T) {
+	dir := t.TempDir()
+	ks := newTestKeyStoreInDir(t, dir)
+
+	pub1, _, err := ks.GenerateOrLoad(context.Background())
+	require.NoError(t, err)
+
+	pub2, _, err := ks.GenerateOrLoad(context.Background())
+	require.NoError(t, err)
+
+	assert.Equal(t, []byte(pub1), []byte(pub2))
+}
+
+// TestFileKeyStore_PublicKey returns the key loaded by GenerateOrLoad.
+func TestFileKeyStore_PublicKey(t *testing.T) {
+	dir := t.TempDir()
+	ks := newTestKeyStoreInDir(t, dir)
+
+	assert.Nil(t, ks.PublicKey(), "PublicKey must be nil before GenerateOrLoad")
+
+	pub, _, err := ks.GenerateOrLoad(context.Background())
+	require.NoError(t, err)
+
+	assert.Equal(t, []byte(pub), []byte(ks.PublicKey()))
+}

--- a/pkg/secrets/providers/steward/crypto.go
+++ b/pkg/secrets/providers/steward/crypto.go
@@ -21,6 +21,28 @@ import (
 	"golang.org/x/crypto/hkdf"
 )
 
+// Encryptor provides symmetric encryption and decryption.
+// Returned by NewPlatformEncryptor for use outside this package.
+type Encryptor interface {
+	Encrypt(plaintext []byte) ([]byte, error)
+	Decrypt(ciphertext []byte) ([]byte, error)
+}
+
+// NewPlatformEncryptor creates an OS-native encryptor for the given directory.
+// On Linux/macOS: AES-256-GCM with HKDF-SHA256 derived from the machine ID.
+// On Windows: DPAPI.
+// The dir is used to persist the HKDF salt (Linux/macOS only).
+func NewPlatformEncryptor(dir string) (Encryptor, error) {
+	return newPlatformEncryptor(dir)
+}
+
+// NewEncryptorFromBytes creates an AES-256-GCM encryptor using the supplied machineID bytes
+// instead of reading the platform machine ID. Intended for use in tests where
+// /etc/machine-id or the platform equivalent is unavailable.
+func NewEncryptorFromBytes(machineID []byte, dir string) (Encryptor, error) {
+	return newAesGcmEncryptor(machineID, dir)
+}
+
 // platformEncryptor abstracts OS-native encryption for secret storage.
 // Each platform provides its own implementation via build tags.
 type platformEncryptor interface {


### PR DESCRIPTION
## Summary

- Generates a stable Ed25519 device identity keypair on first run; stores private key AES-256-GCM encrypted at rest (HKDF-SHA256 from machine ID on Linux/macOS, DPAPI on Windows) with mode 0600 — plaintext never hits disk
- Implements registration-refresh handshake (challenge → PoP sign → complete) so a steward with expired mTLS certs can reconnect via proof-of-possession without full re-registration, per ADR-011
- `ErrRefreshRejected` (HTTP 403) halts immediately with no fall-through to HTTP re-registration; `ErrRefreshPending` (HTTP 202) logs and retries later
- DeviceID = `hex(sha256(publicKey))` — 64-char lowercase hex, stable across cert rotations
- Test injection via `NewEncryptorFromBytes` + `NewFileKeyStoreForTesting` avoids `/etc/machine-id` dependency while using real AES-256-GCM (no mocks)

## Changed files

| File | Change |
|------|--------|
| `pkg/registration/identity/keystore.go` | New — `KeyStore` interface + `FileKeyStore` impl |
| `pkg/registration/identity/keystore_test.go` | New — 8 tests (encrypt-at-rest, round-trip, DeviceID formula, Sign, idempotent, file mode, etc.) |
| `pkg/secrets/providers/steward/crypto.go` | Export `Encryptor` interface, `NewPlatformEncryptor`, `NewEncryptorFromBytes` |
| `features/steward/registration/types.go` | New — `ErrRefreshPending`, `ErrRefreshRejected`, `RefreshChallengeResponse`, `RefreshCompleteResponse` |
| `features/steward/registration/client_http.go` | `Register` takes `RegistrationRequest` struct (DeviceID + IdentityKeyPub); `RefreshChallenge` + `RefreshComplete` methods |
| `features/steward/registration/client_http_test.go` | Updated existing tests; 6 new tests for refresh methods |
| `cmd/steward/identity.go` | `StewardIdentity` gains `DeviceID` + `IdentityKeyPub` fields |
| `cmd/steward/main.go` | `hasExpiredClientCert`, `refreshAndConnect` (PoP handshake), `enrichApprovedWithDeviceIdentity`; key store initialised before first connect |
| `cmd/steward/main_test.go` | `TestHasExpiredClientCert` + `TestRefreshAndConnect_202_ReturnsErrRefreshPending` |

## Test plan

- [x] `go test -race ./pkg/registration/identity/...` — 8 tests PASS
- [x] `go test -race ./features/steward/registration/...` — PASS
- [x] `go test -race ./cmd/steward/...` — PASS
- [x] `go test -race ./pkg/secrets/providers/steward/...` — PASS
- [x] `make test-agent-complete` — PASS (175/175 script tests + all Go packages)
- [x] Security scan (`make security-scan`) — PASS (0 blocking findings)
- [x] Architecture check (`make check-architecture`) — PASS
- [x] Cross-platform compilation (linux/amd64, linux/arm64, darwin/amd64, darwin/arm64, windows/amd64) — PASS

Fixes #2094

🤖 Generated with [Claude Code](https://claude.com/claude-code)