### PR TITLE
hyperv/audit: cfg resource identity + before/after change capture (Issue #2169)

### DIFF
--- a/features/modules/hyperv/README.md
+++ b/features/modules/hyperv/README.md
@@ -513,6 +513,30 @@ The following are **not** managed by this module:
 - **Golden-image / template cloning, an image registry, and a branch-build → image pipeline** — these are Phase 3 (#1792). The `source` block provisions either from install media (Windows ISO + autounattend, legacy Linux netinst + preseed) or from a vendor **cloud image** booted with cloud-init (the default Linux path). Booting a stock vendor cloud image is **not** the same as cloning a CFGMS-prepared golden template from an image registry — that pipeline is the later, separate Phase 3 capability.
 - Controller-side ISO blob store or ISO distribution (install media is a host path; see [VM provisioning from install media](#vm-provisioning-from-install-media))
 
+## Audit records
+
+Every mutation the module makes to a Hyper-V host is recorded through `pkg/audit` via `recordHypervOp`. An entry is emitted for each PS verb (`New-VM`, `Start-VM`, `Stop-VM`, `Set-VMProcessor`, `Set-VMMemory`, `Remove-VM`, `New-VMSwitch`, `Remove-VMSwitch`, `Add-VMNetworkAdapter`, `Remove-VMNetworkAdapter`).
+
+**Resource identity**: the audit `ResourceID` is always the cfg-declared id (`vm:<name>` or `vswitch:<name>`), never the bare host-side object name.
+
+**Before/after changes**: captured as non-sensitive scalar fields only. The allowed fields per verb are:
+
+| Verb | Before | After |
+|------|--------|-------|
+| `New-VM` | _(empty)_ | `cpu`, `memory_mb`, `state` |
+| `Remove-VM` | `cpu`, `memory_mb`, `state` | _(empty)_ |
+| `Set-VMProcessor` | `cpu` | `cpu` |
+| `Set-VMMemory` | `memory_mb` | `memory_mb` |
+| `Start-VM` / `Stop-VM` | `state` | `state` |
+| `Add-VMNetworkAdapter` | _(empty)_ | `switch` (cfg switch id) |
+| `Remove-VMNetworkAdapter` | `switch` (cfg switch id) | _(empty)_ |
+| `New-VMSwitch` | _(empty)_ | `switch_type`, `state` |
+| `Remove-VMSwitch` | `switch_type`, `state` | _(empty)_ |
+
+**Excluded from all records**: live VM names (as bare values), VHD/VHDX paths, live switch names, and any host-side values that could aid lateral movement. Switch names in `Add-VMNetworkAdapter`/`Remove-VMNetworkAdapter` records appear as cfg ids (`vswitch:<name>`), not raw host values.
+
+The before-snapshot for delete operations is captured best-effort immediately before the mutation call. If the snapshot fails (VM/switch already absent, host unreachable), the record is emitted with `before=nil` — the audit record is still correct, just less detailed.
+
 ## Security considerations
 
 - **PowerShell injection prevention**: The `Invoke-Command` parameter injection pattern is used — user values are passed as WinRM `Arguments`, never embedded in the script block text

--- a/features/modules/hyperv/audit.go
+++ b/features/modules/hyperv/audit.go
@@ -4,19 +4,28 @@ package hyperv
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
+	"sort"
 
 	"github.com/cfgis/cfgms/pkg/audit"
 	business "github.com/cfgis/cfgms/pkg/storage/interfaces/business"
 )
 
 // recordHypervOp emits a pkg/audit entry for a Hyper-V mutation operation.
-// It is nil-safe: when mgr is nil the function returns immediately so lightweight
-// stewards that do not configure an audit manager are unaffected.
 //
-// Structured fields only — no raw PowerShell script text or user-supplied
-// argument values (VM names, VHD paths, switch names) appear in Details.
-func recordHypervOp(ctx context.Context, mgr *audit.Manager, tenantID, stewardID, host, verb, resourceID string, opErr error) {
+// cfgResourceID is the operator-declared resource identity (e.g. "vm:web-01",
+// "vswitch:ext-01") and is used as the audit Resource id. Live VM names, VHD
+// paths, and live switch names never appear in the emitted record — only
+// non-sensitive scalar state (cpu count, memory MB, power state, cfg switch id).
+//
+// before and after capture the scalar state before and after the mutation;
+// Changes.Fields is derived as the sorted set of keys that differ.
+// Create ops pass before=nil; delete ops pass after=nil.
+//
+// The function is nil-safe: when mgr is nil it returns immediately so
+// lightweight stewards that do not configure an audit manager are unaffected.
+func recordHypervOp(ctx context.Context, mgr *audit.Manager, tenantID, stewardID, host, verb, cfgResourceID string, before, after map[string]interface{}, opErr error) {
 	if mgr == nil {
 		return
 	}
@@ -26,9 +35,13 @@ func recordHypervOp(ctx context.Context, mgr *audit.Manager, tenantID, stewardID
 		Type(business.AuditEventConfiguration).
 		Action(verb).
 		User(audit.SystemUserID, business.AuditUserTypeSystem).
-		Resource("hyperv/"+verb, resourceID, "").
+		Resource("hyperv/"+verb, cfgResourceID, "").
 		Detail("host", host).
 		Detail("steward_id", stewardID)
+
+	if len(before) > 0 || len(after) > 0 {
+		builder = builder.Changes(before, after, changedFields(before, after))
+	}
 
 	if opErr == nil {
 		builder = builder.Result(business.AuditResultSuccess)
@@ -39,8 +52,30 @@ func recordHypervOp(ctx context.Context, mgr *audit.Manager, tenantID, stewardID
 	if err := mgr.RecordEvent(ctx, builder); err != nil {
 		slog.Warn("hyperv: failed to record audit event",
 			"verb", verb,
-			"resource_id", resourceID,
+			"resource_id", cfgResourceID,
 			"error", err,
 		)
 	}
+}
+
+// changedFields returns the sorted list of keys whose values differ between
+// before and after, including keys present in only one of the maps.
+func changedFields(before, after map[string]interface{}) []string {
+	seen := make(map[string]struct{})
+	for k := range before {
+		seen[k] = struct{}{}
+	}
+	for k := range after {
+		seen[k] = struct{}{}
+	}
+	var fields []string
+	for k := range seen {
+		bv := fmt.Sprintf("%v", before[k])
+		av := fmt.Sprintf("%v", after[k])
+		if bv != av {
+			fields = append(fields, k)
+		}
+	}
+	sort.Strings(fields)
+	return fields
 }

--- a/features/modules/hyperv/audit_test.go
+++ b/features/modules/hyperv/audit_test.go
@@ -5,6 +5,7 @@ package hyperv
 import (
 	"context"
 	"errors"
+	"fmt"
 	"sync"
 	"testing"
 	"time"
@@ -114,7 +115,7 @@ func newFakeAuditManager(t *testing.T) (*audit.Manager, *fakeAuditStore) {
 // TestAuditRecordHypervOp_NilSafe verifies that a nil audit manager does not panic.
 func TestAuditRecordHypervOp_NilSafe(t *testing.T) {
 	// Must not panic — nil mgr is the default for lightweight edge stewards.
-	recordHypervOp(context.Background(), nil, "tenant-1", "steward-1", "host-1", "New-VM", "vm1", nil)
+	recordHypervOp(context.Background(), nil, "tenant-1", "steward-1", "host-1", "New-VM", "vm:vm1", nil, nil, nil)
 }
 
 // TestAuditRecordHypervOp_NoRawPS verifies that Details contains no raw PowerShell
@@ -123,7 +124,7 @@ func TestAuditRecordHypervOp_NoRawPS(t *testing.T) {
 	mgr, store := newFakeAuditManager(t)
 	defer func() { _ = mgr.Stop(context.Background()) }()
 
-	recordHypervOp(context.Background(), mgr, "tenant-1", "steward-1", "host-1", "New-VM", "vm1", nil)
+	recordHypervOp(context.Background(), mgr, "tenant-1", "steward-1", "host-1", "New-VM", "vm:vm1", nil, nil, nil)
 
 	require.NoError(t, mgr.Flush(context.Background()))
 	entries := store.captured()
@@ -154,7 +155,7 @@ func TestAuditRecordHypervOp_ErrorPath(t *testing.T) {
 	defer func() { _ = mgr.Stop(context.Background()) }()
 
 	opErr := errors.New("VM creation failed: disk quota exceeded")
-	recordHypervOp(context.Background(), mgr, "tenant-1", "steward-1", "host-1", "New-VM", "vm1", opErr)
+	recordHypervOp(context.Background(), mgr, "tenant-1", "steward-1", "host-1", "New-VM", "vm:vm1", nil, nil, opErr)
 
 	require.NoError(t, mgr.Flush(context.Background()))
 	entries := store.captured()
@@ -179,9 +180,9 @@ func TestAuditLog_VMOperation(t *testing.T) {
 	stewardID := "steward-a"
 	host := "winhost.example.com"
 	verb := "New-VM"
-	resourceID := "myvm" // exact VM name — no namespacing
+	cfgResourceID := "vm:myvm" // cfg-declared resource id
 
-	recordHypervOp(context.Background(), mgr, tenantID, stewardID, host, verb, resourceID, nil)
+	recordHypervOp(context.Background(), mgr, tenantID, stewardID, host, verb, cfgResourceID, nil, nil, nil)
 
 	require.NoError(t, mgr.Flush(context.Background()))
 	entries := store.captured()
@@ -191,7 +192,7 @@ func TestAuditLog_VMOperation(t *testing.T) {
 	assert.Equal(t, tenantID, entry.TenantID, "tenant_id")
 	assert.Equal(t, verb, entry.Action, "action/verb")
 	assert.Equal(t, "hyperv/"+verb, entry.ResourceType, "resource_type")
-	assert.Equal(t, resourceID, entry.ResourceID, "resource_id")
+	assert.Equal(t, cfgResourceID, entry.ResourceID, "resource_id must be the cfg-declared id")
 	assert.Equal(t, business.AuditResultSuccess, entry.Result, "result")
 
 	hostVal, ok := entry.Details["host"].(string)
@@ -201,4 +202,540 @@ func TestAuditLog_VMOperation(t *testing.T) {
 	stewardVal, ok := entry.Details["steward_id"].(string)
 	assert.True(t, ok, "Details[steward_id] must be a string")
 	assert.Equal(t, stewardID, stewardVal, "Details[steward_id]")
+}
+
+// ─── Resource identity tests ──────────────────────────────────────────────────
+
+// TestAuditResourceID_UsesCfgID verifies that the audit Resource id is the
+// cfg-declared id (e.g. "vm:web-01") and not a raw bare name.
+func TestAuditResourceID_UsesCfgID(t *testing.T) {
+	mgr, store := newFakeAuditManager(t)
+	defer func() { _ = mgr.Stop(context.Background()) }()
+
+	cfgID := "vm:web-01"
+	recordHypervOp(context.Background(), mgr, "t", "s", "h", "Set-VMProcessor", cfgID, nil, nil, nil)
+
+	require.NoError(t, mgr.Flush(context.Background()))
+	entries := store.captured()
+	require.Len(t, entries, 1)
+
+	entry := entries[0]
+	assert.Equal(t, cfgID, entry.ResourceID,
+		"ResourceID must be the cfg-declared id (vm:name), not the bare live VM name")
+	// The raw bare name must not appear in ResourceID.
+	assert.NotEqual(t, "web-01", entry.ResourceID,
+		"ResourceID must not be a bare name without the resource type prefix")
+}
+
+// ─── Before/after change capture tests ───────────────────────────────────────
+
+// TestAuditChanges_ResizeBeforeAfter verifies that a resize operation produces
+// an audit entry with correctly populated Changes.Before, Changes.After, and
+// Changes.Fields for both cpu and memory_mb.
+func TestAuditChanges_ResizeBeforeAfter(t *testing.T) {
+	mgr, store := newFakeAuditManager(t)
+	defer func() { _ = mgr.Stop(context.Background()) }()
+
+	before := map[string]interface{}{"cpu": 1, "memory_mb": int64(512)}
+	after := map[string]interface{}{"cpu": 2, "memory_mb": int64(1024)}
+
+	recordHypervOp(context.Background(), mgr, "t", "s", "h", "Set-VMProcessor", "vm:resize-vm", before, after, nil)
+
+	require.NoError(t, mgr.Flush(context.Background()))
+	entries := store.captured()
+	require.Len(t, entries, 1)
+
+	entry := entries[0]
+	require.NotNil(t, entry.Changes, "Changes must be populated for a resize operation")
+
+	assert.Equal(t, 1, entry.Changes.Before["cpu"], "Changes.Before[cpu]")
+	assert.Equal(t, int64(512), entry.Changes.Before["memory_mb"], "Changes.Before[memory_mb]")
+	assert.Equal(t, 2, entry.Changes.After["cpu"], "Changes.After[cpu]")
+	assert.Equal(t, int64(1024), entry.Changes.After["memory_mb"], "Changes.After[memory_mb]")
+	assert.ElementsMatch(t, []string{"cpu", "memory_mb"}, entry.Changes.Fields,
+		"Changes.Fields must list all changed keys")
+}
+
+// TestAuditChanges_CreateEmptyBefore verifies that a create operation records
+// an empty Changes.Before (new resource, no prior state).
+func TestAuditChanges_CreateEmptyBefore(t *testing.T) {
+	mgr, store := newFakeAuditManager(t)
+	defer func() { _ = mgr.Stop(context.Background()) }()
+
+	after := map[string]interface{}{"cpu": 2, "memory_mb": int64(1024), "state": "stopped"}
+	recordHypervOp(context.Background(), mgr, "t", "s", "h", "New-VM", "vm:new-vm", nil, after, nil)
+
+	require.NoError(t, mgr.Flush(context.Background()))
+	entry := store.captured()[0]
+
+	require.NotNil(t, entry.Changes, "Changes must be populated when after is non-nil")
+	assert.Empty(t, entry.Changes.Before, "Changes.Before must be empty for a create op")
+	assert.NotEmpty(t, entry.Changes.After, "Changes.After must carry the desired state")
+	assert.Equal(t, 2, entry.Changes.After["cpu"])
+}
+
+// TestAuditChanges_DeleteEmptyAfter verifies that a delete operation records
+// an empty Changes.After (resource removed, no desired state).
+func TestAuditChanges_DeleteEmptyAfter(t *testing.T) {
+	mgr, store := newFakeAuditManager(t)
+	defer func() { _ = mgr.Stop(context.Background()) }()
+
+	before := map[string]interface{}{"cpu": 4, "memory_mb": int64(2048), "state": "stopped"}
+	recordHypervOp(context.Background(), mgr, "t", "s", "h", "Remove-VM", "vm:old-vm", before, nil, nil)
+
+	require.NoError(t, mgr.Flush(context.Background()))
+	entry := store.captured()[0]
+
+	require.NotNil(t, entry.Changes, "Changes must be populated when before is non-nil")
+	assert.NotEmpty(t, entry.Changes.Before, "Changes.Before must carry the prior state")
+	assert.Equal(t, 4, entry.Changes.Before["cpu"])
+	assert.Empty(t, entry.Changes.After, "Changes.After must be empty for a delete op")
+}
+
+// TestAuditChanges_NilBeforeAfter verifies that when both before and after are
+// nil (e.g. provisioning intermediate ops), Changes is not populated.
+func TestAuditChanges_NilBeforeAfter(t *testing.T) {
+	mgr, store := newFakeAuditManager(t)
+	defer func() { _ = mgr.Stop(context.Background()) }()
+
+	recordHypervOp(context.Background(), mgr, "t", "s", "h", "Set-VMFirmware", "vm:prov-vm", nil, nil, nil)
+
+	require.NoError(t, mgr.Flush(context.Background()))
+	entry := store.captured()[0]
+	assert.Nil(t, entry.Changes, "Changes must be nil when both before and after are nil")
+}
+
+// ─── Security: no live host names in audit ────────────────────────────────────
+
+// TestAuditSecurity_NoLiveNamesInResizeEntry verifies that for a VM resize,
+// the live VM name, VHD path, and any switch names from the host state do NOT
+// appear in the emitted audit entry (Resource id, Details, or Changes).
+func TestAuditSecurity_NoLiveNamesInResizeEntry(t *testing.T) {
+	mgr, store := newFakeAuditManager(t)
+	defer func() { _ = mgr.Stop(context.Background()) }()
+
+	const liveVMName = "prod-vm-7f3a"
+	const vhdPath = `C:\VMs\prod-vm-7f3a.vhdx`
+	const switchName = "corp-network-vswitch"
+	cfgID := "vm:" + liveVMName // the cfg id includes the prefix but not the bare name by itself
+
+	before := map[string]interface{}{"cpu": 2, "memory_mb": int64(4096)}
+	after := map[string]interface{}{"cpu": 4, "memory_mb": int64(8192)}
+
+	recordHypervOp(context.Background(), mgr, "tenant", "steward", "host-a", "Set-VMProcessor", cfgID, before, after, nil)
+
+	require.NoError(t, mgr.Flush(context.Background()))
+	entry := store.captured()[0]
+
+	// The cfg resource id uses the vm: prefix — verify it's the cfg id.
+	assert.Equal(t, cfgID, entry.ResourceID, "ResourceID must be the cfg-declared id")
+
+	// VHD path must not appear anywhere.
+	assertNoString(t, entry, vhdPath, "VHD path")
+	// Switch name must not appear anywhere.
+	assertNoString(t, entry, switchName, "live switch name")
+	// Changes must only contain non-sensitive scalar fields.
+	if entry.Changes != nil {
+		for k := range entry.Changes.Before {
+			assert.NotContains(t, k, "vhd", "Changes.Before key must not reference VHD path")
+			assert.NotContains(t, k, "switch", "Changes.Before key must not reference switch names")
+		}
+		for k := range entry.Changes.After {
+			assert.NotContains(t, k, "vhd", "Changes.After key must not reference VHD path")
+			assert.NotContains(t, k, "switch", "Changes.After key must not reference switch names")
+		}
+	}
+}
+
+// TestAuditSecurity_NoLiveNamesInDeleteEntry verifies that for a VM delete,
+// the live VM name, VHD path, and live switch names do NOT appear in
+// the emitted audit entry.
+func TestAuditSecurity_NoLiveNamesInDeleteEntry(t *testing.T) {
+	mgr, store := newFakeAuditManager(t)
+	defer func() { _ = mgr.Stop(context.Background()) }()
+
+	const liveVMName = "db-server-9a2b"
+	const vhdPath = `C:\ClusterStorage\Volume1\db-server-9a2b.vhdx`
+	const switchName = "storage-fabric-switch"
+	cfgID := "vm:" + liveVMName
+
+	// before carries only safe scalar fields (no VHD path, no switch names).
+	before := map[string]interface{}{
+		"cpu":       8,
+		"memory_mb": int64(32768),
+		"state":     "running",
+	}
+
+	recordHypervOp(context.Background(), mgr, "tenant", "steward", "host-b", "Remove-VM", cfgID, before, nil, nil)
+
+	require.NoError(t, mgr.Flush(context.Background()))
+	entry := store.captured()[0]
+
+	assert.Equal(t, cfgID, entry.ResourceID, "ResourceID must be the cfg-declared id")
+
+	// VHD path and live switch name must not appear anywhere in the entry.
+	assertNoString(t, entry, vhdPath, "VHD path")
+	assertNoString(t, entry, switchName, "live switch name")
+
+	// Changes.Before carries only safe scalars.
+	if entry.Changes != nil && entry.Changes.Before != nil {
+		assert.NotContains(t, entry.Changes.Before, "vhd_path", "vhd_path must not appear in Changes.Before")
+		assert.NotContains(t, entry.Changes.Before, "switch_name", "switch_name must not appear in Changes.Before")
+	}
+	// Changes.After must be nil (delete op).
+	if entry.Changes != nil {
+		assert.Empty(t, entry.Changes.After, "Changes.After must be empty for a delete op")
+	}
+}
+
+// assertNoString checks that a string does not appear in any field of the audit
+// entry (ResourceID, Details values, Changes.Before values, Changes.After values).
+func assertNoString(t *testing.T, entry *business.AuditEntry, forbidden, label string) {
+	t.Helper()
+
+	assert.NotContains(t, entry.ResourceID, forbidden,
+		"%s must not appear in ResourceID", label)
+
+	for k, v := range entry.Details {
+		vStr, _ := v.(string)
+		assert.NotContains(t, vStr, forbidden,
+			"%s must not appear in Details[%q]", label, k)
+	}
+
+	if entry.Changes == nil {
+		return
+	}
+	for k, v := range entry.Changes.Before {
+		msg := fmt.Sprintf("%v", v)
+		assert.NotContains(t, msg, forbidden,
+			"%s must not appear in Changes.Before[%q]", label, k)
+	}
+	for k, v := range entry.Changes.After {
+		msg := fmt.Sprintf("%v", v)
+		assert.NotContains(t, msg, forbidden,
+			"%s must not appear in Changes.After[%q]", label, k)
+	}
+}
+
+// ─── changedFields helper tests ───────────────────────────────────────────────
+
+// TestChangedFields_ComputesDiff verifies that changedFields returns the sorted
+// list of keys whose values differ.
+func TestChangedFields_ComputesDiff(t *testing.T) {
+	before := map[string]interface{}{"cpu": 1, "memory_mb": int64(512), "state": "stopped"}
+	after := map[string]interface{}{"cpu": 2, "memory_mb": int64(512), "state": "stopped"}
+	fields := changedFields(before, after)
+	assert.Equal(t, []string{"cpu"}, fields, "only cpu changed")
+}
+
+// TestChangedFields_BothChanged verifies both fields appear when both differ.
+func TestChangedFields_BothChanged(t *testing.T) {
+	before := map[string]interface{}{"cpu": 1, "memory_mb": int64(512)}
+	after := map[string]interface{}{"cpu": 2, "memory_mb": int64(1024)}
+	fields := changedFields(before, after)
+	assert.Equal(t, []string{"cpu", "memory_mb"}, fields,
+		"both fields changed — sorted alphabetically")
+}
+
+// TestChangedFields_NilBeforeOrAfter verifies that keys in a nil map vs a
+// present map are correctly detected as changed.
+func TestChangedFields_NilBeforeOrAfter(t *testing.T) {
+	after := map[string]interface{}{"cpu": 2}
+	fields := changedFields(nil, after)
+	assert.Equal(t, []string{"cpu"}, fields,
+		"key present only in after should appear as changed")
+
+	before := map[string]interface{}{"cpu": 2}
+	fields2 := changedFields(before, nil)
+	assert.Equal(t, []string{"cpu"}, fields2,
+		"key present only in before should appear as changed")
+}
+
+// TestChangedFields_NoChange verifies that an empty slice is returned when
+// before and after are identical.
+func TestChangedFields_NoChange(t *testing.T) {
+	m := map[string]interface{}{"cpu": 2, "state": "running"}
+	fields := changedFields(m, m)
+	assert.Empty(t, fields, "identical maps must produce no changed fields")
+}
+
+// ─── vm.go call-site audit tests ─────────────────────────────────────────────
+
+// vmModuleWithAudit returns a hypervModule wired with both the given transport
+// and a fake audit manager, for tests that need to inspect audit entries.
+func vmModuleWithAudit(t *testing.T, transport winrmTransport, tenantID string) (*hypervModule, *fakeAuditStore) {
+	t.Helper()
+	store := &fakeAuditStore{}
+	mgr, err := audit.NewManager(store, "hyperv-test-vm")
+	require.NoError(t, err, "audit.NewManager must not fail in test setup")
+	return &hypervModule{
+		executor:  &stubHypervExecutor{},
+		transport: transport,
+		tenantID:  tenantID,
+		auditMgr:  mgr,
+		vms:       make(map[string]VMConfig),
+		detector:  &fakeDetector{result: true},
+	}, store
+}
+
+// TestAuditVM_ResizePopulatesBeforeAfter exercises the full setVM → applyVMState
+// path for a cpu+memory resize and asserts that the audit entries for
+// Set-VMProcessor and Set-VMMemory carry the correct before/after changes.
+func TestAuditVM_ResizePopulatesBeforeAfter(t *testing.T) {
+	const vmName = "resize-me"
+	// Current host state: 2 CPUs, 4096 MB, stopped.
+	transport := &testWinRMTransport{
+		perCallOutputs: []string{hostVMJSON(vmName, "stopped", 2, 4096)},
+	}
+	m, store := vmModuleWithAudit(t, transport, "t1")
+	defer func() { _ = m.auditMgr.Stop(context.Background()) }()
+
+	// Desired: 4 CPUs, 8192 MB, stopped.
+	cfg := &VMConfig{
+		Name:       vmName,
+		MemoryMB:   8192,
+		CPUCount:   4,
+		VHDPath:    `C:\VMs\resize-me.vhdx`,
+		SwitchName: "External",
+		Generation: 2,
+		State:      "stopped",
+	}
+
+	err := m.Set(context.Background(), "vm:"+vmName, cfg)
+	require.NoError(t, err)
+
+	mgr := m.auditMgr
+	require.NoError(t, mgr.Flush(context.Background()))
+
+	entries := store.captured()
+	require.NotEmpty(t, entries, "at least one audit entry expected for resize")
+
+	// Find the Set-VMProcessor and Set-VMMemory entries.
+	var cpuEntry, memEntry *business.AuditEntry
+	for _, e := range entries {
+		switch e.Action {
+		case "Set-VMProcessor":
+			cpuEntry = e
+		case "Set-VMMemory":
+			memEntry = e
+		}
+	}
+
+	require.NotNil(t, cpuEntry, "Set-VMProcessor audit entry must be emitted")
+	require.NotNil(t, memEntry, "Set-VMMemory audit entry must be emitted")
+
+	// Resource IDs must be the cfg id.
+	assert.Equal(t, "vm:"+vmName, cpuEntry.ResourceID, "cpu entry must use cfg resource id")
+	assert.Equal(t, "vm:"+vmName, memEntry.ResourceID, "memory entry must use cfg resource id")
+
+	// cpu entry: before={cpu:2}, after={cpu:4}
+	require.NotNil(t, cpuEntry.Changes, "cpu entry must have Changes")
+	assert.Equal(t, 2, cpuEntry.Changes.Before["cpu"])
+	assert.Equal(t, 4, cpuEntry.Changes.After["cpu"])
+	assert.Equal(t, []string{"cpu"}, cpuEntry.Changes.Fields)
+
+	// memory entry: before={memory_mb:4096}, after={memory_mb:8192}
+	require.NotNil(t, memEntry.Changes, "memory entry must have Changes")
+	assert.Equal(t, int64(4096), memEntry.Changes.Before["memory_mb"])
+	assert.Equal(t, int64(8192), memEntry.Changes.After["memory_mb"])
+	assert.Equal(t, []string{"memory_mb"}, memEntry.Changes.Fields)
+
+	// Neither entry should contain raw VM name (bare, without prefix) in resource id.
+	assert.NotEqual(t, vmName, cpuEntry.ResourceID,
+		"bare VM name must not be the resource id (must include vm: prefix)")
+}
+
+// TestAuditVM_DeleteEmptyAfter verifies that a Remove-VM audit entry has
+// a populated Before and an empty After, and uses the cfg resource id.
+func TestAuditVM_DeleteEmptyAfter(t *testing.T) {
+	const vmName = "del-vm"
+	// Transport: first call (getVM in absent path) returns current VM state;
+	// second call (Remove-VM) returns empty.
+	transport := &testWinRMTransport{
+		perCallOutputs: []string{
+			hostVMJSON(vmName, "stopped", 2, 2048),
+			"", // Remove-VM response ignored
+		},
+	}
+	m, store := vmModuleWithAudit(t, transport, "t2")
+	defer func() { _ = m.auditMgr.Stop(context.Background()) }()
+
+	err := m.Set(context.Background(), "vm:"+vmName, mapConfigState{"name": vmName, "state": "absent"})
+	require.NoError(t, err)
+
+	mgr := m.auditMgr
+	require.NoError(t, mgr.Flush(context.Background()))
+
+	entries := store.captured()
+	var removeEntry *business.AuditEntry
+	for _, e := range entries {
+		if e.Action == "Remove-VM" {
+			removeEntry = e
+		}
+	}
+	require.NotNil(t, removeEntry, "Remove-VM audit entry must be emitted")
+
+	assert.Equal(t, "vm:"+vmName, removeEntry.ResourceID, "delete entry must use cfg resource id")
+
+	require.NotNil(t, removeEntry.Changes, "Changes must be populated for delete")
+	assert.NotEmpty(t, removeEntry.Changes.Before, "Changes.Before must carry prior state for delete")
+	assert.Empty(t, removeEntry.Changes.After, "Changes.After must be empty for delete")
+}
+
+// TestAuditVM_CreateEmptyBefore verifies that a New-VM audit entry has an
+// empty Before and a populated After, and uses the cfg resource id.
+func TestAuditVM_CreateEmptyBefore(t *testing.T) {
+	const vmName = "new-vm"
+	// Transport: first call (getVM) returns absent; second call (New-VM) succeeds.
+	transport := &testWinRMTransport{
+		perCallOutputs: []string{`{"found":false}`},
+	}
+	m, store := vmModuleWithAudit(t, transport, "t3")
+	defer func() { _ = m.auditMgr.Stop(context.Background()) }()
+
+	cfg := &VMConfig{
+		Name:       vmName,
+		MemoryMB:   2048,
+		CPUCount:   2,
+		VHDPath:    `C:\VMs\new-vm.vhdx`,
+		SwitchName: "External",
+		Generation: 2,
+		State:      "stopped",
+	}
+
+	err := m.Set(context.Background(), "vm:"+vmName, cfg)
+	require.NoError(t, err)
+
+	mgr := m.auditMgr
+	require.NoError(t, mgr.Flush(context.Background()))
+
+	entries := store.captured()
+	var createEntry *business.AuditEntry
+	for _, e := range entries {
+		if e.Action == "New-VM" {
+			createEntry = e
+		}
+	}
+	require.NotNil(t, createEntry, "New-VM audit entry must be emitted")
+
+	assert.Equal(t, "vm:"+vmName, createEntry.ResourceID, "create entry must use cfg resource id")
+
+	require.NotNil(t, createEntry.Changes, "Changes must be populated for create")
+	assert.Empty(t, createEntry.Changes.Before, "Changes.Before must be empty for create op")
+	assert.NotEmpty(t, createEntry.Changes.After, "Changes.After must carry desired state for create")
+}
+
+// TestAuditVM_SecurityNoLiveNames verifies that for a resize operation performed
+// via the full setVM path, the live VM name (bare), VHD path, and live switch
+// names do not appear anywhere in the emitted audit entries.
+func TestAuditVM_SecurityNoLiveNames(t *testing.T) {
+	const vmName = "secret-vm"
+	const vhdPath = `C:\VMs\secret-vm.vhdx`
+	const switchName = "corp-internal"
+
+	// Host reports the VM with the VHD path and switch name.
+	transport := &testWinRMTransport{
+		perCallOutputs: []string{
+			fmt.Sprintf(`{"found":true,"Name":%q,"MemoryStartupBytes":%d,"ProcessorCount":%d,"Generation":2,"Path":%q,"SwitchName":%q,"SwitchNames":[%q],"State":"Off"}`,
+				vmName, int64(4096)*1024*1024, 2, vhdPath, switchName, switchName),
+		},
+	}
+	m, store := vmModuleWithAudit(t, transport, "t4")
+	defer func() { _ = m.auditMgr.Stop(context.Background()) }()
+
+	cfg := &VMConfig{
+		Name:       vmName,
+		MemoryMB:   8192,
+		CPUCount:   4,
+		VHDPath:    vhdPath,
+		SwitchName: switchName,
+		Generation: 2,
+		State:      "stopped",
+	}
+	err := m.Set(context.Background(), "vm:"+vmName, cfg)
+	require.NoError(t, err)
+
+	mgr := m.auditMgr
+	require.NoError(t, mgr.Flush(context.Background()))
+
+	for _, entry := range store.captured() {
+		// Live VM name (bare) must not be the resource id.
+		assert.NotEqual(t, vmName, entry.ResourceID,
+			"bare VM name must not appear as ResourceID (must use vm: prefix)")
+
+		// VHD path must not appear in any entry field.
+		assertNoString(t, entry, vhdPath, "VHD path")
+
+		// Live switch name must not appear in resize audit entries.
+		if entry.Action == "Set-VMProcessor" || entry.Action == "Set-VMMemory" {
+			assertNoString(t, entry, switchName, "switch name in resize entry")
+		}
+	}
+}
+
+// TestAuditVM_PowerStateBeforeAfter verifies that Start-VM and Stop-VM audit
+// entries carry the correct before/after power state.
+func TestAuditVM_PowerStateBeforeAfter(t *testing.T) {
+	const vmName = "power-vm"
+	// VM is running; desired state is stopped.
+	transport := &testWinRMTransport{
+		perCallOutputs: []string{hostVMJSON(vmName, "running", 2, 4096)},
+	}
+	m, store := vmModuleWithAudit(t, transport, "t5")
+	defer func() { _ = m.auditMgr.Stop(context.Background()) }()
+
+	cfg := &VMConfig{
+		Name:       vmName,
+		MemoryMB:   4096,
+		CPUCount:   2,
+		VHDPath:    `C:\VMs\power-vm.vhdx`,
+		SwitchName: "External",
+		Generation: 2,
+		State:      "stopped",
+	}
+	err := m.Set(context.Background(), "vm:"+vmName, cfg)
+	require.NoError(t, err)
+
+	mgr := m.auditMgr
+	require.NoError(t, mgr.Flush(context.Background()))
+
+	var stopEntry *business.AuditEntry
+	for _, e := range store.captured() {
+		if e.Action == "Stop-VM" {
+			stopEntry = e
+		}
+	}
+	require.NotNil(t, stopEntry, "Stop-VM audit entry must be emitted")
+
+	assert.Equal(t, "vm:"+vmName, stopEntry.ResourceID)
+
+	require.NotNil(t, stopEntry.Changes, "Stop-VM must have Changes")
+	// getVM normalizes "Running" → "running", so current.State is "running" when passed to execStopVM.
+	assert.Equal(t, "running", stopEntry.Changes.Before["state"], "before state must be running (getVM-normalized)")
+	assert.Equal(t, "stopped", stopEntry.Changes.After["state"], "after state must be stopped")
+}
+
+// ─── vswitch audit tests ──────────────────────────────────────────────────────
+
+// TestAuditVSwitch_CreateUsescfgID verifies that New-VMSwitch audit entries use
+// the vswitch: prefixed cfg resource id.
+func TestAuditVSwitch_CreateUsesCfgID(t *testing.T) {
+	mgr, store := newFakeAuditManager(t)
+	defer func() { _ = mgr.Stop(context.Background()) }()
+
+	const switchName = "my-internal"
+	cfgID := "vswitch:" + switchName
+
+	after := map[string]interface{}{"switch_type": "internal", "state": "present"}
+	recordHypervOp(context.Background(), mgr, "t", "s", "h", "New-VMSwitch", cfgID, nil, after, nil)
+
+	require.NoError(t, mgr.Flush(context.Background()))
+	entries := store.captured()
+	require.Len(t, entries, 1)
+
+	assert.Equal(t, cfgID, entries[0].ResourceID,
+		"vswitch audit entry must use vswitch:<name> cfg resource id")
+	require.NotNil(t, entries[0].Changes)
+	assert.Empty(t, entries[0].Changes.Before, "New-VMSwitch must have empty Before")
+	assert.Equal(t, "internal", entries[0].Changes.After["switch_type"])
 }

--- a/features/modules/hyperv/vm.go
+++ b/features/modules/hyperv/vm.go
@@ -678,7 +678,17 @@ func (m *hypervModule) setVM(ctx context.Context, resourceID string, config modu
 	state, _ := configMap["state"].(string)
 
 	if state == "absent" {
-		return m.removeVM(ctx, vmName)
+		// Snapshot current state for the audit before-capture (best-effort: nil is
+		// acceptable if the VM is already absent or the host is unreachable).
+		var deleteBefore map[string]interface{}
+		if cur, gErr := m.getVM(ctx, vmName); gErr == nil && cur != nil && cur.State != "absent" {
+			deleteBefore = map[string]interface{}{
+				"cpu":       cur.CPUCount,
+				"memory_mb": cur.MemoryMB,
+				"state":     cur.State,
+			}
+		}
+		return m.removeVM(ctx, vmName, deleteBefore)
 	}
 
 	cfg := &VMConfig{Name: vmName}
@@ -802,7 +812,9 @@ func (m *hypervModule) setVM(ctx context.Context, resourceID string, config modu
 	}
 
 	if state == "running" {
-		if err := m.execStartVM(ctx, vmName, hostName); err != nil {
+		if err := m.execStartVM(ctx, "vm:"+vmName, hostName,
+			map[string]interface{}{"state": "stopped"},
+			map[string]interface{}{"state": "running"}); err != nil {
 			return err
 		}
 	}
@@ -872,7 +884,15 @@ func (m *hypervModule) applySourceGated(ctx context.Context, vmName, hostName st
 		// Explicit destructive opt-in. Tear the existing VM down, reset any
 		// provisioning record so the create path starts clean (absent), then
 		// provision from source.
-		if err := m.removeVM(ctx, vmName); err != nil {
+		var recreateBefore map[string]interface{}
+		if vmExists && currentVM != nil {
+			recreateBefore = map[string]interface{}{
+				"cpu":       currentVM.CPUCount,
+				"memory_mb": currentVM.MemoryMB,
+				"state":     currentVM.State,
+			}
+		}
+		if err := m.removeVM(ctx, vmName, recreateBefore); err != nil {
 			return err
 		}
 		if m.provisionStore != nil {
@@ -942,6 +962,15 @@ func (m *hypervModule) createVM(ctx context.Context, vmName, hostName string, cf
 		"Generation": fmt.Sprintf("%d", generation),
 	}
 
+	cfgResourceID := "vm:" + vmName
+	// after captures the non-sensitive scalar desired state for audit; VHD path
+	// and switch names are deliberately omitted (sensitive / not scalar).
+	after := map[string]interface{}{
+		"cpu":       cfg.CPUCount,
+		"memory_mb": cfg.MemoryMB,
+		"state":     "stopped", // New-VM always creates in Off state
+	}
+
 	// cloud-init (Linux VM-from-cloud-image): the boot disk IS the cloud image,
 	// not a freshly-created empty VHD. Prepare it (raw → fixed VHD → dynamic VHDX,
 	// optional resize) and create the VM attaching the EXISTING disk
@@ -953,35 +982,35 @@ func (m *hypervModule) createVM(ctx context.Context, vmName, hostName string, cf
 			"VhdPath":     cfg.VHDPath,
 			"ResizeBytes": fmt.Sprintf("%d", resizeBytes),
 		}); psErr != nil {
-			recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.host, "Convert-VHD", hostName, psErr)
+			recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.host, "Convert-VHD", cfgResourceID, nil, nil, psErr)
 			return fmt.Errorf("hyperv: prepare cloud boot disk for VM %q: %w", vmName, psErr)
 		}
-		recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.host, "Convert-VHD", hostName, nil)
+		recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.host, "Convert-VHD", cfgResourceID, nil, nil, nil)
 		_, psErr := m.transport.ExecutePS(ctx, psCreateVMFromDisk, psArgs)
-		recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.host, "New-VM", hostName, psErr)
+		recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.host, "New-VM", cfgResourceID, nil, after, psErr)
 		if psErr != nil {
 			return fmt.Errorf("hyperv: create VM %q from cloud image: %w", vmName, psErr)
 		}
-		return m.connectAdditionalNics(ctx, vmName, hostName, cfg)
+		return m.connectAdditionalNics(ctx, cfgResourceID, vmName, hostName, cfg)
 	}
 
 	_, psErr := m.transport.ExecutePS(ctx, psCreateVM, psArgs)
-	recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.host, "New-VM", hostName, psErr)
+	recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.host, "New-VM", cfgResourceID, nil, after, psErr)
 	if psErr != nil {
 		return fmt.Errorf("hyperv: create VM %q: %w", vmName, psErr)
 	}
 
-	return m.connectAdditionalNics(ctx, vmName, hostName, cfg)
+	return m.connectAdditionalNics(ctx, cfgResourceID, vmName, hostName, cfg)
 }
 
 // connectAdditionalNics connects one extra network adapter for every desired
 // switch beyond the first (New-VM -SwitchName already connected the first), so a
 // multi-NIC declaration materialises all adapters at create time. Shared by the
 // empty-VHD and cloud-image create paths.
-func (m *hypervModule) connectAdditionalNics(ctx context.Context, vmName, hostName string, cfg *VMConfig) error {
+func (m *hypervModule) connectAdditionalNics(ctx context.Context, cfgResourceID, vmName, hostName string, cfg *VMConfig) error {
 	desired := cfg.desiredSwitches()
 	for _, sw := range desired[min(1, len(desired)):] {
-		if err := m.connectVMToSwitch(ctx, vmName, hostName, sw); err != nil {
+		if err := m.connectVMToSwitch(ctx, cfgResourceID, vmName, hostName, sw); err != nil {
 			return err
 		}
 	}
@@ -991,18 +1020,33 @@ func (m *hypervModule) connectAdditionalNics(ctx context.Context, vmName, hostNa
 // applyVMState transitions an existing VM to the desired power state, applying
 // CPU/memory resize when the desired values differ from current.
 func (m *hypervModule) applyVMState(ctx context.Context, vmName, hostName string, desired, current *VMConfig, state string) error {
+	cfgResourceID := "vm:" + vmName
+
 	// Reconcile the VM's network adapters to the desired switch set before any
 	// power-state change. Add-VMNetworkAdapter / Remove-VMNetworkAdapter both
 	// operate on running and stopped VMs, so ordering relative to start/stop
 	// does not matter. reconcileNetwork mutates current.SwitchNames in place so
 	// the cache write at the end of this function reflects the converged set.
-	if err := m.reconcileNetwork(ctx, vmName, hostName, desired, current); err != nil {
+	if err := m.reconcileNetwork(ctx, cfgResourceID, vmName, hostName, desired, current); err != nil {
 		return err
 	}
 
 	needsCPUResize := desired.CPUCount != 0 && desired.CPUCount != current.CPUCount
 	needsMemResize := desired.MemoryMB != 0 && desired.MemoryMB != current.MemoryMB
 	needsResize := needsCPUResize || needsMemResize
+
+	// Build per-operation before/after snapshots for resize auditing. Only
+	// non-sensitive scalars (cpu count, memory MB) are included — no VHD paths,
+	// no switch names, no live host values.
+	var cpuBefore, cpuAfter, memBefore, memAfter map[string]interface{}
+	if needsCPUResize {
+		cpuBefore = map[string]interface{}{"cpu": current.CPUCount}
+		cpuAfter = map[string]interface{}{"cpu": desired.CPUCount}
+	}
+	if needsMemResize {
+		memBefore = map[string]interface{}{"memory_mb": current.MemoryMB}
+		memAfter = map[string]interface{}{"memory_mb": desired.MemoryMB}
+	}
 
 	switch state {
 	case "running":
@@ -1012,30 +1056,36 @@ func (m *hypervModule) applyVMState(ctx context.Context, vmName, hostName string
 			// Gating on current.State keeps the transition idempotent: a VM that
 			// is already stopped is not issued a redundant Stop-VM.
 			if current.State != "stopped" {
-				if err := m.execStopVM(ctx, vmName, hostName); err != nil {
+				if err := m.execStopVM(ctx, cfgResourceID, hostName,
+					map[string]interface{}{"state": current.State},
+					map[string]interface{}{"state": "stopped"}); err != nil {
 					return err
 				}
 			}
 			if needsCPUResize {
-				if err := m.execSetVMProcessor(ctx, vmName, hostName, desired.CPUCount); err != nil {
+				if err := m.execSetVMProcessor(ctx, cfgResourceID, hostName, desired.CPUCount, cpuBefore, cpuAfter); err != nil {
 					return err
 				}
 			}
 			if needsMemResize {
-				if err := m.execSetVMMemory(ctx, vmName, hostName, desired.MemoryMB); err != nil {
+				if err := m.execSetVMMemory(ctx, cfgResourceID, hostName, desired.MemoryMB, memBefore, memAfter); err != nil {
 					return err
 				}
 			}
 			// A resize always ends with the VM stopped, so the desired running
 			// state requires an unconditional Start-VM here.
-			if err := m.execStartVM(ctx, vmName, hostName); err != nil {
+			if err := m.execStartVM(ctx, cfgResourceID, hostName,
+				map[string]interface{}{"state": "stopped"},
+				map[string]interface{}{"state": "running"}); err != nil {
 				return err
 			}
 		} else if current.State != "running" {
 			// No resize needed — only start the VM if it is not already running.
 			// Re-applying a config whose power state already matches issues no
 			// Start-VM (Hyper-V errors "already in the running state" otherwise).
-			if err := m.execStartVM(ctx, vmName, hostName); err != nil {
+			if err := m.execStartVM(ctx, cfgResourceID, hostName,
+				map[string]interface{}{"state": current.State},
+				map[string]interface{}{"state": "running"}); err != nil {
 				return err
 			}
 		}
@@ -1049,18 +1099,20 @@ func (m *hypervModule) applyVMState(ctx context.Context, vmName, hostName string
 		// Stop ONLY IF the VM is not already stopped — re-applying a stopped
 		// config on an already-stopped VM issues no Stop-VM.
 		if current.State != "stopped" {
-			if err := m.execStopVM(ctx, vmName, hostName); err != nil {
+			if err := m.execStopVM(ctx, cfgResourceID, hostName,
+				map[string]interface{}{"state": current.State},
+				map[string]interface{}{"state": "stopped"}); err != nil {
 				return err
 			}
 		}
 		// The VM is stopped (or was already), so resize can proceed.
 		if needsCPUResize {
-			if err := m.execSetVMProcessor(ctx, vmName, hostName, desired.CPUCount); err != nil {
+			if err := m.execSetVMProcessor(ctx, cfgResourceID, hostName, desired.CPUCount, cpuBefore, cpuAfter); err != nil {
 				return err
 			}
 		}
 		if needsMemResize {
-			if err := m.execSetVMMemory(ctx, vmName, hostName, desired.MemoryMB); err != nil {
+			if err := m.execSetVMMemory(ctx, cfgResourceID, hostName, desired.MemoryMB, memBefore, memAfter); err != nil {
 				return err
 			}
 		}
@@ -1084,7 +1136,7 @@ func (m *hypervModule) applyVMState(ctx context.Context, vmName, hostName string
 // Switch names are passed to the connect/disconnect primitives exactly as the
 // VM create path passes them to New-VM -SwitchName (the literal name the admin
 // specified — no prefix or suffix is added on the host).
-func (m *hypervModule) reconcileNetwork(ctx context.Context, vmName, hostName string, desired, current *VMConfig) error {
+func (m *hypervModule) reconcileNetwork(ctx context.Context, cfgResourceID, vmName, hostName string, desired, current *VMConfig) error {
 	desiredSet := desired.desiredSwitches()
 	// No network declared on the desired config → leave the VM's adapters
 	// untouched (never implicitly strip a VM to zero NICs).
@@ -1094,12 +1146,12 @@ func (m *hypervModule) reconcileNetwork(ctx context.Context, vmName, hostName st
 
 	toConnect, toDisconnect := switchSetDiff(desiredSet, current.desiredSwitches())
 	for _, sw := range toConnect {
-		if err := m.connectVMToSwitch(ctx, vmName, hostName, sw); err != nil {
+		if err := m.connectVMToSwitch(ctx, cfgResourceID, vmName, hostName, sw); err != nil {
 			return err
 		}
 	}
 	for _, sw := range toDisconnect {
-		if err := m.disconnectVMFromSwitch(ctx, vmName, hostName, sw); err != nil {
+		if err := m.disconnectVMFromSwitch(ctx, cfgResourceID, vmName, hostName, sw); err != nil {
 			return err
 		}
 	}
@@ -1112,14 +1164,15 @@ func (m *hypervModule) reconcileNetwork(ctx context.Context, vmName, hostName st
 
 // connectVMToSwitch connects a new network adapter on the VM to switchName.
 // switchName travels via ArgumentList — never interpolated into script text.
-func (m *hypervModule) connectVMToSwitch(ctx context.Context, vmName, hostName, switchName string) error {
+func (m *hypervModule) connectVMToSwitch(ctx context.Context, cfgResourceID, vmName, hostName, switchName string) error {
 	// switchName is the exact switch name the admin specified — used verbatim so
 	// Add-VMNetworkAdapter targets the switch by the name on the host.
 	_, psErr := m.transport.ExecutePS(ctx, psConnectVMNic, map[string]string{
 		"Name":       hostName,
 		"SwitchName": switchName,
 	})
-	recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.host, "Add-VMNetworkAdapter", hostName, psErr)
+	after := map[string]interface{}{"switch": "vswitch:" + switchName}
+	recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.host, "Add-VMNetworkAdapter", cfgResourceID, nil, after, psErr)
 	if psErr != nil {
 		return fmt.Errorf("hyperv: connect VM %q to switch %q: %w", vmName, switchName, psErr)
 	}
@@ -1128,70 +1181,74 @@ func (m *hypervModule) connectVMToSwitch(ctx context.Context, vmName, hostName, 
 
 // disconnectVMFromSwitch removes the network adapter connected to switchName on
 // the VM. switchName travels via ArgumentList — never interpolated.
-func (m *hypervModule) disconnectVMFromSwitch(ctx context.Context, vmName, hostName, switchName string) error {
+func (m *hypervModule) disconnectVMFromSwitch(ctx context.Context, cfgResourceID, vmName, hostName, switchName string) error {
 	// switchName is the exact switch name; the adapter's SwitchName on the host is
 	// the same literal name, so it travels verbatim for the Where-Object match.
 	_, psErr := m.transport.ExecutePS(ctx, psDisconnectVMNic, map[string]string{
 		"Name":       hostName,
 		"SwitchName": switchName,
 	})
-	recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.host, "Remove-VMNetworkAdapter", hostName, psErr)
+	before := map[string]interface{}{"switch": "vswitch:" + switchName}
+	recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.host, "Remove-VMNetworkAdapter", cfgResourceID, before, nil, psErr)
 	if psErr != nil {
 		return fmt.Errorf("hyperv: disconnect VM %q from switch %q: %w", vmName, switchName, psErr)
 	}
 	return nil
 }
 
-func (m *hypervModule) execStartVM(ctx context.Context, vmName, hostName string) error {
+func (m *hypervModule) execStartVM(ctx context.Context, cfgResourceID, hostName string, before, after map[string]interface{}) error {
 	_, psErr := m.transport.ExecutePS(ctx, psStartVM, map[string]string{"Name": hostName})
-	recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.host, "Start-VM", hostName, psErr)
+	recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.host, "Start-VM", cfgResourceID, before, after, psErr)
 	if psErr != nil {
-		return fmt.Errorf("hyperv: Start-VM %q: %w", vmName, psErr)
+		return fmt.Errorf("hyperv: Start-VM %q: %w", hostName, psErr)
 	}
 	return nil
 }
 
-func (m *hypervModule) execStopVM(ctx context.Context, vmName, hostName string) error {
+func (m *hypervModule) execStopVM(ctx context.Context, cfgResourceID, hostName string, before, after map[string]interface{}) error {
 	_, psErr := m.transport.ExecutePS(ctx, psStopVM, map[string]string{"Name": hostName})
-	recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.host, "Stop-VM", hostName, psErr)
+	recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.host, "Stop-VM", cfgResourceID, before, after, psErr)
 	if psErr != nil {
-		return fmt.Errorf("hyperv: Stop-VM %q: %w", vmName, psErr)
+		return fmt.Errorf("hyperv: Stop-VM %q: %w", hostName, psErr)
 	}
 	return nil
 }
 
-func (m *hypervModule) execSetVMProcessor(ctx context.Context, vmName, hostName string, cpuCount int) error {
+func (m *hypervModule) execSetVMProcessor(ctx context.Context, cfgResourceID, hostName string, cpuCount int, before, after map[string]interface{}) error {
 	_, psErr := m.transport.ExecutePS(ctx, psSetVMProcessor, map[string]string{
 		"Name": hostName,
 		"CPU":  fmt.Sprintf("%d", cpuCount),
 	})
-	recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.host, "Set-VMProcessor", hostName, psErr)
+	recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.host, "Set-VMProcessor", cfgResourceID, before, after, psErr)
 	if psErr != nil {
-		return fmt.Errorf("hyperv: Set-VMProcessor %q: %w", vmName, psErr)
+		return fmt.Errorf("hyperv: Set-VMProcessor %q: %w", hostName, psErr)
 	}
 	return nil
 }
 
-func (m *hypervModule) execSetVMMemory(ctx context.Context, vmName, hostName string, memoryMB int64) error {
+func (m *hypervModule) execSetVMMemory(ctx context.Context, cfgResourceID, hostName string, memoryMB int64, before, after map[string]interface{}) error {
 	_, psErr := m.transport.ExecutePS(ctx, psSetVMMemory, map[string]string{
 		"Name":     hostName,
 		"MemoryMB": fmt.Sprintf("%d", memoryMB),
 	})
-	recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.host, "Set-VMMemory", hostName, psErr)
+	recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.host, "Set-VMMemory", cfgResourceID, before, after, psErr)
 	if psErr != nil {
-		return fmt.Errorf("hyperv: Set-VMMemory %q: %w", vmName, psErr)
+		return fmt.Errorf("hyperv: Set-VMMemory %q: %w", hostName, psErr)
 	}
 	return nil
 }
 
 // removeVM deletes a VM from the host.
+// before captures the non-sensitive scalar state (cpu, memory_mb, state) prior to
+// deletion for the audit record; pass nil when the state is unknown.
 // Write-through cache semantics: transport is called first; cache updated on success only.
-func (m *hypervModule) removeVM(ctx context.Context, vmName string) error {
+func (m *hypervModule) removeVM(ctx context.Context, vmName string, before map[string]interface{}) error {
 	// The host object name is the exact VM name — no namespacing.
 	hostName := vmName
+	cfgResourceID := "vm:" + vmName
 
 	_, psErr := m.transport.ExecutePS(ctx, psRemoveVM, map[string]string{"Name": hostName})
-	recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.host, "Remove-VM", hostName, psErr)
+	recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.host, "Remove-VM", cfgResourceID, before, nil, psErr)
 	if psErr != nil {
 		return fmt.Errorf("hyperv: remove VM %q: %w", vmName, psErr)
 	}

--- a/features/modules/hyperv/vm_provision.go
+++ b/features/modules/hyperv/vm_provision.go
@@ -362,6 +362,8 @@ func (m *hypervModule) provisionVM(ctx context.Context, vmName, hostName string,
 		generation = 2
 	}
 
+	cfgResourceID := "vm:" + vmName
+
 	// Gen2 secure-boot template by os_family; Gen1 has no UEFI/secure boot.
 	if generation == 2 {
 		template := secureBootTemplate(cfg.Source.OSFamily)
@@ -369,10 +371,10 @@ func (m *hypervModule) provisionVM(ctx context.Context, vmName, hostName string,
 			"Name":     hostName,
 			"Template": template,
 		}); psErr != nil {
-			recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.host, "Set-VMFirmware", hostName, psErr)
+			recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.host, "Set-VMFirmware", cfgResourceID, nil, nil, psErr)
 			return m.failProvision(ctx, vmName, record, fmt.Errorf("hyperv: set firmware for VM %q: %w", vmName, psErr))
 		}
-		recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.host, "Set-VMFirmware", hostName, nil)
+		recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.host, "Set-VMFirmware", cfgResourceID, nil, nil, nil)
 	}
 
 	// cloud-init (Linux VM-from-cloud-image): the boot disk (already prepared
@@ -385,7 +387,9 @@ func (m *hypervModule) provisionVM(ctx context.Context, vmName, hostName string,
 		if err := m.provisionCloudInit(ctx, vmName, hostName, cfg, record, generation); err != nil {
 			return err
 		}
-		if err := m.execStartVM(ctx, vmName, hostName); err != nil {
+		if err := m.execStartVM(ctx, cfgResourceID, hostName,
+			map[string]interface{}{"state": "stopped"},
+			map[string]interface{}{"state": "running"}); err != nil {
 			return m.failProvision(ctx, vmName, record, err)
 		}
 		return m.advanceProvision(ctx, vmName, record, ProvisionStateInstalling)
@@ -417,18 +421,18 @@ func (m *hypervModule) provisionVM(ctx context.Context, vmName, hostName string,
 			"StewardSrc": m.enrollStewardPath,
 			"CASrc":      m.enrollCAPath,
 		}); psErr != nil {
-			recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.host, "Cfgms-BuildAnswerIso", hostName, psErr)
+			recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.host, "Cfgms-BuildAnswerIso", cfgResourceID, nil, nil, psErr)
 			return m.failProvision(ctx, vmName, record, fmt.Errorf("hyperv: build answer ISO for VM %q: %w", vmName, psErr))
 		}
-		recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.host, "Cfgms-BuildAnswerIso", hostName, nil)
+		recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.host, "Cfgms-BuildAnswerIso", cfgResourceID, nil, nil, nil)
 		if _, psErr := m.transport.ExecutePS(ctx, psAttachDVD, map[string]string{
 			"Name":    hostName,
 			"ISOPath": isoPath,
 		}); psErr != nil {
-			recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.host, "Add-VMDvdDrive", hostName, psErr)
+			recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.host, "Add-VMDvdDrive", cfgResourceID, nil, nil, psErr)
 			return m.failProvision(ctx, vmName, record, fmt.Errorf("hyperv: attach answer ISO to VM %q: %w", vmName, psErr))
 		}
-		recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.host, "Add-VMDvdDrive", hostName, nil)
+		recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.host, "Add-VMDvdDrive", cfgResourceID, nil, nil, nil)
 	} else {
 		seedPath := seedVHDPath(vmName, cfg.VHDPath, m.seedDir)
 		if err := validateSeedPath(seedPath); err != nil {
@@ -438,15 +442,15 @@ func (m *hypervModule) provisionVM(ctx context.Context, vmName, hostName string,
 			"Path":      seedPath,
 			"SizeBytes": "268435456",
 		}); psErr != nil {
-			recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.host, "New-VHD", hostName, psErr)
+			recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.host, "New-VHD", cfgResourceID, nil, nil, psErr)
 			return m.failProvision(ctx, vmName, record, fmt.Errorf("hyperv: create seed VHDX for VM %q: %w", vmName, psErr))
 		}
-		recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.host, "New-VHD", hostName, nil)
+		recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.host, "New-VHD", cfgResourceID, nil, nil, nil)
 		if _, psErr := m.transport.ExecutePS(ctx, psMountSeedVHD, map[string]string{"Path": seedPath}); psErr != nil {
-			recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.host, "Format-Volume", hostName, psErr)
+			recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.host, "Format-Volume", cfgResourceID, nil, nil, psErr)
 			return m.failProvision(ctx, vmName, record, fmt.Errorf("hyperv: format seed VHDX for VM %q: %w", vmName, psErr))
 		}
-		recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.host, "Format-Volume", hostName, nil)
+		recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.host, "Format-Volume", cfgResourceID, nil, nil, nil)
 		if _, psErr := m.transport.ExecutePS(ctx, psCopyToSeedVHD, map[string]string{
 			"SeedPath":   seedPath,
 			"FileName":   seedAnswerFileName("linux"),
@@ -454,18 +458,18 @@ func (m *hypervModule) provisionVM(ctx context.Context, vmName, hostName string,
 			"StewardSrc": "",
 			"CASrc":      "",
 		}); psErr != nil {
-			recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.host, "Set-Content", hostName, psErr)
+			recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.host, "Set-Content", cfgResourceID, nil, nil, psErr)
 			return m.failProvision(ctx, vmName, record, fmt.Errorf("hyperv: write answer file to seed for VM %q: %w", vmName, psErr))
 		}
-		recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.host, "Set-Content", hostName, nil)
+		recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.host, "Set-Content", cfgResourceID, nil, nil, nil)
 		if _, psErr := m.transport.ExecutePS(ctx, psAttachSeedDisk, map[string]string{
 			"Name":     hostName,
 			"SeedPath": seedPath,
 		}); psErr != nil {
-			recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.host, "Add-VMHardDiskDrive", hostName, psErr)
+			recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.host, "Add-VMHardDiskDrive", cfgResourceID, nil, nil, psErr)
 			return m.failProvision(ctx, vmName, record, fmt.Errorf("hyperv: attach seed disk to VM %q: %w", vmName, psErr))
 		}
-		recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.host, "Add-VMHardDiskDrive", hostName, nil)
+		recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.host, "Add-VMHardDiskDrive", cfgResourceID, nil, nil, nil)
 	}
 
 	// Attach the install ISO as a DVD drive (host path, never repacked).
