### PR TITLE
devcontainer: enable serena MCP in dev/po-live containers (build-time only)

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -134,6 +134,40 @@ ENV TRIVY_CACHE_DIR=/home/agent/.cache/trivy
 ENV GOMODCACHE=/home/agent/go/pkg/mod
 ENV GOFLAGS=-modcacherw
 
+# === Serena MCP server (semantic code navigation for PO/dev sessions) ===
+# Everything is fetched at BUILD time (unrestricted network) and baked into the
+# image. At RUNTIME serena resolves entirely from the warmed uv cache with
+# UV_OFFLINE=1, so NO pypi/astral egress is added to the container firewall.
+#
+# uv/uvx — pinned release binary + SHA-256 (same supply-chain pattern as trivy).
+RUN set -eu; \
+    UV_VERSION='0.11.24'; \
+    UV_SHA256='5ce1ad074a78f96c5c8122088bb85a12eb282195bc1453151a48762e4fc31fed'; \
+    curl -sSfL -o /tmp/uv.tgz \
+      "https://github.com/astral-sh/uv/releases/download/${UV_VERSION}/uv-x86_64-unknown-linux-gnu.tar.gz"; \
+    printf '%s  /tmp/uv.tgz\n' "${UV_SHA256}" | sha256sum -c -; \
+    tar -xzf /tmp/uv.tgz -C /tmp; \
+    install -m 0755 /tmp/uv-x86_64-unknown-linux-gnu/uv  /usr/local/bin/uv; \
+    install -m 0755 /tmp/uv-x86_64-unknown-linux-gnu/uvx /usr/local/bin/uvx; \
+    rm -rf /tmp/uv.tgz /tmp/uv-x86_64-unknown-linux-gnu
+
+# gopls — serena's Go language server (pinned), on the shared PATH.
+RUN go install golang.org/x/tools/gopls@v0.22.0 \
+    && install -m 0755 "$(go env GOPATH)/bin/gopls" /usr/local/bin/gopls
+
+# Install serena (pinned v1.5.3) as a self-contained tool for the agent user.
+# This bakes serena + all its Python deps into the image (~/.local/share/uv +
+# the `serena` launcher on ~/.local/bin), so at runtime serena starts directly
+# from the binary with no uvx git re-resolution and no pypi/astral egress.
+# setup-env.sh repoints the project .mcp.json at this binary.
+ENV UV_CACHE_DIR=/home/agent/.cache/uv
+RUN install -d -o agent -g agent /home/agent/.cache/uv /home/agent/.local \
+    && su agent -c 'set -e; export UV_CACHE_DIR=/home/agent/.cache/uv; \
+         uv tool install --from git+https://github.com/oraios/serena@v1.5.3 serena-agent' \
+    && chown -R agent:agent /home/agent/.cache/uv /home/agent/.local
+# Defense-in-depth: keep any stray uv invocation offline behind the firewall.
+ENV UV_OFFLINE=1
+
 # Not a long-running service; health checks are not applicable for on-demand
 # agent containers. HEALTHCHECK NONE suppresses the Trivy DS-0026 advisory.
 HEALTHCHECK NONE

--- a/.devcontainer/scripts/setup-env.sh
+++ b/.devcontainer/scripts/setup-env.sh
@@ -45,3 +45,31 @@ git config --global user.name "cfg-agent"
 git config --global user.email "agent@cfg.is"
 git config --global push.autoSetupRemote true
 gh auth setup-git 2>/dev/null || true
