### PR TITLE
po: /po work is drain-then-stop with fresh per-story preflight (not a timer loop)

### DIFF
--- a/.claude/agents/po.md
+++ b/.claude/agents/po.md
@@ -749,45 +749,69 @@ no docker container, because a Linux container can't provide a Windows execution
 environment. Stories are worked **one at a time, in-process**.
 
 **Why no distributed lock is needed.** The orchestrator (Linux, docker dispatch)
-and this host serve **disjoint execution-environment slices**, so the two cron
-loops never select the same story even when out of phase. The only required
-guard is claiming each story (`Ready → In Progress`) **before** working it —
-`po-act.sh claim` does this with the same status check the docker path uses.
+and this host serve **disjoint execution-environment slices**, so the
+orchestrator's cron and this host's `/po work` drain never select the same story
+even when interleaved. The only required guard is claiming each story
+(`Ready → In Progress`) **before** working it — `po-act.sh claim` does this with
+the same status check the docker path uses.
 
-### Loop
+### Drain loop (availability-gated — drain-then-stop, NOT a timer)
 
-1. **Preflight** with this host's caps already set in the environment.
-   `CFGMS_PO_HOST_CAPS` must be **exported in the shell before** this call — the
-   preflight reads it to compute which stories are dispatchable here:
+`/po work` is **availability-gated, not time-gated**: it works every story this
+host can currently claim, back-to-back, **in one invocation**, then **stops**.
+
+**Do NOT wrap `/po work` in a fixed-interval `/loop` / cron.** There is nothing
+to do "every N minutes" — work is gated on a story *becoming claimable* (a
+blocking dependency PR merging, a new tagged story going `Ready`), which are
+**events, not a clock**. A timer just burns idle invocations when nothing is
+claimable and doesn't accelerate a backlog. Re-invoke `/po work` **on demand**
+(or when you know a blocker has cleared); within the invocation it drains
+everything already claimable.
+
+Each iteration:
+
+1. **Preflight FRESH** — re-run this at the start of *every* iteration (after each
+   completed story) and read the LIVE result. **Never reuse a prior preflight's
+   output or your own remembered pipeline view.** The Linux orchestrator runs on
+   **another host** and drains the pipeline **concurrently** (merging deps,
+   promoting stories to `Ready`, clearing holds), so a story that was held when
+   you started the last story may be claimable now — and vice-versa. Beware even
+   the preflight's own on-disk cache: a stale cache can hide a now-`Ready` story,
+   so re-running `preflight` (which re-queries GitHub/project state) is required,
+   not optional. `CFGMS_PO_HOST_CAPS` must be exported in the shell first:
    ```bash
    export CFGMS_PO_HOST_CAPS=windows   # set once per shell/session on this host
    ./.claude/scripts/po-act.sh preflight
    ```
-   Read `windows_queue` (or, generally, `dispatch_recommendations` entries with
-   `action: "dispatch"` — under this host's caps, its environment's stories
-   become dispatchable while `linux` stories are held). Also honor the
-   `dispatch_blocked` code-health gate exactly as §4.0 (don't start work on a
-   broken `develop`).
+   Read `dispatch_recommendations` entries with `action: "dispatch"` (under this
+   host's caps its environment's stories are dispatchable; other-environment
+   stories are `hold`). Honor the `dispatch_blocked` code-health gate exactly as
+   §4.0 (don't start work on a broken `develop`).
 
-2. **Pick the first eligible story** (ascending order — same ordering the
-   preflight uses).
+2. **If nothing is `action: "dispatch"` → STOP.** No claimable story for this
+   host's caps means the drain is done — exit the invocation. **Do not idle,
+   poll, or schedule a tick.** A tagged story that merely *exists but is held* on
+   a dependency or file-conflict owned by the orchestrator (e.g. a `needs-windows`
+   story blocked behind a non-windows PR) is **not claimable** and **not yours to
+   wait on** — it becomes claimable on a future `/po work` once its blocker
+   clears. Report what (if anything) you shipped and what remains held, then end.
 
-3. **Claim it** before doing any work:
+3. **Otherwise pick the first eligible story** (ascending order) and **claim it**:
    ```bash
    ./.claude/scripts/po-act.sh claim <ITEM_ID>
    ```
    - `CLAIMED:<item>` → proceed.
-   - `CLAIM_LOST:<item>` → another host/cycle took it (or it left Ready); skip to
-     the next story. Never work an unclaimed story.
+   - `CLAIM_LOST:<item>` → another host/cycle took it (or it left `Ready`); go
+     back to step 1 (fresh preflight). Never work an unclaimed story.
 
-4. **Work it locally in this session** — run the standard dev workflow against the
+4. **Work it to completion, in-process** — the standard dev workflow against the
    claimed story: `/story-start <NUM>` → implement (TDD, real components, no
-   mocks) → validation gates (`make test-complete`) → `/story-complete` (opens a
-   PR targeting `develop`). This runs natively on the host, so Windows-only
-   build/test paths are exercised for real.
+   mocks) → validation gates (`make test-complete`) → `/story-complete`
+   (adversarial review → PR targeting `develop`). **One invocation carries the
+   story start-to-finish; there are no timer ticks mid-story.** This runs natively
+   on the host, so the environment's build/test paths are exercised for real.
 
