### PR TITLE
initialization: include transport external_address in cert SAN list (Issue #2017)

### DIFF
--- a/features/controller/initialization/transport_sans.go
+++ b/features/controller/initialization/transport_sans.go
@@ -23,6 +23,8 @@ import (
 //     certificate.internal.ip_addresses), if set
 //   - the CFGMS_EXTERNAL_HOSTNAME env value, classified as IP SAN if it parses
 //     as an IP literal and DNS SAN otherwise
+//   - cfg.Transport.ExternalAddress, classified the same way (both sources are
+//     honored and de-duped; neither overrides the other)
 //
 // Without merging in cfg.Certificate.Server and CFGMS_EXTERNAL_HOSTNAME, a
 // steward dialing the controller by its external hostname fails mTLS
@@ -54,6 +56,16 @@ func TransportCertSANs(cfg *config.Config) (dnsNames, ipAddresses []string) {
 			ipAddresses = append(ipAddresses, hostname)
 		} else {
 			dnsNames = append(dnsNames, hostname)
+		}
+	}
+
+	if cfg != nil && cfg.Transport != nil {
+		if addr := strings.TrimSpace(cfg.Transport.ExternalAddress); addr != "" {
+			if net.ParseIP(addr) != nil {
+				ipAddresses = append(ipAddresses, addr)
+			} else {
+				dnsNames = append(dnsNames, addr)
+			}
 		}
 	}
 

--- a/features/controller/initialization/transport_sans_test.go
+++ b/features/controller/initialization/transport_sans_test.go
@@ -77,6 +77,67 @@ func TestTransportCertSANs_InternalAndServerMerge(t *testing.T) {
 	assert.Contains(t, ipAddresses, "10.0.0.2")
 }
 
+func TestTransportCertSANs_ConfigExternalAddressHostname(t *testing.T) {
+	t.Setenv("CFGMS_EXTERNAL_HOSTNAME", "")
+
+	cfg := &config.Config{
+		Transport: &config.TransportConfig{
+			ExternalAddress: "controller.example.com",
+		},
+	}
+
+	dnsNames, ipAddresses := TransportCertSANs(cfg)
+	assert.Contains(t, dnsNames, "controller.example.com", "config external_address hostname must appear in DNS SANs")
+	assert.NotContains(t, ipAddresses, "controller.example.com", "hostname must not appear in IP SANs")
+}
+
+func TestTransportCertSANs_ConfigExternalAddressIP(t *testing.T) {
+	t.Setenv("CFGMS_EXTERNAL_HOSTNAME", "")
+
+	cfg := &config.Config{
+		Transport: &config.TransportConfig{
+			ExternalAddress: "203.0.113.42",
+		},
+	}
+
+	dnsNames, ipAddresses := TransportCertSANs(cfg)
+	assert.Contains(t, ipAddresses, "203.0.113.42", "config external_address IP must appear in IP SANs")
+	assert.NotContains(t, dnsNames, "203.0.113.42", "IP-literal must not appear in DNS SANs")
+}
+
+func TestTransportCertSANs_EnvVarAndConfigBothAdded(t *testing.T) {
+	t.Setenv("CFGMS_EXTERNAL_HOSTNAME", "env-controller.example.com")
+
+	cfg := &config.Config{
+		Transport: &config.TransportConfig{
+			ExternalAddress: "cfg-controller.example.com",
+		},
+	}
+
+	dnsNames, _ := TransportCertSANs(cfg)
+	assert.Contains(t, dnsNames, "env-controller.example.com", "env var hostname must appear in DNS SANs")
+	assert.Contains(t, dnsNames, "cfg-controller.example.com", "config external_address hostname must appear in DNS SANs")
+}
+
+func TestTransportCertSANs_NoDuplicatesWhenEnvAndConfigMatch(t *testing.T) {
+	t.Setenv("CFGMS_EXTERNAL_HOSTNAME", "shared-controller.example.com")
+
+	cfg := &config.Config{
+		Transport: &config.TransportConfig{
+			ExternalAddress: "shared-controller.example.com",
+		},
+	}
+
+	dnsNames, _ := TransportCertSANs(cfg)
+	count := 0
+	for _, n := range dnsNames {
+		if n == "shared-controller.example.com" {
+			count++
+		}
+	}
+	assert.Equal(t, 1, count, "same value from env and config must be de-duped to a single SAN entry")
+}
+
 func TestTransportCertSANs_DedupesAndPreservesOrder(t *testing.T) {
 	t.Setenv("CFGMS_EXTERNAL_HOSTNAME", "localhost")
 


### PR DESCRIPTION
## Summary

- `TransportCertSANs` now reads `cfg.Transport.ExternalAddress` in addition to `CFGMS_EXTERNAL_HOSTNAME`, so a config-only external address is present in the minted certificate SAN list and mTLS to the stable endpoint succeeds
- Both sources are honored independently and merged through `dedupeSANs` (a value present in both collapses to a single entry)
- All existing SAN sources (env var, certificate.server, certificate.internal, defaults) are unchanged

Fixes #2017

## Specialist Review Results

| Reviewer | Result |
|---|---|
| qa-test-runner | **PASS** — all 10 tests in `features/controller/initialization/` pass, including 4 new SAN tests |
| qa-code-reviewer | **PASS** — 0 blocking issues, 0 warnings |
| security-engineer | **PASS** — 0 blocking issues; no injection, no disclosure, no central provider violations; SAN expansion strengthens (not weakens) mTLS |

## Test plan

- [ ] `TestTransportCertSANs_ConfigExternalAddressHostname` — config hostname → DNS SANs
- [ ] `TestTransportCertSANs_ConfigExternalAddressIP` — config IP → IP SANs
- [ ] `TestTransportCertSANs_EnvVarAndConfigBothAdded` — both env var and config honored
- [ ] `TestTransportCertSANs_NoDuplicatesWhenEnvAndConfigMatch` — no duplicate when both carry the same value
- [ ] Existing tests unchanged and passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)