### PR TITLE
dna: Hyper-V host attributes (Windows) + virtualization guest/host detection (Linux) (Issue #1950)

### DIFF
--- a/docs/architecture/dna-collection.md
+++ b/docs/architecture/dna-collection.md
@@ -577,8 +577,12 @@ Collected in the background via `collectSecurityInfo()` → `CollectPermissions`
 | `etc_permissions` | Permissions string on /etc | `collectKeyDirectoryPermissions` (darwin) | Background | public | N/A | N/A | GREEN | NO |
 | `tmp_permissions` | Permissions string on /tmp | `collectKeyDirectoryPermissions` (darwin) | Background | public | N/A | N/A | GREEN | NO |
 | `var_permissions` | Permissions string on /var | `collectKeyDirectoryPermissions` (darwin) | Background | public | N/A | N/A | GREEN | NO |
-| `hyperv_role` | Whether Hyper-V role is enabled | — | — | public | N/A | N/A | N/A | YES <!-- GAP: hyperv_role is not collected on any platform. Windows would require querying WMI Win32_OptionalFeature for the Microsoft-Hyper-V-All feature or checking the DISM feature state. No collector queries this. Required for VM inventory (Epic #1932). --> |
-| `vm_inventory` | Summary of hosted virtual machines | — | — | tenant-sensitive | N/A | N/A | N/A | YES <!-- GAP: vm_inventory is not collected on any platform. Depends on hyperv_role gap being filled first. --> |
+| `hyperv_role_installed` | Whether the Hyper-V role (vmms service) is installed | `collectHyperVInfo` (windows) | Fast | public | N/A | N/A | GREEN | NO |
+| `hyperv_enabled` | Whether the Microsoft-Hyper-V-All feature is enabled (DISM; elevation-gated, omitted with a WARN when unavailable) | `collectHyperVInfo` (windows) | Fast | public | N/A | N/A | GREEN | NO |
+| `virtualization_type` | Detected hypervisor when running as a guest, else `none` | `collectVirtualizationInfo` (linux) / `collectHyperVInfo` (windows) | Fast | public | GREEN | N/A | GREEN | NO |
+| `virtualization_role` | `guest` / `host` / `baremetal` | `collectVirtualizationInfo` (linux) / `collectHyperVInfo` (windows) | Fast | public | GREEN | N/A | GREEN | NO |
+| `hyperv_host` | Whether this Linux host runs the mshv hypervisor (`/dev/mshv` or mshv module) | `collectVirtualizationInfo` (linux) | Fast | public | GREEN | N/A | N/A | NO |
+| `vm_inventory` | Summary of hosted virtual machines | — | — | tenant-sensitive | N/A | N/A | N/A | NO <!-- N/A — deferred to module Monitor epic #2110: VM presence/state is observed via the hyperv module Get() + Monitor capability, not a DNA snapshot. VM names are tenant-sensitive and must never enter DNA; a running-VM count is volatile telemetry that would churn the DNA hash. --> |
 | `permission_info` | Stub (generic/unsupported platforms) | `GenericSecurityCollector.CollectPermissions` | Background | public | N/A | N/A | N/A | NO |
 
 ---
@@ -627,8 +631,8 @@ The operating model doc (lines 221–226) documents four DNA categories. This ta
 | Linux certificate store not enumerated (`certificate_info` = stub) | Linux | `LinuxSecurityCollector.CollectCertificates` | Open |
 | `firewall_state` unreliable when ufw/iptables absent | Linux | `LinuxNetworkCollector.CollectFirewall` | Open |
 | No unified `firewall_state` key (Windows uses per-profile keys only) | Windows | `WindowsNetworkCollector.CollectFirewall` | Open |
-| `hyperv_role` not collected | Windows | `WindowsSecurityCollector.CollectPermissions` | Open |
-| `vm_inventory` not collected | Windows | (new collector needed) | Open |
+| `hyperv_role` not collected | Windows | `WindowsHardwareCollector.collectHyperVInfo` (now `hyperv_role_installed` + `hyperv_enabled`) | Resolved (#1950) |
+| `vm_inventory` not collected | Windows | N/A — deferred to module Monitor epic #2110 (observed via module `Get()` + `Monitor`, not DNA) | Resolved (#1950) |
 | `system_serial_number` not collected | Windows, macOS | `WindowsHardwareCollector`, `DarwinHardwareCollector` | Open |
 | No unified `encryption_state` key | All | Multi-platform | Open |
 

--- a/features/steward/dna/hardware_linux.go
+++ b/features/steward/dna/hardware_linux.go
@@ -8,11 +8,14 @@ package dna
 import (
 	"context"
 	"fmt"
+	"os"
 	"os/exec"
 	"runtime"
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/cfgis/cfgms/pkg/logging"
 )
 
 const linuxCmdTimeout = 30 * time.Second
@@ -144,7 +147,82 @@ func (l *LinuxHardwareCollector) CollectMotherboard(ctx context.Context, attribu
 	}
 	cancel3()
 
+	l.collectVirtualizationInfo(ctx, attributes)
+
 	return nil
+}
+
+// collectVirtualizationInfo records whether the steward is running inside a VM
+// (guest) and which hypervisor, plus whether this Linux host is itself a Hyper-V
+// host (the mshv hypervisor device/module). It sets virtualization_type,
+// virtualization_role, and hyperv_host.
+//
+// VM inventory / running-VM count is deliberately NOT collected (#1950): VM
+// presence/state is volatile runtime telemetry observed via the hyperv module's
+// Get()/Monitor path, not a stable DNA attribute, and would churn the DNA hash.
+//
+// Every exec uses the argv form (exec.CommandContext(ctx, bin, args...)); no
+// command composes a shell string or pipes through a shell.
+func (l *LinuxHardwareCollector) collectVirtualizationInfo(ctx context.Context, attributes map[string]string) {
+	// Preferred: systemd-detect-virt. It exits non-zero with stdout "none" on
+	// bare metal, so read stdout regardless of exit status.
+	cmdCtx, cancel := context.WithTimeout(ctx, linuxCmdTimeout)
+	out, _ := exec.CommandContext(cmdCtx, "systemd-detect-virt").Output()
+	cancel()
+	virtType := strings.TrimSpace(string(out))
+
+	// Fallback to the DMI product name when systemd-detect-virt is unavailable.
+	if virtType == "" {
+		if data, err := os.ReadFile("/sys/class/dmi/id/product_name"); err == nil {
+			pn := strings.ToLower(strings.TrimSpace(string(data)))
+			switch {
+			case strings.Contains(pn, "virtual machine"): // Hyper-V guest
+				virtType = "microsoft"
+			case strings.Contains(pn, "vmware"):
+				virtType = "vmware"
+			case strings.Contains(pn, "kvm"), strings.Contains(pn, "qemu"):
+				virtType = "kvm"
+			case strings.Contains(pn, "virtualbox"):
+				virtType = "oracle"
+			}
+		}
+	}
+	if virtType == "" {
+		// Neither source resolved a type; default to "none" and note the
+		// degradation rather than emitting an empty attribute.
+		virtType = "none"
+		_ = logging.Warn(ctx, "dna: virtualization type undetermined (systemd-detect-virt and DMI both unavailable); defaulting to none", nil)
+	}
+	attributes["virtualization_type"] = virtType
+
+	// Hyper-V host detection: the mshv hypervisor device, or the mshv kernel
+	// module. Search lsmod output in Go — never an `lsmod | grep` shell pipe.
+	hypervHost := false
+	if _, err := os.Stat("/dev/mshv"); err == nil {
+		hypervHost = true
+	} else {
+		cmdCtx2, cancel2 := context.WithTimeout(ctx, linuxCmdTimeout)
+		if lsmod, lerr := exec.CommandContext(cmdCtx2, "lsmod").Output(); lerr == nil {
+			for _, line := range strings.Split(string(lsmod), "\n") {
+				if strings.HasPrefix(strings.TrimSpace(line), "mshv") {
+					hypervHost = true
+					break
+				}
+			}
+		}
+		cancel2()
+	}
+	attributes["hyperv_host"] = strconv.FormatBool(hypervHost)
+
+	// Role: guest if detected inside a VM; otherwise a Hyper-V host, or bare metal.
+	switch {
+	case virtType != "none":
+		attributes["virtualization_role"] = "guest"
+	case hypervHost:
+		attributes["virtualization_role"] = "host"
+	default:
+		attributes["virtualization_role"] = "baremetal"
+	}
 }
 
 // parseProcCPUInfo parses /proc/cpuinfo for CPU details

--- a/features/steward/dna/hardware_linux_test.go
+++ b/features/steward/dna/hardware_linux_test.go
@@ -1,0 +1,51 @@
+//go:build linux
+
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+
+package dna
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestLinuxVirtualizationCollector runs the real Linux motherboard collector and
+// asserts the shape of the virtualization guest/host attributes added by #1950.
+// Values are host-dependent (bare metal vs guest), so only their shape is
+// asserted. It also verifies no VM inventory / running-VM count is emitted.
+func TestLinuxVirtualizationCollector(t *testing.T) {
+	col := &LinuxHardwareCollector{}
+	attrs := make(map[string]string)
+	require.NoError(t, col.CollectMotherboard(context.Background(), attrs))
+
+	// virtualization_type must be a non-empty string (at least "none").
+	vt, ok := attrs["virtualization_type"]
+	require.True(t, ok, "virtualization_type must be set")
+	assert.NotEmpty(t, vt, "virtualization_type must be non-empty")
+
+	// virtualization_role must be one of the three allowed roles.
+	role, ok := attrs["virtualization_role"]
+	require.True(t, ok, "virtualization_role must be set")
+	assert.Contains(t, []string{"guest", "host", "baremetal"}, role,
+		"virtualization_role must be guest/host/baremetal, got %q", role)
+
+	// hyperv_host must be a strict boolean.
+	hh, ok := attrs["hyperv_host"]
+	require.True(t, ok, "hyperv_host must be set")
+	assert.Contains(t, []string{"true", "false"}, hh,
+		"hyperv_host must be 'true' or 'false', got %q", hh)
+
+	// No VM inventory / count / name attribute may ever be emitted as DNA
+	// (#1950 Out of Scope — VM presence is observed via the module path).
+	for _, forbidden := range []string{
+		"hyperv_vm_running_count", "vm_inventory", "vm_count",
+		"vm_running_count", "vm_names", "hyperv_vm_names",
+	} {
+		_, present := attrs[forbidden]
+		assert.False(t, present, "forbidden VM-inventory key %q must not be emitted as DNA", forbidden)
+	}
+}

--- a/features/steward/dna/hardware_linux_test.go
+++ b/features/steward/dna/hardware_linux_test.go
@@ -7,6 +7,7 @@ package dna
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -47,5 +48,14 @@ func TestLinuxVirtualizationCollector(t *testing.T) {
 	} {
 		_, present := attrs[forbidden]
 		assert.False(t, present, "forbidden VM-inventory key %q must not be emitted as DNA", forbidden)
+	}
+	// Defense in depth: no DNA key may reference per-VM inventory/state/identity,
+	// regardless of exact spelling (tenant-sensitive).
+	for k := range attrs {
+		lk := strings.ToLower(k)
+		vmRef := strings.HasPrefix(lk, "vm_") || strings.Contains(lk, "_vm_") ||
+			strings.Contains(lk, "vm_inventory") || strings.Contains(lk, "vm_count") ||
+			strings.Contains(lk, "vm_running") || strings.Contains(lk, "vm_name")
+		assert.Falsef(t, vmRef, "no DNA key may reference per-VM inventory/state; got %q", k)
 	}
 }

--- a/features/steward/dna/hardware_windows.go
+++ b/features/steward/dna/hardware_windows.go
@@ -15,6 +15,8 @@ import (
 	"time"
 
 	"golang.org/x/sys/windows/registry"
+
+	"github.com/cfgis/cfgms/pkg/logging"
 )
 
 // WindowsHardwareCollector handles Windows-specific hardware collection.
@@ -152,7 +154,86 @@ func (w *WindowsHardwareCollector) CollectMotherboard(ctx context.Context, attri
 	// OS version for hardware context — native registry reads (no process spawn)
 	w.collectOSVersionFromRegistry(attributes)
 
+	w.collectHyperVInfo(ctx, attributes)
+
 	return nil
+}
+
+// collectHyperVInfo records Hyper-V host-capability and guest-detection
+// attributes:
+//   - hyperv_role_installed (true/false): the Virtual Machine Management service
+//     (vmms) is registered. Read from the registry — no process spawn, no
+//     elevation.
+//   - virtualization_type / virtualization_role: guest detection from the BIOS
+//     system identity (registry, no elevation).
+//   - hyperv_enabled (true/false): the Microsoft-Hyper-V-All optional feature is
+//     enabled. Queried with DISM in argv form (no PowerShell string
+//     composition). This requires elevation; on any error the attribute is
+//     omitted (not stubbed) with a WARN, per #1950.
+//
+// VM inventory / running-VM count / VM names are deliberately NOT collected
+// (#1950): VM presence/state is observed via the hyperv module Get()/Monitor
+// path, and VM names are tenant-sensitive and must never enter DNA.
+func (w *WindowsHardwareCollector) collectHyperVInfo(ctx context.Context, attributes map[string]string) {
+	// Hyper-V role installed: the vmms service key exists. Registry read only.
+	roleInstalled := false
+	if key, err := registry.OpenKey(registry.LOCAL_MACHINE,
+		`SYSTEM\CurrentControlSet\Services\vmms`, registry.QUERY_VALUE); err == nil {
+		_ = key.Close()
+		roleInstalled = true
+	}
+	attributes["hyperv_role_installed"] = strconv.FormatBool(roleInstalled)
+
+	// Guest detection from the BIOS system identity (registry, no elevation).
+	virtType := "none"
+	if key, err := registry.OpenKey(registry.LOCAL_MACHINE,
+		`HARDWARE\DESCRIPTION\System\BIOS`, registry.QUERY_VALUE); err == nil {
+		manufacturer, _, _ := key.GetStringValue("SystemManufacturer")
+		product, _, _ := key.GetStringValue("SystemProductName")
+		_ = key.Close()
+		combined := strings.ToLower(manufacturer + " " + product)
+		switch {
+		case strings.Contains(combined, "microsoft") && strings.Contains(combined, "virtual"):
+			virtType = "hyperv"
+		case strings.Contains(combined, "vmware"):
+			virtType = "vmware"
+		case strings.Contains(combined, "virtualbox"):
+			virtType = "virtualbox"
+		case strings.Contains(combined, "kvm"), strings.Contains(combined, "qemu"):
+			virtType = "kvm"
+		}
+	}
+	attributes["virtualization_type"] = virtType
+
+	switch {
+	case virtType != "none":
+		attributes["virtualization_role"] = "guest"
+	case roleInstalled:
+		attributes["virtualization_role"] = "host"
+	default:
+		attributes["virtualization_role"] = "baremetal"
+	}
+
+	// Hyper-V enabled: query the optional feature via DISM in argv form. Requires
+	// elevation; on any error, WARN and omit rather than emit a misleading value.
+	out, err := runCommand(ctx, "dism", "/online", "/english", "/get-featureinfo",
+		"/featurename:Microsoft-Hyper-V-All")
+	if err != nil {
+		_ = logging.Warn(ctx, "dna: could not query Hyper-V feature state via DISM (elevation may be required); omitting hyperv_enabled", nil)
+		return
+	}
+	for _, line := range strings.Split(out, "\n") {
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(line, "State :") {
+			state := strings.ToLower(strings.TrimSpace(strings.TrimPrefix(line, "State :")))
+			// DISM reports "Enabled", "Disabled", or transitional
+			// "Enable Pending" / "Disable Pending".
+			attributes["hyperv_enabled"] = strconv.FormatBool(strings.HasPrefix(state, "enable"))
+			return
+		}
+	}
+	// Feature info returned but no State line — treat as undeterminable.
+	_ = logging.Warn(ctx, "dna: DISM returned no State for Microsoft-Hyper-V-All; omitting hyperv_enabled", nil)
 }
 
 // parseWMICPUOutput parses WMI CPU output

--- a/features/steward/dna/hardware_windows_test.go
+++ b/features/steward/dna/hardware_windows_test.go
@@ -7,6 +7,7 @@ package dna
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -69,4 +70,22 @@ func assertNoVMInventoryKeys(t *testing.T, attrs map[string]string) {
 		_, present := attrs[forbidden]
 		assert.False(t, present, "forbidden VM-inventory key %q must not be emitted as DNA", forbidden)
 	}
+	// Defense in depth: no DNA key may reference per-VM inventory/state/identity,
+	// regardless of exact spelling (tenant-sensitive — #1950 Out of Scope).
+	for k := range attrs {
+		assert.Falsef(t, keyReferencesVMInventory(k),
+			"no DNA key may reference per-VM inventory/state; got %q", k)
+	}
+}
+
+// keyReferencesVMInventory reports whether an attribute key names per-VM
+// inventory, count, or identity (which must never enter DNA).
+func keyReferencesVMInventory(key string) bool {
+	k := strings.ToLower(key)
+	return strings.HasPrefix(k, "vm_") ||
+		strings.Contains(k, "_vm_") ||
+		strings.Contains(k, "vm_inventory") ||
+		strings.Contains(k, "vm_count") ||
+		strings.Contains(k, "vm_running") ||
+		strings.Contains(k, "vm_name")
 }

