### PR TITLE
workflow: in-controller module runtime for controller-kind modules (Issue #1914)

### DIFF
--- a/features/controller/api/handlers_workflows_test.go
+++ b/features/controller/api/handlers_workflows_test.go
@@ -32,7 +32,7 @@ func newTestWorkflowHandler(t *testing.T) (*WorkflowHandler, cfgconfig.ConfigSto
 	configStore := storageManager.GetConfigStore()
 
 	logger := logging.NewNoopLogger()
-	engine := workflow.NewEngine(workflow.NewWorkflowModuleFactory(nil), logger, nil)
+	engine := workflow.NewEngine(workflow.NewWorkflowModuleFactory(nil, nil), logger, nil)
 
 	handler := NewWorkflowHandler(engine, configStore, nil, logger)
 	return handler, configStore
@@ -547,7 +547,7 @@ func TestWorkflowHandler_SpecialCharsInName_HandledSafely(t *testing.T) {
 	_, configStore := newTestWorkflowHandler(t)
 	capLogger := &capturingLogger{}
 
-	engine := workflow.NewEngine(workflow.NewWorkflowModuleFactory(nil), capLogger, nil)
+	engine := workflow.NewEngine(workflow.NewWorkflowModuleFactory(nil, nil), capLogger, nil)
 	h := NewWorkflowHandler(engine, configStore, nil, capLogger)
 	router := newWorkflowRouter(h)
 

--- a/features/controller/api/registration_hook_test.go
+++ b/features/controller/api/registration_hook_test.go
@@ -92,7 +92,7 @@ func newTestApprovalHook(t *testing.T) (*WorkflowApprovalHook, cfgconfig.ConfigS
 	configStore := storageManager.GetConfigStore()
 
 	logger := logging.NewNoopLogger()
-	engine := workflow.NewEngine(workflow.NewWorkflowModuleFactory(nil), logger, nil)
+	engine := workflow.NewEngine(workflow.NewWorkflowModuleFactory(nil, nil), logger, nil)
 
 	hook := NewWorkflowApprovalHook(engine, configStore, logger)
 	return hook, configStore

--- a/features/controller/server/server.go
+++ b/features/controller/server/server.go
@@ -31,6 +31,7 @@ import (
 	"github.com/cfgis/cfgms/features/controller/health"
 	"github.com/cfgis/cfgms/features/controller/heartbeat"
 	"github.com/cfgis/cfgms/features/controller/initialization"
+	modulecache "github.com/cfgis/cfgms/features/controller/modules/cache"
 	"github.com/cfgis/cfgms/features/controller/push"
 	controllerRegistration "github.com/cfgis/cfgms/features/controller/registration"
 	controllerrun "github.com/cfgis/cfgms/features/controller/run"
@@ -48,6 +49,7 @@ import (
 	reportstemplates "github.com/cfgis/cfgms/features/reports/templates"
 	"github.com/cfgis/cfgms/features/tenant"
 	"github.com/cfgis/cfgms/features/workflow"
+	workflowruntime "github.com/cfgis/cfgms/features/workflow/runtime"
 	workflowtrigger "github.com/cfgis/cfgms/features/workflow/trigger"
 	"github.com/cfgis/cfgms/pkg/audit"
 	"github.com/cfgis/cfgms/pkg/cert"
@@ -997,8 +999,19 @@ func New(cfg *config.Config, logger logging.Logger) (*Server, error) {
 		logger.Info("Reports engine wired to HTTP API server")
 	}
 
-	// Issue #414: Wire workflow engine and trigger manager into API server
-	workflowHandler, triggerMgr := initializeWorkflowHandler(storageManager, logger)
+	// Issue #414: Wire workflow engine and trigger manager into API server.
+	// Issue #1914: Create the controller module cache and workflow module runtime
+	// so the factory can fork/exec controller-kind bundles instead of returning
+	// ErrWorkflowRuntimeNotAvailable on every cache hit.
+	moduleCacheDir := filepath.Join(resolveDNADataRoot(cfg), "module-cache")
+	moduleCache, moduleCacheErr := modulecache.New(moduleCacheDir)
+	if moduleCacheErr != nil {
+		logger.Warn("Failed to initialize controller module cache; workflow modules will be unavailable",
+			"error", moduleCacheErr, "dir", moduleCacheDir)
+	}
+	workflowRuntimeDir := filepath.Join(resolveDNADataRoot(cfg), "workflow-runtime")
+	workflowModuleRuntime := workflowruntime.NewModuleRuntime(workflowRuntimeDir)
+	workflowHandler, triggerMgr := initializeWorkflowHandler(storageManager, moduleCache, workflowModuleRuntime, logger)
 	if workflowHandler != nil {
 		httpServer.SetWorkflowHandler(workflowHandler)
 		srv.triggerManager = triggerMgr
@@ -1246,17 +1259,21 @@ func initializeReportsHandler(dnaStorageManager *dnaStorage.Manager, logger logg
 
 // initializeWorkflowHandler creates the workflow engine, trigger manager, and API handler.
 // Returns nil, nil on failure so the controller starts without workflow support rather than failing.
-func initializeWorkflowHandler(storageManager *interfaces.StorageManager, logger logging.Logger) (*api.WorkflowHandler, *workflowtrigger.TriggerManagerImpl) {
+func initializeWorkflowHandler(
+	storageManager *interfaces.StorageManager,
+	moduleCache *modulecache.ModuleCache,
+	workflowRT *workflowruntime.ModuleRuntime,
+	logger logging.Logger,
+) (*api.WorkflowHandler, *workflowtrigger.TriggerManagerImpl) {
 	// Workflow module factory: looks up controller-kind module bundles by
-	// name in the controller's module cache (#1883) and (eventually) fork/
-	// execs them as workflow-kind module subprocesses connected over the
-	// WorkflowModuleClient gRPC contract (#1881).
+	// name in the controller's module cache (#1883) and fork/execs them as
+	// workflow-kind module subprocesses connected over the WorkflowModuleClient
+	// gRPC contract (#1881, #1914).
 	//
-	// The cache is wired in once a controller-side ModuleCache instance is
-	// available; until then we pass nil and the factory surfaces
-	// "no cache backing" on any module instantiation. REST-only deployments
-	// (which never resolve modules through the engine) are unaffected.
-	moduleFactory := workflow.NewWorkflowModuleFactory(nil)
+	// moduleCache and workflowRT may be nil when initialization failed; in that
+	// case the factory surfaces descriptive errors on any module instantiation.
+	// REST-only deployments that never resolve modules through the engine are unaffected.
+	moduleFactory := workflow.NewWorkflowModuleFactory(moduleCache, workflowRT)
 
 	workflowEngine := workflow.NewEngine(moduleFactory, logger, nil)
 

--- a/features/workflow/module_loader.go
+++ b/features/workflow/module_loader.go
@@ -8,14 +8,8 @@ import (
 
 	"github.com/cfgis/cfgms/features/controller/modules/cache"
 	"github.com/cfgis/cfgms/features/modules"
-	contractpkg "github.com/cfgis/cfgms/pkg/modules/contract"
+	"github.com/cfgis/cfgms/features/workflow/runtime"
 )
-
-// workflowModuleClient is a local alias for the gRPC contract type that the
-// controller workflow engine expects. It anchors this file's dependency on
-// pkg/modules/contract so the import is compile-checked rather than a bare
-// string.
-type workflowModuleClient = contractpkg.WorkflowModuleClient
 
 // ModuleLoader creates module instances by name for use by the workflow engine.
 // Placing this interface here (rather than in features/modules/) keeps it
@@ -32,42 +26,41 @@ type ModuleLoader interface {
 // the controller cache APIs (#1883).
 var ErrModuleNotCached = errors.New("workflow: module bundle not found in controller cache")
 
-// ErrWorkflowRuntimeNotAvailable is returned when the lookup succeeded but the
-// fork/exec + gRPC connect path for workflow modules has not been implemented
-// yet. Tracked as a follow-up to #1887: the steward runtime (#1885) covers
-// steward-kind module hosting; the workflow-kind equivalent for hosting
-// controller-kind modules is its own story and is not in scope for this PR.
-var ErrWorkflowRuntimeNotAvailable = errors.New("workflow: in-controller module runtime is not yet implemented (follow-up to #1887)")
-
 // WorkflowModuleFactory is the controller-side ModuleLoader.
 //
-// It looks up controller-kind module bundles by name in the controller module
-// cache (#1883), then — once the runtime piece lands — fork/execs the bundle's
-// binary and connects a WorkflowModuleClient gRPC client to it.
-//
-// Today the factory implements the lookup half: an unknown name returns
-// ErrModuleNotCached and an unapproved/wrong-kind match is filtered out. A
-// successful lookup proceeds to the (currently un-implemented) runtime helper,
-// which surfaces ErrWorkflowRuntimeNotAvailable. Callers should treat that as
-// "queued for a future runtime story" rather than as a hard failure of #1887.
+// It looks up approved controller-kind module bundles by name in the
+// controller module cache (#1883), then fork/execs the bundle's binary and
+// connects a WorkflowModuleClient gRPC client to it via the embedded
+// workflow module runtime.
 type WorkflowModuleFactory struct {
-	cache *cache.ModuleCache
+	cache   *cache.ModuleCache
+	runtime *runtime.ModuleRuntime
 }
 
 // NewWorkflowModuleFactory returns a WorkflowModuleFactory backed by the given
-// controller module cache. Production callers pass the controller's shared
-// ModuleCache so workflow-kind bundles delivered via the cache APIs are
-// discoverable.
-func NewWorkflowModuleFactory(c *cache.ModuleCache) ModuleLoader {
-	return &WorkflowModuleFactory{cache: c}
+// controller module cache and workflow module runtime. Production callers pass
+// the controller's shared ModuleCache and a ModuleRuntime so workflow-kind
+// bundles delivered via the cache APIs are discoverable and executable.
+//
+// Passing nil for cache causes every CreateModuleInstance call to return a
+// descriptive error (useful for REST-only controllers that never resolve
+// modules through the engine). Passing nil for rt causes a descriptive error
+// when a cache hit is found but the runtime is unavailable.
+func NewWorkflowModuleFactory(c *cache.ModuleCache, rt *runtime.ModuleRuntime) ModuleLoader {
+	return &WorkflowModuleFactory{cache: c, runtime: rt}
 }
 
 // CreateModuleInstance looks up an approved controller-kind bundle matching
-// moduleName in the cache. The first matching entry wins (List does not
-// guarantee an order; once the cache exposes a "latest approved version by
-// name" helper, prefer it). When found, the runtime helper is asked to
-// fork/exec the bundle's binary and connect a WorkflowModuleClient gRPC; that
-// helper is not implemented yet and surfaces ErrWorkflowRuntimeNotAvailable.
+// moduleName in the cache, then fork/execs it via the workflow module runtime
+// and returns a connected WorkflowModuleClient as a modules.Module.
+//
+// Error precedence:
+//  1. nil cache — returns a descriptive error
+//  2. cache list error — propagated as-is
+//  3. no approved bundle for moduleName — ErrModuleNotCached
+//  4. bundle load error — propagated as-is
+//  5. runtime unavailable (nil rt) — descriptive error
+//  6. runtime.Start error — propagated as-is (fork/exec or gRPC failure)
 func (f *WorkflowModuleFactory) CreateModuleInstance(moduleName string) (modules.Module, error) {
 	if f.cache == nil {
 		return nil, fmt.Errorf("workflow: module factory has no cache backing — call NewWorkflowModuleFactory with a non-nil cache")
@@ -85,14 +78,31 @@ func (f *WorkflowModuleFactory) CreateModuleInstance(moduleName string) (modules
 		if e.Status != cache.ApprovalStatusApproved {
 			continue
 		}
-		// Found an approved bundle. The next step — fork binary + connect
-		// gRPC — needs the workflow-kind module runtime to exist.
-		return nil, fmt.Errorf("workflow: %s found in cache (version %s, hash %s) but %w",
-			moduleName, e.Addr.Version, e.Addr.ContentHash, ErrWorkflowRuntimeNotAvailable)
+
+		// Found an approved bundle — load it from the cache to get the binary paths.
+		b, loadErr := f.cache.Get(e.Addr)
+		if loadErr != nil {
+			return nil, fmt.Errorf("workflow: load bundle %q: %w", moduleName, loadErr)
+		}
+
+		// Derive Kind from Executors since Kind is yaml:"-" and is not persisted
+		// in the cache YAML — it must be re-derived after deserialization.
+		if b.Manifest != nil && b.Manifest.Kind == "" &&
+			len(b.Manifest.Executors) > 0 && b.Manifest.Executors[0] == "controller" {
+			b.Manifest.Kind = "workflow"
+		}
+
+		if f.runtime == nil {
+			return nil, fmt.Errorf("workflow: %s found in cache (version %s, hash %s) but no workflow module runtime is configured",
+				moduleName, e.Addr.Version, e.Addr.ContentHash)
+		}
+
+		handle, startErr := f.runtime.Start(b)
+		if startErr != nil {
+			return nil, fmt.Errorf("workflow: start module %q: %w", moduleName, startErr)
+		}
+		return handle, nil
 	}
 
 	return nil, fmt.Errorf("workflow: %s: %w", moduleName, ErrModuleNotCached)
 }
-
-// Ensure workflowModuleClient alias is referenced so the compiler sees it as used.
-var _ workflowModuleClient

--- a/features/workflow/module_loader_test.go
+++ b/features/workflow/module_loader_test.go
@@ -5,6 +5,7 @@ package workflow
 import (
 	"context"
 	"errors"
+	"os"
 	goruntime "runtime"
 	"testing"
 
@@ -117,8 +118,12 @@ func TestWorkflowModuleFactory_IntegrationWithEchoModule(t *testing.T) {
 	require.NoError(t, c.Put(b))
 	require.NoError(t, c.SetApprovalStatus(b.ContentAddress(), cache.ApprovalStatusApproved))
 
-	// Create a runtime and factory backed by the real cache.
-	rt := runtime.NewModuleRuntime(t.TempDir())
+	// Use /tmp explicitly so the socket path fits within macOS's 103-byte sun_path limit.
+	// t.TempDir() on macOS generates paths under /var/folders/... that are too long.
+	runtimeDir, err := os.MkdirTemp("/tmp", "cfgms-wf-")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = os.RemoveAll(runtimeDir) })
+	rt := runtime.NewModuleRuntime(runtimeDir)
 	factory := NewWorkflowModuleFactory(c, rt)
 
 	// CreateModuleInstance must resolve the cached bundle, fork/exec the binary,

--- a/features/workflow/module_loader_test.go
+++ b/features/workflow/module_loader_test.go
@@ -3,13 +3,18 @@
 package workflow
 
 import (
+	"context"
 	"errors"
+	goruntime "runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/cfgis/cfgms/features/controller/modules/cache"
+	featuremodules "github.com/cfgis/cfgms/features/modules"
+	"github.com/cfgis/cfgms/features/workflow/runtime"
+	"github.com/cfgis/cfgms/pkg/modules/bundle"
 )
 
 // TestWorkflowModuleFactory_NilCache verifies that a factory built without
@@ -19,7 +24,7 @@ import (
 // such a deployment somehow tries to instantiate a module the error must
 // be self-explanatory.
 func TestWorkflowModuleFactory_NilCache(t *testing.T) {
-	loader := NewWorkflowModuleFactory(nil)
+	loader := NewWorkflowModuleFactory(nil, nil)
 	module, err := loader.CreateModuleInstance("any-module")
 	require.Error(t, err)
 	assert.Nil(t, module)
@@ -35,7 +40,7 @@ func TestWorkflowModuleFactory_ModuleNotCached(t *testing.T) {
 	c, err := cache.New(cacheDir)
 	require.NoError(t, err)
 
-	loader := NewWorkflowModuleFactory(c)
+	loader := NewWorkflowModuleFactory(c, nil)
 	module, err := loader.CreateModuleInstance("nonexistent-module")
 
 	require.Error(t, err)
@@ -43,4 +48,95 @@ func TestWorkflowModuleFactory_ModuleNotCached(t *testing.T) {
 	assert.True(t, errors.Is(err, ErrModuleNotCached),
 		"missing bundle must surface as ErrModuleNotCached, got: %v", err)
 	assert.Contains(t, err.Error(), "nonexistent-module")
+}
+
+// TestWorkflowModuleFactory_NilRuntime verifies that a factory with a cache
+// but no runtime returns a descriptive error when a matching approved bundle
+// is found — rather than a confusing nil-pointer panic.
+func TestWorkflowModuleFactory_NilRuntime(t *testing.T) {
+	cacheDir := t.TempDir()
+	c, err := cache.New(cacheDir)
+	require.NoError(t, err)
+
+	// Put an approved controller-kind bundle in the cache.
+	b := &bundle.Bundle{
+		Manifest: &featuremodules.ModuleMetadata{
+			Name:      "my-module",
+			Version:   "1.0.0",
+			Executors: []string{"controller"},
+			Kind:      "workflow",
+			Publisher: "test",
+		},
+		ContentHash: "sha256-nil-runtime-test",
+		Binaries:    map[string]string{goruntime.GOOS + "-" + goruntime.GOARCH: "/nonexistent/bin"},
+	}
+	require.NoError(t, c.Put(b))
+	require.NoError(t, c.SetApprovalStatus(b.ContentAddress(), cache.ApprovalStatusApproved))
+
+	loader := NewWorkflowModuleFactory(c, nil)
+	module, err := loader.CreateModuleInstance("my-module")
+
+	require.Error(t, err)
+	assert.Nil(t, module)
+	assert.Contains(t, err.Error(), "no workflow module runtime is configured",
+		"error must clearly explain that the runtime is missing")
+}
+
+// TestWorkflowModuleFactory_IntegrationWithEchoModule is the end-to-end
+// integration test that verifies the complete path from cache lookup to
+// gRPC call:
+//
+//   - A controller-kind bundle is published and approved in a real ModuleCache.
+//   - WorkflowModuleFactory.CreateModuleInstance resolves the bundle, starts the
+//     echo_module subprocess via the workflow ModuleRuntime, and returns a
+//     modules.Module backed by the live gRPC connection.
+//   - Get("my-resource") via the modules.Module interface returns "echo:my-resource".
+//
+// The echo_module binary is compiled once per test run by TestMain.
+func TestWorkflowModuleFactory_IntegrationWithEchoModule(t *testing.T) {
+	if integrationEchoModuleBin == "" {
+		t.Skip("echo_module binary not available — integration test skipped")
+	}
+
+	// Set up a real module cache with an approved echo bundle.
+	cacheDir := t.TempDir()
+	c, err := cache.New(cacheDir)
+	require.NoError(t, err)
+
+	b := &bundle.Bundle{
+		Manifest: &featuremodules.ModuleMetadata{
+			Name:      "echo",
+			Version:   "0.1.0",
+			Executors: []string{"controller"},
+			Kind:      "workflow",
+			Publisher: "test",
+		},
+		ContentHash: "sha256-echo-integration-hash",
+		Binaries:    map[string]string{goruntime.GOOS + "-" + goruntime.GOARCH: integrationEchoModuleBin},
+	}
+	require.NoError(t, c.Put(b))
+	require.NoError(t, c.SetApprovalStatus(b.ContentAddress(), cache.ApprovalStatusApproved))
+
+	// Create a runtime and factory backed by the real cache.
+	rt := runtime.NewModuleRuntime(t.TempDir())
+	factory := NewWorkflowModuleFactory(c, rt)
+
+	// CreateModuleInstance must resolve the cached bundle, fork/exec the binary,
+	// and return a live gRPC-backed module.
+	mod, err := factory.CreateModuleInstance("echo")
+	require.NoError(t, err, "CreateModuleInstance must not return ErrWorkflowRuntimeNotAvailable")
+	require.NotNil(t, mod)
+
+	// Retrieve the handle for lifecycle cleanup.
+	handle, ok := mod.(*runtime.ModuleHandle)
+	require.True(t, ok, "CreateModuleInstance must return *runtime.ModuleHandle")
+	t.Cleanup(func() { _ = rt.Stop(handle) })
+
+	// Call Get via the modules.Module interface and verify the echo response.
+	ctx := context.Background()
+	state, err := mod.Get(ctx, "my-resource")
+	require.NoError(t, err)
+	require.NotNil(t, state)
+	assert.Equal(t, "echo:my-resource", state.AsMap()["config_data"],
+		"module Get must return the echo response via the gRPC client")
 }

--- a/features/workflow/runtime/lifecycle.go
+++ b/features/workflow/runtime/lifecycle.go
@@ -1,0 +1,119 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 CFGMS Contributors
+package runtime
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"sync"
+
+	proto "github.com/cfgis/cfgms/api/proto/modules"
+	featuremodules "github.com/cfgis/cfgms/features/modules"
+	"github.com/cfgis/cfgms/pkg/modules/contract"
+	"google.golang.org/grpc"
+	"gopkg.in/yaml.v3"
+)
+
+// LifecycleState tracks the state of a running workflow module process.
+type LifecycleState int
+
+const (
+	// StateStarting: binary fork/exec'd, socket not yet connected.
+	StateStarting LifecycleState = iota + 1
+	// StateReady: gRPC connection established and Handshake completed.
+	StateReady
+	// StateRunning: module is operating normally, ready to serve RPCs.
+	StateRunning
+	// StateStopping: Shutdown RPC sent, waiting for process exit.
+	StateStopping
+	// StateStopped: process has exited and resources are cleaned up.
+	StateStopped
+)
+
+// ModuleHandle represents a running out-of-process workflow module instance.
+// Obtain one via ModuleRuntime.Start; release with ModuleRuntime.Stop.
+//
+// ModuleHandle implements features/modules.Module so callers can return it
+// directly from WorkflowModuleFactory.CreateModuleInstance.
+type ModuleHandle struct {
+	// Name is the module's name from its manifest.
+	Name string
+
+	// Client is the gRPC client for this module session.
+	Client contract.WorkflowModuleClient
+
+	conn       *grpc.ClientConn
+	cmd        *exec.Cmd
+	socketPath string
+	state      LifecycleState
+	waitCh     chan struct{} // closed when the module process exits
+	mu         sync.Mutex
+}
+
+// GetState returns the current lifecycle state of the handle.
+func (h *ModuleHandle) GetState() LifecycleState {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return h.state
+}
+
+// Get implements features/modules.Module by delegating to the WorkflowModuleClient.
+// The proto GetResponse.ConfigData is returned as a workflowConfigState whose
+// AsMap() exposes the raw string under the "config_data" key for workflow variable bindings.
+func (h *ModuleHandle) Get(ctx context.Context, resourceID string) (featuremodules.ConfigState, error) {
+	resp, err := h.Client.Get(ctx, &proto.GetRequest{ResourceId: resourceID})
+	if err != nil {
+		return nil, fmt.Errorf("workflow module %q Get(%q): %w", h.Name, resourceID, err)
+	}
+	return &workflowConfigState{data: resp.ConfigData}, nil
+}
+
+// Set implements features/modules.Module by delegating to the WorkflowModuleClient.
+// The config state is serialized to YAML for the proto SetRequest.ConfigData field.
+func (h *ModuleHandle) Set(ctx context.Context, resourceID string, config featuremodules.ConfigState) error {
+	var configData string
+	if config != nil {
+		b, err := config.ToYAML()
+		if err != nil {
+			return fmt.Errorf("workflow module %q Set(%q): serialize config: %w", h.Name, resourceID, err)
+		}
+		configData = string(b)
+	}
+	resp, err := h.Client.Set(ctx, &proto.SetRequest{ResourceId: resourceID, ConfigData: configData})
+	if err != nil {
+		return fmt.Errorf("workflow module %q Set(%q): %w", h.Name, resourceID, err)
+	}
+	if resp.GetError() != "" {
+		return fmt.Errorf("workflow module %q Set(%q): module error: %s", h.Name, resourceID, resp.GetError())
+	}
+	return nil
+}
+
+// workflowConfigState is the minimal ConfigState implementation for workflow
+// module Get responses. It carries the raw ConfigData string from the proto
+// response and exposes it as a map for use in workflow variable bindings.
+type workflowConfigState struct {
+	data string
+}
+
+func (s *workflowConfigState) AsMap() map[string]interface{} {
+	return map[string]interface{}{"config_data": s.data}
+}
+
+func (s *workflowConfigState) ToYAML() ([]byte, error) {
+	return yaml.Marshal(map[string]string{"config_data": s.data})
+}
+
+func (s *workflowConfigState) FromYAML(b []byte) error {
+	var m map[string]string
+	if err := yaml.Unmarshal(b, &m); err != nil {
+		return err
+	}
+	s.data = m["config_data"]
+	return nil
+}
+
+func (s *workflowConfigState) Validate() error { return nil }
+
+func (s *workflowConfigState) GetManagedFields() []string { return []string{"config_data"} }

--- a/features/workflow/runtime/runtime.go
+++ b/features/workflow/runtime/runtime.go
@@ -1,0 +1,196 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 CFGMS Contributors
+
+// Package runtime implements the workflow module runtime: fork/exec, gRPC client,
+// and lifecycle management for out-of-process controller-kind (workflow) modules.
+//
+// Only controller-kind ("workflow") modules may be started by this runtime. Steward-
+// and outpost-kind modules are handled by their respective runtimes.
+package runtime
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	goruntime "runtime"
+	"strings"
+	"sync/atomic"
+	"time"
+	"unicode"
+
+	proto "github.com/cfgis/cfgms/api/proto/modules"
+	"github.com/cfgis/cfgms/pkg/modules/bundle"
+)
+
+// ErrWrongModuleKind is returned by Start when the bundle's manifest kind is not
+// "workflow". The workflow runtime hosts only controller-kind ("workflow") modules.
+var ErrWrongModuleKind = errors.New("wrong module kind: workflow runtime hosts only controller-kind (workflow) modules")
+
+// handleSeq generates unique monotonic IDs for socket path generation.
+var handleSeq atomic.Int64
+
+// ModuleRuntime manages the lifecycle of out-of-process controller-kind workflow
+// module binaries. Create one per controller instance with NewModuleRuntime.
+type ModuleRuntime struct {
+	runtimeDir string
+}
+
+// NewModuleRuntime returns a ModuleRuntime that creates sockets under runtimeDir.
+// runtimeDir must be a writable directory; use t.TempDir() in tests.
+func NewModuleRuntime(runtimeDir string) *ModuleRuntime {
+	return &ModuleRuntime{runtimeDir: runtimeDir}
+}
+
+// Start fork/execs the module binary for the current OS/arch, waits for it to
+// start listening, dials gRPC, and returns a ModuleHandle ready for RPC calls.
+//
+// Error precedence:
+//  1. ErrWrongModuleKind — bundle.Manifest.Kind != "workflow"
+//  2. binary not found in bundle.Binaries for current os-arch
+//  3. fork/exec, socket, or gRPC errors
+func (r *ModuleRuntime) Start(b *bundle.Bundle) (*ModuleHandle, error) {
+	// 1. Kind gate — must be first; workflow runtime hosts only workflow-kind modules.
+	if b.Manifest == nil || b.Manifest.Kind != "workflow" {
+		got := ""
+		if b.Manifest != nil {
+			got = b.Manifest.Kind
+		}
+		return nil, fmt.Errorf("%w: got %q", ErrWrongModuleKind, got)
+	}
+
+	// 2. Locate the binary for the current platform.
+	osArch := goruntime.GOOS + "-" + goruntime.GOARCH
+	binPath, ok := b.Binaries[osArch]
+	if !ok {
+		return nil, fmt.Errorf("no binary for %q in bundle %q (available: %v)",
+			osArch, b.Manifest.Name, binaryKeys(b.Binaries))
+	}
+
+	// 3. Construct a unique socket path for this module instance. makeSocketPath
+	// also creates the controller-private socket directory (mode 0700).
+	id := handleSeq.Add(1)
+	socketPath, err := makeSocketPath(r.runtimeDir, b.Manifest.Name, id)
+	if err != nil {
+		return nil, fmt.Errorf("socket path for module %q: %w", b.Manifest.Name, err)
+	}
+
+	// 4. Fork/exec the module binary with the socket path in its environment.
+	// #nosec G204 — binPath comes from the bundle manifest, not user-supplied input.
+	cmd := exec.Command(binPath)
+	cmd.Env = append(os.Environ(), "CFGMS_MODULE_SOCKET="+socketPath)
+
+	if err := cmd.Start(); err != nil {
+		return nil, fmt.Errorf("fork/exec module %q (%s): %w", b.Manifest.Name, binPath, err)
+	}
+
+	// 5. Wait for the module to start listening on its socket (up to 30 s).
+	startCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	if err := waitForSocket(startCtx, socketPath); err != nil {
+		_ = cmd.Process.Kill()
+		_ = cmd.Wait()
+		_ = os.Remove(socketPath)
+		return nil, fmt.Errorf("module %q did not start listening: %w", b.Manifest.Name, err)
+	}
+
+	// 6. Dial gRPC over the local socket.
+	conn, err := dialGRPCSocket(socketPath)
+	if err != nil {
+		_ = cmd.Process.Kill()
+		_ = cmd.Wait()
+		_ = os.Remove(socketPath)
+		return nil, fmt.Errorf("dial gRPC for module %q: %w", b.Manifest.Name, err)
+	}
+
+	client := proto.NewWorkflowModuleServiceClient(conn)
+
+	// 7. Perform the workflow handshake to confirm the gRPC session.
+	hsCtx, hsCancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer hsCancel()
+
+	if _, err := client.Handshake(hsCtx, &proto.WorkflowHandshakeRequest{
+		ModuleName:    b.Manifest.Name,
+		ModuleVersion: b.Manifest.Version,
+		Publisher:     b.Manifest.Publisher,
+	}); err != nil {
+		_ = conn.Close()
+		_ = cmd.Process.Kill()
+		_ = cmd.Wait()
+		_ = os.Remove(socketPath)
+		return nil, fmt.Errorf("handshake with module %q: %w", b.Manifest.Name, err)
+	}
+
+	// 8. Start a goroutine to collect the process exit status.
+	waitCh := make(chan struct{})
+	go func() {
+		_ = cmd.Wait()
+		close(waitCh)
+	}()
+
+	h := &ModuleHandle{
+		Name:       b.Manifest.Name,
+		Client:     client,
+		conn:       conn,
+		cmd:        cmd,
+		socketPath: socketPath,
+		state:      StateRunning,
+		waitCh:     waitCh,
+	}
+	return h, nil
+}
+
+// Stop sends the Shutdown RPC, waits for the module process to exit, and kills
+// the process if it has not exited within 10 seconds. Stop is idempotent.
+func (r *ModuleRuntime) Stop(h *ModuleHandle) error {
+	h.mu.Lock()
+	if h.state >= StateStopping {
+		h.mu.Unlock()
+		return nil
+	}
+	h.state = StateStopping
+	h.mu.Unlock()
+
+	// Send Shutdown RPC (best-effort: process may already have exited).
+	shutCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	_, _ = h.Client.Shutdown(shutCtx, &proto.ShutdownRequest{})
+	cancel()
+
+	// Wait for process exit with a 10-second deadline.
+	select {
+	case <-h.waitCh:
+	case <-time.After(10 * time.Second):
+		_ = h.cmd.Process.Kill()
+		<-h.waitCh
+	}
+
+	h.mu.Lock()
+	h.state = StateStopped
+	h.mu.Unlock()
+
+	_ = h.conn.Close()
+	_ = os.Remove(h.socketPath)
+	return nil
+}
+
+// sanitizeName replaces characters that are unsafe in socket/pipe names with
+// hyphens so module names like "publisher/name" produce valid path components.
+func sanitizeName(name string) string {
+	return strings.Map(func(r rune) rune {
+		if unicode.IsLetter(r) || unicode.IsDigit(r) || r == '-' || r == '_' {
+			return r
+		}
+		return '-'
+	}, name)
+}
+
+// binaryKeys returns the keys of the binaries map for use in error messages.
+func binaryKeys(binaries map[string]string) []string {
+	keys := make([]string, 0, len(binaries))
+	for k := range binaries {
+		keys = append(keys, k)
+	}
+	return keys
+}

--- a/features/workflow/runtime/runtime_test.go
+++ b/features/workflow/runtime/runtime_test.go
@@ -1,0 +1,201 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 CFGMS Contributors
+
+//go:build !windows
+
+package runtime_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	goruntime "runtime"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	proto "github.com/cfgis/cfgms/api/proto/modules"
+	featuremodules "github.com/cfgis/cfgms/features/modules"
+	"github.com/cfgis/cfgms/features/workflow/runtime"
+	"github.com/cfgis/cfgms/pkg/modules/bundle"
+)
+
+// echoModuleBin is the path to the compiled echo_module binary. It is set by
+// TestMain before any tests run.
+var echoModuleBin string
+
+// binaryDir holds the temp dir for the compiled echo_module binary; cleaned up
+// after all tests complete.
+var binaryDir string
+
+func TestMain(m *testing.M) {
+	os.Exit(run(m))
+}
+
+func run(m *testing.M) int {
+	var err error
+	binaryDir, err = os.MkdirTemp("", "echo-workflow-module-test-*")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "runtime_test: failed to create temp dir: %v\n", err)
+		return 1
+	}
+	defer func() { _ = os.RemoveAll(binaryDir) }()
+
+	echoModuleBin = filepath.Join(binaryDir, "echo_module")
+	cmd := exec.Command("go", "build", "-o", echoModuleBin, "./testdata/echo_module")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		fmt.Fprintf(os.Stderr, "runtime_test: failed to build echo_module: %s: %v\n", out, err)
+		return 1
+	}
+
+	return m.Run()
+}
+
+// shortBaseDir creates a temp dir under /tmp with a predictably short path so
+// that socket paths constructed from it fit within the macOS sun_path limit
+// (103 bytes).
+func shortBaseDir(t *testing.T) string {
+	t.Helper()
+	base, err := os.MkdirTemp("/tmp", "cfgms-wf-rt-")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = os.RemoveAll(base) })
+	return base
+}
+
+// makeWorkflowBundle creates a minimal workflow-kind bundle using the echo_module binary.
+func makeWorkflowBundle(binPath string) *bundle.Bundle {
+	return &bundle.Bundle{
+		Manifest: &featuremodules.ModuleMetadata{
+			Name:      "echo",
+			Version:   "0.1.0",
+			Executors: []string{"controller"},
+			Kind:      "workflow",
+			Publisher: "test",
+		},
+		ContentHash: "sha256-echo-workflow-test-hash",
+		Binaries:    map[string]string{goruntime.GOOS + "-" + goruntime.GOARCH: binPath},
+	}
+}
+
+// TestEchoModuleLifecycle verifies the full lifecycle:
+//   - Start() fork/execs echo_module and connects via gRPC
+//   - Get() returns "echo:<resource_id>"
+//   - Stop() sends Shutdown RPC and the process exits within 10 s
+func TestEchoModuleLifecycle(t *testing.T) {
+	rt := runtime.NewModuleRuntime(shortBaseDir(t))
+	b := makeWorkflowBundle(echoModuleBin)
+
+	handle, err := rt.Start(b)
+	require.NoError(t, err)
+	require.NotNil(t, handle)
+	assert.Equal(t, runtime.StateRunning, handle.GetState())
+
+	// Call Get via gRPC; expect echo response.
+	ctx := context.Background()
+	resp, err := handle.Client.Get(ctx, &proto.GetRequest{ResourceId: "my-resource"})
+	require.NoError(t, err)
+	assert.Equal(t, "echo:my-resource", resp.ConfigData)
+
+	// Stop and verify clean shutdown.
+	require.NoError(t, rt.Stop(handle))
+	assert.Equal(t, runtime.StateStopped, handle.GetState())
+}
+
+// TestEchoModuleLifecycle_ModuleInterface verifies that ModuleHandle implements
+// features/modules.Module and that Get/Set delegate to the gRPC client correctly.
+func TestEchoModuleLifecycle_ModuleInterface(t *testing.T) {
+	rt := runtime.NewModuleRuntime(shortBaseDir(t))
+	b := makeWorkflowBundle(echoModuleBin)
+
+	handle, err := rt.Start(b)
+	require.NoError(t, err)
+	require.NotNil(t, handle)
+
+	// Compile-time check: ModuleHandle must satisfy the modules.Module interface.
+	var _ featuremodules.Module = handle
+
+	ctx := context.Background()
+
+	// Get via modules.Module interface; verify ConfigState carries the echo response.
+	state, err := handle.Get(ctx, "test-resource")
+	require.NoError(t, err)
+	require.NotNil(t, state, "Get must return a non-nil ConfigState")
+	assert.Equal(t, "echo:test-resource", state.AsMap()["config_data"])
+
+	// Verify ConfigState ToYAML/AsMap round-trip for the returned state.
+	yamlBytes, err := state.ToYAML()
+	require.NoError(t, err)
+	assert.Contains(t, string(yamlBytes), "echo:test-resource",
+		"ToYAML must serialise the echo response")
+	assert.Equal(t, []string{"config_data"}, state.GetManagedFields())
+	assert.NoError(t, state.Validate())
+
+	// Set via modules.Module interface; verify the call succeeds (echo_module
+	// responds with Applied = true and no error).
+	setErr := handle.Set(ctx, "test-resource", state)
+	require.NoError(t, setErr, "Set via modules.Module interface must succeed")
+
+	require.NoError(t, rt.Stop(handle))
+}
+
+// TestStartReturnsErrWrongModuleKindForNonWorkflowBundle verifies that Start()
+// returns ErrWrongModuleKind before any fork/exec for bundles whose kind is not "workflow".
+func TestStartReturnsErrWrongModuleKindForNonWorkflowBundle(t *testing.T) {
+	rt := runtime.NewModuleRuntime(t.TempDir())
+
+	cases := []struct {
+		name string
+		kind string
+	}{
+		{"steward kind", "steward"},
+		{"outpost kind", "outpost"},
+		{"empty kind", ""},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			b := &bundle.Bundle{
+				Manifest: &featuremodules.ModuleMetadata{
+					Name:      "wrong-kind",
+					Version:   "1.0.0",
+					Kind:      tc.kind,
+					Publisher: "test",
+				},
+				Binaries: map[string]string{goruntime.GOOS + "-" + goruntime.GOARCH: "/nonexistent"},
+			}
+
+			_, err := rt.Start(b)
+			require.Error(t, err)
+			assert.ErrorIs(t, err, runtime.ErrWrongModuleKind)
+		})
+	}
+}
+
+// TestStartReturnsErrWrongModuleKindForNilManifest verifies that a nil Manifest
+// returns ErrWrongModuleKind.
+func TestStartReturnsErrWrongModuleKindForNilManifest(t *testing.T) {
+	rt := runtime.NewModuleRuntime(t.TempDir())
+	b := &bundle.Bundle{
+		Manifest: nil,
+		Binaries: map[string]string{goruntime.GOOS + "-" + goruntime.GOARCH: "/nonexistent"},
+	}
+	_, err := rt.Start(b)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, runtime.ErrWrongModuleKind)
+}
+
+// TestStopIsIdempotent verifies that calling Stop multiple times on the same
+// handle does not error or panic.
+func TestStopIsIdempotent(t *testing.T) {
+	rt := runtime.NewModuleRuntime(shortBaseDir(t))
+	b := makeWorkflowBundle(echoModuleBin)
+
+	handle, err := rt.Start(b)
+	require.NoError(t, err)
+
+	require.NoError(t, rt.Stop(handle))
+	require.NoError(t, rt.Stop(handle))
+}

--- a/features/workflow/runtime/socket_unix.go
+++ b/features/workflow/runtime/socket_unix.go
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 CFGMS Contributors
+
+//go:build !windows
+
+package runtime
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+	"time"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+)
+
+// unixSocketPathMax is the maximum Unix domain socket path length set by the
+// strictest mainstream platform. macOS sockaddr_un.sun_path is 104 bytes
+// (including the null terminator), so the usable path length is 103 chars.
+// Linux allows 108. Picking the smaller value keeps cross-platform behavior
+// predictable.
+const unixSocketPathMax = 103
+
+// socketsSubdir is the name of the controller-private directory created under
+// runtimeDir for all module sockets. Mode 0700 restricts access to the
+// controller process owner, which is the sole trust boundary on the module
+// gRPC channel (the dialer uses insecure.NewCredentials with no per-caller
+// authentication).
+const socketsSubdir = "sockets"
+
+// makeSocketPath returns the Unix domain socket path for a module instance,
+// creating the controller-private socket directory if it does not already exist.
+//
+// All sockets live under ${runtimeDir}/sockets (mode 0700). The mode is
+// re-asserted on every call to guard against a pre-existing directory with
+// looser permissions. When the natural path would exceed the platform's
+// sun_path limit, the name is hashed into the same private directory — never
+// into /tmp or any world-writable location. If even the hashed path would
+// exceed sun_path, an error is returned; the operator must configure a shorter
+// runtimeDir (production deployments typically use /var/run/cfgms or similar).
+func makeSocketPath(runtimeDir, moduleName string, id int64) (string, error) {
+	sockDir := filepath.Join(runtimeDir, socketsSubdir)
+	if err := os.MkdirAll(sockDir, 0o700); err != nil {
+		return "", fmt.Errorf("create module socket dir %q: %w", sockDir, err)
+	}
+	// Re-assert mode in case the directory already existed with looser permissions.
+	if err := os.Chmod(sockDir, 0o700); err != nil { // #nosec G302 -- 0700 on a directory is intentional hardening; execute bit is required for traversal
+		return "", fmt.Errorf("chmod module socket dir %q: %w", sockDir, err)
+	}
+
+	name := fmt.Sprintf("cfgms-module-%s-%d.sock", sanitizeName(moduleName), id)
+	natural := filepath.Join(sockDir, name)
+	if len(natural) <= unixSocketPathMax {
+		return natural, nil
+	}
+
+	// Hash the natural path (including sockDir and id) to retain uniqueness
+	// across runtime instances. 12 hex chars give 48 bits of entropy — ample
+	// for collision avoidance within a host. The hash stays in the private
+	// directory so socket permissions remain the access control boundary.
+	sum := sha256.Sum256([]byte(natural))
+	hash := hex.EncodeToString(sum[:6])
+	hashed := filepath.Join(sockDir, fmt.Sprintf("cfgms-%s.sock", hash))
+	if len(hashed) <= unixSocketPathMax {
+		return hashed, nil
+	}
+
+	return "", fmt.Errorf(
+		"module socket path %q (%d bytes) exceeds sun_path limit (%d); "+
+			"configure a shorter runtimeDir (e.g. /var/run/cfgms)",
+		hashed, len(hashed), unixSocketPathMax,
+	)
+}
+
+// waitForSocket polls the Unix socket at socketPath until it accepts a
+// connection or ctx is cancelled.
+func waitForSocket(ctx context.Context, socketPath string) error {
+	for {
+		conn, err := net.DialTimeout("unix", socketPath, 100*time.Millisecond)
+		if err == nil {
+			_ = conn.Close()
+			return nil
+		}
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("socket %q not ready: %w", socketPath, ctx.Err())
+		case <-time.After(50 * time.Millisecond):
+		}
+	}
+}
+
+// dialGRPCSocket creates a gRPC client connection over the Unix socket at socketPath.
+func dialGRPCSocket(socketPath string) (*grpc.ClientConn, error) {
+	return grpc.NewClient(
+		"unix://"+socketPath,
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+}

--- a/features/workflow/runtime/socket_windows.go
+++ b/features/workflow/runtime/socket_windows.go
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 CFGMS Contributors
+
+//go:build windows
+
+package runtime
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"time"
+
+	"github.com/Microsoft/go-winio"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+)
+
+// makeSocketPath returns the named pipe path for a module instance.
+// Format: \\.\pipe\cfgms-module-${name}-${id}
+//
+// runtimeDir is unused on Windows: named pipes are identified by name, not
+// filesystem path. Windows enforces per-user pipe ACLs at the kernel level,
+// so no additional directory permission hardening is required here.
+func makeSocketPath(runtimeDir, moduleName string, id int64) (string, error) {
+	return fmt.Sprintf(`\\.\pipe\cfgms-wf-module-%s-%d`, sanitizeName(moduleName), id), nil
+}
+
+// waitForSocket polls the named pipe at socketPath until it accepts a
+// connection or ctx is cancelled.
+func waitForSocket(ctx context.Context, socketPath string) error {
+	for {
+		conn, err := winio.DialPipeContext(ctx, socketPath)
+		if err == nil {
+			_ = conn.Close()
+			return nil
+		}
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("named pipe %q not ready: %w", socketPath, ctx.Err())
+		case <-time.After(50 * time.Millisecond):
+		}
+	}
+}
+
+// dialGRPCSocket creates a gRPC client connection over the Windows named pipe.
+func dialGRPCSocket(socketPath string) (*grpc.ClientConn, error) {
+	return grpc.NewClient(
+		socketPath,
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithContextDialer(func(ctx context.Context, addr string) (net.Conn, error) {
+			return winio.DialPipeContext(ctx, addr)
+		}),
+	)
+}

--- a/features/workflow/runtime/testdata/echo_module/main.go
+++ b/features/workflow/runtime/testdata/echo_module/main.go
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 CFGMS Contributors
+
+// echo_module is a minimal out-of-process workflow module binary used exclusively
+// by runtime tests. It implements the WorkflowModuleService gRPC contract:
+//
+//   - Handshake: acknowledges the session with an "echo" capability.
+//   - Get: returns ConfigData = "echo:" + req.ResourceId.
+//   - Set: acknowledges with Applied = true.
+//   - Test: returns InCompliance = true.
+//   - Shutdown: stops the gRPC server and exits cleanly.
+//
+// The socket path is supplied via the CFGMS_MODULE_SOCKET environment variable.
+package main
+
+import (
+	"context"
+	"log"
+	"net"
+	"os"
+	"os/signal"
+	"syscall"
+
+	proto "github.com/cfgis/cfgms/api/proto/modules"
+	"google.golang.org/grpc"
+)
+
+type echoServer struct {
+	proto.UnimplementedWorkflowModuleServiceServer
+	srv *grpc.Server
+}
+
+func (s *echoServer) Handshake(_ context.Context, _ *proto.WorkflowHandshakeRequest) (*proto.WorkflowHandshakeResponse, error) {
+	return &proto.WorkflowHandshakeResponse{Capabilities: []string{"echo"}}, nil
+}
+
+func (s *echoServer) Get(_ context.Context, req *proto.GetRequest) (*proto.GetResponse, error) {
+	return &proto.GetResponse{ConfigData: "echo:" + req.ResourceId}, nil
+}
+
+func (s *echoServer) Set(_ context.Context, _ *proto.SetRequest) (*proto.SetResponse, error) {
+	return &proto.SetResponse{Applied: true}, nil
+}
+
+func (s *echoServer) Test(_ context.Context, _ *proto.TestRequest) (*proto.TestResponse, error) {
+	return &proto.TestResponse{InCompliance: true}, nil
+}
+
+func (s *echoServer) Shutdown(_ context.Context, _ *proto.ShutdownRequest) (*proto.ShutdownResponse, error) {
+	go s.srv.GracefulStop()
+	return &proto.ShutdownResponse{}, nil
+}
+
+func main() {
+	socketPath := os.Getenv("CFGMS_MODULE_SOCKET")
+	if socketPath == "" {
+		log.Fatal("echo_module: CFGMS_MODULE_SOCKET environment variable is required")
+	}
+
+	lis, err := net.Listen("unix", socketPath)
+	if err != nil {
+		log.Fatalf("echo_module: failed to listen on %s: %v", socketPath, err)
+	}
+
+	srv := grpc.NewServer()
+	es := &echoServer{srv: srv}
+	proto.RegisterWorkflowModuleServiceServer(srv, es)
+
+	// Handle SIGTERM/SIGINT for graceful shutdown when killed by the runtime.
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGTERM, syscall.SIGINT)
+	go func() {
+		<-sigCh
+		srv.GracefulStop()
+	}()
+
+	if err := srv.Serve(lis); err != nil {
+		log.Fatalf("echo_module: gRPC server exited with error: %v", err)
+	}
+}

--- a/features/workflow/testmain_test.go
+++ b/features/workflow/testmain_test.go
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 CFGMS Contributors
+
+//go:build !windows
+
+package workflow
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+// integrationEchoModuleBin is the path to the compiled workflow echo_module
+// binary used by integration tests. Set by TestMain before any tests run;
+// empty string means the binary could not be compiled.
+var integrationEchoModuleBin string
+
+// integrationBinaryCleanupDir is cleaned up after all tests complete.
+var integrationBinaryCleanupDir string
+
+func TestMain(m *testing.M) {
+	os.Exit(runTestSuite(m))
+}
+
+func runTestSuite(m *testing.M) int {
+	var err error
+	integrationBinaryCleanupDir, err = os.MkdirTemp("", "cfgms-wf-int-bin-*")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "workflow_test: failed to create temp dir for echo_module: %v\n", err)
+		return 1
+	}
+	defer func() { _ = os.RemoveAll(integrationBinaryCleanupDir) }()
+
+	bin := filepath.Join(integrationBinaryCleanupDir, "echo_module")
+	// Path is relative to the features/workflow/ package directory where tests run.
+	cmd := exec.Command("go", "build", "-o", bin, "./runtime/testdata/echo_module")
+	if out, buildErr := cmd.CombinedOutput(); buildErr != nil {
+		fmt.Fprintf(os.Stderr, "workflow_test: echo_module build failed (integration tests will be skipped): %s: %v\n", out, buildErr)
+		// Non-fatal: unit tests in this package do not need the binary.
+	} else {
+		integrationEchoModuleBin = bin
+	}
+
+	return m.Run()
+}

