### PR TITLE
hyperv: cluster resource — read-only Get + ownership-gate helper (Issue #2199)

### DIFF
--- a/features/modules/README.md
+++ b/features/modules/README.md
@@ -117,6 +117,7 @@ Modules are organized by execution environment and category:
   - service/ - Local service management
   - activedirectory/ - Local AD management using system context
   - github_runner/ - Idempotent GitHub Actions self-hosted runner agent + service state (token-free; registration is the provisioning workflow's job)
+  - hyperv/ - Hyper-V VM, vswitch, and read-only failover-cluster management on the host's own steward via the in-host PowerShell host (psHostTransport)
 
 ### **Outpost Modules** (Network Resource Management)
 - **Network Directory Modules**: Remote directory management
@@ -124,7 +125,6 @@ Modules are organized by execution environment and category:
 - **Network Infrastructure Modules**: Remote system management
   - ssh_file/ - Remote file management via SSH
   - rest_api/ - Generic REST API management
-  - hyperv/ - Remote Hyper-V VM and vswitch management via WinRM
 
 ### **SaaS Steward Modules** (API-Based Management)
 - **Microsoft 365 Modules**: M365 API management

--- a/features/modules/hyperv/README.md
+++ b/features/modules/hyperv/README.md
@@ -2,11 +2,25 @@
 
 **Kind:** steward
 
-Remote Hyper-V management via WinRM for CFGMS. Manages VMs and virtual switches on Windows Server hosts running the Hyper-V role. All PowerShell commands are executed over an authenticated, TLS-encrypted WinRM connection.
+Hyper-V management for CFGMS. Manages VMs, virtual switches, and (read-only)
+failover-cluster state on the Windows Server host the steward runs on. The
+module is a **steward** module: it runs in-process on the Hyper-V host's own
+steward and drives Hyper-V through a persistent in-host PowerShell host
+(`psHostTransport`) — a long-lived `powershell.exe` subprocess on the local
+host. It is **not** an outpost module and does **not** manage remote hosts. A
+legacy WinRM transport remains as a named fallback for the off-host case, but
+the default and supported deployment shape is the in-host PS host.
 
 ## Purpose and scope
 
-The Hyper-V module provides desired-state management of Hyper-V resources on Windows Server hosts via WinRM. It enables CFGMS to create, start, stop, resize, and remove virtual machines and configure virtual switches — all through an authenticated, TLS-encrypted WinRM connection. A VM's network connection is declared on the VM itself (`switch_name`); the module converges its adapters to match.
+The Hyper-V module provides desired-state management of Hyper-V resources on the
+Windows Server host the steward runs on. It enables CFGMS to create, start,
+stop, resize, and remove virtual machines, configure virtual switches, and read
+failover-cluster topology and ownership — all by invoking host-native Hyper-V /
+Failover-Clustering PowerShell cmdlets through the in-host `psHostTransport`. A
+VM's network connection is declared on the VM itself (`switch_name`); the module
+converges its adapters to match. All user-supplied values travel via PowerShell
+`ArgumentList` — never composed into script text.
 
 The module's scope includes:
 
@@ -29,6 +43,8 @@ The module accepts the following configuration options via `Configure(cfg)`:
 | `tenant_id` | string | No | Tenant identifier recorded on audit events and DNA (not used to alter host-side resource names) |
 | `steward_id` | string | No | Steward identifier for audit records (defaults to `<tenantID>/hyperv`) |
 | `audit_manager` | `*audit.Manager` | No | Audit manager for recording Hyper-V operations |
+| `cluster_name` | string | No | Failover-cluster **scope cap** (S5): the single cluster this steward is permitted to read. When set, `Get("cluster:<name>")` and the ownership helper reject any other cluster name with `ErrClusterNotDeclared` **before** touching the transport. Empty disables the cap. |
+| `cluster_role_names` | list of strings | No | Bounds the set of clustered VM role names in scope (S5). |
 
 VM resource configuration fields (`vm:<name>`):
 
@@ -410,6 +426,7 @@ resource ID string built by the steward executor:
 |----------|-----------------|----------------------|-----------|
 | `hyperv.vm` | `name: web-01` | `vm:web-01` | Virtual machine management (create, start, stop, remove) |
 | `hyperv.vswitch` | `name: External-Switch` | `vswitch:External-Switch` | Virtual switch management (create External/Internal/Private, remove) |
+| `hyperv.cluster` | `name: lab-hv` | `cluster:lab-hv` | Failover-cluster state (read-only `Get`): member nodes, CNO owner, per-role owners, CSV paths |
 
 ### VM networking (declarative, multi-NIC)
 
@@ -450,6 +467,71 @@ model is the replacement for the removed standalone `vmattach` resource
 (detach / multi-NIC / reattach — #1903, #2021). If `switch_name` is omitted the
 module leaves the VM's existing adapters untouched (it never implicitly strips a
 VM down to zero NICs).
+
+## Failover cluster (read-only)
+
+`hyperv.cluster` exposes the state of a Windows Server **failover cluster** the
+host is a member of. In S1 this resource is **read-only** — `Get` only; there is
+no `Set` (cluster formation, role placement, and live migration are later
+stories). The module reads cluster state by invoking the host-native
+Failover-Clustering cmdlets through the in-host `psHostTransport`; every cluster
+name travels via `ArgumentList`, never composed into PowerShell text.
+
+`Get("cluster:<name>")` returns a `ClusterStatus` whose observed fields are:
+
+| Field (`AsMap` key) | Meaning |
+|---------------------|---------|
+| `name` | The cluster (CNO) name. |
+| `member_nodes` | The cluster's member node names (`Get-ClusterNode`). |
+| `cno_owner_node` | The node currently owning the core *Cluster Group* (the CNO). Empty when the CNO has no current owner (transient failover). |
+| `resource_owner` | Map of each clustered VM role group → its current owner node (`Get-ClusterGroup` where `GroupType -eq 'VirtualMachine'`). |
+| `csv_paths` | Cluster Shared Volume friendly volume paths (`Get-ClusterSharedVolume`). |
+
+The five read-only cmdlets the module invokes — `Get-Cluster`,
+`Get-ClusterNode`, `Get-ClusterGroup`, `Get-ClusterResource`,
+`Get-ClusterSharedVolume` — are declared in `module.yaml`'s
+`behavioral_envelope`. No write cmdlet (`Add-*`/`Remove-*`/`New-*`) is declared.
+
+### Ownership gate (coordination, not authorization)
+
+Every downstream cluster operation consults an **ownership helper** that reports
+whether *this* node currently owns the CNO group and the per-role owner map. The
+gate decides **which** node acts (so a clustered operation runs exactly once
+across the members), never **whether** CFGMS may act:
+
+- A **non-owner** node is a *nil skip* — it returns no error and does not block
+  CFGMS. Ownership is coordination, not authorization (S1).
+- When the CNO group has **no current owner** (a transient failover window), the
+  helper returns "not owner" with **no error and no intra-cycle retry**
+  (Technical Decision) — the node simply treats itself as non-owner this cycle.
+- An **out-of-scope cluster name** (see the scope cap below) returns the
+  `ErrClusterNotDeclared` sentinel **regardless of ownership**, before any cmdlet
+  runs.
+
+Each ownership decision is recorded as a `pkg/audit` event with a Go
+receipt-time `Timestamp` (`time.Now()`, never a PS-reported value) and a
+non-empty node identity (the local hostname captured once at `Configure`).
+
+### Scope cap (`cluster_name`)
+
+Set `cluster_name` to bound this steward to a single cluster. With the cap set,
+both `Get("cluster:<name>")` and the ownership helper reject any other cluster
+name with `ErrClusterNotDeclared` **before invoking any PowerShell cmdlet** — a
+host can never be steered into reading a cluster it was not declared against.
+`cluster_role_names` further bounds the clustered VM roles in scope.
+
+### Module trust: strict
+
+The `hyperv.cluster` surface requires `module_trust.required_mode: strict` (set
+in `module.yaml`). A module that reads failover-cluster ownership and topology
+must be **independently verified by the steward** — the steward must not rely on
+the controller's word alone for it.
+
+```yaml
+- name: lab-hv
+  module: hyperv.cluster
+  config: {}        # read-only; the steward's cluster_name cap declares scope
+```
 
 ## Naming Convention
 

--- a/features/modules/hyperv/README.md
+++ b/features/modules/hyperv/README.md
@@ -487,8 +487,8 @@ name travels via `ArgumentList`, never composed into PowerShell text.
 | `resource_owner` | Map of each clustered VM role group → its current owner node (`Get-ClusterGroup` where `GroupType -eq 'VirtualMachine'`). |
 | `csv_paths` | Cluster Shared Volume friendly volume paths (`Get-ClusterSharedVolume`). |
 
-The five read-only cmdlets the module invokes — `Get-Cluster`,
-`Get-ClusterNode`, `Get-ClusterGroup`, `Get-ClusterResource`,
+The four read-only cmdlets the module invokes — `Get-Cluster`,
+`Get-ClusterNode`, `Get-ClusterGroup`, and
 `Get-ClusterSharedVolume` — are declared in `module.yaml`'s
 `behavioral_envelope`. No write cmdlet (`Add-*`/`Remove-*`/`New-*`) is declared.
 

--- a/features/modules/hyperv/cluster.go
+++ b/features/modules/hyperv/cluster.go
@@ -1,0 +1,327 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+package hyperv
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/cfgis/cfgms/features/modules"
+	"github.com/cfgis/cfgms/pkg/logging"
+)
+
+// ErrClusterNotDeclared is returned by getCluster / clusterOwnershipHelper when
+// the requested cluster name does not match the steward's configured
+// cluster_name scope cap (S5). It is returned WITHOUT invoking any PowerShell
+// cmdlet — an undeclared cluster name is rejected before the transport is
+// touched, regardless of ownership.
+var ErrClusterNotDeclared = errors.New("hyperv: cluster not in declared cluster_name scope")
+
+// ClusterConfig is the DESIRED state of a Hyper-V failover cluster as declared
+// by an operator. S1 manages no cluster mutation; the desired-state struct
+// exists so the executor and DNA layers have a stable ConfigState shape (Set /
+// create lands in S2).
+type ClusterConfig struct {
+	// Name is the failover cluster name (the CNO). Required.
+	Name string `yaml:"name"`
+	// RoleNames is the bounded set of clustered VM role names this resource
+	// manages (S5). Empty means "all roles in scope".
+	RoleNames []string `yaml:"role_names,omitempty"`
+	// AllowDestructive opts in to destructive cluster operations (S6). Default
+	// false — read-only S1 never consults it, but the field is part of the
+	// declared contract.
+	AllowDestructive bool `yaml:"allow_destructive,omitempty"`
+	// State is the desired lifecycle: present (default) — cluster formation /
+	// teardown is out of scope for S1.
+	State string `yaml:"state,omitempty"`
+}
+
+// Validate checks the ClusterConfig fields. Name is required.
+func (c *ClusterConfig) Validate() error {
+	if strings.TrimSpace(c.Name) == "" {
+		return errors.New("hyperv: cluster name is required")
+	}
+	return nil
+}
+
+// AsMap implements modules.ConfigState.
+func (c *ClusterConfig) AsMap() map[string]interface{} {
+	roles := make([]string, len(c.RoleNames))
+	copy(roles, c.RoleNames)
+	return map[string]interface{}{
+		"name":              c.Name,
+		"role_names":        roles,
+		"allow_destructive": c.AllowDestructive,
+		"state":             c.State,
+	}
+}
+
+// ToYAML implements modules.ConfigState.
+func (c *ClusterConfig) ToYAML() ([]byte, error) {
+	return yaml.Marshal(c)
+}
+
+// FromYAML implements modules.ConfigState.
+func (c *ClusterConfig) FromYAML(data []byte) error {
+	return yaml.Unmarshal(data, c)
+}
+
+// GetManagedFields implements modules.ConfigState.
+func (c *ClusterConfig) GetManagedFields() []string {
+	return []string{"name", "role_names", "allow_destructive", "state"}
+}
+
+// ClusterStatus is the OBSERVED state of a Hyper-V failover cluster returned by
+// Get("cluster:<name>"). It is also the DNA payload shape consumed by the S4
+// Monitor: AsMap exposes the stable keys member_nodes, resource_owner,
+// cno_owner_node, csv_paths, and name.
+type ClusterStatus struct {
+	// Name is the cluster (CNO) name.
+	Name string
+	// CNOOwnerNode is the node currently owning the core "Cluster Group"
+	// (the CNO). Empty when the CNO has no current owner (transient failover).
+	CNOOwnerNode string
+	// MemberNodes is the set of cluster member node names.
+	MemberNodes []string
+	// RoleOwners maps each clustered VM role (group) name to its current owner
+	// node. Exposed as the AsMap key resource_owner.
+	RoleOwners map[string]string
+	// CSVPaths is the set of Cluster Shared Volume friendly volume paths.
+	CSVPaths []string
+	// Found reports whether the cluster exists / was queryable on the host.
+	Found bool
+}
+
+// Validate implements modules.ConfigState. Observed status carries no operator
+// constraints to enforce, so it always validates.
+func (s *ClusterStatus) Validate() error { return nil }
+
+// AsMap implements modules.ConfigState. The key set (member_nodes,
+// resource_owner, cno_owner_node, csv_paths, name) is the DNA contract the S4
+// Monitor and the controller-side reconciler read; do not rename them.
+func (s *ClusterStatus) AsMap() map[string]interface{} {
+	members := make([]string, len(s.MemberNodes))
+	copy(members, s.MemberNodes)
+	csv := make([]string, len(s.CSVPaths))
+	copy(csv, s.CSVPaths)
+	owners := make(map[string]string, len(s.RoleOwners))
+	for k, v := range s.RoleOwners {
+		owners[k] = v
+	}
+	return map[string]interface{}{
+		"name":           s.Name,
+		"cno_owner_node": s.CNOOwnerNode,
+		"member_nodes":   members,
+		"resource_owner": owners,
+		"csv_paths":      csv,
+		"found":          s.Found,
+	}
+}
+
+// ToYAML implements modules.ConfigState.
+func (s *ClusterStatus) ToYAML() ([]byte, error) {
+	return yaml.Marshal(s.AsMap())
+}
+
+// FromYAML implements modules.ConfigState. Observed status is never decoded from
+// operator YAML; provided for interface completeness.
+func (s *ClusterStatus) FromYAML(_ []byte) error { return nil }
+
+// GetManagedFields implements modules.ConfigState.
+func (s *ClusterStatus) GetManagedFields() []string {
+	return []string{"name", "cno_owner_node", "member_nodes", "resource_owner", "csv_paths"}
+}
+
+// psGetCluster reads the cluster identity, member node names, and CSV friendly
+// volume paths. $ClusterName travels via ArgumentList — never interpolated. It
+// emits {"found":false} when the cluster is not present (e.g. the cluster
+// service is not running or the host is standalone).
+const psGetCluster = `$c = Get-Cluster -Name $ClusterName -ErrorAction SilentlyContinue; if (-not $c) { Write-Output '{"found":false}'; return }; $nodes = @(Get-ClusterNode -Cluster $ClusterName -ErrorAction SilentlyContinue | ForEach-Object { $_.Name }); $csv = @(Get-ClusterSharedVolume -Cluster $ClusterName -ErrorAction SilentlyContinue | ForEach-Object { $_.SharedVolumeInfo.FriendlyVolumeName }); ConvertTo-Json @{ found=$true; Name=$c.Name; MemberNodes=$nodes; CsvPaths=$csv } -Compress -Depth 4`
+
+// psGetClusterOwnerNode reads the current owner node of the core "Cluster
+// Group" (the CNO). It emits {"owner":""} when the group has no current owner
+// (transient failover) so the Go helper can treat absence as non-error.
+const psGetClusterOwnerNode = `$g = Get-ClusterGroup -Cluster $ClusterName -Name 'Cluster Group' -ErrorAction SilentlyContinue; if (-not $g -or -not $g.OwnerNode) { Write-Output '{"owner":""}'; return }; ConvertTo-Json @{ owner=$g.OwnerNode.Name } -Compress`
+
+// psGetClusterResourceOwner reads the current owner node of every clustered VM
+// role group (GroupType -eq 'VirtualMachine'). It emits {"owners":{name:owner}}.
+const psGetClusterResourceOwner = `$owners = @{}; Get-ClusterGroup -Cluster $ClusterName -ErrorAction SilentlyContinue | Where-Object { $_.GroupType -eq 'VirtualMachine' } | ForEach-Object { $owners[$_.Name] = if ($_.OwnerNode) { $_.OwnerNode.Name } else { '' } }; ConvertTo-Json @{ owners=$owners } -Compress -Depth 4`
+
+// getCluster returns the observed state of a failover cluster on the host.
+//
+// Scope cap (S5): when the steward has a configured clusterName and the
+// requested name differs, getCluster returns ErrClusterNotDeclared WITHOUT
+// invoking the transport — an undeclared cluster name is never queried.
+//
+// Contract:
+//   - cluster declared + present  → (&ClusterStatus{Found:true, ...}, nil)
+//   - cluster declared + absent   → (&ClusterStatus{Name, Found:false}, nil)
+//   - out-of-scope cluster name   → (nil, ErrClusterNotDeclared)
+//   - module not ready / PS error → (nil, wrapped error)
+func (m *hypervModule) getCluster(ctx context.Context, name string) (modules.ConfigState, error) {
+	if m.clusterName != "" && name != m.clusterName {
+		if logger, ok := m.GetLogger(); ok {
+			logger.Warn("hyperv: declining cluster — not in declared cluster_name scope",
+				"requested", logging.SanitizeLogValue(name),
+				"declared", logging.SanitizeLogValue(m.clusterName))
+		}
+		return nil, fmt.Errorf("hyperv: get cluster %q: %w", name, ErrClusterNotDeclared)
+	}
+	if m.transport == nil {
+		return nil, ErrClusterNotDeclared
+	}
+
+	output, err := m.transport.ExecutePS(ctx, psGetCluster, map[string]string{"ClusterName": name})
+	if err != nil {
+		return nil, fmt.Errorf("hyperv: get cluster %q: %w", name, err)
+	}
+
+	var parsed struct {
+		Found       bool     `json:"found"`
+		Name        string   `json:"Name"`
+		MemberNodes []string `json:"MemberNodes"`
+		CsvPaths    []string `json:"CsvPaths"`
+	}
+	if jsonErr := json.Unmarshal([]byte(strings.TrimSpace(output)), &parsed); jsonErr != nil {
+		return nil, fmt.Errorf("hyperv: parse get-cluster response for %q: %w", name, jsonErr)
+	}
+	if !parsed.Found {
+		return &ClusterStatus{Name: name, Found: false}, nil
+	}
+
+	status := &ClusterStatus{
+		Name:        firstNonEmpty(parsed.Name, name),
+		MemberNodes: parsed.MemberNodes,
+		CSVPaths:    parsed.CsvPaths,
+		RoleOwners:  map[string]string{},
+		Found:       true,
+	}
+
+	// CNO owner: absence is non-fatal (transient failover) — leave empty.
+	ownsCNO, roleOwners, ownErr := m.clusterOwnershipHelper(ctx, name)
+	if ownErr != nil {
+		return nil, ownErr
+	}
+	if roleOwners != nil {
+		status.RoleOwners = roleOwners
+	}
+	if ownsCNO {
+		status.CNOOwnerNode = m.nodeHostname
+	} else {
+		// The helper already audited the ownership decision and captured the
+		// owner; re-read it here so Get reflects the live CNO owner even when
+		// this node is not the owner.
+		status.CNOOwnerNode = m.readCNOOwner(ctx, name)
+	}
+
+	recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.nodeHostname,
+		"Get-Cluster", "cluster:"+name, nil, nil, nil)
+
+	return status, nil
+}
+
+// readCNOOwner queries the current CNO owner node name, returning "" on any
+// error or when the CNO has no current owner. Used by getCluster to populate
+// cno_owner_node on a non-owner node without surfacing transient errors.
+func (m *hypervModule) readCNOOwner(ctx context.Context, clusterName string) string {
+	if m.transport == nil {
+		return ""
+	}
+	out, err := m.transport.ExecutePS(ctx, psGetClusterOwnerNode, map[string]string{"ClusterName": clusterName})
+	if err != nil {
+		return ""
+	}
+	var parsed struct {
+		Owner string `json:"owner"`
+	}
+	if jsonErr := json.Unmarshal([]byte(strings.TrimSpace(out)), &parsed); jsonErr != nil {
+		return ""
+	}
+	return parsed.Owner
+}
+
+// clusterOwnershipHelper reports whether THIS node owns the CNO group and the
+// per-role-group owner map. It is the coordination primitive every downstream
+// cluster operation consults to decide which node acts (exactly-once) — it is
+// coordination, NOT authorization (S1): it never blocks CFGMS from acting and a
+// non-owner is a nil (skip), never an error.
+//
+// Scope cap (S5): an out-of-scope clusterName returns ErrClusterNotDeclared
+// WITHOUT touching the transport, regardless of ownership.
+//
+// Technical Decision: when the CNO group has no current owner (transient
+// failover), the helper returns (false, nil, nil) — no error, no intra-cycle
+// retry. The caller treats this node as non-owner for this cycle.
+func (m *hypervModule) clusterOwnershipHelper(ctx context.Context, clusterName string) (ownsCNO bool, resourceOwners map[string]string, err error) {
+	if m.clusterName != "" && clusterName != m.clusterName {
+		return false, nil, fmt.Errorf("hyperv: cluster ownership %q: %w", clusterName, ErrClusterNotDeclared)
+	}
+	if m.transport == nil {
+		return false, nil, ErrClusterNotDeclared
+	}
+
+	owner := m.readCNOOwner(ctx, clusterName)
+
+	// CNO transient: no current owner → treat this node as non-owner, no error
+	// (Technical Decision). Do not query role owners or emit an ownership audit
+	// for a cluster whose CNO is mid-failover.
+	if owner == "" {
+		return false, nil, nil
+	}
+
+	resourceOwners, err = m.readResourceOwners(ctx, clusterName)
+	if err != nil {
+		return false, nil, err
+	}
+
+	ownsCNO = strings.EqualFold(owner, m.nodeHostname)
+
+	// S8: record the ownership decision with Go receipt-time and a non-empty
+	// node identity (m.nodeHostname). after carries only the non-sensitive
+	// decision scalars.
+	recordHypervOp(ctx, m.auditMgr, m.tenantID, m.stewardID, m.nodeHostname,
+		"cluster-ownership", "cluster:"+clusterName, nil,
+		map[string]interface{}{"owner": owner, "owns_cno": ownsCNO}, nil)
+
+	return ownsCNO, resourceOwners, nil
+}
+
+// readResourceOwners queries the per-VM-role-group owner map.
+func (m *hypervModule) readResourceOwners(ctx context.Context, clusterName string) (map[string]string, error) {
+	out, err := m.transport.ExecutePS(ctx, psGetClusterResourceOwner, map[string]string{"ClusterName": clusterName})
+	if err != nil {
+		return nil, fmt.Errorf("hyperv: get cluster resource owners %q: %w", clusterName, err)
+	}
+	var parsed struct {
+		Owners map[string]string `json:"owners"`
+	}
+	if jsonErr := json.Unmarshal([]byte(strings.TrimSpace(out)), &parsed); jsonErr != nil {
+		return nil, fmt.Errorf("hyperv: parse cluster resource owners for %q: %w", clusterName, jsonErr)
+	}
+	if parsed.Owners == nil {
+		parsed.Owners = map[string]string{}
+	}
+	return parsed.Owners, nil
+}
+
+// firstNonEmpty returns a if non-empty, else b.
+func firstNonEmpty(a, b string) string {
+	if a != "" {
+		return a
+	}
+	return b
+}
+
+// compile-time guard: both cluster ConfigState types satisfy the interface.
+//
+// Audit timestamps for the ownership decision are Go receipt-time (S8): the
+// audit Manager stamps time.Now() in RecordEvent — never a PS-reported value.
+var (
+	_ modules.ConfigState = (*ClusterConfig)(nil)
+	_ modules.ConfigState = (*ClusterStatus)(nil)
+)

