### PR TITLE
controlplane/grpc: fix leaked QUIC transport goroutines causing test hangs (Issue #2160)

### DIFF
--- a/pkg/controlplane/providers/grpc/provider.go
+++ b/pkg/controlplane/providers/grpc/provider.go
@@ -344,8 +344,12 @@ func (p *Provider) startServer() error {
 		)
 		transportpb.RegisterStewardTransportServer(p.grpcServer, p.serverImpl)
 
+		// Capture local references: ForceStop/stopServer may nil the shared
+		// fields before this goroutine runs, and reading p.grpcServer inside
+		// the goroutine would then panic.
+		grpcSrv := p.grpcServer
 		go func() {
-			if err := p.grpcServer.Serve(ql); err != nil {
+			if err := grpcSrv.Serve(ql); err != nil {
 				p.logger.Error("gRPC server stopped", "error", err)
 			}
 		}()
@@ -631,13 +635,16 @@ func (p *Provider) checkClientConnected() error {
 // Stop gracefully shuts down the control plane.
 func (p *Provider) Stop(ctx context.Context) error {
 	p.mu.Lock()
-	defer p.mu.Unlock()
-
 	if p.cancel != nil {
 		p.cancel()
 	}
+	mode := p.mode
+	p.mu.Unlock()
+	// mu is released before the blocking teardown so that ControlChannel
+	// handlers (which acquire mu.RLock in dispatchEvent/dispatchHeartbeat)
+	// can exit without deadlocking against GracefulStop.
 
-	switch p.mode {
+	switch mode {
 	case ModeServer:
 		return p.stopServer()
 	case ModeClient:
@@ -648,21 +655,31 @@ func (p *Provider) Stop(ctx context.Context) error {
 }
 
 func (p *Provider) stopServer() error {
-	if p.ownGRPCServer {
-		if p.grpcServer != nil {
-			p.grpcServer.GracefulStop()
-		}
-		if p.listener != nil {
-			_ = p.listener.Close()
-		}
-	}
-	// Clear server state so the singleton can be re-initialized cleanly
-	// (e.g., when multiple integration tests create separate controllers)
-	p.grpcServer = nil
+	// Snapshot and clear fields under mu so concurrent calls and
+	// ForceStop() see nil fields and skip double-teardown.
+	p.mu.Lock()
+	ownGRPC := p.ownGRPCServer
+	listener := p.listener
+	grpcServer := p.grpcServer
 	p.listener = nil
+	p.grpcServer = nil
 	p.serverImpl = nil
 	p.eventHandlers = nil
 	p.heartbeatHandlers = nil
+	p.mu.Unlock()
+
+	if ownGRPC {
+		// Close the QUIC listener first so that all active ControlChannel
+		// streams receive an error from stream.Recv(). This unblocks
+		// GracefulStop, which would otherwise wait forever for persistent
+		// bidirectional streams to close on their own.
+		if listener != nil {
+			_ = listener.Close()
+		}
+		if grpcServer != nil {
+			grpcServer.GracefulStop()
+		}
+	}
 	return nil
 }
 
@@ -980,12 +997,27 @@ func (p *Provider) ListenAddr() string {
 // waiting for in-progress RPCs to complete. Use in tests when GracefulStop
 // would hang on long-lived ControlChannel streams.
 func (p *Provider) ForceStop() {
-	if p.ownGRPCServer {
-		if p.listener != nil {
-			_ = p.listener.Close()
+	// Cancel the provider context and snapshot+clear shared fields under mu
+	// so that concurrent Stop() calls and multiple ForceStop() invocations
+	// are safe (mu also guards p.listener and p.grpcServer against races).
+	p.mu.Lock()
+	if p.cancel != nil {
+		p.cancel()
+	}
+	ownGRPC := p.ownGRPCServer
+	listener := p.listener
+	grpcServer := p.grpcServer
+	p.listener = nil
+	p.grpcServer = nil
+	p.serverImpl = nil
+	p.mu.Unlock()
+
+	if ownGRPC {
+		if listener != nil {
+			_ = listener.Close()
 		}
-		if p.grpcServer != nil {
-			p.grpcServer.Stop()
+		if grpcServer != nil {
+			grpcServer.Stop()
 		}
 	}
 }

--- a/pkg/controlplane/providers/grpc/reconnect_test.go
+++ b/pkg/controlplane/providers/grpc/reconnect_test.go
@@ -280,6 +280,8 @@ func TestOnStateChangeCallback(t *testing.T) {
 		},
 	}))
 	require.NoError(t, client.Start(context.Background()))
+	t.Cleanup(func() { _ = client.Stop(context.Background()) })
+	t.Cleanup(server.ForceStop)
 
 	// Should have seen Connecting → Connected
 	require.Eventually(t, func() bool {

--- a/pkg/controlplane/providers/grpc/testmain_test.go
+++ b/pkg/controlplane/providers/grpc/testmain_test.go
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+
+package grpc
+
+import (
+	"testing"
+
+	"go.uber.org/goleak"
+)
+
+// TestMain installs a package-wide goroutine-leak guard. Any test that starts
+// a server or client without a matching teardown will be caught here.
+//
+// goleak retries for up to 100 iterations (≈10 s) before declaring a leak, so
+// quic-go's internal send-queue goroutines (which exit asynchronously after
+// Transport.Close returns) are given time to drain before a false positive is
+// reported.
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m)
+}

--- a/pkg/transport/quic/listener.go
+++ b/pkg/transport/quic/listener.go
@@ -8,6 +8,7 @@ import (
 	"crypto/tls"
 	"errors"
 	"net"
+	"sync"
 	"time"
 
 	quicgo "github.com/quic-go/quic-go"
@@ -97,7 +98,8 @@ type Listener struct {
 	cfg    *quicgo.Config    // effective config after Listen() injection
 	ctx    context.Context
 	cancel context.CancelFunc
-	conns  chan net.Conn // buffered queue of ready connections
+	conns  chan net.Conn  // buffered queue of ready connections
+	wg     sync.WaitGroup // tracks acceptLoop and acceptStream goroutines
 }
 
 // Compile-time check that Listener implements net.Listener.
@@ -157,7 +159,11 @@ func Listen(addr string, tlsConfig *tls.Config, quicConfig *quicgo.Config) (*Lis
 		cancel: cancel,
 		conns:  make(chan net.Conn, 64),
 	}
-	go l.acceptLoop()
+	l.wg.Add(1)
+	go func() {
+		defer l.wg.Done()
+		l.acceptLoop()
+	}()
 	return l, nil
 }
 
@@ -170,6 +176,7 @@ func (l *Listener) acceptLoop() {
 		if err != nil {
 			return
 		}
+		l.wg.Add(1)
 		go l.acceptStream(quicConn)
 	}
 }
@@ -178,6 +185,7 @@ func (l *Listener) acceptLoop() {
 // bidirectional stream. On success the wrapped Conn is pushed to l.conns.
 // On timeout the QUIC connection is closed so the peer is not left dangling.
 func (l *Listener) acceptStream(quicConn *quicgo.Conn) {
+	defer l.wg.Done()
 	ctx, cancel := context.WithTimeout(l.ctx, 5*time.Second)
 	defer cancel()
 	stream, err := quicConn.AcceptStream(ctx)
@@ -211,6 +219,12 @@ func (l *Listener) Accept() (net.Conn, error) {
 // Close stops the listener. Any blocked Accept call will return with an error.
 func (l *Listener) Close() error {
 	l.cancel()
+	// Wait for acceptLoop and all in-flight acceptStream goroutines to exit
+	// before closing the underlying QUIC infrastructure. This ensures that
+	// by the time Close returns, every goroutine we own has exited, so the
+	// quic-go transport goroutines (runSendQueue, listen) can proceed to
+	// their own exit without competing I/O from our side.
+	l.wg.Wait()
 	err := l.ql.Close()
 	if l.tr != nil {
 		_ = l.tr.Close()


### PR DESCRIPTION
## Summary

- **Root cause pinned**: `TestOnStateChangeCallback` in `reconnect_test.go` created a `ModeServer` provider and started it but never called `server.ForceStop()` at teardown, leaving all quic-go transport goroutines alive across every `-count=N` iteration
- **Production deadlock fixed**: `stopServer()` now closes the QUIC listener before `GracefulStop()` so active `ControlChannel` streams unblock; lock is released before blocking calls so `dispatchEvent`/`dispatchHeartbeat` handlers can exit without deadlocking
- **Data race fixed**: `ForceStop()` now holds `p.mu` when clearing shared fields; `startServer()` captures a local `grpcSrv` reference before launching the serve goroutine
- **Transport drain**: `pkg/transport/quic/listener.go` adds a `sync.WaitGroup` so `Close()` waits for `acceptLoop`/`acceptStream` goroutines to exit before tearing down QUIC infrastructure
- **Leak guard added**: new `TestMain` with `goleak.VerifyTestMain(m)` catches future leaks in this package at test time

## Changed files

| File | Change |
|------|--------|
| `pkg/controlplane/providers/grpc/provider.go` | Fix `stopServer()`, `ForceStop()`, and `startServer()` goroutine |
| `pkg/controlplane/providers/grpc/reconnect_test.go` | Add `t.Cleanup(server.ForceStop)` and `t.Cleanup(client.Stop)` |
| `pkg/controlplane/providers/grpc/testmain_test.go` | New: `TestMain` with `goleak.VerifyTestMain` |
| `pkg/transport/quic/listener.go` | Add `sync.WaitGroup`; `Close()` waits for goroutines before QUIC teardown |

## Test plan

- [x] `CFGMS_TEST_INTEGRATION=0 go test -race -count=5 -timeout=5m ./pkg/controlplane/providers/grpc/...` — PASS (299s, 5 clean runs, no goleak reports, no race detector hits)
- [x] `CFGMS_TEST_INTEGRATION=0 go test -race -count=1 ./pkg/controlplane/...` — PASS
- [x] `CFGMS_TEST_INTEGRATION=0 go test -race -count=3 ./pkg/transport/quic/...` — PASS
- [x] `make test-agent-complete` — PASS
- [x] `make check-architecture` — PASS (no central provider violations)
- [x] `make security-scan` — PASS (no findings in changed files)
- [x] Three-agent adversarial review: QA Code Review PASS, Security PASS, Test Runner PASS

Fixes #2160

🤖 Generated with [Claude Code](https://claude.com/claude-code)