### PR TITLE
security: check path containment before symlink resolution in ValidateAndCleanPath (Issue #2120)

### DIFF
--- a/pkg/security/fileaccess.go
+++ b/pkg/security/fileaccess.go
@@ -100,18 +100,22 @@ func SecureOpenFile(basePath, userPath string, flag int, perm os.FileMode) (*os.
 //  1. Cleans the user path using filepath.Clean()
 //  2. Resolves both paths to absolute paths
 //  3. Eval-symlinks the base path so the final containment comparison uses canonical paths.
-//     The pre-resolution form (rawAbsBasePath) is preserved for the preliminary check in
-//     the non-existent-path branch so both sides are in the same (unresolved) form.
-//  4. Resolves symlinks in the user path; for non-existent targets, walks up to the
+//     The pre-resolution form (rawAbsBasePath) is kept for the raw-form containment checks
+//     so both sides are compared in the same (unresolved) form.
+//  4. Performs a preliminary containment check in raw form BEFORE touching the filesystem:
+//     a path already outside the base is rejected as a traversal attempt without calling
+//     EvalSymlinks on it (so out-of-base, possibly access-restricted, files are never
+//     touched and are reported as traversal rather than as a permission error — #2120)
+//  5. Resolves symlinks in the user path; for non-existent targets, walks up to the
 //     deepest existing ancestor, eval-symlinks it, and re-joins the non-existing remainder
-//  5. Validates containment after symlink resolution using filepath.Rel (not strings.HasPrefix)
+//  6. Validates containment after symlink resolution using filepath.Rel (not strings.HasPrefix)
 //     to prevent sibling-prefix attacks (e.g. /base_extra/secret incorrectly matching /base)
-//     and symlink-escape attacks
+//     and symlink-escape attacks (an in-base symlink that resolves outside the base)
 //
 // On macOS /tmp is a symlink to /private/tmp, so t.TempDir() paths under /var/folders
 // resolve to /private/var/folders after EvalSymlinks. On Windows, short path names
-// (RUNNER~1) expand to long names (runneradmin). The preliminary check in the
-// non-existent-path branch uses the pre-resolution base so both sides match.
+// (RUNNER~1) expand to long names (runneradmin). The raw-form containment checks use the
+// pre-resolution base so both sides match.
 //
 // Returns the validated, canonicalized absolute path.
 func ValidateAndCleanPath(basePath, userPath string) (string, error) {
@@ -154,7 +158,8 @@ func ValidateAndCleanPath(basePath, userPath string) (string, error) {
 	// from EvalSymlinks (#2120). A symlink inside the base that escapes is still
 	// caught by the final containmentCheck after resolution below.
 	if rawRel, rawRelErr := filepath.Rel(rawAbsBasePath, absUserPath); rawRelErr != nil ||
-		strings.HasPrefix(rawRel, "..") || filepath.IsAbs(rawRel) {
+		rawRel == ".." || strings.HasPrefix(rawRel, ".."+string(filepath.Separator)) ||
+		filepath.IsAbs(rawRel) {
 		return "", fmt.Errorf("path traversal attempt detected: %s is outside %s", userPath, absBasePath)
 	}
 

--- a/pkg/security/fileaccess.go
+++ b/pkg/security/fileaccess.go
@@ -144,6 +144,20 @@ func ValidateAndCleanPath(basePath, userPath string) (string, error) {
 		absUserPath = filepath.Join(rawAbsBasePath, cleanUserPath)
 	}
 
+	// Preliminary containment check in raw (pre-symlink-resolution) form, BEFORE
+	// touching the filesystem. If the path is already outside the base, it is a
+	// traversal attempt — reject it now rather than calling EvalSymlinks on a path
+	// outside the sandbox. This both (a) avoids touching out-of-base files at all,
+	// and (b) ensures an out-of-base path that exists but is inaccessible (e.g. an
+	// ACL-protected file on Windows such as C:\Windows\System32\config\sam) is
+	// reported as a traversal attempt instead of an incidental "permission denied"
+	// from EvalSymlinks (#2120). A symlink inside the base that escapes is still
+	// caught by the final containmentCheck after resolution below.
+	if rawRel, rawRelErr := filepath.Rel(rawAbsBasePath, absUserPath); rawRelErr != nil ||
+		strings.HasPrefix(rawRel, "..") || filepath.IsAbs(rawRel) {
+		return "", fmt.Errorf("path traversal attempt detected: %s is outside %s", userPath, absBasePath)
+	}
+
 	// Resolve symlinks in the user path, with fallback for non-existent targets.
 	// This must happen before the final containment check so both paths are canonical.
 	resolved, resolveErr := filepath.EvalSymlinks(absUserPath)

--- a/pkg/security/fileaccess_test.go
+++ b/pkg/security/fileaccess_test.go
@@ -45,7 +45,14 @@ func TestValidateAndCleanPath(t *testing.T) {
 			name:     "directory traversal with absolute path",
 			basePath: tempDir,
 			userPath: func() string {
-				// On Windows, use a Windows absolute path; on Unix, use a Unix absolute path
+				// An absolute path well outside the base. Both fixtures normally
+				// exist but are read-restricted, which is the point of #2120: on
+				// Windows the SAM hive is ACL-protected, so a naive EvalSymlinks
+				// would fail with "Access is denied" before any containment check
+				// and surface a permission error instead of a traversal error.
+				// ValidateAndCleanPath must reject it as a traversal attempt
+				// (containment is checked in raw form before the filesystem is
+				// touched), with the same assertion on every platform.
 				if runtime.GOOS == "windows" {
 					return "C:\\Windows\\System32\\config\\sam"
 				}


### PR DESCRIPTION
## Summary

`pkg/security.ValidateAndCleanPath` (a path-traversal / sandbox-containment guard) called `filepath.EvalSymlinks` on the absolute user path **before** any containment check. For an out-of-base path that exists but is inaccessible — e.g. the ACL-protected `C:\Windows\System32\config\sam` on Windows — `EvalSymlinks` returns "Access is denied" (not `os.ErrNotExist`), so the function returned `"failed to evaluate symlinks: ..."` instead of `"path traversal attempt detected"`. `TestValidateAndCleanPath/directory_traversal_with_absolute_path` asserted the traversal message and failed on Windows.

Per the story AC ("test-only change UNLESS analysis proves a production ordering bug"), analysis proved a **genuine rejection-ordering bug**: containment must be checked before resolving symlinks of an out-of-sandbox path.

## Fix

Add a **preliminary containment check in raw (pre-resolution) form, before touching the filesystem**:
- An absolute path outside the base is rejected as a traversal attempt immediately — `EvalSymlinks` is never called on a path outside the sandbox (better hygiene: out-of-base, possibly access-restricted, files are never touched).
- In-base symlinks that resolve to outside the base are **still caught** by the existing final `containmentCheck` after resolution — unchanged.
- No behavior change on Linux: the same out-of-base path is still rejected with the same `"path traversal attempt detected"` message, just reported earlier. The strict assertion is preserved on every platform (not weakened).

A precise predicate (`rawRel == ".."` / `HasPrefix(rawRel, ".."+sep)`) is used so a legitimate base-level child literally named `..foo` is not over-rejected.

## Changes

- `pkg/security/fileaccess.go` — preliminary raw-form containment check before `EvalSymlinks`; precise traversal predicate; godoc updated to reflect the new unconditional preliminary step.
- `pkg/security/fileaccess_test.go` — documents the Windows ACL scenario in the existing case (comment-only; assertion unchanged).

## Test results (adversarial story-complete team — all PASS)

- **Acceptance check**: PASS — `TestValidateAndCleanPath` (8/8 sub-cases) passes on Windows; the traversal assertion is identical to the Linux cases (not weakened); no new dep.
- **QA test-quality**: PASS — full `pkg/security` package green; symlink-escape & sibling-prefix protections show no regression (symlink sub-cases SKIP on the non-admin Windows host for lack of `SeCreateSymbolicLinkPrivilege`; covered on Linux CI); build/vet/gofmt clean.
- **Security review (opus, adversarial)**: PASS — **explicitly confirmed no directory-traversal bypass is introduced or possible.** The change is a strict *early-reject* (its only effect is `return error`); it never accepts anything previously rejected, and the post-resolution `containmentCheck` remains the authoritative symlink-escape guard. Verified sibling-prefix, cross-volume, UNC, extended-length, and case-insensitivity edge cases — no false-accept path. `make check-architecture` clean; no new dependency.
- **QA code review**: PASS — confirmed the existing test genuinely exercises the new path (the fixtures exist on disk), the inner `ErrNotExist`-branch check is complementary (not dead code), no test-quality issues. The two raised warnings (stale godoc; pre-existing happy-path `HasPrefix` assertions) — the godoc was fixed in this PR; the pre-existing happy-path assertion weakness is out of scope.

## Host / CI caveats

Validated on the Windows e2e host. `golangci-lint`/gitleaks/gosec/Trivy aren't installed there (CI enforces lint + `security-deployment-gate`; `go vet`/`gofmt`/`check-architecture` used locally). The change touches only path-validation logic — no secrets, no new dependencies.

Fixes #2120

Co-Authored-By: Claude <noreply@anthropic.com>