### PR TITLE
deps: bump nancy v2.0.0 → v2.1.0 (Issue #2174)

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -85,7 +85,7 @@ RUN set -eu; \
 
 # Nancy (Go dependency scanner)
 RUN GOPATH=$(go env GOPATH) \
-    && curl -L "https://github.com/sonatype-nexus-community/nancy/releases/download/v2.0.0/nancy-v2.0.0-linux-amd64" \
+    && curl -L "https://github.com/sonatype-nexus-community/nancy/releases/download/v2.1.0/nancy-v2.1.0-linux-amd64" \
        -o "$GOPATH/bin/nancy" \
     && chmod +x "$GOPATH/bin/nancy"
 

--- a/.github/workflows/dependency-pin-check.yml
+++ b/.github/workflows/dependency-pin-check.yml
@@ -119,7 +119,7 @@ jobs:
         check_version "gosec"       "securego/gosec"                          "v2.27.1"
         check_version "staticcheck" "dominikh/go-tools"                       "2026.1"
         check_version "gitleaks"    "zricethezav/gitleaks"                    "v8.30.1"
-        check_version "nancy"       "sonatype-nexus-community/nancy"          "v2.0.0"
+        check_version "nancy"       "sonatype-nexus-community/nancy"          "v2.1.0"
         check_version "trufflehog"  "trufflesecurity/trufflehog"              "v3.95.5"
         check_version "trivy"       "aquasecurity/trivy"                      "v0.71.2"
         check_version "go-licenses" "google/go-licenses"                      "v2.0.1"

--- a/Makefile
+++ b/Makefile
@@ -827,7 +827,7 @@ test-data-consistency:
 
 # Automatic Nancy installation (cross-platform)
 install-nancy:
-	@echo "📦 Installing Nancy v2.0.0..."
+	@echo "📦 Installing Nancy v2.1.0..."
 	@echo "============================="
 	@if command -v nancy >/dev/null 2>&1; then \
 		echo "✅ Nancy is already installed: $$(nancy --version)"; \
@@ -845,16 +845,16 @@ install-nancy:
 	case "$$os" in \
 		linux) \
 			if [ "$$arch" = "x86_64" ]; then \
-				curl -L "https://github.com/sonatype-nexus-community/nancy/releases/download/v2.0.0/nancy-v2.0.0-linux-amd64" -o "$$gopath/bin/nancy"; \
+				curl -L "https://github.com/sonatype-nexus-community/nancy/releases/download/v2.1.0/nancy-v2.1.0-linux-amd64" -o "$$gopath/bin/nancy"; \
 			else \
 				echo "❌ Unsupported architecture: $$arch"; \
 				exit 1; \
 			fi ;; \
 		darwin) \
 			if [ "$$arch" = "x86_64" ]; then \
-				curl -L "https://github.com/sonatype-nexus-community/nancy/releases/download/v2.0.0/nancy-v2.0.0-darwin-amd64" -o "$$gopath/bin/nancy"; \
+				curl -L "https://github.com/sonatype-nexus-community/nancy/releases/download/v2.1.0/nancy-v2.1.0-darwin-amd64" -o "$$gopath/bin/nancy"; \
 			elif [ "$$arch" = "arm64" ]; then \
-				curl -L "https://github.com/sonatype-nexus-community/nancy/releases/download/v2.0.0/nancy-v2.0.0-darwin-arm64" -o "$$gopath/bin/nancy"; \
+				curl -L "https://github.com/sonatype-nexus-community/nancy/releases/download/v2.1.0/nancy-v2.1.0-darwin-arm64" -o "$$gopath/bin/nancy"; \
 			else \
 				echo "❌ Unsupported architecture: $$arch"; \
 				exit 1; \
@@ -904,25 +904,25 @@ security-deps:
 	@if ! command -v nancy >/dev/null 2>&1; then \
 		echo "❌ Error: nancy is not installed"; \
 		echo ""; \
-		echo "Install nancy (v2.0.0) for your platform:"; \
+		echo "Install nancy (v2.1.0) for your platform:"; \
 		echo ""; \
 		echo "🚀 Quick Install (recommended):"; \
 		echo "  make install-nancy"; \
 		echo ""; \
 		echo "📥 Manual Install - Linux (amd64):"; \