@@ -473,10 +477,10 @@ func (m *hypervModule) provisionVM(ctx context.Context, vmName, hostName string,
 		"Name":    hostName,
 		"ISOPath": cfg.Source.ISO,
 	}); psErr != nil {
-		recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.host, "Add-VMDvdDrive", hostName, psErr)
+		recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.host, "Add-VMDvdDrive", cfgResourceID, nil, nil, psErr)
 		return m.failProvision(ctx, vmName, record, fmt.Errorf("hyperv: attach install ISO to VM %q: %w", vmName, psErr))
 	}
-	recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.host, "Add-VMDvdDrive", hostName, nil)
+	recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.host, "Add-VMDvdDrive", cfgResourceID, nil, nil, nil)
 
 	// Make the install DVD the first boot device so a Gen2 VM boots the installer
 	// rather than the empty OS VHD or the (bootloader-less) answer ISO. The
@@ -486,16 +490,18 @@ func (m *hypervModule) provisionVM(ctx context.Context, vmName, hostName string,
 			"Name":    hostName,
 			"ISOPath": cfg.Source.ISO,
 		}); psErr != nil {
-			recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.host, "Set-VMFirmware", hostName, psErr)
+			recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.host, "Set-VMFirmware", cfgResourceID, nil, nil, psErr)
 			return m.failProvision(ctx, vmName, record, fmt.Errorf("hyperv: set DVD first boot for VM %q: %w", vmName, psErr))
 		}
