### PR TITLE
controller: steward.event.log permission + CN-matched LogStream ingestion + back-pressure

### DIFF
--- a/features/controller/server/composite_handler.go
+++ b/features/controller/server/composite_handler.go
@@ -15,16 +15,17 @@ import (
 // compositeTransportServer delegates StewardTransport RPCs to the appropriate
 // handler. Control plane RPCs go to the CP handler; SyncConfig is handled
 // directly by the config handler; SyncDNA by the DNA handler; BulkTransfer
-// by the bulk handler. Future RPCs (TaskStream, Terminal, LogStream) fall
-// through to the Unimplemented base.
+// by the bulk handler; LogStream by the log stream handler. Future RPCs
+// (TaskStream, Terminal) fall through to the Unimplemented base.
 type compositeTransportServer struct {
 	transportpb.UnimplementedStewardTransportServer
 
-	cpHandler     transportpb.StewardTransportServer // Register, Ping, ControlChannel
-	configHandler *controllerTransport.ConfigHandler // SyncConfig (direct handling)
-	dnaHandler    *controllerTransport.DNAHandler    // SyncDNA (direct handling)
-	bulkHandler   *controllerTransport.BulkHandler   // BulkTransfer (direct handling)
-	logger        logging.Logger
+	cpHandler        transportpb.StewardTransportServer    // Register, Ping, ControlChannel
+	configHandler    *controllerTransport.ConfigHandler    // SyncConfig (direct handling)
+	dnaHandler       *controllerTransport.DNAHandler       // SyncDNA (direct handling)
+	bulkHandler      *controllerTransport.BulkHandler      // BulkTransfer (direct handling)
+	logStreamHandler *controllerTransport.LogStreamHandler // LogStream (direct handling)
+	logger           logging.Logger
 }
 
 // newCompositeTransportServer creates a composite handler that delegates RPCs.
@@ -33,14 +34,16 @@ func newCompositeTransportServer(
 	dnaHandler *controllerTransport.DNAHandler,
 	bulkHandler *controllerTransport.BulkHandler,
 	configHandler *controllerTransport.ConfigHandler,
+	logStreamHandler *controllerTransport.LogStreamHandler,
 	logger logging.Logger,
 ) *compositeTransportServer {
 	return &compositeTransportServer{
-		cpHandler:     cpHandler,
-		configHandler: configHandler,
-		dnaHandler:    dnaHandler,
-		bulkHandler:   bulkHandler,
-		logger:        logger,
+		cpHandler:        cpHandler,
+		configHandler:    configHandler,
+		dnaHandler:       dnaHandler,
+		bulkHandler:      bulkHandler,
+		logStreamHandler: logStreamHandler,
+		logger:           logger,
 	}
 }
 
@@ -87,4 +90,15 @@ func (c *compositeTransportServer) BulkTransfer(stream grpc.BidiStreamingServer[
 		return c.bulkHandler.HandleGRPC(stream)
 	}
 	return c.UnimplementedStewardTransportServer.BulkTransfer(stream)
+}
+
+// LogStream is handled directly by the log stream handler. Each ingested
+// LogEntry is CN-matched against the authenticated mTLS peer, tenant-derived
+// server-side from the fleet registry, rate-limited per steward, and written
+// via the dedicated steward-event LoggingManager.
+func (c *compositeTransportServer) LogStream(stream grpc.ClientStreamingServer[transportpb.LogEntry, transportpb.LogStreamResponse]) error {
+	if c.logStreamHandler != nil {
+		return c.logStreamHandler.HandleGRPC(stream)
+	}
+	return c.UnimplementedStewardTransportServer.LogStream(stream)
 }

--- a/features/controller/server/composite_handler_test.go
+++ b/features/controller/server/composite_handler_test.go
@@ -92,13 +92,29 @@ func (s *emptyBulkStream) RecvMsg(interface{}) error             { return nil }
 // Compile-time check.
 var _ grpc.BidiStreamingServer[transportpb.BulkChunk, transportpb.BulkChunk] = (*emptyBulkStream)(nil)
 
+// emptyLogStream implements grpc.ClientStreamingServer[LogEntry, LogStreamResponse].
+// Recv immediately returns EOF so the nil-handler fallback path is tested.
+type emptyLogStream struct{}
+
+func (s *emptyLogStream) Recv() (*transportpb.LogEntry, error)              { return nil, io.EOF }
+func (s *emptyLogStream) SendAndClose(*transportpb.LogStreamResponse) error { return nil }
+func (s *emptyLogStream) SetHeader(metadata.MD) error                       { return nil }
+func (s *emptyLogStream) SendHeader(metadata.MD) error                      { return nil }
+func (s *emptyLogStream) SetTrailer(metadata.MD)                            {}
+func (s *emptyLogStream) Context() context.Context                          { return context.Background() }
+func (s *emptyLogStream) SendMsg(interface{}) error                         { return nil }
+func (s *emptyLogStream) RecvMsg(interface{}) error                         { return nil }
+
+// Compile-time check.
+var _ grpc.ClientStreamingServer[transportpb.LogEntry, transportpb.LogStreamResponse] = (*emptyLogStream)(nil)
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
 
 func TestComposite_RegisterDelegatesToCP(t *testing.T) {
 	cp := newRecordingHandler()
-	composite := newCompositeTransportServer(cp, nil, nil, nil, nil)
+	composite := newCompositeTransportServer(cp, nil, nil, nil, nil, nil)
 
 	_, err := composite.Register(context.Background(), &controllerpb.RegisterRequest{})
 	require.NoError(t, err)
@@ -107,7 +123,7 @@ func TestComposite_RegisterDelegatesToCP(t *testing.T) {
 
 func TestComposite_PingDelegatesToCP(t *testing.T) {
 	cp := newRecordingHandler()
-	composite := newCompositeTransportServer(cp, nil, nil, nil, nil)
+	composite := newCompositeTransportServer(cp, nil, nil, nil, nil, nil)
 
 	_, err := composite.Ping(context.Background(), &transportpb.PingRequest{})
 	require.NoError(t, err)
@@ -116,7 +132,7 @@ func TestComposite_PingDelegatesToCP(t *testing.T) {
 
 func TestComposite_ControlChannelDelegatesToCP(t *testing.T) {
 	cp := newRecordingHandler()
-	composite := newCompositeTransportServer(cp, nil, nil, nil, nil)
+	composite := newCompositeTransportServer(cp, nil, nil, nil, nil, nil)
 
 	err := composite.ControlChannel(nil)
 	require.NoError(t, err)
@@ -125,7 +141,7 @@ func TestComposite_ControlChannelDelegatesToCP(t *testing.T) {
 
 func TestComposite_SyncDNA_NilHandler(t *testing.T) {
 	cp := newRecordingHandler()
-	composite := newCompositeTransportServer(cp, nil, nil, nil, nil)
+	composite := newCompositeTransportServer(cp, nil, nil, nil, nil, nil)
 
 	err := composite.SyncDNA(&emptyDNAStream{})
 	require.Error(t, err, "SyncDNA with nil dnaHandler should return unimplemented error")
@@ -135,7 +151,7 @@ func TestComposite_SyncDNA_WithHandler(t *testing.T) {
 	cp := newRecordingHandler()
 	logger := logging.NewNoopLogger()
 	dnaHandler := controllerTransport.NewDNAHandler(logger, controllerTransport.NewTenantQueue())
-	composite := newCompositeTransportServer(cp, dnaHandler, nil, nil, nil)
+	composite := newCompositeTransportServer(cp, dnaHandler, nil, nil, nil, nil)
 
 	// Empty stream with background context (no mTLS peer) → Unauthenticated from handler.
 	// This proves that dnaHandler.HandleGRPC is called, not the Unimplemented fallback.
@@ -147,7 +163,7 @@ func TestComposite_SyncDNA_WithHandler(t *testing.T) {
 
 func TestComposite_BulkTransfer_NilHandler(t *testing.T) {
 	cp := newRecordingHandler()
-	composite := newCompositeTransportServer(cp, nil, nil, nil, nil)
+	composite := newCompositeTransportServer(cp, nil, nil, nil, nil, nil)
 
 	err := composite.BulkTransfer(&emptyBulkStream{})
 	require.Error(t, err, "BulkTransfer with nil bulkHandler should return unimplemented error")
@@ -157,7 +173,7 @@ func TestComposite_BulkTransfer_WithHandler(t *testing.T) {
 	cp := newRecordingHandler()
 	logger := logging.NewNoopLogger()
 	bulkHandler := controllerTransport.NewBulkHandler(logger, controllerTransport.NewTenantQueue())
-	composite := newCompositeTransportServer(cp, nil, bulkHandler, nil, nil)
+	composite := newCompositeTransportServer(cp, nil, bulkHandler, nil, nil, nil)
 
 	err := composite.BulkTransfer(&emptyBulkStream{})
 	require.NoError(t, err, "BulkTransfer with valid handler and empty stream must succeed")
@@ -165,8 +181,18 @@ func TestComposite_BulkTransfer_WithHandler(t *testing.T) {
 
 func TestComposite_SyncConfigWithoutHandler(t *testing.T) {
 	cp := newRecordingHandler()
-	composite := newCompositeTransportServer(cp, nil, nil, nil, nil)
+	composite := newCompositeTransportServer(cp, nil, nil, nil, nil, nil)
 
 	err := composite.SyncConfig(&transportpb.ConfigSyncRequest{}, nil)
 	require.Error(t, err, "SyncConfig without handler should return unimplemented error")
+}
+
+func TestComposite_LogStream_NilHandler(t *testing.T) {
+	cp := newRecordingHandler()
+	composite := newCompositeTransportServer(cp, nil, nil, nil, nil, nil)
+
+	err := composite.LogStream(&emptyLogStream{})
+	require.Error(t, err, "LogStream with nil logStreamHandler should return unimplemented error")
+	assert.Contains(t, err.Error(), "not implemented",
+		"LogStream with nil handler must return Unimplemented")
 }

--- a/features/controller/server/server.go
+++ b/features/controller/server/server.go
@@ -102,9 +102,10 @@ type Server struct {
 	registrationTokenStore  pkgRegistration.Store
 	dataPlaneProvider       dataplaneInterfaces.DataPlaneProvider
 	configHandler           *controllerTransport.ConfigHandler
-	grpcServer              *grpc.Server            // Shared gRPC server for CP+DP (Story #515)
-	quicListener            *quictransport.Listener // Shared QUIC listener (Story #515)
-	signerCertSerial        string                  // Serial number of server cert used for config signing (Story #378)
+	logStreamHandler        *controllerTransport.LogStreamHandler // Issue #2140: LogStream ingestion handler
+	grpcServer              *grpc.Server                          // Shared gRPC server for CP+DP (Story #515)
+	quicListener            *quictransport.Listener               // Shared QUIC listener (Story #515)
+	signerCertSerial        string                                // Serial number of server cert used for config signing (Story #378)
 	healthCollector         *health.Collector
 	alertManager            *health.DefaultAlertManager
 	dnaStorageManager       *dnaStorage.Manager                      // Reports engine DNA storage (must be closed on Stop)
@@ -1483,7 +1484,14 @@ func (s *Server) Start() error {
 		tenantQueue := controllerTransport.NewTenantQueue()
 		dnaHandler := controllerTransport.NewDNAHandler(s.logger, tenantQueue)
 		bulkHandler := controllerTransport.NewBulkHandler(s.logger, tenantQueue)
-		composite := newCompositeTransportServer(cpHandler, dnaHandler, bulkHandler, s.configHandler, s.logger)
+		logStreamHandler := controllerTransport.NewLogStreamHandler(
+			s.stewardEventManager,
+			s.controllerService,
+			s.logger,
+			controllerTransport.DefaultLogStreamConfig(),
+		)
+		s.logStreamHandler = logStreamHandler
+		composite := newCompositeTransportServer(cpHandler, dnaHandler, bulkHandler, s.configHandler, logStreamHandler, s.logger)
 		transportpb.RegisterStewardTransportServer(s.grpcServer, composite)
 
 		// Start serving on the shared QUIC listener

--- a/features/controller/transport/log_stream_handler.go
+++ b/features/controller/transport/log_stream_handler.go
@@ -1,0 +1,258 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+package transport
+
+import (
+	"io"
+	"sync"
+	"time"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/peer"
+	"google.golang.org/grpc/status"
+
+	transportpb "github.com/cfgis/cfgms/api/proto/transport"
+	"github.com/cfgis/cfgms/features/controller/service"
+	"github.com/cfgis/cfgms/pkg/logging"
+	loggingInterfaces "github.com/cfgis/cfgms/pkg/logging/interfaces"
+	quictransport "github.com/cfgis/cfgms/pkg/transport/quic"
+)
+
+// LogStreamConfig holds rate-limiting configuration for LogStream ingestion.
+type LogStreamConfig struct {
+	// RateLimitPerSteward is the maximum log entries per second per steward.
+	RateLimitPerSteward int
+}
+
+// DefaultLogStreamConfig returns the default LogStream configuration.
+func DefaultLogStreamConfig() LogStreamConfig {
+	return LogStreamConfig{
+		RateLimitPerSteward: 100,
+	}
+}
+
+// tokenBucket implements a simple token-bucket rate limiter for per-steward ingest.
+type tokenBucket struct {
+	mu       sync.Mutex
+	tokens   float64
+	capacity float64
+	rate     float64 // tokens per second
+	lastFill time.Time
+}
+
+func newTokenBucket(ratePerSecond int) *tokenBucket {
+	cap := float64(ratePerSecond)
+	return &tokenBucket{
+		tokens:   cap,
+		capacity: cap,
+		rate:     cap,
+		lastFill: time.Now(),
+	}
+}
+
+// tryConsume attempts to consume one token. Returns true if consumed, false if
+// the bucket is empty (entry should be dropped).
+func (tb *tokenBucket) tryConsume() bool {
+	tb.mu.Lock()
+	defer tb.mu.Unlock()
+	now := time.Now()
+	elapsed := now.Sub(tb.lastFill).Seconds()
+	tb.lastFill = now
+	tb.tokens += elapsed * tb.rate
+	if tb.tokens > tb.capacity {
+		tb.tokens = tb.capacity
+	}
+	if tb.tokens < 1 {
+		return false
+	}
+	tb.tokens--
+	return true
+}
+
+// LogStreamHandler handles LogStream RPCs from stewards. Each ingested LogEntry
+// is CN-matched to the authenticated mTLS peer, tenant-derived server-side from
+// the fleet registry, rate-limited per steward, and written via the dedicated
+// steward-event LoggingManager (Issue #2140).
+type LogStreamHandler struct {
+	loggingManager    *logging.LoggingManager
+	controllerService *service.ControllerService
+	logger            logging.Logger
+	config            LogStreamConfig
+
+	mu           sync.Mutex
+	dropCounters map[string]int64
+	tokenBuckets map[string]*tokenBucket
+}
+
+// NewLogStreamHandler creates a new LogStreamHandler.
+func NewLogStreamHandler(
+	loggingManager *logging.LoggingManager,
+	controllerService *service.ControllerService,
+	logger logging.Logger,
+	config LogStreamConfig,
+) *LogStreamHandler {
+	return &LogStreamHandler{
+		loggingManager:    loggingManager,
+		controllerService: controllerService,
+		logger:            logger,
+		config:            config,
+		dropCounters:      make(map[string]int64),
+		tokenBuckets:      make(map[string]*tokenBucket),
+	}
+}
+
+// GetDropCount returns the number of dropped entries for the given steward.
+func (h *LogStreamHandler) GetDropCount(stewardID string) int64 {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return h.dropCounters[stewardID]
+}
+
+func (h *LogStreamHandler) getOrCreateBucket(stewardID string) *tokenBucket {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if b, ok := h.tokenBuckets[stewardID]; ok {
+		return b
+	}
+	b := newTokenBucket(h.config.RateLimitPerSteward)
+	h.tokenBuckets[stewardID] = b
+	return b
+}
+
+func (h *LogStreamHandler) incrementDropCounter(stewardID string) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.dropCounters[stewardID]++
+}
+
+// HandleGRPC processes a LogStream RPC.
+//
+//  1. Extracts the CN from the mTLS peer — fails closed if absent or empty.
+//  2. CN-matches every received LogEntry against the peer CN; mismatches return
+//     PermissionDenied without disclosing the peer CN in the error message.
+//  3. Derives TenantID server-side from the fleet registry; any wire-supplied
+//     tenant value is ignored to prevent a compromised steward from stamping
+//     another tenant's events.
+//  4. Applies a per-steward token-bucket rate limit; entries above the limit are
+//     dropped (non-blocking) and counted per steward.
+//  5. Maps each accepted entry to a loggingInterfaces.LogEntry and calls
+//     WriteEntry on the steward-event LoggingManager.
+//
+// On clean EOF, returns LogStreamResponse{EntriesReceived: N, Acknowledged: true}.
+func (h *LogStreamHandler) HandleGRPC(stream grpc.ClientStreamingServer[transportpb.LogEntry, transportpb.LogStreamResponse]) error {
+	ctx := stream.Context()
+
+	// Extract mTLS peer CN — fail closed if missing or empty.
+	p, ok := peer.FromContext(ctx)
+	if !ok {
+		return status.Error(codes.Unauthenticated, "mTLS certificate required")
+	}
+	tlsInfo, ok := p.AuthInfo.(credentials.TLSInfo)
+	if !ok {
+		return status.Error(codes.Unauthenticated, "mTLS certificate required")
+	}
+	peerID, err := quictransport.PeerStewardID(tlsInfo.State)
+	if err != nil || peerID == "" {
+		return status.Error(codes.Unauthenticated, "mTLS certificate required")
+	}
+
+	// Derive TenantID server-side from the authenticated peer's fleet-registry record.
+	tenantID := ""
+	if h.controllerService != nil {
+		if info, ok := h.controllerService.GetStewardInfo(peerID); ok {
+			tenantID = info.TenantID
+		}
+	}
+
+	bucket := h.getOrCreateBucket(peerID)
+	var received int64
+
+	for {
+		entry, recvErr := stream.Recv()
+		if recvErr == io.EOF {
+			break
+		}
+		if recvErr != nil {
+			return recvErr
+		}
+
+		// CN-match: entry StewardID must equal the authenticated peer CN.
+		if entry.GetStewardId() != peerID {
+			return status.Error(codes.PermissionDenied, "steward ID mismatch")
+		}
+
+		// Rate-limit: drop entries above per-steward budget without blocking.
+		if !bucket.tryConsume() {
+			h.incrementDropCounter(peerID)
+			if h.logger != nil {
+				h.logger.Warn("LogStream entry dropped: rate limit exceeded",
+					"steward_id", logging.SanitizeLogValue(peerID),
+					"drops", h.GetDropCount(peerID))
+			}
+			continue
+		}
+
+		logEntry := mapLogEntry(entry, peerID, tenantID)
+
+		written := true
+		if h.loggingManager != nil {
+			if writeErr := h.loggingManager.WriteEntry(ctx, logEntry); writeErr != nil {
+				written = false
+				if h.logger != nil {
+					h.logger.Warn("LogStream WriteEntry failed",
+						"steward_id", logging.SanitizeLogValue(peerID),
+						"error", writeErr)
+				}
+			}
+		}
+		if written {
+			received++
+		}
+	}
+
+	return stream.SendAndClose(&transportpb.LogStreamResponse{
+		EntriesReceived: received,
+		Acknowledged:    true,
+	})
+}
+
+// mapLogEntry converts a transport-layer LogEntry proto to a loggingInterfaces.LogEntry.
+// peerID (CN-verified) is always stamped into Fields["steward_id"], overriding
+// any wire-supplied value so events are attributable per steward. TenantID is
+// always the server-derived registry value.
+func mapLogEntry(entry *transportpb.LogEntry, peerID, tenantID string) loggingInterfaces.LogEntry {
+	fields := make(map[string]interface{}, len(entry.GetFields())+1)
+	for k, v := range entry.GetFields() {
+		fields[k] = v
+	}
+	// Stamp CN-verified steward identity (overrides any wire-supplied steward_id).
+	fields["steward_id"] = peerID
+
+	ts := time.Now()
+	if entry.GetTimestamp() != nil {
+		ts = entry.GetTimestamp().AsTime()
+	}
+
+	return loggingInterfaces.LogEntry{
+		Timestamp:     ts,
+		Level:         mapSeverityToLevel(entry.GetLevel()),
+		Message:       entry.GetMessage(),
+		TenantID:      tenantID,
+		CorrelationID: entry.GetCorrelationId(),
+		Fields:        fields,
+	}
+}
+
+// mapSeverityToLevel converts a transport Severity to a logging level string.
+func mapSeverityToLevel(s transportpb.Severity) string {
+	switch s {
+	case transportpb.Severity_SEVERITY_WARNING:
+		return "WARN"
+	case transportpb.Severity_SEVERITY_ERROR, transportpb.Severity_SEVERITY_CRITICAL:
+		return "ERROR"
+	default:
+		return "INFO"
+	}
+}

--- a/features/controller/transport/log_stream_handler_test.go
+++ b/features/controller/transport/log_stream_handler_test.go
@@ -1,0 +1,314 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+package transport
+
+import (
+	"context"
+	"errors"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	transportpb "github.com/cfgis/cfgms/api/proto/transport"
+	"github.com/cfgis/cfgms/features/controller/service"
+	"github.com/cfgis/cfgms/pkg/logging"
+	loggingInterfaces "github.com/cfgis/cfgms/pkg/logging/interfaces"
+
+	// Register the file provider so NewLoggingManager("file") works in tests.
+	_ "github.com/cfgis/cfgms/pkg/logging/providers/file"
+)
+
+// ---------------------------------------------------------------------------
+// Test double for grpc.ClientStreamingServer[LogEntry, LogStreamResponse]
+// ---------------------------------------------------------------------------
+
+type testLogStream struct {
+	entries []*transportpb.LogEntry
+	pos     int
+	resp    *transportpb.LogStreamResponse
+	ctx     context.Context
+	recvErr error
+}
+
+func newTestLogStream(ctx context.Context, entries ...*transportpb.LogEntry) *testLogStream {
+	return &testLogStream{entries: entries, ctx: ctx}
+}
+
+func (s *testLogStream) Recv() (*transportpb.LogEntry, error) {
+	if s.recvErr != nil {
+		return nil, s.recvErr
+	}
+	if s.pos >= len(s.entries) {
+		return nil, io.EOF
+	}
+	e := s.entries[s.pos]
+	s.pos++
+	return e, nil
+}
+
+func (s *testLogStream) SendAndClose(resp *transportpb.LogStreamResponse) error {
+	s.resp = resp
+	return nil
+}
+
+func (s *testLogStream) SetHeader(metadata.MD) error  { return nil }
+func (s *testLogStream) SendHeader(metadata.MD) error { return nil }
+func (s *testLogStream) SetTrailer(metadata.MD)       {}
+func (s *testLogStream) Context() context.Context     { return s.ctx }
+func (s *testLogStream) SendMsg(interface{}) error    { return nil }
+func (s *testLogStream) RecvMsg(interface{}) error    { return nil }
+
+// Compile-time check.
+var _ grpc.ClientStreamingServer[transportpb.LogEntry, transportpb.LogStreamResponse] = (*testLogStream)(nil)
+
+// ---------------------------------------------------------------------------
+// Test helper: file-backed LoggingManager
+// ---------------------------------------------------------------------------
+
+func newTestLoggingManager(t *testing.T) *logging.LoggingManager {
+	t.Helper()
+	cfg := &logging.LoggingConfig{
+		Provider: "file",
+		Config: map[string]interface{}{
+			"directory":        t.TempDir(),
+			"file_prefix":      "log-stream-test",
+			"max_file_size":    1024 * 1024,
+			"retention_days":   1,
+			"compress_rotated": false,
+		},
+		Level:       "DEBUG",
+		ServiceName: "cfgms",
+		Component:   "log-stream-handler-test",
+		BatchSize:   1,
+		AsyncWrites: false,
+	}
+	m, err := logging.NewLoggingManager(cfg)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		if closeErr := m.Close(); closeErr != nil {
+			t.Logf("LoggingManager.Close() error: %v", closeErr)
+		}
+	})
+	return m
+}
+
+// queryAllEntries flushes and returns every log entry written to the manager.
+func queryAllEntries(t *testing.T, m *logging.LoggingManager) []loggingInterfaces.LogEntry {
+	t.Helper()
+	ctx := context.Background()
+	require.NoError(t, m.Flush(ctx))
+	entries, err := m.QueryTimeRange(ctx, loggingInterfaces.TimeRangeQuery{
+		StartTime: time.Unix(0, 0),
+		EndTime:   time.Now().Add(time.Hour),
+	})
+	require.NoError(t, err)
+	return entries
+}
+
+// ---------------------------------------------------------------------------
+// Acceptance-criteria tests (Issue #2140)
+// ---------------------------------------------------------------------------
+
+// TestLogStreamHandler_CNMismatch_Rejected verifies that a LogEntry whose
+// StewardID differs from the mTLS peer CN is rejected with PermissionDenied
+// and the error message does not disclose the peer CN.
+func TestLogStreamHandler_CNMismatch_Rejected(t *testing.T) {
+	ca := newTestCA(t)
+	h := NewLogStreamHandler(nil, nil, logging.NewNoopLogger(), DefaultLogStreamConfig())
+
+	// Peer authenticates as "steward-alice".
+	ctx := peerContextWithCA(t, ca, "steward-alice")
+
+	// Entry claims to be from "steward-bob" — deliberate mismatch.
+	stream := newTestLogStream(ctx, &transportpb.LogEntry{
+		StewardId: "steward-bob",
+		Level:     transportpb.Severity_SEVERITY_INFO,
+		Message:   "hello",
+		Timestamp: timestamppb.Now(),
+	})
+
+	err := h.HandleGRPC(stream)
+
+	require.Error(t, err)
+	assert.Equal(t, codes.PermissionDenied, status.Code(err))
+	msg := status.Convert(err).Message()
+	assert.NotContains(t, msg, "steward-alice", "error must not disclose the peer CN")
+	assert.NotContains(t, msg, "steward-bob", "error must not disclose the wire steward ID")
+}
+
+// TestLogStreamHandler_EmptyCN_FailsClosed verifies that a stream authenticated
+// with no or blank CN is rejected (never treated as a wildcard or pass-through).
+func TestLogStreamHandler_EmptyCN_FailsClosed(t *testing.T) {
+	h := NewLogStreamHandler(nil, nil, logging.NewNoopLogger(), DefaultLogStreamConfig())
+
+	// context.Background() carries no peer info at all.
+	stream := newTestLogStream(context.Background(), &transportpb.LogEntry{
+		StewardId: "steward-xyz",
+		Level:     transportpb.Severity_SEVERITY_INFO,
+		Message:   "test",
+		Timestamp: timestamppb.Now(),
+	})
+
+	err := h.HandleGRPC(stream)
+
+	require.Error(t, err)
+	assert.Equal(t, codes.Unauthenticated, status.Code(err))
+}
+
+// TestLogStreamHandler_RateLimit_DropWithCounter verifies that entries above
+// the per-steward rate limit are dropped (non-blocking) with the drop counter
+// incremented, while accepted entries are persisted via WriteEntry.
+func TestLogStreamHandler_RateLimit_DropWithCounter(t *testing.T) {
+	ca := newTestCA(t)
+	mgr := newTestLoggingManager(t)
+
+	const stewardID = "steward-rate"
+	// Set rate limit to 1 so the second entry is always dropped.
+	cfg := LogStreamConfig{RateLimitPerSteward: 1}
+	h := NewLogStreamHandler(mgr, nil, logging.NewNoopLogger(), cfg)
+
+	ctx := peerContextWithCA(t, ca, stewardID)
+
+	// Exhaust the bucket's single token by sending 3 entries.
+	entries := []*transportpb.LogEntry{
+		{StewardId: stewardID, Level: transportpb.Severity_SEVERITY_INFO, Message: "entry-1", Timestamp: timestamppb.Now()},
+		{StewardId: stewardID, Level: transportpb.Severity_SEVERITY_INFO, Message: "entry-2", Timestamp: timestamppb.Now()},
+		{StewardId: stewardID, Level: transportpb.Severity_SEVERITY_INFO, Message: "entry-3", Timestamp: timestamppb.Now()},
+	}
+	stream := newTestLogStream(ctx, entries...)
+
+	err := h.HandleGRPC(stream)
+	require.NoError(t, err)
+	require.NotNil(t, stream.resp)
+	assert.True(t, stream.resp.GetAcknowledged())
+
+	// At least one entry must have been dropped (bucket started at capacity=1,
+	// so entries 2 and 3 are both candidates for dropping).
+	drops := h.GetDropCount(stewardID)
+	assert.Greater(t, drops, int64(0), "drop counter must be positive")
+
+	// Accepted entries (received count) + drops must equal total sent.
+	received := stream.resp.GetEntriesReceived()
+	assert.Equal(t, int64(3), received+drops, "received + drops must equal total sent")
+
+	// At least the first accepted entry must be retrievable from storage.
+	persisted := queryAllEntries(t, mgr)
+	assert.NotEmpty(t, persisted, "at least one entry must be persisted")
+}
+
+// TestLogStreamHandler_TenantDerivedServerSide verifies that a LogEntry whose
+// fields["tenant_id"] claims a foreign tenant is persisted under the steward's
+// registry tenant, not the claimed one.
+func TestLogStreamHandler_TenantDerivedServerSide(t *testing.T) {
+	ca := newTestCA(t)
+	mgr := newTestLoggingManager(t)
+
+	const stewardID = "steward-tenant"
+	const registryTenant = "tenant-registry"
+	const claimedTenant = "tenant-foreign"
+
+	cs := service.NewControllerService(logging.NewNoopLogger())
+	require.NoError(t, cs.RegisterSteward(stewardID, registryTenant, "", "active"))
+
+	h := NewLogStreamHandler(mgr, cs, logging.NewNoopLogger(), DefaultLogStreamConfig())
+	ctx := peerContextWithCA(t, ca, stewardID)
+
+	stream := newTestLogStream(ctx, &transportpb.LogEntry{
+		StewardId: stewardID,
+		Level:     transportpb.Severity_SEVERITY_INFO,
+		Message:   "tenant-test",
+		Timestamp: timestamppb.Now(),
+		Fields:    map[string]string{"tenant_id": claimedTenant},
+	})
+
+	err := h.HandleGRPC(stream)
+	require.NoError(t, err)
+
+	entries := queryAllEntries(t, mgr)
+	require.NotEmpty(t, entries)
+	assert.Equal(t, registryTenant, entries[0].TenantID,
+		"persisted entry must use the server-derived tenant, not the wire value")
+}
+
+// TestLogStreamHandler_StampsCNVerifiedStewardID verifies that the persisted
+// entry's Fields["steward_id"] equals the CN-verified peer identity (not any
+// wire-supplied value), ensuring events are attributable per steward.
+func TestLogStreamHandler_StampsCNVerifiedStewardID(t *testing.T) {
+	ca := newTestCA(t)
+	mgr := newTestLoggingManager(t)
+
+	const peerCN = "steward-verified"
+	h := NewLogStreamHandler(mgr, nil, logging.NewNoopLogger(), DefaultLogStreamConfig())
+	ctx := peerContextWithCA(t, ca, peerCN)
+
+	// Wire payload supplies a different steward_id in fields — must be overridden.
+	stream := newTestLogStream(ctx, &transportpb.LogEntry{
+		StewardId: peerCN,
+		Level:     transportpb.Severity_SEVERITY_INFO,
+		Message:   "stamp-test",
+		Timestamp: timestamppb.Now(),
+		Fields:    map[string]string{"steward_id": "some-other-steward"},
+	})
+
+	err := h.HandleGRPC(stream)
+	require.NoError(t, err)
+
+	entries := queryAllEntries(t, mgr)
+	require.NotEmpty(t, entries)
+	sid, ok := entries[0].Fields["steward_id"]
+	require.True(t, ok, "steward_id must be present in persisted entry fields")
+	assert.Equal(t, peerCN, sid,
+		"persisted steward_id must be CN-verified peer identity, not the wire value")
+}
+
+// ---------------------------------------------------------------------------
+// Error-path tests
+// ---------------------------------------------------------------------------
+
+// TestLogStreamHandler_RecvError verifies that a mid-stream Recv() error
+// (not EOF) propagates from HandleGRPC.
+func TestLogStreamHandler_RecvError(t *testing.T) {
+	ca := newTestCA(t)
+	h := NewLogStreamHandler(nil, nil, logging.NewNoopLogger(), DefaultLogStreamConfig())
+
+	ctx := peerContextWithCA(t, ca, "steward-recv-err")
+	injected := errors.New("simulated network failure")
+	stream := &testLogStream{ctx: ctx, recvErr: injected}
+
+	err := h.HandleGRPC(stream)
+
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, injected), "error must wrap the injected recv error")
+}
+
+// ---------------------------------------------------------------------------
+// Severity mapping unit tests
+// ---------------------------------------------------------------------------
+
+// TestMapSeverityToLevel verifies that all proto Severity values map to the
+// expected logging level strings.
+func TestMapSeverityToLevel(t *testing.T) {
+	cases := []struct {
+		severity transportpb.Severity
+		want     string
+	}{
+		{transportpb.Severity_SEVERITY_UNSPECIFIED, "INFO"},
+		{transportpb.Severity_SEVERITY_INFO, "INFO"},
+		{transportpb.Severity_SEVERITY_WARNING, "WARN"},
+		{transportpb.Severity_SEVERITY_ERROR, "ERROR"},
+		{transportpb.Severity_SEVERITY_CRITICAL, "ERROR"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.severity.String(), func(t *testing.T) {
+			assert.Equal(t, tc.want, mapSeverityToLevel(tc.severity))
+		})
+	}
+}

--- a/features/rbac/defaults.go
+++ b/features/rbac/defaults.go
@@ -88,6 +88,13 @@ var DefaultPermissions = []*common.Permission{
 		ResourceType: "configuration",
 		Actions:      []string{"create", "update"},
 	},
+	{
+		Id:           "steward.event.log",
+		Name:         "Emit Steward Event Log",
+		Description:  "Allow steward to stream event log entries to the controller; grants emit-only access with no read capability",
+		ResourceType: "steward",
+		Actions:      []string{"create"},
+	},
 
 	// Tenant Management Permissions
 	{
@@ -267,6 +274,7 @@ var DefaultRoles = []*common.Role{
 			"config.read",
 			"config.validate",
 			"config.status.report",
+			"steward.event.log",
 			"module.execute",
 		},
 		IsSystemRole: true,

--- a/features/rbac/defaults_test.go
+++ b/features/rbac/defaults_test.go
@@ -67,6 +67,30 @@ func TestAgentDevRole_HasNoWriteOrAdminPerms(t *testing.T) {
 	}
 }
 
+// TestStewardEventLogPermission_ExistsAndEmitOnly verifies the steward.event.log
+// permission exists in DefaultPermissions with emit-only (create) access — no read.
+func TestStewardEventLogPermission_ExistsAndEmitOnly(t *testing.T) {
+	var found *common.Permission
+	for _, p := range DefaultPermissions {
+		if p.Id == "steward.event.log" {
+			found = p
+			break
+		}
+	}
+	require.NotNil(t, found, "steward.event.log must exist in DefaultPermissions")
+	assert.Equal(t, []string{"create"}, found.Actions,
+		"steward.event.log must be emit-only (create), no read")
+}
+
+// TestStewardServiceRole_IncludesStewardEventLog verifies steward.service grants
+// steward.event.log but not a corresponding read permission.
+func TestStewardServiceRole_IncludesStewardEventLog(t *testing.T) {
+	role := findDefaultRole("steward.service")
+	require.NotNil(t, role, "steward.service must exist in DefaultRoles")
+	assert.Contains(t, role.PermissionIds, "steward.event.log",
+		"steward.service must include steward.event.log")
+}
+
 // findDefaultRole searches DefaultRoles by ID and returns nil if not found.
 func findDefaultRole(id string) *common.Role {
 	for _, role := range DefaultRoles {


### PR DESCRIPTION
Fixes #2140

Agent session failed with exit code 1. Review container logs for details.