### PR TITLE
deps: re-apply trivy v0.71.2 bump to agent Dockerfile (Issue #2164)

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -73,8 +73,8 @@ RUN go install github.com/securego/gosec/v2/cmd/gosec@v2.27.1 \
 # fetched at install time and can be tampered with). See
 # docs/runbooks/trivy-rollback.md for rollback procedure.
 RUN set -eu; \
-    TRIVY_VERSION='v0.71.0'; \
-    TRIVY_SHA256='30a3d22b23f88c233f1658f562fb477cae3b3e8b4761109d515b7698daf85814'; \
+    TRIVY_VERSION='v0.71.2'; \
+    TRIVY_SHA256='0510e71e2fd39bf863856d499c8dc19feb4e7336546394c502a8f5cc7ab27460'; \
     ARCHIVE="trivy_${TRIVY_VERSION#v}_Linux-64bit.tar.gz"; \
     curl -sSfL -o "/tmp/${ARCHIVE}" \
       "https://github.com/aquasecurity/trivy/releases/download/${TRIVY_VERSION}/${ARCHIVE}"; \


### PR DESCRIPTION
## Regression fix
#2165 bumped the agent Dockerfile's pinned trivy to **v0.71.2**, but **#2168** (serena containers) — whose branch was cut *before* #2165 merged — reverted it back to **v0.71.0** when it merged (its squash carried the older Dockerfile state). Merge-order regression.

This re-applies the bump so the agent image's trivy matches the v0.71.2 used everywhere else (workflows + `install-trivy.sh`). SHA `0510e71e…` independently verified upstream and validated locally earlier (#2165).

One-line change to `.devcontainer/Dockerfile` (`TRIVY_VERSION` + `TRIVY_SHA256`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)