### PR TITLE
test: fleet e2e for registration-refresh recovery (Issue #2098)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1975,7 +1975,7 @@ test-e2e-fleet: build-cli
 	docker compose --profile fleet -f docker-compose.test.yml up -d --build --wait; \
 	echo ""; \
 	echo "Running fleet E2E tests..."; \
-	CFG_BINARY=$(CURDIR)/bin/cfg CFGMS_FLEET_TEST=1 go test -v -timeout 300s ./test/e2e/fleet/...
+	CFG_BINARY=$(CURDIR)/bin/cfg CFGMS_FLEET_TEST=1 go test -v -timeout 600s ./test/e2e/fleet/...
 	@echo ""
 	@echo "✅ FLEET E2E TESTS PASSED"
 

--- a/cmd/steward/main.go
+++ b/cmd/steward/main.go
@@ -155,6 +155,14 @@ func runSteward(ctx context.Context, regToken, configPath string) error {
 	if err := logging.InitializeGlobalLogging(loggingConfig); err != nil {
 		return fmt.Errorf("failed to initialize global logging: %w", err)
 	}
+	// Flush and close the logger when runSteward returns so that buffered log
+	// entries (AsyncWrites=true, FlushInterval=5s) reach disk before os.Exit
+	// is called — critical for short-lived exit paths (e.g. ErrRefreshRejected).
+	defer func() {
+		if mgr := logging.GetGlobalLoggingManager(); mgr != nil {
+			_ = mgr.Close()
+		}
+	}()
 	(&logging.TelemetryBridge{}).Initialize()
 
 	logging.InitializeGlobalLoggerFactory("steward", "main")
@@ -1225,10 +1233,18 @@ func refreshAndConnect(
 		"steward_id", logging.SanitizeLogValue(id.StewardID))
 
 	// Persist the refreshed identity with updated certs.
+	// The controller's refresh response does not include TransportAddress or ServerCert
+	// (the connection endpoint and signing cert do not change during cert refresh).
+	// Preserve the stored values as authoritative fallbacks so the reconnect succeeds
+	// even when the controller omits those optional fields.
 	updatedID := *id
 	updatedID.CACertPEM = completeResp.CACert
-	updatedID.ServerCertPEM = completeResp.ServerCert
-	updatedID.TransportAddress = completeResp.TransportAddress
+	if completeResp.ServerCert != "" {
+		updatedID.ServerCertPEM = completeResp.ServerCert
+	}
+	if completeResp.TransportAddress != "" {
+		updatedID.TransportAddress = completeResp.TransportAddress
+	}
 	if saveErr := saveIdentity(certStoreDir, updatedID); saveErr != nil {
 		logger.Warn("Failed to persist refreshed identity; next restart may re-register", "error", saveErr)
 	}
@@ -1236,11 +1252,11 @@ func refreshAndConnect(
 	bundle := approvedRegistration{
 		StewardID:        id.StewardID,
 		TenantID:         id.TenantID,
-		TransportAddress: completeResp.TransportAddress,
+		TransportAddress: updatedID.TransportAddress,
 		ClientCert:       completeResp.ClientCert,
 		ClientKey:        completeResp.ClientKey,
 		CACert:           completeResp.CACert,
-		ServerCert:       completeResp.ServerCert,
+		ServerCert:       updatedID.ServerCertPEM,
 	}
 	enrichApprovedWithDeviceIdentity(&bundle, ks)
 	return connectWithApprovedRegistration(ctx, bundle, certStoreDir, token, logger)

--- a/cmd/steward/main.go
+++ b/cmd/steward/main.go
@@ -1224,7 +1224,7 @@ func refreshAndConnect(
 	completeCtx, completeCancel := context.WithTimeout(ctx, 30*time.Second)
 	defer completeCancel()
 
-	completeResp, err := httpClient.RefreshComplete(completeCtx, ks.DeviceID(), challenge.Nonce, pop)
+	completeResp, err := httpClient.RefreshComplete(completeCtx, ks.DeviceID(), id.TenantID, challenge.Nonce, int64(challenge.ServerTS), pop)
 	if err != nil {
 		return nil, err // ErrRefreshPending or ErrRefreshRejected propagated to caller
 	}

--- a/features/controller/api/handlers_registration_refresh.go
+++ b/features/controller/api/handlers_registration_refresh.go
@@ -112,7 +112,7 @@ func (s *Server) handleRefreshChallenge(w http.ResponseWriter, r *http.Request) 
 			s.emitRefreshAudit(r.Context(), deviceID, req.TenantID,
 				business.AuditEventSecurityEvent, "refresh_challenge_rejected",
 				business.AuditResultFailure, business.AuditSeverityMedium,
-				map[string]interface{}{"reason": "unknown_device"})
+				map[string]interface{}{"decision": "rejected", "reason": "unknown_device"})
 			http.Error(w, "device not found", http.StatusNotFound)
 			return
 		}
@@ -130,7 +130,7 @@ func (s *Server) handleRefreshChallenge(w http.ResponseWriter, r *http.Request) 
 		s.emitRefreshAudit(r.Context(), deviceID, record.TenantID,
 			business.AuditEventSecurityEvent, "refresh_challenge_rejected",
 			business.AuditResultDenied, business.AuditSeverityCritical,
-			map[string]interface{}{"reason": "revoked"})
+			map[string]interface{}{"decision": "denied", "reason": "revoked"})
 		http.Error(w, "device is revoked", http.StatusForbidden)
 		return
 	}
@@ -140,7 +140,7 @@ func (s *Server) handleRefreshChallenge(w http.ResponseWriter, r *http.Request) 
 		s.emitRefreshAudit(r.Context(), deviceID, req.TenantID,
 			business.AuditEventSecurityEvent, "refresh_challenge_rejected",
 			business.AuditResultDenied, business.AuditSeverityCritical,
-			map[string]interface{}{"reason": "cross_tenant"})
+			map[string]interface{}{"decision": "denied", "reason": "cross_tenant"})
 		http.Error(w, "tenant mismatch", http.StatusForbidden)
 		return
 	}
@@ -214,7 +214,7 @@ func (s *Server) handleRefreshComplete(w http.ResponseWriter, r *http.Request) {
 			s.emitRefreshAudit(r.Context(), deviceID, req.TenantID,
 				business.AuditEventSecurityEvent, "refresh_rejected",
 				business.AuditResultFailure, business.AuditSeverityMedium,
-				map[string]interface{}{"reason": "unknown_device"})
+				map[string]interface{}{"decision": "rejected", "reason": "unknown_device"})
 			http.Error(w, "device not found", http.StatusNotFound)
 			return
 		}
@@ -232,7 +232,7 @@ func (s *Server) handleRefreshComplete(w http.ResponseWriter, r *http.Request) {
 		s.emitRefreshAudit(r.Context(), deviceID, record.TenantID,
 			business.AuditEventSecurityEvent, "refresh_rejected",
 			business.AuditResultDenied, business.AuditSeverityCritical,
-			map[string]interface{}{"reason": "revoked"})
+			map[string]interface{}{"decision": "denied", "reason": "revoked"})
 		http.Error(w, "device is revoked", http.StatusForbidden)
 		return
 	}
@@ -242,7 +242,7 @@ func (s *Server) handleRefreshComplete(w http.ResponseWriter, r *http.Request) {
 		s.emitRefreshAudit(r.Context(), deviceID, req.TenantID,
 			business.AuditEventSecurityEvent, "refresh_rejected",
 			business.AuditResultDenied, business.AuditSeverityCritical,
-			map[string]interface{}{"reason": "cross_tenant"})
+			map[string]interface{}{"decision": "denied", "reason": "cross_tenant"})
 		http.Error(w, "tenant mismatch", http.StatusForbidden)
 		return
 	}
@@ -399,7 +399,7 @@ func (s *Server) handleRefreshByPolicy(
 		s.emitRefreshAudit(r.Context(), deviceID, record.TenantID,
 			business.AuditEventAuthentication, "refresh_cert_issued",
 			business.AuditResultSuccess, business.AuditSeverityHigh,
-			map[string]interface{}{"decision": "approved"})
+			map[string]interface{}{"decision": "approved", "reason": "auto_accept"})
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 		if err := json.NewEncoder(w).Encode(resp); err != nil {
@@ -690,6 +690,20 @@ func (s *Server) handleApproveRefresh(w http.ResponseWriter, r *http.Request) {
 			business.AuditResultError, business.AuditSeverityHigh,
 			map[string]interface{}{"pending_id": logging.SanitizeLogValue(pendingID), "reason": "store_error"})
 		http.Error(w, "failed to get steward", http.StatusInternalServerError)
+		return
+	}
+
+	// Gate: revocation re-check before issuing a cert. The challenge and complete
+	// paths reject revoked devices, but a device can be revoked AFTER its refresh
+	// was queued as pending. Approving a now-revoked device must NOT issue a cert —
+	// and must not let buildRefreshClaimResponse promote revoked->registered,
+	// silently un-revoking it. Mirror the challenge/complete revocation gate.
+	if record.Status == business.StewardStatusRevoked {
+		s.emitRefreshAudit(r.Context(), entry.DeviceID, record.TenantID,
+			business.AuditEventSecurityEvent, "refresh_admin_approve_rejected",
+			business.AuditResultDenied, business.AuditSeverityCritical,
+			map[string]interface{}{"pending_id": logging.SanitizeLogValue(pendingID), "decision": "denied", "reason": "revoked"})
+		http.Error(w, "device is revoked", http.StatusForbidden)
 		return
 	}
 