-		echo "  curl -L https://github.com/sonatype-nexus-community/nancy/releases/download/v2.0.0/nancy-v2.0.0-linux-amd64 -o ~/nancy"; \
+		echo "  curl -L https://github.com/sonatype-nexus-community/nancy/releases/download/v2.1.0/nancy-v2.1.0-linux-amd64 -o ~/nancy"; \
 		echo "  chmod +x ~/nancy && mv ~/nancy \$$(go env GOPATH)/bin/nancy"; \
 		echo ""; \
 		echo "🍎 Manual Install - macOS (Intel):"; \
-		echo "  curl -L https://github.com/sonatype-nexus-community/nancy/releases/download/v2.0.0/nancy-v2.0.0-darwin-amd64 -o ~/nancy"; \
+		echo "  curl -L https://github.com/sonatype-nexus-community/nancy/releases/download/v2.1.0/nancy-v2.1.0-darwin-amd64 -o ~/nancy"; \
 		echo "  chmod +x ~/nancy && mv ~/nancy \$$(go env GOPATH)/bin/nancy"; \
 		echo ""; \
 		echo "🍎 Manual Install - macOS (Apple Silicon):"; \
-		echo "  curl -L https://github.com/sonatype-nexus-community/nancy/releases/download/v2.0.0/nancy-v2.0.0-darwin-arm64 -o ~/nancy"; \
+		echo "  curl -L https://github.com/sonatype-nexus-community/nancy/releases/download/v2.1.0/nancy-v2.1.0-darwin-arm64 -o ~/nancy"; \
 		echo "  chmod +x ~/nancy && mv ~/nancy \$$(go env GOPATH)/bin/nancy"; \
 		echo ""; \
 		echo "🪟 Manual Install - Windows (PowerShell):"; \
-		echo "  Invoke-WebRequest -Uri 'https://github.com/sonatype-nexus-community/nancy/releases/download/v2.0.0/nancy-v2.0.0-windows-amd64.exe' -OutFile 'nancy.exe'"; \
+		echo "  Invoke-WebRequest -Uri 'https://github.com/sonatype-nexus-community/nancy/releases/download/v2.1.0/nancy-v2.1.0-windows-amd64.exe' -OutFile 'nancy.exe'"; \
 		echo "  Move-Item nancy.exe \$$(go env GOPATH)\\bin\\nancy.exe"; \
 		echo ""; \
 		echo "📦 Package Managers:"; \


### PR DESCRIPTION
## Summary

Routine version bump of `nancy` (Sonatype OSS Index Go dependency scanner) from v2.0.0 to v2.1.0. Cooldown elapsed (7 days since release 2026-06-17; threshold 3 days). No CVEs affect the currently-pinned v2.0.0.

- Updated 10 references across 3 files in lockstep
- Download URLs in Makefile install targets and Dockerfile updated (version appears twice per URL)
- Freshness-check pin in `dependency-pin-check.yml` updated so the weekly check stops flagging it
- Error-message instructions in `security-deps` Makefile target updated to match

Fixes #2174

## Files Changed

- `.github/workflows/dependency-pin-check.yml` — freshness-check pin (line 122)
- `.devcontainer/Dockerfile` — linux-amd64 download URL (line 88)
- `Makefile` — install-nancy target (linux/darwin/arm64) + security-deps error messages (9 occurrences)

## Test Plan

- [x] `grep -rnE "nancy-v2\.0\.0|v2\.0\.0/nancy|Nancy v2\.0\.0|\"v2\.0\.0\"" .github/workflows/dependency-pin-check.yml .devcontainer/Dockerfile Makefile` → 0 matches
- [x] `grep -rnE "v2\.1\.0" .github/workflows/dependency-pin-check.yml .devcontainer/Dockerfile Makefile | grep nancy` → 10 matches
- [x] `make test-agent-complete` passed (all unit, integration, cross-platform compilation)

## Specialist Review Results

| Reviewer | Result | Notes |
|----------|--------|-------|
| QA Test Runner | **PASS** | All quality gates passed; cross-platform builds verified |
| QA Code Reviewer | **PASS** | Purely mechanical version string substitution; no test files changed |
| Security Engineer | **PASS** | Security scans (Trivy, Nancy, gosec, staticcheck) all PASS; no blocking issues |

🤖 Generated with [Claude Code](https://claude.com/claude-code)