### PR TITLE
devcontainer: disable 600s background-task wait ceiling in dev-agent entrypoint

### DIFF
--- a/.devcontainer/entrypoint.sh
+++ b/.devcontainer/entrypoint.sh
@@ -631,6 +631,12 @@ AGENT_MODEL="claude-sonnet-4-6"
 
 echo "Starting Claude agent (mode=${MODE}, model=${AGENT_MODEL})..."
 EXIT_CODE=0
+# Wait indefinitely for background tasks (the story-complete / fix-pr review team
+# runs qa-test-runner etc. as background Task tool invocations). The CLI default
+# ceiling is 600s, which terminated agents mid-validation on slow-validation
+# stories (security + fleet-e2e suites) BEFORE PR creation/commit, silently
+# dropping completed work (#2173, #2176, #2177 — dev and fix-pr agents alike).
+export CLAUDE_CODE_PRINT_BG_WAIT_CEILING_MS=0
 # Read prompt from file to avoid shell metacharacter corruption.
 # Issue/PR bodies contain backticks and $ in code blocks which break heredoc expansion.
 PROMPT_CONTENT=$(cat "$PROMPT_FILE")


### PR DESCRIPTION
## Problem

The Claude CLI's default 600s background-task wait ceiling was terminating dev-agent and fix-pr containers **mid-validation** — while the `story-complete` / `fix-pr` review team (qa-test-runner, etc.) was still running as background Task invocations — and killing them **before commit/PR creation**. Completed work was silently dropped.

Observed signature in container logs:
```
Background tasks still running after 600s; terminating.
Waiting for QA test runner result.
ERROR: fix-pr agent ran but made no commits (HEAD unchanged)
Agent failed with exit code 1
```

Confirmed on three stories whose validation exceeds 600s — #2173 and #2176 (security suites, dev mode) and #2177 (fleet-e2e, fix-pr mode). Trivial-validation stories (dependency bumps) finished under 600s and PR'd fine, which is the diagnostic asymmetry.

## Fix

`export CLAUDE_CODE_PRINT_BG_WAIT_CEILING_MS=0` immediately before the agent invocation in `.devcontainer/entrypoint.sh`, so the container waits indefinitely for the review-team background tasks.

## Validation

- `bash -n .devcontainer/entrypoint.sh` — syntax OK
- Shell-only change; CI Build Gate exercises the entrypoint via Docker integration.

Unblocks #2173, #2176, #2177 (will be unblocked + re-dispatched once this lands).

🤖 Generated with [Claude Code](https://claude.com/claude-code)