### PR TITLE
agent-dispatch: smoke-test sub-command + Tier 1 health probe + ops doc (Issue #2125)

### DIFF
--- a/.claude/scripts/agent-dispatch.sh
+++ b/.claude/scripts/agent-dispatch.sh
@@ -391,7 +391,11 @@ Commands:
   inspect-exit    <NUM>                     Print exit code of container
   inspect-detail  <NUM>                     Print stats + last 30 log lines
   inspect-container <NAME>                  Print stats + last 30 log lines for named container
-  health-check                              Check image age, Claude version, creds staleness
+  smoke-test      <N>                       Run cfg config list against Tier 1 as agent-test/<N>
+                                            Emits SMOKE_OK:<N> (exit 0) or SMOKE_FAILED:<N>:<error> (non-zero)
+                                            Requires CFGMS_TIER1_URL and a credential (CFGMS_API_KEY_FILE,
+                                            CFGMS_API_KEY, or the per-agent cred at AGENT_CRED_BASE/<N>/api.key)
+  health-check                              Check image age, Claude version, creds staleness, Tier 1 reachability
 EOF
   exit 1
 }
@@ -1101,6 +1105,67 @@ else:
     docker logs --tail 30 "$1" 2>/dev/null || echo "(no logs available)"
     ;;
 
