### PR TITLE
dna: per-platform must-collect verification gate + Collector.WaitForBackground (Issue #1951)

### DIFF
--- a/features/steward/dna/dna.go
+++ b/features/steward/dna/dna.go
@@ -162,6 +162,20 @@ func (c *Collector) Collect(ctx context.Context) (*commonpb.DNA, error) {
 	return dna, nil
 }
 
+// WaitForBackground blocks until the asynchronous background collection started
+// by the first Collect call has completed, or until ctx is cancelled. Background
+// collection is kicked off by Collect (via bgOnce), so callers must call Collect
+// at least once before WaitForBackground for it to make progress; a second
+// Collect after this returns yields the merged full snapshot. It exists so that
+// external packages (e.g. integration tests) can wait for the full snapshot
+// without reaching into the unexported bgDone channel.
+func (c *Collector) WaitForBackground(ctx context.Context) {
+	select {
+	case <-c.bgDone:
+	case <-ctx.Done():
+	}
+}
+
 // runBackgroundCollection collects slow software and security data asynchronously.
 // Software and security run concurrently since they write to separate attribute keys.
 // It merges results into slowAttrs and closes bgDone when finished.

--- a/test/integration/dna_snapshot_test.go
+++ b/test/integration/dna_snapshot_test.go
@@ -44,6 +44,14 @@ func collectFullSnapshot(t *testing.T) map[string]string {
 		t.Fatalf("first Collect (kicks off background collection): %v", err)
 	}
 	c.WaitForBackground(ctx)
+	// If WaitForBackground returned because ctx was cancelled (e.g. a short test
+	// -timeout) rather than because background collection finished, the snapshot
+	// is PARTIAL — fail with a clear message so missing background attributes are
+	// not misread as a genuine must-collect coverage gap.
+	if err := ctx.Err(); err != nil {
+		t.Fatalf("background collection did not complete before ctx cancellation (%v); "+
+			"snapshot is partial — increase the test timeout rather than treating this as a coverage gap", err)
+	}
 	snap, err := c.Collect(ctx)
 	if err != nil {
 		t.Fatalf("second Collect (merged full snapshot): %v", err)

--- a/test/integration/dna_snapshot_test.go
+++ b/test/integration/dna_snapshot_test.go
@@ -1,0 +1,191 @@
+//go:build linux || windows
+
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+
+package integration
+
+import (
+	"os"
+	"os/exec"
+	"runtime"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/cfgis/cfgms/features/steward/dna"
+	"github.com/cfgis/cfgms/pkg/logging"
+)
+
+// This is the automated verification gate for the DNA-collection-audit epic
+// (#1932): it spawns a real steward DNA Collector, waits for the first full
+// snapshot (background collection completed), and asserts every Must-Collect
+// attribute from docs/architecture/dna-collection.md is present and non-empty on
+// the corresponding platform.
+//
+// Tiers, per the must-collect spec:
+//   - must-collect (no privilege): asserted unconditionally.
+//   - must-collect-privileged: validated when present; when absent and the
+//     runner is not elevated, a WARN is logged and the assertion is skipped
+//     (an unprivileged runner cannot read e.g. encryption state).
+//   - #2147 carve-out: on a Windows host where wmic has been removed, the memory
+//     collector's CIM fallback does not yet populate memory_total_gb; that gap is
+//     tracked by #2147, so its absence there is a WARN, not a failure. The carve-
+//     out auto-tightens once memory_total_gb is collected.
+
+// collectFullSnapshot spawns a real Collector, triggers and waits for background
+// collection, then returns the merged full-snapshot attributes. Real components
+// only (no mocks), per CLAUDE.md testing standards.
+func collectFullSnapshot(t *testing.T) map[string]string {
+	t.Helper()
+	c := dna.NewCollector(logging.NewLogger("error"))
+	ctx := t.Context()
+	if _, err := c.Collect(ctx); err != nil {
+		t.Fatalf("first Collect (kicks off background collection): %v", err)
+	}
+	c.WaitForBackground(ctx)
+	snap, err := c.Collect(ctx)
+	if err != nil {
+		t.Fatalf("second Collect (merged full snapshot): %v", err)
+	}
+	if snap == nil || snap.Attributes == nil {
+		t.Fatal("nil snapshot or attributes")
+	}
+	return snap.Attributes
+}
+
+// dumpKeysOnFailure logs the collected attribute KEYS only — never values, which
+// may contain hostnames, IP addresses, or usernames — so CI can inspect coverage
+// when an assertion fails.
+func dumpKeysOnFailure(t *testing.T, attrs map[string]string) {
+	t.Helper()
+	if !t.Failed() {
+		return
+	}
+	keys := make([]string, 0, len(attrs))
+	for k := range attrs {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	t.Logf("collected %d attribute keys (values omitted — may be tenant-sensitive): %s",
+		len(keys), strings.Join(keys, ", "))
+}
+
+func requireNonEmpty(t *testing.T, attrs map[string]string, key string) {
+	t.Helper()
+	if v, ok := attrs[key]; !ok || strings.TrimSpace(v) == "" {
+		t.Errorf("must-collect attribute %q is missing or empty", key)
+	}
+}
+
+// requireOneOf asserts that at least one of keys is present and non-empty.
+func requireOneOf(t *testing.T, attrs map[string]string, keys ...string) {
+	t.Helper()
+	for _, k := range keys {
+		if v, ok := attrs[k]; ok && strings.TrimSpace(v) != "" {
+			return
+		}
+	}
+	t.Errorf("at least one of must-collect attributes %v must be present and non-empty", keys)
+}
+
+// checkPrivileged validates a must-collect-privileged attribute: present and
+// non-empty is always good; absent fails only on an elevated runner, otherwise it
+// is a WARN+skip (an unprivileged runner legitimately cannot read it).
+func checkPrivileged(t *testing.T, attrs map[string]string, key string, elevated bool) {
+	t.Helper()
+	v, ok := attrs[key]
+	switch {
+	case ok && strings.TrimSpace(v) != "":
+		return
+	case elevated:
+		t.Errorf("privileged must-collect attribute %q missing or empty despite elevated privileges", key)
+	default:
+		t.Logf("WARN: privileged attribute %q not collected (requires elevation); skipping assertion", key)
+	}
+}
+
+// assertMemoryTotalGB asserts memory_total_gb with the #2147 carve-out: absence
+// is tolerated (WARN) only on a Windows host where wmic has been removed and the
+// CIM-fallback parser gap (#2147) is responsible; present values are always
+// validated, and absence for any other reason is a hard failure.
+func assertMemoryTotalGB(t *testing.T, attrs map[string]string) {
+	t.Helper()
+	if v, ok := attrs["memory_total_gb"]; ok && strings.TrimSpace(v) != "" {
+		return
+	}
+	if runtime.GOOS == "windows" && !wmicAvailable() {
+		t.Logf("WARN: memory_total_gb absent on a wmic-less Windows host; the memory CIM-fallback parser gap is tracked by #2147 — skipping (enforced once #2147 lands)")
+		return
+	}
+	t.Errorf("must-collect attribute %q is missing or empty", "memory_total_gb")
+}
+
+// runnerIsElevated reports whether the test runner has elevated privileges.
+// os.Geteuid() returns 0 for root on Linux; on Windows it returns -1, so Windows
+// runs are treated as unprivileged here (privileged attrs are validated when
+// present and WARN-skipped when absent). Detecting Windows token elevation needs
+// platform-specific code outside this integration test's scope.
+func runnerIsElevated() bool {
+	return os.Geteuid() == 0
+}
+
+func wmicAvailable() bool {
+	_, err := exec.LookPath("wmic")
+	return err == nil
+}
+
+// assertAllPlatformMustCollect asserts the cross-platform must-collect set
+// (docs/architecture/dna-collection.md "All platforms").
+func assertAllPlatformMustCollect(t *testing.T, attrs map[string]string) {
+	t.Helper()
+	for _, k := range []string{
+		"timestamp", "runtime_os", "runtime_arch", "hostname", "num_cpu",
+		"primary_mac", "ip_addresses", "network_interface_count",
+		"default_gateway", "os",
+	} {
+		requireNonEmpty(t, attrs, k)
+	}
+}
+
+func TestDNASnapshotLinux(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		// The file builds on linux||windows; this test asserts the Linux
+		// must-collect set, so it is a no-op on a Windows runner.
+		t.Skipf("Linux-only DNA must-collect gate; running on %s", runtime.GOOS)
+	}
+	attrs := collectFullSnapshot(t)
+	defer dumpKeysOnFailure(t, attrs)
+	elevated := runnerIsElevated()
+
+	assertAllPlatformMustCollect(t, attrs)
+	requireOneOf(t, attrs, "os_name", "os_pretty_name")
+	requireNonEmpty(t, attrs, "kernel_version")
+	assertMemoryTotalGB(t, attrs)
+	requireNonEmpty(t, attrs, "local_user_count")
+	requireNonEmpty(t, attrs, "domain_joined")
+	requireNonEmpty(t, attrs, "av_products_detected")
+	requireOneOf(t, attrs, "ufw_firewall_state", "iptables_rule_count", "firewall_state")
+	checkPrivileged(t, attrs, "luks_encrypted_devices", elevated)
+}
+
+func TestDNASnapshotWindows(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		// The file builds on linux||windows; this test asserts the Windows
+		// must-collect set, so it is a no-op on a Linux runner.
+		t.Skipf("Windows-only DNA must-collect gate; running on %s", runtime.GOOS)
+	}
+	attrs := collectFullSnapshot(t)
+	defer dumpKeysOnFailure(t, attrs)
+	elevated := runnerIsElevated()
+
+	assertAllPlatformMustCollect(t, attrs)
+	requireOneOf(t, attrs, "windows_caption", "windows_version")
+	requireNonEmpty(t, attrs, "windows_build_number")
+	assertMemoryTotalGB(t, attrs)
+	requireNonEmpty(t, attrs, "local_user_count")
+	requireNonEmpty(t, attrs, "domain_joined")
+	requireNonEmpty(t, attrs, "av_products_detected")
+	requireNonEmpty(t, attrs, "windows_firewall_domain_profile")
+	checkPrivileged(t, attrs, "bitlocker_enabled", elevated)
+}


### PR DESCRIPTION
## Summary

The automated **verification gate for the DNA-collection-audit epic (#1932)**: spawns a real steward DNA `Collector`, waits for the first full snapshot (background collection complete), and asserts every Must-Collect attribute from `docs/architecture/dna-collection.md` is present and non-empty on the corresponding platform.

## Changes

- **`features/steward/dna/dna.go`** — exported `Collector.WaitForBackground(ctx context.Context)` that blocks on the unexported `bgDone` channel or `ctx.Done()`, so external packages can await background collection without reaching into internals.
- **`test/integration/dna_snapshot_test.go`** (new, `//go:build linux || windows`) — `TestDNASnapshotLinux` and `TestDNASnapshotWindows`. Real `NewCollector` + `logging.NewLogger`, **no mocks**.

## Design

- **Must-collect lists pulled from the authoritative doc** (`dna-collection.md` §Must-Collect, All-platforms + Linux + Windows), including OR-groups (`windows_caption` OR `windows_version`, firewall OR-groups). The story's longer inline list was illustrative; the AC directs pulling the exact list from the doc.
- **Tiers** (per the spec): must-collect (asserted unconditionally); must-collect-privileged (validated when present; WARN+skip when absent on an unprivileged runner — `bitlocker_enabled`, `luks_encrypted_devices`).
- **Failure dump logs attribute KEYS only** — never values, which may be hostnames/IPs/usernames (tenant-sensitive).
- **Partial-snapshot guard**: if `WaitForBackground` returns due to ctx cancellation (a short test `-timeout`) rather than completion, the test fails with a clear "snapshot is partial — increase the timeout" message, so a timeout is never misread as a coverage gap.

## `memory_total_gb` / wmic carve-out (founder-approved, tracked)

On the Windows e2e host (Server 2025), **`wmic` is removed**; the memory collector's `Get-CimInstance` fallback runs but its CSV output isn't parsed, so `memory_total_gb` is absent. Fixing the collector is **out of #1951's scope** (its Out-of-Scope forbids collector changes) and is tracked as **#2147**. The gate carves this out with an explicit WARN referencing #2147 **only** when `runtime.GOOS == "windows" && wmic is absent`; present values are always validated and absence for any other reason is a hard failure — so the carve-out **auto-tightens** once #2147 lands. Per founder direction, #2147 was reframed as the wmic→**native in-process API** migration that will also underpin the coming process/service monitoring (state + resource utilization).

## Test results (adversarial story-complete team — all PASS)

- **Acceptance check**: PASS — all AC verified; test asserts the doc's must-collect sets exactly (All + Linux + Windows, OR-groups); the doc-vs-inline-list and #2147 carve-out deviations assessed as correct/well-scoped; no new dep.
- **QA test-quality**: PASS — `TestDNASnapshotWindows` passes on the Windows host; `TestDNASnapshotLinux` compiles under `GOOS=linux` (runs on Linux CI); `WaitForBackground` didn't regress the dna package; build/vet/gofmt clean.
- **QA code review**: PASS — `WaitForBackground` correct (non-nil close-once channel, safe on misuse); real components; keys-only dump confirmed; carve-out narrowly scoped; privileged handling correct.
- **Security review**: PASS — explicitly confirmed **no tenant-sensitive value can leak into test logs** (every sink emits keys/static strings only; collector created at `error` level); `WaitForBackground` is a read-only select (no race/leak); `wmicAvailable` is a PATH lookup only (no execution); no new dependency.

## Host / CI caveats

Validated on the Windows e2e host. `golangci-lint`/gitleaks/gosec/Trivy aren't installed there (CI enforces lint + `security-deployment-gate`; `go vet`/`gofmt`/`check-architecture` used locally).

Fixes #1951

Co-Authored-By: Claude <noreply@anthropic.com>