### PR TITLE
po-act: fix materialize-at-dispatch clone path so draft dispatch doesn't crash

### DIFF
--- a/.claude/scripts/po-act.sh
+++ b/.claude/scripts/po-act.sh
@@ -211,7 +211,14 @@ except Exception: print('')" 2>/dev/null || echo "")
     # handled explicitly in the LAUNCH_FAILED branch below (it runs inside an `if`
     # condition, which `set -e`/ERR does not trap).
     trap 'rc=$?; bash "$PROJECT_QUEUE" update-field "$item_id" status "Ready" >/dev/null 2>&1 || true; echo "ROLLED_BACK:${item_id} -> Ready (dispatch failed before launch, rc=$rc)"; exit "$rc"' ERR
-    if [[ "$arg" =~ ^[0-9]+$ ]]; then
+    # Branch on the RESOLVED story number ($first_arg), not the raw input ($arg).
+    # An issueless draft is materialized above into issue #$story and $first_arg
+    # is set to that number, so it must clone first-class as feature/story-<N>
+    # (matching clone_path=$WORKTREE_BASE/story-<N>). Testing $arg here instead
+    # left materialized drafts on the review-invisible feature/item-<id> path AND
+    # mounted a non-existent worktree (clone_path=story-<N> vs the item-<id> clone
+    # that create-clone-item actually made) → empty /workspace → entrypoint crash.
+    if [[ "$first_arg" =~ ^[0-9]+$ ]]; then
       "$DISPATCH" check-conflicts "$story" >/dev/null
       "$DISPATCH" create-clone "$story" | tail -1
     else


### PR DESCRIPTION
## Critical regression in #2158 (materialize-at-dispatch)

The first draft dispatched under the new flow (#2160) **crashed on container startup** with no PR. Root cause is a single line in `po-act.sh dispatch`:

```bash
if [[ "$arg" =~ ^[0-9]+$ ]]; then        # tests RAW input
  "$DISPATCH" create-clone "$story"       # feature/story-N
else
  "$DISPATCH" create-clone-item "$item_id" # feature/item-<id>  ← taken for drafts
fi
```

For an issueless draft, the dispatch materializes it into issue #N and sets `clone_path=$WORKTREE_BASE/story-N`, `container_name`, and `first_arg` to N — but the branch decision still tested `$arg` (the **non-numeric item-id**), so it fell into `create-clone-item` and cloned to `worktrees/item-<id>`. The container then mounted `realpath(clone_path)` = `worktrees/story-N`, **which doesn't exist**, so Docker mounted an empty `/workspace` and the entrypoint died:

```
bash: /workspace/scripts/project-queue.sh: No such file or directory
ERROR: Cannot fetch project item ...   (exit 1, no PR)
```

So **every draft dispatched through materialize-at-dispatch failed**, and any that didn't crash would land on the review-sweep-invisible `feature/item-<id>` branch (the exact path #2158 set out to retire, Issue #1700).

## Fix

Branch on `$first_arg` (the resolved, always-numeric story number) instead of `$arg`. A materialized draft now clones first-class as `feature/story-N`, matching `clone_path` and the review sweep. One line + an explanatory comment.

## Testing

`bash -n` clean. The fix makes `create-clone` (not `create-clone-item`) handle materialized drafts; `#2160` will be re-dispatched cleanly once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)