### PR TITLE
hyperv: VM-from-ISO/cloud-image → managed endpoint via cfg (Windows autounattend + Linux cloud-init) (Issue #2080)

### DIFF
--- a/docs/architecture/decisions/009-hyperv-vm-provisioning-from-install-media.md
+++ b/docs/architecture/decisions/009-hyperv-vm-provisioning-from-install-media.md
@@ -93,6 +93,17 @@ The unattended answer file is delivered on a **secondary VHDX seed disk** attach
 
 `autounattend.xml` is the supported mechanism for unattended Windows **Setup** from ISO (not deprecated; install-time, not config-time). A `.ppkg` cannot install the OS — it configures an already-installed Windows. Using a **signed ppkg** for the post-install/enrollment step (rather than an inline PowerShell blob in `<FirstLogonCommands>`) is a deliberate fit with the module banned-pattern rules: a signed declarative artifact over runtime script composition.
 
+### 6a. Linux default: cloud image + cloud-init (NoCloud), not netinst + preseed (amendment, 2026-06)
+
+**For Linux the default/recommended path is a prebuilt vendor cloud image booted with cloud-init, not a netinst ISO + preseed.** This was adopted after live validation showed the netinst route is structurally awkward on a headless Hyper-V host: an unattended debian-installer needs its **kernel command line** to point at the preseed (`auto=true preseed/file=…`), and the only ways to set that headless are (a) repacking the boot media — which to preserve Secure Boot requires `xorriso -boot_image any replay` (xorriso is **not** a winget/choco package, and **WSL cannot run as `LocalSystem`**, which the steward is — so the steward cannot shell out to it), or (b) typing the cmdline via the emulated keyboard (too fragile to ship). Both were rejected.
+
+cloud-init sidesteps the problem entirely:
+
+- **Boot disk = the cloud image.** A `.raw` cloud image is wrapped with a fixed-VHD footer (computed host-side) and converted to a dynamic VHDX with the in-box `Convert-VHD` cmdlet (`.vhd`/`.vhdx` images convert/copy directly), optionally grown via `resize_gb`. **No `qemu-img`, no `xorriso`, no WSL, no external host tool** — and the cloud image's **signed bootloader is never modified**, so Secure Boot stays on (`MicrosoftUEFICertificateAuthority` template).
+- **Enrollment via a NoCloud `CIDATA` seed.** A FAT32 VHDX labelled `CIDATA` carrying `user-data` + `meta-data` (built with the same host-native `New-VHD`/`Mount-VHD`/`Format-Volume` seed machinery as §5, relabelled) is attached as a data disk. cloud-init **auto-detects it by volume label on first boot — no kernel cmdline, no boot-media repack.** The `user-data` `runcmd` is **list/exec form only** (argv arrays, never shell strings) so it carries no banned patterns, and runs `cfgms-steward install --regtoken … --ca-cert … --fingerprint …`.
+
+The host prerequisite is identical to the ISO case — the cloud image is a host path, staged out of band (use the Debian **`generic`** cloud image, which ships cloud-init; not the `nocloud` variant). The legacy netinst + preseed path (§5/§6) remains available for air-gapped/ISO-only sites by setting `source.iso` (instead of `source.image`) on a linux source. Windows stays ISO + autounattend; the Windows-ISO / Linux-cloud-image asymmetry mirrors real-world idiomatic practice. The §8 enrollment model, correlation identity, and `finalizing`→`ready` controller-side completion are unchanged.
+
 ### 7. Unattended profiles are stored config, addable without code
 
 A profile (`profile://<name>`) is a stored config object (ADR-003 taxonomy) describing `os_family`, `answer_format`, the answer-file template, and an `enroll` block. Operators add a new OS by adding a profile — **no code change** (the AC). Profiles are rendered with per-VM variables and **secrets from the secrets provider at provision time** — never cleartext in the profile or committed media.
@@ -107,7 +118,7 @@ First boot installs and enrolls the steward exactly as a normal steward deployme
 
 ### 9. Scope boundary
 
-This capability is **ISO-install only**. Golden-image / template cloning, an image registry, and a branch-build→image pipeline are **Phase 3** (#1792) — they need an image store and build pipeline and are the scale optimization for ephemeral per-dispatch fleets. They are explicitly **out of scope** here.
+This capability provisions from **install media or a vendor cloud image** (§6a) — both are host-staged inputs the module turns into a managed endpoint in one converge. Booting a stock vendor cloud image is **not** golden-image cloning: **CFGMS-prepared** golden-image / template cloning, an image registry, and a branch-build→image pipeline are **Phase 3** (#1792) — they need an image store and build pipeline and are the scale optimization for ephemeral per-dispatch fleets. They are explicitly **out of scope** here.
 
 ## Consequences
 

--- a/features/modules/hyperv/README.md
+++ b/features/modules/hyperv/README.md
@@ -46,9 +46,12 @@ The `source` block (present only when provisioning a VM from install media):
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `source.iso` | string | Yes | Absolute Windows path to the installation ISO on the Hyper-V host (e.g. `C:\ISO\server.iso`). Never repacked or re-signed. |
-| `source.os_family` | string | Yes | Installer family: `linux` or `windows`. Selects the answer-file format, the seed answer-file name, and the Gen2 secure-boot template. |
-| `source.unattend` | string | No | Reference to a stored unattended-install profile as a `profile://<name>` URI. Omit to use the built-in default profile for the `os_family` (`debian-12-base` for linux, `windows-server-default` for windows). |
+| `source.image` | string | One of `image`/`iso` (linux) | Absolute Windows path to a **cloud image** (`.raw` or `.vhdx`) on the Hyper-V host (e.g. `C:\images\debian-13-generic-amd64.raw`). Selects the **cloud-init** path (the default/recommended Linux path): the module prepares the VM's boot disk from this image and delivers enrollment via a NoCloud `CIDATA` seed — no boot-media repack, Secure Boot intact. Ignored for `os_family: windows`. See [Linux provisioning: cloud-init](#linux-provisioning-cloud-init-default). |
+| `source.iso` | string | Yes (windows); legacy (linux) | Absolute Windows path to the installation ISO on the Hyper-V host (e.g. `C:\ISO\server.iso`). Required for `os_family: windows` (autounattend). For `os_family: linux` it selects the legacy netinst + preseed path (use `image` instead unless you specifically need ISO install). Never repacked or re-signed. |
+| `source.resize_gb` | integer | No | Cloud-init path only: grow the converted boot disk to this many GB (cloud-init `growpart` expands the root filesystem on first boot). `0`/omitted leaves the image at its native size. |
+| `source.os_family` | string | Yes | Installer family: `linux` or `windows`. Selects the answer-file format and the Gen2 secure-boot template. |
+| `source.unattend` | string | No | Reference to a stored unattended-install profile as a `profile://<name>` URI. Omit to use the built-in default profile for the media kind (`debian-cloudinit-base` for a linux cloud image, `debian-12-base` for a linux ISO, `windows-server-default` for windows). |
+| `source.edition` | string | No | Windows only: the exact image name the autounattend `ImageInstall` step selects (the `/IMAGE/NAME` value, e.g. `Windows Server 2025 SERVERSTANDARD`). Omit to use the built-in default. |
 | `source.completion` | object | No | How the module detects provisioning succeeded. `completion.mode` accepts only `steward-registration` (the v1 value); `completion.timeout` is a Go duration string (e.g. `60m`) bounding the wait. |
 | `source.on_existing` | string | No | Behaviour when the VM already exists. `never` (default) leaves an existing VM untouched; `recreate` is an explicit opt-in to destroy and re-provision. |
 
@@ -184,7 +187,75 @@ a FAT32 volume labelled `CFGMS_SEED` created next to the VM's primary VHD
 - **The install ISO is never repacked or re-signed.** It is attached as-is from
   its host path. Repacking signed UEFI boot media breaks the boot chain.
 
-### Annotated Linux example (Debian 12, preseed)
+### Linux provisioning: cloud-init (default)
+
+For Linux, the **default and recommended** path boots a prebuilt **cloud image**
+(`source.image`) and enrols via **cloud-init**, rather than running a netinst
+installer. This is how Linux VMs are idiomatically provisioned on every cloud and
+hypervisor, and it sidesteps the netinst constraint that the kernel command line
+(the only way to point an installer at a preseed) can only be set by repacking the
+boot media — which breaks the signed shim under Secure Boot.
+
+How it works (all host-native — no `qemu-img`, no `xorriso`, no WSL, no external
+tool added to the host):
+
+1. **Boot disk from the cloud image.** A `.raw` cloud image is wrapped with a
+   fixed-VHD footer and converted to a dynamic VHDX with the Hyper-V `Convert-VHD`
+   cmdlet (a `.vhd`/`.vhdx` image is converted/copied directly), optionally grown
+   with `source.resize_gb`. The cloud image's **signed bootloader is never
+   modified**, so Secure Boot stays on (Gen2 uses the
+   `MicrosoftUEFICertificateAuthority` template).
+2. **Enrollment via a NoCloud `CIDATA` seed.** A small FAT32 VHDX labelled
+   `CIDATA` carrying `user-data` + `meta-data` (plus the steward binary and the
+   controller CA) is attached as a data disk. cloud-init **auto-detects the
+   `CIDATA` volume by label on first boot — no kernel command line, no boot-media
+   repack.** Its `user-data` `runcmd` (list/exec form only — no shell-string
+   composition) runs `cfgms-steward install --regtoken … --ca-cert … --fingerprint
+   …`, which on a live system stages the binary, writes the systemd unit, and
+   starts enrollment.
+3. The seed is detached at `finalizing`; the OS disk is the first boot device.
+
+**Host prerequisite:** the cloud image (`source.image`) must already be on the
+host, exactly like an ISO — stage it with the `file` module or out of band. Debian
+publishes suitable **generic** cloud images (`.raw`) at
+`https://cloud.debian.org/images/cloud/<release>/latest/` (use the `generic`
+variant, which ships cloud-init — **not** the `nocloud` variant, which has no
+cloud-init). No ISO-builder, no Linux toolchain, and no answer-file repack are
+required on the host.
+
+```yaml
+- name: stw-lin-01
+  module: hyperv.vm
+  config:
+    generation: 2
+    cpu_count: 2
+    memory_mb: 2048
+    vhd_path: C:\VMs\stw-lin-01.vhdx                          # the converted boot disk
+    switch_name: HVSwitch_1G
+    state: running
+    seed_dir: C:\cfgms-seeds                                  # local (non-CSV) seed dir
+    source:
+      image: C:\images\debian-13-generic-amd64.raw           # cloud image; signed bootloader untouched
+      os_family: linux                                        # selects cloud-init + UEFI-CA template
+      resize_gb: 20                                           # grow rootfs on first boot (optional)
+      unattend: profile://debian-cloudinit-base               # omit to use the built-in default
+      completion:
+        mode: steward-registration                            # the only v1 mode
+        timeout: 60m
+      on_existing: never                                       # default; never destroys an existing VM
+```
+
+The enrollment join token and CA fingerprint are supplied via the module's
+controller-synced config (`enroll_token`, `enroll_ca_fingerprint`), and the
+steward binary + CA are staged from `enroll_steward_path` / `enroll_ca_path` (the
+linux steward built for the guest). See [ADR-009](../../../docs/architecture/decisions/009-vm-from-iso-managed-endpoint.md).
+
+### Annotated Linux example (legacy netinst ISO + preseed)
+
+The netinst + preseed path remains available for air-gapped or ISO-only sites that
+cannot use a cloud image. Set `source.iso` (instead of `source.image`) for a linux
+source to select it. It uses a `CFGMS_SEED` preseed seed VHDX and the install ISO
+attached as a DVD; the ISO is never repacked or re-signed.
 
 ```yaml
 - name: stw-lin-01
@@ -198,7 +269,7 @@ a FAT32 volume labelled `CFGMS_SEED` created next to the VM's primary VHD
     state: running
     source:
       iso: C:\ClusterStorage\CSV01\iso\debian-12.iso   # host path; never repacked
-      os_family: linux                                  # selects preseed + UEFI-CA template
+      os_family: linux                                  # with iso (not image) → preseed + UEFI-CA template
       unattend: profile://debian-12-base                # omit to use the built-in default
       completion:
         mode: steward-registration                      # the only v1 mode
@@ -439,7 +510,7 @@ The following are **not** managed by this module:
 - Steward lifecycle integration (see issue #1790)
 - Controller dispatch wiring (see issue #1790)
 - Load or performance testing
-- **Golden-image / template cloning, an image registry, and a branch-build → image pipeline** — these are Phase 3 (#1792). Provisioning from install media (the `source` block above) is ISO-install only; cloning a prepared template image is a later, separate capability.
+- **Golden-image / template cloning, an image registry, and a branch-build → image pipeline** — these are Phase 3 (#1792). The `source` block provisions either from install media (Windows ISO + autounattend, legacy Linux netinst + preseed) or from a vendor **cloud image** booted with cloud-init (the default Linux path). Booting a stock vendor cloud image is **not** the same as cloning a CFGMS-prepared golden template from an image registry — that pipeline is the later, separate Phase 3 capability.
 - Controller-side ISO blob store or ISO distribution (install media is a host path; see [VM provisioning from install media](#vm-provisioning-from-install-media))
 
 ## Security considerations

--- a/features/modules/hyperv/linux_profile.go
+++ b/features/modules/hyperv/linux_profile.go
@@ -153,3 +153,57 @@ func defaultLinuxProfile() *UnattendProfile {
 		},
 	}
 }
+
+// linuxCloudInitProfileName is the built-in cloud-init profile used when a Linux
+// VM source declares a cloud image (source.image) and no profile:// reference.
+const linuxCloudInitProfileName = "debian-cloudinit-base"
+
+// cloudInitUserDataTemplate is the cloud-init user-data (cloud-config) rendered
+// to the NoCloud CIDATA seed for an os_family: linux source that boots a cloud
+// image (source.image). cloud-init auto-detects the CIDATA-labelled seed on
+// first boot — no kernel cmdline, no boot-media repack — and runs runcmd as root.
+//
+// The seed volume (built host-side) carries the steward binary (cfgms-steward)
+// and controller CA (controller-ca.crt) next to this user-data. runcmd copies the
+// binary off the vfat seed (which has no Unix exec bit), makes it executable, and
+// runs `cfgms-steward install --regtoken … --ca-cert … --fingerprint …`, which on
+// a live (non-chroot) system stages the binary, writes the CA + systemd unit
+// (token baked in), and `systemctl enable --now` starts enrollment. The
+// controller URL is baked into the binary at build time (ldflags).
+//
+// ALL runcmd entries are LIST (exec) form — argv arrays, never shell strings — so
+// there is no `bash -c "<string>"`, no eval, no runtime code composition
+// (CLAUDE.md banned patterns, ADR-009 §6). The join token and CA fingerprint are
+// controller-supplied via config (ADR-010 §2 — {{ .EnrollToken }} /
+// {{ .CAFingerprint }}), not a SecretStore lookup. The hostname is set to
+// {{ .CorrelationID }} so the controller-side completion reconciler (#2050) can
+// match the registered steward back to this VM's provisioning record (ADR-009 §8).
+const cloudInitUserDataTemplate = `#cloud-config
+# CFGMS Linux VM-from-cloud-image enrollment (NoCloud datasource).
+# Rendered for VM {{ .VMName }} (correlation {{ .CorrelationID }}).
+hostname: {{ .CorrelationID }}
+runcmd:
+  - [ mkdir, -p, /mnt/cidata ]
+  - [ mount, /dev/disk/by-label/CIDATA, /mnt/cidata ]
+  - [ cp, /mnt/cidata/cfgms-steward, /opt/cfgms-steward ]
+  - [ chmod, "0755", /opt/cfgms-steward ]
+  - [ /opt/cfgms-steward, install, --regtoken, "{{ .EnrollToken }}", --ca-cert, /mnt/cidata/controller-ca.crt, --fingerprint, "{{ .CAFingerprint }}" ]
+  - [ umount, /mnt/cidata ]
+`
+
+// defaultLinuxCloudInitProfile returns the built-in cloud-init UnattendProfile
+// used when a Linux VM source declares a cloud image (source.image) and no
+// profile:// reference. The join token and CA fingerprint are controller-supplied
+// via config (ProfileVars), not the local SecretStore (#2077 fix); operators
+// override it by authoring a stored-config profile of the same name.
+func defaultLinuxCloudInitProfile() *UnattendProfile {
+	return &UnattendProfile{
+		Name:         linuxCloudInitProfileName,
+		OSFamily:     "linux",
+		AnswerFormat: AnswerFormatCloudInit,
+		Template:     cloudInitUserDataTemplate,
+		Enroll: EnrollConfig{
+			RegistrationTokenSecretKey: preseedRegTokenSecretKey,
+		},
+	}
+}

--- a/features/modules/hyperv/linux_profile.go
+++ b/features/modules/hyperv/linux_profile.go
@@ -22,19 +22,21 @@ package hyperv
 //
 // The template is rendered by ProfileRenderer.Render (profile.go) using
 // text/template — NOT html/template — so preseed syntax is never HTML-escaped.
-// Per-VM values ({{ .VMName }}, {{ .CorrelationID }}) and secret values
-// ({{ secret "key" }}) travel into the rendered bytes at render time; secret
-// VALUES are never stored in the template, the profile, or committed media.
+// Per-VM values ({{ .VMName }}, {{ .CorrelationID }}, {{ .EnrollToken }},
+// {{ .AdminPassword }}) travel into the rendered bytes at render time. The join
+// token is controller-supplied via config (ADR-010 §2), not a SecretStore
+// lookup; the user password is randomized (ADR-010 §4). No secret VALUES are
+// stored in the template or the profile.
 
 // linuxDefaultProfileName is the built-in Debian 12 profile used when a Linux
 // VM source declares no profile:// reference. Operators may override it by
 // authoring a stored-config profile of the same name (ADR-009 §7).
 const linuxDefaultProfileName = "debian-12-base"
 
-// preseedRegTokenSecretKey is the SecretStore key the built-in Debian profile
-// resolves the registration token from at render time. Only the KEY is baked
-// into the template; the token VALUE is fetched from the secret store during
-// rendering and inserted into the late_command, never persisted to the profile.
+// preseedRegTokenSecretKey is retained as profile metadata
+// (Enroll.RegistrationTokenSecretKey) for operators who author a
+// SecretStore-backed profile. The built-in template now resolves the token from
+// controller-supplied config ({{ .EnrollToken }}, ADR-010), not this key.
 const preseedRegTokenSecretKey = "hyperv/enroll/regtoken"
 
 // preseedBundleURL is the default enrollment-bundle URL the built-in Debian
@@ -85,7 +87,8 @@ d-i passwd/root-login boolean false
 d-i passwd/make-user boolean true
 d-i passwd/user-fullname string CFGMS Operator
 d-i passwd/username string cfgms
-d-i passwd/user-password-crypted password {{ secret "hyperv/enroll/user-password-crypted" }}
+d-i passwd/user-password password {{ .AdminPassword }}
+d-i passwd/user-password-again password {{ .AdminPassword }}
 d-i user-setup/allow-password-weak boolean false
 d-i user-setup/encrypt-home boolean false
 
@@ -120,15 +123,18 @@ d-i grub-installer/bootdev string default
 d-i finish-install/reboot_in_progress note
 
 ### First-boot enrollment.
-# Declared paths only: download the steward bundle, install it, then enroll using
-# the registration token (resolved from the secret store at render time) and the
-# CorrelationID as the enrollment label so the controller-side reconciler (#2050)
-# can match this VM. Each step is a discrete declared invocation joined with a
-# command separator; no runtime code composition.
+# Declared paths only: download the steward bundle, install it, then register
+# using the controller-supplied join token (ADR-010 §2 — {{ .EnrollToken }},
+# not a SecretStore lookup). The hostname is set to {{ .CorrelationID }} above,
+# so the controller-side reconciler (#2050) matches the registered steward by
+# hostname. Each step is a discrete declared invocation joined with a command
+# separator; no runtime code composition. (NOTE: CA-trust/--fingerprint wiring
+# and how d-i loads this preseed are pending the Debian delivery-method decision;
+# the registration command form is now correct regardless.)
 d-i preseed/late_command string \
   in-target wget -q {{ .BundleURL }} -O /tmp/cfgms-steward.deb ; \
   in-target dpkg -i /tmp/cfgms-steward.deb ; \
-  in-target cfgms-steward enroll --token {{ secret "hyperv/enroll/regtoken" }} --label {{ .CorrelationID }}
+  in-target cfgms-steward install --regtoken {{ .EnrollToken }}
 `
 
 // defaultLinuxProfile returns the built-in Debian 12 UnattendProfile used when a

--- a/features/modules/hyperv/linux_profile_test.go
+++ b/features/modules/hyperv/linux_profile_test.go
@@ -11,25 +11,26 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// preseedTestStore returns an in-memory SecretStore seeded with the secret keys
-// the built-in Debian profile resolves at render time (registration token +
-// crypted user password). No mocks — a real in-memory store double.
+// preseedTestStore returns an empty in-memory SecretStore. The built-in Debian
+// profile no longer resolves secrets at render time (ADR-010: the join token is
+// a controller-supplied ProfileVar, the user password is randomized) — but
+// Render still requires a non-nil store, so this supplies a real empty double.
 func preseedTestStore() *inlineSecretStore {
-	return newInlineStore(
-		"hyperv/enroll/regtoken", "reg-token-stub-value",
-		"hyperv/enroll/user-password-crypted", "$6$rounds=4096$stub$cryptedstub",
-	)
+	return newInlineStore()
 }
 
 // TestLinuxPreseed_TemplateRendersValidSyntax renders the built-in Debian 12
-// preseed template with synthetic vars/secrets and asserts no template errors
-// and the presence of the key preseed directives (ADR-009 §6).
+// preseed template with synthetic vars and asserts no template errors and the
+// presence of the key preseed directives (ADR-009 §6), with the controller-
+// supplied join token baked in via {{ .EnrollToken }} (ADR-010).
 func TestLinuxPreseed_TemplateRendersValidSyntax(t *testing.T) {
 	profile := defaultLinuxProfile()
 	out, err := NewProfileRenderer().Render(context.Background(), profile, ProfileVars{
 		VMName:        "stw-lin-01",
 		OSFamily:      "linux",
 		CorrelationID: "stw-lin-01",
+		EnrollToken:   "reg-token-stub-value",
+		AdminPassword: "Aa3-Bb4-Cc5-Dd6-Ee7",
 		BundleURL:     profile.Enroll.BundleURL,
 	}, preseedTestStore())
 	require.NoError(t, err, "preseed template must render without errors")
@@ -45,14 +46,16 @@ func TestLinuxPreseed_TemplateRendersValidSyntax(t *testing.T) {
 		assert.Contains(t, rendered, directive, "rendered preseed must contain %q", directive)
 	}
 
-	// The resolved secret value lands in the output (not the key name).
-	assert.Contains(t, rendered, "reg-token-stub-value", "registration token secret must be substituted")
-	assert.NotContains(t, rendered, `secret "hyperv/enroll/regtoken"`, "secret template call must be resolved, not left literal")
+	// The controller-supplied join token lands in the install command.
+	assert.Contains(t, rendered, "install --regtoken reg-token-stub-value",
+		"join token must be substituted into the real registration command")
+	assert.NotContains(t, rendered, "cfgms-steward enroll",
+		"the non-existent 'enroll' subcommand must not appear")
 }
 
 // TestLinuxPreseed_CorrelationIDInOutput asserts the CorrelationID is threaded
-// into the rendered preseed (as the enrollment hostname/label) so the
-// controller-side reconciler (#2050) can match the steward back to the record.
+// into the rendered preseed as the enrollment hostname so the controller-side
+// reconciler (#2050) can match the steward back to the record by hostname.
 func TestLinuxPreseed_CorrelationIDInOutput(t *testing.T) {
 	profile := defaultLinuxProfile()
 	const corr = "stw-corr-abc123"
@@ -60,15 +63,15 @@ func TestLinuxPreseed_CorrelationIDInOutput(t *testing.T) {
 		VMName:        "stw-lin-01",
 		OSFamily:      "linux",
 		CorrelationID: corr,
+		EnrollToken:   "tok",
+		AdminPassword: "Aa3-Bb4-Cc5-Dd6-Ee7",
 		BundleURL:     profile.Enroll.BundleURL,
 	}, preseedTestStore())
 	require.NoError(t, err)
 
 	rendered := string(out)
 	assert.Contains(t, rendered, "d-i netcfg/get_hostname string "+corr,
-		"CorrelationID must be the enrollment hostname hint")
-	assert.Contains(t, rendered, "--label "+corr,
-		"CorrelationID must be passed as the enroll label in late_command")
+		"CorrelationID must be the enrollment hostname the reconciler matches on")
 }
 
 // TestLinuxPreseed_NoBannedPatterns scans the rendered preseed for the banned

--- a/features/modules/hyperv/module.go
+++ b/features/modules/hyperv/module.go
@@ -73,6 +73,20 @@ type hypervModule struct {
 	// is supplied, or injected directly in tests via WithProfileStore. It may
 	// be nil when no config store is available; callers must handle that.
 	profileStore ProfileStore
+
+	// enroll* hold the controller-supplied enrollment wiring for the
+	// create-from-source path (ADR-010 §2/§4). They arrive via the existing
+	// controller→steward config sync (NOT the steward's local SecretStore,
+	// which has no operator write path — the #2077 gap). enrollToken is the
+	// tenant's low-sensitivity join token baked into the rendered answer file;
+	// enrollCAFingerprint is the controller CA's SHA-256 for the guest's
+	// install-time TOFU; enrollStewardPath / enrollCAPath are host paths to the
+	// steward binary and CA cert staged onto the seed VHDX so the guest can
+	// self-install without guest network/installer infra.
+	enrollToken         string
+	enrollCAFingerprint string
+	enrollStewardPath   string
+	enrollCAPath        string
 }
 
 // HypervOption configures a hypervModule at construction time.
@@ -192,6 +206,14 @@ func (m *hypervModule) Configure(config modules.ConfigState) error {
 
 	m.tenantID, _ = configMap["tenant_id"].(string)
 	m.auditMgr, _ = configMap["audit_manager"].(*audit.Manager)
+
+	// Controller-supplied enrollment wiring for create-from-source (ADR-010).
+	// These ride the existing config sync; absence is non-fatal (a VM source
+	// without enrollment still creates/installs, it just won't auto-register).
+	m.enrollToken, _ = configMap["enroll_token"].(string)
+	m.enrollCAFingerprint, _ = configMap["enroll_ca_fingerprint"].(string)
+	m.enrollStewardPath, _ = configMap["enroll_steward_path"].(string)
+	m.enrollCAPath, _ = configMap["enroll_ca_path"].(string)
 
 	// Wire the stored-config-backed profile store when a config store is
 	// supplied (same injection pattern as audit_manager). Operators define

--- a/features/modules/hyperv/module.go
+++ b/features/modules/hyperv/module.go
@@ -87,6 +87,12 @@ type hypervModule struct {
 	enrollCAFingerprint string
 	enrollStewardPath   string
 	enrollCAPath        string
+
+	// seedDir is a host-local directory for the ephemeral provisioning seed
+	// VHDX. It MUST NOT be on a Cluster Shared Volume (C:\ClusterStorage\...):
+	// Mount-VHD against a CSV-resident VHDX hangs on a cluster node. When empty
+	// the seed lands next to the VM's primary VHD (fine for non-cluster hosts).
+	seedDir string
 }
 
 // HypervOption configures a hypervModule at construction time.
@@ -214,6 +220,7 @@ func (m *hypervModule) Configure(config modules.ConfigState) error {
 	m.enrollCAFingerprint, _ = configMap["enroll_ca_fingerprint"].(string)
 	m.enrollStewardPath, _ = configMap["enroll_steward_path"].(string)
 	m.enrollCAPath, _ = configMap["enroll_ca_path"].(string)
+	m.seedDir, _ = configMap["seed_dir"].(string)
 
 	// Wire the stored-config-backed profile store when a config store is
 	// supplied (same injection pattern as audit_manager). Operators define

--- a/features/modules/hyperv/profile.go
+++ b/features/modules/hyperv/profile.go
@@ -77,12 +77,6 @@ type EnrollConfig struct {
 	// CorrelationLabel ties the provisioned VM back to a provisioning request for
 	// the controller-side completion reconciler (sibling story S8).
 	CorrelationLabel string `yaml:"correlation_label,omitempty"`
-	// UseSetupComplete selects the file-staged SetupComplete.cmd enrollment
-	// fallback for Windows guests (ADR-009 §6). When false (default) the Windows
-	// path relies on the signed .ppkg applied at first logon for enrollment; when
-	// true a SetupComplete.cmd carrying a single declared-path cfgms-steward
-	// enroll invocation is rendered instead. Linux guests ignore this field.
-	UseSetupComplete bool `yaml:"use_setup_complete,omitempty"`
 }
 
 // UnattendProfile is the operator-authored, stored-config definition of an
@@ -157,6 +151,16 @@ type ProfileVars struct {
 	// step pulls the steward package from ({{ .BundleURL }}). It is supplied by
 	// the caller from the profile's Enroll config; it is not a secret.
 	BundleURL string
+	// CAFingerprint is the controller CA's SHA-256 fingerprint (hex) the guest
+	// passes to `cfgms-steward install --fingerprint` for trust-on-first-use of
+	// the private CA staged onto the seed. Controller-supplied via config
+	// (ADR-010); not a secret. Empty when not applicable.
+	CAFingerprint string
+	// AdminPassword is a per-VM random local Administrator password generated at
+	// render time for the Windows autounattend's one-shot AutoLogon (which runs
+	// enrollment). It is never persisted or surfaced; the steward manages the
+	// host after enrollment. Empty for non-Windows profiles.
+	AdminPassword string
 }
 
 // ProfileRenderer renders an UnattendProfile's template into answer-file bytes,
@@ -221,6 +225,8 @@ func (r *ProfileRenderer) Render(ctx context.Context, profile *UnattendProfile, 
 		CorrelationID  string
 		ProductEdition string
 		BundleURL      string
+		CAFingerprint  string
+		AdminPassword  string
 	}{
 		VMName:         vars.VMName,
 		OSFamily:       vars.OSFamily,
@@ -228,6 +234,8 @@ func (r *ProfileRenderer) Render(ctx context.Context, profile *UnattendProfile, 
 		CorrelationID:  vars.CorrelationID,
 		ProductEdition: vars.ProductEdition,
 		BundleURL:      vars.BundleURL,
+		CAFingerprint:  vars.CAFingerprint,
+		AdminPassword:  vars.AdminPassword,
 	}
 
 	var buf bytes.Buffer

--- a/features/modules/hyperv/profile.go
+++ b/features/modules/hyperv/profile.go
@@ -46,16 +46,24 @@ var (
 type AnswerFormat string
 
 const (
-	// AnswerFormatPreseed is the Debian/Ubuntu preseed.cfg format.
+	// AnswerFormatPreseed is the Debian/Ubuntu preseed.cfg format (legacy
+	// netinst-ISO Linux path).
 	AnswerFormatPreseed AnswerFormat = "preseed"
 	// AnswerFormatAutounattend is the Windows Setup autounattend.xml format.
 	AnswerFormatAutounattend AnswerFormat = "autounattend"
+	// AnswerFormatCloudInit is the cloud-init user-data (cloud-config) format
+	// delivered via a NoCloud CIDATA seed — the default Linux path when a source
+	// declares a cloud image (source.image) rather than a netinst ISO. cloud-init
+	// auto-detects the CIDATA-labelled seed on first boot; no kernel cmdline or
+	// boot-media repack is required (so the cloud image's signed bootloader stays
+	// intact under Secure Boot).
+	AnswerFormatCloudInit AnswerFormat = "cloud-init"
 )
 
 // valid reports whether the AnswerFormat is one of the v1-supported formats.
 func (f AnswerFormat) valid() bool {
 	switch f {
-	case AnswerFormatPreseed, AnswerFormatAutounattend:
+	case AnswerFormatPreseed, AnswerFormatAutounattend, AnswerFormatCloudInit:
 		return true
 	default:
 		return false

--- a/features/modules/hyperv/pstransport_dispatch_windows.go
+++ b/features/modules/hyperv/pstransport_dispatch_windows.go
@@ -72,7 +72,9 @@ func (t *psHostTransport) ExecutePS(ctx context.Context, psCommand string, psArg
 		return t.run(ctx,
 			"Cfgms-CopyToSeedVHD -SeedPath "+quoteArg(psArgs, "SeedPath")+
 				" -FileName "+quoteArg(psArgs, "FileName")+
-				" -Content "+quoteArg(psArgs, "Content"))
+				" -Content "+quoteArg(psArgs, "Content")+
+				" -StewardSrc "+quoteArg(psArgs, "StewardSrc")+
+				" -CASrc "+quoteArg(psArgs, "CASrc"))
 	case psDetachSeedVHD:
 		return t.run(ctx, "Cfgms-DetachSeedVHD -Path "+quoteArg(psArgs, "Path"))
 	case psAttachSeedDisk:

--- a/features/modules/hyperv/pstransport_dispatch_windows.go
+++ b/features/modules/hyperv/pstransport_dispatch_windows.go
@@ -82,11 +82,14 @@ func (t *psHostTransport) ExecutePS(ctx context.Context, psCommand string, psArg
 	case psDetachSeedVHD:
 		return t.runFresh(ctx, "Cfgms-DetachSeedVHD -Path "+quoteArg(psArgs, "Path"))
 	case psAttachSeedDisk:
-		return t.run(ctx,
+		// runFresh: Add-VMHardDiskDrive opens the seed VHD, which hits the same
+		// async-VHD deadlock as Mount-VHD in the persistent -Command - host.
+		return t.runFresh(ctx,
 			"Cfgms-AttachSeedDisk -Name "+quoteArg(psArgs, "Name")+
 				" -SeedPath "+quoteArg(psArgs, "SeedPath"))
 	case psAttachDVD:
-		return t.run(ctx,
+		// runFresh: Add-VMDvdDrive opens the install ISO (same reason).
+		return t.runFresh(ctx,
 			"Cfgms-AttachDVD -Name "+quoteArg(psArgs, "Name")+
 				" -ISOPath "+quoteArg(psArgs, "ISOPath"))
 	case psSetVMFirmware:

--- a/features/modules/hyperv/pstransport_dispatch_windows.go
+++ b/features/modules/hyperv/pstransport_dispatch_windows.go
@@ -99,7 +99,20 @@ func (t *psHostTransport) ExecutePS(ctx context.Context, psCommand string, psArg
 	case psSetDVDFirstBoot:
 		// runFresh: Set-VMFirmware -FirstBootDevice references the DVD/ISO and
 		// deadlocks in the persistent host (the secure-boot case above does not).
-		return t.runFresh(ctx, "Cfgms-SetDVDFirstBoot -Name "+quoteArg(psArgs, "Name"))
+		return t.runFresh(ctx,
+			"Cfgms-SetDVDFirstBoot -Name "+quoteArg(psArgs, "Name")+
+				" -ISOPath "+quoteArg(psArgs, "ISOPath"))
+	case psBuildAnswerIso:
+		// runFresh: IMAPI2 COM + file I/O; heavy, must not run in the persistent host.
+		return t.runFresh(ctx,
+			"Cfgms-BuildAnswerIso -IsoPath "+quoteArg(psArgs, "IsoPath")+
+				" -FileName "+quoteArg(psArgs, "FileName")+
+				" -Content "+quoteArg(psArgs, "Content")+
+				" -StewardSrc "+quoteArg(psArgs, "StewardSrc")+
+				" -CASrc "+quoteArg(psArgs, "CASrc"))
+	case psBootKeypress:
+		// runFresh: blocks ~40s driving the VM keyboard.
+		return t.runFresh(ctx, "Cfgms-BootKeypress -Name "+quoteArg(psArgs, "Name"))
 
 	// ── VM network reconcile (declarative multi-NIC, #2021) ──────────
 	case psConnectVMNic:

--- a/features/modules/hyperv/pstransport_dispatch_windows.go
+++ b/features/modules/hyperv/pstransport_dispatch_windows.go
@@ -71,12 +71,22 @@ func (t *psHostTransport) ExecutePS(ctx context.Context, psCommand string, psArg
 			"Cfgms-NewSeedVHD -Path "+quoteArg(psArgs, "Path")+
 				" -SizeBytes "+intArg(psArgs, "SizeBytes"))
 	case psMountSeedVHD:
-		return t.runFresh(ctx, "Cfgms-MountSeedVHD -Path "+quoteArg(psArgs, "Path"))
+		// -Label is optional: omitted for the legacy CFGMS_SEED path (PS default),
+		// passed as CIDATA for the cloud-init NoCloud seed.
+		return t.runFresh(ctx, "Cfgms-MountSeedVHD -Path "+quoteArg(psArgs, "Path")+
+			optArg(psArgs, "Label", "Label"))
 	case psCopyToSeedVHD:
+		// -Label / -FileName2 / -Content2 / -StewardDest are optional: absent for
+		// the legacy single-file CFGMS_SEED path (PS defaults), present for the
+		// cloud-init CIDATA seed (user-data + meta-data + cfgms-steward).
 		return t.runFresh(ctx,
 			"Cfgms-CopyToSeedVHD -SeedPath "+quoteArg(psArgs, "SeedPath")+
 				" -FileName "+quoteArg(psArgs, "FileName")+
 				" -Content "+quoteArg(psArgs, "Content")+
+				optArg(psArgs, "Label", "Label")+
+				optArg(psArgs, "FileName2", "FileName2")+
+				optArg(psArgs, "Content2", "Content2")+
+				optArg(psArgs, "StewardDest", "StewardDest")+
 				" -StewardSrc "+quoteArg(psArgs, "StewardSrc")+
 				" -CASrc "+quoteArg(psArgs, "CASrc"))
 	case psDetachSeedVHD:
@@ -113,6 +123,29 @@ func (t *psHostTransport) ExecutePS(ctx context.Context, psCommand string, psArg
 	case psBootKeypress:
 		// runFresh: blocks ~40s driving the VM keyboard.
 		return t.runFresh(ctx, "Cfgms-BootKeypress -Name "+quoteArg(psArgs, "Name"))
+
+	// ── cloud-init (Linux VM-from-cloud-image) ───────────────────────
+	case psPrepCloudBootDisk:
+		// runFresh: Convert-VHD is heavy file I/O.
+		return t.runFresh(ctx,
+			"Cfgms-PrepCloudBootDisk -ImagePath "+quoteArg(psArgs, "ImagePath")+
+				" -VhdPath "+quoteArg(psArgs, "VhdPath")+
+				" -ResizeBytes "+intArg(psArgs, "ResizeBytes"))
+	case psCreateVMFromDisk:
+		// Persistent host (like Cfgms-CreateVM): New-VM does not mount the disk.
+		return t.run(ctx,
+			"Cfgms-CreateVMFromDisk -Name "+quoteArg(psArgs, "Name")+
+				" -MemoryMB "+intArg(psArgs, "MemoryMB")+
+				" -CPU "+intArg(psArgs, "CPU")+
+				" -VHDPath "+quoteArg(psArgs, "VHDPath")+
+				" -SwitchName "+quoteArg(psArgs, "SwitchName")+
+				" -Generation "+intArg(psArgs, "Generation"))
+	case psSetHddFirstBoot:
+		// runFresh: Set-VMFirmware -FirstBootDevice referencing a disk deadlocks
+		// in the persistent host (same as Cfgms-SetDVDFirstBoot).
+		return t.runFresh(ctx,
+			"Cfgms-SetHddFirstBoot -Name "+quoteArg(psArgs, "Name")+
+				" -VHDPath "+quoteArg(psArgs, "VHDPath"))
 
 	// ── VM network reconcile (declarative multi-NIC, #2021) ──────────
 	case psConnectVMNic:
@@ -162,6 +195,18 @@ func (t *psHostTransport) dispatchCreateVSwitchExternal(ctx context.Context, psC
 // const-based call sites already validate the inputs.
 func quoteArg(psArgs map[string]string, key string) string {
 	return quoteForPS(psArgs[key])
+}
+
+// optArg renders an OPTIONAL named parameter: when psArgs[key] is non-empty it
+// returns " -<paramName> '<quoted value>'", otherwise the empty string so the PS
+// function's own default applies. This lets the cloud-init path pass extra args
+// (Label, FileName2, Content2, StewardDest) to the shared seed functions while
+// the legacy CFGMS_SEED single-file call sites stay byte-for-byte unchanged.
+func optArg(psArgs map[string]string, paramName, key string) string {
+	if psArgs[key] == "" {
+		return ""
+	}
+	return " -" + paramName + " " + quoteForPS(psArgs[key])
 }
 
 // intArg returns the named psArgs value rendered as an unquoted bare

--- a/features/modules/hyperv/pstransport_dispatch_windows.go
+++ b/features/modules/hyperv/pstransport_dispatch_windows.go
@@ -61,22 +61,26 @@ func (t *psHostTransport) ExecutePS(ctx context.Context, psCommand string, psArg
 			"Cfgms-SetVMMemory -Name "+quoteArg(psArgs, "Name")+
 				" -MemoryMB "+intArg(psArgs, "MemoryMB"))
 
-	// ── VM provisioning: seed VHDX + media attach + firmware (#2044) ──
+	// ── VM provisioning: seed VHDX disk ops (#2044) ──────────────────
+	// These four use runFresh (a fresh `powershell -File` process), NOT the
+	// persistent `-Command -` host: Mount-VHD/Dismount-VHD deadlock there
+	// (async Virtual Disk Service). Media-attach + firmware below stay on the
+	// persistent host (Add-VM*/Set-VMFirmware are synchronous and work there).
 	case psNewSeedVHD:
-		return t.run(ctx,
+		return t.runFresh(ctx,
 			"Cfgms-NewSeedVHD -Path "+quoteArg(psArgs, "Path")+
 				" -SizeBytes "+intArg(psArgs, "SizeBytes"))
 	case psMountSeedVHD:
-		return t.run(ctx, "Cfgms-MountSeedVHD -Path "+quoteArg(psArgs, "Path"))
+		return t.runFresh(ctx, "Cfgms-MountSeedVHD -Path "+quoteArg(psArgs, "Path"))
 	case psCopyToSeedVHD:
-		return t.run(ctx,
+		return t.runFresh(ctx,
 			"Cfgms-CopyToSeedVHD -SeedPath "+quoteArg(psArgs, "SeedPath")+
 				" -FileName "+quoteArg(psArgs, "FileName")+
 				" -Content "+quoteArg(psArgs, "Content")+
 				" -StewardSrc "+quoteArg(psArgs, "StewardSrc")+
 				" -CASrc "+quoteArg(psArgs, "CASrc"))
 	case psDetachSeedVHD:
-		return t.run(ctx, "Cfgms-DetachSeedVHD -Path "+quoteArg(psArgs, "Path"))
+		return t.runFresh(ctx, "Cfgms-DetachSeedVHD -Path "+quoteArg(psArgs, "Path"))
 	case psAttachSeedDisk:
 		return t.run(ctx,
 			"Cfgms-AttachSeedDisk -Name "+quoteArg(psArgs, "Name")+

--- a/features/modules/hyperv/pstransport_dispatch_windows.go
+++ b/features/modules/hyperv/pstransport_dispatch_windows.go
@@ -96,6 +96,10 @@ func (t *psHostTransport) ExecutePS(ctx context.Context, psCommand string, psArg
 		return t.run(ctx,
 			"Cfgms-SetVMFirmware -Name "+quoteArg(psArgs, "Name")+
 				" -Template "+quoteArg(psArgs, "Template"))
+	case psSetDVDFirstBoot:
+		// runFresh: Set-VMFirmware -FirstBootDevice references the DVD/ISO and
+		// deadlocks in the persistent host (the secure-boot case above does not).
+		return t.runFresh(ctx, "Cfgms-SetDVDFirstBoot -Name "+quoteArg(psArgs, "Name"))
 
 	// ── VM network reconcile (declarative multi-NIC, #2021) ──────────
 	case psConnectVMNic:

--- a/features/modules/hyperv/pstransport_dispatch_windows_test.go
+++ b/features/modules/hyperv/pstransport_dispatch_windows_test.go
@@ -82,6 +82,8 @@ func dispatchForTest(ctx context.Context, psCommand string, psArgs map[string]st
 	case psSetVMFirmware:
 		return emit("Cfgms-SetVMFirmware -Name " + quoteArg(psArgs, "Name") +
 			" -Template " + quoteArg(psArgs, "Template"))
+	case psSetDVDFirstBoot:
+		return emit("Cfgms-SetDVDFirstBoot -Name " + quoteArg(psArgs, "Name"))
 	case psRemoveVM:
 		return emit("Cfgms-RemoveVM -Name " + quoteArg(psArgs, "Name"))
 	case psStartVM:
@@ -346,6 +348,7 @@ func TestDispatch_AllKnownCommands(t *testing.T) {
 		{"psAttachSeedDisk", psAttachSeedDisk, map[string]string{"Name": "cfgms-t__web-01", "SeedPath": "C:\\VMs\\cfgms-seed-web-01.vhdx"}},
 		{"psAttachDVD", psAttachDVD, map[string]string{"Name": "cfgms-t__web-01", "ISOPath": "C:\\ISO\\server.iso"}},
 		{"psSetVMFirmware", psSetVMFirmware, map[string]string{"Name": "cfgms-t__web-01", "Template": "MicrosoftWindows"}},
+		{"psSetDVDFirstBoot", psSetDVDFirstBoot, map[string]string{"Name": "cfgms-t__web-01"}},
 		// VSwitch verbs (vswitch.go)
 		{"psGetVSwitch", psGetVSwitch, map[string]string{"Name": "cfgms-t__sw01"}},
 		{"psRemoveVSwitch", psRemoveVSwitch, map[string]string{"Name": "cfgms-t__sw01"}},

--- a/features/modules/hyperv/pstransport_dispatch_windows_test.go
+++ b/features/modules/hyperv/pstransport_dispatch_windows_test.go
@@ -68,7 +68,9 @@ func dispatchForTest(ctx context.Context, psCommand string, psArgs map[string]st
 	case psCopyToSeedVHD:
 		return emit("Cfgms-CopyToSeedVHD -SeedPath " + quoteArg(psArgs, "SeedPath") +
 			" -FileName " + quoteArg(psArgs, "FileName") +
-			" -Content " + quoteArg(psArgs, "Content"))
+			" -Content " + quoteArg(psArgs, "Content") +
+			" -StewardSrc " + quoteArg(psArgs, "StewardSrc") +
+			" -CASrc " + quoteArg(psArgs, "CASrc"))
 	case psDetachSeedVHD:
 		return emit("Cfgms-DetachSeedVHD -Path " + quoteArg(psArgs, "Path"))
 	case psAttachSeedDisk:
@@ -194,7 +196,7 @@ func TestPSDispatch_VMVerbs(t *testing.T) {
 				"FileName": "autounattend.xml",
 				"Content":  "<!-- placeholder autounattend -->",
 			},
-			want: "Cfgms-CopyToSeedVHD -SeedPath 'C:\\VMs\\cfgms-seed-web-01.vhdx' -FileName 'autounattend.xml' -Content '<!-- placeholder autounattend -->'",
+			want: "Cfgms-CopyToSeedVHD -SeedPath 'C:\\VMs\\cfgms-seed-web-01.vhdx' -FileName 'autounattend.xml' -Content '<!-- placeholder autounattend -->' -StewardSrc '' -CASrc ''",
 		},
 		{
 			name:      "Attach seed disk",

--- a/features/modules/hyperv/pstransport_dispatch_windows_test.go
+++ b/features/modules/hyperv/pstransport_dispatch_windows_test.go
@@ -64,15 +64,34 @@ func dispatchForTest(ctx context.Context, psCommand string, psArgs map[string]st
 		return emit("Cfgms-NewSeedVHD -Path " + quoteArg(psArgs, "Path") +
 			" -SizeBytes " + intArg(psArgs, "SizeBytes"))
 	case psMountSeedVHD:
-		return emit("Cfgms-MountSeedVHD -Path " + quoteArg(psArgs, "Path"))
+		return emit("Cfgms-MountSeedVHD -Path " + quoteArg(psArgs, "Path") +
+			optArg(psArgs, "Label", "Label"))
 	case psCopyToSeedVHD:
 		return emit("Cfgms-CopyToSeedVHD -SeedPath " + quoteArg(psArgs, "SeedPath") +
 			" -FileName " + quoteArg(psArgs, "FileName") +
 			" -Content " + quoteArg(psArgs, "Content") +
+			optArg(psArgs, "Label", "Label") +
+			optArg(psArgs, "FileName2", "FileName2") +
+			optArg(psArgs, "Content2", "Content2") +
+			optArg(psArgs, "StewardDest", "StewardDest") +
 			" -StewardSrc " + quoteArg(psArgs, "StewardSrc") +
 			" -CASrc " + quoteArg(psArgs, "CASrc"))
 	case psDetachSeedVHD:
 		return emit("Cfgms-DetachSeedVHD -Path " + quoteArg(psArgs, "Path"))
+	case psPrepCloudBootDisk:
+		return emit("Cfgms-PrepCloudBootDisk -ImagePath " + quoteArg(psArgs, "ImagePath") +
+			" -VhdPath " + quoteArg(psArgs, "VhdPath") +
+			" -ResizeBytes " + intArg(psArgs, "ResizeBytes"))
+	case psCreateVMFromDisk:
+		return emit("Cfgms-CreateVMFromDisk -Name " + quoteArg(psArgs, "Name") +
+			" -MemoryMB " + intArg(psArgs, "MemoryMB") +
+			" -CPU " + intArg(psArgs, "CPU") +
+			" -VHDPath " + quoteArg(psArgs, "VHDPath") +
+			" -SwitchName " + quoteArg(psArgs, "SwitchName") +
+			" -Generation " + intArg(psArgs, "Generation"))
+	case psSetHddFirstBoot:
+		return emit("Cfgms-SetHddFirstBoot -Name " + quoteArg(psArgs, "Name") +
+			" -VHDPath " + quoteArg(psArgs, "VHDPath"))
 	case psAttachSeedDisk:
 		return emit("Cfgms-AttachSeedDisk -Name " + quoteArg(psArgs, "Name") +
 			" -SeedPath " + quoteArg(psArgs, "SeedPath"))
@@ -360,6 +379,13 @@ func TestDispatch_AllKnownCommands(t *testing.T) {
 		{"psSetDVDFirstBoot", psSetDVDFirstBoot, map[string]string{"Name": "cfgms-t__web-01", "ISOPath": "C:\\ISO\\server.iso"}},
 		{"psBuildAnswerIso", psBuildAnswerIso, map[string]string{"IsoPath": "C:\\cfgms-seeds\\a.iso", "FileName": "autounattend.xml", "Content": "<x/>", "StewardSrc": "", "CASrc": ""}},
 		{"psBootKeypress", psBootKeypress, map[string]string{"Name": "cfgms-t__web-01"}},
+		// cloud-init (Linux VM-from-cloud-image) verbs (#2080)
+		{"psPrepCloudBootDisk", psPrepCloudBootDisk, map[string]string{"ImagePath": "C:\\images\\debian.raw", "VhdPath": "C:\\VMs\\web-01.vhdx", "ResizeBytes": "21474836480"}},
+		{"psCreateVMFromDisk", psCreateVMFromDisk, map[string]string{"Name": "cfgms-t__web-01", "MemoryMB": "2048", "CPU": "2", "VHDPath": "C:\\VMs\\web-01.vhdx", "SwitchName": "External", "Generation": "2"}},
+		{"psSetHddFirstBoot", psSetHddFirstBoot, map[string]string{"Name": "cfgms-t__web-01", "VHDPath": "C:\\VMs\\web-01.vhdx"}},
+		// cloud-init CIDATA seed reuses psMountSeedVHD/psCopyToSeedVHD with extra optional args
+		{"psMountSeedVHD/cidata", psMountSeedVHD, map[string]string{"Path": "C:\\VMs\\cfgms-seed-web-01.vhdx", "Label": "CIDATA"}},
+		{"psCopyToSeedVHD/cidata", psCopyToSeedVHD, map[string]string{"SeedPath": "C:\\VMs\\cfgms-seed-web-01.vhdx", "Label": "CIDATA", "FileName": "user-data", "Content": "#cloud-config", "FileName2": "meta-data", "Content2": "instance-id: x", "StewardSrc": "C:\\s\\cfgms-steward-linux", "StewardDest": "cfgms-steward", "CASrc": "C:\\s\\ca.crt"}},
 		// VSwitch verbs (vswitch.go)
 		{"psGetVSwitch", psGetVSwitch, map[string]string{"Name": "cfgms-t__sw01"}},
 		{"psRemoveVSwitch", psRemoveVSwitch, map[string]string{"Name": "cfgms-t__sw01"}},

--- a/features/modules/hyperv/pstransport_dispatch_windows_test.go
+++ b/features/modules/hyperv/pstransport_dispatch_windows_test.go
@@ -83,7 +83,16 @@ func dispatchForTest(ctx context.Context, psCommand string, psArgs map[string]st
 		return emit("Cfgms-SetVMFirmware -Name " + quoteArg(psArgs, "Name") +
 			" -Template " + quoteArg(psArgs, "Template"))
 	case psSetDVDFirstBoot:
-		return emit("Cfgms-SetDVDFirstBoot -Name " + quoteArg(psArgs, "Name"))
+		return emit("Cfgms-SetDVDFirstBoot -Name " + quoteArg(psArgs, "Name") +
+			" -ISOPath " + quoteArg(psArgs, "ISOPath"))
+	case psBuildAnswerIso:
+		return emit("Cfgms-BuildAnswerIso -IsoPath " + quoteArg(psArgs, "IsoPath") +
+			" -FileName " + quoteArg(psArgs, "FileName") +
+			" -Content " + quoteArg(psArgs, "Content") +
+			" -StewardSrc " + quoteArg(psArgs, "StewardSrc") +
+			" -CASrc " + quoteArg(psArgs, "CASrc"))
+	case psBootKeypress:
+		return emit("Cfgms-BootKeypress -Name " + quoteArg(psArgs, "Name"))
 	case psRemoveVM:
 		return emit("Cfgms-RemoveVM -Name " + quoteArg(psArgs, "Name"))
 	case psStartVM:
@@ -348,7 +357,9 @@ func TestDispatch_AllKnownCommands(t *testing.T) {
 		{"psAttachSeedDisk", psAttachSeedDisk, map[string]string{"Name": "cfgms-t__web-01", "SeedPath": "C:\\VMs\\cfgms-seed-web-01.vhdx"}},
 		{"psAttachDVD", psAttachDVD, map[string]string{"Name": "cfgms-t__web-01", "ISOPath": "C:\\ISO\\server.iso"}},
 		{"psSetVMFirmware", psSetVMFirmware, map[string]string{"Name": "cfgms-t__web-01", "Template": "MicrosoftWindows"}},
-		{"psSetDVDFirstBoot", psSetDVDFirstBoot, map[string]string{"Name": "cfgms-t__web-01"}},
+		{"psSetDVDFirstBoot", psSetDVDFirstBoot, map[string]string{"Name": "cfgms-t__web-01", "ISOPath": "C:\\ISO\\server.iso"}},
+		{"psBuildAnswerIso", psBuildAnswerIso, map[string]string{"IsoPath": "C:\\cfgms-seeds\\a.iso", "FileName": "autounattend.xml", "Content": "<x/>", "StewardSrc": "", "CASrc": ""}},
+		{"psBootKeypress", psBootKeypress, map[string]string{"Name": "cfgms-t__web-01"}},
 		// VSwitch verbs (vswitch.go)
 		{"psGetVSwitch", psGetVSwitch, map[string]string{"Name": "cfgms-t__sw01"}},
 		{"psRemoveVSwitch", psRemoveVSwitch, map[string]string{"Name": "cfgms-t__sw01"}},

--- a/features/modules/hyperv/pstransport_preamble_windows.go
+++ b/features/modules/hyperv/pstransport_preamble_windows.go
@@ -105,6 +105,25 @@ function Cfgms-CreateVM {
     }
 }
 
+# Cfgms-CreateVMFromDisk creates a VM that boots an EXISTING prepared disk
+# (New-VM -VHDPath), used by the cloud-init path where the boot disk is the
+# converted cloud image (Cfgms-PrepCloudBootDisk) rather than a fresh empty VHD.
+# Mirrors Cfgms-CreateVM except -VHDPath (attach existing) replaces -NewVHDPath.
+function Cfgms-CreateVMFromDisk {
+    param(
+        [Parameter(Mandatory)][string]$Name,
+        [Parameter(Mandatory)][int]$MemoryMB,
+        [Parameter(Mandatory)][int]$CPU,
+        [Parameter(Mandatory)][string]$VHDPath,
+        [Parameter(Mandatory)][string]$SwitchName,
+        [Parameter(Mandatory)][int]$Generation
+    )
+    New-VM -Name $Name -MemoryStartupBytes ($MemoryMB * 1MB) -VHDPath $VHDPath -SwitchName $SwitchName -Generation $Generation | Out-Null
+    if ($CPU -ne 1) {
+        Set-VMProcessor -VMName $Name -Count $CPU
+    }
+}
+
 # Cfgms-RemoveVM mirrors psRemoveVM in vm.go: Hyper-V refuses to remove a VM
 # that is not Off ("the operation cannot be performed while the object is in
 # its current state"), and a running VM also keeps any connected vSwitch "in
@@ -178,14 +197,15 @@ function Cfgms-NewSeedVHD {
 }
 
 # Cfgms-MountSeedVHD mounts the seed VHDX, lays down a single FAT32 volume
-# labelled CFGMS_SEED, then DISMOUNTS (so the later copy step can re-mount; a
-# left-mounted VHD causes a 0x80070020 sharing violation on the next Mount-VHD).
+# (label $Label, default CFGMS_SEED — the cloud-init path passes CIDATA), then
+# DISMOUNTS (so the later copy step can re-mount; a left-mounted VHD causes a
+# 0x80070020 sharing violation on the next Mount-VHD).
 function Cfgms-MountSeedVHD {
-    param([Parameter(Mandatory)][string]$Path)
+    param([Parameter(Mandatory)][string]$Path, [string]$Label = 'CFGMS_SEED')
     Mount-VHD -Path $Path -Passthru |
         Initialize-Disk -PartitionStyle MBR -PassThru |
         New-Partition -UseMaximumSize -AssignDriveLetter |
-        Format-Volume -FileSystem FAT32 -NewFileSystemLabel 'CFGMS_SEED' -Confirm:$false | Out-Null
+        Format-Volume -FileSystem FAT32 -NewFileSystemLabel $Label -Confirm:$false | Out-Null
     Cfgms-DismountAndVerify -Path $Path
 }
 
@@ -207,24 +227,32 @@ function Cfgms-DismountAndVerify {
     }
 }
 
-# Cfgms-CopyToSeedVHD re-mounts the formatted seed, writes $Content to
-# <drive>:\$FileName, optionally stages the steward binary ($StewardSrc →
-# cfgms-steward.exe) and controller CA ($CASrc → controller-ca.crt) so a Windows
-# guest can self-install + enroll offline (ADR-010), then dismounts.
+# Cfgms-CopyToSeedVHD re-mounts the formatted seed (matched by label $Label,
+# default CFGMS_SEED), writes $Content to <drive>:\$FileName and — when supplied —
+# a second file $Content2 to <drive>:\$FileName2 (the cloud-init path writes both
+# user-data and meta-data). It optionally stages the steward binary ($StewardSrc →
+# $StewardDest, default cfgms-steward.exe; the linux cloud-init path passes
+# cfgms-steward) and the controller CA ($CASrc → controller-ca.crt) so the guest
+# can self-install + enroll offline (ADR-010), then dismounts.
 function Cfgms-CopyToSeedVHD {
     param(
         [Parameter(Mandatory)][string]$SeedPath,
         [Parameter(Mandatory)][string]$FileName,
         [Parameter(Mandatory)][string]$Content,
+        [string]$Label = 'CFGMS_SEED',
+        [string]$FileName2 = '',
+        [string]$Content2 = '',
         [string]$StewardSrc = '',
+        [string]$StewardDest = 'cfgms-steward.exe',
         [string]$CASrc = ''
     )
     $disk = Mount-VHD -Path $SeedPath -Passthru
     $letter = ($disk | Get-Disk | Get-Partition | Get-Volume |
-        Where-Object { $_.FileSystemLabel -eq 'CFGMS_SEED' } |
+        Where-Object { $_.FileSystemLabel -eq $Label } |
         Select-Object -First 1).DriveLetter
     Set-Content -Path ($letter + ':\' + $FileName) -Value $Content -NoNewline
-    if ($StewardSrc -and (Test-Path -LiteralPath $StewardSrc)) { Copy-Item -LiteralPath $StewardSrc -Destination ($letter + ':\cfgms-steward.exe') -Force }
+    if ($FileName2) { Set-Content -Path ($letter + ':\' + $FileName2) -Value $Content2 -NoNewline }
+    if ($StewardSrc -and (Test-Path -LiteralPath $StewardSrc)) { Copy-Item -LiteralPath $StewardSrc -Destination ($letter + ':\' + $StewardDest) -Force }
     if ($CASrc -and (Test-Path -LiteralPath $CASrc)) { Copy-Item -LiteralPath $CASrc -Destination ($letter + ':\controller-ca.crt') -Force }
     Cfgms-DismountAndVerify -Path $SeedPath
 }
@@ -271,6 +299,110 @@ function Cfgms-SetDVDFirstBoot {
     if ($ISOPath) { $dvd = Get-VMDvdDrive -VMName $Name | Where-Object { $_.Path -eq $ISOPath } | Select-Object -First 1 }
     if (-not $dvd) { $dvd = Get-VMDvdDrive -VMName $Name | Select-Object -First 1 }
     Set-VMFirmware -VMName $Name -FirstBootDevice $dvd
+}
+
+# ── cloud-init (Linux VM-from-cloud-image) ─────────────────────────────
+# Host-native cloud-image → VHDX conversion: no qemu-img, no xorriso, no WSL. A
+# raw cloud image is wrapped with a fixed-VHD footer (Cfgms-VhdFixedFooter) so
+# Convert-VHD can read it, then converted to a dynamic VHDX; a .vhd/.vhdx image is
+# converted/copied directly. The cloud image's signed bootloader is never modified
+# (Secure Boot stays intact). Dispatched via runFresh (Convert-VHD is heavy I/O).
+
+# Cfgms-VhdFixedFooter returns the 512-byte Microsoft fixed-VHD footer for a disk
+# image of $Size bytes (a multiple of 512). All multi-byte fields are big-endian;
+# disk geometry (CHS) follows the VHD spec; the checksum is the ones-complement of
+# the byte sum (with the checksum field zeroed). Appending it to a raw image
+# produces a valid fixed VHD.
+function Cfgms-VhdFixedFooter {
+    param([Parameter(Mandatory)][long]$Size)
+    function _BE { param([uint64]$v, [int]$width)
+        $b = New-Object byte[] $width
+        for ($i = 0; $i -lt $width; $i++) { $b[$width - 1 - $i] = [byte](($v -shr ($i * 8)) -band 0xFF) }
+        return ,$b
+    }
+    $f = New-Object byte[] 512
+    [Array]::Copy([Text.Encoding]::ASCII.GetBytes('conectix'), 0, $f, 0, 8)
+    [Array]::Copy((_BE 2 4), 0, $f, 8, 4)                         # features
+    [Array]::Copy((_BE 0x00010000 4), 0, $f, 12, 4)              # file format version
+    [Array]::Copy((_BE ([uint64]::MaxValue) 8), 0, $f, 16, 8)    # data offset (fixed = all-ones)
+    $tstamp = [uint32]([DateTimeOffset]::UtcNow.ToUnixTimeSeconds() - 946684800)
+    [Array]::Copy((_BE $tstamp 4), 0, $f, 24, 4)                 # timestamp (since 2000-01-01)
+    [Array]::Copy([Text.Encoding]::ASCII.GetBytes('cfgm'), 0, $f, 28, 4)   # creator application
+    [Array]::Copy((_BE 0x00010000 4), 0, $f, 32, 4)             # creator version
+    [Array]::Copy([Text.Encoding]::ASCII.GetBytes('Wi2k'), 0, $f, 36, 4)   # creator host OS (Windows)
+    [Array]::Copy((_BE ([uint64]$Size) 8), 0, $f, 40, 8)        # original size
+    [Array]::Copy((_BE ([uint64]$Size) 8), 0, $f, 48, 8)        # current size
+    # CHS geometry (VHD spec appendix).
+    $tsec = [int64]($Size / 512)
+    $maxS = [int64]65535 * 16 * 255
+    if ($tsec -gt $maxS) { $tsec = $maxS }
+    if ($tsec -ge ([int64]65535 * 16 * 63)) {
+        $spt = 255; $heads = 16; $cth = [int64]($tsec / $spt)
+    } else {
+        $spt = 17; $cth = [int64]($tsec / $spt)
+        $heads = [int64](($cth + 1023) / 1024)
+        if ($heads -lt 4) { $heads = 4 }
+        if (($cth -ge ($heads * 1024)) -or ($heads -gt 16)) { $spt = 31; $heads = 16; $cth = [int64]($tsec / $spt) }
+        if ($cth -ge ($heads * 1024)) { $spt = 63; $heads = 16; $cth = [int64]($tsec / $spt) }
+    }
+    $cyl = [int64]($cth / $heads)
+    $f[56] = [byte](($cyl -shr 8) -band 0xFF); $f[57] = [byte]($cyl -band 0xFF)
+    $f[58] = [byte]$heads; $f[59] = [byte]$spt
+    [Array]::Copy((_BE 2 4), 0, $f, 60, 4)                       # disk type = fixed
+    [Array]::Copy(([guid]::NewGuid().ToByteArray()), 0, $f, 68, 16)  # unique id
+    $sum = [uint64]0
+    foreach ($b in $f) { $sum += $b }
+    # Ones-complement of the 32-bit byte sum. Use an explicit [uint64] mask: the
+    # bare hex literal 0xFFFFFFFF parses as Int32 (-1) in PowerShell, which would
+    # make the subtraction negative and fail the [uint32] cast.
+    $mask = [uint64]4294967295
+    $cks = [uint32]($mask - ($sum -band $mask))
+    [Array]::Copy((_BE ([uint64]$cks) 4), 0, $f, 64, 4)         # checksum
+    return ,$f
+}
+
+# Cfgms-PrepCloudBootDisk prepares the VM boot disk from a cloud image. A .vhdx is
+# copied as-is; a .vhd is converted; any other extension is treated as a raw image
+# (footer-wrapped → fixed VHD → dynamic VHDX). Optionally resized larger
+# ($ResizeBytes > 0; cloud-init growpart expands the rootfs on first boot).
+function Cfgms-PrepCloudBootDisk {
+    param(
+        [Parameter(Mandatory)][string]$ImagePath,
+        [Parameter(Mandatory)][string]$VhdPath,
+        [long]$ResizeBytes = 0
+    )
+    New-Item -ItemType Directory -Force -Path (Split-Path -Path $VhdPath -Parent) | Out-Null
+    if (Test-Path -LiteralPath $VhdPath) { Remove-Item -LiteralPath $VhdPath -Force }
+    $ext = [IO.Path]::GetExtension($ImagePath).ToLowerInvariant()
+    if ($ext -eq '.vhdx') {
+        Copy-Item -LiteralPath $ImagePath -Destination $VhdPath -Force
+    } elseif ($ext -eq '.vhd') {
+        Convert-VHD -Path $ImagePath -DestinationPath $VhdPath -VHDType Dynamic
+    } else {
+        $parent = Split-Path -Path $VhdPath -Parent
+        $tmpVhd = Join-Path $parent ([IO.Path]::GetFileNameWithoutExtension($VhdPath) + '.fixed.vhd')
+        if (Test-Path -LiteralPath $tmpVhd) { Remove-Item -LiteralPath $tmpVhd -Force }
+        Copy-Item -LiteralPath $ImagePath -Destination $tmpVhd -Force
+        $size = (Get-Item -LiteralPath $tmpVhd).Length
+        if (($size % 512) -ne 0) { throw ('cloud image size not a multiple of 512: ' + $size) }
+        $footer = Cfgms-VhdFixedFooter -Size $size
+        $fsAppend = [IO.File]::Open($tmpVhd, [IO.FileMode]::Append, [IO.FileAccess]::Write)
+        try { $fsAppend.Write($footer, 0, 512) } finally { $fsAppend.Dispose() }
+        Convert-VHD -Path $tmpVhd -DestinationPath $VhdPath -VHDType Dynamic
+        Remove-Item -LiteralPath $tmpVhd -Force -ErrorAction SilentlyContinue
+    }
+    if ($ResizeBytes -gt 0) { Resize-VHD -Path $VhdPath -SizeBytes $ResizeBytes }
+}
+
+# Cfgms-SetHddFirstBoot makes the OS hard disk (matched by $VHDPath) the Gen2
+# firmware's first boot device, so a cloud-init VM boots the cloud image rather
+# than the attached CIDATA seed disk. Dispatched via runFresh (Set-VMFirmware
+# -FirstBootDevice referencing a disk deadlocks in the persistent host).
+function Cfgms-SetHddFirstBoot {
+    param([Parameter(Mandatory)][string]$Name, [Parameter(Mandatory)][string]$VHDPath)
+    $hdd = Get-VMHardDiskDrive -VMName $Name | Where-Object { $_.Path -eq $VHDPath } | Select-Object -First 1
+    if (-not $hdd) { $hdd = Get-VMHardDiskDrive -VMName $Name | Select-Object -First 1 }
+    Set-VMFirmware -VMName $Name -FirstBootDevice $hdd
 }
 
 # Cfgms-BuildAnswerIso builds a small ISO ($IsoPath) carrying the rendered

--- a/features/modules/hyperv/pstransport_preamble_windows.go
+++ b/features/modules/hyperv/pstransport_preamble_windows.go
@@ -400,8 +400,12 @@ function Cfgms-PrepCloudBootDisk {
 # -FirstBootDevice referencing a disk deadlocks in the persistent host).
 function Cfgms-SetHddFirstBoot {
     param([Parameter(Mandatory)][string]$Name, [Parameter(Mandatory)][string]$VHDPath)
+    # Match the OS disk by path. Do NOT silently fall back to "first disk found":
+    # on a cloud-init VM the seed CIDATA VHDX is also attached, and booting it (a
+    # tiny non-bootable FAT32 disk) instead of the OS disk would brick the boot.
+    # A genuine no-match is a provisioning bug — fail loudly.
     $hdd = Get-VMHardDiskDrive -VMName $Name | Where-Object { $_.Path -eq $VHDPath } | Select-Object -First 1
-    if (-not $hdd) { $hdd = Get-VMHardDiskDrive -VMName $Name | Select-Object -First 1 }
+    if (-not $hdd) { throw ('OS boot disk not found on VM ' + $Name + ' for path: ' + $VHDPath) }
     Set-VMFirmware -VMName $Name -FirstBootDevice $hdd
 }
 

--- a/features/modules/hyperv/pstransport_preamble_windows.go
+++ b/features/modules/hyperv/pstransport_preamble_windows.go
@@ -162,26 +162,38 @@ function Cfgms-DisconnectVMNic {
 # Storage roles the host already runs). Each function wraps a single logical
 # host-atomic step; all user-controlled values travel via parameters.
 
-# Cfgms-RunDiskJob runs a disk/VHD scriptblock in a FRESH PowerShell child
-# process (Start-Job) and surfaces its result. This is REQUIRED for Mount-VHD /
-# Dismount-VHD: those cmdlets attach the VHD asynchronously via the Virtual Disk
-# Service, which DEADLOCKS when run directly in this persistent stdin-piped host
-# (powershell.exe -Command -). A fresh child process has its own message pump and
-# completes normally. $ProgressPreference is silenced in the child to avoid
-# progress-stream stalls. Values pass via -ArgumentList (bound params), never
-# interpolated into script text. A non-Completed job re-throws the child error.
-function Cfgms-RunDiskJob {
-    param([Parameter(Mandatory)][scriptblock]$ScriptBlock, [object[]]$ArgumentList = @())
-    $j = Start-Job -ScriptBlock $ScriptBlock -ArgumentList $ArgumentList
-    $null = Wait-Job $j
-    $out = Receive-Job $j 2>&1
-    $state = $j.State
-    Remove-Job $j -Force
-    if ($state -ne 'Completed') { throw ('hyperv seed disk job ' + $state + ': ' + (($out | ForEach-Object { $_.ToString() }) -join '; ')) }
+# Cfgms-RunDiskScript runs a disk/VHD script in a FRESH powershell.exe child via
+# Start-Process -Wait. This is REQUIRED for Mount-VHD / Dismount-VHD: those
+# cmdlets attach the VHD asynchronously via the Virtual Disk Service, which
+# DEADLOCKS when run in this persistent stdin-REPL host (powershell.exe
+# -Command -) — and so do Start-Job / Wait-Job (they share the host's async
+# machinery). Start-Process -Wait blocks on the OS process handle, which does NOT
+# deadlock, and the child (a normal -File invocation) runs the disk cmdlets fine.
+# $BodyLines are written to a temp .ps1; $ScriptArgs bind positionally to its
+# param() block (never interpolated into script text). A non-zero child exit
+# re-throws the captured stderr.
+function Cfgms-RunDiskScript {
+    param([Parameter(Mandatory)][string[]]$BodyLines, [string[]]$ScriptArgs = @())
+    $tmp = Join-Path $env:TEMP ('cfgms-seed-' + [guid]::NewGuid().ToString('N') + '.ps1')
+    $errFile = $tmp + '.err'
+    Set-Content -Path $tmp -Value $BodyLines -Encoding UTF8
+    try {
+        $quoted = ($ScriptArgs | ForEach-Object { '"' + ($_ -replace '"', '""') + '"' }) -join ' '
+        $argLine = '-NoProfile -NonInteractive -File "' + $tmp + '" ' + $quoted
+        $pr = Start-Process -FilePath 'powershell.exe' -ArgumentList $argLine -Wait -PassThru -WindowStyle Hidden -RedirectStandardError $errFile
+        if ($pr.ExitCode -ne 0) {
+            $e = ''
+            if (Test-Path $errFile) { $e = (Get-Content $errFile -Raw) }
+            throw ('hyperv seed disk script exit ' + $pr.ExitCode + ': ' + $e)
+        }
+    } finally {
+        Remove-Item $tmp, $errFile -Force -ErrorAction SilentlyContinue
+    }
 }
 
 # Cfgms-NewSeedVHD creates an empty dynamic VHDX for the answer-file seed,
 # creating the parent directory first (seed_dir may be a fresh local path).
+# New-VHD is synchronous and is safe to run in-host.
 function Cfgms-NewSeedVHD {
     param([Parameter(Mandatory)][string]$Path, [int]$SizeBytes = 67108864)
     New-Item -ItemType Directory -Force -Path (Split-Path -Path $Path -Parent) | Out-Null
@@ -191,28 +203,25 @@ function Cfgms-NewSeedVHD {
 # Cfgms-MountSeedVHD mounts the seed VHDX, lays down a single FAT32 volume
 # labelled CFGMS_SEED, then DISMOUNTS (so the later copy step can re-mount; a
 # left-mounted VHD causes a 0x80070020 sharing violation on the next Mount-VHD).
-# Runs in a fresh child process (Cfgms-RunDiskJob) because Mount-VHD deadlocks in
-# the persistent host. Windows Setup and debian-installer auto-discover their
-# answer file from the labelled volume.
+# Runs in a fresh child process (Mount-VHD deadlocks in the persistent host).
 function Cfgms-MountSeedVHD {
     param([Parameter(Mandatory)][string]$Path)
-    Cfgms-RunDiskJob -ArgumentList $Path -ScriptBlock {
-        param($p)
-        $ProgressPreference = 'SilentlyContinue'
-        Mount-VHD -Path $p -Passthru |
-            Initialize-Disk -PartitionStyle MBR -PassThru |
-            New-Partition -UseMaximumSize -AssignDriveLetter |
-            Format-Volume -FileSystem FAT32 -NewFileSystemLabel 'CFGMS_SEED' -Confirm:$false | Out-Null
-        Dismount-VHD -Path $p
-    }
+    Cfgms-RunDiskScript -ScriptArgs $Path -BodyLines @(
+        'param([string]$p)',
+        '$ErrorActionPreference = ''Stop''',
+        '$ProgressPreference = ''SilentlyContinue''',
+        'Mount-VHD -Path $p -Passthru | Initialize-Disk -PartitionStyle MBR -PassThru | New-Partition -UseMaximumSize -AssignDriveLetter | Format-Volume -FileSystem FAT32 -NewFileSystemLabel ''CFGMS_SEED'' -Confirm:$false | Out-Null',
+        'Dismount-VHD -Path $p'
+    )
 }
 
 # Cfgms-CopyToSeedVHD re-mounts the formatted seed, writes $Content to
 # <drive>:\$FileName, optionally stages the steward binary ($StewardSrc →
 # cfgms-steward.exe) and controller CA ($CASrc → controller-ca.crt) so a Windows
 # guest can self-install + enroll offline (ADR-010), then dismounts. Runs in a
-# fresh child process (Mount-VHD deadlocks in the persistent host). All values
-# travel via ArgumentList — never interpolated into script text.
+# fresh child process (Mount-VHD deadlocks in the persistent host). The answer
+# content is handed to the child via a temp file (avoids argv size/quoting
+# limits); paths bind positionally.
 function Cfgms-CopyToSeedVHD {
     param(
         [Parameter(Mandatory)][string]$SeedPath,
@@ -221,17 +230,23 @@ function Cfgms-CopyToSeedVHD {
         [string]$StewardSrc = '',
         [string]$CASrc = ''
     )
-    Cfgms-RunDiskJob -ArgumentList $SeedPath,$FileName,$Content,$StewardSrc,$CASrc -ScriptBlock {
-        param($sp,$fn,$content,$stewardSrc,$caSrc)
-        $ProgressPreference = 'SilentlyContinue'
-        $disk = Mount-VHD -Path $sp -Passthru
-        $letter = ($disk | Get-Disk | Get-Partition | Get-Volume |
-            Where-Object { $_.FileSystemLabel -eq 'CFGMS_SEED' } |
-            Select-Object -First 1).DriveLetter
-        Set-Content -Path ($letter + ':\' + $fn) -Value $content -NoNewline
-        if ($stewardSrc -and (Test-Path -LiteralPath $stewardSrc)) { Copy-Item -LiteralPath $stewardSrc -Destination ($letter + ':\cfgms-steward.exe') -Force }
-        if ($caSrc -and (Test-Path -LiteralPath $caSrc)) { Copy-Item -LiteralPath $caSrc -Destination ($letter + ':\controller-ca.crt') -Force }
-        Dismount-VHD -Path $sp
+    $contentFile = Join-Path $env:TEMP ('cfgms-ans-' + [guid]::NewGuid().ToString('N') + '.tmp')
+    Set-Content -Path $contentFile -Value $Content -NoNewline
+    try {
+        Cfgms-RunDiskScript -ScriptArgs $SeedPath, $FileName, $contentFile, $StewardSrc, $CASrc -BodyLines @(
+            'param([string]$sp,[string]$fn,[string]$cf,[string]$ss,[string]$ca)',
+            '$ErrorActionPreference = ''Stop''',
+            '$ProgressPreference = ''SilentlyContinue''',
+            '$content = Get-Content -LiteralPath $cf -Raw',
+            '$disk = Mount-VHD -Path $sp -Passthru',
+            '$letter = ($disk | Get-Disk | Get-Partition | Get-Volume | Where-Object { $_.FileSystemLabel -eq ''CFGMS_SEED'' } | Select-Object -First 1).DriveLetter',
+            'Set-Content -Path ($letter + '':\'' + $fn) -Value $content -NoNewline',
+            'if ($ss -and (Test-Path -LiteralPath $ss)) { Copy-Item -LiteralPath $ss -Destination ($letter + '':\cfgms-steward.exe'') -Force }',
+            'if ($ca -and (Test-Path -LiteralPath $ca)) { Copy-Item -LiteralPath $ca -Destination ($letter + '':\controller-ca.crt'') -Force }',
+            'Dismount-VHD -Path $sp'
+        )
+    } finally {
+        Remove-Item $contentFile -Force -ErrorAction SilentlyContinue
     }
 }
 
@@ -240,11 +255,11 @@ function Cfgms-CopyToSeedVHD {
 # same Dismount-VHD-deadlock reason as the mount path.
 function Cfgms-DetachSeedVHD {
     param([Parameter(Mandatory)][string]$Path)
-    Cfgms-RunDiskJob -ArgumentList $Path -ScriptBlock {
-        param($p)
-        $ProgressPreference = 'SilentlyContinue'
-        Dismount-VHD -Path $p -ErrorAction SilentlyContinue
-    }
+    Cfgms-RunDiskScript -ScriptArgs $Path -BodyLines @(
+        'param([string]$p)',
+        '$ProgressPreference = ''SilentlyContinue''',
+        'Dismount-VHD -Path $p -ErrorAction SilentlyContinue'
+    )
 }
 
 # Cfgms-AttachSeedDisk attaches the seed VHDX to the VM as a secondary hard

--- a/features/modules/hyperv/pstransport_preamble_windows.go
+++ b/features/modules/hyperv/pstransport_preamble_windows.go
@@ -162,38 +162,15 @@ function Cfgms-DisconnectVMNic {
 # Storage roles the host already runs). Each function wraps a single logical
 # host-atomic step; all user-controlled values travel via parameters.
 
-# Cfgms-RunDiskScript runs a disk/VHD script in a FRESH powershell.exe child via
-# Start-Process -Wait. This is REQUIRED for Mount-VHD / Dismount-VHD: those
-# cmdlets attach the VHD asynchronously via the Virtual Disk Service, which
-# DEADLOCKS when run in this persistent stdin-REPL host (powershell.exe
-# -Command -) — and so do Start-Job / Wait-Job (they share the host's async
-# machinery). Start-Process -Wait blocks on the OS process handle, which does NOT
-# deadlock, and the child (a normal -File invocation) runs the disk cmdlets fine.
-# $BodyLines are written to a temp .ps1; $ScriptArgs bind positionally to its
-# param() block (never interpolated into script text). A non-zero child exit
-# re-throws the captured stderr.
-function Cfgms-RunDiskScript {
-    param([Parameter(Mandatory)][string[]]$BodyLines, [string[]]$ScriptArgs = @())
-    $tmp = Join-Path $env:TEMP ('cfgms-seed-' + [guid]::NewGuid().ToString('N') + '.ps1')
-    $errFile = $tmp + '.err'
-    Set-Content -Path $tmp -Value $BodyLines -Encoding UTF8
-    try {
-        $quoted = ($ScriptArgs | ForEach-Object { '"' + ($_ -replace '"', '""') + '"' }) -join ' '
-        $argLine = '-NoProfile -NonInteractive -File "' + $tmp + '" ' + $quoted
-        $pr = Start-Process -FilePath 'powershell.exe' -ArgumentList $argLine -Wait -PassThru -WindowStyle Hidden -RedirectStandardError $errFile
-        if ($pr.ExitCode -ne 0) {
-            $e = ''
-            if (Test-Path $errFile) { $e = (Get-Content $errFile -Raw) }
-            throw ('hyperv seed disk script exit ' + $pr.ExitCode + ': ' + $e)
-        }
-    } finally {
-        Remove-Item $tmp, $errFile -Force -ErrorAction SilentlyContinue
-    }
-}
+# SEED VHDX disk ops (New/Mount/Copy/Detach) below run direct cmdlets. They are
+# dispatched via the Go transport runFresh() — a fresh powershell.exe -File
+# process — NOT the persistent -Command - host. This is REQUIRED: Mount-VHD /
+# Dismount-VHD attach the VHD via the async Virtual Disk Service, which DEADLOCKS
+# in the persistent stdin-REPL host (and so do Start-Job / Start-Process -Wait
+# launched from inside it). A fresh -File process runs them with no deadlock.
 
 # Cfgms-NewSeedVHD creates an empty dynamic VHDX for the answer-file seed,
 # creating the parent directory first (seed_dir may be a fresh local path).
-# New-VHD is synchronous and is safe to run in-host.
 function Cfgms-NewSeedVHD {
     param([Parameter(Mandatory)][string]$Path, [int]$SizeBytes = 67108864)
     New-Item -ItemType Directory -Force -Path (Split-Path -Path $Path -Parent) | Out-Null
@@ -203,25 +180,19 @@ function Cfgms-NewSeedVHD {
 # Cfgms-MountSeedVHD mounts the seed VHDX, lays down a single FAT32 volume
 # labelled CFGMS_SEED, then DISMOUNTS (so the later copy step can re-mount; a
 # left-mounted VHD causes a 0x80070020 sharing violation on the next Mount-VHD).
-# Runs in a fresh child process (Mount-VHD deadlocks in the persistent host).
 function Cfgms-MountSeedVHD {
     param([Parameter(Mandatory)][string]$Path)
-    Cfgms-RunDiskScript -ScriptArgs $Path -BodyLines @(
-        'param([string]$p)',
-        '$ErrorActionPreference = ''Stop''',
-        '$ProgressPreference = ''SilentlyContinue''',
-        'Mount-VHD -Path $p -Passthru | Initialize-Disk -PartitionStyle MBR -PassThru | New-Partition -UseMaximumSize -AssignDriveLetter | Format-Volume -FileSystem FAT32 -NewFileSystemLabel ''CFGMS_SEED'' -Confirm:$false | Out-Null',
-        'Dismount-VHD -Path $p'
-    )
+    Mount-VHD -Path $Path -Passthru |
+        Initialize-Disk -PartitionStyle MBR -PassThru |
+        New-Partition -UseMaximumSize -AssignDriveLetter |
+        Format-Volume -FileSystem FAT32 -NewFileSystemLabel 'CFGMS_SEED' -Confirm:$false | Out-Null
+    Dismount-VHD -Path $Path
 }
 
 # Cfgms-CopyToSeedVHD re-mounts the formatted seed, writes $Content to
 # <drive>:\$FileName, optionally stages the steward binary ($StewardSrc →
 # cfgms-steward.exe) and controller CA ($CASrc → controller-ca.crt) so a Windows
-# guest can self-install + enroll offline (ADR-010), then dismounts. Runs in a
-# fresh child process (Mount-VHD deadlocks in the persistent host). The answer
-# content is handed to the child via a temp file (avoids argv size/quoting
-# limits); paths bind positionally.
+# guest can self-install + enroll offline (ADR-010), then dismounts.
 function Cfgms-CopyToSeedVHD {
     param(
         [Parameter(Mandatory)][string]$SeedPath,
@@ -230,36 +201,21 @@ function Cfgms-CopyToSeedVHD {
         [string]$StewardSrc = '',
         [string]$CASrc = ''
     )
-    $contentFile = Join-Path $env:TEMP ('cfgms-ans-' + [guid]::NewGuid().ToString('N') + '.tmp')
-    Set-Content -Path $contentFile -Value $Content -NoNewline
-    try {
-        Cfgms-RunDiskScript -ScriptArgs $SeedPath, $FileName, $contentFile, $StewardSrc, $CASrc -BodyLines @(
-            'param([string]$sp,[string]$fn,[string]$cf,[string]$ss,[string]$ca)',
-            '$ErrorActionPreference = ''Stop''',
-            '$ProgressPreference = ''SilentlyContinue''',
-            '$content = Get-Content -LiteralPath $cf -Raw',
-            '$disk = Mount-VHD -Path $sp -Passthru',
-            '$letter = ($disk | Get-Disk | Get-Partition | Get-Volume | Where-Object { $_.FileSystemLabel -eq ''CFGMS_SEED'' } | Select-Object -First 1).DriveLetter',
-            'Set-Content -Path ($letter + '':\'' + $fn) -Value $content -NoNewline',
-            'if ($ss -and (Test-Path -LiteralPath $ss)) { Copy-Item -LiteralPath $ss -Destination ($letter + '':\cfgms-steward.exe'') -Force }',
-            'if ($ca -and (Test-Path -LiteralPath $ca)) { Copy-Item -LiteralPath $ca -Destination ($letter + '':\controller-ca.crt'') -Force }',
-            'Dismount-VHD -Path $sp'
-        )
-    } finally {
-        Remove-Item $contentFile -Force -ErrorAction SilentlyContinue
-    }
+    $disk = Mount-VHD -Path $SeedPath -Passthru
+    $letter = ($disk | Get-Disk | Get-Partition | Get-Volume |
+        Where-Object { $_.FileSystemLabel -eq 'CFGMS_SEED' } |
+        Select-Object -First 1).DriveLetter
+    Set-Content -Path ($letter + ':\' + $FileName) -Value $Content -NoNewline
+    if ($StewardSrc -and (Test-Path -LiteralPath $StewardSrc)) { Copy-Item -LiteralPath $StewardSrc -Destination ($letter + ':\cfgms-steward.exe') -Force }
+    if ($CASrc -and (Test-Path -LiteralPath $CASrc)) { Copy-Item -LiteralPath $CASrc -Destination ($letter + ':\controller-ca.crt') -Force }
+    Dismount-VHD -Path $SeedPath
 }
 
 # Cfgms-DetachSeedVHD dismounts the seed VHDX from the host (called at
-# finalizing). Idempotent via -ErrorAction. Runs in a fresh child process for the
-# same Dismount-VHD-deadlock reason as the mount path.
+# finalizing). Idempotent via -ErrorAction.
 function Cfgms-DetachSeedVHD {
     param([Parameter(Mandatory)][string]$Path)
-    Cfgms-RunDiskScript -ScriptArgs $Path -BodyLines @(
-        'param([string]$p)',
-        '$ProgressPreference = ''SilentlyContinue''',
-        'Dismount-VHD -Path $p -ErrorAction SilentlyContinue'
-    )
+    Dismount-VHD -Path $Path -ErrorAction SilentlyContinue
 }
 
 # Cfgms-AttachSeedDisk attaches the seed VHDX to the VM as a secondary hard

--- a/features/modules/hyperv/pstransport_preamble_windows.go
+++ b/features/modules/hyperv/pstransport_preamble_windows.go
@@ -162,51 +162,89 @@ function Cfgms-DisconnectVMNic {
 # Storage roles the host already runs). Each function wraps a single logical
 # host-atomic step; all user-controlled values travel via parameters.
 
-# Cfgms-NewSeedVHD creates an empty dynamic VHDX for the answer-file seed.
+# Cfgms-RunDiskJob runs a disk/VHD scriptblock in a FRESH PowerShell child
+# process (Start-Job) and surfaces its result. This is REQUIRED for Mount-VHD /
+# Dismount-VHD: those cmdlets attach the VHD asynchronously via the Virtual Disk
+# Service, which DEADLOCKS when run directly in this persistent stdin-piped host
+# (powershell.exe -Command -). A fresh child process has its own message pump and
+# completes normally. $ProgressPreference is silenced in the child to avoid
+# progress-stream stalls. Values pass via -ArgumentList (bound params), never
+# interpolated into script text. A non-Completed job re-throws the child error.
+function Cfgms-RunDiskJob {
+    param([Parameter(Mandatory)][scriptblock]$ScriptBlock, [object[]]$ArgumentList = @())
+    $j = Start-Job -ScriptBlock $ScriptBlock -ArgumentList $ArgumentList
+    $null = Wait-Job $j
+    $out = Receive-Job $j 2>&1
+    $state = $j.State
+    Remove-Job $j -Force
+    if ($state -ne 'Completed') { throw ('hyperv seed disk job ' + $state + ': ' + (($out | ForEach-Object { $_.ToString() }) -join '; ')) }
+}
+
+# Cfgms-NewSeedVHD creates an empty dynamic VHDX for the answer-file seed,
+# creating the parent directory first (seed_dir may be a fresh local path).
 function Cfgms-NewSeedVHD {
     param([Parameter(Mandatory)][string]$Path, [int]$SizeBytes = 67108864)
+    New-Item -ItemType Directory -Force -Path (Split-Path -Path $Path -Parent) | Out-Null
     New-VHD -Path $Path -SizeBytes $SizeBytes -Dynamic | Out-Null
 }
 
-# Cfgms-MountSeedVHD mounts the seed VHDX and lays down a single FAT32
-# volume labelled CFGMS_SEED. Windows Setup and debian-installer both
-# auto-discover their answer file from a removable/labelled volume. This is
-# a single host-atomic "make the seed a usable filesystem" step — the
-# pipeline cannot be decomposed into Go without holding the mounted-disk
-# handle across calls, so it intentionally chains more than one cmdlet
-# (same exception class as Cfgms-RemoveVM / Cfgms-GetVM).
+# Cfgms-MountSeedVHD mounts the seed VHDX, lays down a single FAT32 volume
+# labelled CFGMS_SEED, then DISMOUNTS (so the later copy step can re-mount; a
+# left-mounted VHD causes a 0x80070020 sharing violation on the next Mount-VHD).
+# Runs in a fresh child process (Cfgms-RunDiskJob) because Mount-VHD deadlocks in
+# the persistent host. Windows Setup and debian-installer auto-discover their
+# answer file from the labelled volume.
 function Cfgms-MountSeedVHD {
     param([Parameter(Mandatory)][string]$Path)
-    Mount-VHD -Path $Path -Passthru |
-        Initialize-Disk -PartitionStyle MBR -PassThru |
-        New-Partition -UseMaximumSize -AssignDriveLetter |
-        Format-Volume -FileSystem FAT32 -NewFileSystemLabel 'CFGMS_SEED' -Confirm:$false | Out-Null
+    Cfgms-RunDiskJob -ArgumentList $Path -ScriptBlock {
+        param($p)
+        $ProgressPreference = 'SilentlyContinue'
+        Mount-VHD -Path $p -Passthru |
+            Initialize-Disk -PartitionStyle MBR -PassThru |
+            New-Partition -UseMaximumSize -AssignDriveLetter |
+            Format-Volume -FileSystem FAT32 -NewFileSystemLabel 'CFGMS_SEED' -Confirm:$false | Out-Null
+        Dismount-VHD -Path $p
+    }
 }
 
-# Cfgms-CopyToSeedVHD writes the answer file to the root of the seed volume.
-# It mounts the VHDX, resolves the drive letter of the CFGMS_SEED volume,
-# writes $Content to <drive>:\$FileName, then dismounts. $Content and
-# $FileName travel via ArgumentList — never interpolated into script text.
+# Cfgms-CopyToSeedVHD re-mounts the formatted seed, writes $Content to
+# <drive>:\$FileName, optionally stages the steward binary ($StewardSrc →
+# cfgms-steward.exe) and controller CA ($CASrc → controller-ca.crt) so a Windows
+# guest can self-install + enroll offline (ADR-010), then dismounts. Runs in a
+# fresh child process (Mount-VHD deadlocks in the persistent host). All values
+# travel via ArgumentList — never interpolated into script text.
 function Cfgms-CopyToSeedVHD {
     param(
         [Parameter(Mandatory)][string]$SeedPath,
         [Parameter(Mandatory)][string]$FileName,
-        [Parameter(Mandatory)][string]$Content
+        [Parameter(Mandatory)][string]$Content,
+        [string]$StewardSrc = '',
+        [string]$CASrc = ''
     )
-    $disk = Mount-VHD -Path $SeedPath -Passthru
-    $letter = ($disk | Get-Disk | Get-Partition | Get-Volume |
-        Where-Object { $_.FileSystemLabel -eq 'CFGMS_SEED' } |
-        Select-Object -First 1).DriveLetter
-    Set-Content -Path ($letter + ':\' + $FileName) -Value $Content -NoNewline
-    Dismount-VHD -Path $SeedPath
+    Cfgms-RunDiskJob -ArgumentList $SeedPath,$FileName,$Content,$StewardSrc,$CASrc -ScriptBlock {
+        param($sp,$fn,$content,$stewardSrc,$caSrc)
+        $ProgressPreference = 'SilentlyContinue'
+        $disk = Mount-VHD -Path $sp -Passthru
+        $letter = ($disk | Get-Disk | Get-Partition | Get-Volume |
+            Where-Object { $_.FileSystemLabel -eq 'CFGMS_SEED' } |
+            Select-Object -First 1).DriveLetter
+        Set-Content -Path ($letter + ':\' + $fn) -Value $content -NoNewline
+        if ($stewardSrc -and (Test-Path -LiteralPath $stewardSrc)) { Copy-Item -LiteralPath $stewardSrc -Destination ($letter + ':\cfgms-steward.exe') -Force }
+        if ($caSrc -and (Test-Path -LiteralPath $caSrc)) { Copy-Item -LiteralPath $caSrc -Destination ($letter + ':\controller-ca.crt') -Force }
+        Dismount-VHD -Path $sp
+    }
 }
 
 # Cfgms-DetachSeedVHD dismounts the seed VHDX from the host (called at
-# finalizing — not in this story's create path). Idempotent on an already
-# dismounted disk via -ErrorAction.
+# finalizing). Idempotent via -ErrorAction. Runs in a fresh child process for the
+# same Dismount-VHD-deadlock reason as the mount path.
 function Cfgms-DetachSeedVHD {
     param([Parameter(Mandatory)][string]$Path)
-    Dismount-VHD -Path $Path -ErrorAction SilentlyContinue
+    Cfgms-RunDiskJob -ArgumentList $Path -ScriptBlock {
+        param($p)
+        $ProgressPreference = 'SilentlyContinue'
+        Dismount-VHD -Path $p -ErrorAction SilentlyContinue
+    }
 }
 
 # Cfgms-AttachSeedDisk attaches the seed VHDX to the VM as a secondary hard

--- a/features/modules/hyperv/pstransport_preamble_windows.go
+++ b/features/modules/hyperv/pstransport_preamble_windows.go
@@ -186,7 +186,25 @@ function Cfgms-MountSeedVHD {
         Initialize-Disk -PartitionStyle MBR -PassThru |
         New-Partition -UseMaximumSize -AssignDriveLetter |
         Format-Volume -FileSystem FAT32 -NewFileSystemLabel 'CFGMS_SEED' -Confirm:$false | Out-Null
-    Dismount-VHD -Path $Path
+    Cfgms-DismountAndVerify -Path $Path
+}
+
+# Cfgms-DismountAndVerify dismounts a seed VHD and confirms it is fully detached
+# before returning. A VHD left attached (even transiently after a failed/slow
+# dismount) blocks the subsequent Add-VMHardDiskDrive with a 0x80070020
+# "in use by another process" error, so the seed build must guarantee detachment.
+function Cfgms-DismountAndVerify {
+    param([Parameter(Mandatory)][string]$Path)
+    Dismount-VHD -Path $Path -ErrorAction SilentlyContinue
+    $tries = 0
+    while ((Get-VHD -Path $Path -ErrorAction SilentlyContinue).Attached -and $tries -lt 30) {
+        Start-Sleep -Milliseconds 200
+        Dismount-VHD -Path $Path -ErrorAction SilentlyContinue
+        $tries++
+    }
+    if ((Get-VHD -Path $Path -ErrorAction SilentlyContinue).Attached) {
+        throw ('seed VHD still attached to host after dismount: ' + $Path)
+    }
 }
 
 # Cfgms-CopyToSeedVHD re-mounts the formatted seed, writes $Content to
@@ -208,7 +226,7 @@ function Cfgms-CopyToSeedVHD {
     Set-Content -Path ($letter + ':\' + $FileName) -Value $Content -NoNewline
     if ($StewardSrc -and (Test-Path -LiteralPath $StewardSrc)) { Copy-Item -LiteralPath $StewardSrc -Destination ($letter + ':\cfgms-steward.exe') -Force }
     if ($CASrc -and (Test-Path -LiteralPath $CASrc)) { Copy-Item -LiteralPath $CASrc -Destination ($letter + ':\controller-ca.crt') -Force }
-    Dismount-VHD -Path $SeedPath
+    Cfgms-DismountAndVerify -Path $SeedPath
 }
 
 # Cfgms-DetachSeedVHD dismounts the seed VHDX from the host (called at

--- a/features/modules/hyperv/pstransport_preamble_windows.go
+++ b/features/modules/hyperv/pstransport_preamble_windows.go
@@ -259,6 +259,17 @@ function Cfgms-SetVMFirmware {
     Set-VMFirmware -VMName $Name -EnableSecureBoot On -SecureBootTemplate $Template
 }
 
+# Cfgms-SetDVDFirstBoot makes the install DVD the Gen2 firmware's first boot
+# device so the VM boots the installer rather than the empty OS disk. Dispatched
+# via runFresh: Set-VMFirmware -FirstBootDevice references the DVD drive, which
+# touches the ISO and deadlocks in the persistent -Command - host (unlike the
+# secure-boot Set-VMFirmware above, which sets only a flag).
+function Cfgms-SetDVDFirstBoot {
+    param([Parameter(Mandatory)][string]$Name)
+    $dvd = Get-VMDvdDrive -VMName $Name | Select-Object -First 1
+    Set-VMFirmware -VMName $Name -FirstBootDevice $dvd
+}
+
 # ── VSwitch read + lifecycle ──────────────────────────────────────────
 function Cfgms-GetVSwitch {
     param([Parameter(Mandatory)][string]$Name)

--- a/features/modules/hyperv/pstransport_preamble_windows.go
+++ b/features/modules/hyperv/pstransport_preamble_windows.go
@@ -259,15 +259,80 @@ function Cfgms-SetVMFirmware {
     Set-VMFirmware -VMName $Name -EnableSecureBoot On -SecureBootTemplate $Template
 }
 
-# Cfgms-SetDVDFirstBoot makes the install DVD the Gen2 firmware's first boot
-# device so the VM boots the installer rather than the empty OS disk. Dispatched
-# via runFresh: Set-VMFirmware -FirstBootDevice references the DVD drive, which
-# touches the ISO and deadlocks in the persistent -Command - host (unlike the
-# secure-boot Set-VMFirmware above, which sets only a flag).
+# Cfgms-SetDVDFirstBoot makes the INSTALL DVD (matched by $ISOPath) the Gen2
+# firmware's first boot device so the VM boots the installer rather than the
+# empty OS disk or the (bootloader-less) answer ISO. Two DVDs are attached for
+# Windows (install ISO + answer ISO), so the install ISO must be selected by
+# path. Dispatched via runFresh: Set-VMFirmware -FirstBootDevice references the
+# DVD/ISO and deadlocks in the persistent -Command - host.
 function Cfgms-SetDVDFirstBoot {
-    param([Parameter(Mandatory)][string]$Name)
-    $dvd = Get-VMDvdDrive -VMName $Name | Select-Object -First 1
+    param([Parameter(Mandatory)][string]$Name, [string]$ISOPath = '')
+    $dvd = $null
+    if ($ISOPath) { $dvd = Get-VMDvdDrive -VMName $Name | Where-Object { $_.Path -eq $ISOPath } | Select-Object -First 1 }
+    if (-not $dvd) { $dvd = Get-VMDvdDrive -VMName $Name | Select-Object -First 1 }
     Set-VMFirmware -VMName $Name -FirstBootDevice $dvd
+}
+
+# Cfgms-BuildAnswerIso builds a small ISO ($IsoPath) carrying the rendered
+# answer file ($FileName/$Content) plus, when supplied, the steward binary and
+# controller CA, so the new Windows Server 2025 Setup auto-applies the answer
+# file (the redesigned Setup scans DVD roots but NOT data disks). Built natively
+# via IMAPI2 — no oscdimg/ADK/WSL needed. The IMAPI image IStream is copied to
+# the file by a C# helper because the equivalent PowerShell IStream.Read interop
+# hangs. Dispatched via runFresh (a fresh process; the COM/file work is heavy and
+# must not run in the persistent host).
+function Cfgms-BuildAnswerIso {
+    param(
+        [Parameter(Mandatory)][string]$IsoPath,
+        [Parameter(Mandatory)][string]$FileName,
+        [Parameter(Mandatory)][string]$Content,
+        [string]$StewardSrc = '',
+        [string]$CASrc = ''
+    )
+    Add-Type -ErrorAction SilentlyContinue -TypeDefinition @'
+using System; using System.IO; using System.Runtime.InteropServices; using System.Runtime.InteropServices.ComTypes;
+public static class CfgmsIsoWriter {
+  public static void Save(object comStream, string path) {
+    IStream s = (IStream)comStream;
+    using (FileStream fs = File.Create(path)) {
+      byte[] buf = new byte[1048576];
+      IntPtr read = Marshal.AllocHGlobal(4);
+      try { while (true) { s.Read(buf, buf.Length, read); int n = Marshal.ReadInt32(read); if (n <= 0) break; fs.Write(buf, 0, n); } }
+      finally { Marshal.FreeHGlobal(read); }
+    }
+  }
+}
+'@
+    $tmp = Join-Path $env:TEMP ('cfgms-ans-' + [guid]::NewGuid().ToString('N'))
+    New-Item -ItemType Directory -Force -Path $tmp | Out-Null
+    try {
+        Set-Content -Path (Join-Path $tmp $FileName) -Value $Content -NoNewline
+        if ($StewardSrc -and (Test-Path -LiteralPath $StewardSrc)) { Copy-Item -LiteralPath $StewardSrc -Destination (Join-Path $tmp 'cfgms-steward.exe') -Force }
+        if ($CASrc -and (Test-Path -LiteralPath $CASrc)) { Copy-Item -LiteralPath $CASrc -Destination (Join-Path $tmp 'controller-ca.crt') -Force }
+        Remove-Item $IsoPath -Force -ErrorAction SilentlyContinue
+        $fsi = New-Object -ComObject IMAPI2FS.MsftFileSystemImage
+        $fsi.FileSystemsToCreate = 7
+        $fsi.VolumeName = 'CFGMS_ANS'
+        $fsi.Root.AddTree($tmp, $false)
+        $res = $fsi.CreateResultImage()
+        [CfgmsIsoWriter]::Save($res.ImageStream, $IsoPath)
+    } finally {
+        Remove-Item $tmp -Recurse -Force -ErrorAction SilentlyContinue
+    }
+}
+
+# Cfgms-BootKeypress drives the VM keyboard for ~40s after power-on to satisfy
+# the Windows install media's "Press any key to boot from CD or DVD..." prompt,
+# which otherwise times out in a headless VM and the boot loader gives up. Uses
+# the Msvm_Keyboard WMI device. Dispatched via runFresh (it blocks ~40s).
+function Cfgms-BootKeypress {
+    param([Parameter(Mandatory)][string]$Name)
+    for ($i = 0; $i -lt 50; $i++) {
+        $vm = Get-WmiObject -Namespace root\virtualization\v2 -Class Msvm_ComputerSystem -Filter "ElementName='$Name'"
+        $kb = $vm.GetRelated('Msvm_Keyboard') | Select-Object -First 1
+        if ($kb) { $kb.TypeKey(0x20) | Out-Null }
+        Start-Sleep -Milliseconds 400
+    }
 }
 
 # ── VSwitch read + lifecycle ──────────────────────────────────────────

--- a/features/modules/hyperv/pstransport_windows.go
+++ b/features/modules/hyperv/pstransport_windows.go
@@ -13,6 +13,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"os"
 	"os/exec"
 	"strings"
 	"sync"
@@ -222,6 +223,44 @@ func (t *psHostTransport) loadPreamble() error {
 // surfaced as an error if non-empty.
 //
 // Holds the transport mutex for the duration of the round trip.
+// runFresh executes a single Cfgms-* expression in a FRESH powershell.exe
+// process via -File, instead of the persistent `-Command -` host. This is
+// REQUIRED for the seed VHDX disk operations (New/Mount/Copy/Detach): Mount-VHD
+// and Dismount-VHD attach the VHD via the async Virtual Disk Service, which
+// DEADLOCKS in the persistent stdin-REPL host — and so do Start-Job and
+// Start-Process -Wait launched from inside it. A fresh `powershell -File`
+// process runs the disk cmdlets directly with no deadlock (proven on cfg-lab).
+//
+// The temp script is the full preamble (Cfgms-* defs + safe defaults) followed
+// by the expression, so the verb resolves exactly as in the persistent host.
+// The script is removed after the run. Unlike run(), this does not serialise on
+// t.mu (it spawns an independent process) and is unaffected by t.closed.
+func (t *psHostTransport) runFresh(ctx context.Context, expression string) (string, error) {
+	f, err := os.CreateTemp("", "cfgms-seedop-*.ps1")
+	if err != nil {
+		return "", fmt.Errorf("hyperv-ps-host: create temp seed script: %w", err)
+	}
+	tmpPath := f.Name()
+	defer func() { _ = os.Remove(tmpPath) }()
+	if _, werr := io.WriteString(f, psHostPreamble+"\n"+expression+"\n"); werr != nil {
+		_ = f.Close()
+		return "", fmt.Errorf("hyperv-ps-host: write temp seed script: %w", werr)
+	}
+	if cerr := f.Close(); cerr != nil {
+		return "", fmt.Errorf("hyperv-ps-host: close temp seed script: %w", cerr)
+	}
+
+	cmd := exec.CommandContext(ctx, "powershell.exe",
+		"-NoProfile", "-NonInteractive", "-File", tmpPath,
+	) //#nosec G204 -- fixed flags; the temp script path is generated, not user-supplied
+	out, runErr := cmd.CombinedOutput()
+	if runErr != nil {
+		return string(out), fmt.Errorf("hyperv-ps-host: fresh seed op failed: %w: %s",
+			runErr, strings.TrimSpace(string(out)))
+	}
+	return string(out), nil
+}
+
 func (t *psHostTransport) run(_ context.Context, expression string) (string, error) {
 	t.mu.Lock()
 	defer t.mu.Unlock()

--- a/features/modules/hyperv/vm.go
+++ b/features/modules/hyperv/vm.go
@@ -33,6 +33,12 @@ var (
 	// ErrInvalidSourceISO is returned when the source iso field is missing or not an absolute Windows path.
 	ErrInvalidSourceISO = errors.New("hyperv: invalid source iso: must be a non-empty absolute Windows path (e.g. C:\\ISO\\server.iso)")
 
+	// ErrInvalidSourceImage is returned when a linux cloud-init source image field is not an absolute Windows path.
+	ErrInvalidSourceImage = errors.New("hyperv: invalid source image: must be an absolute Windows path to a .raw or .vhdx cloud image (e.g. C:\\images\\debian.raw)")
+
+	// ErrInvalidSourceMedia is returned when a linux source declares neither iso (preseed) nor image (cloud-init).
+	ErrInvalidSourceMedia = errors.New("hyperv: invalid source: a linux source requires either image (cloud-init) or iso (netinst+preseed)")
+
 	// ErrInvalidSourceOSFamily is returned when source os_family is not linux or windows.
 	ErrInvalidSourceOSFamily = errors.New("hyperv: invalid source os_family: must be linux or windows")
 
@@ -70,8 +76,21 @@ type CompletionConfig struct {
 // Presence of a source block in a hyperv.vm resource triggers the provisioning
 // state machine (absent → creating → installing → finalizing → ready).
 type SourceConfig struct {
-	// ISO is the absolute Windows path to the installation ISO.
-	ISO string `yaml:"iso"`
+	// ISO is the absolute Windows path to the installation ISO. Required for
+	// os_family: windows (autounattend) and for the legacy os_family: linux
+	// netinst+preseed path. Ignored when Image is set (cloud-init).
+	ISO string `yaml:"iso,omitempty"`
+	// Image is the absolute Windows host path to a cloud image (.raw or .vhdx)
+	// for the os_family: linux cloud-init path. When set, the module prepares the
+	// VM's boot disk from this image (raw → fixed VHD → dynamic VHDX) and delivers
+	// enrollment via a NoCloud CIDATA seed instead of a netinst ISO + preseed.
+	// This is the default/recommended Linux path (no boot-media repack, Secure
+	// Boot intact). Ignored for os_family: windows.
+	Image string `yaml:"image,omitempty"`
+	// ResizeGB optionally grows the cloud-image boot disk to this many GB after
+	// conversion (cloud-init growpart expands the root filesystem on first boot).
+	// 0 leaves the image at its native size. Cloud-init (Image) path only.
+	ResizeGB int `yaml:"resize_gb,omitempty"`
 	// OSFamily distinguishes the installer type: linux or windows.
 	OSFamily string `yaml:"os_family"`
 	// Unattend is an optional reference to an unattended-install profile,
@@ -289,13 +308,36 @@ func (c *VMConfig) Validate() error {
 	return nil
 }
 
+// isCloudInit reports whether this source uses the cloud-init/NoCloud path: a
+// linux source that declares a cloud image (source.image). The alternative linux
+// path is the legacy netinst ISO + preseed (Image empty, ISO set).
+func (s *SourceConfig) isCloudInit() bool {
+	return s.OSFamily == "linux" && s.Image != ""
+}
+
 // validate checks all SourceConfig fields against their constraints.
 func (s *SourceConfig) validate() error {
-	if !vhdPathPattern.MatchString(s.ISO) {
-		return ErrInvalidSourceISO
-	}
 	switch s.OSFamily {
-	case "linux", "windows":
+	case "windows":
+		// Windows requires an install ISO (autounattend).
+		if !vhdPathPattern.MatchString(s.ISO) {
+			return ErrInvalidSourceISO
+		}
+	case "linux":
+		// Linux accepts EITHER a cloud image (cloud-init, default/recommended) OR
+		// a netinst ISO (legacy preseed). At least one must be a valid path.
+		switch {
+		case s.Image != "":
+			if !vhdPathPattern.MatchString(s.Image) {
+				return ErrInvalidSourceImage
+			}
+		case s.ISO != "":
+			if !vhdPathPattern.MatchString(s.ISO) {
+				return ErrInvalidSourceISO
+			}
+		default:
+			return ErrInvalidSourceMedia
+		}
 	default:
 		return ErrInvalidSourceOSFamily
 	}
@@ -328,16 +370,26 @@ func parseSourceMap(v interface{}) *SourceConfig {
 	}
 	src := &SourceConfig{}
 	src.ISO, _ = m["iso"].(string)
+	src.Image, _ = m["image"].(string)
 	src.OSFamily, _ = m["os_family"].(string)
 	src.Unattend, _ = m["unattend"].(string)
 	src.OnExisting, _ = m["on_existing"].(string)
 	src.Edition, _ = m["edition"].(string)
+	// resize_gb may arrive as int or int64 (YAML/JSON numeric shapes).
+	switch v := m["resize_gb"].(type) {
+	case int:
+		src.ResizeGB = v
+	case int64:
+		src.ResizeGB = int(v)
+	case float64:
+		src.ResizeGB = int(v)
+	}
 	if comp, ok := m["completion"].(map[string]interface{}); ok {
 		src.Completion.Mode, _ = comp["mode"].(string)
 		src.Completion.Timeout, _ = comp["timeout"].(string)
 	}
 	// An entirely empty source map (all fields zero) is treated as no source.
-	if src.ISO == "" && src.OSFamily == "" && src.Unattend == "" &&
+	if src.ISO == "" && src.Image == "" && src.OSFamily == "" && src.Unattend == "" &&
 		src.OnExisting == "" && src.Completion.Mode == "" && src.Completion.Timeout == "" {
 		return nil
 	}
@@ -365,6 +417,8 @@ func (c *VMConfig) AsMap() map[string]interface{} {
 	if c.Source != nil {
 		m["source"] = map[string]interface{}{
 			"iso":       c.Source.ISO,
+			"image":     c.Source.Image,
+			"resize_gb": c.Source.ResizeGB,
 			"os_family": c.Source.OSFamily,
 			"unattend":  c.Source.Unattend,
 			"completion": map[string]interface{}{
@@ -372,6 +426,7 @@ func (c *VMConfig) AsMap() map[string]interface{} {
 				"timeout": c.Source.Completion.Timeout,
 			},
 			"on_existing": c.Source.OnExisting,
+			"edition":     c.Source.Edition,
 		}
 	}
 	return m
@@ -877,22 +932,49 @@ func (m *hypervModule) createVM(ctx context.Context, vmName, hostName string, cf
 		"Generation": fmt.Sprintf("%d", generation),
 	}
 
+	// cloud-init (Linux VM-from-cloud-image): the boot disk IS the cloud image,
+	// not a freshly-created empty VHD. Prepare it (raw → fixed VHD → dynamic VHDX,
+	// optional resize) and create the VM attaching the EXISTING disk
+	// (New-VM -VHDPath) instead of New-VM -NewVHDPath.
+	if cfg.Source != nil && cfg.Source.isCloudInit() {
+		resizeBytes := int64(cfg.Source.ResizeGB) * gibibyte
+		if _, psErr := m.transport.ExecutePS(ctx, psPrepCloudBootDisk, map[string]string{
+			"ImagePath":   cfg.Source.Image,
+			"VhdPath":     cfg.VHDPath,
+			"ResizeBytes": fmt.Sprintf("%d", resizeBytes),
+		}); psErr != nil {
+			recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.host, "Convert-VHD", hostName, psErr)
+			return fmt.Errorf("hyperv: prepare cloud boot disk for VM %q: %w", vmName, psErr)
+		}
+		recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.host, "Convert-VHD", hostName, nil)
+		_, psErr := m.transport.ExecutePS(ctx, psCreateVMFromDisk, psArgs)
+		recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.host, "New-VM", hostName, psErr)
+		if psErr != nil {
+			return fmt.Errorf("hyperv: create VM %q from cloud image: %w", vmName, psErr)
+		}
+		return m.connectAdditionalNics(ctx, vmName, hostName, cfg)
+	}
+
 	_, psErr := m.transport.ExecutePS(ctx, psCreateVM, psArgs)
 	recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.host, "New-VM", hostName, psErr)
 	if psErr != nil {
 		return fmt.Errorf("hyperv: create VM %q: %w", vmName, psErr)
 	}
 
-	// New-VM -SwitchName connected the first desired switch (cfg.SwitchName).
-	// Connect one additional adapter for every remaining switch in the desired
-	// set so a multi-NIC declaration materialises all adapters at create time.
+	return m.connectAdditionalNics(ctx, vmName, hostName, cfg)
+}
+
+// connectAdditionalNics connects one extra network adapter for every desired
+// switch beyond the first (New-VM -SwitchName already connected the first), so a
+// multi-NIC declaration materialises all adapters at create time. Shared by the
+// empty-VHD and cloud-image create paths.
+func (m *hypervModule) connectAdditionalNics(ctx context.Context, vmName, hostName string, cfg *VMConfig) error {
 	desired := cfg.desiredSwitches()
 	for _, sw := range desired[min(1, len(desired)):] {
 		if err := m.connectVMToSwitch(ctx, vmName, hostName, sw); err != nil {
 			return err
 		}
 	}
-
 	return nil
 }
 

--- a/features/modules/hyperv/vm.go
+++ b/features/modules/hyperv/vm.go
@@ -82,6 +82,11 @@ type SourceConfig struct {
 	// OnExisting controls behaviour when the VM already exists:
 	// never (default) leaves it untouched; recreate destroys and re-provisions.
 	OnExisting string `yaml:"on_existing,omitempty"`
+	// Edition is the exact Windows image name the autounattend ImageInstall step
+	// selects (the /IMAGE/NAME value, e.g. "Windows Server 2025 Standard
+	// Evaluation (Desktop Experience)"). Optional; when empty the built-in
+	// defaultWindowsEdition is used. Ignored for os_family: linux.
+	Edition string `yaml:"edition,omitempty"`
 }
 
 // VMConfig represents the desired state of a Hyper-V virtual machine.
@@ -326,6 +331,7 @@ func parseSourceMap(v interface{}) *SourceConfig {
 	src.OSFamily, _ = m["os_family"].(string)
 	src.Unattend, _ = m["unattend"].(string)
 	src.OnExisting, _ = m["on_existing"].(string)
+	src.Edition, _ = m["edition"].(string)
 	if comp, ok := m["completion"].(map[string]interface{}); ok {
 		src.Completion.Mode, _ = comp["mode"].(string)
 		src.Completion.Timeout, _ = comp["timeout"].(string)

--- a/features/modules/hyperv/vm.go
+++ b/features/modules/hyperv/vm.go
@@ -39,6 +39,9 @@ var (
 	// ErrInvalidSourceMedia is returned when a linux source declares neither iso (preseed) nor image (cloud-init).
 	ErrInvalidSourceMedia = errors.New("hyperv: invalid source: a linux source requires either image (cloud-init) or iso (netinst+preseed)")
 
+	// ErrInvalidSourceResize is returned when source resize_gb is negative or exceeds the VHDX maximum (64 TiB).
+	ErrInvalidSourceResize = errors.New("hyperv: invalid source resize_gb: must be between 0 and 65536 (GiB)")
+
 	// ErrInvalidSourceOSFamily is returned when source os_family is not linux or windows.
 	ErrInvalidSourceOSFamily = errors.New("hyperv: invalid source os_family: must be linux or windows")
 
@@ -328,7 +331,10 @@ func (s *SourceConfig) validate() error {
 		// a netinst ISO (legacy preseed). At least one must be a valid path.
 		switch {
 		case s.Image != "":
-			if !vhdPathPattern.MatchString(s.Image) {
+			// Reject a UNC image path (\\server\share) — the cloud image must live
+			// on a local/CSV drive, never an arbitrary network share (matches the
+			// seed-path guard). A drive-letter absolute path is required.
+			if strings.HasPrefix(s.Image, `\\`) || !vhdPathPattern.MatchString(s.Image) {
 				return ErrInvalidSourceImage
 			}
 		case s.ISO != "":
@@ -340,6 +346,10 @@ func (s *SourceConfig) validate() error {
 		}
 	default:
 		return ErrInvalidSourceOSFamily
+	}
+	// resize_gb (cloud-init only) must be non-negative and within the VHDX max.
+	if s.ResizeGB < 0 || s.ResizeGB > 65536 {
+		return ErrInvalidSourceResize
 	}
 	if s.Unattend != "" && !strings.HasPrefix(s.Unattend, "profile://") {
 		return ErrInvalidSourceUnattend

--- a/features/modules/hyperv/vm_provision.go
+++ b/features/modules/hyperv/vm_provision.go
@@ -174,6 +174,9 @@ func (m *hypervModule) renderSeedAnswerFile(ctx context.Context, vmName string, 
 	// password backs the one-shot AutoLogon that runs enrollment.
 	if src.OSFamily == "windows" {
 		vars.ProductEdition = defaultWindowsEdition
+		if src.Edition != "" {
+			vars.ProductEdition = src.Edition
+		}
 		pw, pwErr := randomAdminPassword()
 		if pwErr != nil {
 			return "", fmt.Errorf("hyperv: generate admin password for VM %q: %w", vmName, pwErr)

--- a/features/modules/hyperv/vm_provision.go
+++ b/features/modules/hyperv/vm_provision.go
@@ -39,15 +39,28 @@ const (
 	// a sharing violation (0x80070020 "being used by another process"). The
 	// formatted volume persists on the (now-detached) VHD for the copy step to
 	// re-mount.
-	psMountSeedVHD = `Mount-VHD -Path $Path -Passthru | Initialize-Disk -PartitionStyle MBR -PassThru | New-Partition -UseMaximumSize -AssignDriveLetter | Format-Volume -FileSystem FAT32 -NewFileSystemLabel 'CFGMS_SEED' -Confirm:$false | Out-Null; Dismount-VHD -Path $Path`
+	//
+	// This const is the script the WinRM transport runs directly (buildInvokeCommand
+	// wraps it as Invoke-Command); the ps-host transport instead dispatches to the
+	// preamble's Cfgms-MountSeedVHD. The two must agree on the PARAMETER CONTRACT —
+	// $Label (optional) selects the FAT32 volume label: legacy preseed/windows
+	// callers omit it (so it is $null on WinRM → defaults to CFGMS_SEED), the
+	// cloud-init path passes CIDATA. (The ps-host preamble additionally hardens the
+	// trailing dismount with a verify-loop, Cfgms-DismountAndVerify, which the bare
+	// WinRM const text below does not replicate — WinRM is the secondary transport.)
+	psMountSeedVHD = `Mount-VHD -Path $Path -Passthru | Initialize-Disk -PartitionStyle MBR -PassThru | New-Partition -UseMaximumSize -AssignDriveLetter | Format-Volume -FileSystem FAT32 -NewFileSystemLabel $(if ($Label) { $Label } else { 'CFGMS_SEED' }) -Confirm:$false | Out-Null; Dismount-VHD -Path $Path`
 
-	// psCopyToSeedVHD mounts the seed, writes $Content to <drive>:\$FileName,
-	// optionally stages the steward binary ($StewardSrc → <drive>:\cfgms-steward.exe)
-	// and controller CA ($CASrc → <drive>:\controller-ca.crt) so a Windows guest
-	// can self-install + enroll offline (ADR-010), and dismounts. $Content,
-	// $FileName, $StewardSrc and $CASrc travel via ArgumentList; empty
-	// $StewardSrc / $CASrc skip staging (the Linux/preseed path stages neither).
-	psCopyToSeedVHD = `$disk = Mount-VHD -Path $SeedPath -Passthru; $letter = ($disk | Get-Disk | Get-Partition | Get-Volume | Where-Object { $_.FileSystemLabel -eq 'CFGMS_SEED' } | Select-Object -First 1).DriveLetter; Set-Content -Path ($letter + ':\' + $FileName) -Value $Content -NoNewline; if ($StewardSrc -and (Test-Path -LiteralPath $StewardSrc)) { Copy-Item -LiteralPath $StewardSrc -Destination ($letter + ':\cfgms-steward.exe') -Force }; if ($CASrc -and (Test-Path -LiteralPath $CASrc)) { Copy-Item -LiteralPath $CASrc -Destination ($letter + ':\controller-ca.crt') -Force }; Dismount-VHD -Path $SeedPath`
+	// psCopyToSeedVHD mounts the seed (volume matched by $Label, default
+	// CFGMS_SEED), writes $Content to <drive>:\$FileName and — when supplied — a
+	// second file $Content2 to <drive>:\$FileName2 (the cloud-init path writes both
+	// user-data and meta-data). It optionally stages the steward binary ($StewardSrc
+	// → $StewardDest, default cfgms-steward.exe; the linux cloud-init path passes
+	// cfgms-steward) and controller CA ($CASrc → <drive>:\controller-ca.crt) so the
+	// guest can self-install + enroll offline (ADR-010), and dismounts. All values
+	// travel via ArgumentList; empty optional params fall back to their defaults.
+	// WinRM-transport variant of the preamble's Cfgms-CopyToSeedVHD — same parameter
+	// contract; the preamble adds the verify-dismount hardening (see psMountSeedVHD).
+	psCopyToSeedVHD = `$disk = Mount-VHD -Path $SeedPath -Passthru; $label = $(if ($Label) { $Label } else { 'CFGMS_SEED' }); $letter = ($disk | Get-Disk | Get-Partition | Get-Volume | Where-Object { $_.FileSystemLabel -eq $label } | Select-Object -First 1).DriveLetter; Set-Content -Path ($letter + ':\' + $FileName) -Value $Content -NoNewline; if ($FileName2) { Set-Content -Path ($letter + ':\' + $FileName2) -Value $Content2 -NoNewline }; if ($StewardSrc -and (Test-Path -LiteralPath $StewardSrc)) { Copy-Item -LiteralPath $StewardSrc -Destination ($letter + ':\' + $(if ($StewardDest) { $StewardDest } else { 'cfgms-steward.exe' })) -Force }; if ($CASrc -and (Test-Path -LiteralPath $CASrc)) { Copy-Item -LiteralPath $CASrc -Destination ($letter + ':\controller-ca.crt') -Force }; Dismount-VHD -Path $SeedPath`
 
 	// psDetachSeedVHD wraps Dismount-VHD (called at finalizing, not in the
 	// create path this story implements).

--- a/features/modules/hyperv/vm_provision.go
+++ b/features/modules/hyperv/vm_provision.go
@@ -81,7 +81,29 @@ const (
 	// psBootKeypress drives the VM keyboard after power-on to satisfy the Windows
 	// install media's "Press any key to boot from CD or DVD" prompt.
 	psBootKeypress = `Cfgms-BootKeypress`
+
+	// ── cloud-init (Linux VM-from-cloud-image) path (ADR-009 §6) ─────────────
+	//
+	// psPrepCloudBootDisk prepares the VM's boot disk from a cloud image: a raw
+	// image is wrapped with a fixed-VHD footer and converted to a dynamic VHDX (a
+	// .vhdx image is copied as-is), optionally resized. Host-native — no qemu-img,
+	// no xorriso, no WSL. The cloud image's signed bootloader is never modified.
+	psPrepCloudBootDisk = `Cfgms-PrepCloudBootDisk`
+
+	// psCreateVMFromDisk creates a VM that boots an EXISTING prepared disk
+	// (New-VM -VHDPath), used by the cloud-init path where the boot disk is the
+	// converted cloud image rather than a freshly-created empty VHD.
+	psCreateVMFromDisk = `Cfgms-CreateVMFromDisk`
+
+	// psSetHddFirstBoot makes the OS hard disk (matched by path) the Gen2
+	// firmware's first boot device, so a cloud-init VM boots the cloud image
+	// rather than the attached CIDATA seed disk.
+	psSetHddFirstBoot = `Cfgms-SetHddFirstBoot`
 )
+
+// gibibyte is 1024^3, used to convert source.resize_gb into a byte count for the
+// cloud boot-disk resize (0 means "leave at native size").
+const gibibyte = int64(1) << 30
 
 // secureBootTemplate returns the Gen2 secure-boot firmware template for the
 // given os_family. Windows guests use the Microsoft Windows template; Linux
@@ -126,7 +148,7 @@ func seedAnswerFilePlaceholder(osFamily string) string {
 func (m *hypervModule) resolveProfile(ctx context.Context, src *SourceConfig) (*UnattendProfile, error) {
 	switch src.OSFamily {
 	case "linux":
-		return m.resolveLinuxProfile(ctx, src.Unattend)
+		return m.resolveLinuxProfile(ctx, src)
 	case "windows":
 		return m.resolveWindowsProfile(ctx, src.Unattend)
 	default:
@@ -340,6 +362,22 @@ func (m *hypervModule) provisionVM(ctx context.Context, vmName, hostName string,
 		recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.host, "Set-VMFirmware", hostName, nil)
 	}
 
+	// cloud-init (Linux VM-from-cloud-image): the boot disk (already prepared
+	// from the cloud image by createVM) carries its own OS + cloud-init. There is
+	// NO installer and NO install ISO — enrollment rides a NoCloud CIDATA seed
+	// VHDX (user-data + meta-data + steward + CA) that cloud-init auto-detects on
+	// first boot. Build + attach that seed, make the OS disk the first boot
+	// device, and we're done (no DVD, no keypress).
+	if cfg.Source.isCloudInit() {
+		if err := m.provisionCloudInit(ctx, vmName, hostName, cfg, record, generation); err != nil {
+			return err
+		}
+		if err := m.execStartVM(ctx, vmName, hostName); err != nil {
+			return m.failProvision(ctx, vmName, record, err)
+		}
+		return m.advanceProvision(ctx, vmName, record, ProvisionStateInstalling)
+	}
+
 	// Render the unattended answer file (os_family dispatch): linux → preseed
 	// (#2046), windows → autounattend.xml (#2047). The per-VM CorrelationID is
 	// baked in so the controller-side reconciler (#2050) can match the registered
@@ -467,16 +505,117 @@ func (m *hypervModule) provisionVM(ctx context.Context, vmName, hostName string,
 	return m.advanceProvision(ctx, vmName, record, ProvisionStateInstalling)
 }
 
+// cloudInitMetaData returns the minimal NoCloud meta-data document for a VM.
+// instance-id is unique per VM (cloud-init only re-runs when it changes);
+// local-hostname is set to the CorrelationID so the booted guest's hostname
+// matches the provisioning record the controller-side reconciler keys on.
+func cloudInitMetaData(vmName, correlationID string) string {
+	host := correlationID
+	if host == "" {
+		host = vmName
+	}
+	return "instance-id: " + vmName + "\nlocal-hostname: " + host + "\n"
+}
+
+// provisionCloudInit performs the cloud-init media setup for a Linux
+// VM-from-cloud-image: render user-data, build the NoCloud CIDATA seed VHDX
+// (user-data + meta-data + steward binary + controller CA), attach it as a data
+// disk, and make the OS disk the Gen2 first boot device. The boot disk itself was
+// already prepared from the cloud image by createVM. No install ISO, no keypress
+// — cloud-init auto-detects the CIDATA seed on first boot. The caller powers the
+// VM on and advances the record to installing.
+func (m *hypervModule) provisionCloudInit(ctx context.Context, vmName, hostName string, cfg *VMConfig, record *ProvisionRecord, generation int) error {
+	// Render the cloud-init user-data (resolves the built-in or operator
+	// cloud-init profile). CorrelationID is baked in for controller-side matching.
+	userData, renderErr := m.renderSeedAnswerFile(ctx, vmName, cfg.Source, record.CorrelationID)
+	if renderErr != nil {
+		return m.failProvision(ctx, vmName, record, fmt.Errorf("hyperv: render cloud-init user-data for VM %q: %w", vmName, renderErr))
+	}
+	metaData := cloudInitMetaData(vmName, record.CorrelationID)
+
+	// Build the NoCloud seed: a FAT32 volume labelled CIDATA carrying user-data,
+	// meta-data, the linux steward binary (dest name cfgms-steward) and the
+	// controller CA. Reuses the seed-VHDX machinery (#2044) via the Label /
+	// FileName2 / StewardDest parameters. The seed MUST be on a local (non-CSV)
+	// path — Mount-VHD against a CSV-resident VHDX hangs (seed_dir handles this).
+	seedPath := seedVHDPath(vmName, cfg.VHDPath, m.seedDir)
+	if err := validateSeedPath(seedPath); err != nil {
+		return m.failProvision(ctx, vmName, record, err)
+	}
+	if _, psErr := m.transport.ExecutePS(ctx, psNewSeedVHD, map[string]string{
+		"Path":      seedPath,
+		"SizeBytes": "268435456",
+	}); psErr != nil {
+		recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.host, "New-VHD", hostName, psErr)
+		return m.failProvision(ctx, vmName, record, fmt.Errorf("hyperv: create CIDATA seed VHDX for VM %q: %w", vmName, psErr))
+	}
+	recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.host, "New-VHD", hostName, nil)
+	if _, psErr := m.transport.ExecutePS(ctx, psMountSeedVHD, map[string]string{
+		"Path":  seedPath,
+		"Label": cidataVolumeLabel,
+	}); psErr != nil {
+		recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.host, "Format-Volume", hostName, psErr)
+		return m.failProvision(ctx, vmName, record, fmt.Errorf("hyperv: format CIDATA seed VHDX for VM %q: %w", vmName, psErr))
+	}
+	recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.host, "Format-Volume", hostName, nil)
+	if _, psErr := m.transport.ExecutePS(ctx, psCopyToSeedVHD, map[string]string{
+		"SeedPath":    seedPath,
+		"Label":       cidataVolumeLabel,
+		"FileName":    "user-data",
+		"Content":     userData,
+		"FileName2":   "meta-data",
+		"Content2":    metaData,
+		"StewardSrc":  m.enrollStewardPath,
+		"StewardDest": "cfgms-steward",
+		"CASrc":       m.enrollCAPath,
+	}); psErr != nil {
+		recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.host, "Set-Content", hostName, psErr)
+		return m.failProvision(ctx, vmName, record, fmt.Errorf("hyperv: write cloud-init seed for VM %q: %w", vmName, psErr))
+	}
+	recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.host, "Set-Content", hostName, nil)
+	if _, psErr := m.transport.ExecutePS(ctx, psAttachSeedDisk, map[string]string{
+		"Name":     hostName,
+		"SeedPath": seedPath,
+	}); psErr != nil {
+		recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.host, "Add-VMHardDiskDrive", hostName, psErr)
+		return m.failProvision(ctx, vmName, record, fmt.Errorf("hyperv: attach CIDATA seed to VM %q: %w", vmName, psErr))
+	}
+	recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.host, "Add-VMHardDiskDrive", hostName, nil)
+
+	// Make the OS disk (the converted cloud image) the first boot device so the
+	// VM boots the cloud image rather than the attached CIDATA seed. Gen1 uses
+	// BIOS startup order and is skipped.
+	if generation == 2 {
+		if _, psErr := m.transport.ExecutePS(ctx, psSetHddFirstBoot, map[string]string{
+			"Name":    hostName,
+			"VHDPath": cfg.VHDPath,
+		}); psErr != nil {
+			recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.host, "Set-VMFirmware", hostName, psErr)
+			return m.failProvision(ctx, vmName, record, fmt.Errorf("hyperv: set OS-disk first boot for VM %q: %w", vmName, psErr))
+		}
+		recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.host, "Set-VMFirmware", hostName, nil)
+	}
+	return nil
+}
+
+// cidataVolumeLabel is the NoCloud seed volume label cloud-init auto-detects.
+const cidataVolumeLabel = "CIDATA"
+
 // resolveLinuxProfile returns the UnattendProfile for a Linux VM source. When
 // the source references a profile (profile://<name>) it is loaded from the
-// profile store; when no reference is given the built-in Debian 12 profile is
-// used so a minimal Linux source ("iso" + "os_family: linux") provisions
-// without operator-authored config (ADR-009 §6/§7).
-func (m *hypervModule) resolveLinuxProfile(ctx context.Context, unattendRef string) (*UnattendProfile, error) {
-	if unattendRef == "" {
+// profile store; when no reference is given the built-in profile is used so a
+// minimal Linux source provisions without operator-authored config: cloud-init
+// for a cloud image (source.image), preseed for a netinst ISO (ADR-009 §6/§7).
+func (m *hypervModule) resolveLinuxProfile(ctx context.Context, src *SourceConfig) (*UnattendProfile, error) {
+	if src.Unattend == "" {
+		// No operator profile: choose the built-in by media kind. A cloud image
+		// (source.image) → cloud-init user-data; a netinst ISO → preseed (legacy).
+		if src.isCloudInit() {
+			return defaultLinuxCloudInitProfile(), nil
+		}
 		return defaultLinuxProfile(), nil
 	}
-	name, err := parseProfileName(unattendRef)
+	name, err := parseProfileName(src.Unattend)
 	if err != nil {
 		return nil, err
 	}

--- a/features/modules/hyperv/vm_provision.go
+++ b/features/modules/hyperv/vm_provision.go
@@ -33,8 +33,12 @@ const (
 	psMountSeedVHD = `Mount-VHD -Path $Path -Passthru | Initialize-Disk -PartitionStyle MBR -PassThru | New-Partition -UseMaximumSize -AssignDriveLetter | Format-Volume -FileSystem FAT32 -NewFileSystemLabel 'CFGMS_SEED' -Confirm:$false | Out-Null`
 
 	// psCopyToSeedVHD mounts the seed, writes $Content to <drive>:\$FileName,
-	// and dismounts. $Content and $FileName travel via ArgumentList.
-	psCopyToSeedVHD = `$disk = Mount-VHD -Path $SeedPath -Passthru; $letter = ($disk | Get-Disk | Get-Partition | Get-Volume | Where-Object { $_.FileSystemLabel -eq 'CFGMS_SEED' } | Select-Object -First 1).DriveLetter; Set-Content -Path ($letter + ':\' + $FileName) -Value $Content -NoNewline; Dismount-VHD -Path $SeedPath`
+	// optionally stages the steward binary ($StewardSrc → <drive>:\cfgms-steward.exe)
+	// and controller CA ($CASrc → <drive>:\controller-ca.crt) so a Windows guest
+	// can self-install + enroll offline (ADR-010), and dismounts. $Content,
+	// $FileName, $StewardSrc and $CASrc travel via ArgumentList; empty
+	// $StewardSrc / $CASrc skip staging (the Linux/preseed path stages neither).
+	psCopyToSeedVHD = `$disk = Mount-VHD -Path $SeedPath -Passthru; $letter = ($disk | Get-Disk | Get-Partition | Get-Volume | Where-Object { $_.FileSystemLabel -eq 'CFGMS_SEED' } | Select-Object -First 1).DriveLetter; Set-Content -Path ($letter + ':\' + $FileName) -Value $Content -NoNewline; if ($StewardSrc -and (Test-Path -LiteralPath $StewardSrc)) { Copy-Item -LiteralPath $StewardSrc -Destination ($letter + ':\cfgms-steward.exe') -Force }; if ($CASrc -and (Test-Path -LiteralPath $CASrc)) { Copy-Item -LiteralPath $CASrc -Destination ($letter + ':\controller-ca.crt') -Force }; Dismount-VHD -Path $SeedPath`
 
 	// psDetachSeedVHD wraps Dismount-VHD (called at finalizing, not in the
 	// create path this story implements).
@@ -157,11 +161,24 @@ func (m *hypervModule) renderSeedAnswerFile(ctx context.Context, vmName string, 
 		OSFamily:      src.OSFamily,
 		CorrelationID: correlationID,
 		BundleURL:     profile.Enroll.BundleURL,
+		// Controller-supplied enrollment values (ADR-010 §2/§4): the join token
+		// and CA fingerprint ride the config sync, not the local SecretStore.
+		// The default Windows/Linux profiles reference {{ .EnrollToken }} /
+		// {{ .CAFingerprint }} directly so render no longer depends on the
+		// (operator-unwritable) SecretStore for the token (#2077 fix).
+		EnrollToken:   m.enrollToken,
+		CAFingerprint: m.enrollCAFingerprint,
 	}
 	// ProductEdition only applies to the Windows autounattend image-install step;
-	// it is ignored by the Linux preseed template.
+	// it is ignored by the Linux preseed template. A per-VM random Administrator
+	// password backs the one-shot AutoLogon that runs enrollment.
 	if src.OSFamily == "windows" {
 		vars.ProductEdition = defaultWindowsEdition
+		pw, pwErr := randomAdminPassword()
+		if pwErr != nil {
+			return "", fmt.Errorf("hyperv: generate admin password for VM %q: %w", vmName, pwErr)
+		}
+		vars.AdminPassword = pw
 	}
 
 	rendered, err := NewProfileRenderer().Render(ctx, profile, vars, store)
@@ -268,8 +285,11 @@ func (m *hypervModule) provisionVM(ctx context.Context, vmName, hostName string,
 	}
 
 	if _, psErr := m.transport.ExecutePS(ctx, psNewSeedVHD, map[string]string{
-		"Path":      seedPath,
-		"SizeBytes": "67108864", // 64 MiB
+		"Path": seedPath,
+		// 256 MiB (dynamic, so near-zero on-disk until written). The Windows path
+		// stages the steward binary (~tens of MB) + CA onto the seed; 64 MiB was
+		// too small for the binary, so the seed is sized to hold it (ADR-010).
+		"SizeBytes": "268435456",
 	}); psErr != nil {
 		recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.host, "New-VHD", hostName, psErr)
 		return m.failProvision(ctx, vmName, record, fmt.Errorf("hyperv: create seed VHDX for VM %q: %w", vmName, psErr))
@@ -296,10 +316,20 @@ func (m *hypervModule) provisionVM(ctx context.Context, vmName, hostName string,
 		return m.failProvision(ctx, vmName, record, fmt.Errorf("hyperv: render answer file for VM %q: %w", vmName, renderErr))
 	}
 
+	// Stage the steward binary + controller CA onto the seed for the Windows
+	// self-install path (ADR-010); the Linux/preseed path stages neither (it
+	// fetches the .deb in late_command). Empty values skip staging.
+	var stewardSrc, caSrc string
+	if cfg.Source.OSFamily == "windows" {
+		stewardSrc = m.enrollStewardPath
+		caSrc = m.enrollCAPath
+	}
 	if _, psErr := m.transport.ExecutePS(ctx, psCopyToSeedVHD, map[string]string{
-		"SeedPath": seedPath,
-		"FileName": seedAnswerFileName(cfg.Source.OSFamily),
-		"Content":  answerContent,
+		"SeedPath":   seedPath,
+		"FileName":   seedAnswerFileName(cfg.Source.OSFamily),
+		"Content":    answerContent,
+		"StewardSrc": stewardSrc,
+		"CASrc":      caSrc,
 	}); psErr != nil {
 		recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.host, "Set-Content", hostName, psErr)
 		return m.failProvision(ctx, vmName, record, fmt.Errorf("hyperv: write answer file to seed for VM %q: %w", vmName, psErr))

--- a/features/modules/hyperv/vm_provision.go
+++ b/features/modules/hyperv/vm_provision.go
@@ -176,19 +176,23 @@ func (m *hypervModule) renderSeedAnswerFile(ctx context.Context, vmName string, 
 		EnrollToken:   m.enrollToken,
 		CAFingerprint: m.enrollCAFingerprint,
 	}
+	// A per-VM random password is generated for both families: Windows uses it
+	// for the one-shot AutoLogon that runs enrollment; Linux uses it for the
+	// local cfgms user (the steward is the management path, so the value is
+	// never surfaced — ADR-010 §4 "randomize it").
+	pw, pwErr := randomAdminPassword()
+	if pwErr != nil {
+		return "", fmt.Errorf("hyperv: generate provisioning password for VM %q: %w", vmName, pwErr)
+	}
+	vars.AdminPassword = pw
+
 	// ProductEdition only applies to the Windows autounattend image-install step;
-	// it is ignored by the Linux preseed template. A per-VM random Administrator
-	// password backs the one-shot AutoLogon that runs enrollment.
+	// it is ignored by the Linux preseed template.
 	if src.OSFamily == "windows" {
 		vars.ProductEdition = defaultWindowsEdition
 		if src.Edition != "" {
 			vars.ProductEdition = src.Edition
 		}
-		pw, pwErr := randomAdminPassword()
-		if pwErr != nil {
-			return "", fmt.Errorf("hyperv: generate admin password for VM %q: %w", vmName, pwErr)
-		}
-		vars.AdminPassword = pw
 	}
 
 	rendered, err := NewProfileRenderer().Render(ctx, profile, vars, store)

--- a/features/modules/hyperv/vm_provision.go
+++ b/features/modules/hyperv/vm_provision.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"strings"
 	"time"
+
+	"github.com/cfgis/cfgms/pkg/logging"
 )
 
 // ── Provisioning PS verb constants (ADR-009 §5) ────────────────────────────
@@ -69,6 +71,16 @@ const (
 	// psSetVMFirmware wraps Set-VMFirmware: select the Gen2 secure-boot
 	// template. Gen1 VMs never reach this.
 	psSetVMFirmware = `Set-VMFirmware -VMName $Name -EnableSecureBoot On -SecureBootTemplate $Template`
+
+	// psBuildAnswerIso builds a small ISO carrying the rendered answer file
+	// (+ steward binary + CA) for the Windows path: the new Server 2025 Setup
+	// scans DVD roots for autounattend.xml but NOT data disks, so the answer file
+	// is delivered on an ISO attached as a second DVD (built natively via IMAPI2).
+	psBuildAnswerIso = `Cfgms-BuildAnswerIso`
+
+	// psBootKeypress drives the VM keyboard after power-on to satisfy the Windows
+	// install media's "Press any key to boot from CD or DVD" prompt.
+	psBootKeypress = `Cfgms-BootKeypress`
 )
 
 // secureBootTemplate returns the Gen2 secure-boot firmware template for the
@@ -237,6 +249,23 @@ func seedVHDPath(vmName, vhdPath, seedDir string) string {
 	return dir + `\` + "cfgms-seed-" + vmName + ".vhdx"
 }
 
+// answerISOPath derives the Windows answer-ISO path, mirroring seedVHDPath's
+// directory rules (seed_dir when set, else next to the VM's VHD). The answer ISO
+// carries autounattend.xml (+ steward binary + CA) and is attached as a second
+// DVD so the new Server 2025 Setup auto-discovers it (it does not scan data
+// disks). Must be a local, non-CSV path for the same reason as the seed.
+func answerISOPath(vmName, vhdPath, seedDir string) string {
+	dir := seedDir
+	if dir == "" {
+		dir = vhdPath
+		if i := strings.LastIndexAny(vhdPath, `\/`); i >= 0 {
+			dir = vhdPath[:i]
+		}
+	}
+	dir = strings.TrimRight(dir, `\/`)
+	return dir + `\` + "cfgms-answer-" + vmName + ".iso"
+}
+
 // validateSeedPath rejects a seed path that is not a safe absolute Windows
 // path before it can reach the PS transport. A non-absolute path (no drive
 // letter) and a UNC path (\\server\share) are both rejected: the seed must
@@ -311,75 +340,84 @@ func (m *hypervModule) provisionVM(ctx context.Context, vmName, hostName string,
 		recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.host, "Set-VMFirmware", hostName, nil)
 	}
 
-	// Build the seed VHDX next to the VM's primary VHD.
-	seedPath := seedVHDPath(vmName, cfg.VHDPath, m.seedDir)
-	if err := validateSeedPath(seedPath); err != nil {
-		return m.failProvision(ctx, vmName, record, err)
-	}
-
-	if _, psErr := m.transport.ExecutePS(ctx, psNewSeedVHD, map[string]string{
-		"Path": seedPath,
-		// 256 MiB (dynamic, so near-zero on-disk until written). The Windows path
-		// stages the steward binary (~tens of MB) + CA onto the seed; 64 MiB was
-		// too small for the binary, so the seed is sized to hold it (ADR-010).
-		"SizeBytes": "268435456",
-	}); psErr != nil {
-		recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.host, "New-VHD", hostName, psErr)
-		return m.failProvision(ctx, vmName, record, fmt.Errorf("hyperv: create seed VHDX for VM %q: %w", vmName, psErr))
-	}
-	recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.host, "New-VHD", hostName, nil)
-
-	if _, psErr := m.transport.ExecutePS(ctx, psMountSeedVHD, map[string]string{
-		"Path": seedPath,
-	}); psErr != nil {
-		recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.host, "Format-Volume", hostName, psErr)
-		return m.failProvision(ctx, vmName, record, fmt.Errorf("hyperv: format seed VHDX for VM %q: %w", vmName, psErr))
-	}
-	recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.host, "Format-Volume", hostName, nil)
-
-	// Render the unattended answer file for the os_family. renderSeedAnswerFile
-	// dispatches on os_family: linux renders the REAL preseed from the referenced
-	// (or built-in Debian) profile (#2046); windows renders the real
-	// autounattend.xml from the referenced (or built-in Windows) profile (#2047).
-	// Both bake the per-VM CorrelationID in so the controller-side reconciler
-	// (#2050) can match the registered steward (ADR-009 §8). Per-VM vars +
-	// secrets are substituted at render time.
+	// Render the unattended answer file (os_family dispatch): linux → preseed
+	// (#2046), windows → autounattend.xml (#2047). The per-VM CorrelationID is
+	// baked in so the controller-side reconciler (#2050) can match the registered
+	// steward (ADR-009 §8). Per-VM vars + secrets substituted at render time.
 	answerContent, renderErr := m.renderSeedAnswerFile(ctx, vmName, cfg.Source, record.CorrelationID)
 	if renderErr != nil {
 		return m.failProvision(ctx, vmName, record, fmt.Errorf("hyperv: render answer file for VM %q: %w", vmName, renderErr))
 	}
 
-	// Stage the steward binary + controller CA onto the seed for the Windows
-	// self-install path (ADR-010); the Linux/preseed path stages neither (it
-	// fetches the .deb in late_command). Empty values skip staging.
-	var stewardSrc, caSrc string
+	// Answer-file delivery is os_family-specific. Windows: the new Server 2025
+	// Setup scans DVD roots for autounattend.xml but NOT data disks, so the
+	// answer file (+ steward binary + CA) ships on a small ISO attached as a
+	// second DVD (built natively via IMAPI2). Linux: debian-installer reads the
+	// preseed from the labelled FAT32 CFGMS_SEED volume on a seed VHDX.
 	if cfg.Source.OSFamily == "windows" {
-		stewardSrc = m.enrollStewardPath
-		caSrc = m.enrollCAPath
+		isoPath := answerISOPath(vmName, cfg.VHDPath, m.seedDir)
+		if err := validateSeedPath(isoPath); err != nil {
+			return m.failProvision(ctx, vmName, record, err)
+		}
+		if _, psErr := m.transport.ExecutePS(ctx, psBuildAnswerIso, map[string]string{
+			"IsoPath":    isoPath,
+			"FileName":   seedAnswerFileName("windows"),
+			"Content":    answerContent,
+			"StewardSrc": m.enrollStewardPath,
+			"CASrc":      m.enrollCAPath,
+		}); psErr != nil {
+			recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.host, "Cfgms-BuildAnswerIso", hostName, psErr)
+			return m.failProvision(ctx, vmName, record, fmt.Errorf("hyperv: build answer ISO for VM %q: %w", vmName, psErr))
+		}
+		recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.host, "Cfgms-BuildAnswerIso", hostName, nil)
+		if _, psErr := m.transport.ExecutePS(ctx, psAttachDVD, map[string]string{
+			"Name":    hostName,
+			"ISOPath": isoPath,
+		}); psErr != nil {
+			recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.host, "Add-VMDvdDrive", hostName, psErr)
+			return m.failProvision(ctx, vmName, record, fmt.Errorf("hyperv: attach answer ISO to VM %q: %w", vmName, psErr))
+		}
+		recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.host, "Add-VMDvdDrive", hostName, nil)
+	} else {
+		seedPath := seedVHDPath(vmName, cfg.VHDPath, m.seedDir)
+		if err := validateSeedPath(seedPath); err != nil {
+			return m.failProvision(ctx, vmName, record, err)
+		}
+		if _, psErr := m.transport.ExecutePS(ctx, psNewSeedVHD, map[string]string{
+			"Path":      seedPath,
+			"SizeBytes": "268435456",
+		}); psErr != nil {
+			recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.host, "New-VHD", hostName, psErr)
+			return m.failProvision(ctx, vmName, record, fmt.Errorf("hyperv: create seed VHDX for VM %q: %w", vmName, psErr))
+		}
+		recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.host, "New-VHD", hostName, nil)
+		if _, psErr := m.transport.ExecutePS(ctx, psMountSeedVHD, map[string]string{"Path": seedPath}); psErr != nil {
+			recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.host, "Format-Volume", hostName, psErr)
+			return m.failProvision(ctx, vmName, record, fmt.Errorf("hyperv: format seed VHDX for VM %q: %w", vmName, psErr))
+		}
+		recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.host, "Format-Volume", hostName, nil)
+		if _, psErr := m.transport.ExecutePS(ctx, psCopyToSeedVHD, map[string]string{
+			"SeedPath":   seedPath,
+			"FileName":   seedAnswerFileName("linux"),
+			"Content":    answerContent,
+			"StewardSrc": "",
+			"CASrc":      "",
+		}); psErr != nil {
+			recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.host, "Set-Content", hostName, psErr)
+			return m.failProvision(ctx, vmName, record, fmt.Errorf("hyperv: write answer file to seed for VM %q: %w", vmName, psErr))
+		}
+		recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.host, "Set-Content", hostName, nil)
+		if _, psErr := m.transport.ExecutePS(ctx, psAttachSeedDisk, map[string]string{
+			"Name":     hostName,
+			"SeedPath": seedPath,
+		}); psErr != nil {
+			recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.host, "Add-VMHardDiskDrive", hostName, psErr)
+			return m.failProvision(ctx, vmName, record, fmt.Errorf("hyperv: attach seed disk to VM %q: %w", vmName, psErr))
+		}
+		recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.host, "Add-VMHardDiskDrive", hostName, nil)
 	}
-	if _, psErr := m.transport.ExecutePS(ctx, psCopyToSeedVHD, map[string]string{
-		"SeedPath":   seedPath,
-		"FileName":   seedAnswerFileName(cfg.Source.OSFamily),
-		"Content":    answerContent,
-		"StewardSrc": stewardSrc,
-		"CASrc":      caSrc,
-	}); psErr != nil {
-		recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.host, "Set-Content", hostName, psErr)
-		return m.failProvision(ctx, vmName, record, fmt.Errorf("hyperv: write answer file to seed for VM %q: %w", vmName, psErr))
-	}
-	recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.host, "Set-Content", hostName, nil)
 
-	// Attach the seed VHDX as the secondary disk.
-	if _, psErr := m.transport.ExecutePS(ctx, psAttachSeedDisk, map[string]string{
-		"Name":     hostName,
-		"SeedPath": seedPath,
-	}); psErr != nil {
-		recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.host, "Add-VMHardDiskDrive", hostName, psErr)
-		return m.failProvision(ctx, vmName, record, fmt.Errorf("hyperv: attach seed disk to VM %q: %w", vmName, psErr))
-	}
-	recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.host, "Add-VMHardDiskDrive", hostName, nil)
-
-	// Attach the install ISO as the DVD drive (host path, never repacked).
+	// Attach the install ISO as a DVD drive (host path, never repacked).
 	if _, psErr := m.transport.ExecutePS(ctx, psAttachDVD, map[string]string{
 		"Name":    hostName,
 		"ISOPath": cfg.Source.ISO,
@@ -390,11 +428,12 @@ func (m *hypervModule) provisionVM(ctx context.Context, vmName, hostName string,
 	recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.host, "Add-VMDvdDrive", hostName, nil)
 
 	// Make the install DVD the first boot device so a Gen2 VM boots the installer
-	// rather than the empty OS VHD. Gen1 uses BIOS startup order (CD precedes the
-	// IDE disk by default) and is skipped.
+	// rather than the empty OS VHD or the (bootloader-less) answer ISO. The
+	// install ISO is selected by path. Gen1 uses BIOS startup order and is skipped.
 	if generation == 2 {
 		if _, psErr := m.transport.ExecutePS(ctx, psSetDVDFirstBoot, map[string]string{
-			"Name": hostName,
+			"Name":    hostName,
+			"ISOPath": cfg.Source.ISO,
 		}); psErr != nil {
 			recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.host, "Set-VMFirmware", hostName, psErr)
 			return m.failProvision(ctx, vmName, record, fmt.Errorf("hyperv: set DVD first boot for VM %q: %w", vmName, psErr))
@@ -407,6 +446,22 @@ func (m *hypervModule) provisionVM(ctx context.Context, vmName, hostName string,
 	// controller-side reconciler (#2050) flips ready.
 	if err := m.execStartVM(ctx, vmName, hostName); err != nil {
 		return m.failProvision(ctx, vmName, record, err)
+	}
+
+	// Windows: drive the keyboard past the install media's "Press any key to
+	// boot from CD or DVD" prompt, which otherwise times out headlessly. The
+	// post-install reboots boot the OS (Windows Setup re-prioritises its own boot
+	// manager). Best-effort — a keypress failure does not fail the provision.
+	if cfg.Source.OSFamily == "windows" {
+		if _, psErr := m.transport.ExecutePS(ctx, psBootKeypress, map[string]string{"Name": hostName}); psErr != nil {
+			recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.host, "Cfgms-BootKeypress", hostName, psErr)
+			if logger, ok := m.GetLogger(); ok {
+				logger.Warn("hyperv: boot keypress failed (install may still proceed)",
+					"vm_name", logging.SanitizeLogValue(vmName))
+			}
+		} else {
+			recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.host, "Cfgms-BootKeypress", hostName, nil)
+		}
 	}
 
 	return m.advanceProvision(ctx, vmName, record, ProvisionStateInstalling)

--- a/features/modules/hyperv/vm_provision.go
+++ b/features/modules/hyperv/vm_provision.go
@@ -52,6 +52,13 @@ const (
 	// drive. The ISO is never repacked or re-signed.
 	psAttachDVD = `Add-VMDvdDrive -VMName $Name -Path $ISOPath`
 
+	// psSetDVDFirstBoot makes the install DVD the Gen2 firmware's first boot
+	// device. Without this a freshly-created Gen2 VM boots the empty OS VHD (no
+	// bootloader) instead of the installer ISO, so the unattended install never
+	// starts. Gen1 VMs use BIOS startup order (CD precedes IDE by default) and
+	// never reach this.
+	psSetDVDFirstBoot = `$dvd = Get-VMDvdDrive -VMName $Name | Select-Object -First 1; Set-VMFirmware -VMName $Name -FirstBootDevice $dvd`
+
 	// psSetVMFirmware wraps Set-VMFirmware: select the Gen2 secure-boot
 	// template. Gen1 VMs never reach this.
 	psSetVMFirmware = `Set-VMFirmware -VMName $Name -EnableSecureBoot On -SecureBootTemplate $Template`
@@ -358,6 +365,19 @@ func (m *hypervModule) provisionVM(ctx context.Context, vmName, hostName string,
 		return m.failProvision(ctx, vmName, record, fmt.Errorf("hyperv: attach install ISO to VM %q: %w", vmName, psErr))
 	}
 	recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.host, "Add-VMDvdDrive", hostName, nil)
+
+	// Make the install DVD the first boot device so a Gen2 VM boots the installer
+	// rather than the empty OS VHD. Gen1 uses BIOS startup order (CD precedes the
+	// IDE disk by default) and is skipped.
+	if generation == 2 {
+		if _, psErr := m.transport.ExecutePS(ctx, psSetDVDFirstBoot, map[string]string{
+			"Name": hostName,
+		}); psErr != nil {
+			recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.host, "Set-VMFirmware", hostName, psErr)
+			return m.failProvision(ctx, vmName, record, fmt.Errorf("hyperv: set DVD first boot for VM %q: %w", vmName, psErr))
+		}
+		recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.host, "Set-VMFirmware", hostName, nil)
+	}
 
 	// Power on and advance creating → installing. The unattended install runs
 	// inside the guest; the host-side module observes no further until the

--- a/features/modules/hyperv/vm_provision.go
+++ b/features/modules/hyperv/vm_provision.go
@@ -25,12 +25,19 @@ import (
 // maps each const to its Cfgms-* preamble function.
 
 const (
-	// psNewSeedVHD wraps New-VHD: create the empty dynamic seed disk.
-	psNewSeedVHD = `New-VHD -Path $Path -SizeBytes $SizeBytes -Dynamic | Out-Null`
+	// psNewSeedVHD ensures the seed's parent directory exists (seed_dir may be a
+	// fresh local path), then wraps New-VHD to create the empty dynamic seed disk.
+	psNewSeedVHD = `New-Item -ItemType Directory -Force -Path (Split-Path -Path $Path -Parent) | Out-Null; New-VHD -Path $Path -SizeBytes $SizeBytes -Dynamic | Out-Null`
 
 	// psMountSeedVHD wraps the Mount-VHD → Initialize-Disk → New-Partition →
-	// Format-Volume pipeline: lay a FAT32 CFGMS_SEED volume on the seed disk.
-	psMountSeedVHD = `Mount-VHD -Path $Path -Passthru | Initialize-Disk -PartitionStyle MBR -PassThru | New-Partition -UseMaximumSize -AssignDriveLetter | Format-Volume -FileSystem FAT32 -NewFileSystemLabel 'CFGMS_SEED' -Confirm:$false | Out-Null`
+	// Format-Volume pipeline: lay a FAT32 CFGMS_SEED volume on the seed disk, then
+	// Dismount-VHD. The trailing dismount is REQUIRED: Mount-VHD attaches the VHD
+	// host-wide (not process-scoped), so without it the disk stays mounted after
+	// this PS process exits and the subsequent psCopyToSeedVHD Mount-VHD fails with
+	// a sharing violation (0x80070020 "being used by another process"). The
+	// formatted volume persists on the (now-detached) VHD for the copy step to
+	// re-mount.
+	psMountSeedVHD = `Mount-VHD -Path $Path -Passthru | Initialize-Disk -PartitionStyle MBR -PassThru | New-Partition -UseMaximumSize -AssignDriveLetter | Format-Volume -FileSystem FAT32 -NewFileSystemLabel 'CFGMS_SEED' -Confirm:$false | Out-Null; Dismount-VHD -Path $Path`
 
 	// psCopyToSeedVHD mounts the seed, writes $Content to <drive>:\$FileName,
 	// optionally stages the steward binary ($StewardSrc → <drive>:\cfgms-steward.exe)
@@ -202,17 +209,29 @@ func (m *hypervModule) renderSeedAnswerFile(ctx context.Context, vmName string, 
 	return string(rendered), nil
 }
 
-// seedVHDPath derives the seed VHDX path from the VM's VHD path so the seed
-// lands in the same directory as the VM's primary disk:
-// <vhdDir>\cfgms-seed-<vmName>.vhdx. The parent directory is computed with
-// Windows path semantics (split on \ or /) rather than filepath.Dir, which is
-// OS-dependent: filepath.Dir("C:\\dir\\x.vhdx") returns "." on Linux (it does
-// not treat "\" as a separator), mangling the always-Windows Hyper-V path when
-// the steward or CI runs on a non-Windows OS (Issue #2044).
-func seedVHDPath(vmName, vhdPath string) string {
-	dir := vhdPath
-	if i := strings.LastIndexAny(vhdPath, `\/`); i >= 0 {
-		dir = vhdPath[:i]
+// seedVHDPath derives the seed VHDX path. When seedDir is set (module config
+// seed_dir) the seed lands there: <seedDir>\cfgms-seed-<vmName>.vhdx. Otherwise
+// it lands next to the VM's primary disk: <vhdDir>\cfgms-seed-<vmName>.vhdx.
+//
+// IMPORTANT: the seed must NOT live on a Cluster Shared Volume
+// (C:\ClusterStorage\...). Mount-VHD against a VHDX on a CSV hangs on a cluster
+// node (CSV redirected-I/O / cluster coordination), stalling the whole seed
+// build. The seed is ephemeral (built, attached for install, detached and
+// deleted at finalize), so seed_dir should point at a local, non-CSV directory
+// even when the VM's own VHD lives on CSV.
+//
+// The parent directory is computed with Windows path semantics (split on \ or /)
+// rather than filepath.Dir, which is OS-dependent: filepath.Dir("C:\\dir\\x.vhdx")
+// returns "." on Linux (it does not treat "\" as a separator), mangling the
+// always-Windows Hyper-V path when the steward or CI runs on a non-Windows OS
+// (Issue #2044).
+func seedVHDPath(vmName, vhdPath, seedDir string) string {
+	dir := seedDir
+	if dir == "" {
+		dir = vhdPath
+		if i := strings.LastIndexAny(vhdPath, `\/`); i >= 0 {
+			dir = vhdPath[:i]
+		}
 	}
 	dir = strings.TrimRight(dir, `\/`)
 	return dir + `\` + "cfgms-seed-" + vmName + ".vhdx"
@@ -293,7 +312,7 @@ func (m *hypervModule) provisionVM(ctx context.Context, vmName, hostName string,
 	}
 
 	// Build the seed VHDX next to the VM's primary VHD.
-	seedPath := seedVHDPath(vmName, cfg.VHDPath)
+	seedPath := seedVHDPath(vmName, cfg.VHDPath, m.seedDir)
 	if err := validateSeedPath(seedPath); err != nil {
 		return m.failProvision(ctx, vmName, record, err)
 	}
@@ -458,7 +477,7 @@ func (m *hypervModule) finalizeProvision(ctx context.Context, vmName, hostName s
 	}
 
 	// Detach the seed VHDX so the answer file is gone on the next boot.
-	seedPath := seedVHDPath(vmName, cfg.VHDPath)
+	seedPath := seedVHDPath(vmName, cfg.VHDPath, m.seedDir)
 	if vErr := validateSeedPath(seedPath); vErr != nil {
 		return m.failProvision(ctx, vmName, record, vErr)
 	}

--- a/features/modules/hyperv/vm_provision_test.go
+++ b/features/modules/hyperv/vm_provision_test.go
@@ -242,17 +242,19 @@ func TestProvisionVM_Gen2LinuxFirmwareTemplate(t *testing.T) {
 
 // ── Seed VHDX build + attach sequence ────────────────────────────────────────
 
-// TestProvisionVM_SeedVHDBuildAndAttachSequence drives an absent Gen2 windows
+// TestProvisionVM_SeedVHDBuildAndAttachSequence drives an absent Gen2 LINUX
 // VM with a source block and asserts the full seed build + media attach
 // sequence is emitted in order: New-VHD → Format-Volume (Mount) → Set-Content
-// (copy) → Add-VMHardDiskDrive (seed attach) → Add-VMDvdDrive (ISO).
+// (copy) → Add-VMHardDiskDrive (seed attach) → Add-VMDvdDrive (ISO). The seed
+// VHDX path is Linux-only; Windows delivers its answer file on an ISO (see
+// TestProvisionVM_WindowsBuildsAnswerISO).
 func TestProvisionVM_SeedVHDBuildAndAttachSequence(t *testing.T) {
 	transport := &testWinRMTransport{
 		perCallOutputs: []string{`{"found":false}`},
 	}
 	m := provisionModuleWithTransport(transport)
 
-	cfg := rawConfigState{m: sourceVMConfigMap(2, "windows")}
+	cfg := rawConfigState{m: sourceVMConfigMap(2, "linux")}
 	require.NoError(t, m.Set(context.Background(), "vm:stw-01", cfg))
 
 	transport.mu.Lock()
@@ -289,8 +291,36 @@ func TestProvisionVM_SeedVHDBuildAndAttachSequence(t *testing.T) {
 		"seed path must not be interpolated into the script text")
 
 	copy := callsContaining(calls, "Set-Content")[0]
-	assert.True(t, argsContain(copy, "autounattend.xml"),
-		"windows os_family must seed autounattend.xml")
+	assert.True(t, argsContain(copy, "preseed.cfg"),
+		"linux os_family must seed preseed.cfg")
+}
+
+// TestProvisionVM_WindowsBuildsAnswerISO asserts the Windows path delivers the
+// answer file via an ISO (the new Server 2025 Setup does not scan data disks):
+// it builds an answer ISO, attaches TWO DVDs (answer ISO + install ISO), sets
+// the install DVD first boot, and drives the boot keypress — and never builds a
+// seed VHDX.
+func TestProvisionVM_WindowsBuildsAnswerISO(t *testing.T) {
+	transport := &testWinRMTransport{perCallOutputs: []string{`{"found":false}`}}
+	m := provisionModuleWithTransport(transport)
+
+	cfg := rawConfigState{m: sourceVMConfigMap(2, "windows")}
+	require.NoError(t, m.Set(context.Background(), "vm:stw-01", cfg))
+
+	transport.mu.Lock()
+	calls := transport.calls
+	transport.mu.Unlock()
+
+	require.Len(t, callsContaining(calls, "Cfgms-BuildAnswerIso"), 1, "one answer-ISO build")
+	require.Len(t, callsContaining(calls, "Add-VMDvdDrive"), 2, "two DVDs: answer ISO + install ISO")
+	require.Len(t, callsContaining(calls, "Cfgms-BootKeypress"), 1, "one boot keypress")
+	assert.Empty(t, callsContaining(calls, "New-VHD"), "windows must NOT build a seed VHDX")
+	assert.Empty(t, callsContaining(calls, "Add-VMHardDiskDrive"), "windows attaches no seed disk")
+
+	build := callsContaining(calls, "Cfgms-BuildAnswerIso")[0]
+	assert.True(t, argsContain(build, "autounattend.xml"), "windows answer file is autounattend.xml")
+	assert.True(t, argsContain(build, `C:\ClusterStorage\CSV01\cfgms-answer-stw-01.iso`),
+		"answer ISO path derives from the VM VHD dir and travels via args")
 }
 
 // TestProvisionVM_AttachesInstallISOFromHostPath asserts the install ISO is
@@ -301,7 +331,7 @@ func TestProvisionVM_AttachesInstallISOFromHostPath(t *testing.T) {
 	}
 	m := provisionModuleWithTransport(transport)
 
-	cfg := rawConfigState{m: sourceVMConfigMap(2, "windows")}
+	cfg := rawConfigState{m: sourceVMConfigMap(2, "linux")}
 	require.NoError(t, m.Set(context.Background(), "vm:stw-01", cfg))
 
 	transport.mu.Lock()

--- a/features/modules/hyperv/vm_provision_test.go
+++ b/features/modules/hyperv/vm_provision_test.go
@@ -25,6 +25,10 @@ func provisionModuleWithTransport(transport winrmTransport) *hypervModule {
 		vms:            make(map[string]VMConfig),
 		detector:       &fakeDetector{result: true},
 		provisionStore: NewMemProvisionStore(),
+		// Controller-supplied enrollment wiring (ADR-010): both the Windows
+		// autounattend and the Linux preseed bake these in via ProfileVars.
+		enrollToken:         "reg-token-stub-value",
+		enrollCAFingerprint: "abc123fingerprint",
 	}
 	// Inject a single in-memory SecretStore carrying the keys the Linux preseed
 	// (#2046) still resolves at render time so the create-from-source tests

--- a/features/modules/hyperv/vm_provision_test.go
+++ b/features/modules/hyperv/vm_provision_test.go
@@ -421,6 +421,31 @@ func TestProvisionVM_CloudInitPath(t *testing.T) {
 	require.Len(t, callsContaining(calls, "Start-VM"), 1, "VM is powered on")
 }
 
+// TestProvisionVM_CloudInitGen1SkipsHddFirstBoot drives an absent Gen1 linux
+// cloud-image VM and asserts the cloud-init seed is still built and attached but
+// Cfgms-SetHddFirstBoot is NOT issued (Gen1 uses BIOS startup order, not UEFI
+// firmware boot device — same Gen1 contract as the install-media path).
+func TestProvisionVM_CloudInitGen1SkipsHddFirstBoot(t *testing.T) {
+	transport := &testWinRMTransport{perCallOutputs: []string{`{"found":false}`}}
+	m := provisionModuleWithTransport(transport)
+
+	cfg := rawConfigState{m: cloudInitVMConfigMap(1)}
+	require.NoError(t, m.Set(context.Background(), "vm:stw-01", cfg))
+
+	transport.mu.Lock()
+	calls := transport.calls
+	transport.mu.Unlock()
+
+	assert.Empty(t, callsContaining(calls, "Cfgms-SetHddFirstBoot"),
+		"Gen1 cloud-init VMs must not set a UEFI first boot device")
+	assert.Empty(t, callsContaining(calls, "Set-VMFirmware"),
+		"Gen1 has no secure boot / firmware step")
+	// The cloud-init seed build + boot-disk prep still happen on Gen1.
+	require.Len(t, callsContaining(calls, "Cfgms-PrepCloudBootDisk"), 1, "Gen1 still preps the cloud boot disk")
+	require.Len(t, callsContaining(calls, "New-VHD"), 1, "Gen1 still builds the CIDATA seed")
+	require.Len(t, callsContaining(calls, "Add-VMHardDiskDrive"), 1, "Gen1 still attaches the seed")
+}
+
 // TestProvision_CloudInitUserDataRenderedToSeed asserts the cloud-init path
 // writes a REAL rendered cloud-config user-data (not the placeholder) carrying the
 // controller-supplied token + CA fingerprint and the CorrelationID, with list-form
@@ -446,11 +471,15 @@ func TestProvision_CloudInitUserDataRenderedToSeed(t *testing.T) {
 	require.NotEmpty(t, userData, "rendered cloud-config user-data must be present in the copy args")
 	assert.Contains(t, userData, "runcmd", "user-data must carry runcmd")
 	assert.Contains(t, userData, "cfgms-steward", "user-data must install the steward")
+	assert.Contains(t, userData, "install", "user-data must run the steward install command")
 	assert.Contains(t, userData, "reg-token-stub-value", "controller-supplied token must be rendered into user-data")
 	assert.Contains(t, userData, "abc123fingerprint", "CA fingerprint must be rendered into user-data")
 	assert.Contains(t, userData, "stw-01", "CorrelationID must appear in the user-data")
+	// runcmd must be list/exec form (argv arrays), never shell-string composition.
+	assert.Contains(t, userData, "  - [ ", "runcmd entries must be YAML list (exec) form, not shell strings")
 	lower := strings.ToLower(userData)
-	for _, banned := range []string{"eval", "bash -c", "iex", "invoke-expression"} {
+	// CLAUDE.md banned patterns: no shell-string composition / runtime code eval.
+	for _, banned := range []string{"eval", "bash -c", "sh -c", "iex", "invoke-expression", "-encodedcommand", "python -c"} {
 		assert.NotContains(t, lower, banned, "rendered user-data must not contain banned pattern %q", banned)
 	}
 }

--- a/features/modules/hyperv/vm_provision_test.go
+++ b/features/modules/hyperv/vm_provision_test.go
@@ -26,16 +26,15 @@ func provisionModuleWithTransport(transport winrmTransport) *hypervModule {
 		detector:       &fakeDetector{result: true},
 		provisionStore: NewMemProvisionStore(),
 	}
-	// Inject a single in-memory SecretStore carrying every key both OS create
-	// paths resolve at render time so the create-from-source provisioning tests
-	// exercise the real render path (no mocks):
-	//   - Linux preseed (#2046): registration token + crypted user password
-	//   - Windows autounattend (#2047): .ppkg host path + registration token
-	// defaultRegTokenSecretKey is "hyperv/enroll/regtoken", shared by both paths.
+	// Inject a single in-memory SecretStore carrying the keys the Linux preseed
+	// (#2046) still resolves at render time so the create-from-source tests
+	// exercise the real render path (no mocks): registration token + crypted
+	// user password. The Windows autounattend (ADR-010) no longer reads secrets
+	// (token + CA fingerprint are controller-supplied ProfileVars), so it needs
+	// no store entries.
 	_ = m.SetSecretStore(newInlineStore(
 		"hyperv/enroll/regtoken", "reg-token-stub-value",
 		"hyperv/enroll/user-password-crypted", "$6$rounds=4096$stub$cryptedstub",
-		ppkgPathSecretKey, `C:\cfgms\packages\cfgms-enroll.ppkg`,
 	))
 	return m
 }

--- a/features/modules/hyperv/vm_provision_test.go
+++ b/features/modules/hyperv/vm_provision_test.go
@@ -346,6 +346,115 @@ func TestProvisionVM_AttachesInstallISOFromHostPath(t *testing.T) {
 		"ISO path must not be interpolated into the script text")
 }
 
+// ── cloud-init (Linux VM-from-cloud-image) path ──────────────────────────────
+
+// cloudInitVMConfigMap returns the executor-shaped config map for an absent
+// linux VM that boots a cloud image (source.image) via cloud-init.
+func cloudInitVMConfigMap(generation int) map[string]interface{} {
+	return map[string]interface{}{
+		"name":        "stw-01",
+		"memory_mb":   2048,
+		"cpu_count":   2,
+		"vhd_path":    `C:\VMs\stw-01.vhdx`,
+		"generation":  generation,
+		"state":       "running",
+		"switch_name": "HVSwitch_1G",
+		"source": map[string]interface{}{
+			"image":     `C:\images\debian-13-generic-amd64.raw`,
+			"os_family": "linux",
+			"resize_gb": 20,
+			"completion": map[string]interface{}{
+				"mode":    "steward-registration",
+				"timeout": "60m",
+			},
+			"on_existing": "never",
+		},
+	}
+}
+
+// TestProvisionVM_CloudInitPath drives an absent Gen2 linux VM that declares a
+// cloud image and asserts the codified cloud-init path: the boot disk is prepared
+// from the image (Cfgms-PrepCloudBootDisk) and the VM is created attaching that
+// existing disk (Cfgms-CreateVMFromDisk); a CIDATA NoCloud seed (user-data +
+// meta-data + cfgms-steward) is built and attached; the OS disk is made the first
+// boot device; and there is NO install ISO, NO answer ISO, and NO boot keypress.
+func TestProvisionVM_CloudInitPath(t *testing.T) {
+	transport := &testWinRMTransport{perCallOutputs: []string{`{"found":false}`}}
+	m := provisionModuleWithTransport(transport)
+	// The linux steward binary + CA host paths the seed stages (ADR-010).
+	m.enrollStewardPath = `C:\seed-assets\cfgms-steward-linux`
+	m.enrollCAPath = `C:\seed-assets\controller-ca.crt`
+
+	cfg := rawConfigState{m: cloudInitVMConfigMap(2)}
+	require.NoError(t, m.Set(context.Background(), "vm:stw-01", cfg))
+
+	transport.mu.Lock()
+	calls := transport.calls
+	transport.mu.Unlock()
+
+	// Boot disk prepared from the cloud image, then VM created attaching it.
+	prep := callsContaining(calls, "Cfgms-PrepCloudBootDisk")
+	require.Len(t, prep, 1, "one Cfgms-PrepCloudBootDisk (cloud image → boot VHDX)")
+	assert.True(t, argsContain(prep[0], `C:\images\debian-13-generic-amd64.raw`),
+		"cloud image path travels via args")
+	assert.True(t, argsContain(prep[0], `C:\VMs\stw-01.vhdx`), "boot VHDX path travels via args")
+	require.Len(t, callsContaining(calls, "Cfgms-CreateVMFromDisk"), 1,
+		"cloud-init VM is created attaching the existing prepared disk")
+
+	// NoCloud CIDATA seed: New-VHD → Format → Set-Content (user-data + meta-data)
+	// → Add-VMHardDiskDrive. The seed carries the steward binary too.
+	require.Len(t, callsContaining(calls, "New-VHD"), 1, "one New-VHD (CIDATA seed)")
+	require.Len(t, callsContaining(calls, "Set-Content"), 1, "one Set-Content (seed write)")
+	require.Len(t, callsContaining(calls, "Add-VMHardDiskDrive"), 1, "one seed attach")
+	copyCall := callsContaining(calls, "Set-Content")[0]
+	assert.True(t, argsContain(copyCall, "CIDATA"), "seed volume is labelled CIDATA")
+	assert.True(t, argsContain(copyCall, "user-data"), "seed carries user-data")
+	assert.True(t, argsContain(copyCall, "meta-data"), "seed carries meta-data")
+	assert.True(t, argsContain(copyCall, "cfgms-steward"), "seed stages the linux steward (dest cfgms-steward)")
+
+	// OS disk made first boot; no installer media; no keypress.
+	require.Len(t, callsContaining(calls, "Cfgms-SetHddFirstBoot"), 1,
+		"cloud-init must make the OS disk the first boot device")
+	assert.Empty(t, callsContaining(calls, "Add-VMDvdDrive"), "cloud-init attaches no install ISO")
+	assert.Empty(t, callsContaining(calls, "Cfgms-BuildAnswerIso"), "cloud-init builds no answer ISO")
+	assert.Empty(t, callsContaining(calls, "Cfgms-BootKeypress"), "cloud-init needs no boot keypress")
+	require.Len(t, callsContaining(calls, "Start-VM"), 1, "VM is powered on")
+}
+
+// TestProvision_CloudInitUserDataRenderedToSeed asserts the cloud-init path
+// writes a REAL rendered cloud-config user-data (not the placeholder) carrying the
+// controller-supplied token + CA fingerprint and the CorrelationID, with list-form
+// runcmd and no banned patterns.
+func TestProvision_CloudInitUserDataRenderedToSeed(t *testing.T) {
+	transport := &testWinRMTransport{perCallOutputs: []string{`{"found":false}`}}
+	m := provisionModuleWithTransport(transport)
+
+	cfg := rawConfigState{m: cloudInitVMConfigMap(2)}
+	require.NoError(t, m.Set(context.Background(), "vm:stw-01", cfg))
+
+	transport.mu.Lock()
+	calls := transport.calls
+	transport.mu.Unlock()
+
+	copyCall := callsContaining(calls, "Set-Content")[0]
+	var userData string
+	for _, a := range copyCall.args {
+		if s, ok := a.(string); ok && strings.Contains(s, "#cloud-config") && len(s) > len(userData) {
+			userData = s
+		}
+	}
+	require.NotEmpty(t, userData, "rendered cloud-config user-data must be present in the copy args")
+	assert.Contains(t, userData, "runcmd", "user-data must carry runcmd")
+	assert.Contains(t, userData, "cfgms-steward", "user-data must install the steward")
+	assert.Contains(t, userData, "reg-token-stub-value", "controller-supplied token must be rendered into user-data")
+	assert.Contains(t, userData, "abc123fingerprint", "CA fingerprint must be rendered into user-data")
+	assert.Contains(t, userData, "stw-01", "CorrelationID must appear in the user-data")
+	lower := strings.ToLower(userData)
+	for _, banned := range []string{"eval", "bash -c", "iex", "invoke-expression"} {
+		assert.NotContains(t, lower, banned, "rendered user-data must not contain banned pattern %q", banned)
+	}
+}
+
 // ── REQUIRED TEST: installing → finalizing detaches the seed ─────────────────
 
 // runningSourceVMJSON returns a getVM JSON response for a running VM whose

--- a/features/modules/hyperv/vm_provision_test.go
+++ b/features/modules/hyperv/vm_provision_test.go
@@ -204,12 +204,15 @@ func TestProvisionVM_Gen2WindowsFirmwareTemplate(t *testing.T) {
 	calls := transport.calls
 	transport.mu.Unlock()
 
-	fw := callsContaining(calls, "Set-VMFirmware")
-	require.Len(t, fw, 1, "Gen2 VM must call Set-VMFirmware exactly once")
+	fw := callsContaining(calls, "SecureBootTemplate")
+	require.Len(t, fw, 1, "Gen2 VM must set the secure-boot template exactly once")
 	assert.True(t, argsContain(fw[0], "MicrosoftWindows"),
 		"windows os_family must select the MicrosoftWindows template")
 	assert.NotContains(t, fw[0].scriptBlock, "MicrosoftWindows",
 		"firmware template must travel via args, not the script text")
+	// Gen2 must also make the install DVD the first boot device.
+	require.Len(t, callsContaining(calls, "FirstBootDevice"), 1,
+		"Gen2 VM must set the install DVD as the first boot device")
 }
 
 // TestProvisionVM_Gen2LinuxFirmwareTemplate asserts the linux os_family selects
@@ -227,7 +230,7 @@ func TestProvisionVM_Gen2LinuxFirmwareTemplate(t *testing.T) {
 	calls := transport.calls
 	transport.mu.Unlock()
 
-	fw := callsContaining(calls, "Set-VMFirmware")
+	fw := callsContaining(calls, "SecureBootTemplate")
 	require.Len(t, fw, 1)
 	assert.True(t, argsContain(fw[0], "MicrosoftUEFICertificateAuthority"),
 		"linux os_family must select the MicrosoftUEFICertificateAuthority template")

--- a/features/modules/hyperv/vm_test.go
+++ b/features/modules/hyperv/vm_test.go
@@ -703,6 +703,81 @@ func TestSourceConfig_Validate(t *testing.T) {
 		require.NoError(t, cfg.Validate())
 	})
 
+	// ── cloud-init (source.image) validation ──────────────────────────────
+	// validCloudInit returns a linux cloud-init source (image, no iso).
+	validCloudInit := func() *VMConfig {
+		return &VMConfig{
+			Name:    "ci-vm",
+			VHDPath: `C:\VMs\ci-vm.vhdx`,
+			Source: &SourceConfig{
+				Image:    `C:\images\debian-13-generic-amd64.raw`,
+				OSFamily: "linux",
+				ResizeGB: 20,
+				Completion: CompletionConfig{
+					Mode: "steward-registration",
+				},
+			},
+		}
+	}
+
+	t.Run("linux cloud-init image is valid", func(t *testing.T) {
+		require.NoError(t, validCloudInit().Validate())
+	})
+
+	t.Run("linux cloud-init image is detected", func(t *testing.T) {
+		assert.True(t, validCloudInit().Source.isCloudInit())
+		// A linux source with iso (not image) is NOT cloud-init.
+		legacy := validBase()
+		legacy.Source.OSFamily = "linux"
+		assert.False(t, legacy.Source.isCloudInit())
+	})
+
+	t.Run("linux with neither image nor iso", func(t *testing.T) {
+		cfg := validCloudInit()
+		cfg.Source.Image = ""
+		err := cfg.Validate()
+		require.Error(t, err)
+		assert.ErrorIs(t, err, ErrInvalidSourceMedia)
+	})
+
+	t.Run("non-absolute image path", func(t *testing.T) {
+		cfg := validCloudInit()
+		cfg.Source.Image = "images/debian.raw"
+		err := cfg.Validate()
+		require.Error(t, err)
+		assert.ErrorIs(t, err, ErrInvalidSourceImage)
+	})
+
+	t.Run("UNC image path is rejected", func(t *testing.T) {
+		cfg := validCloudInit()
+		cfg.Source.Image = `\\fileserver\share\debian.raw`
+		err := cfg.Validate()
+		require.Error(t, err)
+		assert.ErrorIs(t, err, ErrInvalidSourceImage)
+	})
+
+	t.Run("negative resize_gb is rejected", func(t *testing.T) {
+		cfg := validCloudInit()
+		cfg.Source.ResizeGB = -1
+		err := cfg.Validate()
+		require.Error(t, err)
+		assert.ErrorIs(t, err, ErrInvalidSourceResize)
+	})
+
+	t.Run("oversized resize_gb is rejected", func(t *testing.T) {
+		cfg := validCloudInit()
+		cfg.Source.ResizeGB = 100000
+		err := cfg.Validate()
+		require.Error(t, err)
+		assert.ErrorIs(t, err, ErrInvalidSourceResize)
+	})
+
+	t.Run("zero resize_gb is valid (native size)", func(t *testing.T) {
+		cfg := validCloudInit()
+		cfg.Source.ResizeGB = 0
+		require.NoError(t, cfg.Validate())
+	})
+
 	t.Run("unattend without profile:// prefix", func(t *testing.T) {
 		cfg := validBase()
 		cfg.Source.Unattend = "s3://bucket/unattend.xml"

--- a/features/modules/hyperv/windows_profile.go
+++ b/features/modules/hyperv/windows_profile.go
@@ -12,6 +12,42 @@
 // vm_provision.go for keeping the provisioning consts platform-neutral.
 package hyperv
 
+import (
+	"crypto/rand"
+	"fmt"
+)
+
+// randomAdminPassword returns a 24-character random password that satisfies
+// Windows password complexity (lower + upper + digit + symbol). It is generated
+// per VM at render time to back the Windows autounattend's one-shot AutoLogon
+// (which runs enrollment) and is never persisted or surfaced — after enrollment
+// the steward manages the host. Visually-ambiguous characters (0/O, 1/l/I) are
+// excluded. Uses crypto/rand; the first four positions guarantee one character
+// from each class so complexity is always met.
+func randomAdminPassword() (string, error) {
+	const (
+		lowers  = "abcdefghijkmnpqrstuvwxyz"
+		uppers  = "ABCDEFGHJKLMNPQRSTUVWXYZ"
+		digits  = "23456789"
+		symbols = "-_#%+="
+	)
+	classes := []string{lowers, uppers, digits, symbols}
+	all := lowers + uppers + digits + symbols
+	const n = 24
+	buf := make([]byte, n)
+	if _, err := rand.Read(buf); err != nil {
+		return "", fmt.Errorf("hyperv: read random bytes: %w", err)
+	}
+	out := make([]byte, n)
+	for i := range classes {
+		out[i] = classes[i][int(buf[i])%len(classes[i])]
+	}
+	for i := len(classes); i < n; i++ {
+		out[i] = all[int(buf[i])%len(all)]
+	}
+	return string(out), nil
+}
+
 // autounattendTemplate is the Windows Server autounattend.xml answer file
 // rendered to the seed VHDX for an os_family: windows VM (ADR-009 §6). Windows
 // Setup auto-discovers autounattend.xml from the root of attached removable
@@ -23,16 +59,24 @@ package hyperv
 //   - {{ .CorrelationID }}  correlation identity baked into RegisteredOrganization;
 //     the controller-side reconciler (#2050) matches the registered steward's
 //     mTLS CN against this value to flip the record to ready (ADR-009 §8)
-//   - {{ secret "ppkg-path-key" }} declared host path to the staged .ppkg,
-//     resolved from the secrets provider at render time — never composed at
-//     runtime, never embedded as a literal in the profile
+//   - {{ .AdminPassword }}  per-VM random Administrator password (generated at
+//     render time) used only for the one-shot AutoLogon that runs enrollment;
+//     never persisted or surfaced
+//   - {{ .EnrollToken }}    tenant join token (controller-supplied via config,
+//     ADR-010 §2 — NOT a SecretStore lookup; the #2077 fix)
+//   - {{ .CAFingerprint }}  controller CA SHA-256 for guest-side TOFU
 //
-// Enrollment runs first-boot via <FirstLogonCommands>: a cmd.exe /c copy of the
-// staged .ppkg to a local temp path followed by dism.exe /online /add-package.
-// Both commands use explicit, quoted, declared paths and fixed argument lists —
-// no iex / Invoke-Expression, no powershell -Command "<string>", no
-// -EncodedCommand, no runtime code composition (CLAUDE.md banned patterns,
-// ADR-009 §6).
+// Enrollment runs first-boot via <FirstLogonCommands>: an AutoLogon of the local
+// Administrator triggers a single cmd.exe /c command that locates the FAT32
+// CFGMS_SEED volume (staged with cfgms-steward.exe + controller-ca.crt next to
+// autounattend.xml) and runs `cfgms-steward install --regtoken … --ca-cert …
+// --fingerprint …`, which self-copies the binary to the platform path and
+// registers as a service. The steward's controller URL is baked in at build
+// time (ldflags). A fixed argument list with declared paths — no iex /
+// Invoke-Expression, no powershell -Command "<string>", no -EncodedCommand, no
+// runtime code composition (CLAUDE.md banned patterns, ADR-009 §6). The seed
+// (which briefly holds the low-value token) is detached at finalizing and
+// deleted on enrollment (ADR-010 §5, #2081).
 const autounattendTemplate = `<?xml version="1.0" encoding="utf-8"?>
 <unattend xmlns="urn:schemas-microsoft-com:unattend">
   <settings pass="windowsPE">
@@ -116,6 +160,21 @@ const autounattendTemplate = `<?xml version="1.0" encoding="utf-8"?>
       <UserLocale>en-US</UserLocale>
     </component>
     <component name="Microsoft-Windows-Shell-Setup" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
+      <UserAccounts>
+        <AdministratorPassword>
+          <Value>{{ .AdminPassword }}</Value>
+          <PlainText>true</PlainText>
+        </AdministratorPassword>
+      </UserAccounts>
+      <AutoLogon>
+        <Password>
+          <Value>{{ .AdminPassword }}</Value>
+          <PlainText>true</PlainText>
+        </Password>
+        <Enabled>true</Enabled>
+        <LogonCount>1</LogonCount>
+        <Username>Administrator</Username>
+      </AutoLogon>
       <OOBE>
         <HideEULAPage>true</HideEULAPage>
         <HideOEMRegistrationScreen>true</HideOEMRegistrationScreen>
@@ -126,13 +185,8 @@ const autounattendTemplate = `<?xml version="1.0" encoding="utf-8"?>
       <FirstLogonCommands>
         <SynchronousCommand wcm:action="add" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State">
           <Order>1</Order>
-          <Description>Stage CFGMS enrollment provisioning package</Description>
-          <CommandLine>cmd.exe /c copy /Y "{{ secret "ppkg-path-key" }}" "C:\Windows\Temp\cfgms-enroll.ppkg"</CommandLine>
-        </SynchronousCommand>
-        <SynchronousCommand wcm:action="add" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State">
-          <Order>2</Order>
-          <Description>Apply CFGMS enrollment provisioning package</Description>
-          <CommandLine>dism.exe /online /add-package /packagepath:"C:\Windows\Temp\cfgms-enroll.ppkg" /quiet /norestart</CommandLine>
+          <Description>Install and enroll the CFGMS steward from the seed volume</Description>
+          <CommandLine>cmd.exe /c for %i in (D E F G H I J K) do @if exist "%i:\cfgms-steward.exe" "%i:\cfgms-steward.exe" install --regtoken "{{ .EnrollToken }}" --ca-cert "%i:\controller-ca.crt" --fingerprint "{{ .CAFingerprint }}"</CommandLine>
         </SynchronousCommand>
       </FirstLogonCommands>
     </component>
@@ -140,33 +194,13 @@ const autounattendTemplate = `<?xml version="1.0" encoding="utf-8"?>
 </unattend>
 `
 
-// setupCompleteTemplate is the file-staged SetupComplete.cmd enrollment fallback
-// for Windows guests (ADR-009 §6). It is rendered ONLY when a profile sets
-// enroll.use_setup_complete: true; the default Windows path enrolls via the
-// signed .ppkg applied at first logon. The template contains a single
-// declared-path cfgms-steward enroll invocation with a fixed argument list and
-// no runtime composition — no iex, no powershell -Command "<string>", no
-// -EncodedCommand.
-//
-// Template vars:
-//   - {{ .EnrollToken }}   resolved registration token (supplied pre-resolved)
-//   - {{ .CorrelationID }} steward enrollment label the controller matches on
-//   - {{ .BundleURL }}     enrollment-bundle location the steward pulls from
-const setupCompleteTemplate = `@echo off
-"C:\Program Files\CFGMS\cfgms-steward.exe" enroll --token "{{ .EnrollToken }}" --bundle-url "{{ .BundleURL }}" --label "{{ .CorrelationID }}"
-`
-
 // defaultWindowsProfile returns the built-in Windows Server unattended-install
 // profile used when an os_family: windows source declares no explicit
-// profile:// reference. It carries the autounattend template and an enroll block
-// referencing the .ppkg host-path secret key. It mirrors the Linux analog used
-// by the create-from-source path: a code-resident default that operators can
-// override with a stored profile (ADR-009 §7).
-//
-// The .ppkg is a host-path staged asset referenced via the secrets provider at
-// render time (ppkgPathSecretKey) — its signing infrastructure is out of scope
-// (#1851 PO decision #3); an unsigned/self-signed package behind
-// module_trust.mode: bypass is acceptable for lab/dogfood.
+// profile:// reference. It carries the autounattend template that self-installs
+// the steward from the seed volume (ADR-010) and mirrors the Linux analog: a
+// code-resident default that operators can override with a stored profile
+// (ADR-009 §7). The join token and CA fingerprint are controller-supplied via
+// config (ProfileVars), not the local SecretStore (#2077 fix).
 func defaultWindowsProfile() *UnattendProfile {
 	return &UnattendProfile{
 		Name:         defaultWindowsProfileName,
@@ -183,14 +217,9 @@ const (
 	// defaultWindowsProfileName is the name of the built-in Windows profile.
 	defaultWindowsProfileName = "windows-server-default"
 
-	// ppkgPathSecretKey is the secrets-provider key the autounattend template
-	// resolves to obtain the declared host path of the staged .ppkg. It matches
-	// the {{ secret "ppkg-path-key" }} reference in autounattendTemplate.
-	ppkgPathSecretKey = "ppkg-path-key"
-
-	// defaultRegTokenSecretKey is the conventional secrets-provider key under
-	// which the enrollment registration token is stored when a profile does not
-	// override it.
+	// defaultRegTokenSecretKey is retained as profile metadata for operators who
+	// author a SecretStore-backed profile; the built-in template resolves the
+	// token from controller-supplied config ({{ .EnrollToken }}), not this key.
 	defaultRegTokenSecretKey = "hyperv/enroll/regtoken"
 
 	// defaultWindowsEdition is the Windows Server image name selected by the

--- a/features/modules/hyperv/windows_profile.go
+++ b/features/modules/hyperv/windows_profile.go
@@ -97,21 +97,16 @@ const autounattendTemplate = `<?xml version="1.0" encoding="utf-8"?>
           <CreatePartitions>
             <CreatePartition wcm:action="add">
               <Order>1</Order>
-              <Type>Primary</Type>
-              <Size>500</Size>
+              <Type>EFI</Type>
+              <Size>200</Size>
             </CreatePartition>
             <CreatePartition wcm:action="add">
               <Order>2</Order>
-              <Type>EFI</Type>
-              <Size>100</Size>
-            </CreatePartition>
-            <CreatePartition wcm:action="add">
-              <Order>3</Order>
               <Type>MSR</Type>
               <Size>128</Size>
             </CreatePartition>
             <CreatePartition wcm:action="add">
-              <Order>4</Order>
+              <Order>3</Order>
               <Type>Primary</Type>
               <Extend>true</Extend>
             </CreatePartition>
@@ -119,9 +114,16 @@ const autounattendTemplate = `<?xml version="1.0" encoding="utf-8"?>
           <ModifyPartitions>
             <ModifyPartition wcm:action="add">
               <Order>1</Order>
-              <PartitionID>4</PartitionID>
+              <PartitionID>1</PartitionID>
+              <Label>System</Label>
+              <Format>FAT32</Format>
+            </ModifyPartition>
+            <ModifyPartition wcm:action="add">
+              <Order>2</Order>
+              <PartitionID>3</PartitionID>
               <Label>Windows</Label>
               <Format>NTFS</Format>
+              <Letter>C</Letter>
             </ModifyPartition>
           </ModifyPartitions>
         </Disk>
@@ -130,7 +132,7 @@ const autounattendTemplate = `<?xml version="1.0" encoding="utf-8"?>
         <OSImage>
           <InstallTo>
             <DiskID>0</DiskID>
-            <PartitionID>4</PartitionID>
+            <PartitionID>3</PartitionID>
           </InstallTo>
           <InstallFrom>
             <MetaData wcm:action="add" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State">

--- a/features/modules/hyperv/windows_profile_test.go
+++ b/features/modules/hyperv/windows_profile_test.go
@@ -13,8 +13,8 @@ import (
 )
 
 // bannedPatterns are the runtime-code-composition markers that must never appear
-// in a rendered Windows answer file or enrollment script (CLAUDE.md banned
-// patterns, ADR-009 §6). The scan is case-insensitive.
+// in a rendered Windows answer file (CLAUDE.md banned patterns, ADR-009 §6). The
+// scan is case-insensitive.
 var bannedPatterns = []string{
 	"iex",
 	"invoke-expression",
@@ -36,10 +36,12 @@ func assertNoBannedPatterns(t *testing.T, rendered string) {
 }
 
 // renderWindowsAutounattend renders the default Windows profile's autounattend
-// template with a real in-memory secret store supplying the .ppkg host path.
+// template. The template self-installs the steward from the seed volume and
+// reads the join token / CA fingerprint from controller-supplied ProfileVars
+// (ADR-010), so no SecretStore entries are required — an empty store suffices.
 func renderWindowsAutounattend(t *testing.T, vars ProfileVars) string {
 	t.Helper()
-	store := newInlineStore(ppkgPathSecretKey, `C:\cfgms\packages\cfgms-enroll.ppkg`)
+	store := newInlineStore()
 	out, err := NewProfileRenderer().Render(context.Background(), defaultWindowsProfile(), vars, store)
 	require.NoError(t, err)
 	return string(out)
@@ -54,6 +56,9 @@ func TestAutounattend_TemplateRendersValidXML(t *testing.T) {
 		OSFamily:       "windows",
 		CorrelationID:  "stw-win-01",
 		ProductEdition: defaultWindowsEdition,
+		AdminPassword:  "Aa3-Bb4-Cc5-Dd6-Ee7",
+		EnrollToken:    "tok-abc",
+		CAFingerprint:  "AB12CD34",
 	})
 
 	// Parse the full document with encoding/xml: any malformed markup (unbalanced
@@ -71,45 +76,67 @@ func TestAutounattend_TemplateRendersValidXML(t *testing.T) {
 }
 
 // TestAutounattend_NoBannedPatterns is the REQUIRED TEST: scans the rendered
-// autounattend output for iex, -EncodedCommand, Invoke-Expression, and
-// powershell -Command and asserts none are present. The enrollment path uses
-// cmd.exe /c copy + dism.exe with explicit quoted declared paths only.
+// autounattend output for runtime-composition markers and asserts the
+// declared-path self-install enrollment command is present.
 func TestAutounattend_NoBannedPatterns(t *testing.T) {
 	rendered := renderWindowsAutounattend(t, ProfileVars{
 		VMName:         "WIN-02",
 		OSFamily:       "windows",
 		CorrelationID:  "stw-win-02",
 		ProductEdition: defaultWindowsEdition,
+		EnrollToken:    "tok-def",
+		CAFingerprint:  "FF99",
 	})
 
 	assertNoBannedPatterns(t, rendered)
 
-	// Positive assertions: the declared-path enrollment commands are present.
-	assert.Contains(t, rendered, "cmd.exe /c copy",
-		"enrollment must copy the .ppkg via cmd.exe /c copy with explicit paths")
-	assert.Contains(t, rendered, "dism.exe /online /add-package",
-		"enrollment must apply the .ppkg via dism.exe /online /add-package")
+	// Positive assertions: the declared-path self-install enrollment command is
+	// present (locate the seed volume, run cfgms-steward install).
+	assert.Contains(t, rendered, `cfgms-steward.exe" install --regtoken`,
+		"enrollment must self-install the steward via install --regtoken")
+	assert.Contains(t, rendered, "--ca-cert",
+		"enrollment must pass the staged controller CA via --ca-cert")
+	assert.Contains(t, rendered, "--fingerprint",
+		"enrollment must pass the CA fingerprint via --fingerprint")
 }
 
-// TestAutounattend_SubstitutesCorrelationIDAndPpkg confirms the per-VM
-// CorrelationID and the secrets-provided .ppkg path are substituted into the
-// rendered output, and the secret KEY name never leaks.
-func TestAutounattend_SubstitutesCorrelationIDAndPpkg(t *testing.T) {
+// TestAutounattend_AutoLogonAndAdminPassword guards that the one-shot AutoLogon
+// and Administrator password (which let FirstLogonCommands run unattended) are
+// rendered, and that the random password substitutes via {{ .AdminPassword }}.
+func TestAutounattend_AutoLogonAndAdminPassword(t *testing.T) {
+	rendered := renderWindowsAutounattend(t, ProfileVars{
+		VMName:         "WIN-05",
+		OSFamily:       "windows",
+		CorrelationID:  "stw-win-05",
+		ProductEdition: defaultWindowsEdition,
+		AdminPassword:  "Zz9-Yy8-Xx7-Ww6",
+	})
+	assert.Contains(t, rendered, "<AutoLogon>", "autologon must be configured so first-logon enrollment runs")
+	assert.Contains(t, rendered, "<AdministratorPassword>", "an administrator password must be set to clear OOBE")
+	assert.Contains(t, rendered, "Zz9-Yy8-Xx7-Ww6", "AdminPassword must substitute into the answer file")
+}
+
+// TestAutounattend_SubstitutesCorrelationAndEnrollVars confirms the per-VM
+// CorrelationID, join token, and CA fingerprint are substituted into the
+// rendered output.
+func TestAutounattend_SubstitutesCorrelationAndEnrollVars(t *testing.T) {
 	rendered := renderWindowsAutounattend(t, ProfileVars{
 		VMName:         "WIN-03",
 		OSFamily:       "windows",
 		CorrelationID:  "stw-win-03",
 		ProductEdition: defaultWindowsEdition,
+		EnrollToken:    "join-tok-77",
+		CAFingerprint:  "DEADBEEF",
 	})
 
 	assert.Contains(t, rendered, "<ComputerName>WIN-03</ComputerName>",
 		"VMName must render as the guest ComputerName")
 	assert.Contains(t, rendered, "stw-win-03",
 		"CorrelationID must appear (RegisteredOrganization/Organization) for controller-side matching")
-	assert.Contains(t, rendered, `C:\cfgms\packages\cfgms-enroll.ppkg`,
-		".ppkg host path must be substituted from the secrets provider")
-	assert.NotContains(t, rendered, ppkgPathSecretKey,
-		"the raw secret key name must never appear in rendered output")
+	assert.Contains(t, rendered, `--regtoken "join-tok-77"`,
+		"join token must be substituted from controller-supplied config")
+	assert.Contains(t, rendered, `--fingerprint "DEADBEEF"`,
+		"CA fingerprint must be substituted")
 	assert.Contains(t, rendered, defaultWindowsEdition,
 		"ProductEdition must render into the image-install step")
 }
@@ -131,48 +158,6 @@ func TestAutounattend_CorrelationIDIsTemplateVar(t *testing.T) {
 	assert.NotContains(t, b, "corr-AAA")
 }
 
-// TestSetupComplete_RendersDeclaredPathEnroll is the REQUIRED TEST for the
-// fallback: SetupComplete.cmd renders a single declared-path cfgms-steward
-// enroll invocation with the token/label/bundle substituted and no banned
-// patterns.
-func TestSetupComplete_RendersDeclaredPathEnroll(t *testing.T) {
-	store := newInlineStore()
-	profile := defaultWindowsProfile()
-	profile.Enroll.BundleURL = "https://controller.example/enroll"
-
-	scProfile := &UnattendProfile{
-		Name:         profile.Name,
-		OSFamily:     "windows",
-		AnswerFormat: AnswerFormatAutounattend,
-		Template:     setupCompleteTemplate,
-		Enroll:       profile.Enroll,
-	}
-	out, err := NewProfileRenderer().Render(context.Background(), scProfile, ProfileVars{
-		VMName:        "WIN-04",
-		OSFamily:      "windows",
-		CorrelationID: "stw-win-04",
-		EnrollToken:   "tok-xyz",
-		BundleURL:     profile.Enroll.BundleURL,
-	}, store)
-	require.NoError(t, err)
-	rendered := string(out)
-
-	assert.Contains(t, rendered, `cfgms-steward.exe" enroll`,
-		"SetupComplete.cmd must invoke cfgms-steward enroll via a declared exe path")
-	assert.Contains(t, rendered, `--token "tok-xyz"`, "token must be substituted")
-	assert.Contains(t, rendered, `--label "stw-win-04"`, "correlation label must be substituted")
-	assert.Contains(t, rendered, `--bundle-url "https://controller.example/enroll"`, "bundle url must be substituted")
-	assertNoBannedPatterns(t, rendered)
-}
-
-// TestSetupComplete_OnlyWhenUseSetupCompleteEnabled asserts the SetupComplete.cmd
-// fallback is gated on enroll.use_setup_complete: by default the Windows profile
-// does not request it (the .ppkg is the primary enrollment mechanism).
-func TestSetupComplete_OnlyWhenUseSetupCompleteEnabled(t *testing.T) {
-	assert.False(t, defaultWindowsProfile().Enroll.UseSetupComplete,
-		"default Windows profile must enroll via the .ppkg, not the SetupComplete.cmd fallback")
-}
-
 // TestDefaultWindowsProfile_Shape confirms the built-in profile carries the
 // autounattend format and template and validates structurally.
 func TestDefaultWindowsProfile_Shape(t *testing.T) {
@@ -183,10 +168,27 @@ func TestDefaultWindowsProfile_Shape(t *testing.T) {
 	require.NoError(t, p.validate())
 }
 
+// TestRandomAdminPassword_ComplexAndUnique checks the generated password meets
+// Windows complexity (4 character classes) and differs across calls.
+func TestRandomAdminPassword_ComplexAndUnique(t *testing.T) {
+	seen := map[string]bool{}
+	for i := 0; i < 50; i++ {
+		pw, err := randomAdminPassword()
+		require.NoError(t, err)
+		require.Len(t, pw, 24)
+		assert.False(t, seen[pw], "passwords must be unique across calls")
+		seen[pw] = true
+		assert.True(t, strings.ContainsAny(pw, "abcdefghijkmnpqrstuvwxyz"), "needs a lowercase")
+		assert.True(t, strings.ContainsAny(pw, "ABCDEFGHJKLMNPQRSTUVWXYZ"), "needs an uppercase")
+		assert.True(t, strings.ContainsAny(pw, "23456789"), "needs a digit")
+		assert.True(t, strings.ContainsAny(pw, "-_#%+="), "needs a symbol")
+	}
+}
+
 // TestRenderSeedAnswerFile_WindowsRendersAutounattend exercises the module-level
 // wiring: the create-from-source path resolves the default Windows profile and
 // renders a real autounattend (not the placeholder), with the CorrelationID
-// baked in.
+// baked in and a generated AdminPassword present.
 func TestRenderSeedAnswerFile_WindowsRendersAutounattend(t *testing.T) {
 	m := provisionModuleWithTransport(&testWinRMTransport{})
 	src := &SourceConfig{ISO: `C:\iso\ws2025.iso`, OSFamily: "windows"}
@@ -195,6 +197,7 @@ func TestRenderSeedAnswerFile_WindowsRendersAutounattend(t *testing.T) {
 	require.NoError(t, err)
 	assert.Contains(t, content, "<ComputerName>stw-win-09</ComputerName>")
 	assert.Contains(t, content, "stw-win-09")
+	assert.Contains(t, content, "<AutoLogon>", "module render must include the one-shot autologon")
 	assert.NotContains(t, content, "placeholder autounattend")
 	assertNoBannedPatterns(t, content)
 }

--- a/features/steward/execution/execution.go
+++ b/features/steward/execution/execution.go
@@ -125,15 +125,19 @@ func (g *genericConfigState) GetManagedFields() []string {
 	// and `tenant_id`; future modules may add their own) plumbs them in
 	// through resource.config and consumes them at Configure-time only.
 	excludedFields := map[string]bool{
-		"path":              true, // resourceID, not state
-		"name":              true, // resource identifier
-		"transport":         true, // module operational: which client to use
-		"tenant_id":         true, // module operational: namespace prefix
-		"steward_id":        true, // module operational: audit subject
-		"audit_manager":     true, // module operational: pointer, never serialised
-		"winrm_host":        true, // module operational: WinRM endpoint
-		"winrm_user_secret": true, // module operational: SecretStore key
-		"winrm_pass_secret": true, // module operational: SecretStore key
+		"path":                  true, // resourceID, not state
+		"name":                  true, // resource identifier
+		"transport":             true, // module operational: which client to use
+		"tenant_id":             true, // module operational: namespace prefix
+		"steward_id":            true, // module operational: audit subject
+		"audit_manager":         true, // module operational: pointer, never serialised
+		"winrm_host":            true, // module operational: WinRM endpoint
+		"winrm_user_secret":     true, // module operational: SecretStore key
+		"winrm_pass_secret":     true, // module operational: SecretStore key
+		"enroll_token":          true, // module operational: hyperv create-from-source join token (ADR-010)
+		"enroll_ca_fingerprint": true, // module operational: controller CA fingerprint for guest TOFU
+		"enroll_steward_path":   true, // module operational: host path to steward binary staged on seed
+		"enroll_ca_path":        true, // module operational: host path to CA cert staged on seed
 	}
 
 	fields := make([]string, 0, len(g.data))

--- a/features/steward/execution/execution.go
+++ b/features/steward/execution/execution.go
@@ -138,6 +138,7 @@ func (g *genericConfigState) GetManagedFields() []string {
 		"enroll_ca_fingerprint": true, // module operational: controller CA fingerprint for guest TOFU
 		"enroll_steward_path":   true, // module operational: host path to steward binary staged on seed
 		"enroll_ca_path":        true, // module operational: host path to CA cert staged on seed
+		"seed_dir":              true, // module operational: local dir for the provisioning seed VHDX
 	}
 
 	fields := make([]string, 0, len(g.data))


### PR DESCRIPTION
## Summary

Completes the **bare hypervisor → installed OS → enrolled steward → managed endpoint** path for a `hyperv.vm` resource, driven entirely by `cfg config push`, for **both** Windows and Linux. A `source` block on a `hyperv.vm` turns convergence into an unattended OS install that self-enrolls with the controller.

Two OS paths, each idiomatic:

- **Windows** — `source.iso` + autounattend. The new Server 2025 Setup ignores answer files on data disks, so the rendered `autounattend.xml` (+ steward binary + CA) ships on a small **module-built ISO** (IMAPI2, host-native — no ADK/oscdimg) attached as a second DVD; a headless boot keypress clears the "press any key to boot from CD" prompt; the disk layout formats the ESP for UEFI.
- **Linux** — `source.image` + **cloud-init/NoCloud** (the default/recommended Linux path). Boots a prebuilt vendor **cloud image** and enrolls via a NoCloud `CIDATA` seed instead of a netinst installer. The legacy netinst+preseed path remains available via `source.iso` for air-gapped/ISO-only sites.

## Why cloud-init for Linux (not netinst+preseed)

An unattended debian-installer needs its **kernel command line** to point at the preseed, and headless the only ways to set it are repacking the boot media (breaks the signed shim under Secure Boot — needs `xorriso`, which isn't a winget/choco package, and **WSL can't run as `LocalSystem`**, which the steward is) or typing it via the emulated keyboard (too fragile). cloud-init sidesteps all of it: the cloud image's **signed bootloader is never modified** and cloud-init **auto-detects the `CIDATA` seed by volume label** — no kernel cmdline, no repack, Secure Boot intact.

Host-native, **zero new external tool**: raw cloud image → fixed-VHD footer (computed in PowerShell) → dynamic VHDX via the in-box `Convert-VHD` (no qemu-img/xorriso/WSL). The CIDATA seed reuses the existing host-native seed-VHDX machinery. user-data `runcmd` is **list/exec form only** (no shell-string composition → no CLAUDE.md banned patterns); the join token + CA fingerprint are controller-supplied via config (ADR-010), not a SecretStore lookup.

## Validated live on cfg-lab (CFG-70-02), pure `cfg config push`

- **Windows**: `cfgms-win-02` created from the Server 2025 eval ISO → enrolled → **active**.
- **Linux**: `cfgms-deb-ci-02` created from the Debian 13 `generic` cloud image by the codified module → enrolled → **active**.

## Changes

- Schema: `source.image` (.raw/.vhdx cloud image) + `source.resize_gb`; linux accepts image (cloud-init) OR iso (legacy preseed); windows requires iso. UNC image rejected; resize bounded.
- `createVM` branches to prep the cloud boot disk and attach it (`New-VM -VHDPath`); `provisionCloudInit` builds the CIDATA seed, sets UEFI-CA secure boot, makes the OS disk first boot (fails loudly if not matched), no install ISO / keypress.
- New PowerShell preamble funcs (`Cfgms-PrepCloudBootDisk`, `Cfgms-VhdFixedFooter`, `Cfgms-CreateVMFromDisk`, `Cfgms-SetHddFirstBoot`) + parameterized seed funcs; the WinRM-transport const text kept at parameter-contract parity.
- Docs: README cloud-init section + schema; ADR-009 §6a documents the cloud-init Linux decision.

## Review (pre-PR, parallel adversarial)

- **QA**: PASS — found 5 blocking + 3 warnings on first pass (WinRM const-text parity, dispatch test-mirror drift, silent first-boot fallback, missing tests); all fixed; re-review confirmed **0 blocking**.
- **Security**: PASS — 0 blocking (3 LOW hardening notes addressed: resize bound, UNC guard). Banned patterns clean, all values via ArgumentList, no secret logging, `check-architecture` clean.
- **Acceptance**: PASS — 21/21 criteria realized.
- `make test-complete` and `make check-architecture`: green.

Fixes #2080

🤖 Generated with [Claude Code](https://claude.com/claude-code)