+  smoke-test)
+    [[ $# -eq 1 ]] || { echo "smoke-test requires exactly one issue number"; exit 1; }
+    num="$1"
+    [[ "$num" =~ ^[0-9]+$ ]] || { echo "SMOKE_FAILED:${num}:invalid_issue_num"; exit 1; }
+
+    tier1_url="${CFGMS_TIER1_URL:-}"
+    if [[ -z "$tier1_url" ]]; then
+      echo "SMOKE_FAILED:${num}:no_tier1_url"
+      exit 1
+    fi
+
+    # Determine credential source before launching — missing cred exits without starting a container.
+    # Priority: CFGMS_API_KEY_FILE env → per-agent tmpfs cred → CFGMS_API_KEY env.
+    api_key_file="${CFGMS_API_KEY_FILE:-}"
+    api_key_env="${CFGMS_API_KEY:-}"
+    agent_cred_file="${AGENT_CRED_BASE}/${num}/api.key"
+
+    use_cred_file=""
+    use_cred_env=""
+
+    if [[ -n "$api_key_file" && -f "$api_key_file" ]]; then
+      use_cred_file="$api_key_file"
+    elif [[ -f "$agent_cred_file" ]]; then
+      use_cred_file="$agent_cred_file"
+    elif [[ -n "$api_key_env" ]]; then
+      use_cred_env="$api_key_env"
+    else
+      echo "SMOKE_FAILED:${num}:no_cred"
+      exit 1
+    fi
+
+    # Build docker env args for credential injection.
+    smoke_docker_env=("-e" "CFGMS_TIER1_URL=${tier1_url}")
+    if [[ -n "$use_cred_file" ]]; then
+      smoke_docker_env+=("-v" "${use_cred_file}:/run/cfgms/smoke.key:ro"
+                         "-e" "CFGMS_API_KEY_FILE=/run/cfgms/smoke.key")
+    else
+      smoke_docker_env+=("-e" "CFGMS_API_KEY=${use_cred_env}")
+    fi
+
+    # Run smoke test. --rm ensures the container is always removed on exit.
+    # Test hook: CFGMS_TEST_SMOKE_RUN_CMD replaces docker run for hermetic tests.
+    smoke_exit=0
+    if [[ -n "${CFGMS_TEST_SMOKE_RUN_CMD:-}" ]]; then
+      smoke_out=$(bash -c "${CFGMS_TEST_SMOKE_RUN_CMD}" 2>&1) || smoke_exit=$?
+    else
+      smoke_out=$(docker run --rm \
+        "${smoke_docker_env[@]}" \
+        cfg-agent:latest \
+        cfg config list --tenant="agent-test/${num}" --no-bundle 2>&1) || smoke_exit=$?
+    fi
+
+    if [[ $smoke_exit -eq 0 ]]; then
+      echo "SMOKE_OK:${num}"
+    else
+      err_msg=$(echo "$smoke_out" | head -1)
+      echo "SMOKE_FAILED:${num}:${err_msg}"
+      exit 1
+    fi
+    ;;
+
   health-check)
     warnings=0
 
@@ -1144,6 +1209,22 @@ else:
     else
       echo "WARN:creds:No credentials found — run /agent-setup creds"
       warnings=$((warnings + 1))
+    fi
+
+    # Tier 1 reachability probe
+    tier1_url="${CFGMS_TIER1_URL:-}"
+    if [[ -z "$tier1_url" ]]; then
+      echo "WARN:tier1_url_not_set"
+      warnings=$((warnings + 1))
+    else
+      http_code=$(curl -s --max-time 5 -o /dev/null -w "%{http_code}" \
+        "${tier1_url}/api/v1/health" 2>/dev/null || echo "000")
+      if [[ "$http_code" =~ ^2[0-9]{2}$ ]]; then
+        echo "INFO:tier1_reachable:true"
+      else
+        echo "WARN:tier1_unreachable:${http_code}"
+        warnings=$((warnings + 1))
+      fi
     fi
 
     echo "HEALTH_DONE:warnings=${warnings}"

--- a/.claude/scripts/tests/test-smoke-test.sh
+++ b/.claude/scripts/tests/test-smoke-test.sh
@@ -1,0 +1,207 @@
+#!/usr/bin/env bash
+# Hermetic tests for smoke-test sub-command (Issue #2125).
+#
+# Covers:
+#  - stub cfg exits 1 → SMOKE_FAILED:<N>: emitted, non-zero exit
+#  - missing cred dir → SMOKE_FAILED:<N>:no_cred without launching
+#  - CFGMS_API_KEY env passes cred check
+#  - CFGMS_API_KEY_FILE env (highest-priority) passes cred check
+#  - missing CFGMS_TIER1_URL → SMOKE_FAILED:<N>:no_tier1_url without launching
+#  - non-numeric issue number → SMOKE_FAILED:<N>:invalid_issue_num without launching
+#  - successful stub cfg exits 0 → SMOKE_OK:<N>
+#  - smoke-test is in usage() output
+#  - health-check behavioral: WARN:tier1_url_not_set when CFGMS_TIER1_URL is unset
+#
+# All tests are hermetic: no real Docker, no real controller calls.
+# Uses CFGMS_TEST_SMOKE_RUN_CMD to substitute the docker run command.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+DISPATCH="${SCRIPT_DIR}/../agent-dispatch.sh"
+
+if [[ ! -f "${DISPATCH}" ]]; then
+  printf 'FAIL: agent-dispatch.sh not found at %s\n' "${DISPATCH}" >&2
+  exit 1
+fi
+
+echo "test-smoke-test.sh"
+echo "------------------"
+
+ran=0
+fail=0
+
+check() {
+  local desc="$1" got="$2" want="$3"
+  ran=$((ran + 1))
+  if [[ "$got" == "$want" ]]; then
+    printf '  ok    %s\n' "$desc"
+  else
+    fail=$((fail + 1))
+    printf '  FAIL  %s\n         expected: %s\n         actual:   %s\n' "$desc" "$want" "$got"
+  fi
+}
+
+check_contains() {
+  local desc="$1" haystack="$2" needle="$3"
+  ran=$((ran + 1))
+  if echo "$haystack" | grep -qF "$needle"; then
+    printf '  ok    %s\n' "$desc"
+  else
+    fail=$((fail + 1))
+    printf '  FAIL  %s\n         expected to contain: %s\n         actual: %s\n' "$desc" "$needle" "$haystack"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Shared setup
+# ---------------------------------------------------------------------------
+tmpdir=$(mktemp -d)
+trap 'rm -rf "$tmpdir"' EXIT
+
+cred_base="${tmpdir}/creds"
+
+# Helper: create a fake api.key file for issue <N>
+make_cred() {
+  local n="$1"
+  mkdir -p "${cred_base}/${n}"
+  chmod 700 "${cred_base}/${n}"
+  printf 'fake-api-key-%s' "$n" > "${cred_base}/${n}/api.key"
+  chmod 600 "${cred_base}/${n}/api.key"
+}
+
+# ---------------------------------------------------------------------------
+# T1: stub cfg exits 1 → smoke-test emits SMOKE_FAILED:<N>: and exits non-zero
+# ---------------------------------------------------------------------------
+make_cred 42
+
+t1_out=""
+t1_exit=0
+t1_out=$(
+  CFGMS_TEST_CRED_BASE="$cred_base" \
+  CFGMS_TIER1_URL="https://fake-tier1.test" \
+  CFGMS_TEST_SMOKE_RUN_CMD="exit 1" \
+  bash "${DISPATCH}" smoke-test 42 2>&1
+) || t1_exit=$?
+
+check_contains "T1 stub cfg exits 1 → SMOKE_FAILED:42:" "$t1_out" "SMOKE_FAILED:42:"
+check "T1 stub cfg exits 1 → non-zero exit" "$t1_exit" "1"
+
+# ---------------------------------------------------------------------------
+# T2: missing cred dir → SMOKE_FAILED:<N>:no_cred without launching
+# ---------------------------------------------------------------------------
+t2_out=""
+t2_exit=0
+t2_out=$(
+  CFGMS_TEST_CRED_BASE="${tmpdir}/empty-creds" \
+  CFGMS_TIER1_URL="https://fake-tier1.test" \
+  bash "${DISPATCH}" smoke-test 99 2>&1
+) || t2_exit=$?
+
+check_contains "T2 missing cred → SMOKE_FAILED:99:no_cred" "$t2_out" "SMOKE_FAILED:99:no_cred"
+check "T2 missing cred → non-zero exit" "$t2_exit" "1"
+
+# T2b: CFGMS_API_KEY env var passes the cred check
+t2b_out=""
+t2b_exit=0
+t2b_out=$(
+  CFGMS_TEST_CRED_BASE="${tmpdir}/empty-creds" \
+  CFGMS_TIER1_URL="https://fake-tier1.test" \
+  CFGMS_API_KEY="test-key-value" \
+  CFGMS_TEST_SMOKE_RUN_CMD="exit 0" \
+  bash "${DISPATCH}" smoke-test 99 2>&1
+) || t2b_exit=$?
+
+check_contains "T2b CFGMS_API_KEY env passes cred check → SMOKE_OK" "$t2b_out" "SMOKE_OK:99"
+check "T2b CFGMS_API_KEY env → exit 0" "$t2b_exit" "0"
+
+# T2c: CFGMS_API_KEY_FILE env var (highest-priority path) passes the cred check
+key_file="${tmpdir}/test-api.key"
+printf 'fake-key-from-file' > "$key_file"
+t2c_out=""
+t2c_exit=0
+t2c_out=$(
+  CFGMS_TEST_CRED_BASE="${tmpdir}/empty-creds" \
+  CFGMS_TIER1_URL="https://fake-tier1.test" \
+  CFGMS_API_KEY_FILE="$key_file" \
+  CFGMS_TEST_SMOKE_RUN_CMD="exit 0" \
+  bash "${DISPATCH}" smoke-test 99 2>&1
+) || t2c_exit=$?
+
+check_contains "T2c CFGMS_API_KEY_FILE env passes cred check → SMOKE_OK" "$t2c_out" "SMOKE_OK:99"
+check "T2c CFGMS_API_KEY_FILE env → exit 0" "$t2c_exit" "0"
+
+# ---------------------------------------------------------------------------
+# T3: missing CFGMS_TIER1_URL → SMOKE_FAILED:<N>:no_tier1_url without launching
+# ---------------------------------------------------------------------------
+make_cred 77
+
+t3_out=""
+t3_exit=0
+t3_out=$(
+  env -u CFGMS_TIER1_URL \
+  CFGMS_TEST_CRED_BASE="$cred_base" \
+  bash "${DISPATCH}" smoke-test 77 2>&1
+) || t3_exit=$?
+
+check_contains "T3 missing CFGMS_TIER1_URL → SMOKE_FAILED:77:no_tier1_url" "$t3_out" "SMOKE_FAILED:77:no_tier1_url"
+check "T3 missing CFGMS_TIER1_URL → non-zero exit" "$t3_exit" "1"
+
+# T3b: non-numeric issue number → SMOKE_FAILED with invalid_issue_num
+t3b_out=""
+t3b_exit=0
+t3b_out=$(
+  CFGMS_TIER1_URL="https://fake-tier1.test" \
+  bash "${DISPATCH}" smoke-test "not-a-number" 2>&1
+) || t3b_exit=$?
+
+check_contains "T3b non-numeric arg → SMOKE_FAILED:not-a-number:invalid_issue_num" \
+  "$t3b_out" "SMOKE_FAILED:not-a-number:invalid_issue_num"
+check "T3b non-numeric arg → non-zero exit" "$t3b_exit" "1"
+
+# ---------------------------------------------------------------------------
+# T4: successful stub cfg (exits 0) → SMOKE_OK:<N>
+# ---------------------------------------------------------------------------
+make_cred 11
+
+t4_out=""
+t4_exit=0
+t4_out=$(
+  CFGMS_TEST_CRED_BASE="$cred_base" \
+  CFGMS_TIER1_URL="https://fake-tier1.test" \
+  CFGMS_TEST_SMOKE_RUN_CMD="exit 0" \
+  bash "${DISPATCH}" smoke-test 11 2>&1
+) || t4_exit=$?
+
+check_contains "T4 stub cfg exits 0 → SMOKE_OK:11" "$t4_out" "SMOKE_OK:11"
+check "T4 stub cfg exits 0 → exit 0" "$t4_exit" "0"
+
+# ---------------------------------------------------------------------------
+# T5: smoke-test is in usage() output
+# ---------------------------------------------------------------------------
+usage_out=$(bash "${DISPATCH}" 2>&1 || true)
+ran=$((ran + 1))
+if echo "$usage_out" | grep -q 'smoke-test'; then
+  printf '  ok    T5 smoke-test appears in usage() output\n'
+else
+  fail=$((fail + 1))
+  printf '  FAIL  T5 smoke-test not found in usage() output\n'
+fi
+
+# ---------------------------------------------------------------------------
+# T6: health-check behavioral — WARN:tier1_url_not_set when CFGMS_TIER1_URL is unset.
+# The Tier 1 probe fires before any curl call (it checks the var first), so this
+# is fully hermetic — no real docker or network required. The health-check command
+# tolerates missing docker by using || true and || echo "unknown" patterns.
+# ---------------------------------------------------------------------------
+t6_out=""
+t6_out=$(env -u CFGMS_TIER1_URL bash "${DISPATCH}" health-check 2>&1 || true)
+check_contains "T6 health-check emits WARN:tier1_url_not_set" "$t6_out" "WARN:tier1_url_not_set"
+check_contains "T6 health-check reaches HEALTH_DONE" "$t6_out" "HEALTH_DONE:"
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+printf '\nResults: %d passed, %d failed (%d total)\n' "$((ran - fail))" "$fail" "$ran"
+if [[ $fail -gt 0 ]]; then
+  exit 1
+fi

--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,8 @@ test-steward
 test-*
 # Shell test scripts in devcontainer are not binaries — allow them
 !.devcontainer/scripts/test-*.sh
+# Shell test scripts in .claude/scripts/tests/ are not binaries — allow them
+!.claude/scripts/tests/test-*.sh
 
 # Generated protobuf files in wrong location (should be in api/proto/)
 /steward/

--- a/docs/operations/agent-dispatch.md
+++ b/docs/operations/agent-dispatch.md
@@ -1,36 +1,149 @@
 # Agent Dispatch
 
-Operational reference for the `agent-dispatch.sh` lifecycle, with a focus on
-the credential lifecycle introduced in Issue #2124.
+Operational reference for the `agent-dispatch.sh` lifecycle — environment
+variables, container lifecycle, credential flows, Tier 1 connectivity, and
+tenant isolation.
 
 ---
 
-## Credential Lifecycle
+## Environment Variables
 
-Each agent container launched by `agent-dispatch.sh launch <N>` receives a
-**short-lived, tenant-scoped, least-privilege API key** bound to the
-`agent-test/<N>` sub-tenant and the `agent.dev` role. This document covers
-how those credentials are minted, injected, and revoked.
+### Container-side (injected by the dispatcher)
 
-### Roles and permissions
+These variables are set in every agent container launched by
+`agent-dispatch.sh launch <N>`.
 
-The `agent.dev` role grants read-only access sufficient for a dev agent to
-inspect controller state but not modify it:
+| Variable | Example | Description |
+|---|---|---|
+| `CFGMS_TIER1_URL` | `https://ctrl.cfgms.lab:9080` | Base URL of the Tier 1 controller REST API. All `cfg` CLI calls use this as the server endpoint. |
+| `CFGMS_API_KEY_FILE` | `/run/cfgms/agent-cred/api.key` | Path to the scoped API key file inside the container. The key value is **never** in an env var; `docker inspect` shows only the file path. |
+| `CFGMS_TENANT` | `agent-test/42` | The agent's own sub-tenant. The `agent.dev` role assigned to the key is scoped to this tenant only. |
+| `CFGMS_AGENT_MODE` | `true` | Tells Claude Code to follow the Agent Implementation Workflow (Phase 1–4) rather than entering interactive mode. |
+| `CFGMS_ADMIN_BUNDLE` | _(empty)_ | Explicitly cleared so the container cannot use the host admin mTLS bundle even if the volume were somehow accessible. |
 
-| Permission | Description |
+### Host-side (required before launch/cleanup)
+
+| Variable | Purpose |
 |---|---|
-| `steward:read` | Read steward metadata |
-| `steward:list` | List stewards in the tenant |
-| `steward:read-config` | Read steward configuration |
-| `steward:read-modules` | Read module assignments |
-| `steward:validate-config` | Validate configuration without applying it |
-| `config:list` | List config objects |
-| `config:list-deployments` | List deployments |
-| `tenant:read` | Read tenant metadata |
+| `CFGMS_TIER1_URL` | Tier 1 controller base URL — passed through to the container. Required for `launch`, `smoke-test`, and `health-check`. |
+| `CFGMS_TIER1_ADMIN_KEY` | Admin Bearer token for mint/revoke REST calls (preferred). |
+| `CFGMS_ADMIN_BUNDLE` | Path to admin mTLS bundle YAML — used if `CFGMS_TIER1_ADMIN_KEY` is unset. |
 
-Write operations (`config:create`, `config:update`, `config:delete`),
-management operations (`steward:manage`, `terminal:*`, `rbac:*`), and
-system-admin operations are explicitly excluded.
+One of `CFGMS_TIER1_ADMIN_KEY` or `CFGMS_ADMIN_BUNDLE` must be set for `launch`
+and cleanup operations that reach the controller. If neither is set, mint fails
+with `CRED_MINT_FAILED:no auth available`.
+
+---
+
+## Lifecycle
+
+### Full issue-agent lifecycle
+
+```
+agent-dispatch.sh launch <N>
+  │
+  ├─ mint_agent_creds <N>
+  │     POST /api/v1/tenants        → create agent-test/<N> sub-tenant (idempotent)
+  │     POST /api/v1/api-keys       → issue agent.dev-scoped key
+  │     write /run/cfgms/agent-cred/<N>/api.key   (0600)
+  │     write /run/cfgms/agent-cred/<N>/api.key.id (0600)
+  │     emit  CRED_MINTED:<N>:<key-id>
+  │
+  ├─ docker run -d cfg-agent:latest <N>
+  │     -v /run/cfgms/agent-cred/<N>:/run/cfgms/agent-cred:ro
+  │     -e CFGMS_API_KEY_FILE=/run/cfgms/agent-cred/api.key
+  │     -e CFGMS_TENANT=agent-test/<N>
+  │     -e CFGMS_TIER1_URL=<...>
+  │     -e CFGMS_AGENT_MODE=true
+  │     emit  LAUNCHED:<N>:<container-id>
+  │
+  └─ (agent works; on completion, acceptance reviewer merges PR)
+
+agent-dispatch.sh smoke-test <N>   # optional, on-demand verification
+  │     docker run --rm cfg-agent:latest cfg config list \
+  │           --tenant=agent-test/<N> --no-bundle
+  │     emit  SMOKE_OK:<N>          (exit 0)
+  │        or SMOKE_FAILED:<N>:<error> (exit 1)
+
+agent-dispatch.sh cleanup-issue <N>
+  │
+  ├─ revoke_agent_creds <N>
+  │     DELETE /api/v1/api-keys/<key-id>
+  │     POST   /api/v1/tenants/agent-test/<N>/suspend
+  │     emit   CRED_REVOKED:apikey:<key-id>
+  │     emit   CRED_REVOKED:tenant:agent-test/<N>
+  │
+  ├─ docker rm -f cfg-agent-<N>
+  │     emit  CLEANED:container:cfg-agent-<N>
+  │
+  └─ rm -rf <WORKTREE_BASE>/story-<N>
+        emit  CLEANED:clone:<path>
+```
+
+### Expected output samples
+
+**launch:**
+```
+CRED_MINTED:42:key-id-abc123
+LAUNCHED:42:d3f1a2b4c5e6...
+```
+
+**smoke-test (success):**
+```
+SMOKE_OK:42
+```
+
+**smoke-test (failure):**
+```
+SMOKE_FAILED:42:connection refused
+```
+
+**cleanup-issue:**
+```
+CRED_REVOKED:apikey:key-id-abc123
+CRED_REVOKED:tenant:agent-test/42
+CLEANED:container:cfg-agent-42
+CLEANED:clone:/path/to/worktrees/story-42
+CLEANUP_DONE:42
+```
+
+---
+
+## Smoke Test (`smoke-test <N>`)
+
+`smoke-test <N>` verifies that an agent container can reach the Tier 1
+controller and authenticate with its scoped key. It runs `cfg config list
+--tenant=agent-test/<N> --no-bundle` in a short-lived `--rm` container.
+
+### Credential resolution order
+
+The command checks for credentials **before** launching any container. If none
+are found it exits immediately with `SMOKE_FAILED:<N>:no_cred`.
+
+Priority order:
+
+1. `CFGMS_API_KEY_FILE` env var pointing to an existing file
+2. Per-agent tmpfs cred at `${AGENT_CRED_BASE}/<N>/api.key` (written by `launch`)
+3. `CFGMS_API_KEY` env var (key value directly)
+
+### Output format
+
+| Output | Exit | Meaning |
+|---|---|---|
+| `SMOKE_OK:<N>` | 0 | `cfg config list` succeeded — Tier 1 reachable and auth valid |
+| `SMOKE_FAILED:<N>:no_cred` | 1 | No credential found; container not started |
+| `SMOKE_FAILED:<N>:no_tier1_url` | 1 | `CFGMS_TIER1_URL` not set; container not started |
+| `SMOKE_FAILED:<N>:<error>` | 1 | `cfg config list` failed; `<error>` is the first line of stderr |
+
+The container is always removed (`--rm`) regardless of success or failure.
+
+---
+
+## API Key Mint / Inject / Revoke Flow
+
+Each agent container receives a **short-lived, tenant-scoped, least-privilege
+API key**. The key never appears in `docker inspect` output and is never baked
+into an image layer.
 
 ### Mint (launch)
 
@@ -51,7 +164,7 @@ When `agent-dispatch.sh launch <N>` runs:
    `/run` is a tmpfs mount — credentials never reach disk.
 
 4. **Inject into container** — The cred dir is bind-mounted read-only at
-   `/run/cfgms/agent-cred` inside the container. The container receives:
+   `/run/cfgms/agent-cred` inside the container:
 
    | Env var | Value |
    |---|---|
@@ -59,9 +172,8 @@ When `agent-dispatch.sh launch <N>` runs:
    | `CFGMS_TENANT` | `agent-test/<N>` |
    | `CFGMS_TIER1_URL` | Tier 1 controller base URL |
 
-   The **key value is never in a container env var** — `docker inspect` shows
-   only the file path. The key is never in the `claude-creds` volume and never
-   baked into an image layer.
+   **The key value is never in a container env var.** `docker inspect` shows
+   only the file path. The key is never in the `claude-creds` volume.
 
 **Mint failure** — if the sub-tenant creation or key issuance fails, the
 dispatcher emits `CRED_MINT_FAILED:<reason>`, removes any partial cred dir,
@@ -76,11 +188,11 @@ container and clone:
 - `cleanup-stale` — orphan sweep for closed/failed/blocked stories
 - `cleanup-stale-reviews` — orphan sweep for review containers
 
-The revoke sequence for issue agents:
+The revoke sequence:
 
 1. **Delete API key** — `DELETE /api/v1/api-keys/<key-id>`. The in-memory
    cache entry is removed immediately; any in-flight request with the key
-   receives HTTP 401 with no cache flush required.
+   receives HTTP 401.
 
 2. **Suspend sub-tenant** — `POST /api/v1/tenants/agent-test/<N>/suspend`
    sets `status: suspended`. Suspended tenants cannot issue new keys or
@@ -89,41 +201,113 @@ The revoke sequence for issue agents:
 3. **Remove cred dir** — `/run/cfgms/agent-cred/<N>/` is deleted; because it
    lives in tmpfs the data is gone from RAM immediately.
 
-**No-op safety** — if `/run/cfgms/agent-cred/<N>/` does not exist (agent was
-launched before Issue #2124 or cred was already cleaned), the revoke path
-emits `INFO:no_cred_to_revoke:<N>` and continues without error.
+### Security properties
 
-**Controller-unreachable** — if the controller cannot be reached during
-revocation, the failure is recorded to
+- Key value never appears in `docker inspect` env output.
+- Key value never enters the `claude-creds` Docker volume.
+- Key value never appears in the image.
+- Credentials live in RAM only (Linux `/run` tmpfs) and are destroyed on host
+  reboot even if cleanup is skipped.
+- The `agent.dev` role is fail-closed: full RBAC and tenant isolation
+  enforcement on every controller request — no admin short-circuit.
+
+---
+
+## Tenant-Isolation Model
+
+Each agent container is bound to its own `agent-test/<N>` sub-tenant. The
+`agent.dev` role assigned to the key grants these read-only permissions within
+that tenant only:
+
+| Permission | Description |
+|---|---|
+| `steward:read` | Read steward metadata |
+| `steward:list` | List stewards in the tenant |
+| `steward:read-config` | Read steward configuration |
+| `steward:read-modules` | Read module assignments |
+| `steward:validate-config` | Validate config without applying it |
+| `config:list` | List config objects |
+| `config:list-deployments` | List deployments |
+| `tenant:read` | Read tenant metadata |
+
+**What an agent-test/<N> key cannot do:**
+
+- Read or write data in any other tenant (including `agent-test/<M>` where
+  M ≠ N, and the root tenant).
+- Write configuration (`config:create`, `config:update`, `config:delete`).
+- Manage stewards (`steward:manage`), open remote shells (`terminal:*`), or
+  modify RBAC assignments (`rbac:*`).
+- Perform system-admin operations or modify the tenant tree.
+
+Cross-tenant access is blocked by the controller's tenant isolation enforcement:
+a key bound to `agent-test/42` receives HTTP 403 for any request scoped to a
+different tenant — even within the `agent-test/` namespace.
+
+---
+
+## Orphan-Revocation Paths
+
+An agent container is an orphan if it is running or exited but its
+corresponding story is no longer active. Three automated sweeps handle this:
+
+### `cleanup-issue <N>` — normal exit path
+
+Called by the acceptance reviewer after merging a PR. Revokes creds, removes
+the container, and removes the clone worktree.
+
+### `cleanup-stale` — periodic orphan sweep
+
+Runs on the PO cron cycle. For every `cfg-agent-<NUM>` container found (running
+or exited), checks:
+
+- Is the GitHub issue CLOSED? → clean up.
+- Does the project queue show status `Failed` or `Blocked`? → clean up.
+
+Revokes creds for each stale container before removing it.
+
+### `cleanup-stale-reviews` — review container failsafe
+
+For review containers (`cfg-agent-review-pr-<N>`) that exited without cleaning
+up (e.g. the agent crashed). Removes containers older than 30 minutes,
+archives the result JSON, and deletes the worktree. Also calls
+`revoke_agent_creds` for `review-pr-<N>`.
+
+### Controller-unreachable during revocation
+
+If the controller cannot be reached, the failure is recorded to
 `/run/cfgms/agent-cred/<N>/revoke-failed.txt` (`0600`) in the format:
 
 ```
 <key-id> <unix-timestamp> <error>
 ```
 
-Container and clone removal proceed regardless — revocation failures never
-block cleanup. The file is left for manual follow-up.
+Container and clone removal proceed regardless. The file is left for manual
+follow-up. `cleanup-stale` will attempt revocation again on its next cycle if
+the cred dir still exists.
 
-### Required host configuration
+---
 
-| Env var | Purpose |
-|---|---|
-| `CFGMS_TIER1_URL` | Tier 1 controller base URL, e.g. `https://ctrl.cfgms.lab:9080` |
-| `CFGMS_TIER1_ADMIN_KEY` | Admin API key for mint/revoke calls (preferred) |
-| `CFGMS_ADMIN_BUNDLE` | Path to admin mTLS bundle (used if `CFGMS_TIER1_ADMIN_KEY` is unset) |
+## `SMOKE_FAILED` Troubleshooting
 
-One of `CFGMS_TIER1_ADMIN_KEY` or `CFGMS_ADMIN_BUNDLE` must be set for
-launch and cleanup operations that reach the controller. If neither is set,
-mint fails with `CRED_MINT_FAILED:no auth available`.
+| Output | Cause | Fix |
+|---|---|---|
+| `SMOKE_FAILED:<N>:no_cred` | No API key found for issue `<N>` | Run `launch <N>` first, or set `CFGMS_API_KEY` / `CFGMS_API_KEY_FILE` |
+| `SMOKE_FAILED:<N>:no_tier1_url` | `CFGMS_TIER1_URL` not set | Export `CFGMS_TIER1_URL=https://<controller>:<port>` on the host |
+| `SMOKE_FAILED:<N>:connection refused` | Controller not reachable | Check `health-check` output for `WARN:tier1_unreachable`; verify the controller is up and the port is accessible from the dispatch host |
+| `SMOKE_FAILED:<N>:401` | Key was revoked or expired | Run `cleanup-issue <N>` then `launch <N>` to mint a fresh key |
+| `SMOKE_FAILED:<N>:403` | Key lacks permission for the tenant path | Verify `CFGMS_TENANT` matches `agent-test/<N>`; the key is bound to that tenant only |
+| `SMOKE_FAILED:<N>:certificate verify failed` | TLS trust mismatch | The controller's cert is not trusted by the agent image; rebuild the image with the correct CA or set `CFGMS_TLS_CA_FILE` |
 
-### Security properties
+### `health-check` Tier 1 probes
 
-- Key value never appears in `docker inspect` env output.
-- Key value never enters the `claude-creds` Docker volume.
-- Key value never appears in the image (not baked in at build time).
-- Credentials live in RAM only (Linux `/run` tmpfs) and are destroyed on host
-  reboot even if cleanup is skipped.
-- The `agent.dev` role is fail-closed: it goes through full RBAC and tenant
-  isolation enforcement on every controller request — no admin short-circuit.
-- Tenant isolation enforcement (Issue #2123) blocks cross-tenant access: a
-  key bound to `agent-test/42` cannot read `agent-test/43` data.
+`health-check` includes a Tier 1 reachability probe:
+
+```
+INFO:tier1_reachable:true         — controller /api/v1/health returned 2xx
+WARN:tier1_unreachable:<code>     — HTTP <code> or 000 (connection failure)
+WARN:tier1_url_not_set            — CFGMS_TIER1_URL not exported on the host
+```
+
+`WARN:tier1_url_not_set` is non-fatal for development but means all
+`cfg`-to-controller calls from agent containers will fail. Export
+`CFGMS_TIER1_URL` before dispatching.


### PR DESCRIPTION
## Summary

- Adds `smoke-test <N>` sub-command to `agent-dispatch.sh`: runs `cfg config list --tenant=agent-test/<N> --no-bundle` in a short-lived `--rm` container, emits `SMOKE_OK:<N>` (exit 0) or `SMOKE_FAILED:<N>:<error>` (non-zero); missing cred exits as `SMOKE_FAILED:<N>:no_cred` before launching
- Extends `health-check` with a Tier 1 reachability probe (`curl --max-time 5` against `CFGMS_TIER1_URL/api/v1/health`): emits `INFO:tier1_reachable:true`, `WARN:tier1_unreachable:<code>`, or `WARN:tier1_url_not_set`
- Expands `docs/operations/agent-dispatch.md` with full env-var reference, launch/smoke-test/cleanup lifecycle diagrams with expected output, credential mint/inject/revoke flow, tenant isolation model, orphan-revocation paths, and SMOKE_FAILED troubleshooting guide
- Adds `.claude/scripts/tests/test-smoke-test.sh` (17 hermetic tests covering happy path, all error paths, credential priority, behavioral health-check probe)
- Adds `.gitignore` exception `!.claude/scripts/tests/test-*.sh` (parallel to the existing `.devcontainer/scripts/` exception)

## Specialist Review Results

**Security Engineer: PASS** — no blocking issues; two low-severity warnings (CFGMS_TEST_SMOKE_RUN_CMD follows established CFGMS_TEST_* test-hook pattern; CFGMS_API_KEY env fallback documents as dev-only). Automated scans: security-precommit PASS, check-architecture PASS, security-scan PASS.

**QA Code Reviewer: PASS** (after fix round) — found 4 blocking issues in initial test draft; all fixed: removed dead code block, added behavioral health-check test, added non-numeric-arg error path test, added CFGMS_API_KEY_FILE priority path test. 17 tests now pass.

**QA Test Runner: PASS** — `make test-agent-complete` exit 0; all shell tests pass.

## Test Plan

- [ ] `bash .claude/scripts/tests/test-smoke-test.sh` → 17/17 pass
- [ ] `bash .claude/scripts/tests/agent-apikey-injection.test.sh` → 28/28 pass
- [ ] `make test-agent-complete` → exit 0
- [ ] `agent-dispatch.sh smoke-test <N>` with missing CFGMS_TIER1_URL → `SMOKE_FAILED:<N>:no_tier1_url`
- [ ] `agent-dispatch.sh smoke-test <N>` with no cred → `SMOKE_FAILED:<N>:no_cred`
- [ ] `agent-dispatch.sh health-check` with CFGMS_TIER1_URL unset → `WARN:tier1_url_not_set` in output

Fixes #2125

🤖 Generated with [Claude Code](https://claude.com/claude-code)