### PR TITLE
skill(pipeline-sweep): resolve project-queue path from repo root, not hardcoded /workspace

### DIFF
--- a/.claude/skills/pipeline-sweep/SKILL.md
+++ b/.claude/skills/pipeline-sweep/SKILL.md
@@ -33,8 +33,13 @@ For each non-terminal status, list its items and check whether their backing Git
 # Non-terminal statuses worth checking. Done and Blocked are excluded:
 #   Done    — already terminal
 #   Blocked — may be intentionally held by founder action; don't auto-resolve
+# Resolve the project-queue helper from the repo root so this works in both the
+# container (repo at /workspace) and a host session (repo elsewhere). Do NOT
+# hardcode /workspace — that silently no-ops on the host and yields a false
+# "no stale items" reading.
+PQ="$(git rev-parse --show-toplevel)/scripts/project-queue.sh"
 for status in "Draft" "Ready" "In Progress" "Reviewing" "Fix" "Failed"; do
-    /workspace/scripts/project-queue.sh list-by-status "$status" 2>/dev/null \
+    "$PQ" list-by-status "$status" 2>/dev/null \
       | jq -r --arg s "$status" '.[] | "\($s)\t\(.item_id)\t\(.issue_num)\t\(.title)"'
 done > /tmp/pipeline-sweep-nonterm.tsv
 ```
@@ -67,8 +72,9 @@ done < /tmp/pipeline-sweep-nonterm.tsv > /tmp/pipeline-sweep-stale.tsv
 For each stale entry, move the project item to `Done`:
 
 ```bash
+PQ="$(git rev-parse --show-toplevel)/scripts/project-queue.sh"
 while IFS=$'\t' read -r issue_num prev_status item_id title; do
-    /workspace/scripts/project-queue.sh update-field "$item_id" status Done
+    "$PQ" update-field "$item_id" status Done
     echo "Updated #$issue_num ($title): $prev_status → Done"
 done < /tmp/pipeline-sweep-stale.tsv
 ```
@@ -76,7 +82,8 @@ done < /tmp/pipeline-sweep-stale.tsv
 **Special case — Blocked items:** do NOT touch Blocked items even if the backing issue is CLOSED. Blocked is held intentionally by founder action (CLA Assistant configuration, release tagging, etc.); if a Blocked item's issue is closed, that's a state worth surfacing to the founder, not auto-resolving.
 
 ```bash
-/workspace/scripts/project-queue.sh list-by-status Blocked \
+PQ="$(git rev-parse --show-toplevel)/scripts/project-queue.sh"
+"$PQ" list-by-status Blocked \
   | jq -r '.[] | "\(.item_id)\t\(.issue_num)\t\(.title)"' \
   | while IFS=$'\t' read -r item_id issue_num title; do
       state=$(gh issue view "$issue_num" --repo cfg-is/cfgms --json state -q .state 2>/dev/null || echo MISSING)


### PR DESCRIPTION
## What

The `pipeline-sweep` skill hardcoded `/workspace/scripts/project-queue.sh` (the container's repo root) in three places: the Phase 2 non-terminal listing loop, the stale→Done update loop, and the Blocked-anomaly check.

## Why it mattered

`/po cron` and `/po cycle` run the sweep as a forked skill **in whatever session invoked them**. On the host PO session the repo is not at `/workspace`, so all three commands hit a nonexistent path. The errors were masked by `2>/dev/null`, so the sweep silently produced a **false clean reading** — "no stale items", "no Blocked anomalies" — without ever querying the board.

This surfaced two cron cycles running, where the sweep agent had to manually work around the path.

## Fix

Resolve the helper from the repo root via `git rev-parse --show-toplevel`, which yields the correct path in **both** contexts:
- container: `/workspace/scripts/project-queue.sh`
- host: `<repo>/scripts/project-queue.sh`

## Validation

Smoke-tested on the host. The corrected non-terminal listing now reads real board state:

```
Draft: 13 items
Ready: 10 items
In Progress: 6 items
Fix: 4 items
```

(Previously empty/silent on the host.) No `/workspace` command paths remain — the only remaining occurrences are in an explanatory comment warning against re-introducing the hardcode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
