### PR TITLE
controller: registration-refresh challenge + complete gate endpoints (Issue #2096)

### DIFF
--- a/features/controller/api/handlers_registration_refresh.go
+++ b/features/controller/api/handlers_registration_refresh.go
@@ -1,0 +1,549 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+package api
+
+import (
+	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/binary"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/gorilla/mux"
+
+	"github.com/cfgis/cfgms/features/controller/registration"
+	"github.com/cfgis/cfgms/pkg/audit"
+	"github.com/cfgis/cfgms/pkg/cert"
+	"github.com/cfgis/cfgms/pkg/logging"
+	business "github.com/cfgis/cfgms/pkg/storage/interfaces/business"
+)
+
+// PoPVerifier verifies an Ed25519 proof-of-possession signature.
+// Injected on the Server so tests can assert it is never called for revoked devices.
+type PoPVerifier interface {
+	Verify(pub ed25519.PublicKey, message, sig []byte) bool
+}
+
+// ed25519PoPVerifier is the default PoPVerifier backed by the stdlib ed25519.Verify.
+type ed25519PoPVerifier struct{}
+
+func (ed25519PoPVerifier) Verify(pub ed25519.PublicKey, message, sig []byte) bool {
+	return ed25519.Verify(pub, message, sig)
+}
+
+// nonceEntry is the value stored in the nonce cache keyed by "refresh-nonce:<device_id>".
+type nonceEntry struct {
+	NonceBytes []byte
+	ServerTS   uint64    // Unix nanoseconds; encoded BE-uint64 in the PoP message
+	IssuedAt   time.Time // wall-clock time for the 60s expiry check
+}
+
+// nonce cache constants (ADR-010 §2).
+const (
+	nonceCacheKeyPrefix = "refresh-nonce:"
+	nonceTTL            = 65 * time.Second // cache TTL; IssuedAt check enforces 60s
+	nonceMaxAge         = 60 * time.Second // enforced window for IssuedAt
+)
+
+// ---- Request / response types -----------------------------------------------
+
+// RefreshChallengeRequest is the optional body for the challenge endpoint.
+type RefreshChallengeRequest struct {
+	TenantID string `json:"tenant_id,omitempty"`
+}
+
+// RefreshChallengeResponse is returned by POST /api/v1/stewards/{device_id}/refresh/challenge.
+type RefreshChallengeResponse struct {
+	Nonce    string `json:"nonce"`     // base64url-encoded 32-byte random value
+	ServerTS uint64 `json:"server_ts"` // Unix nanoseconds when the nonce was issued
+}
+
+// RefreshCompleteRequest is the body for the complete endpoint.
+type RefreshCompleteRequest struct {
+	TenantID   string            `json:"tenant_id"`
+	Nonce      string            `json:"nonce"`     // base64url nonce from challenge response
+	IssuedAt   int64             `json:"issued_at"` // server_ts from challenge (Unix nanoseconds)
+	Signature  string            `json:"signature"` // base64url Ed25519 sig over PoP message
+	Provenance map[string]string `json:"provenance,omitempty"`
+}
+
+// RefreshCompleteResponse is returned by POST /api/v1/stewards/{device_id}/refresh/complete.
+type RefreshCompleteResponse struct {
+	Status    string `json:"status"`
+	PendingID string `json:"pending_id,omitempty"` // set when queued for approval
+	// Certificate fields: populated only on the auto-accept path
+	ClientCert  string `json:"client_cert,omitempty"`
+	ClientKey   string `json:"client_key,omitempty"`
+	CACert      string `json:"ca_cert,omitempty"`
+	SigningCert string `json:"signing_cert,omitempty"`
+}
+
+// ---- Handlers ---------------------------------------------------------------
+
+// handleRefreshChallenge handles POST /api/v1/stewards/{device_id}/refresh/challenge.
+// Revocation is the authoritative pre-nonce gate: revoked devices receive 403 before
+// any nonce is generated (ADR-010 §3 revocation-before-PoP invariant).
+func (s *Server) handleRefreshChallenge(w http.ResponseWriter, r *http.Request) {
+	deviceID := mux.Vars(r)["device_id"]
+
+	var req RefreshChallengeRequest
+	_ = json.NewDecoder(r.Body).Decode(&req) // body is optional; TenantID defaults to "" if absent or malformed
+
+	if s.stewardStore == nil {
+		s.emitRefreshAudit(r.Context(), deviceID, req.TenantID,
+			business.AuditEventSystemEvent, "refresh_challenge_error",
+			business.AuditResultError, business.AuditSeverityHigh,
+			map[string]interface{}{"reason": "steward_store_unavailable"})
+		http.Error(w, "steward store unavailable", http.StatusServiceUnavailable)
+		return
+	}
+
+	record, err := s.stewardStore.GetStewardByDeviceID(r.Context(), deviceID)
+	if err != nil {
+		if err == business.ErrStewardNotFound {
+			s.emitRefreshAudit(r.Context(), deviceID, req.TenantID,
+				business.AuditEventSecurityEvent, "refresh_challenge_rejected",
+				business.AuditResultFailure, business.AuditSeverityMedium,
+				map[string]interface{}{"reason": "unknown_device"})
+			http.Error(w, "device not found", http.StatusNotFound)
+			return
+		}
+		s.logger.Error("Failed to look up steward by device ID", "device_id", logging.SanitizeLogValue(deviceID), "error", err)
+		s.emitRefreshAudit(r.Context(), deviceID, req.TenantID,
+			business.AuditEventSystemEvent, "refresh_challenge_error",
+			business.AuditResultError, business.AuditSeverityHigh,
+			map[string]interface{}{"reason": "store_error"})
+		http.Error(w, "failed to look up device", http.StatusInternalServerError)
+		return
+	}
+
+	// Revocation gate — MUST be checked before generating any nonce.
+	if record.Status == business.StewardStatusRevoked {
+		s.emitRefreshAudit(r.Context(), deviceID, record.TenantID,
+			business.AuditEventSecurityEvent, "refresh_challenge_rejected",
+			business.AuditResultDenied, business.AuditSeverityCritical,
+			map[string]interface{}{"reason": "revoked"})
+		http.Error(w, "device is revoked", http.StatusForbidden)
+		return
+	}
+
+	// Cross-tenant isolation: request tenant must match the steward's registered tenant.
+	if req.TenantID != "" && req.TenantID != record.TenantID {
+		s.emitRefreshAudit(r.Context(), deviceID, req.TenantID,
+			business.AuditEventSecurityEvent, "refresh_challenge_rejected",
+			business.AuditResultDenied, business.AuditSeverityCritical,
+			map[string]interface{}{"reason": "cross_tenant"})
+		http.Error(w, "tenant mismatch", http.StatusForbidden)
+		return
+	}
+
+	// Generate 32-byte cryptographically random nonce.
+	nonceBytes := make([]byte, 32)
+	if _, err := rand.Read(nonceBytes); err != nil {
+		s.logger.Error("Failed to generate refresh nonce", "error", err)
+		s.emitRefreshAudit(r.Context(), deviceID, record.TenantID,
+			business.AuditEventSystemEvent, "refresh_challenge_error",
+			business.AuditResultError, business.AuditSeverityHigh,
+			map[string]interface{}{"reason": "nonce_generation_failed"})
+		http.Error(w, "failed to generate challenge", http.StatusInternalServerError)
+		return
+	}
+
+	issuedAt := time.Now().UTC()
+	serverTS := uint64(issuedAt.UnixNano())
+
+	cacheKey := nonceCacheKeyPrefix + deviceID
+	if err := s.nonceCache.Set(cacheKey, &nonceEntry{
+		NonceBytes: nonceBytes,
+		ServerTS:   serverTS,
+		IssuedAt:   issuedAt,
+	}, nonceTTL); err != nil {
+		s.logger.Error("Failed to store nonce in cache", "error", err)
+		s.emitRefreshAudit(r.Context(), deviceID, record.TenantID,
+			business.AuditEventSystemEvent, "refresh_challenge_error",
+			business.AuditResultError, business.AuditSeverityHigh,
+			map[string]interface{}{"reason": "cache_store_failed"})
+		http.Error(w, "failed to issue challenge", http.StatusInternalServerError)
+		return
+	}
+
+	s.emitRefreshAudit(r.Context(), deviceID, record.TenantID,
+		business.AuditEventAuthentication, "refresh_challenge_issued",
+		business.AuditResultSuccess, business.AuditSeverityLow, nil)
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	if err := json.NewEncoder(w).Encode(RefreshChallengeResponse{
+		Nonce:    base64.RawURLEncoding.EncodeToString(nonceBytes),
+		ServerTS: serverTS,
+	}); err != nil {
+		s.logger.Error("Failed to encode challenge response", "error", err)
+	}
+}
+
+// handleRefreshComplete handles POST /api/v1/stewards/{device_id}/refresh/complete.
+// Gate order (ADR-010 §3): (1) lookup, (2) revocation, (3) nonce, (4) IssuedAt,
+// (5) consume nonce, (6) PoP verify, (7) lifecycle policy, (8) issue cert or queue.
+// Audit is emitted before WriteHeader on every outcome.
+func (s *Server) handleRefreshComplete(w http.ResponseWriter, r *http.Request) {
+	deviceID := mux.Vars(r)["device_id"]
+
+	var req RefreshCompleteRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "invalid request body", http.StatusBadRequest)
+		return
+	}
+
+	if s.stewardStore == nil {
+		http.Error(w, "steward store unavailable", http.StatusServiceUnavailable)
+		return
+	}
+
+	// Gate (1): lookup → 404
+	record, err := s.stewardStore.GetStewardByDeviceID(r.Context(), deviceID)
+	if err != nil {
+		if err == business.ErrStewardNotFound {
+			s.emitRefreshAudit(r.Context(), deviceID, req.TenantID,
+				business.AuditEventSecurityEvent, "refresh_rejected",
+				business.AuditResultFailure, business.AuditSeverityMedium,
+				map[string]interface{}{"reason": "unknown_device"})
+			http.Error(w, "device not found", http.StatusNotFound)
+			return
+		}
+		s.logger.Error("Failed to look up steward by device ID", "device_id", logging.SanitizeLogValue(deviceID), "error", err)
+		s.emitRefreshAudit(r.Context(), deviceID, req.TenantID,
+			business.AuditEventSystemEvent, "refresh_error",
+			business.AuditResultError, business.AuditSeverityHigh,
+			map[string]interface{}{"reason": "store_error"})
+		http.Error(w, "failed to look up device", http.StatusInternalServerError)
+		return
+	}
+
+	// Gate (2): revocation — PoPVerifier must NEVER be called for revoked devices.
+	if record.Status == business.StewardStatusRevoked {
+		s.emitRefreshAudit(r.Context(), deviceID, record.TenantID,
+			business.AuditEventSecurityEvent, "refresh_rejected",
+			business.AuditResultDenied, business.AuditSeverityCritical,
+			map[string]interface{}{"reason": "revoked"})
+		http.Error(w, "device is revoked", http.StatusForbidden)
+		return
+	}
+
+	// Cross-tenant isolation before any nonce operations.
+	if req.TenantID != "" && req.TenantID != record.TenantID {
+		s.emitRefreshAudit(r.Context(), deviceID, req.TenantID,
+			business.AuditEventSecurityEvent, "refresh_rejected",
+			business.AuditResultDenied, business.AuditSeverityCritical,
+			map[string]interface{}{"reason": "cross_tenant"})
+		http.Error(w, "tenant mismatch", http.StatusForbidden)
+		return
+	}
+
+	// Gate (3): nonce absent or expired → 401
+	cacheKey := nonceCacheKeyPrefix + deviceID
+	raw, found := s.nonceCache.Get(cacheKey)
+	if !found {
+		s.emitRefreshAudit(r.Context(), deviceID, record.TenantID,
+			business.AuditEventSecurityEvent, "refresh_rejected",
+			business.AuditResultFailure, business.AuditSeverityMedium,
+			map[string]interface{}{"reason": "nonce_not_found"})
+		http.Error(w, "challenge expired or not found", http.StatusUnauthorized)
+		return
+	}
+	nonce, ok := raw.(*nonceEntry)
+	if !ok {
+		s.emitRefreshAudit(r.Context(), deviceID, record.TenantID,
+			business.AuditEventSystemEvent, "refresh_error",
+			business.AuditResultError, business.AuditSeverityHigh,
+			map[string]interface{}{"reason": "nonce_type_error"})
+		http.Error(w, "internal error reading challenge", http.StatusInternalServerError)
+		return
+	}
+
+	// Gate (4): IssuedAt > 60s → 401
+	issuedAtTime := time.Unix(0, req.IssuedAt)
+	if time.Since(issuedAtTime) > nonceMaxAge {
+		s.emitRefreshAudit(r.Context(), deviceID, record.TenantID,
+			business.AuditEventSecurityEvent, "refresh_rejected",
+			business.AuditResultFailure, business.AuditSeverityMedium,
+			map[string]interface{}{"reason": "nonce_expired_issuedAt"})
+		http.Error(w, "challenge nonce has expired", http.StatusUnauthorized)
+		return
+	}
+
+	// Gate (5): consume nonce — deleted regardless of subsequent result.
+	s.nonceCache.Delete(cacheKey)
+
+	// Decode nonce bytes from base64url.
+	nonceBytes, err := base64.RawURLEncoding.DecodeString(req.Nonce)
+	if err != nil {
+		s.emitRefreshAudit(r.Context(), deviceID, record.TenantID,
+			business.AuditEventSecurityEvent, "refresh_rejected",
+			business.AuditResultFailure, business.AuditSeverityMedium,
+			map[string]interface{}{"reason": "invalid_nonce_encoding"})
+		http.Error(w, "invalid nonce encoding", http.StatusUnauthorized)
+		return
+	}
+
+	sigBytes, err := base64.RawURLEncoding.DecodeString(req.Signature)
+	if err != nil {
+		s.emitRefreshAudit(r.Context(), deviceID, record.TenantID,
+			business.AuditEventSecurityEvent, "refresh_rejected",
+			business.AuditResultFailure, business.AuditSeverityMedium,
+			map[string]interface{}{"reason": "invalid_signature_encoding"})
+		http.Error(w, "invalid signature encoding", http.StatusUnauthorized)
+		return
+	}
+
+	// Gate (6): PoP verify — message = sha256(nonce_bytes || device_id_utf8 || server_ts_be_uint64)
+	if len(record.IdentityKeyPub) != ed25519.PublicKeySize {
+		s.emitRefreshAudit(r.Context(), deviceID, record.TenantID,
+			business.AuditEventSecurityEvent, "refresh_rejected",
+			business.AuditResultDenied, business.AuditSeverityHigh,
+			map[string]interface{}{"reason": "no_identity_key"})
+		http.Error(w, "device has no identity key registered", http.StatusForbidden)
+		return
+	}
+
+	var tsBytes [8]byte
+	binary.BigEndian.PutUint64(tsBytes[:], nonce.ServerTS)
+	h := sha256.New()
+	h.Write(nonceBytes)
+	h.Write([]byte(deviceID))
+	h.Write(tsBytes[:])
+	popMsg := h.Sum(nil)
+
+	if !s.popVerifier.Verify(ed25519.PublicKey(record.IdentityKeyPub), popMsg, sigBytes) {
+		s.emitRefreshAudit(r.Context(), deviceID, record.TenantID,
+			business.AuditEventSecurityEvent, "refresh_rejected",
+			business.AuditResultFailure, business.AuditSeverityCritical,
+			map[string]interface{}{"reason": "invalid_pop"})
+		http.Error(w, "proof-of-possession verification failed", http.StatusUnauthorized)
+		return
+	}
+
+	// Gate (7): lifecycle gate
+	switch record.Status {
+	case business.StewardStatusArchived:
+		// Archived: add pending refresh and return 202 — policy is skipped.
+		s.handleRefreshQueueEntry(w, r, record, deviceID, req.Provenance, 0, 0, "archived")
+
+	default:
+		// active / registered / dormant / lost / deregistered — consult policy.
+		if s.refreshPolicyStore == nil {
+			// No policy store: default to require_approval.
+			s.handleRefreshQueueEntry(w, r, record, deviceID, req.Provenance, 0, 0, "no_policy_store")
+			return
+		}
+		policy, err := s.refreshPolicyStore.GetPolicy(r.Context(), record.TenantID)
+		if err != nil {
+			s.logger.Error("Failed to get refresh policy", "tenant_id", logging.SanitizeLogValue(record.TenantID), "error", err)
+			s.emitRefreshAudit(r.Context(), deviceID, record.TenantID,
+				business.AuditEventSystemEvent, "refresh_error",
+				business.AuditResultError, business.AuditSeverityHigh,
+				map[string]interface{}{"reason": "policy_store_error"})
+			http.Error(w, "failed to get refresh policy", http.StatusInternalServerError)
+			return
+		}
+		s.handleRefreshByPolicy(w, r, record, deviceID, req.Provenance, policy)
+	}
+}
+
+// handleRefreshByPolicy applies the per-tenant policy gate for non-archived stewards.
+func (s *Server) handleRefreshByPolicy(
+	w http.ResponseWriter, r *http.Request,
+	record *business.StewardRecord, deviceID string,
+	provenance map[string]string, policy *business.RefreshPolicy,
+) {
+	switch policy.Mode {
+	case "reject":
+		s.emitRefreshAudit(r.Context(), deviceID, record.TenantID,
+			business.AuditEventSecurityEvent, "refresh_rejected",
+			business.AuditResultDenied, business.AuditSeverityHigh,
+			map[string]interface{}{"reason": "policy_reject", "decision": "rejected"})
+		http.Error(w, "refresh rejected by tenant policy", http.StatusForbidden)
+
+	case "auto_accept":
+		pm := registration.ProvenanceMatcher{}
+		result := pm.FuzzyMatch(record.LastProvenanceJSON, provenance)
+		if result.Score < registration.ProvenanceMatchThreshold {
+			// Demote to require_approval (demote-only invariant).
+			s.handleRefreshQueueEntry(w, r, record, deviceID, provenance,
+				result.MatchedFields, result.TotalFields, "auto_accept_demoted")
+			return
+		}
+		// Sufficient provenance: issue new certificate immediately.
+		resp, err := s.buildRefreshClaimResponse(r.Context(), record)
+		if err != nil {
+			s.logger.Error("Failed to issue refresh certificate", "steward_id", record.ID, "error", err)
+			s.emitRefreshAudit(r.Context(), deviceID, record.TenantID,
+				business.AuditEventSystemEvent, "refresh_error",
+				business.AuditResultError, business.AuditSeverityHigh,
+				map[string]interface{}{"reason": "cert_issuance_failed"})
+			http.Error(w, "failed to issue certificate", http.StatusInternalServerError)
+			return
+		}
+		s.emitRefreshAudit(r.Context(), deviceID, record.TenantID,
+			business.AuditEventAuthentication, "refresh_cert_issued",
+			business.AuditResultSuccess, business.AuditSeverityHigh,
+			map[string]interface{}{
+				"decision":       "approved",
+				"matched_fields": result.MatchedFields,
+				"total_fields":   result.TotalFields,
+			})
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		if err := json.NewEncoder(w).Encode(resp); err != nil {
+			s.logger.Error("Failed to encode refresh complete response", "error", err)
+		}
+
+	default: // require_approval (and unknown modes)
+		s.handleRefreshQueueEntry(w, r, record, deviceID, provenance, 0, 0, "require_approval")
+	}
+}
+
+// handleRefreshQueueEntry writes a pending refresh record and responds with 202.
+func (s *Server) handleRefreshQueueEntry(
+	w http.ResponseWriter, r *http.Request,
+	record *business.StewardRecord, deviceID string,
+	_ map[string]string, matchedFields, totalFields int, reason string,
+) {
+	if s.pendingRefreshStore == nil {
+		s.emitRefreshAudit(r.Context(), deviceID, record.TenantID,
+			business.AuditEventSystemEvent, "refresh_error",
+			business.AuditResultError, business.AuditSeverityHigh,
+			map[string]interface{}{"reason": "pending_store_unavailable"})
+		http.Error(w, "pending refresh store unavailable", http.StatusServiceUnavailable)
+		return
+	}
+
+	pendingID := fmt.Sprintf("refresh-%d", time.Now().UnixNano())
+	entry := &business.PendingRefreshEntry{
+		PendingID:               pendingID,
+		DeviceID:                deviceID,
+		TenantID:                record.TenantID,
+		SourceIP:                extractSourceIP(r, s.trustedProxies),
+		ProvenanceMatchedFields: matchedFields,
+		ProvenanceTotalFields:   totalFields,
+		Status:                  business.PendingRefreshStatusPending,
+		CreatedAt:               time.Now().UTC(),
+		ExpiresAt:               time.Now().UTC().Add(7 * 24 * time.Hour),
+	}
+	if err := s.pendingRefreshStore.AddPendingRefresh(r.Context(), entry); err != nil {
+		s.logger.Error("Failed to add pending refresh", "steward_id", record.ID, "error", err)
+		s.emitRefreshAudit(r.Context(), deviceID, record.TenantID,
+			business.AuditEventSystemEvent, "refresh_error",
+			business.AuditResultError, business.AuditSeverityHigh,
+			map[string]interface{}{"reason": "pending_store_write_failed"})
+		http.Error(w, "failed to queue refresh request", http.StatusInternalServerError)
+		return
+	}
+
+	s.emitRefreshAudit(r.Context(), deviceID, record.TenantID,
+		business.AuditEventAuthentication, "refresh_queued",
+		business.AuditResultSuccess, business.AuditSeverityMedium,
+		map[string]interface{}{
+			"pending_id": pendingID,
+			"decision":   "queued",
+			"reason":     reason,
+		})
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusAccepted)
+	if err := json.NewEncoder(w).Encode(RefreshCompleteResponse{
+		Status:    "queued",
+		PendingID: pendingID,
+	}); err != nil {
+		s.logger.Error("Failed to encode refresh queued response", "error", err)
+	}
+}
+
+// buildRefreshClaimResponse generates a new mTLS certificate for a steward that has
+// passed the registration-refresh gate. Mirrors the cert issuance in buildClaimResponse.
+func (s *Server) buildRefreshClaimResponse(ctx context.Context, record *business.StewardRecord) (*RefreshCompleteResponse, error) {
+	if s.certManager == nil {
+		return nil, fmt.Errorf("certificate manager not initialized")
+	}
+
+	validityDays := 365
+	if s.cfg.Certificate != nil && s.cfg.Certificate.ClientCertValidityDays > 0 {
+		validityDays = s.cfg.Certificate.ClientCertValidityDays
+	}
+
+	clientCert, err := s.certManager.GenerateClientCertificate(&cert.ClientCertConfig{
+		CommonName:   record.ID,
+		Organization: "CFGMS Stewards",
+		ClientID:     record.ID,
+		ValidityDays: validityDays,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate client certificate: %w", err)
+	}
+
+	caCert, err := s.certManager.GetCACertificate()
+	if err != nil || len(caCert) == 0 {
+		return nil, fmt.Errorf("CA certificate unavailable: %w", err)
+	}
+
+	resp := &RefreshCompleteResponse{
+		Status:     "approved",
+		ClientCert: string(clientCert.CertificatePEM),
+		ClientKey:  string(clientCert.PrivateKeyPEM),
+		CACert:     string(caCert),
+	}
+
+	if signingCertPEM, sigErr := s.certManager.GetSigningCertificate(); sigErr == nil && len(signingCertPEM) > 0 {
+		resp.SigningCert = string(signingCertPEM)
+	}
+
+	// Promote steward back to registered status after cert issuance.
+	if s.controllerService != nil {
+		if err := s.controllerService.UpdateStewardStatus(record.ID, "registered"); err != nil {
+			s.logger.Warn("Failed to update steward status after refresh cert issuance",
+				"steward_id", record.ID, "error", err)
+		}
+	}
+
+	s.logger.Info("Issued refresh certificate",
+		"steward_id", record.ID,
+		"validity_days", validityDays)
+
+	return resp, nil
+}
+
+// emitRefreshAudit records a registration-refresh audit event.
+// It is a no-op when auditManager is nil.
+// Must be called BEFORE WriteHeader on every code path.
+func (s *Server) emitRefreshAudit(
+	ctx context.Context,
+	deviceID, tenantID string,
+	eventType business.AuditEventType,
+	action string,
+	result business.AuditResult,
+	severity business.AuditSeverity,
+	extras map[string]interface{},
+) {
+	if s.auditManager == nil {
+		return
+	}
+	b := audit.NewEventBuilder().
+		Tenant(tenantID).
+		Type(eventType).
+		Action(action).
+		User(deviceID, business.AuditUserTypeSystem).
+		Resource("steward", deviceID, "").
+		Result(result).
+		Severity(severity).
+		Detail("device_id", deviceID).
+		Detail("tenant_id", tenantID)
+	for k, v := range extras {
+		b = b.Detail(k, v)
+	}
+	if err := s.auditManager.RecordEvent(ctx, b); err != nil {
+		s.logger.Warn("Failed to emit refresh audit event", "error", err, "action", action)
+	}
+}

--- a/features/controller/api/handlers_registration_refresh_test.go
+++ b/features/controller/api/handlers_registration_refresh_test.go
@@ -1,0 +1,746 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+package api
+
+import (
+	"bytes"
+	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/binary"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/gorilla/mux"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cfgis/cfgms/features/controller/config"
+	"github.com/cfgis/cfgms/features/controller/service"
+	"github.com/cfgis/cfgms/features/rbac"
+	"github.com/cfgis/cfgms/features/tenant"
+	"github.com/cfgis/cfgms/pkg/audit"
+	"github.com/cfgis/cfgms/pkg/logging"
+	business "github.com/cfgis/cfgms/pkg/storage/interfaces/business"
+	pkgtesting "github.com/cfgis/cfgms/pkg/testing"
+)
+
+// ---- Test-only in-memory stores ---------------------------------------------
+
+// testStewardStore is a thread-safe in-memory StewardStore for handler tests.
+type testStewardStore struct {
+	mu       sync.RWMutex
+	records  map[string]*business.StewardRecord // keyed by steward ID
+	byDevice map[string]*business.StewardRecord // keyed by device ID
+}
+
+func newTestStewardStore() *testStewardStore {
+	return &testStewardStore{
+		records:  make(map[string]*business.StewardRecord),
+		byDevice: make(map[string]*business.StewardRecord),
+	}
+}
+
+func (s *testStewardStore) add(rec *business.StewardRecord) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	cp := *rec
+	s.records[rec.ID] = &cp
+	if rec.DeviceID != "" {
+		s.byDevice[rec.DeviceID] = &cp
+	}
+}
+
+func (s *testStewardStore) RegisterSteward(_ context.Context, r *business.StewardRecord) error {
+	s.add(r)
+	return nil
+}
+func (s *testStewardStore) UpdateHeartbeat(_ context.Context, _ string) error { return nil }
+func (s *testStewardStore) GetSteward(_ context.Context, id string) (*business.StewardRecord, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	r, ok := s.records[id]
+	if !ok {
+		return nil, business.ErrStewardNotFound
+	}
+	cp := *r
+	return &cp, nil
+}
+func (s *testStewardStore) GetStewardByDeviceID(_ context.Context, deviceID string) (*business.StewardRecord, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	r, ok := s.byDevice[deviceID]
+	if !ok {
+		return nil, business.ErrStewardNotFound
+	}
+	cp := *r
+	return &cp, nil
+}
+func (s *testStewardStore) ListStewards(_ context.Context) ([]*business.StewardRecord, error) {
+	return nil, nil
+}
+func (s *testStewardStore) ListStewardsByStatus(_ context.Context, _ business.StewardStatus) ([]*business.StewardRecord, error) {
+	return nil, nil
+}
+func (s *testStewardStore) UpdateStewardStatus(_ context.Context, id string, status business.StewardStatus) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if r, ok := s.records[id]; ok {
+		r.Status = status
+	}
+	return nil
+}
+func (s *testStewardStore) DeregisterSteward(_ context.Context, _ string) error { return nil }
+func (s *testStewardStore) GetStewardsSeen(_ context.Context, _ time.Time) ([]*business.StewardRecord, error) {
+	return nil, nil
+}
+func (s *testStewardStore) HealthCheck(_ context.Context) error { return nil }
+func (s *testStewardStore) Initialize(_ context.Context) error  { return nil }
+func (s *testStewardStore) Close() error                        { return nil }
+
+// testPendingRefreshStore is a thread-safe in-memory PendingRefreshStore.
+type testPendingRefreshStore struct {
+	mu      sync.RWMutex
+	entries map[string]*business.PendingRefreshEntry
+}
+
+func newTestPendingRefreshStore() *testPendingRefreshStore {
+	return &testPendingRefreshStore{entries: make(map[string]*business.PendingRefreshEntry)}
+}
+
+func (s *testPendingRefreshStore) AddPendingRefresh(_ context.Context, e *business.PendingRefreshEntry) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	cp := *e
+	s.entries[e.PendingID] = &cp
+	return nil
+}
+func (s *testPendingRefreshStore) GetPendingRefreshByID(_ context.Context, id string) (*business.PendingRefreshEntry, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	e, ok := s.entries[id]
+	if !ok {
+		return nil, business.ErrPendingRefreshNotFound
+	}
+	cp := *e
+	return &cp, nil
+}
+func (s *testPendingRefreshStore) UpdateRefreshStatus(_ context.Context, id, status string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if e, ok := s.entries[id]; ok {
+		e.Status = status
+	}
+	return nil
+}
+func (s *testPendingRefreshStore) ListPendingRefresh(_ context.Context, _ string) ([]*business.PendingRefreshEntry, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	out := make([]*business.PendingRefreshEntry, 0, len(s.entries))
+	for _, e := range s.entries {
+		cp := *e
+		out = append(out, &cp)
+	}
+	return out, nil
+}
+func (s *testPendingRefreshStore) ExpireStaleRefresh(_ context.Context, _ time.Time) (int, error) {
+	return 0, nil
+}
+func (s *testPendingRefreshStore) StoreClaimBundle(_ context.Context, id string, bundle []byte) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if e, ok := s.entries[id]; ok {
+		e.ClaimBundle = bundle
+	}
+	return nil
+}
+func (s *testPendingRefreshStore) count() int {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return len(s.entries)
+}
+
+// testRefreshPolicyStore is a thread-safe in-memory RefreshPolicyStore.
+type testRefreshPolicyStore struct {
+	mu       sync.RWMutex
+	policies map[string]*business.RefreshPolicy
+}
+
+func newTestRefreshPolicyStore() *testRefreshPolicyStore {
+	return &testRefreshPolicyStore{policies: make(map[string]*business.RefreshPolicy)}
+}
+
+func (s *testRefreshPolicyStore) GetPolicy(_ context.Context, tenantID string) (*business.RefreshPolicy, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if p, ok := s.policies[tenantID]; ok {
+		cp := *p
+		return &cp, nil
+	}
+	// Default per ADR-010 §4.
+	return &business.RefreshPolicy{TenantID: tenantID, Mode: "require_approval"}, nil
+}
+
+func (s *testRefreshPolicyStore) SetPolicy(_ context.Context, p *business.RefreshPolicy) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	cp := *p
+	s.policies[p.TenantID] = &cp
+	return nil
+}
+
+// neverCallPolicyStore panics if GetPolicy is called — used to assert policy is not consulted.
+type neverCallPolicyStore struct{}
+
+func (neverCallPolicyStore) GetPolicy(_ context.Context, _ string) (*business.RefreshPolicy, error) {
+	panic("GetPolicy must not be called for archived stewards")
+}
+func (neverCallPolicyStore) SetPolicy(_ context.Context, _ *business.RefreshPolicy) error {
+	panic("SetPolicy must not be called")
+}
+
+// recordingPoPVerifier counts Verify calls and delegates to an optional func.
+type recordingPoPVerifier struct {
+	mu    sync.Mutex
+	calls int
+	fn    func(pub ed25519.PublicKey, msg, sig []byte) bool
+}
+
+func (v *recordingPoPVerifier) Verify(pub ed25519.PublicKey, msg, sig []byte) bool {
+	v.mu.Lock()
+	v.calls++
+	v.mu.Unlock()
+	if v.fn != nil {
+		return v.fn(pub, msg, sig)
+	}
+	return false
+}
+
+func (v *recordingPoPVerifier) callCount() int {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	return v.calls
+}
+
+// ---- Server factory for refresh handler tests --------------------------------
+
+// newRefreshTestServer builds a minimal Server with real audit + steward infrastructure
+// wired for the registration-refresh handler tests.
+func newRefreshTestServer(
+	t *testing.T,
+	stewardSt *testStewardStore,
+	pendingRefreshSt *testPendingRefreshStore,
+	policyStore business.RefreshPolicyStore,
+) (*Server, *audit.Manager) {
+	t.Helper()
+	t.Setenv("CFGMS_SECRETS_REPO_PATH", t.TempDir())
+
+	cfg := config.DefaultConfig()
+	cfg.Certificate.EnableCertManagement = false
+
+	storageManager := pkgtesting.SetupTestStorage(t)
+	auditMgr, err := audit.NewManager(storageManager.GetAuditStore(), "controller")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = auditMgr.Stop(context.Background()) })
+
+	logger := logging.NewNoopLogger()
+
+	rbacManager := rbac.NewManagerWithStorage(
+		storageManager.GetAuditStore(),
+		storageManager.GetClientTenantStore(),
+		storageManager.GetRBACStore(),
+	)
+	require.NoError(t, rbacManager.Initialize(context.Background()))
+	t.Cleanup(func() {
+		closeCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_ = rbacManager.Close(closeCtx)
+	})
+
+	tenantStore := tenant.NewStorageAdapter(storageManager.GetTenantStore())
+	tenantManager := tenant.NewManager(tenantStore, rbacManager)
+	controllerService := service.NewControllerService(logger)
+	configService := service.NewConfigurationServiceV2(logger, storageManager, controllerService)
+	rbacService := service.NewRBACService(rbacManager)
+
+	server, err := New(
+		cfg, logger,
+		controllerService, configService, nil, rbacService,
+		nil, tenantManager, rbacManager,
+		nil, nil,
+		newTestRegistrationStore(t),
+		"", nil,
+		auditMgr,
+		nil, nil, nil,
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_ = server.Close(ctx)
+	})
+
+	server.SetStewardStore(stewardSt)
+	if pendingRefreshSt != nil {
+		server.SetPendingRefreshStore(pendingRefreshSt)
+	}
+	if policyStore != nil {
+		server.SetRefreshPolicyStore(policyStore)
+	}
+
+	return server, auditMgr
+}
+
+// ---- Helpers ----------------------------------------------------------------
+
+const (
+	testDeviceID = "aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899"
+	testTenantID = "test-tenant"
+)
+
+// newTestEd25519KeyPair generates a fresh Ed25519 key pair for tests.
+func newTestEd25519KeyPair(t *testing.T) (ed25519.PublicKey, ed25519.PrivateKey) {
+	t.Helper()
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	require.NoError(t, err)
+	return pub, priv
+}
+
+// issueChallenge calls handleRefreshChallenge and returns the parsed response.
+func issueChallenge(t *testing.T, server *Server, deviceID, tenantID string) *RefreshChallengeResponse {
+	t.Helper()
+	body, _ := json.Marshal(RefreshChallengeRequest{TenantID: tenantID})
+	r := httptest.NewRequest(http.MethodPost, "/api/v1/stewards/"+deviceID+"/refresh/challenge", bytes.NewReader(body))
+	r = mux.SetURLVars(r, map[string]string{"device_id": deviceID})
+	r.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	server.handleRefreshChallenge(rec, r)
+	require.Equal(t, http.StatusOK, rec.Code, "challenge must succeed: %s", rec.Body.String())
+	var resp RefreshChallengeResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	return &resp
+}
+
+// buildValidCompleteRequest constructs a valid RefreshCompleteRequest with a correct PoP signature.
+func buildValidCompleteRequest(
+	t *testing.T,
+	deviceID, tenantID string,
+	challenge *RefreshChallengeResponse,
+	priv ed25519.PrivateKey,
+	provenance map[string]string,
+) RefreshCompleteRequest {
+	t.Helper()
+	nonceBytes, err := base64.RawURLEncoding.DecodeString(challenge.Nonce)
+	require.NoError(t, err)
+
+	var tsBytes [8]byte
+	binary.BigEndian.PutUint64(tsBytes[:], challenge.ServerTS)
+	h := sha256.New()
+	h.Write(nonceBytes)
+	h.Write([]byte(deviceID))
+	h.Write(tsBytes[:])
+	msg := h.Sum(nil)
+
+	sig := ed25519.Sign(priv, msg)
+	return RefreshCompleteRequest{
+		TenantID:   tenantID,
+		Nonce:      challenge.Nonce,
+		IssuedAt:   int64(challenge.ServerTS),
+		Signature:  base64.RawURLEncoding.EncodeToString(sig),
+		Provenance: provenance,
+	}
+}
+
+// postComplete sends a POST to handleRefreshComplete and returns the recorder.
+func postComplete(server *Server, deviceID string, req RefreshCompleteRequest) *httptest.ResponseRecorder {
+	body, _ := json.Marshal(req)
+	r := httptest.NewRequest(http.MethodPost, "/api/v1/stewards/"+deviceID+"/refresh/complete", bytes.NewReader(body))
+	r = mux.SetURLVars(r, map[string]string{"device_id": deviceID})
+	r.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	server.handleRefreshComplete(rec, r)
+	return rec
+}
+
+// ---- Challenge endpoint tests -----------------------------------------------
+
+func TestHandleRefreshChallenge_UnknownDevice(t *testing.T) {
+	ss := newTestStewardStore()
+	server, _ := newRefreshTestServer(t, ss, nil, nil)
+
+	body, _ := json.Marshal(RefreshChallengeRequest{TenantID: testTenantID})
+	r := httptest.NewRequest(http.MethodPost, "/api/v1/stewards/unknowndevice/refresh/challenge", bytes.NewReader(body))
+	r = mux.SetURLVars(r, map[string]string{"device_id": "unknowndevice"})
+	rec := httptest.NewRecorder()
+	server.handleRefreshChallenge(rec, r)
+
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+}
+
+func TestHandleRefreshChallenge_KnownActiveDevice(t *testing.T) {
+	pub, _ := newTestEd25519KeyPair(t)
+	ss := newTestStewardStore()
+	ss.add(&business.StewardRecord{
+		ID:             "steward-1",
+		DeviceID:       testDeviceID,
+		TenantID:       testTenantID,
+		Status:         business.StewardStatusActive,
+		IdentityKeyPub: []byte(pub),
+	})
+	server, _ := newRefreshTestServer(t, ss, nil, nil)
+
+	resp := issueChallenge(t, server, testDeviceID, testTenantID)
+	assert.NotEmpty(t, resp.Nonce)
+	assert.NotZero(t, resp.ServerTS)
+	// Nonce must decode to 32 bytes.
+	raw, err := base64.RawURLEncoding.DecodeString(resp.Nonce)
+	require.NoError(t, err)
+	assert.Len(t, raw, 32)
+}
+
+func TestHandleRefreshChallenge_RevokedDeviceReturns403(t *testing.T) {
+	pub, _ := newTestEd25519KeyPair(t)
+	ss := newTestStewardStore()
+	ss.add(&business.StewardRecord{
+		ID:             "steward-rev",
+		DeviceID:       testDeviceID,
+		TenantID:       testTenantID,
+		Status:         business.StewardStatusRevoked,
+		IdentityKeyPub: []byte(pub),
+	})
+	server, _ := newRefreshTestServer(t, ss, nil, nil)
+
+	body, _ := json.Marshal(RefreshChallengeRequest{TenantID: testTenantID})
+	r := httptest.NewRequest(http.MethodPost, "/api/v1/stewards/"+testDeviceID+"/refresh/challenge", bytes.NewReader(body))
+	r = mux.SetURLVars(r, map[string]string{"device_id": testDeviceID})
+	rec := httptest.NewRecorder()
+	server.handleRefreshChallenge(rec, r)
+
+	assert.Equal(t, http.StatusForbidden, rec.Code)
+	// Verify no nonce was placed in cache.
+	_, found := server.nonceCache.Get(nonceCacheKeyPrefix + testDeviceID)
+	assert.False(t, found, "no nonce must be stored for revoked device")
+}
+
+// ---- Complete endpoint tests ------------------------------------------------
+
+func TestHandleRefreshComplete_RevokedBeforePoP(t *testing.T) {
+	pub, _ := newTestEd25519KeyPair(t)
+	ss := newTestStewardStore()
+	ss.add(&business.StewardRecord{
+		ID:             "steward-rev",
+		DeviceID:       testDeviceID,
+		TenantID:       testTenantID,
+		Status:         business.StewardStatusRevoked,
+		IdentityKeyPub: []byte(pub),
+	})
+
+	prs := newTestPendingRefreshStore()
+	server, _ := newRefreshTestServer(t, ss, prs, newTestRefreshPolicyStore())
+
+	verifier := &recordingPoPVerifier{}
+	server.SetPoPVerifier(verifier)
+
+	// Manually plant a nonce to rule out the "no nonce" 401 path.
+	server.nonceCache.Set(nonceCacheKeyPrefix+testDeviceID, &nonceEntry{ //nolint:errcheck // in-memory cache; Set only fails on empty key, which is impossible here
+		NonceBytes: make([]byte, 32),
+		ServerTS:   uint64(time.Now().UnixNano()),
+		IssuedAt:   time.Now(),
+	}, nonceTTL)
+
+	rec := postComplete(server, testDeviceID, RefreshCompleteRequest{
+		TenantID:  testTenantID,
+		Nonce:     base64.RawURLEncoding.EncodeToString(make([]byte, 32)),
+		IssuedAt:  time.Now().UnixNano(),
+		Signature: base64.RawURLEncoding.EncodeToString(make([]byte, 64)),
+	})
+
+	assert.Equal(t, http.StatusForbidden, rec.Code)
+	assert.Equal(t, 0, verifier.callCount(), "PoPVerifier must not be called for revoked device")
+}
+
+func TestHandleRefreshComplete_NonceReplay(t *testing.T) {
+	pub, priv := newTestEd25519KeyPair(t)
+	ss := newTestStewardStore()
+	ss.add(&business.StewardRecord{
+		ID:             "steward-active",
+		DeviceID:       testDeviceID,
+		TenantID:       testTenantID,
+		Status:         business.StewardStatusActive,
+		IdentityKeyPub: []byte(pub),
+	})
+
+	prs := newTestPendingRefreshStore()
+	ps := newTestRefreshPolicyStore()
+	server, _ := newRefreshTestServer(t, ss, prs, ps)
+	// Use real ed25519.Verify so the first request can succeed (queued for require_approval).
+	server.SetPoPVerifier(ed25519PoPVerifier{})
+
+	challenge := issueChallenge(t, server, testDeviceID, testTenantID)
+	req := buildValidCompleteRequest(t, testDeviceID, testTenantID, challenge, priv, nil)
+
+	// First attempt: nonce consumed, status 202 (require_approval default).
+	rec1 := postComplete(server, testDeviceID, req)
+	assert.Equal(t, http.StatusAccepted, rec1.Code, "first complete must succeed: %s", rec1.Body.String())
+
+	// Second attempt with same nonce: nonce was consumed, must get 401.
+	rec2 := postComplete(server, testDeviceID, req)
+	assert.Equal(t, http.StatusUnauthorized, rec2.Code, "nonce replay must be rejected")
+}
+
+func TestHandleRefreshComplete_ExpiredNonce(t *testing.T) {
+	pub, priv := newTestEd25519KeyPair(t)
+	ss := newTestStewardStore()
+	ss.add(&business.StewardRecord{
+		ID:             "steward-active",
+		DeviceID:       testDeviceID,
+		TenantID:       testTenantID,
+		Status:         business.StewardStatusActive,
+		IdentityKeyPub: []byte(pub),
+	})
+
+	prs := newTestPendingRefreshStore()
+	server, _ := newRefreshTestServer(t, ss, prs, newTestRefreshPolicyStore())
+	server.SetPoPVerifier(ed25519PoPVerifier{})
+
+	challenge := issueChallenge(t, server, testDeviceID, testTenantID)
+	req := buildValidCompleteRequest(t, testDeviceID, testTenantID, challenge, priv, nil)
+	// Override IssuedAt to simulate a 61-second-old nonce.
+	req.IssuedAt = time.Now().Add(-61 * time.Second).UnixNano()
+
+	rec := postComplete(server, testDeviceID, req)
+	assert.Equal(t, http.StatusUnauthorized, rec.Code)
+	assert.Contains(t, rec.Body.String(), "expired")
+}
+
+func TestHandleRefreshComplete_InvalidPoP(t *testing.T) {
+	pub, _ := newTestEd25519KeyPair(t)
+	_, wrongPriv := newTestEd25519KeyPair(t) // different key pair
+	ss := newTestStewardStore()
+	ss.add(&business.StewardRecord{
+		ID:             "steward-active",
+		DeviceID:       testDeviceID,
+		TenantID:       testTenantID,
+		Status:         business.StewardStatusActive,
+		IdentityKeyPub: []byte(pub),
+	})
+
+	prs := newTestPendingRefreshStore()
+	server, _ := newRefreshTestServer(t, ss, prs, newTestRefreshPolicyStore())
+	server.SetPoPVerifier(ed25519PoPVerifier{})
+
+	challenge := issueChallenge(t, server, testDeviceID, testTenantID)
+	// Sign with a DIFFERENT private key — PoP must fail.
+	req := buildValidCompleteRequest(t, testDeviceID, testTenantID, challenge, wrongPriv, nil)
+
+	rec := postComplete(server, testDeviceID, req)
+	assert.Equal(t, http.StatusUnauthorized, rec.Code)
+}
+
+func TestHandleRefreshComplete_Lifecycle_Archived(t *testing.T) {
+	pub, priv := newTestEd25519KeyPair(t)
+	ss := newTestStewardStore()
+	ss.add(&business.StewardRecord{
+		ID:             "steward-archived",
+		DeviceID:       testDeviceID,
+		TenantID:       testTenantID,
+		Status:         business.StewardStatusArchived,
+		IdentityKeyPub: []byte(pub),
+	})
+
+	prs := newTestPendingRefreshStore()
+	server, _ := newRefreshTestServer(t, ss, prs, neverCallPolicyStore{})
+	server.SetPoPVerifier(ed25519PoPVerifier{})
+
+	challenge := issueChallenge(t, server, testDeviceID, testTenantID)
+	req := buildValidCompleteRequest(t, testDeviceID, testTenantID, challenge, priv, nil)
+
+	rec := postComplete(server, testDeviceID, req)
+	assert.Equal(t, http.StatusAccepted, rec.Code, "archived steward must be queued: %s", rec.Body.String())
+
+	// Verify pending entry was created.
+	assert.Equal(t, 1, prs.count(), "one pending refresh entry must be created")
+
+	// Verify response body.
+	var resp RefreshCompleteResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Equal(t, "queued", resp.Status)
+	assert.NotEmpty(t, resp.PendingID)
+}
+
+func TestHandleRefreshComplete_CrossTenantReturns403(t *testing.T) {
+	pub, _ := newTestEd25519KeyPair(t)
+	ss := newTestStewardStore()
+	ss.add(&business.StewardRecord{
+		ID:             "steward-a",
+		DeviceID:       testDeviceID,
+		TenantID:       "tenant-a",
+		Status:         business.StewardStatusActive,
+		IdentityKeyPub: []byte(pub),
+	})
+
+	prs := newTestPendingRefreshStore()
+	server, _ := newRefreshTestServer(t, ss, prs, newTestRefreshPolicyStore())
+	server.SetPoPVerifier(ed25519PoPVerifier{})
+
+	// Manually plant a nonce so we reach the cross-tenant gate.
+	server.nonceCache.Set(nonceCacheKeyPrefix+testDeviceID, &nonceEntry{ //nolint:errcheck // in-memory cache; Set only fails on empty key, which is impossible here
+		NonceBytes: make([]byte, 32),
+		ServerTS:   uint64(time.Now().UnixNano()),
+		IssuedAt:   time.Now(),
+	}, nonceTTL)
+
+	// Request from "tenant-b" for a steward that belongs to "tenant-a".
+	rec := postComplete(server, testDeviceID, RefreshCompleteRequest{
+		TenantID:  "tenant-b",
+		Nonce:     base64.RawURLEncoding.EncodeToString(make([]byte, 32)),
+		IssuedAt:  time.Now().UnixNano(),
+		Signature: base64.RawURLEncoding.EncodeToString(make([]byte, 64)),
+	})
+	// Must be 403, not 404, so the steward's existence is acknowledged but access denied.
+	assert.Equal(t, http.StatusForbidden, rec.Code)
+}
+
+func TestHandleRefreshComplete_AuditEmittedOnAllOutcomes(t *testing.T) {
+	pub, priv := newTestEd25519KeyPair(t)
+
+	outcomes := []struct {
+		name     string
+		setup    func(t *testing.T, ss *testStewardStore, server *Server) RefreshCompleteRequest
+		wantCode int
+		wantAct  string
+	}{
+		{
+			name: "revoked device",
+			setup: func(t *testing.T, ss *testStewardStore, server *Server) RefreshCompleteRequest {
+				ss.add(&business.StewardRecord{
+					ID:             "s-rev",
+					DeviceID:       testDeviceID,
+					TenantID:       testTenantID,
+					Status:         business.StewardStatusRevoked,
+					IdentityKeyPub: []byte(pub),
+				})
+				return RefreshCompleteRequest{
+					TenantID:  testTenantID,
+					Nonce:     base64.RawURLEncoding.EncodeToString(make([]byte, 32)),
+					IssuedAt:  time.Now().UnixNano(),
+					Signature: base64.RawURLEncoding.EncodeToString(make([]byte, 64)),
+				}
+			},
+			wantCode: http.StatusForbidden,
+			wantAct:  "refresh_rejected",
+		},
+		{
+			name: "valid PoP — queued",
+			setup: func(t *testing.T, ss *testStewardStore, server *Server) RefreshCompleteRequest {
+				ss.add(&business.StewardRecord{
+					ID:             "s-active",
+					DeviceID:       testDeviceID,
+					TenantID:       testTenantID,
+					Status:         business.StewardStatusActive,
+					IdentityKeyPub: []byte(pub),
+				})
+				server.SetPoPVerifier(ed25519PoPVerifier{})
+				ch := issueChallenge(t, server, testDeviceID, testTenantID)
+				return buildValidCompleteRequest(t, testDeviceID, testTenantID, ch, priv, nil)
+			},
+			wantCode: http.StatusAccepted,
+			wantAct:  "refresh_queued",
+		},
+	}
+
+	for _, tc := range outcomes {
+		t.Run(tc.name, func(t *testing.T) {
+			ss := newTestStewardStore()
+			prs := newTestPendingRefreshStore()
+			server, auditMgr := newRefreshTestServer(t, ss, prs, newTestRefreshPolicyStore())
+
+			req := tc.setup(t, ss, server)
+			rec := postComplete(server, testDeviceID, req)
+			assert.Equal(t, tc.wantCode, rec.Code)
+
+			require.NoError(t, auditMgr.Flush(context.Background()))
+			entries, err := auditMgr.QueryEntries(context.Background(), &business.AuditFilter{})
+			require.NoError(t, err)
+			require.GreaterOrEqual(t, len(entries), 1, "at least one audit event expected")
+
+			found := false
+			for _, e := range entries {
+				if e.Action == tc.wantAct {
+					assert.NotEmpty(t, e.Details["device_id"], "device_id in audit")
+					assert.NotEmpty(t, e.Details["tenant_id"], "tenant_id in audit")
+					found = true
+					break
+				}
+			}
+			assert.True(t, found, "expected audit action %q not found in %v", tc.wantAct, entries)
+		})
+	}
+}
+
+func TestProvenance_CannotUngateRevoked(t *testing.T) {
+	pub, _ := newTestEd25519KeyPair(t)
+	ss := newTestStewardStore()
+	ss.add(&business.StewardRecord{
+		ID:             "s-rev",
+		DeviceID:       testDeviceID,
+		TenantID:       testTenantID,
+		Status:         business.StewardStatusRevoked,
+		IdentityKeyPub: []byte(pub),
+		// Perfect provenance — revocation must still win.
+		LastProvenanceJSON: `{"hostname":"host1","mac_address":"aa:bb"}`,
+	})
+
+	prs := newTestPendingRefreshStore()
+	server, _ := newRefreshTestServer(t, ss, prs, newTestRefreshPolicyStore())
+	verifier := &recordingPoPVerifier{}
+	server.SetPoPVerifier(verifier)
+
+	// Plant a nonce so we reach the revocation gate.
+	server.nonceCache.Set(nonceCacheKeyPrefix+testDeviceID, &nonceEntry{ //nolint:errcheck // in-memory cache; Set only fails on empty key, which is impossible here
+		NonceBytes: make([]byte, 32),
+		ServerTS:   uint64(time.Now().UnixNano()),
+		IssuedAt:   time.Now(),
+	}, nonceTTL)
+
+	rec := postComplete(server, testDeviceID, RefreshCompleteRequest{
+		TenantID:   testTenantID,
+		Nonce:      base64.RawURLEncoding.EncodeToString(make([]byte, 32)),
+		IssuedAt:   time.Now().UnixNano(),
+		Signature:  base64.RawURLEncoding.EncodeToString(make([]byte, 64)),
+		Provenance: map[string]string{"hostname": "host1", "mac_address": "aa:bb"},
+	})
+
+	assert.Equal(t, http.StatusForbidden, rec.Code)
+	assert.Equal(t, 0, verifier.callCount(), "PoP must not be called for revoked device")
+}
+
+func TestRefresh_NoPolicyDefault(t *testing.T) {
+	pub, priv := newTestEd25519KeyPair(t)
+	ss := newTestStewardStore()
+	ss.add(&business.StewardRecord{
+		ID:             "s-active",
+		DeviceID:       testDeviceID,
+		TenantID:       testTenantID,
+		Status:         business.StewardStatusActive,
+		IdentityKeyPub: []byte(pub),
+	})
+
+	prs := newTestPendingRefreshStore()
+	// Policy store returns default (require_approval) — no policy set for this tenant.
+	server, _ := newRefreshTestServer(t, ss, prs, newTestRefreshPolicyStore())
+	server.SetPoPVerifier(ed25519PoPVerifier{})
+
+	challenge := issueChallenge(t, server, testDeviceID, testTenantID)
+	req := buildValidCompleteRequest(t, testDeviceID, testTenantID, challenge, priv, nil)
+
+	rec := postComplete(server, testDeviceID, req)
+	assert.Equal(t, http.StatusAccepted, rec.Code, "default policy must queue: %s", rec.Body.String())
+	assert.Equal(t, 1, prs.count(), "one pending entry must be created")
+}