--- a/features/steward/dna/hardware_windows_test.go
+++ b/features/steward/dna/hardware_windows_test.go
@@ -1,0 +1,72 @@
+//go:build windows
+
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+
+package dna
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestWindowsHyperVCollector runs the real Windows motherboard collector and
+// asserts the shape of the Hyper-V host-capability and guest-detection
+// attributes added by #1950. Values are host-dependent, so only their shape is
+// asserted. Crucially it verifies that NO VM inventory / running-VM count / VM
+// name attribute is emitted (those belong to the module Get()/Monitor path, not
+// DNA).
+func TestWindowsHyperVCollector(t *testing.T) {
+	col := &WindowsHardwareCollector{}
+	attrs := make(map[string]string)
+	require.NoError(t, col.CollectMotherboard(context.Background(), attrs))
+
+	// hyperv_role_installed is read from the registry (no elevation) and must
+	// always be present as a strict boolean.
+	role, ok := attrs["hyperv_role_installed"]
+	require.True(t, ok, "hyperv_role_installed must be set")
+	assert.Contains(t, []string{"true", "false"}, role,
+		"hyperv_role_installed must be 'true' or 'false', got %q", role)
+
+	// hyperv_enabled requires elevation (DISM). It is set when queryable and
+	// omitted (not stubbed) otherwise — but when present it must be a strict
+	// boolean.
+	if enabled, ok := attrs["hyperv_enabled"]; ok {
+		assert.Contains(t, []string{"true", "false"}, enabled,
+			"hyperv_enabled, when present, must be 'true' or 'false', got %q", enabled)
+	}
+
+	// virtualization_type must be a non-empty string.
+	vt, ok := attrs["virtualization_type"]
+	require.True(t, ok, "virtualization_type must be set")
+	assert.NotEmpty(t, vt, "virtualization_type must be non-empty")
+
+	// virtualization_role must be one of the three allowed roles.
+	role2, ok := attrs["virtualization_role"]
+	require.True(t, ok, "virtualization_role must be set")
+	assert.Contains(t, []string{"guest", "host", "baremetal"}, role2,
+		"virtualization_role must be guest/host/baremetal, got %q", role2)
+
+	// No VM inventory / count / name attribute may ever be emitted as DNA.
+	assertNoVMInventoryKeys(t, attrs)
+}
+
+// assertNoVMInventoryKeys verifies that none of the forbidden VM-inventory /
+// volatile-runtime keys are present (#1950 Out of Scope).
+func assertNoVMInventoryKeys(t *testing.T, attrs map[string]string) {
+	t.Helper()
+	for _, forbidden := range []string{
+		"hyperv_vm_running_count",
+		"vm_inventory",
+		"vm_count",
+		"vm_running_count",
+		"vm_names",
+		"hyperv_vm_names",
+	} {
+		_, present := attrs[forbidden]
+		assert.False(t, present, "forbidden VM-inventory key %q must not be emitted as DNA", forbidden)
+	}
+}


