### PR TITLE
dna: Get-CimInstance fallback for six Windows hardware collectors when wmic absent (Issue #2147)

### DIFF
--- a/features/steward/dna/hardware_parse.go
+++ b/features/steward/dna/hardware_parse.go
@@ -150,30 +150,40 @@ func parseCIMSystemUUID(csv string, attributes map[string]string) {
 }
 
 // parseCIMMemoryModules parses Win32_PhysicalMemory selected as
-// Capacity,FormFactor,MemoryType,Speed. Mirrors parseWMIMemoryModulesOutput:
-// the attribute keys are not indexed, so the last valid module wins.
+// Capacity,FormFactor,MemoryType,Speed. Mirrors parseWMIMemoryModulesOutput
+// exactly: it counts every module, sums the parseable capacities into
+// memory_modules_total_capacity, emits memory_module_count, and stores the
+// FIRST module's details as the representative sample.
 func parseCIMMemoryModules(csv string, attributes map[string]string) {
+	var moduleCount int
+	var totalCapacity int64
 	for _, f := range cimDataRows(csv) {
 		if len(f) < 4 {
 			continue
 		}
-		// Only record a module whose Capacity is a valid integer (mirrors the
-		// wmic parser's guard).
-		if _, err := strconv.ParseInt(f[0], 10, 64); err != nil {
-			continue
+		moduleCount++
+		if capacity, err := strconv.ParseInt(f[0], 10, 64); err == nil {
+			totalCapacity += capacity
 		}
-		if f[0] != "" {
-			attributes["memory_module_capacity"] = f[0]
+		// First module's details as the representative sample.
+		if moduleCount == 1 {
+			if f[0] != "" {
+				attributes["memory_module_capacity"] = f[0]
+			}
+			if f[1] != "" {
+				attributes["memory_module_form_factor"] = f[1]
+			}
+			if f[2] != "" {
+				attributes["memory_module_type"] = f[2]
+			}
+			if f[3] != "" {
+				attributes["memory_module_speed"] = f[3] + "MHz"
+			}
 		}
-		if f[1] != "" {
-			attributes["memory_module_form_factor"] = f[1]
-		}
-		if f[2] != "" {
-			attributes["memory_module_type"] = f[2]
-		}
-		if f[3] != "" {
-			attributes["memory_module_speed"] = f[3] + "MHz"
-		}
+	}
+	if moduleCount > 0 {
+		attributes["memory_module_count"] = fmt.Sprintf("%d", moduleCount)
+		attributes["memory_modules_total_capacity"] = fmt.Sprintf("%d", totalCapacity)
 	}
 }
 

--- a/features/steward/dna/hardware_parse.go
+++ b/features/steward/dna/hardware_parse.go
@@ -1,0 +1,210 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+
+package dna
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// Parsers for `Get-CimInstance ... | ConvertTo-Csv -NoTypeInformation` output,
+// used as the fallback when `wmic` is absent (deprecated/removed on Windows
+// Server 2025 / Windows 11 24H2+; #2147). They live in this NON build-tagged
+// file (and are tested in hardware_parse_test.go) so the parse logic is covered
+// by Linux CI even though the WindowsHardwareCollector that calls them is
+// //go:build windows.
+//
+// CIM CSV differs from `wmic /format:csv`: fields are double-quoted, there is no
+// leading "Node" (hostname) column, and the column order is the Select-Object
+// order rather than alphabetical. Each parser therefore expects a specific
+// Select-Object order (documented per function) and populates exactly the same
+// attribute keys as its wmic primary parser — no new host-identifying field.
+
+// splitCSVLine splits one ConvertTo-Csv line into unquoted fields, honoring
+// double-quoted fields, embedded commas, and "" escaped quotes (RFC 4180).
+func splitCSVLine(line string) []string {
+	var fields []string
+	var cur strings.Builder
+	inQuotes := false
+	for i := 0; i < len(line); i++ {
+		c := line[i]
+		switch {
+		case c == '"':
+			if inQuotes && i+1 < len(line) && line[i+1] == '"' {
+				cur.WriteByte('"')
+				i++
+			} else {
+				inQuotes = !inQuotes
+			}
+		case c == ',' && !inQuotes:
+			fields = append(fields, cur.String())
+			cur.Reset()
+		default:
+			cur.WriteByte(c)
+		}
+	}
+	fields = append(fields, cur.String())
+	return fields
+}
+
+// cimDataRows returns the data rows of ConvertTo-Csv -NoTypeInformation output,
+// skipping the single header row and any blank lines. Each row is split into
+// unquoted fields.
+func cimDataRows(csv string) [][]string {
+	var rows [][]string
+	seenHeader := false
+	for _, raw := range strings.Split(csv, "\n") {
+		line := strings.TrimSpace(raw)
+		if line == "" {
+			continue
+		}
+		if !seenHeader {
+			seenHeader = true // first non-empty line is the header
+			continue
+		}
+		rows = append(rows, splitCSVLine(line))
+	}
+	return rows
+}
+
+// parseCIMComputerSystem parses Win32_ComputerSystem selected as
+// Manufacturer,Model,TotalPhysicalMemory. Mirrors parseWMIComputerSystemOutput.
+func parseCIMComputerSystem(csv string, attributes map[string]string) {
+	rows := cimDataRows(csv)
+	if len(rows) == 0 {
+		return
+	}
+	f := rows[0]
+	if len(f) >= 3 {
+		if f[0] != "" {
+			attributes["system_manufacturer"] = f[0]
+		}
+		if f[1] != "" {
+			attributes["system_model"] = f[1]
+		}
+		if f[2] != "" {
+			if total, err := strconv.ParseInt(f[2], 10, 64); err == nil {
+				attributes["system_total_memory"] = fmt.Sprintf("%.2f GB", float64(total)/1024/1024/1024)
+			}
+		}
+	}
+}
+
+// parseCIMBIOS parses Win32_BIOS selected as
+// Manufacturer,ReleaseDate,SMBIOSBIOSVersion. Mirrors parseWMIBIOSOutput.
+func parseCIMBIOS(csv string, attributes map[string]string) {
+	rows := cimDataRows(csv)
+	if len(rows) == 0 {
+		return
+	}
+	f := rows[0]
+	if len(f) >= 3 {
+		if f[0] != "" {
+			attributes["bios_manufacturer"] = f[0]
+		}
+		if f[1] != "" {
+			attributes["bios_release_date"] = f[1]
+		}
+		if f[2] != "" {
+			attributes["bios_version"] = f[2]
+		}
+	}
+}
+
+// parseCIMBaseboard parses Win32_BaseBoard selected as
+// Manufacturer,Product,SerialNumber,Version. Mirrors parseWMIMotherboardOutput.
+func parseCIMBaseboard(csv string, attributes map[string]string) {
+	rows := cimDataRows(csv)
+	if len(rows) == 0 {
+		return
+	}
+	f := rows[0]
+	if len(f) >= 4 {
+		if f[0] != "" {
+			attributes["motherboard_manufacturer"] = f[0]
+		}
+		if f[1] != "" {
+			attributes["motherboard_product"] = f[1]
+		}
+		if f[2] != "" {
+			attributes["motherboard_serial"] = f[2]
+		}
+		if f[3] != "" {
+			attributes["motherboard_version"] = f[3]
+		}
+	}
+}
+
+// parseCIMSystemUUID parses Win32_ComputerSystemProduct selected as UUID.
+// Mirrors parseWMIUUIDOutput.
+func parseCIMSystemUUID(csv string, attributes map[string]string) {
+	rows := cimDataRows(csv)
+	if len(rows) == 0 {
+		return
+	}
+	if f := rows[0]; len(f) >= 1 && f[0] != "" {
+		attributes["system_uuid"] = f[0]
+	}
+}
+
+// parseCIMMemoryModules parses Win32_PhysicalMemory selected as
+// Capacity,FormFactor,MemoryType,Speed. Mirrors parseWMIMemoryModulesOutput:
+// the attribute keys are not indexed, so the last valid module wins.
+func parseCIMMemoryModules(csv string, attributes map[string]string) {
+	for _, f := range cimDataRows(csv) {
+		if len(f) < 4 {
+			continue
+		}
+		// Only record a module whose Capacity is a valid integer (mirrors the
+		// wmic parser's guard).
+		if _, err := strconv.ParseInt(f[0], 10, 64); err != nil {
+			continue
+		}
+		if f[0] != "" {
+			attributes["memory_module_capacity"] = f[0]
+		}
+		if f[1] != "" {
+			attributes["memory_module_form_factor"] = f[1]
+		}
+		if f[2] != "" {
+			attributes["memory_module_type"] = f[2]
+		}
+		if f[3] != "" {
+			attributes["memory_module_speed"] = f[3] + "MHz"
+		}
+	}
+}
+
+// parseCIMPhysicalDisks parses Win32_DiskDrive selected as
+// InterfaceType,MediaType,Model,Size. Mirrors parseWMIDiskOutput, including the
+// 1-based physical_disk_<n>_* indexing and physical_disk_count.
+func parseCIMPhysicalDisks(csv string, attributes map[string]string) {
+	var diskCount int
+	for _, f := range cimDataRows(csv) {
+		if len(f) < 4 {
+			continue
+		}
+		diskCount++
+		prefix := fmt.Sprintf("physical_disk_%d", diskCount)
+		if f[0] != "" {
+			attributes[prefix+"_interface"] = f[0]
+		}
+		if f[1] != "" {
+			attributes[prefix+"_media_type"] = f[1]
+		}
+		if f[2] != "" {
+			attributes[prefix+"_model"] = f[2]
+		}
+		if f[3] != "" {
+			if size, err := strconv.ParseInt(f[3], 10, 64); err == nil {
+				attributes[prefix+"_size_bytes"] = fmt.Sprintf("%d", size)
+				attributes[prefix+"_size_gb"] = fmt.Sprintf("%.2f", float64(size)/1024/1024/1024)
+			}
+		}
+	}
+	if diskCount > 0 {
+		attributes["physical_disk_count"] = fmt.Sprintf("%d", diskCount)
+	}
+}

--- a/features/steward/dna/hardware_parse_test.go
+++ b/features/steward/dna/hardware_parse_test.go
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+
+package dna
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// These tests run on every platform (no build tag), so the CIM-fallback parse
+// logic for the wmic-less Windows path (#2147) is covered by Linux CI even
+// though WindowsHardwareCollector is //go:build windows. The sample inputs are
+// real `Get-CimInstance ... | ConvertTo-Csv -NoTypeInformation` output captured
+// on a Windows Server 2025 host.
+
+func TestSplitCSVLine(t *testing.T) {
+	cases := []struct {
+		in   string
+		want []string
+	}{
+		{`"a","b","c"`, []string{"a", "b", "c"}},
+		{`"HP","HP ProDesk 600 G5 SFF","34123063296"`, []string{"HP", "HP ProDesk 600 G5 SFF", "34123063296"}},
+		{`"with, comma","plain"`, []string{"with, comma", "plain"}}, // embedded comma inside quotes
+		{`"he said ""hi""","x"`, []string{`he said "hi"`, "x"}},     // escaped quotes
+		{`a,b,c`, []string{"a", "b", "c"}},                          // unquoted
+		{``, []string{""}},                                          // empty
+	}
+	for _, c := range cases {
+		assert.Equal(t, c.want, splitCSVLine(c.in), "splitCSVLine(%q)", c.in)
+	}
+}
+
+func TestParseCIMComputerSystem(t *testing.T) {
+	csv := "\"Manufacturer\",\"Model\",\"TotalPhysicalMemory\"\r\n\"HP\",\"HP ProDesk 600 G5 SFF\",\"34123063296\"\r\n"
+	a := map[string]string{}
+	parseCIMComputerSystem(csv, a)
+	assert.Equal(t, "HP", a["system_manufacturer"])
+	assert.Equal(t, "HP ProDesk 600 G5 SFF", a["system_model"])
+	assert.Equal(t, "31.78 GB", a["system_total_memory"])
+
+	// Header-only / empty / malformed → no attributes, no panic.
+	for _, bad := range []string{"", "\"Manufacturer\",\"Model\",\"TotalPhysicalMemory\"\r\n", "\"x\",\"y\"\r\n\"a\",\"b\"\r\n"} {
+		m := map[string]string{}
+		require.NotPanics(t, func() { parseCIMComputerSystem(bad, m) })
+		assert.Empty(t, m)
+	}
+}
+
+func TestParseCIMBIOS(t *testing.T) {
+	csv := "\"Manufacturer\",\"ReleaseDate\",\"SMBIOSBIOSVersion\"\r\n\"HP\",\"1/11/2026 7:00:00 PM\",\"R07 Ver. 02.25.00\"\r\n"
+	a := map[string]string{}
+	parseCIMBIOS(csv, a)
+	assert.Equal(t, "HP", a["bios_manufacturer"])
+	assert.Equal(t, "1/11/2026 7:00:00 PM", a["bios_release_date"])
+	assert.Equal(t, "R07 Ver. 02.25.00", a["bios_version"])
+}
+
+func TestParseCIMBaseboard(t *testing.T) {
+	csv := "\"Manufacturer\",\"Product\",\"SerialNumber\",\"Version\"\r\n\"HP\",\"8597\",\"PJEAP0DMVDH6K9\",\"KBC Version 08.09.22\"\r\n"
+	a := map[string]string{}
+	parseCIMBaseboard(csv, a)
+	assert.Equal(t, "HP", a["motherboard_manufacturer"])
+	assert.Equal(t, "8597", a["motherboard_product"])
+	assert.Equal(t, "PJEAP0DMVDH6K9", a["motherboard_serial"])
+	assert.Equal(t, "KBC Version 08.09.22", a["motherboard_version"])
+}
+
+func TestParseCIMSystemUUID(t *testing.T) {
+	csv := "\"UUID\"\r\n\"3B4602D8-1C05-7372-352B-45BF6B1453FD\"\r\n"
+	a := map[string]string{}
+	parseCIMSystemUUID(csv, a)
+	assert.Equal(t, "3B4602D8-1C05-7372-352B-45BF6B1453FD", a["system_uuid"])
+}
+
+func TestParseCIMMemoryModules(t *testing.T) {
+	// Two identical modules; last valid module wins (mirrors the wmic parser,
+	// whose keys are not indexed).
+	csv := "\"Capacity\",\"FormFactor\",\"MemoryType\",\"Speed\"\r\n\"17179869184\",\"8\",\"0\",\"2667\"\r\n\"17179869184\",\"8\",\"0\",\"2667\"\r\n"
+	a := map[string]string{}
+	parseCIMMemoryModules(csv, a)
+	assert.Equal(t, "17179869184", a["memory_module_capacity"])
+	assert.Equal(t, "8", a["memory_module_form_factor"])
+	assert.Equal(t, "0", a["memory_module_type"])
+	assert.Equal(t, "2667MHz", a["memory_module_speed"])
+
+	// A row with a non-integer Capacity is skipped (guard).
+	m := map[string]string{}
+	parseCIMMemoryModules("\"Capacity\",\"FormFactor\",\"MemoryType\",\"Speed\"\r\n\"n/a\",\"8\",\"0\",\"2667\"\r\n", m)
+	assert.Empty(t, m)
+}
+
+func TestParseCIMPhysicalDisks(t *testing.T) {
+	csv := "\"InterfaceType\",\"MediaType\",\"Model\",\"Size\"\r\n" +
+		"\"SCSI\",\"Fixed hard disk media\",\"Microsoft Storage Space Device\",\"322101964800\"\r\n" +
+		"\"SCSI\",\"Fixed hard disk media\",\"SAMSUNG MZVLB1T0HBLR-000L7\",\"1024203640320\"\r\n"
+	a := map[string]string{}
+	parseCIMPhysicalDisks(csv, a)
+	assert.Equal(t, "2", a["physical_disk_count"])
+	assert.Equal(t, "SCSI", a["physical_disk_1_interface"])
+	assert.Equal(t, "Fixed hard disk media", a["physical_disk_1_media_type"])
+	assert.Equal(t, "Microsoft Storage Space Device", a["physical_disk_1_model"])
+	assert.Equal(t, "322101964800", a["physical_disk_1_size_bytes"])
+	assert.NotEmpty(t, a["physical_disk_1_size_gb"])
+	assert.Equal(t, "SAMSUNG MZVLB1T0HBLR-000L7", a["physical_disk_2_model"])
+	assert.Equal(t, "1024203640320", a["physical_disk_2_size_bytes"])
+}

--- a/features/steward/dna/hardware_parse_test.go
+++ b/features/steward/dna/hardware_parse_test.go
@@ -76,20 +76,35 @@ func TestParseCIMSystemUUID(t *testing.T) {
 }
 
 func TestParseCIMMemoryModules(t *testing.T) {
-	// Two identical modules; last valid module wins (mirrors the wmic parser,
-	// whose keys are not indexed).
-	csv := "\"Capacity\",\"FormFactor\",\"MemoryType\",\"Speed\"\r\n\"17179869184\",\"8\",\"0\",\"2667\"\r\n\"17179869184\",\"8\",\"0\",\"2667\"\r\n"
+	// Two DIFFERENT modules: the FIRST module is the representative sample,
+	// count is all modules, and total_capacity is the sum (mirrors the wmic
+	// parser exactly).
+	csv := "\"Capacity\",\"FormFactor\",\"MemoryType\",\"Speed\"\r\n" +
+		"\"17179869184\",\"8\",\"0\",\"2667\"\r\n" +
+		"\"8589934592\",\"8\",\"0\",\"3200\"\r\n"
 	a := map[string]string{}
 	parseCIMMemoryModules(csv, a)
-	assert.Equal(t, "17179869184", a["memory_module_capacity"])
+	assert.Equal(t, "17179869184", a["memory_module_capacity"], "first module wins")
 	assert.Equal(t, "8", a["memory_module_form_factor"])
 	assert.Equal(t, "0", a["memory_module_type"])
-	assert.Equal(t, "2667MHz", a["memory_module_speed"])
+	assert.Equal(t, "2667MHz", a["memory_module_speed"], "first module's speed")
+	assert.Equal(t, "2", a["memory_module_count"])
+	assert.Equal(t, "25769803776", a["memory_modules_total_capacity"], "17179869184 + 8589934592")
 
-	// A row with a non-integer Capacity is skipped (guard).
+	// A row whose Capacity is non-integer is still counted (mirrors wmic: the
+	// raw value is stored, but it does not contribute to total_capacity).
 	m := map[string]string{}
 	parseCIMMemoryModules("\"Capacity\",\"FormFactor\",\"MemoryType\",\"Speed\"\r\n\"n/a\",\"8\",\"0\",\"2667\"\r\n", m)
-	assert.Empty(t, m)
+	assert.Equal(t, "n/a", m["memory_module_capacity"])
+	assert.Equal(t, "1", m["memory_module_count"])
+	assert.Equal(t, "0", m["memory_modules_total_capacity"])
+
+	// Empty / header-only → no attributes, no panic.
+	for _, bad := range []string{"", "\"Capacity\",\"FormFactor\",\"MemoryType\",\"Speed\"\r\n"} {
+		e := map[string]string{}
+		require.NotPanics(t, func() { parseCIMMemoryModules(bad, e) })
+		assert.Empty(t, e)
+	}
 }
 
 func TestParseCIMPhysicalDisks(t *testing.T) {
@@ -104,6 +119,16 @@ func TestParseCIMPhysicalDisks(t *testing.T) {
 	assert.Equal(t, "Microsoft Storage Space Device", a["physical_disk_1_model"])
 	assert.Equal(t, "322101964800", a["physical_disk_1_size_bytes"])
 	assert.NotEmpty(t, a["physical_disk_1_size_gb"])
+	assert.Equal(t, "SCSI", a["physical_disk_2_interface"])
+	assert.Equal(t, "Fixed hard disk media", a["physical_disk_2_media_type"])
 	assert.Equal(t, "SAMSUNG MZVLB1T0HBLR-000L7", a["physical_disk_2_model"])
 	assert.Equal(t, "1024203640320", a["physical_disk_2_size_bytes"])
+	assert.NotEmpty(t, a["physical_disk_2_size_gb"])
+
+	// Empty / header-only → no disks, no panic.
+	for _, bad := range []string{"", "\"InterfaceType\",\"MediaType\",\"Model\",\"Size\"\r\n"} {
+		e := map[string]string{}
+		require.NotPanics(t, func() { parseCIMPhysicalDisks(bad, e) })
+		assert.Empty(t, e)
+	}
 }

--- a/features/steward/dna/hardware_windows.go
+++ b/features/steward/dna/hardware_windows.go
@@ -83,6 +83,13 @@ func (w *WindowsHardwareCollector) CollectMemory(ctx context.Context, attributes
 		"Capacity,Speed,MemoryType,FormFactor", "/format:csv")
 	if err == nil {
 		w.parseWMIMemoryModulesOutput(modOutput, attributes)
+	} else {
+		// Fallback: Get-CimInstance (wmic absent on Windows Server 2025 / 11 24H2+)
+		psOut, psErr := runCommand(ctx, "powershell", "-NoProfile", "-NonInteractive", "-Command",
+			"Get-CimInstance -ClassName Win32_PhysicalMemory | Select-Object Capacity,FormFactor,MemoryType,Speed | ConvertTo-Csv -NoTypeInformation")
+		if psErr == nil {
+			parseCIMMemoryModules(psOut, attributes)
+		}
 	}
 
 	// Virtual memory — primary: PowerShell (no wmic equivalent)
@@ -102,6 +109,13 @@ func (w *WindowsHardwareCollector) CollectDisk(ctx context.Context, attributes m
 		"Model,Size,MediaType,InterfaceType", "/format:csv")
 	if err == nil {
 		w.parseWMIDiskOutput(diskOutput, attributes)
+	} else {
+		// Fallback: Get-CimInstance (wmic absent on Windows Server 2025 / 11 24H2+)
+		psOut, psErr := runCommand(ctx, "powershell", "-NoProfile", "-NonInteractive", "-Command",
+			"Get-CimInstance -ClassName Win32_DiskDrive | Select-Object InterfaceType,MediaType,Model,Size | ConvertTo-Csv -NoTypeInformation")
+		if psErr == nil {
+			parseCIMPhysicalDisks(psOut, attributes)
+		}
 	}
 
 	// Logical disk — primary: wmic
@@ -128,6 +142,13 @@ func (w *WindowsHardwareCollector) CollectMotherboard(ctx context.Context, attri
 		"Manufacturer,Model,TotalPhysicalMemory", "/format:csv")
 	if err == nil {
 		w.parseWMIComputerSystemOutput(csOutput, attributes)
+	} else {
+		// Fallback: Get-CimInstance (wmic absent on Windows Server 2025 / 11 24H2+)
+		psOut, psErr := runCommand(ctx, "powershell", "-NoProfile", "-NonInteractive", "-Command",
+			"Get-CimInstance -ClassName Win32_ComputerSystem | Select-Object Manufacturer,Model,TotalPhysicalMemory | ConvertTo-Csv -NoTypeInformation")
+		if psErr == nil {
+			parseCIMComputerSystem(psOut, attributes)
+		}
 	}
 
 	// BIOS info — primary: wmic
@@ -135,6 +156,13 @@ func (w *WindowsHardwareCollector) CollectMotherboard(ctx context.Context, attri
 		"Manufacturer,SMBIOSBIOSVersion,ReleaseDate", "/format:csv")
 	if err == nil {
 		w.parseWMIBIOSOutput(biosOutput, attributes)
+	} else {
+		// Fallback: Get-CimInstance (wmic absent on Windows Server 2025 / 11 24H2+)
+		psOut, psErr := runCommand(ctx, "powershell", "-NoProfile", "-NonInteractive", "-Command",
+			"Get-CimInstance -ClassName Win32_BIOS | Select-Object Manufacturer,ReleaseDate,SMBIOSBIOSVersion | ConvertTo-Csv -NoTypeInformation")
+		if psErr == nil {
+			parseCIMBIOS(psOut, attributes)
+		}
 	}
 
 	// Baseboard info — primary: wmic
@@ -142,6 +170,13 @@ func (w *WindowsHardwareCollector) CollectMotherboard(ctx context.Context, attri
 		"Manufacturer,Product,Version,SerialNumber", "/format:csv")
 	if err == nil {
 		w.parseWMIMotherboardOutput(bbOutput, attributes)
+	} else {
+		// Fallback: Get-CimInstance (wmic absent on Windows Server 2025 / 11 24H2+)
+		psOut, psErr := runCommand(ctx, "powershell", "-NoProfile", "-NonInteractive", "-Command",
+			"Get-CimInstance -ClassName Win32_BaseBoard | Select-Object Manufacturer,Product,SerialNumber,Version | ConvertTo-Csv -NoTypeInformation")
+		if psErr == nil {
+			parseCIMBaseboard(psOut, attributes)
+		}
 	}
 
 	// System UUID — primary: wmic
@@ -149,6 +184,13 @@ func (w *WindowsHardwareCollector) CollectMotherboard(ctx context.Context, attri
 		"UUID", "/format:csv")
 	if err == nil {
 		w.parseWMIUUIDOutput(uuidOutput, attributes)
+	} else {
+		// Fallback: Get-CimInstance (wmic absent on Windows Server 2025 / 11 24H2+)
+		psOut, psErr := runCommand(ctx, "powershell", "-NoProfile", "-NonInteractive", "-Command",
+			"Get-CimInstance -ClassName Win32_ComputerSystemProduct | Select-Object UUID | ConvertTo-Csv -NoTypeInformation")
+		if psErr == nil {
+			parseCIMSystemUUID(psOut, attributes)
+		}
 	}
 
 	// OS version for hardware context — native registry reads (no process spawn)


### PR DESCRIPTION
## Summary

`wmic` is removed on Windows Server 2025 / Windows 11 24H2+. Six `hardware_windows.go` collectors called `wmic` inside `if err == nil { parse }` with **no `else`**, so on a wmic-less host they contributed zero attributes — dropping the first-`Collect()` fast-path DNA snapshot below the `>50` `TestDNACollectionPerformance` threshold (41 on this host). This adds a `Get-CimInstance` fallback to each, mirroring the existing CPU/logical-disk fallbacks.

This is the wmic→native-CIM migration foundation flagged for the coming process/service monitoring (in-process managed APIs over `wmic`/shelling out).

## Changes

- **`hardware_windows.go`** — `Get-CimInstance` `else`-fallback for the six collectors: `memorychip`, `diskdrive`, `computersystem`, `bios`, `baseboard`, `csproduct`/UUID. Each uses the security-approved invocation form `runCommand(ctx,"powershell","-NoProfile","-NonInteractive","-Command","<compile-time-constant one-liner>")` — argv form, **zero interpolation**, no `-EncodedCommand`/`-ExecutionPolicy`/`-File`/`iex`. Each populates exactly the same attribute set as its `wmic` primary (no new host-identifying field; VM-name exclusion untouched).
- **`hardware_parse.go`** (new, **no build tag**) — six package-level CIM parse free functions + a quoted-CSV splitter (`splitCSVLine`/`cimDataRows`), so the parse logic is covered by Linux CI even though `WindowsHardwareCollector` is `//go:build windows`.
- **`hardware_parse_test.go`** (new, **no build tag**) — table tests fed **real** `Get-CimInstance | ConvertTo-Csv` output captured on Windows Server 2025.

## Validation

- **AC4 (Windows-only, validated on the e2e host):** `TestDNACollectionPerformance` now collects **70** fast-path attributes (was 41) and **passes**.
- **Linux:** the six parser table tests run on CI (non-build-tagged); full `features/steward/dna` package green; no regression to existing Windows collector tests.

## Adversarial review (story-complete team)

- **Acceptance check**: PASS — six fallbacks wired; CIM parsers are non-build-tagged free functions; invocation form compile-time-constant with no interpolation; no new dep; 70 attributes on Windows.
- **QA test-quality**: PASS — full package green (70 attrs); parser tests pass; build/vet/gofmt clean; Linux cross-compile OK.
- **QA code review**: PASS — after a fix round. One **genuine** blocking issue found and fixed: `parseCIMMemoryModules` initially omitted `memory_module_count`/`memory_modules_total_capacity` and used last-wins; now mirrors the wmic parser exactly (first-module-wins, count + total). Two "BIOS/baseboard field-swap" findings were confirmed **false positives** — `wmic /format:csv` emits columns alphabetically (with a leading `Node`), so the wmic and CIM parsers agree on every property→key mapping (this is why the CPU path already has separate wmic/CIM parsers).
- **Security review**: PASS — explicitly confirmed **no `-Command` string interpolates host/CIM/runtime data** (no injection sink; all six are constant literals); approved invocation-form ruling met verbatim; all calls inherit `runCommand`'s 30s timeout; no VM names / new PII; `make check-architecture` clean; no new dependency.

## Host / CI caveats

Validated on the Windows e2e host. `golangci-lint`/gitleaks/gosec/Trivy aren't installed there (CI enforces lint + `security-deployment-gate`).

Fixes #2147

Co-Authored-By: Claude <noreply@anthropic.com>