--- a/features/controller/api/permissions.go
+++ b/features/controller/api/permissions.go
@@ -82,6 +82,11 @@ var knownPermissions = map[string]bool{
 	// Steward upgrade dispatch and approval (Issue #1945)
 	"installer:dispatch:steward": true,
 	"installer:approve:steward":  true,
+	// Registration-refresh management (Issue #2096)
+	"registration:list-refresh":          true,
+	"registration:approve-refresh":       true,
+	"registration:deny-refresh":          true,
+	"registration:manage-refresh-policy": true,
 }
 
 // isKnownPermission reports whether p is a recognized permission ID.

--- a/features/controller/api/server.go
+++ b/features/controller/api/server.go
@@ -34,6 +34,7 @@ import (
 	reportapi "github.com/cfgis/cfgms/features/reports/api"
 	"github.com/cfgis/cfgms/features/tenant"
 	"github.com/cfgis/cfgms/pkg/audit"
+	"github.com/cfgis/cfgms/pkg/cache"
 	"github.com/cfgis/cfgms/pkg/cert"
 	"github.com/cfgis/cfgms/pkg/ctxkeys"
 	"github.com/cfgis/cfgms/pkg/ha"
@@ -104,6 +105,11 @@ type Server struct {
 	stewardBinaryTrustStore        trust.TrustStore                  // Issue #1944: overridable trust store for steward binary signature verification (injected in tests)
 	testAutoApproveStewardBinaries bool                              // Issue #1948: when true, publish sets approved_by automatically (test-only, CFGMS_SEED_TEST_API_KEYS gate)
 	upgradeStore                   business.UpgradeStore             // Issue #1945: durable per-steward upgrade state; nil means dispatch is refused with 503
+	stewardStore                   business.StewardStore             // Issue #2096: durable fleet-registry store for device-ID refresh gate
+	pendingRefreshStore            business.PendingRefreshStore      // Issue #2096: durable pending-refresh queue
+	refreshPolicyStore             business.RefreshPolicyStore       // Issue #2096: per-tenant refresh policy
+	nonceCache                     *cache.Cache                      // Issue #2096: in-memory nonce store (TTL 65s)
+	popVerifier                    PoPVerifier                       // Issue #2096: injectable for revoked-before-PoP testing
 	stopCleanup                    chan struct{}                     // signals startAPIKeyCleanup to exit
 	cleanupDone                    chan struct{}                     // closed when cleanup goroutine exits
 	closeOnce                      sync.Once                         // idempotent Close
@@ -202,6 +208,8 @@ func New(
 		commandPublisher:        commandPublisher,         // Issue #1319: fan-out config push to active stewards
 		pushStore:               pushStore,                // Issue #1320: durable push-state persistence for HA failover
 		blobStore:               blobStore,                // Issue #1702: installer artifact storage
+		nonceCache:              newNonceCache(),          // Issue #2096: nonce store for registration-refresh
+		popVerifier:             ed25519PoPVerifier{},     // Issue #2096: default PoP verifier; override in tests
 		stopCleanup:             make(chan struct{}),
 		cleanupDone:             make(chan struct{}),
 	}
@@ -389,6 +397,11 @@ func (s *Server) setupRouter() {
 	// Use separate path to avoid conflict with authenticated subrouter
 	// TODO: Remove or protect this endpoint in production
 	s.router.HandleFunc("/api/v1/test/stewards/{id}/config", s.handleUpdateStewardConfig).Methods("PUT", "OPTIONS")
+
+	// Registration-refresh endpoints (unauthenticated — authenticated by device key PoP).
+	// Registered on the base router like /api/v1/register (Issue #2096).
+	s.router.HandleFunc("/api/v1/stewards/{device_id}/refresh/challenge", s.handleRefreshChallenge).Methods("POST", "OPTIONS")
+	s.router.HandleFunc("/api/v1/stewards/{device_id}/refresh/complete", s.handleRefreshComplete).Methods("POST", "OPTIONS")
 
 	// Steward management endpoints (require API key authentication)
 	stewards := api.PathPrefix("/stewards").Subrouter()
@@ -708,6 +721,11 @@ func (s *Server) Close(ctx context.Context) error {
 			}
 		}
 
+		// Close nonce cache to stop its background cleanup goroutine (Issue #2096).
+		if s.nonceCache != nil {
+			s.nonceCache.Close()
+		}
+
 		s.mu.Lock()
 		defer s.mu.Unlock()
 
@@ -892,6 +910,39 @@ func (s *Server) SetUpgradeStore(store business.UpgradeStore) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.upgradeStore = store
+}
+
+// SetStewardStore wires the durable StewardStore used by the registration-refresh
+// endpoints (Issue #2096). When nil, the refresh endpoints return 503.
+func (s *Server) SetStewardStore(store business.StewardStore) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.stewardStore = store
+}
+
+// SetPendingRefreshStore wires the durable PendingRefreshStore for the
+// registration-refresh approval queue (Issue #2096).
+func (s *Server) SetPendingRefreshStore(store business.PendingRefreshStore) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.pendingRefreshStore = store
+}
+
+// SetRefreshPolicyStore wires the per-tenant RefreshPolicyStore (Issue #2096).
+func (s *Server) SetRefreshPolicyStore(store business.RefreshPolicyStore) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.refreshPolicyStore = store
+}
+
+// SetPoPVerifier replaces the proof-of-possession verifier.
+// Used in tests to assert the verifier is never called for revoked devices.
+func (s *Server) SetPoPVerifier(v PoPVerifier) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if v != nil {
+		s.popVerifier = v
+	}
 }
 
 // SetSigningRotationService wires the signing rotation service for the
