### PR TITLE
security: resolve 9 CodeQL FP alerts via extension-pack sanitizer modeling (Issue #2176)

### DIFF
--- a/.github/codeql/extensions/models/log-injection-sanitizers.model.yml
+++ b/.github/codeql/extensions/models/log-injection-sanitizers.model.yml
@@ -31,3 +31,18 @@ extensions:
       - ["github.com/cfgis/cfgms/pkg/logging", "", false, "SanitizeLogValue", "", "", "ReturnValue", "clear-text-logging", "manual"]
       - ["github.com/cfgis/cfgms/pkg/logging", "", false, "RedactedID", "", "", "ReturnValue", "log-injection", "manual"]
       - ["github.com/cfgis/cfgms/pkg/logging", "", false, "RedactedID", "", "", "ReturnValue", "clear-text-logging", "manual"]
+
+  # Belt-and-suspenders: summaryModel(kind=value) declares that SanitizeLogValue and
+  # RedactedID produce clean output — taint from Argument[0] does NOT propagate to
+  # ReturnValue. This complements the barrierModel entries above: flows that the
+  # barrierModel does not suppress (e.g., json.Decode field-selection sources on some
+  # CodeQL versions) are caught here. Both models must be present; neither alone is
+  # reliable across all taint-flow paths (per testing in pack 0.0.5 / 0.0.6 history).
+  # Alerts #669, #713, #714, #715, #722 — belt-and-suspenders for SanitizeLogValue
+  # log-injection FPs that originate from JSON-decoded request fields.
+  - addsTo:
+      pack: codeql/go-all
+      extensible: summaryModel
+    data:
+      - ["github.com/cfgis/cfgms/pkg/logging", "", false, "SanitizeLogValue", "", "", "Argument[0]", "ReturnValue", "value", "manual"]
+      - ["github.com/cfgis/cfgms/pkg/logging", "", false, "RedactedID", "", "", "Argument[0]", "ReturnValue", "value", "manual"]

--- a/.github/codeql/extensions/models/path-injection-sanitizers.model.yml
+++ b/.github/codeql/extensions/models/path-injection-sanitizers.model.yml
@@ -39,6 +39,14 @@ extensions:
     data:
       - ["github.com/cfgis/cfgms/pkg/storage/providers/flatfile", "", false, "safeJoin", "", "", "Argument[0]", "ReturnValue[0]", "value", "manual"]
       - ["github.com/cfgis/cfgms/pkg/storage/providers/flatfile", "", false, "safeJoin", "", "", "Argument[1]", "ReturnValue[0]", "value", "manual"]
+      # security.ValidateAndCleanPath validates userPath against basePath and returns
+      # the cleaned canonical path. The return value (ReturnValue[0]) carries no taint
+      # from either argument — the function either returns a safe path or an error.
+      # Modeling both arguments as value-flow (not taint-flow) to ReturnValue[0] ensures
+      # that CodeQL does not propagate path-injection taint through the return value.
+      # Used in pkg/configrouting/providers/git/git_store.go to clear alerts #745/#746.
+      - ["github.com/cfgis/cfgms/pkg/security", "", false, "ValidateAndCleanPath", "", "", "Argument[0]", "ReturnValue[0]", "value", "manual"]
+      - ["github.com/cfgis/cfgms/pkg/security", "", false, "ValidateAndCleanPath", "", "", "Argument[1]", "ReturnValue[0]", "value", "manual"]
 
   # Durable upgrade: barrierModel (CodeQL >=2.25.2) marks safeJoin's cleaned
   # return value as a path-injection barrier directly, rather than relying on
@@ -56,3 +64,7 @@ extensions:
       extensible: barrierModel
     data:
       - ["github.com/cfgis/cfgms/pkg/storage/providers/flatfile", "", false, "safeJoin", "", "", "ReturnValue[0]", "path-injection", "manual"]
+      # ValidateAndCleanPath: belt-and-suspenders barrierModel alongside the summaryModel
+      # above. Marks the validated return value as a path-injection barrier so that taint
+      # cannot flow out through it even if the summaryModel is bypassed on some flow paths.
+      - ["github.com/cfgis/cfgms/pkg/security", "", false, "ValidateAndCleanPath", "", "", "ReturnValue[0]", "path-injection", "manual"]

--- a/.github/codeql/extensions/qlpack.yml
+++ b/.github/codeql/extensions/qlpack.yml
@@ -1,5 +1,5 @@
 name: cfg-is/cfgms-go-extensions
-version: 0.0.6
+version: 0.0.7
 library: true
 
 # Apply our model extensions on top of the standard Go query pack so that

--- a/docs/development/security-workflow-guide.md
+++ b/docs/development/security-workflow-guide.md
@@ -62,13 +62,24 @@ CodeQL cannot see our runtime validators, so it raises false positives where a v
 - **Pack source**: `.github/codeql/extensions/` — `qlpack.yml` (`cfg-is/cfgms-go-extensions`) plus `models/*.model.yml`.
 - **Publish requirement**: the pack is referenced *by name* from `.github/codeql/codeql-config.yml` (`packs:`) and **must be published to the ghcr.io CodeQL pack registry** by `.github/workflows/codeql-pack-publish.yml`. **Local-path pack references are not supported by the codeql-action** — a model file on disk does nothing until the pack is republished.
 - **Bump the version (REQUIRED for every model change)**: editing a `models/*.yml` does nothing on its own. `codeql pack publish` refuses to overwrite an existing `<name>@<version>` and no-ops (`"already exists"`); the publish workflow treats that as a green no-op. You **must bump `version:` in `.github/codeql/extensions/qlpack.yml`** in the same change, or the registry keeps serving the old pack and your model stays inert (it will still *bundle* fine, masking the problem).
-- **Already modeled**: `safeJoin` (path-injection), `SanitizeLogValue` + `RedactedID` (log-injection / clear-text-logging).
+- **Already modeled**: `safeJoin` (path-injection), `ValidateAndCleanPath` (path-injection), `SanitizeLogValue` + `RedactedID` (log-injection / clear-text-logging).
 
 Decision path for a CodeQL alert:
 
 1. **Genuine bug** → fix the code (e.g. wrap operator-supplied values in `logging.SanitizeLogValue`).
-2. **False positive with a real, value-returning sanitizer** (e.g. `safeJoin`) → add/extend a model. Prefer **`barrierModel`** (kind = the sink kind, e.g. `path-injection`; CodeQL ≥ 2.25.2) over the older **`summaryModel(kind=value)`**, which is unreliable on some flow paths. Verify the exact `barrierModel` tuple format against `github/codeql:go/ql/lib/ext/` — the format is finicky and CI is the only reliable verification (CodeQL can't be modeled-and-tested purely locally).
+2. **False positive with a real, value-returning sanitizer** (e.g. `safeJoin`, `ValidateAndCleanPath`) → add/extend a model. Use **both** `barrierModel` (kind = the sink kind, e.g. `path-injection`; CodeQL ≥ 2.25.2) **and** `summaryModel(kind=value)` together — neither is reliable alone across all taint-flow paths (json.Decode field-selection flows bypass barrierModel in some CodeQL versions; summaryModel can miss other paths). Also prefer refactoring the call site to *use the sanitizer's return value* (e.g. `cleanedBase := ValidateAndCleanPath(...)`) rather than discarding it — a code-level taint barrier is more robust than any model. Verify the exact `barrierModel` tuple format against `github/codeql:go/ql/lib/ext/` — the format is finicky and CI is the only reliable verification (CodeQL can't be modeled-and-tested purely locally).
 3. **False positive from a guard-style validator** (returns only `error`, e.g. blobstore `validateKey`/`validateKeyComponent`) or a **heuristic source** (CodeQL flagging a variable *named* `*SecretKey` that holds a SecretStore key *reference*, not a value) → data extensions can't cleanly model these; **dismiss the alert with justification** (or refactor to a value-returning sanitizer that *can* be modeled).
+4. **False positive from struct field-insensitivity** (CodeQL traces taint through a whole struct because one field is a secret — e.g. `APIKey.Key` — even though only non-secret fields are logged) → these **cannot** be fixed by extension-pack models (no field-access barrier primitive exists). Dismiss with justification; confirm via grep that no secret/credential field value is passed to the logger at the flagged site.
+
+#### Model inventory and dismissal log (most recent first)
+
+| Pack version | Alert IDs | Kind | Resolution | Notes |
+|---|---|---|---|---|
+| 0.0.7 | #745, #746 | path-injection | Code fix + model | `git_store.go`: use `cleanedBase` (return value of `ValidateAndCleanPath`) instead of raw `tenantID` in `filepath.Join`. `ValidateAndCleanPath` added as `summaryModel` + `barrierModel` in `path-injection-sanitizers.model.yml`. |
+| 0.0.7 | #669, #713, #714, #715, #722 | log-injection | Model + dismiss | `SanitizeLogValue` `summaryModel(kind=value)` added as belt-and-suspenders over existing `barrierModel` (json.Decode field-selection flows bypass barrierModel alone). Alerts dismissed as FP: all sites already wrap input in `SanitizeLogValue`; the barrierModel is correct but insufficiently reliable. |
+| 0.0.7 | #774, #777 | clear-text-logging | Dismiss | Struct field-insensitivity FP: `keyInfo.ID`/`keyInfo.TenantID` (middleware.go) and `deviceID` (controller_service.go) are non-secret fields; the struct's `Key`/`Token` field is never logged. Cannot be modeled (no field-access barrier primitive). |
+| 0.0.6 | #747–#751 | log-injection | Dismiss | handlers_registration_refresh.go — json.Decode field-selection sources; all sites use `SanitizeLogValue`. Same heuristic-source class as #669–#722. |
+| 0.0.5 | safeJoin | path-injection | Model | `summaryModel` + `barrierModel` for `pkg/storage/providers/flatfile.safeJoin`. |
 
 ## Local Development Workflow
 

--- a/pkg/configrouting/providers/git/git_store.go
+++ b/pkg/configrouting/providers/git/git_store.go
@@ -61,12 +61,15 @@ func NewGitConfigStore(
 ) (*GitConfigStore, error) {
 	// Validate tenantID against workDir before constructing any paths.
 	// ValidateAndCleanPath requires workDir to exist; callers must ensure this.
-	if _, err := security.ValidateAndCleanPath(workDir, tenantID); err != nil {
+	// The cleaned return value (not the raw tenantID) is used in filepath.Join so that
+	// the sanitizer's return value acts as a natural path-injection barrier for CodeQL.
+	cleanedBase, err := security.ValidateAndCleanPath(workDir, tenantID)
+	if err != nil {
 		return nil, fmt.Errorf("invalid tenantID %q: %w", tenantID, err)
 	}
 
 	urlHash := fmt.Sprintf("%x", sha256.Sum256([]byte(source.URL)))
-	repoDir := filepath.Join(workDir, tenantID, urlHash)
+	repoDir := filepath.Join(cleanedBase, urlHash)
 
 	if err := os.MkdirAll(repoDir, 0750); err != nil {
 		return nil, fmt.Errorf("failed to create repo directory: %w", err)

--- a/pkg/configrouting/providers/git/git_store_test.go
+++ b/pkg/configrouting/providers/git/git_store_test.go
@@ -4,6 +4,7 @@ package git
 
 import (
 	"context"
+	"crypto/sha256"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -20,6 +21,7 @@ import (
 	pkgconfig "github.com/cfgis/cfgms/pkg/config"
 	"github.com/cfgis/cfgms/pkg/logging"
 	secretsiface "github.com/cfgis/cfgms/pkg/secrets/interfaces"
+	"github.com/cfgis/cfgms/pkg/security"
 	cfgconfig "github.com/cfgis/cfgms/pkg/storage/interfaces/config"
 )
 
@@ -687,6 +689,37 @@ func TestGitConfigStore_ValidateConfig(t *testing.T) {
 	assert.ErrorIs(t, store.ValidateConfig(ctx, jsonEntry), cfgconfig.ErrInvalidFormat, "non-YAML must return ErrInvalidFormat")
 
 	assert.Error(t, store.ValidateConfig(ctx, nil), "nil entry must return error")
+}
+
+// TestGitConfigStore_RepoDirUsesValidatedBasePath verifies that store.repoDir is
+// constructed from the cleaned return value of security.ValidateAndCleanPath, not the
+// raw tenantID string. The parent of repoDir must equal ValidateAndCleanPath(workDir,
+// tenantID) and the leaf segment must be the hex SHA-256 of the source URL. (#2176)
+func TestGitConfigStore_RepoDirUsesValidatedBasePath(t *testing.T) {
+	remoteDir := createBareRemote(t, map[string][]byte{
+		"configs/default/app.yaml": []byte("x: 1\n"),
+	})
+
+	workDir := t.TempDir()
+	ss := newMemorySecretStore(nil)
+	const tenantID = "acme-tenant"
+	source := makeSource(remoteDir, "configs")
+
+	store, err := NewGitConfigStore(context.Background(), source, tenantID, ss, workDir, logging.NewNoopLogger())
+	require.NoError(t, err)
+
+	// cleanedBase is the canonical path that ValidateAndCleanPath returns for workDir/tenantID.
+	cleanedBase, cleanErr := security.ValidateAndCleanPath(workDir, tenantID)
+	require.NoError(t, cleanErr)
+
+	// repoDir parent must equal cleanedBase (validated path, not raw filepath.Join).
+	assert.Equal(t, cleanedBase, filepath.Dir(store.repoDir),
+		"repoDir parent must equal the cleaned base from ValidateAndCleanPath")
+
+	// repoDir leaf must be the hex-encoded SHA-256 of the source URL.
+	expectedLeaf := fmt.Sprintf("%x", sha256.Sum256([]byte(source.URL)))
+	assert.Equal(t, expectedLeaf, filepath.Base(store.repoDir),
+		"repoDir leaf must be hex-SHA256 of the source URL")
 }
 
 // TestGitConfigStore_ResolveConfigWithInheritance verifies that ResolveConfigWithInheritance


### PR DESCRIPTION
## Summary

- **Path-injection #745, #746**: Code fix in `git_store.go` to use the cleaned return value of `security.ValidateAndCleanPath` in `filepath.Join` (instead of raw `tenantID`), eliminating the validate/use gap. `ValidateAndCleanPath` added to `path-injection-sanitizers.model.yml` as `summaryModel`+`barrierModel` (belt-and-suspenders, mirrors `safeJoin` precedent).
- **Log-injection #669, #713, #714, #715, #722**: `summaryModel(kind=value)` added for `SanitizeLogValue`/`RedactedID` alongside existing `barrierModel`; json.Decode field-selection flows bypass `barrierModel` alone on some CodeQL versions. Five alerts dismissed via GHAS API — all sites already wrap input in `SanitizeLogValue`.
- **Clear-text-logging #774, #777**: Struct field-insensitivity FPs (non-secret `ID`/`TenantID`/`deviceID` fields logged; CodeQL traces whole-struct taint). Cannot be modeled (no field-access barrier primitive). Dismissed via GHAS API with justification. Grep confirms no credential value reaches either logger.
- **qlpack.yml**: bumped `0.0.6 ��� 0.0.7` so `codeql-pack-publish.yml` republishes to ghcr.io.
- **Docs**: updated `security-workflow-guide.md` with dual `summaryModel`+`barrierModel` guidance, struct field-insensitivity dismissal step, and model inventory table for future FP triage precedent.

Fixes #2176

## Specialist Review Results

- **QA Test Runner**: PASS — `make test-agent-complete` all gates passed; new `TestGitConfigStore_RepoDirUsesValidatedBasePath` test passing
- **QA Code Reviewer**: PASS — no mocks, no skips, proper assertions, error paths covered
- **Security Engineer**: PASS — all scans green; path fix adversarially verified (traversal still rejected; `old==new` for valid IDs; validate/use gap closed)

## Test plan

- [ ] CI unit-tests gate passes
- [ ] CI integration-tests gate passes  
- [ ] CI Build Gate (cross-platform) passes
- [ ] CI security-deployment-gate passes
- [ ] `codeql-pack-publish.yml` republishes `cfg-is/cfgms-go-extensions@0.0.7` to ghcr.io on merge
- [ ] Post-merge CodeQL scan auto-dismisses/clears alerts #745 and #746 (path-injection — fixed by code + model)
- [ ] Alerts #669, #713, #714, #715, #722, #774, #777 confirmed dismissed in GitHub Security tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)