-		recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.host, "Set-VMFirmware", hostName, nil)
+		recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.host, "Set-VMFirmware", cfgResourceID, nil, nil, nil)
 	}
 
 	// Power on and advance creating → installing. The unattended install runs
 	// inside the guest; the host-side module observes no further until the
 	// controller-side reconciler (#2050) flips ready.
-	if err := m.execStartVM(ctx, vmName, hostName); err != nil {
+	if err := m.execStartVM(ctx, cfgResourceID, hostName,
+		map[string]interface{}{"state": "stopped"},
+		map[string]interface{}{"state": "running"}); err != nil {
 		return m.failProvision(ctx, vmName, record, err)
 	}
 
@@ -505,13 +511,13 @@ func (m *hypervModule) provisionVM(ctx context.Context, vmName, hostName string,
 	// manager). Best-effort — a keypress failure does not fail the provision.
 	if cfg.Source.OSFamily == "windows" {
 		if _, psErr := m.transport.ExecutePS(ctx, psBootKeypress, map[string]string{"Name": hostName}); psErr != nil {
-			recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.host, "Cfgms-BootKeypress", hostName, psErr)
+			recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.host, "Cfgms-BootKeypress", cfgResourceID, nil, nil, psErr)
 			if logger, ok := m.GetLogger(); ok {
 				logger.Warn("hyperv: boot keypress failed (install may still proceed)",
 					"vm_name", logging.SanitizeLogValue(vmName))
 			}
 		} else {
-			recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.host, "Cfgms-BootKeypress", hostName, nil)
+			recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.host, "Cfgms-BootKeypress", cfgResourceID, nil, nil, nil)
 		}
 	}
 
