### PR TITLE
docs: correct ADR-011 lifecycle model + provenance decision (Issue #2092)

### DIFF
--- a/docs/architecture/decisions/011-registration-refresh.md
+++ b/docs/architecture/decisions/011-registration-refresh.md
@@ -6,21 +6,27 @@
 
 **Deciders:** Founder, Architecture
 
-**Related:** [001](001-central-provider-compliance-enforcement.md) (secrets central provider), [010](010-steward-side-provisioning-enrollment.md) (enrollment, which this protocol follows). Epic: #1845. Stories: S2 (steward detect + handshake), S3 (controller endpoint + policy), S4 (cfg CLI), S5 (fleet E2E).
+**Related:** [001](001-central-provider-compliance-enforcement.md) (secrets central provider), [010](010-steward-side-provisioning-enrollment.md) (enrollment, which this protocol follows). Epic: #1845. Stories: #2092 (this ADR), #2093 (storage foundation), #2094 (steward identity key + handshake), #2095 (controller persist-at-registration), #2096 (controller gate), #2097 (cfg admin CLI), #2098 (fleet E2E).
 
 ---
 
 ## Context
 
-A steward that was offline past its mTLS cert expiry is today completely locked out: its certificate is expired, mTLS handshakes fail, and re-registration from scratch loses fleet identity (tenant, group, audit history, pinned config). MSPs managing 50k+ endpoints across multiple time zones cannot guarantee all devices stay online within cert validity windows — devices hibernate, sites lose WAN for weeks, devices are in a warehouse.
+A steward that was offline past its mTLS cert expiry is today completely locked out: its certificate is expired, mTLS handshakes fail, and re-registration from scratch loses fleet identity (tenant, group, audit history, pinned config). MSPs managing 50k+ endpoints across multiple time zones cannot guarantee all devices stay online within cert validity windows — devices hibernate, sites lose WAN for weeks, devices sit in a warehouse.
 
-Three design questions had to be settled before any implementation could proceed, because the answers span multiple stories (S2–S5) and getting them wrong mid-implementation would require rewrites:
+Three design questions had to be settled before any implementation could proceed, because the answers span multiple stories and getting them wrong mid-implementation would require rewrites:
 
 1. **Device identity**: what credential proves "I am the same device that originally registered" when the mTLS cert is expired?
 2. **Proof of possession**: how does the controller verify that credential without trusting the expired cert at the TLS layer?
-3. **Revocation gate ordering**: how do we prevent the refresh path from becoming a re-registration bypass for a genuinely revoked steward?
+3. **Gate ordering and blast radius**: how do we prevent the refresh path from becoming a re-registration bypass for a revoked steward, and how do we honor "reconnect like nothing happened" for a normal long-offline device without auto-rehydrating a device an admin has retired?
 
-This ADR records the founder-approved answers so that S2–S5 implementers have no open design questions and any future change to the security model requires an explicit ADR update.
+The three founder requirements this protocol must satisfy:
+
+- **R1 — Archived devices need manual approval.** A device an admin has explicitly retired (`archived`) must never auto-rehydrate; it requires manual approval.
+- **R2 — Long-disconnected devices reconnect seamlessly.** A device offline for an extended period (even past mTLS cert expiry) can reconnect "like nothing happened," subject to the operator's policy.
+- **R3 — Always match the existing object.** A returning device is always matched to its existing record by stable `DeviceID` — it never registers as a new object, and recovery never destroys identity.
+
+This ADR records the founder-approved answers so implementers have no open design questions and any future change to the security model requires an explicit ADR update.
 
 ---
 
@@ -28,7 +34,7 @@ This ADR records the founder-approved answers so that S2–S5 implementers have 
 
 ### 1. Stable Ed25519 device identity key, separate from the rotating mTLS cert
 
-Each steward holds an **Ed25519 device identity key pair** (`device_id_ed25519.key` / `.pub`) that is generated once at first registration and never replaced. This is categorically different from the mTLS client certificate, which is short-lived and rotated:
+Each steward holds an **Ed25519 device identity key pair** that is generated once at first registration and never replaced. This is categorically different from the mTLS client certificate, which is short-lived and rotated:
 
 | | mTLS cert | Device identity key |
 |---|---|---|
@@ -37,60 +43,50 @@ Each steward holds an **Ed25519 device identity key pair** (`device_id_ed25519.k
 | Rotation | Yes, on renewal / refresh | Never |
 | Used by | gRPC-over-QUIC TLS handshake | Registration-refresh PoP only |
 
-The **64-char lowercase hex SHA-256 hash of the Ed25519 public key** is the `DeviceID`. It is stable across mTLS cert rotations and is the primary key in `GetStewardByDeviceID`. The controller stores the public key in the steward record at first registration.
+The **64-char lowercase hex SHA-256 hash of the Ed25519 public key** is the `DeviceID`: `hex.EncodeToString(sha256(publicKeyBytes))`. It is stable across mTLS cert rotations and is the primary lookup key in `GetStewardByDeviceID`. The controller stores the public key on the steward record at first registration (#2095); the expired mTLS cert serial is retained as a chain-of-custody/audit signal only, never as the PoP credential.
 
-The key is stored locally on the steward with a `key_protection_level` attribute:
+The key carries a `key_protection_level` attribute (`file` in v1; `tpm` / `secure-enclave` as future drop-ins). Whether a tenant *requires* a hardware-backed level is a future policy knob; v1 ships `file` and records the attested level so "require TPM" is additive later, not a re-architecture.
 
-```
-key_protection_level: file   # v1 — encrypted at rest via OS-level disk encryption
-# key_protection_level: tpm  # future drop-in when TPM is supported
-```
+### 2. File-backed KeyStore in v1, encrypted at rest at the application layer; TPM as a future drop-in
 
-### 2. File-backed KeyStore in v1; TPM as a future drop-in
+The private key is **encrypted at rest by the application**, via the existing steward secrets provider `pkg/secrets/providers/steward/crypto.go` (AES-256-GCM, HKDF-SHA256 from machine ID). It is written to `{identityDir}/device_identity.enc` with mode `0600`. **The plaintext private key never touches disk**, and the on-disk bytes are ciphertext — they must fail to parse as PEM or DER (this is a required test in #2094). This is stronger than relying on OS-level disk encryption alone, which would leave a cleartext key readable by any process with file access and violates the CFGMS "no cleartext secrets on disk, even in dev" rule.
 
-The `KeyStore` interface abstracts key material storage:
+The `KeyStore` interface abstracts key material storage and signing so a TPM/secure-enclave backend is a future drop-in with no protocol change:
 
 ```go
 type KeyStore interface {
-    LoadDeviceKey() (ed25519.PrivateKey, error)
-    StoreDeviceKey(key ed25519.PrivateKey) error
-    KeyProtectionLevel() string
+    // GenerateOrLoad returns the device identity keypair, creating and
+    // persisting it (encrypted) on first call.
+    GenerateOrLoad(ctx context.Context) (ed25519.PublicKey, ed25519.PrivateKey, error)
+    // DeviceID returns the stable 64-char lowercase hex DeviceID.
+    DeviceID() string
+    // Sign signs the PoP digest with the device identity private key.
+    Sign(message []byte) ([]byte, error)
 }
 ```
 
-V1 ships `FileKeyStore` (`key_protection_level: "file"`), which persists the private key to the steward's state directory. TPM-backed storage is a future drop-in that implements the same interface with `key_protection_level: "tpm"` — no other code changes required. V1 does not implement TPM; TPM integration is explicitly out of scope for this epic.
+### 3. Lifecycle state machine — the rehydration decision is gated on object state, not connectivity
 
-### 3. Lifecycle state machine — new states for this epic
+The existing steward lifecycle (`registered` → `active` → `lost` / `deregistered`) gains three states. The controller resolves the object by `DeviceID`, then gates the refresh outcome on that object's state. **Connectivity is not a state an admin sets** — a normally-offline device stays `active` (or `dormant` only if the backstop is enabled and tripped). Only an explicit admin **archive** action moves a device into the approval branch.
 
-The existing steward lifecycle (`registered` → `active` → `lost` / `deregistered`) is extended with three new states:
+| State | Set by | Refresh outcome |
+|-------|--------|-----------------|
+| `active` / `registered` | normal operation | **Policy-governed** (see §6): `auto_accept` → 200 seamless cert; `require_approval` → 202 queued; `reject` → 403. Provenance (§7) may demote `auto_accept` → 202. |
+| `dormant` | dormancy backstop (default OFF) | Same policy-governed path as `active`; when the backstop is enabled and the device is past `MaxDormancyDays`, the decision is **escalated to `require_approval`** (202) for that request. Never re-register — identity is preserved (R3). |
+| `archived` | **explicit admin action** | **Always 202 queued for approval, regardless of policy** (R1). Archive is how an admin says "this device must not silently come back." |
+| `revoked` | **explicit admin action** | **Always 403, checked before PoP** (§5). Terminal — return to service requires a deliberate admin action, not a refresh. |
 
-```
-registered ──► active ──► lost ──────────────────────────────┐
-                   │                                          │
-                   └──► archived ──► (pending-refresh queue) │
-                          │                                   │
-                          └──► dormant  (backstop, default OFF)
-                                  │
-                          revoked ◄┘──── (any state → revoked is always allowed)
-```
+This satisfies all three requirements: a normal long-offline device rehydrates per policy and can be seamless (R2: operator sets `auto_accept`); an admin-archived device always needs approval (R1); every returning device is matched to its existing record and never loses identity (R3).
 
-| New State | Meaning | Refresh allowed? |
-|-----------|---------|-----------------|
-| `archived` | Offline past mTLS cert expiry; identity intact | Yes — queued for approval |
-| `dormant` | Offline past `MaxDormancyDays` threshold (backstop) | No — must re-register |
-| `revoked` | Explicitly revoked by admin | No — 403 immediately |
+**State transitions are monotonic (non-promoting):** a refresh can never move a steward to a *less*-restricted state. An archived/revoked device is never auto-promoted to `active` by the refresh path; promotion to `active` happens only through a completed, approved refresh that issues a cert (for `archived`) or an explicit admin action (for `revoked`). This monotonicity is a separate property from §7 provenance — do not conflate the two.
 
-**Provenance is demote-only:** state transitions can only move a steward to a more-restricted state. An admin cannot directly promote `archived` → `active`; promotion happens only via a completed refresh that results in cert issuance. `revoked` is a terminal state — no direct path back to `active` (re-registration after revocation requires manual admin action).
-
-**Dormancy backstop** (`MaxDormancyDays`): an optional config knob that auto-demotes `archived` → `dormant` after N days of no contact. Default is **OFF** (`MaxDormancyDays: nil`). When nil, stewards stay `archived` indefinitely. MSPs with stricter policies can set this; it is never a silent surprise default.
-
-**Pending-refresh queue:** when an `archived` steward initiates refresh and policy is `require_approval`, a `PendingRefresh` record is created and the steward polls until approved or rejected. Only `archived` stewards enter the pending queue; `dormant` and `revoked` stewards receive 403 immediately.
+**Dormancy backstop** (`MaxDormancyDays`): an optional per-tenant config knob. Default **OFF** (`nil`) — stewards rehydrate per policy indefinitely, honoring R2 out of the box. When set, a device past the threshold is escalated to `require_approval` for its next refresh (it is *not* rejected and *not* forced to re-register). MSPs with stricter blast-radius requirements opt in; it is never a silent default.
 
 ### 4. Registration-refresh wire protocol — two new endpoints
 
-The existing no-op HA stub at `POST /api/v1/stewards/{id}/auth/refresh` (`features/controller/api/handlers_stewards.go:561`, `handleStewardAuthRefresh`) is **NOT** this epic's endpoint. It is an HA test instrumentation surface that acknowledges refresh requests without modifying any credential state. It must not be modified or repurposed by this epic.
+The existing no-op HA stub at `POST /api/v1/stewards/{id}/auth/refresh` (`features/controller/api/handlers_stewards.go:561`, `handleStewardAuthRefresh`) is **NOT** this epic's endpoint. It is an HA test-instrumentation surface that acknowledges refresh requests without modifying credential state. It must not be modified or repurposed by this epic.
 
-This epic adds two new endpoints in a new file `features/controller/api/handlers_registration_refresh.go`:
+This epic adds two endpoints in a new file `features/controller/api/handlers_registration_refresh.go`:
 
 ```
 POST /api/v1/stewards/{device_id}/refresh/challenge
@@ -101,105 +97,113 @@ POST /api/v1/stewards/{device_id}/refresh/complete
 
 Request: `{ "device_id": "<64-char hex>" }`
 
-Controller response (200):
+Before issuing a nonce, the controller checks:
+1. `GetStewardByDeviceID(device_id)` — not found → **404**
+2. `record.Status == revoked` → **403 immediately** (no nonce issued — a revoked device gets no cryptographic feedback)
+3. any other state (`active` / `registered` / `dormant` / `archived`) → **200 + nonce** (a refresh candidate; the lifecycle/policy decision is made at `/complete`)
+
+Response (200):
 ```json
-{
-  "nonce": "<base64url-encoded 32 random bytes>",
-  "server_ts": <unix-seconds-uint64>,
-  "expires_in": 60
-}
+{ "nonce": "<base64url 32 random bytes>", "server_ts": <unix-seconds-uint64>, "expires_in": 60 }
 ```
 
-The nonce is single-use, stored in an in-memory cache with a **65-second TTL** (60 s enforced server-side + 5 s grace for clock drift). Any replay of the same nonce after first use returns 409 Conflict.
-
-Before issuing the nonce, the controller checks:
-1. `GetStewardByDeviceID(device_id)` — if record not found → 404
-2. `record.Status == revoked` → 403 **immediately** (no nonce issued)
-3. `record.Status == dormant` → 403 (dormant stewards must re-register)
-4. `record.Status == archived` → 200 + nonce (valid refresh candidate)
+The nonce is single-use, stored in an in-memory cache with a **65-second TTL** (60 s enforced server-side + 5 s grace for clock drift). It is consumed (deleted) on first use at `/complete`. A replayed, expired, or absent nonce is rejected with **401** — identical handling for all three, so a caller learns nothing from the distinction.
 
 #### Complete phase (`/refresh/complete`)
 
 Request:
 ```json
 {
-  "device_id": "<64-char hex>",
-  "nonce":     "<base64url nonce from /challenge>",
-  "pop":       "<base64url ed25519 signature>"
+  "device_id":       "<64-char hex>",
+  "nonce":           "<base64url nonce from /challenge>",
+  "pop":             "<base64url ed25519 signature>",
+  "host_attributes": { "...": "..." }
 }
 ```
 
-The `pop` (proof-of-possession) signature covers the following digest, computed identically by the steward (S2) and the controller (S3b):
+The `pop` (proof-of-possession) signature covers a digest computed **identically** by the steward (#2094) and the controller (#2096):
 
 ```
 digest = sha256(nonce_bytes || device_id_utf8 || server_ts_big_endian_uint64)
 ```
 
-Where:
 - `nonce_bytes` — raw bytes of the base64url-decoded nonce (32 bytes)
-- `device_id_utf8` — UTF-8 bytes of the 64-character lowercase hex `DeviceID`
-- `server_ts_big_endian_uint64` — the `server_ts` value from the challenge response, encoded as a big-endian unsigned 64-bit integer (8 bytes)
+- `device_id_utf8` — UTF-8 bytes of the 64-char lowercase hex `DeviceID`
+- `server_ts_big_endian_uint64` — the `server_ts` from the challenge response, big-endian uint64 (8 bytes)
 
-**This formula must appear identically in S2 (steward side) and S3b (controller side).** Any deviation between the two is a security bug.
+**Any deviation between the two implementations is a security bug.**
 
 ### 5. Revocation-before-PoP ordering invariant (mandatory)
 
-The revocation check MUST precede signature verification in `/refresh/complete`. The controller handler MUST follow this order:
+The controller `/refresh/complete` handler MUST follow this order; each step short-circuits:
 
 ```
-1. GetStewardByDeviceID(device_id)      → 404 if not found
-2. record.Status == revoked             → 403 BEFORE any ed25519.Verify call
-3. consume nonce (mark used)            → 409 if already consumed
-4. ed25519.Verify(pubkey, digest, pop)  → 401 if signature invalid
-5. apply refresh policy                 → 202 (pending) or 200 (cert issued)
+1. GetStewardByDeviceID(device_id)        → 404 if not found
+2. record.Status == revoked               → 403 BEFORE any ed25519.Verify call
+3. tenant check: record.TenantID != req   → 403 (not 404 — 404 leaks existence)
+4. consume nonce (delete; 401 if absent/expired/used)
+5. PoPVerifier.Verify(pubkey, digest, pop) → 401 if signature invalid
+6. lifecycle + policy + provenance gate (§3, §6, §7) → 200 / 202 / 403
+7. audit the outcome (accept / queue / reject) → before WriteHeader
 ```
 
-**Why this order matters:** if PoP verification precedes the revocation check, an attacker with a stolen device key can learn "my key is still valid" from a successful signature check even though the device is revoked. The 403 from revocation must be unconditional and prior to any cryptographic feedback.
+**Why the order matters:** the device-revocation signal is `record.Status == revoked`, *not* the cert-serial revocation store (`pkg/cert/revocation.go`), which is serial-keyed and admin-cert-scoped and is **not** populated when a steward device is revoked. The authoritative check is therefore the status check, and it must precede signature verification — otherwise a stolen-but-revoked device key produces a successful verify and the attacker learns the key is still valid. Revocation must be unconditional and prior to any cryptographic feedback. The cert-serial revocation store MAY be consulted as a secondary defense-in-depth check, but it is not the primary signal.
 
-The controller implements this via an injectable `PoPVerifier` interface:
+The check is implemented behind an injectable `PoPVerifier` so tests can assert `Verify` is called **zero times** for a revoked device (a 403 response alone does not prove the invariant):
 
 ```go
 type PoPVerifier interface {
-    // VerifyPoP checks the proof-of-possession for the given device.
-    // Returns ErrDeviceRevoked before any cryptographic check if the device is revoked.
-    // Returns ErrNonceExpiredOrUsed if the nonce is invalid.
-    // Returns ErrInvalidPoP if the signature does not verify.
-    VerifyPoP(ctx context.Context, deviceID string, nonce string, pop []byte) error
+    Verify(pub ed25519.PublicKey, msg, sig []byte) bool
 }
 ```
 
-The interface is injectable to allow test implementations that exercise each error path without real Ed25519 operations.
+### 6. Refresh policy — per-tenant, safe default
 
-### 6. Policy defaults
+Policy governs only the `active` / `dormant` path (`archived` and `revoked` are policy-independent per §3).
 
-| Policy knob | Default | Meaning |
-|-------------|---------|---------|
-| `refresh_policy` | `require_approval` | Admin must approve each refresh request |
-| `auto_accept` | (not the default) | Auto-issue cert without approval; only if explicitly configured |
-| `MaxDormancyDays` | `nil` (OFF) | No automatic dormancy; stewards stay `archived` indefinitely |
+| Policy `Mode` | Default? | Outcome for active/dormant |
+|---------------|----------|----------------------------|
+| `require_approval` | **yes** | 202 — admin must approve each refresh |
+| `auto_accept` | no (opt-in) | 200 — cert issued without approval (the seamless R2 experience); subject to provenance demotion |
+| `reject` | no | 403 — refresh disabled for the tenant |
 
-The default is `require_approval` (not `auto_accept`) because the threat model for registration-refresh is similar to initial registration: an admin account may be transiently compromised, and automatic cert issuance without approval expands the blast radius of such a compromise. Operators who trust their infrastructure can opt into `auto_accept`.
+`GetPolicy` returns `{Mode: "require_approval", DormancyBackstopEnabled: false, MaxDormancyDays: nil}` when no record exists. The default is `require_approval`, not `auto_accept`: the refresh threat model mirrors initial registration — a transiently compromised admin account should not yield automatic cert issuance. Operators who want "reconnect like nothing happened" with no human in the loop opt into `auto_accept` deliberately (R2 is achievable, not the unsafe default).
+
+### 7. Provenance — demote-only confidence signal from soft host attributes
+
+On `/refresh/complete`, the steward includes a `host_attributes` map (SMBIOS/machine UUID, disk serial(s), NIC MAC(s), install date, cert-serial lineage). The controller's `ProvenanceMatcher.FuzzyMatch(stored, incoming) → ProvenanceResult{Score, MatchedFields, TotalFields}` compares them, N-of-M tolerant, against the last-known recorded set (default threshold **60%**). The result is recorded to `StewardRecord.LastProvenanceJSON`.
+
+Provenance is strictly **demote-only**:
+- A below-threshold score **demotes** an `auto_accept` decision to `require_approval` (202), so a device whose hardware fingerprint looks wrong gets a human in the loop even under `auto_accept`. The admin sees the attribute diff in the pending-refresh queue.
+- Provenance can **never promote**: an `archived` or `revoked` device is never auto-rehydrated regardless of a perfect provenance score. The revocation/lifecycle gates (§3, §5) run *before* provenance is consulted. (Required test: revoked + perfect score → 403, `PoPVerifier.Verify` call count == 0.)
+- **DNA is explicitly not a provenance input.** Config/managed-state DNA (`dna_hash`, `dna_aggregate`) is non-secret and shared across a ring — it has near-zero per-device entropy and is excluded from `FuzzyMatch` inputs (enforced by test).
+
+Provenance is corroboration, not proof: the cryptographic identity proof is the PoP (§4–5). A device-image attacker holds both the key and the attributes, so provenance only ever *adds* friction (demote), never removes a gate.
 
 ---
 
 ## Consequences
 
 **Positive**
-- Stewards that go offline past cert expiry recover fleet identity without manual re-registration.
-- Stable device ID (Ed25519 key hash) survives mTLS rotations, controller upgrades, and hostname changes.
-- Revocation gate ordering is explicit and tested — the refresh path cannot bypass a revoked status.
-- `KeyStore` interface makes TPM support a future drop-in with no protocol changes.
+- Stewards offline past cert expiry recover fleet identity without manual re-registration; identity (`DeviceID`) survives mTLS rotations, controller upgrades, and hostname changes (R3).
+- A normal long-offline device reconnects per policy and can be made seamless via `auto_accept` (R2); an admin-archived device always requires approval (R1).
+- Revocation gate ordering is explicit and tested — the refresh path cannot bypass a revoked status, and no cryptographic feedback precedes the revocation check.
+- Identity key is application-encrypted at rest; the `KeyStore` interface makes TPM a future drop-in with no protocol change.
 - Conservative defaults (`require_approval`, dormancy OFF) match the operator threat model; operators opt into looser policies, not into tighter ones.
 
 **Negative / risks (accepted)**
-- A stolen device key allows an attacker to initiate a refresh handshake. Mitigation: the revocation check fires before PoP, so a revoked device key produces a 403 before the attacker learns anything cryptographic. For non-revoked devices, the `require_approval` default means an admin must approve before a cert is issued.
-- File-backed key storage (`key_protection_level: file`) relies on OS disk encryption for confidentiality. This is acceptable for v1 given the threat model (stewards run on managed, EDR-covered endpoints); TPM is the hardening path.
-- Nonce TTL of 65 s means the challenge–complete round trip must complete within that window. This is generous for any non-hibernating network path.
+- A stolen device key allows an attacker to *initiate* a refresh handshake. Mitigations: revocation check fires before PoP (revoked → 403 with no crypto feedback); the `require_approval` default keeps a human in the loop; provenance demotes a mismatched-hardware refresh to approval even under `auto_accept`.
+- File-backed key storage is application-encrypted (AES-256-GCM) but still resident on a host that may be compromised; TPM is the hardening path (deferred), made cheap by the `KeyStore` abstraction and the recorded `key_protection_level`.
+- Nonce TTL of 65 s means the challenge→complete round trip must complete within that window — generous for any non-hibernating path.
 
 ## Alternatives considered
 
-- **Reuse the existing `/auth/refresh` HA stub endpoint.** Rejected — the stub is an HA test surface with no cryptographic semantics. Repurposing it would conflate two unrelated operations and introduce subtle HA-vs-security coupling.
-- **Use the expired mTLS cert directly as proof of identity.** Rejected — expired certs are not verifiable at the TLS layer without special exemptions, which would require disabling standard TLS validation for the refresh path. The Ed25519 identity key is explicitly not subject to cert expiry.
-- **Auto-accept by default.** Rejected — the `require_approval` default is intentional. Auto-accept expands blast radius for compromised admin accounts. Operators opt into auto-accept explicitly.
-- **Shared nonce cache via HA replication.** Deferred — single-instance controller in v1; nonce cache is in-process. When multi-controller HA ships, the nonce cache moves to the shared durable store (same pattern as session store).
-- **TPM-backed key storage in v1.** Explicitly deferred — out of scope for this epic. The `KeyStore` interface is designed so TPM is a drop-in.
+- **Reuse the existing `/auth/refresh` HA stub.** Rejected — the stub is an HA test surface with no cryptographic semantics; repurposing it conflates two unrelated operations.
+- **Use the expired mTLS cert directly as proof of identity.** Rejected — expired certs are not verifiable at the TLS layer without disabling standard validation for the refresh path. The Ed25519 identity key is explicitly not subject to cert expiry. (The expired cert serial is kept only as an audit/chain-of-custody signal.)
+- **Auto-accept by default.** Rejected — expands blast radius for a compromised admin account. `require_approval` is the default; `auto_accept` is opt-in.
+- **Treat every offline-past-expiry device as needing approval (no seamless path).** Rejected — this breaks R2. The seamless path exists via the `active`/`dormant` policy branch with `auto_accept`; only explicit admin `archive` forces approval.
+- **`dormant` → force full re-registration.** Rejected — re-registration destroys fleet identity (violates R3). The dormancy backstop escalates to `require_approval`, preserving identity.
+- **Cert-serial revocation store as the device-revocation signal.** Rejected — it is admin-cert-scoped and not populated on device revocation; `StewardStatus == revoked` is the authoritative signal.
+- **DNA as an identity/provenance input.** Rejected — non-secret and ring-shared; excluded from provenance scoring.
+- **Shared nonce cache via HA replication.** Deferred — single-instance controller in v1; nonce cache is in-process and moves to the shared durable store when multi-controller HA ships.
+- **TPM-backed key storage in v1.** Deferred — out of scope; the `KeyStore` interface and `key_protection_level` attribute make it a drop-in.


### PR DESCRIPTION
## What

Corrects **ADR-011** (registration-refresh), which was dispatched to an agent (PR #2100, issue #2092) and shipped a lifecycle model that contradicted the founder-approved design.

## Why

The merged ADR passed keyword review but inverted the product semantics:

- **No seamless rehydrate path** — every offline-past-expiry steward was routed to `archived → require_approval`, breaking the "reconnect like nothing happened" requirement.
- **`dormant → must re-register`** — destroys device identity (violates "always match the existing object").
- **`archived` redefined** as "any offline-past-expiry" instead of an explicit admin-retire action, collapsing the distinction between the two requirements.
- **Provenance decision missing** — the word "provenance" was reused for state-machine monotonicity; the host-attribute confidence-score model (with DNA exclusion) had no design of record.
- **Key-at-rest** described as OS-disk-encryption; the design and tests require application-level AES-256-GCM.
- Nonce replay returned `409`; story #2096 tests expect `401`.

## Change

Restores the locked model: `active`/`dormant` rehydrate per policy (`auto_accept` = seamless); `archived` = explicit admin retire → always approval; dormancy backstop escalates to approval (never re-register); `revoked` → 403 before PoP. Re-adds the demote-only provenance decision. Fixes the key-at-rest encryption claim and the replay status code. Updates Related/Stories to the real 7-story decomposition.

The security mechanics the agent got right (revocation-before-PoP ordering, injectable `PoPVerifier`, PoP digest formula, nonce TTL, no-op stub disambiguation) are preserved.

Going forward, ADRs are drafted inline rather than dispatched — agents lack the design-conversation context to get them right.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