### PR DESCRIPTION
## Summary

Adds stable virtualization **host-capability** attributes to the DNA snapshot — the bits the hyperv module relies on for host detection — without ever collecting VM inventory.

**Windows** (`collectHyperVInfo`, called from `WindowsHardwareCollector.CollectMotherboard`):
- `hyperv_role_installed` — vmms service registered (registry read, no elevation)
- `hyperv_enabled` — Microsoft-Hyper-V-All feature state via **DISM** (argv form); elevation-gated, **omitted with a WARN** when unavailable
- `virtualization_type` / `virtualization_role` — from the BIOS system identity (registry)

**Linux** (`collectVirtualizationInfo`, called from `LinuxHardwareCollector.CollectMotherboard`):
- `virtualization_type` / `virtualization_role` — `systemd-detect-virt` (DMI product-name fallback)
- `hyperv_host` — `/dev/mshv` device or `mshv` kernel module (`lsmod` output scanned in Go, never an `lsmod | grep` shell pipe)

## Tenant-isolation constraint (central to this story)

VM inventory / running-VM count / **VM names are deliberately NOT collected**. VM presence/state is observed via the hyperv module's `Get()` + `Monitor` (epic #2110), not a DNA snapshot — a running-VM count is volatile telemetry that would churn the DNA aggregate hash, and VM names are tenant-sensitive. The `vm_inventory` doc row is re-pointed to "N/A — deferred to #2110". A prefix/substring test scan asserts **no** `vm_*` / `*_vm_*` / `vm_inventory|count|running|name` key is ever emitted.