@@ -538,6 +544,8 @@ func cloudInitMetaData(vmName, correlationID string) string {
 // — cloud-init auto-detects the CIDATA seed on first boot. The caller powers the
 // VM on and advances the record to installing.
 func (m *hypervModule) provisionCloudInit(ctx context.Context, vmName, hostName string, cfg *VMConfig, record *ProvisionRecord, generation int) error {
+	cfgResourceID := "vm:" + vmName
+
 	// Render the cloud-init user-data (resolves the built-in or operator
 	// cloud-init profile). CorrelationID is baked in for controller-side matching.
 	userData, renderErr := m.renderSeedAnswerFile(ctx, vmName, cfg.Source, record.CorrelationID)
@@ -559,18 +567,18 @@ func (m *hypervModule) provisionCloudInit(ctx context.Context, vmName, hostName 
 		"Path":      seedPath,
 		"SizeBytes": "268435456",
 	}); psErr != nil {
-		recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.host, "New-VHD", hostName, psErr)
+		recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.host, "New-VHD", cfgResourceID, nil, nil, psErr)
 		return m.failProvision(ctx, vmName, record, fmt.Errorf("hyperv: create CIDATA seed VHDX for VM %q: %w", vmName, psErr))
 	}
-	recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.host, "New-VHD", hostName, nil)
+	recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.host, "New-VHD", cfgResourceID, nil, nil, nil)
 	if _, psErr := m.transport.ExecutePS(ctx, psMountSeedVHD, map[string]string{
 		"Path":  seedPath,
 		"Label": cidataVolumeLabel,
 	}); psErr != nil {
-		recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.host, "Format-Volume", hostName, psErr)
+		recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.host, "Format-Volume", cfgResourceID, nil, nil, psErr)
 		return m.failProvision(ctx, vmName, record, fmt.Errorf("hyperv: format CIDATA seed VHDX for VM %q: %w", vmName, psErr))
 	}
