### PR TITLE
steward: controller-trust anchoring install + compile options (Issue #1517)

### DIFF
--- a/build/linux/install.sh
+++ b/build/linux/install.sh
@@ -10,21 +10,29 @@
 # service registration.
 #
 # Usage:
-#   sudo bash install.sh --regtoken TOKEN [--fingerprint HEX] [--ca-cert PATH]
+#   sudo bash install.sh --regtoken TOKEN [--controller-url URL] \
+#       [--fingerprint HEX] [--controller-ca PATH]
 #
 # Flags:
-#   --regtoken TOKEN    Registration token (required)
-#   --fingerprint HEX   CA cert SHA-256 fingerprint, lowercase hex no colons;
-#                       skips interactive prompt
-#   --ca-cert PATH      CA cert PEM path (default: ca.crt in script directory
-#                       if present — matches the tar.gz bundle layout)
+#   --regtoken TOKEN        Registration token (required)
+#   --controller-url URL    Controller URL (install-pinned and TOFU modes;
+#                           omit to use the compile-time URL baked into the binary)
+#   --fingerprint HEX       CA cert SHA-256 fingerprint, lowercase hex no colons;
+#                           skips interactive prompt
+#   --controller-ca PATH    CA cert PEM path (default: ca.crt in script directory
+#                           if present — matches the tar.gz bundle layout)
 #
-# Non-interactive example:
-#   sudo bash install.sh --regtoken mytoken --fingerprint aabbcc1122...
+# Non-interactive install-pinned example:
+#   sudo bash install.sh --regtoken TOKEN \
+#       --controller-url https://ctrl.example.com \
+#       --controller-ca ca.crt --fingerprint aabbcc1122...
 #
-# Interactive example:
-#   sudo bash install.sh --regtoken mytoken
+# Interactive example (CA bundled in tar.gz):
+#   sudo bash install.sh --regtoken TOKEN --controller-url https://ctrl.example.com
 #   (Displays the fingerprint from ca.fingerprint, prompts for confirmation)
+#
+# Compile-baked URL (default, binary rebuilt per controller):
+#   sudo bash install.sh --regtoken TOKEN
 #
 # Test isolation:
 #   CFGMS_INSTALL_PREFIX=/tmp/test sudo bash install.sh ...
@@ -38,14 +46,16 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # ── Argument parsing ──────────────────────────────────────────────────────────
 
 REGTOKEN=""
+CONTROLLER_URL=""
 FINGERPRINT=""
 CA_CERT=""
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
-        --regtoken)    REGTOKEN="$2";     shift 2 ;;
-        --fingerprint) FINGERPRINT="$2";  shift 2 ;;
-        --ca-cert)     CA_CERT="$2";      shift 2 ;;
+        --regtoken)        REGTOKEN="$2";        shift 2 ;;
+        --controller-url)  CONTROLLER_URL="$2";  shift 2 ;;
+        --fingerprint)     FINGERPRINT="$2";     shift 2 ;;
+        --controller-ca)   CA_CERT="$2";         shift 2 ;;
         *) echo "Unknown argument: $1" >&2; exit 1 ;;
     esac
 done
@@ -53,11 +63,12 @@ done
 # ── Validation ────────────────────────────────────────────────────────────────
 
 if [[ -z "$REGTOKEN" ]]; then
-    echo "Usage: sudo bash install.sh --regtoken TOKEN [--fingerprint HEX] [--ca-cert PATH]" >&2
+    echo "Usage: sudo bash install.sh --regtoken TOKEN [--controller-url URL] [--fingerprint HEX] [--controller-ca PATH]" >&2
     echo "" >&2
-    echo "  --regtoken TOKEN    Registration token (required)" >&2
-    echo "  --fingerprint HEX   CA cert SHA-256 fingerprint for non-interactive install" >&2
-    echo "  --ca-cert PATH      Path to CA cert PEM (default: ca.crt in script directory)" >&2
+    echo "  --regtoken TOKEN        Registration token (required)" >&2
+    echo "  --controller-url URL    Controller URL (install-pinned/TOFU; omit for compile-baked binary)" >&2
+    echo "  --fingerprint HEX       CA cert SHA-256 fingerprint for non-interactive install" >&2
+    echo "  --controller-ca PATH    Path to CA cert PEM (default: ca.crt in script directory)" >&2
     exit 1
 fi
 
@@ -140,8 +151,11 @@ done
 # ── Build and run install command ─────────────────────────────────────────────
 
 INSTALL_ARGS=(install --regtoken "$REGTOKEN")
+if [[ -n "$CONTROLLER_URL" ]]; then
+    INSTALL_ARGS+=(--controller-url "$CONTROLLER_URL")
+fi
 if [[ -n "$CA_CERT" ]]; then
-    INSTALL_ARGS+=(--ca-cert "$CA_CERT")
+    INSTALL_ARGS+=(--controller-ca "$CA_CERT")
 fi
 if [[ -n "$FINGERPRINT" ]]; then
     INSTALL_ARGS+=(--fingerprint "$FINGERPRINT")

--- a/cmd/steward/identity.go
+++ b/cmd/steward/identity.go
@@ -116,8 +116,8 @@ type StewardIdentity struct {
 	DeviceID       string `json:"device_id,omitempty"`        // 64-char lowercase hex SHA-256 of Ed25519 public key
 	IdentityKeyPub string `json:"identity_key_pub,omitempty"` // base64-encoded Ed25519 public key (32 bytes)
 	// Trust anchor fields (ADR-013 §3, Issue #1517).
-	TrustMode        string `json:"trust_mode,omitempty"`          // "compile-baked", "install-pinned", "tofu"
-	CAPinFingerprint string `json:"ca_pin_fingerprint,omitempty"`  // SHA-256 hex of pinned CA cert (install-pinned and TOFU)
+	TrustMode        string `json:"trust_mode,omitempty"`         // "compile-baked", "install-pinned", "tofu"
+	CAPinFingerprint string `json:"ca_pin_fingerprint,omitempty"` // SHA-256 hex of pinned CA cert (install-pinned and TOFU)
 }
 
 // saveIdentity writes id to dir/steward-identity.json with permissions 0600

--- a/cmd/steward/identity.go
+++ b/cmd/steward/identity.go
@@ -99,6 +99,10 @@ const identityFileName = "steward-identity.json"
 // SigningCertPEM (singular) is kept for backward-compatible reading of identity
 // files written before multi-cert support. loadIdentity migrates it into
 // SigningCertPEMs automatically on read.
