### PR TITLE
steward: drain AfterFunc goroutines before monitorWg.Done() (Issue #2157)

### DIFF
--- a/features/steward/steward.go
+++ b/features/steward/steward.go
@@ -593,13 +593,25 @@ func (s *Steward) monitorEventLoop(ctx context.Context, events <-chan modules.Ch
 	fireCh := make(chan string, 16)
 	// debounce maps resourceID → pending AfterFunc timer.
 	debounce := make(map[string]*time.Timer)
+	// afterFuncWg tracks in-flight AfterFunc goroutines so monitorEventLoop
+	// does not return (and monitorWg.Done() is not called) until every timer
+	// callback has exited. Without this, a timer that fires concurrently with
+	// Stop() outlives monitorWg.Wait() and is caught by goleak as a leak.
+	var afterFuncWg sync.WaitGroup
 
 	defer func() {
-		// Stop all pending timers so their functions never run and no goroutines
-		// are created after this loop exits.
+		// Stop pending timers. t.Stop() returns true only if the timer has not
+		// yet fired — in that case the goroutine will never run, so we call
+		// Done() ourselves to balance the Add(1) from below. If t.Stop()
+		// returns false the goroutine is already running; it will call Done().
 		for _, t := range debounce {
-			t.Stop()
+			if t.Stop() {
+				afterFuncWg.Done()
+			}
 		}
+		// Wait for any in-flight AfterFunc goroutines to exit. They observe
+		// s.shutdown (already closed) via their select and return promptly.
+		afterFuncWg.Wait()
 	}()
 
 	for {
@@ -618,7 +630,9 @@ func (s *Steward) monitorEventLoop(ctx context.Context, events <-chan modules.Ch
 			resourceID := evt.ResourceID
 			if _, exists := debounce[resourceID]; !exists {
 				// First event for this resourceID in the window — start the timer.
+				afterFuncWg.Add(1)
 				debounce[resourceID] = time.AfterFunc(s.debounceWindow, func() {
+					defer afterFuncWg.Done()
 					select {
 					case fireCh <- resourceID:
 					case <-ctx.Done():


### PR DESCRIPTION
## Root Cause

Real lifecycle bug (Path A). `monitorEventLoop` creates `time.AfterFunc` goroutines for debouncing ChangeEvents. These goroutines were not tracked by `monitorWg`. When `Stop()` closed `s.shutdown`, the event loop exited and called `t.Stop()` on pending timers — but `t.Stop()` returns `false` if a timer has already fired, meaning the goroutine is still in flight. `monitorWg.Wait()` returned before those goroutines exited, so `goleak.VerifyNone` (called after `Stop()`) caught them as leaks.

The AfterFunc goroutine guards its `fireCh` send with a `select` on `s.shutdown`, so it exits quickly — but there is a narrow window between `monitorWg.Wait()` returning and the goroutine observing the closed channel.

## Fix

Added a local `sync.WaitGroup` (`afterFuncWg`) inside `monitorEventLoop`:

- `afterFuncWg.Add(1)` before each `time.AfterFunc` call
- `defer afterFuncWg.Done()` inside every AfterFunc goroutine body
- Cleanup defer updated: `t.Stop()` returning `true` means the goroutine will never run → call `Done()` to balance; `t.Stop()` returning `false` means the goroutine is in flight and calls `Done()` itself
- `afterFuncWg.Wait()` at the end of the cleanup defer ensures all in-flight goroutines exit before `monitorEventLoop` returns (and therefore before `monitorWg.Done()` fires)

No goleak ignore rules were added or broadened. The two existing `IgnoreTopFunction` entries for DNA `os/exec` goroutines are unchanged and narrowly scoped.

## Verification

```
go test -race -run TestMonitorCloseRace -count=100 ./features/steward
```
100/100 runs, zero failures. All steward tests pass under `-race`. `make test-agent-complete` passes (301 packages, cross-platform compilation).

## Specialist Review

- **QA Test Runner**: PASS — 100x `-race` clean, all 301 packages pass, cross-platform build passes
- **QA Code Reviewer**: PASS — no mocks, no skips, no hacky workarounds, WaitGroup accounting verified correct across all three timer-state scenarios
- **Security Engineer**: PASS — no new attack surface, no unsanitized inputs, architecture checks pass, no new dependencies

Fixes #2157