### PR TITLE
cfg: admin CLI + REST for pending refreshes and refresh policy (Issue #2097)

### DIFF
--- a/.github/codeql/extensions/qlpack.yml
+++ b/.github/codeql/extensions/qlpack.yml
@@ -1,5 +1,5 @@
 name: cfg-is/cfgms-go-extensions
-version: 0.0.5
+version: 0.0.6
 library: true
 
 # Apply our model extensions on top of the standard Go query pack so that

--- a/cmd/cfg/cmd/api_client.go
+++ b/cmd/cfg/cmd/api_client.go
@@ -715,6 +715,116 @@ func (c *APIClient) RollbackUpgrade(ctx context.Context, upgradeID string, req *
 	return &result, nil
 }
 
+// ListPendingRefreshes lists pending registration-refresh requests.
+// An empty tenantID returns entries for all tenants.
+func (c *APIClient) ListPendingRefreshes(ctx context.Context, tenantID string) ([]APIPendingRefreshEntry, error) {
+	path := "/api/v1/stewards/refresh/pending"
+	if tenantID != "" {
+		path += "?tenant_id=" + url.QueryEscape(tenantID)
+	}
+
+	resp, err := c.doRequest(ctx, "GET", path, nil)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, c.parseError(resp)
+	}
+
+	var entries []APIPendingRefreshEntry
+	if err := json.NewDecoder(resp.Body).Decode(&entries); err != nil {
+		return nil, fmt.Errorf("failed to decode response: %w", err)
+	}
+	return entries, nil
+}
+
+// ApproveRefresh approves a pending registration-refresh request by pending_id.
+func (c *APIClient) ApproveRefresh(ctx context.Context, pendingID string) (*APIApproveRefreshResponse, error) {
+	resp, err := c.doRequest(ctx, "POST", "/api/v1/stewards/refresh/"+url.PathEscape(pendingID)+"/approve", nil)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, c.parseError(resp)
+	}
+
+	var result APIApproveRefreshResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("failed to decode response: %w", err)
+	}
+	return &result, nil
+}
+
+// RejectRefresh rejects a pending registration-refresh request by pending_id.
+func (c *APIClient) RejectRefresh(ctx context.Context, pendingID, reason string) error {
+	body, err := json.Marshal(struct {
+		Reason string `json:"reason,omitempty"`
+	}{Reason: reason})
+	if err != nil {
+		return fmt.Errorf("failed to marshal request: %w", err)
+	}
+
+	resp, err := c.doRequest(ctx, "POST", "/api/v1/stewards/refresh/"+url.PathEscape(pendingID)+"/reject", bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return c.parseError(resp)
+	}
+	return nil
+}
+
+// GetRefreshPolicy retrieves the per-tenant registration-refresh policy.
+func (c *APIClient) GetRefreshPolicy(ctx context.Context, tenantID string) (*APIRefreshPolicyResponse, error) {
+	resp, err := c.doRequest(ctx, "GET", "/api/v1/tenants/"+url.PathEscape(tenantID)+"/refresh-policy", nil)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, c.parseError(resp)
+	}
+
+	var policy APIRefreshPolicyResponse
+	if err := json.NewDecoder(resp.Body).Decode(&policy); err != nil {
+		return nil, fmt.Errorf("failed to decode response: %w", err)
+	}
+	return &policy, nil
+}
+
+// SetRefreshPolicy creates or replaces the per-tenant registration-refresh policy.
+func (c *APIClient) SetRefreshPolicy(ctx context.Context, tenantID, mode string, maxDormancyDays *int) error {
+	reqBody := struct {
+		Mode            string `json:"mode"`
+		MaxDormancyDays *int   `json:"max_dormancy_days,omitempty"`
+	}{
+		Mode:            mode,
+		MaxDormancyDays: maxDormancyDays,
+	}
+	body, err := json.Marshal(reqBody)
+	if err != nil {
+		return fmt.Errorf("failed to marshal request: %w", err)
+	}
+
+	resp, err := c.doRequest(ctx, "PUT", "/api/v1/tenants/"+url.PathEscape(tenantID)+"/refresh-policy", bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return c.parseError(resp)
+	}
+	return nil
+}
+
 // parseError extracts error message from HTTP response
 func (c *APIClient) parseError(resp *http.Response) error {
 	body, err := io.ReadAll(resp.Body)

--- a/cmd/cfg/cmd/refresh.go
+++ b/cmd/cfg/cmd/refresh.go
@@ -1,0 +1,359 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+// Package cmd implements the CLI commands for cfg
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"text/tabwriter"
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	refreshAPIURL      string
+	refreshAPIKey      string
+	refreshTLSCACert   string
+	refreshTLSInsecure bool
+	refreshTenantID    string
+	refreshReason      string
+	refreshPolicyMode  string
+	refreshMaxDormancy int
+	refreshSetDormancy bool
+)
+
+// refreshCmd is the parent command for refresh management subcommands.
+var refreshCmd = &cobra.Command{
+	Use:   "refresh",
+	Short: "Manage steward registration-refresh requests and policy",
+	Long: `Manage the registration-refresh approval queue and per-tenant refresh policy.
+
+When a steward's mTLS certificate expires while it has been offline, it must
+complete a registration-refresh challenge to regain access. Depending on the
+tenant's refresh policy, the request may be queued for manual operator review.
+
+Use these commands to list, approve, or reject pending refresh requests and to
+get or set the per-tenant refresh policy.
+
+This command communicates with the controller's REST API. The controller URL and
+API key can be provided via flags or environment variables:
+  - CFGMS_API_URL: Controller REST API URL (default: http://localhost:9080)
+  - CFGMS_API_KEY: API key for authentication
+  - CFGMS_TLS_CA_CERT: Path to CA certificate for TLS verification
+  - CFGMS_TLS_INSECURE: Skip TLS verification (development only)
+
+Examples:
+  # List pending refresh requests for all tenants
+  cfg steward refresh list
+
+  # List pending refresh requests for a specific tenant
+  cfg steward refresh list --tenant acme-corp
+
+  # Approve a pending refresh request
+  cfg steward refresh approve refresh-1234567890
+
+  # Reject a pending refresh request with a reason
+  cfg steward refresh reject refresh-1234567890 --reason "Device decommissioned"
+
+  # Get the refresh policy for a tenant
+  cfg steward refresh policy get --tenant acme-corp
+
+  # Set the refresh policy for a tenant
+  cfg steward refresh policy set --mode auto_accept --tenant acme-corp`,
+}
+
+// refreshListCmd lists pending refresh requests.
+var refreshListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List pending registration-refresh requests",
+	Long: `List stewards with pending registration-refresh requests awaiting operator review.
+
+Examples:
+  cfg steward refresh list
+  cfg steward refresh list --tenant acme-corp`,
+	RunE: runRefreshList,
+}
+
+// refreshApproveCmd approves a pending refresh request.
+var refreshApproveCmd = &cobra.Command{
+	Use:   "approve <pending_id>",
+	Short: "Approve a pending registration-refresh request",
+	Long: `Approve a pending registration-refresh request by its pending_id.
+
+A new mTLS certificate is generated and stored. The steward receives the
+certificate bundle on its next poll.
+
+Examples:
+  cfg steward refresh approve refresh-1234567890`,
+	Args: cobra.ExactArgs(1),
+	RunE: runRefreshApprove,
+}
+
+// refreshRejectCmd rejects a pending refresh request.
+var refreshRejectCmd = &cobra.Command{
+	Use:   "reject <pending_id>",
+	Short: "Reject a pending registration-refresh request",
+	Long: `Reject a pending registration-refresh request by its pending_id.
+
+The steward's refresh request is marked rejected. The steward must re-initiate
+the challenge flow to get a new pending_id.
+
+Examples:
+  cfg steward refresh reject refresh-1234567890
+  cfg steward refresh reject refresh-1234567890 --reason "Device decommissioned"`,
+	Args: cobra.ExactArgs(1),
+	RunE: runRefreshReject,
+}
+
+// refreshPolicyCmd is the parent command for policy subcommands.
+var refreshPolicyCmd = &cobra.Command{
+	Use:   "policy",
+	Short: "Manage the per-tenant registration-refresh policy",
+}
+
+// refreshPolicyGetCmd gets the refresh policy for a tenant.
+var refreshPolicyGetCmd = &cobra.Command{
+	Use:   "get",
+	Short: "Get the registration-refresh policy for a tenant",
+	Long: `Display the registration-refresh policy for the given tenant.
+
+When no policy has been set, the default is require_approval.
+
+Examples:
+  cfg steward refresh policy get --tenant acme-corp`,
+	RunE: runRefreshPolicyGet,
+}
+
+// refreshPolicySetCmd sets the refresh policy for a tenant.
+var refreshPolicySetCmd = &cobra.Command{
+	Use:   "set",
+	Short: "Set the registration-refresh policy for a tenant",
+	Long: `Set the registration-refresh policy for the given tenant.
+
+Modes:
+  auto_accept      — approve automatically when provenance score is sufficient
+  require_approval — queue for manual operator review (default)
+  reject           — deny all refresh requests for this tenant
+
+Examples:
+  cfg steward refresh policy set --mode require_approval --tenant acme-corp
+  cfg steward refresh policy set --mode auto_accept --tenant acme-corp
+  cfg steward refresh policy set --mode auto_accept --max-dormancy-days 90 --tenant acme-corp`,
+	RunE: runRefreshPolicySet,
+}
+
+func init() {
+	// Persistent flags available on all refresh subcommands.
+	refreshCmd.PersistentFlags().StringVar(&refreshAPIURL, "api-url", "", "Controller REST API URL (env: CFGMS_API_URL)")
+	refreshCmd.PersistentFlags().StringVar(&refreshAPIKey, "api-key", "", "API key for authentication (env: CFGMS_API_KEY)")
+	refreshCmd.PersistentFlags().StringVar(&refreshTLSCACert, "tls-ca-cert", "", "Path to CA certificate for TLS verification (env: CFGMS_TLS_CA_CERT)")
+	refreshCmd.PersistentFlags().BoolVar(&refreshTLSInsecure, "tls-insecure", false, "Skip TLS verification (development only, env: CFGMS_TLS_INSECURE)")
+
+	// refresh list
+	refreshListCmd.Flags().StringVar(&refreshTenantID, "tenant", "", "Filter by tenant ID")
+
+	// refresh reject
+	refreshRejectCmd.Flags().StringVar(&refreshReason, "reason", "", "Reason for rejection (optional)")
+
+	// refresh policy get
+	refreshPolicyGetCmd.Flags().StringVar(&refreshTenantID, "tenant", "", "Tenant ID (required)")
+	_ = refreshPolicyGetCmd.MarkFlagRequired("tenant")
+
+	// refresh policy set
+	refreshPolicySetCmd.Flags().StringVar(&refreshPolicyMode, "mode", "", "Refresh policy mode: auto_accept, require_approval, or reject (required)")
+	refreshPolicySetCmd.Flags().IntVar(&refreshMaxDormancy, "max-dormancy-days", 0, "Maximum dormancy in days (0 = disabled)")
+	refreshPolicySetCmd.Flags().BoolVar(&refreshSetDormancy, "set-dormancy", false, "Explicitly set max-dormancy-days (required to disable with 0)")
+	refreshPolicySetCmd.Flags().StringVar(&refreshTenantID, "tenant", "", "Tenant ID (required)")
+	_ = refreshPolicySetCmd.MarkFlagRequired("mode")
+	_ = refreshPolicySetCmd.MarkFlagRequired("tenant")
+
+	// Wire subcommands.
+	refreshPolicyCmd.AddCommand(refreshPolicyGetCmd)
+	refreshPolicyCmd.AddCommand(refreshPolicySetCmd)
+	refreshCmd.AddCommand(refreshListCmd)
+	refreshCmd.AddCommand(refreshApproveCmd)
+	refreshCmd.AddCommand(refreshRejectCmd)
+	refreshCmd.AddCommand(refreshPolicyCmd)
+}
+
+// getRefreshClient creates an API client for refresh management commands.
+func getRefreshClient() (*APIClient, error) {
+	apiURL := refreshAPIURL
+	if apiURL == "" {
+		apiURL = os.Getenv("CFGMS_API_URL")
+	}
+
+	client, err := resolveBundleClient(apiURL)
+	if err != nil {
+		return nil, fmt.Errorf("bundle lookup failed: %w", err)
+	}
+	if client != nil {
+		return client, nil
+	}
+
+	if apiURL == "" {
+		apiURL = "http://localhost:9080"
+	}
+
+	apiKey := refreshAPIKey
+	if apiKey == "" {
+		apiKey = os.Getenv("CFGMS_API_KEY")
+	}
+
+	tlsInsecure := refreshTLSInsecure
+	if !tlsInsecure && os.Getenv("CFGMS_TLS_INSECURE") == "true" {
+		tlsInsecure = true
+	}
+
+	tlsCACertPath := refreshTLSCACert
+	if tlsCACertPath == "" {
+		tlsCACertPath = os.Getenv("CFGMS_TLS_CA_CERT")
+	}
+
+	return newClientFromFlags(apiURL, apiKey, tlsCACertPath, tlsInsecure)
+}
+
+func runRefreshList(_ *cobra.Command, _ []string) error {
+	client, err := getRefreshClient()
+	if err != nil {
+		return fmt.Errorf("failed to create API client: %w", err)
+	}
+
+	entries, err := client.ListPendingRefreshes(context.Background(), refreshTenantID)
+	if err != nil {
+		return fmt.Errorf("failed to list pending refreshes: %w", err)
+	}
+
+	if len(entries) == 0 {
+		fmt.Println("No pending refresh requests.")
+		return nil
+	}
+
+	fmt.Printf("Pending refresh requests (%d):\n\n", len(entries))
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	_, _ = fmt.Fprintf(w, "PENDING ID\tDEVICE ID\tTENANT ID\tSOURCE IP\tSTATUS\tCREATED AT\n")
+	for _, e := range entries {
+		createdAt := e.CreatedAt.UTC().Format(time.RFC3339)
+		deviceID := e.DeviceID
+		if len(deviceID) > 16 {
+			deviceID = deviceID[:16] + "…"
+		}
+		_, _ = fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\n",
+			e.PendingID, deviceID, e.TenantID, e.SourceIP, e.Status, createdAt)
+	}
+	_ = w.Flush()
+
+	return nil
+}
+
+func runRefreshApprove(_ *cobra.Command, args []string) error {
+	pendingID := args[0]
+
+	client, err := getRefreshClient()
+	if err != nil {
+		return fmt.Errorf("failed to create API client: %w", err)
+	}
+
+	resp, err := client.ApproveRefresh(context.Background(), pendingID)
+	if err != nil {
+		return fmt.Errorf("failed to approve refresh %s: %w", pendingID, err)
+	}
+
+	fmt.Printf("Refresh request approved: %s (status: %s)\n", resp.PendingID, resp.Status)
+	return nil
+}
+
+func runRefreshReject(_ *cobra.Command, args []string) error {
+	pendingID := args[0]
+
+	client, err := getRefreshClient()
+	if err != nil {
+		return fmt.Errorf("failed to create API client: %w", err)
+	}
+
+	if err := client.RejectRefresh(context.Background(), pendingID, refreshReason); err != nil {
+		return fmt.Errorf("failed to reject refresh %s: %w", pendingID, err)
+	}
+
+	fmt.Printf("Refresh request rejected: %s\n", pendingID)
+	return nil
+}
+
+func runRefreshPolicyGet(_ *cobra.Command, _ []string) error {
+	client, err := getRefreshClient()
+	if err != nil {
+		return fmt.Errorf("failed to create API client: %w", err)
+	}
+
+	policy, err := client.GetRefreshPolicy(context.Background(), refreshTenantID)
+	if err != nil {
+		return fmt.Errorf("failed to get refresh policy for tenant %s: %w", refreshTenantID, err)
+	}
+
+	fmt.Printf("Tenant:           %s\n", policy.TenantID)
+	fmt.Printf("Mode:             %s\n", policy.Mode)
+	if policy.MaxDormancyDays != nil {
+		fmt.Printf("Max Dormancy:     %d days\n", *policy.MaxDormancyDays)
+	} else {
+		fmt.Printf("Max Dormancy:     disabled\n")
+	}
+	return nil
+}
+
+func runRefreshPolicySet(_ *cobra.Command, _ []string) error {
+	client, err := getRefreshClient()
+	if err != nil {
+		return fmt.Errorf("failed to create API client: %w", err)
+	}
+
+	var maxDormancy *int
+	if refreshSetDormancy || refreshMaxDormancy > 0 {
+		v := refreshMaxDormancy
+		maxDormancy = &v
+	}
+
+	if err := client.SetRefreshPolicy(context.Background(), refreshTenantID, refreshPolicyMode, maxDormancy); err != nil {
+		return fmt.Errorf("failed to set refresh policy for tenant %s: %w", refreshTenantID, err)
+	}
+
+	fmt.Printf("Refresh policy updated for tenant %s: mode=%s\n", refreshTenantID, refreshPolicyMode)
+	if maxDormancy != nil {
+		fmt.Printf("Max dormancy: %d days\n", *maxDormancy)
+	}
+	return nil
+}
+
+// ---- CLI response types -------------------------------------------------------
+
+// APIPendingRefreshEntry is the CLI view of a pending refresh record.
+type APIPendingRefreshEntry struct {
+	PendingID               string    `json:"pending_id"`
+	DeviceID                string    `json:"device_id"`
+	TenantID                string    `json:"tenant_id"`
+	SourceIP                string    `json:"source_ip"`
+	ProvenanceMatchedFields int       `json:"provenance_matched_fields"`
+	ProvenanceTotalFields   int       `json:"provenance_total_fields"`
+	Status                  string    `json:"status"`
+	CreatedAt               time.Time `json:"created_at"`
+	ExpiresAt               time.Time `json:"expires_at"`
+}
+
+// APIApproveRefreshResponse is the CLI view of the approve response.
+type APIApproveRefreshResponse struct {
+	Status      string `json:"status"`
+	PendingID   string `json:"pending_id"`
+	ClientCert  string `json:"client_cert,omitempty"`
+	ClientKey   string `json:"client_key,omitempty"`
+	CACert      string `json:"ca_cert,omitempty"`
+	SigningCert string `json:"signing_cert,omitempty"`
+}
+
+// APIRefreshPolicyResponse is the CLI view of a refresh policy.
+type APIRefreshPolicyResponse struct {
+	TenantID        string `json:"tenant_id"`
+	Mode            string `json:"mode"`
+	MaxDormancyDays *int   `json:"max_dormancy_days,omitempty"`
+}