@@ -1300,4 +1351,15 @@ func (s *Server) loadAPIKeysFromStore() error {
 
 	s.logger.Info("Secret store ready - API keys will be loaded on first access")
 	return nil
+}
+
+// newNonceCache creates the short-lived nonce cache for registration-refresh (Issue #2096).
+// Entries have a 65-second TTL; the 60-second enforcement window is applied in the handler.
+func newNonceCache() *cache.Cache {
+	return cache.NewCache(cache.CacheConfig{
+		MaxRuntimeItems: 10000,
+		DefaultTTL:      nonceTTL,
+		CleanupInterval: 30 * time.Second,
+		EvictionPolicy:  cache.EvictionLRU,
+	})
 }

--- a/features/controller/registration/provenance.go
+++ b/features/controller/registration/provenance.go
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+// Package registration provides provenance matching for the registration-refresh flow (ADR-010).
+package registration
+
+import "encoding/json"
+
+// DNAFieldKeys are volatile device-state fields excluded from provenance scoring.
+// These change on every boot or OS update and carry no re-entry identity signal.
+var DNAFieldKeys = map[string]bool{
+	"os_version":        true,
+	"kernel_version":    true,
+	"uptime_seconds":    true,
+	"load_avg":          true,
+	"memory_free":       true,
+	"disk_free":         true,
+	"running_processes": true,
+}
+
+// ProvenanceMatchThreshold is the minimum score (0.0–1.0) for auto-accept.
+// Scores below this threshold demote auto_accept → require_approval (demote-only).
+const ProvenanceMatchThreshold = 0.60
+
+// ProvenanceResult holds the outcome of a FuzzyMatch comparison.
+type ProvenanceResult struct {
+	Score         float64 // 0.0–1.0; 1.0 means every comparable field matched
+	MatchedFields int
+	TotalFields   int
+}
+
+// ProvenanceMatcher compares stored and incoming device-identity provenance signals.
+// It is stateless; the zero value is ready for use.
+type ProvenanceMatcher struct{}
+
+// FuzzyMatch compares a stored provenance JSON string against an incoming signal map.
+// DNA fields (see DNAFieldKeys) are excluded from scoring. Scoring is based only on
+// fields present in the stored snapshot — extra incoming fields are ignored.
+// Returns a zero ProvenanceResult when storedJSON is empty, unparseable, or contains
+// no non-DNA fields.
+func (ProvenanceMatcher) FuzzyMatch(storedJSON string, incoming map[string]string) ProvenanceResult {
+	if storedJSON == "" {
+		return ProvenanceResult{}
+	}
+	var stored map[string]string
+	if err := json.Unmarshal([]byte(storedJSON), &stored); err != nil {
+		return ProvenanceResult{}
+	}
+
+	matched := 0
+	total := 0
+	for k, sv := range stored {
+		if DNAFieldKeys[k] {
+			continue
+		}
+		total++
+		if iv, ok := incoming[k]; ok && iv == sv {
+			matched++
+		}
+	}
+
+	if total == 0 {
+		return ProvenanceResult{}
+	}
+	return ProvenanceResult{
+		Score:         float64(matched) / float64(total),
+		MatchedFields: matched,
+		TotalFields:   total,
+	}
+}

