### PR TITLE
controller: refuse startup when 0.0.0.0 bind has no external address (Issue #1901)

### DIFF
--- a/docs/deployment/controller.cfg
+++ b/docs/deployment/controller.cfg
@@ -63,6 +63,14 @@ logging:
 transport:
   # CHANGE: Port for steward connections (UDP). Default is 4433.
   listen_addr: "0.0.0.0:4433"
+
+  # REQUIRED when listen_addr binds 0.0.0.0: the hostname or IP that stewards
+  # use to reach this controller. Must be reachable from all managed endpoints.
+  # Example: "controller.example.com" or "203.0.113.10"
+  # Alternative: set CFGMS_EXTERNAL_HOSTNAME env var (accepted for backwards
+  # compatibility, but transport.external_address in this file takes precedence).
+  external_address: "CHANGE-TO-YOUR-CONTROLLER-HOSTNAME-OR-IP"
+
   use_cert_manager: true
   max_connections: 50000
   keepalive_period: "30s"

--- a/features/controller/api/handlers_registration.go
+++ b/features/controller/api/handlers_registration.go
@@ -313,13 +313,18 @@ func (s *Server) buildClaimResponse(ctx context.Context, entry *business.Pending
 		}
 	}
 
+	transportAddr, err := s.getTransportAddress()
+	if err != nil {
+		return nil, fmt.Errorf("transport address unavailable: %w", err)
+	}
+
 	resp := &RegistrationStatusResponse{
 		Status:           business.PendingRegistrationStatusClaimed,
 		StewardID:        entry.StewardID,
 		TenantID:         entry.TenantID,
 		Group:            tok.Group,
 		ControllerURL:    tok.ControllerURL,
-		TransportAddress: s.getTransportAddress(),
+		TransportAddress: transportAddr,
 		ClientCert:       string(clientCert.CertificatePEM),
 		ClientKey:        string(clientCert.PrivateKeyPEM),
 		CACert:           string(caCert),
@@ -553,7 +558,14 @@ func (s *Server) handleRegister(w http.ResponseWriter, r *http.Request) {
 					"tenant_id", token.TenantID,
 					"pending_id", pendingID)
 
-				if err := s.controllerService.RegisterSteward(stewardID, token.TenantID, s.getTransportAddress(), "quarantined"); err != nil {
+				quarantineTransportAddr, taErr := s.getTransportAddress()
+				if taErr != nil {
+					s.logger.Error("Transport address not configured; steward cannot reconnect after approval",
+						"steward_id", stewardID, "error", taErr)
+					http.Error(w, "Server misconfiguration: transport address not configured", http.StatusInternalServerError)
+					return
+				}
+				if err := s.controllerService.RegisterSteward(stewardID, token.TenantID, quarantineTransportAddr, "quarantined"); err != nil {
 					s.logger.Error("Failed to register quarantined steward in controller service",
 						"steward_id", stewardID, "error", err)
 				}
@@ -606,12 +618,19 @@ func (s *Server) handleRegister(w http.ResponseWriter, r *http.Request) {
 		"group", token.Group)
 
 	// Build response with connection details
+	approveTransportAddr, taErr := s.getTransportAddress()
+	if taErr != nil {
+		s.logger.Error("Transport address not configured; steward cannot connect after registration",
+			"steward_id", stewardID, "error", taErr)
+		http.Error(w, "Server misconfiguration: transport address not configured", http.StatusInternalServerError)
+		return
+	}
 	resp := RegistrationResponse{
 		StewardID:        stewardID,
 		TenantID:         token.TenantID,
 		Group:            token.Group,
 		ControllerURL:    token.ControllerURL,
-		TransportAddress: s.getTransportAddress(),
+		TransportAddress: approveTransportAddr,
 	}
 
 	// Story #294 Phase 3: Generate client certificates for mTLS (REQUIRED)
@@ -712,25 +731,37 @@ func (s *Server) handleRegister(w http.ResponseWriter, r *http.Request) {
 }
 
 // getTransportAddress returns the unified transport address for steward connections.
-func (s *Server) getTransportAddress() string {
-	addr := "localhost:4433" // Default transport address
+// Returns an error if ListenAddr binds 0.0.0.0 and neither transport.external_address
+// nor CFGMS_EXTERNAL_HOSTNAME is configured.
+func (s *Server) getTransportAddress() (string, error) {
+	addr := "localhost:4433"
 	if s.cfg.Transport != nil && s.cfg.Transport.ListenAddr != "" {
 		addr = s.cfg.Transport.ListenAddr
 	}
-	return replaceBindAddress(addr)
+
+	// Resolve the external address: config file takes precedence over env var.
+	externalAddress := ""
+	if s.cfg.Transport != nil {
+		externalAddress = s.cfg.Transport.ExternalAddress
+	}
+	if externalAddress == "" {
+		externalAddress = os.Getenv("CFGMS_EXTERNAL_HOSTNAME")
+	}
+
+	return replaceBindAddress(addr, externalAddress)
 }
 
-// replaceBindAddress replaces 0.0.0.0 bind addresses with external hostname
-func replaceBindAddress(addr string) string {
+// replaceBindAddress substitutes the 0.0.0.0 wildcard with the resolved external address.
+// Returns an error when addr starts with "0.0.0.0:" and externalAddress is empty.
+func replaceBindAddress(addr, externalAddress string) (string, error) {
 	if !strings.HasPrefix(addr, "0.0.0.0:") {
-		return addr
+		return addr, nil
 	}
-	externalHostname := os.Getenv("CFGMS_EXTERNAL_HOSTNAME")
-	if externalHostname == "" {
-		externalHostname = "localhost"
+	if externalAddress == "" {
+		return "", fmt.Errorf("transport.listen_addr binds 0.0.0.0 but no external address is configured; set transport.external_address in controller.cfg or CFGMS_EXTERNAL_HOSTNAME env var")
 	}
 	port := strings.TrimPrefix(addr, "0.0.0.0:")
-	return externalHostname + ":" + port
+	return externalAddress + ":" + port, nil
 }
 
 // extractSourceIP returns the source IP from the HTTP request.

--- a/features/controller/api/handlers_registration_test.go
+++ b/features/controller/api/handlers_registration_test.go
@@ -55,6 +55,10 @@ func newHandleRegisterServer(t *testing.T, tokenStore registration.Store, certMg
 
 	cfg := config.DefaultConfig()
 	cfg.Certificate.EnableCertManagement = false
+	// Default config binds 0.0.0.0:4433; set ExternalAddress so getTransportAddress() succeeds.
+	if cfg.Transport != nil {
+		cfg.Transport.ExternalAddress = "localhost"
+	}
 
 	var logger logging.Logger
 	if len(loggers) > 0 && loggers[0] != nil {
@@ -1122,4 +1126,128 @@ func TestHandleApproveAll_NoPendingStore(t *testing.T) {
 	defer func() { _ = resp.Body.Close() }()
 
 	assert.Equal(t, http.StatusServiceUnavailable, resp.StatusCode)
+}
+
+// TestGetTransportAddress_ExternalAddressConfig verifies that transport.external_address
+// is returned as the steward-facing address when ListenAddr binds 0.0.0.0.
+func TestGetTransportAddress_ExternalAddressConfig(t *testing.T) {
+	tokenStore := newTestRegistrationStore(t)
+	srv, _ := newHandleRegisterServer(t, tokenStore, nil)
+	srv.cfg.Transport = &config.TransportConfig{
+		ListenAddr:      "0.0.0.0:4433",
+		ExternalAddress: "controller.example.com",
+	}
+
+	addr, err := srv.getTransportAddress()
+	require.NoError(t, err)
+	assert.Equal(t, "controller.example.com:4433", addr)
+}
+
+// TestGetTransportAddress_EnvVarFallback verifies that CFGMS_EXTERNAL_HOSTNAME is used
+// when no transport.external_address is configured.
+func TestGetTransportAddress_EnvVarFallback(t *testing.T) {
+	t.Setenv("CFGMS_EXTERNAL_HOSTNAME", "env-controller.example.com")
+	tokenStore := newTestRegistrationStore(t)
+	srv, _ := newHandleRegisterServer(t, tokenStore, nil)
+	srv.cfg.Transport = &config.TransportConfig{ListenAddr: "0.0.0.0:9433"}
+
+	addr, err := srv.getTransportAddress()
+	require.NoError(t, err)
+	assert.Equal(t, "env-controller.example.com:9433", addr)
+}
+
+// TestGetTransportAddress_ConfigPrecedenceOverEnvVar verifies that transport.external_address
+// takes precedence over CFGMS_EXTERNAL_HOSTNAME when both are set.
+func TestGetTransportAddress_ConfigPrecedenceOverEnvVar(t *testing.T) {
+	t.Setenv("CFGMS_EXTERNAL_HOSTNAME", "env-controller.example.com")
+	tokenStore := newTestRegistrationStore(t)
+	srv, _ := newHandleRegisterServer(t, tokenStore, nil)
+	srv.cfg.Transport = &config.TransportConfig{
+		ListenAddr:      "0.0.0.0:4433",
+		ExternalAddress: "config-controller.example.com",
+	}
+
+	addr, err := srv.getTransportAddress()
+	require.NoError(t, err)
+	assert.Equal(t, "config-controller.example.com:4433", addr)
+}
+
+// TestGetTransportAddress_NonBindAll verifies that a specific bind address is
+// returned unchanged without requiring an external address.
+func TestGetTransportAddress_NonBindAll(t *testing.T) {
+	tokenStore := newTestRegistrationStore(t)
+	srv, _ := newHandleRegisterServer(t, tokenStore, nil)
+	srv.cfg.Transport = &config.TransportConfig{ListenAddr: "192.168.1.10:4433"}
+
+	addr, err := srv.getTransportAddress()
+	require.NoError(t, err)
+	assert.Equal(t, "192.168.1.10:4433", addr)
+}
+
+// TestGetTransportAddress_BindAll_NoExternalAddress_ReturnsError verifies that
+// getTransportAddress() returns an informative error when ListenAddr is 0.0.0.0
+// and no external address is available.
+func TestGetTransportAddress_BindAll_NoExternalAddress_ReturnsError(t *testing.T) {
+	t.Setenv("CFGMS_EXTERNAL_HOSTNAME", "")
+	tokenStore := newTestRegistrationStore(t)
+	srv, _ := newHandleRegisterServer(t, tokenStore, nil)
+	srv.cfg.Transport = &config.TransportConfig{ListenAddr: "0.0.0.0:4433"}
+
+	_, err := srv.getTransportAddress()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "transport.external_address")
+	assert.Contains(t, err.Error(), "CFGMS_EXTERNAL_HOSTNAME")
+}
+
+// TestHandleRegister_QuarantinePath_TransportAddressError verifies that the quarantine
+// branch returns HTTP 500 when getTransportAddress() fails (misconfigured 0.0.0.0 bind
+// with no external address). This can only occur if startup validation is bypassed.
+func TestHandleRegister_QuarantinePath_TransportAddressError(t *testing.T) {
+	t.Setenv("CFGMS_EXTERNAL_HOSTNAME", "")
+	tokenStore := newTestRegistrationStore(t)
+	// newHandleRegisterServer sets ExternalAddress="localhost" so the server builds.
+	server, _ := newHandleRegisterServer(t, tokenStore, nil)
+	// Now simulate a misconfigured transport address (clears the ExternalAddress).
+	server.cfg.Transport = &config.TransportConfig{ListenAddr: "0.0.0.0:4433"}
+	server.SetApprovalHook(&quarantineHookForTest{})
+
+	tok := &registration.Token{
+		Token:         "cfgms_reg_quarantine_transport_err",
+		TenantID:      "test-tenant",
+		ControllerURL: "grpc://controller:7443",
+	}
+	require.NoError(t, tokenStore.SaveToken(context.Background(), tok))
+
+	rec := postRegister(server, "cfgms_reg_quarantine_transport_err")
+
+	assert.Equal(t, http.StatusInternalServerError, rec.Code,
+		"quarantine path must return HTTP 500 when transport address is misconfigured")
+	assert.Contains(t, rec.Body.String(), "transport address not configured")
+}
+
+// TestHandleRegister_ApprovePath_TransportAddressError verifies that the approve
+// branch returns HTTP 500 when getTransportAddress() fails (misconfigured 0.0.0.0 bind
+// with no external address). This can only occur if startup validation is bypassed.
+func TestHandleRegister_ApprovePath_TransportAddressError(t *testing.T) {
+	t.Setenv("CFGMS_EXTERNAL_HOSTNAME", "")
+	tokenStore := newTestRegistrationStore(t)
+	certMgr := newTestCertManager(t)
+	// newHandleRegisterServer sets ExternalAddress="localhost" so the server builds.
+	server, _ := newHandleRegisterServer(t, tokenStore, certMgr)
+	// Now simulate a misconfigured transport address (clears the ExternalAddress).
+	server.cfg.Transport = &config.TransportConfig{ListenAddr: "0.0.0.0:4433"}
+	server.SetApprovalHook(&AlwaysApproveHook{})
+
+	tok := &registration.Token{
+		Token:         "cfgms_reg_approve_transport_err",
+		TenantID:      "test-tenant",
+		ControllerURL: "grpc://controller:7443",
+	}
+	require.NoError(t, tokenStore.SaveToken(context.Background(), tok))
+
+	rec := postRegister(server, "cfgms_reg_approve_transport_err")
+
+	assert.Equal(t, http.StatusInternalServerError, rec.Code,
+		"approve path must return HTTP 500 when transport address is misconfigured")
+	assert.Contains(t, rec.Body.String(), "transport address not configured")
 }

--- a/features/controller/config/config.go
+++ b/features/controller/config/config.go
@@ -372,6 +372,11 @@ type TransportConfig struct {
 	// ListenAddr is the address for the unified transport server (e.g., "0.0.0.0:4433")
 	ListenAddr string `yaml:"listen_addr"`
 
+	// ExternalAddress is the hostname or IP address advertised to stewards when
+	// ListenAddr binds 0.0.0.0. Required when ListenAddr starts with "0.0.0.0" and
+	// CFGMS_EXTERNAL_HOSTNAME env var is not set. Example: "controller.example.com"
+	ExternalAddress string `yaml:"external_address,omitempty"`
+
 	// UseCertManager enables the controller's certificate manager for TLS.
 	// When true (default), certificates are managed automatically.
 	UseCertManager bool `yaml:"use_cert_manager"`

--- a/features/controller/controller_test.go
+++ b/features/controller/controller_test.go
@@ -63,6 +63,10 @@ func TestControllerCreation(t *testing.T) {
 						tt.cfg.Storage.Config["repository_path"] = tempDir + "/storage"
 					}
 				}
+				// Required when ListenAddr binds 0.0.0.0 (the default): set external address.
+				if tt.cfg.Transport != nil && tt.cfg.Transport.ExternalAddress == "" {
+					tt.cfg.Transport.ExternalAddress = "localhost"
+				}
 				// Pre-initialize if cert management is enabled (Story #410)
 				if tt.cfg.Certificate != nil && tt.cfg.Certificate.EnableCertManagement {
 					pkgtestutil.PreInitControllerForTest(t, tt.cfg.CertPath, tt.cfg.Certificate.CAPath)
@@ -189,6 +193,10 @@ func TestModuleRegistration(t *testing.T) {
 		if cfg.Storage.Config != nil {
 			cfg.Storage.Config["repository_path"] = tempDir + "/storage"
 		}
+	}
+	// Required when ListenAddr binds 0.0.0.0 (the default): set external address.
+	if cfg.Transport != nil {
+		cfg.Transport.ExternalAddress = "localhost"
 	}
 	pkgtestutil.PreInitControllerForTest(t, cfg.CertPath, cfg.Certificate.CAPath)
 	ctrl, err := New(cfg, logger)

--- a/features/controller/server/server.go
+++ b/features/controller/server/server.go
@@ -165,6 +165,17 @@ func New(cfg *config.Config, logger logging.Logger) (*Server, error) {
 		return nil, ErrNilConfig
 	}
 
+	// Validate transport config early: refuse to start if 0.0.0.0 bind has no external address.
+	if cfg.Transport != nil && strings.HasPrefix(cfg.Transport.ListenAddr, "0.0.0.0") {
+		externalAddr := cfg.Transport.ExternalAddress
+		if externalAddr == "" {
+			externalAddr = os.Getenv("CFGMS_EXTERNAL_HOSTNAME")
+		}
+		if externalAddr == "" {
+			return nil, fmt.Errorf("transport.listen_addr binds 0.0.0.0 but no external address is configured; set transport.external_address in controller.cfg or CFGMS_EXTERNAL_HOSTNAME env var")
+		}
+	}
+
 	logger.Info("Config validated, proceeding with storage initialization...")
 
 	// Initialize global storage provider system - REQUIRED for all deployments

--- a/features/controller/server/server_test.go
+++ b/features/controller/server/server_test.go
@@ -310,3 +310,86 @@ func TestBuiltinWorkflowSeedingManualReview(t *testing.T) {
 	require.True(t, ok, "manual-review workflow must have a string 'registration_decision' variable")
 	assert.Equal(t, "quarantine", decision, "manual-review workflow must set registration_decision=quarantine")
 }
+
+// TestServer_New_Fails_BindAll_NoExternalAddress verifies that server.New() returns
+// a non-nil error when transport.listen_addr binds 0.0.0.0 and neither
+// transport.external_address nor CFGMS_EXTERNAL_HOSTNAME is configured.
+func TestServer_New_Fails_BindAll_NoExternalAddress(t *testing.T) {
+	t.Setenv("CFGMS_EXTERNAL_HOSTNAME", "")
+
+	tempDir := t.TempDir()
+	cfg := &config.Config{
+		ListenAddr: "127.0.0.1:0",
+		Certificate: &config.CertificateConfig{
+			EnableCertManagement: false,
+		},
+		Storage: &config.StorageConfig{
+			FlatfileRoot: tempDir + "/flatfile",
+			SQLitePath:   tempDir + "/cfgms.db",
+		},
+		Transport: &config.TransportConfig{
+			ListenAddr: "0.0.0.0:4433",
+		},
+	}
+
+	_, err := New(cfg, logging.NewNoopLogger())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "transport.listen_addr binds 0.0.0.0 but no external address is configured")
+	assert.Contains(t, err.Error(), "transport.external_address")
+	assert.Contains(t, err.Error(), "CFGMS_EXTERNAL_HOSTNAME")
+}
+
+// TestServer_New_Succeeds_BindAll_WithExternalAddressConfig verifies that server.New()
+// succeeds when transport.listen_addr binds 0.0.0.0 and transport.external_address is set.
+func TestServer_New_Succeeds_BindAll_WithExternalAddressConfig(t *testing.T) {
+	t.Setenv("CFGMS_EXTERNAL_HOSTNAME", "")
+
+	tempDir := t.TempDir()
+	cfg := &config.Config{
+		ListenAddr: "127.0.0.1:0",
+		Certificate: &config.CertificateConfig{
+			EnableCertManagement: false,
+		},
+		Storage: &config.StorageConfig{
+			Provider:     "flatfile",
+			FlatfileRoot: tempDir + "/flatfile",
+			SQLitePath:   tempDir + "/cfgms.db",
+		},
+		Transport: &config.TransportConfig{
+			ListenAddr:      "0.0.0.0:4433",
+			ExternalAddress: "controller.example.com",
+		},
+	}
+
+	srv, err := New(cfg, logging.NewNoopLogger())
+	require.NoError(t, err)
+	require.NotNil(t, srv)
+	t.Cleanup(func() { _ = srv.Stop() })
+}
+
+// TestServer_New_Succeeds_BindAll_WithEnvVar verifies that server.New() succeeds when
+// transport.listen_addr binds 0.0.0.0 and CFGMS_EXTERNAL_HOSTNAME is set.
+func TestServer_New_Succeeds_BindAll_WithEnvVar(t *testing.T) {
+	t.Setenv("CFGMS_EXTERNAL_HOSTNAME", "env-controller.example.com")
+
+	tempDir := t.TempDir()
+	cfg := &config.Config{
+		ListenAddr: "127.0.0.1:0",
+		Certificate: &config.CertificateConfig{
+			EnableCertManagement: false,
+		},
+		Storage: &config.StorageConfig{
+			Provider:     "flatfile",
+			FlatfileRoot: tempDir + "/flatfile",
+			SQLitePath:   tempDir + "/cfgms.db",
+		},
+		Transport: &config.TransportConfig{
+			ListenAddr: "0.0.0.0:4433",
+		},
+	}
+
+	srv, err := New(cfg, logging.NewNoopLogger())
+	require.NoError(t, err)
+	require.NotNil(t, srv)
+	t.Cleanup(func() { _ = srv.Stop() })
+}

--- a/test/unit/controller/module_test.go
+++ b/test/unit/controller/module_test.go
@@ -28,6 +28,10 @@ func newTestController(t *testing.T) *controller.Controller {
 	cfg.Certificate.CAPath = tempDir + "/certs/ca"
 	cfg.Storage.FlatfileRoot = tempDir + "/storage-flatfile"
 	cfg.Storage.SQLitePath = tempDir + "/cfgms.db"
+	// Required when ListenAddr binds 0.0.0.0 (the default): set external address.
+	if cfg.Transport != nil {
+		cfg.Transport.ExternalAddress = "localhost"
+	}
 
 	// Pre-initialize: create CA and write init marker (Story #410)
 	pkgtestutil.PreInitControllerForTest(t, cfg.CertPath, cfg.Certificate.CAPath)


### PR DESCRIPTION
## Summary

- Controllers binding `transport.listen_addr` to `0.0.0.0` previously fell back to advertising `localhost:4433` to stewards when `CFGMS_EXTERNAL_HOSTNAME` was unset — stewards received an unreachable address and failed to connect silently.
- `server.New()` now returns a clear startup error when `ListenAddr` starts with `0.0.0.0` and neither `transport.external_address` (config file) nor `CFGMS_EXTERNAL_HOSTNAME` (env var) is set.
- `getTransportAddress()` / `replaceBindAddress()` return errors instead of silently substituting `localhost` — registration handlers return HTTP 500 if the startup check is bypassed.
- Config-file `transport.external_address` takes precedence over the env var; env var is retained for backwards compatibility.

Fixes #1901

## Changes

- `features/controller/config/config.go` — `ExternalAddress string` field added to `TransportConfig`
- `features/controller/api/handlers_registration.go` — `getTransportAddress()` → `(string, error)`; `replaceBindAddress()` accepts resolved external address; three call sites updated with HTTP 500 handling
- `features/controller/server/server.go` — startup validation in `New()` before storage initialization
- `features/controller/api/handlers_registration_test.go` — 7 new tests (transport address resolution, precedence, error paths, HTTP 500 branches)
- `features/controller/server/server_test.go` — 3 new tests (startup fail, pass-with-config, pass-with-env-var)
- `features/controller/controller_test.go`, `test/unit/controller/module_test.go` — set `ExternalAddress = "localhost"` on `DefaultConfig()`-based tests to maintain passing behaviour
- `docs/deployment/controller.cfg` — `external_address` documented as required when binding `0.0.0.0`

## Specialist Review Results

- **QA Test Runner: PASS** — 175 packages, all passing; cross-platform builds verified
- **QA Code Reviewer: PASS** — no mocks, no skipped tests, all new code paths have error-path coverage including HTTP 500 branches
- **Security Engineer: PASS** — no hardcoded secrets, no log injection, no central provider violations; error messages return generic text to callers, internal detail goes only to server logs

## Test Plan

- [ ] Verify `TestServer_New_Fails_BindAll_NoExternalAddress` passes (startup refusal)
- [ ] Verify `TestGetTransportAddress_ExternalAddressConfig` passes (config file precedence)
- [ ] Verify `TestGetTransportAddress_EnvVarFallback` passes (backwards compat)
- [ ] Verify `TestHandleRegister_QuarantinePath_TransportAddressError` passes (HTTP 500 quarantine path)
- [ ] Verify `TestHandleRegister_ApprovePath_TransportAddressError` passes (HTTP 500 approve path)
- [ ] Verify all existing registration tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)