### PR TITLE
security(pipeline): gate external-contributor PRs before any agent action (Issue #1786)

### DIFF
--- a/.claude/agents/acceptance-reviewer.md
+++ b/.claude/agents/acceptance-reviewer.md
@@ -27,6 +27,26 @@ You receive a PR number, story issue number, and project item ID as `$ARGUMENTS`
 
 The story issue number is retained for PR linking and assignee operations. `ITEM_ID` is used for body reads and status updates.
 
+## Phase 0.5: External-Author Gate (BLOCKING)
+
+Before any review work, verify that the PR author is a trusted collaborator. Run:
+
+```bash
+.claude/scripts/agent-dispatch.sh check-pr-author <PR_NUM>
+```
+
+If the exit code is non-zero (`AUTHOR_EXTERNAL:…`):
+
+- Do **NOT** run Phase 0–4. Do **NOT** fetch code, check CI, or evaluate acceptance criteria.
+- The `check-pr-author` call already posts a quarantine comment on the PR.
+- Update the project item status back to `In Progress` (not Blocked or Failed):
+  ```bash
+  ./scripts/project-queue.sh update-field <ITEM_ID> status "In Progress"
+  ```
+- Exit with verdict `SKIPPED_EXTERNAL_AUTHOR`. Do NOT enqueue or merge.
+
+A maintainer must apply the `human-reviewed:ok` label (verified to push+ actor) before the pipeline will process this PR. See `docs/development/external-contributors.md`.
+
 ## Phase 0: Draft-PR Short-Circuit (BLOCKING)
 
 Before any review work, check if the PR is a draft:

--- a/.claude/agents/po.md
+++ b/.claude/agents/po.md
@@ -98,6 +98,8 @@ Also read:
 
 Display sections in this order. **Omit any section with zero items.**
 
+**Section 0.5: EXTERNAL PR QUARANTINE** — PRs quarantined because the author is not a trusted (`push`/`maintain`/`admin`) collaborator. Read `external_prs` from preflight output. For each entry show: PR number, author login, head branch, title, and whether `is_released` (has `human-reviewed:ok` from a push+ actor). Omit if empty.
+
 **Section 1: NEEDS ATTENTION** — project items with `Blocked` status. Flag items older than 7 days as stale.
 
 **Section 2: MERGE DECISIONS** — Open PRs where `has_acceptance_review_comment: false` and CI is not failing (read from `review_recommendations` in the preflight output). Show QA verdict summary and CI status.
@@ -294,6 +296,9 @@ Each step sets project status `Blocked` on unrecoverable failure and continues t
 **Priority order (cap-constrained):** in-flight work is processed before new work. The 7-container cap is shared across all autonomous activity (dev agents, fix-pr, review containers), so when slots are scarce the cycle finishes existing PRs first — they unblock the merge queue, which is more valuable than starting more dev work that would just queue behind them. The numbered steps below reflect this priority: Step 3 (rebase) → Step 4 (review) → Step 5 (fix-cycle) → Step 6 (dispatch new dev). If the cap is exhausted by Steps 3-5, defer Step 6 to the next cycle.
 
 Maintenance steps that create new work (Step 1.6 — pin refresh) or reconcile state run regardless of the container cap, since they do not consume container slots.
+
+**Step 0 — External PR triage (Issue #1786):**
+Read `external_prs` from the preflight output (`po-act.sh state '.external_prs'`). For each entry where `is_released == false`, log the quarantine and skip all pipeline actions for that PR. For entries where `is_released == true` (maintainer has applied `human-reviewed:ok` via a push+ actor), treat the PR as internal and allow it through normal review/merge flow. Do NOT call `review-pr`, `dispatch-fix`, or `enqueue` on any PR where `is_released == false`.
 
 **Step 1 — Unblock check:**
 Find recently merged PRs. Check if any `Draft` stories had `## Dependencies` referencing the merged story. If satisfied, they're eligible for Tech Lead review.

--- a/.claude/scripts/agent-dispatch.sh
+++ b/.claude/scripts/agent-dispatch.sh
@@ -325,6 +325,90 @@ refresh_creds_from_host() {
     || echo "WARN: Failed to refresh credentials from host"
 }
 
+# ---------------------------------------------------------------------------
+# External-author trust gate helpers (Issue #1786)
+# ---------------------------------------------------------------------------
+
+# _check_author_permission <login> [<pr_num>] [<pr_labels_newline_separated>]
+# Classifies a PR author as "internal" or "external:<reason>".
+# Trusts only push/maintain/admin collaborators (fail-closed on any API error).
+# When external and the release marker human-reviewed:ok is present (and was
+# applied by a push+ actor), returns "internal" (PR has been released).
+#
+# Test hooks (all env vars, only active when set):
+#   CFGMS_TEST_COLLAB_PERM   — override the author's permission lookup
+#   CFGMS_TEST_ACTOR_LOGIN   — override the GraphQL actor-login lookup (set to
+#                              empty to simulate "no actor found"; use +x check)
+#   CFGMS_TEST_ACTOR_PERM    — override the label-actor's permission lookup;
+#                              falls back to CFGMS_TEST_COLLAB_PERM if unset
+_check_author_permission() {
+  local login="$1"
+  local pr_num="${2:-}"
+  local pr_labels_str="${3:-}"
+
+  if [[ -z "$login" ]]; then
+    echo "external:null_author"
+    return 0
+  fi
+
+  local perm
+  if [[ -n "${CFGMS_TEST_COLLAB_PERM:-}" ]]; then
+    perm="$CFGMS_TEST_COLLAB_PERM"
+  else
+    perm=$(gh api "repos/cfg-is/cfgms/collaborators/${login}/permission" \
+      --jq '.permission // ""' 2>/dev/null || echo "")
+  fi
+
+  if [[ "$perm" == "push" || "$perm" == "maintain" || "$perm" == "admin" ]]; then
+    echo "internal"
+    return 0
+  fi
+
+  # External author — check for a valid human-reviewed:ok release marker (AC5).
+  # Only the label presence is checked here; actor affiliation is verified below.
+  if [[ -n "$pr_num" ]] && echo "$pr_labels_str" | grep -qx "human-reviewed:ok" 2>/dev/null; then
+    local actor_login
+    if [[ -n "${CFGMS_TEST_ACTOR_LOGIN+x}" ]]; then
+      actor_login="${CFGMS_TEST_ACTOR_LOGIN}"
+    else
+      local tl_gql
+      tl_gql="query { repository(owner: \"cfg-is\", name: \"cfgms\") { pullRequest(number: ${pr_num}) { timelineItems(itemTypes: [LABELED_EVENT], first: 50) { nodes { ... on LabeledEvent { label { name } actor { login } } } } } } }"
+      actor_login=$(gh api graphql -f "query=${tl_gql}" \
+        --jq '[.data.repository.pullRequest.timelineItems.nodes[] | select(.label.name == "human-reviewed:ok") | .actor.login] | last // ""' \
+        2>/dev/null || echo "")
+    fi
+    if [[ -n "$actor_login" ]]; then
+      local actor_perm
+      if [[ -n "${CFGMS_TEST_ACTOR_PERM+x}" ]]; then
+        actor_perm="${CFGMS_TEST_ACTOR_PERM}"
+      elif [[ -n "${CFGMS_TEST_COLLAB_PERM:-}" ]]; then
+        actor_perm="$CFGMS_TEST_COLLAB_PERM"
+      else
+        actor_perm=$(gh api "repos/cfg-is/cfgms/collaborators/${actor_login}/permission" \
+          --jq '.permission // ""' 2>/dev/null || echo "")
+      fi
+      if [[ "$actor_perm" == "push" || "$actor_perm" == "maintain" || "$actor_perm" == "admin" ]]; then
+        echo "internal"  # Released by push+ collaborator (AC5)
+        return 0
+      fi
+    fi
+  fi
+
+  echo "external:${perm:-api_error}"
+  return 0
+}
+
+# _post_quarantine_comment <pr_num> <author_login>
+# Posts a best-effort quarantine notice on the PR. Idempotent (duplicate comments
+# are harmless). Uses || true so a failed comment never aborts the caller.
+_post_quarantine_comment() {
+  local pr_num="$1"
+  local author_login="${2:-unknown}"
+  gh pr comment "$pr_num" --repo cfg-is/cfgms \
+    --body "**External-author PR quarantined.** Author \`${author_login}\` is not a trusted (\`push\`/\`maintain\`/\`admin\`) repository collaborator. The autonomous pipeline will not fetch, review, rebase, fix, or merge this PR until a maintainer applies the \`human-reviewed:ok\` label (verified to push+ actor). See \`docs/development/external-contributors.md\` for the contributor triage and release process." \
+    2>/dev/null || true
+}
+
 # Gate on credential validity before launching any agent container.
 # Threshold: 30 minutes (raised from 15; a 401 was observed at 27 min remaining).
 # Sets CFGMS_TEST_CREDS_STATUS to inject a synthetic result in hermetic tests.
@@ -576,14 +660,30 @@ case "$cmd" in
     dest="${WORKTREE_BASE}/pr-fix-${pr_num}"
     github_url=$(git -C "$REPO_ROOT" remote get-url origin)
 
-    # Get branch from PR
-    pr_branch=$(gh pr view "$pr_num" --json headRefName -q '.headRefName' 2>/dev/null) || {
-      echo "ERROR: Failed to get branch for PR #${pr_num}"
+    # Fetch all PR metadata in one call (author gate + branch + body).
+    pr_meta_fix=$(gh pr view "$pr_num" --json headRefName,body,labels,author 2>/dev/null) || {
+      echo "ERROR: Failed to get metadata for PR #${pr_num}"
       exit 1
     }
+    pr_branch=$(echo "$pr_meta_fix" | jq -r '.headRefName // empty')
+    pr_body=$(echo "$pr_meta_fix" | jq -r '.body // ""')
+    pr_labels_fix=$(echo "$pr_meta_fix" | jq -r '.labels[].name')
+    pr_author_login=$(echo "$pr_meta_fix" | jq -r '.author.login // empty')
 
-    # Extract issue number from PR body
-    pr_body=$(gh pr view "$pr_num" --json body -q '.body' 2>/dev/null || echo "")
+    if [[ -z "$pr_branch" ]]; then
+      echo "ERROR: Failed to get branch for PR #${pr_num}"
+      exit 1
+    fi
+
+    # External-author gate (Issue #1786): check trust BEFORE git clone/fetch of PR content.
+    author_trust=$(_check_author_permission "$pr_author_login" "$pr_num" "$pr_labels_fix")
+    if [[ "$author_trust" != "internal" ]]; then
+      _post_quarantine_comment "$pr_num" "$pr_author_login"
+      echo "FIX_REFUSED:${pr_num}:external_author_${pr_author_login}:${author_trust}"
+      exit 3
+    fi
+
+    # Extract issue number from body or branch name.
     issue_num=$(echo "$pr_body" | grep -oP 'Fixes #\K[0-9]+' | head -1 || true)
     if [[ -z "$issue_num" ]] && [[ "$pr_branch" =~ story-([0-9]+) ]]; then
       issue_num="${BASH_REMATCH[1]}"
@@ -1249,7 +1349,7 @@ else:
 
     # Validate PR + auto-detect story number.
     pr_meta=$(gh pr view "$pr_num" --repo cfg-is/cfgms \
-      --json state,headRefName,body,labels,headRepositoryOwner 2>/dev/null) || {
+      --json state,headRefName,body,labels,headRepositoryOwner,author 2>/dev/null) || {
       echo "REVIEW_REFUSED:${pr_num}:pr_not_found"
       exit 3
     }
@@ -1258,6 +1358,7 @@ else:
     fork_owner=$(echo "$pr_meta" | jq -r '.headRepositoryOwner.login // empty')
     pr_body=$(echo "$pr_meta" | jq -r '.body // ""')
     pr_labels=$(echo "$pr_meta" | jq -r '.labels[].name')
+    pr_author_login=$(echo "$pr_meta" | jq -r '.author.login // empty')
 
     if [[ "$state" != "OPEN" ]]; then
       echo "REVIEW_REFUSED:${pr_num}:pr_state_${state}"
@@ -1267,6 +1368,16 @@ else:
       echo "REVIEW_REFUSED:${pr_num}:fork_branch_${fork_owner}"
       exit 3
     fi
+
+    # External-author gate (Issue #1786): check trust BEFORE any git fetch/checkout.
+    # Fail-closed: null/empty author or any API error → external.
+    author_trust=$(_check_author_permission "$pr_author_login" "$pr_num" "$pr_labels")
+    if [[ "$author_trust" != "internal" ]]; then
+      _post_quarantine_comment "$pr_num" "$pr_author_login"
+      echo "REVIEW_REFUSED:${pr_num}:external_author_${pr_author_login}:${author_trust}"
+      exit 3
+    fi
+
     validate_branch "$pr_branch"
 
     # Resolve story/item from the branch (authoritative) or, for legacy
@@ -1632,6 +1743,38 @@ PROMPT_EOF
     done
 
     echo "CLEANUP_STALE_DONE:cleaned=${cleaned}"
+    ;;
+
+  check-pr-author)
+    # Public API used by po-act.sh (Issue #1786).
+    # check-pr-author <PR_NUM>
+    # Exits 0 (internal) or 3 (external/quarantined).
+    [[ $# -eq 1 ]] || { echo "check-pr-author requires exactly one PR number"; exit 1; }
+    _cpa_pr="$1"
+    _cpa_meta=$(gh pr view "$_cpa_pr" --json author,labels 2>/dev/null) || {
+      echo "AUTHOR_CHECK_ERROR:${_cpa_pr}:api_error"
+      exit 3
+    }
+    _cpa_login=$(echo "$_cpa_meta" | jq -r '.author.login // empty')
+    _cpa_labels=$(echo "$_cpa_meta" | jq -r '.labels[].name')
+    _cpa_trust=$(_check_author_permission "$_cpa_login" "$_cpa_pr" "$_cpa_labels")
+    if [[ "$_cpa_trust" == "internal" ]]; then
+      echo "AUTHOR_TRUSTED:${_cpa_pr}:${_cpa_login}"
+      exit 0
+    else
+      _post_quarantine_comment "$_cpa_pr" "$_cpa_login"
+      echo "AUTHOR_EXTERNAL:${_cpa_pr}:${_cpa_login}:${_cpa_trust}"
+      exit 3
+    fi
+    ;;
+
+  _test-check-author)
+    # Hidden test hook for review_pr_detection.test.sh (Issue #1786).
+    # _test-check-author <login> [<pr_num>] [<pr_labels_newline_separated>]
+    # Calls _check_author_permission with the supplied args and prints result.
+    # Test hooks: CFGMS_TEST_COLLAB_PERM, CFGMS_TEST_ACTOR_LOGIN, CFGMS_TEST_ACTOR_PERM.
+    [[ $# -ge 1 ]] || { echo "_test-check-author requires <login> [<pr_num>] [<pr_labels>]"; exit 1; }
+    _check_author_permission "${1}" "${2:-}" "${3:-}"
     ;;
 
   _test-resolve-pr)

--- a/.claude/scripts/po-act.sh
+++ b/.claude/scripts/po-act.sh
@@ -26,9 +26,12 @@
 set -euo pipefail
 
 REPO="cfg-is/cfgms"
-WORKTREE_BASE="$(cd "$(dirname "$0")/../.." && pwd)/../worktrees"
-WORKTREE_BASE="$(cd "$WORKTREE_BASE" 2>/dev/null && pwd || echo "/home/jrdn/git/cfg.is/worktrees")"
-DISPATCH="$(dirname "$0")/agent-dispatch.sh"
+WORKTREE_BASE="${CFGMS_TEST_WORKTREE_BASE:-}"
+if [[ -z "$WORKTREE_BASE" ]]; then
+  WORKTREE_BASE="$(cd "$(dirname "$0")/../.." && pwd)/../worktrees"
+  WORKTREE_BASE="$(cd "$WORKTREE_BASE" 2>/dev/null && pwd || echo "/home/jrdn/git/cfg.is/worktrees")"
+fi
+DISPATCH="${CFGMS_TEST_DISPATCH:-$(dirname "$0")/agent-dispatch.sh}"
 PREFLIGHT="$(dirname "$0")/po-cycle-preflight.py"
 PROJECT_QUEUE="$(cd "$(dirname "$0")/../.." && pwd)/scripts/project-queue.sh"
 
@@ -285,6 +288,11 @@ except Exception: print('')" 2>/dev/null || echo "")
   dispatch-fix)
     pr="${1:?PR number required}"
     container="cfg-agent-pr-fix-${pr}"
+    # External-author gate (Issue #1786): refuse before touching any PR content.
+    if ! "$DISPATCH" check-pr-author "$pr"; then
+      echo "DISPATCH_FIX_REFUSED:${pr}:external_author"
+      exit 3
+    fi
     # Remove any stale exited container from a previous attempt
     docker rm -f "$container" >/dev/null 2>&1 || true
     # Remove any stale worktree directory
@@ -305,6 +313,13 @@ except Exception: print('')" 2>/dev/null || echo "")
   enqueue)
     pr="${1:?PR number required}"
     story="${2:-}"
+    # TOCTOU re-check: verify author trust at enqueue time (Issue #1786).
+    # Even if review-pr passed earlier, labels or collaborator status may have
+    # changed between review and merge. Fail-closed: refuse if not internal.
+    if ! "$DISPATCH" check-pr-author "$pr"; then
+      echo "ENQUEUE_REFUSED:${pr}:external_author"
+      exit 3
+    fi
     # If a story is provided, ensure the PR body contains a GitHub auto-close
     # keyword for that issue. Dev agents miss this ~85% of the time, leaving
     # orphan issues that stay open after the PR merges. Patching here is cheap

--- a/.claude/scripts/po-cycle-preflight.py
+++ b/.claude/scripts/po-cycle-preflight.py
@@ -50,6 +50,9 @@ BARE_PATH_RE = re.compile(
 )
 BRANCH_STORY_RE = re.compile(r"feature/(?:story-(\d+)|item-([a-zA-Z0-9]+)-agent)")
 
+# Permission levels that indicate a trusted (first-party) collaborator.
+_TRUSTED_PERMS = frozenset({"push", "maintain", "admin"})
+
 # Execution-environment routing. A story declares the environment it must run in
 # via a `## Environment` body section and/or a `needs-<env>` GitHub label; a host
 # declares the environments it can serve via CFGMS_PO_HOST_CAPS. The default for
@@ -107,6 +110,10 @@ CACHE_FILE_NAME = "preflight.json"
 # regress back to per-issue / per-PR fan-out.
 _GH_CALL_COUNT = 0
 
+# Per-cycle collaborator permission cache. Key: login (str), value: permission
+# string or None (None = API failure / 404 / unknown → treated as external).
+_perm_cache: dict = {}
+
 
 def gh_graphql_tolerant(query):
     """Run a GraphQL query that may produce partial errors (e.g. mixed-type
@@ -151,6 +158,75 @@ def gh(*args, check=True):
         return json.loads(result.stdout)
     except json.JSONDecodeError:
         return result.stdout
+
+
+def _collab_permission(login):
+    """Return collaborator permission level for a login, or None on any failure.
+
+    Permission levels GitHub returns: 'admin', 'maintain', 'push', 'triage',
+    'read', 'none'.  A non-affirmative outcome (404, 403, 5xx, timeout, JSON
+    error) returns None — callers treat None as external (fail-closed).
+
+    Test hook: set CFGMS_TEST_COLLAB_PERM_MAP to a JSON object {"login": "perm"}.
+    Logins absent from the map return None (simulates 404).
+
+    Cached per module lifetime (one Python process = one preflight cycle).
+    """
+    global _GH_CALL_COUNT, _perm_cache
+    if login in _perm_cache:
+        return _perm_cache[login]
+
+    test_map_env = os.environ.get("CFGMS_TEST_COLLAB_PERM_MAP")
+    if test_map_env is not None:
+        try:
+            test_map = json.loads(test_map_env)
+            perm = test_map.get(login)  # None if absent → simulates 404
+        except (json.JSONDecodeError, TypeError):
+            perm = None
+        _perm_cache[login] = perm
+        return perm
+
+    _GH_CALL_COUNT += 1
+    try:
+        result = subprocess.run(
+            ["gh", "api", f"repos/cfg-is/cfgms/collaborators/{login}/permission",
+             "--jq", ".permission"],
+            capture_output=True, text=True, encoding="utf-8", errors="replace",
+            check=False, timeout=15,
+        )
+        perm = result.stdout.strip() if result.returncode == 0 and result.stdout.strip() else None
+    except Exception:
+        perm = None
+    _perm_cache[login] = perm
+    return perm
+
+
+def is_external(login):
+    """Return True if the login is NOT a trusted (push+/maintain/admin) collaborator.
+
+    Fails closed: null/empty login, deleted/ghost accounts, API errors, 403/404,
+    and any non-affirmative permission outcome all resolve to True (external).
+    This is the single source of truth for author-trust classification (Issue #1786).
+    """
+    if not login or not str(login).strip():
+        return True  # null/empty login = ghost/deleted account = external
+    perm = _collab_permission(str(login).strip())
+    return perm not in _TRUSTED_PERMS
+
+
+def _release_marker_actor_login(timeline_items):
+    """Return the actor login of the most recent 'human-reviewed:ok' LABELED_EVENT.
+
+    GitHub returns timeline items in chronological order; iterating to the last
+    matching item gives the most recent applicant of the release label.
+    Returns empty string if no matching event is found.
+    """
+    actor = ""
+    for item in (timeline_items or []):
+        label_name = ((item.get("label") or {}).get("name")) or ""
+        if label_name == "human-reviewed:ok":
+            actor = ((item.get("actor") or {}).get("login")) or ""
+    return actor
 
 
 PARENT_EPIC_RE = re.compile(r"Parent epic:\s*#(\d+)", re.IGNORECASE)
@@ -216,6 +292,17 @@ query {
         mergeable
         mergeStateStatus
         autoMergeRequest { enabledAt }
+        author { login }
+        labels(first: 20) { nodes { name } }
+        timelineItems(itemTypes: [LABELED_EVENT], first: 20) {
+          nodes {
+            ... on LabeledEvent {
+              createdAt
+              label { name }
+              actor { login }
+            }
+          }
+        }
         comments(first: 30) { nodes { author { login } body createdAt } }
         commits(last: 1) {
           nodes {
@@ -286,6 +373,9 @@ query {
             "mergeable": n.get("mergeable"),
             "mergeStateStatus": n.get("mergeStateStatus"),
             "autoMergeRequest": n.get("autoMergeRequest"),
+            "author_login": ((n.get("author") or {}).get("login")) or "",
+            "labels": ((n.get("labels") or {}).get("nodes")) or [],
+            "timeline_items": ((n.get("timelineItems") or {}).get("nodes")) or [],
             "comments": ((n.get("comments") or {}).get("nodes")) or [],
             "statusCheckRollup": _normalize_status_check_rollup(rollup),
             "latest_commit_date": latest_commit_date,
@@ -1172,6 +1262,27 @@ def compute_review_recommendations(pr_summaries, queued_pr_numbers, active_fix_p
             })
             continue
 
+        # PRIORITY 0.55: external-author PR quarantine (Issue #1786).
+        # A PR whose author is not a push+/maintain/admin collaborator must never
+        # be rebased, reviewed, fixed, or enqueued by the autonomous pipeline.
+        # Applies BEFORE the draft/blocked check so an external draft still gets
+        # the quarantine reason, not the founder-managed reason.
+        # Exception: a validly-released PR (human-reviewed:ok applied by push+
+        # actor) is cleared and proceeds through the normal pipeline.
+        if pr.get("is_external") and not pr.get("is_released"):
+            recs.append({
+                "pr": pr["pr"],
+                "story": pr["story_number"],  # always None for external PRs (AC4)
+                "action": "skip",
+                "reason": (
+                    f"external-author PR quarantined (author: {pr.get('author_login') or 'unknown'}) — "
+                    "pipeline will not fetch, review, or merge until a maintainer applies "
+                    "the human-reviewed:ok label (verified to push+ actor). "
+                    "See docs/development/external-contributors.md for release process."
+                ),
+            })
+            continue
+
         # PRIORITY 0.6: founder-managed / fenced-off PRs. A draft PR that is NOT
         # a wip_session_failed resume is manual work in progress; a PR whose
         # linked story has project status Blocked was deliberately removed from
@@ -1473,6 +1584,78 @@ def compute_fix_recommendations(fix_stories, pr_summaries, active_fix_pr_nums=No
             "reason": f"Fix-status story with open PR (CI={overall}, mergeStateStatus={ms or 'UNKNOWN'}) — run `./.claude/scripts/po-act.sh dispatch-fix <PR>`",
         })
     return recs
+
+
+def _build_pr_summaries(prs):
+    """Build pr_summaries from raw PR nodes (Phase 4 of the preflight cycle).
+
+    Each summary includes author trust signals (is_external, is_released) and
+    story_number (None when author is external — defeats branch-name impersonation).
+
+    Extracted as a standalone function so it is unit-testable without mocking
+    the full main() flow (Issue #1786 — external-author gating).
+    """
+    summaries = []
+    for pr in prs:
+        head = pr.get("headRefName", "")
+        title = pr.get("title", "")
+        body = pr.get("body") or ""
+
+        # Author trust classification (fail-closed).
+        author_login = pr.get("author_login", "")
+        pr_is_external = is_external(author_login)
+
+        # Release marker: human-reviewed:ok label present AND applied by push+ actor.
+        labels = pr.get("labels", [])
+        pr_label_names = {
+            (l.get("name") if isinstance(l, dict) else l) or ""
+            for l in labels
+        }
+        pr_is_released = False
+        if "human-reviewed:ok" in pr_label_names:
+            actor_login = _release_marker_actor_login(pr.get("timeline_items", []))
+            if actor_login and not is_external(actor_login):
+                pr_is_released = True
+
+        # story_number only assigned to internal-author PRs.
+        # An external author naming their branch feature/story-N-agent gains no
+        # pipeline trust from the branch name (impersonation defeated — AC4).
+        story_number = None
+        if not pr_is_external:
+            m = BRANCH_STORY_RE.match(head)
+            if m and m.group(1) and m.group(1).isdigit():
+                story_number = int(m.group(1))
+
+        comments = pr.get("comments") or []
+        has_review_comment = any(is_trusted_review_comment(c) for c in comments)
+        review_verdict_val, review_comment_date = latest_review(comments)
+        is_draft = bool(pr.get("isDraft"))
+        wip_session_failed = is_draft and (
+            body.startswith("Agent session failed with exit code")
+            or (title.startswith("WIP:") and title.endswith("(agent failed)"))
+        )
+
+        summaries.append({
+            "pr": pr["number"],
+            "title": title,
+            "head_ref": head,
+            "author_login": author_login,
+            "is_external": pr_is_external,
+            "is_released": pr_is_released,
+            "story_number": story_number,
+            "comment_count": len(comments),
+            "has_acceptance_review_comment": has_review_comment,
+            "latest_review_verdict": review_verdict_val,
+            "latest_review_comment_date": review_comment_date,
+            "latest_commit_date": pr.get("latest_commit_date"),
+            "is_draft": is_draft,
+            "wip_session_failed": wip_session_failed,
+            "merge_state_status": pr.get("mergeStateStatus"),
+            "mergeable": pr.get("mergeable"),
+            "auto_merge_enabled": pr.get("autoMergeRequest") is not None,
+            "ci_summary": ci_summary(pr.get("statusCheckRollup") or []),
+        })
+    return summaries
 
 
 def main():
@@ -1795,46 +1978,42 @@ def main():
         if s.get("number") is not None and s["number"] in pr_story_nums and s["number"] not in in_progress_nums
     ]
 
-    # Phase 4: PR summaries
-    pr_summaries = []
-    for pr in prs:
-        head = pr.get("headRefName", "")
-        m = BRANCH_STORY_RE.match(head)
-        if m and m.group(1) and m.group(1).isdigit():
-            story_number = int(m.group(1))
-        else:
-            story_number = None
-        comments = pr.get("comments") or []
-        has_review_comment = any(is_trusted_review_comment(c) for c in comments)
-        review_verdict_val, review_comment_date = latest_review(comments)
-        body = pr.get("body") or ""
-        title = pr.get("title", "")
-        is_draft = bool(pr.get("isDraft"))
-        # Detect WIP draft PRs created by .devcontainer/entrypoint.sh on agent
-        # session failure (token reauth, token-limit truncation, etc.). The
-        # entrypoint pushes draft PRs with the literal markers below.
-        wip_session_failed = is_draft and (
-            body.startswith("Agent session failed with exit code")
-            or title.startswith("WIP:") and title.endswith("(agent failed)")
-        )
-        pr_summaries.append({
-            "pr": pr["number"],
-            "title": title,
-            "head_ref": head,
-            "story_number": story_number,
-            "comment_count": len(comments),
-            "has_acceptance_review_comment": has_review_comment,
-            "latest_review_verdict": review_verdict_val,
-            "latest_review_comment_date": review_comment_date,
-            "latest_commit_date": pr.get("latest_commit_date"),
-            "is_draft": is_draft,
-            "wip_session_failed": wip_session_failed,
-            "merge_state_status": pr.get("mergeStateStatus"),
-            "mergeable": pr.get("mergeable"),
-            "auto_merge_enabled": pr.get("autoMergeRequest") is not None,
-            "ci_summary": ci_summary(pr.get("statusCheckRollup") or []),
-        })
+    # Phase 3.5: pre-warm collaborator permission cache in parallel (Issue #1786).
+    # Resolve each unique PR author login once before Phase 4 processes pr_summaries,
+    # so all is_external() calls below are cache hits (no per-PR serial API calls).
+    unique_author_logins = {
+        pr.get("author_login", "")
+        for pr in prs
+        if pr.get("author_login")
+    }
+    if unique_author_logins:
+        with ThreadPoolExecutor(max_workers=min(len(unique_author_logins), 5)) as ex:
+            warmup_futures = {ex.submit(_collab_permission, login): login
+                              for login in unique_author_logins}
+            for fut in as_completed(warmup_futures):
+                try:
+                    fut.result()  # Result stored in _perm_cache by _collab_permission
+                except Exception as e:
+                    degraded_reasons.append(
+                        f"permission cache warmup failed for {warmup_futures[fut]!r}: {e}"
+                    )
+
+    # Phase 4: PR summaries (includes author trust classification — Issue #1786).
+    pr_summaries = _build_pr_summaries(prs)
     out["prs_open"] = pr_summaries
+
+    # Surface external-author PRs as a top-priority cron section (AC7).
+    out["external_prs"] = [
+        {
+            "pr": s["pr"],
+            "author_login": s.get("author_login", ""),
+            "head_ref": s.get("head_ref", ""),
+            "title": s.get("title", ""),
+            "is_released": s.get("is_released", False),
+        }
+        for s in pr_summaries
+        if s.get("is_external")
+    ]
 
     caps = host_caps()
     out["host_caps"] = sorted(caps)
@@ -1938,6 +2117,7 @@ def write_output(out, mode):
             "undecomposed_epics": len(out.get("epics_undecomposed", [])),
         },
         "host_caps": out.get("host_caps", [DEFAULT_ENV]),
+        "external_prs": out.get("external_prs", []),
         "windows_queue": out.get("windows_queue", []),
         "running_containers": out.get("running_containers", []),
         "merge_queue": out.get("merge_queue", []),

--- a/.claude/scripts/tests/review_pr_detection.test.sh
+++ b/.claude/scripts/tests/review_pr_detection.test.sh
@@ -88,5 +88,98 @@ assert_resolves "empty body falls through cleanly" \
   "REFUSED:no_story_link"
 
 echo
+echo "--- dispatch-gate: author trust classification (issue #1786) ---"
+
+assert_author_trust() {
+  local description="$1"
+  local login="$2"
+  local perm="$3"
+  local expected_prefix="$4"
+  ran=$((ran + 1))
+  local actual
+  actual=$(CFGMS_TEST_COLLAB_PERM="$perm" "$DISPATCH" _test-check-author "$login")
+  if [[ "$actual" == "$expected_prefix"* ]]; then
+    printf '  ok    %s\n' "$description"
+  else
+    printf '  FAIL  %s\n        login=%q perm=%q\n        expected prefix=%q\n        actual=%q\n' \
+      "$description" "$login" "$perm" "$expected_prefix" "$actual"
+    fail=$((fail + 1))
+  fi
+}
+
+# push/maintain/admin → internal
+assert_author_trust "push perm → internal" "alice" "push" "internal"
+assert_author_trust "maintain perm → internal" "bob" "maintain" "internal"
+assert_author_trust "admin perm → internal" "carol" "admin" "internal"
+
+# triage/read/none/empty → external (fail-closed)
+assert_author_trust "triage perm → external" "dan" "triage" "external:"
+assert_author_trust "read perm → external" "eve" "read" "external:"
+assert_author_trust "empty perm (api error) → external" "frank" "" "external:"
+
+# null/empty login → external (fail-closed)
+assert_author_trust "empty login → external" "" "" "external:"
+
+# branch-name impersonation: external author with story branch name still gated
+assert_author_trust "external author despite story branch name → external" "impersonator" "read" "external:"
+
+echo
+echo "--- dispatch-gate: AC5 release-marker (issue #1786) ---"
+
+assert_author_trust_with_release() {
+  local description="$1"
+  local login="$2"
+  local author_perm="$3"
+  local actor_login="$4"
+  local actor_perm="$5"
+  local labels="$6"
+  local expected_prefix="$7"
+  ran=$((ran + 1))
+  local actual
+  # Pass pr_num=42 and labels as 3rd arg; CFGMS_TEST_ACTOR_LOGIN/PERM mock actor check
+  actual=$(CFGMS_TEST_COLLAB_PERM="$author_perm" \
+    CFGMS_TEST_ACTOR_LOGIN="$actor_login" \
+    CFGMS_TEST_ACTOR_PERM="$actor_perm" \
+    "$DISPATCH" _test-check-author "$login" "42" "$labels")
+  if [[ "$actual" == "$expected_prefix"* ]]; then
+    printf '  ok    %s\n' "$description"
+  else
+    printf '  FAIL  %s\n        expected prefix=%q\n        actual=%q\n' \
+      "$description" "$expected_prefix" "$actual"
+    fail=$((fail + 1))
+  fi
+}
+
+# AC5: push+ actor applied human-reviewed:ok → released (external PR becomes internal)
+assert_author_trust_with_release \
+  "AC5: push+ actor on human-reviewed:ok releases external PR" \
+  "external-user" "read" "trusted-maintainer" "push" "human-reviewed:ok" \
+  "internal"
+
+# AC5: maintain actor also releases
+assert_author_trust_with_release \
+  "AC5: maintain actor on human-reviewed:ok releases external PR" \
+  "external-user" "triage" "senior-dev" "maintain" "human-reviewed:ok" \
+  "internal"
+
+# AC5: triage actor does NOT release
+assert_author_trust_with_release \
+  "AC5: triage actor on human-reviewed:ok does NOT release external PR" \
+  "external-user" "read" "triage-user" "triage" "human-reviewed:ok" \
+  "external:"
+
+# AC5: empty actor login does NOT release (fail-closed)
+assert_author_trust_with_release \
+  "AC5: empty actor login does NOT release external PR" \
+  "external-user" "read" "" "push" "human-reviewed:ok" \
+  "external:"
+
+# AC5: human-reviewed:ok label absent → not released even with push+ actor
+assert_author_trust_with_release \
+  "AC5: no human-reviewed:ok label → not released despite push+ actor" \
+  "external-user" "read" "trusted-maintainer" "push" "some-other-label" \
+  "external:"
+
+echo
 echo "ran ${ran} assertions; failures: ${fail}"
 exit "$fail"

--- a/.claude/scripts/tests/test-preflight-external-pr.py
+++ b/.claude/scripts/tests/test-preflight-external-pr.py
@@ -1,0 +1,409 @@
+#!/usr/bin/env python3
+"""
+Tests: external-PR author trust gating in po-cycle-preflight.py (Issue #1786).
+
+AC1: is_external() — push/maintain/admin → internal; read/triage/none/404 → external.
+AC2: Fail-closed — null/empty login, 403/5xx/timeout, unknown login → external.
+AC4: External author on feature/story-N-agent branch yields story_number=None
+     (impersonation defeated).
+AC5: human-reviewed:ok release marker valid only when actor has push+ permission.
+
+Run: python3 .claude/scripts/tests/test-preflight-external-pr.py
+"""
+import importlib.util
+import json
+import os
+import sys
+import unittest
+
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+PREFLIGHT_PATH = os.path.join(SCRIPT_DIR, "..", "po-cycle-preflight.py")
+
+
+def _load_preflight():
+    spec = importlib.util.spec_from_file_location("preflight", PREFLIGHT_PATH)
+    m = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(m)
+    return m
+
+
+def _make_raw_pr(number=999, head_ref="feature/story-999-agent", author_login="someuser",
+                 is_draft=False, labels=None, timeline_items=None, comments=None,
+                 status_rollup=None, body="", mergeable="MERGEABLE", merge_state="CLEAN"):
+    """Build a minimal PR node as returned by gh_graphql_pipeline_overview (prs list)."""
+    return {
+        "number": number,
+        "title": f"PR #{number}",
+        "body": body,
+        "isDraft": is_draft,
+        "headRefName": head_ref,
+        "mergeable": mergeable,
+        "mergeStateStatus": merge_state,
+        "autoMergeRequest": None,
+        "author_login": author_login,
+        "labels": labels if labels is not None else [],
+        "timeline_items": timeline_items if timeline_items is not None else [],
+        "comments": comments if comments is not None else [],
+        "statusCheckRollup": status_rollup if status_rollup is not None else [],
+        "latest_commit_date": None,
+    }
+
+
+class TestIsExternal(unittest.TestCase):
+    """AC1 + AC2: is_external() classification with permission-level semantics."""
+
+    def setUp(self):
+        self.pf = _load_preflight()
+        self.pf._perm_cache.clear()
+
+    def tearDown(self):
+        os.environ.pop("CFGMS_TEST_COLLAB_PERM_MAP", None)
+        self.pf._perm_cache.clear()
+
+    def _set_perm_map(self, mapping):
+        os.environ["CFGMS_TEST_COLLAB_PERM_MAP"] = json.dumps(mapping)
+
+    # AC1: trusted permission levels
+    def test_push_is_internal(self):
+        self._set_perm_map({"alice": "push"})
+        self.assertFalse(self.pf.is_external("alice"))
+
+    def test_maintain_is_internal(self):
+        self._set_perm_map({"alice": "maintain"})
+        self.assertFalse(self.pf.is_external("alice"))
+
+    def test_admin_is_internal(self):
+        self._set_perm_map({"alice": "admin"})
+        self.assertFalse(self.pf.is_external("alice"))
+
+    # AC1: untrusted permission levels
+    def test_read_is_external(self):
+        self._set_perm_map({"bob": "read"})
+        self.assertTrue(self.pf.is_external("bob"))
+
+    def test_triage_is_external(self):
+        self._set_perm_map({"bob": "triage"})
+        self.assertTrue(self.pf.is_external("bob"))
+
+    def test_none_perm_is_external(self):
+        self._set_perm_map({"bob": "none"})
+        self.assertTrue(self.pf.is_external("bob"))
+
+    # AC2: fail-closed outcomes
+    def test_404_login_not_in_map_is_external(self):
+        """Login not in collaborators map (404) → _collab_permission returns None → external."""
+        self._set_perm_map({})
+        self.assertTrue(self.pf.is_external("unknown-user"))
+
+    def test_empty_login_is_external(self):
+        """AC2: null/empty author login → fail-closed → external."""
+        self._set_perm_map({})
+        self.assertTrue(self.pf.is_external(""))
+
+    def test_none_login_is_external(self):
+        """AC2: None author login (deleted/ghost account) → fail-closed → external."""
+        self._set_perm_map({})
+        self.assertTrue(self.pf.is_external(None))
+
+    def test_whitespace_login_is_external(self):
+        """AC2: whitespace-only login → external (no valid identity)."""
+        self._set_perm_map({})
+        self.assertTrue(self.pf.is_external("   "))
+
+    def test_perm_cache_consulted(self):
+        """Cached result is used on second call."""
+        self._set_perm_map({"alice": "push"})
+        self.pf.is_external("alice")
+        # Poison cache: simulate stale entry degrading to triage.
+        self.pf._perm_cache["alice"] = "triage"
+        # Must return True (external) from stale cache — no second API call.
+        self.assertTrue(self.pf.is_external("alice"))
+
+
+class TestReleaseMarkerActorLogin(unittest.TestCase):
+    """AC5: _release_marker_actor_login extracts the actor of the most recent
+    LABELED_EVENT for 'human-reviewed:ok'."""
+
+    def setUp(self):
+        self.pf = _load_preflight()
+
+    def test_no_timeline_items(self):
+        self.assertEqual(self.pf._release_marker_actor_login([]), "")
+
+    def test_non_matching_label(self):
+        items = [{"label": {"name": "other-label"}, "actor": {"login": "alice"}, "createdAt": "2026-01-01Z"}]
+        self.assertEqual(self.pf._release_marker_actor_login(items), "")
+
+    def test_matching_label_returns_actor(self):
+        items = [{"label": {"name": "human-reviewed:ok"}, "actor": {"login": "alice"}, "createdAt": "2026-01-01Z"}]
+        self.assertEqual(self.pf._release_marker_actor_login(items), "alice")
+
+    def test_multiple_events_returns_last(self):
+        """Most recent (last) LABELED_EVENT actor for the label is authoritative."""
+        items = [
+            {"label": {"name": "human-reviewed:ok"}, "actor": {"login": "first-actor"}, "createdAt": "2026-01-01Z"},
+            {"label": {"name": "other-label"}, "actor": {"login": "noise"}, "createdAt": "2026-01-02Z"},
+            {"label": {"name": "human-reviewed:ok"}, "actor": {"login": "last-actor"}, "createdAt": "2026-01-03Z"},
+        ]
+        self.assertEqual(self.pf._release_marker_actor_login(items), "last-actor")
+
+    def test_null_label_ignored(self):
+        items = [{"label": None, "actor": {"login": "alice"}, "createdAt": "2026-01-01Z"}]
+        self.assertEqual(self.pf._release_marker_actor_login(items), "")
+
+    def test_null_actor_yields_empty(self):
+        items = [{"label": {"name": "human-reviewed:ok"}, "actor": None, "createdAt": "2026-01-01Z"}]
+        self.assertEqual(self.pf._release_marker_actor_login(items), "")
+
+
+class TestBuildPrSummaries(unittest.TestCase):
+    """Integration tests for _build_pr_summaries — the Phase 4 refactor.
+
+    Covers: author_login extraction, is_external flag, story_number gating (AC4),
+    and is_released flag (AC5).
+    """
+
+    def setUp(self):
+        self.pf = _load_preflight()
+        self.pf._perm_cache.clear()
+
+    def tearDown(self):
+        os.environ.pop("CFGMS_TEST_COLLAB_PERM_MAP", None)
+        self.pf._perm_cache.clear()
+
+    def _set_perm_map(self, mapping):
+        os.environ["CFGMS_TEST_COLLAB_PERM_MAP"] = json.dumps(mapping)
+
+    def test_internal_author_gets_story_number(self):
+        self._set_perm_map({"cfg-agent": "push"})
+        prs = [_make_raw_pr(number=1234, head_ref="feature/story-1234-agent",
+                             author_login="cfg-agent")]
+        summaries = self.pf._build_pr_summaries(prs)
+        self.assertEqual(len(summaries), 1)
+        self.assertEqual(summaries[0]["story_number"], 1234)
+        self.assertFalse(summaries[0]["is_external"])
+        self.assertFalse(summaries[0]["is_released"])
+
+    def test_external_story_branch_yields_none_story_number(self):
+        """AC4: external author on feature/story-N-agent gets story_number=None (impersonation defeated)."""
+        self._set_perm_map({"external-user": "read"})
+        prs = [_make_raw_pr(number=999, head_ref="feature/story-999-agent",
+                             author_login="external-user")]
+        summaries = self.pf._build_pr_summaries(prs)
+        self.assertEqual(len(summaries), 1)
+        self.assertIsNone(summaries[0]["story_number"])
+        self.assertTrue(summaries[0]["is_external"])
+
+    def test_null_author_yields_none_story_number(self):
+        """AC2: null author_login fails closed — story_number=None, is_external=True."""
+        self._set_perm_map({})
+        prs = [_make_raw_pr(number=999, head_ref="feature/story-999-agent",
+                             author_login="")]
+        summaries = self.pf._build_pr_summaries(prs)
+        self.assertEqual(len(summaries), 1)
+        self.assertIsNone(summaries[0]["story_number"])
+        self.assertTrue(summaries[0]["is_external"])
+
+    def test_human_reviewed_ok_by_push_sets_released(self):
+        """AC5: human-reviewed:ok applied by push+ collaborator → is_released=True."""
+        self._set_perm_map({
+            "external-user": "read",
+            "maintainer": "push",
+        })
+        timeline = [
+            {"label": {"name": "human-reviewed:ok"}, "actor": {"login": "maintainer"},
+             "createdAt": "2026-06-01T00:00:00Z"},
+        ]
+        prs = [_make_raw_pr(
+            number=999,
+            author_login="external-user",
+            labels=[{"name": "human-reviewed:ok"}],
+            timeline_items=timeline,
+        )]
+        summaries = self.pf._build_pr_summaries(prs)
+        self.assertTrue(summaries[0]["is_external"])
+        self.assertTrue(summaries[0]["is_released"])
+
+    def test_human_reviewed_ok_by_triage_does_not_release(self):
+        """AC5: triage actor applying human-reviewed:ok does NOT release an external PR."""
+        self._set_perm_map({
+            "external-user": "read",
+            "triager": "triage",
+        })
+        timeline = [
+            {"label": {"name": "human-reviewed:ok"}, "actor": {"login": "triager"},
+             "createdAt": "2026-06-01T00:00:00Z"},
+        ]
+        prs = [_make_raw_pr(
+            number=999,
+            author_login="external-user",
+            labels=[{"name": "human-reviewed:ok"}],
+            timeline_items=timeline,
+        )]
+        summaries = self.pf._build_pr_summaries(prs)
+        self.assertTrue(summaries[0]["is_external"])
+        self.assertFalse(summaries[0]["is_released"])
+
+    def test_label_absent_means_not_released(self):
+        """No human-reviewed:ok label → is_released=False."""
+        self._set_perm_map({"external-user": "read", "maintainer": "push"})
+        prs = [_make_raw_pr(
+            number=999,
+            author_login="external-user",
+            labels=[],
+            timeline_items=[
+                {"label": {"name": "human-reviewed:ok"}, "actor": {"login": "maintainer"},
+                 "createdAt": "2026-06-01T00:00:00Z"},
+            ],
+        )]
+        summaries = self.pf._build_pr_summaries(prs)
+        self.assertFalse(summaries[0]["is_released"])
+
+
+class TestComputeReviewRecommendationsExternalPR(unittest.TestCase):
+    """AC3/AC4: external PRs get action='skip' (quarantined)."""
+
+    def setUp(self):
+        self.pf = _load_preflight()
+
+    def _make_summary(self, pr_num=999, story_num=None, is_external=True,
+                      is_released=False, is_draft=False, ci_overall="green",
+                      has_review=False, wip_failed=False, merge_state="CLEAN",
+                      mergeable="MERGEABLE"):
+        return {
+            "pr": pr_num,
+            "story_number": story_num,
+            "is_external": is_external,
+            "is_released": is_released,
+            "is_draft": is_draft,
+            "wip_session_failed": wip_failed,
+            "has_acceptance_review_comment": has_review,
+            "latest_review_verdict": None,
+            "latest_review_comment_date": None,
+            "latest_commit_date": None,
+            "merge_state_status": merge_state,
+            "mergeable": mergeable,
+            "auto_merge_enabled": False,
+            "ci_summary": {
+                "overall": ci_overall,
+                "pass": 4 if ci_overall == "green" else 0,
+                "pending": 0, "fail": 0 if ci_overall != "red" else 1,
+                "skipped": 0,
+                "pending_checks": [],
+                "failed_checks": ["unit-tests"] if ci_overall == "red" else [],
+            },
+        }
+
+    def test_external_unreleased_pr_is_skipped(self):
+        """AC3: unreleased external PR → action=skip (quarantined, never reviewed/merged)."""
+        summaries = [self._make_summary(is_external=True, is_released=False)]
+        recs = self.pf.compute_review_recommendations(summaries, set())
+        self.assertEqual(len(recs), 1)
+        self.assertEqual(recs[0]["action"], "skip")
+        self.assertIn("external", recs[0]["reason"].lower())
+
+    def test_external_released_pr_proceeds_to_review(self):
+        """AC5: validly released external PR (human-reviewed:ok by push+) proceeds normally."""
+        summaries = [self._make_summary(
+            is_external=True, is_released=True,
+            ci_overall="green", has_review=False,
+        )]
+        recs = self.pf.compute_review_recommendations(summaries, set())
+        self.assertEqual(len(recs), 1)
+        self.assertEqual(recs[0]["action"], "spawn_acceptance_reviewer")
+
+    def test_internal_pr_not_affected(self):
+        """Internal PRs are unaffected by the external gate."""
+        summaries = [self._make_summary(
+            is_external=False, is_released=False,
+            ci_overall="green", has_review=False,
+        )]
+        recs = self.pf.compute_review_recommendations(summaries, set())
+        self.assertEqual(len(recs), 1)
+        self.assertEqual(recs[0]["action"], "spawn_acceptance_reviewer")
+
+    def test_external_draft_pr_is_skipped_as_external(self):
+        """External draft PR gets the external-quarantine skip, not the draft skip."""
+        summaries = [self._make_summary(
+            is_external=True, is_released=False, is_draft=True,
+        )]
+        recs = self.pf.compute_review_recommendations(summaries, set())
+        self.assertEqual(len(recs), 1)
+        self.assertEqual(recs[0]["action"], "skip")
+        # Reason should call out external, not 'draft PR' (external gate fires first).
+        self.assertIn("external", recs[0]["reason"].lower())
+
+    def test_external_unreleased_red_ci_still_skipped(self):
+        """External PR with red CI → skip (quarantined), not investigate/rebase."""
+        summaries = [self._make_summary(is_external=True, is_released=False, ci_overall="red")]
+        recs = self.pf.compute_review_recommendations(summaries, set())
+        self.assertEqual(len(recs), 1)
+        self.assertEqual(recs[0]["action"], "skip")
+
+
+class TestExternalPRImpersonationBlocked(unittest.TestCase):
+    """AC4: feature/story-<N>-agent branch from external author yields story_number=None.
+
+    This defeats a scenario where an external attacker names their branch
+    feature/story-<N>-agent to spoof story linkage and cause the pipeline
+    to act on their PR as if it were first-party story work.
+    """
+
+    def setUp(self):
+        self.pf = _load_preflight()
+        self.pf._perm_cache.clear()
+
+    def tearDown(self):
+        os.environ.pop("CFGMS_TEST_COLLAB_PERM_MAP", None)
+        self.pf._perm_cache.clear()
+
+    def _set_perm_map(self, mapping):
+        os.environ["CFGMS_TEST_COLLAB_PERM_MAP"] = json.dumps(mapping)
+
+    def test_impersonating_branch_from_external_author_blocked(self):
+        """External author on feature/story-N-agent → story_number=None, action=skip."""
+        self._set_perm_map({"external-attacker": "read"})
+        prs = [_make_raw_pr(
+            number=1786,
+            head_ref="feature/story-1786-agent",
+            author_login="external-attacker",
+        )]
+        summaries = self.pf._build_pr_summaries(prs)
+        self.assertIsNone(summaries[0]["story_number"])
+        self.assertTrue(summaries[0]["is_external"])
+
+        recs = self.pf.compute_review_recommendations(summaries, set())
+        self.assertEqual(recs[0]["action"], "skip")
+        self.assertIn("external", recs[0]["reason"].lower())
+
+    def test_internal_story_branch_gets_correct_story_number(self):
+        """Internal author on the same branch pattern gets the correct story_number."""
+        self._set_perm_map({"cfg-agent": "push"})
+        prs = [_make_raw_pr(
+            number=1786,
+            head_ref="feature/story-1786-agent",
+            author_login="cfg-agent",
+        )]
+        summaries = self.pf._build_pr_summaries(prs)
+        self.assertEqual(summaries[0]["story_number"], 1786)
+        self.assertFalse(summaries[0]["is_external"])
+
+    def test_item_branch_from_external_author_blocked(self):
+        """AC4: external author on feature/item-XXX-agent also denied story linkage."""
+        self._set_perm_map({"external-user": "triage"})
+        prs = [_make_raw_pr(
+            number=500,
+            head_ref="feature/item-BX5ezzgtQqQA-agent",
+            author_login="external-user",
+        )]
+        summaries = self.pf._build_pr_summaries(prs)
+        # story_number is None for item branches regardless, but is_external must be True.
+        self.assertIsNone(summaries[0]["story_number"])
+        self.assertTrue(summaries[0]["is_external"])
+
+        recs = self.pf.compute_review_recommendations(summaries, set())
+        self.assertEqual(recs[0]["action"], "skip")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,8 @@ test-*
 !.devcontainer/scripts/test-*.sh
 # Shell test scripts in .claude/scripts/tests/ are not binaries — allow them
 !.claude/scripts/tests/test-*.sh
+# Python test scripts in .claude/scripts/tests/ are also tracked
+!.claude/scripts/tests/test-*.py
 
 # Generated protobuf files in wrong location (should be in api/proto/)
 /steward/

--- a/docs/development/external-contributors.md
+++ b/docs/development/external-contributors.md
@@ -1,0 +1,61 @@
+# External Contributors
+
+This document describes how the CFGMS autonomous pipeline handles pull requests from contributors who are not trusted repository collaborators (`push`, `maintain`, or `admin` permission level).
+
+## Quarantine model
+
+The pipeline classifies every PR author by their GitHub collaborator permission level:
+
+| Permission | Classification | Pipeline action |
+|------------|---------------|-----------------|
+| `admin`, `maintain`, `push` | Internal (trusted) | Normal review and merge flow |
+| `triage`, `read`, `none` | External (untrusted) | Quarantined — pipeline skips |
+| Unknown / API error | External (fail-closed) | Quarantined — pipeline skips |
+
+Quarantine is enforced **before any `git fetch`, `git checkout`, container launch, or merge-queue enqueue** across all dispatch paths:
+
+- `agent-dispatch.sh review-pr` — refused before cloning
+- `agent-dispatch.sh create-clone-pr` — refused before cloning
+- `agent-dispatch.sh check-pr-author` — explicit trust check (used by po-act.sh)
+- `po-act.sh dispatch-fix` — refused before worktree creation
+- `po-act.sh enqueue` — TOCTOU re-check before `gh pr merge --squash`
+
+A quarantine comment is posted on the PR explaining the hold and linking to this document.
+
+## Releasing a quarantined PR
+
+A repository maintainer (push+) reviews the PR manually and, when satisfied:
+
+1. Checks that the contributor has signed the CLA (see below).
+2. Reviews the branch name — external authors cannot spoof an internal story link via a `feature/story-N-agent`-style branch name; the pipeline gates on author trust, not branch naming.
+3. Applies the `human-reviewed:ok` label.
+
+The label application event is recorded in the GitHub timeline. When the pipeline next processes the PR, it verifies that the actor who applied the label holds `push`, `maintain`, or `admin` permission. A label applied by another external actor is not accepted.
+
+Once released, the PR flows through the normal autonomous review and merge path.
+
+## Contributor License Agreement (CLA)
+
+External contributors must sign the CLA before their work can be merged. To sign:
+
+1. Read [docs/legal/CLA.md](../legal/CLA.md).
+2. Add your name and GitHub username to `CONTRIBUTORS.md` in the same PR.
+3. A maintainer can verify CLA status with:
+
+   ```bash
+   scripts/check-cla-signed.sh <github-login>
+   ```
+
+   Exit 0 = signed; exit 1 = not signed.
+
+## Attribution
+
+When an external-contributor PR is merged, the maintainer confirms attribution in the merge commit. The contributor's name and any co-author lines already in the PR are preserved by the squash merge.
+
+## Branch-name impersonation
+
+The pipeline does **not** use branch names as a trust signal. An external author naming their branch `feature/story-1234-agent` to impersonate a pipeline-dispatched story branch is detected and blocked: the branch-to-story link is suppressed for external PRs, and the author gate fires independently of the branch name.
+
+## Cron dashboard output
+
+The `po-cycle-preflight.py` preflight emits an `external_prs` list in its JSON output. The PO agent surfaces this in the dashboard under **EXTERNAL PR QUARANTINE**. Each entry shows the PR number, author login, head branch, title, and whether it has been released with `human-reviewed:ok`.

--- a/features/steward/steward_test.go
+++ b/features/steward/steward_test.go
@@ -350,6 +350,18 @@ func TestMonitorCloseRace(t *testing.T) {
 		// on Linux/macOS it appears below internal/poll.runtime_pollWait; on Windows
 		// it appears below syscall.syscalln via Start.func2.
 		goleak.IgnoreAnyFunction("os/exec.(*Cmd).writerDescriptor.func1"),
+		// DNA background collection goroutine tree from sibling tests. Each goroutine
+		// is ignored by its OWN function name (top-level closure) so it is caught
+		// regardless of which frame it is currently executing — in particular when the
+		// called method has returned but the deferred cancel/Done hasn't run yet.
+		// Without these, the outer wrapper (Collect.func1.1) can be seen in the brief
+		// window between runBackgroundCollection returning and defer bgCancel() completing
+		// on a slow macOS runner, slipping past the frame-based ignores below.
+		goleak.IgnoreAnyFunction("github.com/cfgis/cfgms/features/steward/dna.(*Collector).Collect.func1.1"),
+		goleak.IgnoreAnyFunction("github.com/cfgis/cfgms/features/steward/dna.(*Collector).runBackgroundCollection.func1"),
+		goleak.IgnoreAnyFunction("github.com/cfgis/cfgms/features/steward/dna.(*Collector).runBackgroundCollection.func2"),
+		// Frame-based ignores: match any goroutine whose stack passes through these
+		// functions (belt-and-suspenders for the common case where the method is active).
 		goleak.IgnoreAnyFunction("github.com/cfgis/cfgms/features/steward/dna.(*Collector).runBackgroundCollection"),
 		goleak.IgnoreAnyFunction("github.com/cfgis/cfgms/features/steward/dna.(*Collector).collectSoftwareInfo"),
 		goleak.IgnoreAnyFunction("github.com/cfgis/cfgms/features/steward/dna.(*Collector).collectSecurityInfo"),

--- a/features/steward/steward_test.go
+++ b/features/steward/steward_test.go
@@ -335,22 +335,21 @@ func TestMonitorCloseRace(t *testing.T) {
 	// goroutines (stdout/stderr pipe copy + ctx-watch). All of these can be
 	// mid-flight when this test's goleak check runs on a slow runner.
 	//
-	// goleak.IgnoreAnyFunction matches goroutines that have the named function
-	// anywhere in their OWN stack — it does NOT match the "created by" line
-	// (goleak explicitly excludes creator functions from the match set). The
-	// os/exec goroutines fall into two families:
-	//
-	//   1. Pipe I/O copiers: top = internal/poll.runtime_pollWait, with
-	//      os/exec.(*Cmd).Start.func2 further down (the goroutine entry point).
-	//      IgnoreTopFunction("writerDescriptor") misses these because the top
-	//      function is the poll wait, not the copier.
-	//
-	//   2. Context watcher: os/exec.(*Cmd).watchCtx on top.
-	//
-	// Match by the actual goroutine entry-point functions visible in the stack.
+	// Match each family by ANY frame in the stack. The os/exec pipe-reader goroutines
+	// are the ones that trip this on Windows: they block in syscall.syscalln (slow I/O)
+	// long after the command exits. goleak.HasFunction checks allFunctions which
+	// excludes the "created by" frame, so IgnoreAnyFunction("os/exec.(*Cmd).Start")
+	// is a no-op. writerDescriptor.func1 IS a regular call-stack frame on all
+	// platforms: on Linux/macOS it sits below internal/poll.runtime_pollWait; on
+	// Windows it sits below syscall.syscalln via Start.func2.
 	goleak.VerifyNone(t, existingGoroutines,
-		goleak.IgnoreAnyFunction("os/exec.(*Cmd).Start.func2"),
-		goleak.IgnoreAnyFunction("os/exec.(*Cmd).watchCtx"),
+		// os/exec pipe-reader goroutines spawned by DNA collection in sibling tests.
+		// goleak.HasFunction checks allFunctions which excludes the "created by"
+		// frame, so IgnoreAnyFunction("os/exec.(*Cmd).Start") is a no-op.
+		// writerDescriptor.func1 IS a regular call-stack frame on all platforms:
+		// on Linux/macOS it appears below internal/poll.runtime_pollWait; on Windows
+		// it appears below syscall.syscalln via Start.func2.
+		goleak.IgnoreAnyFunction("os/exec.(*Cmd).writerDescriptor.func1"),
 		goleak.IgnoreAnyFunction("github.com/cfgis/cfgms/features/steward/dna.(*Collector).runBackgroundCollection"),
 		goleak.IgnoreAnyFunction("github.com/cfgis/cfgms/features/steward/dna.(*Collector).collectSoftwareInfo"),
 		goleak.IgnoreAnyFunction("github.com/cfgis/cfgms/features/steward/dna.(*Collector).collectSecurityInfo"),

--- a/scripts/check-cla-signed.sh
+++ b/scripts/check-cla-signed.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# check-cla-signed.sh <github-login>
+# Exits 0 if the login appears in CONTRIBUTORS.md; exits 1 otherwise.
+# Used as a CLA stopgap during human review of external-author PRs.
+set -euo pipefail
+
+login="${1:?Usage: check-cla-signed.sh <github-login>}"
+repo_root="$(cd "$(dirname "$0")/.." && pwd)"
+contributors="${repo_root}/CONTRIBUTORS.md"
+
+if [[ ! -f "$contributors" ]]; then
+  echo "ERROR: CONTRIBUTORS.md not found at ${contributors}" >&2
+  exit 1
+fi
+
+if grep -qiF "@${login}" "$contributors" 2>/dev/null || \
+   grep -qiF "github.com/${login}" "$contributors" 2>/dev/null || \
+   grep -qiF "[${login}]" "$contributors" 2>/dev/null; then
+  echo "CLA_SIGNED:${login}"
+  exit 0
+else
+  echo "CLA_NOT_SIGNED:${login}"
+  exit 1
+fi

--- a/scripts/test-scripts.sh
+++ b/scripts/test-scripts.sh
@@ -1569,6 +1569,128 @@ print(d.get('fields',{}).get('PR',''))
     fi
 }
 
+test_check_cla_signed() {
+    log_test "Testing check-cla-signed.sh: exit 0 for known contributor, exit 1 for absent login..."
+
+    local script
+    script="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/check-cla-signed.sh"
+
+    if [[ ! -f "$script" ]]; then
+        log_fail "check-cla-signed.sh: Script not found at $script"
+        return
+    fi
+
+    if [[ ! -x "$script" ]]; then
+        log_fail "check-cla-signed.sh: Not executable"
+        return
+    fi
+
+    local tmp_dir
+    tmp_dir=$(mktemp -d)
+    trap 'rm -rf "$tmp_dir"' RETURN
+
+    # Build a temp repo layout: $tmp_dir/CONTRIBUTORS.md + $tmp_dir/scripts/check-cla-signed.sh
+    # The script derives repo root as $(dirname "$0")/.. — so placing it under scripts/ makes
+    # it pick up $tmp_dir/CONTRIBUTORS.md without modifying the script under test.
+    mkdir -p "${tmp_dir}/scripts"
+    cp "$script" "${tmp_dir}/scripts/check-cla-signed.sh"
+
+    cat > "${tmp_dir}/CONTRIBUTORS.md" << 'CONTRIBEOF'
+# Test Contributors
+@alice-contributor
+github.com/bob-contributor
+[carol-contributor] carol@example.com
+CONTRIBEOF
+
+    local exit_code output
+
+    # --- AC7 Part 1: login present via @login pattern → exit 0 ----------------
+    exit_code=0
+    output=$("${tmp_dir}/scripts/check-cla-signed.sh" "alice-contributor" 2>&1) || exit_code=$?
+    if [[ $exit_code -eq 0 ]]; then
+        log_pass "check-cla-signed.sh: exit 0 for login matched via @login pattern"
+    else
+        log_fail "check-cla-signed.sh: expected exit 0 for @alice-contributor, got $exit_code (output: $output)"
+    fi
+    if echo "$output" | grep -q "CLA_SIGNED:alice-contributor"; then
+        log_pass "check-cla-signed.sh: prints CLA_SIGNED:<login> on success"
+    else
+        log_fail "check-cla-signed.sh: expected CLA_SIGNED:alice-contributor in output, got: $output"
+    fi
+
+    # --- AC7 Part 2: login present via github.com/login pattern → exit 0 ------
+    exit_code=0
+    output=$("${tmp_dir}/scripts/check-cla-signed.sh" "bob-contributor" 2>&1) || exit_code=$?
+    if [[ $exit_code -eq 0 ]]; then
+        log_pass "check-cla-signed.sh: exit 0 for login matched via github.com/login pattern"
+    else
+        log_fail "check-cla-signed.sh: expected exit 0 for bob-contributor, got $exit_code"
+    fi
+    if echo "$output" | grep -q "CLA_SIGNED:bob-contributor"; then
+        log_pass "check-cla-signed.sh: prints CLA_SIGNED:<login> for github.com/login pattern"
+    else
+        log_fail "check-cla-signed.sh: expected CLA_SIGNED:bob-contributor in output, got: $output"
+    fi
+
+    # --- AC7 Part 3: login present via [login] pattern → exit 0 ---------------
+    exit_code=0
+    output=$("${tmp_dir}/scripts/check-cla-signed.sh" "carol-contributor" 2>&1) || exit_code=$?
+    if [[ $exit_code -eq 0 ]]; then
+        log_pass "check-cla-signed.sh: exit 0 for login matched via [login] pattern"
+    else
+        log_fail "check-cla-signed.sh: expected exit 0 for carol-contributor, got $exit_code"
+    fi
+    if echo "$output" | grep -q "CLA_SIGNED:carol-contributor"; then
+        log_pass "check-cla-signed.sh: prints CLA_SIGNED:<login> for [login] pattern"
+    else
+        log_fail "check-cla-signed.sh: expected CLA_SIGNED:carol-contributor in output, got: $output"
+    fi
+
+    # --- AC7 Part 4: login absent from CONTRIBUTORS.md → exit 1 ---------------
+    exit_code=0
+    output=$("${tmp_dir}/scripts/check-cla-signed.sh" "unknown-outsider" 2>&1) || exit_code=$?
+    if [[ $exit_code -eq 1 ]]; then
+        log_pass "check-cla-signed.sh: exit 1 for login absent from CONTRIBUTORS.md"
+    else
+        log_fail "check-cla-signed.sh: expected exit 1 for absent login, got $exit_code"
+    fi
+    if echo "$output" | grep -q "CLA_NOT_SIGNED:unknown-outsider"; then
+        log_pass "check-cla-signed.sh: prints CLA_NOT_SIGNED:<login> when absent"
+    else
+        log_fail "check-cla-signed.sh: expected CLA_NOT_SIGNED:unknown-outsider in output, got: $output"
+    fi
+
+    # --- AC7 Part 5: CONTRIBUTORS.md absent → exit 1 with ERROR message -------
+    local no_contrib_dir
+    no_contrib_dir=$(mktemp -d)
+    mkdir -p "${no_contrib_dir}/scripts"
+    cp "$script" "${no_contrib_dir}/scripts/check-cla-signed.sh"
+    # No CONTRIBUTORS.md created in no_contrib_dir
+
+    exit_code=0
+    output=$("${no_contrib_dir}/scripts/check-cla-signed.sh" "anyone" 2>&1) || exit_code=$?
+    rm -rf "$no_contrib_dir"
+    if [[ $exit_code -eq 1 ]]; then
+        log_pass "check-cla-signed.sh: exit 1 when CONTRIBUTORS.md does not exist"
+    else
+        log_fail "check-cla-signed.sh: expected exit 1 for missing CONTRIBUTORS.md, got $exit_code"
+    fi
+    if echo "$output" | grep -q "ERROR:"; then
+        log_pass "check-cla-signed.sh: prints ERROR: message when CONTRIBUTORS.md missing"
+    else
+        log_fail "check-cla-signed.sh: expected ERROR: in output when CONTRIBUTORS.md missing, got: $output"
+    fi
+
+    # --- AC7 Part 6: no argument → non-zero exit (usage guard) ----------------
+    exit_code=0
+    output=$("${tmp_dir}/scripts/check-cla-signed.sh" 2>&1) || exit_code=$?
+    if [[ $exit_code -ne 0 ]]; then
+        log_pass "check-cla-signed.sh: non-zero exit when invoked with no argument"
+    else
+        log_fail "check-cla-signed.sh: expected non-zero exit with no argument, got 0"
+    fi
+}
+
 test_trust_boundary() {
     log_test "Running trust boundary regression suite (test/security/trust_boundary_test.sh)..."
 
@@ -3071,6 +3193,8 @@ echo ""
 test_preflight_acceptance_review_comment_match
 echo ""
 test_preflight_review_verdict_routing
+echo ""
+test_check_cla_signed
 echo ""
 test_trust_boundary
 echo ""

--- a/scripts/test-scripts.sh
+++ b/scripts/test-scripts.sh
@@ -2223,11 +2223,13 @@ exit 0
 PQEOF
     chmod +x "${fake_repo}/scripts/project-queue.sh"
 
-    # Mock gh: returns an open item-branch PR
+    # Mock gh: returns an open item-branch PR with a trusted internal author.
+    # The CFGMS_TEST_COLLAB_PERM=push env var below satisfies the external-author
+    # gate without a real gh api call, so the test reaches the item-branch scan.
     cat > "${tmp_dir}/gh" << 'GHEOF'
 #!/usr/bin/env bash
 if [[ "$1" == "pr" && "$2" == "view" ]]; then
-    printf '{"state":"OPEN","headRefName":"feature/item-ABCD12345678-agent","body":"No fixes link","labels":[],"headRepositoryOwner":{"login":"cfg-is"}}\n'
+    printf '{"state":"OPEN","headRefName":"feature/item-ABCD12345678-agent","body":"No fixes link","labels":[],"headRepositoryOwner":{"login":"cfg-is"},"author":{"login":"trusted-maintainer"}}\n'
 elif [[ "$1" == "auth" && "$2" == "token" ]]; then
     echo "fake-token"
 else
@@ -2250,6 +2252,7 @@ DOCKEREOF
         CFGMS_TEST_REPO_ROOT="$fake_repo" \
         CFGMS_TEST_WORKTREE_BASE="$worktree_dir" \
         CFGMS_TEST_CREDS_STATUS="CREDS_OK:60" \
+        CFGMS_TEST_COLLAB_PERM="push" \
         bash "$dispatch_script" review-pr 77 2>&1
     ) || exit_code=$?
 
@@ -2270,6 +2273,148 @@ DOCKEREOF
         log_pass "review_pr_item_branch: project-queue list-by-status was called (scan attempted)"
     else
         log_fail "review_pr_item_branch: list-by-status not called — item-branch scan path not exercised"
+    fi
+
+    rm -rf "$tmp_dir"
+}
+
+test_create_clone_pr_external_author() {
+    log_test "Testing create-clone-pr: external-author gate refuses before git clone..."
+
+    local tmp_dir
+    tmp_dir=$(mktemp -d)
+    local worktree_dir="${tmp_dir}/worktrees"
+    mkdir -p "$worktree_dir"
+    local dispatch_script
+    dispatch_script="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/../.claude/scripts/agent-dispatch.sh"
+
+    # Mock gh: returns an open PR with an external (read-level) author.
+    # The CFGMS_TEST_COLLAB_PERM=read below makes the permission API return "read".
+    cat > "${tmp_dir}/gh" << 'GHEOF'
+#!/usr/bin/env bash
+if [[ "$1" == "pr" && "$2" == "view" ]]; then
+    printf '{"headRefName":"feature/story-9999-test","body":"Fixes #9999","labels":[],"author":{"login":"external-user"}}\n'
+elif [[ "$1" == "pr" && "$2" == "comment" ]]; then
+    exit 0
+else
+    printf '{}\n'
+fi
+exit 0
+GHEOF
+    chmod +x "${tmp_dir}/gh"
+
+    local fake_repo="${tmp_dir}/repo"
+    git -C "${tmp_dir}" init -q repo
+    git -C "${fake_repo}" remote add origin "https://github.com/cfg-is/cfgms.git"
+
+    local output exit_code=0
+    output=$(
+        PATH="${tmp_dir}:${PATH}" \
+        CFGMS_TEST_REPO_ROOT="$fake_repo" \
+        CFGMS_TEST_WORKTREE_BASE="$worktree_dir" \
+        CFGMS_TEST_COLLAB_PERM="read" \
+        bash "$dispatch_script" create-clone-pr 9999 2>&1
+    ) || exit_code=$?
+
+    if [[ $exit_code -eq 3 ]]; then
+        log_pass "create_clone_pr_external: exits 3 for external author"
+    else
+        log_fail "create_clone_pr_external: expected exit 3, got ${exit_code}: ${output}"
+    fi
+
+    if echo "$output" | grep -q "FIX_REFUSED:9999:external_author"; then
+        log_pass "create_clone_pr_external: emits FIX_REFUSED:9999:external_author*"
+    else
+        log_fail "create_clone_pr_external: expected FIX_REFUSED:9999:external_author* in: ${output}"
+    fi
+
+    if [[ ! -d "${worktree_dir}/pr-fix-9999" ]]; then
+        log_pass "create_clone_pr_external: clone directory not created (gate fired before git clone)"
+    else
+        log_fail "create_clone_pr_external: clone directory must not exist when gate refuses"
+    fi
+
+    rm -rf "$tmp_dir"
+}
+
+test_dispatch_fix_external_author() {
+    log_test "Testing po-act.sh dispatch-fix: external-author gate refuses before container launch..."
+
+    local tmp_dir
+    tmp_dir=$(mktemp -d)
+    local po_act_script
+    po_act_script="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/../.claude/scripts/po-act.sh"
+
+    # Mock dispatch: check-pr-author returns external; any other subcommand fails loudly.
+    cat > "${tmp_dir}/mock-dispatch.sh" << 'DISPEOF'
+#!/usr/bin/env bash
+if [[ "$1" == "check-pr-author" ]]; then
+    echo "AUTHOR_EXTERNAL:${2:-?}:external-user:external:read"
+    exit 3
+fi
+echo "UNEXPECTED_DISPATCH_CALL: $*" >&2
+exit 1
+DISPEOF
+    chmod +x "${tmp_dir}/mock-dispatch.sh"
+
+    local output exit_code=0
+    output=$(
+        CFGMS_TEST_DISPATCH="${tmp_dir}/mock-dispatch.sh" \
+        CFGMS_TEST_WORKTREE_BASE="${tmp_dir}/worktrees" \
+        bash "$po_act_script" dispatch-fix 9999 2>&1
+    ) || exit_code=$?
+
+    if [[ $exit_code -eq 3 ]]; then
+        log_pass "dispatch_fix_external: exits 3 for external author"
+    else
+        log_fail "dispatch_fix_external: expected exit 3, got ${exit_code}: ${output}"
+    fi
+
+    if echo "$output" | grep -q "DISPATCH_FIX_REFUSED:9999:external_author"; then
+        log_pass "dispatch_fix_external: emits DISPATCH_FIX_REFUSED:9999:external_author"
+    else
+        log_fail "dispatch_fix_external: expected DISPATCH_FIX_REFUSED:9999:external_author in: ${output}"
+    fi
+
+    rm -rf "$tmp_dir"
+}
+
+test_enqueue_external_author_toctou() {
+    log_test "Testing po-act.sh enqueue: TOCTOU re-check refuses external author before merge queue..."
+
+    local tmp_dir
+    tmp_dir=$(mktemp -d)
+    local po_act_script
+    po_act_script="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/../.claude/scripts/po-act.sh"
+
+    # Mock dispatch: check-pr-author returns external.
+    cat > "${tmp_dir}/mock-dispatch.sh" << 'DISPEOF'
+#!/usr/bin/env bash
+if [[ "$1" == "check-pr-author" ]]; then
+    echo "AUTHOR_EXTERNAL:${2:-?}:external-user:external:read"
+    exit 3
+fi
+echo "UNEXPECTED_DISPATCH_CALL: $*" >&2
+exit 1
+DISPEOF
+    chmod +x "${tmp_dir}/mock-dispatch.sh"
+
+    local output exit_code=0
+    output=$(
+        CFGMS_TEST_DISPATCH="${tmp_dir}/mock-dispatch.sh" \
+        bash "$po_act_script" enqueue 9999 2>&1
+    ) || exit_code=$?
+
+    if [[ $exit_code -eq 3 ]]; then
+        log_pass "enqueue_external_toctou: exits 3 for external author (TOCTOU defense)"
+    else
+        log_fail "enqueue_external_toctou: expected exit 3, got ${exit_code}: ${output}"
+    fi
+
+    if echo "$output" | grep -q "ENQUEUE_REFUSED:9999:external_author"; then
+        log_pass "enqueue_external_toctou: emits ENQUEUE_REFUSED:9999:external_author"
+    else
+        log_fail "enqueue_external_toctou: expected ENQUEUE_REFUSED:9999:external_author in: ${output}"
     fi
 
     rm -rf "$tmp_dir"
@@ -2904,6 +3049,12 @@ echo ""
 test_cleanup_issue_item_mode
 echo ""
 test_review_pr_item_branch
+echo ""
+test_create_clone_pr_external_author
+echo ""
+test_dispatch_fix_external_author
+echo ""
+test_enqueue_external_author_toctou
 echo ""
 test_entrypoint_set_pr_call
 echo ""


### PR DESCRIPTION
## Summary

- Adds a fail-closed external-author trust gate to all autonomous pipeline dispatch paths (preflight, review-pr, create-clone-pr, dispatch-fix, enqueue) — fires before any `git fetch`/`git checkout`/container launch
- Trust is by collaborator permission level (`push`/`maintain`/`admin`); `triage`/`read`/`none`/API-error are all treated as external (fail-closed)
- Release mechanism: maintainer applies `human-reviewed:ok` label; pipeline verifies the labeling actor holds `push+` permission via timeline GraphQL (actor affiliation, not just label presence)
- Branch-name impersonation defeated: `story_number = None` for external authors regardless of branch name
- TOCTOU defense: `po-act.sh enqueue` re-checks author trust at merge time

## Acceptance Criteria Verification

| AC | Status |
|----|--------|
| AC1: `triage`/`read`/`none` → external; `push`/`maintain`/`admin` → internal | ✅ |
| AC2: Fail-closed on null/empty login, API errors | ✅ |
| AC3: Gate on `review-pr`, `dispatch-fix`/`create-clone-pr`, `enqueue` before git fetch/checkout | ✅ |
| AC4: Branch-name impersonation blocked (`story_number=None` for external authors) | ✅ |
| AC5: `human-reviewed:ok` release verified to push+ actor (not just label presence) | ✅ |
| AC6: `external_prs` in preflight output; Section 0.5 in PO dashboard | ✅ |
| AC7: `scripts/check-cla-signed.sh` exists and executable | ✅ |

## Files Changed

- `.claude/scripts/po-cycle-preflight.py` — `_collab_permission()`, `is_external()`, `_release_marker_actor_login()`, `_build_pr_summaries()`; updated GraphQL query; Phase 3.5 cache warmup; PRIORITY 0.55 quarantine; `external_prs` output
- `.claude/scripts/agent-dispatch.sh` — `_check_author_permission()`, `_post_quarantine_comment()`, `check-pr-author`, `_test-check-author` subcommands; updated `review-pr` and `create-clone-pr`
- `.claude/scripts/po-act.sh` — author gate in `dispatch-fix`; TOCTOU re-check in `enqueue`; `CFGMS_TEST_DISPATCH` override support
- `.claude/agents/acceptance-reviewer.md` — Phase 0.5 external-author gate (BLOCKING)
- `.claude/agents/po.md` — Section 0.5 dashboard, Step 0 cron cycle
- `scripts/check-cla-signed.sh` — CLA stopgap
- `docs/development/external-contributors.md` — quarantine/release/CLA/attribution doc
- `.gitignore` — allow `test-*.py` alongside existing `test-*.sh` exemption

## Test Plan

- [x] 31 Python unit tests (`test-preflight-external-pr.py`) covering AC1–AC5 preflight behavior
- [x] 21 bash integration tests (`review_pr_detection.test.sh`) covering AC1–AC5 dispatch gate including AC5 release path
- [x] 3 new integration tests (`test-scripts.sh`): `create-clone-pr` external rejection, `dispatch-fix` external gate, `enqueue` TOCTOU re-check
- [x] 183 total tests pass (`make test-agent-complete`)
- [x] Phase 4 adversarial review: security-engineer (PASS, 0 blocking), qa-code-reviewer (5 blocking issues found and resolved), qa-test-runner (PASS, 183/183)

Fixes #1786

🤖 Generated with [Claude Code](https://claude.com/claude-code)