### PR TITLE
feat(audit): controller audit list command + REST endpoint (Issue #2190)

### DIFF
--- a/cmd/cfg/cmd/controller_audit.go
+++ b/cmd/cfg/cmd/controller_audit.go
@@ -1,0 +1,170 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"strconv"
+	"text/tabwriter"
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+// Flags for cfg controller audit list.
+var (
+	auditSince     string
+	auditUntil     string
+	auditLimit     int
+	auditOffset    int
+	auditSeverity  string
+	auditAction    string
+	auditEventType string
+	auditUserID    string
+	auditResult    string
+	auditModule    string
+)
+
+// controllerAuditCmd groups audit-log subcommands under cfg controller audit.
+var controllerAuditCmd = &cobra.Command{
+	Use:   "audit",
+	Short: "Audit log commands",
+	Long:  `Read and query controller audit log entries for the current tenant.`,
+}
+
+// controllerAuditListCmd lists audit log entries from the controller.
+var controllerAuditListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List audit log entries",
+	Long: `List audit log entries for the authenticated tenant.
+
+Entries are returned in descending timestamp order. Use --since and --until to
+narrow the time range, and --module to filter by resource-type prefix (e.g.
+--module=hyperv returns entries whose ResourceType starts with "hyperv/").
+
+Output format defaults to tabular text with columns:
+  TIMESTAMP  SEVERITY  ACTION  USER  RESULT
+
+Use --format=json to receive the raw JSON array.`,
+	RunE: runControllerAuditList,
+}
+
+func init() {
+	controllerAuditListCmd.Flags().StringVar(&auditSince, "since", "", "Return entries at or after this time (RFC3339, e.g. 2026-01-01T00:00:00Z)")
+	controllerAuditListCmd.Flags().StringVar(&auditUntil, "until", "", "Return entries at or before this time (RFC3339)")
+	controllerAuditListCmd.Flags().IntVar(&auditLimit, "limit", 50, "Maximum number of entries to return (1-500)")
+	controllerAuditListCmd.Flags().IntVar(&auditOffset, "offset", 0, "Number of entries to skip (pagination)")
+	controllerAuditListCmd.Flags().StringVar(&auditSeverity, "severity", "", "Filter by severity (low, medium, high, critical)")
+	controllerAuditListCmd.Flags().StringVar(&auditAction, "action", "", "Filter by action string")
+	controllerAuditListCmd.Flags().StringVar(&auditEventType, "event-type", "", "Filter by event type")
+	controllerAuditListCmd.Flags().StringVar(&auditUserID, "user-id", "", "Filter by user ID")
+	controllerAuditListCmd.Flags().StringVar(&auditResult, "result", "", "Filter by result (success, failure, error, denied)")
+	controllerAuditListCmd.Flags().StringVar(&auditModule, "module", "", "Filter by resource-type prefix (e.g. hyperv)")
+
+	controllerAuditCmd.AddCommand(controllerAuditListCmd)
+	controllerCmd.AddCommand(controllerAuditCmd)
+}
+
+// auditEntry mirrors the fields of business.AuditEntry used for display.
+// Defined locally to avoid importing the business package from the CLI layer.
+type auditEntry struct {
+	ID           string    `json:"id"`
+	TenantID     string    `json:"tenant_id"`
+	Timestamp    time.Time `json:"timestamp"`
+	EventType    string    `json:"event_type"`
+	Action       string    `json:"action"`
+	UserID       string    `json:"user_id"`
+	ResourceType string    `json:"resource_type"`
+	ResourceID   string    `json:"resource_id"`
+	Result       string    `json:"result"`
+	Severity     string    `json:"severity"`
+	Source       string    `json:"source"`
+}
+
+func runControllerAuditList(_ *cobra.Command, _ []string) error {
+	client, err := getControllerClient()
+	if err != nil {
+		return fmt.Errorf("failed to create API client: %w", err)
+	}
+
+	params := url.Values{}
+	if auditSince != "" {
+		params.Set("since", auditSince)
+	}
+	if auditUntil != "" {
+		params.Set("until", auditUntil)
+	}
+	params.Set("limit", strconv.Itoa(auditLimit))
+	params.Set("offset", strconv.Itoa(auditOffset))
+	if auditSeverity != "" {
+		params.Set("severity", auditSeverity)
+	}
+	if auditAction != "" {
+		params.Set("action", auditAction)
+	}
+	if auditEventType != "" {
+		params.Set("event_type", auditEventType)
+	}
+	if auditUserID != "" {
+		params.Set("user_id", auditUserID)
+	}
+	if auditResult != "" {
+		params.Set("result", auditResult)
+	}
+	if auditModule != "" {
+		params.Set("module", auditModule)
+	}
+
+	path := "/api/v1/audit/entries?" + params.Encode()
+	resp, err := client.Get(context.Background(), path)
+	if err != nil {
+		return fmt.Errorf("failed to fetch audit entries: %w", err)
+	}
+	defer func() {
+		if closeErr := resp.Body.Close(); closeErr != nil {
+			fmt.Fprintf(os.Stderr, "Failed to close response body: %v\n", closeErr)
+		}
+	}()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("API request failed: %s - %s", resp.Status, string(body))
+	}
+
+	var apiResp struct {
+		Data []auditEntry `json:"data"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&apiResp); err != nil {
+		return fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	if healthFormat == "json" {
+		encoder := json.NewEncoder(os.Stdout)
+		encoder.SetIndent("", "  ")
+		return encoder.Encode(apiResp.Data)
+	}
+
+	if len(apiResp.Data) == 0 {
+		fmt.Println("No audit entries found")
+		return nil
+	}
+
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(w, "TIMESTAMP\tSEVERITY\tACTION\tUSER\tRESULT")
+	for _, e := range apiResp.Data {
+		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n",
+			e.Timestamp.Format(time.RFC3339),
+			e.Severity,
+			e.Action,
+			e.UserID,
+			e.Result,
+		)
+	}
+	return w.Flush()
+}

--- a/cmd/cfg/cmd/controller_audit.go
+++ b/cmd/cfg/cmd/controller_audit.go
@@ -156,15 +156,19 @@ func runControllerAuditList(_ *cobra.Command, _ []string) error {
 	}
 
 	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
-	fmt.Fprintln(w, "TIMESTAMP\tSEVERITY\tACTION\tUSER\tRESULT")
+	if _, err := fmt.Fprintln(w, "TIMESTAMP\tSEVERITY\tACTION\tUSER\tRESULT"); err != nil {
+		return err
+	}
 	for _, e := range apiResp.Data {
-		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n",
+		if _, err := fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n",
 			e.Timestamp.Format(time.RFC3339),
 			e.Severity,
 			e.Action,
 			e.UserID,
 			e.Result,
-		)
+		); err != nil {
+			return err
+		}
 	}
 	return w.Flush()
 }

--- a/cmd/cfg/cmd/controller_audit_test.go
+++ b/cmd/cfg/cmd/controller_audit_test.go
@@ -1,0 +1,197 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+package cmd
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// setupAuditTestServer creates a test server and wires the controller URL to it.
+// Returns a cleanup function and a channel that receives the last request URL.
+func setupAuditTestServer(t *testing.T, handler http.HandlerFunc) {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+
+	origURL := healthURL
+	origInsecure := controllerTLSInsecure
+	origAPIKey := healthAPIKey
+	t.Cleanup(func() {
+		healthURL = origURL
+		controllerTLSInsecure = origInsecure
+		healthAPIKey = origAPIKey
+	})
+	healthURL = srv.URL
+	controllerTLSInsecure = true
+	healthAPIKey = "test-key"
+}
+
+// resetAuditFlags restores default values for audit list command flags.
+func resetAuditFlags(t *testing.T) {
+	t.Helper()
+	origSince := auditSince
+	origUntil := auditUntil
+	origLimit := auditLimit
+	origOffset := auditOffset
+	origSeverity := auditSeverity
+	origAction := auditAction
+	origEventType := auditEventType
+	origUserID := auditUserID
+	origResult := auditResult
+	origModule := auditModule
+	origFormat := healthFormat
+	t.Cleanup(func() {
+		auditSince = origSince
+		auditUntil = origUntil
+		auditLimit = origLimit
+		auditOffset = origOffset
+		auditSeverity = origSeverity
+		auditAction = origAction
+		auditEventType = origEventType
+		auditUserID = origUserID
+		auditResult = origResult
+		auditModule = origModule
+		healthFormat = origFormat
+	})
+	auditSince = ""
+	auditUntil = ""
+	auditLimit = 50
+	auditOffset = 0
+	auditSeverity = ""
+	auditAction = ""
+	auditEventType = ""
+	auditUserID = ""
+	auditResult = ""
+	auditModule = ""
+	healthFormat = "text"
+}
+
+func TestControllerAuditList_TabularOutput(t *testing.T) {
+	resetAuditFlags(t)
+
+	ts := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
+	entries := []auditEntry{
+		{
+			ID:        "entry-1",
+			TenantID:  "tenant-a",
+			Timestamp: ts,
+			Action:    "create",
+			UserID:    "alice",
+			Severity:  "low",
+			Result:    "success",
+		},
+	}
+
+	setupAuditTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{"data": entries})
+	})
+
+	output := captureStdout(t, func() {
+		err := runControllerAuditList(controllerAuditListCmd, []string{})
+		require.NoError(t, err)
+	})
+
+	assert.Contains(t, output, "TIMESTAMP", "tabular header must include TIMESTAMP")
+	assert.Contains(t, output, "SEVERITY", "tabular header must include SEVERITY")
+	assert.Contains(t, output, "ACTION", "tabular header must include ACTION")
+	assert.Contains(t, output, "USER", "tabular header must include USER")
+	assert.Contains(t, output, "RESULT", "tabular header must include RESULT")
+	assert.Contains(t, output, "alice")
+	assert.Contains(t, output, "create")
+	assert.Contains(t, output, "success")
+}
+
+func TestControllerAuditList_JSONFormat(t *testing.T) {
+	resetAuditFlags(t)
+	healthFormat = "json"
+
+	ts := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
+	entries := []auditEntry{
+		{
+			ID:        "entry-json",
+			TenantID:  "tenant-a",
+			Timestamp: ts,
+			Action:    "delete",
+			UserID:    "bob",
+			Severity:  "high",
+			Result:    "success",
+		},
+	}
+
+	setupAuditTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{"data": entries})
+	})
+
+	output := captureStdout(t, func() {
+		err := runControllerAuditList(controllerAuditListCmd, []string{})
+		require.NoError(t, err)
+	})
+
+	var parsed []auditEntry
+	require.NoError(t, json.Unmarshal([]byte(strings.TrimSpace(output)), &parsed),
+		"--format=json output must be a valid JSON array; got: %s", output)
+	require.Len(t, parsed, 1)
+	assert.Equal(t, "entry-json", parsed[0].ID)
+	assert.Equal(t, "bob", parsed[0].UserID)
+}
+
+func TestControllerAuditList_EmptyResultMessage(t *testing.T) {
+	resetAuditFlags(t)
+
+	setupAuditTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{"data": []interface{}{}})
+	})
+
+	output := captureStdout(t, func() {
+		err := runControllerAuditList(controllerAuditListCmd, []string{})
+		require.NoError(t, err)
+	})
+
+	assert.Contains(t, output, "No audit entries found")
+}
+
+func TestControllerAuditList_OffsetAndLimitForwardedAsQueryParams(t *testing.T) {
+	resetAuditFlags(t)
+	auditLimit = 25
+	auditOffset = 100
+
+	var capturedQuery string
+	setupAuditTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		capturedQuery = r.URL.RawQuery
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{"data": []interface{}{}})
+	})
+
+	output := captureStdout(t, func() {
+		err := runControllerAuditList(controllerAuditListCmd, []string{})
+		require.NoError(t, err)
+	})
+
+	assert.Contains(t, capturedQuery, "limit=25", "limit must be forwarded as query param")
+	assert.Contains(t, capturedQuery, "offset=100", "offset must be forwarded as query param")
+	assert.Contains(t, output, "No audit entries found")
+}
+
+func TestControllerAuditList_HTTPErrorPropagates(t *testing.T) {
+	resetAuditFlags(t)
+
+	setupAuditTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+		_, _ = w.Write([]byte(`{"error":{"code":"AUDIT_NOT_AVAILABLE"}}`))
+	})
+
+	err := runControllerAuditList(controllerAuditListCmd, []string{})
+	require.Error(t, err, "non-OK HTTP response must propagate as an error")
+	assert.Contains(t, err.Error(), "503")
+}

--- a/features/controller/api/handlers_audit.go
+++ b/features/controller/api/handlers_audit.go
@@ -1,0 +1,118 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+package api
+
+import (
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/cfgis/cfgms/pkg/ctxkeys"
+	"github.com/cfgis/cfgms/pkg/logging"
+	business "github.com/cfgis/cfgms/pkg/storage/interfaces/business"
+)
+
+// handleListAuditEntries handles GET /api/v1/audit/entries.
+// TenantID is always sourced from the authenticated principal's context —
+// any tenant_id query param supplied by the caller is silently discarded.
+func (s *Server) handleListAuditEntries(w http.ResponseWriter, r *http.Request) {
+	if s.auditManager == nil {
+		s.writeErrorResponse(w, http.StatusServiceUnavailable, "Audit service not available", "AUDIT_NOT_AVAILABLE")
+		return
+	}
+
+	tenantID, _ := r.Context().Value(ctxkeys.TenantID).(string)
+
+	filter := &business.AuditFilter{
+		TenantID: tenantID,
+		Limit:    50,
+	}
+
+	if since := r.URL.Query().Get("since"); since != "" {
+		if t, err := time.Parse(time.RFC3339, since); err == nil {
+			if filter.TimeRange == nil {
+				filter.TimeRange = &business.TimeRange{}
+			}
+			filter.TimeRange.Start = &t
+		}
+	}
+	if until := r.URL.Query().Get("until"); until != "" {
+		if t, err := time.Parse(time.RFC3339, until); err == nil {
+			if filter.TimeRange == nil {
+				filter.TimeRange = &business.TimeRange{}
+			}
+			filter.TimeRange.End = &t
+		}
+	}
+
+	if limitStr := r.URL.Query().Get("limit"); limitStr != "" {
+		if l, err := strconv.Atoi(limitStr); err == nil {
+			if l < 1 {
+				l = 1
+			}
+			if l > 500 {
+				l = 500
+			}
+			filter.Limit = l
+		}
+	}
+
+	if offsetStr := r.URL.Query().Get("offset"); offsetStr != "" {
+		if o, err := strconv.Atoi(offsetStr); err == nil && o >= 0 {
+			filter.Offset = o
+		}
+	}
+
+	if severity := r.URL.Query().Get("severity"); severity != "" {
+		filter.Severities = []business.AuditSeverity{business.AuditSeverity(severity)}
+	}
+
+	if action := r.URL.Query().Get("action"); action != "" {
+		filter.Actions = []string{action}
+	}
+
+	if eventType := r.URL.Query().Get("event_type"); eventType != "" {
+		filter.EventTypes = []business.AuditEventType{business.AuditEventType(eventType)}
+	}
+
+	if userID := r.URL.Query().Get("user_id"); userID != "" {
+		filter.UserIDs = []string{userID}
+	}
+
+	if result := r.URL.Query().Get("result"); result != "" {
+		filter.Results = []business.AuditResult{business.AuditResult(result)}
+	}
+
+	// module is a post-query prefix filter; do not set ResourceTypes on the filter
+	// because the storage layer does exact-match only.
+	module := r.URL.Query().Get("module")
+
+	entries, err := s.auditManager.QueryEntries(r.Context(), filter)
+	if err != nil {
+		s.logger.Error("Failed to query audit entries",
+			"tenant_id", logging.SanitizeLogValue(tenantID),
+			"error", err,
+		)
+		s.writeErrorResponse(w, http.StatusInternalServerError, "Failed to retrieve audit entries", "INTERNAL_ERROR")
+		return
+	}
+
+	if module != "" {
+		prefix := module + "/"
+		filtered := make([]*business.AuditEntry, 0, len(entries))
+		for _, e := range entries {
+			if strings.HasPrefix(e.ResourceType, prefix) {
+				filtered = append(filtered, e)
+			}
+		}
+		entries = filtered
+	}
+
+	s.logger.Info("Retrieved audit entries",
+		"tenant_id", logging.SanitizeLogValue(tenantID),
+		"count", len(entries),
+		"module", logging.SanitizeLogValue(module),
+	)
+	s.writeSuccessResponse(w, entries)
+}

--- a/features/controller/api/handlers_audit_test.go
+++ b/features/controller/api/handlers_audit_test.go
@@ -1,0 +1,201 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cfgis/cfgms/pkg/audit"
+	"github.com/cfgis/cfgms/pkg/ctxkeys"
+	business "github.com/cfgis/cfgms/pkg/storage/interfaces/business"
+)
+
+// getAuditEntries performs GET /api/v1/audit/entries with the given tenant and optional query params.
+func getAuditEntries(server *Server, tenantID, query string) *httptest.ResponseRecorder {
+	url := "/api/v1/audit/entries"
+	if query != "" {
+		url += "?" + query
+	}
+	req := httptest.NewRequest(http.MethodGet, url, nil)
+	if tenantID != "" {
+		req = req.WithContext(context.WithValue(req.Context(), ctxkeys.TenantID, tenantID))
+	}
+	rec := httptest.NewRecorder()
+	server.handleListAuditEntries(rec, req)
+	return rec
+}
+
+// recordAndFlush records an audit event and flushes the manager so the entry reaches the store.
+func recordAndFlush(t *testing.T, mgr *audit.Manager, event *audit.AuditEventBuilder) {
+	t.Helper()
+	require.NoError(t, mgr.RecordEvent(context.Background(), event))
+	require.NoError(t, mgr.Flush(context.Background()))
+}
+
+func TestHandleListAuditEntries_HappyPath(t *testing.T) {
+	server := setupTestServer(t)
+
+	recordAndFlush(t, server.auditManager, audit.NewEventBuilder().
+		Tenant("tenant-a").
+		Type(business.AuditEventConfiguration).
+		Action("update").
+		User("user-1", business.AuditUserTypeHuman).
+		Resource("config/dns", "res-1", "").
+		Result(business.AuditResultSuccess).
+		Severity(business.AuditSeverityLow),
+	)
+
+	rec := getAuditEntries(server, "tenant-a", "")
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var resp struct {
+		Data []*business.AuditEntry `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.NotEmpty(t, resp.Data, "expected at least one audit entry")
+	for _, e := range resp.Data {
+		assert.Equal(t, "tenant-a", e.TenantID, "all entries must belong to tenant-a")
+	}
+}
+
+func TestHandleListAuditEntries_EmptyResult(t *testing.T) {
+	server := setupTestServer(t)
+
+	rec := getAuditEntries(server, "tenant-no-data", "")
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var resp struct {
+		Data []*business.AuditEntry `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	// Empty slice or nil both satisfy: no entries for an unknown tenant.
+	assert.Empty(t, resp.Data)
+}
+
+func TestHandleListAuditEntries_ModulePrefixFilter(t *testing.T) {
+	server := setupTestServer(t)
+
+	// Seed two entries: one with hyperv/ prefix, one without.
+	recordAndFlush(t, server.auditManager, audit.NewEventBuilder().
+		Tenant("tenant-b").
+		Type(business.AuditEventConfiguration).
+		Action("New-VM").
+		User("system", business.AuditUserTypeSystem).
+		Resource("hyperv/New-VM", "vm-001", "").
+		Result(business.AuditResultSuccess).
+		Severity(business.AuditSeverityLow),
+	)
+	recordAndFlush(t, server.auditManager, audit.NewEventBuilder().
+		Tenant("tenant-b").
+		Type(business.AuditEventConfiguration).
+		Action("set").
+		User("system", business.AuditUserTypeSystem).
+		Resource("config", "cfg-001", "").
+		Result(business.AuditResultSuccess).
+		Severity(business.AuditSeverityLow),
+	)
+
+	rec := getAuditEntries(server, "tenant-b", "module=hyperv")
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var resp struct {
+		Data []*business.AuditEntry `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	require.Len(t, resp.Data, 1, "only the hyperv/ entry must be returned")
+	assert.Equal(t, "hyperv/New-VM", resp.Data[0].ResourceType)
+}
+
+func TestHandleListAuditEntries_AuditManagerNil_Returns503(t *testing.T) {
+	server := setupTestServer(t)
+	server.auditManager = nil
+
+	rec := getAuditEntries(server, "tenant-a", "")
+	require.Equal(t, http.StatusServiceUnavailable, rec.Code)
+
+	var resp ErrorResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Equal(t, "AUDIT_NOT_AVAILABLE", resp.Error.Code)
+}
+
+// TestHandleListAuditEntries_CrossTenantIsolation is the REQUIRED cross-tenant isolation test.
+// It stores entries under two different tenants and asserts that a request authenticated as
+// tenant A only returns tenant A's entries — no tenant B entries appear.
+func TestHandleListAuditEntries_CrossTenantIsolation(t *testing.T) {
+	server := setupTestServer(t)
+
+	// Seed entries for both tenants.
+	recordAndFlush(t, server.auditManager, audit.NewEventBuilder().
+		Tenant("tenant-a").
+		Type(business.AuditEventConfiguration).
+		Action("create").
+		User("user-a", business.AuditUserTypeHuman).
+		Resource("config/a", "a-1", "").
+		Result(business.AuditResultSuccess).
+		Severity(business.AuditSeverityLow),
+	)
+	recordAndFlush(t, server.auditManager, audit.NewEventBuilder().
+		Tenant("tenant-b").
+		Type(business.AuditEventConfiguration).
+		Action("delete").
+		User("user-b", business.AuditUserTypeHuman).
+		Resource("config/b", "b-1", "").
+		Result(business.AuditResultSuccess).
+		Severity(business.AuditSeverityLow),
+	)
+
+	// Request as tenant-a — must only see tenant-a's entries.
+	rec := getAuditEntries(server, "tenant-a", "")
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var resp struct {
+		Data []*business.AuditEntry `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+
+	for _, e := range resp.Data {
+		assert.Equal(t, "tenant-a", e.TenantID,
+			"tenant-a request must not expose tenant-b entry: %s", e.ID)
+	}
+
+	// Confirm at least one tenant-a entry is present.
+	found := false
+	for _, e := range resp.Data {
+		if e.TenantID == "tenant-a" {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found, "tenant-a entry must be present in the response")
+}
+
+func TestHandleListAuditEntries_InvalidQueryParamsIgnored(t *testing.T) {
+	server := setupTestServer(t)
+
+	// Non-numeric limit and offset should be silently ignored (defaults used).
+	rec := getAuditEntries(server, "tenant-a", "limit=notanumber&offset=bad")
+	assert.Equal(t, http.StatusOK, rec.Code)
+}
+
+func TestHandleListAuditEntries_LimitClamped(t *testing.T) {
+	server := setupTestServer(t)
+
+	// limit > 500 should be silently clamped to 500; request must succeed.
+	rec := getAuditEntries(server, "tenant-a", "limit=9999")
+	assert.Equal(t, http.StatusOK, rec.Code)
+}
+
+func TestHandleListAuditEntries_OffsetAndLimitForwarded(t *testing.T) {
+	server := setupTestServer(t)
+
+	// With no data, just verify the request parses fine and returns 200.
+	rec := getAuditEntries(server, "tenant-a", "offset=10&limit=5")
+	assert.Equal(t, http.StatusOK, rec.Code)
+}

--- a/features/controller/api/server.go
+++ b/features/controller/api/server.go
@@ -435,6 +435,9 @@ func (s *Server) setupRouter() {
 	scripts.Handle("/{id}", s.requirePermission("script", "admin")(http.HandlerFunc(s.handleGetScriptLibraryItem))).Methods("GET")
 	scripts.Handle("/{id}/privilege", s.requirePermission("script", "admin")(http.HandlerFunc(s.handlePutScriptPrivilege))).Methods("PUT")
 
+	// Audit log readback endpoint (Issue #2190)
+	api.Handle("/audit/entries", s.requirePermission("audit", "list")(http.HandlerFunc(s.handleListAuditEntries))).Methods("GET")
+
 	// Configuration list endpoint (Issue #1570)
 	api.Handle("/configs", s.requirePermission("config", "list")(http.HandlerFunc(s.handleListConfigs))).Methods("GET")
 


### PR DESCRIPTION
## Summary

- Adds `GET /api/v1/audit/entries` REST endpoint that returns audit log entries scoped to the authenticated principal's tenant; query params `since`, `until`, `limit`, `offset`, `severity`, `action`, `event_type`, `user_id`, `result` are passed through to `business.AuditFilter`; `module` query param filters by resource-type prefix applied post-query in the handler
- Adds `cfg controller audit list` CLI command with flags `--since`, `--until`, `--limit` (default 50), `--offset`, `--severity`, `--action`, `--event-type`, `--user-id`, `--result`, `--module`; tabular output with TIMESTAMP/SEVERITY/ACTION/USER/RESULT columns; `--format=json` emits raw JSON array; empty result prints "No audit entries found"
- Handler returns HTTP 503 with code `AUDIT_NOT_AVAILABLE` when `auditManager` is nil; tenant isolation enforced via `ctxkeys.TenantID` from context — caller-supplied `tenant_id` query params are silently discarded

## Test plan

- [x] `TestHandleListAuditEntries_HappyPath` — entries returned for tenant
- [x] `TestHandleListAuditEntries_EmptyResult` — empty list returns 200 with empty data
- [x] `TestHandleListAuditEntries_ModulePrefixFilter` — `?module=hyperv` filters to `hyperv/New-VM` and excludes `config`
- [x] `TestHandleListAuditEntries_AuditManagerNil_Returns503` — 503 with `AUDIT_NOT_AVAILABLE` code
- [x] `TestHandleListAuditEntries_CrossTenantIsolation` — [REQUIRED] seeds entries under two tenants, verifies only tenant A entries returned when authenticated as tenant A
- [x] `TestHandleListAuditEntries_InvalidQueryParamsIgnored` — malformed `limit`/`offset` silently use defaults
- [x] `TestHandleListAuditEntries_LimitClamped` — `limit=9999` returns 200 (silently clamped)
- [x] `TestControllerAuditList_TabularOutput` — TIMESTAMP/SEVERITY/ACTION/USER/RESULT columns present
- [x] `TestControllerAuditList_JSONFormat` — `--format=json` emits valid JSON array
- [x] `TestControllerAuditList_EmptyResultMessage` — "No audit entries found" printed
- [x] `TestControllerAuditList_OffsetAndLimitForwardedAsQueryParams` — `limit=25&offset=100` forwarded as query params
- [x] `TestControllerAuditList_HTTPErrorPropagates` — 503 from server propagates as CLI error

## Specialist review

- **QA Test Runner**: PASS — all 13 new tests pass, no regressions
- **QA Code Reviewer**: PASS — blocking issue (discarded `captureStdout` result) fixed before commit
- **Security Engineer**: PASS — 0 blocking issues; tenant isolation, log sanitization, input validation all verified clean; security scans (gitleaks, truffleHog, gosec, Trivy, Nancy, staticcheck, architecture) all PASSED

Fixes #2190

🤖 Generated with [Claude Code](https://claude.com/claude-code)