### PR TITLE
hyperv: implement modules.Monitor for VM state via Event Log subscription (Issue #2114)

### DIFF
--- a/docs/architecture/steward-operating-model.md
+++ b/docs/architecture/steward-operating-model.md
@@ -207,7 +207,7 @@ The convergence runtime now wires `Monitor` automatically: on cfg load it calls 
 
 Current adoption:
 
-- **Implemented**: none (first implementation planned for Hyper-V, S2)
+- **Implemented**: `hyperv` (VM state — power on/off and create/delete, via a single host-level Windows Event Log subscription over the Hyper-V VMMS/Worker channels; Windows only, polling backstop elsewhere)
 - **Polling-only (no Monitor yet)**: `activedirectory`, `file`, `script`, `firewall`, `package`, `patch`
 
 Adding `Monitor` support to additional modules is an ongoing enhancement, prioritized by user impact (security-sensitive resources benefit most from event-driven detection).

--- a/features/modules/hyperv/module.go
+++ b/features/modules/hyperv/module.go
@@ -93,6 +93,26 @@ type hypervModule struct {
 	// Mount-VHD against a CSV-resident VHDX hangs on a cluster node. When empty
 	// the seed lands next to the VM's primary VHD (fine for non-cluster hosts).
 	seedDir string
+
+	// Monitor (modules.Monitor, #2114) state. A single host-level Windows Event
+	// Log subscription fans out to per-VM ChangeEvents on the one monChanges
+	// channel. Fields live here (cross-platform) so module.go owns the struct;
+	// the subscription is driven entirely by the build-tagged monitor_*.go files.
+	//
+	// monSub holds the wevtapi EvtSubscribe handle as a uintptr so this struct
+	// stays platform-neutral (monitor_windows.go casts it to windows.Handle).
+	// Zero means "no active subscription". monInterest is the set of registered
+	// resourceIDs (vm:<name>); the subscription is created on first interest and
+	// torn down when the last is removed or on Close.
+	monMu       sync.Mutex
+	monChanges  chan modules.ChangeEvent
+	monInterest map[string]struct{}
+	monSub      uintptr
+	monClosed   bool
+	// monTeardown stops the reader goroutine and releases the EvtSubscribe and
+	// signal handles. It is set by the platform establish routine when the
+	// subscription is created and cleared on Close. nil means "no subscription".
+	monTeardown func() error
 }
 
 // HypervOption configures a hypervModule at construction time.

--- a/features/modules/hyperv/module.yaml
+++ b/features/modules/hyperv/module.yaml
@@ -17,6 +17,7 @@ interfaces:
   - Get
   - Set
   - Test
+  - Monitor
 
 security:
   requires_root: false

--- a/features/modules/hyperv/monitor_nonwindows.go
+++ b/features/modules/hyperv/monitor_nonwindows.go
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+
+//go:build !windows
+
+package hyperv
+
+import (
+	"context"
+	"errors"
+
+	"github.com/cfgis/cfgms/features/modules"
+)
+
+// ErrNotSupported is returned by Monitor on non-Windows hosts. Hyper-V VM-state
+// monitoring is implemented with a Windows Event Log subscription
+// (monitor_windows.go), so there is no portable equivalent. The steward's
+// scheduled poll remains the cross-platform backstop.
+var ErrNotSupported = errors.New("hyperv: VM-state monitoring is only supported on Windows hosts")
+
+// Monitor satisfies modules.Monitor on non-Windows builds by reporting that
+// event-driven monitoring is unavailable. Callers fall back to polling.
+func (m *hypervModule) Monitor(_ context.Context, _ string, _ modules.ConfigState) error {
+	return ErrNotSupported
+}
+
+// Changes returns nil on non-Windows builds: there is no subscription, so there
+// is no channel to receive on. A nil channel blocks forever on receive, which a
+// caller must guard with the ErrNotSupported it got from Monitor.
+func (m *hypervModule) Changes() <-chan modules.ChangeEvent {
+	return nil
+}
+
+// Close is a no-op on non-Windows builds: no subscription handle is ever held.
+func (m *hypervModule) Close() error {
+	return nil
+}

--- a/features/modules/hyperv/monitor_nonwindows_test.go
+++ b/features/modules/hyperv/monitor_nonwindows_test.go
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+
+//go:build !windows
+
+package hyperv
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// On non-Windows builds the Hyper-V VM-state Monitor is unavailable: Monitor
+// reports ErrNotSupported, Changes returns nil, and Close is a no-op. The
+// steward's scheduled poll is the cross-platform backstop.
+func TestHypervMonitorNotSupportedOnNonWindows(t *testing.T) {
+	m, ok := New(nil).(*hypervModule)
+	require.True(t, ok, "New must return *hypervModule")
+
+	err := m.Monitor(context.Background(), "vm:x", nil)
+	require.ErrorIs(t, err, ErrNotSupported)
+
+	require.Nil(t, m.Changes(), "Changes() is nil when monitoring is unsupported")
+	require.NoError(t, m.Close(), "Close is a no-op on non-Windows")
+}

--- a/features/modules/hyperv/monitor_windows.go
+++ b/features/modules/hyperv/monitor_windows.go
@@ -1,0 +1,398 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+
+//go:build windows
+
+package hyperv
+
+import (
+	"context"
+	"encoding/xml"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+
+	"github.com/cfgis/cfgms/features/modules"
+)
+
+// Hyper-V VM-state Monitor (modules.Monitor, #2114).
+//
+// A single host-level Windows Event Log subscription (one EvtSubscribe handle)
+// watches the Hyper-V VMMS and Worker *Admin* channels for VM lifecycle and
+// power-state events and fans them out to per-VM modules.ChangeEvents on the one
+// Changes() channel. There is no persistent helper process and no PowerShell —
+// the subscription is driven entirely through wevtapi.dll via
+// golang.org/x/sys/windows (already a direct dependency; no new dependency, no
+// CGO).
+//
+// The EventID -> ChangeType map below is grounded in the provider event
+// manifests (read non-privileged with `wevtutil gp <provider> /ge:true`):
+//
+//	Microsoft-Windows-Hyper-V-VMMS  (Admin channel)
+//	  13002  "A new virtual machine '%1' was created"   -> Created
+//	  13003  "The virtual machine '%1' was deleted"     -> Deleted
+//	  18302  "The virtual machine '%1' was imported"    -> Created
+//
+//	Microsoft-Windows-Hyper-V-Worker (Admin channel) — EnabledState changes
+//	  18500 started, 18502 turned off, 18504/18506/18508 shut down,
+//	  18510 saved, 18512/18514 reset, 18516 paused, 18518 resumed,
+//	  18524/18526/18528 critical-error transitions, 18592 fast-restored,
+//	  18594 fast-saved, 18596 restored, 18608 hibernated  -> Modified
+//
+// In every one of these events %1 is the VM name and %2 the VM ID, so the
+// emitted ChangeEvent.ResourceID is "vm:<name>".
+
+// wevtapi.dll bindings. NewLazySystemDLL resolves from %SystemRoot%\System32,
+// so this is not susceptible to working-directory DLL planting.
+var (
+	modwevtapi = windows.NewLazySystemDLL("wevtapi.dll")
+
+	procEvtSubscribe = modwevtapi.NewProc("EvtSubscribe")
+	procEvtNext      = modwevtapi.NewProc("EvtNext")
+	procEvtRender    = modwevtapi.NewProc("EvtRender")
+	procEvtClose     = modwevtapi.NewProc("EvtClose")
+)
+
+const (
+	evtSubscribeToFutureEvents = 1
+	evtRenderEventXML          = 1
+	// monitorChannelDepth bounds the fan-out channel. The signal carries no
+	// actionable payload (the consumer re-checks via Get), so a modest buffer
+	// is sufficient; a slow consumer drops oldest-safe (see dispatch).
+	monitorChannelDepth = 64
+)
+
+// changeTypeForEventID maps a Hyper-V event ID to the modules.ChangeType it
+// represents, grounded in the provider manifests (see file header). The bool is
+// false for event IDs outside the watched set (which the structured query
+// already excludes; the check is defence in depth).
+func changeTypeForEventID(id int) (modules.ChangeType, bool) {
+	switch id {
+	case 13002, 18302:
+		return modules.ChangeTypeCreated, true
+	case 13003:
+		return modules.ChangeTypeDeleted, true
+	case 18500, 18502, 18504, 18506, 18508, 18510, 18512, 18514,
+		18516, 18518, 18524, 18526, 18528, 18592, 18594, 18596, 18608:
+		return modules.ChangeTypeModified, true
+	default:
+		return 0, false
+	}
+}
+
+// monitorSubscriptionQuery is the structured query for the single host
+// subscription. Channel=NULL + a <QueryList> spanning both -Admin channels is
+// what keeps this to ONE EvtSubscribe handle rather than one per channel or one
+// per VM (the epic's single-subscription invariant).
+func monitorSubscriptionQuery() string {
+	worker := []int{18500, 18502, 18504, 18506, 18508, 18510, 18512, 18514,
+		18516, 18518, 18524, 18526, 18528, 18592, 18594, 18596, 18608}
+	vmms := []int{13002, 13003, 18302}
+	return "<QueryList>\n" +
+		"  <Query Id=\"0\">\n" +
+		"    <Select Path=\"Microsoft-Windows-Hyper-V-Worker-Admin\">" + eventIDPredicate(worker) + "</Select>\n" +
+		"    <Select Path=\"Microsoft-Windows-Hyper-V-VMMS-Admin\">" + eventIDPredicate(vmms) + "</Select>\n" +
+		"  </Query>\n" +
+		"</QueryList>"
+}
+
+func eventIDPredicate(ids []int) string {
+	parts := make([]string, len(ids))
+	for i, id := range ids {
+		parts[i] = fmt.Sprintf("EventID=%d", id)
+	}
+	return "*[System[(" + strings.Join(parts, " or ") + ")]]"
+}
+
+// evtEstablish creates the host subscription and starts the reader goroutine.
+// It is a package-level seam so unit tests can exercise the interest registry,
+// decode, fan-out, and Close logic without touching the live Event Log (which
+// requires privilege and real VM churn). The real implementation is
+// realEvtEstablish; tests swap it and restore it.
+var evtEstablish = realEvtEstablish
+
+// realEvtEstablish opens the single EvtSubscribe subscription in pull mode (a
+// signalled auto-reset event + EvtNext loop) and wires teardown onto m. The
+// caller holds m.monMu.
+func realEvtEstablish(m *hypervModule) error {
+	signal, err := windows.CreateEvent(nil, 0 /*auto-reset*/, 0 /*non-signalled*/, nil)
+	if err != nil {
+		return fmt.Errorf("hyperv monitor: create signal event: %w", err)
+	}
+
+	query, err := windows.UTF16PtrFromString(monitorSubscriptionQuery())
+	if err != nil {
+		windows.CloseHandle(signal)
+		return fmt.Errorf("hyperv monitor: encode query: %w", err)
+	}
+
+	sub, _, callErr := procEvtSubscribe.Call(
+		0,                              // Session = NULL (local)
+		uintptr(signal),                // SignalEvent (pull mode)
+		0,                              // ChannelPath = NULL (structured query)
+		uintptr(unsafe.Pointer(query)), // Query = <QueryList>
+		0,                              // Bookmark = NULL
+		0,                              // Context = NULL
+		0,                              // Callback = NULL (pull mode)
+		uintptr(evtSubscribeToFutureEvents),
+	)
+	if sub == 0 {
+		windows.CloseHandle(signal)
+		return fmt.Errorf("hyperv monitor: EvtSubscribe failed: %w", callErr)
+	}
+
+	stop := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		m.pump(sub, signal, stop)
+	}()
+
+	m.monSub = sub
+	m.monTeardown = func() error {
+		close(stop)
+		// Closing the subscription unblocks EvtNext; setting the signal unblocks
+		// the wait. Then wait for the goroutine to return before closing handles.
+		windows.SetEvent(signal)
+		wg.Wait()
+		procEvtClose.Call(sub)
+		windows.CloseHandle(signal)
+		return nil
+	}
+	return nil
+}
+
+// pump waits for the subscription signal and drains ready events, rendering and
+// dispatching each, until stop is closed.
+func (m *hypervModule) pump(sub uintptr, signal windows.Handle, stop <-chan struct{}) {
+	const batch = 16
+	events := make([]uintptr, batch)
+	for {
+		select {
+		case <-stop:
+			return
+		default:
+		}
+		// Wait up to 1s so a closed stop channel is noticed promptly even when
+		// no events arrive.
+		_, _ = windows.WaitForSingleObject(signal, 1000)
+		for {
+			var returned uint32
+			ok, _, _ := procEvtNext.Call(
+				sub,
+				uintptr(batch),
+				uintptr(unsafe.Pointer(&events[0])),
+				0, // Timeout: return immediately
+				0,
+				uintptr(unsafe.Pointer(&returned)),
+			)
+			if ok == 0 || returned == 0 {
+				break // ERROR_NO_MORE_ITEMS or error: back to wait
+			}
+			for i := 0; i < int(returned); i++ {
+				if xmlStr, err := renderEventXML(events[i]); err == nil {
+					m.dispatchXML(xmlStr)
+				}
+				procEvtClose.Call(events[i])
+			}
+		}
+	}
+}
+
+// renderEventXML renders one event handle to its XML form.
+func renderEventXML(event uintptr) (string, error) {
+	var bufUsed, propCount uint32
+	// First call sizes the buffer.
+	procEvtRender.Call(0, event, uintptr(evtRenderEventXML), 0, 0,
+		uintptr(unsafe.Pointer(&bufUsed)), uintptr(unsafe.Pointer(&propCount)))
+	if bufUsed == 0 {
+		return "", fmt.Errorf("hyperv monitor: EvtRender sizing returned 0")
+	}
+	buf := make([]uint16, (bufUsed+1)/2)
+	ok, _, callErr := procEvtRender.Call(0, event, uintptr(evtRenderEventXML),
+		uintptr(bufUsed), uintptr(unsafe.Pointer(&buf[0])),
+		uintptr(unsafe.Pointer(&bufUsed)), uintptr(unsafe.Pointer(&propCount)))
+	if ok == 0 {
+		return "", fmt.Errorf("hyperv monitor: EvtRender: %w", callErr)
+	}
+	return windows.UTF16ToString(buf), nil
+}
+
+// renderedEvent is the subset of the Windows event XML schema the monitor reads.
+// Hyper-V emits the VM name under <UserData> (typically
+// UserData/VmlEventLog/VmName); the EventData fallbacks cover providers that use
+// the generic <EventData> shape instead.
+type renderedEvent struct {
+	System struct {
+		EventID int `xml:"EventID"`
+	} `xml:"System"`
+	UserData struct {
+		Inner string `xml:",innerxml"`
+	} `xml:"UserData"`
+	EventData struct {
+		Data []struct {
+			Name  string `xml:"Name,attr"`
+			Value string `xml:",chardata"`
+		} `xml:"Data"`
+	} `xml:"EventData"`
+}
+
+// dispatchXML decodes one rendered event and, if it is a watched VM event,
+// dispatches it. Malformed XML or unwatched IDs are ignored.
+func (m *hypervModule) dispatchXML(eventXML string) {
+	var ev renderedEvent
+	if err := xml.Unmarshal([]byte(eventXML), &ev); err != nil {
+		return
+	}
+	ct, ok := changeTypeForEventID(ev.System.EventID)
+	if !ok {
+		return
+	}
+	name := vmNameFromEvent(ev)
+	if name == "" {
+		return
+	}
+	m.dispatch(name, ct)
+}
+
+// vmNameFromEvent extracts the VM name robustly across the event shapes Hyper-V
+// uses: the UserData VmName element first, then a named EventData field, then the
+// first positional EventData value (%1 is always the VM name in these events).
+func vmNameFromEvent(ev renderedEvent) string {
+	if name := firstElementText(ev.UserData.Inner, "VmName"); name != "" {
+		return name
+	}
+	for _, d := range ev.EventData.Data {
+		if strings.EqualFold(d.Name, "VmName") || strings.EqualFold(d.Name, "Name") {
+			if v := strings.TrimSpace(d.Value); v != "" {
+				return v
+			}
+		}
+	}
+	if len(ev.EventData.Data) > 0 {
+		return strings.TrimSpace(ev.EventData.Data[0].Value)
+	}
+	return ""
+}
+
+// firstElementText returns the chardata of the first element with the given
+// local name found in the XML fragment, ignoring namespaces.
+func firstElementText(fragment, local string) string {
+	if fragment == "" {
+		return ""
+	}
+	dec := xml.NewDecoder(strings.NewReader(fragment))
+	for {
+		tok, err := dec.Token()
+		if err != nil {
+			return ""
+		}
+		if se, ok := tok.(xml.StartElement); ok && se.Name.Local == local {
+			var text string
+			if err := dec.DecodeElement(&text, &se); err != nil {
+				return ""
+			}
+			return strings.TrimSpace(text)
+		}
+	}
+}
+
+// dispatch fans a decoded VM event out to the Changes() channel, but only for
+// resourceIDs that were registered via Monitor — an event for an unregistered
+// ("forged"/unrelated) VM is dropped, so the monitor never fabricates an
+// unmanaged resource as managed. The ChangeEvent carries no actionable Details
+// (Details is nil): the signal conveys only *which* resource changed, and the
+// steward consumer re-checks via Get().
+func (m *hypervModule) dispatch(vmName string, ct modules.ChangeType) {
+	resourceID := "vm:" + vmName
+
+	m.monMu.Lock()
+	if m.monClosed || m.monChanges == nil {
+		m.monMu.Unlock()
+		return
+	}
+	if _, watched := m.monInterest[resourceID]; !watched {
+		m.monMu.Unlock()
+		return
+	}
+	ch := m.monChanges
+	m.monMu.Unlock()
+
+	ev := modules.ChangeEvent{
+		ResourceID: resourceID,
+		Timestamp:  time.Now().Unix(),
+		ChangeType: ct,
+		Details:    nil,
+	}
+	// Non-blocking send: a wedged consumer must not block the reader goroutine.
+	select {
+	case ch <- ev:
+	default:
+	}
+}
+
+// Monitor registers interest in a resource (resourceID "vm:<name>") and ensures
+// the single host subscription exists. The config argument is unused: the event
+// signal carries no actionable payload, so no per-resource configuration is
+// retained. Satisfies modules.Monitor.
+func (m *hypervModule) Monitor(_ context.Context, resourceID string, _ modules.ConfigState) error {
+	m.monMu.Lock()
+	defer m.monMu.Unlock()
+	if m.monClosed {
+		return fmt.Errorf("hyperv monitor: closed")
+	}
+	if m.monChanges == nil {
+		m.monChanges = make(chan modules.ChangeEvent, monitorChannelDepth)
+	}
+	if m.monInterest == nil {
+		m.monInterest = make(map[string]struct{})
+	}
+	m.monInterest[resourceID] = struct{}{}
+
+	// Create the subscription on first interest; subsequent Monitor calls reuse
+	// the one host subscription (single-subscription invariant).
+	if m.monSub == 0 && m.monTeardown == nil {
+		if err := evtEstablish(m); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// Changes returns the fan-out channel. It is created on first Monitor (or here,
+// lazily) so a caller can select on it before registering interest.
+func (m *hypervModule) Changes() <-chan modules.ChangeEvent {
+	m.monMu.Lock()
+	defer m.monMu.Unlock()
+	if m.monChanges == nil {
+		m.monChanges = make(chan modules.ChangeEvent, monitorChannelDepth)
+	}
+	return m.monChanges
+}
+
+// Close stops monitoring, releases the subscription and signal handles, and
+// halts emission. It is idempotent. Satisfies modules.Monitor.
+func (m *hypervModule) Close() error {
+	m.monMu.Lock()
+	teardown := m.monTeardown
+	m.monTeardown = nil
+	m.monSub = 0
+	m.monClosed = true
+	ch := m.monChanges
+	m.monChanges = nil
+	m.monMu.Unlock()
+
+	var err error
+	if teardown != nil {
+		err = teardown()
+	}
+	if ch != nil {
+		close(ch)
+	}
+	return err
+}

--- a/features/modules/hyperv/monitor_windows.go
+++ b/features/modules/hyperv/monitor_windows.go
@@ -207,11 +207,14 @@ func (m *hypervModule) pump(sub uintptr, signal windows.Handle, stop <-chan stru
 // renderEventXML renders one event handle to its XML form.
 func renderEventXML(event uintptr) (string, error) {
 	var bufUsed, propCount uint32
-	// First call sizes the buffer.
-	procEvtRender.Call(0, event, uintptr(evtRenderEventXML), 0, 0,
+	// First call sizes the buffer: it returns FALSE with
+	// ERROR_INSUFFICIENT_BUFFER and sets bufUsed to the required byte count. A
+	// zero size means a different failure (e.g. ERROR_EVT_INVALID_EVENT_DATA);
+	// surface that errno rather than lumping it into a generic message.
+	_, _, sizeErr := procEvtRender.Call(0, event, uintptr(evtRenderEventXML), 0, 0,
 		uintptr(unsafe.Pointer(&bufUsed)), uintptr(unsafe.Pointer(&propCount)))
 	if bufUsed == 0 {
-		return "", fmt.Errorf("hyperv monitor: EvtRender sizing returned 0")
+		return "", fmt.Errorf("hyperv monitor: EvtRender sizing returned 0: %w", sizeErr)
 	}
 	buf := make([]uint16, (bufUsed+1)/2)
 	ok, _, callErr := procEvtRender.Call(0, event, uintptr(evtRenderEventXML),

--- a/features/modules/hyperv/monitor_windows_test.go
+++ b/features/modules/hyperv/monitor_windows_test.go
@@ -1,0 +1,238 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+
+//go:build windows
+
+package hyperv
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/cfgis/cfgms/features/modules"
+)
+
+// The tests below exercise the interest registry, the manifest-grounded
+// EventID->ChangeType decode, the single-subscription invariant, fan-out, and
+// Close semantics WITHOUT touching the live Windows Event Log (which requires
+// privilege and real VM churn). The OS subscription is established through the
+// evtEstablish seam, which these tests replace with a hermetic fake; the decode
+// path is driven directly with representative rendered-event XML.
+
+// fakeEstablish installs a seam that records subscription creation and assigns a
+// sentinel handle, without opening a real EvtSubscribe handle. It returns a
+// pointer to the call counter and a restore func.
+func fakeEstablish(t *testing.T) (calls *int, teardowns *int) {
+	t.Helper()
+	var c, td int
+	orig := evtEstablish
+	evtEstablish = func(m *hypervModule) error {
+		c++
+		m.monSub = 0xBEEF
+		m.monTeardown = func() error { td++; return nil }
+		return nil
+	}
+	t.Cleanup(func() { evtEstablish = orig })
+	return &c, &td
+}
+
+// workerEventXML renders a representative Hyper-V Worker -Admin event in the
+// shape the provider emits: VM name under UserData/VmlEventLog/VmName.
+func workerEventXML(eventID int, vmName string) string {
+	return fmt.Sprintf(`<Event xmlns='http://schemas.microsoft.com/win/2004/08/events/event'>
+  <System>
+    <Provider Name='Microsoft-Windows-Hyper-V-Worker' Guid='{51ddfa29-d5c8-4803-be4b-2ecb715570fe}'/>
+    <EventID>%d</EventID>
+    <Version>0</Version>
+    <Level>4</Level>
+    <Channel>Microsoft-Windows-Hyper-V-Worker-Admin</Channel>
+    <Computer>host.local</Computer>
+  </System>
+  <UserData>
+    <VmlEventLog xmlns='http://www.microsoft.com/Windows/Virtualization/Events'>
+      <VmName>%s</VmName>
+      <VmId>5816C90A-0000-0000-0000-000000000000</VmId>
+    </VmlEventLog>
+  </UserData>
+</Event>`, eventID, vmName)
+}
+
+// vmmsEventXML renders a representative Hyper-V VMMS -Admin event.
+func vmmsEventXML(eventID int, vmName string) string {
+	return fmt.Sprintf(`<Event xmlns='http://schemas.microsoft.com/win/2004/08/events/event'>
+  <System>
+    <Provider Name='Microsoft-Windows-Hyper-V-VMMS' Guid='{6066f867-7ca1-4418-85fd-36e3f9c0600c}'/>
+    <EventID>%d</EventID>
+    <Channel>Microsoft-Windows-Hyper-V-VMMS-Admin</Channel>
+    <Computer>host.local</Computer>
+  </System>
+  <UserData>
+    <VmlEventLog xmlns='http://www.microsoft.com/Windows/Virtualization/Events'>
+      <VmName>%s</VmName>
+      <VmId>5816C90A-0000-0000-0000-000000000000</VmId>
+    </VmlEventLog>
+  </UserData>
+</Event>`, eventID, vmName)
+}
+
+func recvWithin(t *testing.T, ch <-chan modules.ChangeEvent, d time.Duration) modules.ChangeEvent {
+	t.Helper()
+	select {
+	case ev := <-ch:
+		return ev
+	case <-time.After(d):
+		t.Fatalf("expected a ChangeEvent within %s, got none", d)
+		return modules.ChangeEvent{}
+	}
+}
+
+func assertNoEvent(t *testing.T, ch <-chan modules.ChangeEvent, d time.Duration) {
+	t.Helper()
+	select {
+	case ev := <-ch:
+		t.Fatalf("expected no ChangeEvent, got %+v", ev)
+	case <-time.After(d):
+	}
+}
+
+func newMonitorModule(t *testing.T) *hypervModule {
+	t.Helper()
+	m, ok := New(nil).(*hypervModule)
+	require.True(t, ok, "New must return *hypervModule")
+	return m
+}
+
+// AC#1: registering interest in N VMs creates exactly ONE host subscription.
+func TestHypervMonitorSingleSubscription(t *testing.T) {
+	calls, _ := fakeEstablish(t)
+	m := newMonitorModule(t)
+
+	for _, rid := range []string{"vm:alpha", "vm:bravo", "vm:charlie"} {
+		require.NoError(t, m.Monitor(context.Background(), rid, nil))
+	}
+
+	require.Equal(t, 1, *calls, "exactly one EvtSubscribe host subscription for N VMs")
+	require.NotZero(t, m.monSub, "subscription handle recorded")
+	require.NotNil(t, m.Changes(), "Changes() channel is non-nil after Monitor")
+}
+
+// AC#2: a power-state change emits Modified; create emits Created; delete emits
+// Deleted. Driven through the real decode path with representative event XML.
+func TestHypervMonitorDecodeEmitsChangeEvents(t *testing.T) {
+	fakeEstablish(t)
+	m := newMonitorModule(t)
+	require.NoError(t, m.Monitor(context.Background(), "vm:TestVM", nil))
+	ch := m.Changes()
+
+	cases := []struct {
+		name string
+		xml  string
+		want modules.ChangeType
+	}{
+		{"started", workerEventXML(18500, "TestVM"), modules.ChangeTypeModified},
+		{"turned-off", workerEventXML(18502, "TestVM"), modules.ChangeTypeModified},
+		{"created", vmmsEventXML(13002, "TestVM"), modules.ChangeTypeCreated},
+		{"deleted", vmmsEventXML(13003, "TestVM"), modules.ChangeTypeDeleted},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			m.dispatchXML(tc.xml)
+			ev := recvWithin(t, ch, 2*time.Second)
+			require.Equal(t, "vm:TestVM", ev.ResourceID)
+			require.Equal(t, tc.want, ev.ChangeType)
+			require.Nil(t, ev.Details, "signal carries no actionable payload")
+			require.NotZero(t, ev.Timestamp)
+		})
+	}
+}
+
+// AC#3: an event for a VM not registered in cfg is dropped — the monitor never
+// fabricates an unmanaged resource as managed — and matched events carry no
+// actionable Details.
+func TestHypervMonitorForgedEvent(t *testing.T) {
+	fakeEstablish(t)
+	m := newMonitorModule(t)
+	require.NoError(t, m.Monitor(context.Background(), "vm:real", nil))
+	ch := m.Changes()
+
+	// Forged/unrelated VM: not in the interest set -> no emission.
+	m.dispatchXML(workerEventXML(18500, "evil-unmanaged"))
+	assertNoEvent(t, ch, 300*time.Millisecond)
+
+	// A genuinely registered VM still emits, with nil Details.
+	m.dispatchXML(workerEventXML(18500, "real"))
+	ev := recvWithin(t, ch, 2*time.Second)
+	require.Equal(t, "vm:real", ev.ResourceID)
+	require.Nil(t, ev.Details)
+}
+
+// AC: the event path produces no banned runtime-composition / PowerShell
+// patterns. The monitor uses wevtapi syscalls exclusively; the only generated
+// string is the structured subscription query.
+func TestHypervMonitorBannedPatterns(t *testing.T) {
+	q := strings.ToLower(monitorSubscriptionQuery())
+	for _, banned := range []string{
+		"iex", "invoke-expression", "-encodedcommand", "-command ",
+		"bash -c", "eval", "powershell", "-executionpolicy",
+	} {
+		require.NotContainsf(t, q, banned, "subscription query must not contain %q", banned)
+	}
+}
+
+// AC: Close releases the subscription handle and stops emission; it is
+// idempotent.
+func TestHypervMonitorCloseReleasesSubscription(t *testing.T) {
+	_, teardowns := fakeEstablish(t)
+	m := newMonitorModule(t)
+	require.NoError(t, m.Monitor(context.Background(), "vm:x", nil))
+	ch := m.Changes()
+	require.NotZero(t, m.monSub)
+
+	require.NoError(t, m.Close())
+	require.Equal(t, 1, *teardowns, "teardown released the subscription exactly once")
+	require.Zero(t, m.monSub, "subscription handle cleared")
+
+	// The Changes() channel is closed so consumers unblock.
+	_, open := <-ch
+	require.False(t, open, "Changes() channel closed on Close")
+
+	// Emission has stopped: dispatch after Close is a no-op and must not panic
+	// (no send on a closed channel).
+	require.NotPanics(t, func() { m.dispatch("x", modules.ChangeTypeModified) })
+
+	// Close is idempotent.
+	require.NoError(t, m.Close())
+}
+
+// changeTypeForEventID is the manifest-grounded core; assert the documented
+// mappings directly so a future edit that drops an ID is caught.
+func TestChangeTypeForEventID(t *testing.T) {
+	created := []int{13002, 18302}
+	deleted := []int{13003}
+	modified := []int{18500, 18502, 18504, 18506, 18508, 18510, 18512, 18514,
+		18516, 18518, 18524, 18526, 18528, 18592, 18594, 18596, 18608}
+
+	for _, id := range created {
+		ct, ok := changeTypeForEventID(id)
+		require.Truef(t, ok, "event %d should be watched", id)
+		require.Equalf(t, modules.ChangeTypeCreated, ct, "event %d -> Created", id)
+	}
+	for _, id := range deleted {
+		ct, ok := changeTypeForEventID(id)
+		require.Truef(t, ok, "event %d should be watched", id)
+		require.Equalf(t, modules.ChangeTypeDeleted, ct, "event %d -> Deleted", id)
+	}
+	for _, id := range modified {
+		ct, ok := changeTypeForEventID(id)
+		require.Truef(t, ok, "event %d should be watched", id)
+		require.Equalf(t, modules.ChangeTypeModified, ct, "event %d -> Modified", id)
+	}
+	// An unrelated/forged event ID is not watched.
+	_, ok := changeTypeForEventID(1)
+	require.False(t, ok, "unwatched event id must return ok=false")
+}

--- a/features/modules/hyperv/monitor_windows_test.go
+++ b/features/modules/hyperv/monitor_windows_test.go
@@ -104,7 +104,46 @@ func newMonitorModule(t *testing.T) *hypervModule {
 	t.Helper()
 	m, ok := New(nil).(*hypervModule)
 	require.True(t, ok, "New must return *hypervModule")
+	// Close at teardown so the lifecycle contract is self-documenting and any
+	// future regression that leaks a real reader goroutine is caught.
+	t.Cleanup(func() { _ = m.Close() })
 	return m
+}
+
+// TestVMNameFromEvent covers all three extraction shapes vmNameFromEvent
+// supports: the primary Hyper-V UserData/VmName element, a named EventData
+// field, and a positional EventData value (%1 is always the VM name). The
+// EventData fallbacks are defense-in-depth for providers that use the generic
+// <EventData> shape, so they need direct coverage.
+func TestVMNameFromEvent(t *testing.T) {
+	mk := func(userData string, data ...struct{ name, val string }) renderedEvent {
+		var ev renderedEvent
+		ev.UserData.Inner = userData
+		for _, d := range data {
+			ev.EventData.Data = append(ev.EventData.Data, struct {
+				Name  string `xml:"Name,attr"`
+				Value string `xml:",chardata"`
+			}{Name: d.name, Value: d.val})
+		}
+		return ev
+	}
+	cases := []struct {
+		name string
+		ev   renderedEvent
+		want string
+	}{
+		{"userdata vmname", mk(`<VmlEventLog xmlns='http://www.microsoft.com/Windows/Virtualization/Events'><VmName>UD-VM</VmName><VmId>x</VmId></VmlEventLog>`), "UD-VM"},
+		{"eventdata named vmname", mk("", struct{ name, val string }{"VmName", "ED-VM"}), "ED-VM"},
+		{"eventdata named generic", mk("", struct{ name, val string }{"Name", "ED-Name"}), "ED-Name"},
+		{"eventdata positional", mk("", struct{ name, val string }{"", "POS-VM"}, struct{ name, val string }{"", "id"}), "POS-VM"},
+		{"userdata wins over eventdata", mk(`<X><VmName>UD-WINS</VmName></X>`, struct{ name, val string }{"VmName", "ED-LOSES"}), "UD-WINS"},
+		{"none", mk(""), ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, vmNameFromEvent(tc.ev))
+		})
+	}
 }
 
 // AC#1: registering interest in N VMs creates exactly ONE host subscription.


### PR DESCRIPTION
## Summary

Implements `modules.Monitor` on the Hyper-V module for VM `EnabledState` changes (power on/off) and VM create/delete, using a single host-level **Windows Event Log subscription** (`EvtSubscribe`) over the Hyper-V VMMS/Worker channels. A single subscription fans out per-VM `ChangeEvent`s on the one `Changes()` channel — no persistent helper process, no PowerShell, no hot-poll. Windows build-tagged; the non-Windows build returns `ErrNotSupported` and the steward's scheduled poll remains the backstop.

## Mechanism rationale (recorded per AC)

- **`EvtSubscribe` via `wevtapi.dll`** through `golang.org/x/sys/windows.NewLazySystemDLL` — pure-Go, **no new dependency** (`golang.org/x/sys` is already a direct dep; it ships no `Evt*` wrappers, so the DLL is called directly), **no CGO**.
- **Single host subscription** (epic invariant): one `EvtSubscribe` with `Channel=NULL` + a structured `<QueryList>` spanning `Microsoft-Windows-Hyper-V-Worker-Admin` and `-VMMS-Admin`, filtered to the watched EventIDs — not one subscription per VM or per channel.
- **EventID → ChangeType map is grounded in the provider manifests** (read non-privileged via `wevtutil gp <provider> /ge:true`), not guessed:
  - VMMS `13002` "a new virtual machine '%1' was created" → `Created`; `13003` "was deleted" → `Deleted`; `18302` imported → `Created`.
  - Worker `18500` started, `18502` turned off, `18504/18506/18508` shut down, `18510` saved, `18512/18514` reset, `18516` paused, `18518` resumed, `18592/18594/18596` restored, `18608` hibernated → `Modified` (EnabledState changes).
- **Signal carries no actionable payload (T3):** `ChangeEvent.Details` is `nil` — the event conveys only *which* resource changed; the consumer re-checks via `Get()`. The monitor emits **only** for registered `resourceID`s; an event for an unregistered/forged VM is dropped (never fabricated as managed).

## Changes

- `monitor_windows.go` (new, `//go:build windows`) — subscription lifecycle, pull-mode reader goroutine (EvtNext→EvtRender→decode→dispatch), EventID map, robust VM-name extraction (UserData `VmName` / EventData named / positional), `Monitor`/`Changes`/`Close`.
- `monitor_nonwindows.go` (new, `//go:build !windows`) — `Monitor`→`ErrNotSupported`, `Changes`→nil, `Close`→nil.
- `module.go` — cross-platform monitor state on `hypervModule` (handle as `uintptr`).
- `module.yaml` — `Monitor` added to `interfaces:`.
- `monitor_windows_test.go` / `monitor_nonwindows_test.go` (new) — required tests.
- `docs/architecture/steward-operating-model.md` — `hyperv` added to Monitor "current adoption".

## Test results (adversarial story-complete team — all PASS)

- **Acceptance check**: PASS — 7/7 AC verified; no new dep (go.mod/go.sum diff empty); no CGO; all named tests present.
- **QA test-quality**: PASS — full `features/modules/hyperv` package green under `-race`; build/vet/gofmt clean; non-Windows path verified under `GOOS=linux`.
- **QA code review**: PASS — verified inlined `unsafe.Pointer` at every `Call` site (no kept-uintptr hazard), all handles closed on every path (sub, signal, per-event), no send-on-closed-channel/deadlock (teardown runs after `monMu` released; `wg.Wait()` before handle close). 3 non-blocking warnings raised and **addressed** in this PR (untested EventData fallbacks → `TestVMNameFromEvent`; `t.Cleanup(Close)` lifecycle; `EvtRender` sizing errno).
- **Security review**: PASS — `make check-architecture` clean; no banned patterns (pure syscalls, no shelling out); `NewLazySystemDLL` (System32-resolved, not CWD-plantable); event XML parsed into a fixed struct, VM name only ever becomes a matched resourceID; no secrets; no new dependency.

Required tests: `TestHypervMonitorSingleSubscription`, `TestHypervMonitorDecodeEmitsChangeEvents` (started/turned-off/created/deleted), `TestHypervMonitorForgedEvent`, `TestHypervMonitorBannedPatterns`, `TestHypervMonitorCloseReleasesSubscription`, `TestHypervMonitorNotSupportedOnNonWindows`, plus `TestVMNameFromEvent` and `TestChangeTypeForEventID`.

## Verification note

The EventID map and channel paths are manifest-grounded (authoritative). The rendered-event **XML field extraction** is verified against representative Hyper-V event XML and made robust across the documented UserData/EventData shapes; the unit tests drive the real decode path. A live end-to-end confirmation against real VM churn requires Hyper-V admin on the host and is the one remaining manual check (the implementation degrades safely — an unrecognized shape simply yields no emission, and the scheduled poll backstops).

## Host / CI caveats

Developed and validated on the Windows e2e host. `golangci-lint`, `gitleaks`/`truffleHog`, and gosec/Trivy are not installed there, so `make lint` and secret/security scans run in CI (`go vet`/`gofmt`/`make check-architecture` used locally). CI's lint check and `security-deployment-gate` enforce the rest.

Fixes #2114

Co-Authored-By: Claude <noreply@anthropic.com>