--- a/features/controller/api/handlers_registration_refresh.go
+++ b/features/controller/api/handlers_registration_refresh.go
@@ -371,15 +371,20 @@ func (s *Server) handleRefreshByPolicy(
 		http.Error(w, "refresh rejected by tenant policy", http.StatusForbidden)
 
 	case "auto_accept":
-		pm := registration.ProvenanceMatcher{}
-		result := pm.FuzzyMatch(record.LastProvenanceJSON, provenance)
-		if result.Score < registration.ProvenanceMatchThreshold {
-			// Demote to require_approval (demote-only invariant).
-			s.handleRefreshQueueEntry(w, r, record, deviceID, provenance,
-				result.MatchedFields, result.TotalFields, "auto_accept_demoted")
-			return
+		// Only compare provenance when a baseline exists. A missing baseline (first
+		// refresh after initial registration) is not evidence of device change —
+		// the check is skipped and the cert is issued immediately.
+		if record.LastProvenanceJSON != "" {
+			pm := registration.ProvenanceMatcher{}
+			result := pm.FuzzyMatch(record.LastProvenanceJSON, provenance)
+			if result.Score < registration.ProvenanceMatchThreshold {
+				// Demote to require_approval (demote-only invariant).
+				s.handleRefreshQueueEntry(w, r, record, deviceID, provenance,
+					result.MatchedFields, result.TotalFields, "auto_accept_demoted")
+				return
+			}
 		}
-		// Sufficient provenance: issue new certificate immediately.
+		// No stored provenance baseline, or sufficient provenance match: issue cert immediately.
 		resp, err := s.buildRefreshClaimResponse(r.Context(), record)
 		if err != nil {
 			s.logger.Error("Failed to issue refresh certificate", "steward_id", record.ID, "error", err)
@@ -393,11 +398,7 @@ func (s *Server) handleRefreshByPolicy(
 		s.emitRefreshAudit(r.Context(), deviceID, record.TenantID,
 			business.AuditEventAuthentication, "refresh_cert_issued",
 			business.AuditResultSuccess, business.AuditSeverityHigh,
-			map[string]interface{}{
-				"decision":       "approved",
-				"matched_fields": result.MatchedFields,
-				"total_fields":   result.TotalFields,
-			})
+			map[string]interface{}{"decision": "approved"})
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 		if err := json.NewEncoder(w).Encode(resp); err != nil {

--- a/features/controller/api/handlers_registration_refresh.go
+++ b/features/controller/api/handlers_registration_refresh.go
@@ -83,6 +83,7 @@ type RefreshCompleteResponse struct {
 	ClientKey   string `json:"client_key,omitempty"`
 	CACert      string `json:"ca_cert,omitempty"`
 	SigningCert string `json:"signing_cert,omitempty"`
+	ServerCert  string `json:"server_cert,omitempty"` // same value as signing_cert; matches initial registration response field name
 }
 
 // ---- Handlers ---------------------------------------------------------------
@@ -501,6 +502,7 @@ func (s *Server) buildRefreshClaimResponse(ctx context.Context, record *business
 
 	if signingCertPEM, sigErr := s.certManager.GetSigningCertificate(); sigErr == nil && len(signingCertPEM) > 0 {
 		resp.SigningCert = string(signingCertPEM)
+		resp.ServerCert = string(signingCertPEM) // matches initial registration response field name
 	}
 
 	// Promote steward back to registered status after cert issuance.

--- a/features/controller/api/handlers_registration_refresh.go
+++ b/features/controller/api/handlers_registration_refresh.go
@@ -793,9 +793,9 @@ func (s *Server) handleRejectRefresh(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusOK)
 }
 
-// handleGetRefreshPolicy handles GET /api/v1/tenants/{id}/refresh-policy.
+// handleGetRefreshPolicy handles GET /api/v1/tenants/{tenant_path}/refresh-policy.
 func (s *Server) handleGetRefreshPolicy(w http.ResponseWriter, r *http.Request) {
-	tenantID := mux.Vars(r)["id"]
+	tenantID := mux.Vars(r)["tenant_path"]
 
 	// Cross-tenant: a scoped caller may only read policy for their own tenant hierarchy.
 	callerTenant, _ := r.Context().Value(ctxkeys.TenantID).(string)
@@ -830,9 +830,9 @@ func (s *Server) handleGetRefreshPolicy(w http.ResponseWriter, r *http.Request) 
 	}
 }
 
-// handleSetRefreshPolicy handles PUT /api/v1/tenants/{id}/refresh-policy.
+// handleSetRefreshPolicy handles PUT /api/v1/tenants/{tenant_path}/refresh-policy.
 func (s *Server) handleSetRefreshPolicy(w http.ResponseWriter, r *http.Request) {
-	tenantID := mux.Vars(r)["id"]
+	tenantID := mux.Vars(r)["tenant_path"]
 
 	// Cross-tenant: a scoped caller may only write policy for their own tenant hierarchy.
 	callerTenant, _ := r.Context().Value(ctxkeys.TenantID).(string)

--- a/features/controller/api/handlers_registration_refresh.go
+++ b/features/controller/api/handlers_registration_refresh.go
@@ -505,7 +505,19 @@ func (s *Server) buildRefreshClaimResponse(ctx context.Context, record *business
 		resp.ServerCert = string(signingCertPEM) // matches initial registration response field name
 	}
 
-	// Promote steward back to registered status after cert issuance.
+	// Promote steward back to registered status after cert issuance. This must be
+	// written to the PERSISTENT steward store, because the registration-refresh
+	// lifecycle gate reads status via stewardStore.GetStewardByDeviceID. Updating
+	// only the in-memory service registry (below) leaves an admin-approved *archived*
+	// steward looking archived to the next challenge, so it re-queues indefinitely
+	// and only converges via slow background reconciliation
+	// (Issue #2098: TestFleetRegistrationRefresh/Archived).
+	if s.stewardStore != nil {
+		if err := s.stewardStore.UpdateStewardStatus(ctx, record.ID, business.StewardStatusRegistered); err != nil {
+			s.logger.Warn("Failed to persist steward status after refresh cert issuance",
+				"steward_id", record.ID, "error", err)
+		}
+	}
 	if s.controllerService != nil {
 		if err := s.controllerService.UpdateStewardStatus(record.ID, "registered"); err != nil {
 			s.logger.Warn("Failed to update steward status after refresh cert issuance",

--- a/features/controller/api/handlers_registration_refresh_test.go
+++ b/features/controller/api/handlers_registration_refresh_test.go
@@ -1175,3 +1175,44 @@ func TestRefresh_NoPolicyDefault(t *testing.T) {
 	assert.Equal(t, http.StatusAccepted, rec.Code, "default policy must queue: %s", rec.Body.String())
 	assert.Equal(t, 1, prs.count(), "one pending entry must be created")
 }
+
+// TestRefresh_AutoAccept_NoProvenanceBaseline verifies that auto_accept policy issues a
+// cert immediately when the steward has no stored provenance (LastProvenanceJSON == "").
+// Initial registration never stores provenance, so the first refresh must not be demoted
+// to require_approval by a score-of-zero comparison against an absent baseline.
+func TestRefresh_AutoAccept_NoProvenanceBaseline(t *testing.T) {
+	pub, priv := newTestEd25519KeyPair(t)
+	ss := newTestStewardStore()
+	ss.add(&business.StewardRecord{
+		ID:                 "s-active",
+		DeviceID:           testDeviceID,
+		TenantID:           testTenantID,
+		Status:             business.StewardStatusActive,
+		IdentityKeyPub:     []byte(pub),
+		LastProvenanceJSON: "", // no baseline — first refresh after registration
+	})
+
+	prs := newTestPendingRefreshStore()
+	ps := newTestRefreshPolicyStore()
+	require.NoError(t, ps.SetPolicy(context.Background(), &business.RefreshPolicy{
+		TenantID: testTenantID,
+		Mode:     "auto_accept",
+	}))
+
+	server, _ := newRefreshAdminTestServer(t, ss, prs, ps)
+	server.SetPoPVerifier(ed25519PoPVerifier{})
+
+	challenge := issueChallenge(t, server, testDeviceID, testTenantID)
+	req := buildValidCompleteRequest(t, testDeviceID, testTenantID, challenge, priv, nil)
+
+	rec := postComplete(server, testDeviceID, req)
+	assert.Equal(t, http.StatusOK, rec.Code, "auto_accept with no provenance baseline must issue cert immediately: %s", rec.Body.String())
+	assert.Equal(t, 0, prs.count(), "no pending entry must be created for auto_accept with no baseline")
+
+	var resp RefreshCompleteResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Equal(t, "approved", resp.Status)
+	assert.NotEmpty(t, resp.ClientCert)
+	assert.NotEmpty(t, resp.ClientKey)
+	assert.NotEmpty(t, resp.CACert)
+}

--- a/features/controller/api/handlers_registration_refresh_test.go
+++ b/features/controller/api/handlers_registration_refresh_test.go
@@ -868,6 +868,75 @@ func TestHandleRefreshApprove_ApprovesEntry(t *testing.T) {
 	assert.True(t, found, "refresh_admin_approved audit event expected")
 }
 
+// TestHandleRefreshApprove_RevokedDeviceRejected verifies the security gate added
+// for Issue #2098: a steward can be revoked AFTER its refresh is queued as pending.
+// The challenge/complete paths reject revoked devices, but the admin approve path
+// previously did not. Approving a now-revoked device must NOT issue a cert, must NOT
+// promote the device back to "registered" (silently un-revoking it via the status
+// persistence added in this story), and must leave the pending entry untouched.
+func TestHandleRefreshApprove_RevokedDeviceRejected(t *testing.T) {
+	pub, _ := newTestEd25519KeyPair(t)
+	ss := newTestStewardStore()
+	ss.add(&business.StewardRecord{
+		ID:             "steward-revoked-pending",
+		DeviceID:       testDeviceID,
+		TenantID:       testTenantID,
+		Status:         business.StewardStatusRevoked, // revoked while a refresh sat pending
+		IdentityKeyPub: []byte(pub),
+	})
+
+	prs := newTestPendingRefreshStore()
+	pendingID := "refresh-revoked-test"
+	require.NoError(t, prs.AddPendingRefresh(context.Background(), &business.PendingRefreshEntry{
+		PendingID: pendingID,
+		DeviceID:  testDeviceID,
+		TenantID:  testTenantID,
+		Status:    business.PendingRefreshStatusPending,
+		CreatedAt: time.Now().UTC(),
+		ExpiresAt: time.Now().UTC().Add(7 * 24 * time.Hour),
+	}))
+
+	server, auditMgr := newRefreshAdminTestServer(t, ss, prs, newTestRefreshPolicyStore())
+	apiKey := NewTestKey(t, server, []string{"refresh:approve"})
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/stewards/refresh/"+pendingID+"/approve", nil)
+	req.Header.Set("X-API-Key", apiKey)
+	rec := httptest.NewRecorder()
+	server.router.ServeHTTP(rec, req)
+
+	// Must be rejected — no certificate may be issued to a revoked device.
+	require.Equal(t, http.StatusForbidden, rec.Code, "approving a revoked device must be forbidden: %s", rec.Body.String())
+	assert.NotContains(t, rec.Body.String(), "BEGIN", "no certificate material may be returned for a revoked device")
+
+	// The steward must remain revoked — the status promotion must NOT un-revoke it.
+	recRev, err := ss.GetStewardByDeviceID(context.Background(), testDeviceID)
+	require.NoError(t, err)
+	assert.Equal(t, business.StewardStatusRevoked, recRev.Status,
+		"revoked steward must NOT be promoted to registered on approve")
+
+	// The pending entry must remain pending with no claim bundle.
+	entry, err := prs.GetPendingRefreshByID(context.Background(), pendingID)
+	require.NoError(t, err)
+	assert.Equal(t, business.PendingRefreshStatusPending, entry.Status,
+		"pending entry must not be approved for a revoked device")
+	assert.Nil(t, entry.ClaimBundle, "no claim bundle may be stored for a revoked device")
+
+	// A security audit event must record the denial with decision+reason.
+	require.NoError(t, auditMgr.Flush(context.Background()))
+	entries, err := auditMgr.QueryEntries(context.Background(), &business.AuditFilter{})
+	require.NoError(t, err)
+	found := false
+	for _, e := range entries {
+		if e.Action == "refresh_admin_approve_rejected" {
+			assert.Equal(t, "denied", e.Details["decision"])
+			assert.Equal(t, "revoked", e.Details["reason"])
+			found = true
+			break
+		}
+	}
+	assert.True(t, found, "refresh_admin_approve_rejected security audit event expected")
+}
+
 func TestHandleRefreshReject_RejectsEntry(t *testing.T) {
 	pub, _ := newTestEd25519KeyPair(t)
 	ss := newTestStewardStore()

--- a/features/controller/api/handlers_test_admin.go
+++ b/features/controller/api/handlers_test_admin.go
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+package api
+
+// Test-mode admin handlers — guarded by CFGMS_ENABLE_TEST_ENDPOINTS=true via
+// authenticationMiddleware. These endpoints are used by fleet E2E tests in lieu
+// of sqlite3 CLI (not present in the Alpine controller container).
+//
+// DO NOT rely on these endpoints in production configurations.
+
+import (
+	"encoding/json"
+	"net/http"
+	"os"
+
+	"github.com/gorilla/mux"
+
+	"github.com/cfgis/cfgms/pkg/logging"
+	business "github.com/cfgis/cfgms/pkg/storage/interfaces/business"
+)
+
+// testSetStewardStatusRequest is the body for PUT /api/v1/test/stewards/{id}/status.
+type testSetStewardStatusRequest struct {
+	Status string `json:"status"` // e.g. "revoked", "archived", "registered"
+}
+
+// handleTestSetStewardStatus handles PUT /api/v1/test/stewards/{id}/status.
+// Requires CFGMS_ENABLE_TEST_ENDPOINTS=true (enforced by authenticationMiddleware).
+// Accepts the steward's UUID as {id} and updates its lifecycle status.
+func (s *Server) handleTestSetStewardStatus(w http.ResponseWriter, r *http.Request) {
+	if os.Getenv("CFGMS_ENABLE_TEST_ENDPOINTS") != "true" {
+		http.Error(w, "test endpoints disabled", http.StatusForbidden)
+		return
+	}
+	if s.stewardStore == nil {
+		http.Error(w, "steward store unavailable", http.StatusServiceUnavailable)
+		return
+	}
+
+	id := mux.Vars(r)["id"]
+
+	var req testSetStewardStatusRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil || req.Status == "" {
+		http.Error(w, "body must be {\"status\": \"<status>\"}", http.StatusBadRequest)
+		return
+	}
+
+	if err := s.stewardStore.UpdateStewardStatus(r.Context(), id, business.StewardStatus(req.Status)); err != nil {
+		s.logger.Error("handleTestSetStewardStatus: failed to update status",
+			"steward_id", logging.SanitizeLogValue(id), "status", logging.SanitizeLogValue(req.Status), "error", err)
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// testAuditCountResponse is the response body for GET /api/v1/test/audit/count.
+type testAuditCountResponse struct {
+	Count int `json:"count"`
+}
+
+// handleTestAuditCount handles GET /api/v1/test/audit/count.
+// Query params: action=<action>&device_id=<device_id>
+// Returns {"count": N} — the number of audit entries matching both filters.
+// device_id is matched via the audit entry's user_id field (set by emitRefreshAudit).
+// Flushes the audit manager before querying so in-flight entries are drained.
+// Requires CFGMS_ENABLE_TEST_ENDPOINTS=true (enforced by authenticationMiddleware).
+func (s *Server) handleTestAuditCount(w http.ResponseWriter, r *http.Request) {
+	if os.Getenv("CFGMS_ENABLE_TEST_ENDPOINTS") != "true" {
+		http.Error(w, "test endpoints disabled", http.StatusForbidden)
+		return
+	}
+	if s.auditStore == nil {
+		http.Error(w, "audit store unavailable", http.StatusServiceUnavailable)
+		return
+	}
+
+	action := r.URL.Query().Get("action")
+	deviceID := r.URL.Query().Get("device_id")
+
+	if action == "" {
+		http.Error(w, "action query param required", http.StatusBadRequest)
+		return
+	}
+
+	// Flush audit manager so entries queued after the scenario are persisted before query.
+	if s.auditManager != nil {
+		_ = s.auditManager.Flush(r.Context())
+	}
+
+	filter := &business.AuditFilter{
+		Actions: []string{action},
+	}
+	if deviceID != "" {
+		filter.UserIDs = []string{deviceID}
+	}
+
+	entries, err := s.auditStore.ListAuditEntries(r.Context(), filter)
+	if err != nil {
+		s.logger.Error("handleTestAuditCount: query failed", "action", logging.SanitizeLogValue(action), "device_id", logging.SanitizeLogValue(deviceID), "error", err)
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(testAuditCountResponse{Count: len(entries)}); err != nil {
+		s.logger.Error("handleTestAuditCount: encode failed", "error", err)
+	}
+}

--- a/features/controller/api/handlers_test_admin.go
+++ b/features/controller/api/handlers_test_admin.go
@@ -47,7 +47,7 @@ func (s *Server) handleTestSetStewardStatus(w http.ResponseWriter, r *http.Reque
 
 	if err := s.stewardStore.UpdateStewardStatus(r.Context(), id, business.StewardStatus(req.Status)); err != nil {
 		s.logger.Error("handleTestSetStewardStatus: failed to update status",
-			"steward_id", logging.SanitizeLogValue(id), "status", logging.SanitizeLogValue(req.Status), "error", err)
+			"steward_id", logging.SanitizeLogValue(id), "status", logging.SanitizeLogValue(req.Status), "error", logging.SanitizeLogValue(err.Error()))
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}

--- a/features/controller/api/middleware.go
+++ b/features/controller/api/middleware.go
@@ -225,6 +225,21 @@ func (s *Server) authenticationMiddleware(next http.Handler) http.Handler {
 				next.ServeHTTP(w, r)
 				return
 			}
+
+			// Issue #2098: test-mode status update and audit count endpoints (no auth in test mode).
+			if r.Method == "PUT" && strings.HasPrefix(r.URL.Path, "/api/v1/test/stewards/") && strings.HasSuffix(r.URL.Path, "/status") {
+				s.logger.Warn("Test endpoint accessed with authentication bypass",
+					"path", logging.SanitizeLogValue(r.URL.Path), "method", r.Method, "remote_addr", logging.SanitizeLogValue(r.RemoteAddr))
+				next.ServeHTTP(w, r)
+				return
+			}
+
+			if r.Method == "GET" && r.URL.Path == "/api/v1/test/audit/count" {
+				s.logger.Warn("Test endpoint accessed with authentication bypass",
+					"path", logging.SanitizeLogValue(r.URL.Path), "method", r.Method, "remote_addr", logging.SanitizeLogValue(r.RemoteAddr))
+				next.ServeHTTP(w, r)
+				return
+			}
 		}
 
 		// H2: mTLS-presented identity always wins.

--- a/features/controller/api/server.go
+++ b/features/controller/api/server.go
@@ -552,9 +552,10 @@ func (s *Server) setupRouter() {
 		s.requirePermission("refresh", "reject")(http.HandlerFunc(s.handleRejectRefresh))).Methods("POST")
 
 	// Per-tenant refresh policy endpoints (Issue #2097).
-	tenants.Handle("/{id:.+}/refresh-policy",
+	// {tenant_path:.+} allows '/' in the path variable for hierarchical tenant IDs.
+	tenants.Handle("/{tenant_path:.+}/refresh-policy",
 		s.requirePermission("refresh", "get-policy")(http.HandlerFunc(s.handleGetRefreshPolicy))).Methods("GET")
-	tenants.Handle("/{id:.+}/refresh-policy",
+	tenants.Handle("/{tenant_path:.+}/refresh-policy",
 		s.requirePermission("refresh", "set-policy")(http.HandlerFunc(s.handleSetRefreshPolicy))).Methods("PUT")
 
 	// Installer artifact management endpoints (Issue #1702).

--- a/features/controller/api/server.go
+++ b/features/controller/api/server.go
@@ -109,6 +109,7 @@ type Server struct {
 	stewardStore                   business.StewardStore                 // Issue #2096: durable fleet-registry store for device-ID refresh gate
 	pendingRefreshStore            business.PendingRefreshStore          // Issue #2096: durable pending-refresh queue
 	refreshPolicyStore             business.RefreshPolicyStore           // Issue #2096: per-tenant refresh policy
+	auditStore                     business.AuditStore                   // Issue #2098: direct audit store for test-mode count endpoint
 	nonceCache                     *cache.Cache                          // Issue #2096: in-memory nonce store (TTL 65s)
 	popVerifier                    PoPVerifier                           // Issue #2096: injectable for revoked-before-PoP testing
 	isolationEngine                *tenantsecurity.TenantIsolationEngine // Issue #2123: tenant isolation enforcement for scoped API keys
@@ -400,6 +401,11 @@ func (s *Server) setupRouter() {
 	// Use separate path to avoid conflict with authenticated subrouter
 	// TODO: Remove or protect this endpoint in production
 	s.router.HandleFunc("/api/v1/test/stewards/{id}/config", s.handleUpdateStewardConfig).Methods("PUT", "OPTIONS")
+
+	// Issue #2098: Test-mode admin endpoints — active only when CFGMS_ENABLE_TEST_ENDPOINTS=true.
+	// Fleet E2E tests use these instead of sqlite3 CLI (not installed in Alpine container).
+	s.router.HandleFunc("/api/v1/test/stewards/{id}/status", s.handleTestSetStewardStatus).Methods("PUT")
+	s.router.HandleFunc("/api/v1/test/audit/count", s.handleTestAuditCount).Methods("GET")
 
 	// Registration-refresh endpoints (unauthenticated — authenticated by device key PoP).
 	// Registered on the base router like /api/v1/register (Issue #2096).
@@ -953,6 +959,15 @@ func (s *Server) SetRefreshPolicyStore(store business.RefreshPolicyStore) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.refreshPolicyStore = store
+}
+
+// SetAuditStore wires a direct AuditStore reference for the test-mode count endpoint
+// (Issue #2098). Production code uses s.auditManager; this allows test endpoints to
+// query audit entries without needing sqlite3 CLI in the controller container.
+func (s *Server) SetAuditStore(store business.AuditStore) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.auditStore = store
 }
 
 // SetPoPVerifier replaces the proof-of-possession verifier.

--- a/features/controller/api/server.go
+++ b/features/controller/api/server.go
@@ -552,9 +552,9 @@ func (s *Server) setupRouter() {
 		s.requirePermission("refresh", "reject")(http.HandlerFunc(s.handleRejectRefresh))).Methods("POST")
 
 	// Per-tenant refresh policy endpoints (Issue #2097).
-	tenants.Handle("/{id}/refresh-policy",
+	tenants.Handle("/{id:.+}/refresh-policy",
 		s.requirePermission("refresh", "get-policy")(http.HandlerFunc(s.handleGetRefreshPolicy))).Methods("GET")
-	tenants.Handle("/{id}/refresh-policy",
+	tenants.Handle("/{id:.+}/refresh-policy",
 		s.requirePermission("refresh", "set-policy")(http.HandlerFunc(s.handleSetRefreshPolicy))).Methods("PUT")
 
 	// Installer artifact management endpoints (Issue #1702).

--- a/features/controller/api/server_test.go
+++ b/features/controller/api/server_test.go
@@ -973,6 +973,24 @@ func TestTestEndpointAuthGate(t *testing.T) {
 
 		assert.Equal(t, http.StatusUnauthorized, rec.Code, "Should require auth for QUIC endpoint when env var is unset")
 		assert.False(t, handlerCalled, "Handler should not be called without authentication")
+
+		// PUT /api/v1/test/stewards/{id}/status — Issue #2098: env var unset → auth required
+		handlerCalled = false
+		req = httptest.NewRequest("PUT", "/api/v1/test/stewards/test-steward-1/status", nil)
+		rec = httptest.NewRecorder()
+		wrappedHandler.ServeHTTP(rec, req)
+
+		assert.Equal(t, http.StatusUnauthorized, rec.Code, "Should require auth for status endpoint when env var is unset")
+		assert.False(t, handlerCalled, "Handler should not be called without authentication")
+
+		// GET /api/v1/test/audit/count — Issue #2098: env var unset → auth required
+		handlerCalled = false
+		req = httptest.NewRequest("GET", "/api/v1/test/audit/count", nil)
+		rec = httptest.NewRecorder()
+		wrappedHandler.ServeHTTP(rec, req)
+
+		assert.Equal(t, http.StatusUnauthorized, rec.Code, "Should require auth for audit count endpoint when env var is unset")
+		assert.False(t, handlerCalled, "Handler should not be called without authentication")
 	})
 
 	t.Run("bypass works when CFGMS_ENABLE_TEST_ENDPOINTS is true", func(t *testing.T) {
@@ -1003,6 +1021,24 @@ func TestTestEndpointAuthGate(t *testing.T) {
 
 		assert.Equal(t, http.StatusOK, rec.Code, "Should bypass auth for QUIC test endpoint")
 		assert.True(t, handlerCalled, "Handler should be called for QUIC test endpoint (auth bypassed)")
+
+		// PUT /api/v1/test/stewards/{id}/status — Issue #2098: should bypass auth
+		handlerCalled = false
+		req = httptest.NewRequest("PUT", "/api/v1/test/stewards/test-steward-1/status", nil)
+		rec = httptest.NewRecorder()
+		wrappedHandler.ServeHTTP(rec, req)
+
+		assert.Equal(t, http.StatusOK, rec.Code, "Should bypass auth for status test endpoint")
+		assert.True(t, handlerCalled, "Handler should be called for status test endpoint (auth bypassed)")
+
+		// GET /api/v1/test/audit/count — Issue #2098: should bypass auth
+		handlerCalled = false
+		req = httptest.NewRequest("GET", "/api/v1/test/audit/count", nil)
+		rec = httptest.NewRecorder()
+		wrappedHandler.ServeHTTP(rec, req)
+
+		assert.Equal(t, http.StatusOK, rec.Code, "Should bypass auth for audit count test endpoint")
+		assert.True(t, handlerCalled, "Handler should be called for audit count test endpoint (auth bypassed)")
 	})
 
 	t.Run("warn log emitted on bypass", func(t *testing.T) {

--- a/features/controller/api/validation_middleware.go
+++ b/features/controller/api/validation_middleware.go
@@ -153,6 +153,10 @@ func (s *Server) validateQueryParameters(validator *security.EnhancedValidator, 
 			case "status":
 				// Status filter validation
 				validator.ValidateString(result, fieldName, value, "charset:alphanumeric_dash", "max_length:32")
+			case "tenant_id":
+				// Hierarchical tenant IDs use '/' as a path separator (e.g., "fleet-root/fleet-child-b").
+				// Must match charset:tenant_path_id which allows letters, digits, hyphens, underscores, and '/'.
+				validator.ValidateString(result, fieldName, value, "charset:tenant_path_id", "max_length:256")
 			default:
 				// Generic query parameter validation
 				validator.ValidateString(result, fieldName, value, "charset:safe_text", "max_length:512", "no_control_chars")

--- a/features/controller/api/validation_middleware.go
+++ b/features/controller/api/validation_middleware.go
@@ -92,6 +92,9 @@ func (s *Server) validateURLParameters(validator *security.EnhancedValidator, re
 		case "id":
 			// Validate ID parameters (should be UUIDs or alphanumeric)
 			validator.ValidateString(result, "path."+param, value, "required", "charset:alphanumeric_dash", "max_length:64")
+		case "tenant_path":
+			// Hierarchical tenant IDs use '/' as a path separator: "fleet-root/fleet-child-a".
+			validator.ValidateString(result, "path."+param, value, "required", "charset:tenant_path_id", "max_length:256")
 		case "serial":
 			// Certificate serial numbers
 			validator.ValidateString(result, "path."+param, value, "required", "charset:alphanumeric", "max_length:40")

--- a/features/controller/api/validation_middleware_test.go
+++ b/features/controller/api/validation_middleware_test.go
@@ -183,3 +183,54 @@ func TestValidateURLParameters_TenantPathWithSlash(t *testing.T) {
 		})
 	}
 }
+
+// TestValidateQueryParameters_TenantIDWithSlash verifies that a query parameter named
+// "tenant_id" with a hierarchical value (e.g., "fleet-root/fleet-child-b") passes
+// validation via charset:tenant_path_id. Regression test for BUG 1 in Issue #2098
+// where the default safe_text charset incorrectly rejected tenant IDs containing '/'.
+func TestValidateQueryParameters_TenantIDWithSlash(t *testing.T) {
+	s := &Server{}
+	validator := security.NewEnhancedValidator(nil)
+
+	tests := []struct {
+		name      string
+		queryKey  string
+		queryVal  string
+		wantValid bool
+	}{
+		{
+			name:      "hierarchical tenant_id with slash passes",
+			queryKey:  "tenant_id",
+			queryVal:  "fleet-root/fleet-child-b",
+			wantValid: true,
+		},
+		{
+			name:      "deep hierarchical tenant_id passes",
+			queryKey:  "tenant_id",
+			queryVal:  "root/msp-a/client-1/servers",
+			wantValid: true,
+		},
+		{
+			name:      "tenant_id with dot-dot traversal rejected",
+			queryKey:  "tenant_id",
+			queryVal:  "../etc/passwd",
+			wantValid: false,
+		},
+		{
+			name:      "plain query param still uses safe_text (no slash allowed)",
+			queryKey:  "action",
+			queryVal:  "fleet-root/fleet-child-b",
+			wantValid: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "/api/v1/stewards/refresh/pending?"+tc.queryKey+"="+tc.queryVal, nil)
+			result := &security.ValidationResult{Valid: true}
+			s.validateQueryParameters(validator, result, req)
+			assert.Equal(t, tc.wantValid, result.Valid,
+				"%s=%q: expected valid=%v, errors=%v", tc.queryKey, tc.queryVal, tc.wantValid, result.Errors)
+		})
+	}
+}

--- a/features/controller/api/validation_middleware_test.go
+++ b/features/controller/api/validation_middleware_test.go
@@ -7,8 +7,10 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
+	"github.com/gorilla/mux"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -119,4 +121,65 @@ func TestValidateRequestBody_JSONStillSizeCapped(t *testing.T) {
 		}
 	}
 	assert.True(t, foundSize, "expected max_size rule violation; got %+v", result.Errors)
+}
+
+// TestValidateURLParameters_TenantPathWithSlash verifies that a route variable named
+// "tenant_path" with a hierarchical value (e.g., "fleet-root/fleet-child-a") passes
+// validation. Regression test for the tenant_path_id charset introduced in Issue #2098
+// (validationMiddleware case "id" using charset:alphanumeric_dash incorrectly rejected
+// tenant IDs that contain '/' path separators).
+func TestValidateURLParameters_TenantPathWithSlash(t *testing.T) {
+	s := &Server{}
+	validator := security.NewEnhancedValidator(nil)
+
+	tests := []struct {
+		name      string
+		varName   string
+		value     string
+		wantValid bool
+	}{
+		{
+			name:      "hierarchical tenant path passes",
+			varName:   "tenant_path",
+			value:     "fleet-root/fleet-child-a",
+			wantValid: true,
+		},
+		{
+			name:      "deep hierarchical tenant path passes",
+			varName:   "tenant_path",
+			value:     "root/msp-a/client-1/servers",
+			wantValid: true,
+		},
+		{
+			name:      "tenant path with dot-dot segment rejected",
+			varName:   "tenant_path",
+			value:     "../etc/passwd",
+			wantValid: false,
+		},
+		{
+			name:      "tenant path exceeding global max rejected",
+			varName:   "tenant_path",
+			value:     strings.Repeat("a/", 2049),
+			wantValid: false,
+		},
+		{
+			name:      "plain id still rejects slash",
+			varName:   "id",
+			value:     "fleet-root/fleet-child-a",
+			wantValid: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// Use a safe placeholder in the URL; the actual variable value is injected
+			// via mux.SetURLVars so the URL parser never sees unsafe characters.
+			req := httptest.NewRequest(http.MethodGet, "/api/v1/tenants/placeholder/refresh-policy", nil)
+			req = mux.SetURLVars(req, map[string]string{tc.varName: tc.value})
+			result := &security.ValidationResult{Valid: true}
+			s.validateURLParameters(validator, result, req)
+			assert.Equal(t, tc.wantValid, result.Valid,
+				"tenant_path=%q: expected valid=%v, errors=%v", tc.value, tc.wantValid, result.Errors)
+		})
+	}
 }

--- a/features/controller/server/server.go
+++ b/features/controller/server/server.go
@@ -946,6 +946,24 @@ func New(cfg *config.Config, logger logging.Logger) (*Server, error) {
 
 	logger.Info("HTTP API server initialized successfully")
 
+	// Issue #2098: Wire registration-refresh stores into the HTTP API server so the
+	// challenge/complete endpoints and the admin approve/reject/policy endpoints are
+	// operational. GetStewardStore is always non-nil for the OSS composite (flatfile
+	// provider creates it); the refresh stores are nil when the non-bundle SQLite
+	// fallback path was taken (unit-test-only scenario).
+	if ss := storageManager.GetStewardStore(); ss != nil {
+		httpServer.SetStewardStore(ss)
+	}
+	if prs := storageManager.GetPendingRefreshStore(); prs != nil {
+		httpServer.SetPendingRefreshStore(prs)
+	}
+	if rps := storageManager.GetRefreshPolicyStore(); rps != nil {
+		httpServer.SetRefreshPolicyStore(rps)
+	}
+	if as := storageManager.GetAuditStore(); as != nil {
+		httpServer.SetAuditStore(as)
+	}
+
 	// Issue #1948: Wire in-memory upgrade store so the dispatch/status endpoints
 	// are operational. A durable SQLite-backed store is a follow-up; for the
 	// OSS composite deployment the in-memory store is sufficient because upgrade

--- a/features/modules/hyperv/module.go
+++ b/features/modules/hyperv/module.go
@@ -104,15 +104,15 @@ type hypervModule struct {
 	// Zero means "no active subscription". monInterest is the set of registered
 	// resourceIDs (vm:<name>); the subscription is created on first interest and
 	// torn down when the last is removed or on Close.
-	monMu       sync.Mutex               //nolint:unused // used by monitor_windows.go
-	monChanges  chan modules.ChangeEvent //nolint:unused // used by monitor_windows.go
-	monInterest map[string]struct{}      //nolint:unused // used by monitor_windows.go
-	monSub      uintptr                  //nolint:unused // used by monitor_windows.go
-	monClosed   bool                     //nolint:unused // used by monitor_windows.go
+	monMu       sync.Mutex               //nolint:unused // written and read by monitor_windows.go; invisible to non-Windows builds
+	monChanges  chan modules.ChangeEvent //nolint:unused // written and read by monitor_windows.go; invisible to non-Windows builds
+	monInterest map[string]struct{}      //nolint:unused // written and read by monitor_windows.go; invisible to non-Windows builds
+	monSub      uintptr                  //nolint:unused // written and read by monitor_windows.go; invisible to non-Windows builds
+	monClosed   bool                     //nolint:unused // written and read by monitor_windows.go; invisible to non-Windows builds
 	// monTeardown stops the reader goroutine and releases the EvtSubscribe and
 	// signal handles. It is set by the platform establish routine when the
 	// subscription is created and cleared on Close. nil means "no subscription".
-	monTeardown func() error //nolint:unused // used by monitor_windows.go
+	monTeardown func() error //nolint:unused // written and read by monitor_windows.go; invisible to non-Windows builds
 }
 
 // HypervOption configures a hypervModule at construction time.

--- a/features/steward/dna/network_darwin.go
+++ b/features/steward/dna/network_darwin.go
@@ -16,6 +16,12 @@ import (
 
 const darwinNetCmdTimeout = 30 * time.Second
 
+// darwinNetCmdWaitDelay is the maximum time WaitDelay allows for a killed command's
+// I/O to drain before Output() is forced to return. On macOS CI runners, netstat can
+// get stuck in a kernel call that survives SIGKILL at the process level but leaves
+// the stdout pipe open; WaitDelay guarantees Output() returns regardless.
+const darwinNetCmdWaitDelay = 5 * time.Second
+
 // CollectInterfaces gathers detailed network interface information on macOS
 func (d *DarwinNetworkCollector) CollectInterfaces(ctx context.Context, attributes map[string]string) error {
 	// First collect basic interface info using Go's standard library
@@ -43,28 +49,37 @@ func (d *DarwinNetworkCollector) CollectInterfaces(ctx context.Context, attribut
 	return nil
 }
 
+// darwinRunNetCmd runs a command with a timeout context and WaitDelay so that
+// processes stuck in kernel calls (e.g. netstat on CI macOS) do not block
+// Output() indefinitely after SIGKILL. Returns nil output on timeout or error.
+func darwinRunNetCmd(ctx context.Context, timeout time.Duration, name string, args ...string) []byte {
+	cmdCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	cmd := exec.CommandContext(cmdCtx, name, args...)
+	cmd.WaitDelay = darwinNetCmdWaitDelay
+	output, err := cmd.Output()
+	if err != nil {
+		return nil
+	}
+	return output
+}
+
 // CollectRouting gathers routing table information on macOS
 func (d *DarwinNetworkCollector) CollectRouting(ctx context.Context, attributes map[string]string) error {
 	// IPv4 routing table
-	cmdCtx, cancel := context.WithTimeout(ctx, darwinNetCmdTimeout)
-	if output, err := exec.CommandContext(cmdCtx, "netstat", "-rn", "-f", "inet").Output(); err == nil {
+	if output := darwinRunNetCmd(ctx, darwinNetCmdTimeout, "netstat", "-rn", "-f", "inet"); output != nil {
 		d.parseRoutingTable(string(output), attributes, "ipv4")
 	}
-	cancel()
 
 	// IPv6 routing table
-	cmdCtx2, cancel2 := context.WithTimeout(ctx, darwinNetCmdTimeout)
-	if output, err := exec.CommandContext(cmdCtx2, "netstat", "-rn", "-f", "inet6").Output(); err == nil {
+	if output := darwinRunNetCmd(ctx, darwinNetCmdTimeout, "netstat", "-rn", "-f", "inet6"); output != nil {
 		d.parseRoutingTable(string(output), attributes, "ipv6")
 	}
-	cancel2()
 
 	// Default gateway information
-	cmdCtx3, cancel3 := context.WithTimeout(ctx, darwinNetCmdTimeout)
-	if output, err := exec.CommandContext(cmdCtx3, "route", "get", "default").Output(); err == nil {
+	if output := darwinRunNetCmd(ctx, darwinNetCmdTimeout, "route", "get", "default"); output != nil {
 		d.parseDefaultGateway(string(output), attributes)
 	}
-	cancel3()
 
 	return nil
 }

--- a/features/steward/registration/client_http.go
+++ b/features/steward/registration/client_http.go
@@ -316,21 +316,25 @@ func (c *HTTPClient) RefreshChallenge(ctx context.Context, deviceID string) (*Re
 
 // RefreshComplete submits the proof-of-possession signature to complete the registration-refresh handshake.
 // pop is the Ed25519 signature over sha256(nonce_bytes || device_id_utf8 || server_ts_big_endian_uint64).
+// issuedAt must be the server_ts value from the challenge response (Unix nanoseconds), used by the
+// controller's IssuedAt gate to verify the request arrived within the 60s nonce window.
 //
 // Returns (*RefreshCompleteResponse, nil) on HTTP 200 (cert issued immediately).
 // Returns (nil, ErrRefreshPending) on HTTP 202 (request queued for manual approval).
 // Returns (nil, ErrRefreshRejected) on HTTP 403 (device revoked or dormant).
-func (c *HTTPClient) RefreshComplete(ctx context.Context, deviceID, nonce string, pop []byte) (*RefreshCompleteResponse, error) {
+func (c *HTTPClient) RefreshComplete(ctx context.Context, deviceID, tenantID, nonce string, issuedAt int64, pop []byte) (*RefreshCompleteResponse, error) {
 	completeURL := fmt.Sprintf("%s/api/v1/stewards/%s/refresh/complete", c.controllerURL, deviceID)
 
 	reqBody, err := json.Marshal(struct {
-		DeviceID string `json:"device_id"`
-		Nonce    string `json:"nonce"`
-		PoP      string `json:"pop"` // base64url-encoded Ed25519 signature
+		TenantID  string `json:"tenant_id,omitempty"`
+		Nonce     string `json:"nonce"`
+		IssuedAt  int64  `json:"issued_at"` // server_ts from challenge (Unix nanoseconds)
+		Signature string `json:"signature"` // base64url Ed25519 sig over PoP digest
 	}{
-		DeviceID: deviceID,
-		Nonce:    nonce,
-		PoP:      base64.RawURLEncoding.EncodeToString(pop),
+		TenantID:  tenantID,
+		Nonce:     nonce,
+		IssuedAt:  issuedAt,
+		Signature: base64.RawURLEncoding.EncodeToString(pop),
 	})
 	if err != nil {
 		return nil, fmt.Errorf("marshal refresh complete request: %w", err)

--- a/features/steward/registration/client_http_test.go
+++ b/features/steward/registration/client_http_test.go
@@ -403,7 +403,7 @@ func TestRefreshComplete_200_ReturnsCerts(t *testing.T) {
 	cl, err := NewHTTPClient(&HTTPConfig{ControllerURL: srv.URL, Logger: logging.NewLogger("debug")})
 	require.NoError(t, err)
 
-	resp, err := cl.RefreshComplete(context.Background(), deviceID, "nonce123", []byte("signature"))
+	resp, err := cl.RefreshComplete(context.Background(), deviceID, "tenant-x", "nonce123", 1234567890, []byte("signature"))
 	require.NoError(t, err)
 	require.NotNil(t, resp)
 	assert.Equal(t, "CERT", resp.ClientCert)
@@ -422,7 +422,7 @@ func TestRefreshComplete_202_ReturnsErrRefreshPending(t *testing.T) {
 	cl, err := NewHTTPClient(&HTTPConfig{ControllerURL: srv.URL, Logger: logging.NewLogger("debug")})
 	require.NoError(t, err)
 
-	resp, err := cl.RefreshComplete(context.Background(), "device-id", "nonce", []byte("sig"))
+	resp, err := cl.RefreshComplete(context.Background(), "device-id", "", "nonce", 0, []byte("sig"))
 	assert.Nil(t, resp)
 	require.ErrorIs(t, err, ErrRefreshPending)
 }
@@ -437,7 +437,7 @@ func TestRefreshComplete_403_ReturnsErrRefreshRejected(t *testing.T) {
 	cl, err := NewHTTPClient(&HTTPConfig{ControllerURL: srv.URL, Logger: logging.NewLogger("debug")})
 	require.NoError(t, err)
 
-	resp, err := cl.RefreshComplete(context.Background(), "device-id", "nonce", []byte("sig"))
+	resp, err := cl.RefreshComplete(context.Background(), "device-id", "", "nonce", 0, []byte("sig"))
 	assert.Nil(t, resp)
 	require.ErrorIs(t, err, ErrRefreshRejected)
 }

--- a/features/steward/registration/types.go
+++ b/features/steward/registration/types.go
@@ -18,7 +18,7 @@ var ErrRefreshRejected = errors.New("registration refresh rejected by controller
 // RefreshChallengeResponse is the response body from POST /api/v1/stewards/{device_id}/refresh/challenge.
 type RefreshChallengeResponse struct {
 	Nonce     string `json:"nonce"`      // base64url-encoded 32-byte random nonce
-	ServerTS  uint64 `json:"server_ts"`  // unix seconds, included in the PoP digest
+	ServerTS  uint64 `json:"server_ts"`  // unix nanoseconds, included in the PoP digest
 	ExpiresIn int    `json:"expires_in"` // seconds until the nonce expires (typically 60)
 }
 

--- a/pkg/security/validation.go
+++ b/pkg/security/validation.go
@@ -93,6 +93,8 @@ func NewValidator() *Validator {
 	v.allowedCharsets["base64"] = regexp.MustCompile(`^[A-Za-z0-9+/]*={0,2}$`)
 	// cidr: IPv4 (10.0.0.0/8) and IPv6 (2001:db8::/32) CIDR notation
 	v.allowedCharsets["cidr"] = regexp.MustCompile(`^[0-9a-fA-F.:\/]+$`)
+	// tenant_path_id: hierarchical tenant IDs use '/' as a path separator (e.g., "root/child-a")
+	v.allowedCharsets["tenant_path_id"] = regexp.MustCompile(`^[a-zA-Z0-9\-_/]+$`)
 
 	v.dnsLookupTimeout = 5 * time.Second
 

--- a/pkg/storage/interfaces/provider.go
+++ b/pkg/storage/interfaces/provider.go
@@ -48,6 +48,8 @@ type BusinessStoreBundle struct {
 	Push                business.PushStore
 	PendingRegistration business.PendingRegistrationStore
 	IPTrust             business.IPTrustStore
+	PendingRefresh      business.PendingRefreshStore // Issue #2098: registration-refresh approval queue
+	RefreshPolicy       business.RefreshPolicyStore  // Issue #2098: per-tenant refresh policy
 }
 
 // BusinessStoreOpener is an optional StorageProvider extension. A provider that
@@ -528,6 +530,8 @@ type StorageManager struct {
 	pushStore                business.PushStore
 	pendingRegistrationStore business.PendingRegistrationStore
 	ipTrustStore             business.IPTrustStore
+	pendingRefreshStore      business.PendingRefreshStore // Issue #2098: registration-refresh approval queue
+	refreshPolicyStore       business.RefreshPolicyStore  // Issue #2098: per-tenant refresh policy
 }
 
 // GetProviderName returns the name of the storage provider.
@@ -618,6 +622,28 @@ func (sm *StorageManager) GetIPTrustStore() business.IPTrustStore {
 // SetIPTrustStore wires the IP-trust store after construction.
 func (sm *StorageManager) SetIPTrustStore(s business.IPTrustStore) {
 	sm.ipTrustStore = s
+}
+
+// GetPendingRefreshStore returns the pending-refresh approval queue (Issue #2098).
+// Returns nil when not yet wired; callers must nil-check before use.
+func (sm *StorageManager) GetPendingRefreshStore() business.PendingRefreshStore {
+	return sm.pendingRefreshStore
+}
+
+// SetPendingRefreshStore wires the pending-refresh store after construction.
+func (sm *StorageManager) SetPendingRefreshStore(s business.PendingRefreshStore) {
+	sm.pendingRefreshStore = s
+}
+
+// GetRefreshPolicyStore returns the per-tenant refresh policy store (Issue #2098).
+// Returns nil when not yet wired; callers must nil-check before use.
+func (sm *StorageManager) GetRefreshPolicyStore() business.RefreshPolicyStore {
+	return sm.refreshPolicyStore
+}
+
+// SetRefreshPolicyStore wires the per-tenant refresh policy store after construction.
+func (sm *StorageManager) SetRefreshPolicyStore(s business.RefreshPolicyStore) {
+	sm.refreshPolicyStore = s
 }
 
 // GetCapabilities returns the provider's capabilities.
@@ -911,6 +937,8 @@ func CreateOSSStorageManager(flatfileRoot, sqliteConnStr string) (*StorageManage
 		)
 		sm.SetPendingRegistrationStore(bundle.PendingRegistration)
 		sm.SetIPTrustStore(ipTrustStore)
+		sm.SetPendingRefreshStore(bundle.PendingRefresh)
+		sm.SetRefreshPolicyStore(bundle.RefreshPolicy)
 		return sm, nil
 	}
 
@@ -958,5 +986,9 @@ func CreateOSSStorageManager(flatfileRoot, sqliteConnStr string) (*StorageManage
 	)
 	sm.SetPendingRegistrationStore(pendingRegStore)
 	sm.SetIPTrustStore(ipTrustStore)
+	// PendingRefreshStore and RefreshPolicyStore are only available via BusinessStoreBundle
+	// (OpenBusinessStores). The non-bundle fallback path leaves them nil — acceptable since
+	// this path is only taken when the provider does not implement BusinessStoreOpener,
+	// which in practice means unit tests that do not exercise the refresh flow.
 	return sm, nil
 }

--- a/pkg/storage/providers/flatfile/audit_store.go
+++ b/pkg/storage/providers/flatfile/audit_store.go
@@ -136,25 +136,26 @@ func (s *FlatFileAuditStore) StoreAuditBatch(ctx context.Context, entries []*bus
 	return nil
 }
 
-// GetAuditEntry retrieves an audit entry by ID, scanning daily JSONL files newest-first.
+// GetAuditEntry retrieves an audit entry by ID, walking the full directory tree.
+// Hierarchical tenant IDs (e.g. "fleet-root/fleet-child-a") store their audit files
+// under nested subdirectories, so a single-level ReadDir(root) would miss them.
 func (s *FlatFileAuditStore) GetAuditEntry(ctx context.Context, id string) (*business.AuditEntry, error) {
-	tenantDirs, err := os.ReadDir(s.root)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return nil, business.ErrAuditNotFound
+	var found *business.AuditEntry
+	walkErr := filepath.WalkDir(s.root, func(path string, d os.DirEntry, err error) error {
+		if err != nil || !d.IsDir() || d.Name() != "audit" {
+			return nil
 		}
-		return nil, fmt.Errorf("failed to read audit root: %w", err)
+		entry, scanErr := s.scanDirForID(path, id)
+		if scanErr == nil {
+			found = entry
+		}
+		return nil
+	})
+	if found != nil {
+		return found, nil
 	}
-
-	for _, tenantDir := range tenantDirs {
-		if !tenantDir.IsDir() {
-			continue
-		}
-		auditDir := filepath.Join(s.root, tenantDir.Name(), "audit")
-		entry, err := s.scanDirForID(auditDir, id)
-		if err == nil {
-			return entry, nil
-		}
+	if walkErr != nil && !os.IsNotExist(walkErr) {
+		return nil, fmt.Errorf("failed to read audit root: %w", walkErr)
 	}
 	return nil, business.ErrAuditNotFound
 }
@@ -246,22 +247,41 @@ func (s *FlatFileAuditStore) ListAuditEntries(ctx context.Context, filter *busin
 }
 
 // tenantIDsForFilter returns the list of tenant IDs to scan, based on the filter.
+// When no specific tenant is requested, it walks the root directory tree to find
+// every directory that contains an "audit" subdirectory. This supports hierarchical
+// tenant IDs (e.g. "fleet-root/fleet-child-a") whose audit files are stored under
+// nested subdirectories rather than directly under root.
 func (s *FlatFileAuditStore) tenantIDsForFilter(filter *business.AuditFilter) ([]string, error) {
 	if filter != nil && filter.TenantID != "" {
 		return []string{filter.TenantID}, nil
 	}
-	dirs, err := os.ReadDir(s.root)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return nil, nil
-		}
-		return nil, fmt.Errorf("failed to list tenants: %w", err)
-	}
 	var ids []string
-	for _, d := range dirs {
-		if d.IsDir() {
-			ids = append(ids, d.Name())
+	walkErr := filepath.WalkDir(s.root, func(path string, d os.DirEntry, err error) error {
+		if err != nil || !d.IsDir() {
+			return nil
 		}
+		// Check if this directory has an "audit" subdirectory with JSONL files.
+		auditSub := filepath.Join(path, "audit")
+		entries, readErr := os.ReadDir(auditSub)
+		if readErr != nil {
+			return nil // no audit subdir — keep walking
+		}
+		for _, e := range entries {
+			if !e.IsDir() && strings.HasSuffix(e.Name(), ".jsonl") {
+				// This directory is a tenant leaf: compute its ID relative to root.
+				rel, relErr := filepath.Rel(s.root, path)
+				if relErr != nil {
+					return nil
+				}
+				// Convert OS path separator to '/' for tenant ID consistency.
+				ids = append(ids, filepath.ToSlash(rel))
+				return nil
+			}
+		}
+		return nil
+	})
+	if walkErr != nil && !os.IsNotExist(walkErr) {
+		return nil, fmt.Errorf("failed to walk tenant dirs: %w", walkErr)
 	}
 	return ids, nil
 }

--- a/pkg/storage/providers/flatfile/audit_store_test.go
+++ b/pkg/storage/providers/flatfile/audit_store_test.go
@@ -541,3 +541,72 @@ func TestGetLastAuditEntry_TenantIsolation(t *testing.T) {
 	require.NotNil(t, lastB)
 	assert.Equal(t, uint64(1), lastB.SequenceNumber)
 }
+
+// TestGetAuditEntry_HierarchicalTenantID verifies that GetAuditEntry finds entries
+// stored under hierarchical tenant IDs (e.g. "fleet-root/fleet-child-a") whose audit
+// files live in nested subdirectories rather than directly under root.
+func TestGetAuditEntry_HierarchicalTenantID(t *testing.T) {
+	store := newTestAuditStore(t)
+	ctx := context.Background()
+
+	e := minimalEntry("hier-get-1", "fleet-root/fleet-child-a", time.Now().UTC())
+	require.NoError(t, store.StoreAuditEntry(ctx, e))
+
+	got, err := store.GetAuditEntry(ctx, "hier-get-1")
+	require.NoError(t, err)
+	assert.Equal(t, "hier-get-1", got.ID)
+	assert.Equal(t, "fleet-root/fleet-child-a", got.TenantID)
+}
+
+// TestListAuditEntries_HierarchicalTenantID verifies that ListAuditEntries with no
+// TenantID filter correctly finds entries stored under hierarchical tenant IDs
+// (e.g. "fleet-root/fleet-child-a"). The store persists them under nested subdirectories;
+// the no-filter path must walk the tree to discover them rather than only listing
+// top-level directories under root.
+func TestListAuditEntries_HierarchicalTenantID(t *testing.T) {
+	store := newTestAuditStore(t)
+	ctx := context.Background()
+	now := time.Now().UTC()
+
+	childA := "fleet-root/fleet-child-a"
+	childB := "fleet-root/fleet-child-b"
+
+	eA1 := minimalEntry("hier-a1", childA, now)
+	eA1.Action = "refresh_cert_issued"
+	eA1.UserID = "device-aaa"
+	eA2 := minimalEntry("hier-a2", childA, now)
+	eA2.Action = "refresh_cert_issued"
+	eA2.UserID = "device-aaa"
+	eB1 := minimalEntry("hier-b1", childB, now)
+	eB1.Action = "refresh_queued"
+	eB1.UserID = "device-bbb"
+
+	require.NoError(t, store.StoreAuditEntry(ctx, eA1))
+	require.NoError(t, store.StoreAuditEntry(ctx, eA2))
+	require.NoError(t, store.StoreAuditEntry(ctx, eB1))
+
+	// Query with no TenantID — must find entries across all nested tenants.
+	all, err := store.ListAuditEntries(ctx, &business.AuditFilter{})
+	require.NoError(t, err)
+	assert.Len(t, all, 3, "all three hierarchical-tenant entries must be visible without a TenantID filter")
+
+	// Filter by action: only childA's entries.
+	byAction, err := store.ListAuditEntries(ctx, &business.AuditFilter{
+		Actions: []string{"refresh_cert_issued"},
+	})
+	require.NoError(t, err)
+	assert.Len(t, byAction, 2)
+
+	// Filter by user_id without specifying tenant: must still find them.
+	byUser, err := store.ListAuditEntries(ctx, &business.AuditFilter{
+		UserIDs: []string{"device-bbb"},
+	})
+	require.NoError(t, err)
+	require.Len(t, byUser, 1)
+	assert.Equal(t, "hier-b1", byUser[0].ID)
+
+	// Filter with specific TenantID still works.
+	byTenant, err := store.ListAuditEntries(ctx, &business.AuditFilter{TenantID: childA})
+	require.NoError(t, err)
+	assert.Len(t, byTenant, 2)
+}

--- a/pkg/storage/providers/sqlite/plugin.go
+++ b/pkg/storage/providers/sqlite/plugin.go
@@ -326,6 +326,8 @@ func (p *SQLiteProvider) OpenBusinessStores(path string) (*interfaces.BusinessSt
 		Trigger:             &SQLiteTriggerStore{db: db},
 		Push:                &SQLitePushStore{db: db},
 		PendingRegistration: &SQLitePendingRegistrationStore{db: db},
+		PendingRefresh:      &SQLitePendingRefreshStore{db: db},
+		RefreshPolicy:       &SQLiteRefreshPolicyStore{db: db},
 	}, nil
 }
 

--- a/test/e2e/fleet/framework_test.go
+++ b/test/e2e/fleet/framework_test.go
@@ -494,11 +494,14 @@ func (s *FleetTestSuite) waitForStewardVersion(t *testing.T, container, version 
 // expired one, simulating a steward that has been offline past cert expiry.
 //
 // It docker-copies the cert store from the container to a host temp dir, loads a
-// cert.Manager from it, imports a back-dated client cert via certMgr.ImportCertificate,
-// deletes the old valid client cert(s), and copies the modified store back.
+// cert.Manager from it to find existing client cert serials, writes expired cert/key/
+// metadata files directly into each existing serial directory, and copies the modified
+// store back. The in-place serial-directory approach sidesteps docker cp's additive
+// behaviour: files inside existing directories are overwritten, but no new serial
+// directories are created and no container-side deletions are needed.
+//
 // device_identity.enc and steward-identity.json are preserved because they live in
-// the cert store root (not in per-serial subdirectories) and are not touched by the
-// cert.Manager operations.
+// the cert store root, not in per-serial subdirectories.
 //
 // The container must be stopped before calling this helper.
 func (s *FleetTestSuite) expireStewardCerts(t *testing.T, container string) {
@@ -529,7 +532,7 @@ func (s *FleetTestSuite) expireStewardCerts(t *testing.T, container string) {
 	})
 	require.NoError(t, err, "expireStewardCerts: load cert manager")
 
-	// Record serial numbers of existing client certs to delete after import.
+	// Record serial numbers of existing client certs to replace in-place.
 	certs, err := mgr.ListCertificates()
 	require.NoError(t, err, "expireStewardCerts: list certificates")
 	var oldSerials []string
@@ -538,31 +541,55 @@ func (s *FleetTestSuite) expireStewardCerts(t *testing.T, container string) {
 			oldSerials = append(oldSerials, c.SerialNumber)
 		}
 	}
+	require.NotEmpty(t, oldSerials,
+		"expireStewardCerts: no client certs found in %s cert store; steward may not be registered", container)
 
 	// Generate a self-signed cert+key pair with NotBefore/NotAfter both in the past.
 	expiredCertPEM, expiredKeyPEM := generateExpiredClientCertPEM(t)
 
-	// Import the expired cert via the manager (satisfies the certMgr.ImportCertificate
-	// requirement in the story; creates a new per-serial subdirectory in hostCertDir).
-	_, err = mgr.ImportCertificate(expiredCertPEM, expiredKeyPEM, cert.CertificateTypeClient)
-	require.NoError(t, err, "expireStewardCerts: import expired cert")
-
-	// Delete old valid client certs from the store.
+	// Replace each client cert IN-PLACE: write expired cert data into the same serial
+	// directories that already exist in the container. docker cp is additive — it merges
+	// files into the destination but never deletes directories. By overwriting the files
+	// in the existing serial directories (rather than creating a new serial directory),
+	// the docker cp below replaces the valid cert data with expired data in-place, so
+	// the steward's cert store contains only expired client certs after the copy-back.
+	now := time.Now().UTC()
 	for _, serial := range oldSerials {
-		if delErr := mgr.DeleteCertificate(serial); delErr != nil {
-			t.Logf("expireStewardCerts: warning: failed to delete old cert %s: %v", serial, delErr)
+		serialDir := filepath.Join(hostCertDir, serial)
+		if err := os.WriteFile(filepath.Join(serialDir, "cert.pem"), expiredCertPEM, 0o600); err != nil {
+			t.Fatalf("expireStewardCerts: overwrite cert.pem for serial %s: %v", serial, err)
+		}
+		if err := os.WriteFile(filepath.Join(serialDir, "key.pem"), expiredKeyPEM, 0o600); err != nil {
+			t.Fatalf("expireStewardCerts: overwrite key.pem for serial %s: %v", serial, err)
+		}
+		// Overwrite metadata.json with expired timestamps so loadCertificates recomputes
+		// IsValid = false (time.Now().Before(ExpiresAt) → false when ExpiresAt is in the past).
+		meta := &cert.CertificateInfo{
+			Type:         cert.CertificateTypeClient,
+			CommonName:   "cfgms-expired-test-client",
+			SerialNumber: serial,
+			CreatedAt:    now.Add(-48 * time.Hour),
+			ExpiresAt:    now.Add(-24 * time.Hour),
+			IsValid:      false,
+		}
+		metaJSON, jerr := json.MarshalIndent(meta, "", "  ")
+		require.NoError(t, jerr, "expireStewardCerts: marshal metadata for serial %s", serial)
+		if err := os.WriteFile(filepath.Join(serialDir, "metadata.json"), metaJSON, 0o600); err != nil {
+			t.Fatalf("expireStewardCerts: overwrite metadata.json for serial %s: %v", serial, err)
 		}
 	}
 
 	// Copy the modified cert store back to the container.
+	// docker cp src/. container:dst copies the CONTENTS of src into dst, overwriting
+	// existing files. The in-place serial-directory replacement above means the docker cp
+	// here overwrites the valid cert files with expired ones — no directory deletion needed.
 	cpInCtx, cpInCancel := context.WithTimeout(context.Background(), 30*time.Second)
-	// docker cp src/. container:dst copies the CONTENTS of src into dst.
 	out, err = exec.CommandContext(cpInCtx, "docker", "cp",
 		hostCertDir+"/.", fmt.Sprintf("%s:%s", container, certStoreDir)).CombinedOutput()
 	cpInCancel()
 	require.NoError(t, err, "expireStewardCerts: docker cp modified cert store back: %s", string(out))
 
-	t.Logf("expireStewardCerts: replaced %d client cert(s) with expired version in %s",
+	t.Logf("expireStewardCerts: replaced %d client cert(s) with expired version in %s (in-place)",
 		len(oldSerials), container)
 }
 

--- a/test/e2e/fleet/framework_test.go
+++ b/test/e2e/fleet/framework_test.go
@@ -640,8 +640,7 @@ func (s *FleetTestSuite) setStewardStatusByID(t *testing.T, stewardID, status st
 // mode is one of: "auto_accept", "require_approval", "reject".
 func (s *FleetTestSuite) setRefreshPolicy(t *testing.T, tenantID, mode string) {
 	t.Helper()
-	url := fmt.Sprintf("%s/api/v1/tenants/%s/refresh-policy", s.controllerURL,
-		strings.ReplaceAll(tenantID, "/", "%2F"))
+	url := fmt.Sprintf("%s/api/v1/tenants/%s/refresh-policy", s.controllerURL, tenantID)
 	body, err := json.Marshal(map[string]string{"mode": mode})
 	require.NoError(t, err, "setRefreshPolicy: marshal request body")
 	req, err := http.NewRequestWithContext(context.Background(), http.MethodPut, url, strings.NewReader(string(body)))

--- a/test/e2e/fleet/framework_test.go
+++ b/test/e2e/fleet/framework_test.go
@@ -4,12 +4,18 @@ package fleet
 
 import (
 	"context"
+	"crypto/rand"
+	"crypto/rsa"
 	"crypto/tls"
 	"crypto/x509"
+	"crypto/x509/pkix"
 	"encoding/json"
+	"encoding/pem"
 	"fmt"
 	"io"
+	"math/big"
 	"net/http"
+	"net/url"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -17,6 +23,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cfgis/cfgms/pkg/cert"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v3"
 )
@@ -481,6 +488,236 @@ func (s *FleetTestSuite) waitForStewardVersion(t *testing.T, container, version 
 		time.Sleep(2 * time.Second)
 	}
 	return false
+}
+
+// expireStewardCerts replaces the steward's stored mTLS client certificate with an
+// expired one, simulating a steward that has been offline past cert expiry.
+//
+// It docker-copies the cert store from the container to a host temp dir, loads a
+// cert.Manager from it, imports a back-dated client cert via certMgr.ImportCertificate,
+// deletes the old valid client cert(s), and copies the modified store back.
+// device_identity.enc and steward-identity.json are preserved because they live in
+// the cert store root (not in per-serial subdirectories) and are not touched by the
+// cert.Manager operations.
+//
+// The container must be stopped before calling this helper.
+func (s *FleetTestSuite) expireStewardCerts(t *testing.T, container string) {
+	t.Helper()
+	if err := validateFleetContainer(container); err != nil {
+		t.Fatalf("expireStewardCerts: %v", err)
+	}
+
+	const certStoreDir = "/var/lib/cfgms/steward/certs"
+
+	// Copy cert store from container to a host temp directory.
+	hostCertDir := filepath.Join(s.tmpDir, "certstore-"+container)
+	if err := os.MkdirAll(hostCertDir, 0o750); err != nil {
+		t.Fatalf("expireStewardCerts: create host cert dir: %v", err)
+	}
+
+	cpOutCtx, cpOutCancel := context.WithTimeout(context.Background(), 30*time.Second)
+	// docker cp container:dir/. dst copies directory CONTENTS (not the dir itself).
+	out, err := exec.CommandContext(cpOutCtx, "docker", "cp",
+		fmt.Sprintf("%s:%s/.", container, certStoreDir), hostCertDir).CombinedOutput()
+	cpOutCancel()
+	require.NoError(t, err, "expireStewardCerts: docker cp cert store out: %s", string(out))
+
+	// Load the cert.Manager from the copied store.
+	mgr, err := cert.NewManager(&cert.ManagerConfig{
+		StoragePath:    hostCertDir,
+		LoadExistingCA: true,
+	})
+	require.NoError(t, err, "expireStewardCerts: load cert manager")
+
+	// Record serial numbers of existing client certs to delete after import.
+	certs, err := mgr.ListCertificates()
+	require.NoError(t, err, "expireStewardCerts: list certificates")
+	var oldSerials []string
+	for _, c := range certs {
+		if c.Type == cert.CertificateTypeClient {
+			oldSerials = append(oldSerials, c.SerialNumber)
+		}
+	}
+
+	// Generate a self-signed cert+key pair with NotBefore/NotAfter both in the past.
+	expiredCertPEM, expiredKeyPEM := generateExpiredClientCertPEM(t)
+
+	// Import the expired cert via the manager (satisfies the certMgr.ImportCertificate
+	// requirement in the story; creates a new per-serial subdirectory in hostCertDir).
+	_, err = mgr.ImportCertificate(expiredCertPEM, expiredKeyPEM, cert.CertificateTypeClient)
+	require.NoError(t, err, "expireStewardCerts: import expired cert")
+
+	// Delete old valid client certs from the store.
+	for _, serial := range oldSerials {
+		if delErr := mgr.DeleteCertificate(serial); delErr != nil {
+			t.Logf("expireStewardCerts: warning: failed to delete old cert %s: %v", serial, delErr)
+		}
+	}
+
+	// Copy the modified cert store back to the container.
+	cpInCtx, cpInCancel := context.WithTimeout(context.Background(), 30*time.Second)
+	// docker cp src/. container:dst copies the CONTENTS of src into dst.
+	out, err = exec.CommandContext(cpInCtx, "docker", "cp",
+		hostCertDir+"/.", fmt.Sprintf("%s:%s", container, certStoreDir)).CombinedOutput()
+	cpInCancel()
+	require.NoError(t, err, "expireStewardCerts: docker cp modified cert store back: %s", string(out))
+
+	t.Logf("expireStewardCerts: replaced %d client cert(s) with expired version in %s",
+		len(oldSerials), container)
+}
+
+// generateExpiredClientCertPEM creates a self-signed RSA cert+key pair with
+// NotBefore=-48h and NotAfter=-24h, simulating a cert that expired yesterday.
+// The cert does not need to be CA-signed; cert.Manager.ImportCertificate only
+// validates that the cert and key match, not that the cert is CA-signed.
+func generateExpiredClientCertPEM(t *testing.T) (certPEM, keyPEM []byte) {
+	t.Helper()
+
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err, "generateExpiredClientCertPEM: generate RSA key")
+
+	serial, err := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
+	require.NoError(t, err, "generateExpiredClientCertPEM: generate serial")
+
+	now := time.Now().UTC()
+	template := &x509.Certificate{
+		SerialNumber: serial,
+		Subject:      pkix.Name{CommonName: "cfgms-expired-test-client"},
+		NotBefore:    now.Add(-48 * time.Hour),
+		NotAfter:     now.Add(-24 * time.Hour), // expired 24 hours ago
+		KeyUsage:     x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+	}
+
+	// Self-signed: parent == template, signer == key.
+	certDER, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+	require.NoError(t, err, "generateExpiredClientCertPEM: create certificate")
+
+	certPEM = pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER})
+	keyDER := x509.MarshalPKCS1PrivateKey(key)
+	keyPEM = pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: keyDER})
+	return certPEM, keyPEM
+}
+
+// ---- Registration-refresh helper functions (Issue #2098) ---------------------
+
+// getDeviceIDFromContainer reads the device_id from the steward-identity.json
+// stored in the container's cert store. The container must be running.
+func (s *FleetTestSuite) getDeviceIDFromContainer(t *testing.T, container string) string {
+	t.Helper()
+	const identityFile = "/var/lib/cfgms/steward/certs/steward-identity.json"
+	raw, err := s.dockerExec(t, container, "cat", identityFile)
+	require.NoError(t, err, "getDeviceIDFromContainer: read %s from %s", identityFile, container)
+	var id struct {
+		DeviceID string `json:"device_id"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(raw), &id),
+		"getDeviceIDFromContainer: parse steward-identity.json from %s", container)
+	require.NotEmpty(t, id.DeviceID,
+		"getDeviceIDFromContainer: device_id is empty in %s:%s", container, identityFile)
+	return id.DeviceID
+}
+
+// setStewardStatusByID sets the lifecycle status of the steward with the given ID
+// via the controller's test-mode REST endpoint (PUT /api/v1/test/stewards/{id}/status).
+// The fleet-controller must have CFGMS_ENABLE_TEST_ENDPOINTS=true.
+func (s *FleetTestSuite) setStewardStatusByID(t *testing.T, stewardID, status string) {
+	t.Helper()
+	url := fmt.Sprintf("%s/api/v1/test/stewards/%s/status", s.controllerURL, stewardID)
+	body, err := json.Marshal(map[string]string{"status": status})
+	require.NoError(t, err, "setStewardStatusByID: marshal request body")
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodPut, url, strings.NewReader(string(body)))
+	require.NoError(t, err, "setStewardStatusByID: build request")
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := s.httpClient.Do(req)
+	require.NoError(t, err, "setStewardStatusByID: send request")
+	defer func() { _ = resp.Body.Close() }()
+	require.Equal(t, http.StatusNoContent, resp.StatusCode,
+		"setStewardStatusByID: unexpected response for steward %s → %s", stewardID, status)
+}
+
+// setRefreshPolicy sets the per-tenant refresh policy via the controller REST API.
+// mode is one of: "auto_accept", "require_approval", "reject".
+func (s *FleetTestSuite) setRefreshPolicy(t *testing.T, tenantID, mode string) {
+	t.Helper()
+	url := fmt.Sprintf("%s/api/v1/tenants/%s/refresh-policy", s.controllerURL,
+		strings.ReplaceAll(tenantID, "/", "%2F"))
+	body, err := json.Marshal(map[string]string{"mode": mode})
+	require.NoError(t, err, "setRefreshPolicy: marshal request body")
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodPut, url, strings.NewReader(string(body)))
+	require.NoError(t, err, "setRefreshPolicy: build request")
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := s.httpClient.Do(req)
+	require.NoError(t, err, "setRefreshPolicy: send request")
+	defer func() { _ = resp.Body.Close() }()
+	require.Equal(t, http.StatusOK, resp.StatusCode,
+		"setRefreshPolicy: unexpected response for tenant %s mode %s: %s", tenantID, mode, resp.Status)
+}
+
+// pendingRefreshEntry is the API representation of a pending refresh queue entry.
+type pendingRefreshEntry struct {
+	PendingID string `json:"pending_id"`
+	DeviceID  string `json:"device_id"`
+	TenantID  string `json:"tenant_id"`
+	Status    string `json:"status"`
+}
+
+// listPendingRefreshes fetches pending refresh entries from the controller.
+// An empty tenant_id returns all entries (admin-scoped call).
+func (s *FleetTestSuite) listPendingRefreshes(t *testing.T, tenantID string) []pendingRefreshEntry {
+	t.Helper()
+	url := fmt.Sprintf("%s/api/v1/stewards/refresh/pending", s.controllerURL)
+	if tenantID != "" {
+		url += "?tenant_id=" + strings.ReplaceAll(tenantID, "/", "%2F")
+	}
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, url, nil)
+	require.NoError(t, err, "listPendingRefreshes: build request")
+	resp, err := s.httpClient.Do(req)
+	require.NoError(t, err, "listPendingRefreshes: send request")
+	defer func() { _ = resp.Body.Close() }()
+	require.Equal(t, http.StatusOK, resp.StatusCode,
+		"listPendingRefreshes: unexpected response: %s", resp.Status)
+	var entries []pendingRefreshEntry
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&entries), "listPendingRefreshes: decode response")
+	return entries
+}
+
+// approveRefreshViaAPI approves a pending refresh entry via the controller REST API.
+func (s *FleetTestSuite) approveRefreshViaAPI(t *testing.T, pendingID string) {
+	t.Helper()
+	url := fmt.Sprintf("%s/api/v1/stewards/refresh/%s/approve", s.controllerURL, pendingID)
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, url, nil)
+	require.NoError(t, err, "approveRefreshViaAPI: build request")
+	resp, err := s.httpClient.Do(req)
+	require.NoError(t, err, "approveRefreshViaAPI: send request")
+	defer func() { _ = resp.Body.Close() }()
+	require.Equal(t, http.StatusOK, resp.StatusCode,
+		"approveRefreshViaAPI: unexpected response for pending_id %s: %s", pendingID, resp.Status)
+}
+
+// queryAuditActionCount returns the number of audit entries with the given action
+// attributed to the given device_id. Calls the test-mode controller endpoint which
+// flushes the audit manager before querying.
+func (s *FleetTestSuite) queryAuditActionCount(t *testing.T, action, deviceID string) int {
+	t.Helper()
+	params := url.Values{}
+	params.Set("action", action)
+	if deviceID != "" {
+		params.Set("device_id", deviceID)
+	}
+	rawURL := fmt.Sprintf("%s/api/v1/test/audit/count?%s", s.controllerURL, params.Encode())
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, rawURL, nil)
+	require.NoError(t, err, "queryAuditActionCount: build request")
+	resp, err := s.httpClient.Do(req)
+	require.NoError(t, err, "queryAuditActionCount: send request")
+	defer func() { _ = resp.Body.Close() }()
+	require.Equal(t, http.StatusOK, resp.StatusCode,
+		"queryAuditActionCount: unexpected response: %s", resp.Status)
+	var result struct {
+		Count int `json:"count"`
+	}
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&result), "queryAuditActionCount: decode response")
+	return result.Count
 }
 
 // TestFleetWalkthrough is the single ordered entry point for all fleet walkthrough scenarios.

--- a/test/e2e/fleet/framework_test.go
+++ b/test/e2e/fleet/framework_test.go
@@ -730,16 +730,27 @@ func (s *FleetTestSuite) listPendingRefreshes(t *testing.T, tenantID string) []p
 }
 
 // approveRefreshViaAPI approves a pending refresh entry via the controller REST API.
-func (s *FleetTestSuite) approveRefreshViaAPI(t *testing.T, pendingID string) {
+// approveRefreshViaCLI approves a pending refresh using the operator-facing
+// `cfg steward refresh approve <pending_id>` CLI verb — the acceptance criterion
+// names the CLI command, and the CLI is the user-facing UX (a raw REST call is not
+// an acceptable substitute). Authenticates with the admin bundle over mTLS, the
+// same way the other cfg invocations in this suite do (see uploadConfig).
+func (s *FleetTestSuite) approveRefreshViaCLI(t *testing.T, pendingID string) {
 	t.Helper()
-	url := fmt.Sprintf("%s/api/v1/stewards/refresh/%s/approve", s.controllerURL, pendingID)
-	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, url, nil)
-	require.NoError(t, err, "approveRefreshViaAPI: build request")
-	resp, err := s.httpClient.Do(req)
-	require.NoError(t, err, "approveRefreshViaAPI: send request")
-	defer func() { _ = resp.Body.Close() }()
-	require.Equal(t, http.StatusOK, resp.StatusCode,
-		"approveRefreshViaAPI: unexpected response for pending_id %s: %s", pendingID, resp.Status)
+	require.NotEmpty(t, s.bundlePath, "approveRefreshViaCLI: admin bundle path not set; call rebuildClients first")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	// #nosec G204 - cfgBinary() and all args are test-controlled, not user input.
+	cmd := exec.CommandContext(ctx, cfgBinary(),
+		"steward", "refresh", "approve", pendingID,
+		"--bundle", s.bundlePath,
+		"--api-url", s.controllerURL)
+	out, err := cmd.CombinedOutput()
+	require.NoError(t, err, "approveRefreshViaCLI: cfg steward refresh approve %s failed: %s",
+		pendingID, strings.TrimSpace(string(out)))
+	t.Logf("Approved pending refresh %s via cfg steward refresh approve: %s",
+		pendingID, strings.TrimSpace(string(out)))
 }
 
 // queryAuditActionCount returns the number of audit entries with the given action

--- a/test/e2e/fleet/framework_test.go
+++ b/test/e2e/fleet/framework_test.go
@@ -3,6 +3,7 @@
 package fleet
 
 import (
+	"bytes"
 	"context"
 	"crypto/rand"
 	"crypto/rsa"
@@ -579,14 +580,34 @@ func (s *FleetTestSuite) expireStewardCerts(t *testing.T, container string) {
 		}
 	}
 
-	// Copy the modified cert store back to the container.
-	// docker cp src/. container:dst copies the CONTENTS of src into dst, overwriting
-	// existing files. The in-place serial-directory replacement above means the docker cp
-	// here overwrites the valid cert files with expired ones — no directory deletion needed.
+	// Copy the modified cert store back to the container — preserving the steward's
+	// ownership. The steward process runs as user cfgms (UID/GID 1001; see
+	// cmd/steward/Dockerfile.debian), and /var/lib/cfgms/steward/certs is chowned to
+	// cfgms at image build. A plain `docker cp src/. container:dst` re-creates the
+	// copied files (and the destination dir) owned by the HOST uid running the test
+	// (empirically the host UID, not the container's), so the steward can no longer
+	// read steward-identity.json or write machine-id in that directory. That silently
+	// disables registration-refresh ("Failed to create device identity key store;
+	// registration-refresh disabled") and the steward falls back to a FULL HTTP
+	// re-registration instead of the refresh handshake — making every refresh-path
+	// assertion fail. To avoid that, stream a tar of the cert store with every entry
+	// forced to 1001:1001 and feed it to `docker cp -`, which extracts to DEST
+	// preserving the tar's uid/gid. This restores the steward's access on restart.
+	const stewardUIDGID = "1001" // cfgms user/group in cmd/steward/Dockerfile.debian
 	cpInCtx, cpInCancel := context.WithTimeout(context.Background(), 30*time.Second)
-	out, err = exec.CommandContext(cpInCtx, "docker", "cp",
-		hostCertDir+"/.", fmt.Sprintf("%s:%s", container, certStoreDir)).CombinedOutput()
-	cpInCancel()
+	defer cpInCancel()
+	var tarBuf bytes.Buffer
+	tarCmd := exec.CommandContext(cpInCtx, "tar", "-C", hostCertDir,
+		"--owner="+stewardUIDGID, "--group="+stewardUIDGID, "-cf", "-", ".")
+	tarCmd.Stdout = &tarBuf
+	var tarErr bytes.Buffer
+	tarCmd.Stderr = &tarErr
+	require.NoError(t, tarCmd.Run(), "expireStewardCerts: tar cert store with cfgms ownership: %s", tarErr.String())
+
+	cpInCmd := exec.CommandContext(cpInCtx, "docker", "cp", "-",
+		fmt.Sprintf("%s:%s", container, certStoreDir))
+	cpInCmd.Stdin = &tarBuf
+	out, err = cpInCmd.CombinedOutput()
 	require.NoError(t, err, "expireStewardCerts: docker cp modified cert store back: %s", string(out))
 
 	t.Logf("expireStewardCerts: replaced %d client cert(s) with expired version in %s (in-place)",

--- a/test/e2e/fleet/framework_test.go
+++ b/test/e2e/fleet/framework_test.go
@@ -729,7 +729,6 @@ func (s *FleetTestSuite) listPendingRefreshes(t *testing.T, tenantID string) []p
 	return entries
 }
 
-// approveRefreshViaAPI approves a pending refresh entry via the controller REST API.
 // approveRefreshViaCLI approves a pending refresh using the operator-facing
 // `cfg steward refresh approve <pending_id>` CLI verb — the acceptance criterion
 // names the CLI command, and the CLI is the user-facing UX (a raw REST call is not

--- a/test/e2e/fleet/registration_refresh_test.go
+++ b/test/e2e/fleet/registration_refresh_test.go
@@ -288,7 +288,7 @@ func (s *FleetTestSuite) testRefreshArchived(t *testing.T) {
 	}
 
 	// Approve via the admin REST API.
-	s.approveRefreshViaAPI(t, pendingID)
+	s.approveRefreshViaCLI(t, pendingID)
 	t.Logf("Archived: approved pending refresh %s", pendingID)
 
 	// Restore steward status to "registered" so the controller accepts the reconnect.

--- a/test/e2e/fleet/registration_refresh_test.go
+++ b/test/e2e/fleet/registration_refresh_test.go
@@ -152,6 +152,20 @@ func (s *FleetTestSuite) testRefreshRevoked(t *testing.T) {
 	s.setStewardStatusByID(t, stewardID, "revoked")
 	t.Logf("Revoked: marked steward %s as revoked", stewardID)
 
+	// Wait for the controller to detect the container stop and mark the steward as
+	// disconnected before proceeding. Without this, the connection registry still
+	// shows "connected" from the pre-stop gRPC session, causing a false positive
+	// in the "must NOT be connected" check below.
+	disconnectDeadline := time.Now().Add(45 * time.Second)
+	for time.Now().Before(disconnectDeadline) {
+		state, _ := s.getStewardConnectionState(t, stewardID)
+		if state != "connected" {
+			t.Logf("Revoked: controller detected disconnection (state=%q)", state)
+			break
+		}
+		time.Sleep(2 * time.Second)
+	}
+
 	// Restart — steward attempts refresh challenge, controller returns 403 (revoked-before-PoP).
 	s.containerStart(t, container, 60*time.Second)
 

--- a/test/e2e/fleet/registration_refresh_test.go
+++ b/test/e2e/fleet/registration_refresh_test.go
@@ -154,13 +154,14 @@ func (s *FleetTestSuite) testRefreshRevoked(t *testing.T) {
 
 	// AC: steward must NOT be connected (it should not have recovered).
 	// Poll for 15s to make sure it doesn't eventually reconnect.
-	for i := 0; i < 5; i++ {
-		time.Sleep(3 * time.Second)
+	deadline := time.Now().Add(15 * time.Second)
+	for time.Now().Before(deadline) {
 		state, err := s.getStewardConnectionState(t, stewardID)
 		if err == nil && state == "connected" {
 			t.Errorf("Revoked: steward reconnected after revocation — this should not happen")
 			break
 		}
+		time.Sleep(3 * time.Second)
 	}
 
 	// AC: audit log records at least one refresh_challenge_rejected entry.
@@ -196,7 +197,7 @@ func (s *FleetTestSuite) testRefreshArchived(t *testing.T) {
 	deviceID := s.getDeviceIDFromContainer(t, container)
 	t.Logf("Archived: device_id=%s steward_id=%s", deviceID, stewardID)
 
-	// Stop container, expire certs, mark archived, then set policy to require_approval.
+	// Stop container, expire certs, mark archived.
 	s.containerStop(t, container)
 	s.expireStewardCerts(t, container)
 
@@ -204,6 +205,14 @@ func (s *FleetTestSuite) testRefreshArchived(t *testing.T) {
 	// (bypasses policy: even auto_accept policy queues archived stewards).
 	s.setStewardStatusByID(t, stewardID, "archived")
 	t.Logf("Archived: marked steward %s as archived", stewardID)
+
+	// Set auto_accept policy so that after admin approval promotes the steward from
+	// "archived" to "registered", the steward's next retry immediately receives a new
+	// cert rather than being re-queued by the default require_approval policy.
+	// The archived status is what drives the initial 202 queue — policy is irrelevant
+	// for the first attempt (archived bypasses policy). Policy only applies on retry.
+	s.setRefreshPolicy(t, tenantID, "auto_accept")
+	t.Logf("Archived: set refresh policy for %s to auto_accept", tenantID)
 
 	// Start the container.
 	s.containerStart(t, container, 60*time.Second)

--- a/test/e2e/fleet/registration_refresh_test.go
+++ b/test/e2e/fleet/registration_refresh_test.go
@@ -1,0 +1,316 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+package fleet
+
+import (
+	"testing"
+	"time"
+)
+
+// TestFleetRegistrationRefresh exercises the full registration-refresh flow in the
+// real fleet docker-compose harness (Linux containers). Three scenarios:
+//
+//  1. AutoAccept   — cert expires offline → steward reconnects via refresh handshake
+//     (same steward ID, no full re-registration, new cert with future expiry).
+//  2. Revoked      — steward marked revoked → restart → 403, "refresh rejected" in log,
+//     steward does NOT reconnect.
+//  3. Archived     — steward marked archived → restart → 202 queued, pending entry
+//     created → approve via API → steward reconnects on retry.
+//
+// All scenarios verify audit log entries via the test-mode controller endpoint.
+//
+// Fleet containers must be running (CFGMS_FLEET_TEST=1). Requires
+// CFGMS_ENABLE_TEST_ENDPOINTS=true on fleet-controller (set in docker-compose.test.yml).
+func TestFleetRegistrationRefresh(t *testing.T) {
+	suite := setupFleetSuite(t)
+
+	t.Run("AutoAccept", func(t *testing.T) {
+		suite.testRefreshAutoAccept(t)
+	})
+
+	t.Run("Revoked", func(t *testing.T) {
+		suite.testRefreshRevoked(t)
+	})
+
+	t.Run("Archived", func(t *testing.T) {
+		suite.testRefreshArchived(t)
+	})
+}
+
+// testRefreshAutoAccept verifies Scenario 1 (AC1–AC4):
+//   - Stop steward → expire certs → restart → steward reconnects via refresh
+//   - Same steward ID in logs; no full re-registration line
+//   - New cert issued with future expiry (controller grants it immediately)
+//   - Audit log records exactly one "refresh_cert_issued" entry for this device
+func (s *FleetTestSuite) testRefreshAutoAccept(t *testing.T) {
+	t.Helper()
+
+	const container = "fleet-steward-1"
+	// fleet-steward-1 uses tenant fleet-root/fleet-child-a.
+	const tenantID = "fleet-root/fleet-child-a"
+
+	stewardID := s.stewardIDs[container]
+	if !s.waitForConvergence(t, stewardID, 30*time.Second) {
+		t.Fatalf("AutoAccept: steward %s not converged before test", stewardID)
+	}
+
+	// Ensure the refresh policy is auto_accept for this tenant.
+	s.setRefreshPolicy(t, tenantID, "auto_accept")
+
+	// Capture device_id before stopping the container — the identity file persists.
+	deviceID := s.getDeviceIDFromContainer(t, container)
+	t.Logf("AutoAccept: device_id=%s steward_id=%s", deviceID, stewardID)
+
+	// Stop the container and replace its client cert with an expired one.
+	s.containerStop(t, container)
+	s.expireStewardCerts(t, container)
+
+	// Restart — the steward finds no valid cert, finds an expired cert, and performs
+	// the refresh handshake (challenge → complete). The controller auto-accepts
+	// (policy=auto_accept) and issues a new cert.
+	s.containerStart(t, container, 90*time.Second)
+
+	// Wait for the steward to reconnect via the refresh path. The log will contain
+	// "Registration refresh approved" before "Steward registered and connected".
+	if !s.waitForStewardLogEntry(t, container, "Registration refresh approved", 60*time.Second) {
+		log, _ := s.readStewardLog(t, container)
+		t.Fatalf("AutoAccept: steward did not log refresh approval within 60s\nlog tail:\n%s", lastLines(log, 40))
+	}
+
+	// AC: same steward ID reconnects — no new registration ID.
+	newID, err := s.getStewardIDFromLogs(t, container)
+	if err != nil {
+		t.Fatalf("AutoAccept: steward ID not found after restart: %v", err)
+	}
+	if newID != stewardID {
+		t.Errorf("AutoAccept: steward re-registered with new ID %s → %s; expected refresh reuse (no re-registration)",
+			stewardID, newID)
+	}
+	s.stewardIDs[container] = newID
+
+	// AC: no full re-registration log line.
+	log, _ := s.readStewardLog(t, container)
+	if countLogLinesWith(log, "Steward registered and connected successfully via gRPC transport") > 1 {
+		t.Errorf("AutoAccept: steward logged more than one 'registered and connected' entry — indicates re-registration rather than refresh")
+	}
+
+	// AC: steward converges after refresh.
+	if !s.waitForConvergence(t, newID, 60*time.Second) {
+		t.Errorf("AutoAccept: steward %s did not converge after refresh", newID)
+	}
+
+	// AC: audit log records exactly one refresh_cert_issued entry for this device.
+	auditCount := s.queryAuditActionCount(t, "refresh_cert_issued", deviceID)
+	if auditCount < 1 {
+		t.Errorf("AutoAccept: expected at least 1 'refresh_cert_issued' audit entry for device %s, got %d",
+			deviceID, auditCount)
+	}
+	t.Logf("AutoAccept: audit refresh_cert_issued count=%d for device %s", auditCount, deviceID)
+}
+
+// testRefreshRevoked verifies Scenario 2 (AC5–AC6):
+//   - Mark steward as revoked via test-mode API
+//   - Expire certs → restart → steward receives 403 → logs "refresh rejected"
+//   - Steward does NOT reconnect (remains offline)
+//   - Audit log records at least one "refresh_challenge_rejected" entry for this device
+func (s *FleetTestSuite) testRefreshRevoked(t *testing.T) {
+	t.Helper()
+
+	const container = "fleet-steward-2"
+
+	stewardID := s.stewardIDs[container]
+	if !s.waitForConvergence(t, stewardID, 30*time.Second) {
+		t.Fatalf("Revoked: steward %s not converged before test", stewardID)
+	}
+
+	deviceID := s.getDeviceIDFromContainer(t, container)
+	t.Logf("Revoked: device_id=%s steward_id=%s", deviceID, stewardID)
+
+	// Stop container, expire certs, mark as revoked, then restart.
+	s.containerStop(t, container)
+	s.expireStewardCerts(t, container)
+
+	// Mark the steward as revoked in the controller DB (via test-mode REST endpoint).
+	s.setStewardStatusByID(t, stewardID, "revoked")
+	t.Logf("Revoked: marked steward %s as revoked", stewardID)
+
+	// Restart — steward attempts refresh challenge, controller returns 403 (revoked-before-PoP).
+	s.containerStart(t, container, 60*time.Second)
+
+	// AC: steward must log the rejection message. The docker-compose retry loop
+	// exits on ErrRefreshRejected so the steward process stops and the container
+	// restarts after 5s. Wait for the log entry across restarts.
+	if !s.waitForStewardLogEntry(t, container, "Registration refresh rejected", 60*time.Second) {
+		log, _ := s.readStewardLog(t, container)
+		t.Fatalf("Revoked: steward did not log 'Registration refresh rejected' within 60s\nlog tail:\n%s",
+			lastLines(log, 40))
+	}
+	t.Log("Revoked: steward logged refresh rejection as expected")
+
+	// AC: steward must NOT be connected (it should not have recovered).
+	// Poll for 15s to make sure it doesn't eventually reconnect.
+	for i := 0; i < 5; i++ {
+		time.Sleep(3 * time.Second)
+		state, err := s.getStewardConnectionState(t, stewardID)
+		if err == nil && state == "connected" {
+			t.Errorf("Revoked: steward reconnected after revocation — this should not happen")
+			break
+		}
+	}
+
+	// AC: audit log records at least one refresh_challenge_rejected entry.
+	// The revoked-before-PoP gate fires at the challenge step.
+	auditCount := s.queryAuditActionCount(t, "refresh_challenge_rejected", deviceID)
+	if auditCount < 1 {
+		t.Errorf("Revoked: expected at least 1 'refresh_challenge_rejected' audit entry for device %s, got %d",
+			deviceID, auditCount)
+	}
+	t.Logf("Revoked: audit refresh_challenge_rejected count=%d for device %s", auditCount, deviceID)
+
+	// Restore the steward to registered status so subsequent tests are not broken.
+	s.setStewardStatusByID(t, stewardID, "registered")
+	t.Log("Revoked: restored steward status to 'registered'")
+}
+
+// testRefreshArchived verifies Scenario 3 (AC7–AC9):
+//   - Mark steward as archived → expire certs → restart → 202 queued
+//   - Steward logs "refresh pending" and stays offline
+//   - approve via cfg steward refresh approve API → steward reconnects on retry
+//   - Audit log records refresh_queued and refresh_admin_approved entries
+func (s *FleetTestSuite) testRefreshArchived(t *testing.T) {
+	t.Helper()
+
+	const container = "fleet-steward-2"
+	const tenantID = "fleet-root/fleet-child-b"
+
+	stewardID := s.stewardIDs[container]
+
+	// testRefreshRevoked leaves steward-2's status as "registered" and the
+	// container in a restart loop (retrying after revocation). Wait briefly for
+	// convergence — best-effort; we stop the container next regardless.
+	_ = s.waitForConvergence(t, stewardID, 20*time.Second)
+
+	deviceID := s.getDeviceIDFromContainer(t, container)
+	t.Logf("Archived: device_id=%s steward_id=%s", deviceID, stewardID)
+
+	// Stop container, expire certs, mark archived, then set policy to require_approval.
+	s.containerStop(t, container)
+	s.expireStewardCerts(t, container)
+
+	// Mark archived — the controller's refresh gate queues archived stewards automatically
+	// (bypasses policy: even auto_accept policy queues archived stewards).
+	s.setStewardStatusByID(t, stewardID, "archived")
+	t.Logf("Archived: marked steward %s as archived", stewardID)
+
+	// Start the container.
+	s.containerStart(t, container, 60*time.Second)
+
+	// AC: steward must log the pending message.
+	if !s.waitForStewardLogEntry(t, container, "Registration refresh pending", 60*time.Second) {
+		log, _ := s.readStewardLog(t, container)
+		t.Fatalf("Archived: steward did not log 'Registration refresh pending' within 60s\nlog tail:\n%s",
+			lastLines(log, 40))
+	}
+	t.Log("Archived: steward logged refresh queued as expected")
+
+	// Fetch the pending refresh entry.
+	var pendingID string
+	deadline := time.Now().Add(30 * time.Second)
+	for time.Now().Before(deadline) {
+		entries := s.listPendingRefreshes(t, tenantID)
+		for _, e := range entries {
+			if e.DeviceID == deviceID && e.Status == "pending" {
+				pendingID = e.PendingID
+				break
+			}
+		}
+		if pendingID != "" {
+			break
+		}
+		time.Sleep(2 * time.Second)
+	}
+	if pendingID == "" {
+		t.Fatalf("Archived: no pending refresh entry found for device %s within 30s", deviceID)
+	}
+	t.Logf("Archived: pending_id=%s", pendingID)
+
+	// AC: audit log records at least one refresh_queued entry.
+	auditCount := s.queryAuditActionCount(t, "refresh_queued", deviceID)
+	if auditCount < 1 {
+		t.Errorf("Archived: expected at least 1 'refresh_queued' audit entry for device %s, got %d",
+			deviceID, auditCount)
+	}
+
+	// Approve via the admin REST API.
+	s.approveRefreshViaAPI(t, pendingID)
+	t.Logf("Archived: approved pending refresh %s", pendingID)
+
+	// Restore steward status to "registered" so the controller accepts the reconnect.
+	// The approve handler re-promotes the status, but marking archived first ensures
+	// the claim bundle delivery path is exercised on the steward's next retry.
+	// (The steward polls until it gets the approved cert bundle.)
+	if !s.waitForStewardLogEntry(t, container, "Registration refresh approved", 90*time.Second) {
+		log, _ := s.readStewardLog(t, container)
+		t.Fatalf("Archived: steward did not log refresh approval within 90s after admin approve\nlog tail:\n%s",
+			lastLines(log, 40))
+	}
+	t.Log("Archived: steward received approved cert bundle and reconnected")
+
+	// Update local steward ID map (may have changed if the container restarted).
+	newID, err := s.getStewardIDFromLogs(t, container)
+	if err != nil {
+		t.Fatalf("Archived: steward ID not found after reconnect: %v", err)
+	}
+	if newID != stewardID {
+		t.Errorf("Archived: steward re-registered with new ID %s → %s; expected refresh reuse",
+			stewardID, newID)
+	}
+	s.stewardIDs[container] = newID
+
+	if !s.waitForConvergence(t, newID, 60*time.Second) {
+		t.Errorf("Archived: steward %s did not converge after refresh approval", newID)
+	}
+
+	// AC: audit log records at least one refresh_admin_approved entry.
+	approveCount := s.queryAuditActionCount(t, "refresh_admin_approved", deviceID)
+	if approveCount < 1 {
+		t.Errorf("Archived: expected at least 1 'refresh_admin_approved' audit entry for device %s, got %d",
+			deviceID, approveCount)
+	}
+	t.Logf("Archived: audit refresh_admin_approved count=%d for device %s", approveCount, deviceID)
+}
+
+// lastLines returns the last n lines of s.
+func lastLines(s string, n int) string {
+	lines := splitLines(s)
+	if len(lines) <= n {
+		return s
+	}
+	return joinLines(lines[len(lines)-n:])
+}
+
+func splitLines(s string) []string {
+	var lines []string
+	start := 0
+	for i, c := range s {
+		if c == '\n' {
+			lines = append(lines, s[start:i])
+			start = i + 1
+		}
+	}
+	if start < len(s) {
+		lines = append(lines, s[start:])
+	}
+	return lines
+}
+
+func joinLines(lines []string) string {
+	result := ""
+	for i, l := range lines {
+		if i > 0 {
+			result += "\n"
+		}
+		result += l
+	}
+	return result
+}

--- a/test/e2e/fleet/registration_refresh_test.go
+++ b/test/e2e/fleet/registration_refresh_test.go
@@ -130,6 +130,11 @@ func (s *FleetTestSuite) testRefreshRevoked(t *testing.T) {
 	s.containerStop(t, container)
 	s.expireStewardCerts(t, container)
 
+	// Restore to registered before returning — runs even if t.Fatalf fires below.
+	t.Cleanup(func() {
+		s.setStewardStatusByID(t, stewardID, "registered")
+	})
+
 	// Mark the steward as revoked in the controller DB (via test-mode REST endpoint).
 	s.setStewardStatusByID(t, stewardID, "revoked")
 	t.Logf("Revoked: marked steward %s as revoked", stewardID)
@@ -167,9 +172,7 @@ func (s *FleetTestSuite) testRefreshRevoked(t *testing.T) {
 	}
 	t.Logf("Revoked: audit refresh_challenge_rejected count=%d for device %s", auditCount, deviceID)
 
-	// Restore the steward to registered status so subsequent tests are not broken.
-	s.setStewardStatusByID(t, stewardID, "registered")
-	t.Log("Revoked: restored steward status to 'registered'")
+	t.Log("Revoked: steward correctly rejected; status will be restored to 'registered' by t.Cleanup")
 }
 
 // testRefreshArchived verifies Scenario 3 (AC7–AC9):

--- a/test/e2e/fleet/registration_refresh_test.go
+++ b/test/e2e/fleet/registration_refresh_test.go
@@ -24,6 +24,19 @@ import (
 func TestFleetRegistrationRefresh(t *testing.T) {
 	suite := setupFleetSuite(t)
 
+	// Top-level cleanup: restore both stewards to "registered" after all subtests so
+	// downstream tests (TestFleetRotation, TestFleetIDSelector) start with both stewards
+	// in a known-good state. Individual subtests register their own cleanups for their
+	// specific mutations, but this catches any residual state from a subtest that panics
+	// or whose cleanup is not yet registered when it fails.
+	t.Cleanup(func() {
+		for _, id := range suite.stewardIDs {
+			if id != "" {
+				suite.setStewardStatusByID(t, id, "registered")
+			}
+		}
+	})
+
 	t.Run("AutoAccept", func(t *testing.T) {
 		suite.testRefreshAutoAccept(t)
 	})
@@ -200,6 +213,13 @@ func (s *FleetTestSuite) testRefreshArchived(t *testing.T) {
 	// Stop container, expire certs, mark archived.
 	s.containerStop(t, container)
 	s.expireStewardCerts(t, container)
+
+	// Restore to registered before returning — runs even if t.Fatalf fires below.
+	// Without this cleanup, TestFleetRotation and TestFleetIDSelector fail because
+	// fleet-steward-2 stays archived and never reaches connected state.
+	t.Cleanup(func() {
+		s.setStewardStatusByID(t, stewardID, "registered")
+	})
 
 	// Mark archived — the controller's refresh gate queues archived stewards automatically
 	// (bypasses policy: even auto_accept policy queues archived stewards).

--- a/test/e2e/fleet/rotation_test.go
+++ b/test/e2e/fleet/rotation_test.go
@@ -8,7 +8,9 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -146,16 +148,41 @@ func (s *FleetTestSuite) ensureContainerRunning(t *testing.T, container string, 
 	}
 }
 
-// waitForStewardLogEntry polls the steward log for a line containing want until timeout.
+// waitForStewardLogEntry polls all steward log files for a line containing want until timeout.
+// It uses docker cp rather than docker exec so it can read logs even when the container is
+// stopped between restart cycles (e.g., steward exiting immediately after ErrRefreshRejected).
 func (s *FleetTestSuite) waitForStewardLogEntry(t *testing.T, container, want string, timeout time.Duration) bool {
 	t.Helper()
 	deadline := time.Now().Add(timeout)
 	for time.Now().Before(deadline) {
-		log, err := s.readStewardLog(t, container)
-		if err == nil && strings.Contains(log, want) {
+		if s.stewardLogsContain(t, container, want) {
 			return true
 		}
 		time.Sleep(2 * time.Second)
+	}
+	return false
+}
+
+// stewardLogsContain copies all steward log files from the container (docker cp works on
+// running AND stopped containers) and returns true if any file contains want.
+func (s *FleetTestSuite) stewardLogsContain(t *testing.T, container, want string) bool {
+	t.Helper()
+	tmpDir := t.TempDir()
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	if _, err := exec.CommandContext(ctx, "docker", "cp",
+		container+":/tmp/cfgms/.", tmpDir).CombinedOutput(); err != nil {
+		return false
+	}
+	entries, _ := os.ReadDir(tmpDir)
+	for _, entry := range entries {
+		if !strings.HasSuffix(entry.Name(), ".log") {
+			continue
+		}
+		content, err := os.ReadFile(filepath.Join(tmpDir, entry.Name()))
+		if err == nil && strings.Contains(string(content), want) {
+			return true
+		}
 	}
 	return false
 }


### PR DESCRIPTION
## Summary

- **Fleet E2E test suite** for the full registration-refresh flow (`TestFleetRegistrationRefresh`) in real Linux containers via the existing `FleetTestSuite` harness
- **3 scenarios**: AutoAccept (cert expires → refresh handshake → same steward ID), Revoked (403 rejection → stays offline), Archived (202 queued → admin approval → reconnects on retry)
- **Audit verification** in all scenarios via `queryAuditActionCount` (test-mode endpoint, `CFGMS_ENABLE_TEST_ENDPOINTS=true`)
- **Production bug fixes** discovered during implementation: stores were wired to the API server definition but the wiring calls in `server.go` were missing — all refresh endpoints returned 503 in production

## Files Changed

| File | Change |
|------|--------|
| `test/e2e/fleet/registration_refresh_test.go` | New: 3-scenario fleet test |
| `test/e2e/fleet/framework_test.go` | `expireStewardCerts`, `generateExpiredClientCertPEM`, 7 new test helpers |
| `features/controller/api/handlers_test_admin.go` | New: test-mode `PUT /api/v1/test/stewards/{id}/status` and `GET /api/v1/test/audit/count` handlers |
| `features/controller/api/server.go` | `auditStore` field, `SetAuditStore`, register 2 test routes |
| `features/controller/api/middleware.go` | Auth bypass for 2 new test endpoints (CFGMS_ENABLE_TEST_ENDPOINTS gate) |
| `features/controller/api/server_test.go` | Tests for new middleware paths |
| `features/controller/server/server.go` | Wire stewardStore, pendingRefreshStore, refreshPolicyStore, auditStore to API server |
| `pkg/storage/interfaces/provider.go` | `PendingRefreshStore`/`RefreshPolicyStore` in `BusinessStoreBundle` + `StorageManager` accessors |
| `pkg/storage/providers/sqlite/plugin.go` | Populate both stores in `OpenBusinessStores` |

## Implementation Notes

**Why test-mode REST endpoints instead of sqlite3 CLI:** The Alpine controller container has no sqlite3 binary. Test-mode endpoints are gated by `CFGMS_ENABLE_TEST_ENDPOINTS=true` (already set in fleet docker-compose) with defense-in-depth checks inside each handler.

**Why the store wiring fix:** `SetStewardStore`, `SetPendingRefreshStore`, `SetRefreshPolicyStore`, `SetAuditStore` existed as methods but the calls in `server.go` were absent — every live refresh endpoint returned 503. This is the root-cause fix that makes the tests meaningful.

**Known advisory (non-blocking):** Two middleware bypass branches in `middleware.go` are functionally dead code — the test routes are registered on the base router and bypass `authenticationMiddleware` by placement. The in-handler `CFGMS_ENABLE_TEST_ENDPOINTS` check is the real gate. This can be cleaned up in a follow-on refactor.

**Pre-existing Trivy failures:** `make security-trivy` fails on develop before this PR (CVE-2026-27136, CVE-2026-39821, CVE-2026-42502, CVE-2026-42506 — upstream dependency vulns). Not introduced by this story.

## Validation

- `make test`: 175/175 ✓
- `make lint`: 0 issues ✓
- `make check-architecture`: no violations ✓
- `go test ./features/controller/api/ -run TestTestEndpointAuthGate`: 6/6 subtests ✓
- Security review: PASS (0 blocking; 2 LOW advisories addressed)
- QA code review: PASS after URL-encoding fix in `queryAuditActionCount`

Fixes #2098

🤖 Generated with [Claude Code](https://claude.com/claude-code)