-	recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.host, "Format-Volume", hostName, nil)
+	recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.host, "Format-Volume", cfgResourceID, nil, nil, nil)
 	if _, psErr := m.transport.ExecutePS(ctx, psCopyToSeedVHD, map[string]string{
 		"SeedPath":    seedPath,
 		"Label":       cidataVolumeLabel,
@@ -582,18 +590,18 @@ func (m *hypervModule) provisionCloudInit(ctx context.Context, vmName, hostName 
 		"StewardDest": "cfgms-steward",
 		"CASrc":       m.enrollCAPath,
 	}); psErr != nil {
-		recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.host, "Set-Content", hostName, psErr)
+		recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.host, "Set-Content", cfgResourceID, nil, nil, psErr)
 		return m.failProvision(ctx, vmName, record, fmt.Errorf("hyperv: write cloud-init seed for VM %q: %w", vmName, psErr))
 	}
-	recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.host, "Set-Content", hostName, nil)
+	recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.host, "Set-Content", cfgResourceID, nil, nil, nil)
 	if _, psErr := m.transport.ExecutePS(ctx, psAttachSeedDisk, map[string]string{
 		"Name":     hostName,
 		"SeedPath": seedPath,
 	}); psErr != nil {
-		recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.host, "Add-VMHardDiskDrive", hostName, psErr)
+		recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.host, "Add-VMHardDiskDrive", cfgResourceID, nil, nil, psErr)
 		return m.failProvision(ctx, vmName, record, fmt.Errorf("hyperv: attach CIDATA seed to VM %q: %w", vmName, psErr))
 	}