-5. **Next.** Repeat 2–4 until no eligible stories remain for this host's caps,
-   then idle. Re-invoked each tick via `/loop /po work`.
+5. **Loop back to step 1** (fresh preflight). Keep draining until step 2 stops you.
 
 **Scope.** This host only **produces** PRs for its environment's stories. Review,
 fix-cycle, merge-queue, and decomposition stay with the Linux orchestrator

--- a/.claude/commands/po.md
+++ b/.claude/commands/po.md
@@ -27,7 +27,7 @@ If `$ARGUMENTS` starts with any of `cron`, `cycle`, `work`, `decompose`, or `pla
 |------|--------|
 | `cron` | Pipeline Cycle (§4) — **skip Step 7 (Planning Team)**. Autonomous; cheap; runs every interval. Dispatches via docker containers (orchestrator role). |
 | `cycle` | Pipeline Cycle (§4) — **including Step 7**. Manual; full cycle on demand. |
-| `work` | Self-Dispatch Mode (§7) — **no docker**. The local session claims and works this host's tagged stories one at a time, in-process. For a host (e.g. Windows) whose `CFGMS_PO_HOST_CAPS` names a non-default execution environment. Pace via `/loop /po work`. |
+| `work` | Self-Dispatch Mode (§7) — **no docker**. The local session claims and works this host's tagged stories one at a time, in-process, for a host (e.g. Windows) whose `CFGMS_PO_HOST_CAPS` names a non-default execution environment. **Drain-then-stop, not a timer:** works every currently-claimable story back-to-back in ONE invocation — re-running a FRESH preflight after each completed story (the orchestrator on another host drains the pipeline concurrently) — then stops when nothing is claimable. Do NOT wrap in `/loop`/cron; re-invoke on demand or when a blocker clears. |
 | `decompose [<epic#>]` | Run §4.1 Step 7 (Planning Team) only — for the named epic, or every `epic` with no sub-issues if no number is given. |
 | `plan [<epic#>]` | Alias for `decompose`. |
 


### PR DESCRIPTION
## Why

`/po work` (Self-Dispatch §7) is **availability-gated, not time-gated**. Running it under a fixed-interval `/loop`/cron is the wrong pattern: it burns idle invocations when nothing is claimable and doesn't accelerate a backlog. What it actually waits for — a blocking dependency PR merging, or a new tagged story going `Ready` — are **events, not a clock**.

A real failure mode this fixes: deciding "nothing's claimable" from a remembered/cached pipeline view. The Linux orchestrator runs on **another host** and drains the pipeline **concurrently**, so holds clear underneath you between stories; you must re-query live. (A stale preflight cache once hid a now-`Ready` story from the dispatch list until it was re-run.)

## What

Encodes the correct behavior **directly in the definition** so any host picks it up with no external context:

- **Drain-then-stop**: work every currently-claimable story back-to-back in **one** invocation, then **stop**. Do **not** wrap in `/loop`/cron; re-invoke on demand (or when a blocker clears).
- **Fresh preflight every iteration**: re-run `po-act.sh preflight` at the start of each iteration (after each completed story) and read the LIVE result — never a prior preflight's output, the preflight's on-disk cache, or a remembered view.
- **One invocation carries a story start-to-finish** — no timer ticks mid-story.
- **Stop when nothing is `action:"dispatch"`**; a tagged story merely *held* on an orchestrator-owned dependency/file-conflict is not claimable and not yours to wait on.

## Files

- `.claude/agents/po.md` — §7 rewritten as the "Drain loop (availability-gated — drain-then-stop, NOT a timer)".
- `.claude/commands/po.md` — `work` routing row updated to match (drops "Pace via `/loop /po work`").

Docs/process change to the PO agent definitions only — no code, no tests.

Co-Authored-By: Claude <noreply@anthropic.com>