### PR TITLE
steward: wire Monitor consumer into convergence loop (Issue #2112)

### DIFF
--- a/docs/architecture/steward-operating-model.md
+++ b/docs/architecture/steward-operating-model.md
@@ -203,9 +203,11 @@ Modules **should, when possible, implement the `Monitor` interface** to watch fo
 
 Some resources don't have a feasible event-source (no OS-level watcher, no vendor API hook); those modules fall back to the scheduled re-check interval (`steward.converge_interval`). Event-driven Monitor support is preferred and should be added where the underlying platform permits it.
 
-Current adoption (as of v0.9.x):
+The convergence runtime now wires `Monitor` automatically: on cfg load it calls `Monitor(ctx, resourceID, desired)` for every module that implements the interface, fans in the `Changes()` channels, and on each `ChangeEvent` runs a targeted `ExecuteResource` for the changed `resourceID` (treating the event as a hint — actual state is re-read via `module.Get()` and desired state comes from the cfg, never from `event.Details`).
 
-- **Implemented**: none
+Current adoption:
+
+- **Implemented**: none (first implementation planned for Hyper-V, S2)
 - **Polling-only (no Monitor yet)**: `activedirectory`, `file`, `script`, `firewall`, `package`, `patch`
 
 Adding `Monitor` support to additional modules is an ongoing enhancement, prioritized by user impact (security-sensitive resources benefit most from event-driven detection).

--- a/features/steward/execution/execution.go
+++ b/features/steward/execution/execution.go
@@ -36,6 +36,7 @@ import (
 
 	"gopkg.in/yaml.v3"
 
+	"github.com/cfgis/cfgms/features/modules"
 	stewardtesting "github.com/cfgis/cfgms/features/steward/testing"
 )
 
@@ -86,6 +87,13 @@ const (
 	// module.Set() and module.Verify() were NOT called; the drift is reported but not corrected.
 	StatusNonCompliant
 )
+
+// NewConfigState creates a ConfigState from a raw configuration map.
+// Used by the steward to build the desired-state argument for Monitor() calls
+// without duplicating the executor's internal createConfigState logic.
+func NewConfigState(data map[string]interface{}) modules.ConfigState {
+	return &genericConfigState{data: data}
+}
 
 // genericConfigState is a simple map-backed ConfigState implementation used
 // when no module-specific state type is needed.

--- a/features/steward/execution/executor.go
+++ b/features/steward/execution/executor.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"sync"
 	"time"
 
 	"gopkg.in/yaml.v3"
@@ -61,11 +62,16 @@ type ExecutorConfig struct {
 // It serves both standalone mode (direct ExecuteConfiguration calls) and controller
 // mode (ApplyConfiguration with raw config bytes in, ConfigStatusReport out).
 type Executor struct {
-	factory      *factory.ModuleFactory
-	comparator   *stewardtesting.StateComparator
-	config       config.ErrorHandlingConfig
-	tenantID     string
-	logger       logging.Logger
+	factory    *factory.ModuleFactory
+	comparator *stewardtesting.StateComparator
+	config     config.ErrorHandlingConfig
+	tenantID   string
+	logger     logging.Logger
+
+	// mu protects driftHandler and driftMode. Both can be written after construction
+	// (controller delivers new cfg, tests replace the handler) while ExecuteResource
+	// reads them concurrently from the monitor event loop.
+	mu           sync.RWMutex
 	driftHandler DriftEventHandler
 	driftMode    config.DriftMode
 }
@@ -116,14 +122,18 @@ func NewExecutor(cfg *ExecutorConfig) (*Executor, error) {
 // SetDriftEventHandler registers a callback invoked when the Compare step detects
 // drift on a managed resource, before Set corrects it. Pass nil to remove a handler.
 func (e *Executor) SetDriftEventHandler(handler DriftEventHandler) {
+	e.mu.Lock()
 	e.driftHandler = handler
+	e.mu.Unlock()
 }
 
 // SetDriftMode updates the executor's drift mode. Call this when the
 // controller delivers a new cfg with an updated drift_mode field.
 // An empty string is treated as DriftModeApply (default behavior).
 func (e *Executor) SetDriftMode(mode config.DriftMode) {
+	e.mu.Lock()
 	e.driftMode = mode
+	e.mu.Unlock()
 }
 
 // ExecuteConfiguration executes the complete configuration for all resources.
@@ -277,22 +287,30 @@ func (e *Executor) ExecuteResource(ctx context.Context, resource config.Resource
 		"added_fields", stateDiff.GetAddedFieldNames(),
 		"removed_fields", stateDiff.GetRemovedFieldNames())
 
+	// Snapshot drift mode and handler under the read lock. Both may be updated
+	// concurrently (controller delivers new cfg, tests replace the handler) while
+	// the monitor event loop dispatches ExecuteResource calls.
+	e.mu.RLock()
+	driftMode := e.driftMode
+	driftHandler := e.driftHandler
+	e.mu.RUnlock()
+
 	// Tag the event type for upstream telemetry before invoking the handler.
 	// "drift.detected.monitor" lets the controller distinguish monitor-mode stewards
 	// from apply-mode stewards that simply have not drifted.
-	if e.driftMode == config.DriftModeMonitor {
+	if driftMode == config.DriftModeMonitor {
 		stateDiff.EventType = "drift.detected.monitor"
 	} else {
 		stateDiff.EventType = "drift.detected"
 	}
 
 	// Emit drift event. Handler fires in both modes — ordering is always preserved.
-	if e.driftHandler != nil {
-		e.driftHandler(resource.Name, resource.Module, &stateDiff)
+	if driftHandler != nil {
+		driftHandler(resource.Name, resource.Module, &stateDiff)
 	}
 
 	// In monitor mode, report non-compliance without correcting the drift.
-	if e.driftMode == config.DriftModeMonitor {
+	if driftMode == config.DriftModeMonitor {
 		result.Status = StatusNonCompliant
 		result.ExecutionTime = time.Since(startTime)
 		e.logger.Info("Monitor mode: drift detected, skipping Set",
@@ -336,6 +354,14 @@ func (e *Executor) ExecuteResource(ctx context.Context, resource config.Resource
 // createConfigState converts a map[string]interface{} to a ConfigState.
 func (e *Executor) createConfigState(configData map[string]interface{}) (modules.ConfigState, error) {
 	return &genericConfigState{data: configData}, nil
+}
+
+// GetResourceID returns the module-internal resource identifier for the given
+// ResourceConfig. This is the identifier passed to module.Get, module.Set, and
+// Monitor() — callers that need to match ChangeEvent.ResourceID against cfg
+// resources must use this method to ensure the IDs are consistent.
+func (e *Executor) GetResourceID(resource config.ResourceConfig) string {
+	return e.getResourceIdentifier(resource)
 }
 
 // parseModuleRef splits a module reference into its bundle and resource-type

--- a/features/steward/export_test.go
+++ b/features/steward/export_test.go
@@ -4,8 +4,11 @@ package steward
 
 import (
 	commonpb "github.com/cfgis/cfgms/api/proto/common"
+	"github.com/cfgis/cfgms/features/modules"
+	"github.com/cfgis/cfgms/features/steward/config"
 	"github.com/cfgis/cfgms/features/steward/dna"
 	"github.com/cfgis/cfgms/features/steward/dna/drift"
+	"github.com/cfgis/cfgms/features/steward/execution"
 )
 
 // RunConvergence exposes the unexported runConvergence method for black-box tests.
@@ -36,4 +39,25 @@ var SetDNACollector = func(s *Steward, c *dna.Collector) {
 // SetDriftDetector replaces the driftDetector field for test injection (e.g. nil-safety tests).
 var SetDriftDetector = func(s *Steward, d drift.Detector) {
 	s.driftDetector = d
+}
+
+// RunTargetedReconcile exposes the unexported runTargetedReconcile for black-box tests.
+var RunTargetedReconcile = (*Steward).runTargetedReconcile
+
+// RegisterTestModule injects a module instance into the steward's factory cache.
+// Subsequent calls to LoadModule or CreateModuleInstance for name will return mod.
+var RegisterTestModule = func(s *Steward, name string, mod modules.Module) {
+	s.moduleFactory.RegisterModule(name, mod)
+}
+
+// SetDriftModeForTest sets the executor's drift mode for tests that need to
+// exercise monitor-mode reconcile paths.
+var SetDriftModeForTest = func(s *Steward, mode config.DriftMode) {
+	s.executor.SetDriftMode(mode)
+}
+
+// SetDriftEventHandlerForTest sets the executor's drift event handler for tests
+// that need to capture drift events (e.g. to assert EventType in monitor mode).
+var SetDriftEventHandlerForTest = func(s *Steward, handler execution.DriftEventHandler) {
+	s.executor.SetDriftEventHandler(handler)
 }

--- a/features/steward/factory/factory.go
+++ b/features/steward/factory/factory.go
@@ -228,6 +228,14 @@ func (f *ModuleFactory) GetLoadedModules() []string {
 	return modules
 }
 
+// RegisterModule adds or replaces a module instance in the cache.
+// Subsequent calls to LoadModule or CreateModuleInstance for name will return mod.
+// Used in tests to inject real test implementations and in production to pre-wire
+// modules that need special construction (e.g. modules with injected dependencies).
+func (f *ModuleFactory) RegisterModule(name string, mod modules.Module) {
+	f.instances[name] = mod
+}
+
 // UnloadModule removes a module instance from the cache
 func (f *ModuleFactory) UnloadModule(moduleName string) {
 	delete(f.instances, moduleName)

--- a/features/steward/monitor_test.go
+++ b/features/steward/monitor_test.go
@@ -1,0 +1,370 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+package steward_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cfgis/cfgms/features/modules"
+	steward "github.com/cfgis/cfgms/features/steward"
+	"github.com/cfgis/cfgms/features/steward/config"
+	"github.com/cfgis/cfgms/features/steward/execution"
+	stewardtesting "github.com/cfgis/cfgms/features/steward/testing"
+	"github.com/cfgis/cfgms/pkg/logging"
+)
+
+// testMonitorModule is a real implementation of modules.Module + modules.Monitor
+// for monitor consumer tests. It does not use any mock framework.
+type testMonitorModule struct {
+	mu sync.Mutex
+
+	getCalls   int
+	setConfigs []map[string]interface{} // config passed to each Set call
+
+	monitorCalled     bool
+	monitorResourceID string
+	monitorDesired    modules.ConfigState
+
+	changesCh chan modules.ChangeEvent
+}
+
+func newTestMonitorModule(t *testing.T) *testMonitorModule {
+	t.Helper()
+	return &testMonitorModule{
+		changesCh: make(chan modules.ChangeEvent, 16),
+	}
+}
+
+func (m *testMonitorModule) Get(_ context.Context, _ string) (modules.ConfigState, error) {
+	m.mu.Lock()
+	m.getCalls++
+	m.mu.Unlock()
+	// Return a state that differs from the desired cfg state to ensure drift is detected.
+	return execution.NewConfigState(map[string]interface{}{"state": "drifted"}), nil
+}
+
+func (m *testMonitorModule) Set(_ context.Context, _ string, cfg modules.ConfigState) error {
+	m.mu.Lock()
+	m.setConfigs = append(m.setConfigs, cfg.AsMap())
+	m.mu.Unlock()
+	return nil
+}
+
+func (m *testMonitorModule) Monitor(_ context.Context, resourceID string, desired modules.ConfigState) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.monitorCalled = true
+	m.monitorResourceID = resourceID
+	m.monitorDesired = desired
+	return nil
+}
+
+func (m *testMonitorModule) Changes() <-chan modules.ChangeEvent {
+	return m.changesCh
+}
+
+func (m *testMonitorModule) Close() error {
+	return nil
+}
+
+func (m *testMonitorModule) SendChange(evt modules.ChangeEvent) {
+	m.changesCh <- evt
+}
+
+func (m *testMonitorModule) GetCallCount() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.getCalls
+}
+
+func (m *testMonitorModule) SetCallCount() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return len(m.setConfigs)
+}
+
+func (m *testMonitorModule) GetSetConfigs() []map[string]interface{} {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	out := make([]map[string]interface{}, len(m.setConfigs))
+	copy(out, m.setConfigs)
+	return out
+}
+
+func (m *testMonitorModule) MonitorCalled() bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.monitorCalled
+}
+
+func (m *testMonitorModule) MonitorResourceID() string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.monitorResourceID
+}
+
+func (m *testMonitorModule) ResetTracking() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.getCalls = 0
+	m.setConfigs = nil
+}
+
+// testNoopModule implements modules.Module but NOT modules.Monitor.
+// Its Get returns a state that matches the cfg desired state so no drift is detected.
+type testNoopModule struct {
+	mu       sync.Mutex
+	getCalls int
+}
+
+func newTestNoopModule() *testNoopModule { return &testNoopModule{} }
+
+func (m *testNoopModule) Get(_ context.Context, _ string) (modules.ConfigState, error) {
+	m.mu.Lock()
+	m.getCalls++
+	m.mu.Unlock()
+	return execution.NewConfigState(map[string]interface{}{"state": "present"}), nil
+}
+
+func (m *testNoopModule) Set(_ context.Context, _ string, _ modules.ConfigState) error {
+	return nil
+}
+
+func (m *testNoopModule) GetCallCount() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.getCalls
+}
+
+// writeTwoResourceCfg writes a cfg with two resources: one for testmonitor and one for testnoop.
+func writeTwoResourceCfg(t *testing.T, dir, id string) string {
+	t.Helper()
+	cfgData := `steward:
+  id: ` + id + `
+resources:
+  - name: my-resource
+    module: testmonitor
+    config:
+      state: present
+  - name: other-resource
+    module: testnoop
+    config:
+      state: present
+`
+	path := filepath.Join(dir, "test.cfg")
+	require.NoError(t, os.WriteFile(path, []byte(cfgData), 0644))
+	return path
+}
+
+// writeSingleMonitorCfg writes a cfg with one resource for the testmonitor module.
+func writeSingleMonitorCfg(t *testing.T, dir, id string) string {
+	t.Helper()
+	cfgData := `steward:
+  id: ` + id + `
+resources:
+  - name: my-resource
+    module: testmonitor
+    config:
+      state: present
+`
+	path := filepath.Join(dir, "test.cfg")
+	require.NoError(t, os.WriteFile(path, []byte(cfgData), 0644))
+	return path
+}
+
+// TestMonitorConsumerWiring verifies that after startStandalone:
+//   - every module in cfg.Resources implementing Monitor has had Monitor() called,
+//   - its Changes() channel is consumed, and
+//   - a ChangeEvent triggers ExecuteResource for that resourceID only
+//     (not a full ExecuteConfiguration of all resources).
+func TestMonitorConsumerWiring(t *testing.T) {
+	logger := logging.NewLogger("debug")
+	dir := t.TempDir()
+	cfgPath := writeTwoResourceCfg(t, dir, "monitor-wiring-steward")
+
+	testMon := newTestMonitorModule(t)
+	testNoop := newTestNoopModule()
+
+	s, err := steward.NewStandalone(cfgPath, logger)
+	require.NoError(t, err)
+	steward.RegisterTestModule(s, "testmonitor", testMon)
+	steward.RegisterTestModule(s, "testnoop", testNoop)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	require.NoError(t, s.Start(ctx))
+
+	// Monitor() must have been called with the correct resourceID.
+	require.True(t, testMon.MonitorCalled(), "Monitor() must be called for testmonitor module")
+	assert.Equal(t, "my-resource", testMon.MonitorResourceID())
+
+	// testNoop does not implement Monitor — verify no Monitor call happened on it
+	// (trivially true since testNoopModule has no Monitor method, but we still assert
+	// that testnoop.GetCallCount is from initial convergence only, not a monitor start).
+
+	// Record call counts after initial convergence.
+	initialMonGet := testMon.GetCallCount()
+	initialNoopGet := testNoop.GetCallCount()
+
+	// Send a ChangeEvent — this must trigger a targeted reconcile for "my-resource" only.
+	testMon.SendChange(modules.ChangeEvent{
+		ResourceID: "my-resource",
+		ChangeType: modules.ChangeTypeModified,
+	})
+
+	// Wait for the targeted reconcile to run (testMon.Get is called again).
+	require.Eventually(t, func() bool {
+		return testMon.GetCallCount() > initialMonGet
+	}, 2*time.Second, 10*time.Millisecond, "targeted reconcile must run after ChangeEvent")
+
+	// The other module must NOT have had an extra Get call — proving targeted, not full, convergence.
+	assert.Equal(t, initialNoopGet, testNoop.GetCallCount(),
+		"testnoop must not be called by a targeted reconcile for my-resource")
+
+	require.NoError(t, s.Stop(context.Background()))
+}
+
+// TestMonitorEventIsHintNotTruth verifies that a ChangeEvent with a forged Details
+// does not influence the Set decision. The reconcile must use module.Get() for
+// current state and the cfg ResourceConfig for desired state; event.Details is ignored.
+func TestMonitorEventIsHintNotTruth(t *testing.T) {
+	logger := logging.NewLogger("debug")
+	dir := t.TempDir()
+	cfgPath := writeSingleMonitorCfg(t, dir, "monitor-hint-steward")
+
+	testMon := newTestMonitorModule(t)
+
+	s, err := steward.NewStandalone(cfgPath, logger)
+	require.NoError(t, err)
+	steward.RegisterTestModule(s, "testmonitor", testMon)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	require.NoError(t, s.Start(ctx))
+
+	// Reset tracking after initial convergence so we isolate the event-triggered reconcile.
+	testMon.ResetTracking()
+
+	// Send a forged event whose Details claim a fabricated state that differs from both
+	// current (Get returns "drifted") and desired cfg ("present").
+	testMon.SendChange(modules.ChangeEvent{
+		ResourceID: "my-resource",
+		ChangeType: modules.ChangeTypeModified,
+		Details:    execution.NewConfigState(map[string]interface{}{"state": "fabricated_evil_value"}),
+	})
+
+	// Wait for the Set call (drift detected → Set called in apply mode).
+	require.Eventually(t, func() bool {
+		return testMon.SetCallCount() > 0
+	}, 2*time.Second, 10*time.Millisecond, "Set must be called after event-triggered reconcile")
+
+	// Get must have been called — actual current state was read, not event.Details.
+	assert.Greater(t, testMon.GetCallCount(), 0, "Get must be called to read actual current state")
+
+	// Set must have been called with the cfg desired state ("present"), not event.Details ("fabricated_evil_value").
+	setConfigs := testMon.GetSetConfigs()
+	require.NotEmpty(t, setConfigs)
+	lastSet := setConfigs[len(setConfigs)-1]
+	assert.Equal(t, "present", lastSet["state"],
+		"Set must use cfg desired state, not forged event Details")
+	assert.NotEqual(t, "fabricated_evil_value", lastSet["state"],
+		"forged event Details must never reach Set")
+}
+
+// TestMonitorModeNeverSets verifies that with DriftModeMonitor, a ChangeEvent
+// reconcile never calls Set() and emits "drift.detected.monitor".
+func TestMonitorModeNeverSets(t *testing.T) {
+	logger := logging.NewLogger("debug")
+	dir := t.TempDir()
+	cfgPath := writeSingleMonitorCfg(t, dir, "monitor-mode-steward")
+
+	testMon := newTestMonitorModule(t)
+
+	s, err := steward.NewStandalone(cfgPath, logger)
+	require.NoError(t, err)
+	steward.RegisterTestModule(s, "testmonitor", testMon)
+
+	// Set monitor mode BEFORE start so both initial convergence and event-triggered
+	// reconciles run in monitor mode.
+	steward.SetDriftModeForTest(s, config.DriftModeMonitor)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	require.NoError(t, s.Start(ctx))
+
+	// Capture drift events AFTER start to isolate event-triggered reconciles.
+	// startStandalone sets its own handler; we replace it here to record EventType.
+	mu := &sync.Mutex{}
+	var capturedEventTypes []string
+	steward.SetDriftEventHandlerForTest(s, func(_ string, _ string, diff *stewardtesting.StateDiff) {
+		mu.Lock()
+		capturedEventTypes = append(capturedEventTypes, diff.EventType)
+		mu.Unlock()
+	})
+
+	// Initial convergence ran in monitor mode — Set must not have been called.
+	assert.Equal(t, 0, testMon.SetCallCount(), "Set must not be called in monitor mode during initial convergence")
+
+	initialGetCount := testMon.GetCallCount()
+
+	// Send a ChangeEvent to trigger a targeted reconcile.
+	testMon.SendChange(modules.ChangeEvent{
+		ResourceID: "my-resource",
+		ChangeType: modules.ChangeTypeModified,
+	})
+
+	// Wait for the targeted reconcile (Get called again).
+	require.Eventually(t, func() bool {
+		return testMon.GetCallCount() > initialGetCount
+	}, 2*time.Second, 10*time.Millisecond, "targeted reconcile must run after ChangeEvent")
+
+	// Set must never have been called — monitor mode skips Set/Verify.
+	assert.Equal(t, 0, testMon.SetCallCount(), "Set must never be called in monitor mode")
+
+	// "drift.detected.monitor" must have been emitted.
+	mu.Lock()
+	types := make([]string, len(capturedEventTypes))
+	copy(types, capturedEventTypes)
+	mu.Unlock()
+	assert.Contains(t, types, "drift.detected.monitor",
+		"drift.detected.monitor must be emitted for monitor-mode reconciles")
+
+	require.NoError(t, s.Stop(context.Background()))
+}
+
+// TestMonitorUnmanagedResource verifies that a ChangeEvent whose ResourceID is not
+// present in cfg performs no Set — the reconcile is skipped entirely.
+func TestMonitorUnmanagedResource(t *testing.T) {
+	logger := logging.NewLogger("debug")
+	dir := t.TempDir()
+	cfgPath := writeSingleMonitorCfg(t, dir, "monitor-unmanaged-steward")
+
+	testMon := newTestMonitorModule(t)
+
+	s, err := steward.NewStandalone(cfgPath, logger)
+	require.NoError(t, err)
+	steward.RegisterTestModule(s, "testmonitor", testMon)
+
+	ctx := context.Background()
+
+	// Call runTargetedReconcile directly with a resourceID not in cfg.
+	// This tests the function's early-exit path without the async event loop.
+	steward.RunTargetedReconcile(s, ctx, "nonexistent-resource-not-in-cfg")
+
+	// No module was called — "nonexistent-resource" is not in cfg.
+	assert.Equal(t, 0, testMon.GetCallCount(), "Get must not be called for unmanaged resource")
+	assert.Equal(t, 0, testMon.SetCallCount(), "Set must not be called for unmanaged resource")
+
+	require.NoError(t, s.Stop(ctx))
+}

--- a/features/steward/steward.go
+++ b/features/steward/steward.go
@@ -28,10 +28,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"sync"
 	"time"
 
 	commonpb "github.com/cfgis/cfgms/api/proto/common"
+	"github.com/cfgis/cfgms/features/modules"
 	"github.com/cfgis/cfgms/features/modules/script"
 	"github.com/cfgis/cfgms/features/steward/config"
 	"github.com/cfgis/cfgms/features/steward/discovery"
@@ -48,6 +50,23 @@ import (
 // (derived from MAC + hostname) changes between convergence cycles, indicating a
 // VM/container migration or hardware change that requires manual reconciliation.
 var ErrDNAIDMismatch = errors.New("DNA-ID mismatch: manual reconciliation required")
+
+// monitorEntry pairs a module's Monitor with its resource configuration.
+// Used to fan-in ChangeEvents and dispatch targeted reconciles.
+type monitorEntry struct {
+	resourceID string
+	resource   config.ResourceConfig
+	monitor    modules.Monitor
+}
+
+// bundleNameFromModuleRef extracts the module bundle name from a module reference.
+// "hyperv.vm" → "hyperv"; "file" → "file".
+func bundleNameFromModuleRef(moduleRef string) string {
+	if idx := strings.IndexByte(moduleRef, '.'); idx >= 0 {
+		return moduleRef[:idx]
+	}
+	return moduleRef
+}
 
 // Steward manages configuration for a single endpoint in standalone mode.
 //
@@ -82,6 +101,10 @@ type Steward struct {
 
 	// Secret store for steward-side secret management
 	secretStore secretsif.SecretStore
+
+	// monitors holds active monitor entries started on cfg load.
+	// Each entry has had Monitor(ctx, resourceID, desired) called on it.
+	monitors []monitorEntry
 
 	// Shutdown coordination
 	shutdown chan struct{}
@@ -250,8 +273,9 @@ func (s *Steward) startStandalone(ctx context.Context) error {
 	// When the Compare step detects drift, this logs the event before Set corrects it.
 	s.executor.SetDriftEventHandler(s.onManagedResourceDrift)
 
-	// Give monitors a moment to start
-	time.Sleep(50 * time.Millisecond)
+	// Start monitors for modules that implement the Monitor interface.
+	// Monitor events feed a targeted reconcile of the changed resource.
+	s.startMonitors(ctx)
 
 	// Converge immediately on startup
 	s.runConvergence(ctx)
@@ -429,6 +453,130 @@ func (s *Steward) convergenceLoop(ctx context.Context, interval time.Duration) {
 			s.runConvergence(ctx)
 		}
 	}
+}
+
+// startMonitors iterates the cfg resources, loads each module from the factory,
+// type-asserts modules.Monitor, and calls Monitor(ctx, resourceID, desired) for
+// each module that implements the interface. A fan-in goroutine forwards all
+// ChangeEvents to a single dispatch loop that calls runTargetedReconcile.
+//
+// Modules that do not implement Monitor are silently skipped — they fall back
+// to the scheduled convergence interval. This is always the case today; the
+// first Monitor implementation (Hyper-V) lands in S2.
+func (s *Steward) startMonitors(ctx context.Context) {
+	var entries []monitorEntry
+
+	for _, resource := range s.standaloneConfig.Resources {
+		bundle := bundleNameFromModuleRef(resource.Module)
+
+		mod, err := s.moduleFactory.LoadModule(bundle)
+		if err != nil || mod == nil {
+			continue
+		}
+
+		mon, ok := mod.(modules.Monitor)
+		if !ok {
+			continue
+		}
+
+		resourceID := s.executor.GetResourceID(resource)
+		desired := execution.NewConfigState(resource.Config)
+
+		if err := mon.Monitor(ctx, resourceID, desired); err != nil {
+			s.logger.Warn("Failed to start module monitor",
+				"resource", resource.Name,
+				"resource_id", logging.SanitizeLogValue(resourceID),
+				"error", err)
+			continue
+		}
+
+		entries = append(entries, monitorEntry{
+			resourceID: resourceID,
+			resource:   resource,
+			monitor:    mon,
+		})
+	}
+
+	if len(entries) == 0 {
+		return
+	}
+
+	s.monitors = entries
+
+	// Fan-in: one forwarding goroutine per monitor channel; all send to fanIn.
+	fanIn := make(chan modules.ChangeEvent, len(entries)*4)
+	for _, entry := range entries {
+		ch := entry.monitor.Changes()
+		go func(ch <-chan modules.ChangeEvent) {
+			for {
+				select {
+				case evt, ok := <-ch:
+					if !ok {
+						return
+					}
+					select {
+					case fanIn <- evt:
+					case <-ctx.Done():
+						return
+					}
+				case <-ctx.Done():
+					return
+				}
+			}
+		}(ch)
+	}
+
+	go s.monitorEventLoop(ctx, fanIn)
+}
+
+// monitorEventLoop reads ChangeEvents from the fan-in channel and dispatches
+// a targeted reconcile for each event. It exits when the context is cancelled
+// or the shutdown channel is closed.
+func (s *Steward) monitorEventLoop(ctx context.Context, events <-chan modules.ChangeEvent) {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-s.shutdown:
+			return
+		case evt, ok := <-events:
+			if !ok {
+				return
+			}
+			s.logger.Info("Monitor change event received",
+				"resource_id", logging.SanitizeLogValue(evt.ResourceID),
+				"change_type", evt.ChangeType)
+			s.runTargetedReconcile(ctx, evt.ResourceID)
+		}
+	}
+}
+
+// runTargetedReconcile finds the ResourceConfig whose module-internal ID matches
+// resourceID and calls ExecuteResource for it. The ChangeEvent that triggered
+// this call is treated as a hint only — current state is read via module.Get()
+// and desired state comes from the cfg ResourceConfig, never from the event.
+//
+// If resourceID is not present in cfg (unmanaged resource), the call is a no-op.
+// ctx.Done() is checked before the reconcile so a shutdown mid-dispatch exits cleanly.
+func (s *Steward) runTargetedReconcile(ctx context.Context, resourceID string) {
+	select {
+	case <-ctx.Done():
+		return
+	default:
+	}
+
+	for _, resource := range s.standaloneConfig.Resources {
+		if s.executor.GetResourceID(resource) == resourceID {
+			s.logger.Info("Running targeted reconcile for monitored resource",
+				"resource", resource.Name,
+				"resource_id", logging.SanitizeLogValue(resourceID))
+			s.executor.ExecuteResource(ctx, resource)
+			return
+		}
+	}
+
+	s.logger.Info("Monitor event for unmanaged resource (not in cfg, skipping)",
+		"resource_id", logging.SanitizeLogValue(resourceID))
 }
 
 // Stop gracefully shuts down the steward and cleans up resources.


### PR DESCRIPTION
## Summary

- Wires the convergence runtime to detect and consume `modules.Monitor` on startup: `startMonitors` iterates cfg resources, type-asserts `modules.Monitor`, calls `Monitor(ctx, resourceID, desired)`, fans all `Changes()` channels into a dispatch goroutine, and calls `runTargetedReconcile` on each `ChangeEvent`
- `runTargetedReconcile` finds the matching `ResourceConfig` and calls `executor.ExecuteResource` — a targeted single-resource reconcile, not a full convergence; treats the event as a hint (current state read via `module.Get()`, desired state from cfg, `event.Details` ignored for all Set/Compare decisions)
- Fixes data race on `Executor.driftHandler` and `Executor.driftMode` with `sync.RWMutex` — both fields can be updated after start while the monitor event loop dispatches concurrent `ExecuteResource` calls
- `ChangeEvent.ResourceID` sanitized via `logging.SanitizeLogValue()` at every log site; unmanaged resource events are no-ops; `ctx.Done()` checked before each targeted reconcile

## Acceptance Criteria Status

- [x] `TestMonitorConsumerWiring` — Monitor called for every implementing module; ChangeEvent triggers `ExecuteResource` for that resourceID only (not full `ExecuteConfiguration`)
- [x] `TestMonitorEventIsHintNotTruth` — forged `Details` never reaches Set; Set receives cfg desired state
- [x] `TestMonitorModeNeverSets` — `DriftModeMonitor` reconcile never calls Set; emits `drift.detected.monitor`
- [x] Unmanaged resource event performs no Set
- [x] `ChangeEvent.ResourceID` sanitized at all log sites; `time.Sleep(50ms)` placeholder replaced
- [x] `make test-complete` passes

## Specialist Review Results

**QA Test Runner: PASS** — 143 packages, 0 failures; cross-platform builds verified; lint clean; marker file written

**QA Code Reviewer: PASS** — 0 blocking issues; 3 non-blocking warnings (pre-existing factory map race, minor test robustness notes)

**Security Engineer: PASS** — T1 invariant verified (Details never used for Set/Compare); ResourceID sanitized at all log sites; no central provider violations; no hardcoded secrets; DriftMode security invariant preserved

Fixes #2112