-	recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.host, "Add-VMHardDiskDrive", hostName, nil)
+	recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.host, "Add-VMHardDiskDrive", cfgResourceID, nil, nil, nil)
 
 	// Make the OS disk (the converted cloud image) the first boot device so the
 	// VM boots the cloud image rather than the attached CIDATA seed. Gen1 uses
@@ -603,10 +611,10 @@ func (m *hypervModule) provisionCloudInit(ctx context.Context, vmName, hostName 
 			"Name":    hostName,
 			"VHDPath": cfg.VHDPath,
 		}); psErr != nil {
-			recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.host, "Set-VMFirmware", hostName, psErr)
+			recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.host, "Set-VMFirmware", cfgResourceID, nil, nil, psErr)
 			return m.failProvision(ctx, vmName, record, fmt.Errorf("hyperv: set OS-disk first boot for VM %q: %w", vmName, psErr))
 		}
-		recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.host, "Set-VMFirmware", hostName, nil)
+		recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.host, "Set-VMFirmware", cfgResourceID, nil, nil, nil)
 	}
 	return nil
 }
@@ -691,10 +699,10 @@ func (m *hypervModule) finalizeProvision(ctx context.Context, vmName, hostName s
 	if _, psErr := m.transport.ExecutePS(ctx, psDetachSeedVHD, map[string]string{
 		"Path": seedPath,
 	}); psErr != nil {
-		recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.host, "Dismount-VHD", hostName, psErr)
+		recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.host, "Dismount-VHD", "vm:"+vmName, nil, nil, psErr)
 		return m.failProvision(ctx, vmName, record, fmt.Errorf("hyperv: detach seed VHDX for VM %q: %w", vmName, psErr))
 	}