## Changes

- `features/steward/dna/hardware_linux.go`, `hardware_windows.go` — the two collectors.
- `features/steward/dna/hardware_linux_test.go`, `hardware_windows_test.go` (new) — REQUIRED TESTS.
- `docs/architecture/dna-collection.md` — hyperv/virtualization rows GREEN; `vm_inventory` re-pointed; gap register updated.

## Test results (adversarial story-complete team — all PASS)

- **Acceptance check**: PASS — all AC verified; no new dep (go.mod/go.sum diff empty); REQUIRED TESTS present with correct build tags.
- **QA test-quality**: PASS — `TestWindowsHyperVCollector` passes (DISM correctly WARN-omits `hyperv_enabled` at non-elevated privilege); `go build ./...`, vet, gofmt clean; Linux REQUIRED TEST compiles under `GOOS=linux`.
- **QA code review**: PASS — real collectors (no mocks), substantive assertions, exhaustive `virtualization_role` switch, `systemd-detect-virt` exit-status handled, registry keys closed, graceful degradation correct.
- **Security review**: PASS — `make check-architecture` clean; all exec is argv form (no banned patterns); no VM identities emitted (tenant isolation upheld in code + tests); WARN logs are static strings (no unsanitized host data); no new dependency.

REQUIRED TESTS: `TestLinuxVirtualizationCollector` (linux), `TestWindowsHyperVCollector` (windows) — both assert attribute shape and that no VM-inventory/count/name key is present.

## Design note

The story suggested `Get-WindowsOptionalFeature` via `-File stagedPs1` for `hyperv_enabled`; I used **DISM in argv form** instead — same elevation requirement and result, but no PowerShell script staging / execution-policy surface and a cleaner fit with the argv-only / declared-LOLBIN threat model.

## Host / CI caveats

Developed and validated on the Windows e2e host. `golangci-lint`/`gitleaks`/gosec/Trivy aren't installed there (CI enforces lint + `security-deployment-gate`; `go vet`/`gofmt`/`check-architecture` used locally). A **pre-existing, unrelated** Windows-host failure surfaced — `TestDNACollectionPerformance` asserts >50 DNA attributes but this host's wmic deprecation yields <50 (41 on develop baseline; this story *raises* it to 44). Not caused by #1950; tracked separately as **#2147**.

Fixes #1950

Co-Authored-By: Claude <noreply@anthropic.com>