--- a/features/workflow/testmain_windows_test.go
+++ b/features/workflow/testmain_windows_test.go
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 CFGMS Contributors
+
+//go:build windows
+
+package workflow
+
+import (
+	"os"
+	"testing"
+)
+
+// integrationEchoModuleBin is empty on Windows: the echo_module binary uses
+// Unix sockets and cannot run on Windows. Integration tests that depend on it
+// are skipped automatically when this is the empty string.
+var integrationEchoModuleBin string
+
+func TestMain(m *testing.M) {
+	os.Exit(m.Run())
+}


### PR DESCRIPTION
## Summary

- Adds `features/workflow/runtime` package: `ModuleRuntime` (fork/exec + Unix socket gRPC), `ModuleHandle` (implements `features/modules.Module`), `workflowConfigState`, and socket helpers for both Unix (with sun_path hash fallback for paths > 103 bytes) and Windows named pipes
- Adds `features/workflow/runtime/testdata/echo_module`: an out-of-process `WorkflowModuleServiceServer` that responds with `echo:<resource_id>`, compiled once per test run by `TestMain`
- Updates `WorkflowModuleFactory.CreateModuleInstance`: resolves approved bundle from `ModuleCache`, re-derives `Kind` from `Executors` when `yaml:"-"` omits it after deserialization, then calls `runtime.Start` and returns `*ModuleHandle` as `modules.Module` — no longer returns `ErrWorkflowRuntimeNotAvailable`
- Wires real `ModuleCache` and `ModuleRuntime` into `server.go`'s `initializeWorkflowHandler`

## Test plan

- [ ] `make test-commit` passes (security, lint, architecture, secrets)
- [ ] `make test-fast` passes (all packages including `features/workflow/runtime`)
- [ ] `TestEchoModuleLifecycle`: Start → gRPC Get → Stop lifecycle
- [ ] `TestEchoModuleLifecycle_ModuleInterface`: `ModuleHandle` satisfies `modules.Module`; Get/Set/ToYAML/GetManagedFields/Validate all verified
- [ ] `TestWorkflowModuleFactory_IntegrationWithEchoModule`: end-to-end cache lookup → fork/exec → gRPC call
- [ ] `TestStartReturnsErrWrongModuleKindForNonWorkflowBundle`: steward/outpost/empty kinds rejected before fork
- [ ] `TestStopIsIdempotent`: second Stop call returns no error

Fixes #1914

🤖 Generated with [Claude Code](https://claude.com/claude-code)