--- a/features/controller/registration/provenance_test.go
+++ b/features/controller/registration/provenance_test.go
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+package registration
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestProvenanceMatcher_FuzzyMatch(t *testing.T) {
+	tests := []struct {
+		name        string
+		storedJSON  string
+		incoming    map[string]string
+		wantScore   float64
+		wantMatched int
+		wantTotal   int
+	}{
+		{
+			name:       "empty stored JSON returns zero result",
+			storedJSON: "",
+			incoming:   map[string]string{"hostname": "host1"},
+			wantScore:  0, wantMatched: 0, wantTotal: 0,
+		},
+		{
+			name:       "invalid stored JSON returns zero result",
+			storedJSON: "not-json",
+			incoming:   map[string]string{"hostname": "host1"},
+			wantScore:  0, wantMatched: 0, wantTotal: 0,
+		},
+		{
+			name:       "all three stable fields match",
+			storedJSON: `{"hostname":"host1","mac_address":"aa:bb:cc:dd:ee:ff","bios_uuid":"uuid-1"}`,
+			incoming:   map[string]string{"hostname": "host1", "mac_address": "aa:bb:cc:dd:ee:ff", "bios_uuid": "uuid-1"},
+			wantScore:  1.0, wantMatched: 3, wantTotal: 3,
+		},
+		{
+			name:       "no fields match",
+			storedJSON: `{"hostname":"host1","mac_address":"aa:bb:cc:dd:ee:ff"}`,
+			incoming:   map[string]string{"hostname": "other", "mac_address": "11:22:33:44:55:66"},
+			wantScore:  0.0, wantMatched: 0, wantTotal: 2,
+		},
+		{
+			name:       "60% boundary — 3 of 5 fields match",
+			storedJSON: `{"hostname":"h1","mac_address":"aa","bios_uuid":"u1","cpu_serial":"c1","machine_id":"m1"}`,
+			incoming: map[string]string{
+				"hostname":    "h1",
+				"mac_address": "aa",
+				"bios_uuid":   "u1",
+				"cpu_serial":  "DIFFERENT",
+				"machine_id":  "DIFFERENT",
+			},
+			wantScore: 0.6, wantMatched: 3, wantTotal: 5,
+		},
+		{
+			name:       "DNA fields excluded from scoring",
+			storedJSON: `{"hostname":"host1","os_version":"5.15","kernel_version":"5.15.0"}`,
+			incoming:   map[string]string{"hostname": "host1", "os_version": "CHANGED", "kernel_version": "CHANGED"},
+			wantScore:  1.0, wantMatched: 1, wantTotal: 1,
+		},
+		{
+			name:       "stored has only DNA fields — zero result",
+			storedJSON: `{"os_version":"5.15","kernel_version":"5.15.0"}`,
+			incoming:   map[string]string{"os_version": "5.15"},
+			wantScore:  0, wantMatched: 0, wantTotal: 0,
+		},
+		{
+			name:       "extra incoming fields ignored",
+			storedJSON: `{"hostname":"host1"}`,
+			incoming:   map[string]string{"hostname": "host1", "extra_field": "value"},
+			wantScore:  1.0, wantMatched: 1, wantTotal: 1,
+		},
+		{
+			name:       "stored field absent in incoming counts as mismatch",
+			storedJSON: `{"hostname":"host1","mac_address":"aa:bb"}`,
+			incoming:   map[string]string{"hostname": "host1"},
+			wantScore:  0.5, wantMatched: 1, wantTotal: 2,
+		},
+		{
+			name:       "empty incoming map — all stored fields are unmatched",
+			storedJSON: `{"hostname":"host1","mac_address":"aa:bb"}`,
+			incoming:   map[string]string{},
+			wantScore:  0.0, wantMatched: 0, wantTotal: 2,
+		},
+	}
+
+	pm := ProvenanceMatcher{}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result := pm.FuzzyMatch(tc.storedJSON, tc.incoming)
+			assert.InDelta(t, tc.wantScore, result.Score, 0.001, "score")
+			assert.Equal(t, tc.wantMatched, result.MatchedFields, "matched fields")
+			assert.Equal(t, tc.wantTotal, result.TotalFields, "total fields")
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Add `POST /api/v1/stewards/{device_id}/refresh/challenge` (unauthenticated, PoP nonce issuance with 65s TTL cache entry)
- Add `POST /api/v1/stewards/{device_id}/refresh/complete` (unauthenticated, ordered gate: lookup→revoked→nonce→IssuedAt→consume→PoP→lifecycle)
- Add `ProvenanceMatcher.FuzzyMatch` in `features/controller/registration` — scores stable hardware fields vs incoming map, excludes DNA keys, drives auto_accept demote path at 60% threshold
- Add server struct fields and setter methods; mount unauthenticated routes in `setupRouter`
- Add four `registration:*-refresh` entries to `knownPermissions`

## Gate ordering (ADR-011 §3)

1. Device lookup → 404
2. Revoked → 403 **before any PoP verification** (revocation-before-PoP invariant)
3. Nonce absent/expired → 401
4. IssuedAt > 60s → 401
5. Consume nonce (cache delete, single-use)
6. PoP signature verify → 401
7. Lifecycle: archived → queue+202; active/registered/dormant → policy gate

## Test coverage

- `TestHandleRefreshChallenge_UnknownDevice`, `_KnownActiveDevice`, `_RevokedDeviceReturns403`
- `TestHandleRefreshComplete_RevokedBeforePoP` — asserts `popVerifier.callCount() == 0`
- `TestHandleRefreshComplete_NonceReplay`, `_ExpiredNonce`, `_InvalidPoP`
- `TestHandleRefreshComplete_Lifecycle_Archived`, `_CrossTenantReturns403`, `_AuditEmittedOnAllOutcomes`
- `TestProvenance_CannotUngateRevoked`, `TestRefresh_NoPolicyDefault`
- `TestProvenanceMatcher_FuzzyMatch` — 10 cases including 60% boundary, DNA exclusion, empty/invalid JSON

## Validation

- `make test-agent-complete` — PASS
- `make check-architecture` — PASS
- `make security-scan` — PASS (no new HIGH/CRITICAL)
- Cross-platform build (linux/amd64, linux/arm64, darwin/amd64, darwin/arm64, windows/amd64) — all PASS

Fixes #2096