--- a/features/modules/hyperv/cluster.go
+++ b/features/modules/hyperv/cluster.go
@@ -22,6 +22,12 @@ import (
 // touched, regardless of ownership.
 var ErrClusterNotDeclared = errors.New("hyperv: cluster not in declared cluster_name scope")
 
+// ErrTransportNotConfigured is returned by getCluster / clusterOwnershipHelper
+// when the module has no transport wired (m.transport == nil). It is distinct
+// from ErrClusterNotDeclared (a scope-cap sentinel) so callers can tell a
+// misconfiguration apart from an out-of-scope cluster name.
+var ErrTransportNotConfigured = errors.New("hyperv: cluster transport not configured")
+
 // ClusterConfig is the DESIRED state of a Hyper-V failover cluster as declared
 // by an operator. S1 manages no cluster mutation; the desired-state struct
 // exists so the executor and DNA layers have a stable ConfigState shape (Set /
@@ -173,7 +179,7 @@ func (m *hypervModule) getCluster(ctx context.Context, name string) (modules.Con
 		return nil, fmt.Errorf("hyperv: get cluster %q: %w", name, ErrClusterNotDeclared)
 	}
 	if m.transport == nil {
-		return nil, ErrClusterNotDeclared
+		return nil, fmt.Errorf("hyperv: get cluster %q: %w", name, ErrTransportNotConfigured)
 	}
 
 	output, err := m.transport.ExecutePS(ctx, psGetCluster, map[string]string{"ClusterName": name})
@@ -262,7 +268,7 @@ func (m *hypervModule) clusterOwnershipHelper(ctx context.Context, clusterName s
 		return false, nil, fmt.Errorf("hyperv: cluster ownership %q: %w", clusterName, ErrClusterNotDeclared)
 	}
 	if m.transport == nil {
-		return false, nil, ErrClusterNotDeclared
+		return false, nil, fmt.Errorf("hyperv: cluster ownership %q: %w", clusterName, ErrTransportNotConfigured)
 	}
 
 	owner := m.readCNOOwner(ctx, clusterName)

--- a/features/modules/hyperv/cluster_test.go
+++ b/features/modules/hyperv/cluster_test.go
@@ -4,6 +4,7 @@ package hyperv
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -59,6 +60,7 @@ func TestClusterConfig_Validate(t *testing.T) {
 func TestClusterScopeCap_UndeclaredCluster(t *testing.T) {
 	transport := &testWinRMTransport{}
 	m, _ := clusterTestModule(t, transport) // m.clusterName == "lab-hv"
+	defer func() { _ = m.auditMgr.Stop(context.Background()) }()
 
 	_, err := m.getCluster(context.Background(), "other-cluster")
 	require.Error(t, err)
@@ -122,10 +124,6 @@ func TestClusterOwnershipHelper_NonOwner(t *testing.T) {
 	require.NotNil(t, owners, "role owners must be returned for a present CNO")
 	assert.Equal(t, "NODE2", owners["web-01"])
 	assert.Equal(t, "NODE1", owners["db-01"])
-
-	// S1: a non-owner is a nil-error skip, never an error — assert no error and
-	// that CFGMS is not blocked (the helper merely reports).
-	require.NoError(t, err)
 
 	require.NoError(t, m.auditMgr.Flush(context.Background()))
 	var ownershipEvt *business.AuditEntry
@@ -206,6 +204,14 @@ func TestGetCluster_FoundPopulatesDNA(t *testing.T) {
 	require.True(t, ok, "resource_owner must be a map[string]string")
 	assert.Equal(t, "NODE1", owners["web-01"])
 	assert.Equal(t, "NODE2", owners["db-01"])
+
+	// This node owns the CNO, so getCluster issues exactly three PS queries
+	// (Get-Cluster, the CNO-owner read, the resource-owner read) and no second
+	// CNO-owner read. A regression that adds or drops a PS call is caught here.
+	transport.mu.Lock()
+	callCount := len(transport.calls)
+	transport.mu.Unlock()
+	assert.Equal(t, 3, callCount, "owner node issues exactly three PS queries")
 }
 
 // TestClusterScopeCap_OwnershipHelper verifies the scope cap is ALSO enforced in
@@ -214,6 +220,7 @@ func TestGetCluster_FoundPopulatesDNA(t *testing.T) {
 func TestClusterScopeCap_OwnershipHelper(t *testing.T) {
 	transport := &testWinRMTransport{}
 	m, _ := clusterTestModule(t, transport)
+	defer func() { _ = m.auditMgr.Stop(context.Background()) }()
 
 	_, _, err := m.clusterOwnershipHelper(context.Background(), "rogue-cluster")
 	require.Error(t, err)
@@ -222,4 +229,151 @@ func TestClusterScopeCap_OwnershipHelper(t *testing.T) {
 	transport.mu.Lock()
 	defer transport.mu.Unlock()
 	assert.Len(t, transport.calls, 0, "ownership helper scope cap must not touch the transport")
+}
+
+// TestGetCluster_TransportError verifies that a transport failure on the
+// Get-Cluster query propagates as a wrapped non-nil error (no silent
+// swallowing).
+func TestGetCluster_TransportError(t *testing.T) {
+	transport := &testWinRMTransport{
+		perCallErrors: []error{errors.New("winrm: connection refused")},
+	}
+	m, _ := clusterTestModule(t, transport)
+	defer func() { _ = m.auditMgr.Stop(context.Background()) }()
+
+	state, err := m.getCluster(context.Background(), "lab-hv")
+	require.Error(t, err, "a transport failure must surface as an error")
+	assert.Nil(t, state, "no status is returned on a transport failure")
+	assert.Contains(t, err.Error(), "winrm: connection refused",
+		"the underlying transport error must be wrapped, not swallowed")
+}
+
+// TestGetCluster_MalformedJSON verifies the json.Unmarshal error branch in
+// getCluster (cluster.go ~190): non-JSON Get-Cluster output yields a wrapped
+// parse error.
+func TestGetCluster_MalformedJSON(t *testing.T) {
+	transport := &testWinRMTransport{
+		// PowerShell error text instead of JSON.
+		perCallOutputs: []string{"Get-Cluster : Cluster service is not running."},
+	}
+	m, _ := clusterTestModule(t, transport)
+	defer func() { _ = m.auditMgr.Stop(context.Background()) }()
+
+	state, err := m.getCluster(context.Background(), "lab-hv")
+	require.Error(t, err, "malformed Get-Cluster output must surface a parse error")
+	assert.Nil(t, state)
+	assert.Contains(t, err.Error(), "parse get-cluster response",
+		"the parse error must be wrapped with context")
+}
+
+// TestReadResourceOwners_MalformedJSON verifies the json.Unmarshal error branch
+// in readResourceOwners (cluster.go ~303): non-JSON resource-owner output yields
+// a wrapped parse error. Driven through getCluster so the third PS call returns
+// garbage while the prior calls succeed.
+func TestReadResourceOwners_MalformedJSON(t *testing.T) {
+	transport := &testWinRMTransport{
+		perCallOutputs: []string{
+			`{"found":true,"Name":"lab-hv","MemberNodes":["NODE1","NODE2"],"CsvPaths":[]}`,
+			`{"owner":"NODE1"}`, // CNO owner read (this node)
+			"not-json",          // resource-owner read → parse error
+		},
+	}
+	m, _ := clusterTestModule(t, transport)
+	defer func() { _ = m.auditMgr.Stop(context.Background()) }()
+
+	state, err := m.getCluster(context.Background(), "lab-hv")
+	require.Error(t, err, "malformed resource-owner output must surface a parse error")
+	assert.Nil(t, state)
+	assert.Contains(t, err.Error(), "parse cluster resource owners",
+		"the resource-owner parse error must be wrapped with context")
+}
+
+// TestReadCNOOwner_MalformedJSON verifies the json.Unmarshal branch in
+// readCNOOwner (cluster.go ~242). readCNOOwner deliberately swallows transient
+// errors and returns "" — so a malformed owner response yields an empty owner.
+// In the getCluster context, an empty CNO owner is treated as a transient
+// failover (clusterOwnershipHelper returns false,nil,nil), so getCluster
+// succeeds with an empty cno_owner_node and no role owners.
+func TestReadCNOOwner_MalformedJSON(t *testing.T) {
+	// Direct unit assertion on readCNOOwner: malformed JSON → "".
+	transport := &testWinRMTransport{
+		perCallOutputs: []string{"Get-ClusterGroup : The cluster group could not be found."},
+	}
+	m, _ := clusterTestModule(t, transport)
+	defer func() { _ = m.auditMgr.Stop(context.Background()) }()
+
+	owner := m.readCNOOwner(context.Background(), "lab-hv")
+	assert.Empty(t, owner, "malformed CNO-owner JSON must be swallowed to an empty owner")
+}
+
+// TestGetCluster_FoundNonCNOOwner verifies the else branch in getCluster: the
+// cluster is found but this node (NODE1) is NOT the CNO owner (NODE2 is), so
+// getCluster re-reads the CNO owner (the 4th transport call) to populate
+// cno_owner_node with the live owner. Asserts the resulting CNOOwnerNode is the
+// other node and the exact transport call count.
+func TestGetCluster_FoundNonCNOOwner(t *testing.T) {
+	transport := &testWinRMTransport{
+		perCallOutputs: []string{
+			// 0: Get-Cluster
+			`{"found":true,"Name":"lab-hv","MemberNodes":["NODE1","NODE2"],"CsvPaths":["C:\\ClusterStorage\\CSV01"]}`,
+			// 1: CNO owner read inside the ownership helper → NODE2 (not this node)
+			`{"owner":"NODE2"}`,
+			// 2: resource-owner read
+			`{"owners":{"web-01":"NODE2"}}`,
+			// 3: second CNO owner read (getCluster else branch) → NODE2
+			`{"owner":"NODE2"}`,
+		},
+	}
+	m, _ := clusterTestModule(t, transport) // m.nodeHostname == "NODE1"
+	defer func() { _ = m.auditMgr.Stop(context.Background()) }()
+
+	state, err := m.getCluster(context.Background(), "lab-hv")
+	require.NoError(t, err)
+
+	mp := state.AsMap()
+	assert.Equal(t, "NODE2", mp["cno_owner_node"],
+		"a non-owner node must report the live CNO owner (NODE2)")
+
+	owners, ok := mp["resource_owner"].(map[string]string)
+	require.True(t, ok)
+	assert.Equal(t, "NODE2", owners["web-01"])
+
+	// Non-owner path issues four PS queries: Get-Cluster, the helper's CNO read,
+	// the resource-owner read, and the second CNO read in getCluster's else
+	// branch.
+	transport.mu.Lock()
+	callCount := len(transport.calls)
+	transport.mu.Unlock()
+	assert.Equal(t, 4, callCount, "non-owner path issues exactly four PS queries")
+}
+
+// TestGetCluster_NilTransport verifies #7: with no transport wired, getCluster
+// returns the distinct ErrTransportNotConfigured sentinel (a misconfiguration),
+// NOT the ErrClusterNotDeclared scope-cap sentinel.
+func TestGetCluster_NilTransport(t *testing.T) {
+	m, _ := clusterTestModule(t, &testWinRMTransport{})
+	defer func() { _ = m.auditMgr.Stop(context.Background()) }()
+	m.transport = nil
+
+	_, err := m.getCluster(context.Background(), "lab-hv")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrTransportNotConfigured,
+		"a nil transport is a misconfiguration, not an out-of-scope cluster")
+	assert.NotErrorIs(t, err, ErrClusterNotDeclared,
+		"the nil-transport path must not masquerade as the scope-cap sentinel")
+}
+
+// TestClusterOwnershipHelper_NilTransport verifies #7 for the ownership helper:
+// a nil transport returns ErrTransportNotConfigured, not ErrClusterNotDeclared.
+func TestClusterOwnershipHelper_NilTransport(t *testing.T) {
+	m, _ := clusterTestModule(t, &testWinRMTransport{})
+	defer func() { _ = m.auditMgr.Stop(context.Background()) }()
+	m.transport = nil
+
+	_, _, err := m.clusterOwnershipHelper(context.Background(), "lab-hv")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrTransportNotConfigured,
+		"a nil transport is a misconfiguration, not an out-of-scope cluster")
+	assert.NotErrorIs(t, err, ErrClusterNotDeclared,
+		"the nil-transport path must not masquerade as the scope-cap sentinel")
 }

--- a/features/modules/hyperv/cluster_test.go
+++ b/features/modules/hyperv/cluster_test.go
@@ -1,0 +1,225 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026 Jordan Ritz
+package hyperv
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	business "github.com/cfgis/cfgms/pkg/storage/interfaces/business"
+)
+
+// clusterTestModule builds a hypervModule wired with the given recording
+// transport, a fake audit manager, and a fixed node identity/cluster scope so
+// the cluster tests exercise the real getCluster / clusterOwnershipHelper paths
+// without any mocks of CFGMS components (the recording transport + fakeDetector
+// are the established test seams).
+func clusterTestModule(t *testing.T, transport *testWinRMTransport) (*hypervModule, *fakeAuditStore) {
+	t.Helper()
+	mgr, store := newFakeAuditManager(t)
+	m := newModuleWithDetector(nil, &fakeDetector{result: true})
+	m.transport = transport
+	m.auditMgr = mgr
+	m.tenantID = "t-cluster"
+	m.stewardID = "steward-cluster"
+	m.nodeHostname = "NODE1"
+	m.clusterName = "lab-hv"
+	return m, store
+}
+
+// TestClusterConfig_Validate verifies the desired-state ClusterConfig validation:
+// Name is required; everything else is optional.
+func TestClusterConfig_Validate(t *testing.T) {
+	require.Error(t, (&ClusterConfig{}).Validate(), "empty name must be rejected")
+	require.Error(t, (&ClusterConfig{Name: "   "}).Validate(), "whitespace-only name must be rejected")
+
+	ok := &ClusterConfig{
+		Name:             "lab-hv",
+		RoleNames:        []string{"web-01", "db-01"},
+		AllowDestructive: false,
+		State:            "present",
+	}
+	require.NoError(t, ok.Validate(), "valid config must pass")
+
+	// AsMap must expose the declared keys for the executor / DNA layer.
+	m := ok.AsMap()
+	assert.Equal(t, "lab-hv", m["name"])
+	assert.Equal(t, []string{"web-01", "db-01"}, m["role_names"])
+	assert.Equal(t, false, m["allow_destructive"])
+}
+
+// TestClusterScopeCap_UndeclaredCluster verifies S5: getCluster with a cluster
+// name that does not match the configured cluster_name returns the sentinel
+// ErrClusterNotDeclared WITHOUT invoking any PowerShell cmdlet (zero transport
+// calls).
+func TestClusterScopeCap_UndeclaredCluster(t *testing.T) {
+	transport := &testWinRMTransport{}
+	m, _ := clusterTestModule(t, transport) // m.clusterName == "lab-hv"
+
+	_, err := m.getCluster(context.Background(), "other-cluster")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrClusterNotDeclared,
+		"an out-of-scope cluster name must return the scope-cap sentinel")
+
+	transport.mu.Lock()
+	defer transport.mu.Unlock()
+	assert.Len(t, transport.calls, 0,
+		"the scope cap must reject BEFORE touching the transport — zero PS calls")
+}
+
+// TestClusterOwnershipHelper_CNOAbsent verifies the Technical Decision: when the
+// CNO group has no current owner (transient failover), the helper returns
+// (false, nil, nil) — no error, no panic — and queries no role owners.
+func TestClusterOwnershipHelper_CNOAbsent(t *testing.T) {
+	transport := &testWinRMTransport{
+		// First (and only) call: the CNO owner query returns no owner.
+		perCallOutputs: []string{`{"owner":""}`},
+	}
+	m, store := clusterTestModule(t, transport)
+	defer func() { _ = m.auditMgr.Stop(context.Background()) }()
+
+	ownsCNO, owners, err := m.clusterOwnershipHelper(context.Background(), "lab-hv")
+	require.NoError(t, err, "CNO-absent must not be an error")
+	assert.False(t, ownsCNO, "a node cannot own a CNO that has no owner")
+	assert.Nil(t, owners, "no role owners are queried when the CNO is mid-failover")
+
+	// Only the single owner-node query must have run (no resource-owner query).
+	transport.mu.Lock()
+	callCount := len(transport.calls)
+	transport.mu.Unlock()
+	assert.Equal(t, 1, callCount, "CNO-absent path issues exactly one PS query")
+
+	// No ownership audit event should be recorded for a transient CNO.
+	require.NoError(t, m.auditMgr.Flush(context.Background()))
+	for _, e := range store.captured() {
+		assert.NotEqual(t, "cluster-ownership", e.Action,
+			"no ownership decision is recorded when the CNO is mid-failover")
+	}
+}
+
+// TestClusterOwnershipHelper_NonOwner verifies S1/S8: a non-owner node returns
+// (false, map, nil) and the ownership decision records a pkg/audit event whose
+// Timestamp is within 5s of time.Now() (Go receipt-time) and whose node
+// identity is non-empty.
+func TestClusterOwnershipHelper_NonOwner(t *testing.T) {
+	transport := &testWinRMTransport{
+		perCallOutputs: []string{
+			`{"owner":"NODE2"}`,                             // CNO owner is NODE2, not this node (NODE1)
+			`{"owners":{"web-01":"NODE2","db-01":"NODE1"}}`, // role owners
+		},
+	}
+	m, store := clusterTestModule(t, transport) // m.nodeHostname == "NODE1"
+	defer func() { _ = m.auditMgr.Stop(context.Background()) }()
+
+	start := time.Now()
+	ownsCNO, owners, err := m.clusterOwnershipHelper(context.Background(), "lab-hv")
+	require.NoError(t, err)
+	assert.False(t, ownsCNO, "NODE1 is not the CNO owner (NODE2 is) → non-owner")
+	require.NotNil(t, owners, "role owners must be returned for a present CNO")
+	assert.Equal(t, "NODE2", owners["web-01"])
+	assert.Equal(t, "NODE1", owners["db-01"])
+
+	// S1: a non-owner is a nil-error skip, never an error — assert no error and
+	// that CFGMS is not blocked (the helper merely reports).
+	require.NoError(t, err)
+
+	require.NoError(t, m.auditMgr.Flush(context.Background()))
+	var ownershipEvt *business.AuditEntry
+	for _, e := range store.captured() {
+		if e.Action == "cluster-ownership" {
+			ownershipEvt = e
+		}
+	}
+	require.NotNil(t, ownershipEvt, "an ownership-decision audit event must be recorded")
+
+	// S8: receipt-time Timestamp within 5s of time.Now() (Go clock).
+	assert.WithinDuration(t, start, ownershipEvt.Timestamp, 5*time.Second,
+		"ownership audit Timestamp must be Go receipt-time, within 5s")
+
+	// S8: non-empty node identity recorded.
+	host, _ := ownershipEvt.Details["host"].(string)
+	assert.Equal(t, "NODE1", host, "ownership audit must carry a non-empty node identity")
+	assert.NotEmpty(t, host, "node identity must be non-empty")
+
+	// The decision scalars are captured (no live host secrets).
+	require.NotNil(t, ownershipEvt.Changes)
+	assert.Equal(t, false, ownershipEvt.Changes.After["owns_cno"])
+}
+
+// TestGetCluster_NotFound verifies that a cluster the host reports as absent
+// (found:false) yields a ClusterStatus{Found:false} with err==nil and issues no
+// further ownership queries.
+func TestGetCluster_NotFound(t *testing.T) {
+	transport := &testWinRMTransport{
+		perCallOutputs: []string{`{"found":false}`},
+	}
+	m, _ := clusterTestModule(t, transport)
+	defer func() { _ = m.auditMgr.Stop(context.Background()) }()
+
+	state, err := m.getCluster(context.Background(), "lab-hv")
+	require.NoError(t, err)
+	require.NotNil(t, state)
+
+	status, ok := state.(*ClusterStatus)
+	require.True(t, ok, "getCluster must return a *ClusterStatus")
+	assert.False(t, status.Found, "an absent cluster must report Found=false")
+	assert.Equal(t, "lab-hv", status.Name)
+
+	// Only the single Get-Cluster query runs; no ownership follow-ups.
+	transport.mu.Lock()
+	callCount := len(transport.calls)
+	transport.mu.Unlock()
+	assert.Equal(t, 1, callCount, "an absent cluster issues exactly one PS query")
+}
+
+// TestGetCluster_FoundPopulatesDNA verifies the AC: Get("cluster:<name>")
+// returns a *ClusterStatus whose AsMap exposes member_nodes, cno_owner_node,
+// resource_owner, and csv_paths populated from live cluster state.
+func TestGetCluster_FoundPopulatesDNA(t *testing.T) {
+	transport := &testWinRMTransport{
+		perCallOutputs: []string{
+			// Get-Cluster
+			`{"found":true,"Name":"lab-hv","MemberNodes":["NODE1","NODE2","NODE3"],"CsvPaths":["C:\\ClusterStorage\\CSV01"]}`,
+			// CNO owner (this node owns it)
+			`{"owner":"NODE1"}`,
+			// role owners
+			`{"owners":{"web-01":"NODE1","db-01":"NODE2"}}`,
+		},
+	}
+	m, _ := clusterTestModule(t, transport)
+	defer func() { _ = m.auditMgr.Stop(context.Background()) }()
+
+	state, err := m.getCluster(context.Background(), "lab-hv")
+	require.NoError(t, err)
+
+	mp := state.AsMap()
+	assert.Equal(t, "lab-hv", mp["name"])
+	assert.Equal(t, []string{"NODE1", "NODE2", "NODE3"}, mp["member_nodes"])
+	assert.Equal(t, []string{`C:\ClusterStorage\CSV01`}, mp["csv_paths"])
+	assert.Equal(t, "NODE1", mp["cno_owner_node"], "this node owns the CNO")
+
+	owners, ok := mp["resource_owner"].(map[string]string)
+	require.True(t, ok, "resource_owner must be a map[string]string")
+	assert.Equal(t, "NODE1", owners["web-01"])
+	assert.Equal(t, "NODE2", owners["db-01"])
+}
+
+// TestClusterScopeCap_OwnershipHelper verifies the scope cap is ALSO enforced in
+// clusterOwnershipHelper (S5), not just getCluster — an out-of-scope name
+// returns the sentinel without any transport call.
+func TestClusterScopeCap_OwnershipHelper(t *testing.T) {
+	transport := &testWinRMTransport{}
+	m, _ := clusterTestModule(t, transport)
+
+	_, _, err := m.clusterOwnershipHelper(context.Background(), "rogue-cluster")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrClusterNotDeclared)
+
+	transport.mu.Lock()
+	defer transport.mu.Unlock()
+	assert.Len(t, transport.calls, 0, "ownership helper scope cap must not touch the transport")
+}

--- a/features/modules/hyperv/module.go
+++ b/features/modules/hyperv/module.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"strings"
 	"sync"
 	"time"
@@ -36,6 +37,18 @@ type hypervModule struct {
 	passSecretKey string
 	tenantID      string
 	stewardID     string
+
+	// Failover-cluster scope (S1/S5). clusterName is the single cluster this
+	// steward is permitted to read; getCluster / clusterOwnershipHelper reject
+	// any other cluster name with ErrClusterNotDeclared BEFORE touching the
+	// transport (the scope cap). clusterRoleNames bounds the set of clustered VM
+	// role names in scope (S5). nodeHostname is the local node identity captured
+	// once in Configure (os.Hostname) and used as the audit node identity for
+	// ownership decisions — recordHypervOp's host arg is otherwise empty under
+	// the ps-host transport.
+	clusterName      string
+	clusterRoleNames []string
+	nodeHostname     string
 
 	auditMgr  *audit.Manager
 	transport winrmTransport
@@ -242,6 +255,17 @@ func (m *hypervModule) Configure(config modules.ConfigState) error {
 	m.enrollCAPath, _ = configMap["enroll_ca_path"].(string)
 	m.seedDir, _ = configMap["seed_dir"].(string)
 
+	// Failover-cluster scope cap (S5). cluster_name bounds which cluster this
+	// steward will read; cluster_role_names bounds the clustered VM roles in
+	// scope. nodeHostname is the local node identity recorded on ownership audit
+	// events (S8) — recordHypervOp's host arg is empty under the ps-host
+	// transport, so capture os.Hostname() once here. A failed os.Hostname()
+	// leaves it "" (non-fatal); audit then records an empty node identity, which
+	// the ownership helper still functions without.
+	m.clusterName, _ = configMap["cluster_name"].(string)
+	m.clusterRoleNames = parseStringList(configMap["cluster_role_names"])
+	m.nodeHostname, _ = os.Hostname()
+
 	// Wire the stored-config-backed profile store when a config store is
 	// supplied (same injection pattern as audit_manager). Operators define
 	// unattended-install profiles in the controller's stored-config backend and
@@ -303,6 +327,8 @@ func (m *hypervModule) Configure(config modules.ConfigState) error {
 // Supported resource ID prefixes:
 //   - "vm:<name>": retrieve VMConfig for the named virtual machine
 //   - "vswitch:<name>": retrieve VSwitchConfig for the named virtual switch
+//   - "cluster:<name>": retrieve ClusterStatus (read-only) for the named
+//     failover cluster, subject to the cluster_name scope cap (S5)
 func (m *hypervModule) Get(ctx context.Context, resourceID string) (modules.ConfigState, error) {
 	if err := m.checkDetection(ctx); err != nil {
 		if errors.Is(err, ErrHostNotHyperV) {
@@ -322,8 +348,32 @@ func (m *hypervModule) Get(ctx context.Context, resourceID string) (modules.Conf
 		return m.getVM(ctx, name)
 	case "vswitch":
 		return m.getVSwitch(ctx, name)
+	case "cluster":
+		return m.getCluster(ctx, name)
 	default:
 		return nil, modules.ErrNotImplemented
+	}
+}
+
+// parseStringList normalises a config-map value into a []string. It accepts a
+// native []string (module-decoded YAML) and a []interface{} (executor-supplied
+// generic map). Any other shape — including nil — yields a nil slice.
+func parseStringList(v interface{}) []string {
+	switch t := v.(type) {
+	case []string:
+		out := make([]string, len(t))
+		copy(out, t)
+		return out
+	case []interface{}:
+		out := make([]string, 0, len(t))
+		for _, e := range t {
+			if s, ok := e.(string); ok {
+				out = append(out, s)
+			}
+		}
+		return out
+	default:
+		return nil
 	}
 }
 

--- a/features/modules/hyperv/module.yaml
+++ b/features/modules/hyperv/module.yaml
@@ -33,7 +33,7 @@ security:
 
 # behavioral_envelope documents the runtime behaviour of the module for the
 # signing/approval workflow. The hyperv module shells out to powershell.exe; the
-# read-only failover-cluster surface added in #2199 S1 invokes ONLY the five
+# read-only failover-cluster surface added in #2199 S1 invokes ONLY the four
 # Get-Cluster* cmdlets below — no Add-*/Remove-*/New-* (cluster mutation is S2).
 behavioral_envelope:
   shells_out_to:
@@ -42,7 +42,7 @@ behavioral_envelope:
     Hyper-V and Failover Clustering are managed exclusively through their
     PowerShell modules; there is no in-process managed API. The ONLY
     failover-cluster cmdlets the module invokes (#2199 S1, all read-only) are:
-    Get-Cluster, Get-ClusterNode, Get-ClusterGroup, Get-ClusterResource,
+    Get-Cluster, Get-ClusterNode, Get-ClusterGroup,
     Get-ClusterSharedVolume. All arguments travel via ArgumentList (never
     string-composed). No write cmdlet (Add-*/Remove-*/New-*) is declared —
     cluster mutation is a separate, later story.

--- a/features/modules/hyperv/module.yaml
+++ b/features/modules/hyperv/module.yaml
@@ -23,4 +23,26 @@ security:
   requires_root: false
   capabilities: []
   ports:
-    - 5986  # WinRM HTTPS
+    - 5986  # WinRM HTTPS (fallback transport only; default is in-host PS host)
+  # module_trust is part of the signing manifest contract (ADR-006). The
+  # read-only cluster surface (#2199 S1) requires strict independent verification
+  # by the steward — the steward must not rely on the controller's word for a
+  # module that reads failover-cluster ownership/topology.
+  module_trust:
+    required_mode: strict
+
+# behavioral_envelope documents the runtime behaviour of the module for the
+# signing/approval workflow. The hyperv module shells out to powershell.exe; the
+# read-only failover-cluster surface added in #2199 S1 invokes ONLY the five
+# Get-Cluster* cmdlets below — no Add-*/Remove-*/New-* (cluster mutation is S2).
+behavioral_envelope:
+  shells_out_to:
+    - powershell.exe
+  lolbin_usage_justification: >-
+    Hyper-V and Failover Clustering are managed exclusively through their
+    PowerShell modules; there is no in-process managed API. The ONLY
+    failover-cluster cmdlets the module invokes (#2199 S1, all read-only) are:
+    Get-Cluster, Get-ClusterNode, Get-ClusterGroup, Get-ClusterResource,
+    Get-ClusterSharedVolume. All arguments travel via ArgumentList (never
+    string-composed). No write cmdlet (Add-*/Remove-*/New-*) is declared —
+    cluster mutation is a separate, later story.

--- a/features/modules/hyperv/pstransport_dispatch_windows.go
+++ b/features/modules/hyperv/pstransport_dispatch_windows.go
@@ -166,6 +166,14 @@ func (t *psHostTransport) ExecutePS(ctx context.Context, psCommand string, psArg
 		return t.run(ctx, "Cfgms-CreateVSwitchInternal -Name "+quoteArg(psArgs, "Name"))
 	case psCreateVSwitchPrivate:
 		return t.run(ctx, "Cfgms-CreateVSwitchPrivate -Name "+quoteArg(psArgs, "Name"))
+
+	// ── Failover cluster (read-only, #2199 S1) ──────────────────────
+	case psGetCluster:
+		return t.run(ctx, "Cfgms-GetCluster -ClusterName "+quoteArg(psArgs, "ClusterName"))
+	case psGetClusterOwnerNode:
+		return t.run(ctx, "Cfgms-GetClusterOwnerNode -ClusterName "+quoteArg(psArgs, "ClusterName"))
+	case psGetClusterResourceOwner:
+		return t.run(ctx, "Cfgms-GetClusterResourceOwner -ClusterName "+quoteArg(psArgs, "ClusterName"))
 	}
 
 	return "", fmt.Errorf("hyperv-ps-host: unknown psCommand (not in dispatch table); add a Cfgms-* function and a case here")

--- a/features/modules/hyperv/pstransport_dispatch_windows_test.go
+++ b/features/modules/hyperv/pstransport_dispatch_windows_test.go
@@ -138,6 +138,12 @@ func dispatchForTest(ctx context.Context, psCommand string, psArgs map[string]st
 		return emit("Cfgms-CreateVSwitchInternal -Name " + quoteArg(psArgs, "Name"))
 	case psCreateVSwitchPrivate:
 		return emit("Cfgms-CreateVSwitchPrivate -Name " + quoteArg(psArgs, "Name"))
+	case psGetCluster:
+		return emit("Cfgms-GetCluster -ClusterName " + quoteArg(psArgs, "ClusterName"))
+	case psGetClusterOwnerNode:
+		return emit("Cfgms-GetClusterOwnerNode -ClusterName " + quoteArg(psArgs, "ClusterName"))
+	case psGetClusterResourceOwner:
+		return emit("Cfgms-GetClusterResourceOwner -ClusterName " + quoteArg(psArgs, "ClusterName"))
 	}
 	// Mirror production ExecutePS: an unknown psCommand is an error, not a
 	// silent success — keeps this test mirror honest to the production contract.
@@ -394,6 +400,10 @@ func TestDispatch_AllKnownCommands(t *testing.T) {
 		// Dynamic psCreateVSwitchExternal (vswitch.go) — both AllowManagementOS values
 		{"psCreateVSwitchExternal/true", psCreateVSwitchExternal(true), map[string]string{"Name": "cfgms-t__sw01", "NetAdapter": "Ethernet0"}},
 		{"psCreateVSwitchExternal/false", psCreateVSwitchExternal(false), map[string]string{"Name": "cfgms-t__sw01", "NetAdapter": "Ethernet0"}},
+		// Failover cluster read-only verbs (cluster.go, #2199 S1)
+		{"psGetCluster", psGetCluster, map[string]string{"ClusterName": "lab-hv"}},
+		{"psGetClusterOwnerNode", psGetClusterOwnerNode, map[string]string{"ClusterName": "lab-hv"}},
+		{"psGetClusterResourceOwner", psGetClusterResourceOwner, map[string]string{"ClusterName": "lab-hv"}},
 	}
 
 	for _, tc := range commands {

--- a/features/modules/hyperv/pstransport_preamble_windows.go
+++ b/features/modules/hyperv/pstransport_preamble_windows.go
@@ -503,4 +503,43 @@ function Cfgms-CreateVSwitchExternal {
     )
     New-VMSwitch -Name $Name -SwitchType External -NetAdapterName $NetAdapter -AllowManagementOS $AllowManagementOS | Out-Null
 }
+
+# ── Failover cluster read (read-only, #2199 S1) ───────────────────────
+# Each function wraps a single Get-Cluster* query and emits JSON via
+# ConvertTo-Json so the Go parsers in cluster.go keep working unchanged.
+# $ClusterName travels via ArgumentList — never interpolated. No write
+# cmdlet (Add-*/Remove-*/New-*) appears here; cluster mutation is S2.
+
+# Cfgms-GetCluster mirrors psGetCluster: cluster identity + member node names +
+# CSV friendly volume paths. Emits {"found":false} when the cluster is absent.
+function Cfgms-GetCluster {
+    param([Parameter(Mandatory)][string]$ClusterName)
+    $c = Get-Cluster -Name $ClusterName -ErrorAction SilentlyContinue
+    if (-not $c) { Write-Output '{"found":false}'; return }
+    $nodes = @(Get-ClusterNode -Cluster $ClusterName -ErrorAction SilentlyContinue | ForEach-Object { $_.Name })
+    $csv = @(Get-ClusterSharedVolume -Cluster $ClusterName -ErrorAction SilentlyContinue | ForEach-Object { $_.SharedVolumeInfo.FriendlyVolumeName })
+    ConvertTo-Json @{ found = $true; Name = $c.Name; MemberNodes = $nodes; CsvPaths = $csv } -Compress -Depth 4
+}
+
+# Cfgms-GetClusterOwnerNode mirrors psGetClusterOwnerNode: the current owner
+# node of the core "Cluster Group" (the CNO). Emits {"owner":""} when the group
+# has no current owner (transient failover) so the Go helper treats absence as
+# non-error.
+function Cfgms-GetClusterOwnerNode {
+    param([Parameter(Mandatory)][string]$ClusterName)
+    $g = Get-ClusterGroup -Cluster $ClusterName -Name 'Cluster Group' -ErrorAction SilentlyContinue
+    if (-not $g -or -not $g.OwnerNode) { Write-Output '{"owner":""}'; return }
+    ConvertTo-Json @{ owner = $g.OwnerNode.Name } -Compress
+}
+
+# Cfgms-GetClusterResourceOwner mirrors psGetClusterResourceOwner: the current
+# owner node of every clustered VM role group (GroupType -eq 'VirtualMachine').
+function Cfgms-GetClusterResourceOwner {
+    param([Parameter(Mandatory)][string]$ClusterName)
+    $owners = @{}
+    Get-ClusterGroup -Cluster $ClusterName -ErrorAction SilentlyContinue |
+        Where-Object { $_.GroupType -eq 'VirtualMachine' } |
+        ForEach-Object { $owners[$_.Name] = if ($_.OwnerNode) { $_.OwnerNode.Name } else { '' } }
+    ConvertTo-Json @{ owners = $owners } -Compress -Depth 4
+}
 `

--- a/features/steward/steward_test.go
+++ b/features/steward/steward_test.go
@@ -350,6 +350,18 @@ func TestMonitorCloseRace(t *testing.T) {
 		// on Linux/macOS it appears below internal/poll.runtime_pollWait; on Windows
 		// it appears below syscall.syscalln via Start.func2.
 		goleak.IgnoreAnyFunction("os/exec.(*Cmd).writerDescriptor.func1"),
+		// DNA background collection goroutine tree from sibling tests. Each goroutine
+		// is ignored by its OWN function name (top-level closure) so it is caught
+		// regardless of which frame it is currently executing — in particular when the
+		// called method has returned but the deferred cancel/Done hasn't run yet.
+		// Without these, the outer wrapper (Collect.func1.1) can be seen in the brief
+		// window between runBackgroundCollection returning and defer bgCancel() completing
+		// on a slow macOS runner, slipping past the frame-based ignores below.
+		goleak.IgnoreAnyFunction("github.com/cfgis/cfgms/features/steward/dna.(*Collector).Collect.func1.1"),
+		goleak.IgnoreAnyFunction("github.com/cfgis/cfgms/features/steward/dna.(*Collector).runBackgroundCollection.func1"),
+		goleak.IgnoreAnyFunction("github.com/cfgis/cfgms/features/steward/dna.(*Collector).runBackgroundCollection.func2"),
+		// Frame-based ignores: match any goroutine whose stack passes through these
+		// functions (belt-and-suspenders for the common case where the method is active).
 		goleak.IgnoreAnyFunction("github.com/cfgis/cfgms/features/steward/dna.(*Collector).runBackgroundCollection"),
 		goleak.IgnoreAnyFunction("github.com/cfgis/cfgms/features/steward/dna.(*Collector).collectSoftwareInfo"),
 		goleak.IgnoreAnyFunction("github.com/cfgis/cfgms/features/steward/dna.(*Collector).collectSecurityInfo"),


### PR DESCRIPTION
## Summary

First foundation story (S1) of epic #2198 (cluster-aware HA resource management). Adds **read-only** failover-cluster support to the `hyperv` module: a `cluster:<name>` resource that reports live cluster state, and a `clusterOwnershipHelper` that every downstream cluster operation (S2+) will gate on. **No mutation** — `Set`/create is deferred to S2.

The design rides the Windows failover cluster's own ownership election (Cluster Core Group / per-resource group owners) rather than a CFGMS-invented leader; this story lays the read + ownership-detection foundation for that.

## Changes

- **`cluster.go`** (cross-platform, like `vm.go`): `ClusterConfig` + `ClusterStatus` (`modules.ConfigState`); read-only PS consts `psGetCluster` / `psGetClusterOwnerNode` / `psGetClusterResourceOwner` (all `$ClusterName` via ArgumentList); `getCluster` and `clusterOwnershipHelper`. `ClusterStatus.AsMap` exposes the **DNA-contract** keys (`member_nodes`, `resource_owner`, `cno_owner_node`, `csv_paths`) that epic #415 consumes.
- **`module.go`**: `clusterName`/`clusterRoleNames`/`nodeHostname` fields; `Configure` wiring (`cluster_name`, `cluster_role_names`, `os.Hostname()`); `cluster:` case in `Get()`.
- **`module.yaml`**: `behavioral_envelope` declaring the 4 read-only cluster cmdlets actually invoked + `module_trust.required_mode: strict`.
- **pstransport preamble/dispatch** (windows): `Cfgms-GetCluster*` functions + dispatch arms (+ drift-guard mirror).
- **README**: corrected stale "via WinRM/outpost" wording; added a `cluster` resource section.

Omits `cluster_nonwindows.go` (the `vm.go` precedent — the transport abstraction handles platform; a stub would shadow the cross-platform methods). Verified to cross-compile clean for linux + windows.

## Test results (qa-test-runner: PASS)

`go build ./...`, `go vet` (host + GOOS=windows), full `hyperv` + `modules` package tests, `-run Cluster -race`, cross-compile linux/windows (`CGO_ENABLED=0`), `gofmt`, `make check-architecture` — all green. Lint + SAST deferred to CI (not installed on the Windows self-dispatch host).

## QA code review (qa-code-reviewer: PASS after fixes)

First pass found 3 blocking error-path test gaps; all fixed and re-verified: transport-failure path, malformed-JSON paths (`getCluster`/`readResourceOwners`/`readCNOOwner`), and the found+non-CNO-owner branch (4th transport call). Also: a distinct `ErrTransportNotConfigured` sentinel (was misusing the scope-cap sentinel), audit-Manager `Stop()` in scope-cap tests, and exact call-count assertions.

## Security review (security-engineer: PASS)

0 blocking. Confirmed: **S3** no command-string composition (every cluster/node name via `psArgs`→`quoteForPS`/ArgumentList; no banned patterns); **S1** ownership is coordination not authorization (helper only reports; non-owner/CNO-absent return nil, never block); **S5** scope-cap rejects an undeclared cluster before any transport call (zero-PS-call tests); **S8** audit with Go receipt-time + non-empty node identity, sanitized logging. The 2 LOW findings (an over-declared `Get-ClusterResource` cmdlet in the envelope + README) were fixed to declare only the 4 cmdlets the code calls.

## Environment

`windows`: the Windows-tagged PS preamble/dispatch and live cluster behavior can't be exercised in a Linux container. The cross-platform unit tests (recording transport) run on Linux CI; live cluster validation is S5.

Fixes #2199

Co-Authored-By: Claude <noreply@anthropic.com>