--- a/cmd/cfg/cmd/refresh_test.go
+++ b/cmd/cfg/cmd/refresh_test.go
@@ -1,0 +1,251 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// pendingRefreshHandler returns a handler that serves a fixed list of pending
+// refresh entries. It records the received requests for assertion.
+func pendingRefreshHandler(t *testing.T, entries []APIPendingRefreshEntry) http.HandlerFunc {
+	t.Helper()
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(entries); err != nil {
+			t.Errorf("failed to encode response: %v", err)
+		}
+	}
+}
+
+func TestListPendingRefreshes_Empty(t *testing.T) {
+	srv := httptest.NewServer(pendingRefreshHandler(t, nil))
+	t.Cleanup(srv.Close)
+
+	client, err := newClientFromFlags(srv.URL, "test-key", "", false)
+	require.NoError(t, err)
+
+	entries, err := client.ListPendingRefreshes(context.Background(), "")
+	require.NoError(t, err)
+	assert.Empty(t, entries)
+}
+
+func TestListPendingRefreshes_WithEntries(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Second)
+	fixture := []APIPendingRefreshEntry{
+		{
+			PendingID: "refresh-001",
+			DeviceID:  "aabbccddeeff0011",
+			TenantID:  "acme-corp",
+			SourceIP:  "10.0.0.1",
+			Status:    "pending",
+			CreatedAt: now,
+			ExpiresAt: now.Add(7 * 24 * time.Hour),
+		},
+		{
+			PendingID: "refresh-002",
+			DeviceID:  "aabbccddeeff0022",
+			TenantID:  "acme-corp",
+			SourceIP:  "10.0.0.2",
+			Status:    "pending",
+			CreatedAt: now,
+			ExpiresAt: now.Add(7 * 24 * time.Hour),
+		},
+	}
+
+	srv := httptest.NewServer(pendingRefreshHandler(t, fixture))
+	t.Cleanup(srv.Close)
+
+	client, err := newClientFromFlags(srv.URL, "test-key", "", false)
+	require.NoError(t, err)
+
+	entries, err := client.ListPendingRefreshes(context.Background(), "acme-corp")
+	require.NoError(t, err)
+	require.Len(t, entries, 2)
+	assert.Equal(t, "refresh-001", entries[0].PendingID)
+	assert.Equal(t, "acme-corp", entries[0].TenantID)
+}
+
+func TestApproveRefresh_Success(t *testing.T) {
+	pendingID := "refresh-approve-test"
+	response := APIApproveRefreshResponse{
+		Status:     "approved",
+		PendingID:  pendingID,
+		ClientCert: "-----BEGIN CERTIFICATE-----\ntest\n-----END CERTIFICATE-----\n",
+		ClientKey:  "-----BEGIN PRIVATE KEY-----\ntest\n-----END PRIVATE KEY-----\n",
+		CACert:     "-----BEGIN CERTIFICATE-----\nca\n-----END CERTIFICATE-----\n",
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Contains(t, r.URL.Path, pendingID)
+		assert.Contains(t, r.URL.Path, "/approve")
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(response); err != nil {
+			t.Errorf("failed to encode response: %v", err)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	client, err := newClientFromFlags(srv.URL, "test-key", "", false)
+	require.NoError(t, err)
+
+	result, err := client.ApproveRefresh(context.Background(), pendingID)
+	require.NoError(t, err)
+	assert.Equal(t, "approved", result.Status)
+	assert.Equal(t, pendingID, result.PendingID)
+	assert.NotEmpty(t, result.ClientCert)
+}
+
+func TestApproveRefresh_NotFound(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "pending refresh not found", http.StatusNotFound)
+	}))
+	t.Cleanup(srv.Close)
+
+	client, err := newClientFromFlags(srv.URL, "test-key", "", false)
+	require.NoError(t, err)
+
+	_, err = client.ApproveRefresh(context.Background(), "nonexistent")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "404")
+}
+
+func TestRejectRefresh_Success(t *testing.T) {
+	pendingID := "refresh-reject-test"
+	var capturedReason string
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Contains(t, r.URL.Path, pendingID)
+		assert.Contains(t, r.URL.Path, "/reject")
+
+		var body struct {
+			Reason string `json:"reason"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err == nil {
+			capturedReason = body.Reason
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+
+	client, err := newClientFromFlags(srv.URL, "test-key", "", false)
+	require.NoError(t, err)
+
+	err = client.RejectRefresh(context.Background(), pendingID, "Device decommissioned")
+	require.NoError(t, err)
+	assert.Equal(t, "Device decommissioned", capturedReason)
+}
+
+func TestRejectRefresh_NoReason(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+
+	client, err := newClientFromFlags(srv.URL, "test-key", "", false)
+	require.NoError(t, err)
+
+	err = client.RejectRefresh(context.Background(), "refresh-no-reason", "")
+	require.NoError(t, err)
+}
+
+func TestGetRefreshPolicy_Success(t *testing.T) {
+	days := 90
+	expected := APIRefreshPolicyResponse{
+		TenantID:        "acme-corp",
+		Mode:            "auto_accept",
+		MaxDormancyDays: &days,
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Contains(t, r.URL.Path, "acme-corp")
+		assert.Contains(t, r.URL.Path, "refresh-policy")
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(expected); err != nil {
+			t.Errorf("failed to encode: %v", err)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	client, err := newClientFromFlags(srv.URL, "test-key", "", false)
+	require.NoError(t, err)
+
+	policy, err := client.GetRefreshPolicy(context.Background(), "acme-corp")
+	require.NoError(t, err)
+	assert.Equal(t, "acme-corp", policy.TenantID)
+	assert.Equal(t, "auto_accept", policy.Mode)
+	require.NotNil(t, policy.MaxDormancyDays)
+	assert.Equal(t, 90, *policy.MaxDormancyDays)
+}
+
+func TestSetRefreshPolicy_Success(t *testing.T) {
+	var capturedMode string
+	var capturedDormancy *int
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPut, r.Method)
+		assert.Contains(t, r.URL.Path, "acme-corp")
+		assert.Contains(t, r.URL.Path, "refresh-policy")
+
+		var body struct {
+			Mode            string `json:"mode"`
+			MaxDormancyDays *int   `json:"max_dormancy_days,omitempty"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err == nil {
+			capturedMode = body.Mode
+			capturedDormancy = body.MaxDormancyDays
+		}
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(APIRefreshPolicyResponse{
+			TenantID: "acme-corp",
+			Mode:     body.Mode,
+		}); err != nil {
+			t.Errorf("failed to encode: %v", err)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	client, err := newClientFromFlags(srv.URL, "test-key", "", false)
+	require.NoError(t, err)
+
+	days := 60
+	err = client.SetRefreshPolicy(context.Background(), "acme-corp", "require_approval", &days)
+	require.NoError(t, err)
+	assert.Equal(t, "require_approval", capturedMode)
+	require.NotNil(t, capturedDormancy)
+	assert.Equal(t, 60, *capturedDormancy)
+}
+
+func TestSetRefreshPolicy_NoDormancy(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(APIRefreshPolicyResponse{
+			TenantID: "acme-corp",
+			Mode:     "reject",
+		}); err != nil {
+			t.Errorf("failed to encode: %v", err)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	client, err := newClientFromFlags(srv.URL, "test-key", "", false)
+	require.NoError(t, err)
+
+	err = client.SetRefreshPolicy(context.Background(), "acme-corp", "reject", nil)
+	require.NoError(t, err)
+}

--- a/cmd/cfg/cmd/steward.go
+++ b/cmd/cfg/cmd/steward.go
@@ -416,6 +416,9 @@ func init() {
 	stewardCmd.AddCommand(stewardUpgradeCmd)
 	stewardUpgradeCmd.AddCommand(stewardUpgradeStatusCmd)
 	stewardUpgradeCmd.AddCommand(stewardUpgradeRollbackCmd)
+
+	// Refresh management subcommands (Issue #2097).
+	stewardCmd.AddCommand(refreshCmd)
 }
 
 // getStewardClient creates an API client using bundle auth (mTLS) when available,

--- a/docs/deployment/steward-refresh-management.md
+++ b/docs/deployment/steward-refresh-management.md
@@ -1,0 +1,151 @@
+# Steward Registration-Refresh Management
+
+When a steward's mTLS certificate expires while the device has been offline, it must
+complete a **registration-refresh** challenge to regain fleet membership. Depending on
+the tenant's configured refresh policy, these requests may be queued for manual
+operator review.
+
+This guide covers the `cfg steward refresh` commands for managing the refresh approval
+queue and the per-tenant refresh policy.
+
+## Prerequisites
+
+- `cfg` CLI installed and authenticated (see [fleet walkthrough](fleet/walkthrough.md))
+- An API key with the appropriate `refresh:*` permissions
+
+## Commands
+
+### List pending refresh requests
+
+```bash
+# All tenants
+cfg steward refresh list
+
+# Specific tenant
+cfg steward refresh list --tenant acme-corp
+```
+
+Output:
+
+```
+Pending refresh requests (2):
+
+PENDING ID              DEVICE ID          TENANT ID   SOURCE IP   STATUS   CREATED AT
+refresh-1750001234567   aabbccddeeff0011…  acme-corp   10.0.1.5    pending  2026-06-20T09:00:00Z
+refresh-1750009876543   aabbccddeeff0022…  acme-corp   10.0.1.6    pending  2026-06-20T09:05:00Z
+```
+
+### Approve a pending refresh request
+
+Approves the request, generates a new mTLS certificate for the steward, and stores
+the certificate bundle. The steward receives the bundle on its next poll.
+
+```bash
+cfg steward refresh approve refresh-1750001234567
+```
+
+### Reject a pending refresh request
+
+Rejects the request. The steward must re-initiate the challenge flow to get a new
+pending ID.
+
+```bash
+cfg steward refresh reject refresh-1750001234567
+cfg steward refresh reject refresh-1750001234567 --reason "Device decommissioned"
+```
+
+## Refresh Policy
+
+The refresh policy controls how the controller handles incoming refresh requests for
+a given tenant. It can be set per-tenant.
+
+### Policy modes
+
+| Mode               | Behaviour                                                                    |
+|--------------------|------------------------------------------------------------------------------|
+| `require_approval` | Queue all requests for manual operator review (default).                     |
+| `auto_accept`      | Approve automatically when the steward's provenance score is sufficient.     |
+| `reject`           | Deny all refresh requests for this tenant.                                   |
+
+### Get the current policy
+
+```bash
+cfg steward refresh policy get --tenant acme-corp
+```
+
+Output:
+
+```
+Tenant:           acme-corp
+Mode:             require_approval
+Max Dormancy:     disabled
+```
+
+### Set the policy
+
+```bash
+# Require manual approval (default)
+cfg steward refresh policy set --mode require_approval --tenant acme-corp
+
+# Auto-accept when provenance matches
+cfg steward refresh policy set --mode auto_accept --tenant acme-corp
+
+# Auto-accept with a 90-day dormancy backstop
+cfg steward refresh policy set --mode auto_accept --max-dormancy-days 90 --set-dormancy --tenant acme-corp
+
+# Reject all refresh requests
+cfg steward refresh policy set --mode reject --tenant acme-corp
+```
+
+### Max dormancy days
+
+`--max-dormancy-days` sets a cap on how long a steward may remain offline before its
+refresh request is auto-rejected regardless of mode. When `0` or not set, the dormancy
+backstop is disabled.
+
+To explicitly disable a previously set dormancy limit, pass `--max-dormancy-days 0
+--set-dormancy`.
+
+## REST API
+
+These commands communicate with the following authenticated REST endpoints. All
+endpoints require a valid API key with the matching permission.
+
+| Method | Path                                              | Permission           | Description                    |
+|--------|---------------------------------------------------|----------------------|--------------------------------|
+| GET    | `/api/v1/stewards/refresh/pending`                | `refresh:list-pending` | List pending refresh requests  |
+| POST   | `/api/v1/stewards/refresh/{pending_id}/approve`   | `refresh:approve`    | Approve a pending request      |
+| POST   | `/api/v1/stewards/refresh/{pending_id}/reject`    | `refresh:reject`     | Reject a pending request       |
+| GET    | `/api/v1/tenants/{tenant_id}/refresh-policy`      | `refresh:get-policy` | Get the per-tenant policy      |
+| PUT    | `/api/v1/tenants/{tenant_id}/refresh-policy`      | `refresh:set-policy` | Set the per-tenant policy      |
+
+### Example: approve via REST
+
+```bash
+curl -s -X POST \
+  -H "X-API-Key: $CFGMS_API_KEY" \
+  https://controller.example.com/api/v1/stewards/refresh/refresh-1750001234567/approve \
+  | jq '{status, pending_id, client_cert_present: (.client_cert != null)}'
+```
+
+### Example: set policy via REST
+
+```bash
+curl -s -X PUT \
+  -H "X-API-Key: $CFGMS_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"mode":"auto_accept","max_dormancy_days":90}' \
+  https://controller.example.com/api/v1/tenants/acme-corp/refresh-policy
+```
+
+## Global flags
+
+All `cfg steward refresh` subcommands accept these flags (or the equivalent
+environment variables):
+
+| Flag              | Env var              | Description                               |
+|-------------------|----------------------|-------------------------------------------|
+| `--api-url`       | `CFGMS_API_URL`      | Controller REST API URL                   |
+| `--api-key`       | `CFGMS_API_KEY`      | API key for authentication                |
+| `--tls-ca-cert`   | `CFGMS_TLS_CA_CERT`  | Path to CA certificate for TLS            |
+| `--tls-insecure`  | `CFGMS_TLS_INSECURE` | Skip TLS verification (development only)  |

--- a/features/controller/api/handlers_registration_refresh.go
+++ b/features/controller/api/handlers_registration_refresh.go
@@ -12,6 +12,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/gorilla/mux"
@@ -19,6 +20,7 @@ import (
 	"github.com/cfgis/cfgms/features/controller/registration"
 	"github.com/cfgis/cfgms/pkg/audit"
 	"github.com/cfgis/cfgms/pkg/cert"
+	"github.com/cfgis/cfgms/pkg/ctxkeys"
 	"github.com/cfgis/cfgms/pkg/logging"
 	business "github.com/cfgis/cfgms/pkg/storage/interfaces/business"
 )
@@ -513,6 +515,374 @@ func (s *Server) buildRefreshClaimResponse(ctx context.Context, record *business
 		"validity_days", validityDays)
 
 	return resp, nil
+}
+
+// ---- Admin request / response types -----------------------------------------
+
+// AdminRefreshApproveRequest is the optional body for the admin approve endpoint.
+type AdminRefreshApproveRequest struct {
+	Reason string `json:"reason,omitempty"`
+}
+
+// AdminRefreshApproveResponse is returned by POST /api/v1/stewards/refresh/{pending_id}/approve.
+type AdminRefreshApproveResponse struct {
+	Status      string `json:"status"`
+	PendingID   string `json:"pending_id"`
+	ClientCert  string `json:"client_cert,omitempty"`
+	ClientKey   string `json:"client_key,omitempty"`
+	CACert      string `json:"ca_cert,omitempty"`
+	SigningCert string `json:"signing_cert,omitempty"`
+}
+
+// AdminRefreshRejectRequest is the body for the admin reject endpoint.
+type AdminRefreshRejectRequest struct {
+	Reason string `json:"reason,omitempty"`
+}
+
+// AdminRefreshPolicyRequest is the body for PUT /api/v1/tenants/{id}/refresh-policy.
+type AdminRefreshPolicyRequest struct {
+	Mode            string `json:"mode"`
+	MaxDormancyDays *int   `json:"max_dormancy_days,omitempty"`
+}
+
+// AdminRefreshPolicyResponse is returned by GET /api/v1/tenants/{id}/refresh-policy.
+type AdminRefreshPolicyResponse struct {
+	TenantID        string `json:"tenant_id"`
+	Mode            string `json:"mode"`
+	MaxDormancyDays *int   `json:"max_dormancy_days,omitempty"`
+}
+
+// APIPendingRefreshEntry is the wire representation of a pending refresh entry.
+type APIPendingRefreshEntry struct {
+	PendingID               string    `json:"pending_id"`
+	DeviceID                string    `json:"device_id"`
+	TenantID                string    `json:"tenant_id"`
+	SourceIP                string    `json:"source_ip"`
+	ProvenanceMatchedFields int       `json:"provenance_matched_fields"`
+	ProvenanceTotalFields   int       `json:"provenance_total_fields"`
+	Status                  string    `json:"status"`
+	CreatedAt               time.Time `json:"created_at"`
+	ExpiresAt               time.Time `json:"expires_at"`
+}
+
+// ---- Admin handlers ----------------------------------------------------------
+
+// handleListPendingRefreshes handles GET /api/v1/stewards/refresh/pending.
+// Requires "refresh:list-pending" permission.
+func (s *Server) handleListPendingRefreshes(w http.ResponseWriter, r *http.Request) {
+	if s.pendingRefreshStore == nil {
+		http.Error(w, "pending refresh store unavailable", http.StatusServiceUnavailable)
+		return
+	}
+
+	// TenantID is always taken from the authenticated context for scoped callers;
+	// unscoped admins (TenantID=="") may use the query param to filter.
+	callerTenant, _ := r.Context().Value(ctxkeys.TenantID).(string)
+	tenantID := callerTenant
+	if tenantID == "" {
+		tenantID = r.URL.Query().Get("tenant_id")
+	}
+
+	entries, err := s.pendingRefreshStore.ListPendingRefresh(r.Context(), tenantID)
+	if err != nil {
+		s.logger.Error("Failed to list pending refreshes", "error", err)
+		http.Error(w, "failed to list pending refreshes", http.StatusInternalServerError)
+		return
+	}
+
+	out := make([]APIPendingRefreshEntry, 0, len(entries))
+	for _, e := range entries {
+		out = append(out, APIPendingRefreshEntry{
+			PendingID:               e.PendingID,
+			DeviceID:                e.DeviceID,
+			TenantID:                e.TenantID,
+			SourceIP:                e.SourceIP,
+			ProvenanceMatchedFields: e.ProvenanceMatchedFields,
+			ProvenanceTotalFields:   e.ProvenanceTotalFields,
+			Status:                  e.Status,
+			CreatedAt:               e.CreatedAt,
+			ExpiresAt:               e.ExpiresAt,
+		})
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(out); err != nil {
+		s.logger.Error("Failed to encode pending refreshes", "error", err)
+	}
+}
+
+// handleApproveRefresh handles POST /api/v1/stewards/refresh/{pending_id}/approve.
+// Generates a cert bundle for the steward, stores it, sets status to approved, and
+// emits an audit event. The cert bundle is returned to the caller and stored for
+// delivery on the steward's next poll.
+func (s *Server) handleApproveRefresh(w http.ResponseWriter, r *http.Request) {
+	pendingID := mux.Vars(r)["pending_id"]
+
+	var req AdminRefreshApproveRequest
+	_ = json.NewDecoder(r.Body).Decode(&req)
+
+	if s.pendingRefreshStore == nil {
+		http.Error(w, "pending refresh store unavailable", http.StatusServiceUnavailable)
+		return
+	}
+
+	entry, err := s.pendingRefreshStore.GetPendingRefreshByID(r.Context(), pendingID)
+	if err != nil {
+		if err == business.ErrPendingRefreshNotFound {
+			http.Error(w, "pending refresh not found", http.StatusNotFound)
+			return
+		}
+		s.logger.Error("Failed to get pending refresh", "pending_id", logging.SanitizeLogValue(pendingID), "error", err)
+		http.Error(w, "failed to get pending refresh", http.StatusInternalServerError)
+		return
+	}
+
+	if entry.Status != business.PendingRefreshStatusPending {
+		http.Error(w, "refresh request is not in pending state", http.StatusConflict)
+		return
+	}
+
+	// Cross-tenant: a scoped caller may only approve refreshes within their tenant hierarchy.
+	callerTenant, _ := r.Context().Value(ctxkeys.TenantID).(string)
+	if callerTenant != "" {
+		sameTenant := entry.TenantID == callerTenant
+		ancestorTenant := strings.HasPrefix(entry.TenantID, callerTenant+"/")
+		if !sameTenant && !ancestorTenant {
+			// 404 to avoid disclosing existence of pending refreshes across tenants.
+			http.Error(w, "pending refresh not found", http.StatusNotFound)
+			return
+		}
+	}
+
+	if s.stewardStore == nil {
+		http.Error(w, "steward store unavailable", http.StatusServiceUnavailable)
+		return
+	}
+
+	record, err := s.stewardStore.GetStewardByDeviceID(r.Context(), entry.DeviceID)
+	if err != nil {
+		if err == business.ErrStewardNotFound {
+			s.emitRefreshAudit(r.Context(), entry.DeviceID, entry.TenantID,
+				business.AuditEventSystemEvent, "refresh_admin_approve_error",
+				business.AuditResultError, business.AuditSeverityHigh,
+				map[string]interface{}{"pending_id": logging.SanitizeLogValue(pendingID), "reason": "steward_not_found"})
+			http.Error(w, "steward not found", http.StatusNotFound)
+			return
+		}
+		s.logger.Error("Failed to get steward for refresh approval", "device_id", logging.SanitizeLogValue(entry.DeviceID), "error", err)
+		s.emitRefreshAudit(r.Context(), entry.DeviceID, entry.TenantID,
+			business.AuditEventSystemEvent, "refresh_admin_approve_error",
+			business.AuditResultError, business.AuditSeverityHigh,
+			map[string]interface{}{"pending_id": logging.SanitizeLogValue(pendingID), "reason": "store_error"})
+		http.Error(w, "failed to get steward", http.StatusInternalServerError)
+		return
+	}
+
+	certResp, err := s.buildRefreshClaimResponse(r.Context(), record)
+	if err != nil {
+		s.logger.Error("Failed to build refresh cert for approval", "pending_id", logging.SanitizeLogValue(pendingID), "error", err)
+		s.emitRefreshAudit(r.Context(), entry.DeviceID, entry.TenantID,
+			business.AuditEventSystemEvent, "refresh_admin_approve_error",
+			business.AuditResultError, business.AuditSeverityHigh,
+			map[string]interface{}{"pending_id": logging.SanitizeLogValue(pendingID), "reason": "cert_issuance_failed"})
+		http.Error(w, "failed to issue certificate", http.StatusInternalServerError)
+		return
+	}
+
+	bundle, err := json.Marshal(certResp)
+	if err != nil {
+		s.logger.Error("Failed to marshal claim bundle", "pending_id", logging.SanitizeLogValue(pendingID), "error", err)
+		http.Error(w, "internal error serializing cert bundle", http.StatusInternalServerError)
+		return
+	}
+
+	if err := s.pendingRefreshStore.StoreClaimBundle(r.Context(), pendingID, bundle); err != nil {
+		s.logger.Error("Failed to store claim bundle", "pending_id", logging.SanitizeLogValue(pendingID), "error", err)
+		http.Error(w, "failed to store claim bundle", http.StatusInternalServerError)
+		return
+	}
+
+	if err := s.pendingRefreshStore.UpdateRefreshStatus(r.Context(), pendingID, business.PendingRefreshStatusApproved); err != nil {
+		s.logger.Error("Failed to update refresh status to approved", "pending_id", logging.SanitizeLogValue(pendingID), "error", err)
+		http.Error(w, "failed to update refresh status", http.StatusInternalServerError)
+		return
+	}
+
+	s.emitRefreshAudit(r.Context(), entry.DeviceID, entry.TenantID,
+		business.AuditEventAuthentication, "refresh_admin_approved",
+		business.AuditResultSuccess, business.AuditSeverityHigh,
+		map[string]interface{}{
+			"pending_id": logging.SanitizeLogValue(pendingID),
+			"device_id":  logging.SanitizeLogValue(entry.DeviceID),
+			"tenant_id":  logging.SanitizeLogValue(entry.TenantID),
+			"decision":   "approved",
+			"reason":     logging.SanitizeLogValue(req.Reason),
+		})
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	if err := json.NewEncoder(w).Encode(AdminRefreshApproveResponse{
+		Status:      "approved",
+		PendingID:   pendingID,
+		ClientCert:  certResp.ClientCert,
+		ClientKey:   certResp.ClientKey,
+		CACert:      certResp.CACert,
+		SigningCert: certResp.SigningCert,
+	}); err != nil {
+		s.logger.Error("Failed to encode approve response", "error", err)
+	}
+}
+
+// handleRejectRefresh handles POST /api/v1/stewards/refresh/{pending_id}/reject.
+// Sets status to rejected and emits an audit event.
+func (s *Server) handleRejectRefresh(w http.ResponseWriter, r *http.Request) {
+	pendingID := mux.Vars(r)["pending_id"]
+
+	var req AdminRefreshRejectRequest
+	_ = json.NewDecoder(r.Body).Decode(&req)
+
+	if s.pendingRefreshStore == nil {
+		http.Error(w, "pending refresh store unavailable", http.StatusServiceUnavailable)
+		return
+	}
+
+	entry, err := s.pendingRefreshStore.GetPendingRefreshByID(r.Context(), pendingID)
+	if err != nil {
+		if err == business.ErrPendingRefreshNotFound {
+			http.Error(w, "pending refresh not found", http.StatusNotFound)
+			return
+		}
+		s.logger.Error("Failed to get pending refresh for rejection", "pending_id", logging.SanitizeLogValue(pendingID), "error", err)
+		http.Error(w, "failed to get pending refresh", http.StatusInternalServerError)
+		return
+	}
+
+	if entry.Status != business.PendingRefreshStatusPending {
+		http.Error(w, "refresh request is not in pending state", http.StatusConflict)
+		return
+	}
+
+	// Cross-tenant: a scoped caller may only reject refreshes within their tenant hierarchy.
+	callerTenant, _ := r.Context().Value(ctxkeys.TenantID).(string)
+	if callerTenant != "" {
+		sameTenant := entry.TenantID == callerTenant
+		ancestorTenant := strings.HasPrefix(entry.TenantID, callerTenant+"/")
+		if !sameTenant && !ancestorTenant {
+			http.Error(w, "pending refresh not found", http.StatusNotFound)
+			return
+		}
+	}
+
+	if err := s.pendingRefreshStore.UpdateRefreshStatus(r.Context(), pendingID, business.PendingRefreshStatusRejected); err != nil {
+		s.logger.Error("Failed to update refresh status to rejected", "pending_id", logging.SanitizeLogValue(pendingID), "error", err)
+		http.Error(w, "failed to update refresh status", http.StatusInternalServerError)
+		return
+	}
+
+	s.emitRefreshAudit(r.Context(), entry.DeviceID, entry.TenantID,
+		business.AuditEventSecurityEvent, "refresh_admin_rejected",
+		business.AuditResultDenied, business.AuditSeverityMedium,
+		map[string]interface{}{
+			"pending_id": logging.SanitizeLogValue(pendingID),
+			"device_id":  logging.SanitizeLogValue(entry.DeviceID),
+			"tenant_id":  logging.SanitizeLogValue(entry.TenantID),
+			"decision":   "rejected",
+			"reason":     logging.SanitizeLogValue(req.Reason),
+		})
+
+	w.WriteHeader(http.StatusOK)
+}
+
+// handleGetRefreshPolicy handles GET /api/v1/tenants/{id}/refresh-policy.
+func (s *Server) handleGetRefreshPolicy(w http.ResponseWriter, r *http.Request) {
+	tenantID := mux.Vars(r)["id"]
+
+	// Cross-tenant: a scoped caller may only read policy for their own tenant hierarchy.
+	callerTenant, _ := r.Context().Value(ctxkeys.TenantID).(string)
+	if callerTenant != "" {
+		sameTenant := tenantID == callerTenant
+		ancestorTenant := strings.HasPrefix(tenantID, callerTenant+"/")
+		if !sameTenant && !ancestorTenant {
+			http.Error(w, "tenant not found", http.StatusNotFound)
+			return
+		}
+	}
+
+	if s.refreshPolicyStore == nil {
+		http.Error(w, "refresh policy store unavailable", http.StatusServiceUnavailable)
+		return
+	}
+
+	policy, err := s.refreshPolicyStore.GetPolicy(r.Context(), tenantID)
+	if err != nil {
+		s.logger.Error("Failed to get refresh policy", "tenant_id", logging.SanitizeLogValue(tenantID), "error", err)
+		http.Error(w, "failed to get refresh policy", http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(AdminRefreshPolicyResponse{
+		TenantID:        policy.TenantID,
+		Mode:            policy.Mode,
+		MaxDormancyDays: policy.MaxDormancyDays,
+	}); err != nil {
+		s.logger.Error("Failed to encode refresh policy", "error", err)
+	}
+}
+
+// handleSetRefreshPolicy handles PUT /api/v1/tenants/{id}/refresh-policy.
+func (s *Server) handleSetRefreshPolicy(w http.ResponseWriter, r *http.Request) {
+	tenantID := mux.Vars(r)["id"]
+
+	// Cross-tenant: a scoped caller may only write policy for their own tenant hierarchy.
+	callerTenant, _ := r.Context().Value(ctxkeys.TenantID).(string)
+	if callerTenant != "" {
+		sameTenant := tenantID == callerTenant
+		ancestorTenant := strings.HasPrefix(tenantID, callerTenant+"/")
+		if !sameTenant && !ancestorTenant {
+			http.Error(w, "tenant not found", http.StatusNotFound)
+			return
+		}
+	}
+
+	var req AdminRefreshPolicyRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "invalid request body", http.StatusBadRequest)
+		return
+	}
+
+	switch req.Mode {
+	case "auto_accept", "require_approval", "reject":
+	default:
+		http.Error(w, "invalid mode: must be auto_accept, require_approval, or reject", http.StatusBadRequest)
+		return
+	}
+
+	if s.refreshPolicyStore == nil {
+		http.Error(w, "refresh policy store unavailable", http.StatusServiceUnavailable)
+		return
+	}
+
+	policy := &business.RefreshPolicy{
+		TenantID:        tenantID,
+		Mode:            req.Mode,
+		MaxDormancyDays: req.MaxDormancyDays,
+	}
+	if err := s.refreshPolicyStore.SetPolicy(r.Context(), policy); err != nil {
+		s.logger.Error("Failed to set refresh policy", "tenant_id", logging.SanitizeLogValue(tenantID), "error", err)
+		http.Error(w, "failed to set refresh policy", http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	if err := json.NewEncoder(w).Encode(AdminRefreshPolicyResponse{
+		TenantID:        tenantID,
+		Mode:            req.Mode,
+		MaxDormancyDays: req.MaxDormancyDays,
+	}); err != nil {
+		s.logger.Error("Failed to encode refresh policy response", "error", err)
+	}
 }
 
 // emitRefreshAudit records a registration-refresh audit event.

--- a/features/controller/api/handlers_registration_refresh_test.go
+++ b/features/controller/api/handlers_registration_refresh_test.go
@@ -139,13 +139,15 @@ func (s *testPendingRefreshStore) UpdateRefreshStatus(_ context.Context, id, sta
 	}
 	return nil
 }
-func (s *testPendingRefreshStore) ListPendingRefresh(_ context.Context, _ string) ([]*business.PendingRefreshEntry, error) {
+func (s *testPendingRefreshStore) ListPendingRefresh(_ context.Context, tenantID string) ([]*business.PendingRefreshEntry, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	out := make([]*business.PendingRefreshEntry, 0, len(s.entries))
 	for _, e := range s.entries {
-		cp := *e
-		out = append(out, &cp)
+		if tenantID == "" || e.TenantID == tenantID {
+			cp := *e
+			out = append(out, &cp)
+		}
 	}
 	return out, nil
 }
@@ -719,6 +721,435 @@ func TestProvenance_CannotUngateRevoked(t *testing.T) {
 
 	assert.Equal(t, http.StatusForbidden, rec.Code)
 	assert.Equal(t, 0, verifier.callCount(), "PoP must not be called for revoked device")
+}
+
+// ---- Admin handler tests ----------------------------------------------------
+
+// newRefreshAdminTestServer builds a Server with a cert manager for admin handler tests.
+func newRefreshAdminTestServer(
+	t *testing.T,
+	stewardSt *testStewardStore,
+	pendingRefreshSt *testPendingRefreshStore,
+	policyStore business.RefreshPolicyStore,
+) (*Server, *audit.Manager) {
+	t.Helper()
+	t.Setenv("CFGMS_SECRETS_REPO_PATH", t.TempDir())
+
+	cfg := config.DefaultConfig()
+	cfg.Certificate.EnableCertManagement = false
+
+	storageManager := pkgtesting.SetupTestStorage(t)
+	auditMgr, err := audit.NewManager(storageManager.GetAuditStore(), "controller")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = auditMgr.Stop(context.Background()) })
+
+	logger := logging.NewNoopLogger()
+
+	rbacManager := rbac.NewManagerWithStorage(
+		storageManager.GetAuditStore(),
+		storageManager.GetClientTenantStore(),
+		storageManager.GetRBACStore(),
+	)
+	require.NoError(t, rbacManager.Initialize(context.Background()))
+	t.Cleanup(func() {
+		closeCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_ = rbacManager.Close(closeCtx)
+	})
+
+	tenantStore := tenant.NewStorageAdapter(storageManager.GetTenantStore())
+	tenantManager := tenant.NewManager(tenantStore, rbacManager)
+	controllerService := service.NewControllerService(logger)
+	configService := service.NewConfigurationServiceV2(logger, storageManager, controllerService)
+	rbacService := service.NewRBACService(rbacManager)
+
+	certMgr := newTestCertManager(t)
+
+	server, err := New(
+		cfg, logger,
+		controllerService, configService, nil, rbacService,
+		certMgr, tenantManager, rbacManager,
+		nil, nil,
+		newTestRegistrationStore(t),
+		"", nil,
+		auditMgr,
+		nil, nil, nil,
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_ = server.Close(ctx)
+	})
+
+	server.SetStewardStore(stewardSt)
+	if pendingRefreshSt != nil {
+		server.SetPendingRefreshStore(pendingRefreshSt)
+	}
+	if policyStore != nil {
+		server.SetRefreshPolicyStore(policyStore)
+	}
+
+	return server, auditMgr
+}
+
+func TestHandleRefreshApprove_Unauthenticated(t *testing.T) {
+	server := setupTestServer(t)
+	server.SetStewardStore(newTestStewardStore())
+	server.SetPendingRefreshStore(newTestPendingRefreshStore())
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/stewards/refresh/some-pending-id/approve", nil)
+	rec := httptest.NewRecorder()
+	server.router.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusUnauthorized, rec.Code)
+}
+
+func TestHandleRefreshApprove_ApprovesEntry(t *testing.T) {
+	pub, _ := newTestEd25519KeyPair(t)
+	ss := newTestStewardStore()
+	ss.add(&business.StewardRecord{
+		ID:             "steward-approve",
+		DeviceID:       testDeviceID,
+		TenantID:       testTenantID,
+		Status:         business.StewardStatusActive,
+		IdentityKeyPub: []byte(pub),
+	})
+
+	prs := newTestPendingRefreshStore()
+	pendingID := "refresh-approve-test"
+	require.NoError(t, prs.AddPendingRefresh(context.Background(), &business.PendingRefreshEntry{
+		PendingID: pendingID,
+		DeviceID:  testDeviceID,
+		TenantID:  testTenantID,
+		Status:    business.PendingRefreshStatusPending,
+		CreatedAt: time.Now().UTC(),
+		ExpiresAt: time.Now().UTC().Add(7 * 24 * time.Hour),
+	}))
+
+	server, auditMgr := newRefreshAdminTestServer(t, ss, prs, newTestRefreshPolicyStore())
+	apiKey := NewTestKey(t, server, []string{"refresh:approve"})
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/stewards/refresh/"+pendingID+"/approve", nil)
+	req.Header.Set("X-API-Key", apiKey)
+	rec := httptest.NewRecorder()
+	server.router.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code, "approve must succeed: %s", rec.Body.String())
+
+	var resp AdminRefreshApproveResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Equal(t, "approved", resp.Status)
+	assert.Equal(t, pendingID, resp.PendingID)
+	assert.NotEmpty(t, resp.ClientCert, "client cert must be in response")
+	assert.NotEmpty(t, resp.ClientKey, "client key must be in response")
+	assert.NotEmpty(t, resp.CACert, "CA cert must be in response")
+
+	// Verify the store was updated.
+	updated, err := prs.GetPendingRefreshByID(context.Background(), pendingID)
+	require.NoError(t, err)
+	assert.Equal(t, business.PendingRefreshStatusApproved, updated.Status)
+	assert.NotNil(t, updated.ClaimBundle, "claim bundle must be stored")
+
+	// Verify audit event was emitted.
+	require.NoError(t, auditMgr.Flush(context.Background()))
+	entries, err := auditMgr.QueryEntries(context.Background(), &business.AuditFilter{})
+	require.NoError(t, err)
+	found := false
+	for _, e := range entries {
+		if e.Action == "refresh_admin_approved" {
+			assert.NotEmpty(t, e.Details["device_id"], "device_id in audit")
+			assert.NotEmpty(t, e.Details["tenant_id"], "tenant_id in audit")
+			assert.Equal(t, "approved", e.Details["decision"])
+			found = true
+			break
+		}
+	}
+	assert.True(t, found, "refresh_admin_approved audit event expected")
+}
+
+func TestHandleRefreshReject_RejectsEntry(t *testing.T) {
+	pub, _ := newTestEd25519KeyPair(t)
+	ss := newTestStewardStore()
+	ss.add(&business.StewardRecord{
+		ID:             "steward-reject",
+		DeviceID:       testDeviceID,
+		TenantID:       testTenantID,
+		Status:         business.StewardStatusActive,
+		IdentityKeyPub: []byte(pub),
+	})
+
+	prs := newTestPendingRefreshStore()
+	pendingID := "refresh-reject-test"
+	require.NoError(t, prs.AddPendingRefresh(context.Background(), &business.PendingRefreshEntry{
+		PendingID: pendingID,
+		DeviceID:  testDeviceID,
+		TenantID:  testTenantID,
+		Status:    business.PendingRefreshStatusPending,
+		CreatedAt: time.Now().UTC(),
+		ExpiresAt: time.Now().UTC().Add(7 * 24 * time.Hour),
+	}))
+
+	server, auditMgr := newRefreshAdminTestServer(t, ss, prs, newTestRefreshPolicyStore())
+	apiKey := NewTestKey(t, server, []string{"refresh:reject"})
+
+	body, _ := json.Marshal(AdminRefreshRejectRequest{Reason: "unauthorized device"})
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/stewards/refresh/"+pendingID+"/reject", bytes.NewReader(body))
+	req.Header.Set("X-API-Key", apiKey)
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	server.router.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code, "reject must succeed: %s", rec.Body.String())
+
+	updated, err := prs.GetPendingRefreshByID(context.Background(), pendingID)
+	require.NoError(t, err)
+	assert.Equal(t, business.PendingRefreshStatusRejected, updated.Status)
+
+	require.NoError(t, auditMgr.Flush(context.Background()))
+	entries, err := auditMgr.QueryEntries(context.Background(), &business.AuditFilter{})
+	require.NoError(t, err)
+	found := false
+	for _, e := range entries {
+		if e.Action == "refresh_admin_rejected" {
+			assert.Equal(t, "rejected", e.Details["decision"])
+			found = true
+			break
+		}
+	}
+	assert.True(t, found, "refresh_admin_rejected audit event expected")
+}
+
+func TestHandleListPendingRefreshes_ReturnsList(t *testing.T) {
+	ss := newTestStewardStore()
+	prs := newTestPendingRefreshStore()
+	require.NoError(t, prs.AddPendingRefresh(context.Background(), &business.PendingRefreshEntry{
+		PendingID: "refresh-list-1",
+		DeviceID:  testDeviceID,
+		TenantID:  testTenantID,
+		Status:    business.PendingRefreshStatusPending,
+		CreatedAt: time.Now().UTC(),
+		ExpiresAt: time.Now().UTC().Add(7 * 24 * time.Hour),
+	}))
+
+	server, _ := newRefreshAdminTestServer(t, ss, prs, newTestRefreshPolicyStore())
+	apiKey := NewTestKey(t, server, []string{"refresh:list-pending"})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/stewards/refresh/pending", nil)
+	req.Header.Set("X-API-Key", apiKey)
+	rec := httptest.NewRecorder()
+	server.router.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	var entries []APIPendingRefreshEntry
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &entries))
+	assert.Len(t, entries, 1)
+	assert.Equal(t, "refresh-list-1", entries[0].PendingID)
+}
+
+func TestHandleGetRefreshPolicy_ReturnsDefault(t *testing.T) {
+	server, _ := newRefreshAdminTestServer(t, newTestStewardStore(), nil, newTestRefreshPolicyStore())
+	server.SetRefreshPolicyStore(newTestRefreshPolicyStore())
+	apiKey := NewTestKey(t, server, []string{"refresh:get-policy"})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/tenants/"+testTenantID+"/refresh-policy", nil)
+	req.Header.Set("X-API-Key", apiKey)
+	rec := httptest.NewRecorder()
+	server.router.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code, "get-policy must succeed: %s", rec.Body.String())
+	var policy AdminRefreshPolicyResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &policy))
+	assert.Equal(t, testTenantID, policy.TenantID)
+	assert.Equal(t, "require_approval", policy.Mode)
+}
+
+func TestHandleSetRefreshPolicy_SetsMode(t *testing.T) {
+	ps := newTestRefreshPolicyStore()
+	server, _ := newRefreshAdminTestServer(t, newTestStewardStore(), nil, ps)
+	apiKey := NewTestKey(t, server, []string{"refresh:set-policy"})
+
+	body, _ := json.Marshal(AdminRefreshPolicyRequest{Mode: "auto_accept"})
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/tenants/"+testTenantID+"/refresh-policy", bytes.NewReader(body))
+	req.Header.Set("X-API-Key", apiKey)
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	server.router.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code, "set-policy must succeed: %s", rec.Body.String())
+
+	policy, err := ps.GetPolicy(context.Background(), testTenantID)
+	require.NoError(t, err)
+	assert.Equal(t, "auto_accept", policy.Mode)
+}
+
+func TestHandleSetRefreshPolicy_InvalidMode_Returns400(t *testing.T) {
+	server, _ := newRefreshAdminTestServer(t, newTestStewardStore(), nil, newTestRefreshPolicyStore())
+	apiKey := NewTestKey(t, server, []string{"refresh:set-policy"})
+
+	body, _ := json.Marshal(AdminRefreshPolicyRequest{Mode: "invalid_mode"})
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/tenants/"+testTenantID+"/refresh-policy", bytes.NewReader(body))
+	req.Header.Set("X-API-Key", apiKey)
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	server.router.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestHandleRefreshApprove_NotFound(t *testing.T) {
+	server, _ := newRefreshAdminTestServer(t, newTestStewardStore(), newTestPendingRefreshStore(), nil)
+	apiKey := NewTestKey(t, server, []string{"refresh:approve"})
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/stewards/refresh/nonexistent-id/approve", nil)
+	req.Header.Set("X-API-Key", apiKey)
+	rec := httptest.NewRecorder()
+	server.router.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+}
+
+func TestHandleRefreshReject_Unauthenticated(t *testing.T) {
+	server := setupTestServer(t)
+	server.SetStewardStore(newTestStewardStore())
+	server.SetPendingRefreshStore(newTestPendingRefreshStore())
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/stewards/refresh/some-id/reject", nil)
+	rec := httptest.NewRecorder()
+	server.router.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusUnauthorized, rec.Code)
+}
+
+// ---- Cross-tenant isolation tests for admin handlers -------------------------
+
+func TestHandleApproveRefresh_CrossTenantReturns404(t *testing.T) {
+	prs := newTestPendingRefreshStore()
+	pendingID := "refresh-cross-approve"
+	require.NoError(t, prs.AddPendingRefresh(context.Background(), &business.PendingRefreshEntry{
+		PendingID: pendingID,
+		DeviceID:  testDeviceID,
+		TenantID:  testTenantID, // belongs to "test-tenant"
+		Status:    business.PendingRefreshStatusPending,
+		CreatedAt: time.Now().UTC(),
+		ExpiresAt: time.Now().UTC().Add(7 * 24 * time.Hour),
+	}))
+
+	server, _ := newRefreshAdminTestServer(t, newTestStewardStore(), prs, nil)
+	// API key scoped to a different tenant.
+	apiKey := NewEphemeralTestKey(t, server, []string{"refresh:approve"}, "other-tenant", 5*time.Minute)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/stewards/refresh/"+pendingID+"/approve", nil)
+	req.Header.Set("X-API-Key", apiKey)
+	rec := httptest.NewRecorder()
+	server.router.ServeHTTP(rec, req)
+
+	// 404 rather than 403 to avoid disclosing pending-refresh existence across tenants.
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+
+	// Entry must remain pending — nothing was mutated.
+	entry, err := prs.GetPendingRefreshByID(context.Background(), pendingID)
+	require.NoError(t, err)
+	assert.Equal(t, business.PendingRefreshStatusPending, entry.Status)
+}
+
+func TestHandleRejectRefresh_CrossTenantReturns404(t *testing.T) {
+	prs := newTestPendingRefreshStore()
+	pendingID := "refresh-cross-reject"
+	require.NoError(t, prs.AddPendingRefresh(context.Background(), &business.PendingRefreshEntry{
+		PendingID: pendingID,
+		DeviceID:  testDeviceID,
+		TenantID:  testTenantID, // belongs to "test-tenant"
+		Status:    business.PendingRefreshStatusPending,
+		CreatedAt: time.Now().UTC(),
+		ExpiresAt: time.Now().UTC().Add(7 * 24 * time.Hour),
+	}))
+
+	server, _ := newRefreshAdminTestServer(t, newTestStewardStore(), prs, nil)
+	// API key scoped to a different tenant.
+	apiKey := NewEphemeralTestKey(t, server, []string{"refresh:reject"}, "other-tenant", 5*time.Minute)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/stewards/refresh/"+pendingID+"/reject", nil)
+	req.Header.Set("X-API-Key", apiKey)
+	rec := httptest.NewRecorder()
+	server.router.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+
+	// Entry must remain pending — nothing was mutated.
+	entry, err := prs.GetPendingRefreshByID(context.Background(), pendingID)
+	require.NoError(t, err)
+	assert.Equal(t, business.PendingRefreshStatusPending, entry.Status)
+}
+
+func TestHandleListPendingRefreshes_ScopedCallerSeesOnlyOwnTenant(t *testing.T) {
+	prs := newTestPendingRefreshStore()
+	require.NoError(t, prs.AddPendingRefresh(context.Background(), &business.PendingRefreshEntry{
+		PendingID: "refresh-own-tenant",
+		DeviceID:  testDeviceID,
+		TenantID:  testTenantID, // caller's own tenant
+		Status:    business.PendingRefreshStatusPending,
+		CreatedAt: time.Now().UTC(),
+		ExpiresAt: time.Now().UTC().Add(7 * 24 * time.Hour),
+	}))
+	require.NoError(t, prs.AddPendingRefresh(context.Background(), &business.PendingRefreshEntry{
+		PendingID: "refresh-other-tenant",
+		DeviceID:  "bbbbbbbbbbbbbbbb",
+		TenantID:  "other-tenant", // another tenant's entry
+		Status:    business.PendingRefreshStatusPending,
+		CreatedAt: time.Now().UTC(),
+		ExpiresAt: time.Now().UTC().Add(7 * 24 * time.Hour),
+	}))
+
+	server, _ := newRefreshAdminTestServer(t, newTestStewardStore(), prs, newTestRefreshPolicyStore())
+	// Key scoped to testTenantID — must only see its own entries regardless of query param.
+	apiKey := NewTestKey(t, server, []string{"refresh:list-pending"})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/stewards/refresh/pending", nil)
+	req.Header.Set("X-API-Key", apiKey)
+	rec := httptest.NewRecorder()
+	server.router.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	var entries []APIPendingRefreshEntry
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &entries))
+	require.Len(t, entries, 1, "scoped caller must only see own-tenant entries")
+	assert.Equal(t, testTenantID, entries[0].TenantID)
+	assert.Equal(t, "refresh-own-tenant", entries[0].PendingID)
+}
+
+func TestHandleGetRefreshPolicy_CrossTenantReturns404(t *testing.T) {
+	server, _ := newRefreshAdminTestServer(t, newTestStewardStore(), nil, newTestRefreshPolicyStore())
+	// Key scoped to "other-tenant" — must not read policy for testTenantID.
+	apiKey := NewEphemeralTestKey(t, server, []string{"refresh:get-policy"}, "other-tenant", 5*time.Minute)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/tenants/"+testTenantID+"/refresh-policy", nil)
+	req.Header.Set("X-API-Key", apiKey)
+	rec := httptest.NewRecorder()
+	server.router.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+}
+
+func TestHandleSetRefreshPolicy_CrossTenantReturns404(t *testing.T) {
+	ps := newTestRefreshPolicyStore()
+	server, _ := newRefreshAdminTestServer(t, newTestStewardStore(), nil, ps)
+	// Key scoped to "other-tenant" — must not write policy for testTenantID.
+	apiKey := NewEphemeralTestKey(t, server, []string{"refresh:set-policy"}, "other-tenant", 5*time.Minute)
+
+	body, _ := json.Marshal(AdminRefreshPolicyRequest{Mode: "reject"})
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/tenants/"+testTenantID+"/refresh-policy", bytes.NewReader(body))
+	req.Header.Set("X-API-Key", apiKey)
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	server.router.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+
+	// Policy for testTenantID must remain at default — nothing mutated.
+	policy, err := ps.GetPolicy(context.Background(), testTenantID)
+	require.NoError(t, err)
+	assert.Equal(t, "require_approval", policy.Mode)
 }
 
 func TestRefresh_NoPolicyDefault(t *testing.T) {

--- a/features/controller/api/server.go
+++ b/features/controller/api/server.go
@@ -531,6 +531,21 @@ func (s *Server) setupRouter() {
 	tenants.Handle("/{id}/config-source/test",
 		s.requirePermission("tenant", "manage")(http.HandlerFunc(s.handleConfigSourceTest))).Methods("POST")
 
+	// Refresh approval queue endpoints (Issue #2097). Registered on the api subrouter
+	// (not the stewards subrouter) so they are not confused with /{id} parameterized routes.
+	api.Handle("/stewards/refresh/pending",
+		s.requirePermission("refresh", "list-pending")(http.HandlerFunc(s.handleListPendingRefreshes))).Methods("GET")
+	api.Handle("/stewards/refresh/{pending_id}/approve",
+		s.requirePermission("refresh", "approve")(http.HandlerFunc(s.handleApproveRefresh))).Methods("POST")
+	api.Handle("/stewards/refresh/{pending_id}/reject",
+		s.requirePermission("refresh", "reject")(http.HandlerFunc(s.handleRejectRefresh))).Methods("POST")
+
+	// Per-tenant refresh policy endpoints (Issue #2097).
+	tenants.Handle("/{id}/refresh-policy",
+		s.requirePermission("refresh", "get-policy")(http.HandlerFunc(s.handleGetRefreshPolicy))).Methods("GET")
+	tenants.Handle("/{id}/refresh-policy",
+		s.requirePermission("refresh", "set-policy")(http.HandlerFunc(s.handleSetRefreshPolicy))).Methods("PUT")
+
 	// Installer artifact management endpoints (Issue #1702).
 	// Always registered — handlers return 503 when blobStore is nil (nil-safe by design).
 	installer := api.PathPrefix("/installer/artifacts").Subrouter()


### PR DESCRIPTION
## Summary

- Adds five `requirePermission`-gated REST endpoints on the controller for fleet administrators to manage the registration-refresh approval queue and per-tenant refresh policy
- Adds `cfg steward refresh` CLI subcommands (`list`, `approve`, `reject`, `policy get`, `policy set`) backed by the new REST surface via `APIClient`
- Enforces cross-tenant isolation on all five admin handlers: scoped API-key callers are constrained to their own tenant hierarchy; 404 (not 403) on cross-tenant access to avoid existence disclosure — consistent with the existing steward handler pattern

## Changes

**`features/controller/api/handlers_registration_refresh.go`** — five new admin handlers with `ctxkeys.TenantID` isolation on list (forces store filter to caller's tenant), approve/reject (404 on cross-tenant entry), and policy get/set (404 on cross-tenant tenant ID)

**`features/controller/api/server.go`** — route registrations on the `api` subrouter (not `stewards`) to avoid collision with `/{id}` parameterised routes

**`cmd/cfg/cmd/refresh.go`** + **`api_client.go`** + **`steward.go`** — CLI command tree and five API client methods

**`docs/deployment/steward-refresh-management.md`** — operator reference

## Test plan

- [ ] `TestHandleRefreshApprove_Unauthenticated` — 401 without API key
- [ ] `TestHandleRefreshApprove_ApprovesEntry` — 200, cert bundle, status=approved, claim bundle stored, audit emitted
- [ ] `TestHandleRejectRefresh_RejectsEntry` — 200, status=rejected, audit emitted
- [ ] `TestHandleListPendingRefreshes_ReturnsList` — 200, entries returned
- [ ] `TestHandleGetRefreshPolicy_ReturnsDefault` — 200, require_approval default
- [ ] `TestHandleSetRefreshPolicy_SetsMode` — 200, mode persisted
- [ ] `TestHandleSetRefreshPolicy_InvalidMode_Returns400` — 400 on bad mode
- [ ] `TestHandleRefreshApprove_NotFound` — 404 on missing pending ID
- [ ] `TestHandleApproveRefresh_CrossTenantReturns404` — 404, entry unmutated
- [ ] `TestHandleRejectRefresh_CrossTenantReturns404` — 404, entry unmutated
- [ ] `TestHandleListPendingRefreshes_ScopedCallerSeesOnlyOwnTenant` — scoped caller cannot see other-tenant entries
- [ ] `TestHandleGetRefreshPolicy_CrossTenantReturns404` — 404 on cross-tenant read
- [ ] `TestHandleSetRefreshPolicy_CrossTenantReturns404` — 404 on cross-tenant write, policy unmutated
- [ ] `make test-complete` passes

Fixes #2097

🤖 Generated with [Claude Code](https://claude.com/claude-code)