### PR TITLE
test: close controller stack before TempDir cleanup on Windows (Issue #1923)

### DIFF
--- a/test/unit/controller/module_test.go
+++ b/test/unit/controller/module_test.go
@@ -39,6 +39,18 @@ func newTestController(t *testing.T) *controller.Controller {
 	logger := unit.NewTestLogger(t)
 	ctrl, err := controller.New(cfg, logger)
 	require.NoError(t, err)
+
+	// Close the controller stack before the deferred t.TempDir() cleanup runs.
+	// t.Cleanup callbacks run LIFO and before TempDir removal, so closing here
+	// releases the SQLite file handle and avoids the Windows "file is being used
+	// by another process" unlink error during TempDir cleanup (#1923). Cleanup
+	// errors are secondary to the test outcome, so log rather than fail.
+	t.Cleanup(func() {
+		if cerr := ctrl.Close(); cerr != nil {
+			t.Logf("newTestController: controller close during cleanup: %v", cerr)
+		}
+	})
+
 	return ctrl
 }
 


### PR DESCRIPTION
## Summary

`TestModuleInterface` and `TestModuleCustomBehavior` in `test/unit/controller/module_test.go` failed on Windows during `t.TempDir()` cleanup with *"The process cannot access the file because it is being used by another process"* — the SQLite handle opened by the controller stack was still open when the deferred TempDir removal ran.

`newTestController` now registers `t.Cleanup(func() { ctrl.Close() })` immediately after `controller.New(...)`. `t.Cleanup` callbacks run LIFO and before `t.TempDir()` removal, so the SQLite handle is released first. Registering it inside the helper covers both tests with no per-test boilerplate.

## Changes made

- `test/unit/controller/module_test.go`: `newTestController` registers a `t.Cleanup` that closes the controller stack; close errors are logged via `t.Logf` (cleanup errors are secondary to the test outcome), not `t.Fatal`.

## Test results

- Failure reproduced **deterministically** on the Windows host before the fix.
- After the fix: `TestModuleInterface` and `TestModuleCustomBehavior` pass under `go test -race -short -count=3`.
- Full `./test/unit/controller` package passes under `-race`.
- `go build ./...`, `go vet ./test/unit/controller/`, and `gofmt` all clean.
- Test-only change; no production code paths touched (per story Out of Scope).

## Adversarial review (story-complete team — all PASS)

- **Acceptance check**: PASS — all AC code references verified; scope confirmed (exactly 1 file).
- **QA test-quality**: PASS — package green under `-race`, build/vet/fmt clean.
- **QA code review**: PASS — appropriate `t.Logf` teardown handling, no double-close (only call site closes once per test), no masked assertions.
- **Security review**: PASS — `make check-architecture` clean, no central-provider violations, no secrets.

## CI / host caveats

This work was done and validated on the Windows e2e host. `golangci-lint`, `gitleaks`/`truffleHog`, and the gosec/Trivy/Nancy scanners are not installed on that host, so `make lint` and the secret/security scans run in CI rather than locally; `go vet`/`gofmt`/`make check-architecture` were used locally. CI's `security-deployment-gate` and lint check enforce the rest.

While running `make test` on the Windows host, a **pre-existing, unrelated** failure surfaced in `pkg/security` (`TestValidateAndCleanPath/directory_traversal_with_absolute_path` — Windows ACL on `C:\Windows\System32\config\sam`). It is independent of this story (different package, untouched by this diff) and is now tracked separately as **#2120**.

Fixes #1923

Co-Authored-By: Claude <noreply@anthropic.com>