### PR TITLE
fleet/server: externalize DNA/fleet state to shared Postgres backend (Issue #2118)

### DIFF
--- a/features/controller/fleet/storage/backends.go
+++ b/features/controller/fleet/storage/backends.go
@@ -298,8 +298,11 @@ type DatabaseBackend struct {
 
 // NewDatabaseBackend creates a new PostgreSQL-based DNA storage backend
 func NewDatabaseBackend(config *Config, logger logging.Logger) (*DatabaseBackend, error) {
-	// Get connection string from environment or config
-	connString := os.Getenv("CFGMS_DNA_DATABASE_URL")
+	// Get connection string: config field > environment variable > individual env vars
+	connString := config.DatabaseURL
+	if connString == "" {
+		connString = os.Getenv("CFGMS_DNA_DATABASE_URL")
+	}
 	if connString == "" {
 		var err error
 		connString, err = buildDNAConnString()
@@ -372,6 +375,11 @@ func (b *DatabaseBackend) StoreRecord(ctx context.Context, record *DNARecord, co
 		return fmt.Errorf("failed to marshal DNA to JSON: %w", err)
 	}
 
+	// Extract fleet query fields from DNA attributes for indexed columns
+	osVal := extractDNAAttr(record.DNA, "os")
+	arch := extractDNAAttr(record.DNA, "architecture")
+	hostname := extractDNAAttr(record.DNA, "hostname")
+
 	// Execute insert with prepared statement
 	_, err = b.stmts.insertRecord.ExecContext(ctx,
 		record.DeviceID,
@@ -383,6 +391,11 @@ func (b *DatabaseBackend) StoreRecord(ctx context.Context, record *DNARecord, co
 		record.CompressedSize,
 		record.CompressionRatio,
 		record.ShardID,
+		record.TenantID,
+		osVal,
+		arch,
+		hostname,
+		record.Status,
 	)
 
 	if err != nil {
@@ -589,7 +602,14 @@ func (b *DatabaseBackend) initializeSchema() error {
 			compression_ratio REAL NOT NULL,
 			shard_id TEXT NOT NULL DEFAULT 'default',
 			created_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
-			
+
+			-- Fleet query fields extracted from DNA attributes for efficient filtering
+			tenant_id TEXT NOT NULL DEFAULT '',
+			os TEXT NOT NULL DEFAULT '',
+			architecture TEXT NOT NULL DEFAULT '',
+			hostname TEXT NOT NULL DEFAULT '',
+			status TEXT NOT NULL DEFAULT '',
+
 			-- Ensure unique version per device
 			UNIQUE(device_id, version)
 		);
@@ -604,6 +624,12 @@ func (b *DatabaseBackend) initializeSchema() error {
 
 		-- GIN index for JSONB queries (PostgreSQL-specific)
 		CREATE INDEX IF NOT EXISTS idx_dna_json_gin ON dna_history USING GIN(dna_json);
+
+		-- Fleet query indexes for efficient filtered searches
+		CREATE INDEX IF NOT EXISTS idx_dna_tenant ON dna_history(tenant_id);
+		CREATE INDEX IF NOT EXISTS idx_dna_os ON dna_history(os);
+		CREATE INDEX IF NOT EXISTS idx_dna_architecture ON dna_history(architecture);
+		CREATE INDEX IF NOT EXISTS idx_dna_status ON dna_history(status);
 
 		-- Reference table for deduplication
 		CREATE TABLE IF NOT EXISTS dna_references (
@@ -650,10 +676,11 @@ func (b *DatabaseBackend) prepareStatements() error {
 
 	// Insert DNA record statement
 	b.stmts.insertRecord, err = b.db.Prepare(`
-		INSERT INTO dna_history 
-		(device_id, timestamp, version, dna_json, content_hash, 
-		 original_size, compressed_size, compression_ratio, shard_id)
-		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+		INSERT INTO dna_history
+		(device_id, timestamp, version, dna_json, content_hash,
+		 original_size, compressed_size, compression_ratio, shard_id,
+		 tenant_id, os, architecture, hostname, status)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)
 	`)
 	if err != nil {
 		return fmt.Errorf("failed to prepare PostgreSQL insert record statement: %w", err)

--- a/features/controller/fleet/storage/database_backend.go
+++ b/features/controller/fleet/storage/database_backend.go
@@ -1,0 +1,221 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+// Package storage provides PostgreSQL-backed fleet query operations for DNA records.
+
+package storage
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	commonpb "github.com/cfgis/cfgms/api/proto/common"
+)
+
+// listAllDeviceIDs returns the distinct device IDs stored in the PostgreSQL dna_history table.
+// Used during controller startup to warm the in-memory steward registry.
+func (b *DatabaseBackend) listAllDeviceIDs(ctx context.Context) ([]string, error) {
+	rows, err := b.db.QueryContext(ctx, `SELECT DISTINCT device_id FROM dna_history`)
+	if err != nil {
+		return nil, fmt.Errorf("database: failed to list device IDs: %w", err)
+	}
+	defer rows.Close() //nolint:errcheck // rows.Close() error is non-actionable after row iteration completes
+
+	var ids []string
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			return nil, fmt.Errorf("database: failed to scan device ID: %w", err)
+		}
+		ids = append(ids, id)
+	}
+	return ids, rows.Err()
+}
+
+// GetLatestByDeviceID retrieves the most recent DNA record for a device, reading
+// directly from the PostgreSQL store rather than the in-memory index. This is the
+// path LoadFromStorage uses to warm the steward registry on startup.
+func (b *DatabaseBackend) GetLatestByDeviceID(ctx context.Context, deviceID string) (*DNARecord, error) {
+	row := b.db.QueryRowContext(ctx, `
+		SELECT device_id, tenant_id, os, architecture, hostname, status,
+		       version, timestamp, dna_json, content_hash,
+		       original_size, compressed_size, compression_ratio, shard_id
+		FROM dna_history
+		WHERE device_id = $1
+		ORDER BY version DESC
+		LIMIT 1
+	`, deviceID)
+
+	var rec DNARecord
+	var storedAt time.Time
+	var dnaJSON string
+	if err := row.Scan(
+		&rec.DeviceID,
+		&rec.TenantID,
+		new(string), // os — available in DNA.Attributes
+		new(string), // architecture
+		new(string), // hostname
+		&rec.Status,
+		&rec.Version,
+		&storedAt,
+		&dnaJSON,
+		&rec.ContentHash,
+		&rec.OriginalSize,
+		&rec.CompressedSize,
+		&rec.CompressionRatio,
+		&rec.ShardID,
+	); err != nil {
+		if err == sql.ErrNoRows {
+			return nil, fmt.Errorf("database: no DNA record found for device %s", deviceID)
+		}
+		return nil, fmt.Errorf("database: failed to retrieve latest DNA for device %s: %w", deviceID, err)
+	}
+	rec.StoredAt = storedAt
+
+	var dna commonpb.DNA
+	if err := json.Unmarshal([]byte(dnaJSON), &dna); err != nil {
+		return nil, fmt.Errorf("database: failed to unmarshal DNA JSON for device %s: %w", deviceID, err)
+	}
+	rec.DNA = &dna
+
+	return &rec, nil
+}
+
+// ping issues a trivial SELECT to confirm the PostgreSQL connection is live.
+func (b *DatabaseBackend) ping(ctx context.Context) error {
+	var one int
+	if err := b.db.QueryRowContext(ctx, `SELECT 1`).Scan(&one); err != nil {
+		return fmt.Errorf("database: ping failed: %w", err)
+	}
+	return nil
+}
+
+// QueryFleet executes a fleet query against the PostgreSQL backend.
+// Each non-empty filter field maps to an indexed column so the query
+// remains efficient at fleet scale.
+func (b *DatabaseBackend) QueryFleet(ctx context.Context, filter *FleetFilter) (*FleetQueryResult, error) {
+	if filter == nil {
+		filter = &FleetFilter{}
+	}
+
+	// Subquery: keep only the latest version per device
+	baseQuery := `
+		WITH latest AS (
+			SELECT device_id, MAX(version) AS max_version
+			FROM dna_history
+			GROUP BY device_id
+		)
+		SELECT h.device_id, h.tenant_id, h.os, h.architecture, h.hostname,
+		       h.status, h.version, h.timestamp, h.dna_json
+		FROM dna_history h
+		INNER JOIN latest l ON h.device_id = l.device_id AND h.version = l.max_version
+	`
+
+	var conditions []string
+	var args []interface{}
+	argIdx := 1
+
+	if filter.TenantID != "" {
+		conditions = append(conditions, fmt.Sprintf("h.tenant_id = $%d", argIdx))
+		args = append(args, filter.TenantID)
+		argIdx++
+	}
+	if filter.OS != "" {
+		conditions = append(conditions, fmt.Sprintf("h.os = $%d", argIdx))
+		args = append(args, filter.OS)
+		argIdx++
+	}
+	if filter.Architecture != "" {
+		conditions = append(conditions, fmt.Sprintf("h.architecture = $%d", argIdx))
+		args = append(args, filter.Architecture)
+		argIdx++
+	}
+	if filter.Status != "" {
+		conditions = append(conditions, fmt.Sprintf("h.status = $%d", argIdx))
+		args = append(args, filter.Status)
+		argIdx++
+	}
+	if len(filter.DeviceIDs) > 0 {
+		placeholders := make([]string, len(filter.DeviceIDs))
+		for i, id := range filter.DeviceIDs {
+			placeholders[i] = fmt.Sprintf("$%d", argIdx)
+			args = append(args, id)
+			argIdx++
+		}
+		conditions = append(conditions, "h.device_id IN ("+strings.Join(placeholders, ",")+")")
+	}
+
+	query := baseQuery
+	if len(conditions) > 0 {
+		query += " WHERE " + strings.Join(conditions, " AND ")
+	}
+	query += " ORDER BY h.device_id"
+
+	// Count query for pagination metadata
+	countQuery := `SELECT COUNT(*) FROM (` + query + `) sub`
+	countArgs := make([]interface{}, len(args))
+	copy(countArgs, args)
+	var totalCount int64
+	if err := b.db.QueryRowContext(ctx, countQuery, countArgs...).Scan(&totalCount); err != nil {
+		return nil, fmt.Errorf("database: failed to count fleet query results: %w", err)
+	}
+
+	// Apply pagination using integer formatting (type-safe; prevents injection).
+	if filter.Limit > 0 {
+		query += fmt.Sprintf(" LIMIT %d", filter.Limit)
+	}
+	if filter.Offset > 0 {
+		query += fmt.Sprintf(" OFFSET %d", filter.Offset)
+	}
+
+	rows, err := b.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("database: failed to execute fleet query: %w", err)
+	}
+	defer rows.Close() //nolint:errcheck // rows.Close() error is non-actionable after row iteration completes
+
+	var records []*FleetRecord
+	for rows.Next() {
+		var rec FleetRecord
+		var storedAt time.Time
+		var dnaJSON string
+
+		if err := rows.Scan(
+			&rec.DeviceID,
+			&rec.TenantID,
+			&rec.OS,
+			&rec.Architecture,
+			&rec.Hostname,
+			&rec.Status,
+			&rec.Version,
+			&storedAt,
+			&dnaJSON,
+		); err != nil {
+			return nil, fmt.Errorf("database: failed to scan fleet record: %w", err)
+		}
+		rec.StoredAt = storedAt
+
+		var dna commonpb.DNA
+		if err := json.Unmarshal([]byte(dnaJSON), &dna); err != nil {
+			b.logger.Warn("Failed to unmarshal DNA JSON for fleet record",
+				"device_id", rec.DeviceID, "error", err)
+		} else {
+			rec.DNA = &dna
+		}
+
+		records = append(records, &rec)
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("database: fleet query row iteration error: %w", err)
+	}
+
+	return &FleetQueryResult{
+		Records:    records,
+		TotalCount: totalCount,
+		Filter:     filter,
+	}, nil
+}

--- a/features/controller/fleet/storage/database_backend_test.go
+++ b/features/controller/fleet/storage/database_backend_test.go
@@ -1,0 +1,293 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+// Package storage provides tests for the PostgreSQL-backed DNA storage backend.
+
+package storage
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"os"
+	"strconv"
+	"testing"
+	"time"
+
+	_ "github.com/lib/pq"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	commonpb "github.com/cfgis/cfgms/api/proto/common"
+	"github.com/cfgis/cfgms/pkg/logging"
+	"github.com/cfgis/cfgms/pkg/testutil"
+
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+// buildDNATestDSN constructs a PostgreSQL DSN for DNA backend tests using the
+// same environment variables as the rest of the integration test suite.
+func buildDNATestDSN() string {
+	password := testutil.GetTestDBPassword()
+	host := "localhost"
+	port := 5432
+	if portStr := os.Getenv("CFGMS_TEST_DB_PORT"); portStr != "" {
+		if p, err := strconv.Atoi(portStr); err == nil {
+			port = p
+		}
+	}
+	return fmt.Sprintf("host=%s port=%d dbname=%s user=%s password=%s sslmode=disable",
+		host, port, "cfgms_test", "cfgms_test", password)
+}
+
+// skipIfDatabaseUnavailable skips the test when PostgreSQL is unreachable or
+// when running in short mode.
+func skipIfDatabaseUnavailable(t *testing.T) {
+	t.Helper()
+	if testing.Short() {
+		t.Skip("Skipping DNA database backend tests in short mode")
+	}
+
+	dsn := buildDNATestDSN()
+	db, err := sql.Open("postgres", dsn)
+	if err != nil {
+		t.Skip("PostgreSQL test database not available:", err)
+	}
+	defer db.Close() //nolint:errcheck
+
+	if err := db.Ping(); err != nil {
+		t.Skip("PostgreSQL test database not reachable:", err)
+	}
+}
+
+// dropDNATables removes DNA-related tables so each test starts with a clean schema.
+func dropDNATables(t *testing.T, dsn string) {
+	t.Helper()
+	db, err := sql.Open("postgres", dsn)
+	require.NoError(t, err)
+	defer db.Close() //nolint:errcheck
+
+	for _, table := range []string{"dna_references", "storage_stats", "dna_history"} {
+		_, err := db.Exec("DROP TABLE IF EXISTS " + table + " CASCADE")
+		require.NoError(t, err, "failed to drop %s", table)
+	}
+}
+
+// TestDatabaseBackend_TwoManagersShareState is the REQUIRED test for Issue #2118:
+// two Manager instances backed by the same PostgreSQL connection string
+// independently store and retrieve the same DNA records, proving no node-local
+// dependency exists in cluster mode.
+func TestDatabaseBackend_TwoManagersShareState(t *testing.T) {
+	skipIfDatabaseUnavailable(t)
+
+	dsn := buildDNATestDSN()
+	dropDNATables(t, dsn)
+
+	logger := logging.NewNoopLogger()
+
+	makeCfg := func() *Config {
+		cfg := DefaultConfig()
+		cfg.Backend = BackendDatabase
+		cfg.DatabaseURL = dsn
+		cfg.EnableDeduplication = false
+		return cfg
+	}
+
+	// Open first manager — simulates controller node A.
+	mgr1, err := NewManager(makeCfg(), logger)
+	require.NoError(t, err, "failed to create manager 1")
+	defer mgr1.Close() //nolint:errcheck
+
+	// Open second manager with the same connection string — simulates controller node B.
+	mgr2, err := NewManager(makeCfg(), logger)
+	require.NoError(t, err, "failed to create manager 2")
+	defer mgr2.Close() //nolint:errcheck
+
+	ctx := context.Background()
+
+	t.Run("NodeA_StoresDNA_NodeB_Retrieves", func(t *testing.T) {
+		deviceID := "shared-device-001"
+		dna := &commonpb.DNA{
+			Id: deviceID,
+			Attributes: map[string]string{
+				"os":           "linux",
+				"architecture": "amd64",
+				"hostname":     "node-a-host",
+				"version":      "1.2.3",
+			},
+			LastUpdated:     timestamppb.New(time.Now()),
+			ConfigHash:      "hash-abc",
+			LastSyncTime:    timestamppb.New(time.Now()),
+			AttributeCount:  4,
+			SyncFingerprint: "fp-001",
+		}
+
+		// Node A stores the DNA record.
+		require.NoError(t, mgr1.Store(ctx, deviceID, dna, nil))
+
+		// Node B retrieves it directly from the shared store (not from its own
+		// in-memory index, which is empty for mgr2).
+		record, err := mgr2.GetLatestByDeviceID(ctx, deviceID)
+		require.NoError(t, err, "node B must retrieve record stored by node A")
+
+		assert.Equal(t, deviceID, record.DeviceID)
+		require.NotNil(t, record.DNA)
+		assert.Equal(t, "linux", record.DNA.Attributes["os"])
+		assert.Equal(t, "amd64", record.DNA.Attributes["architecture"])
+		assert.Equal(t, "node-a-host", record.DNA.Attributes["hostname"])
+	})
+
+	t.Run("ListAllDeviceIDs_CrossNode", func(t *testing.T) {
+		devices := []string{"fleet-device-101", "fleet-device-102", "fleet-device-103"}
+		for _, id := range devices {
+			dna := &commonpb.DNA{
+				Id:              id,
+				Attributes:      map[string]string{"os": "linux", "hostname": id},
+				LastUpdated:     timestamppb.New(time.Now()),
+				AttributeCount:  2,
+				SyncFingerprint: "fp-" + id,
+			}
+			require.NoError(t, mgr1.Store(ctx, id, dna, nil), "node A failed to store %s", id)
+		}
+
+		// Node B lists all device IDs — must see records written by node A.
+		ids, err := mgr2.ListAllDeviceIDs(ctx)
+		require.NoError(t, err)
+
+		idSet := make(map[string]bool, len(ids))
+		for _, id := range ids {
+			idSet[id] = true
+		}
+		for _, expected := range devices {
+			assert.True(t, idSet[expected], "node B missing device %s stored by node A", expected)
+		}
+	})
+
+	t.Run("Ping_DatabaseBackend", func(t *testing.T) {
+		require.NoError(t, mgr1.Ping(ctx))
+		require.NoError(t, mgr2.Ping(ctx))
+	})
+
+	t.Run("StoreWithTenantAndStatus", func(t *testing.T) {
+		deviceID := "tenant-device-001"
+		dna := &commonpb.DNA{
+			Id: deviceID,
+			Attributes: map[string]string{
+				"os":           "windows",
+				"architecture": "amd64",
+				"hostname":     "win-host-01",
+			},
+			LastUpdated:     timestamppb.New(time.Now()),
+			AttributeCount:  3,
+			SyncFingerprint: "fp-tenant-001",
+		}
+		opts := &StoreOptions{TenantID: "tenant-alpha", Status: "online"}
+		require.NoError(t, mgr1.Store(ctx, deviceID, dna, opts))
+
+		// Node B retrieves the record and verifies tenant/status fields.
+		record, err := mgr2.GetLatestByDeviceID(ctx, deviceID)
+		require.NoError(t, err)
+		assert.Equal(t, "tenant-alpha", record.TenantID)
+		assert.Equal(t, "online", record.Status)
+	})
+}
+
+// TestDatabaseBackend_StoreAndRetrieve is a unit test for the single-node
+// DatabaseBackend verifying that Store and GetLatestByDeviceID round-trip
+// correctly using the same Manager instance.
+func TestDatabaseBackend_StoreAndRetrieve(t *testing.T) {
+	skipIfDatabaseUnavailable(t)
+
+	dsn := buildDNATestDSN()
+	dropDNATables(t, dsn)
+
+	cfg := DefaultConfig()
+	cfg.Backend = BackendDatabase
+	cfg.DatabaseURL = dsn
+	cfg.EnableDeduplication = false
+
+	mgr, err := NewManager(cfg, logging.NewNoopLogger())
+	require.NoError(t, err)
+	defer mgr.Close() //nolint:errcheck
+
+	ctx := context.Background()
+	deviceID := "db-test-device"
+	dna := &commonpb.DNA{
+		Id: deviceID,
+		Attributes: map[string]string{
+			"os":           "darwin",
+			"architecture": "arm64",
+			"hostname":     "mac-host",
+		},
+		LastUpdated:     timestamppb.New(time.Now()),
+		AttributeCount:  3,
+		SyncFingerprint: "fp-db",
+	}
+
+	require.NoError(t, mgr.Store(ctx, deviceID, dna, nil))
+
+	record, err := mgr.GetLatestByDeviceID(ctx, deviceID)
+	require.NoError(t, err)
+	require.NotNil(t, record)
+	assert.Equal(t, deviceID, record.DeviceID)
+	require.NotNil(t, record.DNA)
+	assert.Equal(t, "darwin", record.DNA.Attributes["os"])
+	assert.Equal(t, "arm64", record.DNA.Attributes["architecture"])
+}
+
+// TestDatabaseBackend_QueryFleet verifies that QueryFleet against the Postgres
+// backend filters records correctly by OS, status, and tenant.
+func TestDatabaseBackend_QueryFleet(t *testing.T) {
+	skipIfDatabaseUnavailable(t)
+
+	dsn := buildDNATestDSN()
+	dropDNATables(t, dsn)
+
+	cfg := DefaultConfig()
+	cfg.Backend = BackendDatabase
+	cfg.DatabaseURL = dsn
+	cfg.EnableDeduplication = false
+
+	mgr, err := NewManager(cfg, logging.NewNoopLogger())
+	require.NoError(t, err)
+	defer mgr.Close() //nolint:errcheck
+
+	ctx := context.Background()
+
+	// Seed records with varied attributes.
+	seed := []struct {
+		id     string
+		attrs  map[string]string
+		tenant string
+		status string
+	}{
+		{"dev-linux-1", map[string]string{"os": "linux", "architecture": "amd64", "hostname": "h1"}, "t1", "online"},
+		{"dev-linux-2", map[string]string{"os": "linux", "architecture": "arm64", "hostname": "h2"}, "t1", "offline"},
+		{"dev-windows-1", map[string]string{"os": "windows", "architecture": "amd64", "hostname": "h3"}, "t2", "online"},
+	}
+	for _, s := range seed {
+		dna := &commonpb.DNA{Id: s.id, Attributes: s.attrs, SyncFingerprint: "fp-" + s.id}
+		require.NoError(t, mgr.Store(ctx, s.id, dna, &StoreOptions{TenantID: s.tenant, Status: s.status}))
+	}
+
+	t.Run("FilterByOS", func(t *testing.T) {
+		result, err := mgr.QueryFleet(ctx, &FleetFilter{OS: "linux"})
+		require.NoError(t, err)
+		assert.Equal(t, int64(2), result.TotalCount)
+		for _, r := range result.Records {
+			assert.Equal(t, "linux", r.OS)
+		}
+	})
+
+	t.Run("FilterByStatus", func(t *testing.T) {
+		result, err := mgr.QueryFleet(ctx, &FleetFilter{Status: "online"})
+		require.NoError(t, err)
+		assert.Equal(t, int64(2), result.TotalCount)
+	})
+
+	t.Run("FilterByTenant", func(t *testing.T) {
+		result, err := mgr.QueryFleet(ctx, &FleetFilter{TenantID: "t2"})
+		require.NoError(t, err)
+		assert.Equal(t, int64(1), result.TotalCount)
+		assert.Equal(t, "dev-windows-1", result.Records[0].DeviceID)
+	})
+}

--- a/features/controller/fleet/storage/fleet_query.go
+++ b/features/controller/fleet/storage/fleet_query.go
@@ -70,12 +70,14 @@ func (m *Manager) QueryFleet(ctx context.Context, filter *FleetFilter) (*FleetQu
 		filter = &FleetFilter{}
 	}
 
-	sqliteBackend, ok := m.storage.(*SQLiteBackend)
-	if !ok {
-		return nil, fmt.Errorf("fleet query requires SQLite backend")
+	switch backend := m.storage.(type) {
+	case *SQLiteBackend:
+		return backend.QueryFleet(ctx, filter)
+	case *DatabaseBackend:
+		return backend.QueryFleet(ctx, filter)
+	default:
+		return nil, fmt.Errorf("fleet query requires SQLite or database backend, got %T", m.storage)
 	}
-
-	return sqliteBackend.QueryFleet(ctx, filter)
 }
 
 // QueryFleet executes the fleet query against the SQLite backend.
@@ -202,11 +204,14 @@ func (b *SQLiteBackend) QueryFleet(ctx context.Context, filter *FleetFilter) (*F
 // ListAllDeviceIDs returns the device IDs of all stewards in storage.
 // Used during controller startup to warm the in-memory registry.
 func (m *Manager) ListAllDeviceIDs(ctx context.Context) ([]string, error) {
-	sqliteBackend, ok := m.storage.(*SQLiteBackend)
-	if !ok {
-		return nil, fmt.Errorf("ListAllDeviceIDs requires SQLite backend")
+	switch backend := m.storage.(type) {
+	case *SQLiteBackend:
+		return backend.listAllDeviceIDs(ctx)
+	case *DatabaseBackend:
+		return backend.listAllDeviceIDs(ctx)
+	default:
+		return nil, fmt.Errorf("ListAllDeviceIDs requires SQLite or database backend, got %T", m.storage)
 	}
-	return sqliteBackend.listAllDeviceIDs(ctx)
 }
 
 // Ping performs a cheap O(1) round-trip to the durable store to confirm it is
@@ -215,15 +220,14 @@ func (m *Manager) ListAllDeviceIDs(ctx context.Context) ([]string, error) {
 // real-state signal a readiness probe needs (Issue #2012). Used by
 // ControllerService.StorageReady and the blue/green cutover smoketest.
 func (m *Manager) Ping(ctx context.Context) error {
-	// Mirrors the SQLite-only constraint of ListAllDeviceIDs/GetLatestByDeviceID:
-	// the OSS composite DNA backend is SQLite (DefaultConfig). A future
-	// PostgreSQL/file backend rollout must extend this to round-trip that
-	// backend, or readiness (and the cutover smoketest) will hard-fail there.
-	sqliteBackend, ok := m.storage.(*SQLiteBackend)
-	if !ok {
-		return fmt.Errorf("Ping requires SQLite backend")
+	switch backend := m.storage.(type) {
+	case *SQLiteBackend:
+		return backend.ping(ctx)
+	case *DatabaseBackend:
+		return backend.ping(ctx)
+	default:
+		return fmt.Errorf("Ping requires SQLite or database backend, got %T", m.storage)
 	}
-	return sqliteBackend.ping(ctx)
 }
 
 // ping issues a trivial SELECT to confirm the SQLite connection is live and the
@@ -245,11 +249,14 @@ func (b *SQLiteBackend) ping(ctx context.Context) error {
 // in-memory index, which starts empty after a controller restart — so this is
 // the path LoadFromStorage must use to warm the steward registry on startup.
 func (m *Manager) GetLatestByDeviceID(ctx context.Context, deviceID string) (*DNARecord, error) {
-	sqliteBackend, ok := m.storage.(*SQLiteBackend)
-	if !ok {
-		return nil, fmt.Errorf("GetLatestByDeviceID requires SQLite backend")
+	switch backend := m.storage.(type) {
+	case *SQLiteBackend:
+		return backend.GetLatestByDeviceID(ctx, deviceID)
+	case *DatabaseBackend:
+		return backend.GetLatestByDeviceID(ctx, deviceID)
+	default:
+		return nil, fmt.Errorf("GetLatestByDeviceID requires SQLite or database backend, got %T", m.storage)
 	}
-	return sqliteBackend.GetLatestByDeviceID(ctx, deviceID)
 }
 
 // listAllDeviceIDs queries the distinct device IDs stored in dna_history.

--- a/features/controller/fleet/storage/fleet_query_test.go
+++ b/features/controller/fleet/storage/fleet_query_test.go
@@ -282,15 +282,19 @@ func TestQueryFleet_NonSQLiteBackendReturnsError(t *testing.T) {
 
 	_, err := mgr.QueryFleet(context.Background(), nil)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "fleet query requires SQLite backend")
+	assert.Contains(t, err.Error(), "fleet query requires SQLite or database backend")
 
 	_, err = mgr.ListAllDeviceIDs(context.Background())
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "ListAllDeviceIDs requires SQLite backend")
+	assert.Contains(t, err.Error(), "ListAllDeviceIDs requires SQLite or database backend")
 
 	_, err = mgr.GetLatestByDeviceID(context.Background(), "dev-1")
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "GetLatestByDeviceID requires SQLite backend")
+	assert.Contains(t, err.Error(), "GetLatestByDeviceID requires SQLite or database backend")
+
+	err = mgr.Ping(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "Ping requires SQLite or database backend")
 }
 
 // noopBackend is a minimal Backend implementation used to exercise error paths.

--- a/features/controller/fleet/storage/storage.go
+++ b/features/controller/fleet/storage/storage.go
@@ -51,8 +51,9 @@ type Manager struct {
 // Config defines the configuration for DNA storage management.
 type Config struct {
 	// Storage backend configuration
-	Backend BackendType `json:"backend" yaml:"backend"`
-	DataDir string      `json:"data_dir" yaml:"data_dir"` // Directory for storage files (default: "data")
+	Backend     BackendType `json:"backend" yaml:"backend"`
+	DataDir     string      `json:"data_dir" yaml:"data_dir"`         // Directory for storage files (default: "data")
+	DatabaseURL string      `json:"database_url" yaml:"database_url"` // PostgreSQL connection string for BackendDatabase
 
 	// Compression configuration
 	CompressionLevel       int     `json:"compression_level" yaml:"compression_level"`               // 1-9, higher = better compression

--- a/features/controller/server/server.go
+++ b/features/controller/server/server.go
@@ -68,6 +68,7 @@ import (
 	business "github.com/cfgis/cfgms/pkg/storage/interfaces/business"
 	cfgconfig "github.com/cfgis/cfgms/pkg/storage/interfaces/config"
 	_ "github.com/cfgis/cfgms/pkg/storage/providers/blobstore/filesystem" // register filesystem blob provider (Issue #1702)
+	_ "github.com/cfgis/cfgms/pkg/storage/providers/blobstore/s3"         // register S3 blob provider for cluster mode (Issue #2118)
 	_ "github.com/cfgis/cfgms/pkg/storage/providers/flatfile"             // register flatfile provider for OSS composite manager
 	memoryprovider "github.com/cfgis/cfgms/pkg/storage/providers/memory"  // in-memory upgrade store (Issue #1948)
 	_ "github.com/cfgis/cfgms/pkg/storage/providers/sqlite"               // register sqlite provider for OSS composite manager
@@ -246,18 +247,32 @@ func New(cfg *config.Config, logger logging.Logger) (*Server, error) {
 	// Initialize tenant management with durable storage
 	tenantManager := tenant.NewManager(storageManager.GetTenantStore(), rbacManager)
 
+	// Detect HA deployment mode early so we can select the correct DNA backend
+	// and blob provider before initializing either. The full haManager is
+	// initialized below; this read is environment-only and has no side effects.
+	haEarlyCfg := ha.DefaultConfig()
+	if err := haEarlyCfg.LoadFromEnvironment(); err != nil {
+		logger.Warn("Failed to load HA config from environment for backend selection", "error", err)
+	}
+	isClusterMode := haEarlyCfg.Mode == ha.ClusterMode
+
 	// DNA storage — durable steward DNA + fleet registry. Shared by the
 	// controller service (warm-loading the steward registry after a restart)
 	// and the reports engine. (Issue #1572)
 	//
-	// The data root must be an ABSOLUTE, CWD-independent path: two controllers
-	// of the same deployment can be launched from different working directories
-	// (notably the systemd unit vs. a blue/green candidate spawned by
-	// `cfg controller upgrade`), and they must resolve the SAME DNA store or the
-	// candidate comes up with an empty steward registry. See resolveDNADataRoot
-	// and Issue #2010.
+	// Single-node: SQLite at an absolute, CWD-independent path (see resolveDNADataRoot
+	// and Issue #2010). Cluster: PostgreSQL-backed DatabaseBackend shared by all nodes
+	// (connection string from CFGMS_DNA_DATABASE_URL); resolveDNADataRoot is not
+	// called in cluster mode (Issue #2118).
 	dnaStorageConfig := dnaStorage.DefaultConfig()
-	dnaStorageConfig.DataDir = filepath.Join(resolveDNADataRoot(cfg), "dna-reports")
+	if isClusterMode {
+		dnaStorageConfig.Backend = dnaStorage.BackendDatabase
+		// DatabaseURL left empty: NewDatabaseBackend reads CFGMS_DNA_DATABASE_URL
+		// or individual CFGMS_DNA_DB_* env vars.
+		logger.Info("Cluster mode: using PostgreSQL DNA backend (CFGMS_DNA_DATABASE_URL)")
+	} else {
+		dnaStorageConfig.DataDir = filepath.Join(resolveDNADataRoot(cfg), "dna-reports")
+	}
 	dnaStorageManager, dnaErr := dnaStorage.NewManager(dnaStorageConfig, logger)
 	if dnaErr != nil {
 		logger.Warn("Failed to initialize DNA storage; steward registry will not survive a controller restart", "error", dnaErr)
@@ -842,22 +857,49 @@ func New(cfg *config.Config, logger logging.Logger) (*Server, error) {
 	}
 
 	// Initialize installer artifact blob store (Issue #1702).
-	// Default BlobStorage.Root when not explicitly configured (e.g. in tests or
-	// minimal configs that rely on the storage path for co-location).
-	blobRoot := cfg.BlobStorage.Root
-	if blobRoot == "" {
-		if cfg.Storage.FlatfileRoot != "" {
-			blobRoot = filepath.Join(filepath.Dir(cfg.Storage.FlatfileRoot), "installers")
-		} else if cfg.Storage.SQLitePath != "" {
-			blobRoot = filepath.Join(filepath.Dir(cfg.Storage.SQLitePath), "installers")
+	// Cluster mode: S3-compatible blob store so all nodes share one installer
+	// repository (bucket from CFGMS_S3_INSTALLER_BUCKET, credentials from the
+	// default AWS credential chain). Single-node: filesystem blob store with the
+	// node-local path resolved from config (Issue #2118).
+	var installerBlobStore blob.BlobStore
+	var blobErr error
+	if isClusterMode {
+		bucket := os.Getenv("CFGMS_S3_INSTALLER_BUCKET")
+		if bucket == "" {
+			return nil, fmt.Errorf("cluster mode requires CFGMS_S3_INSTALLER_BUCKET to be set for installer artifact storage")
 		}
+		s3Cfg := map[string]interface{}{
+			"bucket": bucket,
+		}
+		if region := os.Getenv("CFGMS_S3_INSTALLER_REGION"); region != "" {
+			s3Cfg["region"] = region
+		}
+		if endpoint := os.Getenv("CFGMS_S3_INSTALLER_ENDPOINT_URL"); endpoint != "" {
+			s3Cfg["endpoint_url"] = endpoint
+		}
+		installerBlobStore, blobErr = blob.CreateBlobStoreFromConfig("s3", s3Cfg)
+		if blobErr != nil {
+			return nil, fmt.Errorf("failed to initialize S3 installer blob store: %w", blobErr)
+		}
+		logger.Info("Cluster mode: S3 installer blob store initialized", "bucket", bucket)
+	} else {
+		// Default BlobStorage.Root when not explicitly configured (e.g. in tests or
+		// minimal configs that rely on the storage path for co-location).
+		blobRoot := cfg.BlobStorage.Root
+		if blobRoot == "" {
+			if cfg.Storage.FlatfileRoot != "" {
+				blobRoot = filepath.Join(filepath.Dir(cfg.Storage.FlatfileRoot), "installers")
+			} else if cfg.Storage.SQLitePath != "" {
+				blobRoot = filepath.Join(filepath.Dir(cfg.Storage.SQLitePath), "installers")
+			}
+		}
+		installerBlobStore, blobErr = blob.CreateBlobStoreFromConfig("filesystem",
+			map[string]interface{}{"root": blobRoot})
+		if blobErr != nil {
+			return nil, fmt.Errorf("failed to initialize installer blob store: %w", blobErr)
+		}
+		logger.Info("Installer artifact blob store initialized", "root", blobRoot)
 	}
-	installerBlobStore, blobErr := blob.CreateBlobStoreFromConfig("filesystem",
-		map[string]interface{}{"root": blobRoot})
-	if blobErr != nil {
-		return nil, fmt.Errorf("failed to initialize installer blob store: %w", blobErr)
-	}
-	logger.Info("Installer artifact blob store initialized", "root", blobRoot)
 
 	// Initialize HTTP API server
 	httpServer, err := api.New(


### PR DESCRIPTION
## Summary

- `features/controller/fleet/storage/database_backend.go` (new): PostgreSQL implementations of `listAllDeviceIDs`, `GetLatestByDeviceID`, `ping`, `QueryFleet` — the four direct-SQL methods previously hard-requiring the SQLite backend.
- `backends.go` / `fleet_query.go` / `storage.go`: expand Postgres `dna_history` schema with fleet-query columns, update `StoreRecord`, dispatch fleet-query methods to either SQLite or DatabaseBackend via type switches.
- `server.go`: in cluster mode (`CFGMS_HA_MODE=cluster`) select the PostgreSQL DNA backend and S3 blob store; single-node defaults (SQLite + filesystem blob) unchanged.
- `database_backend_test.go` (new): two-Manager Postgres shared-state test proving no node-local dependency.

## Acceptance Criteria Status

- [x] `features/controller/fleet/storage/` gains a `DatabaseBackend` so `dnaStorage.NewManager` targets Postgres when `Config.Backend == BackendDatabase`.
- [x] `server.go` selects the database DNA backend and the S3 blob provider when `ha.ClusterMode` is active; node-local SQLite + filesystem blob remain the single-node default.
- [x] In cluster mode no durable fleet-state code path reads/writes a node-local path (`resolveDNADataRoot` unreachable in cluster mode).
- [x] [REQUIRED TEST] `TestDatabaseBackend_TwoManagersShareState` — two `Manager` instances sharing one Postgres connection string independently store and retrieve the same DNA records and steward registrations (no node-local dependency).
- [x] `make test-complete` passes.

## Specialist Review Results

**QA Test Runner:** PASS — all 80+ packages pass; cross-platform builds (linux/darwin/windows × amd64/arm64) PASS; linting PASS (gofmt auto-applied minor alignment fix to import block).

**QA Code Reviewer:** PASS — no blocking issues. Verified: no mocks, legitimate `t.Skip()` calls (short mode + DB reachability), parameterized SQL queries, proper nolint justification comments. Two warnings addressed: added Ping error-path test to `fleet_query_test.go`, added nolint justification comments to `database_backend.go`.

**Security Engineer:** PASS — 0 blocking issues, 0 warnings. SQL injection: all parameterized; LIMIT/OFFSET type-safe integer formatting; credentials never logged; `sslmode=require` default in production; architecture check clean.

Fixes #2118