### PR TITLE
deps: bump trivy v0.71.0 → v0.71.2 (Issue #2164)

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -66,15 +66,15 @@ RUN go install github.com/securego/gosec/v2/cmd/gosec@v2.27.1 \
     && curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh \
        | sh -s -- -b "$(go env GOPATH)/bin" v2.12.2
 
-# Trivy — v0.69.4-v0.69.6 are compromised (CVE-2026-33634); v0.71.0 is the
+# Trivy — v0.69.4-v0.69.6 are compromised (CVE-2026-33634); v0.71.2 is the
 # post-incident clean release. We download the project's release archive and
 # verify its SHA-256 against a pinned value before extraction, rather than
 # piping the trivy main branch's install.sh through `sh` (whose contents are
 # fetched at install time and can be tampered with). See
 # docs/runbooks/trivy-rollback.md for rollback procedure.
 RUN set -eu; \
-    TRIVY_VERSION='v0.71.0'; \
-    TRIVY_SHA256='30a3d22b23f88c233f1658f562fb477cae3b3e8b4761109d515b7698daf85814'; \
+    TRIVY_VERSION='v0.71.2'; \
+    TRIVY_SHA256='0510e71e2fd39bf863856d499c8dc19feb4e7336546394c502a8f5cc7ab27460'; \
     ARCHIVE="trivy_${TRIVY_VERSION#v}_Linux-64bit.tar.gz"; \
     curl -sSfL -o "/tmp/${ARCHIVE}" \
       "https://github.com/aquasecurity/trivy/releases/download/${TRIVY_VERSION}/${ARCHIVE}"; \

--- a/.github/scripts/install-trivy.sh
+++ b/.github/scripts/install-trivy.sh
@@ -4,7 +4,7 @@
 # versions per the GHSA-69fq-xp46-6x23 advisory (CVE-2026-33634).
 #
 # Usage: install-trivy.sh <version> <sha256> [dest_dir]
-#   version    Trivy version tag (e.g. "v0.71.0")
+#   version    Trivy version tag (e.g. "v0.71.2")
 #   sha256     Expected SHA-256 of trivy_<v>_Linux-64bit.tar.gz from the
 #              upstream release's checksums.txt — pinned in caller's env.
 #   dest_dir   Install directory (default: /usr/local/bin)

--- a/.github/workflows/dependency-pin-check.yml
+++ b/.github/workflows/dependency-pin-check.yml
@@ -50,7 +50,7 @@ jobs:
           echo "" >&2
           echo "ERROR: a known-compromised Trivy version (v0.69.4 - v0.69.6) was found in a pin-usage context." >&2
           echo "These releases are part of the CVE-2026-33634 supply-chain compromise." >&2
-          echo "Use v0.71.0 (post-incident clean release) or v0.69.3 (pre-incident)." >&2
+          echo "Use v0.71.2 (post-incident clean release) or v0.69.3 (pre-incident)." >&2
           echo "See docs/runbooks/trivy-rollback.md for context." >&2
           exit 1
         fi
@@ -121,7 +121,7 @@ jobs:
         check_version "gitleaks"    "zricethezav/gitleaks"                    "v8.30.1"
         check_version "nancy"       "sonatype-nexus-community/nancy"          "v2.0.0"
         check_version "trufflehog"  "trufflesecurity/trufflehog"              "v3.95.5"
-        check_version "trivy"       "aquasecurity/trivy"                      "v0.71.0"
+        check_version "trivy"       "aquasecurity/trivy"                      "v0.71.2"
         check_version "go-licenses" "google/go-licenses"                      "v2.0.1"
         check_version "golangci-lint" "golangci/golangci-lint"                "v2.12.2"
 

--- a/.github/workflows/docker-security.yml
+++ b/.github/workflows/docker-security.yml
@@ -32,7 +32,7 @@ env:
   GO_VERSION: '1.26.4'
   REGISTRY: ghcr.io
   IMAGE_PREFIX: cfg-is/cfgms
-  TRIVY_VERSION: 'v0.71.0'
+  TRIVY_VERSION: 'v0.71.2'
 
 jobs:
   # Scan Controller Docker Image

--- a/.github/workflows/production-gates.yml
+++ b/.github/workflows/production-gates.yml
@@ -60,10 +60,10 @@ jobs:
         echo "=============================================="
         
         # Install Trivy — v0.69.4-v0.69.6 are compromised (CVE-2026-33634);
-        # v0.71.0 is the post-incident clean release. The install helper
+        # v0.71.2 is the post-incident clean release. The install helper
         # verifies the archive SHA-256 against the pinned value before
         # extraction. See docs/runbooks/trivy-rollback.md for rollback.
-        sudo .github/scripts/install-trivy.sh 'v0.71.0' '30a3d22b23f88c233f1658f562fb477cae3b3e8b4761109d515b7698daf85814'
+        sudo .github/scripts/install-trivy.sh 'v0.71.2' '0510e71e2fd39bf863856d499c8dc19feb4e7336546394c502a8f5cc7ab27460'
 
         # Install other security tools
         make install-nancy

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -53,12 +53,12 @@ jobs:
 
     - name: Install Trivy
       env:
-        # Trivy v0.69.4-v0.69.6 are compromised (CVE-2026-33634); v0.71.0 is
+        # Trivy v0.69.4-v0.69.6 are compromised (CVE-2026-33634); v0.71.2 is
         # the post-incident clean release. The install helper verifies the
         # archive SHA-256 against this pinned value before extraction. See
         # docs/runbooks/trivy-rollback.md for rollback procedure.
-        TRIVY_VERSION: 'v0.71.0'
-        TRIVY_SHA256: '30a3d22b23f88c233f1658f562fb477cae3b3e8b4761109d515b7698daf85814'
+        TRIVY_VERSION: 'v0.71.2'
+        TRIVY_SHA256: '0510e71e2fd39bf863856d499c8dc19feb4e7336546394c502a8f5cc7ab27460'
       run: sudo .github/scripts/install-trivy.sh "$TRIVY_VERSION" "$TRIVY_SHA256"
 
     - name: Run Trivy Scan
@@ -324,10 +324,10 @@ jobs:
         make install-nancy
         
         # Install Trivy — v0.69.4-v0.69.6 are compromised (CVE-2026-33634);
-        # v0.71.0 is the post-incident clean release. The install helper
+        # v0.71.2 is the post-incident clean release. The install helper
         # verifies the archive SHA-256 against the pinned value before
         # extraction. See docs/runbooks/trivy-rollback.md for rollback.
-        sudo .github/scripts/install-trivy.sh 'v0.71.0' '30a3d22b23f88c233f1658f562fb477cae3b3e8b4761109d515b7698daf85814'
+        sudo .github/scripts/install-trivy.sh 'v0.71.2' '0510e71e2fd39bf863856d499c8dc19feb4e7336546394c502a8f5cc7ab27460'
 
         # Install gosec and staticcheck
         go install github.com/securego/gosec/v2/cmd/gosec@v2.27.1


### PR DESCRIPTION
## Summary

Bumps the pinned Trivy tool version **v0.71.0 → v0.71.2** and its archive SHA-256 across all install sites (security-scan, production-gates, docker-security, dependency-pin-check, install-trivy.sh).

## Validated locally (this is why it was done on the host, not an agent)

- **SHA-256 `0510e71e2fd39bf863856d499c8dc19feb4e7336546394c502a8f5cc7ab27460`** independently verified against the upstream `trivy_0.71.2_checksums.txt`.
- Ran the pinned `install-trivy.sh v0.71.2 <sha>` locally → download + checksum match + install all OK.
- Functional scan with v0.71.2 (`trivy fs --scanners secret,misconfig`) → exit 0, clean.

The agent path can't run the docker-security gate (no docker-in-docker), so local validation de-risks the SHA pin before it ever hits the flaky merge queue.

## Unchanged

- CVE-2026-33634 compromised-version denylist (v0.69.4–v0.69.6) and the rollback-runbook references stay exactly as-is.

Fixes #2164

🤖 Generated with [Claude Code](https://claude.com/claude-code)