-	recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.host, "Dismount-VHD", hostName, nil)
+	recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.host, "Dismount-VHD", "vm:"+vmName, nil, nil, nil)
 
 	// Advance installing → finalizing. ready is controller-side (#2050).
 	return m.advanceProvision(ctx, vmName, record, ProvisionStateFinalizing)

--- a/features/modules/hyperv/vm_test.go
+++ b/features/modules/hyperv/vm_test.go
@@ -53,7 +53,8 @@ func TestVMHostName_IsExactConfigName(t *testing.T) {
 	transport := &testWinRMTransport{}
 	m := vmModuleWithTransport(transport, tenantID)
 
-	// state:absent → Remove-VM, which passes only Name in args.
+	// state:absent → getVM (call 0) then Remove-VM (call 1).
+	// Both pass only Name in args — the exact config name, no prefix.
 	require.NoError(t, m.Set(context.Background(), "vm:"+vmName,
 		mapConfigState{"name": vmName, "state": "absent"}))
 
@@ -61,9 +62,10 @@ func TestVMHostName_IsExactConfigName(t *testing.T) {
 	calls := transport.calls
 	transport.mu.Unlock()
 
-	require.Len(t, calls, 1)
-	require.NotEmpty(t, calls[0].args)
-	assert.Equal(t, vmName, calls[0].args[0],
+	require.Len(t, calls, 2, "getVM + Remove-VM expected for absent path")
+	// calls[1] is Remove-VM — verify the exact name is passed as an arg.
+	require.NotEmpty(t, calls[1].args)
+	assert.Equal(t, vmName, calls[1].args[0],
 		"host-side VM name must be the exact config name — no cfgms- prefix or tenant namespacing")
 }
 
@@ -166,8 +168,9 @@ func TestSet_VMAbsent_CallsRemoveVM(t *testing.T) {
 	calls := transport.calls
 	transport.mu.Unlock()
 
-	require.Len(t, calls, 1, "exactly one ExecutePS call expected for Remove")
-	call := calls[0]
+	// absent path: call 0 = getVM (before-snapshot), call 1 = Remove-VM.
+	require.Len(t, calls, 2, "getVM + Remove-VM expected for absent path")
+	call := calls[1]
 
 	// script must contain Remove-VM
 	assert.Contains(t, call.scriptBlock, "Remove-VM",
@@ -244,18 +247,19 @@ func TestExactName_RegardlessOfTenant(t *testing.T) {
 	callsB := transportB.calls
 	transportB.mu.Unlock()
 
-	require.Len(t, callsA, 1)
-	require.Len(t, callsB, 1)
+	// absent path: call 0 = getVM, call 1 = Remove-VM.
+	require.Len(t, callsA, 2, "getVM + Remove-VM expected for absent path (tenant A)")
+	require.Len(t, callsB, 2, "getVM + Remove-VM expected for absent path (tenant B)")
 
-	// Both tenants must target the exact name "foo" — no prefix.
-	require.NotEmpty(t, callsA[0].args)
-	assert.Equal(t, "foo", callsA[0].args[0], "tenant A must use the exact name")
-	require.NotEmpty(t, callsB[0].args)
-	assert.Equal(t, "foo", callsB[0].args[0], "tenant B must use the exact name")
+	// Both tenants must target the exact name "foo" in the Remove-VM call — no prefix.
+	require.NotEmpty(t, callsA[1].args)
+	assert.Equal(t, "foo", callsA[1].args[0], "tenant A must use the exact name")
+	require.NotEmpty(t, callsB[1].args)
+	assert.Equal(t, "foo", callsB[1].args[0], "tenant B must use the exact name")
 
 	// Injection safety: the name still travels via args, never interpolated.
-	assert.NotContains(t, callsA[0].scriptBlock, "foo")
-	assert.NotContains(t, callsB[0].scriptBlock, "foo")
+	assert.NotContains(t, callsA[1].scriptBlock, "foo")
+	assert.NotContains(t, callsB[1].scriptBlock, "foo")
 }
 
 // ─── VMConfig ConfigState interface tests ─────────────────────────────────────

--- a/features/modules/hyperv/vswitch.go
+++ b/features/modules/hyperv/vswitch.go
@@ -196,7 +196,15 @@ func (m *hypervModule) setVSwitch(ctx context.Context, resourceID string, config
 	state, _ := configMap["state"].(string)
 
 	if state == "absent" {
-		return m.removeVSwitch(ctx, switchName)
+		// Snapshot current state for audit before-capture (best-effort).
+		var deleteBefore map[string]interface{}
+		if cur, gErr := m.getVSwitch(ctx, switchName); gErr == nil && cur != nil && cur.State != "absent" {
+			deleteBefore = map[string]interface{}{
+				"switch_type": cur.SwitchType,
+				"state":       cur.State,
+			}
+		}
+		return m.removeVSwitch(ctx, switchName, deleteBefore)
 	}
 
 	cfg := &VSwitchConfig{Name: switchName}
@@ -229,6 +237,11 @@ func (m *hypervModule) setVSwitch(ctx context.Context, resourceID string, config
 func (m *hypervModule) createVSwitch(ctx context.Context, switchName string, cfg *VSwitchConfig) error {
 	// The host object name is the exact switch name — no namespacing.
 	hostName := switchName
+	cfgResourceID := "vswitch:" + switchName
+	after := map[string]interface{}{
+		"switch_type": cfg.SwitchType,
+		"state":       "present",
+	}
 
 	var (
 		psCmd  string
@@ -253,7 +266,7 @@ func (m *hypervModule) createVSwitch(ctx context.Context, switchName string, cfg
 	}
 
 	_, psErr := m.transport.ExecutePS(ctx, psCmd, psArgs)
-	recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.host, "New-VMSwitch", hostName, psErr)
+	recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.host, "New-VMSwitch", cfgResourceID, nil, after, psErr)
 	if psErr != nil {
 		return fmt.Errorf("hyperv: create vswitch %q: %w", switchName, psErr)
 	}
@@ -268,13 +281,16 @@ func (m *hypervModule) createVSwitch(ctx context.Context, switchName string, cfg
 }
 
 // removeVSwitch deletes a virtual switch from the host.
+// before captures the non-sensitive scalar state prior to deletion; pass nil
+// when the current state is unknown.
 // Write-through cache semantics: transport is called first; cache updated on success only.
-func (m *hypervModule) removeVSwitch(ctx context.Context, switchName string) error {
+func (m *hypervModule) removeVSwitch(ctx context.Context, switchName string, before map[string]interface{}) error {
 	// The host object name is the exact switch name — no namespacing.
 	hostName := switchName
+	cfgResourceID := "vswitch:" + switchName
 
 	_, psErr := m.transport.ExecutePS(ctx, psRemoveVSwitch, map[string]string{"Name": hostName})
-	recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.host, "Remove-VMSwitch", hostName, psErr)
+	recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.host, "Remove-VMSwitch", cfgResourceID, before, nil, psErr)
 	if psErr != nil {
 		return fmt.Errorf("hyperv: remove vswitch %q: %w", switchName, psErr)
 	}

--- a/features/modules/hyperv/vswitch_test.go
+++ b/features/modules/hyperv/vswitch_test.go
@@ -41,9 +41,10 @@ func TestVSwitchHostName_IsExactConfigName(t *testing.T) {
 	calls := transport.calls
 	transport.mu.Unlock()
 
-	require.Len(t, calls, 1)
-	require.NotEmpty(t, calls[0].args)
-	assert.Equal(t, "myswitch", calls[0].args[0],
+	// absent path: call 0 = getVSwitch (before-snapshot), call 1 = Remove-VMSwitch.
+	require.Len(t, calls, 2, "getVSwitch + Remove-VMSwitch expected for absent path")
+	require.NotEmpty(t, calls[1].args)
+	assert.Equal(t, "myswitch", calls[1].args[0],
 		"host-side switch name must be the exact config name — no cfgms- prefix or tenant namespacing")
 }
 
@@ -196,8 +197,9 @@ func TestVSwitchInjectionDefense(t *testing.T) {
 	calls := transport.calls
 	transport.mu.Unlock()
 
-	require.Len(t, calls, 1, "exactly one ExecutePS call expected for Remove")
-	call := calls[0]
+	// absent path: call 0 = getVSwitch, call 1 = Remove-VMSwitch.
+	require.Len(t, calls, 2, "getVSwitch + Remove-VMSwitch expected for absent path")
+	call := calls[1]
 
 	// Exact name must appear in args, not scriptBlock.
 	require.Len(t, call.args, 1)
@@ -366,8 +368,9 @@ func TestSet_VSwitch_DeleteAbsent(t *testing.T) {
 	calls := transport.calls
 	transport.mu.Unlock()
 
-	require.Len(t, calls, 1)
-	call := calls[0]
+	// absent path: call 0 = getVSwitch (before-snapshot), call 1 = Remove-VMSwitch.
+	require.Len(t, calls, 2, "getVSwitch + Remove-VMSwitch expected for absent path")
+	call := calls[1]
 
 	assert.Contains(t, call.scriptBlock, "Remove-VMSwitch",
 		"Set with state absent must invoke Remove-VMSwitch")
@@ -446,16 +449,17 @@ func TestVSwitchExactName_RegardlessOfTenant(t *testing.T) {
 	callsB := transportB.calls
 	transportB.mu.Unlock()
 
-	require.Len(t, callsA, 1)
-	require.Len(t, callsB, 1)
+	// absent path: call 0 = getVSwitch, call 1 = Remove-VMSwitch.
+	require.Len(t, callsA, 2, "getVSwitch + Remove-VMSwitch expected for absent path (tenant A)")
+	require.Len(t, callsB, 2, "getVSwitch + Remove-VMSwitch expected for absent path (tenant B)")
 
-	require.Len(t, callsA[0].args, 1)
-	assert.Equal(t, "net", callsA[0].args[0], "tenant A must use the exact name")
+	require.Len(t, callsA[1].args, 1)
+	assert.Equal(t, "net", callsA[1].args[0], "tenant A must use the exact name")
 
-	require.Len(t, callsB[0].args, 1)
-	assert.Equal(t, "net", callsB[0].args[0], "tenant B must use the exact name")
+	require.Len(t, callsB[1].args, 1)
+	assert.Equal(t, "net", callsB[1].args[0], "tenant B must use the exact name")
 
 	// Injection safety: the name still travels via args, never interpolated.
-	assert.NotContains(t, callsA[0].scriptBlock, "net")
-	assert.NotContains(t, callsB[0].scriptBlock, "net")
+	assert.NotContains(t, callsA[1].scriptBlock, "net")
+	assert.NotContains(t, callsB[1].scriptBlock, "net")
 }


### PR DESCRIPTION
## Summary

- `recordHypervOp` signature extended with `cfgResourceID string` and `before, after map[string]interface{}`: audit `ResourceID` is now the cfg-declared id (`vm:<name>`, `vswitch:<name>`), never a bare live name
- All mutation call sites in `vm.go`, `vm_provision.go`, `vswitch.go` thread `cfgResourceID` and before/after through to `recordHypervOp`; absent (delete) paths do a best-effort `getVM`/`getVSwitch` before-snapshot
- Before/after maps carry only non-sensitive scalars (`cpu`, `memory_mb`, `state`, `switch_type`, `switch`); VHD paths and raw switch names are explicitly excluded from every record
- `changedFields` helper computes `Changes.Fields` as the sorted diff of keys that differ between before and after
- 21 new tests in `audit_test.go`: unit tests for `recordHypervOp` and `changedFields`, vm- and vswitch-level integration tests via real call sites, and two security tests asserting no live names/VHD paths appear in emitted entries
- Absent-path tests in `vm_test.go` and `vswitch_test.go` updated to expect 2 PS calls (getVM/getVSwitch + Remove) instead of 1
- `README.md`: "Audit records" section added with per-verb before/after field table

## Test plan

- [ ] `go test ./features/modules/hyperv/...` — all tests pass (including 21 new audit tests)
- [ ] `make test-agent-complete` — all gates green
- [ ] QA test runner: PASS
- [ ] QA code reviewer: blocking finding (error swallowing in `vmModuleWithAudit`) raised and fixed before commit
- [ ] Security engineer: PASS — no sensitive values in records, automated scans clean

Fixes #2169

🤖 Generated with [Claude Code](https://claude.com/claude-code)