+//
+// TrustMode and CAPinFingerprint record the trust anchor established at enrollment
+// (ADR-013 §3). The downgrade guard uses these to ensure trust is never silently
+// weakened across restarts or re-enrollments.
 type StewardIdentity struct {
 	StewardID        string     `json:"steward_id"`
 	TenantID         string     `json:"tenant_id"`
@@ -111,6 +115,9 @@ type StewardIdentity struct {
 	// Device identity fields (Issue #2094): stable across mTLS cert rotations.
 	DeviceID       string `json:"device_id,omitempty"`        // 64-char lowercase hex SHA-256 of Ed25519 public key
 	IdentityKeyPub string `json:"identity_key_pub,omitempty"` // base64-encoded Ed25519 public key (32 bytes)
+	// Trust anchor fields (ADR-013 §3, Issue #1517).
+	TrustMode        string `json:"trust_mode,omitempty"`          // "compile-baked", "install-pinned", "tofu"
+	CAPinFingerprint string `json:"ca_pin_fingerprint,omitempty"`  // SHA-256 hex of pinned CA cert (install-pinned and TOFU)
 }
 
 // saveIdentity writes id to dir/steward-identity.json with permissions 0600

--- a/cmd/steward/main.go
+++ b/cmd/steward/main.go
@@ -1063,7 +1063,7 @@ func connectWithApprovedRegistration(
 	case trustSourceTOFU:
 		if reg.CACert != "" {
 			if err := pinTOFUCA(defaultPlatformCACertPath(), reg.CACert, &persistedID); err != nil {
-				logger.Warn("TOFU CA pin failed; identity will not have fingerprint", "error", err)
+				return nil, fmt.Errorf("TOFU CA pin failed: %w", err)
 			}
 		}
 	case trustSourceInstallPinned:

--- a/cmd/steward/main.go
+++ b/cmd/steward/main.go
@@ -8,8 +8,11 @@ import (
 	"context"
 	"crypto/ed25519"
 	"crypto/sha256"
+	"crypto/x509"
 	"encoding/base64"
 	"encoding/binary"
+	"encoding/hex"
+	"encoding/pem"
 	"errors"
 	"fmt"
 	"log"
@@ -45,9 +48,131 @@ import (
 
 // ControllerURL is the controller address baked in at build time via ldflags.
 // Set during build: go build -ldflags "-X main.ControllerURL=https://ctrl.example.com"
-// No runtime override is supported — the signed binary is a trust assertion about
-// which controller it connects to.
+// For deployments where the binary is not rebuilt per controller, pass
+// --controller-url at install time (ADR-013 §3, Issue #1517).
 var ControllerURL string
+
+// TrustSource identifies the enrollment channel that established the trust anchor.
+// Higher values denote stronger assurance. A steward never silently accepts a
+// weaker source than it was built or enrolled for (ADR-013 §3, Issue #1517).
+type TrustSource int
+
+const (
+	trustSourceTOFU          TrustSource = 1 // first-registration CA pin
+	trustSourceInstallPinned TrustSource = 2 // --controller-ca at install time
+	trustSourceCompileBaked  TrustSource = 3 // URL baked via ldflags
+)
+
+func trustModeString(ts TrustSource) string {
+	switch ts {
+	case trustSourceCompileBaked:
+		return "compile-baked"
+	case trustSourceInstallPinned:
+		return "install-pinned"
+	case trustSourceTOFU:
+		return "tofu"
+	default:
+		return "unknown"
+	}
+}
+
+func trustSourceFromMode(mode string) TrustSource {
+	switch mode {
+	case "compile-baked":
+		return trustSourceCompileBaked
+	case "install-pinned":
+		return trustSourceInstallPinned
+	case "tofu":
+		return trustSourceTOFU
+	default:
+		return 0
+	}
+}
+
+// computeCAPEMFingerprint returns the SHA-256 hex fingerprint of the DER bytes
+// of the first certificate block in caPEM.
+func computeCAPEMFingerprint(caPEM string) (string, error) {
+	block, _ := pem.Decode([]byte(caPEM))
+	if block == nil {
+		return "", fmt.Errorf("no PEM block found in CA PEM")
+	}
+	if _, err := x509.ParseCertificate(block.Bytes); err != nil {
+		return "", fmt.Errorf("invalid CA certificate: %w", err)
+	}
+	sum := sha256.Sum256(block.Bytes)
+	return hex.EncodeToString(sum[:]), nil
+}
+
+// resolveTrustSource determines the effective trust level and controller URL.
+//
+// Rules (ADR-013 §3):
+//   - compile-baked: no installURL supplied — use compiledURL
+//   - install-pinned: installURL and installCA both non-empty
+//   - tofu: installURL non-empty, installCA empty
+func resolveTrustSource(compiledURL, installURL, installCA string) (TrustSource, string, error) {
+	if installURL == "" {
+		if compiledURL == "" {
+			return 0, "", fmt.Errorf("controller URL not set: binary must be built with " +
+				"-ldflags \"-X main.ControllerURL=https://your-controller.example.com\". " +
+				"See docs/deployment/ for build instructions")
+		}
+		return trustSourceCompileBaked, compiledURL, nil
+	}
+	if installCA != "" {
+		return trustSourceInstallPinned, installURL, nil
+	}
+	return trustSourceTOFU, installURL, nil
+}
+
+// checkTrustDowngrade rejects an enroll attempt that would weaken the trust
+// anchor recorded in id. Also rejects a same-level re-enroll with a different CA.
+func checkTrustDowngrade(current TrustSource, currentCAPEM string, id *StewardIdentity) error {
+	stored := trustSourceFromMode(id.TrustMode)
+	if stored == 0 {
+		return nil
+	}
+	if current < stored {
+		return fmt.Errorf("trust downgrade rejected: enrolled with %s (level %d); "+
+			"cannot re-enroll with %s (level %d) — wipe identity to change trust anchor",
+			id.TrustMode, stored, trustModeString(current), current)
+	}
+	if current >= trustSourceInstallPinned && id.CAPinFingerprint != "" && currentCAPEM != "" {
+		fp, err := computeCAPEMFingerprint(currentCAPEM)
+		if err != nil {
+			return fmt.Errorf("compute CA fingerprint for downgrade check: %w", err)
+		}
+		if fp != id.CAPinFingerprint {
+			return fmt.Errorf("already enrolled; re-pin requires wipe + re-enroll")
+		}
+	}
+	return nil
+}
+
+// pinTOFUCA pins the controller CA on first TOFU enrollment. On first call it
+// records the fingerprint in id and writes the CA to caPath at 0444 (public,
+// immutable). On subsequent calls it verifies the CA matches the pinned value.
+func pinTOFUCA(caPath, caPEM string, id *StewardIdentity) error {
+	fp, err := computeCAPEMFingerprint(caPEM)
+	if err != nil {
+		return fmt.Errorf("compute TOFU CA fingerprint: %w", err)
+	}
+	if id.CAPinFingerprint != "" {
+		if fp != id.CAPinFingerprint {
+			return fmt.Errorf("already enrolled; re-pin requires wipe + re-enroll")
+		}
+		return nil
+	}
+	id.CAPinFingerprint = fp
+	if caPath != "" {
+		if err := os.MkdirAll(filepath.Dir(caPath), 0755); err != nil {
+			return fmt.Errorf("create TOFU CA cert directory: %w", err)
+		}
+		if err := os.WriteFile(caPath, []byte(caPEM), 0444); err != nil { //#nosec G306 -- 0444 intentional: CA is public material, immutable after TOFU pin
+			return fmt.Errorf("write TOFU CA cert: %w", err)
+		}
+	}
+	return nil
+}
 
 func main() {
 	// On Windows: detect if launched by the Service Control Manager and run as
@@ -65,8 +190,9 @@ func main() {
 // buildRootCommand constructs the cobra command tree for cfgms-steward.
 func buildRootCommand() *cobra.Command {
 	var (
-		configPath string
-		regToken   string
+		configPath    string
+		regToken      string
+		controllerURL string
 	)
 
 	root := &cobra.Command{
@@ -84,13 +210,14 @@ Entry paths:
 		// SilenceUsage prevents cobra printing usage on every error.
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runRootCommand(cmd, regToken, configPath)
+			return runRootCommand(cmd, regToken, controllerURL, configPath)
 		},
 	}
 
 	// Flags used by the root command (foreground run mode).
 	root.Flags().StringVar(&configPath, "config", "", "Path to configuration file (enables standalone mode)")
 	root.Flags().StringVar(&regToken, "regtoken", "", "Registration token for controller registration")
+	root.Flags().StringVar(&controllerURL, "controller-url", "", "Controller URL (overrides compile-time URL; set at install time via service definition)")
 
 	// Subcommands.
 	root.AddCommand(
@@ -104,7 +231,7 @@ Entry paths:
 
 // runRootCommand implements the default (foreground) run behaviour.
 // When no meaningful flags are provided it enters interactive mode.
-func runRootCommand(cmd *cobra.Command, regToken, configPath string) error {
+func runRootCommand(cmd *cobra.Command, regToken, controllerURL, configPath string) error {
 	// Interactive mode: no flags set and no subcommand selected.
 	noFlags := regToken == "" && configPath == ""
 	if noFlags {
@@ -121,13 +248,13 @@ func runRootCommand(cmd *cobra.Command, regToken, configPath string) error {
 		cancel()
 	}()
 
-	return runSteward(ctx, regToken, configPath)
+	return runSteward(ctx, regToken, controllerURL, configPath)
 }
 
 // runSteward starts the steward with the given configuration and blocks until
 // ctx is cancelled. It is called from both the root cobra command and the
 // Windows service handler.
-func runSteward(ctx context.Context, regToken, configPath string) error {
+func runSteward(ctx context.Context, regToken, controllerURL, configPath string) error {
 	// Initialize global logging provider. File is the only supported provider
 	// for the steward binary. Log level is read from CFGMS_LOG_LEVEL (default INFO).
 	logDir := os.Getenv("CFGMS_LOG_DIR")
@@ -193,7 +320,21 @@ func runSteward(ctx context.Context, regToken, configPath string) error {
 			ks = nil
 		}
 
-		transportCl, err := registerAndConnect(runCtx, regToken, ks, logger)
+		// Resolve trust source using the compile-baked URL, install-time URL,
+		// and the CA cert on disk (written by the installer for install-pinned mode).
+		installCACertPath := resolveRegistrationCACertPath(logger)
+		var installCAPEM string
+		if installCACertPath != "" {
+			if caData, caErr := os.ReadFile(installCACertPath); caErr == nil { //#nosec G304 -- path from resolveRegistrationCACertPath
+				installCAPEM = string(caData)
+			}
+		}
+		trustSrc, resolvedURL, trustErr := resolveTrustSource(ControllerURL, controllerURL, installCAPEM)
+		if trustErr != nil {
+			return trustErr
+		}
+
+		transportCl, err := registerAndConnect(runCtx, regToken, resolvedURL, trustSrc, installCAPEM, ks, logger)
 		if err != nil {
 			return fmt.Errorf("failed to register with controller: %w", err)
 		}
@@ -312,7 +453,7 @@ func runSteward(ctx context.Context, regToken, configPath string) error {
 
 // buildInstallCommand builds the `cfgms-steward install` subcommand.
 func buildInstallCommand() *cobra.Command {
-	var regToken, caCertPath, fingerprint string
+	var regToken, controllerURL, caCertPath, fingerprint string
 
 	cmd := &cobra.Command{
 		Use:   "install",
@@ -328,24 +469,30 @@ Platforms:
 Requires elevated privileges (Administrator on Windows, root on Linux/macOS).
 Install is idempotent: running it again updates the binary and restarts the service.
 
-Standard form (controller certificate issued by a public CA):
+Compile-baked URL (default — binary built with -ldflags):
 
   cfgms-steward install --regtoken TOKEN
 
-Private-CA deployments (Tier 1, internal CA, lab environments):
-  Pass --ca-cert and --fingerprint for fingerprint-verified trust-on-first-use
-  (TOFU) of the controller CA certificate. The fingerprint is printed by the
-  controller during --init and can also be retrieved with:
+Install-pinned (private CA, self-hosted deployments — ADR-013 §3):
 
-    cfg admin ca fingerprint`,
+  cfgms-steward install --regtoken TOKEN \
+    --controller-url https://ctrl.example.com \
+    --controller-ca /path/to/ca.crt \
+    --fingerprint HEXFP
+
+TOFU — trust-on-first-use (lab environments):
+
+  cfgms-steward install --regtoken TOKEN \
+    --controller-url https://ctrl.example.com`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runInstall(regToken, caCertPath, fingerprint)
+			return runInstall(regToken, controllerURL, caCertPath, fingerprint)
 		},
 	}
 
 	cmd.Flags().StringVar(&regToken, "regtoken", "", "Registration token (required)")
 	_ = cmd.MarkFlagRequired("regtoken")
-	cmd.Flags().StringVar(&caCertPath, "ca-cert", "", "Path to controller CA certificate PEM file (private-CA deployments only)")
+	cmd.Flags().StringVar(&controllerURL, "controller-url", "", "Controller URL (install-pinned and TOFU modes; omit to use compile-time URL)")
+	cmd.Flags().StringVar(&caCertPath, "controller-ca", "", "Path to controller CA certificate PEM file (install-pinned mode)")
 	cmd.Flags().StringVar(&fingerprint, "fingerprint", "", "Expected SHA-256 fingerprint of the CA certificate (hex, from controller --init output)")
 
 	return cmd
@@ -385,7 +532,7 @@ func buildStatusCommand() *cobra.Command {
 }
 
 // runInstall performs the install operation for the current platform.
-func runInstall(regToken, caCertPath, fingerprint string) error {
+func runInstall(regToken, controllerURL, caCertPath, fingerprint string) error {
 	exe, err := os.Executable()
 	if err != nil {
 		return fmt.Errorf("failed to determine executable path: %w", err)
@@ -393,7 +540,7 @@ func runInstall(regToken, caCertPath, fingerprint string) error {
 
 	var caCertPEM string
 	if caCertPath != "" {
-		data, readErr := os.ReadFile(caCertPath)
+		data, readErr := os.ReadFile(caCertPath) //#nosec G304 -- path from --controller-ca flag, admin-controlled
 		if readErr != nil {
 			return fmt.Errorf("failed to read CA cert file %s: %w", caCertPath, readErr)
 		}
@@ -408,7 +555,7 @@ func runInstall(regToken, caCertPath, fingerprint string) error {
 			"  Linux/macOS: re-run with sudo")
 	}
 
-	return mgr.Install(regToken, caCertPEM, fingerprint)
+	return mgr.Install(regToken, controllerURL, caCertPEM, fingerprint)
 }
 
 // runUninstall performs the uninstall operation for the current platform.
@@ -512,7 +659,7 @@ func runInteractive() error {
 
 	switch choice {
 	case "1":
-		return runInstall(token, "", "")
+		return runInstall(token, "", "", "")
 	case "2":
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
@@ -525,7 +672,7 @@ func runInteractive() error {
 		}()
 
 		fmt.Println("Running in foreground. Press Ctrl+C to stop.")
-		return runSteward(ctx, token, "")
+		return runSteward(ctx, token, "", "")
 	case "3", "":
 		fmt.Println("Exiting.")
 		return nil
@@ -552,6 +699,17 @@ func buildHTTPConfig(controllerURL string, timeout time.Duration, logger logging
 		ControllerURL: controllerURL,
 		Timeout:       timeout,
 		CACertPath:    resolveRegistrationCACertPath(logger),
+		Logger:        logger,
+	}
+}
+
+// buildHTTPConfigForInstallPinned returns an HTTPConfig that pins the TLS CA
+// exclusively to installCAPEM with no web-PKI fallback (ADR-013 §3, Issue #1517).
+func buildHTTPConfigForInstallPinned(controllerURL string, timeout time.Duration, installCAPEM string, logger logging.Logger) *registration.HTTPConfig {
+	return &registration.HTTPConfig{
+		ControllerURL: controllerURL,
+		Timeout:       timeout,
+		CAPEM:         installCAPEM,
 		Logger:        logger,
 	}
 }
@@ -632,13 +790,23 @@ type approvedRegistration struct {
 // persists the pending_id locally and polls GET /api/v1/registration/status/{pending_id}
 // with exponential backoff (5s → 60s max) until approved, denied, or timed out.
 // On restart, the persisted pending_id is resumed rather than creating a new pending record.
-func registerAndConnect(ctx context.Context, token string, ks *identity.FileKeyStore, logger logging.Logger) (*client.TransportClient, error) {
+//
+// trustSrc and installCAPEM implement the ADR-013 §3 trust anchoring model (Issue #1517).
+// installCAPEM is non-empty only for install-pinned mode; TOFU and compile-baked pass "".
+func registerAndConnect(ctx context.Context, token, controllerURL string, trustSrc TrustSource, installCAPEM string, ks *identity.FileKeyStore, logger logging.Logger) (*client.TransportClient, error) {
 	logger.Info("Starting steward connect sequence")
 
 	certStoreDir := defaultCertStoreDir()
 
+	// Downgrade guard: reject if stored enrollment had stronger trust assurance.
+	if storedID, loadErr := loadIdentity(certStoreDir); loadErr == nil && storedID != nil {
+		if dgErr := checkTrustDowngrade(trustSrc, installCAPEM, storedID); dgErr != nil {
+			return nil, dgErr
+		}
+	}
+
 	// Attempt cert-reuse reconnect (skips HTTP registration on restart).
-	if tc, reconnErr := tryReconnectWithStoredIdentity(ctx, certStoreDir, token, logger); tc != nil {
+	if tc, reconnErr := tryReconnectWithStoredIdentity(ctx, certStoreDir, token, trustSrc, logger); tc != nil {
 		return tc, nil
 	} else if reconnErr != nil {
 		logger.Warn("Stored-identity reconnect failed; checking for expired-cert refresh path", "error", reconnErr)
@@ -655,7 +823,7 @@ func registerAndConnect(ctx context.Context, token string, ks *identity.FileKeyS
 			})
 			if certMgrErr == nil {
 				if certs, listErr := certMgr.ListCertificates(); listErr == nil && hasExpiredClientCert(certs) {
-					tc, refreshErr := refreshAndConnect(ctx, storedID, ks, certStoreDir, token, logger)
+					tc, refreshErr := refreshAndConnect(ctx, storedID, ks, certStoreDir, token, controllerURL, logger)
 					if refreshErr == nil {
 						return tc, nil
 					}
@@ -677,14 +845,13 @@ func registerAndConnect(ctx context.Context, token string, ks *identity.FileKeyS
 
 	logger.Info("Registering steward via HTTP API")
 
-	controllerURL := ControllerURL
-	if controllerURL == "" {
-		return nil, fmt.Errorf("controller URL not set: binary must be built with " +
-			"-ldflags \"-X main.ControllerURL=https://your-controller.example.com\". " +
-			"See docs/deployment/ for build instructions")
+	var httpCfg *registration.HTTPConfig
+	if trustSrc == trustSourceInstallPinned {
+		httpCfg = buildHTTPConfigForInstallPinned(controllerURL, 30*time.Second, installCAPEM, logger)
+	} else {
+		httpCfg = buildHTTPConfig(controllerURL, 30*time.Second, logger)
 	}
-
-	httpClient, err := registration.NewHTTPClient(buildHTTPConfig(controllerURL, 30*time.Second, logger))
+	httpClient, err := registration.NewHTTPClient(httpCfg)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create HTTP registration client: %w", err)
 	}
@@ -711,7 +878,7 @@ func registerAndConnect(ctx context.Context, token string, ks *identity.FileKeyS
 		if approved != nil {
 			enrichApprovedWithDeviceIdentity(approved, ks)
 			_ = clearPendingState(certStoreDir)
-			return connectWithApprovedRegistration(ctx, *approved, certStoreDir, token, logger)
+			return connectWithApprovedRegistration(ctx, *approved, certStoreDir, token, trustSrc, installCAPEM, logger)
 		}
 		// approved == nil: pending record expired (HTTP 410); fall through to fresh registration.
 		logger.Info("Persisted pending record expired on controller; performing fresh registration")
@@ -760,7 +927,7 @@ func registerAndConnect(ctx context.Context, token string, ks *identity.FileKeyS
 		}
 		enrichApprovedWithDeviceIdentity(approved, ks)
 		_ = clearPendingState(certStoreDir)
-		return connectWithApprovedRegistration(ctx, *approved, certStoreDir, token, logger)
+		return connectWithApprovedRegistration(ctx, *approved, certStoreDir, token, trustSrc, installCAPEM, logger)
 	}
 
 	// Immediate approval (HTTP 200): proceed directly to transport setup.
@@ -782,7 +949,7 @@ func registerAndConnect(ctx context.Context, token string, ks *identity.FileKeyS
 		SigningCert:      regResp.SigningCert,
 	}
 	enrichApprovedWithDeviceIdentity(&bundle, ks)
-	return connectWithApprovedRegistration(ctx, bundle, certStoreDir, token, logger)
+	return connectWithApprovedRegistration(ctx, bundle, certStoreDir, token, trustSrc, installCAPEM, logger)
 }
 
 // pollForApproval polls GET /api/v1/registration/status/{pendingID} with exponential
@@ -865,10 +1032,16 @@ func pollForApproval(
 // registration (immediate or manual-review poll), then builds and connects the
 // transport client. Shared by the immediate-approval and poll-approval paths to
 // avoid duplication.
+//
+// trustSrc and installCAPEM implement ADR-013 §3 trust anchoring (Issue #1517).
+// For TOFU mode, the CA from reg.CACert is pinned to disk before the identity
+// is saved. For install-pinned, the fingerprint of installCAPEM is recorded.
 func connectWithApprovedRegistration(
 	ctx context.Context,
 	reg approvedRegistration,
 	certStoreDir, token string,
+	trustSrc TrustSource,
+	installCAPEM string,
 	logger logging.Logger,
 ) (*client.TransportClient, error) {
 	// Persist the identity record so that a subsequent restart can reconnect
@@ -882,7 +1055,28 @@ func connectWithApprovedRegistration(
 		SigningCertPEM:   reg.SigningCert,
 		DeviceID:         reg.DeviceID,
 		IdentityKeyPub:   reg.IdentityKeyPub,
+		TrustMode:        trustModeString(trustSrc),
 	}
+
+	// Record the CA pin fingerprint for install-pinned and TOFU modes.
+	switch trustSrc {
+	case trustSourceTOFU:
+		if reg.CACert != "" {
+			if err := pinTOFUCA(defaultPlatformCACertPath(), reg.CACert, &persistedID); err != nil {
+				logger.Warn("TOFU CA pin failed; identity will not have fingerprint", "error", err)
+			}
+		}
+	case trustSourceInstallPinned:
+		if installCAPEM != "" {
+			fp, fpErr := computeCAPEMFingerprint(installCAPEM)
+			if fpErr == nil {
+				persistedID.CAPinFingerprint = fp
+			} else {
+				logger.Warn("Failed to compute install CA fingerprint; CAPinFingerprint not recorded", "error", fpErr)
+			}
+		}
+	}
+
 	if saveErr := saveIdentity(certStoreDir, persistedID); saveErr != nil {
 		logger.Warn("Failed to persist steward identity; next restart will re-register", "error", saveErr)
 	} else {
@@ -975,7 +1169,7 @@ func connectWithApprovedRegistration(
 // HTTP registration (first run or manually cleared identity).
 // Returns (nil, err) when a stored identity exists but reconnect fails — caller
 // should log the error and fall back to HTTP registration.
-func tryReconnectWithStoredIdentity(ctx context.Context, certStoreDir, token string, logger logging.Logger) (*client.TransportClient, error) {
+func tryReconnectWithStoredIdentity(ctx context.Context, certStoreDir, token string, trustSrc TrustSource, logger logging.Logger) (*client.TransportClient, error) {
 	id, err := loadIdentity(certStoreDir)
 	if err != nil {
 		// corrupt/unreadable identity: log and treat as absent so the caller falls through
@@ -984,6 +1178,17 @@ func tryReconnectWithStoredIdentity(ctx context.Context, certStoreDir, token str
 	}
 	if id == nil {
 		return nil, nil // first run; no stored identity
+	}
+
+	// Trust downgrade guard: reject reconnect if the current trust source would
+	// weaken the assurance level of the stored enrollment (ADR-013 §3, Issue #1517).
+	if id.TrustMode != "" {
+		stored := trustSourceFromMode(id.TrustMode)
+		if stored > 0 && trustSrc > 0 && trustSrc < stored {
+			return nil, fmt.Errorf("trust downgrade rejected: enrolled with %s (level %d); "+
+				"current source is %s (level %d) — wipe identity to change trust anchor",
+				id.TrustMode, stored, trustModeString(trustSrc), trustSrc)
+		}
 	}
 
 	// The reconnect path must be able to verify signed sync_config commands.
@@ -1174,10 +1379,9 @@ func refreshAndConnect(
 	ctx context.Context,
 	id *StewardIdentity,
 	ks *identity.FileKeyStore,
-	certStoreDir, token string,
+	certStoreDir, token, controllerURL string,
 	logger logging.Logger,
 ) (*client.TransportClient, error) {
-	controllerURL := ControllerURL
 	if controllerURL == "" {
 		return nil, fmt.Errorf("controller URL not set; cannot perform registration refresh")
 	}
@@ -1259,7 +1463,12 @@ func refreshAndConnect(
 		ServerCert:       updatedID.ServerCertPEM,
 	}
 	enrichApprovedWithDeviceIdentity(&bundle, ks)
-	return connectWithApprovedRegistration(ctx, bundle, certStoreDir, token, logger)
+	// Preserve the stored trust mode on refresh — the trust anchor is already established.
+	refreshTrustSrc := trustSourceFromMode(id.TrustMode)
+	if refreshTrustSrc == 0 {
+		refreshTrustSrc = trustSourceCompileBaked
+	}
+	return connectWithApprovedRegistration(ctx, bundle, certStoreDir, token, refreshTrustSrc, "", logger)
 }
 
 // buildCertManagerAndSecretStore initialises a cert.Manager (holding the

--- a/cmd/steward/main_test.go
+++ b/cmd/steward/main_test.go
@@ -747,6 +747,30 @@ func TestTOFUCAPinImmutable(t *testing.T) {
 	assert.Equal(t, certPEMA, string(got), "CA file must not be modified after rejection")
 }
 
+// TestConnectWithApprovedRegistration_TOFUPinFails_ReturnsError verifies that
+// connectWithApprovedRegistration returns a hard error and does NOT persist the
+// identity when pinTOFUCA fails in TOFU mode.  ADR-013 §3 / implementation note:
+// "on error, do not save identity, do not connect."
+func TestConnectWithApprovedRegistration_TOFUPinFails_ReturnsError(t *testing.T) {
+	dir := t.TempDir()
+	logger := logging.NewLogger("error")
+
+	reg := approvedRegistration{
+		StewardID:        "s1",
+		TenantID:         "t1",
+		TransportAddress: "https://ctrl.example.com",
+		CACert:           "not-a-valid-pem", // invalid PEM → computeCAPEMFingerprint fails → pinTOFUCA returns error
+	}
+
+	_, err := connectWithApprovedRegistration(context.Background(), reg, dir, "tok", trustSourceTOFU, "", logger)
+	require.Error(t, err, "must return a hard error when TOFU CA pin fails")
+
+	// Identity MUST NOT be saved when pinTOFUCA fails.
+	savedID, loadErr := loadIdentity(dir)
+	require.NoError(t, loadErr)
+	assert.Nil(t, savedID, "identity must not be persisted to disk when TOFU CA pin fails")
+}
+
 // TestTrustSourceDowngradeGuard verifies that checkTrustDowngrade enforces the
 // trust level ordering and CA fingerprint immutability (ADR-013 §3, Issue #1517).
 func TestTrustSourceDowngradeGuard(t *testing.T) {

--- a/cmd/steward/main_test.go
+++ b/cmd/steward/main_test.go
@@ -5,8 +5,17 @@ package main
 
 import (
 	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/sha256"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/hex"
 	"encoding/json"
+	"encoding/pem"
 	"io"
+	"math/big"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -83,31 +92,34 @@ func TestRunInstallRequiresElevation(t *testing.T) {
 	if isElevated() {
 		t.Skip("test requires non-elevated process — running as root")
 	}
-	err := runInstall("tok_test_abc123", "", "")
+	err := runInstall("tok_test_abc123", "", "", "")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "elevated privileges")
 }
 
 func TestRunInstallCACertFileNotFound(t *testing.T) {
-	// Verify runInstall returns an error that includes the filename when --ca-cert
+	// Verify runInstall returns an error that includes the filename when --controller-ca
 	// names a path that does not exist.
 	missing := filepath.Join(t.TempDir(), "nonexistent-ca.crt")
-	err := runInstall("tok_test_abc123", missing, "")
+	err := runInstall("tok_test_abc123", "", missing, "")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "nonexistent-ca.crt")
 }
 
 // TestInstallCommandFlagSurface asserts the install subcommand's flag set is
-// exactly {--regtoken, --ca-cert, --fingerprint}. All Hyper-V-specific flags
-// were removed in Issue #1894; no role-specific flags belong on the install command.
+// exactly {--regtoken, --controller-url, --controller-ca, --fingerprint}.
+// All Hyper-V-specific flags were removed in Issue #1894; no role-specific
+// flags belong on the install command. --ca-cert was renamed to --controller-ca
+// (ADR-013 §3, Issue #1517).
 func TestInstallCommandFlagSurface(t *testing.T) {
 	cmd := buildInstallCommand()
 	require.NotNil(t, cmd)
 
 	expected := map[string]bool{
-		"regtoken":    true,
-		"ca-cert":     true,
-		"fingerprint": true,
+		"regtoken":       true,
+		"controller-url": true,
+		"controller-ca":  true,
+		"fingerprint":    true,
 	}
 
 	var flagNames []string
@@ -117,14 +129,14 @@ func TestInstallCommandFlagSurface(t *testing.T) {
 
 	for _, name := range flagNames {
 		assert.True(t, expected[name],
-			"unexpected flag %q on install subcommand — install accepts only --regtoken, --ca-cert, --fingerprint", name)
+			"unexpected flag %q on install subcommand — install accepts only --regtoken, --controller-url, --controller-ca, --fingerprint", name)
 	}
 	for name := range expected {
 		assert.NotNil(t, cmd.Flags().Lookup(name),
 			"required flag %q must be registered on install subcommand", name)
 	}
 	assert.Len(t, flagNames, len(expected),
-		"install command must have exactly %d flags: --regtoken, --ca-cert, --fingerprint", len(expected))
+		"install command must have exactly %d flags: --regtoken, --controller-url, --controller-ca, --fingerprint", len(expected))
 }
 
 func TestRunUninstallRequiresElevation(t *testing.T) {
@@ -212,7 +224,7 @@ func TestTryReconnectWithStoredIdentity_NoStoredIdentity_FallsThrough(t *testing
 	// No identity file on disk — first run. The function returns (nil, nil) so
 	// the caller falls through to HTTP registration without logging an error.
 	dir := t.TempDir()
-	tc, err := tryReconnectWithStoredIdentity(context.Background(), dir, "token", logging.NewLogger("error"))
+	tc, err := tryReconnectWithStoredIdentity(context.Background(), dir, "token", trustSourceCompileBaked, logging.NewLogger("error"))
 	assert.Nil(t, tc)
 	assert.NoError(t, err)
 }
@@ -230,7 +242,7 @@ func TestTryReconnectWithStoredIdentity_MissingServerCert_RejectsAndFallsBack(t 
 		CACertPEM:        "-----BEGIN CERTIFICATE-----\nca\n-----END CERTIFICATE-----",
 	}))
 
-	tc, err := tryReconnectWithStoredIdentity(context.Background(), dir, "token", logging.NewLogger("error"))
+	tc, err := tryReconnectWithStoredIdentity(context.Background(), dir, "token", trustSourceCompileBaked, logging.NewLogger("error"))
 	assert.Nil(t, tc)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "missing controller server/signing certificate")
@@ -243,9 +255,30 @@ func TestTryReconnectWithStoredIdentity_CorruptIdentity_FallsThrough(t *testing.
 	dir := t.TempDir()
 	require.NoError(t, os.WriteFile(filepath.Join(dir, identityFileName), []byte("{not json"), 0600))
 
-	tc, err := tryReconnectWithStoredIdentity(context.Background(), dir, "token", logging.NewLogger("error"))
+	tc, err := tryReconnectWithStoredIdentity(context.Background(), dir, "token", trustSourceCompileBaked, logging.NewLogger("error"))
 	assert.Nil(t, tc)
 	assert.NoError(t, err)
+}
+
+func TestTryReconnectWithStoredIdentity_TrustDowngrade_ReturnsError(t *testing.T) {
+	// An identity enrolled with install-pinned (level 2) must not be reconnected
+	// with a TOFU source (level 1) — that would silently weaken the trust anchor.
+	// The downgrade guard at tryReconnectWithStoredIdentity:1177-1184 must fire
+	// and return a non-nil error so the caller does not proceed with the connection.
+	dir := t.TempDir()
+	require.NoError(t, saveIdentity(dir, StewardIdentity{
+		StewardID:        "steward-pinned",
+		TenantID:         "tenant-1",
+		TransportAddress: "controller:4433",
+		TrustMode:        "install-pinned",
+		CACertPEM:        "-----BEGIN CERTIFICATE-----\nca\n-----END CERTIFICATE-----",
+		ServerCertPEM:    "-----BEGIN CERTIFICATE-----\nserver\n-----END CERTIFICATE-----",
+	}))
+
+	tc, err := tryReconnectWithStoredIdentity(context.Background(), dir, "token", trustSourceTOFU, logging.NewLogger("error"))
+	assert.Nil(t, tc)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "trust downgrade rejected")
 }
 
 func TestControllerURLOrUnknown(t *testing.T) {
@@ -296,7 +329,7 @@ func TestStandaloneStartErrorPropagatesToRunSteward(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	err := runSteward(ctx, "", "/nonexistent/cfgms-config-does-not-exist.yaml")
+	err := runSteward(ctx, "", "", "/nonexistent/cfgms-config-does-not-exist.yaml")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to create standalone steward")
 }
@@ -488,11 +521,6 @@ func TestRefreshAndConnect_202_ReturnsErrRefreshPending(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	// Temporarily point ControllerURL at the test server.
-	origURL := ControllerURL
-	ControllerURL = srv.URL
-	t.Cleanup(func() { ControllerURL = origURL })
-
 	storedID := &StewardIdentity{
 		StewardID:        "steward-refresh-test",
 		TenantID:         "tenant-1",
@@ -501,7 +529,7 @@ func TestRefreshAndConnect_202_ReturnsErrRefreshPending(t *testing.T) {
 		ServerCertPEM:    "fake-server",
 	}
 
-	_, err = refreshAndConnect(context.Background(), storedID, ks, dir, "tok", logging.NewLogger("error"))
+	_, err = refreshAndConnect(context.Background(), storedID, ks, dir, "tok", srv.URL, logging.NewLogger("error"))
 	require.ErrorIs(t, err, registration.ErrRefreshPending,
 		"HTTP 202 from refresh/complete must return ErrRefreshPending, not a fatal error")
 }
@@ -547,10 +575,6 @@ func TestRefreshAndConnect_SuccessPathPersistsDeviceIdentity(t *testing.T) {
 	defer srv.Close()
 	srvURL = srv.URL
 
-	origURL := ControllerURL
-	ControllerURL = srv.URL
-	t.Cleanup(func() { ControllerURL = origURL })
-
 	storedID := &StewardIdentity{
 		StewardID:        "steward-refresh-test",
 		TenantID:         "tenant-1",
@@ -561,7 +585,7 @@ func TestRefreshAndConnect_SuccessPathPersistsDeviceIdentity(t *testing.T) {
 
 	// refreshAndConnect will fail at connectWithApprovedRegistration (no real transport),
 	// but saveIdentity is invoked before the transport attempt so the identity file is written.
-	_, _ = refreshAndConnect(context.Background(), storedID, ks, dir, "tok", logging.NewLogger("error"))
+	_, _ = refreshAndConnect(context.Background(), storedID, ks, dir, "tok", srv.URL, logging.NewLogger("error"))
 
 	// The identity file saved by connectWithApprovedRegistration must carry the
 	// DeviceID and IdentityKeyPub from the key store.  An empty DeviceID here
@@ -605,4 +629,203 @@ func TestPollForApproval_BackoffIntervalGrows(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, result)
 	assert.Equal(t, "CERT", result.ClientCert)
+}
+
+// generateMainTestCACert generates a self-signed ECDSA CA cert for use in main_test.go.
+// Returns the PEM-encoded cert string and its SHA-256 fingerprint as lowercase hex.
+func generateMainTestCACert(t *testing.T) (certPEM, fingerprint string) {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	template := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{Organization: []string{"CFGMS Main Test CA"}},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(24 * time.Hour),
+		IsCA:                  true,
+		KeyUsage:              x509.KeyUsageCertSign,
+		BasicConstraintsValid: true,
+	}
+
+	certDER, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+	require.NoError(t, err)
+
+	hash := sha256.Sum256(certDER)
+	fingerprint = hex.EncodeToString(hash[:])
+	certPEM = string(pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER}))
+	return
+}
+
+// TestResolveTrustSource verifies the trust-source resolution rules from ADR-013 §3.
+func TestResolveTrustSource(t *testing.T) {
+	cases := []struct {
+		name        string
+		compiledURL string
+		installURL  string
+		installCA   string
+		wantSrc     TrustSource
+		wantURL     string
+		wantErr     bool
+	}{
+		{
+			name: "no URLs at all → error",
+		},
+		{
+			name:        "compile-baked: only compiledURL set",
+			compiledURL: "https://baked.example.com",
+			wantSrc:     trustSourceCompileBaked,
+			wantURL:     "https://baked.example.com",
+		},
+		{
+			name:        "dev flow regression: compiledURL set, no installURL → compile-baked",
+			compiledURL: "https://baked.example.com", installURL: "", installCA: "",
+			wantSrc: trustSourceCompileBaked, wantURL: "https://baked.example.com",
+		},
+		{
+			name:        "install-pinned: installURL + installCA both set",
+			compiledURL: "https://baked.example.com", installURL: "https://install.example.com", installCA: "ca.pem",
+			wantSrc: trustSourceInstallPinned, wantURL: "https://install.example.com",
+		},
+		{
+			name:        "tofu: installURL set but no CA",
+			compiledURL: "", installURL: "https://tofu.example.com",
+			wantSrc: trustSourceTOFU, wantURL: "https://tofu.example.com",
+		},
+		{
+			name:        "tofu: installURL set, compiledURL also set, no CA",
+			compiledURL: "https://baked.example.com", installURL: "https://tofu.example.com",
+			wantSrc: trustSourceTOFU, wantURL: "https://tofu.example.com",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			src, url, err := resolveTrustSource(tc.compiledURL, tc.installURL, tc.installCA)
+			if tc.wantErr || (tc.compiledURL == "" && tc.installURL == "") {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.wantSrc, src)
+			assert.Equal(t, tc.wantURL, url)
+		})
+	}
+}
+
+// TestTOFUCAPinImmutable verifies that pinTOFUCA pins the CA on first enroll and
+// rejects a different CA on re-enroll (ADR-013 §3, Issue #1517).
+func TestTOFUCAPinImmutable(t *testing.T) {
+	certPEMA, fingerprintA := generateMainTestCACert(t)
+	certPEMB, _ := generateMainTestCACert(t)
+
+	dir := t.TempDir()
+	caPath := filepath.Join(dir, "etc", "cfgms", "controller-ca.crt")
+
+	// First enrollment: pin CA A and record fingerprint.
+	id1 := &StewardIdentity{}
+	require.NoError(t, pinTOFUCA(caPath, certPEMA, id1))
+	assert.Equal(t, fingerprintA, id1.CAPinFingerprint, "fingerprint must be recorded on first pin")
+
+	// CA file must be written at 0444 (public, immutable).
+	info, err := os.Stat(caPath)
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0444), info.Mode().Perm(), "CA cert must be written with mode 0444 after TOFU pin")
+
+	// Second call with same CA A: must succeed (fingerprint matches).
+	id2 := &StewardIdentity{CAPinFingerprint: id1.CAPinFingerprint}
+	require.NoError(t, pinTOFUCA(caPath, certPEMA, id2))
+
+	// Second call with different CA B: must be rejected.
+	id3 := &StewardIdentity{CAPinFingerprint: id1.CAPinFingerprint}
+	err = pinTOFUCA(caPath, certPEMB, id3)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "re-pin requires wipe + re-enroll")
+
+	// CA file must be unchanged after rejection.
+	got, readErr := os.ReadFile(caPath)
+	require.NoError(t, readErr)
+	assert.Equal(t, certPEMA, string(got), "CA file must not be modified after rejection")
+}
+
+// TestTrustSourceDowngradeGuard verifies that checkTrustDowngrade enforces the
+// trust level ordering and CA fingerprint immutability (ADR-013 §3, Issue #1517).
+func TestTrustSourceDowngradeGuard(t *testing.T) {
+	certPEM, fingerprint := generateMainTestCACert(t)
+	certPEM2, _ := generateMainTestCACert(t)
+
+	t.Run("no prior enrollment allows any source", func(t *testing.T) {
+		id := &StewardIdentity{}
+		require.NoError(t, checkTrustDowngrade(trustSourceTOFU, "", id))
+		require.NoError(t, checkTrustDowngrade(trustSourceCompileBaked, "", id))
+	})
+
+	t.Run("downgrade from install-pinned to tofu rejected", func(t *testing.T) {
+		id := &StewardIdentity{TrustMode: "install-pinned", CAPinFingerprint: fingerprint}
+		err := checkTrustDowngrade(trustSourceTOFU, "", id)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "trust downgrade rejected")
+	})
+
+	t.Run("downgrade from compile-baked to install-pinned rejected", func(t *testing.T) {
+		id := &StewardIdentity{TrustMode: "compile-baked"}
+		err := checkTrustDowngrade(trustSourceInstallPinned, certPEM, id)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "trust downgrade rejected")
+	})
+
+	t.Run("same-level install-pinned with different CA rejected", func(t *testing.T) {
+		id := &StewardIdentity{TrustMode: "install-pinned", CAPinFingerprint: fingerprint}
+		err := checkTrustDowngrade(trustSourceInstallPinned, certPEM2, id)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "re-pin requires wipe + re-enroll")
+	})
+
+	t.Run("same-level install-pinned with matching CA allowed", func(t *testing.T) {
+		id := &StewardIdentity{TrustMode: "install-pinned", CAPinFingerprint: fingerprint}
+		require.NoError(t, checkTrustDowngrade(trustSourceInstallPinned, certPEM, id))
+	})
+
+	t.Run("upgrade from tofu to install-pinned allowed", func(t *testing.T) {
+		id := &StewardIdentity{TrustMode: "tofu", CAPinFingerprint: fingerprint}
+		require.NoError(t, checkTrustDowngrade(trustSourceInstallPinned, "", id))
+	})
+}
+
+// TestRegistrationUsesPinnedCAInPinnedMode verifies that buildHTTPConfigForInstallPinned
+// produces a client that exclusively uses the pinned CA and rejects connections to
+// servers whose cert is not signed by that CA (ADR-013 §3, Issue #1517).
+func TestRegistrationUsesPinnedCAInPinnedMode(t *testing.T) {
+	logger := logging.NewLogger("error")
+
+	// Use httptest.NewTLSServer which uses Go's built-in test CA.
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer srv.Close()
+
+	// Extract the server's own TLS certificate to use as the pinned CA.
+	serverCertDER := srv.TLS.Certificates[0].Certificate[0]
+	serverCertPEM := string(pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: serverCertDER}))
+
+	// With the correct server cert as pinned CA: NewHTTPClient must succeed.
+	correctCfg := buildHTTPConfigForInstallPinned(srv.URL, 5*time.Second, serverCertPEM, logger)
+	_, createErr := registration.NewHTTPClient(correctCfg)
+	require.NoError(t, createErr, "NewHTTPClient with matching pinned CA must not error")
+
+	// With a different CA (wrong): the TLS connection must be rejected.
+	wrongCAPEM, _ := generateMainTestCACert(t)
+	wrongCfg := buildHTTPConfigForInstallPinned(srv.URL, 5*time.Second, wrongCAPEM, logger)
+	httpCl, createErr2 := registration.NewHTTPClient(wrongCfg)
+	require.NoError(t, createErr2, "NewHTTPClient itself must not error — TLS error happens at dial time")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	_, _, reqErr := httpCl.Register(ctx, registration.RegistrationRequest{Token: "tok_pintest"})
+	require.Error(t, reqErr, "request to server with wrong pinned CA must fail")
+	errStr := reqErr.Error()
+	isTLSError := strings.Contains(errStr, "certificate") ||
+		strings.Contains(errStr, "tls") ||
+		strings.Contains(errStr, "x509")
+	assert.True(t, isTLSError, "error must be TLS/cert related, got: %v", reqErr)
 }

--- a/cmd/steward/service/cert.go
+++ b/cmd/steward/service/cert.go
@@ -36,11 +36,12 @@ func verifyCACertFingerprint(caCertPEM, expectedFingerprint string) error {
 	return nil
 }
 
-// writeCACert writes caCertPEM to destPath with mode 0644, creating any missing
-// parent directories. The CA cert is public material — 0644 is intentional.
+// writeCACert writes caCertPEM to destPath with mode 0444, creating any missing
+// parent directories. ADR-013 §3: the pinned CA is public material; 0444 (immutable
+// to non-root) makes it tamper-evident without hiding it.
 func writeCACert(caCertPEM, destPath string) error {
 	if err := os.MkdirAll(filepath.Dir(destPath), 0755); err != nil { // #nosec G301 -- /etc/cfgms must be world-readable; CA cert is public material
 		return fmt.Errorf("failed to create CA cert directory: %w", err)
 	}
-	return os.WriteFile(destPath, []byte(caCertPEM), 0644) // #nosec G306 -- CA cert is public material
+	return os.WriteFile(destPath, []byte(caCertPEM), 0444) // #nosec G306 -- CA cert is public material; 0444 per ADR-013 §3
 }

--- a/cmd/steward/service/cert_test.go
+++ b/cmd/steward/service/cert_test.go
@@ -85,7 +85,7 @@ func TestWriteCACertMode(t *testing.T) {
 
 	info, err := os.Stat(destPath)
 	require.NoError(t, err)
-	assert.Equal(t, os.FileMode(0644), info.Mode().Perm())
+	assert.Equal(t, os.FileMode(0444), info.Mode().Perm())
 }
 
 func TestWriteCACertContent(t *testing.T) {

--- a/cmd/steward/service/manager.go
+++ b/cmd/steward/service/manager.go
@@ -32,11 +32,15 @@ type Manager interface {
 	// binary replaced, and the service restarted.
 	// Requires elevated privileges (root on Linux/macOS, Administrator on Windows).
 	//
+	// When controllerURL is non-empty, it is embedded in the service definition
+	// (ExecStart/launchd args/CreateService args) as --controller-url so the
+	// steward connects to the specified URL on startup (ADR-013 §3, Issue #1517).
+	//
 	// When caCertPEM is non-empty, Install writes the CA cert to the platform-standard
 	// path before registering the service. When expectedFingerprint is also non-empty,
 	// the cert's SHA-256 fingerprint is verified first and Install returns an error
 	// without writing the cert or registering the service if it does not match.
-	Install(token, caCertPEM, expectedFingerprint string) error
+	Install(token, controllerURL, caCertPEM, expectedFingerprint string) error
 
 	// Uninstall stops and removes the OS service definition.
 	// If purge is true the installed binary is also deleted.

--- a/cmd/steward/service/manager_darwin.go
+++ b/cmd/steward/service/manager_darwin.go
@@ -45,11 +45,12 @@ func (m *darwinManager) IsElevated() bool {
 // loads it via launchctl. If already installed, the existing daemon is unloaded
 // first, the binary replaced, then reloaded.
 //
-// If caCertPEM is non-empty, the CA cert is written to the platform-standard
-// path before the daemon is loaded. When expectedFingerprint is also non-empty,
-// fingerprint verification runs first — a mismatch returns an error without any
-// disk writes or service changes.
-func (m *darwinManager) Install(token, caCertPEM, expectedFingerprint string) error {
+// When controllerURL is non-empty, it is embedded in ProgramArguments as
+// --controller-url. If caCertPEM is non-empty, the CA cert is written to the
+// platform-standard path before the daemon is loaded. When expectedFingerprint is
+// also non-empty, fingerprint verification runs first — a mismatch returns an
+// error without any disk writes or service changes.
+func (m *darwinManager) Install(token, controllerURL, caCertPEM, expectedFingerprint string) error {
 	if err := validateToken(token); err != nil {
 		return err
 	}
@@ -84,7 +85,7 @@ func (m *darwinManager) Install(token, caCertPEM, expectedFingerprint string) er
 	}
 
 	fmt.Println("Writing launchd plist...")
-	plist := generateLaunchdPlist(token)
+	plist := generateLaunchdPlist(token, controllerURL)
 	if err := os.WriteFile(darwinPlistPath, []byte(plist), 0644); err != nil {
 		return fmt.Errorf("failed to write plist %s: %w", darwinPlistPath, err)
 	}
@@ -156,12 +157,19 @@ func (m *darwinManager) Status() (*ServiceStatus, error) {
 }
 
 // generateLaunchdPlist returns a macOS launchd plist for the steward daemon.
+// When controllerURL is non-empty, --controller-url is added to ProgramArguments.
 // KeepAlive ensures the daemon restarts on exit; RunAtLoad starts it immediately.
 //
 // Security note: the token appears in the plist (readable by root only for
 // LaunchDaemons). The token is a one-time registration credential — after
 // first registration the steward authenticates via mTLS certificates.
-func generateLaunchdPlist(token string) string {
+func generateLaunchdPlist(token, controllerURL string) string {
+	urlArgs := ""
+	if controllerURL != "" {
+		urlArgs = fmt.Sprintf(`
+    <string>--controller-url</string>
+    <string>%s</string>`, controllerURL)
+	}
 	return fmt.Sprintf(`<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
   "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
@@ -173,7 +181,7 @@ func generateLaunchdPlist(token string) string {
   <array>
     <string>%s</string>
     <string>--regtoken</string>
-    <string>%s</string>
+    <string>%s</string>%s
   </array>
   <key>RunAtLoad</key>
   <true/>
@@ -185,6 +193,6 @@ func generateLaunchdPlist(token string) string {
   <string>/var/log/cfgms-steward.log</string>
 </dict>
 </plist>
-`, darwinServiceName, darwinInstallPath, token)
+`, darwinServiceName, darwinInstallPath, token, urlArgs)
 }
 

--- a/cmd/steward/service/manager_darwin_test.go
+++ b/cmd/steward/service/manager_darwin_test.go
@@ -40,11 +40,9 @@ func TestDarwinManagerInstallRequiresElevation(t *testing.T) {
 
 // TestDarwinInstallFingerprintMismatch verifies that a mismatched CA fingerprint causes
 // Install to return an error before writing the cert or registering the daemon.
-// Runs without root because fingerprint verification is checked before the elevation gate.
+// verifyCACertFingerprint is called before IsElevated(), so the error is returned
+// regardless of whether the caller is root.
 func TestDarwinInstallFingerprintMismatch(t *testing.T) {
-	if os.Getuid() == 0 {
-		t.Skip("skipping — running as root would proceed past fingerprint check to service ops")
-	}
 	dir := t.TempDir()
 	t.Setenv("CFGMS_INSTALL_PREFIX", dir)
 
@@ -61,7 +59,7 @@ func TestDarwinInstallFingerprintMismatch(t *testing.T) {
 }
 
 // TestDarwinInstallCACertWritten verifies that the CA cert is written to the prefixed
-// platform path with mode 0644 when a correct fingerprint is provided.
+// platform path with mode 0444 when a correct fingerprint is provided (ADR-013 §3).
 func TestDarwinInstallCACertWritten(t *testing.T) {
 	dir := t.TempDir()
 	certPEM, fingerprint := generateTestCACert(t)
@@ -73,7 +71,7 @@ func TestDarwinInstallCACertWritten(t *testing.T) {
 
 	info, err := os.Stat(destPath)
 	require.NoError(t, err)
-	assert.Equal(t, os.FileMode(0644), info.Mode().Perm(), "CA cert must be written with mode 0644")
+	assert.Equal(t, os.FileMode(0444), info.Mode().Perm(), "CA cert must be written with mode 0444 per ADR-013 §3")
 }
 
 func TestDarwinManagerUninstallRequiresElevation(t *testing.T) {

--- a/cmd/steward/service/manager_darwin_test.go
+++ b/cmd/steward/service/manager_darwin_test.go
@@ -33,7 +33,7 @@ func TestDarwinManagerInstallRequiresElevation(t *testing.T) {
 		t.Skip("skipping elevation check — running as root")
 	}
 	m := New("/usr/local/bin/cfgms-steward")
-	err := m.Install("tok_test123", "", "")
+	err := m.Install("tok_test123", "", "", "")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "root")
 }
@@ -50,7 +50,7 @@ func TestDarwinInstallFingerprintMismatch(t *testing.T) {
 
 	certPEM, _ := generateTestCACert(t)
 	m := New("/usr/local/bin/cfgms-steward")
-	err := m.Install("tok_test123", certPEM, "deadbeefdeadbeefdeadbeef")
+	err := m.Install("tok_test123", "", certPEM, "deadbeefdeadbeefdeadbeef")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "fingerprint mismatch")
 
@@ -100,7 +100,7 @@ func TestDarwinManagerStatusNotInstalled(t *testing.T) {
 
 func TestGenerateLaunchdPlist(t *testing.T) {
 	token := "tok_plist_test_abc123"
-	plist := generateLaunchdPlist(token)
+	plist := generateLaunchdPlist(token, "")
 
 	assert.Contains(t, plist, "<?xml")
 	assert.Contains(t, plist, darwinServiceName)
@@ -110,6 +110,8 @@ func TestGenerateLaunchdPlist(t *testing.T) {
 	assert.Contains(t, plist, "<key>KeepAlive</key>")
 	assert.Contains(t, plist, "<key>RunAtLoad</key>")
 	assert.Contains(t, plist, "<true/>")
+	// Without URL: --controller-url must not appear.
+	assert.NotContains(t, plist, "--controller-url")
 
 	// Token appears exactly once (no duplication).
 	count := strings.Count(plist, token)
@@ -117,9 +119,23 @@ func TestGenerateLaunchdPlist(t *testing.T) {
 }
 
 func TestGenerateLaunchdPlistKeepAliveRequired(t *testing.T) {
-	plist := generateLaunchdPlist("tok_test")
+	plist := generateLaunchdPlist("tok_test", "")
 	assert.Contains(t, plist, "<key>KeepAlive</key>", "KeepAlive required by acceptance criteria")
 	assert.Contains(t, plist, "<key>RunAtLoad</key>", "RunAtLoad required by acceptance criteria")
+}
+
+func TestGenerateLaunchdPlistWithControllerURL(t *testing.T) {
+	token := "tok_url_test"
+	controllerURL := "https://ctrl.example.com"
+	plist := generateLaunchdPlist(token, controllerURL)
+
+	assert.Contains(t, plist, "--controller-url")
+	assert.Contains(t, plist, controllerURL)
+	assert.Contains(t, plist, "--regtoken")
+	assert.Contains(t, plist, token)
+	// Token and URL each appear exactly once.
+	assert.Equal(t, 1, strings.Count(plist, token), "token should appear exactly once")
+	assert.Equal(t, 1, strings.Count(plist, controllerURL), "controller URL should appear exactly once")
 }
 
 func TestDarwinManagerNew(t *testing.T) {

--- a/cmd/steward/service/manager_linux.go
+++ b/cmd/steward/service/manager_linux.go
@@ -45,11 +45,12 @@ func (m *linuxManager) IsElevated() bool {
 // enables/starts the service. Running Install on an already-installed service
 // stops it first, replaces the binary, then restarts.
 //
+// When controllerURL is non-empty, it is embedded in ExecStart as --controller-url.
 // If caCertPEM is non-empty, the CA cert is written to the platform-standard
 // path before the service is registered. When expectedFingerprint is also
 // non-empty, fingerprint verification runs first — a mismatch returns an error
 // without any disk writes or service changes.
-func (m *linuxManager) Install(token, caCertPEM, expectedFingerprint string) error {
+func (m *linuxManager) Install(token, controllerURL, caCertPEM, expectedFingerprint string) error {
 	if err := validateToken(token); err != nil {
 		return err
 	}
@@ -81,7 +82,7 @@ func (m *linuxManager) Install(token, caCertPEM, expectedFingerprint string) err
 	}
 
 	fmt.Println("Writing systemd unit...")
-	unit := generateSystemdUnit(token)
+	unit := generateSystemdUnit(token, controllerURL)
 	if err := writeSystemdUnit(linuxSystemdUnit, []byte(unit)); err != nil {
 		return fmt.Errorf("failed to write systemd unit %s: %w", linuxSystemdUnit, err)
 	}
@@ -171,13 +172,18 @@ func writeSystemdUnit(path string, content []byte) error {
 }
 
 // generateSystemdUnit returns a systemd unit that runs cfgms-steward with the
-// given registration token. Restart=always and RestartSec=10 ensure the steward
-// recovers from transient failures.
+// given registration token. When controllerURL is non-empty, --controller-url is
+// appended to ExecStart so the steward connects to the specified controller.
+// Restart=always and RestartSec=10 ensure the steward recovers from transient failures.
 //
 // Security note: the token appears in the unit file (readable by root). This
 // mirrors the behaviour of --regtoken in ps output. The token is a one-time
 // registration credential — after registration the steward uses mTLS certs.
-func generateSystemdUnit(token string) string {
+func generateSystemdUnit(token, controllerURL string) string {
+	execStart := fmt.Sprintf(`%s --regtoken "%s"`, linuxInstallPath, token)
+	if controllerURL != "" {
+		execStart += fmt.Sprintf(` --controller-url "%s"`, controllerURL)
+	}
 	return fmt.Sprintf(`[Unit]
 Description=CFGMS Steward
 Documentation=https://docs.cfg.is/steward
@@ -186,7 +192,7 @@ Wants=network-online.target
 
 [Service]
 Type=simple
-ExecStart=%s --regtoken "%s"
+ExecStart=%s
 Restart=always
 RestartSec=10
 StandardOutput=journal
@@ -195,5 +201,5 @@ SyslogIdentifier=cfgms-steward
 
 [Install]
 WantedBy=multi-user.target
-`, linuxInstallPath, token)
+`, execStart)
 }

--- a/cmd/steward/service/manager_linux_test.go
+++ b/cmd/steward/service/manager_linux_test.go
@@ -26,7 +26,7 @@ func TestLinuxInstallFingerprintMismatch(t *testing.T) {
 
 	certPEM, _ := generateTestCACert(t)
 	m := New("/usr/bin/cfgms-steward")
-	err := m.Install("tok_test123", certPEM, "deadbeefdeadbeefdeadbeef")
+	err := m.Install("tok_test123", "", certPEM, "deadbeefdeadbeefdeadbeef")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "fingerprint mismatch")
 
@@ -37,7 +37,7 @@ func TestLinuxInstallFingerprintMismatch(t *testing.T) {
 }
 
 // TestLinuxInstallCACertWritten verifies that the CA cert is written to the prefixed
-// platform path with mode 0644 when a correct fingerprint is provided.
+// platform path with mode 0444 (ADR-013 §3: immutable to non-root, tamper-evident).
 func TestLinuxInstallCACertWritten(t *testing.T) {
 	dir := t.TempDir()
 	certPEM, fingerprint := generateTestCACert(t)
@@ -51,7 +51,7 @@ func TestLinuxInstallCACertWritten(t *testing.T) {
 
 	info, err := os.Stat(destPath)
 	require.NoError(t, err)
-	assert.Equal(t, os.FileMode(0644), info.Mode().Perm(), "CA cert must be written with mode 0644")
+	assert.Equal(t, os.FileMode(0444), info.Mode().Perm(), "CA cert must be written with mode 0444 per ADR-013 §3")
 }
 
 func TestLinuxManagerIsElevated(t *testing.T) {
@@ -67,7 +67,7 @@ func TestLinuxManagerInstallRequiresElevation(t *testing.T) {
 		t.Skip("skipping elevation check — running as root")
 	}
 	m := New("/usr/bin/cfgms-steward")
-	err := m.Install("tok_test123", "", "")
+	err := m.Install("tok_test123", "", "", "")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "root")
 }
@@ -99,7 +99,7 @@ func TestLinuxManagerStatusNotInstalled(t *testing.T) {
 
 func TestGenerateSystemdUnit(t *testing.T) {
 	token := "tok_unit_test_abc123"
-	unit := generateSystemdUnit(token)
+	unit := generateSystemdUnit(token, "")
 
 	assert.Contains(t, unit, "[Unit]")
 	assert.Contains(t, unit, "[Service]")
@@ -116,9 +116,29 @@ func TestGenerateSystemdUnit(t *testing.T) {
 }
 
 func TestGenerateSystemdUnitContainsRestartPolicy(t *testing.T) {
-	unit := generateSystemdUnit("tok_test")
+	unit := generateSystemdUnit("tok_test", "")
 	assert.Contains(t, unit, "Restart=always", "Restart=always required by acceptance criteria")
 	assert.Contains(t, unit, "RestartSec=10", "RestartSec=10 required by acceptance criteria")
+}
+
+// TestGenerateSystemdUnitWithControllerURL verifies that generateSystemdUnit embeds
+// --controller-url in ExecStart when a non-empty URL is provided (ADR-013 §3, Issue #1517).
+func TestGenerateSystemdUnitWithControllerURL(t *testing.T) {
+	token := "tok_test_url"
+	controllerURL := "https://ctrl.example.com"
+	unit := generateSystemdUnit(token, controllerURL)
+
+	assert.Contains(t, unit, `--controller-url "`+controllerURL+`"`)
+	assert.Contains(t, unit, `--regtoken "`+token+`"`)
+	assert.Contains(t, unit, linuxInstallPath)
+
+	// Verify token and URL each appear exactly once.
+	assert.Equal(t, 1, strings.Count(unit, token), "token should appear exactly once")
+	assert.Equal(t, 1, strings.Count(unit, controllerURL), "controller URL should appear exactly once")
+
+	// Without URL: --controller-url must not appear.
+	unitNoURL := generateSystemdUnit(token, "")
+	assert.NotContains(t, unitNoURL, "--controller-url")
 }
 
 func TestCopyBinaryPermissions(t *testing.T) {
@@ -136,7 +156,7 @@ func TestCopyBinaryPermissions(t *testing.T) {
 
 func TestSystemdUnitFilePermissions(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "cfgms-steward.service")
-	content := generateSystemdUnit("tok_test")
+	content := generateSystemdUnit("tok_test", "")
 	require.NoError(t, writeSystemdUnit(path, []byte(content)))
 
 	info, err := os.Stat(path)

--- a/cmd/steward/service/manager_stub.go
+++ b/cmd/steward/service/manager_stub.go
@@ -18,7 +18,7 @@ type stubManager struct{}
 
 func (m *stubManager) IsElevated() bool { return false }
 
-func (m *stubManager) Install(token, caCertPEM, expectedFingerprint string) error {
+func (m *stubManager) Install(token, controllerURL, caCertPEM, expectedFingerprint string) error {
 	return fmt.Errorf("service install is not supported on %s", runtime.GOOS)
 }
 

--- a/cmd/steward/service/manager_windows.go
+++ b/cmd/steward/service/manager_windows.go
@@ -67,11 +67,13 @@ func (m *windowsManager) IsElevated() bool {
 // Uses the native Windows Service API via golang.org/x/sys/windows/svc/mgr.
 // Does NOT shell out to sc.exe.
 //
+// When controllerURL is non-empty, --controller-url is passed to CreateService
+// args so the steward connects to the specified controller on start.
 // If caCertPEM is non-empty, the CA cert is written to the platform-standard
 // path before the service is started. When expectedFingerprint is also non-empty,
 // fingerprint verification runs first — a mismatch returns an error without any
 // disk writes or service changes.
-func (m *windowsManager) Install(token, caCertPEM, expectedFingerprint string) error {
+func (m *windowsManager) Install(token, controllerURL, caCertPEM, expectedFingerprint string) error {
 	if err := validateToken(token); err != nil {
 		return err
 	}
@@ -125,6 +127,12 @@ func (m *windowsManager) Install(token, caCertPEM, expectedFingerprint string) e
 		}
 	}
 
+	// Build service start arguments; --controller-url is optional (ADR-013 §3).
+	svcArgs := []string{"--regtoken", token}
+	if controllerURL != "" {
+		svcArgs = append(svcArgs, "--controller-url", controllerURL)
+	}
+
 	fmt.Println("Registering Windows service...")
 	newSvc, err := scm.CreateService(
 		windowsServiceName,
@@ -135,7 +143,7 @@ func (m *windowsManager) Install(token, caCertPEM, expectedFingerprint string) e
 			Description: windowsDescription,
 		},
 		// Arguments appended to the binary path; received as os.Args on service start.
-		"--regtoken", token,
+		svcArgs...,
 	)
 	if err != nil {
 		return fmt.Errorf("failed to create Windows service: %w", err)

--- a/cmd/steward/service/manager_windows_test.go
+++ b/cmd/steward/service/manager_windows_test.go
@@ -35,7 +35,7 @@ func TestWindowsManagerInstallRequiresElevation(t *testing.T) {
 	if m.IsElevated() {
 		t.Skip("skipping elevation check — running as Administrator")
 	}
-	err := m.Install("tok_test123", "", "")
+	err := m.Install("tok_test123", "", "", "")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "Administrator")
 }
@@ -52,7 +52,7 @@ func TestWindowsInstallFingerprintMismatch(t *testing.T) {
 	t.Setenv("CFGMS_INSTALL_PREFIX", dir)
 
 	certPEM, _ := generateTestCACert(t)
-	err := m.Install("tok_test123", certPEM, "deadbeefdeadbeefdeadbeef")
+	err := m.Install("tok_test123", "", certPEM, "deadbeefdeadbeefdeadbeef")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "fingerprint mismatch")
 

--- a/cmd/steward/service/manager_windows_test.go
+++ b/cmd/steward/service/manager_windows_test.go
@@ -63,7 +63,7 @@ func TestWindowsInstallFingerprintMismatch(t *testing.T) {
 }
 
 // TestWindowsInstallCACertWritten verifies that the CA cert is written to the prefixed
-// platform path with mode 0644 when a correct fingerprint is provided.
+// platform path with mode 0444 when a correct fingerprint is provided (ADR-013 §3).
 func TestWindowsInstallCACertWritten(t *testing.T) {
 	dir := t.TempDir()
 	t.Setenv("CFGMS_INSTALL_PREFIX", dir)
@@ -77,7 +77,7 @@ func TestWindowsInstallCACertWritten(t *testing.T) {
 
 	info, err := os.Stat(destPath)
 	require.NoError(t, err)
-	assert.Equal(t, os.FileMode(0644), info.Mode().Perm(), "CA cert must be written with mode 0644")
+	assert.Equal(t, os.FileMode(0444), info.Mode().Perm(), "CA cert must be written with mode 0444 per ADR-013 §3")
 }
 
 func TestWindowsManagerUninstallRequiresElevation(t *testing.T) {

--- a/cmd/steward/windows_service.go
+++ b/cmd/steward/windows_service.go
@@ -55,9 +55,10 @@ func (h *stewardServiceHandler) Execute(
 	status <- svc.Status{State: svc.StartPending}
 
 	// Parse the flags directly from os.Args so the service handler can read
-	// --regtoken etc. that were stored in the service definition.
+	// --regtoken, --controller-url etc. that were stored in the service definition.
 	flags := pflag.NewFlagSet("steward-service", pflag.ContinueOnError)
 	regToken := flags.String("regtoken", "", "registration token")
+	controllerURL := flags.String("controller-url", "", "controller URL")
 	configPath := flags.String("config", "", "config path")
 	// Ignore unknown flags (e.g. subcommand names) so the service can start even
 	// if the arg list changes between versions.
@@ -69,7 +70,7 @@ func (h *stewardServiceHandler) Execute(
 
 	errCh := make(chan error, 1)
 	go func() {
-		errCh <- runSteward(ctx, *regToken, *configPath)
+		errCh <- runSteward(ctx, *regToken, *controllerURL, *configPath)
 	}()
 
 	status <- svc.Status{

--- a/docs/deployment/fleet/walkthrough.md
+++ b/docs/deployment/fleet/walkthrough.md
@@ -269,14 +269,19 @@ tar -C /tmp/cfgms-install -xzf cfgms-steward-linux-amd64.tar.gz
 
 ### 4c — Install on Linux (`install.sh`)
 
-The install package includes `build/linux/install.sh`. Copy it alongside the extracted
-archive and run it with the CA fingerprint from `installer/ca.fingerprint`:
+The install package includes `build/linux/install.sh`. The preferred installation for
+self-hosted controllers uses **install-pinned** trust: the controller URL and CA cert are
+provided at install time, so the binary does not need to be rebuilt per controller
+(ADR-013 §3, Issue #1517).
 
 ```bash
 FINGERPRINT="$(cat /tmp/cfgms-install/installer/ca.fingerprint)"
+CA_CERT="/tmp/cfgms-install/installer/ca.crt"
 
 sudo bash install.sh \
   --regtoken <REGISTRATION_TOKEN> \
+  --controller-url https://<CONTROLLER_IP>:9080 \
+  --controller-ca "$CA_CERT" \
   --fingerprint "$FINGERPRINT"
 ```
 
@@ -284,14 +289,24 @@ The script:
 1. Verifies the CA cert fingerprint matches the supplied value (aborts on mismatch)
 2. Copies the steward binary to `/usr/local/bin/cfgms-steward`
 3. Writes the CA cert to `/etc/cfgms/controller-ca.crt`
-4. Registers the systemd service and starts it
+4. Registers the systemd service with `--controller-url` embedded in the unit file and starts it
 
-> **CA fingerprint**: `install.sh` computes the fingerprint from `ca.crt` and compares it
+> **CA fingerprint**: `install.sh` computes the fingerprint from the cert and compares it
 > against the value you provide. Retrieve the fingerprint at any time from the controller:
 > `cfg controller info --url=https://<IP>:9080 | grep fingerprint`
 
 > **Non-interactive install** (CI, RMM scripts): pass `--fingerprint` to skip the
 > interactive confirmation prompt.
+
+> **Compile-baked URL** (alternative): if the binary was built with
+> `make build-steward STEWARD_CONTROLLER_URL=https://<IP>:9080`, you can omit
+> `--controller-url` and `--controller-ca`. The URL is baked in and trusted as strongly
+> as the signed binary itself. Install-pinned is preferred when distributing the same
+> binary to multiple controllers.
+
+> **TOFU (lab only)**: omit `--controller-ca` to use trust-on-first-use semantics. The CA
+> from the first registration response is pinned and immutable thereafter. Only use TOFU in
+> lab environments where the initial registration is known to be untampered.
 
 ### 4d — Install on Windows (MSI via RMM — `msiexec /qn`)
 
@@ -728,7 +743,7 @@ sudo journalctl -u cfgms-steward -f
 | `cfg controller status` returns cert error | Bundle CA does not match controller CA | Re-copy `admin.bundle.yaml` from controller |
 | Steward registration fails: `x509: certificate signed by unknown authority` | `CFGMS_HTTP_CA_CERT_PATH` not set or wrong path | Set env var to the controller's CA cert (`/var/lib/cfgms/certs/ca/ca.crt` on controller) |
 | Steward registration fails: `token expired` or `token not found` | Token expired or already used | `cfg token create` to issue a new token |
-| Steward registration fails: `controller URL not set` | Binary not built with `STEWARD_CONTROLLER_URL` | `make build-steward STEWARD_CONTROLLER_URL=https://<IP>:9080` |
+| Steward registration fails: `controller URL not set` | Neither `--controller-url` nor compile-baked URL set | Pass `--controller-url` to `install.sh`, or rebuild with `make build-steward STEWARD_CONTROLLER_URL=https://<IP>:9080` |
 | `Connected Stewards: 0` in controller metrics | Stewards registered but not connecting on 4433/UDP | Check firewall — port 4433 must be open for UDP |
 | `curl` REST API call returns `401` | No valid auth credentials | Extract cert/key from admin bundle; see Phase 5 |
 | Convergence not running | Steward is in standalone mode (no regtoken path) | Verify service is using `--regtoken` not `--config` |
@@ -769,7 +784,7 @@ The table below collects all `[GAP: ...]` markers from this walkthrough for easy
 | save=deploy auto-distribution not wired | [#1525](https://github.com/cfg-is/cfgms/issues/1525) | Phase 6 |
 | apply/monitor mode toggle not implemented | [#1524](https://github.com/cfg-is/cfgms/issues/1524) | Phase 8 |
 | `modules.Monitor()` not implemented by any module | [#1590](https://github.com/cfg-is/cfgms/issues/1590) | Phase 8 |
-| Multi-controller / failover not supported | [#1517](https://github.com/cfg-is/cfgms/issues/1517) | Phase 4 |
+| Multi-controller / failover not supported | (backlog) | Phase 4 |
 
 ---
 

--- a/docs/deployment/single-controller/walkthrough.md
+++ b/docs/deployment/single-controller/walkthrough.md
@@ -54,6 +54,14 @@ make build
 
 This produces `bin/controller`, `bin/cfgms-steward`, and `bin/cfg`.
 
+> **Controller URL**: `make build` bakes `localhost:9080` into the steward binary — the
+> correct default for the controller-steward running on the same node. For remote stewards
+> deployed to other machines, you can either rebuild with
+> `make build-steward STEWARD_CONTROLLER_URL=https://<IP>:9080` (compile-baked trust) or
+> pass `--controller-url https://<IP>:9080 --controller-ca ca.crt` to `install.sh` at
+> install time (install-pinned trust, ADR-013 §3). Both are equally secure for a single
+> self-hosted controller.
+
 ## Step 2: Deploy the Controller
 
 Copy the controller binary to the controller VM:

--- a/features/steward/registration/client_http.go
+++ b/features/steward/registration/client_http.go
@@ -94,9 +94,13 @@ type HTTPConfig struct {
 	ControllerURL string
 	Timeout       time.Duration
 	// CACertPath is the optional path to a PEM-encoded CA certificate used to verify
-	// the controller's TLS certificate during registration. When empty, system root CAs are used.
+	// the controller's TLS certificate during registration. When empty, system root CAs are used
+	// (unless CAPEM is set).
 	CACertPath string
-	Logger     logging.Logger
+	// CAPEM is an inline PEM-encoded CA certificate. Takes precedence over CACertPath when set.
+	// Used in install-pinned and TOFU modes to provide the pinned CA without requiring a disk read.
+	CAPEM  string
+	Logger logging.Logger
 }
 
 // NewHTTPClient creates a new HTTP-based registration client
@@ -113,13 +117,20 @@ func NewHTTPClient(cfg *HTTPConfig) (*HTTPClient, error) {
 		timeout = 30 * time.Second
 	}
 
-	transport := &http.Transport{}
-	if cfg.CACertPath != "" {
-		caPEM, err := os.ReadFile(cfg.CACertPath)
+	// Resolve CA PEM: inline CAPEM takes precedence over CACertPath.
+	var caPEM []byte
+	if cfg.CAPEM != "" {
+		caPEM = []byte(cfg.CAPEM)
+	} else if cfg.CACertPath != "" {
+		var err error
+		caPEM, err = os.ReadFile(cfg.CACertPath)
 		if err != nil {
 			return nil, fmt.Errorf("failed to read CA cert from %q: %w", cfg.CACertPath, err)
 		}
+	}
 
+	transport := &http.Transport{}
+	if len(caPEM) > 0 {
 		parsed, err := url.Parse(cfg.ControllerURL)
 		if err != nil {
 			return nil, fmt.Errorf("failed to parse controller URL: %w", err)


### PR DESCRIPTION
## Summary

- Adds three trust-source enrollment modes (compile-baked/3, install-pinned/2, TOFU/1) to the steward as specified in ADR-013 §3
- Trust downgrade is rejected at both registration and reconnect paths; stored assurance level wins
- TOFU CA fingerprint immutable after first enrollment; install-pinned CA written at 0444 and applied exclusively (no system-roots fallback) for the registration HTTP leg and onward
- Dev/CI flow (`make build` → `cfgms-steward --regtoken TOKEN`) unchanged — no new flags required for compile-baked default

## Key changes

| File | Change |
|------|--------|
| `cmd/steward/main.go` | `TrustSource` type + `resolveTrustSource`, `checkTrustDowngrade`, `pinTOFUCA`, `buildHTTPConfigForInstallPinned`; `--controller-url` flag on run and install subcommands |
| `cmd/steward/identity.go` | `TrustMode` + `CAPinFingerprint` persistence fields |
| `cmd/steward/service/manager*.go` | `Install(token, url, caPEM, fingerprint string)` — 4-param; `--controller-url` embedded in systemd unit/plist/Windows service args |
| `cmd/steward/service/cert.go` | `writeCACert` mode `0644` → `0444` (ADR-013 §3) |
| `features/steward/registration/client_http.go` | `CAPEM` field; `CAPEM → CACertPath → system-roots` resolution chain |
| `build/linux/install.sh` | `--controller-url` + `--controller-ca` flags; `--ca-cert` renamed to `--controller-ca` |
| `docs/deployment/fleet/walkthrough.md` | install-pinned as preferred self-hosted path; TOFU lab note |
| `docs/deployment/single-controller/walkthrough.md` | URL bake-vs-install explanation |

## Security properties

- No `InsecureSkipVerify` anywhere; registration TLS via `pkg/cert.CreateClientTLSConfig` (TLS 1.2 minimum)
- Pinned CA written at `0444` in both paths (consistent with ADR-013 §3)
- Registration token logged only via `logging.RedactedID`; never persisted cleartext
- Trust strength: compile-baked(3) > install-pinned(2) > TOFU(1); never silently downgraded

## Test plan

- [x] `TestResolveTrustSource` — all three modes + dev-flow regression (no URL -> compile-baked)
- [x] `TestTOFUCAPinImmutable` — first enroll pins CA at 0444; differing CA rejected on re-enroll
- [x] `TestTrustSourceDowngradeGuard` — downgrade rejected, same-level CA mismatch rejected, upgrade allowed
- [x] `TestTryReconnectWithStoredIdentity_TrustDowngrade_ReturnsError` — reconnect path downgrade guard (install-pinned -> TOFU rejected)
- [x] `TestRegistrationUsesPinnedCAInPinnedMode` — install-pinned uses pinned CA exclusively; wrong CA -> TLS error
- [x] `TestGenerateSystemdUnitWithControllerURL` — --controller-url embedded in ExecStart
- [x] `TestLinuxInstallFingerprintMismatch` — fingerprint mismatch aborts before cert write
- [x] `TestLinuxInstallCACertWritten` — CA written at 0444
- [x] `make test` — all packages pass (80+ packages, 175 script tests)
- [x] `make check-architecture` — no central provider violations
- [x] `make security-scan` — Trivy, Nancy, gosec, staticcheck all green

Fixes #1517

Generated with Claude Code