+
+# --- Serena MCP (semantic code navigation) ---
+# Serena is baked into the image as a self-contained, offline-capable binary
+# (see Dockerfile). The committed .mcp.json runs it via `uvx --from git+...`,
+# which re-resolves the git source at launch and would need pypi/astral egress —
+# so in the container we (a) repoint the serena entry at the offline binary and
+# (b) approve the project MCP server (the clone has no settings.local.json, which
+# is gitignored on the host). `skip-worktree` keeps this container-local rewrite
+# out of the dev agent's `git status` so it can never be accidentally committed.
+SERENA_BIN="${HOME}/.local/bin/serena"
+if [ -x "$SERENA_BIN" ] && [ -f /workspace/.mcp.json ]; then
+    tmp=$(mktemp)
+    jq --arg bin "$SERENA_BIN" '.mcpServers.serena = {
+        "type": "stdio", "command": $bin,
+        "args": ["start-mcp-server", "--context", "ide-assistant", "--project", "."],
+        "env": {}
+    }' /workspace/.mcp.json > "$tmp" && mv "$tmp" /workspace/.mcp.json
+    git -C /workspace update-index --skip-worktree .mcp.json 2>/dev/null || true
+
+    mkdir -p /workspace/.claude
+    WS_LOCAL="/workspace/.claude/settings.local.json"
+    if [ -f "$WS_LOCAL" ]; then
+        tmp=$(mktemp)
+        jq '.enabledMcpjsonServers = (((.enabledMcpjsonServers // []) + ["serena"]) | unique)' "$WS_LOCAL" > "$tmp" && mv "$tmp" "$WS_LOCAL"
+    else
+        echo '{"enabledMcpjsonServers":["serena"]}' > "$WS_LOCAL"
+    fi
+fi

--- a/.mcp.json
+++ b/.mcp.json
@@ -5,7 +5,7 @@
       "command": "uvx",
       "args": [
         "--from",
-        "git+https://github.com/oraios/serena",
+        "git+https://github.com/oraios/serena@v1.5.3",
         "serena",
         "start-mcp-server",
         "--context",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -259,6 +259,10 @@ docs/          # Documentation
 - Committing test artifacts — use `git add <specific files>`
 - Logging unsanitized input — use `logging.SanitizeLogValue()`
 
+### Code Navigation (serena MCP)
+
+When the `serena` MCP server is connected (interactive, PO, and dev-agent sessions), prefer its semantic tools over text search for navigating and editing Go code: `find_symbol`, `get_symbols_overview`, and `find_referencing_symbols` to locate code; `replace_symbol_body` / `insert_after_symbol` / `insert_before_symbol` for symbol-level edits. They are more precise and burn far less context than `Grep` + `Read` + whole-file `Edit`. Fall back to grep/read only when the target isn't a code symbol (config, docs, generated files) or serena is unavailable. Serena ships its own usage manual — call its `initial_instructions` tool at the start of a coding task to load it.
+
 ## Desired State Development (DSD)
 
 Stories are outcome-based. Work is complete only when the entire system reflects the desired end state.


### PR DESCRIPTION
## Summary
Makes serena's semantic-code tools available in the agent containers (dev + po-live). Three gaps were blocking it — no `uv`/`uvx` in the image, the project `.mcp.json` server stuck at "Pending approval", and no Go language server. All fixed with **zero new runtime egress**: everything is fetched at image-**build** time and serena runs fully offline behind the container firewall.

## Changes
**`.devcontainer/Dockerfile`**
- `uv 0.11.24` from a pinned release binary + SHA-256 (same supply-chain pattern as the trivy install above it)
- `gopls v0.22.0` (serena's Go language server) on the shared PATH
- `uv tool install` serena pinned **v1.5.3** as a self-contained tool (binary at `~/.local/bin/serena`); `UV_OFFLINE=1` at runtime

**`.devcontainer/scripts/setup-env.sh`** (runs for po-live and dev)
- repoint the project `.mcp.json` serena entry at the offline binary → no uvx git re-resolution, no pypi/astral egress at launch
- approve the project MCP server (the clone lacks the gitignored `settings.local.json`)
- `git update-index --skip-worktree .mcp.json` so the container-local rewrite never dirties a dev agent's tree

**`.mcp.json`** — pin serena to `@v1.5.3` (version-lock for the host; the container uses the baked binary).

## Why build-time only
The container firewall runs at **startup**, not build. Baking uv + serena + gopls into the image means runtime needs **no** pypi/astral access, so no firewall allowlist changes and no new egress attack surface. Serena is pinned (no unpinned `git HEAD` RCE).

## Tested locally
- Built the image; `serena --version` / `start-mcp-server` run under `--network none` (proves offline).
- Ran `setup-env.sh` with the **firewall active** (`policy DROP`) → `claude mcp list` reports **serena ✔ Connected**.
- git tree stays clean (skip-worktree); uv/gopls/serena versions verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)