### PR TITLE
agent-dispatch: mint sub-tenant + scoped API key, tmpfs-inject, revoke on cleanup (Issue #2124)

### DIFF
--- a/.claude/scripts/agent-dispatch.sh
+++ b/.claude/scripts/agent-dispatch.sh
@@ -7,6 +7,209 @@ set -euo pipefail
 REPO_ROOT="${CFGMS_TEST_REPO_ROOT:-$(cd "$(dirname "$0")/../.." && pwd)}"
 WORKTREE_BASE="${CFGMS_TEST_WORKTREE_BASE:-$(cd "$REPO_ROOT/.." && pwd)/worktrees}"
 
+# Base directory for per-agent API key tmpfs files.
+# Override CFGMS_TEST_CRED_BASE in hermetic tests.
+AGENT_CRED_BASE="${CFGMS_TEST_CRED_BASE:-/run/cfgms/agent-cred}"
+
+# ---------------------------------------------------------------------------
+# Tier 1 credential lifecycle helpers (Issue #2124)
+# ---------------------------------------------------------------------------
+
+# _tier1_curl <method> <path> [curl-args...]
+# Authenticated curl call to the Tier 1 controller REST API.
+# Auth: uses CFGMS_TIER1_ADMIN_KEY (Bearer token) when set, otherwise extracts
+# mTLS cert+key from CFGMS_ADMIN_BUNDLE and uses --cert/--key.
+# Returns: curl output on stdout; curl exit code propagated.
+#
+# Test hook: set CFGMS_TEST_MOCK_TIER1_DIR to a directory containing mock
+# response files named <METHOD>_<sanitized-path> (e.g. POST__api_v1_tenants).
+# Non-alphanumeric chars in path are replaced with underscores. If a matching
+# file exists, its content is echoed and the function returns 0 — no real HTTP.
+_tier1_curl() {
+  local method="$1"; shift
+  local path="$1"; shift
+  local tier1_url="${CFGMS_TIER1_URL:-}"
+
+  # Test hook: file-based mock responses avoid bash variable-name constraints.
+  if [[ -n "${CFGMS_TEST_MOCK_TIER1_DIR:-}" && -d "${CFGMS_TEST_MOCK_TIER1_DIR}" ]]; then
+    local safe_path
+    safe_path=$(echo "$path" | tr -c 'a-zA-Z0-9' '_')
+    local mock_file="${CFGMS_TEST_MOCK_TIER1_DIR}/${method}_${safe_path}"
+    if [[ -f "$mock_file" ]]; then
+      cat "$mock_file"
+      return 0
+    fi
+    # No matching mock file → simulate connection error (controller unreachable).
+    echo "mock:no_response_for:${method}:${path}" >&2
+    return 1
+  fi
+
+  if [[ -z "$tier1_url" ]]; then
+    echo "CFGMS_TIER1_URL not set" >&2
+    return 1
+  fi
+
+  local curl_auth=()
+  local admin_key="${CFGMS_TIER1_ADMIN_KEY:-}"
+  if [[ -n "$admin_key" ]]; then
+    curl_auth=(-H "Authorization: Bearer ${admin_key}")
+  elif [[ -n "${CFGMS_ADMIN_BUNDLE:-}" ]] && [[ -f "${CFGMS_ADMIN_BUNDLE}" ]]; then
+    # Extract cert, key, CA from the bundle YAML into temp files.
+    local tmp_cert tmp_key tmp_ca
+    tmp_cert=$(mktemp /tmp/cfgms-dispatch-cert-XXXXXX.pem)
+    tmp_key=$(mktemp /tmp/cfgms-dispatch-key-XXXXXX.pem)
+    tmp_ca=$(mktemp /tmp/cfgms-dispatch-ca-XXXXXX.pem)
+    # shellcheck disable=SC2064
+    trap "rm -f '$tmp_cert' '$tmp_key' '$tmp_ca'" RETURN
+    python3 - "${CFGMS_ADMIN_BUNDLE}" "$tmp_cert" "$tmp_key" "$tmp_ca" <<'PY'
+import sys, re
+bundle_path, cert_out, key_out, ca_out = sys.argv[1:]
+text = open(bundle_path).read()
+def extract(name):
+    m = re.search(r'(?m)^' + name + r':\s*\|\s*\n((?:  .+\n?)*)', text)
+    if not m:
+        raise SystemExit(f"field {name} not found in bundle")
+    return re.sub(r'(?m)^  ', '', m.group(1))
+open(cert_out, 'w').write(extract('cert_pem'))
+open(key_out, 'w').write(extract('key_pem'))
+open(ca_out, 'w').write(extract('ca_pem'))
+PY
+    curl_auth=(--cert "$tmp_cert" --key "$tmp_key" --cacert "$tmp_ca")
+  else
+    echo "no auth available — set CFGMS_TIER1_ADMIN_KEY or CFGMS_ADMIN_BUNDLE" >&2
+    return 1
+  fi
+
+  curl -sf -X "$method" \
+    "${tier1_url}${path}" \
+    -H "Content-Type: application/json" \
+    "${curl_auth[@]}" \
+    "$@"
+}
+
+# mint_agent_creds <num>
+# Creates agent-test/<num> sub-tenant (idempotent) and issues an agent.dev-scoped
+# API key. Writes key value to ${AGENT_CRED_BASE}/<num>/api.key (0600) and the
+# key ID to ${AGENT_CRED_BASE}/<num>/api.key.id (0600).
+# On failure: emits CRED_MINT_FAILED:<reason> and returns non-zero.
+mint_agent_creds() {
+  local num="$1"
+  local cred_dir="${AGENT_CRED_BASE}/${num}"
+  local tenant_id="agent-test/${num}"
+
+  # Create and secure the per-agent cred dir.
+  mkdir -p "$cred_dir"
+  chmod 700 "$cred_dir"
+
+  # 1. Create agent-test sub-tenant (idempotent — 409 is success).
+  local create_resp http_code
+  create_resp=$(_tier1_curl POST /api/v1/tenants \
+    -d "{\"id\":\"${num}\",\"name\":\"Agent Test ${num}\",\"parent_id\":\"agent-test\"}" 2>&1) || {
+    # Check if it was a 409 conflict — tenant already exists, continue.
+    if echo "$create_resp" | grep -q "TENANT_EXISTS\|409\|already exists"; then
+      : # idempotent
+    else
+      rm -rf "$cred_dir"
+      echo "CRED_MINT_FAILED:tenant_create:${create_resp}"
+      return 1
+    fi
+  }
+
+  # 2. Issue agent.dev-scoped API key bound to agent-test/<num>.
+  local key_resp key_value key_id
+  key_resp=$(_tier1_curl POST /api/v1/api-keys \
+    -d "{\"name\":\"agent-${num}\",\"role_id\":\"agent.dev\",\"tenant_id\":\"${tenant_id}\"}" 2>&1) || {
+    rm -rf "$cred_dir"
+    echo "CRED_MINT_FAILED:apikey_create:${key_resp}"
+    return 1
+  }
+
+  # Extract key value and ID from the response envelope.
+  key_value=$(echo "$key_resp" | python3 -c "
+import json, sys
+d = json.load(sys.stdin)
+print(d.get('data', {}).get('key', '') or d.get('key', ''))
+" 2>/dev/null || true)
+  key_id=$(echo "$key_resp" | python3 -c "
+import json, sys
+d = json.load(sys.stdin)
+print(d.get('data', {}).get('id', '') or d.get('id', ''))
+" 2>/dev/null || true)
+
+  if [[ -z "$key_value" || -z "$key_id" ]]; then
+    rm -rf "$cred_dir"
+    local missing_fields=""
+    [[ -z "$key_value" ]] && missing_fields+="key,"
+    [[ -z "$key_id" ]] && missing_fields+="id,"
+    echo "CRED_MINT_FAILED:apikey_parse:missing=${missing_fields%,}"
+    return 1
+  fi
+
+  # 3. Write credential files (600 — no world or group read).
+  printf '%s' "$key_value" > "${cred_dir}/api.key"
+  chmod 600 "${cred_dir}/api.key"
+  printf '%s' "$key_id" > "${cred_dir}/api.key.id"
+  chmod 600 "${cred_dir}/api.key.id"
+
+  echo "CRED_MINTED:${num}:${key_id}"
+}
+
+# revoke_agent_creds <num>
+# Deletes the API key and suspends the agent-test/<num> sub-tenant.
+# Idempotent: missing cred dir emits INFO:no_cred_to_revoke:<num> and returns 0.
+# Controller-unreachable: records failure to revoke-failed.txt (0600); never blocks cleanup.
+revoke_agent_creds() {
+  local num="$1"
+  local cred_dir="${AGENT_CRED_BASE}/${num}"
+  local tenant_id="agent-test/${num}"
+
+  if [[ ! -d "$cred_dir" ]]; then
+    echo "INFO:no_cred_to_revoke:${num}"
+    return 0
+  fi
+
+  local key_id_file="${cred_dir}/api.key.id"
+  local revoke_failed_file="${cred_dir}/revoke-failed.txt"
+  local errors=()
+
+  # 1. Delete the API key (key lookup miss → immediate 401, no cache flush needed).
+  if [[ -f "$key_id_file" ]]; then
+    local key_id
+    key_id=$(cat "$key_id_file")
+    local del_resp
+    del_resp=$(_tier1_curl DELETE "/api/v1/api-keys/${key_id}" 2>&1) || {
+      local ts
+      ts=$(date -u +%s 2>/dev/null || echo "unknown")
+      errors+=("${key_id} ${ts} apikey_delete:${del_resp}")
+    }
+    if [[ ${#errors[@]} -eq 0 ]]; then
+      echo "CRED_REVOKED:apikey:${key_id}"
+    fi
+  else
+    echo "INFO:no_key_id_file:${num}"
+  fi
+
+  # 2. Suspend the agent sub-tenant.
+  local susp_resp
+  susp_resp=$(_tier1_curl POST "/api/v1/tenants/${tenant_id}/suspend" 2>&1) || {
+    local ts
+    ts=$(date -u +%s 2>/dev/null || echo "unknown")
+    errors+=("${tenant_id} ${ts} tenant_suspend:${susp_resp}")
+  }
+  if [[ ${#errors[@]} -eq 0 || ( ${#errors[@]} -eq 1 && "${errors[0]}" != *"tenant_suspend"* ) ]]; then
+    echo "CRED_REVOKED:tenant:${tenant_id}"
+  fi
+
+  # Record any revocation failures for manual follow-up (never block cleanup).
+  if [[ ${#errors[@]} -gt 0 ]]; then
+    printf '%s\n' "${errors[@]}" >> "$revoke_failed_file"
+    chmod 600 "$revoke_failed_file"
+    for err in "${errors[@]}"; do
+      echo "WARN:revoke_failed:${num}:${err}"
+    done
+  fi
+}
+
 # Ensure clone is based on latest remote develop, not stale local state.
 # Called inside fresh clones after setting the remote URL.
 sync_to_remote_develop() {
@@ -398,10 +601,25 @@ case "$cmd" in
   launch)
     [[ $# -eq 1 ]] || { echo "launch requires exactly one issue number"; exit 1; }
     num="$1"
+    [[ "$num" =~ ^[0-9]+$ ]] || { echo "launch requires a numeric issue number"; exit 1; }
     gate_credentials_for_launch
     clone_path="${WORKTREE_BASE}/story-${num}"
     real_path=$(realpath "$clone_path")
     gh_token=$(gh auth token)
+
+    # Mint sub-tenant + scoped API key; write to per-agent tmpfs dir (Issue #2124).
+    # On mint failure: emit CRED_MINT_FAILED, clean up, exit non-zero — never start the container.
+    cred_dir="${AGENT_CRED_BASE}/${num}"
+    if ! mint_out=$(mint_agent_creds "$num" 2>&1); then
+      echo "$mint_out"
+      rm -rf "$clone_path"
+      echo "CLEANED:clone:${clone_path}"
+      exit 1
+    fi
+    echo "$mint_out"
+
+    tier1_url="${CFGMS_TIER1_URL:-}"
+
     if container_id=$(docker run -d \
       --name "cfg-agent-${num}" \
       --label "cfg-agent=true" \
@@ -414,14 +632,20 @@ case "$cmd" in
       -v "claude-creds:/persist" \
       -v "cfgms-go-build-cache:/home/agent/.cache/go-build" \
       -v "cfgms-go-mod-cache:/home/agent/go/pkg/mod" \
+      -v "${cred_dir}:/run/cfgms/agent-cred:ro" \
       -e "GH_TOKEN=${gh_token}" \
+      -e "CFGMS_API_KEY_FILE=/run/cfgms/agent-cred/api.key" \
+      -e "CFGMS_TENANT=agent-test/${num}" \
+      -e "CFGMS_TIER1_URL=${tier1_url}" \
       --cap-add NET_ADMIN \
       cfg-agent:latest \
       "${num}" 2>&1); then
       echo "LAUNCHED:${num}:${container_id}"
     else
-      # Launch failed — clean up orphaned clone to prevent blocking future dispatches
+      # Launch failed — revoke creds and clean up to prevent orphaned resources.
       echo "LAUNCH_FAILED:${num}:${container_id}"
+      revoke_agent_creds "$num" || true
+      rm -rf "${cred_dir}" 2>/dev/null || true
       rm -rf "$clone_path"
       echo "CLEANED:clone:${clone_path}"
       exit 1
@@ -780,7 +1004,9 @@ else:
     [[ $# -eq 1 ]] || { echo "cleanup-issue requires exactly one issue number or item_id"; exit 1; }
     num="$1"
     if [[ "$num" =~ ^[0-9]+$ ]]; then
-      # Issue mode (numeric): existing behavior
+      # Issue mode (numeric): revoke API key + suspend tenant, then remove container + clone.
+      revoke_agent_creds "$num" || true
+      rm -rf "${AGENT_CRED_BASE}/${num}" 2>/dev/null || true
       docker cp "cfg-agent-${num}:/tmp/agent-result.json" "/tmp/agent-result-${num}.json" 2>/dev/null || true
       if docker rm -f "cfg-agent-${num}" >/dev/null 2>&1; then
         echo "CLEANED:container:cfg-agent-${num}"
@@ -1197,6 +1423,13 @@ PROMPT_EOF
 
       echo "STALE:${container_name}:finished=${finished_iso}:pr=${pr_num:-unknown}"
 
+      # Revoke any agent.dev API key associated with this review agent (Issue #2124).
+      # Review agents use the same cred dir layout as issue agents when pr_num is known.
+      if [[ -n "$pr_num" ]]; then
+        revoke_agent_creds "review-pr-${pr_num}" || true
+        rm -rf "${AGENT_CRED_BASE}/review-pr-${pr_num}" 2>/dev/null || true
+      fi
+
       # Archive the result JSON for forensics.
       docker cp "${container_name}:/tmp/agent-result.json" "/tmp/agent-result-review-${pr_num:-${container_name}}.json" 2>/dev/null || true
 
@@ -1279,7 +1512,9 @@ PROMPT_EOF
 
       if $should_clean; then
         echo "STALE:${num}:${reason}"
-        # Reuse cleanup-issue logic
+        # Revoke API key + suspend tenant before removing container/clone (Issue #2124).
+        revoke_agent_creds "$num" || true
+        rm -rf "${AGENT_CRED_BASE}/${num}" 2>/dev/null || true
         docker cp "cfg-agent-${num}:/tmp/agent-result.json" "/tmp/agent-result-${num}.json" 2>/dev/null || true
         if docker rm -f "cfg-agent-${num}" >/dev/null 2>&1; then
           echo "CLEANED:container:cfg-agent-${num}"
@@ -1320,6 +1555,22 @@ PROMPT_EOF
     # branch + body and prints its result. Safe (no docker, no gh, no writes).
     [[ $# -eq 2 ]] || { echo "_test-resolve-pr requires <branch> <body>"; exit 1; }
     resolve_pr_story_or_item "$1" "$2"
+    ;;
+
+  _test-mint-creds)
+    # Hidden test hook for agent-apikey-injection.test.sh (Issue #2124).
+    # Calls mint_agent_creds with the supplied issue number.
+    # Env overrides: CFGMS_TEST_CRED_BASE, CFGMS_TEST_MOCK_TIER1_DIR, CFGMS_TIER1_URL.
+    [[ $# -eq 1 ]] || { echo "_test-mint-creds requires exactly one issue number"; exit 1; }
+    mint_agent_creds "$1"
+    ;;
+
+  _test-revoke-creds)
+    # Hidden test hook for agent-apikey-injection.test.sh (Issue #2124).
+    # Calls revoke_agent_creds with the supplied issue number.
+    # Env overrides: CFGMS_TEST_CRED_BASE, CFGMS_TEST_MOCK_TIER1_DIR, CFGMS_TIER1_URL.
+    [[ $# -eq 1 ]] || { echo "_test-revoke-creds requires exactly one issue number"; exit 1; }
+    revoke_agent_creds "$1"
     ;;
 
   *)

--- a/.claude/scripts/agent-dispatch.sh
+++ b/.claude/scripts/agent-dispatch.sh
@@ -637,6 +637,7 @@ case "$cmd" in
       -e "CFGMS_API_KEY_FILE=/run/cfgms/agent-cred/api.key" \
       -e "CFGMS_TENANT=agent-test/${num}" \
       -e "CFGMS_TIER1_URL=${tier1_url}" \
+      -e "CFGMS_ADMIN_BUNDLE=" \
       --cap-add NET_ADMIN \
       cfg-agent:latest \
       "${num}" 2>&1); then

--- a/.claude/scripts/tests/agent-apikey-injection.test.sh
+++ b/.claude/scripts/tests/agent-apikey-injection.test.sh
@@ -186,6 +186,14 @@ else
   printf '  FAIL  T3 cred dir :ro bind-mount not found in dispatch script\n'
 fi
 
+ran=$((ran + 1))
+if grep -q 'CFGMS_ADMIN_BUNDLE=' "${DISPATCH}"; then
+  printf '  ok    T3 launch sets CFGMS_ADMIN_BUNDLE="" (bundle auto-discovery disabled)\n'
+else
+  fail=$((fail + 1))
+  printf '  FAIL  T3 CFGMS_ADMIN_BUNDLE="" not found in dispatch script (bundle isolation missing)\n'
+fi
+
 # ---------------------------------------------------------------------------
 # T4: mint failure — CRED_MINT_FAILED, no cred dir, no orphan container
 # ---------------------------------------------------------------------------

--- a/.claude/scripts/tests/agent-apikey-injection.test.sh
+++ b/.claude/scripts/tests/agent-apikey-injection.test.sh
@@ -1,0 +1,382 @@
+#!/usr/bin/env bash
+# Hermetic tests for agent API key mint/inject/revoke lifecycle (Issue #2124).
+#
+# Covers:
+#  - mint_agent_creds: creates cred dir (0700), key file (0600), key-id file (0600)
+#  - launch: no key value in container env; key only via bind-mount path
+#  - mint failure: CRED_MINT_FAILED emitted, no cred dir left, no orphan container
+#  - launch: rejects non-numeric issue numbers before credential lookup (exit 1)
+#  - revoke_agent_creds: deletes key + suspends tenant; records revoke-failed.txt on error
+#  - cleanup paths: cleanup-issue, cleanup-stale, cleanup-stale-reviews each call revoke
+#  - after cleanup: key is rejected (401) — verified structurally via revoke call emission
+#
+# All tests are hermetic: no real Docker, no real controller calls.
+# Uses the _test-mint-creds / _test-revoke-creds hidden subcommands added in Issue #2124,
+# and the CFGMS_TEST_MOCK_TIER1_DIR file-based mock facility.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+DISPATCH="${SCRIPT_DIR}/../agent-dispatch.sh"
+
+if [[ ! -f "${DISPATCH}" ]]; then
+  printf 'FAIL: agent-dispatch.sh not found at %s\n' "${DISPATCH}" >&2
+  exit 1
+fi
+
+echo "agent-apikey-injection.test.sh"
+echo "------------------------------"
+
+ran=0
+fail=0
+
+check() {
+  local desc="$1" got="$2" want="$3"
+  ran=$((ran + 1))
+  if [[ "$got" == "$want" ]]; then
+    printf '  ok    %s\n' "$desc"
+  else
+    fail=$((fail + 1))
+    printf '  FAIL  %s\n         expected: %s\n         actual:   %s\n' "$desc" "$want" "$got"
+  fi
+}
+
+check_contains() {
+  local desc="$1" haystack="$2" needle="$3"
+  ran=$((ran + 1))
+  if echo "$haystack" | grep -qF "$needle"; then
+    printf '  ok    %s\n' "$desc"
+  else
+    fail=$((fail + 1))
+    printf '  FAIL  %s\n         expected to contain: %s\n         actual: %s\n' "$desc" "$needle" "$haystack"
+  fi
+}
+
+check_not_contains() {
+  local desc="$1" haystack="$2" needle="$3"
+  ran=$((ran + 1))
+  if ! echo "$haystack" | grep -qF "$needle"; then
+    printf '  ok    %s\n' "$desc"
+  else
+    fail=$((fail + 1))
+    printf '  FAIL  %s (must NOT contain "%s")\n         actual: %s\n' "$desc" "$needle" "$haystack"
+  fi
+}
+
+check_file_exists() {
+  local desc="$1" path="$2"
+  ran=$((ran + 1))
+  if [[ -f "$path" ]]; then
+    printf '  ok    %s\n' "$desc"
+  else
+    fail=$((fail + 1))
+    printf '  FAIL  %s — file not found: %s\n' "$desc" "$path"
+  fi
+}
+
+check_no_file() {
+  local desc="$1" path="$2"
+  ran=$((ran + 1))
+  if [[ ! -f "$path" ]]; then
+    printf '  ok    %s\n' "$desc"
+  else
+    fail=$((fail + 1))
+    printf '  FAIL  %s — file must not exist: %s\n' "$desc" "$path"
+  fi
+}
+
+check_perms() {
+  local desc="$1" path="$2" want_perms="$3"
+  ran=$((ran + 1))
+  local got_perms
+  got_perms=$(stat -c '%a' "$path" 2>/dev/null || stat -f '%p' "$path" 2>/dev/null | tail -c 4 || echo "ERR")
+  if [[ "$got_perms" == "$want_perms" ]]; then
+    printf '  ok    %s\n' "$desc"
+  else
+    fail=$((fail + 1))
+    printf '  FAIL  %s — expected %s, got %s (%s)\n' "$desc" "$want_perms" "$got_perms" "$path"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Shared mock values
+# ---------------------------------------------------------------------------
+MOCK_KEY_VALUE="test-api-key-value-abc123"
+MOCK_KEY_ID="test-key-id-xyz789"
+
+# Compute the sanitized path suffix that _tier1_curl uses for mock file lookup.
+# tr -c 'a-zA-Z0-9' '_' replaces all non-alphanumeric chars with underscores.
+# Path /api/v1/tenants  → _api_v1_tenants
+# Path /api/v1/api-keys → _api_v1_api_keys
+path_to_safe() { echo "$1" | tr -c 'a-zA-Z0-9' '_'; }
+
+# ---------------------------------------------------------------------------
+# T1: mint_agent_creds — happy path
+# ---------------------------------------------------------------------------
+tmpdir=$(mktemp -d)
+trap 'rm -rf "$tmpdir"' EXIT
+
+cred_base="${tmpdir}/creds"
+mock_dir="${tmpdir}/mock"
+mkdir -p "$mock_dir"
+
+# Write mock controller responses to the mock directory.
+# Each file: <METHOD>_<safe-path>
+printf '{"data":{"id":"42","name":"agent-test","status":"active"}}' \
+  > "${mock_dir}/POST_$(path_to_safe /api/v1/tenants)"
+printf '{"data":{"id":"%s","key":"%s","name":"agent-42","tenant_id":"agent-test/42"}}' \
+  "$MOCK_KEY_ID" "$MOCK_KEY_VALUE" \
+  > "${mock_dir}/POST_$(path_to_safe /api/v1/api-keys)"
+
+mint_out=$(
+  CFGMS_TEST_CRED_BASE="$cred_base" \
+  CFGMS_TEST_MOCK_TIER1_DIR="$mock_dir" \
+  CFGMS_TIER1_URL="https://fake-tier1.test" \
+  bash "${DISPATCH}" _test-mint-creds 42 2>&1
+) || true
+
+check_contains "T1 mint outputs CRED_MINTED" "$mint_out" "CRED_MINTED:42:"
+
+cred_dir="${cred_base}/42"
+
+# ---------------------------------------------------------------------------
+# T2: cred dir and file permissions
+# ---------------------------------------------------------------------------
+if [[ -d "$cred_dir" ]]; then
+  check_perms "T2 cred dir is 700" "$cred_dir" "700"
+  check_file_exists "T2 api.key exists" "${cred_dir}/api.key"
+  check_file_exists "T2 api.key.id exists" "${cred_dir}/api.key.id"
+  check_perms "T2 api.key is 600" "${cred_dir}/api.key" "600"
+  check_perms "T2 api.key.id is 600" "${cred_dir}/api.key.id" "600"
+
+  key_contents=$(cat "${cred_dir}/api.key" 2>/dev/null || true)
+  keyid_contents=$(cat "${cred_dir}/api.key.id" 2>/dev/null || true)
+  check "T2 api.key contains key value" "$key_contents" "$MOCK_KEY_VALUE"
+  check "T2 api.key.id contains key ID" "$keyid_contents" "$MOCK_KEY_ID"
+else
+  # Mark all T2 subtests as failed
+  for _ in 1 2 3 4 5 6 7; do
+    fail=$((fail + 1)); ran=$((ran + 1))
+  done
+  printf '  FAIL  T2 cred dir not created at %s\n' "$cred_dir"
+fi
+
+# ---------------------------------------------------------------------------
+# T3: launch — key value NOT in container env; cred injected via file
+# ---------------------------------------------------------------------------
+# Verify the launch block sets CFGMS_API_KEY_FILE, never CFGMS_API_KEY.
+# Structural check: search the dispatch script's launch block.
+launch_api_key_lines=$(awk '/^  launch\)/{p=1} p && /^  [a-z].*\)$/{if(!/^  launch\)/) exit} p' \
+  "${DISPATCH}" | grep -E '^\s*-e\s+"CFGMS_API_KEY=' | grep -v "CFGMS_API_KEY_FILE" || true)
+check "T3 launch does not set CFGMS_API_KEY (key value) in container env" \
+  "${launch_api_key_lines}" ""
+
+ran=$((ran + 1))
+if grep -q 'CFGMS_API_KEY_FILE=/run/cfgms/agent-cred/api.key' "${DISPATCH}"; then
+  printf '  ok    T3 launch sets CFGMS_API_KEY_FILE (not key value)\n'
+else
+  fail=$((fail + 1))
+  printf '  FAIL  T3 CFGMS_API_KEY_FILE not found in dispatch script\n'
+fi
+
+ran=$((ran + 1))
+if grep -q 'run/cfgms/agent-cred:ro' "${DISPATCH}"; then
+  printf '  ok    T3 launch bind-mounts cred dir as :ro\n'
+else
+  fail=$((fail + 1))
+  printf '  FAIL  T3 cred dir :ro bind-mount not found in dispatch script\n'
+fi
+
+# ---------------------------------------------------------------------------
+# T4: mint failure — CRED_MINT_FAILED, no cred dir, no orphan container
+# ---------------------------------------------------------------------------
+tmpdir2=$(mktemp -d)
+cred_base2="${tmpdir2}/creds"
+mock_dir2="${tmpdir2}/mock"
+mkdir -p "$mock_dir2"
+
+# Tenant create succeeds but api-keys returns unparseable content.
+printf '{"data":{"id":"99"}}' \
+  > "${mock_dir2}/POST_$(path_to_safe /api/v1/tenants)"
+printf 'not-valid-json' \
+  > "${mock_dir2}/POST_$(path_to_safe /api/v1/api-keys)"
+
+mint_fail_out=$(
+  CFGMS_TEST_CRED_BASE="$cred_base2" \
+  CFGMS_TEST_MOCK_TIER1_DIR="$mock_dir2" \
+  CFGMS_TIER1_URL="https://fake-tier1.test" \
+  bash "${DISPATCH}" _test-mint-creds 99 2>&1
+) || true
+
+check_contains "T4 mint failure emits CRED_MINT_FAILED" "$mint_fail_out" "CRED_MINT_FAILED"
+check_no_file "T4 mint failure leaves no api.key" "${cred_base2}/99/api.key"
+rm -rf "$tmpdir2"
+
+# ---------------------------------------------------------------------------
+# T4b: launch rejects non-numeric issue numbers before credential lookup
+# ---------------------------------------------------------------------------
+bad_launch_out=$(bash "${DISPATCH}" launch "not-a-number" 2>&1) || true
+bad_launch_exit=0
+(bash "${DISPATCH}" launch "not-a-number" >/dev/null 2>&1) || bad_launch_exit=$?
+check "T4b launch non-numeric exits non-zero" "$bad_launch_exit" "1"
+check_contains "T4b launch non-numeric emits error" "$bad_launch_out" "numeric"
+
+# ---------------------------------------------------------------------------
+# T5: revoke_agent_creds — happy path (key deleted, tenant suspended)
+# ---------------------------------------------------------------------------
+tmpdir3=$(mktemp -d)
+cred_base3="${tmpdir3}/creds"
+mock_dir3="${tmpdir3}/mock"
+mkdir -p "$mock_dir3"
+mkdir -p "${cred_base3}/55"
+chmod 700 "${cred_base3}/55"
+printf '%s' "$MOCK_KEY_VALUE" > "${cred_base3}/55/api.key"
+chmod 600 "${cred_base3}/55/api.key"
+printf '%s' "$MOCK_KEY_ID" > "${cred_base3}/55/api.key.id"
+chmod 600 "${cred_base3}/55/api.key.id"
+
+# Mock: DELETE the specific key ID
+printf '{"data":{"id":"%s","deleted":true}}' "$MOCK_KEY_ID" \
+  > "${mock_dir3}/DELETE_$(path_to_safe "/api/v1/api-keys/${MOCK_KEY_ID}")"
+# Mock: POST suspend the tenant
+printf '{"data":{"id":"agent-test/55","status":"suspended"}}' \
+  > "${mock_dir3}/POST_$(path_to_safe "/api/v1/tenants/agent-test/55/suspend")"
+
+revoke_out=$(
+  CFGMS_TEST_CRED_BASE="$cred_base3" \
+  CFGMS_TEST_MOCK_TIER1_DIR="$mock_dir3" \
+  CFGMS_TIER1_URL="https://fake-tier1.test" \
+  bash "${DISPATCH}" _test-revoke-creds 55 2>&1
+) || true
+
+check_contains "T5 revoke emits CRED_REVOKED:apikey" "$revoke_out" "CRED_REVOKED:apikey:${MOCK_KEY_ID}"
+check_contains "T5 revoke emits CRED_REVOKED:tenant" "$revoke_out" "CRED_REVOKED:tenant:agent-test/55"
+check_not_contains "T5 revoke no WARN:revoke_failed on success" "$revoke_out" "WARN:revoke_failed"
+rm -rf "$tmpdir3"
+
+# ---------------------------------------------------------------------------
+# T6: revoke — missing cred dir is a no-op
+# ---------------------------------------------------------------------------
+noop_out=$(
+  CFGMS_TEST_CRED_BASE="/tmp/definitely-nonexistent-cfgms-creds-$$" \
+  CFGMS_TIER1_URL="https://fake-tier1.test" \
+  bash "${DISPATCH}" _test-revoke-creds 77 2>&1
+) || true
+
+check_contains "T6 missing cred dir emits INFO:no_cred_to_revoke" \
+  "$noop_out" "INFO:no_cred_to_revoke:77"
+
+# ---------------------------------------------------------------------------
+# T7: revoke — controller unreachable writes revoke-failed.txt
+# ---------------------------------------------------------------------------
+tmpdir4=$(mktemp -d)
+cred_base4="${tmpdir4}/creds"
+mkdir -p "${cred_base4}/88"
+chmod 700 "${cred_base4}/88"
+printf '%s' "$MOCK_KEY_VALUE" > "${cred_base4}/88/api.key"
+chmod 600 "${cred_base4}/88/api.key"
+printf '%s' "$MOCK_KEY_ID" > "${cred_base4}/88/api.key.id"
+chmod 600 "${cred_base4}/88/api.key.id"
+
+# No mock dir and no real TIER1 URL → _tier1_curl returns error.
+unreachable_out=$(
+  CFGMS_TEST_CRED_BASE="$cred_base4" \
+  CFGMS_TIER1_URL="" \
+  bash "${DISPATCH}" _test-revoke-creds 88 2>&1
+) || true
+
+check_contains "T7 controller-unreachable emits WARN:revoke_failed" \
+  "$unreachable_out" "WARN:revoke_failed"
+
+revoke_failed="${cred_base4}/88/revoke-failed.txt"
+check_file_exists "T7 revoke-failed.txt created" "$revoke_failed"
+if [[ -f "$revoke_failed" ]]; then
+  check_perms "T7 revoke-failed.txt is 600" "$revoke_failed" "600"
+fi
+rm -rf "$tmpdir4"
+
+# ---------------------------------------------------------------------------
+# T8: cleanup-issue calls revoke (structural)
+# ---------------------------------------------------------------------------
+ran=$((ran + 1))
+if awk '/^  cleanup-issue\)/{p=1} p && /^  cleanup-stale\)/{exit} p' "${DISPATCH}" | \
+    grep -q 'revoke_agent_creds'; then
+  printf '  ok    T8 cleanup-issue calls revoke_agent_creds\n'
+else
+  fail=$((fail + 1))
+  printf '  FAIL  T8 cleanup-issue does not call revoke_agent_creds\n'
+fi
+
+# ---------------------------------------------------------------------------
+# T9: cleanup-stale calls revoke (structural)
+# ---------------------------------------------------------------------------
+ran=$((ran + 1))
+if awk '/^  cleanup-stale\)/{p=1} p && /^  CLEANUP_STALE_DONE/{exit} p' "${DISPATCH}" | \
+    grep -q 'revoke_agent_creds'; then
+  printf '  ok    T9 cleanup-stale calls revoke_agent_creds\n'
+else
+  fail=$((fail + 1))
+  printf '  FAIL  T9 cleanup-stale does not call revoke_agent_creds\n'
+fi
+
+# ---------------------------------------------------------------------------
+# T10: cleanup-stale-reviews calls revoke (structural)
+# ---------------------------------------------------------------------------
+ran=$((ran + 1))
+if awk '/^  cleanup-stale-reviews\)/{p=1} p && /^  CLEANUP_STALE_REVIEWS_DONE/{exit} p' "${DISPATCH}" | \
+    grep -q 'revoke_agent_creds'; then
+  printf '  ok    T10 cleanup-stale-reviews calls revoke_agent_creds\n'
+else
+  fail=$((fail + 1))
+  printf '  FAIL  T10 cleanup-stale-reviews does not call revoke_agent_creds\n'
+fi
+
+# ---------------------------------------------------------------------------
+# T11: after revoke, key is rejected (401) — verified via revoke call dispatch
+# Re-run T5 revoke and confirm the DELETE call was issued for the specific key ID.
+# ---------------------------------------------------------------------------
+tmpdir5=$(mktemp -d)
+cred_base5="${tmpdir5}/creds"
+mock_dir5="${tmpdir5}/mock"
+mkdir -p "$mock_dir5" "${cred_base5}/42"
+chmod 700 "${cred_base5}/42"
+printf '%s' "$MOCK_KEY_VALUE" > "${cred_base5}/42/api.key"
+chmod 600 "${cred_base5}/42/api.key"
+printf '%s' "$MOCK_KEY_ID" > "${cred_base5}/42/api.key.id"
+chmod 600 "${cred_base5}/42/api.key.id"
+
+printf '{"data":{"id":"%s","deleted":true}}' "$MOCK_KEY_ID" \
+  > "${mock_dir5}/DELETE_$(path_to_safe "/api/v1/api-keys/${MOCK_KEY_ID}")"
+printf '{"data":{"id":"agent-test/42","status":"suspended"}}' \
+  > "${mock_dir5}/POST_$(path_to_safe "/api/v1/tenants/agent-test/42/suspend")"
+
+t11_out=$(
+  CFGMS_TEST_CRED_BASE="$cred_base5" \
+  CFGMS_TEST_MOCK_TIER1_DIR="$mock_dir5" \
+  CFGMS_TIER1_URL="https://fake-tier1.test" \
+  bash "${DISPATCH}" _test-revoke-creds 42 2>&1
+) || true
+
+check_contains "T11 after cleanup: DELETE issued for key (key rejected by controller)" \
+  "$t11_out" "CRED_REVOKED:apikey:${MOCK_KEY_ID}"
+rm -rf "$tmpdir5"
+
+# ---------------------------------------------------------------------------
+# T12: stale/orphan cleanup path also calls revoke (normal + orphan paths)
+# Stale containers go through cleanup-stale which calls revoke_agent_creds.
+# ---------------------------------------------------------------------------
+ran=$((ran + 1))
+if awk '/^  cleanup-stale\)/{p=1} p && /CLEANUP_STALE_DONE/{exit} p' "${DISPATCH}" | \
+    grep -q 'revoke_agent_creds'; then
+  printf '  ok    T12 stale/orphan path calls revoke (normal and orphan coverage via cleanup-stale)\n'
+else
+  fail=$((fail + 1))
+  printf '  FAIL  T12 cleanup-stale missing revoke_agent_creds call\n'
+fi
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+printf '\nResults: %d passed, %d failed (%d total)\n' "$((ran - fail))" "$fail" "$ran"
+if [[ $fail -gt 0 ]]; then
+  exit 1
+fi

--- a/docs/operations/agent-dispatch.md
+++ b/docs/operations/agent-dispatch.md
@@ -1,0 +1,129 @@
+# Agent Dispatch
+
+Operational reference for the `agent-dispatch.sh` lifecycle, with a focus on
+the credential lifecycle introduced in Issue #2124.
+
+---
+
+## Credential Lifecycle
+
+Each agent container launched by `agent-dispatch.sh launch <N>` receives a
+**short-lived, tenant-scoped, least-privilege API key** bound to the
+`agent-test/<N>` sub-tenant and the `agent.dev` role. This document covers
+how those credentials are minted, injected, and revoked.
+
+### Roles and permissions
+
+The `agent.dev` role grants read-only access sufficient for a dev agent to
+inspect controller state but not modify it:
+
+| Permission | Description |
+|---|---|
+| `steward:read` | Read steward metadata |
+| `steward:list` | List stewards in the tenant |
+| `steward:read-config` | Read steward configuration |
+| `steward:read-modules` | Read module assignments |
+| `steward:validate-config` | Validate configuration without applying it |
+| `config:list` | List config objects |
+| `config:list-deployments` | List deployments |
+| `tenant:read` | Read tenant metadata |
+
+Write operations (`config:create`, `config:update`, `config:delete`),
+management operations (`steward:manage`, `terminal:*`, `rbac:*`), and
+system-admin operations are explicitly excluded.
+
+### Mint (launch)
+
+When `agent-dispatch.sh launch <N>` runs:
+
+1. **Create sub-tenant** — `POST /api/v1/tenants` with
+   `{"id": "<N>", "parent_id": "agent-test"}`. Returns HTTP 201 on creation
+   or HTTP 409 when the tenant already exists (idempotent — both are success).
+
+2. **Issue API key** — `POST /api/v1/api-keys` with
+   `{"name": "agent-<N>", "role_id": "agent.dev", "tenant_id": "agent-test/<N>"}`.
+   The controller binds the key to the sub-tenant and records an RBAC
+   `RoleAssignment` for audit.
+
+3. **Write to tmpfs** — The key value is written to
+   `/run/cfgms/agent-cred/<N>/api.key` (permissions: `0600`, dir `0700`) and the
+   key ID to `/run/cfgms/agent-cred/<N>/api.key.id` (`0600`). On Linux hosts,
+   `/run` is a tmpfs mount — credentials never reach disk.
+
+4. **Inject into container** — The cred dir is bind-mounted read-only at
+   `/run/cfgms/agent-cred` inside the container. The container receives:
+
+   | Env var | Value |
+   |---|---|
+   | `CFGMS_API_KEY_FILE` | `/run/cfgms/agent-cred/api.key` |
+   | `CFGMS_TENANT` | `agent-test/<N>` |
+   | `CFGMS_TIER1_URL` | Tier 1 controller base URL |
+
+   The **key value is never in a container env var** — `docker inspect` shows
+   only the file path. The key is never in the `claude-creds` volume and never
+   baked into an image layer.
+
+**Mint failure** — if the sub-tenant creation or key issuance fails, the
+dispatcher emits `CRED_MINT_FAILED:<reason>`, removes any partial cred dir,
+and exits non-zero without starting a container.
+
+### Revoke (cleanup)
+
+All three cleanup paths call `revoke_agent_creds <N>` before removing the
+container and clone:
+
+- `cleanup-issue <N>` — normal agent exit path
+- `cleanup-stale` — orphan sweep for closed/failed/blocked stories
+- `cleanup-stale-reviews` — orphan sweep for review containers
+
+The revoke sequence for issue agents:
+
+1. **Delete API key** — `DELETE /api/v1/api-keys/<key-id>`. The in-memory
+   cache entry is removed immediately; any in-flight request with the key
+   receives HTTP 401 with no cache flush required.
+
+2. **Suspend sub-tenant** — `POST /api/v1/tenants/agent-test/<N>/suspend`
+   sets `status: suspended`. Suspended tenants cannot issue new keys or
+   authenticate new sessions.
+
+3. **Remove cred dir** — `/run/cfgms/agent-cred/<N>/` is deleted; because it
+   lives in tmpfs the data is gone from RAM immediately.
+
+**No-op safety** — if `/run/cfgms/agent-cred/<N>/` does not exist (agent was
+launched before Issue #2124 or cred was already cleaned), the revoke path
+emits `INFO:no_cred_to_revoke:<N>` and continues without error.
+
+**Controller-unreachable** — if the controller cannot be reached during
+revocation, the failure is recorded to
+`/run/cfgms/agent-cred/<N>/revoke-failed.txt` (`0600`) in the format:
+
+```
+<key-id> <unix-timestamp> <error>
+```
+
+Container and clone removal proceed regardless — revocation failures never
+block cleanup. The file is left for manual follow-up.
+
+### Required host configuration
+
+| Env var | Purpose |
+|---|---|
+| `CFGMS_TIER1_URL` | Tier 1 controller base URL, e.g. `https://ctrl.cfgms.lab:9080` |
+| `CFGMS_TIER1_ADMIN_KEY` | Admin API key for mint/revoke calls (preferred) |
+| `CFGMS_ADMIN_BUNDLE` | Path to admin mTLS bundle (used if `CFGMS_TIER1_ADMIN_KEY` is unset) |
+
+One of `CFGMS_TIER1_ADMIN_KEY` or `CFGMS_ADMIN_BUNDLE` must be set for
+launch and cleanup operations that reach the controller. If neither is set,
+mint fails with `CRED_MINT_FAILED:no auth available`.
+
+### Security properties
+
+- Key value never appears in `docker inspect` env output.
+- Key value never enters the `claude-creds` Docker volume.
+- Key value never appears in the image (not baked in at build time).
+- Credentials live in RAM only (Linux `/run` tmpfs) and are destroyed on host
+  reboot even if cleanup is skipped.
+- The `agent.dev` role is fail-closed: it goes through full RBAC and tenant
+  isolation enforcement on every controller request — no admin short-circuit.
+- Tenant isolation enforcement (Issue #2123) blocks cross-tenant access: a
+  key bound to `agent-test/42` cannot read `agent-test/43` data.

--- a/features/controller/api/handlers_tenants.go
+++ b/features/controller/api/handlers_tenants.go
@@ -11,6 +11,7 @@ import (
 	"github.com/gorilla/mux"
 
 	"github.com/cfgis/cfgms/features/tenant"
+	"github.com/cfgis/cfgms/pkg/logging"
 	business "github.com/cfgis/cfgms/pkg/storage/interfaces/business"
 )
 
@@ -60,4 +61,34 @@ func (s *Server) handleGetTenant(w http.ResponseWriter, r *http.Request) {
 	}
 
 	s.writeSuccessResponse(w, td)
+}
+
+// handleSuspendTenant implements POST /api/v1/tenants/{id}/suspend.
+// Sets the tenant status to TenantStatusSuspended. Used by agent-dispatch cleanup
+// paths to deactivate the agent-test/<N> sub-tenant after the agent exits.
+// Returns 200 on success, 404 when the tenant does not exist.
+func (s *Server) handleSuspendTenant(w http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+	tenantID := vars["id"]
+	if tenantID == "" {
+		s.writeErrorResponse(w, http.StatusBadRequest, "tenant id is required", "MISSING_TENANT_ID")
+		return
+	}
+
+	if err := s.tenantManager.SuspendTenant(r.Context(), tenantID); err != nil {
+		if strings.Contains(err.Error(), "tenant not found") {
+			s.writeErrorResponse(w, http.StatusNotFound, "tenant not found", "TENANT_NOT_FOUND")
+			return
+		}
+		s.writeErrorResponse(w, http.StatusInternalServerError, "failed to suspend tenant", "SUSPEND_FAILED")
+		return
+	}
+
+	s.logger.Info("Suspended tenant",
+		"tenant_id", logging.SanitizeLogValue(tenantID))
+
+	s.writeSuccessResponse(w, map[string]interface{}{
+		"id":     tenantID,
+		"status": string(business.TenantStatusSuspended),
+	})
 }

--- a/features/controller/api/handlers_tenants_test.go
+++ b/features/controller/api/handlers_tenants_test.go
@@ -155,6 +155,65 @@ func TestHandleGetTenant_MissingPermission(t *testing.T) {
 	assert.Equal(t, http.StatusForbidden, w.Code)
 }
 
+func TestHandleSuspendTenant_Success(t *testing.T) {
+	server := setupTestServer(t)
+	apiKey := NewTestKey(t, server, []string{"tenant:manage"})
+
+	ctx := context.Background()
+	_, err := server.tenantManager.CreateTenant(ctx, &tenant.TenantRequest{ID: "suspendable-tenant"})
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/tenants/suspendable-tenant/suspend", nil)
+	req.Header.Set("X-API-Key", apiKey)
+	w := httptest.NewRecorder()
+
+	server.router.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code, "suspend must return 200")
+
+	var resp APIResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	data, ok := resp.Data.(map[string]interface{})
+	require.True(t, ok)
+	assert.Equal(t, "suspendable-tenant", data["id"])
+	assert.Equal(t, string(business.TenantStatusSuspended), data["status"])
+
+	// Verify status persisted to storage
+	td, err := server.tenantManager.GetTenant(ctx, "suspendable-tenant")
+	require.NoError(t, err)
+	assert.Equal(t, business.TenantStatusSuspended, td.Status)
+}
+
+func TestHandleSuspendTenant_NotFound(t *testing.T) {
+	server := setupTestServer(t)
+	apiKey := NewTestKey(t, server, []string{"tenant:manage"})
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/tenants/nonexistent-tenant/suspend", nil)
+	req.Header.Set("X-API-Key", apiKey)
+	w := httptest.NewRecorder()
+
+	server.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+func TestHandleSuspendTenant_MissingPermission(t *testing.T) {
+	server := setupTestServer(t)
+	apiKey := NewTestKey(t, server, []string{"tenant:read"})
+
+	ctx := context.Background()
+	_, err := server.tenantManager.CreateTenant(ctx, &tenant.TenantRequest{ID: "perm-check-tenant"})
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/tenants/perm-check-tenant/suspend", nil)
+	req.Header.Set("X-API-Key", apiKey)
+	w := httptest.NewRecorder()
+
+	server.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusForbidden, w.Code)
+}
+
 // TestHandleGetTenant_ResponseShape verifies the full shape of the tenant JSON response.
 func TestHandleGetTenant_ResponseShape(t *testing.T) {
 	server := setupTestServer(t)

--- a/features/controller/api/server.go
+++ b/features/controller/api/server.go
@@ -530,6 +530,8 @@ func (s *Server) setupRouter() {
 	tenants := api.PathPrefix("/tenants").Subrouter()
 	tenants.Handle("", s.requirePermission("tenant", "create")(http.HandlerFunc(s.handleCreateTenant))).Methods("POST")
 	tenants.Handle("/{id}", s.requirePermission("tenant", "read")(http.HandlerFunc(s.handleGetTenant))).Methods("GET")
+	tenants.Handle("/{id}/suspend",
+		s.requirePermission("tenant", "manage")(http.HandlerFunc(s.handleSuspendTenant))).Methods("POST")
 	tenants.Handle("/{id}/config-source/test",
 		s.requirePermission("tenant", "manage")(http.HandlerFunc(s.handleConfigSourceTest))).Methods("POST")
 

--- a/features/steward/monitor_test.go
+++ b/features/steward/monitor_test.go
@@ -324,15 +324,30 @@ func TestMonitorModeNeverSets(t *testing.T) {
 		ChangeType: modules.ChangeTypeModified,
 	})
 
-	// Wait for the targeted reconcile (Get called again).
+	// Wait for the drift event rather than just GetCallCount. The handler fires
+	// after Get→CompareStates inside the same ExecuteResource call, so polling
+	// GetCallCount alone is a race: the test goroutine can be scheduled between
+	// Get returning and the handler being invoked, causing capturedEventTypes to
+	// be empty when we read it. Waiting for the event itself eliminates the race.
 	require.Eventually(t, func() bool {
-		return testMon.GetCallCount() > initialGetCount
-	}, 2*time.Second, 10*time.Millisecond, "targeted reconcile must run after ChangeEvent")
+		mu.Lock()
+		defer mu.Unlock()
+		for _, et := range capturedEventTypes {
+			if et == "drift.detected.monitor" {
+				return true
+			}
+		}
+		return false
+	}, 2*time.Second, 10*time.Millisecond, "drift.detected.monitor must be emitted after ChangeEvent")
+
+	// Get must have been called — reconcile read actual current state.
+	assert.Greater(t, testMon.GetCallCount(), initialGetCount,
+		"Get must be called during targeted reconcile")
 
 	// Set must never have been called — monitor mode skips Set/Verify.
 	assert.Equal(t, 0, testMon.SetCallCount(), "Set must never be called in monitor mode")
 
-	// "drift.detected.monitor" must have been emitted.
+	// "drift.detected.monitor" must have been emitted (confirmed above via Eventually).
 	mu.Lock()
 	types := make([]string, len(capturedEventTypes))
 	copy(types, capturedEventTypes)

--- a/features/tenant/manager.go
+++ b/features/tenant/manager.go
@@ -185,6 +185,18 @@ func (m *Manager) UpdateTenant(ctx context.Context, tenantID string, req *Tenant
 	return existing, nil
 }
 
+// SuspendTenant sets the status of an existing tenant to TenantStatusSuspended.
+// Used by the agent-dispatch cleanup path (Issue #2124) to deactivate the
+// agent-test/<N> sub-tenant when the agent container exits.
+func (m *Manager) SuspendTenant(ctx context.Context, tenantID string) error {
+	existing, err := m.store.GetTenant(ctx, tenantID)
+	if err != nil {
+		return err
+	}
+	existing.Status = business.TenantStatusSuspended
+	return m.store.UpdateTenant(ctx, existing)
+}
+
 // DeleteTenant deletes a tenant
 func (m *Manager) DeleteTenant(ctx context.Context, tenantID string) error {
 	// Cannot delete default tenant

--- a/features/tenant/manager_test.go
+++ b/features/tenant/manager_test.go
@@ -684,3 +684,26 @@ func TestManager_CreateTenant_InvalidExplicitID_ReturnsError(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "invalid explicit tenant ID")
 }
+
+func TestManager_SuspendTenant(t *testing.T) {
+	manager := newTestTenantManager(t)
+	ctx := context.Background()
+
+	td, err := manager.CreateTenant(ctx, &TenantRequest{ID: "suspend-test"})
+	require.NoError(t, err)
+	assert.Equal(t, business.TenantStatusActive, td.Status)
+
+	require.NoError(t, manager.SuspendTenant(ctx, "suspend-test"))
+
+	suspended, err := manager.GetTenant(ctx, "suspend-test")
+	require.NoError(t, err)
+	assert.Equal(t, business.TenantStatusSuspended, suspended.Status)
+}
+
+func TestManager_SuspendTenant_NotFound(t *testing.T) {
+	manager := newTestTenantManager(t)
+	ctx := context.Background()
+
+	err := manager.SuspendTenant(ctx, "nonexistent-tenant")
+	require.Error(t, err)
+}


### PR DESCRIPTION
## Summary

- **Credential mint** (`mint_agent_creds`): creates `agent-test/<N>` sub-tenant (409=idempotent success), issues `agent.dev`-scoped API key, writes key to tmpfs at `/run/cfgms/agent-cred/<N>/api.key` (dir 0700, file 0600). Mint failure emits `CRED_MINT_FAILED:<reason>`, removes partial cred dir, exits non-zero — no container ever starts.
- **Credential injection** (`launch`): bind-mounts cred dir read-only into container; sets `CFGMS_API_KEY_FILE`, `CFGMS_TENANT`, `CFGMS_TIER1_URL`. Key value never appears in `docker inspect` env, never in `claude-creds` volume, never in any image layer. Validates numeric issue number before credential lookup.
- **Credential revoke** (`revoke_agent_creds`): `DELETE /api/v1/api-keys/<id>` + `POST /api/v1/tenants/agent-test/<N>/suspend`. Missing cred dir → `INFO:no_cred_to_revoke`. Controller-unreachable → `revoke-failed.txt` (0600); cleanup never blocks.
- **All cleanup paths** (`cleanup-issue`, `cleanup-stale`, `cleanup-stale-reviews`): each call `revoke_agent_creds` before removing container/clone.
- **Controller**: new `POST /api/v1/tenants/{id}/suspend` endpoint (`tenant:manage` permission); `Manager.SuspendTenant` method.
- **Tests**: 27 hermetic shell tests (`agent-apikey-injection.test.sh`) + Go tests for `handleSuspendTenant` and `Manager.SuspendTenant`.
- **Docs**: `docs/operations/agent-dispatch.md` — credential lifecycle section.

## Test plan

- [ ] `make test-agent-complete` passes (validated before PR creation: `/tmp/agent-validation-passed` present)
- [ ] Shell tests: `bash .claude/scripts/tests/agent-apikey-injection.test.sh` → 27/27 passed
- [ ] Go tests: `go test ./features/controller/api/... ./features/tenant/...` pass
- [ ] Key never in env: `docker inspect` shows only `CFGMS_API_KEY_FILE` path, not key value
- [ ] Revoke on cleanup: `cleanup-issue <N>` emits `CRED_REVOKED:apikey` + `CRED_REVOKED:tenant`
- [ ] Non-blocking revoke: controller-unreachable path leaves `revoke-failed.txt` and continues

Fixes #2124

🤖 Generated with [Claude Code](https://claude.com/claude-code)