### PR TITLE
steward: periodic DNA refresh in controller-connected mode (Issue #1915)

### DIFF
--- a/cmd/steward/main.go
+++ b/cmd/steward/main.go
@@ -240,6 +240,11 @@ func runSteward(ctx context.Context, regToken, configPath string) error {
 		// convergence as an out-of-band optimization on top of the schedule.
 		transportCl.StartConvergenceLoop(runCtx)
 
+		// Start periodic DNA refresh loop. Re-collects system attributes on
+		// the configured interval and publishes delta updates so the controller
+		// fleet view stays current without requiring a full reconnect. (Issue #1915)
+		transportCl.StartDNARefreshLoop(runCtx)
+
 		// Wait for context cancellation (signal, SCM stop, or a pushed-upgrade
 		// graceful self-exit request via SetShutdownFunc → runCancel).
 		<-runCtx.Done()
@@ -877,17 +882,20 @@ func connectWithApprovedRegistration(
 	}
 
 	// Optionally load the local steward config to apply custom replay window,
-	// params-size limits, and upgrade policy. If no config file is found (the
-	// common case when the steward is purely controller-managed), defaults apply.
+	// params-size limits, upgrade policy, and DNA refresh interval.
+	// If no config file is found (the common case when the steward is purely
+	// controller-managed), defaults apply.
 	var commandReplayWindow time.Duration
 	var commandMaxParamsBytes int
 	var scriptSigning stewardconfig.ScriptSigningConfig
 	var upgradeAllowDowngrade bool
+	var dnaRefreshInterval time.Duration
 	if cfg, cfgErr := stewardconfig.LoadConfiguration(""); cfgErr == nil {
 		commandReplayWindow = cfg.Steward.SignedCommandReplayWindow
 		commandMaxParamsBytes = cfg.Steward.SignedCommandMaxParamsBytes
 		scriptSigning = cfg.Steward.ScriptSigning
 		upgradeAllowDowngrade = cfg.Steward.Upgrade.AllowDowngrade
+		dnaRefreshInterval = stewardconfig.GetDNARefreshInterval(cfg)
 	}
 
 	// Build cert.Manager and SecretStore for on-demand TLS cert loading and
@@ -908,6 +916,8 @@ func connectWithApprovedRegistration(
 		CertStoreDir:                certStoreDir,
 		UpgradeAllowDowngrade:       upgradeAllowDowngrade,
 		UpgradePublisherTrustStore:  buildTestPublisherTrustStore(logger),
+		DNARefreshInterval:          dnaRefreshInterval,
+		DNACollector:                newDNACollectorAdapter(logger),
 		Logger:                      logger,
 		IdentityPersistFunc: func(pems []string, at *time.Time) error {
 			cur, loadErr := loadIdentity(certStoreDir)
@@ -1010,10 +1020,12 @@ func tryReconnectWithStoredIdentity(ctx context.Context, certStoreDir, token str
 	var commandReplayWindow time.Duration
 	var commandMaxParamsBytes int
 	var upgradeAllowDowngradeReconnect bool
+	var dnaRefreshIntervalReconnect time.Duration
 	if cfg, cfgErr := stewardconfig.LoadConfiguration(""); cfgErr == nil {
 		commandReplayWindow = cfg.Steward.SignedCommandReplayWindow
 		commandMaxParamsBytes = cfg.Steward.SignedCommandMaxParamsBytes
 		upgradeAllowDowngradeReconnect = cfg.Steward.Upgrade.AllowDowngrade
+		dnaRefreshIntervalReconnect = stewardconfig.GetDNARefreshInterval(cfg)
 	}
 
 	transportClient, err := client.NewTransportClient(&client.TransportConfig{
@@ -1030,6 +1042,8 @@ func tryReconnectWithStoredIdentity(ctx context.Context, certStoreDir, token str
 		CertStoreDir:                certStoreDir,
 		UpgradeAllowDowngrade:       upgradeAllowDowngradeReconnect,
 		UpgradePublisherTrustStore:  buildTestPublisherTrustStore(logger),
+		DNARefreshInterval:          dnaRefreshIntervalReconnect,
+		DNACollector:                newDNACollectorAdapter(logger),
 		Logger:                      logger,
 		IdentityPersistFunc: func(pems []string, at *time.Time) error {
 			cur, loadErr := loadIdentity(certStoreDir)
@@ -1386,4 +1400,25 @@ func publishUpgradeLifecycleEvent(ctx context.Context, tc upgradeEventPublisher,
 	logger.Info("Upgrade lifecycle event (no control plane publish)",
 		"event_type", eventType, "version", version)
 	return nil
+}
+
+// dnaCollectorAdapter adapts dna.Collector to the client.DNACollector interface
+// by extracting the Attributes map from the proto DNA result. (Issue #1915)
+type dnaCollectorAdapter struct {
+	collector *dna.Collector
+}
+
+func newDNACollectorAdapter(logger logging.Logger) *dnaCollectorAdapter {
+	return &dnaCollectorAdapter{collector: dna.NewCollector(logger)}
+}
+
+func (a *dnaCollectorAdapter) CollectAttributes(ctx context.Context) (map[string]string, error) {
+	result, err := a.collector.Collect(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if result == nil {
+		return nil, nil
+	}
+	return result.Attributes, nil
 }

--- a/docs/deployment/steward.cfg
+++ b/docs/deployment/steward.cfg
@@ -33,6 +33,12 @@ steward:
   # Remove this field to run once and exit (useful for one-shot scripts).
   converge_interval: "30m"
 
+  # How often the steward re-collects system DNA (hostname, OS version, etc.)
+  # and publishes attribute deltas to the controller while connected.
+  # Only changed attributes are sent; unchanged attributes are suppressed.
+  # Default: 30m. Accepts Go duration strings (e.g. "15m", "1h").
+  # dna_refresh_interval: "30m"
+
   logging:
     level: "info"
     format: "text"

--- a/features/config/stewardtypes/stewardtypes_test.go
+++ b/features/config/stewardtypes/stewardtypes_test.go
@@ -233,6 +233,30 @@ func TestGetConvergeInterval_EmptyFallback(t *testing.T) {
 	assert.Equal(t, 30*time.Minute, GetConvergeInterval(cfg))
 }
 
+// --- GetDNARefreshInterval ---
+
+func TestGetDNARefreshInterval_ValidInterval(t *testing.T) {
+	cfg := StewardConfig{Steward: StewardSettings{DNARefreshInterval: "15m"}}
+	assert.Equal(t, 15*time.Minute, GetDNARefreshInterval(cfg))
+}
+
+func TestGetDNARefreshInterval_EmptyFallback(t *testing.T) {
+	cfg := StewardConfig{Steward: StewardSettings{}}
+	assert.Equal(t, 30*time.Minute, GetDNARefreshInterval(cfg))
+}
+
+func TestGetDNARefreshInterval_InvalidStringFallback(t *testing.T) {
+	cfg := StewardConfig{Steward: StewardSettings{DNARefreshInterval: "notaduration"}}
+	assert.Equal(t, 30*time.Minute, GetDNARefreshInterval(cfg),
+		"unparseable duration must fall back to 30m default")
+}
+
+func TestGetDNARefreshInterval_ZeroFallback(t *testing.T) {
+	cfg := StewardConfig{Steward: StewardSettings{DNARefreshInterval: "0s"}}
+	assert.Equal(t, 30*time.Minute, GetDNARefreshInterval(cfg),
+		"zero duration must fall back to 30m default")
+}
+
 // --- GetConfiguredModules ---
 
 func TestGetConfiguredModules_DeduplicatesModules(t *testing.T) {

--- a/features/config/stewardtypes/types.go
+++ b/features/config/stewardtypes/types.go
@@ -55,6 +55,11 @@ type StewardSettings struct {
 	// approval when the controller uses registration.workflow: manual (Issue #1899).
 	// Default is 24h. Set to 0 to use the default.
 	RegistrationPollTimeout time.Duration `yaml:"registration_poll_timeout,omitempty"`
+
+	// DNARefreshInterval is how often the steward re-collects and publishes DNA
+	// attribute deltas while connected to the controller (Issue #1915).
+	// Accepts Go duration strings (e.g. "30m", "1h"). Default: 30m.
+	DNARefreshInterval string `yaml:"dna_refresh_interval,omitempty"`
 }
 
 // UpgradeConfig holds upgrade-related steward policy settings. (Issue #1943)

--- a/features/config/stewardtypes/validation.go
+++ b/features/config/stewardtypes/validation.go
@@ -94,6 +94,16 @@ func ValidateConfiguration(config StewardConfig) error {
 		}
 	}
 
+	if config.Steward.DNARefreshInterval != "" {
+		d, err := time.ParseDuration(config.Steward.DNARefreshInterval)
+		if err != nil {
+			return fmt.Errorf("invalid dna_refresh_interval %q: must be a valid duration (e.g. \"30m\", \"15m\", \"1h\")", config.Steward.DNARefreshInterval)
+		}
+		if d <= 0 {
+			return fmt.Errorf("dna_refresh_interval must be positive, got %q", config.Steward.DNARefreshInterval)
+		}
+	}
+
 	if err := ValidateScriptSigningConfig(config.Steward.ScriptSigning); err != nil {
 		return fmt.Errorf("script_signing configuration invalid: %w", err)
 	}
@@ -186,6 +196,19 @@ func GetConvergeInterval(cfg StewardConfig) time.Duration {
 		return 30 * time.Minute
 	}
 	d, err := time.ParseDuration(cfg.Steward.ConvergeInterval)
+	if err != nil || d <= 0 {
+		return 30 * time.Minute
+	}
+	return d
+}
+
+// GetDNARefreshInterval returns the parsed DNA refresh interval.
+// Falls back to 30 minutes if the field is empty or unparseable.
+func GetDNARefreshInterval(cfg StewardConfig) time.Duration {
+	if cfg.Steward.DNARefreshInterval == "" {
+		return 30 * time.Minute
+	}
+	d, err := time.ParseDuration(cfg.Steward.DNARefreshInterval)
 	if err != nil || d <= 0 {
 		return 30 * time.Minute
 	}

--- a/features/steward/client/client_transport.go
+++ b/features/steward/client/client_transport.go
@@ -50,6 +50,13 @@ import (
 	"github.com/cfgis/cfgms/pkg/version"
 )
 
+// DNACollector is the interface used by the DNA refresh loop to re-collect
+// system attributes on each tick. Production code wraps dna.Collector; tests
+// inject a stub returning deterministic attribute maps without real I/O.
+type DNACollector interface {
+	CollectAttributes(ctx context.Context) (map[string]string, error)
+}
+
 // TransportClient represents the steward client using gRPC-over-QUIC for both
 // control plane and data plane communication with the controller.
 // Story #516: Connects once to transport_address for both CP and DP.
@@ -120,10 +127,10 @@ type TransportClient struct {
 	// Connection state — single flag for unified gRPC transport
 	connected bool
 
-	// disconnected guards the one-time close of heartbeatStop/convergenceStop in
-	// Disconnect. A pushed-upgrade graceful self-exit (Issue #2001) adds a second
-	// shutdown trigger path (runCancel → runCtx.Done → Disconnect), so Disconnect
-	// can now legitimately be invoked more than once; closing an already-closed
+	// disconnected guards the one-time close of heartbeatStop/convergenceStop/
+	// dnaRefreshStop in Disconnect. A pushed-upgrade graceful self-exit (Issue #2001)
+	// adds a second shutdown trigger path (runCancel → runCtx.Done → Disconnect), so
+	// Disconnect can now legitimately be invoked more than once; closing an already-closed
 	// channel panics, so the close is gated on this flag under c.mu.
 	disconnected bool
 
@@ -151,6 +158,13 @@ type TransportClient struct {
 	dnaMu            sync.RWMutex
 	currentDNAHash   string            // SHA-256 hash of most-recently observed DNA
 	lastPublishedDNA map[string]string // full DNA from the last PublishDNAUpdate call
+
+	// DNA refresh loop control (Issue #1915).
+	dnaRefreshInterval time.Duration
+	dnaRefreshStop     chan struct{}
+	// dnaCollector is the DNA collection implementation used by the refresh loop.
+	// Injectable for testing; production code uses dna.NewCollector.
+	dnaCollector DNACollector
 
 	// certStoreDir is the on-disk cert/identity directory. The upgrade handler
 	// downloads binaries to a subdirectory here. (Issue #1943)
@@ -339,6 +353,16 @@ type TransportConfig struct {
 	// only — production deployments leave this nil. (Issue #1948)
 	UpgradePublisherTrustStore trust.TrustStore
 
+	// DNARefreshInterval is how often the connected steward re-collects and
+	// publishes DNA attribute deltas (Issue #1915). Defaults to 30 minutes.
+	DNARefreshInterval time.Duration
+
+	// DNACollector is the implementation used by the DNA refresh loop to collect
+	// system attributes. When nil, the refresh loop is disabled (no collection
+	// is attempted). Injectable for testing — production code passes a real
+	// dna.Collector via main.go after registration.
+	DNACollector DNACollector
+
 	// Logger for client logging
 	Logger logging.Logger
 }
@@ -355,6 +379,11 @@ func NewTransportClient(cfg *TransportConfig) (*TransportClient, error) {
 	heartbeatInterval := cfg.HeartbeatInterval
 	if heartbeatInterval == 0 {
 		heartbeatInterval = 20 * time.Second // epic #1664: 20s base + [0,10s) jitter
+	}
+
+	dnaRefreshInterval := cfg.DNARefreshInterval
+	if dnaRefreshInterval == 0 {
+		dnaRefreshInterval = 30 * time.Minute
 	}
 
 	// Per-instance RNG for per-tick heartbeat jitter (epic #1664).
@@ -385,8 +414,11 @@ func NewTransportClient(cfg *TransportConfig) (*TransportClient, error) {
 		rng:                        rng,
 		heartbeatStop:              make(chan struct{}),
 		convergenceStop:            make(chan struct{}),
+		dnaRefreshStop:             make(chan struct{}),
 		convergeInterval:           30 * time.Minute,
 		convergeIntervalCh:         make(chan struct{}, 1),
+		dnaRefreshInterval:         dnaRefreshInterval,
+		dnaCollector:               cfg.DNACollector,
 		transportAddress:           cfg.ControllerURL,
 		certPath:                   cfg.TLSCertPath,
 		caCertPEM:                  cfg.CACertPEM,
@@ -1256,6 +1288,60 @@ func (c *TransportClient) TriggerConvergence(ctx context.Context) error {
 	return nil
 }
 
+// StartDNARefreshLoop starts a background goroutine that re-collects system DNA
+// attributes on the configured interval and publishes delta updates to the
+// controller when at least one attribute value has changed.
+//
+// If no DNACollector was provided, the loop exits immediately after logging a
+// warning. The loop exits cleanly when ctx is cancelled or Disconnect is called.
+// The existing 15-second graceful disconnect window applies — the loop does not
+// block shutdown. (Issue #1915)
+func (c *TransportClient) StartDNARefreshLoop(ctx context.Context) {
+	c.mu.RLock()
+	interval := c.dnaRefreshInterval
+	collector := c.dnaCollector
+	c.mu.RUnlock()
+
+	if collector == nil {
+		c.logger.Warn("DNA refresh loop started without a collector; DNA will not be refreshed periodically")
+		return
+	}
+
+	c.logger.Info("Starting DNA refresh loop", "interval", interval)
+	go func() {
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-c.dnaRefreshStop:
+				return
+			case <-ticker.C:
+				// Re-read collector on each tick so tests can inject a new
+				// implementation after the loop has started.
+				c.mu.RLock()
+				currentCollector := c.dnaCollector
+				c.mu.RUnlock()
+				if currentCollector == nil {
+					continue
+				}
+				attrs, err := currentCollector.CollectAttributes(ctx)
+				if err != nil {
+					c.logger.Warn("DNA refresh collection failed", "error", err)
+					continue
+				}
+				if len(attrs) == 0 {
+					continue
+				}
+				if err := c.PublishDNAUpdate(ctx, attrs, "", ""); err != nil {
+					c.logger.Warn("DNA refresh publish failed", "error", err)
+				}
+			}
+		}
+	}()
+}
+
 // SetShutdownFunc wires the graceful-shutdown trigger used after a successful
 // push_steward_binary swap. In production main.go passes the steward's RUN
 // context (runCtx) and its cancel func (runCancel) so a pushed upgrade ends the
@@ -1288,9 +1374,12 @@ func (c *TransportClient) Disconnect(ctx context.Context) error {
 	// idempotent at their own layers) and return cleanly.
 	if !c.disconnected {
 		c.disconnected = true
-		// Stop heartbeat and convergence loop
+		// Stop heartbeat, convergence, and DNA refresh loops.
 		close(c.heartbeatStop)
 		close(c.convergenceStop)
+		if c.dnaRefreshStop != nil {
+			close(c.dnaRefreshStop)
+		}
 	}
 
 	// Close data plane session

--- a/features/steward/client/client_transport_dna_test.go
+++ b/features/steward/client/client_transport_dna_test.go
@@ -10,6 +10,7 @@ package client
 import (
 	"context"
 	"errors"
+	"sync"
 	"testing"
 	"time"
 
@@ -26,13 +27,18 @@ import (
 // ---------------------------------------------------------------------------
 
 // stubDNACollector satisfies DNACollector and returns the configured snapshot.
-// Call setAttrs to change what CollectAttributes returns on the next tick.
+// Use setAttrs to safely change what CollectAttributes returns on the next tick;
+// the mutex prevents data races when the loop goroutine and the test body
+// access attrs concurrently.
 type stubDNACollector struct {
+	mu    sync.RWMutex
 	attrs map[string]string
 	err   error
 }
 
 func (s *stubDNACollector) CollectAttributes(_ context.Context) (map[string]string, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
 	if s.err != nil {
 		return nil, s.err
 	}
@@ -41,6 +47,12 @@ func (s *stubDNACollector) CollectAttributes(_ context.Context) (map[string]stri
 		out[k] = v
 	}
 	return out, nil
+}
+
+func (s *stubDNACollector) setAttrs(attrs map[string]string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.attrs = attrs
 }
 
 // newClientWithOfflineQueue returns a minimal TransportClient wired with an
@@ -441,10 +453,7 @@ func TestDNARefreshLoop_StopsOnContextCancel(t *testing.T) {
 	cancel()
 	time.Sleep(20 * time.Millisecond) // let goroutine observe ctx.Done
 
-	stub.attrs = map[string]string{"os": "linux", "hostname": "new"}
-	c.mu.Lock()
-	c.dnaCollector = stub
-	c.mu.Unlock()
+	stub.setAttrs(map[string]string{"os": "linux", "hostname": "new"})
 
 	time.Sleep(40 * time.Millisecond) // extra ticks after cancel
 	assert.Equal(t, 0, q.Len(), "no events must be published after context cancellation")
@@ -475,10 +484,7 @@ func TestDNARefreshLoop_StopsOnDNARefreshStop(t *testing.T) {
 	close(c.dnaRefreshStop)
 	time.Sleep(20 * time.Millisecond) // let goroutine observe channel close
 
-	stub.attrs = map[string]string{"os": "linux", "hostname": "new"}
-	c.mu.Lock()
-	c.dnaCollector = stub
-	c.mu.Unlock()
+	stub.setAttrs(map[string]string{"os": "linux", "hostname": "new"})
 
 	time.Sleep(40 * time.Millisecond) // extra ticks after stop
 	assert.Equal(t, 0, q.Len(), "no events must be published after dnaRefreshStop is closed")

--- a/features/steward/client/client_transport_dna_test.go
+++ b/features/steward/client/client_transport_dna_test.go
@@ -3,11 +3,13 @@
 // Package client_test exercises the DNA-sync logic in TransportClient.
 //
 // These tests cover the pure, non-networked functions (delta computation,
-// hash tracking) and the Heartbeat DNAHash field contract.
+// hash tracking), the Heartbeat DNAHash field contract, and the periodic
+// DNA refresh loop (Issue #1915).
 package client
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -18,6 +20,49 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// ---------------------------------------------------------------------------
+// Stub DNACollector for refresh-loop tests (Issue #1915)
+// ---------------------------------------------------------------------------
+
+// stubDNACollector satisfies DNACollector and returns the configured snapshot.
+// Call setAttrs to change what CollectAttributes returns on the next tick.
+type stubDNACollector struct {
+	attrs map[string]string
+	err   error
+}
+
+func (s *stubDNACollector) CollectAttributes(_ context.Context) (map[string]string, error) {
+	if s.err != nil {
+		return nil, s.err
+	}
+	out := make(map[string]string, len(s.attrs))
+	for k, v := range s.attrs {
+		out[k] = v
+	}
+	return out, nil
+}
+
+// newClientWithOfflineQueue returns a minimal TransportClient wired with an
+// in-memory OfflineQueue so tests can observe events without a real control plane.
+func newClientWithOfflineQueue(t *testing.T) (*TransportClient, *OfflineQueue) {
+	t.Helper()
+	logger := newTestLogger(t)
+	q, err := NewOfflineQueue(OfflineQueueConfig{Logger: logger})
+	require.NoError(t, err)
+	c := &TransportClient{
+		stewardID:          "steward-1",
+		tenantID:           "tenant-1",
+		heartbeatStop:      make(chan struct{}),
+		convergenceStop:    make(chan struct{}),
+		dnaRefreshStop:     make(chan struct{}),
+		convergeInterval:   30 * time.Minute,
+		dnaRefreshInterval: 10 * time.Millisecond,
+		offlineQueue:       q,
+		logger:             logger,
+	}
+	return c, q
+}
 
 // ---------------------------------------------------------------------------
 // Minimal DataPlaneSession for sync_dna handler tests
@@ -287,4 +332,223 @@ func TestSyncDNAHandler_SendsFullDNAOverDataPlane(t *testing.T) {
 	case <-time.After(250 * time.Millisecond):
 		t.Fatal("timed out waiting for sync_dna handler to call SendDNA")
 	}
+}
+
+// ---------------------------------------------------------------------------
+// StartDNARefreshLoop (Issue #1915)
+// ---------------------------------------------------------------------------
+
+// TestDNARefreshLoop_NoDeltaSkipsPublish verifies that when the collector
+// returns the same attributes as the last-published snapshot, the refresh
+// loop does not enqueue any event.
+func TestDNARefreshLoop_NoDeltaSkipsPublish(t *testing.T) {
+	c, q := newClientWithOfflineQueue(t)
+
+	// Seed last-published DNA so the collector returns the same snapshot.
+	attrs := map[string]string{"hostname": "host-a", "os": "linux"}
+	c.dnaMu.Lock()
+	c.lastPublishedDNA = copyStringMap(attrs)
+	c.dnaMu.Unlock()
+
+	stub := &stubDNACollector{attrs: attrs}
+	c.mu.Lock()
+	c.dnaCollector = stub
+	c.mu.Unlock()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	c.StartDNARefreshLoop(ctx)
+
+	// Allow multiple ticks to fire; none should enqueue an event.
+	time.Sleep(80 * time.Millisecond)
+	cancel()
+
+	assert.Equal(t, 0, q.Len(),
+		"no event must be queued when the DNA delta is empty")
+}
+
+// TestDNARefreshLoop_ChangedAttributePublishesOne verifies that when the collector
+// returns a single changed attribute, the refresh loop enqueues exactly one
+// EventDNAChanged event carrying only that changed attribute in the delta.
+func TestDNARefreshLoop_ChangedAttributePublishesOne(t *testing.T) {
+	c, q := newClientWithOfflineQueue(t)
+
+	// Seed a prior snapshot; collector will return a single changed value.
+	c.dnaMu.Lock()
+	c.lastPublishedDNA = map[string]string{"hostname": "host-a", "os": "linux"}
+	c.dnaMu.Unlock()
+
+	stub := &stubDNACollector{attrs: map[string]string{"hostname": "host-b", "os": "linux"}}
+	c.mu.Lock()
+	c.dnaCollector = stub
+	c.mu.Unlock()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	c.StartDNARefreshLoop(ctx)
+
+	// Wait for at least one tick to fire and enqueue the event.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) && q.Len() == 0 {
+		time.Sleep(5 * time.Millisecond)
+	}
+	cancel()
+
+	require.Equal(t, 1, q.Len(), "exactly one DNA event must be queued after a single attribute change")
+
+	// Drain the queue and inspect the event.
+	var captured *cpTypes.Event
+	q.Drain(func(ev *cpTypes.Event) error {
+		captured = ev
+		return nil
+	})
+	require.NotNil(t, captured)
+	assert.Equal(t, cpTypes.EventDNAChanged, captured.Type)
+
+	delta, ok := captured.Details["dna"].(map[string]string)
+	require.True(t, ok, "event details must contain a string-string delta map")
+	assert.Equal(t, map[string]string{"hostname": "host-b"}, delta,
+		"delta must contain only the changed attribute with its new value")
+}
+
+// TestDNARefreshLoop_StopsOnContextCancel verifies that cancelling the context
+// stops the refresh loop within the existing 15-second graceful disconnect window.
+func TestDNARefreshLoop_StopsOnContextCancel(t *testing.T) {
+	c, q := newClientWithOfflineQueue(t)
+
+	// Seed prior state so the first tick produces no event (stable baseline).
+	initial := map[string]string{"os": "linux"}
+	c.dnaMu.Lock()
+	c.lastPublishedDNA = copyStringMap(initial)
+	c.dnaMu.Unlock()
+
+	stub := &stubDNACollector{attrs: copyStringMap(initial)}
+	c.mu.Lock()
+	c.dnaCollector = stub
+	c.mu.Unlock()
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	// Allow a few ticks to confirm the loop is running (no events = stable).
+	c.StartDNARefreshLoop(ctx)
+	time.Sleep(40 * time.Millisecond)
+	assert.Equal(t, 0, q.Len(), "no events expected while DNA is unchanged")
+
+	// Cancel and verify the loop has stopped: inject a change and confirm the
+	// event is NOT published after cancellation.
+	cancel()
+	time.Sleep(20 * time.Millisecond) // let goroutine observe ctx.Done
+
+	stub.attrs = map[string]string{"os": "linux", "hostname": "new"}
+	c.mu.Lock()
+	c.dnaCollector = stub
+	c.mu.Unlock()
+
+	time.Sleep(40 * time.Millisecond) // extra ticks after cancel
+	assert.Equal(t, 0, q.Len(), "no events must be published after context cancellation")
+}
+
+// TestDNARefreshLoop_StopsOnDNARefreshStop verifies that closing dnaRefreshStop
+// (via Disconnect) terminates the loop even when the context is still active.
+func TestDNARefreshLoop_StopsOnDNARefreshStop(t *testing.T) {
+	c, q := newClientWithOfflineQueue(t)
+
+	// Seed prior state so the first tick produces no event (stable baseline).
+	initial := map[string]string{"os": "linux"}
+	c.dnaMu.Lock()
+	c.lastPublishedDNA = copyStringMap(initial)
+	c.dnaMu.Unlock()
+
+	stub := &stubDNACollector{attrs: copyStringMap(initial)}
+	c.mu.Lock()
+	c.dnaCollector = stub
+	c.mu.Unlock()
+
+	ctx := context.Background()
+	c.StartDNARefreshLoop(ctx)
+	time.Sleep(40 * time.Millisecond)
+	assert.Equal(t, 0, q.Len(), "no events expected while DNA is unchanged")
+
+	// Close the stop channel (mimics Disconnect) and verify the loop stops.
+	close(c.dnaRefreshStop)
+	time.Sleep(20 * time.Millisecond) // let goroutine observe channel close
+
+	stub.attrs = map[string]string{"os": "linux", "hostname": "new"}
+	c.mu.Lock()
+	c.dnaCollector = stub
+	c.mu.Unlock()
+
+	time.Sleep(40 * time.Millisecond) // extra ticks after stop
+	assert.Equal(t, 0, q.Len(), "no events must be published after dnaRefreshStop is closed")
+}
+
+// TestDNARefreshLoop_CollectorErrorSkipsTick verifies that a collection error
+// does not terminate the loop — subsequent ticks still fire.
+func TestDNARefreshLoop_CollectorErrorSkipsTick(t *testing.T) {
+	c, q := newClientWithOfflineQueue(t)
+
+	// Start with an error-producing collector.
+	errCollector := &stubDNACollector{err: errors.New("transient")}
+	c.mu.Lock()
+	c.dnaCollector = errCollector
+	c.mu.Unlock()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	c.StartDNARefreshLoop(ctx)
+
+	// Give the loop several ticks to fail at collection; queue must stay empty.
+	time.Sleep(60 * time.Millisecond)
+	assert.Equal(t, 0, q.Len(), "collection errors must not enqueue events")
+
+	// Now swap to a collector that produces a real change (no prior snapshot).
+	goodCollector := &stubDNACollector{attrs: map[string]string{"os": "linux"}}
+	c.mu.Lock()
+	c.dnaCollector = goodCollector
+	c.mu.Unlock()
+
+	// Wait for the event to arrive — confirms the loop kept running after errors.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) && q.Len() == 0 {
+		time.Sleep(5 * time.Millisecond)
+	}
+	cancel()
+
+	assert.Equal(t, 1, q.Len(),
+		"loop must continue after a collection error and publish when a change is detected")
+}
+
+// TestStartDNARefreshLoop_NilCollectorWarns verifies that StartDNARefreshLoop
+// logs a warning and returns immediately when no DNACollector is configured.
+func TestStartDNARefreshLoop_NilCollectorWarns(t *testing.T) {
+	capLog := &kvCapturingLogger{}
+	c := &TransportClient{
+		heartbeatStop:      make(chan struct{}),
+		convergenceStop:    make(chan struct{}),
+		dnaRefreshStop:     make(chan struct{}),
+		convergeInterval:   30 * time.Minute,
+		dnaRefreshInterval: 10 * time.Millisecond,
+		logger:             capLog,
+		// dnaCollector intentionally nil
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	c.StartDNARefreshLoop(ctx)
+
+	// No goroutine is spawned; give the scheduler a moment to settle.
+	time.Sleep(30 * time.Millisecond)
+
+	found := false
+	for _, e := range capLog.allEntries() {
+		if e.msg == "DNA refresh loop started without a collector; DNA will not be refreshed periodically" {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found, "must log a warning when dnaCollector is nil")
 }

--- a/features/steward/config/config.go
+++ b/features/steward/config/config.go
@@ -350,6 +350,11 @@ func applyDefaults(config *StewardConfig) {
 	if config.Steward.RegistrationPollTimeout == 0 {
 		config.Steward.RegistrationPollTimeout = 24 * time.Hour
 	}
+
+	// Default DNA refresh interval: 30m (Issue #1915).
+	if config.Steward.DNARefreshInterval == "" {
+		config.Steward.DNARefreshInterval = "30m"
+	}
 }
 
 // validateScriptSigningConfig delegates to the shared stewardtypes validator.

--- a/features/steward/config/validation.go
+++ b/features/steward/config/validation.go
@@ -23,6 +23,11 @@ func GetConvergeInterval(cfg StewardConfig) time.Duration {
 	return stewardtypes.GetConvergeInterval(cfg)
 }
 
+// GetDNARefreshInterval delegates to the shared stewardtypes implementation.
+func GetDNARefreshInterval(cfg StewardConfig) time.Duration {
+	return stewardtypes.GetDNARefreshInterval(cfg)
+}
+
 // GetConfiguredModules delegates to the shared stewardtypes implementation.
 func GetConfiguredModules(config StewardConfig) []string {
 	return stewardtypes.GetConfiguredModules(config)


### PR DESCRIPTION
## Summary

- Adds a background DNA refresh loop to `TransportClient` that re-collects system attributes on a configurable interval (default 30m) and publishes **delta-only** updates when attributes have changed
- New config key `steward.dna_refresh_interval` validated at startup; documented in `docs/deployment/steward.cfg`
- Injectable `DNACollector` interface enables test verification without mocks or a real control plane

## Changes

**Core implementation** (`features/steward/client/client_transport.go`):
- `DNACollector` interface with `CollectAttributes(ctx) (map[string]string, error)`
- `StartDNARefreshLoop(ctx)` goroutine: ticker at `dnaRefreshInterval`, stops on `ctx.Done()` or `dnaRefreshStop` close, skips publish when delta is empty
- `dnaRefreshStop chan struct{}` added to `TransportClient`; closed in `Disconnect` with nil guard

**Config** (`features/config/stewardtypes/`, `features/steward/config/`):
- `DNARefreshInterval string` field on `StewardSettings`
- `GetDNARefreshInterval()` helper (default 30m, rejects ≤0)
- `ValidateConfiguration` rejects invalid/zero duration strings

**Wiring** (`cmd/steward/main.go`):
- `dnaCollectorAdapter` wraps `*dna.Collector`, adapting proto return to `map[string]string`
- `StartDNARefreshLoop` called after `StartConvergenceLoop` in `runSteward`

## Tests

10 new tests covering all acceptance criteria:
- `TestDNARefreshLoop_NoDeltaSkipsPublish` — unchanged attributes → no event
- `TestDNARefreshLoop_ChangedAttributePublishesOne` — single changed attribute → exactly that delta
- `TestDNARefreshLoop_StopsOnContextCancel` — post-cancel change → no event (real assertion)
- `TestDNARefreshLoop_StopsOnDNARefreshStop` — post-close change → no event (real assertion)
- `TestDNARefreshLoop_CollectorErrorSkipsTick` — error resilience, loop continues
- `TestStartDNARefreshLoop_NilCollectorWarns` — nil collector logs warning, no panic
- 4× `GetDNARefreshInterval` unit tests (valid, empty, invalid, zero)

## Specialist review

All three story-complete reviewers passed:
- **QA Test Runner**: PASS — all 133 packages pass
- **QA Code Reviewer**: PASS — stop-loop tests updated to use real assertions (no bare time.Sleep without verification)
- **Security Engineer**: PASS — no security findings, all scans clean

Fixes #1915